### PR TITLE
adobe-source-han-sans: update to 2.002

### DIFF
--- a/extra-fonts/adobe-source-han-sans/autobuild/build
+++ b/extra-fonts/adobe-source-han-sans/autobuild/build
@@ -1,6 +1,9 @@
+abinfo "unzip SourceHanSans.ttc.zip..."
+unzip "$SRCDIR"/SuperOTC/SourceHanSans.ttc.zip
+
 abinfo "Installing font file and LICENSE..."
 install -dvm755 "$PKGDIR"/usr/share/fonts/TTF
 install -vm644 "$SRCDIR"/SourceHanSans.ttc "$PKGDIR"/usr/share/fonts/TTF
 install -dvm755 "$PKGDIR"/usr/share/doc/adobe-source-han-sans
-install -vm644 "$SRCDIR"/source-han-sans-$PKGVER/LICENSE.txt \
+install -vm644 "$SRCDIR"/LICENSE.txt \
 	"$PKGDIR"/usr/share/doc/adobe-source-han-sans/

--- a/extra-fonts/adobe-source-han-sans/spec
+++ b/extra-fonts/adobe-source-han-sans/spec
@@ -1,6 +1,3 @@
-VER=2.001R
-SRCS="file::rename=SourceHanSans.ttc::https://github.com/adobe-fonts/source-han-sans/releases/download/$VER/SourceHanSans.ttc \
-      tbl::https://github.com/adobe-fonts/source-han-sans/archive/$VER.tar.gz"
-CHKSUMS="sha256::9e94fe493685a7c99ce61e4488169007e3b97badb9f1ef43d3c13da501463780 \
-         sha256::7c515573dd6784d9d2be564f50e0b9bbee4ad560a853ab87a25532b1d8a03582"
-SUBDIR=.
+VER=2.002
+SRCS="tbl::https://github.com/adobe-fonts/source-han-sans/archive/${VER}R.tar.gz"
+CHKSUMS="sha256::941c905892e6528948eccaa3ae51066a16542d7b734a17b8286fe16c8e0cd523"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

adobe-source-han-sans: update to 2.002

Package(s) Affected
-------------------

adobe-source-han-sans 2.002

Security Update?
----------------

No

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->


<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [x] Architecture-independent `noarch` 


----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch` 

