### PR TITLE
adobe-source-han-sans: update to 2.001R; lint

### DIFF
--- a/extra-fonts/adobe-source-han-sans/autobuild/build
+++ b/extra-fonts/adobe-source-han-sans/autobuild/build
@@ -1,4 +1,6 @@
-mkdir -p "$PKGDIR"/usr/share/fonts/OTF
-for i in `find OTF -name '*.otf'`; do
-    cp -v $i "$PKGDIR"/usr/share/fonts/OTF/
-done
+abinfo "Installing font file and LICENSE..."
+install -dvm755 "$PKGDIR"/usr/share/fonts/TTF
+install -vm644 "$SRCDIR"/SourceHanSans.ttc "$PKGDIR"/usr/share/fonts/TTF
+install -dvm755 "$PKGDIR"/usr/share/doc/adobe-source-han-sans
+install -vm644 "$SRCDIR"/source-han-sans-$PKGVER/LICENSE.txt \
+	"$PKGDIR"/usr/share/doc/adobe-source-han-sans/

--- a/extra-fonts/adobe-source-han-sans/spec
+++ b/extra-fonts/adobe-source-han-sans/spec
@@ -1,5 +1,6 @@
 VER=2.001R
 SRCS="file::rename=SourceHanSans.ttc::https://github.com/adobe-fonts/source-han-sans/releases/download/$VER/SourceHanSans.ttc \
       tbl::https://github.com/adobe-fonts/source-han-sans/archive/$VER.tar.gz"
-CHKSUMS="sha256::9e94fe493685a7c99ce61e4488169007e3b97badb9f1ef43d3c13da501463780 sha256::7c515573dd6784d9d2be564f50e0b9bbee4ad560a853ab87a25532b1d8a03582"
+CHKSUMS="sha256::9e94fe493685a7c99ce61e4488169007e3b97badb9f1ef43d3c13da501463780 \
+         sha256::7c515573dd6784d9d2be564f50e0b9bbee4ad560a853ab87a25532b1d8a03582"
 SUBDIR=.

--- a/extra-fonts/adobe-source-han-sans/spec
+++ b/extra-fonts/adobe-source-han-sans/spec
@@ -1,6 +1,5 @@
-VER=1.004
-RELVER=1.004R
-REL=4
-SRCTBL="https://github.com/adobe-fonts/source-han-sans/archive/$RELVER.tar.gz"
-CHKSUM="sha256::7f2d5fdbc76a5ff24ce8d4cacbebe2f87efd5f23dba1ed90acc66b90b8035deb"
-SUBDIR="source-han-sans-$RELVER"
+VER=2.001R
+SRCS="file::rename=SourceHanSans.ttc::https://github.com/adobe-fonts/source-han-sans/releases/download/$VER/SourceHanSans.ttc \
+      tbl::https://github.com/adobe-fonts/source-han-sans/archive/$VER.tar.gz"
+CHKSUMS="sha256::9e94fe493685a7c99ce61e4488169007e3b97badb9f1ef43d3c13da501463780 sha256::7c515573dd6784d9d2be564f50e0b9bbee4ad560a853ab87a25532b1d8a03582"
+SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

adobe-source-han-sans: update to 2.001R; lint

Package(s) Affected
-------------------

adobe-source-han-sans 2.001R

Security Update?
----------------

<!-- If this topic is part of a security update, please select yes, and mark with the `security` label for priority processing. -->

- [ ] Yes
- [x] No

Architectural Progress
----------------------

 - [x] Architecture-independent `noarch` 

