### PR TITLE
qbittorrent: update to 4.3.0.1

### DIFF
--- a/extra-libs/libtorrent-rasterbar/autobuild/defines
+++ b/extra-libs/libtorrent-rasterbar/autobuild/defines
@@ -7,6 +7,8 @@ AUTOTOOLS_AFTER="--enable-python-binding \
                  --with-libiconv \
                  --with-boost-python=boost_python \
                  PYTHON=/usr/bin/python2"
-ABSHADOW=no
+ABSHADOW=0
 
 PKGBREAK="deluge<=1.3.15 epour<=0.7.0"
+
+NOLTO__LOONGSON3=1

--- a/extra-web/qbittorrent/autobuild/defines
+++ b/extra-web/qbittorrent/autobuild/defines
@@ -6,3 +6,4 @@ PKGDES="Free and reliable P2P Bittorrent client"
 
 MAKE_AFTER="INSTALL_ROOT=$PKGDIR"
 RECONF=0
+NOLTO__LOONGSON3=1

--- a/extra-web/qbittorrent/spec
+++ b/extra-web/qbittorrent/spec
@@ -1,4 +1,3 @@
-VER=4.2.1
-REL=1
+VER=4.3.0.1
 SRCTBL="https://sourceforge.net/projects/qbittorrent/files/qbittorrent/qbittorrent-$VER/qbittorrent-$VER.tar.xz/download"
-CHKSUM="sha256::a43466b4415a7a220584e0faabdaba60545f11a0be34040c64c2747c04bb3209"
+CHKSUM="sha256::30a4bf23e92accf93bb840c96518358a4da836427713f0cc13db4a3f9a612220"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
Update qBittorrent to 4.3.0.1
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- qbittorrent
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
