### PR TITLE
zola: update to 0.13.0

### DIFF
--- a/extra-web/zola/autobuild/defines
+++ b/extra-web/zola/autobuild/defines
@@ -5,3 +5,4 @@ BUILDDEP="cargo llvm"
 PKGDES="A fast static site generator in a single binary with everything built in"
 
 USECLANG=1
+CARGO_AFTER="--features search/indexing-zh,search/indexing-ja"

--- a/extra-web/zola/autobuild/patches/0001-zola-enable-cjk-indexing.patch
+++ b/extra-web/zola/autobuild/patches/0001-zola-enable-cjk-indexing.patch
@@ -1,0 +1,35 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 5225d59..11ca950 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -3258,6 +3258,7 @@ dependencies = [
+  "open",
+  "percent-encoding",
+  "relative-path",
++ "search",
+  "serde_json",
+  "site",
+  "termcolor",
+diff --git a/Cargo.toml b/Cargo.toml
+index 5445f5c..a429539 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -37,7 +37,7 @@ open = "1.2"
+ globset = "0.4"
+ relative-path = "1"
+ serde_json = "1.0"
+-
++search = { path = "components/search" }
+ site = { path = "components/site" }
+ errors = { path = "components/errors" }
+ front_matter = { path = "components/front_matter" }
+diff --git a/components/utils/src/de.rs b/components/utils/src/de.rs
+index e294e92..568d71a 100644
+--- a/components/utils/src/de.rs
++++ b/components/utils/src/de.rs
+@@ -1,5 +1,4 @@
+ use serde::{Deserialize, Deserializer};
+-use serde_derive::Deserialize;
+ use tera::{Map, Value};
+ 
+ /// Used as an attribute when we want to convert from TOML to a string date

--- a/extra-web/zola/spec
+++ b/extra-web/zola/spec
@@ -1,4 +1,3 @@
-VER=0.12.2
-REL=2
-SRCTBL="https://github.com/getzola/zola/archive/v$VER.tar.gz"
-CHKSUM="sha256::1c0cb37e9a3d9f7ff41012996eb068fb5453c9727f107ac817429cbdae4dae84"
+VER=0.13.0
+SRCS="tbl::https://github.com/getzola/zola/archive/v$VER.tar.gz"
+CHKSUMS="sha256::84c20cf5c851a465266c5cc343623752102c53929f6da31b2a4ce747a87c5c23"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

zola: update to 0.13.0

Package(s) Affected
-------------------

zola 0.13.0

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
