### PR TITLE
mono: update to 5.18.0.268

### DIFF
--- a/extra-mono/mono/autobuild/prepare
+++ b/extra-mono/mono/autobuild/prepare
@@ -1,3 +1,3 @@
-git submodule update --init --recursive
+# git submodule update --init --recursive
 export AUTOTOOLS_DEF=""
 ./autogen.sh

--- a/extra-mono/mono/autobuild/prepare
+++ b/extra-mono/mono/autobuild/prepare
@@ -1,3 +1,2 @@
-# git submodule update --init --recursive
 export AUTOTOOLS_DEF=""
 ./autogen.sh

--- a/extra-mono/mono/spec
+++ b/extra-mono/mono/spec
@@ -1,5 +1,2 @@
 VER=5.18.0.268
 SRCTBL="https://download.mono-project.com/sources/mono/mono-${VER}.tar.bz2"
-#SRCTBL="https://github.com/mono/mono/archive/mono-${VER}.tar.gz"
-#GITSRC="https://github.com/mono/mono.git"
-GITCO="tags/mono-$VER"

--- a/extra-mono/mono/spec
+++ b/extra-mono/mono/spec
@@ -1,4 +1,5 @@
-VER=5.18.0.240
+VER=5.18.0.268
+SRCTBL="https://download.mono-project.com/sources/mono/mono-${VER}.tar.bz2"
 #SRCTBL="https://github.com/mono/mono/archive/mono-${VER}.tar.gz"
-GITSRC="https://github.com/mono/mono.git"
+#GITSRC="https://github.com/mono/mono.git"
 GITCO="tags/mono-$VER"


### PR DESCRIPTION
It seems that Mono doesn't always push a tag while a new stable release is available, so using tarballs from official site makes sense now. What else changes are needed for this?