### PR TITLE
Nvidia drivers 460.32.03

### DIFF
--- a/extra-devel/cuda/autobuild/build
+++ b/extra-devel/cuda/autobuild/build
@@ -30,6 +30,7 @@ for f in $(find "$PKGDIR"${CUDA_ROOT} -name Makefile); do
 done
 
 abinfo "Specifying the compiler that CUDA uses"
+abinfo "Trying GCC 10"
 ln -sv /usr/bin/gcc "$PKGDIR"/usr/lib/cuda/bin/gcc
 ln -sv /usr/bin/g++ "$PKGDIR"/usr/lib/cuda/bin/g++
 

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/accinj64.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/accinj64.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: accinj64
 Description: OpenACC 64-bit Injection Library
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -laccinj64
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cublas.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cublas.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: cublas
 Description: CUDA BLAS Library
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lcublas
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cuda.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cuda.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: cuda
 Description: CUDA Driver Library
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lcuda
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cudart.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cudart.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: cudart
 Description: CUDA Runtime Library
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lcudart
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cufft.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cufft.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: cufft
 Description: CUDA Fast Fourier Transform
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lcufft
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cufftw.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cufftw.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: cufftw
 Description: CUDA Fast Fourier Transform Wide
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lcufftw
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cuinj64.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cuinj64.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: cuinj64
 Description: CUDA 64-bit Injection Library
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lcuinj64
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/curand.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/curand.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: curand
 Description: CUDA Random Number Generation Library
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lcurand
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cusolver.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cusolver.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: cusolver
 Description: A LAPACK-like library on dense and sparse linear algebra
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lcusolver
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cusparse.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/cusparse.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: cusparse
 Description: CUDA Sparse Matrix Library
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lcusparse
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppc.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppc.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nppc
 Description: NVIDIA Performance Primitives - Core
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnppc
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppi.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppi.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nppi
 Description: NVIDIA Performance Primitives - Image Processing
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnppi
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppial.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppial.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nppial
 Description: NVIDIA Performance Primitives - Image Processing - Arithmetic and Logic
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnppial
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppicc.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppicc.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nppicc
 Description: NVIDIA Performance Primitives - Image Processing - Color Conversion
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnppicc
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppicom.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppicom.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nppicom
 Description: NVIDIA Performance Primitives - Image Processing - Compression
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnppicom
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppidei.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppidei.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nppidei
 Description: NVIDIA Performance Primitives - Image Processing - DEI
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnppidei
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppif.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppif.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nppif
 Description: NVIDIA Performance Primitives - Image Processing - Filters
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnppif
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppig.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppig.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nppig
 Description: NVIDIA Performance Primitives - Image Processing - Geometry
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnppig
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppim.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppim.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nppim
 Description: NVIDIA Performance Primitives - Image Processing - Morphological
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnppim
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppist.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppist.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nppist
 Description: NVIDIA Performance Primitives - Image Processing - Statistic and Linear
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnppist
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppisu.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppisu.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nppisu
 Description: NVIDIA Performance Primitives - Image Processing - Support and Data Exchange
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnppisu
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppitc.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nppitc.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nppitc
 Description: NVIDIA Performance Primitives - Image Processing - Threshold and Compare
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnppitc
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/npps.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/npps.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: npps
 Description: NVIDIA Performance Primitives - Signal Processing
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnpps
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nvToolsExt.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nvToolsExt.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nvToolsExt
 Description: NVIDIA Tools Extension
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnvToolsExt
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nvgraph.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nvgraph.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nvgraph
 Description: NVIDIA Accelerated Graph Analytics
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnvgraph
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nvidia-ml.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nvidia-ml.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nvidia-ml
 Description: NVML
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir}/stubs -lnvidia-ml
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nvjpeg.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nvjpeg.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nvjpeg
 Description: NVIDIA JPEG Library
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnvjpeg
 Cflags: -I${includedir}

--- a/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nvrtc.pc
+++ b/extra-devel/cuda/autobuild/overrides/usr/lib/pkgconfig/nvrtc.pc
@@ -4,6 +4,6 @@ includedir=${cudaroot}/targets/x86_64-linux/include
 
 Name: nvrtc
 Description: A runtime compilation library for CUDA C++
-Version: 11.0
+Version: 11.2
 Libs: -L${libdir} -lnvrtc
 Cflags: -I${includedir}

--- a/extra-devel/cuda/spec
+++ b/extra-devel/cuda/spec
@@ -1,6 +1,6 @@
-MAJOR_VER=11.1.1
-MINOR_VER=455.32.00
+MAJOR_VER=11.2.0
+MINOR_VER=460.27.04
 VER=${MAJOR_VER}+${MINOR_VER}
 REL=1
 SRCS="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${MAJOR_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS="sha256::3eae6727086024925ebbcef3e9a45ad379d8490768fd00f9c2d8b6fd9cd8dd8f"
+CHKSUMS="sha256::9c50283241ac325d3085289ed9b9c170531369de41165ce271352d4a898cbdce"

--- a/extra-optenv32/nvidia+32/spec
+++ b/extra-optenv32/nvidia+32/spec
@@ -1,5 +1,6 @@
-VER=455.45.01
+VER=460.32.03
 SRCS="file::rename=NVIDIA-Linux-x86_64-$VER.run::http://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run \
       tbl::https://github.com/NVIDIA/nvidia-settings/archive/$VER.tar.gz"
-CHKSUMS="sha256::eadc8c7e082f65540fa7f6a249d8309fb546fe62066f495472701dc8c103a153 sha256::da83a598d01e8355e89617deebcce3007964c9f3593e6d27097de0df0c0fc388"
+CHKSUMS="sha256::4f2122fc23655439f214717c4c35ab9b4f5ab8537cddfdf059a5682f1b726061 \
+         sha256::ddcb4c6ea7330cb0f9dc272e36e8a0a4867cfce9a930a22d21fad1307173f0b7"
 SUBDIR=.

--- a/extra-x11/nvidia/autobuild/postinst
+++ b/extra-x11/nvidia/autobuild/postinst
@@ -1,6 +1,6 @@
 unset ARCH
 
-DRIVER_VER=455.45.01
+DRIVER_VER=460.32.03
 
 for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
     if [ -f "/usr/lib/modules/${i}/modules.dep" -a -f "/usr/lib/modules/${i}/modules.order" -a -f "/usr/lib/modules/${i}/modules.builtin" ]; then

--- a/extra-x11/nvidia/autobuild/prerm
+++ b/extra-x11/nvidia/autobuild/prerm
@@ -1,4 +1,4 @@
 unset ARCH
 
-DRIVER_VER=455.45.01
+DRIVER_VER=460.32.03
 dkms remove nvidia/${DRIVER_VER} --all || true > /dev/null

--- a/extra-x11/nvidia/spec
+++ b/extra-x11/nvidia/spec
@@ -1,5 +1,6 @@
-VER=455.45.01
+VER=460.32.03
 SRCS="file::rename=NVIDIA-Linux-x86_64-$VER-no-compat32.run::http://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER-no-compat32.run \
       tbl::https://github.com/NVIDIA/nvidia-settings/archive/$VER.tar.gz"
-CHKSUMS="sha256::9b707d6244735cf0f745a74c47ed0feeec47bc56baec8122306dee6169ce10fd sha256::da83a598d01e8355e89617deebcce3007964c9f3593e6d27097de0df0c0fc388"
+CHKSUMS="sha256::45aa9d75e8d463d87dcf7ea78a1ea046b9ddc2e159dfab6e861cbf833e6b14cf \
+         sha256::ddcb4c6ea7330cb0f9dc272e36e8a0a4867cfce9a930a22d21fad1307173f0b7"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This PR updates nvidia drivers to 460.32.03 and cuda to 11.2.0+460.27.04. This version of cuda no longer depends on `gcc-8`.

Package(s) Affected
-------------------

* `nvidia`, `nvidia+32`: 460.32.03
* `cuda`: 11.2.0+460.27.04

Build Order
-----------

(nvidia | nvidia+32) -> cuda

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] 32-bit Optional Environment `optenv32`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] 32-bit Optional Environment `optenv32`

<!-- TODO: CI to auto-fill architectural progress. -->
