### PR TITLE
picom: new, 8.2

### DIFF
--- a/extra-libs/uthash/autobuild/build
+++ b/extra-libs/uthash/autobuild/build
@@ -1,14 +1,11 @@
 # Taken from https://www.archlinux.org/packages/community/any/uthash/
 
 abinfo "create directory for header files"
-install -dm755 "$PKGDIR"/usr/include/
+install -dvm755 "$PKGDIR"/usr/include/
 
 abinfo "install header files in /usr/include"
 cd "$SRCDIR/src"
 
 for h in *.h; do
-  install -m 644 "$h" "$PKGDIR"/usr/include/
+  install -vm 644 "$h" "$PKGDIR"/usr/include/
 done
-
-abinfo "install license file"
-install -D -m644 "$SRCDIR"/LICENSE "$PKGDIR"/usr/share/licenses/"$PKGNAME"/LICENSE

--- a/extra-libs/uthash/autobuild/build
+++ b/extra-libs/uthash/autobuild/build
@@ -1,0 +1,14 @@
+# Taken from https://www.archlinux.org/packages/community/any/uthash/
+
+abinfo "create directory for header files"
+install -dm755 "$PKGDIR"/usr/include/
+
+abinfo "install header files in /usr/include"
+cd "$SRCDIR/src"
+
+for h in *.h; do
+  install -m 644 "$h" "$PKGDIR"/usr/include/
+done
+
+abinfo "install license file"
+install -D -m644 "$SRCDIR"/LICENSE "$PKGDIR"/usr/share/licenses/"$PKGNAME"/LICENSE

--- a/extra-libs/uthash/autobuild/defines
+++ b/extra-libs/uthash/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=uthash
+PKGDES="C macros for hash tables and more"
+PKGSEC=libs
+
+# It's just some macros
+ABHOST=noarch

--- a/extra-libs/uthash/spec
+++ b/extra-libs/uthash/spec
@@ -1,0 +1,3 @@
+VER=2.1.0
+SRCTBL="https://github.com/troydhanson/uthash/archive/v$VER.tar.gz"
+CHKSUM="sha256::152ccd8e64d0f495377232e3964d06c7ec8bb8c3fbd3217f8a5702614f9a669e"

--- a/extra-libs/uthash/spec
+++ b/extra-libs/uthash/spec
@@ -1,3 +1,3 @@
 VER=2.1.0
-SRCTBL="https://github.com/troydhanson/uthash/archive/v$VER.tar.gz"
-CHKSUM="sha256::152ccd8e64d0f495377232e3964d06c7ec8bb8c3fbd3217f8a5702614f9a669e"
+SRCS="https://github.com/troydhanson/uthash/archive/v$VER.tar.gz"
+CHKSUMS="sha256::152ccd8e64d0f495377232e3964d06c7ec8bb8c3fbd3217f8a5702614f9a669e"

--- a/extra-x11/picom/autobuild/defines
+++ b/extra-x11/picom/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=picom
+PKGSEC=x11
+PKGDEP="hicolor-icon-theme libconfig dbus libev libglvnd pcre pixman xcb-util-image xcb-util-renderutil"
+BUILDDEP="uthash x11-app asciidoc"
+PKGDES="A lightweight compositor for X11"

--- a/extra-x11/picom/autobuild/prepare
+++ b/extra-x11/picom/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Adding libev to search path"
+export CPPFLAGS="${CPPFLAGS} -I/usr/include/libev"

--- a/extra-x11/picom/spec
+++ b/extra-x11/picom/spec
@@ -1,3 +1,3 @@
 VER=8.2
-SRCTBL="https://github.com/yshui/picom/archive/v8.2.tar.gz"
-CHKSUM="sha256::9d0c2533985e9670ff175e717a42b5bf1a2a00ccde5cac1e1009f5d6ee7912ec"
+SRCS="https://github.com/yshui/picom/archive/v8.2.tar.gz"
+CHKSUMS="sha256::9d0c2533985e9670ff175e717a42b5bf1a2a00ccde5cac1e1009f5d6ee7912ec"

--- a/extra-x11/picom/spec
+++ b/extra-x11/picom/spec
@@ -1,0 +1,3 @@
+VER=8.2
+SRCTBL="https://github.com/yshui/picom/archive/v8.2.tar.gz"
+CHKSUM="sha256::9d0c2533985e9670ff175e717a42b5bf1a2a00ccde5cac1e1009f5d6ee7912ec"


### PR DESCRIPTION
Topic Description
-----------------
Adding `picom`, an active fork of `compton`, to the repository.

Package(s) Affected
-------------------
N/A

Security Update?
----------------
- [ ] Yes
- [x] No

Architectural Progress
----------------------

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

<!-- TODO: CI to auto-fill architectural progress. -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
