### PR TITLE
fcitx5-pinyin-moegirl: update to 20201014

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/01-fcitx5-pinyin-moegirl/build
+++ b/extra-i18n/fcitx5-pinyin-moegirl/01-fcitx5-pinyin-moegirl/build
@@ -2,3 +2,8 @@ abinfo "Install fcitx5-pinyin-moegirl dict file to $PKGDIR..."
 mkdir -p "$PKGDIR"/usr/share/fcitx5/pinyin/dictionaries/
 install -vDm644 "$SRCDIR"/moegirl.dict \
 	-t "$PKGDIR"/usr/share/fcitx5/pinyin/dictionaries/
+
+abinfo "Installing LICENSE..."
+mkdir -p "$PKGDIR"/usr/share/doc/fcitx5-pinyin-moegirl
+install -vm644 "$SRCDIR"/mw2fcitx-$PKGVER/LICENSE \
+	"$PKGDIR"/usr/share/doc/fcitx5-pinyin-moegirl

--- a/extra-i18n/fcitx5-pinyin-moegirl/01-fcitx5-pinyin-moegirl/defines
+++ b/extra-i18n/fcitx5-pinyin-moegirl/01-fcitx5-pinyin-moegirl/defines
@@ -1,5 +1,6 @@
 PKGNAME="fcitx5-pinyin-moegirl"
 PKGDES="Fcitx 5 Pinyin Dictionary from zh.moegirl.org.cn"
+PKGDEP="fcitx5"
 PKGSEC="x11"
 
 ABHOST=noarch

--- a/extra-i18n/fcitx5-pinyin-moegirl/02-rime-pinyin-moegirl/build
+++ b/extra-i18n/fcitx5-pinyin-moegirl/02-rime-pinyin-moegirl/build
@@ -2,3 +2,8 @@ abinfo "Install rime-pinyin-moegirl dict file to $PKGDIR..."
 mkdir -p "$PKGDIR"/usr/share/rime-data
 install -vDm644 "$SRCDIR"/moegirl.dict.yaml \
 	-t "$PKGDIR"/usr/share/rime-data
+
+abinfo "Installing LICENSE..."
+install -vm644 "$SRCDIR"/mw2fcitx-$PKGVER/LICENSE \
+        "$PKGDIR"/usr/share/doc/rime-pinyin-moegirl
+

--- a/extra-i18n/fcitx5-pinyin-moegirl/02-rime-pinyin-moegirl/build
+++ b/extra-i18n/fcitx5-pinyin-moegirl/02-rime-pinyin-moegirl/build
@@ -1,9 +1,10 @@
 abinfo "Install rime-pinyin-moegirl dict file to $PKGDIR..."
-mkdir -p "$PKGDIR"/usr/share/rime-data
+mkdir -pv "$PKGDIR"/usr/share/rime-data
 install -vDm644 "$SRCDIR"/moegirl.dict.yaml \
 	-t "$PKGDIR"/usr/share/rime-data
 
 abinfo "Installing LICENSE..."
+mkdir -pv "$PKGDIR"/usr/share/doc/rime-pinyin-moegirl
 install -vm644 "$SRCDIR"/mw2fcitx-$PKGVER/LICENSE \
         "$PKGDIR"/usr/share/doc/rime-pinyin-moegirl
 

--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,6 +1,5 @@
-VER=20200914
+VER=20201014
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml"
-CHKSUMS="sha256::5a5a73b1a95ddd673f9fb6fe79d0d89e6df3e20fcb1ae7c79c355d9a035f5333 \
-         sha256::32dd2e2bd1cf5a0b1a87e50f2c4df2416cf0f53b923990943b6c2ebfa1fb6d40"
+CHKSUMS="sha256::7be47320cf5ffeda11862b6afb5bef33c506391c419211400c8b5b1ab0d55569 sha256::b8997e883b70486bad26eabe93c15aa736b3c516107e5c97c37d0f510151f16e"
 SUBDIR=.

--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,5 +1,6 @@
 VER=20201014
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml"
-CHKSUMS="sha256::7be47320cf5ffeda11862b6afb5bef33c506391c419211400c8b5b1ab0d55569 sha256::b8997e883b70486bad26eabe93c15aa736b3c516107e5c97c37d0f510151f16e"
+CHKSUMS="sha256::7be47320cf5ffeda11862b6afb5bef33c506391c419211400c8b5b1ab0d55569 \
+         sha256::b8997e883b70486bad26eabe93c15aa736b3c516107e5c97c37d0f510151f16e"
 SUBDIR=.

--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,6 +1,8 @@
 VER=20201014
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
-      file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml"
+      file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
+      tbl::https://github.com/outloudvi/mw2fcitx/archive/$VER.tar.gz"
 CHKSUMS="sha256::7be47320cf5ffeda11862b6afb5bef33c506391c419211400c8b5b1ab0d55569 \
-         sha256::b8997e883b70486bad26eabe93c15aa736b3c516107e5c97c37d0f510151f16e"
+         sha256::b8997e883b70486bad26eabe93c15aa736b3c516107e5c97c37d0f510151f16e \
+         sha256::ea10e4e791e55cdd092d1af8c2c3334f3ede362a4bf3854101b0be7db4b0bd06"
 SUBDIR=.


### PR DESCRIPTION

Topic Description
-----------------

fcitx5-pinyin-moegirl: update to 20201014

Package(s) Affected
-------------------

fcitx5-pinyin-moegirl: 20201014
rime-pinyin-moegirl: 20201014

Security Update?
----------------

<!-- If this topic is part of a security update, please select yes, and mark with the `security` label for priority processing. -->

- [ ] Yes
- [x] No

Architectural Progress
----------------------

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [x] Architecture-independent `noarch` 

