### PR TITLE
systemd: add trigger to update kernel in ESP partition automatically

### DIFF
--- a/extra-admin/systemd/autobuild/overrides/usr/bin/systemd-boot-friend
+++ b/extra-admin/systemd/autobuild/overrides/usr/bin/systemd-boot-friend
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+linfo() {
+    bold=$(tput bold)
+    normal=$(tput sgr0)
+    echo -e "${bold}[systemd-boot-friend]${normal} $*"
+}
+
+if [[ -d /boot/efi/EFI/aosc ]]; then
+    linfo "/boot/efi/EFI/aosc exists. Moving latest kernel and initramfs to this location."
+    # First clean up the old ones
+    DISTRO_NAME="aosc"
+    rm /boot/efi/EFI/aosc/initramfs-"$DISTRO_NAME"-*.img
+    rm /boot/efi/EFI/aosc/vmlinuz-"$DISTRO_NAME"-*
+
+    for i in $(ls /usr/lib/modules | grep -v 'extramodules'); do
+        KERNEL_VER=$(echo $i | cut -d'-' -f1)
+        DISTRO_NAME=$(echo $i | cut -d'-' -f2)
+        KERNEL_FLAVOR=$(echo $i | cut -d'-' -f3)
+
+        # Then move new kernels and initramfs to location
+        linfo "Installing $i to /boot/efi/EFI/aosc..."
+        cp /boot/initramfs-"$KERNEL_VER"-"$DISTRO_NAME"-"$KERNEL_FLAVOR".img /boot/efi/EFI/aosc/initramfs-"$DISTRO_NAME"-"$KERNEL_FLAVOR".img
+        cp /boot/vmlinuz-"$DISTRO_NAME"-"$KERNEL_FLAVOR"-"$KERNEL_VER" /boot/efi/EFI/aosc/vmlinuz-"$DISTRO_NAME"-"$KERNEL_FLAVOR"
+    done
+
+    if [[ -e /boot/intel-ucode.img ]]; then
+        linfo "intel-ucode detected. Installing..."
+        cp /boot/intel-ucode.img /boot/efi/EFI/aosc/intel-ucode.img
+    fi
+else
+    linfo "/boot/efi/EFI/aosc does not exists. Doing nothing."
+    linfo "If you wish to use systemd-boot, run systemd-boot-friend-init ."
+fi

--- a/extra-admin/systemd/autobuild/overrides/usr/bin/systemd-boot-friend-init
+++ b/extra-admin/systemd/autobuild/overrides/usr/bin/systemd-boot-friend-init
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+linfo() {
+    bold=$(tput bold)
+    normal=$(tput sgr0)
+    echo -e "${bold}[systemd-boot-friend-init]${normal} $*"
+}
+
+linfo "This script helps you to initialize systemd-boot on AOSC OS."
+
+if [[ $EUID > 0 ]]; then
+  linfo "Please run as root"
+  exit 1
+fi
+
+# Check if /boot/efi is mounted and has a vfat filesystem, according to UEFI specification.
+cat /proc/mounts | grep "/boot/efi vfat" 2>&1 > /dev/null
+if [[ $? != 0 ]]; then
+    linfo "It seems that /boot/efi is not mounted or does not have vfat filesystem. Please mount your ESP to /boot/efi and make sure it has correct filesystem."
+    exit 1
+fi
+
+linfo "Attempting to install systemd-boot..."
+bootctl install
+# If failed, exit now.
+if [[ $? != 0 ]]; then
+    linfo "Failed to install systemd-boot. Exiting now."
+fi
+
+
+# Layout structure for trigger 
+linfo "Creating folder structure for friend..."
+mkdir -p /boot/efi/EFI/aosc
+linfo "Calling systemd-boot-friend to install the kernels..."
+bash systemd-boot-friend
+
+# Then try to create systemd-boot config files.
+linfo "Attempting to create systemd-boot boot entries..."
+
+# Probe PARTUUID for /
+ROOT_PARTITION=$(cat /proc/mounts | grep " / " | awk '{print $1}')
+if [[ $? != 0 ]]; then
+    linfo "Failed to probe root partition, you may want to manually edit /boot/efi/loader/entries/aosc-*.conf manually later."
+    ROOT_PARTUUID="EDITME"
+else
+    ROOT_PARTUUID=$(blkid --match-tag PARTUUID --output value "$ROOT_PARTITION")
+    if [[ $? != 0 ]]; then
+        linfo "Failed to probe PARTUUID for root partition, you may want to manually edit /boot/efi/loader/entries/aosc-*.conf manually later."
+        ROOT_PARTUUID="EDITME"
+    fi
+fi
+
+for i in $(ls /usr/lib/modules | grep -v 'extramodules'); do
+    KERNEL_VER=$(echo $i | cut -d'-' -f1)
+    DISTRO_NAME=$(echo $i | cut -d'-' -f2)
+    KERNEL_FLAVOR=$(echo $i | cut -d'-' -f3)
+    
+    linfo "Creating boot entry for $i..."
+    ENTRY_FILE="/boot/efi/loader/entries/$DISTRO_NAME-$KERNEL_FLAVOR.conf"
+    if [[ -r /boot/bootargs ]]; then
+        KERNEL_ARGS=$(cat /boot/bootargs)
+    fi
+    echo "title AOSC OS ($KERNEL_FLAVOR)" > "$ENTRY_FILE" # Empty the file here
+    echo "linux /EFI/aosc/vmlinuz-$DISTRO_NAME-$KERNEL_FLAVOR" >> "$ENTRY_FILE"
+    if [[ -e /boot/efi/EFI/aosc/intel-ucode.img ]]; then
+        echo "initrd /EFI/aosc/intel-ucode.img" >> "$ENTRY_FILE"
+    fi
+    echo "initrd /EFI/aosc/initramfs-$DISTRO_NAME-$KERNEL_FLAVOR.img" >> "$ENTRY_FILE"
+    echo "options root=PARTUUID=$ROOT_PARTUUID rw $KERNEL_ARGS" >> "$ENTRY_FILE"
+done
+
+linfo "Success! Now you should be able to boot the system via systemd-boot. Please make sure Linux Boot Manager is the first boot option in this computer's firmware setting."
+linfo "If you want to change the kernel arguments, you can edit /boot/bootargs and re-run this script."

--- a/extra-admin/systemd/autobuild/triggers
+++ b/extra-admin/systemd/autobuild/triggers
@@ -1,0 +1,1 @@
+interest /boot


### PR DESCRIPTION
- add systemd-boot-friend to deal with kernel updates and install it to ESP
- add systemd-boot-friend-init to initialize systemd-boot and generate boot config files