### PR TITLE
palemoon: update to 28.15.0

### DIFF
--- a/extra-web/palemoon/autobuild/defines
+++ b/extra-web/palemoon/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="dbus-glib desktop-file-utils gst-plugins-base-1-0 gtk-2 \
         gtk-3 hunspell hyphen libevent libjpeg-turbo libpng libvpx \
         mime-types nss pulseaudio startup-notification icu"
 PKGSUG="networkmanager"
-BUILDDEP="autoconf-2.13 networkmanager yasm gcc-5.4"
+BUILDDEP="autoconf-2.13 networkmanager yasm"
 PKGDES="An Open Source, Goanna-based web browser"
 
 PKGPROV="pale-moon"

--- a/extra-web/palemoon/autobuild/defines
+++ b/extra-web/palemoon/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=palemoon
 PKGSEC=web
 PKGDEP="dbus-glib desktop-file-utils gst-plugins-base-1-0 gtk-2 \
-        hunspell hyphen libevent libjpeg-turbo libpng libvpx \
+        gtk-3 hunspell hyphen libevent libjpeg-turbo libpng libvpx \
         mime-types nss pulseaudio startup-notification icu"
 PKGSUG="networkmanager"
 BUILDDEP="autoconf-2.13 networkmanager yasm gcc-5.4"

--- a/extra-web/palemoon/autobuild/patch
+++ b/extra-web/palemoon/autobuild/patch
@@ -1,7 +1,0 @@
-abinfo "Moving platform folder..."
-rm -rv "$SRCDIR/platform"
-mv -v "$SRCDIR/../uxp/" "$SRCDIR/platform"
-
-abinfo "Patching files..."
-find "$SRCDIR/autobuild/patches/" -exec patch -p1 -i '{}' \;
-

--- a/extra-web/palemoon/autobuild/patch
+++ b/extra-web/palemoon/autobuild/patch
@@ -1,0 +1,7 @@
+abinfo "Moving platform folder..."
+rm -rv "$SRCDIR/platform"
+mv -v "$SRCDIR/../uxp/" "$SRCDIR/platform"
+
+abinfo "Patching files..."
+find "$SRCDIR/autobuild/patches/" -exec patch -p1 -i '{}' \;
+

--- a/extra-web/palemoon/spec
+++ b/extra-web/palemoon/spec
@@ -1,4 +1,5 @@
-VER=28.13.0
-GITSRC="https://github.com/MoonchildProductions/Pale-Moon"
-GITCO="tags/${VER}_Release"
-CHKSUMS="SKIP"
+VER=28.15.0
+SRCS="tbl::https://repo.palemoon.org/MoonchildProductions/Pale-Moon/archive/${VER}_Release.tar.gz tbl::https://repo.palemoon.org/MoonchildProductions/UXP/archive/RELBASE_20201024.tar.gz"
+CHKSUMS="sha256::1475113c47c5a44539c402dba46e3ff15bc7cf6a6303cdb755408a01cdff9a65 sha256::4a4c7e1751527b5d0231590978f14e55d70d70a8c654c8766aeeaedca0af6b58"
+SUBDIR=pale-moon
+

--- a/extra-web/palemoon/spec
+++ b/extra-web/palemoon/spec
@@ -1,4 +1,4 @@
 VER=28.15.0
-SRCS="git::icommit=tags/${VER}_Release::https://repo.palemoon.org/MoonchildProductions/Pale-Moon"
+SRCS="git::commit=tags/${VER}_Release::https://repo.palemoon.org/MoonchildProductions/Pale-Moon"
 CHKSUMS="SKIP"
 

--- a/extra-web/palemoon/spec
+++ b/extra-web/palemoon/spec
@@ -1,4 +1,3 @@
 VER=28.15.0
 SRCS="git::commit=tags/${VER}_Release::https://repo.palemoon.org/MoonchildProductions/Pale-Moon"
 CHKSUMS="SKIP"
-

--- a/extra-web/palemoon/spec
+++ b/extra-web/palemoon/spec
@@ -1,5 +1,4 @@
 VER=28.15.0
-SRCS="tbl::https://repo.palemoon.org/MoonchildProductions/Pale-Moon/archive/${VER}_Release.tar.gz tbl::https://repo.palemoon.org/MoonchildProductions/UXP/archive/RELBASE_20201024.tar.gz"
-CHKSUMS="sha256::1475113c47c5a44539c402dba46e3ff15bc7cf6a6303cdb755408a01cdff9a65 sha256::4a4c7e1751527b5d0231590978f14e55d70d70a8c654c8766aeeaedca0af6b58"
-SUBDIR=pale-moon
+SRCS="git::icommit=tags/${VER}_Release::https://repo.palemoon.org/MoonchildProductions/Pale-Moon"
+CHKSUMS="SKIP"
 


### PR DESCRIPTION
Topic Description
-----------------
Update the `palemoon` package to version `28.15.0`.
Also source repository has changed.

Package(s) Affected
-------------------
`palemoon`

Security Update?
----------------
No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

