### PR TITLE
Package request: easytag

### DIFF
--- a/extra-gnome/easytag/autobuild/defines
+++ b/extra-gnome/easytag/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=easytag
+PKGSEC=gnome
+PKGDEP="gtk-3 libid3tag id3libs flac libogg libvorbis opus opusfile taglib wavpack"
+BUILDDEP="pkg-config yelp-tools appdata-tools intltool"
+PKGDES="View and edit tags for audio files"
+AUTOTOOLS_AFTER="--disable-man"
+ABSHADOW=0

--- a/extra-gnome/easytag/spec
+++ b/extra-gnome/easytag/spec
@@ -1,0 +1,3 @@
+VER=2.3.7
+REL=0
+SRCTBL=https://download.gnome.org/sources/easytag/2.3/easytag-${VER}.tar.xz

--- a/extra-gnome/easytag/spec
+++ b/extra-gnome/easytag/spec
@@ -1,3 +1,2 @@
 VER=2.3.7
-REL=0
 SRCTBL=https://download.gnome.org/sources/easytag/2.3/easytag-${VER}.tar.xz


### PR DESCRIPTION
Easytag is a GTK+-based tag editor for audio files, which is part of the GNOME project.