### PR TITLE
grub: strip all strings before kernel version number

### DIFF
--- a/extra-admin/grub/autobuild/patches/10008-Do-not-use-hard-coded-kernel-local-names.patch
+++ b/extra-admin/grub/autobuild/patches/10008-Do-not-use-hard-coded-kernel-local-names.patch
@@ -1,7 +1,7 @@
 diff --git a/10_linux.orig b/10_linux
 index 008b627..b82ecee 100644
---- a/10_linux.orig
-+++ b/10_linux
+--- a/util/grub.d/10_linux.in
++++ b/util/grub.d/10_linux.in
 @@ -216,6 +216,7 @@ while [ "x$list" != "x" ] ; do
    basename=`basename $linux`
    dirname=`dirname $linux`

--- a/extra-admin/grub/autobuild/patches/10009-Strip-all-strings-before-kernel-version-number.patch
+++ b/extra-admin/grub/autobuild/patches/10009-Strip-all-strings-before-kernel-version-number.patch
@@ -1,0 +1,14 @@
+diff --git a/10_linux.orig b/10_linux
+old mode 100644
+new mode 100755
+index b82ecee..e79af9c
+--- a/10_linux.orig
++++ b/10_linux
+@@ -217,7 +217,7 @@ while [ "x$list" != "x" ] ; do
+   dirname=`dirname $linux`
+   rel_dirname=`make_system_path_relative_to_its_root $dirname`
+   localname=`echo $basename | sed -e "s,vmlinuz-,,g" | sed -e "s,-[0-9].*,,g"`
+-  version=`echo $basename | sed -e "s,^[^0-9]*-,,g"`
++  version=`echo $basename | sed -e "s,.*-,,g"`
+   alt_version=`echo $version | sed -e "s,\.old$,,g"`
+   linux_root_device_thisversion="${LINUX_ROOT_DEVICE}"

--- a/extra-admin/grub/autobuild/patches/10009-Strip-all-strings-before-kernel-version-number.patch
+++ b/extra-admin/grub/autobuild/patches/10009-Strip-all-strings-before-kernel-version-number.patch
@@ -2,8 +2,8 @@ diff --git a/10_linux.orig b/10_linux
 old mode 100644
 new mode 100755
 index b82ecee..e79af9c
---- a/10_linux.orig
-+++ b/10_linux
+--- a/util/grub.d/10_linux.in
++++ b/util/grub.d/10_linux.in
 @@ -217,7 +217,7 @@ while [ "x$list" != "x" ] ; do
    dirname=`dirname $linux`
    rel_dirname=`make_system_path_relative_to_its_root $dirname`

--- a/extra-admin/grub/spec
+++ b/extra-admin/grub/spec
@@ -1,4 +1,4 @@
 VER=2.02~beta2
-REL=3
+REL=4
 SRCTBL="ftp://alpha.gnu.org/gnu/grub/grub-$VER.tar.xz"
 SUBDIR=.


### PR DESCRIPTION
Patch 10008 is intended to fix problems with detecting the corresponding
initrd of kernels with local names other than "aosc-main". However, the
regexp parser for "$version" still keep strings containing numeric
characters. For example:

    vmlinuz-aosc-ck5-4.7.6

will have a `$version` of

    ck5-4.7.6

because of the "5" in "ck5", which will not produce a correct pattern
when detecting initramfs:

    initramfs-ck5-4.7.6-aosc-ck5.img

(should be `initramfs-4.7.6-aosc-ck5.img` instead)

This PR fixes this problem by stripping out *all* characters before
the *real* version number.