### PR TITLE
bluez: update to 5.55

### DIFF
--- a/extra-libs/bluez/spec
+++ b/extra-libs/bluez/spec
@@ -1,4 +1,3 @@
-VER=5.54
+VER=5.55
 SRCTBL="https://www.kernel.org/pub/linux/bluetooth/bluez-$VER.tar.xz"
-CHKSUM="sha256::68cdab9e63e8832b130d5979dc8c96fdb087b31278f342874d992af3e56656dc"
-REL=1
+CHKSUM="sha256::8863717113c4897e2ad3271fc808ea245319e6fd95eed2e934fae8e0894e9b88"


### PR DESCRIPTION
Topic Description
-----------------
Update bluez 5.55 and (potentially) rebuild its reverse dependencies.

Package(s) Affected
-------------------
+ bluez

Security Update?
----------------
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

