### PR TITLE
bcc: fix build on ppc64el

### DIFF
--- a/extra-devel/bcc/autobuild/defines
+++ b/extra-devel/bcc/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=bcc
 PKGSEC=devel
 PKGDEP="llvm elfutils libedit ethtool luajit python-3 netaddr libbpf"
+PKGDEP__PPC64EL="${PKGDEP/luajit/lua}"
 BUILDDEP="flex bison"
 PKGDES="BPF compiler collection and tools for Linux kernel tracing and instrumentation"
 


### PR DESCRIPTION
Topic Description
-----------------

Fix bcc build on `ppc64el` by changing `luajit` depenedency to `lua` for `ppc64el`.

Package(s) Affected
-------------------

`bcc` v0.18.0 (no version change)

Security Update?
----------------

No

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] PowerPC 64-bit (Little Endian) `ppc64el`