### PR TITLE
vscode: update to 1.50.1

### DIFF
--- a/extra-editors/vscode/autobuild/defines
+++ b/extra-editors/vscode/autobuild/defines
@@ -5,4 +5,4 @@ PKGDEP="alsa-lib at-spi2-atk cups desktop-file-utils fontconfig gtk-3 gconf libn
 BUILDDEP="gcc gulp make nodejs pkg-config python-2 yarn"
 PKGPROV="code"
 
-FAIL_ARCH="!(amd64||arm64||armel)"
+FAIL_ARCH="!(amd64||arm64)"

--- a/extra-editors/vscode/spec
+++ b/extra-editors/vscode/spec
@@ -1,3 +1,3 @@
 VER=1.50.1
-SRCS="git::commit=d2e414d9e4239a252d1ab117bd7067f125afd80a::https://github.com/microsoft/vscode/"
+SRCS="git::commit=tags/$VER::https://github.com/microsoft/vscode/"
 CHKSUMS="SKIP"

--- a/extra-editors/vscode/spec
+++ b/extra-editors/vscode/spec
@@ -1,3 +1,3 @@
-VER=1.49.2
-GITSRC="https://github.com/microsoft/vscode/"
-GITCO="tags/$VER"
+VER=1.50.1
+SRCS="git::commit=d2e414d9e4239a252d1ab117bd7067f125afd80a::https://github.com/microsoft/vscode/"
+CHKSUMS="SKIP"


### PR DESCRIPTION

Topic Description
-----------------

vscode: update to 1.50.1

- Use SRCS
- Drop armel support

Package(s) Affected
-------------------

vscode 1.50.1

Security Update?
----------------

<!-- If this topic is part of a security update, please select yes, and mark with the `security` label for priority processing. -->

- [ ] Yes
- [x] No

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

