### PR TITLE
systemd: use robuster re-execute method

### DIFF
--- a/extra-admin/systemd/autobuild/postinst
+++ b/extra-admin/systemd/autobuild/postinst
@@ -2,6 +2,7 @@ if [ -f /run/systemd/private ]; then
 	# Equivalent to
 	# systemctl daemon-reexec
 	# However, this will be robuster when systemctl itself is not available.
+	# Ref: https://manpages.ubuntu.com/manpages/disco/en/man1/init.1.html#signals
 	kill 1
 fi
 

--- a/extra-admin/systemd/autobuild/postinst
+++ b/extra-admin/systemd/autobuild/postinst
@@ -1,10 +1,13 @@
-systemctl --system daemon-reexec
+if [ -f /run/systemd/private ]; then
+	# Equivalent to
+	# systemctl daemon-reexec
+	# However, this will be robuster when systemctl itself is not available.
+	kill 1
+fi
 
 systemd-machine-id-setup
 
 setfacl -Rnm g:wheel:rx,d:g:wheel:rx,g:adm:rx,d:g:adm:rx var/log/journal/ 2>/dev/null
-
-systemctl --system daemon-reexec
 
 systemd-sysusers
 udevadm hwdb --update

--- a/extra-admin/systemd/spec
+++ b/extra-admin/systemd/spec
@@ -1,3 +1,4 @@
 VER=242
+REL=1
 GITSRC="https://github.com/systemd/systemd-stable"
 GITCO="1e5d2d656420d0e755dbcf72aeba3c3aba54e956"


### PR DESCRIPTION
This replace the daemon-reexec for smoother transition
through the version 240 due to protocol incompatibility
introduced from 3f10c66270b74530339b3f466c43874bb40c210f