### PR TITLE
darktable: fix a race condition in thumbnail widget

### DIFF
--- a/extra-creativity/darktable/autobuild/defines
+++ b/extra-creativity/darktable/autobuild/defines
@@ -30,3 +30,5 @@ CMAKE_AFTER__PPC64EL=" \
 PKGEPOCH=1
 
 NOLTO=1
+
+FAIL_ARCH="!(amd64|arm64|ppc64el)"

--- a/extra-creativity/darktable/autobuild/defines
+++ b/extra-creativity/darktable/autobuild/defines
@@ -31,4 +31,3 @@ PKGEPOCH=1
 
 NOLTO=1
 
-FAIL_ARCH="!(amd64|arm64|ppc64el)"

--- a/extra-creativity/darktable/autobuild/patches/0001-thumbnail-record-expose_again-source-ID-and-cancel-t.patch
+++ b/extra-creativity/darktable/autobuild/patches/0001-thumbnail-record-expose_again-source-ID-and-cancel-t.patch
@@ -1,0 +1,82 @@
+From 15ee5748109980ce78868e7eef1c7969db825c7d Mon Sep 17 00:00:00 2001
+From: Tianhao Chai <cth451@gmail.com>
+Date: Mon, 26 Oct 2020 00:02:22 -0500
+Subject: [PATCH] thumbnail: record expose_again source ID and cancel timeout
+ on destroy
+
+This resolves a race condition where a thumbnail widget may be destroyed
+before the expose_again timeout is triggered, causing a use-after-free
+problem. In particular, this commit fixes #6620.
+
+thumbnail: check thumb pointer before deref in expose_again
+
+thumbnail: restore expose_again timeout to 250ms
+---
+ src/dtgtk/thumbnail.c | 15 +++++++++++----
+ src/dtgtk/thumbnail.h |  2 ++
+ 2 files changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/src/dtgtk/thumbnail.c b/src/dtgtk/thumbnail.c
+index 0fad809e4..30c9723bd 100644
+--- a/src/dtgtk/thumbnail.c
++++ b/src/dtgtk/thumbnail.c
+@@ -196,10 +196,13 @@ static void _image_get_infos(dt_thumbnail_t *thumb)
+ 
+ static gboolean _thumb_expose_again(gpointer user_data)
+ {
+-  if(!user_data || !GTK_IS_WIDGET(user_data)) return FALSE;
++  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
++  if(!thumb) return FALSE;
++  gpointer w_image = thumb->w_image;
++  if(!w_image || !GTK_IS_WIDGET(w_image)) return FALSE;
+ 
+-  GtkWidget *widget = (GtkWidget *)user_data;
+-  gtk_widget_queue_draw(widget);
++  thumb->expose_again_timeout_id = 0;
++  gtk_widget_queue_draw((GtkWidget *)w_image);
+   return FALSE;
+ }
+ 
+@@ -408,7 +411,9 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
+       if(res)
+       {
+         // if the image is missing, we reload it again
+-        g_timeout_add(250, _thumb_expose_again, widget);
++        if(!thumb->expose_again_timeout_id)
++          thumb->expose_again_timeout_id = g_timeout_add(250, _thumb_expose_again, thumb);
++
+         // we still draw the thumb to avoid flickering
+         _thumb_draw_image(thumb, cr);
+         return TRUE;
+@@ -1215,6 +1220,7 @@ dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt
+   thumb->zoom = 1.0f;
+   thumb->overlay_timeout_duration = dt_conf_get_int("plugins/lighttable/overlay_timeout");
+   thumb->tooltip = tooltip;
++  thumb->expose_again_timeout_id = 0;
+ 
+   // we read and cache all the infos from dt_image_t that we need
+   const dt_image_t *img = dt_image_cache_get(darktable.image_cache, thumb->imgid, 'r');
+@@ -1269,6 +1275,7 @@ dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt
+ void dt_thumbnail_destroy(dt_thumbnail_t *thumb)
+ {
+   if(thumb->overlay_timeout_id > 0) g_source_remove(thumb->overlay_timeout_id);
++  if(thumb->expose_again_timeout_id != 0) g_source_remove(thumb->expose_again_timeout_id);
+   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_dt_selection_changed_callback), thumb);
+   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_dt_active_images_callback), thumb);
+   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_dt_mipmaps_updated_callback), thumb);
+diff --git a/src/dtgtk/thumbnail.h b/src/dtgtk/thumbnail.h
+index f37d5c0c4..ba144a6c6 100644
+--- a/src/dtgtk/thumbnail.h
++++ b/src/dtgtk/thumbnail.h
+@@ -116,6 +116,8 @@ typedef struct
+   int overlay_timeout_id;       // id of the g_source timeout fct
+   gboolean tooltip;             // should we show the tooltip ?
+ 
++  int expose_again_timeout_id;  // source id of the expose_again timeout
++
+   // specific for culling and preview
+   gboolean zoomable;   // can we zoom in/out the thumbnail (used for culling/preview)
+   double aspect_ratio; // aspect ratio of the image
+-- 
+2.28.0
+

--- a/extra-creativity/darktable/autobuild/patches/0002-meta-allow-compiling-on-mips64el.patch
+++ b/extra-creativity/darktable/autobuild/patches/0002-meta-allow-compiling-on-mips64el.patch
@@ -1,0 +1,40 @@
+From afd77d8ed47dfa8c1193277bf7f8b7e3941fd33a Mon Sep 17 00:00:00 2001
+From: Tianhao Chai <cth451@gmail.com>
+Date: Fri, 30 Oct 2020 01:03:45 -0500
+Subject: [PATCH] meta: allow compiling on mips64el
+
+---
+ src/is_supported_platform.h | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/is_supported_platform.h b/src/is_supported_platform.h
+index e8b968776..8aab340a7 100644
+--- a/src/is_supported_platform.h
++++ b/src/is_supported_platform.h
+@@ -36,6 +36,12 @@
+ #define DT_SUPPORTED_ARMv8A 0
+ #endif
+ 
++#if defined(__mips__) && defined(__mips64)
++#define DT_SUPPORTED_MIPS64 1
++#else
++#define DT_SUPPORTED_MIPS64 0
++#endif
++
+ #if defined(__PPC64__)
+ #define DT_SUPPORTED_PPC64 1
+ #else
+@@ -46,8 +52,8 @@
+ #error "Looks like hardware platform detection macros are broken?"
+ #endif
+ 
+-#if !DT_SUPPORTED_X86 && !DT_SUPPORTED_ARMv8A && !DT_SUPPORTED_PPC64
+-#error "Unfortunately we only work on amd64, ARMv8-A and PPC64 (64-bit little-endian only)."
++#if !DT_SUPPORTED_X86 && !DT_SUPPORTED_ARMv8A && !DT_SUPPORTED_PPC64 && !DT_SUPPORTED_MIPS64
++#error "Unfortunately we only work on amd64, ARMv8-A, MIPS64 and PPC64 (64-bit little-endian only)."
+ #endif
+ 
+ #undef DT_SUPPORTED_PPC64
+-- 
+2.28.0
+

--- a/extra-creativity/darktable/spec
+++ b/extra-creativity/darktable/spec
@@ -1,3 +1,4 @@
 VER=3.2.1
+REL=1
 SRCTBL="https://github.com/darktable-org/darktable/releases/download/release-$VER/darktable-$VER.tar.xz"
 CHKSUM="sha256::6e3683ea88dc0a0271be7eca4fd594b9e46b1b7194847825a8d0a0c12bdeb90c"


### PR DESCRIPTION
Topic Description
-----------------

This PR fixes a usability bug where darktable would segfault when scrolling too fast due to a use-after-free in the thumbnail table.

Package(s) Affected
-------------------

`darktable < 1:3.2.1-1`

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Extra Notes
----------------

The patch should be removed when darktable 3.4.x is released in the future, as this patch is part of darktable [3.4 milestone](https://github.com/darktable-org/darktable/milestone/16).

<!-- TODO: CI to auto-fill architectural progress. -->
