### PR TITLE
snapper-gui: new, 0.1+git20201020

### DIFF
--- a/extra-admin/snapper-gui/autobuild/defines
+++ b/extra-admin/snapper-gui/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=snapper-gui
+PKGSEC=admin
+PKGDEP="python-3 gtk-3 dbus-python pygobject-3 gtksourceview-3"
+BUILDDEP="setuptools"
+PKGDES="A graphical user interface for the tool snapper for Linux filesystem snapshot management"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/extra-admin/snapper-gui/autobuild/defines
+++ b/extra-admin/snapper-gui/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=snapper-gui
 PKGSEC=admin
 PKGDEP="python-3 gtk-3 dbus-python pygobject-3 gtksourceview-3"
 BUILDDEP="setuptools"
-PKGDES="A graphical user interface for the tool snapper for Linux filesystem snapshot management"
+PKGDES="A GUI tool for snapper"
 
 NOPYTHON2=1
 ABHOST=noarch

--- a/extra-admin/snapper-gui/spec
+++ b/extra-admin/snapper-gui/spec
@@ -1,0 +1,3 @@
+VER=0.1+git20201020
+SRCS="git::commit=f0c67abe0e10cc9e2ebed400cf80ecdf763fb1d1::https://github.com/ricardomv/snapper-gui"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Add package `snapper-gui`

Package(s) Affected
-------------------

`snapper-gui`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`
