### PR TITLE
polybar: update to 3.5.3

### DIFF
--- a/extra-utils/polybar/autobuild/defines
+++ b/extra-utils/polybar/autobuild/defines
@@ -6,3 +6,5 @@ PKGDEP="alsa-lib cairo curl jsoncpp libmpdclient libxcb python-3 pulseaudio \
 PKGRECOM="i3"
 BUILDDEP="i3 xcb-proto"
 PKGDES="A fast and easy-to-use tool for creating status bars"
+
+NOLTO__LOONGSON3=1

--- a/extra-utils/polybar/spec
+++ b/extra-utils/polybar/spec
@@ -1,3 +1,3 @@
-VER=3.4.3
-SRCTBL="https://github.com/polybar/polybar/releases/download/$VER/polybar-$VER.tar"
-CHKSUM="sha256::d4ed121c1d3960493f8268f966d65a94d94c4646a4abb131687e37b63616822f"
+VER=3.5.3
+SRCTBL="https://github.com/polybar/polybar/releases/download/$VER/polybar-$VER.tar.gz"
+CHKSUM="sha256::d23fbb9a7b7f1cdd334fe0ba3adc0f9602cfc94aa0827c058584059416792680"

--- a/extra-utils/polybar/spec
+++ b/extra-utils/polybar/spec
@@ -1,3 +1,3 @@
 VER=3.5.3
-SRCTBL="https://github.com/polybar/polybar/releases/download/$VER/polybar-$VER.tar.gz"
-CHKSUM="sha256::d23fbb9a7b7f1cdd334fe0ba3adc0f9602cfc94aa0827c058584059416792680"
+SRCS="https://github.com/polybar/polybar/releases/download/$VER/polybar-$VER.tar.gz"
+CHKSUMS="sha256::d23fbb9a7b7f1cdd334fe0ba3adc0f9602cfc94aa0827c058584059416792680"

--- a/extra-wm/i3-gaps/autobuild/defines
+++ b/extra-wm/i3-gaps/autobuild/defines
@@ -8,3 +8,4 @@ BUILDDEP="graphviz doxygen xmlto"
 PKGDES="Improved tiling WM (window manager), with more features"
 
 PKGCONFL="i3"
+PKGPROV="i3"

--- a/extra-wm/i3-gaps/spec
+++ b/extra-wm/i3-gaps/spec
@@ -1,3 +1,4 @@
 VER=4.19
 SRCS="tbl::https://github.com/Airblader/i3/releases/download/$VER/i3-$VER.tar.xz"
 CHKSUMS="sha256::905c8f54cece9fb54a5116792368c2f080aca599d3fb0d8ab44e5e57809c2948"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

Update polybar to 3.5.3,
resolve dep confl between i3 and i3-gaps when installing polybar.

Package(s) Affected
-------------------

polybar
i3-gaps

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`