### PR TITLE
mesa: fix arm64 packaging

### DIFF
--- a/extra-libs/libglvnd/autobuild/defines
+++ b/extra-libs/libglvnd/autobuild/defines
@@ -3,5 +3,5 @@ PKGSEC=libs
 PKGDEP="x11-lib"
 PKGDES="The GL Vendor-Neutral Dispatch library"
 
-PKGBREAK="mesa<=1:19.3.1 nvidia<=390.25-2 nvidia-libgl<=390.25-2 nvidia-libgl+340<=340.106-1"
-PKGREP="mesa<=1:19.3.1 nvidia<=390.25-2 nvidia-libgl<=390.25-2 nvidia-libgl+340<=340.106-1"
+PKGBREAK="mesa<=1:20.1.8-3 nvidia<=390.25-2 nvidia-libgl<=390.25-2 nvidia-libgl+340<=340.106-1"
+PKGREP="mesa<=1:20.1.8-3 nvidia<=390.25-2 nvidia-libgl<=390.25-2 nvidia-libgl+340<=340.106-1"

--- a/extra-libs/libglvnd/spec
+++ b/extra-libs/libglvnd/spec
@@ -1,3 +1,4 @@
 VER=1.3.2
+REL=1
 SRCTBL="https://github.com/NVIDIA/libglvnd/archive/v$VER.tar.gz"
 CHKSUM="sha256::6f41ace909302e6a063fd9dc04760b391a25a670ba5f4b6edf9e30f21410b673"

--- a/extra-libs/mesa/autobuild/defines
+++ b/extra-libs/mesa/autobuild/defines
@@ -50,6 +50,12 @@ MESON_AFTER__X86=" \
              -Ddri-drivers=i915,i965,r100,r200,nouveau \
              -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,svga,swrast,iris \
              -Dvulkan-drivers=amd,intel"
+MESON_AFTER__ARM=" \
+             ${MESON_AFTER} \
+             -Db_lto=true \
+             -Ddri-drivers=r100,r200,nouveau \
+             -Dgallium-drivers=freedreno,tegra,vc4,r300,r600,radeonsi,nouveau,virgl,lima,kmsro,swrast,panfrost \
+             -Dvulkan-drivers=amd"
 MESON_AFTER__OTHER=" \
              ${MESON_AFTER} \
              -Db_lto=false \

--- a/extra-libs/mesa/spec
+++ b/extra-libs/mesa/spec
@@ -1,4 +1,4 @@
 VER=20.1.8
-REL=3
+REL=4
 SRCTBL="https://mesa.freedesktop.org/archive/mesa-$VER.tar.xz"
 CHKSUM="sha256::df21351494f7caaec5a3ccc16f14f15512e98d2ecde178bba1d134edc899b961"

--- a/extra-x11/xorg-server/spec
+++ b/extra-x11/xorg-server/spec
@@ -1,4 +1,4 @@
 VER=1.20.9
-REL=1
+REL=2
 SRCTBL="https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.bz2"
 CHKSUM="sha256::e219f2e0dfe455467939149d7cd2ee53b79b512cc1d2094ae4f5c9ed9ccd3571"


### PR DESCRIPTION
Topic Description
-----------------

Fix broken mesa on arm64.

Package(s) Affected
-------------------

- `mesa` v1:20.1.8-4
- `xorg-server` v1.20.9 (rebuild for `mesa`)
- `libglvnd` v1.3.2-1 (rebuild for `mesa`, breaks `mesa<=1:20.1.8-3`)

Security Update?
----------------

No

Build Order
-----------------

`mesa` -> `libglvnd` -> `xorg-server`

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
