### PR TITLE
bash-startup: update to 0.6.4.5

### DIFF
--- a/base-misc/bash-startup/spec
+++ b/base-misc/bash-startup/spec
@@ -1,3 +1,3 @@
-VER=0.4.6.4
+VER=0.4.6.5
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"

--- a/extra-shells/zsh/autobuild/beyond
+++ b/extra-shells/zsh/autobuild/beyond
@@ -1,4 +1,4 @@
-abinfo "Installing a symlink, /etc/zprofile => /etc/profile ..."
-mkdir -pv "$PKGDIR"/etc
-ln -sv profile \
-    "$PKGDIR"/etc/zprofile
+abinfo "Installing a symlink, /etc/zsh/zprofile => /etc/profile ..."
+mkdir -pv "$PKGDIR"/etc/zsh
+ln -sv /etc/profile \
+    "$PKGDIR"/etc/zsh/zprofile

--- a/extra-shells/zsh/autobuild/beyond
+++ b/extra-shells/zsh/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing a symlink, /etc/zprofile => /etc/profile ..."
+ln -sv profile \
+    "$PKGDIR"/etc/zprofile

--- a/extra-shells/zsh/autobuild/beyond
+++ b/extra-shells/zsh/autobuild/beyond
@@ -1,3 +1,4 @@
 abinfo "Installing a symlink, /etc/zprofile => /etc/profile ..."
+mkdir -pv "$PKGDIR"/etc
 ln -sv profile \
     "$PKGDIR"/etc/zprofile

--- a/extra-shells/zsh/spec
+++ b/extra-shells/zsh/spec
@@ -1,4 +1,4 @@
 VER=5.8
-REL=1
+REL=2
 SRCTBL="https://www.zsh.org/pub/zsh-$VER.tar.xz"
 CHKSUM="sha256::dcc4b54cc5565670a65581760261c163d720991f0d06486da61f8d839b52de27"


### PR DESCRIPTION
Topic Description
-----------------

Update `bash-startup` to v0.6.4.5, which resolves an error on login:

```
/etc/profile: line 35: syntax error near unexpected token `('
/etc/profile: line 35: `for script in /etc/profile.d/!(*.dpkg*) ; do'
```

This also makes `/etc/profile` compatible with Zsh, making it easier for Zsh users (@OriginCode Should we ship /etc/zprofile => /etc/profile symlink with `zsh`?).

Package(s) Affected
-------------------

- `bash-startup` v0.4.6.5

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`