### PR TITLE
Package request: httpd-rivet

### DIFF
--- a/extra-tcl/httpd-rivet/autobuild/defines
+++ b/extra-tcl/httpd-rivet/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=httpd-rivet
+PKGDES="Server-side Tcl programming system combining ease of use and power"
+PKGDEP="httpd tcl"
+PKGSEC=web
+ABSHADOW=0
+

--- a/extra-tcl/httpd-rivet/spec
+++ b/extra-tcl/httpd-rivet/spec
@@ -1,0 +1,3 @@
+VER=2.2.3
+REL=0
+SRCTBL="http://www.us.apache.org/dist/tcl/rivet/rivet-${VER}.tar.gz"


### PR DESCRIPTION
Rivet brings server-side Tcl programming to Apache HTTP Server.

NOTE: Due to ill-designed configure.ac, ABSHADOW is disabled. Let me know if it's inappropriate.