### PR TITLE
v2ray-desktop: drop

### DIFF
--- a/extra-network/v2ray-desktop/autobuild/beyond
+++ b/extra-network/v2ray-desktop/autobuild/beyond
@@ -1,9 +1,0 @@
-abinfo "Installing v2ray-desktop binary..."
-install -Dvm644 "$PKGDIR"/opt/V2Ray-Desktop/bin/V2Ray-Desktop "$PKGDIR"/usr/bin/v2ray-desktop
-abinfo "Installing v2ray-desktop.desktop..."
-install -Dvm644 "$SRCDIR"/misc/tpl-linux-autostart.desktop "$PKGDIR"/usr/share/applications/v2ray-desktop.desktop
-abinfo "Installing v2ray-desktop icon..."
-sed -i  's/.png//g' "$PKGDIR"/usr/share/applications/v2ray-desktop.desktop
-install -Dvm644 "$SRCDIR"/images/v2ray.png "$PKGDIR"/usr/share/pixmaps/v2ray-desktop.png
-abinfo "Removing the useless directory"
-rm -rv "$PKGDIR"/opt/V2Ray-Desktop

--- a/extra-network/v2ray-desktop/autobuild/defines
+++ b/extra-network/v2ray-desktop/autobuild/defines
@@ -1,6 +1,0 @@
-PKGNAME=v2ray-desktop
-PKGSEC=net
-PKGDES="A cross-platform GUI proxy client for Shadowsocks, V2Ray, and Trojan protocols"
-PKGDEP="clash qt-5"
-BUILDDEP="jq"
-ABTYPE=qtproj

--- a/extra-network/v2ray-desktop/autobuild/prepare
+++ b/extra-network/v2ray-desktop/autobuild/prepare
@@ -1,1 +1,0 @@
-acbs_copy_git

--- a/extra-network/v2ray-desktop/spec
+++ b/extra-network/v2ray-desktop/spec
@@ -1,4 +1,0 @@
-VER=2.1.7
-GITSRC="https://github.com/Dr-Incognito/V2Ray-Desktop"
-GITCO="$VER"
-SUBDIR="v2ray-desktop/src"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

v2ray-desktop: drop

The upstream is no longer maintained and there are problems with availability, so drop

Package(s) Affected
-------------------

None

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
