### PR TITLE
kmscon: update to 8+git20201004

### DIFF
--- a/extra-libs/libtsm/spec
+++ b/extra-libs/libtsm/spec
@@ -1,3 +1,3 @@
-VER=3
-SRCTBL="https://www.freedesktop.org/software/kmscon/releases/libtsm-$VER.tar.xz"
-CHKSUM="sha256::114115d84a2bc1802683871ea2d70a16ddeec8d2f8cde89ebd2046d775e6cf07"
+VER=4.0.1
+GITSRC="https://github.com/Aetf/libtsm.git"
+GITCO="tags/v$VER"

--- a/extra-utils/kmscon/autobuild/beyond
+++ b/extra-utils/kmscon/autobuild/beyond
@@ -1,1 +1,3 @@
-cp docs/kmscon{,vt@}.service "$PKGDIR"/usr/lib/systemd/system/
+abinfo "Installing systemd services..."
+mkdir -pv "$PKGDIR"/usr/lib/systemd/system/
+cp -v docs/kmscon{,vt@}.service "$PKGDIR"/usr/lib/systemd/system/

--- a/extra-utils/kmscon/spec
+++ b/extra-utils/kmscon/spec
@@ -1,3 +1,3 @@
-VER=8
-SRCTBL="https://github.com/dvdhrm/kmscon/archive/kmscon-$VER.tar.gz"
-CHKSUM="sha256::656e496ebc7d78905c9ed8488e020067e7b96198ab784bc05238937aa3fb278c"
+VER=8+git20201004
+GITSRC="https://github.com/AOSC-Dev/kmscon"
+GITCO="c45b8bccac02c18f9933b5f4875daf823f317b60"


### PR DESCRIPTION
Topic Description
-----------------

Update kmscon to a forked version (the dependency libtsm is also updated).

Package(s) Affected
-------------------

`libtsm` 4.0.1
`kmscon` 8+git20201004

Security Update?
----------------

- [ ] Yes
- [x] No

Architectural Progress
----------------------

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

<!-- TODO: CI to auto-fill architectural progress. -->

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
