### PR TITLE
gdm, sddm, tdebase: drop pam_tally module from PAM configurations

### DIFF
--- a/base-admin/shadow/autobuild/retro/overrides/etc/pam.d/system-login
+++ b/base-admin/shadow/autobuild/retro/overrides/etc/pam.d/system-login
@@ -1,5 +1,4 @@
 #%PAM-1.0
-auth       required   pam_tally.so         onerr=succeed file=/var/log/faillog
 auth       required   pam_shells.so
 auth       requisite  pam_nologin.so
 auth       include    system-auth

--- a/extra-displaymanagers/sddm/autobuild/overrides/etc/pam.d/sddm-autologin
+++ b/extra-displaymanagers/sddm/autobuild/overrides/etc/pam.d/sddm-autologin
@@ -1,6 +1,5 @@
 #%PAM-1.0
 auth        required    pam_env.so
-auth        required    pam_tally.so file=/var/log/faillog onerr=succeed
 auth        required    pam_shells.so
 auth        required    pam_nologin.so
 auth        required    pam_permit.so

--- a/extra-displaymanagers/sddm/spec
+++ b/extra-displaymanagers/sddm/spec
@@ -1,3 +1,4 @@
 VER=0.18.1
-SRCTBL="https://github.com/sddm/sddm/releases/download/v$VER/sddm-$VER.tar.xz"
-CHKSUM="sha256::b0930d874f9ce38e8e027d5f80787d5f99c0c6b10830d79f7c766e4f39cc345a"
+REL=1
+SRCS="tbl::https://github.com/sddm/sddm/releases/download/v$VER/sddm-$VER.tar.xz"
+CHKSUMS="sha256::b0930d874f9ce38e8e027d5f80787d5f99c0c6b10830d79f7c766e4f39cc345a"

--- a/extra-gnome/gdm/autobuild/beyond
+++ b/extra-gnome/gdm/autobuild/beyond
@@ -1,13 +1,19 @@
-mkdir -p "$PKGDIR"/var/lib/gdm "$PKGDIR"/var/cache/gdm "$PKGDIR"/var/log/gdm
-chown -R -v 771:771 "$PKGDIR"/var/lib/gdm "$PKGDIR"/var/cache/gdm "$PKGDIR"/var/log/gdm
+abinfo "Creating daemon directory ..."
+mkdir -pv "$PKGDIR"/var/{cache,lib,log}/gdm
+chown -vR 771:771 "$PKGDIR"/var/{cache,lib,log}/gdm
 
-chmod 711 "$PKGDIR"/var/log/gdm
-rm -r "$PKGDIR"/var/run
+abinfo "Setting permission for /var/log/gdm ..."
+chmod -v 711 "$PKGDIR"/var/log/gdm
 
+abinfo "Removing empty /var/run ..."
+rm -rv "$PKGDIR"/var/run
+
+abinfo "Renaming gdmflexiserver for alternative ..."
 mv "$PKGDIR"/usr/bin/gdmflexiserver{,-gdm}
 
-# Workaround buggy wayland on nvidia
-pushd "$PKGDIR"
+abinfo "Applying workaround for buggy wayland on NVIDIA ..."
+(
+cd "$PKGDIR"
 patch -Np2 << EOF
 diff -Naur gdm-3.30.0/abdist/etc/gdm/custom.conf gdm-3.30.0.nowayland/abdist/etc/gdm/custom.conf
 --- gdm-3.30.0/abdist/etc/gdm/custom.conf       2018-09-14 05:46:42.402911767 +0000
@@ -25,5 +31,8 @@ diff -Naur gdm-3.30.0/abdist/etc/gdm/custom.conf gdm-3.30.0.nowayland/abdist/etc
  [security]
  
 EOF
+)
 
-popd
+abinfo "Dropping pam_tally from GDM PAM configurations ..."
+sed -e '/pam_tally/d' \
+    -i "$PKGDIR"/etc/pam.d/*

--- a/extra-gnome/gdm/spec
+++ b/extra-gnome/gdm/spec
@@ -1,4 +1,4 @@
 VER=3.34.1
-REL=1
-SRCTBL="https://download.gnome.org/sources/gdm/${VER:0:4}/gdm-$VER.tar.xz"
-CHKSUM="sha256::e85df657aa8d9361af4fb122014d8f123a93bfe45a7662fba2b373d839dbd8d3"
+REL=2
+SRCS="tbl::https://download.gnome.org/sources/gdm/${VER:0:4}/gdm-$VER.tar.xz"
+CHKSUMS="sha256::e85df657aa8d9361af4fb122014d8f123a93bfe45a7662fba2b373d839dbd8d3"

--- a/extra-trinity/tdebase/autobuild/overrides/etc/pam.d/tdm-np
+++ b/extra-trinity/tdebase/autobuild/overrides/etc/pam.d/tdm-np
@@ -1,6 +1,5 @@
 #%PAM-1.0
 auth        required    pam_env.so
-auth        required    pam_tally.so file=/var/log/faillog onerr=succeed
 auth        required    pam_shells.so
 auth        required    pam_nologin.so
 auth        required    pam_permit.so

--- a/extra-trinity/tdebase/spec
+++ b/extra-trinity/tdebase/spec
@@ -1,4 +1,4 @@
 VER=14.0.7
-REL=3
+REL=4
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/tdebase-trinity-$VER.tar.xz"
 CHKSUMS="sha256::10d241d15ccbf8e13cf696420d0e638a60a27403a79dbcb6a60165b60efcb80e"


### PR DESCRIPTION
Topic Description
-----------------

Drop deprecated `pam_tally` module from PAM configurations. Also drop `pam_tally` from `shadow`'s Retro overrides (no build required, no version/release change).

Package(s) Affected
-------------------

- `gdm` v3.34.1-2
- `sddm` v0.18.1-1
- `tdebase` v14.0.7-4

Security Update?
----------------

No

Build Order
-----------

None in particular.

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
