### PR TITLE
cgproxy: new, 0.19

### DIFF
--- a/extra-network/cgproxy/autobuild/conffiles
+++ b/extra-network/cgproxy/autobuild/conffiles
@@ -1,0 +1,1 @@
+/etc/cgproxy/config.json

--- a/extra-network/cgproxy/autobuild/defines
+++ b/extra-network/cgproxy/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=cgproxy
+PKGSEC=net
+PKGDEP="libbpf iproute2 which iptables"
+BUILDDEP="nlohmann-json"
+PKGDES="Transparent proxy with cgroup v2 and tproxy."

--- a/extra-network/cgproxy/spec
+++ b/extra-network/cgproxy/spec
@@ -1,0 +1,4 @@
+VER=0.19
+SRCTBL="https://github.com/springzfx/cgproxy/archive/v$VER.tar.gz"
+CHKSUM="sha256::aa1a7ee1f62b9bb56872353d16835f82b9a27454ce1e3ddfe668c96f7af9cef7"
+

--- a/extra-network/libbpf/autobuild/build
+++ b/extra-network/libbpf/autobuild/build
@@ -1,0 +1,2 @@
+make -C src
+make -C src DESTDIR="${PKGDIR}" LIBSUBDIR=lib install install_headers

--- a/extra-network/libbpf/autobuild/defines
+++ b/extra-network/libbpf/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=libbpf
+PKGSEC=net
+PKGDEP="glibc elfutils linux+api"
+BUILDDEP="pkg-config"
+PKGDES="Automated upstream mirror for libbpf stand-alone build."
+NOLTO=1

--- a/extra-network/libbpf/spec
+++ b/extra-network/libbpf/spec
@@ -1,0 +1,3 @@
+VER=0.3
+SRCS="https://github.com/libbpf/libbpf/archive/v$VER.tar.gz"
+CHKSUMS="sha256::c168d84a75b541f753ceb49015d9eb886e3fb5cca87cdd9aabce7e10ad3a1efc"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
cgproxy: new, 0.19
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- `libbpf`
- `cgproxy`
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------
- `libbpf`-> `cgproxy`


Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
