### PR TITLE
extra-cross: update AMD64 cross compiler

### DIFF
--- a/extra-cross/binutils+cross-amd64/autobuild/defines
+++ b/extra-cross/binutils+cross-amd64/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=binutils+cross-amd64
 PKGDEP="glibc"
 PKGSEC=devel
 PKGDES="Binutils for amd64 cross build"
+
+FAIL_ARCH="amd64"

--- a/extra-cross/binutils+cross-amd64/spec
+++ b/extra-cross/binutils+cross-amd64/spec
@@ -1,3 +1,3 @@
-VER=2.32
+VER=2.34
 GITSRC="https://sourceware.org/git/binutils-gdb.git"
-GITCO="ef17a19d0694d5b861f5dfb8dc3c2baefc14d66e"
+GITCO="f7930a553ccec9a9155237add6fcac8da8d0d096"

--- a/extra-cross/gcc+cross-amd64/autobuild/build
+++ b/extra-cross/gcc+cross-amd64/autobuild/build
@@ -7,7 +7,8 @@ AR=ar ../configure --prefix=/opt/abcross/amd64 --target=x86_64-aosc-linux-gnu \
                    --enable-languages=c,c++,fortran,lto --enable-__cxa_atexit \
                    --enable-lto --enable-gnu-unique-object --with-linker-hash-style=gnu \
                    --enable-linker-build-id --enable-libstdcxx-dual-abi --with-default-libstdcxx-abi=new \
-                   --enable-gnu-indirect-function \
-                   make AS_FOR_TARGET=/opt/abcross/amd64/bin/x86_64-aosc-linux-gnu-as \
+                   --enable-gnu-indirect-function
+
+make AS_FOR_TARGET=/opt/abcross/amd64/bin/x86_64-aosc-linux-gnu-as \
      LD_FOR_TARGET=/opt/abcross/amd64/bin/x86_64-aosc-linux-gnu-ld
 make DESTDIR=$PKGDIR install

--- a/extra-cross/gcc+cross-amd64/autobuild/defines
+++ b/extra-cross/gcc+cross-amd64/autobuild/defines
@@ -3,3 +3,5 @@ PKGSEC=devel
 PKGDEP="binutils+cross-amd64"
 PKGDES="GCC for amd64 build"
 NOSTATIC=no
+
+FAIL_ARCH="amd64"

--- a/extra-cross/gcc+cross-amd64/autobuild/prepare
+++ b/extra-cross/gcc+cross-amd64/autobuild/prepare
@@ -1,0 +1,4 @@
+if [ ! -d /var/ab/cross-root/amd64 ]; then
+	mkdir -p /var/ab/cross-root/amd64
+	wget https://releases.aosc.io/os-amd64/stub/aosc-os_stub_20201025_amd64.tar.xz -O - | tar xfpJ - -C /var/ab/cross-root/amd64/
+fi

--- a/extra-cross/gcc+cross-amd64/spec
+++ b/extra-cross/gcc+cross-amd64/spec
@@ -1,3 +1,3 @@
-VER=8.3.1
-GITSRC="https://gcc.gnu.org/git/gcc.git"
-GITCO="9c4899f703499018b2bf79a611521f66cadb8ba5"
+VER=9.3.1
+GITSRC="https://github.com/gcc-mirror/gcc"
+GITCO="93c2834e92419abf04fd9f54ca25ed22086611b0"


### PR DESCRIPTION
Topic Description
-----------------

Update version numbers of AMD64 cross compiler to match Core.

Automatical sysroot extraction is added to prepare script, to allow Ciel operation.

Package(s) Affected
-------------------

- `binutils+cross-amd64`
- `gcc+cross-amd64`

Security Update?
----------------
No

Architectural Progress
----------------------

- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
