### PR TITLE
wine: switch the compiler from gcc to mingw-w64 on AMD64

### DIFF
--- a/extra-emulation/wine/autobuild/amd64/build32
+++ b/extra-emulation/wine/autobuild/amd64/build32
@@ -14,6 +14,7 @@ pushd wine32
     --with-gtk3 \
     --with-pulse \
     --with-vulkan \
+    --with-mingw \
     PKG_CONFIG_PATH="/opt/32/lib/pkgconfig"
 make
 make prefix="$PKGDIR/usr" \

--- a/extra-emulation/wine/autobuild/amd64/build64
+++ b/extra-emulation/wine/autobuild/amd64/build64
@@ -12,6 +12,7 @@ pushd wine64
       --with-gtk3 \
       --with-pulse \
       --with-vulkan \
+      --with-mingw \
       --with-vkd3d
 make
 make prefix="$PKGDIR/usr" \

--- a/extra-emulation/wine/autobuild/defines
+++ b/extra-emulation/wine/autobuild/defines
@@ -9,6 +9,10 @@ PKGSUG="noto-fonts noto-cjk-fonts"
 BUILDDEP="chrpath wayland-protocols opencl-registry-api dos2unix"
 PKGDES="Runtime/Compatibility Layer for running programs designed for Microsoft Windows"
 
+# AMD64 build requires MingW-w64, according to https://bugs.winehq.org/show_bug.cgi?id=49436#c27
+BUILDDEP__AMD64="${BUILDDEP} gcc+w64 binutils+w64 mingw+w64"
+
+
 # AArch64 build requires Clang.
 BUILDDEP__ARM64="${BUILDDEP} llvm"
 USECLANG__ARM64=1

--- a/extra-emulation/wine/spec
+++ b/extra-emulation/wine/spec
@@ -1,4 +1,4 @@
 VER=5.20
 SRCS="tbl::https://dl.winehq.org/wine/source/5.x/wine-$VER.tar.xz"
 CHKSUMS="sha256::8f5522f8cebebdbaa12f58e1ba671a11f66372e0aedf74fb932cf5a89390861c"
-REL=1
+REL=2


### PR DESCRIPTION

Topic Description
-----------------
Switch the compiler from `gcc` to `mingw-w64`, for wine in AMD64 architecture.

Package(s) Affected
-------------------
wine

Security Update?
----------------
No

Architectural Progress
----------------------
- [x] AMD64 `amd64`   


Post-Merge Architectural Progress
---------------------------------
- [x] AMD64 `amd64`   
