### PR TITLE
ldc-1.23.0: make-up rebuilds

### DIFF
--- a/extra-dlang/dub/spec
+++ b/extra-dlang/dub/spec
@@ -1,3 +1,4 @@
 VER=1.18.0
-SRCTBL="https://github.com/dlang/dub/archive/v$VER.tar.gz"
-CHKSUM="sha256::5ea118388217ad9afe7ccd6a486c0139c39a45e464de662fecfa142a408c1880"
+SRCS="https://github.com/dlang/dub/archive/v$VER.tar.gz"
+CHKSUMS="sha256::5ea118388217ad9afe7ccd6a486c0139c39a45e464de662fecfa142a408c1880"
+REL=1

--- a/extra-dlang/ldc/01-liblphobos/defines
+++ b/extra-dlang/ldc/01-liblphobos/defines
@@ -1,6 +1,6 @@
 PKGNAME=liblphobos
 PKGSEC=devel
-PKGDEP="libconfig libedit ncurses"
+PKGDEP="libconfig libedit ncurses spirv-llvm-translator"
 BUILDDEP="cmake llvm ldc"
 PKGDES="The LLVM-based D compiler runtime"
 
@@ -8,6 +8,5 @@ AB_FLAGS_SPECS=0
 NOLTO=1
 NOSTATIC=0
 
-PKGBREAK="tilix<=20190901 gtkd<=3.9.0-1 ldc<=1.14.0-2 \
-          dub<=1.17.0-1"
+PKGBREAK="dub<=1.18.0 gtkd<=3.9.0-2 ldc<=1.18.0 tilix<=20190901-2"
 PKGREP="ldc<=1.1.0b5"

--- a/extra-dlang/ldc/spec
+++ b/extra-dlang/ldc/spec
@@ -1,4 +1,4 @@
 VER=1.23.0
-SRCTBL="https://github.com/ldc-developers/ldc/releases/download/v${VER/b/-beta}/ldc-${VER/b/-beta}-src.tar.gz"
-CHKSUM='sha256::6d18d233fb3a666113827bdb7d96a6ff0b54014bbeb76d0cd12a892e8490afb9'
-REL=1
+REL=3
+SRCS="https://github.com/ldc-developers/ldc/releases/download/v${VER/b/-beta}/ldc-${VER/b/-beta}-src.tar.gz"
+CHKSUMS="sha256::6d18d233fb3a666113827bdb7d96a6ff0b54014bbeb76d0cd12a892e8490afb9"

--- a/extra-gnome/gtkd/spec
+++ b/extra-gnome/gtkd/spec
@@ -1,4 +1,4 @@
 VER=3.9.0
-REL=3
-SRCTBL="https://github.com/gtkd-developers/GtkD/archive/v$VER.tar.gz"
-CHKSUM="sha256::02a5d84b120e66011d6595f92679780f5782e8fe733c5517de1629c397a0d7d9"
+REL=4
+SRCS="https://github.com/gtkd-developers/GtkD/archive/v$VER.tar.gz"
+CHKSUMS="sha256::02a5d84b120e66011d6595f92679780f5782e8fe733c5517de1629c397a0d7d9"

--- a/extra-utils/tilix/autobuild/defines
+++ b/extra-utils/tilix/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=tilix
 PKGSEC=utils
-PKGDEP="gtkd vte-gtk3 dconf gsettings-desktop-schemas gettext liblphobos"
+PKGDEP="gtkd vte-gtk3 dconf gsettings-desktop-schemas gettext liblphobos librsvg"
 BUILDDEP="ldc po4a"
 PKGSUG="nautilus-python"
 PKGDES="A tiling terminal emulator"

--- a/extra-utils/tilix/spec
+++ b/extra-utils/tilix/spec
@@ -1,4 +1,3 @@
 VER=20190901
-REL=2
-GITSRC="https://github.com/gnunn1/tilix"
-GITCO="e302c58e7ec262496dce27db3e4adc394caf457d"
+REL=3
+SRCS="git::commit=e302c58e7ec262496dce27db3e4adc394caf457d::https://github.com/gnunn1/tilix"


### PR DESCRIPTION
Topic Description
-----------------

When LDC was updated for LLVM 10, reverse dependencies were not rebuilt. Rebuilding all reverse dependencies to make them usable again.

Package(s) Affected
-------------------

```
ldc v1.23.0-3
dub v1.18.0-1
gtkd v3.9.0-4
tilix v20190901-3
```

Security Update?
----------------

No

Build Order
-----------

```
ldc v1.23.0-3
dub v1.18.0-1
gtkd v3.9.0-4
tilix v20190901-3
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`