### PR TITLE
kodi: fix non-amd64 dependency

### DIFF
--- a/extra-multimedia/kodi/autobuild/defines
+++ b/extra-multimedia/kodi/autobuild/defines
@@ -8,6 +8,9 @@ PKGDEP="afpfs-ng bluez dcadec fribidi glew hicolor-icon-theme \
         taglib tinyxml udisks unrar unzip upower yajl crossguid rtmpdump \
         pybluez cwiid flatbuffers fmt fstrcmp rapidjson mariadb libxslt \
         sndio"
+PKGDEP__ARM64="${PKGDEP} fmt"
+PKGDEP__PPC64="${PKGDEP} fmt"
+PKGDEP__LOONGSON3="${PKGDEP} fmt"
 BUILDDEP="boost cmake curl doxygen gperf jasper openjdk swig zip"
 BUILDDEP__AMD64="${BUILDDEP} yasm"
 PKGDES="Kodi Entertainment Center"

--- a/extra-multimedia/kodi/spec
+++ b/extra-multimedia/kodi/spec
@@ -1,4 +1,5 @@
 VER=18.9
+REL=1
 CODE=Leia
 SRCS="tbl::rename=kodi::https://github.com/xbmc/xbmc/archive/$VER-$CODE.tar.gz \
       git::commit=4a733e3f10ee41f0d639376b11706d916974ae94;rename=kodi-res::https://github.com/xbmc/repo-resources"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

kodi: fix non-amd64 dependency

Kodi non-amd64 need `fmt`

Package(s) Affected
-------------------

kodi 18.9-1

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
