### PR TITLE
libvirt: disable LTO

### DIFF
--- a/extra-emulation/libvirt/autobuild/defines
+++ b/extra-emulation/libvirt/autobuild/defines
@@ -10,3 +10,4 @@ PKGSUG="qemu zfs"
 PKGDES="API for controlling virtualization engines"
 
 MESON_AFTER="-Dlibexecdir=/usr/lib/libvirt"
+NOLTO=1

--- a/extra-emulation/libvirt/spec
+++ b/extra-emulation/libvirt/spec
@@ -1,3 +1,4 @@
 VER=6.8.0
+REL=1
 SRCTBL="https://libvirt.org/sources/libvirt-$VER.tar.xz"
 CHKSUM="sha256::0c2d7f6ed8bc4956bf7f0c8ca2897c6c82ddb91e3118ab7a588b25eedd16ef69"


### PR DESCRIPTION
Topic Description
-----------------

`virtlogd` linked with optimization on may segfault with an error in TIRPC library. This error originates from the linker mis-optimizes a global variable in libtirpc. This issue is beyond my capability to repair by myself, so the solution for now is disable LTO when building `libvirt`.

Package(s) Affected
-------------------

`libvirt` 6.8.0 -> 6.8.0-1

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
