### PR TITLE
openjdk-8: update to 8u272

### DIFF
--- a/extra-java/openjdk-8/autobuild/build
+++ b/extra-java/openjdk-8/autobuild/build
@@ -8,8 +8,9 @@ SJAVAC=1
 [ "${CROSS:-$ARCH}" = "loongson3" ] && export JARCH="mips64" CONFARCH="mips64el"
 [ "${CROSS:-$ARCH}" = "powerpc" ] && export JARCH="ppc" CONFARCH="ppc"
 [ "${CROSS:-$ARCH}" = "ppc64" ] && export JARCH="ppc64" CONFARCH="ppc64"
+[ "${CROSS:-$ARCH}" = "ppc64el" ] && export JARCH="ppc64le" CONFARCH="ppc64le"
 
-if [[ "${CROSS:-$ARCH}" != "amd64" && "${CROSS:-$ARCH}" != arm64 && "${CROSS:-$ARCH}" != "ppc64" && "${CROSS:-$ARCH}" != "loongson3" ]]; then
+if [[ "${CROSS:-$ARCH}" != "amd64" && "${CROSS:-$ARCH}" != arm64 && "${CROSS:-$ARCH}" != ppc64* && "${CROSS:-$ARCH}" != "loongson3" ]]; then
     config_zero="--with-jvm-variants=zero"
     SJAVAC=0
 else
@@ -99,7 +100,7 @@ mv "$PKGDIR"/usr/lib/java-8/src.zip "$PKGDIR"/usr/src/openjdk-8/src.zip
 ln -sv /usr/src/openjdk-8/src.zip "$PKGDIR"/usr/lib/java-8/src.zip
 
 install -d -m 755 "$PKGDIR"/usr/share/doc/openjdk-8
-if [[ "${CROSS:-$ARCH}" != "amd64" && "${CROSS:-$ARCH}" != "arm64" && "${CROSS:-$ARCH}" != 'armel' && "${CROSS:-$ARCH}" != 'ppc64' && "${CROSS:-$ARCH}" != 'loongson3' ]]; then
+if [[ "${CROSS:-$ARCH}" != "amd64" && "${CROSS:-$ARCH}" != "arm64" && "${CROSS:-$ARCH}" != 'armel' && "${CROSS:-$ARCH}" != ppc64* && "${CROSS:-$ARCH}" != 'loongson3' ]]; then
     cp -r build/linux-${JARCH}-normal-zero-release/docs/* \
         "$PKGDIR"/usr/share/doc/openjdk-8/
 elif [[ "${CROSS:-$ARCH}" = 'armel' ]]; then # 32-bit architectures are "client" variants

--- a/extra-java/openjdk-8/spec
+++ b/extra-java/openjdk-8/spec
@@ -1,10 +1,10 @@
-VER=8u265+ga
+VER=8u272+ga
 # aarch64 specific tarball
 SRCS__ARM64="https://repo.aosc.io/aosc-repacks/aarch64-java/openjdk-${VER/+/-}.tar.xz"
-CHKSUMS__ARM64="sha256::289abbb93c3ddcbd865139cb37fac46456a690f1ec0bad5c6010a7519ee982dd"
+CHKSUMS__ARM64="sha256::fcc7a04f1e48c842b965b4f75171a7526fc94b711cc075d4de507c38052396fb"
 # loongson3 specific tarball
 SRCS__LOONGSON3="https://repo.aosc.io/aosc-repacks/ls3-java/openjdk-${VER/+/-}.tar.xz"
-CHKSUMS__LOONGSON3="sha256::a6c769db95bf6fb5738425ca0460f380a2c961f74883a09f9b1f992f4bcf06d5"
+CHKSUMS__LOONGSON3="sha256::2fc57ccb9de585fa65f2f43f2587f47093aeefc4843c7244ecde1e683e461b49"
 
 SRCS="https://openjdk-sources.osci.io/openjdk8/openjdk${VER/+/-}.tar.xz"
-CHKSUMS="sha256::53f5eb7893ef35dcc16ae5b8056613c33a2e8dcfd14281941523fed7a5c397b8"
+CHKSUMS="sha256::ce77e0a3d2b7ff3e2e17e25dd4e1d1499ca950a539c56e5020416957ea7eac6f"

--- a/extra-java/openjfx-8/autobuild/build
+++ b/extra-java/openjfx-8/autobuild/build
@@ -13,7 +13,8 @@ if [[ "${CROSS:-$ARCH}" != "amd64" ]]; then
     BUILD_WEBKIT="false"
 fi
 
-./gradlew -PCOMPILE_WEBKIT="${BUILD_WEBKIT}" -PCOMPILE_MEDIA="true" -PBUILD_JAVADOC="true" -PBUILD_SRC_ZIP="true" -PCONF="Release" -PCOMPANY_NAME="AOSC" "$SINGLE" sdkLinux
+./gradlew -PCOMPILE_JFR="false" -PCOMPILE_WEBKIT="${BUILD_WEBKIT}" -PCOMPILE_MEDIA="true" \
+          -PBUILD_JAVADOC="true" -PBUILD_SRC_ZIP="true" -PCONF="Release" -PCOMPANY_NAME="AOSC" "$SINGLE" sdkLinux
 
 # Adapted from Arch Linux.
 

--- a/extra-java/openjfx-8/spec
+++ b/extra-java/openjfx-8/spec
@@ -1,4 +1,4 @@
 VER=8u202+ga
-REL=4
+REL=5
 SRCTBL="https://hg.openjdk.java.net/openjfx/8u-dev/rt/archive/${VER/+/-}.tar.bz2"
 CHKSUM="sha256::12b0538d04c4bd451e4692ee06357ac36233ff4ec2af9fa3b9bbdbab48c3f2fc"

--- a/extra-java/openjfx-8/spec
+++ b/extra-java/openjfx-8/spec
@@ -1,4 +1,4 @@
 VER=8u202+ga
 REL=5
-SRCTBL="https://hg.openjdk.java.net/openjfx/8u-dev/rt/archive/${VER/+/-}.tar.bz2"
+SRCTBL="https://repo.aosc.io/aosc-repacks/openjfx-8u202-ga.tar.bz2"
 CHKSUM="sha256::12b0538d04c4bd451e4692ee06357ac36233ff4ec2af9fa3b9bbdbab48c3f2fc"


### PR DESCRIPTION
Topic Description
-----------------

Update OpenJDK 8 to version 8u272+ga

Package(s) Affected
-------------------

- `openjdk-8`
- `openjfx-8`

Security Update?
----------------

Yes, #2457

Build Order
-----------

1. `openjdk-8`
1. `openjfx-8`

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2458)
<!-- Reviewable:end -->
