### PR TITLE
atm: update to 0.1.5

### DIFF
--- a/extra-admin/atm/spec
+++ b/extra-admin/atm/spec
@@ -1,3 +1,3 @@
-VER=0.1.4
+VER=0.1.5
 SRCS="https://github.com/AOSC-Dev/atm/archive/v$VER.tar.gz"
-CHKSUMS="sha256::e2ab2a6a31507af11abf1bfd62e81d51afaa682ac59a0da0e43296bcb1f6fb30"
+CHKSUMS="sha256::41a7127edac877e9f3bfba84c35a8a009e6be70a5ad5d5e789ef780e3c89f3a9"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update ATM to v0.1.5, this should fix issues with terminal control and crash on Loongson 3.

Package(s) Affected
-------------------

- `atm` v0.1.5

Security Update?
----------------

<!-- If this topic is part of a security update, please select yes, and mark with the `security` label for priority processing. -->

- [ ] Yes
- [x] No

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

<!-- TODO: CI to auto-fill architectural progress. -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
