### PR TITLE
kernel-tools: rebuild for binutils 2.35+git20201210

### DIFF
--- a/extra-kernel/kernel-tools/spec
+++ b/extra-kernel/kernel-tools/spec
@@ -1,3 +1,4 @@
 VER=5.9.13
+REL=1
 SRCTBL="https://cdn.kernel.org/pub/linux/kernel/v${VER:0:1}.x/linux-$VER.tar.xz"
 CHKSUM="sha256::b436a89a5c872a2a029d5dee6aa5bc61128978f4cae6fcb7e507c35cdd6acc2a"


### PR DESCRIPTION
Topic Description
-----------------

This package rebuilds kernel-tools against  binutils `2.35+git20201210`.

Package(s) Affected
-------------------

* kernel-tools: 5.9.13-1

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
