### PR TITLE
wine: update to 5.22

### DIFF
--- a/extra-emulation/wine/autobuild/prepare
+++ b/extra-emulation/wine/autobuild/prepare
@@ -1,13 +1,6 @@
-abinfo "Fetching Wine Staging patches ..."
-git clone https://github.com/wine-staging/wine-staging.git
-cd "$SRCDIR"/wine-staging
-git checkout v"${PKGVER}" || exit 1
-
 abinfo "Applying Wine Staging patches ..."
-cd "$SRCDIR"/wine-staging/patches
-ln -s ../../ wine
-./patchinstall.sh DESTDIR=../../ --all
-cd "$SRCDIR"/
+ln -sv "$SRCDIR" "$SRCDIR"/../wine-staging/patches/wine
+"$SRCDIR"/../wine-staging/patches/patchinstall.sh DESTDIR="$SRCDIR" --all
 
 abinfo "Setting -fPIC ..."
 export CFLAGS="${CFLAGS} -fPIC"

--- a/extra-emulation/wine/spec
+++ b/extra-emulation/wine/spec
@@ -1,3 +1,5 @@
-VER=5.21
-SRCS="tbl::https://dl.winehq.org/wine/source/5.x/wine-$VER.tar.xz"
-CHKSUMS="sha256::5a1a5c2549d11bce0d6640220ed6fd31042afcbcb366f475e0ccb4781d2d2840"
+VER=5.22
+SRCS="tbl::https://dl.winehq.org/wine/source/5.x/wine-$VER.tar.xz \
+      git::rename=wine-staging;commit=tags/v$VER::https://github.com/wine-staging/wine-staging"
+CHKSUMS="sha256::09bd06c87c8c974e6ad34507cec875d7217eb56fc09df838d5453e0ebbce4d21 SKIP"
+SUBDIR="wine-$VER"


### PR DESCRIPTION


Topic Description
-----------------

wine: update to 5.22

- Use SRCS to fetch wine-staging patches

Package(s) Affected
-------------------

wine 5.22

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


