### PR TITLE
Version Bump for BLAST and SAMTools

### DIFF
--- a/extra-scientific/ncbi-blast/autobuild/prepare
+++ b/extra-scientific/ncbi-blast/autobuild/prepare
@@ -1,2 +1,2 @@
 cd c++
-./configure --prefix=/usr
+./configure --prefix=$PKGDIR/usr

--- a/extra-scientific/ncbi-blast/spec
+++ b/extra-scientific/ncbi-blast/spec
@@ -1,3 +1,3 @@
-VER=2.6.0
+VER=2.7.1
 REL=0
 SRCTBL="ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-$VER+-src.tar.gz"

--- a/extra-scientific/samtools/spec
+++ b/extra-scientific/samtools/spec
@@ -1,2 +1,2 @@
-VER=1.4.1
-SRCTBL="https://github.com/samtools/samtools/releases/download/$VER/samtools-$VER-solo.tar.bz2"
+VER=1.8
+SRCTBL="https://github.com/samtools/samtools/releases/download/$VER/samtools-$VER.tar.bz2"


### PR DESCRIPTION
Tested. Compiles just fine.

SAMTools has 1.9 released but it would not compile, thus I upgrade it to 1.8 as of now, and try to figure out what the issue is with 1.9.