### PR TITLE
shadowsocks-libev: update to 3.2.4

### DIFF
--- a/extra-network/shadowsocks-libev/spec
+++ b/extra-network/shadowsocks-libev/spec
@@ -1,2 +1,2 @@
-VER=3.2.3
+VER=3.2.4
 SRCTBL="https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$VER/shadowsocks-libev-$VER.tar.gz"


### PR DESCRIPTION
## See also

[Release v3.2.4](https://github.com/shadowsocks/shadowsocks-libev/releases/tag/v3.2.4)