### PR TITLE
udiskie: new, 2.2.0

### DIFF
--- a/extra-python/python-keyutils/autobuild/defines
+++ b/extra-python/python-keyutils/autobuild/defines
@@ -1,7 +1,6 @@
 PKGNAME=python-keyutils
 PKGSEC=python
 PKGDES="a python binding library of keyutils"
-PKGDEP="python-3 keyutils"
+PKGDEP="python-3 python-2 keyutils"
 
 ABTYPE=python
-NOPYTHON2=1

--- a/extra-python/python-keyutils/autobuild/defines
+++ b/extra-python/python-keyutils/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=python-keyutils
+PKGSEC=python
+PKGDES="a python binding library of keyutils"
+PKGDEP="python-3 keyutils"
+
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/python-keyutils/autobuild/defines
+++ b/extra-python/python-keyutils/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=python-keyutils
 PKGSEC=python
-PKGDES="a python binding library of keyutils"
+PKGDES="A python binding library of keyutils"
 PKGDEP="python-3 python-2 keyutils"
 
 ABTYPE=python

--- a/extra-python/python-keyutils/spec
+++ b/extra-python/python-keyutils/spec
@@ -1,3 +1,3 @@
-    VER=0.6
-    SRCTBL="https://github.com/sassoftware/python-keyutils/archive/${VER}.tar.gz"
-    CHKSUM="sha256::f69e6cadc50525dcb117714e440ee6579b0e5b7f12910b2bb2e910b236a2b18b"
+VER=0.6
+SRCTBL="https://github.com/sassoftware/python-keyutils/archive/${VER}.tar.gz"
+CHKSUM="sha256::f69e6cadc50525dcb117714e440ee6579b0e5b7f12910b2bb2e910b236a2b18b"

--- a/extra-python/python-keyutils/spec
+++ b/extra-python/python-keyutils/spec
@@ -1,0 +1,3 @@
+    VER=0.6
+    SRCTBL="https://github.com/sassoftware/python-keyutils/archive/${VER}.tar.gz"
+    CHKSUM="sha256::f69e6cadc50525dcb117714e440ee6579b0e5b7f12910b2bb2e910b236a2b18b"

--- a/extra-utils/udiskie/autobuild/defines
+++ b/extra-utils/udiskie/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=udiskie
 PKGSEC=utils
-PKGDES="A udisks-2 GUI frontend"
+PKGDES="A GUI frontend for UDisks-2"
 PKGDEP="python-3 docopt libappindicator pyyaml pygobject-3 libnotify udisks-2 polkit systemd python-keyutils"
 BUILDDEP="asciidoc"
 

--- a/extra-utils/udiskie/autobuild/defines
+++ b/extra-utils/udiskie/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=udiskie
+PKGSEC=utils
+PKGDES="a udisks-2 GUI frontend"
+PKGDEP="python-3 docopt libappindicator pyyaml pygobject-3 libnotify udisks-2 polkit systemd python-keyutils"
+BUILDDEP="asciidoc"
+
+ABTYPE=python
+NOPYTHON2=1
+ABHOST=noarch

--- a/extra-utils/udiskie/autobuild/defines
+++ b/extra-utils/udiskie/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=udiskie
 PKGSEC=utils
-PKGDES="a udisks-2 GUI frontend"
+PKGDES="A udisks-2 GUI frontend"
 PKGDEP="python-3 docopt libappindicator pyyaml pygobject-3 libnotify udisks-2 polkit systemd python-keyutils"
 BUILDDEP="asciidoc"
 

--- a/extra-utils/udiskie/spec
+++ b/extra-utils/udiskie/spec
@@ -1,0 +1,3 @@
+VER=2.2.0
+SRCTBL="https://github.com/coldfix/udiskie/archive/${VER}.tar.gz"
+CHKSUM="sha256::1041bdf33e64371a68fe40ff242a7010244f4e90021cdd1435fd62ad1c5fcc50"


### PR DESCRIPTION
Topic Description
-----------------
add udiskie 2.2.0
add python-keyutils 0.6

Package(s) Affected
-------------------
- udiskie
- python-keyutils

Security Update?
----------------

<!-- If this topic is part of a security update, please select yes, and mark with the `security` label for priority processing. -->

- [ ] Yes
- [x] No

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [x] Architecture-independent `noarch` 

<!-- TODO: CI to auto-fill architectural progress. -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
