### PR TITLE
aiohttp: update to 3.7.3

### DIFF
--- a/extra-python/aiohttp/autobuild/prepare
+++ b/extra-python/aiohttp/autobuild/prepare
@@ -1,4 +1,0 @@
-abinfo "Converting .pyx file into C file..."
-cd "$SRCDIR"
-sed 's| .install-cython ||g' -i "$SRCDIR"/Makefile
-make cythonize

--- a/extra-python/aiohttp/spec
+++ b/extra-python/aiohttp/spec
@@ -1,3 +1,3 @@
-VER=3.7.2
-SRCTBL="https://pypi.python.org/packages/source/a/aiohttp/aiohttp-3.7.2.tar.gz"
-CHKSUM="sha256::c6da1af59841e6d43255d386a2c4bfb59c0a3b262bdb24325cc969d211be6070"
+VER=3.7.3
+SRCTBL="https://pypi.python.org/packages/source/a/aiohttp/aiohttp-${VER}.tar.gz"
+CHKSUM="sha256::9c1a81af067e72261c9cbe33ea792893e83bc6aa987bfbd6fdc1e5e7b22777c4"

--- a/extra-python/multidict/spec
+++ b/extra-python/multidict/spec
@@ -1,3 +1,3 @@
-VER=5.0.2
+VER=5.1.0
 SRCS="tbl::https://github.com/aio-libs/multidict/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::1847502cb325866a07ef3f3d06553f1dadeaf2de5691a39299720aace6681c71"
+CHKSUMS="sha256::1798708288851b808d2d03ea6046ca51bc44c228aaea12c9643a0a481ee41d8c"

--- a/extra-python/yarl/spec
+++ b/extra-python/yarl/spec
@@ -1,4 +1,3 @@
 VER=1.6.3
-REL=1
 SRCS="tbl::https://github.com/aio-libs/yarl/archive/v${VER}.tar.gz"
 CHKSUMS="sha256::0dd52e81a7079982c33a22098148f2f6973209823418e820f8d9e596d7bacca4"

--- a/extra-python/yarl/spec
+++ b/extra-python/yarl/spec
@@ -1,3 +1,4 @@
 VER=1.6.3
+REL=1
 SRCS="tbl::https://github.com/aio-libs/yarl/archive/v${VER}.tar.gz"
 CHKSUMS="sha256::0dd52e81a7079982c33a22098148f2f6973209823418e820f8d9e596d7bacca4"


### PR DESCRIPTION
Topic Description
-----------------

```
aiohttp => 3.7.3
yarl => 1.6.3-1
multidict => 5.1.0
```

Package(s) Affected
-------------------

aiohttp
yarl
multidict

Security Update?
----------------

No

Build Order
-----------

`multidict -> yarl -> aiohttp`

Architectural Progress
----------------------

- [ ] AMD64 `amd64`: 
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`: 
- [ ] AArch64 `arm64`


Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
