### PR TITLE
Enhancement - Specify boincmgr data folder

### DIFF
--- a/extra-scientific/boinc/autobuild/overrides/usr/share/applications/boinc.desktop
+++ b/extra-scientific/boinc/autobuild/overrides/usr/share/applications/boinc.desktop
@@ -1,19 +1,22 @@
 [Desktop Entry]
 Type=Application
 Version=1.0
-Exec=/usr/bin/boincmgr
+Exec=/usr/bin/boincmgr -d /var/lib/boinc
 Path=/var/lib/boinc
 Icon=boinc
 Categories=System;Monitor;GTK;
 Name=BOINC Manager
 Name[zh_CN]=BOINC 管理中心
+Name[zh_TW]=BOINC 管理中心
 GenericName=BOINC monitor and control utility
 GenericName[zh_CN]=BOINC 监视与控制中心
+GenericName[zh_TW]=BOINC 監視與控制中心
 GenericName[cs]=Monitorovací a ovládací nástroj pro BOINC
 GenericName[de]=BOINC Überwachungs- und Kontrollprogramm
 GenericName[pt]=Monitorização BOINC e utilitário de controlo
 Comment=Configure or monitor a BOINC core client
 Comment[zh_CN]=配置或监视 BOINC 客户端
+Comment[zh_TW]=配置或監視 BOINC 客戶端
 Comment[cs]=Monitoruje a nastavuje klienta BOINC
 Comment[de]=BOINC Basis Client konfigurieren oder überwachen
 Comment[pt]=Configurar ou monitorizar o cliente básico do BOINC


### PR DESCRIPTION
Specify the data folder in order to prevent opening a boincmgr that was not connected to boinc client by clicking the icon provided by application launchers. Also add zh_TW