### PR TITLE
grub-loongson3 (grub): new, 2.02+0.40.lns7.13

### DIFF
--- a/extra-admin/grub-loongson3/autobuild/build
+++ b/extra-admin/grub-loongson3/autobuild/build
@@ -1,0 +1,57 @@
+mkdir -pv "$PKGDIR"
+
+(
+    cd "$PKGDIR"
+    for i in "$SRCDIR"/*.rpm; do
+        abinfo "Extracting $i ..."
+        rpmextract $i
+    done
+)
+
+abinfo "Tweaking /etc/grub.d/10_linux to append rw by default ..."
+sed -e 's| ro | rw |g' \
+    -i "$PKGDIR"/etc/grub.d/10_linux
+
+abinfo "Moving /usr/lib64 => /usr/lib ..."
+mv -v "$PKGDIR"/usr/lib{64,}
+
+abinfo "Moving /usr/sbin => /usr/bin ..."
+mv -v "$PKGDIR"/usr/sbin/* \
+    "$PKGDIR"/usr/bin
+rm -rv "$PKGDIR"/usr/sbin
+
+abinfo "Renaming executables to grub-* ..."
+cd "$PKGDIR"/usr/bin
+for i in *; do
+    mv -v $i ${i/grub2-/grub-}
+done
+
+abinfo "Removing pre-generated /boot files ..."
+rm -rv "$PKGDIR"/boot
+
+abinfo "Renaming documentation directories ..."
+mkdir -pv "$PKGDIR"/usr/share/doc/grub
+mv -v "$PKGDIR"/usr/share/doc/*/* \
+    "$PKGDIR"/usr/share/doc/grub/ || true
+rm -rv "$PKGDIR"/usr/share/doc/grub2*
+
+abinfo "Renaming man pages ..."
+for i in "$PKGDIR"/usr/share/man/man1/* \
+         "$PKGDIR"/usr/share/man/man8/*; do
+    mv -v $i ${i/grub2/grub}
+done
+
+abinfo "Renaming and decompressing Texinfo pages ..."
+for i in "$PKGDIR"/usr/share/info/*; do
+    mv -v $i ${i/grub2/grub}
+done
+gzip -dvvv "$PKGDIR"/usr/share/info/*
+
+abinfo "Dropping unneeded prelink configuration ..."
+rm -rv "$PKGDIR"/etc/prelink.conf.d
+
+abinfo "Dropping /etc/grub2-efi.cfg ..."
+rm -v "$PKGDIR"/etc/grub2-efi.cfg
+
+abinfo "Dropping /etc/sysconfig ..."
+rm -rv "$PKGDIR"/etc/sysconfig

--- a/extra-admin/grub-loongson3/autobuild/conffiles
+++ b/extra-admin/grub-loongson3/autobuild/conffiles
@@ -1,0 +1,2 @@
+/etc/default/grub
+/etc/grub.d/40_custom

--- a/extra-admin/grub-loongson3/autobuild/defines
+++ b/extra-admin/grub-loongson3/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=grub
+PKGSEC=admin
+PKGDES="GNU GRand Unified Bootloader (Loongson 3)"
+PKGDEP="bash dosfstools freetype fuse gettext libisoburn lvm2 mtools os-prober xz"
+BUILDDEP="rpmextract"
+
+FAIL_ARCH="!(loongson3)"
+ABSTRIP=0

--- a/extra-admin/grub-loongson3/autobuild/overrides/etc/default/grub
+++ b/extra-admin/grub-loongson3/autobuild/overrides/etc/default/grub
@@ -1,0 +1,47 @@
+GRUB_DEFAULT=0
+GRUB_TIMEOUT=5
+GRUB_DISTRIBUTOR="AOSC OS"
+GRUB_CMDLINE_LINUX_DEFAULT="quiet rw rd.auto rd.auto=1 splash"
+GRUB_CMDLINE_LINUX=""
+
+# Preload both GPT and MBR modules so that they are not missed
+GRUB_PRELOAD_MODULES="part_gpt part_msdos"
+
+# Uncomment to enable Hidden Menu, and optionally hide the timeout count
+#GRUB_HIDDEN_TIMEOUT=5
+#GRUB_HIDDEN_TIMEOUT_QUIET=true
+
+# Uncomment to use basic console
+GRUB_TERMINAL_INPUT=console
+
+# Uncomment to disable graphical terminal
+#GRUB_TERMINAL_OUTPUT=console
+
+# The resolution used on graphical terminal
+# note that you can use only modes which your graphic card supports via VBE
+# you can see them in real GRUB with the command `vbeinfo'
+GRUB_GFXMODE=auto
+
+# Uncomment to allow the kernel use the same resolution used by grub
+GRUB_GFXPAYLOAD_LINUX=keep
+
+# Uncomment if you want GRUB to pass to the Linux kernel the old parameter 
+# format "root=/dev/xxx" instead of "root=/dev/disk/by-uuid/xxx" 
+#GRUB_DISABLE_LINUX_UUID=true
+
+# Uncomment to disable generation of recovery mode menu entries
+GRUB_DISABLE_RECOVERY=true
+
+# Uncomment and set to the desired menu colors.  Used by normal and wallpaper 
+# modes only.  Entries specified as foreground/background.
+GRUB_COLOR_NORMAL="white/black"
+GRUB_COLOR_HIGHLIGHT="cyan/black"
+
+# Uncomment one of them for the gfx desired, a image background or a gfxtheme
+#GRUB_BACKGROUND="/boot/grub/wallpaper.png"
+#GRUB_THEME="/path/to/gfxtheme"
+
+# Uncomment to get a beep at GRUB start
+#GRUB_INIT_TUNE="480 440 1"
+
+GRUB_SAVEDEFAULT="true"

--- a/extra-admin/grub-loongson3/spec
+++ b/extra-admin/grub-loongson3/spec
@@ -1,0 +1,7 @@
+VER=2.02+0.40.lns7.13
+SRCS="file::rename=grub2-efi-${VER/+/-}.loongnix.mips64el.rpm::http://ftp.loongnix.org/os/loongnix-server/1.7/os/mips64el/Packages/grub2-efi-${VER/+/-}.loongnix.mips64el.rpm \
+      file::rename=grub2-efi-modules-${VER/+/-}.loongnix.mips64el.rpm::http://ftp.loongnix.org/os/loongnix-server/1.7/os/mips64el/Packages/grub2-efi-modules-${VER/+/-}.loongnix.mips64el.rpm \
+      file::rename=grub2-tools-${VER/+/-}.loongnix.mips64el.rpm::http://ftp.loongnix.org/os/loongnix-server/1.7/os/mips64el/Packages/grub2-tools-${VER/+/-}.loongnix.mips64el.rpm"
+CHKSUMS="sha256::bc8b5f55bcf96fdae44e444f86f81dc52685207db9f468df8eedffed08b7d57a \
+         sha256::5c224dbf0db34ee13d8ba1abf5dff4c809005448fd759540ddb486d8c1129ffb \
+         sha256::14ad22f57c1d6272d53ce61b5735501b5c9a3aaa759d6627ed4a65ca6ecab44f"


### PR DESCRIPTION
Topic Description
-----------------

Introducing GRUB for Loongson 3 with Kunlun firmware, binary package from Loongnix.

Package(s) Affected
-------------------

- `grub` v2.02+0.40.lns7.13 (`loongson3` only)

Security Update?
----------------

No

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
