### PR TITLE
dnsmasq: update to 2.83, fix translations and dbus conf install location

### DIFF
--- a/extra-network/dnsmasq/autobuild/build
+++ b/extra-network/dnsmasq/autobuild/build
@@ -1,24 +1,34 @@
+_COPTS="-DHAVE_DNSSEC -DHAVE_DBUS -DHAVE_LIBIDN2"
 abinfo "Building Dnsmasq ..."
 make \
     CFLAGS="$CPPFLAGS $CFLAGS" \
     LDFLAGS="$LDFLAGS" \
-    COPTS="-DHAVE_DNSSEC -DHAVE_DBUS"
+    COPTS="${_COPTS}" \
+    all
+
+abinfo "Generating translations"
+make \
+    CFLAGS="$CPPFLAGS $CFLAGS" \
+    LDFLAGS="$LDFLAGS" \
+    COPTS="${_COPTS}" \
+    all-i18n
 
 abinfo "Installing Dnsmasq ..."
 make BINDIR=/usr/bin \
      PREFIX=/usr \
      DESTDIR="$PKGDIR" \
-     install
+     COPTS="${_COPTS}" \
+     install install-i18n
 
 abinfo "Installing D-Bus configuration ..."
 install -Dvm644 "$SRCDIR"/dbus/dnsmasq.conf \
-    "$PKGDIR"/etc/dbus-1/system.d/dnsmasq.conf
+    "$PKGDIR"/usr/share/dbus-1/system.d/dnsmasq.conf
 
 abinfo "Installing default dnsmasq.conf ..."
 install -Dvm644 "$SRCDIR"/dnsmasq.conf.example \
     "$PKGDIR"/etc/dnsmasq.conf
 
-abinfo "Tweaking /etc/dnsmasq ..."
+abinfo "Setting prefix location in config files ..."
 sed -e 's,%%PREFIX%%,/usr,' \
     -i "$PKGDIR"/etc/dnsmasq.conf
 

--- a/extra-network/dnsmasq/autobuild/defines
+++ b/extra-network/dnsmasq/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=dnsmasq
 PKGSEC=net
-PKGDEP="dbus glibc gmp nettle"
+PKGDEP="dbus glibc gmp nettle libidn2"
 PKGDES="Lightweight, easy to configure DNS forwarder and DHCP server"

--- a/extra-network/dnsmasq/spec
+++ b/extra-network/dnsmasq/spec
@@ -1,3 +1,3 @@
-VER=2.82
+VER=2.83
 SRCTBL="http://www.thekelleys.org.uk/dnsmasq/dnsmasq-$VER.tar.xz"
-CHKSUM='sha256::84523646f3116bb5e1151efb66e645030f6e6a8256f29aab444777a343ebc132'
+CHKSUM="sha256::ffc1f7e8b05e22d910b9a71d09f1128197292766dc7c54cb7018a1b2c3af4aea"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates dnsmasq to 2.83. This version now includes translations.

Package(s) Affected
-------------------

* dnsmasq

Security Update?
----------------

Yes - Issue Number: #2715 .

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`


Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
