### PR TITLE
frp: update to 0.34.3

### DIFF
--- a/extra-network/frp/spec
+++ b/extra-network/frp/spec
@@ -1,3 +1,3 @@
-VER=0.34.2
+VER=0.34.3
 SRCS="tbl::https://github.com/fatedier/frp/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::53d8c29ef627e544cf8970b0a05570589d5270398068eb162957bdddb36de9ac"
+CHKSUMS="sha256::f03e280d9e8fdd4948ed6a5d141e927bf9b5168d7a47a4f3e90a08065e5f192d"


### PR DESCRIPTION
Topic Description
-----------------

Update frp to 0.34.3

Package(s) Affected
-------------------

frp

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`