### PR TITLE
keepassxc: update to 2.6.2

### DIFF
--- a/extra-libs/quazip/spec
+++ b/extra-libs/quazip/spec
@@ -1,3 +1,3 @@
-VER=0.8.1
-SRCTBL="https://github.com/stachenov/quazip/archive/v$VER.tar.gz"
-CHKSUM="sha256::4fda4d4248e08015b5090d0369ef9e68bdc4475aa12494f7c0f6d79e43270d14"
+VER=0.9.1
+SRCS="https://github.com/stachenov/quazip/archive/v$VER.tar.gz"
+CHKSUMS="sha256::5d36b745cb94da440432690050e6db45b99b477cfe9bc3b82fd1a9d36fff95f5"

--- a/extra-security/keepassxc/autobuild/defines
+++ b/extra-security/keepassxc/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=keepassxc
 PKGSEC=security
 PKGDES="A cross-platform community-driven port for Keepass"
-PKGDEP="qt-5 libgcrypt zlib libmicrohttpd yubikey-personalization argon2 libsodium"
+PKGDEP="qt-5 libgcrypt zlib libmicrohttpd yubikey-personalization argon2 quazip libsodium"
 
 CMAKE_AFTER="-DWITH_XC_AUTOTYPE=ON -DWITH_XC_BROWSER=ON \
-             -DWITH_XC_YUBIKEY=ON -DWITH_XC_ALL=ON"
+             -DWITH_XC_YUBIKEY=ON -DWITH_XC_ALL=ON
+             -DWITH_XC_SSHAGENT=ON -DWITH_XC_KEESHARE=ON
+             -DWITH_XC_KEESHARE=ON"
 NOLTO=1

--- a/extra-security/keepassxc/autobuild/defines
+++ b/extra-security/keepassxc/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=keepassxc
 PKGSEC=security
 PKGDES="A cross-platform community-driven port for Keepass"
-PKGDEP="qt-5 libgcrypt zlib libmicrohttpd yubikey-personalization argon2 quazip libsodium"
+PKGDEP="qt-5 libgcrypt zlib libmicrohttpd yubikey-personalization argon2 quazip libsodium asciidoctor"
 
 CMAKE_AFTER="-DWITH_XC_AUTOTYPE=ON -DWITH_XC_BROWSER=ON \
              -DWITH_XC_YUBIKEY=ON -DWITH_XC_ALL=ON

--- a/extra-security/keepassxc/autobuild/defines
+++ b/extra-security/keepassxc/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=keepassxc
 PKGSEC=security
 PKGDES="A cross-platform community-driven port for Keepass"
-PKGDEP="qt-5 libgcrypt zlib libmicrohttpd yubikey-personalization argon2 quazip libsodium asciidoctor"
+PKGDEP="qt-5 libgcrypt zlib libmicrohttpd yubikey-personalization argon2 quazip libsodium"
+BUILDDEP="asciidoctor"
 
 CMAKE_AFTER="-DWITH_XC_AUTOTYPE=ON -DWITH_XC_BROWSER=ON \
              -DWITH_XC_YUBIKEY=ON -DWITH_XC_ALL=ON

--- a/extra-security/keepassxc/spec
+++ b/extra-security/keepassxc/spec
@@ -1,4 +1,3 @@
-VER=2.5.1
-SRCTBL="https://github.com/keepassxreboot/keepassxc/releases/download/${VER}/keepassxc-${VER}-src.tar.xz"
-CHKSUM="sha256::ef33258b859a7b996af007113613b0f6210f2341e8f5fb3a005564262c2caf30"
-REL=2
+VER=2.6.2
+SRCS="https://github.com/keepassxreboot/keepassxc/releases/download/${VER}/keepassxc-${VER}-src.tar.xz"
+CHKSUMS="sha256::101bfade0a760d6ec6b8c4f3556e7f1201f1edd29ceabc73ad5846f9a57d7e38"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
update keepassxc to 2.6.2

Package(s) Affected
-------------------
`keepassxc` 2.5.1 -> 2.6.2

Security Update?
----------------
No

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

