### PR TITLE
mesa: update to 20.2.2

### DIFF
--- a/extra-libs/libdrm/autobuild/defines
+++ b/extra-libs/libdrm/autobuild/defines
@@ -3,12 +3,14 @@ PKGDES="Direct Rendering Manager runtime library"
 PKGDEP="x11-lib"
 PKGSEC=libs
 
-AUTOTOOLS_AFTER="--enable-udev"
-AUTOTOOLS_AFTER__ARM=" \
-                 --enable-exynos-experimental-api \
-                 --enable-omap-experimental-api \
-                 --enable-tegra-experimental-api \
-                 --enable-vc4"
-AUTOTOOLS_AFTER__ARM64="${AUTOTOOLS_AFTER__ARM}"
-AUTOTOOLS_AFTER__ARMEL="${AUTOTOOLS_AFTER__ARM}"
-AUTOTOOLS_AFTER__ARMHF="${AUTOTOOLS_AFTER__ARM}"
+MESON_AFTER="-Dudev=true"
+MESON_AFTER__ARM="${MESON_AFTER} \
+                  -Domap=true \
+                  -Dexynos=true \
+                  -Dfreedreno=true \
+                  -Dtegra=true \
+                  -Dvc4=true \
+                  -Detnaviv=true"
+MESON_AFTER__ARM64="${MESON_AFTER__ARM}"
+MESON_AFTER__ARMEL="${MESON_AFTER__ARM}"
+MESON_AFTER__ARMHF="${MESON_AFTER__ARM}"

--- a/extra-libs/libdrm/spec
+++ b/extra-libs/libdrm/spec
@@ -1,3 +1,3 @@
-VER=2.4.102
+VER=2.4.103
 SRCTBL="https://dri.freedesktop.org/libdrm/libdrm-$VER.tar.xz"
-CHKSUM="sha256::8bcbf9336c28e393d76c1f16d7e79e394a7fce8a2e929d52d3ad7ad8525ba05b"
+CHKSUM="sha256::3fe0affdba6460166a7323290c18cf68e9b59edcb520722826cb244e9cb50222"

--- a/extra-libs/mesa/autobuild/defines
+++ b/extra-libs/mesa/autobuild/defines
@@ -47,14 +47,14 @@ MESON_AFTER="-Ddri-drivers-path=/usr/lib/xorg/modules/dri \
 MESON_AFTER__X86=" \
              ${MESON_AFTER} \
              -Db_lto=true \
-             -Ddri-drivers=i915,i965,r100,r200,nouveau \
-             -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,svga,swrast,iris \
+             -Ddri-drivers=r100,r200,nouveau,i915,i965 \
+             -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,swrast,svga,iris \
              -Dvulkan-drivers=amd,intel"
 MESON_AFTER__ARM=" \
              ${MESON_AFTER} \
              -Db_lto=true \
              -Ddri-drivers=r100,r200,nouveau \
-             -Dgallium-drivers=freedreno,tegra,vc4,r300,r600,radeonsi,nouveau,virgl,lima,kmsro,swrast,panfrost \
+             -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,swrast,kmsro,lima,panfrost,freedreno,tegra,vc4,v3d,etnaviv \
              -Dvulkan-drivers=amd"
 MESON_AFTER__OTHER=" \
              ${MESON_AFTER} \

--- a/extra-libs/mesa/spec
+++ b/extra-libs/mesa/spec
@@ -1,4 +1,3 @@
-VER=20.1.8
-REL=4
+VER=20.2.2
 SRCTBL="https://mesa.freedesktop.org/archive/mesa-$VER.tar.xz"
-CHKSUM="sha256::df21351494f7caaec5a3ccc16f14f15512e98d2ecde178bba1d134edc899b961"
+CHKSUM="sha256::1f93eb1090cf71490cd0e204e04f8427a82b6ed534b7f49ca50cea7dcc89b861"

--- a/extra-optenv32/libdrm+32/spec
+++ b/extra-optenv32/libdrm+32/spec
@@ -1,3 +1,3 @@
-VER=2.4.102
+VER=2.4.103
 SRCTBL="https://dri.freedesktop.org/libdrm/libdrm-$VER.tar.xz"
-CHKSUM="sha256::8bcbf9336c28e393d76c1f16d7e79e394a7fce8a2e929d52d3ad7ad8525ba05b"
+CHKSUM="sha256::3fe0affdba6460166a7323290c18cf68e9b59edcb520722826cb244e9cb50222"

--- a/extra-optenv32/mesa+32/spec
+++ b/extra-optenv32/mesa+32/spec
@@ -1,3 +1,3 @@
-VER=20.1.8
+VER=20.2.2
 SRCTBL="https://mesa.freedesktop.org/archive/mesa-$VER.tar.xz"
-CHKSUM="sha256::df21351494f7caaec5a3ccc16f14f15512e98d2ecde178bba1d134edc899b961"
+CHKSUM="sha256::1f93eb1090cf71490cd0e204e04f8427a82b6ed534b7f49ca50cea7dcc89b861"


### PR DESCRIPTION
Topic Description
-----------------

Update Mesa and enable extra drivers for ARM64.

Libdrm is also updated during this.

Package(s) Affected
-------------------

- `libdrm` 2.4.103
- `mesa` 20.2.2

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit Optional Environment `optenv32`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit Optional Environment `optenv32`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
