### PR TITLE
telegram-desktop: fix group voice chat

### DIFF
--- a/extra-web/telegram-desktop/autobuild/prepare
+++ b/extra-web/telegram-desktop/autobuild/prepare
@@ -4,12 +4,14 @@ for i in autobuild/patches/*.patch.deferred; do
   patch -Np1 -d "../tg_owt" -i "$(readlink -f $i)"
 done
 
-abinfo "Set CMAKE_PREFOX_PATH to fix tg-owt can't not find"
-export CMAKE_PREFIX_PATH="$SRCDIR/../tg_owt:$CMAKE_PREFIX_PATH"
 
 abinfo "Making tg_owt..."
 cd "$SRCDIR"/../tg_owt
-cmake -DBUILD_SHARED_LIBS=OFF . 
-make
+cmake -G Ninja \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/usr .
+ninja
+ninja install
 
 cd "$SRCDIR"

--- a/extra-web/telegram-desktop/spec
+++ b/extra-web/telegram-desktop/spec
@@ -1,7 +1,8 @@
 VER=2.5.8
+REL=1
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
-      git::rename=tg_owt;commit=be23804afce3bb2e80a1d57a7c1318c71b82b7de::https://github.com/desktop-app/tg_owt"
+      git::rename=tg_owt;commit=a19877363082da634a3c851a4698376504d2eaee::https://github.com/desktop-app/tg_owt"
 CHKSUMS="sha256::9c89cb31f8ba8a26821fe3c2769b04162e8d7629d327f9cd25a892e88878417e \
          SKIP"
 SUBDIR=tdesktop-$VER-full


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

telegram-desktop: fix group voice chat

- Use ninja to build tg_owt

Package(s) Affected
-------------------

telegram-desktop 2.5.8-1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
