### PR TITLE
htop: update to 3.0.3

### DIFF
--- a/extra-admin/htop/autobuild/defines
+++ b/extra-admin/htop/autobuild/defines
@@ -1,12 +1,14 @@
 PKGNAME=htop
 PKGEPOCH=1
 PKGSEC=utils
-PKGDEP="ncurses lsof"
+PKGDEP="ncurses lsof lm-sensors"
 PKGDES="Interactive process viewer"
 
 AUTOTOOLS_AFTER="--enable-unicode \
                  --enable-openvz \
-                 --enable-vserver \
                  --enable-delayacct \
-                 --enable-vserver"
-ABSHADOW=no
+                 --enable-vserver \
+                 --enable-ancient-vserver \
+                 --enable-linux-affinity \
+                 --with-sensors"
+ABSHADOW=0

--- a/extra-admin/htop/autobuild/defines
+++ b/extra-admin/htop/autobuild/defines
@@ -3,7 +3,10 @@ PKGEPOCH=1
 PKGSEC=utils
 PKGDEP="ncurses lsof"
 PKGDES="Interactive process viewer"
-BUILDDEP="python-2"
 
-AUTOTOOLS_AFTER="--enable-unicode --enable-openvz --enable-vserver --enable-cgroup"
+AUTOTOOLS_AFTER="--enable-unicode \
+                 --enable-openvz \
+                 --enable-vserver \
+                 --enable-delayacct \
+                 --enable-vserver"
 ABSHADOW=no

--- a/extra-admin/htop/spec
+++ b/extra-admin/htop/spec
@@ -1,3 +1,3 @@
-VER=3.0.2
-SRCTBL="https://github.com/htop-dev/htop/archive/$VER.tar.gz"
-CHKSUM="sha256::b4744a3bea279f2a3725ed8e5e35ffd9cb10d66673bf07c8fe21feb3c4661305"
+VER=3.0.3
+SRCS="tbl::https://github.com/htop-dev/htop/archive/$VER.tar.gz"
+CHKSUMS="sha256::725103929c925a7252b4dedeb29b3a1da86a2f74e96c50eb9ea6c8fec1942cd2"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

htop: update to 3.0.3

- Drop `--enable-cgroup` (follow upstream, see https://github.com/htop-dev/htop/pull/165/commits/eac43eeb29ed757ce3b9394d871347cf4f9b7c96).
- Enable ancient VServer, delay accounting, libsensor, Linux affinity support.
- Drop unneeded `python-2` build dep.

Package(s) Affected
-------------------

htop 3.0.3

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
