### PR TITLE
xss-lock: new, 0.3.0+git20140302

### DIFF
--- a/extra-utils/xss-lock/autobuild/defines
+++ b/extra-utils/xss-lock/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=xss-lock
+PKGSEC=utils
+PKGDEP="glib xcb-util"
+PKGDES="A tool helps use external locker as X screen saver"

--- a/extra-utils/xss-lock/autobuild/defines
+++ b/extra-utils/xss-lock/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=xss-lock
 PKGSEC=utils
 PKGDEP="glib xcb-util"
-PKGDES="A tool helps use external locker as X screen saver"
+PKGDES="A tool for using external lockers as XScreenSaver replacements"

--- a/extra-utils/xss-lock/spec
+++ b/extra-utils/xss-lock/spec
@@ -1,0 +1,3 @@
+VER=0.3.0+git20140302
+SRCS="git::commit=1e158fb::https://bitbucket.org/raymonad/xss-lock"
+CHKSUMS="SKIP"

--- a/extra-wm/i3-gaps/autobuild/conffiles
+++ b/extra-wm/i3-gaps/autobuild/conffiles
@@ -1,3 +1,2 @@
 /etc/i3/config.keycodes
 /etc/i3/config
-

--- a/extra-wm/i3-gaps/autobuild/defines
+++ b/extra-wm/i3-gaps/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=i3-gaps
 PKGSEC=x11
 PKGDEP="dmenu libev libxkbcommon pango perl-anyevent-i3 perl-json-xs \
         startup-notification xcb-util-cursor xcb-util-keysyms \
-        xcb-util-wm yajl xcb-util-xrm"
+        xcb-util-wm yajl xcb-util-xrm xss-lock"
 PKGSUG="i3lock i3status i3blocks"
 BUILDDEP="graphviz doxygen xmlto"
 PKGDES="Improved tiling WM (window manager), with more features"

--- a/extra-wm/i3-gaps/spec
+++ b/extra-wm/i3-gaps/spec
@@ -1,4 +1,4 @@
 VER=4.17.1
-SRCTBL="https://github.com/Airblader/i3/releases/download/$VER/i3-$VER.tar.bz2"
-CHKSUM="sha256::3a7fd919416d54bfe889d4a459bd27d0729b0150961998bc7063b651b4c90c3f"
-REL=1
+SRCS="tbl::https://github.com/Airblader/i3/releases/download/$VER/i3-$VER.tar.bz2"
+CHKSUMS="sha256::3a7fd919416d54bfe889d4a459bd27d0729b0150961998bc7063b651b4c90c3f"
+REL=2

--- a/extra-wm/i3-gaps/spec
+++ b/extra-wm/i3-gaps/spec
@@ -1,4 +1,3 @@
-VER=4.17.1
-SRCS="tbl::https://github.com/Airblader/i3/releases/download/$VER/i3-$VER.tar.bz2"
-CHKSUMS="sha256::3a7fd919416d54bfe889d4a459bd27d0729b0150961998bc7063b651b4c90c3f"
-REL=2
+VER=4.19
+SRCS="tbl::https://github.com/Airblader/i3/releases/download/$VER/i3-$VER.tar.xz"
+CHKSUMS="sha256::905c8f54cece9fb54a5116792368c2f080aca599d3fb0d8ab44e5e57809c2948"

--- a/extra-wm/i3/autobuild/defines
+++ b/extra-wm/i3/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=i3
 PKGSEC=x11
 PKGDEP="dmenu libev libxkbcommon pango perl-anyevent-i3 perl-json-xs \
         startup-notification xcb-util-cursor xcb-util-keysyms \
-        xcb-util-wm yajl xcb-util-xrm"
+        xcb-util-wm yajl xcb-util-xrm xss-lock"
 PKGSUG="i3lock i3status"
 BUILDDEP="graphviz doxygen xmlto"
 PKGDES="Improved tiling WM (window manager)"

--- a/extra-wm/i3/spec
+++ b/extra-wm/i3/spec
@@ -1,4 +1,4 @@
 VER=4.17.1
-SRCTBL="https://i3wm.org/downloads/i3-$VER.tar.bz2"
-CHKSUM="sha256::1e8fe133a195c29a8e2aa3b1c56e5bc77e7f5534f2dd92e09faabe2ca2d85f45"
-REL=1
+SRCS="tbl::https://i3wm.org/downloads/i3-$VER.tar.bz2"
+CHKSUMS="sha256::1e8fe133a195c29a8e2aa3b1c56e5bc77e7f5534f2dd92e09faabe2ca2d85f45"
+REL=2

--- a/extra-wm/i3/spec
+++ b/extra-wm/i3/spec
@@ -1,4 +1,3 @@
-VER=4.17.1
-SRCS="tbl::https://i3wm.org/downloads/i3-$VER.tar.bz2"
-CHKSUMS="sha256::1e8fe133a195c29a8e2aa3b1c56e5bc77e7f5534f2dd92e09faabe2ca2d85f45"
-REL=2
+VER=4.19
+SRCS="tbl::https://i3wm.org/downloads/i3-$VER.tar.xz"
+CHKSUMS="sha256::aca48b03c0c70607826a1a91333065ff44d61774c152ddc9210fbc1627355872"


### PR DESCRIPTION
Topic Description
-----------------

Add package xss-lock.
Add PKGDEP xss-lock to i3 and i3-gaps

Package(s) Affected
-------------------

`xss-lock`
`i3`
`i3-gaps`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
