### PR TITLE
snap-sync: new, 0.6.1

### DIFF
--- a/extra-utils/snap-sync/autobuild/defines
+++ b/extra-utils/snap-sync/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=snap-sync
+PKGSEC=utils
+PKGDEP="snapper bash libnotify"
+PKGDES="A bash script sends incremental snapshots to another drive for backing up data"
+
+MAKE_AFTER="SNAPPER_CONFIG=/etc/conf.d/snapper"
+ABHOST=noarch

--- a/extra-utils/snap-sync/spec
+++ b/extra-utils/snap-sync/spec
@@ -1,0 +1,3 @@
+VER=0.6.1
+SRCS="tbl::https://github.com/wesbarnett/snap-sync/releases/download/${VER}/snap-sync-${VER}.tar.gz"
+CHKSUMS="sha256::d49bc0fe466b7fd46c9269f60e3c2b7111582f34cf422d263d83bd353cf87ad2"


### PR DESCRIPTION
Topic Description
-----------------
Add package `snap-sync`

Package(s) Affected
-------------------
`snap-sync`

Security Update?
----------------
No

Architectural Progress
----------------------
- [x] Architecture-independent `noarch`

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [x] Architecture-independent `noarch`
