### PR TITLE
Corrected a package dependency typo in the package "abiword". (User Report)

### DIFF
--- a/extra-productivity/abiword/autobuild/defines
+++ b/extra-productivity/abiword/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=abiword
 PKGSEC=doc
-PKGDEP="fribidi wv goffice librsvg enchant desktop-file-utils redland libical loudmouth libwpg libwmf link-grammar gtkmathview akisaurus libsoup libgsf psiconv libwpd libchamplain evolution-data-server"
+PKGDEP="fribidi wv goffice librsvg enchant desktop-file-utils redland libical loudmouth libwpg libwmf link-grammar gtkmathview aiksaurus libsoup libgsf psiconv libwpd libchamplain evolution-data-server"
 BUILDDEP="asio lasem"
 PKGDES="fully-featured FOSS word processor"
 


### PR DESCRIPTION
The package "abiword" need another package named "aiksaurus", but there was a typo ("aiksaurus" -> "akisaurus") in the dependencies list made been unable to use.