### PR TITLE
yarl: update to 1.6.3

### DIFF
--- a/extra-python/multidict/spec
+++ b/extra-python/multidict/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
-SRCTBL="https://github.com/aio-libs/multidict/archive/v${VER}.tar.gz"
-CHKSUM="sha256::d18fe7497c1565f1851b81c90ccf43d8bdbc1e40ea4627098e5d93be0e1e3780"
+VER=5.0.2
+SRCS="tbl::https://github.com/aio-libs/multidict/archive/v${VER}.tar.gz"
+CHKSUMS="sha256::1847502cb325866a07ef3f3d06553f1dadeaf2de5691a39299720aace6681c71"

--- a/extra-python/yarl/spec
+++ b/extra-python/yarl/spec
@@ -1,3 +1,3 @@
-VER=1.6.2
-SRCTBL="https://github.com/aio-libs/yarl/archive/v${VER}.tar.gz"
-CHKSUM="sha256::a4a674d655eeac67f3beae09268104f75e961b9e9c50b354935cad6186e0c52f"
+VER=1.6.3
+SRCS="tbl::https://github.com/aio-libs/yarl/archive/v${VER}.tar.gz"
+CHKSUMS="sha256::0dd52e81a7079982c33a22098148f2f6973209823418e820f8d9e596d7bacca4"


### PR DESCRIPTION
Topic Description
-----------------

Update yarl to 1.6.3
Update multidict to 5.0.2

Package(s) Affected
-------------------

yarl
multidict

Security Update?
----------------

No

Build Order
-----------

`multidict -> yarl`


Architectural Progress
----------------------

`multidict`
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

`yarl`
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

`multidict`
- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

`yarl`
- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

`multidict`
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

`yarl`
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

`multidict`
- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

`yarl`
- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`