### PR TITLE
obs-studio: update to 26.0.2; use SRCS

### DIFF
--- a/extra-multimedia/obs-studio/spec
+++ b/extra-multimedia/obs-studio/spec
@@ -1,4 +1,3 @@
-VER=25.0.8
-REL=1
-SRCTBL=https://github.com/obsproject/obs-studio/archive/${VER}.tar.gz
-CHKSUM="sha256::ef1179c23256c312212e3dce9083d4fa67751db05c3001ad824e2b6995943941"
+VER=26.0.2
+SRCS="tbl::https://github.com/obsproject/obs-studio/archive/${VER}.tar.gz"
+CHKSUMS="sha256::06eef30156d21f179f590599ab866b7745209045825a3bf8461a85b60d880ed5"


### PR DESCRIPTION


Topic Description
-----------------

obs-studio update to 26.0.2

Package(s) Affected
-------------------

obs-studio

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
