### PR TITLE
webkit2gtk: update to 2.30.5

### DIFF
--- a/extra-libs/webkit2gtk/spec
+++ b/extra-libs/webkit2gtk/spec
@@ -1,3 +1,3 @@
-VER=2.30.3
+VER=2.30.5
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
-CHKSUMS="sha256::6dea14f03916882816f2fed9497a5103fc54b2ab8602ab145ca991e4951e5e7f"
+CHKSUMS="sha256::7d0dab08e3c5ae07bec80b2822ef42e952765d5724cac86eb23999bfed5a7f1f"


### PR DESCRIPTION
Topic Description
-----------------

Update WebKit2GTK+ to v2.30.5 to address a security issue.

Package(s) Affected
-------------------

`webkit2gtk`

Security Update?
----------------

Yes, [WSA-2021-0001](https://webkitgtk.org/security/WSA-2021-0001.html) (CVE-2020-13558).

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`