### PR TITLE
xiccd: new, 0.3.0

### DIFF
--- a/extra-utils/xiccd/autobuild/defines
+++ b/extra-utils/xiccd/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=xiccd
 PKGSEC=utils
 PKGDEP="x11-lib glib colord"
-PKGDES="a color management daemon for displays, printers, etc."
+PKGDES="A color management daemon for displays, printers, etc."
 
 ABTYPE=autotools

--- a/extra-utils/xiccd/autobuild/defines
+++ b/extra-utils/xiccd/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=xiccd
+PKGSEC=utils
+PKGDEP="x11-lib glib colord"
+PKGDES="a color management daemon for displays, printers, etc."
+
+ABTYPE=autotools

--- a/extra-utils/xiccd/spec
+++ b/extra-utils/xiccd/spec
@@ -1,0 +1,3 @@
+VER=0.3.0
+SRCTBL="https://github.com/agalakhov/xiccd/archive/v${VER}.tar.gz"
+CHKSUM="sha256::94dbe352ad3043079fa5edd8150318ec88f1dc87b75f69b1fced8ce2981c36a9"

--- a/extra-xfce/xfce4-settings/autobuild/defines
+++ b/extra-xfce/xfce4-settings/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=xfce4-settings
 PKGDES="Settings manager for Xfce"
 PKGDEP="exo libxfce4ui garcon libnotify libxklavier gtk-engines-2 \
-        gnome-themes-standard libcanberra sound-theme-freedesktop xf86-input-libinput"
+        gnome-themes-standard libcanberra sound-theme-freedesktop xf86-input-libinput xiccd"
 BUILDDEP="intltool"
 PKGSEC=xfce
 

--- a/extra-xfce/xfce4-settings/spec
+++ b/extra-xfce/xfce4-settings/spec
@@ -1,3 +1,4 @@
 VER=4.14.3
 SRCTBL="https://archive.xfce.org/src/xfce/xfce4-settings/${VER%.*}/xfce4-settings-$VER.tar.bz2"
 CHKSUM="sha256::cab1a4d5351f9871533700523570f86f92bbe6e4055f44e5df950eb4b4f48bb3"
+REL=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

add `xiccd` 0.3.0
add the dependency `xiccd` for `xfce4-settings` because of the color management settings program `xfce4-color-settings` required.

Package(s) Affected
-------------------

- `xiccd`
- `xfce4-settings`

Security Update?
----------------

<!-- If this topic is part of a security update, please select yes, and mark with the `security` label for priority processing. -->

- [ ] Yes
- [x] No

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

<!-- TODO: CI to auto-fill architectural progress. -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
