### PR TITLE
systemd: fix wrong syntax in FallbackNTP

### DIFF
--- a/extra-admin/systemd/autobuild/defines
+++ b/extra-admin/systemd/autobuild/defines
@@ -42,7 +42,7 @@ MESON_AFTER="-Dkmod=true \
              -Dseccomp=true \
              -Dfallback-hostname=aosc
              -Dnobody_user=systemd-nobody -Dnobody_group=systemd-nogroup \
-             -Dntp-servers=0.pool.ntp.org,1.pool.ntp.org,2.pool.ntp.org,3.pool.ntp.org"
+             -Dntp-servers=pool.ntp.org"
 
 if [[ "${CROSS:-$ARCH}" = "powerpc" || "${CROSS:-$ARCH}" = "ppc64" ]]; then
     MESON_AFTER+=" -Db_lto=false"


### PR DESCRIPTION
FallbackNTP is a *space-separated* list of NTP server hostnames or IP addresses.
I don't know how to escape whitespace in MESON_AFTER. It seems difficult.
Let's use pool.ntp.org in the meantime.