### PR TITLE
bash-startup: update to 0.4.6.6

### DIFF
--- a/base-misc/bash-startup/spec
+++ b/base-misc/bash-startup/spec
@@ -1,4 +1,3 @@
-VER=0.4.6.5
-REL=1
+VER=0.4.6.6
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Update `bash-startup` to v0.4.6.6 to address usability issues with `autojmp`.

Package(s) Affected
-------------------

- `bash-startup` v0.4.6.6

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`