### PR TITLE
libime: update to 1.0.1

### DIFF
--- a/extra-i18n/fcitx5-chinese-addons/spec
+++ b/extra-i18n/fcitx5-chinese-addons/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.1
 SRCS="tbl::https://github.com/fcitx/fcitx5-chinese-addons/archive/$VER.tar.gz"
-CHKSUMS="sha256::fa5b740ff20a5f33d611a1be622be024dcc1c6722d6cce9c8db48c257c62248b"
+CHKSUMS="sha256::47393c1410f9b5ef1a68512f01af017fb9e09ae89f92d601035b8f193d443595"

--- a/extra-i18n/libime/spec
+++ b/extra-i18n/libime/spec
@@ -1,3 +1,3 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/libime/"
 CHKSUMS="SKIP"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

libime: update to 1.0.1
fcitx5-chinese-addons: update to 5.0.1

Package(s) Affected
-------------------

libime 1.0.1
fcitx5-chinese-addons 5.0.1

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

libime
fcitx5-chinese-addons

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
