### PR TITLE
wine: update to 6.0

### DIFF
--- a/extra-emulation/wine/spec
+++ b/extra-emulation/wine/spec
@@ -1,5 +1,6 @@
-VER=5.22
-SRCS="tbl::https://dl.winehq.org/wine/source/5.x/wine-$VER.tar.xz \
+VER=6.0
+SRCS="tbl::https://dl.winehq.org/wine/source/$VER/wine-$VER.tar.xz \
       git::rename=wine-staging;commit=tags/v$VER::https://github.com/wine-staging/wine-staging"
-CHKSUMS="sha256::09bd06c87c8c974e6ad34507cec875d7217eb56fc09df838d5453e0ebbce4d21 SKIP"
+CHKSUMS="sha256::b493065f2f83ee429c62e2ec58698a3cf63ef78722e1b20765823152e8582c56 \
+         SKIP"
 SUBDIR="wine-$VER"

--- a/extra-libs/vkd3d/spec
+++ b/extra-libs/vkd3d/spec
@@ -1,4 +1,3 @@
-VER=1.1
+VER=1.2
 SRCTBL=https://dl.winehq.org/vkd3d/source/vkd3d-${VER}.tar.xz
-CHKSUM="sha256::495adc61cc80c65d54b2f5b52092ea05d3797cc2c17a610f0fc98457d2f56ab6"
-REL=1
+CHKSUM="sha256::b04b030fcbf0f2dacc933c76c74b449bffef1fc1a18d50254ef1ad3e380df96b"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

wine: update to 6.0

Package(s) Affected
-------------------

vkd3d: 1.2
wine: 6.0

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->
