### PR TITLE
snapper: new, 0.8.14

### DIFF
--- a/extra-admin/snapper/autobuild/beyond
+++ b/extra-admin/snapper/autobuild/beyond
@@ -1,0 +1,6 @@
+abinfo "Installing sysconfig.snapper to conf.d..."
+install -Dvm644 "$SRCDIR"/data/sysconfig.snapper \
+                "$PKGDIR"/etc/conf.d/snapper
+
+abinfo "Removing testsuite..."
+rm -rfv "$PKGDIR"/usr/lib/snapper/testsuite

--- a/extra-admin/snapper/autobuild/defines
+++ b/extra-admin/snapper/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=snapper
+PKGSEC=admin
+PKGDEP="btrfs-progs libxml2 dbus boost acl"
+BUILDDEP="libxslt docbook-xsl"
+PKGDES="A tool for Linux btrfs snapshot management"
+
+AUTOTOOLS_AFTER="--with-conf=/etc/conf.d \
+                 --disable-zypp \
+                 --disable-silent-rules"
+
+RECONF=0
+ABSHADOW=0

--- a/extra-admin/snapper/autobuild/patches/fix-drift-file-path.patch
+++ b/extra-admin/snapper/autobuild/patches/fix-drift-file-path.patch
@@ -1,0 +1,10 @@
+diff --git a/data/base.txt b/data/base.txt
+index c75fde9..e1d5303 100644
+--- a/data/base.txt
++++ b/data/base.txt
+@@ -2,4 +2,4 @@
+ /etc/mtab
+ /var/lib/logrotate.status
+ /var/lib/misc/random-seed
+-/var/lib/ntp/drift/ntp.drift
++/var/lib/ntp/ntp.drift

--- a/extra-admin/snapper/autobuild/patches/fix-macro-iterate.patch
+++ b/extra-admin/snapper/autobuild/patches/fix-macro-iterate.patch
@@ -1,0 +1,264 @@
+diff --git a/client/Command.h b/client/Command.h
+index 9ce7760..53cb601 100644
+--- a/client/Command.h
++++ b/client/Command.h
+@@ -23,6 +23,7 @@
+ #define SNAPPER_CLI_COMMAND_H
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ 
+ #include "client/GlobalOptions.h"
+diff --git a/client/Options.h b/client/Options.h
+index 10bfe1d..f94688f 100644
+--- a/client/Options.h
++++ b/client/Options.h
+@@ -23,6 +23,7 @@
+ #define SNAPPER_CLI_OPTIONS_H
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ 
+ #include "client/utils/GetOpts.h"
+diff --git a/client/cleanup.cc b/client/cleanup.cc
+index e1d5f5b..0c2a084 100644
+--- a/client/cleanup.cc
++++ b/client/cleanup.cc
+@@ -22,6 +22,7 @@
+ 
+ 
+ #include <iostream>
++#include <iterator>
+ #include <vector>
+ 
+ #include "dbus/DBusMessage.h"
+diff --git a/client/commands.h b/client/commands.h
+index 11cbc0e..9db78dd 100644
+--- a/client/commands.h
++++ b/client/commands.h
+@@ -22,6 +22,7 @@
+ 
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ #include <map>
+ 
+diff --git a/client/proxy.h b/client/proxy.h
+index 606105e..828a786 100644
+--- a/client/proxy.h
++++ b/client/proxy.h
+@@ -25,6 +25,7 @@
+ 
+ 
+ #include <memory>
++#include <iterator>
+ #include <vector>
+ #include <list>
+ #include <map>
+diff --git a/client/types.h b/client/types.h
+index 9217eac..86fc101 100644
+--- a/client/types.h
++++ b/client/types.h
+@@ -22,6 +22,7 @@
+ 
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ #include <map>
+ 
+diff --git a/dbus/DBusMessage.h b/dbus/DBusMessage.h
+index 09190d0..bf5c519 100644
+--- a/dbus/DBusMessage.h
++++ b/dbus/DBusMessage.h
+@@ -28,6 +28,7 @@
+ #include <dbus/dbus.h>
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ #include <list>
+ #include <map>
+diff --git a/snapper/Acls.h b/snapper/Acls.h
+index 6aa5d7e..4bed783 100644
+--- a/snapper/Acls.h
++++ b/snapper/Acls.h
+@@ -22,6 +22,7 @@
+ #define SNAPPER_ACLS_H
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ #include <sys/acl.h>
+ 
+diff --git a/snapper/AppUtil.h b/snapper/AppUtil.h
+index 75947a1..3b52d65 100644
+--- a/snapper/AppUtil.h
++++ b/snapper/AppUtil.h
+@@ -32,6 +32,7 @@
+ #include <string>
+ #include <list>
+ #include <map>
++#include <iterator>
+ #include <vector>
+ #include <stdexcept>
+ #include <chrono>
+diff --git a/snapper/AsciiFile.h b/snapper/AsciiFile.h
+index 63e0abb..930333a 100644
+--- a/snapper/AsciiFile.h
++++ b/snapper/AsciiFile.h
+@@ -25,6 +25,7 @@
+ 
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ #include <map>
+ 
+diff --git a/snapper/BtrfsUtils.h b/snapper/BtrfsUtils.h
+index dd3dd17..65dc21a 100644
+--- a/snapper/BtrfsUtils.h
++++ b/snapper/BtrfsUtils.h
+@@ -27,6 +27,7 @@
+ 
+ #include <stdint.h>
+ #include <string>
++#include <iterator>
+ #include <vector>
+ 
+ 
+diff --git a/snapper/Compare.h b/snapper/Compare.h
+index 0b56c85..fbff80c 100644
+--- a/snapper/Compare.h
++++ b/snapper/Compare.h
+@@ -25,6 +25,7 @@
+ 
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ #include <functional>
+ 
+diff --git a/snapper/Enum.h b/snapper/Enum.h
+index f2abd7f..279d370 100644
+--- a/snapper/Enum.h
++++ b/snapper/Enum.h
+@@ -25,6 +25,7 @@
+ 
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ #include <algorithm>
+ #include <exception>
+diff --git a/snapper/File.h b/snapper/File.h
+index ade271b..9cf7547 100644
+--- a/snapper/File.h
++++ b/snapper/File.h
+@@ -27,6 +27,7 @@
+ #include <sys/stat.h>
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ 
+ 
+diff --git a/snapper/FileUtils.h b/snapper/FileUtils.h
+index 21eed79..c318251 100644
+--- a/snapper/FileUtils.h
++++ b/snapper/FileUtils.h
+@@ -26,6 +26,7 @@
+ 
+ #include <fcntl.h>
+ #include <string>
++#include <iterator>
+ #include <vector>
+ #include <functional>
+ #include <boost/thread.hpp>
+diff --git a/snapper/Filesystem.h b/snapper/Filesystem.h
+index fb8f020..dcd904d 100644
+--- a/snapper/Filesystem.h
++++ b/snapper/Filesystem.h
+@@ -26,6 +26,7 @@
+ 
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ #include <utility>
+ 
+diff --git a/snapper/LvmCache.cc b/snapper/LvmCache.cc
+index f610b60..f62d32c 100644
+--- a/snapper/LvmCache.cc
++++ b/snapper/LvmCache.cc
+@@ -20,6 +20,7 @@
+ 
+ #include "config.h"
+ 
++#include <iterator>
+ #include <vector>
+ #include <boost/algorithm/string.hpp>
+ 
+diff --git a/snapper/LvmCache.h b/snapper/LvmCache.h
+index 5d5e3e3..24a2abf 100644
+--- a/snapper/LvmCache.h
++++ b/snapper/LvmCache.h
+@@ -24,6 +24,7 @@
+ #include <map>
+ #include <set>
+ #include <string>
++#include <iterator>
+ #include <vector>
+ 
+ #include <boost/noncopyable.hpp>
+diff --git a/snapper/Snapper.h b/snapper/Snapper.h
+index cd36e75..49cafb7 100644
+--- a/snapper/Snapper.h
++++ b/snapper/Snapper.h
+@@ -25,6 +25,7 @@
+ #define SNAPPER_SNAPPER_H
+ 
+ 
++#include <iterator>
+ #include <vector>
+ #include <boost/noncopyable.hpp>
+ 
+diff --git a/snapper/SnapperTypes.h b/snapper/SnapperTypes.h
+index 6b482ce..f670a78 100644
+--- a/snapper/SnapperTypes.h
++++ b/snapper/SnapperTypes.h
+@@ -25,6 +25,7 @@
+ 
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ #include <ostream>
+ #include <boost/algorithm/string.hpp>
+diff --git a/snapper/SystemCmd.h b/snapper/SystemCmd.h
+index 3d38604..a11a3a4 100644
+--- a/snapper/SystemCmd.h
++++ b/snapper/SystemCmd.h
+@@ -28,6 +28,7 @@
+ #include <stdio.h>
+ 
+ #include <string>
++#include <iterator>
+ #include <vector>
+ #include <list>
+ #include <boost/noncopyable.hpp>
+diff --git a/snapper/XAttributes.h b/snapper/XAttributes.h
+index 434b4d9..014fe4d 100644
+--- a/snapper/XAttributes.h
++++ b/snapper/XAttributes.h
+@@ -24,6 +24,7 @@
+ 
+ #include <stdint.h>
+ #include <map>
++#include <iterator>
+ #include <vector>
+ #include <string>
+ #include <ostream>

--- a/extra-admin/snapper/autobuild/patches/fix-suse-cron-dir-name.patch
+++ b/extra-admin/snapper/autobuild/patches/fix-suse-cron-dir-name.patch
@@ -1,0 +1,15 @@
+diff --git a/scripts/Makefile.am b/scripts/Makefile.am
+index 2222483..4736c73 100644
+--- a/scripts/Makefile.am
++++ b/scripts/Makefile.am
+@@ -17,8 +17,8 @@ endif
+ EXTRA_DIST = snapper-hourly snapper-daily zypp-plugin.py $(pam_snapper_SCRIPTS)
+ 
+ install-data-local:
+-	install -D snapper-hourly $(DESTDIR)/etc/cron.hourly/suse.de-snapper
+-	install -D snapper-daily $(DESTDIR)/etc/cron.daily/suse.de-snapper
++	install -D snapper-hourly $(DESTDIR)/etc/cron.hourly/snapper
++	install -D snapper-daily $(DESTDIR)/etc/cron.daily/snapper
+ 
+ if HAVE_ZYPP
+ 	install -D zypp-plugin.py $(DESTDIR)/usr/lib/zypp/plugins/commit/snapper.py

--- a/extra-admin/snapper/autobuild/patches/use-conf-d-instead-of-sysconfig.patch
+++ b/extra-admin/snapper/autobuild/patches/use-conf-d-instead-of-sysconfig.patch
@@ -1,0 +1,49 @@
+diff --git a/scripts/pam_snapper_userdel.sh b/scripts/pam_snapper_userdel.sh
+index 30be9be..1ffa63e 100755
+--- a/scripts/pam_snapper_userdel.sh
++++ b/scripts/pam_snapper_userdel.sh
+@@ -40,7 +40,7 @@ fi
+ if [ ${DRYRUN} == 0 ] ; then
+ 	# Delete the snapper configuration
+ 	# This deletes $SNAPPERCFGDIR/home_${MYUSER}
+-	# removes "home_${MYUSER}" from /etc/sysconfig/snapper
++	# removes "home_${MYUSER}" from /etc/conf.d/snapper
+ 	# and deletes all snapshots
+ 	${CMD_SNAPPER} -c home_${MYUSER} delete-config
+ 	# Delete the USER's home subvolume
+diff --git a/scripts/snapper-daily b/scripts/snapper-daily
+index 27e7a10..2ee7fff 100755
+--- a/scripts/snapper-daily
++++ b/scripts/snapper-daily
+@@ -9,10 +9,10 @@ export PATH
+ 
+ 
+ #
+-# get information from /etc/sysconfig/snapper
++# get information from /etc/conf.d/snapper
+ #
+-if [ -f /etc/sysconfig/snapper ] ; then
+-    . /etc/sysconfig/snapper
++if [ -f /etc/conf.d/snapper ] ; then
++    . /etc/conf.d/snapper
+ fi
+ 
+ 
+diff --git a/scripts/snapper-hourly b/scripts/snapper-hourly
+index bc6cd4d..1ef49ff 100755
+--- a/scripts/snapper-hourly
++++ b/scripts/snapper-hourly
+@@ -9,10 +9,10 @@ export PATH
+ 
+ 
+ #
+-# get information from /etc/sysconfig/snapper
++# get information from /etc/conf.d/snapper
+ #
+-if [ -f /etc/sysconfig/snapper ] ; then
+-    . /etc/sysconfig/snapper
++if [ -f /etc/conf.d/snapper ] ; then
++    . /etc/conf.d/snapper
+ fi
+ 
+ 

--- a/extra-admin/snapper/autobuild/patches/use-usr-path.patch
+++ b/extra-admin/snapper/autobuild/patches/use-usr-path.patch
@@ -1,0 +1,37 @@
+diff --git a/data/Makefile.am b/data/Makefile.am
+index e2036ba..c80b269 100644
+--- a/data/Makefile.am
++++ b/data/Makefile.am
+@@ -18,7 +18,7 @@ install-data-local:
+ 	install -D -m 644 lvm.txt $(DESTDIR)/etc/snapper/filters/lvm.txt
+ 	install -D -m 644 x11.txt $(DESTDIR)/etc/snapper/filters/x11.txt
+ 
+-	install -D -m 644 org.opensuse.Snapper.conf $(DESTDIR)/etc/dbus-1/system.d/org.opensuse.Snapper.conf
++	install -D -m 644 org.opensuse.Snapper.conf $(DESTDIR)/usr/share/dbus-1/system.d/org.opensuse.Snapper.conf
+ 	install -D -m 644 org.opensuse.Snapper.service $(DESTDIR)/usr/share/dbus-1/system-services/org.opensuse.Snapper.service
+ 
+ 	install -D -m 644 timeline.service $(DESTDIR)/usr/lib/systemd/system/snapper-timeline.service
+diff --git a/data/org.opensuse.Snapper.service b/data/org.opensuse.Snapper.service
+index 39d7333..6c49474 100644
+--- a/data/org.opensuse.Snapper.service
++++ b/data/org.opensuse.Snapper.service
+@@ -1,5 +1,5 @@
+ # DBus service activation config
+ [D-BUS Service]
+ Name=org.opensuse.Snapper
+-Exec=/usr/sbin/snapperd
++Exec=/usr/bin/snapperd
+ User=root
+diff --git a/pam/Makefile.am b/pam/Makefile.am
+index befccf8..dd1652c 100644
+--- a/pam/Makefile.am
++++ b/pam/Makefile.am
+@@ -8,7 +8,7 @@ AM_CFLAGS = -D_GNU_SOURCE -Wwrite-strings
+ 
+ AM_CPPFLAGS = -I$(top_srcdir) $(DBUS_CFLAGS)
+ 
+-securelibdir = $(shell echo /`basename $(libdir)`/security)
++securelibdir = $(shell echo /usr/`basename $(libdir)`/security)
+ 
+ securelib_LTLIBRARIES = pam_snapper.la
+ 

--- a/extra-admin/snapper/autobuild/prepare
+++ b/extra-admin/snapper/autobuild/prepare
@@ -1,0 +1,7 @@
+abinfo "Configuring..."
+cd "$SRCDIR"
+aclocal --verbose
+libtoolize -v --force --automake --copy
+autoheader -v
+automake --add-missing --copy
+autoconf -v

--- a/extra-admin/snapper/spec
+++ b/extra-admin/snapper/spec
@@ -1,0 +1,3 @@
+VER=0.8.14
+SRCS="tbl::https://github.com/openSUSE/snapper/archive/v0.8.14.tar.gz"
+CHKSUMS="sha256::d3abe4d542dade06b361e7c89b5de03bb5202853bc5e314ca74080caa24923f6"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Add `snapper`! The ultimate tool for automatically managing your btrfs snapshots!

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
