### PR TITLE
pipewire: update to 0.3.20

### DIFF
--- a/extra-multimedia/pipewire/spec
+++ b/extra-multimedia/pipewire/spec
@@ -1,3 +1,3 @@
-VER=0.3.17
+VER=0.3.20
 SRCS="https://github.com/PipeWire/pipewire/archive/$VER.tar.gz"
-CHKSUMS="sha256::46d2f597506ef56b0be54498ab26b58bacdd7cae30f87f47836f1f717a0d05ac"
+CHKSUMS="whirlpool::c1979076c57eb2c9537ac15b1b03d9a6e7e97c196030ced3b92a0c1525f6afa5cc3c40142d4a470bfb50f35b50809f2f4f354409119450059239c3197145beec"


### PR DESCRIPTION

Topic Description
-----------------
Update `pipewire` to the version 0.3.20.

Package(s) Affected
-------------------
- `pipewire`


Security Update?
----------------
No

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------
- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

