### PR TITLE
Introduce triehash to build apt

### DIFF
--- a/extra-admin/apt/autobuild/defines
+++ b/extra-admin/apt/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=admin
 PKGDEP="dpkg glibc zlib bzip2 curl gtest lz4 apt-gen-list libidn2 \
         systemd gnutls zstd"
 BUILDDEP="graphviz w3m docbook2x docbook-xml docbook-xsl docbook-sgml \
-          po4a cmake doxygen"
+          po4a cmake doxygen triehash"
 PKGDES="Advanced Packaging Tools"
 
 PKGEPOCH=1

--- a/extra-admin/apt/spec
+++ b/extra-admin/apt/spec
@@ -1,3 +1,3 @@
-VER=1.8.2
+VER=1.9.2
 GITSRC="https://salsa.debian.org/apt-team/apt"
 GITCO="tags/$VER"

--- a/extra-admin/apt/spec
+++ b/extra-admin/apt/spec
@@ -1,3 +1,3 @@
 VER=1.9.2
-GITSRC="https://salsa.debian.org/apt-team/apt"
+GITSRC="https://salsa.debian.org/apt-team/apt.git"
 GITCO="tags/$VER"

--- a/extra-devel/triehash/autobuild/build
+++ b/extra-devel/triehash/autobuild/build
@@ -1,7 +1,7 @@
-abinfo "Build TrieHash"
+abinfo "Building TrieHash"
 pod2man -r "triehash v$PKGVER" -c triehash triehash.pl triehash.1
 
-abinfo "Deploy files"
+abinfo "Deploying files"
 install -Dm755 "$SRCDIR"/triehash.pl "$PKGDIR"/usr/bin/triehash
 mkdir -p "$PKGDIR"/usr/share/man/man1
 cp "$SRCDIR"/triehash.1 "$PKGDIR"/usr/share/man/man1

--- a/extra-devel/triehash/autobuild/build
+++ b/extra-devel/triehash/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Build TrieHash"
+pod2man -r "triehash v$PKGVER" -c triehash triehash.pl triehash.1
+
+abinfo "Deploy files"
+install -Dm755 "$SRCDIR"/triehash.pl "$PKGDIR"/usr/bin/triehash
+mkdir -p "$PKGDIR"/usr/share/man/man1
+cp "$SRCDIR"/triehash.1 "$PKGDIR"/usr/share/man/man1

--- a/extra-devel/triehash/autobuild/defines
+++ b/extra-devel/triehash/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=triehash
+PKGSEC=devel
+PKGDEP="perl"
+PKGDES="A generator that generates a minimal order-preserving perfect hash function in C code"

--- a/extra-devel/triehash/spec
+++ b/extra-devel/triehash/spec
@@ -1,0 +1,3 @@
+VER=0.3
+SRCTBL="https://github.com/julian-klode/triehash/archive/v$VER.tar.gz"
+CHKSUM="sha256::289a0966c02c2008cd263d3913a8e3c84c97b8ded3e08373d63a382c71d2199c"


### PR DESCRIPTION
Fix #1913.

> Fixed by introducing triehash, thanks to Debian/apt#68, close this after the PR gets merged.
