### PR TITLE
radvd: upgrade to 2.19

### DIFF
--- a/extra-network/radvd/autobuild/defines
+++ b/extra-network/radvd/autobuild/defines
@@ -3,4 +3,4 @@ PKGSEC=net
 PKGDEP="glibc"
 PKGDES="IPv6 router advertisement daemon"
 
-AUTOTOOLS_AFTER="--with-pidfile=/var/run/radvd.pid"
+AUTOTOOLS_AFTER="--with-pidfile=/run/radvd.pid"

--- a/extra-network/radvd/autobuild/overrides/usr/lib/systemd/system/radvd.service
+++ b/extra-network/radvd/autobuild/overrides/usr/lib/systemd/system/radvd.service
@@ -3,7 +3,7 @@ Description=IPv6 Router Advertisement Daemon
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/radvd --nodaemon --logmethod=stderr
+ExecStart=/usr/bin/radvd --nodaemon
 
 [Install]
 WantedBy=multi-user.target

--- a/extra-network/radvd/spec
+++ b/extra-network/radvd/spec
@@ -1,3 +1,3 @@
-VER=2.18
+VER=2.19
 SRCTBL="http://www.litech.org/radvd/dist/radvd-$VER.tar.xz"
-CHKSUM="sha256::e1bffefe6537e4b205d33afda35fec6014e5f860cc364850068a6ed9c6a65cdc"
+CHKSUM="sha256::564e04597f71a9057d02290da0dd21b592d277ceb0e7277550991d788213e240"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates `radvd` to 2.19 and resolves #2695. Note that the pid file is now in `/run` instead of `/var/run`.

Package(s) Affected
-------------------

* radvd 2.18 -> 2.19

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
