### PR TITLE
rime-data: update on 20201027

### DIFF
--- a/extra-i18n/fcitx5-pinyin-zhwiki/01-fcitx5-pinyin-zhwiki/build
+++ b/extra-i18n/fcitx5-pinyin-zhwiki/01-fcitx5-pinyin-zhwiki/build
@@ -1,8 +1,5 @@
 dict_ver=$(echo "${PKGVER}" | cut -d '+' -f2)
 
-abinfo "Downloading wikipedia-zh dict..."
-wget https://dumps.wikimedia.org/zhwiki/${dict_ver}/zhwiki-${dict_ver}-all-titles-in-ns0.gz
-
 abinfo "Conventing dict..."
 make VERSION=${dict_ver}
 

--- a/extra-i18n/fcitx5-pinyin-zhwiki/01-fcitx5-pinyin-zhwiki/prepare
+++ b/extra-i18n/fcitx5-pinyin-zhwiki/01-fcitx5-pinyin-zhwiki/prepare
@@ -1,0 +1,2 @@
+abinfo "Copy dict file to fcitx5-pinyin-zhwiki directory..."
+cp "$SRCDIR"/../zhwiki-*-all-titles-in-ns0.gz "$SRCDIR"

--- a/extra-i18n/fcitx5-pinyin-zhwiki/spec
+++ b/extra-i18n/fcitx5-pinyin-zhwiki/spec
@@ -1,5 +1,8 @@
-dict_ver=20200920
+dict_ver=20201020
 package_ver=0.2.1
 VER="${package_ver}"+"${dict_ver}"
-SRCTBL="https://github.com/felixonmars/fcitx5-pinyin-zhwiki/archive/${package_ver}.tar.gz"
-CHKSUM="sha256::eb52a09414b3659e679b08edc0c4ca076db3a0ae6b30a9716e0b5f03aa0fb901"
+SRCS="tbl::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/archive/${package_ver}.tar.gz \
+      file::rename=zhwiki-${dict_ver}-all-titles-in-ns0.gz::https://dumps.wikimedia.org/zhwiki/${dict_ver}/zhwiki-${dict_ver}-all-titles-in-ns0.gz"
+CHKSUMS="sha256::eb52a09414b3659e679b08edc0c4ca076db3a0ae6b30a9716e0b5f03aa0fb901 \
+         sha256::f819ddcfd0279120d064e8ccfc4dcf57ab222be61004cb271cc863c0cd6fdc6a"
+SUBDIR=fcitx5-pinyin-zhwiki-$package_ver

--- a/extra-i18n/fcitx5-pinyin-zhwiki/spec
+++ b/extra-i18n/fcitx5-pinyin-zhwiki/spec
@@ -5,4 +5,4 @@ SRCS="tbl::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/archive/${package
       file::rename=zhwiki-${dict_ver}-all-titles-in-ns0.gz::https://dumps.wikimedia.org/zhwiki/${dict_ver}/zhwiki-${dict_ver}-all-titles-in-ns0.gz"
 CHKSUMS="sha256::eb52a09414b3659e679b08edc0c4ca076db3a0ae6b30a9716e0b5f03aa0fb901 \
          sha256::f819ddcfd0279120d064e8ccfc4dcf57ab222be61004cb271cc863c0cd6fdc6a"
-SUBDIR=fcitx5-pinyin-zhwiki-$package_ver
+SUBDIR="fcitx5-pinyin-zhwiki-$package_ver"

--- a/extra-i18n/rime-cantonese/spec
+++ b/extra-i18n/rime-cantonese/spec
@@ -1,3 +1,3 @@
-VER=20200927.1
-GITSRC="https://github.com/rime/rime-cantonese"
-GITCO="a0ffe037ef6836ea24d373635abf8198c46437f4"
+VER=20201025
+SRCS="git::commit=7709132fa8b5060ee4ac7aeee4539f326c461201::https://github.com/rime/rime-cantonese"
+CHKSUMS="SKIP"

--- a/extra-i18n/rime-combo-pinyin/spec
+++ b/extra-i18n/rime-combo-pinyin/spec
@@ -1,4 +1,3 @@
-VER=20200914
-REL=1
-GITSRC="https://github.com/rime/rime-combo-pinyin"
-GITCO="4486ea0ceb986802a00e76ff6a6ccede8c9bcb4a"
+VER=20201011
+SRCS="git::commit=c245dc9882861863f56acd6f056ff255b3385c89::https://github.com/rime/rime-combo-pinyin"
+CHKSUMS="SKIP"

--- a/extra-i18n/rime-essay/spec
+++ b/extra-i18n/rime-essay/spec
@@ -1,4 +1,3 @@
-VER=20200724
-GITSRC="https://github.com/rime/rime-essay"
-GITCO="917e5691d090f75c40f0bc72476c2f483bae0c21"
-REL=1
+VER=20201004
+SRCS="git::commit=964ff5c5854a4452256891a4fe3b333592f3d68b::https://github.com/rime/rime-essay"
+CHKSUMS="SKIP"

--- a/extra-i18n/rime-luna-pinyin/spec
+++ b/extra-i18n/rime-luna-pinyin/spec
@@ -1,3 +1,3 @@
-VER=20200920
-GITSRC="https://github.com/rime/rime-luna-pinyin"
-GITCO="57d9320bcaa618ae5f99a88d1be5e11081882737"
+VER=20201018
+SRCS="git::commit=9b405d7ad3cc0fa7d7ba25db8d3359699fafb086::https://github.com/rime/rime-luna-pinyin"
+CHKSUMS="SKIP"

--- a/extra-i18n/rime-terra-pinyin/spec
+++ b/extra-i18n/rime-terra-pinyin/spec
@@ -1,4 +1,3 @@
-VER=20200914
-REL=1
-GITSRC="https://github.com/rime/rime-terra-pinyin"
-GITCO="3fc0721e30f9b5dcae9116e393d565332fa10f1b"
+VER=20201018
+SRCS="git::commit=5a445e2953c4b8149daac9d4625782fd5f80d9f2::https://github.com/rime/rime-terra-pinyin"
+CHKSUMS="SKIP"


### PR DESCRIPTION

Topic Description
-----------------

Update packages: 
rime-cantonese 20201025
rime-luna-pinyin 20201018
rime-terra-pinyin 20201018
rime-combo-pinyin 20201011
rime-essay 20201004
rime-pinyin-zhwiki 0.2.1+20201020
fcitx5-pinyin-zhwiki 0.2.1+20201020

Package(s) Affected
-------------------

rime-cantonese 20201025
rime-luna-pinyin 20201018
rime-terra-pinyin 20201018
rime-combo-pinyin 20201011
rime-essay 20201004
rime-pinyin-zhwiki 0.2.1+20201020
fcitx5-pinyin-zhwiki 0.2.1+20201020

Security Update?
----------------

<!-- If this topic is part of a security update, please select yes, and mark with the `security` label for priority processing. -->

- [ ] Yes
- [x] No

Architectural Progress
----------------------


<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
 - [x] Architecture-independent `noarch` 

