### PR TITLE
openjdk 11.0.9

### DIFF
--- a/extra-java/openjdk/autobuild/build
+++ b/extra-java/openjdk/autobuild/build
@@ -31,9 +31,9 @@ SJAVAC=0
 [ "${CROSS:-$ARCH}" = "arm64" ] && export JARCH="aarch64" CONFARCH="aarch64"
 [ "${CROSS:-$ARCH}" = "mipsel" ] && export JARCH="mipsel" CONFARCH="mipsel"
 [ "${CROSS:-$ARCH}" = "powerpc" ] && export JARCH="ppc" CONFARCH="ppc"
-[ "${CROSS:-$ARCH}" = "ppc64" ] && export JARCH="ppc64" CONFARCH="ppc64"
+[ "${CROSS:-$ARCH}" = "ppc64el" ] && export JARCH="ppc64le" CONFARCH="ppc64le"
 
-if [[ "${CROSS:-$ARCH}" != "amd64" && "${CROSS:-$ARCH}" != armel && "${CROSS:-$ARCH}" != "ppc64" && "${CROSS:-$ARCH}" != "arm64" ]]; then
+if [[ "${CROSS:-$ARCH}" != "amd64" && "${CROSS:-$ARCH}" != armel && "${CROSS:-$ARCH}" != ppc64* && "${CROSS:-$ARCH}" != "arm64" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
     SJAVAC=0
 else

--- a/extra-java/openjdk/spec
+++ b/extra-java/openjdk/spec
@@ -1,4 +1,4 @@
-VER=11.0.8+ga
+VER=11.0.9+ga
 SRCTBL="https://openjdk-sources.osci.io/openjdk11/openjdk-${VER/+/-}.tar.xz"
-CHKSUM="sha256::aa991f4a87c9b778800dea39988c556ea7d20582fab13ee11724557a29d2aa96"
-REL=2
+CHKSUM="sha256::94b83faa3db395892d0c84d35bbbb194233c291a6bee2d1a43e0a72e49348b18"
+REL=0

--- a/extra-java/openjfx/spec
+++ b/extra-java/openjfx/spec
@@ -1,3 +1,3 @@
-VER=11.0.8+2
+VER=11.0.9+4
 SRCTBL="https://repo.aosc.io/aosc-repacks/openjfx-${VER}.tar.xz"
-CHKSUM="sha256::8b99830515af6c7bf9be441fa0bfed4916a064229d5ebc34c87e89e95a4c9289"
+CHKSUM="sha256::026535f717de40c34c31a799b7765046f9e6162bcd2338c5b38ff57d7149b189"


### PR DESCRIPTION
Topic Description
-----------------

Update OpenJDK 11 to version 11.0.9
Package(s) Affected
-------------------

- `openjdk`
- `openjfx`

Security Update?
----------------

Yes, #2459

Build Order
-----------

1. `openjdk`
1. `openjfx`

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2465)
<!-- Reviewable:end -->
