### PR TITLE
aiohttp: update to 3.7.2

### DIFF
--- a/extra-python/aiohttp/autobuild/defines
+++ b/extra-python/aiohttp/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=aiohttp
 PKGSEC=python
 PKGDEP="attrs chardet multidict async-timeout yarl idna"
-BUILDDEP="setuptools pathlib"
+BUILDDEP="setuptools pathlib cython"
 PKGDES="An async http client/server framework"
 
 ABTYPE=python

--- a/extra-python/aiohttp/autobuild/defines
+++ b/extra-python/aiohttp/autobuild/defines
@@ -1,9 +1,8 @@
 PKGNAME=aiohttp
 PKGSEC=python
-PKGDEP="attrs chardet multidict async-timeout yarl idna"
+PKGDEP="attrs chardet multidict async-timeout yarl idna typing-extensions"
 BUILDDEP="setuptools pathlib cython"
 PKGDES="An async http client/server framework"
 
 ABTYPE=python
-ABHOST=noarch
 NOPYTHON2=1

--- a/extra-python/aiohttp/autobuild/defines
+++ b/extra-python/aiohttp/autobuild/defines
@@ -5,4 +5,5 @@ BUILDDEP="setuptools pathlib cython"
 PKGDES="An async http client/server framework"
 
 ABTYPE=python
+ABHOST=noarch
 NOPYTHON2=1

--- a/extra-python/aiohttp/autobuild/prepare
+++ b/extra-python/aiohttp/autobuild/prepare
@@ -1,0 +1,4 @@
+abinfo "Converting .pyx file into C file..."
+cd "$SRCDIR"
+sed 's| .install-cython ||g' -i Makefile
+make cythonize

--- a/extra-python/aiohttp/autobuild/prepare
+++ b/extra-python/aiohttp/autobuild/prepare
@@ -1,4 +1,4 @@
 abinfo "Converting .pyx file into C file..."
 cd "$SRCDIR"
-sed 's| .install-cython ||g' -i Makefile
+sed 's| .install-cython ||g' -i "$SRCDIR"/Makefile
 make cythonize

--- a/extra-python/aiohttp/spec
+++ b/extra-python/aiohttp/spec
@@ -1,3 +1,3 @@
 VER=3.7.2
-SRCTBL="https://github.com/aio-libs/aiohttp/archive/v${VER}.tar.gz"
-CHKSUM="sha256::22ed7395d53c03f0f4872e5cdd051330bbce33f3d81b0af9aefd48a7077db040"
+SRCTBL="https://pypi.python.org/packages/source/a/aiohttp/aiohttp-3.7.2.tar.gz"
+CHKSUM="sha256::c6da1af59841e6d43255d386a2c4bfb59c0a3b262bdb24325cc969d211be6070"

--- a/extra-python/aiohttp/spec
+++ b/extra-python/aiohttp/spec
@@ -1,3 +1,3 @@
-VER=3.6.2
+VER=3.7.2
 SRCTBL="https://github.com/aio-libs/aiohttp/archive/v${VER}.tar.gz"
-CHKSUM="sha256::4ad2d8393843ea0c7b50a93bf04fb1cf20b93c0a5e958de128efcd2e5f8adf80"
+CHKSUM="sha256::22ed7395d53c03f0f4872e5cdd051330bbce33f3d81b0af9aefd48a7077db040"

--- a/extra-python/multidict/autobuild/defines
+++ b/extra-python/multidict/autobuild/defines
@@ -5,4 +5,5 @@ BUILDDEP="setuptools"
 PKGDES="Dict-like key-value pairs collection for Python"
 
 ABTYPE=python
+ABHOST=noarch
 NOPYTHON2=1

--- a/extra-python/multidict/autobuild/defines
+++ b/extra-python/multidict/autobuild/defines
@@ -5,5 +5,4 @@ BUILDDEP="setuptools"
 PKGDES="Dict-like key-value pairs collection for Python"
 
 ABTYPE=python
-ABHOST=noarch
 NOPYTHON2=1

--- a/extra-python/multidict/spec
+++ b/extra-python/multidict/spec
@@ -1,3 +1,3 @@
-VER=4.7.6
+VER=5.0.0
 SRCTBL="https://github.com/aio-libs/multidict/archive/v${VER}.tar.gz"
-CHKSUM="sha256::449035f89a12f189579ff83811424c71e4a39e335bcb8045145ad084b7bde2dc"
+CHKSUM="sha256::d18fe7497c1565f1851b81c90ccf43d8bdbc1e40ea4627098e5d93be0e1e3780"

--- a/extra-python/typing-extensions/autobuild/defines
+++ b/extra-python/typing-extensions/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=typing-extensions
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="Backported and Experimental Type Hint Support for Python 3.5+"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/typing-extensions/spec
+++ b/extra-python/typing-extensions/spec
@@ -1,0 +1,3 @@
+VER=3.7.4.3
+SRCTBL="https://pypi.io/packages/source/t/typing_extensions/typing_extensions-$VER.tar.gz"
+CHKSUM="sha256::99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"

--- a/extra-python/yarl/autobuild/defines
+++ b/extra-python/yarl/autobuild/defines
@@ -5,5 +5,4 @@ BUILDDEP="setuptools pathlib cython"
 PKGDES="Yet another URL library for Python"
 
 ABTYPE=python
-ABHOST=noarch
 NOPYTHON2=1

--- a/extra-python/yarl/autobuild/defines
+++ b/extra-python/yarl/autobuild/defines
@@ -5,4 +5,5 @@ BUILDDEP="setuptools pathlib cython"
 PKGDES="Yet another URL library for Python"
 
 ABTYPE=python
+ABHOST=noarch
 NOPYTHON2=1

--- a/extra-python/yarl/autobuild/defines
+++ b/extra-python/yarl/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=yarl
 PKGSEC=python
 PKGDEP="glibc multidict idna"
-BUILDDEP="setuptools pathlib"
+BUILDDEP="setuptools pathlib cython"
 PKGDES="Yet another URL library for Python"
 
 ABTYPE=python

--- a/extra-python/yarl/autobuild/prepare
+++ b/extra-python/yarl/autobuild/prepare
@@ -1,0 +1,4 @@
+abinfo "Converting .pyx file into C file..."
+cd "$SRCDIR"
+sed 's| .install-cython ||g' -i Makefile
+make cythonize

--- a/extra-python/yarl/autobuild/prepare
+++ b/extra-python/yarl/autobuild/prepare
@@ -1,4 +1,4 @@
 abinfo "Converting .pyx file into C file..."
 cd "$SRCDIR"
-sed 's| .install-cython ||g' -i Makefile
+sed 's| .install-cython ||g' -i "$SRCDIR"/Makefile
 make cythonize

--- a/extra-python/yarl/spec
+++ b/extra-python/yarl/spec
@@ -1,3 +1,3 @@
-VER=1.5.0
+VER=1.6.2
 SRCTBL="https://github.com/aio-libs/yarl/archive/v${VER}.tar.gz"
-CHKSUM="sha256::6bd62c4a97648f8c052b514a72c6db5f626e94bef98a40a7423e8202a299bb7e"
+CHKSUM="sha256::a4a674d655eeac67f3beae09268104f75e961b9e9c50b354935cad6186e0c52f"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

```
aiohttp => 3.7.2
yarl => 1.6.2
multidict => 5.0.0
typing-extensions => 3.7.4.3
```

Package(s) Affected
-------------------

aiohttp
yarl
multidict
typing-extensions

Security Update?
----------------

No

Build Order
-----------

`(multidict -> yarl), typing-extensions -> aiohttp`

Architectural Progress
----------------------

* `aiohttp` `yarl` `multidict`
- [x] AMD64 `amd64`: 
- [x] AArch64 `arm64`

* `typing-extensions`
- [x] Architecture-independent `noarch`

Secondary Architectural Progress
--------------------------------

* `aiohttp` `yarl` `multidict`
- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

* `aiohttp` `yarl` `multidict`
- [x] AMD64 `amd64`: 
- [x] AArch64 `arm64`

* `typing-extensions`
- [x] Architecture-independent `noarch`

Post-Merge Secondary Architectural Progress
-------------------------------------------

* `aiohttp` `yarl` `multidict`
- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
