### PR TITLE
fcitx5 use acbs tofetch dict file

### DIFF
--- a/extra-i18n/fcitx5-chinese-addons/spec
+++ b/extra-i18n/fcitx5-chinese-addons/spec
@@ -1,3 +1,7 @@
 VER=5.0.2
-SRCS="tbl::https://github.com/fcitx/fcitx5-chinese-addons/archive/$VER.tar.gz"
-CHKSUMS="sha256::4b3731fc790d071273fbd91beb76d23166992add060cfd89ecaa55f147036dc6"
+SRCS="tbl::https://github.com/fcitx/fcitx5-chinese-addons/archive/$VER.tar.gz \
+      tbl::https://download.fcitx-im.org/fcitx5/fcitx5-chinese-addons/fcitx5-chinese-addons-${VER}_dict.tar.xz"
+CHKSUMS="sha256::4b3731fc790d071273fbd91beb76d23166992add060cfd89ecaa55f147036dc6 \
+         sha256::d76522f236fd07080e5dd6c607c8261971d94d28743c632588ccc1cfff0bc955"
+SUBDIR="fcitx5-chinese-addons-$VER"
+REL=1

--- a/extra-i18n/fcitx5/spec
+++ b/extra-i18n/fcitx5/spec
@@ -1,3 +1,7 @@
 VER=5.0.3
-SRCS="tbl::https://github.com/fcitx/fcitx5/archive/$VER.tar.gz"
-CHKSUMS="sha256::025eed83775c70f099bb1cbceb81fd3cdd490df32db122329340046f33abda9a"
+SRCS="tbl::https://github.com/fcitx/fcitx5/archive/$VER.tar.gz \
+      tbl::https://download.fcitx-im.org/fcitx5/fcitx5/fcitx5-${VER}_dict.tar.xz"
+CHKSUMS="sha256::025eed83775c70f099bb1cbceb81fd3cdd490df32db122329340046f33abda9a \
+         sha256::439351ce5e900e857b30b191b3d592e56f4df2b0e9f858d078d06651c758f31b"
+SUBDIR="fcitx5-$VER"
+REL=1

--- a/extra-i18n/libime/spec
+++ b/extra-i18n/libime/spec
@@ -1,3 +1,7 @@
 VER=1.0.2
-SRCS="git::commit=tags/$VER::https://github.com/fcitx/libime/"
-CHKSUMS="SKIP"
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/libime/ \
+      tbl::https://download.fcitx-im.org/fcitx5/libime/libime-${VER}_dict.tar.xz"
+CHKSUMS="SKIP \
+         sha256::61f04729b58a02c4e25de91ab970c4597f6922977f32166d1ed0dce317b3d700"
+SUBDIR="libime-$VER"
+REL=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fcitx5 use acbs tofetch dict file

Package(s) Affected
-------------------

fcitx5 5.0.3-1
fcitx5-chinese-addons 5.0.2-1
libime 1.0.2-1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
