### PR TITLE
NVIDIA drivers 460.39

### DIFF
--- a/extra-optenv32/nvidia+32/spec
+++ b/extra-optenv32/nvidia+32/spec
@@ -1,6 +1,6 @@
-VER=460.32.03
-SRCS="file::rename=NVIDIA-Linux-x86_64-$VER.run::http://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run \
+VER=460.39
+SRCS="file::rename=NVIDIA-Linux-x86_64-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run \
       tbl::https://github.com/NVIDIA/nvidia-settings/archive/$VER.tar.gz"
-CHKSUMS="sha256::4f2122fc23655439f214717c4c35ab9b4f5ab8537cddfdf059a5682f1b726061 \
-         sha256::ddcb4c6ea7330cb0f9dc272e36e8a0a4867cfce9a930a22d21fad1307173f0b7"
+CHKSUMS="sha256::0bf0664078013aa62ed6840caed0637b226884b9398e1fb647e127ad3ad9a37f \
+         sha256::ea4183fcf38f4cdfedbf782f101de57a88e2c38fc25b9bd691b101087da0e5e2"
 SUBDIR=.

--- a/extra-x11/nvidia/autobuild/postinst
+++ b/extra-x11/nvidia/autobuild/postinst
@@ -1,6 +1,6 @@
 unset ARCH
 
-DRIVER_VER=460.32.03
+DRIVER_VER=460.39
 
 for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
     if [ -f "/usr/lib/modules/${i}/modules.dep" -a -f "/usr/lib/modules/${i}/modules.order" -a -f "/usr/lib/modules/${i}/modules.builtin" ]; then

--- a/extra-x11/nvidia/autobuild/prerm
+++ b/extra-x11/nvidia/autobuild/prerm
@@ -1,4 +1,4 @@
 unset ARCH
 
-DRIVER_VER=460.32.03
+DRIVER_VER=460.39
 dkms remove nvidia/${DRIVER_VER} --all || true > /dev/null

--- a/extra-x11/nvidia/spec
+++ b/extra-x11/nvidia/spec
@@ -1,6 +1,6 @@
-VER=460.32.03
-SRCS="file::rename=NVIDIA-Linux-x86_64-$VER-no-compat32.run::http://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER-no-compat32.run \
+VER=460.39
+SRCS="file::rename=NVIDIA-Linux-x86_64-$VER-no-compat32.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER-no-compat32.run \
       tbl::https://github.com/NVIDIA/nvidia-settings/archive/$VER.tar.gz"
-CHKSUMS="sha256::45aa9d75e8d463d87dcf7ea78a1ea046b9ddc2e159dfab6e861cbf833e6b14cf \
-         sha256::ddcb4c6ea7330cb0f9dc272e36e8a0a4867cfce9a930a22d21fad1307173f0b7"
+CHKSUMS="sha256::07042bd0c2f5c37b455a973f15561450f789590b8650a6ea573c819591d572a9 \
+         sha256::ea4183fcf38f4cdfedbf782f101de57a88e2c38fc25b9bd691b101087da0e5e2"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This PR updates nvidia drivers to 460.39 with support on 5.11.x kernel.

Package(s) Affected
-------------------

* nvidia/nvidia+32 460.39

Architectural Progress
----------------------

- [x] AMD64 `amd64`   

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   

<!-- TODO: CI to auto-fill architectural progress. -->
