### PR TITLE
shadowsocks-rust: add systemd units

### DIFF
--- a/extra-network/shadowsocks-rust/autobuild/beyond
+++ b/extra-network/shadowsocks-rust/autobuild/beyond
@@ -1,1 +1,8 @@
 make TARGET="release" DESTDIR="$PKGDIR" PREFIX="/usr/bin" install
+
+abinfo "Installing shadowsocks-rust systemd units..."
+mkdir -pv "$PKGDIR"/usr/lib/systemd/system
+for unit in "$SRCDIR"/debian/*.service; do
+    sed -i "s|/etc/shadowsocks-rust|/etc/shadowsocks|g" $unit
+    install -Dvm644 $unit "$PKGDIR"/usr/lib/systemd/system/
+done

--- a/extra-network/shadowsocks-rust/autobuild/defines
+++ b/extra-network/shadowsocks-rust/autobuild/defines
@@ -4,5 +4,6 @@ PKGDEP="openssl libsodium"
 BUILDDEP="rustc llvm asciidoc"
 PKGDES="A Rust port of shadowsocks, lightweight yet secured SOCKS5 proxy"
 
+FAIL_ARCH="!(amd64|arm64)"
 USECLANG=1
 ABTYPE=rust

--- a/extra-network/shadowsocks-rust/spec
+++ b/extra-network/shadowsocks-rust/spec
@@ -1,4 +1,4 @@
 VER=1.8.23
-REL=1
+REL=2
 SRCTBL="https://github.com/shadowsocks/shadowsocks-rust/archive/v$VER.tar.gz"
 CHKSUM="sha256::a24602023940b53d9a02017aa182b3ac04eda53c1fc51e822337c902a4061def"


### PR DESCRIPTION
Topic Description
-----------------

Add systemd units to run shadowsocks-rust

Package(s) Affected
-------------------

shadowsocks-rust

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`