### PR TITLE
dnsmasq: update to 2.78

### DIFF
--- a/extra-network/dnsmasq/spec
+++ b/extra-network/dnsmasq/spec
@@ -1,2 +1,2 @@
-VER=2.77
+VER=2.78
 SRCTBL="http://www.thekelleys.org.uk/dnsmasq/dnsmasq-$VER.tar.xz"


### PR DESCRIPTION
See https://security.googleblog.com/2017/10/behind-masq-yet-more-dns-and-dhcp.html and http://www.openwall.com/lists/oss-security/2017/10/02/5.