### PR TITLE
ciel: update to 3.0.0-rc2

### DIFF
--- a/extra-devel/ciel/spec
+++ b/extra-devel/ciel/spec
@@ -1,3 +1,3 @@
-VER=3.0.0~beta3
+VER=3.0.0~rc2
 GITSRC="https://github.com/AOSC-Dev/ciel-rs"
 GITCO="tags/v${VER/\~/-}"


### PR DESCRIPTION
Topic Description
-----------------

Update Ciel to 3.0.0 RC 2

Package(s) Affected
-------------------

```
ciel
```

Security Update?
----------------

No

Architectural Progress
----------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2727)
<!-- Reviewable:end -->
