### PR TITLE
firefox: update to 85.0

### DIFF
--- a/extra-libs/nss/spec
+++ b/extra-libs/nss/spec
@@ -1,3 +1,3 @@
-VER=3.59.1
+VER=3.60.1
 SRCS="https://download-origin.cdn.mozilla.net/pub/security/nss/releases/NSS_${VER//./_}_RTM/src/nss-$VER.tar.gz"
-CHKSUMS="sha256::bb655669533d81fd0d7de46da210645b87c4c2fd4046ccc4f60f3b0d64ce2ecf"
+CHKSUMS="sha256::2051c20b61112df24bad533ac37f6c66c1bc0d6ea70bb9d9cad102d20324279d"

--- a/extra-web/firefox/spec
+++ b/extra-web/firefox/spec
@@ -1,4 +1,3 @@
-VER=84.0.1
-REL=2
+VER=85.0
 SRCS="tbl::https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz"
-CHKSUMS="sha256::ae5500d270a199f9a10674fbd4ba7a6beac1f260a4c009bbca8ea39967592243"
+CHKSUMS="sha256::5f03712642f5e77de4581d2ba3ee3e87cfa44c3d2fdd8fe0fb56ea05a57f7b50"


### PR DESCRIPTION
Topic Description
-----------------

Update Firefox to 85.0.

Package(s) Affected
-------------------

- `nss` v3.60.1
- `firefox` v85.0

Security Update?
----------------

Yes, see [MFSA2021-03](https://www.mozilla.org/en-US/security/advisories/mfsa2021-03/)

Build Order
-----------

```
nss firefox
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
