### PR TITLE
kitty: update 0.19.3

### DIFF
--- a/extra-utils/kitty/spec
+++ b/extra-utils/kitty/spec
@@ -1,3 +1,3 @@
-VER=0.19.2
-SRCTBL="https://github.com/kovidgoyal/kitty/archive/v$VER.tar.gz"
-CHKSUM="sha256::7bad5787e05ebc9989b15c8759c09c5754c5c10dbd072fa777bca3e9ec2800d5"
+VER=0.19.3
+SRCS="https://github.com/kovidgoyal/kitty/archive/v$VER.tar.gz"
+CHKSUMS="whirlpool::a7cf52e55bd9a71c9dc001946aedb73229a611f1c84a7ed5358cdf1e61d8d418c1900ff943c4cf75f400194abb0f5eb3bc2dbfe6aa1e3d25950c25dfb55ba1d5"


### PR DESCRIPTION
Topic Description
-----------------
Update to `kitty` to version 0.19.3

Package(s) Affected
-------------------
- `kitty`

Security Update?
----------------
 No 

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

