### PR TITLE
discord: update to 0.0.13

### DIFF
--- a/extra-web/discord/spec
+++ b/extra-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.12
-SRCTBL="https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUM="sha256::68f2cd3c397b5c54b15b08f0d873e14e569da024b12c2e56585fa1cb10db3f63"
+VER=0.0.13
+SRCS="https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
+CHKSUMS="sha256::feeca83531607eec1a6231ad8eab88bbf1865c39cf5f82b884e3b5241733bf34"
 SUBDIR=.


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update Discord to version `0.0.13`.

Package(s) Affected
-------------------

discord: update to 0.0.13

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

None, this package is AMD64 only.

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

None, this package is AMD64 only.
