### PR TITLE
ffmpeg: disable x86 intrinsics on ppc64el

### DIFF
--- a/extra-multimedia/ffmpeg/autobuild/prepare
+++ b/extra-multimedia/ffmpeg/autobuild/prepare
@@ -1,0 +1,4 @@
+if [[ "${CROSS:-$ARCH}" = "ppc64el" ]]; then
+    abinfo "Disbling x86 intrinsics to avoid SIGILL when playing .wmv files ..."
+    export CPPFLAGS="${CPPFLAGS/-DNO_WARN_X86_INTRINSICS/}"
+fi

--- a/extra-multimedia/ffmpeg/spec
+++ b/extra-multimedia/ffmpeg/spec
@@ -1,4 +1,4 @@
 VER=4.2.4
-REL=2
+REL=3
 SRCTBL="https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUM="sha256::0d5da81feba073ee78e0f18e0966bcaf91464ae75e18e9a0135186249e3d2a0b"


### PR DESCRIPTION
Topic Description
-----------------

Disable x86 intrinsics on `ppc64el` by removing `-DNO_WARN_X86_INTRINSICS` from CPPFLAGS. Enabling x86 intrinsics causes SIGSILL when playing WMV fiels.

Package(s) Affected
-------------------

`ffmpeg` v4.2.4-3

Security Update?
----------------

No

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
