### PR TITLE
ffmpeg: enable libaom

### DIFF
--- a/extra-libs/aom/autobuild/build
+++ b/extra-libs/aom/autobuild/build
@@ -1,0 +1,16 @@
+abinfo "Create build directory..."
+mkdir -p "$SRCDIR"/../aom_build
+
+abinfo "Configure and Making..."
+cmake \
+	-B "$SRCDIR"/../aom_build \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_INSTALL_PREFIX="/usr" \
+	-DCMAKE_INSTALL_LIBDIR="lib" \
+	-DBUILD_SHARED_LIBS=1 \
+	.
+
+make -C "$SRCDIR"/../aom_build
+
+abinfo "Installing aom..."
+make -C "$SRCDIR"/../aom_build DESTDIR="$PKGDIR" install

--- a/extra-libs/aom/autobuild/defines
+++ b/extra-libs/aom/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=aom
+PKGDES="AV1 Video Codec Library"
+PKGDEP="gcc-runtime"
+BUILDDEP="doxygen yasm"
+PKGSEC="libs"
+
+ABSHADOW=0

--- a/extra-libs/aom/spec
+++ b/extra-libs/aom/spec
@@ -1,0 +1,3 @@
+VER=2.0.0
+SRCS="git::commit=tags/v$VER::https://aomedia.googlesource.com/aom"
+CHKSUMS="SKIP"

--- a/extra-multimedia/ffmpeg/autobuild/build
+++ b/extra-multimedia/ffmpeg/autobuild/build
@@ -72,6 +72,7 @@ if [[ "${CROSS:-$ARCH}" != "i486" && "${CROSS:-$ARCH}" != "powerpc" && "${CROSS:
                 --enable-version3 \
                 --enable-vaapi \
                 --enable-lto \
+                --enable-libaom \
                 $MIPSCONF $PPCCONF $MFX $NVENC
     make
     make tools/qt-faststart

--- a/extra-multimedia/ffmpeg/autobuild/defines
+++ b/extra-multimedia/ffmpeg/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=sound
 PKGDEP="alsa-lib bzip2 fontconfig freetype fribidi gnutls gsm lame libass libbluray \
         libmodplug pulseaudio libssh libtheora libvdpau libvorbis libvpx libxcb \
         x264 x265 opencore-amr opus schroedinger sdl speex v4l-utils xvidcore \
-        zlib soxr libva sdl2 numactl ladspa-sdk xz"
+        zlib soxr libva sdl2 numactl ladspa-sdk xz aom"
 PKGDEP__AMD64="${PKGDEP} intel-media-sdk libcrystalhd"
 BUILDDEP__AMD64="${BUILDDEP} yasm ffnvcodec"
 BUILDDEP_ARM64="${BUILDDEP} yasm"

--- a/extra-multimedia/ffmpeg/spec
+++ b/extra-multimedia/ffmpeg/spec
@@ -1,4 +1,4 @@
 VER=4.2.4
-REL=3
+REL=4
 SRCTBL="https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUM="sha256::0d5da81feba073ee78e0f18e0966bcaf91464ae75e18e9a0135186249e3d2a0b"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Ffmpeg: enable libaom

Package(s) Affected
-------------------

aom 2.0.0
Ffmpeg 4.2.4-4

Security Update?
----------------

No
<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------
aom -> ffmpeg

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
