### PR TITLE
linux-firmware: upgrade to 20210208

### DIFF
--- a/extra-kernel/linux-firmware/spec
+++ b/extra-kernel/linux-firmware/spec
@@ -1,5 +1,5 @@
-VER=20200901
+VER=20210208
 GITSRC="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git"
-GITCO="d5f9eea5a251d43412b07f5295d03e97b89ac4a5"
+GITCO="b79d2396bc630bfd9b4058459d3e82d7c3428599"
 SUBDIR=.
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates linux firmware packages to 20210208.

Package(s) Affected
-------------------

* `firmware-free`
* `firmware-nonfree`

Architectural Progress
----------------------
- [x] Architecture-independent `noarch`

----

Post-Merge Architectural Progress
---------------------------------
- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
