### PR TITLE
apt: tweaks on sources.list{.d}

### DIFF
--- a/extra-admin/apt/autobuild/amd64/overrides/etc/apt/sources.list
+++ b/extra-admin/apt/autobuild/amd64/overrides/etc/apt/sources.list
@@ -2,7 +2,7 @@
 deb http://mirrors.anthonos.org/anthon/os-amd64/os3-dpkg /
 
 # The "source" server, no delay on package updates. Probably slower.
-deb https://repo.aosc.io/os-amd64/os3-dpkg /
+#deb https://repo.aosc.io/os-amd64/os3-dpkg /
 
 # Mirror by USTC, a stable yet fast mirror for updates.
 deb https://mirrors.ustc.edu.cn/anthon/os-amd64/os3-dpkg /

--- a/extra-admin/apt/autobuild/amd64/overrides/etc/apt/sources.list
+++ b/extra-admin/apt/autobuild/amd64/overrides/etc/apt/sources.list
@@ -1,8 +1,10 @@
 # Automatic mirror, may have delays on package updates. Probably faster.
 deb http://mirrors.anthonos.org/anthon/os-amd64/os3-dpkg /
+deb http://mirrors.anthonos.org/anthon/os-noarch/os3-dpkg /
 
 # The "source" server, no delay on package updates. Probably slower.
 #deb https://repo.aosc.io/os-amd64/os3-dpkg /
 
 # Mirror by USTC, a stable yet fast mirror for updates.
 deb https://mirrors.ustc.edu.cn/anthon/os-amd64/os3-dpkg /
+deb https://mirrors.ustc.edu.cn/anthon/os-noarch/os3-dpkg /

--- a/extra-admin/apt/autobuild/arm64/overrides/etc/apt/sources.list
+++ b/extra-admin/apt/autobuild/arm64/overrides/etc/apt/sources.list
@@ -2,7 +2,7 @@
 deb http://mirrors.anthonos.org/anthon/os-arm64/os3-dpkg /
 
 # The "source" server, no delay on package updates. Probably slower.
-deb https://repo.aosc.io/os-arm64/os3-dpkg /
+#deb https://repo.aosc.io/os-arm64/os3-dpkg /
 
 # Mirror by USTC, a stable yet fast mirror for updates.
 deb https://mirrors.ustc.edu.cn/anthon/os-arm64/os3-dpkg /

--- a/extra-admin/apt/autobuild/arm64/overrides/etc/apt/sources.list
+++ b/extra-admin/apt/autobuild/arm64/overrides/etc/apt/sources.list
@@ -1,8 +1,10 @@
 # Automatic mirror, may have delays on package updates. Probably faster.
 deb http://mirrors.anthonos.org/anthon/os-arm64/os3-dpkg /
+deb http://mirrors.anthonos.org/anthon/os-noarch/os3-dpkg /
 
 # The "source" server, no delay on package updates. Probably slower.
 #deb https://repo.aosc.io/os-arm64/os3-dpkg /
 
 # Mirror by USTC, a stable yet fast mirror for updates.
 deb https://mirrors.ustc.edu.cn/anthon/os-arm64/os3-dpkg /
+deb https://mirrors.ustc.edu.cn/anthon/os-noarch/os3-dpkg /

--- a/extra-admin/apt/autobuild/armel/overrides/etc/apt/sources.list
+++ b/extra-admin/apt/autobuild/armel/overrides/etc/apt/sources.list
@@ -1,8 +1,10 @@
 # Automatic mirror, may have delays on package updates. Probably faster.
 deb http://mirrors.anthonos.org/anthon/os-armel/os3-dpkg /
+deb http://mirrors.anthonos.org/anthon/os-noarch/os3-dpkg /
 
 # The "source" server, no delay on package updates. Probably slower.
 #deb https://repo.aosc.io/os-armel/os3-dpkg /
 
 # Mirror by USTC, a stable yet fast mirror for updates.
 deb https://mirrors.ustc.edu.cn/anthon/os-armel/os3-dpkg /
+deb https://mirrors.ustc.edu.cn/anthon/os-noarch/os3-dpkg /

--- a/extra-admin/apt/autobuild/armel/overrides/etc/apt/sources.list
+++ b/extra-admin/apt/autobuild/armel/overrides/etc/apt/sources.list
@@ -2,7 +2,7 @@
 deb http://mirrors.anthonos.org/anthon/os-armel/os3-dpkg /
 
 # The "source" server, no delay on package updates. Probably slower.
-deb https://repo.aosc.io/os-armel/os3-dpkg /
+#deb https://repo.aosc.io/os-armel/os3-dpkg /
 
 # Mirror by USTC, a stable yet fast mirror for updates.
 deb https://mirrors.ustc.edu.cn/anthon/os-armel/os3-dpkg /

--- a/extra-admin/apt/autobuild/beyond
+++ b/extra-admin/apt/autobuild/beyond
@@ -1,8 +1,0 @@
-# Data package repositories.
-
-mkdir -p "$PKGDIR"/etc/apt/sources.list.d
-cat > "$PKGDIR"/etc/apt/sources.list.d/10-noarch.list << EOF
-deb http://mirrors.anthonos.org/anthon/os-noarch/os3-dpkg /
-deb https://repo.aosc.io/os-noarch/os3-dpkg /
-deb https://mirrors.ustc.edu.cn/anthon/os-noarch/os3-dpkg /
-EOF

--- a/extra-admin/apt/autobuild/mipsel/overrides/etc/apt/sources.list
+++ b/extra-admin/apt/autobuild/mipsel/overrides/etc/apt/sources.list
@@ -1,8 +1,10 @@
 # Automatic mirror, may have delays on package updates. Probably faster.
 deb http://mirrors.anthonos.org/anthon/os-mipsel/os3-dpkg /
+deb http://mirrors.anthonos.org/anthon/os-noarch/os3-dpkg /
 
 # The "source" server, no delay on package updates. Probably slower.
 #deb https://repo.aosc.io/os-mipsel/os3-dpkg /
 
 # Mirror by USTC, a stable yet fast mirror for updates.
 deb https://mirrors.ustc.edu.cn/anthon/os-mipsel/os3-dpkg /
+deb https://mirrors.ustc.edu.cn/anthon/os-noarch/os3-dpkg /

--- a/extra-admin/apt/autobuild/mipsel/overrides/etc/apt/sources.list
+++ b/extra-admin/apt/autobuild/mipsel/overrides/etc/apt/sources.list
@@ -2,7 +2,7 @@
 deb http://mirrors.anthonos.org/anthon/os-mipsel/os3-dpkg /
 
 # The "source" server, no delay on package updates. Probably slower.
-deb https://repo.aosc.io/os-mipsel/os3-dpkg /
+#deb https://repo.aosc.io/os-mipsel/os3-dpkg /
 
 # Mirror by USTC, a stable yet fast mirror for updates.
 deb https://mirrors.ustc.edu.cn/anthon/os-mipsel/os3-dpkg /


### PR DESCRIPTION
This Pull Request does some fixes on `apt`'s `sources.list` and removes the directory `sources.list.d` to avoid slow upgrade speed for most of our users.

----------------------------------------------------------------
Junde Yhi (3):
      apt: remote data package repository configuration
      apt: sources.list: comment the main repository
      add: sources.list: noarch line

 extra-admin/apt/autobuild/amd64/overrides/etc/apt/sources.list  | 4 +++-
 extra-admin/apt/autobuild/arm64/overrides/etc/apt/sources.list  | 4 +++-
 extra-admin/apt/autobuild/armel/overrides/etc/apt/sources.list  | 4 +++-
 extra-admin/apt/autobuild/beyond                                | 8 --------
 extra-admin/apt/autobuild/mipsel/overrides/etc/apt/sources.list | 4 +++-
 5 files changed, 12 insertions(+), 12 deletions(-)
 delete mode 100644 extra-admin/apt/autobuild/beyond