### PR TITLE
dephell: add the missing "ruamel-yaml" dependency

### DIFF
--- a/extra-python/dephell/autobuild/defines
+++ b/extra-python/dephell/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=dephell
 PKGSEC=python
 PKGDES="A dependencies resolver for Python"
-PKGDEP="python-3 aiohttp attrs cerberus certifi \
+PKGDEP="python-3 aiohttp attrs cerberus certifi ruamel-yaml \
         dephell-archive dephell-argparse dephell-changelogs dephell-discover \
         dephell-licenses dephell-links dephell-markers dephell-pythons \
 	dephell-setuptools dephell-shells dephell-specifier dephell-venvs \


### PR DESCRIPTION
Topic Description
-----------------
Add the missing `ruamel-yaml` dependency for `dephell`.

Package(s) Affected
-------------------
dephell

Security Update?
----------------
No

Architectural Progress
----------------------
 - [x] Architecture-independent `noarch` -->

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
 - [x] Architecture-independent `noarch` -->

