### PR TITLE
wmctrl: new, 1.07

### DIFF
--- a/extra-wm/wmctrl/autobuild/defines
+++ b/extra-wm/wmctrl/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=wmctrl
+PKGSEC=x11
+PKGDEP="glib x11-lib"
+PKGDES="A command line tool to interact with EWMH/NetWM-compatible X window managers"

--- a/extra-wm/wmctrl/autobuild/patches/0001-Debian-amd64-architecture-fix.patch
+++ b/extra-wm/wmctrl/autobuild/patches/0001-Debian-amd64-architecture-fix.patch
@@ -1,0 +1,423 @@
+--- wmctrl-1.07.orig/debian/control
++++ wmctrl-1.07/debian/control
+@@ -0,0 +1,20 @@
++Source: wmctrl
++Section: x11
++Priority: optional
++Maintainer: Decklin Foster <decklin@red-bean.com>
++Build-Depends: debhelper (>= 4.0.0), x11proto-core-dev, libx11-dev, libxmu-dev, libglib2.0-dev (>= 2.4.0)
++Standards-Version: 3.6.2
++
++Package: wmctrl
++Architecture: any
++Depends: ${shlibs:Depends}
++Description: control an EWMH/NetWM compatible X Window Manager
++ Wmctrl is a command line tool to interact with an
++ EWMH/NetWM compatible X Window Manager (examples include
++ Enlightenment, icewm, kwin, metacity, and sawfish).
++ .
++ Wmctrl provides command line access to almost all the features
++ defined in the EWMH specification. For example it can maximize
++ windows, make them sticky, set them to be always on top. It can
++ switch and resize desktops and perform many other useful
++ operations.
+--- wmctrl-1.07.orig/debian/wmctrl.docs
++++ wmctrl-1.07/debian/wmctrl.docs
+@@ -0,0 +1 @@
++README
+--- wmctrl-1.07.orig/debian/watch
++++ wmctrl-1.07/debian/watch
+@@ -0,0 +1,2 @@
++version=2
++http://sweb.cz/tripie/utils/wmctrl/dist/ wmctrl-(.*)\.tar\.gz debian uupdate
+--- wmctrl-1.07.orig/debian/compat
++++ wmctrl-1.07/debian/compat
+@@ -0,0 +1 @@
++4
+--- wmctrl-1.07.orig/debian/changelog
++++ wmctrl-1.07/debian/changelog
+@@ -0,0 +1,69 @@
++wmctrl (1.07-6) unstable; urgency=low
++
++  * Reverted CARD32 patch, which was broken on amd64; use fix from Chris
++    Donoghue instead. (Closes: #362068)
++  * Change x-dev -> x11proto-core-dev build-dep.
++
++ -- Decklin Foster <decklin@red-bean.com>  Tue, 18 Apr 2006 10:20:00 -0400
++
++wmctrl (1.07-5) unstable; urgency=low
++
++  * Not all the new build-deps from -2 were actually added to debian/control.
++    (Closes: #345816)
++
++ -- Decklin Foster <decklin@red-bean.com>  Tue,  3 Jan 2006 14:26:57 -0500
++
++wmctrl (1.07-4) unstable; urgency=low
++
++  * Get rid of huge mess in .diff.gz caused by vim's braindead folding.
++
++ -- Decklin Foster <decklin@red-bean.com>  Mon,  2 Jan 2006 23:27:14 -0500
++
++wmctrl (1.07-3) unstable; urgency=low
++
++  * Fix typo in description (Closes: #345576)
++
++ -- Decklin Foster <decklin@red-bean.com>  Mon,  2 Jan 2006 22:53:30 -0500
++
++wmctrl (1.07-2) unstable; urgency=low
++
++  * Patch main.c to use CARD32 for all EWMH properties instead of unsigned
++    long, which may be 64 bits on 64-bit archs. (Closes: #344080)
++  * Replace xlibs-dev build-dep with libx11-dev, x-dev, libxmu-dev.
++  * Update Standards-Version to 3.6.2.
++
++ -- Decklin Foster <decklin@red-bean.com>  Mon,  2 Jan 2006 22:34:27 -0500
++
++wmctrl (1.07-1) unstable; urgency=low
++
++  * New upstream release
++
++ -- Decklin Foster <decklin@red-bean.com>  Sat, 29 Jan 2005 09:45:14 -0500
++
++wmctrl (1.06-1) unstable; urgency=low
++
++  * New upstream release
++    - debian/wmctrl.1: merged upstream.
++  * debian/watch: added trailing / to directory (Thanks, Shyamal).
++  * debian/control: lowercase first letter of description.
++
++ -- Decklin Foster <decklin@red-bean.com>  Sat, 22 Jan 2005 14:04:09 -0500
++
++wmctrl (1.05-2) unstable; urgency=low
++
++  * Adopting package created by Debian user Shyamal Prasad
++    <shyamal@member.fsf.org>.
++  * Removed debian/{pre,post}{inst,rm}.ex and config.{sub,guess}, and do not
++    generate config.{sub,guess} in clean.
++  * Removed example cruft in copyright and watch.
++  * Install ChangeLog as the upstream changelog, not a doc. Do not install
++    NEWS, since it is empty.
++
++ -- Decklin Foster <decklin@red-bean.com>  Mon, 13 Dec 2004 10:41:11 -0500
++
++wmctrl (1.05-1) unstable; urgency=low
++
++  * Initial Release. Added man page wmctrl.1 (closes: #285397)
++
++ -- Shyamal Prasad <shyamal@member.fsf.org>  Thu, 12 Dec 2004 18:59:40 -0800
++
+--- wmctrl-1.07.orig/debian/rules
++++ wmctrl-1.07/debian/rules
+@@ -0,0 +1,91 @@
++#!/usr/bin/make -f
++# -*- makefile -*-
++# Sample debian/rules that uses debhelper.
++# This file was originally written by Joey Hess and Craig Small.
++# As a special exception, when this file is copied by dh-make into a
++# dh-make output file, you may use that output file without restriction.
++# This special exception was added by Craig Small in version 0.37 of dh-make.
++
++# Uncomment this to turn on verbose mode.
++#export DH_VERBOSE=1
++
++
++# These are used for cross-compiling and for saving the configure script
++# from having to guess our platform (since we know it already)
++DEB_HOST_GNU_TYPE   ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
++DEB_BUILD_GNU_TYPE  ?= $(shell dpkg-architecture -qDEB_BUILD_GNU_TYPE)
++
++
++CFLAGS = -Wall -g
++
++ifneq (,$(findstring noopt,$(DEB_BUILD_OPTIONS)))
++	CFLAGS += -O0
++else
++	CFLAGS += -O2
++endif
++
++config.status: configure
++	dh_testdir
++	# Add here commands to configure the package.
++	CFLAGS="$(CFLAGS)" ./configure --host=$(DEB_HOST_GNU_TYPE) --build=$(DEB_BUILD_GNU_TYPE) --prefix=/usr --mandir=\$${prefix}/share/man --infodir=\$${prefix}/share/info
++
++
++build: build-stamp
++
++build-stamp:  config.status
++	dh_testdir
++
++	# Add here commands to compile the package.
++	$(MAKE)
++
++	touch build-stamp
++
++clean:
++	dh_testdir
++	dh_testroot
++	rm -f build-stamp 
++
++	# Add here commands to clean up after the build process.
++	-$(MAKE) distclean
++
++	dh_clean 
++
++install: build
++	dh_testdir
++	dh_testroot
++	dh_clean -k 
++	dh_installdirs
++
++	# Add here commands to install the package into debian/wmctrl.
++	$(MAKE) install DESTDIR=$(CURDIR)/debian/wmctrl
++
++
++# Build architecture-independent files here.
++binary-indep: build install
++# We have nothing to do by default.
++
++# Build architecture-dependent files here.
++binary-arch: build install
++	dh_testdir
++	dh_testroot
++	dh_installchangelogs ChangeLog
++	dh_installdocs
++	dh_installexamples
++#	dh_install
++#	dh_installmenu
++#	dh_installlogrotate
++#	dh_installinit
++#	dh_installinfo
++	dh_link
++	dh_strip
++	dh_compress
++	dh_fixperms
++#	dh_makeshlibs
++	dh_installdeb
++	dh_shlibdeps
++	dh_gencontrol
++	dh_md5sums
++	dh_builddeb
++
++binary: binary-indep binary-arch
++.PHONY: build clean binary-indep binary-arch binary install 
+--- wmctrl-1.07.orig/debian/copyright
++++ wmctrl-1.07/debian/copyright
+@@ -0,0 +1,15 @@
++This package was debianized by Shyamal Prasad <shyamal@member.fsf.org> on
++Thu, 12 Dec 2004 18:59:40 -0800.
++
++It was downloaded from http://sweb.cz/tripie/utils/wmctrl/
++
++Upstream Author: Tomas Styblo <tripie@cpan.org>
++
++Copyright (C) 2003, Tomas Styblo <tripie@cpan.org>
++
++You are free to distribute this software under the terms of the GNU
++General Public License.
++
++On Debian systems, the complete text of the GNU General Public License
++can be found in the file `/usr/share/common-licenses/GPL'.
++
+--- wmctrl-1.07.orig/BAH
++++ wmctrl-1.07/BAH
+@@ -0,0 +1,172 @@
++--- wmctrl-1.07.orig/main.c
+++++ wmctrl-1.07/main.c
++@@ -31,6 +31,7 @@
++ #include <string.h>
++ #include <locale.h>
++ #include <X11/Xlib.h>
+++#include <X11/Xmd.h>
++ #include <X11/Xatom.h>
++ #include <X11/cursorfont.h>
++ #include <X11/Xmu/WinUtil.h>
++@@ -477,8 +478,8 @@
++     Window *sup_window = NULL;
++     gchar *wm_name = NULL;
++     gchar *wm_class = NULL;
++-    unsigned long *wm_pid = NULL;
++-    unsigned long *showing_desktop = NULL;
+++    CARD32 *wm_pid = NULL;
+++    CARD32 *showing_desktop = NULL;
++     gboolean name_is_utf8 = TRUE;
++     gchar *name_out;
++     gchar *class_out;
++@@ -517,13 +518,13 @@
++   
++ 
++     /* WM_PID */
++-    if (! (wm_pid = (unsigned long *)get_property(disp, *sup_window,
+++    if (! (wm_pid = (CARD32 *)get_property(disp, *sup_window,
++                     XA_CARDINAL, "_NET_WM_PID", NULL))) {
++         p_verbose("Cannot get pid of the window manager (_NET_WM_PID).\n");
++     }
++     
++     /* _NET_SHOWING_DESKTOP */
++-    if (! (showing_desktop = (unsigned long *)get_property(disp, DefaultRootWindow(disp),
+++    if (! (showing_desktop = (CARD32 *)get_property(disp, DefaultRootWindow(disp),
++                     XA_CARDINAL, "_NET_SHOWING_DESKTOP", NULL))) {
++         p_verbose("Cannot get the _NET_SHOWING_DESKTOP property.\n");
++     }
++@@ -678,13 +679,13 @@
++ }/*}}}*/
++ 
++ static int window_to_desktop (Display *disp, Window win, int desktop) {/*{{{*/
++-    unsigned long *cur_desktop = NULL;
+++    CARD32 *cur_desktop = NULL;
++     Window root = DefaultRootWindow(disp);
++    
++     if (desktop == -1) {
++-        if (! (cur_desktop = (unsigned long *)get_property(disp, root,
+++        if (! (cur_desktop = (CARD32 *)get_property(disp, root,
++                 XA_CARDINAL, "_NET_CURRENT_DESKTOP", NULL))) {
++-            if (! (cur_desktop = (unsigned long *)get_property(disp, root,
+++            if (! (cur_desktop = (CARD32 *)get_property(disp, root,
++                     XA_CARDINAL, "_WIN_WORKSPACE", NULL))) {
++                 fputs("Cannot get current desktop properties. "
++                       "(_NET_CURRENT_DESKTOP or _WIN_WORKSPACE property)"
++@@ -702,12 +703,12 @@
++ 
++ static int activate_window (Display *disp, Window win, /* {{{ */
++         gboolean switch_desktop) {
++-    unsigned long *desktop;
+++    CARD32 *desktop;
++ 
++     /* desktop ID */
++-    if ((desktop = (unsigned long *)get_property(disp, win,
+++    if ((desktop = (CARD32 *)get_property(disp, win,
++             XA_CARDINAL, "_NET_WM_DESKTOP", NULL)) == NULL) {
++-        if ((desktop = (unsigned long *)get_property(disp, win,
+++        if ((desktop = (CARD32 *)get_property(disp, win,
++                 XA_CARDINAL, "_WIN_WORKSPACE", NULL)) == NULL) {
++             p_verbose("Cannot find desktop ID of the window.\n");
++         }
++@@ -1016,16 +1017,16 @@
++ }/*}}}*/
++ 
++ static int list_desktops (Display *disp) {/*{{{*/
++-    unsigned long *num_desktops = NULL;
++-    unsigned long *cur_desktop = NULL;
+++    CARD32 *num_desktops = NULL;
+++    CARD32 *cur_desktop = NULL;
++     unsigned long desktop_list_size = 0;
++-    unsigned long *desktop_geometry = NULL;
+++    CARD32 *desktop_geometry = NULL;
++     unsigned long desktop_geometry_size = 0;
++     gchar **desktop_geometry_str = NULL;
++-    unsigned long *desktop_viewport = NULL;
+++    CARD32 *desktop_viewport = NULL;
++     unsigned long desktop_viewport_size = 0;
++     gchar **desktop_viewport_str = NULL;
++-    unsigned long *desktop_workarea = NULL;
+++    CARD32 *desktop_workarea = NULL;
++     unsigned long desktop_workarea_size = 0;
++     gchar **desktop_workarea_str = NULL;
++     gchar *list = NULL;
++@@ -1036,9 +1037,9 @@
++     gchar **names = NULL;
++     gboolean names_are_utf8 = TRUE;
++     
++-    if (! (num_desktops = (unsigned long *)get_property(disp, root,
+++    if (! (num_desktops = (CARD32 *)get_property(disp, root,
++             XA_CARDINAL, "_NET_NUMBER_OF_DESKTOPS", NULL))) {
++-        if (! (num_desktops = (unsigned long *)get_property(disp, root,
+++        if (! (num_desktops = (CARD32 *)get_property(disp, root,
++                 XA_CARDINAL, "_WIN_WORKSPACE_COUNT", NULL))) {
++             fputs("Cannot get number of desktops properties. "
++                   "(_NET_NUMBER_OF_DESKTOPS or _WIN_WORKSPACE_COUNT)"
++@@ -1047,9 +1048,9 @@
++         }
++     }
++     
++-    if (! (cur_desktop = (unsigned long *)get_property(disp, root,
+++    if (! (cur_desktop = (CARD32 *)get_property(disp, root,
++             XA_CARDINAL, "_NET_CURRENT_DESKTOP", NULL))) {
++-        if (! (cur_desktop = (unsigned long *)get_property(disp, root,
+++        if (! (cur_desktop = (CARD32 *)get_property(disp, root,
++                 XA_CARDINAL, "_WIN_WORKSPACE", NULL))) {
++             fputs("Cannot get current desktop properties. "
++                   "(_NET_CURRENT_DESKTOP or _WIN_WORKSPACE property)"
++@@ -1074,21 +1075,21 @@
++     }
++  
++     /* common size of all desktops */
++-    if (! (desktop_geometry = (unsigned long *)get_property(disp, DefaultRootWindow(disp),
+++    if (! (desktop_geometry = (CARD32 *)get_property(disp, DefaultRootWindow(disp),
++                     XA_CARDINAL, "_NET_DESKTOP_GEOMETRY", &desktop_geometry_size))) {
++         p_verbose("Cannot get common size of all desktops (_NET_DESKTOP_GEOMETRY).\n");
++     }
++      
++     /* desktop viewport */
++-    if (! (desktop_viewport = (unsigned long *)get_property(disp, DefaultRootWindow(disp),
+++    if (! (desktop_viewport = (CARD32 *)get_property(disp, DefaultRootWindow(disp),
++                     XA_CARDINAL, "_NET_DESKTOP_VIEWPORT", &desktop_viewport_size))) {
++         p_verbose("Cannot get common size of all desktops (_NET_DESKTOP_VIEWPORT).\n");
++     }
++      
++     /* desktop workarea */
++-    if (! (desktop_workarea = (unsigned long *)get_property(disp, DefaultRootWindow(disp),
+++    if (! (desktop_workarea = (CARD32 *)get_property(disp, DefaultRootWindow(disp),
++                     XA_CARDINAL, "_NET_WORKAREA", &desktop_workarea_size))) {
++-        if (! (desktop_workarea = (unsigned long *)get_property(disp, DefaultRootWindow(disp),
+++        if (! (desktop_workarea = (CARD32 *)get_property(disp, DefaultRootWindow(disp),
++                         XA_CARDINAL, "_WIN_WORKAREA", &desktop_workarea_size))) {
++             p_verbose("Cannot get _NET_WORKAREA property.\n");
++         }
++@@ -1301,16 +1302,16 @@
++         gchar *title_out = get_output_str(title_utf8, TRUE);
++         gchar *client_machine;
++         gchar *class_out = get_window_class(disp, client_list[i]); /* UTF8 */
++-        unsigned long *pid;
++-        unsigned long *desktop;
+++        CARD32 *pid;
+++        CARD32 *desktop;
++         int x, y, junkx, junky;
++         unsigned int wwidth, wheight, bw, depth;
++         Window junkroot;
++ 
++         /* desktop ID */
++-        if ((desktop = (unsigned long *)get_property(disp, client_list[i],
+++        if ((desktop = (CARD32 *)get_property(disp, client_list[i],
++                 XA_CARDINAL, "_NET_WM_DESKTOP", NULL)) == NULL) {
++-            desktop = (unsigned long *)get_property(disp, client_list[i],
+++            desktop = (CARD32 *)get_property(disp, client_list[i],
++                     XA_CARDINAL, "_WIN_WORKSPACE", NULL);
++         }
++ 
++@@ -1319,7 +1320,7 @@
++                 XA_STRING, "WM_CLIENT_MACHINE", NULL);
++        
++         /* pid */
++-        pid = (unsigned long *)get_property(disp, client_list[i],
+++        pid = (CARD32 *)get_property(disp, client_list[i],
++                 XA_CARDINAL, "_NET_WM_PID", NULL);
++ 
++ 	    /* geometry */
+--- wmctrl-1.07.orig/main.c
++++ wmctrl-1.07/main.c
+@@ -1425,6 +1425,16 @@
+      *
+      * long_length = Specifies the length in 32-bit multiples of the
+      *               data to be retrieved.
++     *
++     * NOTE:  see 
++     * http://mail.gnome.org/archives/wm-spec-list/2003-March/msg00067.html
++     * In particular:
++     *
++     * 	When the X window system was ported to 64-bit architectures, a
++     * rather peculiar design decision was made. 32-bit quantities such
++     * as Window IDs, atoms, etc, were kept as longs in the client side
++     * APIs, even when long was changed to 64 bits.
++     *
+      */
+     if (XGetWindowProperty(disp, win, xa_prop_name, 0, MAX_PROPERTY_VALUE_LEN / 4, False,
+             xa_prop_type, &xa_ret_type, &ret_format,     
+@@ -1441,6 +1451,8 @@
+ 
+     /* null terminate the result to make string handling easier */
+     tmp_size = (ret_format / 8) * ret_nitems;
++    /* Correct 64 Architecture implementation of 32 bit data */
++    if(ret_format==32) tmp_size *= sizeof(long)/4;
+     ret = g_malloc(tmp_size + 1);
+     memcpy(ret, ret_prop, tmp_size);
+     ret[tmp_size] = '\0';

--- a/extra-wm/wmctrl/autobuild/patches/0002-Fedora-wmctrl-sticky-workspace.patch
+++ b/extra-wm/wmctrl/autobuild/patches/0002-Fedora-wmctrl-sticky-workspace.patch
@@ -1,0 +1,33 @@
+--- a/main.c    
++++ a/main.c    
+@@ -681,7 +681,7 @@ static int window_to_desktop (Display *disp, Window win, int desktop) {/*{{{*/
+     unsigned long *cur_desktop = NULL;
+     Window root = DefaultRootWindow(disp);
+    
+-    if (desktop == -1) {
++    if (desktop == -2) {
+         if (! (cur_desktop = (unsigned long *)get_property(disp, root,
+                 XA_CARDINAL, "_NET_CURRENT_DESKTOP", NULL))) {
+             if (! (cur_desktop = (unsigned long *)get_property(disp, root,
+@@ -897,7 +897,7 @@ static int action_window (Display *disp, Window win, char mode) {/*{{{*/
+         
+         case 'R':
+             /* move the window to the current desktop and activate it => -r */
+-            if (window_to_desktop(disp, win, -1) == EXIT_SUCCESS) {
++            if (window_to_desktop(disp, win, -2) == EXIT_SUCCESS) {
+                 usleep(100000); /* 100 ms - make sure the WM has enough
+                     time to move the window, before we activate it */
+                 return activate_window(disp, win, FALSE);
+--- a/wmctrl.1  
++++ a/wmctrl.1  
+@@ -258,7 +258,8 @@ Include WM_CLASS in the window list or interpret <WIN> as the WM_CLASS name.
+ .TP
+ .I <DESK>
+ A Desktop is always specified by an integer which represents the
+-desktop numbers. Desktop numbers start at 0.
++desktop numbers. Desktop numbers start at 0. Use -1 to pin to all
++desktops.
+ 
+ .TP
+ .I <MVARG>
+

--- a/extra-wm/wmctrl/spec
+++ b/extra-wm/wmctrl/spec
@@ -1,0 +1,3 @@
+VER=1.07
+SRCS="http://tripie.sweb.cz/utils/wmctrl/dist/wmctrl-${VER}.tar.gz"
+CHKSUMS="sha256::d78a1efdb62f18674298ad039c5cbdb1edb6e8e149bb3a8e3a01a4750aa3cca9"


### PR DESCRIPTION
Topic Description
-----------------

Add `wmctrl` package

Package(s) Affected
-------------------

wmctrl

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`