### PR TITLE
i2pd: update to 2.34.0

### DIFF
--- a/extra-web/i2pd/autobuild/beyond
+++ b/extra-web/i2pd/autobuild/beyond
@@ -1,0 +1,34 @@
+abinfo "The following script is adapted from Arch Linux ..."
+
+abinfo "Installing configuration files ..."
+install -Dvm644 "$SRCDIR"/../contrib/i2pd.conf \
+    -t "$PKGDIR"/etc/i2pd
+install -Dvm644 "$SRCDIR"/../contrib/tunnels.conf \
+    -t "$PKGDIR"/etc/i2pd
+install -dvm755 "$PKGDIR"/etc/i2pd/tunnels.d
+    
+abinfo "Installing certificates ..."    # certificates
+local _file
+while read -r -d '' _file; do
+    install -Dvm644 "$_file" \
+        "$PKGDIR"/usr/share/i2pd/certificates/${_file#contrib/certificates/}
+done < <(find "$SRCDIR"/../contrib/certificates -type f -print0)
+    
+abinfo "Installing systemd unit ..."
+install -Dvm644 "$SRCDIR"/../contrib/i2pd.service \
+    -t "$PKGDIR"/usr/lib/systemd/system
+    
+abinfo "Installing documentations ..."
+install -Dvm644 \
+    "$SRCDIR"/../contrib/tunnels.d/README \
+    "$SRCDIR"/../contrib/tunnels.d/IRC-Ilita.conf \
+    "$SRCDIR"/../contrib/tunnels.d/IRC-Irc2P.conf \
+    -t "$PKGDIR"/usr/share/doc/${pkgname}/tunnels.d
+    
+abinfo "Installing i2pd headers ..."
+install -Dvm644 "$SRCDIR"/../libi2pd{,_client}/*.h \
+    -t "$PKGDIR"/usr/include/i2pd
+    
+abinfo "Installing man page ..."
+install -Dvm644 "$SRCDIR"/../debian/i2pd.1 \
+    -t "$PKGDIR"/usr/share/man/man1

--- a/extra-web/i2pd/autobuild/defines
+++ b/extra-web/i2pd/autobuild/defines
@@ -4,8 +4,10 @@ PKGDEP="boost miniupnpc openssl"
 PKGDES="End-to-End encrypted and anonymous Internet"
 
 ABSHADOW=0
-CMAKE_AFTER="-DWITH_AESNI=OFF -DWITH_AVX=OFF \
-             -DWITH_HARDENING=ON -DWITH_UPNP=ON \
+CMAKE_AFTER="-DWITH_AESNI=OFF \
+             -DWITH_AVX=OFF \
+             -DWITH_HARDENING=ON \
+             -DWITH_UPNP=ON \
              -DWITH_THREADSANITIZER=ON"
 
 # FIXME: Host compiler must support std::atomic!

--- a/extra-web/i2pd/autobuild/overrides/usr/lib/sysusers.d/i2pd.conf
+++ b/extra-web/i2pd/autobuild/overrides/usr/lib/sysusers.d/i2pd.conf
@@ -1,0 +1,1 @@
+u i2pd - "i2pd Daemon Owner" /var/lib/i2pd -

--- a/extra-web/i2pd/autobuild/overrides/usr/lib/tmpfiles.d/i2pd.conf
+++ b/extra-web/i2pd/autobuild/overrides/usr/lib/tmpfiles.d/i2pd.conf
@@ -1,0 +1,6 @@
+d /var/lib/i2pd 0700 i2pd i2pd - -
+d /var/log/i2pd 0700 i2pd i2pd - -
+L /var/lib/i2pd/i2pd.conf - - - - /etc/i2pd/i2pd.conf
+L /var/lib/i2pd/tunnels.d - - - - /etc/i2pd/tunnels.d
+L /var/lib/i2pd/tunnels.conf - - - - /etc/i2pd/tunnels.conf
+L /var/lib/i2pd/certificates - - - - /usr/share/i2pd/certificates

--- a/extra-web/i2pd/autobuild/patch
+++ b/extra-web/i2pd/autobuild/patch
@@ -1,0 +1,4 @@
+for i in "$SRCDIR"/autobuild/patches/*.patch; do
+    abinfo "Applying $i ..."
+    patch -d "$SRCDIR"/../ -Np1 -i $i
+done

--- a/extra-web/i2pd/autobuild/patches/0001-Arch-Linux-tweak-i2pd-default-config.patch
+++ b/extra-web/i2pd/autobuild/patches/0001-Arch-Linux-tweak-i2pd-default-config.patch
@@ -1,0 +1,30 @@
+--- a/contrib/i2pd.conf
++++ b/contrib/i2pd.conf
+@@ -8,15 +8,17 @@
+ 
+ ## Tunnels config file
+ ## Default: ~/.i2pd/tunnels.conf or /var/lib/i2pd/tunnels.conf
++## Note: /var/lib/i2pd/tunnels.conf is a symlink to /etc/i2pd/tunnels.conf (use the latter)
+ # tunconf = /var/lib/i2pd/tunnels.conf
+ 
+ ## Tunnels config files path
+ ## Use that path to store separated tunnels in different config files.
+ ## Default: ~/.i2pd/tunnels.d or /var/lib/i2pd/tunnels.d
++## Note: /var/lib/i2pd/tunnels.d is a symlink to /etc/i2pd/tunnels.d (use the latter)
+ # tunnelsdir = /var/lib/i2pd/tunnels.d
+ 
+ ## Where to write pidfile (default: i2pd.pid, not used in Windows)
+-# pidfile = /run/i2pd.pid
++# pidfile = /run/i2pd/i2pd.pid
+ 
+ ## Logging configuration section
+ ## By default logs go to stdout with level 'info' and higher
+@@ -27,7 +29,7 @@
+ ##  * syslog - use syslog, see man 3 syslog
+ # log = file
+ ## Path to logfile (default - autodetect)
+-# logfile = /var/log/i2pd/i2pd.log
++logfile = /var/log/i2pd/i2pd.log
+ ## Log messages above this level (debug, info, *warn, error, none)
+ ## If you set it to none, logging will be disabled
+ # loglevel = warn

--- a/extra-web/i2pd/autobuild/patches/0002-Arch-Linux-i2pd-do-not-override-config.patch
+++ b/extra-web/i2pd/autobuild/patches/0002-Arch-Linux-i2pd-do-not-override-config.patch
@@ -1,0 +1,29 @@
+--- a/contrib/i2pd.service
++++ b/contrib/i2pd.service
+@@ -11,20 +11,24 @@ RuntimeDirectoryMode=0700
+ LogsDirectory=i2pd
+ LogsDirectoryMode=0700
+ Type=forking
+-ExecStart=/usr/sbin/i2pd --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf --tunnelsdir=/etc/i2pd/tunnels.conf.d --pidfile=/run/i2pd/i2pd.pid --logfile=/var/log/i2pd/i2pd.log --daemon --service
++ExecStart=/usr/sbin/i2pd --conf=/var/lib/i2pd/i2pd.conf --pidfile=/run/i2pd/i2pd.pid --daemon --service
+ ExecReload=/bin/sh -c "kill -HUP $MAINPID"
+ PIDFile=/run/i2pd/i2pd.pid
+ ### Uncomment, if auto restart needed
+ #Restart=on-failure
+ 
++# SIGQUIT is setted by upstream and always generates a core dump.
++# You can ignore the failed exit (core dump) when stopping the service.
+ KillSignal=SIGQUIT
++
+ # If you have the patience waiting 10 min on restarting/stopping it, uncomment this.
+ # i2pd stops accepting new tunnels and waits ~10 min while old ones do not die.
+ #KillSignal=SIGINT
+ #TimeoutStopSec=10m
+ 
+-# If you have problems with hanging i2pd, you can try increase this
++# If you have problems with hanging i2pd, you can try to increase this
+ LimitNOFILE=4096
++
+ # To enable write of coredump uncomment this
+ #LimitCORE=infinity
+ 

--- a/extra-web/i2pd/autobuild/patches/0003-Arch-Linux-i2pd-tunnels-d-readme.patch
+++ b/extra-web/i2pd/autobuild/patches/0003-Arch-Linux-i2pd-tunnels-d-readme.patch
@@ -1,0 +1,8 @@
+--- a/contrib/tunnels.d/README
++++ b/contrib/tunnels.d/README
+@@ -1,4 +1,4 @@
+-# In that directory you can store separated config files for every tunnel.
++# In the /etc/i2pd/tunnels.d directory you can store separated config files for every tunnel.
+ # Please read documentation for more info.
+ #
+ # You can find examples in /usr/share/doc/i2pd/tunnels.d directory

--- a/extra-web/i2pd/autobuild/postinst
+++ b/extra-web/i2pd/autobuild/postinst
@@ -1,0 +1,2 @@
+systemd-sysusers i2pd.conf
+systemd-tmpfiles --create i2pd.conf

--- a/extra-web/i2pd/spec
+++ b/extra-web/i2pd/spec
@@ -1,4 +1,4 @@
-VER=2.33.0
+VER=2.34.0
 SRCTBL="https://github.com/PurpleI2P/i2pd/archive/$VER.tar.gz"
-CHKSUM="sha256::6a30eb410263d2da23d238758ad156e36983bff1ed347fe57789763ae986d0f4"
+CHKSUM="sha256::1adb4cf629f1315e9de394630b6bf1e3ba2365fd0a3601635dfb4ba9b481cb94"
 SUBDIR="i2pd-$VER/build"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update i2pd to 2.34.0.

Package(s) Affected
-------------------

`i2pd` v2.34.0

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

~- Loongson 3 `loongson3`~
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

~- Loongson 3 `loongson3`~
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
