### PR TITLE
aiohttp: new, 3.6.2 with its dependencies

### DIFF
--- a/extra-python/aiohttp/autobuild/defines
+++ b/extra-python/aiohttp/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=aiohttp
+PKGSEC=python
+PKGDEP="attrs chardet multidict async-timeout yarl idna"
+BUILDDEP="setuptools pathlib"
+PKGDES="An async http client/server framework"
+
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/aiohttp/spec
+++ b/extra-python/aiohttp/spec
@@ -1,0 +1,3 @@
+VER=3.6.2
+SRCTBL="https://github.com/aio-libs/aiohttp/archive/v${VER}.tar.gz"
+CHKSUM="sha256::4ad2d8393843ea0c7b50a93bf04fb1cf20b93c0a5e958de128efcd2e5f8adf80"

--- a/extra-python/async-timeout/autobuild/defines
+++ b/extra-python/async-timeout/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=async-timeout
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="An asyncio-compatible timeout context manager"
+
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/async-timeout/spec
+++ b/extra-python/async-timeout/spec
@@ -1,0 +1,3 @@
+VER=3.0.1
+SRCTBL="https://github.com/aio-libs/async-timeout/archive/v${VER}.tar.gz"
+CHKSUM="sha256::d0a7a927ed6b922835e1b014dfcaa9982caccbb25131320582cc660af7c93949"

--- a/extra-python/multidict/autobuild/defines
+++ b/extra-python/multidict/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=multidict
 PKGSEC=python
 PKGDEP="python-3 glibc"
 BUILDDEP="setuptools"
-PKGDES="A dict-like collection of key-value pairs where key might be occurred more than once in the container"
+PKGDES="Dict-like key-value pairs collection for Python"
 
 ABTYPE=python
 NOPYTHON2=1

--- a/extra-python/multidict/autobuild/defines
+++ b/extra-python/multidict/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=multidict
+PKGSEC=python
+PKGDEP="python-3 glibc"
+BUILDDEP="setuptools"
+PKGDES="A dict-like collection of key-value pairs where key might be occurred more than once in the container"
+
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/multidict/spec
+++ b/extra-python/multidict/spec
@@ -1,0 +1,3 @@
+VER=4.7.6
+SRCTBL="https://github.com/aio-libs/multidict/archive/v${VER}.tar.gz"
+CHKSUM="sha256::449035f89a12f189579ff83811424c71e4a39e335bcb8045145ad084b7bde2dc"

--- a/extra-python/yarl/autobuild/defines
+++ b/extra-python/yarl/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=yarl
 PKGSEC=python
 PKGDEP="glibc multidict idna"
 BUILDDEP="setuptools pathlib"
-PKGDES="A URL library"
+PKGDES="Yet another URL library for Python"
 
 ABTYPE=python
 NOPYTHON2=1

--- a/extra-python/yarl/autobuild/defines
+++ b/extra-python/yarl/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=yarl
+PKGSEC=python
+PKGDEP="glibc multidict idna"
+BUILDDEP="setuptools pathlib"
+PKGDES="A URL library"
+
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/yarl/spec
+++ b/extra-python/yarl/spec
@@ -1,0 +1,3 @@
+VER=1.5.0
+SRCTBL="https://github.com/aio-libs/yarl/archive/v${VER}.tar.gz"
+CHKSUM="sha256::6bd62c4a97648f8c052b514a72c6db5f626e94bef98a40a7423e8202a299bb7e"


### PR DESCRIPTION
```
yarl 1.5.0
async-timeout 3.0.1
multidict 4.7.6
aiohttp 3.6.2
```