### PR TITLE
patray: new, 0.1.1

### DIFF
--- a/extra-multimedia/patray/autobuild/defines
+++ b/extra-multimedia/patray/autobuild/defines
@@ -3,5 +3,6 @@ PKGSEC=sound
 PKGDES="Yet another systray controller for PulseAudio"
 PKGDEP="python-3 cock addict loguru pulsectl click pyside2 pyyaml"
 
-ABTYPE="python"
+ABHOST=noarch
+ABTYPE=python
 NOPYTHON2=1

--- a/extra-multimedia/patray/autobuild/defines
+++ b/extra-multimedia/patray/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=patray
 PKGSEC=sound
 PKGDES="Yet another systray controller for PulseAudio"
-PKGDEP="python-3 cock addict loguru pulsectl click pyside2 pyyaml"
+PKGDEP="python-3 cock loguru pulsectl pyside2"
 
 ABHOST=noarch
 ABTYPE=python

--- a/extra-multimedia/patray/autobuild/defines
+++ b/extra-multimedia/patray/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=patray
+PKGSEC=sound
+PKGDES="Yet another systray controller for PulseAudio"
+PKGDEP="python-3 cock addict shiboken2 loguru pulsectl click pyside2 pyyaml"
+
+ABTYPE="python"
+NOPYTHON2=1

--- a/extra-multimedia/patray/autobuild/defines
+++ b/extra-multimedia/patray/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=patray
 PKGSEC=sound
 PKGDES="Yet another systray controller for PulseAudio"
-PKGDEP="python-3 cock addict shiboken2 loguru pulsectl click pyside2 pyyaml"
+PKGDEP="python-3 cock addict loguru pulsectl click pyside2 pyyaml"
 
 ABTYPE="python"
 NOPYTHON2=1

--- a/extra-multimedia/patray/spec
+++ b/extra-multimedia/patray/spec
@@ -1,0 +1,3 @@
+VER=0.1.1
+SRCS="https://pypi.org/packages/source/p/patray/patray-${VER}.tar.gz"
+CHKSUMS="sha256::cfc0152aee6709886fca0f98020085f42c5104b4dc2e5b5aa8a7087285bd4a6d"

--- a/extra-python/addict/autobuild/defines
+++ b/extra-python/addict/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=addict
 PKGSEC=python
-PKGDES="A better Python dict implementation allowed items can be set both attribute and item syntax"
+PKGDES="A Python module that exposes a dictionary subclass that allows items to be set like attributes"
 PKGDEP="python-2 python-3"
 
 ABHOST=noarch

--- a/extra-python/addict/autobuild/defines
+++ b/extra-python/addict/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=addict
 PKGSEC=python
-PKGDES="A better Python dict implementation"
+PKGDES="A better Python dict implementation allowed items can be set both attribute and item syntax"
 PKGDEP="python-2 python-3"
 
 ABHOST=noarch

--- a/extra-python/addict/autobuild/defines
+++ b/extra-python/addict/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=addict
+PKGSEC=python
+PKGDES="A better Python dict implementation"
+PKGDEP="python-2 python-3"
+
+ABHOST=noarch
+ABTYPE=python

--- a/extra-python/addict/spec
+++ b/extra-python/addict/spec
@@ -1,0 +1,3 @@
+VER=2.4.0
+SRCS="https://pypi.org/packages/source/a/addict/addict-${VER}.tar.gz"
+CHKSUMS="sha256::b3b2210e0e067a281f5646c8c5db92e99b7231ea8b0eb5f74dbdf9e259d4e494"

--- a/extra-python/click/spec
+++ b/extra-python/click/spec
@@ -1,4 +1,3 @@
-VER=7.0
-REL=2
-SRCTBL="https://github.com/pallets/click/archive/$VER.tar.gz"
-CHKSUM="sha256::7cd752d4b5621bddf6428ca00ef5c2cd9b4b77bc41076a69eff51cbbfd4f8646"
+VER=7.1.2
+SRCS="https://github.com/pallets/click/archive/$VER.tar.gz"
+CHKSUMS="sha256::da626c7e5fa918a8c9bf9b5c0c0255b55469ca6b0c3cb2318ea0dc7eb05a56c3"

--- a/extra-python/cock/autobuild/defines
+++ b/extra-python/cock/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=cock
+PKGSEC=python
+PKGDES="A configuration builder library for Python"
+PKGDEP="python-3 addict pyyaml click"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/cock/spec
+++ b/extra-python/cock/spec
@@ -1,0 +1,3 @@
+VER=0.6.0
+SRCS="https://pypi.org/packages/source/c/cock/cock-${VER}.tar.gz"
+CHKSUMS="sha256::42fa3842ac17d9f1306bfd3e5e997608437b2e9cc8c811aafb803bcb06f12e8a"

--- a/extra-python/loguru/autobuild/defines
+++ b/extra-python/loguru/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=loguru
+PKGSEC=python
+PKGDES="A simple logging library for Python"
+PKGDEP="python-3"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/loguru/spec
+++ b/extra-python/loguru/spec
@@ -1,0 +1,3 @@
+VER=0.5.3
+SRCS="https://pypi.org/packages/source/l/loguru/loguru-${VER}.tar.gz"
+CHKSUMS="sha256::b28e72ac7a98be3d28ad28570299a393dfcd32e5e3f6a353dec94675767b6319"

--- a/extra-python/pulsectl/autobuild/defines
+++ b/extra-python/pulsectl/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=pulsectl
+PKGSEC=python
+PKGDES="Python binding for PulseAudio"
+PKGDEP="python-2 python-3 pulseaudio"
+
+ABHOST=noarch
+ABTYPE=python

--- a/extra-python/pulsectl/spec
+++ b/extra-python/pulsectl/spec
@@ -1,0 +1,3 @@
+VER=20.5.1
+SRCS="https://pypi.org/packages/source/p/pulsectl/pulsectl-${VER}.tar.gz"
+CHKSUMS="sha256::39b0a0e7974a7d6468d826a838822f78b00ac9c3803f0d7bfa9b1cad08ee22db"


### PR DESCRIPTION

Topic Description
-----------------
Introduce the package `patray`, which is a simple systray program for controlling PulseAudio. 

Package(s) Affected
-------------------
* `patray`, new
* `addict`, new
* `cock`, new
* `pulsectl`, new
* `loguru`, new
* `click`, update to 7.1.2

Security Update?
----------------
No

Build Order
-----------
* `addict`, `click` -> `cock`
* `pulsectl`, `loguru`
* `patray`

Architectural Progress
----------------------
 - [x] Architecture-independent `noarch` 

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [x] Architecture-independent `noarch` 

