### PR TITLE
systemd: (upstream patch) add cacheflush to default syscall set

### DIFF
--- a/extra-admin/systemd/autobuild/patches/0002-seccomp-util-add-cacheflush-syscall-to-default-sysca.patch
+++ b/extra-admin/systemd/autobuild/patches/0002-seccomp-util-add-cacheflush-syscall-to-default-sysca.patch
@@ -1,0 +1,30 @@
+From 8e24b1d23f5fa711bfdfd38bcfef525de04cd3c1 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 29 Sep 2020 15:59:28 +0200
+Subject: [PATCH] seccomp-util: add cacheflush() syscall to @default syscall
+ set
+
+This is like membarrier() I guess and basically just exposes CPU
+functionality via kernel syscall on some archs. Let's whitelist it for
+everyone.
+
+Fixes: #17197
+---
+ src/shared/seccomp-util.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/shared/seccomp-util.c b/src/shared/seccomp-util.c
+index 358960d5c4..b22ef7cec1 100644
+--- a/src/shared/seccomp-util.c
++++ b/src/shared/seccomp-util.c
+@@ -272,6 +272,7 @@ const SyscallFilterSet syscall_filter_sets[_SYSCALL_FILTER_SET_MAX] = {
+                 .name = "@default",
+                 .help = "System calls that are always permitted",
+                 .value =
++                "cacheflush\0"
+                 "clock_getres\0"
+                 "clock_getres_time64\0"
+                 "clock_gettime\0"
+-- 
+2.27.0
+

--- a/extra-admin/systemd/spec
+++ b/extra-admin/systemd/spec
@@ -1,4 +1,4 @@
 VER=246.6
-REL=1
+REL=2
 SRCTBL="https://github.com/systemd/systemd-stable/archive/v$VER.tar.gz"
 CHKSUM="sha256::e999dbf0cff5b0109c28b307741b7dc315877fe2e1999f25c153548db44bb020"


### PR DESCRIPTION
Topic Description
-----------------

Backport a systemd patch to add `cacheflush()` to default syscall set, this will allow Node.js to run from within a `systemd-nspawn` container on MIPS platforms (Loongson 3).

Package(s) Affected
-------------------

- `systemd` v246.6-2

Security Update?
----------------

No

Architectural Progress
----------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`