### PR TITLE
werkzeug: upgrade to 1.0.1

### DIFF
--- a/extra-python/werkzeug/spec
+++ b/extra-python/werkzeug/spec
@@ -1,4 +1,3 @@
-VER=0.14.1
-REL=2
+VER=1.0.1
 SRCTBL="https://pypi.io/packages/source/W/Werkzeug/Werkzeug-$VER.tar.gz"
-CHKSUM="sha256::c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c"
+CHKSUM="sha256::6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates `werkzeug` to 1.0.1 so that we can actually run flask which requires werkzeug >= 0.15.

Package(s) Affected
-------------------

* werkzeug: 0.14.1-2 -> 1.0.1

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`
