### PR TITLE
Upgrade pip to 20.3.3 (and update its dependencies)

### DIFF
--- a/extra-python/certifi/spec
+++ b/extra-python/certifi/spec
@@ -1,4 +1,3 @@
-VER=2018.11.29
-REL=2
+VER=2020.12.5
 SRCTBL="https://pypi.io/packages/source/c/certifi/certifi-$VER.tar.gz"
-CHKSUM="sha256::47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7"
+CHKSUM="sha256::1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"

--- a/extra-python/packaging/spec
+++ b/extra-python/packaging/spec
@@ -1,5 +1,4 @@
-VER=19.0
-REL=2
+VER=20.8
 SRCTBL="https://github.com/pypa/packaging/archive/$VER.tar.gz"
-CHKSUM="sha256::03432ca3d87a962ab267f17fd59a16bbd43bb0eff9291c10b6801a002422b17a"
+CHKSUM="sha256::9aa4307378c6a1386890844a78344d91fbc07d9ecc14e79d66d6ab8360a2bfc1"
 SUBDIR="packaging-$VER"

--- a/extra-python/pip/spec
+++ b/extra-python/pip/spec
@@ -1,3 +1,3 @@
-VER=20.2.3
+VER=20.3.3
 SRCTBL="https://github.com/pypa/pip/archive/${VER}.tar.gz"
-CHKSUM="sha256::57125defc81049b227fd81679664221d2d9b2bc5d3b855660a93bf87ecdc3509"
+CHKSUM="sha256::016f8d509871b72fb05da911db513c11059d8a99f4591dda3050a3cf83a29a79"

--- a/extra-python/pyparsing/spec
+++ b/extra-python/pyparsing/spec
@@ -1,4 +1,3 @@
-VER=2.2.0
-REL=2
-SRCTBL="https://downloads.sourceforge.net/pyparsing/pyparsing-$VER.tar.gz"
-CHKSUM="sha256::0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04"
+VER=2.4.7
+SRCTBL="https://github.com/pyparsing/pyparsing/releases/download/pyparsing_${VER}/pyparsing-${VER}.tar.gz"
+CHKSUM="sha256::c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"

--- a/extra-python/setuptools/spec
+++ b/extra-python/setuptools/spec
@@ -1,4 +1,3 @@
-VER=40.8.0
-REL=2
+VER=44.1.0
 SRCTBL="https://github.com/pypa/setuptools/archive/v$VER.tar.gz"
-CHKSUM="sha256::c6039693f2065617c475ca08636f267ea4493c14900c8daace8683d445ebf434"
+CHKSUM="sha256::77839f3c8fec402a974afa25e2d910948c59cd6dd7dbf72e0f35e65012b01645"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates pip tp 20.3.3, and updates a bunch of its dependencies as well. See _Packages Affected_ section for details.

Package(s) Affected
-------------------

* `pyparsing`: 2.2.0-2 -> 2.4.7
* `packaging`: 19.0-2 -> 20.8
* `certifi`: 2018.11.29-2 -> 2020.12.5
* `setuptools`: 40.8.0-2 -> 44.1.0. Note that this is the last known-good version on python 2.7. Whether we should hold at this version or move on and get rid of python 2 needs further discussion (thus belongs to another issue or RFC).
* `pip`: 20.2.3 -> 20.3.3

Build Order
-----------

* (Group 1 or 2) -> setuptools -> pip
* Group 1: pyparsing -> packaging
* Group 2: certifi

Architectural Progress
----------------------

* [x] Architecture-independent `noarch`

Post-Merge Architectural Progress
---------------------------------

* [x] Architecture-independent `noarch`