### PR TITLE
dnsmasq: update to 2.84

### DIFF
--- a/extra-network/dnsmasq/autobuild/build
+++ b/extra-network/dnsmasq/autobuild/build
@@ -35,3 +35,7 @@ sed -e 's,%%PREFIX%%,/usr,' \
 abinfo "Installing trust-anchors.conf ..."
 install -Dvm644 "$SRCDIR"/trust-anchors.conf \
     "$PKGDIR"/usr/share/dnsmasq/trust-anchors.conf
+
+abinfo "Setting default port to 5353 ..."
+sed -e 's|^#port=5353|port=5353|g' \
+    -i /etc/dnsmasq.conf

--- a/extra-network/dnsmasq/spec
+++ b/extra-network/dnsmasq/spec
@@ -1,3 +1,3 @@
-VER=2.83
-SRCTBL="http://www.thekelleys.org.uk/dnsmasq/dnsmasq-$VER.tar.xz"
-CHKSUM="sha256::ffc1f7e8b05e22d910b9a71d09f1128197292766dc7c54cb7018a1b2c3af4aea"
+VER=2.84
+SRCS="tbl::http://www.thekelleys.org.uk/dnsmasq/dnsmasq-$VER.tar.xz"
+CHKSUMS="sha256::603195c64b73137609b07e1024ae0b37f652b2f5fe467dce66985b3d1850050c"


### PR DESCRIPTION
Topic Description
-----------------

Update `dnsmasq` to v2.84. #2729

Package(s) Affected
-------------------

`dnsmasq`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`