### PR TITLE
telegram-desktop: update to 2.5.8

### DIFF
--- a/extra-web/telegram-desktop/autobuild/defines
+++ b/extra-web/telegram-desktop/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=telegram-desktop
 PKGSEC=web
 PKGDEP="ffmpeg hicolor-icon-theme libappindicator libnotify minizip \
         openal-soft openssl lz4 qt-5 xxhash hunspell libdbusmenu-qt \
-	libjpeg-turbo opus pulseaudio"
+	libjpeg-turbo opus pulseaudio kwayland"
 BUILDDEP="cmake range-v3 python-3 tl-expected microsoft-gsl yasm"
 PKGDES="The official Telegram desktop application"
 

--- a/extra-web/telegram-desktop/spec
+++ b/extra-web/telegram-desktop/spec
@@ -1,7 +1,7 @@
-VER=2.5.1
+VER=2.5.7
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
-      git::rename=tg_owt;commit=6eaebec41b34a0a0d98f02892d0cfe6bbcbc0a39::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::f1cc5e876deaa4fa4eaafbba95f127d5a3114c166802902b8584099852b9eae2 \
+      git::rename=tg_owt;commit=be23804afce3bb2e80a1d57a7c1318c71b82b7de::https://github.com/desktop-app/tg_owt"
+CHKSUMS="sha256::eb9cfc075a9634a3917d222997d8173b9ca3baf978d7457fa1c8fd196ad3d2b8 \
          SKIP"
 SUBDIR=tdesktop-$VER-full

--- a/extra-web/telegram-desktop/spec
+++ b/extra-web/telegram-desktop/spec
@@ -1,7 +1,7 @@
-VER=2.5.7
+VER=2.5.8
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=be23804afce3bb2e80a1d57a7c1318c71b82b7de::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::eb9cfc075a9634a3917d222997d8173b9ca3baf978d7457fa1c8fd196ad3d2b8 \
+CHKSUMS="sha256::9c89cb31f8ba8a26821fe3c2769b04162e8d7629d327f9cd25a892e88878417e \
          SKIP"
 SUBDIR=tdesktop-$VER-full


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

telegram-desktop: update to 2.5.8

Package(s) Affected
-------------------

telegram-desktop 2.5.8

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
