### PR TITLE
Perl dependency rework + po4a 0.62

### DIFF
--- a/extra-i18n/po4a/autobuild/build
+++ b/extra-i18n/po4a/autobuild/build
@@ -1,3 +1,4 @@
+export LC_ALL=en_US.UTF-8
 perl Build.PL create_packlist=0
 perl Build
 

--- a/extra-i18n/po4a/autobuild/build
+++ b/extra-i18n/po4a/autobuild/build
@@ -1,5 +1,7 @@
+abinfo "Set locale to unicode"
 export LC_ALL=en_US.UTF-8
+abinfo "Building po4a"
 perl Build.PL create_packlist=0
 perl Build
-
+abinfo "Installing"
 perl Build destdir="$PKGDIR" install

--- a/extra-i18n/po4a/autobuild/defines
+++ b/extra-i18n/po4a/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=po4a
 PKGSEC=doc
-PKGDEP="perl-locale-gettext"
-BUILDDEP="perl-module-build"
+PKGDEP="perl-unicode-linebreak gettext"
+BUILDDEP="perl-module-build libxslt perl-locale-gettext perl-text-wrapi18n perl-mime-charset perl-pod-parser docbook-xsl"
 PKGDES="Tools for helping translation of documentation"
 
 ABHOST=noarch

--- a/extra-i18n/po4a/spec
+++ b/extra-i18n/po4a/spec
@@ -1,3 +1,3 @@
-VER=0.57
+VER=0.62
 SRCTBL="https://github.com/mquinson/po4a/releases/download/v$VER/po4a-$VER.tar.gz"
-CHKSUM="sha256::bb55ec2b419ec7eefb0f13752fb08bc2701e6689467b6e1994bb5d9ae711cd97"
+CHKSUM="sha256::0eb510a66f59de68cf7a205342036cc9fc08b39334b91f1456421a5f3359e68b"

--- a/extra-perl/perl-mime-charset/autobuild/defines
+++ b/extra-perl/perl-mime-charset/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=perl-mime-charset
+PKGSEC=perl
+PKGDES='Charset Information for MIME'
+PKGDEP="perl "
+
+ABHOST=noarch

--- a/extra-perl/perl-mime-charset/spec
+++ b/extra-perl/perl-mime-charset/spec
@@ -1,0 +1,3 @@
+VER=1.012.2
+SRCTBL="https://cpan.metacpan.org/authors/id/N/NE/NEZUMI/MIME-Charset-${VER}.tar.gz"
+CHKSUM='sha256::878c779c0256c591666bd06c0cde4c0d7820eeeb98fd1183082aee9a1e7b1d13'

--- a/extra-perl/perl-pod-parser/autobuild/defines
+++ b/extra-perl/perl-pod-parser/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=perl-pod-parser
+PKGSEC=perl
+PKGDES='base class for creating POD filters and translators'
+PKGDEP="perl "
+
+ABHOST=noarch

--- a/extra-perl/perl-pod-parser/spec
+++ b/extra-perl/perl-pod-parser/spec
@@ -1,0 +1,3 @@
+VER=1.63
+SRCTBL="https://cpan.metacpan.org/authors/id/M/MA/MAREKR/Pod-Parser-$VER.tar.gz"
+CHKSUM='sha256::dbe0b56129975b2f83a02841e8e0ed47be80f060686c66ea37e529d97aa70ccd'

--- a/extra-perl/perl-text-wrapi18n/autobuild/defines
+++ b/extra-perl/perl-text-wrapi18n/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=perl-text-wrapi18n
 PKGSEC=perl
-PKGDEP="perl-text-charwidth"
+PKGDEP="perl-text-charwidth perl-mime-charset perl-unicode-linebreak"
 PKGDES="Perl line wrapping module"
 
 ABHOST=noarch

--- a/extra-perl/perl-text-wrapi18n/spec
+++ b/extra-perl/perl-text-wrapi18n/spec
@@ -1,4 +1,4 @@
 VER=0.06
-REL=4
+REL=5
 SRCTBL="https://search.cpan.org/CPAN/authors/id/K/KU/KUBOTA/Text-WrapI18N-$VER.tar.gz"
 CHKSUM="sha256::4bd29a17f0c2c792d12c1005b3c276f2ab0fae39c00859ae1741d7941846a488"

--- a/extra-perl/perl-unicode-linebreak/autobuild/defines
+++ b/extra-perl/perl-unicode-linebreak/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=perl-unicode-linebreak
+PKGSEC=perl
+PKGDES='Unicode Line Breaking Algorithm'
+PKGDEP="perl perl-mime-charset"

--- a/extra-perl/perl-unicode-linebreak/spec
+++ b/extra-perl/perl-unicode-linebreak/spec
@@ -1,0 +1,3 @@
+VER=2019.001
+SRCTBL="https://cpan.metacpan.org/authors/id/N/NE/NEZUMI/Unicode-LineBreak-$VER.tar.gz"
+CHKSUM='sha256::486762e4cacddcc77b13989f979a029f84630b8175e7fef17989e157d4b6318a'


### PR DESCRIPTION
Topic Description
-----------------

This PR attempts to rework dependency mess in perl packages... Notably missing dependencies of `perl-text-wrapi18n`, and `perl-pod-parser` for `po4a`. However po4a is currently missing unknown symbol `PerlIO::F_UTF8`.

Package(s) Affected
-------------------

##### Group 0:

* noarch: `perl-mime-charset` 1.012.2
* ELF: `perl-unicode-linebreak` 2019.001

##### Group 1:

* noarch: `perl-text-wrapi18n` 0.06

##### Group 2:

* noarch: `perl-pod-parser` 1.63

##### Failing group 3:

* noarch: `po4a` 0.62

Build Order by groups
-----------

{(0 -> 1), 2} -> Group 3

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] Architecture-independent `noarch`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] Architecture-independent `noarch`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
