### PR TITLE
xorgxrdp: new, 0.2.14

### DIFF
--- a/extra-network/tigervnc/autobuild/defines
+++ b/extra-network/tigervnc/autobuild/defines
@@ -3,3 +3,6 @@ PKGSEC=net
 PKGDEP="fltk gnutls libgcrypt mesa libjpeg-turbo pixman x11-app xkeyboard-config"
 BUILDDEP="x11-font x11-app x11-proto cmake imagemagick nasm"
 PKGDES="Suite of VNC servers and clients"
+
+NOLTO__LOONGSON3=1
+

--- a/extra-network/xrdp/autobuild/patches/0003-add-arch-for-ppc64.patch
+++ b/extra-network/xrdp/autobuild/patches/0003-add-arch-for-ppc64.patch
@@ -1,0 +1,16 @@
+diff --git a/common/arch.h b/common/arch.h
+index ccccfa5a..6bf1d9dd 100644
+--- a/common/arch.h
++++ b/common/arch.h
+@@ -80,7 +80,9 @@ typedef int bool_t;
+     defined(__AIX__) || defined(__mips__) || \
+     defined(__ia64__) || defined(__arm__) || \
+     (defined(__PPC__) && defined(__BIG_ENDIAN__)) || \
+-    (defined(__ppc__) && defined(__BIG_ENDIAN__))
++    (defined(__ppc__) && defined(__BIG_ENDIAN__)) || \
++    (defined(__PPC64__) && defined(__LITTLE_ENDIAN__)) || \
++    (defined(__ppc64__) && defined(__LITTLE_ENDIAN__))
+ #define NEED_ALIGN
+ #elif defined(__x86__) || defined(__x86_64__) || \
+       defined(__AMD64__) || defined(_M_IX86) || defined (_M_AMD64) || \
+

--- a/extra-x11/xorgxrdp/autobuild/defines
+++ b/extra-x11/xorgxrdp/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="xorgxrdp"
+PKGSEC=x11
+PKGDES="Xorg drivers for xrdp"
+PKGDEP="xrdp xorg-server"
+BUILDDEP="nasm autoconf automake pkg-config libtool"
+ABTYPE="autotools"

--- a/extra-x11/xorgxrdp/spec
+++ b/extra-x11/xorgxrdp/spec
@@ -1,0 +1,4 @@
+VER="0.2.14"
+SRCTBL="https://github.com/neutrinolabs/xorgxrdp/releases/download/v0.2.14/xorgxrdp-$VER.tar.gz"
+CHKSUM="sha256::cfecc882d7c435109c0a28e3f7e9d7dea35b05db0096bc52ef80653a02f1bf9f"
+


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->

To make `xrdp` usable with default `xorg` backend, the missing component `xorgxrdp` should present in system. xorgxrdp provides config files and some modules for Xorg, to make xrdp work with xorg.

Package(s) Affected
-------------------
Global
- [New] `xorgxrdp`

loongson3
- `tigervnc`
- `xorg`

ppc64le:
- `xorg`

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
