### PR TITLE
kdiskmark: new, 2.0.0

### DIFF
--- a/extra-kde/kdiskmark/autobuild/defines
+++ b/extra-kde/kdiskmark/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=kdiskmark
+PKGDES="A simple disk benchmark tool"
+PKGDEP="qt-5 libbfio libaio"
+BUILDDEP="extra-cmake-modules"
+PKGSEC="utils"

--- a/extra-kde/kdiskmark/autobuild/defines
+++ b/extra-kde/kdiskmark/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=kdiskmark
 PKGDES="A simple disk benchmark tool"
-PKGDEP="qt-5 libbfio libaio"
+PKGDEP="qt-5 fio libaio"
 BUILDDEP="extra-cmake-modules"
 PKGSEC="utils"

--- a/extra-kde/kdiskmark/spec
+++ b/extra-kde/kdiskmark/spec
@@ -1,0 +1,3 @@
+VER=2.0.0
+SRCS="tbl::https://github.com/JonMagon/KDiskMark/archive/$VER.tar.gz"
+CHKSUMS="sha256::09b791be5fbb9b262c9757e3a2a2df41d70c74c59d80440c6d151f0288284f08"

--- a/extra-utils/fio/autobuild/build
+++ b/extra-utils/fio/autobuild/build
@@ -1,11 +1,10 @@
 abinfo "Configureing..."
-./configure --disable-native --enable-gfio --extra-cflags="$CFLAGS"
+"$SRCDIR"/configure --disable-native --enable-gfio --extra-cflags="$CFLAGS"
 
 abinfo "Making..."
 make DESTDIR="$PKGDIR" prefix=/usr mandir=/usr/share/man install
 
 abinfo "Installing file..."
 install -dvm755 "$PKGDIR/usr/share/doc/$PKGNAME"
-install -vm644 HOWTO README REPORTING-BUGS SERVER-TODO "$PKGDIR/usr/share/doc/$PKGNAME"
-install -Dvm644 COPYING "$PKGDIR/usr/share/doc/$PKGNAME/COPYING"
-install -Dvm644 MORAL-LICENSE "$PKGDIR/usr/share/doc/$PKGNAME/MORAL-LICENSE"
+install -vm644 "$SRCDIR"/{HOWTO,README,REPORTING-BUGS,SERVER-TODO} "$PKGDIR/usr/share/doc/$PKGNAME"
+install -Dvm644 "$SRCDIR"/MORAL-LICENSE "$PKGDIR/usr/share/doc/$PKGNAME/MORAL-LICENSE"

--- a/extra-utils/fio/autobuild/build
+++ b/extra-utils/fio/autobuild/build
@@ -1,0 +1,11 @@
+abinfo "Configureing..."
+./configure --disable-native --enable-gfio --extra-cflags="$CFLAGS"
+
+abinfo "Making..."
+make DESTDIR="$PKGDIR" prefix=/usr mandir=/usr/share/man install
+
+abinfo "Installing file..."
+install -dvm755 "$PKGDIR/usr/share/doc/$PKGNAME"
+install -vm644 HOWTO README REPORTING-BUGS SERVER-TODO "$PKGDIR/usr/share/doc/$PKGNAME"
+install -Dvm644 COPYING "$PKGDIR/usr/share/doc/$PKGNAME/COPYING"
+install -Dvm644 MORAL-LICENSE "$PKGDIR/usr/share/doc/$PKGNAME/MORAL-LICENSE"

--- a/extra-utils/fio/autobuild/defines
+++ b/extra-utils/fio/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME="fio"
+PKGDES="Scriptable I/O tool for storage benchmarks and drive testing"
+PKGDEP="bash libaio python-2 numactl gtk-2"
+PKGSEC="utils"

--- a/extra-utils/fio/spec
+++ b/extra-utils/fio/spec
@@ -1,0 +1,3 @@
+VER=3.23
+SRCS="tbl::https://github.com/axboe/fio/archive/fio-$VER.zip"
+CHKSUMS="sha256::066a44fdbdd2b35d33987fee5991dcc7d932760c2743e90648041aa1a5406e09"


### PR DESCRIPTION


Topic Description
-----------------

kdiskmark: new, 2.0.0

Package(s) Affected
-------------------

kdiskmark 2.0.0

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
