### PR TITLE
zxtune: fix Qt 5 port and add ncsf support

### DIFF
--- a/extra-multimedia/zxtune/autobuild/patches/0004-zxtune-qt-Port-to-Qt-5.patch
+++ b/extra-multimedia/zxtune/autobuild/patches/0004-zxtune-qt-Port-to-Qt-5.patch
@@ -1,7 +1,7 @@
-From 40c0101b9dd4b196c765af5824660a2e634dfc44 Mon Sep 17 00:00:00 2001
+From 3c492449e6809180fbe72cc52826f06d2a9bdbeb Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Thu, 3 Oct 2019 21:16:18 -0600
-Subject: [PATCH] zxtune-qt: Port to Qt 5
+Subject: [PATCH 1/3] zxtune-qt: Port to Qt 5
 
 ---
  apps/zxtune-qt/Makefile                       |  6 ++--
@@ -74,10 +74,8 @@ Subject: [PATCH] zxtune-qt: Port to Qt 5
  apps/zxtune-qt/ui/utils.h                     |  1 +
  apps/zxtune-qt/update/check.cpp               |  8 ++---
  apps/zxtune-qt/update/check.h                 |  2 +-
- make.sh                                       |  1 +
  make/qt.mak                                   |  2 +-
- 72 files changed, 159 insertions(+), 144 deletions(-)
- create mode 100644 make.sh
+ 71 files changed, 158 insertions(+), 144 deletions(-)
 
 diff --git a/apps/zxtune-qt/Makefile b/apps/zxtune-qt/Makefile
 index 36fd6c41c..3c322d978 100644
@@ -351,7 +349,7 @@ index 893da97f0..5868dab81 100644
  namespace Playlist
  {
 diff --git a/apps/zxtune-qt/playlist/ui/playlist_view.cpp b/apps/zxtune-qt/playlist/ui/playlist_view.cpp
-index b7c7d9ef0..f17dc9d65 100644
+index b7c7d9ef0..17c98ca32 100644
 --- a/apps/zxtune-qt/playlist/ui/playlist_view.cpp
 +++ b/apps/zxtune-qt/playlist/ui/playlist_view.cpp
 @@ -39,15 +39,16 @@
@@ -368,7 +366,7 @@ index b7c7d9ef0..f17dc9d65 100644
 -#include <QtGui/QProxyModel>
 -#include <QtGui/QVBoxLayout>
 +#include <QtCore/QMimeData>
-+#include <QtCore/QSortFilterProxyModel>
++#include <QtCore/QIdentityProxyModel>
 +#include <QApplication>
 +#include <QClipboard>
 +#include <QDragEnterEvent>
@@ -394,12 +392,12 @@ index b7c7d9ef0..f17dc9d65 100644
    };
  
 -  class RetranslateModel : public QProxyModel
-+  class RetranslateModel : public QSortFilterProxyModel
++  class RetranslateModel : public QIdentityProxyModel
    {
    public:
      explicit RetranslateModel(Playlist::Model& model)
 -      : QProxyModel(&model)
-+      : QSortFilterProxyModel(&model)
++      : QIdentityProxyModel(&model)
        , Delegate(model)
      {
 -      setModel(&model);
@@ -412,7 +410,7 @@ index b7c7d9ef0..f17dc9d65 100644
          return GetHeaderText(section);
        }
 -      return QProxyModel::headerData(section, orientation, role);
-+      return QSortFilterProxyModel::headerData(section, orientation, role);
++      return sourceModel()->headerData(section, orientation, role);
      }
  
      QVariant data(const QModelIndex& index, int role) const override
@@ -421,7 +419,7 @@ index b7c7d9ef0..f17dc9d65 100644
        else
        {
 -        return QProxyModel::data(index, role);
-+        return QSortFilterProxyModel::data(index, role);
++        return QIdentityProxyModel::data(index, role);
        }
      }
  
@@ -1315,13 +1313,6 @@ index 4f354e5b0..d24ad2927 100644
  
  class Error;
  
-diff --git a/make.sh b/make.sh
-new file mode 100644
-index 000000000..97f51ff25
---- /dev/null
-+++ b/make.sh
-@@ -0,0 +1 @@
-+make -j4 system.zlib=1 packaging=any platform=linux arch=x86_64 distro= prebuilt.dir=/usr/lib/ qt.includes='/usr/include/qt /usr/include/qt/QtWidgets/ /usr/include/qt/QtGui/' pic=1
 diff --git a/make/qt.mak b/make/qt.mak
 index 243311aae..8777e7c17 100644
 --- a/make/qt.mak
@@ -1336,5 +1327,5 @@ index 243311aae..8777e7c17 100644
  ifneq (,$(findstring Core,$(libraries.qt)))
  libraries.windows += Qtmain kernel32 user32 shell32 uuid ole32 advapi32 ws2_32 oldnames
 -- 
-2.28.0
+2.29.1
 

--- a/extra-multimedia/zxtune/autobuild/patches/0005-format-Add-support-for-NCSF-format.patch
+++ b/extra-multimedia/zxtune/autobuild/patches/0005-format-Add-support-for-NCSF-format.patch
@@ -1,0 +1,7313 @@
+From c858c993d711220d717fc66687b3a3a1d9c37b5a Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Tue, 25 Aug 2020 21:52:39 -0600
+Subject: [PATCH 3/3] format: Add support for NCSF format
+
+---
+ 3rdparty/sseqplayer/.gitignore                |    6 +
+ 3rdparty/sseqplayer/Channel.cpp               |  763 ++++++
+ 3rdparty/sseqplayer/Channel.h                 |  165 ++
+ 3rdparty/sseqplayer/FATSection.cpp            |   40 +
+ 3rdparty/sseqplayer/FATSection.h              |   30 +
+ 3rdparty/sseqplayer/INFOEntry.cpp             |   48 +
+ 3rdparty/sseqplayer/INFOEntry.h               |   51 +
+ 3rdparty/sseqplayer/INFOSection.cpp           |   61 +
+ 3rdparty/sseqplayer/INFOSection.h             |   34 +
+ 3rdparty/sseqplayer/LICENSE.TXT               |   13 +
+ 3rdparty/sseqplayer/Makefile                  |    8 +
+ 3rdparty/sseqplayer/NDSStdHeader.cpp          |   31 +
+ 3rdparty/sseqplayer/NDSStdHeader.h            |   23 +
+ 3rdparty/sseqplayer/Player.cpp                |  232 ++
+ 3rdparty/sseqplayer/Player.h                  |   52 +
+ 3rdparty/sseqplayer/SBNK.cpp                  |  123 +
+ 3rdparty/sseqplayer/SBNK.h                    |   58 +
+ 3rdparty/sseqplayer/SDAT.cpp                  |   93 +
+ 3rdparty/sseqplayer/SDAT.h                    |   28 +
+ 3rdparty/sseqplayer/SSEQ.cpp                  |   50 +
+ 3rdparty/sseqplayer/SSEQ.h                    |   29 +
+ 3rdparty/sseqplayer/SSEQPlayer.vcxproj        |  117 +
+ .../sseqplayer/SSEQPlayer.vcxproj.filters     |  104 +
+ 3rdparty/sseqplayer/SWAR.cpp                  |   42 +
+ 3rdparty/sseqplayer/SWAR.h                    |   30 +
+ 3rdparty/sseqplayer/SWAV.cpp                  |  125 +
+ 3rdparty/sseqplayer/SWAV.h                    |   29 +
+ 3rdparty/sseqplayer/SYMBSection.cpp           |   60 +
+ 3rdparty/sseqplayer/SYMBSection.h             |   36 +
+ 3rdparty/sseqplayer/Track.cpp                 |  811 +++++++
+ 3rdparty/sseqplayer/Track.h                   |   96 +
+ 3rdparty/sseqplayer/codecvt.h                 | 2098 +++++++++++++++++
+ 3rdparty/sseqplayer/common.h                  |  280 +++
+ 3rdparty/sseqplayer/consts.h                  |   60 +
+ 3rdparty/sseqplayer/convert.h                 |  170 ++
+ 3rdparty/sseqplayer/wstring_convert.h         |  183 ++
+ apps/libzxtune/Makefile                       |    2 +-
+ .../zxtune/src/main/jni/Makefile              |    2 +-
+ apps/zxtune-qt/Makefile                       |    2 +-
+ apps/zxtune123/Makefile                       |    2 +-
+ src/core/plugins/players/plugins_list.cpp     |    1 +
+ src/core/plugins/players/plugins_list.h       |    1 +
+ src/core/plugins/players/xsf/ncsf_supp.cpp    |   31 +
+ src/formats/chiptune/decoders.h               |    1 +
+ .../emulation/nitrocomposersoundformat.cpp    |   94 +
+ .../emulation/nitrocomposersoundformat.h      |   39 +
+ src/formats/instrumentation/fuzz.cpp          |    1 +
+ src/formats/text/chiptune.cpp                 |    3 +
+ src/formats/text/chiptune.h                   |    1 +
+ src/formats/text/chiptune.txt                 |    4 +
+ src/module/players/xsf/ncsf.cpp               |  454 ++++
+ src/module/players/xsf/ncsf.h                 |   22 +
+ 52 files changed, 6835 insertions(+), 4 deletions(-)
+ create mode 100644 3rdparty/sseqplayer/.gitignore
+ create mode 100644 3rdparty/sseqplayer/Channel.cpp
+ create mode 100644 3rdparty/sseqplayer/Channel.h
+ create mode 100644 3rdparty/sseqplayer/FATSection.cpp
+ create mode 100644 3rdparty/sseqplayer/FATSection.h
+ create mode 100644 3rdparty/sseqplayer/INFOEntry.cpp
+ create mode 100644 3rdparty/sseqplayer/INFOEntry.h
+ create mode 100644 3rdparty/sseqplayer/INFOSection.cpp
+ create mode 100644 3rdparty/sseqplayer/INFOSection.h
+ create mode 100644 3rdparty/sseqplayer/LICENSE.TXT
+ create mode 100644 3rdparty/sseqplayer/Makefile
+ create mode 100644 3rdparty/sseqplayer/NDSStdHeader.cpp
+ create mode 100644 3rdparty/sseqplayer/NDSStdHeader.h
+ create mode 100644 3rdparty/sseqplayer/Player.cpp
+ create mode 100644 3rdparty/sseqplayer/Player.h
+ create mode 100644 3rdparty/sseqplayer/SBNK.cpp
+ create mode 100644 3rdparty/sseqplayer/SBNK.h
+ create mode 100644 3rdparty/sseqplayer/SDAT.cpp
+ create mode 100644 3rdparty/sseqplayer/SDAT.h
+ create mode 100644 3rdparty/sseqplayer/SSEQ.cpp
+ create mode 100644 3rdparty/sseqplayer/SSEQ.h
+ create mode 100644 3rdparty/sseqplayer/SSEQPlayer.vcxproj
+ create mode 100644 3rdparty/sseqplayer/SSEQPlayer.vcxproj.filters
+ create mode 100644 3rdparty/sseqplayer/SWAR.cpp
+ create mode 100644 3rdparty/sseqplayer/SWAR.h
+ create mode 100644 3rdparty/sseqplayer/SWAV.cpp
+ create mode 100644 3rdparty/sseqplayer/SWAV.h
+ create mode 100644 3rdparty/sseqplayer/SYMBSection.cpp
+ create mode 100644 3rdparty/sseqplayer/SYMBSection.h
+ create mode 100644 3rdparty/sseqplayer/Track.cpp
+ create mode 100644 3rdparty/sseqplayer/Track.h
+ create mode 100644 3rdparty/sseqplayer/codecvt.h
+ create mode 100644 3rdparty/sseqplayer/common.h
+ create mode 100644 3rdparty/sseqplayer/consts.h
+ create mode 100644 3rdparty/sseqplayer/convert.h
+ create mode 100644 3rdparty/sseqplayer/wstring_convert.h
+ create mode 100644 src/core/plugins/players/xsf/ncsf_supp.cpp
+ create mode 100644 src/formats/chiptune/emulation/nitrocomposersoundformat.cpp
+ create mode 100644 src/formats/chiptune/emulation/nitrocomposersoundformat.h
+ create mode 100644 src/module/players/xsf/ncsf.cpp
+ create mode 100644 src/module/players/xsf/ncsf.h
+
+diff --git a/3rdparty/sseqplayer/.gitignore b/3rdparty/sseqplayer/.gitignore
+new file mode 100644
+index 000000000..728c71e0d
+--- /dev/null
++++ b/3rdparty/sseqplayer/.gitignore
+@@ -0,0 +1,6 @@
++*.user
++Debug
++Release
++*.o
++*.d
++*.a
+diff --git a/3rdparty/sseqplayer/Channel.cpp b/3rdparty/sseqplayer/Channel.cpp
+new file mode 100644
+index 000000000..e5bb0ee47
+--- /dev/null
++++ b/3rdparty/sseqplayer/Channel.cpp
+@@ -0,0 +1,763 @@
++/*
++ * SSEQ Player - Channel structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-10-23
++ *
++ * Adapted from source code of FeOS Sound System
++ * By fincs
++ * https://github.com/fincs/FSS
++ *
++ * Some code/concepts from DeSmuME
++ * http://desmume.org/
++ */
++
++#define _USE_MATH_DEFINES
++#include <cmath>
++#include <limits>
++#include "Channel.h"
++#include "Player.h"
++#include "common.h"
++
++NDSSoundRegister::NDSSoundRegister() : volumeMul(0), volumeDiv(0), panning(0), waveDuty(0), repeatMode(0), format(0), enable(false),
++	source(nullptr), timer(0), psgX(0), psgLast(0), psgLastCount(0), samplePosition(0), sampleIncrease(0), loopStart(0), length(0), totalLength(0)
++{
++}
++
++void NDSSoundRegister::ClearControlRegister()
++{
++	this->volumeMul = this->volumeDiv = this->panning = this->waveDuty = this->repeatMode = this->format = 0;
++	this->enable = false;
++}
++
++void NDSSoundRegister::SetControlRegister(uint32_t reg)
++{
++	this->volumeMul = reg & 0x7F;
++	this->volumeDiv = (reg >> 8) & 0x03;
++	this->panning = (reg >> 16) & 0x7F;
++	this->waveDuty = (reg >> 24) & 0x07;
++	this->repeatMode = (reg >> 27) & 0x03;
++	this->format = (reg >> 29) & 0x03;
++	this->enable = (reg >> 31) & 0x01;
++}
++
++TempSndReg::TempSndReg() : CR(0), SOURCE(nullptr), TIMER(0), REPEAT_POINT(0), LENGTH(0)
++{
++}
++
++bool Channel::initializedLUTs = false;
++double Channel::sinc_lut[Channel::SINC_SAMPLES + 1];
++double Channel::window_lut[Channel::SINC_SAMPLES + 1];
++
++#ifndef M_PI
++static const double M_PI = 3.14159265358979323846;
++#endif
++
++// Code from http://learningcppisfun.blogspot.com/2010/04/comparing-floating-point-numbers.html
++template<typename T> inline bool fEqual(T x, T y, int N = 1)
++{
++	T diff = std::abs(x - y);
++	T tolerance = N * std::numeric_limits<T>::epsilon();
++	return diff <= tolerance * std::abs(x) && diff <= tolerance * std::abs(y);
++}
++
++static inline double sinc(double x)
++{
++	return fEqual(x, 0.0) ? 1.0 : std::sin(x * M_PI) / (x * M_PI);
++}
++
++Channel::Channel() : chnId(-1), tempReg(), state(CS_NONE), trackId(-1), prio(0), manualSweep(false), flags(), pan(0), extAmpl(0), velocity(0), extPan(0),
++	key(0), ampl(0), extTune(0), orgKey(0), modType(0), modSpeed(0), modDepth(0), modRange(0), modDelay(0), modDelayCnt(0), modCounter(0),
++	sweepLen(0), sweepCnt(0), sweepPitch(0), attackLvl(0), sustainLvl(0x7F), decayRate(0), releaseRate(0xFFFF), noteLength(-1), vol(0), ply(nullptr), reg()
++{
++	this->clearHistory();
++	if (!this->initializedLUTs)
++	{
++		double dx = static_cast<double>(SINC_WIDTH) / SINC_SAMPLES, x = 0.0;
++		for (unsigned i = 0; i <= SINC_SAMPLES; ++i, x += dx)
++		{
++			double y = x / SINC_WIDTH;
++			this->sinc_lut[i] = std::abs(x) < SINC_WIDTH ? sinc(x) : 0.0;
++			this->window_lut[i] = (0.40897 + 0.5 * std::cos(M_PI * y) + 0.09103 * std::cos(2 * M_PI * y));
++		}
++		this->initializedLUTs = true;
++	}
++}
++
++// Original FSS Function: Chn_UpdateVol
++void Channel::UpdateVol(const Track &trk)
++{
++	int finalVol = trk.ply->masterVol;
++	finalVol += trk.ply->sseqVol;
++	finalVol += Cnv_Sust(trk.vol);
++	finalVol += Cnv_Sust(trk.expr);
++	if (finalVol < -AMPL_K)
++		finalVol = -AMPL_K;
++	this->extAmpl = finalVol;
++}
++
++// Original FSS Function: Chn_UpdatePan
++void Channel::UpdatePan(const Track &trk)
++{
++	this->extPan = trk.pan;
++}
++
++// Original FSS Function: Chn_UpdateTune
++void Channel::UpdateTune(const Track &trk)
++{
++	int tune = (static_cast<int>(this->key) - static_cast<int>(this->orgKey)) * 64;
++	tune += (static_cast<int>(trk.pitchBend) * static_cast<int>(trk.pitchBendRange)) >> 1;
++	this->extTune = tune;
++}
++
++// Original FSS Function: Chn_UpdateMod
++void Channel::UpdateMod(const Track &trk)
++{
++	this->modType = trk.modType;
++	this->modSpeed = trk.modSpeed;
++	this->modDepth = trk.modDepth;
++	this->modRange = trk.modRange;
++	this->modDelay = trk.modDelay;
++}
++
++// Original FSS Function: Chn_UpdatePorta
++void Channel::UpdatePorta(const Track &trk)
++{
++	this->manualSweep = false;
++	this->sweepPitch = trk.sweepPitch;
++	this->sweepCnt = 0;
++	if (!trk.state[TS_PORTABIT])
++	{
++		this->sweepLen = 0;
++		return;
++	}
++
++	int diff = (static_cast<int>(trk.portaKey) - static_cast<int>(this->key)) << 22;
++	this->sweepPitch += diff >> 16;
++
++	if (!trk.portaTime)
++	{
++		this->sweepLen = this->noteLength;
++		this->manualSweep = true;
++	}
++	else
++	{
++		int sq_time = static_cast<uint32_t>(trk.portaTime) * static_cast<uint32_t>(trk.portaTime);
++		int abs_sp = std::abs(this->sweepPitch);
++		this->sweepLen = (abs_sp * sq_time) >> 11;
++	}
++}
++
++// Original FSS Function: Chn_Release
++void Channel::Release()
++{
++	this->noteLength = -1;
++	this->prio = 1;
++	this->state = CS_RELEASE;
++}
++
++// Original FSS Function: Chn_Kill
++void Channel::Kill()
++{
++	this->state = CS_NONE;
++	this->trackId = -1;
++	this->prio = 0;
++	this->reg.ClearControlRegister();
++	this->vol = 0;
++	this->noteLength = -1;
++	this->clearHistory();
++}
++
++static inline int getModFlag(int type)
++{
++	switch (type)
++	{
++		case 0:
++			return CF_UPDTMR;
++		case 1:
++			return CF_UPDVOL;
++		case 2:
++			return CF_UPDPAN;
++		default:
++			return 0;
++	}
++}
++
++// Original FSS Function: Chn_UpdateTracks
++void Channel::UpdateTrack()
++{
++	if (!this->ply)
++		return;
++
++	int trkn = this->trackId;
++	if (trkn == -1)
++		return;
++
++	auto &trk = this->ply->tracks[trkn];
++	auto &trackFlags = trk.updateFlags;
++	if (trackFlags.none())
++		return;
++
++	if (trackFlags[TUF_LEN])
++	{
++		int st = this->state;
++		if (st > CS_START)
++		{
++			if (st < CS_RELEASE && !--this->noteLength)
++				this->Release();
++			if (this->manualSweep && this->sweepCnt < this->sweepLen)
++				++this->sweepCnt;
++		}
++	}
++	if (trackFlags[TUF_VOL])
++	{
++		this->UpdateVol(trk);
++		this->flags.set(CF_UPDVOL);
++	}
++	if (trackFlags[TUF_PAN])
++	{
++		this->UpdatePan(trk);
++		this->flags.set(CF_UPDPAN);
++	}
++	if (trackFlags[TUF_TIMER])
++	{
++		this->UpdateTune(trk);
++		this->flags.set(CF_UPDTMR);
++	}
++	if (trackFlags[TUF_MOD])
++	{
++		int oldType = this->modType;
++		int newType = trk.modType;
++		this->UpdateMod(trk);
++		if (oldType != newType)
++		{
++			this->flags.set(getModFlag(oldType));
++			this->flags.set(getModFlag(newType));
++		}
++	}
++}
++
++static const uint16_t getpitchtbl[] =
++{
++	0x0000, 0x003B, 0x0076, 0x00B2, 0x00ED, 0x0128, 0x0164, 0x019F,
++	0x01DB, 0x0217, 0x0252, 0x028E, 0x02CA, 0x0305, 0x0341, 0x037D,
++	0x03B9, 0x03F5, 0x0431, 0x046E, 0x04AA, 0x04E6, 0x0522, 0x055F,
++	0x059B, 0x05D8, 0x0614, 0x0651, 0x068D, 0x06CA, 0x0707, 0x0743,
++	0x0780, 0x07BD, 0x07FA, 0x0837, 0x0874, 0x08B1, 0x08EF, 0x092C,
++	0x0969, 0x09A7, 0x09E4, 0x0A21, 0x0A5F, 0x0A9C, 0x0ADA, 0x0B18,
++	0x0B56, 0x0B93, 0x0BD1, 0x0C0F, 0x0C4D, 0x0C8B, 0x0CC9, 0x0D07,
++	0x0D45, 0x0D84, 0x0DC2, 0x0E00, 0x0E3F, 0x0E7D, 0x0EBC, 0x0EFA,
++	0x0F39, 0x0F78, 0x0FB6, 0x0FF5, 0x1034, 0x1073, 0x10B2, 0x10F1,
++	0x1130, 0x116F, 0x11AE, 0x11EE, 0x122D, 0x126C, 0x12AC, 0x12EB,
++	0x132B, 0x136B, 0x13AA, 0x13EA, 0x142A, 0x146A, 0x14A9, 0x14E9,
++	0x1529, 0x1569, 0x15AA, 0x15EA, 0x162A, 0x166A, 0x16AB, 0x16EB,
++	0x172C, 0x176C, 0x17AD, 0x17ED, 0x182E, 0x186F, 0x18B0, 0x18F0,
++	0x1931, 0x1972, 0x19B3, 0x19F5, 0x1A36, 0x1A77, 0x1AB8, 0x1AFA,
++	0x1B3B, 0x1B7D, 0x1BBE, 0x1C00, 0x1C41, 0x1C83, 0x1CC5, 0x1D07,
++	0x1D48, 0x1D8A, 0x1DCC, 0x1E0E, 0x1E51, 0x1E93, 0x1ED5, 0x1F17,
++	0x1F5A, 0x1F9C, 0x1FDF, 0x2021, 0x2064, 0x20A6, 0x20E9, 0x212C,
++	0x216F, 0x21B2, 0x21F5, 0x2238, 0x227B, 0x22BE, 0x2301, 0x2344,
++	0x2388, 0x23CB, 0x240E, 0x2452, 0x2496, 0x24D9, 0x251D, 0x2561,
++	0x25A4, 0x25E8, 0x262C, 0x2670, 0x26B4, 0x26F8, 0x273D, 0x2781,
++	0x27C5, 0x280A, 0x284E, 0x2892, 0x28D7, 0x291C, 0x2960, 0x29A5,
++	0x29EA, 0x2A2F, 0x2A74, 0x2AB9, 0x2AFE, 0x2B43, 0x2B88, 0x2BCD,
++	0x2C13, 0x2C58, 0x2C9D, 0x2CE3, 0x2D28, 0x2D6E, 0x2DB4, 0x2DF9,
++	0x2E3F, 0x2E85, 0x2ECB, 0x2F11, 0x2F57, 0x2F9D, 0x2FE3, 0x302A,
++	0x3070, 0x30B6, 0x30FD, 0x3143, 0x318A, 0x31D0, 0x3217, 0x325E,
++	0x32A5, 0x32EC, 0x3332, 0x3379, 0x33C1, 0x3408, 0x344F, 0x3496,
++	0x34DD, 0x3525, 0x356C, 0x35B4, 0x35FB, 0x3643, 0x368B, 0x36D3,
++	0x371A, 0x3762, 0x37AA, 0x37F2, 0x383A, 0x3883, 0x38CB, 0x3913,
++	0x395C, 0x39A4, 0x39ED, 0x3A35, 0x3A7E, 0x3AC6, 0x3B0F, 0x3B58,
++	0x3BA1, 0x3BEA, 0x3C33, 0x3C7C, 0x3CC5, 0x3D0E, 0x3D58, 0x3DA1,
++	0x3DEA, 0x3E34, 0x3E7D, 0x3EC7, 0x3F11, 0x3F5A, 0x3FA4, 0x3FEE,
++	0x4038, 0x4082, 0x40CC, 0x4116, 0x4161, 0x41AB, 0x41F5, 0x4240,
++	0x428A, 0x42D5, 0x431F, 0x436A, 0x43B5, 0x4400, 0x444B, 0x4495,
++	0x44E1, 0x452C, 0x4577, 0x45C2, 0x460D, 0x4659, 0x46A4, 0x46F0,
++	0x473B, 0x4787, 0x47D3, 0x481E, 0x486A, 0x48B6, 0x4902, 0x494E,
++	0x499A, 0x49E6, 0x4A33, 0x4A7F, 0x4ACB, 0x4B18, 0x4B64, 0x4BB1,
++	0x4BFE, 0x4C4A, 0x4C97, 0x4CE4, 0x4D31, 0x4D7E, 0x4DCB, 0x4E18,
++	0x4E66, 0x4EB3, 0x4F00, 0x4F4E, 0x4F9B, 0x4FE9, 0x5036, 0x5084,
++	0x50D2, 0x5120, 0x516E, 0x51BC, 0x520A, 0x5258, 0x52A6, 0x52F4,
++	0x5343, 0x5391, 0x53E0, 0x542E, 0x547D, 0x54CC, 0x551A, 0x5569,
++	0x55B8, 0x5607, 0x5656, 0x56A5, 0x56F4, 0x5744, 0x5793, 0x57E2,
++	0x5832, 0x5882, 0x58D1, 0x5921, 0x5971, 0x59C1, 0x5A10, 0x5A60,
++	0x5AB0, 0x5B01, 0x5B51, 0x5BA1, 0x5BF1, 0x5C42, 0x5C92, 0x5CE3,
++	0x5D34, 0x5D84, 0x5DD5, 0x5E26, 0x5E77, 0x5EC8, 0x5F19, 0x5F6A,
++	0x5FBB, 0x600D, 0x605E, 0x60B0, 0x6101, 0x6153, 0x61A4, 0x61F6,
++	0x6248, 0x629A, 0x62EC, 0x633E, 0x6390, 0x63E2, 0x6434, 0x6487,
++	0x64D9, 0x652C, 0x657E, 0x65D1, 0x6624, 0x6676, 0x66C9, 0x671C,
++	0x676F, 0x67C2, 0x6815, 0x6869, 0x68BC, 0x690F, 0x6963, 0x69B6,
++	0x6A0A, 0x6A5E, 0x6AB1, 0x6B05, 0x6B59, 0x6BAD, 0x6C01, 0x6C55,
++	0x6CAA, 0x6CFE, 0x6D52, 0x6DA7, 0x6DFB, 0x6E50, 0x6EA4, 0x6EF9,
++	0x6F4E, 0x6FA3, 0x6FF8, 0x704D, 0x70A2, 0x70F7, 0x714D, 0x71A2,
++	0x71F7, 0x724D, 0x72A2, 0x72F8, 0x734E, 0x73A4, 0x73FA, 0x7450,
++	0x74A6, 0x74FC, 0x7552, 0x75A8, 0x75FF, 0x7655, 0x76AC, 0x7702,
++	0x7759, 0x77B0, 0x7807, 0x785E, 0x78B4, 0x790C, 0x7963, 0x79BA,
++	0x7A11, 0x7A69, 0x7AC0, 0x7B18, 0x7B6F, 0x7BC7, 0x7C1F, 0x7C77,
++	0x7CCF, 0x7D27, 0x7D7F, 0x7DD7, 0x7E2F, 0x7E88, 0x7EE0, 0x7F38,
++	0x7F91, 0x7FEA, 0x8042, 0x809B, 0x80F4, 0x814D, 0x81A6, 0x81FF,
++	0x8259, 0x82B2, 0x830B, 0x8365, 0x83BE, 0x8418, 0x8472, 0x84CB,
++	0x8525, 0x857F, 0x85D9, 0x8633, 0x868E, 0x86E8, 0x8742, 0x879D,
++	0x87F7, 0x8852, 0x88AC, 0x8907, 0x8962, 0x89BD, 0x8A18, 0x8A73,
++	0x8ACE, 0x8B2A, 0x8B85, 0x8BE0, 0x8C3C, 0x8C97, 0x8CF3, 0x8D4F,
++	0x8DAB, 0x8E07, 0x8E63, 0x8EBF, 0x8F1B, 0x8F77, 0x8FD4, 0x9030,
++	0x908C, 0x90E9, 0x9146, 0x91A2, 0x91FF, 0x925C, 0x92B9, 0x9316,
++	0x9373, 0x93D1, 0x942E, 0x948C, 0x94E9, 0x9547, 0x95A4, 0x9602,
++	0x9660, 0x96BE, 0x971C, 0x977A, 0x97D8, 0x9836, 0x9895, 0x98F3,
++	0x9952, 0x99B0, 0x9A0F, 0x9A6E, 0x9ACD, 0x9B2C, 0x9B8B, 0x9BEA,
++	0x9C49, 0x9CA8, 0x9D08, 0x9D67, 0x9DC7, 0x9E26, 0x9E86, 0x9EE6,
++	0x9F46, 0x9FA6, 0xA006, 0xA066, 0xA0C6, 0xA127, 0xA187, 0xA1E8,
++	0xA248, 0xA2A9, 0xA30A, 0xA36B, 0xA3CC, 0xA42D, 0xA48E, 0xA4EF,
++	0xA550, 0xA5B2, 0xA613, 0xA675, 0xA6D6, 0xA738, 0xA79A, 0xA7FC,
++	0xA85E, 0xA8C0, 0xA922, 0xA984, 0xA9E7, 0xAA49, 0xAAAC, 0xAB0E,
++	0xAB71, 0xABD4, 0xAC37, 0xAC9A, 0xACFD, 0xAD60, 0xADC3, 0xAE27,
++	0xAE8A, 0xAEED, 0xAF51, 0xAFB5, 0xB019, 0xB07C, 0xB0E0, 0xB145,
++	0xB1A9, 0xB20D, 0xB271, 0xB2D6, 0xB33A, 0xB39F, 0xB403, 0xB468,
++	0xB4CD, 0xB532, 0xB597, 0xB5FC, 0xB662, 0xB6C7, 0xB72C, 0xB792,
++	0xB7F7, 0xB85D, 0xB8C3, 0xB929, 0xB98F, 0xB9F5, 0xBA5B, 0xBAC1,
++	0xBB28, 0xBB8E, 0xBBF5, 0xBC5B, 0xBCC2, 0xBD29, 0xBD90, 0xBDF7,
++	0xBE5E, 0xBEC5, 0xBF2C, 0xBF94, 0xBFFB, 0xC063, 0xC0CA, 0xC132,
++	0xC19A, 0xC202, 0xC26A, 0xC2D2, 0xC33A, 0xC3A2, 0xC40B, 0xC473,
++	0xC4DC, 0xC544, 0xC5AD, 0xC616, 0xC67F, 0xC6E8, 0xC751, 0xC7BB,
++	0xC824, 0xC88D, 0xC8F7, 0xC960, 0xC9CA, 0xCA34, 0xCA9E, 0xCB08,
++	0xCB72, 0xCBDC, 0xCC47, 0xCCB1, 0xCD1B, 0xCD86, 0xCDF1, 0xCE5B,
++	0xCEC6, 0xCF31, 0xCF9C, 0xD008, 0xD073, 0xD0DE, 0xD14A, 0xD1B5,
++	0xD221, 0xD28D, 0xD2F8, 0xD364, 0xD3D0, 0xD43D, 0xD4A9, 0xD515,
++	0xD582, 0xD5EE, 0xD65B, 0xD6C7, 0xD734, 0xD7A1, 0xD80E, 0xD87B,
++	0xD8E9, 0xD956, 0xD9C3, 0xDA31, 0xDA9E, 0xDB0C, 0xDB7A, 0xDBE8,
++	0xDC56, 0xDCC4, 0xDD32, 0xDDA0, 0xDE0F, 0xDE7D, 0xDEEC, 0xDF5B,
++	0xDFC9, 0xE038, 0xE0A7, 0xE116, 0xE186, 0xE1F5, 0xE264, 0xE2D4,
++	0xE343, 0xE3B3, 0xE423, 0xE493, 0xE503, 0xE573, 0xE5E3, 0xE654,
++	0xE6C4, 0xE735, 0xE7A5, 0xE816, 0xE887, 0xE8F8, 0xE969, 0xE9DA,
++	0xEA4B, 0xEABC, 0xEB2E, 0xEB9F, 0xEC11, 0xEC83, 0xECF5, 0xED66,
++	0xEDD9, 0xEE4B, 0xEEBD, 0xEF2F, 0xEFA2, 0xF014, 0xF087, 0xF0FA,
++	0xF16D, 0xF1E0, 0xF253, 0xF2C6, 0xF339, 0xF3AD, 0xF420, 0xF494,
++	0xF507, 0xF57B, 0xF5EF, 0xF663, 0xF6D7, 0xF74C, 0xF7C0, 0xF834,
++	0xF8A9, 0xF91E, 0xF992, 0xFA07, 0xFA7C, 0xFAF1, 0xFB66, 0xFBDC,
++	0xFC51, 0xFCC7, 0xFD3C, 0xFDB2, 0xFE28, 0xFE9E, 0xFF14, 0xFF8A
++};
++
++static const uint8_t getvoltbl[] =
++{
++	0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
++	0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
++	0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
++	0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
++	0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
++	0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
++	0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
++	0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
++	0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x03, 0x03, 0x03,
++	0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
++	0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
++	0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
++	0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05,
++	0x05, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06,
++	0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x08, 0x08, 0x08, 0x08,
++	0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x09, 0x09, 0x09, 0x09, 0x09, 0x09, 0x09, 0x09, 0x09,
++	0x09, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0B, 0x0B, 0x0B, 0x0B, 0x0B, 0x0B, 0x0B,
++	0x0B, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x0D, 0x0D, 0x0D, 0x0D, 0x0D, 0x0D, 0x0E,
++	0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x10, 0x10, 0x10, 0x10, 0x10,
++	0x10, 0x11, 0x11, 0x11, 0x11, 0x11, 0x12, 0x12, 0x12, 0x12, 0x12, 0x13, 0x13, 0x13, 0x13, 0x14,
++	0x14, 0x14, 0x14, 0x14, 0x15, 0x15, 0x15, 0x15, 0x16, 0x16, 0x16, 0x16, 0x17, 0x17, 0x17, 0x18,
++	0x18, 0x18, 0x18, 0x19, 0x19, 0x19, 0x19, 0x1A, 0x1A, 0x1A, 0x1B, 0x1B, 0x1B, 0x1C, 0x1C, 0x1C,
++	0x1D, 0x1D, 0x1D, 0x1E, 0x1E, 0x1E, 0x1F, 0x1F, 0x1F, 0x20, 0x20, 0x20, 0x21, 0x21, 0x22, 0x22,
++	0x22, 0x23, 0x23, 0x24, 0x24, 0x24, 0x25, 0x25, 0x26, 0x26, 0x27, 0x27, 0x27, 0x28, 0x28, 0x29,
++	0x29, 0x2A, 0x2A, 0x2B, 0x2B, 0x2C, 0x2C, 0x2D, 0x2D, 0x2E, 0x2E, 0x2F, 0x2F, 0x30, 0x31, 0x31,
++	0x32, 0x32, 0x33, 0x33, 0x34, 0x35, 0x35, 0x36, 0x36, 0x37, 0x38, 0x38, 0x39, 0x3A, 0x3A, 0x3B,
++	0x3C, 0x3C, 0x3D, 0x3E, 0x3F, 0x3F, 0x40, 0x41, 0x42, 0x42, 0x43, 0x44, 0x45, 0x45, 0x46, 0x47,
++	0x48, 0x49, 0x4A, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52, 0x52, 0x53, 0x54, 0x55,
++	0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5D, 0x5E, 0x5F, 0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x67,
++	0x68, 0x69, 0x6A, 0x6B, 0x6D, 0x6E, 0x6F, 0x71, 0x72, 0x73, 0x75, 0x76, 0x77, 0x79, 0x7A, 0x7B,
++	0x7D, 0x7E, 0x7F, 0x20, 0x21, 0x21, 0x21, 0x22, 0x22, 0x23, 0x23, 0x23, 0x24, 0x24, 0x25, 0x25,
++	0x26, 0x26, 0x26, 0x27, 0x27, 0x28, 0x28, 0x29, 0x29, 0x2A, 0x2A, 0x2B, 0x2B, 0x2C, 0x2C, 0x2D,
++	0x2D, 0x2E, 0x2E, 0x2F, 0x2F, 0x30, 0x30, 0x31, 0x31, 0x32, 0x33, 0x33, 0x34, 0x34, 0x35, 0x36,
++	0x36, 0x37, 0x37, 0x38, 0x39, 0x39, 0x3A, 0x3B, 0x3B, 0x3C, 0x3D, 0x3E, 0x3E, 0x3F, 0x40, 0x40,
++	0x41, 0x42, 0x43, 0x43, 0x44, 0x45, 0x46, 0x47, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4D,
++	0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x5D,
++	0x5E, 0x5F, 0x60, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6F, 0x70,
++	0x71, 0x73, 0x74, 0x75, 0x77, 0x78, 0x79, 0x7B, 0x7C, 0x7E, 0x7E, 0x40, 0x41, 0x42, 0x43, 0x43,
++	0x44, 0x45, 0x46, 0x47, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51,
++	0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x5D, 0x5E, 0x5F, 0x60, 0x61,
++	0x62, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6B, 0x6C, 0x6D, 0x6E, 0x70, 0x71, 0x72, 0x74, 0x75,
++	0x76, 0x78, 0x79, 0x7B, 0x7C, 0x7D, 0x7E, 0x40, 0x41, 0x42, 0x42, 0x43, 0x44, 0x45, 0x46, 0x46,
++	0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55,
++	0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x5D, 0x5E, 0x5F, 0x60, 0x61, 0x62, 0x63, 0x65, 0x66,
++	0x67, 0x68, 0x69, 0x6A, 0x6C, 0x6D, 0x6E, 0x6F, 0x71, 0x72, 0x73, 0x75, 0x76, 0x77, 0x79, 0x7A,
++	0x7C, 0x7D, 0x7E, 0x7F
++};
++
++// This function was obtained through disassembly of Ninty's sound driver
++static inline uint16_t Timer_Adjust(uint16_t basetmr, int pitch)
++{
++	int shift = 0;
++	pitch = -pitch;
++
++	while (pitch < 0)
++	{
++		--shift;
++		pitch += 0x300;
++	}
++
++	while (pitch >= 0x300)
++	{
++		++shift;
++		pitch -= 0x300;
++	}
++
++	uint64_t tmr = static_cast<uint64_t>(basetmr) * (static_cast<uint32_t>(getpitchtbl[pitch]) + 0x10000);
++	shift -= 16;
++	if (shift <= 0)
++		tmr >>= -shift;
++	else if (shift < 32)
++	{
++		if (tmr & ((~0ULL) << (32 - shift)))
++			return 0xFFFF;
++		tmr <<= shift;
++	}
++	else
++		return 0xFFFF;
++
++	if (tmr < 0x10)
++		return 0x10;
++	if (tmr > 0xFFFF)
++		return 0xFFFF;
++	return static_cast<uint16_t>(tmr);
++}
++
++static inline int calcVolDivShift(int x)
++{
++	// VOLDIV(0) /1  >>0
++	// VOLDIV(1) /2  >>1
++	// VOLDIV(2) /4  >>2
++	// VOLDIV(3) /16 >>4
++	if (x < 3)
++		return x;
++	return 4;
++}
++
++// Original FSS Function: Snd_UpdChannel
++void Channel::Update()
++{
++	// Kill active channels that aren't physically active
++	if (this->state > CS_START && !this->reg.enable)
++	{
++		this->Kill();
++		return;
++	}
++
++	bool bNotInSustain = this->state != CS_SUSTAIN;
++	bool bInStart = this->state == CS_START;
++	bool bPitchSweep = this->sweepPitch && this->sweepLen && this->sweepCnt <= this->sweepLen;
++	bool bModulation = !!this->modDepth;
++	bool bVolNeedUpdate = this->flags[CF_UPDVOL] || bNotInSustain;
++	bool bPanNeedUpdate = this->flags[CF_UPDPAN] || bInStart;
++	bool bTmrNeedUpdate = this->flags[CF_UPDTMR] || bInStart || bPitchSweep;
++	int modParam = 0;
++
++	switch (this->state)
++	{
++		case CS_NONE:
++			return;
++		case CS_START:
++			this->reg.ClearControlRegister();
++			this->reg.source = this->tempReg.SOURCE;
++			this->reg.loopStart = this->tempReg.REPEAT_POINT;
++			this->reg.length = this->tempReg.LENGTH;
++			this->reg.totalLength = this->reg.loopStart + this->reg.length;
++			this->ampl = AMPL_THRESHOLD;
++			this->state = CS_ATTACK;
++			// Fall down
++		case CS_ATTACK:
++		{
++			int newAmpl = this->ampl;
++			int oldAmpl = this->ampl >> 7;
++			do
++				newAmpl = (newAmpl * static_cast<int>(this->attackLvl)) / 256;
++			while ((newAmpl >> 7) == oldAmpl);
++			this->ampl = newAmpl;
++			if (!this->ampl)
++				this->state = CS_DECAY;
++			break;
++		}
++		case CS_DECAY:
++		{
++			this->ampl -= static_cast<int>(this->decayRate);
++			int sustLvl = Cnv_Sust(this->sustainLvl) << 7;
++			if (this->ampl <= sustLvl)
++			{
++				this->ampl = sustLvl;
++				this->state = CS_SUSTAIN;
++			}
++			break;
++		}
++		case CS_RELEASE:
++			this->ampl -= static_cast<int>(this->releaseRate);
++			if (this->ampl <= AMPL_THRESHOLD)
++			{
++				this->Kill();
++				return;
++			}
++	}
++
++	if (bModulation && this->modDelayCnt < this->modDelay)
++	{
++		++this->modDelayCnt;
++		bModulation = false;
++	}
++
++	if (bModulation)
++	{
++		switch (this->modType)
++		{
++			case 0:
++				bTmrNeedUpdate = true;
++				break;
++			case 1:
++				bVolNeedUpdate = true;
++				break;
++			case 2:
++				bPanNeedUpdate = true;
++		}
++
++		// Get the current modulation parameter
++		modParam = Cnv_Sine(this->modCounter >> 8) * this->modRange * this->modDepth; // 7.14
++
++		if (this->modType == 1)
++			modParam = static_cast<int64_t>(modParam * 60) >> 14; // vol: adjust range to 6dB = 60cB (no fractional bits)
++		else
++			modParam >>= 8; // tmr/pan: adjust to 7.6
++
++		// Update the modulation variables
++		uint32_t counter = this->modCounter + (this->modSpeed << 6);
++		while (counter >= 0x8000)
++			counter -= 0x8000;
++		this->modCounter = counter;
++	}
++
++	if (bTmrNeedUpdate)
++	{
++		int totalAdj = this->extTune;
++		if (bModulation && !this->modType)
++			totalAdj += modParam;
++		if (bPitchSweep)
++		{
++			int len = this->sweepLen;
++			int cnt = this->sweepCnt;
++			totalAdj += (static_cast<int64_t>(this->sweepPitch) * (len - cnt)) / len;
++			if (!this->manualSweep)
++				++this->sweepCnt;
++		}
++		uint16_t tmr = this->tempReg.TIMER;
++
++		if (totalAdj)
++			tmr = Timer_Adjust(tmr, totalAdj);
++		this->reg.timer = -tmr;
++		this->reg.sampleIncrease = (ARM7_CLOCK / static_cast<double>(this->ply->sampleRate * 2)) / (0x10000 - this->reg.timer);
++		this->flags.reset(CF_UPDTMR);
++	}
++
++	if (bVolNeedUpdate || bPanNeedUpdate)
++	{
++		uint32_t cr = this->tempReg.CR;
++		if (bVolNeedUpdate)
++		{
++			int totalVol = this->ampl >> 7;
++			totalVol += this->extAmpl;
++			totalVol += this->velocity;
++			if (bModulation && this->modType == 1)
++				totalVol += modParam;
++			totalVol += AMPL_K;
++			clamp(totalVol, 0, AMPL_K);
++
++			cr &= ~(SOUND_VOL(0x7F) | SOUND_VOLDIV(3));
++			cr |= SOUND_VOL(static_cast<int>(getvoltbl[totalVol]));
++
++			if (totalVol < AMPL_K - 240)
++				cr |= SOUND_VOLDIV(3);
++			else if (totalVol < AMPL_K - 120)
++				cr |= SOUND_VOLDIV(2);
++			else if (totalVol < AMPL_K - 60)
++				cr |= SOUND_VOLDIV(1);
++
++			this->vol = ((cr & SOUND_VOL(0x7F)) << 4) >> calcVolDivShift((cr & SOUND_VOLDIV(3)) >> 8);
++
++			this->flags.reset(CF_UPDVOL);
++		}
++
++		if (bPanNeedUpdate)
++		{
++			int realPan = this->pan;
++			realPan += this->extPan;
++			if (bModulation && this->modType == 2)
++				realPan += modParam;
++			realPan += 64;
++			clamp(realPan, 0, 127);
++
++			cr &= ~SOUND_PAN(0x7F);
++			cr |= SOUND_PAN(realPan);
++			this->flags.reset(CF_UPDPAN);
++		}
++
++		this->tempReg.CR = cr;
++		this->reg.SetControlRegister(cr);
++	}
++}
++
++static const int16_t wavedutytbl[8][8] =
++{
++	{ -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, 0x7FFF },
++	{ -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, 0x7FFF, 0x7FFF },
++	{ -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF },
++	{ -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF },
++	{ -0x7FFF, -0x7FFF, -0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF },
++	{ -0x7FFF, -0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF },
++	{ -0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF, 0x7FFF },
++	{ -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF, -0x7FFF }
++};
++
++// Linear interpolation code originally from DeSmuME
++// Legrange comes from Olli Niemitalo:
++// http://www.student.oulu.fi/~oniemita/dsp/deip.pdf
++int32_t Channel::Interpolate()
++{
++	double ratio = this->reg.samplePosition;
++	ratio -= static_cast<int32_t>(ratio);
++
++	const auto &data = &this->sampleHistory[this->sampleHistoryPtr + 16];
++
++	if (this->ply->interpolation == INTERPOLATION_SINC)
++	{
++		double kernel[SINC_WIDTH * 2], kernel_sum = 0.0;
++		int i = SINC_WIDTH, shift = static_cast<int>(std::floor(ratio * SINC_RESOLUTION));
++		int step = this->reg.sampleIncrease > 1.0 ? static_cast<int>(SINC_RESOLUTION / this->reg.sampleIncrease) : SINC_RESOLUTION;
++		int shift_adj = shift * step / SINC_RESOLUTION;
++		const int window_step = SINC_RESOLUTION;
++		for (; i >= -static_cast<int>(SINC_WIDTH - 1); --i)
++		{
++			int pos = i * step;
++			int window_pos = i * window_step;
++			kernel_sum += kernel[i + SINC_WIDTH - 1] = this->sinc_lut[std::abs(shift_adj - pos)] * this->window_lut[std::abs(shift - window_pos)];
++		}
++		double sum = 0.0;
++		for (i = 0; i < static_cast<int>(SINC_WIDTH * 2); ++i)
++			sum += data[i - static_cast<int>(SINC_WIDTH) + 1] * kernel[i];
++		return static_cast<int32_t>(sum / kernel_sum);
++	}
++	else if (this->ply->interpolation > INTERPOLATION_LINEAR)
++	{
++		double c0, c1, c2, c3, c4, c5;
++
++		if (this->ply->interpolation == INTERPOLATION_6POINTLEGRANGE)
++		{
++			ratio -= 0.5;
++			double even1 = data[-2] + data[3], odd1 = data[-2] - data[3];
++			double even2 = data[-1] + data[2], odd2 = data[-1] - data[2];
++			double even3 = data[0] + data[1], odd3 = data[0] - data[1];
++			c0 = 0.01171875 * even1 - 0.09765625 * even2 + 0.5859375 * even3;
++			c1 = 25 / 384.0 * odd2 - 1.171875 * odd3 - 0.0046875 * odd1;
++			c2 = 0.40625 * even2 - 17 / 48.0 * even3 - 5 / 96.0 * even1;
++			c3 = 1 / 48.0 * odd1 - 13 / 48.0 * odd2 + 17 / 24.0 * odd3;
++			c4 = 1 / 48.0 * even1 - 0.0625 * even2 + 1 / 24.0 * even3;
++			c5 = 1 / 24.0 * odd2 - 1 / 12.0 * odd3 - 1 / 120.0 * odd1;
++			return static_cast<int32_t>(((((c5 * ratio + c4) * ratio + c3) * ratio + c2) * ratio + c1) * ratio + c0);
++		}
++		else // INTERPOLATION_4POINTLEAGRANGE
++		{
++			c0 = data[0];
++			c1 = data[1] - 1 / 3.0 * data[-1] - 0.5 * data[0] - 1 / 6.0 * data[2];
++			c2 = 0.5 * (data[-1] + data[1]) - data[0];
++			c3 = 1 / 6.0 * (data[2] - data[-1]) + 0.5 * (data[0] - data[1]);
++			return static_cast<int32_t>(((c3 * ratio + c2) * ratio + c1) * ratio + c0);
++		}
++	}
++	else // INTERPOLATION_LINEAR
++		return static_cast<int32_t>(data[0] + ratio * (data[1] - data[0]));
++}
++
++int32_t Channel::GenerateSample()
++{
++	if (this->reg.samplePosition < 0)
++		return 0;
++
++	if (this->reg.format != 3)
++	{
++		if (this->ply->interpolation == INTERPOLATION_NONE)
++			return this->reg.source->dataptr[static_cast<uint32_t>(this->reg.samplePosition)];
++		else
++			return this->Interpolate();
++	}
++	else
++	{
++		if (this->chnId < 8)
++			return 0;
++		else if (this->chnId < 14)
++			return wavedutytbl[this->reg.waveDuty][static_cast<uint32_t>(this->reg.samplePosition) & 0x7];
++		else
++		{
++			if (this->reg.psgLastCount != static_cast<uint32_t>(this->reg.samplePosition))
++			{
++				uint32_t max = static_cast<uint32_t>(this->reg.samplePosition);
++				for (uint32_t i = this->reg.psgLastCount; i < max; ++i)
++				{
++					if (this->reg.psgX & 0x1)
++					{
++						this->reg.psgX = (this->reg.psgX >> 1) ^ 0x6000;
++						this->reg.psgLast = -0x7FFF;
++					}
++					else
++					{
++						this->reg.psgX >>= 1;
++						this->reg.psgLast = 0x7FFF;
++					}
++				}
++
++				this->reg.psgLastCount = static_cast<uint32_t>(this->reg.samplePosition);
++			}
++
++			return this->reg.psgLast;
++		}
++	}
++}
++
++void Channel::IncrementSample()
++{
++	double samplePosition = this->reg.samplePosition + this->reg.sampleIncrease;
++
++	if (this->reg.format != 3 && this->reg.samplePosition >= 0)
++	{
++		uint32_t loc = static_cast<uint32_t>(this->reg.samplePosition);
++		uint32_t newloc = static_cast<uint32_t>(samplePosition);
++
++		if (newloc >= this->reg.totalLength)
++			newloc -= this->reg.length;
++
++		while (loc != newloc)
++		{
++			this->sampleHistory[this->sampleHistoryPtr] = this->sampleHistory[this->sampleHistoryPtr + 32] = this->reg.source->dataptr[loc++];
++
++			this->sampleHistoryPtr = (this->sampleHistoryPtr + 1) & 31;
++
++			if (loc >= this->reg.totalLength)
++				loc -= this->reg.length;
++		}
++	}
++
++	this->reg.samplePosition = samplePosition;
++
++	if (this->reg.format != 3 && this->reg.samplePosition >= this->reg.totalLength)
++	{
++		if (this->reg.repeatMode == 1)
++		{
++			while (this->reg.samplePosition >= this->reg.totalLength)
++				this->reg.samplePosition -= this->reg.length;
++		}
++		else
++			this->Kill();
++	}
++}
++
++void Channel::clearHistory()
++{
++	this->sampleHistoryPtr = 0;
++	memset(this->sampleHistory, 0, sizeof(this->sampleHistory));
++}
+diff --git a/3rdparty/sseqplayer/Channel.h b/3rdparty/sseqplayer/Channel.h
+new file mode 100644
+index 000000000..f958adb8e
+--- /dev/null
++++ b/3rdparty/sseqplayer/Channel.h
+@@ -0,0 +1,165 @@
++/*
++ * SSEQ Player - Channel structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-17
++ *
++ * Adapted from source code of FeOS Sound System
++ * By fincs
++ * https://github.com/fincs/FSS
++ *
++ * Some code/concepts from DeSmuME
++ * http://desmume.org/
++ */
++
++#pragma once
++
++#include <bitset>
++#include <tuple>
++#include <cstdint>
++#include "SWAV.h"
++#include "Track.h"
++
++/*
++ * This structure is meant to be similar to what is stored in the actual
++ * Nintendo DS's sound registers.  Items that were not being used by this
++ * player have been removed, and items which help the simulated registers
++ * have been added.
++ */
++struct NDSSoundRegister
++{
++	// Control Register
++	uint8_t volumeMul;
++	uint8_t volumeDiv;
++	uint8_t panning;
++	uint8_t waveDuty;
++	uint8_t repeatMode;
++	uint8_t format;
++	bool enable;
++
++	// Data Source Register
++	const SWAV *source;
++
++	// Timer Register
++	uint16_t timer;
++
++	// PSG Handling, not a DS register
++	uint16_t psgX;
++	int16_t psgLast;
++	uint32_t psgLastCount;
++
++	// The following are taken from DeSmuME
++	double samplePosition;
++	double sampleIncrease;
++
++	// Loopstart Register
++	uint32_t loopStart;
++
++	// Length Register
++	uint32_t length;
++
++	uint32_t totalLength;
++
++	NDSSoundRegister();
++
++	void ClearControlRegister();
++	void SetControlRegister(uint32_t reg);
++};
++
++/*
++ * From FeOS Sound System, this is temporary storage of what will go into
++ * the Nintendo DS sound registers.  It is kept separate as the original code
++ * from FeOS Sound System utilized this to hold data prior to passing it into
++ * the DS's registers.
++ */
++struct TempSndReg
++{
++	uint32_t CR;
++	const SWAV *SOURCE;
++	uint16_t TIMER;
++	uint32_t REPEAT_POINT, LENGTH;
++
++	TempSndReg();
++};
++
++struct Player;
++
++struct Channel
++{
++	int8_t chnId;
++
++	TempSndReg tempReg;
++	uint8_t state;
++	int8_t trackId; // -1 = none
++	uint8_t prio;
++	bool manualSweep;
++
++	std::bitset<CF_BITS> flags;
++	int8_t pan; // -64 .. 63
++	int16_t extAmpl;
++
++	int16_t velocity;
++	int8_t extPan;
++	uint8_t key;
++
++	int ampl; // 7 fractionary bits
++	int extTune; // in 64ths of a semitone
++
++	uint8_t orgKey;
++
++	uint8_t modType, modSpeed, modDepth, modRange;
++	uint16_t modDelay, modDelayCnt, modCounter;
++
++	uint32_t sweepLen, sweepCnt;
++	int16_t sweepPitch;
++
++	uint8_t attackLvl, sustainLvl;
++	uint16_t decayRate, releaseRate;
++
++	/*
++	 * These were originally global variables in FeOS Sound System, but
++	 * since they were linked to a certain channel anyways, I moved them
++	 * into this class.
++	 */
++	int noteLength;
++	uint16_t vol;
++
++	const Player *ply;
++	NDSSoundRegister reg;
++
++	/*
++	 * Interpolation history buffer, which contains the maximum number of
++	 * samples required for any given interpolation mode. Doubled to
++	 * simplify the case of wrapping. Thanks to kode54 for providing this.
++	 */
++	uint32_t sampleHistoryPtr;
++	int16_t sampleHistory[64];
++
++	/*
++	 * Lookup tables for the Sinc interpolation, to
++	 * avoid the need to call the sin/cos functions all the time.
++	 * These are static as they will not change between channels or runs
++	 * of the program.
++	 */
++	static bool initializedLUTs;
++	static const unsigned SINC_RESOLUTION = 8192;
++	static const unsigned SINC_WIDTH = 8;
++	static const unsigned SINC_SAMPLES = SINC_RESOLUTION * SINC_WIDTH;
++	static double sinc_lut[SINC_SAMPLES + 1];
++	static double window_lut[SINC_SAMPLES + 1];
++
++	Channel();
++
++	void UpdateVol(const Track &trk);
++	void UpdatePan(const Track &trk);
++	void UpdateTune(const Track &trk);
++	void UpdateMod(const Track &trk);
++	void UpdatePorta(const Track &trk);
++	void Release();
++	void Kill();
++	void UpdateTrack();
++	void Update();
++	int32_t Interpolate();
++	int32_t GenerateSample();
++	void IncrementSample();
++	void clearHistory();
++};
+diff --git a/3rdparty/sseqplayer/FATSection.cpp b/3rdparty/sseqplayer/FATSection.cpp
+new file mode 100644
+index 000000000..5062b60c2
+--- /dev/null
++++ b/3rdparty/sseqplayer/FATSection.cpp
+@@ -0,0 +1,40 @@
++/*
++ * SSEQ Player - SDAT FAT (File Allocation Table) Section structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2013-03-21
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#include <stdexcept>
++#include "FATSection.h"
++
++FATRecord::FATRecord() : offset(0)
++{
++}
++
++void FATRecord::Read(PseudoFile &file)
++{
++	this->offset = file.ReadLE<uint32_t>();
++	file.ReadLE<uint32_t>(); // size
++	uint32_t reserved[2];
++	file.ReadLE(reserved);
++}
++
++FATSection::FATSection() : records()
++{
++}
++
++void FATSection::Read(PseudoFile &file)
++{
++	int8_t type[4];
++	file.ReadLE(type);
++	if (!VerifyHeader(type, "FAT "))
++		throw std::runtime_error("SDAT FAT Section invalid");
++	file.ReadLE<uint32_t>(); // size
++	uint32_t count = file.ReadLE<uint32_t>();
++	this->records.resize(count);
++	for (uint32_t i = 0; i < count; ++i)
++		this->records[i].Read(file);
++}
+diff --git a/3rdparty/sseqplayer/FATSection.h b/3rdparty/sseqplayer/FATSection.h
+new file mode 100644
+index 000000000..636c6f121
+--- /dev/null
++++ b/3rdparty/sseqplayer/FATSection.h
+@@ -0,0 +1,30 @@
++/*
++ * SSEQ Player - SDAT FAT (File Allocation Table) Section structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-08
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#pragma once
++
++#include "common.h"
++
++struct FATRecord
++{
++	uint32_t offset;
++
++	FATRecord();
++
++	void Read(PseudoFile &file);
++};
++
++struct FATSection
++{
++	std::vector<FATRecord> records;
++
++	FATSection();
++
++	void Read(PseudoFile &file);
++};
+diff --git a/3rdparty/sseqplayer/INFOEntry.cpp b/3rdparty/sseqplayer/INFOEntry.cpp
+new file mode 100644
+index 000000000..8bc69bdea
+--- /dev/null
++++ b/3rdparty/sseqplayer/INFOEntry.cpp
+@@ -0,0 +1,48 @@
++/*
++ * SSEQ Player - SDAT INFO Entry structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2013-03-21
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#include "INFOEntry.h"
++
++INFOEntrySEQ::INFOEntrySEQ() : fileID(0), bank(0), vol(0)
++{
++}
++
++void INFOEntrySEQ::Read(PseudoFile &file)
++{
++	this->fileID = file.ReadLE<uint16_t>();
++	file.ReadLE<uint16_t>(); // unknown
++	this->bank = file.ReadLE<uint16_t>();
++	this->vol = file.ReadLE<uint8_t>();
++	if (!this->vol)
++		this->vol = 0x7F; // Prevents nothing for volume
++	file.ReadLE<uint8_t>(); // cpr
++	file.ReadLE<uint8_t>(); // ppr
++	file.ReadLE<uint8_t>(); // ply
++}
++
++INFOEntryBANK::INFOEntryBANK() : fileID(0)
++{
++	memset(this->waveArc, 0, sizeof(this->waveArc));
++}
++
++void INFOEntryBANK::Read(PseudoFile &file)
++{
++	this->fileID = file.ReadLE<uint16_t>();
++	file.ReadLE<uint16_t>(); // unknown
++	file.ReadLE(this->waveArc);
++}
++
++INFOEntryWAVEARC::INFOEntryWAVEARC() : fileID(0)
++{
++}
++
++void INFOEntryWAVEARC::Read(PseudoFile &file)
++{
++	this->fileID = file.ReadLE<uint16_t>();
++}
+diff --git a/3rdparty/sseqplayer/INFOEntry.h b/3rdparty/sseqplayer/INFOEntry.h
+new file mode 100644
+index 000000000..c06a7d82f
+--- /dev/null
++++ b/3rdparty/sseqplayer/INFOEntry.h
+@@ -0,0 +1,51 @@
++/*
++ * SSEQ Player - SDAT INFO Entry structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-08
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#pragma once
++
++#include "common.h"
++
++struct INFOEntry
++{
++	virtual ~INFOEntry()
++	{
++	}
++
++	virtual void Read(PseudoFile &file) = 0;
++};
++
++struct INFOEntrySEQ : INFOEntry
++{
++	uint16_t fileID;
++	uint16_t bank;
++	uint8_t vol;
++
++	INFOEntrySEQ();
++
++	void Read(PseudoFile &file);
++};
++
++struct INFOEntryBANK : INFOEntry
++{
++	uint16_t fileID;
++	uint16_t waveArc[4];
++
++	INFOEntryBANK();
++
++	void Read(PseudoFile &file);
++};
++
++struct INFOEntryWAVEARC : INFOEntry
++{
++	uint16_t fileID;
++
++	INFOEntryWAVEARC();
++
++	void Read(PseudoFile &file);
++};
+diff --git a/3rdparty/sseqplayer/INFOSection.cpp b/3rdparty/sseqplayer/INFOSection.cpp
+new file mode 100644
+index 000000000..e72085ab6
+--- /dev/null
++++ b/3rdparty/sseqplayer/INFOSection.cpp
+@@ -0,0 +1,61 @@
++/*
++ * SSEQ Player - SDAT INFO Section structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2013-03-25
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#include <vector>
++#include <stdexcept>
++#include "INFOSection.h"
++
++template<typename T> INFORecord<T>::INFORecord() : entries()
++{
++}
++
++template<typename T> void INFORecord<T>::Read(PseudoFile &file, uint32_t startOffset)
++{
++	uint32_t count = file.ReadLE<uint32_t>();
++	auto entryOffsets = std::vector<uint32_t>(count);
++	file.ReadLE(entryOffsets);
++	for (uint32_t i = 0; i < count; ++i)
++		if (entryOffsets[i])
++		{
++			file.pos = startOffset + entryOffsets[i];
++			this->entries[i] = T();
++			this->entries[i].Read(file);
++		}
++}
++
++INFOSection::INFOSection() : SEQrecord(), BANKrecord(), WAVEARCrecord()
++{
++}
++
++void INFOSection::Read(PseudoFile &file)
++{
++	uint32_t startOfINFO = file.pos;
++	int8_t type[4];
++	file.ReadLE(type);
++	if (!VerifyHeader(type, "INFO"))
++		throw std::runtime_error("SDAT INFO Section invalid");
++	file.ReadLE<uint32_t>(); // size
++	uint32_t recordOffsets[8];
++	file.ReadLE(recordOffsets);
++	if (recordOffsets[REC_SEQ])
++	{
++		file.pos = startOfINFO + recordOffsets[REC_SEQ];
++		this->SEQrecord.Read(file, startOfINFO);
++	}
++	if (recordOffsets[REC_BANK])
++	{
++		file.pos = startOfINFO + recordOffsets[REC_BANK];
++		this->BANKrecord.Read(file, startOfINFO);
++	}
++	if (recordOffsets[REC_WAVEARC])
++	{
++		file.pos = startOfINFO + recordOffsets[REC_WAVEARC];
++		this->WAVEARCrecord.Read(file, startOfINFO);
++	}
++}
+diff --git a/3rdparty/sseqplayer/INFOSection.h b/3rdparty/sseqplayer/INFOSection.h
+new file mode 100644
+index 000000000..0fbe58246
+--- /dev/null
++++ b/3rdparty/sseqplayer/INFOSection.h
+@@ -0,0 +1,34 @@
++/*
++ * SSEQ Player - SDAT INFO Section structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-08
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#pragma once
++
++#include <map>
++#include "INFOEntry.h"
++#include "common.h"
++
++template<typename T> struct INFORecord
++{
++	std::map<uint32_t, T> entries;
++
++	INFORecord();
++
++	void Read(PseudoFile &file, uint32_t startOffset);
++};
++
++struct INFOSection
++{
++	INFORecord<INFOEntrySEQ> SEQrecord;
++	INFORecord<INFOEntryBANK> BANKrecord;
++	INFORecord<INFOEntryWAVEARC> WAVEARCrecord;
++
++	INFOSection();
++
++	void Read(PseudoFile &file);
++};
+diff --git a/3rdparty/sseqplayer/LICENSE.TXT b/3rdparty/sseqplayer/LICENSE.TXT
+new file mode 100644
+index 000000000..3efe11857
+--- /dev/null
++++ b/3rdparty/sseqplayer/LICENSE.TXT
+@@ -0,0 +1,13 @@
++           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
++                    Version 2, December 2004
++
++ Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
++
++ Everyone is permitted to copy and distribute verbatim or modified
++ copies of this license document, and changing it is allowed as long
++ as the name is changed.
++
++            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
++   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
++
++  0. You just DO WHAT THE FUCK YOU WANT TO.
+diff --git a/3rdparty/sseqplayer/Makefile b/3rdparty/sseqplayer/Makefile
+new file mode 100644
+index 000000000..d92e8312e
+--- /dev/null
++++ b/3rdparty/sseqplayer/Makefile
+@@ -0,0 +1,8 @@
++library_name := sseqplayer
++dirs.root := ../..
++
++source_dirs = .
++
++defines += _LIBCPP_VERSION
++
++include $(dirs.root)/makefile.mak
+diff --git a/3rdparty/sseqplayer/NDSStdHeader.cpp b/3rdparty/sseqplayer/NDSStdHeader.cpp
+new file mode 100644
+index 000000000..f996168cc
+--- /dev/null
++++ b/3rdparty/sseqplayer/NDSStdHeader.cpp
+@@ -0,0 +1,31 @@
++/*
++ * SSEQ Player - Nintendo DS Standard Header structure
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2013-03-21
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#include <stdexcept>
++#include "NDSStdHeader.h"
++
++NDSStdHeader::NDSStdHeader() : magic(0)
++{
++	memset(this->type, 0, sizeof(this->type));
++}
++
++void NDSStdHeader::Read(PseudoFile &file)
++{
++	file.ReadLE(this->type);
++	this->magic = file.ReadLE<uint32_t>();
++	file.ReadLE<uint32_t>(); // file size
++	file.ReadLE<uint16_t>(); // structure size
++	file.ReadLE<uint16_t>(); // # of blocks
++}
++
++void NDSStdHeader::Verify(const std::string &typeToCheck, uint32_t magicToCheck)
++{
++	if (!VerifyHeader(this->type, typeToCheck) || this->magic != magicToCheck)
++		throw std::runtime_error("NDS Standard Header for " + typeToCheck + " invalid");
++}
+diff --git a/3rdparty/sseqplayer/NDSStdHeader.h b/3rdparty/sseqplayer/NDSStdHeader.h
+new file mode 100644
+index 000000000..2a8e141b8
+--- /dev/null
++++ b/3rdparty/sseqplayer/NDSStdHeader.h
+@@ -0,0 +1,23 @@
++/*
++ * SSEQ Player - Nintendo DS Standard Header structure
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-08
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#pragma once
++
++#include "common.h"
++
++struct NDSStdHeader
++{
++	int8_t type[4];
++	uint32_t magic;
++
++	NDSStdHeader();
++
++	void Read(PseudoFile &file);
++	void Verify(const std::string &typeToCheck, uint32_t magicToCheck);
++};
+diff --git a/3rdparty/sseqplayer/Player.cpp b/3rdparty/sseqplayer/Player.cpp
+new file mode 100644
+index 000000000..854f49d3b
+--- /dev/null
++++ b/3rdparty/sseqplayer/Player.cpp
+@@ -0,0 +1,232 @@
++/*
++ * SSEQ Player - Player structure
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-10-23
++ *
++ * Adapted from source code of FeOS Sound System
++ * By fincs
++ * https://github.com/fincs/FSS
++ */
++
++#include "Player.h"
++#include "common.h"
++
++#if (defined(__GNUC__) || defined(__clang__)) && !defined(_LIBCPP_VERSION)
++std::locale::id std::codecvt<char16_t, char, mbstate_t>::id;
++std::locale::id std::codecvt<char32_t, char, mbstate_t>::id;
++#endif
++
++Player::Player() : prio(0), nTracks(0), tempo(0), tempoCount(0), tempoRate(0), masterVol(0), sseqVol(0), sseq(nullptr), sampleRate(0), interpolation(INTERPOLATION_NONE)
++{
++	memset(this->trackIds, 0, sizeof(this->trackIds));
++	for (size_t i = 0; i < 16; ++i)
++	{
++		this->channels[i].chnId = i;
++		this->channels[i].ply = this;
++	}
++	memset(this->variables, -1, sizeof(this->variables));
++}
++
++// Original FSS Function: Player_Setup
++bool Player::Setup(const SSEQ *sseqToPlay)
++{
++	this->sseq = sseqToPlay;
++
++	int firstTrack = this->TrackAlloc();
++	if (firstTrack == -1)
++		return false;
++	this->tracks[firstTrack].Init(firstTrack, this, nullptr, 0);
++
++	this->nTracks = 1;
++	this->trackIds[0] = firstTrack;
++
++	this->tracks[firstTrack].startPos = this->tracks[firstTrack].pos = &this->sseq->data[0];
++
++	this->secondsPerSample = 1.0 / this->sampleRate;
++
++	this->ClearState();
++
++	return true;
++}
++
++// Original FSS Function: Player_ClearState
++void Player::ClearState()
++{
++	this->tempo = 120;
++	this->tempoCount = 0;
++	this->tempoRate = 0x100;
++	this->masterVol = 0; // this is actually the highest level
++	memset(this->variables, -1, sizeof(this->variables));
++	this->secondsIntoPlayback = 0;
++	this->secondsUntilNextClock = SecondsPerClockCycle;
++}
++
++// Original FSS Function: Player_FreeTracks
++void Player::FreeTracks()
++{
++	for (uint8_t i = 0; i < this->nTracks; ++i)
++		this->tracks[this->trackIds[i]].Free();
++	this->nTracks = 0;
++}
++
++// Original FSS Function: Player_Stop
++void Player::Stop(bool bKillSound)
++{
++	this->ClearState();
++	for (uint8_t i = 0; i < this->nTracks; ++i)
++	{
++		uint8_t trackId = this->trackIds[i];
++		this->tracks[trackId].ClearState();
++		for (int j = 0; j < 16; ++j)
++		{
++			Channel &chn = this->channels[j];
++			if (chn.state != CS_NONE && chn.trackId == trackId)
++			{
++				if (bKillSound)
++					chn.Kill();
++				else
++					chn.Release();
++			}
++		}
++	}
++	this->FreeTracks();
++}
++
++// Original FSS Function: Chn_Alloc
++int Player::ChannelAlloc(int type, int priority)
++{
++	static const uint8_t pcmChnArray[] = { 4, 5, 6, 7, 2, 0, 3, 1, 8, 9, 10, 11, 14, 12, 15, 13 };
++	static const uint8_t psgChnArray[] = { 8, 9, 10, 11, 12, 13 };
++	static const uint8_t noiseChnArray[] = { 14, 15 };
++	static const uint8_t arraySizes[] = { sizeof(pcmChnArray), sizeof(psgChnArray), sizeof(noiseChnArray) };
++	static const uint8_t *const arrayArray[] = { pcmChnArray, psgChnArray, noiseChnArray };
++
++	auto chnArray = arrayArray[type];
++	int arraySize = arraySizes[type];
++
++	int curChnNo = -1;
++	for (int i = 0; i < arraySize; ++i)
++	{
++		int thisChnNo = chnArray[i];
++		Channel &thisChn = this->channels[thisChnNo];
++		Channel &curChn = this->channels[curChnNo];
++		if (curChnNo != -1 && thisChn.prio >= curChn.prio)
++		{
++			if (thisChn.prio != curChn.prio)
++				continue;
++			if (curChn.vol <= thisChn.vol)
++				continue;
++		}
++		curChnNo = thisChnNo;
++	}
++
++	if (curChnNo == -1 || priority < this->channels[curChnNo].prio)
++		return -1;
++	this->channels[curChnNo].noteLength = -1;
++	this->channels[curChnNo].vol = 0x7FF;
++	this->channels[curChnNo].clearHistory();
++	return curChnNo;
++}
++
++// Original FSS Function: Track_Alloc
++int Player::TrackAlloc()
++{
++	for (int i = 0; i < FSS_MAXTRACKS; ++i)
++	{
++		Track &thisTrk = this->tracks[i];
++		if (!thisTrk.state[TS_ALLOCBIT])
++		{
++			thisTrk.Zero();
++			thisTrk.state.set(TS_ALLOCBIT);
++			thisTrk.updateFlags.reset();
++			return i;
++		}
++	}
++	return -1;
++}
++
++// Original FSS Function: Player_Run
++void Player::Run()
++{
++	while (this->tempoCount > 240)
++	{
++		this->tempoCount -= 240;
++		for (uint8_t i = 0; i < this->nTracks; ++i)
++			this->tracks[this->trackIds[i]].Run();
++	}
++	this->tempoCount += (static_cast<int>(this->tempo) * static_cast<int>(this->tempoRate)) >> 8;
++}
++
++void Player::UpdateTracks()
++{
++	for (int i = 0; i < 16; ++i)
++		this->channels[i].UpdateTrack();
++	for (int i = 0; i < FSS_MAXTRACKS; ++i)
++		this->tracks[i].updateFlags.reset();
++}
++
++// Original FSS Function: Snd_Timer
++void Player::Timer()
++{
++	this->UpdateTracks();
++
++	for (int i = 0; i < 16; ++i)
++		this->channels[i].Update();
++
++	this->Run();
++}
++
++static inline int32_t muldiv7(int32_t val, uint8_t mul)
++{
++	return mul == 127 ? val : ((val * mul) >> 7);
++}
++
++void Player::GenerateSamples(std::vector<uint8_t> &buf, unsigned offset, unsigned samples)
++{
++	unsigned long mute = this->mutes.to_ulong();
++
++	for (unsigned smpl = 0; smpl < samples; ++smpl)
++	{
++		this->secondsIntoPlayback += this->secondsPerSample;
++
++		int32_t leftChannel = 0, rightChannel = 0;
++
++		// I need to advance the sound channels here
++		for (int i = 0; i < 16; ++i)
++		{
++			Channel &chn = this->channels[i];
++
++			if (chn.state > CS_NONE)
++			{
++				int32_t sample = chn.GenerateSample();
++				chn.IncrementSample();
++
++				if (mute & BIT(i))
++					continue;
++
++				uint8_t datashift = chn.reg.volumeDiv;
++				if (datashift == 3)
++					datashift = 4;
++				sample = muldiv7(sample, chn.reg.volumeMul) >> datashift;
++
++				leftChannel += muldiv7(sample, 127 - chn.reg.panning);
++				rightChannel += muldiv7(sample, chn.reg.panning);
++			}
++		}
++
++		clamp(leftChannel, -0x8000, 0x7FFF);
++		clamp(rightChannel, -0x8000, 0x7FFF);
++
++		buf[offset++] = leftChannel & 0xFF;
++		buf[offset++] = (leftChannel >> 8) & 0xFF;
++		buf[offset++] = rightChannel & 0xFF;
++		buf[offset++] = (rightChannel >> 8) & 0xFF;
++
++		if (this->secondsIntoPlayback > this->secondsUntilNextClock)
++		{
++			this->Timer();
++			this->secondsUntilNextClock += SecondsPerClockCycle;
++		}
++	}
++}
++
+diff --git a/3rdparty/sseqplayer/Player.h b/3rdparty/sseqplayer/Player.h
+new file mode 100644
+index 000000000..afa948bae
+--- /dev/null
++++ b/3rdparty/sseqplayer/Player.h
+@@ -0,0 +1,52 @@
++/*
++ * SSEQ Player - Player structure
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-10-18
++ *
++ * Adapted from source code of FeOS Sound System
++ * By fincs
++ * https://github.com/fincs/FSS
++ */
++
++#pragma once
++
++#include <memory>
++#include <bitset>
++#include "SSEQ.h"
++#include "Track.h"
++#include "Channel.h"
++#include "consts.h"
++
++struct Player
++{
++	uint8_t prio, nTracks;
++	uint16_t tempo, tempoCount, tempoRate /* 8.8 fixed point */;
++	int16_t masterVol, sseqVol;
++
++	const SSEQ *sseq;
++
++	uint8_t trackIds[FSS_TRACKCOUNT];
++	Track tracks[FSS_MAXTRACKS];
++	Channel channels[16];
++	int16_t variables[32];
++
++	uint32_t sampleRate;
++	Interpolation interpolation;
++
++	Player();
++
++	bool Setup(const SSEQ *sseq);
++	void ClearState();
++	void FreeTracks();
++	void Stop(bool bKillSound);
++	int ChannelAlloc(int type, int prio);
++	int TrackAlloc();
++	void Run();
++	void UpdateTracks();
++	void Timer();
++
++	/* Playback helper */
++	double secondsPerSample, secondsIntoPlayback, secondsUntilNextClock;
++	std::bitset<16> mutes;
++	void GenerateSamples(std::vector<uint8_t> &buf, unsigned offset, unsigned samples);
++};
+diff --git a/3rdparty/sseqplayer/SBNK.cpp b/3rdparty/sseqplayer/SBNK.cpp
+new file mode 100644
+index 000000000..2f070b874
+--- /dev/null
++++ b/3rdparty/sseqplayer/SBNK.cpp
+@@ -0,0 +1,123 @@
++/*
++ * SSEQ Player - SDAT SBNK (Sound Bank) structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2013-03-25
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#include <stdexcept>
++#include "SBNK.h"
++#include "NDSStdHeader.h"
++
++SBNKInstrumentRange::SBNKInstrumentRange(uint8_t lowerNote, uint8_t upperNote, int recordType) : lowNote(lowerNote), highNote(upperNote),
++	record(recordType), swav(0), swar(0), noteNumber(0), attackRate(0), decayRate(0), sustainLevel(0), releaseRate(0), pan(0)
++{
++}
++
++void SBNKInstrumentRange::Read(PseudoFile &file)
++{
++	this->swav = file.ReadLE<uint16_t>();
++	this->swar = file.ReadLE<uint16_t>();
++	this->noteNumber = file.ReadLE<uint8_t>();
++	this->attackRate = file.ReadLE<uint8_t>();
++	this->decayRate = file.ReadLE<uint8_t>();
++	this->sustainLevel = file.ReadLE<uint8_t>();
++	this->releaseRate = file.ReadLE<uint8_t>();
++	this->pan = file.ReadLE<uint8_t>();
++}
++
++SBNKInstrument::SBNKInstrument() : record(0), ranges()
++{
++}
++
++void SBNKInstrument::Read(PseudoFile &file, uint32_t startOffset)
++{
++	this->record = file.ReadLE<uint8_t>();
++	uint16_t offset = file.ReadLE<uint16_t>();
++	file.ReadLE<uint8_t>();
++	uint32_t endOfInst = file.pos;
++	file.pos = startOffset + offset;
++	if (this->record)
++	{
++		if (this->record == 16)
++		{
++			uint8_t lowNote = file.ReadLE<uint8_t>();
++			uint8_t highNote = file.ReadLE<uint8_t>();
++			uint8_t num = highNote - lowNote + 1;
++			for (uint8_t i = 0; i < num; ++i)
++			{
++				uint16_t thisRecord = file.ReadLE<uint16_t>();
++				auto range = SBNKInstrumentRange(lowNote + i, lowNote + i, thisRecord);
++				range.Read(file);
++				this->ranges.push_back(range);
++			}
++		}
++		else if (this->record == 17)
++		{
++			uint8_t thisRanges[8];
++			file.ReadLE(thisRanges);
++			uint8_t i = 0;
++			while (i < 8 && thisRanges[i])
++			{
++				uint16_t thisRecord = file.ReadLE<uint16_t>();
++				uint8_t lowNote = i ? thisRanges[i - 1] + 1 : 0;
++				uint8_t highNote = thisRanges[i];
++				auto range = SBNKInstrumentRange(lowNote, highNote, thisRecord);
++				range.Read(file);
++				this->ranges.push_back(range);
++				++i;
++			}
++		}
++		else
++		{
++			auto range = SBNKInstrumentRange(0, 127, this->record);
++			range.Read(file);
++			this->ranges.push_back(range);
++		}
++	}
++	file.pos = endOfInst;
++}
++
++SBNK::SBNK(const std::string &fn) : filename(fn), instruments(), info()
++{
++	memset(this->waveArc, 0, sizeof(this->waveArc));
++}
++
++SBNK::SBNK(const SBNK &sbnk) : filename(sbnk.filename), instruments(sbnk.instruments), info(sbnk.info)
++{
++	memcpy(this->waveArc, sbnk.waveArc, sizeof(this->waveArc));
++}
++
++SBNK &SBNK::operator=(const SBNK &sbnk)
++{
++	if (this != &sbnk)
++	{
++		this->filename = sbnk.filename;
++		this->instruments = sbnk.instruments;
++
++		memcpy(this->waveArc, sbnk.waveArc, sizeof(this->waveArc));
++		this->info = sbnk.info;
++	}
++	return *this;
++}
++
++void SBNK::Read(PseudoFile &file)
++{
++	uint32_t startOfSBNK = file.pos;
++	NDSStdHeader header;
++	header.Read(file);
++	header.Verify("SBNK", 0x0100FEFF);
++	int8_t type[4];
++	file.ReadLE(type);
++	if (!VerifyHeader(type, "DATA"))
++		throw std::runtime_error("SBNK DATA structure invalid");
++	file.ReadLE<uint32_t>(); // size
++	uint32_t reserved[8];
++	file.ReadLE(reserved);
++	uint32_t count = file.ReadLE<uint32_t>();
++	this->instruments.resize(count);
++	for (uint32_t i = 0; i < count; ++i)
++		this->instruments[i].Read(file, startOfSBNK);
++}
+diff --git a/3rdparty/sseqplayer/SBNK.h b/3rdparty/sseqplayer/SBNK.h
+new file mode 100644
+index 000000000..e35f28067
+--- /dev/null
++++ b/3rdparty/sseqplayer/SBNK.h
+@@ -0,0 +1,58 @@
++/*
++ * SSEQ Player - SDAT SBNK (Sound Bank) structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-08
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#pragma once
++
++#include "SWAR.h"
++#include "INFOEntry.h"
++#include "common.h"
++
++struct SBNKInstrumentRange
++{
++	uint8_t lowNote;
++	uint8_t highNote;
++	uint16_t record;
++	uint16_t swav;
++	uint16_t swar;
++	uint8_t noteNumber;
++	uint8_t attackRate;
++	uint8_t decayRate;
++	uint8_t sustainLevel;
++	uint8_t releaseRate;
++	uint8_t pan;
++
++	SBNKInstrumentRange(uint8_t lowerNote, uint8_t upperNote, int recordType);
++
++	void Read(PseudoFile &file);
++};
++
++struct SBNKInstrument
++{
++	uint8_t record;
++	std::vector<SBNKInstrumentRange> ranges;
++
++	SBNKInstrument();
++
++	void Read(PseudoFile &file, uint32_t startOffset);
++};
++
++struct SBNK
++{
++	std::string filename;
++	std::vector<SBNKInstrument> instruments;
++
++	const SWAR *waveArc[4];
++	INFOEntryBANK info;
++
++	SBNK(const std::string &fn = "");
++	SBNK(const SBNK &sbnk);
++	SBNK &operator=(const SBNK &sbnk);
++
++	void Read(PseudoFile &file);
++};
+diff --git a/3rdparty/sseqplayer/SDAT.cpp b/3rdparty/sseqplayer/SDAT.cpp
+new file mode 100644
+index 000000000..89d96f483
+--- /dev/null
++++ b/3rdparty/sseqplayer/SDAT.cpp
+@@ -0,0 +1,93 @@
++/*
++ * SSEQ Player - SDAT structure
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2013-03-21
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#include "SDAT.h"
++#include "NDSStdHeader.h"
++#include "SYMBSection.h"
++#include "INFOSection.h"
++#include "FATSection.h"
++#include "convert.h"
++
++SDAT::SDAT(PseudoFile &file, uint32_t sseqToLoad) : sseq(), sbnk()
++{
++	// Read sections
++	NDSStdHeader header;
++	header.Read(file);
++	header.Verify("SDAT", 0x0100FEFF);
++	uint32_t SYMBOffset = file.ReadLE<uint32_t>();
++	file.ReadLE<uint32_t>(); // SYMB size
++	uint32_t INFOOffset = file.ReadLE<uint32_t>();
++	file.ReadLE<uint32_t>(); // INFO size
++	uint32_t FATOffset = file.ReadLE<uint32_t>();
++	file.ReadLE<uint32_t>(); // FAT Size
++	SYMBSection symbSection;
++	if (SYMBOffset)
++	{
++		file.pos = SYMBOffset;
++		symbSection.Read(file);
++	}
++	file.pos = INFOOffset;
++	INFOSection infoSection;
++	infoSection.Read(file);
++	file.pos = FATOffset;
++	FATSection fatSection;
++	fatSection.Read(file);
++
++	if (infoSection.SEQrecord.entries.empty())
++		throw std::logic_error("No SSEQ records found in SDAT");
++
++	if (!infoSection.SEQrecord.entries.count(sseqToLoad))
++		throw std::range_error("SSEQ of " + stringify(sseqToLoad) + " is not found");
++
++	// Read SSEQ
++	if (infoSection.SEQrecord.entries.count(sseqToLoad))
++	{
++		uint16_t fileID = infoSection.SEQrecord.entries[sseqToLoad].fileID;
++		std::string name = "SSEQ" + NumToHexString(fileID).substr(2);
++		if (SYMBOffset)
++			name = NumToHexString(sseqToLoad).substr(6) + " - " + symbSection.SEQrecord.entries[sseqToLoad];
++		file.pos = fatSection.records[fileID].offset;
++		SSEQ *newSSEQ = new SSEQ(name);
++		newSSEQ->info = infoSection.SEQrecord.entries[sseqToLoad];
++		newSSEQ->Read(file);
++		this->sseq.reset(newSSEQ);
++
++		// Read SBNK for this SSEQ
++		uint16_t bank = newSSEQ->info.bank;
++		fileID = infoSection.BANKrecord.entries[bank].fileID;
++		name = "SBNK" + NumToHexString(fileID).substr(2);
++		if (SYMBOffset)
++			name = NumToHexString(bank).substr(2) + " - " + symbSection.BANKrecord.entries[bank];
++		file.pos = fatSection.records[fileID].offset;
++		SBNK *newSBNK = new SBNK(name);
++		newSSEQ->bank = newSBNK;
++		newSBNK->info = infoSection.BANKrecord.entries[bank];
++		newSBNK->Read(file);
++		this->sbnk.reset(newSBNK);
++
++		// Read SWARs for this SBNK
++		for (int i = 0; i < 4; ++i)
++			if (newSBNK->info.waveArc[i] != 0xFFFF)
++			{
++				uint16_t waveArc = newSBNK->info.waveArc[i];
++				fileID = infoSection.WAVEARCrecord.entries[waveArc].fileID;
++				name = "SWAR" + NumToHexString(fileID).substr(2);
++				if (SYMBOffset)
++					name = NumToHexString(waveArc).substr(2) + " - " + symbSection.WAVEARCrecord.entries[waveArc];
++				file.pos = fatSection.records[fileID].offset;
++				SWAR *newSWAR = new SWAR(name);
++				newSBNK->waveArc[i] = newSWAR;
++				newSWAR->info = infoSection.WAVEARCrecord.entries[waveArc];
++				newSWAR->Read(file);
++				this->swar[i].reset(newSWAR);
++			}
++			else
++				this->swar[i].release();
++	}
++}
+diff --git a/3rdparty/sseqplayer/SDAT.h b/3rdparty/sseqplayer/SDAT.h
+new file mode 100644
+index 000000000..a850b0afc
+--- /dev/null
++++ b/3rdparty/sseqplayer/SDAT.h
+@@ -0,0 +1,28 @@
++/*
++ * SSEQ Player - SDAT structure
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-08
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#pragma once
++
++#include <memory>
++#include "SSEQ.h"
++#include "SBNK.h"
++#include "SWAR.h"
++#include "common.h"
++
++struct SDAT
++{
++	std::unique_ptr<SSEQ> sseq;
++	std::unique_ptr<SBNK> sbnk;
++	std::unique_ptr<SWAR> swar[4];
++
++	SDAT(PseudoFile &file, uint32_t sseqToLoad);
++private:
++	SDAT(const SDAT &);
++	SDAT &operator=(const SDAT &);
++};
+diff --git a/3rdparty/sseqplayer/SSEQ.cpp b/3rdparty/sseqplayer/SSEQ.cpp
+new file mode 100644
+index 000000000..03847bce5
+--- /dev/null
++++ b/3rdparty/sseqplayer/SSEQ.cpp
+@@ -0,0 +1,50 @@
++/*
++ * SSEQ Player - SDAT SSEQ (Sequence) structure
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2013-03-30
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#include <stdexcept>
++#include "SSEQ.h"
++#include "NDSStdHeader.h"
++
++SSEQ::SSEQ(const std::string &fn) : filename(fn), data(), bank(nullptr), info()
++{
++}
++
++SSEQ::SSEQ(const SSEQ &sseq) : filename(sseq.filename), data(sseq.data), bank(sseq.bank), info(sseq.info)
++{
++}
++
++SSEQ &SSEQ::operator=(const SSEQ &sseq)
++{
++	if (this != &sseq)
++	{
++		this->filename = sseq.filename;
++		this->data = sseq.data;
++
++		this->bank = sseq.bank;
++		this->info = sseq.info;
++	}
++	return *this;
++}
++
++void SSEQ::Read(PseudoFile &file)
++{
++	uint32_t startOfSSEQ = file.pos;
++	NDSStdHeader header;
++	header.Read(file);
++	header.Verify("SSEQ", 0x0100FEFF);
++	int8_t type[4];
++	file.ReadLE(type);
++	if (!VerifyHeader(type, "DATA"))
++		throw std::runtime_error("SSEQ DATA structure invalid");
++	uint32_t size = file.ReadLE<uint32_t>();
++	uint32_t dataOffset = file.ReadLE<uint32_t>();
++	this->data.resize(size - 12, 0);
++	file.pos = startOfSSEQ + dataOffset;
++	file.ReadLE(this->data);
++}
+diff --git a/3rdparty/sseqplayer/SSEQ.h b/3rdparty/sseqplayer/SSEQ.h
+new file mode 100644
+index 000000000..d036f7e58
+--- /dev/null
++++ b/3rdparty/sseqplayer/SSEQ.h
+@@ -0,0 +1,29 @@
++/*
++ * SSEQ Player - SDAT SSEQ (Sequence) structure
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-08
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#pragma once
++
++#include "SBNK.h"
++#include "INFOEntry.h"
++#include "common.h"
++
++struct SSEQ
++{
++	std::string filename;
++	std::vector<uint8_t> data;
++
++	const SBNK *bank;
++	INFOEntrySEQ info;
++
++	SSEQ(const std::string &fn = "");
++	SSEQ(const SSEQ &sseq);
++	SSEQ &operator=(const SSEQ &sseq);
++
++	void Read(PseudoFile &file);
++};
+diff --git a/3rdparty/sseqplayer/SSEQPlayer.vcxproj b/3rdparty/sseqplayer/SSEQPlayer.vcxproj
+new file mode 100644
+index 000000000..61d77cbd9
+--- /dev/null
++++ b/3rdparty/sseqplayer/SSEQPlayer.vcxproj
+@@ -0,0 +1,117 @@
++﻿<?xml version="1.0" encoding="utf-8"?>
++<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
++  <ItemGroup Label="ProjectConfigurations">
++    <ProjectConfiguration Include="Debug|Win32">
++      <Configuration>Debug</Configuration>
++      <Platform>Win32</Platform>
++    </ProjectConfiguration>
++    <ProjectConfiguration Include="Release|Win32">
++      <Configuration>Release</Configuration>
++      <Platform>Win32</Platform>
++    </ProjectConfiguration>
++  </ItemGroup>
++  <ItemGroup>
++    <ClInclude Include="Channel.h" />
++    <ClInclude Include="common.h" />
++    <ClInclude Include="consts.h" />
++    <ClInclude Include="convert.h" />
++    <ClInclude Include="FATSection.h" />
++    <ClInclude Include="INFOEntry.h" />
++    <ClInclude Include="INFOSection.h" />
++    <ClInclude Include="NDSStdHeader.h" />
++    <ClInclude Include="Player.h" />
++    <ClInclude Include="SBNK.h" />
++    <ClInclude Include="SDAT.h" />
++    <ClInclude Include="SSEQ.h" />
++    <ClInclude Include="SWAR.h" />
++    <ClInclude Include="SWAV.h" />
++    <ClInclude Include="SYMBSection.h" />
++    <ClInclude Include="Track.h" />
++  </ItemGroup>
++  <ItemGroup>
++    <ClCompile Include="Channel.cpp" />
++    <ClCompile Include="FATSection.cpp" />
++    <ClCompile Include="INFOEntry.cpp" />
++    <ClCompile Include="INFOSection.cpp" />
++    <ClCompile Include="NDSStdHeader.cpp" />
++    <ClCompile Include="Player.cpp" />
++    <ClCompile Include="SBNK.cpp" />
++    <ClCompile Include="SDAT.cpp" />
++    <ClCompile Include="SSEQ.cpp" />
++    <ClCompile Include="SWAR.cpp" />
++    <ClCompile Include="SWAV.cpp" />
++    <ClCompile Include="SYMBSection.cpp" />
++    <ClCompile Include="Track.cpp" />
++  </ItemGroup>
++  <PropertyGroup Label="Globals">
++    <ProjectGuid>{1B825AB0-287E-4F75-9C15-22469D52BE73}</ProjectGuid>
++    <Keyword>Win32Proj</Keyword>
++    <RootNamespace>SSEQPlayer</RootNamespace>
++    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
++  </PropertyGroup>
++  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
++    <ConfigurationType>StaticLibrary</ConfigurationType>
++    <UseDebugLibraries>true</UseDebugLibraries>
++    <CharacterSet>Unicode</CharacterSet>
++    <PlatformToolset>v142</PlatformToolset>
++  </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
++    <ConfigurationType>StaticLibrary</ConfigurationType>
++    <UseDebugLibraries>false</UseDebugLibraries>
++    <WholeProgramOptimization>true</WholeProgramOptimization>
++    <CharacterSet>Unicode</CharacterSet>
++    <PlatformToolset>v142</PlatformToolset>
++  </PropertyGroup>
++  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
++  <ImportGroup Label="ExtensionSettings">
++  </ImportGroup>
++  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
++  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
++  <PropertyGroup Label="UserMacros" />
++  <PropertyGroup />
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
++    <ClCompile>
++      <PrecompiledHeader>
++      </PrecompiledHeader>
++      <WarningLevel>Level3</WarningLevel>
++      <Optimization>Disabled</Optimization>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
++      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
++      <AdditionalOptions>/d2notypeopt %(AdditionalOptions)</AdditionalOptions>
++    </ClCompile>
++    <Link>
++      <SubSystem>Windows</SubSystem>
++      <GenerateDebugInformation>true</GenerateDebugInformation>
++    </Link>
++  </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
++    <ClCompile>
++      <WarningLevel>Level3</WarningLevel>
++      <PrecompiledHeader>
++      </PrecompiledHeader>
++      <Optimization>MaxSpeed</Optimization>
++      <FunctionLevelLinking>true</FunctionLevelLinking>
++      <IntrinsicFunctions>true</IntrinsicFunctions>
++      <PreprocessorDefinitions>_WIN32_WINNT=0x501;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
++      <FloatingPointModel>Fast</FloatingPointModel>
++      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
++      <AdditionalOptions>/d2notypeopt</AdditionalOptions>
++    </ClCompile>
++    <Link>
++      <SubSystem>Windows</SubSystem>
++      <GenerateDebugInformation>true</GenerateDebugInformation>
++      <EnableCOMDATFolding>true</EnableCOMDATFolding>
++      <OptimizeReferences>true</OptimizeReferences>
++    </Link>
++  </ItemDefinitionGroup>
++  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
++  <ImportGroup Label="ExtensionTargets">
++  </ImportGroup>
++</Project>
+\ No newline at end of file
+diff --git a/3rdparty/sseqplayer/SSEQPlayer.vcxproj.filters b/3rdparty/sseqplayer/SSEQPlayer.vcxproj.filters
+new file mode 100644
+index 000000000..064d6dace
+--- /dev/null
++++ b/3rdparty/sseqplayer/SSEQPlayer.vcxproj.filters
+@@ -0,0 +1,104 @@
++﻿<?xml version="1.0" encoding="utf-8"?>
++<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
++  <ItemGroup>
++    <Filter Include="Source Files">
++      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
++      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
++    </Filter>
++    <Filter Include="Header Files">
++      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
++      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
++    </Filter>
++  </ItemGroup>
++  <ItemGroup>
++    <ClInclude Include="Channel.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="common.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="consts.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="convert.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="FATSection.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="INFOEntry.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="INFOSection.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="NDSStdHeader.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="Player.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="SBNK.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="SDAT.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="SSEQ.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="SWAR.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="SWAV.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="SYMBSection.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="Track.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++  </ItemGroup>
++  <ItemGroup>
++    <ClCompile Include="Channel.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="FATSection.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="INFOEntry.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="INFOSection.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="NDSStdHeader.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="Player.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="SBNK.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="SDAT.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="SSEQ.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="SWAR.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="SWAV.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="SYMBSection.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="Track.cpp">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++  </ItemGroup>
++</Project>
+\ No newline at end of file
+diff --git a/3rdparty/sseqplayer/SWAR.cpp b/3rdparty/sseqplayer/SWAR.cpp
+new file mode 100644
+index 000000000..fcba7728e
+--- /dev/null
++++ b/3rdparty/sseqplayer/SWAR.cpp
+@@ -0,0 +1,42 @@
++/*
++ * SSEQ Player - SDAT SWAR (Wave Archive) structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2013-03-25
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#include <vector>
++#include <stdexcept>
++#include "SWAR.h"
++#include "NDSStdHeader.h"
++
++SWAR::SWAR(const std::string &fn) : filename(fn), swavs(), info()
++{
++}
++
++void SWAR::Read(PseudoFile &file)
++{
++	uint32_t startOfSWAR = file.pos;
++	NDSStdHeader header;
++	header.Read(file);
++	header.Verify("SWAR", 0x0100FEFF);
++	int8_t type[4];
++	file.ReadLE(type);
++	if (!VerifyHeader(type, "DATA"))
++		throw std::runtime_error("SWAR DATA structure invalid");
++	file.ReadLE<uint32_t>(); // size
++	uint32_t reserved[8];
++	file.ReadLE(reserved);
++	uint32_t count = file.ReadLE<uint32_t>();
++	auto offsets = std::vector<uint32_t>(count);
++	file.ReadLE(offsets);
++	for (uint32_t i = 0; i < count; ++i)
++		if (offsets[i])
++		{
++			file.pos = startOfSWAR + offsets[i];
++			this->swavs[i] = SWAV();
++			this->swavs[i].Read(file);
++		}
++}
+diff --git a/3rdparty/sseqplayer/SWAR.h b/3rdparty/sseqplayer/SWAR.h
+new file mode 100644
+index 000000000..90d36a04f
+--- /dev/null
++++ b/3rdparty/sseqplayer/SWAR.h
+@@ -0,0 +1,30 @@
++/*
++ * SSEQ Player - SDAT SWAR (Wave Archive) structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-08
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#pragma once
++
++#include <map>
++#include "SWAV.h"
++#include "INFOEntry.h"
++#include "common.h"
++
++/*
++ * The size has been left out of this structure as it is unused by this player.
++ */
++struct SWAR
++{
++	std::string filename;
++	std::map<uint32_t, SWAV> swavs;
++
++	INFOEntryWAVEARC info;
++
++	SWAR(const std::string &fn = "");
++
++	void Read(PseudoFile &file);
++};
+diff --git a/3rdparty/sseqplayer/SWAV.cpp b/3rdparty/sseqplayer/SWAV.cpp
+new file mode 100644
+index 000000000..9ea5e3363
+--- /dev/null
++++ b/3rdparty/sseqplayer/SWAV.cpp
+@@ -0,0 +1,125 @@
++/*
++ * SSEQ Player - SDAT SWAV (Waveform/Sample) structure
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2013-04-12
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#include "SWAV.h"
++
++static int ima_index_table[] =
++{
++	-1, -1, -1, -1, 2, 4, 6, 8,
++	-1, -1, -1, -1, 2, 4, 6, 8
++};
++
++static int ima_step_table[] =
++{
++	7, 8, 9, 10, 11, 12, 13, 14, 16, 17,
++	19, 21, 23, 25, 28, 31, 34, 37, 41, 45,
++	50, 55, 60, 66, 73, 80, 88, 97, 107, 118,
++	130, 143, 157, 173, 190, 209, 230, 253, 279, 307,
++	337, 371, 408, 449, 494, 544, 598, 658, 724, 796,
++	876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066,
++	2272, 2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358,
++	5894, 6484, 7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899,
++	15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
++};
++
++SWAV::SWAV() : waveType(0), loop(0), sampleRate(0), time(0), loopOffset(0), nonLoopLength(0), data(), dataptr(nullptr)
++{
++}
++
++static inline void DecodeADPCMNibble(int32_t nibble, int32_t &stepIndex, int32_t &predictedValue)
++{
++	int32_t step = ima_step_table[stepIndex];
++
++	stepIndex += ima_index_table[nibble];
++
++	if (stepIndex < 0)
++		stepIndex = 0;
++	else if (stepIndex > 88)
++		stepIndex = 88;
++
++	int32_t diff = step >> 3;
++
++	if (nibble & 4)
++		diff += step;
++	if (nibble & 2)
++		diff += step >> 1;
++	if (nibble & 1)
++		diff += step >> 2;
++	if (nibble & 8)
++		predictedValue -= diff;
++	else
++		predictedValue += diff;
++
++	if (predictedValue < -0x8000)
++		predictedValue = -0x8000;
++	else if (predictedValue > 0x7FFF)
++		predictedValue = 0x7FFF;
++}
++
++void SWAV::DecodeADPCM(const uint8_t *origData, uint32_t len)
++{
++	int32_t predictedValue = origData[0] | (origData[1] << 8);
++	int32_t stepIndex = origData[2] | (origData[3] << 8);
++	auto finalData = &this->data[0];
++
++	for (uint32_t i = 0; i < len; ++i)
++	{
++		int32_t nibble = origData[i + 4] & 0x0F;
++		DecodeADPCMNibble(nibble, stepIndex, predictedValue);
++		finalData[2 * i] = predictedValue;
++
++		nibble = (origData[i + 4] >> 4) & 0x0F;
++		DecodeADPCMNibble(nibble, stepIndex, predictedValue);
++		finalData[2 * i + 1] = predictedValue;
++	}
++}
++
++void SWAV::Read(PseudoFile &file)
++{
++	this->waveType = file.ReadLE<uint8_t>();
++	this->loop = file.ReadLE<uint8_t>();
++	this->sampleRate = file.ReadLE<uint16_t>();
++	this->time = file.ReadLE<uint16_t>();
++	this->loopOffset = file.ReadLE<uint16_t>();
++	this->nonLoopLength = file.ReadLE<uint32_t>();
++	uint32_t size = (this->loopOffset + this->nonLoopLength) * 4;
++	auto origData = std::vector<uint8_t>(size);
++	file.ReadLE(origData);
++
++	// Convert data accordingly
++	if (!this->waveType)
++	{
++		// PCM 8-bit -> PCM signed 16-bit
++		this->data.resize(size, 0);
++		for (size_t i = 0; i < size; ++i)
++			this->data[i] = origData[i] << 8;
++		this->loopOffset *= 4;
++		this->nonLoopLength *= 4;
++	}
++	else if (this->waveType == 1)
++	{
++		// PCM signed 16-bit, no conversion
++		this->data.resize(size / 2, 0);
++		for (size_t i = 0; i < size / 2; ++i)
++			this->data[i] = ReadLE<int16_t>(&origData[2 * i]);
++		this->loopOffset *= 2;
++		this->nonLoopLength *= 2;
++	}
++	else if (this->waveType == 2)
++	{
++		// IMA ADPCM -> PCM signed 16-bit
++		this->data.resize((size - 4) * 2, 0);
++		this->DecodeADPCM(&origData[0], size - 4);
++		if (this->loopOffset)
++			--this->loopOffset;
++		this->loopOffset *= 8;
++		this->nonLoopLength *= 8;
++	}
++	this->dataptr = &this->data[0];
++}
+diff --git a/3rdparty/sseqplayer/SWAV.h b/3rdparty/sseqplayer/SWAV.h
+new file mode 100644
+index 000000000..85ddf1828
+--- /dev/null
++++ b/3rdparty/sseqplayer/SWAV.h
+@@ -0,0 +1,29 @@
++/*
++ * SSEQ Player - SDAT SWAV (Waveform/Sample) structure
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-08
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#pragma once
++
++#include "common.h"
++
++struct SWAV
++{
++	uint8_t waveType;
++	uint8_t loop;
++	uint16_t sampleRate;
++	uint16_t time;
++	uint32_t loopOffset;
++	uint32_t nonLoopLength;
++	std::vector<int16_t> data;
++	const int16_t *dataptr;
++
++	SWAV();
++
++	void Read(PseudoFile &file);
++	void DecodeADPCM(const uint8_t *origData, uint32_t len);
++};
+diff --git a/3rdparty/sseqplayer/SYMBSection.cpp b/3rdparty/sseqplayer/SYMBSection.cpp
+new file mode 100644
+index 000000000..a166f610f
+--- /dev/null
++++ b/3rdparty/sseqplayer/SYMBSection.cpp
+@@ -0,0 +1,60 @@
++/*
++ * SSEQ Player - SDAT SYMB (Symbol/Filename) Section structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2013-03-25
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#include <vector>
++#include <stdexcept>
++#include "SYMBSection.h"
++
++SYMBRecord::SYMBRecord() : entries()
++{
++}
++
++void SYMBRecord::Read(PseudoFile &file, uint32_t startOffset)
++{
++	uint32_t count = file.ReadLE<uint32_t>();
++	auto entryOffsets = std::vector<uint32_t>(count);
++	file.ReadLE(entryOffsets);
++	for (uint32_t i = 0; i < count; ++i)
++		if (entryOffsets[i])
++		{
++			file.pos = startOffset + entryOffsets[i];
++			this->entries[i] = file.ReadNullTerminatedString();
++		}
++}
++
++SYMBSection::SYMBSection() : SEQrecord(), BANKrecord(), WAVEARCrecord()
++{
++}
++
++void SYMBSection::Read(PseudoFile &file)
++{
++	uint32_t startOfSYMB = file.pos;
++	int8_t type[4];
++	file.ReadLE(type);
++	if (!VerifyHeader(type, "SYMB"))
++		throw std::runtime_error("SDAT SYMB Section invalid");
++	file.ReadLE<uint32_t>(); // size
++	uint32_t recordOffsets[8];
++	file.ReadLE(recordOffsets);
++	if (recordOffsets[REC_SEQ])
++	{
++		file.pos = startOfSYMB + recordOffsets[REC_SEQ];
++		this->SEQrecord.Read(file, startOfSYMB);
++	}
++	if (recordOffsets[REC_BANK])
++	{
++		file.pos = startOfSYMB + recordOffsets[REC_BANK];
++		this->BANKrecord.Read(file, startOfSYMB);
++	}
++	if (recordOffsets[REC_WAVEARC])
++	{
++		file.pos = startOfSYMB + recordOffsets[REC_WAVEARC];
++		this->WAVEARCrecord.Read(file, startOfSYMB);
++	}
++}
+diff --git a/3rdparty/sseqplayer/SYMBSection.h b/3rdparty/sseqplayer/SYMBSection.h
+new file mode 100644
+index 000000000..9afa3e926
+--- /dev/null
++++ b/3rdparty/sseqplayer/SYMBSection.h
+@@ -0,0 +1,36 @@
++/*
++ * SSEQ Player - SDAT SYMB (Symbol/Filename) Section structures
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-08
++ *
++ * Nintendo DS Nitro Composer (SDAT) Specification document found at
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++
++#pragma once
++
++#include <map>
++#include "common.h"
++
++struct SYMBRecord
++{
++	std::map<uint32_t, std::string> entries;
++
++	SYMBRecord();
++
++	void Read(PseudoFile &file, uint32_t startOffset);
++};
++
++/*
++ * The size has been left out of this structure as it is unused by this player.
++ */
++struct SYMBSection
++{
++	SYMBRecord SEQrecord;
++	SYMBRecord BANKrecord;
++	SYMBRecord WAVEARCrecord;
++
++	SYMBSection();
++
++	void Read(PseudoFile &file);
++};
+diff --git a/3rdparty/sseqplayer/Track.cpp b/3rdparty/sseqplayer/Track.cpp
+new file mode 100644
+index 000000000..1f1b5f955
+--- /dev/null
++++ b/3rdparty/sseqplayer/Track.cpp
+@@ -0,0 +1,811 @@
++/*
++ * SSEQ Player - Track structure
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-10-23
++ *
++ * Adapted from source code of FeOS Sound System
++ * By fincs
++ * https://github.com/fincs/FSS
++ */
++
++#include <cstdlib>
++#include "Track.h"
++#include "Player.h"
++#include "common.h"
++
++Track::Track()
++{
++	this->Zero();
++}
++
++// Original FSS Function: Player_InitTrack
++void Track::Init(uint8_t handle, Player *player, const uint8_t *dataPos, int n)
++{
++	this->trackId = handle;
++	this->num = n;
++	this->ply = player;
++	this->startPos = dataPos;
++	this->ClearState();
++}
++
++void Track::Zero()
++{
++	this->trackId = -1;
++
++	this->state.reset();
++	this->num = this->prio = 0;
++	this->ply = nullptr;
++
++	this->startPos = this->pos = nullptr;
++	std::fill_n(&this->stack[0], FSS_TRACKSTACKSIZE, StackValue());
++	this->stackPos = 0;
++	memset(this->loopCount, 0, sizeof(this->loopCount));
++	this->overriding() = false;
++	this->lastComparisonResult = true;
++
++	this->wait = 0;
++	this->patch = 0;
++	this->portaKey = this->portaTime = 0;
++	this->sweepPitch = 0;
++	this->vol = this->expr = 0;
++	this->pan = 0;
++	this->pitchBendRange = 0;
++	this->pitchBend = this->transpose = 0;
++
++	this->a = this->d = this->s = this->r = 0;
++
++	this->modType = this->modSpeed = this->modDepth = this->modRange = 0;
++	this->modDelay = 0;
++
++	this->updateFlags.reset();
++}
++
++// Original FSS Function: Track_ClearState
++void Track::ClearState()
++{
++	this->state.reset();
++	this->state.set(TS_ALLOCBIT);
++	this->state.set(TS_NOTEWAIT);
++	this->prio = this->ply->prio + 64;
++
++	this->pos = this->startPos;
++	this->stackPos = 0;
++
++	this->wait = 0;
++	this->patch = 0;
++	this->portaKey = 60;
++	this->portaTime = 0;
++	this->sweepPitch = 0;
++	this->vol = this->expr = 127;
++	this->pan = 0;
++	this->pitchBendRange = 2;
++	this->pitchBend = this->transpose = 0;
++
++	this->a = this->d = this->s = this->r = 0xFF;
++
++	this->modType = 0;
++	this->modRange = 1;
++	this->modSpeed = 16;
++	this->modDelay = 0;
++	this->modDepth = 0;
++}
++
++// Original FSS Function: Track_Free
++void Track::Free()
++{
++	this->state.reset();
++	this->updateFlags.reset();
++}
++
++// Original FSS Function: Note_On
++int Track::NoteOn(int key, int vel, int len)
++{
++	auto sbnk = this->ply->sseq->bank;
++
++	if (this->patch >= sbnk->instruments.size())
++		return -1;
++
++	bool bIsPCM = true;
++	Channel *chn = nullptr;
++	int nCh = -1;
++
++	auto &instrument = sbnk->instruments[this->patch];
++	const SBNKInstrumentRange *noteDef = nullptr;
++	int fRecord = instrument.record;
++
++	if (fRecord == 16)
++	{
++		if (!(instrument.ranges[0].lowNote <= key && key <= instrument.ranges[instrument.ranges.size() - 1].highNote))
++			return -1;
++		int rn = key - instrument.ranges[0].lowNote;
++		noteDef = &instrument.ranges[rn];
++		fRecord = noteDef->record;
++	}
++	else if (fRecord == 17)
++	{
++		size_t reg, ranges;
++		for (reg = 0, ranges = instrument.ranges.size(); reg < ranges; ++reg)
++			if (key <= instrument.ranges[reg].highNote)
++				break;
++		if (reg == ranges)
++			return -1;
++
++		noteDef = &instrument.ranges[reg];
++		fRecord = noteDef->record;
++	}
++
++	if (!fRecord)
++		return -1;
++	else if (fRecord == 1)
++	{
++		if (!noteDef)
++			noteDef = &instrument.ranges[0];
++	}
++	else if (fRecord < 4)
++	{
++		// PSG
++		// fRecord = 2 -> PSG tone, pNoteDef->wavid -> PSG duty
++		// fRecord = 3 -> PSG noise
++		bIsPCM = false;
++		if (!noteDef)
++			noteDef = &instrument.ranges[0];
++		if (fRecord == 3)
++		{
++			nCh = this->ply->ChannelAlloc(TYPE_NOISE, this->prio);
++			if (nCh < 0)
++				return -1;
++			chn = &this->ply->channels[nCh];
++			chn->tempReg.CR = SOUND_FORMAT_PSG | SCHANNEL_ENABLE;
++		}
++		else
++		{
++			nCh = this->ply->ChannelAlloc(TYPE_PSG, this->prio);
++			if (nCh < 0)
++				return -1;
++			chn = &this->ply->channels[nCh];
++			chn->tempReg.CR = SOUND_FORMAT_PSG | SCHANNEL_ENABLE | SOUND_DUTY(noteDef->swav & 0x7);
++		}
++		chn->tempReg.TIMER = -SOUND_FREQ(262 * 8); // key #60 (C4)
++		chn->reg.samplePosition = -1;
++		chn->reg.psgX = 0x7FFF;
++	}
++
++	if (bIsPCM)
++	{
++		nCh = this->ply->ChannelAlloc(TYPE_PCM, this->prio);
++		if (nCh < 0)
++			return -1;
++		chn = &this->ply->channels[nCh];
++
++		auto swav = &sbnk->waveArc[noteDef->swar]->swavs.find(noteDef->swav)->second;
++		chn->tempReg.CR = SOUND_FORMAT(swav->waveType & 3) | SOUND_LOOP(!!swav->loop) | SCHANNEL_ENABLE;
++		chn->tempReg.SOURCE = swav;
++		chn->tempReg.TIMER = swav->time;
++		chn->tempReg.REPEAT_POINT = swav->loopOffset;
++		chn->tempReg.LENGTH = swav->nonLoopLength;
++		chn->reg.samplePosition = -3;
++	}
++
++	chn->state = CS_START;
++	chn->trackId = this->trackId;
++	chn->flags.reset();
++	chn->prio = this->prio;
++	chn->key = key;
++	chn->orgKey = noteDef->noteNumber;
++	chn->velocity = Cnv_Sust(vel);
++	chn->pan = static_cast<int>(noteDef->pan) - 64;
++	chn->modDelayCnt = 0;
++	chn->modCounter = 0;
++	chn->noteLength = len;
++	chn->reg.sampleIncrease = 0;
++
++	chn->attackLvl = Cnv_Attack(this->a == 0xFF ? noteDef->attackRate : this->a);
++	chn->decayRate = Cnv_Fall(this->d == 0xFF ? noteDef->decayRate : this->d);
++	chn->sustainLvl = this->s == 0xFF ? noteDef->sustainLevel : this->s;
++	chn->releaseRate = Cnv_Fall(this->r == 0xFF ? noteDef->releaseRate : this->r);
++
++	chn->UpdateVol(*this);
++	chn->UpdatePan(*this);
++	chn->UpdateTune(*this);
++	chn->UpdateMod(*this);
++	chn->UpdatePorta(*this);
++
++	this->portaKey = key;
++
++	return nCh;
++}
++
++// Original FSS Function: Note_On_Tie
++int Track::NoteOnTie(int key, int vel)
++{
++	// Find an existing note
++	int i;
++	Channel *chn = nullptr;
++	for (i = 0; i < 16; ++i)
++	{
++		chn = &this->ply->channels[i];
++		if (chn->state > CS_NONE && chn->trackId == this->trackId && chn->state != CS_RELEASE)
++			break;
++	}
++
++	if (i == 16)
++		// Can't find note -> create an endless one
++		return this->NoteOn(key, vel, -1);
++
++	chn->flags.reset();
++	chn->prio = this->prio;
++	chn->key = key;
++	chn->velocity = Cnv_Sust(vel);
++	chn->modDelayCnt = 0;
++	chn->modCounter = 0;
++
++	chn->UpdateVol(*this);
++	//chn->UpdatePan(*this);
++	chn->UpdateTune(*this);
++	chn->UpdateMod(*this);
++	chn->UpdatePorta(*this);
++
++	this->portaKey = key;
++	chn->flags.set(CF_UPDTMR);
++
++	return i;
++}
++
++// Original FSS Function: Track_ReleaseAllNotes
++void Track::ReleaseAllNotes()
++{
++	for (int i = 0; i < 16; ++i)
++	{
++		Channel &chn = this->ply->channels[i];
++		if (chn.state > CS_NONE && chn.trackId == this->trackId && chn.state != CS_RELEASE)
++			chn.Release();
++	}
++}
++
++enum SseqCommand
++{
++	SSEQ_CMD_ALLOCTRACK = 0xFE, // Silently ignored
++	SSEQ_CMD_OPENTRACK = 0x93,
++
++	SSEQ_CMD_REST = 0x80,
++	SSEQ_CMD_PATCH = 0x81,
++	SSEQ_CMD_PAN = 0xC0,
++	SSEQ_CMD_VOL = 0xC1,
++	SSEQ_CMD_MASTERVOL = 0xC2,
++	SSEQ_CMD_PRIO = 0xC6,
++	SSEQ_CMD_NOTEWAIT = 0xC7,
++	SSEQ_CMD_TIE = 0xC8,
++	SSEQ_CMD_EXPR = 0xD5,
++	SSEQ_CMD_TEMPO = 0xE1,
++	SSEQ_CMD_END = 0xFF,
++
++	SSEQ_CMD_GOTO = 0x94,
++	SSEQ_CMD_CALL = 0x95,
++	SSEQ_CMD_RET = 0xFD,
++	SSEQ_CMD_LOOPSTART = 0xD4,
++	SSEQ_CMD_LOOPEND = 0xFC,
++
++	SSEQ_CMD_TRANSPOSE = 0xC3,
++	SSEQ_CMD_PITCHBEND = 0xC4,
++	SSEQ_CMD_PITCHBENDRANGE = 0xC5,
++
++	SSEQ_CMD_ATTACK = 0xD0,
++	SSEQ_CMD_DECAY = 0xD1,
++	SSEQ_CMD_SUSTAIN = 0xD2,
++	SSEQ_CMD_RELEASE = 0xD3,
++
++	SSEQ_CMD_PORTAKEY = 0xC9,
++	SSEQ_CMD_PORTAFLAG = 0xCE,
++	SSEQ_CMD_PORTATIME = 0xCF,
++	SSEQ_CMD_SWEEPPITCH = 0xE3,
++
++	SSEQ_CMD_MODDEPTH = 0xCA,
++	SSEQ_CMD_MODSPEED = 0xCB,
++	SSEQ_CMD_MODTYPE = 0xCC,
++	SSEQ_CMD_MODRANGE = 0xCD,
++	SSEQ_CMD_MODDELAY = 0xE0,
++
++	SSEQ_CMD_RANDOM = 0xA0,
++	SSEQ_CMD_PRINTVAR = 0xD6,
++	SSEQ_CMD_IF = 0xA2,
++	SSEQ_CMD_FROMVAR = 0xA1,
++	SSEQ_CMD_SETVAR = 0xB0,
++	SSEQ_CMD_ADDVAR = 0xB1,
++	SSEQ_CMD_SUBVAR = 0xB2,
++	SSEQ_CMD_MULVAR = 0xB3,
++	SSEQ_CMD_DIVVAR = 0xB4,
++	SSEQ_CMD_SHIFTVAR = 0xB5,
++	SSEQ_CMD_RANDVAR = 0xB6,
++	SSEQ_CMD_CMP_EQ = 0xB8,
++	SSEQ_CMD_CMP_GE = 0xB9,
++	SSEQ_CMD_CMP_GT = 0xBA,
++	SSEQ_CMD_CMP_LE = 0xBB,
++	SSEQ_CMD_CMP_LT = 0xBC,
++	SSEQ_CMD_CMP_NE = 0xBD,
++
++	SSEQ_CMD_MUTE = 0xD7 // Unsupported
++};
++
++static const uint8_t VariableByteCount = 1 << 7;
++static const uint8_t ExtraByteOnNoteOrVarOrCmp = 1 << 6;
++
++static inline uint8_t SseqCommandByteCount(int cmd)
++{
++	if (cmd < 0x80)
++		return 1 | VariableByteCount;
++	else
++		switch (cmd)
++		{
++			case SSEQ_CMD_REST:
++			case SSEQ_CMD_PATCH:
++				return VariableByteCount;
++
++			case SSEQ_CMD_PAN:
++			case SSEQ_CMD_VOL:
++			case SSEQ_CMD_MASTERVOL:
++			case SSEQ_CMD_PRIO:
++			case SSEQ_CMD_NOTEWAIT:
++			case SSEQ_CMD_TIE:
++			case SSEQ_CMD_EXPR:
++			case SSEQ_CMD_LOOPSTART:
++			case SSEQ_CMD_TRANSPOSE:
++			case SSEQ_CMD_PITCHBEND:
++			case SSEQ_CMD_PITCHBENDRANGE:
++			case SSEQ_CMD_ATTACK:
++			case SSEQ_CMD_DECAY:
++			case SSEQ_CMD_SUSTAIN:
++			case SSEQ_CMD_RELEASE:
++			case SSEQ_CMD_PORTAKEY:
++			case SSEQ_CMD_PORTAFLAG:
++			case SSEQ_CMD_PORTATIME:
++			case SSEQ_CMD_MODDEPTH:
++			case SSEQ_CMD_MODSPEED:
++			case SSEQ_CMD_MODTYPE:
++			case SSEQ_CMD_MODRANGE:
++			case SSEQ_CMD_PRINTVAR:
++			case SSEQ_CMD_MUTE:
++				return 1;
++
++			case SSEQ_CMD_ALLOCTRACK:
++			case SSEQ_CMD_TEMPO:
++			case SSEQ_CMD_SWEEPPITCH:
++			case SSEQ_CMD_MODDELAY:
++				return 2;
++
++			case SSEQ_CMD_GOTO:
++			case SSEQ_CMD_CALL:
++			case SSEQ_CMD_SETVAR:
++			case SSEQ_CMD_ADDVAR:
++			case SSEQ_CMD_SUBVAR:
++			case SSEQ_CMD_MULVAR:
++			case SSEQ_CMD_DIVVAR:
++			case SSEQ_CMD_SHIFTVAR:
++			case SSEQ_CMD_RANDVAR:
++			case SSEQ_CMD_CMP_EQ:
++			case SSEQ_CMD_CMP_GE:
++			case SSEQ_CMD_CMP_GT:
++			case SSEQ_CMD_CMP_LE:
++			case SSEQ_CMD_CMP_LT:
++			case SSEQ_CMD_CMP_NE:
++				return 3;
++
++			case SSEQ_CMD_OPENTRACK:
++				return 4;
++
++			case SSEQ_CMD_FROMVAR:
++				return 1 | ExtraByteOnNoteOrVarOrCmp; // Technically 2 bytes with an additional 1, leaving 1 off because we will be reading it to determine if the additional byte is needed
++
++			case SSEQ_CMD_RANDOM:
++				return 4 | ExtraByteOnNoteOrVarOrCmp; // Technically 5 bytes with an additional 1, leaving 1 off because we will be reading it to determine if the additional byte is needed
++
++			default:
++				return 0;
++		}
++}
++
++static auto varFuncSet = [](int16_t, int16_t value) { return value; };
++static auto varFuncAdd = [](int16_t var, int16_t value) -> int16_t { return var + value; };
++static auto varFuncSub = [](int16_t var, int16_t value) -> int16_t { return var - value; };
++static auto varFuncMul = [](int16_t var, int16_t value) -> int16_t { return var * value; };
++static auto varFuncDiv = [](int16_t var, int16_t value) -> int16_t { return var / value; };
++static auto varFuncShift = [](int16_t var, int16_t value) -> int16_t
++{
++	if (value < 0)
++		return var >> -value;
++	else
++		return var << value;
++};
++static auto varFuncRand = [](int16_t, int16_t value) -> int16_t
++{
++	if (value < 0)
++		return -(std::rand() % (-value + 1));
++	else
++		return std::rand() % (value + 1);
++};
++
++static inline std::function<int16_t (int16_t, int16_t)> VarFunc(int cmd)
++{
++	switch (cmd)
++	{
++		case SSEQ_CMD_SETVAR:
++			return varFuncSet;
++		case SSEQ_CMD_ADDVAR:
++			return varFuncAdd;
++		case SSEQ_CMD_SUBVAR:
++			return varFuncSub;
++		case SSEQ_CMD_MULVAR:
++			return varFuncMul;
++		case SSEQ_CMD_DIVVAR:
++			return varFuncDiv;
++		case SSEQ_CMD_SHIFTVAR:
++			return varFuncShift;
++		case SSEQ_CMD_RANDVAR:
++			return varFuncRand;
++		default:
++			return nullptr;
++	}
++}
++
++static auto compareFuncEq = [](int16_t a, int16_t b) { return a == b; };
++static auto compareFuncGe = [](int16_t a, int16_t b) { return a >= b; };
++static auto compareFuncGt = [](int16_t a, int16_t b) { return a > b; };
++static auto compareFuncLe = [](int16_t a, int16_t b) { return a <= b; };
++static auto compareFuncLt = [](int16_t a, int16_t b) { return a < b; };
++static auto compareFuncNe = [](int16_t a, int16_t b) { return a != b; };
++
++static inline std::function<bool (int16_t, int16_t)> CompareFunc(int cmd)
++{
++	switch (cmd)
++	{
++		case SSEQ_CMD_CMP_EQ:
++			return compareFuncEq;
++		case SSEQ_CMD_CMP_GE:
++			return compareFuncGe;
++		case SSEQ_CMD_CMP_GT:
++			return compareFuncGt;
++		case SSEQ_CMD_CMP_LE:
++			return compareFuncLe;
++		case SSEQ_CMD_CMP_LT:
++			return compareFuncLt;
++		case SSEQ_CMD_CMP_NE:
++			return compareFuncNe;
++		default:
++			return nullptr;
++	}
++}
++
++// Original FSS Function: Track_Run
++void Track::Run()
++{
++	// Indicate "heartbeat" for this track
++	this->updateFlags.set(TUF_LEN);
++
++	// Exit if the track has already ended
++	if (this->state[TS_END])
++		return;
++
++	if (this->wait)
++	{
++		--this->wait;
++		if (this->wait)
++			return;
++	}
++
++	auto pData = &this->pos;
++
++	while (!this->wait)
++	{
++		int cmd;
++		if (this->overriding())
++			cmd = this->overriding.cmd;
++		else
++			cmd = read8(pData);
++		if (cmd < 0x80)
++		{
++			// Note on
++			int key = cmd + this->transpose;
++			int vel = this->overriding.val(pData, read8, true);
++			int len = this->overriding.val(pData, readvl);
++			if (this->state[TS_NOTEWAIT])
++				this->wait = len;
++			if (this->state[TS_TIEBIT])
++				this->NoteOnTie(key, vel);
++			else
++				this->NoteOn(key, vel, len);
++		}
++		else
++		{
++			int value;
++			switch (cmd)
++			{
++				//-----------------------------------------------------------------
++				// Main commands
++				//-----------------------------------------------------------------
++
++				case SSEQ_CMD_OPENTRACK:
++				{
++					int tNum = read8(pData);
++					auto trackPos = &this->ply->sseq->data[read24(pData)];
++					int newTrack = this->ply->TrackAlloc();
++					if (newTrack != -1)
++					{
++						this->ply->tracks[newTrack].Init(newTrack, this->ply, trackPos, tNum);
++						this->ply->trackIds[this->ply->nTracks++] = newTrack;
++					}
++					break;
++				}
++
++				case SSEQ_CMD_REST:
++					this->wait = this->overriding.val(pData, readvl);
++					break;
++
++				case SSEQ_CMD_PATCH:
++					this->patch = this->overriding.val(pData, readvl);
++					break;
++
++				case SSEQ_CMD_GOTO:
++					*pData = &this->ply->sseq->data[read24(pData)];
++					break;
++
++				case SSEQ_CMD_CALL:
++					value = read24(pData);
++					if (this->stackPos < FSS_TRACKSTACKSIZE)
++					{
++						const uint8_t *dest = &this->ply->sseq->data[value];
++						this->stack[this->stackPos++] = StackValue(STACKTYPE_CALL, *pData);
++						*pData = dest;
++					}
++					break;
++
++				case SSEQ_CMD_RET:
++					if (this->stackPos && this->stack[this->stackPos - 1].type == STACKTYPE_CALL)
++						*pData = this->stack[--this->stackPos].dest;
++					break;
++
++				case SSEQ_CMD_PAN:
++					this->pan = this->overriding.val(pData, read8) - 64;
++					this->updateFlags.set(TUF_PAN);
++					break;
++
++				case SSEQ_CMD_VOL:
++					this->vol = this->overriding.val(pData, read8);
++					this->updateFlags.set(TUF_VOL);
++					break;
++
++				case SSEQ_CMD_MASTERVOL:
++					this->ply->masterVol = Cnv_Sust(this->overriding.val(pData, read8));
++					for (uint8_t i = 0; i < this->ply->nTracks; ++i)
++						this->ply->tracks[this->ply->trackIds[i]].updateFlags.set(TUF_VOL);
++					break;
++
++				case SSEQ_CMD_PRIO:
++					this->prio = this->ply->prio + read8(pData);
++					// Update here?
++					break;
++
++				case SSEQ_CMD_NOTEWAIT:
++					this->state.set(TS_NOTEWAIT, !!read8(pData));
++					break;
++
++				case SSEQ_CMD_TIE:
++					this->state.set(TS_TIEBIT, !!read8(pData));
++					this->ReleaseAllNotes();
++					break;
++
++				case SSEQ_CMD_EXPR:
++					this->expr = this->overriding.val(pData, read8);
++					this->updateFlags.set(TUF_VOL);
++					break;
++
++				case SSEQ_CMD_TEMPO:
++					this->ply->tempo = read16(pData);
++					break;
++
++				case SSEQ_CMD_END:
++					this->state.set(TS_END);
++					return;
++
++				case SSEQ_CMD_LOOPSTART:
++					value = this->overriding.val(pData, read8);
++					if (this->stackPos < FSS_TRACKSTACKSIZE)
++					{
++						this->loopCount[this->stackPos] = value;
++						this->stack[this->stackPos++] = StackValue(STACKTYPE_LOOP, *pData);
++					}
++					break;
++
++				case SSEQ_CMD_LOOPEND:
++					if (this->stackPos && this->stack[this->stackPos - 1].type == STACKTYPE_LOOP)
++					{
++						const uint8_t *rPos = this->stack[this->stackPos - 1].dest;
++						uint8_t &nR = this->loopCount[this->stackPos - 1];
++						uint8_t prevR = nR;
++						if (!prevR || --nR)
++							*pData = rPos;
++						else
++							--this->stackPos;
++					}
++					break;
++
++				//-----------------------------------------------------------------
++				// Tuning commands
++				//-----------------------------------------------------------------
++
++				case SSEQ_CMD_TRANSPOSE:
++					this->transpose = this->overriding.val(pData, read8);
++					break;
++
++				case SSEQ_CMD_PITCHBEND:
++					this->pitchBend = this->overriding.val(pData, read8);
++					this->updateFlags.set(TUF_TIMER);
++					break;
++
++				case SSEQ_CMD_PITCHBENDRANGE:
++					this->pitchBendRange = read8(pData);
++					this->updateFlags.set(TUF_TIMER);
++					break;
++
++				//-----------------------------------------------------------------
++				// Envelope-related commands
++				//-----------------------------------------------------------------
++
++				case SSEQ_CMD_ATTACK:
++					this->a = this->overriding.val(pData, read8);
++					break;
++
++				case SSEQ_CMD_DECAY:
++					this->d = this->overriding.val(pData, read8);
++					break;
++
++				case SSEQ_CMD_SUSTAIN:
++					this->s = this->overriding.val(pData, read8);
++					break;
++
++				case SSEQ_CMD_RELEASE:
++					this->r = this->overriding.val(pData, read8);
++					break;
++
++				//-----------------------------------------------------------------
++				// Portamento-related commands
++				//-----------------------------------------------------------------
++
++				case SSEQ_CMD_PORTAKEY:
++					this->portaKey = read8(pData) + this->transpose;
++					this->state.set(TS_PORTABIT);
++					// Update here?
++					break;
++
++				case SSEQ_CMD_PORTAFLAG:
++					this->state.set(TS_PORTABIT, !!read8(pData));
++					// Update here?
++					break;
++
++				case SSEQ_CMD_PORTATIME:
++					this->portaTime = this->overriding.val(pData, read8);
++					// Update here?
++					break;
++
++				case SSEQ_CMD_SWEEPPITCH:
++					this->sweepPitch = this->overriding.val(pData, read16);
++					// Update here?
++					break;
++
++				//-----------------------------------------------------------------
++				// Modulation-related commands
++				//-----------------------------------------------------------------
++
++				case SSEQ_CMD_MODDEPTH:
++					this->modDepth = this->overriding.val(pData, read8);
++					this->updateFlags.set(TUF_MOD);
++					break;
++
++				case SSEQ_CMD_MODSPEED:
++					this->modSpeed = this->overriding.val(pData, read8);
++					this->updateFlags.set(TUF_MOD);
++					break;
++
++				case SSEQ_CMD_MODTYPE:
++					this->modType = read8(pData);
++					this->updateFlags.set(TUF_MOD);
++					break;
++
++				case SSEQ_CMD_MODRANGE:
++					this->modRange = read8(pData);
++					this->updateFlags.set(TUF_MOD);
++					break;
++
++				case SSEQ_CMD_MODDELAY:
++					this->modDelay = this->overriding.val(pData, read16);
++					this->updateFlags.set(TUF_MOD);
++					break;
++
++				//-----------------------------------------------------------------
++				// Randomness-related commands
++				//-----------------------------------------------------------------
++
++				case SSEQ_CMD_RANDOM:
++				{
++					this->overriding() = true;
++					this->overriding.cmd = read8(pData);
++					if ((this->overriding.cmd >= SSEQ_CMD_SETVAR && this->overriding.cmd <= SSEQ_CMD_CMP_NE) || this->overriding.cmd < 0x80)
++						this->overriding.extraValue = read8(pData);
++					int16_t minVal = read16(pData);
++					int16_t maxVal = read16(pData);
++					this->overriding.value = (std::rand() % (maxVal - minVal + 1)) + minVal;
++					break;
++				}
++
++				//-----------------------------------------------------------------
++				// Variable-related commands
++				//-----------------------------------------------------------------
++
++				case SSEQ_CMD_FROMVAR:
++					this->overriding() = true;
++					this->overriding.cmd = read8(pData);
++					if ((this->overriding.cmd >= SSEQ_CMD_SETVAR && this->overriding.cmd <= SSEQ_CMD_CMP_NE) || this->overriding.cmd < 0x80)
++						this->overriding.extraValue = read8(pData);
++					this->overriding.value = this->ply->variables[read8(pData)];
++					break;
++
++				case SSEQ_CMD_SETVAR:
++				case SSEQ_CMD_ADDVAR:
++				case SSEQ_CMD_SUBVAR:
++				case SSEQ_CMD_MULVAR:
++				case SSEQ_CMD_DIVVAR:
++				case SSEQ_CMD_SHIFTVAR:
++				case SSEQ_CMD_RANDVAR:
++				{
++					int8_t varNo = this->overriding.val(pData, read8, true);
++					value = this->overriding.val(pData, read16);
++					if (cmd == SSEQ_CMD_DIVVAR && !value) // Division by 0, skip it to prevent crashing
++					break;
++					this->ply->variables[varNo] = VarFunc(cmd)(this->ply->variables[varNo], value);
++					break;
++				}
++
++				//-----------------------------------------------------------------
++				// Conditional-related commands
++				//-----------------------------------------------------------------
++
++				case SSEQ_CMD_CMP_EQ:
++				case SSEQ_CMD_CMP_GE:
++				case SSEQ_CMD_CMP_GT:
++				case SSEQ_CMD_CMP_LE:
++				case SSEQ_CMD_CMP_LT:
++				case SSEQ_CMD_CMP_NE:
++				{
++					int8_t varNo = this->overriding.val(pData, read8, true);
++					value = this->overriding.val(pData, read16);
++					this->lastComparisonResult = CompareFunc(cmd)(this->ply->variables[varNo], value);
++					break;
++				}
++
++				case SSEQ_CMD_IF:
++					if (!this->lastComparisonResult)
++					{
++						int nextCmd = read8(pData);
++						uint8_t cmdBytes = SseqCommandByteCount(nextCmd);
++						bool variableBytes = !!(cmdBytes & VariableByteCount);
++						bool extraByte = !!(cmdBytes & ExtraByteOnNoteOrVarOrCmp);
++						cmdBytes &= ~(VariableByteCount | ExtraByteOnNoteOrVarOrCmp);
++						if (extraByte)
++						{
++							int extraCmd = read8(pData);
++							if ((extraCmd >= SSEQ_CMD_SETVAR && extraCmd <= SSEQ_CMD_CMP_NE) || extraCmd < 0x80)
++								++cmdBytes;
++						}
++						*pData += cmdBytes;
++						if (variableBytes)
++							readvl(pData);
++					}
++					break;
++
++				default:
++					*pData += SseqCommandByteCount(cmd);
++			}
++		}
++
++		if (cmd != SSEQ_CMD_RANDOM && cmd != SSEQ_CMD_FROMVAR)
++			this->overriding() = false;
++	}
++}
+diff --git a/3rdparty/sseqplayer/Track.h b/3rdparty/sseqplayer/Track.h
+new file mode 100644
+index 000000000..41ab47cd6
+--- /dev/null
++++ b/3rdparty/sseqplayer/Track.h
+@@ -0,0 +1,96 @@
++/*
++ * SSEQ Player - Track structure
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-10-13
++ *
++ * Adapted from source code of FeOS Sound System
++ * By fincs
++ * https://github.com/fincs/FSS
++ */
++
++#pragma once
++
++#include <functional>
++#include <bitset>
++#include "consts.h"
++
++struct Player;
++
++enum StackType
++{
++	STACKTYPE_CALL,
++	STACKTYPE_LOOP
++};
++
++struct StackValue
++{
++	StackType type;
++	const uint8_t *dest;
++
++	StackValue() : type(STACKTYPE_CALL), dest(nullptr) { }
++	StackValue(StackType newType, const uint8_t *newDest) : type(newType), dest(newDest) { }
++};
++
++struct Override
++{
++	bool overriding;
++	int cmd;
++	int value;
++	int extraValue;
++
++	Override() : overriding(false) { }
++	bool operator()() const { return this->overriding; }
++	bool &operator()() { return this->overriding; }
++	int val(const uint8_t **pData, std::function<int (const uint8_t **)> reader, bool returnExtra = false)
++	{
++		if (this->overriding)
++			return returnExtra ? this->extraValue : this->value;
++		else
++			return reader(pData);
++	}
++};
++
++struct Track
++{
++	int8_t trackId;
++
++	std::bitset<TS_BITS> state;
++	uint8_t num, prio;
++	Player *ply;
++
++	const uint8_t *startPos;
++	const uint8_t *pos;
++	StackValue stack[FSS_TRACKSTACKSIZE];
++	uint8_t stackPos;
++	uint8_t loopCount[FSS_TRACKSTACKSIZE];
++	Override overriding;
++	bool lastComparisonResult;
++
++	int wait;
++	uint16_t patch;
++	uint8_t portaKey, portaTime;
++	int16_t sweepPitch;
++	uint8_t vol, expr;
++	int8_t pan; // -64..63
++	uint8_t pitchBendRange;
++	int8_t pitchBend;
++	int8_t transpose;
++
++	uint8_t a, d, s, r;
++
++	uint8_t modType, modSpeed, modDepth, modRange;
++	uint16_t modDelay;
++
++	std::bitset<TUF_BITS> updateFlags;
++
++	Track();
++
++	void Init(uint8_t handle, Player *ply, const uint8_t *pos, int n);
++	void Zero();
++	void ClearState();
++	void Free();
++	int NoteOn(int key, int vel, int len);
++	int NoteOnTie(int key, int vel);
++	void ReleaseAllNotes();
++	void Run();
++};
+diff --git a/3rdparty/sseqplayer/codecvt.h b/3rdparty/sseqplayer/codecvt.h
+new file mode 100644
+index 000000000..d7e1a8504
+--- /dev/null
++++ b/3rdparty/sseqplayer/codecvt.h
+@@ -0,0 +1,2098 @@
++// This comes from llvm's libcxx project. I've copied the code from there (with very minor modifications) for use with GCC and Clang when libcxx isn't being used.
++
++#if (defined(__GNUC__) || defined(__clang__)) && !defined(_LIBCPP_VERSION)
++#pragma once
++
++#include <locale>
++
++namespace std
++{
++
++enum codecvt_mode
++{
++	consume_header = 4,
++	generate_header = 2,
++	little_endian = 1
++};
++
++//                                     Valid UTF ranges
++//     UTF-32               UTF-16                          UTF-8               # of code points
++//                     first      second       first   second    third   fourth
++// 000000 - 00007F  0000 - 007F               00 - 7F                                 127
++// 000080 - 0007FF  0080 - 07FF               C2 - DF, 80 - BF                       1920
++// 000800 - 000FFF  0800 - 0FFF               E0 - E0, A0 - BF, 80 - BF              2048
++// 001000 - 00CFFF  1000 - CFFF               E1 - EC, 80 - BF, 80 - BF             49152
++// 00D000 - 00D7FF  D000 - D7FF               ED - ED, 80 - 9F, 80 - BF              2048
++// 00D800 - 00DFFF                invalid
++// 00E000 - 00FFFF  E000 - FFFF               EE - EF, 80 - BF, 80 - BF              8192
++// 010000 - 03FFFF  D800 - D8BF, DC00 - DFFF  F0 - F0, 90 - BF, 80 - BF, 80 - BF   196608
++// 040000 - 0FFFFF  D8C0 - DBBF, DC00 - DFFF  F1 - F3, 80 - BF, 80 - BF, 80 - BF   786432
++// 100000 - 10FFFF  DBC0 - DBFF, DC00 - DFFF  F4 - F4, 80 - 8F, 80 - BF, 80 - BF    65536
++
++namespace UnicodeConverters
++{
++	inline codecvt_base::result utf16_to_utf8(const uint16_t *frm, const uint16_t *frm_end, const uint16_t *&frm_nxt, uint8_t *to, uint8_t *to_end, uint8_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if (mode & generate_header)
++		{
++			if (to_end - to_nxt < 3)
++				return codecvt_base::partial;
++			*to_nxt++ = 0xEF;
++			*to_nxt++ = 0xBB;
++			*to_nxt++ = 0xBF;
++		}
++		for (; frm_nxt < frm_end; ++frm_nxt)
++		{
++			uint16_t wc1 = *frm_nxt;
++			if (wc1 > Maxcode)
++				return codecvt_base::error;
++			if (wc1 < 0x0080)
++			{
++				if (to_end - to_nxt < 1)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(wc1);
++			}
++			else if (wc1 < 0x0800)
++			{
++				if (to_end - to_nxt < 2)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(0xC0 | (wc1 >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc1 & 0x03F));
++			}
++			else if (wc1 < 0xD800)
++			{
++				if (to_end - to_nxt < 3)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(0xE0 | (wc1 >> 12));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | ((wc1 & 0x0FC0) >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc1 & 0x003F));
++			}
++			else if (wc1 < 0xDC00)
++			{
++				if (frm_end - frm_nxt < 2)
++					return codecvt_base::partial;
++				uint16_t wc2 = frm_nxt[1];
++				if ((wc2 & 0xFC00) != 0xDC00)
++					return codecvt_base::error;
++				if (to_end - to_nxt < 4)
++					return codecvt_base::partial;
++				if (((((static_cast<unsigned long>(wc1) & 0x03C0) >> 6) + 1) << 16) + ((static_cast<unsigned long>(wc1) & 0x003F) << 10) + (wc2 & 0x03FF) > Maxcode)
++					return codecvt_base::error;
++				++frm_nxt;
++				uint8_t z = ((wc1 & 0x03C0) >> 6) + 1;
++				*to_nxt++ = static_cast<uint8_t>(0xF0 | (z >> 2));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | ((z & 0x03) << 4) | ((wc1 & 0x003C) >> 2));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | ((wc1 & 0x0003) << 4) | ((wc2 & 0x03C0) >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc2 & 0x003F));
++			}
++			else if (wc1 < 0xE000)
++				return codecvt_base::error;
++			else
++			{
++				if (to_end - to_nxt < 3)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(0xE0 | (wc1 >> 12));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | ((wc1 & 0x0FC0) >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc1 & 0x003F));
++			}
++		}
++		return codecvt_base::ok;
++	}
++
++	inline codecvt_base::result utf16_to_utf8(const uint32_t *frm, const uint32_t *frm_end, const uint32_t *&frm_nxt, uint8_t *to, uint8_t *to_end, uint8_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if (mode & generate_header)
++		{
++			if (to_end - to_nxt < 3)
++				return codecvt_base::partial;
++			*to_nxt++ = 0xEF;
++			*to_nxt++ = 0xBB;
++			*to_nxt++ = 0xBF;
++		}
++		for (; frm_nxt < frm_end; ++frm_nxt)
++		{
++			uint16_t wc1 = static_cast<uint16_t>(*frm_nxt);
++			if (wc1 > Maxcode)
++				return codecvt_base::error;
++			if (wc1 < 0x0080)
++			{
++				if (to_end - to_nxt < 1)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(wc1);
++			}
++			else if (wc1 < 0x0800)
++			{
++				if (to_end - to_nxt < 2)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(0xC0 | (wc1 >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc1 & 0x03F));
++			}
++			else if (wc1 < 0xD800)
++			{
++				if (to_end - to_nxt < 3)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(0xE0 | (wc1 >> 12));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | ((wc1 & 0x0FC0) >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc1 & 0x003F));
++			}
++			else if (wc1 < 0xDC00)
++			{
++				if (frm_end - frm_nxt < 2)
++					return codecvt_base::partial;
++				uint16_t wc2 = static_cast<uint16_t>(frm_nxt[1]);
++				if ((wc2 & 0xFC00) != 0xDC00)
++					return codecvt_base::error;
++				if (to_end - to_nxt < 4)
++					return codecvt_base::partial;
++				if (((((static_cast<unsigned long>(wc1) & 0x03C0) >> 6) + 1) << 16) + ((static_cast<unsigned long>(wc1) & 0x003F) << 10) + (wc2 & 0x03FF) > Maxcode)
++					return codecvt_base::error;
++				++frm_nxt;
++				uint8_t z = ((wc1 & 0x03C0) >> 6) + 1;
++				*to_nxt++ = static_cast<uint8_t>(0xF0 | (z >> 2));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | ((z & 0x03) << 4) | ((wc1 & 0x003C) >> 2));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | ((wc1 & 0x0003) << 4) | ((wc2 & 0x03C0) >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc2 & 0x003F));
++			}
++			else if (wc1 < 0xE000)
++				return codecvt_base::error;
++			else
++			{
++				if (to_end - to_nxt < 3)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(0xE0 | (wc1 >> 12));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | ((wc1 & 0x0FC0) >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc1 & 0x003F));
++			}
++		}
++		return codecvt_base::ok;
++	}
++
++	inline codecvt_base::result utf8_to_utf16(const uint8_t *frm, const uint8_t *frm_end, const uint8_t *&frm_nxt, uint16_t *to, uint16_t *to_end, uint16_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 3 && frm_nxt[0] == 0xEF && frm_nxt[1] == 0xBB && frm_nxt[2] == 0xBF)
++			frm_nxt += 3;
++		for (; frm_nxt < frm_end && to_nxt < to_end; ++to_nxt)
++		{
++			uint8_t c1 = *frm_nxt;
++			if (c1 > Maxcode)
++				return codecvt_base::error;
++			if (c1 < 0x80)
++			{
++				*to_nxt = static_cast<uint16_t>(c1);
++				++frm_nxt;
++			}
++			else if (c1 < 0xC2)
++				return codecvt_base::error;
++			else if (c1 < 0xE0)
++			{
++				if (frm_end - frm_nxt < 2)
++					return codecvt_base::partial;
++				uint8_t c2 = frm_nxt[1];
++				if ((c2 & 0xC0) != 0x80)
++					return codecvt_base::error;
++				uint16_t t = static_cast<uint16_t>(((c1 & 0x1F) << 6) | (c2 & 0x3F));
++				if (t > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = t;
++				frm_nxt += 2;
++			}
++			else if (c1 < 0xF0)
++			{
++				if (frm_end - frm_nxt < 3)
++					return codecvt_base::partial;
++				uint8_t c2 = frm_nxt[1];
++				uint8_t c3 = frm_nxt[2];
++				switch (c1)
++				{
++					case 0xE0:
++						if ((c2 & 0xE0) != 0xA0)
++							return codecvt_base::error;
++						break;
++					case 0xED:
++						if ((c2 & 0xE0) != 0x80)
++							return codecvt_base::error;
++						break;
++					default:
++						if ((c2 & 0xC0) != 0x80)
++							return codecvt_base::error;
++				}
++				if ((c3 & 0xC0) != 0x80)
++					return codecvt_base::error;
++				uint16_t t = static_cast<uint16_t>(((c1 & 0x0F) << 12) | ((c2 & 0x3F) << 6) | (c3 & 0x3F));
++				if (t > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = t;
++				frm_nxt += 3;
++			}
++			else if (c1 < 0xF5)
++			{
++				if (frm_end - frm_nxt < 4)
++					return codecvt_base::partial;
++				uint8_t c2 = frm_nxt[1];
++				uint8_t c3 = frm_nxt[2];
++				uint8_t c4 = frm_nxt[3];
++				switch (c1)
++				{
++					case 0xF0:
++						if (c2 < 0x90 || c2 > 0xBF)
++							return codecvt_base::error;
++						break;
++					case 0xF4:
++						if ((c2 & 0xF0) != 0x80)
++							return codecvt_base::error;
++						break;
++					default:
++						if ((c2 & 0xC0) != 0x80)
++							return codecvt_base::error;
++				}
++				if ((c3 & 0xC0) != 0x80 || (c4 & 0xC0) != 0x80)
++					return codecvt_base::error;
++				if (to_end - to_nxt < 2)
++					return codecvt_base::partial;
++				if ((((static_cast<unsigned long>(c1) & 7) << 18) + ((static_cast<unsigned long>(c2) & 0x3F) << 12) + ((static_cast<unsigned long>(c3) & 0x3F) << 6) + (c4 & 0x3F)) > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = static_cast<uint16_t>(0xD800 | (((((c1 & 0x07) << 2) | ((c2 & 0x30) >> 4)) - 1) << 6) | ((c2 & 0x0F) << 2) | ((c3 & 0x30) >> 4));
++				*++to_nxt = static_cast<uint16_t>(0xDC00 | ((c3 & 0x0F) << 6) | (c4 & 0x3F));
++				frm_nxt += 4;
++			}
++			else
++				return codecvt_base::error;
++		}
++		return frm_nxt < frm_end ? codecvt_base::partial : codecvt_base::ok;
++	}
++
++	inline codecvt_base::result utf8_to_utf16(const uint8_t *frm, const uint8_t *frm_end, const uint8_t *&frm_nxt, uint32_t *to, uint32_t *to_end, uint32_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 3 && frm_nxt[0] == 0xEF && frm_nxt[1] == 0xBB && frm_nxt[2] == 0xBF)
++			frm_nxt += 3;
++		for (; frm_nxt < frm_end && to_nxt < to_end; ++to_nxt)
++		{
++			uint8_t c1 = *frm_nxt;
++			if (c1 > Maxcode)
++				return codecvt_base::error;
++			if (c1 < 0x80)
++			{
++				*to_nxt = static_cast<uint32_t>(c1);
++				++frm_nxt;
++			}
++			else if (c1 < 0xC2)
++				return codecvt_base::error;
++			else if (c1 < 0xE0)
++			{
++				if (frm_end - frm_nxt < 2)
++					return codecvt_base::partial;
++				uint8_t c2 = frm_nxt[1];
++				if ((c2 & 0xC0) != 0x80)
++					return codecvt_base::error;
++				uint16_t t = static_cast<uint16_t>(((c1 & 0x1F) << 6) | (c2 & 0x3F));
++				if (t > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = static_cast<uint32_t>(t);
++				frm_nxt += 2;
++			}
++			else if (c1 < 0xF0)
++			{
++				if (frm_end - frm_nxt < 3)
++					return codecvt_base::partial;
++				uint8_t c2 = frm_nxt[1];
++				uint8_t c3 = frm_nxt[2];
++				switch (c1)
++				{
++					case 0xE0:
++						if ((c2 & 0xE0) != 0xA0)
++							return codecvt_base::error;
++						break;
++					case 0xED:
++						if ((c2 & 0xE0) != 0x80)
++							return codecvt_base::error;
++						break;
++					default:
++						if ((c2 & 0xC0) != 0x80)
++							return codecvt_base::error;
++				}
++				if ((c3 & 0xC0) != 0x80)
++					return codecvt_base::error;
++				uint16_t t = static_cast<uint16_t>(((c1 & 0x0F) << 12) | ((c2 & 0x3F) << 6) | (c3 & 0x3F));
++				if (t > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = static_cast<uint32_t>(t);
++				frm_nxt += 3;
++			}
++			else if (c1 < 0xF5)
++			{
++				if (frm_end - frm_nxt < 4)
++					return codecvt_base::partial;
++				uint8_t c2 = frm_nxt[1];
++				uint8_t c3 = frm_nxt[2];
++				uint8_t c4 = frm_nxt[3];
++				switch (c1)
++				{
++					case 0xF0:
++						if (c2 < 0x90 || c2 > 0xBF)
++							return codecvt_base::error;
++						break;
++					case 0xF4:
++						if ((c2 & 0xF0) != 0x80)
++							return codecvt_base::error;
++						break;
++					default:
++						if ((c2 & 0xC0) != 0x80)
++							return codecvt_base::error;
++				}
++				if ((c3 & 0xC0) != 0x80 || (c4 & 0xC0) != 0x80)
++					return codecvt_base::error;
++				if (to_end - to_nxt < 2)
++					return codecvt_base::partial;
++				if ((((static_cast<unsigned long>(c1) & 7) << 18) + ((static_cast<unsigned long>(c2) & 0x3F) << 12) + ((static_cast<unsigned long>(c3) & 0x3F) << 6) + (c4 & 0x3F)) > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = static_cast<uint32_t>(0xD800 | (((((c1 & 0x07) << 2) | ((c2 & 0x30) >> 4)) - 1) << 6) | ((c2 & 0x0F) << 2) | ((c3 & 0x30) >> 4));
++				*++to_nxt = static_cast<uint32_t>( 0xDC00 | ((c3 & 0x0F) << 6) | (c4 & 0x3F));
++				frm_nxt += 4;
++			}
++			else
++				return codecvt_base::error;
++		}
++		return frm_nxt < frm_end ? codecvt_base::partial : codecvt_base::ok;
++	}
++
++	inline int utf8_to_utf16_length(const uint8_t *frm, const uint8_t *frm_end, size_t mx, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		auto frm_nxt = frm;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 3 && frm_nxt[0] == 0xEF && frm_nxt[1] == 0xBB && frm_nxt[2] == 0xBF)
++			frm_nxt += 3;
++		for (size_t nchar16_t = 0; frm_nxt < frm_end && nchar16_t < mx; ++nchar16_t)
++		{
++			uint8_t c1 = *frm_nxt;
++			if (c1 > Maxcode)
++				break;
++			if (c1 < 0x80)
++				++frm_nxt;
++			else if (c1 < 0xC2)
++				break;
++			else if (c1 < 0xE0)
++			{
++				if (frm_end - frm_nxt < 2 || (frm_nxt[1] & 0xC0) != 0x80)
++					break;
++				uint16_t t = static_cast<uint16_t>(((c1 & 0x1F) << 6) | (frm_nxt[1] & 0x3F));
++				if (t > Maxcode)
++					break;
++				frm_nxt += 2;
++			}
++			else if (c1 < 0xF0)
++			{
++				if (frm_end - frm_nxt < 3)
++					break;
++				uint8_t c2 = frm_nxt[1];
++				uint8_t c3 = frm_nxt[2];
++				switch (c1)
++				{
++					case 0xE0:
++						if ((c2 & 0xE0) != 0xA0)
++							return static_cast<int>(frm_nxt - frm);
++						break;
++					case 0xED:
++						if ((c2 & 0xE0) != 0x80)
++							return static_cast<int>(frm_nxt - frm);
++						break;
++					default:
++						if ((c2 & 0xC0) != 0x80)
++							return static_cast<int>(frm_nxt - frm);
++				}
++				if ((c3 & 0xC0) != 0x80)
++					break;
++				if ((((c1 & 0x0Fu) << 12) | ((c2 & 0x3Fu) << 6) | (c3 & 0x3Fu)) > Maxcode)
++					break;
++				frm_nxt += 3;
++			}
++			else if (c1 < 0xF5)
++			{
++				if (frm_end - frm_nxt < 4 || mx - nchar16_t < 2)
++					break;
++				uint8_t c2 = frm_nxt[1];
++				uint8_t c3 = frm_nxt[2];
++				uint8_t c4 = frm_nxt[3];
++				switch (c1)
++				{
++					case 0xF0:
++						if (c2 < 0x90 || c2 > 0xBF)
++							return static_cast<int>(frm_nxt - frm);
++						break;
++					case 0xF4:
++						if ((c2 & 0xF0) != 0x80)
++							return static_cast<int>(frm_nxt - frm);
++						break;
++					default:
++						if ((c2 & 0xC0) != 0x80)
++							return static_cast<int>(frm_nxt - frm);
++				}
++				if ((c3 & 0xC0) != 0x80 || (c4 & 0xC0) != 0x80)
++					break;
++				if ((((static_cast<unsigned long>(c1) & 7) << 18) + ((static_cast<unsigned long>(c2) & 0x3F) << 12) + ((static_cast<unsigned long>(c3) & 0x3F) << 6) + (c4 & 0x3F)) > Maxcode)
++					break;
++				++nchar16_t;
++				frm_nxt += 4;
++			}
++			else
++				break;
++		}
++		return static_cast<int>(frm_nxt - frm);
++	}
++
++	inline codecvt_base::result ucs4_to_utf8(const uint32_t *frm, const uint32_t *frm_end, const uint32_t *&frm_nxt, uint8_t *to, uint8_t *to_end, uint8_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if (mode & generate_header)
++		{
++			if (to_end - to_nxt < 3)
++				return codecvt_base::partial;
++			*to_nxt++ = 0xEF;
++			*to_nxt++ = 0xBB;
++			*to_nxt++ = 0xBF;
++		}
++		for (; frm_nxt < frm_end; ++frm_nxt)
++		{
++			uint32_t wc = *frm_nxt;
++			if ((wc & 0xFFFFF800) == 0x00D800 || wc > Maxcode)
++				return codecvt_base::error;
++			if (wc < 0x000080)
++			{
++				if (to_end - to_nxt < 1)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(wc);
++			}
++			else if (wc < 0x000800)
++			{
++				if (to_end - to_nxt < 2)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(0xC0 | (wc >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc & 0x03F));
++			}
++			else if (wc < 0x010000)
++			{
++				if (to_end - to_nxt < 3)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(0xE0 | (wc >> 12));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | ((wc & 0x0FC0) >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc & 0x003F));
++			}
++			else // if (wc < 0x110000)
++			{
++				if (to_end - to_nxt < 4)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(0xF0 | (wc >> 18));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | ((wc & 0x03F000) >> 12));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | ((wc & 0x000FC0) >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc & 0x00003F));
++			}
++		}
++		return codecvt_base::ok;
++	}
++
++	inline codecvt_base::result utf8_to_ucs4(const uint8_t *frm, const uint8_t *frm_end, const uint8_t *&frm_nxt, uint32_t *to, uint32_t *to_end, uint32_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 3 && frm_nxt[0] == 0xEF && frm_nxt[1] == 0xBB && frm_nxt[2] == 0xBF)
++			frm_nxt += 3;
++		for (; frm_nxt < frm_end && to_nxt < to_end; ++to_nxt)
++		{
++			uint8_t c1 = *frm_nxt;
++			if (c1 < 0x80)
++			{
++				if (c1 > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = static_cast<uint32_t>(c1);
++				++frm_nxt;
++			}
++			else if (c1 < 0xC2)
++				return codecvt_base::error;
++			else if (c1 < 0xE0)
++			{
++				if (frm_end - frm_nxt < 2)
++					return codecvt_base::partial;
++				uint8_t c2 = frm_nxt[1];
++				if ((c2 & 0xC0) != 0x80)
++					return codecvt_base::error;
++				uint32_t t = static_cast<uint32_t>(((c1 & 0x1F) << 6) | (c2 & 0x3F));
++				if (t > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = t;
++				frm_nxt += 2;
++			}
++			else if (c1 < 0xF0)
++			{
++				if (frm_end - frm_nxt < 3)
++					return codecvt_base::partial;
++				uint8_t c2 = frm_nxt[1];
++				uint8_t c3 = frm_nxt[2];
++				switch (c1)
++				{
++					case 0xE0:
++						if ((c2 & 0xE0) != 0xA0)
++							return codecvt_base::error;
++						break;
++					case 0xED:
++						if ((c2 & 0xE0) != 0x80)
++							return codecvt_base::error;
++						break;
++					default:
++						if ((c2 & 0xC0) != 0x80)
++							return codecvt_base::error;
++				}
++				if ((c3 & 0xC0) != 0x80)
++					return codecvt_base::error;
++				uint32_t t = static_cast<uint32_t>(((c1 & 0x0F) << 12) | ((c2 & 0x3F) << 6) |  (c3 & 0x3F));
++				if (t > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = t;
++				frm_nxt += 3;
++			}
++			else if (c1 < 0xF5)
++			{
++				if (frm_end - frm_nxt < 4)
++					return codecvt_base::partial;
++				uint8_t c2 = frm_nxt[1];
++				uint8_t c3 = frm_nxt[2];
++				uint8_t c4 = frm_nxt[3];
++				switch (c1)
++				{
++					case 0xF0:
++						if (c2 < 0x90 || c2 > 0xBF)
++							return codecvt_base::error;
++						break;
++					case 0xF4:
++						if ((c2 & 0xF0) != 0x80)
++							return codecvt_base::error;
++						break;
++					default:
++						if ((c2 & 0xC0) != 0x80)
++							return codecvt_base::error;
++				}
++				if ((c3 & 0xC0) != 0x80 || (c4 & 0xC0) != 0x80)
++					return codecvt_base::error;
++				uint32_t t = static_cast<uint32_t>(((c1 & 0x07) << 18) | ((c2 & 0x3F) << 12) | ((c3 & 0x3F) << 6) |  (c4 & 0x3F));
++				if (t > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = t;
++				frm_nxt += 4;
++			}
++			else
++				return codecvt_base::error;
++		}
++		return frm_nxt < frm_end ? codecvt_base::partial : codecvt_base::ok;
++	}
++
++	inline int utf8_to_ucs4_length(const uint8_t *frm, const uint8_t *frm_end, size_t mx, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		auto frm_nxt = frm;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 3 && frm_nxt[0] == 0xEF && frm_nxt[1] == 0xBB && frm_nxt[2] == 0xBF)
++			frm_nxt += 3;
++		for (size_t nchar32_t = 0; frm_nxt < frm_end && nchar32_t < mx; ++nchar32_t)
++		{
++			uint8_t c1 = *frm_nxt;
++			if (c1 < 0x80)
++			{
++				if (c1 > Maxcode)
++					break;
++				++frm_nxt;
++			}
++			else if (c1 < 0xC2)
++				break;
++			else if (c1 < 0xE0)
++			{
++				if (frm_end - frm_nxt < 2 || (frm_nxt[1] & 0xC0) != 0x80)
++					break;
++				if ((((c1 & 0x1Fu) << 6) | (frm_nxt[1] & 0x3Fu)) > Maxcode)
++					break;
++				frm_nxt += 2;
++			}
++			else if (c1 < 0xF0)
++			{
++				if (frm_end - frm_nxt < 3)
++					break;
++				uint8_t c2 = frm_nxt[1];
++				uint8_t c3 = frm_nxt[2];
++				switch (c1)
++				{
++					case 0xE0:
++						if ((c2 & 0xE0) != 0xA0)
++							return static_cast<int>(frm_nxt - frm);
++						break;
++					case 0xED:
++						if ((c2 & 0xE0) != 0x80)
++							return static_cast<int>(frm_nxt - frm);
++						break;
++					default:
++						if ((c2 & 0xC0) != 0x80)
++							return static_cast<int>(frm_nxt - frm);
++				}
++				if ((c3 & 0xC0) != 0x80)
++					break;
++				if ((((c1 & 0x0Fu) << 12) | ((c2 & 0x3Fu) << 6) | (c3 & 0x3Fu)) > Maxcode)
++					break;
++				frm_nxt += 3;
++			}
++			else if (c1 < 0xF5)
++			{
++				if (frm_end - frm_nxt < 4)
++					break;
++				uint8_t c2 = frm_nxt[1];
++				uint8_t c3 = frm_nxt[2];
++				uint8_t c4 = frm_nxt[3];
++				switch (c1)
++				{
++					case 0xF0:
++						if (c2 < 0x90 || c2 > 0xBF)
++							return static_cast<int>(frm_nxt - frm);
++						break;
++					case 0xF4:
++						if ((c2 & 0xF0) != 0x80)
++							return static_cast<int>(frm_nxt - frm);
++						break;
++					default:
++						if ((c2 & 0xC0) != 0x80)
++							return static_cast<int>(frm_nxt - frm);
++				}
++				if ((c3 & 0xC0) != 0x80 || (c4 & 0xC0) != 0x80)
++					break;
++				if ((((c1 & 0x07u) << 18) | ((c2 & 0x3Fu) << 12) | ((c3 & 0x3Fu) << 6)  |  (c4 & 0x3Fu)) > Maxcode)
++					break;
++				frm_nxt += 4;
++			}
++			else
++				break;
++		}
++		return static_cast<int>(frm_nxt - frm);
++	}
++
++	inline codecvt_base::result ucs2_to_utf8(const uint16_t *frm, const uint16_t *frm_end, const uint16_t *&frm_nxt, uint8_t *to, uint8_t *to_end, uint8_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if (mode & generate_header)
++		{
++			if (to_end - to_nxt < 3)
++				return codecvt_base::partial;
++			*to_nxt++ = 0xEF;
++			*to_nxt++ = 0xBB;
++			*to_nxt++ = 0xBF;
++		}
++		for (; frm_nxt < frm_end; ++frm_nxt)
++		{
++			uint16_t wc = *frm_nxt;
++			if ((wc & 0xF800) == 0xD800 || wc > Maxcode)
++				return codecvt_base::error;
++			if (wc < 0x0080)
++			{
++				if (to_end - to_nxt < 1)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(wc);
++			}
++			else if (wc < 0x0800)
++			{
++				if (to_end - to_nxt < 2)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(0xC0 | (wc >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc & 0x03F));
++			}
++			else // if (wc <= 0xFFFF)
++			{
++				if (to_end - to_nxt < 3)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(0xE0 | (wc >> 12));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | ((wc & 0x0FC0) >> 6));
++				*to_nxt++ = static_cast<uint8_t>(0x80 | (wc & 0x003F));
++			}
++		}
++		return codecvt_base::ok;
++	}
++
++	inline codecvt_base::result utf8_to_ucs2(const uint8_t *frm, const uint8_t *frm_end, const uint8_t *&frm_nxt, uint16_t *to, uint16_t *to_end, uint16_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 3 && frm_nxt[0] == 0xEF && frm_nxt[1] == 0xBB && frm_nxt[2] == 0xBF)
++			frm_nxt += 3;
++		for (; frm_nxt < frm_end && to_nxt < to_end; ++to_nxt)
++		{
++			uint8_t c1 = *frm_nxt;
++			if (c1 < 0x80)
++			{
++				if (c1 > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = static_cast<uint16_t>(c1);
++				++frm_nxt;
++			}
++			else if (c1 < 0xC2)
++				return codecvt_base::error;
++			else if (c1 < 0xE0)
++			{
++				if (frm_end - frm_nxt < 2)
++					return codecvt_base::partial;
++				uint8_t c2 = frm_nxt[1];
++				if ((c2 & 0xC0) != 0x80)
++					return codecvt_base::error;
++				uint16_t t = static_cast<uint16_t>(((c1 & 0x1F) << 6) | (c2 & 0x3F));
++				if (t > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = t;
++				frm_nxt += 2;
++			}
++			else if (c1 < 0xF0)
++			{
++				if (frm_end - frm_nxt < 3)
++					return codecvt_base::partial;
++				uint8_t c2 = frm_nxt[1];
++				uint8_t c3 = frm_nxt[2];
++				switch (c1)
++				{
++					case 0xE0:
++						if ((c2 & 0xE0) != 0xA0)
++							return codecvt_base::error;
++						break;
++					case 0xED:
++						if ((c2 & 0xE0) != 0x80)
++							return codecvt_base::error;
++						break;
++					default:
++						if ((c2 & 0xC0) != 0x80)
++							return codecvt_base::error;
++				}
++				if ((c3 & 0xC0) != 0x80)
++					return codecvt_base::error;
++				uint16_t t = static_cast<uint16_t>(((c1 & 0x0F) << 12) | ((c2 & 0x3F) << 6) |  (c3 & 0x3F));
++				if (t > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = t;
++				frm_nxt += 3;
++			}
++			else
++				return codecvt_base::error;
++		}
++		return frm_nxt < frm_end ? codecvt_base::partial : codecvt_base::ok;
++	}
++
++	inline int utf8_to_ucs2_length(const uint8_t *frm, const uint8_t *frm_end, size_t mx, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		auto frm_nxt = frm;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 3 && frm_nxt[0] == 0xEF && frm_nxt[1] == 0xBB && frm_nxt[2] == 0xBF)
++			frm_nxt += 3;
++		for (size_t nchar32_t = 0; frm_nxt < frm_end && nchar32_t < mx; ++nchar32_t)
++		{
++			uint8_t c1 = *frm_nxt;
++			if (c1 < 0x80)
++			{
++				if (c1 > Maxcode)
++					break;
++				++frm_nxt;
++			}
++			else if (c1 < 0xC2)
++				break;
++			else if (c1 < 0xE0)
++			{
++				if (frm_end - frm_nxt < 2 || (frm_nxt[1] & 0xC0) != 0x80)
++					break;
++				if ((((c1 & 0x1Fu) << 6) | (frm_nxt[1] & 0x3Fu)) > Maxcode)
++					break;
++				frm_nxt += 2;
++			}
++			else if (c1 < 0xF0)
++			{
++				if (frm_end - frm_nxt < 3)
++					break;
++				uint8_t c2 = frm_nxt[1];
++				uint8_t c3 = frm_nxt[2];
++				switch (c1)
++				{
++					case 0xE0:
++						if ((c2 & 0xE0) != 0xA0)
++							return static_cast<int>(frm_nxt - frm);
++						break;
++					case 0xED:
++						if ((c2 & 0xE0) != 0x80)
++							return static_cast<int>(frm_nxt - frm);
++						break;
++					default:
++						if ((c2 & 0xC0) != 0x80)
++							return static_cast<int>(frm_nxt - frm);
++				}
++				if ((c3 & 0xC0) != 0x80)
++					break;
++				if ((((c1 & 0x0Fu) << 12) | ((c2 & 0x3Fu) << 6) | (c3 & 0x3Fu)) > Maxcode)
++					break;
++				frm_nxt += 3;
++			}
++			else
++				break;
++		}
++		return static_cast<int>(frm_nxt - frm);
++	}
++
++	inline codecvt_base::result ucs4_to_utf16be(const uint32_t *frm, const uint32_t *frm_end, const uint32_t *&frm_nxt, uint8_t *to, uint8_t *to_end, uint8_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if (mode & generate_header)
++		{
++			if (to_end - to_nxt < 2)
++				return codecvt_base::partial;
++			*to_nxt++ = 0xFE;
++			*to_nxt++ = 0xFF;
++		}
++		for (; frm_nxt < frm_end; ++frm_nxt)
++		{
++			uint32_t wc = *frm_nxt;
++			if ((wc & 0xFFFFF800) == 0x00D800 || wc > Maxcode)
++				return codecvt_base::error;
++			if (wc < 0x010000)
++			{
++				if (to_end - to_nxt < 2)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(wc >> 8);
++				*to_nxt++ = static_cast<uint8_t>(wc);
++			}
++			else
++			{
++				if (to_end - to_nxt < 4)
++					return codecvt_base::partial;
++				uint16_t t = static_cast<uint16_t>(0xD800 | ((((wc & 0x1F0000) >> 16) - 1) << 6) | ((wc & 0x00FC00) >> 10));
++				*to_nxt++ = static_cast<uint8_t>(t >> 8);
++				*to_nxt++ = static_cast<uint8_t>(t);
++				t = static_cast<uint16_t>(0xDC00 | (wc & 0x03FF));
++				*to_nxt++ = static_cast<uint8_t>(t >> 8);
++				*to_nxt++ = static_cast<uint8_t>(t);
++			}
++		}
++		return codecvt_base::ok;
++	}
++
++	inline codecvt_base::result utf16be_to_ucs4(const uint8_t *frm, const uint8_t *frm_end, const uint8_t *&frm_nxt, uint32_t *to, uint32_t *to_end, uint32_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 2 && frm_nxt[0] == 0xFE && frm_nxt[1] == 0xFF)
++			frm_nxt += 2;
++		for (; frm_nxt < frm_end - 1 && to_nxt < to_end; ++to_nxt)
++		{
++			uint16_t c1 = static_cast<uint16_t>((frm_nxt[0] << 8) | frm_nxt[1]);
++			if ((c1 & 0xFC00) == 0xDC00)
++				return codecvt_base::error;
++			if ((c1 & 0xFC00) != 0xD800)
++			{
++				if (c1 > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = static_cast<uint32_t>(c1);
++				frm_nxt += 2;
++			}
++			else
++			{
++				if (frm_end - frm_nxt < 4)
++					return codecvt_base::partial;
++				uint16_t c2 = static_cast<uint16_t>((frm_nxt[2] << 8) | frm_nxt[3]);
++				if ((c2 & 0xFC00) != 0xDC00)
++					return codecvt_base::error;
++				uint32_t t = static_cast<uint32_t>(((((c1 & 0x03C0) >> 6) + 1) << 16) | ((c1 & 0x003F) << 10) | (c2 & 0x03FF));
++				if (t > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = t;
++				frm_nxt += 4;
++			}
++		}
++		return frm_nxt < frm_end ? codecvt_base::partial : codecvt_base::ok;
++	}
++
++	inline int utf16be_to_ucs4_length(const uint8_t *frm, const uint8_t *frm_end, size_t mx, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		auto frm_nxt = frm;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 2 && frm_nxt[0] == 0xFE && frm_nxt[1] == 0xFF)
++			frm_nxt += 2;
++		for (size_t nchar32_t = 0; frm_nxt < frm_end - 1 && nchar32_t < mx; ++nchar32_t)
++		{
++			uint16_t c1 = static_cast<uint16_t>((frm_nxt[0] << 8) | frm_nxt[1]);
++			if ((c1 & 0xFC00) == 0xDC00)
++				break;
++			if ((c1 & 0xFC00) != 0xD800)
++			{
++				if (c1 > Maxcode)
++					break;
++				frm_nxt += 2;
++			}
++			else
++			{
++				if (frm_end - frm_nxt < 4)
++					break;
++				uint16_t c2 = static_cast<uint16_t>((frm_nxt[2] << 8) | frm_nxt[3]);
++				if ((c2 & 0xFC00) != 0xDC00)
++					break;
++				uint32_t t = static_cast<uint32_t>(((((c1 & 0x03C0) >> 6) + 1) << 16) | ((c1 & 0x003F) << 10) | (c2 & 0x03FF));
++				if (t > Maxcode)
++					break;
++				frm_nxt += 4;
++			}
++		}
++		return static_cast<int>(frm_nxt - frm);
++	}
++
++	inline codecvt_base::result ucs4_to_utf16le(const uint32_t *frm, const uint32_t *frm_end, const uint32_t *&frm_nxt, uint8_t *to, uint8_t *to_end, uint8_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if (mode & generate_header)
++		{
++			if (to_end - to_nxt < 2)
++				return codecvt_base::partial;
++			*to_nxt++ = 0xFF;
++			*to_nxt++ = 0xFE;
++		}
++		for (; frm_nxt < frm_end; ++frm_nxt)
++		{
++			uint32_t wc = *frm_nxt;
++			if ((wc & 0xFFFFF800) == 0x00D800 || wc > Maxcode)
++				return codecvt_base::error;
++			if (wc < 0x010000)
++			{
++				if (to_end - to_nxt < 2)
++					return codecvt_base::partial;
++				*to_nxt++ = static_cast<uint8_t>(wc);
++				*to_nxt++ = static_cast<uint8_t>(wc >> 8);
++			}
++			else
++			{
++				if (to_end - to_nxt < 4)
++					return codecvt_base::partial;
++				uint16_t t = static_cast<uint16_t>(0xD800 | ((((wc & 0x1F0000) >> 16) - 1) << 6) | ((wc & 0x00FC00) >> 10));
++				*to_nxt++ = static_cast<uint8_t>(t);
++				*to_nxt++ = static_cast<uint8_t>(t >> 8);
++				t = static_cast<uint16_t>(0xDC00 | (wc & 0x03FF));
++				*to_nxt++ = static_cast<uint8_t>(t);
++				*to_nxt++ = static_cast<uint8_t>(t >> 8);
++			}
++		}
++		return codecvt_base::ok;
++	}
++
++	inline codecvt_base::result utf16le_to_ucs4(const uint8_t *frm, const uint8_t *frm_end, const uint8_t *&frm_nxt, uint32_t *to, uint32_t *to_end, uint32_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 2 && frm_nxt[0] == 0xFF && frm_nxt[1] == 0xFE)
++			frm_nxt += 2;
++		for (; frm_nxt < frm_end - 1 && to_nxt < to_end; ++to_nxt)
++		{
++			uint16_t c1 = static_cast<uint16_t>((frm_nxt[1] << 8) | frm_nxt[0]);
++			if ((c1 & 0xFC00) == 0xDC00)
++				return codecvt_base::error;
++			if ((c1 & 0xFC00) != 0xD800)
++			{
++				if (c1 > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = static_cast<uint32_t>(c1);
++				frm_nxt += 2;
++			}
++			else
++			{
++				if (frm_end - frm_nxt < 4)
++					return codecvt_base::partial;
++				uint16_t c2 = static_cast<uint16_t>((frm_nxt[3] << 8) | frm_nxt[2]);
++				if ((c2 & 0xFC00) != 0xDC00)
++					return codecvt_base::error;
++				uint32_t t = static_cast<uint32_t>(((((c1 & 0x03C0) >> 6) + 1) << 16) | ((c1 & 0x003F) << 10) | (c2 & 0x03FF));
++				if (t > Maxcode)
++					return codecvt_base::error;
++				*to_nxt = t;
++				frm_nxt += 4;
++			}
++		}
++		return frm_nxt < frm_end ? codecvt_base::partial : codecvt_base::ok;
++	}
++
++	inline int utf16le_to_ucs4_length(const uint8_t *frm, const uint8_t *frm_end, size_t mx, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		auto frm_nxt = frm;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 2 && frm_nxt[0] == 0xFF && frm_nxt[1] == 0xFE)
++			frm_nxt += 2;
++		for (size_t nchar32_t = 0; frm_nxt < frm_end - 1 && nchar32_t < mx; ++nchar32_t)
++		{
++			uint16_t c1 = static_cast<uint16_t>((frm_nxt[1] << 8) | frm_nxt[0]);
++			if ((c1 & 0xFC00) == 0xDC00)
++				break;
++			if ((c1 & 0xFC00) != 0xD800)
++			{
++				if (c1 > Maxcode)
++					break;
++				frm_nxt += 2;
++			}
++			else
++			{
++				if (frm_end - frm_nxt < 4)
++					break;
++				uint16_t c2 = static_cast<uint16_t>((frm_nxt[3] << 8) | frm_nxt[2]);
++				if ((c2 & 0xFC00) != 0xDC00)
++					break;
++				uint32_t t = static_cast<uint32_t>(((((c1 & 0x03C0) >> 6) + 1) << 16) | ((c1 & 0x003F) << 10) | (c2 & 0x03FF));
++				if (t > Maxcode)
++					break;
++				frm_nxt += 4;
++			}
++		}
++		return static_cast<int>(frm_nxt - frm);
++	}
++
++	inline codecvt_base::result ucs2_to_utf16be(const uint16_t *frm, const uint16_t *frm_end, const uint16_t *&frm_nxt, uint8_t *to, uint8_t *to_end, uint8_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if (mode & generate_header)
++		{
++			if (to_end - to_nxt < 2)
++				return codecvt_base::partial;
++			*to_nxt++ = 0xFE;
++			*to_nxt++ = 0xFF;
++		}
++		for (; frm_nxt < frm_end; ++frm_nxt)
++		{
++			uint16_t wc = *frm_nxt;
++			if ((wc & 0xF800) == 0xD800 || wc > Maxcode)
++				return codecvt_base::error;
++			if (to_end - to_nxt < 2)
++				return codecvt_base::partial;
++			*to_nxt++ = static_cast<uint8_t>(wc >> 8);
++			*to_nxt++ = static_cast<uint8_t>(wc);
++		}
++		return codecvt_base::ok;
++	}
++
++	inline codecvt_base::result utf16be_to_ucs2(const uint8_t *frm, const uint8_t *frm_end, const uint8_t *&frm_nxt, uint16_t *to, uint16_t *to_end, uint16_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 2 && frm_nxt[0] == 0xFE && frm_nxt[1] == 0xFF)
++			frm_nxt += 2;
++		for (; frm_nxt < frm_end - 1 && to_nxt < to_end; ++to_nxt)
++		{
++			uint16_t c1 = static_cast<uint16_t>((frm_nxt[0] << 8) | frm_nxt[1]);
++			if ((c1 & 0xF800) == 0xD800 || c1 > Maxcode)
++				return codecvt_base::error;
++			*to_nxt = c1;
++			frm_nxt += 2;
++		}
++		return frm_nxt < frm_end ? codecvt_base::partial : codecvt_base::ok;
++	}
++
++	inline int utf16be_to_ucs2_length(const uint8_t *frm, const uint8_t *frm_end, size_t mx, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		auto frm_nxt = frm;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 2 && frm_nxt[0] == 0xFE && frm_nxt[1] == 0xFF)
++			frm_nxt += 2;
++		for (size_t nchar16_t = 0; frm_nxt < frm_end - 1 && nchar16_t < mx; ++nchar16_t)
++		{
++			uint16_t c1 = static_cast<uint16_t>((frm_nxt[0] << 8) | frm_nxt[1]);
++			if ((c1 & 0xF800) == 0xD800 || c1 > Maxcode)
++				break;
++			frm_nxt += 2;
++		}
++		return static_cast<int>(frm_nxt - frm);
++	}
++
++	inline codecvt_base::result ucs2_to_utf16le(const uint16_t *frm, const uint16_t *frm_end, const uint16_t *&frm_nxt, uint8_t *to, uint8_t *to_end, uint8_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if (mode & generate_header)
++		{
++			if (to_end - to_nxt < 2)
++				return codecvt_base::partial;
++			*to_nxt++ = 0xFF;
++			*to_nxt++ = 0xFE;
++		}
++		for (; frm_nxt < frm_end; ++frm_nxt)
++		{
++			uint16_t wc = *frm_nxt;
++			if ((wc & 0xF800) == 0xD800 || wc > Maxcode)
++				return codecvt_base::error;
++			if (to_end - to_nxt < 2)
++				return codecvt_base::partial;
++			*to_nxt++ = static_cast<uint8_t>(wc);
++			*to_nxt++ = static_cast<uint8_t>(wc >> 8);
++		}
++		return codecvt_base::ok;
++	}
++
++	inline codecvt_base::result utf16le_to_ucs2(const uint8_t *frm, const uint8_t *frm_end, const uint8_t *&frm_nxt, uint16_t *to, uint16_t *to_end, uint16_t *&to_nxt, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		frm_nxt = frm;
++		to_nxt = to;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 2 && frm_nxt[0] == 0xFF && frm_nxt[1] == 0xFE)
++			frm_nxt += 2;
++		for (; frm_nxt < frm_end - 1 && to_nxt < to_end; ++to_nxt)
++		{
++			uint16_t c1 = static_cast<uint16_t>((frm_nxt[1] << 8) | frm_nxt[0]);
++			if ((c1 & 0xF800) == 0xD800 || c1 > Maxcode)
++				return codecvt_base::error;
++			*to_nxt = c1;
++			frm_nxt += 2;
++		}
++		return frm_nxt < frm_end ? codecvt_base::partial : codecvt_base::ok;
++	}
++
++	inline int utf16le_to_ucs2_length(const uint8_t *frm, const uint8_t *frm_end, size_t mx, unsigned long Maxcode = 0x10FFFF, codecvt_mode mode = static_cast<codecvt_mode>(0))
++	{
++		auto frm_nxt = frm;
++		if ((mode & consume_header) && frm_end - frm_nxt >= 2 && frm_nxt[0] == 0xFF && frm_nxt[1] == 0xFE)
++			frm_nxt += 2;
++		for (size_t nchar16_t = 0; frm_nxt < frm_end - 1 && nchar16_t < mx; ++nchar16_t)
++		{
++			uint16_t c1 = static_cast<uint16_t>((frm_nxt[1] << 8) | frm_nxt[0]);
++			if ((c1 & 0xF800) == 0xD800 || c1 > Maxcode)
++				break;
++			frm_nxt += 2;
++		}
++		return static_cast<int>(frm_nxt - frm);
++	}
++}
++
++template<> class codecvt<char16_t, char, mbstate_t> : public locale::facet, public codecvt_base
++{
++public:
++	typedef char16_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit codecvt(size_t __refs = 0) : locale::facet(__refs) { }
++
++	result out(state_type &__st, const intern_type *__frm, const intern_type *__frm_end, const intern_type *&__frm_nxt, extern_type *__to, extern_type *__to_end, extern_type *&__to_nxt) const
++	{
++		return this->do_out(__st, __frm, __frm_end, __frm_nxt, __to, __to_end, __to_nxt);
++	}
++
++	result unshift(state_type &__st, extern_type *__to, extern_type *__to_end, extern_type *&__to_nxt) const
++	{
++		return this->do_unshift(__st, __to, __to_end, __to_nxt);
++	}
++
++	result in(state_type &__st, const extern_type *__frm, const extern_type *__frm_end, const extern_type *&__frm_nxt, intern_type *__to, intern_type *__to_end, intern_type *&__to_nxt) const
++	{
++		return this->do_in(__st, __frm, __frm_end, __frm_nxt, __to, __to_end, __to_nxt);
++	}
++
++	int encoding() const noexcept
++	{
++		return this->do_encoding();
++	}
++
++	bool always_noconv() const noexcept
++	{
++		return this->do_always_noconv();
++	}
++
++	int length(state_type &__st, const extern_type *__frm, const extern_type *__end, size_t __mx) const
++	{
++		return this->do_length(__st, __frm, __end, __mx);
++	}
++
++	int max_length() const noexcept
++	{
++		return this->do_max_length();
++	}
++
++	static locale::id id;
++
++protected:
++	explicit codecvt(const char *, size_t __refs = 0) : locale::facet(__refs) { }
++
++	~codecvt() { }
++
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint16_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint16_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf16_to_utf8(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint16_t *>(to);
++		auto _to_end = reinterpret_cast<uint16_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf8_to_utf16(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf8_to_utf16_length(_frm, _frm_end, mx);
++	}
++	virtual int do_max_length() const noexcept { return 4; }
++};
++
++template<> class codecvt<char32_t, char, mbstate_t> : public locale::facet, public codecvt_base
++{
++public:
++	typedef char32_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit codecvt(size_t __refs = 0) : locale::facet(__refs) { }
++
++	result out(state_type &__st, const intern_type *__frm, const intern_type *__frm_end, const intern_type *&__frm_nxt, extern_type *__to, extern_type *__to_end, extern_type *&__to_nxt) const
++	{
++		return this->do_out(__st, __frm, __frm_end, __frm_nxt, __to, __to_end, __to_nxt);
++	}
++
++	result unshift(state_type &__st, extern_type *__to, extern_type *__to_end, extern_type *&__to_nxt) const
++	{
++		return this->do_unshift(__st, __to, __to_end, __to_nxt);
++	}
++
++	result in(state_type &__st, const extern_type *__frm, const extern_type *__frm_end, const extern_type *&__frm_nxt, intern_type *__to, intern_type *__to_end, intern_type *&__to_nxt) const
++	{
++		return this->do_in(__st, __frm, __frm_end, __frm_nxt, __to, __to_end, __to_nxt);
++	}
++
++	int encoding() const noexcept
++	{
++		return this->do_encoding();
++	}
++
++	bool always_noconv() const noexcept
++	{
++		return this->do_always_noconv();
++	}
++
++	int length(state_type &__st, const extern_type *__frm, const extern_type *__end, size_t __mx) const
++	{
++		return this->do_length(__st, __frm, __end, __mx);
++	}
++
++	int max_length() const noexcept
++	{
++		return this->do_max_length();
++	}
++
++	static locale::id id;
++
++protected:
++	explicit codecvt(const char *, size_t __refs = 0) : locale::facet(__refs) { }
++
++	~codecvt() { }
++
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint32_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint32_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::ucs4_to_utf8(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint32_t *>(to);
++		auto _to_end = reinterpret_cast<uint32_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf8_to_ucs4(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf8_to_ucs4_length(_frm, _frm_end, mx);
++	}
++	virtual int do_max_length() const noexcept { return 4; }
++};
++
++template<class _Elem> class __codecvt_utf8;
++
++template<> class __codecvt_utf8<wchar_t> : public codecvt<wchar_t, char, mbstate_t>
++{
++	unsigned long _Maxcode_;
++	codecvt_mode _Mode_;
++public:
++	typedef wchar_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit __codecvt_utf8(size_t __refs, unsigned long _Maxcode, codecvt_mode _Mode) : codecvt<wchar_t, char, mbstate_t>(__refs), _Maxcode_(_Maxcode), _Mode_(_Mode) { }
++protected:
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++#ifdef _WIN32
++		auto _frm = reinterpret_cast<const uint16_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint16_t *>(frm_end);
++#else
++		auto _frm = reinterpret_cast<const uint32_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint32_t *>(frm_end);
++#endif
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::
++#ifdef _WIN32
++			ucs2_to_utf8
++#else
++			ucs4_to_utf8
++#endif
++			(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++#ifdef _WIN32
++		auto _to = reinterpret_cast<uint16_t *>(to);
++		auto _to_end = reinterpret_cast<uint16_t *>(to_end);
++#else
++		auto _to = reinterpret_cast<uint32_t *>(to);
++		auto _to_end = reinterpret_cast<uint32_t *>(to_end);
++#endif
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::
++#ifdef _WIN32
++			utf8_to_ucs2
++#else
++			utf8_to_ucs4
++#endif
++			(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf8_to_ucs4_length(_frm, _frm_end, mx, this->_Maxcode_, this->_Mode_);
++	}
++	virtual int do_max_length() const noexcept
++	{
++		if (this->_Mode_ & consume_header)
++			return 7;
++		return 4;
++	}
++};
++
++template<> class __codecvt_utf8<char16_t> : public codecvt<char16_t, char, mbstate_t>
++{
++	unsigned long _Maxcode_;
++	codecvt_mode _Mode_;
++public:
++	typedef char16_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit __codecvt_utf8(size_t __refs, unsigned long _Maxcode, codecvt_mode _Mode) : codecvt<char16_t, char, mbstate_t>(__refs), _Maxcode_(_Maxcode), _Mode_(_Mode) { }
++protected:
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint16_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint16_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::ucs2_to_utf8(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint16_t *>(to);
++		auto _to_end = reinterpret_cast<uint16_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf8_to_ucs2(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf8_to_ucs2_length(_frm, _frm_end, mx, this->_Maxcode_, this->_Mode_);
++	}
++	virtual int do_max_length() const noexcept
++	{
++		if (this->_Mode_ & consume_header)
++			return 6;
++		return 3;
++	}
++};
++
++template<> class __codecvt_utf8<char32_t> : public codecvt<char32_t, char, mbstate_t>
++{
++	unsigned long _Maxcode_;
++	codecvt_mode _Mode_;
++public:
++	typedef char32_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit __codecvt_utf8(size_t __refs, unsigned long _Maxcode, codecvt_mode _Mode) : codecvt<char32_t, char, mbstate_t>(__refs), _Maxcode_(_Maxcode), _Mode_(_Mode) { }
++protected:
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint32_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint32_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::ucs4_to_utf8(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint32_t *>(to);
++		auto _to_end = reinterpret_cast<uint32_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf8_to_ucs4(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf8_to_ucs4_length(_frm, _frm_end, mx, this->_Maxcode_, this->_Mode_);
++	}
++	virtual int do_max_length() const noexcept
++	{
++		if (this->_Mode_ & consume_header)
++			return 7;
++		return 4;
++	}
++};
++
++template<class _Elem, unsigned long _Maxcode = 0x10ffff, codecvt_mode _Mode = static_cast<codecvt_mode>(0)> class codecvt_utf8 : public __codecvt_utf8<_Elem>
++{
++public:
++	explicit codecvt_utf8(size_t __refs = 0) : __codecvt_utf8<_Elem>(__refs, _Maxcode, _Mode) { }
++
++	~codecvt_utf8() { }
++};
++
++template<class _Elem, bool _LittleEndian> class __codecvt_utf16;
++
++template<> class __codecvt_utf16<wchar_t, false> : public codecvt<wchar_t, char, mbstate_t>
++{
++	unsigned long _Maxcode_;
++	codecvt_mode _Mode_;
++public:
++	typedef wchar_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit __codecvt_utf16(size_t __refs, unsigned long _Maxcode, codecvt_mode _Mode) : codecvt<wchar_t, char, mbstate_t>(__refs), _Maxcode_(_Maxcode), _Mode_(_Mode) { }
++protected:
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint32_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint32_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::ucs4_to_utf16be(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint32_t *>(to);
++		auto _to_end = reinterpret_cast<uint32_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf16be_to_ucs4(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf16be_to_ucs4_length(_frm, _frm_end, mx, this->_Maxcode_, this->_Mode_);
++	}
++	virtual int do_max_length() const noexcept
++	{
++		if (this->_Mode_ & consume_header)
++			return 6;
++		return 4;
++	}
++};
++
++template<> class __codecvt_utf16<wchar_t, true> : public codecvt<wchar_t, char, mbstate_t>
++{
++	unsigned long _Maxcode_;
++	codecvt_mode _Mode_;
++public:
++	typedef wchar_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit __codecvt_utf16(size_t __refs, unsigned long _Maxcode, codecvt_mode _Mode) : codecvt<wchar_t, char, mbstate_t>(__refs), _Maxcode_(_Maxcode), _Mode_(_Mode) { }
++protected:
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint32_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint32_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::ucs4_to_utf16le(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint32_t *>(to);
++		auto _to_end = reinterpret_cast<uint32_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf16le_to_ucs4(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf16le_to_ucs4_length(_frm, _frm_end, mx, this->_Maxcode_, this->_Mode_);
++	}
++	virtual int do_max_length() const noexcept
++	{
++		if (this->_Mode_ & consume_header)
++			return 6;
++		return 4;
++	}
++};
++
++template<> class __codecvt_utf16<char16_t, false> : public codecvt<char16_t, char, mbstate_t>
++{
++	unsigned long _Maxcode_;
++	codecvt_mode _Mode_;
++public:
++	typedef char16_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit __codecvt_utf16(size_t __refs, unsigned long _Maxcode, codecvt_mode _Mode) : codecvt<char16_t, char, mbstate_t>(__refs), _Maxcode_(_Maxcode), _Mode_(_Mode) { }
++protected:
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint16_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint16_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::ucs2_to_utf16be(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint16_t *>(to);
++		auto _to_end = reinterpret_cast<uint16_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf16be_to_ucs2(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf16be_to_ucs2_length(_frm, _frm_end, mx, this->_Maxcode_, this->_Mode_);
++	}
++	virtual int do_max_length() const noexcept
++	{
++		if (this->_Mode_ & consume_header)
++			return 4;
++		return 2;
++	}
++};
++
++template<> class __codecvt_utf16<char16_t, true> : public codecvt<char16_t, char, mbstate_t>
++{
++	unsigned long _Maxcode_;
++	codecvt_mode _Mode_;
++public:
++	typedef char16_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit __codecvt_utf16(size_t __refs, unsigned long _Maxcode, codecvt_mode _Mode) : codecvt<char16_t, char, mbstate_t>(__refs), _Maxcode_(_Maxcode), _Mode_(_Mode) { }
++protected:
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint16_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint16_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::ucs2_to_utf16le(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint16_t *>(to);
++		auto _to_end = reinterpret_cast<uint16_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf16le_to_ucs2(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf16le_to_ucs2_length(_frm, _frm_end, mx, this->_Maxcode_, this->_Mode_);
++	}
++	virtual int do_max_length() const noexcept
++	{
++		if (this->_Mode_ & consume_header)
++			return 4;
++		return 2;
++	}
++};
++
++template<> class __codecvt_utf16<char32_t, false> : public codecvt<char32_t, char, mbstate_t>
++{
++	unsigned long _Maxcode_;
++	codecvt_mode _Mode_;
++public:
++	typedef char32_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit __codecvt_utf16(size_t __refs, unsigned long _Maxcode, codecvt_mode _Mode) : codecvt<char32_t, char, mbstate_t>(__refs), _Maxcode_(_Maxcode), _Mode_(_Mode) { }
++protected:
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint32_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint32_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::ucs4_to_utf16be(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint32_t *>(to);
++		auto _to_end = reinterpret_cast<uint32_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf16be_to_ucs4(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf16be_to_ucs4_length(_frm, _frm_end, mx, this->_Maxcode_, this->_Mode_);
++	}
++	virtual int do_max_length() const noexcept
++	{
++		if (this->_Mode_ & consume_header)
++			return 6;
++		return 4;
++	}
++};
++
++template<> class __codecvt_utf16<char32_t, true> : public codecvt<char32_t, char, mbstate_t>
++{
++	unsigned long _Maxcode_;
++	codecvt_mode _Mode_;
++public:
++	typedef char32_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit __codecvt_utf16(size_t __refs, unsigned long _Maxcode, codecvt_mode _Mode) : codecvt<char32_t, char, mbstate_t>(__refs), _Maxcode_(_Maxcode), _Mode_(_Mode) { }
++protected:
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint32_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint32_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::ucs4_to_utf16le(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint32_t *>(to);
++		auto _to_end = reinterpret_cast<uint32_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf16le_to_ucs4(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf16le_to_ucs4_length(_frm, _frm_end, mx, this->_Maxcode_, this->_Mode_);
++	}
++	virtual int do_max_length() const noexcept
++	{
++		if (this->_Mode_ & consume_header)
++			return 6;
++		return 4;
++	}
++};
++
++template<class _Elem, unsigned long _Maxcode = 0x10ffff, codecvt_mode _Mode = static_cast<codecvt_mode>(0)> class codecvt_utf16 : public __codecvt_utf16<_Elem, _Mode & little_endian>
++{
++public:
++	explicit codecvt_utf16(size_t __refs = 0) : __codecvt_utf16<_Elem, _Mode & little_endian>(__refs, _Maxcode, _Mode) { }
++
++	~codecvt_utf16() { }
++};
++
++template<class _Elem> class __codecvt_utf8_utf16;
++
++template<> class __codecvt_utf8_utf16<wchar_t> : public codecvt<wchar_t, char, mbstate_t>
++{
++	unsigned long _Maxcode_;
++	codecvt_mode _Mode_;
++public:
++	typedef wchar_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit __codecvt_utf8_utf16(size_t __refs, unsigned long _Maxcode, codecvt_mode _Mode) : codecvt<wchar_t, char, mbstate_t>(__refs), _Maxcode_(_Maxcode), _Mode_(_Mode) { }
++protected:
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint32_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint32_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf16_to_utf8(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint32_t *>(to);
++		auto _to_end = reinterpret_cast<uint32_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf8_to_utf16(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf8_to_utf16_length(_frm, _frm_end, mx, this->_Maxcode_, this->_Mode_);
++	}
++	virtual int do_max_length() const noexcept
++	{
++		if (this->_Mode_ & consume_header)
++			return 7;
++		return 4;
++	}
++};
++
++template<> class __codecvt_utf8_utf16<char32_t> : public codecvt<char32_t, char, mbstate_t>
++{
++	unsigned long _Maxcode_;
++	codecvt_mode _Mode_;
++public:
++	typedef char32_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit __codecvt_utf8_utf16(size_t __refs, unsigned long _Maxcode, codecvt_mode _Mode) : codecvt<char32_t, char, mbstate_t>(__refs), _Maxcode_(_Maxcode), _Mode_(_Mode) { }
++protected:
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint32_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint32_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf16_to_utf8(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint32_t *>(to);
++		auto _to_end = reinterpret_cast<uint32_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf8_to_utf16(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf8_to_utf16_length(_frm, _frm_end, mx, this->_Maxcode_, this->_Mode_);
++	}
++	virtual int do_max_length() const noexcept
++	{
++		if (this->_Mode_ & consume_header)
++			return 7;
++		return 4;
++	}
++};
++
++template<> class __codecvt_utf8_utf16<char16_t> : public codecvt<char16_t, char, mbstate_t>
++{
++	unsigned long _Maxcode_;
++	codecvt_mode _Mode_;
++public:
++	typedef char16_t intern_type;
++	typedef char extern_type;
++	typedef mbstate_t state_type;
++
++	explicit __codecvt_utf8_utf16(size_t __refs, unsigned long _Maxcode, codecvt_mode _Mode) : codecvt<char16_t, char, mbstate_t>(__refs), _Maxcode_(_Maxcode), _Mode_(_Mode) { }
++protected:
++	virtual result do_out(state_type &, const intern_type *frm, const intern_type *frm_end, const intern_type *&frm_nxt, extern_type *to, extern_type *to_end, extern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint16_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint16_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint8_t *>(to);
++		auto _to_end = reinterpret_cast<uint8_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf16_to_utf8(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_in(state_type &, const extern_type *frm, const extern_type *frm_end, const extern_type *&frm_nxt, intern_type *to, intern_type *to_end, intern_type *&to_nxt) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		auto _frm_nxt = _frm;
++		auto _to = reinterpret_cast<uint16_t *>(to);
++		auto _to_end = reinterpret_cast<uint16_t *>(to_end);
++		auto _to_nxt = _to;
++		auto r = UnicodeConverters::utf8_to_utf16(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, this->_Maxcode_, this->_Mode_);
++		frm_nxt = frm + (_frm_nxt - _frm);
++		to_nxt = to + (_to_nxt - _to);
++		return r;
++	}
++	virtual result do_unshift(state_type &, extern_type *to, extern_type *, extern_type *&to_nxt) const
++	{
++		to_nxt = to;
++		return noconv;
++	}
++	virtual int do_encoding() const noexcept { return 0; }
++	virtual bool do_always_noconv() const noexcept { return false; }
++	virtual int do_length(state_type &, const extern_type *frm, const extern_type *frm_end, size_t mx) const
++	{
++		auto _frm = reinterpret_cast<const uint8_t *>(frm);
++		auto _frm_end = reinterpret_cast<const uint8_t *>(frm_end);
++		return UnicodeConverters::utf8_to_utf16_length(_frm, _frm_end, mx, this->_Maxcode_, this->_Mode_);
++	}
++	virtual int do_max_length() const noexcept
++	{
++		if (this->_Mode_ & consume_header)
++			return 7;
++		return 4;
++	}
++};
++
++template<class _Elem, unsigned long _Maxcode = 0x10ffff, codecvt_mode _Mode = static_cast<codecvt_mode>(0)> class codecvt_utf8_utf16 : public __codecvt_utf8_utf16<_Elem>
++{
++public:
++	explicit codecvt_utf8_utf16(size_t __refs = 0) : __codecvt_utf8_utf16<_Elem>(__refs, _Maxcode, _Mode) { }
++
++	~codecvt_utf8_utf16() {}
++};
++
++}
++#endif
+diff --git a/3rdparty/sseqplayer/common.h b/3rdparty/sseqplayer/common.h
+new file mode 100644
+index 000000000..747000615
+--- /dev/null
++++ b/3rdparty/sseqplayer/common.h
+@@ -0,0 +1,280 @@
++/*
++ * SSEQ Player - Common functions
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-10-18
++ *
++ * Some code from FeOS Sound System
++ * By fincs
++ * https://github.com/fincs/FSS
++ */
++
++#pragma once
++
++#include <string>
++#include <vector>
++#include <cstring>
++#include <cstdint>
++
++/*
++ * Pseudo-file data structure
++ */
++
++struct PseudoFile
++{
++	std::vector<uint8_t> *data;
++	uint32_t pos;
++
++	PseudoFile() : data(nullptr), pos(0)
++	{
++	}
++
++	template<typename T> T ReadLE()
++	{
++		T finalVal = 0;
++		for (size_t i = 0; i < sizeof(T); ++i)
++			finalVal |= (*this->data)[this->pos++] << (i * 8);
++		return finalVal;
++	}
++
++	template<typename T, size_t N> void ReadLE(T (&arr)[N])
++	{
++		for (size_t i = 0; i < N; ++i)
++			arr[i] = this->ReadLE<T>();
++	}
++
++	template<size_t N> void ReadLE( uint8_t arr[N])
++	{
++		memcpy(&arr[0], &(*this->data)[this->pos], N);
++		this->pos += N;
++	}
++
++	template<typename T> void ReadLE(std::vector<T> &arr)
++	{
++		for (size_t i = 0, len = arr.size(); i < len; ++i)
++			arr[i] = this->ReadLE<T>();
++	}
++
++	void ReadLE(std::vector<uint8_t> &arr)
++	{
++		memcpy(&arr[0], &(*this->data)[this->pos], arr.size());
++		this->pos += arr.size();
++	}
++
++	std::string ReadNullTerminatedString()
++	{
++		char chr;
++		std::string str;
++		do
++		{
++			chr = static_cast<char>(this->ReadLE<uint8_t>());
++			if (chr)
++				str += chr;
++		} while (chr);
++		return str;
++	}
++};
++
++/*
++ * Data Reading
++ *
++ * The following ReadLE functions will either read from a file or from an
++ * array (sent in as a pointer), while making sure that the data is read in
++ * as little-endian formating.
++ */
++
++template<typename T> inline T ReadLE(const uint8_t *arr)
++{
++	T finalVal = 0;
++	for (size_t i = 0; i < sizeof(T); ++i)
++		finalVal |= arr[i] << (i * 8);
++	return finalVal;
++}
++
++/*
++ * The following function is used to convert an integer into a hexidecimal
++ * string, the length being determined by the size of the integer.  8-bit
++ * integers are in the format of 0x00, 16-bit integers are in the format of
++ * 0x0000, and so on.
++ */
++template<typename T> inline std::string NumToHexString(const T &num)
++{
++	std::string hex;
++	uint8_t len = sizeof(T) * 2;
++	for (uint8_t i = 0; i < len; ++i)
++	{
++		uint8_t tmp = (num >> (i * 4)) & 0xF;
++		hex = static_cast<char>(tmp < 10 ? tmp + '0' : tmp - 10 + 'a') + hex;
++	}
++	return "0x" + hex;
++}
++
++/*
++ * SDAT Record types
++ * List of types taken from the Nitro Composer Specification
++ * http://www.feshrine.net/hacking/doc/nds-sdat.html
++ */
++enum RecordName
++{
++	REC_SEQ,
++	REC_SEQARC,
++	REC_BANK,
++	REC_WAVEARC,
++	REC_PLAYER,
++	REC_GROUP,
++	REC_PLAYER2,
++	REC_STRM
++};
++
++template<size_t N> inline bool VerifyHeader(int8_t (&arr)[N], const std::string &header)
++{
++	std::string arrHeader = std::string(&arr[0], &arr[N]);
++	return arrHeader == header;
++}
++
++/*
++ * The remaining functions in this file come from the FeOS Sound System source code.
++ */
++inline int Cnv_Attack(int attk)
++{
++	static const uint8_t lut[] =
++	{
++		0x00, 0x01, 0x05, 0x0E, 0x1A, 0x26, 0x33, 0x3F, 0x49, 0x54,
++		0x5C, 0x64, 0x6D, 0x74, 0x7B, 0x7F, 0x84, 0x89, 0x8F
++	};
++
++	if (attk & 0x80) // Supposedly invalid value...
++		attk = 0; // Use apparently correct default
++	return attk >= 0x6D ? lut[0x7F - attk] : 0xFF - attk;
++}
++
++inline int Cnv_Fall(int fall)
++{
++	if (fall & 0x80) // Supposedly invalid value...
++		fall = 0; // Use apparently correct default
++	if (fall == 0x7F)
++		return 0xFFFF;
++	else if (fall == 0x7E)
++		return 0x3C00;
++	else if (fall < 0x32)
++		return ((fall << 1) + 1) & 0xFFFF;
++	else
++		return (0x1E00 / (0x7E - fall)) & 0xFFFF;
++}
++
++inline int Cnv_Scale(int scale)
++{
++	static const int16_t lut[] =
++	{
++		-32768, -421, -361, -325, -300, -281, -265, -252,
++		-240, -230, -221, -212, -205, -198, -192, -186,
++		-180, -175, -170, -165, -161, -156, -152, -148,
++		-145, -141, -138, -134, -131, -128, -125, -122,
++		-120, -117, -114, -112, -110, -107, -105, -103,
++		-100, -98, -96, -94, -92, -90, -88, -86,
++		-85, -83, -81, -79, -78, -76, -74, -73,
++		-71, -70, -68, -67, -65, -64, -62, -61,
++		-60, -58, -57, -56, -54, -53, -52, -51,
++		-49, -48, -47, -46, -45, -43, -42, -41,
++		-40, -39, -38, -37, -36, -35, -34, -33,
++		-32, -31, -30, -29, -28, -27, -26, -25,
++		-24, -23, -23, -22, -21, -20, -19, -18,
++		-17, -17, -16, -15, -14, -13, -12, -12,
++		-11, -10, -9, -9, -8, -7, -6, -6,
++		-5, -4, -3, -3, -2, -1, -1, 0
++	};
++
++	if (scale & 0x80) // Supposedly invalid value...
++		scale = 0x7F; // Use apparently correct default
++	return lut[scale];
++}
++
++inline int Cnv_Sust(int sust)
++{
++	static const int16_t lut[] =
++	{
++		-32768, -722, -721, -651, -601, -562, -530, -503,
++		-480, -460, -442, -425, -410, -396, -383, -371,
++		-360, -349, -339, -330, -321, -313, -305, -297,
++		-289, -282, -276, -269, -263, -257, -251, -245,
++		-239, -234, -229, -224, -219, -214, -210, -205,
++		-201, -196, -192, -188, -184, -180, -176, -173,
++		-169, -165, -162, -158, -155, -152, -149, -145,
++		-142, -139, -136, -133, -130, -127, -125, -122,
++		-119, -116, -114, -111, -109, -106, -103, -101,
++		-99, -96, -94, -91, -89, -87, -85, -82,
++		-80, -78, -76, -74, -72, -70, -68, -66,
++		-64, -62, -60, -58, -56, -54, -52, -50,
++		-49, -47, -45, -43, -42, -40, -38, -36,
++		-35, -33, -31, -30, -28, -27, -25, -23,
++		-22, -20, -19, -17, -16, -14, -13, -11,
++		-10, -8, -7, -6, -4, -3, -1, 0
++	};
++
++	if (sust & 0x80) // Supposedly invalid value...
++		sust = 0x7F; // Use apparently correct default
++	return lut[sust];
++}
++
++inline int Cnv_Sine(int arg)
++{
++	static const int lut_size = 32;
++	static const int8_t lut[] =
++	{
++		0, 6, 12, 19, 25, 31, 37, 43, 49, 54, 60, 65, 71, 76, 81, 85, 90, 94,
++		98, 102, 106, 109, 112, 115, 117, 120, 122, 123, 125, 126, 126, 127, 127
++	};
++
++	if (arg < lut_size)
++		return lut[arg];
++	if (arg < 2 * lut_size)
++		return lut[2 * lut_size - arg];
++	if (arg < 3 * lut_size)
++		return -lut[arg - 2 * lut_size];
++	/*else*/
++	return -lut[4 * lut_size - arg];
++}
++
++inline int read8(const uint8_t **ppData)
++{
++	auto pData = *ppData;
++	int x = *pData;
++	*ppData = pData + 1;
++	return x;
++}
++
++inline int read16(const uint8_t **ppData)
++{
++	int x = read8(ppData);
++	x |= read8(ppData) << 8;
++	return x;
++}
++
++inline int read24(const uint8_t **ppData)
++{
++	int x = read8(ppData);
++	x |= read8(ppData) << 8;
++	x |= read8(ppData) << 16;
++	return x;
++}
++
++inline int readvl(const uint8_t **ppData)
++{
++	int x = 0;
++	for (;;)
++	{
++		int data = read8(ppData);
++		x = (x << 7) | (data & 0x7F);
++		if (!(data & 0x80))
++			break;
++	}
++	return x;
++}
++
++// Clamp a value between a minimum and maximum value
++template<typename T1, typename T2> inline void clamp(T1 &valueToClamp, const T2 &minValue, const T2 &maxValue)
++{
++	if (valueToClamp < minValue)
++		valueToClamp = minValue;
++	else if (valueToClamp > maxValue)
++		valueToClamp = maxValue;
++}
+diff --git a/3rdparty/sseqplayer/consts.h b/3rdparty/sseqplayer/consts.h
+new file mode 100644
+index 000000000..be1cc9a3d
+--- /dev/null
++++ b/3rdparty/sseqplayer/consts.h
+@@ -0,0 +1,60 @@
++/*
++ * SSEQ Player - Constants/Macros
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-08
++ *
++ * Adapted from source code of FeOS Sound System
++ * By fincs
++ * https://github.com/fincs/FSS
++ *
++ * Some constants/macros also taken from libdns, part of the devkitARM portion of devkitPro
++ * http://devkitpro.org/
++ */
++
++#pragma once
++
++#include <cstdint>
++
++const uint32_t ARM7_CLOCK = 33513982;
++const double SecondsPerClockCycle = 64.0 * 2728.0 / ARM7_CLOCK;
++
++inline uint32_t BIT(uint32_t n) { return 1 << n; }
++
++enum { TS_ALLOCBIT, TS_NOTEWAIT, TS_PORTABIT, TS_TIEBIT, TS_END, TS_BITS };
++
++enum { TUF_VOL, TUF_PAN, TUF_TIMER, TUF_MOD, TUF_LEN, TUF_BITS };
++
++enum { CS_NONE, CS_START, CS_ATTACK, CS_DECAY, CS_SUSTAIN, CS_RELEASE };
++
++enum { CF_UPDVOL, CF_UPDPAN, CF_UPDTMR, CF_BITS };
++
++enum { TYPE_PCM, TYPE_PSG, TYPE_NOISE };
++
++const int FSS_TRACKCOUNT = 16;
++const int FSS_MAXTRACKS = 32;
++const int FSS_TRACKSTACKSIZE = 3;
++const int AMPL_K = 723;
++const int AMPL_MIN = -AMPL_K;
++const int AMPL_THRESHOLD = AMPL_MIN << 7;
++
++inline int SOUND_FREQ(int n) { return -0x1000000 / n; }
++
++inline uint32_t SOUND_VOL(int n) { return n; }
++inline uint32_t SOUND_VOLDIV(int n) { return n << 8; }
++inline uint32_t SOUND_PAN(int n) { return n << 16; }
++inline uint32_t SOUND_DUTY(int n) { return n << 24; }
++const uint32_t SOUND_REPEAT = BIT(27);
++const uint32_t SOUND_ONE_SHOT = BIT(28);
++inline uint32_t SOUND_LOOP(bool a) { return a ? SOUND_REPEAT : SOUND_ONE_SHOT; }
++const uint32_t SOUND_FORMAT_PSG = 3 << 29;
++inline uint32_t SOUND_FORMAT(int n) { return n << 29; }
++const uint32_t SCHANNEL_ENABLE = BIT(31);
++
++enum Interpolation
++{
++	INTERPOLATION_NONE,
++	INTERPOLATION_LINEAR,
++	INTERPOLATION_4POINTLEGRANGE,
++	INTERPOLATION_6POINTLEGRANGE,
++	INTERPOLATION_SINC
++};
+diff --git a/3rdparty/sseqplayer/convert.h b/3rdparty/sseqplayer/convert.h
+new file mode 100644
+index 000000000..db5ade16b
+--- /dev/null
++++ b/3rdparty/sseqplayer/convert.h
+@@ -0,0 +1,170 @@
++/*
++ * Common conversion functions
++ * By Naram Qashat (CyberBotX) [cyberbotx@cyberbotx.com]
++ * Last modification on 2014-09-24
++ */
++
++#pragma once
++
++#include <stdexcept>
++#include <string>
++#include <sstream>
++#include <typeinfo>
++#include <locale>
++#if (defined(__GNUC__) || defined(__clang__)) && !defined(_LIBCPP_VERSION)
++# include "wstring_convert.h"
++# include "codecvt.h"
++#else
++# include <codecvt>
++#endif
++#include <vector>
++#include <cmath>
++
++/*
++ * The following exception class and the *stringify and convert* functions are
++ * from the C++ FAQ, section 39, entry 3:
++ * http://www.parashift.com/c++-faq/convert-string-to-any.html
++ *
++ * The convert and convertTo functions were made into templates of std::basic_string
++ * to handle wide-character strings properly, as well as adding wstringify for the
++ * same reason.
++ */
++class BadConversion : public std::runtime_error
++{
++public:
++	BadConversion(const std::string &s) : std::runtime_error(s) { }
++};
++
++template<typename T> inline std::string stringify(const T &x)
++{
++	std::ostringstream o;
++	if (!(o << x))
++		throw BadConversion(std::string("stringify(") + typeid(x).name() + ")");
++	return o.str();
++}
++
++template<typename T> inline std::wstring wstringify(const T &x)
++{
++	std::wostringstream o;
++	if (!(o << x))
++		throw BadConversion(std::string("wstringify(") + typeid(x).name() + ")");
++	return o.str();
++}
++
++template<typename T, typename S> inline void convert(const std::basic_string<S> &s, T &x, bool failIfLeftoverChars = true)
++{
++	std::basic_istringstream<S> i(s);
++	S c;
++	if (!(i >> x) || (failIfLeftoverChars && i.get(c)))
++		throw BadConversion(std::string("convert(") + typeid(S).name() + ")");
++}
++
++template<typename T, typename S> inline T convertTo(const std::basic_string<S> &s, bool failIfLeftoverChars = true)
++{
++	T x;
++	convert(s, x, failIfLeftoverChars);
++	return x;
++}
++
++// Miscellaneous conversion functions
++class ConvertFuncs
++{
++private:
++	static inline bool IsDigitsOnly(const std::string &input, const std::locale &loc = std::locale::classic())
++	{
++		auto inputChars = std::vector<char>(input.begin(), input.end());
++		size_t length = inputChars.size();
++		auto masks = std::vector<std::ctype<char>::mask>(length);
++		std::use_facet<std::ctype<char>>(loc).is(&inputChars[0], &inputChars[length], &masks[0]);
++		for (size_t x = 0; x < length; ++x)
++			if (inputChars[x] != '.' && !(masks[x] & std::ctype<char>::digit))
++				return false;
++		return true;
++	}
++
++public:
++	static unsigned long StringToMS(const std::string &time)
++	{
++		unsigned long hours = 0, minutes = 0;
++		double seconds = 0.0;
++		std::string hoursStr, minutesStr, secondsStr;
++		size_t firstcolon = time.find(':');
++		if (firstcolon != std::string::npos)
++		{
++			size_t secondcolon = time.substr(firstcolon + 1).find(':');
++			if (secondcolon != std::string::npos)
++			{
++				secondcolon = firstcolon + secondcolon + 1;
++				hoursStr = time.substr(0, firstcolon);
++				minutesStr = time.substr(firstcolon + 1, secondcolon - firstcolon - 1);
++				secondsStr = time.substr(secondcolon + 1);
++			}
++			else
++			{
++				minutesStr = time.substr(0, firstcolon);
++				secondsStr = time.substr(firstcolon + 1);
++			}
++		}
++		else
++			secondsStr = time;
++		if (!hoursStr.empty())
++		{
++			if (!ConvertFuncs::IsDigitsOnly(hoursStr))
++				return 0;
++			hours = convertTo<unsigned long>(hoursStr, false);
++		}
++		if (!minutesStr.empty())
++		{
++			if (!ConvertFuncs::IsDigitsOnly(minutesStr))
++				return 0;
++			minutes = convertTo<unsigned long>(minutesStr, false);
++		}
++		if (!secondsStr.empty())
++		{
++			if (!ConvertFuncs::IsDigitsOnly(secondsStr))
++				return 0;
++			size_t comma = secondsStr.find(',');
++			if (comma != std::string::npos)
++				secondsStr[comma] = '.';
++			seconds = convertTo<double>(secondsStr, false);
++		}
++		seconds += minutes * 60 + hours * 1440;
++		return static_cast<unsigned long>(std::floor(seconds * 1000 + 0.5));
++	}
++
++	static unsigned long StringToMS(const std::wstring &time)
++	{
++		return ConvertFuncs::StringToMS(ConvertFuncs::WStringToString(time));
++	}
++
++	static std::string MSToString(unsigned long time)
++	{
++		double seconds = time / 1000.0;
++		if (seconds < 60)
++			return stringify(seconds);
++		unsigned long minutes = static_cast<unsigned long>(seconds) / 60;
++		seconds -= minutes * 60;
++		if (minutes < 60)
++			return stringify(minutes) + ":" + (seconds < 10 ? "0" : "") + stringify(seconds);
++		unsigned long hours = minutes / 60;
++		minutes %= 60;
++		return stringify(hours) + ":" + (minutes < 10 ? "0" : "") + stringify(minutes) + ":" + (seconds < 10 ? "0" : "") + stringify(seconds);
++	}
++
++	static std::wstring MSToWString(unsigned long time)
++	{
++		return ConvertFuncs::StringToWString(ConvertFuncs::MSToString(time));
++	}
++
++	static std::wstring StringToWString(const std::string &str)
++	{
++		static std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
++		return conv.from_bytes(str);
++	}
++
++	static std::string WStringToString(const std::wstring &wstr)
++	{
++		static std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
++		return conv.to_bytes(wstr);
++	}
++};
+diff --git a/3rdparty/sseqplayer/wstring_convert.h b/3rdparty/sseqplayer/wstring_convert.h
+new file mode 100644
+index 000000000..5ab6a4bb5
+--- /dev/null
++++ b/3rdparty/sseqplayer/wstring_convert.h
+@@ -0,0 +1,183 @@
++// This comes from llvm's libcxx project. I've copied the code from there (with very minor modifications) for use with GCC and Clang when libcxx isn't being used.
++
++#if (defined(__GNUC__) || defined(__clang__)) && !defined(_LIBCPP_VERSION)
++#pragma once
++
++#include <memory>
++#include <string>
++#include <locale>
++
++namespace std
++{
++
++template<class _Codecvt, class _Elem = wchar_t, class _Wide_alloc = allocator<_Elem>, class _Byte_alloc = allocator<char>> class wstring_convert
++{
++public:
++	typedef basic_string<char, char_traits<char>, _Byte_alloc> byte_string;
++	typedef basic_string<_Elem, char_traits<_Elem>, _Wide_alloc> wide_string;
++	typedef typename _Codecvt::state_type state_type;
++	typedef typename wide_string::traits_type::int_type int_type;
++
++private:
++	byte_string __byte_err_string_;
++	wide_string __wide_err_string_;
++	_Codecvt *__cvtptr_;
++	state_type __cvtstate_;
++	size_t __cvtcount_;
++
++	wstring_convert(const wstring_convert &__wc);
++	wstring_convert& operator=(const wstring_convert &__wc);
++public:
++	wstring_convert(_Codecvt *__pcvt = new _Codecvt) : __cvtptr_(__pcvt), __cvtstate_(), __cvtcount_(0) { }
++	wstring_convert(_Codecvt *__pcvt, state_type __state) : __cvtptr_(__pcvt), __cvtstate_(__state), __cvtcount_(0) { }
++	wstring_convert(const byte_string &__byte_err, const wide_string &__wide_err = wide_string()) : __byte_err_string_(__byte_err), __wide_err_string_(__wide_err), __cvtptr_(new _Codecvt), __cvtstate_(), __cvtcount_(0) { }
++	wstring_convert(wstring_convert &&__wc) : __byte_err_string_(move(__wc.__byte_err_string_)), __wide_err_string_(move(__wc.__wide_err_string_)), __cvtptr_(__wc.__cvtptr_), __cvtstate_(__wc.__cvtstate_), __cvtcount_(__wc.__cvtstate_)
++	{
++		__wc.__cvtptr_ = nullptr;
++	}
++	~wstring_convert() { delete this->__cvtptr_; }
++
++	wide_string from_bytes(char __byte) { return from_bytes(&__byte, &__byte + 1); }
++	wide_string from_bytes(const char *__ptr) { return from_bytes(__ptr, __ptr + char_traits<char>::length(__ptr)); }
++	wide_string from_bytes(const byte_string &__str) { return from_bytes(__str.data(), __str.data() + __str.size()); }
++	wide_string from_bytes(const char *__frm, const char *__frm_end)
++	{
++		this->__cvtcount_ = 0;
++		if (this->__cvtptr_)
++		{
++			wide_string __ws(2 * (__frm_end - __frm), _Elem());
++			if (__frm != __frm_end)
++				__ws.resize(__ws.capacity());
++			auto __r = codecvt_base::ok;
++			auto __st = this->__cvtstate_;
++			if (__frm != __frm_end)
++			{
++				auto __to = &__ws[0];
++				auto __to_end = __to + __ws.size();
++				const char *__frm_nxt;
++				do
++				{
++					_Elem *__to_nxt;
++					__r = this->__cvtptr_->in(__st, __frm, __frm_end, __frm_nxt, __to, __to_end, __to_nxt);
++					this->__cvtcount_ += __frm_nxt - __frm;
++					if (__frm_nxt == __frm)
++						__r = codecvt_base::error;
++					else if (__r == codecvt_base::noconv)
++					{
++						__ws.resize(__to - &__ws[0]);
++						// This only gets executed if _Elem is char
++						__ws.append(reinterpret_cast<const _Elem *>(__frm), reinterpret_cast<const _Elem *>(__frm_end));
++						__frm = __frm_nxt;
++						__r = codecvt_base::ok;
++					}
++					else if (__r == codecvt_base::ok)
++					{
++						__ws.resize(__to_nxt - &__ws[0]);
++						__frm = __frm_nxt;
++					}
++					else if (__r == codecvt_base::partial)
++					{
++						ptrdiff_t __s = __to_nxt - &__ws[0];
++						__ws.resize(2 * __s);
++						__to = &__ws[0] + __s;
++						__to_end = &__ws[0] + __ws.size();
++						__frm = __frm_nxt;
++					}
++				} while (__r == codecvt_base::partial && __frm_nxt < __frm_end);
++			}
++			if (__r == codecvt_base::ok)
++				return __ws;
++		}
++		if (this->__wide_err_string_.empty())
++			throw range_error("wstring_convert: from_bytes error");
++		return this->__wide_err_string_;
++	}
++
++	byte_string to_bytes(_Elem __wchar) { return to_bytes(&__wchar, &__wchar + 1); }
++	byte_string to_bytes(const _Elem *__wptr) { return to_bytes(__wptr, __wptr + char_traits<_Elem>::length(__wptr)); }
++	byte_string to_bytes(const wide_string &__wstr) { return to_bytes(__wstr.data(), __wstr.data() + __wstr.size()); }
++	byte_string to_bytes(const _Elem *__frm, const _Elem *__frm_end)
++	{
++		this->__cvtcount_ = 0;
++		if (this->__cvtptr_)
++		{
++			byte_string __bs(2 * (__frm_end - __frm), char());
++			if (__frm != __frm_end)
++				__bs.resize(__bs.capacity());
++			auto __r = codecvt_base::ok;
++			auto __st = this->__cvtstate_;
++			if (__frm != __frm_end)
++			{
++				auto __to = &__bs[0];
++				auto __to_end = __to + __bs.size();
++				const _Elem *__frm_nxt;
++				do
++				{
++					char *__to_nxt;
++					__r = this->__cvtptr_->out(__st, __frm, __frm_end, __frm_nxt, __to, __to_end, __to_nxt);
++					this->__cvtcount_ += __frm_nxt - __frm;
++					if (__frm_nxt == __frm)
++						__r = codecvt_base::error;
++					else if (__r == codecvt_base::noconv)
++					{
++						__bs.resize(__to - &__bs[0]);
++						// This only gets executed if _Elem is char
++						__bs.append(reinterpret_cast<const char *>(__frm), reinterpret_cast<const char *>(__frm_end));
++						__frm = __frm_nxt;
++						__r = codecvt_base::ok;
++					}
++					else if (__r == codecvt_base::ok)
++					{
++						__bs.resize(__to_nxt - &__bs[0]);
++						__frm = __frm_nxt;
++					}
++					else if (__r == codecvt_base::partial)
++					{
++						ptrdiff_t __s = __to_nxt - &__bs[0];
++						__bs.resize(2 * __s);
++						__to = &__bs[0] + __s;
++						__to_end = &__bs[0] + __bs.size();
++						__frm = __frm_nxt;
++					}
++				} while (__r == codecvt_base::partial && __frm_nxt < __frm_end);
++			}
++			if (__r == codecvt_base::ok)
++			{
++				auto __s = __bs.size();
++				__bs.resize(__bs.capacity());
++				auto __to = &__bs[0] + __s;
++				auto __to_end = __to + __bs.size();
++				do
++				{
++					char *__to_nxt;
++					__r = this->__cvtptr_->unshift(__st, __to, __to_end, __to_nxt);
++					if (__r == codecvt_base::noconv)
++					{
++						__bs.resize(__to - &__bs[0]);
++						__r = codecvt_base::ok;
++					}
++					else if (__r == codecvt_base::ok)
++						__bs.resize(__to_nxt - &__bs[0]);
++					else if (__r == codecvt_base::partial)
++					{
++						ptrdiff_t __sp = __to_nxt - &__bs[0];
++						__bs.resize(2 * __sp);
++						__to = &__bs[0] + __sp;
++						__to_end = &__bs[0] + __bs.size();
++					}
++				} while (__r == codecvt_base::partial);
++				if (__r == codecvt_base::ok)
++					return __bs;
++			}
++		}
++		if (this->__byte_err_string_.empty())
++			throw range_error("wstring_convert: to_bytes error");
++		return this->__byte_err_string_;
++	}
++
++	size_t converted() const noexcept { return this->__cvtcount_; }
++	state_type state() const { return this->__cvtstate_; }
++};
++
++}
++#endif
+diff --git a/apps/libzxtune/Makefile b/apps/libzxtune/Makefile
+index a5a948871..a77dd888a 100644
+--- a/apps/libzxtune/Makefile
++++ b/apps/libzxtune/Makefile
+@@ -15,7 +15,7 @@ libraries.common = analysis \
+                    sound strings \
+                    tools
+ 
+-libraries.3rdparty = gme he hvl lazyusf2 lhasa mgba sidplayfp snesspc vio2sf xmp z80ex zlib
++libraries.3rdparty = gme he hvl lazyusf2 lhasa mgba sidplayfp snesspc sseqplayer vio2sf xmp z80ex zlib
+ 
+ libraries.windows += oldnames
+ 
+diff --git a/apps/zxtune-android/zxtune/src/main/jni/Makefile b/apps/zxtune-android/zxtune/src/main/jni/Makefile
+index ba79f760a..23e6cc8a4 100644
+--- a/apps/zxtune-android/zxtune/src/main/jni/Makefile
++++ b/apps/zxtune-android/zxtune/src/main/jni/Makefile
+@@ -13,7 +13,7 @@ libraries.common = analysis \
+                    sound strings \
+                    tools
+ 
+-libraries.3rdparty = asap ffmpeg FLAC gme he ht hvl lazyusf2 lhasa lzma mgba sidplayfp snesspc unrar v2m vgm vio2sf xmp z80ex zlib
++libraries.3rdparty = asap ffmpeg FLAC gme he ht hvl lazyusf2 lhasa lzma mgba sidplayfp snesspc sseqplayer unrar v2m vgm vio2sf xmp z80ex zlib
+ 
+ ld_flags += -Wl,--version-script=libzxtune.version
+ 
+diff --git a/apps/zxtune-qt/Makefile b/apps/zxtune-qt/Makefile
+index 3c322d978..3a4e65710 100644
+--- a/apps/zxtune-qt/Makefile
++++ b/apps/zxtune-qt/Makefile
+@@ -30,7 +30,7 @@ libraries.common = analysis async \
+                   resource \
+                   sound sound_backends strings \
+                   tools
+-libraries.3rdparty = asap ffmpeg FLAC gme he ht hvl lazyusf2 lhasa lzma mgba sidplayfp snesspc unrar v2m vgm vio2sf xmp z80ex zlib
++libraries.3rdparty = asap ffmpeg FLAC gme he ht hvl lazyusf2 lhasa lzma mgba sidplayfp snesspc sseqplayer unrar v2m vgm vio2sf xmp z80ex zlib
+ 
+ #ui
+ libraries += playlist_ui playlist_supp playlist_io ui_common
+diff --git a/apps/zxtune123/Makefile b/apps/zxtune123/Makefile
+index fa955989f..bce8f36a5 100644
+--- a/apps/zxtune123/Makefile
++++ b/apps/zxtune123/Makefile
+@@ -22,7 +22,7 @@ libraries.common = analysis async \
+                   parameters platform platform_application platform_version \
+                   sound sound_backends strings \
+                   tools
+-libraries.3rdparty = asap ffmpeg FLAC gme he ht hvl lazyusf2 lhasa lzma mgba sidplayfp snesspc unrar v2m vio2sf vgm xmp z80ex zlib
++libraries.3rdparty = asap ffmpeg FLAC gme he ht hvl lazyusf2 lhasa lzma mgba sidplayfp snesspc sseqplayer unrar v2m vio2sf vgm xmp z80ex zlib
+ 
+ #platform
+ libraries.windows = advapi32 ole32 oldnames shell32 user32
+diff --git a/src/core/plugins/players/plugins_list.cpp b/src/core/plugins/players/plugins_list.cpp
+index 34e26d59d..088fda8ce 100644
+--- a/src/core/plugins/players/plugins_list.cpp
++++ b/src/core/plugins/players/plugins_list.cpp
+@@ -59,6 +59,7 @@ namespace ZXTune
+     RegisterUSFSupport(registrator);
+     RegisterGSFSupport(registrator);
+     Register2SFSupport(registrator);
++    RegisterNCSFSupport(registrator);
+     RegisterSDSFSupport(registrator);
+     RegisterASAPPlugins(registrator);
+     RegisterMP3Plugin(registrator);
+diff --git a/src/core/plugins/players/plugins_list.h b/src/core/plugins/players/plugins_list.h
+index 067443b60..6cc7300e0 100644
+--- a/src/core/plugins/players/plugins_list.h
++++ b/src/core/plugins/players/plugins_list.h
+@@ -56,6 +56,7 @@ namespace ZXTune
+   void RegisterUSFSupport(PlayerPluginsRegistrator& registrator);
+   void RegisterGSFSupport(PlayerPluginsRegistrator& registrator);
+   void Register2SFSupport(PlayerPluginsRegistrator& registrator);
++  void RegisterNCSFSupport(PlayerPluginsRegistrator& registrator);
+   void RegisterSDSFSupport(PlayerPluginsRegistrator& registrator);
+   void RegisterASAPPlugins(PlayerPluginsRegistrator& registrator);
+   void RegisterMP3Plugin(PlayerPluginsRegistrator& registrator);
+diff --git a/src/core/plugins/players/xsf/ncsf_supp.cpp b/src/core/plugins/players/xsf/ncsf_supp.cpp
+new file mode 100644
+index 000000000..4a10824d2
+--- /dev/null
++++ b/src/core/plugins/players/xsf/ncsf_supp.cpp
+@@ -0,0 +1,31 @@
++/**
++* 
++* @file
++*
++* @brief  2SF support plugin
++*
++* @author vitamin.caig@gmail.com
++*
++**/
++//local includes
++#include "core/plugins/player_plugins_registrator.h"
++#include "core/plugins/players/plugin.h"
++//library includes
++#include <core/plugin_attrs.h>
++#include <formats/chiptune/decoders.h>
++#include <module/players/xsf/ncsf.h>
++
++namespace ZXTune
++{
++  void RegisterNCSFSupport(PlayerPluginsRegistrator& registrator)
++  {
++    //plugin attributes
++    const Char ID[] = {'N', 'C', 'S', 'F', 0};
++    const uint_t CAPS = Capabilities::Module::Type::MEMORYDUMP | Capabilities::Module::Device::DAC | Capabilities::Module::Traits::MULTIFILE;
++
++    const auto factory = Module::NCSF::CreateFactory();
++    const auto decoder = Formats::Chiptune::CreateNCSFDecoder();
++    const auto plugin = CreatePlayerPlugin(ID, CAPS, decoder, factory);
++    registrator.RegisterPlugin(plugin);
++  }
++}
+diff --git a/src/formats/chiptune/decoders.h b/src/formats/chiptune/decoders.h
+index 517986aef..7f2c48fde 100644
+--- a/src/formats/chiptune/decoders.h
++++ b/src/formats/chiptune/decoders.h
+@@ -63,6 +63,7 @@ namespace Formats
+     Decoder::Ptr CreateUSFDecoder();
+     Decoder::Ptr CreateGSFDecoder();
+     Decoder::Ptr Create2SFDecoder();
++    Decoder::Ptr CreateNCSFDecoder();
+     Decoder::Ptr CreateSSFDecoder();
+     Decoder::Ptr CreateDSFDecoder();
+     Decoder::Ptr CreateRasterMusicTrackerDecoder();
+diff --git a/src/formats/chiptune/emulation/nitrocomposersoundformat.cpp b/src/formats/chiptune/emulation/nitrocomposersoundformat.cpp
+new file mode 100644
+index 000000000..e8486a4c3
+--- /dev/null
++++ b/src/formats/chiptune/emulation/nitrocomposersoundformat.cpp
+@@ -0,0 +1,94 @@
++/**
++* 
++* @file
++*
++* @brief  2SF parser implementation
++*
++* @author vitamin.caig@gmail.com
++*
++**/
++
++//local includes
++#include "formats/chiptune/emulation/nitrocomposersoundformat.h"
++//common includes
++#include <byteorder.h>
++#include <make_ptr.h>
++//library includes
++#include <binary/format_factories.h>
++#include <binary/input_stream.h>
++#include <binary/compression/zlib_container.h>
++//text includes
++#include <formats/text/chiptune.h>
++
++namespace Formats
++{
++namespace Chiptune
++{
++  namespace NitroComposerSoundFormat
++  {
++    typedef std::array<uint8_t, 4> SignatureType;
++    const SignatureType SAVESTATE_SIGNATURE = {{'S', 'A', 'V', 'E'}};
++  
++    void ParseRom(Binary::View data, Builder& target)
++    {
++      Binary::DataInputStream stream(data);
++      stream.Seek(8);
++      // const auto offset = stream.ReadLE<uint32_t>();
++      const auto size = stream.ReadLE<uint32_t>();
++      stream.Seek(0);
++      target.SetChunk(0, stream.ReadData(size));
++      Require(0 == stream.GetRestSize());
++    }
++    
++    uint32_t ParseState(Binary::View data)
++    {
++      Binary::DataInputStream stream(data);
++      if (data.Size() >= 4) {
++        return stream.ReadLE<uint32_t>();
++      }
++      return 0;
++    }
++    
++    const std::string FORMAT(
++      "'P'S'F"
++      "25"
++    );
++    
++    class Decoder : public Formats::Chiptune::Decoder
++    {
++    public:
++      Decoder()
++        : Format(Binary::CreateMatchOnlyFormat(FORMAT))
++      {
++      }
++
++      String GetDescription() const override
++      {
++        return Text::NITROCOMPOSERSOUNDFORMAT_DECODER_DESCRIPTION;
++      }
++
++      Binary::Format::Ptr GetFormat() const override
++      {
++        return Format;
++      }
++
++      bool Check(const Binary::Container& rawData) const override
++      {
++        return Format->Match(rawData);
++      }
++
++      Formats::Chiptune::Container::Ptr Decode(const Binary::Container& /*rawData*/) const override
++      {
++        return Formats::Chiptune::Container::Ptr();//TODO
++      }
++    private:
++      const Binary::Format::Ptr Format;
++    };
++  }
++
++  Decoder::Ptr CreateNCSFDecoder()
++  {
++    return MakePtr<NitroComposerSoundFormat::Decoder>();
++  }
++}
++}
+diff --git a/src/formats/chiptune/emulation/nitrocomposersoundformat.h b/src/formats/chiptune/emulation/nitrocomposersoundformat.h
+new file mode 100644
+index 000000000..04dad45ff
+--- /dev/null
++++ b/src/formats/chiptune/emulation/nitrocomposersoundformat.h
+@@ -0,0 +1,39 @@
++/**
++* 
++* @file
++*
++* @brief  NCSF parser interface
++*
++* @author vitamin.caig@gmail.com
++*
++**/
++
++#pragma once
++
++//library includes
++#include <binary/view.h>
++#include <formats/chiptune.h>
++
++namespace Formats
++{
++  namespace Chiptune
++  {
++    namespace NitroComposerSoundFormat
++    {
++      const uint_t VERSION_ID = 0x25;
++      
++      class Builder
++      {
++      public:
++        virtual ~Builder() = default;
++        
++        virtual void SetChunk(uint32_t offset, Binary::View content) = 0;
++      };
++
++      void ParseRom(Binary::View data, Builder& target);
++      uint32_t ParseState(Binary::View data);
++    }
++
++    Decoder::Ptr CreateNCSFDecoder();
++  }
++}
+diff --git a/src/formats/instrumentation/fuzz.cpp b/src/formats/instrumentation/fuzz.cpp
+index 9ca135170..e44967dee 100644
+--- a/src/formats/instrumentation/fuzz.cpp
++++ b/src/formats/instrumentation/fuzz.cpp
+@@ -132,6 +132,7 @@ namespace
+       ChiptuneDecoders.push_back(CreateUSFDecoder());
+       ChiptuneDecoders.push_back(CreateGSFDecoder());
+       ChiptuneDecoders.push_back(Create2SFDecoder());
++      ChiptuneDecoders.push_back(CreateNCSFDecoder());
+       ChiptuneDecoders.push_back(CreateSSFDecoder());
+       ChiptuneDecoders.push_back(CreateDSFDecoder());
+       ChiptuneDecoders.push_back(CreateRasterMusicTrackerDecoder());
+diff --git a/src/formats/text/chiptune.cpp b/src/formats/text/chiptune.cpp
+index 92540aa75..413e3ef06 100644
+--- a/src/formats/text/chiptune.cpp
++++ b/src/formats/text/chiptune.cpp
+@@ -111,6 +111,9 @@ extern const Char MULTITRACK_CONTAINER_DECODER_DESCRIPTION[] = {
+ extern const Char NINTENDODSSOUNDFORMAT_DECODER_DESCRIPTION[] = {
+   'N','i','n','t','e','n','d','o',' ','D','S',' ','S','o','u','n','d',' ','F','o','r','m','a','t',0
+ };
++extern const Char NITROCOMPOSERSOUNDFORMAT_DECODER_DESCRIPTION[] = {
++  'N','i','t','r','o',' ','C','o','m','p','o','s','e','r',' ','S','o','u','n','d',' ','F','o','r','m','a','t',0
++};
+ extern const Char NSFE_DECODER_DESCRIPTION[] = {
+   'E','x','t','e','n','d','e','d',' ','N','i','n','t','e','n','d','o',' ','S','o','u','n','d',' ','F','o','r',
+   'm','a','t',0
+diff --git a/src/formats/text/chiptune.h b/src/formats/text/chiptune.h
+index a4c214b93..5289f936d 100644
+--- a/src/formats/text/chiptune.h
++++ b/src/formats/text/chiptune.h
+@@ -38,6 +38,7 @@ extern const Char KSS_DECODER_DESCRIPTION[];
+ extern const Char MP3_DECODER_DESCRIPTION[];
+ extern const Char MULTITRACK_CONTAINER_DECODER_DESCRIPTION[];
+ extern const Char NINTENDODSSOUNDFORMAT_DECODER_DESCRIPTION[];
++extern const Char NITROCOMPOSERSOUNDFORMAT_DECODER_DESCRIPTION[];
+ extern const Char NSFE_DECODER_DESCRIPTION[];
+ extern const Char NSF_DECODER_DESCRIPTION[];
+ extern const Char OGGVORBIS_DECODER_DESCRIPTION[];
+diff --git a/src/formats/text/chiptune.txt b/src/formats/text/chiptune.txt
+index 2be21b5b9..054e3431d 100644
+--- a/src/formats/text/chiptune.txt
++++ b/src/formats/text/chiptune.txt
+@@ -307,6 +307,10 @@ __cpp> "}//namespace Text\n"
+ < NINTENDODSSOUNDFORMAT_DECODER_DESCRIPTION
+ > "Nintendo DS Sound Format"
+ 
++#NCSF
++< NITROCOMPOSERSOUNDFORMAT_DECODER_DESCRIPTION
++> "Nitro Composer Sound Format"
++
+ #SSF
+ < SEGASATURNSOUNDFORMAT_DECODER_DESCRIPTION
+ > "Sega Saturn Sound Format"
+diff --git a/src/module/players/xsf/ncsf.cpp b/src/module/players/xsf/ncsf.cpp
+new file mode 100644
+index 000000000..bcceb025e
+--- /dev/null
++++ b/src/module/players/xsf/ncsf.cpp
+@@ -0,0 +1,454 @@
++/**
++*
++* @file
++*
++* @brief  NCSF chiptune factory implementation
++*
++* @author liushuyu011@gmail.com
++*
++**/
++
++//local includes
++#include "module/players/xsf/ncsf.h"
++#include "module/players/xsf/memory_region.h"
++#include "module/players/xsf/xsf.h"
++#include "module/players/xsf/xsf_factory.h"
++//common includes
++#include <contract.h>
++#include <make_ptr.h>
++//library includes
++#include <binary/compression/zlib_container.h>
++#include <debug/log.h>
++#include <devices/details/analysis_map.h>
++#include <formats/chiptune/emulation/nitrocomposersoundformat.h>
++#include <math/bitops.h>
++#include <module/attributes.h>
++#include <module/players/analyzer.h>
++#include <module/players/fading.h>
++#include <module/players/streaming.h>
++#include <parameters/tracking_helper.h>
++#include <sound/chunk_builder.h>
++#include <sound/render_params.h>
++#include <sound/resampler.h>
++#include <sound/sound_parameters.h>
++//std includes
++#include <list>
++//3rdparty includes
++#include <3rdparty/sseqplayer/Player.h>
++#include <3rdparty/sseqplayer/SDAT.h>
++//text includes
++#include <module/text/platforms.h>
++
++namespace Module
++{
++    namespace NCSF
++    {
++        const Debug::Stream Dbg("Module::NCSF");
++
++        struct ModuleData
++        {
++            using Ptr = std::shared_ptr<const ModuleData>;
++            using RWPtr = std::shared_ptr<ModuleData>;
++
++            ModuleData() = default;
++            ModuleData(const ModuleData &) = delete;
++
++            std::list<Binary::Container::Ptr> PackedProgramSections;
++            std::list<Binary::Container::Ptr> ReservedSections;
++
++            XSF::MetaInformation::Ptr Meta;
++        };
++
++        class AnalysisMap
++        {
++        public:
++            AnalysisMap()
++            {
++                const auto CLOCKRATE = 33513982 / 2;
++                const auto C3_RATE = 130.81f;
++                const auto C3_SAMPLERATE = 8000;
++                Delegate.SetClockRate(CLOCKRATE * C3_RATE / C3_SAMPLERATE);
++            }
++
++            uint_t GetBand(uint_t timer) const
++            {
++                return Delegate.GetBandByPeriod(0x10000 - timer);
++            }
++
++        private:
++            Devices::Details::AnalysisMap Delegate;
++        };
++
++        class NCSFEngine : public Module::Analyzer
++        {
++        public:
++            using Ptr = std::shared_ptr<NCSFEngine>;
++
++            enum
++            {
++                SAMPLERATE = 48000
++            };
++
++            explicit NCSFEngine(const ModuleData &data)
++            {
++                if (data.Meta)
++                {
++                    SetupEnvironment(*data.Meta);
++                }
++                if (!data.PackedProgramSections.empty())
++                {
++                    SetupRom(data.PackedProgramSections);
++                }
++                if (!data.ReservedSections.empty())
++                {
++                    SetupState(data.ReservedSections);
++                }
++
++                PseudoFile file;
++                file.data = &Rom.Data;
++                sdat.reset(new SDAT(file, sseq));
++                NCSFPlayer.sampleRate = SAMPLERATE;
++                NCSFPlayer.interpolation = INTERPOLATION_SINC;
++                NCSFPlayer.Setup(sdat->sseq.get());
++                NCSFPlayer.Timer(); // start the emulation timer
++            }
++
++            ~NCSFEngine() override
++            {
++                NCSFPlayer.Stop(true); // stop the emulation and shut off the sound output (true = kill sound)
++            }
++
++            Sound::Chunk Render(uint_t samples)
++            {
++                static_assert(Sound::Sample::CHANNELS == 2, "Invalid sound channels count");
++                static_assert(Sound::Sample::MID == 0, "Invalid sound sample type");
++                static_assert(Sound::Sample::MAX == 32767 && Sound::Sample::MIN == -32768, "Invalid sound sample type");
++
++                Sound::Chunk res(samples);
++                std::vector<uint8_t> sampleBuffer;
++                sampleBuffer.resize(samples * 2 * sizeof(int16_t), 0);
++                NCSFPlayer.GenerateSamples(sampleBuffer, 0, samples);
++                memmove(res.data(), sampleBuffer.data(), samples * 2 * sizeof(int16_t));
++                return res;
++            }
++
++            void Skip(uint_t samples)
++            {
++                std::vector<uint8_t> sampleBuffer;
++                sampleBuffer.resize(samples * 2 * sizeof(int16_t), 0);
++                NCSFPlayer.GenerateSamples(sampleBuffer, 0, samples);
++            }
++
++            SpectrumState GetState() const override
++            {
++                static const AnalysisMap ANALYSIS;
++                SpectrumState result;
++                for (const auto &in : NCSFPlayer.channels)
++                {
++                    const auto band = ANALYSIS.GetBand(in.reg.timer);
++                    result.Set(band, LevelType(in.vol, 100));
++                }
++                return result;
++            }
++
++        private:
++            void SetupEnvironment(const XSF::MetaInformation &meta)
++            {
++            }
++
++            int *FindTagTarget(const String &name)
++            {
++                return nullptr;
++            }
++
++            void SetupRom(const std::list<Binary::Container::Ptr> &blocks)
++            {
++                ChunkBuilder builder;
++                for (const auto &block : blocks)
++                {
++                    const auto unpacked = Binary::Compression::Zlib::Decompress(*block);
++                    Formats::Chiptune::NitroComposerSoundFormat::ParseRom(*unpacked, builder);
++                }
++                //possibly, emulation writes to ROM are, so copy it
++                Rom = builder.CaptureResult();
++                //required power of 2 size
++                const auto alignedRomSize = uint32_t(1) << Math::Log2(Rom.Data.size());
++                Rom.Data.resize(alignedRomSize);
++            }
++
++            void SetupState(const std::list<Binary::Container::Ptr> &blocks)
++            {
++                ChunkBuilder builder;
++                for (const auto &block : blocks)
++                {
++                    sseq = Formats::Chiptune::NitroComposerSoundFormat::ParseState(*block);
++                }
++            }
++
++        private:
++            class ChunkBuilder : public Formats::Chiptune::NitroComposerSoundFormat::Builder
++            {
++            public:
++                void SetChunk(uint32_t offset, Binary::View content) override
++                {
++                    Result.Update(offset, content);
++                }
++
++                MemoryRegion CaptureResult()
++                {
++                    return std::move(Result);
++                }
++
++            private:
++                MemoryRegion Result;
++            };
++
++        private:
++            Player NCSFPlayer;
++            std::unique_ptr<SDAT> sdat;
++            uint32_t sseq = 0;
++            MemoryRegion Rom;
++        };
++
++        class Renderer : public Module::Renderer
++        {
++        public:
++            Renderer(ModuleData::Ptr data, Information::Ptr info, Sound::Receiver::Ptr target, Parameters::Accessor::Ptr params)
++                : Data(std::move(data)), Iterator(Module::CreateStreamStateIterator(info)), State(Iterator->GetStateObserver()), SoundParams(Sound::RenderParameters::Create(params)), Target(Module::CreateFadingReceiver(std::move(params), std::move(info), State, std::move(target))), Engine(MakePtr<NCSFEngine>(*Data)), Looped()
++            {
++                const auto frameDuration = SoundParams->FrameDuration();
++                SamplesPerFrame = frameDuration.Get() * NCSFEngine::SAMPLERATE / frameDuration.PER_SECOND;
++                ApplyParameters();
++            }
++
++            Module::State::Ptr GetState() const override
++            {
++                return State;
++            }
++
++            Module::Analyzer::Ptr GetAnalyzer() const override
++            {
++                return Engine;
++            }
++
++            bool RenderFrame() override
++            {
++                try
++                {
++                    ApplyParameters();
++
++                    Resampler->ApplyData(Engine->Render(SamplesPerFrame));
++                    Iterator->NextFrame(Looped);
++                    return Iterator->IsValid();
++                }
++                catch (const std::exception &)
++                {
++                    return false;
++                }
++            }
++
++            void Reset() override
++            {
++                SoundParams.Reset();
++                Iterator->Reset();
++                Engine = MakePtr<NCSFEngine>(*Data);
++                Looped = {};
++            }
++
++            void SetPosition(uint_t frame) override
++            {
++                SeekTune(frame);
++                Module::SeekIterator(*Iterator, frame);
++            }
++
++        private:
++            void ApplyParameters()
++            {
++                if (SoundParams.IsChanged())
++                {
++                    Looped = SoundParams->Looped();
++                    Resampler = Sound::CreateResampler(NCSFEngine::SAMPLERATE, SoundParams->SoundFreq(), Target);
++                }
++            }
++
++            void SeekTune(uint_t frame)
++            {
++                uint_t current = State->Frame();
++                if (frame < current)
++                {
++                    Engine = MakePtr<NCSFEngine>(*Data);
++                    current = 0;
++                }
++                if (const uint_t delta = frame - current)
++                {
++                    Engine->Skip(delta * SamplesPerFrame);
++                }
++            }
++
++        private:
++            const ModuleData::Ptr Data;
++            const StateIterator::Ptr Iterator;
++            const Module::State::Ptr State;
++            uint_t SamplesPerFrame;
++            Parameters::TrackingHelper<Sound::RenderParameters> SoundParams;
++            const Sound::Receiver::Ptr Target;
++            NCSFEngine::Ptr Engine;
++            Sound::Receiver::Ptr Resampler;
++            Sound::LoopParameters Looped;
++        };
++
++        class Holder : public Module::Holder
++        {
++        public:
++            Holder(ModuleData::Ptr tune, Information::Ptr info, Parameters::Accessor::Ptr props)
++                : Tune(std::move(tune)), Info(std::move(info)), Properties(std::move(props))
++            {
++            }
++
++            Module::Information::Ptr GetModuleInformation() const override
++            {
++                return Info;
++            }
++
++            Parameters::Accessor::Ptr GetModuleProperties() const override
++            {
++                return Properties;
++            }
++
++            Renderer::Ptr CreateRenderer(Parameters::Accessor::Ptr params, Sound::Receiver::Ptr target) const override
++            {
++                return MakePtr<Renderer>(Tune, Info, std::move(target), std::move(params));
++            }
++
++            static Ptr Create(ModuleData::Ptr tune, Parameters::Container::Ptr properties)
++            {
++                const auto period = Sound::GetFrameDuration(*properties);
++                const auto duration = tune->Meta->Duration;
++                const auto frames = duration.Divide<uint_t>(period);
++                Information::Ptr info = CreateStreamInfo(frames);
++                if (tune->Meta)
++                {
++                    tune->Meta->Dump(*properties);
++                }
++                properties->SetValue(ATTR_PLATFORM, Platforms::NINTENDO_DS);
++                return MakePtr<Holder>(std::move(tune), std::move(info), std::move(properties));
++            }
++
++        private:
++            const ModuleData::Ptr Tune;
++            const Information::Ptr Info;
++            const Parameters::Accessor::Ptr Properties;
++        };
++
++        class ModuleDataBuilder
++        {
++        public:
++            ModuleDataBuilder()
++                : Result(MakeRWPtr<ModuleData>())
++            {
++            }
++
++            void AddProgramSection(Binary::Container::Ptr packedSection)
++            {
++                Require(!!packedSection);
++                Result->PackedProgramSections.push_back(std::move(packedSection));
++            }
++
++            void AddReservedSection(Binary::Container::Ptr reservedSection)
++            {
++                Require(!!reservedSection);
++                Result->ReservedSections.push_back(std::move(reservedSection));
++            }
++
++            void AddMeta(const XSF::MetaInformation &meta)
++            {
++                if (!Meta)
++                {
++                    Result->Meta = Meta = MakeRWPtr<XSF::MetaInformation>(meta);
++                }
++                else
++                {
++                    Meta->Merge(meta);
++                }
++            }
++
++            ModuleData::Ptr CaptureResult()
++            {
++                return Result;
++            }
++
++        private:
++            const ModuleData::RWPtr Result;
++            XSF::MetaInformation::RWPtr Meta;
++        };
++
++        class Factory : public XSF::Factory
++        {
++        public:
++            Holder::Ptr CreateSinglefileModule(const XSF::File &file, Parameters::Container::Ptr properties) const override
++            {
++                ModuleDataBuilder builder;
++                if (file.PackedProgramSection)
++                {
++                    builder.AddProgramSection(file.PackedProgramSection);
++                }
++                if (file.ReservedSection)
++                {
++                    builder.AddReservedSection(file.ReservedSection);
++                }
++                if (file.Meta)
++                {
++                    builder.AddMeta(*file.Meta);
++                }
++                return Holder::Create(builder.CaptureResult(), std::move(properties));
++            }
++
++            Holder::Ptr CreateMultifileModule(const XSF::File &file, const std::map<String, XSF::File> &additionalFiles, Parameters::Container::Ptr properties) const override
++            {
++                ModuleDataBuilder builder;
++                MergeSections(file, additionalFiles, builder);
++                MergeMeta(file, additionalFiles, builder);
++                return Holder::Create(builder.CaptureResult(), std::move(properties));
++            }
++
++        private:
++            static const uint_t MAX_LEVEL = 10;
++
++            static void MergeSections(const XSF::File &data, const std::map<String, XSF::File> &additionalFiles, ModuleDataBuilder &dst, uint_t level = 1)
++            {
++                if (!data.Dependencies.empty() && level < MAX_LEVEL)
++                {
++                    MergeSections(additionalFiles.at(data.Dependencies.front()), additionalFiles, dst, level + 1);
++                }
++                if (data.PackedProgramSection)
++                {
++                    dst.AddProgramSection(data.PackedProgramSection);
++                }
++                if (data.ReservedSection)
++                {
++                    dst.AddReservedSection(data.ReservedSection);
++                }
++            }
++
++            static void MergeMeta(const XSF::File &data, const std::map<String, XSF::File> &additionalFiles, ModuleDataBuilder &dst, uint_t level = 1)
++            {
++                if (level < MAX_LEVEL)
++                {
++                    for (const auto &dep : data.Dependencies)
++                    {
++                        MergeMeta(additionalFiles.at(dep), additionalFiles, dst, level + 1);
++                    }
++                }
++                if (data.Meta)
++                {
++                    dst.AddMeta(*data.Meta);
++                }
++            }
++        };
++
++        Module::Factory::Ptr CreateFactory()
++        {
++            return XSF::CreateFactory(MakePtr<Factory>());
++        }
++    } // namespace NCSF
++} // namespace Module
+\ No newline at end of file
+diff --git a/src/module/players/xsf/ncsf.h b/src/module/players/xsf/ncsf.h
+new file mode 100644
+index 000000000..9f85c64ae
+--- /dev/null
++++ b/src/module/players/xsf/ncsf.h
+@@ -0,0 +1,22 @@
++/**
++* 
++* @file
++*
++* @brief  NCSF chiptune factory
++*
++* @author liushuyu011@gmail.com
++*
++**/
++
++#pragma once
++
++//library includes
++#include <module/players/factory.h>
++
++namespace Module
++{
++  namespace NCSF
++  {
++    Factory::Ptr CreateFactory();
++  }
++}
+-- 
+2.29.1
+

--- a/extra-multimedia/zxtune/spec
+++ b/extra-multimedia/zxtune/spec
@@ -1,4 +1,4 @@
 VER=4960
-REL=1
+REL=2
 GITSRC="https://bitbucket.org/zxtune/zxtune/"
 GITCO="tags/r$VER"


### PR DESCRIPTION
Topic Description
-----------------

Add and update patches included in the `zxtune` package

Package(s) Affected
-------------------

- `zxtune`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2449)
<!-- Reviewable:end -->
