### PR TITLE
libatomic-ops: update to 7.6.6

### DIFF
--- a/base-libs/libatomic-ops/spec
+++ b/base-libs/libatomic-ops/spec
@@ -1,2 +1,2 @@
-VER=7.6.4
+VER=7.6.6
 SRCTBL="https://github.com/ivmai/libatomic_ops/releases/download/v$VER/libatomic_ops-$VER.tar.gz"


### PR DESCRIPTION
* Fix 'undefined reference to __atomic_load/store/cas_16' error (gcc-7/x64)