### PR TITLE
baidupcs-go: update to 3.7.2

### DIFF
--- a/extra-web/baidupcs-go/autobuild/prepare
+++ b/extra-web/baidupcs-go/autobuild/prepare
@@ -1,0 +1,1 @@
+export GOCACHE="$SRCDIR"

--- a/extra-web/baidupcs-go/spec
+++ b/extra-web/baidupcs-go/spec
@@ -1,4 +1,3 @@
-VER=3.6.2
-REL=2
-SRCTBL="https://github.com/felixonmars/BaiduPCS-Go/archive/v$VER.tar.gz"
-CHKSUM="sha256::27c64733e0d4dd276b6a914f521242fd33e97343da58a8b2de73a72c034c2bc7"
+VER=3.7.2
+SRCTBL="https://github.com/qjfoidnh/BaiduPCS-Go/archive/v$VER.tar.gz"
+CHKSUM="sha256::e4ead9177957d02b6814f17e88b8f1681e482b45369142c76aca7441ff5a9146"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

baidupcs-go: update to 3.7.2

- Switch upstream to github.com/qjfoidnh/BaiduPCS-Go

Package(s) Affected
-------------------

baidupcs-go 3.7.2

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
