### PR TITLE
Reworks for general-survey-20201222

### DIFF
--- a/extra-admin/aosc-os-arm-boot-flasher/autobuild/defines
+++ b/extra-admin/aosc-os-arm-boot-flasher/autobuild/defines
@@ -3,5 +3,4 @@ PKGDES="AOSC OS boot-related file update(flash)er for ARM architecture (and mayb
 PKGSEC=admin
 PKGDEP="uboot-tools bash"
 
-ABHOST=noarch
 FAIL_ARCH="!(arm64|armel|armhf)"

--- a/extra-admin/gotop/spec
+++ b/extra-admin/gotop/spec
@@ -1,4 +1,4 @@
 VER=4.0.1
 SRCS="https://github.com/xxxserxxx/gotop/archive/v$VER.tar.gz"
 CHKSUMS="sha256::38a34543ed828ed8cedd93049d9634c2e578390543d4068c19f0d0c20aaf7ba0"
-REL=1
+REL=2

--- a/extra-admin/iozone/autobuild/build
+++ b/extra-admin/iozone/autobuild/build
@@ -1,35 +1,14 @@
-abinfo "Building iozone (like an absolute muppet) ..."
+abinfo "Building iozone ..."
 if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
-    make linux-AMD64 \
-        -C "$SRCDIR"/src/current || true
+    make linux-AMD64
 elif [[ "${CROSS:-$ARCH}" = "armel" || "${CROSS:-$ARCH}" = "armhf" ]]; then
-    make linux-arm \
-        -C "$SRCDIR"/src/current || true
+    make linux-arm
 elif [[ "${CROSS:-$ARCH}" = "ppc64el" || "${CROSS:-$ARCH}" = "ppc64" ]]; then
-    make linux-powerpc64 \
-        -C "$SRCDIR"/src/current || true
+    make linux-powerpc64
 else
-    make linux \
-        -C "$SRCDIR"/src/current || true
-fi
-
-make clean \
-    -C "$SRCDIR"/src/current
-
-if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
-    make linux-AMD64 \
-        -C "$SRCDIR"/src/current
-elif [[ "${CROSS:-$ARCH}" = "armel" || "${CROSS:-$ARCH}" = "armhf" ]]; then
-    make linux-arm \
-        -C "$SRCDIR"/src/current
-elif [[ "${CROSS:-$ARCH}" = "ppc64el" || "${CROSS:-$ARCH}" = "ppc64" ]]; then
-    make linux-powerpc64 \
-        -C "$SRCDIR"/src/current
-else
-    make linux \
-        -C "$SRCDIR"/src/current
+    make linux
 fi
 
 abinfo "Installing iozone ..."
-install -Dvm755 "$SRCDIR"/src/current/{iozone,fileop,pit_server} \
+install -Dvm755 "$SRCDIR"/{iozone,fileop,pit_server} \
     -t "$PKGDIR"/usr/bin/

--- a/extra-admin/iozone/autobuild/build
+++ b/extra-admin/iozone/autobuild/build
@@ -1,3 +1,35 @@
-make -C src/current linux
-mkdir -p ${PKGDIR}/usr/bin
-cp src/current/{iozone,fileop,pit_server} ${PKGDIR}/usr/bin/
+abinfo "Building iozone (like an absolute muppet) ..."
+if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
+    make linux-AMD64 \
+        -C "$SRCDIR"/src/current || true
+elif [[ "${CROSS:-$ARCH}" = "armel" || "${CROSS:-$ARCH}" = "armhf" ]]; then
+    make linux-arm \
+        -C "$SRCDIR"/src/current || true
+elif [[ "${CROSS:-$ARCH}" = "ppc64el" || "${CROSS:-$ARCH}" = "ppc64" ]]; then
+    make linux-powerpc64 \
+        -C "$SRCDIR"/src/current || true
+else
+    make linux \
+        -C "$SRCDIR"/src/current || true
+fi
+
+make clean \
+    -C "$SRCDIR"/src/current
+
+if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
+    make linux-AMD64 \
+        -C "$SRCDIR"/src/current
+elif [[ "${CROSS:-$ARCH}" = "armel" || "${CROSS:-$ARCH}" = "armhf" ]]; then
+    make linux-arm \
+        -C "$SRCDIR"/src/current
+elif [[ "${CROSS:-$ARCH}" = "ppc64el" || "${CROSS:-$ARCH}" = "ppc64" ]]; then
+    make linux-powerpc64 \
+        -C "$SRCDIR"/src/current
+else
+    make linux \
+        -C "$SRCDIR"/src/current
+fi
+
+abinfo "Installing iozone ..."
+install -Dvm755 "$SRCDIR"/src/current/{iozone,fileop,pit_server} \
+    -t "$PKGDIR"/usr/bin/

--- a/extra-admin/iozone/autobuild/defines
+++ b/extra-admin/iozone/autobuild/defines
@@ -1,3 +1,6 @@
 PKGNAME=iozone
-PKGDES="A filesystem benchmark tool"
 PKGSEC=admin
+PKGDEP="glibc"
+PKGDES="A filesystem benchmarking tool"
+
+PKGEPOCH=1

--- a/extra-admin/iozone/autobuild/patch
+++ b/extra-admin/iozone/autobuild/patch
@@ -1,1 +1,0 @@
-sed -i 's/CFLAGS\t=/CFLAGS\t?=/g' src/current/makefile

--- a/extra-admin/iozone/autobuild/prepare
+++ b/extra-admin/iozone/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Dropping pre-packaged binaries (why, why, why?!) ..."
+rm -fv "$SRCDIR"/{*.o,iozone,fileop,pit_server}
+

--- a/extra-admin/iozone/spec
+++ b/extra-admin/iozone/spec
@@ -1,3 +1,4 @@
 VER=3.491
 SRCS="tbl::http://www.iozone.org/src/current/iozone${VER/./_}.tgz"
 CHKSUMS="sha256::14ce89b60a43c21f1fadb82f15c1b926c993f3c6ad2a647202a6ccf117c72317"
+SUBDIR="iozone${VER/./_}/src/current"

--- a/extra-admin/iozone/spec
+++ b/extra-admin/iozone/spec
@@ -1,3 +1,3 @@
 VER=3.491
 SRCS="tbl::http://www.iozone.org/src/current/iozone${VER/./_}.tgz"
-CHKSUMS="sha256::057d310cc0c16fcb35ac6de25bee363d54503377cbd93a6122797f8277aab6f0"
+CHKSUMS="sha256::14ce89b60a43c21f1fadb82f15c1b926c993f3c6ad2a647202a6ccf117c72317"

--- a/extra-admin/mdadm/autobuild/prepare
+++ b/extra-admin/mdadm/autobuild/prepare
@@ -1,2 +1,5 @@
-abinfo "Merge all flags to CPPFLAGS ..."
+abinfo "Merge all flags to CFLAGS ..."
 export CPPFLAGS="${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
+
+abinfo "Appending -Wno-error=maybe-unitialized to fix build ..."
+export CC="gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -Wno-error=maybe-uninitialized"

--- a/extra-i18n/po4a/autobuild/defines
+++ b/extra-i18n/po4a/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=po4a
 PKGSEC=doc
-PKGDEP="perl-unicode-linebreak gettext"
+PKGDEP="perl-unicode-linebreak gettext perl-yaml-tiny"
 BUILDDEP="perl-module-build libxslt perl-locale-gettext perl-text-wrapi18n perl-mime-charset perl-pod-parser docbook-xsl"
 PKGDES="Tools for helping translation of documentation"
 

--- a/extra-i18n/po4a/spec
+++ b/extra-i18n/po4a/spec
@@ -1,3 +1,4 @@
 VER=0.62
+REL=1
 SRCTBL="https://github.com/mquinson/po4a/releases/download/v$VER/po4a-$VER.tar.gz"
 CHKSUM="sha256::0eb510a66f59de68cf7a205342036cc9fc08b39334b91f1456421a5f3359e68b"

--- a/extra-perl/perl-yaml-tiny/autobuild/defines
+++ b/extra-perl/perl-yaml-tiny/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=perl-yaml-tiny
+PKGSEC=perl
+PKGDES="Read/Write YAML files with as little code as possible"
+PKGDEP="perl"
+
+ABHOST=noarch

--- a/extra-perl/perl-yaml-tiny/spec
+++ b/extra-perl/perl-yaml-tiny/spec
@@ -1,0 +1,3 @@
+VER=1.73
+SRCS="tbl::https://cpan.metacpan.org/authors/id/E/ET/ETHER/YAML-Tiny-$VER.tar.gz"
+CHKSUMS="sha256::bc315fa12e8f1e3ee5e2f430d90b708a5dc7e47c867dba8dce3a6b8fbe257744"


### PR DESCRIPTION
Topic Description
-----------------

This topic addresses several FTBFS's found with `general-survey-20201222`, when Autobuild3 and Ciel 3 changes were introduced.

Package(s) Affected
-------------------

```
extra-i18n/po4a
extra-admin/apt
extra-admin/gotop
extra-admin/iozone
extra-admin/mdadm
extra-admin/podman
```

Security Update?
----------------

No

Build Order
-----------

```
extra-i18n/po4a extra-admin/apt extra-admin/gotop extra-admin/iozone extra-admin/mdadm extra-admin/podman
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`