### PR TITLE
optenvarmhf: introduce

### DIFF
--- a/extra-optenvarmhf/binutils+cross-optenvarmhf/autobuild/beyond
+++ b/extra-optenvarmhf/binutils+cross-optenvarmhf/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing Texinfo index..."
+rm -v "$PKGDIR"/opt/abcross/optenvarmhf/share/info/dir

--- a/extra-optenvarmhf/binutils+cross-optenvarmhf/autobuild/defines
+++ b/extra-optenvarmhf/binutils+cross-optenvarmhf/autobuild/defines
@@ -1,0 +1,26 @@
+PKGNAME=binutils+cross-optenvarmhf
+PKGSEC=devel
+PKGDEP="glibc zlib"
+PKGDES="A set of programs to assemble and manipulate binary and object files"
+
+NOSTATIC=0
+NOLTO=1
+AB_FLAGS_O3=1
+
+AUTOTOOLS_STRICT=0
+AUTOTOOLS_AFTER="--prefix=/opt/abcross/optenvarmhf \
+                 --with-lib-path=/opt/armhf/lib \
+                 --with-bugurl=https://github.com/AOSC-Dev/aosc-os-core \
+                 --enable-threads --enable-shared --with-pic \
+                 --enable-ld --enable-plugins --enable-gold=yes \
+                 --disable-werror --enable-lto --disable-gdb \
+                 --disable-gdbserver \
+                 --enable-deterministic-archives \
+                 --enable-64-bit-bfd \
+                 --build=${ARCH_TARGET[$ARCH]} \
+                 --host=${ARCH_TARGET[$ARCH]} \
+                 --target=arm-aosc-linux-gnueabihf"
+
+alias BUILD_READY='make configure-host'
+
+RECONF=0

--- a/extra-optenvarmhf/binutils+cross-optenvarmhf/autobuild/prepare
+++ b/extra-optenvarmhf/binutils+cross-optenvarmhf/autobuild/prepare
@@ -1,0 +1,10 @@
+# Disable gold testsuite.
+sed -i 's/testsuite//g' "$SRCDIR"/gold/Makefile.in
+
+# $CPPFLAGS adjustment for libiberty.
+sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" "$SRCDIR"/libiberty/configure
+
+export AUTOTOOLS_DEF=""
+
+# FIXME: armel uses an unconventional triplet.
+export AUTOTOOLS_TARGET=""

--- a/extra-optenvarmhf/binutils+cross-optenvarmhf/spec
+++ b/extra-optenvarmhf/binutils+cross-optenvarmhf/spec
@@ -1,0 +1,3 @@
+VER=2.35+git20201210
+SRCS="git::commit=e733eaef28034880ca6aea2a7583f000fe0811f1::https://sourceware.org/git/binutils-gdb.git"
+CHKSUMS="SKIP"

--- a/extra-optenvarmhf/gcc+cross-optenvarmhf/autobuild/beyond
+++ b/extra-optenvarmhf/gcc+cross-optenvarmhf/autobuild/beyond
@@ -1,0 +1,6 @@
+abinfo "Linking optenv include folder to toolchain..."
+mkdir -p "$PKGDIR"/opt/abcross/optenvarmhf/arm-aosc-linux-gnueabihf/
+ln -sfv /opt/armhf/include/ "$PKGDIR"/opt/abcross/optenvarmhf/arm-aosc-linux-gnueabihf/sys-include
+
+abinfo "Removing Texinfo index..."
+rm -v "$PKGDIR"/opt/abcross/optenvarmhf/share/info/dir

--- a/extra-optenvarmhf/gcc+cross-optenvarmhf/autobuild/defines
+++ b/extra-optenvarmhf/gcc+cross-optenvarmhf/autobuild/defines
@@ -1,0 +1,66 @@
+PKGNAME=gcc+cross-optenvarmhf
+PKGSEC=devel
+PKGDEP="glibc+armhf binutils+cross-optenvarmhf"
+PKGDES="GNU Compiler Collection"
+
+# The following configuration:
+#
+# 1.  Enables support for C, C++ and "LTO";
+#     a. "LTO" is not really a language, but it enables GCC to use LTO flags, and
+#        thus provide respective optimizations later;
+# 2.  Enables shared libraries for linking
+#     (this is probably a good choice to reduce binary sizes of any packages that
+#     links to GCC runtime libraries);
+# 3.  Enables POSIX style threading;
+# 4.  Enables linking to system Zlib;
+# 5.  Disables libunwind support for exception detection;
+# 6.  Enables GNU style C locales (you probably would not want to change this);
+# 7.  Disables pre-compiled headers for libstdcxx;
+# 8.  Disables libssp linking (not needed);
+# 9.  Enables GNU unique object;
+# 10. Enables linker build ID;
+# 11. Enables LTO support (as mentioned in note 1, section c);
+# 12. Enables isl for Graphite loop optimization;
+# 13. Enables plugin support;
+# 14. Enables libiberty installation
+#     (you may disable "--enable-install-libiberty" if you really feel the urge...);
+# 15. Enables GNU style linker hash;
+# 16. Disables multilib support 
+#     (you may remove "--disable-multilib" to enable the support for it, however
+#     you will need a copy of GCC with multilib support to build);
+#     a. AOSC OS uses subsystems to provide binary support for foreign architectures.
+# 17. Enable release level checking;
+# 18. Enables support for GNU indirect function
+#     (you may disable this by removing "--enable-gnu-indirect-function");
+# 19. Use the new "cxx11/new" for libstdc++, available since GCC 5. The old
+#     "gcc4-compatbile" ABI was used until Core 5.
+# 20. --enable-default-pie enables PIE by default (-fpie or `-fPIE`?).
+# 21. --enable-default-ssp enables --fstack-protector-strong by default.
+
+AUTOTOOLS_STRICT=0
+AUTOTOOLS_AFTER="--prefix=/opt/abcross/optenvarmhf \
+                 --libdir=/opt/abcross/optenvarmhf/lib --libexecdir=/opt/abcross/optenvarmhf/lib \
+                 --mandir=/opt/abcross/optenvarmhf/share/man --infodir=/opt/abcross/optenvarmhf/share/info \
+                 --with-local-prefix=/opt/armhf \
+                 --with-native-system-header-dir=/opt/armhf/include \
+                 --with-bugurl=https://github.com/AOSC-Dev/aosc-os-core \
+                 --enable-shared --enable-threads=posix \
+                 --with-system-zlib --enable-gnu-indirect-function --enable-__cxa_atexit \
+                 --disable-libunwind-exceptions --enable-clocale=gnu \
+                 --disable-libstdcxx-pch --disable-libssp \
+                 --enable-gnu-unique-object --enable-linker-build-id \
+                 --enable-lto --enable-plugin \
+                 --disable-multilib --disable-werror \
+                 --enable-pie \
+                 --enable-checking=release \
+                 --enable-libstdcxx-dual-abi --with-default-libstdcxx-abi=new \
+                 --enable-default-pie --enable-default-ssp --disable-bootstrap
+                 --disable-altivec --disable-fixed-point \
+                 --with-arch=armv7-a --with-float=hard --with-fpu=neon \
+                 --enable-languages=c,c++,lto \
+                 --build=${ARCH_TARGET[$ARCH]} \
+                 --host=${ARCH_TARGET[$ARCH]} \
+                 --target=arm-aosc-linux-gnueabihf"
+
+RECONF=0
+NOSTATIC=no

--- a/extra-optenvarmhf/gcc+cross-optenvarmhf/autobuild/patch
+++ b/extra-optenvarmhf/gcc+cross-optenvarmhf/autobuild/patch
@@ -1,0 +1,14 @@
+for file in gcc/config/linux.h gcc/config/arm/linux-{eabi,elf}.h
+do
+  cp -uv $file{,.orig}
+  sed -e 's@/lib\(64\)\?\(32\)\?/ld@/opt/armhf&@g' \
+      -e 's@/usr@/opt/armhf@g' $file.orig > $file
+  echo '
+#undef STARTFILE_PREFIX_SPEC
+#undef STANDARD_STARTFILE_PREFIX_1
+#undef STANDARD_STARTFILE_PREFIX_2
+#define STARTFILE_PREFIX_SPEC "/opt/armhf/lib/ "
+#define STANDARD_STARTFILE_PREFIX_1 "/opt/armhf/lib/"
+#define STANDARD_STARTFILE_PREFIX_2 ""' >> $file
+  touch $file.orig
+done

--- a/extra-optenvarmhf/gcc+cross-optenvarmhf/autobuild/prepare
+++ b/extra-optenvarmhf/gcc+cross-optenvarmhf/autobuild/prepare
@@ -1,0 +1,25 @@
+abinfo "Nutering fixinc.sh in gcc/Makefile ..."
+sed -i 's@\./fixinc\.sh@-c true@' "$SRCDIR"/gcc/Makefile.in
+
+abinfo 'Adjusting $CPPFLAGS ...'
+sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" "$SRCDIR"/{libiberty,gcc}/configure
+
+# You will see this in "gcc -v" output.
+# BASE-VER identifies the GCC version, please DO NOT EDIT.
+# * DEV-PHASE are used as branding identification, you may alter the line.
+abinfo "Appending AOSC versions to gcc -v ..."
+echo $PKGVER > "$SRCDIR"/gcc/BASE-VER
+echo 'AOSC OS, Optenvarmhf' > "$SRCDIR"/gcc/DEV-PHASE
+
+abinfo "Stripping pre-defined configure options ..."
+export AUTOTOOLS_DEF=""
+
+abinfo "Unsetting flags..."
+unset CFLAGS CXXFLAGS LDFLAGS CPPFLAGS
+
+abinfo "Linking optenv include folder to toolchain..."
+mkdir -p /opt/abcross/optenvarmhf/arm-aosc-linux-gnueabihf/
+ln -sfv /opt/armhf/include/ /opt/abcross/optenvarmhf/arm-aosc-linux-gnueabihf/sys-include
+
+abinfo "Setting PATH to ensure cross compiler can be found..."
+export PATH="/opt/abcross/optenvarmhf:$PATH"

--- a/extra-optenvarmhf/gcc+cross-optenvarmhf/spec
+++ b/extra-optenvarmhf/gcc+cross-optenvarmhf/spec
@@ -1,0 +1,3 @@
+VER=10.2.1+git20201209
+SRCS="git::commit=027d3288de87fc6c9b97dc3f0c1fa02ea619f82e::https://github.com/gcc-mirror/gcc"
+CHKSUMS=SKIP

--- a/extra-optenvarmhf/glibc+armhf/autobuild/build
+++ b/extra-optenvarmhf/glibc+armhf/autobuild/build
@@ -1,0 +1,48 @@
+abinfo "Setting PATH to enable optenvarmhf cross compiler..."
+export PATH="/opt/abcross/optenvarmhf/bin:$PATH"
+
+abinfo "Shadow build to ensure sanity..."
+mkdir -pv build
+cd build
+
+# Linker environment definition.
+echo "slibdir=/opt/armhf/lib" >> configparms
+echo "rtlddir=/opt/armhf/lib" >> configparms
+echo "sbindir=/opt/armhf/bin" >> configparms
+echo "rootsbindir=/opt/armhf/bin" >> configparms
+
+abinfo "Setting flags..."
+export CFLAGS="-O2 -fira-loop-pressure -fira-hoist-pressure -ftree-vectorize -pipe -Wno-error -marm -march=armv7-a -mtune=cortex-a53 -mfloat-abi=hard -mfpu=neon -fPIC"
+export CXXFLAGS="$CFLAGS -fdeclone-ctor-dtor -ftree-vectorize -fpermissive"
+export CPPFLAGS=""
+export LDFLAGS="-Wl,-O1,--sort-common,--as-needed -fPIC"
+
+abinfo "Configuration (parameters in autobuild/defines)..."
+../configure ${AUTOTOOLS_AFTER}
+
+abinfo "Building GNU C Library..."
+make
+
+abinfo "Installing runtime and files..."
+make install_root="$PKGDIR" install
+
+abinfo "Removing upstream ld.so configurations..."
+rm -fv "$PKGDIR"/etc/ld.so.{cache,conf}
+
+abinfo "Stripping libraries and executables..."
+arm-aosc-linux-gnueabihf-strip -v --strip-all "$PKGDIR"/opt/armhf/bin/{gencat,getconf,getent,iconv,iconvconfig} \
+                     "$PKGDIR"/opt/armhf/bin/{ldconfig,locale,localedef,nscd,makedb} \
+                     "$PKGDIR"/opt/armhf/bin/{pcprofiledump,pldd,sln,sprof,zdump,zic} \
+                     "$PKGDIR"/opt/armhf/lib/getconf/*
+arm-aosc-linux-gnueabihf-strip -v --strip-unneeded "$PKGDIR"/opt/armhf/lib/{libanl,libBrokenLocale,libcrypt,libdl,libm}-*.so \
+                           "$PKGDIR"/opt/armhf/lib/libnss_{compat,db,dns,files,hesiod}-*.so \
+                           "$PKGDIR"/opt/armhf/lib/{libmvec,libnsl,libpthread,libresolv,librt,libutil}-*.so \
+                           "$PKGDIR"/opt/armhf/lib/{libmemusage,libpcprofile,libSegFault,libthread_db}.so \
+                           "$PKGDIR"/opt/armhf/lib/{audit,gconv}/*.so
+
+abinfo "Symlink the locale-archive of main system..."
+mkdir -p "$PKGDIR"/opt/armhf/lib/locale/
+ln -sfv /usr/lib/locale/locale-archive "$PKGDIR"/opt/armhf/lib/locale/
+
+abinfo "Purging conflicting files..."
+rm -rv "$PKGDIR"/{etc,var}

--- a/extra-optenvarmhf/glibc+armhf/autobuild/defines
+++ b/extra-optenvarmhf/glibc+armhf/autobuild/defines
@@ -1,0 +1,61 @@
+PKGNAME=glibc+armhf
+PKGSEC=libs
+PKGDEP="linux+api+armhf"
+BUILDDEP="gcc+cross-optenvarmhf"
+PKGDES="GNU C Library for optenvarmhf"
+
+# The following configuration:
+#
+# 1.  Declares that libraries should be installed into /usr/lib instead of /lib64;
+# 2.  Declares bug tracking URL (should not be changed unless you are building a derivative);
+# 3.  Enables add-on support;
+# 4.  Enables obsolete RPC (Remote Procedural Call) support  
+#     (--disable-obsolete-rpc to disable such support, if you know what you are doing);
+# 5.  Declares that Kernel verion 3.4.0 is the minimum accepted
+#     (you may raise the version number as you like);
+# 6.  Enables "bind now" (dynamic loader) support;
+# 7.  Disables profiling support 
+#     (you may enable, using --enable-profile to your need, however this is not realistic in
+#     a "Core" environment);
+# 8.  Enables stackguard randomization for extra security;
+# 9.  Enables stack protector (libssp);
+# 10. Enables tunables (allows for altering of runtime libraries);
+# 10. Enables lock elision (essential for GUILE, and many others that is lock-sensitive);
+# 11. Enables multiple architecture support 
+#     (mainly used to distinguish among different builds, multiarch is not supported);
+# 12. Disables "warning as error";
+# 13. Ensure that static libraries are installed for development purposes;
+# 14. Enable deprecated NSL and RPC headers (<= 2.14) for compatibility;
+
+AUTOTOOLS_AFTER="--prefix=/opt/armhf \
+                 --sysconfdir=/etc \
+                 --localstatedir=/var
+                 --libexecdir=/opt/armhf/lib \
+                 --with-headers=/opt/armhf/include \
+                 --with-bugurl=https://github.com/AOSC-Dev/aosc-os-core \
+                 --enable-add-ons \
+                 --enable-obsolete-rpc \
+                 --enable-kernel=3.4.0 \
+                 --disable-profile \
+                 --enable-tunables \
+                 --enable-lock-elision \
+                 --enable-multi-arch \
+                 --disable-werror \
+                 --enable-static \
+                 --disable-multi-arch \
+                 --with-__thread \
+                 --enable-obsolete-nsl \
+                 --enable-obsolete-rpc \
+                 --enable-bind-now \
+                 --enable-stackguard-randomization \
+                 --enable-stack-protector=strong \
+                 --build=${ARCH_TARGET[$ARCH]} \
+                 --host=arm-aosc-linux-gnueabihf"
+
+NOSTATIC=no
+
+# Do not strip the library to provide sufficient symbols
+# to assist debuggers
+ABSTRIP=0
+
+ABHOST=noarch

--- a/extra-optenvarmhf/glibc+armhf/spec
+++ b/extra-optenvarmhf/glibc+armhf/spec
@@ -1,0 +1,3 @@
+VER=2.32+git20201130
+SRCS="git::commit=050022910be1d1f5c11cd5168f1685ad4f9580d2::https://sourceware.org/git/glibc.git"
+CHKSUMS=SKIP

--- a/extra-optenvarmhf/linux+api+armhf/autobuild/build
+++ b/extra-optenvarmhf/linux+api+armhf/autobuild/build
@@ -1,0 +1,16 @@
+# Unset $ARCH as it is defined by Autobuild.
+export OLDARCH=$ARCH
+unset ARCH
+
+abinfo "Preparing directories..."
+mkdir -pv "$PKGDIR"/opt/armhf/include
+
+abinfo "Building and installing headers..."
+make ARCH=arm mrproper
+make ARCH=arm headers_check
+make ARCH=arm INSTALL_HDR_PATH=dest headers_install
+find dest/include \( -name .install -o -name ..install.cmd \) -delete
+cp -rv dest/include/* "$PKGDIR"/opt/armhf/include
+
+# Then revert.
+export ARCH=$OLDARCH

--- a/extra-optenvarmhf/linux+api+armhf/autobuild/defines
+++ b/extra-optenvarmhf/linux+api+armhf/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=linux+api+armhf
+PKGSEC=devel
+PKGDES="Linux API Headers for GNU C Library"
+
+ABHOST=noarch

--- a/extra-optenvarmhf/linux+api+armhf/spec
+++ b/extra-optenvarmhf/linux+api+armhf/spec
@@ -1,0 +1,3 @@
+VER=5.4.82
+SRCS="tbl::https://www.kernel.org/pub/linux/kernel/v${VER%%.*}.x/linux-$VER.tar.xz"
+CHKSUMS="sha256::fb4458e4ea38b6c5df4ee8cee0d9b0420b5aed07e273787b045c0db48709ddaf"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

This commit introduces the basic part of optenvarmhf which needs bootstrapping, contains the cross compiler and glibc of optenvarmhf.

Package(s) Affected
-------------------

- `linux+api+armhf` new, 5.4.46
- `glibc+armhf` new, 2.31
- `binutils+cross+optenvarmhf` new, 2.34
- `gcc+cross+optenvarmhf` new, 9.3.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

To build these packages w/o re-bootstrapping, first install the prebuilt `linux+api+armhf` and `glibc+armhf` packages (both are already noarch).

Then build in the following sequence:
- `binutils+cross+optenvarmhf`
- `gcc+cross+optenvarmhf`
- `linux+api+armhf`
- `glibc+armhf`

Architectural Progress
----------------------

The following applies to cross compilers:
- [ ] AMD64 `amd64`   
- [x] AArch64 `arm64`

The following applies to packages inside optenv:
- [ ] Architecture-independent `noarch`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

The following applies to cross compilers:
- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
----------------------

The following applies to cross compilers:
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

The following applies to packages inside optenv:
- [ ] Architecture-independent `noarch`

Post-Merge Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

The following applies to cross compilers:
- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el

<!-- TODO: CI to auto-fill architectural progress. -->
