### PR TITLE
i3status-rust: new 0.14.2

### DIFF
--- a/extra-wm/i3status-rust/autobuild/beyond
+++ b/extra-wm/i3status-rust/autobuild/beyond
@@ -1,0 +1,9 @@
+# From: https://www.archlinux.org/packages/community/x86_64/i3status-rust
+
+abinfo "Installing man page"
+install -Dvm644 "${SRCDIR}"/man/i3status-rs.1 "${PKGDIR}"/usr/share/man/man1/i3status-rs.1
+
+abinfo "Installing example configuration file"
+for example in example_config.toml example_icon.toml example_theme.toml; do
+  install -Dvm644 "${SRCDIR}/${example}" "${PKGDIR}/usr/share/doc/${PKGNAME}/examples/${example}"
+done

--- a/extra-wm/i3status-rust/autobuild/defines
+++ b/extra-wm/i3status-rust/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=i3status-rust
+PKGSEC=x11
+PKGDEP="pulseaudio"
+BUILDDEP="rustc llvm"
+PKGDES="A Rust re-implementation of i3status"
+USECLANG=1
+NOLTO__LOONGSON3=1
+ABTYPE=rust

--- a/extra-wm/i3status-rust/spec
+++ b/extra-wm/i3status-rust/spec
@@ -1,0 +1,3 @@
+VER=0.14.2
+SRCS="tbl::https://github.com/greshake/i3status-rust/archive/v$VER.tar.gz"
+CHKSUMS="sha256::66a11cbcfa515c761701788edd573d408391c024086219d8b6641333129a6f87"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

i3status-rust, a i3 status bar written in Rust.

Package(s) Affected
-------------------

i3status-rust

Security Update?
----------------

no

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
