### PR TITLE
openexr: upgrade to 2.5.4, fix #2593

### DIFF
--- a/extra-libs/openexr/autobuild/defines
+++ b/extra-libs/openexr/autobuild/defines
@@ -18,7 +18,7 @@ PKGBREAK="blender<=2.81a-2 calligra<=3.1.0-9 cinelerracv<=2.3.0-3 \
           openimageio<=2.0.12 openscenegraph<=2:3.4.1-3 povray<=3.7.0.8-2 \
           synfig<=1.2.2-2 tdegraphics<=14.0.7 tdelibs<=14.0.7 \
           vigra<=1.11.1-6 \
-          \
           ilmbase<=2.3.0-2 \
           openexr-viewers<=2.3.0-2"
+
 # ilmbase and openexr is replaced by openexr since version 2.4.0

--- a/extra-libs/openexr/autobuild/prepare
+++ b/extra-libs/openexr/autobuild/prepare
@@ -1,0 +1,5 @@
+CMAKE_AFTER+="""
+	-DPyIlmBase_Python3_SITEARCH_REL=/usr/lib/python${ABPY3VER}/site-packages
+	-DPyIlmBase_Python2_SITEARCH_REL=/usr/lib/python${ABPY2VER}/site-packages
+"""
+

--- a/extra-libs/openexr/spec
+++ b/extra-libs/openexr/spec
@@ -1,3 +1,3 @@
-VER=2.5.2
+VER=2.5.4
 SRCTBL="https://github.com/AcademySoftwareFoundation/openexr/archive/v${VER}.tar.gz"
-CHKSUM="sha256::5da8dff448d0c4a529e52c97daf238a461d01cd233944f75095668d6d7528761"
+CHKSUM="sha256::dba19e9c6720c6f64fbc8b9d1867eaa75da6438109b941eefdc75ed141b6576d"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates openexr and its utilities to 2.5.4 and fixes python binding install locations. No rebuild is required as this update does not bump major sover.

Package(s) Affected
-------------------

openexr 2.5.2 -> 2.5.4

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
