### PR TITLE
iSCSI target userspace utilities

### DIFF
--- a/extra-admin/targetcli-fb/autobuild/defines
+++ b/extra-admin/targetcli-fb/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=targetcli-fb
+PKGSEC=admin
+PKGDEP="pygobject-3 rtslib-fb configshell-fb six dbus python-3"
+PKGDES="Userland iSCSI target utilities"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-admin/targetcli-fb/spec
+++ b/extra-admin/targetcli-fb/spec
@@ -1,0 +1,3 @@
+VER=2.1.53
+SRCS="https://github.com/open-iscsi/targetcli-fb/archive/v$VER.tar.gz"
+CHKSUMS="sha256::7e6779a1cad7526ac058d72b87607da3840289a9e4b066d13e53108366999938"

--- a/extra-python/configshell-fb/autobuild/defines
+++ b/extra-python/configshell-fb/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=configshell-fb
+PKGSEC=python
+PKGDEP="pyparsing six urwid"
+PKGDES="A Python library for building configuration shells"
+
+ABHOST=noarch

--- a/extra-python/configshell-fb/spec
+++ b/extra-python/configshell-fb/spec
@@ -1,0 +1,3 @@
+VER=1.1.28
+SRCTBL="https://github.com/open-iscsi/configshell-fb/archive/v${VER}.tar.gz"
+CHKSUM="sha256::435822d4cee6d66cd7dc0d34725962bcf0168840556bbb9cc01335a78a3ec79d"

--- a/extra-python/rtslib-fb/autobuild/defines
+++ b/extra-python/rtslib-fb/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=rtslib-fb
+PKGSEC=python
+PKGDEP="pyudev six"
+PKGDES="Python API for in-kernel LIO target"
+
+ABHOST=noarch

--- a/extra-python/rtslib-fb/autobuild/overrides/usr/lib/systemd/system/target.service
+++ b/extra-python/rtslib-fb/autobuild/overrides/usr/lib/systemd/system/target.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Restore LIO kernel target configuration
+Requires=sys-kernel-config.mount
+After=sys-kernel-config.mount network.target local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/targetctl restore
+ExecStop=/usr/bin/targetctl clear
+SyslogIdentifier=target
+
+[Install]
+WantedBy=multi-user.target

--- a/extra-python/rtslib-fb/spec
+++ b/extra-python/rtslib-fb/spec
@@ -1,0 +1,3 @@
+VER=2.1.74
+SRCTBL="https://github.com/open-iscsi/rtslib-fb/archive/v${VER}.tar.gz"
+CHKSUM="sha256::9f581c4bcffebc60be236af8a6ebdeccdb66d0435eeb04ab1b743c170b95d046"


### PR DESCRIPTION
Topic Description
-----------------

This PR introduces the userspace utilities for managing in-kernel LIO iSCSI target implementation (and the dependencies).

Package(s) Affected
-------------------

* `configshell-fb`
* `rtslib-fb`
* `targetcli-fb`

Build Order
-----------

(`configshell-fb` | `rtslib-fb`) -> `targetcli-fb`

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
