### PR TITLE
Userspace programs for extended Berkeley packet filter support

### DIFF
--- a/extra-admin/bpftrace/autobuild/defines
+++ b/extra-admin/bpftrace/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=bpftrace
+PKGSEC=admin
+PKGDEP="elfutils zlib llvm bcc libbpf"
+BUILDDEP="linux+kernel"
+PKGDES="High-level tracing language and utilities for BPF, kprobes, uprobes and tracepoints"
+
+CMAKE_AFTER="
+        -DLIBBFD_LIBRARIES=${SRCDIR}/libbfd.so
+        -DLIBOPCODES_LIBRARIES=${SRCDIR}/libopcodes.so
+"
+
+# bpftrace needs to lookup symbols from itself. Stripping off would remove BEGIN_trigger
+# and other symbols from itself.
+ABSTRIP=0

--- a/extra-admin/bpftrace/autobuild/defines
+++ b/extra-admin/bpftrace/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=bpftrace
 PKGSEC=admin
 PKGDEP="elfutils zlib llvm bcc libbpf"
-BUILDDEP="linux+kernel"
+BUILDDEP="linux+kernel gdb"
+# linux+kernel: system call and tracepoint definitions
+# gdb: /usr/include/diagnostics.h
 PKGDES="High-level tracing language and utilities for BPF, kprobes, uprobes and tracepoints"
 
 CMAKE_AFTER="

--- a/extra-admin/bpftrace/autobuild/patches/0001-include-btf_func_linkage-for-older-kernels.patch
+++ b/extra-admin/bpftrace/autobuild/patches/0001-include-btf_func_linkage-for-older-kernels.patch
@@ -1,0 +1,28 @@
+diff --git a/src/btf.h b/src/btf.h
+index 61579a3..4e9f9fc 100644
+--- a/src/btf.h
++++ b/src/btf.h
+@@ -2,6 +2,7 @@
+ 
+ #include "types.h"
+ #include <linux/types.h>
++#include <linux/version.h>
+ #include <map>
+ #include <regex>
+ #include <string>
+@@ -11,6 +12,15 @@
+ struct btf;
+ struct btf_type;
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0)
++/* this is required to build with 5.4 and earlier kernel headers */
++enum btf_func_linkage {
++    BTF_FUNC_STATIC = 0,
++    BTF_FUNC_GLOBAL = 1,
++    BTF_FUNC_EXTERN = 2,
++};
++#endif
++
+ namespace bpftrace {
+ 
+ class BTF

--- a/extra-admin/bpftrace/autobuild/patches/0002-test-cases-replace-open-with-openat-on-arm64.patch
+++ b/extra-admin/bpftrace/autobuild/patches/0002-test-cases-replace-open-with-openat-on-arm64.patch
@@ -1,0 +1,84 @@
+From 330953c11190c23a12f98d374d1b5eb6d7aad1fe Mon Sep 17 00:00:00 2001
+From: Chunmei Xu <xuchunmei@linux.alibaba.com>
+Date: Wed, 11 Nov 2020 16:23:19 +0800
+Subject: [PATCH] fix build failed on aarch64
+
+since linux has drop __NR_open on aarch64, syscall.c  will build
+failed on aarch64 without __NR_open defined.
+
+Signed-off-by: Chunmei Xu <xuchunmei@linux.alibaba.com>
+---
+ tests/testprogs/syscall.c | 31 ++++++++++++++++++++++++-------
+ 1 file changed, 24 insertions(+), 7 deletions(-)
+
+diff --git a/tests/testprogs/syscall.c b/tests/testprogs/syscall.c
+index c21246603..ca1f69968 100644
+--- a/tests/testprogs/syscall.c
++++ b/tests/testprogs/syscall.c
+@@ -15,7 +15,9 @@ void usage()
+   printf("\t./syscall <syscall name> [<arguments>]\n");
+   printf("Supported Syscalls:\n");
+   printf("\t nanosleep [$N] (default args: 100ns)\n");
++#if defined(SYS_open)
+   printf("\t open\n");
++#endif
+   printf("\t openat\n");
+   printf("\t read\n");
+   printf("\t execve <path> [<arguments>] (at most 128 arguments)\n");
+@@ -82,8 +84,19 @@ int gen_open_openat(bool is_sys_open)
+ {
+   char *file_path = get_tmp_file_path(
+       "/bpftrace_runtime_test_syscall_gen_open_temp");
+-  int fd = is_sys_open ? syscall(SYS_open, file_path, O_CREAT)
+-                       : syscall(SYS_openat, AT_FDCWD, file_path, O_CREAT);
++  int fd = -1;
++
++  if (is_sys_open)
++  {
++#if defined(SYS_open)
++    fd = syscall(SYS_open, file_path, O_CREAT);
++#endif
++  }
++  else
++  {
++    fd = syscall(SYS_openat, AT_FDCWD, file_path, O_CREAT);
++  }
++
+   if (fd < 0)
+   {
+     perror("Error in syscall open/openat");
+@@ -154,7 +167,6 @@ int main(int argc, char *argv[])
+     return 1;
+   }
+   const char *syscall_name = argv[1];
+-  bool is_sys_open = false;
+   int r = 0;
+ 
+   if (strcmp("--help", syscall_name) == 0 || strcmp("-h", syscall_name) == 0)
+@@ -165,11 +177,16 @@ int main(int argc, char *argv[])
+   {
+     r = gen_nanosleep(argc, argv);
+   }
+-  else if ((is_sys_open = (strcmp("open", syscall_name) == 0)) ||
+-           strcmp("openat", syscall_name) == 0)
++  else if (strcmp("openat", syscall_name) == 0)
+   {
+-    r = gen_open_openat(is_sys_open);
++    r = gen_open_openat(false);
+   }
++#if defined(SYS_open)
++  else if (strcmp("open", syscall_name) == 0)
++  {
++    r = gen_open_openat(true);
++  }
++#endif
+   else if (strcmp("read", syscall_name) == 0)
+   {
+     r = gen_read();
+@@ -186,4 +203,4 @@ int main(int argc, char *argv[])
+   }
+ 
+   return r;
+-}
+\ No newline at end of file
++}

--- a/extra-admin/bpftrace/autobuild/prepare
+++ b/extra-admin/bpftrace/autobuild/prepare
@@ -1,0 +1,5 @@
+abinfo "Ask CMake to link statically against libbfd"
+echo 'INPUT( /usr/lib/libbfd.a -liberty -lz -ldl )' > "${SRCDIR}/libbfd.so"
+
+abinfo "Ask CMake to link statically against libopcodes"
+echo 'INPUT( /usr/lib/libopcodes.a -lbfd )' > "${SRCDIR}/libopcodes.so"

--- a/extra-admin/bpftrace/spec
+++ b/extra-admin/bpftrace/spec
@@ -1,0 +1,3 @@
+VER=0.11.4
+SRCS="tbl::https://github.com/iovisor/bpftrace/archive/v${VER}.tar.gz"
+CHKSUMS="sha256::5b9c7509887e4337841e3188eabcc7247bc2c1cc312c983cbb8b77e341d20242"

--- a/extra-devel/bcc/autobuild/build
+++ b/extra-devel/bcc/autobuild/build
@@ -1,0 +1,18 @@
+abinfo "Entering shadow build directory"
+mkdir "${SRCDIR}"/build
+pushd "${SRCDIR}"/build
+
+abinfo "Generating Ninja build configuration ..."
+cmake -GNinja \
+      ${CMAKE_DEF} \
+      -DPYTHON_CMD="python3" \
+      -DREVISION=$PKGVER \
+      ..
+
+abinfo "Compiling binaries ..."
+cmake --build .
+
+abinfo "Instaling binaries ..."
+DESTDIR="${PKGDIR}" cmake --install .
+
+popd

--- a/extra-devel/bcc/autobuild/defines
+++ b/extra-devel/bcc/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=bcc
+PKGSEC=devel
+PKGDEP="llvm elfutils libedit ethtool luajit python-3 netaddr libbpf"
+BUILDDEP="flex bison"
+PKGDES="BPF compiler collection and tools for Linux kernel tracing and instrumentation"
+
+NOSTATIC=0

--- a/extra-devel/bcc/spec
+++ b/extra-devel/bcc/spec
@@ -1,0 +1,3 @@
+VER=0.18.0
+SRCS="tarball::https://github.com/iovisor/bcc/releases/download/v${VER}/bcc-src-with-submodule.tar.gz"
+CHKSUMS="sha256::d05f2da69545bbb727b929e581c12f6c47729316211899d3734e08f7cff2215b"

--- a/extra-kernel/libbpf/autobuild/build
+++ b/extra-kernel/libbpf/autobuild/build
@@ -1,0 +1,9 @@
+pushd "${SRCDIR}"/src
+abinfo "Building binaries ..."
+make
+abinfo "Installing binaries ..."
+make install DESTDIR="${PKGDIR}" LIBSUBDIR=lib install install_headers
+popd
+
+abinfo "Installing readme documents ..."
+install -Dm644 "${SRCDIR}"/README.md "${SRCDIR}"/src/README.rst -t "${PKGDIR}/usr/share/doc/libbpf"

--- a/extra-kernel/libbpf/autobuild/defines
+++ b/extra-kernel/libbpf/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=libbpf
+PKGSEC=kernel
+PKGDEP="elfutils"
+BUILDDEP="linux+api rsync"
+PKGDES="Library for loading eBPF programs from userspace"
+
+# GCC has issue handling versioned symbols with LTO. This should've been fixed,
+# but for some reason this doesn't work.
+NOLTO=1

--- a/extra-kernel/libbpf/spec
+++ b/extra-kernel/libbpf/spec
@@ -1,0 +1,3 @@
+VER=0.3
+SRCS="tarball::https://github.com/libbpf/libbpf/archive/v${VER}/libbpf-${VER}.tar.gz"
+CHKSUMS="sha256::c168d84a75b541f753ceb49015d9eb886e3fb5cca87cdd9aabce7e10ad3a1efc"

--- a/extra-utils/pahole/autobuild/defines
+++ b/extra-utils/pahole/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=pahole
+PKGSEC=utils
+PKGDEP="elfutils zlib"
+PKGDES="Object file and debug information analysis utility"
+
+CMAKE_AFTER="-DLIB_INSTALL_DIR=/usr/lib"

--- a/extra-utils/pahole/spec
+++ b/extra-utils/pahole/spec
@@ -1,0 +1,3 @@
+VER=1.19
+SRCS="git::commit=v$VER::https://git.kernel.org/pub/scm/devel/pahole/pahole.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

This PR introduces a handful of packages required to utilize eBPF tracepoints in kernel.

Package(s) Affected
-------------------

* `pahole`: DWARF debug symbol processor (by Lion Yang)
* `libbpf`: Library for eBPF loading from user-space
* `bcc`: eBPF program compiler collection (and python 3 bindings)
* `bpftrace`: High level BPF tracing utilities

Build Order
-----------

`pahole` | (`libbpf` -> `bcc` -> `bpftrace`) 

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
