### PR TITLE
telegram-desktop: update to 2.4.7

### DIFF
--- a/extra-web/telegram-desktop/autobuild/prepare
+++ b/extra-web/telegram-desktop/autobuild/prepare
@@ -9,7 +9,7 @@ export CMAKE_PREFIX_PATH="$SRCDIR/../tg_owt:$CMAKE_PREFIX_PATH"
 
 abinfo "Making tg_owt..."
 cd "$SRCDIR"/../tg_owt
-cmake .
+cmake -DBUILD_SHARED_LIBS=OFF . 
 make
 
 cd "$SRCDIR"

--- a/extra-web/telegram-desktop/spec
+++ b/extra-web/telegram-desktop/spec
@@ -1,6 +1,6 @@
-VER=2.4.6
+VER=2.4.7
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
-      git::rename=tg_owt;commit=e8fcae73947445db3d418fb7c20b964b59e14706::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::2c6f97ca079c3f9aad700f133d8bcd45ae4cfa32423e91d02c79a163664c13a4 SKIP"
+      git::rename=tg_owt;commit=12f4a27f2f02f9dd40f9891d8ec6e58bc1ff5263::https://github.com/desktop-app/tg_owt"
+CHKSUMS="sha256::7b13df53be5d6b58d07d730c9429e415be2fea7f7be37bcaa80a505152125bc8 SKIP"
 SUBDIR=tdesktop-$VER-full


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

telegram-desktop: update to 2.4.7

- Update tg_owt

Package(s) Affected
-------------------

telegram-desktop 2.4.7

Security Update?
----------------

No
<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
