### PR TITLE
obmenu-generator 0.85 and its friends

### DIFF
--- a/extra-perl/perl-data-dump/autobuild/defines
+++ b/extra-perl/perl-data-dump/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=perl-data-dump
+PKGDES="Pretty printing of data structures"
+PKGDEP="perl"
+
+ABHOST=noarch

--- a/extra-perl/perl-data-dump/spec
+++ b/extra-perl/perl-data-dump/spec
@@ -1,0 +1,2 @@
+VER=1.23
+SRCTBL="https://cpan.metacpan.org/authors/id/G/GA/GAAS/Data-Dump-$VER.tar.gz"

--- a/extra-perl/perl-linux-desktopfiles/autobuild/defines
+++ b/extra-perl/perl-linux-desktopfiles/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=perl-linux-desktopfiles
+PKGSEC=perl
+PKGDEP="perl"
+PKGDES="A very fast Perl module for parsing application .desktop files."
+
+ABHOST=noarch

--- a/extra-perl/perl-linux-desktopfiles/spec
+++ b/extra-perl/perl-linux-desktopfiles/spec
@@ -1,0 +1,2 @@
+VER=0.25
+SRCTBL="https://cpan.metacpan.org/authors/id/T/TR/TRIZEN/Linux-DesktopFiles-$VER.tar.gz"

--- a/extra-wm/obmenu-generator/autobuild/build
+++ b/extra-wm/obmenu-generator/autobuild/build
@@ -1,0 +1,2 @@
+install -Dvm755 obmenu-generator "$PKGDIR"/usr/bin/obmenu-generator
+install -Dvm644 schema.pl "$PKGDIR"/etc/xdg/obmenu-generator/schema.pl

--- a/extra-wm/obmenu-generator/autobuild/defines
+++ b/extra-wm/obmenu-generator/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=obmenu-generator
+PKGDES="A fast menu generator for the Openbox Window Manager."
+PKGDEP="openbox perl perl-data-dump perl-linux-desktopfiles perl-gtk2 perl-file-desktopentry"
+
+ABHOST=noarch

--- a/extra-wm/obmenu-generator/spec
+++ b/extra-wm/obmenu-generator/spec
@@ -1,0 +1,2 @@
+VER=0.85
+SRCTBL="https://github.com/trizen/obmenu-generator/archive/$VER.tar.gz"


### PR DESCRIPTION
perl-linux-desktopfiles:
  - A very fast Perl module for parsing application .desktop files.
  - https://metacpan.org/release/Linux-DesktopFiles
  - Depended by obmenu-generator

perl-data-dump (not perl-data-dumper):
  - Pretty printing of data structures.
  - https://metacpan.org/pod/Data::Dump
  - Depended by obmenu-generator

obmenu-generator:
  - A fast menu generator for the Openbox Window Manager.
  - https://github.com/trizen/obmenu-generator