### PR TITLE
Fix zsh completions and flameshot file conflict

### DIFF
--- a/extra-shells/zsh-completions/autobuild/beyond
+++ b/extra-shells/zsh-completions/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Remove flameshot completion..."
+rm -v "$PKGDIR"/usr/share/zsh/site-functions/_flameshot

--- a/extra-shells/zsh-completions/spec
+++ b/extra-shells/zsh-completions/spec
@@ -1,4 +1,5 @@
 VER=0.32.0
+REL=1
 SRCTBL="https://github.com/zsh-users/zsh-completions/archive/$VER.tar.gz"
 CHKSUM="sha256::d2d20836fb60d2e5de11b08f1a8373484dc01260d224e64c6de9eec44137fa63"
 SUBDIR="zsh-completions-$VER"

--- a/extra-utils/flameshot/autobuild/defines
+++ b/extra-utils/flameshot/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=flameshot
 PKGSEC=utils
 PKGDEP="qt-5"
 PKGDES="Powerful yet simple to use screenshot software"
+PKGBREAK="zsh-completions<=0.32.0"
+PKGREP="zsh-completions<=0.32.0"

--- a/extra-utils/flameshot/spec
+++ b/extra-utils/flameshot/spec
@@ -1,3 +1,4 @@
 VER=0.8.5
+REL=1
 SRCS="tbl::https://github.com/flameshot-org/flameshot/archive/v$VER.tar.gz"
 CHKSUMS="sha256::f820c1f8cd464988cfcfc1af1fbcea2a3d0e5c4fb32accc3f54d93a8b5e1e890"


### PR DESCRIPTION
Topic Description
-----------------

Remove the conflict zsh completion file

Package(s) Affected
-------------------

zsh-completions
flameshot

Security Update?
----------------

No

Architectural Progress
----------------------

`flameshot`
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

`zsh-completions`
- [x] Architecture-independent `noarch`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

`flameshot`
- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

`flameshot`
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

`zsh-completions`
- [ ] Architecture-independent `noarch`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

`flameshot`
- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`