### PR TITLE
groups/gnome: add missing dependency for 3 packages

### DIFF
--- a/extra-gnome/gnome-screenshot/autobuild/defines
+++ b/extra-gnome/gnome-screenshot/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gnome-screenshot
 PKGSEC=gnome
-PKGDEP="dconf gtk-3 libcanberra"
+PKGDEP="dconf gtk-3 libcanberra libhandy"
 BUILDDEP="intltool itstool meson ninja appstream-glib"
 PKGDES="Screenshot utility for GNOME"
 

--- a/extra-gnome/gnome-screenshot/spec
+++ b/extra-gnome/gnome-screenshot/spec
@@ -1,3 +1,4 @@
 VER=3.38.0
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-screenshot/${VER:0:4}/gnome-screenshot-$VER.tar.xz"
 CHKSUMS="sha256::e556d3dd134d91344d2857c066434bfb64f7c85bdec7bc33739366b9bcd29fc0"

--- a/extra-gnome/gnome-usage/autobuild/defines
+++ b/extra-gnome/gnome-usage/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=gnome-usage
 PKGSEC=gnome
-PKGDEP="accountsservice gtk-3 libgtop libdazzle"
+PKGDEP="accountsservice gtk-3 libgtop libdazzle libhandy"
 BUILDDEP="gobject-introspection meson ninja vala"
 PKGDES="View information about use of system resources"

--- a/extra-gnome/gnome-usage/autobuild/defines
+++ b/extra-gnome/gnome-usage/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=gnome-usage
 PKGSEC=gnome
-PKGDEP="accountsservice gtk-3 libgtop libdazzle libhandy"
+PKGDEP="accountsservice gtk-3 libgtop libdazzle libhandy tracker"
 BUILDDEP="gobject-introspection meson ninja vala"
 PKGDES="View information about use of system resources"

--- a/extra-gnome/gnome-usage/spec
+++ b/extra-gnome/gnome-usage/spec
@@ -1,3 +1,4 @@
 VER=3.38.0
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-usage/${VER:0:4}/gnome-usage-$VER.tar.xz"
 CHKSUMS="sha256::94d58202fd92094ee2a2647ea3f96d0b16b5f5d7f9bf5ae99f1c33117d1a1a57"

--- a/extra-gnome/seahorse/autobuild/defines
+++ b/extra-gnome/seahorse/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=seahorse
 PKGSEC=gnome
 PKGDEP="gtk-3 gcr libsecret libsoup gpgme desktop-file-utils \
-        hicolor-icon-theme dconf"
+        hicolor-icon-theme dconf libhandy"
 BUILDDEP="gobject-introspection openldap intltool vala yelp-tools"
 PKGDES="GNOME application for managing PGP keys"

--- a/extra-gnome/seahorse/spec
+++ b/extra-gnome/seahorse/spec
@@ -1,3 +1,4 @@
 VER=3.38.0.1
+REL=1
 SRCS="https://download.gnome.org/sources/seahorse/${VER:0:4}/seahorse-$VER.tar.xz"
 CHKSUMS="sha256::c745dd1de6e1a20f19a2b07a438b8ef7cca235a6aa73410db7f137b021e9b2a2"


### PR DESCRIPTION
Topic Description
-----------------
Add missing dependencies for some GNOME applications, specifically `libhandy`.

Package(s) Affected
-------------------

- `gnome-screenshot`
- `gnome-usage`
- `seahorse`
- `gnupg` (rebuild for arm64)

Security Update?
----------------
 No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
