### PR TITLE
fontconfig: rebase AOSC modifications on top of 2.13.92 for performance improvement

### DIFF
--- a/extra-libs/fontconfig/spec
+++ b/extra-libs/fontconfig/spec
@@ -1,3 +1,3 @@
-VER=2.13.92
-SRCTBL="https://www.freedesktop.org/software/fontconfig/release/fontconfig-$VER.tar.xz"
-CHKSUM="sha256::506e61283878c1726550bc94f2af26168f1e9f2106eac77eaaf0b2cdfad66e4e"
+VER=2.13.92+aosc
+GITSRC="https://github.com/AOSC-Dev/fontconfig"
+GITCO="6cbe067a0717f8308c7d3440b6aa49a2f53dded8"

--- a/extra-optenv32/fontconfig+32/spec
+++ b/extra-optenv32/fontconfig+32/spec
@@ -1,4 +1,3 @@
-VER=2.13.92
-SRCTBL="https://www.freedesktop.org/software/fontconfig/release/fontconfig-$VER.tar.xz"
-CHKSUM="sha256::506e61283878c1726550bc94f2af26168f1e9f2106eac77eaaf0b2cdfad66e4e"
-REL=2
+VER=2.13.92+aosc
+GITSRC="https://github.com/AOSC-Dev/fontconfig"
+GITCO="6cbe067a0717f8308c7d3440b6aa49a2f53dded8"


### PR DESCRIPTION
Topic Description
-----------------

Rebase AOSC-Dev/fontconfig changes on top of 2.13.92, and pack it, to workaround some performance issue in LibreOffice.

Package(s) Affected
-------------------

- `fontconfig` 2.13.92+aosc
- `fontconfig+32` 2.13.92+aosc

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] 32-bit Optional Environment `optenv32`
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] 32-bit Optional Environment `optenv32`
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
