### PR TITLE
openjdk-8: update to 8u275

### DIFF
--- a/extra-java/openjdk-8/spec
+++ b/extra-java/openjdk-8/spec
@@ -1,10 +1,10 @@
-VER=8u272+ga
+VER=8u275+ga
 # aarch64 specific tarball
 SRCS__ARM64="https://repo.aosc.io/aosc-repacks/aarch64-java/openjdk-${VER/+/-}.tar.xz"
-CHKSUMS__ARM64="sha256::fcc7a04f1e48c842b965b4f75171a7526fc94b711cc075d4de507c38052396fb"
+CHKSUMS__ARM64="sha256::52d37517a14a32f52f21641bc86133d3b24f2b1ea89272a24f3be7e56c3d70f2"
 # loongson3 specific tarball
 SRCS__LOONGSON3="https://repo.aosc.io/aosc-repacks/ls3-java/openjdk-${VER/+/-}.tar.xz"
-CHKSUMS__LOONGSON3="sha256::2fc57ccb9de585fa65f2f43f2587f47093aeefc4843c7244ecde1e683e461b49"
+CHKSUMS__LOONGSON3="sha256::ad011ce40960830fca5f477d409cebfc1eebb6ca99ee16b8100f23d9ea19f79c"
 
 SRCS="https://openjdk-sources.osci.io/openjdk8/openjdk${VER/+/-}.tar.xz"
-CHKSUMS="sha256::ce77e0a3d2b7ff3e2e17e25dd4e1d1499ca950a539c56e5020416957ea7eac6f"
+CHKSUMS="sha256::6a83e8bd8caebf5dc8989a22925ac5598c9edb2ba8dcfad7472a5ff99a14c0e7"


### PR DESCRIPTION
Topic Description
-----------------

Emergency fix from OpenJDK 8u, JVM may crash or cause undefined behavior in some cases.

Package(s) Affected
-------------------

- `openjdk-8`

Security Update?
----------------

No


Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2486)
<!-- Reviewable:end -->
