### PR TITLE
firefox: update to 83.0

### DIFF
--- a/extra-web/firefox/autobuild/patches/0006-Fix-GCC-build-failure-in-WasmBaselineCompile.cpp.patch
+++ b/extra-web/firefox/autobuild/patches/0006-Fix-GCC-build-failure-in-WasmBaselineCompile.cpp.patch
@@ -1,0 +1,62 @@
+From 71597faac0fde4f608a60dd610d0cefac4972cc3 Mon Sep 17 00:00:00 2001
+From: Jonathan Wakely <jwakely@redhat.com>
+Date: Tue, 17 Nov 2020 12:56:17 +0000
+Subject: [PATCH] Fix GCC build failure in WasmBaselineCompile.cpp
+
+GCC does not yet implement C++ Core DR 727, so explicit specializations
+at class scope aren't allowed. This replaces it with a different C++17
+feature: using if-constexpr inside the function body and checking the
+template argument there.
+
+See https://bugzilla.mozilla.org/show_bug.cgi?id=1677690
+and https://bugzilla.redhat.com/show_bug.cgi?id=1897675
+---
+ js/src/wasm/WasmBaselineCompile.cpp | 24 ++++++++++--------------
+ 1 file changed, 10 insertions(+), 14 deletions(-)
+
+diff --git a/js/src/wasm/WasmBaselineCompile.cpp b/js/src/wasm/WasmBaselineCompile.cpp
+index 676dbfa73d33a..b82aa242d3c6b 100644
+--- a/js/src/wasm/WasmBaselineCompile.cpp
++++ b/js/src/wasm/WasmBaselineCompile.cpp
+@@ -655,15 +655,13 @@ class BaseRegAlloc {
+ 
+   template <MIRType t>
+   bool hasFPU() {
+-    return availFPU.hasAny<RegTypeOf<t>::value>();
+-  }
+-
+ #ifdef RABALDR_SIDEALLOC_V128
+-  template <>
+-  bool hasFPU<MIRType::Simd128>() {
+-    MOZ_CRASH("Should not happen");
+-  }
++    if constexpr (t == MIRType::Simd128)
++      MOZ_CRASH("Should not happen");
++    else
+ #endif
++    return availFPU.hasAny<RegTypeOf<t>::value>();
++  }
+ 
+   bool isAvailableGPR(Register r) { return availGPR.has(r); }
+ 
+@@ -746,15 +744,13 @@ class BaseRegAlloc {
+ 
+   template <MIRType t>
+   FloatRegister allocFPU() {
+-    return availFPU.takeAny<RegTypeOf<t>::value>();
+-  }
+-
+ #ifdef RABALDR_SIDEALLOC_V128
+-  template <>
+-  FloatRegister allocFPU<MIRType::Simd128>() {
+-    MOZ_CRASH("Should not happen");
+-  }
++    if constexpr (t == MIRType::Simd128)
++      MOZ_CRASH("Should not happen");
++    else
+ #endif
++    return availFPU.takeAny<RegTypeOf<t>::value>();
++  }
+ 
+   void freeGPR(Register r) { availGPR.add(r); }
+ 

--- a/extra-web/firefox/spec
+++ b/extra-web/firefox/spec
@@ -1,3 +1,3 @@
-VER=82.0.2
+VER=83.0
 SRCS="tbl::https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz"
-CHKSUMS='sha256::8851cae2df9923844c3dc97a4f77f6f3c86cc6f298b888b38949fbf74fcf2ca9'
+CHKSUMS="sha256::d69e84e8b8449f828683d274c24e03095858362bfed21b08bdd7fe715eea5398"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

firefox: update to 83.0

Package(s) Affected
-------------------

firefox 83.0

Security Update?
----------------

No
<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

~- Loongson 3 `loongson3`~
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

~- Loongson 3 `loongson3`~
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
