### PR TITLE
direnv: update to 2.24.0

### DIFF
--- a/extra-utils/direnv/spec
+++ b/extra-utils/direnv/spec
@@ -1,3 +1,3 @@
-VER=2.23.1
+VER=2.24.0
 SRCTBL="https://github.com/direnv/direnv/archive/v$VER.tar.gz"
-CHKSUM="sha256::12e01b1df182541654a39c8d631140cf528bfdca6c492545c7e6455748503efa"
+CHKSUM="sha256::a0993912bc6e89580bc8320d3c9b3e70ccd6aa06c1d847a4d9174bee8a8b9431"

--- a/extra-utils/direnv/spec
+++ b/extra-utils/direnv/spec
@@ -1,3 +1,3 @@
 VER=2.24.0
-SRCTBL="https://github.com/direnv/direnv/archive/v$VER.tar.gz"
-CHKSUM="sha256::a0993912bc6e89580bc8320d3c9b3e70ccd6aa06c1d847a4d9174bee8a8b9431"
+SRCS="https://github.com/direnv/direnv/archive/v$VER.tar.gz"
+CHKSUMS="sha256::a0993912bc6e89580bc8320d3c9b3e70ccd6aa06c1d847a4d9174bee8a8b9431"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update `direnv` to v2.24.0, which is the latest version.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

`direnv` update to 2.24.0
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
