### PR TITLE
systemd-swap: fix dependency

### DIFF
--- a/extra-admin/systemd-swap/autobuild/defines
+++ b/extra-admin/systemd-swap/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=systemd-swap
 PKGDES="Script for creating hybrid swap space from zram swaps, swap files and swap partitions"
-PKGDEP="systemd bash util-linux"
+PKGDEP="systemd util-linux python-systemd sysv-ipc"
 PKGSEC=admin
 
 ABHOST=noarch

--- a/extra-admin/systemd-swap/spec
+++ b/extra-admin/systemd-swap/spec
@@ -1,4 +1,4 @@
 VER=4.4.0
-GITSRC="https://github.com/Nefelim4ag/systemd-swap.git"
-GITCO="$VER"
+REL=1
+SRCS="git::commit=tags/$VER::https://github.com/Nefelim4ag/systemd-swap.git"
 CHKSUMS="SKIP"

--- a/extra-python/python-systemd/autobuild/defines
+++ b/extra-python/python-systemd/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME="python-systemd"
+PKGDES="Python wrappers for systemd functionalities"
+PKGDEP="python-3 python-2"
+BUILDDEP="systemd python-3 python-2"
+PKGSEC="python"

--- a/extra-python/python-systemd/spec
+++ b/extra-python/python-systemd/spec
@@ -1,0 +1,3 @@
+VER=234
+SRCS="tbl::https://github.com/systemd/python-systemd/archive/v$VER.tar.gz"
+CHKSUMS="sha256::1037e6a92762be500a40e97bade0e2f2306e00a31a39361c5dbe99ab50eb3b93"

--- a/extra-python/sysv-ipc/autobuild/defines
+++ b/extra-python/sysv-ipc/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME="sysv-ipc"
+PKGDES="System V IPC for Python - Semaphores, Shared Memory and Message Queues"
+PKGDEP="python-3 python-2"
+BUILDDEP="setuptools"
+PKGSEC="python"

--- a/extra-python/sysv-ipc/spec
+++ b/extra-python/sysv-ipc/spec
@@ -1,0 +1,3 @@
+VER="1.0.1"
+SRCS="tbl::http://semanchuk.com/philip/sysv_ipc/sysv_ipc-$VER.tar.gz"
+CHKSUMS="sha256::8eff10dd17789ddf21b422ce46ae0f6420088902a88e4296cb805cf2fde8b4dc"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

systemd-swap: fix dependency

This PR to fix:

```
Dec 20 03:55:49 Magputer systemd-swap[1409706]:   File "/usr/bin/systemd-swap", line 23, in <module>
Dec 20 03:55:49 Magputer systemd-swap[1409706]:     import systemd.daemon
Dec 20 03:55:49 Magputer systemd-swap[1409706]: ModuleNotFoundError: No module named 'systemd'
```

Package(s) Affected
-------------------

systemd-swap: 4.4.0-1
python-systemd: 234
sysv-ipc: 1.0.1

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
