### PR TITLE
nnn: update to 3.5

### DIFF
--- a/extra-utils/nnn/spec
+++ b/extra-utils/nnn/spec
@@ -1,3 +1,3 @@
 VER=3.5
-SRCTBL="https://github.com/jarun/nnn/archive/v$VER.tar.gz"
-CHKSUM="sha256::e636d4035499a112a0ad33f1557838132ed2e39d8857c5b219714fe9f64681f3"
+SRCS="tbl::https://github.com/jarun/nnn/archive/v$VER.tar.gz"
+CHKSUMS="sha256::e636d4035499a112a0ad33f1557838132ed2e39d8857c5b219714fe9f64681f3"

--- a/extra-utils/nnn/spec
+++ b/extra-utils/nnn/spec
@@ -1,3 +1,3 @@
-VER=3.4
+VER=3.5
 SRCTBL="https://github.com/jarun/nnn/archive/v$VER.tar.gz"
-CHKSUM="sha256::7803ae6e974aeb4008507d9d1afbcca8d084a435f36ff636b459ca50414930a1"
+CHKSUM="sha256::e636d4035499a112a0ad33f1557838132ed2e39d8857c5b219714fe9f64681f3"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

nnn: update to 3.5

Package(s) Affected
-------------------

nnn 3.5

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
