### PR TITLE
pgadmin: update to 4.2

### DIFF
--- a/extra-database/pgadmin/autobuild/prepare
+++ b/extra-database/pgadmin/autobuild/prepare
@@ -1,3 +1,3 @@
 # Adapted from Arch Linux (community).
 export PYTHONVERSION="$(python3 -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')"
-sed 's|value("PythonPath")|value("PythonPath", "/usr/lib/pgadmin4/venv/lib/python'${PYTHONVERSION}'/site-packages:/usr/lib/python'${PYTHONVERSION}'/site-packages:/usr/lib/python'${PYTHONVERSION}'")|g' -i runtime/{pgAdmin4.cpp,Server.cpp,BrowserWindow.cpp}
+sed 's|value("PythonPath")|value("PythonPath", "/usr/lib/pgadmin4/venv/lib/python'${PYTHONVERSION}'/site-packages:/usr/lib/python'${PYTHONVERSION}'/site-packages:/usr/lib/python'${PYTHONVERSION}'")|g' -i runtime/{pgAdmin4.cpp,Server.cpp}

--- a/extra-database/pgadmin/spec
+++ b/extra-database/pgadmin/spec
@@ -1,2 +1,2 @@
-VER=2.1
+VER=4.2
 SRCTBL="https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v$VER/source/pgadmin4-$VER.tar.gz"


### PR DESCRIPTION
It builds and runs, after manually install all pip packages...

## See also

[Release Notes Version 4.2](https://www.pgadmin.org/docs/pgadmin4/4.x/release_notes_4_2.html)