### PR TITLE
ghostscript: add libidn dep

### DIFF
--- a/extra-doc/ghostscript/autobuild/defines
+++ b/extra-doc/ghostscript/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=ghostscript
 PKGSEC=doc
 PKGDEP="cups x11-lib fontconfig jasper zlib libpng libjpeg-turbo libtiff \
-        lcms2 dbus libpaper"
+        lcms2 dbus libpaper libidn"
 BUILDDEP="ijs"
 PKGDES="An interpreter for the PostScript language"
 ABTYPE=self

--- a/extra-doc/ghostscript/spec
+++ b/extra-doc/ghostscript/spec
@@ -1,4 +1,4 @@
 VER=9.27
-REL=1
+REL=2
 SRCTBL="https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${VER//./}/ghostscript-$VER.tar.gz"
 CHKSUM="sha256::9760e8bdd07a08dbd445188a6557cb70e60ccb6a5601f7dbfba0d225e28ce285"

--- a/extra-doc/ghostscript/spec
+++ b/extra-doc/ghostscript/spec
@@ -1,4 +1,4 @@
 VER=9.27
 REL=2
-SRCTBL="https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${VER//./}/ghostscript-$VER.tar.gz"
-CHKSUM="sha256::9760e8bdd07a08dbd445188a6557cb70e60ccb6a5601f7dbfba0d225e28ce285"
+SRCS="tbl::https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${VER//./}/ghostscript-$VER.tar.gz"
+CHKSUMS="sha256::9760e8bdd07a08dbd445188a6557cb70e60ccb6a5601f7dbfba0d225e28ce285"

--- a/extra-libs/libtiff/autobuild/defines
+++ b/extra-libs/libtiff/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libtiff
 PKGSEC=libs
-PKGDEP="gcc-runtime libjpeg-turbo zlib xz freeglut"
+PKGDEP="gcc-runtime libjpeg-turbo zlib xz freeglut libwebp"
 BUILDDEP="glu jbigkit"
 PKGSUG="glu jbigkit"
 PKGDES="Library for manipulation of TIFF images"

--- a/extra-libs/libtiff/spec
+++ b/extra-libs/libtiff/spec
@@ -1,4 +1,4 @@
 VER=4.0.10
-REL=5
+REL=6
 SRCTBL="https://download.osgeo.org/libtiff/tiff-$VER.tar.gz"
 CHKSUM="sha256::2c52d11ccaf767457db0c46795d9c7d1a8d8f76f68b0b800a3dfe45786b996e4"

--- a/extra-libs/libtiff/spec
+++ b/extra-libs/libtiff/spec
@@ -1,4 +1,4 @@
 VER=4.0.10
 REL=6
-SRCTBL="https://download.osgeo.org/libtiff/tiff-$VER.tar.gz"
-CHKSUM="sha256::2c52d11ccaf767457db0c46795d9c7d1a8d8f76f68b0b800a3dfe45786b996e4"
+SRCS="tbl::https://download.osgeo.org/libtiff/tiff-$VER.tar.gz"
+CHKSUMS="sha256::2c52d11ccaf767457db0c46795d9c7d1a8d8f76f68b0b800a3dfe45786b996e4"


### PR DESCRIPTION
Topic Description
-----------------

This topic adds `libidn` dependency to `ghostscript`, and `libwebp` depencency to `libtiff` (one of `ghostscript`'s dependencies).

This issue (at least the former part) likely only affects AMD64 - build for all architectures just to be sure.

Package(s) Affected
-------------------

- `libtiff` v4.0.10-6
- `ghostscript` v9.27-2

Security Update?
----------------

No

Build Order
-----------

`libtiff` => `ghostscript`.

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`