### PR TITLE
linux-kernel*: fix systemd-boot-friend trigger

### DIFF
--- a/extra-kernel/linux-kernel-lts/autobuild/defines
+++ b/extra-kernel/linux-kernel-lts/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=linux-kernel-lts-5.4.65
 PKGSEC=kernel
 PKGDEP=""
-BUILDDEP="bc dracut git"
+BUILDDEP="bc dracut systemd-boot-friend git"
 BUILDDEP__AMD64="grub"
 PKGDES="Generic Linux Kernel v5.4.65 for AOSC OS (Long Term Support)"
 

--- a/extra-kernel/linux-kernel-lts/spec
+++ b/extra-kernel/linux-kernel-lts/spec
@@ -1,3 +1,4 @@
 VER=5.4.65
+REL=1
 SRCTBL="https://cdn.kernel.org/pub/linux/kernel/v${VER:0:1}.x/linux-$VER.tar.xz"
 CHKSUM="sha256::f514834417d09de1667836e443e085bf37952603f23572b69ef0fcfda16cac69"

--- a/extra-kernel/linux-kernel/autobuild/defines
+++ b/extra-kernel/linux-kernel/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=linux-kernel-5.8.2
 PKGSEC=kernel
 PKGDEP=""
-BUILDDEP="bc dracut git"
+BUILDDEP="bc dracut git systemd-boot-friend"
 BUILDDEP__AMD64="${BUILDDEP} grub"
 PKGDES="Generic Linux Kernel v5.8.2 for AOSC OS (Mainline)"
 

--- a/extra-kernel/linux-kernel/spec
+++ b/extra-kernel/linux-kernel/spec
@@ -1,4 +1,4 @@
 VER=5.8.2
-REL=1
+REL=2
 SRCTBL="https://cdn.kernel.org/pub/linux/kernel/v${VER:0:1}.x/linux-$VER.tar.xz"
 CHKSUM="sha256::dc9432f97f08b6a0e5f5e0aaf56025c37094acc343f42f65b2919e66f3acb2a1"


### PR DESCRIPTION
Topic Description
-----------------
Add `systemd-boot-friend` as a builddep of linux-kernel*, so that its trigger will work and will install the kernels to ESP partitions when kernels or their initramfs are updated.

Package(s) Affected
-------------------
+ `linux-kernel`
+ `linux-kernel-lts`

Security Update?
----------------
No

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

~- Loongson 3 `loongson3`~
~- PowerPC 64-bit (Little Endian) `ppc64el`~

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

~- Loongson 3 `loongson3`~
~- PowerPC 64-bit (Little Endian) `ppc64el`~