### PR TITLE
osu-lazer: update to 2021.220.0

### DIFF
--- a/extra-games/osu-lazer/autobuild/defines
+++ b/extra-games/osu-lazer/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=osu-lazer
 PKGSEC=games
 PKGDES="Rhythm is just a click away!"
-PKGDEP="alsa-lib desktop-file-utils libgdiplus dotnet-runtime-3.1"
-BUILDDEP="dotnet-sdk-3.1.1xx"
+PKGDEP="alsa-lib desktop-file-utils libgdiplus dotnet-runtime-5.0"
+BUILDDEP="dotnet-sdk-5.0.1xx"
 
 FAIL_ARCH="!(amd64)"
 NOSTATIC=0

--- a/extra-games/osu-lazer/spec
+++ b/extra-games/osu-lazer/spec
@@ -1,3 +1,3 @@
-VER=2021.109.0
+VER=2021.220.0
 SRCS="tbl::https://github.com/ppy/osu/archive/$VER.tar.gz"
-CHKSUMS="sha256::498b05df5270667901c0c21f9963052f0277dc06600569d0953a1cfd9bfcd99d"
+CHKSUMS="sha256::d7ad8e89e0ad57b64eb324708cc5d6d7e497183e0e3b10dda4498e58cb54900c"


### PR DESCRIPTION
Topic Description
-----------------

Update `osu-lazer` to 2021.220.0

Package(s) Affected
-------------------

osu-lazer

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   