### PR TITLE
linux-kernel: enable ASHMEM

### DIFF
--- a/extra-kernel/linux-kernel/autobuild/amd64/config
+++ b/extra-kernel/linux-kernel/autobuild/amd64/config
@@ -8709,7 +8709,7 @@ CONFIG_VIDEO_USBVISION=m
 #
 # Android
 #
-# CONFIG_ASHMEM is not set
+CONFIG_ASHMEM=y
 # CONFIG_ION is not set
 # end of Android
 

--- a/extra-kernel/linux-kernel/autobuild/arm64/config
+++ b/extra-kernel/linux-kernel/autobuild/arm64/config
@@ -9044,7 +9044,7 @@ CONFIG_VIDEO_USBVISION=m
 #
 # Android
 #
-# CONFIG_ASHMEM is not set
+CONFIG_ASHMEM=y
 # CONFIG_ION is not set
 # end of Android
 

--- a/extra-kernel/linux-kernel/spec
+++ b/extra-kernel/linux-kernel/spec
@@ -1,4 +1,4 @@
 VER=5.8.2
-REL=2
+REL=3
 SRCTBL="https://cdn.kernel.org/pub/linux/kernel/v${VER:0:1}.x/linux-$VER.tar.xz"
 CHKSUM="sha256::dc9432f97f08b6a0e5f5e0aaf56025c37094acc343f42f65b2919e66f3acb2a1"


### PR DESCRIPTION
Topic Description
-----------------

Enable ashmem for linux-kernel for Anbox.

Package(s) Affected
-------------------

- `linux-kernel`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

<!-- TODO: CI to auto-fill architectural progress. -->
