### PR TITLE
thunderbird: update to 78.5.0

### DIFF
--- a/extra-web/thunderbird/autobuild/prepare
+++ b/extra-web/thunderbird/autobuild/prepare
@@ -6,6 +6,12 @@ export LDFLAGS="${LDFLAGS/\-flto/}"
 abinfo "Installing mozconfig ..."
 cp -v "$SRCDIR"/{autobuild/,}mozconfig
 
+if [[ "${CROSS:-$ARCH}" = "armd64" || "${CROSS:-$ARCH}" = "loongson3" ]]; then
+    abinfo "Set linker as bfd..."
+    sed -i "s|gold|bfd|" "$SRCDIR"/mozconfig
+fi
+
+
 if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
     abinfo "Disabling ELF hacks in mozconfig..."
     echo "ac_add_options --disable-elf-hack" >> "$SRCDIR"/mozconfig

--- a/extra-web/thunderbird/autobuild/prepare
+++ b/extra-web/thunderbird/autobuild/prepare
@@ -11,6 +11,12 @@ if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
     echo "ac_add_options --disable-elf-hack" >> "$SRCDIR"/mozconfig
 fi
 
+if [[ "${CROSS:-$ARCH}" = "loongson3" ]]; then
+    abinfo "Disabling JIT in mozconfig..."
+    echo "ac_add_options --disable-jit" >> "$SRCDIR"/mozconfig
+fi
+
+
 abinfo "Declaring $SHELL as /bin/bash ..."
 export SHELL=/bin/bash
 

--- a/extra-web/thunderbird/spec
+++ b/extra-web/thunderbird/spec
@@ -1,3 +1,3 @@
-VER=78.3.1
+VER=78.5.0
 SRCTBL="https://archive.mozilla.org/pub/thunderbird/releases/$VER/source/thunderbird-$VER.source.tar.xz"
-CHKSUM="sha256::4ea61f59a819f5a8a4574b0735952e23b4c86387b8da24906129c45e71bf2718"
+CHKSUM="sha256::5f8a89c20e3ede73510da3eef866a1d07f31251c7912f6c52759db78f2307b77"

--- a/extra-web/thunderbird/spec
+++ b/extra-web/thunderbird/spec
@@ -1,3 +1,3 @@
 VER=78.5.0
-SRCTBL="https://archive.mozilla.org/pub/thunderbird/releases/$VER/source/thunderbird-$VER.source.tar.xz"
-CHKSUM="sha256::5f8a89c20e3ede73510da3eef866a1d07f31251c7912f6c52759db78f2307b77"
+SRCS="https://archive.mozilla.org/pub/thunderbird/releases/$VER/source/thunderbird-$VER.source.tar.xz"
+CHKSUMS="sha256::5f8a89c20e3ede73510da3eef866a1d07f31251c7912f6c52759db78f2307b77"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

thunderbird: update to 78.5.0

Package(s) Affected
-------------------

thunderbird 78.5.0

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

Yes, [MFSA2020-52](https://www.mozilla.org/en-US/security/advisories/mfsa2020-52/).

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

~- Loongson 3 `loongson3`~
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

~- Loongson 3 `loongson3`~
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
