### PR TITLE
fcitx5-material-color: update to 20201022

### DIFF
--- a/extra-i18n/fcitx5-material-color/autobuild/build
+++ b/extra-i18n/fcitx5-material-color/autobuild/build
@@ -1,7 +1,7 @@
 abinfo "Installing file to $PKGDIR..."
 
 install -Dm644 arrow.png radio.png -t "$PKGDIR"/usr/share/$PKGNAME/
-for _variant in blue brown deepPurple indigo pink red teal; do
+for _variant in blue brown deepPurple indigo pink red teal black; do
 _variant_name=Material-Color-${_variant^}
     install -Dm644 panel-$_variant.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/panel.png
     ln -s ../../../$PKGNAME/arrow.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/

--- a/extra-i18n/fcitx5-material-color/spec
+++ b/extra-i18n/fcitx5-material-color/spec
@@ -1,3 +1,3 @@
-VER="20200816"
-GITSRC="https://github.com/hosxy/Fcitx5-Material-Color"
-GITCO="41d52e93ba3bd68417635b257e8187be52acdb64"
+VER=20201022
+SRCS="git::commit=359df8149f466fa7b0413452a6bf990a8677c6cd::https://github.com/hosxy/Fcitx5-Material-Color"
+CHKSUMS="SKIP"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fcitx5-material-color: update to 20201022

Package(s) Affected
-------------------

fcitx5-material-color 20201022

Security Update?
----------------

No
<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch` 

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [ ] Architecture-independent `noarch` 