### PR TITLE
pighead: new, 20201028

### DIFF
--- a/extra-misc/pighead/autobuild/build
+++ b/extra-misc/pighead/autobuild/build
@@ -1,2 +1,2 @@
 abinfo "Installing Pighead (Gumblex)..."
-install -Dm755 "$SRCDIR"/pighead "$PKGDIR"/usr/bin/pighead
+install -Dvm755 "$SRCDIR"/pighead "$PKGDIR"/usr/bin/pighead

--- a/extra-misc/pighead/autobuild/build
+++ b/extra-misc/pighead/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Installing Pighead (Gumblex)..."
+install -Dm755 "$SRCDIR"/pighead "$PKGDIR"/usr/bin/pighead

--- a/extra-misc/pighead/autobuild/defines
+++ b/extra-misc/pighead/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=pighead
+PKGSEC=misc
+PKGDEP=""
+BUILDDEP=""
+PKGDES="Pighead of Gumblex, the logo of AOSC 7"

--- a/extra-misc/pighead/autobuild/defines
+++ b/extra-misc/pighead/autobuild/defines
@@ -3,3 +3,5 @@ PKGSEC=misc
 PKGDEP=""
 BUILDDEP=""
 PKGDES="Pighead of Gumblex, the logo of AOSC 7"
+
+ABHOST=noarch

--- a/extra-misc/pighead/spec
+++ b/extra-misc/pighead/spec
@@ -1,3 +1,3 @@
-VER=1.0
+VER=20201028
 SRCS="git::commit=a5b9f5c87be45a1f600dd175b94642b7b251e269::https://github.com/chenx97/pighead"
 CHKSUMS="SKIP"

--- a/extra-misc/pighead/spec
+++ b/extra-misc/pighead/spec
@@ -1,0 +1,3 @@
+VER=1.0
+SRCS="git::commit=a5b9f5c87be45a1f600dd175b94642b7b251e269::https://github.com/chenx97/pighead"
+CHKSUMS="SKIP"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
`pighead NULL => 20201028`

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
pighead

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [x] Architecture-independent `noarch`

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
