### PR TITLE
js-78: (loongson3) fix build

### DIFF
--- a/extra-libs/js-78/autobuild/defines
+++ b/extra-libs/js-78/autobuild/defines
@@ -22,7 +22,8 @@ AUTOTOOLS_AFTER__LOONGSON3=" \
                  ${AUTOTOOLS_AFTER} \
                  --target=mips64el-aosc-linux-gnuabi64 \
                  --host=mips64el-aosc-linux-gnuabi64 \
-                 --disable-ion"
+                 --disable-jit \
+                 --enable-linker=bfd"
 
 AB_FLAGS_SPECS__ARMEL=0
 AB_FLAGS_SPECS__ARMHF=0


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Fix MozJS 78 build on Loongson 3 by correctly disabling JIT (`--disable-jit` versus `--disable-ion`), and specifying BFD linker (`--enable-linker=bfd`)

Package(s) Affected
-------------------

- `js-78` v78.3.0 (`loongson3` only)

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`

<!-- TODO: CI to auto-fill architectural progress. -->
