### PR TITLE
Reworks for lxqt-0.16.0

### DIFF
--- a/extra-libs/menu-cache/autobuild/patches/0001-BLFS-fix-build-with-GCC-10.patch
+++ b/extra-libs/menu-cache/autobuild/patches/0001-BLFS-fix-build-with-GCC-10.patch
@@ -1,0 +1,106 @@
+From 1ce739649b4d66339a03fc0ec9ee7a2f7c141780 Mon Sep 17 00:00:00 2001
+From: Mamoru TASAKA <mtasaka@fedoraproject.org>
+Date: Fri, 24 Jan 2020 13:33:00 +0900
+Subject: [PATCH] Support gcc10 compilation
+
+gcc10 now defaults to -fno-common, and with gcc10 menu-cache compilation fails like
+
+/bin/ld: menu-merge.o:menu-cache-gen/menu-tags.h:167: multiple definition of `DirDirs'; main.o:menu-cache-gen/menu-tags.h:167: first defined here
+/bin/ld: menu-merge.o:menu-cache-gen/menu-tags.h:164: multiple definition of `AppDirs'; main.o:menu-cache-gen/menu-tags.h:164: first defined here
+/bin/ld: menu-merge.o:menu-cache-gen/menu-tags.h:52: multiple definition of `menuTag_Layout'; main.o:menu-cache-gen/menu-tags.h:52: first defined here
+....
+
+This patch fixes compilation with gcc10: properly declaring variables in header with "extern", and also removing some unneeded variables in header files.
+---
+ menu-cache-gen/menu-tags.h | 55 ++++++++++++--------------------------
+ 1 file changed, 17 insertions(+), 38 deletions(-)
+
+diff --git a/menu-cache-gen/menu-tags.h b/menu-cache-gen/menu-tags.h
+index f3fd7d3..f71c0bc 100644
+--- a/menu-cache-gen/menu-tags.h
++++ b/menu-cache-gen/menu-tags.h
+@@ -22,38 +22,17 @@
+ #include <libfm/fm-extra.h>
+ #include <menu-cache.h>
+ 
+-FmXmlFileTag menuTag_Menu;
+-FmXmlFileTag menuTag_AppDir;
+-FmXmlFileTag menuTag_DefaultAppDirs;
+-FmXmlFileTag menuTag_DirectoryDir;
+-FmXmlFileTag menuTag_DefaultDirectoryDirs;
+-FmXmlFileTag menuTag_Include;
+-FmXmlFileTag menuTag_Exclude;
+-FmXmlFileTag menuTag_Filename;
+-FmXmlFileTag menuTag_Or;
+-FmXmlFileTag menuTag_And;
+-FmXmlFileTag menuTag_Not;
+-FmXmlFileTag menuTag_Category;
+-FmXmlFileTag menuTag_MergeFile;
+-FmXmlFileTag menuTag_MergeDir;
+-FmXmlFileTag menuTag_DefaultMergeDirs;
+-FmXmlFileTag menuTag_Directory;
+-FmXmlFileTag menuTag_Name;
+-FmXmlFileTag menuTag_Deleted;
+-FmXmlFileTag menuTag_NotDeleted;
+-FmXmlFileTag menuTag_OnlyUnallocated;
+-FmXmlFileTag menuTag_NotOnlyUnallocated;
+-FmXmlFileTag menuTag_All;
+-FmXmlFileTag menuTag_LegacyDir;
+-FmXmlFileTag menuTag_KDELegacyDirs;
+-FmXmlFileTag menuTag_Move;
+-FmXmlFileTag menuTag_Old;
+-FmXmlFileTag menuTag_New;
+-FmXmlFileTag menuTag_Layout;
+-FmXmlFileTag menuTag_DefaultLayout;
+-FmXmlFileTag menuTag_Menuname;
+-FmXmlFileTag menuTag_Separator;
+-FmXmlFileTag menuTag_Merge;
++extern FmXmlFileTag menuTag_AppDir;
++extern FmXmlFileTag menuTag_DirectoryDir;
++extern FmXmlFileTag menuTag_Include;
++extern FmXmlFileTag menuTag_Exclude;
++extern FmXmlFileTag menuTag_Filename;
++extern FmXmlFileTag menuTag_Or;
++extern FmXmlFileTag menuTag_And;
++extern FmXmlFileTag menuTag_Not;
++extern FmXmlFileTag menuTag_Category;
++extern FmXmlFileTag menuTag_All;
++extern FmXmlFileTag menuTag_LegacyDir;
+ 
+ typedef enum {
+     MERGE_NONE, /* starting value */
+@@ -152,19 +131,19 @@ typedef struct {
+ } MenuRule;
+ 
+ /* requested language(s) */
+-char **languages;
++extern char **languages;
+ 
+ /* list of menu files to monitor */
+-GSList *MenuFiles;
++extern GSList *MenuFiles;
+ 
+ /* list of menu dirs to monitor */
+-GSList *MenuDirs;
++extern GSList *MenuDirs;
+ 
+ /* list of available app dirs */
+-GSList *AppDirs;
++extern GSList *AppDirs;
+ 
+ /* list of available dir dirs */
+-GSList *DirDirs;
++extern GSList *DirDirs;
+ 
+ /* parse and merge menu files */
+ MenuMenu *get_merged_menu(const char *file, FmXmlFile **xmlfile, GError **error);
+@@ -177,7 +156,7 @@ gboolean save_menu_cache(MenuMenu *layout, const char *menuname, const char *fil
+ void _free_layout_items(GList *data);
+ 
+ /* verbosity level */
+-gint verbose;
++extern gint verbose;
+ 
+ #define DBG if (verbose) g_debug
+ #define VDBG if (verbose > 1) g_debug
+

--- a/extra-libs/menu-cache/spec
+++ b/extra-libs/menu-cache/spec
@@ -1,3 +1,4 @@
 VER=1.1.0
+REL=1
 SRCTBL="https://downloads.sourceforge.net/lxde/menu-cache/menu-cache-$VER.tar.xz"
 CHKSUM="sha256::ed02eb459dcb398f69b9fa5bf4dd813020405afc84331115469cdf7be9273ec7"

--- a/extra-lxqt/lxqt-powermanagement/autobuild/defines
+++ b/extra-lxqt/lxqt-powermanagement/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxqt-powermanagement
 PKGSEC=LxQt
-PKGDEP="kidletime liblxqt solid xdg-utils"
+PKGDEP="kidletime liblxqt lxqt-config lxqt-globalkeys solid xdg-utils"
 BUILDDEP="lxqt-build-tools"
 PKGDES="Power management module for LxQt"

--- a/extra-lxqt/obconf-qt/autobuild/defines
+++ b/extra-lxqt/obconf-qt/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=obconf-qt
 PKGSEC=x11
 PKGDEP="openbox qt-5"
+BUILDDEP="lxqt-build-tools"
 PKGDES="Qt based OpenBox configurator"

--- a/extra-lxqt/qterminal/autobuild/defines
+++ b/extra-lxqt/qterminal/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=qterminal
 PKGSEC=LxQt
 PKGDEP="liblxqt qtermwidget"
-BUILDDEP="doxygen"
+BUILDDEP="doxygen lxqt-build-tools"
 PKGDES="A Qt widget based terminal emulator"
 
-CMAKE_AFTER="-DUSE_SYSTEM_QXT=OFF -DUSE_QT5=true"
+CMAKE_AFTER="-DUSE_SYSTEM_QXT=OFF \
+             -DUSE_QT5=true"

--- a/extra-lxqt/screengrab/autobuild/defines
+++ b/extra-lxqt/screengrab/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=screengrab
 PKGSEC=LxQt
-PKGDEP="kwindowsystem qt-5"
+PKGDEP="kwindowsystem libqtxdg qt-5"
 PKGDES="A program for fast creating screenshots, and easily publishing them on internet image hosting services"
 
 CMAKE_AFTER="-DSG_XDG_CONFIG_SUPPORT=ON \


### PR DESCRIPTION
Topic Description
-----------------

This topic reworks a few FTBFS that were uncaught when building sequentially with Ciel 2. AOSC OS now requires rolling back a build environment per package, which resulted in a few missing (runtime and build-time) dependencies being discovered.

Package(s) Affected
-------------------

### Updated packages:

```
extra-lxqt/lxqt-build-tools
extra-libs/libsysstat
extra-libs/libqtxdg
extra-lxqt/liblxqt
extra-lxqt/libfm-qt
extra-lxqt/lxqt-about
extra-lxqt/lxqt-config
extra-lxqt/lxqt-globalkeys
extra-lxqt/lxqt-notificationd
extra-lxqt/lxqt-panel
extra-lxqt/lxqt-policykit
extra-lxqt/lxqt-powermanagement
extra-lxqt/lxqt-qtplugin
extra-lxqt/lxqt-runner
extra-lxqt/lxqt-session
extra-lxqt/lxqt-sudo
extra-lxqt/lxqt-admin
extra-lxqt/lxqt-themes
extra-lxqt/pcmanfm-qt
extra-lxqt/qtermwidget
extra-lxqt/qterminal
extra-lxqt/obconf-qt
extra-lxqt/pavucontrol-qt
extra-lxqt/lximage-qt
extra-bases/lxqt-base
```

### New packages:

```
extra-lxqt/screengrab
extra-lxqt/lxqt-archiver
extra-lxqt/sddm-config-editor
extra-lxqt/qps
extra-lxqt/compton-conf
extra-lxqt/lxqt-wallet
```

### Changed packages:

```
extra-libs/menu-cache
extra-x11/compton
extra-x11/picom
```

Security Update?
----------------

No

Build Order
-----------

```
picom compton menu-cache groups/lxqt lxqt-base
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`