### PR TITLE
cpprestsdk: update to 2.10.10

### DIFF
--- a/extra-devel/cpprestsdk/spec
+++ b/extra-devel/cpprestsdk/spec
@@ -1,3 +1,3 @@
-VER=2.10.8
+VER=2.10.10
 SRCTBL="https://github.com/Microsoft/cpprestsdk/archive/v$VER.tar.gz"
 SUBDIR="cpprestsdk-$VER/Release"


### PR DESCRIPTION
Update from https://github.com/Microsoft/cpprestsdk/releases/tag/v2.10.10