### PR TITLE
ss-tproxy: fix availability

### DIFF
--- a/extra-network/chinadns-ng/autobuild/build
+++ b/extra-network/chinadns-ng/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Making..."
+make all
+
+abinfo "Installing file..."
+install -dv "$PKGDIR"/usr/bin
+install -vm0755 "$SRCDIR"/chinadns-ng "$PKGDIR"/usr/bin

--- a/extra-network/chinadns-ng/autobuild/defines
+++ b/extra-network/chinadns-ng/autobuild/defines
@@ -2,5 +2,3 @@ PKGNAME=chinadns-ng
 PKGSEC=net
 PKGDES="The next generation of chinadns, refactoring with epoll and ipset"
 PKGDEP="glibc ipset"
-
-ABTYPE=plainmake

--- a/extra-network/chinadns-ng/spec
+++ b/extra-network/chinadns-ng/spec
@@ -1,3 +1,4 @@
 VER="0.0+git20201121"
+REL=1
 SRCS="git::commit=748a043dd7fb7ec71efbb7306f9dd21db5ce560f::https://github.com/zfl9/chinadns-ng"
 CHKSUMS="SKIP"

--- a/extra-network/ss-tproxy/autobuild/build
+++ b/extra-network/ss-tproxy/autobuild/build
@@ -1,3 +1,7 @@
+abinfo "Fixing systemd service ss-tproxy exec path..."
+sed -i 's|/usr/local/bin|/usr/bin|g' "${SRCDIR}"/ss-tproxy.service
+
+abinfo "Installing ss-tproxy file..."
 install -vDm755  "${SRCDIR}"/ss-tproxy          "${PKGDIR}"/usr/bin/ss-tproxy
 install -vDm644  "${SRCDIR}"/ss-tproxy.conf     "${PKGDIR}"/etc/ss-tproxy/ss-tproxy.conf
 install -vDm644  "${SRCDIR}"/gfwlist*           "${PKGDIR}"/etc/ss-tproxy

--- a/extra-network/ss-tproxy/spec
+++ b/extra-network/ss-tproxy/spec
@@ -1,3 +1,4 @@
 VER=4.6.1
+REL=1
 SRCS="https://github.com/zfl9/ss-tproxy/archive/v${VER}.tar.gz"
 CHKSUMS="whirlpool::d2133526b02e544298f2b5bfdd2960122e6a1b7a8acd86a1f8d4d4c0852a4d09decbfb17a762fb7847bec3cfdf82680823ea6ac4aa6c2d5f10d379b6b05c6451"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

ss-tproxy: fix availability

Package(s) Affected
-------------------

ss-tproxy 4.6.1-1
chinadns-ng 0.0+git20201121-1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
