### PR TITLE
proton-bridge: new, 1.5.7

### DIFF
--- a/extra-web/proton-bridge/autobuild/build
+++ b/extra-web/proton-bridge/autobuild/build
@@ -33,6 +33,7 @@ export CGO_CXXFLAGS_ALLOW=".*"
 abinfo "Swapping Qt 5 prebuilt binaries with our fake one ..."
 rm -rf "$SRCDIR"/vendor/github.com/therecipe/env_linux_amd64_513
 ln -sv "$SRCDIR"/qt5_dir/env_linux_amd64_513 vendor/github.com/therecipe/env_linux_amd64_513
+export QT_DIR="$SRCDIR/qt5_dir/env_linux_amd64_513/"
 
 abinfo "Building main executable ..."
 cp -v "$SRCDIR"/cmd/Desktop-Bridge/main.go .

--- a/extra-web/proton-bridge/autobuild/build
+++ b/extra-web/proton-bridge/autobuild/build
@@ -6,10 +6,10 @@ abinfo "Fetching Go dependencies ..."
 go mod vendor
 
 abinfo "Setting up a fake Go Qt 5 binary prefix ..."
-mkdir -pv qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/{qml,resources,translations,plugins,mkspecs,libexec,lib,bin}/
-ln -sv /usr/bin/rcc qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/
-ln -sv /usr/bin/moc qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/
-cat << EOF > qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/qmake
+mkdir -pv "$SRCDIR"/qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/{qml,resources,translations,plugins,mkspecs,libexec,lib,bin}/
+ln -sv /usr/bin/rcc "$SRCDIR"/qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/
+ln -sv /usr/bin/moc "$SRCDIR"/qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/
+cat << 'EOF' > qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/qmake
 #!/bin/bash
 
 case "$1" in
@@ -23,7 +23,7 @@ case "$1" in
 esac
 EOF
 ln -sv /usr/include/qt5/ qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/include
-chmod a+x qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/qmake
+chmod a+x "$SRCDIR"/qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/qmake
 
 abinfo "Adjusting CGO flags whitelist ..."
 export CGO_LDFLAGS_ALLOW=".*"
@@ -31,13 +31,25 @@ export CGO_CFLAGS_ALLOW=".*"
 export CGO_CXXFLAGS_ALLOW=".*"
 
 abinfo "Swapping Qt 5 prebuilt binaries with our fake one ..."
-rm -rf vendor/github.com/therecipe/env_linux_amd64_513
-ln -sv qt5_dir/env_linux_amd64_513 vendor/github.com/therecipe/env_linux_amd64_513
+rm -rf "$SRCDIR"/vendor/github.com/therecipe/env_linux_amd64_513
+ln -sv "$SRCDIR"/qt5_dir/env_linux_amd64_513 vendor/github.com/therecipe/env_linux_amd64_513
 
 abinfo "Building main executable ..."
-cp cmd/Desktop-Bridge/main.go .
-qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg/constants.Version=$PKGVER -X github.com/ProtonMail/proton-bridge/pkg/constants.Revision=$(git rev-parse --short=10 HEAD) -X github.com/ProtonMail/proton-bridge/pkg/constants.BuildTime=$(date -uIs) -w -s -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/gcc/specs/hardened-ld'" build desktop
+cp "$SRCDIR"/cmd/Desktop-Bridge/main.go .
+qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg/constants.Version=$PKGVER-git -X github.com/ProtonMail/proton-bridge/pkg/constants.Revision=$(git rev-parse --short=10 HEAD) -X github.com/ProtonMail/proton-bridge/pkg/constants.BuildTime=$(date -uIs) -w -s -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/gcc/specs/hardened-ld'" build desktop
+rm -fv main.go
+
+abinfo "Building Importer ..."
+cp "$SRCDIR"/cmd/Import-Export/main.go .
+qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg/constants.Version=1.2.3-git -X github.com/ProtonMail/proton-bridge/pkg/constants.Revision=$(git rev-parse --short=10 HEAD) -X github.com/ProtonMail/proton-bridge/pkg/constants.BuildTime=$(date -uIs) -w -s -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/gcc/specs/hardened-ld'" build desktop
 
 abinfo "Installing files ..."
 install -d "$PKGDIR"/usr/bin/
 install -Dm755 "$SRCDIR"/deploy/linux/proton-bridge "$PKGDIR"/usr/bin/
+install -Dm755 "$SRCDIR"/deploy/linux/proton-ie "$PKGDIR"/usr/bin/
+
+abinfo "Making symlinks to the LICENSE files ..."
+install -d "$PKGDIR"/usr/share/doc/
+# the application will actually try to access these files
+ln -sv proton-bridge "$PKGDIR"/usr/share/doc/protonmail-bridge
+ln -sv proton-bridge "$PKGDIR"/usr/share/doc/protonmail-import-export

--- a/extra-web/proton-bridge/autobuild/build
+++ b/extra-web/proton-bridge/autobuild/build
@@ -1,0 +1,43 @@
+abinfo "Installing Qt 5 binding for Go ..."
+go install -v -tags=no_env github.com/therecipe/qt/cmd/...
+export PATH="$PATH":"$HOME/go/bin/"
+
+abinfo "Fetching Go dependencies ..."
+go mod vendor
+
+abinfo "Setting up a fake Go Qt 5 binary prefix ..."
+mkdir -pv qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/{qml,resources,translations,plugins,mkspecs,libexec,lib,bin}/
+ln -sv /usr/bin/rcc qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/
+ln -sv /usr/bin/moc qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/
+cat << EOF > qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/qmake
+#!/bin/bash
+
+case "$1" in
+  -query)
+    DIRNAME="$(dirname "$0")"
+    echo "$(readlink -f "${DIRNAME}/../")"
+    ;;
+  *)
+    /usr/bin/qmake $@
+    ;;
+esac
+EOF
+ln -sv /usr/include/qt5/ qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/include
+chmod a+x qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/qmake
+
+abinfo "Adjusting CGO flags whitelist ..."
+export CGO_LDFLAGS_ALLOW=".*"
+export CGO_CFLAGS_ALLOW=".*"
+export CGO_CXXFLAGS_ALLOW=".*"
+
+abinfo "Swapping Qt 5 prebuilt binaries with our fake one ..."
+rm -rf vendor/github.com/therecipe/env_linux_amd64_513
+ln -sv qt5_dir/env_linux_amd64_513 vendor/github.com/therecipe/env_linux_amd64_513
+
+abinfo "Building main executable ..."
+cp cmd/Desktop-Bridge/main.go .
+qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg/constants.Version=$PKGVER -X github.com/ProtonMail/proton-bridge/pkg/constants.Revision=$(git rev-parse --short=10 HEAD) -X github.com/ProtonMail/proton-bridge/pkg/constants.BuildTime=$(date -uIs) -w -s -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/gcc/specs/hardened-ld'" build desktop
+
+abinfo "Installing files ..."
+install -d "$PKGDIR"/usr/bin/
+install -Dm755 "$SRCDIR"/deploy/linux/proton-bridge "$PKGDIR"/usr/bin/

--- a/extra-web/proton-bridge/autobuild/build
+++ b/extra-web/proton-bridge/autobuild/build
@@ -61,3 +61,4 @@ ln -sv ../proton-bridge "$PKGDIR"/usr/share/doc/protonmail/import-export
 
 install -d /usr/share/pixmaps/
 install -Dm644 "$SRCDIR"/internal/frontend/share/icons/logo.svg "$PKGDIR"/usr/share/pixmaps/proton-bridge.svg
+install -Dm644 "$SRCDIR"/internal/frontend/share/icons/ie.svg "$PKGDIR"/usr/share/pixmaps/proton-ie.svg

--- a/extra-web/proton-bridge/autobuild/build
+++ b/extra-web/proton-bridge/autobuild/build
@@ -9,7 +9,7 @@ abinfo "Setting up a fake Go Qt 5 binary prefix ..."
 mkdir -pv "$SRCDIR"/qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/{qml,resources,translations,plugins,mkspecs,libexec,lib,bin}/
 ln -sv /usr/bin/rcc "$SRCDIR"/qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/
 ln -sv /usr/bin/moc "$SRCDIR"/qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/
-cat << 'EOF' > qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/qmake
+cat << 'EOF' > "$SRCDIR"/qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/qmake
 #!/bin/bash
 
 case "$1" in
@@ -22,8 +22,8 @@ case "$1" in
     ;;
 esac
 EOF
-ln -sv /usr/include/qt5/ qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/include
-chmod a+x "$SRCDIR"/qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/qmake
+ln -sv /usr/include/qt5/ "$SRCDIR"/qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/include
+chmod -v a+x "$SRCDIR"/qt5_dir/env_linux_amd64_513/5.13.0/gcc_64/bin/qmake
 
 abinfo "Adjusting CGO flags whitelist ..."
 export CGO_LDFLAGS_ALLOW=".*"
@@ -31,7 +31,7 @@ export CGO_CFLAGS_ALLOW=".*"
 export CGO_CXXFLAGS_ALLOW=".*"
 
 abinfo "Swapping Qt 5 prebuilt binaries with our fake one ..."
-rm -rf "$SRCDIR"/vendor/github.com/therecipe/env_linux_amd64_513
+rm -rfv "$SRCDIR"/vendor/github.com/therecipe/env_linux_amd64_513
 ln -sv "$SRCDIR"/qt5_dir/env_linux_amd64_513 vendor/github.com/therecipe/env_linux_amd64_513
 export QT_DIR="$SRCDIR/qt5_dir/env_linux_amd64_513/"
 
@@ -41,8 +41,8 @@ qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg
 rm -fv main.go
 
 abinfo "Installing main ..."
-install -d "$PKGDIR"/usr/bin/
-install -Dm755 "$SRCDIR"/deploy/linux/proton-bridge "$PKGDIR"/usr/bin/
+install -dv "$PKGDIR"/usr/bin/
+install -Dvm755 "$SRCDIR"/deploy/linux/proton-bridge "$PKGDIR"/usr/bin/
 
 abinfo "Cleaning up ..."
 rm -rfv "$SRCDIR"/deploy/
@@ -51,14 +51,14 @@ abinfo "Building Importer ..."
 cp -v "$SRCDIR"/cmd/Import-Export/main.go .
 qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg/constants.Version=1.2.3-git -X github.com/ProtonMail/proton-bridge/pkg/constants.Revision=$(git rev-parse --short=10 HEAD) -X github.com/ProtonMail/proton-bridge/pkg/constants.BuildTime=$(date -uIs) -w -s -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/gcc/specs/hardened-ld'" build desktop
 
-install -Dm755 "$SRCDIR"/deploy/linux/proton-bridge "$PKGDIR"/usr/bin/proton-ie
+install -Dvm755 "$SRCDIR"/deploy/linux/proton-bridge "$PKGDIR"/usr/bin/proton-ie
 
 abinfo "Making symlinks to the LICENSE files ..."
-install -d "$PKGDIR"/usr/share/doc/protonmail/
+install -dv "$PKGDIR"/usr/share/doc/protonmail/
 # the application will actually try to access these files
 ln -sv ../proton-bridge "$PKGDIR"/usr/share/doc/protonmail/bridge
 ln -sv ../proton-bridge "$PKGDIR"/usr/share/doc/protonmail/import-export
 
-install -d /usr/share/pixmaps/
-install -Dm644 "$SRCDIR"/internal/frontend/share/icons/logo.svg "$PKGDIR"/usr/share/pixmaps/proton-bridge.svg
-install -Dm644 "$SRCDIR"/internal/frontend/share/icons/ie.svg "$PKGDIR"/usr/share/pixmaps/proton-ie.svg
+install -dv "$PKGDIR"/usr/share/pixmaps/
+install -Dvm644 "$SRCDIR"/internal/frontend/share/icons/logo.svg "$PKGDIR"/usr/share/pixmaps/proton-bridge.svg
+install -Dvm644 "$SRCDIR"/internal/frontend/share/icons/ie.svg "$PKGDIR"/usr/share/pixmaps/proton-ie.svg

--- a/extra-web/proton-bridge/autobuild/build
+++ b/extra-web/proton-bridge/autobuild/build
@@ -53,7 +53,7 @@ qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg
 install -Dm755 "$SRCDIR"/deploy/linux/proton-bridge "$PKGDIR"/usr/bin/proton-ie
 
 abinfo "Making symlinks to the LICENSE files ..."
-install -d "$PKGDIR"/usr/share/doc/
+install -d "$PKGDIR"/usr/share/doc/protonmail/
 # the application will actually try to access these files
-ln -sv proton-bridge "$PKGDIR"/usr/share/doc/protonmail-bridge
-ln -sv proton-bridge "$PKGDIR"/usr/share/doc/protonmail-import-export
+ln -sv ../proton-bridge "$PKGDIR"/usr/share/doc/protonmail/bridge
+ln -sv ../proton-bridge "$PKGDIR"/usr/share/doc/protonmail/import-export

--- a/extra-web/proton-bridge/autobuild/build
+++ b/extra-web/proton-bridge/autobuild/build
@@ -38,7 +38,7 @@ export QT_DIR="$SRCDIR/qt5_dir/env_linux_amd64_513/"
 abinfo "Building main executable ..."
 cp -v "$SRCDIR"/cmd/Desktop-Bridge/main.go .
 qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg/constants.Version=$PKGVER-git -X github.com/ProtonMail/proton-bridge/pkg/constants.Revision=$(git rev-parse --short=10 HEAD) -X github.com/ProtonMail/proton-bridge/pkg/constants.BuildTime=$(date -uIs) -w -s -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/gcc/specs/hardened-ld'" build desktop
-rm -fv main.go
+rm -fv "$SRCDIR"/main.go
 
 abinfo "Installing main ..."
 install -dv "$PKGDIR"/usr/bin/

--- a/extra-web/proton-bridge/autobuild/build
+++ b/extra-web/proton-bridge/autobuild/build
@@ -57,3 +57,6 @@ install -d "$PKGDIR"/usr/share/doc/protonmail/
 # the application will actually try to access these files
 ln -sv ../proton-bridge "$PKGDIR"/usr/share/doc/protonmail/bridge
 ln -sv ../proton-bridge "$PKGDIR"/usr/share/doc/protonmail/import-export
+
+install -d /usr/share/pixmaps/
+install -Dm644 "$SRCDIR"/internal/frontend/share/icons/logo.svg "$PKGDIR"/usr/share/pixmaps/proton-bridge.svg

--- a/extra-web/proton-bridge/autobuild/build
+++ b/extra-web/proton-bridge/autobuild/build
@@ -35,18 +35,22 @@ rm -rf "$SRCDIR"/vendor/github.com/therecipe/env_linux_amd64_513
 ln -sv "$SRCDIR"/qt5_dir/env_linux_amd64_513 vendor/github.com/therecipe/env_linux_amd64_513
 
 abinfo "Building main executable ..."
-cp "$SRCDIR"/cmd/Desktop-Bridge/main.go .
+cp -v "$SRCDIR"/cmd/Desktop-Bridge/main.go .
 qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg/constants.Version=$PKGVER-git -X github.com/ProtonMail/proton-bridge/pkg/constants.Revision=$(git rev-parse --short=10 HEAD) -X github.com/ProtonMail/proton-bridge/pkg/constants.BuildTime=$(date -uIs) -w -s -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/gcc/specs/hardened-ld'" build desktop
 rm -fv main.go
 
-abinfo "Building Importer ..."
-cp "$SRCDIR"/cmd/Import-Export/main.go .
-qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg/constants.Version=1.2.3-git -X github.com/ProtonMail/proton-bridge/pkg/constants.Revision=$(git rev-parse --short=10 HEAD) -X github.com/ProtonMail/proton-bridge/pkg/constants.BuildTime=$(date -uIs) -w -s -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/gcc/specs/hardened-ld'" build desktop
-
-abinfo "Installing files ..."
+abinfo "Installing main ..."
 install -d "$PKGDIR"/usr/bin/
 install -Dm755 "$SRCDIR"/deploy/linux/proton-bridge "$PKGDIR"/usr/bin/
-install -Dm755 "$SRCDIR"/deploy/linux/proton-ie "$PKGDIR"/usr/bin/
+
+abinfo "Cleaning up ..."
+rm -rfv "$SRCDIR"/deploy/
+
+abinfo "Building Importer ..."
+cp -v "$SRCDIR"/cmd/Import-Export/main.go .
+qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg/constants.Version=1.2.3-git -X github.com/ProtonMail/proton-bridge/pkg/constants.Revision=$(git rev-parse --short=10 HEAD) -X github.com/ProtonMail/proton-bridge/pkg/constants.BuildTime=$(date -uIs) -w -s -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/gcc/specs/hardened-ld'" build desktop
+
+install -Dm755 "$SRCDIR"/deploy/linux/proton-bridge "$PKGDIR"/usr/bin/proton-ie
 
 abinfo "Making symlinks to the LICENSE files ..."
 install -d "$PKGDIR"/usr/share/doc/

--- a/extra-web/proton-bridge/autobuild/build
+++ b/extra-web/proton-bridge/autobuild/build
@@ -38,14 +38,14 @@ export QT_DIR="$SRCDIR/qt5_dir/env_linux_amd64_513/"
 abinfo "Building main executable ..."
 cp -v "$SRCDIR"/cmd/Desktop-Bridge/main.go .
 qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg/constants.Version=$PKGVER-git -X github.com/ProtonMail/proton-bridge/pkg/constants.Revision=$(git rev-parse --short=10 HEAD) -X github.com/ProtonMail/proton-bridge/pkg/constants.BuildTime=$(date -uIs) -w -s -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/gcc/specs/hardened-ld'" build desktop
-rm -fv "$SRCDIR"/main.go
+rm -v "$SRCDIR"/main.go
 
 abinfo "Installing main ..."
 install -dv "$PKGDIR"/usr/bin/
 install -Dvm755 "$SRCDIR"/deploy/linux/proton-bridge "$PKGDIR"/usr/bin/
 
 abinfo "Cleaning up ..."
-rm -rfv "$SRCDIR"/deploy/
+rm -rv "$SRCDIR"/deploy/
 
 abinfo "Building Importer ..."
 cp -v "$SRCDIR"/cmd/Import-Export/main.go .

--- a/extra-web/proton-bridge/autobuild/defines
+++ b/extra-web/proton-bridge/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=proton-bridge
+PKGSEC=web
+PKGDES="ProtonMail Bridge for e-mail clients"
+PKGDEP="qt-5"
+BUILDDEP="go"

--- a/extra-web/proton-bridge/autobuild/defines
+++ b/extra-web/proton-bridge/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=proton-bridge
 PKGSEC=web
 PKGDES="ProtonMail Bridge for e-mail clients"
-PKGDEP="qt-5"
+PKGDEP="qt-5 desktop-file-utils"
 BUILDDEP="go"

--- a/extra-web/proton-bridge/autobuild/overrides/usr/share/applications/proton-bridge.desktop
+++ b/extra-web/proton-bridge/autobuild/overrides/usr/share/applications/proton-bridge.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=ProtonMail Bridge
+Keywords=Email;E-mail;Protonmail;
+Icon=proton-bridge
+Categories=Application;Network;Email;
+Type=Application
+Exec=proton-mail

--- a/extra-web/proton-bridge/autobuild/overrides/usr/share/applications/proton-bridge.desktop
+++ b/extra-web/proton-bridge/autobuild/overrides/usr/share/applications/proton-bridge.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Encoding=UTF-8
 Name=ProtonMail Bridge
+Comment=ProtonMail Bridge for e-mail clients
 Keywords=Email;E-mail;Protonmail;
 Icon=proton-bridge
 Categories=Application;Network;Email;
 Type=Application
-Exec=proton-mail
+Exec=proton-bridge

--- a/extra-web/proton-bridge/autobuild/overrides/usr/share/applications/proton-ie.desktop
+++ b/extra-web/proton-bridge/autobuild/overrides/usr/share/applications/proton-ie.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=ProtonMail Import-Export app
+Comment=ProtonMail Import-Export app for importing and exporting messages
+Keywords=Email;E-mail;Protonmail;
+Icon=proton-ie
+Categories=Application;Network;Email;
+Type=Application
+Exec=proton-ie

--- a/extra-web/proton-bridge/autobuild/prepare
+++ b/extra-web/proton-bridge/autobuild/prepare
@@ -1,0 +1,2 @@
+export HOME=/root
+acbs_copy_git

--- a/extra-web/proton-bridge/autobuild/prepare
+++ b/extra-web/proton-bridge/autobuild/prepare
@@ -1,2 +1,1 @@
-export HOME=/root
 acbs_copy_git

--- a/extra-web/proton-bridge/spec
+++ b/extra-web/proton-bridge/spec
@@ -1,0 +1,3 @@
+VER=1.5.7
+SRCS="git::commit=tags/v$VER::https://github.com/ProtonMail/proton-bridge.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

New `proton-bridge` package, version `1.5.7`.

Package(s) Affected
-------------------

- `proton-bridge`

Security Update?
----------------

No

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [X] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [X] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2743)
<!-- Reviewable:end -->
