### PR TITLE
fcitx5: update to 5.0.3

### DIFF
--- a/extra-i18n/fcitx5-anthy/spec
+++ b/extra-i18n/fcitx5-anthy/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.1
 SRCS="tbl::https://github.com/fcitx/fcitx5-anthy/archive/$VER.tar.gz"
-CHKSUMS="sha256::0ddbd4460d50130192f7ec3ea8faf0041eb8ace0f45e7153b5a03b5aff84ca27"
+CHKSUMS="sha256::73edfa4b69e21cf368ac70bc6c08aa75c9bb8cb482f1e998928fc581067efc22"

--- a/extra-i18n/fcitx5-chewing/spec
+++ b/extra-i18n/fcitx5-chewing/spec
@@ -1,3 +1,3 @@
-VER=5.0.1
+VER=5.0.2
 SRCS="tbl::https://github.com/fcitx/fcitx5-chewing/archive/$VER.tar.gz"
-CHKSUMS="sha256::59a5a980eca7a43f1d2d636e617832f96b55913eca46beb95cce1b1583287b1e"
+CHKSUMS="sha256::acf4a18ccbc815dfbb28bc92fc1d4552133c15c355ca41052d01b1b1e6d5301b"

--- a/extra-i18n/fcitx5-chinese-addons/spec
+++ b/extra-i18n/fcitx5-chinese-addons/spec
@@ -1,3 +1,3 @@
-VER=5.0.1
+VER=5.0.2
 SRCS="tbl::https://github.com/fcitx/fcitx5-chinese-addons/archive/$VER.tar.gz"
-CHKSUMS="sha256::47393c1410f9b5ef1a68512f01af017fb9e09ae89f92d601035b8f193d443595"
+CHKSUMS="sha256::4b3731fc790d071273fbd91beb76d23166992add060cfd89ecaa55f147036dc6"

--- a/extra-i18n/fcitx5-configtool/spec
+++ b/extra-i18n/fcitx5-configtool/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.1
 SRCS="tbl::https://github.com/fcitx/fcitx5-configtool/archive/$VER.tar.gz"
-CHKSUMS="sha256::6298fd17149b85e2fbe0376c4a396d62e356322a172079ff0b5493716bb71d81"
+CHKSUMS="sha256::523541f8d44e8820d52953cf87b199bcdbb51dc1d9dabdfed6fc22ebacff2db6"

--- a/extra-i18n/fcitx5-gtk/spec
+++ b/extra-i18n/fcitx5-gtk/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.1
 SRCS="tbl::https://github.com/fcitx/fcitx5-gtk/archive/$VER.tar.gz"
-CHKSUMS="sha256::4cec66319d1154f8aeef6712d8b1069deabedd2d4588238e5d201571f690282a"
+CHKSUMS="sha256::464645a9445e0d301b2274f4b86bcdec3a2d0ecc3ff993f59985927a39b17bb9"

--- a/extra-i18n/fcitx5-hangul/spec
+++ b/extra-i18n/fcitx5-hangul/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.1
 SRCS="tbl::https://github.com/fcitx/fcitx5-hangul/archive/$VER.tar.gz"
-CHKSUMS="sha256::bb6b99310c810b9baadd8f86e0b1cb78045a050b338424c098af6a2db743cd59"
+CHKSUMS="sha256::8e0b90539a14a5ce36189ae021faf71d71345f89f7e1e2e9acb9c3e4f45964cc"

--- a/extra-i18n/fcitx5-libthai/spec
+++ b/extra-i18n/fcitx5-libthai/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.1
 SRCS="tbl::https://github.com/fcitx/fcitx5-libthai/archive/$VER.tar.gz"
-CHKSUMS="sha256::8b5df45399a68e934ab626ae2610f157a852b17bc0b67da84bdee048abcd30cb"
+CHKSUMS="sha256::0eebcebc1724ee7787149f766122a9524ab827bd1c1c46089b47cd6331123cc2"

--- a/extra-i18n/fcitx5-lua/spec
+++ b/extra-i18n/fcitx5-lua/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.1
 SRCS="tbl::https://github.com/fcitx/fcitx5-lua/archive/$VER.tar.gz"
-CHKSUMS="sha256::577d91f51389b4ac82c0f584e866862dfecc4c6730820734fb25ea769ebbde8c"
+CHKSUMS="sha256::04ee90aa2c06224a31b8088168c98fab675515ab925930cb6f8ece3f78d3269c"

--- a/extra-i18n/fcitx5-m17n/spec
+++ b/extra-i18n/fcitx5-m17n/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.1
 SRCS="tbl::https://github.com/fcitx/fcitx5-m17n/archive/$VER.tar.gz"
-CHKSUMS="sha256::ea57258c1eb2c005eb42dcdc6165d5b9e5900204a6ec805034e6b1208f85ee87"
+CHKSUMS="sha256::0f1d05e81c09802332923cf4917ae5469cf03d7b824a584019f491ee115b1445"

--- a/extra-i18n/fcitx5-qt/spec
+++ b/extra-i18n/fcitx5-qt/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.1
 SRCS="https://github.com/fcitx/fcitx5-qt/archive/$VER.tar.gz"
-CHKSUMS="sha256::1893f4ed3df56b8f52478cf11e418876f3ca075f5f43df554be2fb585104a11f"
+CHKSUMS="sha256::15f3ea902dba2d9a1f368e3ad2efd6e7fde120e49c647452ad136fec8fd92046"

--- a/extra-i18n/fcitx5-rime/spec
+++ b/extra-i18n/fcitx5-rime/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.2
 SRCS="tbl::https://github.com/fcitx/fcitx5-rime/archive/$VER.tar.gz"
-CHKSUMS="sha256::f10c1fdc64dfc1a7f9153486062e0fa7e8c52706a0f74725500a3bcd0bbf7f27"
+CHKSUMS="sha256::d3c2663c483a04fc5fbb0490a0de53220903314faa642d0c921815e8a1c28094"

--- a/extra-i18n/fcitx5-sayura/spec
+++ b/extra-i18n/fcitx5-sayura/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.1
 SRCS="tbl::https://github.com/fcitx/fcitx5-sayura/archive/$VER.tar.gz"
-CHKSUMS="sha256::00088a0ebefcd13d46c16204300960ea3893abe1d43cfc41765f4eab374f8da7"
+CHKSUMS="sha256::200fb588a76956a3e488a778768fc6f98bbf228ee70da47a02cb2cf678b02a6b"

--- a/extra-i18n/fcitx5-skk/spec
+++ b/extra-i18n/fcitx5-skk/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.2
 SRCS="tbl::https://github.com/fcitx/fcitx5-skk/archive/$VER.tar.gz"
-CHKSUMS="sha256::82b63c09e2260978818178b530e8ef6b84e4e90f42a4984e611f09c871d40631"
+CHKSUMS="sha256::c3259ddafea2ba8412e3c85683514c98428dcd3289b9f3dbe67b01596550a9d9"

--- a/extra-i18n/fcitx5-unikey/spec
+++ b/extra-i18n/fcitx5-unikey/spec
@@ -1,3 +1,3 @@
-VER=5.0.0
+VER=5.0.2
 SRCS="tbl::https://github.com/fcitx/fcitx5-unikey/archive/$VER.tar.gz"
-CHKSUMS="sha256::c15bfc9651d38248dd1862752e1eb6685e435f0aecb06123e01e333a24eaac4e"
+CHKSUMS="sha256::a6159c57a9301b3abf3a89275d8935189c6d47c2ae458fa35c76dffc64da7268"

--- a/extra-i18n/fcitx5/spec
+++ b/extra-i18n/fcitx5/spec
@@ -1,3 +1,3 @@
-VER=5.0.1
+VER=5.0.3
 SRCS="tbl::https://github.com/fcitx/fcitx5/archive/$VER.tar.gz"
-CHKSUMS="sha256::fb3e96bc13f8976c7e794c7a486ce9564da63059670ba0d6da4f4f976951cf64"
+CHKSUMS="sha256::025eed83775c70f099bb1cbceb81fd3cdd490df32db122329340046f33abda9a"

--- a/extra-i18n/libime/spec
+++ b/extra-i18n/libime/spec
@@ -1,3 +1,3 @@
-VER=1.0.1
+VER=1.0.2
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/libime/"
 CHKSUMS="SKIP"

--- a/extra-libs/xcb-imdkit/spec
+++ b/extra-libs/xcb-imdkit/spec
@@ -1,3 +1,3 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="tbl::https://github.com/fcitx/xcb-imdkit/archive/$VER.tar.gz"
-CHKSUMS="sha256::b058575dc2fa809fb3daa2117bbbe312063b83284a40b12b6b20ba6e31fe2a13"
+CHKSUMS="sha256::78572cc37f16fed62b9e8749d8919b7b6834fe71819847d88b16db7646481e71"

--- a/extra-lua/lua-5.3/autobuild/prepare
+++ b/extra-lua/lua-5.3/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Set LIBS and luac_LDADD..."
+export LIBS="-lm -ldl"
+export luac_LDADD="liblua.la -lm -ldl"

--- a/extra-lua/lua-5.3/spec
+++ b/extra-lua/lua-5.3/spec
@@ -1,3 +1,4 @@
 VER=5.3.6
-SRCTBL="https://www.lua.org/ftp/lua-$VER.tar.gz"
-CHKSUM="sha256::fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60"
+SRCS="tbl::https://www.lua.org/ftp/lua-$VER.tar.gz"
+CHKSUMS="sha256::fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60"
+REL=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fcitx5: update to 5.0.3

Package(s) Affected
-------------------

See `groups/fcitx5`

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

Use `acbs-build groups/fcitx5` to build.

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
