### PR TITLE
openjdk-8: Update to 8u282

### DIFF
--- a/extra-java/openjdk-8/spec
+++ b/extra-java/openjdk-8/spec
@@ -1,10 +1,10 @@
-VER=8u275+ga
+VER=8u282+ga
 # aarch64 specific tarball
 SRCS__ARM64="https://repo.aosc.io/aosc-repacks/aarch64-java/openjdk-${VER/+/-}.tar.xz"
-CHKSUMS__ARM64="sha256::52d37517a14a32f52f21641bc86133d3b24f2b1ea89272a24f3be7e56c3d70f2"
+CHKSUMS__ARM64="sha256::37d7218f27377638c17978cbfb4f7bbd2c1e80f2d925f68dc46267cad5f29532"
 # loongson3 specific tarball
 SRCS__LOONGSON3="https://repo.aosc.io/aosc-repacks/ls3-java/openjdk-${VER/+/-}.tar.xz"
-CHKSUMS__LOONGSON3="sha256::ad011ce40960830fca5f477d409cebfc1eebb6ca99ee16b8100f23d9ea19f79c"
+CHKSUMS__LOONGSON3="sha256::64f12078dcf69274ab16ca1e3b80d1f24b7c2d921176c594c10e8e23802ebf2c"
 
 SRCS="https://openjdk-sources.osci.io/openjdk8/openjdk${VER/+/-}.tar.xz"
-CHKSUMS="sha256::6a83e8bd8caebf5dc8989a22925ac5598c9edb2ba8dcfad7472a5ff99a14c0e7"
+CHKSUMS="sha256::e5c0000d54fea680375ab06e6d477713fb5c294d84baf0ed6224498bde811b7c"

--- a/extra-java/openjfx-8/autobuild/patches/0005-fix-build-on-gcc10.patch
+++ b/extra-java/openjfx-8/autobuild/patches/0005-fix-build-on-gcc10.patch
@@ -1,0 +1,24 @@
+diff -Naur rt-8u202-ga-bak/modules/fxpackager/src/main/native/library/common/PosixPlatform.cpp rt-8u202-ga/modules/fxpackager/src/main/native/library/common/PosixPlatform.cpp
+--- rt-8u202-ga-bak/modules/fxpackager/src/main/native/library/common/PosixPlatform.cpp	2021-01-21 01:27:38.384099997 -0700
++++ rt-8u202-ga/modules/fxpackager/src/main/native/library/common/PosixPlatform.cpp	2021-01-21 01:32:06.400365334 -0700
+@@ -43,7 +43,7 @@
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ #include <unistd.h>
+-#include <sys/sysctl.h>
++#include <linux/sysctl.h>
+ #include <iostream>
+ #include <dlfcn.h>
+ #include <signal.h>
+diff -Naur rt-8u202-ga-bak/modules/media/src/main/native/gstreamer/projects/linux/gstreamer-lite/Makefile rt-8u202-ga/modules/media/src/main/native/gstreamer/projects/linux/gstreamer-lite/Makefile
+--- rt-8u202-ga-bak/modules/media/src/main/native/gstreamer/projects/linux/gstreamer-lite/Makefile	2021-01-21 01:27:38.474099750 -0700
++++ rt-8u202-ga/modules/media/src/main/native/gstreamer/projects/linux/gstreamer-lite/Makefile	2021-01-21 01:31:10.390518523 -0700
+@@ -56,7 +56,7 @@
+         -DGST_DISABLE_GST_DEBUG \
+         -DGST_DISABLE_LOADSAVE  \
+         -DG_DISABLE_DEPRECATED   \
+-        -ffunction-sections -fdata-sections
++        -ffunction-sections -fdata-sections -fcommon
+ 
+ ifeq ($(BUILD_TYPE), Release)
+     CFLAGS += -Os

--- a/extra-java/openjfx-8/spec
+++ b/extra-java/openjfx-8/spec
@@ -1,4 +1,4 @@
 VER=8u202+ga
-REL=5
+REL=6
 SRCTBL="https://repo.aosc.io/aosc-repacks/openjfx-8u202-ga.tar.bz2"
 CHKSUM="sha256::12b0538d04c4bd451e4692ee06357ac36233ff4ec2af9fa3b9bbdbab48c3f2fc"


### PR DESCRIPTION
Topic Description
-----------------
Update OpenJDK 8u to 8u282


Package(s) Affected
-------------------

```
openjfx-8
openjdk-8
```

Security Update?
----------------

Yes - Issue Number: `#PENDING`

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [X] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [X] Loongson 3 `loongson3`
- [X] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

