### PR TITLE
fcitx5-material-color: update to 0.1+git20201212

### DIFF
--- a/extra-i18n/fcitx5-material-color/spec
+++ b/extra-i18n/fcitx5-material-color/spec
@@ -1,3 +1,3 @@
-VER=0.1
-SRCS="tbl::https://github.com/hosxy/Fcitx5-Material-Color/archive/$VER.tar.gz"
-CHKSUMS="sha256::bd063d532c46ed242c2612364ed232e98d62e34562fb4c8991e2e9e459c1b841"
+VER=0.1+git20201212
+SRCS="git::commit=c5f240591af52a041ff0fcde6fe245761c926f61::https://github.com/hosxy/Fcitx5-Material-Color"
+CHKSUMS="SKIP"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fcitx5-material-color: update to 0.1+git20201212

Package(s) Affected
-------------------

fcitx5-material-color 0.1+git20201212

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch` 

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch` 

