### PR TITLE
gdk-pixbuf-xlib: new, 2.40.2

### DIFF
--- a/extra-libs/gdk-pixbuf-xlib/autobuild/defines
+++ b/extra-libs/gdk-pixbuf-xlib/autobuild/defines
@@ -1,0 +1,31 @@
+PKGNAME=gdk-pixbuf-xlib
+PKGDES="A toolkit for image loading and pixel buffer manipulation (Xlib component)"
+PKGDEP="gdk-pixbuf x11-lib"
+BUILDDEP="gobject-introspection gtk-doc vim"
+BUILDDEP__RETRO=""
+BUILDDEP__ARMEL="${BUILDDEP__RETRO}"
+BUILDDEP__ARMHF="${BUILDDEP__RETRO}"
+BUILDDEP__I486="${BUILDDEP__RETRO}"
+BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
+BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
+BUILDDEP__PPC64="${BUILDDEP__RETRO}"
+PKGSEC=libs
+
+MESON_AFTER="-Dgtk_docs=true \
+             -Dman=true \
+             -Dgir=true \
+             -Dinstalled_tests=false"
+MESON_AFTER__RETRO=" \
+             -Dgtk_docs=false \
+             -Dman=false \
+             -Dgir=false \
+             -Dinstalled_tests=false"
+MESON_AFTER__ARMEL="${MESON_AFTER__RETRO}"
+MESON_AFTER__ARMHF="${MESON_AFTER__RETRO}"
+MESON_AFTER__I486="${MESON_AFTER__RETRO}"
+MESON_AFTER__LOONGSON2F="${MESON_AFTER__RETRO}"
+MESON_AFTER__POWERPC="${MESON_AFTER__RETRO}"
+MESON_AFTER__PPC64="${MESON_AFTER__RETRO}"
+
+PKGBREAK="gdk-pixbuf<=2.38.2-1"
+PKGREP="gdk-pixbuf<=2.38.2-1"

--- a/extra-libs/gdk-pixbuf-xlib/autobuild/postinst
+++ b/extra-libs/gdk-pixbuf-xlib/autobuild/postinst
@@ -1,0 +1,3 @@
+#! /bin/bash
+echo "Querying GDK Pixbuf loader cache..."
+LD_LIBRARY_PATH=/usr/lib/mesa gdk-pixbuf-query-loaders --update-cache 2>&1 >/dev/null

--- a/extra-libs/gdk-pixbuf-xlib/autobuild/triggers
+++ b/extra-libs/gdk-pixbuf-xlib/autobuild/triggers
@@ -1,0 +1,1 @@
+interest /usr/lib/gdk-pixbuf-2.0/2.10.0/loaders

--- a/extra-libs/gdk-pixbuf-xlib/spec
+++ b/extra-libs/gdk-pixbuf-xlib/spec
@@ -1,0 +1,3 @@
+VER=2.40.2
+SRCS="https://gitlab.gnome.org/Archive/gdk-pixbuf-xlib/-/archive/$VER/gdk-pixbuf-xlib-$VER.tar.gz"
+CHKSUMS="sha256::e7d9b6a8ca53b6500a82ee8d5a1b3c17780740a6ca7bf04a5dabba0fe50bb7ff"

--- a/extra-wm/icewm/autobuild/defines
+++ b/extra-wm/icewm/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=icewm
 PKGSEC=x11
 PKGDES="A lightweighted window manager for the X Window System"
-PKGDEP="gdk-pixbuf x11-lib x11-font x11-app fribidi libsndfile aosc-xdg-menu"
-PKGDEP__RETRO="gdk-pixbuf x11-lib x11-app fribidi aosc-xdg-menu"
+PKGDEP="gdk-pixbuf-xlib x11-lib x11-font x11-app fribidi libsndfile aosc-xdg-menu"
+PKGDEP__RETRO="gdk-pixbuf-xlib x11-lib x11-app fribidi aosc-xdg-menu"
 PKGDEP__ARMEL="${PKGDEP__RETRO}"
 PKGDEP__ARMHF="${PKGDEP__RETRO}"
 PKGDEP__I486="${PKGDEP__RETRO}"

--- a/extra-wm/icewm/spec
+++ b/extra-wm/icewm/spec
@@ -1,3 +1,4 @@
 VER=1.8.3
+REL=1
 SRCTBL="https://github.com/ice-wm/icewm/releases/download/${VER}/icewm-${VER}.tar.lz"
 CHKSUM="sha256::37b151f9977a020cde7ebb2341961cb96c0954c5209fcfd1151cf690746f7fd3"

--- a/extra-x11/xscreensaver/autobuild/defines
+++ b/extra-x11/xscreensaver/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=xscreensaver
 PKGSEC=x11
-PKGDEP="libwww-perl x11-lib libglade appres"
+PKGDEP="libwww-perl x11-lib libglade appres gdk-pixbuf-xlib"
 PKGDEP__RETRO="x11-lib libglade"
 PKGDEP__ARMEL="${PKGDEP__RETRO}"
 PKGDEP__ARMHF="${PKGDEP__RETRO}"

--- a/extra-x11/xscreensaver/spec
+++ b/extra-x11/xscreensaver/spec
@@ -1,4 +1,4 @@
 VER=5.43
-REL=1
-SRCTBL="https://www.jwz.org/xscreensaver/xscreensaver-$VER.tar.gz"
+REL=2
+SRCTBL="https://ftp.osuosl.org/pub/blfs/conglomeration/xscreensaver/xscreensaver-$VER.tar.gz"
 CHKSUM="sha256::158f381d687e8360a6debb0d3af0148d279e853666244f02d628a5a482bce194"

--- a/extra-x11/xscreensaver/spec
+++ b/extra-x11/xscreensaver/spec
@@ -1,4 +1,4 @@
 VER=5.43
 REL=2
-SRCTBL="https://ftp.osuosl.org/pub/blfs/conglomeration/xscreensaver/xscreensaver-$VER.tar.gz"
-CHKSUM="sha256::158f381d687e8360a6debb0d3af0148d279e853666244f02d628a5a482bce194"
+SRCS="https://ftp.osuosl.org/pub/blfs/conglomeration/xscreensaver/xscreensaver-$VER.tar.gz"
+CHKSUMS="sha256::158f381d687e8360a6debb0d3af0148d279e853666244f02d628a5a482bce194"


### PR DESCRIPTION
Topic Description
-----------------

Introduce `gdk-pixbuf-xlib`, which was split from `gdk-pixbuf` with a recent release. Adjust dependencies for reverse dependees.

Package(s) Affected
-------------------

- `gdk-pixbuf-xlib` v2.40.2
- `icewm` v1.8.3-1
- `xscreensaver` v5.43-2

Security Update?
----------------

No

Build Order
-----------

```
gdk-pixbuf-xlib
icewm
xscreensaver
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`