### PR TITLE
deno: update to 1.5.0

### DIFF
--- a/extra-js/deno/autobuild/defines
+++ b/extra-js/deno/autobuild/defines
@@ -2,6 +2,6 @@ PKGNAME=deno
 PKGSEC=devel
 PKGDES="A secure JavaScript and TypeScript runtime"
 PKGDEP="glibc gcc-runtime"
-BUILDDEP="python-2 cargo llvm"
+BUILDDEP="python-2 rustc llvm"
 
 USECLANG=1

--- a/extra-js/deno/autobuild/defines
+++ b/extra-js/deno/autobuild/defines
@@ -5,3 +5,4 @@ PKGDEP="glibc gcc-runtime"
 BUILDDEP="python-2 rustc llvm gn"
 
 USECLANG=1
+FAIL_ARCH="!(amd64||arm64)"

--- a/extra-js/deno/autobuild/defines
+++ b/extra-js/deno/autobuild/defines
@@ -2,6 +2,6 @@ PKGNAME=deno
 PKGSEC=devel
 PKGDES="A secure JavaScript and TypeScript runtime"
 PKGDEP="glibc gcc-runtime"
-BUILDDEP="python-2 rustc llvm"
+BUILDDEP="python-2 rustc llvm gn"
 
 USECLANG=1

--- a/extra-js/deno/autobuild/defines
+++ b/extra-js/deno/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=deno
 PKGSEC=devel
 PKGDES="A secure JavaScript and TypeScript runtime"
 PKGDEP="glibc gcc-runtime"
-BUILDDEP="python-2 rustc gn"
+BUILDDEP="python-2 rustc gn llvm"
 
-NOLTO=1
+USECLANG=1
 FAIL_ARCH="!(amd64||arm64)"

--- a/extra-js/deno/autobuild/defines
+++ b/extra-js/deno/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=deno
 PKGSEC=devel
 PKGDES="A secure JavaScript and TypeScript runtime"
 PKGDEP="glibc gcc-runtime"
-BUILDDEP="python-2 rustc llvm gn"
+BUILDDEP="python-2 rustc gn"
 
-USECLANG=1
+NOLTO=1
 FAIL_ARCH="!(amd64||arm64)"

--- a/extra-js/deno/autobuild/prepare
+++ b/extra-js/deno/autobuild/prepare
@@ -1,4 +1,4 @@
 export V8_FROM_SOURCE=1
 export CLANG_BASE_PATH='/usr/'
 export GN_ARGS="no_inline_line_tables=false use_lld=false"
-
+export GN="/usr/bin/gn"

--- a/extra-js/deno/autobuild/prepare
+++ b/extra-js/deno/autobuild/prepare
@@ -1,4 +1,4 @@
 export V8_FROM_SOURCE=1
 export CLANG_BASE_PATH='/usr/'
-export GN_ARGS="no_inline_line_tables=false use_lld=false"
+export GN_ARGS="no_inline_line_tables=false use_lld=false is_clang=true"
 export GN="/usr/bin/gn"

--- a/extra-js/deno/spec
+++ b/extra-js/deno/spec
@@ -1,3 +1,3 @@
-VER=1.4.6
+VER=1.5.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz"
-CHKSUMS="sha256::a99444a8021455237efb2e52dc608a7747693c8609a4911cad97e10de9d83756"
+CHKSUMS="sha256::ca6ff399d3f00586dd90e4578016f8efc5a728eb9cd600463f031d085019fe0e"

--- a/extra-js/deno/spec
+++ b/extra-js/deno/spec
@@ -1,3 +1,3 @@
-VER=1.4.2
-SRCTBL="https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz"
-CHKSUM="sha256::4ccf4f4c75cb21d8ac21c9bba2ec82521c2dae46546c2d49defdb8146a3a3cd1"
+VER=1.4.6
+SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz"
+CHKSUMS="sha256::a99444a8021455237efb2e52dc608a7747693c8609a4911cad97e10de9d83756"


### PR DESCRIPTION

Topic Description
-----------------

deno: update to 1.5.0

- Use gcc to fix build
- Disable LTO, because rust + gcc cannot enable LTO


Package(s) Affected
-------------------

deno 1.5.0

Security Update?
----------------

No

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`



----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

