### PR TITLE
svxlink: new, 17.12.2

### DIFF
--- a/extra-radio/svxlink/autobuild/defines
+++ b/extra-radio/svxlink/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=svxlink
+PKGSEC=hamradio
+PKGDEP="alsa-utils alsa-lib libsigc++ gsm libgcrypt popt tcl speex opus qt-5"
+PKGDES="Echolink Software to provide Ham Radio Voip Operations"
+
+ABTYPE="cmake"
+CMAKE_AFTER=" -DUSE_QT=YES ../src"

--- a/extra-radio/svxlink/autobuild/override/usr/lib/systemd/system/remotetrx.service
+++ b/extra-radio/svxlink/autobuild/override/usr/lib/systemd/system/remotetrx.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Echolink Software Remotetrx
+After=network.target
+After=sound.target
+
+[Service]
+Type=simple
+User=svxlink
+Group=svxlink
+ExecStart=/usr/bin/remotetrx
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/extra-radio/svxlink/autobuild/override/usr/lib/systemd/system/svxlink.service
+++ b/extra-radio/svxlink/autobuild/override/usr/lib/systemd/system/svxlink.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Echolink Software
+After=network.target
+After=sound.target
+
+[Service]
+Type=simple
+User=svxlink
+Group=svxlink
+ExecStart=/usr/bin/svxlink
+Restart=always
+
+
+[Install]
+WantedBy=multi-user.target

--- a/extra-radio/svxlink/autobuild/postinst
+++ b/extra-radio/svxlink/autobuild/postinst
@@ -1,0 +1,12 @@
+/usr/bin/egrep -i "^svxlink" /etc/group >> /dev/zero
+if [ ! $? -eq 0 ]
+then
+	groupadd svxlink
+fi
+
+/usr/bin/egrep -i "^svxlink" /etc/passwd >> /dev/zero
+if [ ! $? -eq 0 ]
+then
+	useradd svxlink -m -d /var/spool/svxlink -g svxlink -G uucp,tty,audio
+fi
+chown -R svxlink:svxlink ${pkgdir}/var/spool/svxlink

--- a/extra-radio/svxlink/autobuild/postrm
+++ b/extra-radio/svxlink/autobuild/postrm
@@ -1,0 +1,11 @@
+/usr/bin/egrep -i "^svxlink" /etc/passwd >> /dev/zero
+if [ $? -eq 0 ]
+then
+        userdel svxlink
+fi
+
+/usr/bin/egrep -i "^svxlink" /etc/group >> /dev/zero
+if [ $? -eq 0 ]
+then
+        groupdel svxlink
+fi

--- a/extra-radio/svxlink/spec
+++ b/extra-radio/svxlink/spec
@@ -1,0 +1,3 @@
+VER=17.12.2
+SRCTBL="https://github.com/sm0svx/svxlink/archive/$VER.tar.gz"
+CHKSUM="sha256::0e21b172858d54d642cd9c8a7e33e87bb50b1548f0291074271e08ab5f1e060c"


### PR DESCRIPTION
https://www.svxlink.org/
VoIP for HAMs. Maybe an [EchoLink](http://www.echolink.org/) replacement on GNU/Linux.

Re-target #1885 to explosive branch.