### PR TITLE
irssi: update to 1.0.4

### DIFF
--- a/extra-web/irssi/spec
+++ b/extra-web/irssi/spec
@@ -1,2 +1,2 @@
-VER=1.0.3
+VER=1.0.4
 SRCTBL="https://github.com/irssi/irssi/releases/download/$VER/irssi-$VER.tar.xz"


### PR DESCRIPTION
```
Two vulnerabilities have been located in Irssi.

(a) When receiving messages with invalid time stamps, Irssi would try
    to dereference a NULL pointer. Found by Brian 'geeknik' Carpenter
    of Geeknik Labs. (CWE-690)

    CVE-2017-10965 [2] was assigned to this bug

(b) While updating the internal nick list, Irssi may incorrectly use
    the GHashTable interface and free the nick while updating it. This
    will then result in use-after-free conditions on each access of
    the hash table. Found by Brian 'geeknik' Carpenter of Geeknik
    Labs. (CWE-416 caused by CWE-227)

    CVE-2017-10966 [3] was assigned to this bug
```

See https://irssi.org/2017/07/07/irssi-1.0.4-released/ and https://irssi.org/security/irssi_sa_2017_07.txt.

NOT tested.