### PR TITLE
Nvidia drivers 455.45.01

### DIFF
--- a/extra-optenv32/nvidia+32/spec
+++ b/extra-optenv32/nvidia+32/spec
@@ -1,6 +1,5 @@
-VER=455.38
-REL=1
+VER=455.45.01
 SRCS="file::rename=NVIDIA-Linux-x86_64-$VER.run::http://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run \
       tbl::https://github.com/NVIDIA/nvidia-settings/archive/$VER.tar.gz"
-CHKSUMS="sha256::d87d1e58bf4df889a219f659eb07241813aff852b8cf6c68fa09972ad914dc74 sha256::55af71bb03b103f5f92909b1a6c225224d373597de29e924160bf4d985547c1d"
+CHKSUMS="sha256::eadc8c7e082f65540fa7f6a249d8309fb546fe62066f495472701dc8c103a153 sha256::da83a598d01e8355e89617deebcce3007964c9f3593e6d27097de0df0c0fc388"
 SUBDIR=.

--- a/extra-x11/nvidia/autobuild/postinst
+++ b/extra-x11/nvidia/autobuild/postinst
@@ -1,6 +1,6 @@
 unset ARCH
 
-DRIVER_VER=455.38
+DRIVER_VER=455.45.01
 
 for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
     if [ -f "/usr/lib/modules/${i}/modules.dep" -a -f "/usr/lib/modules/${i}/modules.order" -a -f "/usr/lib/modules/${i}/modules.builtin" ]; then

--- a/extra-x11/nvidia/autobuild/prerm
+++ b/extra-x11/nvidia/autobuild/prerm
@@ -1,4 +1,4 @@
 unset ARCH
 
-DRIVER_VER=455.38
+DRIVER_VER=455.45.01
 dkms remove nvidia/${DRIVER_VER} --all || true > /dev/null

--- a/extra-x11/nvidia/spec
+++ b/extra-x11/nvidia/spec
@@ -1,7 +1,5 @@
-VER=455.38
-REL=1
+VER=455.45.01
 SRCS="file::rename=NVIDIA-Linux-x86_64-$VER-no-compat32.run::http://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER-no-compat32.run \
       tbl::https://github.com/NVIDIA/nvidia-settings/archive/$VER.tar.gz"
-CHKSUMS="sha256::fb0eb9e2a9119398a8ae4b54bb898fcf3c39bc74afc7822515e87f314cdc43f3 \
-         sha256::55af71bb03b103f5f92909b1a6c225224d373597de29e924160bf4d985547c1d"
+CHKSUMS="sha256::9b707d6244735cf0f745a74c47ed0feeec47bc56baec8122306dee6169ce10fd sha256::da83a598d01e8355e89617deebcce3007964c9f3593e6d27097de0df0c0fc388"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This PR updates Nvidia driver dkms modules to 455.45.01. This also prepares nvidia cards for use with kernel 5.10+. As 5.10 is still WIP, this can be merged without affecting usability on older kernels.

Package(s) Affected
-------------------

`nvidia` and `nvidia+32`: 455.45.01

Architectural Progress
----------------------

- [x] AMD64 `amd64`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`
