### PR TITLE
vim: fix for KMSCON

### DIFF
--- a/extra-editors/vim/autobuild/patches/0001-Fix-for-kmscon.patch
+++ b/extra-editors/vim/autobuild/patches/0001-Fix-for-kmscon.patch
@@ -1,0 +1,31 @@
+From fd01b3c1ea6d0ea5339119abffd3ec8dbb305784 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <icenowy@aosc.io>
+Date: Sat, 31 Oct 2020 18:59:34 +0800
+Subject: [PATCH] Fix for kmscon
+
+Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
+---
+ src/term.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/term.c b/src/term.c
+index 4d4cc589d..af4cbd802 100644
+--- a/src/term.c
++++ b/src/term.c
+@@ -4681,6 +4681,13 @@ handle_version_response(int first, int *arg, int argc, char_u *tp)
+ 	    term_props[TPR_CURSOR_BLINK].tpr_status = TPR_NO;
+ 	}
+ 
++	// KMSCON sends 1;1;0 and it cannot handle cursor style and blink
++	if (arg[0] == 1 && arg[1] == 1 && arg[2] == 0)
++	{
++	    term_props[TPR_CURSOR_STYLE].tpr_status = TPR_NO;
++	    term_props[TPR_CURSOR_BLINK].tpr_status = TPR_NO;
++	}
++
+ 	// Xterm first responded to this request at patch level
+ 	// 95, so assume anything below 95 is not xterm and hopefully supports
+ 	// the underline RGB color sequence.
+-- 
+2.28.0
+

--- a/extra-editors/vim/autobuild/patches/0002-remove-nolto-flag-from-perl-libs.patch
+++ b/extra-editors/vim/autobuild/patches/0002-remove-nolto-flag-from-perl-libs.patch
@@ -1,0 +1,27 @@
+diff -ur vim-8.2.1725-a/src/auto/configure vim-8.2.1725-b/src/auto/configure
+--- vim-8.2.1725-a/src/auto/configure	2020-09-23 01:15:31.000000000 +0800
++++ vim-8.2.1725-b/src/auto/configure	2020-11-02 16:16:45.122859421 +0800
+@@ -6136,9 +6136,9 @@
+ 		-e 's/-D_FORTIFY_SOURCE=.//g'`
+             perllibs=`cd $srcdir; $vi_cv_path_perl -MExtUtils::Embed -e 'ldopts' | \
+ 		sed -e '/Warning/d' -e '/Note (probably harmless)/d' \
+-			-e 's/-bE:perl.exp//' -e 's/-lc //'`
++			-e 's/-bE:perl.exp//' -e 's/-lc //' -e 's/-fno-lto//'`
+                   perlldflags=`cd $srcdir; $vi_cv_path_perl -MExtUtils::Embed \
+-		-e 'ccdlflags' | sed -e 's/-bE:perl.exp//'`
++		-e 'ccdlflags' | sed -e 's/-bE:perl.exp//' | sed -e 's/-fno-lto//'`
+ 
+                   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if compile and link flags for Perl are sane" >&5
+ $as_echo_n "checking if compile and link flags for Perl are sane... " >&6; }
+diff -ur vim-8.2.1725-a/src/configure.ac vim-8.2.1725-b/src/configure.ac
+--- vim-8.2.1725-a/src/configure.ac	2020-09-23 01:15:31.000000000 +0800
++++ vim-8.2.1725-b/src/configure.ac	2020-11-02 13:50:44.110086408 +0800
+@@ -1090,7 +1090,7 @@
+       dnl Don't add perl lib to $LIBS: if it's not in LD_LIBRARY_PATH
+       dnl a test in configure may fail because of that.
+       perlldflags=`cd $srcdir; $vi_cv_path_perl -MExtUtils::Embed \
+-		-e 'ccdlflags' | sed -e 's/-bE:perl.exp//'`
++		-e 'ccdlflags' | sed -e 's/-bE:perl.exp//' | sed -e 's/-fno-lto//'`
+ 
+       dnl check that compiling a simple program still works with the flags
+       dnl added for Perl.

--- a/extra-editors/vim/spec
+++ b/extra-editors/vim/spec
@@ -1,3 +1,4 @@
 VER=8.2.1725
+REL=1
 SRCTBL="https://github.com/vim/vim/archive/v$VER.tar.gz"
 CHKSUM="sha256::bb031003b8dd0a7273e8e83224a6cc72e8e8efe15e67624358d2d4b8f85768ad"


### PR DESCRIPTION
Topic Description
-----------------

Fix VIM running on KMSCON.

Package(s) Affected
-------------------

- `vim`

Security Update?
----------------
No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
