### PR TITLE
grub: adapt for ppc64el (POWER8+)

### DIFF
--- a/extra-admin/grub/autobuild/defines
+++ b/extra-admin/grub/autobuild/defines
@@ -13,6 +13,7 @@ PKGDEP__I486="${PKGDEP__RETRO}"
 PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO} powerpc-utils pmac-utils"
 PKGDEP__PPC64="${PKGDEP__RETRO} powerpc-utils pmac-utils"
+PKGDEP__PPC64EL="${PKGDEP__RETRO} powerpc-utils pmac-utils"
 
 BUILDDEP="autogen grub help2man rsync texinfo"
 BUILDDEP__RETRO=""

--- a/extra-admin/grub/autobuild/ppc64el/build
+++ b/extra-admin/grub/autobuild/ppc64el/build
@@ -1,0 +1,30 @@
+pushd grub-${PKGVER/\~/-}
+NOCONFIGURE=1 ./autogen.sh
+./configure \
+	--with-platform="ieee1275" \
+	--target="powerpc" \
+	--disable-efiemu \
+	--disable-mm-debug \
+	--enable-nls \
+	--enable-device-mapper \
+	--enable-cache-stats \
+	--enable-boot-time \
+	--enable-grub-mkfont \
+	--enable-grub-mount \
+	--prefix="/usr" \
+	--bindir="/usr/bin" \
+        --sbindir="/usr/bin" \
+	--mandir="/usr/share/man" \
+	--infodir="/usr/share/info" \
+	--datarootdir="/usr/share" \
+	--sysconfdir="/etc" \
+	--program-prefix="" \
+	--with-bootdir="/boot" \
+	--with-grubdir="grub" \
+	--disable-werror
+make
+make install DESTDIR="$PKGDIR" bashcompletiondir="/usr/share/bash-completion/completions"
+rm -f "$PKGDIR"/usr/lib/grub/i386-efi/*.module || true
+rm -f "$PKGDIR"/usr/lib/grub/i386-efi/*.image || true
+rm -f "$PKGDIR"/usr/lib/grub/i386-efi/{kernel.exec,gdb_grub,gmodule.pl} || true
+popd

--- a/extra-admin/pmac-utils/autobuild/build
+++ b/extra-admin/pmac-utils/autobuild/build
@@ -1,4 +1,4 @@
-for i in autoboot bootsched clock mousemode nvsetenv \
+for i in autoboot bootsched clock mousemode \
          backlight trackpad nvsetvol fblevel fnset; do
     make $i
     install -Dm755 $i "$PKGDIR"/usr/bin/$i

--- a/extra-admin/pmac-utils/autobuild/defines
+++ b/extra-admin/pmac-utils/autobuild/defines
@@ -3,4 +3,4 @@ PKGSEC=admin
 PKGDEP="powerpc-utils"
 PKGDES="Utilities for PowerPC-based Macintosh computers"
 
-FAIL_ARCH="!(powerpc|ppc64)"
+FAIL_ARCH="!(powerpc|ppc64|ppc64el)"

--- a/extra-admin/pmac-utils/spec
+++ b/extra-admin/pmac-utils/spec
@@ -1,3 +1,4 @@
 VER=1.1.3
+REL=1
 SRCTBL="https://repo.aosc.io/aosc-repacks/pmac-utils_1.1.3.orig.tar.gz"
 CHKSUM="sha256::fde422d13e75d0154fa5d9d94ba3c74f4a91dc0f8ba0351e675ee99eeaddbe95"

--- a/extra-admin/powerpc-utils/autobuild/beyond
+++ b/extra-admin/powerpc-utils/autobuild/beyond
@@ -1,2 +1,2 @@
-abinfo "Dropping nvsetenv ..."
-rm -v "$PKGDIR"/usr/bin/nvsetenv
+#abinfo "Dropping nvsetenv ..."
+#rm -v "$PKGDIR"/usr/bin/nvsetenv

--- a/extra-admin/powerpc-utils/autobuild/defines
+++ b/extra-admin/powerpc-utils/autobuild/defines
@@ -1,4 +1,7 @@
 PKGNAME=powerpc-utils
 PKGSEC=admin
 PKGDEP="bc librtas"
-PKGDES="Utilities for PowerPC-based systems"
+PKGDES="Utilities for PowerPC/POWER-based systems"
+
+PKGBREAK="pmac-utils<=1.1.3"
+PKGREP="pmac-utils<=1.1.3"

--- a/extra-admin/powerpc-utils/spec
+++ b/extra-admin/powerpc-utils/spec
@@ -1,3 +1,4 @@
 VER=1.3.8
+REL=1
 SRCTBL="https://github.com/nfont/powerpc-utils/archive/v$VER.tar.gz"
 CHKSUM="sha256::4e3a21419863c08adde49f0795eff0fbfe4597ce82593fa5fe1f1177913fb7b9"


### PR DESCRIPTION
Topic Description
-----------------

Adapt GRUB for `ppc64el`, or POWER8+ systems. Use `nvsetenv` from `powerpc-utils`, instead of that from `pmac-utils`.

Package(s) Affected
-------------------

- `pmac-utils` v1.1.3-1
- `powerpc-utils` v1.3.8-1
- `grub` v2.04-11 (no release change for there was never a release for `ppc64el`)

Security Update?
----------------

No

Build Order
-----------

```
pmac-utils powerpc-utils grub
```

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] PowerPC 64-bit (Little Endian) `ppc64el`