### PR TITLE
Package add - clinfo

### DIFF
--- a/extra-devel/clinfo/autobuild/build
+++ b/extra-devel/clinfo/autobuild/build
@@ -1,0 +1,2 @@
+make
+PREFIX=$PKGDIR/usr make install

--- a/extra-devel/clinfo/autobuild/defines
+++ b/extra-devel/clinfo/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=clinfo
+PKGSEC=devel
+PKGDEP="opencl-registry-api"
+PKGDES="Display OpenCL information"

--- a/extra-devel/clinfo/spec
+++ b/extra-devel/clinfo/spec
@@ -1,0 +1,2 @@
+VER=2.2.18.04.06
+SRCTBL="https://github.com/Oblomov/clinfo/archive/${VER}.tar.gz"


### PR DESCRIPTION
License: CC0 (PD)

Note: it would build and install to `/bin` but it seemed like would not build into a deb package