### PR TITLE
pipewire: update to 0.3.19

### DIFF
--- a/extra-multimedia/pipewire/spec
+++ b/extra-multimedia/pipewire/spec
@@ -1,3 +1,3 @@
-VER=0.3.17
+VER=0.3.19
 SRCS="https://github.com/PipeWire/pipewire/archive/$VER.tar.gz"
-CHKSUMS="sha256::46d2f597506ef56b0be54498ab26b58bacdd7cae30f87f47836f1f717a0d05ac"
+CHKSUMS="whirlpool::c9dcec461f3cd348d47da0cb7b09b9200807712f74957e90999c716bb16ec11b375744252fc9b61ee166515b053613e4cc5d012464d38ca8e672996d04051ea5"


### PR DESCRIPTION
Topic Description
-----------------
Update `pipewire` to version 0.3.19

Package(s) Affected
-------------------
* `pipewire`

Security Update?
----------------
No 

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
