### PR TITLE
syncthing: update to 1.10.0

### DIFF
--- a/extra-network/syncthing/spec
+++ b/extra-network/syncthing/spec
@@ -1,5 +1,4 @@
-VER=1.3.2
+VER=1.10.0
 SRCTBL="https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
-CHKSUM="sha256::0de3096bd307d6f845a236100e6dc3096145c51d852443b57cd2c5a9a138537b"
+CHKSUM="sha256::6598bc8daaae70e6e11c8df86f1e38a6a286401cfcbec44f25f5aee9f444eb4e" 
 SUBDIR=.
-REL=4


### PR DESCRIPTION
Topic Description
-----------------
Update syncthing to 1.10.0

Package(s) Affected
-------------------
- syncthing

Security Update?
----------------
No

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Test prosedure
-------------------------------------------
Install `syncthing`, then start systemd user service `syncthing.service`. Then go to http://localhost:8384 to see if the daemon is running correctly.