### PR TITLE
qliveplayer: update to 3.20.2

### DIFF
--- a/extra-multimedia/qliveplayer/spec
+++ b/extra-multimedia/qliveplayer/spec
@@ -1,3 +1,3 @@
-VER=3.20.1
+VER=3.20.2
 SRCS="https://github.com/IsoaSFlus/QLivePlayer/archive/${VER}.tar.gz"
-CHKSUMS="sha256::bd5c9e9e9a8b9453b3f1330a7140eec51b9232c50047d000ea3a1f77391fa9be"
+CHKSUMS="sha256::9859e3da8e4d194d153d2a3725f9f34fea527f67866867fb48299a43bf9c9e84"


### PR DESCRIPTION
Topic Description
-----------------
Update "qliveplayer" to the version 3.20.2.

Package(s) Affected
-------------------
* qliveplayer

Security Update?
----------------
No 

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`