### PR TITLE
fcitx5-material-color: update to 20201124

### DIFF
--- a/extra-i18n/fcitx5-material-color/autobuild/build
+++ b/extra-i18n/fcitx5-material-color/autobuild/build
@@ -1,7 +1,7 @@
 abinfo "Installing file to $PKGDIR..."
 
 install -Dm644 arrow.png radio.png -t "$PKGDIR"/usr/share/$PKGNAME/
-for _variant in blue brown deepPurple indigo pink red teal; do
+for _variant in blue brown deepPurple indigo pink red teal black; do
 _variant_name=Material-Color-${_variant^}
     install -Dm644 panel-$_variant.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/panel.png
     ln -s ../../../$PKGNAME/arrow.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/

--- a/extra-i18n/fcitx5-material-color/autobuild/build
+++ b/extra-i18n/fcitx5-material-color/autobuild/build
@@ -1,11 +1,17 @@
 abinfo "Installing file to $PKGDIR..."
+install -Dvm644 "$SRCDIR"/arrow.png "$SRCDIR"/radio.png -t "$PKGDIR"/usr/share/$PKGNAME/
 
-install -Dm644 arrow.png radio.png -t "$PKGDIR"/usr/share/$PKGNAME/
-for _variant in blue brown deepPurple indigo pink red teal black; do
-_variant_name=Material-Color-${_variant^}
-    install -Dm644 panel-$_variant.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/panel.png
-    ln -s ../../../$PKGNAME/arrow.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
-    ln -s ../../../$PKGNAME/radio.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
-    install -Dm644 theme-${_variant}.conf  "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/theme.conf
+variants=""
+for path in `ls "$SRCDIR"/panel-*`; do 
+    basename=$(basename $path)
+    variants+="$(echo "$basename" | cut -d '-' -f2 | cut -d '.' -f1) "
+done
+
+for _variant in $variants; do
+    _variant_name=Material-Color-${_variant^}
+    install -Dvm644 "$SRCDIR"/panel-$_variant.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/panel.png
+    ln -sv "$SRCDIR"/arrow.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
+    ln -sv "$SRCDIR"/radio.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
+    install -Dvm644 "$SRCDIR"/theme-${_variant}.conf  "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/theme.conf
     sed -i "s/^Name=.*/Name=$_variant_name/" "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/theme.conf
 done

--- a/extra-i18n/fcitx5-material-color/spec
+++ b/extra-i18n/fcitx5-material-color/spec
@@ -1,3 +1,3 @@
-VER=20201022
-SRCS="git::commit=359df8149f466fa7b0413452a6bf990a8677c6cd::https://github.com/hosxy/Fcitx5-Material-Color"
+VER=20201124
+SRCS="git::commit=361902ad043699925230a79bbda3d3a68f2e4d38::https://github.com/hosxy/Fcitx5-Material-Color"
 CHKSUMS="SKIP"

--- a/extra-i18n/fcitx5-material-color/spec
+++ b/extra-i18n/fcitx5-material-color/spec
@@ -1,3 +1,3 @@
-VER="20200816"
-GITSRC="https://github.com/hosxy/Fcitx5-Material-Color"
-GITCO="41d52e93ba3bd68417635b257e8187be52acdb64"
+VER=20201022
+SRCS="git::commit=359df8149f466fa7b0413452a6bf990a8677c6cd::https://github.com/hosxy/Fcitx5-Material-Color"
+CHKSUMS="SKIP"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fcitx5-material-color: update to 20201124

Package(s) Affected
-------------------

fcitx5-material-color 20201124

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->


 - [x] Architecture-independent `noarch`


----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

 - [x] Architecture-independent `noarch` 

