### PR TITLE
fcitx5: update on 20201030

### DIFF
--- a/extra-i18n/fcitx5-anthy/spec
+++ b/extra-i18n/fcitx5-anthy/spec
@@ -1,4 +1,4 @@
 VER=20200915
-GITSRC="https://github.com/fcitx/fcitx5-anthy"
-GITCO="4f2975033dc51fb67e0647b2683d7cd667b6c330"
-REL=2
+SRCS="git::commit=4f2975033dc51fb67e0647b2683d7cd667b6c330::https://github.com/fcitx/fcitx5-anthy"
+CHKSUMS="SKIP"
+REL=3

--- a/extra-i18n/fcitx5-chinese-addons/spec
+++ b/extra-i18n/fcitx5-chinese-addons/spec
@@ -1,4 +1,3 @@
-VER=20200928
-GITSRC="https://github.com/fcitx/fcitx5-chinese-addons"
-GITCO="6565855480f827d08f0eebd3e5150dd4d378b356"
-REL=1
+VER=20201029
+SRCS="git::commit=930b4c2b869b2f12bef9b0ca885e8299c631f3aa::https://github.com/fcitx/fcitx5-chinese-addons"
+CHKSUMS="SKIP"

--- a/extra-i18n/fcitx5-configtool/spec
+++ b/extra-i18n/fcitx5-configtool/spec
@@ -1,4 +1,3 @@
-VER=20200927
-GITSRC="https://github.com/fcitx/fcitx5-configtool"
-GITCO="bdb10254919a4f88672ab904dd73cd8c38c4e7e7"
-REL=1
+VER=20201029
+SRCS="git::commit=fd9831de14b8fbcbf6f901512d2e0146cb54043e::https://github.com/fcitx/fcitx5-configtool"
+CHKSUMS="SKIP"

--- a/extra-i18n/fcitx5-gtk/spec
+++ b/extra-i18n/fcitx5-gtk/spec
@@ -1,4 +1,4 @@
 VER=20200913
-GITSRC="https://github.com/fcitx/fcitx5-gtk"
-GITCO="8835e96d9ce0620b930d3f4ef7db73ceae4f029c"
-REL=3
+SRCS="git::commit=8835e96d9ce0620b930d3f4ef7db73ceae4f029c::https://github.com/fcitx/fcitx5-gtk"
+CHKSUMS="SKIP"
+REL=4

--- a/extra-i18n/fcitx5-kkc/spec
+++ b/extra-i18n/fcitx5-kkc/spec
@@ -1,4 +1,4 @@
 VER=20200915
-GITSRC="https://github.com/fcitx/fcitx5-kkc"
-GITCO="0ffde563576b3ac4f62c55f5508251de3f22fd0b"
-REL=2
+SRCS="git::commit=0ffde563576b3ac4f62c55f5508251de3f22fd0b::https://github.com/fcitx/fcitx5-kkc"
+CHKSUMS="SKIP"
+REL=3

--- a/extra-i18n/fcitx5-lua/spec
+++ b/extra-i18n/fcitx5-lua/spec
@@ -1,4 +1,4 @@
 VER=20200824
-GITSRC="https://github.com/fcitx/fcitx5-lua"
-GITCO="ff218dd82db069d4a502a3eb212a80184c592ce0"
-REL=5
+SRCS="git::commit=ff218dd82db069d4a502a3eb212a80184c592ce0::https://github.com/fcitx/fcitx5-lua"
+CHKSUMS="SKIP"
+REL=6

--- a/extra-i18n/fcitx5-qt/spec
+++ b/extra-i18n/fcitx5-qt/spec
@@ -1,4 +1,3 @@
-VER=20200915
-GITSRC="https://github.com/fcitx/fcitx5-qt"
-GITCO="f5adc1bd85a89a1d3888052fa9403c8e9b454bfa"
-REL=2
+VER=20201029
+SRCS="git::commit=97ea203b406849328d14918e135985ef64e1031b::https://github.com/fcitx/fcitx5-qt"
+CHKSUMS="SKIP"

--- a/extra-i18n/fcitx5-rime/spec
+++ b/extra-i18n/fcitx5-rime/spec
@@ -1,4 +1,4 @@
 VER=20200913
-GITSRC="https://github.com/fcitx/fcitx5-rime"
-GITCO="e20996d752e3b2882d35c15630fa4b75da177485"
-REL=3
+SRCS="git::commit=e20996d752e3b2882d35c15630fa4b75da177485::https://github.com/fcitx/fcitx5-rime"
+CHKSUMS="SKIP"
+REL=4

--- a/extra-i18n/fcitx5/autobuild/defines
+++ b/extra-i18n/fcitx5/autobuild/defines
@@ -7,8 +7,8 @@ PKGDEP="enchant iso-codes cairo xkeyboard-config libxkbcommon pango \
 BUILDDEP="extra-cmake-modules"
 PKGCONFL="fcitx"
 
-PKGBREAK="fcitx5-anthy<=20200915-1 fcitx5-chinese-addons<=20200928 \
-          fcitx5-configtool<=20200927 fcitx5-gtk<=20200913-2 \
-          fcitx5-kkc<=20200915-1 fcitx5-lua<=20200824-4 \
-          fcitx5-qt<=20200915-1 fcitx5-rime<=20200913-2 \
-          kcm-fcitx5<=20200803 libime<=20200928"
+PKGBREAK="fcitx5-anthy<=20200915-2 fcitx5-chinese-addons<=20200928-1 \
+          fcitx5-configtool<=20200927-1 fcitx5-gtk<=20200913-3 \
+          fcitx5-kkc<=20200915-2 fcitx5-lua<=20200824-5 \
+          fcitx5-qt<=20200915-2 fcitx5-rime<=20200913-3 \
+          kcm-fcitx5<=20200803 libime<=20200928-1"

--- a/extra-i18n/fcitx5/autobuild/defines
+++ b/extra-i18n/fcitx5/autobuild/defines
@@ -7,8 +7,8 @@ PKGDEP="enchant iso-codes cairo xkeyboard-config libxkbcommon pango \
 BUILDDEP="extra-cmake-modules"
 PKGCONFL="fcitx"
 
-PKGBREAK="fcitx5-anthy<=20200915-2 fcitx5-chinese-addons<=20200928-1 \
-          fcitx5-configtool<=20200927-1 fcitx5-gtk<=20200913-3 \
-          fcitx5-kkc<=20200915-2 fcitx5-lua<=20200824-5 \
-          fcitx5-qt<=20200915-2 fcitx5-rime<=20200913-3 \
-          kcm-fcitx5<=20200803 libime<=20200928-1"
+PKGBREAK="fcitx5-anthy<=20200915-1 fcitx5-chinese-addons<=20200928 \
+          fcitx5-configtool<=20200927 fcitx5-gtk<=20200913-2 \
+          fcitx5-kkc<=20200915-1 fcitx5-lua<=20200824-4 \
+          fcitx5-qt<=20200915-1 fcitx5-rime<=20200913-2 \
+          kcm-fcitx5<=20200803 libime<=20200928"

--- a/extra-i18n/fcitx5/spec
+++ b/extra-i18n/fcitx5/spec
@@ -1,4 +1,3 @@
-VER=20200928
-REL=1
-GITSRC="https://github.com/fcitx/fcitx5"
-GITCO="645da53b7dd2d852e9630970c5dababa52f2b907"
+VER=20201030
+SRCS="git::commit=c66d341618e150862a9134a13b495b2d7e733c7c::https://github.com/fcitx/fcitx5"
+CHKSUMS="SKIP"

--- a/extra-i18n/libime/spec
+++ b/extra-i18n/libime/spec
@@ -1,4 +1,3 @@
-VER=20200928
-GITSRC="https://github.com/fcitx/libime"
-GITCO="640b39a7993c51dd15e35f879cba8eedefbc7a94"
-REL=1
+VER=20201029
+SRCS="git::commit=22106dcf1681f6a5135a2d7fd35a3775187ca111::https://github.com/fcitx/libime"
+CHKSUMS="SKIP"

--- a/extra-libs/xcb-imdkit/autobuild/defines
+++ b/extra-libs/xcb-imdkit/autobuild/defines
@@ -4,3 +4,4 @@ PKGDES="input method development support for xcb"
 BUILDDEP="extra-cmake-modules xcb-util xcb-util-keysyms"
 PKGDEP="xcb-util xcb-util-keysyms"
 
+PKGBREAK="fcitx5<=20200928-1"

--- a/extra-libs/xcb-imdkit/autobuild/defines
+++ b/extra-libs/xcb-imdkit/autobuild/defines
@@ -3,5 +3,3 @@ PKGSEC=libs
 PKGDES="input method development support for xcb"
 BUILDDEP="extra-cmake-modules xcb-util xcb-util-keysyms"
 PKGDEP="xcb-util xcb-util-keysyms"
-
-PKGBREAK="fcitx5<=20200928-1"

--- a/extra-libs/xcb-imdkit/spec
+++ b/extra-libs/xcb-imdkit/spec
@@ -1,3 +1,3 @@
-VER=20200904
-GITSRC="https://github.com/fcitx/xcb-imdkit/"
-GITCO="33f5c35daf543c0faac1041c2896306b82baff64"
+VER=202001029
+SRCS="git::commit=6a5280cf92f8715e483d1511a6d0cd50efea6633::https://github.com/fcitx/xcb-imdkit/"
+CHKSUMS="SKIP"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
```
* 4d01870a8f (HEAD -> fcitx5-20201030, upstream/fcitx5-20201030) xcb-imdkit: update package break
* 1a7327dd7f fcitx5: update package break
* 5e9fa8ecff fcitx5-lua：rebuild for fcitx5; use SRCS
* 124d3ae90d fcitx5-configtool: update to 20201029; use SRCS
* 73ff22a9e1 fcitx5-kkc: rebuild for fcitx5; use SRCS
* 56d5bafc3d fcitx5-anthy: rebuild for fcitx5; use SRCS
* 7cb5c6d7f0 fcitx5-rime: rebuild for fcitx5; use SRCS
* a7652a492c fcitx5-chinese-addons: update to 20201029; use SRCS
* 82f1017be0 libime: update to 20201029; use SRCS
* 51da634961 fcitx5-gtk: use SRCS; rebuild for fcitx5
* e53e4af74a fcitx5-qt: update to 20201029
* 2761d50b8f fcitx5: update to 20201030
* 7358df2681 xcb-imdkit: update to 20201029
```

Package(s) Affected
-------------------

See Topic Description

Security Update?
----------------

No
<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

See TREE/groups/fcitx5

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
