### PR TITLE
wine: add a patch for disabling wechat/netease cloud music windows shadow

### DIFF
--- a/extra-emulation/wine/autobuild/patches/0002-wine-user32-hack-for-disabling-wechat-and-netease-cloud-music-windows-shadow.patch
+++ b/extra-emulation/wine/autobuild/patches/0002-wine-user32-hack-for-disabling-wechat-and-netease-cloud-music-windows-shadow.patch
@@ -1,0 +1,19 @@
+--- a/dlls/user32/win.c  2020-04-09 22:20:30.459968806 +0800
++++ b/dlls/user32/win.c  2020-04-09 21:54:09.588643751 +0800
+@@ -1795,6 +1795,17 @@
+     cs.lpszClass      = className;
+     cs.dwExStyle      = exStyle;
+ 
++    if (exStyle == 0x080800a0) // WeChat/WxWork shadow hwnd
++    {
++        FIXME("hack %x\n", cs.dwExStyle);
++        return NULL;
++    }
++    if (exStyle == 0x000800a0) // Netease Cloudmusic shadow hwnd
++    {
++        FIXME("hack %x\n", cs.dwExStyle);
++        return NULL;
++    }
++
+     return wow_handlers.create_window( &cs, className, instance, TRUE );
+ }

--- a/extra-emulation/wine/spec
+++ b/extra-emulation/wine/spec
@@ -1,4 +1,4 @@
 VER=5.18
 SRCTBL="https://dl.winehq.org/wine/source/5.x/wine-$VER.tar.xz"
 CHKSUM="sha256::9001f488651a9beb83a1cddf230dc0e79c708847f2ffc7de5cc20469e265f342"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------
add a `wine` patch for disabling wechat/netease cloud music windows shadow

Package(s) Affected
-------------------

wine

Security Update?
----------------

<!-- If this topic is part of a security update, please select yes, and mark with the `security` label for priority processing. -->

- [ ] Yes
- [x] No

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

<!-- TODO: CI to auto-fill architectural progress. -->
