### PR TITLE
Revert "nano: update to 4.2"

### DIFF
--- a/base-editors/nano/spec
+++ b/base-editors/nano/spec
@@ -1,3 +1,3 @@
-VER=4.2
+VER=4.1
 SRCTBL="https://www.nano-editor.org/dist/v${VER:0:1}/nano-$VER.tar.xz"
-CHKSUM="sha256::1143defce62e391b241252ffdb6e5c1ded56cfe26d46ee81b796abe0ccc45df9"
+CHKSUM="SHA256::86bde596a038d6fde619b49d785c0ebf0b3eaa7001a39dbe9316bd5392d221d0"


### PR DESCRIPTION
Reverts AOSC-Dev/aosc-os-abbs#1824
should merge to explosive, not testing