### PR TITLE
plasma-browser-integration: new, 5.14.3

### DIFF
--- a/extra-kde/plasma-browser-integration/autobuild/defines
+++ b/extra-kde/plasma-browser-integration/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=plasma-browser-integration
+PKGSEC=kde
+PKGDEP="kio ki18n kconfig kdbusaddons knotifications krunner kwindowsystem kactivities"
+BUILDDEP="extra-cmake-modules"
+PKGDES="Components necessary to integrate browsers into the Plasma Desktop"
+
+ABTYPE=cmake

--- a/extra-kde/plasma-browser-integration/spec
+++ b/extra-kde/plasma-browser-integration/spec
@@ -1,0 +1,2 @@
+VER=5.14.3
+SRCTBL="https://github.com/KDE/plasma-browser-integration/archive/v$VER.tar.gz"


### PR DESCRIPTION
Wiki page: https://community.kde.org/Plasma/Browser_Integration

Components necessary to integrate browsers into the Plasma Desktop

-----

By the way, I met some problem while using the following $SRCTBL: 
```
SRCTBL="https://download.kde.org/stable/plasma/$VER/plasma-browser-integration-$VER.tar.xz"
```
When ACBS download the file using aria2 from this URL, it will download two files (one meta and the real file) instead of one, and ACBS will try to decompress the meta but not the actual tarball...