### PR TITLE
kitty: update to 0.19.2

### DIFF
--- a/extra-utils/kitty/autobuild/defines
+++ b/extra-utils/kitty/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=kitty
 PKGSEC=utils
-PKGDEP="fontconfig glew glfw python-3 x11-app"
+PKGDEP="fontconfig glew glfw python-3 x11-app lcms2"
 BUILDDEP="sphinx"
 PKGDES="A modern, hackable, featureful, OpenGL based terminal emulator"

--- a/extra-utils/kitty/spec
+++ b/extra-utils/kitty/spec
@@ -1,3 +1,3 @@
-VER=0.16.0
+VER=0.19.2
 SRCTBL="https://github.com/kovidgoyal/kitty/archive/v$VER.tar.gz"
-CHKSUM="sha256::01d4d7dcb8606577752f9d9009dd54dfd4607780a55c6f1caab9fa30d6651b41"
+CHKSUM="sha256::7bad5787e05ebc9989b15c8759c09c5754c5c10dbd072fa777bca3e9ec2800d5"


### PR DESCRIPTION
Topic Description
-----------------
Update the package `kitty` to the version 0.19.2

Package(s) Affected
-------------------
kitty

Security Update?
----------------
No

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
