### PR TITLE
intel-graphics-compiler: update to igc-1.0.5964

### DIFF
--- a/extra-devel/intel-graphics-compiler/autobuild/patches/0004-fix-build-with-llvm-11.patch
+++ b/extra-devel/intel-graphics-compiler/autobuild/patches/0004-fix-build-with-llvm-11.patch
@@ -45,19 +45,6 @@ index fd1e7656..293fcd5e 100644
                  offset += (unsigned int) DL.getTypeAllocSize(varType);
              }
  
-diff --git a/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp b/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp
-index 9b185a49..ffd721db 100644
---- a/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp
-+++ b/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp
-@@ -2269,7 +2269,7 @@ static void decomposeSdivPow2(Instruction &Sdiv,
- 
-   auto createConstantVector = [](unsigned int OperandWidth, Type *Ty,
-                                  int Value) {
--    return ConstantDataVector::getSplat(IGCLLVM::getElementCount(OperandWidth),
-+    return ConstantDataVector::getSplat(OperandWidth,
-                                         ConstantInt::get(Ty, Value));
-   };
- 
 diff --git a/IGC/VectorCompiler/lib/GenXCodeGen/GenXThreadPrivateMemory.cpp b/IGC/VectorCompiler/lib/GenXCodeGen/GenXThreadPrivateMemory.cpp
 index e8529e7a..4421a0eb 100644
 --- a/IGC/VectorCompiler/lib/GenXCodeGen/GenXThreadPrivateMemory.cpp
@@ -128,6 +115,25 @@ index 6cf5f06d..00079a89 100644
  #endif
      }
  
--- 
-2.29.2
-
+--- intel-graphics-compiler-igc-1.0.5964/IGC/VectorCompiler/lib/GenXCodeGen/GenXLegalization.cpp	2020-12-24 05:04:21.000000000 -0800
++++ intel-graphics-compiler-igc-1.0.5964-bak/IGC/VectorCompiler/lib/GenXCodeGen/GenXLegalization.cpp	2021-01-22 23:10:17.181133688 -0800
+@@ -2105,7 +2105,7 @@
+   if (OldElemSize * OldNumElems % NewElemSize)
+     return nullptr;
+   return VectorType::get(NewScalarType,
+-                         OldElemSize * OldNumElems / NewElemSize);
++                         OldElemSize * OldNumElems / NewElemSize, false);
+ }
+ 
+ /***********************************************************************
+--- a/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp	2021-01-22 23:18:20.513033428 -0800
++++ b/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp	2021-01-22 23:18:36.069213137 -0800
+@@ -2281,7 +2281,7 @@
+ 
+   auto createConstant = [](unsigned int OperandWidth, Type *Ty, int Value) {
+     return OperandWidth != 0 ? ConstantDataVector::getSplat(
+-                                   IGCLLVM::getElementCount(OperandWidth),
++                                   OperandWidth,
+                                    ConstantInt::get(Ty, Value))
+                              : ConstantInt::get(Ty, Value);
+     ;

--- a/extra-devel/intel-graphics-compiler/spec
+++ b/extra-devel/intel-graphics-compiler/spec
@@ -1,8 +1,8 @@
-VER=1.0.5884
+VER=1.0.5964
 SRCS="tbl::https://github.com/intel/intel-graphics-compiler/archive/igc-$VER.tar.gz \
       git::commit=50326439b1d0733c6af697de856d922273e4cfbe;rename=vc-intrinsics::https://github.com/intel/vc-intrinsics \
       git::commit=d6dc999eee381158a26f048a333467c9ce7e77f2;rename=SPIRV-LLVM-Translator::https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
-CHKSUMS="sha256::9bf29ef4c70ff7951f67861c21825e5f341716b8cc48af29aef3fc023845d7a7 \
+CHKSUMS="sha256::2edc768d3ffa25879dda23766bd1b56d08f3d4db1d51e66ec8195e02e7479f00 \
          SKIP \
          SKIP"
 SUBDIR="intel-graphics-compiler-igc-$VER"


### PR DESCRIPTION
Topic Description
-----------------

Update Intel Graphics Compiler to 1.0.5964

Package(s) Affected
-------------------

Security Update?
----------------

No

Architectural Progress
----------------------

- [X] AMD64 `amd64`

Secondary Architectural Progress
--------------------------------

N/A

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2725)
<!-- Reviewable:end -->
