### PR TITLE
mesa{,+32}: update to 20.3.1

### DIFF
--- a/extra-libs/mesa/autobuild/beyond
+++ b/extra-libs/mesa/autobuild/beyond
@@ -1,38 +1,3 @@
 abinfo "Making a symlink from libGLX_mesa to libGLX_indirect ..."
 ln -sv libGLX_mesa.so.0 \
     "$PKGDIR"/usr/lib/libGLX_indirect.so.0
-
-abinfo "Dropping headers from libGLVND ..."
-rm -fv "$PKGDIR"/usr/include/EGL/egl.h
-rm -fv "$PKGDIR"/usr/include/EGL/eglext.h
-rm -fv "$PKGDIR"/usr/include/EGL/eglplatform.h
-rm -fv "$PKGDIR"/usr/include/GL/gl.h
-rm -fv "$PKGDIR"/usr/include/GL/glcorearb.h
-rm -fv "$PKGDIR"/usr/include/GL/glext.h
-rm -fv "$PKGDIR"/usr/include/GL/glx.h
-rm -fv "$PKGDIR"/usr/include/GL/glxext.h
-rm -fv "$PKGDIR"/usr/include/GLES/egl.h
-rm -fv "$PKGDIR"/usr/include/GLES/gl.h
-rm -fv "$PKGDIR"/usr/include/GLES/glext.h
-rm -fv "$PKGDIR"/usr/include/GLES/glplatform.h
-rm -fv "$PKGDIR"/usr/include/GLES2/gl2.h
-rm -fv "$PKGDIR"/usr/include/GLES2/gl2ext.h
-rm -fv "$PKGDIR"/usr/include/GLES2/gl2platform.h
-rm -fv "$PKGDIR"/usr/include/GLES3/gl3.h
-rm -fv "$PKGDIR"/usr/include/GLES3/gl31.h
-rm -fv "$PKGDIR"/usr/include/GLES3/gl32.h
-rm -fv "$PKGDIR"/usr/include/GLES3/gl3ext.h
-rm -fv "$PKGDIR"/usr/include/GLES3/gl3platform.h
-rm -fv "$PKGDIR"/usr/include/KHR/khrplatform.h
-rm -fv "$PKGDIR"/usr/include/glvnd/GLdispatchABI.h
-rm -fv "$PKGDIR"/usr/include/glvnd/libeglabi.h
-rm -fv "$PKGDIR"/usr/include/glvnd/libglxabi.h
-
-abinfo "Dropping pkg-config data from libGLVND ..."
-rm -fv "$PKGDIR"/usr/lib/pkgconfig/egl.pc
-rm -fv "$PKGDIR"/usr/lib/pkgconfig/gl.pc
-rm -fv "$PKGDIR"/usr/lib/pkgconfig/glesv1_cm.pc
-rm -fv "$PKGDIR"/usr/lib/pkgconfig/glesv2.pc
-rm -fv "$PKGDIR"/usr/lib/pkgconfig/glx.pc
-rm -fv "$PKGDIR"/usr/lib/pkgconfig/libglvnd.pc
-rm -fv "$PKGDIR"/usr/lib/pkgconfig/opengl.pc

--- a/extra-libs/mesa/autobuild/defines
+++ b/extra-libs/mesa/autobuild/defines
@@ -22,7 +22,7 @@ PKGSEC=libs
 
 MESON_AFTER="-Ddri-drivers-path=/usr/lib/xorg/modules/dri \
              -Db_ndebug=true \
-             -Dplatforms=x11,wayland,drm,surfaceless \
+             -Dplatforms=x11,wayland \
              -Dvulkan-overlay-layer=true \
              -Ddri3=true \
              -Degl=true \
@@ -83,7 +83,7 @@ MESON_AFTER__LOONGSON3=" \
 MESON_AFTER__RETRO=" \
              -Ddri-drivers-path=/usr/lib/xorg/modules/dri \
              -Db_ndebug=true \
-             -Dplatforms=x11,drm \
+             -Dplatforms=x11 \
              -Dvulkan-overlay-layer=false \
              -Ddri3=false \
              -Degl=true \

--- a/extra-libs/mesa/spec
+++ b/extra-libs/mesa/spec
@@ -1,4 +1,3 @@
-VER=20.2.2
-SRCTBL="https://mesa.freedesktop.org/archive/mesa-$VER.tar.xz"
-CHKSUM="sha256::1f93eb1090cf71490cd0e204e04f8427a82b6ed534b7f49ca50cea7dcc89b861"
-REL=2
+VER=20.3.1
+SRCS="tbl::https://mesa.freedesktop.org/archive/mesa-$VER.tar.xz"
+CHKSUMS="sha256::af751b49bb2ab0264d58c31e73d869e80333de02b2d1becc93f1b28c67aa780f"

--- a/extra-optenv32/mesa+32/autobuild/build
+++ b/extra-optenv32/mesa+32/autobuild/build
@@ -10,7 +10,7 @@ cd "$SRCDIR"/build
 meson "$SRCDIR" --prefix=/opt/32 \
       -Ddri-drivers-path=/opt/32/lib/xorg/modules/dri \
       -Db_ndebug=true \
-      -Dplatforms=x11,drm,surfaceless \
+      -Dplatforms=x11 \
       -Dvulkan-overlay-layer=false \
       -Ddri3=true \
       -Degl=true \
@@ -42,28 +42,3 @@ cd "$SRCDIR"
 rm -rf "$PKGDIR"/opt/32/etc
 
 ln -sv /opt/32/lib/libGLX_mesa.so.0 "$PKGDIR"/opt/32/lib/libGLX_indirect.so.0
-
-rm -fv "$PKGDIR"/opt/32/include/EGL/egl.h
-rm -fv "$PKGDIR"/opt/32/include/EGL/eglext.h
-rm -fv "$PKGDIR"/opt/32/include/EGL/eglplatform.h
-rm -fv "$PKGDIR"/opt/32/include/GL/gl.h
-rm -fv "$PKGDIR"/opt/32/include/GL/glcorearb.h
-rm -fv "$PKGDIR"/opt/32/include/GL/glext.h
-rm -fv "$PKGDIR"/opt/32/include/GL/glx.h
-rm -fv "$PKGDIR"/opt/32/include/GL/glxext.h
-rm -fv "$PKGDIR"/opt/32/include/GLES/egl.h
-rm -fv "$PKGDIR"/opt/32/include/GLES/glext.h
-rm -fv "$PKGDIR"/opt/32/include/GLES/gl.h
-rm -fv "$PKGDIR"/opt/32/include/GLES/glplatform.h
-rm -fv "$PKGDIR"/opt/32/include/GLES2/gl2.h
-rm -fv "$PKGDIR"/opt/32/include/GLES2/gl2ext.h
-rm -fv "$PKGDIR"/opt/32/include/GLES2/gl2platform.h
-rm -fv "$PKGDIR"/opt/32/include/GLES3/gl3.h
-rm -fv "$PKGDIR"/opt/32/include/GLES3/gl31.h
-rm -fv "$PKGDIR"/opt/32/include/GLES3/gl32.h
-rm -fv "$PKGDIR"/opt/32/include/GLES3/gl3ext.h
-rm -fv "$PKGDIR"/opt/32/include/GLES3/gl3platform.h
-rm -fv "$PKGDIR"/opt/32/include/KHR/khrplatform.h
-
-rm -fv "$PKGDIR"/opt/32/lib/pkgconfig/egl.pc
-rm -fv "$PKGDIR"/opt/32/lib/pkgconfig/gl.pc

--- a/extra-optenv32/mesa+32/spec
+++ b/extra-optenv32/mesa+32/spec
@@ -1,3 +1,3 @@
-VER=20.2.2
-SRCTBL="https://mesa.freedesktop.org/archive/mesa-$VER.tar.xz"
-CHKSUM="sha256::1f93eb1090cf71490cd0e204e04f8427a82b6ed534b7f49ca50cea7dcc89b861"
+VER=20.3.1
+SRCS="tbl::https://mesa.freedesktop.org/archive/mesa-$VER.tar.xz"
+CHKSUMS="sha256::af751b49bb2ab0264d58c31e73d869e80333de02b2d1becc93f1b28c67aa780f"


### PR DESCRIPTION
Topic Description
-----------------

Update Mesa to 20.3.1. Improves AArch64 platform support.

Package(s) Affected
-------------------

`mesa`, `mesa+32` v20.3.1

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit Optional Environment `optenv32`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit Optional Environment `optenv32`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`