### PR TITLE
libbluray: upgrade to 1.2.1, build userspace tools

### DIFF
--- a/extra-multimedia/libbluray/autobuild/defines
+++ b/extra-multimedia/libbluray/autobuild/defines
@@ -8,5 +8,5 @@ BUILDDEP__LOONGSON3=""
 PKGBREAK="ffmpeg<=3.4.2 gvfs<=1.36.0 kodi<=1:17.4 \
           mplayer<=1:1.3.0-8 vlc<=3.0.1 xine-lib<=1.2.8-1"
 
-AUTOTOOLS_AFTER="--disable-examples --with-java9"
-AUTOTOOLS_AFTER__LOONGSON3="--disable-examples --without-java9 --disable-bdjava-jar"
+AUTOTOOLS_AFTER="--with-java9"
+AUTOTOOLS_AFTER__LOONGSON3="--without-java9 --disable-bdjava-jar"

--- a/extra-multimedia/libbluray/autobuild/defines
+++ b/extra-multimedia/libbluray/autobuild/defines
@@ -3,10 +3,8 @@ PKGSEC=libs
 PKGDES="Library to access Blu-Ray disks for video playback"
 PKGDEP="libxml2 freetype"
 BUILDDEP="apache-ant"
-BUILDDEP__LOONGSON3=""
 
 PKGBREAK="ffmpeg<=3.4.2 gvfs<=1.36.0 kodi<=1:17.4 \
           mplayer<=1:1.3.0-8 vlc<=3.0.1 xine-lib<=1.2.8-1"
 
 AUTOTOOLS_AFTER="--with-java9"
-AUTOTOOLS_AFTER__LOONGSON3="--without-java9 --disable-bdjava-jar"

--- a/extra-multimedia/libbluray/spec
+++ b/extra-multimedia/libbluray/spec
@@ -1,4 +1,3 @@
-VER=1.1.2
-REL=1
+VER=1.2.1
 SRCTBL="https://download.videolan.org/pub/videolan/libbluray/$VER/libbluray-$VER.tar.bz2"
-CHKSUM="sha256::a3dd452239b100dc9da0d01b30e1692693e2a332a7d29917bf84bb10ea7c0b42"
+CHKSUM="sha256::5223e83f7988ea2cc860b5cadcaf9cf971087b0c80ca7b60cc17c8300cae36ec"

--- a/extra-optenv32/libbluray+32/spec
+++ b/extra-optenv32/libbluray+32/spec
@@ -1,4 +1,3 @@
-VER=1.1.2
+VER=1.2.1
 SRCTBL="https://download.videolan.org/pub/videolan/libbluray/$VER/libbluray-$VER.tar.bz2"
-CHKSUM="sha256::a3dd452239b100dc9da0d01b30e1692693e2a332a7d29917bf84bb10ea7c0b42"
-REL=1
+CHKSUM="sha256::5223e83f7988ea2cc860b5cadcaf9cf971087b0c80ca7b60cc17c8300cae36ec"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates `libbluray` to 1.2.1. The new version now includes userspace program `bd_info`, `bd_list_titles` and `bd_splice`.

Package(s) Affected
-------------------

* `libbluray` 1.2.1

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit x86 Optional Environment `optenv32`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit x86 Optional Environment `optenv32`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
