### PR TITLE
frp: update to 0.34.2

### DIFF
--- a/extra-network/frp/autobuild/defines
+++ b/extra-network/frp/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=frp
+PKGSEC=net
 PKGDEP="glibc"
 BUILDDEP="go"
 PKGDES="Fast reverse proxy"

--- a/extra-network/frp/spec
+++ b/extra-network/frp/spec
@@ -1,3 +1,3 @@
-VER=0.34.1
-SRCTBL="https://github.com/fatedier/frp/archive/v${VER}.tar.gz"
-CHKSUM="sha256::a47f952cc491a1d5d6f838306f221d6a8635db7cf626453df72fe6531613d560"
+VER=0.34.2
+SRCS="tbl::https://github.com/fatedier/frp/archive/v${VER}.tar.gz"
+CHKSUMS="sha256::53d8c29ef627e544cf8970b0a05570589d5270398068eb162957bdddb36de9ac"


### PR DESCRIPTION
Topic Description
-----------------

Update frp to 0.34.2

Package(s) Affected
-------------------

frp

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`