### PR TITLE
kodi: rebuild for fmt on {ppc64el,arm64}

### DIFF
--- a/extra-libs/fmt/autobuild/defines
+++ b/extra-libs/fmt/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=libs
 PKGDES="A modern formatting library for C++"
 BUILDDEP="cmake ninja"
 
+PKGBREAK="kodi<=18.9"
 NOLTO=1

--- a/extra-libs/fmt/spec
+++ b/extra-libs/fmt/spec
@@ -1,4 +1,4 @@
 VER=7.0.3
 SRCTBL="https://github.com/fmtlib/fmt/archive/$VER.tar.gz"
 CHKSUM="sha256::b4b51bc16288e2281cddc59c28f0b4f84fed58d016fb038273a09f05f8473297"
-REL=1
+REL=2

--- a/extra-multimedia/kodi/spec
+++ b/extra-multimedia/kodi/spec
@@ -1,4 +1,5 @@
 VER=18.9
+REL=1
 CODE=Leia
 SRCS="tbl::rename=kodi::https://github.com/xbmc/xbmc/archive/$VER-$CODE.tar.gz \
       git::commit=4a733e3f10ee41f0d639376b11706d916974ae94;rename=kodi-res::https://github.com/xbmc/repo-resources"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

kodi: rebuild for fmt on {ppc64el,arm64}.

This PR to fix:

```
saki@MagRaspi [ ~ ] $ kodi
/usr/lib/kodi/kodi-x11: error while loading shared libraries: libfmt.so.6: cannot open shared object file: No such file or directory
```

Package(s) Affected
-------------------

kodi: 18.9-1
fmt: 7.0.3-2

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
