### PR TITLE
v2ray: mark as non-free and add XTLS license in package

### DIFF
--- a/extra-network/v2ray/autobuild/build
+++ b/extra-network/v2ray/autobuild/build
@@ -57,4 +57,8 @@ install -Dvm644 "${V2CONFIG}/vpoint_vmess_freedom.json" "${PKGDIR}/etc/v2ray/vpo
 
 install -Dvm644 "${V2CONFIG}"/*.json -t "$PKGDIR"/etc/v2ray/
 
+abinfo "Installing the broken license of XTLS..."
+mkdir -p "$PKGDIR"/usr/share/doc/v2ray
+wget https://github.com/XTLS/Go/raw/4c3710394d5e83f942b009e247b017abb4614654/LICENSE -O "$PKGDIR"/usr/share/doc/v2ray/LICENSE.XTLS
+
 cd "$SRCDIR"

--- a/extra-network/v2ray/autobuild/build
+++ b/extra-network/v2ray/autobuild/build
@@ -58,7 +58,8 @@ install -Dvm644 "${V2CONFIG}/vpoint_vmess_freedom.json" "${PKGDIR}/etc/v2ray/vpo
 install -Dvm644 "${V2CONFIG}"/*.json -t "$PKGDIR"/etc/v2ray/
 
 abinfo "Installing the broken license of XTLS..."
-mkdir -p "$PKGDIR"/usr/share/doc/v2ray
-wget https://github.com/XTLS/Go/raw/4c3710394d5e83f942b009e247b017abb4614654/LICENSE -O "$PKGDIR"/usr/share/doc/v2ray/LICENSE.XTLS
+mkdir -pv "$PKGDIR"/usr/share/doc/v2ray
+wget https://github.com/XTLS/Go/raw/4c3710394d5e83f942b009e247b017abb4614654/LICENSE \
+    -O "$PKGDIR"/usr/share/doc/v2ray/LICENSE.XTLS
 
 cd "$SRCDIR"

--- a/extra-network/v2ray/autobuild/defines
+++ b/extra-network/v2ray/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=v2ray
-PKGSEC=net
+PKGSEC=non-free/net
 PKGDES="A platform for building proxies to bypass network restrictions."
 PKGDEP="glibc"
 BUILDDEP="go"

--- a/extra-network/v2ray/spec
+++ b/extra-network/v2ray/spec
@@ -1,4 +1,5 @@
 VER=4.32.0
+REL=1
 SRCTBL="https://github.com/v2fly/v2ray-core/archive/v$VER.tar.gz"
 CHKSUM="sha256::a3d04aade039a3945e3704e674d61433e125e4b54e32cca9e794915aff3ca4c4"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

V2ray now statically link to non-free software (which allows redistribution but disallow source modification) now.

Mark this and attach the license of the non-free part to the package.

Package(s) Affected
-------------------

- `v2ray`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
