### PR TITLE
foliate: update to 2.5.0

### DIFF
--- a/extra-doc/foliate/spec
+++ b/extra-doc/foliate/spec
@@ -1,3 +1,3 @@
-VER=2.4.2
-SRCTBL="https://github.com/johnfactotum/foliate/archive/$VER.tar.gz"
-CHKSUM="sha256::7c713c7a0793d931c1762f9825a7c27ccf94e39f982a77d7344643e2d25e35ee"
+VER=2.5.0
+SRCS="tbl::https://github.com/johnfactotum/foliate/archive/$VER.tar.gz"
+CHKSUMS="sha256::3b5317b96ccb19aaa79a1ff0a751a7cc5f8607649681c42900daf0f02a4da672"


### PR DESCRIPTION
Topic Description
-----------------

foliate: update to 2.5.0

- Use SRCS

Package(s) Affected
-------------------

foliate 2.5.0

Security Update?
----------------

<!-- If this topic is part of a security update, please select yes, and mark with the `security` label for priority processing. -->

- [ ] Yes
- [x] No

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
~- AArch64 `arm64`~

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

<!-- TODO: CI to auto-fill architectural progress. -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

~- Loongson 3 `loongson3`~
~- PowerPC 64-bit (Little Endian) `ppc64el`~
