### PR TITLE
musicbox: update to 0.3.0+git20201222

### DIFF
--- a/extra-doc/m2r/autobuild/defines
+++ b/extra-doc/m2r/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=m2r
+PKGSEC=python
+PKGDES="Markdown to reStructuredText converter"
+PKGDEP="python-2 python-3 mistune docutils"
+
+ABHOST=noarch
+ABTYPE=python

--- a/extra-doc/m2r/spec
+++ b/extra-doc/m2r/spec
@@ -1,0 +1,4 @@
+VER=0.2.1
+SRCS="https://pypi.io/packages/source/m/m2r/m2r-${VER}.tar.gz"
+CHKSUMS="sha256::bf90bad66cda1164b17e5ba4a037806d2443f2a4d5ddc9f6a5554a0322aaed99"
+

--- a/extra-multimedia/musicbox/autobuild/defines
+++ b/extra-multimedia/musicbox/autobuild/defines
@@ -2,8 +2,11 @@ PKGNAME=musicbox
 PKGSEC=sound
 PKGDEP="requests-cache beautifulsoup4 pycryptodome future \
         mpg123 pycryptodomex"
-BUILDDEP="setuptools"
+BUILDDEP="setuptools dephell"
 PKGDES="CLI Version of Netease-CloudMusic"
 
 NOPYTHON2=1
 ABHOST=noarch
+ABTYPE=python
+
+PKGEPOCH=1

--- a/extra-multimedia/musicbox/autobuild/defines
+++ b/extra-multimedia/musicbox/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=musicbox
 PKGSEC=sound
-PKGDEP="requests-cache beautifulsoup4 pycryptodome future \
-        mpg123 pycryptodomex"
+PKGDEP="requests requests-cache fuzzywuzzy pycryptodome future \
+        mpg123 pycryptodomex pyqt5 dbus-python libnotify"
 BUILDDEP="setuptools dephell"
 PKGDES="CLI Version of Netease-CloudMusic"
 

--- a/extra-multimedia/musicbox/autobuild/patches/0001-let-musicbox-use-python-3.8-native-importlib-metadata.patch
+++ b/extra-multimedia/musicbox/autobuild/patches/0001-let-musicbox-use-python-3.8-native-importlib-metadata.patch
@@ -1,0 +1,11 @@
+--- a/NEMbox/__init__.py 2020-12-27 04:15:34.483095459 -0600
++++ b/NEMbox/__init__.pyy        2020-12-27 04:16:25.621264052 -0600
+@@ -26,7 +26,7 @@
+ + ------------------------------------------ +
+ 
+ """
+-from importlib_metadata import version
++from importlib.metadata import version
+ 
+ from .const import Constant
+ from .utils import create_dir

--- a/extra-multimedia/musicbox/autobuild/prepare
+++ b/extra-multimedia/musicbox/autobuild/prepare
@@ -1,0 +1,1 @@
+dephell deps convert --from pyproject.toml --to setup.py

--- a/extra-multimedia/musicbox/autobuild/prepare
+++ b/extra-multimedia/musicbox/autobuild/prepare
@@ -1,1 +1,5 @@
+abinfo "Remove the unneccessary importlib-metadata dependency for Python3.8 from the poetry configure file"
+sed -i 's|importlib-metadata = "^2.0.0"||' pyproject.toml
+
+abinfo "Generating the setup.py from the poetry configure file"
 dephell deps convert --from pyproject.toml --to setup.py

--- a/extra-multimedia/musicbox/spec
+++ b/extra-multimedia/musicbox/spec
@@ -1,4 +1,3 @@
-VER=20190901
+VER=0.3.0+git20201222
 GITSRC="https://github.com/darknessomi/musicbox"
-GITCO="d09e2f009abc546327cee213a9e58c06dd0d5114"
-REL=2
+GITCO="9fcaf1116ec3493c92fe2942c43fae442de65b8c"

--- a/extra-python/attrs/spec
+++ b/extra-python/attrs/spec
@@ -1,3 +1,3 @@
 VER=20.3.0
-SRCTBL="https://pypi.io/packages/source/a/attrs/attrs-$VER.tar.gz"
-CHKSUM="sha256::10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69"
+SRCS="https://pypi.io/packages/source/a/attrs/attrs-$VER.tar.gz"
+CHKSUMS="sha256::832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"

--- a/extra-python/attrs/spec
+++ b/extra-python/attrs/spec
@@ -1,4 +1,3 @@
-VER=18.2.0
-REL=2
+VER=20.3.0
 SRCTBL="https://pypi.io/packages/source/a/attrs/attrs-$VER.tar.gz"
 CHKSUM="sha256::10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69"

--- a/extra-python/cerberus/autobuild/defines
+++ b/extra-python/cerberus/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=cerberus
+PKGSEC=python
+PKGDES="Lightweight, extensible schema and data validation tool for Python dictionaries"
+PKGDEP="python-3"
+
+ABHOST=noarch
+ABTYPE=python

--- a/extra-python/cerberus/spec
+++ b/extra-python/cerberus/spec
@@ -1,0 +1,3 @@
+VER=1.3.2
+SRCS="https://pypi.io/packages/source/C/Cerberus/Cerberus-${VER}.tar.gz"
+CHKSUMS="sha256::302e6694f206dd85cb63f13fd5025b31ab6d38c99c50c6d769f8fa0b0f299589"

--- a/extra-python/dephell-archive/autobuild/defines
+++ b/extra-python/dephell-archive/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-archive
+PKGSEC=python
+PKGDEP="python-3"
+PKGDES="A Python module to work with files and directories in archive in pathlib style"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-archive/spec
+++ b/extra-python/dephell-archive/spec
@@ -1,0 +1,3 @@
+VER=0.1.7
+SRCS="https://pypi.io/packages/source/d/dephell-archive/dephell-archive-${VER}.tar.gz"
+CHKSUMS="sha256::bb263492a7d430f9e04cef9a0237b7752cc797ab364bf35e70196af09c73ea37"

--- a/extra-python/dephell-argparse/autobuild/defines
+++ b/extra-python/dephell-argparse/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-argparse
+PKGSEC=python
+PKGDEP="python-3"
+PKGDES="A Python module powered argparse with fuzzy matching"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-argparse/spec
+++ b/extra-python/dephell-argparse/spec
@@ -1,0 +1,3 @@
+VER=0.1.3
+SRCS="https://pypi.io/packages/source/d/dephell-argparse/dephell_argparse-${VER}.tar.gz"
+CHKSUMS="sha256::2ab9b2441f808bb11c338c4849d22ded898cde8325946800ac9e39d2b138735d"

--- a/extra-python/dephell-changelogs/autobuild/defines
+++ b/extra-python/dephell-changelogs/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-changelogs
+PKGSEC=python
+PKGDEP="python-3 requests"
+PKGDES="A Python module which can find changelog for github repository, local dir, parse changelog"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-changelogs/spec
+++ b/extra-python/dephell-changelogs/spec
@@ -1,3 +1,3 @@
 VER=0.0.1
-SRCS="https://pypi.org/sources/packages/source/d/dephell-changelogs/dephell_changelogs-${VER}.tar.gz"
+SRCS="https://pypi.io/packages/source/d/dephell-changelogs/dephell_changelogs-${VER}.tar.gz"
 CHKSUMS="sha256::e639a3d08d389e22fbac0cc64181dbe93c4b4ba9f0134e273e6dd3e26ae70b21"

--- a/extra-python/dephell-changelogs/spec
+++ b/extra-python/dephell-changelogs/spec
@@ -1,0 +1,3 @@
+VER=0.0.1
+SRCS="https://pypi.org/sources/packages/source/d/dephell-changelogs/dephell_changelogs-${VER}.tar.gz"
+CHKSUMS="sha256::e639a3d08d389e22fbac0cc64181dbe93c4b4ba9f0134e273e6dd3e26ae70b21"

--- a/extra-python/dephell-discover/autobuild/defines
+++ b/extra-python/dephell-discover/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-discover
+PKGSEC=python
+PKGDEP="python-3 attrs"
+PKGDES="A Python module which can find project modules and data files"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-discover/spec
+++ b/extra-python/dephell-discover/spec
@@ -1,0 +1,4 @@
+VER=0.2.10
+SRCS="https://pypi.io/packages/source/d/dephell-discover/dephell_discover-${VER}.tar.gz"
+CHKSUMS="sha256::a2ad414e5e0fe16c82c537d6a3198afd9818c0c010760eccb23e2d60e5b66df6"
+

--- a/extra-python/dephell-licenses/autobuild/defines
+++ b/extra-python/dephell-licenses/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-licenses
+PKGSEC=python
+PKGDEP="python-3 attrs requests"
+PKGDES="A Python module which getting info about OSS licenses"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-licenses/spec
+++ b/extra-python/dephell-licenses/spec
@@ -1,0 +1,3 @@
+VER=0.1.7
+SRCS="https://pypi.io/packages/source/d/dephell-licenses/dephell-licenses-${VER}.tar.gz"
+CHKSUMS="sha256::f175cec822a32bda5b56442f48dae39efbb5c3851275ecd41cfd7e849ddd2ea6"

--- a/extra-python/dephell-links/autobuild/defines
+++ b/extra-python/dephell-links/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-links
+PKGSEC=python
+PKGDEP="python-3 attrs"
+PKGDES="A Python module for parsing dependency links"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-links/spec
+++ b/extra-python/dephell-links/spec
@@ -1,0 +1,3 @@
+VER=0.1.5
+SRCS="https://pypi.io/packages/source/d/dephell-links/dephell_links-${VER}.tar.gz"
+CHKSUMS="sha256::28d694142e2827a59d2c301e7185afb52fb8acdb950b1da38308d69e43418eaa"

--- a/extra-python/dephell-markers/autobuild/defines
+++ b/extra-python/dephell-markers/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-markers
+PKGSEC=python
+PKGDEP="python-3 packaging attrs dephell-specifier"
+PKGDES="A Python module works with environment markers for dephell"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-markers/spec
+++ b/extra-python/dephell-markers/spec
@@ -1,0 +1,3 @@
+VER=1.0.3
+SRCS="https://pypi.io/packages/source/d/dephell-markers/dephell_markers-${VER}.tar.gz"
+CHKSUMS="sha256::525e17914e705acf8652dd8681fccdec912432a747d8def4720f49416817f2d4"

--- a/extra-python/dephell-pythons/autobuild/defines
+++ b/extra-python/dephell-pythons/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=dephell-pythons
 PKGSEC=python
-PKGDEP="python-3 attrs dephell-specifiers packaging"
+PKGDEP="python-3 attrs dephell-specifier packaging"
 PKGDES="A Python module works with python versions for dephell"
 
 ABHOST=noarch

--- a/extra-python/dephell-pythons/autobuild/defines
+++ b/extra-python/dephell-pythons/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-pythons
+PKGSEC=python
+PKGDEP="python-3 attrs dephell-specifiers packaging"
+PKGDES="A Python module works with python versions for dephell"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-pythons/spec
+++ b/extra-python/dephell-pythons/spec
@@ -1,0 +1,4 @@
+VER=0.1.15
+SRCS="https://pypi.io/packages/source/d/dephell-pythons/dephell_pythons-${VER}.tar.gz"
+CHKSUMS="sha256::804c29afa2147322aa23e791f591d0204fd1e9983afa7d91e1d1452fc7be1c5c"
+

--- a/extra-python/dephell-setuptools/autobuild/defines
+++ b/extra-python/dephell-setuptools/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-setuptools
+PKGSEC=python
+PKGDEP="python-3 setuptools"
+PKGDES="A Python module reads metainfo from setup.py for dephell"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-setuptools/spec
+++ b/extra-python/dephell-setuptools/spec
@@ -1,0 +1,3 @@
+VER=0.2.4
+SRCS="https://pypi.io/packages/source/d/dephell-setuptools/dephell_setuptools-${VER}.tar.gz"
+CHKSUMS="sha256::663629e1ebf7b20bf7e372ee2a2e7ebf1a15aeb3bc6d46ad32e1bcb21044ca29"

--- a/extra-python/dephell-shells/autobuild/defines
+++ b/extra-python/dephell-shells/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-shells
+PKGSEC=python
+PKGDEP="python-3 attrs pexpect shellingham"
+PKGDES="A Python module activates virtual environment for current shell"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-shells/spec
+++ b/extra-python/dephell-shells/spec
@@ -1,0 +1,3 @@
+VER=0.1.6
+SRCS="https://pypi.io/packages/source/d/dephell-shells/dephell_shells-${VER}.tar.gz"
+CHKSUMS="sha256::77150b732db135d436f41c2c6f12694e6058a8609214117ee80f6c40234ac2d5"

--- a/extra-python/dephell-shells/spec
+++ b/extra-python/dephell-shells/spec
@@ -1,3 +1,3 @@
-VER=0.1.6
+VER=0.1.5
 SRCS="https://pypi.io/packages/source/d/dephell-shells/dephell_shells-${VER}.tar.gz"
 CHKSUMS="sha256::77150b732db135d436f41c2c6f12694e6058a8609214117ee80f6c40234ac2d5"

--- a/extra-python/dephell-specifier/autobuild/defines
+++ b/extra-python/dephell-specifier/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-specifier
+PKGSEC=python
+PKGDEP="python-3 packaging"
+PKGDES="A Python module Work with version specifiers for dephell"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-specifier/spec
+++ b/extra-python/dephell-specifier/spec
@@ -1,0 +1,3 @@
+VER=0.2.2
+SRCS="https://pypi.io/packages/source/d/dephell-specifier/dephell_specifier-${VER}.tar.gz"
+CHKSUMS="sha256::b5ec6409a1916980c4861da2cb7538246555bff4b95bef2c952c56bd19eb2de6"

--- a/extra-python/dephell-venvs/autobuild/defines
+++ b/extra-python/dephell-venvs/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-venvs
+PKGSEC=python
+PKGDEP="python-3 attrs dephell-pythons"
+PKGDES="A Python module manages virtual environments for dephell"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-venvs/spec
+++ b/extra-python/dephell-venvs/spec
@@ -1,0 +1,3 @@
+VER=0.1.18
+SRCS="https://pypi.io/packages/source/d/dephell-venvs/dephell_venvs-${VER}.tar.gz"
+CHKSUMS="sha256::c7307291b754edba325ab27edeb05d85ee4dd2f1487c48872a1ebfc372bf7a2e"

--- a/extra-python/dephell-versioning/autobuild/defines
+++ b/extra-python/dephell-versioning/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dephell-versioning
+PKGSEC=python
+PKGDEP="python-3 packaging"
+PKGDES="A Python helper module for version styling"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell-versioning/spec
+++ b/extra-python/dephell-versioning/spec
@@ -1,0 +1,3 @@
+VER=0.1.2
+SRCS="https://pypi.io/packages/source/d/dephell-versioning/dephell_versioning-${VER}.tar.gz"
+CHKSUMS="sha256::9ba7636704af7bd64af5a64ab8efb482c8b0bf4868699722f5e2647763edf8e5"

--- a/extra-python/dephell/autobuild/defines
+++ b/extra-python/dephell/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=dephell
+PKGSEC=python
+PKGDES="A dependencies resolver for Python"
+PKGDEP="python-3 aiohttp attrs cerberus certifi \
+        dephell-archive dephell-argparse dephell-changelogs dephell-discover \
+        dephell-licenses dephell-links dephell-markers dephell-pythons \
+	dephell-setuptools dephell-shells dephell-specifier dephell-venvs \
+	dephell-versioning jinja2 m2r packaging requests tomlkit yaspin"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/dephell/autobuild/prepare
+++ b/extra-python/dephell/autobuild/prepare
@@ -1,2 +1,2 @@
 abinfo "Make the \"pip\" dependency have no the version restriction"
-sed -i 's/pip<=19.3.1,>=18.0/pip/' "${SRCDIR}"setup.py
+sed -i 's/pip<=19.3.1,>=18.0/pip/' "${SRCDIR}"/setup.py

--- a/extra-python/dephell/autobuild/prepare
+++ b/extra-python/dephell/autobuild/prepare
@@ -1,2 +1,2 @@
 abinfo "Make the \"pip\" dependency have no the version restriction"
-sed -i 's/pip<=19.3.1,>=18.0/pip/' setup.py
+sed -i 's/pip<=19.3.1,>=18.0/pip/' "${SRCDIR}"setup.py

--- a/extra-python/dephell/autobuild/prepare
+++ b/extra-python/dephell/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Make the \"pip\" dependency have no the version restriction"
+sed -i 's/pip<=19.3.1,>=18.0/pip/' setup.py

--- a/extra-python/dephell/spec
+++ b/extra-python/dephell/spec
@@ -1,0 +1,3 @@
+VER=0.8.3
+SRCS="https://pypi.io/packages/source/d/dephell/dephell-${VER}.tar.gz"
+CHKSUMS="sha256::a9fcc528a0c6f9f5d721292bdf846e5338e4dca7cd6fef1551fbe71564dfe61e"

--- a/extra-python/fuzzywuzzy/spec
+++ b/extra-python/fuzzywuzzy/spec
@@ -1,4 +1,3 @@
-VER=0.17.0
-REL=2
-SRCTBL="https://pypi.io/packages/source/f/fuzzywuzzy/fuzzywuzzy-$VER.tar.gz"
-CHKSUM="sha256::6f49de47db00e1c71d40ad16da42284ac357936fa9b66bea1df63fed07122d62"
+VER=0.18.0
+SRCS="https://pypi.io/packages/source/f/fuzzywuzzy/fuzzywuzzy-${VER}.tar.gz"
+CHKSUMS="sha256::45016e92264780e58972dca1b3d939ac864b78437422beecebb3095f8efd00e8"

--- a/extra-python/mistune/autobuild/defines
+++ b/extra-python/mistune/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=mistune
+PKGSEC=python
+PKGDES="A markdown parser in pure Python"
+PKGDEP="python-2 python-3"
+
+ABHOST=noarch
+ABTYPE=python

--- a/extra-python/mistune/spec
+++ b/extra-python/mistune/spec
@@ -1,0 +1,3 @@
+VER=0.8.4
+SRCS="https://pypi.io/packages/source/m/mistune/mistune-${VER}.tar.gz"
+CHKSUMS="sha256::59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e"

--- a/extra-python/pycryptodomex/spec
+++ b/extra-python/pycryptodomex/spec
@@ -1,4 +1,3 @@
-VER=3.7.2
-REL=2
-SRCTBL="https://pypi.org/packages/source/p/pycryptodomex/pycryptodomex-$VER.tar.gz"
-CHKSUM="sha256::5d4e10ad9ff7940da534119ef92a500dcf7c28351d15e12d74ef0ce025e37d5b"
+VER=3.9.9
+SRCS="https://pypi.org/packages/source/p/pycryptodomex/pycryptodomex-${VER}.tar.gz"
+CHKSUMS="sha256::7b5b7c5896f8172ea0beb283f7f9428e0ab88ec248ce0a5b8c98d73e26267d51"

--- a/extra-python/requests/spec
+++ b/extra-python/requests/spec
@@ -1,3 +1,3 @@
-VER=2.23.0
-SRCTBL="https://pypi.io/packages/source/r/requests/requests-$VER.tar.gz"
-CHKSUM="sha256::b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+VER=2.25.1
+SRCS="https://pypi.io/packages/source/r/requests/requests-${VER}.tar.gz"
+CHKSUMS="sha256::27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"

--- a/extra-python/tomlkit/autobuild/beyond
+++ b/extra-python/tomlkit/autobuild/beyond
@@ -1,0 +1,1 @@
+rm -rv ${PKGDIR}/usr/lib/python*/site-packages/tests

--- a/extra-python/tomlkit/spec
+++ b/extra-python/tomlkit/spec
@@ -1,3 +1,4 @@
 VER=0.6.0
 SRCTBL="https://pypi.io/packages/source/t/tomlkit/tomlkit-$VER.tar.gz"
 CHKSUM="sha256::74f976908030ff164c0aa1edabe3bf83ea004b3daa5b0940b9c86a060c004e9a"
+REL=1

--- a/extra-python/yaspin/autobuild/beyond
+++ b/extra-python/yaspin/autobuild/beyond
@@ -1,0 +1,1 @@
+rm -rv ${PKGDIR}/usr/lib/python*/site-packages/tests

--- a/extra-python/yaspin/autobuild/defines
+++ b/extra-python/yaspin/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=yaspin
+PKGSEC=python
+PKGDEP="python-3 python-2"
+PKGDES="A Python written fancy terminal spinner"
+
+ABHOST=noarch
+ABTYPE=python

--- a/extra-python/yaspin/spec
+++ b/extra-python/yaspin/spec
@@ -1,0 +1,3 @@
+VER=1.2.0
+SRCS="https://pypi.io/packages/source/y/yaspin/yaspin-${VER}.tar.gz"
+CHKSUMS="sha256::72e9cdbc0e797ef886c373fef2bcd6526a704a470696f9d78d0bb27951fe659a"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
Update `musicbox` to 0.3.0+git20201222

Package(s) Affected
-------------------
`musicbox`
`dephell`
`dephell-archive`
`dephell-argparse`
`dephell-changelogs`
`dephell-discover`
`dephell-licenses`
`dephell-links`
`dephell-markers`
`dephell-pythons`
`dephell-setuptools`
`dephell-shells`
`dephell-specifier`
`dephell-venvs`
`dephell-versioning`
`fuzzywuzzy`
`m2r`
`mistune`
`pycryptodomex`
`requests`
`tomlkit`
`yaspin`
`cerberus`
`attrs`

Security Update?
----------------
No


Build Order
-----------
1. `attrs` -> `cerberus` ->`tomlkit` -> `yaspin` -> `mistune` -> `m2r` -> `dephell-*` -> `dephell`
2. `requests`, `pycryptodomex`, `fuzzywuzzy` -> `musicbox`

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

- [x] Architecture-independent `noarch` 

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
- [ ] Architecture-independent `noarch` 

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

