### PR TITLE
fuse-3: upgrade to 3.10.1, remove /dev/fuse from package

### DIFF
--- a/extra-libs/fuse-3/02-fuse-3/patches/do-not-mknod-dev-fuse-on-install.patch
+++ b/extra-libs/fuse-3/02-fuse-3/patches/do-not-mknod-dev-fuse-on-install.patch
@@ -1,0 +1,16 @@
+diff -Naur fuse-3.10.1.orig/util/install_helper.sh fuse-3.10.1.mod/util/install_helper.sh
+--- fuse-3.10.1.orig/util/install_helper.sh	2020-12-13 15:42:07.149454208 -0600
++++ fuse-3.10.1.mod/util/install_helper.sh	2020-12-13 15:41:07.686333784 -0600
+@@ -30,10 +30,12 @@
+     chown root:root "${DESTDIR}${bindir}/fusermount3"
+     chmod u+s "${DESTDIR}${bindir}/fusermount3"
+ 
++    if false; then
+     if test ! -e "${DESTDIR}/dev/fuse"; then
+         mkdir -p "${DESTDIR}/dev"
+         mknod "${DESTDIR}/dev/fuse" -m 0666 c 10 229
+     fi
++    fi
+ fi
+ 
+ install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \

--- a/extra-libs/fuse-3/spec
+++ b/extra-libs/fuse-3/spec
@@ -1,4 +1,3 @@
-VER=3.9.0
-REL=1
+VER=3.10.1
 SRCTBL="https://github.com/libfuse/libfuse/releases/download/fuse-$VER/fuse-$VER.tar.xz"
-CHKSUM="sha256::fcb7079a1bb4e510377b427d1c5c37c349281d498e249ae0c2379b4cf50059c2"
+CHKSUM="sha256::d82d74d4c03e099f806e4bb31483955637c69226576bf0ca9bd142f1d50ae451"


### PR DESCRIPTION
Topic Description
-----------------

At the time of writing, current version 3.9.0-1 of `fuse-3` on arm64 contains `/dev/fuse` within the package, created by `util/install_helper.sh`. Since `/dev/fuse` on AOSC OS is actually handled by udev, dpkg will refuse to remove the device node and the package will fail to install. Some build environment may have more restrictions than others. In the case where `mknod` in the container is forbidden, `mknod` during build will fail without getting caught by autobuild, thus resulting in a package without `/dev/fuse`.

This PR updates `fuse-3` and `fuse-common` to 3.10.1 and uniformly patches away creation of `/dev/fuse` at build time.

Package(s) Affected
-------------------

`fuse-3` and `fuse-common` in the same build group `fuse-3`: 3.10.1

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
