### PR TITLE
ffmpeg: Massage loongson2f support for Retro

### DIFF
--- a/extra-multimedia/ffmpeg/autobuild/build
+++ b/extra-multimedia/ffmpeg/autobuild/build
@@ -1,10 +1,5 @@
 if [[ "${CROSS:-$ARCH}" = "loongson2f" ]]; then
-    MIPSCONF="--disable-mipsdsp \
-              --disable-mipsdspr2 \
-              --enable-mipsfpu \
-              --disable-msa \
-              --disable-msa2 \
-              --disable-mmi"
+    MIPSCONF="--cpu=loongson2f"
 fi
 
 if [[ "${CROSS:-$ARCH}" = "powerpc" ]]; then

--- a/extra-multimedia/ffmpeg/autobuild/loongson2f/prepare
+++ b/extra-multimedia/ffmpeg/autobuild/loongson2f/prepare
@@ -1,4 +1,0 @@
-unset CPPFLAGS CFLAGS CXXFLAGS LDFLAGS
-export CFLAGS="-march=mips3 -mtune=loongson2f -mloongson-mmi"
-export CXXFLAGS="-march=mips3 -mtune=loongson2f -mloongson-mmi"
-

--- a/extra-multimedia/ffmpeg/autobuild/patches/0001-avcodec-mips-loongson-refine-process-of-setting-bloc.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0001-avcodec-mips-loongson-refine-process-of-setting-bloc.patch
@@ -1,0 +1,133 @@
+From bc4dc4c26234f4509e646869d3861549212da3f9 Mon Sep 17 00:00:00 2001
+From: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Date: Sun, 28 Jul 2019 12:42:09 +0800
+Subject: [PATCH 01/26] avcodec/mips: [loongson] refine process of setting
+ block as 0 in h264dsp_mmi.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In function ff_h264_add_pixels4_8_mmi, there is no need to reset '%[ftmp0]'
+to 0, because it's value has never changed since the start of the asm block.
+This patch remove the redundant 'xor' and set src to zero once it was loaded.
+
+In function ff_h264_idct_add_8_mmi, 'block' is seted to zero twice.
+This patch removed the first setting zero operation and move the second one
+after the load operation of block.
+
+In function ff_h264_idct8_add_8_mmi, 'block' is seted to zero twice too.
+This patch just removed the second setting zero operation.
+
+This patch mainly simplifies the implementation of functions above,
+the effect on the performance of whole h264 decoding process is not obvious.
+According to the perf data, proportion of ff_h264_idct_add_8_mmi decreased from
+0.29% to 0.26% and ff_h264_idct8_add_8_mmi decreased from 0.62% to 0.59% when decoding
+H264 format on loongson 3A3000(For reference only , not very stable.).
+
+Reviewed-by: Reimar Döffinger <Reimar.Doeffinger@gmx.de>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/h264dsp_mmi.c | 44 +++++++++++------------------------
+ 1 file changed, 13 insertions(+), 31 deletions(-)
+
+diff --git a/libavcodec/mips/h264dsp_mmi.c b/libavcodec/mips/h264dsp_mmi.c
+index ac65a20db0..0459711b82 100644
+--- a/libavcodec/mips/h264dsp_mmi.c
++++ b/libavcodec/mips/h264dsp_mmi.c
+@@ -38,6 +38,9 @@ void ff_h264_add_pixels4_8_mmi(uint8_t *dst, int16_t *src, int stride)
+         MMI_LDC1(%[ftmp2], %[src], 0x08)
+         MMI_LDC1(%[ftmp3], %[src], 0x10)
+         MMI_LDC1(%[ftmp4], %[src], 0x18)
++        /* memset(src, 0, 32); */
++        "gssqc1     %[ftmp0],   %[ftmp0],       0x00(%[src])            \n\t"
++        "gssqc1     %[ftmp0],   %[ftmp0],       0x10(%[src])            \n\t"
+         MMI_ULWC1(%[ftmp5], %[dst0], 0x00)
+         MMI_ULWC1(%[ftmp6], %[dst1], 0x00)
+         MMI_ULWC1(%[ftmp7], %[dst2], 0x00)
+@@ -58,11 +61,6 @@ void ff_h264_add_pixels4_8_mmi(uint8_t *dst, int16_t *src, int stride)
+         MMI_SWC1(%[ftmp2], %[dst1], 0x00)
+         MMI_SWC1(%[ftmp3], %[dst2], 0x00)
+         MMI_SWC1(%[ftmp4], %[dst3], 0x00)
+-
+-        /* memset(src, 0, 32); */
+-        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x00(%[src])            \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x10(%[src])            \n\t"
+         : [ftmp0]"=&f"(ftmp[0]),            [ftmp1]"=&f"(ftmp[1]),
+           [ftmp2]"=&f"(ftmp[2]),            [ftmp3]"=&f"(ftmp[3]),
+           [ftmp4]"=&f"(ftmp[4]),            [ftmp5]"=&f"(ftmp[5]),
+@@ -85,15 +83,19 @@ void ff_h264_idct_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+     DECLARE_VAR_ADDRT;
+ 
+     __asm__ volatile (
+-        "dli        %[tmp0],    0x01                                    \n\t"
+         MMI_LDC1(%[ftmp0], %[block], 0x00)
+-        "mtc1       %[tmp0],    %[ftmp8]                                \n\t"
+         MMI_LDC1(%[ftmp1], %[block], 0x08)
+-        "dli        %[tmp0],    0x06                                    \n\t"
+         MMI_LDC1(%[ftmp2], %[block], 0x10)
++        MMI_LDC1(%[ftmp3], %[block], 0x18)
++        /* memset(block, 0, 32) */
++        "xor        %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
++        "gssqc1     %[ftmp4],   %[ftmp4],       0x00(%[block])          \n\t"
++        "gssqc1     %[ftmp4],   %[ftmp4],       0x10(%[block])          \n\t"
++        "dli        %[tmp0],    0x01                                    \n\t"
++        "mtc1       %[tmp0],    %[ftmp8]                                \n\t"
++        "dli        %[tmp0],    0x06                                    \n\t"
+         "mtc1       %[tmp0],    %[ftmp9]                                \n\t"
+         "psrah      %[ftmp4],   %[ftmp1],       %[ftmp8]                \n\t"
+-        MMI_LDC1(%[ftmp3], %[block], 0x18)
+         "psrah      %[ftmp5],   %[ftmp3],       %[ftmp8]                \n\t"
+         "psubh      %[ftmp4],   %[ftmp4],       %[ftmp3]                \n\t"
+         "paddh      %[ftmp5],   %[ftmp5],       %[ftmp1]                \n\t"
+@@ -121,15 +123,11 @@ void ff_h264_idct_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "paddh      %[ftmp10],  %[ftmp3],       %[ftmp1]                \n\t"
+         "psubh      %[ftmp1],   %[ftmp1],       %[ftmp3]                \n\t"
+         "paddh      %[ftmp11],  %[ftmp4],       %[ftmp5]                \n\t"
+-        "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
+         "psubh      %[ftmp5],   %[ftmp5],       %[ftmp4]                \n\t"
+-        MMI_SDC1(%[ftmp7], %[block], 0x00)
+-        MMI_SDC1(%[ftmp7], %[block], 0x08)
+-        MMI_SDC1(%[ftmp7], %[block], 0x10)
+-        MMI_SDC1(%[ftmp7], %[block], 0x18)
+         MMI_ULWC1(%[ftmp2], %[dst], 0x00)
+-        "psrah      %[ftmp3],   %[ftmp10],      %[ftmp9]                \n\t"
+         MMI_LWXC1(%[ftmp0], %[dst], %[stride], 0x00)
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
++        "psrah      %[ftmp3],   %[ftmp10],      %[ftmp9]                \n\t"
+         "psrah      %[ftmp4],   %[ftmp11],      %[ftmp9]                \n\t"
+         "punpcklbh  %[ftmp2],   %[ftmp2],       %[ftmp7]                \n\t"
+         "punpcklbh  %[ftmp0],   %[ftmp0],       %[ftmp7]                \n\t"
+@@ -153,11 +151,6 @@ void ff_h264_idct_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         MMI_SWC1(%[ftmp2], %[dst], 0x00)
+         "packushb   %[ftmp0],   %[ftmp0],       %[ftmp7]                \n\t"
+         MMI_SWXC1(%[ftmp0], %[dst], %[stride], 0x00)
+-
+-        /* memset(block, 0, 32) */
+-        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x00(%[block])          \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x10(%[block])          \n\t"
+         : [ftmp0]"=&f"(ftmp[0]),            [ftmp1]"=&f"(ftmp[1]),
+           [ftmp2]"=&f"(ftmp[2]),            [ftmp3]"=&f"(ftmp[3]),
+           [ftmp4]"=&f"(ftmp[4]),            [ftmp5]"=&f"(ftmp[5]),
+@@ -620,17 +613,6 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         MMI_SWC1(%[ftmp6], %[addr0], 0x00)
+         MMI_SWXC1(%[ftmp7], %[addr0], %[stride], 0x00)
+         PTR_ADDIU  "$29,        $29,            0x20                    \n\t"
+-
+-        /* memset(block, 0, 128) */
+-        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x00(%[block])          \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x10(%[block])          \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x20(%[block])          \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x30(%[block])          \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x40(%[block])          \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x50(%[block])          \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x60(%[block])          \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x70(%[block])          \n\t"
+         : [ftmp0]"=&f"(ftmp[0]),            [ftmp1]"=&f"(ftmp[1]),
+           [ftmp2]"=&f"(ftmp[2]),            [ftmp3]"=&f"(ftmp[3]),
+           [ftmp4]"=&f"(ftmp[4]),            [ftmp5]"=&f"(ftmp[5]),
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0002-avutil-mips-Avoid-instruction-exception-caused-by-gs.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0002-avutil-mips-Avoid-instruction-exception-caused-by-gs.patch
@@ -1,0 +1,41 @@
+From 7626f5b394e09d5dc071b119f5a10c82f2180b21 Mon Sep 17 00:00:00 2001
+From: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Date: Wed, 31 Jul 2019 09:30:01 +0800
+Subject: [PATCH 02/26] avutil/mips: Avoid instruction exception caused by
+ gssqc1/gslqc1.
+
+Ensure the address accesed by gssqc1/gslqc1 are 16-byte aligned.
+---
+ libavcodec/mips/simple_idct_mmi.c | 2 +-
+ libavutil/mips/mmiutils.h         | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libavcodec/mips/simple_idct_mmi.c b/libavcodec/mips/simple_idct_mmi.c
+index 7f4bb74fd2..73d797ffbc 100644
+--- a/libavcodec/mips/simple_idct_mmi.c
++++ b/libavcodec/mips/simple_idct_mmi.c
+@@ -39,7 +39,7 @@
+ #define COL_SHIFT 20
+ #define DC_SHIFT 3
+ 
+-DECLARE_ALIGNED(8, const int16_t, W_arr)[46] = {
++DECLARE_ALIGNED(16, const int16_t, W_arr)[46] = {
+     W4,  W2,  W4,  W6,
+     W1,  W3,  W5,  W7,
+     W4,  W6, -W4, -W2,
+diff --git a/libavutil/mips/mmiutils.h b/libavutil/mips/mmiutils.h
+index 05f6b31155..8f692e86c5 100644
+--- a/libavutil/mips/mmiutils.h
++++ b/libavutil/mips/mmiutils.h
+@@ -205,7 +205,7 @@
+  * backup register
+  */
+ #define BACKUP_REG \
+-  double temp_backup_reg[8];                                    \
++  LOCAL_ALIGNED_16(double, temp_backup_reg, [8]);               \
+   if (_MIPS_SIM == _ABI64)                                      \
+     __asm__ volatile (                                          \
+       "gssqc1       $f25,      $f24,       0x00(%[temp])  \n\t" \
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0003-avutil-mips-refine-msa-macros-CLIP_.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0003-avutil-mips-refine-msa-macros-CLIP_.patch
@@ -1,0 +1,1809 @@
+From 4983512a0e18a924426259e83ebe0477b9d0f470 Mon Sep 17 00:00:00 2001
+From: gxw <guxiwei-hf@loongson.cn>
+Date: Wed, 7 Aug 2019 17:52:00 +0800
+Subject: [PATCH 03/26] avutil/mips: refine msa macros CLIP_*.
+
+Changing details as following:
+1. Remove the local variable 'out_m' in 'CLIP_SH' and store the result in
+   source vector.
+2. Refine the implementation of macro 'CLIP_SH_0_255' and 'CLIP_SW_0_255'.
+   Performance of VP8 decoding has speed up about 1.1%(from 7.03x to 7.11x).
+   Performance of H264 decoding has speed up about 0.5%(from 4.35x to 4.37x).
+   Performance of Theora decoding has speed up about 0.7%(from 5.79x to 5.83x).
+3. Remove redundant macro 'CLIP_SH/Wn_0_255_MAX_SATU' and use 'CLIP_SH/Wn_0_255'
+   instead, because there are no difference in the effect of this two macros.
+
+Reviewed-by: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/h264dsp_msa.c       |  39 ++++----
+ libavcodec/mips/h264idct_msa.c      |   7 +-
+ libavcodec/mips/hevc_idct_msa.c     |  21 ++---
+ libavcodec/mips/hevc_lpf_sao_msa.c  | 132 ++++++++++++++--------------
+ libavcodec/mips/hevc_mc_bi_msa.c    |  44 +++++-----
+ libavcodec/mips/hevc_mc_biw_msa.c   |  56 ++++++------
+ libavcodec/mips/hevc_mc_uniw_msa.c  |  40 ++++-----
+ libavcodec/mips/hevcpred_msa.c      |   8 +-
+ libavcodec/mips/idctdsp_msa.c       |   9 +-
+ libavcodec/mips/qpeldsp_msa.c       |   4 +-
+ libavcodec/mips/simple_idct_msa.c   |  98 +++++++++------------
+ libavcodec/mips/vp3dsp_idct_msa.c   |  68 +++-----------
+ libavcodec/mips/vp8_idct_msa.c      |   5 +-
+ libavcodec/mips/vp9_idct_msa.c      |  10 +--
+ libavutil/mips/generic_macros_msa.h | 119 +++++++++++--------------
+ 15 files changed, 280 insertions(+), 380 deletions(-)
+
+diff --git a/libavcodec/mips/h264dsp_msa.c b/libavcodec/mips/h264dsp_msa.c
+index 89fe399469..c580d884f5 100644
+--- a/libavcodec/mips/h264dsp_msa.c
++++ b/libavcodec/mips/h264dsp_msa.c
+@@ -413,8 +413,7 @@ static void avc_biwgt_8x8_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+     tmp7 = __msa_dpadd_s_h(offset, wgt, vec7);
+     SRA_4V(tmp0, tmp1, tmp2, tmp3, denom);
+     SRA_4V(tmp4, tmp5, tmp6, tmp7, denom);
+-    CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+-    CLIP_SH4_0_255(tmp4, tmp5, tmp6, tmp7);
++    CLIP_SH8_0_255(tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7);
+     PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, dst0, dst1);
+     PCKEV_B2_UB(tmp5, tmp4, tmp7, tmp6, dst2, dst3);
+     ST_D8(dst0, dst1, dst2, dst3, 0, 1, 0, 1, 0, 1, 0, 1, dst, stride);
+@@ -475,8 +474,7 @@ static void avc_biwgt_8x16_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+ 
+         SRA_4V(temp0, temp1, temp2, temp3, denom);
+         SRA_4V(temp4, temp5, temp6, temp7, denom);
+-        CLIP_SH4_0_255(temp0, temp1, temp2, temp3);
+-        CLIP_SH4_0_255(temp4, temp5, temp6, temp7);
++        CLIP_SH8_0_255(temp0, temp1, temp2, temp3, temp4, temp5, temp6, temp7);
+         PCKEV_B4_UB(temp1, temp0, temp3, temp2, temp5, temp4, temp7, temp6,
+                     dst0, dst1, dst2, dst3);
+         ST_D8(dst0, dst1, dst2, dst3, 0, 1, 0, 1, 0, 1, 0, 1, dst, stride);
+@@ -531,7 +529,7 @@ static void avc_biwgt_8x16_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+     temp = p1_or_q1_org_in << 1;                              \
+     clip3 = clip3 - temp;                                     \
+     clip3 = __msa_ave_s_h(p2_or_q2_org_in, clip3);            \
+-    clip3 = CLIP_SH(clip3, negate_tc_in, tc_in);              \
++    CLIP_SH(clip3, negate_tc_in, tc_in);                      \
+     p1_or_q1_out = p1_or_q1_org_in + clip3;                   \
+ }
+ 
+@@ -549,7 +547,7 @@ static void avc_biwgt_8x16_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+     delta = q0_sub_p0 + p1_sub_q1;                              \
+     delta >>= 3;                                                \
+                                                                 \
+-    delta = CLIP_SH(delta, negate_threshold_in, threshold_in);  \
++    CLIP_SH(delta, negate_threshold_in, threshold_in);          \
+                                                                 \
+     p0_or_q0_out = p0_or_q0_org_in + delta;                     \
+     q0_or_p0_out = q0_or_p0_org_in - delta;                     \
+@@ -598,7 +596,7 @@ static void avc_biwgt_8x16_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+     delta = q0_sub_p0 + p1_sub_q1;                                       \
+     delta = __msa_srari_h(delta, 3);                                     \
+                                                                          \
+-    delta = CLIP_SH(delta, -tc, tc);                                     \
++    CLIP_SH(delta, -tc, tc);                                             \
+                                                                          \
+     ILVR_B2_SH(zeros, src1, zeros, src2, res0_r, res1_r);                \
+                                                                          \
+@@ -662,7 +660,7 @@ static void avc_biwgt_8x16_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+     q0_sub_p0 <<= 2;                                                       \
+     delta = q0_sub_p0 + p1_sub_q1;                                         \
+     delta = __msa_srari_h(delta, 3);                                       \
+-    delta = CLIP_SH(delta, -tc, tc);                                       \
++    CLIP_SH(delta, -tc, tc);                                               \
+                                                                            \
+     ILVR_B2_SH(zeros, src1, zeros, src2, res0_r, res1_r);                  \
+                                                                            \
+@@ -1741,7 +1739,7 @@ static void avc_h_loop_filter_luma_mbaff_msa(uint8_t *in, int32_t stride,
+     v8i16 tc, tc_orig_r, tc_plus1;
+     v16u8 is_tc_orig1, is_tc_orig2, tc_orig = { 0 };
+     v8i16 p0_ilvr_q0, p0_add_q0, q0_sub_p0, p1_sub_q1;
+-    v8u16 src2_r, src3_r;
++    v8i16 src2_r, src3_r;
+     v8i16 p2_r, p1_r, q2_r, q1_r;
+     v16u8 p2, q2, p0, q0;
+     v4i32 dst0, dst1;
+@@ -1839,8 +1837,8 @@ static void avc_h_loop_filter_luma_mbaff_msa(uint8_t *in, int32_t stride,
+     tc_orig_r = (v8i16) __msa_ilvr_b(zeros, (v16i8) tc_orig);
+     tc = tc_orig_r;
+ 
+-    p2_r = CLIP_SH(p2_r, -tc_orig_r, tc_orig_r);
+-    q2_r = CLIP_SH(q2_r, -tc_orig_r, tc_orig_r);
++    CLIP_SH(p2_r, -tc_orig_r, tc_orig_r);
++    CLIP_SH(q2_r, -tc_orig_r, tc_orig_r);
+ 
+     p2_r += p1_r;
+     q2_r += q1_r;
+@@ -1872,14 +1870,13 @@ static void avc_h_loop_filter_luma_mbaff_msa(uint8_t *in, int32_t stride,
+                                               (v16i8) is_less_than_beta2);
+     tc = (v8i16) __msa_bmnz_v((v16u8) tc, (v16u8) tc_plus1, is_less_than_beta2);
+ 
+-    q0_sub_p0 = CLIP_SH(q0_sub_p0, -tc, tc);
++    CLIP_SH(q0_sub_p0, -tc, tc);
+ 
+-    ILVR_B2_UH(zeros, src2, zeros, src3, src2_r, src3_r);
++    ILVR_B2_SH(zeros, src2, zeros, src3, src2_r, src3_r);
+     src2_r += q0_sub_p0;
+     src3_r -= q0_sub_p0;
+ 
+-    src2_r = (v8u16) CLIP_SH_0_255(src2_r);
+-    src3_r = (v8u16) CLIP_SH_0_255(src3_r);
++    CLIP_SH2_0_255(src2_r, src3_r);
+ 
+     PCKEV_B2_UB(src2_r, src2_r, src3_r, src3_r, p0, q0);
+ 
+@@ -2509,10 +2506,8 @@ void ff_biweight_h264_pixels16_8_msa(uint8_t *dst, uint8_t *src,
+     SRA_4V(tmp4, tmp5, tmp6, tmp7, denom);
+     SRA_4V(tmp8, tmp9, tmp10, tmp11, denom);
+     SRA_4V(tmp12, tmp13, tmp14, tmp15, denom);
+-    CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+-    CLIP_SH4_0_255(tmp4, tmp5, tmp6, tmp7);
+-    CLIP_SH4_0_255(tmp8, tmp9, tmp10, tmp11);
+-    CLIP_SH4_0_255(tmp12, tmp13, tmp14, tmp15);
++    CLIP_SH8_0_255(tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7);
++    CLIP_SH8_0_255(tmp8, tmp9, tmp10, tmp11, tmp12, tmp13, tmp14, tmp15);
+     PCKEV_B4_UB(tmp1, tmp0, tmp3, tmp2, tmp5, tmp4, tmp7, tmp6, dst0, dst1,
+                 dst2, dst3);
+     PCKEV_B4_UB(tmp9, tmp8, tmp11, tmp10, tmp13, tmp12, tmp15, tmp14, dst4,
+@@ -2553,10 +2548,8 @@ void ff_biweight_h264_pixels16_8_msa(uint8_t *dst, uint8_t *src,
+         SRA_4V(tmp4, tmp5, tmp6, tmp7, denom);
+         SRA_4V(tmp8, tmp9, tmp10, tmp11, denom);
+         SRA_4V(tmp12, tmp13, tmp14, tmp15, denom);
+-        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+-        CLIP_SH4_0_255(tmp4, tmp5, tmp6, tmp7);
+-        CLIP_SH4_0_255(tmp8, tmp9, tmp10, tmp11);
+-        CLIP_SH4_0_255(tmp12, tmp13, tmp14, tmp15);
++        CLIP_SH8_0_255(tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7);
++        CLIP_SH8_0_255(tmp8, tmp9, tmp10, tmp11, tmp12, tmp13, tmp14, tmp15);
+         PCKEV_B4_UB(tmp1, tmp0, tmp3, tmp2, tmp5, tmp4, tmp7, tmp6, dst0, dst1,
+                     dst2, dst3);
+         PCKEV_B4_UB(tmp9, tmp8, tmp11, tmp10, tmp13, tmp12, tmp15, tmp14, dst4,
+diff --git a/libavcodec/mips/h264idct_msa.c b/libavcodec/mips/h264idct_msa.c
+index 7851bfdf4b..fbf7795e27 100644
+--- a/libavcodec/mips/h264idct_msa.c
++++ b/libavcodec/mips/h264idct_msa.c
+@@ -233,8 +233,7 @@ static void avc_idct8_addblk_msa(uint8_t *dst, int16_t *src, int32_t dst_stride)
+          res0, res1, res2, res3);
+     ADD4(res4, tmp4, res5, tmp5, res6, tmp6, res7, tmp7,
+          res4, res5, res6, res7);
+-    CLIP_SH4_0_255(res0, res1, res2, res3);
+-    CLIP_SH4_0_255(res4, res5, res6, res7);
++    CLIP_SH8_0_255(res0, res1, res2, res3, res4, res5, res6, res7);
+     PCKEV_B4_SB(res1, res0, res3, res2, res5, res4, res7, res6,
+                 dst0, dst1, dst2, dst3);
+     ST_D8(dst0, dst1, dst2, dst3, 0, 1, 0, 1, 0, 1, 0, 1, dst, dst_stride)
+@@ -263,8 +262,8 @@ static void avc_idct8_dc_addblk_msa(uint8_t *dst, int16_t *src,
+          dst0_r, dst1_r, dst2_r, dst3_r);
+     ADD4(dst4_r, dc, dst5_r, dc, dst6_r, dc, dst7_r, dc,
+          dst4_r, dst5_r, dst6_r, dst7_r);
+-    CLIP_SH4_0_255(dst0_r, dst1_r, dst2_r, dst3_r);
+-    CLIP_SH4_0_255(dst4_r, dst5_r, dst6_r, dst7_r);
++    CLIP_SH8_0_255(dst0_r, dst1_r, dst2_r, dst3_r,
++                   dst4_r, dst5_r, dst6_r, dst7_r);
+     PCKEV_B4_SB(dst1_r, dst0_r, dst3_r, dst2_r, dst5_r, dst4_r, dst7_r, dst6_r,
+                 dst0, dst1, dst2, dst3);
+     ST_D8(dst0, dst1, dst2, dst3, 0, 1, 0, 1, 0, 1, 0, 1, dst, dst_stride)
+diff --git a/libavcodec/mips/hevc_idct_msa.c b/libavcodec/mips/hevc_idct_msa.c
+index b14aec95eb..5ab6acd1df 100644
+--- a/libavcodec/mips/hevc_idct_msa.c
++++ b/libavcodec/mips/hevc_idct_msa.c
+@@ -803,8 +803,9 @@ static void hevc_addblk_16x16_msa(int16_t *coeffs, uint8_t *dst, int32_t stride)
+         LD_SH4((coeffs + 8), 16, in1, in3, in5, in7);
+         coeffs += 64;
+ 
+-        CLIP_SH4_0_255(dst_r0, dst_l0, dst_r1, dst_l1);
+-        CLIP_SH4_0_255(dst_r2, dst_l2, dst_r3, dst_l3);
++        CLIP_SH8_0_255(dst_r0, dst_l0, dst_r1, dst_l1,
++                       dst_r2, dst_l2, dst_r3, dst_l3);
++
+         PCKEV_B4_UB(dst_l0, dst_r0, dst_l1, dst_r1, dst_l2, dst_r2, dst_l3,
+                     dst_r3, dst0, dst1, dst2, dst3);
+         ST_UB4(dst0, dst1, dst2, dst3, dst, stride);
+@@ -825,8 +826,8 @@ static void hevc_addblk_16x16_msa(int16_t *coeffs, uint8_t *dst, int32_t stride)
+     dst_r3 += in6;
+     dst_l3 += in7;
+ 
+-    CLIP_SH4_0_255(dst_r0, dst_l0, dst_r1, dst_l1);
+-    CLIP_SH4_0_255(dst_r2, dst_l2, dst_r3, dst_l3);
++    CLIP_SH8_0_255(dst_r0, dst_l0, dst_r1, dst_l1,
++                   dst_r2, dst_l2, dst_r3, dst_l3);
+     PCKEV_B4_UB(dst_l0, dst_r0, dst_l1, dst_r1, dst_l2, dst_r2, dst_l3,
+                 dst_r3, dst0, dst1, dst2, dst3);
+     ST_UB4(dst0, dst1, dst2, dst3, dst, stride);
+@@ -873,8 +874,8 @@ static void hevc_addblk_32x32_msa(int16_t *coeffs, uint8_t *dst, int32_t stride)
+         LD_SH4((coeffs + 8), 16, in1, in3, in5, in7);
+         coeffs += 64;
+ 
+-        CLIP_SH4_0_255(dst_r0, dst_l0, dst_r1, dst_l1);
+-        CLIP_SH4_0_255(dst_r2, dst_l2, dst_r3, dst_l3);
++        CLIP_SH8_0_255(dst_r0, dst_l0, dst_r1, dst_l1,
++                       dst_r2, dst_l2, dst_r3, dst_l3);
+         PCKEV_B4_UB(dst_l0, dst_r0, dst_l1, dst_r1, dst_l2, dst_r2, dst_l3,
+                     dst_r3, dst0, dst1, dst2, dst3);
+         ST_UB2(dst0, dst1, dst, 16);
+@@ -905,8 +906,8 @@ static void hevc_addblk_32x32_msa(int16_t *coeffs, uint8_t *dst, int32_t stride)
+     LD_SH4(coeffs, 16, in0, in2, in4, in6);
+     LD_SH4((coeffs + 8), 16, in1, in3, in5, in7);
+ 
+-    CLIP_SH4_0_255(dst_r0, dst_l0, dst_r1, dst_l1);
+-    CLIP_SH4_0_255(dst_r2, dst_l2, dst_r3, dst_l3);
++    CLIP_SH8_0_255(dst_r0, dst_l0, dst_r1, dst_l1,
++                   dst_r2, dst_l2, dst_r3, dst_l3);
+     PCKEV_B4_UB(dst_l0, dst_r0, dst_l1, dst_r1, dst_l2, dst_r2, dst_l3,
+                 dst_r3, dst0, dst1, dst2, dst3);
+     ST_UB2(dst0, dst1, dst, 16);
+@@ -928,8 +929,8 @@ static void hevc_addblk_32x32_msa(int16_t *coeffs, uint8_t *dst, int32_t stride)
+     dst_r3 += in6;
+     dst_l3 += in7;
+ 
+-    CLIP_SH4_0_255(dst_r0, dst_l0, dst_r1, dst_l1);
+-    CLIP_SH4_0_255(dst_r2, dst_l2, dst_r3, dst_l3);
++    CLIP_SH8_0_255(dst_r0, dst_l0, dst_r1, dst_l1,
++                   dst_r2, dst_l2, dst_r3, dst_l3);
+     PCKEV_B4_UB(dst_l0, dst_r0, dst_l1, dst_r1, dst_l2, dst_r2, dst_l3,
+                 dst_r3, dst0, dst1, dst2, dst3);
+     ST_UB2(dst0, dst1, dst, 16);
+diff --git a/libavcodec/mips/hevc_lpf_sao_msa.c b/libavcodec/mips/hevc_lpf_sao_msa.c
+index ac21806404..7153fef7b9 100644
+--- a/libavcodec/mips/hevc_lpf_sao_msa.c
++++ b/libavcodec/mips/hevc_lpf_sao_msa.c
+@@ -140,19 +140,19 @@ static void hevc_loopfilter_luma_hor_msa(uint8_t *src, int32_t stride,
+             temp1 = ((p3_src + p2_src) << 1) + p2_src + temp0;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - p2_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst0 = (v16u8) (temp2 + (v8i16) p2_src);
+ 
+             temp1 = temp0 + p2_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 2);
+             temp2 = (v8i16) (temp1 - p1_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst1 = (v16u8) (temp2 + (v8i16) p1_src);
+ 
+             temp1 = (temp0 << 1) + p2_src + q1_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - p0_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst2 = (v16u8) (temp2 + (v8i16) p0_src);
+ 
+             dst0 = __msa_bmz_v(dst0, (v16u8) p2_src, (v16u8) p_is_pcm_vec);
+@@ -165,19 +165,19 @@ static void hevc_loopfilter_luma_hor_msa(uint8_t *src, int32_t stride,
+             temp1 = ((q3_src + q2_src) << 1) + q2_src + temp0;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - q2_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst5 = (v16u8) (temp2 + (v8i16) q2_src);
+ 
+             temp1 = temp0 + q2_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 2);
+             temp2 = (v8i16) (temp1 - q1_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst4 = (v16u8) (temp2 + (v8i16) q1_src);
+ 
+             temp1 = (temp0 << 1) + p1_src + q2_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - q0_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst3 = (v16u8) (temp2 + (v8i16) q0_src);
+ 
+             dst3 = __msa_bmz_v(dst3, (v16u8) q0_src, (v16u8) q_is_pcm_vec);
+@@ -218,15 +218,15 @@ static void hevc_loopfilter_luma_hor_msa(uint8_t *src, int32_t stride,
+             abs_delta0 = __msa_add_a_h(delta0, (v8i16) zero);
+             abs_delta0 = (v8u16) abs_delta0 < temp1;
+ 
+-            delta0 = CLIP_SH(delta0, tc_neg, tc_pos);
++            CLIP_SH(delta0, tc_neg, tc_pos);
+ 
+-            temp0 = (v8u16) (delta0 + p0_src);
+-            temp0 = (v8u16) CLIP_SH_0_255(temp0);
+-            temp0 = (v8u16) __msa_bmz_v((v16u8) temp0, (v16u8) p0_src,
++            temp2 = (v8i16) (delta0 + p0_src);
++            CLIP_SH_0_255(temp2);
++            temp0 = (v8u16) __msa_bmz_v((v16u8) temp2, (v16u8) p0_src,
+                                         (v16u8) p_is_pcm_vec);
+ 
+             temp2 = (v8i16) (q0_src - delta0);
+-            temp2 = CLIP_SH_0_255(temp2);
++            CLIP_SH_0_255(temp2);
+             temp2 = (v8i16) __msa_bmz_v((v16u8) temp2, (v16u8) q0_src,
+                                         (v16u8) q_is_pcm_vec);
+ 
+@@ -252,9 +252,9 @@ static void hevc_loopfilter_luma_hor_msa(uint8_t *src, int32_t stride,
+             delta1 -= (v8i16) p1_src;
+             delta1 += delta0;
+             delta1 >>= 1;
+-            delta1 = CLIP_SH(delta1, tc_neg, tc_pos);
++            CLIP_SH(delta1, tc_neg, tc_pos);
+             delta1 = (v8i16) p1_src + (v8i16) delta1;
+-            delta1 = CLIP_SH_0_255(delta1);
++            CLIP_SH_0_255(delta1);
+             delta1 = (v8i16) __msa_bmnz_v((v16u8) delta1, (v16u8) p1_src,
+                                           (v16u8) p_is_pcm_vec);
+ 
+@@ -262,9 +262,9 @@ static void hevc_loopfilter_luma_hor_msa(uint8_t *src, int32_t stride,
+             delta2 = delta2 - (v8i16) q1_src;
+             delta2 = delta2 - delta0;
+             delta2 = delta2 >> 1;
+-            delta2 = CLIP_SH(delta2, tc_neg, tc_pos);
++            CLIP_SH(delta2, tc_neg, tc_pos);
+             delta2 = (v8i16) q1_src + (v8i16) delta2;
+-            delta2 = CLIP_SH_0_255(delta2);
++            CLIP_SH_0_255(delta2);
+             delta2 = (v8i16) __msa_bmnz_v((v16u8) delta2, (v16u8) q1_src,
+                                           (v16u8) q_is_pcm_vec);
+ 
+@@ -298,19 +298,19 @@ static void hevc_loopfilter_luma_hor_msa(uint8_t *src, int32_t stride,
+             temp1 = ((p3_src + p2_src) << 1) + p2_src + temp0;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - p2_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst0 = (v16u8) (temp2 + (v8i16) p2_src);
+ 
+             temp1 = temp0 + p2_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 2);
+             temp2 = (v8i16) (temp1 - p1_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst1 = (v16u8) (temp2 + (v8i16) p1_src);
+ 
+             temp1 = (temp0 << 1) + p2_src + q1_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - p0_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst2 = (v16u8) (temp2 + (v8i16) p0_src);
+ 
+             dst0 = __msa_bmz_v(dst0, (v16u8) p2_src, (v16u8) p_is_pcm_vec);
+@@ -323,19 +323,19 @@ static void hevc_loopfilter_luma_hor_msa(uint8_t *src, int32_t stride,
+             temp1 = ((q3_src + q2_src) << 1) + q2_src + temp0;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - q2_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst5 = (v16u8) (temp2 + (v8i16) q2_src);
+ 
+             temp1 = temp0 + q2_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 2);
+             temp2 = (v8i16) (temp1 - q1_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst4 = (v16u8) (temp2 + (v8i16) q1_src);
+ 
+             temp1 = (temp0 << 1) + p1_src + q2_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - q0_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst3 = (v16u8) (temp2 + (v8i16) q0_src);
+ 
+             dst3 = __msa_bmz_v(dst3, (v16u8) q0_src, (v16u8) q_is_pcm_vec);
+@@ -362,15 +362,15 @@ static void hevc_loopfilter_luma_hor_msa(uint8_t *src, int32_t stride,
+             abs_delta0 = __msa_add_a_h(delta0, (v8i16) zero);
+             abs_delta0 = (v8u16) abs_delta0 < temp1;
+ 
+-            delta0 = CLIP_SH(delta0, tc_neg, tc_pos);
++            CLIP_SH(delta0, tc_neg, tc_pos);
+ 
+-            temp0 = (v8u16) (delta0 + p0_src);
+-            temp0 = (v8u16) CLIP_SH_0_255(temp0);
+-            temp0 = (v8u16) __msa_bmz_v((v16u8) temp0, (v16u8) p0_src,
++            temp2 = (v8i16) (delta0 + p0_src);
++            CLIP_SH_0_255(temp2);
++            temp0 = (v8u16) __msa_bmz_v((v16u8) temp2, (v16u8) p0_src,
+                                         (v16u8) p_is_pcm_vec);
+ 
+             temp2 = (v8i16) (q0_src - delta0);
+-            temp2 = CLIP_SH_0_255(temp2);
++            CLIP_SH_0_255(temp2);
+             temp2 = (v8i16) __msa_bmz_v((v16u8) temp2, (v16u8) q0_src,
+                                         (v16u8) q_is_pcm_vec);
+ 
+@@ -394,9 +394,9 @@ static void hevc_loopfilter_luma_hor_msa(uint8_t *src, int32_t stride,
+             delta1 -= (v8i16) p1_src;
+             delta1 += delta0;
+             delta1 >>= 1;
+-            delta1 = CLIP_SH(delta1, tc_neg, tc_pos);
++            CLIP_SH(delta1, tc_neg, tc_pos);
+             delta1 = (v8i16) p1_src + (v8i16) delta1;
+-            delta1 = CLIP_SH_0_255(delta1);
++            CLIP_SH_0_255(delta1);
+             delta1 = (v8i16) __msa_bmnz_v((v16u8) delta1, (v16u8) p1_src,
+                                           (v16u8) p_is_pcm_vec);
+ 
+@@ -404,9 +404,9 @@ static void hevc_loopfilter_luma_hor_msa(uint8_t *src, int32_t stride,
+             delta2 = delta2 - (v8i16) q1_src;
+             delta2 = delta2 - delta0;
+             delta2 = delta2 >> 1;
+-            delta2 = CLIP_SH(delta2, tc_neg, tc_pos);
++            CLIP_SH(delta2, tc_neg, tc_pos);
+             delta2 = (v8i16) q1_src + (v8i16) delta2;
+-            delta2 = CLIP_SH_0_255(delta2);
++            CLIP_SH_0_255(delta2);
+             delta2 = (v8i16) __msa_bmnz_v((v16u8) delta2, (v16u8) q1_src,
+                                           (v16u8) q_is_pcm_vec);
+ 
+@@ -561,19 +561,19 @@ static void hevc_loopfilter_luma_ver_msa(uint8_t *src, int32_t stride,
+             temp1 = ((p3_src + p2_src) << 1) + p2_src + temp0;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - p2_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst0 = (v16u8) (temp2 + (v8i16) p2_src);
+ 
+             temp1 = temp0 + p2_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 2);
+             temp2 = (v8i16) (temp1 - p1_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst1 = (v16u8) (temp2 + (v8i16) p1_src);
+ 
+             temp1 = (temp0 << 1) + p2_src + q1_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - p0_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst2 = (v16u8) (temp2 + (v8i16) p0_src);
+ 
+             dst0 = __msa_bmz_v(dst0, (v16u8) p2_src, (v16u8) p_is_pcm_vec);
+@@ -585,19 +585,19 @@ static void hevc_loopfilter_luma_ver_msa(uint8_t *src, int32_t stride,
+             temp1 = ((q3_src + q2_src) << 1) + q2_src + temp0;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - q2_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst5 = (v16u8) (temp2 + (v8i16) q2_src);
+ 
+             temp1 = temp0 + q2_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 2);
+             temp2 = (v8i16) (temp1 - q1_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst4 = (v16u8) (temp2 + (v8i16) q1_src);
+ 
+             temp1 = (temp0 << 1) + p1_src + q2_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - q0_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst3 = (v16u8) (temp2 + (v8i16) q0_src);
+ 
+             dst3 = __msa_bmz_v(dst3, (v16u8) q0_src, (v16u8) q_is_pcm_vec);
+@@ -620,14 +620,14 @@ static void hevc_loopfilter_luma_ver_msa(uint8_t *src, int32_t stride,
+             abs_delta0 = __msa_add_a_h(delta0, (v8i16) zero);
+             abs_delta0 = (v8u16) abs_delta0 < temp1;
+ 
+-            delta0 = CLIP_SH(delta0, tc_neg, tc_pos);
+-            temp0 = (v8u16) (delta0 + p0_src);
+-            temp0 = (v8u16) CLIP_SH_0_255(temp0);
+-            temp0 = (v8u16) __msa_bmz_v((v16u8) temp0, (v16u8) p0_src,
++            CLIP_SH(delta0, tc_neg, tc_pos);
++            temp2 = (v8i16) (delta0 + p0_src);
++            CLIP_SH_0_255(temp2);
++            temp0 = (v8u16) __msa_bmz_v((v16u8) temp2, (v16u8) p0_src,
+                                         (v16u8) p_is_pcm_vec);
+ 
+             temp2 = (v8i16) (q0_src - delta0);
+-            temp2 = CLIP_SH_0_255(temp2);
++            CLIP_SH_0_255(temp2);
+             temp2 = (v8i16) __msa_bmz_v((v16u8) temp2, (v16u8) q0_src,
+                                         (v16u8) q_is_pcm_vec);
+ 
+@@ -649,9 +649,9 @@ static void hevc_loopfilter_luma_ver_msa(uint8_t *src, int32_t stride,
+             delta1 -= (v8i16) p1_src;
+             delta1 += delta0;
+             delta1 >>= 1;
+-            delta1 = CLIP_SH(delta1, tc_neg, tc_pos);
++            CLIP_SH(delta1, tc_neg, tc_pos);
+             delta1 = (v8i16) p1_src + (v8i16) delta1;
+-            delta1 = CLIP_SH_0_255(delta1);
++            CLIP_SH_0_255(delta1);
+             delta1 = (v8i16) __msa_bmnz_v((v16u8) delta1, (v16u8) p1_src,
+                                           (v16u8) p_is_pcm_vec);
+ 
+@@ -659,9 +659,9 @@ static void hevc_loopfilter_luma_ver_msa(uint8_t *src, int32_t stride,
+             delta2 = delta2 - (v8i16) q1_src;
+             delta2 = delta2 - delta0;
+             delta2 = delta2 >> 1;
+-            delta2 = CLIP_SH(delta2, tc_neg, tc_pos);
++            CLIP_SH(delta2, tc_neg, tc_pos);
+             delta2 = (v8i16) q1_src + (v8i16) delta2;
+-            delta2 = CLIP_SH_0_255(delta2);
++            CLIP_SH_0_255(delta2);
+             delta2 = (v8i16) __msa_bmnz_v((v16u8) delta2, (v16u8) q1_src,
+                                           (v16u8) q_is_pcm_vec);
+ 
+@@ -726,19 +726,19 @@ static void hevc_loopfilter_luma_ver_msa(uint8_t *src, int32_t stride,
+             temp1 = ((p3_src + p2_src) << 1) + p2_src + temp0;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - p2_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst0 = (v16u8) (temp2 + (v8i16) p2_src);
+ 
+             temp1 = temp0 + p2_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 2);
+             temp2 = (v8i16) (temp1 - p1_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst1 = (v16u8) (temp2 + (v8i16) p1_src);
+ 
+             temp1 = (temp0 << 1) + p2_src + q1_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - p0_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst2 = (v16u8) (temp2 + (v8i16) p0_src);
+ 
+             dst0 = __msa_bmz_v(dst0, (v16u8) p2_src, (v16u8) p_is_pcm_vec);
+@@ -750,19 +750,19 @@ static void hevc_loopfilter_luma_ver_msa(uint8_t *src, int32_t stride,
+             temp1 = ((q3_src + q2_src) << 1) + q2_src + temp0;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - q2_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst5 = (v16u8) (temp2 + (v8i16) q2_src);
+ 
+             temp1 = temp0 + q2_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 2);
+             temp2 = (v8i16) (temp1 - q1_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst4 = (v16u8) (temp2 + (v8i16) q1_src);
+ 
+             temp1 = (temp0 << 1) + p1_src + q2_src;
+             temp1 = (v8u16) __msa_srari_h((v8i16) temp1, 3);
+             temp2 = (v8i16) (temp1 - q0_src);
+-            temp2 = CLIP_SH(temp2, tc_neg, tc_pos);
++            CLIP_SH(temp2, tc_neg, tc_pos);
+             dst3 = (v16u8) (temp2 + (v8i16) q0_src);
+ 
+             dst3 = __msa_bmz_v(dst3, (v16u8) q0_src, (v16u8) q_is_pcm_vec);
+@@ -785,15 +785,15 @@ static void hevc_loopfilter_luma_ver_msa(uint8_t *src, int32_t stride,
+             abs_delta0 = __msa_add_a_h(delta0, (v8i16) zero);
+             abs_delta0 = (v8u16) abs_delta0 < temp1;
+ 
+-            delta0 = CLIP_SH(delta0, tc_neg, tc_pos);
++            CLIP_SH(delta0, tc_neg, tc_pos);
+ 
+-            temp0 = (v8u16) (delta0 + p0_src);
+-            temp0 = (v8u16) CLIP_SH_0_255(temp0);
+-            temp0 = (v8u16) __msa_bmz_v((v16u8) temp0, (v16u8) p0_src,
++            temp2 = (v8i16) (delta0 + p0_src);
++            CLIP_SH_0_255(temp2);
++            temp0 = (v8u16) __msa_bmz_v((v16u8) temp2, (v16u8) p0_src,
+                                         (v16u8) p_is_pcm_vec);
+ 
+             temp2 = (v8i16) (q0_src - delta0);
+-            temp2 = CLIP_SH_0_255(temp2);
++            CLIP_SH_0_255(temp2);
+             temp2 = (v8i16) __msa_bmz_v((v16u8) temp2, (v16u8) q0_src,
+                                         (v16u8) q_is_pcm_vec);
+ 
+@@ -815,9 +815,9 @@ static void hevc_loopfilter_luma_ver_msa(uint8_t *src, int32_t stride,
+             delta1 -= (v8i16) p1_src;
+             delta1 += delta0;
+             delta1 >>= 1;
+-            delta1 = CLIP_SH(delta1, tc_neg, tc_pos);
++            CLIP_SH(delta1, tc_neg, tc_pos);
+             delta1 = (v8i16) p1_src + (v8i16) delta1;
+-            delta1 = CLIP_SH_0_255(delta1);
++            CLIP_SH_0_255(delta1);
+             delta1 = (v8i16) __msa_bmnz_v((v16u8) delta1, (v16u8) p1_src,
+                                           (v16u8) p_is_pcm_vec);
+ 
+@@ -825,9 +825,9 @@ static void hevc_loopfilter_luma_ver_msa(uint8_t *src, int32_t stride,
+             delta2 = delta2 - (v8i16) q1_src;
+             delta2 = delta2 - delta0;
+             delta2 = delta2 >> 1;
+-            delta2 = CLIP_SH(delta2, tc_neg, tc_pos);
++            CLIP_SH(delta2, tc_neg, tc_pos);
+             delta2 = (v8i16) q1_src + (v8i16) delta2;
+-            delta2 = CLIP_SH_0_255(delta2);
++            CLIP_SH_0_255(delta2);
+             delta2 = (v8i16) __msa_bmnz_v((v16u8) delta2, (v16u8) q1_src,
+                                           (v16u8) q_is_pcm_vec);
+             delta1 = (v8i16) __msa_bmz_v((v16u8) delta1, (v16u8) p1_src,
+@@ -955,15 +955,15 @@ static void hevc_loopfilter_chroma_hor_msa(uint8_t *src, int32_t stride,
+         temp0 <<= 2;
+         temp0 += temp1;
+         delta = __msa_srari_h((v8i16) temp0, 3);
+-        delta = CLIP_SH(delta, tc_neg, tc_pos);
++        CLIP_SH(delta, tc_neg, tc_pos);
+ 
+         temp0 = (v8i16) ((v8i16) p0 + delta);
+-        temp0 = CLIP_SH_0_255(temp0);
++        CLIP_SH_0_255(temp0);
+         temp0 = (v8i16) __msa_bmz_v((v16u8) temp0, (v16u8) p0,
+                                     (v16u8) p_is_pcm_vec);
+ 
+         temp1 = (v8i16) ((v8i16) q0 - delta);
+-        temp1 = CLIP_SH_0_255(temp1);
++        CLIP_SH_0_255(temp1);
+         temp1 = (v8i16) __msa_bmz_v((v16u8) temp1, (v16u8) q0,
+                                     (v16u8) q_is_pcm_vec);
+ 
+@@ -1014,15 +1014,15 @@ static void hevc_loopfilter_chroma_ver_msa(uint8_t *src, int32_t stride,
+         temp0 <<= 2;
+         temp0 += temp1;
+         delta = __msa_srari_h((v8i16) temp0, 3);
+-        delta = CLIP_SH(delta, tc_neg, tc_pos);
++        CLIP_SH(delta, tc_neg, tc_pos);
+ 
+         temp0 = (v8i16) ((v8i16) p0 + delta);
+-        temp0 = CLIP_SH_0_255(temp0);
++        CLIP_SH_0_255(temp0);
+         temp0 = (v8i16) __msa_bmz_v((v16u8) temp0, (v16u8) p0,
+                                     (v16u8) p_is_pcm_vec);
+ 
+         temp1 = (v8i16) ((v8i16) q0 - delta);
+-        temp1 = CLIP_SH_0_255(temp1);
++        CLIP_SH_0_255(temp1);
+         temp1 = (v8i16) __msa_bmz_v((v16u8) temp1, (v16u8) q0,
+                                     (v16u8) q_is_pcm_vec);
+ 
+diff --git a/libavcodec/mips/hevc_mc_bi_msa.c b/libavcodec/mips/hevc_mc_bi_msa.c
+index 34613c84b8..c6c8d2705d 100644
+--- a/libavcodec/mips/hevc_mc_bi_msa.c
++++ b/libavcodec/mips/hevc_mc_bi_msa.c
+@@ -48,7 +48,7 @@ static const uint8_t ff_hevc_mask_arr[16 * 2] __attribute__((aligned(0x40))) = {
+ {                                                                  \
+     ADDS_SH2_SH(vec0, in0, vec1, in1, out0, out1);                 \
+     SRARI_H2_SH(out0, out1, rnd_val);                              \
+-    CLIP_SH2_0_255_MAX_SATU(out0, out1);                           \
++    CLIP_SH2_0_255(out0, out1);                                    \
+ }
+ 
+ #define HEVC_BI_RND_CLIP4_MAX_SATU(in0, in1, in2, in3, vec0, vec1, vec2,    \
+@@ -83,7 +83,7 @@ static void hevc_bi_copy_4w_msa(uint8_t *src0_ptr,
+         dst0 <<= 6;
+         dst0 += in0;
+         dst0 = __msa_srari_h(dst0, 7);
+-        dst0 = CLIP_SH_0_255_MAX_SATU(dst0);
++        CLIP_SH_0_255(dst0);
+ 
+         dst0 = (v8i16) __msa_pckev_b((v16i8) dst0, (v16i8) dst0);
+         ST_W2(dst0, 0, 1, dst, dst_stride);
+@@ -739,7 +739,7 @@ static void hevc_hz_bi_8t_12w_msa(uint8_t *src0_ptr,
+         HEVC_BI_RND_CLIP2(in0, in1, dst0, dst1, 7, dst0, dst1);
+         dst2 = __msa_adds_s_h(in2, dst2);
+         dst2 = __msa_srari_h(dst2, 7);
+-        dst2 = CLIP_SH_0_255(dst2);
++        CLIP_SH_0_255(dst2);
+         PCKEV_B2_SH(dst1, dst0, dst2, dst2, dst0, dst1);
+ 
+         tmp2 = __msa_copy_s_d((v2i64) dst0, 0);
+@@ -888,7 +888,7 @@ static void hevc_hz_bi_8t_24w_msa(uint8_t *src0_ptr,
+         HEVC_BI_RND_CLIP2(in0, in1, dst0, dst1, 7, dst0, dst1);
+         dst2 = __msa_adds_s_h(dst2, in2);
+         dst2 = __msa_srari_h(dst2, 7);
+-        dst2 = CLIP_SH_0_255(dst2);
++        CLIP_SH_0_255(dst2);
+ 
+         PCKEV_B2_SB(dst1, dst0, dst2, dst2, tmp0, tmp1);
+         dst_val0 = __msa_copy_u_d((v2i64) tmp1, 0);
+@@ -1726,7 +1726,7 @@ static void hevc_hv_bi_8t_4w_msa(uint8_t *src0_ptr,
+         ADDS_SH2_SH(out0, in0, out1, in1, out0, out1);
+         ADDS_SH2_SH(out0, const_vec, out1, const_vec, out0, out1);
+         SRARI_H2_SH(out0, out1, 7);
+-        CLIP_SH2_0_255_MAX_SATU(out0, out1);
++        CLIP_SH2_0_255(out0, out1);
+         out = (v16u8) __msa_pckev_b((v16i8) out1, (v16i8) out0);
+         ST_W4(out, 0, 1, 2, 3, dst, dst_stride);
+         dst += (4 * dst_stride);
+@@ -1854,7 +1854,7 @@ static void hevc_hv_bi_8t_8multx1mult_msa(uint8_t *src0_ptr,
+             tmp = __msa_pckev_h((v8i16) dst0_l, (v8i16) dst0_r);
+             ADDS_SH2_SH(tmp, in0, tmp, const_vec, tmp, tmp);
+             tmp = __msa_srari_h(tmp, 7);
+-            tmp = CLIP_SH_0_255_MAX_SATU(tmp);
++            CLIP_SH_0_255(tmp);
+             out = (v16u8) __msa_pckev_b((v16i8) tmp, (v16i8) tmp);
+             ST_D1(out, 0, dst_tmp);
+             dst_tmp += dst_stride;
+@@ -2000,7 +2000,7 @@ static void hevc_hv_bi_8t_12w_msa(uint8_t *src0_ptr,
+         tmp = __msa_pckev_h((v8i16) dst0_l, (v8i16) dst0_r);
+         ADDS_SH2_SH(tmp, in0, tmp, const_vec, tmp, tmp);
+         tmp = __msa_srari_h(tmp, 7);
+-        tmp = CLIP_SH_0_255_MAX_SATU(tmp);
++        CLIP_SH_0_255(tmp);
+         out = (v16u8) __msa_pckev_b((v16i8) tmp, (v16i8) tmp);
+         ST_D1(out, 0, dst_tmp);
+         dst_tmp += dst_stride;
+@@ -2088,7 +2088,7 @@ static void hevc_hv_bi_8t_12w_msa(uint8_t *src0_ptr,
+         ADDS_SH2_SH(out0, in0, out1, in1, out0, out1);
+         ADDS_SH2_SH(out0, const_vec, out1, const_vec, out0, out1);
+         SRARI_H2_SH(out0, out1, 7);
+-        CLIP_SH2_0_255_MAX_SATU(out0, out1);
++        CLIP_SH2_0_255(out0, out1);
+         out = (v16u8) __msa_pckev_b((v16i8) out1, (v16i8) out0);
+         ST_W4(out, 0, 1, 2, 3, dst, dst_stride);
+         dst += (4 * dst_stride);
+@@ -2215,7 +2215,7 @@ static void hevc_hz_bi_4t_4x2_msa(uint8_t *src0_ptr,
+ 
+     tmp0 = __msa_adds_s_h(tmp0, in0);
+     tmp0 = __msa_srari_h(tmp0, 7);
+-    tmp0 = CLIP_SH_0_255(tmp0);
++    CLIP_SH_0_255(tmp0);
+     dst0 = __msa_pckev_b((v16i8) tmp0, (v16i8) tmp0);
+ 
+     ST_W2(dst0, 0, 1, dst, dst_stride);
+@@ -2943,7 +2943,7 @@ static void hevc_vt_bi_4t_4x2_msa(uint8_t *src0_ptr,
+     DPADD_SB2_SH(src2110, src4332, filt0, filt1, dst10, dst10);
+     dst10 = __msa_adds_s_h(dst10, in0);
+     dst10 = __msa_srari_h(dst10, 7);
+-    dst10 = CLIP_SH_0_255(dst10);
++    CLIP_SH_0_255(dst10);
+ 
+     dst10 = (v8i16) __msa_pckev_b((v16i8) dst10, (v16i8) dst10);
+     ST_W2(dst10, 0, 1, dst, dst_stride);
+@@ -3843,7 +3843,7 @@ static void hevc_hv_bi_4t_4x2_msa(uint8_t *src0_ptr,
+     tmp = __msa_pckev_h((v8i16) dst1, (v8i16) dst0);
+     tmp = __msa_adds_s_h(tmp, in0);
+     tmp = __msa_srari_h(tmp, 7);
+-    tmp = CLIP_SH_0_255_MAX_SATU(tmp);
++    CLIP_SH_0_255(tmp);
+     out = (v16u8) __msa_pckev_b((v16i8) tmp, (v16i8) tmp);
+     ST_W2(out, 0, 1, dst, dst_stride);
+ }
+@@ -3919,7 +3919,7 @@ static void hevc_hv_bi_4t_4x4_msa(uint8_t *src0_ptr,
+     PCKEV_H2_SH(dst1, dst0, dst3, dst2, tmp0, tmp1);
+     ADDS_SH2_SH(tmp0, in0, tmp1, in1, tmp0, tmp1);
+     SRARI_H2_SH(tmp0, tmp1, 7);
+-    CLIP_SH2_0_255_MAX_SATU(tmp0, tmp1);
++    CLIP_SH2_0_255(tmp0, tmp1);
+     out = (v16u8) __msa_pckev_b((v16i8) tmp1, (v16i8) tmp0);
+     ST_W4(out, 0, 1, 2, 3, dst, dst_stride);
+ }
+@@ -4032,7 +4032,7 @@ static void hevc_hv_bi_4t_4multx8mult_msa(uint8_t *src0_ptr,
+         ADDS_SH4_SH(in0, tmp0, in1, tmp1, in2, tmp2, in3, tmp3, tmp0, tmp1,
+                     tmp2, tmp3);
+         SRARI_H4_SH(tmp0, tmp1, tmp2, tmp3, 7);
+-        CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+         PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+         ST_W8(out0, out1, 0, 1, 2, 3, 0, 1, 2, 3, dst, dst_stride);
+         dst += (8 * dst_stride);
+@@ -4200,7 +4200,7 @@ static void hevc_hv_bi_4t_6w_msa(uint8_t *src0_ptr,
+     ADDS_SH4_SH(in0, tmp0, in1, tmp1, in2, tmp2, in3, tmp3, tmp0, tmp1, tmp2,
+                 tmp3);
+     SRARI_H4_SH(tmp0, tmp1, tmp2, tmp3, 7);
+-    CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++    CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+     PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+     ST_W8(out0, out1, 0, 1, 2, 3, 0, 1, 2, 3, dst, dst_stride);
+ 
+@@ -4212,7 +4212,7 @@ static void hevc_hv_bi_4t_6w_msa(uint8_t *src0_ptr,
+     ADDS_SH2_SH(in4, const_vec, in5, const_vec, in4, in5);
+     ADDS_SH2_SH(in4, tmp4, in5, tmp5, tmp4, tmp5);
+     SRARI_H2_SH(tmp4, tmp5, 7);
+-    CLIP_SH2_0_255_MAX_SATU(tmp4, tmp5);
++    CLIP_SH2_0_255(tmp4, tmp5);
+     out2 = (v16u8) __msa_pckev_b((v16i8) tmp5, (v16i8) tmp4);
+     ST_H8(out2, 0, 1, 2, 3, 4, 5, 6, 7, dst + 4, dst_stride);
+ }
+@@ -4286,7 +4286,7 @@ static void hevc_hv_bi_4t_8x2_msa(uint8_t *src0_ptr,
+     PCKEV_H2_SH(dst0_l, dst0_r, dst1_l, dst1_r, tmp0, tmp1);
+     ADDS_SH2_SH(in0, tmp0, in1, tmp1, tmp0, tmp1);
+     SRARI_H2_SH(tmp0, tmp1, 7);
+-    CLIP_SH2_0_255_MAX_SATU(tmp0, tmp1);
++    CLIP_SH2_0_255(tmp0, tmp1);
+     out = (v16u8) __msa_pckev_b((v16i8) tmp1, (v16i8) tmp0);
+     ST_D2(out, 0, 1, dst, dst_stride);
+ }
+@@ -4380,7 +4380,7 @@ static void hevc_hv_bi_4t_8multx4_msa(uint8_t *src0_ptr,
+         ADDS_SH4_SH(in0, tmp0, in1, tmp1, in2, tmp2, in3, tmp3,
+                     tmp0, tmp1, tmp2, tmp3);
+         SRARI_H4_SH(tmp0, tmp1, tmp2, tmp3, 7);
+-        CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+         PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+         ST_D4(out0, out1, 0, 1, 0, 1, dst, dst_stride);
+         dst += 8;
+@@ -4495,8 +4495,8 @@ static void hevc_hv_bi_4t_8x6_msa(uint8_t *src0_ptr,
+     ADDS_SH2_SH(in4, tmp4, in5, tmp5, tmp4, tmp5);
+     SRARI_H4_SH(tmp0, tmp1, tmp2, tmp3, 7);
+     SRARI_H2_SH(tmp4, tmp5, 7);
+-    CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
+-    CLIP_SH2_0_255_MAX_SATU(tmp4, tmp5);
++    CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
++    CLIP_SH2_0_255(tmp4, tmp5);
+     PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+     out2 = (v16u8) __msa_pckev_b((v16i8) tmp5, (v16i8) tmp4);
+     ST_D4(out0, out1, 0, 1, 0, 1, dst, dst_stride);
+@@ -4610,7 +4610,7 @@ static void hevc_hv_bi_4t_8multx4mult_msa(uint8_t *src0_ptr,
+             ADDS_SH4_SH(in0, tmp0, in1, tmp1, in2, tmp2, in3, tmp3,
+                         tmp0, tmp1, tmp2, tmp3);
+             SRARI_H4_SH(tmp0, tmp1, tmp2, tmp3, 7);
+-            CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++            CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+             PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+             ST_D4(out0, out1, 0, 1, 0, 1, dst_tmp, dst_stride);
+             dst_tmp += (4 * dst_stride);
+@@ -4760,7 +4760,7 @@ static void hevc_hv_bi_4t_12w_msa(uint8_t *src0_ptr,
+         ADDS_SH4_SH(in0, tmp0, in1, tmp1, in2, tmp2, in3, tmp3,
+                     tmp0, tmp1, tmp2, tmp3);
+         SRARI_H4_SH(tmp0, tmp1, tmp2, tmp3, 7);
+-        CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+         PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+         ST_D4(out0, out1, 0, 1, 0, 1, dst_tmp, dst_stride);
+         dst_tmp += (4 * dst_stride);
+@@ -4846,7 +4846,7 @@ static void hevc_hv_bi_4t_12w_msa(uint8_t *src0_ptr,
+         ADDS_SH4_SH(in0, tmp0, in1, tmp1, in2, tmp2, in3, tmp3,
+                     tmp0, tmp1, tmp2, tmp3);
+         SRARI_H4_SH(tmp0, tmp1, tmp2, tmp3, 7);
+-        CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+         PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+         ST_W8(out0, out1, 0, 1, 2, 3, 0, 1, 2, 3, dst, dst_stride);
+         dst += (8 * dst_stride);
+diff --git a/libavcodec/mips/hevc_mc_biw_msa.c b/libavcodec/mips/hevc_mc_biw_msa.c
+index 68f122ea48..f775ea8592 100644
+--- a/libavcodec/mips/hevc_mc_biw_msa.c
++++ b/libavcodec/mips/hevc_mc_biw_msa.c
+@@ -66,7 +66,7 @@ static const uint8_t ff_hevc_mask_arr[16 * 2] __attribute__((aligned(0x40))) = {
+     out1_l = __msa_dpadd_s_w(offset, (v8i16) out1_l, (v8i16) wgt);   \
+     SRAR_W4_SW(out0_r, out1_r, out0_l, out1_l, rnd);                 \
+     PCKEV_H2_SH(out0_l, out0_r, out1_l, out1_r, out0, out1);         \
+-    CLIP_SH2_0_255_MAX_SATU(out0, out1);                             \
++    CLIP_SH2_0_255(out0, out1);                                      \
+ }
+ 
+ #define HEVC_BIW_RND_CLIP4_MAX_SATU(in0, in1, in2, in3, vec0, vec1, vec2,  \
+@@ -124,7 +124,7 @@ static void hevc_biwgt_copy_4w_msa(uint8_t *src0_ptr,
+         dst0_l = __msa_dpadd_s_w(offset_vec, (v8i16) dst0_l, weight_vec);
+         SRAR_W2_SW(dst0_r, dst0_l, rnd_vec);
+         dst0 = (v8i16) __msa_pckev_h((v8i16) dst0_l, (v8i16) dst0_r);
+-        dst0 = CLIP_SH_0_255_MAX_SATU(dst0);
++        CLIP_SH_0_255(dst0);
+         out0 = (v16u8) __msa_pckev_b((v16i8) dst0, (v16i8) dst0);
+         ST_W2(out0, 0, 1, dst, dst_stride);
+     } else if (4 == height) {
+@@ -1069,8 +1069,8 @@ static void hevc_hz_biwgt_8t_24w_msa(uint8_t *src0_ptr,
+         dst2_l = __msa_dpadd_s_w(offset_vec, (v8i16) dst2_l,
+                                  (v8i16) weight_vec);
+         SRAR_W2_SW(dst2_r, dst2_l, rnd_vec);
+-        dst2_r = (v4i32) __msa_pckev_h((v8i16) dst2_l, (v8i16) dst2_r);
+-        out2 = CLIP_SH_0_255(dst2_r);
++        out2 = __msa_pckev_h((v8i16) dst2_l, (v8i16) dst2_r);
++        CLIP_SH_0_255(out2);
+ 
+         LD_SB2(src0_ptr, 16, src0, src1);
+         src0_ptr += src_stride;
+@@ -1100,8 +1100,8 @@ static void hevc_hz_biwgt_8t_24w_msa(uint8_t *src0_ptr,
+     dst2_r = __msa_dpadd_s_w(offset_vec, (v8i16) dst2_r, (v8i16) weight_vec);
+     dst2_l = __msa_dpadd_s_w(offset_vec, (v8i16) dst2_l, (v8i16) weight_vec);
+     SRAR_W2_SW(dst2_r, dst2_l, rnd_vec);
+-    dst2_r = (v4i32) __msa_pckev_h((v8i16) dst2_l, (v8i16) dst2_r);
+-    out2 = CLIP_SH_0_255(dst2_r);
++    out2 = __msa_pckev_h((v8i16) dst2_l, (v8i16) dst2_r);
++    CLIP_SH_0_255(out2);
+     PCKEV_B2_SH(out1, out0, out2, out2, out0, out2);
+     dst_val0 = __msa_copy_u_d((v2i64) out2, 0);
+     ST_SH(out0, dst);
+@@ -1674,8 +1674,8 @@ static void hevc_vt_biwgt_8t_12w_msa(uint8_t *src0_ptr,
+         dst2_l = __msa_dpadd_s_w(offset_vec, (v8i16) dst2_l,
+                                  (v8i16) weight_vec);
+         SRAR_W2_SW(dst2_r, dst2_l, rnd_vec);
+-        dst2_r = (v4i32) __msa_pckev_h((v8i16) dst2_l, (v8i16) dst2_r);
+-        out2 = CLIP_SH_0_255(dst2_r);
++        out2 = __msa_pckev_h((v8i16) dst2_l, (v8i16) dst2_r);
++        CLIP_SH_0_255(out2);
+         PCKEV_B2_SH(out1, out0, out2, out2, out0, out2);
+         ST_D2(out0, 0, 1, dst, dst_stride);
+         ST_W2(out2, 0, 1, dst + 8, dst_stride);
+@@ -2048,7 +2048,7 @@ static void hevc_hv_biwgt_8t_4w_msa(uint8_t *src0_ptr,
+         dst2 = __msa_dpadd_s_w(offset_vec, tmp2, weight_vec);
+         dst3 = __msa_dpadd_s_w(offset_vec, tmp3, weight_vec);
+         SRAR_W4_SW(dst0, dst1, dst2, dst3, rnd_vec);
+-        CLIP_SW4_0_255_MAX_SATU(dst0, dst1, dst2, dst3);
++        CLIP_SW4_0_255(dst0, dst1, dst2, dst3);
+         PCKEV_H2_SH(dst1, dst0, dst3, dst2, tmp0, tmp1);
+         out = (v16u8) __msa_pckev_b((v16i8) tmp1, (v16i8) tmp0);
+         ST_W4(out, 0, 1, 2, 3, dst, dst_stride);
+@@ -2226,7 +2226,7 @@ static void hevc_hv_biwgt_8t_8multx2mult_msa(uint8_t *src0_ptr,
+             dst1_r = __msa_dpadd_s_w(offset_vec, tmp2, weight_vec);
+             dst1_l = __msa_dpadd_s_w(offset_vec, tmp3, weight_vec);
+             SRAR_W4_SW(dst0_l, dst0_r, dst1_l, dst1_r, rnd_vec);
+-            CLIP_SW4_0_255_MAX_SATU(dst0_l, dst0_r, dst1_l, dst1_r);
++            CLIP_SW4_0_255(dst0_l, dst0_r, dst1_l, dst1_r);
+             PCKEV_H2_SH(dst0_l, dst0_r, dst1_l, dst1_r, tmp0, tmp1);
+             out = (v16u8) __msa_pckev_b((v16i8) tmp1, (v16i8) tmp0);
+             ST_D2(out, 0, 1, dst_tmp, dst_stride);
+@@ -2412,7 +2412,7 @@ static void hevc_hv_biwgt_8t_12w_msa(uint8_t *src0_ptr,
+         dst2 = __msa_dpadd_s_w(offset_vec, tmp2, weight_vec);
+         dst3 = __msa_dpadd_s_w(offset_vec, tmp3, weight_vec);
+         SRAR_W4_SW(dst1, dst0, dst3, dst2, rnd_vec);
+-        CLIP_SW4_0_255_MAX_SATU(dst1, dst0, dst3, dst2);
++        CLIP_SW4_0_255(dst1, dst0, dst3, dst2);
+         PCKEV_H2_SH(dst1, dst0, dst3, dst2, tmp0, tmp1);
+         out = (v16u8) __msa_pckev_b((v16i8) tmp1, (v16i8) tmp0);
+         ST_D2(out, 0, 1, dst_tmp, dst_stride);
+@@ -2503,7 +2503,7 @@ static void hevc_hv_biwgt_8t_12w_msa(uint8_t *src0_ptr,
+         dst2 = __msa_dpadd_s_w(offset_vec, tmp2, weight_vec);
+         dst3 = __msa_dpadd_s_w(offset_vec, tmp3, weight_vec);
+         SRAR_W4_SW(dst0, dst1, dst2, dst3, rnd_vec);
+-        CLIP_SW4_0_255_MAX_SATU(dst0, dst1, dst2, dst3);
++        CLIP_SW4_0_255(dst0, dst1, dst2, dst3);
+         PCKEV_H2_SH(dst1, dst0, dst3, dst2, tmp0, tmp1);
+         out = (v16u8) __msa_pckev_b((v16i8) tmp1, (v16i8) tmp0);
+         ST_W4(out, 0, 1, 2, 3, dst, dst_stride);
+@@ -2683,8 +2683,8 @@ static void hevc_hz_biwgt_4t_4x2_msa(uint8_t *src0_ptr,
+     dst0_r = __msa_dpadd_s_w(offset_vec, (v8i16) dst0_r, (v8i16) weight_vec);
+     dst0_l = __msa_dpadd_s_w(offset_vec, (v8i16) dst0_l, (v8i16) weight_vec);
+     SRAR_W2_SW(dst0_r, dst0_l, rnd_vec);
+-    dst0_r = (v4i32) __msa_pckev_h((v8i16) dst0_l, (v8i16) dst0_r);
+-    out0 = CLIP_SH_0_255(dst0_r);
++    out0 = __msa_pckev_h((v8i16) dst0_l, (v8i16) dst0_r);
++    CLIP_SH_0_255(out0);
+     out0 = (v8i16) __msa_pckev_b((v16i8) out0, (v16i8) out0);
+     ST_W2(out0, 0, 1, dst, dst_stride);
+ }
+@@ -3554,8 +3554,8 @@ static void hevc_vt_biwgt_4t_4x2_msa(uint8_t *src0_ptr,
+     dst10_r = __msa_dpadd_s_w(offset_vec, (v8i16) dst10_r, (v8i16) weight_vec);
+     dst10_l = __msa_dpadd_s_w(offset_vec, (v8i16) dst10_l, (v8i16) weight_vec);
+     SRAR_W2_SW(dst10_r, dst10_l, rnd_vec);
+-    dst10_r = (v4i32) __msa_pckev_h((v8i16) dst10_l, (v8i16) dst10_r);
+-    out = CLIP_SH_0_255(dst10_r);
++    out = __msa_pckev_h((v8i16) dst10_l, (v8i16) dst10_r);
++    CLIP_SH_0_255(out);
+     out = (v8i16) __msa_pckev_b((v16i8) out, (v16i8) out);
+     ST_W2(out, 0, 1, dst, dst_stride);
+ }
+@@ -4575,7 +4575,7 @@ static void hevc_hv_biwgt_4t_4x2_msa(uint8_t *src0_ptr,
+     dst1 = __msa_dpadd_s_w(offset_vec, tmp1, weight_vec);
+     SRAR_W2_SW(dst0, dst1, rnd_vec);
+     tmp = __msa_pckev_h((v8i16) dst1, (v8i16) dst0);
+-    tmp = CLIP_SH_0_255_MAX_SATU(tmp);
++    CLIP_SH_0_255(tmp);
+     out = (v16u8) __msa_pckev_b((v16i8) tmp, (v16i8) tmp);
+     ST_W2(out, 0, 1, dst, dst_stride);
+ }
+@@ -4672,7 +4672,7 @@ static void hevc_hv_biwgt_4t_4x4_msa(uint8_t *src0_ptr,
+     dst3 = __msa_dpadd_s_w(offset_vec, tmp3, weight_vec);
+     SRAR_W4_SW(dst0, dst1, dst2, dst3, rnd_vec);
+     PCKEV_H2_SH(dst1, dst0, dst3, dst2, tmp0, tmp1);
+-    CLIP_SH2_0_255_MAX_SATU(tmp0, tmp1);
++    CLIP_SH2_0_255(tmp0, tmp1);
+     out = (v16u8) __msa_pckev_b((v16i8) tmp1, (v16i8) tmp0);
+     ST_W4(out, 0, 1, 2, 3, dst, dst_stride);
+ }
+@@ -4810,7 +4810,7 @@ static void hevc_hv_biwgt_4t_4multx8mult_msa(uint8_t *src0_ptr,
+         SRAR_W4_SW(dst4, dst5, dst6, dst7, rnd_vec);
+         PCKEV_H4_SH(dst1, dst0, dst3, dst2, dst5, dst4, dst7, dst6, tmp0, tmp1,
+                     tmp2, tmp3);
+-        CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+         PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+         ST_W8(out0, out1, 0, 1, 2, 3, 0, 1, 2, 3, dst, dst_stride);
+         dst += (8 * dst_stride);
+@@ -5008,7 +5008,7 @@ static void hevc_hv_biwgt_4t_6w_msa(uint8_t *src0_ptr,
+     SRAR_W4_SW(dst4, dst5, dst6, dst7, rnd_vec);
+     PCKEV_H4_SH(dst1, dst0, dst3, dst2, dst5, dst4, dst7, dst6, tmp0, tmp1,
+                 tmp2, tmp3);
+-    CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++    CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+     PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+     ST_W8(out0, out1, 0, 1, 2, 3, 0, 1, 2, 3, dst, dst_stride);
+ 
+@@ -5030,7 +5030,7 @@ static void hevc_hv_biwgt_4t_6w_msa(uint8_t *src0_ptr,
+     SRAR_W4_SW(dst0, dst1, dst2, dst3, rnd_vec);
+     PCKEV_H2_SH(dst1, dst0, dst3, dst2, tmp4, tmp5);
+ 
+-    CLIP_SH2_0_255_MAX_SATU(tmp4, tmp5);
++    CLIP_SH2_0_255(tmp4, tmp5);
+     out2 = (v16u8) __msa_pckev_b((v16i8) tmp5, (v16i8) tmp4);
+     ST_H8(out2, 0, 1, 2, 3, 4, 5, 6, 7, dst + 4, dst_stride);
+ }
+@@ -5126,7 +5126,7 @@ static void hevc_hv_biwgt_4t_8x2_msa(uint8_t *src0_ptr,
+     dst1_l = __msa_dpadd_s_w(offset_vec, tmp3, weight_vec);
+     SRAR_W4_SW(dst0_r, dst0_l, dst1_r, dst1_l, rnd_vec);
+     PCKEV_H2_SH(dst0_l, dst0_r, dst1_l, dst1_r, tmp0, tmp1);
+-    CLIP_SH2_0_255_MAX_SATU(tmp0, tmp1);
++    CLIP_SH2_0_255(tmp0, tmp1);
+     out = (v16u8) __msa_pckev_b((v16i8) tmp1, (v16i8) tmp0);
+     ST_D2(out, 0, 1, dst, dst_stride);
+ }
+@@ -5248,7 +5248,7 @@ static void hevc_hv_biwgt_4t_8multx4_msa(uint8_t *src0_ptr,
+         SRAR_W4_SW(dst4, dst5, dst6, dst7, rnd_vec);
+         PCKEV_H4_SH(dst1, dst0, dst3, dst2, dst5, dst4, dst7, dst6,
+                     tmp0, tmp1, tmp2, tmp3);
+-        CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+         PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+         ST_D4(out0, out1, 0, 1, 0, 1, dst, dst_stride);
+         dst += 8;
+@@ -5387,7 +5387,7 @@ static void hevc_hv_biwgt_4t_8x6_msa(uint8_t *src0_ptr,
+     SRAR_W4_SW(dst4, dst5, dst6, dst7, rnd_vec);
+     PCKEV_H4_SH(dst1, dst0, dst3, dst2, dst5, dst4, dst7, dst6,
+                 tmp0, tmp1, tmp2, tmp3);
+-    CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++    CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+     PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+ 
+     PCKEV_H2_SW(dst4_l, dst4_r, dst5_l, dst5_r, dst0, dst1);
+@@ -5399,7 +5399,7 @@ static void hevc_hv_biwgt_4t_8x6_msa(uint8_t *src0_ptr,
+     dst3 = __msa_dpadd_s_w(offset_vec, tmp3, weight_vec);
+     SRAR_W4_SW(dst0, dst1, dst2, dst3, rnd_vec);
+     PCKEV_H2_SH(dst1, dst0, dst3, dst2, tmp4, tmp5);
+-    CLIP_SH2_0_255_MAX_SATU(tmp4, tmp5);
++    CLIP_SH2_0_255(tmp4, tmp5);
+     out2 = (v16u8) __msa_pckev_b((v16i8) tmp5, (v16i8) tmp4);
+     ST_D4(out0, out1, 0, 1, 0, 1, dst, dst_stride);
+     ST_D2(out2, 0, 1, dst + 4 * dst_stride, dst_stride);
+@@ -5537,7 +5537,7 @@ static void hevc_hv_biwgt_4t_8multx4mult_msa(uint8_t *src0_ptr,
+             SRAR_W4_SW(dst4, dst5, dst6, dst7, rnd_vec);
+             PCKEV_H4_SH(dst1, dst0, dst3, dst2, dst5, dst4, dst7, dst6,
+                         tmp0, tmp1, tmp2, tmp3);
+-            CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++            CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+             PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+             ST_D4(out0, out1, 0, 1, 0, 1, dst_tmp, dst_stride);
+             dst_tmp += (4 * dst_stride);
+@@ -5724,7 +5724,7 @@ static void hevc_hv_biwgt_4t_12w_msa(uint8_t *src0_ptr,
+         SRAR_W4_SW(dst4, dst5, dst6, dst7, rnd_vec);
+         PCKEV_H4_SH(dst1, dst0, dst3, dst2, dst5, dst4, dst7, dst6,
+                     tmp0, tmp1, tmp2, tmp3);
+-        CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+         PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+         ST_D4(out0, out1, 0, 1, 0, 1, dst_tmp, dst_stride);
+         dst_tmp += (4 * dst_stride);
+@@ -5820,7 +5820,7 @@ static void hevc_hv_biwgt_4t_12w_msa(uint8_t *src0_ptr,
+         SRAR_W4_SW(dst4, dst5, dst6, dst7, rnd_vec);
+         PCKEV_H4_SH(dst1, dst0, dst3, dst2, dst5, dst4, dst7, dst6,
+                     tmp0, tmp1, tmp2, tmp3);
+-        CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+         PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+         ST_W8(out0, out1, 0, 1, 2, 3, 0, 1, 2, 3, dst, dst_stride);
+         dst += (8 * dst_stride);
+diff --git a/libavcodec/mips/hevc_mc_uniw_msa.c b/libavcodec/mips/hevc_mc_uniw_msa.c
+index cad1240b40..1a8c251534 100644
+--- a/libavcodec/mips/hevc_mc_uniw_msa.c
++++ b/libavcodec/mips/hevc_mc_uniw_msa.c
+@@ -41,7 +41,7 @@ static const uint8_t ff_hevc_mask_arr[16 * 2] __attribute__((aligned(0x40))) = {
+     SRAR_W4_SW(in0_r_m, in1_r_m, in0_l_m, in1_l_m, rnd_w);                    \
+     PCKEV_H2_SH(in0_l_m, in0_r_m, in1_l_m, in1_r_m, out0_h, out1_h);          \
+     ADDS_SH2_SH(out0_h, offset_h, out1_h, offset_h, out0_h, out1_h);          \
+-    CLIP_SH2_0_255_MAX_SATU(out0_h, out1_h);                                  \
++    CLIP_SH2_0_255(out0_h, out1_h);                                           \
+ }
+ 
+ #define HEVC_UNIW_RND_CLIP4_MAX_SATU_H(in0_h, in1_h, in2_h, in3_h, wgt_w,  \
+@@ -88,7 +88,7 @@ static void hevc_uniwgt_copy_4w_msa(uint8_t *src,
+         SRAR_W2_SW(dst0_r, dst0_l, rnd_vec);
+         dst0 = __msa_pckev_h((v8i16) dst0_l, (v8i16) dst0_r);
+         dst0 += offset_vec;
+-        dst0 = CLIP_SH_0_255_MAX_SATU(dst0);
++        CLIP_SH_0_255(dst0);
+         out0 = (v16u8) __msa_pckev_b((v16i8) dst0, (v16i8) dst0);
+         ST_W2(out0, 0, 1, dst, dst_stride);
+     } else if (4 == height) {
+@@ -1863,7 +1863,7 @@ static void hevc_hv_uniwgt_8t_4w_msa(uint8_t *src,
+         SRAR_W4_SW(dst0_r, dst1_r, dst2_r, dst3_r, rnd_vec);
+         ADD2(dst0_r, offset_vec, dst1_r, offset_vec, dst0_r, dst1_r);
+         ADD2(dst2_r, offset_vec, dst3_r, offset_vec, dst2_r, dst3_r);
+-        CLIP_SW4_0_255_MAX_SATU(dst0_r, dst1_r, dst2_r, dst3_r);
++        CLIP_SW4_0_255(dst0_r, dst1_r, dst2_r, dst3_r);
+         PCKEV_H2_SW(dst1_r, dst0_r, dst3_r, dst2_r, dst0_r, dst1_r);
+         out = (v16u8) __msa_pckev_b((v16i8) dst1_r, (v16i8) dst0_r);
+         ST_W4(out, 0, 1, 2, 3, dst, dst_stride);
+@@ -2014,7 +2014,7 @@ static void hevc_hv_uniwgt_8t_8multx2mult_msa(uint8_t *src,
+             SRAR_W4_SW(dst0_r, dst1_r, dst0_l, dst1_l, rnd_vec);
+             ADD2(dst0_r, offset_vec, dst0_l, offset_vec, dst0_r, dst0_l);
+             ADD2(dst1_r, offset_vec, dst1_l, offset_vec, dst1_r, dst1_l);
+-            CLIP_SW4_0_255_MAX_SATU(dst0_r, dst1_r, dst0_l, dst1_l);
++            CLIP_SW4_0_255(dst0_r, dst1_r, dst0_l, dst1_l);
+ 
+             PCKEV_H2_SW(dst0_l, dst0_r, dst1_l, dst1_r, dst0_r, dst1_r);
+             dst0_r = (v4i32) __msa_pckev_b((v16i8) dst1_r, (v16i8) dst0_r);
+@@ -2165,7 +2165,7 @@ static void hevc_hv_uniwgt_8t_12w_msa(uint8_t *src,
+         MUL2(dst0_r, weight_vec, dst0_l, weight_vec, dst0_r, dst0_l);
+         SRAR_W2_SW(dst0_r, dst0_l, rnd_vec);
+         ADD2(dst0_r, offset_vec, dst0_l, offset_vec, dst0_r, dst0_l);
+-        CLIP_SW2_0_255_MAX_SATU(dst0_r, dst0_l);
++        CLIP_SW2_0_255(dst0_r, dst0_l);
+         dst0_r = (v4i32) __msa_pckev_h((v8i16) dst0_l, (v8i16) dst0_r);
+         out = (v16u8) __msa_pckev_b((v16i8) dst0_r, (v16i8) dst0_r);
+         ST_D1(out, 0, dst_tmp);
+@@ -2246,7 +2246,7 @@ static void hevc_hv_uniwgt_8t_12w_msa(uint8_t *src,
+         SRAR_W4_SW(dst0_r, dst1_r, dst2_r, dst3_r, rnd_vec);
+         ADD2(dst0_r, offset_vec, dst1_r, offset_vec, dst0_r, dst1_r);
+         ADD2(dst2_r, offset_vec, dst3_r, offset_vec, dst2_r, dst3_r);
+-        CLIP_SW4_0_255_MAX_SATU(dst0_r, dst1_r, dst2_r, dst3_r);
++        CLIP_SW4_0_255(dst0_r, dst1_r, dst2_r, dst3_r);
+         PCKEV_H2_SW(dst1_r, dst0_r, dst3_r, dst2_r, dst0_r, dst1_r);
+         out = (v16u8) __msa_pckev_b((v16i8) dst1_r, (v16i8) dst0_r);
+         ST_W4(out, 0, 1, 2, 3, dst, dst_stride);
+@@ -2394,7 +2394,7 @@ static void hevc_hz_uniwgt_4t_4x2_msa(uint8_t *src,
+     SRAR_W2_SW(dst0_r, dst0_l, rnd_vec);
+     dst0 = __msa_pckev_h((v8i16) dst0_l, (v8i16) dst0_r);
+     dst0 = __msa_adds_s_h(dst0, offset_vec);
+-    dst0 = CLIP_SH_0_255_MAX_SATU(dst0);
++    CLIP_SH_0_255(dst0);
+     out = (v16u8) __msa_pckev_b((v16i8) dst0, (v16i8) dst0);
+     ST_W2(out, 0, 1, dst, dst_stride);
+     dst += (4 * dst_stride);
+@@ -3295,7 +3295,7 @@ static void hevc_vt_uniwgt_4t_4x2_msa(uint8_t *src,
+     SRAR_W2_SW(dst0_r, dst0_l, rnd_vec);
+     dst0 = __msa_pckev_h((v8i16) dst0_l, (v8i16) dst0_r);
+     dst0 = __msa_adds_s_h(dst0, offset_vec);
+-    dst0 = CLIP_SH_0_255_MAX_SATU(dst0);
++    CLIP_SH_0_255(dst0);
+     out = (v16u8) __msa_pckev_b((v16i8) dst0, (v16i8) dst0);
+     ST_W2(out, 0, 1, dst, dst_stride);
+ }
+@@ -4247,7 +4247,7 @@ static void hevc_hv_uniwgt_4t_4x2_msa(uint8_t *src,
+     SRAR_W2_SW(dst0, dst1, rnd_vec);
+     tmp = __msa_pckev_h((v8i16) dst1, (v8i16) dst0);
+     tmp += offset_vec;
+-    tmp = CLIP_SH_0_255_MAX_SATU(tmp);
++    CLIP_SH_0_255(tmp);
+     out = (v16u8) __msa_pckev_b((v16i8) tmp, (v16i8) tmp);
+     ST_W2(out, 0, 1, dst, dst_stride);
+ }
+@@ -4316,7 +4316,7 @@ static void hevc_hv_uniwgt_4t_4x4_msa(uint8_t *src,
+     SRAR_W4_SW(dst0, dst1, dst2, dst3, rnd_vec);
+     PCKEV_H2_SH(dst1, dst0, dst3, dst2, tmp0, tmp1);
+     ADD2(tmp0, offset_vec, tmp1, offset_vec, tmp0, tmp1);
+-    CLIP_SH2_0_255_MAX_SATU(tmp0, tmp1);
++    CLIP_SH2_0_255(tmp0, tmp1);
+     out = (v16u8) __msa_pckev_b((v16i8) tmp1, (v16i8) tmp0);
+     ST_W4(out, 0, 1, 2, 3, dst, dst_stride);
+ }
+@@ -4417,7 +4417,7 @@ static void hevc_hv_uniwgt_4t_4multx8mult_msa(uint8_t *src,
+                     tmp2, tmp3);
+         ADD2(tmp0, offset_vec, tmp1, offset_vec, tmp0, tmp1);
+         ADD2(tmp2, offset_vec, tmp3, offset_vec, tmp2, tmp3);
+-        CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+         PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+         ST_W8(out0, out1, 0, 1, 2, 3, 0, 1, 2, 3, dst, dst_stride);
+         dst += (8 * dst_stride);
+@@ -4574,8 +4574,8 @@ static void hevc_hv_uniwgt_4t_6w_msa(uint8_t *src,
+     ADD2(tmp0, offset_vec, tmp1, offset_vec, tmp0, tmp1);
+     ADD2(tmp2, offset_vec, tmp3, offset_vec, tmp2, tmp3);
+     ADD2(tmp4, offset_vec, tmp5, offset_vec, tmp4, tmp5);
+-    CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
+-    CLIP_SH2_0_255_MAX_SATU(tmp4, tmp5);
++    CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
++    CLIP_SH2_0_255(tmp4, tmp5);
+     PCKEV_B3_UB(tmp1, tmp0, tmp3, tmp2, tmp5, tmp4, out0, out1, out2);
+     ST_W8(out0, out1, 0, 1, 2, 3, 0, 1, 2, 3, dst, dst_stride);
+     ST_H8(out2, 0, 1, 2, 3, 4, 5, 6, 7, dst + 4, dst_stride);
+@@ -4652,7 +4652,7 @@ static void hevc_hv_uniwgt_4t_8x2_msa(uint8_t *src,
+     SRAR_W4_SW(dst0_r, dst0_l, dst1_r, dst1_l, rnd_vec);
+     PCKEV_H2_SH(dst0_l, dst0_r, dst1_l, dst1_r, tmp0, tmp1);
+     ADD2(tmp0, offset_vec, tmp1, offset_vec, tmp0, tmp1);
+-    CLIP_SH2_0_255_MAX_SATU(tmp0, tmp1);
++    CLIP_SH2_0_255(tmp0, tmp1);
+     out = (v16u8) __msa_pckev_b((v16i8) tmp1, (v16i8) tmp0);
+     ST_D2(out, 0, 1, dst, dst_stride);
+ }
+@@ -4745,7 +4745,7 @@ static void hevc_hv_uniwgt_4t_8multx4_msa(uint8_t *src,
+                     dst3_r, tmp0, tmp1, tmp2, tmp3);
+         ADD2(tmp0, offset_vec, tmp1, offset_vec, tmp0, tmp1);
+         ADD2(tmp2, offset_vec, tmp3, offset_vec, tmp2, tmp3);
+-        CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+         PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+         ST_D4(out0, out1, 0, 1, 0, 1, dst, dst_stride);
+         dst += 8;
+@@ -4861,8 +4861,8 @@ static void hevc_hv_uniwgt_4t_8x6_msa(uint8_t *src,
+     ADD2(tmp0, offset_vec, tmp1, offset_vec, tmp0, tmp1);
+     ADD2(tmp2, offset_vec, tmp3, offset_vec, tmp2, tmp3);
+     ADD2(tmp4, offset_vec, tmp5, offset_vec, tmp4, tmp5);
+-    CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
+-    CLIP_SH2_0_255_MAX_SATU(tmp4, tmp5);
++    CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
++    CLIP_SH2_0_255(tmp4, tmp5);
+     PCKEV_B3_UB(tmp1, tmp0, tmp3, tmp2, tmp5, tmp4, out0, out1, out2);
+     ST_D4(out0, out1, 0, 1, 0, 1, dst, dst_stride);
+     ST_D2(out2, 0, 1, dst + 4 * dst_stride, dst_stride);
+@@ -4973,7 +4973,7 @@ static void hevc_hv_uniwgt_4t_8multx4mult_msa(uint8_t *src,
+                         dst3_r, tmp0, tmp1, tmp2, tmp3);
+             ADD2(tmp0, offset_vec, tmp1, offset_vec, tmp0, tmp1);
+             ADD2(tmp2, offset_vec, tmp3, offset_vec, tmp2, tmp3);
+-            CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++            CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+             PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+             ST_D4(out0, out1, 0, 1, 0, 1, dst_tmp, dst_stride);
+             dst_tmp += (4 * dst_stride);
+@@ -5120,7 +5120,7 @@ static void hevc_hv_uniwgt_4t_12w_msa(uint8_t *src,
+                     dst3_r, tmp0, tmp1, tmp2, tmp3);
+         ADD2(tmp0, offset_vec, tmp1, offset_vec, tmp0, tmp1);
+         ADD2(tmp2, offset_vec, tmp3, offset_vec, tmp2, tmp3);
+-        CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+         PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+         ST_D4(out0, out1, 0, 1, 0, 1, dst_tmp, dst_stride);
+         dst_tmp += (4 * dst_stride);
+@@ -5187,7 +5187,7 @@ static void hevc_hv_uniwgt_4t_12w_msa(uint8_t *src,
+                     tmp2, tmp3);
+         ADD2(tmp0, offset_vec, tmp1, offset_vec, tmp0, tmp1);
+         ADD2(tmp2, offset_vec, tmp3, offset_vec, tmp2, tmp3);
+-        CLIP_SH4_0_255_MAX_SATU(tmp0, tmp1, tmp2, tmp3);
++        CLIP_SH4_0_255(tmp0, tmp1, tmp2, tmp3);
+         PCKEV_B2_UB(tmp1, tmp0, tmp3, tmp2, out0, out1);
+         ST_W8(out0, out1, 0, 1, 2, 3, 0, 1, 2, 3, dst, dst_stride);
+         dst += (8 * dst_stride);
+diff --git a/libavcodec/mips/hevcpred_msa.c b/libavcodec/mips/hevcpred_msa.c
+index b8df089e0c..930a89cb48 100644
+--- a/libavcodec/mips/hevcpred_msa.c
++++ b/libavcodec/mips/hevcpred_msa.c
+@@ -83,7 +83,7 @@ static void hevc_intra_pred_vert_4x4_msa(const uint8_t *src_top,
+         vec2 -= vec0;
+         vec2 >>= 1;
+         vec2 += vec1;
+-        vec2 = CLIP_SH_0_255(vec2);
++        CLIP_SH_0_255(vec2);
+ 
+         for (col = 0; col < 4; col++) {
+             dst[stride * col] = (uint8_t) vec2[col];
+@@ -122,7 +122,7 @@ static void hevc_intra_pred_vert_8x8_msa(const uint8_t *src_top,
+         vec2 -= vec0;
+         vec2 >>= 1;
+         vec2 += vec1;
+-        vec2 = CLIP_SH_0_255(vec2);
++        CLIP_SH_0_255(vec2);
+ 
+         val0 = vec2[0];
+         val1 = vec2[1];
+@@ -214,7 +214,7 @@ static void hevc_intra_pred_horiz_4x4_msa(const uint8_t *src_top,
+         src0_r -= src_top_val;
+         src0_r >>= 1;
+         src0_r += src_left_val;
+-        src0_r = CLIP_SH_0_255(src0_r);
++        CLIP_SH_0_255(src0_r);
+         src0 = __msa_pckev_b((v16i8) src0_r, (v16i8) src0_r);
+         val0 = __msa_copy_s_w((v4i32) src0, 0);
+         SW(val0, dst);
+@@ -254,7 +254,7 @@ static void hevc_intra_pred_horiz_8x8_msa(const uint8_t *src_top,
+         src0_r -= src_top_val;
+         src0_r >>= 1;
+         src0_r += src_left_val;
+-        src0_r = CLIP_SH_0_255(src0_r);
++        CLIP_SH_0_255(src0_r);
+         src0 = __msa_pckev_b((v16i8) src0_r, (v16i8) src0_r);
+         val0 = __msa_copy_s_d((v2i64) src0, 0);
+         SD(val0, dst);
+diff --git a/libavcodec/mips/idctdsp_msa.c b/libavcodec/mips/idctdsp_msa.c
+index b29e420556..b6b98dc7fc 100644
+--- a/libavcodec/mips/idctdsp_msa.c
++++ b/libavcodec/mips/idctdsp_msa.c
+@@ -28,8 +28,7 @@ static void put_pixels_clamped_msa(const int16_t *block, uint8_t *pixels,
+     v8i16 in0, in1, in2, in3, in4, in5, in6, in7;
+ 
+     LD_SH8(block, 8, in0, in1, in2, in3, in4, in5, in6, in7);
+-    CLIP_SH4_0_255(in0, in1, in2, in3);
+-    CLIP_SH4_0_255(in4, in5, in6, in7);
++    CLIP_SH8_0_255(in0, in1, in2, in3, in4, in5, in6, in7);
+     PCKEV_B4_SH(in0, in0, in1, in1, in2, in2, in3, in3, in0, in1, in2, in3);
+     PCKEV_B4_SH(in4, in4, in5, in5, in6, in6, in7, in7, in4, in5, in6, in7);
+ 
+@@ -63,8 +62,7 @@ static void put_signed_pixels_clamped_msa(const int16_t *block, uint8_t *pixels,
+     in6 += 128;
+     in7 += 128;
+ 
+-    CLIP_SH4_0_255(in0, in1, in2, in3);
+-    CLIP_SH4_0_255(in4, in5, in6, in7);
++    CLIP_SH8_0_255(in0, in1, in2, in3, in4, in5, in6, in7);
+     PCKEV_B4_SH(in0, in0, in1, in1, in2, in2, in3, in3, in0, in1, in2, in3);
+     PCKEV_B4_SH(in4, in4, in5, in5, in6, in6, in7, in7, in4, in5, in6, in7);
+ 
+@@ -109,8 +107,7 @@ static void add_pixels_clamped_msa(const int16_t *block, uint8_t *pixels,
+     in6 += (v8i16) pix6;
+     in7 += (v8i16) pix7;
+ 
+-    CLIP_SH4_0_255(in0, in1, in2, in3);
+-    CLIP_SH4_0_255(in4, in5, in6, in7);
++    CLIP_SH8_0_255(in0, in1, in2, in3, in4, in5, in6, in7);
+     PCKEV_B4_SH(in0, in0, in1, in1, in2, in2, in3, in3, in0, in1, in2, in3);
+     PCKEV_B4_SH(in4, in4, in5, in5, in6, in6, in7, in7, in4, in5, in6, in7);
+ 
+diff --git a/libavcodec/mips/qpeldsp_msa.c b/libavcodec/mips/qpeldsp_msa.c
+index fba42b3003..b6ffc279ee 100644
+--- a/libavcodec/mips/qpeldsp_msa.c
++++ b/libavcodec/mips/qpeldsp_msa.c
+@@ -96,7 +96,7 @@
+     DPADD_UB2_UH(sum2_r, sum1_r, coef2, coef1, sum0_r, sum3_r);         \
+     res0_r = (v8i16) (sum0_r - sum3_r);                                 \
+     res0_r = __msa_srari_h(res0_r, 5);                                  \
+-    res0_r = CLIP_SH_0_255(res0_r);                                     \
++    CLIP_SH_0_255(res0_r);                                              \
+     out = (v16u8) __msa_pckev_b((v16i8) res0_r, (v16i8) res0_r);        \
+                                                                         \
+     out;                                                                \
+@@ -118,7 +118,7 @@
+     res0_r = (v8i16) (sum0_r - sum3_r);                                   \
+     res0_r += 15;                                                         \
+     res0_r >>= 5;                                                         \
+-    res0_r = CLIP_SH_0_255(res0_r);                                       \
++    CLIP_SH_0_255(res0_r);                                                \
+     out = (v16u8) __msa_pckev_b((v16i8) res0_r, (v16i8) res0_r);          \
+                                                                           \
+     out;                                                                  \
+diff --git a/libavcodec/mips/simple_idct_msa.c b/libavcodec/mips/simple_idct_msa.c
+index 8a7235927e..4bd3dd8a25 100644
+--- a/libavcodec/mips/simple_idct_msa.c
++++ b/libavcodec/mips/simple_idct_msa.c
+@@ -336,35 +336,26 @@ static void simple_idct_put_msa(uint8_t *dst, int32_t dst_stride,
+     SRA_4V(temp2_r, temp2_l, temp3_r, temp3_l, 20);
+     SRA_4V(a3_r, a3_l, a2_r, a2_l, 20);
+     SRA_4V(a1_r, a1_l, a0_r, a0_l, 20);
+-    PCKEV_H4_SW(temp0_l, temp0_r, temp1_l, temp1_r, temp2_l, temp2_r,
+-                temp3_l, temp3_r, temp0_r, temp1_r, temp2_r, temp3_r);
+-    PCKEV_H4_SW(a0_l, a0_r, a1_l, a1_r, a2_l, a2_r, a3_l, a3_r,
+-                a0_r, a1_r, a2_r, a3_r);
+-    temp0_r = (v4i32) CLIP_SH_0_255(temp0_r);
+-    temp1_r = (v4i32) CLIP_SH_0_255(temp1_r);
+-    temp2_r = (v4i32) CLIP_SH_0_255(temp2_r);
+-    temp3_r = (v4i32) CLIP_SH_0_255(temp3_r);
+-    PCKEV_B4_SW(temp0_r, temp0_r, temp1_r, temp1_r,
+-                temp2_r, temp2_r, temp3_r, temp3_r,
+-                temp0_r, temp1_r, temp2_r, temp3_r);
+-    tmp0 = __msa_copy_u_d((v2i64) temp0_r, 1);
+-    tmp1 = __msa_copy_u_d((v2i64) temp1_r, 1);
+-    tmp2 = __msa_copy_u_d((v2i64) temp2_r, 1);
+-    tmp3 = __msa_copy_u_d((v2i64) temp3_r, 1);
+-    SD4(tmp0, tmp1, tmp2, tmp3, dst, dst_stride);
+-    dst += 4 * dst_stride;
+-    a0_r = (v4i32) CLIP_SH_0_255(a0_r);
+-    a1_r = (v4i32) CLIP_SH_0_255(a1_r);
+-    a2_r = (v4i32) CLIP_SH_0_255(a2_r);
+-    a3_r = (v4i32) CLIP_SH_0_255(a3_r);
+-    PCKEV_B4_SW(a0_r, a0_r, a1_r, a1_r,
+-                a2_r, a2_r, a3_r, a3_r, a0_r, a1_r, a2_r, a3_r);
+-    tmp3 = __msa_copy_u_d((v2i64) a0_r, 1);
+-    tmp2 = __msa_copy_u_d((v2i64) a1_r, 1);
+-    tmp1 = __msa_copy_u_d((v2i64) a2_r, 1);
+-    tmp0 = __msa_copy_u_d((v2i64) a3_r, 1);
++    PCKEV_H4_SH(temp0_l, temp0_r, temp1_l, temp1_r, temp2_l, temp2_r,
++                temp3_l, temp3_r, in0, in1, in2, in3);
++    PCKEV_H4_SH(a0_l, a0_r, a1_l, a1_r, a2_l, a2_r, a3_l, a3_r,
++                in4, in5, in6, in7);
++    CLIP_SH4_0_255(in0, in1, in2, in3);
++    PCKEV_B4_SH(in0, in0, in1, in1, in2, in2, in3, in3,
++                in0, in1, in2, in3);
++    tmp0 = __msa_copy_u_d((v2i64) in0, 1);
++    tmp1 = __msa_copy_u_d((v2i64) in1, 1);
++    tmp2 = __msa_copy_u_d((v2i64) in2, 1);
++    tmp3 = __msa_copy_u_d((v2i64) in3, 1);
+     SD4(tmp0, tmp1, tmp2, tmp3, dst, dst_stride);
+-    dst += 4 * dst_stride;
++    CLIP_SH4_0_255(in4, in5, in6, in7);
++    PCKEV_B4_SH(in4, in4, in5, in5, in6, in6, in7, in7,
++                in4, in5, in6, in7);
++    tmp3 = __msa_copy_u_d((v2i64) in4, 1);
++    tmp2 = __msa_copy_u_d((v2i64) in5, 1);
++    tmp1 = __msa_copy_u_d((v2i64) in6, 1);
++    tmp0 = __msa_copy_u_d((v2i64) in7, 1);
++    SD4(tmp0, tmp1, tmp2, tmp3, dst + 4 * dst_stride, dst_stride);
+ }
+ 
+ static void simple_idct_add_msa(uint8_t *dst, int32_t dst_stride,
+@@ -516,21 +507,17 @@ static void simple_idct_add_msa(uint8_t *dst, int32_t dst_stride,
+                 temp3_l, temp3_r, temp0_r, temp1_r, temp2_r, temp3_r);
+     ILVR_B4_SW(zero, in0, zero, in1, zero, in2, zero, in3,
+                temp0_l, temp1_l, temp2_l, temp3_l);
+-    temp0_r = (v4i32) ((v8i16) (temp0_r) + (v8i16) (temp0_l));
+-    temp1_r = (v4i32) ((v8i16) (temp1_r) + (v8i16) (temp1_l));
+-    temp2_r = (v4i32) ((v8i16) (temp2_r) + (v8i16) (temp2_l));
+-    temp3_r = (v4i32) ((v8i16) (temp3_r) + (v8i16) (temp3_l));
+-    temp0_r = (v4i32) CLIP_SH_0_255(temp0_r);
+-    temp1_r = (v4i32) CLIP_SH_0_255(temp1_r);
+-    temp2_r = (v4i32) CLIP_SH_0_255(temp2_r);
+-    temp3_r = (v4i32) CLIP_SH_0_255(temp3_r);
+-    PCKEV_B4_SW(temp0_r, temp0_r, temp1_r, temp1_r,
+-                temp2_r, temp2_r, temp3_r, temp3_r,
+-                temp0_r, temp1_r, temp2_r, temp3_r);
+-    tmp0 = __msa_copy_u_d((v2i64) temp0_r, 1);
+-    tmp1 = __msa_copy_u_d((v2i64) temp1_r, 1);
+-    tmp2 = __msa_copy_u_d((v2i64) temp2_r, 1);
+-    tmp3 = __msa_copy_u_d((v2i64) temp3_r, 1);
++    in0 = (v8i16) (temp0_r) + (v8i16) (temp0_l);
++    in1 = (v8i16) (temp1_r) + (v8i16) (temp1_l);
++    in2 = (v8i16) (temp2_r) + (v8i16) (temp2_l);
++    in3 = (v8i16) (temp3_r) + (v8i16) (temp3_l);
++    CLIP_SH4_0_255(in0, in1, in2, in3);
++    PCKEV_B4_SH(in0, in0, in1, in1, in2, in2, in3, in3,
++                in0, in1, in2, in3);
++    tmp0 = __msa_copy_u_d((v2i64) in0, 1);
++    tmp1 = __msa_copy_u_d((v2i64) in1, 1);
++    tmp2 = __msa_copy_u_d((v2i64) in2, 1);
++    tmp3 = __msa_copy_u_d((v2i64) in3, 1);
+     SD4(tmp0, tmp1, tmp2, tmp3, dst, dst_stride);
+ 
+     SRA_4V(a3_r, a3_l, a2_r, a2_l, 20);
+@@ -540,20 +527,17 @@ static void simple_idct_add_msa(uint8_t *dst, int32_t dst_stride,
+                 a0_r, a1_r, a2_r, a3_r);
+     ILVR_B4_SW(zero, in4, zero, in5, zero, in6, zero, in7,
+                a3_l, a2_l, a1_l, a0_l);
+-    a3_r = (v4i32) ((v8i16) (a3_r) + (v8i16) (a3_l));
+-    a2_r = (v4i32) ((v8i16) (a2_r) + (v8i16) (a2_l));
+-    a1_r = (v4i32) ((v8i16) (a1_r) + (v8i16) (a1_l));
+-    a0_r = (v4i32) ((v8i16) (a0_r) + (v8i16) (a0_l));
+-    a3_r = (v4i32) CLIP_SH_0_255(a3_r);
+-    a2_r = (v4i32) CLIP_SH_0_255(a2_r);
+-    a1_r = (v4i32) CLIP_SH_0_255(a1_r);
+-    a0_r = (v4i32) CLIP_SH_0_255(a0_r);
+-    PCKEV_B4_SW(a0_r, a0_r, a1_r, a1_r,
+-                a2_r, a2_r, a3_r, a3_r, a0_r, a1_r, a2_r, a3_r);
+-    tmp0 = __msa_copy_u_d((v2i64) a3_r, 1);
+-    tmp1 = __msa_copy_u_d((v2i64) a2_r, 1);
+-    tmp2 = __msa_copy_u_d((v2i64) a1_r, 1);
+-    tmp3 = __msa_copy_u_d((v2i64) a0_r, 1);
++    in4 = (v8i16) (a3_r) + (v8i16) (a3_l);
++    in5 = (v8i16) (a2_r) + (v8i16) (a2_l);
++    in6 = (v8i16) (a1_r) + (v8i16) (a1_l);
++    in7 = (v8i16) (a0_r) + (v8i16) (a0_l);
++    CLIP_SH4_0_255(in4, in5, in6, in7);
++    PCKEV_B4_SH(in4, in4, in5, in5, in6, in6, in7, in7,
++                in4, in5, in6, in7);
++    tmp0 = __msa_copy_u_d((v2i64) in4, 1);
++    tmp1 = __msa_copy_u_d((v2i64) in5, 1);
++    tmp2 = __msa_copy_u_d((v2i64) in6, 1);
++    tmp3 = __msa_copy_u_d((v2i64) in7, 1);
+     SD4(tmp0, tmp1, tmp2, tmp3, dst + 4 * dst_stride, dst_stride);
+ }
+ 
+diff --git a/libavcodec/mips/vp3dsp_idct_msa.c b/libavcodec/mips/vp3dsp_idct_msa.c
+index b2899eea4a..90c578f134 100644
+--- a/libavcodec/mips/vp3dsp_idct_msa.c
++++ b/libavcodec/mips/vp3dsp_idct_msa.c
+@@ -187,14 +187,7 @@ static void idct_msa(uint8_t *dst, int stride, int16_t *input, int type)
+         G += c5;
+         H += c6;
+     }
+-    A = CLIP_SW_0_255(A);
+-    B = CLIP_SW_0_255(B);
+-    C = CLIP_SW_0_255(C);
+-    D = CLIP_SW_0_255(D);
+-    E = CLIP_SW_0_255(E);
+-    F = CLIP_SW_0_255(F);
+-    G = CLIP_SW_0_255(G);
+-    H = CLIP_SW_0_255(H);
++    CLIP_SW8_0_255(A, B, C, D, E, F, G, H);
+     sign_l = __msa_or_v((v16u8)r1_r, (v16u8)r2_r);
+     sign_l = __msa_or_v(sign_l, (v16u8)r3_r);
+     sign_l = __msa_or_v(sign_l, (v16u8)r0_l);
+@@ -205,7 +198,7 @@ static void idct_msa(uint8_t *dst, int stride, int16_t *input, int type)
+     Add = ((r0_r * cnst46341w) + (8 << 16)) >> 20;
+     if (type == 1) {
+         Bdd = Add + cnst128w;
+-        Bdd = CLIP_SW_0_255(Bdd);
++        CLIP_SW_0_255(Bdd);
+         Ad = Bdd;
+         Bd = Bdd;
+         Cd = Bdd;
+@@ -223,14 +216,7 @@ static void idct_msa(uint8_t *dst, int stride, int16_t *input, int type)
+         Fd = Add + c5;
+         Gd = Add + c6;
+         Hd = Add + c7;
+-        Ad = CLIP_SW_0_255(Ad);
+-        Bd = CLIP_SW_0_255(Bd);
+-        Cd = CLIP_SW_0_255(Cd);
+-        Dd = CLIP_SW_0_255(Dd);
+-        Ed = CLIP_SW_0_255(Ed);
+-        Fd = CLIP_SW_0_255(Fd);
+-        Gd = CLIP_SW_0_255(Gd);
+-        Hd = CLIP_SW_0_255(Hd);
++        CLIP_SW8_0_255(Ad, Bd, Cd, Dd, Ed, Fd, Gd, Hd);
+     }
+     Ad = (v4i32)__msa_and_v((v16u8)Ad, (v16u8)sign_t);
+     Bd = (v4i32)__msa_and_v((v16u8)Bd, (v16u8)sign_t);
+@@ -309,14 +295,7 @@ static void idct_msa(uint8_t *dst, int stride, int16_t *input, int type)
+         G += c5;
+         H += c6;
+     }
+-    A = CLIP_SW_0_255(A);
+-    B = CLIP_SW_0_255(B);
+-    C = CLIP_SW_0_255(C);
+-    D = CLIP_SW_0_255(D);
+-    E = CLIP_SW_0_255(E);
+-    F = CLIP_SW_0_255(F);
+-    G = CLIP_SW_0_255(G);
+-    H = CLIP_SW_0_255(H);
++    CLIP_SW8_0_255(A, B, C, D, E, F, G, H);
+     sign_l = __msa_or_v((v16u8)r5_r, (v16u8)r6_r);
+     sign_l = __msa_or_v(sign_l, (v16u8)r7_r);
+     sign_l = __msa_or_v(sign_l, (v16u8)r4_l);
+@@ -327,7 +306,7 @@ static void idct_msa(uint8_t *dst, int stride, int16_t *input, int type)
+     Add = ((r4_r * cnst46341w) + (8 << 16)) >> 20;
+     if (type == 1) {
+         Bdd = Add + cnst128w;
+-        Bdd = CLIP_SW_0_255(Bdd);
++        CLIP_SW_0_255(Bdd);
+         Ad = Bdd;
+         Bd = Bdd;
+         Cd = Bdd;
+@@ -345,14 +324,7 @@ static void idct_msa(uint8_t *dst, int stride, int16_t *input, int type)
+         Fd = Add + c5;
+         Gd = Add + c6;
+         Hd = Add + c7;
+-        Ad = CLIP_SW_0_255(Ad);
+-        Bd = CLIP_SW_0_255(Bd);
+-        Cd = CLIP_SW_0_255(Cd);
+-        Dd = CLIP_SW_0_255(Dd);
+-        Ed = CLIP_SW_0_255(Ed);
+-        Fd = CLIP_SW_0_255(Fd);
+-        Gd = CLIP_SW_0_255(Gd);
+-        Hd = CLIP_SW_0_255(Hd);
++        CLIP_SW8_0_255(Ad, Bd, Cd, Dd, Ed, Fd, Gd, Hd);
+     }
+     Ad = (v4i32)__msa_and_v((v16u8)Ad, (v16u8)sign_t);
+     Bd = (v4i32)__msa_and_v((v16u8)Bd, (v16u8)sign_t);
+@@ -436,14 +408,7 @@ void ff_vp3_idct_dc_add_msa(uint8_t *dest, ptrdiff_t line_size, int16_t *block)
+     e5 += dc;
+     e6 += dc;
+     e7 += dc;
+-    e0 = CLIP_SW_0_255(e0);
+-    e1 = CLIP_SW_0_255(e1);
+-    e2 = CLIP_SW_0_255(e2);
+-    e3 = CLIP_SW_0_255(e3);
+-    e4 = CLIP_SW_0_255(e4);
+-    e5 = CLIP_SW_0_255(e5);
+-    e6 = CLIP_SW_0_255(e6);
+-    e7 = CLIP_SW_0_255(e7);
++    CLIP_SW8_0_255(e0, e1, e2, e3, e4, e5, e6, e7);
+ 
+     /* Left part */
+     ILVL_H4_SW(zero, c0, zero, c1, zero, c2, zero, c3,
+@@ -458,14 +423,7 @@ void ff_vp3_idct_dc_add_msa(uint8_t *dest, ptrdiff_t line_size, int16_t *block)
+     r5 += dc;
+     r6 += dc;
+     r7 += dc;
+-    r0 = CLIP_SW_0_255(r0);
+-    r1 = CLIP_SW_0_255(r1);
+-    r2 = CLIP_SW_0_255(r2);
+-    r3 = CLIP_SW_0_255(r3);
+-    r4 = CLIP_SW_0_255(r4);
+-    r5 = CLIP_SW_0_255(r5);
+-    r6 = CLIP_SW_0_255(r6);
+-    r7 = CLIP_SW_0_255(r7);
++    CLIP_SW8_0_255(r0, r1, r2, r3, r4, r5, r6, r7);
+     VSHF_B2_SB(e0, r0, e1, r1, mask, mask, d0, d1);
+     VSHF_B2_SB(e2, r2, e3, r3, mask, mask, d2, d3);
+     VSHF_B2_SB(e4, r4, e5, r5, mask, mask, d4, d5);
+@@ -516,10 +474,7 @@ void ff_vp3_v_loop_filter_msa(uint8_t *first_pixel, ptrdiff_t stride,
+     f1 += e1;
+     g0 -= e0;
+     g1 -= e1;
+-    f0 = CLIP_SW_0_255(f0);
+-    f1 = CLIP_SW_0_255(f1);
+-    g0 = CLIP_SW_0_255(g0);
+-    g1 = CLIP_SW_0_255(g1);
++    CLIP_SW4_0_255(f0, f1, g0, g1);
+     VSHF_B2_SB(f0, f1, g0, g1, mask, mask, d1, d2);
+ 
+     /* Final move to first_pixel */
+@@ -563,10 +518,7 @@ void ff_vp3_h_loop_filter_msa(uint8_t *first_pixel, ptrdiff_t stride,
+     f1 += e1;
+     g0 -= e0;
+     g1 -= e1;
+-    f0 = CLIP_SW_0_255(f0);
+-    f1 = CLIP_SW_0_255(f1);
+-    g0 = CLIP_SW_0_255(g0);
+-    g1 = CLIP_SW_0_255(g1);
++    CLIP_SW4_0_255(f0, f1, g0, g1);
+     VSHF_B2_SB(f0, g0, f1, g1, mask, mask, d1, d2);
+     /* Final move to first_pixel */
+     ST_H4(d1, 0, 1, 2, 3, first_pixel - 1, stride);
+diff --git a/libavcodec/mips/vp8_idct_msa.c b/libavcodec/mips/vp8_idct_msa.c
+index ae6fec0d60..ce37ca1881 100644
+--- a/libavcodec/mips/vp8_idct_msa.c
++++ b/libavcodec/mips/vp8_idct_msa.c
+@@ -71,10 +71,7 @@ void ff_vp8_idct_add_msa(uint8_t *dst, int16_t input[16], ptrdiff_t stride)
+     ILVR_H4_SW(zero, res0, zero, res1, zero, res2, zero, res3,
+                res0, res1, res2, res3);
+     ADD4(res0, vt0, res1, vt1, res2, vt2, res3, vt3, res0, res1, res2, res3);
+-    res0 = CLIP_SW_0_255(res0);
+-    res1 = CLIP_SW_0_255(res1);
+-    res2 = CLIP_SW_0_255(res2);
+-    res3 = CLIP_SW_0_255(res3);
++    CLIP_SW4_0_255(res0, res1, res2, res3);
+     VSHF_B2_SB(res0, res1, res2, res3, mask, mask, dest0, dest1);
+     ST_W2(dest0, 0, 1, dst, stride);
+     ST_W2(dest1, 0, 1, dst + 2 * stride, stride);
+diff --git a/libavcodec/mips/vp9_idct_msa.c b/libavcodec/mips/vp9_idct_msa.c
+index 1f32770139..a3f5270b73 100644
+--- a/libavcodec/mips/vp9_idct_msa.c
++++ b/libavcodec/mips/vp9_idct_msa.c
+@@ -763,13 +763,13 @@ static void vp9_iadst8x8_colcol_addblk_msa(int16_t *input, uint8_t *dst,
+ 
+     res0 = (v8i16) __msa_ilvr_b((v16i8) zero, (v16i8) dst0);
+     res0 += out0;
+-    res0 = CLIP_SH_0_255(res0);
++    CLIP_SH_0_255(res0);
+     res0 = (v8i16) __msa_pckev_b((v16i8) res0, (v16i8) res0);
+     ST_D1(res0, 0, dst);
+ 
+     res7 = (v8i16) __msa_ilvr_b((v16i8) zero, (v16i8) dst7);
+     res7 += out7;
+-    res7 = CLIP_SH_0_255(res7);
++    CLIP_SH_0_255(res7);
+     res7 = (v8i16) __msa_pckev_b((v16i8) res7, (v16i8) res7);
+     ST_D1(res7, 0, dst + 7 * dst_stride);
+ 
+@@ -1192,8 +1192,7 @@ static void vp9_idct16x16_1_add_msa(int16_t *input, uint8_t *dst,
+              res3);
+         ADD4(res4, vec, res5, vec, res6, vec, res7, vec, res4, res5, res6,
+              res7);
+-        CLIP_SH4_0_255(res0, res1, res2, res3);
+-        CLIP_SH4_0_255(res4, res5, res6, res7);
++        CLIP_SH8_0_255(res0, res1, res2, res3, res4, res5, res6, res7);
+         PCKEV_B4_UB(res4, res0, res5, res1, res6, res2, res7, res3,
+                     tmp0, tmp1, tmp2, tmp3);
+         ST_UB4(tmp0, tmp1, tmp2, tmp3, dst, dst_stride);
+@@ -1981,8 +1980,7 @@ static void vp9_idct32x32_1_add_msa(int16_t *input, uint8_t *dst,
+              res3);
+         ADD4(res4, vec, res5, vec, res6, vec, res7, vec, res4, res5, res6,
+              res7);
+-        CLIP_SH4_0_255(res0, res1, res2, res3);
+-        CLIP_SH4_0_255(res4, res5, res6, res7);
++        CLIP_SH8_0_255(res0, res1, res2, res3, res4, res5, res6, res7);
+         PCKEV_B4_UB(res4, res0, res5, res1, res6, res2, res7, res3,
+                     tmp0, tmp1, tmp2, tmp3);
+ 
+diff --git a/libavutil/mips/generic_macros_msa.h b/libavutil/mips/generic_macros_msa.h
+index 9ac0583765..681d87c458 100644
+--- a/libavutil/mips/generic_macros_msa.h
++++ b/libavutil/mips/generic_macros_msa.h
+@@ -933,99 +933,78 @@
+ 
+ /* Description : Clips all halfword elements of input vector between min & max
+                  out = ((in) < (min)) ? (min) : (((in) > (max)) ? (max) : (in))
+-   Arguments   : Inputs  - in       (input vector)
+-                         - min      (min threshold)
+-                         - max      (max threshold)
+-                 Outputs - out_m    (output vector with clipped elements)
++   Arguments   : Inputs  - in    (input vector)
++                         - min   (min threshold)
++                         - max   (max threshold)
++                 Outputs - in    (output vector with clipped elements)
+                  Return Type - signed halfword
+ */
+-#define CLIP_SH(in, min, max)                           \
+-( {                                                     \
+-    v8i16 out_m;                                        \
+-                                                        \
+-    out_m = __msa_max_s_h((v8i16) min, (v8i16) in);     \
+-    out_m = __msa_min_s_h((v8i16) max, (v8i16) out_m);  \
+-    out_m;                                              \
+-} )
++#define CLIP_SH(in, min, max)                     \
++{                                                 \
++    in = __msa_max_s_h((v8i16) min, (v8i16) in);  \
++    in = __msa_min_s_h((v8i16) max, (v8i16) in);  \
++}
+ 
+ /* Description : Clips all signed halfword elements of input vector
+                  between 0 & 255
+-   Arguments   : Inputs  - in       (input vector)
+-                 Outputs - out_m    (output vector with clipped elements)
+-                 Return Type - signed halfword
++   Arguments   : Inputs  - in    (input vector)
++                 Outputs - in    (output vector with clipped elements)
++                 Return Type - signed halfwords
+ */
+-#define CLIP_SH_0_255(in)                                 \
+-( {                                                       \
+-    v8i16 max_m = __msa_ldi_h(255);                       \
+-    v8i16 out_m;                                          \
+-                                                          \
+-    out_m = __msa_maxi_s_h((v8i16) in, 0);                \
+-    out_m = __msa_min_s_h((v8i16) max_m, (v8i16) out_m);  \
+-    out_m;                                                \
+-} )
++#define CLIP_SH_0_255(in)                       \
++{                                               \
++    in = __msa_maxi_s_h((v8i16) in, 0);         \
++    in = (v8i16) __msa_sat_u_h((v8u16) in, 7);  \
++}
++
+ #define CLIP_SH2_0_255(in0, in1)  \
+ {                                 \
+-    in0 = CLIP_SH_0_255(in0);     \
+-    in1 = CLIP_SH_0_255(in1);     \
++    CLIP_SH_0_255(in0);           \
++    CLIP_SH_0_255(in1);           \
+ }
++
+ #define CLIP_SH4_0_255(in0, in1, in2, in3)  \
+ {                                           \
+     CLIP_SH2_0_255(in0, in1);               \
+     CLIP_SH2_0_255(in2, in3);               \
+ }
+ 
+-#define CLIP_SH_0_255_MAX_SATU(in)                    \
+-( {                                                   \
+-    v8i16 out_m;                                      \
+-                                                      \
+-    out_m = __msa_maxi_s_h((v8i16) in, 0);            \
+-    out_m = (v8i16) __msa_sat_u_h((v8u16) out_m, 7);  \
+-    out_m;                                            \
+-} )
+-#define CLIP_SH2_0_255_MAX_SATU(in0, in1)  \
+-{                                          \
+-    in0 = CLIP_SH_0_255_MAX_SATU(in0);     \
+-    in1 = CLIP_SH_0_255_MAX_SATU(in1);     \
+-}
+-#define CLIP_SH4_0_255_MAX_SATU(in0, in1, in2, in3)  \
+-{                                                    \
+-    CLIP_SH2_0_255_MAX_SATU(in0, in1);               \
+-    CLIP_SH2_0_255_MAX_SATU(in2, in3);               \
++#define CLIP_SH8_0_255(in0, in1, in2, in3,  \
++                       in4, in5, in6, in7)  \
++{                                           \
++    CLIP_SH4_0_255(in0, in1, in2, in3);     \
++    CLIP_SH4_0_255(in4, in5, in6, in7);     \
+ }
+ 
+ /* Description : Clips all signed word elements of input vector
+                  between 0 & 255
+-   Arguments   : Inputs  - in       (input vector)
+-                 Outputs - out_m    (output vector with clipped elements)
++   Arguments   : Inputs  - in    (input vector)
++                 Outputs - in    (output vector with clipped elements)
+                  Return Type - signed word
+ */
+-#define CLIP_SW_0_255(in)                                 \
+-( {                                                       \
+-    v4i32 max_m = __msa_ldi_w(255);                       \
+-    v4i32 out_m;                                          \
+-                                                          \
+-    out_m = __msa_maxi_s_w((v4i32) in, 0);                \
+-    out_m = __msa_min_s_w((v4i32) max_m, (v4i32) out_m);  \
+-    out_m;                                                \
+-} )
++#define CLIP_SW_0_255(in)                       \
++{                                               \
++    in = __msa_maxi_s_w((v4i32) in, 0);         \
++    in = (v4i32) __msa_sat_u_w((v4u32) in, 7);  \
++}
+ 
+-#define CLIP_SW_0_255_MAX_SATU(in)                    \
+-( {                                                   \
+-    v4i32 out_m;                                      \
+-                                                      \
+-    out_m = __msa_maxi_s_w((v4i32) in, 0);            \
+-    out_m = (v4i32) __msa_sat_u_w((v4u32) out_m, 7);  \
+-    out_m;                                            \
+-} )
+-#define CLIP_SW2_0_255_MAX_SATU(in0, in1)  \
+-{                                          \
+-    in0 = CLIP_SW_0_255_MAX_SATU(in0);     \
+-    in1 = CLIP_SW_0_255_MAX_SATU(in1);     \
++#define CLIP_SW2_0_255(in0, in1)  \
++{                                 \
++    CLIP_SW_0_255(in0);           \
++    CLIP_SW_0_255(in1);           \
+ }
+-#define CLIP_SW4_0_255_MAX_SATU(in0, in1, in2, in3)  \
+-{                                                    \
+-    CLIP_SW2_0_255_MAX_SATU(in0, in1);               \
+-    CLIP_SW2_0_255_MAX_SATU(in2, in3);               \
++
++#define CLIP_SW4_0_255(in0, in1, in2, in3)  \
++{                                           \
++    CLIP_SW2_0_255(in0, in1);               \
++    CLIP_SW2_0_255(in2, in3);               \
++}
++
++#define CLIP_SW8_0_255(in0, in1, in2, in3,  \
++                       in4, in5, in6, in7)  \
++{                                           \
++    CLIP_SW4_0_255(in0, in1, in2, in3);     \
++    CLIP_SW4_0_255(in4, in5, in6, in7);     \
+ }
+ 
+ /* Description : Addition of 4 signed word elements
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0004-avcodec-mips-Fix-a-warnning-of-indentation-not-refle.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0004-avcodec-mips-Fix-a-warnning-of-indentation-not-refle.patch
@@ -1,0 +1,35 @@
+From c4a45659cf07d13bab4ca724eaf2af905133c47e Mon Sep 17 00:00:00 2001
+From: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Date: Mon, 9 Sep 2019 11:50:51 +0800
+Subject: [PATCH 04/26] avcodec/mips: Fix a warnning of indentation not reflect
+ the block structure.
+
+The indentation of code dose not reflect the if block structure in
+'apply_ltp_mips', and this will generate a warnning when build with
+'-Wall' or '-Wmisleading-indentation'.
+
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/aacdec_mips.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/mips/aacdec_mips.c b/libavcodec/mips/aacdec_mips.c
+index 253cdeb80b..01a2b3087b 100644
+--- a/libavcodec/mips/aacdec_mips.c
++++ b/libavcodec/mips/aacdec_mips.c
+@@ -237,9 +237,9 @@ static void apply_ltp_mips(AACContext *ac, SingleChannelElement *sce)
+ 
+         if (ltp->lag < 1024)
+             num_samples = ltp->lag + 1024;
+-            j = (2048 - num_samples) >> 2;
+-            k = (2048 - num_samples) & 3;
+-            p_predTime = &predTime[num_samples];
++        j = (2048 - num_samples) >> 2;
++        k = (2048 - num_samples) & 3;
++        p_predTime = &predTime[num_samples];
+ 
+         for (i = 0; i < num_samples; i++)
+             predTime[i] = sce->ltp_state[i + 2048 - ltp->lag] * ltp->coef;
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0005-avutil-mips-refactor-msa-SLDI_Bn_0-and-SLDI_Bn-macro.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0005-avutil-mips-refactor-msa-SLDI_Bn_0-and-SLDI_Bn-macro.patch
@@ -1,0 +1,1332 @@
+From 0bf9eac1c82af985b84aec8822d7384e87f5d823 Mon Sep 17 00:00:00 2001
+From: gxw <guxiwei-hf@loongson.cn>
+Date: Tue, 6 Aug 2019 19:11:16 +0800
+Subject: [PATCH 05/26] avutil/mips: refactor msa SLDI_Bn_0 and SLDI_Bn macros.
+
+Changing details as following:
+1. The previous order of parameters are irregular and difficult to
+   understand. Adjust the order of the parameters according to the
+   rule: (RTYPE, input registers, input mask/input index/..., output registers).
+   Most of the existing msa macros follow the rule.
+2. Remove the redundant macro SLDI_Bn_0 and use SLDI_Bn instead.
+
+Reviewed-by: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/h264dsp_msa.c       |  9 ++--
+ libavcodec/mips/h264qpel_msa.c      | 64 +++++++++++-----------
+ libavcodec/mips/hevc_lpf_sao_msa.c  | 70 ++++++++++++------------
+ libavcodec/mips/hevcpred_msa.c      | 30 ++++++-----
+ libavcodec/mips/hpeldsp_msa.c       | 66 ++++++++++++++---------
+ libavcodec/mips/me_cmp_msa.c        |  8 +--
+ libavcodec/mips/qpeldsp_msa.c       | 84 ++++++++++++++---------------
+ libavcodec/mips/vp8_mc_msa.c        |  4 +-
+ libavcodec/mips/vp9_idct_msa.c      |  3 +-
+ libavcodec/mips/vp9_lpf_msa.c       |  3 +-
+ libavcodec/mips/vp9_mc_msa.c        | 16 +++---
+ libavutil/mips/generic_macros_msa.h | 80 +++++++++++----------------
+ 12 files changed, 222 insertions(+), 215 deletions(-)
+
+diff --git a/libavcodec/mips/h264dsp_msa.c b/libavcodec/mips/h264dsp_msa.c
+index c580d884f5..dd0598291e 100644
+--- a/libavcodec/mips/h264dsp_msa.c
++++ b/libavcodec/mips/h264dsp_msa.c
+@@ -618,7 +618,7 @@ static void avc_biwgt_8x16_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+                                                              \
+     out0 = (v16u8) __msa_ilvr_b((v16i8) in1, (v16i8) in0);   \
+     out1 = (v16u8) __msa_sldi_b(zero_m, (v16i8) out0, 2);    \
+-    SLDI_B2_0_UB(out1, out2, out2, out3, 2);                 \
++    SLDI_B2_UB(zero_m, out1, zero_m, out2, 2, out2, out3);   \
+ }
+ 
+ #define AVC_LPF_H_2BYTE_CHROMA_422(src, stride, tc_val, alpha, beta, res)  \
+@@ -1023,7 +1023,8 @@ static void avc_h_loop_filter_luma_mbaff_intra_msa(uint8_t *src, int32_t stride,
+ 
+     ILVR_W2_SB(tmp2, tmp0, tmp3, tmp1, src6, src3);
+     ILVL_W2_SB(tmp2, tmp0, tmp3, tmp1, src1, src5);
+-    SLDI_B4_0_SB(src6, src1, src3, src5, src0, src2, src4, src7, 8);
++    SLDI_B4_SB(zeros, src6, zeros, src1, zeros, src3, zeros, src5,
++               8, src0, src2, src4, src7);
+ 
+     p0_asub_q0 = __msa_asub_u_b((v16u8) src2, (v16u8) src3);
+     p1_asub_p0 = __msa_asub_u_b((v16u8) src1, (v16u8) src2);
+@@ -1114,10 +1115,10 @@ static void avc_h_loop_filter_luma_mbaff_intra_msa(uint8_t *src, int32_t stride,
+     ILVRL_H2_SH(zeros, dst2_x, tmp2, tmp3);
+ 
+     ILVR_W2_UB(tmp2, tmp0, tmp3, tmp1, dst0, dst4);
+-    SLDI_B2_0_UB(dst0, dst4, dst1, dst5, 8);
++    SLDI_B2_UB(zeros, dst0, zeros, dst4, 8, dst1, dst5);
+     dst2_x = (v16u8) __msa_ilvl_w((v4i32) tmp2, (v4i32) tmp0);
+     dst2_y = (v16u8) __msa_ilvl_w((v4i32) tmp3, (v4i32) tmp1);
+-    SLDI_B2_0_UB(dst2_x, dst2_y, dst3_x, dst3_y, 8);
++    SLDI_B2_UB(zeros, dst2_x, zeros, dst2_y, 8, dst3_x, dst3_y);
+ 
+     out0 = __msa_copy_u_w((v4i32) dst0, 0);
+     out1 = __msa_copy_u_h((v8i16) dst0, 2);
+diff --git a/libavcodec/mips/h264qpel_msa.c b/libavcodec/mips/h264qpel_msa.c
+index df7e3e2a3f..e435c18750 100644
+--- a/libavcodec/mips/h264qpel_msa.c
++++ b/libavcodec/mips/h264qpel_msa.c
+@@ -790,8 +790,8 @@ void ff_put_h264_qpel16_mc10_msa(uint8_t *dst, const uint8_t *src,
+                      minus5b, res4, res5, res6, res7);
+         DPADD_SB4_SH(vec2, vec5, vec8, vec11, plus20b, plus20b, plus20b,
+                      plus20b, res4, res5, res6, res7);
+-        SLDI_B2_SB(src1, src3, src0, src2, src0, src2, 2);
+-        SLDI_B2_SB(src5, src7, src4, src6, src4, src6, 2);
++        SLDI_B4_SB(src1, src0, src3, src2, src5, src4, src7, src6, 2,
++                   src0, src2, src4, src6);
+         SRARI_H4_SH(res0, res1, res2, res3, 5);
+         SRARI_H4_SH(res4, res5, res6, res7, 5);
+         SAT_SH4_SH(res0, res1, res2, res3, 7);
+@@ -858,8 +858,8 @@ void ff_put_h264_qpel16_mc30_msa(uint8_t *dst, const uint8_t *src,
+                      minus5b, res4, res5, res6, res7);
+         DPADD_SB4_SH(vec2, vec5, vec8, vec11, plus20b, plus20b, plus20b,
+                      plus20b, res4, res5, res6, res7);
+-        SLDI_B2_SB(src1, src3, src0, src2, src0, src2, 3);
+-        SLDI_B2_SB(src5, src7, src4, src6, src4, src6, 3);
++        SLDI_B4_SB(src1, src0, src3, src2, src5, src4, src7, src6, 3,
++                   src0, src2, src4, src6);
+         SRARI_H4_SH(res0, res1, res2, res3, 5);
+         SRARI_H4_SH(res4, res5, res6, res7, 5);
+         SAT_SH4_SH(res0, res1, res2, res3, 7);
+@@ -911,10 +911,10 @@ void ff_put_h264_qpel8_mc10_msa(uint8_t *dst, const uint8_t *src,
+     VSHF_B2_SB(src6, src6, src7, src7, mask2, mask2, vec10, vec11);
+     DPADD_SB4_SH(vec8, vec9, vec10, vec11, plus20b, plus20b, plus20b, plus20b,
+                  res4, res5, res6, res7);
+-    SLDI_B2_SB(src0, src1, src0, src1, src0, src1, 2);
+-    SLDI_B2_SB(src2, src3, src2, src3, src2, src3, 2);
+-    SLDI_B2_SB(src4, src5, src4, src5, src4, src5, 2);
+-    SLDI_B2_SB(src6, src7, src6, src7, src6, src7, 2);
++    SLDI_B4_SB(src0, src0, src1, src1, src2, src2, src3, src3, 2,
++               src0, src1, src2, src3);
++    SLDI_B4_SB(src4, src4, src5, src5, src6, src6, src7, src7, 2,
++               src4, src5, src6, src7);
+     PCKEV_D2_SB(src1, src0, src3, src2, src0, src1);
+     PCKEV_D2_SB(src5, src4, src7, src6, src4, src5);
+     SRARI_H4_SH(res0, res1, res2, res3, 5);
+@@ -966,10 +966,10 @@ void ff_put_h264_qpel8_mc30_msa(uint8_t *dst, const uint8_t *src,
+     VSHF_B2_SB(src6, src6, src7, src7, mask2, mask2, vec10, vec11);
+     DPADD_SB4_SH(vec8, vec9, vec10, vec11, plus20b, plus20b, plus20b, plus20b,
+                  res4, res5, res6, res7);
+-    SLDI_B2_SB(src0, src1, src0, src1, src0, src1, 3);
+-    SLDI_B2_SB(src2, src3, src2, src3, src2, src3, 3);
+-    SLDI_B2_SB(src4, src5, src4, src5, src4, src5, 3);
+-    SLDI_B2_SB(src6, src7, src6, src7, src6, src7, 3);
++    SLDI_B4_SB(src0, src0, src1, src1, src2, src2, src3, src3, 3,
++               src0, src1, src2, src3);
++    SLDI_B4_SB(src4, src4, src5, src5, src6, src6, src7, src7, 3,
++               src4, src5, src6, src7);
+     PCKEV_D2_SB(src1, src0, src3, src2, src0, src1);
+     PCKEV_D2_SB(src5, src4, src7, src6, src4, src5);
+     SRARI_H4_SH(res0, res1, res2, res3, 5);
+@@ -1007,8 +1007,8 @@ void ff_put_h264_qpel4_mc10_msa(uint8_t *dst, const uint8_t *src,
+     SRARI_H2_SH(res0, res1, 5);
+     SAT_SH2_SH(res0, res1, 7);
+     res = __msa_pckev_b((v16i8) res1, (v16i8) res0);
+-    SLDI_B2_SB(src0, src1, src0, src1, src0, src1, 2);
+-    SLDI_B2_SB(src2, src3, src2, src3, src2, src3, 2);
++    SLDI_B4_SB(src0, src0, src1, src1, src2, src2, src3, src3, 2,
++               src0, src1, src2, src3);
+     src0 = (v16i8) __msa_insve_w((v4i32) src0, 1, (v4i32) src1);
+     src1 = (v16i8) __msa_insve_w((v4i32) src2, 1, (v4i32) src3);
+     src0 = (v16i8) __msa_insve_d((v2i64) src0, 1, (v2i64) src1);
+@@ -1038,8 +1038,8 @@ void ff_put_h264_qpel4_mc30_msa(uint8_t *dst, const uint8_t *src,
+     SRARI_H2_SH(res0, res1, 5);
+     SAT_SH2_SH(res0, res1, 7);
+     res = __msa_pckev_b((v16i8) res1, (v16i8) res0);
+-    SLDI_B2_SB(src0, src1, src0, src1, src0, src1, 3);
+-    SLDI_B2_SB(src2, src3, src2, src3, src2, src3, 3);
++    SLDI_B4_SB(src0, src0, src1, src1, src2, src2, src3, src3, 3,
++               src0, src1, src2, src3);
+     src0 = (v16i8) __msa_insve_w((v4i32) src0, 1, (v4i32) src1);
+     src1 = (v16i8) __msa_insve_w((v4i32) src2, 1, (v4i32) src3);
+     src0 = (v16i8) __msa_insve_d((v2i64) src0, 1, (v2i64) src1);
+@@ -3194,8 +3194,8 @@ void ff_avg_h264_qpel16_mc10_msa(uint8_t *dst, const uint8_t *src,
+                      minus5b, res4, res5, res6, res7);
+         DPADD_SB4_SH(vec2, vec5, vec8, vec11, plus20b, plus20b, plus20b,
+                      plus20b, res4, res5, res6, res7);
+-        SLDI_B2_SB(src1, src3, src0, src2, src0, src2, 2);
+-        SLDI_B2_SB(src5, src7, src4, src6, src4, src6, 2);
++        SLDI_B4_SB(src1, src0, src3, src2, src5, src4, src7, src6, 2,
++                   src0, src2, src4, src6);
+         SRARI_H4_SH(res0, res1, res2, res3, 5);
+         SRARI_H4_SH(res4, res5, res6, res7, 5);
+         SAT_SH4_SH(res0, res1, res2, res3, 7);
+@@ -3266,8 +3266,8 @@ void ff_avg_h264_qpel16_mc30_msa(uint8_t *dst, const uint8_t *src,
+                      minus5b, res4, res5, res6, res7);
+         DPADD_SB4_SH(vec2, vec5, vec8, vec11, plus20b, plus20b, plus20b,
+                      plus20b, res4, res5, res6, res7);
+-        SLDI_B2_SB(src1, src3, src0, src2, src0, src2, 3);
+-        SLDI_B2_SB(src5, src7, src4, src6, src4, src6, 3);
++        SLDI_B4_SB(src1, src0, src3, src2, src5, src4, src7, src6, 3,
++                   src0, src2, src4, src6);
+         SRARI_H4_SH(res0, res1, res2, res3, 5);
+         SRARI_H4_SH(res4, res5, res6, res7, 5);
+         SAT_SH4_SH(res0, res1, res2, res3, 7);
+@@ -3323,10 +3323,10 @@ void ff_avg_h264_qpel8_mc10_msa(uint8_t *dst, const uint8_t *src,
+     VSHF_B2_SB(src6, src6, src7, src7, mask2, mask2, vec10, vec11);
+     DPADD_SB4_SH(vec8, vec9, vec10, vec11, plus20b, plus20b, plus20b, plus20b,
+                  res4, res5, res6, res7);
+-    SLDI_B2_SB(src0, src1, src0, src1, src0, src1, 2);
+-    SLDI_B2_SB(src2, src3, src2, src3, src2, src3, 2);
+-    SLDI_B2_SB(src4, src5, src4, src5, src4, src5, 2);
+-    SLDI_B2_SB(src6, src7, src6, src7, src6, src7, 2);
++    SLDI_B4_SB(src0, src0, src1, src1, src2, src2, src3, src3, 2,
++               src0, src1, src2, src3);
++    SLDI_B4_SB(src4, src4, src5, src5, src6, src6, src7, src7, 2,
++               src4, src5, src6, src7);
+     PCKEV_D2_SB(src1, src0, src3, src2, src0, src1);
+     PCKEV_D2_SB(src5, src4, src7, src6, src4, src5);
+     SRARI_H4_SH(res0, res1, res2, res3, 5);
+@@ -3388,10 +3388,10 @@ void ff_avg_h264_qpel8_mc30_msa(uint8_t *dst, const uint8_t *src,
+     VSHF_B2_SB(src6, src6, src7, src7, mask2, mask2, vec10, vec11);
+     DPADD_SB4_SH(vec8, vec9, vec10, vec11, plus20b, plus20b, plus20b, plus20b,
+                  res4, res5, res6, res7);
+-    SLDI_B2_SB(src0, src1, src0, src1, src0, src1, 3);
+-    SLDI_B2_SB(src2, src3, src2, src3, src2, src3, 3);
+-    SLDI_B2_SB(src4, src5, src4, src5, src4, src5, 3);
+-    SLDI_B2_SB(src6, src7, src6, src7, src6, src7, 3);
++    SLDI_B4_SB(src0, src0, src1, src1, src2, src2, src3, src3, 3,
++               src0, src1, src2, src3);
++    SLDI_B4_SB(src4, src4, src5, src5, src6, src6, src7, src7, 3,
++               src4, src5, src6, src7);
+     PCKEV_D2_SB(src1, src0, src3, src2, src0, src1);
+     PCKEV_D2_SB(src5, src4, src7, src6, src4, src5);
+     SRARI_H4_SH(res0, res1, res2, res3, 5);
+@@ -3439,8 +3439,8 @@ void ff_avg_h264_qpel4_mc10_msa(uint8_t *dst, const uint8_t *src,
+     SRARI_H2_SH(out0, out1, 5);
+     SAT_SH2_SH(out0, out1, 7);
+     res = __msa_pckev_b((v16i8) out1, (v16i8) out0);
+-    SLDI_B2_SB(src0, src1, src0, src1, src0, src1, 2);
+-    SLDI_B2_SB(src2, src3, src2, src3, src2, src3, 2);
++    SLDI_B4_SB(src0, src0, src1, src1, src2, src2, src3, src3, 2,
++               src0, src1, src2, src3);
+     src0 = (v16i8) __msa_insve_w((v4i32) src0, 1, (v4i32) src1);
+     src1 = (v16i8) __msa_insve_w((v4i32) src2, 1, (v4i32) src3);
+     src0 = (v16i8) __msa_insve_d((v2i64) src0, 1, (v2i64) src1);
+@@ -3475,8 +3475,8 @@ void ff_avg_h264_qpel4_mc30_msa(uint8_t *dst, const uint8_t *src,
+     SRARI_H2_SH(out0, out1, 5);
+     SAT_SH2_SH(out0, out1, 7);
+     res = __msa_pckev_b((v16i8) out1, (v16i8) out0);
+-    SLDI_B2_SB(src0, src1, src0, src1, src0, src1, 3);
+-    SLDI_B2_SB(src2, src3, src2, src3, src2, src3, 3);
++    SLDI_B4_SB(src0, src0, src1, src1, src2, src2, src3, src3, 3,
++               src0, src1, src2, src3);
+     src0 = (v16i8) __msa_insve_w((v4i32) src0, 1, (v4i32) src1);
+     src1 = (v16i8) __msa_insve_w((v4i32) src2, 1, (v4i32) src3);
+     src0 = (v16i8) __msa_insve_d((v2i64) src0, 1, (v2i64) src1);
+diff --git a/libavcodec/mips/hevc_lpf_sao_msa.c b/libavcodec/mips/hevc_lpf_sao_msa.c
+index 7153fef7b9..26663dd89b 100644
+--- a/libavcodec/mips/hevc_lpf_sao_msa.c
++++ b/libavcodec/mips/hevc_lpf_sao_msa.c
+@@ -1357,6 +1357,7 @@ static void hevc_sao_edge_filter_0degree_8width_msa(uint8_t *dst,
+     v16u8 cmp_minus10, diff_minus10, diff_minus11;
+     v16u8 src0, src1, dst0, src_minus10, src_minus11, src_plus10, src_plus11;
+     v16i8 offset, sao_offset = LD_SB(sao_offset_val);
++    v16i8 zeros = { 0 };
+ 
+     sao_offset = __msa_pckev_b(sao_offset, sao_offset);
+     src -= 1;
+@@ -1367,8 +1368,8 @@ static void hevc_sao_edge_filter_0degree_8width_msa(uint8_t *dst,
+     for (height -= 2; height; height -= 2) {
+         src += (src_stride << 1);
+ 
+-        SLDI_B2_0_UB(src_minus10, src_minus11, src0, src1, 1);
+-        SLDI_B2_0_UB(src_minus10, src_minus11, src_plus10, src_plus11, 2);
++        SLDI_B2_UB(zeros, src_minus10, zeros, src_minus11, 1, src0, src1);
++        SLDI_B2_UB(zeros, src_minus10, zeros, src_minus11, 2, src_plus10, src_plus11);
+ 
+         PCKEV_D2_UB(src_minus11, src_minus10, src_plus11, src_plus10,
+                     src_minus10, src_plus10);
+@@ -1404,8 +1405,8 @@ static void hevc_sao_edge_filter_0degree_8width_msa(uint8_t *dst,
+         dst += dst_stride;
+     }
+ 
+-    SLDI_B2_0_UB(src_minus10, src_minus11, src0, src1, 1);
+-    SLDI_B2_0_UB(src_minus10, src_minus11, src_plus10, src_plus11, 2);
++    SLDI_B2_UB(zeros, src_minus10, zeros, src_minus11, 1, src0, src1);
++    SLDI_B2_UB(zeros, src_minus10, zeros, src_minus11, 2, src_plus10, src_plus11);
+ 
+     PCKEV_D2_UB(src_minus11, src_minus10, src_plus11, src_plus10, src_minus10,
+                 src_plus10);
+@@ -1473,14 +1474,12 @@ static void hevc_sao_edge_filter_0degree_16multiple_msa(uint8_t *dst,
+             dst_ptr = dst + v_cnt;
+             LD_UB4(src_minus1, src_stride, src10, src11, src12, src13);
+ 
+-            SLDI_B2_SB(src10, src11, src_minus10, src_minus11, src_zero0,
+-                       src_zero1, 1);
+-            SLDI_B2_SB(src12, src13, src_minus12, src_minus13, src_zero2,
+-                       src_zero3, 1);
+-            SLDI_B2_SB(src10, src11, src_minus10, src_minus11, src_plus10,
+-                       src_plus11, 2);
+-            SLDI_B2_SB(src12, src13, src_minus12, src_minus13, src_plus12,
+-                       src_plus13, 2);
++            SLDI_B4_SB(src10, src_minus10, src11, src_minus11,
++                       src12, src_minus12, src13, src_minus13, 1,
++                       src_zero0, src_zero1, src_zero2, src_zero3);
++            SLDI_B4_SB(src10, src_minus10, src11, src_minus11,
++                       src12, src_minus12, src13, src_minus13, 2,
++                       src_plus10, src_plus11, src_plus12, src_plus13);
+ 
+             cmp_minus10 = ((v16u8) src_zero0 == src_minus10);
+             cmp_plus10 = ((v16u8) src_zero0 == (v16u8) src_plus10);
+@@ -1880,6 +1879,7 @@ static void hevc_sao_edge_filter_45degree_4width_msa(uint8_t *dst,
+     v16u8 src_minus11, src10, src11;
+     v16i8 src_plus0, src_zero0, src_plus1, src_zero1, dst0;
+     v8i16 offset_mask0, offset_mask1;
++    v16i8 zeros = { 0 };
+ 
+     sao_offset = __msa_pckev_b(sao_offset, sao_offset);
+ 
+@@ -1892,8 +1892,8 @@ static void hevc_sao_edge_filter_45degree_4width_msa(uint8_t *dst,
+     for (height -= 2; height; height -= 2) {
+         src_orig += (src_stride << 1);
+ 
+-        SLDI_B2_0_SB(src_minus11, src10, src_zero0, src_zero1, 1);
+-        SLDI_B2_0_SB(src10, src11, src_plus0, src_plus1, 2);
++        SLDI_B2_SB(zeros, src_minus11, zeros, src10, 1, src_zero0, src_zero1);
++        SLDI_B2_SB(zeros, src10, zeros, src11, 2, src_plus0, src_plus1);
+ 
+         ILVR_B2_UB(src_plus0, src_minus10, src_plus1, src_minus11, src_minus10,
+                    src_minus11);
+@@ -1938,8 +1938,8 @@ static void hevc_sao_edge_filter_45degree_4width_msa(uint8_t *dst,
+         dst += dst_stride;
+     }
+ 
+-    SLDI_B2_0_SB(src_minus11, src10, src_zero0, src_zero1, 1);
+-    SLDI_B2_0_SB(src10, src11, src_plus0, src_plus1, 2);
++    SLDI_B2_SB(zeros, src_minus11, zeros, src10, 1, src_zero0, src_zero1);
++    SLDI_B2_SB(zeros, src10, zeros, src11, 2, src_plus0, src_plus1);
+ 
+     ILVR_B2_UB(src_plus0, src_minus10, src_plus1, src_minus11, src_minus10,
+                src_minus11);
+@@ -1992,6 +1992,7 @@ static void hevc_sao_edge_filter_45degree_8width_msa(uint8_t *dst,
+     v16u8 src_minus10, src10, src_minus11, src11;
+     v16i8 src_zero0, src_plus10, src_zero1, src_plus11, dst0;
+     v8i16 offset_mask0, offset_mask1;
++    v16i8 zeros = { 0 };
+ 
+     sao_offset = __msa_pckev_b(sao_offset, sao_offset);
+     src_orig = src - 1;
+@@ -2003,8 +2004,8 @@ static void hevc_sao_edge_filter_45degree_8width_msa(uint8_t *dst,
+     for (height -= 2; height; height -= 2) {
+         src_orig += (src_stride << 1);
+ 
+-        SLDI_B2_0_SB(src_minus11, src10, src_zero0, src_zero1, 1);
+-        SLDI_B2_0_SB(src10, src11, src_plus10, src_plus11, 2);
++        SLDI_B2_SB(zeros, src_minus11, zeros, src10, 1, src_zero0, src_zero1);
++        SLDI_B2_SB(zeros, src10, zeros, src11, 2, src_plus10, src_plus11);
+ 
+         ILVR_B2_UB(src_plus10, src_minus10, src_plus11, src_minus11,
+                    src_minus10, src_minus11);
+@@ -2048,8 +2049,8 @@ static void hevc_sao_edge_filter_45degree_8width_msa(uint8_t *dst,
+         dst += dst_stride;
+     }
+ 
+-    SLDI_B2_0_SB(src_minus11, src10, src_zero0, src_zero1, 1);
+-    SLDI_B2_0_SB(src10, src11, src_plus10, src_plus11, 2);
++    SLDI_B2_SB(zeros, src_minus11, zeros, src10, 1, src_zero0, src_zero1);
++    SLDI_B2_SB(zeros, src10, zeros, src11, 2, src_plus10, src_plus11);
+     ILVR_B2_UB(src_plus10, src_minus10, src_plus11, src_minus11, src_minus10,
+                src_minus11);
+     ILVR_B2_SB(src_zero0, src_zero0, src_zero1, src_zero1, src_zero0,
+@@ -2130,12 +2131,11 @@ static void hevc_sao_edge_filter_45degree_16multiple_msa(uint8_t *dst,
+             src_plus13 = LD_UB(src + 1 + v_cnt + (src_stride << 2));
+             src_orig += 16;
+ 
+-            SLDI_B2_SB(src10, src11, src_minus11, src_minus12, src_zero0,
+-                       src_zero1, 1);
+-            SLDI_B2_SB(src12, src13, src_minus13, src_minus14, src_zero2,
+-                       src_zero3, 1);
+-            SLDI_B2_SB(src11, src12, src_minus12, src_minus13, src_plus10,
+-                       src_plus11, 2);
++            SLDI_B4_SB(src10, src_minus11, src11, src_minus12,
++                       src12, src_minus13, src13, src_minus14, 1,
++                       src_zero0, src_zero1, src_zero2, src_zero3);
++            SLDI_B2_SB(src11, src_minus12, src12, src_minus13, 2, src_plus10,
++                       src_plus11);
+ 
+             src_plus12 = __msa_sldi_b((v16i8) src13, (v16i8) src_minus14, 2);
+ 
+@@ -2228,6 +2228,7 @@ static void hevc_sao_edge_filter_135degree_4width_msa(uint8_t *dst,
+     v16u8 cmp_minus10, diff_minus10, cmp_minus11, diff_minus11;
+     v16u8 src_minus10, src10, src_minus11, src11;
+     v8i16 offset_mask0, offset_mask1;
++    v16i8 zeros = { 0 };
+ 
+     sao_offset = __msa_pckev_b(sao_offset, sao_offset);
+     src_orig = src - 1;
+@@ -2239,8 +2240,8 @@ static void hevc_sao_edge_filter_135degree_4width_msa(uint8_t *dst,
+     for (height -= 2; height; height -= 2) {
+         src_orig += (src_stride << 1);
+ 
+-        SLDI_B2_0_SB(src_minus11, src10, src_zero0, src_zero1, 1);
+-        SLDI_B2_0_UB(src_minus10, src_minus11, src_minus10, src_minus11, 2);
++        SLDI_B2_SB(zeros, src_minus11, zeros, src10, 1, src_zero0, src_zero1);
++        SLDI_B2_UB(zeros, src_minus10, zeros, src_minus11, 2, src_minus10, src_minus11);
+ 
+         ILVR_B2_UB(src10, src_minus10, src11, src_minus11, src_minus10,
+                    src_minus11);
+@@ -2286,8 +2287,8 @@ static void hevc_sao_edge_filter_135degree_4width_msa(uint8_t *dst,
+         dst += dst_stride;
+     }
+ 
+-    SLDI_B2_0_SB(src_minus11, src10, src_zero0, src_zero1, 1);
+-    SLDI_B2_0_UB(src_minus10, src_minus11, src_minus10, src_minus11, 2);
++    SLDI_B2_SB(zeros, src_minus11, zeros, src10, 1, src_zero0, src_zero1);
++    SLDI_B2_UB(zeros, src_minus10, zeros, src_minus11, 2, src_minus10, src_minus11);
+ 
+     ILVR_B2_UB(src10, src_minus10, src11, src_minus11, src_minus10,
+                src_minus11);
+@@ -2342,6 +2343,7 @@ static void hevc_sao_edge_filter_135degree_8width_msa(uint8_t *dst,
+     v16u8 src_minus10, src10, src_minus11, src11;
+     v16i8 src_zero0, src_zero1, dst0;
+     v8i16 offset_mask0, offset_mask1;
++    v16i8 zeros = { 0 };
+ 
+     sao_offset = __msa_pckev_b(sao_offset, sao_offset);
+     src_orig = src - 1;
+@@ -2353,8 +2355,8 @@ static void hevc_sao_edge_filter_135degree_8width_msa(uint8_t *dst,
+     for (height -= 2; height; height -= 2) {
+         src_orig += (src_stride << 1);
+ 
+-        SLDI_B2_0_SB(src_minus11, src10, src_zero0, src_zero1, 1);
+-        SLDI_B2_0_UB(src_minus10, src_minus11, src_minus10, src_minus11, 2);
++        SLDI_B2_SB(zeros, src_minus11, zeros, src10, 1, src_zero0, src_zero1);
++        SLDI_B2_UB(zeros, src_minus10, zeros, src_minus11, 2, src_minus10, src_minus11);
+         ILVR_B2_UB(src10, src_minus10, src11, src_minus11, src_minus10,
+                    src_minus11);
+         ILVR_B2_SB(src_zero0, src_zero0, src_zero1, src_zero1, src_zero0,
+@@ -2398,8 +2400,8 @@ static void hevc_sao_edge_filter_135degree_8width_msa(uint8_t *dst,
+         dst += dst_stride;
+     }
+ 
+-    SLDI_B2_0_SB(src_minus11, src10, src_zero0, src_zero1, 1);
+-    SLDI_B2_0_UB(src_minus10, src_minus11, src_minus10, src_minus11, 2);
++    SLDI_B2_SB(zeros, src_minus11, zeros, src10, 1, src_zero0, src_zero1);
++    SLDI_B2_UB(zeros, src_minus10, zeros, src_minus11, 2, src_minus10, src_minus11);
+     ILVR_B2_UB(src10, src_minus10, src11, src_minus11, src_minus10,
+                src_minus11);
+     ILVR_B2_SB(src_zero0, src_zero0, src_zero1, src_zero1, src_zero0,
+diff --git a/libavcodec/mips/hevcpred_msa.c b/libavcodec/mips/hevcpred_msa.c
+index 930a89cb48..f53276d34e 100644
+--- a/libavcodec/mips/hevcpred_msa.c
++++ b/libavcodec/mips/hevcpred_msa.c
+@@ -998,7 +998,8 @@ static void hevc_intra_pred_angular_upper_4width_msa(const uint8_t *src_top,
+     ILVR_D2_SH(fact3, fact1, fact7, fact5, fact1, fact3);
+     ILVR_B4_SH(zero, top0, zero, top1, zero, top2, zero, top3,
+                diff0, diff2, diff4, diff6);
+-    SLDI_B4_0_SH(diff0, diff2, diff4, diff6, diff1, diff3, diff5, diff7, 2);
++    SLDI_B4_SH(zero, diff0, zero, diff2, zero, diff4, zero, diff6, 2,
++               diff1, diff3, diff5, diff7);
+     ILVR_D2_SH(diff2, diff0, diff6, diff4, diff0, diff2);
+     ILVR_D2_SH(diff3, diff1, diff7, diff5, diff1, diff3);
+     MUL2(diff1, fact0, diff3, fact2, diff1, diff3);
+@@ -1093,8 +1094,8 @@ static void hevc_intra_pred_angular_upper_8width_msa(const uint8_t *src_top,
+         UNPCK_UB_SH(top2, diff4, diff5);
+         UNPCK_UB_SH(top3, diff6, diff7);
+ 
+-        SLDI_B2_SH(diff1, diff3, diff0, diff2, diff1, diff3, 2);
+-        SLDI_B2_SH(diff5, diff7, diff4, diff6, diff5, diff7, 2);
++        SLDI_B4_SH(diff1, diff0, diff3, diff2, diff5, diff4, diff7, diff6, 2,
++                   diff1, diff3, diff5, diff7);
+         MUL4(diff1, fact0, diff3, fact2, diff5, fact4, diff7, fact6,
+              diff1, diff3, diff5, diff7);
+ 
+@@ -1186,8 +1187,8 @@ static void hevc_intra_pred_angular_upper_16width_msa(const uint8_t *src_top,
+         fact6 = __msa_fill_h(fact_val3);
+         fact7 = __msa_fill_h(32 - fact_val3);
+ 
+-        SLDI_B2_UB(top1, top3, top0, top2, top1, top3, 1);
+-        SLDI_B2_UB(top5, top7, top4, top6, top5, top7, 1);
++        SLDI_B4_UB(top1, top0, top3, top2, top5, top4, top7, top6, 1,
++                   top1, top3, top5, top7);
+         UNPCK_UB_SH(top0, diff0, diff1);
+         UNPCK_UB_SH(top1, diff2, diff3);
+         UNPCK_UB_SH(top2, diff4, diff5);
+@@ -1297,8 +1298,8 @@ static void hevc_intra_pred_angular_upper_32width_msa(const uint8_t *src_top,
+         top2 = top1;
+         top6 = top5;
+ 
+-        SLDI_B2_UB(top1, top3, top0, top2, top1, top3, 1);
+-        SLDI_B2_UB(top5, top7, top4, top6, top5, top7, 1);
++        SLDI_B4_UB(top1, top0, top3, top2, top5, top4, top7, top6, 1,
++                   top1, top3, top5, top7);
+         UNPCK_UB_SH(top0, diff0, diff1);
+         UNPCK_UB_SH(top1, diff2, diff3);
+         UNPCK_UB_SH(top2, diff4, diff5);
+@@ -1407,7 +1408,8 @@ static void hevc_intra_pred_angular_lower_4width_msa(const uint8_t *src_top,
+     ILVR_D2_SH(fact3, fact1, fact7, fact5, fact1, fact3);
+     ILVR_B4_SH(zero, top0, zero, top1, zero, top2, zero, top3,
+                diff0, diff2, diff4, diff6);
+-    SLDI_B4_0_SH(diff0, diff2, diff4, diff6, diff1, diff3, diff5, diff7, 2);
++    SLDI_B4_SH(zero, diff0, zero, diff2, zero, diff4, zero, diff6, 2,
++               diff1, diff3, diff5, diff7);
+     ILVR_D2_SH(diff2, diff0, diff6, diff4, diff0, diff2);
+     ILVR_D2_SH(diff3, diff1, diff7, diff5, diff1, diff3);
+     MUL2(diff1, fact0, diff3, fact2, diff1, diff3);
+@@ -1511,8 +1513,8 @@ static void hevc_intra_pred_angular_lower_8width_msa(const uint8_t *src_top,
+         UNPCK_UB_SH(top1, diff2, diff3);
+         UNPCK_UB_SH(top2, diff4, diff5);
+         UNPCK_UB_SH(top3, diff6, diff7);
+-        SLDI_B2_SH(diff1, diff3, diff0, diff2, diff1, diff3, 2);
+-        SLDI_B2_SH(diff5, diff7, diff4, diff6, diff5, diff7, 2);
++        SLDI_B4_SH(diff1, diff0, diff3, diff2, diff5, diff4, diff7, diff6, 2,
++                   diff1, diff3, diff5, diff7);
+         MUL4(diff1, fact0, diff3, fact2, diff5, fact4, diff7, fact6,
+              diff1, diff3, diff5, diff7);
+ 
+@@ -1606,8 +1608,8 @@ static void hevc_intra_pred_angular_lower_16width_msa(const uint8_t *src_top,
+         fact6 = __msa_fill_h(fact_val3);
+         fact7 = __msa_fill_h(32 - fact_val3);
+ 
+-        SLDI_B2_SB(top1, top3, top0, top2, top1, top3, 1);
+-        SLDI_B2_SB(top5, top7, top4, top6, top5, top7, 1);
++        SLDI_B4_SB(top1, top0, top3, top2, top5, top4, top7, top6, 1,
++                   top1, top3, top5, top7);
+ 
+         UNPCK_UB_SH(top0, diff0, diff1);
+         UNPCK_UB_SH(top1, diff2, diff3);
+@@ -1713,8 +1715,8 @@ static void hevc_intra_pred_angular_lower_32width_msa(const uint8_t *src_top,
+         top2 = top1;
+         top6 = top5;
+ 
+-        SLDI_B2_SB(top1, top3, top0, top2, top1, top3, 1);
+-        SLDI_B2_SB(top5, top7, top4, top6, top5, top7, 1);
++        SLDI_B4_SB(top1, top0, top3, top2, top5, top4, top7, top6, 1,
++                   top1, top3, top5, top7);
+ 
+         UNPCK_UB_SH(top0, diff0, diff1);
+         UNPCK_UB_SH(top1, diff2, diff3);
+diff --git a/libavcodec/mips/hpeldsp_msa.c b/libavcodec/mips/hpeldsp_msa.c
+index ad92f8f115..2bbe4771d4 100644
+--- a/libavcodec/mips/hpeldsp_msa.c
++++ b/libavcodec/mips/hpeldsp_msa.c
+@@ -59,12 +59,13 @@ static void common_hz_bil_4w_msa(const uint8_t *src, int32_t src_stride,
+     uint8_t loop_cnt;
+     uint32_t out0, out1;
+     v16u8 src0, src1, src0_sld1, src1_sld1, res0, res1;
++    v16i8 zeros = { 0 };
+ 
+     for (loop_cnt = (height >> 1); loop_cnt--;) {
+         LD_UB2(src, src_stride, src0, src1);
+         src += (2 * src_stride);
+ 
+-        SLDI_B2_0_UB(src0, src1, src0_sld1, src1_sld1, 1);
++        SLDI_B2_UB(zeros, src0, zeros, src1, 1, src0_sld1, src1_sld1);
+         AVER_UB2_UB(src0_sld1, src0, src1_sld1, src1, res0, res1);
+ 
+         out0 = __msa_copy_u_w((v4i32) res0, 0);
+@@ -82,13 +83,14 @@ static void common_hz_bil_8w_msa(const uint8_t *src, int32_t src_stride,
+ {
+     uint8_t loop_cnt;
+     v16i8 src0, src1, src2, src3, src0_sld1, src1_sld1, src2_sld1, src3_sld1;
++    v16i8 zeros = { 0 };
+ 
+     for (loop_cnt = (height >> 2); loop_cnt--;) {
+         LD_SB4(src, src_stride, src0, src1, src2, src3);
+         src += (4 * src_stride);
+ 
+-        SLDI_B4_0_SB(src0, src1, src2, src3,
+-                     src0_sld1, src1_sld1, src2_sld1, src3_sld1, 1);
++        SLDI_B4_SB(zeros, src0, zeros, src1, zeros, src2, zeros, src3, 1,
++                   src0_sld1, src1_sld1, src2_sld1, src3_sld1);
+         AVER_ST8x4_UB(src0, src0_sld1, src1, src1_sld1,
+                       src2, src2_sld1, src3, src3_sld1, dst, dst_stride);
+         dst += (4 * dst_stride);
+@@ -125,14 +127,15 @@ static void common_hz_bil_no_rnd_8x8_msa(const uint8_t *src, int32_t src_stride,
+     v16i8 src0, src1, src2, src3, src4, src5, src6, src7;
+     v16i8 src0_sld1, src1_sld1, src2_sld1, src3_sld1;
+     v16i8 src4_sld1, src5_sld1, src6_sld1, src7_sld1;
++    v16i8 zeros = { 0 };
+ 
+     LD_SB8(src, src_stride, src0, src1, src2, src3, src4, src5, src6, src7);
+     src += (8 * src_stride);
+ 
+-    SLDI_B4_0_SB(src0, src1, src2, src3,
+-                 src0_sld1, src1_sld1, src2_sld1, src3_sld1, 1);
+-    SLDI_B4_0_SB(src4, src5, src6, src7,
+-                 src4_sld1, src5_sld1, src6_sld1, src7_sld1, 1);
++    SLDI_B4_SB(zeros, src0, zeros, src1, zeros, src2, zeros, src3, 1,
++               src0_sld1, src1_sld1, src2_sld1, src3_sld1);
++    SLDI_B4_SB(zeros, src4, zeros, src5, zeros, src6, zeros, src7, 1,
++               src4_sld1, src5_sld1, src6_sld1, src7_sld1);
+ 
+     AVE_ST8x4_UB(src0, src0_sld1, src1, src1_sld1,
+                  src2, src2_sld1, src3, src3_sld1, dst, dst_stride);
+@@ -145,10 +148,11 @@ static void common_hz_bil_no_rnd_4x8_msa(const uint8_t *src, int32_t src_stride,
+                                          uint8_t *dst, int32_t dst_stride)
+ {
+     v16i8 src0, src1, src2, src3, src0_sld1, src1_sld1, src2_sld1, src3_sld1;
++    v16i8 zeros = { 0 };
+ 
+     LD_SB4(src, src_stride, src0, src1, src2, src3);
+-    SLDI_B4_0_SB(src0, src1, src2, src3,
+-                 src0_sld1, src1_sld1, src2_sld1, src3_sld1, 1);
++    SLDI_B4_SB(zeros, src0, zeros, src1, zeros, src2, zeros, src3, 1,
++               src0_sld1, src1_sld1, src2_sld1, src3_sld1);
+     AVE_ST8x4_UB(src0, src0_sld1, src1, src1_sld1,
+                  src2, src2_sld1, src3, src3_sld1, dst, dst_stride);
+ }
+@@ -216,12 +220,13 @@ static void common_hz_bil_and_aver_dst_4w_msa(const uint8_t *src,
+     v16u8 src0, src1, src0_sld1, src1_sld1, res0, res1;
+     v16u8 tmp0 = { 0 };
+     v16u8 tmp1 = { 0 };
++    v16i8 zeros = { 0 };
+ 
+     for (loop_cnt = (height >> 1); loop_cnt--;) {
+         LD_UB2(src, src_stride, src0, src1);
+         src += (2 * src_stride);
+ 
+-        SLDI_B2_0_UB(src0, src1, src0_sld1, src1_sld1, 1);
++        SLDI_B2_UB(zeros, src0, zeros, src1, 1, src0_sld1, src1_sld1);
+ 
+         dst0 = LW(dst);
+         dst1 = LW(dst + dst_stride);
+@@ -247,13 +252,14 @@ static void common_hz_bil_and_aver_dst_8w_msa(const uint8_t *src,
+ {
+     uint8_t loop_cnt;
+     v16i8 src0, src1, src2, src3, src0_sld1, src1_sld1, src2_sld1, src3_sld1;
++    v16i8 zeros = { 0 };
+ 
+     for (loop_cnt = (height >> 2); loop_cnt--;) {
+         LD_SB4(src, src_stride, src0, src1, src2, src3);
+         src += (4 * src_stride);
+ 
+-        SLDI_B4_0_SB(src0, src1, src2, src3,
+-                     src0_sld1, src1_sld1, src2_sld1, src3_sld1, 1);
++        SLDI_B4_SB(zeros, src0, zeros, src1, zeros, src2, zeros, src3, 1,
++                   src0_sld1, src1_sld1, src2_sld1, src3_sld1);
+ 
+         AVER_DST_ST8x4_UB(src0, src0_sld1, src1, src1_sld1, src2, src2_sld1,
+                           src3, src3_sld1, dst, dst_stride);
+@@ -529,6 +535,7 @@ static void common_hv_bil_4w_msa(const uint8_t *src, int32_t src_stride,
+     v16i8 src0, src1, src2, src0_sld1, src1_sld1, src2_sld1;
+     v16u8 src0_r, src1_r, src2_r, res;
+     v8u16 add0, add1, add2, sum0, sum1;
++    v16i8 zeros = { 0 };
+ 
+     src0 = LD_SB(src);
+     src += src_stride;
+@@ -537,7 +544,8 @@ static void common_hv_bil_4w_msa(const uint8_t *src, int32_t src_stride,
+         LD_SB2(src, src_stride, src1, src2);
+         src += (2 * src_stride);
+ 
+-        SLDI_B3_0_SB(src0, src1, src2, src0_sld1, src1_sld1, src2_sld1, 1);
++        SLDI_B3_SB(zeros, src0, zeros, src1, zeros, src2, 1, src0_sld1,
++                   src1_sld1, src2_sld1);
+         ILVR_B3_UB(src0_sld1, src0, src1_sld1, src1, src2_sld1, src2,
+                    src0_r, src1_r, src2_r);
+         HADD_UB3_UH(src0_r, src1_r, src2_r, add0, add1, add2);
+@@ -565,6 +573,7 @@ static void common_hv_bil_8w_msa(const uint8_t *src, int32_t src_stride,
+     v16u8 src0_r, src1_r, src2_r, src3_r, src4_r;
+     v8u16 add0, add1, add2, add3, add4;
+     v8u16 sum0, sum1, sum2, sum3;
++    v16i8 zeros = { 0 };
+ 
+     src0 = LD_SB(src);
+     src += src_stride;
+@@ -573,8 +582,9 @@ static void common_hv_bil_8w_msa(const uint8_t *src, int32_t src_stride,
+         LD_SB4(src, src_stride, src1, src2, src3, src4);
+         src += (4 * src_stride);
+ 
+-        SLDI_B3_0_SB(src0, src1, src2, src0_sld1, src1_sld1, src2_sld1, 1);
+-        SLDI_B2_0_SB(src3, src4, src3_sld1, src4_sld1, 1);
++        SLDI_B3_SB(zeros, src0, zeros, src1, zeros, src2, 1, src0_sld1,
++                   src1_sld1, src2_sld1);
++        SLDI_B2_SB(zeros, src3, zeros, src4, 1, src3_sld1, src4_sld1);
+         ILVR_B3_UB(src0_sld1, src0, src1_sld1, src1, src2_sld1, src2, src0_r,
+                    src1_r, src2_r);
+         ILVR_B2_UB(src3_sld1, src3, src4_sld1, src4, src3_r, src4_r);
+@@ -659,15 +669,17 @@ static void common_hv_bil_no_rnd_8x8_msa(const uint8_t *src, int32_t src_stride,
+     v8u16 add0, add1, add2, add3, add4, add5, add6, add7, add8;
+     v8u16 sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7;
+     v16i8 out0, out1;
++    v16i8 zeros = { 0 };
+ 
+     LD_UB8(src, src_stride, src0, src1, src2, src3, src4, src5, src6, src7);
+     src += (8 * src_stride);
+     src8 = LD_UB(src);
+ 
+-    SLDI_B4_0_UB(src0, src1, src2, src3, src0_sld1, src1_sld1, src2_sld1,
+-                 src3_sld1, 1);
+-    SLDI_B3_0_UB(src4, src5, src6, src4_sld1, src5_sld1, src6_sld1, 1);
+-    SLDI_B2_0_UB(src7, src8, src7_sld1, src8_sld1, 1);
++    SLDI_B4_UB(zeros, src0, zeros, src1, zeros, src2, zeros, src3, 1,
++               src0_sld1, src1_sld1, src2_sld1, src3_sld1);
++    SLDI_B3_UB(zeros, src4, zeros, src5, zeros, src6, 1, src4_sld1,
++               src5_sld1, src6_sld1);
++    SLDI_B2_UB(zeros, src7, zeros, src8, 1, src7_sld1, src8_sld1);
+     ILVR_B4_UH(src0_sld1, src0, src1_sld1, src1, src2_sld1, src2, src3_sld1,
+                src3, src0_r, src1_r, src2_r, src3_r);
+     ILVR_B3_UH(src4_sld1, src4, src5_sld1, src5, src6_sld1, src6, src4_r,
+@@ -703,13 +715,15 @@ static void common_hv_bil_no_rnd_4x8_msa(const uint8_t *src, int32_t src_stride,
+     v8u16 add0, add1, add2, add3, add4;
+     v8u16 sum0, sum1, sum2, sum3;
+     v16i8 out0, out1;
++    v16i8 zeros = { 0 };
+ 
+     LD_SB4(src, src_stride, src0, src1, src2, src3);
+     src += (4 * src_stride);
+     src4 = LD_SB(src);
+ 
+-    SLDI_B3_0_SB(src0, src1, src2, src0_sld1, src1_sld1, src2_sld1, 1);
+-    SLDI_B2_0_SB(src3, src4, src3_sld1, src4_sld1, 1);
++    SLDI_B3_SB(zeros, src0, zeros, src1, zeros, src2, 1, src0_sld1,
++               src1_sld1, src2_sld1);
++    SLDI_B2_SB(zeros, src3, zeros, src4, 1, src3_sld1, src4_sld1);
+     ILVR_B3_UH(src0_sld1, src0, src1_sld1, src1, src2_sld1, src2, src0_r,
+                src1_r, src2_r);
+     ILVR_B2_UH(src3_sld1, src3, src4_sld1, src4, src3_r, src4_r);
+@@ -918,6 +932,7 @@ static void common_hv_bil_and_aver_dst_4w_msa(const uint8_t *src,
+     v16u8 src0_r, src1_r, src2_r;
+     v8u16 add0, add1, add2, sum0, sum1;
+     v16u8 dst0, dst1, res0, res1;
++    v16i8 zeros = { 0 };
+ 
+     src0 = LD_SB(src);
+     src += src_stride;
+@@ -927,7 +942,8 @@ static void common_hv_bil_and_aver_dst_4w_msa(const uint8_t *src,
+         src += (2 * src_stride);
+ 
+         LD_UB2(dst, dst_stride, dst0, dst1);
+-        SLDI_B3_0_SB(src0, src1, src2, src0_sld1, src1_sld1, src2_sld1, 1);
++        SLDI_B3_SB(zeros, src0, zeros, src1, zeros, src2, 1, src0_sld1,
++                   src1_sld1, src2_sld1);
+         ILVR_B3_UB(src0_sld1, src0, src1_sld1, src1, src2_sld1, src2, src0_r,
+                    src1_r, src2_r);
+         HADD_UB3_UH(src0_r, src1_r, src2_r, add0, add1, add2);
+@@ -959,6 +975,7 @@ static void common_hv_bil_and_aver_dst_8w_msa(const uint8_t *src,
+     v16u8 src0_r, src1_r, src2_r, src3_r, src4_r;
+     v8u16 add0, add1, add2, add3, add4;
+     v8u16 sum0, sum1, sum2, sum3;
++    v16i8 zeros = { 0 };
+ 
+     src0 = LD_SB(src);
+     src += src_stride;
+@@ -968,8 +985,9 @@ static void common_hv_bil_and_aver_dst_8w_msa(const uint8_t *src,
+         src += (4 * src_stride);
+ 
+         LD_UB4(dst, dst_stride, dst0, dst1, dst2, dst3);
+-        SLDI_B3_0_SB(src0, src1, src2, src0_sld1, src1_sld1, src2_sld1, 1);
+-        SLDI_B2_0_SB(src3, src4, src3_sld1, src4_sld1, 1);
++        SLDI_B3_SB(zeros, src0, zeros, src1, zeros, src2, 1, src0_sld1,
++                   src1_sld1, src2_sld1);
++        SLDI_B2_SB(zeros, src3, zeros, src4, 1, src3_sld1, src4_sld1);
+         ILVR_B3_UB(src0_sld1, src0, src1_sld1, src1, src2_sld1, src2, src0_r,
+                    src1_r, src2_r);
+         ILVR_B2_UB(src3_sld1, src3, src4_sld1, src4, src3_r, src4_r);
+diff --git a/libavcodec/mips/me_cmp_msa.c b/libavcodec/mips/me_cmp_msa.c
+index 0e3165cd8f..7cb7af0047 100644
+--- a/libavcodec/mips/me_cmp_msa.c
++++ b/libavcodec/mips/me_cmp_msa.c
+@@ -87,8 +87,8 @@ static uint32_t sad_horiz_bilinear_filter_8width_msa(uint8_t *src,
+ 
+         PCKEV_D2_UB(src1, src0, src3, src2, src0, src1);
+         PCKEV_D2_UB(ref1, ref0, ref3, ref2, ref4, ref5);
+-        SLDI_B2_UB(ref0, ref1, ref0, ref1, ref0, ref1, 1);
+-        SLDI_B2_UB(ref2, ref3, ref2, ref3, ref2, ref3, 1);
++        SLDI_B4_UB(ref0, ref0, ref1, ref1, ref2, ref2, ref3, ref3, 1,
++                   ref0, ref1, ref2, ref3);
+         PCKEV_D2_UB(ref1, ref0, ref3, ref2, ref0, ref1);
+         AVER_UB2_UB(ref4, ref0, ref5, ref1, comp0, comp1);
+         sad += SAD_UB2_UH(src0, src1, comp0, comp1);
+@@ -100,8 +100,8 @@ static uint32_t sad_horiz_bilinear_filter_8width_msa(uint8_t *src,
+ 
+         PCKEV_D2_UB(src1, src0, src3, src2, src0, src1);
+         PCKEV_D2_UB(ref1, ref0, ref3, ref2, ref4, ref5);
+-        SLDI_B2_UB(ref0, ref1, ref0, ref1, ref0, ref1, 1);
+-        SLDI_B2_UB(ref2, ref3, ref2, ref3, ref2, ref3, 1);
++        SLDI_B4_UB(ref0, ref0, ref1, ref1, ref2, ref2, ref3, ref3, 1,
++                   ref0, ref1, ref2, ref3);
+         PCKEV_D2_UB(ref1, ref0, ref3, ref2, ref0, ref1);
+         AVER_UB2_UB(ref4, ref0, ref5, ref1, comp0, comp1);
+         sad += SAD_UB2_UH(src0, src1, comp0, comp1);
+diff --git a/libavcodec/mips/qpeldsp_msa.c b/libavcodec/mips/qpeldsp_msa.c
+index b6ffc279ee..c7675f112e 100644
+--- a/libavcodec/mips/qpeldsp_msa.c
++++ b/libavcodec/mips/qpeldsp_msa.c
+@@ -480,8 +480,8 @@ static void horiz_mc_qpel_aver_src1_8width_msa(const uint8_t *src,
+         res1 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp2, inp3,
+                                              mask0, mask1, mask2, mask3,
+                                              const20, const6, const3);
+-        SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
+-        SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++        SLDI_B4_UB(inp0, inp0, inp1, inp1, inp2, inp2, inp3, inp3, 1,
++                   inp0, inp1, inp2, inp3);
+         inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+         inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+         AVER_UB2_UB(inp0, res0, inp2, res1, res0, res1);
+@@ -710,8 +710,8 @@ static void horiz_mc_qpel_no_rnd_aver_src1_8width_msa(const uint8_t *src,
+         res1 = APPLY_HORIZ_QPEL_NO_ROUND_FILTER_8BYTE(inp2, inp3, mask0, mask1,
+                                                       mask2, mask3, const20,
+                                                       const6, const3);
+-        SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
+-        SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++        SLDI_B4_UB(inp0, inp0, inp1, inp1, inp2, inp2, inp3, inp3, 1,
++                   inp0, inp1, inp2, inp3);
+         inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+         inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+         res0 = __msa_ave_u_b(inp0, res0);
+@@ -948,8 +948,8 @@ static void horiz_mc_qpel_avg_dst_aver_src1_8width_msa(const uint8_t *src,
+                                              mask0, mask1, mask2, mask3,
+                                              const20, const6, const3);
+         LD_UB4(dst, dst_stride, dst0, dst1, dst2, dst3);
+-        SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
+-        SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++        SLDI_B4_UB(inp0, inp0, inp1, inp1, inp2, inp2, inp3, inp3, 1,
++                   inp0, inp1, inp2, inp3);
+         inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+         inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+         dst0 = (v16u8) __msa_insve_d((v2i64) dst0, 1, (v2i64) dst1);
+@@ -3094,7 +3094,7 @@ static void hv_mc_qpel_no_rnd_aver_hv_src10_8x8_msa(const uint8_t *src,
+     res0 = APPLY_HORIZ_QPEL_NO_ROUND_FILTER_8BYTE(inp0, inp1, mask0, mask1,
+                                                   mask2, mask3, const20,
+                                                   const6, const3);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+     horiz0 = __msa_ave_u_b(inp0, res0);
+@@ -3104,7 +3104,7 @@ static void hv_mc_qpel_no_rnd_aver_hv_src10_8x8_msa(const uint8_t *src,
+     res1 = APPLY_HORIZ_QPEL_NO_ROUND_FILTER_8BYTE(inp2, inp3, mask0, mask1,
+                                                   mask2, mask3, const20,
+                                                   const6, const3);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+     horiz2 = __msa_ave_u_b(inp2, res1);
+@@ -3114,7 +3114,7 @@ static void hv_mc_qpel_no_rnd_aver_hv_src10_8x8_msa(const uint8_t *src,
+     res0 = APPLY_HORIZ_QPEL_NO_ROUND_FILTER_8BYTE(inp0, inp1, mask0, mask1,
+                                                   mask2, mask3, const20,
+                                                   const6, const3);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+     horiz4 = __msa_ave_u_b(inp0, res0);
+@@ -3134,7 +3134,7 @@ static void hv_mc_qpel_no_rnd_aver_hv_src10_8x8_msa(const uint8_t *src,
+     res1 = APPLY_HORIZ_QPEL_NO_ROUND_FILTER_8BYTE(inp2, inp3, mask0, mask1,
+                                                   mask2, mask3, const20,
+                                                   const6, const3);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+     horiz6 = __msa_ave_u_b(inp2, res1);
+@@ -3389,7 +3389,7 @@ static void hv_mc_qpel_no_rnd_aver_h_src1_8x8_msa(const uint8_t *src,
+     res0 = APPLY_HORIZ_QPEL_NO_ROUND_FILTER_8BYTE(inp0, inp1, mask0, mask1,
+                                                   mask2, mask3, const20,
+                                                   const6, const3);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+     horiz0 = __msa_ave_u_b(inp0, res0);
+@@ -3399,7 +3399,7 @@ static void hv_mc_qpel_no_rnd_aver_h_src1_8x8_msa(const uint8_t *src,
+     res1 = APPLY_HORIZ_QPEL_NO_ROUND_FILTER_8BYTE(inp2, inp3, mask0, mask1,
+                                                   mask2, mask3, const20,
+                                                   const6, const3);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+     horiz2 = __msa_ave_u_b(inp2, res1);
+@@ -3409,7 +3409,7 @@ static void hv_mc_qpel_no_rnd_aver_h_src1_8x8_msa(const uint8_t *src,
+     res0 = APPLY_HORIZ_QPEL_NO_ROUND_FILTER_8BYTE(inp0, inp1, mask0, mask1,
+                                                   mask2, mask3, const20,
+                                                   const6, const3);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+     horiz4 = __msa_ave_u_b(inp0, res0);
+@@ -3427,7 +3427,7 @@ static void hv_mc_qpel_no_rnd_aver_h_src1_8x8_msa(const uint8_t *src,
+     res1 = APPLY_HORIZ_QPEL_NO_ROUND_FILTER_8BYTE(inp2, inp3, mask0, mask1,
+                                                   mask2, mask3, const20,
+                                                   const6, const3);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+     horiz6 = __msa_ave_u_b(inp2, res1);
+@@ -3691,7 +3691,7 @@ static void hv_mc_qpel_no_rnd_aver_hv_src11_8x8_msa(const uint8_t *src,
+     res0 = APPLY_HORIZ_QPEL_NO_ROUND_FILTER_8BYTE(inp0, inp1, mask0, mask1,
+                                                   mask2, mask3, const20,
+                                                   const6, const3);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+     horiz0 = __msa_ave_u_b(inp0, res0);
+@@ -3701,7 +3701,7 @@ static void hv_mc_qpel_no_rnd_aver_hv_src11_8x8_msa(const uint8_t *src,
+     res1 = APPLY_HORIZ_QPEL_NO_ROUND_FILTER_8BYTE(inp2, inp3, mask0, mask1,
+                                                   mask2, mask3, const20,
+                                                   const6, const3);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+     horiz2 = __msa_ave_u_b(inp2, res1);
+@@ -3712,7 +3712,7 @@ static void hv_mc_qpel_no_rnd_aver_hv_src11_8x8_msa(const uint8_t *src,
+                                                   mask2, mask3, const20,
+                                                   const6, const3);
+ 
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+     inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+     horiz4 = __msa_ave_u_b(inp0, res0);
+     horiz5 = (v16u8) __msa_splati_d((v2i64) horiz4, 1);
+@@ -3731,7 +3731,7 @@ static void hv_mc_qpel_no_rnd_aver_hv_src11_8x8_msa(const uint8_t *src,
+     res1 = APPLY_HORIZ_QPEL_NO_ROUND_FILTER_8BYTE(inp2, inp3, mask0, mask1,
+                                                   mask2, mask3, const20,
+                                                   const6, const3);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+     horiz6 = __msa_ave_u_b(inp2, res1);
+@@ -4134,12 +4134,12 @@ static void hv_mc_qpel_aver_hv_src10_8x8_msa(const uint8_t *src,
+                                          const20, const6, const3);
+     res1 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp2, inp3, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+     horiz0 = __msa_aver_u_b(inp0, res0);
+     horiz1 = (v16u8) __msa_splati_d((v2i64) horiz0, 1);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+     horiz2 = __msa_aver_u_b(inp2, res1);
+@@ -4150,12 +4150,12 @@ static void hv_mc_qpel_aver_hv_src10_8x8_msa(const uint8_t *src,
+                                          const20, const6, const3);
+     res1 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp2, inp3, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+     horiz4 = __msa_aver_u_b(inp0, res0);
+     horiz5 = (v16u8) __msa_splati_d((v2i64) horiz4, 1);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+     horiz6 = __msa_aver_u_b(inp2, res1);
+@@ -4410,12 +4410,12 @@ static void hv_mc_qpel_aver_h_src1_8x8_msa(const uint8_t *src,
+                                          const20, const6, const3);
+     res1 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp2, inp3, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+     horiz0 = __msa_aver_u_b(inp0, res0);
+     horiz1 = (v16u8) __msa_splati_d((v2i64) horiz0, 1);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+     horiz2 = __msa_aver_u_b(inp2, res1);
+@@ -4426,12 +4426,12 @@ static void hv_mc_qpel_aver_h_src1_8x8_msa(const uint8_t *src,
+                                          const20, const6, const3);
+     res1 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp2, inp3, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+     horiz4 = __msa_aver_u_b(inp0, res0);
+     horiz5 = (v16u8) __msa_splati_d((v2i64) horiz4, 1);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+     horiz6 = __msa_aver_u_b(inp2, res1);
+@@ -4690,14 +4690,14 @@ static void hv_mc_qpel_aver_hv_src11_8x8_msa(const uint8_t *src,
+     res0 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp0, inp1,
+                                          mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+     horiz0 = __msa_aver_u_b(inp0, res0);
+     horiz1 = (v16u8) __msa_splati_d((v2i64) horiz0, 1);
+     res1 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp2, inp3, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+     horiz2 = __msa_aver_u_b(inp2, res1);
+@@ -4706,7 +4706,7 @@ static void hv_mc_qpel_aver_hv_src11_8x8_msa(const uint8_t *src,
+     src += (2 * src_stride);
+     res0 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp0, inp1, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_insve_d((v2i64) inp0, 1, (v2i64) inp1);
+     horiz4 = __msa_aver_u_b(inp0, res0);
+@@ -4725,7 +4725,7 @@ static void hv_mc_qpel_aver_hv_src11_8x8_msa(const uint8_t *src,
+ 
+     res1 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp2, inp3, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_insve_d((v2i64) inp2, 1, (v2i64) inp3);
+     horiz6 = __msa_aver_u_b(inp2, res1);
+@@ -5020,7 +5020,7 @@ static void hv_mc_qpel_avg_dst_aver_hv_src10_8x8_msa(const uint8_t *src,
+ 
+     LD_UB2(src, src_stride, inp2, inp3);
+     src += (2 * src_stride);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_ilvr_d((v2i64) inp1, (v2i64) inp0);
+     horiz0 = __msa_aver_u_b(inp0, res0);
+@@ -5029,7 +5029,7 @@ static void hv_mc_qpel_avg_dst_aver_hv_src10_8x8_msa(const uint8_t *src,
+                                          const20, const6, const3);
+     LD_UB2(src, src_stride, inp0, inp1);
+     src += (2 * src_stride);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_ilvr_d((v2i64) inp3, (v2i64) inp2);
+     horiz2 = __msa_aver_u_b(inp2, res1);
+@@ -5037,7 +5037,7 @@ static void hv_mc_qpel_avg_dst_aver_hv_src10_8x8_msa(const uint8_t *src,
+     res0 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp0, inp1, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+ 
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_ilvr_d((v2i64) inp1, (v2i64) inp0);
+     horiz4 = __msa_aver_u_b(inp0, res0);
+@@ -5060,7 +5060,7 @@ static void hv_mc_qpel_avg_dst_aver_hv_src10_8x8_msa(const uint8_t *src,
+     res1 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp2, inp3, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+ 
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_ilvr_d((v2i64) inp3, (v2i64) inp2);
+     horiz6 = __msa_aver_u_b(inp2, res1);
+@@ -5347,7 +5347,7 @@ static void hv_mc_qpel_avg_dst_aver_h_src1_8x8_msa(const uint8_t *src,
+                                          const20, const6, const3);
+     LD_UB2(src, src_stride, inp2, inp3);
+     src += (2 * src_stride);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_ilvr_d((v2i64) inp1, (v2i64) inp0);
+     horiz0 = __msa_aver_u_b(inp0, res0);
+@@ -5356,7 +5356,7 @@ static void hv_mc_qpel_avg_dst_aver_h_src1_8x8_msa(const uint8_t *src,
+                                          const20, const6, const3);
+     LD_UB2(src, src_stride, inp0, inp1);
+     src += (2 * src_stride);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_ilvr_d((v2i64) inp3, (v2i64) inp2);
+     horiz2 = __msa_aver_u_b(inp2, res1);
+@@ -5364,7 +5364,7 @@ static void hv_mc_qpel_avg_dst_aver_h_src1_8x8_msa(const uint8_t *src,
+     res0 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp0, inp1, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+ 
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_ilvr_d((v2i64) inp1, (v2i64) inp0);
+     horiz4 = __msa_aver_u_b(inp0, res0);
+@@ -5385,7 +5385,7 @@ static void hv_mc_qpel_avg_dst_aver_h_src1_8x8_msa(const uint8_t *src,
+     res1 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp2, inp3, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+ 
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_ilvr_d((v2i64) inp3, (v2i64) inp2);
+     horiz6 = __msa_aver_u_b(inp2, res1);
+@@ -5684,7 +5684,7 @@ static void hv_mc_qpel_avg_dst_aver_hv_src11_8x8_msa(const uint8_t *src,
+                                          const20, const6, const3);
+     LD_UB2(src, src_stride, inp2, inp3);
+     src += (2 * src_stride);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_ilvr_d((v2i64) inp1, (v2i64) inp0);
+     horiz0 = __msa_aver_u_b(inp0, res0);
+@@ -5693,14 +5693,14 @@ static void hv_mc_qpel_avg_dst_aver_hv_src11_8x8_msa(const uint8_t *src,
+                                          const20, const6, const3);
+     LD_UB2(src, src_stride, inp0, inp1);
+     src += (2 * src_stride);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_ilvr_d((v2i64) inp3, (v2i64) inp2);
+     horiz2 = __msa_aver_u_b(inp2, res1);
+     horiz3 = (v16u8) __msa_splati_d((v2i64) horiz2, 1);
+     res0 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp0, inp1, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+-    SLDI_B2_UB(inp0, inp1, inp0, inp1, inp0, inp1, 1);
++    SLDI_B2_UB(inp0, inp0, inp1, inp1, 1, inp0, inp1);
+ 
+     inp0 = (v16u8) __msa_ilvr_d((v2i64) inp1, (v2i64) inp0);
+     horiz4 = __msa_aver_u_b(inp0, res0);
+@@ -5721,7 +5721,7 @@ static void hv_mc_qpel_avg_dst_aver_hv_src11_8x8_msa(const uint8_t *src,
+     src += (2 * src_stride);
+     res1 = APPLY_HORIZ_QPEL_FILTER_8BYTE(inp2, inp3, mask0, mask1, mask2, mask3,
+                                          const20, const6, const3);
+-    SLDI_B2_UB(inp2, inp3, inp2, inp3, inp2, inp3, 1);
++    SLDI_B2_UB(inp2, inp2, inp3, inp3, 1, inp2, inp3);
+ 
+     inp2 = (v16u8) __msa_ilvr_d((v2i64) inp3, (v2i64) inp2);
+     horiz6 = __msa_aver_u_b(inp2, res1);
+diff --git a/libavcodec/mips/vp8_mc_msa.c b/libavcodec/mips/vp8_mc_msa.c
+index 57af6b45f1..a61320625a 100644
+--- a/libavcodec/mips/vp8_mc_msa.c
++++ b/libavcodec/mips/vp8_mc_msa.c
+@@ -1995,8 +1995,8 @@ static void common_hv_2ht_2vt_4x8_msa(uint8_t *src, int32_t src_stride,
+     hz_out4 = HORIZ_2TAP_FILT_UH(src4, src5, mask, filt_hz, 7);
+     hz_out6 = HORIZ_2TAP_FILT_UH(src6, src7, mask, filt_hz, 7);
+     hz_out8 = HORIZ_2TAP_FILT_UH(src8, src8, mask, filt_hz, 7);
+-    SLDI_B3_UH(hz_out2, hz_out4, hz_out6, hz_out0, hz_out2, hz_out4, hz_out1,
+-               hz_out3, hz_out5, 8);
++    SLDI_B3_UH(hz_out2, hz_out0, hz_out4, hz_out2, hz_out6, hz_out4, 8, hz_out1,
++               hz_out3, hz_out5);
+     hz_out7 = (v8u16) __msa_pckod_d((v2i64) hz_out8, (v2i64) hz_out6);
+ 
+     ILVEV_B2_UB(hz_out0, hz_out1, hz_out2, hz_out3, vec0, vec1);
+diff --git a/libavcodec/mips/vp9_idct_msa.c b/libavcodec/mips/vp9_idct_msa.c
+index a3f5270b73..53bfbb4765 100644
+--- a/libavcodec/mips/vp9_idct_msa.c
++++ b/libavcodec/mips/vp9_idct_msa.c
+@@ -249,6 +249,7 @@ static const int32_t sinpi_4_9 = 15212;
+     v8i16 c0_m, c1_m, c2_m, c3_m;                                     \
+     v8i16 step0_m, step1_m;                                           \
+     v4i32 tmp0_m, tmp1_m, tmp2_m, tmp3_m;                             \
++    v16i8 zeros = { 0 };                                              \
+                                                                       \
+     c0_m = VP9_SET_COSPI_PAIR(cospi_16_64, cospi_16_64);              \
+     c1_m = VP9_SET_COSPI_PAIR(cospi_16_64, -cospi_16_64);             \
+@@ -262,7 +263,7 @@ static const int32_t sinpi_4_9 = 15212;
+     SRARI_W4_SW(tmp0_m, tmp1_m, tmp2_m, tmp3_m, VP9_DCT_CONST_BITS);  \
+                                                                       \
+     PCKEV_H2_SW(tmp1_m, tmp0_m, tmp3_m, tmp2_m, tmp0_m, tmp2_m);      \
+-    SLDI_B2_0_SW(tmp0_m, tmp2_m, tmp1_m, tmp3_m, 8);                  \
++    SLDI_B2_SW(zeros, tmp0_m, zeros, tmp2_m, 8, tmp1_m, tmp3_m);      \
+     BUTTERFLY_4((v8i16) tmp0_m, (v8i16) tmp1_m,                       \
+                 (v8i16) tmp2_m, (v8i16) tmp3_m,                       \
+                 out0, out1, out2, out3);                              \
+diff --git a/libavcodec/mips/vp9_lpf_msa.c b/libavcodec/mips/vp9_lpf_msa.c
+index 2450c741d4..cbb140950e 100644
+--- a/libavcodec/mips/vp9_lpf_msa.c
++++ b/libavcodec/mips/vp9_lpf_msa.c
+@@ -1673,6 +1673,7 @@ static void vp9_transpose_16x8_to_8x16(uint8_t *input, int32_t in_pitch,
+     v16u8 p7_org, p6_org, p5_org, p4_org, p3_org, p2_org, p1_org, p0_org;
+     v16i8 tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7;
+     v16u8 p7, p6, p5, p4, p3, p2, p1, p0, q0, q1, q2, q3, q4, q5, q6, q7;
++    v16i8 zeros = { 0 };
+ 
+     LD_UB8(input, in_pitch,
+            p7_org, p6_org, p5_org, p4_org, p3_org, p2_org, p1_org, p0_org);
+@@ -1686,7 +1687,7 @@ static void vp9_transpose_16x8_to_8x16(uint8_t *input, int32_t in_pitch,
+     ILVL_B2_SB(tmp1, tmp0, tmp3, tmp2, tmp5, tmp7);
+     ILVR_W2_UB(tmp6, tmp4, tmp7, tmp5, q0, q4);
+     ILVL_W2_UB(tmp6, tmp4, tmp7, tmp5, q2, q6);
+-    SLDI_B4_0_UB(q0, q2, q4, q6, q1, q3, q5, q7, 8);
++    SLDI_B4_UB(zeros, q0, zeros, q2, zeros, q4, zeros, q6, 8, q1, q3, q5, q7);
+ 
+     ST_UB8(p7, p6, p5, p4, p3, p2, p1, p0, output, out_pitch);
+     output += (8 * out_pitch);
+diff --git a/libavcodec/mips/vp9_mc_msa.c b/libavcodec/mips/vp9_mc_msa.c
+index 1d8a892768..57ea425727 100644
+--- a/libavcodec/mips/vp9_mc_msa.c
++++ b/libavcodec/mips/vp9_mc_msa.c
+@@ -795,7 +795,7 @@ static void common_hv_8ht_8vt_4w_msa(const uint8_t *src, int32_t src_stride,
+                               filt_hz1, filt_hz2, filt_hz3);
+     hz_out5 = HORIZ_8TAP_FILT(src5, src6, mask0, mask1, mask2, mask3, filt_hz0,
+                               filt_hz1, filt_hz2, filt_hz3);
+-    SLDI_B2_SH(hz_out2, hz_out4, hz_out0, hz_out2, hz_out1, hz_out3, 8);
++    SLDI_B2_SH(hz_out2, hz_out0, hz_out4, hz_out2, 8, hz_out1, hz_out3);
+ 
+     filt = LD_SH(filter_vert);
+     SPLATI_H4_SH(filt, 0, 1, 2, 3, filt_vt0, filt_vt1, filt_vt2, filt_vt3);
+@@ -1585,7 +1585,7 @@ static void common_hv_8ht_8vt_and_aver_dst_4w_msa(const uint8_t *src,
+                               filt_hz1, filt_hz2, filt_hz3);
+     hz_out5 = HORIZ_8TAP_FILT(src5, src6, mask0, mask1, mask2, mask3, filt_hz0,
+                               filt_hz1, filt_hz2, filt_hz3);
+-    SLDI_B2_SH(hz_out2, hz_out4, hz_out0, hz_out2, hz_out1, hz_out3, 8);
++    SLDI_B2_SH(hz_out2, hz_out0, hz_out4, hz_out2, 8, hz_out1, hz_out3);
+ 
+     filt = LD_SH(filter_vert);
+     SPLATI_H4_SH(filt, 0, 1, 2, 3, filt_vt0, filt_vt1, filt_vt2, filt_vt3);
+@@ -2093,7 +2093,7 @@ void ff_put_bilin_64h_msa(uint8_t *dst, ptrdiff_t dst_stride,
+         src4 = LD_SB(src + 32);
+         src6 = LD_SB(src + 48);
+         src7 = LD_SB(src + 56);
+-        SLDI_B3_SB(src2, src4, src6, src0, src2, src4, src1, src3, src5, 8);
++        SLDI_B3_SB(src2, src0, src4, src2, src6, src4, 8, src1, src3, src5);
+         src += src_stride;
+ 
+         VSHF_B2_UB(src0, src0, src1, src1, mask, mask, vec0, vec1);
+@@ -2544,8 +2544,8 @@ static void common_hv_2ht_2vt_4x8_msa(const uint8_t *src, int32_t src_stride,
+     hz_out4 = HORIZ_2TAP_FILT_UH(src4, src5, mask, filt_hz, 7);
+     hz_out6 = HORIZ_2TAP_FILT_UH(src6, src7, mask, filt_hz, 7);
+     hz_out8 = HORIZ_2TAP_FILT_UH(src8, src8, mask, filt_hz, 7);
+-    SLDI_B3_UH(hz_out2, hz_out4, hz_out6, hz_out0, hz_out2, hz_out4, hz_out1,
+-               hz_out3, hz_out5, 8);
++    SLDI_B3_UH(hz_out2, hz_out0, hz_out4, hz_out2, hz_out6, hz_out4, 8, hz_out1,
++               hz_out3, hz_out5);
+     hz_out7 = (v8u16) __msa_pckod_d((v2i64) hz_out8, (v2i64) hz_out6);
+ 
+     ILVEV_B2_UB(hz_out0, hz_out1, hz_out2, hz_out3, vec0, vec1);
+@@ -3146,7 +3146,7 @@ void ff_avg_bilin_64h_msa(uint8_t *dst, ptrdiff_t dst_stride,
+     for (loop_cnt = height; loop_cnt--;) {
+         LD_SB4(src, 16, src0, src2, src4, src6);
+         src7 = LD_SB(src + 56);
+-        SLDI_B3_SB(src2, src4, src6, src0, src2, src4, src1, src3, src5, 8);
++        SLDI_B3_SB(src2, src0, src4, src2, src6, src4, 8, src1, src3, src5);
+         src += src_stride;
+ 
+         VSHF_B2_UB(src0, src0, src1, src1, mask, mask, vec0, vec1);
+@@ -3655,8 +3655,8 @@ static void common_hv_2ht_2vt_and_aver_dst_4x8_msa(const uint8_t *src,
+     hz_out4 = HORIZ_2TAP_FILT_UH(src4, src5, mask, filt_hz, 7);
+     hz_out6 = HORIZ_2TAP_FILT_UH(src6, src7, mask, filt_hz, 7);
+     hz_out8 = HORIZ_2TAP_FILT_UH(src8, src8, mask, filt_hz, 7);
+-    SLDI_B3_UH(hz_out2, hz_out4, hz_out6, hz_out0, hz_out2, hz_out4, hz_out1,
+-               hz_out3, hz_out5, 8);
++    SLDI_B3_UH(hz_out2, hz_out0, hz_out4, hz_out2, hz_out6, hz_out4, 8, hz_out1,
++               hz_out3, hz_out5);
+     hz_out7 = (v8u16) __msa_pckod_d((v2i64) hz_out8, (v2i64) hz_out6);
+ 
+     LW4(dst, dst_stride, tp0, tp1, tp2, tp3);
+diff --git a/libavutil/mips/generic_macros_msa.h b/libavutil/mips/generic_macros_msa.h
+index 681d87c458..0061dc4daa 100644
+--- a/libavutil/mips/generic_macros_msa.h
++++ b/libavutil/mips/generic_macros_msa.h
+@@ -602,67 +602,48 @@
+ }
+ #define AVER_UB4_UB(...) AVER_UB4(v16u8, __VA_ARGS__)
+ 
+-/* Description : Immediate number of columns to slide with zero
+-   Arguments   : Inputs  - in0, in1, slide_val
+-                 Outputs - out0, out1
++/* Description : Immediate number of columns to slide
++   Arguments   : Inputs  - s, d, slide_val
++                 Outputs - out
+                  Return Type - as per RTYPE
+-   Details     : Byte elements from 'zero_m' vector are slide into 'in0' by
++   Details     : Byte elements from 'd' vector are slide into 's' by
+                  number of elements specified by 'slide_val'
+ */
+-#define SLDI_B2_0(RTYPE, in0, in1, out0, out1, slide_val)                 \
+-{                                                                         \
+-    v16i8 zero_m = { 0 };                                                 \
+-    out0 = (RTYPE) __msa_sldi_b((v16i8) zero_m, (v16i8) in0, slide_val);  \
+-    out1 = (RTYPE) __msa_sldi_b((v16i8) zero_m, (v16i8) in1, slide_val);  \
+-}
+-#define SLDI_B2_0_UB(...) SLDI_B2_0(v16u8, __VA_ARGS__)
+-#define SLDI_B2_0_SB(...) SLDI_B2_0(v16i8, __VA_ARGS__)
+-#define SLDI_B2_0_SW(...) SLDI_B2_0(v4i32, __VA_ARGS__)
+-
+-#define SLDI_B3_0(RTYPE, in0, in1, in2, out0, out1, out2,  slide_val)     \
+-{                                                                         \
+-    v16i8 zero_m = { 0 };                                                 \
+-    SLDI_B2_0(RTYPE, in0, in1, out0, out1, slide_val);                    \
+-    out2 = (RTYPE) __msa_sldi_b((v16i8) zero_m, (v16i8) in2, slide_val);  \
+-}
+-#define SLDI_B3_0_UB(...) SLDI_B3_0(v16u8, __VA_ARGS__)
+-#define SLDI_B3_0_SB(...) SLDI_B3_0(v16i8, __VA_ARGS__)
+-
+-#define SLDI_B4_0(RTYPE, in0, in1, in2, in3,            \
+-                  out0, out1, out2, out3, slide_val)    \
+-{                                                       \
+-    SLDI_B2_0(RTYPE, in0, in1, out0, out1, slide_val);  \
+-    SLDI_B2_0(RTYPE, in2, in3, out2, out3, slide_val);  \
++#define SLDI_B(RTYPE, d, s, slide_val, out)                       \
++{                                                                 \
++    out = (RTYPE) __msa_sldi_b((v16i8) d, (v16i8) s, slide_val);  \
+ }
+-#define SLDI_B4_0_UB(...) SLDI_B4_0(v16u8, __VA_ARGS__)
+-#define SLDI_B4_0_SB(...) SLDI_B4_0(v16i8, __VA_ARGS__)
+-#define SLDI_B4_0_SH(...) SLDI_B4_0(v8i16, __VA_ARGS__)
+ 
+-/* Description : Immediate number of columns to slide
+-   Arguments   : Inputs  - in0_0, in0_1, in1_0, in1_1, slide_val
+-                 Outputs - out0, out1
+-                 Return Type - as per RTYPE
+-   Details     : Byte elements from 'in0_0' vector are slide into 'in1_0' by
+-                 number of elements specified by 'slide_val'
+-*/
+-#define SLDI_B2(RTYPE, in0_0, in0_1, in1_0, in1_1, out0, out1, slide_val)  \
+-{                                                                          \
+-    out0 = (RTYPE) __msa_sldi_b((v16i8) in0_0, (v16i8) in1_0, slide_val);  \
+-    out1 = (RTYPE) __msa_sldi_b((v16i8) in0_1, (v16i8) in1_1, slide_val);  \
++#define SLDI_B2(RTYPE, d0, s0, d1, s1, slide_val, out0, out1)  \
++{                                                              \
++    SLDI_B(RTYPE, d0, s0, slide_val, out0)                     \
++    SLDI_B(RTYPE, d1, s1, slide_val, out1)                     \
+ }
+ #define SLDI_B2_UB(...) SLDI_B2(v16u8, __VA_ARGS__)
+ #define SLDI_B2_SB(...) SLDI_B2(v16i8, __VA_ARGS__)
+ #define SLDI_B2_SH(...) SLDI_B2(v8i16, __VA_ARGS__)
++#define SLDI_B2_SW(...) SLDI_B2(v4i32, __VA_ARGS__)
+ 
+-#define SLDI_B3(RTYPE, in0_0, in0_1, in0_2, in1_0, in1_1, in1_2,           \
+-                out0, out1, out2, slide_val)                               \
+-{                                                                          \
+-    SLDI_B2(RTYPE, in0_0, in0_1, in1_0, in1_1, out0, out1, slide_val)      \
+-    out2 = (RTYPE) __msa_sldi_b((v16i8) in0_2, (v16i8) in1_2, slide_val);  \
++#define SLDI_B3(RTYPE, d0, s0, d1, s1, d2, s2, slide_val,  \
++                out0, out1, out2)                          \
++{                                                          \
++    SLDI_B2(RTYPE, d0, s0, d1, s1, slide_val, out0, out1)  \
++    SLDI_B(RTYPE, d2, s2, slide_val, out2)                 \
+ }
++#define SLDI_B3_UB(...) SLDI_B3(v16u8, __VA_ARGS__)
+ #define SLDI_B3_SB(...) SLDI_B3(v16i8, __VA_ARGS__)
+ #define SLDI_B3_UH(...) SLDI_B3(v8u16, __VA_ARGS__)
+ 
++#define SLDI_B4(RTYPE, d0, s0, d1, s1, d2, s2, d3, s3,     \
++                slide_val, out0, out1, out2, out3)         \
++{                                                          \
++    SLDI_B2(RTYPE, d0, s0, d1, s1, slide_val, out0, out1)  \
++    SLDI_B2(RTYPE, d2, s2, d3, s3, slide_val, out2, out3)  \
++}
++#define SLDI_B4_UB(...) SLDI_B4(v16u8, __VA_ARGS__)
++#define SLDI_B4_SB(...) SLDI_B4(v16i8, __VA_ARGS__)
++#define SLDI_B4_SH(...) SLDI_B4(v8i16, __VA_ARGS__)
++
+ /* Description : Shuffle byte vector elements as per mask vector
+    Arguments   : Inputs  - in0, in1, in2, in3, mask0, mask1
+                  Outputs - out0, out1
+@@ -2412,6 +2393,7 @@
+ {                                                                        \
+     v16i8 tmp0_m, tmp1_m, tmp2_m, tmp3_m;                                \
+     v16i8 tmp4_m, tmp5_m, tmp6_m, tmp7_m;                                \
++    v16i8 zeros = { 0 };                                                 \
+                                                                          \
+     ILVR_B4_SB(in2, in0, in3, in1, in6, in4, in7, in5,                   \
+                tmp0_m, tmp1_m, tmp2_m, tmp3_m);                          \
+@@ -2419,8 +2401,8 @@
+     ILVRL_B2_SB(tmp3_m, tmp2_m, tmp6_m, tmp7_m);                         \
+     ILVRL_W2(RTYPE, tmp6_m, tmp4_m, out0, out2);                         \
+     ILVRL_W2(RTYPE, tmp7_m, tmp5_m, out4, out6);                         \
+-    SLDI_B2_0(RTYPE, out0, out2, out1, out3, 8);                         \
+-    SLDI_B2_0(RTYPE, out4, out6, out5, out7, 8);                         \
++    SLDI_B4(RTYPE, zeros, out0, zeros, out2, zeros, out4, zeros, out6,   \
++            8, out1, out3, out5, out7);                                  \
+ }
+ #define TRANSPOSE8x8_UB_UB(...) TRANSPOSE8x8_UB(v16u8, __VA_ARGS__)
+ #define TRANSPOSE8x8_UB_UH(...) TRANSPOSE8x8_UB(v8u16, __VA_ARGS__)
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0006-avcodec-mips-Fixed-four-warnings-in-vc1dsp.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0006-avcodec-mips-Fixed-four-warnings-in-vc1dsp.patch
@@ -1,0 +1,83 @@
+From ac0b5f1e71afb63e6d67ef787f4e44bf21bd12fb Mon Sep 17 00:00:00 2001
+From: gxw <guxiwei-hf@loongson.cn>
+Date: Sat, 12 Oct 2019 10:48:19 +0800
+Subject: [PATCH 06/26] avcodec/mips: Fixed four warnings in vc1dsp
+
+Change the stride argument to ptrdiff_t in the following functions:
+ff_put_no_rnd_vc1_chroma_mc8_mmi, ff_put_no_rnd_vc1_chroma_mc4_mmi,
+ff_avg_no_rnd_vc1_chroma_mc8_mmi, ff_avg_no_rnd_vc1_chroma_mc4_mmi.
+
+Reviewed-by: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/vc1dsp_mips.h | 8 ++++----
+ libavcodec/mips/vc1dsp_mmi.c  | 8 ++++----
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/libavcodec/mips/vc1dsp_mips.h b/libavcodec/mips/vc1dsp_mips.h
+index 0db85fac94..ad7d46e539 100644
+--- a/libavcodec/mips/vc1dsp_mips.h
++++ b/libavcodec/mips/vc1dsp_mips.h
+@@ -180,15 +180,15 @@ void ff_vc1_h_loop_filter16_mmi(uint8_t *src, int stride, int pq);
+ 
+ void ff_put_no_rnd_vc1_chroma_mc8_mmi(uint8_t *dst /* align 8 */,
+                                       uint8_t *src /* align 1 */,
+-                                      int stride, int h, int x, int y);
++                                      ptrdiff_t stride, int h, int x, int y);
+ void ff_put_no_rnd_vc1_chroma_mc4_mmi(uint8_t *dst /* align 8 */,
+                                       uint8_t *src /* align 1 */,
+-                                      int stride, int h, int x, int y);
++                                      ptrdiff_t stride, int h, int x, int y);
+ void ff_avg_no_rnd_vc1_chroma_mc8_mmi(uint8_t *dst /* align 8 */,
+                                       uint8_t *src /* align 1 */,
+-                                      int stride, int h, int x, int y);
++                                      ptrdiff_t stride, int h, int x, int y);
+ void ff_avg_no_rnd_vc1_chroma_mc4_mmi(uint8_t *dst /* align 8 */,
+                                       uint8_t *src /* align 1 */,
+-                                      int stride, int h, int x, int y);
++                                      ptrdiff_t stride, int h, int x, int y);
+ 
+ #endif /* AVCODEC_MIPS_VC1DSP_MIPS_H */
+diff --git a/libavcodec/mips/vc1dsp_mmi.c b/libavcodec/mips/vc1dsp_mmi.c
+index db314de496..98378683b8 100644
+--- a/libavcodec/mips/vc1dsp_mmi.c
++++ b/libavcodec/mips/vc1dsp_mmi.c
+@@ -2241,7 +2241,7 @@ DECLARE_FUNCTION(3, 3)
+ 
+ void ff_put_no_rnd_vc1_chroma_mc8_mmi(uint8_t *dst /* align 8 */,
+                                       uint8_t *src /* align 1 */,
+-                                      int stride, int h, int x, int y)
++                                      ptrdiff_t stride, int h, int x, int y)
+ {
+     const int A = (8 - x) * (8 - y);
+     const int B =     (x) * (8 - y);
+@@ -2296,7 +2296,7 @@ void ff_put_no_rnd_vc1_chroma_mc8_mmi(uint8_t *dst /* align 8 */,
+ 
+ void ff_put_no_rnd_vc1_chroma_mc4_mmi(uint8_t *dst /* align 8 */,
+                                       uint8_t *src /* align 1 */,
+-                                      int stride, int h, int x, int y)
++                                      ptrdiff_t stride, int h, int x, int y)
+ {
+     const int A = (8 - x) * (8 - y);
+     const int B =     (x) * (8 - y);
+@@ -2349,7 +2349,7 @@ void ff_put_no_rnd_vc1_chroma_mc4_mmi(uint8_t *dst /* align 8 */,
+ 
+ void ff_avg_no_rnd_vc1_chroma_mc8_mmi(uint8_t *dst /* align 8 */,
+                                       uint8_t *src /* align 1 */,
+-                                      int stride, int h, int x, int y)
++                                      ptrdiff_t stride, int h, int x, int y)
+ {
+     const int A = (8 - x) * (8 - y);
+     const int B =     (x) * (8 - y);
+@@ -2407,7 +2407,7 @@ void ff_avg_no_rnd_vc1_chroma_mc8_mmi(uint8_t *dst /* align 8 */,
+ 
+ void ff_avg_no_rnd_vc1_chroma_mc4_mmi(uint8_t *dst /* align 8 */,
+                                       uint8_t *src /* align 1 */,
+-                                      int stride, int h, int x, int y)
++                                      ptrdiff_t stride, int h, int x, int y)
+ {
+     const int A = (8 - x) * (8 - y);
+     const int B = (    x) * (8 - y);
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0007-avcodec-mips-msa-optimizations-for-vc1dsp.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0007-avcodec-mips-msa-optimizations-for-vc1dsp.patch
@@ -1,0 +1,615 @@
+From ffe4ee5eef898c6da814c50b298ba246db48d1f6 Mon Sep 17 00:00:00 2001
+From: gxw <guxiwei-hf@loongson.cn>
+Date: Mon, 21 Oct 2019 15:56:47 +0800
+Subject: [PATCH 07/26] avcodec/mips: msa optimizations for vc1dsp
+
+Performance of WMV3 decoding has speed up from 3.66x to 5.23x tested on 3A4000.
+
+Reviewed-by: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/Makefile            |   1 +
+ libavcodec/mips/vc1dsp_init_mips.c  |  30 +-
+ libavcodec/mips/vc1dsp_mips.h       |  23 ++
+ libavcodec/mips/vc1dsp_msa.c        | 461 ++++++++++++++++++++++++++++
+ libavutil/mips/generic_macros_msa.h |   3 +
+ 5 files changed, 514 insertions(+), 4 deletions(-)
+ create mode 100644 libavcodec/mips/vc1dsp_msa.c
+
+diff --git a/libavcodec/mips/Makefile b/libavcodec/mips/Makefile
+index c5b54d55c0..b4993f6e76 100644
+--- a/libavcodec/mips/Makefile
++++ b/libavcodec/mips/Makefile
+@@ -89,3 +89,4 @@ MMI-OBJS-$(CONFIG_WMV2DSP)                += mips/wmv2dsp_mmi.o
+ MMI-OBJS-$(CONFIG_HEVC_DECODER)           += mips/hevcdsp_mmi.o
+ MMI-OBJS-$(CONFIG_VP3DSP)                 += mips/vp3dsp_idct_mmi.o
+ MMI-OBJS-$(CONFIG_VP9_DECODER)            += mips/vp9_mc_mmi.o
++MSA-OBJS-$(CONFIG_VC1_DECODER)            += mips/vc1dsp_msa.o
+diff --git a/libavcodec/mips/vc1dsp_init_mips.c b/libavcodec/mips/vc1dsp_init_mips.c
+index 4adc9e1d4e..c0007ff650 100644
+--- a/libavcodec/mips/vc1dsp_init_mips.c
++++ b/libavcodec/mips/vc1dsp_init_mips.c
+@@ -23,6 +23,10 @@
+ #include "vc1dsp_mips.h"
+ #include "config.h"
+ 
++#define FN_ASSIGN(OP, X, Y, INSN) \
++    dsp->OP##vc1_mspel_pixels_tab[1][X+4*Y] = ff_##OP##vc1_mspel_mc##X##Y##INSN; \
++    dsp->OP##vc1_mspel_pixels_tab[0][X+4*Y] = ff_##OP##vc1_mspel_mc##X##Y##_16##INSN
++
+ #if HAVE_MMI
+ static av_cold void vc1dsp_init_mmi(VC1DSPContext *dsp)
+ {
+@@ -49,10 +53,6 @@ static av_cold void vc1dsp_init_mmi(VC1DSPContext *dsp)
+     dsp->vc1_v_loop_filter16 = ff_vc1_v_loop_filter16_mmi;
+     dsp->vc1_h_loop_filter16 = ff_vc1_h_loop_filter16_mmi;
+ 
+-#define FN_ASSIGN(OP, X, Y, INSN) \
+-    dsp->OP##vc1_mspel_pixels_tab[1][X+4*Y] = ff_##OP##vc1_mspel_mc##X##Y##INSN; \
+-    dsp->OP##vc1_mspel_pixels_tab[0][X+4*Y] = ff_##OP##vc1_mspel_mc##X##Y##_16##INSN
+-
+     FN_ASSIGN(put_, 0, 0, _mmi);
+     FN_ASSIGN(put_, 0, 1, _mmi);
+     FN_ASSIGN(put_, 0, 2, _mmi);
+@@ -100,9 +100,31 @@ static av_cold void vc1dsp_init_mmi(VC1DSPContext *dsp)
+ }
+ #endif /* HAVE_MMI */
+ 
++#if HAVE_MSA
++static av_cold void vc1dsp_init_msa(VC1DSPContext *dsp)
++{
++    dsp->vc1_inv_trans_8x8 = ff_vc1_inv_trans_8x8_msa;
++    dsp->vc1_inv_trans_4x8 = ff_vc1_inv_trans_4x8_msa;
++    dsp->vc1_inv_trans_8x4 = ff_vc1_inv_trans_8x4_msa;
++
++    FN_ASSIGN(put_, 1, 1, _msa);
++    FN_ASSIGN(put_, 1, 2, _msa);
++    FN_ASSIGN(put_, 1, 3, _msa);
++    FN_ASSIGN(put_, 2, 1, _msa);
++    FN_ASSIGN(put_, 2, 2, _msa);
++    FN_ASSIGN(put_, 2, 3, _msa);
++    FN_ASSIGN(put_, 3, 1, _msa);
++    FN_ASSIGN(put_, 3, 2, _msa);
++    FN_ASSIGN(put_, 3, 3, _msa);
++}
++#endif /* HAVE_MSA */
++
+ av_cold void ff_vc1dsp_init_mips(VC1DSPContext *dsp)
+ {
+ #if HAVE_MMI
+     vc1dsp_init_mmi(dsp);
+ #endif /* HAVE_MMI */
++#if HAVE_MSA
++    vc1dsp_init_msa(dsp);
++#endif /* HAVE_MSA */
+ }
+diff --git a/libavcodec/mips/vc1dsp_mips.h b/libavcodec/mips/vc1dsp_mips.h
+index ad7d46e539..5897daea8c 100644
+--- a/libavcodec/mips/vc1dsp_mips.h
++++ b/libavcodec/mips/vc1dsp_mips.h
+@@ -191,4 +191,27 @@ void ff_avg_no_rnd_vc1_chroma_mc4_mmi(uint8_t *dst /* align 8 */,
+                                       uint8_t *src /* align 1 */,
+                                       ptrdiff_t stride, int h, int x, int y);
+ 
++void ff_vc1_inv_trans_8x8_msa(int16_t block[64]);
++void ff_vc1_inv_trans_8x4_msa(uint8_t *dest, ptrdiff_t linesize, int16_t *block);
++void ff_vc1_inv_trans_4x8_msa(uint8_t *dest, ptrdiff_t linesize, int16_t *block);
++
++#define FF_PUT_VC1_MSPEL_MC_MSA(hmode, vmode)                                 \
++void ff_put_vc1_mspel_mc ## hmode ## vmode ## _msa(uint8_t *dst,              \
++                                                  const uint8_t *src,         \
++                                                  ptrdiff_t stride, int rnd); \
++void ff_put_vc1_mspel_mc ## hmode ## vmode ## _16_msa(uint8_t *dst,           \
++                                                  const uint8_t *src,         \
++                                                  ptrdiff_t stride, int rnd);
++
++FF_PUT_VC1_MSPEL_MC_MSA(1, 1);
++FF_PUT_VC1_MSPEL_MC_MSA(1, 2);
++FF_PUT_VC1_MSPEL_MC_MSA(1, 3);
++
++FF_PUT_VC1_MSPEL_MC_MSA(2, 1);
++FF_PUT_VC1_MSPEL_MC_MSA(2, 2);
++FF_PUT_VC1_MSPEL_MC_MSA(2, 3);
++
++FF_PUT_VC1_MSPEL_MC_MSA(3, 1);
++FF_PUT_VC1_MSPEL_MC_MSA(3, 2);
++FF_PUT_VC1_MSPEL_MC_MSA(3, 3);
+ #endif /* AVCODEC_MIPS_VC1DSP_MIPS_H */
+diff --git a/libavcodec/mips/vc1dsp_msa.c b/libavcodec/mips/vc1dsp_msa.c
+new file mode 100644
+index 0000000000..6e588e825a
+--- /dev/null
++++ b/libavcodec/mips/vc1dsp_msa.c
+@@ -0,0 +1,461 @@
++/*
++ * Loongson SIMD optimized vc1dsp
++ *
++ * Copyright (c) 2019 Loongson Technology Corporation Limited
++ *                    gxw <guxiwei-hf@loongson.cn>
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "vc1dsp_mips.h"
++#include "constants.h"
++#include "libavutil/mips/generic_macros_msa.h"
++
++void ff_vc1_inv_trans_8x8_msa(int16_t block[64])
++{
++    v8i16 in0, in1, in2, in3, in4, in5, in6, in7;
++    v4i32 in_r0, in_r1, in_r2, in_r3, in_r4, in_r5, in_r6, in_r7;
++    v4i32 in_l0, in_l1, in_l2, in_l3, in_l4, in_l5, in_l6, in_l7;
++    v4i32 t_r1, t_r2, t_r3, t_r4, t_r5, t_r6, t_r7, t_r8;
++    v4i32 t_l1, t_l2, t_l3, t_l4, t_l5, t_l6, t_l7, t_l8;
++    v4i32 cnst_12 = {12, 12, 12, 12};
++    v4i32 cnst_4 = {4, 4, 4, 4};
++    v4i32 cnst_16 = {16, 16, 16, 16};
++    v4i32 cnst_6 = {6, 6, 6, 6};
++    v4i32 cnst_15 = {15, 15, 15, 15};
++    v4i32 cnst_9 = {9, 9, 9, 9};
++    v4i32 cnst_1 = {1, 1, 1, 1};
++    v4i32 cnst_64 = {64, 64, 64, 64};
++
++    LD_SH8(block, 8, in0, in1, in2, in3, in4, in5, in6, in7);
++    UNPCK_SH_SW(in0, in_r0, in_l0);
++    UNPCK_SH_SW(in1, in_r1, in_l1);
++    UNPCK_SH_SW(in2, in_r2, in_l2);
++    UNPCK_SH_SW(in3, in_r3, in_l3);
++    UNPCK_SH_SW(in4, in_r4, in_l4);
++    UNPCK_SH_SW(in5, in_r5, in_l5);
++    UNPCK_SH_SW(in6, in_r6, in_l6);
++    UNPCK_SH_SW(in7, in_r7, in_l7);
++    // First loop
++    t_r1 = cnst_12 * (in_r0 + in_r4) + cnst_4;
++    t_l1 = cnst_12 * (in_l0 + in_l4) + cnst_4;
++    t_r2 = cnst_12 * (in_r0 - in_r4) + cnst_4;
++    t_l2 = cnst_12 * (in_l0 - in_l4) + cnst_4;
++    t_r3 = cnst_16 * in_r2 + cnst_6 * in_r6;
++    t_l3 = cnst_16 * in_l2 + cnst_6 * in_l6;
++    t_r4 = cnst_6 * in_r2 - cnst_16 * in_r6;
++    t_l4 = cnst_6 * in_l2 - cnst_16 * in_l6;
++
++    ADD4(t_r1, t_r3, t_l1, t_l3, t_r2, t_r4, t_l2, t_l4, t_r5, t_l5, t_r6, t_l6);
++    SUB4(t_r2, t_r4, t_l2, t_l4, t_r1, t_r3, t_l1, t_l3, t_r7, t_l7, t_r8, t_l8);
++    t_r1 = cnst_16 * in_r1 + cnst_15 * in_r3 + cnst_9 * in_r5 + cnst_4 * in_r7;
++    t_l1 = cnst_16 * in_l1 + cnst_15 * in_l3 + cnst_9 * in_l5 + cnst_4 * in_l7;
++    t_r2 = cnst_15 * in_r1 - cnst_4 * in_r3 - cnst_16 * in_r5 - cnst_9 * in_r7;
++    t_l2 = cnst_15 * in_l1 - cnst_4 * in_l3 - cnst_16 * in_l5 - cnst_9 * in_l7;
++    t_r3 = cnst_9 * in_r1 - cnst_16 * in_r3 + cnst_4 * in_r5 + cnst_15 * in_r7;
++    t_l3 = cnst_9 * in_l1 - cnst_16 * in_l3 + cnst_4 * in_l5 + cnst_15 * in_l7;
++    t_r4 = cnst_4 * in_r1 - cnst_9 * in_r3 + cnst_15 * in_r5 - cnst_16 * in_r7;
++    t_l4 = cnst_4 * in_l1 - cnst_9 * in_l3 + cnst_15 * in_l5 - cnst_16 * in_l7;
++
++    in_r0 = (t_r5 + t_r1) >> 3;
++    in_l0 = (t_l5 + t_l1) >> 3;
++    in_r1 = (t_r6 + t_r2) >> 3;
++    in_l1 = (t_l6 + t_l2) >> 3;
++    in_r2 = (t_r7 + t_r3) >> 3;
++    in_l2 = (t_l7 + t_l3) >> 3;
++    in_r3 = (t_r8 + t_r4) >> 3;
++    in_l3 = (t_l8 + t_l4) >> 3;
++
++    in_r4 = (t_r8 - t_r4) >> 3;
++    in_l4 = (t_l8 - t_l4) >> 3;
++    in_r5 = (t_r7 - t_r3) >> 3;
++    in_l5 = (t_l7 - t_l3) >> 3;
++    in_r6 = (t_r6 - t_r2) >> 3;
++    in_l6 = (t_l6 - t_l2) >> 3;
++    in_r7 = (t_r5 - t_r1) >> 3;
++    in_l7 = (t_l5 - t_l1) >> 3;
++    TRANSPOSE4x4_SW_SW(in_r0, in_r1, in_r2, in_r3, in_r0, in_r1, in_r2, in_r3);
++    TRANSPOSE4x4_SW_SW(in_l0, in_l1, in_l2, in_l3, in_l0, in_l1, in_l2, in_l3);
++    TRANSPOSE4x4_SW_SW(in_r4, in_r5, in_r6, in_r7, in_r4, in_r5, in_r6, in_r7);
++    TRANSPOSE4x4_SW_SW(in_l4, in_l5, in_l6, in_l7, in_l4, in_l5, in_l6, in_l7);
++    // Second loop
++    t_r1 = cnst_12 * (in_r0 + in_l0) + cnst_64;
++    t_l1 = cnst_12 * (in_r4 + in_l4) + cnst_64;
++    t_r2 = cnst_12 * (in_r0 - in_l0) + cnst_64;
++    t_l2 = cnst_12 * (in_r4 - in_l4) + cnst_64;
++    t_r3 = cnst_16 * in_r2 + cnst_6 * in_l2;
++    t_l3 = cnst_16 * in_r6 + cnst_6 * in_l6;
++    t_r4 = cnst_6 * in_r2 - cnst_16 * in_l2;
++    t_l4 = cnst_6 * in_r6 - cnst_16 * in_l6;
++
++    ADD4(t_r1, t_r3, t_l1, t_l3, t_r2, t_r4, t_l2, t_l4, t_r5, t_l5, t_r6, t_l6);
++    SUB4(t_r2, t_r4, t_l2, t_l4, t_r1, t_r3, t_l1, t_l3, t_r7, t_l7, t_r8, t_l8);
++    t_r1 = cnst_16 * in_r1 + cnst_15 * in_r3 + cnst_9 * in_l1 + cnst_4 * in_l3;
++    t_l1 = cnst_16 * in_r5 + cnst_15 * in_r7 + cnst_9 * in_l5 + cnst_4 * in_l7;
++    t_r2 = cnst_15 * in_r1 - cnst_4 * in_r3 - cnst_16 * in_l1 - cnst_9 * in_l3;
++    t_l2 = cnst_15 * in_r5 - cnst_4 * in_r7 - cnst_16 * in_l5 - cnst_9 * in_l7;
++    t_r3 = cnst_9 * in_r1 - cnst_16 * in_r3 + cnst_4 * in_l1 + cnst_15 * in_l3;
++    t_l3 = cnst_9 * in_r5 - cnst_16 * in_r7 + cnst_4 * in_l5 + cnst_15 * in_l7;
++    t_r4 = cnst_4 * in_r1 - cnst_9 * in_r3 + cnst_15 * in_l1 - cnst_16 * in_l3;
++    t_l4 = cnst_4 * in_r5 - cnst_9 * in_r7 + cnst_15 * in_l5 - cnst_16 * in_l7;
++
++    in_r0 = (t_r5 + t_r1) >> 7;
++    in_l0 = (t_l5 + t_l1) >> 7;
++    in_r1 = (t_r6 + t_r2) >> 7;
++    in_l1 = (t_l6 + t_l2) >> 7;
++    in_r2 = (t_r7 + t_r3) >> 7;
++    in_l2 = (t_l7 + t_l3) >> 7;
++    in_r3 = (t_r8 + t_r4) >> 7;
++    in_l3 = (t_l8 + t_l4) >> 7;
++
++    in_r4 = (t_r8 - t_r4 + cnst_1) >> 7;
++    in_l4 = (t_l8 - t_l4 + cnst_1) >> 7;
++    in_r5 = (t_r7 - t_r3 + cnst_1) >> 7;
++    in_l5 = (t_l7 - t_l3 + cnst_1) >> 7;
++    in_r6 = (t_r6 - t_r2 + cnst_1) >> 7;
++    in_l6 = (t_l6 - t_l2 + cnst_1) >> 7;
++    in_r7 = (t_r5 - t_r1 + cnst_1) >> 7;
++    in_l7 = (t_l5 - t_l1 + cnst_1) >> 7;
++    PCKEV_H4_SH(in_l0, in_r0, in_l1, in_r1, in_l2, in_r2, in_l3, in_r3,
++                in0, in1, in2, in3);
++    PCKEV_H4_SH(in_l4, in_r4, in_l5, in_r5, in_l6, in_r6, in_l7, in_r7,
++                in4, in5, in6, in7);
++    ST_SH8(in0, in1, in2, in3, in4, in5, in6, in7, block, 8);
++}
++
++void ff_vc1_inv_trans_4x8_msa(uint8_t *dest, ptrdiff_t linesize, int16_t *block)
++{
++    v8i16 in0, in1, in2, in3, in4, in5, in6, in7;
++    v4i32 in_r0, in_r1, in_r2, in_r3, in_r4, in_r5, in_r6, in_r7;
++    v4i32 t1, t2, t3, t4, t5, t6, t7, t8;
++    v4i32 dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7;
++    v16i8 zero_m = { 0 };
++    v4i32 cnst_17 = {17, 17, 17, 17};
++    v4i32 cnst_22 = {22, 22, 22, 22};
++    v4i32 cnst_10 = {10, 10, 10, 10};
++    v4i32 cnst_12 = {12, 12, 12, 12};
++    v4i32 cnst_64 = {64, 64, 64, 64};
++    v4i32 cnst_16 = {16, 16, 16, 16};
++    v4i32 cnst_15 = {15, 15, 15, 15};
++    v4i32 cnst_4 = {4, 4, 4, 4};
++    v4i32 cnst_6 = {6, 6, 6, 6};
++    v4i32 cnst_9 = {9, 9, 9, 9};
++    v4i32 cnst_1 = {1, 1, 1, 1};
++
++    LD_SH8(block, 8, in0, in1, in2, in3, in4, in5, in6, in7);
++    UNPCK_R_SH_SW(in0, in_r0);
++    UNPCK_R_SH_SW(in1, in_r1);
++    UNPCK_R_SH_SW(in2, in_r2);
++    UNPCK_R_SH_SW(in3, in_r3);
++    UNPCK_R_SH_SW(in4, in_r4);
++    UNPCK_R_SH_SW(in5, in_r5);
++    UNPCK_R_SH_SW(in6, in_r6);
++    UNPCK_R_SH_SW(in7, in_r7);
++    // First loop
++    TRANSPOSE4x4_SW_SW(in_r0, in_r1, in_r2, in_r3, in_r0, in_r1, in_r2, in_r3);
++    TRANSPOSE4x4_SW_SW(in_r4, in_r5, in_r6, in_r7, in_r4, in_r5, in_r6, in_r7);
++    t1 = cnst_17 * (in_r0 + in_r2) + cnst_4;
++    t5 = cnst_17 * (in_r4 + in_r6) + cnst_4;
++    t2 = cnst_17 * (in_r0 - in_r2) + cnst_4;
++    t6 = cnst_17 * (in_r4 - in_r6) + cnst_4;
++    t3 = cnst_22 * in_r1 + cnst_10 * in_r3;
++    t7 = cnst_22 * in_r5 + cnst_10 * in_r7;
++    t4 = cnst_22 * in_r3 - cnst_10 * in_r1;
++    t8 = cnst_22 * in_r7 - cnst_10 * in_r5;
++
++    in_r0 = (t1 + t3) >> 3;
++    in_r4 = (t5 + t7) >> 3;
++    in_r1 = (t2 - t4) >> 3;
++    in_r5 = (t6 - t8) >> 3;
++    in_r2 = (t2 + t4) >> 3;
++    in_r6 = (t6 + t8) >> 3;
++    in_r3 = (t1 - t3) >> 3;
++    in_r7 = (t5 - t7) >> 3;
++    TRANSPOSE4x4_SW_SW(in_r0, in_r1, in_r2, in_r3, in_r0, in_r1, in_r2, in_r3);
++    TRANSPOSE4x4_SW_SW(in_r4, in_r5, in_r6, in_r7, in_r4, in_r5, in_r6, in_r7);
++    PCKEV_H4_SH(in_r1, in_r0, in_r3, in_r2, in_r5, in_r4, in_r7, in_r6,
++                in0, in1, in2, in3);
++    ST_D8(in0, in1, in2, in3, 0, 1, 0, 1, 0, 1, 0, 1, block, 8);
++    // Second loop
++    t1 = cnst_12 * (in_r0 + in_r4) + cnst_64;
++    t2 = cnst_12 * (in_r0 - in_r4) + cnst_64;
++    t3 = cnst_16 * in_r2 + cnst_6 * in_r6;
++    t4 = cnst_6 * in_r2 - cnst_16 * in_r6;
++    t5 = t1 + t3, t6 = t2 + t4;
++    t7 = t2 - t4, t8 = t1 - t3;
++    t1 = cnst_16 * in_r1 + cnst_15 * in_r3 + cnst_9 * in_r5 + cnst_4 * in_r7;
++    t2 = cnst_15 * in_r1 - cnst_4 * in_r3 - cnst_16 * in_r5 - cnst_9 * in_r7;
++    t3 = cnst_9 * in_r1 - cnst_16 * in_r3 + cnst_4 * in_r5 + cnst_15 * in_r7;
++    t4 = cnst_4 * in_r1 - cnst_9 * in_r3 + cnst_15 * in_r5 - cnst_16 * in_r7;
++    LD_SW8(dest, linesize, dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
++    ILVR_B8_SW(zero_m, dst0, zero_m, dst1, zero_m, dst2, zero_m, dst3,
++               zero_m, dst4, zero_m, dst5, zero_m, dst6, zero_m, dst7,
++               dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
++    ILVR_H4_SW(zero_m, dst0, zero_m, dst1, zero_m, dst2, zero_m, dst3,
++               dst0, dst1, dst2, dst3);
++    ILVR_H4_SW(zero_m, dst4, zero_m, dst5, zero_m, dst6, zero_m, dst7,
++               dst4, dst5, dst6, dst7);
++    in_r0 = (t5 + t1) >> 7;
++    in_r1 = (t6 + t2) >> 7;
++    in_r2 = (t7 + t3) >> 7;
++    in_r3 = (t8 + t4) >> 7;
++    in_r4 = (t8 - t4 + cnst_1) >> 7;
++    in_r5 = (t7 - t3 + cnst_1) >> 7;
++    in_r6 = (t6 - t2 + cnst_1) >> 7;
++    in_r7 = (t5 - t1 + cnst_1) >> 7;
++    ADD4(in_r0, dst0, in_r1, dst1, in_r2, dst2, in_r3, dst3,
++         in_r0, in_r1, in_r2, in_r3);
++    ADD4(in_r4, dst4, in_r5, dst5, in_r6, dst6, in_r7, dst7,
++         in_r4, in_r5, in_r6, in_r7);
++    CLIP_SW8_0_255(in_r0, in_r1, in_r2, in_r3, in_r4, in_r5, in_r6, in_r7);
++    PCKEV_H4_SH(in_r1, in_r0, in_r3, in_r2, in_r5, in_r4, in_r7, in_r6,
++                in0, in1, in2, in3);
++    PCKEV_B2_SH(in1, in0, in3, in2, in0, in1);
++    ST_W8(in0, in1, 0, 1, 2, 3, 0, 1, 2, 3, dest, linesize);
++}
++
++void ff_vc1_inv_trans_8x4_msa(uint8_t *dest, ptrdiff_t linesize, int16_t *block)
++{
++    v4i32 in0, in1, in2, in3, in4, in5, in6, in7;
++    v4i32 t1, t2, t3, t4, t5, t6, t7, t8;
++    v4i32 dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7;
++    v16i8 zero_m = { 0 };
++    v4i32 cnst_17 = {17, 17, 17, 17};
++    v4i32 cnst_22 = {22, 22, 22, 22};
++    v4i32 cnst_10 = {10, 10, 10, 10};
++    v4i32 cnst_12 = {12, 12, 12, 12};
++    v4i32 cnst_64 = {64, 64, 64, 64};
++    v4i32 cnst_16 = {16, 16, 16, 16};
++    v4i32 cnst_15 = {15, 15, 15, 15};
++    v4i32 cnst_4 = {4, 4, 4, 4};
++    v4i32 cnst_6 = {6, 6, 6, 6};
++    v4i32 cnst_9 = {9, 9, 9, 9};
++
++    LD_SW4(block, 8, t1, t2, t3, t4);
++    UNPCK_SH_SW(t1, in0, in4);
++    UNPCK_SH_SW(t2, in1, in5);
++    UNPCK_SH_SW(t3, in2, in6);
++    UNPCK_SH_SW(t4, in3, in7);
++    TRANSPOSE4x4_SW_SW(in0, in1, in2, in3, in0, in1, in2, in3);
++    TRANSPOSE4x4_SW_SW(in4, in5, in6, in7, in4, in5, in6, in7);
++    // First loop
++    t1 = cnst_12 * (in0 + in4) + cnst_4;
++    t2 = cnst_12 * (in0 - in4) + cnst_4;
++    t3 = cnst_16 * in2 + cnst_6 * in6;
++    t4 = cnst_6 * in2 - cnst_16 * in6;
++    t5 = t1 + t3, t6 = t2 + t4;
++    t7 = t2 - t4, t8 = t1 - t3;
++    t1 = cnst_16 * in1 + cnst_15 * in3 + cnst_9 * in5 + cnst_4 * in7;
++    t2 = cnst_15 * in1 - cnst_4 * in3 - cnst_16 * in5 - cnst_9 * in7;
++    t3 = cnst_9 * in1 - cnst_16 * in3 + cnst_4 * in5 + cnst_15 * in7;
++    t4 = cnst_4 * in1 - cnst_9 * in3 + cnst_15 * in5 - cnst_16 * in7;
++    in0 = (t5 + t1) >> 3;
++    in1 = (t6 + t2) >> 3;
++    in2 = (t7 + t3) >> 3;
++    in3 = (t8 + t4) >> 3;
++    in4 = (t8 - t4) >> 3;
++    in5 = (t7 - t3) >> 3;
++    in6 = (t6 - t2) >> 3;
++    in7 = (t5 - t1) >> 3;
++    TRANSPOSE4x4_SW_SW(in0, in1, in2, in3, in0, in1, in2, in3);
++    TRANSPOSE4x4_SW_SW(in4, in5, in6, in7, in4, in5, in6, in7);
++    PCKEV_H4_SW(in4, in0, in5, in1, in6, in2, in7, in3, t1, t2, t3, t4);
++    ST_SW4(t1, t2, t3, t4, block, 8);
++    // Second loop
++    LD_SW4(dest, linesize, dst0, dst1, dst2, dst3);
++    ILVR_B4_SW(zero_m, dst0, zero_m, dst1, zero_m, dst2, zero_m, dst3,
++               dst0, dst1, dst2, dst3);
++    ILVL_H4_SW(zero_m, dst0, zero_m, dst1, zero_m, dst2, zero_m, dst3,
++               dst4, dst5, dst6, dst7);
++    ILVR_H4_SW(zero_m, dst0, zero_m, dst1, zero_m, dst2, zero_m, dst3,
++               dst0, dst1, dst2, dst3);
++    // Right part
++    t1 = cnst_17 * (in0 + in2) + cnst_64;
++    t2 = cnst_17 * (in0 - in2) + cnst_64;
++    t3 = cnst_22 * in1 + cnst_10 * in3;
++    t4 = cnst_22 * in3 - cnst_10 * in1;
++    in0 = (t1 + t3) >> 7;
++    in1 = (t2 - t4) >> 7;
++    in2 = (t2 + t4) >> 7;
++    in3 = (t1 - t3) >> 7;
++    ADD4(in0, dst0, in1, dst1, in2, dst2, in3, dst3, in0, in1, in2, in3);
++    CLIP_SW4_0_255(in0, in1, in2, in3);
++    // Left part
++    t5 = cnst_17 * (in4 + in6) + cnst_64;
++    t6 = cnst_17 * (in4 - in6) + cnst_64;
++    t7 = cnst_22 * in5 + cnst_10 * in7;
++    t8 = cnst_22 * in7 - cnst_10 * in5;
++    in4 = (t5 + t7) >> 7;
++    in5 = (t6 - t8) >> 7;
++    in6 = (t6 + t8) >> 7;
++    in7 = (t5 - t7) >> 7;
++    ADD4(in4, dst4, in5, dst5, in6, dst6, in7, dst7, in4, in5, in6, in7);
++    CLIP_SW4_0_255(in4, in5, in6, in7);
++    PCKEV_H4_SW(in4, in0, in5, in1, in6, in2, in7, in3, in0, in1, in2, in3);
++    PCKEV_B2_SW(in1, in0, in3, in2, in0, in1);
++    ST_D4(in0, in1, 0, 1, 0, 1, dest, linesize);
++}
++
++static void put_vc1_mspel_mc_h_v_msa(uint8_t *dst, const uint8_t *src,
++                                     ptrdiff_t stride, int hmode, int vmode,
++                                     int rnd)
++{
++    v8i16 in_r0, in_r1, in_r2, in_r3, in_l0, in_l1, in_l2, in_l3;
++    v8i16 t0, t1, t2, t3, t4, t5, t6, t7;
++    v8i16 t8, t9, t10, t11, t12, t13, t14, t15;
++    v8i16 cnst_para0, cnst_para1, cnst_para2, cnst_para3, cnst_r;
++    static const int para_value[][4] = {{4, 53, 18, 3},
++                                        {1, 9, 9, 1},
++                                        {3, 18, 53, 4}};
++    static const int shift_value[] = {0, 5, 1, 5};
++    int shift = (shift_value[hmode] + shift_value[vmode]) >> 1;
++    int r = (1 << (shift - 1)) + rnd - 1;
++    cnst_r = __msa_fill_h(r);
++    src -= 1, src -= stride;
++    cnst_para0 = __msa_fill_h(para_value[vmode - 1][0]);
++    cnst_para1 = __msa_fill_h(para_value[vmode - 1][1]);
++    cnst_para2 = __msa_fill_h(para_value[vmode - 1][2]);
++    cnst_para3 = __msa_fill_h(para_value[vmode - 1][3]);
++    LD_SH4(src, stride, in_l0, in_l1, in_l2, in_l3);
++    UNPCK_UB_SH(in_l0, in_r0, in_l0);
++    UNPCK_UB_SH(in_l1, in_r1, in_l1);
++    UNPCK_UB_SH(in_l2, in_r2, in_l2);
++    UNPCK_UB_SH(in_l3, in_r3, in_l3);
++    // row 0
++    t0 = cnst_para1 * in_r1 + cnst_para2 * in_r2
++         - cnst_para0 * in_r0 - cnst_para3 * in_r3;
++    t8 = cnst_para1 * in_l1 + cnst_para2 * in_l2
++         - cnst_para0 * in_l0 - cnst_para3 * in_l3;
++    in_l0 = LD_SH(src + 4 * stride);
++    UNPCK_UB_SH(in_l0, in_r0, in_l0);
++    // row 1
++    t1 = cnst_para1 * in_r2 + cnst_para2 * in_r3
++         - cnst_para0 * in_r1 - cnst_para3 * in_r0;
++    t9 = cnst_para1 * in_l2 + cnst_para2 * in_l3
++         - cnst_para0 * in_l1 - cnst_para3 * in_l0;
++    in_l1 = LD_SH(src + 5 * stride);
++    UNPCK_UB_SH(in_l1, in_r1, in_l1);
++    // row 2
++    t2 = cnst_para1 * in_r3 + cnst_para2 * in_r0
++         - cnst_para0 * in_r2 - cnst_para3 * in_r1;
++    t10 = cnst_para1 * in_l3 + cnst_para2 * in_l0
++          - cnst_para0 * in_l2 - cnst_para3 * in_l1;
++    in_l2 = LD_SH(src + 6 * stride);
++    UNPCK_UB_SH(in_l2, in_r2, in_l2);
++    // row 3
++    t3 = cnst_para1 * in_r0 + cnst_para2 * in_r1
++         - cnst_para0 * in_r3 - cnst_para3 * in_r2;
++    t11 = cnst_para1 * in_l0 + cnst_para2 * in_l1
++          - cnst_para0 * in_l3 - cnst_para3 * in_l2;
++    in_l3 = LD_SH(src + 7 * stride);
++    UNPCK_UB_SH(in_l3, in_r3, in_l3);
++    // row 4
++    t4 = cnst_para1 * in_r1 + cnst_para2 * in_r2
++         - cnst_para0 * in_r0 - cnst_para3 * in_r3;
++    t12 = cnst_para1 * in_l1 + cnst_para2 * in_l2
++          - cnst_para0 * in_l0 - cnst_para3 * in_l3;
++    in_l0 = LD_SH(src + 8 * stride);
++    UNPCK_UB_SH(in_l0, in_r0, in_l0);
++    // row 5
++    t5 = cnst_para1 * in_r2 + cnst_para2 * in_r3
++         - cnst_para0 * in_r1 - cnst_para3 * in_r0;
++    t13 = cnst_para1 * in_l2 + cnst_para2 * in_l3
++          - cnst_para0 * in_l1 - cnst_para3 * in_l0;
++    in_l1 = LD_SH(src + 9 * stride);
++    UNPCK_UB_SH(in_l1, in_r1, in_l1);
++    // row 6
++    t6 = cnst_para1 * in_r3 + cnst_para2 * in_r0
++         - cnst_para0 * in_r2 - cnst_para3 * in_r1;
++    t14 = cnst_para1 * in_l3 + cnst_para2 * in_l0
++          - cnst_para0 * in_l2 - cnst_para3 * in_l1;
++    in_l2 = LD_SH(src + 10 * stride);
++    UNPCK_UB_SH(in_l2, in_r2, in_l2);
++    // row 7
++    t7 = cnst_para1 * in_r0 + cnst_para2 * in_r1
++         - cnst_para0 * in_r3 - cnst_para3 * in_r2;
++    t15 = cnst_para1 * in_l0 + cnst_para2 * in_l1
++          - cnst_para0 * in_l3 - cnst_para3 * in_l2;
++
++    ADD4(t0, cnst_r, t1, cnst_r, t2, cnst_r, t3, cnst_r, t0, t1, t2, t3);
++    ADD4(t4, cnst_r, t5, cnst_r, t6, cnst_r, t7, cnst_r, t4, t5, t6, t7);
++    ADD4(t8, cnst_r, t9, cnst_r, t10, cnst_r, t11, cnst_r,
++         t8, t9, t10, t11);
++    ADD4(t12, cnst_r, t13, cnst_r, t14, cnst_r, t15, cnst_r,
++         t12, t13, t14, t15);
++    t0 >>= shift, t1 >>= shift, t2 >>= shift, t3 >>= shift;
++    t4 >>= shift, t5 >>= shift, t6 >>= shift, t7 >>= shift;
++    t8 >>= shift, t9 >>= shift, t10 >>= shift, t11 >>= shift;
++    t12 >>= shift, t13 >>= shift, t14 >>= shift, t15 >>= shift;
++    TRANSPOSE8x8_SH_SH(t0, t1, t2, t3, t4, t5, t6, t7,
++                       t0, t1, t2, t3, t4, t5, t6, t7);
++    TRANSPOSE8x8_SH_SH(t8, t9, t10, t11, t12, t13, t14, t15,
++                       t8, t9, t10, t11, t12, t13, t14, t15);
++    cnst_para0 = __msa_fill_h(para_value[hmode - 1][0]);
++    cnst_para1 = __msa_fill_h(para_value[hmode - 1][1]);
++    cnst_para2 = __msa_fill_h(para_value[hmode - 1][2]);
++    cnst_para3 = __msa_fill_h(para_value[hmode - 1][3]);
++    r = 64 - rnd;
++    cnst_r = __msa_fill_h(r);
++    // col 0 ~ 7
++    t0 = cnst_para1 * t1 + cnst_para2 * t2 - cnst_para0 * t0 - cnst_para3 * t3;
++    t1 = cnst_para1 * t2 + cnst_para2 * t3 - cnst_para0 * t1 - cnst_para3 * t4;
++    t2 = cnst_para1 * t3 + cnst_para2 * t4 - cnst_para0 * t2 - cnst_para3 * t5;
++    t3 = cnst_para1 * t4 + cnst_para2 * t5 - cnst_para0 * t3 - cnst_para3 * t6;
++    t4 = cnst_para1 * t5 + cnst_para2 * t6 - cnst_para0 * t4 - cnst_para3 * t7;
++    t5 = cnst_para1 * t6 + cnst_para2 * t7 - cnst_para0 * t5 - cnst_para3 * t8;
++    t6 = cnst_para1 * t7 + cnst_para2 * t8 - cnst_para0 * t6 - cnst_para3 * t9;
++    t7 = cnst_para1 * t8 + cnst_para2 * t9 - cnst_para0 * t7 - cnst_para3 * t10;
++    ADD4(t0, cnst_r, t1, cnst_r, t2, cnst_r, t3, cnst_r, t0, t1, t2, t3);
++    ADD4(t4, cnst_r, t5, cnst_r, t6, cnst_r, t7, cnst_r, t4, t5, t6, t7);
++    t0 >>= 7, t1 >>= 7, t2 >>= 7, t3 >>= 7;
++    t4 >>= 7, t5 >>= 7, t6 >>= 7, t7 >>= 7;
++    TRANSPOSE8x8_SH_SH(t0, t1, t2, t3, t4, t5, t6, t7,
++                       t0, t1, t2, t3, t4, t5, t6, t7);
++    CLIP_SH8_0_255(t0, t1, t2, t3, t4, t5, t6, t7);
++    PCKEV_B4_SH(t1, t0, t3, t2, t5, t4, t7, t6, t0, t1, t2, t3);
++    ST_D8(t0, t1, t2, t3, 0, 1, 0, 1, 0, 1, 0, 1, dst, stride);
++}
++
++#define PUT_VC1_MSPEL_MC_MSA(hmode, vmode)                                    \
++void ff_put_vc1_mspel_mc ## hmode ## vmode ## _msa(uint8_t *dst,              \
++                                                const uint8_t *src,           \
++                                                ptrdiff_t stride, int rnd)    \
++{                                                                             \
++    put_vc1_mspel_mc_h_v_msa(dst, src, stride, hmode, vmode, rnd);            \
++}                                                                             \
++void ff_put_vc1_mspel_mc ## hmode ## vmode ## _16_msa(uint8_t *dst,           \
++                                                   const uint8_t *src,        \
++                                                   ptrdiff_t stride, int rnd) \
++{                                                                             \
++    put_vc1_mspel_mc_h_v_msa(dst, src, stride, hmode, vmode, rnd);            \
++    put_vc1_mspel_mc_h_v_msa(dst + 8, src + 8, stride, hmode, vmode, rnd);    \
++    dst += 8 * stride, src += 8 * stride;                                     \
++    put_vc1_mspel_mc_h_v_msa(dst, src, stride, hmode, vmode, rnd);            \
++    put_vc1_mspel_mc_h_v_msa(dst + 8, src + 8, stride, hmode, vmode, rnd);    \
++}
++
++PUT_VC1_MSPEL_MC_MSA(1, 1);
++PUT_VC1_MSPEL_MC_MSA(1, 2);
++PUT_VC1_MSPEL_MC_MSA(1, 3);
++
++PUT_VC1_MSPEL_MC_MSA(2, 1);
++PUT_VC1_MSPEL_MC_MSA(2, 2);
++PUT_VC1_MSPEL_MC_MSA(2, 3);
++
++PUT_VC1_MSPEL_MC_MSA(3, 1);
++PUT_VC1_MSPEL_MC_MSA(3, 2);
++PUT_VC1_MSPEL_MC_MSA(3, 3);
+diff --git a/libavutil/mips/generic_macros_msa.h b/libavutil/mips/generic_macros_msa.h
+index 0061dc4daa..d49c7c37f6 100644
+--- a/libavutil/mips/generic_macros_msa.h
++++ b/libavutil/mips/generic_macros_msa.h
+@@ -299,6 +299,7 @@
+ #define LD_SB4(...) LD_V4(v16i8, __VA_ARGS__)
+ #define LD_UH4(...) LD_V4(v8u16, __VA_ARGS__)
+ #define LD_SH4(...) LD_V4(v8i16, __VA_ARGS__)
++#define LD_SW4(...) LD_V4(v4i32, __VA_ARGS__)
+ 
+ #define LD_V5(RTYPE, psrc, stride, out0, out1, out2, out3, out4)  \
+ {                                                                 \
+@@ -337,6 +338,7 @@
+ #define LD_SB8(...) LD_V8(v16i8, __VA_ARGS__)
+ #define LD_UH8(...) LD_V8(v8u16, __VA_ARGS__)
+ #define LD_SH8(...) LD_V8(v8i16, __VA_ARGS__)
++#define LD_SW8(...) LD_V8(v4i32, __VA_ARGS__)
+ 
+ #define LD_V16(RTYPE, psrc, stride,                                   \
+                out0, out1, out2, out3, out4, out5, out6, out7,        \
+@@ -1382,6 +1384,7 @@
+             out4, out5, out6, out7);                              \
+ }
+ #define ILVR_B8_UH(...) ILVR_B8(v8u16, __VA_ARGS__)
++#define ILVR_B8_SW(...) ILVR_B8(v4i32, __VA_ARGS__)
+ 
+ /* Description : Interleave right half of halfword elements from vectors
+    Arguments   : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0008-lavc-mips-simplify-the-switch-code.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0008-lavc-mips-simplify-the-switch-code.patch
@@ -1,0 +1,29 @@
+From c2fca81152d54249e47278c8755994f485904ed8 Mon Sep 17 00:00:00 2001
+From: Linjie Fu <linjie.fu@intel.com>
+Date: Wed, 11 Dec 2019 16:48:03 +0800
+Subject: [PATCH 08/26] lavc/mips: simplify the switch code
+
+Signed-off-by: Linjie Fu <linjie.fu@intel.com>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/h264pred_init_mips.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/libavcodec/mips/h264pred_init_mips.c b/libavcodec/mips/h264pred_init_mips.c
+index 63637b8732..e537ad8bd4 100644
+--- a/libavcodec/mips/h264pred_init_mips.c
++++ b/libavcodec/mips/h264pred_init_mips.c
+@@ -73,10 +73,7 @@ static av_cold void h264_pred_init_msa(H264PredContext *h, int codec_id,
+ 
+         switch (codec_id) {
+         case AV_CODEC_ID_SVQ3:
+-            ;
+-            break;
+         case AV_CODEC_ID_RV40:
+-            ;
+             break;
+         case AV_CODEC_ID_VP7:
+         case AV_CODEC_ID_VP8:
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0009-avcodec-aacdec-fix-compilation-under-soft-float-MIPS.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0009-avcodec-aacdec-fix-compilation-under-soft-float-MIPS.patch
@@ -1,0 +1,144 @@
+From 6a4fc88750356e5d0af721bded093cf3e9095e48 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sun, 5 Apr 2020 20:37:10 -0700
+Subject: [PATCH 09/26] avcodec/aacdec: fix compilation under soft float MIPS
+
+Place HAVE_MIPSFPU further up so that functions that use floating point
+ASM are defined away. Otherwise compilation failures result when soft
+float in enabled on the toolchain.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ libavcodec/mips/aacdec_mips.c   | 4 ++--
+ libavcodec/mips/aacpsdsp_mips.c | 4 ++--
+ libavcodec/mips/aacsbr_mips.c   | 4 ++--
+ libavcodec/mips/sbrdsp_mips.c   | 4 ++--
+ 4 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/libavcodec/mips/aacdec_mips.c b/libavcodec/mips/aacdec_mips.c
+index 01a2b3087b..8e30652935 100644
+--- a/libavcodec/mips/aacdec_mips.c
++++ b/libavcodec/mips/aacdec_mips.c
+@@ -59,6 +59,7 @@
+ #include "libavutil/mips/asmdefs.h"
+ 
+ #if HAVE_INLINE_ASM
++#if HAVE_MIPSFPU
+ static av_always_inline void float_copy(float *dst, const float *src, int count)
+ {
+     // Copy 'count' floats from src to dst
+@@ -282,7 +283,6 @@ static void apply_ltp_mips(AACContext *ac, SingleChannelElement *sce)
+     }
+ }
+ 
+-#if HAVE_MIPSFPU
+ static av_always_inline void fmul_and_reverse(float *dst, const float *src0, const float *src1, int count)
+ {
+     /* Multiply 'count' floats in src0 by src1 and store the results in dst in reverse */
+@@ -433,9 +433,9 @@ static void update_ltp_mips(AACContext *ac, SingleChannelElement *sce)
+ void ff_aacdec_init_mips(AACContext *c)
+ {
+ #if HAVE_INLINE_ASM
++#if HAVE_MIPSFPU
+     c->imdct_and_windowing         = imdct_and_windowing_mips;
+     c->apply_ltp                   = apply_ltp_mips;
+-#if HAVE_MIPSFPU
+     c->update_ltp                  = update_ltp_mips;
+ #endif /* HAVE_MIPSFPU */
+ #endif /* HAVE_INLINE_ASM */
+diff --git a/libavcodec/mips/aacpsdsp_mips.c b/libavcodec/mips/aacpsdsp_mips.c
+index 83fdc2f9db..ef47e31a9e 100644
+--- a/libavcodec/mips/aacpsdsp_mips.c
++++ b/libavcodec/mips/aacpsdsp_mips.c
+@@ -57,6 +57,7 @@
+ #include "libavutil/mips/asmdefs.h"
+ 
+ #if HAVE_INLINE_ASM
++#if HAVE_MIPSFPU
+ static void ps_hybrid_analysis_ileave_mips(float (*out)[32][2], float L[2][38][64],
+                                         int i, int len)
+ {
+@@ -187,7 +188,6 @@ static void ps_hybrid_synthesis_deint_mips(float out[2][38][64],
+     }
+ }
+ 
+-#if HAVE_MIPSFPU
+ #if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
+ static void ps_add_squares_mips(float *dst, const float (*src)[2], int n)
+ {
+@@ -450,9 +450,9 @@ static void ps_stereo_interpolate_mips(float (*l)[2], float (*r)[2],
+ void ff_psdsp_init_mips(PSDSPContext *s)
+ {
+ #if HAVE_INLINE_ASM
++#if HAVE_MIPSFPU
+     s->hybrid_analysis_ileave = ps_hybrid_analysis_ileave_mips;
+     s->hybrid_synthesis_deint = ps_hybrid_synthesis_deint_mips;
+-#if HAVE_MIPSFPU
+ #if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
+     s->add_squares            = ps_add_squares_mips;
+     s->mul_pair_single        = ps_mul_pair_single_mips;
+diff --git a/libavcodec/mips/aacsbr_mips.c b/libavcodec/mips/aacsbr_mips.c
+index 56aa4e8682..2e0cd723d7 100644
+--- a/libavcodec/mips/aacsbr_mips.c
++++ b/libavcodec/mips/aacsbr_mips.c
+@@ -58,6 +58,7 @@
+ #define ENVELOPE_ADJUSTMENT_OFFSET 2
+ 
+ #if HAVE_INLINE_ASM
++#if HAVE_MIPSFPU
+ static int sbr_lf_gen_mips(AACContext *ac, SpectralBandReplication *sbr,
+                       float X_low[32][40][2], const float W[2][32][32][2],
+                       int buf_idx)
+@@ -310,7 +311,6 @@ static int sbr_x_gen_mips(SpectralBandReplication *sbr, float X[2][38][64],
+       return 0;
+ }
+ 
+-#if HAVE_MIPSFPU
+ #if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
+ static void sbr_hf_assemble_mips(float Y1[38][64][2],
+                             const float X_high[64][40][2],
+@@ -611,9 +611,9 @@ static void sbr_hf_inverse_filter_mips(SBRDSPContext *dsp,
+ void ff_aacsbr_func_ptr_init_mips(AACSBRContext *c)
+ {
+ #if HAVE_INLINE_ASM
++#if HAVE_MIPSFPU
+     c->sbr_lf_gen            = sbr_lf_gen_mips;
+     c->sbr_x_gen             = sbr_x_gen_mips;
+-#if HAVE_MIPSFPU
+ #if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
+     c->sbr_hf_inverse_filter = sbr_hf_inverse_filter_mips;
+     c->sbr_hf_assemble       = sbr_hf_assemble_mips;
+diff --git a/libavcodec/mips/sbrdsp_mips.c b/libavcodec/mips/sbrdsp_mips.c
+index 1b0a10608d..83039fd802 100644
+--- a/libavcodec/mips/sbrdsp_mips.c
++++ b/libavcodec/mips/sbrdsp_mips.c
+@@ -59,6 +59,7 @@
+ #include "libavutil/mips/asmdefs.h"
+ 
+ #if HAVE_INLINE_ASM
++#if HAVE_MIPSFPU
+ static void sbr_qmf_pre_shuffle_mips(float *z)
+ {
+     int Temp1, Temp2, Temp3, Temp4, Temp5, Temp6;
+@@ -165,7 +166,6 @@ static void sbr_qmf_post_shuffle_mips(float W[32][2], const float *z)
+     );
+ }
+ 
+-#if HAVE_MIPSFPU
+ #if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
+ static void sbr_sum64x5_mips(float *z)
+ {
+@@ -890,9 +890,9 @@ static void sbr_hf_apply_noise_3_mips(float (*Y)[2], const float *s_m,
+ void ff_sbrdsp_init_mips(SBRDSPContext *s)
+ {
+ #if HAVE_INLINE_ASM
++#if HAVE_MIPSFPU
+     s->qmf_pre_shuffle = sbr_qmf_pre_shuffle_mips;
+     s->qmf_post_shuffle = sbr_qmf_post_shuffle_mips;
+-#if HAVE_MIPSFPU
+ #if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
+     s->sum64x5 = sbr_sum64x5_mips;
+     s->sum_square = sbr_sum_square_mips;
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0010-avcodec-mips-fix-get_cabac_inline_mips-function-name.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0010-avcodec-mips-fix-get_cabac_inline_mips-function-name.patch
@@ -1,0 +1,30 @@
+From c22ba4e35bc12ca56296a97f6f3468106804ad30 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sat, 11 Apr 2020 18:54:33 -0700
+Subject: [PATCH 10/26] avcodec/mips: fix get_cabac_inline_mips function name
+
+On other platforms, the functions are named get_cabac_inline_xxx but not
+this one. There's also a define.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/cabac.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/mips/cabac.h b/libavcodec/mips/cabac.h
+index 2a05e5ab3c..03b5010edc 100644
+--- a/libavcodec/mips/cabac.h
++++ b/libavcodec/mips/cabac.h
+@@ -29,7 +29,7 @@
+ #include "config.h"
+ 
+ #define get_cabac_inline get_cabac_inline_mips
+-static av_always_inline int get_cabac_inline(CABACContext *c,
++static av_always_inline int get_cabac_inline_mips(CABACContext *c,
+                                              uint8_t * const state){
+     mips_reg tmp0, tmp1, tmp2, bit;
+ 
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0011-avcodec-mips-fix-type-mismatch-in-h264dsp_msa.c.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0011-avcodec-mips-fix-type-mismatch-in-h264dsp_msa.c.patch
@@ -1,0 +1,417 @@
+From 4d020d1b724a01504bc3b10daa6d48a70fd80f51 Mon Sep 17 00:00:00 2001
+From: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Date: Sat, 18 Jul 2020 15:30:49 +0800
+Subject: [PATCH 11/26] avcodec/mips: fix type mismatch in h264dsp_msa.c
+
+gcc warning: assignment from incompatible pointer type.
+
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/h264dsp_mips.h | 24 ++++-----
+ libavcodec/mips/h264dsp_msa.c  | 94 ++++++++++++++++++----------------
+ 2 files changed, 62 insertions(+), 56 deletions(-)
+
+diff --git a/libavcodec/mips/h264dsp_mips.h b/libavcodec/mips/h264dsp_mips.h
+index 21b7de06f0..9b6f054b24 100644
+--- a/libavcodec/mips/h264dsp_mips.h
++++ b/libavcodec/mips/h264dsp_mips.h
+@@ -25,21 +25,21 @@
+ #include "libavcodec/h264dec.h"
+ #include "constants.h"
+ 
+-void ff_h264_h_lpf_luma_inter_msa(uint8_t *src, int stride,
++void ff_h264_h_lpf_luma_inter_msa(uint8_t *src, ptrdiff_t stride,
+                                   int alpha, int beta, int8_t *tc0);
+-void ff_h264_v_lpf_luma_inter_msa(uint8_t *src, int stride,
++void ff_h264_v_lpf_luma_inter_msa(uint8_t *src, ptrdiff_t stride,
+                                   int alpha, int beta, int8_t *tc0);
+-void ff_h264_h_lpf_chroma_inter_msa(uint8_t *src, int stride,
++void ff_h264_h_lpf_chroma_inter_msa(uint8_t *src, ptrdiff_t stride,
+                                     int alpha, int beta, int8_t *tc0);
+-void ff_h264_v_lpf_chroma_inter_msa(uint8_t *src, int stride,
++void ff_h264_v_lpf_chroma_inter_msa(uint8_t *src, ptrdiff_t stride,
+                                     int alpha, int beta, int8_t *tc0);
+-void ff_h264_h_loop_filter_chroma422_msa(uint8_t *src, int32_t stride,
++void ff_h264_h_loop_filter_chroma422_msa(uint8_t *src, ptrdiff_t stride,
+                                          int32_t alpha, int32_t beta,
+                                          int8_t *tc0);
+-void ff_h264_h_loop_filter_chroma422_mbaff_msa(uint8_t *src, int32_t stride,
++void ff_h264_h_loop_filter_chroma422_mbaff_msa(uint8_t *src, ptrdiff_t stride,
+                                                int32_t alpha, int32_t beta,
+                                                int8_t *tc0);
+-void ff_h264_h_loop_filter_luma_mbaff_msa(uint8_t *src, int32_t stride,
++void ff_h264_h_loop_filter_luma_mbaff_msa(uint8_t *src, ptrdiff_t stride,
+                                           int32_t alpha, int32_t beta,
+                                           int8_t *tc0);
+ 
+@@ -67,15 +67,15 @@ void ff_h264_idct8_add4_msa(uint8_t *dst, const int *blk_offset,
+                             int16_t *blk, int dst_stride,
+                             const uint8_t nnzc[15 * 8]);
+ 
+-void ff_h264_h_lpf_luma_intra_msa(uint8_t *src, int stride,
++void ff_h264_h_lpf_luma_intra_msa(uint8_t *src, ptrdiff_t stride,
+                                   int alpha, int beta);
+-void ff_h264_v_lpf_luma_intra_msa(uint8_t *src, int stride,
++void ff_h264_v_lpf_luma_intra_msa(uint8_t *src, ptrdiff_t stride,
+                                   int alpha, int beta);
+-void ff_h264_h_lpf_chroma_intra_msa(uint8_t *src, int stride,
++void ff_h264_h_lpf_chroma_intra_msa(uint8_t *src, ptrdiff_t stride,
+                                     int alpha, int beta);
+-void ff_h264_v_lpf_chroma_intra_msa(uint8_t *src, int stride,
++void ff_h264_v_lpf_chroma_intra_msa(uint8_t *src, ptrdiff_t stride,
+                                     int alpha, int beta);
+-void ff_h264_h_loop_filter_luma_mbaff_intra_msa(uint8_t *src, int stride,
++void ff_h264_h_loop_filter_luma_mbaff_intra_msa(uint8_t *src, ptrdiff_t stride,
+                                                 int alpha, int beta);
+ 
+ void ff_biweight_h264_pixels16_8_msa(uint8_t *dst, uint8_t *src,
+diff --git a/libavcodec/mips/h264dsp_msa.c b/libavcodec/mips/h264dsp_msa.c
+index dd0598291e..a8c3f3cedb 100644
+--- a/libavcodec/mips/h264dsp_msa.c
++++ b/libavcodec/mips/h264dsp_msa.c
+@@ -21,7 +21,7 @@
+ #include "libavutil/mips/generic_macros_msa.h"
+ #include "h264dsp_mips.h"
+ 
+-static void avc_wgt_4x2_msa(uint8_t *data, int32_t stride,
++static void avc_wgt_4x2_msa(uint8_t *data, ptrdiff_t stride,
+                             int32_t log2_denom, int32_t src_weight,
+                             int32_t offset_in)
+ {
+@@ -48,8 +48,9 @@ static void avc_wgt_4x2_msa(uint8_t *data, int32_t stride,
+     ST_W2(src0, 0, 1, data, stride);
+ }
+ 
+-static void avc_wgt_4x4_msa(uint8_t *data, int32_t stride, int32_t log2_denom,
+-                            int32_t src_weight, int32_t offset_in)
++static void avc_wgt_4x4_msa(uint8_t *data, ptrdiff_t stride,
++                            int32_t log2_denom, int32_t src_weight,
++                            int32_t offset_in)
+ {
+     uint32_t tp0, tp1, tp2, tp3, offset_val;
+     v16u8 src0 = { 0 };
+@@ -74,8 +75,9 @@ static void avc_wgt_4x4_msa(uint8_t *data, int32_t stride, int32_t log2_denom,
+     ST_W4(src0, 0, 1, 2, 3, data, stride);
+ }
+ 
+-static void avc_wgt_4x8_msa(uint8_t *data, int32_t stride, int32_t log2_denom,
+-                            int32_t src_weight, int32_t offset_in)
++static void avc_wgt_4x8_msa(uint8_t *data, ptrdiff_t stride,
++                            int32_t log2_denom, int32_t src_weight,
++                            int32_t offset_in)
+ {
+     uint32_t tp0, tp1, tp2, tp3, offset_val;
+     v16u8 src0 = { 0 }, src1 = { 0 };
+@@ -105,8 +107,9 @@ static void avc_wgt_4x8_msa(uint8_t *data, int32_t stride, int32_t log2_denom,
+     ST_W8(src0, src1, 0, 1, 2, 3, 0, 1, 2, 3, data, stride);
+ }
+ 
+-static void avc_wgt_8x4_msa(uint8_t *data, int32_t stride, int32_t log2_denom,
+-                            int32_t src_weight, int32_t offset_in)
++static void avc_wgt_8x4_msa(uint8_t *data, ptrdiff_t stride,
++                            int32_t log2_denom, int32_t src_weight,
++                            int32_t offset_in)
+ {
+     uint32_t offset_val;
+     uint64_t tp0, tp1, tp2, tp3;
+@@ -136,7 +139,7 @@ static void avc_wgt_8x4_msa(uint8_t *data, int32_t stride, int32_t log2_denom,
+     ST_D4(src0, src1, 0, 1, 0, 1, data, stride);
+ }
+ 
+-static void avc_wgt_8x8_msa(uint8_t *data, int32_t stride, int32_t log2_denom,
++static void avc_wgt_8x8_msa(uint8_t *data, ptrdiff_t stride, int32_t log2_denom,
+                             int32_t src_weight, int32_t offset_in)
+ {
+     uint32_t offset_val;
+@@ -178,8 +181,9 @@ static void avc_wgt_8x8_msa(uint8_t *data, int32_t stride, int32_t log2_denom,
+     ST_D8(src0, src1, src2, src3, 0, 1, 0, 1, 0, 1, 0, 1, data, stride);
+ }
+ 
+-static void avc_wgt_8x16_msa(uint8_t *data, int32_t stride, int32_t log2_denom,
+-                             int32_t src_weight, int32_t offset_in)
++static void avc_wgt_8x16_msa(uint8_t *data, ptrdiff_t stride,
++                             int32_t log2_denom, int32_t src_weight,
++                             int32_t offset_in)
+ {
+     uint32_t offset_val, cnt;
+     uint64_t tp0, tp1, tp2, tp3;
+@@ -223,7 +227,7 @@ static void avc_wgt_8x16_msa(uint8_t *data, int32_t stride, int32_t log2_denom,
+     }
+ }
+ 
+-static void avc_biwgt_4x2_msa(uint8_t *src, uint8_t *dst, int32_t stride,
++static void avc_biwgt_4x2_msa(uint8_t *src, uint8_t *dst, ptrdiff_t stride,
+                               int32_t log2_denom, int32_t src_weight,
+                               int32_t dst_weight, int32_t offset_in)
+ {
+@@ -256,7 +260,7 @@ static void avc_biwgt_4x2_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+     ST_W2(dst0, 0, 1, dst, stride);
+ }
+ 
+-static void avc_biwgt_4x4_msa(uint8_t *src, uint8_t *dst, int32_t stride,
++static void avc_biwgt_4x4_msa(uint8_t *src, uint8_t *dst, ptrdiff_t stride,
+                               int32_t log2_denom, int32_t src_weight,
+                               int32_t dst_weight, int32_t offset_in)
+ {
+@@ -290,7 +294,7 @@ static void avc_biwgt_4x4_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+     ST_W4(dst0, 0, 1, 2, 3, dst, stride);
+ }
+ 
+-static void avc_biwgt_4x8_msa(uint8_t *src, uint8_t *dst, int32_t stride,
++static void avc_biwgt_4x8_msa(uint8_t *src, uint8_t *dst, ptrdiff_t stride,
+                               int32_t log2_denom, int32_t src_weight,
+                               int32_t dst_weight, int32_t offset_in)
+ {
+@@ -330,7 +334,7 @@ static void avc_biwgt_4x8_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+     ST_W8(dst0, dst1, 0, 1, 2, 3, 0, 1, 2, 3, dst, stride);
+ }
+ 
+-static void avc_biwgt_8x4_msa(uint8_t *src, uint8_t *dst, int32_t stride,
++static void avc_biwgt_8x4_msa(uint8_t *src, uint8_t *dst, ptrdiff_t stride,
+                               int32_t log2_denom, int32_t src_weight,
+                               int32_t dst_weight, int32_t offset_in)
+ {
+@@ -368,7 +372,7 @@ static void avc_biwgt_8x4_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+     ST_D4(dst0, dst1, 0, 1, 0, 1, dst, stride);
+ }
+ 
+-static void avc_biwgt_8x8_msa(uint8_t *src, uint8_t *dst, int32_t stride,
++static void avc_biwgt_8x8_msa(uint8_t *src, uint8_t *dst, ptrdiff_t stride,
+                               int32_t log2_denom, int32_t src_weight,
+                               int32_t dst_weight, int32_t offset_in)
+ {
+@@ -419,7 +423,7 @@ static void avc_biwgt_8x8_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+     ST_D8(dst0, dst1, dst2, dst3, 0, 1, 0, 1, 0, 1, 0, 1, dst, stride);
+ }
+ 
+-static void avc_biwgt_8x16_msa(uint8_t *src, uint8_t *dst, int32_t stride,
++static void avc_biwgt_8x16_msa(uint8_t *src, uint8_t *dst, ptrdiff_t stride,
+                                int32_t log2_denom, int32_t src_weight,
+                                int32_t dst_weight, int32_t offset_in)
+ {
+@@ -679,7 +683,7 @@ static void avc_biwgt_8x16_msa(uint8_t *src, uint8_t *dst, int32_t stride,
+ static void avc_loopfilter_luma_intra_edge_hor_msa(uint8_t *data,
+                                                    uint8_t alpha_in,
+                                                    uint8_t beta_in,
+-                                                   uint32_t img_width)
++                                                   ptrdiff_t img_width)
+ {
+     v16u8 p0_asub_q0, p1_asub_p0, q1_asub_q0;
+     v16u8 is_less_than, is_less_than_beta, is_less_than_alpha;
+@@ -812,7 +816,7 @@ static void avc_loopfilter_luma_intra_edge_hor_msa(uint8_t *data,
+ static void avc_loopfilter_luma_intra_edge_ver_msa(uint8_t *data,
+                                                    uint8_t alpha_in,
+                                                    uint8_t beta_in,
+-                                                   uint32_t img_width)
++                                                   ptrdiff_t img_width)
+ {
+     uint8_t *src = data - 4;
+     v16u8 alpha, beta, p0_asub_q0;
+@@ -969,7 +973,8 @@ static void avc_loopfilter_luma_intra_edge_ver_msa(uint8_t *data,
+     }
+ }
+ 
+-static void avc_h_loop_filter_luma_mbaff_intra_msa(uint8_t *src, int32_t stride,
++static void avc_h_loop_filter_luma_mbaff_intra_msa(uint8_t *src,
++                                                   ptrdiff_t stride,
+                                                    int32_t alpha_in,
+                                                    int32_t beta_in)
+ {
+@@ -1171,7 +1176,7 @@ static void avc_h_loop_filter_luma_mbaff_intra_msa(uint8_t *src, int32_t stride,
+ static void avc_loopfilter_cb_or_cr_intra_edge_hor_msa(uint8_t *data_cb_or_cr,
+                                                        uint8_t alpha_in,
+                                                        uint8_t beta_in,
+-                                                       uint32_t img_width)
++                                                       ptrdiff_t img_width)
+ {
+     v16u8 alpha, beta;
+     v16u8 is_less_than;
+@@ -1220,7 +1225,7 @@ static void avc_loopfilter_cb_or_cr_intra_edge_hor_msa(uint8_t *data_cb_or_cr,
+ static void avc_loopfilter_cb_or_cr_intra_edge_ver_msa(uint8_t *data_cb_or_cr,
+                                                        uint8_t alpha_in,
+                                                        uint8_t beta_in,
+-                                                       uint32_t img_width)
++                                                       ptrdiff_t img_width)
+ {
+     v8i16 tmp1;
+     v16u8 alpha, beta, is_less_than;
+@@ -1286,7 +1291,7 @@ static void avc_loopfilter_luma_inter_edge_ver_msa(uint8_t *data,
+                                                    uint8_t tc2, uint8_t tc3,
+                                                    uint8_t alpha_in,
+                                                    uint8_t beta_in,
+-                                                   uint32_t img_width)
++                                                   ptrdiff_t img_width)
+ {
+     v16u8 tmp_vec, bs = { 0 };
+ 
+@@ -1566,7 +1571,7 @@ static void avc_loopfilter_luma_inter_edge_hor_msa(uint8_t *data,
+                                                    uint8_t tc2, uint8_t tc3,
+                                                    uint8_t alpha_in,
+                                                    uint8_t beta_in,
+-                                                   uint32_t image_width)
++                                                   ptrdiff_t image_width)
+ {
+     v16u8 tmp_vec;
+     v16u8 bs = { 0 };
+@@ -1715,7 +1720,7 @@ static void avc_loopfilter_luma_inter_edge_hor_msa(uint8_t *data,
+     }
+ }
+ 
+-static void avc_h_loop_filter_luma_mbaff_msa(uint8_t *in, int32_t stride,
++static void avc_h_loop_filter_luma_mbaff_msa(uint8_t *in, ptrdiff_t stride,
+                                              int32_t alpha_in, int32_t beta_in,
+                                              int8_t *tc0)
+ {
+@@ -1941,7 +1946,7 @@ static void avc_loopfilter_cb_or_cr_inter_edge_hor_msa(uint8_t *data,
+                                                        uint8_t tc2, uint8_t tc3,
+                                                        uint8_t alpha_in,
+                                                        uint8_t beta_in,
+-                                                       uint32_t img_width)
++                                                       ptrdiff_t img_width)
+ {
+     v16u8 alpha, beta;
+     v8i16 tmp_vec;
+@@ -2027,7 +2032,7 @@ static void avc_loopfilter_cb_or_cr_inter_edge_ver_msa(uint8_t *data,
+                                                        uint8_t tc2, uint8_t tc3,
+                                                        uint8_t alpha_in,
+                                                        uint8_t beta_in,
+-                                                       uint32_t img_width)
++                                                       ptrdiff_t img_width)
+ {
+     uint8_t *src;
+     v16u8 alpha, beta;
+@@ -2115,7 +2120,7 @@ static void avc_loopfilter_cb_or_cr_inter_edge_ver_msa(uint8_t *data,
+     }
+ }
+ 
+-static void avc_h_loop_filter_chroma422_msa(uint8_t *src, int32_t stride,
++static void avc_h_loop_filter_chroma422_msa(uint8_t *src, ptrdiff_t stride,
+                                             int32_t alpha_in, int32_t beta_in,
+                                             int8_t *tc0)
+ {
+@@ -2139,7 +2144,8 @@ static void avc_h_loop_filter_chroma422_msa(uint8_t *src, int32_t stride,
+     }
+ }
+ 
+-static void avc_h_loop_filter_chroma422_mbaff_msa(uint8_t *src, int32_t stride,
++static void avc_h_loop_filter_chroma422_mbaff_msa(uint8_t *src,
++                                                  ptrdiff_t stride,
+                                                   int32_t alpha_in,
+                                                   int32_t beta_in,
+                                                   int8_t *tc0)
+@@ -2171,7 +2177,7 @@ static void avc_h_loop_filter_chroma422_mbaff_msa(uint8_t *src, int32_t stride,
+     }
+ }
+ 
+-void ff_h264_h_lpf_luma_inter_msa(uint8_t *data, int img_width,
++void ff_h264_h_lpf_luma_inter_msa(uint8_t *data, ptrdiff_t img_width,
+                                   int alpha, int beta, int8_t *tc)
+ {
+     uint8_t bs0 = 1;
+@@ -2193,7 +2199,7 @@ void ff_h264_h_lpf_luma_inter_msa(uint8_t *data, int img_width,
+                                            alpha, beta, img_width);
+ }
+ 
+-void ff_h264_v_lpf_luma_inter_msa(uint8_t *data, int img_width,
++void ff_h264_v_lpf_luma_inter_msa(uint8_t *data, ptrdiff_t img_width,
+                                   int alpha, int beta, int8_t *tc)
+ {
+ 
+@@ -2216,7 +2222,7 @@ void ff_h264_v_lpf_luma_inter_msa(uint8_t *data, int img_width,
+                                            alpha, beta, img_width);
+ }
+ 
+-void ff_h264_h_lpf_chroma_inter_msa(uint8_t *data, int img_width,
++void ff_h264_h_lpf_chroma_inter_msa(uint8_t *data, ptrdiff_t img_width,
+                                     int alpha, int beta, int8_t *tc)
+ {
+     uint8_t bs0 = 1;
+@@ -2238,7 +2244,7 @@ void ff_h264_h_lpf_chroma_inter_msa(uint8_t *data, int img_width,
+                                                alpha, beta, img_width);
+ }
+ 
+-void ff_h264_v_lpf_chroma_inter_msa(uint8_t *data, int img_width,
++void ff_h264_v_lpf_chroma_inter_msa(uint8_t *data, ptrdiff_t img_width,
+                                     int alpha, int beta, int8_t *tc)
+ {
+     uint8_t bs0 = 1;
+@@ -2260,40 +2266,40 @@ void ff_h264_v_lpf_chroma_inter_msa(uint8_t *data, int img_width,
+                                                alpha, beta, img_width);
+ }
+ 
+-void ff_h264_h_lpf_luma_intra_msa(uint8_t *data, int img_width,
++void ff_h264_h_lpf_luma_intra_msa(uint8_t *data, ptrdiff_t img_width,
+                                   int alpha, int beta)
+ {
+     avc_loopfilter_luma_intra_edge_ver_msa(data, (uint8_t) alpha,
+                                            (uint8_t) beta,
+-                                           (unsigned int) img_width);
++                                           img_width);
+ }
+ 
+-void ff_h264_v_lpf_luma_intra_msa(uint8_t *data, int img_width,
++void ff_h264_v_lpf_luma_intra_msa(uint8_t *data, ptrdiff_t img_width,
+                                   int alpha, int beta)
+ {
+     avc_loopfilter_luma_intra_edge_hor_msa(data, (uint8_t) alpha,
+                                            (uint8_t) beta,
+-                                           (unsigned int) img_width);
++                                           img_width);
+ }
+ 
+-void ff_h264_h_lpf_chroma_intra_msa(uint8_t *data, int img_width,
++void ff_h264_h_lpf_chroma_intra_msa(uint8_t *data, ptrdiff_t img_width,
+                                     int alpha, int beta)
+ {
+     avc_loopfilter_cb_or_cr_intra_edge_ver_msa(data, (uint8_t) alpha,
+                                                (uint8_t) beta,
+-                                               (unsigned int) img_width);
++                                               img_width);
+ }
+ 
+-void ff_h264_v_lpf_chroma_intra_msa(uint8_t *data, int img_width,
++void ff_h264_v_lpf_chroma_intra_msa(uint8_t *data, ptrdiff_t img_width,
+                                     int alpha, int beta)
+ {
+     avc_loopfilter_cb_or_cr_intra_edge_hor_msa(data, (uint8_t) alpha,
+                                                (uint8_t) beta,
+-                                               (unsigned int) img_width);
++                                               img_width);
+ }
+ 
+ void ff_h264_h_loop_filter_chroma422_msa(uint8_t *src,
+-                                         int32_t ystride,
++                                         ptrdiff_t ystride,
+                                          int32_t alpha, int32_t beta,
+                                          int8_t *tc0)
+ {
+@@ -2301,7 +2307,7 @@ void ff_h264_h_loop_filter_chroma422_msa(uint8_t *src,
+ }
+ 
+ void ff_h264_h_loop_filter_chroma422_mbaff_msa(uint8_t *src,
+-                                               int32_t ystride,
++                                               ptrdiff_t ystride,
+                                                int32_t alpha,
+                                                int32_t beta,
+                                                int8_t *tc0)
+@@ -2310,7 +2316,7 @@ void ff_h264_h_loop_filter_chroma422_mbaff_msa(uint8_t *src,
+ }
+ 
+ void ff_h264_h_loop_filter_luma_mbaff_msa(uint8_t *src,
+-                                          int32_t ystride,
++                                          ptrdiff_t ystride,
+                                           int32_t alpha,
+                                           int32_t beta,
+                                           int8_t *tc0)
+@@ -2319,7 +2325,7 @@ void ff_h264_h_loop_filter_luma_mbaff_msa(uint8_t *src,
+ }
+ 
+ void ff_h264_h_loop_filter_luma_mbaff_intra_msa(uint8_t *src,
+-                                                int32_t ystride,
++                                                ptrdiff_t ystride,
+                                                 int32_t alpha,
+                                                 int32_t beta)
+ {
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0012-ffbuild-Refine-MIPS-handling.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0012-ffbuild-Refine-MIPS-handling.patch
@@ -1,0 +1,324 @@
+From fbfc6463a046cf64d15150b817637e3f2213ef9c Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Sat, 18 Jul 2020 23:35:37 +0800
+Subject: [PATCH 12/26] ffbuild: Refine MIPS handling
+
+To enable runtime detection for MIPS, we need to refine ffbuild
+part to support buildding these feature together.
+
+Firstly, we fixed configure, let it probe native ability of toolchain
+to decide wether a feature can to be enabled, also clearly marked
+the conflictions between loongson2 & loongson3 and Release 6 & rest.
+
+Secondly, we compile MMI and MSA C sources with their own flags to ensure
+their flags won't pollute the whole program and generate illegal code.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Reviewed-by: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ configure                | 172 ++++++++++++++++++++++-----------------
+ ffbuild/common.mak       |  10 ++-
+ libavcodec/mips/Makefile |   3 +-
+ 3 files changed, 109 insertions(+), 76 deletions(-)
+
+diff --git a/configure b/configure
+index 6a7a85cbb9..0c8d2870f1 100755
+--- a/configure
++++ b/configure
+@@ -2533,7 +2533,7 @@ mips64r6_deps="mips"
+ mipsfpu_deps="mips"
+ mipsdsp_deps="mips"
+ mipsdspr2_deps="mips"
+-mmi_deps="mips"
++mmi_deps_any="loongson2 loongson3"
+ msa_deps="mipsfpu"
+ msa2_deps="msa"
+ 
+@@ -4917,8 +4917,6 @@ elif enabled bfin; then
+ 
+ elif enabled mips; then
+ 
+-    cpuflags="-march=$cpu"
+-
+     if [ "$cpu" != "generic" ]; then
+         disable mips32r2
+         disable mips32r5
+@@ -4927,19 +4925,61 @@ elif enabled mips; then
+         disable mips64r6
+         disable loongson2
+         disable loongson3
++        disable mipsdsp
++        disable mipsdspr2
++        disable msa
++        disable mmi
++
++        cpuflags="-march=$cpu"
+ 
+         case $cpu in
+-            24kc|24kf*|24kec|34kc|1004kc|24kef*|34kf*|1004kf*|74kc|74kf)
++            # General ISA levels
++            mips1|mips3)
++            ;;
++            mips32r2)
++                enable msa
+                 enable mips32r2
+-                disable msa
+             ;;
+-            p5600|i6400|p6600)
+-                disable mipsdsp
+-                disable mipsdspr2
++            mips32r5)
++                enable msa
++                enable mips32r2
++                enable mips32r5
+             ;;
+-            loongson*)
+-                enable loongson2
++            mips64r2|mips64r5)
++                enable msa
++                enable mmi
++                enable mips64r2
+                 enable loongson3
++            ;;
++            # Cores from MIPS(MTI)
++            24kc)
++                disable mipsfpu
++                enable mips32r2
++            ;;
++            24kf*|24kec|34kc|74Kc|1004kc)
++                enable mips32r2
++            ;;
++            24kef*|34kf*|1004kf*)
++                enable mipsdsp
++                enable mips32r2
++            ;;
++            p5600)
++                enable msa
++                enable mips32r2
++                enable mips32r5
++                check_cflags "-mtune=p5600" && check_cflags "-msched-weight -mload-store-pairs -funroll-loops"
++            ;;
++            i6400)
++                enable mips64r6
++                check_cflags "-mtune=i6400 -mabi=64" && check_cflags "-msched-weight -mload-store-pairs -funroll-loops" && check_ldflags "-mabi=64"
++            ;;
++            p6600)
++                enable mips64r6
++                check_cflags "-mtune=p6600 -mabi=64" && check_cflags "-msched-weight -mload-store-pairs -funroll-loops" && check_ldflags "-mabi=64"
++            ;;
++            # Cores from Loongson
++            loongson2e|loongson2f|loongson3*)
++                enable mmi
+                 enable local_aligned
+                 enable simd_align_16
+                 enable fast_64bit
+@@ -4947,75 +4987,43 @@ elif enabled mips; then
+                 enable fast_cmov
+                 enable fast_unaligned
+                 disable aligned_stack
+-                disable mipsdsp
+-                disable mipsdspr2
+                 # When gcc version less than 5.3.0, add -fno-expensive-optimizations flag.
+-                if [ $cc == gcc ]; then
+-                    gcc_version=$(gcc -dumpversion)
+-                    if [ "$(echo "$gcc_version 5.3.0" | tr " " "\n" | sort -rV | head -n 1)" == "$gcc_version" ]; then
+-                        expensive_optimization_flag=""
+-                    else
++                if test "$cc_type" = "gcc"; then
++                    case $gcc_basever in
++                        2|2.*|3.*|4.*|5.0|5.1|5.2)
+                         expensive_optimization_flag="-fno-expensive-optimizations"
+-                    fi
++                        ;;
++                        *)
++                        expensive_optimization_flag=""
++                        ;;
++                    esac
+                 fi
++
+                 case $cpu in
+                     loongson3*)
++                        enable loongson3
++                        enable msa
+                         cpuflags="-march=loongson3a -mhard-float $expensive_optimization_flag"
+                     ;;
+                     loongson2e)
++                        enable loongson2
+                         cpuflags="-march=loongson2e -mhard-float $expensive_optimization_flag"
+                     ;;
+                     loongson2f)
++                        enable loongson2
+                         cpuflags="-march=loongson2f -mhard-float $expensive_optimization_flag"
+                     ;;
+                 esac
+             ;;
+             *)
+-                # Unknown CPU. Disable everything.
+-                warn "unknown CPU. Disabling all MIPS optimizations."
+-                disable mipsfpu
+-                disable mipsdsp
+-                disable mipsdspr2
+-                disable msa
+-                disable mmi
++                warn "unknown MIPS CPU"
+             ;;
+         esac
+ 
+-        case $cpu in
+-            24kc)
+-                disable mipsfpu
+-                disable mipsdsp
+-                disable mipsdspr2
+-            ;;
+-            24kf*)
+-                disable mipsdsp
+-                disable mipsdspr2
+-            ;;
+-            24kec|34kc|1004kc)
+-                disable mipsfpu
+-                disable mipsdspr2
+-            ;;
+-            24kef*|34kf*|1004kf*)
+-                disable mipsdspr2
+-            ;;
+-            74kc)
+-                disable mipsfpu
+-            ;;
+-            p5600)
+-                enable mips32r5
+-                check_cflags "-mtune=p5600" && check_cflags "-msched-weight -mload-store-pairs -funroll-loops"
+-            ;;
+-            i6400)
+-                enable mips64r6
+-                check_cflags "-mtune=i6400 -mabi=64" && check_cflags "-msched-weight -mload-store-pairs -funroll-loops" && check_ldflags "-mabi=64"
+-            ;;
+-            p6600)
+-                enable mips64r6
+-                check_cflags "-mtune=p6600 -mabi=64" && check_cflags "-msched-weight -mload-store-pairs -funroll-loops" && check_ldflags "-mabi=64"
+-            ;;
+-        esac
+     else
+-        # We do not disable anything. Is up to the user to disable the unwanted features.
++        disable mipsdsp
++        disable mipsdspr2
++        # Disable DSP stuff for generic CPU, it can't be detected at runtime.
+         warn 'generic cpu selected'
+     fi
+ 
+@@ -5756,28 +5764,42 @@ EOF
+ 
+ elif enabled mips; then
+ 
+-    enabled loongson2 && check_inline_asm loongson2 '"dmult.g $8, $9, $10"'
+-    enabled loongson3 && check_inline_asm loongson3 '"gsldxc1 $f0, 0($2, $3)"'
+-    enabled mmi && check_inline_asm mmi '"punpcklhw $f0, $f0, $f0"'
+-
+-    # Enable minimum ISA based on selected options
++    # Check toolchain ISA level
+     if enabled mips64; then
+-        enabled mips64r6 && check_inline_asm_flags mips64r6 '"dlsa $0, $0, $0, 1"' '-mips64r6'
+-        enabled mips64r2 && check_inline_asm_flags mips64r2 '"dext $0, $0, 0, 1"' '-mips64r2'
+-        disabled mips64r6 && disabled mips64r2 && check_inline_asm_flags mips64r1 '"daddi $0, $0, 0"' '-mips64'
++        enabled mips64r6 && check_inline_asm mips64r6 '"dlsa $0, $0, $0, 1"' &&
++            disable mips64r2
++
++        enabled mips64r2 && check_inline_asm mips64r2 '"dext $0, $0, 0, 1"'
++
++        disable mips32r6 && disable mips32r5 && disable mips32r2
+     else
+-        enabled mips32r6 && check_inline_asm_flags mips32r6 '"aui $0, $0, 0"' '-mips32r6'
+-        enabled mips32r5 && check_inline_asm_flags mips32r5 '"eretnc"' '-mips32r5'
+-        enabled mips32r2 && check_inline_asm_flags mips32r2 '"ext $0, $0, 0, 1"' '-mips32r2'
+-        disabled mips32r6 && disabled mips32r5 && disabled mips32r2 && check_inline_asm_flags mips32r1 '"addi $0, $0, 0"' '-mips32'
++        enabled mips32r6 && check_inline_asm mips32r6 '"aui $0, $0, 0"' &&
++            disable mips32r5 && disable mips32r2
++
++        enabled mips32r5 && check_inline_asm mips32r5 '"eretnc"'
++        enabled mips32r2 && check_inline_asm mips32r2 '"ext $0, $0, 0, 1"'
++
++        disable mips64r6 && disable mips64r5 && disable mips64r2
+     fi
+ 
+-    enabled mipsfpu && check_inline_asm_flags mipsfpu '"cvt.d.l $f0, $f2"' '-mhard-float'
++    enabled mipsfpu && check_inline_asm mipsfpu '"cvt.d.l $f0, $f2"'
+     enabled mipsfpu && (enabled mips32r5 || enabled mips32r6 || enabled mips64r6) && check_inline_asm_flags mipsfpu '"cvt.d.l $f0, $f1"' '-mfp64'
+-    enabled mipsfpu && enabled msa && check_inline_asm_flags msa '"addvi.b $w0, $w1, 1"' '-mmsa' && check_headers msa.h || disable msa
++
+     enabled mipsdsp && check_inline_asm_flags mipsdsp '"addu.qb $t0, $t1, $t2"' '-mdsp'
+     enabled mipsdspr2 && check_inline_asm_flags mipsdspr2 '"absq_s.qb $t0, $t1"' '-mdspr2'
+-    enabled msa && enabled msa2 && check_inline_asm_flags msa2 '"nxbits.any.b $w0, $w0"' '-mmsa2' && check_headers msa2.h || disable msa2
++
++    # MSA and MSA2 can be detected at runtime so we supply extra flags here
++    enabled mipsfpu && enabled msa && check_inline_asm msa '"addvi.b $w0, $w1, 1"' '-mmsa' && append MSAFLAGS '-mmsa'
++    enabled msa && enabled msa2 && check_inline_asm msa2 '"nxbits.any.b $w0, $w0"' '-mmsa2' && append MSAFLAGS '-mmsa2'
++
++    # loongson2 have no switch cflag so we can only probe toolchain ability
++    enabled loongson2 && check_inline_asm loongson2 '"dmult.g $8, $9, $10"' && disable loongson3
++
++    # loongson3 is paired with MMI
++    enabled loongson3 && check_inline_asm loongson3 '"gsldxc1 $f0, 0($2, $3)"' '-mloongson-ext' && append MMIFLAGS '-mloongson-ext'
++
++    # MMI can be detected at runtime too
++    enabled mmi && check_inline_asm mmi '"punpcklhw $f0, $f0, $f0"' '-mloongson-mmi' && append MMIFLAGS '-mloongson-mmi'
+ 
+     if enabled bigendian && enabled msa; then
+         disable msa
+@@ -7324,6 +7346,8 @@ LDSOFLAGS=$LDSOFLAGS
+ SHFLAGS=$(echo $($ldflags_filter $SHFLAGS))
+ ASMSTRIPFLAGS=$ASMSTRIPFLAGS
+ X86ASMFLAGS=$X86ASMFLAGS
++MSAFLAGS=$MSAFLAGS
++MMIFLAGS=$MMIFLAGS
+ BUILDSUF=$build_suffix
+ PROGSSUF=$progs_suffix
+ FULLNAME=$FULLNAME
+diff --git a/ffbuild/common.mak b/ffbuild/common.mak
+index 7355508ea0..d70719bb61 100644
+--- a/ffbuild/common.mak
++++ b/ffbuild/common.mak
+@@ -44,7 +44,7 @@ LDFLAGS    := $(ALLFFLIBS:%=$(LD_PATH)lib%) $(LDFLAGS)
+ 
+ define COMPILE
+        $(call $(1)DEP,$(1))
+-       $($(1)) $($(1)FLAGS) $($(1)_DEPFLAGS) $($(1)_C) $($(1)_O) $(patsubst $(SRC_PATH)/%,$(SRC_LINK)/%,$<)
++       $($(1)) $($(1)FLAGS) $($(2)) $($(1)_DEPFLAGS) $($(1)_C) $($(1)_O) $(patsubst $(SRC_PATH)/%,$(SRC_LINK)/%,$<)
+ endef
+ 
+ COMPILE_C = $(call COMPILE,CC)
+@@ -54,6 +54,14 @@ COMPILE_M = $(call COMPILE,OBJCC)
+ COMPILE_X86ASM = $(call COMPILE,X86ASM)
+ COMPILE_HOSTC = $(call COMPILE,HOSTCC)
+ COMPILE_NVCC = $(call COMPILE,NVCC)
++COMPILE_MMI = $(call COMPILE,CC,MMIFLAGS)
++COMPILE_MSA = $(call COMPILE,CC,MSAFLAGS)
++
++%_mmi.o: %_mmi.c
++	$(COMPILE_MMI)
++
++%_msa.o: %_msa.c
++	$(COMPILE_MSA)
+ 
+ %.o: %.c
+ 	$(COMPILE_C)
+diff --git a/libavcodec/mips/Makefile b/libavcodec/mips/Makefile
+index b4993f6e76..2be4d9b8a2 100644
+--- a/libavcodec/mips/Makefile
++++ b/libavcodec/mips/Makefile
+@@ -71,6 +71,8 @@ MSA-OBJS-$(CONFIG_IDCTDSP)                += mips/idctdsp_msa.o           \
+ MSA-OBJS-$(CONFIG_MPEGVIDEO)              += mips/mpegvideo_msa.o
+ MSA-OBJS-$(CONFIG_MPEGVIDEOENC)           += mips/mpegvideoencdsp_msa.o
+ MSA-OBJS-$(CONFIG_ME_CMP)                 += mips/me_cmp_msa.o
++MSA-OBJS-$(CONFIG_VC1_DECODER)            += mips/vc1dsp_msa.o
++
+ MMI-OBJS                                  += mips/constants.o
+ MMI-OBJS-$(CONFIG_H264DSP)                += mips/h264dsp_mmi.o
+ MMI-OBJS-$(CONFIG_H264CHROMA)             += mips/h264chroma_mmi.o
+@@ -89,4 +91,3 @@ MMI-OBJS-$(CONFIG_WMV2DSP)                += mips/wmv2dsp_mmi.o
+ MMI-OBJS-$(CONFIG_HEVC_DECODER)           += mips/hevcdsp_mmi.o
+ MMI-OBJS-$(CONFIG_VP3DSP)                 += mips/vp3dsp_idct_mmi.o
+ MMI-OBJS-$(CONFIG_VP9_DECODER)            += mips/vp9_mc_mmi.o
+-MSA-OBJS-$(CONFIG_VC1_DECODER)            += mips/vc1dsp_msa.o
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0013-libavutils-Add-parse_r-helper-for-MIPS.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0013-libavutils-Add-parse_r-helper-for-MIPS.patch
@@ -1,0 +1,70 @@
+From c8c9186dd54321081191e4cee67804e86f2140b1 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Sat, 18 Jul 2020 23:35:38 +0800
+Subject: [PATCH 13/26] libavutils: Add parse_r helper for MIPS
+
+That helper grab from kernel code can allow us to inline
+newer instructions (not implemented by the assembler) in
+a elegant manner.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Reviewed-by: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavutil/mips/asmdefs.h | 42 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 42 insertions(+)
+
+diff --git a/libavutil/mips/asmdefs.h b/libavutil/mips/asmdefs.h
+index 748119918a..76bb2b93fa 100644
+--- a/libavutil/mips/asmdefs.h
++++ b/libavutil/mips/asmdefs.h
+@@ -55,4 +55,46 @@
+ # define PTR_SLL        "sll "
+ #endif
+ 
++/*
++ * parse_r var, r - Helper assembler macro for parsing register names.
++ *
++ * This converts the register name in $n form provided in \r to the
++ * corresponding register number, which is assigned to the variable \var. It is
++ * needed to allow explicit encoding of instructions in inline assembly where
++ * registers are chosen by the compiler in $n form, allowing us to avoid using
++ * fixed register numbers.
++ *
++ * It also allows newer instructions (not implemented by the assembler) to be
++ * transparently implemented using assembler macros, instead of needing separate
++ * cases depending on toolchain support.
++ *
++ * Simple usage example:
++ * __asm__ __volatile__("parse_r __rt, %0\n\t"
++ *                      ".insn\n\t"
++ *                      "# di    %0\n\t"
++ *                      ".word   (0x41606000 | (__rt << 16))"
++ *                      : "=r" (status);
++ */
++
++/* Match an individual register number and assign to \var */
++#define _IFC_REG(n)                                \
++        ".ifc        \\r, $" #n "\n\t"             \
++        "\\var        = " #n "\n\t"                \
++        ".endif\n\t"
++
++__asm__(".macro        parse_r var r\n\t"
++        "\\var        = -1\n\t"
++        _IFC_REG(0)  _IFC_REG(1)  _IFC_REG(2)  _IFC_REG(3)
++        _IFC_REG(4)  _IFC_REG(5)  _IFC_REG(6)  _IFC_REG(7)
++        _IFC_REG(8)  _IFC_REG(9)  _IFC_REG(10) _IFC_REG(11)
++        _IFC_REG(12) _IFC_REG(13) _IFC_REG(14) _IFC_REG(15)
++        _IFC_REG(16) _IFC_REG(17) _IFC_REG(18) _IFC_REG(19)
++        _IFC_REG(20) _IFC_REG(21) _IFC_REG(22) _IFC_REG(23)
++        _IFC_REG(24) _IFC_REG(25) _IFC_REG(26) _IFC_REG(27)
++        _IFC_REG(28) _IFC_REG(29) _IFC_REG(30) _IFC_REG(31)
++        ".iflt        \\var\n\t"
++        ".error        \"Unable to parse register name \\r\"\n\t"
++        ".endif\n\t"
++        ".endm");
++
+ #endif /* AVCODEC_MIPS_ASMDEFS_H */
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0014-libavutil-Detect-MMI-and-MSA-flags-for-MIPS.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0014-libavutil-Detect-MMI-and-MSA-flags-for-MIPS.patch
@@ -1,0 +1,316 @@
+From b3efc94bb78c6d562d9592788a12a0d92f6dc6fa Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Sat, 18 Jul 2020 23:35:39 +0800
+Subject: [PATCH 14/26] libavutil: Detect MMI and MSA flags for MIPS
+
+Add MMI & MSA runtime detection for MIPS.
+
+Basically there are two code pathes. For systems that
+natively support CPUCFG instruction or kernel emulated
+that instruction, we'll sense this feature from HWCAP and
+report the flags according to values grab from CPUCFG. For
+systems that have no CPUCFG (or not export it in HWCAP),
+we'll parse /proc/cpuinfo instead.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Reviewed-by: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavutil/cpu.c           |  10 +++
+ libavutil/cpu.h           |   3 +
+ libavutil/cpu_internal.h  |   2 +
+ libavutil/mips/Makefile   |   2 +-
+ libavutil/mips/cpu.c      | 134 ++++++++++++++++++++++++++++++++++++++
+ libavutil/mips/cpu.h      |  28 ++++++++
+ libavutil/tests/cpu.c     |   3 +
+ tests/checkasm/checkasm.c |   3 +
+ 8 files changed, 184 insertions(+), 1 deletion(-)
+ create mode 100644 libavutil/mips/cpu.c
+ create mode 100644 libavutil/mips/cpu.h
+
+diff --git a/libavutil/cpu.c b/libavutil/cpu.c
+index 6548cc3042..52f6b9a3bf 100644
+--- a/libavutil/cpu.c
++++ b/libavutil/cpu.c
+@@ -51,6 +51,8 @@ static atomic_int cpu_flags = ATOMIC_VAR_INIT(-1);
+ 
+ static int get_cpu_flags(void)
+ {
++    if (ARCH_MIPS)
++        return ff_get_cpu_flags_mips();
+     if (ARCH_AARCH64)
+         return ff_get_cpu_flags_aarch64();
+     if (ARCH_ARM)
+@@ -169,6 +171,9 @@ int av_parse_cpu_flags(const char *s)
+         { "armv8",    NULL, 0, AV_OPT_TYPE_CONST, { .i64 = AV_CPU_FLAG_ARMV8    },    .unit = "flags" },
+         { "neon",     NULL, 0, AV_OPT_TYPE_CONST, { .i64 = AV_CPU_FLAG_NEON     },    .unit = "flags" },
+         { "vfp",      NULL, 0, AV_OPT_TYPE_CONST, { .i64 = AV_CPU_FLAG_VFP      },    .unit = "flags" },
++#elif ARCH_MIPS
++        { "mmi",      NULL, 0, AV_OPT_TYPE_CONST, { .i64 = AV_CPU_FLAG_MMI      },    .unit = "flags" },
++        { "msa",      NULL, 0, AV_OPT_TYPE_CONST, { .i64 = AV_CPU_FLAG_MSA      },    .unit = "flags" },
+ #endif
+         { NULL },
+     };
+@@ -250,6 +255,9 @@ int av_parse_cpu_caps(unsigned *flags, const char *s)
+         { "armv8",    NULL, 0, AV_OPT_TYPE_CONST, { .i64 = AV_CPU_FLAG_ARMV8    },    .unit = "flags" },
+         { "neon",     NULL, 0, AV_OPT_TYPE_CONST, { .i64 = AV_CPU_FLAG_NEON     },    .unit = "flags" },
+         { "vfp",      NULL, 0, AV_OPT_TYPE_CONST, { .i64 = AV_CPU_FLAG_VFP      },    .unit = "flags" },
++#elif ARCH_MIPS
++        { "mmi",      NULL, 0, AV_OPT_TYPE_CONST, { .i64 = AV_CPU_FLAG_MMI      },    .unit = "flags" },
++        { "msa",      NULL, 0, AV_OPT_TYPE_CONST, { .i64 = AV_CPU_FLAG_MSA      },    .unit = "flags" },
+ #endif
+         { NULL },
+     };
+@@ -308,6 +316,8 @@ int av_cpu_count(void)
+ 
+ size_t av_cpu_max_align(void)
+ {
++    if (ARCH_MIPS)
++        return ff_get_cpu_max_align_mips();
+     if (ARCH_AARCH64)
+         return ff_get_cpu_max_align_aarch64();
+     if (ARCH_ARM)
+diff --git a/libavutil/cpu.h b/libavutil/cpu.h
+index 8bb9eb606b..83099dd969 100644
+--- a/libavutil/cpu.h
++++ b/libavutil/cpu.h
+@@ -71,6 +71,9 @@
+ #define AV_CPU_FLAG_VFP_VM       (1 << 7) ///< VFPv2 vector mode, deprecated in ARMv7-A and unavailable in various CPUs implementations
+ #define AV_CPU_FLAG_SETEND       (1 <<16)
+ 
++#define AV_CPU_FLAG_MMI          (1 << 0)
++#define AV_CPU_FLAG_MSA          (1 << 1)
++
+ /**
+  * Return the flags which specify extensions supported by the CPU.
+  * The returned value is affected by av_force_cpu_flags() if that was used
+diff --git a/libavutil/cpu_internal.h b/libavutil/cpu_internal.h
+index 37122d1c5f..889764320b 100644
+--- a/libavutil/cpu_internal.h
++++ b/libavutil/cpu_internal.h
+@@ -41,11 +41,13 @@
+ #define CPUEXT_FAST(flags, cpuext) CPUEXT_SUFFIX_FAST(flags, , cpuext)
+ #define CPUEXT_SLOW(flags, cpuext) CPUEXT_SUFFIX_SLOW(flags, , cpuext)
+ 
++int ff_get_cpu_flags_mips(void);
+ int ff_get_cpu_flags_aarch64(void);
+ int ff_get_cpu_flags_arm(void);
+ int ff_get_cpu_flags_ppc(void);
+ int ff_get_cpu_flags_x86(void);
+ 
++size_t ff_get_cpu_max_align_mips(void);
+ size_t ff_get_cpu_max_align_aarch64(void);
+ size_t ff_get_cpu_max_align_arm(void);
+ size_t ff_get_cpu_max_align_ppc(void);
+diff --git a/libavutil/mips/Makefile b/libavutil/mips/Makefile
+index dbfa5aa341..5f8c9b64e9 100644
+--- a/libavutil/mips/Makefile
++++ b/libavutil/mips/Makefile
+@@ -1 +1 @@
+-OBJS += mips/float_dsp_mips.o
++OBJS += mips/float_dsp_mips.o mips/cpu.o
+diff --git a/libavutil/mips/cpu.c b/libavutil/mips/cpu.c
+new file mode 100644
+index 0000000000..59619d54de
+--- /dev/null
++++ b/libavutil/mips/cpu.c
+@@ -0,0 +1,134 @@
++/*
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "libavutil/cpu.h"
++#include "libavutil/cpu_internal.h"
++#include "config.h"
++#if defined __linux__ || defined __ANDROID__
++#include <stdint.h>
++#include <stdio.h>
++#include <string.h>
++#include <sys/auxv.h>
++#include "asmdefs.h"
++#include "libavutil/avstring.h"
++#endif
++
++#if defined __linux__ || defined __ANDROID__
++
++#define HWCAP_LOONGSON_CPUCFG (1 << 14)
++
++static int cpucfg_available(void)
++{
++    return getauxval(AT_HWCAP) & HWCAP_LOONGSON_CPUCFG;
++}
++
++/* Most toolchains have no CPUCFG support yet */
++static uint32_t read_cpucfg(uint32_t reg)
++{
++        uint32_t __res;
++
++        __asm__ __volatile__(
++                "parse_r __res,%0\n\t"
++                "parse_r reg,%1\n\t"
++                ".insn \n\t"
++                ".word (0xc8080118 | (reg << 21) | (__res << 11))\n\t"
++                :"=r"(__res)
++                :"r"(reg)
++                :
++                );
++        return __res;
++}
++
++#define LOONGSON_CFG1 0x1
++
++#define LOONGSON_CFG1_MMI    (1 << 4)
++#define LOONGSON_CFG1_MSA1   (1 << 5)
++
++static int cpu_flags_cpucfg(void)
++{
++    int flags = 0;
++    uint32_t cfg1 = read_cpucfg(LOONGSON_CFG1);
++
++    if (cfg1 & LOONGSON_CFG1_MMI)
++        flags |= AV_CPU_FLAG_MMI;
++
++    if (cfg1 & LOONGSON_CFG1_MSA1)
++        flags |= AV_CPU_FLAG_MSA;
++
++    return flags;
++}
++
++static int cpu_flags_cpuinfo(void)
++{
++    FILE *f = fopen("/proc/cpuinfo", "r");
++    char buf[200];
++    int flags = 0;
++
++    if (!f)
++        return -1;
++
++    while (fgets(buf, sizeof(buf), f)) {
++        /* Legacy kernel may not export MMI in ASEs implemented */
++        if (av_strstart(buf, "cpu model", NULL)) {
++            if (strstr(buf, "Loongson-3 "))
++                flags |= AV_CPU_FLAG_MMI;
++        }
++
++        if (av_strstart(buf, "ASEs implemented", NULL)) {
++            if (strstr(buf, " loongson-mmi"))
++                flags |= AV_CPU_FLAG_MMI;
++            if (strstr(buf, " msa"))
++                flags |= AV_CPU_FLAG_MSA;
++
++            break;
++        }
++    }
++    fclose(f);
++    return flags;
++}
++#endif
++
++int ff_get_cpu_flags_mips(void)
++{
++#if defined __linux__ || defined __ANDROID__
++    if (cpucfg_available())
++        return cpu_flags_cpucfg();
++    else
++        return cpu_flags_cpuinfo();
++#else
++    /* Assume no SIMD ASE supported */
++    return 0;
++#endif
++}
++
++size_t ff_get_cpu_max_align_mips(void)
++{
++    int flags = av_get_cpu_flags();
++
++    if (flags & AV_CPU_FLAG_MSA)
++        return 16;
++
++    /*
++     * MMI itself is 64-bit but quad word load & store
++     * needs 128-bit align.
++     */
++    if (flags & AV_CPU_FLAG_MMI)
++        return 16;
++
++    return 8;
++}
+diff --git a/libavutil/mips/cpu.h b/libavutil/mips/cpu.h
+new file mode 100644
+index 0000000000..615dc49759
+--- /dev/null
++++ b/libavutil/mips/cpu.h
+@@ -0,0 +1,28 @@
++/*
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#ifndef AVUTIL_MIPS_CPU_H
++#define AVUTIL_MIPS_CPU_H
++
++#include "libavutil/cpu.h"
++#include "libavutil/cpu_internal.h"
++
++#define have_mmi(flags) CPUEXT(flags, MMI)
++#define have_msa(flags) CPUEXT(flags, MSA)
++
++#endif /* AVUTIL_MIPS_CPU_H */
+diff --git a/libavutil/tests/cpu.c b/libavutil/tests/cpu.c
+index ce45b715a0..c853371fb3 100644
+--- a/libavutil/tests/cpu.c
++++ b/libavutil/tests/cpu.c
+@@ -49,6 +49,9 @@ static const struct {
+     { AV_CPU_FLAG_SETEND,    "setend"     },
+ #elif ARCH_PPC
+     { AV_CPU_FLAG_ALTIVEC,   "altivec"    },
++#elif ARCH_MIPS
++    { AV_CPU_FLAG_MMI,       "mmi"        },
++    { AV_CPU_FLAG_MSA,       "msa"        },
+ #elif ARCH_X86
+     { AV_CPU_FLAG_MMX,       "mmx"        },
+     { AV_CPU_FLAG_MMXEXT,    "mmxext"     },
+diff --git a/tests/checkasm/checkasm.c b/tests/checkasm/checkasm.c
+index 3e2ec377be..78b2a4be6a 100644
+--- a/tests/checkasm/checkasm.c
++++ b/tests/checkasm/checkasm.c
+@@ -206,6 +206,9 @@ static const struct {
+     { "ALTIVEC",  "altivec",  AV_CPU_FLAG_ALTIVEC },
+     { "VSX",      "vsx",      AV_CPU_FLAG_VSX },
+     { "POWER8",   "power8",   AV_CPU_FLAG_POWER8 },
++#elif ARCH_MIPS
++    { "MMI",      "mmi",      AV_CPU_FLAG_MMI },
++    { "MSA",      "msa",      AV_CPU_FLAG_MSA },
+ #elif ARCH_X86
+     { "MMX",      "mmx",      AV_CPU_FLAG_MMX|AV_CPU_FLAG_CMOV },
+     { "MMXEXT",   "mmxext",   AV_CPU_FLAG_MMXEXT },
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0015-libavcodec-Enable-runtime-detection-for-MIPS-MMI-MSA.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0015-libavcodec-Enable-runtime-detection-for-MIPS-MMI-MSA.patch
@@ -1,0 +1,3723 @@
+From 51a004e280447ecc0e79c15ff8ada323f4749144 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Sat, 18 Jul 2020 23:35:40 +0800
+Subject: [PATCH 15/26] libavcodec: Enable runtime detection for MIPS MMI & MSA
+
+Apply optimized functions according to cpuflags.
+MSA is usually put after MMI as it's generally faster than MMI.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Reviewed-by: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/blockdsp_init_mips.c        |  40 +-
+ libavcodec/mips/cabac.h                     |   2 +-
+ libavcodec/mips/h263dsp_init_mips.c         |  18 +-
+ libavcodec/mips/h264chroma_init_mips.c      |  55 +-
+ libavcodec/mips/h264dsp_init_mips.c         | 225 +++--
+ libavcodec/mips/h264pred_init_mips.c        | 207 ++--
+ libavcodec/mips/h264qpel_init_mips.c        | 412 ++++----
+ libavcodec/mips/hevcdsp_init_mips.c         | 992 ++++++++++----------
+ libavcodec/mips/hevcpred_init_mips.c        |  40 +-
+ libavcodec/mips/hpeldsp_init_mips.c         | 180 ++--
+ libavcodec/mips/idctdsp_init_mips.c         |  74 +-
+ libavcodec/mips/me_cmp_init_mips.c          |  50 +-
+ libavcodec/mips/mpegvideo_init_mips.c       |  48 +-
+ libavcodec/mips/mpegvideoencdsp_init_mips.c |  21 +-
+ libavcodec/mips/pixblockdsp_init_mips.c     |  63 +-
+ libavcodec/mips/qpeldsp_init_mips.c         | 270 +++---
+ libavcodec/mips/vc1dsp_init_mips.c          | 186 ++--
+ libavcodec/mips/videodsp_init.c             |  10 +-
+ libavcodec/mips/vp3dsp_init_mips.c          |  44 +-
+ libavcodec/mips/vp8dsp_init_mips.c          | 240 +++--
+ libavcodec/mips/vp9dsp_init_mips.c          |  16 +-
+ libavcodec/mips/wmv2dsp_init_mips.c         |  18 +-
+ libavcodec/mips/wmv2dsp_mips.h              |   4 +-
+ libavcodec/mips/wmv2dsp_mmi.c               |   4 +-
+ libavcodec/mips/xvididct_init_mips.c        |  31 +-
+ 25 files changed, 1543 insertions(+), 1707 deletions(-)
+
+diff --git a/libavcodec/mips/blockdsp_init_mips.c b/libavcodec/mips/blockdsp_init_mips.c
+index 55ac1c3e99..c6964fa74e 100644
+--- a/libavcodec/mips/blockdsp_init_mips.c
++++ b/libavcodec/mips/blockdsp_init_mips.c
+@@ -19,36 +19,26 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "blockdsp_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void blockdsp_init_msa(BlockDSPContext *c)
++void ff_blockdsp_init_mips(BlockDSPContext *c)
+ {
+-    c->clear_block = ff_clear_block_msa;
+-    c->clear_blocks = ff_clear_blocks_msa;
++    int cpu_flags = av_get_cpu_flags();
+ 
+-    c->fill_block_tab[0] = ff_fill_block16_msa;
+-    c->fill_block_tab[1] = ff_fill_block8_msa;
+-}
+-#endif  // #if HAVE_MSA
++    if (have_mmi(cpu_flags)) {
++        c->clear_block = ff_clear_block_mmi;
++        c->clear_blocks = ff_clear_blocks_mmi;
+ 
+-#if HAVE_MMI
+-static av_cold void blockdsp_init_mmi(BlockDSPContext *c)
+-{
+-    c->clear_block = ff_clear_block_mmi;
+-    c->clear_blocks = ff_clear_blocks_mmi;
++        c->fill_block_tab[0] = ff_fill_block16_mmi;
++        c->fill_block_tab[1] = ff_fill_block8_mmi;
++    }
+ 
+-    c->fill_block_tab[0] = ff_fill_block16_mmi;
+-    c->fill_block_tab[1] = ff_fill_block8_mmi;
+-}
+-#endif /* HAVE_MMI */
++    if (have_msa(cpu_flags)) {
++        c->clear_block = ff_clear_block_msa;
++        c->clear_blocks = ff_clear_blocks_msa;
+ 
+-void ff_blockdsp_init_mips(BlockDSPContext *c)
+-{
+-#if HAVE_MMI
+-    blockdsp_init_mmi(c);
+-#endif /* HAVE_MMI */
+-#if HAVE_MSA
+-    blockdsp_init_msa(c);
+-#endif  // #if HAVE_MSA
++        c->fill_block_tab[0] = ff_fill_block16_msa;
++        c->fill_block_tab[1] = ff_fill_block8_msa;
++    }
+ }
+diff --git a/libavcodec/mips/cabac.h b/libavcodec/mips/cabac.h
+index 03b5010edc..c595915eda 100644
+--- a/libavcodec/mips/cabac.h
++++ b/libavcodec/mips/cabac.h
+@@ -25,7 +25,7 @@
+ #define AVCODEC_MIPS_CABAC_H
+ 
+ #include "libavcodec/cabac.h"
+-#include "libavutil/mips/mmiutils.h"
++#include "libavutil/mips/asmdefs.h"
+ #include "config.h"
+ 
+ #define get_cabac_inline get_cabac_inline_mips
+diff --git a/libavcodec/mips/h263dsp_init_mips.c b/libavcodec/mips/h263dsp_init_mips.c
+index 09bd93707d..a73eb12d87 100644
+--- a/libavcodec/mips/h263dsp_init_mips.c
++++ b/libavcodec/mips/h263dsp_init_mips.c
+@@ -18,19 +18,15 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "h263dsp_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void h263dsp_init_msa(H263DSPContext *c)
+-{
+-    c->h263_h_loop_filter = ff_h263_h_loop_filter_msa;
+-    c->h263_v_loop_filter = ff_h263_v_loop_filter_msa;
+-}
+-#endif  // #if HAVE_MSA
+-
+ av_cold void ff_h263dsp_init_mips(H263DSPContext *c)
+ {
+-#if HAVE_MSA
+-    h263dsp_init_msa(c);
+-#endif  // #if HAVE_MSA
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_msa(cpu_flags)){
++        c->h263_h_loop_filter = ff_h263_h_loop_filter_msa;
++        c->h263_v_loop_filter = ff_h263_v_loop_filter_msa;
++    }
+ }
+diff --git a/libavcodec/mips/h264chroma_init_mips.c b/libavcodec/mips/h264chroma_init_mips.c
+index ae817e47ae..6bb19d3ddd 100644
+--- a/libavcodec/mips/h264chroma_init_mips.c
++++ b/libavcodec/mips/h264chroma_init_mips.c
+@@ -19,45 +19,34 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "h264chroma_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void h264chroma_init_msa(H264ChromaContext *c, int bit_depth)
+-{
+-    const int high_bit_depth = bit_depth > 8;
+-
+-    if (!high_bit_depth) {
+-        c->put_h264_chroma_pixels_tab[0] = ff_put_h264_chroma_mc8_msa;
+-        c->put_h264_chroma_pixels_tab[1] = ff_put_h264_chroma_mc4_msa;
+-        c->put_h264_chroma_pixels_tab[2] = ff_put_h264_chroma_mc2_msa;
+-
+-        c->avg_h264_chroma_pixels_tab[0] = ff_avg_h264_chroma_mc8_msa;
+-        c->avg_h264_chroma_pixels_tab[1] = ff_avg_h264_chroma_mc4_msa;
+-        c->avg_h264_chroma_pixels_tab[2] = ff_avg_h264_chroma_mc2_msa;
+-    }
+-}
+-#endif  // #if HAVE_MSA
+ 
+-#if HAVE_MMI
+-static av_cold void h264chroma_init_mmi(H264ChromaContext *c, int bit_depth)
++av_cold void ff_h264chroma_init_mips(H264ChromaContext *c, int bit_depth)
+ {
++    int cpu_flags = av_get_cpu_flags();
+     int high_bit_depth = bit_depth > 8;
+ 
+-    if (!high_bit_depth) {
+-        c->put_h264_chroma_pixels_tab[0] = ff_put_h264_chroma_mc8_mmi;
+-        c->avg_h264_chroma_pixels_tab[0] = ff_avg_h264_chroma_mc8_mmi;
+-        c->put_h264_chroma_pixels_tab[1] = ff_put_h264_chroma_mc4_mmi;
+-        c->avg_h264_chroma_pixels_tab[1] = ff_avg_h264_chroma_mc4_mmi;
++    /* MMI apears to be faster than MSA here */
++    if (have_msa(cpu_flags)) {
++        if (!high_bit_depth) {
++            c->put_h264_chroma_pixels_tab[0] = ff_put_h264_chroma_mc8_msa;
++            c->put_h264_chroma_pixels_tab[1] = ff_put_h264_chroma_mc4_msa;
++            c->put_h264_chroma_pixels_tab[2] = ff_put_h264_chroma_mc2_msa;
++
++            c->avg_h264_chroma_pixels_tab[0] = ff_avg_h264_chroma_mc8_msa;
++            c->avg_h264_chroma_pixels_tab[1] = ff_avg_h264_chroma_mc4_msa;
++            c->avg_h264_chroma_pixels_tab[2] = ff_avg_h264_chroma_mc2_msa;
++        }
+     }
+-}
+-#endif /* HAVE_MMI */
+ 
+-av_cold void ff_h264chroma_init_mips(H264ChromaContext *c, int bit_depth)
+-{
+-#if HAVE_MMI
+-    h264chroma_init_mmi(c, bit_depth);
+-#endif /* HAVE_MMI */
+-#if HAVE_MSA
+-    h264chroma_init_msa(c, bit_depth);
+-#endif  // #if HAVE_MSA
++    if (have_mmi(cpu_flags)) {
++        if (!high_bit_depth) {
++            c->put_h264_chroma_pixels_tab[0] = ff_put_h264_chroma_mc8_mmi;
++            c->avg_h264_chroma_pixels_tab[0] = ff_avg_h264_chroma_mc8_mmi;
++            c->put_h264_chroma_pixels_tab[1] = ff_put_h264_chroma_mc4_mmi;
++            c->avg_h264_chroma_pixels_tab[1] = ff_avg_h264_chroma_mc4_mmi;
++        }
++    }
+ }
+diff --git a/libavcodec/mips/h264dsp_init_mips.c b/libavcodec/mips/h264dsp_init_mips.c
+index dc08a25800..9cd05e0f2f 100644
+--- a/libavcodec/mips/h264dsp_init_mips.c
++++ b/libavcodec/mips/h264dsp_init_mips.c
+@@ -19,129 +19,116 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "h264dsp_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void h264dsp_init_msa(H264DSPContext *c,
+-                                     const int bit_depth,
+-                                     const int chroma_format_idc)
+-{
+-    if (8 == bit_depth) {
+-        c->h264_v_loop_filter_luma = ff_h264_v_lpf_luma_inter_msa;
+-        c->h264_h_loop_filter_luma = ff_h264_h_lpf_luma_inter_msa;
+-        c->h264_h_loop_filter_luma_mbaff =
+-            ff_h264_h_loop_filter_luma_mbaff_msa;
+-        c->h264_v_loop_filter_luma_intra = ff_h264_v_lpf_luma_intra_msa;
+-        c->h264_h_loop_filter_luma_intra = ff_h264_h_lpf_luma_intra_msa;
+-        c->h264_h_loop_filter_luma_mbaff_intra =
+-            ff_h264_h_loop_filter_luma_mbaff_intra_msa;
+-        c->h264_v_loop_filter_chroma = ff_h264_v_lpf_chroma_inter_msa;
+-
+-        if (chroma_format_idc <= 1)
+-            c->h264_h_loop_filter_chroma = ff_h264_h_lpf_chroma_inter_msa;
+-        else
+-            c->h264_h_loop_filter_chroma =
+-                ff_h264_h_loop_filter_chroma422_msa;
+-
+-        if (chroma_format_idc > 1)
+-            c->h264_h_loop_filter_chroma_mbaff =
+-                ff_h264_h_loop_filter_chroma422_mbaff_msa;
+-
+-        c->h264_v_loop_filter_chroma_intra =
+-            ff_h264_v_lpf_chroma_intra_msa;
+-
+-        if (chroma_format_idc <= 1)
+-            c->h264_h_loop_filter_chroma_intra =
+-                ff_h264_h_lpf_chroma_intra_msa;
+-
+-        /* Weighted MC */
+-        c->weight_h264_pixels_tab[0] = ff_weight_h264_pixels16_8_msa;
+-        c->weight_h264_pixels_tab[1] = ff_weight_h264_pixels8_8_msa;
+-        c->weight_h264_pixels_tab[2] = ff_weight_h264_pixels4_8_msa;
+-
+-        c->biweight_h264_pixels_tab[0] = ff_biweight_h264_pixels16_8_msa;
+-        c->biweight_h264_pixels_tab[1] = ff_biweight_h264_pixels8_8_msa;
+-        c->biweight_h264_pixels_tab[2] = ff_biweight_h264_pixels4_8_msa;
+-
+-        c->h264_idct_add = ff_h264_idct_add_msa;
+-        c->h264_idct8_add = ff_h264_idct8_addblk_msa;
+-        c->h264_idct_dc_add = ff_h264_idct4x4_addblk_dc_msa;
+-        c->h264_idct8_dc_add = ff_h264_idct8_dc_addblk_msa;
+-        c->h264_idct_add16 = ff_h264_idct_add16_msa;
+-        c->h264_idct8_add4 = ff_h264_idct8_add4_msa;
+-
+-        if (chroma_format_idc <= 1)
+-            c->h264_idct_add8 = ff_h264_idct_add8_msa;
+-        else
+-            c->h264_idct_add8 = ff_h264_idct_add8_422_msa;
+-
+-        c->h264_idct_add16intra = ff_h264_idct_add16_intra_msa;
+-        c->h264_luma_dc_dequant_idct = ff_h264_deq_idct_luma_dc_msa;
+-    }  // if (8 == bit_depth)
+-}
+-#endif  // #if HAVE_MSA
+-
+-#if HAVE_MMI
+-static av_cold void h264dsp_init_mmi(H264DSPContext * c, const int bit_depth,
+-        const int chroma_format_idc)
++av_cold void ff_h264dsp_init_mips(H264DSPContext *c, const int bit_depth,
++                                  const int chroma_format_idc)
+ {
+-    if (bit_depth == 8) {
+-        c->h264_add_pixels4_clear = ff_h264_add_pixels4_8_mmi;
+-        c->h264_idct_add = ff_h264_idct_add_8_mmi;
+-        c->h264_idct8_add = ff_h264_idct8_add_8_mmi;
+-        c->h264_idct_dc_add = ff_h264_idct_dc_add_8_mmi;
+-        c->h264_idct8_dc_add = ff_h264_idct8_dc_add_8_mmi;
+-        c->h264_idct_add16 = ff_h264_idct_add16_8_mmi;
+-        c->h264_idct_add16intra = ff_h264_idct_add16intra_8_mmi;
+-        c->h264_idct8_add4 = ff_h264_idct8_add4_8_mmi;
+-
+-        if (chroma_format_idc <= 1)
+-            c->h264_idct_add8 = ff_h264_idct_add8_8_mmi;
+-        else
+-            c->h264_idct_add8 = ff_h264_idct_add8_422_8_mmi;
+-
+-        c->h264_luma_dc_dequant_idct = ff_h264_luma_dc_dequant_idct_8_mmi;
+-
+-        if (chroma_format_idc <= 1)
+-            c->h264_chroma_dc_dequant_idct =
+-                ff_h264_chroma_dc_dequant_idct_8_mmi;
+-        else
+-            c->h264_chroma_dc_dequant_idct =
+-                ff_h264_chroma422_dc_dequant_idct_8_mmi;
+-
+-        c->weight_h264_pixels_tab[0] = ff_h264_weight_pixels16_8_mmi;
+-        c->weight_h264_pixels_tab[1] = ff_h264_weight_pixels8_8_mmi;
+-        c->weight_h264_pixels_tab[2] = ff_h264_weight_pixels4_8_mmi;
+-
+-        c->biweight_h264_pixels_tab[0] = ff_h264_biweight_pixels16_8_mmi;
+-        c->biweight_h264_pixels_tab[1] = ff_h264_biweight_pixels8_8_mmi;
+-        c->biweight_h264_pixels_tab[2] = ff_h264_biweight_pixels4_8_mmi;
+-
+-        c->h264_v_loop_filter_chroma       = ff_deblock_v_chroma_8_mmi;
+-        c->h264_v_loop_filter_chroma_intra = ff_deblock_v_chroma_intra_8_mmi;
+-
+-        if (chroma_format_idc <= 1) {
+-            c->h264_h_loop_filter_chroma =
+-                ff_deblock_h_chroma_8_mmi;
+-            c->h264_h_loop_filter_chroma_intra =
+-                ff_deblock_h_chroma_intra_8_mmi;
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_mmi(cpu_flags)) {
++        if (bit_depth == 8) {
++            c->h264_add_pixels4_clear = ff_h264_add_pixels4_8_mmi;
++            c->h264_idct_add = ff_h264_idct_add_8_mmi;
++            c->h264_idct8_add = ff_h264_idct8_add_8_mmi;
++            c->h264_idct_dc_add = ff_h264_idct_dc_add_8_mmi;
++            c->h264_idct8_dc_add = ff_h264_idct8_dc_add_8_mmi;
++            c->h264_idct_add16 = ff_h264_idct_add16_8_mmi;
++            c->h264_idct_add16intra = ff_h264_idct_add16intra_8_mmi;
++            c->h264_idct8_add4 = ff_h264_idct8_add4_8_mmi;
++
++            if (chroma_format_idc <= 1)
++                c->h264_idct_add8 = ff_h264_idct_add8_8_mmi;
++            else
++                c->h264_idct_add8 = ff_h264_idct_add8_422_8_mmi;
++
++            c->h264_luma_dc_dequant_idct = ff_h264_luma_dc_dequant_idct_8_mmi;
++
++            if (chroma_format_idc <= 1)
++                c->h264_chroma_dc_dequant_idct =
++                    ff_h264_chroma_dc_dequant_idct_8_mmi;
++            else
++                c->h264_chroma_dc_dequant_idct =
++                    ff_h264_chroma422_dc_dequant_idct_8_mmi;
++
++            c->weight_h264_pixels_tab[0] = ff_h264_weight_pixels16_8_mmi;
++            c->weight_h264_pixels_tab[1] = ff_h264_weight_pixels8_8_mmi;
++            c->weight_h264_pixels_tab[2] = ff_h264_weight_pixels4_8_mmi;
++
++            c->biweight_h264_pixels_tab[0] = ff_h264_biweight_pixels16_8_mmi;
++            c->biweight_h264_pixels_tab[1] = ff_h264_biweight_pixels8_8_mmi;
++            c->biweight_h264_pixels_tab[2] = ff_h264_biweight_pixels4_8_mmi;
++
++            c->h264_v_loop_filter_chroma       = ff_deblock_v_chroma_8_mmi;
++            c->h264_v_loop_filter_chroma_intra = ff_deblock_v_chroma_intra_8_mmi;
++
++            if (chroma_format_idc <= 1) {
++                c->h264_h_loop_filter_chroma =
++                    ff_deblock_h_chroma_8_mmi;
++                c->h264_h_loop_filter_chroma_intra =
++                    ff_deblock_h_chroma_intra_8_mmi;
++            }
++
++            c->h264_v_loop_filter_luma = ff_deblock_v_luma_8_mmi;
++            c->h264_v_loop_filter_luma_intra = ff_deblock_v_luma_intra_8_mmi;
++            c->h264_h_loop_filter_luma = ff_deblock_h_luma_8_mmi;
++            c->h264_h_loop_filter_luma_intra = ff_deblock_h_luma_intra_8_mmi;
+         }
+-
+-        c->h264_v_loop_filter_luma = ff_deblock_v_luma_8_mmi;
+-        c->h264_v_loop_filter_luma_intra = ff_deblock_v_luma_intra_8_mmi;
+-        c->h264_h_loop_filter_luma = ff_deblock_h_luma_8_mmi;
+-        c->h264_h_loop_filter_luma_intra = ff_deblock_h_luma_intra_8_mmi;
+     }
+-}
+-#endif /* HAVE_MMI */
+ 
+-av_cold void ff_h264dsp_init_mips(H264DSPContext *c, const int bit_depth,
+-                                  const int chroma_format_idc)
+-{
+-#if HAVE_MMI
+-    h264dsp_init_mmi(c, bit_depth, chroma_format_idc);
+-#endif /* HAVE_MMI */
+-#if HAVE_MSA
+-    h264dsp_init_msa(c, bit_depth, chroma_format_idc);
+-#endif  // #if HAVE_MSA
++    if (have_msa(cpu_flags)) {
++        if (bit_depth == 8) {
++            c->h264_v_loop_filter_luma = ff_h264_v_lpf_luma_inter_msa;
++            c->h264_h_loop_filter_luma = ff_h264_h_lpf_luma_inter_msa;
++            c->h264_h_loop_filter_luma_mbaff =
++                ff_h264_h_loop_filter_luma_mbaff_msa;
++            c->h264_v_loop_filter_luma_intra = ff_h264_v_lpf_luma_intra_msa;
++            c->h264_h_loop_filter_luma_intra = ff_h264_h_lpf_luma_intra_msa;
++            c->h264_h_loop_filter_luma_mbaff_intra =
++                ff_h264_h_loop_filter_luma_mbaff_intra_msa;
++            c->h264_v_loop_filter_chroma = ff_h264_v_lpf_chroma_inter_msa;
++
++            if (chroma_format_idc <= 1)
++                c->h264_h_loop_filter_chroma = ff_h264_h_lpf_chroma_inter_msa;
++            else
++                c->h264_h_loop_filter_chroma =
++                    ff_h264_h_loop_filter_chroma422_msa;
++
++            if (chroma_format_idc > 1)
++                c->h264_h_loop_filter_chroma_mbaff =
++                    ff_h264_h_loop_filter_chroma422_mbaff_msa;
++
++            c->h264_v_loop_filter_chroma_intra =
++                ff_h264_v_lpf_chroma_intra_msa;
++
++            if (chroma_format_idc <= 1)
++                c->h264_h_loop_filter_chroma_intra =
++                    ff_h264_h_lpf_chroma_intra_msa;
++
++            /* Weighted MC */
++            c->weight_h264_pixels_tab[0] = ff_weight_h264_pixels16_8_msa;
++            c->weight_h264_pixels_tab[1] = ff_weight_h264_pixels8_8_msa;
++            c->weight_h264_pixels_tab[2] = ff_weight_h264_pixels4_8_msa;
++
++            c->biweight_h264_pixels_tab[0] = ff_biweight_h264_pixels16_8_msa;
++            c->biweight_h264_pixels_tab[1] = ff_biweight_h264_pixels8_8_msa;
++            c->biweight_h264_pixels_tab[2] = ff_biweight_h264_pixels4_8_msa;
++
++            c->h264_idct_add = ff_h264_idct_add_msa;
++            c->h264_idct8_add = ff_h264_idct8_addblk_msa;
++            c->h264_idct_dc_add = ff_h264_idct4x4_addblk_dc_msa;
++            c->h264_idct8_dc_add = ff_h264_idct8_dc_addblk_msa;
++            c->h264_idct_add16 = ff_h264_idct_add16_msa;
++            c->h264_idct8_add4 = ff_h264_idct8_add4_msa;
++
++            if (chroma_format_idc <= 1)
++                c->h264_idct_add8 = ff_h264_idct_add8_msa;
++            else
++                c->h264_idct_add8 = ff_h264_idct_add8_422_msa;
++
++            c->h264_idct_add16intra = ff_h264_idct_add16_intra_msa;
++            c->h264_luma_dc_dequant_idct = ff_h264_deq_idct_luma_dc_msa;
++        }
++    }
+ }
+diff --git a/libavcodec/mips/h264pred_init_mips.c b/libavcodec/mips/h264pred_init_mips.c
+index e537ad8bd4..0fd9bb737a 100644
+--- a/libavcodec/mips/h264pred_init_mips.c
++++ b/libavcodec/mips/h264pred_init_mips.c
+@@ -19,134 +19,121 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "config.h"
+ #include "h264dsp_mips.h"
+ #include "h264pred_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void h264_pred_init_msa(H264PredContext *h, int codec_id,
+-                                       const int bit_depth,
+-                                       const int chroma_format_idc)
++av_cold void ff_h264_pred_init_mips(H264PredContext *h, int codec_id,
++                                    int bit_depth,
++                                    const int chroma_format_idc)
+ {
+-    if (8 == bit_depth) {
+-        if (chroma_format_idc == 1) {
+-            h->pred8x8[VERT_PRED8x8] = ff_h264_intra_pred_vert_8x8_msa;
+-            h->pred8x8[HOR_PRED8x8] = ff_h264_intra_pred_horiz_8x8_msa;
+-        }
++    int cpu_flags = av_get_cpu_flags();
+ 
+-        if (codec_id != AV_CODEC_ID_VP7 && codec_id != AV_CODEC_ID_VP8) {
++    if (have_mmi(cpu_flags)) {
++        if (bit_depth == 8) {
+             if (chroma_format_idc == 1) {
+-                h->pred8x8[PLANE_PRED8x8] = ff_h264_intra_predict_plane_8x8_msa;
+-            }
+-        }
+-        if (codec_id != AV_CODEC_ID_RV40 && codec_id != AV_CODEC_ID_VP7
+-            && codec_id != AV_CODEC_ID_VP8) {
+-            if (chroma_format_idc == 1) {
+-                h->pred8x8[DC_PRED8x8] = ff_h264_intra_predict_dc_4blk_8x8_msa;
+-                h->pred8x8[LEFT_DC_PRED8x8] =
+-                    ff_h264_intra_predict_hor_dc_8x8_msa;
+-                h->pred8x8[TOP_DC_PRED8x8] =
+-                    ff_h264_intra_predict_vert_dc_8x8_msa;
+-                h->pred8x8[ALZHEIMER_DC_L0T_PRED8x8] =
+-                    ff_h264_intra_predict_mad_cow_dc_l0t_8x8_msa;
+-                h->pred8x8[ALZHEIMER_DC_0LT_PRED8x8] =
+-                    ff_h264_intra_predict_mad_cow_dc_0lt_8x8_msa;
+-                h->pred8x8[ALZHEIMER_DC_L00_PRED8x8] =
+-                    ff_h264_intra_predict_mad_cow_dc_l00_8x8_msa;
+-                h->pred8x8[ALZHEIMER_DC_0L0_PRED8x8] =
+-                    ff_h264_intra_predict_mad_cow_dc_0l0_8x8_msa;
+-            }
+-        } else {
+-            if (codec_id == AV_CODEC_ID_VP7 || codec_id == AV_CODEC_ID_VP8) {
+-                h->pred8x8[7] = ff_vp8_pred8x8_127_dc_8_msa;
+-                h->pred8x8[8] = ff_vp8_pred8x8_129_dc_8_msa;
++                h->pred8x8  [VERT_PRED8x8       ] = ff_pred8x8_vertical_8_mmi;
++                h->pred8x8  [HOR_PRED8x8        ] = ff_pred8x8_horizontal_8_mmi;
++            } else {
++                h->pred8x8  [VERT_PRED8x8       ] = ff_pred8x16_vertical_8_mmi;
++                h->pred8x8  [HOR_PRED8x8        ] = ff_pred8x16_horizontal_8_mmi;
+             }
+-        }
+ 
+-        if (chroma_format_idc == 1) {
+-            h->pred8x8[DC_128_PRED8x8] = ff_h264_intra_pred_dc_128_8x8_msa;
+-        }
++            h->pred16x16[DC_PRED8x8             ] = ff_pred16x16_dc_8_mmi;
++            h->pred16x16[VERT_PRED8x8           ] = ff_pred16x16_vertical_8_mmi;
++            h->pred16x16[HOR_PRED8x8            ] = ff_pred16x16_horizontal_8_mmi;
++            h->pred8x8l [TOP_DC_PRED            ] = ff_pred8x8l_top_dc_8_mmi;
++            h->pred8x8l [DC_PRED                ] = ff_pred8x8l_dc_8_mmi;
+ 
+-        h->pred16x16[DC_PRED8x8] = ff_h264_intra_pred_dc_16x16_msa;
+-        h->pred16x16[VERT_PRED8x8] = ff_h264_intra_pred_vert_16x16_msa;
+-        h->pred16x16[HOR_PRED8x8] = ff_h264_intra_pred_horiz_16x16_msa;
++    #if ARCH_MIPS64
++            switch (codec_id) {
++            case AV_CODEC_ID_SVQ3:
++                h->pred16x16[PLANE_PRED8x8      ] = ff_pred16x16_plane_svq3_8_mmi;
++                break;
++            case AV_CODEC_ID_RV40:
++                h->pred16x16[PLANE_PRED8x8      ] = ff_pred16x16_plane_rv40_8_mmi;
++                break;
++            case AV_CODEC_ID_VP7:
++            case AV_CODEC_ID_VP8:
++                break;
++            default:
++                h->pred16x16[PLANE_PRED8x8      ] = ff_pred16x16_plane_h264_8_mmi;
++                break;
++            }
++    #endif
+ 
+-        switch (codec_id) {
+-        case AV_CODEC_ID_SVQ3:
+-        case AV_CODEC_ID_RV40:
+-            break;
+-        case AV_CODEC_ID_VP7:
+-        case AV_CODEC_ID_VP8:
+-            h->pred16x16[7] = ff_vp8_pred16x16_127_dc_8_msa;
+-            h->pred16x16[8] = ff_vp8_pred16x16_129_dc_8_msa;
+-            break;
+-        default:
+-            h->pred16x16[PLANE_PRED8x8] =
+-                ff_h264_intra_predict_plane_16x16_msa;
+-            break;
++            if (codec_id == AV_CODEC_ID_SVQ3 || codec_id == AV_CODEC_ID_H264) {
++                if (chroma_format_idc == 1) {
++                    h->pred8x8[TOP_DC_PRED8x8   ] = ff_pred8x8_top_dc_8_mmi;
++                    h->pred8x8[DC_PRED8x8       ] = ff_pred8x8_dc_8_mmi;
++                }
++            }
+         }
+-
+-        h->pred16x16[LEFT_DC_PRED8x8] = ff_h264_intra_pred_dc_left_16x16_msa;
+-        h->pred16x16[TOP_DC_PRED8x8] = ff_h264_intra_pred_dc_top_16x16_msa;
+-        h->pred16x16[DC_128_PRED8x8] = ff_h264_intra_pred_dc_128_16x16_msa;
+     }
+-}
+-#endif  // #if HAVE_MSA
+-
+-#if HAVE_MMI
+-static av_cold void h264_pred_init_mmi(H264PredContext *h, int codec_id,
+-        const int bit_depth, const int chroma_format_idc)
+-{
+-    if (bit_depth == 8) {
+-        if (chroma_format_idc == 1) {
+-            h->pred8x8  [VERT_PRED8x8       ] = ff_pred8x8_vertical_8_mmi;
+-            h->pred8x8  [HOR_PRED8x8        ] = ff_pred8x8_horizontal_8_mmi;
+-        } else {
+-            h->pred8x8  [VERT_PRED8x8       ] = ff_pred8x16_vertical_8_mmi;
+-            h->pred8x8  [HOR_PRED8x8        ] = ff_pred8x16_horizontal_8_mmi;
+-        }
+ 
+-        h->pred16x16[DC_PRED8x8             ] = ff_pred16x16_dc_8_mmi;
+-        h->pred16x16[VERT_PRED8x8           ] = ff_pred16x16_vertical_8_mmi;
+-        h->pred16x16[HOR_PRED8x8            ] = ff_pred16x16_horizontal_8_mmi;
+-        h->pred8x8l [TOP_DC_PRED            ] = ff_pred8x8l_top_dc_8_mmi;
+-        h->pred8x8l [DC_PRED                ] = ff_pred8x8l_dc_8_mmi;
++    if (have_msa(cpu_flags)) {
++        if (8 == bit_depth) {
++            if (chroma_format_idc == 1) {
++                h->pred8x8[VERT_PRED8x8] = ff_h264_intra_pred_vert_8x8_msa;
++                h->pred8x8[HOR_PRED8x8] = ff_h264_intra_pred_horiz_8x8_msa;
++            }
+ 
+-#if ARCH_MIPS64
+-        switch (codec_id) {
+-        case AV_CODEC_ID_SVQ3:
+-            h->pred16x16[PLANE_PRED8x8      ] = ff_pred16x16_plane_svq3_8_mmi;
+-            break;
+-        case AV_CODEC_ID_RV40:
+-            h->pred16x16[PLANE_PRED8x8      ] = ff_pred16x16_plane_rv40_8_mmi;
+-            break;
+-        case AV_CODEC_ID_VP7:
+-        case AV_CODEC_ID_VP8:
+-            break;
+-        default:
+-            h->pred16x16[PLANE_PRED8x8      ] = ff_pred16x16_plane_h264_8_mmi;
+-            break;
+-        }
+-#endif
++            if (codec_id != AV_CODEC_ID_VP7 && codec_id != AV_CODEC_ID_VP8) {
++                if (chroma_format_idc == 1) {
++                    h->pred8x8[PLANE_PRED8x8] = ff_h264_intra_predict_plane_8x8_msa;
++                }
++            }
++            if (codec_id != AV_CODEC_ID_RV40 && codec_id != AV_CODEC_ID_VP7
++                && codec_id != AV_CODEC_ID_VP8) {
++                if (chroma_format_idc == 1) {
++                    h->pred8x8[DC_PRED8x8] = ff_h264_intra_predict_dc_4blk_8x8_msa;
++                    h->pred8x8[LEFT_DC_PRED8x8] =
++                        ff_h264_intra_predict_hor_dc_8x8_msa;
++                    h->pred8x8[TOP_DC_PRED8x8] =
++                        ff_h264_intra_predict_vert_dc_8x8_msa;
++                    h->pred8x8[ALZHEIMER_DC_L0T_PRED8x8] =
++                        ff_h264_intra_predict_mad_cow_dc_l0t_8x8_msa;
++                    h->pred8x8[ALZHEIMER_DC_0LT_PRED8x8] =
++                        ff_h264_intra_predict_mad_cow_dc_0lt_8x8_msa;
++                    h->pred8x8[ALZHEIMER_DC_L00_PRED8x8] =
++                        ff_h264_intra_predict_mad_cow_dc_l00_8x8_msa;
++                    h->pred8x8[ALZHEIMER_DC_0L0_PRED8x8] =
++                        ff_h264_intra_predict_mad_cow_dc_0l0_8x8_msa;
++                }
++            } else {
++                if (codec_id == AV_CODEC_ID_VP7 || codec_id == AV_CODEC_ID_VP8) {
++                    h->pred8x8[7] = ff_vp8_pred8x8_127_dc_8_msa;
++                    h->pred8x8[8] = ff_vp8_pred8x8_129_dc_8_msa;
++                }
++            }
+ 
+-        if (codec_id == AV_CODEC_ID_SVQ3 || codec_id == AV_CODEC_ID_H264) {
+             if (chroma_format_idc == 1) {
+-                h->pred8x8[TOP_DC_PRED8x8   ] = ff_pred8x8_top_dc_8_mmi;
+-                h->pred8x8[DC_PRED8x8       ] = ff_pred8x8_dc_8_mmi;
++                h->pred8x8[DC_128_PRED8x8] = ff_h264_intra_pred_dc_128_8x8_msa;
++            }
++
++            h->pred16x16[DC_PRED8x8] = ff_h264_intra_pred_dc_16x16_msa;
++            h->pred16x16[VERT_PRED8x8] = ff_h264_intra_pred_vert_16x16_msa;
++            h->pred16x16[HOR_PRED8x8] = ff_h264_intra_pred_horiz_16x16_msa;
++
++            switch (codec_id) {
++            case AV_CODEC_ID_SVQ3:
++            case AV_CODEC_ID_RV40:
++                break;
++            case AV_CODEC_ID_VP7:
++            case AV_CODEC_ID_VP8:
++                h->pred16x16[7] = ff_vp8_pred16x16_127_dc_8_msa;
++                h->pred16x16[8] = ff_vp8_pred16x16_129_dc_8_msa;
++                break;
++            default:
++                h->pred16x16[PLANE_PRED8x8] =
++                    ff_h264_intra_predict_plane_16x16_msa;
++                break;
+             }
++
++            h->pred16x16[LEFT_DC_PRED8x8] = ff_h264_intra_pred_dc_left_16x16_msa;
++            h->pred16x16[TOP_DC_PRED8x8] = ff_h264_intra_pred_dc_top_16x16_msa;
++            h->pred16x16[DC_128_PRED8x8] = ff_h264_intra_pred_dc_128_16x16_msa;
+         }
+     }
+ }
+-#endif /* HAVE_MMI */
+-
+-av_cold void ff_h264_pred_init_mips(H264PredContext *h, int codec_id,
+-                                    int bit_depth,
+-                                    const int chroma_format_idc)
+-{
+-#if HAVE_MMI
+-    h264_pred_init_mmi(h, codec_id, bit_depth, chroma_format_idc);
+-#endif /* HAVE_MMI */
+-#if HAVE_MSA
+-    h264_pred_init_msa(h, codec_id, bit_depth, chroma_format_idc);
+-#endif  // #if HAVE_MSA
+-}
+diff --git a/libavcodec/mips/h264qpel_init_mips.c b/libavcodec/mips/h264qpel_init_mips.c
+index 33bae3093a..ea839f0714 100644
+--- a/libavcodec/mips/h264qpel_init_mips.c
++++ b/libavcodec/mips/h264qpel_init_mips.c
+@@ -19,231 +19,221 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "h264dsp_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void h264qpel_init_msa(H264QpelContext *c, int bit_depth)
++av_cold void ff_h264qpel_init_mips(H264QpelContext *c, int bit_depth)
+ {
+-    if (8 == bit_depth) {
+-        c->put_h264_qpel_pixels_tab[0][0] = ff_put_h264_qpel16_mc00_msa;
+-        c->put_h264_qpel_pixels_tab[0][1] = ff_put_h264_qpel16_mc10_msa;
+-        c->put_h264_qpel_pixels_tab[0][2] = ff_put_h264_qpel16_mc20_msa;
+-        c->put_h264_qpel_pixels_tab[0][3] = ff_put_h264_qpel16_mc30_msa;
+-        c->put_h264_qpel_pixels_tab[0][4] = ff_put_h264_qpel16_mc01_msa;
+-        c->put_h264_qpel_pixels_tab[0][5] = ff_put_h264_qpel16_mc11_msa;
+-        c->put_h264_qpel_pixels_tab[0][6] = ff_put_h264_qpel16_mc21_msa;
+-        c->put_h264_qpel_pixels_tab[0][7] = ff_put_h264_qpel16_mc31_msa;
+-        c->put_h264_qpel_pixels_tab[0][8] = ff_put_h264_qpel16_mc02_msa;
+-        c->put_h264_qpel_pixels_tab[0][9] = ff_put_h264_qpel16_mc12_msa;
+-        c->put_h264_qpel_pixels_tab[0][10] = ff_put_h264_qpel16_mc22_msa;
+-        c->put_h264_qpel_pixels_tab[0][11] = ff_put_h264_qpel16_mc32_msa;
+-        c->put_h264_qpel_pixels_tab[0][12] = ff_put_h264_qpel16_mc03_msa;
+-        c->put_h264_qpel_pixels_tab[0][13] = ff_put_h264_qpel16_mc13_msa;
+-        c->put_h264_qpel_pixels_tab[0][14] = ff_put_h264_qpel16_mc23_msa;
+-        c->put_h264_qpel_pixels_tab[0][15] = ff_put_h264_qpel16_mc33_msa;
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_mmi(cpu_flags)) {
++        if (bit_depth == 8) {
++            c->put_h264_qpel_pixels_tab[0][0] = ff_put_h264_qpel16_mc00_mmi;
++            c->put_h264_qpel_pixels_tab[0][1] = ff_put_h264_qpel16_mc10_mmi;
++            c->put_h264_qpel_pixels_tab[0][2] = ff_put_h264_qpel16_mc20_mmi;
++            c->put_h264_qpel_pixels_tab[0][3] = ff_put_h264_qpel16_mc30_mmi;
++            c->put_h264_qpel_pixels_tab[0][4] = ff_put_h264_qpel16_mc01_mmi;
++            c->put_h264_qpel_pixels_tab[0][5] = ff_put_h264_qpel16_mc11_mmi;
++            c->put_h264_qpel_pixels_tab[0][6] = ff_put_h264_qpel16_mc21_mmi;
++            c->put_h264_qpel_pixels_tab[0][7] = ff_put_h264_qpel16_mc31_mmi;
++            c->put_h264_qpel_pixels_tab[0][8] = ff_put_h264_qpel16_mc02_mmi;
++            c->put_h264_qpel_pixels_tab[0][9] = ff_put_h264_qpel16_mc12_mmi;
++            c->put_h264_qpel_pixels_tab[0][10] = ff_put_h264_qpel16_mc22_mmi;
++            c->put_h264_qpel_pixels_tab[0][11] = ff_put_h264_qpel16_mc32_mmi;
++            c->put_h264_qpel_pixels_tab[0][12] = ff_put_h264_qpel16_mc03_mmi;
++            c->put_h264_qpel_pixels_tab[0][13] = ff_put_h264_qpel16_mc13_mmi;
++            c->put_h264_qpel_pixels_tab[0][14] = ff_put_h264_qpel16_mc23_mmi;
++            c->put_h264_qpel_pixels_tab[0][15] = ff_put_h264_qpel16_mc33_mmi;
+ 
+-        c->put_h264_qpel_pixels_tab[1][0] = ff_put_h264_qpel8_mc00_msa;
+-        c->put_h264_qpel_pixels_tab[1][1] = ff_put_h264_qpel8_mc10_msa;
+-        c->put_h264_qpel_pixels_tab[1][2] = ff_put_h264_qpel8_mc20_msa;
+-        c->put_h264_qpel_pixels_tab[1][3] = ff_put_h264_qpel8_mc30_msa;
+-        c->put_h264_qpel_pixels_tab[1][4] = ff_put_h264_qpel8_mc01_msa;
+-        c->put_h264_qpel_pixels_tab[1][5] = ff_put_h264_qpel8_mc11_msa;
+-        c->put_h264_qpel_pixels_tab[1][6] = ff_put_h264_qpel8_mc21_msa;
+-        c->put_h264_qpel_pixels_tab[1][7] = ff_put_h264_qpel8_mc31_msa;
+-        c->put_h264_qpel_pixels_tab[1][8] = ff_put_h264_qpel8_mc02_msa;
+-        c->put_h264_qpel_pixels_tab[1][9] = ff_put_h264_qpel8_mc12_msa;
+-        c->put_h264_qpel_pixels_tab[1][10] = ff_put_h264_qpel8_mc22_msa;
+-        c->put_h264_qpel_pixels_tab[1][11] = ff_put_h264_qpel8_mc32_msa;
+-        c->put_h264_qpel_pixels_tab[1][12] = ff_put_h264_qpel8_mc03_msa;
+-        c->put_h264_qpel_pixels_tab[1][13] = ff_put_h264_qpel8_mc13_msa;
+-        c->put_h264_qpel_pixels_tab[1][14] = ff_put_h264_qpel8_mc23_msa;
+-        c->put_h264_qpel_pixels_tab[1][15] = ff_put_h264_qpel8_mc33_msa;
++            c->put_h264_qpel_pixels_tab[1][0] = ff_put_h264_qpel8_mc00_mmi;
++            c->put_h264_qpel_pixels_tab[1][1] = ff_put_h264_qpel8_mc10_mmi;
++            c->put_h264_qpel_pixels_tab[1][2] = ff_put_h264_qpel8_mc20_mmi;
++            c->put_h264_qpel_pixels_tab[1][3] = ff_put_h264_qpel8_mc30_mmi;
++            c->put_h264_qpel_pixels_tab[1][4] = ff_put_h264_qpel8_mc01_mmi;
++            c->put_h264_qpel_pixels_tab[1][5] = ff_put_h264_qpel8_mc11_mmi;
++            c->put_h264_qpel_pixels_tab[1][6] = ff_put_h264_qpel8_mc21_mmi;
++            c->put_h264_qpel_pixels_tab[1][7] = ff_put_h264_qpel8_mc31_mmi;
++            c->put_h264_qpel_pixels_tab[1][8] = ff_put_h264_qpel8_mc02_mmi;
++            c->put_h264_qpel_pixels_tab[1][9] = ff_put_h264_qpel8_mc12_mmi;
++            c->put_h264_qpel_pixels_tab[1][10] = ff_put_h264_qpel8_mc22_mmi;
++            c->put_h264_qpel_pixels_tab[1][11] = ff_put_h264_qpel8_mc32_mmi;
++            c->put_h264_qpel_pixels_tab[1][12] = ff_put_h264_qpel8_mc03_mmi;
++            c->put_h264_qpel_pixels_tab[1][13] = ff_put_h264_qpel8_mc13_mmi;
++            c->put_h264_qpel_pixels_tab[1][14] = ff_put_h264_qpel8_mc23_mmi;
++            c->put_h264_qpel_pixels_tab[1][15] = ff_put_h264_qpel8_mc33_mmi;
+ 
+-        c->put_h264_qpel_pixels_tab[2][1] = ff_put_h264_qpel4_mc10_msa;
+-        c->put_h264_qpel_pixels_tab[2][2] = ff_put_h264_qpel4_mc20_msa;
+-        c->put_h264_qpel_pixels_tab[2][3] = ff_put_h264_qpel4_mc30_msa;
+-        c->put_h264_qpel_pixels_tab[2][4] = ff_put_h264_qpel4_mc01_msa;
+-        c->put_h264_qpel_pixels_tab[2][5] = ff_put_h264_qpel4_mc11_msa;
+-        c->put_h264_qpel_pixels_tab[2][6] = ff_put_h264_qpel4_mc21_msa;
+-        c->put_h264_qpel_pixels_tab[2][7] = ff_put_h264_qpel4_mc31_msa;
+-        c->put_h264_qpel_pixels_tab[2][8] = ff_put_h264_qpel4_mc02_msa;
+-        c->put_h264_qpel_pixels_tab[2][9] = ff_put_h264_qpel4_mc12_msa;
+-        c->put_h264_qpel_pixels_tab[2][10] = ff_put_h264_qpel4_mc22_msa;
+-        c->put_h264_qpel_pixels_tab[2][11] = ff_put_h264_qpel4_mc32_msa;
+-        c->put_h264_qpel_pixels_tab[2][12] = ff_put_h264_qpel4_mc03_msa;
+-        c->put_h264_qpel_pixels_tab[2][13] = ff_put_h264_qpel4_mc13_msa;
+-        c->put_h264_qpel_pixels_tab[2][14] = ff_put_h264_qpel4_mc23_msa;
+-        c->put_h264_qpel_pixels_tab[2][15] = ff_put_h264_qpel4_mc33_msa;
++            c->put_h264_qpel_pixels_tab[2][0] = ff_put_h264_qpel4_mc00_mmi;
++            c->put_h264_qpel_pixels_tab[2][1] = ff_put_h264_qpel4_mc10_mmi;
++            c->put_h264_qpel_pixels_tab[2][2] = ff_put_h264_qpel4_mc20_mmi;
++            c->put_h264_qpel_pixels_tab[2][3] = ff_put_h264_qpel4_mc30_mmi;
++            c->put_h264_qpel_pixels_tab[2][4] = ff_put_h264_qpel4_mc01_mmi;
++            c->put_h264_qpel_pixels_tab[2][5] = ff_put_h264_qpel4_mc11_mmi;
++            c->put_h264_qpel_pixels_tab[2][6] = ff_put_h264_qpel4_mc21_mmi;
++            c->put_h264_qpel_pixels_tab[2][7] = ff_put_h264_qpel4_mc31_mmi;
++            c->put_h264_qpel_pixels_tab[2][8] = ff_put_h264_qpel4_mc02_mmi;
++            c->put_h264_qpel_pixels_tab[2][9] = ff_put_h264_qpel4_mc12_mmi;
++            c->put_h264_qpel_pixels_tab[2][10] = ff_put_h264_qpel4_mc22_mmi;
++            c->put_h264_qpel_pixels_tab[2][11] = ff_put_h264_qpel4_mc32_mmi;
++            c->put_h264_qpel_pixels_tab[2][12] = ff_put_h264_qpel4_mc03_mmi;
++            c->put_h264_qpel_pixels_tab[2][13] = ff_put_h264_qpel4_mc13_mmi;
++            c->put_h264_qpel_pixels_tab[2][14] = ff_put_h264_qpel4_mc23_mmi;
++            c->put_h264_qpel_pixels_tab[2][15] = ff_put_h264_qpel4_mc33_mmi;
+ 
+-        c->avg_h264_qpel_pixels_tab[0][0] = ff_avg_h264_qpel16_mc00_msa;
+-        c->avg_h264_qpel_pixels_tab[0][1] = ff_avg_h264_qpel16_mc10_msa;
+-        c->avg_h264_qpel_pixels_tab[0][2] = ff_avg_h264_qpel16_mc20_msa;
+-        c->avg_h264_qpel_pixels_tab[0][3] = ff_avg_h264_qpel16_mc30_msa;
+-        c->avg_h264_qpel_pixels_tab[0][4] = ff_avg_h264_qpel16_mc01_msa;
+-        c->avg_h264_qpel_pixels_tab[0][5] = ff_avg_h264_qpel16_mc11_msa;
+-        c->avg_h264_qpel_pixels_tab[0][6] = ff_avg_h264_qpel16_mc21_msa;
+-        c->avg_h264_qpel_pixels_tab[0][7] = ff_avg_h264_qpel16_mc31_msa;
+-        c->avg_h264_qpel_pixels_tab[0][8] = ff_avg_h264_qpel16_mc02_msa;
+-        c->avg_h264_qpel_pixels_tab[0][9] = ff_avg_h264_qpel16_mc12_msa;
+-        c->avg_h264_qpel_pixels_tab[0][10] = ff_avg_h264_qpel16_mc22_msa;
+-        c->avg_h264_qpel_pixels_tab[0][11] = ff_avg_h264_qpel16_mc32_msa;
+-        c->avg_h264_qpel_pixels_tab[0][12] = ff_avg_h264_qpel16_mc03_msa;
+-        c->avg_h264_qpel_pixels_tab[0][13] = ff_avg_h264_qpel16_mc13_msa;
+-        c->avg_h264_qpel_pixels_tab[0][14] = ff_avg_h264_qpel16_mc23_msa;
+-        c->avg_h264_qpel_pixels_tab[0][15] = ff_avg_h264_qpel16_mc33_msa;
++            c->avg_h264_qpel_pixels_tab[0][0] = ff_avg_h264_qpel16_mc00_mmi;
++            c->avg_h264_qpel_pixels_tab[0][1] = ff_avg_h264_qpel16_mc10_mmi;
++            c->avg_h264_qpel_pixels_tab[0][2] = ff_avg_h264_qpel16_mc20_mmi;
++            c->avg_h264_qpel_pixels_tab[0][3] = ff_avg_h264_qpel16_mc30_mmi;
++            c->avg_h264_qpel_pixels_tab[0][4] = ff_avg_h264_qpel16_mc01_mmi;
++            c->avg_h264_qpel_pixels_tab[0][5] = ff_avg_h264_qpel16_mc11_mmi;
++            c->avg_h264_qpel_pixels_tab[0][6] = ff_avg_h264_qpel16_mc21_mmi;
++            c->avg_h264_qpel_pixels_tab[0][7] = ff_avg_h264_qpel16_mc31_mmi;
++            c->avg_h264_qpel_pixels_tab[0][8] = ff_avg_h264_qpel16_mc02_mmi;
++            c->avg_h264_qpel_pixels_tab[0][9] = ff_avg_h264_qpel16_mc12_mmi;
++            c->avg_h264_qpel_pixels_tab[0][10] = ff_avg_h264_qpel16_mc22_mmi;
++            c->avg_h264_qpel_pixels_tab[0][11] = ff_avg_h264_qpel16_mc32_mmi;
++            c->avg_h264_qpel_pixels_tab[0][12] = ff_avg_h264_qpel16_mc03_mmi;
++            c->avg_h264_qpel_pixels_tab[0][13] = ff_avg_h264_qpel16_mc13_mmi;
++            c->avg_h264_qpel_pixels_tab[0][14] = ff_avg_h264_qpel16_mc23_mmi;
++            c->avg_h264_qpel_pixels_tab[0][15] = ff_avg_h264_qpel16_mc33_mmi;
+ 
+-        c->avg_h264_qpel_pixels_tab[1][0] = ff_avg_h264_qpel8_mc00_msa;
+-        c->avg_h264_qpel_pixels_tab[1][1] = ff_avg_h264_qpel8_mc10_msa;
+-        c->avg_h264_qpel_pixels_tab[1][2] = ff_avg_h264_qpel8_mc20_msa;
+-        c->avg_h264_qpel_pixels_tab[1][3] = ff_avg_h264_qpel8_mc30_msa;
+-        c->avg_h264_qpel_pixels_tab[1][4] = ff_avg_h264_qpel8_mc01_msa;
+-        c->avg_h264_qpel_pixels_tab[1][5] = ff_avg_h264_qpel8_mc11_msa;
+-        c->avg_h264_qpel_pixels_tab[1][6] = ff_avg_h264_qpel8_mc21_msa;
+-        c->avg_h264_qpel_pixels_tab[1][7] = ff_avg_h264_qpel8_mc31_msa;
+-        c->avg_h264_qpel_pixels_tab[1][8] = ff_avg_h264_qpel8_mc02_msa;
+-        c->avg_h264_qpel_pixels_tab[1][9] = ff_avg_h264_qpel8_mc12_msa;
+-        c->avg_h264_qpel_pixels_tab[1][10] = ff_avg_h264_qpel8_mc22_msa;
+-        c->avg_h264_qpel_pixels_tab[1][11] = ff_avg_h264_qpel8_mc32_msa;
+-        c->avg_h264_qpel_pixels_tab[1][12] = ff_avg_h264_qpel8_mc03_msa;
+-        c->avg_h264_qpel_pixels_tab[1][13] = ff_avg_h264_qpel8_mc13_msa;
+-        c->avg_h264_qpel_pixels_tab[1][14] = ff_avg_h264_qpel8_mc23_msa;
+-        c->avg_h264_qpel_pixels_tab[1][15] = ff_avg_h264_qpel8_mc33_msa;
++            c->avg_h264_qpel_pixels_tab[1][0] = ff_avg_h264_qpel8_mc00_mmi;
++            c->avg_h264_qpel_pixels_tab[1][1] = ff_avg_h264_qpel8_mc10_mmi;
++            c->avg_h264_qpel_pixels_tab[1][2] = ff_avg_h264_qpel8_mc20_mmi;
++            c->avg_h264_qpel_pixels_tab[1][3] = ff_avg_h264_qpel8_mc30_mmi;
++            c->avg_h264_qpel_pixels_tab[1][4] = ff_avg_h264_qpel8_mc01_mmi;
++            c->avg_h264_qpel_pixels_tab[1][5] = ff_avg_h264_qpel8_mc11_mmi;
++            c->avg_h264_qpel_pixels_tab[1][6] = ff_avg_h264_qpel8_mc21_mmi;
++            c->avg_h264_qpel_pixels_tab[1][7] = ff_avg_h264_qpel8_mc31_mmi;
++            c->avg_h264_qpel_pixels_tab[1][8] = ff_avg_h264_qpel8_mc02_mmi;
++            c->avg_h264_qpel_pixels_tab[1][9] = ff_avg_h264_qpel8_mc12_mmi;
++            c->avg_h264_qpel_pixels_tab[1][10] = ff_avg_h264_qpel8_mc22_mmi;
++            c->avg_h264_qpel_pixels_tab[1][11] = ff_avg_h264_qpel8_mc32_mmi;
++            c->avg_h264_qpel_pixels_tab[1][12] = ff_avg_h264_qpel8_mc03_mmi;
++            c->avg_h264_qpel_pixels_tab[1][13] = ff_avg_h264_qpel8_mc13_mmi;
++            c->avg_h264_qpel_pixels_tab[1][14] = ff_avg_h264_qpel8_mc23_mmi;
++            c->avg_h264_qpel_pixels_tab[1][15] = ff_avg_h264_qpel8_mc33_mmi;
+ 
+-        c->avg_h264_qpel_pixels_tab[2][0] = ff_avg_h264_qpel4_mc00_msa;
+-        c->avg_h264_qpel_pixels_tab[2][1] = ff_avg_h264_qpel4_mc10_msa;
+-        c->avg_h264_qpel_pixels_tab[2][2] = ff_avg_h264_qpel4_mc20_msa;
+-        c->avg_h264_qpel_pixels_tab[2][3] = ff_avg_h264_qpel4_mc30_msa;
+-        c->avg_h264_qpel_pixels_tab[2][4] = ff_avg_h264_qpel4_mc01_msa;
+-        c->avg_h264_qpel_pixels_tab[2][5] = ff_avg_h264_qpel4_mc11_msa;
+-        c->avg_h264_qpel_pixels_tab[2][6] = ff_avg_h264_qpel4_mc21_msa;
+-        c->avg_h264_qpel_pixels_tab[2][7] = ff_avg_h264_qpel4_mc31_msa;
+-        c->avg_h264_qpel_pixels_tab[2][8] = ff_avg_h264_qpel4_mc02_msa;
+-        c->avg_h264_qpel_pixels_tab[2][9] = ff_avg_h264_qpel4_mc12_msa;
+-        c->avg_h264_qpel_pixels_tab[2][10] = ff_avg_h264_qpel4_mc22_msa;
+-        c->avg_h264_qpel_pixels_tab[2][11] = ff_avg_h264_qpel4_mc32_msa;
+-        c->avg_h264_qpel_pixels_tab[2][12] = ff_avg_h264_qpel4_mc03_msa;
+-        c->avg_h264_qpel_pixels_tab[2][13] = ff_avg_h264_qpel4_mc13_msa;
+-        c->avg_h264_qpel_pixels_tab[2][14] = ff_avg_h264_qpel4_mc23_msa;
+-        c->avg_h264_qpel_pixels_tab[2][15] = ff_avg_h264_qpel4_mc33_msa;
++            c->avg_h264_qpel_pixels_tab[2][0] = ff_avg_h264_qpel4_mc00_mmi;
++            c->avg_h264_qpel_pixels_tab[2][1] = ff_avg_h264_qpel4_mc10_mmi;
++            c->avg_h264_qpel_pixels_tab[2][2] = ff_avg_h264_qpel4_mc20_mmi;
++            c->avg_h264_qpel_pixels_tab[2][3] = ff_avg_h264_qpel4_mc30_mmi;
++            c->avg_h264_qpel_pixels_tab[2][4] = ff_avg_h264_qpel4_mc01_mmi;
++            c->avg_h264_qpel_pixels_tab[2][5] = ff_avg_h264_qpel4_mc11_mmi;
++            c->avg_h264_qpel_pixels_tab[2][6] = ff_avg_h264_qpel4_mc21_mmi;
++            c->avg_h264_qpel_pixels_tab[2][7] = ff_avg_h264_qpel4_mc31_mmi;
++            c->avg_h264_qpel_pixels_tab[2][8] = ff_avg_h264_qpel4_mc02_mmi;
++            c->avg_h264_qpel_pixels_tab[2][9] = ff_avg_h264_qpel4_mc12_mmi;
++            c->avg_h264_qpel_pixels_tab[2][10] = ff_avg_h264_qpel4_mc22_mmi;
++            c->avg_h264_qpel_pixels_tab[2][11] = ff_avg_h264_qpel4_mc32_mmi;
++            c->avg_h264_qpel_pixels_tab[2][12] = ff_avg_h264_qpel4_mc03_mmi;
++            c->avg_h264_qpel_pixels_tab[2][13] = ff_avg_h264_qpel4_mc13_mmi;
++            c->avg_h264_qpel_pixels_tab[2][14] = ff_avg_h264_qpel4_mc23_mmi;
++            c->avg_h264_qpel_pixels_tab[2][15] = ff_avg_h264_qpel4_mc33_mmi;
++        }
+     }
+-}
+-#endif  // #if HAVE_MSA
+ 
+-#if HAVE_MMI
+-static av_cold void h264qpel_init_mmi(H264QpelContext *c, int bit_depth)
+-{
+-    if (8 == bit_depth) {
+-        c->put_h264_qpel_pixels_tab[0][0] = ff_put_h264_qpel16_mc00_mmi;
+-        c->put_h264_qpel_pixels_tab[0][1] = ff_put_h264_qpel16_mc10_mmi;
+-        c->put_h264_qpel_pixels_tab[0][2] = ff_put_h264_qpel16_mc20_mmi;
+-        c->put_h264_qpel_pixels_tab[0][3] = ff_put_h264_qpel16_mc30_mmi;
+-        c->put_h264_qpel_pixels_tab[0][4] = ff_put_h264_qpel16_mc01_mmi;
+-        c->put_h264_qpel_pixels_tab[0][5] = ff_put_h264_qpel16_mc11_mmi;
+-        c->put_h264_qpel_pixels_tab[0][6] = ff_put_h264_qpel16_mc21_mmi;
+-        c->put_h264_qpel_pixels_tab[0][7] = ff_put_h264_qpel16_mc31_mmi;
+-        c->put_h264_qpel_pixels_tab[0][8] = ff_put_h264_qpel16_mc02_mmi;
+-        c->put_h264_qpel_pixels_tab[0][9] = ff_put_h264_qpel16_mc12_mmi;
+-        c->put_h264_qpel_pixels_tab[0][10] = ff_put_h264_qpel16_mc22_mmi;
+-        c->put_h264_qpel_pixels_tab[0][11] = ff_put_h264_qpel16_mc32_mmi;
+-        c->put_h264_qpel_pixels_tab[0][12] = ff_put_h264_qpel16_mc03_mmi;
+-        c->put_h264_qpel_pixels_tab[0][13] = ff_put_h264_qpel16_mc13_mmi;
+-        c->put_h264_qpel_pixels_tab[0][14] = ff_put_h264_qpel16_mc23_mmi;
+-        c->put_h264_qpel_pixels_tab[0][15] = ff_put_h264_qpel16_mc33_mmi;
++    if (have_msa(cpu_flags)) {
++        if (bit_depth == 8) {
++            c->put_h264_qpel_pixels_tab[0][0] = ff_put_h264_qpel16_mc00_msa;
++            c->put_h264_qpel_pixels_tab[0][1] = ff_put_h264_qpel16_mc10_msa;
++            c->put_h264_qpel_pixels_tab[0][2] = ff_put_h264_qpel16_mc20_msa;
++            c->put_h264_qpel_pixels_tab[0][3] = ff_put_h264_qpel16_mc30_msa;
++            c->put_h264_qpel_pixels_tab[0][4] = ff_put_h264_qpel16_mc01_msa;
++            c->put_h264_qpel_pixels_tab[0][5] = ff_put_h264_qpel16_mc11_msa;
++            c->put_h264_qpel_pixels_tab[0][6] = ff_put_h264_qpel16_mc21_msa;
++            c->put_h264_qpel_pixels_tab[0][7] = ff_put_h264_qpel16_mc31_msa;
++            c->put_h264_qpel_pixels_tab[0][8] = ff_put_h264_qpel16_mc02_msa;
++            c->put_h264_qpel_pixels_tab[0][9] = ff_put_h264_qpel16_mc12_msa;
++            c->put_h264_qpel_pixels_tab[0][10] = ff_put_h264_qpel16_mc22_msa;
++            c->put_h264_qpel_pixels_tab[0][11] = ff_put_h264_qpel16_mc32_msa;
++            c->put_h264_qpel_pixels_tab[0][12] = ff_put_h264_qpel16_mc03_msa;
++            c->put_h264_qpel_pixels_tab[0][13] = ff_put_h264_qpel16_mc13_msa;
++            c->put_h264_qpel_pixels_tab[0][14] = ff_put_h264_qpel16_mc23_msa;
++            c->put_h264_qpel_pixels_tab[0][15] = ff_put_h264_qpel16_mc33_msa;
+ 
+-        c->put_h264_qpel_pixels_tab[1][0] = ff_put_h264_qpel8_mc00_mmi;
+-        c->put_h264_qpel_pixels_tab[1][1] = ff_put_h264_qpel8_mc10_mmi;
+-        c->put_h264_qpel_pixels_tab[1][2] = ff_put_h264_qpel8_mc20_mmi;
+-        c->put_h264_qpel_pixels_tab[1][3] = ff_put_h264_qpel8_mc30_mmi;
+-        c->put_h264_qpel_pixels_tab[1][4] = ff_put_h264_qpel8_mc01_mmi;
+-        c->put_h264_qpel_pixels_tab[1][5] = ff_put_h264_qpel8_mc11_mmi;
+-        c->put_h264_qpel_pixels_tab[1][6] = ff_put_h264_qpel8_mc21_mmi;
+-        c->put_h264_qpel_pixels_tab[1][7] = ff_put_h264_qpel8_mc31_mmi;
+-        c->put_h264_qpel_pixels_tab[1][8] = ff_put_h264_qpel8_mc02_mmi;
+-        c->put_h264_qpel_pixels_tab[1][9] = ff_put_h264_qpel8_mc12_mmi;
+-        c->put_h264_qpel_pixels_tab[1][10] = ff_put_h264_qpel8_mc22_mmi;
+-        c->put_h264_qpel_pixels_tab[1][11] = ff_put_h264_qpel8_mc32_mmi;
+-        c->put_h264_qpel_pixels_tab[1][12] = ff_put_h264_qpel8_mc03_mmi;
+-        c->put_h264_qpel_pixels_tab[1][13] = ff_put_h264_qpel8_mc13_mmi;
+-        c->put_h264_qpel_pixels_tab[1][14] = ff_put_h264_qpel8_mc23_mmi;
+-        c->put_h264_qpel_pixels_tab[1][15] = ff_put_h264_qpel8_mc33_mmi;
++            c->put_h264_qpel_pixels_tab[1][0] = ff_put_h264_qpel8_mc00_msa;
++            c->put_h264_qpel_pixels_tab[1][1] = ff_put_h264_qpel8_mc10_msa;
++            c->put_h264_qpel_pixels_tab[1][2] = ff_put_h264_qpel8_mc20_msa;
++            c->put_h264_qpel_pixels_tab[1][3] = ff_put_h264_qpel8_mc30_msa;
++            c->put_h264_qpel_pixels_tab[1][4] = ff_put_h264_qpel8_mc01_msa;
++            c->put_h264_qpel_pixels_tab[1][5] = ff_put_h264_qpel8_mc11_msa;
++            c->put_h264_qpel_pixels_tab[1][6] = ff_put_h264_qpel8_mc21_msa;
++            c->put_h264_qpel_pixels_tab[1][7] = ff_put_h264_qpel8_mc31_msa;
++            c->put_h264_qpel_pixels_tab[1][8] = ff_put_h264_qpel8_mc02_msa;
++            c->put_h264_qpel_pixels_tab[1][9] = ff_put_h264_qpel8_mc12_msa;
++            c->put_h264_qpel_pixels_tab[1][10] = ff_put_h264_qpel8_mc22_msa;
++            c->put_h264_qpel_pixels_tab[1][11] = ff_put_h264_qpel8_mc32_msa;
++            c->put_h264_qpel_pixels_tab[1][12] = ff_put_h264_qpel8_mc03_msa;
++            c->put_h264_qpel_pixels_tab[1][13] = ff_put_h264_qpel8_mc13_msa;
++            c->put_h264_qpel_pixels_tab[1][14] = ff_put_h264_qpel8_mc23_msa;
++            c->put_h264_qpel_pixels_tab[1][15] = ff_put_h264_qpel8_mc33_msa;
+ 
+-        c->put_h264_qpel_pixels_tab[2][0] = ff_put_h264_qpel4_mc00_mmi;
+-        c->put_h264_qpel_pixels_tab[2][1] = ff_put_h264_qpel4_mc10_mmi;
+-        c->put_h264_qpel_pixels_tab[2][2] = ff_put_h264_qpel4_mc20_mmi;
+-        c->put_h264_qpel_pixels_tab[2][3] = ff_put_h264_qpel4_mc30_mmi;
+-        c->put_h264_qpel_pixels_tab[2][4] = ff_put_h264_qpel4_mc01_mmi;
+-        c->put_h264_qpel_pixels_tab[2][5] = ff_put_h264_qpel4_mc11_mmi;
+-        c->put_h264_qpel_pixels_tab[2][6] = ff_put_h264_qpel4_mc21_mmi;
+-        c->put_h264_qpel_pixels_tab[2][7] = ff_put_h264_qpel4_mc31_mmi;
+-        c->put_h264_qpel_pixels_tab[2][8] = ff_put_h264_qpel4_mc02_mmi;
+-        c->put_h264_qpel_pixels_tab[2][9] = ff_put_h264_qpel4_mc12_mmi;
+-        c->put_h264_qpel_pixels_tab[2][10] = ff_put_h264_qpel4_mc22_mmi;
+-        c->put_h264_qpel_pixels_tab[2][11] = ff_put_h264_qpel4_mc32_mmi;
+-        c->put_h264_qpel_pixels_tab[2][12] = ff_put_h264_qpel4_mc03_mmi;
+-        c->put_h264_qpel_pixels_tab[2][13] = ff_put_h264_qpel4_mc13_mmi;
+-        c->put_h264_qpel_pixels_tab[2][14] = ff_put_h264_qpel4_mc23_mmi;
+-        c->put_h264_qpel_pixels_tab[2][15] = ff_put_h264_qpel4_mc33_mmi;
++            c->put_h264_qpel_pixels_tab[2][1] = ff_put_h264_qpel4_mc10_msa;
++            c->put_h264_qpel_pixels_tab[2][2] = ff_put_h264_qpel4_mc20_msa;
++            c->put_h264_qpel_pixels_tab[2][3] = ff_put_h264_qpel4_mc30_msa;
++            c->put_h264_qpel_pixels_tab[2][4] = ff_put_h264_qpel4_mc01_msa;
++            c->put_h264_qpel_pixels_tab[2][5] = ff_put_h264_qpel4_mc11_msa;
++            c->put_h264_qpel_pixels_tab[2][6] = ff_put_h264_qpel4_mc21_msa;
++            c->put_h264_qpel_pixels_tab[2][7] = ff_put_h264_qpel4_mc31_msa;
++            c->put_h264_qpel_pixels_tab[2][8] = ff_put_h264_qpel4_mc02_msa;
++            c->put_h264_qpel_pixels_tab[2][9] = ff_put_h264_qpel4_mc12_msa;
++            c->put_h264_qpel_pixels_tab[2][10] = ff_put_h264_qpel4_mc22_msa;
++            c->put_h264_qpel_pixels_tab[2][11] = ff_put_h264_qpel4_mc32_msa;
++            c->put_h264_qpel_pixels_tab[2][12] = ff_put_h264_qpel4_mc03_msa;
++            c->put_h264_qpel_pixels_tab[2][13] = ff_put_h264_qpel4_mc13_msa;
++            c->put_h264_qpel_pixels_tab[2][14] = ff_put_h264_qpel4_mc23_msa;
++            c->put_h264_qpel_pixels_tab[2][15] = ff_put_h264_qpel4_mc33_msa;
+ 
+-        c->avg_h264_qpel_pixels_tab[0][0] = ff_avg_h264_qpel16_mc00_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][1] = ff_avg_h264_qpel16_mc10_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][2] = ff_avg_h264_qpel16_mc20_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][3] = ff_avg_h264_qpel16_mc30_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][4] = ff_avg_h264_qpel16_mc01_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][5] = ff_avg_h264_qpel16_mc11_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][6] = ff_avg_h264_qpel16_mc21_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][7] = ff_avg_h264_qpel16_mc31_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][8] = ff_avg_h264_qpel16_mc02_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][9] = ff_avg_h264_qpel16_mc12_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][10] = ff_avg_h264_qpel16_mc22_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][11] = ff_avg_h264_qpel16_mc32_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][12] = ff_avg_h264_qpel16_mc03_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][13] = ff_avg_h264_qpel16_mc13_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][14] = ff_avg_h264_qpel16_mc23_mmi;
+-        c->avg_h264_qpel_pixels_tab[0][15] = ff_avg_h264_qpel16_mc33_mmi;
++            c->avg_h264_qpel_pixels_tab[0][0] = ff_avg_h264_qpel16_mc00_msa;
++            c->avg_h264_qpel_pixels_tab[0][1] = ff_avg_h264_qpel16_mc10_msa;
++            c->avg_h264_qpel_pixels_tab[0][2] = ff_avg_h264_qpel16_mc20_msa;
++            c->avg_h264_qpel_pixels_tab[0][3] = ff_avg_h264_qpel16_mc30_msa;
++            c->avg_h264_qpel_pixels_tab[0][4] = ff_avg_h264_qpel16_mc01_msa;
++            c->avg_h264_qpel_pixels_tab[0][5] = ff_avg_h264_qpel16_mc11_msa;
++            c->avg_h264_qpel_pixels_tab[0][6] = ff_avg_h264_qpel16_mc21_msa;
++            c->avg_h264_qpel_pixels_tab[0][7] = ff_avg_h264_qpel16_mc31_msa;
++            c->avg_h264_qpel_pixels_tab[0][8] = ff_avg_h264_qpel16_mc02_msa;
++            c->avg_h264_qpel_pixels_tab[0][9] = ff_avg_h264_qpel16_mc12_msa;
++            c->avg_h264_qpel_pixels_tab[0][10] = ff_avg_h264_qpel16_mc22_msa;
++            c->avg_h264_qpel_pixels_tab[0][11] = ff_avg_h264_qpel16_mc32_msa;
++            c->avg_h264_qpel_pixels_tab[0][12] = ff_avg_h264_qpel16_mc03_msa;
++            c->avg_h264_qpel_pixels_tab[0][13] = ff_avg_h264_qpel16_mc13_msa;
++            c->avg_h264_qpel_pixels_tab[0][14] = ff_avg_h264_qpel16_mc23_msa;
++            c->avg_h264_qpel_pixels_tab[0][15] = ff_avg_h264_qpel16_mc33_msa;
+ 
+-        c->avg_h264_qpel_pixels_tab[1][0] = ff_avg_h264_qpel8_mc00_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][1] = ff_avg_h264_qpel8_mc10_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][2] = ff_avg_h264_qpel8_mc20_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][3] = ff_avg_h264_qpel8_mc30_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][4] = ff_avg_h264_qpel8_mc01_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][5] = ff_avg_h264_qpel8_mc11_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][6] = ff_avg_h264_qpel8_mc21_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][7] = ff_avg_h264_qpel8_mc31_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][8] = ff_avg_h264_qpel8_mc02_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][9] = ff_avg_h264_qpel8_mc12_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][10] = ff_avg_h264_qpel8_mc22_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][11] = ff_avg_h264_qpel8_mc32_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][12] = ff_avg_h264_qpel8_mc03_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][13] = ff_avg_h264_qpel8_mc13_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][14] = ff_avg_h264_qpel8_mc23_mmi;
+-        c->avg_h264_qpel_pixels_tab[1][15] = ff_avg_h264_qpel8_mc33_mmi;
++            c->avg_h264_qpel_pixels_tab[1][0] = ff_avg_h264_qpel8_mc00_msa;
++            c->avg_h264_qpel_pixels_tab[1][1] = ff_avg_h264_qpel8_mc10_msa;
++            c->avg_h264_qpel_pixels_tab[1][2] = ff_avg_h264_qpel8_mc20_msa;
++            c->avg_h264_qpel_pixels_tab[1][3] = ff_avg_h264_qpel8_mc30_msa;
++            c->avg_h264_qpel_pixels_tab[1][4] = ff_avg_h264_qpel8_mc01_msa;
++            c->avg_h264_qpel_pixels_tab[1][5] = ff_avg_h264_qpel8_mc11_msa;
++            c->avg_h264_qpel_pixels_tab[1][6] = ff_avg_h264_qpel8_mc21_msa;
++            c->avg_h264_qpel_pixels_tab[1][7] = ff_avg_h264_qpel8_mc31_msa;
++            c->avg_h264_qpel_pixels_tab[1][8] = ff_avg_h264_qpel8_mc02_msa;
++            c->avg_h264_qpel_pixels_tab[1][9] = ff_avg_h264_qpel8_mc12_msa;
++            c->avg_h264_qpel_pixels_tab[1][10] = ff_avg_h264_qpel8_mc22_msa;
++            c->avg_h264_qpel_pixels_tab[1][11] = ff_avg_h264_qpel8_mc32_msa;
++            c->avg_h264_qpel_pixels_tab[1][12] = ff_avg_h264_qpel8_mc03_msa;
++            c->avg_h264_qpel_pixels_tab[1][13] = ff_avg_h264_qpel8_mc13_msa;
++            c->avg_h264_qpel_pixels_tab[1][14] = ff_avg_h264_qpel8_mc23_msa;
++            c->avg_h264_qpel_pixels_tab[1][15] = ff_avg_h264_qpel8_mc33_msa;
+ 
+-        c->avg_h264_qpel_pixels_tab[2][0] = ff_avg_h264_qpel4_mc00_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][1] = ff_avg_h264_qpel4_mc10_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][2] = ff_avg_h264_qpel4_mc20_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][3] = ff_avg_h264_qpel4_mc30_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][4] = ff_avg_h264_qpel4_mc01_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][5] = ff_avg_h264_qpel4_mc11_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][6] = ff_avg_h264_qpel4_mc21_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][7] = ff_avg_h264_qpel4_mc31_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][8] = ff_avg_h264_qpel4_mc02_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][9] = ff_avg_h264_qpel4_mc12_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][10] = ff_avg_h264_qpel4_mc22_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][11] = ff_avg_h264_qpel4_mc32_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][12] = ff_avg_h264_qpel4_mc03_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][13] = ff_avg_h264_qpel4_mc13_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][14] = ff_avg_h264_qpel4_mc23_mmi;
+-        c->avg_h264_qpel_pixels_tab[2][15] = ff_avg_h264_qpel4_mc33_mmi;
++            c->avg_h264_qpel_pixels_tab[2][0] = ff_avg_h264_qpel4_mc00_msa;
++            c->avg_h264_qpel_pixels_tab[2][1] = ff_avg_h264_qpel4_mc10_msa;
++            c->avg_h264_qpel_pixels_tab[2][2] = ff_avg_h264_qpel4_mc20_msa;
++            c->avg_h264_qpel_pixels_tab[2][3] = ff_avg_h264_qpel4_mc30_msa;
++            c->avg_h264_qpel_pixels_tab[2][4] = ff_avg_h264_qpel4_mc01_msa;
++            c->avg_h264_qpel_pixels_tab[2][5] = ff_avg_h264_qpel4_mc11_msa;
++            c->avg_h264_qpel_pixels_tab[2][6] = ff_avg_h264_qpel4_mc21_msa;
++            c->avg_h264_qpel_pixels_tab[2][7] = ff_avg_h264_qpel4_mc31_msa;
++            c->avg_h264_qpel_pixels_tab[2][8] = ff_avg_h264_qpel4_mc02_msa;
++            c->avg_h264_qpel_pixels_tab[2][9] = ff_avg_h264_qpel4_mc12_msa;
++            c->avg_h264_qpel_pixels_tab[2][10] = ff_avg_h264_qpel4_mc22_msa;
++            c->avg_h264_qpel_pixels_tab[2][11] = ff_avg_h264_qpel4_mc32_msa;
++            c->avg_h264_qpel_pixels_tab[2][12] = ff_avg_h264_qpel4_mc03_msa;
++            c->avg_h264_qpel_pixels_tab[2][13] = ff_avg_h264_qpel4_mc13_msa;
++            c->avg_h264_qpel_pixels_tab[2][14] = ff_avg_h264_qpel4_mc23_msa;
++            c->avg_h264_qpel_pixels_tab[2][15] = ff_avg_h264_qpel4_mc33_msa;
++        }
+     }
+ }
+-#endif /* HAVE_MMI */
+-
+-av_cold void ff_h264qpel_init_mips(H264QpelContext *c, int bit_depth)
+-{
+-#if HAVE_MMI
+-    h264qpel_init_mmi(c, bit_depth);
+-#endif /* HAVE_MMI */
+-#if HAVE_MSA
+-    h264qpel_init_msa(c, bit_depth);
+-#endif  // #if HAVE_MSA
+-}
+diff --git a/libavcodec/mips/hevcdsp_init_mips.c b/libavcodec/mips/hevcdsp_init_mips.c
+index 88337f462e..eb261e5adf 100644
+--- a/libavcodec/mips/hevcdsp_init_mips.c
++++ b/libavcodec/mips/hevcdsp_init_mips.c
+@@ -18,512 +18,500 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "libavcodec/mips/hevcdsp_mips.h"
+ 
+-#if HAVE_MMI
+-static av_cold void hevc_dsp_init_mmi(HEVCDSPContext *c,
+-                                      const int bit_depth)
++void ff_hevc_dsp_init_mips(HEVCDSPContext *c, const int bit_depth)
+ {
+-    if (8 == bit_depth) {
+-        c->put_hevc_qpel[1][0][1] = ff_hevc_put_hevc_qpel_h4_8_mmi;
+-        c->put_hevc_qpel[3][0][1] = ff_hevc_put_hevc_qpel_h8_8_mmi;
+-        c->put_hevc_qpel[4][0][1] = ff_hevc_put_hevc_qpel_h12_8_mmi;
+-        c->put_hevc_qpel[5][0][1] = ff_hevc_put_hevc_qpel_h16_8_mmi;
+-        c->put_hevc_qpel[6][0][1] = ff_hevc_put_hevc_qpel_h24_8_mmi;
+-        c->put_hevc_qpel[7][0][1] = ff_hevc_put_hevc_qpel_h32_8_mmi;
+-        c->put_hevc_qpel[8][0][1] = ff_hevc_put_hevc_qpel_h48_8_mmi;
+-        c->put_hevc_qpel[9][0][1] = ff_hevc_put_hevc_qpel_h64_8_mmi;
+-
+-        c->put_hevc_qpel[1][1][1] = ff_hevc_put_hevc_qpel_hv4_8_mmi;
+-        c->put_hevc_qpel[3][1][1] = ff_hevc_put_hevc_qpel_hv8_8_mmi;
+-        c->put_hevc_qpel[4][1][1] = ff_hevc_put_hevc_qpel_hv12_8_mmi;
+-        c->put_hevc_qpel[5][1][1] = ff_hevc_put_hevc_qpel_hv16_8_mmi;
+-        c->put_hevc_qpel[6][1][1] = ff_hevc_put_hevc_qpel_hv24_8_mmi;
+-        c->put_hevc_qpel[7][1][1] = ff_hevc_put_hevc_qpel_hv32_8_mmi;
+-        c->put_hevc_qpel[8][1][1] = ff_hevc_put_hevc_qpel_hv48_8_mmi;
+-        c->put_hevc_qpel[9][1][1] = ff_hevc_put_hevc_qpel_hv64_8_mmi;
+-
+-        c->put_hevc_qpel_bi[1][0][1] = ff_hevc_put_hevc_qpel_bi_h4_8_mmi;
+-        c->put_hevc_qpel_bi[3][0][1] = ff_hevc_put_hevc_qpel_bi_h8_8_mmi;
+-        c->put_hevc_qpel_bi[4][0][1] = ff_hevc_put_hevc_qpel_bi_h12_8_mmi;
+-        c->put_hevc_qpel_bi[5][0][1] = ff_hevc_put_hevc_qpel_bi_h16_8_mmi;
+-        c->put_hevc_qpel_bi[6][0][1] = ff_hevc_put_hevc_qpel_bi_h24_8_mmi;
+-        c->put_hevc_qpel_bi[7][0][1] = ff_hevc_put_hevc_qpel_bi_h32_8_mmi;
+-        c->put_hevc_qpel_bi[8][0][1] = ff_hevc_put_hevc_qpel_bi_h48_8_mmi;
+-        c->put_hevc_qpel_bi[9][0][1] = ff_hevc_put_hevc_qpel_bi_h64_8_mmi;
+-
+-        c->put_hevc_qpel_bi[1][1][1] = ff_hevc_put_hevc_qpel_bi_hv4_8_mmi;
+-        c->put_hevc_qpel_bi[3][1][1] = ff_hevc_put_hevc_qpel_bi_hv8_8_mmi;
+-        c->put_hevc_qpel_bi[4][1][1] = ff_hevc_put_hevc_qpel_bi_hv12_8_mmi;
+-        c->put_hevc_qpel_bi[5][1][1] = ff_hevc_put_hevc_qpel_bi_hv16_8_mmi;
+-        c->put_hevc_qpel_bi[6][1][1] = ff_hevc_put_hevc_qpel_bi_hv24_8_mmi;
+-        c->put_hevc_qpel_bi[7][1][1] = ff_hevc_put_hevc_qpel_bi_hv32_8_mmi;
+-        c->put_hevc_qpel_bi[8][1][1] = ff_hevc_put_hevc_qpel_bi_hv48_8_mmi;
+-        c->put_hevc_qpel_bi[9][1][1] = ff_hevc_put_hevc_qpel_bi_hv64_8_mmi;
+-
+-        c->put_hevc_qpel_bi[3][0][0] = ff_hevc_put_hevc_pel_bi_pixels8_8_mmi;
+-        c->put_hevc_qpel_bi[5][0][0] = ff_hevc_put_hevc_pel_bi_pixels16_8_mmi;
+-        c->put_hevc_qpel_bi[6][0][0] = ff_hevc_put_hevc_pel_bi_pixels24_8_mmi;
+-        c->put_hevc_qpel_bi[7][0][0] = ff_hevc_put_hevc_pel_bi_pixels32_8_mmi;
+-        c->put_hevc_qpel_bi[8][0][0] = ff_hevc_put_hevc_pel_bi_pixels48_8_mmi;
+-        c->put_hevc_qpel_bi[9][0][0] = ff_hevc_put_hevc_pel_bi_pixels64_8_mmi;
+-
+-        c->put_hevc_epel_bi[3][0][0] = ff_hevc_put_hevc_pel_bi_pixels8_8_mmi;
+-        c->put_hevc_epel_bi[5][0][0] = ff_hevc_put_hevc_pel_bi_pixels16_8_mmi;
+-        c->put_hevc_epel_bi[6][0][0] = ff_hevc_put_hevc_pel_bi_pixels24_8_mmi;
+-        c->put_hevc_epel_bi[7][0][0] = ff_hevc_put_hevc_pel_bi_pixels32_8_mmi;
+-
+-        c->put_hevc_epel_bi[1][1][1] = ff_hevc_put_hevc_epel_bi_hv4_8_mmi;
+-        c->put_hevc_epel_bi[3][1][1] = ff_hevc_put_hevc_epel_bi_hv8_8_mmi;
+-        c->put_hevc_epel_bi[4][1][1] = ff_hevc_put_hevc_epel_bi_hv12_8_mmi;
+-        c->put_hevc_epel_bi[5][1][1] = ff_hevc_put_hevc_epel_bi_hv16_8_mmi;
+-        c->put_hevc_epel_bi[6][1][1] = ff_hevc_put_hevc_epel_bi_hv24_8_mmi;
+-        c->put_hevc_epel_bi[7][1][1] = ff_hevc_put_hevc_epel_bi_hv32_8_mmi;
+-
+-        c->put_hevc_qpel_uni[1][1][1] = ff_hevc_put_hevc_qpel_uni_hv4_8_mmi;
+-        c->put_hevc_qpel_uni[3][1][1] = ff_hevc_put_hevc_qpel_uni_hv8_8_mmi;
+-        c->put_hevc_qpel_uni[4][1][1] = ff_hevc_put_hevc_qpel_uni_hv12_8_mmi;
+-        c->put_hevc_qpel_uni[5][1][1] = ff_hevc_put_hevc_qpel_uni_hv16_8_mmi;
+-        c->put_hevc_qpel_uni[6][1][1] = ff_hevc_put_hevc_qpel_uni_hv24_8_mmi;
+-        c->put_hevc_qpel_uni[7][1][1] = ff_hevc_put_hevc_qpel_uni_hv32_8_mmi;
+-        c->put_hevc_qpel_uni[8][1][1] = ff_hevc_put_hevc_qpel_uni_hv48_8_mmi;
+-        c->put_hevc_qpel_uni[9][1][1] = ff_hevc_put_hevc_qpel_uni_hv64_8_mmi;
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_mmi(cpu_flags)) {
++        if (bit_depth == 8) {
++            c->put_hevc_qpel[1][0][1] = ff_hevc_put_hevc_qpel_h4_8_mmi;
++            c->put_hevc_qpel[3][0][1] = ff_hevc_put_hevc_qpel_h8_8_mmi;
++            c->put_hevc_qpel[4][0][1] = ff_hevc_put_hevc_qpel_h12_8_mmi;
++            c->put_hevc_qpel[5][0][1] = ff_hevc_put_hevc_qpel_h16_8_mmi;
++            c->put_hevc_qpel[6][0][1] = ff_hevc_put_hevc_qpel_h24_8_mmi;
++            c->put_hevc_qpel[7][0][1] = ff_hevc_put_hevc_qpel_h32_8_mmi;
++            c->put_hevc_qpel[8][0][1] = ff_hevc_put_hevc_qpel_h48_8_mmi;
++            c->put_hevc_qpel[9][0][1] = ff_hevc_put_hevc_qpel_h64_8_mmi;
++
++            c->put_hevc_qpel[1][1][1] = ff_hevc_put_hevc_qpel_hv4_8_mmi;
++            c->put_hevc_qpel[3][1][1] = ff_hevc_put_hevc_qpel_hv8_8_mmi;
++            c->put_hevc_qpel[4][1][1] = ff_hevc_put_hevc_qpel_hv12_8_mmi;
++            c->put_hevc_qpel[5][1][1] = ff_hevc_put_hevc_qpel_hv16_8_mmi;
++            c->put_hevc_qpel[6][1][1] = ff_hevc_put_hevc_qpel_hv24_8_mmi;
++            c->put_hevc_qpel[7][1][1] = ff_hevc_put_hevc_qpel_hv32_8_mmi;
++            c->put_hevc_qpel[8][1][1] = ff_hevc_put_hevc_qpel_hv48_8_mmi;
++            c->put_hevc_qpel[9][1][1] = ff_hevc_put_hevc_qpel_hv64_8_mmi;
++
++            c->put_hevc_qpel_bi[1][0][1] = ff_hevc_put_hevc_qpel_bi_h4_8_mmi;
++            c->put_hevc_qpel_bi[3][0][1] = ff_hevc_put_hevc_qpel_bi_h8_8_mmi;
++            c->put_hevc_qpel_bi[4][0][1] = ff_hevc_put_hevc_qpel_bi_h12_8_mmi;
++            c->put_hevc_qpel_bi[5][0][1] = ff_hevc_put_hevc_qpel_bi_h16_8_mmi;
++            c->put_hevc_qpel_bi[6][0][1] = ff_hevc_put_hevc_qpel_bi_h24_8_mmi;
++            c->put_hevc_qpel_bi[7][0][1] = ff_hevc_put_hevc_qpel_bi_h32_8_mmi;
++            c->put_hevc_qpel_bi[8][0][1] = ff_hevc_put_hevc_qpel_bi_h48_8_mmi;
++            c->put_hevc_qpel_bi[9][0][1] = ff_hevc_put_hevc_qpel_bi_h64_8_mmi;
++
++            c->put_hevc_qpel_bi[1][1][1] = ff_hevc_put_hevc_qpel_bi_hv4_8_mmi;
++            c->put_hevc_qpel_bi[3][1][1] = ff_hevc_put_hevc_qpel_bi_hv8_8_mmi;
++            c->put_hevc_qpel_bi[4][1][1] = ff_hevc_put_hevc_qpel_bi_hv12_8_mmi;
++            c->put_hevc_qpel_bi[5][1][1] = ff_hevc_put_hevc_qpel_bi_hv16_8_mmi;
++            c->put_hevc_qpel_bi[6][1][1] = ff_hevc_put_hevc_qpel_bi_hv24_8_mmi;
++            c->put_hevc_qpel_bi[7][1][1] = ff_hevc_put_hevc_qpel_bi_hv32_8_mmi;
++            c->put_hevc_qpel_bi[8][1][1] = ff_hevc_put_hevc_qpel_bi_hv48_8_mmi;
++            c->put_hevc_qpel_bi[9][1][1] = ff_hevc_put_hevc_qpel_bi_hv64_8_mmi;
++
++            c->put_hevc_qpel_bi[3][0][0] = ff_hevc_put_hevc_pel_bi_pixels8_8_mmi;
++            c->put_hevc_qpel_bi[5][0][0] = ff_hevc_put_hevc_pel_bi_pixels16_8_mmi;
++            c->put_hevc_qpel_bi[6][0][0] = ff_hevc_put_hevc_pel_bi_pixels24_8_mmi;
++            c->put_hevc_qpel_bi[7][0][0] = ff_hevc_put_hevc_pel_bi_pixels32_8_mmi;
++            c->put_hevc_qpel_bi[8][0][0] = ff_hevc_put_hevc_pel_bi_pixels48_8_mmi;
++            c->put_hevc_qpel_bi[9][0][0] = ff_hevc_put_hevc_pel_bi_pixels64_8_mmi;
++
++            c->put_hevc_epel_bi[3][0][0] = ff_hevc_put_hevc_pel_bi_pixels8_8_mmi;
++            c->put_hevc_epel_bi[5][0][0] = ff_hevc_put_hevc_pel_bi_pixels16_8_mmi;
++            c->put_hevc_epel_bi[6][0][0] = ff_hevc_put_hevc_pel_bi_pixels24_8_mmi;
++            c->put_hevc_epel_bi[7][0][0] = ff_hevc_put_hevc_pel_bi_pixels32_8_mmi;
++
++            c->put_hevc_epel_bi[1][1][1] = ff_hevc_put_hevc_epel_bi_hv4_8_mmi;
++            c->put_hevc_epel_bi[3][1][1] = ff_hevc_put_hevc_epel_bi_hv8_8_mmi;
++            c->put_hevc_epel_bi[4][1][1] = ff_hevc_put_hevc_epel_bi_hv12_8_mmi;
++            c->put_hevc_epel_bi[5][1][1] = ff_hevc_put_hevc_epel_bi_hv16_8_mmi;
++            c->put_hevc_epel_bi[6][1][1] = ff_hevc_put_hevc_epel_bi_hv24_8_mmi;
++            c->put_hevc_epel_bi[7][1][1] = ff_hevc_put_hevc_epel_bi_hv32_8_mmi;
++
++            c->put_hevc_qpel_uni[1][1][1] = ff_hevc_put_hevc_qpel_uni_hv4_8_mmi;
++            c->put_hevc_qpel_uni[3][1][1] = ff_hevc_put_hevc_qpel_uni_hv8_8_mmi;
++            c->put_hevc_qpel_uni[4][1][1] = ff_hevc_put_hevc_qpel_uni_hv12_8_mmi;
++            c->put_hevc_qpel_uni[5][1][1] = ff_hevc_put_hevc_qpel_uni_hv16_8_mmi;
++            c->put_hevc_qpel_uni[6][1][1] = ff_hevc_put_hevc_qpel_uni_hv24_8_mmi;
++            c->put_hevc_qpel_uni[7][1][1] = ff_hevc_put_hevc_qpel_uni_hv32_8_mmi;
++            c->put_hevc_qpel_uni[8][1][1] = ff_hevc_put_hevc_qpel_uni_hv48_8_mmi;
++            c->put_hevc_qpel_uni[9][1][1] = ff_hevc_put_hevc_qpel_uni_hv64_8_mmi;
++        }
+     }
+-}
+-#endif // #if HAVE_MMI
+ 
+-#if HAVE_MSA
+-static av_cold void hevc_dsp_init_msa(HEVCDSPContext *c,
+-                                      const int bit_depth)
+-{
+-    if (8 == bit_depth) {
+-        c->put_hevc_qpel[1][0][0] = ff_hevc_put_hevc_pel_pixels4_8_msa;
+-        c->put_hevc_qpel[2][0][0] = ff_hevc_put_hevc_pel_pixels6_8_msa;
+-        c->put_hevc_qpel[3][0][0] = ff_hevc_put_hevc_pel_pixels8_8_msa;
+-        c->put_hevc_qpel[4][0][0] = ff_hevc_put_hevc_pel_pixels12_8_msa;
+-        c->put_hevc_qpel[5][0][0] = ff_hevc_put_hevc_pel_pixels16_8_msa;
+-        c->put_hevc_qpel[6][0][0] = ff_hevc_put_hevc_pel_pixels24_8_msa;
+-        c->put_hevc_qpel[7][0][0] = ff_hevc_put_hevc_pel_pixels32_8_msa;
+-        c->put_hevc_qpel[8][0][0] = ff_hevc_put_hevc_pel_pixels48_8_msa;
+-        c->put_hevc_qpel[9][0][0] = ff_hevc_put_hevc_pel_pixels64_8_msa;
+-
+-        c->put_hevc_qpel[1][0][1] = ff_hevc_put_hevc_qpel_h4_8_msa;
+-        c->put_hevc_qpel[3][0][1] = ff_hevc_put_hevc_qpel_h8_8_msa;
+-        c->put_hevc_qpel[4][0][1] = ff_hevc_put_hevc_qpel_h12_8_msa;
+-        c->put_hevc_qpel[5][0][1] = ff_hevc_put_hevc_qpel_h16_8_msa;
+-        c->put_hevc_qpel[6][0][1] = ff_hevc_put_hevc_qpel_h24_8_msa;
+-        c->put_hevc_qpel[7][0][1] = ff_hevc_put_hevc_qpel_h32_8_msa;
+-        c->put_hevc_qpel[8][0][1] = ff_hevc_put_hevc_qpel_h48_8_msa;
+-        c->put_hevc_qpel[9][0][1] = ff_hevc_put_hevc_qpel_h64_8_msa;
+-
+-        c->put_hevc_qpel[1][1][0] = ff_hevc_put_hevc_qpel_v4_8_msa;
+-        c->put_hevc_qpel[3][1][0] = ff_hevc_put_hevc_qpel_v8_8_msa;
+-        c->put_hevc_qpel[4][1][0] = ff_hevc_put_hevc_qpel_v12_8_msa;
+-        c->put_hevc_qpel[5][1][0] = ff_hevc_put_hevc_qpel_v16_8_msa;
+-        c->put_hevc_qpel[6][1][0] = ff_hevc_put_hevc_qpel_v24_8_msa;
+-        c->put_hevc_qpel[7][1][0] = ff_hevc_put_hevc_qpel_v32_8_msa;
+-        c->put_hevc_qpel[8][1][0] = ff_hevc_put_hevc_qpel_v48_8_msa;
+-        c->put_hevc_qpel[9][1][0] = ff_hevc_put_hevc_qpel_v64_8_msa;
+-
+-        c->put_hevc_qpel[1][1][1] = ff_hevc_put_hevc_qpel_hv4_8_msa;
+-        c->put_hevc_qpel[3][1][1] = ff_hevc_put_hevc_qpel_hv8_8_msa;
+-        c->put_hevc_qpel[4][1][1] = ff_hevc_put_hevc_qpel_hv12_8_msa;
+-        c->put_hevc_qpel[5][1][1] = ff_hevc_put_hevc_qpel_hv16_8_msa;
+-        c->put_hevc_qpel[6][1][1] = ff_hevc_put_hevc_qpel_hv24_8_msa;
+-        c->put_hevc_qpel[7][1][1] = ff_hevc_put_hevc_qpel_hv32_8_msa;
+-        c->put_hevc_qpel[8][1][1] = ff_hevc_put_hevc_qpel_hv48_8_msa;
+-        c->put_hevc_qpel[9][1][1] = ff_hevc_put_hevc_qpel_hv64_8_msa;
+-
+-        c->put_hevc_epel[1][0][0] = ff_hevc_put_hevc_pel_pixels4_8_msa;
+-        c->put_hevc_epel[2][0][0] = ff_hevc_put_hevc_pel_pixels6_8_msa;
+-        c->put_hevc_epel[3][0][0] = ff_hevc_put_hevc_pel_pixels8_8_msa;
+-        c->put_hevc_epel[4][0][0] = ff_hevc_put_hevc_pel_pixels12_8_msa;
+-        c->put_hevc_epel[5][0][0] = ff_hevc_put_hevc_pel_pixels16_8_msa;
+-        c->put_hevc_epel[6][0][0] = ff_hevc_put_hevc_pel_pixels24_8_msa;
+-        c->put_hevc_epel[7][0][0] = ff_hevc_put_hevc_pel_pixels32_8_msa;
+-
+-        c->put_hevc_epel[1][0][1] = ff_hevc_put_hevc_epel_h4_8_msa;
+-        c->put_hevc_epel[2][0][1] = ff_hevc_put_hevc_epel_h6_8_msa;
+-        c->put_hevc_epel[3][0][1] = ff_hevc_put_hevc_epel_h8_8_msa;
+-        c->put_hevc_epel[4][0][1] = ff_hevc_put_hevc_epel_h12_8_msa;
+-        c->put_hevc_epel[5][0][1] = ff_hevc_put_hevc_epel_h16_8_msa;
+-        c->put_hevc_epel[6][0][1] = ff_hevc_put_hevc_epel_h24_8_msa;
+-        c->put_hevc_epel[7][0][1] = ff_hevc_put_hevc_epel_h32_8_msa;
+-
+-        c->put_hevc_epel[1][1][0] = ff_hevc_put_hevc_epel_v4_8_msa;
+-        c->put_hevc_epel[2][1][0] = ff_hevc_put_hevc_epel_v6_8_msa;
+-        c->put_hevc_epel[3][1][0] = ff_hevc_put_hevc_epel_v8_8_msa;
+-        c->put_hevc_epel[4][1][0] = ff_hevc_put_hevc_epel_v12_8_msa;
+-        c->put_hevc_epel[5][1][0] = ff_hevc_put_hevc_epel_v16_8_msa;
+-        c->put_hevc_epel[6][1][0] = ff_hevc_put_hevc_epel_v24_8_msa;
+-        c->put_hevc_epel[7][1][0] = ff_hevc_put_hevc_epel_v32_8_msa;
+-
+-        c->put_hevc_epel[1][1][1] = ff_hevc_put_hevc_epel_hv4_8_msa;
+-        c->put_hevc_epel[2][1][1] = ff_hevc_put_hevc_epel_hv6_8_msa;
+-        c->put_hevc_epel[3][1][1] = ff_hevc_put_hevc_epel_hv8_8_msa;
+-        c->put_hevc_epel[4][1][1] = ff_hevc_put_hevc_epel_hv12_8_msa;
+-        c->put_hevc_epel[5][1][1] = ff_hevc_put_hevc_epel_hv16_8_msa;
+-        c->put_hevc_epel[6][1][1] = ff_hevc_put_hevc_epel_hv24_8_msa;
+-        c->put_hevc_epel[7][1][1] = ff_hevc_put_hevc_epel_hv32_8_msa;
+-
+-        c->put_hevc_qpel_uni[3][0][0] = ff_hevc_put_hevc_uni_pel_pixels8_8_msa;
+-        c->put_hevc_qpel_uni[4][0][0] = ff_hevc_put_hevc_uni_pel_pixels12_8_msa;
+-        c->put_hevc_qpel_uni[5][0][0] = ff_hevc_put_hevc_uni_pel_pixels16_8_msa;
+-        c->put_hevc_qpel_uni[6][0][0] = ff_hevc_put_hevc_uni_pel_pixels24_8_msa;
+-        c->put_hevc_qpel_uni[7][0][0] = ff_hevc_put_hevc_uni_pel_pixels32_8_msa;
+-        c->put_hevc_qpel_uni[8][0][0] = ff_hevc_put_hevc_uni_pel_pixels48_8_msa;
+-        c->put_hevc_qpel_uni[9][0][0] = ff_hevc_put_hevc_uni_pel_pixels64_8_msa;
+-
+-        c->put_hevc_qpel_uni[1][0][1] = ff_hevc_put_hevc_uni_qpel_h4_8_msa;
+-        c->put_hevc_qpel_uni[3][0][1] = ff_hevc_put_hevc_uni_qpel_h8_8_msa;
+-        c->put_hevc_qpel_uni[4][0][1] = ff_hevc_put_hevc_uni_qpel_h12_8_msa;
+-        c->put_hevc_qpel_uni[5][0][1] = ff_hevc_put_hevc_uni_qpel_h16_8_msa;
+-        c->put_hevc_qpel_uni[6][0][1] = ff_hevc_put_hevc_uni_qpel_h24_8_msa;
+-        c->put_hevc_qpel_uni[7][0][1] = ff_hevc_put_hevc_uni_qpel_h32_8_msa;
+-        c->put_hevc_qpel_uni[8][0][1] = ff_hevc_put_hevc_uni_qpel_h48_8_msa;
+-        c->put_hevc_qpel_uni[9][0][1] = ff_hevc_put_hevc_uni_qpel_h64_8_msa;
+-
+-        c->put_hevc_qpel_uni[1][1][0] = ff_hevc_put_hevc_uni_qpel_v4_8_msa;
+-        c->put_hevc_qpel_uni[3][1][0] = ff_hevc_put_hevc_uni_qpel_v8_8_msa;
+-        c->put_hevc_qpel_uni[4][1][0] = ff_hevc_put_hevc_uni_qpel_v12_8_msa;
+-        c->put_hevc_qpel_uni[5][1][0] = ff_hevc_put_hevc_uni_qpel_v16_8_msa;
+-        c->put_hevc_qpel_uni[6][1][0] = ff_hevc_put_hevc_uni_qpel_v24_8_msa;
+-        c->put_hevc_qpel_uni[7][1][0] = ff_hevc_put_hevc_uni_qpel_v32_8_msa;
+-        c->put_hevc_qpel_uni[8][1][0] = ff_hevc_put_hevc_uni_qpel_v48_8_msa;
+-        c->put_hevc_qpel_uni[9][1][0] = ff_hevc_put_hevc_uni_qpel_v64_8_msa;
+-
+-        c->put_hevc_qpel_uni[1][1][1] = ff_hevc_put_hevc_uni_qpel_hv4_8_msa;
+-        c->put_hevc_qpel_uni[3][1][1] = ff_hevc_put_hevc_uni_qpel_hv8_8_msa;
+-        c->put_hevc_qpel_uni[4][1][1] = ff_hevc_put_hevc_uni_qpel_hv12_8_msa;
+-        c->put_hevc_qpel_uni[5][1][1] = ff_hevc_put_hevc_uni_qpel_hv16_8_msa;
+-        c->put_hevc_qpel_uni[6][1][1] = ff_hevc_put_hevc_uni_qpel_hv24_8_msa;
+-        c->put_hevc_qpel_uni[7][1][1] = ff_hevc_put_hevc_uni_qpel_hv32_8_msa;
+-        c->put_hevc_qpel_uni[8][1][1] = ff_hevc_put_hevc_uni_qpel_hv48_8_msa;
+-        c->put_hevc_qpel_uni[9][1][1] = ff_hevc_put_hevc_uni_qpel_hv64_8_msa;
+-
+-        c->put_hevc_epel_uni[3][0][0] = ff_hevc_put_hevc_uni_pel_pixels8_8_msa;
+-        c->put_hevc_epel_uni[4][0][0] = ff_hevc_put_hevc_uni_pel_pixels12_8_msa;
+-        c->put_hevc_epel_uni[5][0][0] = ff_hevc_put_hevc_uni_pel_pixels16_8_msa;
+-        c->put_hevc_epel_uni[6][0][0] = ff_hevc_put_hevc_uni_pel_pixels24_8_msa;
+-        c->put_hevc_epel_uni[7][0][0] = ff_hevc_put_hevc_uni_pel_pixels32_8_msa;
+-
+-        c->put_hevc_epel_uni[1][0][1] = ff_hevc_put_hevc_uni_epel_h4_8_msa;
+-        c->put_hevc_epel_uni[2][0][1] = ff_hevc_put_hevc_uni_epel_h6_8_msa;
+-        c->put_hevc_epel_uni[3][0][1] = ff_hevc_put_hevc_uni_epel_h8_8_msa;
+-        c->put_hevc_epel_uni[4][0][1] = ff_hevc_put_hevc_uni_epel_h12_8_msa;
+-        c->put_hevc_epel_uni[5][0][1] = ff_hevc_put_hevc_uni_epel_h16_8_msa;
+-        c->put_hevc_epel_uni[6][0][1] = ff_hevc_put_hevc_uni_epel_h24_8_msa;
+-        c->put_hevc_epel_uni[7][0][1] = ff_hevc_put_hevc_uni_epel_h32_8_msa;
+-
+-        c->put_hevc_epel_uni[1][1][0] = ff_hevc_put_hevc_uni_epel_v4_8_msa;
+-        c->put_hevc_epel_uni[2][1][0] = ff_hevc_put_hevc_uni_epel_v6_8_msa;
+-        c->put_hevc_epel_uni[3][1][0] = ff_hevc_put_hevc_uni_epel_v8_8_msa;
+-        c->put_hevc_epel_uni[4][1][0] = ff_hevc_put_hevc_uni_epel_v12_8_msa;
+-        c->put_hevc_epel_uni[5][1][0] = ff_hevc_put_hevc_uni_epel_v16_8_msa;
+-        c->put_hevc_epel_uni[6][1][0] = ff_hevc_put_hevc_uni_epel_v24_8_msa;
+-        c->put_hevc_epel_uni[7][1][0] = ff_hevc_put_hevc_uni_epel_v32_8_msa;
+-
+-        c->put_hevc_epel_uni[1][1][1] = ff_hevc_put_hevc_uni_epel_hv4_8_msa;
+-        c->put_hevc_epel_uni[2][1][1] = ff_hevc_put_hevc_uni_epel_hv6_8_msa;
+-        c->put_hevc_epel_uni[3][1][1] = ff_hevc_put_hevc_uni_epel_hv8_8_msa;
+-        c->put_hevc_epel_uni[4][1][1] = ff_hevc_put_hevc_uni_epel_hv12_8_msa;
+-        c->put_hevc_epel_uni[5][1][1] = ff_hevc_put_hevc_uni_epel_hv16_8_msa;
+-        c->put_hevc_epel_uni[6][1][1] = ff_hevc_put_hevc_uni_epel_hv24_8_msa;
+-        c->put_hevc_epel_uni[7][1][1] = ff_hevc_put_hevc_uni_epel_hv32_8_msa;
+-
+-        c->put_hevc_qpel_uni_w[1][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels4_8_msa;
+-        c->put_hevc_qpel_uni_w[3][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels8_8_msa;
+-        c->put_hevc_qpel_uni_w[4][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels12_8_msa;
+-        c->put_hevc_qpel_uni_w[5][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels16_8_msa;
+-        c->put_hevc_qpel_uni_w[6][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels24_8_msa;
+-        c->put_hevc_qpel_uni_w[7][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels32_8_msa;
+-        c->put_hevc_qpel_uni_w[8][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels48_8_msa;
+-        c->put_hevc_qpel_uni_w[9][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels64_8_msa;
+-
+-        c->put_hevc_qpel_uni_w[1][0][1] = ff_hevc_put_hevc_uni_w_qpel_h4_8_msa;
+-        c->put_hevc_qpel_uni_w[3][0][1] = ff_hevc_put_hevc_uni_w_qpel_h8_8_msa;
+-        c->put_hevc_qpel_uni_w[4][0][1] = ff_hevc_put_hevc_uni_w_qpel_h12_8_msa;
+-        c->put_hevc_qpel_uni_w[5][0][1] = ff_hevc_put_hevc_uni_w_qpel_h16_8_msa;
+-        c->put_hevc_qpel_uni_w[6][0][1] = ff_hevc_put_hevc_uni_w_qpel_h24_8_msa;
+-        c->put_hevc_qpel_uni_w[7][0][1] = ff_hevc_put_hevc_uni_w_qpel_h32_8_msa;
+-        c->put_hevc_qpel_uni_w[8][0][1] = ff_hevc_put_hevc_uni_w_qpel_h48_8_msa;
+-        c->put_hevc_qpel_uni_w[9][0][1] = ff_hevc_put_hevc_uni_w_qpel_h64_8_msa;
+-
+-        c->put_hevc_qpel_uni_w[1][1][0] = ff_hevc_put_hevc_uni_w_qpel_v4_8_msa;
+-        c->put_hevc_qpel_uni_w[3][1][0] = ff_hevc_put_hevc_uni_w_qpel_v8_8_msa;
+-        c->put_hevc_qpel_uni_w[4][1][0] = ff_hevc_put_hevc_uni_w_qpel_v12_8_msa;
+-        c->put_hevc_qpel_uni_w[5][1][0] = ff_hevc_put_hevc_uni_w_qpel_v16_8_msa;
+-        c->put_hevc_qpel_uni_w[6][1][0] = ff_hevc_put_hevc_uni_w_qpel_v24_8_msa;
+-        c->put_hevc_qpel_uni_w[7][1][0] = ff_hevc_put_hevc_uni_w_qpel_v32_8_msa;
+-        c->put_hevc_qpel_uni_w[8][1][0] = ff_hevc_put_hevc_uni_w_qpel_v48_8_msa;
+-        c->put_hevc_qpel_uni_w[9][1][0] = ff_hevc_put_hevc_uni_w_qpel_v64_8_msa;
+-
+-        c->put_hevc_qpel_uni_w[1][1][1] = ff_hevc_put_hevc_uni_w_qpel_hv4_8_msa;
+-        c->put_hevc_qpel_uni_w[3][1][1] = ff_hevc_put_hevc_uni_w_qpel_hv8_8_msa;
+-        c->put_hevc_qpel_uni_w[4][1][1] =
+-            ff_hevc_put_hevc_uni_w_qpel_hv12_8_msa;
+-        c->put_hevc_qpel_uni_w[5][1][1] =
+-            ff_hevc_put_hevc_uni_w_qpel_hv16_8_msa;
+-        c->put_hevc_qpel_uni_w[6][1][1] =
+-            ff_hevc_put_hevc_uni_w_qpel_hv24_8_msa;
+-        c->put_hevc_qpel_uni_w[7][1][1] =
+-            ff_hevc_put_hevc_uni_w_qpel_hv32_8_msa;
+-        c->put_hevc_qpel_uni_w[8][1][1] =
+-            ff_hevc_put_hevc_uni_w_qpel_hv48_8_msa;
+-        c->put_hevc_qpel_uni_w[9][1][1] =
+-            ff_hevc_put_hevc_uni_w_qpel_hv64_8_msa;
+-
+-        c->put_hevc_epel_uni_w[1][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels4_8_msa;
+-        c->put_hevc_epel_uni_w[2][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels6_8_msa;
+-        c->put_hevc_epel_uni_w[3][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels8_8_msa;
+-        c->put_hevc_epel_uni_w[4][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels12_8_msa;
+-        c->put_hevc_epel_uni_w[5][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels16_8_msa;
+-        c->put_hevc_epel_uni_w[6][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels24_8_msa;
+-        c->put_hevc_epel_uni_w[7][0][0] =
+-            ff_hevc_put_hevc_uni_w_pel_pixels32_8_msa;
+-
+-        c->put_hevc_epel_uni_w[1][0][1] = ff_hevc_put_hevc_uni_w_epel_h4_8_msa;
+-        c->put_hevc_epel_uni_w[2][0][1] = ff_hevc_put_hevc_uni_w_epel_h6_8_msa;
+-        c->put_hevc_epel_uni_w[3][0][1] = ff_hevc_put_hevc_uni_w_epel_h8_8_msa;
+-        c->put_hevc_epel_uni_w[4][0][1] = ff_hevc_put_hevc_uni_w_epel_h12_8_msa;
+-        c->put_hevc_epel_uni_w[5][0][1] = ff_hevc_put_hevc_uni_w_epel_h16_8_msa;
+-        c->put_hevc_epel_uni_w[6][0][1] = ff_hevc_put_hevc_uni_w_epel_h24_8_msa;
+-        c->put_hevc_epel_uni_w[7][0][1] = ff_hevc_put_hevc_uni_w_epel_h32_8_msa;
+-
+-        c->put_hevc_epel_uni_w[1][1][0] = ff_hevc_put_hevc_uni_w_epel_v4_8_msa;
+-        c->put_hevc_epel_uni_w[2][1][0] = ff_hevc_put_hevc_uni_w_epel_v6_8_msa;
+-        c->put_hevc_epel_uni_w[3][1][0] = ff_hevc_put_hevc_uni_w_epel_v8_8_msa;
+-        c->put_hevc_epel_uni_w[4][1][0] = ff_hevc_put_hevc_uni_w_epel_v12_8_msa;
+-        c->put_hevc_epel_uni_w[5][1][0] = ff_hevc_put_hevc_uni_w_epel_v16_8_msa;
+-        c->put_hevc_epel_uni_w[6][1][0] = ff_hevc_put_hevc_uni_w_epel_v24_8_msa;
+-        c->put_hevc_epel_uni_w[7][1][0] = ff_hevc_put_hevc_uni_w_epel_v32_8_msa;
+-
+-        c->put_hevc_epel_uni_w[1][1][1] = ff_hevc_put_hevc_uni_w_epel_hv4_8_msa;
+-        c->put_hevc_epel_uni_w[2][1][1] = ff_hevc_put_hevc_uni_w_epel_hv6_8_msa;
+-        c->put_hevc_epel_uni_w[3][1][1] = ff_hevc_put_hevc_uni_w_epel_hv8_8_msa;
+-        c->put_hevc_epel_uni_w[4][1][1] =
+-            ff_hevc_put_hevc_uni_w_epel_hv12_8_msa;
+-        c->put_hevc_epel_uni_w[5][1][1] =
+-            ff_hevc_put_hevc_uni_w_epel_hv16_8_msa;
+-        c->put_hevc_epel_uni_w[6][1][1] =
+-            ff_hevc_put_hevc_uni_w_epel_hv24_8_msa;
+-        c->put_hevc_epel_uni_w[7][1][1] =
+-            ff_hevc_put_hevc_uni_w_epel_hv32_8_msa;
+-
+-        c->put_hevc_qpel_bi[1][0][0] = ff_hevc_put_hevc_bi_pel_pixels4_8_msa;
+-        c->put_hevc_qpel_bi[3][0][0] = ff_hevc_put_hevc_bi_pel_pixels8_8_msa;
+-        c->put_hevc_qpel_bi[4][0][0] = ff_hevc_put_hevc_bi_pel_pixels12_8_msa;
+-        c->put_hevc_qpel_bi[5][0][0] = ff_hevc_put_hevc_bi_pel_pixels16_8_msa;
+-        c->put_hevc_qpel_bi[6][0][0] = ff_hevc_put_hevc_bi_pel_pixels24_8_msa;
+-        c->put_hevc_qpel_bi[7][0][0] = ff_hevc_put_hevc_bi_pel_pixels32_8_msa;
+-        c->put_hevc_qpel_bi[8][0][0] = ff_hevc_put_hevc_bi_pel_pixels48_8_msa;
+-        c->put_hevc_qpel_bi[9][0][0] = ff_hevc_put_hevc_bi_pel_pixels64_8_msa;
+-
+-        c->put_hevc_qpel_bi[1][0][1] = ff_hevc_put_hevc_bi_qpel_h4_8_msa;
+-        c->put_hevc_qpel_bi[3][0][1] = ff_hevc_put_hevc_bi_qpel_h8_8_msa;
+-        c->put_hevc_qpel_bi[4][0][1] = ff_hevc_put_hevc_bi_qpel_h12_8_msa;
+-        c->put_hevc_qpel_bi[5][0][1] = ff_hevc_put_hevc_bi_qpel_h16_8_msa;
+-        c->put_hevc_qpel_bi[6][0][1] = ff_hevc_put_hevc_bi_qpel_h24_8_msa;
+-        c->put_hevc_qpel_bi[7][0][1] = ff_hevc_put_hevc_bi_qpel_h32_8_msa;
+-        c->put_hevc_qpel_bi[8][0][1] = ff_hevc_put_hevc_bi_qpel_h48_8_msa;
+-        c->put_hevc_qpel_bi[9][0][1] = ff_hevc_put_hevc_bi_qpel_h64_8_msa;
+-
+-        c->put_hevc_qpel_bi[1][1][0] = ff_hevc_put_hevc_bi_qpel_v4_8_msa;
+-        c->put_hevc_qpel_bi[3][1][0] = ff_hevc_put_hevc_bi_qpel_v8_8_msa;
+-        c->put_hevc_qpel_bi[4][1][0] = ff_hevc_put_hevc_bi_qpel_v12_8_msa;
+-        c->put_hevc_qpel_bi[5][1][0] = ff_hevc_put_hevc_bi_qpel_v16_8_msa;
+-        c->put_hevc_qpel_bi[6][1][0] = ff_hevc_put_hevc_bi_qpel_v24_8_msa;
+-        c->put_hevc_qpel_bi[7][1][0] = ff_hevc_put_hevc_bi_qpel_v32_8_msa;
+-        c->put_hevc_qpel_bi[8][1][0] = ff_hevc_put_hevc_bi_qpel_v48_8_msa;
+-        c->put_hevc_qpel_bi[9][1][0] = ff_hevc_put_hevc_bi_qpel_v64_8_msa;
+-
+-        c->put_hevc_qpel_bi[1][1][1] = ff_hevc_put_hevc_bi_qpel_hv4_8_msa;
+-        c->put_hevc_qpel_bi[3][1][1] = ff_hevc_put_hevc_bi_qpel_hv8_8_msa;
+-        c->put_hevc_qpel_bi[4][1][1] = ff_hevc_put_hevc_bi_qpel_hv12_8_msa;
+-        c->put_hevc_qpel_bi[5][1][1] = ff_hevc_put_hevc_bi_qpel_hv16_8_msa;
+-        c->put_hevc_qpel_bi[6][1][1] = ff_hevc_put_hevc_bi_qpel_hv24_8_msa;
+-        c->put_hevc_qpel_bi[7][1][1] = ff_hevc_put_hevc_bi_qpel_hv32_8_msa;
+-        c->put_hevc_qpel_bi[8][1][1] = ff_hevc_put_hevc_bi_qpel_hv48_8_msa;
+-        c->put_hevc_qpel_bi[9][1][1] = ff_hevc_put_hevc_bi_qpel_hv64_8_msa;
+-
+-        c->put_hevc_epel_bi[1][0][0] = ff_hevc_put_hevc_bi_pel_pixels4_8_msa;
+-        c->put_hevc_epel_bi[2][0][0] = ff_hevc_put_hevc_bi_pel_pixels6_8_msa;
+-        c->put_hevc_epel_bi[3][0][0] = ff_hevc_put_hevc_bi_pel_pixels8_8_msa;
+-        c->put_hevc_epel_bi[4][0][0] = ff_hevc_put_hevc_bi_pel_pixels12_8_msa;
+-        c->put_hevc_epel_bi[5][0][0] = ff_hevc_put_hevc_bi_pel_pixels16_8_msa;
+-        c->put_hevc_epel_bi[6][0][0] = ff_hevc_put_hevc_bi_pel_pixels24_8_msa;
+-        c->put_hevc_epel_bi[7][0][0] = ff_hevc_put_hevc_bi_pel_pixels32_8_msa;
+-
+-        c->put_hevc_epel_bi[1][0][1] = ff_hevc_put_hevc_bi_epel_h4_8_msa;
+-        c->put_hevc_epel_bi[2][0][1] = ff_hevc_put_hevc_bi_epel_h6_8_msa;
+-        c->put_hevc_epel_bi[3][0][1] = ff_hevc_put_hevc_bi_epel_h8_8_msa;
+-        c->put_hevc_epel_bi[4][0][1] = ff_hevc_put_hevc_bi_epel_h12_8_msa;
+-        c->put_hevc_epel_bi[5][0][1] = ff_hevc_put_hevc_bi_epel_h16_8_msa;
+-        c->put_hevc_epel_bi[6][0][1] = ff_hevc_put_hevc_bi_epel_h24_8_msa;
+-        c->put_hevc_epel_bi[7][0][1] = ff_hevc_put_hevc_bi_epel_h32_8_msa;
+-
+-        c->put_hevc_epel_bi[1][1][0] = ff_hevc_put_hevc_bi_epel_v4_8_msa;
+-        c->put_hevc_epel_bi[2][1][0] = ff_hevc_put_hevc_bi_epel_v6_8_msa;
+-        c->put_hevc_epel_bi[3][1][0] = ff_hevc_put_hevc_bi_epel_v8_8_msa;
+-        c->put_hevc_epel_bi[4][1][0] = ff_hevc_put_hevc_bi_epel_v12_8_msa;
+-        c->put_hevc_epel_bi[5][1][0] = ff_hevc_put_hevc_bi_epel_v16_8_msa;
+-        c->put_hevc_epel_bi[6][1][0] = ff_hevc_put_hevc_bi_epel_v24_8_msa;
+-        c->put_hevc_epel_bi[7][1][0] = ff_hevc_put_hevc_bi_epel_v32_8_msa;
+-
+-        c->put_hevc_epel_bi[1][1][1] = ff_hevc_put_hevc_bi_epel_hv4_8_msa;
+-        c->put_hevc_epel_bi[2][1][1] = ff_hevc_put_hevc_bi_epel_hv6_8_msa;
+-        c->put_hevc_epel_bi[3][1][1] = ff_hevc_put_hevc_bi_epel_hv8_8_msa;
+-        c->put_hevc_epel_bi[4][1][1] = ff_hevc_put_hevc_bi_epel_hv12_8_msa;
+-        c->put_hevc_epel_bi[5][1][1] = ff_hevc_put_hevc_bi_epel_hv16_8_msa;
+-        c->put_hevc_epel_bi[6][1][1] = ff_hevc_put_hevc_bi_epel_hv24_8_msa;
+-        c->put_hevc_epel_bi[7][1][1] = ff_hevc_put_hevc_bi_epel_hv32_8_msa;
+-
+-        c->put_hevc_qpel_bi_w[1][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels4_8_msa;
+-        c->put_hevc_qpel_bi_w[3][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels8_8_msa;
+-        c->put_hevc_qpel_bi_w[4][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels12_8_msa;
+-        c->put_hevc_qpel_bi_w[5][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels16_8_msa;
+-        c->put_hevc_qpel_bi_w[6][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels24_8_msa;
+-        c->put_hevc_qpel_bi_w[7][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels32_8_msa;
+-        c->put_hevc_qpel_bi_w[8][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels48_8_msa;
+-        c->put_hevc_qpel_bi_w[9][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels64_8_msa;
+-
+-        c->put_hevc_qpel_bi_w[1][0][1] = ff_hevc_put_hevc_bi_w_qpel_h4_8_msa;
+-        c->put_hevc_qpel_bi_w[3][0][1] = ff_hevc_put_hevc_bi_w_qpel_h8_8_msa;
+-        c->put_hevc_qpel_bi_w[4][0][1] = ff_hevc_put_hevc_bi_w_qpel_h12_8_msa;
+-        c->put_hevc_qpel_bi_w[5][0][1] = ff_hevc_put_hevc_bi_w_qpel_h16_8_msa;
+-        c->put_hevc_qpel_bi_w[6][0][1] = ff_hevc_put_hevc_bi_w_qpel_h24_8_msa;
+-        c->put_hevc_qpel_bi_w[7][0][1] = ff_hevc_put_hevc_bi_w_qpel_h32_8_msa;
+-        c->put_hevc_qpel_bi_w[8][0][1] = ff_hevc_put_hevc_bi_w_qpel_h48_8_msa;
+-        c->put_hevc_qpel_bi_w[9][0][1] = ff_hevc_put_hevc_bi_w_qpel_h64_8_msa;
+-
+-        c->put_hevc_qpel_bi_w[1][1][0] = ff_hevc_put_hevc_bi_w_qpel_v4_8_msa;
+-        c->put_hevc_qpel_bi_w[3][1][0] = ff_hevc_put_hevc_bi_w_qpel_v8_8_msa;
+-        c->put_hevc_qpel_bi_w[4][1][0] = ff_hevc_put_hevc_bi_w_qpel_v12_8_msa;
+-        c->put_hevc_qpel_bi_w[5][1][0] = ff_hevc_put_hevc_bi_w_qpel_v16_8_msa;
+-        c->put_hevc_qpel_bi_w[6][1][0] = ff_hevc_put_hevc_bi_w_qpel_v24_8_msa;
+-        c->put_hevc_qpel_bi_w[7][1][0] = ff_hevc_put_hevc_bi_w_qpel_v32_8_msa;
+-        c->put_hevc_qpel_bi_w[8][1][0] = ff_hevc_put_hevc_bi_w_qpel_v48_8_msa;
+-        c->put_hevc_qpel_bi_w[9][1][0] = ff_hevc_put_hevc_bi_w_qpel_v64_8_msa;
+-
+-        c->put_hevc_qpel_bi_w[1][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv4_8_msa;
+-        c->put_hevc_qpel_bi_w[3][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv8_8_msa;
+-        c->put_hevc_qpel_bi_w[4][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv12_8_msa;
+-        c->put_hevc_qpel_bi_w[5][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv16_8_msa;
+-        c->put_hevc_qpel_bi_w[6][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv24_8_msa;
+-        c->put_hevc_qpel_bi_w[7][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv32_8_msa;
+-        c->put_hevc_qpel_bi_w[8][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv48_8_msa;
+-        c->put_hevc_qpel_bi_w[9][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv64_8_msa;
+-
+-        c->put_hevc_epel_bi_w[1][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels4_8_msa;
+-        c->put_hevc_epel_bi_w[2][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels6_8_msa;
+-        c->put_hevc_epel_bi_w[3][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels8_8_msa;
+-        c->put_hevc_epel_bi_w[4][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels12_8_msa;
+-        c->put_hevc_epel_bi_w[5][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels16_8_msa;
+-        c->put_hevc_epel_bi_w[6][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels24_8_msa;
+-        c->put_hevc_epel_bi_w[7][0][0] =
+-            ff_hevc_put_hevc_bi_w_pel_pixels32_8_msa;
+-
+-        c->put_hevc_epel_bi_w[1][0][1] = ff_hevc_put_hevc_bi_w_epel_h4_8_msa;
+-        c->put_hevc_epel_bi_w[2][0][1] = ff_hevc_put_hevc_bi_w_epel_h6_8_msa;
+-        c->put_hevc_epel_bi_w[3][0][1] = ff_hevc_put_hevc_bi_w_epel_h8_8_msa;
+-        c->put_hevc_epel_bi_w[4][0][1] = ff_hevc_put_hevc_bi_w_epel_h12_8_msa;
+-        c->put_hevc_epel_bi_w[5][0][1] = ff_hevc_put_hevc_bi_w_epel_h16_8_msa;
+-        c->put_hevc_epel_bi_w[6][0][1] = ff_hevc_put_hevc_bi_w_epel_h24_8_msa;
+-        c->put_hevc_epel_bi_w[7][0][1] = ff_hevc_put_hevc_bi_w_epel_h32_8_msa;
+-
+-        c->put_hevc_epel_bi_w[1][1][0] = ff_hevc_put_hevc_bi_w_epel_v4_8_msa;
+-        c->put_hevc_epel_bi_w[2][1][0] = ff_hevc_put_hevc_bi_w_epel_v6_8_msa;
+-        c->put_hevc_epel_bi_w[3][1][0] = ff_hevc_put_hevc_bi_w_epel_v8_8_msa;
+-        c->put_hevc_epel_bi_w[4][1][0] = ff_hevc_put_hevc_bi_w_epel_v12_8_msa;
+-        c->put_hevc_epel_bi_w[5][1][0] = ff_hevc_put_hevc_bi_w_epel_v16_8_msa;
+-        c->put_hevc_epel_bi_w[6][1][0] = ff_hevc_put_hevc_bi_w_epel_v24_8_msa;
+-        c->put_hevc_epel_bi_w[7][1][0] = ff_hevc_put_hevc_bi_w_epel_v32_8_msa;
+-
+-        c->put_hevc_epel_bi_w[1][1][1] = ff_hevc_put_hevc_bi_w_epel_hv4_8_msa;
+-        c->put_hevc_epel_bi_w[2][1][1] = ff_hevc_put_hevc_bi_w_epel_hv6_8_msa;
+-        c->put_hevc_epel_bi_w[3][1][1] = ff_hevc_put_hevc_bi_w_epel_hv8_8_msa;
+-        c->put_hevc_epel_bi_w[4][1][1] = ff_hevc_put_hevc_bi_w_epel_hv12_8_msa;
+-        c->put_hevc_epel_bi_w[5][1][1] = ff_hevc_put_hevc_bi_w_epel_hv16_8_msa;
+-        c->put_hevc_epel_bi_w[6][1][1] = ff_hevc_put_hevc_bi_w_epel_hv24_8_msa;
+-        c->put_hevc_epel_bi_w[7][1][1] = ff_hevc_put_hevc_bi_w_epel_hv32_8_msa;
+-
+-        c->sao_band_filter[0] =
+-        c->sao_band_filter[1] =
+-        c->sao_band_filter[2] =
+-        c->sao_band_filter[3] =
+-        c->sao_band_filter[4] = ff_hevc_sao_band_filter_0_8_msa;
+-
+-        c->sao_edge_filter[0] =
+-        c->sao_edge_filter[1] =
+-        c->sao_edge_filter[2] =
+-        c->sao_edge_filter[3] =
+-        c->sao_edge_filter[4] = ff_hevc_sao_edge_filter_8_msa;
+-
+-        c->hevc_h_loop_filter_luma = ff_hevc_loop_filter_luma_h_8_msa;
+-        c->hevc_v_loop_filter_luma = ff_hevc_loop_filter_luma_v_8_msa;
+-
+-        c->hevc_h_loop_filter_chroma = ff_hevc_loop_filter_chroma_h_8_msa;
+-        c->hevc_v_loop_filter_chroma = ff_hevc_loop_filter_chroma_v_8_msa;
+-
+-        c->hevc_h_loop_filter_luma_c = ff_hevc_loop_filter_luma_h_8_msa;
+-        c->hevc_v_loop_filter_luma_c = ff_hevc_loop_filter_luma_v_8_msa;
+-
+-        c->hevc_h_loop_filter_chroma_c =
+-            ff_hevc_loop_filter_chroma_h_8_msa;
+-        c->hevc_v_loop_filter_chroma_c =
+-            ff_hevc_loop_filter_chroma_v_8_msa;
+-
+-        c->idct[0] = ff_hevc_idct_4x4_msa;
+-        c->idct[1] = ff_hevc_idct_8x8_msa;
+-        c->idct[2] = ff_hevc_idct_16x16_msa;
+-        c->idct[3] = ff_hevc_idct_32x32_msa;
+-        c->idct_dc[0] = ff_hevc_idct_dc_4x4_msa;
+-        c->idct_dc[1] = ff_hevc_idct_dc_8x8_msa;
+-        c->idct_dc[2] = ff_hevc_idct_dc_16x16_msa;
+-        c->idct_dc[3] = ff_hevc_idct_dc_32x32_msa;
+-        c->add_residual[0] = ff_hevc_addblk_4x4_msa;
+-        c->add_residual[1] = ff_hevc_addblk_8x8_msa;
+-        c->add_residual[2] = ff_hevc_addblk_16x16_msa;
+-        c->add_residual[3] = ff_hevc_addblk_32x32_msa;
+-        c->transform_4x4_luma = ff_hevc_idct_luma_4x4_msa;
++    if (have_msa(cpu_flags)) {
++        if (bit_depth == 8) {
++            c->put_hevc_qpel[1][0][0] = ff_hevc_put_hevc_pel_pixels4_8_msa;
++            c->put_hevc_qpel[2][0][0] = ff_hevc_put_hevc_pel_pixels6_8_msa;
++            c->put_hevc_qpel[3][0][0] = ff_hevc_put_hevc_pel_pixels8_8_msa;
++            c->put_hevc_qpel[4][0][0] = ff_hevc_put_hevc_pel_pixels12_8_msa;
++            c->put_hevc_qpel[5][0][0] = ff_hevc_put_hevc_pel_pixels16_8_msa;
++            c->put_hevc_qpel[6][0][0] = ff_hevc_put_hevc_pel_pixels24_8_msa;
++            c->put_hevc_qpel[7][0][0] = ff_hevc_put_hevc_pel_pixels32_8_msa;
++            c->put_hevc_qpel[8][0][0] = ff_hevc_put_hevc_pel_pixels48_8_msa;
++            c->put_hevc_qpel[9][0][0] = ff_hevc_put_hevc_pel_pixels64_8_msa;
++
++            c->put_hevc_qpel[1][0][1] = ff_hevc_put_hevc_qpel_h4_8_msa;
++            c->put_hevc_qpel[3][0][1] = ff_hevc_put_hevc_qpel_h8_8_msa;
++            c->put_hevc_qpel[4][0][1] = ff_hevc_put_hevc_qpel_h12_8_msa;
++            c->put_hevc_qpel[5][0][1] = ff_hevc_put_hevc_qpel_h16_8_msa;
++            c->put_hevc_qpel[6][0][1] = ff_hevc_put_hevc_qpel_h24_8_msa;
++            c->put_hevc_qpel[7][0][1] = ff_hevc_put_hevc_qpel_h32_8_msa;
++            c->put_hevc_qpel[8][0][1] = ff_hevc_put_hevc_qpel_h48_8_msa;
++            c->put_hevc_qpel[9][0][1] = ff_hevc_put_hevc_qpel_h64_8_msa;
++
++            c->put_hevc_qpel[1][1][0] = ff_hevc_put_hevc_qpel_v4_8_msa;
++            c->put_hevc_qpel[3][1][0] = ff_hevc_put_hevc_qpel_v8_8_msa;
++            c->put_hevc_qpel[4][1][0] = ff_hevc_put_hevc_qpel_v12_8_msa;
++            c->put_hevc_qpel[5][1][0] = ff_hevc_put_hevc_qpel_v16_8_msa;
++            c->put_hevc_qpel[6][1][0] = ff_hevc_put_hevc_qpel_v24_8_msa;
++            c->put_hevc_qpel[7][1][0] = ff_hevc_put_hevc_qpel_v32_8_msa;
++            c->put_hevc_qpel[8][1][0] = ff_hevc_put_hevc_qpel_v48_8_msa;
++            c->put_hevc_qpel[9][1][0] = ff_hevc_put_hevc_qpel_v64_8_msa;
++
++            c->put_hevc_qpel[1][1][1] = ff_hevc_put_hevc_qpel_hv4_8_msa;
++            c->put_hevc_qpel[3][1][1] = ff_hevc_put_hevc_qpel_hv8_8_msa;
++            c->put_hevc_qpel[4][1][1] = ff_hevc_put_hevc_qpel_hv12_8_msa;
++            c->put_hevc_qpel[5][1][1] = ff_hevc_put_hevc_qpel_hv16_8_msa;
++            c->put_hevc_qpel[6][1][1] = ff_hevc_put_hevc_qpel_hv24_8_msa;
++            c->put_hevc_qpel[7][1][1] = ff_hevc_put_hevc_qpel_hv32_8_msa;
++            c->put_hevc_qpel[8][1][1] = ff_hevc_put_hevc_qpel_hv48_8_msa;
++            c->put_hevc_qpel[9][1][1] = ff_hevc_put_hevc_qpel_hv64_8_msa;
++
++            c->put_hevc_epel[1][0][0] = ff_hevc_put_hevc_pel_pixels4_8_msa;
++            c->put_hevc_epel[2][0][0] = ff_hevc_put_hevc_pel_pixels6_8_msa;
++            c->put_hevc_epel[3][0][0] = ff_hevc_put_hevc_pel_pixels8_8_msa;
++            c->put_hevc_epel[4][0][0] = ff_hevc_put_hevc_pel_pixels12_8_msa;
++            c->put_hevc_epel[5][0][0] = ff_hevc_put_hevc_pel_pixels16_8_msa;
++            c->put_hevc_epel[6][0][0] = ff_hevc_put_hevc_pel_pixels24_8_msa;
++            c->put_hevc_epel[7][0][0] = ff_hevc_put_hevc_pel_pixels32_8_msa;
++
++            c->put_hevc_epel[1][0][1] = ff_hevc_put_hevc_epel_h4_8_msa;
++            c->put_hevc_epel[2][0][1] = ff_hevc_put_hevc_epel_h6_8_msa;
++            c->put_hevc_epel[3][0][1] = ff_hevc_put_hevc_epel_h8_8_msa;
++            c->put_hevc_epel[4][0][1] = ff_hevc_put_hevc_epel_h12_8_msa;
++            c->put_hevc_epel[5][0][1] = ff_hevc_put_hevc_epel_h16_8_msa;
++            c->put_hevc_epel[6][0][1] = ff_hevc_put_hevc_epel_h24_8_msa;
++            c->put_hevc_epel[7][0][1] = ff_hevc_put_hevc_epel_h32_8_msa;
++
++            c->put_hevc_epel[1][1][0] = ff_hevc_put_hevc_epel_v4_8_msa;
++            c->put_hevc_epel[2][1][0] = ff_hevc_put_hevc_epel_v6_8_msa;
++            c->put_hevc_epel[3][1][0] = ff_hevc_put_hevc_epel_v8_8_msa;
++            c->put_hevc_epel[4][1][0] = ff_hevc_put_hevc_epel_v12_8_msa;
++            c->put_hevc_epel[5][1][0] = ff_hevc_put_hevc_epel_v16_8_msa;
++            c->put_hevc_epel[6][1][0] = ff_hevc_put_hevc_epel_v24_8_msa;
++            c->put_hevc_epel[7][1][0] = ff_hevc_put_hevc_epel_v32_8_msa;
++
++            c->put_hevc_epel[1][1][1] = ff_hevc_put_hevc_epel_hv4_8_msa;
++            c->put_hevc_epel[2][1][1] = ff_hevc_put_hevc_epel_hv6_8_msa;
++            c->put_hevc_epel[3][1][1] = ff_hevc_put_hevc_epel_hv8_8_msa;
++            c->put_hevc_epel[4][1][1] = ff_hevc_put_hevc_epel_hv12_8_msa;
++            c->put_hevc_epel[5][1][1] = ff_hevc_put_hevc_epel_hv16_8_msa;
++            c->put_hevc_epel[6][1][1] = ff_hevc_put_hevc_epel_hv24_8_msa;
++            c->put_hevc_epel[7][1][1] = ff_hevc_put_hevc_epel_hv32_8_msa;
++
++            c->put_hevc_qpel_uni[3][0][0] = ff_hevc_put_hevc_uni_pel_pixels8_8_msa;
++            c->put_hevc_qpel_uni[4][0][0] = ff_hevc_put_hevc_uni_pel_pixels12_8_msa;
++            c->put_hevc_qpel_uni[5][0][0] = ff_hevc_put_hevc_uni_pel_pixels16_8_msa;
++            c->put_hevc_qpel_uni[6][0][0] = ff_hevc_put_hevc_uni_pel_pixels24_8_msa;
++            c->put_hevc_qpel_uni[7][0][0] = ff_hevc_put_hevc_uni_pel_pixels32_8_msa;
++            c->put_hevc_qpel_uni[8][0][0] = ff_hevc_put_hevc_uni_pel_pixels48_8_msa;
++            c->put_hevc_qpel_uni[9][0][0] = ff_hevc_put_hevc_uni_pel_pixels64_8_msa;
++
++            c->put_hevc_qpel_uni[1][0][1] = ff_hevc_put_hevc_uni_qpel_h4_8_msa;
++            c->put_hevc_qpel_uni[3][0][1] = ff_hevc_put_hevc_uni_qpel_h8_8_msa;
++            c->put_hevc_qpel_uni[4][0][1] = ff_hevc_put_hevc_uni_qpel_h12_8_msa;
++            c->put_hevc_qpel_uni[5][0][1] = ff_hevc_put_hevc_uni_qpel_h16_8_msa;
++            c->put_hevc_qpel_uni[6][0][1] = ff_hevc_put_hevc_uni_qpel_h24_8_msa;
++            c->put_hevc_qpel_uni[7][0][1] = ff_hevc_put_hevc_uni_qpel_h32_8_msa;
++            c->put_hevc_qpel_uni[8][0][1] = ff_hevc_put_hevc_uni_qpel_h48_8_msa;
++            c->put_hevc_qpel_uni[9][0][1] = ff_hevc_put_hevc_uni_qpel_h64_8_msa;
++
++            c->put_hevc_qpel_uni[1][1][0] = ff_hevc_put_hevc_uni_qpel_v4_8_msa;
++            c->put_hevc_qpel_uni[3][1][0] = ff_hevc_put_hevc_uni_qpel_v8_8_msa;
++            c->put_hevc_qpel_uni[4][1][0] = ff_hevc_put_hevc_uni_qpel_v12_8_msa;
++            c->put_hevc_qpel_uni[5][1][0] = ff_hevc_put_hevc_uni_qpel_v16_8_msa;
++            c->put_hevc_qpel_uni[6][1][0] = ff_hevc_put_hevc_uni_qpel_v24_8_msa;
++            c->put_hevc_qpel_uni[7][1][0] = ff_hevc_put_hevc_uni_qpel_v32_8_msa;
++            c->put_hevc_qpel_uni[8][1][0] = ff_hevc_put_hevc_uni_qpel_v48_8_msa;
++            c->put_hevc_qpel_uni[9][1][0] = ff_hevc_put_hevc_uni_qpel_v64_8_msa;
++
++            c->put_hevc_qpel_uni[1][1][1] = ff_hevc_put_hevc_uni_qpel_hv4_8_msa;
++            c->put_hevc_qpel_uni[3][1][1] = ff_hevc_put_hevc_uni_qpel_hv8_8_msa;
++            c->put_hevc_qpel_uni[4][1][1] = ff_hevc_put_hevc_uni_qpel_hv12_8_msa;
++            c->put_hevc_qpel_uni[5][1][1] = ff_hevc_put_hevc_uni_qpel_hv16_8_msa;
++            c->put_hevc_qpel_uni[6][1][1] = ff_hevc_put_hevc_uni_qpel_hv24_8_msa;
++            c->put_hevc_qpel_uni[7][1][1] = ff_hevc_put_hevc_uni_qpel_hv32_8_msa;
++            c->put_hevc_qpel_uni[8][1][1] = ff_hevc_put_hevc_uni_qpel_hv48_8_msa;
++            c->put_hevc_qpel_uni[9][1][1] = ff_hevc_put_hevc_uni_qpel_hv64_8_msa;
++
++            c->put_hevc_epel_uni[3][0][0] = ff_hevc_put_hevc_uni_pel_pixels8_8_msa;
++            c->put_hevc_epel_uni[4][0][0] = ff_hevc_put_hevc_uni_pel_pixels12_8_msa;
++            c->put_hevc_epel_uni[5][0][0] = ff_hevc_put_hevc_uni_pel_pixels16_8_msa;
++            c->put_hevc_epel_uni[6][0][0] = ff_hevc_put_hevc_uni_pel_pixels24_8_msa;
++            c->put_hevc_epel_uni[7][0][0] = ff_hevc_put_hevc_uni_pel_pixels32_8_msa;
++
++            c->put_hevc_epel_uni[1][0][1] = ff_hevc_put_hevc_uni_epel_h4_8_msa;
++            c->put_hevc_epel_uni[2][0][1] = ff_hevc_put_hevc_uni_epel_h6_8_msa;
++            c->put_hevc_epel_uni[3][0][1] = ff_hevc_put_hevc_uni_epel_h8_8_msa;
++            c->put_hevc_epel_uni[4][0][1] = ff_hevc_put_hevc_uni_epel_h12_8_msa;
++            c->put_hevc_epel_uni[5][0][1] = ff_hevc_put_hevc_uni_epel_h16_8_msa;
++            c->put_hevc_epel_uni[6][0][1] = ff_hevc_put_hevc_uni_epel_h24_8_msa;
++            c->put_hevc_epel_uni[7][0][1] = ff_hevc_put_hevc_uni_epel_h32_8_msa;
++
++            c->put_hevc_epel_uni[1][1][0] = ff_hevc_put_hevc_uni_epel_v4_8_msa;
++            c->put_hevc_epel_uni[2][1][0] = ff_hevc_put_hevc_uni_epel_v6_8_msa;
++            c->put_hevc_epel_uni[3][1][0] = ff_hevc_put_hevc_uni_epel_v8_8_msa;
++            c->put_hevc_epel_uni[4][1][0] = ff_hevc_put_hevc_uni_epel_v12_8_msa;
++            c->put_hevc_epel_uni[5][1][0] = ff_hevc_put_hevc_uni_epel_v16_8_msa;
++            c->put_hevc_epel_uni[6][1][0] = ff_hevc_put_hevc_uni_epel_v24_8_msa;
++            c->put_hevc_epel_uni[7][1][0] = ff_hevc_put_hevc_uni_epel_v32_8_msa;
++
++            c->put_hevc_epel_uni[1][1][1] = ff_hevc_put_hevc_uni_epel_hv4_8_msa;
++            c->put_hevc_epel_uni[2][1][1] = ff_hevc_put_hevc_uni_epel_hv6_8_msa;
++            c->put_hevc_epel_uni[3][1][1] = ff_hevc_put_hevc_uni_epel_hv8_8_msa;
++            c->put_hevc_epel_uni[4][1][1] = ff_hevc_put_hevc_uni_epel_hv12_8_msa;
++            c->put_hevc_epel_uni[5][1][1] = ff_hevc_put_hevc_uni_epel_hv16_8_msa;
++            c->put_hevc_epel_uni[6][1][1] = ff_hevc_put_hevc_uni_epel_hv24_8_msa;
++            c->put_hevc_epel_uni[7][1][1] = ff_hevc_put_hevc_uni_epel_hv32_8_msa;
++
++            c->put_hevc_qpel_uni_w[1][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels4_8_msa;
++            c->put_hevc_qpel_uni_w[3][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels8_8_msa;
++            c->put_hevc_qpel_uni_w[4][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels12_8_msa;
++            c->put_hevc_qpel_uni_w[5][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels16_8_msa;
++            c->put_hevc_qpel_uni_w[6][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels24_8_msa;
++            c->put_hevc_qpel_uni_w[7][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels32_8_msa;
++            c->put_hevc_qpel_uni_w[8][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels48_8_msa;
++            c->put_hevc_qpel_uni_w[9][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels64_8_msa;
++
++            c->put_hevc_qpel_uni_w[1][0][1] = ff_hevc_put_hevc_uni_w_qpel_h4_8_msa;
++            c->put_hevc_qpel_uni_w[3][0][1] = ff_hevc_put_hevc_uni_w_qpel_h8_8_msa;
++            c->put_hevc_qpel_uni_w[4][0][1] = ff_hevc_put_hevc_uni_w_qpel_h12_8_msa;
++            c->put_hevc_qpel_uni_w[5][0][1] = ff_hevc_put_hevc_uni_w_qpel_h16_8_msa;
++            c->put_hevc_qpel_uni_w[6][0][1] = ff_hevc_put_hevc_uni_w_qpel_h24_8_msa;
++            c->put_hevc_qpel_uni_w[7][0][1] = ff_hevc_put_hevc_uni_w_qpel_h32_8_msa;
++            c->put_hevc_qpel_uni_w[8][0][1] = ff_hevc_put_hevc_uni_w_qpel_h48_8_msa;
++            c->put_hevc_qpel_uni_w[9][0][1] = ff_hevc_put_hevc_uni_w_qpel_h64_8_msa;
++
++            c->put_hevc_qpel_uni_w[1][1][0] = ff_hevc_put_hevc_uni_w_qpel_v4_8_msa;
++            c->put_hevc_qpel_uni_w[3][1][0] = ff_hevc_put_hevc_uni_w_qpel_v8_8_msa;
++            c->put_hevc_qpel_uni_w[4][1][0] = ff_hevc_put_hevc_uni_w_qpel_v12_8_msa;
++            c->put_hevc_qpel_uni_w[5][1][0] = ff_hevc_put_hevc_uni_w_qpel_v16_8_msa;
++            c->put_hevc_qpel_uni_w[6][1][0] = ff_hevc_put_hevc_uni_w_qpel_v24_8_msa;
++            c->put_hevc_qpel_uni_w[7][1][0] = ff_hevc_put_hevc_uni_w_qpel_v32_8_msa;
++            c->put_hevc_qpel_uni_w[8][1][0] = ff_hevc_put_hevc_uni_w_qpel_v48_8_msa;
++            c->put_hevc_qpel_uni_w[9][1][0] = ff_hevc_put_hevc_uni_w_qpel_v64_8_msa;
++
++            c->put_hevc_qpel_uni_w[1][1][1] = ff_hevc_put_hevc_uni_w_qpel_hv4_8_msa;
++            c->put_hevc_qpel_uni_w[3][1][1] = ff_hevc_put_hevc_uni_w_qpel_hv8_8_msa;
++            c->put_hevc_qpel_uni_w[4][1][1] =
++                ff_hevc_put_hevc_uni_w_qpel_hv12_8_msa;
++            c->put_hevc_qpel_uni_w[5][1][1] =
++                ff_hevc_put_hevc_uni_w_qpel_hv16_8_msa;
++            c->put_hevc_qpel_uni_w[6][1][1] =
++                ff_hevc_put_hevc_uni_w_qpel_hv24_8_msa;
++            c->put_hevc_qpel_uni_w[7][1][1] =
++                ff_hevc_put_hevc_uni_w_qpel_hv32_8_msa;
++            c->put_hevc_qpel_uni_w[8][1][1] =
++                ff_hevc_put_hevc_uni_w_qpel_hv48_8_msa;
++            c->put_hevc_qpel_uni_w[9][1][1] =
++                ff_hevc_put_hevc_uni_w_qpel_hv64_8_msa;
++
++            c->put_hevc_epel_uni_w[1][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels4_8_msa;
++            c->put_hevc_epel_uni_w[2][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels6_8_msa;
++            c->put_hevc_epel_uni_w[3][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels8_8_msa;
++            c->put_hevc_epel_uni_w[4][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels12_8_msa;
++            c->put_hevc_epel_uni_w[5][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels16_8_msa;
++            c->put_hevc_epel_uni_w[6][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels24_8_msa;
++            c->put_hevc_epel_uni_w[7][0][0] =
++                ff_hevc_put_hevc_uni_w_pel_pixels32_8_msa;
++
++            c->put_hevc_epel_uni_w[1][0][1] = ff_hevc_put_hevc_uni_w_epel_h4_8_msa;
++            c->put_hevc_epel_uni_w[2][0][1] = ff_hevc_put_hevc_uni_w_epel_h6_8_msa;
++            c->put_hevc_epel_uni_w[3][0][1] = ff_hevc_put_hevc_uni_w_epel_h8_8_msa;
++            c->put_hevc_epel_uni_w[4][0][1] = ff_hevc_put_hevc_uni_w_epel_h12_8_msa;
++            c->put_hevc_epel_uni_w[5][0][1] = ff_hevc_put_hevc_uni_w_epel_h16_8_msa;
++            c->put_hevc_epel_uni_w[6][0][1] = ff_hevc_put_hevc_uni_w_epel_h24_8_msa;
++            c->put_hevc_epel_uni_w[7][0][1] = ff_hevc_put_hevc_uni_w_epel_h32_8_msa;
++
++            c->put_hevc_epel_uni_w[1][1][0] = ff_hevc_put_hevc_uni_w_epel_v4_8_msa;
++            c->put_hevc_epel_uni_w[2][1][0] = ff_hevc_put_hevc_uni_w_epel_v6_8_msa;
++            c->put_hevc_epel_uni_w[3][1][0] = ff_hevc_put_hevc_uni_w_epel_v8_8_msa;
++            c->put_hevc_epel_uni_w[4][1][0] = ff_hevc_put_hevc_uni_w_epel_v12_8_msa;
++            c->put_hevc_epel_uni_w[5][1][0] = ff_hevc_put_hevc_uni_w_epel_v16_8_msa;
++            c->put_hevc_epel_uni_w[6][1][0] = ff_hevc_put_hevc_uni_w_epel_v24_8_msa;
++            c->put_hevc_epel_uni_w[7][1][0] = ff_hevc_put_hevc_uni_w_epel_v32_8_msa;
++
++            c->put_hevc_epel_uni_w[1][1][1] = ff_hevc_put_hevc_uni_w_epel_hv4_8_msa;
++            c->put_hevc_epel_uni_w[2][1][1] = ff_hevc_put_hevc_uni_w_epel_hv6_8_msa;
++            c->put_hevc_epel_uni_w[3][1][1] = ff_hevc_put_hevc_uni_w_epel_hv8_8_msa;
++            c->put_hevc_epel_uni_w[4][1][1] =
++                ff_hevc_put_hevc_uni_w_epel_hv12_8_msa;
++            c->put_hevc_epel_uni_w[5][1][1] =
++                ff_hevc_put_hevc_uni_w_epel_hv16_8_msa;
++            c->put_hevc_epel_uni_w[6][1][1] =
++                ff_hevc_put_hevc_uni_w_epel_hv24_8_msa;
++            c->put_hevc_epel_uni_w[7][1][1] =
++                ff_hevc_put_hevc_uni_w_epel_hv32_8_msa;
++
++            c->put_hevc_qpel_bi[1][0][0] = ff_hevc_put_hevc_bi_pel_pixels4_8_msa;
++            c->put_hevc_qpel_bi[3][0][0] = ff_hevc_put_hevc_bi_pel_pixels8_8_msa;
++            c->put_hevc_qpel_bi[4][0][0] = ff_hevc_put_hevc_bi_pel_pixels12_8_msa;
++            c->put_hevc_qpel_bi[5][0][0] = ff_hevc_put_hevc_bi_pel_pixels16_8_msa;
++            c->put_hevc_qpel_bi[6][0][0] = ff_hevc_put_hevc_bi_pel_pixels24_8_msa;
++            c->put_hevc_qpel_bi[7][0][0] = ff_hevc_put_hevc_bi_pel_pixels32_8_msa;
++            c->put_hevc_qpel_bi[8][0][0] = ff_hevc_put_hevc_bi_pel_pixels48_8_msa;
++            c->put_hevc_qpel_bi[9][0][0] = ff_hevc_put_hevc_bi_pel_pixels64_8_msa;
++
++            c->put_hevc_qpel_bi[1][0][1] = ff_hevc_put_hevc_bi_qpel_h4_8_msa;
++            c->put_hevc_qpel_bi[3][0][1] = ff_hevc_put_hevc_bi_qpel_h8_8_msa;
++            c->put_hevc_qpel_bi[4][0][1] = ff_hevc_put_hevc_bi_qpel_h12_8_msa;
++            c->put_hevc_qpel_bi[5][0][1] = ff_hevc_put_hevc_bi_qpel_h16_8_msa;
++            c->put_hevc_qpel_bi[6][0][1] = ff_hevc_put_hevc_bi_qpel_h24_8_msa;
++            c->put_hevc_qpel_bi[7][0][1] = ff_hevc_put_hevc_bi_qpel_h32_8_msa;
++            c->put_hevc_qpel_bi[8][0][1] = ff_hevc_put_hevc_bi_qpel_h48_8_msa;
++            c->put_hevc_qpel_bi[9][0][1] = ff_hevc_put_hevc_bi_qpel_h64_8_msa;
++
++            c->put_hevc_qpel_bi[1][1][0] = ff_hevc_put_hevc_bi_qpel_v4_8_msa;
++            c->put_hevc_qpel_bi[3][1][0] = ff_hevc_put_hevc_bi_qpel_v8_8_msa;
++            c->put_hevc_qpel_bi[4][1][0] = ff_hevc_put_hevc_bi_qpel_v12_8_msa;
++            c->put_hevc_qpel_bi[5][1][0] = ff_hevc_put_hevc_bi_qpel_v16_8_msa;
++            c->put_hevc_qpel_bi[6][1][0] = ff_hevc_put_hevc_bi_qpel_v24_8_msa;
++            c->put_hevc_qpel_bi[7][1][0] = ff_hevc_put_hevc_bi_qpel_v32_8_msa;
++            c->put_hevc_qpel_bi[8][1][0] = ff_hevc_put_hevc_bi_qpel_v48_8_msa;
++            c->put_hevc_qpel_bi[9][1][0] = ff_hevc_put_hevc_bi_qpel_v64_8_msa;
++
++            c->put_hevc_qpel_bi[1][1][1] = ff_hevc_put_hevc_bi_qpel_hv4_8_msa;
++            c->put_hevc_qpel_bi[3][1][1] = ff_hevc_put_hevc_bi_qpel_hv8_8_msa;
++            c->put_hevc_qpel_bi[4][1][1] = ff_hevc_put_hevc_bi_qpel_hv12_8_msa;
++            c->put_hevc_qpel_bi[5][1][1] = ff_hevc_put_hevc_bi_qpel_hv16_8_msa;
++            c->put_hevc_qpel_bi[6][1][1] = ff_hevc_put_hevc_bi_qpel_hv24_8_msa;
++            c->put_hevc_qpel_bi[7][1][1] = ff_hevc_put_hevc_bi_qpel_hv32_8_msa;
++            c->put_hevc_qpel_bi[8][1][1] = ff_hevc_put_hevc_bi_qpel_hv48_8_msa;
++            c->put_hevc_qpel_bi[9][1][1] = ff_hevc_put_hevc_bi_qpel_hv64_8_msa;
++
++            c->put_hevc_epel_bi[1][0][0] = ff_hevc_put_hevc_bi_pel_pixels4_8_msa;
++            c->put_hevc_epel_bi[2][0][0] = ff_hevc_put_hevc_bi_pel_pixels6_8_msa;
++            c->put_hevc_epel_bi[3][0][0] = ff_hevc_put_hevc_bi_pel_pixels8_8_msa;
++            c->put_hevc_epel_bi[4][0][0] = ff_hevc_put_hevc_bi_pel_pixels12_8_msa;
++            c->put_hevc_epel_bi[5][0][0] = ff_hevc_put_hevc_bi_pel_pixels16_8_msa;
++            c->put_hevc_epel_bi[6][0][0] = ff_hevc_put_hevc_bi_pel_pixels24_8_msa;
++            c->put_hevc_epel_bi[7][0][0] = ff_hevc_put_hevc_bi_pel_pixels32_8_msa;
++
++            c->put_hevc_epel_bi[1][0][1] = ff_hevc_put_hevc_bi_epel_h4_8_msa;
++            c->put_hevc_epel_bi[2][0][1] = ff_hevc_put_hevc_bi_epel_h6_8_msa;
++            c->put_hevc_epel_bi[3][0][1] = ff_hevc_put_hevc_bi_epel_h8_8_msa;
++            c->put_hevc_epel_bi[4][0][1] = ff_hevc_put_hevc_bi_epel_h12_8_msa;
++            c->put_hevc_epel_bi[5][0][1] = ff_hevc_put_hevc_bi_epel_h16_8_msa;
++            c->put_hevc_epel_bi[6][0][1] = ff_hevc_put_hevc_bi_epel_h24_8_msa;
++            c->put_hevc_epel_bi[7][0][1] = ff_hevc_put_hevc_bi_epel_h32_8_msa;
++
++            c->put_hevc_epel_bi[1][1][0] = ff_hevc_put_hevc_bi_epel_v4_8_msa;
++            c->put_hevc_epel_bi[2][1][0] = ff_hevc_put_hevc_bi_epel_v6_8_msa;
++            c->put_hevc_epel_bi[3][1][0] = ff_hevc_put_hevc_bi_epel_v8_8_msa;
++            c->put_hevc_epel_bi[4][1][0] = ff_hevc_put_hevc_bi_epel_v12_8_msa;
++            c->put_hevc_epel_bi[5][1][0] = ff_hevc_put_hevc_bi_epel_v16_8_msa;
++            c->put_hevc_epel_bi[6][1][0] = ff_hevc_put_hevc_bi_epel_v24_8_msa;
++            c->put_hevc_epel_bi[7][1][0] = ff_hevc_put_hevc_bi_epel_v32_8_msa;
++
++            c->put_hevc_epel_bi[1][1][1] = ff_hevc_put_hevc_bi_epel_hv4_8_msa;
++            c->put_hevc_epel_bi[2][1][1] = ff_hevc_put_hevc_bi_epel_hv6_8_msa;
++            c->put_hevc_epel_bi[3][1][1] = ff_hevc_put_hevc_bi_epel_hv8_8_msa;
++            c->put_hevc_epel_bi[4][1][1] = ff_hevc_put_hevc_bi_epel_hv12_8_msa;
++            c->put_hevc_epel_bi[5][1][1] = ff_hevc_put_hevc_bi_epel_hv16_8_msa;
++            c->put_hevc_epel_bi[6][1][1] = ff_hevc_put_hevc_bi_epel_hv24_8_msa;
++            c->put_hevc_epel_bi[7][1][1] = ff_hevc_put_hevc_bi_epel_hv32_8_msa;
++
++            c->put_hevc_qpel_bi_w[1][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels4_8_msa;
++            c->put_hevc_qpel_bi_w[3][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels8_8_msa;
++            c->put_hevc_qpel_bi_w[4][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels12_8_msa;
++            c->put_hevc_qpel_bi_w[5][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels16_8_msa;
++            c->put_hevc_qpel_bi_w[6][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels24_8_msa;
++            c->put_hevc_qpel_bi_w[7][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels32_8_msa;
++            c->put_hevc_qpel_bi_w[8][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels48_8_msa;
++            c->put_hevc_qpel_bi_w[9][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels64_8_msa;
++
++            c->put_hevc_qpel_bi_w[1][0][1] = ff_hevc_put_hevc_bi_w_qpel_h4_8_msa;
++            c->put_hevc_qpel_bi_w[3][0][1] = ff_hevc_put_hevc_bi_w_qpel_h8_8_msa;
++            c->put_hevc_qpel_bi_w[4][0][1] = ff_hevc_put_hevc_bi_w_qpel_h12_8_msa;
++            c->put_hevc_qpel_bi_w[5][0][1] = ff_hevc_put_hevc_bi_w_qpel_h16_8_msa;
++            c->put_hevc_qpel_bi_w[6][0][1] = ff_hevc_put_hevc_bi_w_qpel_h24_8_msa;
++            c->put_hevc_qpel_bi_w[7][0][1] = ff_hevc_put_hevc_bi_w_qpel_h32_8_msa;
++            c->put_hevc_qpel_bi_w[8][0][1] = ff_hevc_put_hevc_bi_w_qpel_h48_8_msa;
++            c->put_hevc_qpel_bi_w[9][0][1] = ff_hevc_put_hevc_bi_w_qpel_h64_8_msa;
++
++            c->put_hevc_qpel_bi_w[1][1][0] = ff_hevc_put_hevc_bi_w_qpel_v4_8_msa;
++            c->put_hevc_qpel_bi_w[3][1][0] = ff_hevc_put_hevc_bi_w_qpel_v8_8_msa;
++            c->put_hevc_qpel_bi_w[4][1][0] = ff_hevc_put_hevc_bi_w_qpel_v12_8_msa;
++            c->put_hevc_qpel_bi_w[5][1][0] = ff_hevc_put_hevc_bi_w_qpel_v16_8_msa;
++            c->put_hevc_qpel_bi_w[6][1][0] = ff_hevc_put_hevc_bi_w_qpel_v24_8_msa;
++            c->put_hevc_qpel_bi_w[7][1][0] = ff_hevc_put_hevc_bi_w_qpel_v32_8_msa;
++            c->put_hevc_qpel_bi_w[8][1][0] = ff_hevc_put_hevc_bi_w_qpel_v48_8_msa;
++            c->put_hevc_qpel_bi_w[9][1][0] = ff_hevc_put_hevc_bi_w_qpel_v64_8_msa;
++
++            c->put_hevc_qpel_bi_w[1][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv4_8_msa;
++            c->put_hevc_qpel_bi_w[3][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv8_8_msa;
++            c->put_hevc_qpel_bi_w[4][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv12_8_msa;
++            c->put_hevc_qpel_bi_w[5][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv16_8_msa;
++            c->put_hevc_qpel_bi_w[6][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv24_8_msa;
++            c->put_hevc_qpel_bi_w[7][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv32_8_msa;
++            c->put_hevc_qpel_bi_w[8][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv48_8_msa;
++            c->put_hevc_qpel_bi_w[9][1][1] = ff_hevc_put_hevc_bi_w_qpel_hv64_8_msa;
++
++            c->put_hevc_epel_bi_w[1][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels4_8_msa;
++            c->put_hevc_epel_bi_w[2][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels6_8_msa;
++            c->put_hevc_epel_bi_w[3][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels8_8_msa;
++            c->put_hevc_epel_bi_w[4][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels12_8_msa;
++            c->put_hevc_epel_bi_w[5][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels16_8_msa;
++            c->put_hevc_epel_bi_w[6][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels24_8_msa;
++            c->put_hevc_epel_bi_w[7][0][0] =
++                ff_hevc_put_hevc_bi_w_pel_pixels32_8_msa;
++
++            c->put_hevc_epel_bi_w[1][0][1] = ff_hevc_put_hevc_bi_w_epel_h4_8_msa;
++            c->put_hevc_epel_bi_w[2][0][1] = ff_hevc_put_hevc_bi_w_epel_h6_8_msa;
++            c->put_hevc_epel_bi_w[3][0][1] = ff_hevc_put_hevc_bi_w_epel_h8_8_msa;
++            c->put_hevc_epel_bi_w[4][0][1] = ff_hevc_put_hevc_bi_w_epel_h12_8_msa;
++            c->put_hevc_epel_bi_w[5][0][1] = ff_hevc_put_hevc_bi_w_epel_h16_8_msa;
++            c->put_hevc_epel_bi_w[6][0][1] = ff_hevc_put_hevc_bi_w_epel_h24_8_msa;
++            c->put_hevc_epel_bi_w[7][0][1] = ff_hevc_put_hevc_bi_w_epel_h32_8_msa;
++
++            c->put_hevc_epel_bi_w[1][1][0] = ff_hevc_put_hevc_bi_w_epel_v4_8_msa;
++            c->put_hevc_epel_bi_w[2][1][0] = ff_hevc_put_hevc_bi_w_epel_v6_8_msa;
++            c->put_hevc_epel_bi_w[3][1][0] = ff_hevc_put_hevc_bi_w_epel_v8_8_msa;
++            c->put_hevc_epel_bi_w[4][1][0] = ff_hevc_put_hevc_bi_w_epel_v12_8_msa;
++            c->put_hevc_epel_bi_w[5][1][0] = ff_hevc_put_hevc_bi_w_epel_v16_8_msa;
++            c->put_hevc_epel_bi_w[6][1][0] = ff_hevc_put_hevc_bi_w_epel_v24_8_msa;
++            c->put_hevc_epel_bi_w[7][1][0] = ff_hevc_put_hevc_bi_w_epel_v32_8_msa;
++
++            c->put_hevc_epel_bi_w[1][1][1] = ff_hevc_put_hevc_bi_w_epel_hv4_8_msa;
++            c->put_hevc_epel_bi_w[2][1][1] = ff_hevc_put_hevc_bi_w_epel_hv6_8_msa;
++            c->put_hevc_epel_bi_w[3][1][1] = ff_hevc_put_hevc_bi_w_epel_hv8_8_msa;
++            c->put_hevc_epel_bi_w[4][1][1] = ff_hevc_put_hevc_bi_w_epel_hv12_8_msa;
++            c->put_hevc_epel_bi_w[5][1][1] = ff_hevc_put_hevc_bi_w_epel_hv16_8_msa;
++            c->put_hevc_epel_bi_w[6][1][1] = ff_hevc_put_hevc_bi_w_epel_hv24_8_msa;
++            c->put_hevc_epel_bi_w[7][1][1] = ff_hevc_put_hevc_bi_w_epel_hv32_8_msa;
++
++            c->sao_band_filter[0] =
++            c->sao_band_filter[1] =
++            c->sao_band_filter[2] =
++            c->sao_band_filter[3] =
++            c->sao_band_filter[4] = ff_hevc_sao_band_filter_0_8_msa;
++
++            c->sao_edge_filter[0] =
++            c->sao_edge_filter[1] =
++            c->sao_edge_filter[2] =
++            c->sao_edge_filter[3] =
++            c->sao_edge_filter[4] = ff_hevc_sao_edge_filter_8_msa;
++
++            c->hevc_h_loop_filter_luma = ff_hevc_loop_filter_luma_h_8_msa;
++            c->hevc_v_loop_filter_luma = ff_hevc_loop_filter_luma_v_8_msa;
++
++            c->hevc_h_loop_filter_chroma = ff_hevc_loop_filter_chroma_h_8_msa;
++            c->hevc_v_loop_filter_chroma = ff_hevc_loop_filter_chroma_v_8_msa;
++
++            c->hevc_h_loop_filter_luma_c = ff_hevc_loop_filter_luma_h_8_msa;
++            c->hevc_v_loop_filter_luma_c = ff_hevc_loop_filter_luma_v_8_msa;
++
++            c->hevc_h_loop_filter_chroma_c =
++                ff_hevc_loop_filter_chroma_h_8_msa;
++            c->hevc_v_loop_filter_chroma_c =
++                ff_hevc_loop_filter_chroma_v_8_msa;
++
++            c->idct[0] = ff_hevc_idct_4x4_msa;
++            c->idct[1] = ff_hevc_idct_8x8_msa;
++            c->idct[2] = ff_hevc_idct_16x16_msa;
++            c->idct[3] = ff_hevc_idct_32x32_msa;
++            c->idct_dc[0] = ff_hevc_idct_dc_4x4_msa;
++            c->idct_dc[1] = ff_hevc_idct_dc_8x8_msa;
++            c->idct_dc[2] = ff_hevc_idct_dc_16x16_msa;
++            c->idct_dc[3] = ff_hevc_idct_dc_32x32_msa;
++            c->add_residual[0] = ff_hevc_addblk_4x4_msa;
++            c->add_residual[1] = ff_hevc_addblk_8x8_msa;
++            c->add_residual[2] = ff_hevc_addblk_16x16_msa;
++            c->add_residual[3] = ff_hevc_addblk_32x32_msa;
++            c->transform_4x4_luma = ff_hevc_idct_luma_4x4_msa;
++        }
+     }
+ }
+-#endif  // #if HAVE_MSA
+-
+-void ff_hevc_dsp_init_mips(HEVCDSPContext *c, const int bit_depth)
+-{
+-#if HAVE_MMI
+-    hevc_dsp_init_mmi(c, bit_depth);
+-#endif  // #if HAVE_MMI
+-#if HAVE_MSA
+-    hevc_dsp_init_msa(c, bit_depth);
+-#endif  // #if HAVE_MSA
+-}
+diff --git a/libavcodec/mips/hevcpred_init_mips.c b/libavcodec/mips/hevcpred_init_mips.c
+index e987698d66..f7ecb34dcc 100644
+--- a/libavcodec/mips/hevcpred_init_mips.c
++++ b/libavcodec/mips/hevcpred_init_mips.c
+@@ -18,32 +18,28 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "config.h"
+ #include "libavutil/attributes.h"
+ #include "libavcodec/mips/hevcpred_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void hevc_pred_init_msa(HEVCPredContext *c, const int bit_depth)
+-{
+-    if (8 == bit_depth) {
+-        c->intra_pred[2] = ff_intra_pred_8_16x16_msa;
+-        c->intra_pred[3] = ff_intra_pred_8_32x32_msa;
+-        c->pred_planar[0] = ff_hevc_intra_pred_planar_0_msa;
+-        c->pred_planar[1] = ff_hevc_intra_pred_planar_1_msa;
+-        c->pred_planar[2] = ff_hevc_intra_pred_planar_2_msa;
+-        c->pred_planar[3] = ff_hevc_intra_pred_planar_3_msa;
+-        c->pred_dc = ff_hevc_intra_pred_dc_msa;
+-        c->pred_angular[0] = ff_pred_intra_pred_angular_0_msa;
+-        c->pred_angular[1] = ff_pred_intra_pred_angular_1_msa;
+-        c->pred_angular[2] = ff_pred_intra_pred_angular_2_msa;
+-        c->pred_angular[3] = ff_pred_intra_pred_angular_3_msa;
+-    }
+-}
+-#endif  // #if HAVE_MSA
+-
+ void ff_hevc_pred_init_mips(HEVCPredContext *c, const int bit_depth)
+ {
+-#if HAVE_MSA
+-    hevc_pred_init_msa(c, bit_depth);
+-#endif  // #if HAVE_MSA
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_msa(cpu_flags)) {
++        if (bit_depth == 8) {
++            c->intra_pred[2] = ff_intra_pred_8_16x16_msa;
++            c->intra_pred[3] = ff_intra_pred_8_32x32_msa;
++            c->pred_planar[0] = ff_hevc_intra_pred_planar_0_msa;
++            c->pred_planar[1] = ff_hevc_intra_pred_planar_1_msa;
++            c->pred_planar[2] = ff_hevc_intra_pred_planar_2_msa;
++            c->pred_planar[3] = ff_hevc_intra_pred_planar_3_msa;
++            c->pred_dc = ff_hevc_intra_pred_dc_msa;
++            c->pred_angular[0] = ff_pred_intra_pred_angular_0_msa;
++            c->pred_angular[1] = ff_pred_intra_pred_angular_1_msa;
++            c->pred_angular[2] = ff_pred_intra_pred_angular_2_msa;
++            c->pred_angular[3] = ff_pred_intra_pred_angular_3_msa;
++        }
++    }
+ }
+diff --git a/libavcodec/mips/hpeldsp_init_mips.c b/libavcodec/mips/hpeldsp_init_mips.c
+index d6f7a9793d..77cbe99fa4 100644
+--- a/libavcodec/mips/hpeldsp_init_mips.c
++++ b/libavcodec/mips/hpeldsp_init_mips.c
+@@ -19,104 +19,94 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "../hpeldsp.h"
+ #include "libavcodec/mips/hpeldsp_mips.h"
+ 
+-#if HAVE_MSA
+-static void ff_hpeldsp_init_msa(HpelDSPContext *c, int flags)
+-{
+-    c->put_pixels_tab[0][0] = ff_put_pixels16_msa;
+-    c->put_pixels_tab[0][1] = ff_put_pixels16_x2_msa;
+-    c->put_pixels_tab[0][2] = ff_put_pixels16_y2_msa;
+-    c->put_pixels_tab[0][3] = ff_put_pixels16_xy2_msa;
+-
+-    c->put_pixels_tab[1][0] = ff_put_pixels8_msa;
+-    c->put_pixels_tab[1][1] = ff_put_pixels8_x2_msa;
+-    c->put_pixels_tab[1][2] = ff_put_pixels8_y2_msa;
+-    c->put_pixels_tab[1][3] = ff_put_pixels8_xy2_msa;
+-
+-    c->put_pixels_tab[2][1] = ff_put_pixels4_x2_msa;
+-    c->put_pixels_tab[2][2] = ff_put_pixels4_y2_msa;
+-    c->put_pixels_tab[2][3] = ff_put_pixels4_xy2_msa;
+-
+-    c->put_no_rnd_pixels_tab[0][0] = ff_put_pixels16_msa;
+-    c->put_no_rnd_pixels_tab[0][1] = ff_put_no_rnd_pixels16_x2_msa;
+-    c->put_no_rnd_pixels_tab[0][2] = ff_put_no_rnd_pixels16_y2_msa;
+-    c->put_no_rnd_pixels_tab[0][3] = ff_put_no_rnd_pixels16_xy2_msa;
+-
+-    c->put_no_rnd_pixels_tab[1][0] = ff_put_pixels8_msa;
+-    c->put_no_rnd_pixels_tab[1][1] = ff_put_no_rnd_pixels8_x2_msa;
+-    c->put_no_rnd_pixels_tab[1][2] = ff_put_no_rnd_pixels8_y2_msa;
+-    c->put_no_rnd_pixels_tab[1][3] = ff_put_no_rnd_pixels8_xy2_msa;
+-
+-    c->avg_pixels_tab[0][0] = ff_avg_pixels16_msa;
+-    c->avg_pixels_tab[0][1] = ff_avg_pixels16_x2_msa;
+-    c->avg_pixels_tab[0][2] = ff_avg_pixels16_y2_msa;
+-    c->avg_pixels_tab[0][3] = ff_avg_pixels16_xy2_msa;
+-
+-    c->avg_pixels_tab[1][0] = ff_avg_pixels8_msa;
+-    c->avg_pixels_tab[1][1] = ff_avg_pixels8_x2_msa;
+-    c->avg_pixels_tab[1][2] = ff_avg_pixels8_y2_msa;
+-    c->avg_pixels_tab[1][3] = ff_avg_pixels8_xy2_msa;
+-
+-    c->avg_pixels_tab[2][0] = ff_avg_pixels4_msa;
+-    c->avg_pixels_tab[2][1] = ff_avg_pixels4_x2_msa;
+-    c->avg_pixels_tab[2][2] = ff_avg_pixels4_y2_msa;
+-    c->avg_pixels_tab[2][3] = ff_avg_pixels4_xy2_msa;
+-}
+-#endif  // #if HAVE_MSA
+-
+-#if HAVE_MMI
+-static void ff_hpeldsp_init_mmi(HpelDSPContext *c, int flags)
+-{
+-    c->put_pixels_tab[0][0] = ff_put_pixels16_8_mmi;
+-    c->put_pixels_tab[0][1] = ff_put_pixels16_x2_8_mmi;
+-    c->put_pixels_tab[0][2] = ff_put_pixels16_y2_8_mmi;
+-    c->put_pixels_tab[0][3] = ff_put_pixels16_xy2_8_mmi;
+-
+-    c->put_pixels_tab[1][0] = ff_put_pixels8_8_mmi;
+-    c->put_pixels_tab[1][1] = ff_put_pixels8_x2_8_mmi;
+-    c->put_pixels_tab[1][2] = ff_put_pixels8_y2_8_mmi;
+-    c->put_pixels_tab[1][3] = ff_put_pixels8_xy2_8_mmi;
+-
+-    c->put_pixels_tab[2][0] = ff_put_pixels4_8_mmi;
+-    c->put_pixels_tab[2][1] = ff_put_pixels4_x2_8_mmi;
+-    c->put_pixels_tab[2][2] = ff_put_pixels4_y2_8_mmi;
+-    c->put_pixels_tab[2][3] = ff_put_pixels4_xy2_8_mmi;
+-
+-    c->put_no_rnd_pixels_tab[0][0] = ff_put_pixels16_8_mmi;
+-    c->put_no_rnd_pixels_tab[0][1] = ff_put_no_rnd_pixels16_x2_8_mmi;
+-    c->put_no_rnd_pixels_tab[0][2] = ff_put_no_rnd_pixels16_y2_8_mmi;
+-    c->put_no_rnd_pixels_tab[0][3] = ff_put_no_rnd_pixels16_xy2_8_mmi;
+-
+-    c->put_no_rnd_pixels_tab[1][0] = ff_put_pixels8_8_mmi;
+-    c->put_no_rnd_pixels_tab[1][1] = ff_put_no_rnd_pixels8_x2_8_mmi;
+-    c->put_no_rnd_pixels_tab[1][2] = ff_put_no_rnd_pixels8_y2_8_mmi;
+-    c->put_no_rnd_pixels_tab[1][3] = ff_put_no_rnd_pixels8_xy2_8_mmi;
+-
+-    c->avg_pixels_tab[0][0] = ff_avg_pixels16_8_mmi;
+-    c->avg_pixels_tab[0][1] = ff_avg_pixels16_x2_8_mmi;
+-    c->avg_pixels_tab[0][2] = ff_avg_pixels16_y2_8_mmi;
+-    c->avg_pixels_tab[0][3] = ff_avg_pixels16_xy2_8_mmi;
+-
+-    c->avg_pixels_tab[1][0] = ff_avg_pixels8_8_mmi;
+-    c->avg_pixels_tab[1][1] = ff_avg_pixels8_x2_8_mmi;
+-    c->avg_pixels_tab[1][2] = ff_avg_pixels8_y2_8_mmi;
+-    c->avg_pixels_tab[1][3] = ff_avg_pixels8_xy2_8_mmi;
+-
+-    c->avg_pixels_tab[2][0] = ff_avg_pixels4_8_mmi;
+-    c->avg_pixels_tab[2][1] = ff_avg_pixels4_x2_8_mmi;
+-    c->avg_pixels_tab[2][2] = ff_avg_pixels4_y2_8_mmi;
+-    c->avg_pixels_tab[2][3] = ff_avg_pixels4_xy2_8_mmi;
+-}
+-#endif  // #if HAVE_MMI
+-
+ void ff_hpeldsp_init_mips(HpelDSPContext *c, int flags)
+ {
+-#if HAVE_MMI
+-    ff_hpeldsp_init_mmi(c, flags);
+-#endif  // #if HAVE_MMI
+-#if HAVE_MSA
+-    ff_hpeldsp_init_msa(c, flags);
+-#endif  // #if HAVE_MSA
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_mmi(cpu_flags)) {
++        c->put_pixels_tab[0][0] = ff_put_pixels16_8_mmi;
++        c->put_pixels_tab[0][1] = ff_put_pixels16_x2_8_mmi;
++        c->put_pixels_tab[0][2] = ff_put_pixels16_y2_8_mmi;
++        c->put_pixels_tab[0][3] = ff_put_pixels16_xy2_8_mmi;
++
++        c->put_pixels_tab[1][0] = ff_put_pixels8_8_mmi;
++        c->put_pixels_tab[1][1] = ff_put_pixels8_x2_8_mmi;
++        c->put_pixels_tab[1][2] = ff_put_pixels8_y2_8_mmi;
++        c->put_pixels_tab[1][3] = ff_put_pixels8_xy2_8_mmi;
++
++        c->put_pixels_tab[2][0] = ff_put_pixels4_8_mmi;
++        c->put_pixels_tab[2][1] = ff_put_pixels4_x2_8_mmi;
++        c->put_pixels_tab[2][2] = ff_put_pixels4_y2_8_mmi;
++        c->put_pixels_tab[2][3] = ff_put_pixels4_xy2_8_mmi;
++
++        c->put_no_rnd_pixels_tab[0][0] = ff_put_pixels16_8_mmi;
++        c->put_no_rnd_pixels_tab[0][1] = ff_put_no_rnd_pixels16_x2_8_mmi;
++        c->put_no_rnd_pixels_tab[0][2] = ff_put_no_rnd_pixels16_y2_8_mmi;
++        c->put_no_rnd_pixels_tab[0][3] = ff_put_no_rnd_pixels16_xy2_8_mmi;
++
++        c->put_no_rnd_pixels_tab[1][0] = ff_put_pixels8_8_mmi;
++        c->put_no_rnd_pixels_tab[1][1] = ff_put_no_rnd_pixels8_x2_8_mmi;
++        c->put_no_rnd_pixels_tab[1][2] = ff_put_no_rnd_pixels8_y2_8_mmi;
++        c->put_no_rnd_pixels_tab[1][3] = ff_put_no_rnd_pixels8_xy2_8_mmi;
++
++        c->avg_pixels_tab[0][0] = ff_avg_pixels16_8_mmi;
++        c->avg_pixels_tab[0][1] = ff_avg_pixels16_x2_8_mmi;
++        c->avg_pixels_tab[0][2] = ff_avg_pixels16_y2_8_mmi;
++        c->avg_pixels_tab[0][3] = ff_avg_pixels16_xy2_8_mmi;
++
++        c->avg_pixels_tab[1][0] = ff_avg_pixels8_8_mmi;
++        c->avg_pixels_tab[1][1] = ff_avg_pixels8_x2_8_mmi;
++        c->avg_pixels_tab[1][2] = ff_avg_pixels8_y2_8_mmi;
++        c->avg_pixels_tab[1][3] = ff_avg_pixels8_xy2_8_mmi;
++
++        c->avg_pixels_tab[2][0] = ff_avg_pixels4_8_mmi;
++        c->avg_pixels_tab[2][1] = ff_avg_pixels4_x2_8_mmi;
++        c->avg_pixels_tab[2][2] = ff_avg_pixels4_y2_8_mmi;
++        c->avg_pixels_tab[2][3] = ff_avg_pixels4_xy2_8_mmi;
++    }
++
++    if (have_msa(cpu_flags)) {
++        c->put_pixels_tab[0][0] = ff_put_pixels16_msa;
++        c->put_pixels_tab[0][1] = ff_put_pixels16_x2_msa;
++        c->put_pixels_tab[0][2] = ff_put_pixels16_y2_msa;
++        c->put_pixels_tab[0][3] = ff_put_pixels16_xy2_msa;
++
++        c->put_pixels_tab[1][0] = ff_put_pixels8_msa;
++        c->put_pixels_tab[1][1] = ff_put_pixels8_x2_msa;
++        c->put_pixels_tab[1][2] = ff_put_pixels8_y2_msa;
++        c->put_pixels_tab[1][3] = ff_put_pixels8_xy2_msa;
++
++        c->put_pixels_tab[2][1] = ff_put_pixels4_x2_msa;
++        c->put_pixels_tab[2][2] = ff_put_pixels4_y2_msa;
++        c->put_pixels_tab[2][3] = ff_put_pixels4_xy2_msa;
++
++        c->put_no_rnd_pixels_tab[0][0] = ff_put_pixels16_msa;
++        c->put_no_rnd_pixels_tab[0][1] = ff_put_no_rnd_pixels16_x2_msa;
++        c->put_no_rnd_pixels_tab[0][2] = ff_put_no_rnd_pixels16_y2_msa;
++        c->put_no_rnd_pixels_tab[0][3] = ff_put_no_rnd_pixels16_xy2_msa;
++
++        c->put_no_rnd_pixels_tab[1][0] = ff_put_pixels8_msa;
++        c->put_no_rnd_pixels_tab[1][1] = ff_put_no_rnd_pixels8_x2_msa;
++        c->put_no_rnd_pixels_tab[1][2] = ff_put_no_rnd_pixels8_y2_msa;
++        c->put_no_rnd_pixels_tab[1][3] = ff_put_no_rnd_pixels8_xy2_msa;
++
++        c->avg_pixels_tab[0][0] = ff_avg_pixels16_msa;
++        c->avg_pixels_tab[0][1] = ff_avg_pixels16_x2_msa;
++        c->avg_pixels_tab[0][2] = ff_avg_pixels16_y2_msa;
++        c->avg_pixels_tab[0][3] = ff_avg_pixels16_xy2_msa;
++
++        c->avg_pixels_tab[1][0] = ff_avg_pixels8_msa;
++        c->avg_pixels_tab[1][1] = ff_avg_pixels8_x2_msa;
++        c->avg_pixels_tab[1][2] = ff_avg_pixels8_y2_msa;
++        c->avg_pixels_tab[1][3] = ff_avg_pixels8_xy2_msa;
++
++        c->avg_pixels_tab[2][0] = ff_avg_pixels4_msa;
++        c->avg_pixels_tab[2][1] = ff_avg_pixels4_x2_msa;
++        c->avg_pixels_tab[2][2] = ff_avg_pixels4_y2_msa;
++        c->avg_pixels_tab[2][3] = ff_avg_pixels4_xy2_msa;
++    }
+ }
+diff --git a/libavcodec/mips/idctdsp_init_mips.c b/libavcodec/mips/idctdsp_init_mips.c
+index 85b76ca478..23efd9ed58 100644
+--- a/libavcodec/mips/idctdsp_init_mips.c
++++ b/libavcodec/mips/idctdsp_init_mips.c
+@@ -19,56 +19,44 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "idctdsp_mips.h"
+ #include "xvididct_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void idctdsp_init_msa(IDCTDSPContext *c, AVCodecContext *avctx,
+-                                     unsigned high_bit_depth)
++av_cold void ff_idctdsp_init_mips(IDCTDSPContext *c, AVCodecContext *avctx,
++                          unsigned high_bit_depth)
+ {
+-    if ((avctx->lowres != 1) && (avctx->lowres != 2) && (avctx->lowres != 3) &&
+-        (avctx->bits_per_raw_sample != 10) &&
+-        (avctx->bits_per_raw_sample != 12) &&
+-        (avctx->idct_algo == FF_IDCT_AUTO)) {
+-                c->idct_put = ff_simple_idct_put_msa;
+-                c->idct_add = ff_simple_idct_add_msa;
+-                c->idct = ff_simple_idct_msa;
+-                c->perm_type = FF_IDCT_PERM_NONE;
+-    }
++    int cpu_flags = av_get_cpu_flags();
+ 
+-    c->put_pixels_clamped = ff_put_pixels_clamped_msa;
+-    c->put_signed_pixels_clamped = ff_put_signed_pixels_clamped_msa;
+-    c->add_pixels_clamped = ff_add_pixels_clamped_msa;
+-}
+-#endif  // #if HAVE_MSA
++    if (have_mmi(cpu_flags)) {
++        if ((avctx->lowres != 1) && (avctx->lowres != 2) && (avctx->lowres != 3) &&
++            (avctx->bits_per_raw_sample != 10) &&
++            (avctx->bits_per_raw_sample != 12) &&
++            ((avctx->idct_algo == FF_IDCT_AUTO) || (avctx->idct_algo == FF_IDCT_SIMPLE))) {
++                    c->idct_put = ff_simple_idct_put_8_mmi;
++                    c->idct_add = ff_simple_idct_add_8_mmi;
++                    c->idct = ff_simple_idct_8_mmi;
++                    c->perm_type = FF_IDCT_PERM_NONE;
++        }
+ 
+-#if HAVE_MMI
+-static av_cold void idctdsp_init_mmi(IDCTDSPContext *c, AVCodecContext *avctx,
+-        unsigned high_bit_depth)
+-{
+-    if ((avctx->lowres != 1) && (avctx->lowres != 2) && (avctx->lowres != 3) &&
+-        (avctx->bits_per_raw_sample != 10) &&
+-        (avctx->bits_per_raw_sample != 12) &&
+-        ((avctx->idct_algo == FF_IDCT_AUTO) || (avctx->idct_algo == FF_IDCT_SIMPLE))) {
+-                c->idct_put = ff_simple_idct_put_8_mmi;
+-                c->idct_add = ff_simple_idct_add_8_mmi;
+-                c->idct = ff_simple_idct_8_mmi;
+-                c->perm_type = FF_IDCT_PERM_NONE;
++        c->put_pixels_clamped = ff_put_pixels_clamped_mmi;
++        c->add_pixels_clamped = ff_add_pixels_clamped_mmi;
++        c->put_signed_pixels_clamped = ff_put_signed_pixels_clamped_mmi;
+     }
+ 
+-    c->put_pixels_clamped = ff_put_pixels_clamped_mmi;
+-    c->add_pixels_clamped = ff_add_pixels_clamped_mmi;
+-    c->put_signed_pixels_clamped = ff_put_signed_pixels_clamped_mmi;
+-}
+-#endif /* HAVE_MMI */
++    if (have_msa(cpu_flags)) {
++        if ((avctx->lowres != 1) && (avctx->lowres != 2) && (avctx->lowres != 3) &&
++            (avctx->bits_per_raw_sample != 10) &&
++            (avctx->bits_per_raw_sample != 12) &&
++            (avctx->idct_algo == FF_IDCT_AUTO)) {
++                    c->idct_put = ff_simple_idct_put_msa;
++                    c->idct_add = ff_simple_idct_add_msa;
++                    c->idct = ff_simple_idct_msa;
++                    c->perm_type = FF_IDCT_PERM_NONE;
++        }
+ 
+-av_cold void ff_idctdsp_init_mips(IDCTDSPContext *c, AVCodecContext *avctx,
+-                          unsigned high_bit_depth)
+-{
+-#if HAVE_MMI
+-    idctdsp_init_mmi(c, avctx, high_bit_depth);
+-#endif /* HAVE_MMI */
+-#if HAVE_MSA
+-    idctdsp_init_msa(c, avctx, high_bit_depth);
+-#endif  // #if HAVE_MSA
++        c->put_pixels_clamped = ff_put_pixels_clamped_msa;
++        c->put_signed_pixels_clamped = ff_put_signed_pixels_clamped_msa;
++        c->add_pixels_clamped = ff_add_pixels_clamped_msa;
++    }
+ }
+diff --git a/libavcodec/mips/me_cmp_init_mips.c b/libavcodec/mips/me_cmp_init_mips.c
+index 219a0dc00c..e3e33b8e5e 100644
+--- a/libavcodec/mips/me_cmp_init_mips.c
++++ b/libavcodec/mips/me_cmp_init_mips.c
+@@ -18,39 +18,35 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "me_cmp_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void me_cmp_msa(MECmpContext *c, AVCodecContext *avctx)
++av_cold void ff_me_cmp_init_mips(MECmpContext *c, AVCodecContext *avctx)
+ {
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_msa(cpu_flags)) {
+ #if BIT_DEPTH == 8
+-    c->pix_abs[0][0] = ff_pix_abs16_msa;
+-    c->pix_abs[0][1] = ff_pix_abs16_x2_msa;
+-    c->pix_abs[0][2] = ff_pix_abs16_y2_msa;
+-    c->pix_abs[0][3] = ff_pix_abs16_xy2_msa;
+-    c->pix_abs[1][0] = ff_pix_abs8_msa;
+-    c->pix_abs[1][1] = ff_pix_abs8_x2_msa;
+-    c->pix_abs[1][2] = ff_pix_abs8_y2_msa;
+-    c->pix_abs[1][3] = ff_pix_abs8_xy2_msa;
++        c->pix_abs[0][0] = ff_pix_abs16_msa;
++        c->pix_abs[0][1] = ff_pix_abs16_x2_msa;
++        c->pix_abs[0][2] = ff_pix_abs16_y2_msa;
++        c->pix_abs[0][3] = ff_pix_abs16_xy2_msa;
++        c->pix_abs[1][0] = ff_pix_abs8_msa;
++        c->pix_abs[1][1] = ff_pix_abs8_x2_msa;
++        c->pix_abs[1][2] = ff_pix_abs8_y2_msa;
++        c->pix_abs[1][3] = ff_pix_abs8_xy2_msa;
+ 
+-    c->hadamard8_diff[0] = ff_hadamard8_diff16_msa;
+-    c->hadamard8_diff[1] = ff_hadamard8_diff8x8_msa;
++        c->hadamard8_diff[0] = ff_hadamard8_diff16_msa;
++        c->hadamard8_diff[1] = ff_hadamard8_diff8x8_msa;
+ 
+-    c->hadamard8_diff[4] = ff_hadamard8_intra16_msa;
+-    c->hadamard8_diff[5] = ff_hadamard8_intra8x8_msa;
++        c->hadamard8_diff[4] = ff_hadamard8_intra16_msa;
++        c->hadamard8_diff[5] = ff_hadamard8_intra8x8_msa;
+ 
+-    c->sad[0] = ff_pix_abs16_msa;
+-    c->sad[1] = ff_pix_abs8_msa;
+-    c->sse[0] = ff_sse16_msa;
+-    c->sse[1] = ff_sse8_msa;
+-    c->sse[2] = ff_sse4_msa;
++        c->sad[0] = ff_pix_abs16_msa;
++        c->sad[1] = ff_pix_abs8_msa;
++        c->sse[0] = ff_sse16_msa;
++        c->sse[1] = ff_sse8_msa;
++        c->sse[2] = ff_sse4_msa;
+ #endif
+-}
+-#endif  // #if HAVE_MSA
+-
+-av_cold void ff_me_cmp_init_mips(MECmpContext *c, AVCodecContext *avctx)
+-{
+-#if HAVE_MSA
+-    me_cmp_msa(c, avctx);
+-#endif  // #if HAVE_MSA
++    }
+ }
+diff --git a/libavcodec/mips/mpegvideo_init_mips.c b/libavcodec/mips/mpegvideo_init_mips.c
+index be77308140..bfda90bbcc 100644
+--- a/libavcodec/mips/mpegvideo_init_mips.c
++++ b/libavcodec/mips/mpegvideo_init_mips.c
+@@ -18,41 +18,31 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "h263dsp_mips.h"
+ #include "mpegvideo_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void dct_unquantize_init_msa(MpegEncContext *s)
++av_cold void ff_mpv_common_init_mips(MpegEncContext *s)
+ {
+-    s->dct_unquantize_h263_intra = ff_dct_unquantize_h263_intra_msa;
+-    s->dct_unquantize_h263_inter = ff_dct_unquantize_h263_inter_msa;
+-    if (!s->q_scale_type)
+-        s->dct_unquantize_mpeg2_inter = ff_dct_unquantize_mpeg2_inter_msa;
+-}
+-#endif  // #if HAVE_MSA
++    int cpu_flags = av_get_cpu_flags();
+ 
+-#if HAVE_MMI
+-static av_cold void dct_unquantize_init_mmi(MpegEncContext *s)
+-{
+-    s->dct_unquantize_h263_intra = ff_dct_unquantize_h263_intra_mmi;
+-    s->dct_unquantize_h263_inter = ff_dct_unquantize_h263_inter_mmi;
+-    s->dct_unquantize_mpeg1_intra = ff_dct_unquantize_mpeg1_intra_mmi;
+-    s->dct_unquantize_mpeg1_inter = ff_dct_unquantize_mpeg1_inter_mmi;
++    if (have_mmi(cpu_flags)) {
++        s->dct_unquantize_h263_intra = ff_dct_unquantize_h263_intra_mmi;
++        s->dct_unquantize_h263_inter = ff_dct_unquantize_h263_inter_mmi;
++        s->dct_unquantize_mpeg1_intra = ff_dct_unquantize_mpeg1_intra_mmi;
++        s->dct_unquantize_mpeg1_inter = ff_dct_unquantize_mpeg1_inter_mmi;
+ 
+-    if (!(s->avctx->flags & AV_CODEC_FLAG_BITEXACT))
+-        if (!s->q_scale_type)
+-            s->dct_unquantize_mpeg2_intra = ff_dct_unquantize_mpeg2_intra_mmi;
++        if (!(s->avctx->flags & AV_CODEC_FLAG_BITEXACT))
++            if (!s->q_scale_type)
++                s->dct_unquantize_mpeg2_intra = ff_dct_unquantize_mpeg2_intra_mmi;
+ 
+-    s->denoise_dct= ff_denoise_dct_mmi;
+-}
+-#endif /* HAVE_MMI */
++        s->denoise_dct= ff_denoise_dct_mmi;
++    }
+ 
+-av_cold void ff_mpv_common_init_mips(MpegEncContext *s)
+-{
+-#if HAVE_MMI
+-    dct_unquantize_init_mmi(s);
+-#endif /* HAVE_MMI */
+-#if HAVE_MSA
+-    dct_unquantize_init_msa(s);
+-#endif  // #if HAVE_MSA
++    if (have_msa(cpu_flags)) {
++        s->dct_unquantize_h263_intra = ff_dct_unquantize_h263_intra_msa;
++        s->dct_unquantize_h263_inter = ff_dct_unquantize_h263_inter_msa;
++        if (!s->q_scale_type)
++            s->dct_unquantize_mpeg2_inter = ff_dct_unquantize_mpeg2_inter_msa;
++    }
+ }
+diff --git a/libavcodec/mips/mpegvideoencdsp_init_mips.c b/libavcodec/mips/mpegvideoencdsp_init_mips.c
+index 9bfe94e4cd..71831a61ac 100644
+--- a/libavcodec/mips/mpegvideoencdsp_init_mips.c
++++ b/libavcodec/mips/mpegvideoencdsp_init_mips.c
+@@ -18,23 +18,18 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "libavcodec/bit_depth_template.c"
+ #include "h263dsp_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void mpegvideoencdsp_init_msa(MpegvideoEncDSPContext *c,
+-                                             AVCodecContext *avctx)
+-{
+-#if BIT_DEPTH == 8
+-    c->pix_sum = ff_pix_sum_msa;
+-#endif
+-}
+-#endif  // #if HAVE_MSA
+-
+ av_cold void ff_mpegvideoencdsp_init_mips(MpegvideoEncDSPContext *c,
+                                           AVCodecContext *avctx)
+ {
+-#if HAVE_MSA
+-    mpegvideoencdsp_init_msa(c, avctx);
+-#endif  // #if HAVE_MSA
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_msa(cpu_flags)) {
++#if BIT_DEPTH == 8
++        c->pix_sum = ff_pix_sum_msa;
++#endif
++    }
+ }
+diff --git a/libavcodec/mips/pixblockdsp_init_mips.c b/libavcodec/mips/pixblockdsp_init_mips.c
+index fd0238d79b..2e2d70953b 100644
+--- a/libavcodec/mips/pixblockdsp_init_mips.c
++++ b/libavcodec/mips/pixblockdsp_init_mips.c
+@@ -19,51 +19,38 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "pixblockdsp_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void pixblockdsp_init_msa(PixblockDSPContext *c,
+-                                         AVCodecContext *avctx,
+-                                         unsigned high_bit_depth)
++void ff_pixblockdsp_init_mips(PixblockDSPContext *c, AVCodecContext *avctx,
++                              unsigned high_bit_depth)
+ {
+-    c->diff_pixels = ff_diff_pixels_msa;
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_mmi(cpu_flags)) {
++        c->diff_pixels = ff_diff_pixels_mmi;
+ 
+-    switch (avctx->bits_per_raw_sample) {
+-    case 9:
+-    case 10:
+-    case 12:
+-    case 14:
+-        c->get_pixels = ff_get_pixels_16_msa;
+-        break;
+-    default:
+-        if (avctx->bits_per_raw_sample <= 8 || avctx->codec_type !=
+-            AVMEDIA_TYPE_VIDEO) {
+-            c->get_pixels = ff_get_pixels_8_msa;
++        if (!high_bit_depth || avctx->codec_type != AVMEDIA_TYPE_VIDEO) {
++            c->get_pixels = ff_get_pixels_8_mmi;
+         }
+-        break;
+     }
+-}
+-#endif  // #if HAVE_MSA
+ 
+-#if HAVE_MMI
+-static av_cold void pixblockdsp_init_mmi(PixblockDSPContext *c,
+-        AVCodecContext *avctx, unsigned high_bit_depth)
+-{
+-    c->diff_pixels = ff_diff_pixels_mmi;
++    if (have_msa(cpu_flags)) {
++        c->diff_pixels = ff_diff_pixels_msa;
+ 
+-    if (!high_bit_depth || avctx->codec_type != AVMEDIA_TYPE_VIDEO) {
+-        c->get_pixels = ff_get_pixels_8_mmi;
++        switch (avctx->bits_per_raw_sample) {
++        case 9:
++        case 10:
++        case 12:
++        case 14:
++            c->get_pixels = ff_get_pixels_16_msa;
++            break;
++        default:
++            if (avctx->bits_per_raw_sample <= 8 || avctx->codec_type !=
++                AVMEDIA_TYPE_VIDEO) {
++                c->get_pixels = ff_get_pixels_8_msa;
++            }
++            break;
++        }
+     }
+ }
+-#endif /* HAVE_MMI */
+-
+-void ff_pixblockdsp_init_mips(PixblockDSPContext *c, AVCodecContext *avctx,
+-                              unsigned high_bit_depth)
+-{
+-#if HAVE_MMI
+-    pixblockdsp_init_mmi(c, avctx, high_bit_depth);
+-#endif /* HAVE_MMI */
+-#if HAVE_MSA
+-    pixblockdsp_init_msa(c, avctx, high_bit_depth);
+-#endif  // #if HAVE_MSA
+-}
+diff --git a/libavcodec/mips/qpeldsp_init_mips.c b/libavcodec/mips/qpeldsp_init_mips.c
+index 140e8f89c9..cccf9d4429 100644
+--- a/libavcodec/mips/qpeldsp_init_mips.c
++++ b/libavcodec/mips/qpeldsp_init_mips.c
+@@ -18,150 +18,146 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "qpeldsp_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void qpeldsp_init_msa(QpelDSPContext *c)
++void ff_qpeldsp_init_mips(QpelDSPContext *c)
+ {
+-    c->put_qpel_pixels_tab[0][0] = ff_copy_16x16_msa;
+-    c->put_qpel_pixels_tab[0][1] = ff_horiz_mc_qpel_aver_src0_16width_msa;
+-    c->put_qpel_pixels_tab[0][2] = ff_horiz_mc_qpel_16width_msa;
+-    c->put_qpel_pixels_tab[0][3] = ff_horiz_mc_qpel_aver_src1_16width_msa;
+-    c->put_qpel_pixels_tab[0][4] = ff_vert_mc_qpel_aver_src0_16x16_msa;
+-    c->put_qpel_pixels_tab[0][5] = ff_hv_mc_qpel_aver_hv_src00_16x16_msa;
+-    c->put_qpel_pixels_tab[0][6] = ff_hv_mc_qpel_aver_v_src0_16x16_msa;
+-    c->put_qpel_pixels_tab[0][7] = ff_hv_mc_qpel_aver_hv_src10_16x16_msa;
+-    c->put_qpel_pixels_tab[0][8] = ff_vert_mc_qpel_16x16_msa;
+-    c->put_qpel_pixels_tab[0][9] = ff_hv_mc_qpel_aver_h_src0_16x16_msa;
+-    c->put_qpel_pixels_tab[0][10] = ff_hv_mc_qpel_16x16_msa;
+-    c->put_qpel_pixels_tab[0][11] = ff_hv_mc_qpel_aver_h_src1_16x16_msa;
+-    c->put_qpel_pixels_tab[0][12] = ff_vert_mc_qpel_aver_src1_16x16_msa;
+-    c->put_qpel_pixels_tab[0][13] = ff_hv_mc_qpel_aver_hv_src01_16x16_msa;
+-    c->put_qpel_pixels_tab[0][14] = ff_hv_mc_qpel_aver_v_src1_16x16_msa;
+-    c->put_qpel_pixels_tab[0][15] = ff_hv_mc_qpel_aver_hv_src11_16x16_msa;
++    int cpu_flags = av_get_cpu_flags();
+ 
+-    c->put_qpel_pixels_tab[1][0] = ff_copy_8x8_msa;
+-    c->put_qpel_pixels_tab[1][1] = ff_horiz_mc_qpel_aver_src0_8width_msa;
+-    c->put_qpel_pixels_tab[1][2] = ff_horiz_mc_qpel_8width_msa;
+-    c->put_qpel_pixels_tab[1][3] = ff_horiz_mc_qpel_aver_src1_8width_msa;
+-    c->put_qpel_pixels_tab[1][4] = ff_vert_mc_qpel_aver_src0_8x8_msa;
+-    c->put_qpel_pixels_tab[1][5] = ff_hv_mc_qpel_aver_hv_src00_8x8_msa;
+-    c->put_qpel_pixels_tab[1][6] = ff_hv_mc_qpel_aver_v_src0_8x8_msa;
+-    c->put_qpel_pixels_tab[1][7] = ff_hv_mc_qpel_aver_hv_src10_8x8_msa;
+-    c->put_qpel_pixels_tab[1][8] = ff_vert_mc_qpel_8x8_msa;
+-    c->put_qpel_pixels_tab[1][9] = ff_hv_mc_qpel_aver_h_src0_8x8_msa;
+-    c->put_qpel_pixels_tab[1][10] = ff_hv_mc_qpel_8x8_msa;
+-    c->put_qpel_pixels_tab[1][11] = ff_hv_mc_qpel_aver_h_src1_8x8_msa;
+-    c->put_qpel_pixels_tab[1][12] = ff_vert_mc_qpel_aver_src1_8x8_msa;
+-    c->put_qpel_pixels_tab[1][13] = ff_hv_mc_qpel_aver_hv_src01_8x8_msa;
+-    c->put_qpel_pixels_tab[1][14] = ff_hv_mc_qpel_aver_v_src1_8x8_msa;
+-    c->put_qpel_pixels_tab[1][15] = ff_hv_mc_qpel_aver_hv_src11_8x8_msa;
++    if (have_msa(cpu_flags)) {
++        c->put_qpel_pixels_tab[0][0] = ff_copy_16x16_msa;
++        c->put_qpel_pixels_tab[0][1] = ff_horiz_mc_qpel_aver_src0_16width_msa;
++        c->put_qpel_pixels_tab[0][2] = ff_horiz_mc_qpel_16width_msa;
++        c->put_qpel_pixels_tab[0][3] = ff_horiz_mc_qpel_aver_src1_16width_msa;
++        c->put_qpel_pixels_tab[0][4] = ff_vert_mc_qpel_aver_src0_16x16_msa;
++        c->put_qpel_pixels_tab[0][5] = ff_hv_mc_qpel_aver_hv_src00_16x16_msa;
++        c->put_qpel_pixels_tab[0][6] = ff_hv_mc_qpel_aver_v_src0_16x16_msa;
++        c->put_qpel_pixels_tab[0][7] = ff_hv_mc_qpel_aver_hv_src10_16x16_msa;
++        c->put_qpel_pixels_tab[0][8] = ff_vert_mc_qpel_16x16_msa;
++        c->put_qpel_pixels_tab[0][9] = ff_hv_mc_qpel_aver_h_src0_16x16_msa;
++        c->put_qpel_pixels_tab[0][10] = ff_hv_mc_qpel_16x16_msa;
++        c->put_qpel_pixels_tab[0][11] = ff_hv_mc_qpel_aver_h_src1_16x16_msa;
++        c->put_qpel_pixels_tab[0][12] = ff_vert_mc_qpel_aver_src1_16x16_msa;
++        c->put_qpel_pixels_tab[0][13] = ff_hv_mc_qpel_aver_hv_src01_16x16_msa;
++        c->put_qpel_pixels_tab[0][14] = ff_hv_mc_qpel_aver_v_src1_16x16_msa;
++        c->put_qpel_pixels_tab[0][15] = ff_hv_mc_qpel_aver_hv_src11_16x16_msa;
+ 
+-    c->put_no_rnd_qpel_pixels_tab[0][0] = ff_copy_16x16_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][1] =
+-        ff_horiz_mc_qpel_no_rnd_aver_src0_16width_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][2] = ff_horiz_mc_qpel_no_rnd_16width_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][3] =
+-        ff_horiz_mc_qpel_no_rnd_aver_src1_16width_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][4] =
+-        ff_vert_mc_qpel_no_rnd_aver_src0_16x16_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][5] =
+-        ff_hv_mc_qpel_no_rnd_aver_hv_src00_16x16_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][6] =
+-        ff_hv_mc_qpel_no_rnd_aver_v_src0_16x16_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][7] =
+-        ff_hv_mc_qpel_no_rnd_aver_hv_src10_16x16_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][8] = ff_vert_mc_qpel_no_rnd_16x16_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][9] =
+-        ff_hv_mc_qpel_no_rnd_aver_h_src0_16x16_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][10] = ff_hv_mc_qpel_no_rnd_16x16_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][11] =
+-        ff_hv_mc_qpel_no_rnd_aver_h_src1_16x16_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][12] =
+-        ff_vert_mc_qpel_no_rnd_aver_src1_16x16_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][13] =
+-        ff_hv_mc_qpel_no_rnd_aver_hv_src01_16x16_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][14] =
+-        ff_hv_mc_qpel_no_rnd_aver_v_src1_16x16_msa;
+-    c->put_no_rnd_qpel_pixels_tab[0][15] =
+-        ff_hv_mc_qpel_no_rnd_aver_hv_src11_16x16_msa;
++        c->put_qpel_pixels_tab[1][0] = ff_copy_8x8_msa;
++        c->put_qpel_pixels_tab[1][1] = ff_horiz_mc_qpel_aver_src0_8width_msa;
++        c->put_qpel_pixels_tab[1][2] = ff_horiz_mc_qpel_8width_msa;
++        c->put_qpel_pixels_tab[1][3] = ff_horiz_mc_qpel_aver_src1_8width_msa;
++        c->put_qpel_pixels_tab[1][4] = ff_vert_mc_qpel_aver_src0_8x8_msa;
++        c->put_qpel_pixels_tab[1][5] = ff_hv_mc_qpel_aver_hv_src00_8x8_msa;
++        c->put_qpel_pixels_tab[1][6] = ff_hv_mc_qpel_aver_v_src0_8x8_msa;
++        c->put_qpel_pixels_tab[1][7] = ff_hv_mc_qpel_aver_hv_src10_8x8_msa;
++        c->put_qpel_pixels_tab[1][8] = ff_vert_mc_qpel_8x8_msa;
++        c->put_qpel_pixels_tab[1][9] = ff_hv_mc_qpel_aver_h_src0_8x8_msa;
++        c->put_qpel_pixels_tab[1][10] = ff_hv_mc_qpel_8x8_msa;
++        c->put_qpel_pixels_tab[1][11] = ff_hv_mc_qpel_aver_h_src1_8x8_msa;
++        c->put_qpel_pixels_tab[1][12] = ff_vert_mc_qpel_aver_src1_8x8_msa;
++        c->put_qpel_pixels_tab[1][13] = ff_hv_mc_qpel_aver_hv_src01_8x8_msa;
++        c->put_qpel_pixels_tab[1][14] = ff_hv_mc_qpel_aver_v_src1_8x8_msa;
++        c->put_qpel_pixels_tab[1][15] = ff_hv_mc_qpel_aver_hv_src11_8x8_msa;
+ 
+-    c->put_no_rnd_qpel_pixels_tab[1][0] = ff_copy_8x8_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][1] =
+-        ff_horiz_mc_qpel_no_rnd_aver_src0_8width_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][2] = ff_horiz_mc_qpel_no_rnd_8width_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][3] =
+-        ff_horiz_mc_qpel_no_rnd_aver_src1_8width_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][4] =
+-        ff_vert_mc_qpel_no_rnd_aver_src0_8x8_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][5] =
+-        ff_hv_mc_qpel_no_rnd_aver_hv_src00_8x8_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][6] =
+-        ff_hv_mc_qpel_no_rnd_aver_v_src0_8x8_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][7] =
+-        ff_hv_mc_qpel_no_rnd_aver_hv_src10_8x8_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][8] = ff_vert_mc_qpel_no_rnd_8x8_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][9] =
+-        ff_hv_mc_qpel_no_rnd_aver_h_src0_8x8_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][10] = ff_hv_mc_qpel_no_rnd_8x8_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][11] =
+-        ff_hv_mc_qpel_no_rnd_aver_h_src1_8x8_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][12] =
+-        ff_vert_mc_qpel_no_rnd_aver_src1_8x8_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][13] =
+-        ff_hv_mc_qpel_no_rnd_aver_hv_src01_8x8_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][14] =
+-        ff_hv_mc_qpel_no_rnd_aver_v_src1_8x8_msa;
+-    c->put_no_rnd_qpel_pixels_tab[1][15] =
+-        ff_hv_mc_qpel_no_rnd_aver_hv_src11_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][0] = ff_copy_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][1] =
++            ff_horiz_mc_qpel_no_rnd_aver_src0_16width_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][2] = ff_horiz_mc_qpel_no_rnd_16width_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][3] =
++            ff_horiz_mc_qpel_no_rnd_aver_src1_16width_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][4] =
++            ff_vert_mc_qpel_no_rnd_aver_src0_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][5] =
++            ff_hv_mc_qpel_no_rnd_aver_hv_src00_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][6] =
++            ff_hv_mc_qpel_no_rnd_aver_v_src0_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][7] =
++            ff_hv_mc_qpel_no_rnd_aver_hv_src10_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][8] = ff_vert_mc_qpel_no_rnd_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][9] =
++            ff_hv_mc_qpel_no_rnd_aver_h_src0_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][10] = ff_hv_mc_qpel_no_rnd_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][11] =
++            ff_hv_mc_qpel_no_rnd_aver_h_src1_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][12] =
++            ff_vert_mc_qpel_no_rnd_aver_src1_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][13] =
++            ff_hv_mc_qpel_no_rnd_aver_hv_src01_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][14] =
++            ff_hv_mc_qpel_no_rnd_aver_v_src1_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[0][15] =
++            ff_hv_mc_qpel_no_rnd_aver_hv_src11_16x16_msa;
+ 
+-    c->avg_qpel_pixels_tab[0][0] = ff_avg_width16_msa;
+-    c->avg_qpel_pixels_tab[0][1] =
+-        ff_horiz_mc_qpel_avg_dst_aver_src0_16width_msa;
+-    c->avg_qpel_pixels_tab[0][2] = ff_horiz_mc_qpel_avg_dst_16width_msa;
+-    c->avg_qpel_pixels_tab[0][3] =
+-        ff_horiz_mc_qpel_avg_dst_aver_src1_16width_msa;
+-    c->avg_qpel_pixels_tab[0][4] = ff_vert_mc_qpel_avg_dst_aver_src0_16x16_msa;
+-    c->avg_qpel_pixels_tab[0][5] =
+-        ff_hv_mc_qpel_avg_dst_aver_hv_src00_16x16_msa;
+-    c->avg_qpel_pixels_tab[0][6] = ff_hv_mc_qpel_avg_dst_aver_v_src0_16x16_msa;
+-    c->avg_qpel_pixels_tab[0][7] =
+-        ff_hv_mc_qpel_avg_dst_aver_hv_src10_16x16_msa;
+-    c->avg_qpel_pixels_tab[0][8] = ff_vert_mc_qpel_avg_dst_16x16_msa;
+-    c->avg_qpel_pixels_tab[0][9] = ff_hv_mc_qpel_avg_dst_aver_h_src0_16x16_msa;
+-    c->avg_qpel_pixels_tab[0][10] = ff_hv_mc_qpel_avg_dst_16x16_msa;
+-    c->avg_qpel_pixels_tab[0][11] = ff_hv_mc_qpel_avg_dst_aver_h_src1_16x16_msa;
+-    c->avg_qpel_pixels_tab[0][12] = ff_vert_mc_qpel_avg_dst_aver_src1_16x16_msa;
+-    c->avg_qpel_pixels_tab[0][13] =
+-        ff_hv_mc_qpel_avg_dst_aver_hv_src01_16x16_msa;
+-    c->avg_qpel_pixels_tab[0][14] = ff_hv_mc_qpel_avg_dst_aver_v_src1_16x16_msa;
+-    c->avg_qpel_pixels_tab[0][15] =
+-        ff_hv_mc_qpel_avg_dst_aver_hv_src11_16x16_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][0] = ff_copy_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][1] =
++            ff_horiz_mc_qpel_no_rnd_aver_src0_8width_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][2] = ff_horiz_mc_qpel_no_rnd_8width_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][3] =
++            ff_horiz_mc_qpel_no_rnd_aver_src1_8width_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][4] =
++            ff_vert_mc_qpel_no_rnd_aver_src0_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][5] =
++            ff_hv_mc_qpel_no_rnd_aver_hv_src00_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][6] =
++            ff_hv_mc_qpel_no_rnd_aver_v_src0_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][7] =
++            ff_hv_mc_qpel_no_rnd_aver_hv_src10_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][8] = ff_vert_mc_qpel_no_rnd_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][9] =
++            ff_hv_mc_qpel_no_rnd_aver_h_src0_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][10] = ff_hv_mc_qpel_no_rnd_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][11] =
++            ff_hv_mc_qpel_no_rnd_aver_h_src1_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][12] =
++            ff_vert_mc_qpel_no_rnd_aver_src1_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][13] =
++            ff_hv_mc_qpel_no_rnd_aver_hv_src01_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][14] =
++            ff_hv_mc_qpel_no_rnd_aver_v_src1_8x8_msa;
++        c->put_no_rnd_qpel_pixels_tab[1][15] =
++            ff_hv_mc_qpel_no_rnd_aver_hv_src11_8x8_msa;
+ 
+-    c->avg_qpel_pixels_tab[1][0] = ff_avg_width8_msa;
+-    c->avg_qpel_pixels_tab[1][1] =
+-        ff_horiz_mc_qpel_avg_dst_aver_src0_8width_msa;
+-    c->avg_qpel_pixels_tab[1][2] = ff_horiz_mc_qpel_avg_dst_8width_msa;
+-    c->avg_qpel_pixels_tab[1][3] =
+-        ff_horiz_mc_qpel_avg_dst_aver_src1_8width_msa;
+-    c->avg_qpel_pixels_tab[1][4] = ff_vert_mc_qpel_avg_dst_aver_src0_8x8_msa;
+-    c->avg_qpel_pixels_tab[1][5] = ff_hv_mc_qpel_avg_dst_aver_hv_src00_8x8_msa;
+-    c->avg_qpel_pixels_tab[1][6] = ff_hv_mc_qpel_avg_dst_aver_v_src0_8x8_msa;
+-    c->avg_qpel_pixels_tab[1][7] = ff_hv_mc_qpel_avg_dst_aver_hv_src10_8x8_msa;
+-    c->avg_qpel_pixels_tab[1][8] = ff_vert_mc_qpel_avg_dst_8x8_msa;
+-    c->avg_qpel_pixels_tab[1][9] = ff_hv_mc_qpel_avg_dst_aver_h_src0_8x8_msa;
+-    c->avg_qpel_pixels_tab[1][10] = ff_hv_mc_qpel_avg_dst_8x8_msa;
+-    c->avg_qpel_pixels_tab[1][11] = ff_hv_mc_qpel_avg_dst_aver_h_src1_8x8_msa;
+-    c->avg_qpel_pixels_tab[1][12] = ff_vert_mc_qpel_avg_dst_aver_src1_8x8_msa;
+-    c->avg_qpel_pixels_tab[1][13] = ff_hv_mc_qpel_avg_dst_aver_hv_src01_8x8_msa;
+-    c->avg_qpel_pixels_tab[1][14] = ff_hv_mc_qpel_avg_dst_aver_v_src1_8x8_msa;
+-    c->avg_qpel_pixels_tab[1][15] = ff_hv_mc_qpel_avg_dst_aver_hv_src11_8x8_msa;
+-}
+-#endif  // #if HAVE_MSA
++        c->avg_qpel_pixels_tab[0][0] = ff_avg_width16_msa;
++        c->avg_qpel_pixels_tab[0][1] =
++            ff_horiz_mc_qpel_avg_dst_aver_src0_16width_msa;
++        c->avg_qpel_pixels_tab[0][2] = ff_horiz_mc_qpel_avg_dst_16width_msa;
++        c->avg_qpel_pixels_tab[0][3] =
++            ff_horiz_mc_qpel_avg_dst_aver_src1_16width_msa;
++        c->avg_qpel_pixels_tab[0][4] = ff_vert_mc_qpel_avg_dst_aver_src0_16x16_msa;
++        c->avg_qpel_pixels_tab[0][5] =
++            ff_hv_mc_qpel_avg_dst_aver_hv_src00_16x16_msa;
++        c->avg_qpel_pixels_tab[0][6] = ff_hv_mc_qpel_avg_dst_aver_v_src0_16x16_msa;
++        c->avg_qpel_pixels_tab[0][7] =
++            ff_hv_mc_qpel_avg_dst_aver_hv_src10_16x16_msa;
++        c->avg_qpel_pixels_tab[0][8] = ff_vert_mc_qpel_avg_dst_16x16_msa;
++        c->avg_qpel_pixels_tab[0][9] = ff_hv_mc_qpel_avg_dst_aver_h_src0_16x16_msa;
++        c->avg_qpel_pixels_tab[0][10] = ff_hv_mc_qpel_avg_dst_16x16_msa;
++        c->avg_qpel_pixels_tab[0][11] = ff_hv_mc_qpel_avg_dst_aver_h_src1_16x16_msa;
++        c->avg_qpel_pixels_tab[0][12] = ff_vert_mc_qpel_avg_dst_aver_src1_16x16_msa;
++        c->avg_qpel_pixels_tab[0][13] =
++            ff_hv_mc_qpel_avg_dst_aver_hv_src01_16x16_msa;
++        c->avg_qpel_pixels_tab[0][14] = ff_hv_mc_qpel_avg_dst_aver_v_src1_16x16_msa;
++        c->avg_qpel_pixels_tab[0][15] =
++            ff_hv_mc_qpel_avg_dst_aver_hv_src11_16x16_msa;
+ 
+-void ff_qpeldsp_init_mips(QpelDSPContext *c)
+-{
+-#if HAVE_MSA
+-    qpeldsp_init_msa(c);
+-#endif  // #if HAVE_MSA
++        c->avg_qpel_pixels_tab[1][0] = ff_avg_width8_msa;
++        c->avg_qpel_pixels_tab[1][1] =
++            ff_horiz_mc_qpel_avg_dst_aver_src0_8width_msa;
++        c->avg_qpel_pixels_tab[1][2] = ff_horiz_mc_qpel_avg_dst_8width_msa;
++        c->avg_qpel_pixels_tab[1][3] =
++            ff_horiz_mc_qpel_avg_dst_aver_src1_8width_msa;
++        c->avg_qpel_pixels_tab[1][4] = ff_vert_mc_qpel_avg_dst_aver_src0_8x8_msa;
++        c->avg_qpel_pixels_tab[1][5] = ff_hv_mc_qpel_avg_dst_aver_hv_src00_8x8_msa;
++        c->avg_qpel_pixels_tab[1][6] = ff_hv_mc_qpel_avg_dst_aver_v_src0_8x8_msa;
++        c->avg_qpel_pixels_tab[1][7] = ff_hv_mc_qpel_avg_dst_aver_hv_src10_8x8_msa;
++        c->avg_qpel_pixels_tab[1][8] = ff_vert_mc_qpel_avg_dst_8x8_msa;
++        c->avg_qpel_pixels_tab[1][9] = ff_hv_mc_qpel_avg_dst_aver_h_src0_8x8_msa;
++        c->avg_qpel_pixels_tab[1][10] = ff_hv_mc_qpel_avg_dst_8x8_msa;
++        c->avg_qpel_pixels_tab[1][11] = ff_hv_mc_qpel_avg_dst_aver_h_src1_8x8_msa;
++        c->avg_qpel_pixels_tab[1][12] = ff_vert_mc_qpel_avg_dst_aver_src1_8x8_msa;
++        c->avg_qpel_pixels_tab[1][13] = ff_hv_mc_qpel_avg_dst_aver_hv_src01_8x8_msa;
++        c->avg_qpel_pixels_tab[1][14] = ff_hv_mc_qpel_avg_dst_aver_v_src1_8x8_msa;
++        c->avg_qpel_pixels_tab[1][15] = ff_hv_mc_qpel_avg_dst_aver_hv_src11_8x8_msa;
++    }
+ }
+diff --git a/libavcodec/mips/vc1dsp_init_mips.c b/libavcodec/mips/vc1dsp_init_mips.c
+index c0007ff650..94126f3a9d 100644
+--- a/libavcodec/mips/vc1dsp_init_mips.c
++++ b/libavcodec/mips/vc1dsp_init_mips.c
+@@ -18,6 +18,7 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "libavutil/attributes.h"
+ #include "libavcodec/vc1dsp.h"
+ #include "vc1dsp_mips.h"
+@@ -27,104 +28,93 @@
+     dsp->OP##vc1_mspel_pixels_tab[1][X+4*Y] = ff_##OP##vc1_mspel_mc##X##Y##INSN; \
+     dsp->OP##vc1_mspel_pixels_tab[0][X+4*Y] = ff_##OP##vc1_mspel_mc##X##Y##_16##INSN
+ 
+-#if HAVE_MMI
+-static av_cold void vc1dsp_init_mmi(VC1DSPContext *dsp)
+-{
+-#if _MIPS_SIM != _ABIO32
+-    dsp->vc1_inv_trans_8x8    = ff_vc1_inv_trans_8x8_mmi;
+-    dsp->vc1_inv_trans_4x8    = ff_vc1_inv_trans_4x8_mmi;
+-    dsp->vc1_inv_trans_8x4    = ff_vc1_inv_trans_8x4_mmi;
+-#endif
+-    dsp->vc1_inv_trans_4x4    = ff_vc1_inv_trans_4x4_mmi;
+-    dsp->vc1_inv_trans_8x8_dc = ff_vc1_inv_trans_8x8_dc_mmi;
+-    dsp->vc1_inv_trans_4x8_dc = ff_vc1_inv_trans_4x8_dc_mmi;
+-    dsp->vc1_inv_trans_8x4_dc = ff_vc1_inv_trans_8x4_dc_mmi;
+-    dsp->vc1_inv_trans_4x4_dc = ff_vc1_inv_trans_4x4_dc_mmi;
+-
+-    dsp->vc1_h_overlap        = ff_vc1_h_overlap_mmi;
+-    dsp->vc1_v_overlap        = ff_vc1_v_overlap_mmi;
+-    dsp->vc1_h_s_overlap      = ff_vc1_h_s_overlap_mmi;
+-    dsp->vc1_v_s_overlap      = ff_vc1_v_s_overlap_mmi;
+-
+-    dsp->vc1_v_loop_filter4  = ff_vc1_v_loop_filter4_mmi;
+-    dsp->vc1_h_loop_filter4  = ff_vc1_h_loop_filter4_mmi;
+-    dsp->vc1_v_loop_filter8  = ff_vc1_v_loop_filter8_mmi;
+-    dsp->vc1_h_loop_filter8  = ff_vc1_h_loop_filter8_mmi;
+-    dsp->vc1_v_loop_filter16 = ff_vc1_v_loop_filter16_mmi;
+-    dsp->vc1_h_loop_filter16 = ff_vc1_h_loop_filter16_mmi;
+-
+-    FN_ASSIGN(put_, 0, 0, _mmi);
+-    FN_ASSIGN(put_, 0, 1, _mmi);
+-    FN_ASSIGN(put_, 0, 2, _mmi);
+-    FN_ASSIGN(put_, 0, 3, _mmi);
+-
+-    FN_ASSIGN(put_, 1, 0, _mmi);
+-    //FN_ASSIGN(put_, 1, 1, _mmi);//FIXME
+-    //FN_ASSIGN(put_, 1, 2, _mmi);//FIXME
+-    //FN_ASSIGN(put_, 1, 3, _mmi);//FIXME
+-
+-    FN_ASSIGN(put_, 2, 0, _mmi);
+-    //FN_ASSIGN(put_, 2, 1, _mmi);//FIXME
+-    //FN_ASSIGN(put_, 2, 2, _mmi);//FIXME
+-    //FN_ASSIGN(put_, 2, 3, _mmi);//FIXME
+-
+-    FN_ASSIGN(put_, 3, 0, _mmi);
+-    //FN_ASSIGN(put_, 3, 1, _mmi);//FIXME
+-    //FN_ASSIGN(put_, 3, 2, _mmi);//FIXME
+-    //FN_ASSIGN(put_, 3, 3, _mmi);//FIXME
+-
+-    FN_ASSIGN(avg_, 0, 0, _mmi);
+-    FN_ASSIGN(avg_, 0, 1, _mmi);
+-    FN_ASSIGN(avg_, 0, 2, _mmi);
+-    FN_ASSIGN(avg_, 0, 3, _mmi);
+-
+-    FN_ASSIGN(avg_, 1, 0, _mmi);
+-    //FN_ASSIGN(avg_, 1, 1, _mmi);//FIXME
+-    //FN_ASSIGN(avg_, 1, 2, _mmi);//FIXME
+-    //FN_ASSIGN(avg_, 1, 3, _mmi);//FIXME
+-
+-    FN_ASSIGN(avg_, 2, 0, _mmi);
+-    //FN_ASSIGN(avg_, 2, 1, _mmi);//FIXME
+-    //FN_ASSIGN(avg_, 2, 2, _mmi);//FIXME
+-    //FN_ASSIGN(avg_, 2, 3, _mmi);//FIXME
+-
+-    FN_ASSIGN(avg_, 3, 0, _mmi);
+-    //FN_ASSIGN(avg_, 3, 1, _mmi);//FIXME
+-    //FN_ASSIGN(avg_, 3, 2, _mmi);//FIXME
+-    //FN_ASSIGN(avg_, 3, 3, _mmi);//FIXME
+-
+-    dsp->put_no_rnd_vc1_chroma_pixels_tab[0] = ff_put_no_rnd_vc1_chroma_mc8_mmi;
+-    dsp->avg_no_rnd_vc1_chroma_pixels_tab[0] = ff_avg_no_rnd_vc1_chroma_mc8_mmi;
+-    dsp->put_no_rnd_vc1_chroma_pixels_tab[1] = ff_put_no_rnd_vc1_chroma_mc4_mmi;
+-    dsp->avg_no_rnd_vc1_chroma_pixels_tab[1] = ff_avg_no_rnd_vc1_chroma_mc4_mmi;
+-}
+-#endif /* HAVE_MMI */
+-
+-#if HAVE_MSA
+-static av_cold void vc1dsp_init_msa(VC1DSPContext *dsp)
+-{
+-    dsp->vc1_inv_trans_8x8 = ff_vc1_inv_trans_8x8_msa;
+-    dsp->vc1_inv_trans_4x8 = ff_vc1_inv_trans_4x8_msa;
+-    dsp->vc1_inv_trans_8x4 = ff_vc1_inv_trans_8x4_msa;
+-
+-    FN_ASSIGN(put_, 1, 1, _msa);
+-    FN_ASSIGN(put_, 1, 2, _msa);
+-    FN_ASSIGN(put_, 1, 3, _msa);
+-    FN_ASSIGN(put_, 2, 1, _msa);
+-    FN_ASSIGN(put_, 2, 2, _msa);
+-    FN_ASSIGN(put_, 2, 3, _msa);
+-    FN_ASSIGN(put_, 3, 1, _msa);
+-    FN_ASSIGN(put_, 3, 2, _msa);
+-    FN_ASSIGN(put_, 3, 3, _msa);
+-}
+-#endif /* HAVE_MSA */
+-
+ av_cold void ff_vc1dsp_init_mips(VC1DSPContext *dsp)
+ {
+-#if HAVE_MMI
+-    vc1dsp_init_mmi(dsp);
+-#endif /* HAVE_MMI */
+-#if HAVE_MSA
+-    vc1dsp_init_msa(dsp);
+-#endif /* HAVE_MSA */
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_mmi(cpu_flags)) {
++ #if _MIPS_SIM != _ABIO32
++        dsp->vc1_inv_trans_8x8    = ff_vc1_inv_trans_8x8_mmi;
++        dsp->vc1_inv_trans_4x8    = ff_vc1_inv_trans_4x8_mmi;
++        dsp->vc1_inv_trans_8x4    = ff_vc1_inv_trans_8x4_mmi;
++#endif
++        dsp->vc1_inv_trans_4x4    = ff_vc1_inv_trans_4x4_mmi;
++        dsp->vc1_inv_trans_8x8_dc = ff_vc1_inv_trans_8x8_dc_mmi;
++        dsp->vc1_inv_trans_4x8_dc = ff_vc1_inv_trans_4x8_dc_mmi;
++        dsp->vc1_inv_trans_8x4_dc = ff_vc1_inv_trans_8x4_dc_mmi;
++        dsp->vc1_inv_trans_4x4_dc = ff_vc1_inv_trans_4x4_dc_mmi;
++
++        dsp->vc1_h_overlap        = ff_vc1_h_overlap_mmi;
++        dsp->vc1_v_overlap        = ff_vc1_v_overlap_mmi;
++        dsp->vc1_h_s_overlap      = ff_vc1_h_s_overlap_mmi;
++        dsp->vc1_v_s_overlap      = ff_vc1_v_s_overlap_mmi;
++
++        dsp->vc1_v_loop_filter4  = ff_vc1_v_loop_filter4_mmi;
++        dsp->vc1_h_loop_filter4  = ff_vc1_h_loop_filter4_mmi;
++        dsp->vc1_v_loop_filter8  = ff_vc1_v_loop_filter8_mmi;
++        dsp->vc1_h_loop_filter8  = ff_vc1_h_loop_filter8_mmi;
++        dsp->vc1_v_loop_filter16 = ff_vc1_v_loop_filter16_mmi;
++        dsp->vc1_h_loop_filter16 = ff_vc1_h_loop_filter16_mmi;
++
++        FN_ASSIGN(put_, 0, 0, _mmi);
++        FN_ASSIGN(put_, 0, 1, _mmi);
++        FN_ASSIGN(put_, 0, 2, _mmi);
++        FN_ASSIGN(put_, 0, 3, _mmi);
++
++        FN_ASSIGN(put_, 1, 0, _mmi);
++        //FN_ASSIGN(put_, 1, 1, _mmi);//FIXME
++        //FN_ASSIGN(put_, 1, 2, _mmi);//FIXME
++        //FN_ASSIGN(put_, 1, 3, _mmi);//FIXME
++
++        FN_ASSIGN(put_, 2, 0, _mmi);
++        //FN_ASSIGN(put_, 2, 1, _mmi);//FIXME
++        //FN_ASSIGN(put_, 2, 2, _mmi);//FIXME
++        //FN_ASSIGN(put_, 2, 3, _mmi);//FIXME
++
++        FN_ASSIGN(put_, 3, 0, _mmi);
++        //FN_ASSIGN(put_, 3, 1, _mmi);//FIXME
++        //FN_ASSIGN(put_, 3, 2, _mmi);//FIXME
++        //FN_ASSIGN(put_, 3, 3, _mmi);//FIXME
++
++        FN_ASSIGN(avg_, 0, 0, _mmi);
++        FN_ASSIGN(avg_, 0, 1, _mmi);
++        FN_ASSIGN(avg_, 0, 2, _mmi);
++        FN_ASSIGN(avg_, 0, 3, _mmi);
++
++        FN_ASSIGN(avg_, 1, 0, _mmi);
++        //FN_ASSIGN(avg_, 1, 1, _mmi);//FIXME
++        //FN_ASSIGN(avg_, 1, 2, _mmi);//FIXME
++        //FN_ASSIGN(avg_, 1, 3, _mmi);//FIXME
++
++        FN_ASSIGN(avg_, 2, 0, _mmi);
++        //FN_ASSIGN(avg_, 2, 1, _mmi);//FIXME
++        //FN_ASSIGN(avg_, 2, 2, _mmi);//FIXME
++        //FN_ASSIGN(avg_, 2, 3, _mmi);//FIXME
++
++        FN_ASSIGN(avg_, 3, 0, _mmi);
++        //FN_ASSIGN(avg_, 3, 1, _mmi);//FIXME
++        //FN_ASSIGN(avg_, 3, 2, _mmi);//FIXME
++        //FN_ASSIGN(avg_, 3, 3, _mmi);//FIXME
++
++        dsp->put_no_rnd_vc1_chroma_pixels_tab[0] = ff_put_no_rnd_vc1_chroma_mc8_mmi;
++        dsp->avg_no_rnd_vc1_chroma_pixels_tab[0] = ff_avg_no_rnd_vc1_chroma_mc8_mmi;
++        dsp->put_no_rnd_vc1_chroma_pixels_tab[1] = ff_put_no_rnd_vc1_chroma_mc4_mmi;
++        dsp->avg_no_rnd_vc1_chroma_pixels_tab[1] = ff_avg_no_rnd_vc1_chroma_mc4_mmi;
++    }
++
++    if (have_msa(cpu_flags)) {
++        dsp->vc1_inv_trans_8x8 = ff_vc1_inv_trans_8x8_msa;
++        dsp->vc1_inv_trans_4x8 = ff_vc1_inv_trans_4x8_msa;
++        dsp->vc1_inv_trans_8x4 = ff_vc1_inv_trans_8x4_msa;
++
++        FN_ASSIGN(put_, 1, 1, _msa);
++        FN_ASSIGN(put_, 1, 2, _msa);
++        FN_ASSIGN(put_, 1, 3, _msa);
++        FN_ASSIGN(put_, 2, 1, _msa);
++        FN_ASSIGN(put_, 2, 2, _msa);
++        FN_ASSIGN(put_, 2, 3, _msa);
++        FN_ASSIGN(put_, 3, 1, _msa);
++        FN_ASSIGN(put_, 3, 2, _msa);
++        FN_ASSIGN(put_, 3, 3, _msa);
++    }
+ }
+diff --git a/libavcodec/mips/videodsp_init.c b/libavcodec/mips/videodsp_init.c
+index 817040420b..07c23bcf7e 100644
+--- a/libavcodec/mips/videodsp_init.c
++++ b/libavcodec/mips/videodsp_init.c
+@@ -18,12 +18,12 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "config.h"
+ #include "libavutil/attributes.h"
+ #include "libavutil/mips/asmdefs.h"
+ #include "libavcodec/videodsp.h"
+ 
+-#if HAVE_MSA
+ static void prefetch_mips(uint8_t *mem, ptrdiff_t stride, int h)
+ {
+     register const uint8_t *p = mem;
+@@ -41,11 +41,11 @@ static void prefetch_mips(uint8_t *mem, ptrdiff_t stride, int h)
+         : [stride] "r" (stride)
+     );
+ }
+-#endif  // #if HAVE_MSA
+ 
+ av_cold void ff_videodsp_init_mips(VideoDSPContext *ctx, int bpc)
+ {
+-#if HAVE_MSA
+-    ctx->prefetch = prefetch_mips;
+-#endif  // #if HAVE_MSA
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_msa(cpu_flags))
++        ctx->prefetch = prefetch_mips;
+ }
+diff --git a/libavcodec/mips/vp3dsp_init_mips.c b/libavcodec/mips/vp3dsp_init_mips.c
+index e183db35b6..4252ff790e 100644
+--- a/libavcodec/mips/vp3dsp_init_mips.c
++++ b/libavcodec/mips/vp3dsp_init_mips.c
+@@ -19,42 +19,32 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "config.h"
+ #include "libavutil/attributes.h"
+ #include "libavcodec/avcodec.h"
+ #include "libavcodec/vp3dsp.h"
+ #include "vp3dsp_mips.h"
+ 
+-#if HAVE_MSA
+-static av_cold void vp3dsp_init_msa(VP3DSPContext *c, int flags)
++av_cold void ff_vp3dsp_init_mips(VP3DSPContext *c, int flags)
+ {
+-    c->put_no_rnd_pixels_l2 = ff_put_no_rnd_pixels_l2_msa;
++    int cpu_flags = av_get_cpu_flags();
+ 
+-    c->idct_add      = ff_vp3_idct_add_msa;
+-    c->idct_put      = ff_vp3_idct_put_msa;
+-    c->idct_dc_add   = ff_vp3_idct_dc_add_msa;
+-    c->v_loop_filter = ff_vp3_v_loop_filter_msa;
+-    c->h_loop_filter = ff_vp3_h_loop_filter_msa;
+-}
+-#endif /* HAVE_MSA */
++    if (have_mmi(cpu_flags)) {
++        c->put_no_rnd_pixels_l2 = ff_put_no_rnd_pixels_l2_mmi;
+ 
+-#if HAVE_MMI
+-static av_cold void vp3dsp_init_mmi(VP3DSPContext *c, int flags)
+-{
+-    c->put_no_rnd_pixels_l2 = ff_put_no_rnd_pixels_l2_mmi;
++        c->idct_add      = ff_vp3_idct_add_mmi;
++        c->idct_put      = ff_vp3_idct_put_mmi;
++        c->idct_dc_add   = ff_vp3_idct_dc_add_mmi;
++    }
+ 
+-    c->idct_add      = ff_vp3_idct_add_mmi;
+-    c->idct_put      = ff_vp3_idct_put_mmi;
+-    c->idct_dc_add   = ff_vp3_idct_dc_add_mmi;
+-}
+-#endif /* HAVE_MMI */
++    if (have_msa(cpu_flags)) {
++        c->put_no_rnd_pixels_l2 = ff_put_no_rnd_pixels_l2_msa;
+ 
+-av_cold void ff_vp3dsp_init_mips(VP3DSPContext *c, int flags)
+-{
+-#if HAVE_MMI
+-    vp3dsp_init_mmi(c, flags);
+-#endif /* HAVE_MMI */
+-#if HAVE_MSA
+-    vp3dsp_init_msa(c, flags);
+-#endif /* HAVE_MSA */
++        c->idct_add      = ff_vp3_idct_add_msa;
++        c->idct_put      = ff_vp3_idct_put_msa;
++        c->idct_dc_add   = ff_vp3_idct_dc_add_msa;
++        c->v_loop_filter = ff_vp3_v_loop_filter_msa;
++        c->h_loop_filter = ff_vp3_h_loop_filter_msa;
++    }
+ }
+diff --git a/libavcodec/mips/vp8dsp_init_mips.c b/libavcodec/mips/vp8dsp_init_mips.c
+index 7fd8fb0d32..92d8c792cb 100644
+--- a/libavcodec/mips/vp8dsp_init_mips.c
++++ b/libavcodec/mips/vp8dsp_init_mips.c
+@@ -24,6 +24,7 @@
+  * VP8 compatible video decoder
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "config.h"
+ #include "libavutil/attributes.h"
+ #include "libavcodec/vp8dsp.h"
+@@ -71,132 +72,123 @@
+     dsp->put_vp8_bilinear_pixels_tab[IDX][0][0] =  \
+         ff_put_vp8_pixels##SIZE##_msa;
+ 
+-#if HAVE_MSA
+-static av_cold void vp8dsp_init_msa(VP8DSPContext *dsp)
+-{
+-    dsp->vp8_luma_dc_wht = ff_vp8_luma_dc_wht_msa;
+-    dsp->vp8_idct_add = ff_vp8_idct_add_msa;
+-    dsp->vp8_idct_dc_add = ff_vp8_idct_dc_add_msa;
+-    dsp->vp8_idct_dc_add4y = ff_vp8_idct_dc_add4y_msa;
+-    dsp->vp8_idct_dc_add4uv = ff_vp8_idct_dc_add4uv_msa;
+-
+-    VP8_MC_MIPS_FUNC(0, 16);
+-    VP8_MC_MIPS_FUNC(1, 8);
+-    VP8_MC_MIPS_FUNC(2, 4);
+-
+-    VP8_BILINEAR_MC_MIPS_FUNC(0, 16);
+-    VP8_BILINEAR_MC_MIPS_FUNC(1, 8);
+-    VP8_BILINEAR_MC_MIPS_FUNC(2, 4);
+-
+-    VP8_MC_MIPS_COPY(0, 16);
+-    VP8_MC_MIPS_COPY(1, 8);
+-
+-    dsp->vp8_v_loop_filter16y = ff_vp8_v_loop_filter16_msa;
+-    dsp->vp8_h_loop_filter16y = ff_vp8_h_loop_filter16_msa;
+-    dsp->vp8_v_loop_filter8uv = ff_vp8_v_loop_filter8uv_msa;
+-    dsp->vp8_h_loop_filter8uv = ff_vp8_h_loop_filter8uv_msa;
+-
+-    dsp->vp8_v_loop_filter16y_inner = ff_vp8_v_loop_filter16_inner_msa;
+-    dsp->vp8_h_loop_filter16y_inner = ff_vp8_h_loop_filter16_inner_msa;
+-    dsp->vp8_v_loop_filter8uv_inner = ff_vp8_v_loop_filter8uv_inner_msa;
+-    dsp->vp8_h_loop_filter8uv_inner = ff_vp8_h_loop_filter8uv_inner_msa;
+-
+-    dsp->vp8_v_loop_filter_simple = ff_vp8_v_loop_filter_simple_msa;
+-    dsp->vp8_h_loop_filter_simple = ff_vp8_h_loop_filter_simple_msa;
+-}
+-#endif  // #if HAVE_MSA
+ 
+-#if HAVE_MMI
+-static av_cold void vp8dsp_init_mmi(VP8DSPContext *dsp)
+-{
+-    dsp->vp8_luma_dc_wht    = ff_vp8_luma_dc_wht_mmi;
+-    dsp->vp8_luma_dc_wht_dc = ff_vp8_luma_dc_wht_dc_mmi;
+-    dsp->vp8_idct_add       = ff_vp8_idct_add_mmi;
+-    dsp->vp8_idct_dc_add    = ff_vp8_idct_dc_add_mmi;
+-    dsp->vp8_idct_dc_add4y  = ff_vp8_idct_dc_add4y_mmi;
+-    dsp->vp8_idct_dc_add4uv = ff_vp8_idct_dc_add4uv_mmi;
+-
+-    dsp->put_vp8_epel_pixels_tab[0][0][1] = ff_put_vp8_epel16_h4_mmi;
+-    dsp->put_vp8_epel_pixels_tab[0][0][2] = ff_put_vp8_epel16_h6_mmi;
+-    dsp->put_vp8_epel_pixels_tab[0][1][0] = ff_put_vp8_epel16_v4_mmi;
+-    dsp->put_vp8_epel_pixels_tab[0][1][1] = ff_put_vp8_epel16_h4v4_mmi;
+-    dsp->put_vp8_epel_pixels_tab[0][1][2] = ff_put_vp8_epel16_h6v4_mmi;
+-    dsp->put_vp8_epel_pixels_tab[0][2][0] = ff_put_vp8_epel16_v6_mmi;
+-    dsp->put_vp8_epel_pixels_tab[0][2][1] = ff_put_vp8_epel16_h4v6_mmi;
+-    dsp->put_vp8_epel_pixels_tab[0][2][2] = ff_put_vp8_epel16_h6v6_mmi;
+-
+-    dsp->put_vp8_epel_pixels_tab[1][0][1] = ff_put_vp8_epel8_h4_mmi;
+-    dsp->put_vp8_epel_pixels_tab[1][0][2] = ff_put_vp8_epel8_h6_mmi;
+-    dsp->put_vp8_epel_pixels_tab[1][1][0] = ff_put_vp8_epel8_v4_mmi;
+-    dsp->put_vp8_epel_pixels_tab[1][1][1] = ff_put_vp8_epel8_h4v4_mmi;
+-    dsp->put_vp8_epel_pixels_tab[1][1][2] = ff_put_vp8_epel8_h6v4_mmi;
+-    dsp->put_vp8_epel_pixels_tab[1][2][0] = ff_put_vp8_epel8_v6_mmi;
+-    dsp->put_vp8_epel_pixels_tab[1][2][1] = ff_put_vp8_epel8_h4v6_mmi;
+-    dsp->put_vp8_epel_pixels_tab[1][2][2] = ff_put_vp8_epel8_h6v6_mmi;
+-
+-    dsp->put_vp8_epel_pixels_tab[2][0][1] = ff_put_vp8_epel4_h4_mmi;
+-    dsp->put_vp8_epel_pixels_tab[2][0][2] = ff_put_vp8_epel4_h6_mmi;
+-    dsp->put_vp8_epel_pixels_tab[2][1][0] = ff_put_vp8_epel4_v4_mmi;
+-    dsp->put_vp8_epel_pixels_tab[2][1][1] = ff_put_vp8_epel4_h4v4_mmi;
+-    dsp->put_vp8_epel_pixels_tab[2][1][2] = ff_put_vp8_epel4_h6v4_mmi;
+-    dsp->put_vp8_epel_pixels_tab[2][2][0] = ff_put_vp8_epel4_v6_mmi;
+-    dsp->put_vp8_epel_pixels_tab[2][2][1] = ff_put_vp8_epel4_h4v6_mmi;
+-    dsp->put_vp8_epel_pixels_tab[2][2][2] = ff_put_vp8_epel4_h6v6_mmi;
+-
+-    dsp->put_vp8_bilinear_pixels_tab[0][0][1] = ff_put_vp8_bilinear16_h_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[0][0][2] = ff_put_vp8_bilinear16_h_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[0][1][0] = ff_put_vp8_bilinear16_v_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[0][1][1] = ff_put_vp8_bilinear16_hv_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[0][1][2] = ff_put_vp8_bilinear16_hv_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[0][2][0] = ff_put_vp8_bilinear16_v_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[0][2][1] = ff_put_vp8_bilinear16_hv_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[0][2][2] = ff_put_vp8_bilinear16_hv_mmi;
+-
+-    dsp->put_vp8_bilinear_pixels_tab[1][0][1] = ff_put_vp8_bilinear8_h_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[1][0][2] = ff_put_vp8_bilinear8_h_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[1][1][0] = ff_put_vp8_bilinear8_v_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[1][1][1] = ff_put_vp8_bilinear8_hv_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[1][1][2] = ff_put_vp8_bilinear8_hv_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[1][2][0] = ff_put_vp8_bilinear8_v_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[1][2][1] = ff_put_vp8_bilinear8_hv_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[1][2][2] = ff_put_vp8_bilinear8_hv_mmi;
+-
+-    dsp->put_vp8_bilinear_pixels_tab[2][0][1] = ff_put_vp8_bilinear4_h_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[2][0][2] = ff_put_vp8_bilinear4_h_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[2][1][0] = ff_put_vp8_bilinear4_v_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[2][1][1] = ff_put_vp8_bilinear4_hv_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[2][1][2] = ff_put_vp8_bilinear4_hv_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[2][2][0] = ff_put_vp8_bilinear4_v_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[2][2][1] = ff_put_vp8_bilinear4_hv_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[2][2][2] = ff_put_vp8_bilinear4_hv_mmi;
+-
+-    dsp->put_vp8_epel_pixels_tab[0][0][0]     = ff_put_vp8_pixels16_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[0][0][0] = ff_put_vp8_pixels16_mmi;
+-
+-    dsp->put_vp8_epel_pixels_tab[1][0][0]     = ff_put_vp8_pixels8_mmi;
+-    dsp->put_vp8_bilinear_pixels_tab[1][0][0] = ff_put_vp8_pixels8_mmi;
+-
+-    dsp->vp8_v_loop_filter16y = ff_vp8_v_loop_filter16_mmi;
+-    dsp->vp8_h_loop_filter16y = ff_vp8_h_loop_filter16_mmi;
+-    dsp->vp8_v_loop_filter8uv = ff_vp8_v_loop_filter8uv_mmi;
+-    dsp->vp8_h_loop_filter8uv = ff_vp8_h_loop_filter8uv_mmi;
+-
+-    dsp->vp8_v_loop_filter16y_inner = ff_vp8_v_loop_filter16_inner_mmi;
+-    dsp->vp8_h_loop_filter16y_inner = ff_vp8_h_loop_filter16_inner_mmi;
+-    dsp->vp8_v_loop_filter8uv_inner = ff_vp8_v_loop_filter8uv_inner_mmi;
+-    dsp->vp8_h_loop_filter8uv_inner = ff_vp8_h_loop_filter8uv_inner_mmi;
+-
+-    dsp->vp8_v_loop_filter_simple = ff_vp8_v_loop_filter_simple_mmi;
+-    dsp->vp8_h_loop_filter_simple = ff_vp8_h_loop_filter_simple_mmi;
+-}
+-#endif /* HAVE_MMI */
+ 
+ av_cold void ff_vp8dsp_init_mips(VP8DSPContext *dsp)
+ {
+-#if HAVE_MMI
+-    vp8dsp_init_mmi(dsp);
+-#endif /* HAVE_MMI */
+-#if HAVE_MSA
+-    vp8dsp_init_msa(dsp);
+-#endif  // #if HAVE_MSA
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_mmi(cpu_flags)) {
++        dsp->vp8_luma_dc_wht    = ff_vp8_luma_dc_wht_mmi;
++        dsp->vp8_luma_dc_wht_dc = ff_vp8_luma_dc_wht_dc_mmi;
++        dsp->vp8_idct_add       = ff_vp8_idct_add_mmi;
++        dsp->vp8_idct_dc_add    = ff_vp8_idct_dc_add_mmi;
++        dsp->vp8_idct_dc_add4y  = ff_vp8_idct_dc_add4y_mmi;
++        dsp->vp8_idct_dc_add4uv = ff_vp8_idct_dc_add4uv_mmi;
++
++        dsp->put_vp8_epel_pixels_tab[0][0][1] = ff_put_vp8_epel16_h4_mmi;
++        dsp->put_vp8_epel_pixels_tab[0][0][2] = ff_put_vp8_epel16_h6_mmi;
++        dsp->put_vp8_epel_pixels_tab[0][1][0] = ff_put_vp8_epel16_v4_mmi;
++        dsp->put_vp8_epel_pixels_tab[0][1][1] = ff_put_vp8_epel16_h4v4_mmi;
++        dsp->put_vp8_epel_pixels_tab[0][1][2] = ff_put_vp8_epel16_h6v4_mmi;
++        dsp->put_vp8_epel_pixels_tab[0][2][0] = ff_put_vp8_epel16_v6_mmi;
++        dsp->put_vp8_epel_pixels_tab[0][2][1] = ff_put_vp8_epel16_h4v6_mmi;
++        dsp->put_vp8_epel_pixels_tab[0][2][2] = ff_put_vp8_epel16_h6v6_mmi;
++
++        dsp->put_vp8_epel_pixels_tab[1][0][1] = ff_put_vp8_epel8_h4_mmi;
++        dsp->put_vp8_epel_pixels_tab[1][0][2] = ff_put_vp8_epel8_h6_mmi;
++        dsp->put_vp8_epel_pixels_tab[1][1][0] = ff_put_vp8_epel8_v4_mmi;
++        dsp->put_vp8_epel_pixels_tab[1][1][1] = ff_put_vp8_epel8_h4v4_mmi;
++        dsp->put_vp8_epel_pixels_tab[1][1][2] = ff_put_vp8_epel8_h6v4_mmi;
++        dsp->put_vp8_epel_pixels_tab[1][2][0] = ff_put_vp8_epel8_v6_mmi;
++        dsp->put_vp8_epel_pixels_tab[1][2][1] = ff_put_vp8_epel8_h4v6_mmi;
++        dsp->put_vp8_epel_pixels_tab[1][2][2] = ff_put_vp8_epel8_h6v6_mmi;
++
++        dsp->put_vp8_epel_pixels_tab[2][0][1] = ff_put_vp8_epel4_h4_mmi;
++        dsp->put_vp8_epel_pixels_tab[2][0][2] = ff_put_vp8_epel4_h6_mmi;
++        dsp->put_vp8_epel_pixels_tab[2][1][0] = ff_put_vp8_epel4_v4_mmi;
++        dsp->put_vp8_epel_pixels_tab[2][1][1] = ff_put_vp8_epel4_h4v4_mmi;
++        dsp->put_vp8_epel_pixels_tab[2][1][2] = ff_put_vp8_epel4_h6v4_mmi;
++        dsp->put_vp8_epel_pixels_tab[2][2][0] = ff_put_vp8_epel4_v6_mmi;
++        dsp->put_vp8_epel_pixels_tab[2][2][1] = ff_put_vp8_epel4_h4v6_mmi;
++        dsp->put_vp8_epel_pixels_tab[2][2][2] = ff_put_vp8_epel4_h6v6_mmi;
++
++        dsp->put_vp8_bilinear_pixels_tab[0][0][1] = ff_put_vp8_bilinear16_h_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[0][0][2] = ff_put_vp8_bilinear16_h_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[0][1][0] = ff_put_vp8_bilinear16_v_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[0][1][1] = ff_put_vp8_bilinear16_hv_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[0][1][2] = ff_put_vp8_bilinear16_hv_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[0][2][0] = ff_put_vp8_bilinear16_v_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[0][2][1] = ff_put_vp8_bilinear16_hv_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[0][2][2] = ff_put_vp8_bilinear16_hv_mmi;
++
++        dsp->put_vp8_bilinear_pixels_tab[1][0][1] = ff_put_vp8_bilinear8_h_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[1][0][2] = ff_put_vp8_bilinear8_h_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[1][1][0] = ff_put_vp8_bilinear8_v_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[1][1][1] = ff_put_vp8_bilinear8_hv_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[1][1][2] = ff_put_vp8_bilinear8_hv_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[1][2][0] = ff_put_vp8_bilinear8_v_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[1][2][1] = ff_put_vp8_bilinear8_hv_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[1][2][2] = ff_put_vp8_bilinear8_hv_mmi;
++
++        dsp->put_vp8_bilinear_pixels_tab[2][0][1] = ff_put_vp8_bilinear4_h_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[2][0][2] = ff_put_vp8_bilinear4_h_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[2][1][0] = ff_put_vp8_bilinear4_v_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[2][1][1] = ff_put_vp8_bilinear4_hv_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[2][1][2] = ff_put_vp8_bilinear4_hv_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[2][2][0] = ff_put_vp8_bilinear4_v_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[2][2][1] = ff_put_vp8_bilinear4_hv_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[2][2][2] = ff_put_vp8_bilinear4_hv_mmi;
++
++        dsp->put_vp8_epel_pixels_tab[0][0][0]     = ff_put_vp8_pixels16_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[0][0][0] = ff_put_vp8_pixels16_mmi;
++
++        dsp->put_vp8_epel_pixels_tab[1][0][0]     = ff_put_vp8_pixels8_mmi;
++        dsp->put_vp8_bilinear_pixels_tab[1][0][0] = ff_put_vp8_pixels8_mmi;
++
++        dsp->vp8_v_loop_filter16y = ff_vp8_v_loop_filter16_mmi;
++        dsp->vp8_h_loop_filter16y = ff_vp8_h_loop_filter16_mmi;
++        dsp->vp8_v_loop_filter8uv = ff_vp8_v_loop_filter8uv_mmi;
++        dsp->vp8_h_loop_filter8uv = ff_vp8_h_loop_filter8uv_mmi;
++
++        dsp->vp8_v_loop_filter16y_inner = ff_vp8_v_loop_filter16_inner_mmi;
++        dsp->vp8_h_loop_filter16y_inner = ff_vp8_h_loop_filter16_inner_mmi;
++        dsp->vp8_v_loop_filter8uv_inner = ff_vp8_v_loop_filter8uv_inner_mmi;
++        dsp->vp8_h_loop_filter8uv_inner = ff_vp8_h_loop_filter8uv_inner_mmi;
++
++        dsp->vp8_v_loop_filter_simple = ff_vp8_v_loop_filter_simple_mmi;
++        dsp->vp8_h_loop_filter_simple = ff_vp8_h_loop_filter_simple_mmi;
++    }
++
++    if (have_msa(cpu_flags)) {
++        dsp->vp8_luma_dc_wht = ff_vp8_luma_dc_wht_msa;
++        dsp->vp8_idct_add = ff_vp8_idct_add_msa;
++        dsp->vp8_idct_dc_add = ff_vp8_idct_dc_add_msa;
++        dsp->vp8_idct_dc_add4y = ff_vp8_idct_dc_add4y_msa;
++        dsp->vp8_idct_dc_add4uv = ff_vp8_idct_dc_add4uv_msa;
++
++        VP8_MC_MIPS_FUNC(0, 16);
++        VP8_MC_MIPS_FUNC(1, 8);
++        VP8_MC_MIPS_FUNC(2, 4);
++
++        VP8_BILINEAR_MC_MIPS_FUNC(0, 16);
++        VP8_BILINEAR_MC_MIPS_FUNC(1, 8);
++        VP8_BILINEAR_MC_MIPS_FUNC(2, 4);
++
++        VP8_MC_MIPS_COPY(0, 16);
++        VP8_MC_MIPS_COPY(1, 8);
++
++        dsp->vp8_v_loop_filter16y = ff_vp8_v_loop_filter16_msa;
++        dsp->vp8_h_loop_filter16y = ff_vp8_h_loop_filter16_msa;
++        dsp->vp8_v_loop_filter8uv = ff_vp8_v_loop_filter8uv_msa;
++        dsp->vp8_h_loop_filter8uv = ff_vp8_h_loop_filter8uv_msa;
++
++        dsp->vp8_v_loop_filter16y_inner = ff_vp8_v_loop_filter16_inner_msa;
++        dsp->vp8_h_loop_filter16y_inner = ff_vp8_h_loop_filter16_inner_msa;
++        dsp->vp8_v_loop_filter8uv_inner = ff_vp8_v_loop_filter8uv_inner_msa;
++        dsp->vp8_h_loop_filter8uv_inner = ff_vp8_h_loop_filter8uv_inner_msa;
++
++        dsp->vp8_v_loop_filter_simple = ff_vp8_v_loop_filter_simple_msa;
++        dsp->vp8_h_loop_filter_simple = ff_vp8_h_loop_filter_simple_msa;
++    }
+ }
+diff --git a/libavcodec/mips/vp9dsp_init_mips.c b/libavcodec/mips/vp9dsp_init_mips.c
+index 5990fa6952..5a8c599e7e 100644
+--- a/libavcodec/mips/vp9dsp_init_mips.c
++++ b/libavcodec/mips/vp9dsp_init_mips.c
+@@ -18,6 +18,7 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "config.h"
+ #include "libavutil/common.h"
+ #include "libavcodec/vp9dsp.h"
+@@ -209,10 +210,17 @@ static av_cold void vp9dsp_init_mmi(VP9DSPContext *dsp, int bpp)
+ 
+ av_cold void ff_vp9dsp_init_mips(VP9DSPContext *dsp, int bpp)
+ {
++#if HAVE_MSA || HAVE_MMI
++    int cpu_flags = av_get_cpu_flags();
++#endif
++
+ #if HAVE_MMI
+-    vp9dsp_init_mmi(dsp, bpp);
+-#endif  // #if HAVE_MMI
++    if (have_mmi(cpu_flags))
++        vp9dsp_init_mmi(dsp, bpp);
++#endif
++
+ #if HAVE_MSA
+-    vp9dsp_init_msa(dsp, bpp);
+-#endif  // #if HAVE_MSA
++    if (have_msa(cpu_flags))
++        vp9dsp_init_msa(dsp, bpp);
++#endif
+ }
+diff --git a/libavcodec/mips/wmv2dsp_init_mips.c b/libavcodec/mips/wmv2dsp_init_mips.c
+index 51dd2078d9..af1400731a 100644
+--- a/libavcodec/mips/wmv2dsp_init_mips.c
++++ b/libavcodec/mips/wmv2dsp_init_mips.c
+@@ -18,21 +18,17 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "config.h"
+ #include "libavutil/attributes.h"
+ #include "wmv2dsp_mips.h"
+ 
+-#if HAVE_MMI
+-static av_cold void wmv2dsp_init_mmi(WMV2DSPContext *c)
+-{
+-    c->idct_add  = ff_wmv2_idct_add_mmi;
+-    c->idct_put  = ff_wmv2_idct_put_mmi;
+-}
+-#endif /* HAVE_MMI */
+-
+ av_cold void ff_wmv2dsp_init_mips(WMV2DSPContext *c)
+ {
+-#if HAVE_MMI
+-    wmv2dsp_init_mmi(c);
+-#endif /* HAVE_MMI */
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_mmi(cpu_flags)) {
++        c->idct_add  = ff_wmv2_idct_add_mmi;
++        c->idct_put  = ff_wmv2_idct_put_mmi;
++    }
+ }
+diff --git a/libavcodec/mips/wmv2dsp_mips.h b/libavcodec/mips/wmv2dsp_mips.h
+index 22894c505d..c96b3d94c7 100644
+--- a/libavcodec/mips/wmv2dsp_mips.h
++++ b/libavcodec/mips/wmv2dsp_mips.h
+@@ -23,7 +23,7 @@
+ 
+ #include "libavcodec/wmv2dsp.h"
+ 
+-void ff_wmv2_idct_add_mmi(uint8_t *dest, int line_size, int16_t *block);
+-void ff_wmv2_idct_put_mmi(uint8_t *dest, int line_size, int16_t *block);
++void ff_wmv2_idct_add_mmi(uint8_t *dest, ptrdiff_t line_size, int16_t *block);
++void ff_wmv2_idct_put_mmi(uint8_t *dest, ptrdiff_t line_size, int16_t *block);
+ 
+ #endif /* AVCODEC_MIPS_WMV2DSP_MIPS_H */
+diff --git a/libavcodec/mips/wmv2dsp_mmi.c b/libavcodec/mips/wmv2dsp_mmi.c
+index 1f6ccb299b..82e16f929b 100644
+--- a/libavcodec/mips/wmv2dsp_mmi.c
++++ b/libavcodec/mips/wmv2dsp_mmi.c
+@@ -95,7 +95,7 @@ static void wmv2_idct_col_mmi(short * b)
+     b[56] = (a0 + a2 - a1 - a5 + 8192) >> 14;
+ }
+ 
+-void ff_wmv2_idct_add_mmi(uint8_t *dest, int line_size, int16_t *block)
++void ff_wmv2_idct_add_mmi(uint8_t *dest, ptrdiff_t line_size, int16_t *block)
+ {
+     int i;
+     double ftmp[11];
+@@ -212,7 +212,7 @@ void ff_wmv2_idct_add_mmi(uint8_t *dest, int line_size, int16_t *block)
+     );
+ }
+ 
+-void ff_wmv2_idct_put_mmi(uint8_t *dest, int line_size, int16_t *block)
++void ff_wmv2_idct_put_mmi(uint8_t *dest, ptrdiff_t line_size, int16_t *block)
+ {
+     int i;
+     double ftmp[8];
+diff --git a/libavcodec/mips/xvididct_init_mips.c b/libavcodec/mips/xvididct_init_mips.c
+index c1d82cc30c..ed545cfe17 100644
+--- a/libavcodec/mips/xvididct_init_mips.c
++++ b/libavcodec/mips/xvididct_init_mips.c
+@@ -18,28 +18,23 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++#include "libavutil/mips/cpu.h"
+ #include "xvididct_mips.h"
+ 
+-#if HAVE_MMI
+-static av_cold void xvid_idct_init_mmi(IDCTDSPContext *c, AVCodecContext *avctx,
++av_cold void ff_xvid_idct_init_mips(IDCTDSPContext *c, AVCodecContext *avctx,
+         unsigned high_bit_depth)
+ {
+-    if (!high_bit_depth) {
+-        if (avctx->idct_algo == FF_IDCT_AUTO ||
+-                avctx->idct_algo == FF_IDCT_XVID) {
+-            c->idct_put = ff_xvid_idct_put_mmi;
+-            c->idct_add = ff_xvid_idct_add_mmi;
+-            c->idct = ff_xvid_idct_mmi;
+-            c->perm_type = FF_IDCT_PERM_NONE;
++    int cpu_flags = av_get_cpu_flags();
++
++    if (have_mmi(cpu_flags)) {
++        if (!high_bit_depth) {
++            if (avctx->idct_algo == FF_IDCT_AUTO ||
++                    avctx->idct_algo == FF_IDCT_XVID) {
++                c->idct_put = ff_xvid_idct_put_mmi;
++                c->idct_add = ff_xvid_idct_add_mmi;
++                c->idct = ff_xvid_idct_mmi;
++                c->perm_type = FF_IDCT_PERM_NONE;
++            }
+         }
+     }
+ }
+-#endif /* HAVE_MMI */
+-
+-av_cold void ff_xvid_idct_init_mips(IDCTDSPContext *c, AVCodecContext *avctx,
+-        unsigned high_bit_depth)
+-{
+-#if HAVE_MMI
+-    xvid_idct_init_mmi(c, avctx, high_bit_depth);
+-#endif /* HAVE_MMI */
+-}
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0016-libavcodec-MIPS-MMI-Fix-type-mismatches.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0016-libavcodec-MIPS-MMI-Fix-type-mismatches.patch
@@ -1,0 +1,175 @@
+From f51a28b78c25a70edb3b52afc5ddbac8982cacf3 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Sat, 18 Jul 2020 23:35:41 +0800
+Subject: [PATCH 16/26] libavcodec: MIPS: MMI: Fix type mismatches
+
+GCC complains about them.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Reviewed-by: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/h264dsp_mips.h  | 18 +++++++++---------
+ libavcodec/mips/h264dsp_mmi.c   | 18 +++++++++---------
+ libavcodec/mips/xvid_idct_mmi.c |  4 ++--
+ libavcodec/mips/xvididct_mips.h |  4 ++--
+ 4 files changed, 22 insertions(+), 22 deletions(-)
+
+diff --git a/libavcodec/mips/h264dsp_mips.h b/libavcodec/mips/h264dsp_mips.h
+index 9b6f054b24..35e16c41b3 100644
+--- a/libavcodec/mips/h264dsp_mips.h
++++ b/libavcodec/mips/h264dsp_mips.h
+@@ -357,23 +357,23 @@ void ff_h264_biweight_pixels4_8_mmi(uint8_t *dst, uint8_t *src,
+ 
+ void ff_deblock_v_chroma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int beta,
+         int8_t *tc0);
+-void ff_deblock_v_chroma_intra_8_mmi(uint8_t *pix, int stride, int alpha,
++void ff_deblock_v_chroma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         int beta);
+-void ff_deblock_h_chroma_8_mmi(uint8_t *pix, int stride, int alpha, int beta,
++void ff_deblock_h_chroma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int beta,
+         int8_t *tc0);
+-void ff_deblock_h_chroma_intra_8_mmi(uint8_t *pix, int stride, int alpha,
++void ff_deblock_h_chroma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         int beta);
+-void ff_deblock_v_luma_8_mmi(uint8_t *pix, int stride, int alpha, int beta,
++void ff_deblock_v_luma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int beta,
+         int8_t *tc0);
+-void ff_deblock_v_luma_intra_8_mmi(uint8_t *pix, int stride, int alpha,
++void ff_deblock_v_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         int beta);
+-void ff_deblock_h_luma_8_mmi(uint8_t *pix, int stride, int alpha, int beta,
++void ff_deblock_h_luma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int beta,
+         int8_t *tc0);
+-void ff_deblock_h_luma_intra_8_mmi(uint8_t *pix, int stride, int alpha,
++void ff_deblock_h_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         int beta);
+-void ff_deblock_v8_luma_8_mmi(uint8_t *pix, int stride, int alpha, int beta,
++void ff_deblock_v8_luma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int beta,
+         int8_t *tc0);
+-void ff_deblock_v8_luma_intra_8_mmi(uint8_t *pix, int stride, int alpha,
++void ff_deblock_v8_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         int beta);
+ 
+ void ff_put_h264_qpel16_mc00_mmi(uint8_t *dst, const uint8_t *src,
+diff --git a/libavcodec/mips/h264dsp_mmi.c b/libavcodec/mips/h264dsp_mmi.c
+index 0459711b82..d3bd472599 100644
+--- a/libavcodec/mips/h264dsp_mmi.c
++++ b/libavcodec/mips/h264dsp_mmi.c
+@@ -1433,7 +1433,7 @@ void ff_h264_biweight_pixels4_8_mmi(uint8_t *dst, uint8_t *src,
+     }
+ }
+ 
+-void ff_deblock_v8_luma_8_mmi(uint8_t *pix, int stride, int alpha, int beta,
++void ff_deblock_v8_luma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int beta,
+         int8_t *tc0)
+ {
+     double ftmp[12];
+@@ -1561,7 +1561,7 @@ void ff_deblock_v8_luma_8_mmi(uint8_t *pix, int stride, int alpha, int beta,
+     );
+ }
+ 
+-static void deblock_v8_luma_intra_8_mmi(uint8_t *pix, int stride, int alpha,
++static void deblock_v8_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         int beta)
+ {
+     DECLARE_ALIGNED(8, const uint64_t, stack[0x0a]);
+@@ -1871,7 +1871,7 @@ void ff_deblock_v_chroma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+     );
+ }
+ 
+-void ff_deblock_v_chroma_intra_8_mmi(uint8_t *pix, int stride, int alpha,
++void ff_deblock_v_chroma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         int beta)
+ {
+     double ftmp[9];
+@@ -1949,7 +1949,7 @@ void ff_deblock_v_chroma_intra_8_mmi(uint8_t *pix, int stride, int alpha,
+     );
+ }
+ 
+-void ff_deblock_h_chroma_8_mmi(uint8_t *pix, int stride, int alpha, int beta,
++void ff_deblock_h_chroma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int beta,
+         int8_t *tc0)
+ {
+     double ftmp[11];
+@@ -2089,7 +2089,7 @@ void ff_deblock_h_chroma_8_mmi(uint8_t *pix, int stride, int alpha, int beta,
+     );
+ }
+ 
+-void ff_deblock_h_chroma_intra_8_mmi(uint8_t *pix, int stride, int alpha,
++void ff_deblock_h_chroma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         int beta)
+ {
+     double ftmp[11];
+@@ -2222,7 +2222,7 @@ void ff_deblock_h_chroma_intra_8_mmi(uint8_t *pix, int stride, int alpha,
+     );
+ }
+ 
+-void ff_deblock_v_luma_8_mmi(uint8_t *pix, int stride, int alpha, int beta,
++void ff_deblock_v_luma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int beta,
+         int8_t *tc0)
+ {
+     if ((tc0[0] & tc0[1]) >= 0)
+@@ -2231,14 +2231,14 @@ void ff_deblock_v_luma_8_mmi(uint8_t *pix, int stride, int alpha, int beta,
+         ff_deblock_v8_luma_8_mmi(pix + 8, stride, alpha, beta, tc0 + 2);
+ }
+ 
+-void ff_deblock_v_luma_intra_8_mmi(uint8_t *pix, int stride, int alpha,
++void ff_deblock_v_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         int beta)
+ {
+     deblock_v8_luma_intra_8_mmi(pix + 0, stride, alpha, beta);
+     deblock_v8_luma_intra_8_mmi(pix + 8, stride, alpha, beta);
+ }
+ 
+-void ff_deblock_h_luma_8_mmi(uint8_t *pix, int stride, int alpha, int beta,
++void ff_deblock_h_luma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int beta,
+         int8_t *tc0)
+ {
+     DECLARE_ALIGNED(8, const uint64_t, stack[0x0d]);
+@@ -2457,7 +2457,7 @@ void ff_deblock_h_luma_8_mmi(uint8_t *pix, int stride, int alpha, int beta,
+     );
+ }
+ 
+-void ff_deblock_h_luma_intra_8_mmi(uint8_t *pix, int stride, int alpha,
++void ff_deblock_h_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         int beta)
+ {
+     DECLARE_ALIGNED(8, const uint64_t, ptmp[0x11]);
+diff --git a/libavcodec/mips/xvid_idct_mmi.c b/libavcodec/mips/xvid_idct_mmi.c
+index d3f9acb0e2..b822b8add8 100644
+--- a/libavcodec/mips/xvid_idct_mmi.c
++++ b/libavcodec/mips/xvid_idct_mmi.c
+@@ -240,13 +240,13 @@ void ff_xvid_idct_mmi(int16_t *block)
+     );
+ }
+ 
+-void ff_xvid_idct_put_mmi(uint8_t *dest, int32_t line_size, int16_t *block)
++void ff_xvid_idct_put_mmi(uint8_t *dest, ptrdiff_t line_size, int16_t *block)
+ {
+     ff_xvid_idct_mmi(block);
+     ff_put_pixels_clamped_mmi(block, dest, line_size);
+ }
+ 
+-void ff_xvid_idct_add_mmi(uint8_t *dest, int32_t line_size, int16_t *block)
++void ff_xvid_idct_add_mmi(uint8_t *dest, ptrdiff_t line_size, int16_t *block)
+ {
+     ff_xvid_idct_mmi(block);
+     ff_add_pixels_clamped_mmi(block, dest, line_size);
+diff --git a/libavcodec/mips/xvididct_mips.h b/libavcodec/mips/xvididct_mips.h
+index 0768aaa26f..bee03c1391 100644
+--- a/libavcodec/mips/xvididct_mips.h
++++ b/libavcodec/mips/xvididct_mips.h
+@@ -24,7 +24,7 @@
+ #include "libavcodec/xvididct.h"
+ 
+ void ff_xvid_idct_mmi(int16_t *block);
+-void ff_xvid_idct_put_mmi(uint8_t *dest, int32_t line_size, int16_t *block);
+-void ff_xvid_idct_add_mmi(uint8_t *dest, int32_t line_size, int16_t *block);
++void ff_xvid_idct_put_mmi(uint8_t *dest, ptrdiff_t line_size, int16_t *block);
++void ff_xvid_idct_add_mmi(uint8_t *dest, ptrdiff_t line_size, int16_t *block);
+ 
+ #endif /* AVCODEC_MIPS_XVIDIDCT_MIPS_H */
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0017-libavcodec-MIPS-MMI-Move-sp-out-of-the-clobber-list.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0017-libavcodec-MIPS-MMI-Move-sp-out-of-the-clobber-list.patch
@@ -1,0 +1,162 @@
+From 703e63620163303c865e0ef490bfde96db6e0836 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Sat, 18 Jul 2020 23:35:42 +0800
+Subject: [PATCH 17/26] libavcodec: MIPS: MMI: Move sp out of the clobber list
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+GCC complains:
+warning: listing the stack pointer register ‘$29’ in a clobber
+list is deprecated [-Wdeprecated]
+
+Actually stack pointer was restored at the end of the inline assembly
+so there is no reason to add it to the clobber list.
+
+Also use $sp insted of $29 to make our intention much more clear.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Reviewed-by: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/h264dsp_mmi.c | 38 +++++++++++++++++------------------
+ 1 file changed, 19 insertions(+), 19 deletions(-)
+
+diff --git a/libavcodec/mips/h264dsp_mmi.c b/libavcodec/mips/h264dsp_mmi.c
+index d3bd472599..173e191c77 100644
+--- a/libavcodec/mips/h264dsp_mmi.c
++++ b/libavcodec/mips/h264dsp_mmi.c
+@@ -177,7 +177,7 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+ 
+     __asm__ volatile (
+         "lhu        %[tmp0],    0x00(%[block])                          \n\t"
+-        PTR_ADDI   "$29,        $29,            -0x20                   \n\t"
++        PTR_ADDI   "$sp,        $sp,            -0x20                   \n\t"
+         PTR_ADDIU  "%[tmp0],    %[tmp0],        0x20                    \n\t"
+         MMI_LDC1(%[ftmp1], %[block], 0x10)
+         "sh         %[tmp0],    0x00(%[block])                          \n\t"
+@@ -254,8 +254,8 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "punpckhwd  %[ftmp3],   %[ftmp6],       %[ftmp0]                \n\t"
+         "punpcklwd  %[ftmp6],   %[ftmp6],       %[ftmp0]                \n\t"
+         MMI_LDC1(%[ftmp0], %[block], 0x00)
+-        MMI_SDC1(%[ftmp7], $29, 0x00)
+-        MMI_SDC1(%[ftmp1], $29, 0x10)
++        MMI_SDC1(%[ftmp7], $sp, 0x00)
++        MMI_SDC1(%[ftmp1], $sp, 0x10)
+         "dmfc1      %[tmp1],    %[ftmp6]                                \n\t"
+         "dmfc1      %[tmp3],    %[ftmp3]                                \n\t"
+         "punpckhhw  %[ftmp3],   %[ftmp5],       %[ftmp2]                \n\t"
+@@ -266,8 +266,8 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "punpcklwd  %[ftmp5],   %[ftmp5],       %[ftmp4]                \n\t"
+         "punpckhwd  %[ftmp4],   %[ftmp3],       %[ftmp2]                \n\t"
+         "punpcklwd  %[ftmp3],   %[ftmp3],       %[ftmp2]                \n\t"
+-        MMI_SDC1(%[ftmp5], $29, 0x08)
+-        MMI_SDC1(%[ftmp0], $29, 0x18)
++        MMI_SDC1(%[ftmp5], $sp, 0x08)
++        MMI_SDC1(%[ftmp0], $sp, 0x18)
+         "dmfc1      %[tmp2],    %[ftmp3]                                \n\t"
+         "dmfc1      %[tmp4],    %[ftmp4]                                \n\t"
+         MMI_LDC1(%[ftmp1], %[block], 0x18)
+@@ -359,7 +359,7 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         PTR_ADDIU  "%[addr0],   %[dst],         0x04                    \n\t"
+         "mov.d      %[ftmp7],   %[ftmp10]                               \n\t"
+         "dmtc1      %[tmp3],    %[ftmp6]                                \n\t"
+-        MMI_LDC1(%[ftmp1], $29, 0x10)
++        MMI_LDC1(%[ftmp1], $sp, 0x10)
+         "dmtc1      %[tmp1],    %[ftmp3]                                \n\t"
+         "mov.d      %[ftmp4],   %[ftmp1]                                \n\t"
+         "psrah      %[ftmp1],   %[ftmp1],       %[ftmp8]                \n\t"
+@@ -392,7 +392,7 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "psrah      %[ftmp0],   %[ftmp3],       %[ftmp8]                \n\t"
+         "paddh      %[ftmp2],   %[ftmp2],       %[ftmp3]                \n\t"
+         "psubh      %[ftmp0],   %[ftmp0],       %[ftmp7]                \n\t"
+-        MMI_LDC1(%[ftmp3], $29, 0x00)
++        MMI_LDC1(%[ftmp3], $sp, 0x00)
+         "dmtc1      %[tmp5],    %[ftmp7]                                \n\t"
+         "paddh      %[ftmp7],   %[ftmp7],       %[ftmp3]                \n\t"
+         "paddh      %[ftmp3],   %[ftmp3],       %[ftmp3]                \n\t"
+@@ -414,9 +414,9 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "paddh      %[ftmp1],   %[ftmp1],       %[ftmp7]                \n\t"
+         "psubh      %[ftmp3],   %[ftmp3],       %[ftmp6]                \n\t"
+         "paddh      %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
+-        MMI_SDC1(%[ftmp3], $29, 0x00)
++        MMI_SDC1(%[ftmp3], $sp, 0x00)
+         "psubh      %[ftmp7],   %[ftmp7],       %[ftmp1]                \n\t"
+-        MMI_SDC1(%[ftmp0], $29, 0x10)
++        MMI_SDC1(%[ftmp0], $sp, 0x10)
+         "dmfc1      %[tmp1],    %[ftmp2]                                \n\t"
+         "xor        %[ftmp2],   %[ftmp2],       %[ftmp2]                \n\t"
+         MMI_SDC1(%[ftmp2], %[block], 0x00)
+@@ -463,8 +463,8 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "packushb   %[ftmp0],   %[ftmp0],       %[ftmp2]                \n\t"
+         MMI_SWC1(%[ftmp3], %[dst], 0x00)
+         MMI_SWXC1(%[ftmp0], %[dst], %[stride], 0x00)
+-        MMI_LDC1(%[ftmp5], $29, 0x00)
+-        MMI_LDC1(%[ftmp4], $29, 0x10)
++        MMI_LDC1(%[ftmp5], $sp, 0x00)
++        MMI_LDC1(%[ftmp4], $sp, 0x10)
+         "dmtc1      %[tmp1],    %[ftmp6]                                \n\t"
+         PTR_ADDU   "%[dst],     %[dst],         %[stride]               \n\t"
+         PTR_ADDU   "%[dst],     %[dst],         %[stride]               \n\t"
+@@ -496,7 +496,7 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         MMI_SWXC1(%[ftmp0], %[dst], %[stride], 0x00)
+         "dmtc1      %[tmp4],    %[ftmp1]                                \n\t"
+         "dmtc1      %[tmp2],    %[ftmp6]                                \n\t"
+-        MMI_LDC1(%[ftmp4], $29, 0x18)
++        MMI_LDC1(%[ftmp4], $sp, 0x18)
+         "mov.d      %[ftmp5],   %[ftmp4]                                \n\t"
+         "psrah      %[ftmp4],   %[ftmp4],       %[ftmp8]                \n\t"
+         "psrah      %[ftmp7],   %[ftmp11],      %[ftmp8]                \n\t"
+@@ -528,7 +528,7 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "psrah      %[ftmp7],   %[ftmp6],       %[ftmp8]                \n\t"
+         "paddh      %[ftmp0],   %[ftmp0],       %[ftmp6]                \n\t"
+         "psubh      %[ftmp7],   %[ftmp7],       %[ftmp3]                \n\t"
+-        MMI_LDC1(%[ftmp6], $29, 0x08)
++        MMI_LDC1(%[ftmp6], $sp, 0x08)
+         "dmtc1      %[tmp6],    %[ftmp3]                                \n\t"
+         "paddh      %[ftmp3],   %[ftmp3],       %[ftmp6]                \n\t"
+         "paddh      %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
+@@ -550,9 +550,9 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "paddh      %[ftmp4],   %[ftmp4],       %[ftmp3]                \n\t"
+         "psubh      %[ftmp6],   %[ftmp6],       %[ftmp1]                \n\t"
+         "paddh      %[ftmp3],   %[ftmp3],       %[ftmp3]                \n\t"
+-        MMI_SDC1(%[ftmp6], $29, 0x08)
++        MMI_SDC1(%[ftmp6], $sp, 0x08)
+         "psubh      %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
+-        MMI_SDC1(%[ftmp7], $29, 0x18)
++        MMI_SDC1(%[ftmp7], $sp, 0x18)
+         "dmfc1      %[tmp2],    %[ftmp0]                                \n\t"
+         "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         MMI_ULWC1(%[ftmp6], %[addr0], 0x00)
+@@ -581,8 +581,8 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "packushb   %[ftmp7],   %[ftmp7],       %[ftmp0]                \n\t"
+         MMI_SWC1(%[ftmp6], %[addr0], 0x00)
+         MMI_SWXC1(%[ftmp7], %[addr0], %[stride], 0x00)
+-        MMI_LDC1(%[ftmp2], $29, 0x08)
+-        MMI_LDC1(%[ftmp5], $29, 0x18)
++        MMI_LDC1(%[ftmp2], $sp, 0x08)
++        MMI_LDC1(%[ftmp5], $sp, 0x18)
+         PTR_ADDU   "%[addr0],   %[addr0],       %[stride]               \n\t"
+         "dmtc1      %[tmp2],    %[ftmp1]                                \n\t"
+         PTR_ADDU   "%[addr0],   %[addr0],       %[stride]               \n\t"
+@@ -612,7 +612,7 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "packushb   %[ftmp7],   %[ftmp7],       %[ftmp0]                \n\t"
+         MMI_SWC1(%[ftmp6], %[addr0], 0x00)
+         MMI_SWXC1(%[ftmp7], %[addr0], %[stride], 0x00)
+-        PTR_ADDIU  "$29,        $29,            0x20                    \n\t"
++        PTR_ADDIU  "$sp,        $sp,            0x20                    \n\t"
+         : [ftmp0]"=&f"(ftmp[0]),            [ftmp1]"=&f"(ftmp[1]),
+           [ftmp2]"=&f"(ftmp[2]),            [ftmp3]"=&f"(ftmp[3]),
+           [ftmp4]"=&f"(ftmp[4]),            [ftmp5]"=&f"(ftmp[5]),
+@@ -630,7 +630,7 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+           [addr0]"=&r"(addr[0])
+         : [dst]"r"(dst),                    [block]"r"(block),
+           [stride]"r"((mips_reg)stride)
+-        : "$29","memory"
++        : "memory"
+     );
+ 
+ }
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0018-avcodec-mips-Fix-register-constraint-error-reported-.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0018-avcodec-mips-Fix-register-constraint-error-reported-.patch
@@ -1,0 +1,96 @@
+From 6e64e723d7898cc1dd242ef38d6b7d7075f33eb0 Mon Sep 17 00:00:00 2001
+From: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Date: Wed, 29 Jul 2020 18:10:58 +0800
+Subject: [PATCH 18/26] avcodec/mips: Fix register constraint error reported by
+ clang.
+
+Clang report following error in aacsbr_mips.c,ac3dsp_mips.c and aacdec_mips.c:
+"couldn't allocate output register for constraint 'r'"
+
+Use 'f' constraint for float variable.
+
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/aacdec_mips.c |  2 +-
+ libavcodec/mips/aacsbr_mips.c |  2 +-
+ libavcodec/mips/sbrdsp_mips.c | 19 ++++++++++---------
+ 3 files changed, 12 insertions(+), 11 deletions(-)
+
+diff --git a/libavcodec/mips/aacdec_mips.c b/libavcodec/mips/aacdec_mips.c
+index 8e30652935..7f2478957f 100644
+--- a/libavcodec/mips/aacdec_mips.c
++++ b/libavcodec/mips/aacdec_mips.c
+@@ -340,7 +340,7 @@ static void update_ltp_mips(AACContext *ac, SingleChannelElement *sce)
+     float *saved_ltp = sce->coeffs;
+     const float *lwindow = ics->use_kb_window[0] ? ff_aac_kbd_long_1024 : ff_sine_1024;
+     const float *swindow = ics->use_kb_window[0] ? ff_aac_kbd_short_128 : ff_sine_128;
+-    float temp0, temp1, temp2, temp3, temp4, temp5, temp6, temp7;
++    uint32_t temp0, temp1, temp2, temp3, temp4, temp5, temp6, temp7;
+ 
+     if (ics->window_sequence[0] == EIGHT_SHORT_SEQUENCE) {
+         float *p_saved_ltp = saved_ltp + 576;
+diff --git a/libavcodec/mips/aacsbr_mips.c b/libavcodec/mips/aacsbr_mips.c
+index 2e0cd723d7..5ef5e68371 100644
+--- a/libavcodec/mips/aacsbr_mips.c
++++ b/libavcodec/mips/aacsbr_mips.c
+@@ -333,7 +333,7 @@ static void sbr_hf_assemble_mips(float Y1[38][64][2],
+     int indexnoise = ch_data->f_indexnoise;
+     int indexsine  = ch_data->f_indexsine;
+     float *g_temp1, *q_temp1, *pok, *pok1;
+-    float temp1, temp2, temp3, temp4;
++    uint32_t temp1, temp2, temp3, temp4;
+     int size = m_max;
+ 
+     if (sbr->reset) {
+diff --git a/libavcodec/mips/sbrdsp_mips.c b/libavcodec/mips/sbrdsp_mips.c
+index 83039fd802..1c87c99251 100644
+--- a/libavcodec/mips/sbrdsp_mips.c
++++ b/libavcodec/mips/sbrdsp_mips.c
+@@ -796,9 +796,9 @@ static void sbr_hf_apply_noise_2_mips(float (*Y)[2], const float *s_m,
+                                  const float *q_filt, int noise,
+                                  int kx, int m_max)
+ {
+-    int m;
++    int m, temp0, temp1;
+     float *ff_table;
+-    float y0,y1, temp0, temp1, temp2, temp3, temp4, temp5;
++    float y0, y1, temp2, temp3, temp4, temp5;
+ 
+     for (m = 0; m < m_max; m++) {
+ 
+@@ -808,14 +808,14 @@ static void sbr_hf_apply_noise_2_mips(float (*Y)[2], const float *s_m,
+ 
+         __asm__ volatile(
+             "lwc1   %[y0],       0(%[Y1])                                  \n\t"
+-            "lwc1   %[temp1],    0(%[s_m1])                                \n\t"
++            "lwc1   %[temp3],    0(%[s_m1])                                \n\t"
+             "addiu  %[noise],    %[noise],              1                  \n\t"
+             "andi   %[noise],    %[noise],              0x1ff              \n\t"
+             "sll    %[temp0],    %[noise],              3                  \n\t"
+             PTR_ADDU "%[ff_table],%[ff_sbr_noise_table],%[temp0]           \n\t"
+-            "sub.s  %[y0],       %[y0],                 %[temp1]           \n\t"
+-            "mfc1   %[temp3],    %[temp1]                                  \n\t"
+-            "bne    %[temp3],    $0,                    1f                 \n\t"
++            "sub.s  %[y0],       %[y0],                 %[temp3]           \n\t"
++            "mfc1   %[temp1],    %[temp3]                                  \n\t"
++            "bne    %[temp1],    $0,                    1f                 \n\t"
+             "lwc1   %[y1],       4(%[Y1])                                  \n\t"
+             "lwc1   %[temp2],    0(%[q_filt1])                             \n\t"
+             "lwc1   %[temp4],    0(%[ff_table])                            \n\t"
+@@ -826,9 +826,10 @@ static void sbr_hf_apply_noise_2_mips(float (*Y)[2], const float *s_m,
+         "1:                                                                \n\t"
+             "swc1   %[y0],       0(%[Y1])                                  \n\t"
+ 
+-            : [temp0]"=&r"(temp0), [ff_table]"=&r"(ff_table), [y0]"=&f"(y0),
+-              [y1]"=&f"(y1), [temp1]"=&f"(temp1), [temp2]"=&f"(temp2),
+-              [temp3]"=&r"(temp3), [temp4]"=&f"(temp4), [temp5]"=&f"(temp5)
++            : [temp0]"=&r"(temp0), [temp1]"=&r"(temp1), [y0]"=&f"(y0),
++              [y1]"=&f"(y1), [ff_table]"=&r"(ff_table),
++              [temp2]"=&f"(temp2), [temp3]"=&f"(temp3),
++              [temp4]"=&f"(temp4), [temp5]"=&f"(temp5)
+             : [ff_sbr_noise_table]"r"(ff_sbr_noise_table), [noise]"r"(noise),
+               [Y1]"r"(Y1), [s_m1]"r"(s_m1), [q_filt1]"r"(q_filt1)
+             : "memory"
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0019-avcodec-mips-cabac-Fix-a-bug-in-get_cabac_inline_mip.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0019-avcodec-mips-cabac-Fix-a-bug-in-get_cabac_inline_mip.patch
@@ -1,0 +1,29 @@
+From e368725c01994f64e189e6280fdb6d0935cc5e6b Mon Sep 17 00:00:00 2001
+From: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Date: Wed, 29 Jul 2020 18:11:00 +0800
+Subject: [PATCH 19/26] avcodec/mips/cabac: Fix a bug in get_cabac_inline_mips.
+
+Failed fate case: fate-h264-conformance-caba2_sony_e
+Clang is more strict in the use of register constraint.
+
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/cabac.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/mips/cabac.h b/libavcodec/mips/cabac.h
+index c595915eda..3d09e93523 100644
+--- a/libavcodec/mips/cabac.h
++++ b/libavcodec/mips/cabac.h
+@@ -109,7 +109,7 @@ static av_always_inline int get_cabac_inline_mips(CABACContext *c,
+       [lps_off]"i"(H264_LPS_RANGE_OFFSET),
+       [mlps_off]"i"(H264_MLPS_STATE_OFFSET + 128),
+       [norm_off]"i"(H264_NORM_SHIFT_OFFSET),
+-      [cabac_mask]"i"(CABAC_MASK)
++      [cabac_mask]"r"(CABAC_MASK)
+     : "memory"
+     );
+ 
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0020-avcodec-mips-Fix-segfault-in-imdct36_mips_float.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0020-avcodec-mips-Fix-segfault-in-imdct36_mips_float.patch
@@ -1,0 +1,1084 @@
+From 9afb12be656a8a9e70d45adc64b1359776eb9b8c Mon Sep 17 00:00:00 2001
+From: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Date: Wed, 29 Jul 2020 18:11:01 +0800
+Subject: [PATCH 20/26] avcodec/mips: Fix segfault in imdct36_mips_float.
+
+'li.s' is a synthesized instruction, it does not work properly
+when compiled with clang on mips, and A segfault occurred.
+
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/aacpsdsp_mips.c           |  13 +-
+ libavcodec/mips/aacpsy_mips.h             |  14 +-
+ libavcodec/mips/fft_mips.c                |  12 +-
+ libavcodec/mips/mpegaudiodsp_mips_float.c | 492 +++++++++++-----------
+ 4 files changed, 264 insertions(+), 267 deletions(-)
+
+diff --git a/libavcodec/mips/aacpsdsp_mips.c b/libavcodec/mips/aacpsdsp_mips.c
+index ef47e31a9e..f63541330d 100644
+--- a/libavcodec/mips/aacpsdsp_mips.c
++++ b/libavcodec/mips/aacpsdsp_mips.c
+@@ -293,16 +293,17 @@ static void ps_decorrelate_mips(float (*out)[2], float (*delay)[2],
+     float phi_fract0 = phi_fract[0];
+     float phi_fract1 = phi_fract[1];
+     float temp0, temp1, temp2, temp3, temp4, temp5, temp6, temp7, temp8, temp9;
++    float f1, f2, f3;
+ 
+     float *p_delay_end = (p_delay + (len << 1));
+ 
+     /* merged 2 loops */
++    f1 = 0.65143905753106;
++    f2 = 0.56471812200776;
++    f3 = 0.48954165955695;
+     __asm__ volatile(
+         ".set    push                                                    \n\t"
+         ".set    noreorder                                               \n\t"
+-        "li.s    %[ag0],        0.65143905753106                         \n\t"
+-        "li.s    %[ag1],        0.56471812200776                         \n\t"
+-        "li.s    %[ag2],        0.48954165955695                         \n\t"
+         "mul.s   %[ag0],        %[ag0],        %[g_decay_slope]          \n\t"
+         "mul.s   %[ag1],        %[ag1],        %[g_decay_slope]          \n\t"
+         "mul.s   %[ag2],        %[ag2],        %[g_decay_slope]          \n\t"
+@@ -378,10 +379,10 @@ static void ps_decorrelate_mips(float (*out)[2], float (*delay)[2],
+           [temp3]"=&f"(temp3), [temp4]"=&f"(temp4), [temp5]"=&f"(temp5),
+           [temp6]"=&f"(temp6), [temp7]"=&f"(temp7), [temp8]"=&f"(temp8),
+           [temp9]"=&f"(temp9), [p_delay]"+r"(p_delay), [p_ap_delay]"+r"(p_ap_delay),
+-          [p_Q_fract]"+r"(p_Q_fract), [p_t_gain]"+r"(p_t_gain), [p_out]"+r"(p_out),
+-          [ag0]"=&f"(ag0), [ag1]"=&f"(ag1), [ag2]"=&f"(ag2)
++          [p_Q_fract]"+r"(p_Q_fract), [p_t_gain]"+r"(p_t_gain), [p_out]"+r"(p_out)
+         : [phi_fract0]"f"(phi_fract0), [phi_fract1]"f"(phi_fract1),
+-          [p_delay_end]"r"(p_delay_end), [g_decay_slope]"f"(g_decay_slope)
++          [p_delay_end]"r"(p_delay_end), [g_decay_slope]"f"(g_decay_slope),
++          [ag0]"f"(f1), [ag1]"f"(f2), [ag2]"f"(f3)
+         : "memory"
+     );
+ }
+diff --git a/libavcodec/mips/aacpsy_mips.h b/libavcodec/mips/aacpsy_mips.h
+index a1fe5ccea9..7d27d32f18 100644
+--- a/libavcodec/mips/aacpsy_mips.h
++++ b/libavcodec/mips/aacpsy_mips.h
+@@ -135,11 +135,11 @@ static void psy_hp_filter_mips(const float *firbuf, float *hpfsmpl, const float
+     float coeff3 = psy_fir_coeffs[7];
+     float coeff4 = psy_fir_coeffs[9];
+ 
++    float f1 = 32768.0;
+     __asm__ volatile (
+         ".set push                                          \n\t"
+         ".set noreorder                                     \n\t"
+ 
+-        "li.s   $f12,       32768                           \n\t"
+         "1:                                                 \n\t"
+         "lwc1   $f0,        40(%[fb])                       \n\t"
+         "lwc1   $f1,        4(%[fb])                        \n\t"
+@@ -203,14 +203,14 @@ static void psy_hp_filter_mips(const float *firbuf, float *hpfsmpl, const float
+         "madd.s %[sum2],    %[sum2],    $f9,    %[coeff4]   \n\t"
+         "madd.s %[sum4],    %[sum4],    $f6,    %[coeff4]   \n\t"
+         "madd.s %[sum3],    %[sum3],    $f3,    %[coeff4]   \n\t"
+-        "mul.s  %[sum1],    %[sum1],    $f12                \n\t"
+-        "mul.s  %[sum2],    %[sum2],    $f12                \n\t"
++        "mul.s  %[sum1],    %[sum1],    %[f1]               \n\t"
++        "mul.s  %[sum2],    %[sum2],    %[f1]               \n\t"
+         "madd.s %[sum4],    %[sum4],    $f11,   %[coeff4]   \n\t"
+         "madd.s %[sum3],    %[sum3],    $f8,    %[coeff4]   \n\t"
+         "swc1   %[sum1],    0(%[hp])                        \n\t"
+         "swc1   %[sum2],    4(%[hp])                        \n\t"
+-        "mul.s  %[sum4],    %[sum4],    $f12                \n\t"
+-        "mul.s  %[sum3],    %[sum3],    $f12                \n\t"
++        "mul.s  %[sum4],    %[sum4],    %[f1]               \n\t"
++        "mul.s  %[sum3],    %[sum3],    %[f1]               \n\t"
+         "swc1   %[sum4],    12(%[hp])                       \n\t"
+         "swc1   %[sum3],    8(%[hp])                        \n\t"
+         "bne    %[fb],      %[fb_end],  1b                  \n\t"
+@@ -223,9 +223,9 @@ static void psy_hp_filter_mips(const float *firbuf, float *hpfsmpl, const float
+           [fb]"+r"(fb), [hp]"+r"(hp)
+         : [coeff0]"f"(coeff0), [coeff1]"f"(coeff1),
+           [coeff2]"f"(coeff2), [coeff3]"f"(coeff3),
+-          [coeff4]"f"(coeff4), [fb_end]"r"(fb_end)
++          [coeff4]"f"(coeff4), [fb_end]"r"(fb_end), [f1]"f"(f1)
+         : "$f0", "$f1", "$f2", "$f3", "$f4", "$f5", "$f6",
+-          "$f7", "$f8", "$f9", "$f10", "$f11", "$f12",
++          "$f7", "$f8", "$f9", "$f10", "$f11",
+           "memory"
+     );
+ }
+diff --git a/libavcodec/mips/fft_mips.c b/libavcodec/mips/fft_mips.c
+index 03dcbad4d8..69abdc8a08 100644
+--- a/libavcodec/mips/fft_mips.c
++++ b/libavcodec/mips/fft_mips.c
+@@ -71,6 +71,7 @@ static void ff_fft_calc_mips(FFTContext *s, FFTComplex *z)
+     float temp, temp1, temp3, temp4;
+     FFTComplex * tmpz_n2, * tmpz_n34, * tmpz_n4;
+     FFTComplex * tmpz_n2_i, * tmpz_n34_i, * tmpz_n4_i, * tmpz_i;
++    float f1 = 0.7071067812;
+ 
+     num_transforms = (21845 >> (17 - s->nbits)) | 1;
+ 
+@@ -148,7 +149,6 @@ static void ff_fft_calc_mips(FFTContext *s, FFTComplex *z)
+             "swc1  %[pom2], 4(%[tmpz])                      \n\t"  // tmpz[0].im = tmpz[0].im + tmp6;
+             "lwc1  %[pom1], 16(%[tmpz])                     \n\t"
+             "lwc1  %[pom3], 20(%[tmpz])                     \n\t"
+-            "li.s  %[pom],  0.7071067812                    \n\t"  // float pom = 0.7071067812f;
+             "add.s %[temp1],%[tmp1],    %[tmp2]             \n\t"
+             "sub.s %[temp], %[pom1],    %[tmp8]             \n\t"
+             "add.s %[pom2], %[pom3],    %[tmp7]             \n\t"
+@@ -159,10 +159,10 @@ static void ff_fft_calc_mips(FFTContext *s, FFTComplex *z)
+             "add.s %[pom1], %[pom1],    %[tmp8]             \n\t"
+             "sub.s %[pom3], %[pom3],    %[tmp7]             \n\t"
+             "add.s %[tmp3], %[tmp3],    %[tmp4]             \n\t"
+-            "mul.s %[tmp5], %[pom],     %[temp1]            \n\t"  // tmp5 = pom * (tmp1 + tmp2);
+-            "mul.s %[tmp7], %[pom],     %[temp3]            \n\t"  // tmp7 = pom * (tmp3 - tmp4);
+-            "mul.s %[tmp6], %[pom],     %[temp4]            \n\t"  // tmp6 = pom * (tmp2 - tmp1);
+-            "mul.s %[tmp8], %[pom],     %[tmp3]             \n\t"  // tmp8 = pom * (tmp3 + tmp4);
++            "mul.s %[tmp5], %[f1],      %[temp1]            \n\t"  // tmp5 = pom * (tmp1 + tmp2);
++            "mul.s %[tmp7], %[f1],      %[temp3]            \n\t"  // tmp7 = pom * (tmp3 - tmp4);
++            "mul.s %[tmp6], %[f1],      %[temp4]            \n\t"  // tmp6 = pom * (tmp2 - tmp1);
++            "mul.s %[tmp8], %[f1],      %[tmp3]             \n\t"  // tmp8 = pom * (tmp3 + tmp4);
+             "swc1  %[pom1], 16(%[tmpz])                     \n\t"  // tmpz[2].re = tmpz[2].re + tmp8;
+             "swc1  %[pom3], 20(%[tmpz])                     \n\t"  // tmpz[2].im = tmpz[2].im - tmp7;
+             "add.s %[tmp1], %[tmp5],    %[tmp7]             \n\t"  // tmp1 = tmp5 + tmp7;
+@@ -193,7 +193,7 @@ static void ff_fft_calc_mips(FFTContext *s, FFTComplex *z)
+               [tmp3]"=&f"(tmp3), [tmp2]"=&f"(tmp2), [tmp4]"=&f"(tmp4), [tmp5]"=&f"(tmp5),  [tmp7]"=&f"(tmp7),
+               [tmp6]"=&f"(tmp6), [tmp8]"=&f"(tmp8), [pom3]"=&f"(pom3),[temp]"=&f"(temp), [temp1]"=&f"(temp1),
+               [temp3]"=&f"(temp3), [temp4]"=&f"(temp4)
+-            : [tmpz]"r"(tmpz)
++            : [tmpz]"r"(tmpz), [f1]"f"(f1)
+             : "memory"
+         );
+     }
+diff --git a/libavcodec/mips/mpegaudiodsp_mips_float.c b/libavcodec/mips/mpegaudiodsp_mips_float.c
+index 481b69c10e..ae130c752e 100644
+--- a/libavcodec/mips/mpegaudiodsp_mips_float.c
++++ b/libavcodec/mips/mpegaudiodsp_mips_float.c
+@@ -287,9 +287,16 @@ static void ff_dct32_mips_float(float *out, const float *tab)
+           val8 , val9 , val10, val11, val12, val13, val14, val15,
+           val16, val17, val18, val19, val20, val21, val22, val23,
+           val24, val25, val26, val27, val28, val29, val30, val31;
+-    float fTmp1, fTmp2, fTmp3, fTmp4, fTmp5, fTmp6, fTmp7, fTmp8,
+-          fTmp9, fTmp10, fTmp11;
++    float fTmp1, fTmp2, fTmp3, fTmp4, fTmp5, fTmp6, fTmp8, fTmp9;
++    float f1, f2, f3, f4, f5, f6, f7;
+ 
++    f1 = 0.50241928618815570551;
++    f2 = 0.50060299823519630134;
++    f3 = 10.19000812354805681150;
++    f4 = 5.10114861868916385802;
++    f5 = 0.67480834145500574602;
++    f6 = 0.74453627100229844977;
++    f7 = 0.50979557910415916894;
+     /**
+     * instructions are scheduled to minimize pipeline stall.
+     */
+@@ -298,149 +305,142 @@ static void ff_dct32_mips_float(float *out, const float *tab)
+         "lwc1       %[fTmp2],       31*4(%[tab])                            \n\t"
+         "lwc1       %[fTmp3],       15*4(%[tab])                            \n\t"
+         "lwc1       %[fTmp4],       16*4(%[tab])                            \n\t"
+-        "li.s       %[fTmp7],       0.50241928618815570551                  \n\t"
+         "add.s      %[fTmp5],       %[fTmp1],       %[fTmp2]                \n\t"
+         "sub.s      %[fTmp8],       %[fTmp1],       %[fTmp2]                \n\t"
+         "add.s      %[fTmp6],       %[fTmp3],       %[fTmp4]                \n\t"
+         "sub.s      %[fTmp9],       %[fTmp3],       %[fTmp4]                \n\t"
+-        "li.s       %[fTmp10],      0.50060299823519630134                  \n\t"
+-        "li.s       %[fTmp11],      10.19000812354805681150                 \n\t"
+-        "mul.s      %[fTmp8],       %[fTmp8],       %[fTmp10]               \n\t"
++        "mul.s      %[fTmp8],       %[fTmp8],       %[f2]                   \n\t"
+         "add.s      %[val0],        %[fTmp5],       %[fTmp6]                \n\t"
+         "sub.s      %[val15],       %[fTmp5],       %[fTmp6]                \n\t"
+         "lwc1       %[fTmp1],       7*4(%[tab])                             \n\t"
+         "lwc1       %[fTmp2],       24*4(%[tab])                            \n\t"
+-        "madd.s     %[val16],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "nmsub.s    %[val31],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "mul.s      %[val15],       %[val15],       %[fTmp7]                \n\t"
++        "madd.s     %[val16],       %[fTmp8],       %[fTmp9],   %[f3]       \n\t"
++        "nmsub.s    %[val31],       %[fTmp8],       %[fTmp9],   %[f3]       \n\t"
++        "mul.s      %[val15],       %[val15],       %[f1]                   \n\t"
+         "lwc1       %[fTmp3],       8*4(%[tab])                             \n\t"
+         "lwc1       %[fTmp4],       23*4(%[tab])                            \n\t"
+         "add.s      %[fTmp5],       %[fTmp1],       %[fTmp2]                \n\t"
+-        "mul.s      %[val31],       %[val31],       %[fTmp7]                \n\t"
++        "mul.s      %[val31],       %[val31],       %[f1]                   \n\t"
+         "sub.s      %[fTmp8],       %[fTmp1],       %[fTmp2]                \n\t"
+         "add.s      %[fTmp6],       %[fTmp3],       %[fTmp4]                \n\t"
+         "sub.s      %[fTmp9],       %[fTmp3],       %[fTmp4]                \n\t"
+-        "li.s       %[fTmp7],       5.10114861868916385802                  \n\t"
+-        "li.s       %[fTmp10],      0.67480834145500574602                  \n\t"
+-        "li.s       %[fTmp11],      0.74453627100229844977                  \n\t"
+         "add.s      %[val7],        %[fTmp5],       %[fTmp6]                \n\t"
+         "sub.s      %[val8],        %[fTmp5],       %[fTmp6]                \n\t"
+-        "mul.s      %[fTmp8],       %[fTmp8],       %[fTmp10]               \n\t"
+-        "li.s       %[fTmp1],       0.50979557910415916894                  \n\t"
++        "mul.s      %[fTmp8],       %[fTmp8],       %[f5]                   \n\t"
+         "sub.s      %[fTmp2],       %[val0],        %[val7]                 \n\t"
+-        "mul.s      %[val8],        %[val8],        %[fTmp7]                \n\t"
+-        "madd.s     %[val23],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "nmsub.s    %[val24],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
++        "mul.s      %[val8],        %[val8],        %[f4]                   \n\t"
++        "madd.s     %[val23],       %[fTmp8],       %[fTmp9],   %[f6]       \n\t"
++        "nmsub.s    %[val24],       %[fTmp8],       %[fTmp9],   %[f6]       \n\t"
+         "add.s      %[val0],        %[val0],        %[val7]                 \n\t"
+-        "mul.s      %[val7],        %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val7],        %[f7],          %[fTmp2]                \n\t"
+         "sub.s      %[fTmp2],       %[val15],       %[val8]                 \n\t"
+         "add.s      %[val8],        %[val15],       %[val8]                 \n\t"
+-        "mul.s      %[val24],       %[val24],       %[fTmp7]                \n\t"
++        "mul.s      %[val24],       %[val24],       %[f4]                   \n\t"
+         "sub.s      %[fTmp3],       %[val16],       %[val23]                \n\t"
+         "add.s      %[val16],       %[val16],       %[val23]                \n\t"
+-        "mul.s      %[val15],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val15],       %[f7],          %[fTmp2]                \n\t"
+         "sub.s      %[fTmp4],       %[val31],       %[val24]                \n\t"
+-        "mul.s      %[val23],       %[fTmp1],       %[fTmp3]                \n\t"
++        "mul.s      %[val23],       %[f7],          %[fTmp3]                \n\t"
+         "add.s      %[val24],       %[val31],       %[val24]                \n\t"
+-        "mul.s      %[val31],       %[fTmp1],       %[fTmp4]                \n\t"
++        "mul.s      %[val31],       %[f7],          %[fTmp4]                \n\t"
+ 
+         : [fTmp1]  "=&f" (fTmp1),  [fTmp2] "=&f" (fTmp2), [fTmp3] "=&f" (fTmp3),
+           [fTmp4]  "=&f" (fTmp4),  [fTmp5] "=&f" (fTmp5), [fTmp6] "=&f" (fTmp6),
+-          [fTmp7]  "=&f" (fTmp7),  [fTmp8] "=&f" (fTmp8), [fTmp9] "=&f" (fTmp9),
+-          [fTmp10] "=&f" (fTmp10), [fTmp11] "=&f" (fTmp11),
+-          [val0]  "=f" (val0),  [val7]  "=f" (val7),
+-          [val8]  "=f" (val8),  [val15] "=f" (val15),
+-          [val16] "=f" (val16), [val23] "=f" (val23),
+-          [val24] "=f" (val24), [val31] "=f" (val31)
+-        : [tab] "r" (tab)
++          [fTmp8] "=&f" (fTmp8), [fTmp9] "=&f" (fTmp9),
++          [val0]  "=&f" (val0),  [val7]  "=&f" (val7),
++          [val8]  "=&f" (val8),  [val15] "=&f" (val15),
++          [val16] "=&f" (val16), [val23] "=&f" (val23),
++          [val24] "=&f" (val24), [val31] "=&f" (val31)
++        : [tab] "r" (tab), [f1]"f"(f1), [f2]"f"(f2), [f3]"f"(f3),
++          [f4]"f"(f4), [f5]"f"(f5), [f6]"f"(f6), [f7]"f"(f7)
+         : "memory"
+     );
+ 
++    f1 = 0.64682178335999012954;
++    f2 = 0.53104259108978417447;
++    f3 = 1.48416461631416627724;
++    f4 = 0.78815462345125022473;
++    f5 = 0.55310389603444452782;
++    f6 = 1.16943993343288495515;
++    f7 = 2.56291544774150617881;
+     __asm__ volatile (
+         "lwc1       %[fTmp1],       3*4(%[tab])                             \n\t"
+         "lwc1       %[fTmp2],       28*4(%[tab])                            \n\t"
+         "lwc1       %[fTmp3],       12*4(%[tab])                            \n\t"
+         "lwc1       %[fTmp4],       19*4(%[tab])                            \n\t"
+-        "li.s       %[fTmp7],       0.64682178335999012954                  \n\t"
+         "add.s      %[fTmp5],       %[fTmp1],       %[fTmp2]                \n\t"
+         "sub.s      %[fTmp8],       %[fTmp1],       %[fTmp2]                \n\t"
+         "add.s      %[fTmp6],       %[fTmp3],       %[fTmp4]                \n\t"
+         "sub.s      %[fTmp9],       %[fTmp3],       %[fTmp4]                \n\t"
+-        "li.s       %[fTmp10],      0.53104259108978417447                  \n\t"
+-        "li.s       %[fTmp11],      1.48416461631416627724                  \n\t"
+-        "mul.s      %[fTmp8],       %[fTmp8],       %[fTmp10]               \n\t"
++        "mul.s      %[fTmp8],       %[fTmp8],       %[f2]                   \n\t"
+         "add.s      %[val3],        %[fTmp5],       %[fTmp6]                \n\t"
+         "sub.s      %[val12],       %[fTmp5],       %[fTmp6]                \n\t"
+         "lwc1       %[fTmp1],       4*4(%[tab])                             \n\t"
+         "lwc1       %[fTmp2],       27*4(%[tab])                            \n\t"
+-        "madd.s     %[val19],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "nmsub.s    %[val28],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "mul.s      %[val12],       %[val12],       %[fTmp7]                \n\t"
++        "madd.s     %[val19],       %[fTmp8],       %[fTmp9],   %[f3]       \n\t"
++        "nmsub.s    %[val28],       %[fTmp8],       %[fTmp9],   %[f3]       \n\t"
++        "mul.s      %[val12],       %[val12],       %[f1]                   \n\t"
+         "lwc1       %[fTmp3],       11*4(%[tab])                            \n\t"
+         "lwc1       %[fTmp4],       20*4(%[tab])                            \n\t"
+         "add.s      %[fTmp5],       %[fTmp1],       %[fTmp2]                \n\t"
+-        "mul.s      %[val28],       %[val28],       %[fTmp7]                \n\t"
++        "mul.s      %[val28],       %[val28],       %[f1]                   \n\t"
+         "sub.s      %[fTmp8],       %[fTmp1],       %[fTmp2]                \n\t"
+-        "li.s       %[fTmp7],       0.78815462345125022473                  \n\t"
+         "add.s      %[fTmp6],       %[fTmp3],       %[fTmp4]                \n\t"
+         "sub.s      %[fTmp9],       %[fTmp3],       %[fTmp4]                \n\t"
+-        "li.s       %[fTmp10],      0.55310389603444452782                  \n\t"
+-        "li.s       %[fTmp11],      1.16943993343288495515                  \n\t"
+-        "mul.s      %[fTmp8],       %[fTmp8],       %[fTmp10]               \n\t"
++        "mul.s      %[fTmp8],       %[fTmp8],       %[f5]                   \n\t"
+         "add.s      %[val4],        %[fTmp5],       %[fTmp6]                \n\t"
+         "sub.s      %[val11],       %[fTmp5],       %[fTmp6]                \n\t"
+-        "li.s       %[fTmp1],       2.56291544774150617881                  \n\t"
+-        "madd.s     %[val20],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "nmsub.s    %[val27],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "mul.s      %[val11],       %[val11],       %[fTmp7]                \n\t"
++        "madd.s     %[val20],       %[fTmp8],       %[fTmp9],   %[f6]       \n\t"
++        "nmsub.s    %[val27],       %[fTmp8],       %[fTmp9],   %[f6]       \n\t"
++        "mul.s      %[val11],       %[val11],       %[f4]                   \n\t"
+         "sub.s      %[fTmp2],       %[val3],        %[val4]                 \n\t"
+         "add.s      %[val3],        %[val3],        %[val4]                 \n\t"
+         "sub.s      %[fTmp4],       %[val19],       %[val20]                \n\t"
+-        "mul.s      %[val27],       %[val27],       %[fTmp7]                \n\t"
++        "mul.s      %[val27],       %[val27],       %[f4]                   \n\t"
+         "sub.s      %[fTmp3],       %[val12],       %[val11]                \n\t"
+-        "mul.s      %[val4],        %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val4],        %[f7],          %[fTmp2]                \n\t"
+         "add.s      %[val11],       %[val12],       %[val11]                \n\t"
+         "add.s      %[val19],       %[val19],       %[val20]                \n\t"
+-        "mul.s      %[val20],       %[fTmp1],       %[fTmp4]                \n\t"
+-        "mul.s      %[val12],       %[fTmp1],       %[fTmp3]                \n\t"
++        "mul.s      %[val20],       %[f7],          %[fTmp4]                \n\t"
++        "mul.s      %[val12],       %[f7],          %[fTmp3]                \n\t"
+         "sub.s      %[fTmp2],       %[val28],       %[val27]                \n\t"
+         "add.s      %[val27],       %[val28],       %[val27]                \n\t"
+-        "mul.s      %[val28],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val28],       %[f7],          %[fTmp2]                \n\t"
+ 
+         : [fTmp1]  "=&f" (fTmp1),  [fTmp2]  "=&f" (fTmp2), [fTmp3] "=&f" (fTmp3),
+           [fTmp4]  "=&f" (fTmp4),  [fTmp5]  "=&f" (fTmp5), [fTmp6] "=&f" (fTmp6),
+-          [fTmp7]  "=&f" (fTmp7),  [fTmp8]  "=&f" (fTmp8), [fTmp9] "=&f" (fTmp9),
+-          [fTmp10] "=&f" (fTmp10), [fTmp11] "=&f" (fTmp11),
+-          [val3]  "=f" (val3),  [val4]  "=f" (val4),
+-          [val11] "=f" (val11), [val12] "=f" (val12),
+-          [val19] "=f" (val19), [val20] "=f" (val20),
+-          [val27] "=f" (val27), [val28] "=f" (val28)
+-        : [tab] "r" (tab)
++          [fTmp8]  "=&f" (fTmp8), [fTmp9] "=&f" (fTmp9),
++          [val3]  "=&f" (val3),  [val4]  "=&f" (val4),
++          [val11] "=&f" (val11), [val12] "=&f" (val12),
++          [val19] "=&f" (val19), [val20] "=&f" (val20),
++          [val27] "=&f" (val27), [val28] "=&f" (val28)
++        : [tab] "r" (tab), [f1]"f"(f1), [f2]"f"(f2), [f3]"f"(f3),
++          [f4]"f"(f4), [f5]"f"(f5), [f6]"f"(f6), [f7]"f"(f7)
+         : "memory"
+     );
+ 
++    f1 = 0.54119610014619698439;
+     __asm__ volatile (
+-        "li.s       %[fTmp1],       0.54119610014619698439                  \n\t"
+         "sub.s      %[fTmp2],       %[val0],        %[val3]                 \n\t"
+         "add.s      %[val0],        %[val0],        %[val3]                 \n\t"
+         "sub.s      %[fTmp3],       %[val7],        %[val4]                 \n\t"
+         "add.s      %[val4],        %[val7],        %[val4]                 \n\t"
+         "sub.s      %[fTmp4],       %[val8],        %[val11]                \n\t"
+-        "mul.s      %[val3],        %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val3],        %[f1],          %[fTmp2]                \n\t"
+         "add.s      %[val8],        %[val8],        %[val11]                \n\t"
+-        "mul.s      %[val7],        %[fTmp1],       %[fTmp3]                \n\t"
++        "mul.s      %[val7],        %[f1],          %[fTmp3]                \n\t"
+         "sub.s      %[fTmp2],       %[val15],       %[val12]                \n\t"
+-        "mul.s      %[val11],       %[fTmp1],       %[fTmp4]                \n\t"
++        "mul.s      %[val11],       %[f1],          %[fTmp4]                \n\t"
+         "add.s      %[val12],       %[val15],       %[val12]                \n\t"
+-        "mul.s      %[val15],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val15],       %[f1],          %[fTmp2]                \n\t"
+ 
+-        : [val0]  "+f" (val0),   [val3] "+f" (val3),
+-          [val4]  "+f" (val4),   [val7] "+f" (val7),
+-          [val8]  "+f" (val8),   [val11] "+f" (val11),
+-          [val12] "+f" (val12),  [val15] "+f" (val15),
+-          [fTmp1] "=f"  (fTmp1), [fTmp2] "=&f" (fTmp2),
++        : [val0]  "+&f" (val0),   [val3] "+&f" (val3),
++          [val4]  "+&f" (val4),   [val7] "+&f" (val7),
++          [val8]  "+&f" (val8),   [val11] "+&f" (val11),
++          [val12] "+&f" (val12),  [val15] "+&f" (val15),
++          [fTmp2] "=&f" (fTmp2),
+           [fTmp3] "=&f" (fTmp3), [fTmp4] "=&f" (fTmp4)
+-        :
++        : [f1] "f" (f1)
+     );
+ 
+     __asm__ volatile (
+@@ -449,169 +449,169 @@ static void ff_dct32_mips_float(float *out, const float *tab)
+         "sub.s      %[fTmp3],       %[val23],       %[val20]                \n\t"
+         "add.s      %[val20],       %[val23],       %[val20]                \n\t"
+         "sub.s      %[fTmp4],       %[val24],       %[val27]                \n\t"
+-        "mul.s      %[val19],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val19],       %[f1],          %[fTmp2]                \n\t"
+         "add.s      %[val24],       %[val24],       %[val27]                \n\t"
+-        "mul.s      %[val23],       %[fTmp1],       %[fTmp3]                \n\t"
++        "mul.s      %[val23],       %[f1],          %[fTmp3]                \n\t"
+         "sub.s      %[fTmp2],       %[val31],       %[val28]                \n\t"
+-        "mul.s      %[val27],       %[fTmp1],       %[fTmp4]                \n\t"
++        "mul.s      %[val27],       %[f1],          %[fTmp4]                \n\t"
+         "add.s      %[val28],       %[val31],       %[val28]                \n\t"
+-        "mul.s      %[val31],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val31],       %[f1],          %[fTmp2]                \n\t"
+ 
+         : [fTmp2] "=&f" (fTmp2), [fTmp3] "=&f" (fTmp3), [fTmp4] "=&f" (fTmp4),
+-          [val16] "+f" (val16), [val19] "+f" (val19), [val20] "+f" (val20),
+-          [val23] "+f" (val23), [val24] "+f" (val24), [val27] "+f" (val27),
+-          [val28] "+f" (val28), [val31] "+f" (val31)
+-        : [fTmp1] "f" (fTmp1)
++          [val16] "+&f" (val16), [val19] "+&f" (val19), [val20] "+&f" (val20),
++          [val23] "+&f" (val23), [val24] "+&f" (val24), [val27] "+&f" (val27),
++          [val28] "+&f" (val28), [val31] "+&f" (val31)
++        : [f1] "f" (f1)
+     );
+ 
++    f1 = 0.52249861493968888062;
++    f2 = 0.50547095989754365998;
++    f3 = 3.40760841846871878570;
++    f4 = 1.72244709823833392782;
++    f5 = 0.62250412303566481615;
++    f6 = 0.83934964541552703873;
++    f7 = 0.60134488693504528054;
+     __asm__ volatile (
+         "lwc1       %[fTmp1],       1*4(%[tab])                             \n\t"
+         "lwc1       %[fTmp2],       30*4(%[tab])                            \n\t"
+         "lwc1       %[fTmp3],       14*4(%[tab])                            \n\t"
+         "lwc1       %[fTmp4],       17*4(%[tab])                            \n\t"
+-        "li.s       %[fTmp7],       0.52249861493968888062                  \n\t"
+         "add.s      %[fTmp5],       %[fTmp1],       %[fTmp2]                \n\t"
+         "sub.s      %[fTmp8],       %[fTmp1],       %[fTmp2]                \n\t"
+         "add.s      %[fTmp6],       %[fTmp3],       %[fTmp4]                \n\t"
+         "sub.s      %[fTmp9],       %[fTmp3],       %[fTmp4]                \n\t"
+-        "li.s       %[fTmp10],      0.50547095989754365998                  \n\t"
+-        "li.s       %[fTmp11],      3.40760841846871878570                  \n\t"
+-        "mul.s      %[fTmp8],       %[fTmp8],       %[fTmp10]               \n\t"
++        "mul.s      %[fTmp8],       %[fTmp8],       %[f2]                   \n\t"
+         "add.s      %[val1],        %[fTmp5],       %[fTmp6]                \n\t"
+         "sub.s      %[val14],       %[fTmp5],       %[fTmp6]                \n\t"
+         "lwc1       %[fTmp1],       6*4(%[tab])                             \n\t"
+         "lwc1       %[fTmp2],       25*4(%[tab])                            \n\t"
+-        "madd.s     %[val17],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "nmsub.s    %[val30],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "mul.s      %[val14],       %[val14],       %[fTmp7]                \n\t"
++        "madd.s     %[val17],       %[fTmp8],       %[fTmp9],   %[f3]       \n\t"
++        "nmsub.s    %[val30],       %[fTmp8],       %[fTmp9],   %[f3]       \n\t"
++        "mul.s      %[val14],       %[val14],       %[f1]                   \n\t"
+         "lwc1       %[fTmp3],       9*4(%[tab])                             \n\t"
+         "lwc1       %[fTmp4],       22*4(%[tab])                            \n\t"
+         "add.s      %[fTmp5],       %[fTmp1],       %[fTmp2]                \n\t"
+-        "mul.s      %[val30],       %[val30],       %[fTmp7]                \n\t"
++        "mul.s      %[val30],       %[val30],       %[f1]                   \n\t"
+         "sub.s      %[fTmp8],       %[fTmp1],       %[fTmp2]                \n\t"
+         "add.s      %[fTmp6],       %[fTmp3],       %[fTmp4]                \n\t"
+         "sub.s      %[fTmp9],       %[fTmp3],       %[fTmp4]                \n\t"
+-        "li.s       %[fTmp7],       1.72244709823833392782                  \n\t"
+-        "li.s       %[fTmp10],      0.62250412303566481615                  \n\t"
+-        "li.s       %[fTmp11],      0.83934964541552703873                  \n\t"
+         "add.s      %[val6],        %[fTmp5],       %[fTmp6]                \n\t"
+         "sub.s      %[val9],        %[fTmp5],       %[fTmp6]                \n\t"
+-        "mul.s      %[fTmp8],       %[fTmp8],       %[fTmp10]               \n\t"
+-        "li.s       %[fTmp1],       0.60134488693504528054                  \n\t"
++        "mul.s      %[fTmp8],       %[fTmp8],       %[f5]                   \n\t"
+         "sub.s      %[fTmp2],       %[val1],        %[val6]                 \n\t"
+         "add.s      %[val1],        %[val1],        %[val6]                 \n\t"
+-        "mul.s      %[val9],        %[val9],        %[fTmp7]                \n\t"
+-        "madd.s     %[val22],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "nmsub.s    %[val25],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "mul.s      %[val6],        %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val9],        %[val9],        %[f4]                   \n\t"
++        "madd.s     %[val22],       %[fTmp8],       %[fTmp9],   %[f6]       \n\t"
++        "nmsub.s    %[val25],       %[fTmp8],       %[fTmp9],   %[f6]       \n\t"
++        "mul.s      %[val6],        %[f7],          %[fTmp2]                \n\t"
+         "sub.s      %[fTmp2],       %[val14],       %[val9]                 \n\t"
+         "add.s      %[val9],        %[val14],       %[val9]                 \n\t"
+-        "mul.s      %[val25],       %[val25],       %[fTmp7]                \n\t"
++        "mul.s      %[val25],       %[val25],       %[f4]                   \n\t"
+         "sub.s      %[fTmp3],       %[val17],       %[val22]                \n\t"
+         "add.s      %[val17],       %[val17],       %[val22]                \n\t"
+-        "mul.s      %[val14],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val14],       %[f7],          %[fTmp2]                \n\t"
+         "sub.s      %[fTmp2],       %[val30],       %[val25]                \n\t"
+-        "mul.s      %[val22],       %[fTmp1],       %[fTmp3]                \n\t"
++        "mul.s      %[val22],       %[f7],          %[fTmp3]                \n\t"
+         "add.s      %[val25],       %[val30],       %[val25]                \n\t"
+-        "mul.s      %[val30],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val30],       %[f7],          %[fTmp2]                \n\t"
+ 
+         : [fTmp1]  "=&f" (fTmp1),  [fTmp2]  "=&f" (fTmp2), [fTmp3] "=&f" (fTmp3),
+           [fTmp4]  "=&f" (fTmp4),  [fTmp5]  "=&f" (fTmp5), [fTmp6] "=&f" (fTmp6),
+-          [fTmp7]  "=&f" (fTmp7),  [fTmp8]  "=&f" (fTmp8), [fTmp9] "=&f" (fTmp9),
+-          [fTmp10] "=&f" (fTmp10), [fTmp11] "=&f" (fTmp11),
+-          [val1]  "=f" (val1),  [val6]  "=f" (val6),
+-          [val9]  "=f" (val9),  [val14] "=f" (val14),
+-          [val17] "=f" (val17), [val22] "=f" (val22),
+-          [val25] "=f" (val25), [val30] "=f" (val30)
+-        : [tab] "r" (tab)
++          [fTmp8]  "=&f" (fTmp8), [fTmp9] "=&f" (fTmp9),
++          [val1]  "=&f" (val1),  [val6]  "=&f" (val6),
++          [val9]  "=&f" (val9),  [val14] "=&f" (val14),
++          [val17] "=&f" (val17), [val22] "=&f" (val22),
++          [val25] "=&f" (val25), [val30] "=&f" (val30)
++        : [tab] "r" (tab), [f1]"f"(f1), [f2]"f"(f2), [f3]"f"(f3),
++          [f4]"f"(f4), [f5]"f"(f5), [f6]"f"(f6), [f7]"f"(f7)
+         : "memory"
+     );
+ 
++    f1 = 0.56694403481635770368;
++    f2 = 0.51544730992262454697;
++    f3 = 2.05778100995341155085;
++    f4 = 1.06067768599034747134;
++    f5 = 0.58293496820613387367;
++    f6 = 0.97256823786196069369;
++    f7 = 0.89997622313641570463;
+     __asm__ volatile (
+         "lwc1       %[fTmp1],       2*4(%[tab])                             \n\t"
+         "lwc1       %[fTmp2],       29*4(%[tab])                            \n\t"
+         "lwc1       %[fTmp3],       13*4(%[tab])                            \n\t"
+         "lwc1       %[fTmp4],       18*4(%[tab])                            \n\t"
+-        "li.s       %[fTmp7],       0.56694403481635770368                  \n\t"
+         "add.s      %[fTmp5],       %[fTmp1],       %[fTmp2]                \n\t"
+         "sub.s      %[fTmp8],       %[fTmp1],       %[fTmp2]                \n\t"
+         "add.s      %[fTmp6],       %[fTmp3],       %[fTmp4]                \n\t"
+         "sub.s      %[fTmp9],       %[fTmp3],       %[fTmp4]                \n\t"
+-        "li.s       %[fTmp10],      0.51544730992262454697                  \n\t"
+-        "li.s       %[fTmp11],      2.05778100995341155085                  \n\t"
+-        "mul.s      %[fTmp8],       %[fTmp8],       %[fTmp10]               \n\t"
++        "mul.s      %[fTmp8],       %[fTmp8],       %[f2]                   \n\t"
+         "add.s      %[val2],        %[fTmp5],       %[fTmp6]                \n\t"
+         "sub.s      %[val13],       %[fTmp5],       %[fTmp6]                \n\t"
+         "lwc1       %[fTmp1],       5*4(%[tab])                             \n\t"
+         "lwc1       %[fTmp2],       26*4(%[tab])                            \n\t"
+-        "madd.s     %[val18],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "nmsub.s    %[val29],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "mul.s      %[val13],       %[val13],       %[fTmp7]                \n\t"
++        "madd.s     %[val18],       %[fTmp8],       %[fTmp9],   %[f3]       \n\t"
++        "nmsub.s    %[val29],       %[fTmp8],       %[fTmp9],   %[f3]       \n\t"
++        "mul.s      %[val13],       %[val13],       %[f1]                   \n\t"
+         "lwc1       %[fTmp3],       10*4(%[tab])                            \n\t"
+         "lwc1       %[fTmp4],       21*4(%[tab])                            \n\t"
+-        "mul.s      %[val29],       %[val29],       %[fTmp7]                \n\t"
++        "mul.s      %[val29],       %[val29],       %[f1]                   \n\t"
+         "add.s      %[fTmp5],       %[fTmp1],       %[fTmp2]                \n\t"
+         "sub.s      %[fTmp8],       %[fTmp1],       %[fTmp2]                \n\t"
+         "add.s      %[fTmp6],       %[fTmp3],       %[fTmp4]                \n\t"
+         "sub.s      %[fTmp9],       %[fTmp3],       %[fTmp4]                \n\t"
+-        "li.s       %[fTmp7],       1.06067768599034747134                  \n\t"
+-        "li.s       %[fTmp10],      0.58293496820613387367                  \n\t"
+-        "li.s       %[fTmp11],      0.97256823786196069369                  \n\t"
+         "add.s      %[val5],        %[fTmp5],       %[fTmp6]                \n\t"
+         "sub.s      %[val10],       %[fTmp5],       %[fTmp6]                \n\t"
+-        "mul.s      %[fTmp8],       %[fTmp8],       %[fTmp10]               \n\t"
+-        "li.s       %[fTmp1],       0.89997622313641570463                  \n\t"
++        "mul.s      %[fTmp8],       %[fTmp8],       %[f5]                   \n\t"
+         "sub.s      %[fTmp2],       %[val2],        %[val5]                 \n\t"
+-        "mul.s      %[val10],       %[val10],       %[fTmp7]                \n\t"
+-        "madd.s     %[val21],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
+-        "nmsub.s    %[val26],       %[fTmp8],       %[fTmp9],   %[fTmp11]   \n\t"
++        "mul.s      %[val10],       %[val10],       %[f4]                   \n\t"
++        "madd.s     %[val21],       %[fTmp8],       %[fTmp9],   %[f6]       \n\t"
++        "nmsub.s    %[val26],       %[fTmp8],       %[fTmp9],   %[f6]       \n\t"
+         "add.s      %[val2],        %[val2],        %[val5]                 \n\t"
+-        "mul.s      %[val5],        %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val5],        %[f7],          %[fTmp2]                \n\t"
+         "sub.s      %[fTmp3],       %[val13],       %[val10]                \n\t"
+         "add.s      %[val10],       %[val13],       %[val10]                \n\t"
+-        "mul.s      %[val26],       %[val26],       %[fTmp7]                \n\t"
++        "mul.s      %[val26],       %[val26],       %[f4]                   \n\t"
+         "sub.s      %[fTmp4],       %[val18],       %[val21]                \n\t"
+         "add.s      %[val18],       %[val18],       %[val21]                \n\t"
+-        "mul.s      %[val13],       %[fTmp1],       %[fTmp3]                \n\t"
++        "mul.s      %[val13],       %[f7],          %[fTmp3]                \n\t"
+         "sub.s      %[fTmp2],       %[val29],       %[val26]                \n\t"
+         "add.s      %[val26],       %[val29],       %[val26]                \n\t"
+-        "mul.s      %[val21],       %[fTmp1],       %[fTmp4]                \n\t"
+-        "mul.s      %[val29],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val21],       %[f7],          %[fTmp4]                \n\t"
++        "mul.s      %[val29],       %[f7],          %[fTmp2]                \n\t"
+ 
+         : [fTmp1]  "=&f" (fTmp1),  [fTmp2]  "=&f" (fTmp2), [fTmp3] "=&f" (fTmp3),
+           [fTmp4]  "=&f" (fTmp4),  [fTmp5]  "=&f" (fTmp5), [fTmp6] "=&f" (fTmp6),
+-          [fTmp7]  "=&f" (fTmp7),  [fTmp8]  "=&f" (fTmp8), [fTmp9] "=&f" (fTmp9),
+-          [fTmp10] "=&f" (fTmp10), [fTmp11] "=&f" (fTmp11),
+-          [val2]  "=f" (val2),  [val5]  "=f" (val5),
+-          [val10] "=f" (val10), [val13] "=f" (val13),
+-          [val18] "=f" (val18), [val21] "=f" (val21),
+-          [val26] "=f" (val26), [val29] "=f" (val29)
+-        : [tab] "r" (tab)
++          [fTmp8]  "=&f" (fTmp8), [fTmp9] "=&f" (fTmp9),
++          [val2]  "=&f" (val2),  [val5]  "=&f" (val5),
++          [val10] "=&f" (val10), [val13] "=&f" (val13),
++          [val18] "=&f" (val18), [val21] "=&f" (val21),
++          [val26] "=&f" (val26), [val29] "=&f" (val29)
++        : [tab] "r" (tab), [f1]"f"(f1), [f2]"f"(f2), [f3]"f"(f3),
++          [f4]"f"(f4), [f5]"f"(f5), [f6]"f"(f6), [f7]"f"(f7)
+         : "memory"
+     );
+ 
++    f1 = 1.30656296487637652785;
+     __asm__ volatile (
+-        "li.s       %[fTmp1],       1.30656296487637652785                  \n\t"
+         "sub.s      %[fTmp2],       %[val1],        %[val2]                 \n\t"
+         "add.s      %[val1],        %[val1],        %[val2]                 \n\t"
+         "sub.s      %[fTmp3],       %[val6],        %[val5]                 \n\t"
+         "add.s      %[val5],        %[val6],        %[val5]                 \n\t"
+         "sub.s      %[fTmp4],       %[val9],        %[val10]                \n\t"
+-        "mul.s      %[val2],        %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val2],        %[f1],          %[fTmp2]                \n\t"
+         "add.s      %[val9],        %[val9],        %[val10]                \n\t"
+-        "mul.s      %[val6],        %[fTmp1],       %[fTmp3]                \n\t"
++        "mul.s      %[val6],        %[f1],          %[fTmp3]                \n\t"
+         "sub.s      %[fTmp2],       %[val14],       %[val13]                \n\t"
+-        "mul.s      %[val10],       %[fTmp1],       %[fTmp4]                \n\t"
++        "mul.s      %[val10],       %[f1],          %[fTmp4]                \n\t"
+         "add.s      %[val13],       %[val14],       %[val13]                \n\t"
+-        "mul.s      %[val14],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val14],       %[f1],          %[fTmp2]                \n\t"
+ 
+-        : [fTmp1] "=f"  (fTmp1), [fTmp2] "=&f" (fTmp2),
++        : [fTmp2] "=&f" (fTmp2),
+           [fTmp3] "=&f" (fTmp3), [fTmp4] "=&f" (fTmp4),
+-          [val1]  "+f" (val1),  [val2]  "+f" (val2),
+-          [val5]  "+f" (val5),  [val6]  "+f" (val6),
+-          [val9]  "+f" (val9),  [val10] "+f" (val10),
+-          [val13] "+f" (val13), [val14] "+f" (val14)
+-        :
++          [val1]  "+&f" (val1),  [val2]  "+&f" (val2),
++          [val5]  "+&f" (val5),  [val6]  "+&f" (val6),
++          [val9]  "+&f" (val9),  [val10] "+&f" (val10),
++          [val13] "+&f" (val13), [val14] "+&f" (val14)
++        : [f1]"f"(f1)
+     );
+ 
+     __asm__ volatile (
+@@ -620,39 +620,39 @@ static void ff_dct32_mips_float(float *out, const float *tab)
+         "sub.s      %[fTmp3],       %[val22],       %[val21]                \n\t"
+         "add.s      %[val21],       %[val22],       %[val21]                \n\t"
+         "sub.s      %[fTmp4],       %[val25],       %[val26]                \n\t"
+-        "mul.s      %[val18],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val18],       %[f1],          %[fTmp2]                \n\t"
+         "add.s      %[val25],       %[val25],       %[val26]                \n\t"
+-        "mul.s      %[val22],       %[fTmp1],       %[fTmp3]                \n\t"
++        "mul.s      %[val22],       %[f1],          %[fTmp3]                \n\t"
+         "sub.s      %[fTmp2],       %[val30],       %[val29]                \n\t"
+-        "mul.s      %[val26],       %[fTmp1],       %[fTmp4]                \n\t"
++        "mul.s      %[val26],       %[f1],          %[fTmp4]                \n\t"
+         "add.s      %[val29],       %[val30],       %[val29]                \n\t"
+-        "mul.s      %[val30],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val30],       %[f1],          %[fTmp2]                \n\t"
+ 
+         : [fTmp2] "=&f" (fTmp2), [fTmp3] "=&f" (fTmp3), [fTmp4] "=&f" (fTmp4),
+-          [val17] "+f" (val17), [val18] "+f" (val18), [val21] "+f" (val21),
+-          [val22] "+f" (val22), [val25] "+f" (val25), [val26] "+f" (val26),
+-          [val29] "+f" (val29), [val30] "+f" (val30)
+-        : [fTmp1] "f" (fTmp1)
++          [val17] "+&f" (val17), [val18] "+&f" (val18), [val21] "+&f" (val21),
++          [val22] "+&f" (val22), [val25] "+&f" (val25), [val26] "+&f" (val26),
++          [val29] "+&f" (val29), [val30] "+&f" (val30)
++        : [f1] "f" (f1)
+     );
+ 
++    f1 = 0.70710678118654752439;
+     __asm__ volatile (
+-        "li.s       %[fTmp1],       0.70710678118654752439                  \n\t"
+         "sub.s      %[fTmp2],       %[val0],        %[val1]                 \n\t"
+         "add.s      %[val0],        %[val0],        %[val1]                 \n\t"
+         "sub.s      %[fTmp3],       %[val3],        %[val2]                 \n\t"
+         "add.s      %[val2],        %[val3],        %[val2]                 \n\t"
+         "sub.s      %[fTmp4],       %[val4],        %[val5]                 \n\t"
+-        "mul.s      %[val1],        %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val1],        %[f1],          %[fTmp2]                \n\t"
+         "swc1       %[val0],        0(%[out])                               \n\t"
+-        "mul.s      %[val3],        %[fTmp3],       %[fTmp1]                \n\t"
++        "mul.s      %[val3],        %[fTmp3],       %[f1]                   \n\t"
+         "add.s      %[val4],        %[val4],        %[val5]                 \n\t"
+-        "mul.s      %[val5],        %[fTmp1],       %[fTmp4]                \n\t"
++        "mul.s      %[val5],        %[f1],          %[fTmp4]                \n\t"
+         "swc1       %[val1],        16*4(%[out])                            \n\t"
+         "sub.s      %[fTmp2],       %[val7],        %[val6]                 \n\t"
+         "add.s      %[val2],        %[val2],        %[val3]                 \n\t"
+         "swc1       %[val3],        24*4(%[out])                            \n\t"
+         "add.s      %[val6],        %[val7],        %[val6]                 \n\t"
+-        "mul.s      %[val7],        %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val7],        %[f1],          %[fTmp2]                \n\t"
+         "swc1       %[val2],        8*4(%[out])                             \n\t"
+         "add.s      %[val6],        %[val6],        %[val7]                 \n\t"
+         "swc1       %[val7],        28*4(%[out])                            \n\t"
+@@ -663,13 +663,13 @@ static void ff_dct32_mips_float(float *out, const float *tab)
+         "swc1       %[val5],        20*4(%[out])                            \n\t"
+         "swc1       %[val6],        12*4(%[out])                            \n\t"
+ 
+-        : [fTmp1] "=f"  (fTmp1), [fTmp2] "=&f" (fTmp2),
++        : [fTmp2] "=&f" (fTmp2),
+           [fTmp3] "=&f" (fTmp3), [fTmp4] "=&f" (fTmp4),
+-          [val0] "+f" (val0), [val1] "+f" (val1),
+-          [val2] "+f" (val2), [val3] "+f" (val3),
+-          [val4] "+f" (val4), [val5] "+f" (val5),
+-          [val6] "+f" (val6), [val7] "+f" (val7)
+-        : [out] "r" (out)
++          [val0] "+&f" (val0), [val1] "+&f" (val1),
++          [val2] "+&f" (val2), [val3] "+&f" (val3),
++          [val4] "+&f" (val4), [val5] "+&f" (val5),
++          [val6] "+&f" (val6), [val7] "+&f" (val7)
++        : [out] "r" (out), [f1]"f"(f1)
+     );
+ 
+     __asm__ volatile (
+@@ -678,14 +678,14 @@ static void ff_dct32_mips_float(float *out, const float *tab)
+         "sub.s      %[fTmp3],       %[val11],       %[val10]                \n\t"
+         "add.s      %[val10],       %[val11],       %[val10]                \n\t"
+         "sub.s      %[fTmp4],       %[val12],       %[val13]                \n\t"
+-        "mul.s      %[val9],        %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val9],        %[f1],          %[fTmp2]                \n\t"
+         "add.s      %[val12],       %[val12],       %[val13]                \n\t"
+-        "mul.s      %[val11],       %[fTmp1],       %[fTmp3]                \n\t"
++        "mul.s      %[val11],       %[f1],          %[fTmp3]                \n\t"
+         "sub.s      %[fTmp2],       %[val15],       %[val14]                \n\t"
+-        "mul.s      %[val13],       %[fTmp1],       %[fTmp4]                \n\t"
++        "mul.s      %[val13],       %[f1],          %[fTmp4]                \n\t"
+         "add.s      %[val14],       %[val15],       %[val14]                \n\t"
+         "add.s      %[val10],       %[val10],       %[val11]                \n\t"
+-        "mul.s      %[val15],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val15],       %[f1],          %[fTmp2]                \n\t"
+         "add.s      %[val14],       %[val14],       %[val15]                \n\t"
+         "add.s      %[val12],       %[val12],       %[val14]                \n\t"
+         "add.s      %[val14],       %[val14],       %[val13]                \n\t"
+@@ -707,10 +707,10 @@ static void ff_dct32_mips_float(float *out, const float *tab)
+         "swc1       %[val15],       30*4(%[out])                            \n\t"
+ 
+         : [fTmp2] "=&f" (fTmp2), [fTmp3] "=&f" (fTmp3), [fTmp4] "=&f" (fTmp4),
+-          [val8]  "+f" (val8),  [val9]  "+f" (val9),  [val10] "+f" (val10),
+-          [val11] "+f" (val11), [val12] "+f" (val12), [val13] "+f" (val13),
+-          [val14] "+f" (val14), [val15] "+f" (val15)
+-        : [fTmp1] "f" (fTmp1), [out] "r" (out)
++          [val8]  "+&f" (val8),  [val9]  "+&f" (val9),  [val10] "+&f" (val10),
++          [val11] "+&f" (val11), [val12] "+&f" (val12), [val13] "+&f" (val13),
++          [val14] "+&f" (val14), [val15] "+&f" (val15)
++        : [f1] "f" (f1), [out] "r" (out)
+     );
+ 
+     __asm__ volatile (
+@@ -719,24 +719,24 @@ static void ff_dct32_mips_float(float *out, const float *tab)
+         "sub.s      %[fTmp3],       %[val19],       %[val18]                \n\t"
+         "add.s      %[val18],       %[val19],       %[val18]                \n\t"
+         "sub.s      %[fTmp4],       %[val20],       %[val21]                \n\t"
+-        "mul.s      %[val17],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val17],       %[f1],          %[fTmp2]                \n\t"
+         "add.s      %[val20],       %[val20],       %[val21]                \n\t"
+-        "mul.s      %[val19],       %[fTmp1],       %[fTmp3]                \n\t"
++        "mul.s      %[val19],       %[f1],          %[fTmp3]                \n\t"
+         "sub.s      %[fTmp2],       %[val23],       %[val22]                \n\t"
+-        "mul.s      %[val21],       %[fTmp1],       %[fTmp4]                \n\t"
++        "mul.s      %[val21],       %[f1],          %[fTmp4]                \n\t"
+         "add.s      %[val22],       %[val23],       %[val22]                \n\t"
+         "add.s      %[val18],       %[val18],       %[val19]                \n\t"
+-        "mul.s      %[val23],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val23],       %[f1],          %[fTmp2]                \n\t"
+         "add.s      %[val22],       %[val22],       %[val23]                \n\t"
+         "add.s      %[val20],       %[val20],       %[val22]                \n\t"
+         "add.s      %[val22],       %[val22],       %[val21]                \n\t"
+         "add.s      %[val21],       %[val21],       %[val23]                \n\t"
+ 
+         : [fTmp2] "=&f" (fTmp2), [fTmp3] "=&f" (fTmp3), [fTmp4] "=&f" (fTmp4),
+-          [val16] "+f" (val16), [val17] "+f" (val17), [val18] "+f" (val18),
+-          [val19] "+f" (val19), [val20] "+f" (val20), [val21] "+f" (val21),
+-          [val22] "+f" (val22), [val23] "+f" (val23)
+-        : [fTmp1] "f" (fTmp1)
++          [val16] "+&f" (val16), [val17] "+&f" (val17), [val18] "+&f" (val18),
++          [val19] "+&f" (val19), [val20] "+&f" (val20), [val21] "+&f" (val21),
++          [val22] "+&f" (val22), [val23] "+&f" (val23)
++        : [f1] "f" (f1)
+     );
+ 
+     __asm__ volatile (
+@@ -745,14 +745,14 @@ static void ff_dct32_mips_float(float *out, const float *tab)
+         "sub.s      %[fTmp3],       %[val27],       %[val26]                \n\t"
+         "add.s      %[val26],       %[val27],       %[val26]                \n\t"
+         "sub.s      %[fTmp4],       %[val28],       %[val29]                \n\t"
+-        "mul.s      %[val25],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val25],       %[f1],          %[fTmp2]                \n\t"
+         "add.s      %[val28],       %[val28],       %[val29]                \n\t"
+-        "mul.s      %[val27],       %[fTmp1],       %[fTmp3]                \n\t"
++        "mul.s      %[val27],       %[f1],          %[fTmp3]                \n\t"
+         "sub.s      %[fTmp2],       %[val31],       %[val30]                \n\t"
+-        "mul.s      %[val29],       %[fTmp1],       %[fTmp4]                \n\t"
++        "mul.s      %[val29],       %[f1],          %[fTmp4]                \n\t"
+         "add.s      %[val30],       %[val31],       %[val30]                \n\t"
+         "add.s      %[val26],       %[val26],       %[val27]                \n\t"
+-        "mul.s      %[val31],       %[fTmp1],       %[fTmp2]                \n\t"
++        "mul.s      %[val31],       %[f1],          %[fTmp2]                \n\t"
+         "add.s      %[val30],       %[val30],       %[val31]                \n\t"
+         "add.s      %[val28],       %[val28],       %[val30]                \n\t"
+         "add.s      %[val30],       %[val30],       %[val29]                \n\t"
+@@ -766,10 +766,10 @@ static void ff_dct32_mips_float(float *out, const float *tab)
+         "add.s      %[val27],       %[val27],       %[val31]                \n\t"
+ 
+         : [fTmp2] "=&f" (fTmp2), [fTmp3] "=&f" (fTmp3), [fTmp4] "=&f" (fTmp4),
+-          [val24] "+f" (val24), [val25] "+f" (val25), [val26] "+f" (val26),
+-          [val27] "+f" (val27), [val28] "+f" (val28), [val29] "+f" (val29),
+-          [val30] "+f" (val30), [val31] "+f" (val31)
+-        : [fTmp1] "f" (fTmp1)
++          [val24] "+&f" (val24), [val25] "+&f" (val25), [val26] "+&f" (val26),
++          [val27] "+&f" (val27), [val28] "+&f" (val28), [val29] "+&f" (val29),
++          [val30] "+&f" (val30), [val31] "+&f" (val31)
++        : [f1] "f" (f1)
+     );
+ 
+     out[ 1] = val16 + val24;
+@@ -797,7 +797,7 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+     /* temporary variables */
+     float in1, in2, in3, in4, in5, in6;
+     float out1, out2, out3, out4, out5;
+-    float c1, c2, c3, c4, c5, c6, c7, c8, c9;
++    float f1, f2, f3, f4, f5, f6, f7, f8, f9;
+ 
+     /**
+     * all loops are unrolled totally, and instructions are scheduled to
+@@ -881,33 +881,36 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+     );
+ 
+     /* loop 3 */
++    f1 = 0.5;
++    f2 = 0.93969262078590838405;
++    f3 = -0.76604444311897803520;
++    f4 = -0.17364817766693034885;
++    f5 = -0.86602540378443864676;
++    f6 = 0.98480775301220805936;
++    f7 = -0.34202014332566873304;
++    f8 = 0.86602540378443864676;
++    f9 = -0.64278760968653932632;
+     __asm__ volatile (
+-        "li.s    %[c1],   0.5                                           \t\n"
+         "lwc1    %[in1],  8*4(%[in])                                    \t\n"
+         "lwc1    %[in2],  16*4(%[in])                                   \t\n"
+         "lwc1    %[in3],  4*4(%[in])                                    \t\n"
+         "lwc1    %[in4],  0(%[in])                                      \t\n"
+         "lwc1    %[in5],  12*4(%[in])                                   \t\n"
+-        "li.s    %[c2],   0.93969262078590838405                        \t\n"
+         "add.s   %[t2],   %[in1],  %[in2]                               \t\n"
+         "add.s   %[t0],   %[in1],  %[in3]                               \t\n"
+-        "li.s    %[c3],   -0.76604444311897803520                       \t\n"
+-        "madd.s  %[t3],   %[in4],  %[in5], %[c1]                        \t\n"
++        "madd.s  %[t3],   %[in4],  %[in5], %[f1]                        \t\n"
+         "sub.s   %[t1],   %[in4],  %[in5]                               \t\n"
+         "sub.s   %[t2],   %[t2],   %[in3]                               \t\n"
+-        "mul.s   %[t0],   %[t0],   %[c2]                                \t\n"
+-        "li.s    %[c4],   -0.17364817766693034885                       \t\n"
+-        "li.s    %[c5],   -0.86602540378443864676                       \t\n"
+-        "li.s    %[c6],   0.98480775301220805936                        \t\n"
+-        "nmsub.s %[out1], %[t1],   %[t2],  %[c1]                        \t\n"
++        "mul.s   %[t0],   %[t0],   %[f2]                                \t\n"
++        "nmsub.s %[out1], %[t1],   %[t2],  %[f1]                        \t\n"
+         "add.s   %[out2], %[t1],   %[t2]                                \t\n"
+         "add.s   %[t2],   %[in2],  %[in3]                               \t\n"
+         "sub.s   %[t1],   %[in1],  %[in2]                               \t\n"
+         "sub.s   %[out3], %[t3],   %[t0]                                \t\n"
+         "swc1    %[out1], 6*4(%[tmp])                                   \t\n"
+         "swc1    %[out2], 16*4(%[tmp])                                  \t\n"
+-        "mul.s   %[t2],   %[t2],   %[c3]                                \t\n"
+-        "mul.s   %[t1],   %[t1],   %[c4]                                \t\n"
++        "mul.s   %[t2],   %[t2],   %[f3]                                \t\n"
++        "mul.s   %[t1],   %[t1],   %[f4]                                \t\n"
+         "add.s   %[out1], %[t3],   %[t0]                                \t\n"
+         "lwc1    %[in1],  10*4(%[in])                                   \t\n"
+         "lwc1    %[in2],  14*4(%[in])                                   \t\n"
+@@ -923,19 +926,16 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+         "add.s   %[t2],   %[in1],  %[in3]                               \t\n"
+         "sub.s   %[t3],   %[in1],  %[in2]                               \t\n"
+         "swc1    %[out2], 14*4(%[tmp])                                  \t\n"
+-        "li.s    %[c7],   -0.34202014332566873304                       \t\n"
+         "sub.s   %[out1], %[out1], %[in3]                               \t\n"
+-        "mul.s   %[t2],   %[t2],   %[c6]                                \t\n"
+-        "mul.s   %[t3],   %[t3],   %[c7]                                \t\n"
+-        "li.s    %[c8],   0.86602540378443864676                        \t\n"
+-        "mul.s   %[t0],   %[in4],  %[c8]                                \t\n"
+-        "mul.s   %[out1], %[out1], %[c5]                                \t\n"
++        "mul.s   %[t2],   %[t2],   %[f6]                                \t\n"
++        "mul.s   %[t3],   %[t3],   %[f7]                                \t\n"
++        "mul.s   %[t0],   %[in4],  %[f8]                                \t\n"
++        "mul.s   %[out1], %[out1], %[f5]                                \t\n"
+         "add.s   %[t1],   %[in2],  %[in3]                               \t\n"
+-        "li.s    %[c9],   -0.64278760968653932632                       \t\n"
+         "add.s   %[out2], %[t2],   %[t3]                                \t\n"
+         "lwc1    %[in1],  9*4(%[in])                                    \t\n"
+         "swc1    %[out1], 4*4(%[tmp])                                   \t\n"
+-        "mul.s   %[t1],   %[t1],   %[c9]                                \t\n"
++        "mul.s   %[t1],   %[t1],   %[f9]                                \t\n"
+         "lwc1    %[in2],  17*4(%[in])                                   \t\n"
+         "add.s   %[out2], %[out2], %[t0]                                \t\n"
+         "lwc1    %[in3],  5*4(%[in])                                    \t\n"
+@@ -948,21 +948,21 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+         "sub.s   %[out3], %[out3], %[t0]                                \t\n"
+         "sub.s   %[out1], %[out1], %[t0]                                \t\n"
+         "add.s   %[t0],   %[in1],  %[in3]                               \t\n"
+-        "madd.s  %[t3],   %[in4],  %[in5], %[c1]                        \t\n"
++        "madd.s  %[t3],   %[in4],  %[in5], %[f1]                        \t\n"
+         "sub.s   %[t2],   %[t2],   %[in3]                               \t\n"
+         "swc1    %[out3], 12*4(%[tmp])                                  \t\n"
+         "swc1    %[out1], 8*4(%[tmp])                                   \t\n"
+         "sub.s   %[t1],   %[in4],  %[in5]                               \t\n"
+-        "mul.s   %[t0],   %[t0],   %[c2]                                \t\n"
+-        "nmsub.s %[out1], %[t1],   %[t2],  %[c1]                        \t\n"
++        "mul.s   %[t0],   %[t0],   %[f2]                                \t\n"
++        "nmsub.s %[out1], %[t1],   %[t2],  %[f1]                        \t\n"
+         "add.s   %[out2], %[t1],   %[t2]                                \t\n"
+         "add.s   %[t2],   %[in2],  %[in3]                               \t\n"
+         "sub.s   %[t1],   %[in1],  %[in2]                               \t\n"
+         "sub.s   %[out3], %[t3],   %[t0]                                \t\n"
+         "swc1    %[out1], 7*4(%[tmp])                                   \t\n"
+         "swc1    %[out2], 17*4(%[tmp])                                  \t\n"
+-        "mul.s   %[t2],   %[t2],   %[c3]                                \t\n"
+-        "mul.s   %[t1],   %[t1],   %[c4]                                \t\n"
++        "mul.s   %[t2],   %[t2],   %[f3]                                \t\n"
++        "mul.s   %[t1],   %[t1],   %[f4]                                \t\n"
+         "add.s   %[out1], %[t3],   %[t0]                                \t\n"
+         "lwc1    %[in1],  11*4(%[in])                                   \t\n"
+         "lwc1    %[in2],  15*4(%[in])                                   \t\n"
+@@ -978,14 +978,14 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+         "add.s   %[t2],   %[in1],  %[in3]                               \t\n"
+         "sub.s   %[t3],   %[in1],  %[in2]                               \t\n"
+         "swc1    %[out2], 15*4(%[tmp])                                  \t\n"
+-        "mul.s   %[t0],   %[in4],  %[c8]                                \t\n"
++        "mul.s   %[t0],   %[in4],  %[f8]                                \t\n"
+         "sub.s   %[out3], %[out3], %[in3]                               \t\n"
+-        "mul.s   %[t2],   %[t2],   %[c6]                                \t\n"
+-        "mul.s   %[t3],   %[t3],   %[c7]                                \t\n"
++        "mul.s   %[t2],   %[t2],   %[f6]                                \t\n"
++        "mul.s   %[t3],   %[t3],   %[f7]                                \t\n"
+         "add.s   %[t1],   %[in2],  %[in3]                               \t\n"
+-        "mul.s   %[out3], %[out3], %[c5]                                \t\n"
++        "mul.s   %[out3], %[out3], %[f5]                                \t\n"
+         "add.s   %[out1], %[t2],   %[t3]                                \t\n"
+-        "mul.s   %[t1],   %[t1],   %[c9]                                \t\n"
++        "mul.s   %[t1],   %[t1],   %[f9]                                \t\n"
+         "swc1    %[out3], 5*4(%[tmp])                                   \t\n"
+         "add.s   %[out1], %[out1], %[t0]                                \t\n"
+         "add.s   %[out2], %[t2],   %[t1]                                \t\n"
+@@ -1000,26 +1000,29 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+           [t2] "=&f" (t2), [t3] "=&f" (t3),
+           [in1] "=&f" (in1), [in2] "=&f" (in2),
+           [in3] "=&f" (in3), [in4] "=&f" (in4),
+-          [in5] "=&f" (in5),
+-          [out1] "=&f" (out1), [out2] "=&f" (out2),
+-          [out3] "=&f" (out3),
+-          [c1] "=&f" (c1), [c2] "=&f" (c2),
+-          [c3] "=&f" (c3), [c4] "=&f" (c4),
+-          [c5] "=&f" (c5), [c6] "=&f" (c6),
+-          [c7] "=&f" (c7), [c8] "=&f" (c8),
+-          [c9] "=&f" (c9)
+-        : [in] "r" (in), [tmp] "r" (tmp)
++          [in5] "=&f" (in5), [out1] "=&f" (out1),
++          [out2] "=&f" (out2), [out3] "=&f" (out3)
++        : [in] "r" (in), [tmp] "r" (tmp), [f1]"f"(f1), [f2]"f"(f2),
++          [f3]"f"(f3), [f4]"f"(f4), [f5]"f"(f5), [f6]"f"(f6),
++          [f7]"f"(f7), [f8]"f"(f8), [f9]"f"(f9)
+         : "memory"
+     );
+ 
+     /* loop 4 */
++    f1 = 0.50190991877167369479;
++    f2 = 5.73685662283492756461;
++    f3 = 0.51763809020504152469;
++    f4 = 1.93185165257813657349;
++    f5 = 0.55168895948124587824;
++    f6 = 1.18310079157624925896;
++    f7 = 0.61038729438072803416;
++    f8 = 0.87172339781054900991;
++    f9 = 0.70710678118654752439;
+     __asm__ volatile (
+         "lwc1   %[in1],  2*4(%[tmp])                                    \t\n"
+         "lwc1   %[in2],  0(%[tmp])                                      \t\n"
+         "lwc1   %[in3],  3*4(%[tmp])                                    \t\n"
+         "lwc1   %[in4],  1*4(%[tmp])                                    \t\n"
+-        "li.s   %[c1],   0.50190991877167369479                         \t\n"
+-        "li.s   %[c2],   5.73685662283492756461                         \t\n"
+         "add.s  %[s0],   %[in1], %[in2]                                 \t\n"
+         "sub.s  %[s2],   %[in1], %[in2]                                 \t\n"
+         "add.s  %[s1],   %[in3], %[in4]                                 \t\n"
+@@ -1027,15 +1030,13 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+         "lwc1   %[in1],  9*4(%[win])                                    \t\n"
+         "lwc1   %[in2],  4*9*4(%[buf])                                  \t\n"
+         "lwc1   %[in3],  8*4(%[win])                                    \t\n"
+-        "mul.s  %[s1],   %[s1],  %[c1]                                  \t\n"
+-        "mul.s  %[s3],   %[s3],  %[c2]                                  \t\n"
++        "mul.s  %[s1],   %[s1],  %[f1]                                  \t\n"
++        "mul.s  %[s3],   %[s3],  %[f2]                                  \t\n"
+         "lwc1   %[in4],  4*8*4(%[buf])                                  \t\n"
+         "lwc1   %[in5],  29*4(%[win])                                   \t\n"
+         "lwc1   %[in6],  28*4(%[win])                                   \t\n"
+         "add.s  %[t0],   %[s0],  %[s1]                                  \t\n"
+         "sub.s  %[t1],   %[s0],  %[s1]                                  \t\n"
+-        "li.s   %[c1],   0.51763809020504152469                         \t\n"
+-        "li.s   %[c2],   1.93185165257813657349                         \t\n"
+         "mul.s  %[out3], %[in5], %[t0]                                  \t\n"
+         "madd.s %[out1], %[in2], %[in1], %[t1]                          \t\n"
+         "madd.s %[out2], %[in4], %[in3], %[t1]                          \t\n"
+@@ -1071,14 +1072,13 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+         "lwc1   %[in1],  10*4(%[win])                                   \t\n"
+         "lwc1   %[in2],  4*10*4(%[buf])                                 \t\n"
+         "lwc1   %[in3],  7*4(%[win])                                    \t\n"
+-        "mul.s  %[s1],   %[s1],  %[c1]                                  \t\n"
+-        "mul.s  %[s3],   %[s3],  %[c2]                                  \t\n"
++        "mul.s  %[s1],   %[s1],  %[f3]                                  \t\n"
++        "mul.s  %[s3],   %[s3],  %[f4]                                  \t\n"
+         "add.s  %[t0],   %[s0],  %[s1]                                  \t\n"
+         "sub.s  %[t1],   %[s0],  %[s1]                                  \t\n"
+         "lwc1   %[in4],  4*7*4(%[buf])                                  \t\n"
+         "lwc1   %[in5],  30*4(%[win])                                   \t\n"
+         "lwc1   %[in6],  27*4(%[win])                                   \t\n"
+-        "li.s   %[c1],   0.55168895948124587824                         \t\n"
+         "madd.s %[out1], %[in2], %[in1], %[t1]                          \t\n"
+         "madd.s %[out2], %[in4], %[in3], %[t1]                          \t\n"
+         "mul.s  %[out3], %[t0],  %[in5]                                 \t\n"
+@@ -1105,7 +1105,6 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+         "swc1   %[out2], 32*4(%[out])                                   \t\n"
+         "swc1   %[out3], 4*16*4(%[buf])                                 \t\n"
+         "swc1   %[out4], 4*1*4(%[buf])                                  \t\n"
+-        "li.s   %[c2],   1.18310079157624925896                         \t\n"
+         "add.s  %[s0],   %[in1], %[in2]                                 \t\n"
+         "sub.s  %[s2],   %[in1], %[in2]                                 \t\n"
+         "lwc1   %[in3],  11*4(%[tmp])                                   \t\n"
+@@ -1115,8 +1114,8 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+         "lwc1   %[in1],  11*4(%[win])                                   \t\n"
+         "lwc1   %[in2],  4*11*4(%[buf])                                 \t\n"
+         "lwc1   %[in3],  6*4(%[win])                                    \t\n"
+-        "mul.s  %[s1],   %[s1],  %[c1]                                  \t\n"
+-        "mul.s  %[s3],   %[s3],  %[c2]                                  \t\n"
++        "mul.s  %[s1],   %[s1],  %[f5]                                  \t\n"
++        "mul.s  %[s3],   %[s3],  %[f6]                                  \t\n"
+         "lwc1   %[in4],  4*6*4(%[buf])                                  \t\n"
+         "lwc1   %[in5],  31*4(%[win])                                   \t\n"
+         "lwc1   %[in6],  26*4(%[win])                                   \t\n"
+@@ -1152,15 +1151,13 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+         "add.s  %[s0],   %[in1], %[in2]                                 \t\n"
+         "sub.s  %[s2],   %[in1], %[in2]                                 \t\n"
+         "lwc1   %[in4],  13*4(%[tmp])                                   \t\n"
+-        "li.s   %[c1],   0.61038729438072803416                         \t\n"
+-        "li.s   %[c2],   0.87172339781054900991                         \t\n"
+         "add.s  %[s1],   %[in3], %[in4]                                 \t\n"
+         "sub.s  %[s3],   %[in3], %[in4]                                 \t\n"
+         "lwc1   %[in1],  12*4(%[win])                                   \t\n"
+         "lwc1   %[in2],  4*12*4(%[buf])                                 \t\n"
+         "lwc1   %[in3],  5*4(%[win])                                    \t\n"
+-        "mul.s  %[s1],   %[s1],  %[c1]                                  \t\n"
+-        "mul.s  %[s3],   %[s3],  %[c2]                                  \t\n"
++        "mul.s  %[s1],   %[s1],  %[f7]                                  \t\n"
++        "mul.s  %[s3],   %[s3],  %[f8]                                  \t\n"
+         "lwc1   %[in4],  4*5*4(%[buf])                                  \t\n"
+         "lwc1   %[in5],  32*4(%[win])                                   \t\n"
+         "lwc1   %[in6],  25*4(%[win])                                   \t\n"
+@@ -1168,7 +1165,6 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+         "sub.s  %[t1],   %[s0],  %[s1]                                  \t\n"
+         "lwc1   %[s0],   16*4(%[tmp])                                   \t\n"
+         "lwc1   %[s1],   17*4(%[tmp])                                   \t\n"
+-        "li.s   %[c1],   0.70710678118654752439                         \t\n"
+         "mul.s  %[out3], %[t0],  %[in5]                                 \t\n"
+         "madd.s %[out1], %[in2], %[in1], %[t1]                          \t\n"
+         "madd.s %[out2], %[in4], %[in3], %[t1]                          \t\n"
+@@ -1186,7 +1182,7 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+         "lwc1   %[in5],  34*4(%[win])                                   \t\n"
+         "lwc1   %[in6],  23*4(%[win])                                   \t\n"
+         "madd.s %[out1], %[in2], %[in1], %[t1]                          \t\n"
+-        "mul.s  %[s1],   %[s1],  %[c1]                                  \t\n"
++        "mul.s  %[s1],   %[s1],  %[f9]                                  \t\n"
+         "madd.s %[out2], %[in4], %[in3], %[t1]                          \t\n"
+         "mul.s  %[out3], %[in5], %[t0]                                  \t\n"
+         "mul.s  %[out4], %[in6], %[t0]                                  \t\n"
+@@ -1211,18 +1207,18 @@ static void imdct36_mips_float(float *out, float *buf, float *in, float *win)
+         "swc1   %[out3], 4*13*4(%[buf])                                 \t\n"
+         "swc1   %[out4], 4*4*4(%[buf])                                  \t\n"
+ 
+-        : [c1] "=&f" (c1), [c2] "=&f" (c2),
+-          [in1] "=&f" (in1), [in2] "=&f" (in2),
++        : [in1] "=&f" (in1), [in2] "=&f" (in2),
+           [in3] "=&f" (in3), [in4] "=&f" (in4),
+           [in5] "=&f" (in5), [in6] "=&f" (in6),
+           [out1] "=&f" (out1), [out2] "=&f" (out2),
+           [out3] "=&f" (out3), [out4] "=&f" (out4),
+           [t0] "=&f" (t0), [t1] "=&f" (t1),
+-          [t2] "=&f" (t2), [t3] "=&f" (t3),
+           [s0] "=&f" (s0), [s1] "=&f" (s1),
+           [s2] "=&f" (s2), [s3] "=&f" (s3)
+         : [tmp] "r" (tmp), [win] "r" (win),
+-          [buf] "r" (buf), [out] "r" (out)
++          [buf] "r" (buf), [out] "r" (out),
++          [f1]"f"(f1), [f2]"f"(f2), [f3]"f"(f3), [f4]"f"(f4),
++          [f5]"f"(f5), [f6]"f"(f6), [f7]"f"(f7), [f8]"f"(f8), [f9]"f"(f9)
+         : "memory"
+     );
+ }
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0021-avcodec-mips-loongson-Fixed-mmi-optimization.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0021-avcodec-mips-loongson-Fixed-mmi-optimization.patch
@@ -1,0 +1,43 @@
+From 7604c9da68aeb17eed349eec72c4902d33f8b7d5 Mon Sep 17 00:00:00 2001
+From: gxw <guxiwei-hf@loongson.cn>
+Date: Thu, 3 Sep 2020 14:29:51 +0800
+Subject: [PATCH 21/26] avcodec/mips: [loongson] Fixed mmi optimization
+
+Test case fate-checkasm-h264pred failed in latest community code.
+This patch fixed the bug.
+
+Signed-off-by: Shiyou Yin <yinshiyou-hf@loongson.cn>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mips/h264pred_mmi.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/libavcodec/mips/h264pred_mmi.c b/libavcodec/mips/h264pred_mmi.c
+index f4fe0911af..0209c2e43f 100644
+--- a/libavcodec/mips/h264pred_mmi.c
++++ b/libavcodec/mips/h264pred_mmi.c
+@@ -178,7 +178,9 @@ void ff_pred8x8l_top_dc_8_mmi(uint8_t *src, int has_topleft,
+ 
+         "1:                                                             \n\t"
+         "bnez       %[has_topright],            2f                      \n\t"
+-        "pinsrh_3   %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
++        "dli        %[tmp0],    0xa4                                    \n\t"
++        "mtc1       %[tmp0],    %[ftmp1]                                \n\t"
++        "pshufh     %[ftmp2],   %[ftmp2],       %[ftmp1]                \n\t"
+ 
+         "2:                                                             \n\t"
+         "dli        %[tmp0],    0x02                                    \n\t"
+@@ -370,7 +372,9 @@ void ff_pred8x8l_vertical_8_mmi(uint8_t *src, int has_topleft,
+ 
+         "1:                                                             \n\t"
+         "bnez       %[has_topright],            2f                      \n\t"
+-        "pinsrh_3   %[ftmp11],  %[ftmp11],      %[ftmp9]                \n\t"
++        "dli        %[tmp0],    0xa4                                    \n\t"
++        "mtc1       %[tmp0],    %[ftmp1]                                \n\t"
++        "pshufh     %[ftmp11],  %[ftmp11],      %[ftmp1]                \n\t"
+ 
+         "2:                                                             \n\t"
+         "dli        %[tmp0],    0x02                                    \n\t"
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0022-avcodec-mips-Add-switch-for-MADD-instruction.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0022-avcodec-mips-Add-switch-for-MADD-instruction.patch
@@ -1,0 +1,670 @@
+From 3b23abf1ec991410c1bee36b7b9c658cade7d2b1 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 17 Feb 2021 22:27:11 +0800
+Subject: [PATCH 22/26] avcodec/mips: Add switch for MADD instruction
+
+MADD.{d,s} is only available after MIPS IV and being dropped
+in MIPS R6 (Replaced by FMADD).
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+---
+ configure                                 | 5 +++++
+ libavcodec/mips/aaccoder_mips.c           | 8 ++++----
+ libavcodec/mips/aacdec_mips.h             | 4 ++--
+ libavcodec/mips/aacpsdsp_mips.c           | 8 ++++----
+ libavcodec/mips/aacpsy_mips.h             | 4 ++--
+ libavcodec/mips/aacsbr_mips.c             | 8 ++++----
+ libavcodec/mips/aacsbr_mips.h             | 4 ++--
+ libavcodec/mips/ac3dsp_mips.c             | 6 +++---
+ libavcodec/mips/acelp_filters_mips.c      | 6 +++---
+ libavcodec/mips/acelp_vectors_mips.c      | 6 +++---
+ libavcodec/mips/amrwbdec_mips.c           | 4 ++--
+ libavcodec/mips/amrwbdec_mips.h           | 2 +-
+ libavcodec/mips/celp_filters_mips.c       | 6 +++---
+ libavcodec/mips/celp_math_mips.c          | 6 +++---
+ libavcodec/mips/compute_antialias_float.h | 4 ++--
+ libavcodec/mips/fft_mips.c                | 6 +++---
+ libavcodec/mips/iirfilter_mips.c          | 8 ++++----
+ libavcodec/mips/lsp_mips.h                | 4 ++--
+ libavcodec/mips/mpegaudiodsp_mips_fixed.c | 6 +++---
+ libavcodec/mips/mpegaudiodsp_mips_float.c | 6 +++---
+ libavcodec/mips/sbrdsp_mips.c             | 8 ++++----
+ libavutil/mips/float_dsp_mips.c           | 8 ++++----
+ 22 files changed, 66 insertions(+), 61 deletions(-)
+
+diff --git a/configure b/configure
+index 0c8d2870f1..11e09ef96b 100755
+--- a/configure
++++ b/configure
+@@ -444,6 +444,7 @@ Optimization options (experts only):
+   --disable-msa            disable MSA optimizations
+   --disable-msa2           disable MSA2 optimizations
+   --disable-mipsfpu        disable floating point MIPS optimizations
++  --disable-mipsmadd       disable MIPS MADD optimizations
+   --disable-mmi            disable Loongson SIMD optimizations
+   --disable-fast-unaligned consider unaligned accesses slow
+ 
+@@ -2005,6 +2006,7 @@ ARCH_EXT_LIST_MIPS="
+     mips64r6
+     mipsdsp
+     mipsdspr2
++    mipsmadd
+     msa
+     msa2
+ "
+@@ -2533,6 +2535,7 @@ mips64r6_deps="mips"
+ mipsfpu_deps="mips"
+ mipsdsp_deps="mips"
+ mipsdspr2_deps="mips"
++mipsmadd_deps="mipsfpu"
+ mmi_deps_any="loongson2 loongson3"
+ msa_deps="mipsfpu"
+ msa2_deps="msa"
+@@ -5784,6 +5787,7 @@ elif enabled mips; then
+ 
+     enabled mipsfpu && check_inline_asm mipsfpu '"cvt.d.l $f0, $f2"'
+     enabled mipsfpu && (enabled mips32r5 || enabled mips32r6 || enabled mips64r6) && check_inline_asm_flags mipsfpu '"cvt.d.l $f0, $f1"' '-mfp64'
++    enabled mipsfpu && enabled mipsmadd && check_inline_asm mipsmadd '"madd.s $f1,$f1,$f6,$f7"'
+ 
+     enabled mipsdsp && check_inline_asm_flags mipsdsp '"addu.qb $t0, $t1, $t2"' '-mdsp'
+     enabled mipsdspr2 && check_inline_asm_flags mipsdspr2 '"absq_s.qb $t0, $t1"' '-mdspr2'
+@@ -7176,6 +7180,7 @@ if enabled mips; then
+     echo "MIPS FPU enabled          ${mipsfpu-no}"
+     echo "MIPS DSP R1 enabled       ${mipsdsp-no}"
+     echo "MIPS DSP R2 enabled       ${mipsdspr2-no}"
++    echo "MIPS MADD enabled         ${mipsmadd-no}"
+     echo "MIPS MSA enabled          ${msa-no}"
+     echo "MIPS MSA2 enabled         ${msa2-no}"
+     echo "LOONGSON MMI enabled      ${mmi-no}"
+diff --git a/libavcodec/mips/aaccoder_mips.c b/libavcodec/mips/aaccoder_mips.c
+index d690c8c24a..5ea147bccb 100644
+--- a/libavcodec/mips/aaccoder_mips.c
++++ b/libavcodec/mips/aaccoder_mips.c
+@@ -66,7 +66,7 @@
+ #include "libavcodec/aacenc_utils.h"
+ 
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ typedef struct BandCodingPath {
+     int prev_idx;
+     float cost;
+@@ -2478,12 +2478,12 @@ static void search_for_ms_mips(AACEncContext *s, ChannelElement *cpe)
+ 
+ #include "libavcodec/aaccoder_trellis.h"
+ 
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM */
+ 
+ void ff_aac_coder_init_mips(AACEncContext *c) {
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     AACCoefficientsEncoder *e = c->coder;
+     int option = c->options.coder;
+ 
+@@ -2497,6 +2497,6 @@ void ff_aac_coder_init_mips(AACEncContext *c) {
+ #if HAVE_MIPSFPU
+     e->search_for_ms            = search_for_ms_mips;
+ #endif /* HAVE_MIPSFPU */
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM */
+ }
+diff --git a/libavcodec/mips/aacdec_mips.h b/libavcodec/mips/aacdec_mips.h
+index 758266fc16..7488415aaa 100644
+--- a/libavcodec/mips/aacdec_mips.h
++++ b/libavcodec/mips/aacdec_mips.h
+@@ -61,7 +61,7 @@
+ #include "libavutil/mips/asmdefs.h"
+ 
+ #if HAVE_INLINE_ASM && HAVE_MIPSFPU
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static inline float *VMUL2_mips(float *dst, const float *v, unsigned idx,
+                            const float *scale)
+ {
+@@ -247,7 +247,7 @@ static inline float *VMUL4S_mips(float *dst, const float *v, unsigned idx,
+ #define VMUL4 VMUL4_mips
+ #define VMUL2S VMUL2S_mips
+ #define VMUL4S VMUL4S_mips
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM && HAVE_MIPSFPU */
+ 
+ #endif /* AVCODEC_MIPS_AACDEC_MIPS_H */
+diff --git a/libavcodec/mips/aacpsdsp_mips.c b/libavcodec/mips/aacpsdsp_mips.c
+index f63541330d..d3fd975bcc 100644
+--- a/libavcodec/mips/aacpsdsp_mips.c
++++ b/libavcodec/mips/aacpsdsp_mips.c
+@@ -188,7 +188,7 @@ static void ps_hybrid_synthesis_deint_mips(float out[2][38][64],
+     }
+ }
+ 
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static void ps_add_squares_mips(float *dst, const float (*src)[2], int n)
+ {
+     int i;
+@@ -444,7 +444,7 @@ static void ps_stereo_interpolate_mips(float (*l)[2], float (*r)[2],
+         : "memory"
+     );
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_MIPSFPU */
+ #endif /* HAVE_INLINE_ASM */
+ 
+@@ -454,12 +454,12 @@ void ff_psdsp_init_mips(PSDSPContext *s)
+ #if HAVE_MIPSFPU
+     s->hybrid_analysis_ileave = ps_hybrid_analysis_ileave_mips;
+     s->hybrid_synthesis_deint = ps_hybrid_synthesis_deint_mips;
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     s->add_squares            = ps_add_squares_mips;
+     s->mul_pair_single        = ps_mul_pair_single_mips;
+     s->decorrelate            = ps_decorrelate_mips;
+     s->stereo_interpolate[0]  = ps_stereo_interpolate_mips;
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_MIPSFPU */
+ #endif /* HAVE_INLINE_ASM */
+ }
+diff --git a/libavcodec/mips/aacpsy_mips.h b/libavcodec/mips/aacpsy_mips.h
+index 7d27d32f18..dcd5d13408 100644
+--- a/libavcodec/mips/aacpsy_mips.h
++++ b/libavcodec/mips/aacpsy_mips.h
+@@ -59,7 +59,7 @@
+ #include "libavutil/mips/asmdefs.h"
+ 
+ #if HAVE_INLINE_ASM && HAVE_MIPSFPU && ( PSY_LAME_FIR_LEN == 21 )
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static void calc_thr_3gpp_mips(const FFPsyWindowInfo *wi, const int num_bands,
+                                AacPsyChannel *pch, const uint8_t *band_sizes,
+                                const float *coefs, const int cutoff)
+@@ -233,6 +233,6 @@ static void psy_hp_filter_mips(const float *firbuf, float *hpfsmpl, const float
+ #define calc_thr_3gpp calc_thr_3gpp_mips
+ #define psy_hp_filter psy_hp_filter_mips
+ 
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM && HAVE_MIPSFPU */
+ #endif /* AVCODEC_MIPS_AACPSY_MIPS_H */
+diff --git a/libavcodec/mips/aacsbr_mips.c b/libavcodec/mips/aacsbr_mips.c
+index 5ef5e68371..0e5a84d539 100644
+--- a/libavcodec/mips/aacsbr_mips.c
++++ b/libavcodec/mips/aacsbr_mips.c
+@@ -311,7 +311,7 @@ static int sbr_x_gen_mips(SpectralBandReplication *sbr, float X[2][38][64],
+       return 0;
+ }
+ 
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static void sbr_hf_assemble_mips(float Y1[38][64][2],
+                             const float X_high[64][40][2],
+                             SpectralBandReplication *sbr, SBRData *ch_data,
+@@ -604,7 +604,7 @@ static void sbr_hf_inverse_filter_mips(SBRDSPContext *dsp,
+         }
+     }
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_MIPSFPU */
+ #endif /* HAVE_INLINE_ASM */
+ 
+@@ -614,10 +614,10 @@ void ff_aacsbr_func_ptr_init_mips(AACSBRContext *c)
+ #if HAVE_MIPSFPU
+     c->sbr_lf_gen            = sbr_lf_gen_mips;
+     c->sbr_x_gen             = sbr_x_gen_mips;
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     c->sbr_hf_inverse_filter = sbr_hf_inverse_filter_mips;
+     c->sbr_hf_assemble       = sbr_hf_assemble_mips;
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_MIPSFPU */
+ #endif /* HAVE_INLINE_ASM */
+ }
+diff --git a/libavcodec/mips/aacsbr_mips.h b/libavcodec/mips/aacsbr_mips.h
+index 4461e763ed..88a2a9e93a 100644
+--- a/libavcodec/mips/aacsbr_mips.h
++++ b/libavcodec/mips/aacsbr_mips.h
+@@ -150,7 +150,7 @@ static void sbr_qmf_analysis_mips(AVFloatDSPContext *fdsp, FFTContext *mdct,
+ }
+ 
+ #if HAVE_MIPSFPU
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static void sbr_qmf_synthesis_mips(FFTContext *mdct,
+                               SBRDSPContext *sbrdsp, AVFloatDSPContext *fdsp,
+                               float *out, float X[2][38][64],
+@@ -489,7 +489,7 @@ static void sbr_qmf_synthesis_mips(FFTContext *mdct,
+ #define sbr_qmf_analysis sbr_qmf_analysis_mips
+ #define sbr_qmf_synthesis sbr_qmf_synthesis_mips
+ 
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_MIPSFPU */
+ #endif /* HAVE_INLINE_ASM */
+ 
+diff --git a/libavcodec/mips/ac3dsp_mips.c b/libavcodec/mips/ac3dsp_mips.c
+index e5cee16081..066fc8982b 100644
+--- a/libavcodec/mips/ac3dsp_mips.c
++++ b/libavcodec/mips/ac3dsp_mips.c
+@@ -201,7 +201,7 @@ static void ac3_update_bap_counts_mips(uint16_t mant_cnt[16], uint8_t *bap,
+ #endif
+ 
+ #if HAVE_MIPSFPU
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static void float_to_fixed24_mips(int32_t *dst, const float *src, unsigned int len)
+ {
+     const float scale = 1 << 24;
+@@ -396,7 +396,7 @@ static void ac3_downmix_mips(float **samples, float (*matrix)[2],
+         :"memory"
+     );
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_MIPSFPU */
+ #endif /* HAVE_INLINE_ASM */
+ 
+@@ -407,7 +407,7 @@ void ff_ac3dsp_init_mips(AC3DSPContext *c, int bit_exact) {
+     c->update_bap_counts  = ac3_update_bap_counts_mips;
+ #endif
+ #if HAVE_MIPSFPU
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     c->float_to_fixed24 = float_to_fixed24_mips;
+     //c->downmix          = ac3_downmix_mips;
+ #endif
+diff --git a/libavcodec/mips/acelp_filters_mips.c b/libavcodec/mips/acelp_filters_mips.c
+index 478db855b2..bc6baee313 100644
+--- a/libavcodec/mips/acelp_filters_mips.c
++++ b/libavcodec/mips/acelp_filters_mips.c
+@@ -57,7 +57,7 @@
+ #include "libavutil/mips/asmdefs.h"
+ 
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static void ff_acelp_interpolatef_mips(float *out, const float *in,
+                            const float *filter_coeffs, int precision,
+                            int frac_pos, int filter_length, int length)
+@@ -207,13 +207,13 @@ static void ff_acelp_apply_order_2_transfer_function_mips(float *out, const floa
+            "$f12", "$f13", "$f14", "$f15", "$f16", "memory"
+     );
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM */
+ 
+ void ff_acelp_filter_init_mips(ACELPFContext *c)
+ {
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     c->acelp_interpolatef                      = ff_acelp_interpolatef_mips;
+     c->acelp_apply_order_2_transfer_function   = ff_acelp_apply_order_2_transfer_function_mips;
+ #endif
+diff --git a/libavcodec/mips/acelp_vectors_mips.c b/libavcodec/mips/acelp_vectors_mips.c
+index 0ab2b6a87b..dca9442462 100644
+--- a/libavcodec/mips/acelp_vectors_mips.c
++++ b/libavcodec/mips/acelp_vectors_mips.c
+@@ -57,7 +57,7 @@
+ #include "libavutil/mips/asmdefs.h"
+ 
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static void ff_weighted_vector_sumf_mips(
+                   float *out, const float *in_a, const float *in_b,
+                   float weight_coeff_a, float weight_coeff_b, int length)
+@@ -93,13 +93,13 @@ static void ff_weighted_vector_sumf_mips(
+         : "$f0", "$f1", "$f2", "$f3", "$f4", "$f5", "memory"
+     );
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM */
+ 
+ void ff_acelp_vectors_init_mips(ACELPVContext *c)
+ {
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     c->weighted_vector_sumf = ff_weighted_vector_sumf_mips;
+ #endif
+ #endif
+diff --git a/libavcodec/mips/amrwbdec_mips.c b/libavcodec/mips/amrwbdec_mips.c
+index 5dc054361b..3509db65dc 100644
+--- a/libavcodec/mips/amrwbdec_mips.c
++++ b/libavcodec/mips/amrwbdec_mips.c
+@@ -54,7 +54,7 @@
+ #include "amrwbdec_mips.h"
+ 
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ void ff_hb_fir_filter_mips(float *out, const float fir_coef[HB_FIR_SIZE + 1],
+                           float mem[HB_FIR_SIZE], const float *in)
+ {
+@@ -185,5 +185,5 @@ void ff_hb_fir_filter_mips(float *out, const float fir_coef[HB_FIR_SIZE + 1],
+     }
+     memcpy(mem, data + AMRWB_SFR_SIZE_16k, HB_FIR_SIZE * sizeof(float));
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM */
+diff --git a/libavcodec/mips/amrwbdec_mips.h b/libavcodec/mips/amrwbdec_mips.h
+index a9f66fef94..911927745c 100644
+--- a/libavcodec/mips/amrwbdec_mips.h
++++ b/libavcodec/mips/amrwbdec_mips.h
+@@ -54,7 +54,7 @@
+ #include "config.h"
+ 
+ #if HAVE_MIPSFPU && HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ void ff_hb_fir_filter_mips(float *out, const float fir_coef[],
+                           float mem[], const float *in);
+ #define hb_fir_filter ff_hb_fir_filter_mips
+diff --git a/libavcodec/mips/celp_filters_mips.c b/libavcodec/mips/celp_filters_mips.c
+index 926f1cb334..5b040b8cf9 100644
+--- a/libavcodec/mips/celp_filters_mips.c
++++ b/libavcodec/mips/celp_filters_mips.c
+@@ -58,7 +58,7 @@
+ #include "libavutil/mips/asmdefs.h"
+ 
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static void ff_celp_lp_synthesis_filterf_mips(float *out,
+                                   const float *filter_coeffs,
+                                   const float* in, int buffer_length,
+@@ -279,13 +279,13 @@ static void ff_celp_lp_zero_synthesis_filterf_mips(float *out,
+         out[n] = sum_out1;
+     }
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM */
+ 
+ void ff_celp_filter_init_mips(CELPFContext *c)
+ {
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     c->celp_lp_synthesis_filterf        = ff_celp_lp_synthesis_filterf_mips;
+     c->celp_lp_zero_synthesis_filterf   = ff_celp_lp_zero_synthesis_filterf_mips;
+ #endif
+diff --git a/libavcodec/mips/celp_math_mips.c b/libavcodec/mips/celp_math_mips.c
+index ce711bd63c..101e65b782 100644
+--- a/libavcodec/mips/celp_math_mips.c
++++ b/libavcodec/mips/celp_math_mips.c
+@@ -56,7 +56,7 @@
+ #include "libavutil/mips/asmdefs.h"
+ 
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static float ff_dot_productf_mips(const float* a, const float* b,
+                                               int length)
+ {
+@@ -81,13 +81,13 @@ static float ff_dot_productf_mips(const float* a, const float* b,
+     );
+     return sum;
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM */
+ 
+ void ff_celp_math_init_mips(CELPMContext *c)
+ {
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     c->dot_productf = ff_dot_productf_mips;
+ #endif
+ #endif
+diff --git a/libavcodec/mips/compute_antialias_float.h b/libavcodec/mips/compute_antialias_float.h
+index e2b4f29f4a..e0d83ee39b 100644
+--- a/libavcodec/mips/compute_antialias_float.h
++++ b/libavcodec/mips/compute_antialias_float.h
+@@ -58,7 +58,7 @@
+ #include "libavutil/mips/asmdefs.h"
+ 
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static void compute_antialias_mips_float(MPADecodeContext *s,
+                                         GranuleDef *g)
+ {
+@@ -180,7 +180,7 @@ static void compute_antialias_mips_float(MPADecodeContext *s,
+     );
+ }
+ #define compute_antialias compute_antialias_mips_float
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM */
+ 
+ #endif /* AVCODEC_MIPS_COMPUTE_ANTIALIAS_FLOAT_H */
+diff --git a/libavcodec/mips/fft_mips.c b/libavcodec/mips/fft_mips.c
+index 69abdc8a08..7e30dafdbe 100644
+--- a/libavcodec/mips/fft_mips.c
++++ b/libavcodec/mips/fft_mips.c
+@@ -57,7 +57,7 @@
+  */
+ 
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static void ff_fft_calc_mips(FFTContext *s, FFTComplex *z)
+ {
+     int nbits, i, n, num_transforms, offset, step;
+@@ -495,7 +495,7 @@ static void ff_imdct_calc_mips(FFTContext *s, FFTSample *output, const FFTSample
+         output[n-k-4] = output[n2+k+3];
+     }
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM */
+ 
+ av_cold void ff_fft_init_mips(FFTContext *s)
+@@ -506,7 +506,7 @@ av_cold void ff_fft_init_mips(FFTContext *s)
+     ff_init_ff_cos_tabs(17);
+ 
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     s->fft_calc     = ff_fft_calc_mips;
+ #if CONFIG_MDCT
+     s->imdct_calc   = ff_imdct_calc_mips;
+diff --git a/libavcodec/mips/iirfilter_mips.c b/libavcodec/mips/iirfilter_mips.c
+index 3a1352a7e4..e7d6bbef09 100644
+--- a/libavcodec/mips/iirfilter_mips.c
++++ b/libavcodec/mips/iirfilter_mips.c
+@@ -56,7 +56,7 @@
+ #include "libavcodec/iirfilter.h"
+ 
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ typedef struct FFIIRFilterCoeffs {
+     int   order;
+     float gain;
+@@ -197,13 +197,13 @@ static void iir_filter_flt_mips(const struct FFIIRFilterCoeffs *c,
+         }
+     }
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM */
+ 
+ void ff_iir_filter_init_mips(FFIIRFilterContext *f) {
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     f->filter_flt = iir_filter_flt_mips;
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM */
+ }
+diff --git a/libavcodec/mips/lsp_mips.h b/libavcodec/mips/lsp_mips.h
+index 6219c5aa40..86072d7ab0 100644
+--- a/libavcodec/mips/lsp_mips.h
++++ b/libavcodec/mips/lsp_mips.h
+@@ -55,7 +55,7 @@
+ #define AVCODEC_MIPS_LSP_MIPS_H
+ 
+ #if HAVE_MIPSFPU && HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ #include "libavutil/mips/asmdefs.h"
+ 
+ static av_always_inline void ff_lsp2polyf_mips(const double *lsp, double *f, int lp_half_order)
+@@ -108,6 +108,6 @@ static av_always_inline void ff_lsp2polyf_mips(const double *lsp, double *f, int
+     }
+ }
+ #define ff_lsp2polyf ff_lsp2polyf_mips
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_MIPSFPU && HAVE_INLINE_ASM */
+ #endif /* AVCODEC_MIPS_LSP_MIPS_H */
+diff --git a/libavcodec/mips/mpegaudiodsp_mips_fixed.c b/libavcodec/mips/mpegaudiodsp_mips_fixed.c
+index 1c9c68d23c..1b7b7211bb 100644
+--- a/libavcodec/mips/mpegaudiodsp_mips_fixed.c
++++ b/libavcodec/mips/mpegaudiodsp_mips_fixed.c
+@@ -58,7 +58,7 @@
+ #include "libavcodec/mpegaudiodsp.h"
+ 
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ 
+ static void ff_mpadsp_apply_window_mips_fixed(int32_t *synth_buf, int32_t *window,
+                                int *dither_state, int16_t *samples, ptrdiff_t incr)
+@@ -904,13 +904,13 @@ static void ff_imdct36_blocks_mips_fixed(int *out, int *buf, int *in,
+     }
+ }
+ 
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM */
+ 
+ void ff_mpadsp_init_mipsdsp(MPADSPContext *s)
+ {
+ #if HAVE_INLINE_ASM
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     s->apply_window_fixed   = ff_mpadsp_apply_window_mips_fixed;
+     s->imdct36_blocks_fixed = ff_imdct36_blocks_mips_fixed;
+ #endif
+diff --git a/libavcodec/mips/mpegaudiodsp_mips_float.c b/libavcodec/mips/mpegaudiodsp_mips_float.c
+index ae130c752e..ba4443c928 100644
+--- a/libavcodec/mips/mpegaudiodsp_mips_float.c
++++ b/libavcodec/mips/mpegaudiodsp_mips_float.c
+@@ -59,7 +59,7 @@
+ #include "libavcodec/mpegaudiodsp.h"
+ 
+ #if HAVE_INLINE_ASM && HAVE_MIPSFPU
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ 
+ static void ff_mpadsp_apply_window_mips_float(float *synth_buf, float *window,
+                                int *dither_state, float *samples, ptrdiff_t incr)
+@@ -1242,13 +1242,13 @@ static void ff_imdct36_blocks_mips_float(float *out, float *buf, float *in,
+     }
+ }
+ 
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM && HAVE_MIPSFPU */
+ 
+ void ff_mpadsp_init_mipsfpu(MPADSPContext *s)
+ {
+ #if HAVE_INLINE_ASM && HAVE_MIPSFPU
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     s->apply_window_float   = ff_mpadsp_apply_window_mips_float;
+     s->imdct36_blocks_float = ff_imdct36_blocks_mips_float;
+     s->dct32_float          = ff_dct32_mips_float;
+diff --git a/libavcodec/mips/sbrdsp_mips.c b/libavcodec/mips/sbrdsp_mips.c
+index 1c87c99251..a0b783faa8 100644
+--- a/libavcodec/mips/sbrdsp_mips.c
++++ b/libavcodec/mips/sbrdsp_mips.c
+@@ -166,7 +166,7 @@ static void sbr_qmf_post_shuffle_mips(float W[32][2], const float *z)
+     );
+ }
+ 
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static void sbr_sum64x5_mips(float *z)
+ {
+     int k;
+@@ -884,7 +884,7 @@ static void sbr_hf_apply_noise_3_mips(float (*Y)[2], const float *s_m,
+        phi_sign = -phi_sign;
+     }
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_MIPSFPU */
+ #endif /* HAVE_INLINE_ASM */
+ 
+@@ -894,7 +894,7 @@ void ff_sbrdsp_init_mips(SBRDSPContext *s)
+ #if HAVE_MIPSFPU
+     s->qmf_pre_shuffle = sbr_qmf_pre_shuffle_mips;
+     s->qmf_post_shuffle = sbr_qmf_post_shuffle_mips;
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     s->sum64x5 = sbr_sum64x5_mips;
+     s->sum_square = sbr_sum_square_mips;
+     s->qmf_deint_bfly = sbr_qmf_deint_bfly_mips;
+@@ -906,7 +906,7 @@ void ff_sbrdsp_init_mips(SBRDSPContext *s)
+     s->hf_apply_noise[1] = sbr_hf_apply_noise_1_mips;
+     s->hf_apply_noise[2] = sbr_hf_apply_noise_2_mips;
+     s->hf_apply_noise[3] = sbr_hf_apply_noise_3_mips;
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_MIPSFPU */
+ #endif /* HAVE_INLINE_ASM */
+ }
+diff --git a/libavutil/mips/float_dsp_mips.c b/libavutil/mips/float_dsp_mips.c
+index 0943d6f343..8e8c00bda1 100644
+--- a/libavutil/mips/float_dsp_mips.c
++++ b/libavutil/mips/float_dsp_mips.c
+@@ -56,7 +56,7 @@
+ #include "libavutil/mips/asmdefs.h"
+ 
+ #if HAVE_INLINE_ASM && HAVE_MIPSFPU
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+ static void vector_fmul_mips(float *dst, const float *src0, const float *src1,
+                              int len)
+ {
+@@ -340,17 +340,17 @@ static void vector_fmul_reverse_mips(float *dst, const float *src0, const float
+         );
+     }
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM && HAVE_MIPSFPU */
+ 
+ void ff_float_dsp_init_mips(AVFloatDSPContext *fdsp) {
+ #if HAVE_INLINE_ASM && HAVE_MIPSFPU
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if HAVE_MIPSMADD
+     fdsp->vector_fmul = vector_fmul_mips;
+     fdsp->vector_fmul_scalar  = vector_fmul_scalar_mips;
+     fdsp->vector_fmul_window = vector_fmul_window_mips;
+     fdsp->butterflies_float = butterflies_float_mips;
+     fdsp->vector_fmul_reverse = vector_fmul_reverse_mips;
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* HAVE_MIPSMADD */
+ #endif /* HAVE_INLINE_ASM && HAVE_MIPSFPU */
+ }
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0023-avutil-mips-Use-MMI_-L-S-QC1-macro-in-SAVE-RECOVER-_.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0023-avutil-mips-Use-MMI_-L-S-QC1-macro-in-SAVE-RECOVER-_.patch
@@ -1,0 +1,84 @@
+From 7cdb9984081b650b343c424eb026e29f3218e4b8 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Thu, 18 Feb 2021 15:34:04 +0800
+Subject: [PATCH 23/26] avutil/mips: Use MMI_{L,S}QC1 macro in
+ {SAVE,RECOVER}_REG
+
+{SAVE,RECOVER}_REG will be avilable for Loongson2 again,
+also comment about the magic.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+---
+ libavutil/mips/mmiutils.h | 32 +++++++++++++++++---------------
+ 1 file changed, 17 insertions(+), 15 deletions(-)
+
+diff --git a/libavutil/mips/mmiutils.h b/libavutil/mips/mmiutils.h
+index 8f692e86c5..fb85a4dd1b 100644
+--- a/libavutil/mips/mmiutils.h
++++ b/libavutil/mips/mmiutils.h
+@@ -202,25 +202,27 @@
+ #endif /* HAVE_LOONGSON2 */
+ 
+ /**
+- * backup register
++ * Backup saved registers
++ * We're not using compiler's clobber list as it's not smart enough
++ * to take advantage of quad word load/store.
+  */
+ #define BACKUP_REG \
+   LOCAL_ALIGNED_16(double, temp_backup_reg, [8]);               \
+   if (_MIPS_SIM == _ABI64)                                      \
+     __asm__ volatile (                                          \
+-      "gssqc1       $f25,      $f24,       0x00(%[temp])  \n\t" \
+-      "gssqc1       $f27,      $f26,       0x10(%[temp])  \n\t" \
+-      "gssqc1       $f29,      $f28,       0x20(%[temp])  \n\t" \
+-      "gssqc1       $f31,      $f30,       0x30(%[temp])  \n\t" \
++      MMI_SQC1($f25, $f24, %[temp], 0x00)                       \
++      MMI_SQC1($f27, $f26, %[temp], 0x10)                       \
++      MMI_SQC1($f29, $f28, %[temp], 0x20)                       \
++      MMI_SQC1($f31, $f30, %[temp], 0x30)                       \
+       :                                                         \
+       : [temp]"r"(temp_backup_reg)                              \
+       : "memory"                                                \
+     );                                                          \
+   else                                                          \
+     __asm__ volatile (                                          \
+-      "gssqc1       $f22,      $f20,       0x00(%[temp])  \n\t" \
+-      "gssqc1       $f26,      $f24,       0x10(%[temp])  \n\t" \
+-      "gssqc1       $f30,      $f28,       0x20(%[temp])  \n\t" \
++      MMI_SQC1($f22, $f20, %[temp], 0x10)                       \
++      MMI_SQC1($f26, $f24, %[temp], 0x10)                       \
++      MMI_SQC1($f30, $f28, %[temp], 0x20)                       \
+       :                                                         \
+       : [temp]"r"(temp_backup_reg)                              \
+       : "memory"                                                \
+@@ -232,19 +234,19 @@
+ #define RECOVER_REG \
+   if (_MIPS_SIM == _ABI64)                                      \
+     __asm__ volatile (                                          \
+-      "gslqc1       $f25,      $f24,       0x00(%[temp])  \n\t" \
+-      "gslqc1       $f27,      $f26,       0x10(%[temp])  \n\t" \
+-      "gslqc1       $f29,      $f28,       0x20(%[temp])  \n\t" \
+-      "gslqc1       $f31,      $f30,       0x30(%[temp])  \n\t" \
++      MMI_LQC1($f25, $f24, %[temp], 0x00)                       \
++      MMI_LQC1($f27, $f26, %[temp], 0x10)                       \
++      MMI_LQC1($f29, $f28, %[temp], 0x20)                       \
++      MMI_LQC1($f31, $f30, %[temp], 0x30)                       \
+       :                                                         \
+       : [temp]"r"(temp_backup_reg)                              \
+       : "memory"                                                \
+     );                                                          \
+   else                                                          \
+     __asm__ volatile (                                          \
+-      "gslqc1       $f22,      $f20,       0x00(%[temp])  \n\t" \
+-      "gslqc1       $f26,      $f24,       0x10(%[temp])  \n\t" \
+-      "gslqc1       $f30,      $f28,       0x20(%[temp])  \n\t" \
++      MMI_LQC1($f22, $f20, %[temp], 0x10)                       \
++      MMI_LQC1($f26, $f24, %[temp], 0x10)                       \
++      MMI_LQC1($f30, $f28, %[temp], 0x20)                       \
+       :                                                         \
+       : [temp]"r"(temp_backup_reg)                              \
+       : "memory"                                                \
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0024-avutil-mips-Extract-load-store-with-shift-C1-pair-ma.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0024-avutil-mips-Extract-load-store-with-shift-C1-pair-ma.patch
@@ -1,0 +1,142 @@
+From 1d72afd327a6b628eef7f692acc4fb95159b351c Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Thu, 18 Feb 2021 15:58:25 +0800
+Subject: [PATCH 24/26] avutil/mips: Extract load store with shift C1 pair
+ marco
+
+We're doing some fancy hacks with load store with shift C1
+beside unaligned load store. Create a marco for l/r pair
+to allow us use it in these places.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+---
+ libavutil/mips/mmiutils.h | 49 ++++++++++++++++++++++++---------------
+ 1 file changed, 30 insertions(+), 19 deletions(-)
+
+diff --git a/libavutil/mips/mmiutils.h b/libavutil/mips/mmiutils.h
+index fb85a4dd1b..3994085057 100644
+--- a/libavutil/mips/mmiutils.h
++++ b/libavutil/mips/mmiutils.h
+@@ -55,8 +55,9 @@
+ #define MMI_LWC1(fp, addr, bias)                                            \
+     "lwc1       "#fp",      "#bias"("#addr")                        \n\t"
+ 
+-#define MMI_ULWC1(fp, addr, bias)                                           \
+-    "ulw        %[low32],   "#bias"("#addr")                        \n\t"   \
++#define MMI_LWLRC1(fp, addr, bias, off)                                     \
++    "lwl        %[low32],   "#bias"+"#off"("#addr")                 \n\t"   \
++    "lwr        %[low32],   "#bias"("#addr")                        \n\t"   \
+     "mtc1       %[low32],   "#fp"                                   \n\t"
+ 
+ #define MMI_LWXC1(fp, addr, stride, bias)                                   \
+@@ -66,9 +67,10 @@
+ #define MMI_SWC1(fp, addr, bias)                                            \
+     "swc1       "#fp",      "#bias"("#addr")                        \n\t"
+ 
+-#define MMI_USWC1(fp, addr, bias)                                           \
++#define MMI_SWLRC1(fp, addr, bias, off)                                           \
+     "mfc1       %[low32],   "#fp"                                   \n\t"   \
+-    "usw        %[low32],   "#bias"("#addr")                        \n\t"
++    "swl        %[low32],   "#bias"+"#off"("#addr")                 \n\t"   \
++    "swr        %[low32],   "#bias"("#addr")                        \n\t"
+ 
+ #define MMI_SWXC1(fp, addr, stride, bias)                                   \
+     PTR_ADDU    "%[addrt],  "#addr",    "#stride"                   \n\t"   \
+@@ -77,8 +79,9 @@
+ #define MMI_LDC1(fp, addr, bias)                                            \
+     "ldc1       "#fp",      "#bias"("#addr")                        \n\t"
+ 
+-#define MMI_ULDC1(fp, addr, bias)                                           \
+-    "uld        %[all64],   "#bias"("#addr")                        \n\t"   \
++#define MMI_LDLRC1(fp, addr, bias, off)                                     \
++    "ldl        %[all64],   "#bias"+"#off"("#addr")                 \n\t"   \
++    "ldr        %[all64],   "#bias"("#addr")                        \n\t"   \
+     "dmtc1      %[all64],   "#fp"                                   \n\t"
+ 
+ #define MMI_LDXC1(fp, addr, stride, bias)                                   \
+@@ -88,9 +91,10 @@
+ #define MMI_SDC1(fp, addr, bias)                                            \
+     "sdc1       "#fp",      "#bias"("#addr")                        \n\t"
+ 
+-#define MMI_USDC1(fp, addr, bias)                                           \
++#define MMI_SDLRC1(fp, addr, bias, off)                                           \
+     "dmfc1      %[all64],   "#fp"                                   \n\t"   \
+-    "usd        %[all64],   "#bias"("#addr")                        \n\t"
++    "sdl        %[all64],   "#bias"+"#off"("#addr")                 \n\t"   \
++    "sdr        %[all64],   "#bias"("#addr")                        \n\t"
+ 
+ #define MMI_SDXC1(fp, addr, stride, bias)                                   \
+     PTR_ADDU    "%[addrt],  "#addr",    "#stride"                   \n\t"   \
+@@ -139,17 +143,18 @@
+ #define DECLARE_VAR_LOW32       int32_t low32
+ #define RESTRICT_ASM_LOW32      [low32]"=&r"(low32),
+ 
+-#define MMI_ULWC1(fp, addr, bias)                                           \
+-    "ulw        %[low32],   "#bias"("#addr")                        \n\t"   \
+-    "mtc1       %[low32],   "#fp"                                   \n\t"
++#define MMI_LWLRC1(fp, addr, bias, off)                                     \
++    "lwl        %[low32],   "#bias"+"#off"("#addr")                 \n\t"   \
++    "lwr        %[low32],   "#bias"("#addr")                        \n\t"   \
++    "mtc1       %[low32],   "#fp"                                      \n\t"
+ 
+ #else /* _MIPS_SIM != _ABIO32 */
+ 
+ #define DECLARE_VAR_LOW32
+ #define RESTRICT_ASM_LOW32
+ 
+-#define MMI_ULWC1(fp, addr, bias)                                           \
+-    "gslwlc1    "#fp",    3+"#bias"("#addr")                        \n\t"   \
++#define MMI_LWLRC1(fp, addr, bias, off)                                     \
++    "gslwlc1    "#fp",      "#off"+"#bias"("#addr")                 \n\t"   \
+     "gslwrc1    "#fp",      "#bias"("#addr")                        \n\t"
+ 
+ #endif /* _MIPS_SIM != _ABIO32 */
+@@ -160,8 +165,8 @@
+ #define MMI_SWC1(fp, addr, bias)                                            \
+     "swc1       "#fp",      "#bias"("#addr")                        \n\t"
+ 
+-#define MMI_USWC1(fp, addr, bias)                                           \
+-    "gsswlc1    "#fp",    3+"#bias"("#addr")                        \n\t"   \
++#define MMI_SWLRC1(fp, addr, bias, off)                                     \
++    "gsswlc1    "#fp",      "#off"+"#bias"("#addr")                 \n\t"   \
+     "gsswrc1    "#fp",      "#bias"("#addr")                        \n\t"
+ 
+ #define MMI_SWXC1(fp, addr, stride, bias)                                   \
+@@ -170,8 +175,8 @@
+ #define MMI_LDC1(fp, addr, bias)                                            \
+     "ldc1       "#fp",      "#bias"("#addr")                        \n\t"
+ 
+-#define MMI_ULDC1(fp, addr, bias)                                           \
+-    "gsldlc1    "#fp",    7+"#bias"("#addr")                        \n\t"   \
++#define MMI_LDLRC1(fp, addr, bias, off)                                     \
++    "gsldlc1    "#fp",      "#off"+"#bias"("#addr")                 \n\t"   \
+     "gsldrc1    "#fp",      "#bias"("#addr")                        \n\t"
+ 
+ #define MMI_LDXC1(fp, addr, stride, bias)                                   \
+@@ -180,8 +185,8 @@
+ #define MMI_SDC1(fp, addr, bias)                                            \
+     "sdc1       "#fp",      "#bias"("#addr")                        \n\t"
+ 
+-#define MMI_USDC1(fp, addr, bias)                                           \
+-    "gssdlc1    "#fp",    7+"#bias"("#addr")                        \n\t"   \
++#define MMI_SDLRC1(fp, addr, bias, off)                                           \
++    "gssdlc1    "#fp",      "#off"+"#bias"("#addr")                 \n\t"   \
+     "gssdrc1    "#fp",      "#bias"("#addr")                        \n\t"
+ 
+ #define MMI_SDXC1(fp, addr, stride, bias)                                   \
+@@ -201,6 +206,12 @@
+ 
+ #endif /* HAVE_LOONGSON2 */
+ 
++#define MMI_ULWC1(fp, addr, bias) MMI_LWLRC1(fp, addr, bias, 3)
++#define MMI_USWC1(fp, addr, bias) MMI_SWLRC1(fp, addr, bias, 3)
++
++#define MMI_ULDC1(fp, addr, bias) MMI_LDLRC1(fp, addr, bias, 7)
++#define MMI_USDC1(fp, addr, bias) MMI_SDLRC1(fp, addr, bias, 7)
++
+ /**
+  * Backup saved registers
+  * We're not using compiler's clobber list as it's not smart enough
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0025-avcodec-mips-Use-MMI-marcos-to-replace-Loongson3-ins.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0025-avcodec-mips-Use-MMI-marcos-to-replace-Loongson3-ins.patch
@@ -1,0 +1,1308 @@
+From 345b1946e369f0af631864581c47feb77b7df614 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Thu, 18 Feb 2021 17:02:07 +0800
+Subject: [PATCH 25/26] avcodec/mips: Use MMI marcos to replace Loongson3
+ instructions
+
+Loongson3's extention instructions (prefixed with gs) are widely used
+in our MMI codebase. However, these instructions are not avilable on
+Loongson-2E/F while MMI code should work on these processors.
+
+Previously we introduced mmiutils marcos to provide backward compactbility
+but newly commited code didn't follow that. In this patch I revewed the
+codebase and converted all these instructions into MMI marcos to get
+Loongson2 supproted again.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+---
+ libavcodec/mips/h264chroma_mmi.c  |  26 +++-
+ libavcodec/mips/h264dsp_mmi.c     |   8 +-
+ libavcodec/mips/hevcdsp_mmi.c     | 251 ++++++++++++------------------
+ libavcodec/mips/hpeldsp_mmi.c     |   1 +
+ libavcodec/mips/simple_idct_mmi.c |  49 +++---
+ libavcodec/mips/vp3dsp_idct_mmi.c |  11 +-
+ libavcodec/mips/vp8dsp_mmi.c      | 100 +++++-------
+ libavcodec/mips/vp9_mc_mmi.c      | 128 ++++++---------
+ 8 files changed, 245 insertions(+), 329 deletions(-)
+
+diff --git a/libavcodec/mips/h264chroma_mmi.c b/libavcodec/mips/h264chroma_mmi.c
+index 739dd7d4d6..b6ea1ba3b1 100644
+--- a/libavcodec/mips/h264chroma_mmi.c
++++ b/libavcodec/mips/h264chroma_mmi.c
+@@ -32,6 +32,7 @@ void ff_put_h264_chroma_mc8_mmi(uint8_t *dst, uint8_t *src, ptrdiff_t stride,
+     int A = 64, B, C, D, E;
+     double ftmp[12];
+     uint64_t tmp[1];
++    DECLARE_VAR_ALL64;
+ 
+     if (!(x || y)) {
+         /* x=0, y=0, A=64 */
+@@ -57,7 +58,8 @@ void ff_put_h264_chroma_mc8_mmi(uint8_t *dst, uint8_t *src, ptrdiff_t stride,
+             MMI_SDC1(%[ftmp3], %[dst], 0x00)
+             PTR_ADDU   "%[dst],     %[dst],         %[stride]          \n\t"
+             "bnez       %[h],       1b                                 \n\t"
+-            : [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
++            : RESTRICT_ASM_ALL64
++              [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
+               [ftmp2]"=&f"(ftmp[2]),        [ftmp3]"=&f"(ftmp[3]),
+               [dst]"+&r"(dst),              [src]"+&r"(src),
+               [h]"+&r"(h)
+@@ -152,7 +154,8 @@ void ff_put_h264_chroma_mc8_mmi(uint8_t *dst, uint8_t *src, ptrdiff_t stride,
+             MMI_SDC1(%[ftmp3], %[dst], 0x00)
+             PTR_ADDU   "%[dst],     %[dst],         %[stride]          \n\t"
+             "bnez       %[h],       1b                                 \n\t"
+-            : [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
++            : RESTRICT_ASM_ALL64
++              [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
+               [ftmp2]"=&f"(ftmp[2]),        [ftmp3]"=&f"(ftmp[3]),
+               [ftmp4]"=&f"(ftmp[4]),        [ftmp5]"=&f"(ftmp[5]),
+               [ftmp6]"=&f"(ftmp[6]),        [ftmp7]"=&f"(ftmp[7]),
+@@ -203,7 +206,8 @@ void ff_put_h264_chroma_mc8_mmi(uint8_t *dst, uint8_t *src, ptrdiff_t stride,
+             MMI_SDC1(%[ftmp1], %[dst], 0x00)
+             PTR_ADDU   "%[dst],     %[dst],         %[stride]          \n\t"
+             "bnez       %[h],       1b                                 \n\t"
+-            : [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
++            : RESTRICT_ASM_ALL64
++              [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
+               [ftmp2]"=&f"(ftmp[2]),        [ftmp3]"=&f"(ftmp[3]),
+               [ftmp4]"=&f"(ftmp[4]),        [ftmp5]"=&f"(ftmp[5]),
+               [ftmp6]"=&f"(ftmp[6]),        [ftmp7]"=&f"(ftmp[7]),
+@@ -272,7 +276,8 @@ void ff_put_h264_chroma_mc8_mmi(uint8_t *dst, uint8_t *src, ptrdiff_t stride,
+             MMI_SDC1(%[ftmp2], %[dst], 0x00)
+             PTR_ADDU   "%[dst],     %[dst],         %[stride]          \n\t"
+             "bnez       %[h],       1b                                 \n\t"
+-            : [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
++            : RESTRICT_ASM_ALL64
++              [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
+               [ftmp2]"=&f"(ftmp[2]),        [ftmp3]"=&f"(ftmp[3]),
+               [ftmp4]"=&f"(ftmp[4]),        [ftmp5]"=&f"(ftmp[5]),
+               [ftmp6]"=&f"(ftmp[6]),        [ftmp7]"=&f"(ftmp[7]),
+@@ -293,6 +298,7 @@ void ff_avg_h264_chroma_mc8_mmi(uint8_t *dst, uint8_t *src, ptrdiff_t stride,
+     int A = 64, B, C, D, E;
+     double ftmp[10];
+     uint64_t tmp[1];
++    DECLARE_VAR_ALL64;
+ 
+     if(!(x || y)){
+         /* x=0, y=0, A=64 */
+@@ -314,7 +320,8 @@ void ff_avg_h264_chroma_mc8_mmi(uint8_t *dst, uint8_t *src, ptrdiff_t stride,
+             PTR_ADDU   "%[dst],     %[dst],         %[stride]           \n\t"
+             "addi       %[h],       %[h],           -0x02               \n\t"
+             "bnez       %[h],       1b                                  \n\t"
+-            : [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
++            : RESTRICT_ASM_ALL64
++              [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
+               [ftmp2]"=&f"(ftmp[2]),        [ftmp3]"=&f"(ftmp[3]),
+               [dst]"+&r"(dst),              [src]"+&r"(src),
+               [h]"+&r"(h)
+@@ -378,7 +385,8 @@ void ff_avg_h264_chroma_mc8_mmi(uint8_t *dst, uint8_t *src, ptrdiff_t stride,
+             MMI_SDC1(%[ftmp1], %[dst], 0x00)
+             PTR_ADDU   "%[dst],     %[dst],         %[stride]      \n\t"
+             "bnez       %[h],       1b                             \n\t"
+-            : [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
++            : RESTRICT_ASM_ALL64
++              [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
+               [ftmp2]"=&f"(ftmp[2]),        [ftmp3]"=&f"(ftmp[3]),
+               [ftmp4]"=&f"(ftmp[4]),        [ftmp5]"=&f"(ftmp[5]),
+               [ftmp6]"=&f"(ftmp[6]),        [ftmp7]"=&f"(ftmp[7]),
+@@ -429,7 +437,8 @@ void ff_avg_h264_chroma_mc8_mmi(uint8_t *dst, uint8_t *src, ptrdiff_t stride,
+             MMI_SDC1(%[ftmp1], %[dst], 0x00)
+             PTR_ADDU   "%[dst],     %[dst],         %[stride]      \n\t"
+             "bnez       %[h],       1b                             \n\t"
+-            : [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
++            : RESTRICT_ASM_ALL64
++              [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
+               [ftmp2]"=&f"(ftmp[2]),        [ftmp3]"=&f"(ftmp[3]),
+               [ftmp4]"=&f"(ftmp[4]),        [ftmp5]"=&f"(ftmp[5]),
+               [ftmp6]"=&f"(ftmp[6]),        [ftmp7]"=&f"(ftmp[7]),
+@@ -479,7 +488,8 @@ void ff_avg_h264_chroma_mc8_mmi(uint8_t *dst, uint8_t *src, ptrdiff_t stride,
+             MMI_SDC1(%[ftmp1], %[dst], 0x00)
+             PTR_ADDU   "%[dst],     %[dst],         %[stride]      \n\t"
+             "bnez       %[h],       1b                             \n\t"
+-            : [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
++            : RESTRICT_ASM_ALL64
++              [ftmp0]"=&f"(ftmp[0]),        [ftmp1]"=&f"(ftmp[1]),
+               [ftmp2]"=&f"(ftmp[2]),        [ftmp3]"=&f"(ftmp[3]),
+               [ftmp4]"=&f"(ftmp[4]),        [ftmp5]"=&f"(ftmp[5]),
+               [ftmp6]"=&f"(ftmp[6]),        [ftmp7]"=&f"(ftmp[7]),
+diff --git a/libavcodec/mips/h264dsp_mmi.c b/libavcodec/mips/h264dsp_mmi.c
+index 173e191c77..cb78d5a2f8 100644
+--- a/libavcodec/mips/h264dsp_mmi.c
++++ b/libavcodec/mips/h264dsp_mmi.c
+@@ -39,8 +39,8 @@ void ff_h264_add_pixels4_8_mmi(uint8_t *dst, int16_t *src, int stride)
+         MMI_LDC1(%[ftmp3], %[src], 0x10)
+         MMI_LDC1(%[ftmp4], %[src], 0x18)
+         /* memset(src, 0, 32); */
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x00(%[src])            \n\t"
+-        "gssqc1     %[ftmp0],   %[ftmp0],       0x10(%[src])            \n\t"
++        MMI_SQC1(%[ftmp0], %[ftmp0], %[src], 0x00)
++        MMI_SQC1(%[ftmp0], %[ftmp0], %[src], 0x10)
+         MMI_ULWC1(%[ftmp5], %[dst0], 0x00)
+         MMI_ULWC1(%[ftmp6], %[dst1], 0x00)
+         MMI_ULWC1(%[ftmp7], %[dst2], 0x00)
+@@ -89,8 +89,8 @@ void ff_h264_idct_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         MMI_LDC1(%[ftmp3], %[block], 0x18)
+         /* memset(block, 0, 32) */
+         "xor        %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
+-        "gssqc1     %[ftmp4],   %[ftmp4],       0x00(%[block])          \n\t"
+-        "gssqc1     %[ftmp4],   %[ftmp4],       0x10(%[block])          \n\t"
++        MMI_SQC1(%[ftmp4], %[ftmp4], %[block], 0x00)
++        MMI_SQC1(%[ftmp4], %[ftmp4], %[block], 0x10)
+         "dli        %[tmp0],    0x01                                    \n\t"
+         "mtc1       %[tmp0],    %[ftmp8]                                \n\t"
+         "dli        %[tmp0],    0x06                                    \n\t"
+diff --git a/libavcodec/mips/hevcdsp_mmi.c b/libavcodec/mips/hevcdsp_mmi.c
+index aa83e1f9ad..29e8c885bd 100644
+--- a/libavcodec/mips/hevcdsp_mmi.c
++++ b/libavcodec/mips/hevcdsp_mmi.c
+@@ -35,6 +35,7 @@ void ff_hevc_put_hevc_qpel_h##w##_8_mmi(int16_t *dst, uint8_t *_src,     \
+     uint64_t ftmp[15];                                                   \
+     uint64_t rtmp[1];                                                    \
+     const int8_t *filter = ff_hevc_qpel_filters[mx - 1];                 \
++    DECLARE_VAR_ALL64;                                                   \
+                                                                          \
+     x = x_step;                                                          \
+     y = height;                                                          \
+@@ -50,14 +51,10 @@ void ff_hevc_put_hevc_qpel_h##w##_8_mmi(int16_t *dst, uint8_t *_src,     \
+                                                                          \
+         "1:                                                     \n\t"    \
+         "2:                                                     \n\t"    \
+-        "gsldlc1      %[ftmp3],      0x07(%[src])               \n\t"    \
+-        "gsldrc1      %[ftmp3],      0x00(%[src])               \n\t"    \
+-        "gsldlc1      %[ftmp4],      0x08(%[src])               \n\t"    \
+-        "gsldrc1      %[ftmp4],      0x01(%[src])               \n\t"    \
+-        "gsldlc1      %[ftmp5],      0x09(%[src])               \n\t"    \
+-        "gsldrc1      %[ftmp5],      0x02(%[src])               \n\t"    \
+-        "gsldlc1      %[ftmp6],      0x0a(%[src])               \n\t"    \
+-        "gsldrc1      %[ftmp6],      0x03(%[src])               \n\t"    \
++        MMI_ULDC1(%[ftmp3], %[src], 0x00)                                \
++        MMI_ULDC1(%[ftmp4], %[src], 0x01)                                \
++        MMI_ULDC1(%[ftmp5], %[src], 0x02)                                \
++        MMI_ULDC1(%[ftmp6], %[src], 0x03)                                \
+         "punpcklbh    %[ftmp7],      %[ftmp3],      %[ftmp0]    \n\t"    \
+         "punpckhbh    %[ftmp8],      %[ftmp3],      %[ftmp0]    \n\t"    \
+         "pmullh       %[ftmp7],      %[ftmp7],      %[ftmp1]    \n\t"    \
+@@ -83,8 +80,7 @@ void ff_hevc_put_hevc_qpel_h##w##_8_mmi(int16_t *dst, uint8_t *_src,     \
+         "paddh        %[ftmp3],      %[ftmp3],      %[ftmp4]    \n\t"    \
+         "paddh        %[ftmp5],      %[ftmp5],      %[ftmp6]    \n\t"    \
+         "paddh        %[ftmp3],      %[ftmp3],      %[ftmp5]    \n\t"    \
+-        "gssdlc1      %[ftmp3],      0x07(%[dst])               \n\t"    \
+-        "gssdrc1      %[ftmp3],      0x00(%[dst])               \n\t"    \
++        MMI_ULDC1(%[ftmp3], %[dst], 0x00)                                \
+                                                                          \
+         "daddi        %[x],          %[x],         -0x01        \n\t"    \
+         PTR_ADDIU    "%[src],        %[src],        0x04        \n\t"    \
+@@ -98,7 +94,8 @@ void ff_hevc_put_hevc_qpel_h##w##_8_mmi(int16_t *dst, uint8_t *_src,     \
+         PTR_ADDU     "%[src],        %[src],        %[stride]   \n\t"    \
+         PTR_ADDIU    "%[dst],        %[dst],        0x80        \n\t"    \
+         "bnez         %[y],          1b                         \n\t"    \
+-        : [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                  \
++        : RESTRICT_ASM_ALL64                                             \
++          [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                  \
+           [ftmp2]"=&f"(ftmp[2]), [ftmp3]"=&f"(ftmp[3]),                  \
+           [ftmp4]"=&f"(ftmp[4]), [ftmp5]"=&f"(ftmp[5]),                  \
+           [ftmp6]"=&f"(ftmp[6]), [ftmp7]"=&f"(ftmp[7]),                  \
+@@ -134,6 +131,7 @@ void ff_hevc_put_hevc_qpel_hv##w##_8_mmi(int16_t *dst, uint8_t *_src,    \
+     int16_t *tmp = tmp_array;                                            \
+     uint64_t ftmp[15];                                                   \
+     uint64_t rtmp[1];                                                    \
++    DECLARE_VAR_ALL64;                                                   \
+                                                                          \
+     src   -= (QPEL_EXTRA_BEFORE * srcstride + 3);                        \
+     filter = ff_hevc_qpel_filters[mx - 1];                               \
+@@ -151,14 +149,10 @@ void ff_hevc_put_hevc_qpel_hv##w##_8_mmi(int16_t *dst, uint8_t *_src,    \
+                                                                          \
+         "1:                                                     \n\t"    \
+         "2:                                                     \n\t"    \
+-        "gsldlc1      %[ftmp3],      0x07(%[src])               \n\t"    \
+-        "gsldrc1      %[ftmp3],      0x00(%[src])               \n\t"    \
+-        "gsldlc1      %[ftmp4],      0x08(%[src])               \n\t"    \
+-        "gsldrc1      %[ftmp4],      0x01(%[src])               \n\t"    \
+-        "gsldlc1      %[ftmp5],      0x09(%[src])               \n\t"    \
+-        "gsldrc1      %[ftmp5],      0x02(%[src])               \n\t"    \
+-        "gsldlc1      %[ftmp6],      0x0a(%[src])               \n\t"    \
+-        "gsldrc1      %[ftmp6],      0x03(%[src])               \n\t"    \
++        MMI_ULDC1(%[ftmp3], %[src], 0x00)                                \
++        MMI_ULDC1(%[ftmp4], %[src], 0x01)                                \
++        MMI_ULDC1(%[ftmp5], %[src], 0x02)                                \
++        MMI_ULDC1(%[ftmp6], %[src], 0x03)                                \
+         "punpcklbh    %[ftmp7],      %[ftmp3],      %[ftmp0]    \n\t"    \
+         "punpckhbh    %[ftmp8],      %[ftmp3],      %[ftmp0]    \n\t"    \
+         "pmullh       %[ftmp7],      %[ftmp7],      %[ftmp1]    \n\t"    \
+@@ -184,8 +178,7 @@ void ff_hevc_put_hevc_qpel_hv##w##_8_mmi(int16_t *dst, uint8_t *_src,    \
+         "paddh        %[ftmp3],      %[ftmp3],      %[ftmp4]    \n\t"    \
+         "paddh        %[ftmp5],      %[ftmp5],      %[ftmp6]    \n\t"    \
+         "paddh        %[ftmp3],      %[ftmp3],      %[ftmp5]    \n\t"    \
+-        "gssdlc1      %[ftmp3],      0x07(%[tmp])               \n\t"    \
+-        "gssdrc1      %[ftmp3],      0x00(%[tmp])               \n\t"    \
++        MMI_ULDC1(%[ftmp3], %[tmp], 0x00)                                \
+                                                                          \
+         "daddi        %[x],          %[x],         -0x01        \n\t"    \
+         PTR_ADDIU    "%[src],        %[src],        0x04        \n\t"    \
+@@ -199,7 +192,8 @@ void ff_hevc_put_hevc_qpel_hv##w##_8_mmi(int16_t *dst, uint8_t *_src,    \
+         PTR_ADDU     "%[src],        %[src],        %[stride]   \n\t"    \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"    \
+         "bnez         %[y],          1b                         \n\t"    \
+-        : [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                  \
++        : RESTRICT_ASM_ALL64                                             \
++          [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                  \
+           [ftmp2]"=&f"(ftmp[2]), [ftmp3]"=&f"(ftmp[3]),                  \
+           [ftmp4]"=&f"(ftmp[4]), [ftmp5]"=&f"(ftmp[5]),                  \
+           [ftmp6]"=&f"(ftmp[6]), [ftmp7]"=&f"(ftmp[7]),                  \
+@@ -228,29 +222,21 @@ void ff_hevc_put_hevc_qpel_hv##w##_8_mmi(int16_t *dst, uint8_t *_src,    \
+                                                                          \
+         "1:                                                     \n\t"    \
+         "2:                                                     \n\t"    \
+-        "gsldlc1      %[ftmp3],      0x07(%[tmp])               \n\t"    \
+-        "gsldrc1      %[ftmp3],      0x00(%[tmp])               \n\t"    \
++        MMI_ULDC1(%[ftmp3], %[tmp], 0x00)                                \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"    \
+-        "gsldlc1      %[ftmp4],      0x07(%[tmp])               \n\t"    \
+-        "gsldrc1      %[ftmp4],      0x00(%[tmp])               \n\t"    \
++        MMI_ULDC1(%[ftmp4], %[tmp], 0x00)                                \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"    \
+-        "gsldlc1      %[ftmp5],      0x07(%[tmp])               \n\t"    \
+-        "gsldrc1      %[ftmp5],      0x00(%[tmp])               \n\t"    \
++        MMI_ULDC1(%[ftmp5], %[tmp], 0x00)                                \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"    \
+-        "gsldlc1      %[ftmp6],      0x07(%[tmp])               \n\t"    \
+-        "gsldrc1      %[ftmp6],      0x00(%[tmp])               \n\t"    \
++        MMI_ULDC1(%[ftmp6], %[tmp], 0x00)                                \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"    \
+-        "gsldlc1      %[ftmp7],      0x07(%[tmp])               \n\t"    \
+-        "gsldrc1      %[ftmp7],      0x00(%[tmp])               \n\t"    \
++        MMI_ULDC1(%[ftmp7], %[tmp], 0x00)                                \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"    \
+-        "gsldlc1      %[ftmp8],      0x07(%[tmp])               \n\t"    \
+-        "gsldrc1      %[ftmp8],      0x00(%[tmp])               \n\t"    \
++        MMI_ULDC1(%[ftmp8], %[tmp], 0x00)                                \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"    \
+-        "gsldlc1      %[ftmp9],      0x07(%[tmp])               \n\t"    \
+-        "gsldrc1      %[ftmp9],      0x00(%[tmp])               \n\t"    \
++        MMI_ULDC1(%[ftmp9], %[tmp], 0x00)                                \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"    \
+-        "gsldlc1      %[ftmp10],     0x07(%[tmp])               \n\t"    \
+-        "gsldrc1      %[ftmp10],     0x00(%[tmp])               \n\t"    \
++        MMI_ULDC1(%[ftmp10], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        -0x380      \n\t"    \
+         TRANSPOSE_4H(%[ftmp3], %[ftmp4], %[ftmp5], %[ftmp6],             \
+                      %[ftmp11], %[ftmp12], %[ftmp13], %[ftmp14])         \
+@@ -275,8 +261,7 @@ void ff_hevc_put_hevc_qpel_hv##w##_8_mmi(int16_t *dst, uint8_t *_src,    \
+         "paddw        %[ftmp5],      %[ftmp5],      %[ftmp6]    \n\t"    \
+         "psraw        %[ftmp5],      %[ftmp5],      %[ftmp0]    \n\t"    \
+         "packsswh     %[ftmp3],      %[ftmp3],      %[ftmp5]    \n\t"    \
+-        "gssdlc1      %[ftmp3],      0x07(%[dst])               \n\t"    \
+-        "gssdrc1      %[ftmp3],      0x00(%[dst])               \n\t"    \
++        MMI_USDC1(%[ftmp3], %[dst], 0x00)                               \
+                                                                          \
+         "daddi        %[x],          %[x],         -0x01        \n\t"    \
+         PTR_ADDIU    "%[dst],        %[dst],        0x08        \n\t"    \
+@@ -290,7 +275,8 @@ void ff_hevc_put_hevc_qpel_hv##w##_8_mmi(int16_t *dst, uint8_t *_src,    \
+         PTR_ADDIU    "%[dst],        %[dst],        0x80        \n\t"    \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"    \
+         "bnez         %[y],          1b                         \n\t"    \
+-        : [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                  \
++        : RESTRICT_ASM_ALL64                                             \
++          [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                  \
+           [ftmp2]"=&f"(ftmp[2]), [ftmp3]"=&f"(ftmp[3]),                  \
+           [ftmp4]"=&f"(ftmp[4]), [ftmp5]"=&f"(ftmp[5]),                  \
+           [ftmp6]"=&f"(ftmp[6]), [ftmp7]"=&f"(ftmp[7]),                  \
+@@ -333,6 +319,8 @@ void ff_hevc_put_hevc_qpel_bi_h##w##_8_mmi(uint8_t *_dst,               \
+     uint64_t rtmp[1];                                                   \
+     int shift = 7;                                                      \
+     int offset = 64;                                                    \
++    DECLARE_VAR_ALL64;                                                  \
++    DECLARE_VAR_LOW32;                                                  \
+                                                                         \
+     x = width >> 2;                                                     \
+     y = height;                                                         \
+@@ -351,14 +339,10 @@ void ff_hevc_put_hevc_qpel_bi_h##w##_8_mmi(uint8_t *_dst,               \
+         "1:                                                     \n\t"   \
+         "li           %[x],        " #x_step "                  \n\t"   \
+         "2:                                                     \n\t"   \
+-        "gsldlc1      %[ftmp3],      0x07(%[src])               \n\t"   \
+-        "gsldrc1      %[ftmp3],      0x00(%[src])               \n\t"   \
+-        "gsldlc1      %[ftmp4],      0x08(%[src])               \n\t"   \
+-        "gsldrc1      %[ftmp4],      0x01(%[src])               \n\t"   \
+-        "gsldlc1      %[ftmp5],      0x09(%[src])               \n\t"   \
+-        "gsldrc1      %[ftmp5],      0x02(%[src])               \n\t"   \
+-        "gsldlc1      %[ftmp6],      0x0a(%[src])               \n\t"   \
+-        "gsldrc1      %[ftmp6],      0x03(%[src])               \n\t"   \
++        MMI_ULDC1(%[ftmp3], %[src], 0x00)                               \
++        MMI_ULDC1(%[ftmp4], %[src], 0x01)                               \
++        MMI_ULDC1(%[ftmp5], %[src], 0x02)                               \
++        MMI_ULDC1(%[ftmp6], %[src], 0x03)                               \
+         "punpcklbh    %[ftmp7],      %[ftmp3],      %[ftmp0]    \n\t"   \
+         "punpckhbh    %[ftmp8],      %[ftmp3],      %[ftmp0]    \n\t"   \
+         "pmullh       %[ftmp7],      %[ftmp7],      %[ftmp1]    \n\t"   \
+@@ -385,8 +369,7 @@ void ff_hevc_put_hevc_qpel_bi_h##w##_8_mmi(uint8_t *_dst,               \
+         "paddh        %[ftmp5],      %[ftmp5],      %[ftmp6]    \n\t"   \
+         "paddh        %[ftmp3],      %[ftmp3],      %[ftmp5]    \n\t"   \
+         "paddh        %[ftmp3],      %[ftmp3],      %[offset]   \n\t"   \
+-        "gsldlc1      %[ftmp4],      0x07(%[src2])              \n\t"   \
+-        "gsldrc1      %[ftmp4],      0x00(%[src2])              \n\t"   \
++        MMI_ULDC1(%[ftmp4], %[src2], 0x00)                              \
+         "li           %[rtmp0],      0x10                       \n\t"   \
+         "dmtc1        %[rtmp0],      %[ftmp8]                   \n\t"   \
+         "punpcklhw    %[ftmp5],      %[ftmp0],      %[ftmp3]    \n\t"   \
+@@ -405,8 +388,7 @@ void ff_hevc_put_hevc_qpel_bi_h##w##_8_mmi(uint8_t *_dst,               \
+         "pcmpgth      %[ftmp7],      %[ftmp5],      %[ftmp0]    \n\t"   \
+         "and          %[ftmp3],      %[ftmp5],      %[ftmp7]    \n\t"   \
+         "packushb     %[ftmp3],      %[ftmp3],      %[ftmp3]    \n\t"   \
+-        "gsswlc1      %[ftmp3],      0x03(%[dst])               \n\t"   \
+-        "gsswrc1      %[ftmp3],      0x00(%[dst])               \n\t"   \
++        MMI_USWC1(%[ftmp3], %[dst], 0x00)                               \
+                                                                         \
+         "daddi        %[x],          %[x],         -0x01        \n\t"   \
+         PTR_ADDIU    "%[src],        %[src],        0x04        \n\t"   \
+@@ -422,7 +404,8 @@ void ff_hevc_put_hevc_qpel_bi_h##w##_8_mmi(uint8_t *_dst,               \
+         PTR_ADDU     "%[dst],        %[dst],    %[dst_stride]   \n\t"   \
+         PTR_ADDIU    "%[src2],       %[src2],       0x80        \n\t"   \
+         "bnez         %[y],          1b                         \n\t"   \
+-        : [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
++        : RESTRICT_ASM_ALL64 RESTRICT_ASM_LOW32                         \
++          [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
+           [ftmp2]"=&f"(ftmp[2]), [ftmp3]"=&f"(ftmp[3]),                 \
+           [ftmp4]"=&f"(ftmp[4]), [ftmp5]"=&f"(ftmp[5]),                 \
+           [ftmp6]"=&f"(ftmp[6]), [ftmp7]"=&f"(ftmp[7]),                 \
+@@ -467,6 +450,8 @@ void ff_hevc_put_hevc_qpel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+     uint64_t rtmp[1];                                                   \
+     int shift = 7;                                                      \
+     int offset = 64;                                                    \
++    DECLARE_VAR_ALL64;                                                  \
++    DECLARE_VAR_LOW32;                                                  \
+                                                                         \
+     src   -= (QPEL_EXTRA_BEFORE * srcstride + 3);                       \
+     filter = ff_hevc_qpel_filters[mx - 1];                              \
+@@ -484,14 +469,10 @@ void ff_hevc_put_hevc_qpel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+                                                                         \
+         "1:                                                     \n\t"   \
+         "2:                                                     \n\t"   \
+-        "gsldlc1      %[ftmp3],      0x07(%[src])               \n\t"   \
+-        "gsldrc1      %[ftmp3],      0x00(%[src])               \n\t"   \
+-        "gsldlc1      %[ftmp4],      0x08(%[src])               \n\t"   \
+-        "gsldrc1      %[ftmp4],      0x01(%[src])               \n\t"   \
+-        "gsldlc1      %[ftmp5],      0x09(%[src])               \n\t"   \
+-        "gsldrc1      %[ftmp5],      0x02(%[src])               \n\t"   \
+-        "gsldlc1      %[ftmp6],      0x0a(%[src])               \n\t"   \
+-        "gsldrc1      %[ftmp6],      0x03(%[src])               \n\t"   \
++        MMI_ULDC1(%[ftmp3], %[src], 0x00)                               \
++        MMI_ULDC1(%[ftmp4], %[src], 0x01)                               \
++        MMI_ULDC1(%[ftmp5], %[src], 0x02)                               \
++        MMI_ULDC1(%[ftmp6], %[src], 0x03)                               \
+         "punpcklbh    %[ftmp7],      %[ftmp3],      %[ftmp0]    \n\t"   \
+         "punpckhbh    %[ftmp8],      %[ftmp3],      %[ftmp0]    \n\t"   \
+         "pmullh       %[ftmp7],      %[ftmp7],      %[ftmp1]    \n\t"   \
+@@ -517,8 +498,7 @@ void ff_hevc_put_hevc_qpel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "paddh        %[ftmp3],      %[ftmp3],      %[ftmp4]    \n\t"   \
+         "paddh        %[ftmp5],      %[ftmp5],      %[ftmp6]    \n\t"   \
+         "paddh        %[ftmp3],      %[ftmp3],      %[ftmp5]    \n\t"   \
+-        "gssdlc1      %[ftmp3],      0x07(%[tmp])               \n\t"   \
+-        "gssdrc1      %[ftmp3],      0x00(%[tmp])               \n\t"   \
++        MMI_USDC1(%[ftmp3], %[tmp], 0x00)                               \
+                                                                         \
+         "daddi        %[x],          %[x],         -0x01        \n\t"   \
+         PTR_ADDIU    "%[src],        %[src],        0x04        \n\t"   \
+@@ -532,7 +512,8 @@ void ff_hevc_put_hevc_qpel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         PTR_ADDU     "%[src],        %[src],        %[stride]   \n\t"   \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+         "bnez         %[y],          1b                         \n\t"   \
+-        : [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
++        : RESTRICT_ASM_ALL64                                            \
++          [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
+           [ftmp2]"=&f"(ftmp[2]), [ftmp3]"=&f"(ftmp[3]),                 \
+           [ftmp4]"=&f"(ftmp[4]), [ftmp5]"=&f"(ftmp[5]),                 \
+           [ftmp6]"=&f"(ftmp[6]), [ftmp7]"=&f"(ftmp[7]),                 \
+@@ -563,29 +544,21 @@ void ff_hevc_put_hevc_qpel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "1:                                                     \n\t"   \
+         "li           %[x],        " #x_step "                  \n\t"   \
+         "2:                                                     \n\t"   \
+-        "gsldlc1      %[ftmp3],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp3],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp3], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp4],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp4],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp4], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp5],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp5],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp5], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp6],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp6],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp6], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp7],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp7],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp7], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp8],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp8],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp8], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp9],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp9],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp9], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp10],     0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp10],     0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp10], %[tmp], 0x00)                              \
+         PTR_ADDIU    "%[tmp],        %[tmp],        -0x380      \n\t"   \
+         TRANSPOSE_4H(%[ftmp3], %[ftmp4], %[ftmp5], %[ftmp6],            \
+                      %[ftmp11], %[ftmp12], %[ftmp13], %[ftmp14])        \
+@@ -610,8 +583,7 @@ void ff_hevc_put_hevc_qpel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "paddw        %[ftmp5],      %[ftmp5],      %[ftmp6]    \n\t"   \
+         "psraw        %[ftmp5],      %[ftmp5],      %[ftmp0]    \n\t"   \
+         "packsswh     %[ftmp3],      %[ftmp3],      %[ftmp5]    \n\t"   \
+-        "gsldlc1      %[ftmp4],      0x07(%[src2])              \n\t"   \
+-        "gsldrc1      %[ftmp4],      0x00(%[src2])              \n\t"   \
++        MMI_ULDC1(%[ftmp4], %[src2], 0x00)                              \
+         "xor          %[ftmp7],      %[ftmp7],      %[ftmp7]    \n\t"   \
+         "li           %[rtmp0],      0x10                       \n\t"   \
+         "dmtc1        %[rtmp0],      %[ftmp8]                   \n\t"   \
+@@ -633,8 +605,7 @@ void ff_hevc_put_hevc_qpel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "pcmpgth      %[ftmp7],      %[ftmp5],      %[ftmp7]    \n\t"   \
+         "and          %[ftmp3],      %[ftmp5],      %[ftmp7]    \n\t"   \
+         "packushb     %[ftmp3],      %[ftmp3],      %[ftmp3]    \n\t"   \
+-        "gsswlc1      %[ftmp3],      0x03(%[dst])               \n\t"   \
+-        "gsswrc1      %[ftmp3],      0x00(%[dst])               \n\t"   \
++        MMI_USWC1(%[ftmp3], %[dst], 0x00)                               \
+                                                                         \
+         "daddi        %[x],          %[x],         -0x01        \n\t"   \
+         PTR_ADDIU    "%[src2],       %[src2],       0x08        \n\t"   \
+@@ -650,7 +621,8 @@ void ff_hevc_put_hevc_qpel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         PTR_ADDU     "%[dst],        %[dst],        %[stride]   \n\t"   \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+         "bnez         %[y],          1b                         \n\t"   \
+-        : [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
++        : RESTRICT_ASM_ALL64 RESTRICT_ASM_LOW32                         \
++          [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
+           [ftmp2]"=&f"(ftmp[2]), [ftmp3]"=&f"(ftmp[3]),                 \
+           [ftmp4]"=&f"(ftmp[4]), [ftmp5]"=&f"(ftmp[5]),                 \
+           [ftmp6]"=&f"(ftmp[6]), [ftmp7]"=&f"(ftmp[7]),                 \
+@@ -696,6 +668,8 @@ void ff_hevc_put_hevc_epel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+     uint64_t rtmp[1];                                                   \
+     int shift = 7;                                                      \
+     int offset = 64;                                                    \
++    DECLARE_VAR_ALL64;                                                  \
++    DECLARE_VAR_LOW32;                                                  \
+                                                                         \
+     src -= (EPEL_EXTRA_BEFORE * srcstride + 1);                         \
+     x = width >> 2;                                                     \
+@@ -710,14 +684,10 @@ void ff_hevc_put_hevc_epel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+                                                                         \
+         "1:                                                     \n\t"   \
+         "2:                                                     \n\t"   \
+-        "gslwlc1      %[ftmp2],      0x03(%[src])               \n\t"   \
+-        "gslwrc1      %[ftmp2],      0x00(%[src])               \n\t"   \
+-        "gslwlc1      %[ftmp3],      0x04(%[src])               \n\t"   \
+-        "gslwrc1      %[ftmp3],      0x01(%[src])               \n\t"   \
+-        "gslwlc1      %[ftmp4],      0x05(%[src])               \n\t"   \
+-        "gslwrc1      %[ftmp4],      0x02(%[src])               \n\t"   \
+-        "gslwlc1      %[ftmp5],      0x06(%[src])               \n\t"   \
+-        "gslwrc1      %[ftmp5],      0x03(%[src])               \n\t"   \
++        MMI_ULDC1(%[ftmp3], %[src], 0x00)                               \
++        MMI_ULDC1(%[ftmp4], %[src], 0x01)                               \
++        MMI_ULDC1(%[ftmp5], %[src], 0x02)                               \
++        MMI_ULDC1(%[ftmp6], %[src], 0x03)                               \
+         "punpcklbh    %[ftmp2],      %[ftmp2],      %[ftmp0]    \n\t"   \
+         "pmullh       %[ftmp2],      %[ftmp2],      %[ftmp1]    \n\t"   \
+         "punpcklbh    %[ftmp3],      %[ftmp3],      %[ftmp0]    \n\t"   \
+@@ -731,8 +701,7 @@ void ff_hevc_put_hevc_epel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "paddh        %[ftmp2],      %[ftmp2],      %[ftmp3]    \n\t"   \
+         "paddh        %[ftmp4],      %[ftmp4],      %[ftmp5]    \n\t"   \
+         "paddh        %[ftmp2],      %[ftmp2],      %[ftmp4]    \n\t"   \
+-        "gssdlc1      %[ftmp2],      0x07(%[tmp])               \n\t"   \
+-        "gssdrc1      %[ftmp2],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp2], %[tmp], 0x00)                               \
+                                                                         \
+         "daddi        %[x],          %[x],         -0x01        \n\t"   \
+         PTR_ADDIU    "%[src],        %[src],        0x04        \n\t"   \
+@@ -746,7 +715,8 @@ void ff_hevc_put_hevc_epel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         PTR_ADDU     "%[src],        %[src],        %[stride]   \n\t"   \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+         "bnez         %[y],          1b                         \n\t"   \
+-        : [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
++        : RESTRICT_ASM_ALL64                                            \
++          [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
+           [ftmp2]"=&f"(ftmp[2]), [ftmp3]"=&f"(ftmp[3]),                 \
+           [ftmp4]"=&f"(ftmp[4]), [ftmp5]"=&f"(ftmp[5]),                 \
+           [ftmp6]"=&f"(ftmp[6]), [ftmp7]"=&f"(ftmp[7]),                 \
+@@ -776,17 +746,13 @@ void ff_hevc_put_hevc_epel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "1:                                                     \n\t"   \
+         "li           %[x],        " #x_step "                  \n\t"   \
+         "2:                                                     \n\t"   \
+-        "gsldlc1      %[ftmp3],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp3],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp3], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp4],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp4],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp4], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp5],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp5],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp5], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp6],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp6],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp6], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],       -0x180       \n\t"   \
+         TRANSPOSE_4H(%[ftmp3], %[ftmp4], %[ftmp5], %[ftmp6],            \
+                      %[ftmp7], %[ftmp8], %[ftmp9], %[ftmp10])           \
+@@ -801,8 +767,7 @@ void ff_hevc_put_hevc_epel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "paddw        %[ftmp5],      %[ftmp5],      %[ftmp6]    \n\t"   \
+         "psraw        %[ftmp5],      %[ftmp5],      %[ftmp0]    \n\t"   \
+         "packsswh     %[ftmp3],      %[ftmp3],      %[ftmp5]    \n\t"   \
+-        "gsldlc1      %[ftmp4],      0x07(%[src2])              \n\t"   \
+-        "gsldrc1      %[ftmp4],      0x00(%[src2])              \n\t"   \
++        MMI_ULDC1(%[ftmp4], %[tmp], 0x02)                               \
+         "li           %[rtmp0],      0x10                       \n\t"   \
+         "dmtc1        %[rtmp0],      %[ftmp8]                   \n\t"   \
+         "punpcklhw    %[ftmp5],      %[ftmp2],      %[ftmp3]    \n\t"   \
+@@ -823,8 +788,7 @@ void ff_hevc_put_hevc_epel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "pcmpgth      %[ftmp7],      %[ftmp5],      %[ftmp2]    \n\t"   \
+         "and          %[ftmp3],      %[ftmp5],      %[ftmp7]    \n\t"   \
+         "packushb     %[ftmp3],      %[ftmp3],      %[ftmp3]    \n\t"   \
+-        "gsswlc1      %[ftmp3],      0x03(%[dst])               \n\t"   \
+-        "gsswrc1      %[ftmp3],      0x00(%[dst])               \n\t"   \
++        MMI_USWC1(%[ftmp3], %[dst], 0x0)                                \
+                                                                         \
+         "daddi        %[x],          %[x],         -0x01        \n\t"   \
+         PTR_ADDIU    "%[src2],       %[src2],       0x08        \n\t"   \
+@@ -840,7 +804,8 @@ void ff_hevc_put_hevc_epel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         PTR_ADDU     "%[dst],        %[dst],        %[stride]   \n\t"   \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+         "bnez         %[y],          1b                         \n\t"   \
+-        : [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
++        : RESTRICT_ASM_LOW32 RESTRICT_ASM_ALL64                         \
++          [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
+           [ftmp2]"=&f"(ftmp[2]), [ftmp3]"=&f"(ftmp[3]),                 \
+           [ftmp4]"=&f"(ftmp[4]), [ftmp5]"=&f"(ftmp[5]),                 \
+           [ftmp6]"=&f"(ftmp[6]), [ftmp7]"=&f"(ftmp[7]),                 \
+@@ -878,6 +843,7 @@ void ff_hevc_put_hevc_pel_bi_pixels##w##_8_mmi(uint8_t *_dst,             \
+     uint64_t ftmp[12];                                                    \
+     uint64_t rtmp[1];                                                     \
+     int shift = 7;                                                        \
++    DECLARE_VAR_ALL64;                                                    \
+                                                                           \
+     y = height;                                                           \
+     x = width >> 3;                                                       \
+@@ -894,12 +860,9 @@ void ff_hevc_put_hevc_pel_bi_pixels##w##_8_mmi(uint8_t *_dst,             \
+                                                                           \
+         "1:                                                     \n\t"     \
+         "2:                                                     \n\t"     \
+-        "gsldlc1      %[ftmp5],      0x07(%[src])               \n\t"     \
+-        "gsldrc1      %[ftmp5],      0x00(%[src])               \n\t"     \
+-        "gsldlc1      %[ftmp2],      0x07(%[src2])              \n\t"     \
+-        "gsldrc1      %[ftmp2],      0x00(%[src2])              \n\t"     \
+-        "gsldlc1      %[ftmp3],      0x0f(%[src2])              \n\t"     \
+-        "gsldrc1      %[ftmp3],      0x08(%[src2])              \n\t"     \
++        MMI_ULDC1(%[ftmp5], %[src], 0x00)                                 \
++        MMI_ULDC1(%[ftmp2], %[src2], 0x00)                                \
++        MMI_ULDC1(%[ftmp3], %[src2], 0x08)                                \
+         "punpcklbh    %[ftmp4],      %[ftmp5],      %[ftmp0]    \n\t"     \
+         "punpckhbh    %[ftmp5],      %[ftmp5],      %[ftmp0]    \n\t"     \
+         "psllh        %[ftmp4],      %[ftmp4],      %[ftmp1]    \n\t"     \
+@@ -933,8 +896,7 @@ void ff_hevc_put_hevc_pel_bi_pixels##w##_8_mmi(uint8_t *_dst,             \
+         "and          %[ftmp2],      %[ftmp2],      %[ftmp3]    \n\t"     \
+         "and          %[ftmp4],      %[ftmp4],      %[ftmp5]    \n\t"     \
+         "packushb     %[ftmp2],      %[ftmp2],      %[ftmp4]    \n\t"     \
+-        "gssdlc1      %[ftmp2],      0x07(%[dst])               \n\t"     \
+-        "gssdrc1      %[ftmp2],      0x00(%[dst])               \n\t"     \
++        MMI_USDC1(%[ftmp2], %[dst], 0x0)                                  \
+                                                                           \
+         "daddi        %[x],          %[x],         -0x01        \n\t"     \
+         PTR_ADDIU    "%[src],        %[src],        0x08        \n\t"     \
+@@ -951,7 +913,8 @@ void ff_hevc_put_hevc_pel_bi_pixels##w##_8_mmi(uint8_t *_dst,             \
+         PTR_ADDU     "%[dst],        %[dst],       %[dststride] \n\t"     \
+         PTR_ADDIU    "%[src2],       %[src2],       0x80        \n\t"     \
+         "bnez         %[y],          1b                         \n\t"     \
+-        : [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                   \
++        : RESTRICT_ASM_ALL64                                              \
++          [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                   \
+           [ftmp2]"=&f"(ftmp[2]), [ftmp3]"=&f"(ftmp[3]),                   \
+           [ftmp4]"=&f"(ftmp[4]), [ftmp5]"=&f"(ftmp[5]),                   \
+           [ftmp6]"=&f"(ftmp[6]), [ftmp7]"=&f"(ftmp[7]),                   \
+@@ -993,6 +956,8 @@ void ff_hevc_put_hevc_qpel_uni_hv##w##_8_mmi(uint8_t *_dst,             \
+     uint64_t rtmp[1];                                                   \
+     int shift = 6;                                                      \
+     int offset = 32;                                                    \
++    DECLARE_VAR_ALL64;                                                  \
++    DECLARE_VAR_LOW32;                                                  \
+                                                                         \
+     src   -= (QPEL_EXTRA_BEFORE * srcstride + 3);                       \
+     filter = ff_hevc_qpel_filters[mx - 1];                              \
+@@ -1010,14 +975,10 @@ void ff_hevc_put_hevc_qpel_uni_hv##w##_8_mmi(uint8_t *_dst,             \
+                                                                         \
+         "1:                                                     \n\t"   \
+         "2:                                                     \n\t"   \
+-        "gsldlc1      %[ftmp3],      0x07(%[src])               \n\t"   \
+-        "gsldrc1      %[ftmp3],      0x00(%[src])               \n\t"   \
+-        "gsldlc1      %[ftmp4],      0x08(%[src])               \n\t"   \
+-        "gsldrc1      %[ftmp4],      0x01(%[src])               \n\t"   \
+-        "gsldlc1      %[ftmp5],      0x09(%[src])               \n\t"   \
+-        "gsldrc1      %[ftmp5],      0x02(%[src])               \n\t"   \
+-        "gsldlc1      %[ftmp6],      0x0a(%[src])               \n\t"   \
+-        "gsldrc1      %[ftmp6],      0x03(%[src])               \n\t"   \
++        MMI_ULDC1(%[ftmp3], %[src], 0x00)                               \
++        MMI_ULDC1(%[ftmp4], %[src], 0x01)                               \
++        MMI_ULDC1(%[ftmp5], %[src], 0x02)                               \
++        MMI_ULDC1(%[ftmp6], %[src], 0x03)                               \
+         "punpcklbh    %[ftmp7],      %[ftmp3],      %[ftmp0]    \n\t"   \
+         "punpckhbh    %[ftmp8],      %[ftmp3],      %[ftmp0]    \n\t"   \
+         "pmullh       %[ftmp7],      %[ftmp7],      %[ftmp1]    \n\t"   \
+@@ -1043,8 +1004,7 @@ void ff_hevc_put_hevc_qpel_uni_hv##w##_8_mmi(uint8_t *_dst,             \
+         "paddh        %[ftmp3],      %[ftmp3],      %[ftmp4]    \n\t"   \
+         "paddh        %[ftmp5],      %[ftmp5],      %[ftmp6]    \n\t"   \
+         "paddh        %[ftmp3],      %[ftmp3],      %[ftmp5]    \n\t"   \
+-        "gssdlc1      %[ftmp3],      0x07(%[tmp])               \n\t"   \
+-        "gssdrc1      %[ftmp3],      0x00(%[tmp])               \n\t"   \
++        MMI_USDC1(%[ftmp3], %[tmp], 0x0)                                \
+                                                                         \
+         "daddi        %[x],          %[x],         -0x01        \n\t"   \
+         PTR_ADDIU    "%[src],        %[src],        0x04        \n\t"   \
+@@ -1058,7 +1018,8 @@ void ff_hevc_put_hevc_qpel_uni_hv##w##_8_mmi(uint8_t *_dst,             \
+         PTR_ADDU     "%[src],        %[src],        %[stride]   \n\t"   \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+         "bnez         %[y],          1b                         \n\t"   \
+-        : [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
++        : RESTRICT_ASM_ALL64                                            \
++          [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
+           [ftmp2]"=&f"(ftmp[2]), [ftmp3]"=&f"(ftmp[3]),                 \
+           [ftmp4]"=&f"(ftmp[4]), [ftmp5]"=&f"(ftmp[5]),                 \
+           [ftmp6]"=&f"(ftmp[6]), [ftmp7]"=&f"(ftmp[7]),                 \
+@@ -1090,29 +1051,21 @@ void ff_hevc_put_hevc_qpel_uni_hv##w##_8_mmi(uint8_t *_dst,             \
+         "1:                                                     \n\t"   \
+         "li           %[x],        " #x_step "                  \n\t"   \
+         "2:                                                     \n\t"   \
+-        "gsldlc1      %[ftmp3],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp3],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp3], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp4],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp4],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp4], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp5],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp5],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp5], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp6],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp6],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp6], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp7],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp7],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp7], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp8],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp8],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp8], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp9],      0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp9],      0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp9], %[tmp], 0x00)                               \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+-        "gsldlc1      %[ftmp10],     0x07(%[tmp])               \n\t"   \
+-        "gsldrc1      %[ftmp10],     0x00(%[tmp])               \n\t"   \
++        MMI_ULDC1(%[ftmp10], %[tmp], 0x00)                              \
+         PTR_ADDIU    "%[tmp],        %[tmp],        -0x380      \n\t"   \
+         TRANSPOSE_4H(%[ftmp3], %[ftmp4], %[ftmp5], %[ftmp6],            \
+                      %[ftmp11], %[ftmp12], %[ftmp13], %[ftmp14])        \
+@@ -1143,8 +1096,7 @@ void ff_hevc_put_hevc_qpel_uni_hv##w##_8_mmi(uint8_t *_dst,             \
+         "pcmpgth      %[ftmp7],      %[ftmp3],      %[ftmp7]    \n\t"   \
+         "and          %[ftmp3],      %[ftmp3],      %[ftmp7]    \n\t"   \
+         "packushb     %[ftmp3],      %[ftmp3],      %[ftmp3]    \n\t"   \
+-        "gsswlc1      %[ftmp3],      0x03(%[dst])               \n\t"   \
+-        "gsswrc1      %[ftmp3],      0x00(%[dst])               \n\t"   \
++        MMI_USWC1(%[ftmp3], %[dst], 0x00)                               \
+                                                                         \
+         "daddi        %[x],          %[x],         -0x01        \n\t"   \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x08        \n\t"   \
+@@ -1157,7 +1109,8 @@ void ff_hevc_put_hevc_qpel_uni_hv##w##_8_mmi(uint8_t *_dst,             \
+         PTR_ADDU     "%[dst],        %[dst],        %[stride]   \n\t"   \
+         PTR_ADDIU    "%[tmp],        %[tmp],        0x80        \n\t"   \
+         "bnez         %[y],          1b                         \n\t"   \
+-        : [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
++        : RESTRICT_ASM_ALL64 RESTRICT_ASM_LOW32                         \
++          [ftmp0]"=&f"(ftmp[0]), [ftmp1]"=&f"(ftmp[1]),                 \
+           [ftmp2]"=&f"(ftmp[2]), [ftmp3]"=&f"(ftmp[3]),                 \
+           [ftmp4]"=&f"(ftmp[4]), [ftmp5]"=&f"(ftmp[5]),                 \
+           [ftmp6]"=&f"(ftmp[6]), [ftmp7]"=&f"(ftmp[7]),                 \
+diff --git a/libavcodec/mips/hpeldsp_mmi.c b/libavcodec/mips/hpeldsp_mmi.c
+index e69b2bd980..ce51815ff4 100644
+--- a/libavcodec/mips/hpeldsp_mmi.c
++++ b/libavcodec/mips/hpeldsp_mmi.c
+@@ -307,6 +307,7 @@ inline void ff_put_pixels4_l2_8_mmi(uint8_t *dst, const uint8_t *src1,
+     double ftmp[4];
+     mips_reg addr[5];
+     DECLARE_VAR_LOW32;
++    DECLARE_VAR_ADDRT;
+ 
+     __asm__ volatile (
+         "1:                                                             \n\t"
+diff --git a/libavcodec/mips/simple_idct_mmi.c b/libavcodec/mips/simple_idct_mmi.c
+index 73d797ffbc..ca29e2ea4b 100644
+--- a/libavcodec/mips/simple_idct_mmi.c
++++ b/libavcodec/mips/simple_idct_mmi.c
+@@ -55,6 +55,8 @@ DECLARE_ALIGNED(16, const int16_t, W_arr)[46] = {
+ 
+ void ff_simple_idct_8_mmi(int16_t *block)
+ {
++    DECLARE_VAR_ALL64;
++
+     BACKUP_REG
+     __asm__ volatile (
+ 
+@@ -141,20 +143,20 @@ void ff_simple_idct_8_mmi(int16_t *block)
+         /* idctRowCondDC row0~8 */
+ 
+         /* load W */
+-        "gslqc1       $f19,      $f18,      0x00(%[w_arr])      \n\t"
+-        "gslqc1       $f21,      $f20,      0x10(%[w_arr])      \n\t"
+-        "gslqc1       $f23,      $f22,      0x20(%[w_arr])      \n\t"
+-        "gslqc1       $f25,      $f24,      0x30(%[w_arr])      \n\t"
+-        "gslqc1       $f17,      $f16,      0x40(%[w_arr])      \n\t"
++        MMI_LQC1($f19, $f18, %[w_arr], 0x00)
++        MMI_LQC1($f21, $f20, %[w_arr], 0x10)
++        MMI_LQC1($f23, $f22, %[w_arr], 0x20)
++        MMI_LQC1($f25, $f24, %[w_arr], 0x30)
++        MMI_LQC1($f17, $f16, %[w_arr], 0x40)
+         /* load source in block */
+-        "gslqc1       $f1,       $f0,       0x00(%[block])      \n\t"
+-        "gslqc1       $f3,       $f2,       0x10(%[block])      \n\t"
+-        "gslqc1       $f5,       $f4,       0x20(%[block])      \n\t"
+-        "gslqc1       $f7,       $f6,       0x30(%[block])      \n\t"
+-        "gslqc1       $f9,       $f8,       0x40(%[block])      \n\t"
+-        "gslqc1       $f11,      $f10,      0x50(%[block])      \n\t"
+-        "gslqc1       $f13,      $f12,      0x60(%[block])      \n\t"
+-        "gslqc1       $f15,      $f14,      0x70(%[block])      \n\t"
++        MMI_LQC1($f1, $f0, %[block], 0x00)
++        MMI_LQC1($f3, $f2, %[block], 0x10)
++        MMI_LQC1($f5, $f4, %[block], 0x20)
++        MMI_LQC1($f7, $f6, %[block], 0x30)
++        MMI_LQC1($f9, $f8, %[block], 0x40)
++        MMI_LQC1($f11, $f10, %[block], 0x50)
++        MMI_LQC1($f13, $f12, %[block], 0x60)
++        MMI_LQC1($f15, $f14, %[block], 0x70)
+ 
+         /* $9: mask ; $f17: ROW_SHIFT */
+         "dmfc1        $9,        $f17                           \n\t"
+@@ -252,8 +254,7 @@ void ff_simple_idct_8_mmi(int16_t *block)
+         /* idctSparseCol col0~3 */
+ 
+         /* $f17: ff_p16_32; $f16: COL_SHIFT-16 */
+-        "gsldlc1      $f17,      0x57(%[w_arr])                 \n\t"
+-        "gsldrc1      $f17,      0x50(%[w_arr])                 \n\t"
++        MMI_ULDC1($f17, %[w_arr], 0x50)
+         "li           $10,       4                              \n\t"
+         "dmtc1        $10,       $f16                           \n\t"
+         "paddh        $f0,       $f0,       $f17                \n\t"
+@@ -394,16 +395,16 @@ void ff_simple_idct_8_mmi(int16_t *block)
+         "punpcklwd    $f11,      $f27,      $f29                \n\t"
+         "punpckhwd    $f15,      $f27,      $f29                \n\t"
+         /* Store */
+-        "gssqc1       $f1,       $f0,       0x00(%[block])      \n\t"
+-        "gssqc1       $f5,       $f4,       0x10(%[block])      \n\t"
+-        "gssqc1       $f9,       $f8,       0x20(%[block])      \n\t"
+-        "gssqc1       $f13,      $f12,      0x30(%[block])      \n\t"
+-        "gssqc1       $f3,       $f2,       0x40(%[block])      \n\t"
+-        "gssqc1       $f7,       $f6,       0x50(%[block])      \n\t"
+-        "gssqc1       $f11,      $f10,      0x60(%[block])      \n\t"
+-        "gssqc1       $f15,      $f14,      0x70(%[block])      \n\t"
++        MMI_SQC1($f1, $f0, %[block], 0x00)
++        MMI_SQC1($f5, $f4, %[block], 0x10)
++        MMI_SQC1($f9, $f8, %[block], 0x20)
++        MMI_SQC1($f13, $f12, %[block], 0x30)
++        MMI_SQC1($f3, $f2, %[block], 0x40)
++        MMI_SQC1($f7, $f6, %[block], 0x50)
++        MMI_SQC1($f11, $f10, %[block], 0x60)
++        MMI_SQC1($f15, $f14, %[block], 0x70)
+ 
+-        : [block]"+&r"(block)
++        : RESTRICT_ASM_ALL64 [block]"+&r"(block)
+         : [w_arr]"r"(W_arr)
+         : "memory"
+     );
+diff --git a/libavcodec/mips/vp3dsp_idct_mmi.c b/libavcodec/mips/vp3dsp_idct_mmi.c
+index c5c4cf3127..cc1e5bf595 100644
+--- a/libavcodec/mips/vp3dsp_idct_mmi.c
++++ b/libavcodec/mips/vp3dsp_idct_mmi.c
+@@ -722,6 +722,8 @@ void ff_put_no_rnd_pixels_l2_mmi(uint8_t *dst, const uint8_t *src1,
+     if (h == 8) {
+         double ftmp[6];
+         uint64_t tmp[2];
++        DECLARE_VAR_ALL64;
++    
+         __asm__ volatile (
+             "li          %[tmp0],        0x08                            \n\t"
+             "li          %[tmp1],        0xfefefefe                      \n\t"
+@@ -730,10 +732,8 @@ void ff_put_no_rnd_pixels_l2_mmi(uint8_t *dst, const uint8_t *src1,
+             "li          %[tmp1],        0x01                            \n\t"
+             "dmtc1       %[tmp1],        %[ftmp5]                        \n\t"
+             "1:                                                          \n\t"
+-            "gsldlc1     %[ftmp1],       0x07(%[src1])                   \n\t"
+-            "gsldrc1     %[ftmp1],       0x00(%[src1])                   \n\t"
+-            "gsldlc1     %[ftmp2],       0x07(%[src2])                   \n\t"
+-            "gsldrc1     %[ftmp2],       0x00(%[src2])                   \n\t"
++            MMI_ULDC1(%[ftmp1], %[src1], 0x0)
++            MMI_ULDC1(%[ftmp2], %[src2], 0x0)
+             "xor         %[ftmp3],       %[ftmp1],             %[ftmp2]  \n\t"
+             "and         %[ftmp3],       %[ftmp3],             %[ftmp4]  \n\t"
+             "psrlw       %[ftmp3],       %[ftmp3],             %[ftmp5]  \n\t"
+@@ -745,7 +745,8 @@ void ff_put_no_rnd_pixels_l2_mmi(uint8_t *dst, const uint8_t *src1,
+             PTR_ADDU    "%[dst],         %[dst],               %[stride] \n\t"
+             PTR_ADDIU   "%[tmp0],        %[tmp0],              -0x01     \n\t"
+             "bnez        %[tmp0],        1b                              \n\t"
+-            : [dst]"+&r"(dst), [src1]"+&r"(src1), [src2]"+&r"(src2),
++            : RESTRICT_ASM_ALL64
++              [dst]"+&r"(dst), [src1]"+&r"(src1), [src2]"+&r"(src2),
+               [ftmp1]"=&f"(ftmp[0]), [ftmp2]"=&f"(ftmp[1]), [ftmp3]"=&f"(ftmp[2]),
+               [ftmp4]"=&f"(ftmp[3]), [ftmp5]"=&f"(ftmp[4]), [ftmp6]"=&f"(ftmp[5]),
+               [tmp0]"=&r"(tmp[0]), [tmp1]"=&r"(tmp[1])
+diff --git a/libavcodec/mips/vp8dsp_mmi.c b/libavcodec/mips/vp8dsp_mmi.c
+index bd80aa1445..f76c8625f0 100644
+--- a/libavcodec/mips/vp8dsp_mmi.c
++++ b/libavcodec/mips/vp8dsp_mmi.c
+@@ -789,51 +789,40 @@ static av_always_inline void vp8_v_loop_filter8_mmi(uint8_t *dst,
+     DECLARE_DOUBLE_1;
+     DECLARE_DOUBLE_2;
+     DECLARE_UINT32_T;
++    DECLARE_VAR_ALL64;
++
+     __asm__ volatile(
+         /* Get data from dst */
+-        "gsldlc1    %[q0],      0x07(%[dst])                      \n\t"
+-        "gsldrc1    %[q0],      0x00(%[dst])                      \n\t"
++        MMI_ULDC1(%[q0], %[dst], 0x0)
+         PTR_SUBU    "%[tmp0],   %[dst],         %[stride]         \n\t"
+-        "gsldlc1    %[p0],      0x07(%[tmp0])                     \n\t"
+-        "gsldrc1    %[p0],      0x00(%[tmp0])                     \n\t"
++        MMI_ULDC1(%[p0], %[tmp0], 0x0)
+         PTR_SUBU    "%[tmp0],   %[tmp0],        %[stride]         \n\t"
+-        "gsldlc1    %[p1],      0x07(%[tmp0])                     \n\t"
+-        "gsldrc1    %[p1],      0x00(%[tmp0])                     \n\t"
++        MMI_ULDC1(%[p1], %[tmp0], 0x0)
+         PTR_SUBU    "%[tmp0],   %[tmp0],        %[stride]         \n\t"
+-        "gsldlc1    %[p2],      0x07(%[tmp0])                     \n\t"
+-        "gsldrc1    %[p2],      0x00(%[tmp0])                     \n\t"
++        MMI_ULDC1(%[p2], %[tmp0], 0x0)
+         PTR_SUBU    "%[tmp0],   %[tmp0],        %[stride]         \n\t"
+-        "gsldlc1    %[p3],      0x07(%[tmp0])                     \n\t"
+-        "gsldrc1    %[p3],      0x00(%[tmp0])                     \n\t"
++        MMI_ULDC1(%[p3], %[tmp0], 0x0)
+         PTR_ADDU    "%[tmp0],   %[dst],         %[stride]         \n\t"
+-        "gsldlc1    %[q1],      0x07(%[tmp0])                     \n\t"
+-        "gsldrc1    %[q1],      0x00(%[tmp0])                     \n\t"
++        MMI_ULDC1(%[q1], %[tmp0], 0x0)
+         PTR_ADDU    "%[tmp0],   %[tmp0],        %[stride]         \n\t"
+-        "gsldlc1    %[q2],      0x07(%[tmp0])                     \n\t"
+-        "gsldrc1    %[q2],      0x00(%[tmp0])                     \n\t"
++        MMI_ULDC1(%[q2], %[tmp0], 0x0)
+         PTR_ADDU    "%[tmp0],   %[tmp0],        %[stride]         \n\t"
+-        "gsldlc1    %[q3],      0x07(%[tmp0])                     \n\t"
+-        "gsldrc1    %[q3],      0x00(%[tmp0])                     \n\t"
++        MMI_ULDC1(%[q3], %[tmp0], 0x0)
+         MMI_VP8_LOOP_FILTER
+         /* Move to dst */
+-        "gssdlc1    %[q0],      0x07(%[dst])                      \n\t"
+-        "gssdrc1    %[q0],      0x00(%[dst])                      \n\t"
++        MMI_USDC1(%[q0], %[dst], 0x0)
+         PTR_SUBU    "%[tmp0],   %[dst],         %[stride]         \n\t"
+-        "gssdlc1    %[p0],      0x07(%[tmp0])                     \n\t"
+-        "gssdrc1    %[p0],      0x00(%[tmp0])                     \n\t"
++        MMI_USDC1(%[p0], %[tmp0], 0x0)
+         PTR_SUBU    "%[tmp0],   %[tmp0],        %[stride]         \n\t"
+-        "gssdlc1    %[p1],      0x07(%[tmp0])                     \n\t"
+-        "gssdrc1    %[p1],      0x00(%[tmp0])                     \n\t"
++        MMI_USDC1(%[p1], %[tmp0], 0x0)
+         PTR_SUBU    "%[tmp0],   %[tmp0],        %[stride]         \n\t"
+-        "gssdlc1    %[p2],      0x07(%[tmp0])                     \n\t"
+-        "gssdrc1    %[p2],      0x00(%[tmp0])                     \n\t"
++        MMI_USDC1(%[p2], %[tmp0], 0x0)
+         PTR_ADDU    "%[tmp0],   %[dst],         %[stride]         \n\t"
+-        "gssdlc1    %[q1],      0x07(%[tmp0])                     \n\t"
+-        "gssdrc1    %[q1],      0x00(%[tmp0])                     \n\t"
++        MMI_USDC1(%[q1], %[tmp0], 0x0)
+         PTR_ADDU    "%[tmp0],   %[tmp0],        %[stride]         \n\t"
+-        "gssdlc1    %[q2],      0x07(%[tmp0])                     \n\t"
+-        "gssdrc1    %[q2],      0x00(%[tmp0])                     \n\t"
+-        : [p3]"=&f"(ftmp[0]),       [p2]"=&f"(ftmp[1]),
++        MMI_USDC1(%[q2], %[tmp0], 0x0)
++        : RESTRICT_ASM_ALL64
++          [p3]"=&f"(ftmp[0]),       [p2]"=&f"(ftmp[1]),
+           [p1]"=&f"(ftmp[2]),       [p0]"=&f"(ftmp[3]),
+           [q0]"=&f"(ftmp[4]),       [q1]"=&f"(ftmp[5]),
+           [q2]"=&f"(ftmp[6]),       [q3]"=&f"(ftmp[7]),
+@@ -874,31 +863,25 @@ static av_always_inline void vp8_h_loop_filter8_mmi(uint8_t *dst,
+     DECLARE_DOUBLE_1;
+     DECLARE_DOUBLE_2;
+     DECLARE_UINT32_T;
++    DECLARE_VAR_ALL64;
++
+     __asm__ volatile(
+         /* Get data from dst */
+-        "gsldlc1    %[p3],        0x03(%[dst])                    \n\t"
+-        "gsldrc1    %[p3],        -0x04(%[dst])                   \n\t"
++        MMI_ULDC1(%[p3], %[dst], -0x04)
+         PTR_ADDU    "%[tmp0],     %[dst],           %[stride]     \n\t"
+-        "gsldlc1    %[p2],        0x03(%[tmp0])                   \n\t"
+-        "gsldrc1    %[p2],        -0x04(%[tmp0])                  \n\t"
++        MMI_ULDC1(%[p2], %[tmp0], -0x04)
+         PTR_ADDU    "%[tmp0],     %[tmp0],          %[stride]     \n\t"
+-        "gsldlc1    %[p1],        0x03(%[tmp0])                   \n\t"
+-        "gsldrc1    %[p1],        -0x04(%[tmp0])                  \n\t"
++        MMI_ULDC1(%[p1], %[tmp0], -0x04)
+         PTR_ADDU    "%[tmp0],     %[tmp0],          %[stride]     \n\t"
+-        "gsldlc1    %[p0],        0x03(%[tmp0])                   \n\t"
+-        "gsldrc1    %[p0],        -0x04(%[tmp0])                  \n\t"
++        MMI_ULDC1(%[p0], %[tmp0], -0x04)
+         PTR_ADDU    "%[tmp0],     %[tmp0],          %[stride]     \n\t"
+-        "gsldlc1    %[q0],        0x03(%[tmp0])                   \n\t"
+-        "gsldrc1    %[q0],        -0x04(%[tmp0])                  \n\t"
++        MMI_ULDC1(%[q0], %[tmp0], -0x04)
+         PTR_ADDU    "%[tmp0],     %[tmp0],          %[stride]     \n\t"
+-        "gsldlc1    %[q1],        0x03(%[tmp0])                   \n\t"
+-        "gsldrc1    %[q1],        -0x04(%[tmp0])                  \n\t"
++        MMI_ULDC1(%[q1], %[tmp0], -0x04)
+         PTR_ADDU    "%[tmp0],     %[tmp0],          %[stride]     \n\t"
+-        "gsldlc1    %[q2],        0x03(%[tmp0])                   \n\t"
+-        "gsldrc1    %[q2],        -0x04(%[tmp0])                  \n\t"
++        MMI_ULDC1(%[q2], %[tmp0], -0x04)
+         PTR_ADDU    "%[tmp0],     %[tmp0],          %[stride]     \n\t"
+-        "gsldlc1    %[q3],        0x03(%[tmp0])                   \n\t"
+-        "gsldrc1    %[q3],        -0x04(%[tmp0])                  \n\t"
++        MMI_ULDC1(%[q3], %[tmp0], -0x04)
+         /* Matrix transpose */
+         TRANSPOSE_8B(%[p3], %[p2], %[p1], %[p0],
+                      %[q0], %[q1], %[q2], %[q3],
+@@ -909,30 +892,23 @@ static av_always_inline void vp8_h_loop_filter8_mmi(uint8_t *dst,
+                      %[q0], %[q1], %[q2], %[q3],
+                      %[ftmp1], %[ftmp2], %[ftmp3], %[ftmp4])
+         /* Move to dst */
+-        "gssdlc1    %[p3],        0x03(%[dst])                    \n\t"
+-        "gssdrc1    %[p3],        -0x04(%[dst])                   \n\t"
++        MMI_USDC1(%[p3], %[dst], -0x04)
+         PTR_ADDU    "%[dst],      %[dst],           %[stride]     \n\t"
+-        "gssdlc1    %[p2],        0x03(%[dst])                    \n\t"
+-        "gssdrc1    %[p2],        -0x04(%[dst])                   \n\t"
++        MMI_USDC1(%[p2], %[dst], -0x04)
+         PTR_ADDU    "%[dst],      %[dst],           %[stride]     \n\t"
+-        "gssdlc1    %[p1],        0x03(%[dst])                    \n\t"
+-        "gssdrc1    %[p1],        -0x04(%[dst])                   \n\t"
++        MMI_USDC1(%[p1], %[dst], -0x04)
+         PTR_ADDU    "%[dst],      %[dst],           %[stride]     \n\t"
+-        "gssdlc1    %[p0],        0x03(%[dst])                    \n\t"
+-        "gssdrc1    %[p0],        -0x04(%[dst])                   \n\t"
++        MMI_USDC1(%[p0], %[dst], -0x04)
+         PTR_ADDU    "%[dst],      %[dst],           %[stride]     \n\t"
+-        "gssdlc1    %[q0],        0x03(%[dst])                    \n\t"
+-        "gssdrc1    %[q0],        -0x04(%[dst])                   \n\t"
++        MMI_USDC1(%[q0], %[dst], -0x04)
+         PTR_ADDU    "%[dst],      %[dst],           %[stride]     \n\t"
+-        "gssdlc1    %[q1],        0x03(%[dst])                    \n\t"
+-        "gssdrc1    %[q1],        -0x04(%[dst])                   \n\t"
++        MMI_USDC1(%[q1], %[dst], -0x04)
+         PTR_ADDU    "%[dst],      %[dst],           %[stride]     \n\t"
+-        "gssdlc1    %[q2],        0x03(%[dst])                    \n\t"
+-        "gssdrc1    %[q2],        -0x04(%[dst])                   \n\t"
++        MMI_USDC1(%[q2], %[dst], -0x04)
+         PTR_ADDU    "%[dst],      %[dst],           %[stride]     \n\t"
+-        "gssdlc1    %[q3],        0x03(%[dst])                    \n\t"
+-        "gssdrc1    %[q3],        -0x04(%[dst])                   \n\t"
+-        : [p3]"=&f"(ftmp[0]),       [p2]"=&f"(ftmp[1]),
++        MMI_USDC1(%[q3], %[dst], -0x04)
++        : RESTRICT_ASM_ALL64
++          [p3]"=&f"(ftmp[0]),       [p2]"=&f"(ftmp[1]),
+           [p1]"=&f"(ftmp[2]),       [p0]"=&f"(ftmp[3]),
+           [q0]"=&f"(ftmp[4]),       [q1]"=&f"(ftmp[5]),
+           [q2]"=&f"(ftmp[6]),       [q3]"=&f"(ftmp[7]),
+diff --git a/libavcodec/mips/vp9_mc_mmi.c b/libavcodec/mips/vp9_mc_mmi.c
+index e7a83875b9..57825fb967 100644
+--- a/libavcodec/mips/vp9_mc_mmi.c
++++ b/libavcodec/mips/vp9_mc_mmi.c
+@@ -77,29 +77,24 @@ static void convolve_horiz_mmi(const uint8_t *src, int32_t src_stride,
+ {
+     double ftmp[15];
+     uint32_t tmp[2];
++    DECLARE_VAR_ALL64;
+     src -= 3;
+     src_stride -= w;
+     dst_stride -= w;
+     __asm__ volatile (
+         "move       %[tmp1],    %[width]                   \n\t"
+         "xor        %[ftmp0],   %[ftmp0],    %[ftmp0]      \n\t"
+-        "gsldlc1    %[filter1], 0x03(%[filter])            \n\t"
+-        "gsldrc1    %[filter1], 0x00(%[filter])            \n\t"
+-        "gsldlc1    %[filter2], 0x0b(%[filter])            \n\t"
+-        "gsldrc1    %[filter2], 0x08(%[filter])            \n\t"
++        MMI_LDLRC1(%[filter1], %[filter], 0x00, 0x03)
++        MMI_LDLRC1(%[filter2], %[filter], 0x08, 0x03)
+         "li         %[tmp0],    0x07                       \n\t"
+         "dmtc1      %[tmp0],    %[ftmp13]                  \n\t"
+         "punpcklwd  %[ftmp13],  %[ftmp13],   %[ftmp13]     \n\t"
+         "1:                                                \n\t"
+         /* Get 8 data per row */
+-        "gsldlc1    %[ftmp5],   0x07(%[src])               \n\t"
+-        "gsldrc1    %[ftmp5],   0x00(%[src])               \n\t"
+-        "gsldlc1    %[ftmp7],   0x08(%[src])               \n\t"
+-        "gsldrc1    %[ftmp7],   0x01(%[src])               \n\t"
+-        "gsldlc1    %[ftmp9],   0x09(%[src])               \n\t"
+-        "gsldrc1    %[ftmp9],   0x02(%[src])               \n\t"
+-        "gsldlc1    %[ftmp11],  0x0A(%[src])               \n\t"
+-        "gsldrc1    %[ftmp11],  0x03(%[src])               \n\t"
++        MMI_ULDC1(%[ftmp5], %[src], 0x00)
++        MMI_ULDC1(%[ftmp7], %[src], 0x01)
++        MMI_ULDC1(%[ftmp9], %[src], 0x02)
++        MMI_ULDC1(%[ftmp11], %[src], 0x03)
+         "punpcklbh  %[ftmp4],   %[ftmp5],    %[ftmp0]      \n\t"
+         "punpckhbh  %[ftmp5],   %[ftmp5],    %[ftmp0]      \n\t"
+         "punpcklbh  %[ftmp6],   %[ftmp7],    %[ftmp0]      \n\t"
+@@ -127,7 +122,8 @@ static void convolve_horiz_mmi(const uint8_t *src, int32_t src_stride,
+         PTR_ADDU   "%[dst],     %[dst],      %[dst_stride] \n\t"
+         PTR_ADDIU  "%[height],  %[height],   -0x01         \n\t"
+         "bnez       %[height],  1b                         \n\t"
+-        : [srcl]"=&f"(ftmp[0]),     [srch]"=&f"(ftmp[1]),
++        : RESTRICT_ASM_ALL64
++          [srcl]"=&f"(ftmp[0]),     [srch]"=&f"(ftmp[1]),
+           [filter1]"=&f"(ftmp[2]),  [filter2]"=&f"(ftmp[3]),
+           [ftmp0]"=&f"(ftmp[4]),    [ftmp4]"=&f"(ftmp[5]),
+           [ftmp5]"=&f"(ftmp[6]),    [ftmp6]"=&f"(ftmp[7]),
+@@ -153,15 +149,14 @@ static void convolve_vert_mmi(const uint8_t *src, int32_t src_stride,
+     double ftmp[17];
+     uint32_t tmp[1];
+     ptrdiff_t addr = src_stride;
++    DECLARE_VAR_ALL64;
+     src_stride -= w;
+     dst_stride -= w;
+ 
+     __asm__ volatile (
+         "xor        %[ftmp0],    %[ftmp0],   %[ftmp0]      \n\t"
+-        "gsldlc1    %[ftmp4],    0x03(%[filter])           \n\t"
+-        "gsldrc1    %[ftmp4],    0x00(%[filter])           \n\t"
+-        "gsldlc1    %[ftmp5],    0x0b(%[filter])           \n\t"
+-        "gsldrc1    %[ftmp5],    0x08(%[filter])           \n\t"
++        MMI_LDLRC1(%[ftmp4], %[filter], 0x00, 0x03)
++        MMI_LDLRC1(%[ftmp5], %[filter], 0x08, 0x03)
+         "punpcklwd  %[filter10], %[ftmp4],   %[ftmp4]      \n\t"
+         "punpckhwd  %[filter32], %[ftmp4],   %[ftmp4]      \n\t"
+         "punpcklwd  %[filter54], %[ftmp5],   %[ftmp5]      \n\t"
+@@ -171,29 +166,21 @@ static void convolve_vert_mmi(const uint8_t *src, int32_t src_stride,
+         "punpcklwd  %[ftmp13],   %[ftmp13],  %[ftmp13]     \n\t"
+         "1:                                                \n\t"
+         /* Get 8 data per column */
+-        "gsldlc1    %[ftmp4],    0x07(%[src])              \n\t"
+-        "gsldrc1    %[ftmp4],    0x00(%[src])              \n\t"
++        MMI_ULDC1(%[ftmp4], %[src], 0x0)
+         PTR_ADDU   "%[tmp0],     %[src],     %[addr]       \n\t"
+-        "gsldlc1    %[ftmp5],    0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp5],    0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp5], %[tmp0], 0x0)
+         PTR_ADDU   "%[tmp0],     %[tmp0],    %[addr]       \n\t"
+-        "gsldlc1    %[ftmp6],    0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp6],    0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp6], %[tmp0], 0x0)
+         PTR_ADDU   "%[tmp0],     %[tmp0],    %[addr]       \n\t"
+-        "gsldlc1    %[ftmp7],    0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp7],    0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp7], %[tmp0], 0x0)
+         PTR_ADDU   "%[tmp0],     %[tmp0],    %[addr]       \n\t"
+-        "gsldlc1    %[ftmp8],    0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp8],    0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp8], %[tmp0], 0x0)
+         PTR_ADDU   "%[tmp0],     %[tmp0],    %[addr]       \n\t"
+-        "gsldlc1    %[ftmp9],    0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp9],    0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp9], %[tmp0], 0x0)
+         PTR_ADDU   "%[tmp0],     %[tmp0],    %[addr]       \n\t"
+-        "gsldlc1    %[ftmp10],   0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp10],   0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp10], %[tmp0], 0x0)
+         PTR_ADDU   "%[tmp0],     %[tmp0],    %[addr]       \n\t"
+-        "gsldlc1    %[ftmp11],   0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp11],   0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp11], %[tmp0], 0x0)
+         "punpcklbh  %[ftmp4],    %[ftmp4],   %[ftmp0]      \n\t"
+         "punpcklbh  %[ftmp5],    %[ftmp5],   %[ftmp0]      \n\t"
+         "punpcklbh  %[ftmp6],    %[ftmp6],   %[ftmp0]      \n\t"
+@@ -221,7 +208,8 @@ static void convolve_vert_mmi(const uint8_t *src, int32_t src_stride,
+         PTR_ADDU   "%[dst],      %[dst],     %[dst_stride] \n\t"
+         PTR_ADDIU  "%[height],   %[height],  -0x01         \n\t"
+         "bnez       %[height],   1b                        \n\t"
+-        : [srcl]"=&f"(ftmp[0]),     [srch]"=&f"(ftmp[1]),
++        : RESTRICT_ASM_ALL64
++          [srcl]"=&f"(ftmp[0]),     [srch]"=&f"(ftmp[1]),
+           [filter10]"=&f"(ftmp[2]), [filter32]"=&f"(ftmp[3]),
+           [filter54]"=&f"(ftmp[4]), [filter76]"=&f"(ftmp[5]),
+           [ftmp0]"=&f"(ftmp[6]),    [ftmp4]"=&f"(ftmp[7]),
+@@ -247,6 +235,7 @@ static void convolve_avg_horiz_mmi(const uint8_t *src, int32_t src_stride,
+ {
+     double ftmp[15];
+     uint32_t tmp[2];
++    DECLARE_VAR_ALL64;
+     src -= 3;
+     src_stride -= w;
+     dst_stride -= w;
+@@ -254,23 +243,17 @@ static void convolve_avg_horiz_mmi(const uint8_t *src, int32_t src_stride,
+     __asm__ volatile (
+         "move       %[tmp1],    %[width]                   \n\t"
+         "xor        %[ftmp0],   %[ftmp0],    %[ftmp0]      \n\t"
+-        "gsldlc1    %[filter1], 0x03(%[filter])            \n\t"
+-        "gsldrc1    %[filter1], 0x00(%[filter])            \n\t"
+-        "gsldlc1    %[filter2], 0x0b(%[filter])            \n\t"
+-        "gsldrc1    %[filter2], 0x08(%[filter])            \n\t"
++        MMI_LDLRC1(%[filter1], %[filter], 0x00, 0x03)
++        MMI_LDLRC1(%[filter2], %[filter], 0x08, 0x03)
+         "li         %[tmp0],    0x07                       \n\t"
+         "dmtc1      %[tmp0],    %[ftmp13]                  \n\t"
+         "punpcklwd  %[ftmp13],  %[ftmp13],   %[ftmp13]     \n\t"
+         "1:                                                \n\t"
+         /* Get 8 data per row */
+-        "gsldlc1    %[ftmp5],   0x07(%[src])               \n\t"
+-        "gsldrc1    %[ftmp5],   0x00(%[src])               \n\t"
+-        "gsldlc1    %[ftmp7],   0x08(%[src])               \n\t"
+-        "gsldrc1    %[ftmp7],   0x01(%[src])               \n\t"
+-        "gsldlc1    %[ftmp9],   0x09(%[src])               \n\t"
+-        "gsldrc1    %[ftmp9],   0x02(%[src])               \n\t"
+-        "gsldlc1    %[ftmp11],  0x0A(%[src])               \n\t"
+-        "gsldrc1    %[ftmp11],  0x03(%[src])               \n\t"
++        MMI_ULDC1(%[ftmp5], %[src], 0x00)
++        MMI_ULDC1(%[ftmp7], %[src], 0x01)
++        MMI_ULDC1(%[ftmp9], %[src], 0x02)
++        MMI_ULDC1(%[ftmp11], %[src], 0x03)
+         "punpcklbh  %[ftmp4],   %[ftmp5],    %[ftmp0]      \n\t"
+         "punpckhbh  %[ftmp5],   %[ftmp5],    %[ftmp0]      \n\t"
+         "punpcklbh  %[ftmp6],   %[ftmp7],    %[ftmp0]      \n\t"
+@@ -289,8 +272,7 @@ static void convolve_avg_horiz_mmi(const uint8_t *src, int32_t src_stride,
+         "packsswh   %[srcl],    %[srcl],     %[srch]       \n\t"
+         "packushb   %[ftmp12],  %[srcl],     %[ftmp0]      \n\t"
+         "punpcklbh  %[ftmp12],  %[ftmp12],   %[ftmp0]      \n\t"
+-        "gsldlc1    %[ftmp4],   0x07(%[dst])               \n\t"
+-        "gsldrc1    %[ftmp4],   0x00(%[dst])               \n\t"
++        MMI_ULDC1(%[ftmp4], %[dst], 0x0)
+         "punpcklbh  %[ftmp4],   %[ftmp4],    %[ftmp0]      \n\t"
+         "paddh      %[ftmp12],  %[ftmp12],   %[ftmp4]      \n\t"
+         "li         %[tmp0],    0x10001                    \n\t"
+@@ -309,7 +291,8 @@ static void convolve_avg_horiz_mmi(const uint8_t *src, int32_t src_stride,
+         PTR_ADDU   "%[dst],     %[dst],      %[dst_stride] \n\t"
+         PTR_ADDIU  "%[height],  %[height],   -0x01         \n\t"
+         "bnez       %[height],  1b                         \n\t"
+-        : [srcl]"=&f"(ftmp[0]),     [srch]"=&f"(ftmp[1]),
++        : RESTRICT_ASM_ALL64
++          [srcl]"=&f"(ftmp[0]),     [srch]"=&f"(ftmp[1]),
+           [filter1]"=&f"(ftmp[2]),  [filter2]"=&f"(ftmp[3]),
+           [ftmp0]"=&f"(ftmp[4]),    [ftmp4]"=&f"(ftmp[5]),
+           [ftmp5]"=&f"(ftmp[6]),    [ftmp6]"=&f"(ftmp[7]),
+@@ -335,15 +318,14 @@ static void convolve_avg_vert_mmi(const uint8_t *src, int32_t src_stride,
+     double ftmp[17];
+     uint32_t tmp[1];
+     ptrdiff_t addr = src_stride;
++    DECLARE_VAR_ALL64;
+     src_stride -= w;
+     dst_stride -= w;
+ 
+     __asm__ volatile (
+         "xor        %[ftmp0],    %[ftmp0],   %[ftmp0]      \n\t"
+-        "gsldlc1    %[ftmp4],    0x03(%[filter])           \n\t"
+-        "gsldrc1    %[ftmp4],    0x00(%[filter])           \n\t"
+-        "gsldlc1    %[ftmp5],    0x0b(%[filter])           \n\t"
+-        "gsldrc1    %[ftmp5],    0x08(%[filter])           \n\t"
++        MMI_LDLRC1(%[ftmp4], %[filter], 0x00, 0x03)
++        MMI_LDLRC1(%[ftmp5], %[filter], 0x08, 0x03)
+         "punpcklwd  %[filter10], %[ftmp4],   %[ftmp4]      \n\t"
+         "punpckhwd  %[filter32], %[ftmp4],   %[ftmp4]      \n\t"
+         "punpcklwd  %[filter54], %[ftmp5],   %[ftmp5]      \n\t"
+@@ -353,29 +335,21 @@ static void convolve_avg_vert_mmi(const uint8_t *src, int32_t src_stride,
+         "punpcklwd  %[ftmp13],   %[ftmp13],  %[ftmp13]     \n\t"
+         "1:                                                \n\t"
+         /* Get 8 data per column */
+-        "gsldlc1    %[ftmp4],    0x07(%[src])              \n\t"
+-        "gsldrc1    %[ftmp4],    0x00(%[src])              \n\t"
++        MMI_ULDC1(%[ftmp4], %[src], 0x0)
+         PTR_ADDU   "%[tmp0],     %[src],     %[addr]       \n\t"
+-        "gsldlc1    %[ftmp5],    0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp5],    0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp5], %[tmp0], 0x0)
+         PTR_ADDU   "%[tmp0],     %[tmp0],    %[addr]       \n\t"
+-        "gsldlc1    %[ftmp6],    0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp6],    0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp6], %[tmp0], 0x0)
+         PTR_ADDU   "%[tmp0],     %[tmp0],    %[addr]       \n\t"
+-        "gsldlc1    %[ftmp7],    0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp7],    0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp7], %[tmp0], 0x0)
+         PTR_ADDU   "%[tmp0],     %[tmp0],    %[addr]       \n\t"
+-        "gsldlc1    %[ftmp8],    0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp8],    0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp8], %[tmp0], 0x0)
+         PTR_ADDU   "%[tmp0],     %[tmp0],    %[addr]       \n\t"
+-        "gsldlc1    %[ftmp9],    0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp9],    0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp9], %[tmp0], 0x0)
+         PTR_ADDU   "%[tmp0],     %[tmp0],    %[addr]       \n\t"
+-        "gsldlc1    %[ftmp10],   0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp10],   0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp10], %[tmp0], 0x0)
+         PTR_ADDU   "%[tmp0],     %[tmp0],    %[addr]       \n\t"
+-        "gsldlc1    %[ftmp11],   0x07(%[tmp0])             \n\t"
+-        "gsldrc1    %[ftmp11],   0x00(%[tmp0])             \n\t"
++        MMI_ULDC1(%[ftmp11], %[tmp0], 0x0)
+         "punpcklbh  %[ftmp4],    %[ftmp4],   %[ftmp0]      \n\t"
+         "punpcklbh  %[ftmp5],    %[ftmp5],   %[ftmp0]      \n\t"
+         "punpcklbh  %[ftmp6],    %[ftmp6],   %[ftmp0]      \n\t"
+@@ -394,8 +368,7 @@ static void convolve_avg_vert_mmi(const uint8_t *src, int32_t src_stride,
+         "packsswh   %[srcl],     %[srcl],    %[srch]       \n\t"
+         "packushb   %[ftmp12],   %[srcl],    %[ftmp0]      \n\t"
+         "punpcklbh  %[ftmp12],   %[ftmp12],  %[ftmp0]      \n\t"
+-        "gsldlc1    %[ftmp4],    0x07(%[dst])              \n\t"
+-        "gsldrc1    %[ftmp4],    0x00(%[dst])              \n\t"
++        MMI_ULDC1(%[ftmp4], %[dst], 0x00)
+         "punpcklbh  %[ftmp4],    %[ftmp4],   %[ftmp0]      \n\t"
+         "paddh      %[ftmp12],   %[ftmp12],  %[ftmp4]      \n\t"
+         "li         %[tmp0],     0x10001                   \n\t"
+@@ -414,7 +387,8 @@ static void convolve_avg_vert_mmi(const uint8_t *src, int32_t src_stride,
+         PTR_ADDU   "%[dst],      %[dst],     %[dst_stride] \n\t"
+         PTR_ADDIU  "%[height],   %[height],  -0x01         \n\t"
+         "bnez       %[height],   1b                        \n\t"
+-        : [srcl]"=&f"(ftmp[0]),     [srch]"=&f"(ftmp[1]),
++        : RESTRICT_ASM_ALL64
++          [srcl]"=&f"(ftmp[0]),     [srch]"=&f"(ftmp[1]),
+           [filter10]"=&f"(ftmp[2]), [filter32]"=&f"(ftmp[3]),
+           [filter54]"=&f"(ftmp[4]), [filter76]"=&f"(ftmp[5]),
+           [ftmp0]"=&f"(ftmp[6]),    [ftmp4]"=&f"(ftmp[7]),
+@@ -439,6 +413,7 @@ static void convolve_avg_mmi(const uint8_t *src, int32_t src_stride,
+ {
+     double ftmp[4];
+     uint32_t tmp[2];
++    DECLARE_VAR_ALL64;
+     src_stride -= w;
+     dst_stride -= w;
+ 
+@@ -449,10 +424,8 @@ static void convolve_avg_mmi(const uint8_t *src, int32_t src_stride,
+         "dmtc1      %[tmp0],    %[ftmp3]                  \n\t"
+         "punpcklhw  %[ftmp3],   %[ftmp3],   %[ftmp3]      \n\t"
+         "1:                                               \n\t"
+-        "gslwlc1    %[ftmp1],   0x07(%[src])              \n\t"
+-        "gslwrc1    %[ftmp1],   0x00(%[src])              \n\t"
+-        "gslwlc1    %[ftmp2],   0x07(%[dst])              \n\t"
+-        "gslwrc1    %[ftmp2],   0x00(%[dst])              \n\t"
++        MMI_ULDC1(%[ftmp1], %[src], 0x00)
++        MMI_ULDC1(%[ftmp2], %[dst], 0x00)
+         "punpcklbh  %[ftmp1],   %[ftmp1],   %[ftmp0]      \n\t"
+         "punpcklbh  %[ftmp2],   %[ftmp2],   %[ftmp0]      \n\t"
+         "paddh      %[ftmp1],   %[ftmp1],   %[ftmp2]      \n\t"
+@@ -469,7 +442,8 @@ static void convolve_avg_mmi(const uint8_t *src, int32_t src_stride,
+         PTR_ADDU   "%[src],     %[src],     %[src_stride] \n\t"
+         PTR_ADDIU  "%[height],  %[height],  -0x01         \n\t"
+         "bnez       %[height],  1b                        \n\t"
+-        : [ftmp0]"=&f"(ftmp[0]),  [ftmp1]"=&f"(ftmp[1]),
++        : RESTRICT_ASM_ALL64
++          [ftmp0]"=&f"(ftmp[0]),  [ftmp1]"=&f"(ftmp[1]),
+           [ftmp2]"=&f"(ftmp[2]),  [ftmp3]"=&f"(ftmp[3]),
+           [tmp0]"=&r"(tmp[0]),    [tmp1]"=&r"(tmp[1]),
+           [src]"+&r"(src),        [dst]"+&r"(dst),
+-- 
+2.30.1
+

--- a/extra-multimedia/ffmpeg/autobuild/patches/0026-avutil-mips-Use-at-as-MMI-macro-temporary-register.patch
+++ b/extra-multimedia/ffmpeg/autobuild/patches/0026-avutil-mips-Use-at-as-MMI-macro-temporary-register.patch
@@ -1,0 +1,198 @@
+From e379fc423ae4b63b635f512968f757f44f212f29 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Thu, 18 Feb 2021 17:35:03 +0800
+Subject: [PATCH 26/26] avutil/mips: Use $at as MMI macro temporary register
+
+Some function had exceed 30 inline assembly register oprands limiation
+when using LOONGSON2 version of MMI macros. We can avoid that by take
+$at, which is register reserved for assembler, as temporary register.
+
+As none of instructions used in these macros is pseudo, it is safe to
+utilize $at here.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+---
+ libavutil/mips/mmiutils.h | 115 +++++++++++++++++++++++---------------
+ 1 file changed, 69 insertions(+), 46 deletions(-)
+
+diff --git a/libavutil/mips/mmiutils.h b/libavutil/mips/mmiutils.h
+index 3994085057..7b7b405ddf 100644
+--- a/libavutil/mips/mmiutils.h
++++ b/libavutil/mips/mmiutils.h
+@@ -27,78 +27,107 @@
+ #include "config.h"
+ #include "libavutil/mips/asmdefs.h"
+ 
+-#if HAVE_LOONGSON2
++/* 
++ * These were used to define temporary registers for MMI marcos
++ * however now we're using $at. They're theoretically unnecessary
++ * but just leave them here to avoid mess.
++ */
++#define DECLARE_VAR_LOW32
++#define RESTRICT_ASM_LOW32
++#define DECLARE_VAR_ALL64
++#define RESTRICT_ASM_ALL64
++#define DECLARE_VAR_ADDRT
++#define RESTRICT_ASM_ADDRT
+ 
+-#define DECLARE_VAR_LOW32       int32_t low32
+-#define RESTRICT_ASM_LOW32      [low32]"=&r"(low32),
+-#define DECLARE_VAR_ALL64       int64_t all64
+-#define RESTRICT_ASM_ALL64      [all64]"=&r"(all64),
+-#define DECLARE_VAR_ADDRT       mips_reg addrt
+-#define RESTRICT_ASM_ADDRT      [addrt]"=&r"(addrt),
++#if HAVE_LOONGSON2
+ 
+ #define MMI_LWX(reg, addr, stride, bias)                                    \
+-    PTR_ADDU    "%[addrt],  "#addr",    "#stride"                   \n\t"   \
+-    "lw         "#reg",     "#bias"(%[addrt])                       \n\t"
++    ".set noat                                                 \n\t"   \
++    PTR_ADDU    "$at,  "#addr",    "#stride"                   \n\t"   \
++    "lw         "#reg",     "#bias"($at)                       \n\t"   \
++    ".set at                                                   \n\t"
+ 
+ #define MMI_SWX(reg, addr, stride, bias)                                    \
+-    PTR_ADDU    "%[addrt],  "#addr",    "#stride"                   \n\t"   \
+-    "sw         "#reg",     "#bias"(%[addrt])                       \n\t"
++    ".set noat                                                 \n\t"   \
++    PTR_ADDU    "$at,  "#addr",    "#stride"                   \n\t"   \
++    "sw         "#reg",     "#bias"($at)                       \n\t"   \
++    ".set at                                                   \n\t"
+ 
+ #define MMI_LDX(reg, addr, stride, bias)                                    \
+-    PTR_ADDU    "%[addrt],  "#addr",    "#stride"                   \n\t"   \
+-    "ld         "#reg",     "#bias"(%[addrt])                       \n\t"
++    ".set noat                                                 \n\t"   \
++    PTR_ADDU    "$at,  "#addr",    "#stride"                   \n\t"   \
++    "ld         "#reg",     "#bias"($at)                       \n\t"   \
++    ".set at                                                   \n\t"
+ 
+ #define MMI_SDX(reg, addr, stride, bias)                                    \
+-    PTR_ADDU    "%[addrt],  "#addr",    "#stride"                   \n\t"   \
+-    "sd         "#reg",     "#bias"(%[addrt])                       \n\t"
++    ".set noat                                                 \n\t"   \
++    PTR_ADDU    "$at,  "#addr",    "#stride"                   \n\t"   \
++    "sd         "#reg",     "#bias"($at)                       \n\t"   \
++    ".set at                                                   \n\t"
+ 
+ #define MMI_LWC1(fp, addr, bias)                                            \
+     "lwc1       "#fp",      "#bias"("#addr")                        \n\t"
+ 
+ #define MMI_LWLRC1(fp, addr, bias, off)                                     \
+-    "lwl        %[low32],   "#bias"+"#off"("#addr")                 \n\t"   \
+-    "lwr        %[low32],   "#bias"("#addr")                        \n\t"   \
+-    "mtc1       %[low32],   "#fp"                                   \n\t"
++    ".set noat                                                 \n\t"   \
++    "lwl        $at,   "#bias"+"#off"("#addr")                 \n\t"   \
++    "lwr        $at,   "#bias"("#addr")                        \n\t"   \
++    "mtc1       $at,   "#fp"                                   \n\t"   \
++    ".set at                                                   \n\t"
+ 
+ #define MMI_LWXC1(fp, addr, stride, bias)                                   \
+-    PTR_ADDU    "%[addrt],  "#addr",    "#stride"                   \n\t"   \
+-    MMI_LWC1(fp, %[addrt], bias)
++    ".set noat                                                 \n\t"   \
++    PTR_ADDU    "$at,  "#addr",    "#stride"                   \n\t"   \
++    MMI_LWC1(fp, $at, bias)                                            \
++    ".set at                                                   \n\t"
+ 
+ #define MMI_SWC1(fp, addr, bias)                                            \
+     "swc1       "#fp",      "#bias"("#addr")                        \n\t"
+ 
+ #define MMI_SWLRC1(fp, addr, bias, off)                                           \
+-    "mfc1       %[low32],   "#fp"                                   \n\t"   \
+-    "swl        %[low32],   "#bias"+"#off"("#addr")                 \n\t"   \
+-    "swr        %[low32],   "#bias"("#addr")                        \n\t"
++    ".set noat                                                 \n\t"   \
++    "mfc1       $at,   "#fp"                                   \n\t"   \
++    "swl        $at,   "#bias"+"#off"("#addr")                 \n\t"   \
++    "swr        $at,   "#bias"("#addr")                        \n\t"   \
++    ".set at                                                   \n\t"
+ 
+ #define MMI_SWXC1(fp, addr, stride, bias)                                   \
+-    PTR_ADDU    "%[addrt],  "#addr",    "#stride"                   \n\t"   \
+-    MMI_SWC1(fp, %[addrt], bias)
++    ".set noat                                                 \n\t"   \
++    PTR_ADDU    "$at,  "#addr",    "#stride"                   \n\t"   \
++    MMI_SWC1(fp, $at, bias)                                           \
++    ".set at                                                   \n\t"
+ 
+ #define MMI_LDC1(fp, addr, bias)                                            \
+     "ldc1       "#fp",      "#bias"("#addr")                        \n\t"
+ 
+ #define MMI_LDLRC1(fp, addr, bias, off)                                     \
+-    "ldl        %[all64],   "#bias"+"#off"("#addr")                 \n\t"   \
+-    "ldr        %[all64],   "#bias"("#addr")                        \n\t"   \
+-    "dmtc1      %[all64],   "#fp"                                   \n\t"
++    ".set noat                                                 \n\t"   \
++    "ldl        $at,   "#bias"+"#off"("#addr")                 \n\t"   \
++    "ldr        $at,   "#bias"("#addr")                        \n\t"   \
++    "dmtc1      $at,   "#fp"                                   \n\t"   \
++    ".set at                                                   \n\t"
+ 
+ #define MMI_LDXC1(fp, addr, stride, bias)                                   \
+-    PTR_ADDU    "%[addrt],  "#addr",    "#stride"                   \n\t"   \
+-    MMI_LDC1(fp, %[addrt], bias)
++    ".set noat                                                 \n\t"   \
++    PTR_ADDU    "$at,  "#addr",    "#stride"                   \n\t"   \
++    MMI_LDC1(fp, $at, bias)                                           \
++    ".set at                                                   \n\t"
+ 
+ #define MMI_SDC1(fp, addr, bias)                                            \
+     "sdc1       "#fp",      "#bias"("#addr")                        \n\t"
+ 
+ #define MMI_SDLRC1(fp, addr, bias, off)                                           \
+-    "dmfc1      %[all64],   "#fp"                                   \n\t"   \
+-    "sdl        %[all64],   "#bias"+"#off"("#addr")                 \n\t"   \
+-    "sdr        %[all64],   "#bias"("#addr")                        \n\t"
++    ".set noat                                                 \n\t"   \
++    "dmfc1      $at,   "#fp"                                   \n\t"   \
++    "sdl        $at,   "#bias"+"#off"("#addr")                 \n\t"   \
++    "sdr        $at,   "#bias"("#addr")                        \n\t"   \
++    ".set at                                                   \n\t"
+ 
+ #define MMI_SDXC1(fp, addr, stride, bias)                                   \
+-    PTR_ADDU    "%[addrt],  "#addr",    "#stride"                   \n\t"   \
+-    MMI_SDC1(fp, %[addrt], bias)
++    ".set noat                                                 \n\t"   \
++    PTR_ADDU    "$at,  "#addr",    "#stride"                   \n\t"   \
++    MMI_SDC1(fp, $at, bias)                                            \
++    ".set at                                                   \n\t"
+ 
+ #define MMI_LQ(reg1, reg2, addr, bias)                                      \
+     "ld         "#reg1",    "#bias"("#addr")                        \n\t"   \
+@@ -118,11 +147,6 @@
+ 
+ #elif HAVE_LOONGSON3 /* !HAVE_LOONGSON2 */
+ 
+-#define DECLARE_VAR_ALL64
+-#define RESTRICT_ASM_ALL64
+-#define DECLARE_VAR_ADDRT
+-#define RESTRICT_ASM_ADDRT
+-
+ #define MMI_LWX(reg, addr, stride, bias)                                    \
+     "gslwx      "#reg",     "#bias"("#addr", "#stride")             \n\t"
+ 
+@@ -140,13 +164,12 @@
+ 
+ #if _MIPS_SIM == _ABIO32 /* workaround for 3A2000 gslwlc1 bug */
+ 
+-#define DECLARE_VAR_LOW32       int32_t low32
+-#define RESTRICT_ASM_LOW32      [low32]"=&r"(low32),
+-
+ #define MMI_LWLRC1(fp, addr, bias, off)                                     \
+-    "lwl        %[low32],   "#bias"+"#off"("#addr")                 \n\t"   \
+-    "lwr        %[low32],   "#bias"("#addr")                        \n\t"   \
+-    "mtc1       %[low32],   "#fp"                                      \n\t"
++    ".set noat                                                 \n\t"   \
++    "lwl        $at,   "#bias"+"#off"("#addr")                 \n\t"   \
++    "lwr        $at,   "#bias"("#addr")                        \n\t"   \
++    "mtc1       $at,   "#fp"                                   \n\t"   \
++    ".set at                                                   \n\t"
+ 
+ #else /* _MIPS_SIM != _ABIO32 */
+ 
+-- 
+2.30.1
+


### PR DESCRIPTION
Topic Description
-----------------

Backport upstream MIPS changes and fix loongson2f inline assembly.

Package(s) Affected
-------------------
FFmpeg.

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
