### PR TITLE
bind: security update to 9.16.12

### DIFF
--- a/extra-network/bind/autobuild/beyond
+++ b/extra-network/bind/autobuild/beyond
@@ -13,11 +13,13 @@ abinfo "Installing named configuration files ..."
 install -Dvm640 -o 0 -g 40 \
     "$SRCDIR"/autobuild/named.conf "$PKGDIR"/etc/named.conf
 install -dvm770 -o 0 -g 40 "$PKGDIR"/var/named
-for i in root.hint localhost.zone localhost.ip6.zone \
+for i in localhost.zone localhost.ip6.zone \
          127.0.0.zone empty.zone; do
     install -vm640 -o 0 -g 40 \
         "$SRCDIR"/autobuild/$i "$PKGDIR"/var/named
 done
+install -vm640 -o 0 -g 40 \
+    "$SRCDIR"/../root.hint "$PKGDIR"/var/named
 
 abinfo "Moving /var/run => /run ..."
 mv -v "$PKGDIR"/{var/,}run

--- a/extra-network/bind/autobuild/prepare
+++ b/extra-network/bind/autobuild/prepare
@@ -1,5 +1,2 @@
-abinfo "Download root.hint ..."
-wget https://www.internic.net/zones/named.root -O autobuild/root.hint
-
 abinfo "Defining -DDIG_SIGCHASE in CFLAGS ..."
 export CFLAGS+=" -DDIG_SIGCHASE"

--- a/extra-network/bind/spec
+++ b/extra-network/bind/spec
@@ -1,5 +1,5 @@
 VER=9.16.12
 SRCS="tbl::https://ftp.isc.org/isc/bind${VER:0:1}/${VER/.P/-P}/bind-${VER/.P/-P}.tar.xz \
-      file::rename=named.root::https://www.internic.net/zones/named.root"
+      file::rename=root.hint::https://www.internic.net/zones/named.root"
 CHKSUMS="sha256::9914af9311fd349cab441097898d94fb28d0bfd9bf6ed04fe1f97f042644da7f \
          sha256::cc56780553678b1b545b5722564e9c47063edab15b28a5033b36b0a36be64c05"

--- a/extra-network/bind/spec
+++ b/extra-network/bind/spec
@@ -1,4 +1,3 @@
-VER=9.16.4
-SRCTBL="https://ftp.isc.org/isc/bind${VER:0:1}/${VER/.P/-P}/bind-${VER/.P/-P}.tar.xz"
-CHKSUM="sha256::7522088d3daac8bcabaae37998178e09139ef5ccae6631cb1d8a625b770f370a"
-REL=1
+VER=9.16.12
+SRCS="https://ftp.isc.org/isc/bind${VER:0:1}/${VER/.P/-P}/bind-${VER/.P/-P}.tar.xz"
+CHKSUMS="sha256::9914af9311fd349cab441097898d94fb28d0bfd9bf6ed04fe1f97f042644da7f"

--- a/extra-network/bind/spec
+++ b/extra-network/bind/spec
@@ -1,3 +1,5 @@
 VER=9.16.12
-SRCS="https://ftp.isc.org/isc/bind${VER:0:1}/${VER/.P/-P}/bind-${VER/.P/-P}.tar.xz"
-CHKSUMS="sha256::9914af9311fd349cab441097898d94fb28d0bfd9bf6ed04fe1f97f042644da7f"
+SRCS="tbl::https://ftp.isc.org/isc/bind${VER:0:1}/${VER/.P/-P}/bind-${VER/.P/-P}.tar.xz \
+      file::rename=named.root::https://www.internic.net/zones/named.root"
+CHKSUMS="sha256::9914af9311fd349cab441097898d94fb28d0bfd9bf6ed04fe1f97f042644da7f \
+         sha256::cc56780553678b1b545b5722564e9c47063edab15b28a5033b36b0a36be64c05"


### PR DESCRIPTION
Topic Description
-----------------

Update `bind` to v9.16.12 for a security update.

Package(s) Affected
-------------------

- `bind` v9.16.12

Security Update?
----------------

Yes, [CVE-2020-8625](https://kb.isc.org/docs/cve-2020-8625).

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`