### PR TITLE
zd1211-firmware: new, 1.5

### DIFF
--- a/extra-kernel/zd1211-firmware/autobuild/build
+++ b/extra-kernel/zd1211-firmware/autobuild/build
@@ -1,0 +1,3 @@
+abinfo "Installing firmware files into the right location..."
+mkdir -p "$PKGDIR"/usr/lib/firmware/zd1211/
+cp -v zd1211* "$PKGDIR"/usr/lib/firmware/zd1211/

--- a/extra-kernel/zd1211-firmware/autobuild/defines
+++ b/extra-kernel/zd1211-firmware/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=zd1211-firmware
+PKGDES="Firmware for USB wireless card driven by zd1211rw driver."
+PKGSEC=non-free/kernel
+PKGDEP=""
+
+ABHOST=noarch
+ABSTRIP=0

--- a/extra-kernel/zd1211-firmware/spec
+++ b/extra-kernel/zd1211-firmware/spec
@@ -1,0 +1,3 @@
+VER=1.5
+SRCS="tbl::https://sourceforge.net/projects/zd1211/files/zd1211-firmware/$VER/zd1211-firmware-$VER.tar.bz2"
+CHKSUMS="sha256::f11d3810d7f72833997f634584a586dcced71a353f965abf81062ec431d02b12"


### PR DESCRIPTION
Topic Description
-----------------

Add firmware for zd1211 USB wireless card.

Package(s) Affected
-------------------
- `zd1211-firmware` 1.5 (new)

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
