### PR TITLE
genie: new, 1.28

### DIFF
--- a/extra-utils/genie/autobuild/build
+++ b/extra-utils/genie/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building genie..."
+make build
+
+abinfo "Installing genie..."
+make install DESTDIR="$PKGDIR"

--- a/extra-utils/genie/autobuild/defines
+++ b/extra-utils/genie/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=genie
+PKGSEC=utils
+PKGDEP="daemonize dbus dotnet-runtime-3.1 dotnet-sdk-3.1 systemd"
+PKGDES="A way to run systemd as pid 1, with all the trimmings, inside WSL 2"

--- a/extra-utils/genie/spec
+++ b/extra-utils/genie/spec
@@ -1,0 +1,4 @@
+VER=1.28
+SRCS="git::commit=tags/$VER::https://github.com/arkane-systems/genie.git"
+CHKSUMS="SKIP"
+SUBDIR=genie/genie


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

New packages:

- genie

Package(s) Affected
-------------------

- genie

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->


----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->


<!-- TODO: CI to auto-fill architectural progress. -->
