### PR TITLE
(!!) sudo: update to 1.9.5p2

### DIFF
--- a/extra-security/sudo/spec
+++ b/extra-security/sudo/spec
@@ -1,3 +1,3 @@
-VER=1.9.3p1
-SRCTBL="https://www.sudo.ws/dist/sudo-$VER.tar.gz"
-CHKSUM="sha256::dcb9de53e45e1c39042074b847f5e0d8ae1890725dd6a9d9101a81569e6eb49e"
+VER=1.9.5p2
+SRCS="tbl::https://www.sudo.ws/dist/sudo-$VER.tar.gz"
+CHKSUMS="sha256::539e2ef43c8a55026697fb0474ab6a925a11206b5aa58710cb42a0e1c81f0978"


### PR DESCRIPTION
Topic Description
-----------------

Update `sudo` to v1.9.5p2, to address a **critical security vulnerability**.

Package(s) Affected
-------------------

`sudo`

Security Update?
----------------

Yes ([CVE-2021-3156](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3156))

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`