### PR TITLE
Bugfix: Upgrade Ruby

### DIFF
--- a/extra-ruby/ruby/autobuild/overrides/etc/profile.d/ruby-gem.sh
+++ b/extra-ruby/ruby/autobuild/overrides/etc/profile.d/ruby-gem.sh
@@ -1,1 +1,1 @@
-PATH="$PATH:$HOME/.gem/ruby/2.4.0/bin"
+PATH="$PATH:$HOME/.gem/ruby/2.5.0/bin"

--- a/extra-ruby/ruby/spec
+++ b/extra-ruby/ruby/spec
@@ -1,3 +1,3 @@
 VER=2.5.1
-REL=1
+REL=2
 SRCTBL="https://cache.ruby-lang.org/pub/ruby/${VER:0:3}/ruby-$VER.tar.xz"


### PR DESCRIPTION
The profile.d would set $PATH to 2.4.0 but we now have 2.5.0

Should be a minor change and have no impact on the ability to build or any abi change.