### PR TITLE
piper: update to 0.5.1

### DIFF
--- a/extra-libs/libratbag/spec
+++ b/extra-libs/libratbag/spec
@@ -1,4 +1,3 @@
-VER=0.11
-SRCTBL="https://github.com/libratbag/libratbag/archive/v$VER.tar.gz"
-CHKSUM="sha256::aa0bb012c2f581ee35ec023d516d23eb22d38f16092e7de44bd8481df953408d"
-REL=1
+VER=0.15
+SRCS="https://github.com/libratbag/libratbag/archive/v$VER.tar.gz"
+CHKSUMS="sha256::9e6ad8d54daef8cc0f44784bdde9bf5a3879d8a66d11e0b990b87266f81f7329"

--- a/extra-utils/piper/spec
+++ b/extra-utils/piper/spec
@@ -1,4 +1,3 @@
-VER=0.3
-SRCTBL="https://github.com/libratbag/piper/archive/$VER.tar.gz"
-CHKSUM="sha256::c7210c058de6a6803db462754386785cf5b9ab36dd9e69de6b7a3ca583451401"
-REL=1
+VER=0.5.1
+SRCS="https://github.com/libratbag/piper/archive/$VER.tar.gz"
+CHKSUMS="sha256::6a5f4ecfd8f9883a2db9c9692adbf2a3c43d3a6485929428ee9bfe2d421d3cce"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

piper: update to 0.5.1

Package(s) Affected
-------------------

piper 0.5.1

Security Update?
----------------

No
<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
