### PR TITLE
Add boost to Wesnoth Dep

### DIFF
--- a/extra-games/wesnoth/autobuild/defines
+++ b/extra-games/wesnoth/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=wesnoth
 PKGSEC=games
-PKGDEP="sdl sdl-image sdl-mixer sdl-ttf sdl-net"
+PKGDEP="sdl sdl-image sdl-mixer sdl-ttf sdl-net boost"
 PKGDES="Battle of Wesnoth, a fantasy turn-based strategic game"
 PKGRECOM="fribidi"
-BUILDDEP="cmake boost"
+BUILDDEP="cmake"

--- a/extra-games/wesnoth/spec
+++ b/extra-games/wesnoth/spec
@@ -1,2 +1,3 @@
 VER=1.12.6
+REL=1
 SRCTBL="http://sourceforge.net/projects/wesnoth/files/wesnoth-${VER:0:4}/wesnoth-$VER/wesnoth-$VER.tar.bz2"


### PR DESCRIPTION
It happens that Wesnoth require a working boost even in runtime.

It also happens that the wesnoth in the repo was built for boost 1.58 but we now have 1.62
This might suggest a required REL bump with a boost version bump.