### PR TITLE
fcitx5-material-color: update to 0.2.1

### DIFF
--- a/extra-i18n/fcitx5-material-color/autobuild/build
+++ b/extra-i18n/fcitx5-material-color/autobuild/build
@@ -1,17 +1,21 @@
-abinfo "Installing file to $PKGDIR..."
-install -Dvm644 "$SRCDIR"/arrow.png "$SRCDIR"/radio.png -t "$PKGDIR"/usr/share/$PKGNAME/
+abinfo "Installing asset icons ..."
+install -Dvm644 \
+    "$SRCDIR"/{arrow,radio}.png \
+    -t "$PKGDIR"/usr/share/$PKGNAME/
 
-variants=""
-for path in `ls "$SRCDIR"/theme-*`; do 
-    basename=$(basename $path)
-    variants+="$(echo "$basename" | cut -d '-' -f2 | cut -d '.' -f1) "
-done
+for i in theme-*.conf; do
+    export i="${i%.conf}"
+    export pretty="${i#theme-}"
+    export pretty="${pretty^}"
+    abinfo "Installing Fcitx5 Material Color theme, variant $pretty ..."
+    install -Dvm644 "$SRCDIR"/${i}.conf \
+        "$PKGDIR"/usr/share/fcitx5/themes/Material-Color-$pretty/theme.conf
 
-for _variant in $variants; do
-    _variant_name=Material-Color-${_variant^}
-    mkdir -pv "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
-    ln -sv /usr/share/fcitx5-material-color/arrow.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
-    ln -sv /usr/share/fcitx5-material-color/radio.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
-    install -Dvm644 "$SRCDIR"/theme-${_variant}.conf  "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/theme.conf
-    sed -i "s/^Name=.*/Name=$_variant_name/" "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/theme.conf
+    abinfo "Symlinking asset icons for variant $pretty ..."
+    ln -sv ../../../fcitx5-material-color/{arrow,radio}.png \
+        "$PKGDIR"/usr/share/fcitx5/themes/Material-Color-$pretty/
+
+    abinfo "Setting proper theme name for variant $pretty ..."
+    sed -i "s/^Name=.*/Name=Material Color ($pretty)/" \
+        "$PKGDIR"/usr/share/fcitx5/themes/Material-Color-$pretty/theme.conf
 done

--- a/extra-i18n/fcitx5-material-color/autobuild/build
+++ b/extra-i18n/fcitx5-material-color/autobuild/build
@@ -10,8 +10,8 @@ done
 for _variant in $variants; do
     _variant_name=Material-Color-${_variant^}
     mkdir -pv "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
-    ln -sv "$SRCDIR"/arrow.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
-    ln -sv "$SRCDIR"/radio.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
+    ln -sv /usr/share/fcitx5-material-color/arrow.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
+    ln -sv /usr/share/fcitx5-material-color/radio.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
     install -Dvm644 "$SRCDIR"/theme-${_variant}.conf  "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/theme.conf
     sed -i "s/^Name=.*/Name=$_variant_name/" "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/theme.conf
 done

--- a/extra-i18n/fcitx5-material-color/autobuild/build
+++ b/extra-i18n/fcitx5-material-color/autobuild/build
@@ -2,14 +2,14 @@ abinfo "Installing file to $PKGDIR..."
 install -Dvm644 "$SRCDIR"/arrow.png "$SRCDIR"/radio.png -t "$PKGDIR"/usr/share/$PKGNAME/
 
 variants=""
-for path in `ls "$SRCDIR"/panel-*`; do 
+for path in `ls "$SRCDIR"/theme-*`; do 
     basename=$(basename $path)
     variants+="$(echo "$basename" | cut -d '-' -f2 | cut -d '.' -f1) "
 done
 
 for _variant in $variants; do
     _variant_name=Material-Color-${_variant^}
-    install -Dvm644 "$SRCDIR"/panel-$_variant.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/panel.png
+    mkdir -pv "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
     ln -sv "$SRCDIR"/arrow.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
     ln -sv "$SRCDIR"/radio.png "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/
     install -Dvm644 "$SRCDIR"/theme-${_variant}.conf  "$PKGDIR"/usr/share/fcitx5/themes/$_variant_name/theme.conf

--- a/extra-i18n/fcitx5-material-color/spec
+++ b/extra-i18n/fcitx5-material-color/spec
@@ -1,3 +1,3 @@
-VER=0.1+git20201212
-SRCS="git::commit=c5f240591af52a041ff0fcde6fe245761c926f61::https://github.com/hosxy/Fcitx5-Material-Color"
-CHKSUMS="SKIP"
+VER=0.2.1
+SRCS="tbl::https://github.com/hosxy/Fcitx5-Material-Color/archive/$VER.tar.gz"
+CHKSUMS="sha256::eeee748f47a645f2ba6f12258bd7c2a90016f842a8896511d88af42588d30594"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fcitx5-material-color: update to 0.2.1

Package(s) Affected
-------------------

fcitx5-material-color 0.2.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch` 

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

 - [x] Architecture-independent `noarch` 

