### PR TITLE
python-future: new, 0.15.2

### DIFF
--- a/extra-python/future/autobuild/defines
+++ b/extra-python/future/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=future
+PKGSEC=python
+PKGDEP="python-2 python-3"
+BUILDDEP="setuptools"
+PKGDES="Easy, clean, reliable Python 2/3 compatibility"
+

--- a/extra-python/future/spec
+++ b/extra-python/future/spec
@@ -1,0 +1,3 @@
+VER=0.15.2
+SRCTBL="https://github.com/PythonCharmers/python-future/archive/v$VER.tar.gz"
+


### PR DESCRIPTION
Added python-future 0.15.2
Easy, clean, reliable Python 2/3 compatibility