### PR TITLE
ykdl: update to 1.7.0+git20210125

### DIFF
--- a/extra-multimedia/ykdl/spec
+++ b/extra-multimedia/ykdl/spec
@@ -1,3 +1,3 @@
-VER=1.6.3+git20201106
+VER=1.6.3+git20210125
 GITSRC="https://github.com/zhangn1985/ykdl.git"
-GITCO="2d10a5dffdb13067131c1bf187f227f41d3d39d8"
+GITCO="bc556d6df0af642d648337ac09559b56337c0f63"


### PR DESCRIPTION
Topic Description
-----------------
Update `ykdl` to 1.7.0+git20210125

Package(s) Affected
-------------------
- `ykdl`

Security Update?
----------------
No 

Architectural Progress
----------------------
- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] Architecture-independent `noarch` -->
