### PR TITLE
ccache: update to latest stable + changed d/l source

### DIFF
--- a/extra-devel/ccache/spec
+++ b/extra-devel/ccache/spec
@@ -1,3 +1,3 @@
-VER=3.6
-SRCTBL="http://samba.org/ftp/ccache/ccache-$VER.tar.xz"
-CHKSUM="sha256::a6b129576328fcefad00cb72035bc87bc98b6a76aec0f4b59bed76d67a399b1f"
+VER=3.7.1
+SRCTBL="https://github.com/ccache/ccache/releases/download/v$VER/ccache-$VER.tar.xz"
+CHKSUM="sha256::66fc121a2a33968f9ec428e02f48ff4b8896fbabb759e9c09352267014dcbe65"


### PR DESCRIPTION
* ccache [moved their website](https://ccache.dev/news.html#2019-04-03) to https://ccache.dev   
* https://ccache.dev/releasenotes.html#_ccache_3_7_1  
* changed d/l location to the ccache github repo