### PR TITLE
zfs: use dynamic version substitution in autobuild/prerm

### DIFF
--- a/extra-kernel/zfs/autobuild/beyond
+++ b/extra-kernel/zfs/autobuild/beyond
@@ -1,2 +1,5 @@
-rm -rf "${PKGDIR}"/etc/init.d
-rm -rf "${PKGDIR}"/usr/share/initramfs-tools
+abinfo "Removing /etc/init.d ..."
+rm -rfv "${PKGDIR}"/etc/init.d
+
+abinfo "Removing initramfs-tools scripts ..."
+rm -rfv "${PKGDIR}"/usr/share/initramfs-tools

--- a/extra-kernel/zfs/autobuild/build
+++ b/extra-kernel/zfs/autobuild/build
@@ -1,4 +1,6 @@
 abinfo "Configuring ZFS userspace tools ..."
+mkdir -pv "$SRCDIR"/build
+cd "$SRCDIR"/build
 "$SRCDIR"/configure --prefix=/usr \
             --sysconfdir=/etc \
             --sbindir=/usr/bin \
@@ -14,15 +16,18 @@ abinfo "Configuring ZFS userspace tools ..."
 abinfo "Building ZFS userspace tools ..."
 make
 
+abinfo "Installing ZFS userspace tools ..."
+cp -rv "$SRCDIR"/{contrib,build/}
+make DESTDIR="${PKGDIR}" install
+
+cd "$SRCDIR"
+
 abinfo "Installing ZFS kernel module sources ..."
 install -dv "${PKGDIR}"/usr/src/zfs-${PKGVER}
-cp -Rvf "$SRCDIR"/!(abdist) "${PKGDIR}"/usr/src/zfs-${PKGVER}
+cp -Rvf "$SRCDIR"/!(abdist|build) \
+    "${PKGDIR}"/usr/src/zfs-${PKGVER}
 
 abinfo "Cleaning up ZFS kernel module source tree ..."
-(
-    cd "${PKGDIR}"/usr/src/zfs-${PKGVER}
-    make clean distclean
-)
 find "${PKGDIR}"/usr/src/zfs-${PKGVER} -name ".git*" -print0 | \
     xargs -0 rm -vfr --
 "${PKGDIR}"/usr/src/zfs-${PKGVER}/scripts/dkms.mkconf \
@@ -31,9 +36,6 @@ find "${PKGDIR}"/usr/src/zfs-${PKGVER} -name ".git*" -print0 | \
     -n zfs
 rm -rfv "${PKGDIR}"/usr/src/zfs-${PKGVER}/{autobuild,abdist,acbs-build_*.log}
 chmod -v g-w,o-w -R "${PKGDIR}"/usr/src/zfs-${PKGVER}
-
-abinfo "Installing ZFS userspace tools ..."
-make DESTDIR="${PKGDIR}" install
 
 abinfo "Installing Bash completions ..."
 install -Dvm644 \

--- a/extra-kernel/zfs/autobuild/build
+++ b/extra-kernel/zfs/autobuild/build
@@ -1,4 +1,5 @@
-./configure --prefix=/usr \
+abinfo "Configuring ZFS userspace tools ..."
+"$SRCDIR"/configure --prefix=/usr \
             --sysconfdir=/etc \
             --sbindir=/usr/bin \
             --with-mounthelperdir=/usr/bin \
@@ -9,18 +10,32 @@
             --libexecdir=/usr/libexec/zfs \
             --with-dracutdir=/usr/lib/dracut \
             --with-config=user
+
+abinfo "Building ZFS userspace tools ..."
 make
 
-install -d "${PKGDIR}"/usr/src/zfs-${PKGVER}
-cp -Rvf ./!(abdist) "${PKGDIR}"/usr/src/zfs-${PKGVER}
+abinfo "Installing ZFS kernel module sources ..."
+install -dv "${PKGDIR}"/usr/src/zfs-${PKGVER}
+cp -Rvf "$SRCDIR"/!(abdist) "${PKGDIR}"/usr/src/zfs-${PKGVER}
 
-pushd "${PKGDIR}"/usr/src/zfs-${PKGVER}
-make clean distclean
-find . -name ".git*" -print0 | xargs -0 rm -fr --
-scripts/dkms.mkconf -v ${PKGVER} -f dkms.conf -n zfs
-rm -rf autobuild abdist acbs-build_*.log
-chmod g-w,o-w -R .
-popd
+abinfo "Cleaning up ZFS kernel module source tree ..."
+(
+    cd "${PKGDIR}"/usr/src/zfs-${PKGVER}
+    make clean distclean
+)
+find "${PKGDIR}"/usr/src/zfs-${PKGVER} -name ".git*" -print0 | \
+    xargs -0 rm -vfr --
+"${PKGDIR}"/usr/src/zfs-${PKGVER}/scripts/dkms.mkconf \
+    -v ${PKGVER} \
+    -f dkms.conf \
+    -n zfs
+rm -rfv "${PKGDIR}"/usr/src/zfs-${PKGVER}/{autobuild,abdist,acbs-build_*.log}
+chmod -v g-w,o-w -R "${PKGDIR}"/usr/src/zfs-${PKGVER}
 
+abinfo "Installing ZFS userspace tools ..."
 make DESTDIR="${PKGDIR}" install
-install -Dm644 contrib/bash_completion.d/zfs "${PKGDIR}"/usr/share/bash-completion/completions/zfs
+
+abinfo "Installing Bash completions ..."
+install -Dvm644 \
+    "$SRCDIR"/contrib/bash_completion.d/zfs \
+    "${PKGDIR}"/usr/share/bash-completion/completions/zfs

--- a/extra-kernel/zfs/autobuild/prepare
+++ b/extra-kernel/zfs/autobuild/prepare
@@ -3,6 +3,7 @@ for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
     cp -v /usr/share/automake-1.16/$(basename $i) $i ; \
 done
 
-abinfo "Calibrating postinst..."
+abinfo "Calibrating postinst, prerm ..."
 sed -e "s|\@ZFSVER\@|$PKGVER|g" \
-    -i "$SRCDIR"/autobuild/postinst
+    -i "$SRCDIR"/autobuild/postinst \
+    -i "$SRCDIR"/autobuild/prerm

--- a/extra-kernel/zfs/autobuild/prerm
+++ b/extra-kernel/zfs/autobuild/prerm
@@ -1,2 +1,2 @@
 unset ARCH
-dkms remove zfs/0.8.1 --all || true > /dev/null
+dkms remove zfs/@ZFSVER@ --all || true > /dev/null

--- a/extra-kernel/zfs/spec
+++ b/extra-kernel/zfs/spec
@@ -1,4 +1,4 @@
 VER=0.8.4
-REL=1
+REL=2
 SRCS="tbl::https://github.com/zfsonlinux/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
 CHKSUMS="sha256::2b988f5777976f09d08083f6bebf6e67219c4c4c183c1f33033fb7e5e5eacafb"


### PR DESCRIPTION
Topic Description
-----------------

`autobuild/prerm` in `zfs` used to use a (incorrect) hard-coded version, make it a dynamic substitution. Lint scripts along the way.

Package(s) Affected
-------------------

`zfs` v0.8.4-2

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
