### PR TITLE
rime-essay: add missing dep rime-schema-manager

### DIFF
--- a/extra-i18n/rime-essay/autobuild/defines
+++ b/extra-i18n/rime-essay/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME="rime-essay"
 PKGDES="Essay - the shared vocabulary and language model"
 PKGSEC=localization
+PKGDEP="rime-schema-manager"
 PKGREP="rime-data<=20200814"
 PKGBREAK="rime-data<=20200814"
 

--- a/extra-i18n/rime-essay/spec
+++ b/extra-i18n/rime-essay/spec
@@ -1,3 +1,4 @@
 VER=20201004
+REL=1
 SRCS="git::commit=964ff5c5854a4452256891a4fe3b333592f3d68b::https://github.com/rime/rime-essay"
 CHKSUMS="SKIP"


### PR DESCRIPTION


Topic Description
-----------------

rime-essay: add missing dep rime-schema-manager

Package(s) Affected
-------------------

rime-essay 20201004-1

Security Update?
----------------

No

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

 - [x] Architecture-independent `noarch` 

