### PR TITLE
tikzplotlib: new, 0.9.8

### DIFF
--- a/extra-python/tikzplotlib/autobuild/build
+++ b/extra-python/tikzplotlib/autobuild/build
@@ -1,0 +1,4 @@
+abinfo "Installing tikzplotlib ..."
+export PIP_CONFIG_FILE=/dev/null
+pip3 install --isolated --root="${PKGDIR}" --ignore-installed --no-deps --compile .
+unset PIP_CONFIG_FILE

--- a/extra-python/tikzplotlib/autobuild/defines
+++ b/extra-python/tikzplotlib/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=tikzplotlib
+PKGSEC=python
+PKGDEP="matplotlib numpy pillow"
+BUILDDEP="pip"
+PKGDES="A Python tool for convering matplotlib figures to PGF/TikZ figures"
+
+ABHOST=noarch

--- a/extra-python/tikzplotlib/spec
+++ b/extra-python/tikzplotlib/spec
@@ -1,0 +1,3 @@
+VER=0.9.8
+SRCTBL="https://pypi.io/packages/source/t/tikzplotlib/tikzplotlib-$VER.tar.gz"
+CHKSUM="sha256::bf205e74e27e9efefde70d7773675a8432dab600741ac8c0db93daaeb7fc957c"


### PR DESCRIPTION
Topic Description
-----------------

This PR introduces `tikzplotlib`, a library converting matplotlib figures into PGF/Tikz graphics for inclusion in TeX documents.

Package(s) Affected
-------------------

* `tikzplotlib`: new, 0.9.8

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`