### PR TITLE
fcitx5-pinyin-zhwiki: update to 0.2.2+20210201

### DIFF
--- a/extra-i18n/fcitx5-pinyin-zhwiki/spec
+++ b/extra-i18n/fcitx5-pinyin-zhwiki/spec
@@ -1,8 +1,8 @@
-dict_ver=20201220
+dict_ver=20210201
 package_ver=0.2.2
 VER="${package_ver}"+"${dict_ver}"
 SRCS="tbl::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/archive/${package_ver}.tar.gz \
       file::rename=zhwiki-${dict_ver}-all-titles-in-ns0.gz::https://dumps.wikimedia.org/zhwiki/${dict_ver}/zhwiki-${dict_ver}-all-titles-in-ns0.gz"
 CHKSUMS="sha256::a06cc5e6a3630de229cbe0d7093caa2142d740daca681ee7c6aefe541d4a6e86 \
-         sha256::7097dc919fbad1d00d889b4375f452ea4d0cb66f64bb1b01833a45410b6db448"
+         sha256::bf061a11095e23e5b658f846fd8407d5cfd1b25dc200b46f26f66b69fd896804"
 SUBDIR="fcitx5-pinyin-zhwiki-$package_ver"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fcitx5-pinyin-zhwiki: update to 0.2.2+20210201

Package(s) Affected
-------------------

fcitx5-pinyin-zhwiki 0.2.2+20210201

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

 - [x] Architecture-independent `noarch` 


----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

 - [x] Architecture-independent `noarch` 

