### PR TITLE
fcitx5: update to 5.0.5

### DIFF
--- a/extra-i18n/fcitx5-anthy/spec
+++ b/extra-i18n/fcitx5-anthy/spec
@@ -1,3 +1,3 @@
-VER=5.0.2
+VER=5.0.3
 SRCS="tbl::https://github.com/fcitx/fcitx5-anthy/archive/$VER.tar.gz"
-CHKSUMS="sha256::a4ec3dfea46190262c0bbcf35b8a391c899a2baec83afc18c110f0f284d6f443"
+CHKSUMS="sha256::73a8daaf193af2102b75e21a436b30ce3e7b2a49eb6615e664075bf7cc36a41e"

--- a/extra-i18n/fcitx5-chewing/spec
+++ b/extra-i18n/fcitx5-chewing/spec
@@ -1,3 +1,3 @@
-VER=5.0.3
+VER=5.0.4
 SRCS="tbl::https://github.com/fcitx/fcitx5-chewing/archive/$VER.tar.gz"
-CHKSUMS="sha256::6fae9fb01a1fef8267078b4b251d325386edb3b20cfa8d59bb20cad340b093fa"
+CHKSUMS="sha256::4af25b2f0331b5eccd5dfa7caea9a9dfa708ff73e4e4b42fdefdd5e1f4c56cbf"

--- a/extra-i18n/fcitx5-chinese-addons/spec
+++ b/extra-i18n/fcitx5-chinese-addons/spec
@@ -1,6 +1,6 @@
-VER=5.0.3
+VER=5.0.4
 SRCS="tbl::https://github.com/fcitx/fcitx5-chinese-addons/archive/$VER.tar.gz \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5-chinese-addons/fcitx5-chinese-addons-${VER}_dict.tar.xz"
-CHKSUMS="sha256::6d1fff649f5f91cd85aef5bac52c5be6866dc573841e65acd1f430b2580635c2 \
-         sha256::b3c777e6c37cbb2e06923f9ffdbbefb1c348904c96c73bbea8063d30295dbfce"
+CHKSUMS="sha256::9c406bc145d26c06376c6c7f1a0e5483cdb6e366c2a13674cbc551f865c57553 \
+         sha256::3e77872124d5f98c43b20b9118e175fa06b2ac38a7c2a6249bd4f6b6ec6e64c0"
 SUBDIR="fcitx5-chinese-addons-$VER"

--- a/extra-i18n/fcitx5-configtool/spec
+++ b/extra-i18n/fcitx5-configtool/spec
@@ -1,3 +1,3 @@
-VER=5.0.2
+VER=5.0.3
 SRCS="tbl::https://github.com/fcitx/fcitx5-configtool/archive/$VER.tar.gz"
-CHKSUMS="sha256::c730a0282c03bb0b976a16d6be01caf8cad34a752a421f1e0f1fe5bfba7591c2"
+CHKSUMS="sha256::aeac9b4ce4df5b6505cb19ad0711eeffe9dec7d808fc7d53b5dee3d8cd559e5e"

--- a/extra-i18n/fcitx5-gtk/spec
+++ b/extra-i18n/fcitx5-gtk/spec
@@ -1,3 +1,3 @@
-VER=5.0.3
+VER=5.0.4
 SRCS="tbl::https://github.com/fcitx/fcitx5-gtk/archive/$VER.tar.gz"
-CHKSUMS="sha256::43c706fb44df4bc2238ffd309ba5c0a8a30ae3aabb6ff9d1745f6cf8be51eeee"
+CHKSUMS="sha256::e8a58f4a30231b1f0fce9b3d3aa101a9cd685df96b8992b1bcb63b5e46b6591b"

--- a/extra-i18n/fcitx5-kkc/spec
+++ b/extra-i18n/fcitx5-kkc/spec
@@ -1,3 +1,3 @@
-VER=5.0.2
+VER=5.0.3
 SRCS="tbl::https://github.com/fcitx/fcitx5-kkc/archive/$VER.tar.gz"
-CHKSUMS="sha256::699a7d7aea3c71dbd0f0e2ac5775d81ccf9ef64eca78d2a03c88c58e1b2ce725"
+CHKSUMS="sha256::ba4ac6665c4221d115e71b4b2bff69e3b70f8e02d03b342323c02e0946091304"

--- a/extra-i18n/fcitx5-lua/spec
+++ b/extra-i18n/fcitx5-lua/spec
@@ -1,3 +1,3 @@
-VER=5.0.2
+VER=5.0.3
 SRCS="tbl::https://github.com/fcitx/fcitx5-lua/archive/$VER.tar.gz"
-CHKSUMS="sha256::3cee85f8c86ebd0d12c4992acf30be53106b79f70e862de0a1f4bfde5a978393"
+CHKSUMS="sha256::0967c7b56c4013a51c7d41954031f671e1d75d2031e13c0a6dea9b3a7df5794b"

--- a/extra-i18n/fcitx5-m17n/spec
+++ b/extra-i18n/fcitx5-m17n/spec
@@ -1,3 +1,3 @@
-VER=5.0.2
+VER=5.0.3
 SRCS="tbl::https://github.com/fcitx/fcitx5-m17n/archive/$VER.tar.gz"
-CHKSUMS="sha256::b2169c4e78a052337fd3058af9ed12403d14670bbebb13f779d28f093a587b39"
+CHKSUMS="sha256::6aaa74713df41737fcca49f35db6d23f6c8dd08e63d7502dd7a4e7097b9c579f"

--- a/extra-i18n/fcitx5-qt/spec
+++ b/extra-i18n/fcitx5-qt/spec
@@ -1,3 +1,3 @@
-VER=5.0.2
+VER=5.0.3
 SRCS="https://github.com/fcitx/fcitx5-qt/archive/$VER.tar.gz"
-CHKSUMS="sha256::6fb4fc87a3a05bfdd9dad78072e01aa03818e7414bae223af8bb724346aade6f"
+CHKSUMS="sha256::e847b0885f5a1ae6c686cad0a6c8a0269d4c41b840dcfe75985fcf2911805082"

--- a/extra-i18n/fcitx5-rime/spec
+++ b/extra-i18n/fcitx5-rime/spec
@@ -1,3 +1,3 @@
-VER=5.0.3
+VER=5.0.4
 SRCS="tbl::https://github.com/fcitx/fcitx5-rime/archive/$VER.tar.gz"
-CHKSUMS="sha256::164cac0d761f7bd76feb31d1b06f1e84fc346065be6be675b99410833e05f204"
+CHKSUMS="sha256::2a429b25b180b27de589be30cf14c7c986daf6823efa93f88b124fa331df6020"

--- a/extra-i18n/fcitx5-skk/spec
+++ b/extra-i18n/fcitx5-skk/spec
@@ -1,3 +1,3 @@
-VER=5.0.3
+VER=5.0.4
 SRCS="tbl::https://github.com/fcitx/fcitx5-skk/archive/$VER.tar.gz"
-CHKSUMS="sha256::6ebdb5926e1e82e4e14c51c2363bf771a9e7fcce077d160a8ce8b2b9cf20d7b6"
+CHKSUMS="sha256::c9d53ca1193cd083f88cd4620174f41370e033a72b8505c050f500e683ba55ee"

--- a/extra-i18n/fcitx5-unikey/spec
+++ b/extra-i18n/fcitx5-unikey/spec
@@ -1,3 +1,3 @@
-VER=5.0.2
+VER=5.0.3
 SRCS="tbl::https://github.com/fcitx/fcitx5-unikey/archive/$VER.tar.gz"
-CHKSUMS="sha256::a6159c57a9301b3abf3a89275d8935189c6d47c2ae458fa35c76dffc64da7268"
+CHKSUMS="sha256::7967b7b1a6ac2c5f1bc5922f0727499ec674748b935c0d2c48c04a4f51c4bd2f"

--- a/extra-i18n/fcitx5/spec
+++ b/extra-i18n/fcitx5/spec
@@ -1,6 +1,6 @@
-VER=5.0.4
+VER=5.0.5
 SRCS="tbl::https://github.com/fcitx/fcitx5/archive/$VER.tar.gz \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5/fcitx5-${VER}_dict.tar.xz"
-CHKSUMS="sha256::d5a5341f2ba1e99a0177a3c09ce92f78587873c985b3b16c9e7655268a22ae1d \
-         sha256::5a154ec5a40224044c766f68eaad9bfed6f972d04fa4ca3ced650dd6965cf892"
+CHKSUMS="sha256::9de956940c224ef0fcf1cd0994c0c13ccffa64707566b21710e2fb402521db0f \
+         sha256::56992bcee56b7bb71293336a3fb703f033a282faedfeeec69a5f2faeba09479a"
 SUBDIR="fcitx5-$VER"

--- a/extra-i18n/libime/spec
+++ b/extra-i18n/libime/spec
@@ -1,6 +1,6 @@
-VER=1.0.3
+VER=1.0.4
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/libime/ \
       tbl::https://download.fcitx-im.org/fcitx5/libime/libime-${VER}_dict.tar.xz"
 CHKSUMS="SKIP \
-         sha256::3bb7fd76317e0acd940bda6437277e3b3d0179ea270aa5256ca3270531f529be"
+         sha256::59426b865eca13f301b26cbf47a50eae919d53b23819e3847137b3e39908942f"
 SUBDIR="libime-$VER"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fcitx5: update to 5.0.3

Package(s) Affected
-------------------

see `extra-groups/fcitx5`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No
<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

see `extra-groups/fcitx5`

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
