### PR TITLE
ZFS 2.0.2

### DIFF
--- a/extra-kernel/zfs/autobuild/build
+++ b/extra-kernel/zfs/autobuild/build
@@ -30,9 +30,11 @@ cp -Rvf "$SRCDIR"/!(abdist|build) \
 abinfo "Cleaning up ZFS kernel module source tree ..."
 find "${PKGDIR}"/usr/src/zfs-${PKGVER} -name ".git*" -print0 | \
     xargs -0 rm -vfr --
+
+abinfo "Generating DKMS configuration"
 "${PKGDIR}"/usr/src/zfs-${PKGVER}/scripts/dkms.mkconf \
     -v ${PKGVER} \
-    -f dkms.conf \
+    -f "${PKGDIR}"/usr/src/zfs-${PKGVER}/dkms.conf \
     -n zfs
 rm -rfv "${PKGDIR}"/usr/src/zfs-${PKGVER}/{autobuild,abdist,acbs-build_*.log}
 chmod -v g-w,o-w -R "${PKGDIR}"/usr/src/zfs-${PKGVER}

--- a/extra-kernel/zfs/autobuild/prepare
+++ b/extra-kernel/zfs/autobuild/prepare
@@ -5,5 +5,6 @@ done
 
 abinfo "Calibrating postinst, prerm ..."
 sed -e "s|\@ZFSVER\@|$PKGVER|g" \
-    -i "$SRCDIR"/autobuild/postinst \
+    -i "$SRCDIR"/autobuild/postinst
+sed -e "s|\@ZFSVER\@|$PKGVER|g" \
     -i "$SRCDIR"/autobuild/prerm

--- a/extra-kernel/zfs/spec
+++ b/extra-kernel/zfs/spec
@@ -1,3 +1,3 @@
-VER=2.0.0
+VER=2.0.2
 SRCS="tbl::https://github.com/zfsonlinux/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
-CHKSUMS="sha256::3403bf8e993f3c9d772f768142117df47bdbbb8e9bbf85a29c0e166f577f9311"
+CHKSUMS="sha256::bde5067ce4577d26cc0f0313a09173ad40d590d01539b92c93f33f06ee150b24"

--- a/extra-kernel/zfs/spec
+++ b/extra-kernel/zfs/spec
@@ -1,4 +1,3 @@
-VER=0.8.4
-REL=2
+VER=2.0.0
 SRCS="tbl::https://github.com/zfsonlinux/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
-CHKSUMS="sha256::2b988f5777976f09d08083f6bebf6e67219c4c4c183c1f33033fb7e5e5eacafb"
+CHKSUMS="sha256::3403bf8e993f3c9d772f768142117df47bdbbb8e9bbf85a29c0e166f577f9311"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates `zfs` to 2.0.2 and should work with upcoming kernel 5.10+.

Package(s) Affected
-------------------

`zfs`: 2.0.2

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
