### PR TITLE
vulkan: stack update 1.2.166

### DIFF
--- a/extra-libs/spirv-headers/spec
+++ b/extra-libs/spirv-headers/spec
@@ -1,3 +1,3 @@
-VER=1.5.3+git20200803
-GITSRC="https://github.com/KhronosGroup/SPIRV-Headers"
-GITCO="3fdabd0da2932c276b25b9b4a988ba134eba1aa6"
+VER=1.5.4+git20210122
+SRCS="git::commit=f9e1ffdcc1c123b79dd9f6002b418d9703d98904::https://github.com/KhronosGroup/SPIRV-Headers"
+CHKSUMS="SKIP"

--- a/extra-libs/spirv-tools/spec
+++ b/extra-libs/spirv-tools/spec
@@ -1,4 +1,3 @@
-VER=2020.4
-SRCTBL="https://github.com/KhronosGroup/SPIRV-Tools/archive/v$VER.tar.gz"
-CHKSUM="sha256::d6377d2febe831eb78e84593a10d242a4fd52cb12174133151cb48801abdc6d2"
-REL=1
+VER=2020.4+git20210125
+SRCS="git::commit=a61600c7639c1a03df4967806fb8cc48ea3c45ca::https://github.com/KhronosGroup/SPIRV-Tools"
+CHKSUMS="SKIP"

--- a/extra-libs/vulkan-headers/spec
+++ b/extra-libs/vulkan-headers/spec
@@ -1,3 +1,3 @@
-VER=1.2.154
+VER=1.2.166
 SRCTBL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v$VER.tar.gz"
-CHKSUM="sha256::b636f0ace2c2b8a7dbdfddf16c53c1f49a4b39d6da562727bfea00b5ec447537"
+CHKSUM="sha256::75d77088a75e604d0a84b291a385d82ccf78e0e51df788b891bdd595eb80be51"

--- a/extra-libs/vulkan-loader/spec
+++ b/extra-libs/vulkan-loader/spec
@@ -1,3 +1,3 @@
-VER=1.2.154
+VER=1.2.166
 SRCTBL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v$VER.tar.gz"
-CHKSUM="sha256::9a92cee981032be16149603c1b602214f80f5f2d823c7b552b0c7dbb907d667f"
+CHKSUM="sha256::1094b303ead1843fd31a5c11b0f5c2f91949b0608f36619bf92c738f6d561b35"

--- a/extra-libs/vulkan-validationlayers/spec
+++ b/extra-libs/vulkan-validationlayers/spec
@@ -1,3 +1,3 @@
-VER=1.2.154
+VER=1.2.166
 SRCTBL="https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/v$VER.tar.gz"
-CHKSUM="sha256::ebad2409123f3ad476daab7e064bd8e9049bfa977382acdd1b9f20df8e6c965e"
+CHKSUM="sha256::d7b4f96b3a9ecb5935aaa774666bcd6a36a2f5335f24b149b308d6202e4d01c6"

--- a/extra-optenv32/vulkan-headers+32/spec
+++ b/extra-optenv32/vulkan-headers+32/spec
@@ -1,3 +1,3 @@
-VER=1.2.154
+VER=1.2.166
 SRCTBL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v$VER.tar.gz"
-CHKSUM="sha256::b636f0ace2c2b8a7dbdfddf16c53c1f49a4b39d6da562727bfea00b5ec447537"
+CHKSUM="sha256::75d77088a75e604d0a84b291a385d82ccf78e0e51df788b891bdd595eb80be51"

--- a/extra-optenv32/vulkan-loader+32/spec
+++ b/extra-optenv32/vulkan-loader+32/spec
@@ -1,4 +1,3 @@
-VER=1.2.154
-REL=1
+VER=1.2.166
 SRCTBL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v$VER.tar.gz"
-CHKSUM="sha256::9a92cee981032be16149603c1b602214f80f5f2d823c7b552b0c7dbb907d667f"
+CHKSUM="sha256::1094b303ead1843fd31a5c11b0f5c2f91949b0608f36619bf92c738f6d561b35"

--- a/extra-optenv32/vulkan-tools+32/spec
+++ b/extra-optenv32/vulkan-tools+32/spec
@@ -1,4 +1,3 @@
-VER=1.2.154
-REL=1
+VER=1.2.166
 SRCTBL="https://github.com/KhronosGroup/Vulkan-Tools/archive/v$VER.tar.gz"
-CHKSUM="sha256::505692131143da62b36303d66cdffcac19994e9486812aa2f565a43e3ee02b37"
+CHKSUM="sha256::700058b72f9f48321bc0dc1e597bec6528af5c9c7158623459da79c96997cd7b"

--- a/extra-utils/vulkan-tools/spec
+++ b/extra-utils/vulkan-tools/spec
@@ -1,3 +1,3 @@
-VER=1.2.154
+VER=1.2.166
 SRCTBL="https://github.com/KhronosGroup/Vulkan-Tools/archive/v$VER.tar.gz"
-CHKSUM="sha256::505692131143da62b36303d66cdffcac19994e9486812aa2f565a43e3ee02b37"
+CHKSUM="sha256::700058b72f9f48321bc0dc1e597bec6528af5c9c7158623459da79c96997cd7b"


### PR DESCRIPTION
Topic Description
-----------------

Update Vulkan stack to v1.2.166, along with SPIRV updates to fix build.

Package(s) Affected
-------------------

- `spirv-headers` v1.5.4+git20210122
- `spirv-tools` v2020.4+git20210125
- `vulkan-headers` v1.2.166
- `vulkan-loader` v1.2.166
- `vulkan-validationlayers` v1.2.166
- `vulkan-tools` v1.2.166
- `vulkan-headers+32` v1.2.166
- `vulkan-loader+32` v1.2.166
- `vulkan-tools+32` v1.2.166

Security Update?
----------------

No

Build Order
-----------

```
spirv-headers spirv-tools vulkan-headers vulkan-loader vulkan-validationlayers vulkan-tools vulkan-headers+32 vulkan-loader+32 vulkan-tools+32
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit Optional Environment `optenv32`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit Optional Environment `optenv32`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`