### PR TITLE
server-base: use wireguard-tools

### DIFF
--- a/extra-bases/server-base/autobuild/defines
+++ b/extra-bases/server-base/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=server-base
 PKGSEC=Bases
-PKGDEP="bind bird dnsmasq ipmitool lamp-base lnmp-base postgresql sssd v2ray vsftpd wireguard"
+PKGDEP="bind bird dnsmasq ipmitool lamp-base lnmp-base postgresql sssd v2ray vsftpd wireguard-tools"
 PKGDES="Meta package for AOSC OS servers"
 
 VER_NONE=1

--- a/extra-bases/server-base/spec
+++ b/extra-bases/server-base/spec
@@ -1,2 +1,2 @@
-VER=0
+VER=1
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

Make `server-base` depend on `wireguard-tools` instead of `wireguard`, as `wireguard-tools` (part of the `wireguard` metapackage) is no longer needed for Kernels 5.6+.

Package(s) Affected
-------------------

- `server-base` v1

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
----------------------

- [x] Architecture-independent `noarch`