### PR TITLE
flameshot: update to 0.8.5

### DIFF
--- a/extra-utils/flameshot/spec
+++ b/extra-utils/flameshot/spec
@@ -1,3 +1,3 @@
-VER=0.8.3
-GITSRC="https://github.com/flameshot-org/flameshot/"
-GITCO="tags/v$VER"
+VER=0.8.5
+SRCS="tbl::https://github.com/flameshot-org/flameshot/archive/v$VER.tar.gz"
+CHKSUMS="sha256::f820c1f8cd464988cfcfc1af1fbcea2a3d0e5c4fb32accc3f54d93a8b5e1e890"


### PR DESCRIPTION
Topic Description
-----------------

flameshot: update to 0.8.5

- Use SRCS
- Use Source tarball

Package(s) Affected
-------------------

flameshot 0.8.5

Security Update?
----------------

<!-- If this topic is part of a security update, please select yes, and mark with the `security` label for priority processing. -->

- [ ] Yes
- [x] No

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

<!-- TODO: CI to auto-fill architectural progress. -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
