### PR TITLE
feeluown: update to 3.5.3

### DIFF
--- a/extra-multimedia/feeluown-download/autobuild/defines
+++ b/extra-multimedia/feeluown-download/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME="feeluown-download"
 PKGSEC=sound
-PKGDES="a FeelUOwn plugin for downloading music"
+PKGDES="FeelUOwn plugin for downloading music"
 PKGDEP="python-3 feeluown request"
 
 ABHOST=noarch

--- a/extra-multimedia/feeluown-download/autobuild/defines
+++ b/extra-multimedia/feeluown-download/autobuild/defines
@@ -6,3 +6,5 @@ PKGDEP="python-3 feeluown request"
 ABHOST=noarch
 ABTYPE=python
 NOPYTHON2=1
+
+PKGBREAK="fuocore"

--- a/extra-multimedia/feeluown-download/autobuild/defines
+++ b/extra-multimedia/feeluown-download/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME="feeluown-download"
 PKGSEC=sound
 PKGDES="FeelUOwn plugin for downloading music"
-PKGDEP="python-3 feeluown request"
+PKGDEP="python-3 feeluown requests"
 
 ABHOST=noarch
 ABTYPE=python

--- a/extra-multimedia/feeluown-download/autobuild/defines
+++ b/extra-multimedia/feeluown-download/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME="feeluown-download"
+PKGSEC=sound
+PKGDES="a FeelUOwn plugin for downloading music"
+PKGDEP="python-3 feeluown request"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-multimedia/feeluown-download/autobuild/defines
+++ b/extra-multimedia/feeluown-download/autobuild/defines
@@ -7,4 +7,5 @@ ABHOST=noarch
 ABTYPE=python
 NOPYTHON2=1
 
-PKGBREAK="fuocore"
+PKGBREAK="fuocore<=2.3-2"
+PKGREP="fuocore<=2.3-2"

--- a/extra-multimedia/feeluown-download/spec
+++ b/extra-multimedia/feeluown-download/spec
@@ -1,0 +1,3 @@
+VER=0.2
+SRCTBL="https://pypi.org/packages/source/f/fuo-dl/fuo_dl-${VER}.tar.gz"
+CHKSUM="sha256::c3a282c70d3810d4406938500d7a87994fc44924316b7ce41d0d840a1a12b0da"

--- a/extra-multimedia/feeluown-kuwo/autobuild/defines
+++ b/extra-multimedia/feeluown-kuwo/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME="feeluown-kuwo"
 PKGSEC=sound
-PKGDES="a FeelUOwn plugin for KuWo"
+PKGDES="FeelUOwn plugin for KuWo"
 PKGDEP="feeluown python-3 marshmallow requests"
 PKGBREAK="marshmallow<3.0.0 fuocore"
 

--- a/extra-multimedia/feeluown-kuwo/autobuild/defines
+++ b/extra-multimedia/feeluown-kuwo/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="feeluown-kuwo"
+PKGSEC=sound
+PKGDES="a FeelUOwn plugin for KuWo"
+PKGDEP="feeluown python-3 marshmallow requests"
+PKGBREAK="marshmallow<3.0.0"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-multimedia/feeluown-kuwo/autobuild/defines
+++ b/extra-multimedia/feeluown-kuwo/autobuild/defines
@@ -2,7 +2,8 @@ PKGNAME="feeluown-kuwo"
 PKGSEC=sound
 PKGDES="FeelUOwn plugin for KuWo"
 PKGDEP="feeluown python-3 marshmallow requests"
-PKGBREAK="marshmallow<3.0.0 fuocore"
+PKGBREAK="fuocore<=2.3-2"
+PKGREP="fuocore<=2.3-2"
 
 ABHOST=noarch
 ABTYPE=python

--- a/extra-multimedia/feeluown-kuwo/autobuild/defines
+++ b/extra-multimedia/feeluown-kuwo/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME="feeluown-kuwo"
 PKGSEC=sound
 PKGDES="a FeelUOwn plugin for KuWo"
 PKGDEP="feeluown python-3 marshmallow requests"
-PKGBREAK="marshmallow<3.0.0"
+PKGBREAK="marshmallow<3.0.0 fuocore"
 
 ABHOST=noarch
 ABTYPE=python

--- a/extra-multimedia/feeluown-kuwo/spec
+++ b/extra-multimedia/feeluown-kuwo/spec
@@ -1,0 +1,3 @@
+VER=0.1.2
+SRCTBL="https://pypi.org/packages/source/f/fuo-kuwo/fuo_kuwo-${VER}.tar.gz"
+CHKSUM="sha256::33f443566a24f5630aec45d9d7e89c47006be5c0fe845b79aef46375ff51980d"

--- a/extra-multimedia/feeluown-local/autobuild/defines
+++ b/extra-multimedia/feeluown-local/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="feeluown-local"
+PKGSEC=sound
+PKGDES="a FeelUOwn plugin for the local music source(s)"
+PKGDEP="feeluown python-3 marshmallow mutagen fuzzywuzzy"
+PKGBREAK="marshmallow<3.0.0"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-multimedia/feeluown-local/autobuild/defines
+++ b/extra-multimedia/feeluown-local/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME="feeluown-local"
 PKGSEC=sound
 PKGDES="a FeelUOwn plugin for the local music source(s)"
 PKGDEP="feeluown python-3 marshmallow mutagen fuzzywuzzy"
-PKGBREAK="marshmallow<3.0.0"
+PKGBREAK="marshmallow<3.0.0 fuocore"
 
 ABHOST=noarch
 ABTYPE=python

--- a/extra-multimedia/feeluown-local/autobuild/defines
+++ b/extra-multimedia/feeluown-local/autobuild/defines
@@ -2,7 +2,8 @@ PKGNAME="feeluown-local"
 PKGSEC=sound
 PKGDES="FeelUOwn plugin for the local music source(s)"
 PKGDEP="feeluown python-3 marshmallow mutagen fuzzywuzzy"
-PKGBREAK="marshmallow<3.0.0 fuocore"
+PKGBREAK="fuocore<=2.3-2"
+PKGREP="fuocore<=2.3-2"
 
 ABHOST=noarch
 ABTYPE=python

--- a/extra-multimedia/feeluown-local/autobuild/defines
+++ b/extra-multimedia/feeluown-local/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME="feeluown-local"
 PKGSEC=sound
-PKGDES="a FeelUOwn plugin for the local music source(s)"
+PKGDES="FeelUOwn plugin for the local music source(s)"
 PKGDEP="feeluown python-3 marshmallow mutagen fuzzywuzzy"
 PKGBREAK="marshmallow<3.0.0 fuocore"
 

--- a/extra-multimedia/feeluown-local/spec
+++ b/extra-multimedia/feeluown-local/spec
@@ -1,0 +1,3 @@
+VER=0.2.1
+SRCTBL="https://pypi.org/packages/source/f/fuo-local/fuo_local-${VER}.tar.gz"
+CHKSUM="sha256::926f2fb7409a505bbb2712fddcb3f097246199befa5ce64532cb423577fc446f"

--- a/extra-multimedia/feeluown-local/spec
+++ b/extra-multimedia/feeluown-local/spec
@@ -1,3 +1,3 @@
 VER=0.2.1
 SRCTBL="https://pypi.org/packages/source/f/fuo-local/fuo_local-${VER}.tar.gz"
-CHKSUM="sha256::926f2fb7409a505bbb2712fddcb3f097246199befa5ce64532cb423577fc446f"
+CHKSUM="sha256::a799a428e5c3cf8696e8dda124d7e7ac7dce1b1525b1100df40c748e4b13d445"

--- a/extra-multimedia/feeluown-netease/autobuild/defines
+++ b/extra-multimedia/feeluown-netease/autobuild/defines
@@ -2,9 +2,10 @@ PKGNAME="feeluown-netease"
 PKGSEC=sound
 PKGDES="FeelUOwn plugin for the Netease Cloud Music support"
 PKGDEP="feeluown python-3 marshmallow requests beautifulsoup4 pycryptodome"
+PKGBREAK="fuocore<=2.3-2"
+PKGREP="fuocore<=2.3-2"
 
 ABHOST=noarch
 ABTYPE=python
 NOPYTHON2=1
 
-PKGBREAK="marshmallow<3.0.0 fuocore"

--- a/extra-multimedia/feeluown-netease/autobuild/defines
+++ b/extra-multimedia/feeluown-netease/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME="feeluown-netease"
 PKGSEC=sound
-PKGDES="a FeelUOwn plugin for the Netease Cloud Music support"
+PKGDES="FeelUOwn plugin for the Netease Cloud Music support"
 PKGDEP="feeluown python-3 marshmallow requests beautifulsoup4 pycryptodome"
 
 ABHOST=noarch

--- a/extra-multimedia/feeluown-netease/autobuild/defines
+++ b/extra-multimedia/feeluown-netease/autobuild/defines
@@ -7,4 +7,4 @@ ABHOST=noarch
 ABTYPE=python
 NOPYTHON2=1
 
-PKGBREAK="marshmallow<3.0.0"
+PKGBREAK="marshmallow<3.0.0 fuocore"

--- a/extra-multimedia/feeluown-netease/autobuild/defines
+++ b/extra-multimedia/feeluown-netease/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME="feeluown-netease"
+PKGSEC=sound
+PKGDES="a FeelUOwn plugin for the Netease Cloud Music support"
+PKGDEP="feeluown python-3 marshmallow requests beautifulsoup4 pycryptodome"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1
+
+PKGBREAK="marshmallow<3.0.0"

--- a/extra-multimedia/feeluown-netease/spec
+++ b/extra-multimedia/feeluown-netease/spec
@@ -1,3 +1,3 @@
 VER=0.4.3
-SRCTBL="https://files.pythonhosted.org/packages/f/fuo-netease/fuo_netease-${VER}.tar.gz"
+SRCTBL="https://files.pythonhosted.org/packages/source/f/fuo-netease/fuo_netease-${VER}.tar.gz"
 CHKSUM="sha256::20aaa240f034a53a948e2f9d2ff9ec953cb6a98052245a6b6c1912ef6cecf38e"

--- a/extra-multimedia/feeluown-netease/spec
+++ b/extra-multimedia/feeluown-netease/spec
@@ -1,0 +1,3 @@
+VER=0.4.3
+SRCTBL="https://files.pythonhosted.org/packages/f/fuo-netease/fuo_netease-${VER}.tar.gz"
+CHKSUM="sha256::20aaa240f034a53a948e2f9d2ff9ec953cb6a98052245a6b6c1912ef6cecf38e"

--- a/extra-multimedia/feeluown-qqmusic/autobuild/defines
+++ b/extra-multimedia/feeluown-qqmusic/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="feeluown-qqmusic"
+PKGSEC=sound
+PKGDES="a FeelUOwn plugin for QQMusic"
+PKGDEP="feeluown python-3 marshmallow requests"
+PKGBREAK="marshmallow<3.0.0"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-multimedia/feeluown-qqmusic/autobuild/defines
+++ b/extra-multimedia/feeluown-qqmusic/autobuild/defines
@@ -2,7 +2,8 @@ PKGNAME="feeluown-qqmusic"
 PKGSEC=sound
 PKGDES="FeelUOwn plugin for QQMusic"
 PKGDEP="feeluown python-3 marshmallow requests"
-PKGBREAK="marshmallow<3.0.0 fuocore"
+PKGBREAK="fuocore<=2.3-2"
+PKGREP="fuocore<=2.3-2"
 
 ABHOST=noarch
 ABTYPE=python

--- a/extra-multimedia/feeluown-qqmusic/autobuild/defines
+++ b/extra-multimedia/feeluown-qqmusic/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME="feeluown-qqmusic"
 PKGSEC=sound
-PKGDES="a FeelUOwn plugin for QQMusic"
+PKGDES="FeelUOwn plugin for QQMusic"
 PKGDEP="feeluown python-3 marshmallow requests"
 PKGBREAK="marshmallow<3.0.0 fuocore"
 

--- a/extra-multimedia/feeluown-qqmusic/autobuild/defines
+++ b/extra-multimedia/feeluown-qqmusic/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME="feeluown-qqmusic"
 PKGSEC=sound
 PKGDES="a FeelUOwn plugin for QQMusic"
 PKGDEP="feeluown python-3 marshmallow requests"
-PKGBREAK="marshmallow<3.0.0"
+PKGBREAK="marshmallow<3.0.0 fuocore"
 
 ABHOST=noarch
 ABTYPE=python

--- a/extra-multimedia/feeluown-qqmusic/spec
+++ b/extra-multimedia/feeluown-qqmusic/spec
@@ -1,0 +1,3 @@
+VER=0.3.1
+SRCTBL="https://pypi.org/packages/source/f/fuo-qqmusic/fuo_qqmusic-${VER}.tar.gz"
+CHKSUM="sha256::1ee5a01fc684d08fcc43e0968e1b38477b24b7d5a0bbefcdd843970e9850701a"

--- a/extra-multimedia/feeluown-xiami/autobuild/defines
+++ b/extra-multimedia/feeluown-xiami/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME="feeluown-xiami"
 PKGSEC=sound
-PKGDES="a FeelUOwn plugin for Xiami"
+PKGDES="FeelUOwn plugin for Xiami"
 PKGDEP="feeluown python-3 marshmallow requests"
 
 ABHOST=noarch

--- a/extra-multimedia/feeluown-xiami/autobuild/defines
+++ b/extra-multimedia/feeluown-xiami/autobuild/defines
@@ -2,9 +2,10 @@ PKGNAME="feeluown-xiami"
 PKGSEC=sound
 PKGDES="FeelUOwn plugin for Xiami"
 PKGDEP="feeluown python-3 marshmallow requests"
+PKGBREAK="fuocore<=2.3-2"
+PKGREP="fuocore<=2.3-2"
 
 ABHOST=noarch
 ABTYPE=python
 NOPYTHON2=1
 
-PKGBREAK="marshmallow<3.0.0 fuocore"

--- a/extra-multimedia/feeluown-xiami/autobuild/defines
+++ b/extra-multimedia/feeluown-xiami/autobuild/defines
@@ -7,4 +7,4 @@ ABHOST=noarch
 ABTYPE=python
 NOPYTHON2=1
 
-PKGBREAK="marshmallow<3.0.0"
+PKGBREAK="marshmallow<3.0.0 fuocore"

--- a/extra-multimedia/feeluown-xiami/autobuild/defines
+++ b/extra-multimedia/feeluown-xiami/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME="feeluown-xiami"
+PKGSEC=sound
+PKGDES="a FeelUOwn plugin for Xiami"
+PKGDEP="feeluown python-3 marshmallow requests"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1
+
+PKGBREAK="marshmallow<3.0.0"

--- a/extra-multimedia/feeluown-xiami/spec
+++ b/extra-multimedia/feeluown-xiami/spec
@@ -1,0 +1,3 @@
+VER=0.2.4
+SRCTBL="https://pypi.org/packages/source/f/fuo-xiami/fuo_xiami-${VER}.tar.gz"
+CHKSUM="sha256::473e46270a918678ae60e4c3108e1bcd9eda987ea1db63f22e3b77617c2f9f70"

--- a/extra-multimedia/feeluown/autobuild/beyond
+++ b/extra-multimedia/feeluown/autobuild/beyond
@@ -11,7 +11,8 @@ Terminal=false
 StartupNotify=true
 EOF
 
-rm -f "$PKGDIR"/usr/bin/feeluown-genicon
+abinfo "Removing feeluown-genicon ... "
+rm -fv "$PKGDIR"/usr/bin/feeluown-genicon
 
 install -Dm644 "$SRCDIR"/feeluown/feeluown.png \
                "$PKGDIR"/usr/share/pixmaps/feeluown.png

--- a/extra-multimedia/feeluown/autobuild/beyond
+++ b/extra-multimedia/feeluown/autobuild/beyond
@@ -11,7 +11,7 @@ Terminal=false
 StartupNotify=true
 EOF
 
-rm -f "$PKGDIR"/usr/bin/feeluown-{install-dev,genicon,update}
+rm -f "$PKGDIR"/usr/bin/feeluown-genicon
 
 install -Dm644 "$SRCDIR"/feeluown/feeluown.png \
                "$PKGDIR"/usr/share/pixmaps/feeluown.png

--- a/extra-multimedia/feeluown/autobuild/defines
+++ b/extra-multimedia/feeluown/autobuild/defines
@@ -1,11 +1,12 @@
 PKGNAME=feeluown
 PKGSEC=sound
-PKGDEP="python-xlib quamash requests sqlalchemy xdg-utils mpv fuocore future"
-BUILDDEP="setuptools"
 PKGDES="A universal player for various Chinese music streaming services"
+PKGDEP="python-3 janus qasync pyqt5 pyopengl requests toml mpv \
+        feeluown-download feeluown-local feeluown-kuwo feeluown-netease feeluown-qqmusic feeluown-xiami"
+PKGBREAK="fuocore"
 
-NOPYTHON2=1
-ABTYPE=python
 ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1
 
 PKGEPOCH=1

--- a/extra-multimedia/feeluown/autobuild/overrides/usr/bin/feeluown
+++ b/extra-multimedia/feeluown/autobuild/overrides/usr/bin/feeluown
@@ -1,3 +1,0 @@
-#!/bin/sh
-python3 -c 'from feeluown import __main__ as fu;fu.main()' "$@"
-

--- a/extra-multimedia/feeluown/spec
+++ b/extra-multimedia/feeluown/spec
@@ -1,4 +1,3 @@
-VER=1.1.1
-REL=3
-SRCTBL="https://github.com/cosven/FeelUOwn/archive/vv$VER.tar.gz"
-CHKSUM="sha256::fbf6cff681c772c814a86d0a09db8b9e8d37473a9f6f62d3eddc2222842227e9"
+VER=3.5.3
+SRCTBL="https://pypi.org/packages/source/f/feeluown/feeluown-3.5.3.tar.gz"
+CHKSUM="sha256::b06d3ee831e3accef9a52fa3e9ac100b6c63fe76caa58f5f3de53356823757f7"

--- a/extra-python/fuocore/autobuild/defines
+++ b/extra-python/fuocore/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=fuocore
-PKGSEC=python
-PKGDEP="beautifulsoup4 marshmallow pycryptodome requests april aiozmq mutagen fuzzywuzzy"
-PKGDES="Core components and functions for FeelUOwn"
-
-ABHOST=noarch
-NOPYTHON2=1

--- a/extra-python/fuocore/spec
+++ b/extra-python/fuocore/spec
@@ -1,4 +1,0 @@
-VER=2.3
-REL=2
-SRCTBL="https://pypi.io/packages/source/f/fuocore/fuocore-$VER.tar.gz"
-CHKSUM="sha256::ad0f0d6f8c96fe0a46d2fa658515f50613e8daa8cce56eece58d702d1e9e4d51"

--- a/extra-python/janus/autobuild/defines
+++ b/extra-python/janus/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=janus
+PKGSEC=python
+PKGDES="a Python library implemented thread-safe aware async queue"
+PKGDEP="python-3"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/janus/autobuild/defines
+++ b/extra-python/janus/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=janus
 PKGSEC=python
-PKGDES="a Python library implemented thread-safe aware async queue"
+PKGDES="Python library implemented thread-safe aware async queue"
 PKGDEP="python-3"
 
 ABHOST=noarch

--- a/extra-python/janus/spec
+++ b/extra-python/janus/spec
@@ -1,0 +1,3 @@
+VER=0.6.0
+SRCTBL="https://github.com/aio-libs/janus/archive/v${VER}.tar.gz"
+CHKSUM="sha256::5f4069eadc337381a1a60211af890f466e3d28c79117dbfdce8dd8d032d94432"

--- a/extra-python/marshmallow/spec
+++ b/extra-python/marshmallow/spec
@@ -1,3 +1,3 @@
 VER=3.8.0
 SRCTBL="https://pypi.io/packages/source/m/marshmallow/marshmallow-$VER.tar.gz"
-CHKSUM="sha256::6eeaf1301a5f5942bfe8ab2c2eaf03feb793072b56d5fae563638bddd7bb62e6"
+CHKSUM="sha256::47911dd7c641a27160f0df5fd0fe94667160ffe97f70a42c3cc18388d86098cc"

--- a/extra-python/marshmallow/spec
+++ b/extra-python/marshmallow/spec
@@ -1,4 +1,3 @@
-VER=2.18.1
-REL=2
+VER=3.8.0
 SRCTBL="https://pypi.io/packages/source/m/marshmallow/marshmallow-$VER.tar.gz"
 CHKSUM="sha256::6eeaf1301a5f5942bfe8ab2c2eaf03feb793072b56d5fae563638bddd7bb62e6"

--- a/extra-python/qasync/autobuild/defines
+++ b/extra-python/qasync/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=qasync
+PKGSEC=python
+PKGDES="a async library for PyQt applications"
+PKGDEP="python-3 pyside pyqt5"
+
+ABHOST=noarch
+ABTYPE=python 
+NOPYTHON2=1

--- a/extra-python/qasync/autobuild/defines
+++ b/extra-python/qasync/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=qasync
 PKGSEC=python
-PKGDES="a async library for PyQt applications"
+PKGDES="async library for PyQt applications"
 PKGDEP="python-3 pyside pyqt5"
 
 ABHOST=noarch

--- a/extra-python/qasync/autobuild/defines
+++ b/extra-python/qasync/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=qasync
 PKGSEC=python
 PKGDES="Python library for PyQt/PySide applications' async support"
-PKGDEP="python-3 pyside pyqt5"
+PKGDEP="python-3 pyside2 pyqt5"
 
 ABHOST=noarch
 ABTYPE=python 

--- a/extra-python/qasync/autobuild/defines
+++ b/extra-python/qasync/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=qasync
 PKGSEC=python
-PKGDES="async library for PyQt applications"
+PKGDES="Python library for PyQt/PySide applications' async support"
 PKGDEP="python-3 pyside pyqt5"
 
 ABHOST=noarch

--- a/extra-python/qasync/spec
+++ b/extra-python/qasync/spec
@@ -1,0 +1,3 @@
+VER=0.9.4
+SRCTBL="https://github.com/CabbageDevelopment/qasync/archive/v${VER}.tar.gz"
+CHKSUM="sha256::a6799257dc74ac7aa4fa291d36eb5054a5c2ff690082b64f4cc8b030b30f81a1"

--- a/extra-python/toml/autobuild/defines
+++ b/extra-python/toml/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=toml
+PKGSEC=python
+PKGDES="a python library for TOML"
+PKGDEP="python-3"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/toml/autobuild/defines
+++ b/extra-python/toml/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=toml
 PKGSEC=python
-PKGDES="a python library for TOML"
+PKGDES="Python library for TOML"
 PKGDEP="python-3"
 
 ABHOST=noarch

--- a/extra-python/toml/spec
+++ b/extra-python/toml/spec
@@ -1,0 +1,3 @@
+VER=0.10.1
+SRCTBL="https://github.com/uiri/toml/archive/${VER}.tar.gz"
+CHKSUM="sha256::f03a628c5751328fdec6fa84656199f51dd6000b7ecc1fe490e3fbe89ebfd476"


### PR DESCRIPTION
Topic Description
-----------------
Update `FeelUOwn` to 3.5.3
Update `marshmallow` to 3.8.0
Drop deprecated `fuocore`.
Add dependencies `toml`, `janus`, `qasync`, and the FeelUOwn plugins.

Package(s) Affected
-------------------
- `feeluown`
- `fuocore`
- `toml`
- `janus`
- `qasync`
- `feeluown-local`
- `feeluown-netease`
- `feeluown-download`
- `feeluown-xiami`
- `feeluown-qqmusic`
- `feeluown-kuwo`
- `marshmallow`

Security Update?
----------------

<!-- If this topic is part of a security update, please select yes, and mark with the `security` label for priority processing. -->

- [ ] Yes
- [x] No

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->
 - [x] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
