### PR TITLE
Clash and v2ray-desktop: fix the build

### DIFF
--- a/extra-network/clash/autobuild/build
+++ b/extra-network/clash/autobuild/build
@@ -1,0 +1,3 @@
+go build -trimpath -ldflags "-X github.com/Dreamacro/clash/constant.Version=$PKGVER" -mod=readonly
+abinfo "Installing the binary..."
+install -Dvm755 clash "$PKGDIR"/usr/bin/clash

--- a/extra-network/clash/autobuild/defines
+++ b/extra-network/clash/autobuild/defines
@@ -3,4 +3,3 @@ PKGSEC=net
 PKGDEP="glibc"
 BUILDDEP="go"
 PKGDES="A rule-based tunnel for VMess, Shadowsocks, Trojan, Snell protocols"
-ABTYPE=gomod

--- a/extra-network/clash/spec
+++ b/extra-network/clash/spec
@@ -1,3 +1,4 @@
 VER=1.1.0
 SRCTBL="https://github.com/Dreamacro/clash/archive/v$VER.tar.gz"
 CHKSUM="sha256::00c19e27981dd0d6e9235d588a6e913d569157879b150da1f596682f5e525cae"
+REL=1

--- a/extra-network/v2ray-desktop/autobuild/beyond
+++ b/extra-network/v2ray-desktop/autobuild/beyond
@@ -1,9 +1,14 @@
-abinfo "Installing v2ray-desktop binary..."
-install -Dvm644 "$PKGDIR"/opt/V2Ray-Desktop/bin/V2Ray-Desktop "$PKGDIR"/usr/bin/v2ray-desktop
+abinfo "Replacing Exec path..."
+sed -i 's|%1|/usr/bin/v2ray-desktop|' "$SRCDIR"/misc/tpl-linux-autostart.desktop
+
+abinfo "Cutting postfix of Icon..."
+sed -i "s|.png||" "$SRCDIR"/misc/tpl-linux-autostart.desktop
+
+abinfo "Installing Icon..."
+install -Dvm644 "$SRCDIR"/images/v2ray.png "$PKGDIR"/usr/share/pixmaps/v2ray-desktop.png
+
 abinfo "Installing v2ray-desktop.desktop..."
 install -Dvm644 "$SRCDIR"/misc/tpl-linux-autostart.desktop "$PKGDIR"/usr/share/applications/v2ray-desktop.desktop
-abinfo "Installing v2ray-desktop icon..."
-sed -i  's/.png//g' "$PKGDIR"/usr/share/applications/v2ray-desktop.desktop
-install -Dvm644 "$SRCDIR"/images/v2ray.png "$PKGDIR"/usr/share/pixmaps/v2ray-desktop.png
-abinfo "Removing the useless directory"
-rm -rv "$PKGDIR"/opt/V2Ray-Desktop
+
+abinfo "Renaming binary..."
+mv -v "$PKGDIR"/usr/bin/V2Ray-Desktop "$PKGDIR"/usr/bin/v2ray-desktop

--- a/extra-network/v2ray-desktop/autobuild/prepare
+++ b/extra-network/v2ray-desktop/autobuild/prepare
@@ -1,1 +1,4 @@
 acbs_copy_git
+abinfo "Set the v2ray_usr_local_install..."
+sed -ie "s/V2RAY_USE_LOCAL_INSTALL[[:space:]]*= true/V2RAY_USE_LOCAL_INSTALL=false/" "$SRCDIR"/constants.h
+sed -i 's|/opt/$${TARGET}|/usr|' "$SRCDIR"/V2Ray-Desktop.pro

--- a/extra-network/v2ray-desktop/spec
+++ b/extra-network/v2ray-desktop/spec
@@ -2,3 +2,4 @@ VER=2.1.7
 GITSRC="https://github.com/Dr-Incognito/V2Ray-Desktop"
 GITCO="$VER"
 SUBDIR="v2ray-desktop/src"
+REL=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Clash and v2ray-desktop: fix the build

Package(s) Affected
-------------------

ckash 1.1.0
v2ray-desktop

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
