### PR TITLE
httpcore: update to 0.12.2

### DIFF
--- a/extra-python/httpcore/spec
+++ b/extra-python/httpcore/spec
@@ -1,3 +1,3 @@
-VER=0.12.1
+VER=0.12.2
 SRCS="tbl::https://github.com/encode/httpcore/archive/${VER}.tar.gz"
-CHKSUMS="sha256::2819074edded8834d781cf4d4dc30838a01d8c1c0ac16e432c9b275defb89817"
+CHKSUMS="sha256::3a3dd01e123e0916551485f52ac966aa6337324e9e35f8d1be28f23c0f2328a0"


### PR DESCRIPTION
Topic Description
-----------------

Update httpcore to 0.12.2

Package(s) Affected
-------------------

httpcore

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`
