### PR TITLE
Edk2 202011+deps

### DIFF
--- a/extra-devel/acpica-unix/autobuild/defines
+++ b/extra-devel/acpica-unix/autobuild/defines
@@ -4,4 +4,3 @@ PKGDEP="glibc"
 PKGDES="Intel ACPI Source Language compiler"
 
 ABMK="OPT_CFLAGS=${CFLAGS} OPT_LDFLAGS=${LDFLAGS}"
-NOPARALLEL=1

--- a/extra-devel/acpica-unix/spec
+++ b/extra-devel/acpica-unix/spec
@@ -1,5 +1,4 @@
-VER=20191018
-REL=2
+VER=20201217
 SRCTBL="https://acpica.org/sites/acpica/files/acpica-unix-$VER.tar.gz"
-CHKSUM="sha256::029db4014600e4b771b11a84276d2d76eb40fb26eabc85864852ef1f962be95f"
+CHKSUM="sha256::df6bb667c60577c89df5abe3270539c1b9716b69409d1074d6a7fc5c2fea087b"
 SUBDIR="acpica-unix-$VER/generate/unix"

--- a/extra-emulation/edk2/autobuild/prepare
+++ b/extra-emulation/edk2/autobuild/prepare
@@ -1,2 +1,1 @@
-ln -sv /usr/bin/ld.bfd "$SRCDIR"/ld
 export PATH="$SRCDIR:$PATH"

--- a/extra-emulation/edk2/spec
+++ b/extra-emulation/edk2/spec
@@ -1,5 +1,4 @@
-VER=201911
+VER=202011
 # Git submodules not included in tarball
 GITSRC="https://github.com/tianocore/edk2.git"
-GITCO="tags/edk2-stable201911"
-REL=1
+GITCO="tags/edk2-stable${VER}"

--- a/extra-emulation/seabios/spec
+++ b/extra-emulation/seabios/spec
@@ -1,4 +1,3 @@
-VER=1.12.0
-REL=1
+VER=1.14.0
 SRCTBL="https://www.seabios.org/downloads/seabios-$VER.tar.gz"
-CHKSUM="sha256::df17b8e565e75c27897ceb82af853b7c568eba7911f3bd173f8a68c1b4bda74b"
+CHKSUM="sha256::eb70cc62b29aa83e10a653233acebf4bb154d00d0c87dc2a2c6e2da75e5e81fd"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates edk2, seabios and acpica-unix to latest revisions.

Package(s) Affected
-------------------

* `acpica-unix`: 20201217
* `seabios`: 1.14.0
* `edk2`: 202011

Build Order
-----------

Build in the order of commits.

Architectural Progress
----------------------

- [x] AMD64 `amd64`  - `acpica-unix`
- [x] ARM64 `arm64`  - `acpica-unix`
- [x] Architecture-independent `noarch` - `seabios` `edk2`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3` - `acpica-unix`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el` - `acpica-unix`

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`  - `acpica-unix`
- [ ] ARM64 `arm64`  - `acpica-unix`
- [ ] Architecture-independent `noarch` - `seabios` `edk2`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3` - `acpica-unix`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el` - `acpica-unix`
