### PR TITLE
snap-sync: update to 0.7

### DIFF
--- a/extra-utils/snap-sync/autobuild/defines
+++ b/extra-utils/snap-sync/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=snap-sync
 PKGSEC=utils
-PKGDEP="snapper bash libnotify"
+PKGDEP="snapper bash"
+PKGRECOM="pv libnotify rsync openssh sudo"
 PKGDES="A bash script sends incremental snapshots to another drive for backing up data"
 
 MAKE_AFTER="SNAPPER_CONFIG=/etc/conf.d/snapper"

--- a/extra-utils/snap-sync/spec
+++ b/extra-utils/snap-sync/spec
@@ -1,3 +1,3 @@
-VER=0.6.1
+VER=0.7
 SRCS="tbl::https://github.com/wesbarnett/snap-sync/releases/download/${VER}/snap-sync-${VER}.tar.gz"
-CHKSUMS="sha256::d49bc0fe466b7fd46c9269f60e3c2b7111582f34cf422d263d83bd353cf87ad2"
+CHKSUMS="sha256::d8a32b02ba11bfd6ae7ad044a472aed7505fbb391a50b53e6f4ae8b386814c8f"


### PR DESCRIPTION
Topic Description
-----------------

Update `snap-sync` to 0.7

Package(s) Affected
-------------------

`snap-sync`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

---

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`