### PR TITLE
Introduce initial ROCm components

### DIFF
--- a/extra-rocm/rocm-bandwidth-test/autobuild/defines
+++ b/extra-rocm/rocm-bandwidth-test/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=rocm-bandwidth-test
+PKGDES="Utility to measure the GPU application memory bandwidth related performance"
+PKGSEC=devel
+PKGDEP="rocr-runtime"
+BUILDDEP="cmake"
+
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm -DCMAKE_PREFIX_PATH=/usr/lib/rocm -DCMAKE_SKIP_RPATH=OFF -DCMAKE_INSTALL_RPATH=\$ORIGIN/../lib"
+
+FAIL_ARCH="!(amd64)"

--- a/extra-rocm/rocm-bandwidth-test/autobuild/prepare
+++ b/extra-rocm/rocm-bandwidth-test/autobuild/prepare
@@ -1,0 +1,1 @@
+acbs_copy_git

--- a/extra-rocm/rocm-bandwidth-test/spec
+++ b/extra-rocm/rocm-bandwidth-test/spec
@@ -1,0 +1,3 @@
+VER=4.0.0
+SRCS="git::commit=tags/rocm-$VER::https://github.com/RadeonOpenCompute/rocm_bandwidth_test"
+CHKSUMS="SKIP"

--- a/extra-rocm/rocm-cmake/autobuild/defines
+++ b/extra-rocm/rocm-cmake/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=rocm-cmake
+PKGDES="CMake modules for building ROCm components"
+PKGSEC=devel
+PKGDEP="cmake"
+
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm"
+
+ABHOST=noarch

--- a/extra-rocm/rocm-cmake/spec
+++ b/extra-rocm/rocm-cmake/spec
@@ -1,0 +1,3 @@
+VER=4.0.0
+SRCS="git::commit=tags/rocm-$VER::https://github.com/RadeonOpenCompute/rocm-cmake"
+CHKSUMS="SKIP"

--- a/extra-rocm/rocm-compilersupport-comgr/autobuild/defines
+++ b/extra-rocm/rocm-compilersupport-comgr/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=rocm-compilersupport-comgr
+PKGDES="Library for compiling and inspecting AMDGPU code objects"
+PKGSEC=devel
+PKGDEP="zlib rocm-device-libs"
+BUILDDEP="cmake rocm-llvm rocm-cmake"
+
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm -DCMAKE_PREFIX_PATH=/usr/lib/rocm/llvm;/usr/lib/rocm"

--- a/extra-rocm/rocm-compilersupport-comgr/spec
+++ b/extra-rocm/rocm-compilersupport-comgr/spec
@@ -1,0 +1,4 @@
+VER=4.0.0
+SRCS="git::commit=tags/rocm-$VER;rename=ROCm-CompilerSupport::https://github.com/RadeonOpenCompute/ROCm-CompilerSupport"
+CHKSUMS="SKIP"
+SUBDIR="ROCm-CompilerSupport/lib/comgr"

--- a/extra-rocm/rocm-device-libs/autobuild/defines
+++ b/extra-rocm/rocm-device-libs/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=rocm-device-libs
+PKGDES="Prebuilt GPU-side libraries for ROCm"
+PKGSEC=devel
+BUILDDEP="cmake rocm-llvm rocm-cmake"
+
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm"
+ABHOST=noarch

--- a/extra-rocm/rocm-device-libs/autobuild/prepare
+++ b/extra-rocm/rocm-device-libs/autobuild/prepare
@@ -1,0 +1,2 @@
+# Use ROCm LLVM to build GPU-side code, because our LLVM is not new enough
+export PATH="/usr/lib/rocm/llvm/bin:$PATH"

--- a/extra-rocm/rocm-device-libs/spec
+++ b/extra-rocm/rocm-device-libs/spec
@@ -1,0 +1,3 @@
+VER=4.0.0
+SRCS="git::commit=tags/rocm-$VER;rename=ROCm-Device-Libs::https://github.com/RadeonOpenCompute/ROCm-Device-Libs"
+CHKSUMS="SKIP"

--- a/extra-rocm/rocm-llvm/autobuild/config.guess
+++ b/extra-rocm/rocm-llvm/autobuild/config.guess
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+UNAME=$(uname -m)
+
+case $UNAME in
+	x86_64)
+		echo "x86_64-aosc-linux-gnu"
+	;;
+	armv7*|armv8*)
+		echo "armv7a-aosc-linux-gnueabihf"
+	;;
+	aarch64)
+		echo "aarch64-aosc-linux-gnu"
+	;;
+	i586)
+		echo "i586-aosc-linux-gnu"
+	;;
+	mips)
+		echo "mipsel-aosc-linux-gnu"
+	;;
+	mips64)
+		echo "mips64el-aosc-linux-gnuabi64"
+	;;
+	aarch64)
+		echo "aarch64-aosc-linux-gnu"
+	;;
+	ppc)
+		echo "powerpc-aosc-linux-gnu"
+	;;
+	ppc64)
+		echo "powerpc64-aosc-linux-gnu"
+	;;
+	ppc64le)
+		echo "powerpc64le-aosc-linux-gnu"
+	;;
+esac

--- a/extra-rocm/rocm-llvm/autobuild/defines
+++ b/extra-rocm/rocm-llvm/autobuild/defines
@@ -1,0 +1,15 @@
+PKGNAME=rocm-llvm
+PKGDES="LLVM customized for ROCm"
+PKGSEC=devel
+PKGDEP="gcc-runtime libxml2 libedit zlib"
+BUILDDEP="cmake llvm"
+
+USECLANG=1
+NOLTO=1
+NOSTATIC=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm/llvm \
+             -DLLVM_ENABLE_PROJECTS=llvm;clang;lld;compiler-rt \
+             -DLLVM_TARGETS_TO_BUILD=AMDGPU;Native \
+             -DLLVM_ENABLE_BINDINGS=OFF"

--- a/extra-rocm/rocm-llvm/autobuild/prepare
+++ b/extra-rocm/rocm-llvm/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Copying a hacked config.guess to fix tuplet detection ..."
+cp -v "$SRCDIR"/autobuild/config.guess \
+    "$SRCDIR"/cmake/

--- a/extra-rocm/rocm-llvm/spec
+++ b/extra-rocm/rocm-llvm/spec
@@ -1,0 +1,4 @@
+VER=4.0.1
+SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/RadeonOpenCompute/llvm-project"
+CHKSUMS="SKIP"
+SUBDIR="llvm-project/llvm"

--- a/extra-rocm/rocm-opencl-runtime/autobuild/defines
+++ b/extra-rocm/rocm-opencl-runtime/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=rocm-opencl-runtime
+PKGDES="OpenCL implementation for ROCm"
+PKGSEC=devel
+PKGDEP="rocm-device-libs rocm-compilersupport-comgr rocr-runtime libglvnd glew"
+BUILDDEP="cmake rocm-cmake rocm-llvm"
+
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm -DCMAKE_PREFIX_PATH=${SRCDIR}/../ROCclr/build;/usr/lib/rocm/llvm;/usr/lib/rocm -DUSE_COMGR_LIBRARY=ON -DBUILD_TESTING=OFF -DCMAKE_SKIP_RPATH=OFF"
+
+NOLTO=1
+
+FAIL_ARCH="!(amd64)"

--- a/extra-rocm/rocm-opencl-runtime/autobuild/overrides/etc/OpenCL/vendors/amdocl64.icd
+++ b/extra-rocm/rocm-opencl-runtime/autobuild/overrides/etc/OpenCL/vendors/amdocl64.icd
@@ -1,0 +1,1 @@
+/usr/lib/rocm/lib/libamdocl64.so

--- a/extra-rocm/rocm-opencl-runtime/autobuild/prepare
+++ b/extra-rocm/rocm-opencl-runtime/autobuild/prepare
@@ -1,0 +1,7 @@
+acbs_copy_git
+
+abinfo "Building ROCclr used for ROCm-OpenCL-Runtime..."
+cd ${SRCDIR}/../ROCclr
+mkdir -p build && cd build
+cmake .. -DOPENCL_DIR="${SRCDIR}" -DCMAKE_PREFIX_PATH="/usr/lib/rocm/llvm;/usr/lib/rocm" -GNinja && ninja
+cd ${SRCDIR}

--- a/extra-rocm/rocm-opencl-runtime/spec
+++ b/extra-rocm/rocm-opencl-runtime/spec
@@ -1,0 +1,6 @@
+VER=4.0.0
+SRCS="git::commit=tags/rocm-$VER;rename=ROCclr::https://github.com/ROCm-Developer-Tools/ROCclr \
+      git::commit=tags/rocm-$VER;rename=ROCm-OpenCL-Runtime::https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime"
+CHKSUMS="SKIP \
+         SKIP"
+SUBDIR="ROCm-OpenCL-Runtime"

--- a/extra-rocm/rocm-smi-lib/autobuild/defines
+++ b/extra-rocm/rocm-smi-lib/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=rocm-smi-lib
+PKGDES="Library to monitor and control Radeon GPU applications"
+PKGSEC=devel
+PKGDEP="gcc-runtime"
+BUILDDEP="cmake texlive doxygen"
+
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm"
+
+NOLTO=1

--- a/extra-rocm/rocm-smi-lib/autobuild/patches/0001-drop-amd64-flags.patch
+++ b/extra-rocm/rocm-smi-lib/autobuild/patches/0001-drop-amd64-flags.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f2ec0ae..a22c9e0 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -88,7 +88,7 @@ endif()
+ 
+ ## Compiler flags
+ set(CMAKE_CXX_FLAGS
+- "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-rtti -m64 -msse -msse2 -std=c++11 ")
++ "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-rtti -std=c++11 ")
+ # Security options
+ set(CMAKE_CXX_FLAGS
+  "${CMAKE_CXX_FLAGS} -Wconversion -Wcast-align ")
+diff --git a/tests/rocm_smi_test/CMakeLists.txt b/tests/rocm_smi_test/CMakeLists.txt
+index e3b9b86..88c7972 100755
+--- a/tests/rocm_smi_test/CMakeLists.txt
++++ b/tests/rocm_smi_test/CMakeLists.txt
+@@ -144,7 +144,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
+ # Extend the compiler flags for 64-bit builds
+ #
+ if (IS64BIT)
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64  -msse -msse2")
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
+ else()
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
+ endif()

--- a/extra-rocm/rocm-smi-lib/autobuild/prepare
+++ b/extra-rocm/rocm-smi-lib/autobuild/prepare
@@ -1,0 +1,1 @@
+acbs_copy_git

--- a/extra-rocm/rocm-smi-lib/spec
+++ b/extra-rocm/rocm-smi-lib/spec
@@ -1,0 +1,3 @@
+VER=4.0.0
+SRCS="git::commit=tags/rocm-$VER::https://github.com/RadeonOpenCompute/rocm_smi_lib"
+CHKSUMS="SKIP"

--- a/extra-rocm/rocminfo/autobuild/defines
+++ b/extra-rocm/rocminfo/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=rocminfo
+PKGDES="Utility to report system info related to ROCm"
+PKGSEC=devel
+PKGDEP="rocr-runtime"
+BUILDDEP="cmake"
+
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm -DCMAKE_PREFIX_PATH=/usr/lib/rocm -DCMAKE_SKIP_RPATH=OFF"

--- a/extra-rocm/rocminfo/autobuild/patch
+++ b/extra-rocm/rocminfo/autobuild/patch
@@ -1,0 +1,2 @@
+abinfo "Removing -m64 flag from CMakeLists.txt..."
+sed -i 's/ -m64//g' CMakeLists.txt

--- a/extra-rocm/rocminfo/autobuild/prepare
+++ b/extra-rocm/rocminfo/autobuild/prepare
@@ -1,0 +1,1 @@
+acbs_copy_git

--- a/extra-rocm/rocminfo/spec
+++ b/extra-rocm/rocminfo/spec
@@ -1,0 +1,3 @@
+VER=4.0.0
+SRCS="git::commit=tags/rocm-$VER::https://github.com/RadeonOpenCompute/rocminfo"
+CHKSUMS="SKIP"

--- a/extra-rocm/rocr-runtime/autobuild/defines
+++ b/extra-rocm/rocr-runtime/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=rocr-runtime
+PKGDES="User space library for launching compute kernels on ROCm-compatible Radeon cards"
+PKGSEC=devel
+PKGDEP="roct-thunk-interface rocm-device-libs"
+BUILDDEP="cmake rocm-llvm vim"
+
+CMAKE_AFTER__AMD64="-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm -DCMAKE_PREFIX_PATH=/usr/lib/rocm/llvm;/usr/lib/rocm -DCMAKE_SKIP_RPATH=OFF"
+CMAKE_AFTER="${CMAKE_AFTER__AMD64} -DIMAGE_SUPPORT=OFF"
+NOLTO=1

--- a/extra-rocm/rocr-runtime/autobuild/prepare
+++ b/extra-rocm/rocr-runtime/autobuild/prepare
@@ -1,0 +1,4 @@
+# Enable the usage of ROCm LLVM
+export PATH="/usr/lib/rocm/llvm/bin:$PATH"
+
+acbs_copy_git

--- a/extra-rocm/rocr-runtime/spec
+++ b/extra-rocm/rocr-runtime/spec
@@ -1,0 +1,4 @@
+VER=4.0.0
+SRCS="git::commit=tags/rocm-$VER;rename=ROCR-Runtime::https://github.com/RadeonOpenCompute/ROCR-Runtime"
+CHKSUMS="SKIP"
+SUBDIR="ROCR-Runtime/src"

--- a/extra-rocm/roct-thunk-interface/autobuild/defines
+++ b/extra-rocm/roct-thunk-interface/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=roct-thunk-interface
+PKGDES="User-mode API to interact with ROCk driver (amdkfd)"
+PKGSEC=devel
+PKGDEP="numactl"
+BUILDDEP="cmake"
+
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm"

--- a/extra-rocm/roct-thunk-interface/spec
+++ b/extra-rocm/roct-thunk-interface/spec
@@ -1,0 +1,3 @@
+VER=4.0.0
+SRCS="git::commit=tags/rocm-$VER::https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Some basical components of ROCm are introduced, including libraries for building OpenCL Runtime from ROCm and a few tools (rocm_smi, rocminfo, rocm_bandwidth_test)

Package(s) Affected
-------------------

- `roct-thunk-interface`
- `rocm-llvm`
- `rocm-cmake`
- `rocm-device-libs`
- `rocm-compilersupport-comgr`
- `rocm-opencl-runtime`
- `rocm-smi-lib`
- `rocminfo`
- `rocm-bandwidth-test`

Security Update?
----------------

No

Build Order
-----------

```
roct-thunk-interface rocm-llvm rocm-cmake rocm-device-libs rocr-runtime rocm-compilersupport-comgr rocm-opencl-runtime rocm-smi-lib rocminfo
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
