### PR TITLE
librime: update to 1.7.1

### DIFF
--- a/extra-i18n/librime/autobuild/prepare
+++ b/extra-i18n/librime/autobuild/prepare
@@ -10,5 +10,7 @@ ln -sfv "$SRCDIR"/../librime-octagram-* \
     "$SRCDIR"/librime-octagram
 ln -sfv "$SRCDIR"/../librime-lua-* \
     "$SRCDIR"/librime-lua
+ln -sfv "$SRCDIR"/../librime-charcode-* \
+    "$SRCDIR"/librime-charcode
 
 cd "$SRCDIR"

--- a/extra-i18n/librime/spec
+++ b/extra-i18n/librime/spec
@@ -1,11 +1,13 @@
-VER=1.6.1
-OCTAGRAMCOMMIT=3664bc9d0426397541e6dcfb7c3c7d6aaad73b2e
-LUACOMMIT=aeb1e9d76e704dd5472e70e7d3e2b25fcec93f23
-REL=5
+VER=1.7.1
+OCTAGRAMCOMMIT=f92e083052b9983ee3cbddcda5ed60bb3c068e24
+LUACOMMIT=00c999b3c9230d7a6a4f6410479e123b5010d9b8
+CHARCODECOMMIT=b569184772b12965e3ebe1dfd431026951fed81c
 SRCS="https://github.com/rime/librime/archive/$VER.tar.gz \
       https://github.com/lotem/librime-octagram/archive/$OCTAGRAMCOMMIT/librime-octagram-$OCTAGRAMCOMMIT.tar.gz \
-      https://github.com/hchunhui/librime-lua/archive/$LUACOMMIT/librime-lua-$LUACOMMIT.tar.gz"
-CHKSUMS="sha256::774ebd2ddb9c1301a8a981c65788e0fab71ef54505e04f39b3ce4dfdb8510302 \
-         sha256::1b5f49a4953d1da66fa858c5b67ed158453553d676ddac474a96ffa8885e11e5 \
-         sha256::8b254eab4e496ade24c99b6ac39648e1e7bc24f86054ef3aacdec083ede761bd"
+      https://github.com/hchunhui/librime-lua/archive/$LUACOMMIT/librime-lua-$LUACOMMIT.tar.gz \
+      https://github.com/rime/librime-charcode/archive/$CHARCODECOMMIT/librime-lua-$CHARCODECOMMIT.tar.gz"
+CHKSUMS="sha256::a22cc31644557b950579f025e0a4518347a9b74069641e1fbaacaadd61b15dab \
+         sha256::4cb9470e21335f817ccd443179e102721f1d7cb5b332a1d445b903bad170cdc3 \
+         sha256::314a99e4b0e26b3e14e4d600b922d39871e52ae038ac3aa285a8b70791a68d97 \
+         sha256::21496ccb618d5c18e8e197da83631007041fd5cf0fcaca71c53e0f0558dfb092"
 SUBDIR="librime-$VER"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

librime: update to 1.7.1

- Add librime-charcode plugin

Package(s) Affected
-------------------

librime: 1.7.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
