### PR TITLE
poetry: update to 1.1.4

### DIFF
--- a/extra-python/clikit/spec
+++ b/extra-python/clikit/spec
@@ -1,3 +1,3 @@
-VER=0.3.0
-SRCTBL="https://pypi.io/packages/source/c/clikit/clikit-$VER.tar.gz"
-CHKSUM="sha256::b49e0c70577b61fa4458c58e34fe05805f8e9fab0f4d932bed1d61df433e0cbe"
+VER=0.6.2
+SRCS="https://pypi.io/packages/source/c/clikit/clikit-$VER.tar.gz"
+CHKSUMS="sha256::442ee5db9a14120635c5990bcdbfe7c03ada5898291f0c802f77be71569ded59"

--- a/extra-python/crashtest/autobuild/defines
+++ b/extra-python/crashtest/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=crashtest
+PKGSEC=python
+PKGDES="A Python library that makes exceptions handling and inspection easier"
+PKGDEP="python-3"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/crashtest/spec
+++ b/extra-python/crashtest/spec
@@ -1,0 +1,3 @@
+VER=0.3.1
+SRCS="https://pypi.io/packages/source/c/crashtest/crashtest-${VER}.tar.gz"
+CHKSUMS="sha256::42ca7b6ce88b6c7433e2ce47ea884e91ec93104a4b754998be498a8e6c3d37dd"

--- a/extra-python/cryptography/spec
+++ b/extra-python/cryptography/spec
@@ -1,4 +1,3 @@
-VER=2.5
-REL=4
-SRCTBL="https://pypi.io/packages/source/c/cryptography/cryptography-$VER.tar.gz"
-CHKSUM="sha256::4946b67235b9d2ea7d31307be9d5ad5959d6c4a8f98f900157b47abddf698401"
+VER=3.3.1
+SRCS="https://pypi.io/packages/source/c/cryptography/cryptography-$VER.tar.gz"
+CHKSUMS="sha256::7e177e4bea2de937a584b13645cab32f25e3d96fc0bc4a4cf99c27dc77682be6"

--- a/extra-python/distlib/autobuild/defines
+++ b/extra-python/distlib/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=distlib
+PKGSEC=python
+PKGDES="a library which implements low-level functions that relate to packaging and distribution of Python software"
+PKGDEP="python-3 python-2"
+
+ABHOST=noarch
+ABTYPE=python

--- a/extra-python/distlib/autobuild/defines
+++ b/extra-python/distlib/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=distlib
 PKGSEC=python
-PKGDES="a library which implements low-level functions that relate to packaging and distribution of Python software"
+PKGDES="A library which implements low-level functions that relate to packaging and distribution of Python software"
 PKGDEP="python-3 python-2"
 
 ABHOST=noarch

--- a/extra-python/distlib/spec
+++ b/extra-python/distlib/spec
@@ -1,0 +1,3 @@
+VER=0.3.1
+SRCS="https://bitbucket.org/pypa/distlib/get/${VER}.tar.gz"
+CHKSUMS="sha256::01ed9bba4584498c239b604d89f23da1e1e6cfacdc4128ca18e16d0d1bde5595"

--- a/extra-python/jeepney/autobuild/defines
+++ b/extra-python/jeepney/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=jeepney
+PKGSEC=python
+PKGDES="Low-level, pure Python DBus protocol wrapper"
+PKGDEP="python-3 dbus"
+
+ABTYPE=python
+NOPYTHON2=1
+ABHOST=noarch

--- a/extra-python/jeepney/spec
+++ b/extra-python/jeepney/spec
@@ -1,0 +1,3 @@
+VER=0.6.0
+SRCS="https://pypi.io/packages/source/j/jeepney/jeepney-${VER}.tar.gz"
+CHKSUMS="sha256::7d59b6622675ca9e993a6bd38de845051d315f8b0c72cca3aef733a20b648657"

--- a/extra-python/keyring/autobuild/defines
+++ b/extra-python/keyring/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=keyring
 PKGSEC=python
-PKGDEP="pycryptodome pygobject-3 secretstorage entrypoints"
+PKGDEP="python-3 python-2 pycryptodome pygobject-3 secretstorage entrypoints jeepney"
 PKGDES="Store and access your passwords safely"
 
 ABHOST=noarch

--- a/extra-python/keyring/spec
+++ b/extra-python/keyring/spec
@@ -1,4 +1,3 @@
-VER=18.0.0
-REL=2
-SRCTBL="https://pypi.io/packages/source/k/keyring/keyring-$VER.tar.gz"
-CHKSUM="sha256::12833d2b05d2055e0e25931184af9cd6a738f320a2264853cabbd8a3a0f0b65d"
+VER=21.7.0
+SRCS="https://pypi.io/packages/source/k/keyring/keyring-$VER.tar.gz"
+CHKSUMS="sha256::a144f7e1044c897c3976202af868cb0ac860f4d433d5d0f8e750fa1a2f0f0b50"

--- a/extra-python/lockfile/autobuild/defines
+++ b/extra-python/lockfile/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=lockfile
 PKGSEC=python
-PKGDES="A Platform-independent file locking module for Python"
+PKGDES="A platform-independent file locking module for Python"
 PKGDEP="python-3 python-2 pbr"
 
 ABHOST=noarch

--- a/extra-python/lockfile/autobuild/defines
+++ b/extra-python/lockfile/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=lockfile
+PKGSEC=python
+PKGDES="A Platform-independent file locking module for Python"
+PKGDEP="python-3 python-2 pbr"
+
+ABHOST=noarch
+ABTYPE=python

--- a/extra-python/lockfile/spec
+++ b/extra-python/lockfile/spec
@@ -1,0 +1,3 @@
+VER=0.12.2
+SRCS="https://pypi.io/packages/source/l/lockfile/lockfile-${VER}.tar.gz"
+CHKSUMS="sha256::6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799"

--- a/extra-python/pexpect/spec
+++ b/extra-python/pexpect/spec
@@ -1,4 +1,3 @@
-VER=4.6.0
-REL=2
-SRCTBL="https://pypi.io/packages/source/p/pexpect/pexpect-$VER.tar.gz"
-CHKSUM="sha256::2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba"
+VER=4.8.0
+SRCS="https://pypi.io/packages/source/p/pexpect/pexpect-$VER.tar.gz"
+CHKSUMS="sha256::fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"

--- a/extra-python/poetry-core/autobuild/defines
+++ b/extra-python/poetry-core/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=poetry-core
+PKGSEC=python
+PKGDES="Poetry PEP 517 Build Backend"
+PKGDEP="python-3 python-2 typing pathlib2"
+
+ABHOST=noarch
+ABTYPE=python

--- a/extra-python/poetry-core/autobuild/prepare
+++ b/extra-python/poetry-core/autobuild/prepare
@@ -1,0 +1,1 @@
+rm poetry/__init__.py

--- a/extra-python/poetry-core/autobuild/prepare
+++ b/extra-python/poetry-core/autobuild/prepare
@@ -1,2 +1,2 @@
-abinfo "Remove the conflictted __init__.py file against poetry"
+abinfo "Remove the conflicting __init__.py file against poetry"
 rm -v "${SRCDIR}"/poetry/__init__.py

--- a/extra-python/poetry-core/autobuild/prepare
+++ b/extra-python/poetry-core/autobuild/prepare
@@ -1,2 +1,2 @@
 abinfo "Remove the conflictted __init__.py file against poetry"
-rm poetry/__init__.py
+rm -v "${SRCDIR}"/poetry/__init__.py

--- a/extra-python/poetry-core/autobuild/prepare
+++ b/extra-python/poetry-core/autobuild/prepare
@@ -1,1 +1,2 @@
+abinfo "Remove the conflictted __init__.py file against poetry"
 rm poetry/__init__.py

--- a/extra-python/poetry-core/spec
+++ b/extra-python/poetry-core/spec
@@ -1,0 +1,3 @@
+VER=1.0.0
+SRCS="https://pypi.io/packages/source/p/poetry-core/poetry-core-${VER}.tar.gz"
+CHKSUMS="sha256::6a664ff389b9f45382536f8fa1611a0cb4d2de7c5a5c885db1f0c600cd11fbd5"

--- a/extra-python/poetry/autobuild/defines
+++ b/extra-python/poetry/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=poetry
 PKGSEC=python
 PKGDEP="cachecontrol cachy cleo clikit html5lib-python jsonschema pexpect \
-        pkginfo pyparsing pyrsistent toolbelt requests shellingham tomlkit"
+        pkginfo pyparsing pyrsistent toolbelt requests shellingham tomlkit \
+	crashtest pexpect packaging virtualenv keyring poetry-core lockfile"
 BUILDDEP="setuptools"
 PKGDES="Python dependency management and packaging made easy"
 

--- a/extra-python/poetry/spec
+++ b/extra-python/poetry/spec
@@ -1,3 +1,3 @@
-VER=1.0.9
-SRCTBL="https://pypi.io/packages/source/p/poetry/poetry-$VER.tar.gz"
-CHKSUM="sha256::0a4c56983546964b47cbbe0e1b49fef5662277bbf0673e3e350e1215560377ab"
+VER=1.1.4
+SRCS="https://pypi.io/packages/source/p/poetry/poetry-$VER.tar.gz"
+CHKSUMS="sha256::946a5a1173be607c7c5c593358a0fb0c0d6af4400c978929ecdb19c3a37b53a8"

--- a/extra-python/py-filelock/autobuild/defines
+++ b/extra-python/py-filelock/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=py-filelock
 PKGSEC=python
-PKGDES="A platform independent file lock implemention for Python"
+PKGDES="A platform-independent file lock implemention for Python"
 PKGDEP="python-3 python-2"
 
 ABHOST=noarch

--- a/extra-python/py-filelock/autobuild/defines
+++ b/extra-python/py-filelock/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=py-filelock
+PKGSEC=python
+PKGDES="A platform independent file lock implemention for Python"
+PKGDEP="python-3 python-2"
+
+ABHOST=noarch
+ABTYPE=python

--- a/extra-python/py-filelock/spec
+++ b/extra-python/py-filelock/spec
@@ -1,0 +1,3 @@
+VER=3.0.12
+SRCS="https://pypi.io/packages/source/f/filelock/filelock-${VER}.tar.gz"
+CHKSUMS="sha256::18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"

--- a/extra-python/secretstorage/autobuild/defines
+++ b/extra-python/secretstorage/autobuild/defines
@@ -1,7 +1,6 @@
 PKGNAME=secretstorage
 PKGSEC=python
-PKGDEP="dbus-python pycryptodome"
-BUILDDEP="setuptools"
+PKGDEP="python-2 python-3 dbus-python pycryptodome cryptography"
 PKGDES="Securely store passwords and other private data using the SecretService DBus API"
 
 ABHOST=noarch

--- a/extra-python/secretstorage/spec
+++ b/extra-python/secretstorage/spec
@@ -1,4 +1,3 @@
-VER=3.1.2
-SRCTBL="https://pypi.io/packages/source/S/SecretStorage/SecretStorage-$VER.tar.gz"
-CHKSUM="sha256::15da8a989b65498e29be338b3b279965f1b8f09b9668bd8010da183024c8bff6"
-REL=1
+VER=3.3.0
+SRCS="https://pypi.io/packages/source/S/SecretStorage/SecretStorage-$VER.tar.gz"
+CHKSUMS="sha256::30cfdef28829dad64d6ea1ed08f8eff6aa115a77068926bcc9f5225d5a3246aa"

--- a/extra-python/tomlkit/autobuild/beyond
+++ b/extra-python/tomlkit/autobuild/beyond
@@ -1,1 +1,2 @@
+abinfo "Remove the unused unit-test files"
 rm -rv ${PKGDIR}/usr/lib/python*/site-packages/tests

--- a/extra-python/tomlkit/spec
+++ b/extra-python/tomlkit/spec
@@ -1,4 +1,3 @@
-VER=0.6.0
-SRCTBL="https://pypi.io/packages/source/t/tomlkit/tomlkit-$VER.tar.gz"
-CHKSUM="sha256::74f976908030ff164c0aa1edabe3bf83ea004b3daa5b0940b9c86a060c004e9a"
-REL=1
+VER=0.7.0
+SRCS="https://pypi.io/packages/source/t/tomlkit/tomlkit-$VER.tar.gz"
+CHKSUMS="sha256::ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"

--- a/extra-python/tomlkit/spec
+++ b/extra-python/tomlkit/spec
@@ -1,3 +1,4 @@
 VER=0.7.0
+REL=1
 SRCS="https://pypi.io/packages/source/t/tomlkit/tomlkit-$VER.tar.gz"
 CHKSUMS="sha256::ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"

--- a/extra-python/typing/spec
+++ b/extra-python/typing/spec
@@ -1,4 +1,3 @@
-VER=3.6.6
-REL=3
-SRCTBL="https://pypi.io/packages/source/t/typing/typing-$VER.tar.gz"
-CHKSUM="sha256::4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d"
+VER=3.7.4.3
+SRCS="https://pypi.io/packages/source/t/typing/typing-$VER.tar.gz"
+CHKSUMS="sha256::1187fb9c82fd670d10aa07bbb6cfcfe4bdda42d6fab8d5134f04e8c4d0b71cc9"

--- a/extra-python/virtualenv/autobuild/defines
+++ b/extra-python/virtualenv/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=virtualenv
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-2 python-3 py-filelock distlib"
 PKGDES="A tool to create isolated Python environments"
 
 ABHOST=noarch

--- a/extra-python/virtualenv/spec
+++ b/extra-python/virtualenv/spec
@@ -1,4 +1,3 @@
-VER=16.7.9
-SRCTBL="https://github.com/pypa/virtualenv/archive/$VER.tar.gz"
-CHKSUM="sha256::1a002021bace0321ec4f89344c5c2cec6b7cdb9cdc8afea41c8f29a42c3db43b"
-REL=1
+VER=20.2.2
+SRCS="https://pypi.io/packages/source/v/virtualenv/virtualenv-${VER}.tar.gz"
+CHKSUMS="sha256::b7a8ec323ee02fb2312f098b6b4c9de99559b462775bc8fe3627a73706603c1b"


### PR DESCRIPTION
Topic Description
-----------------
Update `poetry` to 1.1.4

Package(s) Affected
-------------------
* `poetry`
* `keyring`
* `jeepney`
* `secretstorage`
* `cryptography`
* `crashtest`
* `virtualenv`
* `tomlkit`
* `typing`
* `poetry-core`
* `pexpect`
* `clikit`
* `py-filelock`
* `distlib`
* `lockfile`

Security Update?
----------------
No


Build Order
-----------
```
poetry
|-crashtest
|-virtualenv
  |-py-filelock
  |-distlib
|-tomlkit
|-pexpect
|-clikit
|-lockfile
|-poetry-core
  \-typing
|-keyring
 |-jeepney
 |-secretstorage
   \-cryptography
```
Architectural Progress
----------------------
- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] Architecture-independent `noarch`