### PR TITLE
Stop icon scanning attempt in postinst

### DIFF
--- a/extra-wm/fluxbox/autobuild/postinst
+++ b/extra-wm/fluxbox/autobuild/postinst
@@ -1,1 +1,1 @@
-fluxbox-generate_menu -o /usr/share/fluxbox/menu
+fluxbox-generate_menu -in -o /usr/share/fluxbox/menu

--- a/extra-wm/fluxbox/spec
+++ b/extra-wm/fluxbox/spec
@@ -1,3 +1,3 @@
 VER=1.3.7
-REL=2
+REL=3
 SRCTBL="http://sourceforge.net/projects/fluxbox/files/fluxbox/$VER/fluxbox-$VER.tar.gz"


### PR DESCRIPTION
The fluxbox-generate_menu should have nothing to do
with icons, but it just did that... Just need a -in
switch to stop it from doing so.