### PR TITLE
aisleriot: update to 3.22.14, upstream switched to meson to build

### DIFF
--- a/extra-gnome/aisleriot/autobuild/defines
+++ b/extra-gnome/aisleriot/autobuild/defines
@@ -4,6 +4,4 @@ PKGDEP="guile gtk-3 librsvg libcanberra gconf hicolor-icon-theme dconf"
 BUILDDEP="desktop-file-utils docbook-xsl intltool itstool yelp-tools"
 PKGDES="A collection of patience games written in guile scheme"
 
-AUTOTOOLS_AFTER="--prefix=/usr --sysconfdir=/etc --localstatedir=/var \
-                 --libexecdir=/usr/lib --disable-static \
-                 --with-pysol-card-theme-path=/usr/share/PySolFC"
+MESON_AFTER="-Dtheme_pysol=true -Dtheme_pysol_path=/usr/share/PySolFC -Dtheme_kde=false"

--- a/extra-gnome/aisleriot/spec
+++ b/extra-gnome/aisleriot/spec
@@ -1,3 +1,3 @@
-VER=3.22.9
-SRCTBL="https://download.gnome.org/sources/aisleriot/${VER:0:4}/aisleriot-$VER.tar.xz"
-CHKSUM="sha256::51f2ffe4dd4f23349b033fd87aab7bf433641285719503dd7e52b2c25982ed7b"
+VER=3.22.14
+SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/aisleriot.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Update aisleriot to 3.22.14 (newest git tag).

This is also a fix because we currently forgot to rebuild it after guile is updated to 3.0.

Package(s) Affected
-------------------

- `aisleriot` 3.22.14

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
