### PR TITLE
wine: add a patch for killing wechat/netease-cloud-music window(s) shadow

### DIFF
--- a/extra-emulation/wine/autobuild/patches/0002-wine-user32-hack-for-disabling-wechat-and-netease-cloud-music-windows-shadow.patch
+++ b/extra-emulation/wine/autobuild/patches/0002-wine-user32-hack-for-disabling-wechat-and-netease-cloud-music-windows-shadow.patch
@@ -1,0 +1,19 @@
+--- a/dlls/user32/win.c  2020-04-09 22:20:30.459968806 +0800
++++ b/dlls/user32/win.c  2020-04-09 21:54:09.588643751 +0800
+@@ -1795,6 +1795,17 @@
+     cs.lpszClass      = className;
+     cs.dwExStyle      = exStyle;
+ 
++    if (exStyle == 0x080800a0) // WeChat/WxWork shadow hwnd
++    {
++        FIXME("hack %x\n", cs.dwExStyle);
++        return NULL;
++    }
++    if (exStyle == 0x000800a0) // Netease Cloudmusic shadow hwnd
++    {
++        FIXME("hack %x\n", cs.dwExStyle);
++        return NULL;
++    }
++
+     return wow_handlers.create_window( &cs, className, instance, TRUE );
+ }

--- a/extra-emulation/wine/spec
+++ b/extra-emulation/wine/spec
@@ -1,3 +1,4 @@
 VER=5.20
 SRCS="tbl::https://dl.winehq.org/wine/source/5.x/wine-$VER.tar.xz"
 CHKSUMS="sha256::8f5522f8cebebdbaa12f58e1ba671a11f66372e0aedf74fb932cf5a89390861c"
+REL=1


### PR DESCRIPTION


Topic Description
-----------------
add a `wine` patch for killing wechat/netease-cloud-music windows shadow

Package(s) Affected
-------------------
`wine`

Security Update?
----------------
No 

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

