### PR TITLE
kf5,plasma: update survey, 20201210

### DIFF
--- a/extra-devel/extra-cmake-modules/spec
+++ b/extra-devel/extra-cmake-modules/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/extra-cmake-modules-$VER.tar.xz"
-CHKSUMS="sha256::878d47a901056d5303bf37414d787046e1d38fac2bd9f2f5ddd00a9dd6b9f4eb"
+CHKSUMS="sha256::4845e9e0a43ba15158c0cfdc7ab594e7d02692fab9083201715270a096704a32"

--- a/extra-kde/attica5/spec
+++ b/extra-kde/attica5/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/attica-$VER.tar.xz"
-CHKSUMS="sha256::fcc0b11620de9d88141fcb36aa2eddc19a78c023a2c753eb9de404271280288d"
+CHKSUMS="sha256::64b262f61935653b91a83f4d1c659e7dcaf575b12aa955fe16d8392adb256e22"

--- a/extra-kde/baloo/spec
+++ b/extra-kde/baloo/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/baloo-$VER.tar.xz"
-CHKSUMS="sha256::e26e0b76eb57889592131c7a95134e32288a8c67d6660342dcc961f37c1926f0"
+CHKSUMS="sha256::8ae9e6dd51c84150f7fc581ebf04617f3ee9e1f96e08df79d6f15ee29f5f95f9"

--- a/extra-kde/bluedevil/spec
+++ b/extra-kde/bluedevil/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/bluedevil-$VER.tar.xz"
-CHKSUMS="sha256::0f3154ced1f44595993694954a640d8a1b2fa1cadaa50efcd07454e5c13ca19e"
+CHKSUMS="sha256::522ad4ff3f3fc4e213328f821041d40b5126d0d3ca49ecc9aea35c59e2c64129"

--- a/extra-kde/bluez-qt/spec
+++ b/extra-kde/bluez-qt/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/bluez-qt-$VER.tar.xz"
-CHKSUMS="sha256::f00446dd89a0d1340256b7c4a1f38de05e5be04a76298956e4bcd153979bad3f"
+CHKSUMS="sha256::a3f99a10e5f018bac91b4bd88be23a6ea9399aa1ab29d16840d5ee2c20537835"

--- a/extra-kde/breeze-grub/spec
+++ b/extra-kde/breeze-grub/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/breeze-grub-$VER.tar.xz"
-CHKSUMS="sha256::a2193c8cbe3ba18c5d2777f0cd70da603775c7a0b5c810e5b20561328d422125"
+CHKSUMS="sha256::8692b6800e89b97973b50d6915f9ca028cdcb0354c34b54719af54441e3f3feb"

--- a/extra-kde/breeze-gtk/spec
+++ b/extra-kde/breeze-gtk/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/breeze-gtk-$VER.tar.xz"
-CHKSUMS="sha256::e2792cf9e434864f466b3823663c976aa77f22cebd5cdb9d3d30e5abaacc1b08"
+CHKSUMS="sha256::8905b3a0ff40a48ed2f00f69b7e30c4658deb9fbd1afc61700a28d078693b61d"

--- a/extra-kde/breeze-icons/spec
+++ b/extra-kde/breeze-icons/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/breeze-icons-$VER.tar.xz"
-CHKSUMS="sha256::21985f62c111e60ebd34bd632b3ee06bb01a1f9f1671d1295f0d24bc21e106a2"
+CHKSUMS="sha256::d0211f0e6fa9137dbb42bcad1ac352bbfe793b6a3e6483adc2051b5c24a7851b"

--- a/extra-kde/breeze-plymouth/spec
+++ b/extra-kde/breeze-plymouth/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/breeze-plymouth-$VER.tar.xz"
-CHKSUMS="sha256::86e43b7bf87eb3d727ececcfdb958abc5f1d213cb10323597e7601f2c40caea2"
+CHKSUMS="sha256::879d4bd8d0c42a5c1f51497a4ee4ebb3e69f7904170bafa392b95e1c0ce05ada"

--- a/extra-kde/breeze/spec
+++ b/extra-kde/breeze/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/breeze-$VER.tar.xz"
-CHKSUMS="sha256::e1c1643221d9cb246cab5c7d9423effee5fe23c22785d20c0d0e841f1ced6793"
+CHKSUMS="sha256::b61b3f9961c196bbcfb33519bbec06d19e6267182f7215e21071a5619681b30f"

--- a/extra-kde/discover/spec
+++ b/extra-kde/discover/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/discover-$VER.tar.xz"
-CHKSUMS="sha256::3a92180217fff52ccca26d1a3b467ceff82404ca363d6b1bfcb8a48d967af511"
+CHKSUMS="sha256::3669648fa39e14a8da059373c9a01caacfd5b126d61daed65d5d7aae7ab30012"

--- a/extra-kde/drkonqi/spec
+++ b/extra-kde/drkonqi/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/drkonqi-$VER.tar.xz"
-CHKSUMS="sha256::7b9fa6f4c77b5ab4c110bb15ec463b00a7bb94c5af46ff57f249cd71a1947106"
+CHKSUMS="sha256::55d4a166ee74c4a935c69cec64ecd8eb3fdd79aae8dcd996f6432a873be3fac8"

--- a/extra-kde/frameworkintegration/spec
+++ b/extra-kde/frameworkintegration/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/frameworkintegration-$VER.tar.xz"
-CHKSUMS="sha256::a98dc6aa464f35f97ef51bfa7873d6d905623417543aaf94ec974f24603e3b0b"
+CHKSUMS="sha256::7ac6c070190ab4c0c2ac15a921886ed7f3b70d6a0b7c41766d21a913e9f086fb"

--- a/extra-kde/kactivities-stats/spec
+++ b/extra-kde/kactivities-stats/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kactivities-stats-$VER.tar.xz"
-CHKSUMS="sha256::eee926b1d49c460f1220957e52858df5271aee3b9c77b848e2969f0afe743aad"
+CHKSUMS="sha256::85bb432a10a48af505a457c7ccacffad7914835f94042472083e878cabcd2c14"

--- a/extra-kde/kactivities/spec
+++ b/extra-kde/kactivities/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kactivities-$VER.tar.xz"
-CHKSUMS="sha256::d25fa31d9ad8bed6af1adbd589945494d1f5741e18e7bb5d67371749c6565e08"
+CHKSUMS="sha256::efba13d0d720502bf8bee161b688ba21704f7c213c8b95da65b77b76c9cb3422"

--- a/extra-kde/kactivitymanagerd/spec
+++ b/extra-kde/kactivitymanagerd/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kactivitymanagerd-$VER.tar.xz"
-CHKSUMS="sha256::675d87636398e1236f2c0af7129b961b9ac2feac53cc32d6194da41a026d8972"
+CHKSUMS="sha256::210215dd9a49fda98febb60f73f4cc95eda3eb9ec96c0db2f2881f6be13afb34"

--- a/extra-kde/kapidox/spec
+++ b/extra-kde/kapidox/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kapidox-$VER.tar.xz"
-CHKSUMS="sha256::80e2a7bb86ed6c87c9d556d5c0f4059e3968fdbbc585bc041a55d130455d07d2"
+CHKSUMS="sha256::8c6c9401059d34fa2d7f052e21387d803a1131a60fcd1305ddf5d5dfe22c6d97"

--- a/extra-kde/karchive/spec
+++ b/extra-kde/karchive/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/karchive-$VER.tar.xz"
-CHKSUMS="sha256::0c833c766d2301335490a1b36197bae20b2e45d1350f4f8100e6e00d5502eaab"
+CHKSUMS="sha256::503d33b247ae24260c73aac2c48601eb4f8be3f10c9149549ea5dd2d22082a2a"

--- a/extra-kde/kauth/spec
+++ b/extra-kde/kauth/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kauth-$VER.tar.xz"
-CHKSUMS="sha256::c2c316b783f3d531c6f3a308087dcdc59211920df8b10f6814272ebf6c8fd083"
+CHKSUMS="sha256::c277a7ab750158a56381d8f74b8ebed5205b785eca2444c65cbf59d429958a89"

--- a/extra-kde/kbookmarks/spec
+++ b/extra-kde/kbookmarks/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kbookmarks-$VER.tar.xz"
-CHKSUMS="sha256::56320e443ba0ec52822b84a968ada0e34331b12251f84df839fc165fcb14e458"
+CHKSUMS="sha256::ac5416f1ac21cb9e9fdf72a95de855a9891cea0ed7e1436a93c019b6c45af2af"

--- a/extra-kde/kcalendarcore/spec
+++ b/extra-kde/kcalendarcore/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kcalendarcore-$VER.tar.xz"
-CHKSUMS="sha256::02ff08c6462a5f0552c85a1da98320ca0a1c8d7295a05230f4b27b7a3f0a3dbc"
+CHKSUMS="sha256::e6fd390b8ba2a899e7abda3de8d9ab7e5155fede6bbee9ca2b302b931a0232ae"

--- a/extra-kde/kcmutils/spec
+++ b/extra-kde/kcmutils/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kcmutils-$VER.tar.xz"
-CHKSUMS="sha256::dd7926548cd05b98c0013cbeac204e47860c517b9121a80c3a739bbbffaba3cd"
+CHKSUMS="sha256::0ea51ea9e46e6359c76fe099fd2cd03c20891a1cad26ea156ca921a9f0869009"

--- a/extra-kde/kcodecs/spec
+++ b/extra-kde/kcodecs/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kcodecs-$VER.tar.xz"
-CHKSUMS="sha256::cf4498c00368cc667910776cf54de02838f17b5f2d0bd48749ec5a2000346327"
+CHKSUMS="sha256::b4e1fe3247fdaf80f4414716f6fbcd42e8de04f64c8dd50bd13e9e9a78abf6e1"

--- a/extra-kde/kcompletion/spec
+++ b/extra-kde/kcompletion/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kcompletion-$VER.tar.xz"
-CHKSUMS="sha256::409b2759b6ac476b16fd6b5efd78381e9a840bae041fef35285404d2b79eeeff"
+CHKSUMS="sha256::014c56172040bf3aa27f81a6bb433914a5c22d2dfb1f8566be4cce678d09193a"

--- a/extra-kde/kconfig/spec
+++ b/extra-kde/kconfig/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kconfig-$VER.tar.xz"
-CHKSUMS="sha256::38aa7cabcb042d3f2614d0229f7a4f65952b19b5c7edd78ee2b0401fd6dd4290"
+CHKSUMS="sha256::153d3ed114954594b0dcc00e1317483609649c064203e6eb8b110686dbaba686"

--- a/extra-kde/kconfigwidgets/spec
+++ b/extra-kde/kconfigwidgets/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kconfigwidgets-$VER.tar.xz"
-CHKSUMS="sha256::cd99dc233d1aaf30fbb910f2f268cffc1e11d3480b7c592d2a566aaf4812f083"
+CHKSUMS="sha256::f8eed399008a041df2da9cc3f2313df11376b94c85472900b39b9d6abcabe6d4"

--- a/extra-kde/kcontacts/spec
+++ b/extra-kde/kcontacts/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kcontacts-$VER.tar.xz"
-CHKSUMS="sha256::8c77f9c5cf9ea630c779096a91f96322f34adc66c9fa64a85dddb294a905d069"
+CHKSUMS="sha256::4a9e3189b4ed1bc0231bf98cba134e78e5a692a14d202f0311f6e5c5190cfad5"

--- a/extra-kde/kcoreaddons/spec
+++ b/extra-kde/kcoreaddons/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kcoreaddons-$VER.tar.xz"
-CHKSUMS="sha256::9ca2cf82ddc12e27ff73aaefdf616c3eb6552a3a5531f014b5bf52a34a4c73f9"
+CHKSUMS="sha256::fbab3e3e18f42922ecdc50138ed31f62007cafa902b959d89b1233b5557282d6"

--- a/extra-kde/kcrash/spec
+++ b/extra-kde/kcrash/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kcrash-$VER.tar.xz"
-CHKSUMS="sha256::1c8950bf699e4df86c2ebe29a364be53017b45d127c1d052c7ac4ef13b96db3a"
+CHKSUMS="sha256::c4e32254b22f1f02db556be2ad40000cc52cac2e30a35682af3c75ac69710993"

--- a/extra-kde/kdav/spec
+++ b/extra-kde/kdav/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kdav-$VER.tar.xz"
-CHKSUMS="sha256::4442abb9afb177085e9d2c82cdb87c67f7992d770b1bee922b84806b9f44256e"
+CHKSUMS="sha256::c6b1d32d9c976585e278c2061091ee90ef2d7feb29642f236a3941cea5ffae72"

--- a/extra-kde/kdbusaddons/spec
+++ b/extra-kde/kdbusaddons/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kdbusaddons-$VER.tar.xz"
-CHKSUMS="sha256::25826b091a22d876621dca040ca47ea1ec34119d300be91f19629a82c7f84af1"
+CHKSUMS="sha256::8e11b19e4a3d4ad8e4deda245eb51b7b77255cbacc07346e7074c8110b946e0a"

--- a/extra-kde/kde-cli-tools/spec
+++ b/extra-kde/kde-cli-tools/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kde-cli-tools-$VER.tar.xz"
-CHKSUMS="sha256::f78d3eb2a9e37276645d7e9cc2b515d14753d20daf6b45dcc2b4538253c7c13e"
+CHKSUMS="sha256::55f35158715bafdd51e448a2760327ed4f91c54fcd3da807dec2736d077b16a3"

--- a/extra-kde/kde-gtk-config/spec
+++ b/extra-kde/kde-gtk-config/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kde-gtk-config-$VER.tar.xz"
-CHKSUMS="sha256::50b73d1d7fb15c99919b841fdc3e663c454ea0a8dca97b4b876581499e9db7d4"
+CHKSUMS="sha256::db3510cb08788c915be5e034106145597de5a412236b60c57b8db4b64dbbd7b1"

--- a/extra-kde/kdeclarative/spec
+++ b/extra-kde/kdeclarative/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kdeclarative-$VER.tar.xz"
-CHKSUMS="sha256::585b3b7d97c26542c8325050d1c4f7e36cf6111c43cf630cd2a729a36963109b"
+CHKSUMS="sha256::3dfaa271a97be48e72d5fff0dd3c3c1995be3b9e7d0451b197b79418d76c4ce3"

--- a/extra-kde/kdecoration/spec
+++ b/extra-kde/kdecoration/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kdecoration-$VER.tar.xz"
-CHKSUMS="sha256::7b49c0a3a0a7be93127b4b7a7273575a037af5447adf55154cabb2c6f87637f6"
+CHKSUMS="sha256::8d1224a50a2e8c0ec24faab4453432eb8083b35a63e479523de95dce644226e8"

--- a/extra-kde/kded/spec
+++ b/extra-kde/kded/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kded-$VER.tar.xz"
-CHKSUMS="sha256::dd811f4e8058348f772133d910aa8623fde4208c50c7d7a834605cf04f8f097d"
+CHKSUMS="sha256::2e94a4737ffc359d3614a1dff15b9727d54cb5fe639828946e0efcdcdbff3516"

--- a/extra-kde/kdelibs4support/spec
+++ b/extra-kde/kdelibs4support/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/portingAids/kdelibs4support-$VER.tar.xz"
-CHKSUMS="sha256::54466e73d05dfbb6ffd65b2018d689b8c807e0569e59da29a70daf2ac195461d"
+CHKSUMS="sha256::b581273dfaebc5697eb7aa616d858119227dd6c5b781f216abdbff1d93076f0d"

--- a/extra-kde/kdeplasma-addons/spec
+++ b/extra-kde/kdeplasma-addons/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kdeplasma-addons-$VER.tar.xz"
-CHKSUMS="sha256::22df49f743cbb0cdc8a27293a75f2a7df913e88f563cbbdb3980cdd669605017"
+CHKSUMS="sha256::44768c7fb00386bc4f005c773bca59d8acc354f8a3f43efa6565cefc74d490d7"

--- a/extra-kde/kdesignerplugin/spec
+++ b/extra-kde/kdesignerplugin/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/portingAids/kdesignerplugin-$VER.tar.xz"
-CHKSUMS="sha256::fd8812b4fb6922091b53da72eb74104f9438be3063e65ffe23d6948a292f18e9"
+CHKSUMS="sha256::5f9190e00761330c031310b94e195766e639115675081765050ddc55069a1b71"

--- a/extra-kde/kdesu/spec
+++ b/extra-kde/kdesu/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kdesu-$VER.tar.xz"
-CHKSUMS="sha256::c9ac069e7958f95f69891b78bd752310688624dc02f6e1595d4c41645f0a2bd9"
+CHKSUMS="sha256::421ef43bd47c3eb6b05806af033276c19df20fd76a06b67fada529bb9c52e642"

--- a/extra-kde/kdewebkit/spec
+++ b/extra-kde/kdewebkit/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/portingAids/kdewebkit-$VER.tar.xz"
-CHKSUMS="sha256::c02b5e206713e436b464eb6c5813096736d3806b458fdf0502b8920efe12e400"
+CHKSUMS="sha256::cf7de765c5fcad0922a1bb9376b65cfb00eb3d29a0c4ed8ef43fc363abe906ba"

--- a/extra-kde/kdnssd/spec
+++ b/extra-kde/kdnssd/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kdnssd-$VER.tar.xz"
-CHKSUMS="sha256::3f197cabab50316fdc6852b90a3ec064ba99b2c8289093198c76d21ec03ddc8b"
+CHKSUMS="sha256::9cc2979e56915b5c4d8f8e66053a41406bff46aefd65af1ab07d2b87d8f4a753"

--- a/extra-kde/kdoctools/spec
+++ b/extra-kde/kdoctools/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kdoctools-$VER.tar.xz"
-CHKSUMS="sha256::4463dd3021ebff078a92d0556f37cbfa1b16ba970e8ad510bf397bd55f49381a"
+CHKSUMS="sha256::84ea7974d741e6261e8c269750367a00375c6111dbc542e917647d0267337ae4"

--- a/extra-kde/kemoticons/spec
+++ b/extra-kde/kemoticons/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kemoticons-$VER.tar.xz"
-CHKSUMS="sha256::4ac70cee9d7fafe6ef9668d37a146489b341804e0bf0dba6a7cce2d6ecaa78c1"
+CHKSUMS="sha256::a50f69e62b342d6f058000ff1823569ab61d3310cb0020d848a78deaf20dff99"

--- a/extra-kde/kfilemetadata/spec
+++ b/extra-kde/kfilemetadata/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kfilemetadata-$VER.tar.xz"
-CHKSUMS="sha256::2798207b796cc37638d3a4fe84cb8be1479b074db772c12d402fc6bfbd5cf0ca"
+CHKSUMS="sha256::fa24758c93ce3df9f8ced4310dc0bf58e129b08e50f254daafa025afc9213d68"

--- a/extra-kde/kgamma/spec
+++ b/extra-kde/kgamma/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kgamma5-$VER.tar.xz"
-CHKSUMS="sha256::79720c6899e6edff68692832a84dc3b935929000b90599ae7dd2cbb6a0d784a4"
+CHKSUMS="sha256::59b1247dfc3c45247cff62e3706b52c9a1be2cf9cfe6e92c9c7299fc5cb51b41"

--- a/extra-kde/kglobalaccel/spec
+++ b/extra-kde/kglobalaccel/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kglobalaccel-$VER.tar.xz"
-CHKSUMS="sha256::a4d0e1f87317870120772444fa6736ce020668675be08d5e445a3ce5a60355d4"
+CHKSUMS="sha256::3a846f783ccb68da1f152fb5778612c4ed14cd79c6b5929ef729cf59e47462d4"

--- a/extra-kde/kguiaddons/spec
+++ b/extra-kde/kguiaddons/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kguiaddons-$VER.tar.xz"
-CHKSUMS="sha256::58aba1bd986020f7b4bde0d35a7b09730716cbdffde734e6d29cc9d18500253b"
+CHKSUMS="sha256::bdaa2ed104bfa9c2ebd702f033935a83560e1d00c7302620a6ae52cb309c7125"

--- a/extra-kde/kholidays/spec
+++ b/extra-kde/kholidays/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kholidays-$VER.tar.xz"
-CHKSUMS="sha256::2ff86514a1165c88fc81b47476c5671b5e840633d3bf04cfe513881e4a0db7e5"
+CHKSUMS="sha256::2eeae5812b33b2527c27a137fee0d7ec66fe7164bd28afd0d2a8362f6114618b"

--- a/extra-kde/khotkeys/spec
+++ b/extra-kde/khotkeys/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/khotkeys-$VER.tar.xz"
-CHKSUMS="sha256::2e6cc767cb3a967462b295165ee7202f25ddef93205fdb78dcd35020c52dce15"
+CHKSUMS="sha256::13c7e5a38f095056c6411b8dc91fc0640256c0a6f0a5166ba716e2454388d648"

--- a/extra-kde/khtml/spec
+++ b/extra-kde/khtml/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/portingAids/khtml-$VER.tar.xz"
-CHKSUMS="sha256::942951da89f0a1d7f74d5771bcfa166f8851e94923952d86c0d62ee445d43f25"
+CHKSUMS="sha256::163139cf9ed9c43bba9532e64ae6376e8ced9b19ea8bb8235ff91c91c4c5a3f4"

--- a/extra-kde/ki18n/spec
+++ b/extra-kde/ki18n/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/ki18n-$VER.tar.xz"
-CHKSUMS="sha256::71f22a4ef4a9e750a1813c9fe37b552d9e053e6e2249079b5908d078160130d3"
+CHKSUMS="sha256::0e87bc1136e21f7860f15daa39e8d16e5a773995fce2b87b0cef0043c4ce0e7a"

--- a/extra-kde/kiconthemes/spec
+++ b/extra-kde/kiconthemes/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kiconthemes-$VER.tar.xz"
-CHKSUMS="sha256::250b551ecfc5381c36267c51fdc86948ed85b1f477b12bd15a57d2d4e44a88db"
+CHKSUMS="sha256::3b3c4ab8369061418677c840963cc868dcecc2a4e57f0c73448e16a46773c7d3"

--- a/extra-kde/kidletime/spec
+++ b/extra-kde/kidletime/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kidletime-$VER.tar.xz"
-CHKSUMS="sha256::da1a980bec52f00baa20bb1f886fc32392587ffd467404888d3a1cb5897bd200"
+CHKSUMS="sha256::0866fc98b5b045158742f03f5810909b24f1edf374a6014d476d67fe0466eb62"

--- a/extra-kde/kimageformats/spec
+++ b/extra-kde/kimageformats/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kimageformats-$VER.tar.xz"
-CHKSUMS="sha256::7ea083bc1b67cf069df1bcf3235f00a750a269cfb38b5ade6e971ece11e46a65"
+CHKSUMS="sha256::78ced2665f8918beb617b74962d188dcbb01a92a90ba49bfd173671bdb14e68d"

--- a/extra-kde/kinfocenter/spec
+++ b/extra-kde/kinfocenter/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kinfocenter-$VER.tar.xz"
-CHKSUMS="sha256::d7650201505477504a812f7923495f2ccf92d85196fc9f9100d6f0c4ede5a141"
+CHKSUMS="sha256::09af2cafde33d0c8a824451ca532a443b6f571e20037fe6b31245c9984e9a6b3"

--- a/extra-kde/kinit/spec
+++ b/extra-kde/kinit/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kinit-$VER.tar.xz"
-CHKSUMS="sha256::f4f6f0caf7bfe7a321b0e822735ac5377e2b46600249ae77010a1252a5b87647"
+CHKSUMS="sha256::a5b63c10b4fc5efcbb5f92b7bce928b4a4880c0ad5d12ff12518106b09239546"

--- a/extra-kde/kio/spec
+++ b/extra-kde/kio/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kio-$VER.tar.xz"
-CHKSUMS="sha256::27af8d83d0ea6c68fc62675a0d0d34e94489e9e518c4a4c32fa9d4784510bc8e"
+CHKSUMS="sha256::9351fc85c4020f2f77012e077f4f9d04d8f233e9b67f9b7619c9bc064714145b"

--- a/extra-kde/kirigami2/spec
+++ b/extra-kde/kirigami2/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kirigami2-$VER.tar.xz"
-CHKSUMS="sha256::cde28a432e2ce56aae6f29eb557dc838af6846eb7dcba587113f73ebf11fca7d"
+CHKSUMS="sha256::90806125143807b74ee7f2fc74cd781d99b4e69ce5f15dcc28e1923f7a34a80a"

--- a/extra-kde/kitemmodels/spec
+++ b/extra-kde/kitemmodels/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kitemmodels-$VER.tar.xz"
-CHKSUMS="sha256::fb3f4caa2e55ffb5e21ea8f65bcb6ea9b074c54f9dbbce458ba7320d6c50fdb6"
+CHKSUMS="sha256::53855ccdd1105aa792914f9c88f357039bf2394af8400beaaecd9729f70e9cb0"

--- a/extra-kde/kitemviews/spec
+++ b/extra-kde/kitemviews/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kitemviews-$VER.tar.xz"
-CHKSUMS="sha256::071f2886cfb213c01cfeb26a9c98b26b720ff6928c5db04d4ead9ca34f72cac1"
+CHKSUMS="sha256::b102cb67513d804fd7eed2ae20bb4ba679d38de4f236de6bc03709ff0c0bc001"

--- a/extra-kde/kjobwidgets/spec
+++ b/extra-kde/kjobwidgets/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kjobwidgets-$VER.tar.xz"
-CHKSUMS="sha256::6cac9b64d4b13211e5f3c001986933ae461af4d08ef1e5351e2cfd432c22b478"
+CHKSUMS="sha256::850b6af6c027476e594e6ed77ea0e531abb69ff726fce41b91e541fbee3ecedf"

--- a/extra-kde/kjs/spec
+++ b/extra-kde/kjs/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/portingAids/kjs-$VER.tar.xz"
-CHKSUMS="sha256::d7411680164f2c9d989528d690888a703c15cd106cddb2665f1325dfb5fe2efa"
+CHKSUMS="sha256::829eb1308b9b07cdd07b34d80eb5e3fcf5225fa4816da19bce886add600bb62a"

--- a/extra-kde/kjsembed/spec
+++ b/extra-kde/kjsembed/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/portingAids/kjsembed-$VER.tar.xz"
-CHKSUMS="sha256::1127c6f558f9272881ec733a21caa0b93376d9a86ffd2a7558fc299fb3a7efe3"
+CHKSUMS="sha256::d7fe11b69445afe372388c5ab310d38ab69e203f3995136a948c9bbf9b8b4a88"

--- a/extra-kde/kmediaplayer/spec
+++ b/extra-kde/kmediaplayer/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/portingAids/kmediaplayer-$VER.tar.xz"
-CHKSUMS="sha256::17cb03fe28f830fd21b5ad7ab93852395ee32cb8de053a026d7402a68a81d796"
+CHKSUMS="sha256::3185da877c2529c6e209cb382593bbb4778f80aee1b1a29b384b3f05ff99ed89"

--- a/extra-kde/kmenuedit/spec
+++ b/extra-kde/kmenuedit/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kmenuedit-$VER.tar.xz"
-CHKSUMS="sha256::3fa4e940d1c8bfe3e6f47a4bb07e73e802be3b43a8d24c3b3805b7843aa32631"
+CHKSUMS="sha256::32c2d2eb979e43e4cc0892aa9460eb8ebaf603b77385b9f058a48ca4347dde4b"

--- a/extra-kde/knewstuff/spec
+++ b/extra-kde/knewstuff/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/knewstuff-$VER.tar.xz"
-CHKSUMS="sha256::1a1f8771ac879e7f08ce688c63a9b0f8bb60d8d3460acf739752c5e05d26c980"
+CHKSUMS="sha256::d6589b420204d1133997f33b598324c839ec6a0db96936e2e51b7b156cafbc6b"

--- a/extra-kde/knotifications/spec
+++ b/extra-kde/knotifications/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/knotifications-$VER.tar.xz"
-CHKSUMS="sha256::15be8f602c3f364b0b72be837c41ddc622a5447129b9d3dcb355f297dc18f9db"
+CHKSUMS="sha256::56a7daf4951b3564e244d8ba48d443e78c6d703d9d4ccc280c56d0c986de47a2"

--- a/extra-kde/knotifyconfig/spec
+++ b/extra-kde/knotifyconfig/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/knotifyconfig-$VER.tar.xz"
-CHKSUMS="sha256::b98f5ff6f92e147d36e1204261895ee1557af847ede00333b0cb946dcd00a94b"
+CHKSUMS="sha256::9f98834a9b8135a60a5d67e7ac45229a668a889d42a14c2ca5365885acd2370e"

--- a/extra-kde/kpackage/spec
+++ b/extra-kde/kpackage/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kpackage-$VER.tar.xz"
-CHKSUMS="sha256::9dd7b8fb029a52c886e2b6c43c4492720851b1242659ebd5dd4a066e569733eb"
+CHKSUMS="sha256::97791ef08ca18892d6aa6a50fa0a87ae72cad10de9f17e3fb503a370de829772"

--- a/extra-kde/kparts/spec
+++ b/extra-kde/kparts/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kparts-$VER.tar.xz"
-CHKSUMS="sha256::ea745811e4b14a9c62fae161eb6bf97306d28a082e25430dac183d0772ba7fee"
+CHKSUMS="sha256::c516b5c1f2bca4a109dc2d186ef6729c1ad53a242877dfe942b84f131e93412d"

--- a/extra-kde/kpeople/spec
+++ b/extra-kde/kpeople/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kpeople-$VER.tar.xz"
-CHKSUMS="sha256::8b8a8fa8829db7b36c0bf0eeb3bc9ba4733d7ce8b9db6bd3b2721a3f39d40367"
+CHKSUMS="sha256::25c03e48a0951f2d17556912893f55750ffbc1333b07b9b42e2ff0bb571b6545"

--- a/extra-kde/kplotting/spec
+++ b/extra-kde/kplotting/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kplotting-$VER.tar.xz"
-CHKSUMS="sha256::55fded2f312d104fe9e22c6baa04fc125dba9bba45db03f02f6811ab3f04a0ae"
+CHKSUMS="sha256::536e0eb7b35700ffe91fccce37386f9b97214cd9bd41bea7f2bb333a49d7ec9e"

--- a/extra-kde/kpty/spec
+++ b/extra-kde/kpty/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kpty-$VER.tar.xz"
-CHKSUMS="sha256::ef5484c65fae63acf744787293e74008601063a5eb74f3183449e85895e27c67"
+CHKSUMS="sha256::faa143bdceb02156ba2f989128376b97161c9799952a3517240816a42abe1ac7"

--- a/extra-kde/kquickcharts/spec
+++ b/extra-kde/kquickcharts/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kquickcharts-$VER.tar.xz"
-CHKSUMS="sha256::d2595bf1f8b6c5c46961cb95feed2b1f0f16b377ef65cb6fb12bbfcec0c81b82"
+CHKSUMS="sha256::65e79e0b4a8f1bca579931d0c0f8345c58f27319bf332e05a32ec930b8e519c2"

--- a/extra-kde/kross/spec
+++ b/extra-kde/kross/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/portingAids/kross-$VER.tar.xz"
-CHKSUMS="sha256::59b34c638893e9489d545c0ae7b5751208ced9315981d59719af28815b258757"
+CHKSUMS="sha256::15591f2a50f995bcaf17ef72662851c805d4644f13848387f056f686b77c5291"

--- a/extra-kde/krunner/spec
+++ b/extra-kde/krunner/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/krunner-$VER.tar.xz"
-CHKSUMS="sha256::50383177abd782ad852985162a00d86e94d1abf8775ceb75825a7015fff21c66"
+CHKSUMS="sha256::08c8addcdd3dac87472e84bd14c6d02b99f98c5efbbda7802de92286105dcdda"

--- a/extra-kde/kscreen/spec
+++ b/extra-kde/kscreen/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kscreen-$VER.tar.xz"
-CHKSUMS="sha256::42d55e891516192773ba1dd405c80c76fef86b7e4e5a6bbea3b9dcf38c713f28"
+CHKSUMS="sha256::4063fae5cb40a22a98fd0cc217e9b0ea4aef6518203c4bbe2664d5d01dfb9d9c"

--- a/extra-kde/kscreenlocker/spec
+++ b/extra-kde/kscreenlocker/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kscreenlocker-$VER.tar.xz"
-CHKSUMS="sha256::2499d88be243d64a854860c2aaa9c03f05f2078419aaf55d7eab65a885c24175"
+CHKSUMS="sha256::d80d4625a0a48a7a63c5ff8255e8639eb2fb57ebc436c46979949b39fc530126"

--- a/extra-kde/kservice/spec
+++ b/extra-kde/kservice/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kservice-$VER.tar.xz"
-CHKSUMS="sha256::17ceccf833d8da807dfaee2c3eb5c0ca7ee6b876c2454b5d6914a91eeb0a7f80"
+CHKSUMS="sha256::ef7715e5d3e0bf4fc2d28a7713913a1283fb9c658b3c3536a6db8da649d185bf"

--- a/extra-kde/ksshaskpass/spec
+++ b/extra-kde/ksshaskpass/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/ksshaskpass-$VER.tar.xz"
-CHKSUMS="sha256::0bb099355966adc6f122b2eb5e6cc001f347c878b25a536175054307ab211be4"
+CHKSUMS="sha256::a391ba0490ca41a33207adb6aff2233165d4aeed119fd056489d6eccfc81f218"

--- a/extra-kde/ksysguard/spec
+++ b/extra-kde/ksysguard/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/ksysguard-$VER.tar.xz"
-CHKSUMS="sha256::1fc3529453c38151bebd582da9256907d213b309d7e1f6870b0aac0626208cf7"
+CHKSUMS="sha256::a5f247b24ce75a28f301446fbeb25abf968e77e0c32cd4be9b574a21d3bbfaf4"

--- a/extra-kde/ktexteditor/spec
+++ b/extra-kde/ktexteditor/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/ktexteditor-$VER.tar.xz"
-CHKSUMS="sha256::acb689e7d5fdaeb43dd2450cd51bca7153d3923df968be46e4aaf2871232f983"
+CHKSUMS="sha256::6f937b7af06562a238f091deef9c4332e94311a697af8466b7f091720eaab2b2"

--- a/extra-kde/ktextwidgets/spec
+++ b/extra-kde/ktextwidgets/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/ktextwidgets-$VER.tar.xz"
-CHKSUMS="sha256::6b92145ceaa758b1d73a337078771899ad14b8ade26c5388cb04f752b982521a"
+CHKSUMS="sha256::a104e894cf21c245a6c22e6f2c38fdbbdb094cb7fde3d7ebff801bfd73af4c84"

--- a/extra-kde/kunitconversion/spec
+++ b/extra-kde/kunitconversion/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kunitconversion-$VER.tar.xz"
-CHKSUMS="sha256::bb0587276d081163cb86328370c77d9ebc109fc3b633f46af299656de900a36a"
+CHKSUMS="sha256::31fa05b082ec3a42c831b840cbc086f97c5e49c05a71af29ab35b9727320990c"

--- a/extra-kde/kwallet-pam/spec
+++ b/extra-kde/kwallet-pam/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwallet-pam-$VER.tar.xz"
-CHKSUMS="sha256::a9461fb1aa387d509d63352f633f1522c65e7850aa78604be3850e748b5a2d7d"
+CHKSUMS="sha256::0749056e9acbbc194b20be5b0921383013ed6c268c22cf905aeeda32514d3ac9"

--- a/extra-kde/kwallet/spec
+++ b/extra-kde/kwallet/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kwallet-$VER.tar.xz"
-CHKSUMS="sha256::87b28d5b0c93f6085d6ccabc78b3e21590889767432ef22316f3e87322df1363"
+CHKSUMS="sha256::5addd560d3f650fbb43cd9c8c9e964c2d6893fa45ac53420b711f6bbb4e7a4fc"

--- a/extra-kde/kwayland-integration/spec
+++ b/extra-kde/kwayland-integration/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwayland-integration-$VER.tar.xz"
-CHKSUMS="sha256::62e8f20a613a5e5a2470a029897ad207ce5b3c21ef05cbb2c88d3e8ec215a0a8"
+CHKSUMS="sha256::2dd985dd8d21cdc7743b9f297d0d582f960339b4714953564f2f047d28cee53d"

--- a/extra-kde/kwayland-server/spec
+++ b/extra-kde/kwayland-server/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwayland-server-$VER.tar.xz"
-CHKSUMS="sha256::dfba976a5485ecd92c69154521a773cbb9c51d7f07b9326cd0e80f8ac0bb0af0"
+CHKSUMS="sha256::3edc7b73baa6fa8b0bec51272e8786bab41998b0f675262d5086fdf6c1e9bb44"

--- a/extra-kde/kwayland/spec
+++ b/extra-kde/kwayland/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kwayland-$VER.tar.xz"
-CHKSUMS="sha256::4476113932b26484698b09a4653c8ffc9772122f4ada42b0cb327527f8f2d9c0"
+CHKSUMS="sha256::eee72a5f57a2f5c6ab5f1717aa3eb5a9089240794a5e40c6d85bdc37fa3027a7"

--- a/extra-kde/kwidgetsaddons/spec
+++ b/extra-kde/kwidgetsaddons/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kwidgetsaddons-$VER.tar.xz"
-CHKSUMS="sha256::9e46a967e7f98f570ab97d231e648770b0c6056a34d8efe0b3201a14f0e17bc0"
+CHKSUMS="sha256::ab7aa94bb1f63e5bea5cf461349c1add96fd608a73c5b7c9d374e6bf035fcac6"

--- a/extra-kde/kwin/spec
+++ b/extra-kde/kwin/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwin-$VER.tar.xz"
-CHKSUMS="sha256::79557de888c8cd671ca592b5d105e236c959f877b7e9f836bcd69ddef193759c"
+CHKSUMS="sha256::c59861e9d456974bffaff2cb371cd8d31bdb789f89a60af632089c556111662a"

--- a/extra-kde/kwindowsystem/spec
+++ b/extra-kde/kwindowsystem/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kwindowsystem-$VER.tar.xz"
-CHKSUMS="sha256::4c180ec41aad90ed83e97db72216913e650b2719946803eec0d6e4cee7aab743"
+CHKSUMS="sha256::8dced74012bed3f33c3c51874aa9c3a57093573c1c0e263b758cefa96c26f7b7"

--- a/extra-kde/kwrited/spec
+++ b/extra-kde/kwrited/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwrited-$VER.tar.xz"
-CHKSUMS="sha256::fcd35ce5d380cefa1d346a0a5b802498f9227410cab579aac0bff30322e41ece"
+CHKSUMS="sha256::f02b900538246f4df2707585052b732552d2ea115a16f8fbda618fa02e5a1bb2"

--- a/extra-kde/kxmlgui/spec
+++ b/extra-kde/kxmlgui/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/kxmlgui-$VER.tar.xz"
-CHKSUMS="sha256::8d5a45cf5ddeb650f76f16872e2b6c7a8d808757fc23d3000e11803bf83f7c91"
+CHKSUMS="sha256::73ae838fb79f97243bea36d438e9bc45315183bbb6b08ab5173c822cfcb4dd82"

--- a/extra-kde/kxmlrpcclient/spec
+++ b/extra-kde/kxmlrpcclient/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/portingAids/kxmlrpcclient-$VER.tar.xz"
-CHKSUMS="sha256::8292beafee7a1ea2ad81d1e7603c35a0fe69e585d0d5cbe6c546d4a97741dc8b"
+CHKSUMS="sha256::66fe826a81cd266ee57ba814cb8c7adfa00aa9112cb55714db061a82895ee8de"

--- a/extra-kde/libkscreen/spec
+++ b/extra-kde/libkscreen/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/libkscreen-$VER.tar.xz"
-CHKSUMS="sha256::2ee2c77556ac30ec49be5bc7db552332f6b1084f6d7737b711d3c9c01b523c5d"
+CHKSUMS="sha256::ce1bd03a25b101793fa1472ac3fc696079e607a6f45330ea724845bda288d28d"

--- a/extra-kde/libksysguard/spec
+++ b/extra-kde/libksysguard/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/libksysguard-$VER.tar.xz"
-CHKSUMS="sha256::9f57a3719d665df6d6b3c494a62bb7d60c79b06f30c0e9c75eb03568d2046d71"
+CHKSUMS="sha256::a89968476cb8a888550e1a5138ab8e86eeb49788187192cba71f79abd4aad422"

--- a/extra-kde/milou/spec
+++ b/extra-kde/milou/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/milou-$VER.tar.xz"
-CHKSUMS="sha256::ae26499141eb277284108c7524dbe11cac7d7dd486ddd8efd8c308d4cf0de980"
+CHKSUMS="sha256::123ac9470a94f2eb6e4212979d2df4160fa15962b1fc18551bfcdfe5aa18a201"

--- a/extra-kde/modemmanager-qt/spec
+++ b/extra-kde/modemmanager-qt/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/modemmanager-qt-$VER.tar.xz"
-CHKSUMS="sha256::9e1ab6e61421ab5fb227f0c04593b27e067f1855a111a0192514d99e442bce80"
+CHKSUMS="sha256::5782b71f60b825244dc017989a4de515eb9eb5cc4edfe494a14ea62d3ac40cd1"

--- a/extra-kde/networkmanager-qt/spec
+++ b/extra-kde/networkmanager-qt/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/networkmanager-qt-$VER.tar.xz"
-CHKSUMS="sha256::ba9d15eb5e0e624ffaac591cdaad43dc62e60ccfa25b98be686b58800b41018b"
+CHKSUMS="sha256::5920862a843898ed169cc61a8f27dd87cb64dd505ec300d95ab8967da89f2f90"

--- a/extra-kde/oxygen-icons/spec
+++ b/extra-kde/oxygen-icons/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/oxygen-icons5-$VER.tar.xz"
-CHKSUMS="sha256::c50d58e7f67ef3011bf169a38a6d4fe11b5bdc383a5adcdbb46c6fdc1605e503"
+CHKSUMS="sha256::95ca95bada43281d09cce000c9cd645af67592205c971052b3e0c27aef9c95b1"

--- a/extra-kde/oxygen/spec
+++ b/extra-kde/oxygen/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/oxygen-$VER.tar.xz"
-CHKSUMS="sha256::39adb9cf9cfa2d18ce4fcb36dac01858ea9e8fa8f85487345e0c373319ffacf7"
+CHKSUMS="sha256::e58cb6a2e1976a973e24d974556e6306a076ce1295f33a9a1bc56a8715857f67"

--- a/extra-kde/plasma-browser-integration/spec
+++ b/extra-kde/plasma-browser-integration/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://github.com/KDE/plasma-browser-integration/archive/v$VER.tar.gz"
-CHKSUMS="sha256::0348b9f3e77513b1be6cfffe300d27953f098ee9c04f0189a9623521cc3a9476"
+CHKSUMS="sha256::3c75e09830e8ac2dbb92f12b2da602dfac7a0d2a3a875a0d72d335cc6d6be648"

--- a/extra-kde/plasma-desktop/spec
+++ b/extra-kde/plasma-desktop/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-desktop-$VER.tar.xz"
-CHKSUMS="sha256::ef569f62740aad3cf6fdea7d2f87c56df84661043a1b9572c12676937ca698b0"
+CHKSUMS="sha256::3864e80bb9b8da596188162b14cd9bb77e7a8abedfb0fa41c8c72d47139d1355"

--- a/extra-kde/plasma-disks/spec
+++ b/extra-kde/plasma-disks/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-disks-$VER.tar.xz"
-CHKSUMS="sha256::2ba7f7f2c0c749f0e736333784d746037dea52106fb8e930d787a9b2389f1db5"
+CHKSUMS="sha256::f0110588b2603905962beedd596cfa6eb6371b7bac2186aa845d22237199d845"

--- a/extra-kde/plasma-framework/spec
+++ b/extra-kde/plasma-framework/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/plasma-framework-$VER.tar.xz"
-CHKSUMS="sha256::a6a68cdfeaeded999ebe7207c524f8a4a6fd13562a6d95b9f6137730ada0697a"
+CHKSUMS="sha256::5bea341bc7b22ffa6a78bf7475c25b138150314c96b3d5154d8bccc532be242a"

--- a/extra-kde/plasma-integration/spec
+++ b/extra-kde/plasma-integration/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-integration-$VER.tar.xz"
-CHKSUMS="sha256::37565fbebcd31fc2fd7c03e778d33716569a225a266cbe7843b633beb78526f2"
+CHKSUMS="sha256::4dbaf6a05d69df02e73c88970be3d7a1efb62a3931edf06c9760cd3bb87e1299"

--- a/extra-kde/plasma-nano/spec
+++ b/extra-kde/plasma-nano/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-nano-$VER.tar.xz"
-CHKSUMS="sha256::f4c86648daf14c6d0089d974a12cec5cb0c456b94a3c08c404aff46a8e03481e"
+CHKSUMS="sha256::8e23e0ce53654daf4ab688edd6a7852b5d859bfd86b4e1795a60f570dda409bd"

--- a/extra-kde/plasma-nm/spec
+++ b/extra-kde/plasma-nm/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-nm-$VER.tar.xz"
-CHKSUMS="sha256::71915af09fd44b4c1783f38bd912e215c003d5df7f73e6fa39daf77579d5b63b"
+CHKSUMS="sha256::7b4d1026f2caa709a9ae284cd18342d1c573276f9b4c356ef47779dadb8b57cf"

--- a/extra-kde/plasma-pa/spec
+++ b/extra-kde/plasma-pa/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-pa-$VER.tar.xz"
-CHKSUMS="sha256::2011169926b9119c4574979d6fa350f16a9587ebca64a09603e9d93ccea103ec"
+CHKSUMS="sha256::56fb4809966aa33290c46fed968f2c7186c415663f032c75b3279c57134674f3"

--- a/extra-kde/plasma-phone-components/spec
+++ b/extra-kde/plasma-phone-components/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-phone-components-$VER.tar.xz"
-CHKSUMS="sha256::de759cdcf63a397b71242ec7202200535cb9d065307f07cffb1f721de20e50a6"
+CHKSUMS="sha256::80053324bfb6431946df67e712638f797c2bcd9cb78766629a0372de7f6f727e"

--- a/extra-kde/plasma-sdk/spec
+++ b/extra-kde/plasma-sdk/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-sdk-$VER.tar.xz"
-CHKSUMS="sha256::b2db0ee70d7b482fe5f0806302ffeae9d55ba3613b47b2a5e38a1210d78963ab"
+CHKSUMS="sha256::49d29c1c95832c585ea3c0b26f8fb46f5fa0fac726f9f7e9cbf0ab83415a00ea"

--- a/extra-kde/plasma-thunderbolt/spec
+++ b/extra-kde/plasma-thunderbolt/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-thunderbolt-$VER.tar.xz"
-CHKSUMS="sha256::1295793d2e6d1db42a4b18f1bb417d089141643b2d7d473476a4effb3ac8b840"
+CHKSUMS="sha256::7c37c66815242b5d1e208df3b4dbf4fe0d8542ac9aa352d06c548fc172348429"

--- a/extra-kde/plasma-vault/spec
+++ b/extra-kde/plasma-vault/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-vault-$VER.tar.xz"
-CHKSUMS="sha256::13468ca59d26569bd6590af508ca76ffe4bd52042fc0789588cd130cc384c4cd"
+CHKSUMS="sha256::525226a143e6bb173e8106ed2f2313a529ed380a0a1488b096a60af6d08d881c"

--- a/extra-kde/plasma-workspace-wallpapers/spec
+++ b/extra-kde/plasma-workspace-wallpapers/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-workspace-wallpapers-$VER.tar.xz"
-CHKSUMS="sha256::5a42c1bbdcc158e886a2544e597f60d5010c1815be615f345367484395477d57"
+CHKSUMS="sha256::4740d67e85910ed398c048916963f31c6632698d6a4494bc09cc1b0cd14e2808"

--- a/extra-kde/plasma-workspace/spec
+++ b/extra-kde/plasma-workspace/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-workspace-$VER.tar.xz"
-CHKSUMS="sha256::2bd71e6054577f881b0fcab7af5c7e1d39db1ef03470fb6e662713559da9e5f4"
+CHKSUMS="sha256::12bfe6c3f62e4d1d2f7bc02ccb2e2ed5aee2ffe21c310987e42a2205374c30c9"

--- a/extra-kde/plymouth-kcm/spec
+++ b/extra-kde/plymouth-kcm/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plymouth-kcm-$VER.tar.xz"
-CHKSUMS="sha256::1bccc9ff909d374c18af4371b7c399f0d5767ba112659f38fbdcbc71cbbeac29"
+CHKSUMS="sha256::0cde268064c92b89c5b2a5f8c033983d372406656d446f52b77611effd67ad77"

--- a/extra-kde/polkit-kde-agent-1/spec
+++ b/extra-kde/polkit-kde-agent-1/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/polkit-kde-agent-1-$VER.tar.xz"
-CHKSUMS="sha256::80d261bac52210c609d9bef99deadd22eefc0fb457a9b5a8e687f4af2ada83be"
+CHKSUMS="sha256::f01a7b3443553810b0c9e6f25d2ca51eeac7c5e9fd624505852e77183e294b61"

--- a/extra-kde/powerdevil/spec
+++ b/extra-kde/powerdevil/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/powerdevil-$VER.tar.xz"
-CHKSUMS="sha256::8fa42d77e21dc29eb5e729102717177b78e8eea0962bc7b856ba56dcce808399"
+CHKSUMS="sha256::864128ea9178701bc322f728402cf9277b3c6feaa15fe425aa2adf92464bd28d"

--- a/extra-kde/prison5/spec
+++ b/extra-kde/prison5/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/prison-$VER.tar.xz"
-CHKSUMS="sha256::7e1ee466b0eed9b861f9b746dc5579f1e82d5e165696116c5c657dd35038ade0"
+CHKSUMS="sha256::6c369efc354f8f3a0e08b0de565fd523f1480d563bec0d19382e9ab01f3efb78"

--- a/extra-kde/purpose/spec
+++ b/extra-kde/purpose/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/purpose-$VER.tar.xz"
-CHKSUMS="sha256::7c9ccf7d2813a9253a217d7a2da1f0ba39dd0eec0bb071633fe58dcd2ccb0ffb"
+CHKSUMS="sha256::fd0edb0e7ba8b5336436848fe2452ff98c1b5bf2c49ea7744a8c0038d4e8887d"

--- a/extra-kde/qqc2-desktop-style/spec
+++ b/extra-kde/qqc2-desktop-style/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/qqc2-desktop-style-$VER.tar.xz"
-CHKSUMS="sha256::770895c4363973ddcbac281526de8297a4df37bfe1df08be59e62a8caf9368d3"
+CHKSUMS="sha256::76d2f85f6f99157aec26e6797889f1b99035a337e8aa12029c222f3d48288ef3"

--- a/extra-kde/sddm-kcm/spec
+++ b/extra-kde/sddm-kcm/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/sddm-kcm-$VER.tar.xz"
-CHKSUMS="sha256::632f5bb8546a46c611b50ec9c4058653d7cdcfcd959f19f0b946290807fc050a"
+CHKSUMS="sha256::c61e136c10b98a91e1bd48ca5bbdd2a15b197a38b83d7ad5ccd289200524935e"

--- a/extra-kde/solid/spec
+++ b/extra-kde/solid/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/solid-$VER.tar.xz"
-CHKSUMS="sha256::471bb76ca0971ab945f2270490b1f72300d86b2b36094ac610e5af69df738a77"
+CHKSUMS="sha256::7958d047c8bd7622f91541acbe2d554c222218419ee18f395059a09fb90d264d"

--- a/extra-kde/sonnet/spec
+++ b/extra-kde/sonnet/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/sonnet-$VER.tar.xz"
-CHKSUMS="sha256::626055b262b3a43e6e947cf7f0383565324f42d6b24ab07b98c6cf054271c9e0"
+CHKSUMS="sha256::cb6bacae27cfa3f8b3ce300b18efe16730783f143c4a7fccfa634f528262ef9b"

--- a/extra-kde/syndication/spec
+++ b/extra-kde/syndication/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/syndication-$VER.tar.xz"
-CHKSUMS="sha256::922a938c6a96287075eae1f5fd18d343e9fdbbb5213d1f5f9b0c454986b6008c"
+CHKSUMS="sha256::239ec30ff8f7ad2911ecc6b9b9c32f2b44c6cad634900105936ae56bf96d6292"

--- a/extra-kde/syntax-highlighting/spec
+++ b/extra-kde/syntax-highlighting/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/syntax-highlighting-$VER.tar.xz"
-CHKSUMS="sha256::c5db1b9a268fa81a1cf72e83c1b3147e4cf4e043da45d917df0165f42ca0d07f"
+CHKSUMS="sha256::3cb61a8c478b76f797db53ed9e8a16c6e70bb1c564f05938680db81c3062bab3"

--- a/extra-kde/systemsettings/spec
+++ b/extra-kde/systemsettings/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/systemsettings-$VER.tar.xz"
-CHKSUMS="sha256::0c7e044becc4d492fe5a313911512d7dccc08a4cd7aabfc0bf7cd878240cb6da"
+CHKSUMS="sha256::e87eedfb40a0255348cf2a775ca0ea15bbce37687eedd521f2200670315953b9"

--- a/extra-kde/threadweaver/autobuild/defines
+++ b/extra-kde/threadweaver/autobuild/defines
@@ -6,3 +6,5 @@ PKGDES="A high-level multithreading framework"
 
 CMAKE_AFTER="-DBUILD_QCH=ON \
              -DBUILD_TESTING=OFF"
+
+NOLTO__LOONGSON3=1

--- a/extra-kde/threadweaver/spec
+++ b/extra-kde/threadweaver/spec
@@ -1,3 +1,3 @@
-VER=5.75.0
+VER=5.76.0
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/threadweaver-$VER.tar.xz"
-CHKSUMS="sha256::d082f863fb119e2b98c9e01877b2730eedc0b54392449e3cc9bd54d7803d16ff"
+CHKSUMS="sha256::8bc0cc4507b4cd7398e18cce8519b4a65b0367e7d22c4faae034a57346297039"

--- a/extra-kde/xdg-desktop-portal-kde/spec
+++ b/extra-kde/xdg-desktop-portal-kde/spec
@@ -1,3 +1,3 @@
-VER=5.20.2
+VER=5.20.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/xdg-desktop-portal-kde-$VER.tar.xz"
-CHKSUMS="sha256::e026f49aee431a2fa0d3ee191de46e36c4b70d352a4a447fc26e51cc5c97e46c"
+CHKSUMS="sha256::cb3d856f7caeae7bd02a3e9e43f12ee3d432aa399df9d40db0636199b7ed4df8"


### PR DESCRIPTION
Topic Description
-----------------

KDE update survey on 20201210. Found updates for KDE Frameworks and Plasma.

- KDE Frameworks v5.76.0.
- Plasma v5.20.4.

Package(s) Affected
-------------------

- `groups/kf5` v5.76,0
- `groups/plasma` v5.20.4

Security Update?
----------------

No

Build Order
-----------

`groups/kf5` => `groups/plasma`

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`