### PR TITLE
retdec: Update to 4.0

### DIFF
--- a/extra-devel/retdec/autobuild/beyond
+++ b/extra-devel/retdec/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Moving lib64 to lib ..."
+mv -v "$PKGDIR"/usr/lib64 "$PKGDIR"/usr/lib

--- a/extra-devel/retdec/autobuild/defines
+++ b/extra-devel/retdec/autobuild/defines
@@ -4,8 +4,10 @@ PKGDES="A retargetable machine-code decompiler based on LLVM"
 PKGDEP="bash upx bc graphviz keystone python-3"
 BUILDDEP="git cmake make perl python-3 wget libtool ncurses zlib doxygen"
 
-ABTYPE="cmake"
+ABTYPE="cmakeninja"
+# CMAKE_INSTALL_LIBDIR: workaround yaramod install issues
 CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr \
+             -DCMAKE_INSTALL_LIBDIR=lib64 \
              -DRETDEC_ENABLE_ALL=ON \
              -DRETDEC_COMPILE_YARA=OFF \
              -DRETDEC_DOC=ON \

--- a/extra-devel/retdec/autobuild/defines
+++ b/extra-devel/retdec/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=retdec
 PKGSEC=devel
 PKGDES="A retargetable machine-code decompiler based on LLVM"
 PKGDEP="bash upx bc graphviz keystone python-3"
-BUILDDEP="git cmake make perl python-3 wget libtool ncurses zlib doxygen"
+BUILDDEP="git cmake make perl python-3 wget libtool ncurses zlib doxygen llvm"
 
 ABTYPE="cmakeninja"
 # CMAKE_INSTALL_LIBDIR: workaround yaramod install issues
@@ -12,3 +12,5 @@ CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr \
              -DRETDEC_COMPILE_YARA=OFF \
              -DRETDEC_DOC=ON \
              -DRETDEC_DEV_TOOLS=ON"
+
+USECLANG=1

--- a/extra-devel/retdec/autobuild/defines
+++ b/extra-devel/retdec/autobuild/defines
@@ -1,11 +1,12 @@
 PKGNAME=retdec
 PKGSEC=devel
 PKGDES="A retargetable machine-code decompiler based on LLVM"
-PKGDEP="bash upx bc graphviz keystone"
+PKGDEP="bash upx bc graphviz keystone python-3"
 BUILDDEP="git cmake make perl python-3 wget libtool ncurses zlib doxygen"
 
 ABTYPE="cmake"
 CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr \
+             -DRETDEC_ENABLE_ALL=ON \
              -DRETDEC_COMPILE_YARA=OFF \
              -DRETDEC_DOC=ON \
              -DRETDEC_DEV_TOOLS=ON"

--- a/extra-devel/retdec/autobuild/prepare
+++ b/extra-devel/retdec/autobuild/prepare
@@ -1,0 +1,2 @@
+export CFLAGS="${CFLAGS} -fuse-ld=lld "
+export CXXFLAGS="${CXXFLAGS} -fuse-ld=lld "

--- a/extra-devel/retdec/autobuild/prepare
+++ b/extra-devel/retdec/autobuild/prepare
@@ -1,2 +1,3 @@
+abinfo "Setting CFLAGS CXXFLAGS to use lld as linker ..."
 export CFLAGS="${CFLAGS} -fuse-ld=lld "
 export CXXFLAGS="${CXXFLAGS} -fuse-ld=lld "

--- a/extra-devel/retdec/spec
+++ b/extra-devel/retdec/spec
@@ -1,3 +1,3 @@
-VER=4.0
-SRCTBL="https://github.com/avast-tl/retdec/archive/v$VER.tar.gz"
-CHKSUM="sha256::b26c2f71556dc4919714899eccdf82d2fefa5e0b3bc0125af664ec60ddc87023"
+VER=4.0+git20200125
+SRCS="git::commit=6ed327e30fd2bbd45767ff45eae7cfd63fdfc2f1::https://github.com/avast-tl/retdec.git"
+CHKSUMS="SKIP"

--- a/extra-devel/retdec/spec
+++ b/extra-devel/retdec/spec
@@ -1,3 +1,3 @@
-VER=3.3
+VER=4.0
 SRCTBL="https://github.com/avast-tl/retdec/archive/v$VER.tar.gz"
-CHKSUM="sha256::f8f3c25794b022727c51f9c4c6ad75f7d2fa60c540ca55b71aa68bbe5a2d102f"
+CHKSUM="sha256::b26c2f71556dc4919714899eccdf82d2fefa5e0b3bc0125af664ec60ddc87023"


### PR DESCRIPTION
Topic Description
-----------------

Update `retdec` to 4.0+git20210125

Package(s) Affected
-------------------

- retdec

Security Update?
----------------
No

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [X] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [X] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------


- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


Post-Merge Secondary Architectural Progress
-------------------------------------------


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2741)
<!-- Reviewable:end -->
