### PR TITLE
xfce: update to 4.16

### DIFF
--- a/extra-bases/xfce-base/autobuild/defines
+++ b/extra-bases/xfce-base/autobuild/defines
@@ -17,5 +17,5 @@ PKGDES="Meta package for XFCE desktop environment"
 PKGPROV="xfce4-meta"
 VER_NONE=1
 ABHOST=noarch
-PKGBREAK="xfce-meta<=0-4"
+PKGBREAK="xfce-meta<=0-4 xfce4-mixer"
 PKGREP="xfce-meta<=0-4"

--- a/extra-bases/xfce-base/autobuild/defines
+++ b/extra-bases/xfce-base/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=xfce-base
 PKGSEC=Bases
 PKGDEP="exo xfburn xfce4-taskmanager garcon xfce4-appfinder xfce4-mount-plugin \
-        xfce4-terminal gtk-xfce-engine xfce4-battery-plugin xfce4-mpc-plugin xfce4-time-out-plugin \
+        xfce4-terminal xfce4-battery-plugin xfce4-mpc-plugin xfce4-time-out-plugin \
         xfce4-clipman-plugin xfce4-netload-plugin xfce4-timer-plugin libxfce4util xfce4-cpufreq-plugin \
         xfce4-verve-plugin mousepad xfce4-cpugraph-plugin xfce4-notifyd \
         xfce4-wavelan-plugin orage xfce4-datetime-plugin xfce4-panel xfce4-weather-plugin \

--- a/extra-bases/xfce-base/autobuild/defines
+++ b/extra-bases/xfce-base/autobuild/defines
@@ -11,7 +11,7 @@ PKGDEP="exo xfburn xfce4-taskmanager garcon xfce4-appfinder xfce4-mount-plugin \
         xfce4-fsguard-plugin xfce4-settings xfwm4 thunar-volman xfce4-genmon-plugin \
         xfce4-smartbookmark-plugin xfwm4-themes tumbler xfce4-mailwatch-plugin xfce4-systemload-plugin \
         desktop-base polkit-gnome file-roller evince xfce4-notes-plugin alacarte flexiserver \
-        xfce4-pulseaudio-plugin xfce4-screensaver pavucontrol"
+        xfce4-pulseaudio-plugin xfce4-screensaver pavucontrol catfish"
 PKGDES="Meta package for XFCE desktop environment"
 
 PKGPROV="xfce4-meta"

--- a/extra-bases/xfce-base/autobuild/defines
+++ b/extra-bases/xfce-base/autobuild/defines
@@ -10,8 +10,8 @@ PKGDEP="exo xfburn xfce4-taskmanager garcon xfce4-appfinder xfce4-mount-plugin \
         thunar-archive-plugin xfce4-eyes-plugin xfce4-session xfdesktop thunar-media-tags-plugin \
         xfce4-fsguard-plugin xfce4-settings xfwm4 thunar-volman xfce4-genmon-plugin \
         xfce4-smartbookmark-plugin xfwm4-themes tumbler xfce4-mailwatch-plugin xfce4-systemload-plugin \
-        desktop-base polkit-gnome file-roller evince light-locker alacarte flexiserver \
-        xfce4-pulseaudio-plugin"
+        desktop-base polkit-gnome file-roller evince xfce4-notes-plugin alacarte flexiserver \
+        xfce4-pulseaudio-plugin xfce4-screensaver pavucontrol"
 PKGDES="Meta package for XFCE desktop environment"
 
 PKGPROV="xfce4-meta"

--- a/extra-bases/xfce-base/autobuild/defines
+++ b/extra-bases/xfce-base/autobuild/defines
@@ -17,5 +17,5 @@ PKGDES="Meta package for XFCE desktop environment"
 PKGPROV="xfce4-meta"
 VER_NONE=1
 ABHOST=noarch
-PKGBREAK="xfce-meta<=0-4 xfce4-mixer"
+PKGBREAK="xfce-meta<=0-4 xfce4-mixer xfce4-statusnotifier-plugin"
 PKGREP="xfce-meta<=0-4"

--- a/extra-bases/xfce-base/autobuild/defines
+++ b/extra-bases/xfce-base/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=xfce-base
 PKGSEC=Bases
-PKGDEP="exo xfburn xfce4-mixer xfce4-taskmanager garcon xfce4-appfinder xfce4-mount-plugin \
+PKGDEP="exo xfburn xfce4-taskmanager garcon xfce4-appfinder xfce4-mount-plugin \
         xfce4-terminal gtk-xfce-engine xfce4-battery-plugin xfce4-mpc-plugin xfce4-time-out-plugin \
         xfce4-clipman-plugin xfce4-netload-plugin xfce4-timer-plugin libxfce4util xfce4-cpufreq-plugin \
-        xfce4-notes-plugin xfce4-verve-plugin mousepad xfce4-cpugraph-plugin xfce4-notifyd \
+        xfce4-verve-plugin mousepad xfce4-cpugraph-plugin xfce4-notifyd \
         xfce4-wavelan-plugin orage xfce4-datetime-plugin xfce4-panel xfce4-weather-plugin \
         parole xfce4-power-manager xfce4-whiskermenu-plugin ristretto xfce4-dict \
         xfce4-screenshooter xfce4-xkb-plugin thunar xfce4-diskperf-plugin xfce4-sensors-plugin xfconf \
@@ -11,7 +11,7 @@ PKGDEP="exo xfburn xfce4-mixer xfce4-taskmanager garcon xfce4-appfinder xfce4-mo
         xfce4-fsguard-plugin xfce4-settings xfwm4 thunar-volman xfce4-genmon-plugin \
         xfce4-smartbookmark-plugin xfwm4-themes tumbler xfce4-mailwatch-plugin xfce4-systemload-plugin \
         desktop-base polkit-gnome file-roller evince light-locker alacarte flexiserver \
-        xfce4-pulseaudio-plugin xfce4-statusnotifier-plugin"
+        xfce4-pulseaudio-plugin"
 PKGDES="Meta package for XFCE desktop environment"
 
 PKGPROV="xfce4-meta"

--- a/extra-bases/xfce-base/spec
+++ b/extra-bases/xfce-base/spec
@@ -1,2 +1,2 @@
-VER=1
+VER=2
 DUMMYSRC=1

--- a/extra-libs/gtksourceview-3/spec
+++ b/extra-libs/gtksourceview-3/spec
@@ -1,3 +1,3 @@
-VER=3.24.8
-SRCTBL="https://download.gnome.org/sources/gtksourceview/${VER:0:4}/gtksourceview-$VER.tar.xz"
-CHKSUM="sha256::1e9bb8ff190db705deb916dd23ff681f0e8803aec407bf0fd64c7e615ac436fe"
+VER=3.24.11
+SRCS="https://download.gnome.org/sources/gtksourceview/${VER:0:4}/gtksourceview-$VER.tar.xz"
+CHKSUMS="whirlpool::9a4772814afca3ae9fcdd7362948db7363be94bf151db23099eba3f570ddc488dd560c089fd614cd56e4a388062bc122732d44c4571c888c2a51bd5bd79e36d3"

--- a/extra-xfce/catfish/spec
+++ b/extra-xfce/catfish/spec
@@ -1,4 +1,3 @@
-VER=1.4.13
-SRCTBL="https://git.xfce.org/apps/catfish/snapshot/catfish-$VER.tar.gz"
-CHKSUM="sha256::4761a8e4c7fb3df1c0299a8d543d7144e492e88cdcd8fe4b3062ffa43c7c02ad"
-REL=2
+VER=4.15.0
+SRCS="https://archive.xfce.org/src/apps/catfish/${VER%.*}/catfish-$VER.tar.bz2"
+CHKSUMS="whirlpool::858c90d8a56651e1b26c072aa96c4d705d29c43740f88d76f4d7639825a79f93b82f8f38578c8fd82e493345eab2769a908ad7bb7abdf5674c8244f87f970215"

--- a/extra-xfce/exo/spec
+++ b/extra-xfce/exo/spec
@@ -1,4 +1,3 @@
-VER=0.12.11
-SRCTBL="https://archive.xfce.org/src/xfce/exo/${VER%.*}/exo-$VER.tar.bz2"
-CHKSUM="sha256::ec892519c08a67f3e0a1f0f8d43446e26871183e5aa6be7f82e214f388d1e5b6"
-REL=1
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/exo/${VER%.*}/exo-$VER.tar.bz2"
+CHKSUMS="sha256::1975b00eed9a8aa1f899eab2efaea593731c19138b83fdff2f13bdca5275bacc"

--- a/extra-xfce/garcon/spec
+++ b/extra-xfce/garcon/spec
@@ -1,3 +1,3 @@
-VER=0.6.4
-SRCTBL="https://archive.xfce.org/src/xfce/garcon/${VER:0:3}/garcon-$VER.tar.bz2"
-CHKSUM="sha256::d75e4753037a74733c07b71b8db7a656d869869f0f107f6411a306bbc87a762d"
+VER=0.8.0
+SRCS="https://archive.xfce.org/src/xfce/garcon/${VER:0:3}/garcon-$VER.tar.bz2"
+CHKSUMS="sha256::4811d89ee5bc48dbdeffd69fc3eec6c112bbf01fde98a9e848335b374a4aa1bb"

--- a/extra-xfce/gigolo/spec
+++ b/extra-xfce/gigolo/spec
@@ -1,3 +1,3 @@
-VER=0.5.0
-SRCTBL="https://archive.xfce.org/src/apps/gigolo/${VER:0:3}/gigolo-$VER.tar.bz2"
-CHKSUM="sha256::97a301aff012a143d0b99e7ecbb27084d3872aa203a74745e8357aab3a1880dc"
+VER=0.5.1
+SRCS="https://archive.xfce.org/src/apps/gigolo/${VER:0:3}/gigolo-$VER.tar.bz2"
+CHKSUMS="whirlpool::3a76ae94e5bca0928ada3ba1952ab5b9d4e923e3e6782f2377dd40c02205eff31d01b90436114f1cc7ad67982bb66ee69b36eb0b0a6431c5558ca70f59491117"

--- a/extra-xfce/gtk-xfce-engine/autobuild/defines
+++ b/extra-xfce/gtk-xfce-engine/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=gtk-xfce-engine
-PKGDES="GTK+ theme engine for Xfce"
-PKGDEP="gtk-2 gtk-3"
-PKGSEC=xfce
-AUTOTOOLS_AFTER="--enable-gtk3 --enable-gtk2"
-
-PKGEPOCH=1
-RECONF=0

--- a/extra-xfce/gtk-xfce-engine/spec
+++ b/extra-xfce/gtk-xfce-engine/spec
@@ -1,3 +1,0 @@
-VER=3.2.0
-SRCTBL="https://archive.xfce.org/src/xfce/gtk-xfce-engine/${VER%.*}/gtk-xfce-engine-$VER.tar.bz2"
-CHKSUM="sha256::875c9c3bda96faf050a2224649cc42129ffb662c4de33add8c0fd1fb860b47ed"

--- a/extra-xfce/libxfce4ui/autobuild/defines
+++ b/extra-xfce/libxfce4ui/autobuild/defines
@@ -1,9 +1,7 @@
 PKGNAME=libxfce4ui
 PKGDES="Common UI library for Xfce"
-PKGDEP="libxfce4util gtk-2 gtk-3 xfconf startup-notification"
+PKGDEP="libxfce4util gtk-3 xfconf startup-notification libgtop libepoxy"
 BUILDDEP="intltool gtk-doc gobject-introspection vala"
 PKGSEC=xfce
 
-AUTOTOOLS_AFTER="--enable-gtk-doc \
-                 --enable-vala=no"
 RECONF=0

--- a/extra-xfce/libxfce4ui/autobuild/defines
+++ b/extra-xfce/libxfce4ui/autobuild/defines
@@ -4,4 +4,5 @@ PKGDEP="libxfce4util gtk-3 xfconf startup-notification libgtop libepoxy"
 BUILDDEP="intltool gtk-doc gobject-introspection vala"
 PKGSEC=xfce
 
+AUTOTOOLS_AFTER="--enable-vala=no"
 RECONF=0

--- a/extra-xfce/libxfce4ui/spec
+++ b/extra-xfce/libxfce4ui/spec
@@ -1,4 +1,3 @@
-VER=4.14.1
-SRCTBL="https://archive.xfce.org/src/xfce/libxfce4ui/${VER%.*}/libxfce4ui-$VER.tar.bz2"
-CHKSUM="sha256::c449075eaeae4d1138d22eeed3d2ad7032b87fb8878eada9b770325bed87f2da"
-REL=2
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/libxfce4ui/${VER%.*}/libxfce4ui-$VER.tar.bz2"
+CHKSUMS="sha256::8b06c9e94f4be88a9d87c47592411b6cbc32073e7af9cbd64c7b2924ec90ceaa"

--- a/extra-xfce/libxfce4util/autobuild/defines
+++ b/extra-xfce/libxfce4util/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libxfce4util
 PKGDES="Utility library for the Xfce desktop environment"
 PKGDEP="glib"
-BUILDDEP="intltool gtk-doc gobject-introspection"
+BUILDDEP="vala intltool gtk-doc gobject-introspection"
 PKGSEC=xfce
 
 AUTOTOOLS_AFTER="--enable-gtk-doc"

--- a/extra-xfce/libxfce4util/spec
+++ b/extra-xfce/libxfce4util/spec
@@ -1,3 +1,3 @@
-VER=4.14.0
-SRCTBL="https://archive.xfce.org/src/xfce/libxfce4util/${VER%.*}/libxfce4util-$VER.tar.bz2"
-CHKSUM="sha256::32ad79b7992ec3fd863e8ff2f03eebda8740363ef9d7d910a35963ac1c1a6324"
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/libxfce4util/${VER%.*}/libxfce4util-${VER}.tar.bz2"
+CHKSUMS="sha256::60598d745d1fc81ff5ad3cecc3a8d1b85990dd22023e7743f55abd87d8b55b83"

--- a/extra-xfce/mousepad/autobuild/patches/0001-mousepad-fix-the-crash-when-call-search-bar-if-only-one-tab.patch
+++ b/extra-xfce/mousepad/autobuild/patches/0001-mousepad-fix-the-crash-when-call-search-bar-if-only-one-tab.patch
@@ -1,0 +1,31 @@
+From 145626141303120f5a772fe0bc809d04b8f40e1d Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Tue, 5 Jan 2021 00:40:18 -0700
+Subject: [PATCH] mousepad-window: fix a crash where...
+
+... if there is only one document, the search function will crash the
+program
+---
+ mousepad/mousepad-window.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/mousepad/mousepad-window.c b/mousepad/mousepad-window.c
+index 7be0fa4..078e2bc 100644
+--- a/mousepad/mousepad-window.c
++++ b/mousepad/mousepad-window.c
+@@ -2389,6 +2389,12 @@ mousepad_window_notebook_removed (GtkNotebook     *notebook,
+   mousepad_disconnect_by_func (document->textview, mousepad_window_menu_textview_popup, window);
+   mousepad_disconnect_by_func (document->textview, mousepad_window_enable_edit_actions, window);
+ 
++  /* reset the reference to NULL to avoid illegal memory access */
++  if (window->previous == document)
++    {
++      window->previous = NULL;
++    }
++
+   /* window contains no tabs: save geometry and destroy it */
+   if (gtk_notebook_get_n_pages (notebook) == 0)
+     {
+-- 
+2.30.0
+

--- a/extra-xfce/mousepad/spec
+++ b/extra-xfce/mousepad/spec
@@ -1,4 +1,3 @@
-VER=0.4.2
-SRCTBL="https://archive.xfce.org/src/apps/mousepad/${VER%.*}/mousepad-$VER.tar.bz2"
-CHKSUM="sha256::84c02adfca7f8b33b9466a306ded72fb9f38f93c9edb78660343854c4a3aded7"
-REL=1
+VER=0.5.1
+SRCS="https://archive.xfce.org/src/apps/mousepad/${VER%.*}/mousepad-$VER.tar.bz2"
+CHKSUMS="sha256::3d2e277b1ae82dd0f0fa25e27169491fc38c2b70a9a624f2ea472604b317a582"

--- a/extra-xfce/orage/spec
+++ b/extra-xfce/orage/spec
@@ -1,4 +1,4 @@
 VER=4.12.1
-REL=5
-SRCTBL="https://archive.xfce.org/src/apps/orage/${VER%.*}/orage-$VER.tar.bz2"
-CHKSUM="sha256::3cf9aa441ae83c8688865f82217025cdf3ebaa152cce4571777b8c2aa8dd9062"
+REL=6
+SRCS="https://archive.xfce.org/src/apps/orage/${VER%.*}/orage-$VER.tar.bz2"
+CHKSUMS="sha256::3cf9aa441ae83c8688865f82217025cdf3ebaa152cce4571777b8c2aa8dd9062"

--- a/extra-xfce/parole/spec
+++ b/extra-xfce/parole/spec
@@ -1,4 +1,3 @@
-VER=1.0.5
-REL=2
-GITSRC="https://github.com/xfce-mirror/parole"
-GITCO="tags/parole-$VER"
+VER=4.15.0
+SRCS="https://archive.xfce.org/src/apps/parole/${VER%.*}/parole-$VER.tar.bz2"
+CHKSUMS="sha256::014431dc565dab4bf4760ec7c2ea7e787523f112aabc99888027213ebecc1f10"

--- a/extra-xfce/ristretto/spec
+++ b/extra-xfce/ristretto/spec
@@ -1,4 +1,4 @@
 VER=0.10.0
-SRCTBL="https://archive.xfce.org/src/apps/ristretto/${VER%.*}/ristretto-$VER.tar.bz2"
-CHKSUM="sha256::16225dd74245eb6e0f82b9c72c6112f161bb8d8b11f3fc77277b7bc3432d4769"
-REL=1
+SRCS="https://archive.xfce.org/src/apps/ristretto/${VER%.*}/ristretto-$VER.tar.bz2"
+CHKSUMS="sha256::16225dd74245eb6e0f82b9c72c6112f161bb8d8b11f3fc77277b7bc3432d4769"
+REL=2

--- a/extra-xfce/thunar-archive-plugin/spec
+++ b/extra-xfce/thunar-archive-plugin/spec
@@ -1,3 +1,4 @@
 VER=0.4.0
-SRCTBL="https://archive.xfce.org/src/thunar-plugins/thunar-archive-plugin/${VER%.*}/thunar-archive-plugin-$VER.tar.bz2"
-CHKSUM="sha256::bf82fa86a388124eb3c4854249c30712b2922e61789607268ee14548549b3115"
+SRCS="https://archive.xfce.org/src/thunar-plugins/thunar-archive-plugin/${VER%.*}/thunar-archive-plugin-$VER.tar.bz2"
+CHKSUMS="sha256::bf82fa86a388124eb3c4854249c30712b2922e61789607268ee14548549b3115"
+REL=1

--- a/extra-xfce/thunar-media-tags-plugin/spec
+++ b/extra-xfce/thunar-media-tags-plugin/spec
@@ -1,3 +1,4 @@
 VER=0.3.0
-SRCTBL="https://archive.xfce.org/src/thunar-plugins/thunar-media-tags-plugin/${VER%.*}/thunar-media-tags-plugin-$VER.tar.bz2"
-CHKSUM="sha256::e265c4415abac40337cc5566c6f706efcf0be4e97723abe22ba8b874c93a591b"
+SRCS="https://archive.xfce.org/src/thunar-plugins/thunar-media-tags-plugin/${VER%.*}/thunar-media-tags-plugin-$VER.tar.bz2"
+CHKSUMS="sha256::e265c4415abac40337cc5566c6f706efcf0be4e97723abe22ba8b874c93a591b"
+REL=1

--- a/extra-xfce/thunar-shares-plugin/spec
+++ b/extra-xfce/thunar-shares-plugin/spec
@@ -1,3 +1,4 @@
 VER=0.3.1
-SRCTBL="https://archive.xfce.org/src/thunar-plugins/thunar-shares-plugin/${VER%.*}/thunar-shares-plugin-$VER.tar.bz2"
-CHKSUM="sha256::dc1d8c7caa727e76d033d4653dc0742613f57a1711d0050900659c90a84452a0"
+SRCS="https://archive.xfce.org/src/thunar-plugins/thunar-shares-plugin/${VER%.*}/thunar-shares-plugin-$VER.tar.bz2"
+CHKSUMS="sha256::dc1d8c7caa727e76d033d4653dc0742613f57a1711d0050900659c90a84452a0"
+REL=1

--- a/extra-xfce/thunar-vcs-plugin/spec
+++ b/extra-xfce/thunar-vcs-plugin/spec
@@ -1,3 +1,4 @@
 VER=0.2.0
-SRCTBL="https://archive.xfce.org/src/thunar-plugins/thunar-vcs-plugin/${VER%.*}/thunar-vcs-plugin-$VER.tar.bz2"
-CHKSUM="sha256::368916d4c3d40862bf7cd1b3000c801c7db801ec88a236f1d8dd44ef780b4db8"
+SRCS="https://archive.xfce.org/src/thunar-plugins/thunar-vcs-plugin/${VER%.*}/thunar-vcs-plugin-$VER.tar.bz2"
+CHKSUMS="sha256::368916d4c3d40862bf7cd1b3000c801c7db801ec88a236f1d8dd44ef780b4db8"
+REL=1

--- a/extra-xfce/thunar-volman/spec
+++ b/extra-xfce/thunar-volman/spec
@@ -1,4 +1,3 @@
-VER=0.9.5
-SRCTBL="https://archive.xfce.org/src/xfce/thunar-volman/${VER%.*}/thunar-volman-$VER.tar.bz2"
-CHKSUM="sha256::7ea7c6693334f2248cf399586af8974dfb7db9aad685ee31ac100e62e19a1837"
-REL=1
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/thunar-volman/${VER%.*}/thunar-volman-$VER.tar.bz2"
+CHKSUMS="whirlpool::9f7c9b1424fb899f23293271edc9f82429fb661d5cf0dd6e0219166016ea67a7bfc67872c50f16886097eafa31bddac0a1c3d29402dc78f16a7bb2d26c1b046d"

--- a/extra-xfce/thunar/spec
+++ b/extra-xfce/thunar/spec
@@ -1,3 +1,3 @@
-VER=1.8.15
-SRCTBL="https://archive.xfce.org/src/xfce/thunar/${VER%.*}/thunar-$VER.tar.bz2"
-CHKSUM="sha256::7624560cf21f13869804947042610aab22075146b711593f11ceb9e494277c93"
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/thunar/${VER%.*}/thunar-$VER.tar.bz2"
+CHKSUMS="sha256::6277c448116a91ebfa564972645d8d79ef69864992a02bb164b7b13f98fdfd9b"

--- a/extra-xfce/tumbler/spec
+++ b/extra-xfce/tumbler/spec
@@ -1,3 +1,3 @@
-VER=0.2.9
-SRCTBL="https://archive.xfce.org/src/xfce/tumbler/${VER%.*}/tumbler-$VER.tar.bz2"
-CHKSUM="sha256::6508906f03e5a6ae3f6503b71b056df47d336d5504f39df6ce0bb9c5248007b6"
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/tumbler/${VER%.*}/tumbler-$VER.tar.bz2"
+CHKSUMS="sha256::9b0b7fed0c64041733d490b1b307297984629d0dd85369749617a8766850af66"

--- a/extra-xfce/xfburn/spec
+++ b/extra-xfce/xfburn/spec
@@ -1,3 +1,4 @@
 VER=0.6.2
-SRCTBL="https://archive.xfce.org/src/apps/xfburn/${VER%.*}/xfburn-$VER.tar.bz2"
-CHKSUM="sha256::83416e132e9bb31cd52fdc41460f96efa9ed57a290ec65f09714b83bb3d00327"
+SRCS="https://archive.xfce.org/src/apps/xfburn/${VER%.*}/xfburn-$VER.tar.bz2"
+CHKSUMS="sha256::83416e132e9bb31cd52fdc41460f96efa9ed57a290ec65f09714b83bb3d00327"
+REL=1

--- a/extra-xfce/xfce4-appfinder/spec
+++ b/extra-xfce/xfce4-appfinder/spec
@@ -1,4 +1,3 @@
-VER=4.14.0
-SRCTBL="https://archive.xfce.org/src/xfce/xfce4-appfinder/${VER%.*}/xfce4-appfinder-$VER.tar.bz2"
-CHKSUM="sha256::7ec175d4954fceb2e76cbfbca76ac4a4f53fe799d097a14117e7de68e88a4d98"
-REL=1
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/xfce4-appfinder/${VER%.*}/xfce4-appfinder-$VER.tar.bz2"
+CHKSUMS="sha256::37b92aaaeeec8220ed23163cf89321168d3b49e0c48b4c10f12dc4a21fdf0954"

--- a/extra-xfce/xfce4-battery-plugin/spec
+++ b/extra-xfce/xfce4-battery-plugin/spec
@@ -1,4 +1,4 @@
 VER=1.1.3
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-battery-plugin/${VER%.*}/xfce4-battery-plugin-$VER.tar.bz2"
-CHKSUM="sha256::12be0a44d16bd1e1618513ee64f946814925872db7d1c1188ab1454b00d040a3"
-REL=1
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-battery-plugin/${VER%.*}/xfce4-battery-plugin-$VER.tar.bz2"
+CHKSUMS="sha256::12be0a44d16bd1e1618513ee64f946814925872db7d1c1188ab1454b00d040a3"
+REL=2

--- a/extra-xfce/xfce4-clipman-plugin/spec
+++ b/extra-xfce/xfce4-clipman-plugin/spec
@@ -1,3 +1,3 @@
-VER=1.4.4
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-clipman-plugin/${VER%.*}/xfce4-clipman-plugin-$VER.tar.bz2"
-CHKSUM="sha256::08e14c5d0fcee9adb4bc77efc0ab4af2b12b3fe1ee5e2121fc60e877ac9c29a0"
+VER=1.6.1
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-clipman-plugin/${VER%.*}/xfce4-clipman-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::96b95c793132d60d10a06c855d632b397d00bf4cceeaab394ee8264128f6d9e91c42ceb96c82388ef8de1e45478fd4b8d1b28f63c2941d62f44e583e55b1b0df"

--- a/extra-xfce/xfce4-cpufreq-plugin/spec
+++ b/extra-xfce/xfce4-cpufreq-plugin/spec
@@ -1,3 +1,3 @@
-VER=1.2.1
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-cpufreq-plugin/${VER%.*}/xfce4-cpufreq-plugin-$VER.tar.bz2"
-CHKSUM="sha256::c5e044c0dc401d2066f208a3df82a588b3e51ff01425f155d0a1d0f8fce8f5b5"
+VER=1.2.2
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-cpufreq-plugin/${VER%.*}/xfce4-cpufreq-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::459651faceda827568b72e1836a60e4ee0704af42fae7cde66e5627bde058ca4d4eedf28673c4ed2772a47652b296b40587dbcfcafc2589616ad3ff1e36d5848"

--- a/extra-xfce/xfce4-cpugraph-plugin/spec
+++ b/extra-xfce/xfce4-cpugraph-plugin/spec
@@ -1,3 +1,3 @@
-VER=1.1.0
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-cpugraph-plugin/${VER%.*}/xfce4-cpugraph-plugin-$VER.tar.bz2"
-CHKSUM="sha256::3ece0a24e55827e0d9b6314129906da60513acdc1748d9dece9f50526e906ba4"
+VER=1.2.0
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-cpugraph-plugin/${VER%.*}/xfce4-cpugraph-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::95e597aa0627617a1a55753b08cc04c82955ca26cfec8d1f6a03e9dd9af3ef331a859f6f679f5a82fe25332de73290c8df6e7c5eb0bc3a4da09ed41d4d78c309"

--- a/extra-xfce/xfce4-datetime-plugin/spec
+++ b/extra-xfce/xfce4-datetime-plugin/spec
@@ -1,3 +1,3 @@
-VER=0.8.0
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-datetime-plugin/${VER%.*}/xfce4-datetime-plugin-$VER.tar.bz2"
-CHKSUM="sha256::cd358bc2ff0707b8ef1504396a19b0a27f802c2ec7bceb5cebe2c7baf6adebd4"
+VER=0.8.1
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-datetime-plugin/${VER%.*}/xfce4-datetime-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::56158f93d9af1b4baee6eaf4d7f13e7e92c0d59fdf842db69c5cfa3a6d9f207cb0e804a255595e1303bd8b8b22ab633767c63fe580b8badf7c56242ce4825717"

--- a/extra-xfce/xfce4-dev-tools/spec
+++ b/extra-xfce/xfce4-dev-tools/spec
@@ -1,3 +1,3 @@
-VER=4.14.0
-SRCTBL="https://archive.xfce.org/src/xfce/xfce4-dev-tools/${VER%.*}/xfce4-dev-tools-$VER.tar.bz2"
-CHKSUM="sha256::2c9eb8e0fe23e47dc31411a93b683fd1b7a49140e9163f0aab9e94a3d8a0b5fd"
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/xfce4-dev-tools/${VER%.*}/xfce4-dev-tools-$VER.tar.bz2"
+CHKSUMS="sha256::f50b3070e66f3ebdf331744dd1ec5e1af5de333965d491e15ce05545e8eb4f04"

--- a/extra-xfce/xfce4-dict/spec
+++ b/extra-xfce/xfce4-dict/spec
@@ -1,4 +1,3 @@
-VER=0.8.3
-REL=1
-GITSRC="https://github.com/xfce-mirror/xfce4-dict"
-GITCO="tags/xfce4-dict-$VER"
+VER=0.8.4
+SRCS="https://archive.xfce.org/src/apps/xfce4-dict/${VER%.*}/xfce4-dict-$VER.tar.bz2"
+CHKSUMS="whirlpool::a3d40004f4e042d108b9001f0320f84dde447954d71824ff885c3fa5c23d217a7e5bcd658c0f58d9c953bcde9dcf23beb7552fa8f3c9d22b3bb50350b82f8edd"

--- a/extra-xfce/xfce4-diskperf-plugin/spec
+++ b/extra-xfce/xfce4-diskperf-plugin/spec
@@ -1,3 +1,3 @@
-VER=2.6.2
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-diskperf-plugin/${VER%.*}/xfce4-diskperf-plugin-$VER.tar.bz2"
-CHKSUM="sha256::fd2e9843da5822de96a7829e50ba496c34a50fb8492d5b5f792558c6b7ce9644"
+VER=2.6.3
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-diskperf-plugin/${VER%.*}/xfce4-diskperf-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::e2111cea0d6634399b3a6fd36c37c2ea0bfe8b3d77160358c696f4817085bcc67406e95037e611f1269c47ea2be03d97cacf2ad3a5e84ed0795e28cfd30dde8d"

--- a/extra-xfce/xfce4-eyes-plugin/spec
+++ b/extra-xfce/xfce4-eyes-plugin/spec
@@ -1,3 +1,4 @@
 VER=4.5.1
 SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-eyes-plugin/${VER%.*}/xfce4-eyes-plugin-$VER.tar.bz2"
 CHKSUM="sha256::4db780178e529391d53da180e49386904e69a5a33b3bd5185835d0a7e6ff5ac5"
+REL=1

--- a/extra-xfce/xfce4-fsguard-plugin/spec
+++ b/extra-xfce/xfce4-fsguard-plugin/spec
@@ -1,3 +1,3 @@
-VER=1.1.1
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-fsguard-plugin/${VER%.*}/xfce4-fsguard-plugin-$VER.tar.bz2"
-CHKSUM="sha256::d6d05d0a90a68453d65cdceec5ca7eeaef864393ab62eef532a7ba58f374d516"
+VER=1.1.2
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-fsguard-plugin/${VER%.*}/xfce4-fsguard-plugin-$VER.tar.bz2"
+CHKSUM="whirlpool::617f893385a983dbd0be3a9821c3a03597d2a3917f1187c3145094515803d9e0b24b39b91a8b831ab30394eb3642b3ac3ce72c98329ead257dc25623a4a3cd0a"

--- a/extra-xfce/xfce4-fsguard-plugin/spec
+++ b/extra-xfce/xfce4-fsguard-plugin/spec
@@ -1,3 +1,3 @@
 VER=1.1.2
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-fsguard-plugin/${VER%.*}/xfce4-fsguard-plugin-$VER.tar.bz2"
-CHKSUM="whirlpool::617f893385a983dbd0be3a9821c3a03597d2a3917f1187c3145094515803d9e0b24b39b91a8b831ab30394eb3642b3ac3ce72c98329ead257dc25623a4a3cd0a"
+CHKSUMS="whirlpool::617f893385a983dbd0be3a9821c3a03597d2a3917f1187c3145094515803d9e0b24b39b91a8b831ab30394eb3642b3ac3ce72c98329ead257dc25623a4a3cd0a"

--- a/extra-xfce/xfce4-genmon-plugin/spec
+++ b/extra-xfce/xfce4-genmon-plugin/spec
@@ -1,3 +1,3 @@
-VER=4.0.2
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-genmon-plugin/${VER%.*}/xfce4-genmon-plugin-$VER.tar.bz2"
-CHKSUM="sha256::256c22526f61aabf43b91b903b976c13e56198657667df443cdb06b31fbf23aa"
+VER=4.1.0
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-genmon-plugin/${VER%.*}/xfce4-genmon-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::056efe880a7bd94af02bac78ed7b17eacc62cc53e7aee7fea05d2260a790e76369f2e18b4a62f79fb9fde04f74b579f03ae9baedc16443cbaacf2dd95d45893b"

--- a/extra-xfce/xfce4-mailwatch-plugin/spec
+++ b/extra-xfce/xfce4-mailwatch-plugin/spec
@@ -1,4 +1,3 @@
-VER=1.2.0
-REL=5
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-mailwatch-plugin/${VER%.*}/xfce4-mailwatch-plugin-$VER.tar.bz2"
-CHKSUM="sha256::624acc8229a8593c0dfeb28f883f4958119a715cc81cecdbaf29efc8ab1edcad"
+VER=1.3.0
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-mailwatch-plugin/${VER%.*}/xfce4-mailwatch-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::53b6cf48084423c0748c3dd78f3b6a67b970413271b91e7043fad80ca8d2b0156455ef1ae3a85f8b5dd98b6fce932865cba011d481e7de1cb4d0ed01abff7ead"

--- a/extra-xfce/xfce4-mixer/autobuild/defines
+++ b/extra-xfce/xfce4-mixer/autobuild/defines
@@ -1,6 +1,0 @@
-PKGNAME=xfce4-mixer
-PKGDES="Volume control and audio mixer for Xfce"
-PKGDEP="gst-plugins-base-0-10 libunique xfce4-panel keybinder"
-BUILDDEP="intltool"
-PKGSEC=xfce
-RECONF=0

--- a/extra-xfce/xfce4-mixer/autobuild/prepare
+++ b/extra-xfce/xfce4-mixer/autobuild/prepare
@@ -1,1 +1,0 @@
-export CFLAGS="${CFLAGS} -I/usr/include/dbus-1.0"

--- a/extra-xfce/xfce4-mixer/spec
+++ b/extra-xfce/xfce4-mixer/spec
@@ -1,4 +1,0 @@
-VER=4.11.0
-REL=7
-SRCTBL="https://archive.xfce.org/src/apps/xfce4-mixer/${VER%.*}/xfce4-mixer-$VER.tar.bz2"
-CHKSUM="sha256::fb0c1df201ed1130f54f15b914cbe5a59286e994a137acda5609570c57112de2"

--- a/extra-xfce/xfce4-mount-plugin/spec
+++ b/extra-xfce/xfce4-mount-plugin/spec
@@ -1,3 +1,3 @@
-VER=1.1.3
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-mount-plugin/${VER%.*}/xfce4-mount-plugin-$VER.tar.bz2"
-CHKSUM="sha256::aae5bd6b984bc78daf6b5fb9d15817a27253674a4264ad60f62ccb1aa194911e"
+VER=1.1.5
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-mount-plugin/${VER%.*}/xfce4-mount-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::a0827417295b2b411af4d688393b0c4cc93eefbf170cf7189f7021cd9433b081c228a56f96aac1c19e0ab9c5bf9bc03ba73ce1f828373fbb3b5b670c9c308255"

--- a/extra-xfce/xfce4-mpc-plugin/spec
+++ b/extra-xfce/xfce4-mpc-plugin/spec
@@ -1,3 +1,4 @@
 VER=0.5.2
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-mpc-plugin/${VER%.*}/xfce4-mpc-plugin-$VER.tar.bz2"
-CHKSUM="sha256::eefe78b7b6b95312b3a52814b7f632dc92970c1b3e9535de616315749bf67760"
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-mpc-plugin/${VER%.*}/xfce4-mpc-plugin-$VER.tar.bz2"
+CHKSUMS="sha256::eefe78b7b6b95312b3a52814b7f632dc92970c1b3e9535de616315749bf67760"
+REL=1

--- a/extra-xfce/xfce4-netload-plugin/spec
+++ b/extra-xfce/xfce4-netload-plugin/spec
@@ -1,3 +1,4 @@
 VER=1.3.2
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-netload-plugin/${VER%.*}/xfce4-netload-plugin-$VER.tar.bz2"
-CHKSUM="sha256::22e40425cfe1e07b01fe275b1afddc7c788af34d9c2c7e2842166963cb41215d"
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-netload-plugin/${VER%.*}/xfce4-netload-plugin-$VER.tar.bz2"
+CHKSUMS="sha256::22e40425cfe1e07b01fe275b1afddc7c788af34d9c2c7e2842166963cb41215d"
+REL=1

--- a/extra-xfce/xfce4-notes-plugin/autobuild/defines
+++ b/extra-xfce/xfce4-notes-plugin/autobuild/defines
@@ -5,3 +5,4 @@ BUILDDEP="intltool"
 PKGDES="Note taking plugin for the Xfce panel"
 
 RECONF=1
+AUTOTOOLS_AFTER="--enable-maintainer-mode"

--- a/extra-xfce/xfce4-notes-plugin/autobuild/defines
+++ b/extra-xfce/xfce4-notes-plugin/autobuild/defines
@@ -6,3 +6,4 @@ PKGDES="Note taking plugin for the Xfce panel"
 
 RECONF=1
 AUTOTOOLS_AFTER="--enable-maintainer-mode"
+ABSHADOW=0

--- a/extra-xfce/xfce4-notes-plugin/autobuild/defines
+++ b/extra-xfce/xfce4-notes-plugin/autobuild/defines
@@ -4,4 +4,4 @@ PKGDEP="libunique xfce4-panel"
 BUILDDEP="intltool"
 PKGDES="Note taking plugin for the Xfce panel"
 
-RECONF=0
+RECONF=1

--- a/extra-xfce/xfce4-notes-plugin/spec
+++ b/extra-xfce/xfce4-notes-plugin/spec
@@ -1,4 +1,4 @@
 VER=1.8.1
-REL=3
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-notes-plugin/${VER%.*}/xfce4-notes-plugin-$VER.tar.bz2"
-CHKSUM="sha256::07a4c3e71431c24f97d2e270452dd0fa51ff0bdb6219a13a20d0bfa8d9de54b2"
+REL=4
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-notes-plugin/${VER%.*}/xfce4-notes-plugin-$VER.tar.bz2"
+CHKSUMS="sha256::07a4c3e71431c24f97d2e270452dd0fa51ff0bdb6219a13a20d0bfa8d9de54b2"

--- a/extra-xfce/xfce4-notes-plugin/spec
+++ b/extra-xfce/xfce4-notes-plugin/spec
@@ -1,4 +1,4 @@
-VER=1.8.1
-REL=4
-SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-notes-plugin/${VER%.*}/xfce4-notes-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::07a4c3e71431c24f97d2e270452dd0fa51ff0bdb6219a13a20d0bfa8d9de54b2"
+VER=1.8.1+git20201231
+#SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-notes-plugin/${VER%.*}/xfce4-notes-plugin-$VER.tar.bz2"
+SRCS="git::commit=b38052b13d0ab6fc9869e9a83c65721423432bbb::https://gitlab.xfce.org/panel-plugins/xfce4-notes-plugin.git"
+CHKSUMS="SKIP"

--- a/extra-xfce/xfce4-notifyd/spec
+++ b/extra-xfce/xfce4-notifyd/spec
@@ -1,4 +1,3 @@
-VER=0.4.4
-SRCTBL="https://archive.xfce.org/src/apps/xfce4-notifyd/${VER%.*}/xfce4-notifyd-$VER.tar.bz2"
-CHKSUM="sha256::090571acf94c423003426cb779fb23e8545c68bab6485563b589c7def8a21b55"
-REL=1
+VER=0.6.2
+SRCS="https://archive.xfce.org/src/apps/xfce4-notifyd/${VER%.*}/xfce4-notifyd-$VER.tar.bz2"
+CHKSUMS="sha256::19ab84c6665c7819998f2269322d53f462c30963ce26042df23ae525e7d16545"

--- a/extra-xfce/xfce4-panel-profiles/spec
+++ b/extra-xfce/xfce4-panel-profiles/spec
@@ -1,3 +1,3 @@
-VER=1.0.10
-SRCTBL="https://archive.xfce.org/src/apps/xfce4-panel-profiles/${VER:0:3}/xfce4-panel-profiles-$VER.tar.bz2"
-CHKSUM="sha256::a84d5e748d53bc5da269954cc3ad7f5ac0c4f5813acfd3892ea6f9064f17fb68"
+VER=1.0.12
+SRCS="https://archive.xfce.org/src/apps/xfce4-panel-profiles/${VER:0:3}/xfce4-panel-profiles-$VER.tar.bz2"
+CHKSUMS="whirlpool::59a3c2ffaa49576c2dd97c57ed2c0915de7fbd5f27dd3bf5932c988ca2afb1fc233e82ec53b30c39ba4b2af8703dfc8b9c7e5304a9c525b0215e6cc4e076f79a"

--- a/extra-xfce/xfce4-panel/spec
+++ b/extra-xfce/xfce4-panel/spec
@@ -1,3 +1,3 @@
-VER=4.14.4
-SRCTBL="https://archive.xfce.org/src/xfce/xfce4-panel/${VER%.*}/xfce4-panel-$VER.tar.bz2"
-CHKSUM="sha256::8e5ea79412ba84cfada897ff309cbe2cd4aca16b9bd4f93df060229528576fd5"
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/xfce4-panel/${VER%.*}/xfce4-panel-$VER.tar.bz2"
+CHKSUMS="sha256::5e979aeeb37d306d72858b1bc67448222ea7a68de01409055b846cd31f3cc53d"

--- a/extra-xfce/xfce4-power-manager/autobuild/patches/0001-xfce-power-manager-1.6.0-no-mate.patch
+++ b/extra-xfce/xfce4-power-manager/autobuild/patches/0001-xfce-power-manager-1.6.0-no-mate.patch
@@ -1,10 +1,10 @@
 diff -Nur xfce4-power-manager-1.6.0.orig/settings/xfce4-power-manager-settings.desktop.in xfce4-power-manager-1.6.0/settings/xfce4-power-manager-settings.desktop.in
 --- xfce4-power-manager-1.6.0.orig/settings/xfce4-power-manager-settings.desktop.in	2015-03-22 05:57:12.000000000 -0600
 +++ xfce4-power-manager-1.6.0/settings/xfce4-power-manager-settings.desktop.in	2016-05-26 16:59:29.924613636 -0600
-@@ -8,7 +8,7 @@
- Terminal=false
+@@ -9,7 +9,7 @@
  Type=Application
  Categories=XFCE;GTK;Settings;DesktopSettings;X-XFCE-SettingsDialog;X-XFCE-HardwareSettings;
+ _Keywords=settings;preferences;buttons;sleep;hibernate;battery;suspend;shutdown;brightness;laptop lid;lock screen;plugged in;saving;critical;
 -NotShowIn=GNOME;KDE;Unity;
 +NotShowIn=GNOME;KDE;Unity;MATE;
  StartupNotify=true

--- a/extra-xfce/xfce4-power-manager/spec
+++ b/extra-xfce/xfce4-power-manager/spec
@@ -1,3 +1,3 @@
-VER=1.6.6
-SRCTBL="https://archive.xfce.org/src/xfce/xfce4-power-manager/${VER%.*}/xfce4-power-manager-$VER.tar.bz2"
-CHKSUM="sha256::1b7bf0d3e8af69b10f7b6a518451e01fc7888e0d9d360bc33f6c89179bb6080b"
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/xfce4-power-manager/${VER%.*}/xfce4-power-manager-$VER.tar.bz2"
+CHKSUMS="sha256::04c0565ec2321a2b881fbe77fb40da24ec3630e716704edd4fe576de89c00fd3"

--- a/extra-xfce/xfce4-power-manager/spec
+++ b/extra-xfce/xfce4-power-manager/spec
@@ -1,3 +1,3 @@
 VER=4.16.0
 SRCS="https://archive.xfce.org/src/xfce/xfce4-power-manager/${VER%.*}/xfce4-power-manager-$VER.tar.bz2"
-CHKSUMS="sha256::04c0565ec2321a2b881fbe77fb40da24ec3630e716704edd4fe576de89c00fd3"
+CHKSUMS="whirlpool::bb6529aa0c4b826e4fefbb8f3f9c3bde2741fbb8a2081d28e2e02344c33605edb7b78ba1372db2d1a7dab55322cec6a272917dcca0e106900f3637e0f064f4cd"

--- a/extra-xfce/xfce4-pulseaudio-plugin/spec
+++ b/extra-xfce/xfce4-pulseaudio-plugin/spec
@@ -1,3 +1,4 @@
 VER=0.4.3
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-pulseaudio-plugin/${VER%.*}/xfce4-pulseaudio-plugin-$VER.tar.bz2"
-CHKSUM="sha256::5a518237e2137341d8ca6584938950525e20c28a0177e30ecaea3ba8e7a2615b"
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-pulseaudio-plugin/${VER%.*}/xfce4-pulseaudio-plugin-$VER.tar.bz2"
+CHKSUMS="sha256::5a518237e2137341d8ca6584938950525e20c28a0177e30ecaea3ba8e7a2615b"
+REL=1

--- a/extra-xfce/xfce4-screensaver/autobuild/patches/0001-Revert-Catch-gs_listener_dbus_init-failures-from-Shawn-Anastasio.patch
+++ b/extra-xfce/xfce4-screensaver/autobuild/patches/0001-Revert-Catch-gs_listener_dbus_init-failures-from-Shawn-Anastasio.patch
@@ -1,0 +1,11 @@
+diff --git a/src/gs-listener-dbus.c b/src/gs-listener-dbus.c
+--- a/src/gs-listener-dbus.c
++++ b/src/gs-listener-dbus.c
+@@ -2196,7 +2196,7 @@ gs_listener_init (GSListener *listener) {
+ #endif
+     listener->priv->prefs = gs_prefs_new();
+ 
+-    g_assert (gs_listener_dbus_init (listener));
++    gs_listener_dbus_init (listener);
+ 
+     init_session_id (listener);

--- a/extra-xfce/xfce4-screensaver/spec
+++ b/extra-xfce/xfce4-screensaver/spec
@@ -1,3 +1,3 @@
-VER=0.1.10
-SRCTBL="https://archive.xfce.org/src/apps/xfce4-screensaver/${VER:0:3}/xfce4-screensaver-$VER.tar.bz2"
-CHKSUM="sha256::586f1c78dd6745a20e9ce9f12d0117189d597ba7ad0c8ffcfcd25c9bb05f1d57"
+VER=0.1.11
+SRCS="https://archive.xfce.org/src/apps/xfce4-screensaver/${VER:0:3}/xfce4-screensaver-$VER.tar.bz2"
+CHKSUMS="whirlpool::b10ddd9b88d16ce797a237d034bb4740bad8ecee7f7ef6123c34cbf3135e31aa22258712d36fd62c5419716a6c54343b8b8fa38a75ae75403ced6e22c5132a62"

--- a/extra-xfce/xfce4-screenshooter/spec
+++ b/extra-xfce/xfce4-screenshooter/spec
@@ -1,3 +1,3 @@
-VER=1.9.7
-SRCTBL="https://archive.xfce.org/src/apps/xfce4-screenshooter/${VER%.*}/xfce4-screenshooter-$VER.tar.bz2"
-CHKSUM="sha256::0f7161053a23a6413376f4d17db6b774d4849384a9b1ffe01fdb2b0035a070d1"
+VER=1.9.8
+SRCS="https://archive.xfce.org/src/apps/xfce4-screenshooter/${VER%.*}/xfce4-screenshooter-$VER.tar.bz2"
+CHKSUMS="whirlpool::9bca5f9cb88c45cac5d98970cea6aef208b7b97b3f0c7dd20c63f1c61a739301280b4d2ccb44263df3d4077acc6c62b453dd2fff0b7a5aff22da3dae67f928b4"

--- a/extra-xfce/xfce4-sensors-plugin/spec
+++ b/extra-xfce/xfce4-sensors-plugin/spec
@@ -1,4 +1,3 @@
-VER=1.3.92
-REL=1
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-sensors-plugin/${VER%.*}/xfce4-sensors-plugin-$VER.tar.bz2"
-CHKSUM="sha256::3dc6643d2c064b7718badff44b948f8d410f00f13db197820b26ae38045f5112"
+VER=1.3.95
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-sensors-plugin/${VER%.*}/xfce4-sensors-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::ac65ecf468e4d8c59bef6615e61c08ad6b1c4e17716fad727b59fbc9596a3a9336cd9f461a3dfdc35f6a76a921c0314657c159d503fd26b72656588142d8bb4e"

--- a/extra-xfce/xfce4-session/autobuild/defines
+++ b/extra-xfce/xfce4-session/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=xfce4-session
 PKGDES="Session manager for Xfce"
 PKGSEC=xfce
-PKGDEP="libwnck-3 libxfce4ui x11-app polkit-gnome upower systemd light-locker"
+PKGDEP="libwnck-3 libxfce4ui x11-app polkit-gnome upower systemd xfce4-screensaver"
 BUILDDEP="intltool"
 
 AUTOTOOLS_AFTER="--enable-polkit \

--- a/extra-xfce/xfce4-session/spec
+++ b/extra-xfce/xfce4-session/spec
@@ -1,3 +1,3 @@
-VER=4.14.2
-SRCTBL="https://archive.xfce.org/src/xfce/xfce4-session/${VER%.*}/xfce4-session-$VER.tar.bz2"
-CHKSUM="sha256::fbe3a4a60c91589a2024ce12b2d2667625a8fedcbc90ef031831f56319f597af"
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/xfce4-session/${VER%.*}/xfce4-session-$VER.tar.bz2"
+CHKSUMS="sha256::22f273f212481d71e0b5618c62710cd85f69aea74f5ea5c0093f7918b07d17b7"

--- a/extra-xfce/xfce4-settings/spec
+++ b/extra-xfce/xfce4-settings/spec
@@ -1,4 +1,3 @@
-VER=4.14.3
-SRCTBL="https://archive.xfce.org/src/xfce/xfce4-settings/${VER%.*}/xfce4-settings-$VER.tar.bz2"
-CHKSUM="sha256::cab1a4d5351f9871533700523570f86f92bbe6e4055f44e5df950eb4b4f48bb3"
-REL=1
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/xfce4-settings/${VER%.*}/xfce4-settings-$VER.tar.bz2"
+CHKSUMS="sha256::67a1404fc754c675c6431e22a8fe0e5d79644fdfadbfe25a4523d68e1442ddc2"

--- a/extra-xfce/xfce4-smartbookmark-plugin/spec
+++ b/extra-xfce/xfce4-smartbookmark-plugin/spec
@@ -1,3 +1,3 @@
-VER=0.5.1
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-smartbookmark-plugin/${VER%.*}/xfce4-smartbookmark-plugin-$VER.tar.bz2"
-CHKSUM="sha256::3e28fb7cd2e2251e89a8715684081b862406e3fb4e6d8c0caa1b798a97703600"
+VER=0.5.2
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-smartbookmark-plugin/${VER%.*}/xfce4-smartbookmark-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::95a2bc1631b377976a4c3e8cce8ccf9ffabddd80b1b6538c985522374927db14f9068b62bfbe873a559b3ae154b5c0a617343b1e6fcfc8eccdd2e275646b2449"

--- a/extra-xfce/xfce4-statusnotifier-plugin/autobuild/defines
+++ b/extra-xfce/xfce4-statusnotifier-plugin/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=xfce4-statusnotifier-plugin
-PKGDES="Status notifier plugin for the Xfce4 panel"
-PKGDEP="xfce4-panel libdbusmenu"
-BUILDDEP="intltool"
-PKGSEC=xfce
-
-RECONF=0

--- a/extra-xfce/xfce4-statusnotifier-plugin/spec
+++ b/extra-xfce/xfce4-statusnotifier-plugin/spec
@@ -1,3 +1,0 @@
-VER=0.2.2
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-statusnotifier-plugin/${VER%.*}/xfce4-statusnotifier-plugin-$VER.tar.bz2"
-CHKSUM="sha256::4c905944d510a7a460246660c6c7a648a3a5fa0d638276b9bf2380d3654a2cfa"

--- a/extra-xfce/xfce4-systemload-plugin/spec
+++ b/extra-xfce/xfce4-systemload-plugin/spec
@@ -1,3 +1,3 @@
-VER=1.2.3
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-systemload-plugin/${VER%.*}/xfce4-systemload-plugin-$VER.tar.bz2"
-CHKSUM="sha256::052407c575203da4de2db6f4a5e997220d95ec655d393dc3875a0d5a20520775"
+VER=1.2.4
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-systemload-plugin/${VER%.*}/xfce4-systemload-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::e36528f9d7650de66b12eb43dce04001b4b62c55f79807cb4b8d3b70be4cd16d130c79bcd11d932ebbcb1e0d78001cb3895d099081a37f357c49696a4e332842"

--- a/extra-xfce/xfce4-taskmanager/spec
+++ b/extra-xfce/xfce4-taskmanager/spec
@@ -1,3 +1,3 @@
-VER=1.2.3
-SRCTBL="https://archive.xfce.org/src/apps/xfce4-taskmanager/${VER%.*}/xfce4-taskmanager-$VER.tar.bz2"
-CHKSUM="sha256::dcfc44da7c1f61d03e2c4bd1cdc8f92ce0d48b013bd0d140b3745d79b75dc3c4"
+VER=1.4.0
+SRCS="https://archive.xfce.org/src/apps/xfce4-taskmanager/${VER%.*}/xfce4-taskmanager-$VER.tar.bz2"
+CHKSUMS="whirlpool::6aefc0c95ccca61119a5ed3c58542a62cecc8a88c8c7ae1ade3f21f6881de23c404039bb56b4ca3b7fd69ed7d3702b8d7ba6cb5f509ac000ee708b3a8fca16b9"

--- a/extra-xfce/xfce4-terminal/spec
+++ b/extra-xfce/xfce4-terminal/spec
@@ -1,3 +1,4 @@
 VER=0.8.9.2
-SRCTBL="https://archive.xfce.org/src/apps/xfce4-terminal/${VER:0:3}/xfce4-terminal-$VER.tar.bz2"
-CHKSUM="sha256::9ba23bf86d350ef8a95d2dfb50bbd1bbb2144d82985a779ec28caf47faaeeeeb"
+SRCS="https://archive.xfce.org/src/apps/xfce4-terminal/${VER:0:3}/xfce4-terminal-$VER.tar.bz2"
+CHKSUMS="sha256::9ba23bf86d350ef8a95d2dfb50bbd1bbb2144d82985a779ec28caf47faaeeeeb"
+REL=1

--- a/extra-xfce/xfce4-time-out-plugin/spec
+++ b/extra-xfce/xfce4-time-out-plugin/spec
@@ -1,3 +1,4 @@
 VER=1.1.1
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-time-out-plugin/${VER%.*}/xfce4-time-out-plugin-$VER.tar.bz2"
-CHKSUM="sha256::194dbeb8751d8aaedf3850a7a9c770f09d32316a99683cde34d7d0fc5bdba31d"
+REL=1
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-time-out-plugin/${VER%.*}/xfce4-time-out-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::4b84793568d6047de5517ed0fec787f1ab210bfc4db1628e023db992699d0b68722d7575fd7dc79abbb1f0a8dd48d6cddc46ca665c6b913ab290d356193c645e"

--- a/extra-xfce/xfce4-timer-plugin/spec
+++ b/extra-xfce/xfce4-timer-plugin/spec
@@ -1,3 +1,4 @@
 VER=1.7.1
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-timer-plugin/${VER%.*}/xfce4-timer-plugin-$VER.tar.bz2"
-CHKSUM="sha256::4b52d2911b1949e945971be6533155ee6ba99c77078eac7fd43b0f2aeca824e3"
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-timer-plugin/${VER%.*}/xfce4-timer-plugin-$VER.tar.bz2"
+CHKSUMS="sha256::4b52d2911b1949e945971be6533155ee6ba99c77078eac7fd43b0f2aeca824e3"
+REL=1

--- a/extra-xfce/xfce4-verve-plugin/spec
+++ b/extra-xfce/xfce4-verve-plugin/spec
@@ -1,3 +1,3 @@
-VER=2.0.0
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-verve-plugin/${VER%.*}/xfce4-verve-plugin-$VER.tar.bz2"
-CHKSUM="sha256::9e6510ba6c48fcfc60d1c6ab14613dd7b6ff095cabbf4746f82bf788d8ab4cd2"
+VER=2.0.1
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-verve-plugin/${VER%.*}/xfce4-verve-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::8506182f0c29030ca2b2322e81c52dc6f292453c4c1bfe6252522ad647a4c7603afec002142e8119b4974de58d593afd662475f19e3c784fb130fdac175111aa"

--- a/extra-xfce/xfce4-volumed-pulse/autobuild/defines
+++ b/extra-xfce/xfce4-volumed-pulse/autobuild/defines
@@ -1,6 +1,0 @@
-PKGNAME=xfce4-volumed-pulse
-PKGDES="Volume keys control daemon for Xfce"
-PKGSEC=xfce
-PKGDEP="keybinder-3.0 pulseaudio xfce4-notifyd xfconf"
-BUILDDEP="intltool"
-RECONF=0

--- a/extra-xfce/xfce4-volumed-pulse/spec
+++ b/extra-xfce/xfce4-volumed-pulse/spec
@@ -1,4 +1,0 @@
-VER=0.2.3
-SRCTBL="https://archive.xfce.org/src/apps/xfce4-volumed-pulse/${VER:0:3}/xfce4-volumed-pulse-$VER.tar.bz2"
-CHKSUM="sha256::13bbf24b8bb52d9ba9b53929764ec0ea4d5ee26aaf71f01fbd021fc9794cc3e0"
-REL=1

--- a/extra-xfce/xfce4-wavelan-plugin/spec
+++ b/extra-xfce/xfce4-wavelan-plugin/spec
@@ -1,3 +1,4 @@
-VER=0.6.1
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-wavelan-plugin/${VER%.*}/xfce4-wavelan-plugin-$VER.tar.bz2"
-CHKSUM="sha256::f41f81ea063ae3c7d7904e1ee647a6b5efafc7436f47caed662ee417038eed17"
+VER=0.6.2
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-wavelan-plugin/${VER%.*}/xfce4-wavelan-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::831dd2d0c2ab1d523b5d94ee251d76add4ae29fe44c6f077507472dac5f11f311832d9f3eee4355cde2c601255e06201963e9dd42283b106a5eb3d8786fe4ceb"
+

--- a/extra-xfce/xfce4-weather-plugin/spec
+++ b/extra-xfce/xfce4-weather-plugin/spec
@@ -1,3 +1,3 @@
-VER=0.10.1
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-weather-plugin/${VER:0:4}/xfce4-weather-plugin-$VER.tar.bz2"
-CHKSUM="sha256::afb2af5f3effc2ea6181636ed0e82e6dafd556ec1b8478100802f85a5d167a89"
+VER=0.10.2
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-weather-plugin/${VER:0:4}/xfce4-weather-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::0d95c391cf54bc823dd429e10dfa252a2623e4607393e6748bf97adcd85015f05525d49ef6e15b5c20415fbbc6e3d8cfbd8375525aaf007bae0ad723a90b39ad"

--- a/extra-xfce/xfce4-whiskermenu-plugin/spec
+++ b/extra-xfce/xfce4-whiskermenu-plugin/spec
@@ -1,3 +1,3 @@
-VER=2.3.5
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-whiskermenu-plugin/${VER:0:3}/xfce4-whiskermenu-plugin-$VER.tar.bz2"
-CHKSUM="sha256::8f7134f4c1b5ff5290048c5b96b130e1238a286002cbe35255c2cd7d5a1ab6b4"
+VER=2.5.0
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-whiskermenu-plugin/${VER:0:3}/xfce4-whiskermenu-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::42524281120048bf913d65df9b1b2b434a8d724ee0e1d0551aa0e38145ffe18bc8b10e71f29470fbe375184bea1f5e42a4d4e092f5aee8fa24263ffa4d28e321"

--- a/extra-xfce/xfce4-xkb-plugin/spec
+++ b/extra-xfce/xfce4-xkb-plugin/spec
@@ -1,4 +1,3 @@
-VER=0.8.1
-SRCTBL="https://archive.xfce.org/src/panel-plugins/xfce4-xkb-plugin/${VER%.*}/xfce4-xkb-plugin-$VER.tar.bz2"
-CHKSUM="sha256::c19ecf126201deb6148741c521124771ad396adc874471512ab5ffe1946567a1"
-REL=1
+VER=0.8.2
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-xkb-plugin/${VER%.*}/xfce4-xkb-plugin-$VER.tar.bz2"
+CHKSUMS="whirlpool::f65a1128dca4a39b52344ddf77accbee9359be50bb6ab94d34fe76d0179dbe271e0e8386ac4a16ae441a21eab3bb3c4fbef3c06f1b25bf48584794c137fbfb99"

--- a/extra-xfce/xfconf/autobuild/defines
+++ b/extra-xfce/xfconf/autobuild/defines
@@ -13,7 +13,7 @@ NOLTO=1
 PKGBREAK="catfish<=1.4.13 libxfce4ui<=4.14.1-2 mousepad<=0.4.2 parole<=1.0.5-2 ristretto<=0.10.0-1 \
           thunar-volman<=0.9.5-1 thunar<=1.8.15 vala-panel-appmenu<=0.7.3-1 \
           xfce4-appfinder<=4.14.0-1 xfce4-clipman-plugin<=1.4.4 xfce4-notes-plugin<=1.8.1-1 \
-          xfce4-notifyd<=0.4.4-1 xfce4-panel<=1:4.14.4 xfce4-power-manager<=4.16.0 \
+          xfce4-notifyd<=0.4.4-1 xfce4-panel<=1:4.14.4 xfce4-power-manager<=1.6.6 \
           xfce4-pulseaudio-plugin<=0.4.3 xfce4-screensaver<=0.1.10 \
           xfce4-session<=1:4.14.2 xfce4-settings<=4.14.3-1  xfce4-terminal<=0.8.9.2 \
           xfce4-xkb-plugin<=0.8.1-1 xfdashboard<=0.7.8 xfdesktop<=4.14.2-1 xfwm4<=4.14.5"

--- a/extra-xfce/xfconf/autobuild/defines
+++ b/extra-xfce/xfconf/autobuild/defines
@@ -7,8 +7,7 @@ BUILDDEP="intltool gtk-doc chrpath perl-extutils-depends \
 PKGSEC=xfce
 
 AUTOTOOLS_AFTER="--enable-gtk-doc \
-                 --enable-gsettings-backend \
-                 --with-perl-options=INSTALLDIRS=vendor"
+                 --enable-gsettings-backend"
 NOLTO=1
 
 PKGBREAK="libxfce4ui<=4.14.1 mousepad<=0.4.2 parole<=1.0.5 ristretto<=0.10.0 \

--- a/extra-xfce/xfconf/autobuild/defines
+++ b/extra-xfce/xfconf/autobuild/defines
@@ -10,14 +10,11 @@ AUTOTOOLS_AFTER="--enable-gtk-doc \
                  --enable-gsettings-backend"
 NOLTO=1
 
-PKGBREAK="libxfce4ui<=4.14.1 mousepad<=0.4.2 parole<=1.0.5 ristretto<=0.10.0 \
-          thunar-volman<=0.9.5 thunar<=1.8.12-2 vala-panel-appmenu<=0.7.3-1 \
-          xfce4-appfinder<=4.14.0 xfce4-clipman-plugin<=1.4.3 \
-          xfce4-mixer<=4.11.0-6 xfce4-notes-plugin<=1.8.1-1 \
-          xfce4-notifyd<=0.4.4 xfce4-panel<=1:4.14.3 xfce4-power-manager<=1.6.5 \
-          xfce4-pulseaudio-plugin<=0.4.2 xfce4-screensaver<=0.1.8 \
-          xfce4-session<=1:4.14.1 xfce4-settings<=4.14.2 \
-          xfce4-statusnotifier-plugin<=0.2.1 xfce4-terminal<=0.8.9.1 \
-          xfce4-volumed-pulse<=0.2.3 xfce4-xkb-plugin<=0.8.1 xfdashboard<=0.7.7 \
-          xfdesktop<=4.14.2 xfwm4<=4.14.0"
+PKGBREAK="catfish<=1.4.13 libxfce4ui<=4.14.1-2 mousepad<=0.4.2 parole<=1.0.5-2 ristretto<=0.10.0-1 \
+          thunar-volman<=0.9.5-1 thunar<=1.8.15 vala-panel-appmenu<=0.7.3-1 \
+          xfce4-appfinder<=4.14.0-1 xfce4-clipman-plugin<=1.4.4 xfce4-notes-plugin<=1.8.1-1 \
+          xfce4-notifyd<=0.4.4-1 xfce4-panel<=1:4.14.4 xfce4-power-manager<=4.16.0 \
+          xfce4-pulseaudio-plugin<=0.4.3 xfce4-screensaver<=0.1.10 \
+          xfce4-session<=1:4.14.2 xfce4-settings<=4.14.3-1  xfce4-terminal<=0.8.9.2 \
+          xfce4-xkb-plugin<=0.8.1-1 xfdashboard<=0.7.8 xfdesktop<=4.14.2-1 xfwm4<=4.14.5"
 RECONF=0

--- a/extra-xfce/xfconf/spec
+++ b/extra-xfce/xfconf/spec
@@ -1,4 +1,3 @@
-VER=4.14.3
-SRCTBL="https://archive.xfce.org/src/xfce/xfconf/${VER%.*}/xfconf-$VER.tar.bz2"
-CHKSUM="sha256::589052a0efc6151c5fb5f438da463502a4fd91848cae7b9376d417be4c5a0c02"
-REL=1
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/xfconf/${VER%.*}/xfconf-$VER.tar.bz2"
+CHKSUMS="sha256::652a119007c67d9ba6c0bc7a740c923d33f32d03dc76dfc7ba682584e72a5425"

--- a/extra-xfce/xfdashboard/spec
+++ b/extra-xfce/xfdashboard/spec
@@ -1,3 +1,3 @@
-VER=0.7.8
-SRCTBL="https://archive.xfce.org/src/apps/xfdashboard/${VER:0:3}/xfdashboard-$VER.tar.bz2"
-CHKSUM="sha256::adfa1931c475501c3c64ce3cde2fd993737947c98ab8256c8792de303ef459b7"
+VER=0.8.0
+SRCS="https://archive.xfce.org/src/apps/xfdashboard/${VER:0:3}/xfdashboard-$VER.tar.bz2"
+CHKSUMS="whirlpool::7685f1efd203c74037e59c11c4c513c496018061051a076d49d0581874458e44f7501e4054a0073afee0ee2d57b95185543f166ba79516bfdbe81b651eda481b"

--- a/extra-xfce/xfdesktop/spec
+++ b/extra-xfce/xfdesktop/spec
@@ -1,4 +1,3 @@
-VER=4.14.2
-SRCTBL="https://archive.xfce.org/src/xfce/xfdesktop/${VER%.*}/xfdesktop-$VER.tar.bz2"
-CHKSUM="sha256::a30534461fea907f969f608a11c84be0b1aaad687c591c32cd56a9d274ea3e74"
-REL=1
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/xfdesktop/${VER%.*}/xfdesktop-$VER.tar.bz2"
+CHKSUMS="sha256::934ba5affecff21e62d9fac1dd50c50cd94b3a807fefa5f5bff59f3d6f155bae"

--- a/extra-xfce/xfmpc/spec
+++ b/extra-xfce/xfmpc/spec
@@ -1,3 +1,4 @@
 VER=0.3.0
-SRCTBL="https://archive.xfce.org/src/apps/xfmpc/${VER:0:3}/xfmpc-$VER.tar.bz2"
-CHKSUM="sha256::c76e2a88dc3e1d345da7a5c68fa39981494c2b40033748efcac54411c9e65689"
+SRCS="https://archive.xfce.org/src/apps/xfmpc/${VER:0:3}/xfmpc-$VER.tar.bz2"
+CHKSUMS="sha256::c76e2a88dc3e1d345da7a5c68fa39981494c2b40033748efcac54411c9e65689"
+REL=1

--- a/extra-xfce/xfwm4/spec
+++ b/extra-xfce/xfwm4/spec
@@ -1,3 +1,3 @@
-VER=4.14.5
-SRCTBL="https://archive.xfce.org/src/xfce/xfwm4/${VER%.*}/xfwm4-$VER.tar.bz2"
-CHKSUM="sha256::d7a7c63fa42ec6d7cb3caab130d6f496be5bd7689b775d20e8786b7f3e282930"
+VER=4.16.0
+SRCS="https://archive.xfce.org/src/xfce/xfwm4/${VER%.*}/xfwm4-$VER.tar.bz2"
+CHKSUMS="sha256::1e22eae1bbb66cebfd1753b0a5606e76ecbf6b09ce4cdfd732d093c936f1feb3"


### PR DESCRIPTION
Topic Description
-----------------
Update Xfce to version 4.16

Package(s) Affected
-------------------
`extra-xfce/*`
`xfce-base`
`gtksourceview-3`

Security Update?
----------------
No 


Build Order
-----------
`xfce4-dev-tools libxfce4util xfconf libxfce4ui exo garcon gtksourceview-3`

`xfce4-panel xfce4-panel-profiles thunar xfdesktop xfwm4 xfce4-notifyd xfce4-power-manager xfce4-screensaver xfce4-settings xfce4-session mousepad orage tumbler xfce4-appfinder parole ristretto xfburn xfce4-dict xfce4-screenshooter xfce4-taskmanager xfce4-terminal xfdashboard gigolo catfish thunar-volman thunar-archive-plugin thunar-media-tags-plugin thunar-shares-plugin thunar-vcs-plugin`

`xfce4-battery-plugin xfce4-clipman-plugin xfce4-cpufreq-plugin xfce4-cpugraph-plugin xfce4-datetime-plugin xfce4-diskperf-plugin xfce4-eyes-plugin xfce4-fsguard-plugin xfce4-genmon-plugin xfce4-mailwatch-plugin xfce4-mount-plugin xfce4-mpc-plugin xfce4-netload-plugin xfce4-notes-plugin xfce4-pulseaudio-plugin xfce4-sensors-plugin xfce4-smartbookmark-plugin xfce4-systemload-plugin xfce4-time-out-plugin xfce4-timer-plugin xfce4-verve-plugin xfce4-wavelan-plugin xfce4-weather-plugin xfce4-whiskermenu-plugin xfce4-xkb-plugin`

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

