### PR TITLE
ffmpeg: enable nvenc

### DIFF
--- a/extra-libs/ffnvcodec/autobuild/build
+++ b/extra-libs/ffnvcodec/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Making..."
+make PREFIX=/usr
+
+abinfo "Installing ffnvcodec and LICENSE to $PKGDIR..."
+make PREFIX=/usr DESTDIR="$PKGDIR" install

--- a/extra-libs/ffnvcodec/autobuild/defines
+++ b/extra-libs/ffnvcodec/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME="ffnvcodec"
+PKGDES="FFmpeg version of headers required to interface with Nvidias codec APIs"
+PKGSEC="libs"
+
+ABHOST=noarch

--- a/extra-libs/ffnvcodec/spec
+++ b/extra-libs/ffnvcodec/spec
@@ -1,3 +1,3 @@
-VER=11.0.10.0
+VER=10.0.26.1
 SRCS="tbl::https://github.com/FFmpeg/nv-codec-headers/releases/download/n$VER/nv-codec-headers-$VER.tar.gz"
-CHKSUMS="sha256::e5d1fe6b18254a3c8747a38714564030e4fda506961a11a7eafb94f2400419bb"
+CHKSUMS="sha256::ed25953eee1568b2ee22042612c6a8b0aaffa2cdccc92b4ece123e420a981466"

--- a/extra-libs/ffnvcodec/spec
+++ b/extra-libs/ffnvcodec/spec
@@ -1,3 +1,3 @@
 VER=11.0.10.0
-SRCS="git::commit=7a81595786463d1c7efcb03aa85def69fc2cad41::https://git.videolan.org/git/ffmpeg/nv-codec-headers.git"
-CHKSUMS="SKIP"
+SRCS="tbl::https://github.com/FFmpeg/nv-codec-headers/releases/download/n$VER/nv-codec-headers-$VER.tar.gz"
+CHKSUMS="sha256::e5d1fe6b18254a3c8747a38714564030e4fda506961a11a7eafb94f2400419bb"

--- a/extra-libs/ffnvcodec/spec
+++ b/extra-libs/ffnvcodec/spec
@@ -1,0 +1,3 @@
+VER=11.0.10.0
+SRCS="git::commit=7a81595786463d1c7efcb03aa85def69fc2cad41::https://git.videolan.org/git/ffmpeg/nv-codec-headers.git"
+CHKSUMS="SKIP"

--- a/extra-multimedia/ffmpeg/autobuild/build
+++ b/extra-multimedia/ffmpeg/autobuild/build
@@ -28,6 +28,11 @@ if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
     MFX="--enable-libmfx"
 fi
 
+if [[ "${CROSS:-$ARCH}" = "amd64" || "${CROSS:-$ARCH}" = "arm64" ]]; then
+    NVENC="--enable-nvenc"
+fi
+
+
 if [[ "${CROSS:-$ARCH}" != "i486" && "${CROSS:-$ARCH}" != "powerpc" && "${CROSS:-$ARCH}" != "ppc64" &&
       "${CROSS:-$ARCH}" != "armel" && "${CROSS:-$ARCH}" != "armhf" && "${CROSS:-$ARCH}" != "loongson2f" ]]; then
     ./configure --prefix=/usr \
@@ -66,9 +71,8 @@ if [[ "${CROSS:-$ARCH}" != "i486" && "${CROSS:-$ARCH}" != "powerpc" && "${CROSS:
                 --enable-vdpau \
                 --enable-version3 \
                 --enable-vaapi \
-                --enable-nvenc \
                 --enable-lto \
-                $MIPSCONF $PPCCONF $MFX
+                $MIPSCONF $PPCCONF $MFX $NVENC
     make
     make tools/qt-faststart
     make install install-man DESTDIR="$PKGDIR"

--- a/extra-multimedia/ffmpeg/autobuild/build
+++ b/extra-multimedia/ffmpeg/autobuild/build
@@ -28,7 +28,7 @@ if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
     MFX="--enable-libmfx"
 fi
 
-if [[ "${CROSS:-$ARCH}" = "amd64" || "${CROSS:-$ARCH}" = "arm64" ]]; then
+if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
     NVENC="--enable-nvenc"
 fi
 

--- a/extra-multimedia/ffmpeg/autobuild/build
+++ b/extra-multimedia/ffmpeg/autobuild/build
@@ -66,6 +66,7 @@ if [[ "${CROSS:-$ARCH}" != "i486" && "${CROSS:-$ARCH}" != "powerpc" && "${CROSS:
                 --enable-vdpau \
                 --enable-version3 \
                 --enable-vaapi \
+                --enable-nvenc \
                 --enable-lto \
                 $MIPSCONF $PPCCONF $MFX
     make

--- a/extra-multimedia/ffmpeg/autobuild/defines
+++ b/extra-multimedia/ffmpeg/autobuild/defines
@@ -6,6 +6,7 @@ PKGDEP="alsa-lib bzip2 fontconfig freetype fribidi gnutls gsm lame libass libblu
         zlib soxr libva sdl2 numactl ladspa-sdk xz"
 PKGDEP__AMD64="${PKGDEP} intel-media-sdk libcrystalhd"
 BUILDDEP__AMD64="${BUILDDEP} yasm ffnvcodec"
+BUILDDEP_ARM64="${BUILDDEP} yasm ffnvcodec"
 PKGDEP__RETRO="alsa-lib bzip2 fontconfig freetype fribidi gnutls lame libass \
               libmodplug libtheora libvdpau libvorbis libxcb x264 xvidcore \
               zlib soxr libva libcue libao libmpcdec wavpack libdiscid"

--- a/extra-multimedia/ffmpeg/autobuild/defines
+++ b/extra-multimedia/ffmpeg/autobuild/defines
@@ -6,7 +6,7 @@ PKGDEP="alsa-lib bzip2 fontconfig freetype fribidi gnutls gsm lame libass libblu
         zlib soxr libva sdl2 numactl ladspa-sdk xz"
 PKGDEP__AMD64="${PKGDEP} intel-media-sdk libcrystalhd"
 BUILDDEP__AMD64="${BUILDDEP} yasm ffnvcodec"
-BUILDDEP_ARM64="${BUILDDEP} yasm ffnvcodec"
+BUILDDEP_ARM64="${BUILDDEP} yasm"
 PKGDEP__RETRO="alsa-lib bzip2 fontconfig freetype fribidi gnutls lame libass \
               libmodplug libtheora libvdpau libvorbis libxcb x264 xvidcore \
               zlib soxr libva libcue libao libmpcdec wavpack libdiscid"

--- a/extra-multimedia/ffmpeg/autobuild/defines
+++ b/extra-multimedia/ffmpeg/autobuild/defines
@@ -5,7 +5,7 @@ PKGDEP="alsa-lib bzip2 fontconfig freetype fribidi gnutls gsm lame libass libblu
         x264 x265 opencore-amr opus schroedinger sdl speex v4l-utils xvidcore \
         zlib soxr libva sdl2 numactl ladspa-sdk xz"
 PKGDEP__AMD64="${PKGDEP} intel-media-sdk libcrystalhd"
-BUILDDEP__AMD64="${BUILDDEP} yasm"
+BUILDDEP__AMD64="${BUILDDEP} yasm ffnvcodec"
 PKGDEP__RETRO="alsa-lib bzip2 fontconfig freetype fribidi gnutls lame libass \
               libmodplug libtheora libvdpau libvorbis libxcb x264 xvidcore \
               zlib soxr libva libcue libao libmpcdec wavpack libdiscid"

--- a/extra-multimedia/ffmpeg/spec
+++ b/extra-multimedia/ffmpeg/spec
@@ -1,4 +1,4 @@
 VER=4.2.4
-REL=1
+REL=2
 SRCTBL="https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUM="sha256::0d5da81feba073ee78e0f18e0966bcaf91464ae75e18e9a0135186249e3d2a0b"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

ffmpeg enable NVENC

Package(s) Affected
-------------------

ffmpeg 4.2.4-2
ffnvcodec 10.0.11.0

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

ffnvcodec
ffmpeg

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
