### PR TITLE
osu-lazer: update to 2020.1204.0

### DIFF
--- a/extra-games/osu-lazer/autobuild/beyond
+++ b/extra-games/osu-lazer/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing PDB files..."
+find "$PKGDIR"/usr/lib/osu-lazer/ -name "*.pdb" -delete -print

--- a/extra-games/osu-lazer/autobuild/build
+++ b/extra-games/osu-lazer/autobuild/build
@@ -1,5 +1,7 @@
 abinfo "Build osu.Desktop"
-dotnet publish osu.Desktop/osu.Desktop.csproj -c Release -o "$PKGDIR"/usr/share/osu-lazer -r linux-x64 --no-self-contained
+dotnet publish "$SRCDIR"/osu.Desktop/osu.Desktop.csproj -c Release \
+    -o "$PKGDIR"/usr/share/osu-lazer \
+    -r linux-x64 --no-self-contained
 
 abinfo "Deploy files"
 chmod 0755 "$PKGDIR"/usr/share/osu-lazer/'osu!'

--- a/extra-games/osu-lazer/autobuild/build
+++ b/extra-games/osu-lazer/autobuild/build
@@ -1,8 +1,8 @@
 abinfo "Build osu.Desktop"
 dotnet publish "$SRCDIR"/osu.Desktop/osu.Desktop.csproj -c Release \
-    -o "$PKGDIR"/usr/share/osu-lazer \
+    -o "$PKGDIR"/usr/lib/osu-lazer \
     -r linux-x64 --no-self-contained
 
 abinfo "Deploy files"
-chmod 0755 "$PKGDIR"/usr/share/osu-lazer/'osu!'
-install -Dm644 "$SRCDIR"/assets/lazer.png "$PKGDIR"/usr/share/pixmaps/osu-lazer.png
+chmod 0755 "$PKGDIR"/usr/lib/osu-lazer/'osu!'
+install -Dm644 "$SRCDIR"/assets/lazer.png "$PKGDIR"/usr/lib/pixmaps/osu-lazer.png

--- a/extra-games/osu-lazer/autobuild/build
+++ b/extra-games/osu-lazer/autobuild/build
@@ -1,5 +1,5 @@
 abinfo "Build osu.Desktop"
-dotnet publish osu.Desktop/osu.Desktop.csproj -c Release -o "$PKGDIR"/usr/share/osu-lazer -r linux-x64 --self-contained
+dotnet publish osu.Desktop/osu.Desktop.csproj -c Release -o "$PKGDIR"/usr/share/osu-lazer -r linux-x64 --no-self-contained
 
 abinfo "Deploy files"
 chmod 0755 "$PKGDIR"/usr/share/osu-lazer/'osu!'

--- a/extra-games/osu-lazer/autobuild/defines
+++ b/extra-games/osu-lazer/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=osu-lazer
 PKGSEC=games
 PKGDES="Rhythm is just a click away!"
-PKGDEP="alsa-lib desktop-file-utils libgdiplus"
+PKGDEP="alsa-lib desktop-file-utils libgdiplus dotnet-runtime-3.1"
 BUILDDEP="dotnet-sdk-3.1.1xx"
 
 FAIL_ARCH="!(amd64)"

--- a/extra-games/osu-lazer/autobuild/overrides/usr/bin/osu-lazer
+++ b/extra-games/osu-lazer/autobuild/overrides/usr/bin/osu-lazer
@@ -2,4 +2,5 @@
 PREFIX="/usr/share/osu-lazer"
 LD_PRELOAD="${LD_PRELOAD} ${PREFIX}/libbass.so"
 export LD_PRELOAD
+export DOTNET_ROOT="/usr/lib/dotnet"
 exec "${PREFIX}"/osu\!

--- a/extra-games/osu-lazer/autobuild/overrides/usr/bin/osu-lazer
+++ b/extra-games/osu-lazer/autobuild/overrides/usr/bin/osu-lazer
@@ -1,5 +1,5 @@
 #!/bin/bash
-PREFIX="/usr/share/osu-lazer"
+PREFIX="/usr/lib/osu-lazer"
 LD_PRELOAD="${LD_PRELOAD} ${PREFIX}/libbass.so"
 export LD_PRELOAD
 export DOTNET_ROOT="/usr/lib/dotnet"

--- a/extra-games/osu-lazer/spec
+++ b/extra-games/osu-lazer/spec
@@ -1,4 +1,3 @@
 VER=2020.1204.0
 SRCS="tbl::https://github.com/ppy/osu/archive/$VER.tar.gz"
 CHKSUMS="sha256::ce90f2d94ca144c37bf68a24946559daffe10eec40028fd1d8904e8cf00fc474"
-REL=1

--- a/extra-games/osu-lazer/spec
+++ b/extra-games/osu-lazer/spec
@@ -1,4 +1,4 @@
-VER=2020.1109.0
+VER=2020.1204.0
 SRCS="tbl::https://github.com/ppy/osu/archive/$VER.tar.gz"
-CHKSUMS="sha256::dcbd2f1da1db2bd94cc998aa33549d12fe6f98c25827933ed8635a974ce8632b"
+CHKSUMS="sha256::ce90f2d94ca144c37bf68a24946559daffe10eec40028fd1d8904e8cf00fc474"
 REL=1


### PR DESCRIPTION
Topic Description
-----------------

Update osu-lazer to 2020.1204.0
Set dotnet `--no-self-contained`. New dependency: `dotnet-runtime-3.1`

Package(s) Affected
-------------------

osu-lazer

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   