### PR TITLE
swift-im: Fix FTBFS (port to Qt 5.11)

### DIFF
--- a/extra-web/swift-im/autobuild/patches/0000-fix-qtwebelement.patch
+++ b/extra-web/swift-im/autobuild/patches/0000-fix-qtwebelement.patch
@@ -1,0 +1,62 @@
+commit ace51a248e7d810f4794a41305f3b65f2e65ad11
+Author: Kay Lin <kaymw@aosc.io>
+Date:   Sun Nov 11 21:08:32 2018 -0800
+
+    Fix build failure with Qt 5.11
+    
+    Replace QWebElement with QtWebKit/QWebElement.
+    
+    Signed-off-by: Kay Lin <kaymw@aosc.io>
+    Co-authored-by: Icenowy Zheng <icenowy@aosc.xyz>
+
+diff --git a/Swift/QtUI/QtWebKitChatView.cpp b/Swift/QtUI/QtWebKitChatView.cpp
+index b543e34bd..b25a01650 100644
+--- a/Swift/QtUI/QtWebKitChatView.cpp
++++ b/Swift/QtUI/QtWebKitChatView.cpp
+@@ -18,7 +18,7 @@
+ #include <QStackedWidget>
+ #include <QTimer>
+ #include <QVBoxLayout>
+-#include <QWebFrame>
++#include <QtWebKitWidgets/QWebFrame>
+ #include <QtDebug>
+ 
+ #include <Swiften/Base/FileSize.h>
+diff --git a/Swift/QtUI/QtWebKitChatView.h b/Swift/QtUI/QtWebKitChatView.h
+index 173a05b7a..5b50f8d3b 100644
+--- a/Swift/QtUI/QtWebKitChatView.h
++++ b/Swift/QtUI/QtWebKitChatView.h
+@@ -10,7 +10,7 @@
+ 
+ #include <QList>
+ #include <QString>
+-#include <QWebElement>
++#include <QtWebKit/QWebElement>
+ #include <QWidget>
+ 
+ #include <Swiften/Base/Override.h>
+diff --git a/Swift/QtUI/QtWebView.h b/Swift/QtUI/QtWebView.h
+index 792f5f7c4..1d1d40465 100644
+--- a/Swift/QtUI/QtWebView.h
++++ b/Swift/QtUI/QtWebView.h
+@@ -7,7 +7,7 @@
+ 
+ #pragma once
+ 
+-#include <QWebView>
++#include <QtWebKitWidgets/QWebView>
+ #include <vector>
+ 
+ namespace Swift {
+diff --git a/Swift/QtUI/UserSearch/QtUserSearchWindow.h b/Swift/QtUI/UserSearch/QtUserSearchWindow.h
+index 15e68bf58..ce8e539e8 100644
+--- a/Swift/QtUI/UserSearch/QtUserSearchWindow.h
++++ b/Swift/QtUI/UserSearch/QtUserSearchWindow.h
+@@ -8,6 +8,7 @@
+ 
+ #include <QWizard>
+ #include <set>
++#include <QAbstractItemModel>
+ 
+ #include <Swift/QtUI/UserSearch/ui_QtUserSearchWizard.h>
+ #include <Swift/Controllers/UIInterfaces/UserSearchWindow.h>

--- a/extra-web/swift-im/spec
+++ b/extra-web/swift-im/spec
@@ -1,3 +1,3 @@
 VER=3.0
-REL=2
+REL=3
 SRCTBL="http://swift.im/downloads/releases/swift-3.0/swift-${VER}.tar.gz"


### PR DESCRIPTION
Added one patch: https://github.com/RedL0tus/aosc-os-abbs/blob/swift-im/extra-web/swift-im/autobuild/patches/0000-fix-qtwebelement.patch