### PR TITLE
Ruby: Bump to 2.3.0

### DIFF
--- a/extra-ruby/ruby/spec
+++ b/extra-ruby/ruby/spec
@@ -1,2 +1,2 @@
-VER=2.2.4
+VER=2.3.0
 SRCTBL="https://cache.ruby-lang.org/pub/ruby/${VER:0:3}/ruby-$VER.tar.gz"


### PR DESCRIPTION
Directly update to 2.3.0.