### PR TITLE
firefox: update to 82.0.2

### DIFF
--- a/extra-libs/nspr/spec
+++ b/extra-libs/nspr/spec
@@ -1,4 +1,4 @@
-VER=4.28
-SRCTBL="https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v$VER/src/nspr-$VER.tar.gz"
-CHKSUM="sha256::63defc8e19a80b6f98fcc7d5a89e84ea703c0b50aa6bc13bf7ad071adf433b56"
+VER=4.29
+SRCS="tbl::https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v$VER/src/nspr-$VER.tar.gz"
+CHKSUMS="sha256::22286bdb8059d74632cc7c2865c139e63953ecfb33bf4362ab58827e86e92582"
 SUBDIR="nspr-$VER/nspr"

--- a/extra-libs/nss/spec
+++ b/extra-libs/nss/spec
@@ -1,3 +1,3 @@
-VER=3.56
-SRCTBL="https://download-origin.cdn.mozilla.net/pub/security/nss/releases/NSS_${VER//./_}_RTM/src/nss-$VER.tar.gz"
-CHKSUM="sha256::f875e0e8ed3b5ce92d675be4a55aa25a8c1199789a4a01f69b5f2327e2048e9c"
+VER=3.58
+SRCS="https://download-origin.cdn.mozilla.net/pub/security/nss/releases/NSS_${VER//./_}_RTM/src/nss-$VER.tar.gz"
+CHKSUMS="sha256::9f73cf789b5f109b978e5239551b609b0cafa88d18f0bc8ce3f976cb629353c0"

--- a/extra-web/firefox/autobuild/patches/0005-Fix-venv-build.patch
+++ b/extra-web/firefox/autobuild/patches/0005-Fix-venv-build.patch
@@ -1,0 +1,23 @@
+# Taken from https://bugzilla.mozilla.org/show_bug.cgi?id=1665675#c2
+diff --git a/build/moz.configure/init.configure b/build/moz.configure/init.configure
+index 970ef849e5e9..bc74d1508c56 100644
+--- a/build/moz.configure/init.configure
++++ b/build/moz.configure/init.configure
+@@ -233,7 +233,7 @@ option(env='VIRTUALENV_NAME', nargs=1, default='init_py3',
+ @imports('os')
+ @imports('sys')
+ @imports('subprocess')
+-@imports('distutils.sysconfig')
++@imports(_from='distutils.sysconfig', _import='get_python_lib')
+ @imports(_from='mozbuild.configure.util', _import='LineIO')
+ @imports(_from='mozbuild.virtualenv', _import='VirtualenvManager')
+ @imports(_from='mozbuild.virtualenv', _import='verify_python_version')
+@@ -368,7 +368,7 @@ def virtualenv_python3(env_python, virtualenv_name, build_env, mozconfig, help):
+         sys.exit(subprocess.call([python] + sys.argv))
+ 
+     # We are now in the virtualenv
+-    if not distutils.sysconfig.get_python_lib():
++    if not get_python_lib():
+         die('Could not determine python site packages directory')
+ 
+     str_version = '.'.join(str(v) for v in version)

--- a/extra-web/firefox/spec
+++ b/extra-web/firefox/spec
@@ -1,3 +1,3 @@
-VER=81.0
-SRCTBL="https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz"
-CHKSUM='sha256::9328745012178aee5a4f47c833539f7872cc6e0f20a853568a313e60cabd1ec8'
+VER=82.0.2
+SRCS="tbl::https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz"
+CHKSUMS='sha256::8851cae2df9923844c3dc97a4f77f6f3c86cc6f298b888b38949fbf74fcf2ca9'


### PR DESCRIPTION
Topic Description
-----------------
Update `firefox` to 82.0.2.

Package(s) Affected
-------------------
- nss
- nspr
- firefox

Security Update?
----------------
No


Build Order
-----------
nss <-> nspr -> firefox


Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- ~~Loongson 3 `loongson3`~~
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- ~~Loongson 3 `loongson3`~~
- [x] PowerPC 64-bit (Little Endian) `ppc64el`