### PR TITLE
grub: fix hard-coded initramfs probing name

### DIFF
--- a/extra-admin/grub/autobuild/patches/10008-Do-not-use-hard-coded-kernel-local-names.patch
+++ b/extra-admin/grub/autobuild/patches/10008-Do-not-use-hard-coded-kernel-local-names.patch
@@ -1,0 +1,23 @@
+diff --git a/10_linux.orig b/10_linux
+index 008b627..b82ecee 100644
+--- a/10_linux.orig
++++ b/10_linux
+@@ -216,6 +216,7 @@ while [ "x$list" != "x" ] ; do
+   basename=`basename $linux`
+   dirname=`dirname $linux`
+   rel_dirname=`make_system_path_relative_to_its_root $dirname`
++  localname=`echo $basename | sed -e "s,vmlinuz-,,g" | sed -e "s,-[0-9].*,,g"`
+   version=`echo $basename | sed -e "s,^[^0-9]*-,,g"`
+   alt_version=`echo $version | sed -e "s,\.old$,,g"`
+   linux_root_device_thisversion="${LINUX_ROOT_DEVICE}"
+@@ -229,9 +230,7 @@ while [ "x$list" != "x" ] ; do
+ 	   "initramfs-genkernel-${alt_version}" \
+ 	   "initramfs-genkernel-${GENKERNEL_ARCH}-${version}" \
+ 	   "initramfs-genkernel-${GENKERNEL_ARCH}-${alt_version}" \
+-	   "initramfs-${version}-aosc-main.img" "initramfs-${version}-oracle-uek.img" \
+-	   "initramfs-${version}-ckt9-debian.img" "initramfs-${version}-fedora.img" \
+-	   "initramfs-${version}-linux-rt.img"; do
++	   "initramfs-${version}-${localname}.img"; do
+     if test -e "${dirname}/${i}" ; then
+       initrd="$i"
+       break


### PR DESCRIPTION
For kernels' localnames are not "-aosc-main", generally kernels in tree
"linux-kernel-extra", grub-mkconfig cannot probe their corresponding
initramfs.

Change "aosc-main" to the corresponding localname can fix this problem.
Also, other localname specifications are not necessary. Remove.