### PR TITLE
httpcore: update to 0.12.1

### DIFF
--- a/extra-python/httpcore/spec
+++ b/extra-python/httpcore/spec
@@ -1,3 +1,3 @@
-VER=0.12.0
-SRCTBL="https://github.com/encode/httpcore/archive/${VER}.tar.gz"
-CHKSUM="sha256::97c5655addb4c3e1056e0d138b6972da5436322dbe8eb77ca14e7348a83ea1f3"
+VER=0.12.1
+SRCS="tbl::https://github.com/encode/httpcore/archive/${VER}.tar.gz"
+CHKSUMS="sha256::2819074edded8834d781cf4d4dc30838a01d8c1c0ac16e432c9b275defb89817"


### PR DESCRIPTION
Topic Description
-----------------

Update httpcore to 0.12.1

Package(s) Affected
-------------------

httpcore

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`
