### PR TITLE
rime-prelude: fix postinst

### DIFF
--- a/extra-i18n/rime-prelude/autobuild/defines
+++ b/extra-i18n/rime-prelude/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME="rime-prelude"
 PKGDES="Essential files for building up your Rime configuration"
 PKGSEC=localization
+PKGDEP="rime-schema-manager"
 PKGREP="rime-data<=20200814"
 PKGBREAK="rime-data<=20200814"
 

--- a/extra-i18n/rime-prelude/autobuild/postinst
+++ b/extra-i18n/rime-prelude/autobuild/postinst
@@ -1,0 +1,8 @@
+echo "Re-add schema..."
+for i in /usr/share/rime-data/*.schema.yaml; do
+	basename=$(basename $i)
+	rime-schema-manager add ${basename/.schema.yaml/}
+done
+
+echo "Deploying schema..."
+rime_deployer --build /usr/share/rime-data

--- a/extra-i18n/rime-prelude/autobuild/prerm
+++ b/extra-i18n/rime-prelude/autobuild/prerm
@@ -1,0 +1,5 @@
+echo "Removing schema..."
+for i in /usr/share/rime-data/*.schema.yaml; do
+        basename=$(basename $i)
+        rime-schema-manager remove ${basename/.schema.yaml/}
+done

--- a/extra-i18n/rime-prelude/spec
+++ b/extra-i18n/rime-prelude/spec
@@ -1,3 +1,4 @@
 VER=20201204
+REL=1
 SRCS="git::commit=e02e2d85fe926b5dfc0c2a343c69df03302a39aa::https://github.com/rime/rime-prelude"
 CHKSUMS="SKIP"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

rime-prelude: fix postinst

- Update rime-prelude need re-add schema to /usr/share/rime-data/default.yaml, the commit fix this issue

Package(s) Affected
-------------------

rime-prelude

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

 - [x] Architecture-independent `noarch` 

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

 - [x] Architecture-independent `noarch` 

