### PR TITLE
pushpkg: update to 0+git20210116

### DIFF
--- a/extra-devel/pushpkg/autobuild/defines
+++ b/extra-devel/pushpkg/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=devel
 PKGDEP="bash rsync"
 PKGDES="A simple wrapper script for the standard AOSC OS package upload procedure"
 
+PKGEPOCH=1
 ABHOST=noarch

--- a/extra-devel/pushpkg/spec
+++ b/extra-devel/pushpkg/spec
@@ -1,4 +1,4 @@
-VER=20190728
-GITSRC="https://github.com/AOSC-Dev/scriptlets"
-GITCO="5a22cc83e7b965a3b7de3868ab40cb39045bfc3d"
+VER=0+git20210116
+SRCS="git::commit=c0b24199d4ebb31f3deb3a1186c0ce272279402e::https://github.com/AOSC-Dev/scriptlets"
+CHKSUMS="SKIP"
 SUBDIR="pushpkg/pushpkg"


### PR DESCRIPTION
Topic Description
-----------------

Update pushpkg to 0+git20210116

Package(s) Affected
-------------------

pushpkg

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`