### PR TITLE
deno: Update to 1.7.0

### DIFF
--- a/extra-js/deno/autobuild/prepare
+++ b/extra-js/deno/autobuild/prepare
@@ -17,7 +17,7 @@ abinfo "Fetching dependency sources ..."
 cargo fetch
 PATCHES_DIR="$SRCDIR/autobuild/patches"
 (
-cd /root/.cargo/registry/src/github.com-1ecc6299db9ec823/rusty_v8-0.15.0 || exit 1
+cd /root/.cargo/registry/src/github.com-1ecc6299db9ec823/rusty_v8-0.16.0 || exit 1
 for i in "$PATCHES_DIR"/*.deferred; do
     abinfo "Applying $i ..."
     patch -Np1 -i "$i"

--- a/extra-js/deno/spec
+++ b/extra-js/deno/spec
@@ -1,3 +1,3 @@
-VER=1.6.3
+VER=1.7.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz"
-CHKSUMS="sha256::457b5dc1fd40b7f9368b7c26c300f19f80caace4e3a19340b7ea037d6383b221"
+CHKSUMS="sha256::f215103d0bea381495008a8f9e90c467248a2a14d3357c6d105c084186423072"


### PR DESCRIPTION
Topic Description
-----------------

Update Deno to 1.7.0

Package(s) Affected
-------------------

```
deno
```

Security Update?
----------------

No

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [X] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

N/A

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2726)
<!-- Reviewable:end -->
