### PR TITLE
pipewire: update to 0.3.22

### DIFF
--- a/extra-libs/libopenaptx/autobuild/defines
+++ b/extra-libs/libopenaptx/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=libopenaptx
+PKGSEC=sound
+PKGDES="Open Source implementation of Audio Processing Technology codec (aptX)"
+PKGDEP="glibc"

--- a/extra-libs/libopenaptx/autobuild/patches/0001-make-the-makefile-compatible-for-autobuild3.patch
+++ b/extra-libs/libopenaptx/autobuild/patches/0001-make-the-makefile-compatible-for-autobuild3.patch
@@ -1,0 +1,53 @@
+From 03bf58e6537a7e28d8abb1e4c9e7b7a649a66287 Mon Sep 17 00:00:00 2001
+From: Lain Yang <fsf@live.com>
+Date: Sat, 13 Feb 2021 15:29:29 +0800
+Subject: [PATCH] change Makefile
+
+---
+ Makefile | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index d59800f..fe67ea7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -45,22 +45,22 @@ clean:
+ 	$(RM) $(BUILD)
+ 
+ install: $(BUILD)
+-	$(MKDIR) $(DESTDIR)$(PREFIX)/$(LIBDIR)
+-	$(CP) $(SOFILENAME) $(SONAME) $(LIBNAME) $(ANAME) $(DESTDIR)$(PREFIX)/$(LIBDIR)
+-	$(MKDIR) $(DESTDIR)$(PREFIX)/$(BINDIR)
+-	$(CP) $(UTILITIES) $(DESTDIR)$(PREFIX)/$(BINDIR)
+-	$(MKDIR) $(DESTDIR)$(PREFIX)/$(INCDIR)
+-	$(CP) $(HEADERS) $(DESTDIR)$(PREFIX)/$(INCDIR)
+-	$(MKDIR) $(DESTDIR)$(PREFIX)/$(PKGDIR)
+-	$(PRINTF) 'prefix=%s\nexec_prefix=$${prefix}\nlibdir=$${exec_prefix}/%s\nincludedir=$${prefix}/%s\n\n' $(PREFIX) $(LIBDIR) $(INCDIR) > $(DESTDIR)$(PREFIX)/$(PKGDIR)/$(PCNAME)
+-	$(PRINTF) 'Name: lib%s\nDescription: Open Source aptX codec library\nVersion: %u.%u.%u\n' $(NAME) $(MAJOR) $(MINOR) $(PATCH) >> $(DESTDIR)$(PREFIX)/$(PKGDIR)/$(PCNAME)
+-	$(PRINTF) 'Libs: -Wl,-rpath=$${libdir} -L$${libdir} -l%s\nCflags: -I$${includedir}\n' $(NAME) >> $(DESTDIR)$(PREFIX)/$(PKGDIR)/$(PCNAME)
++	$(MKDIR) $(DESTDIR)$(LIBDIR)
++	$(CP) $(SOFILENAME) $(SONAME) $(LIBNAME) $(ANAME) $(DESTDIR)$(LIBDIR)
++	$(MKDIR) $(DESTDIR)$(BINDIR)
++	$(CP) $(UTILITIES) $(DESTDIR)$(BINDIR)
++	$(MKDIR) $(DESTDIR)$(INCDIR)
++	$(CP) $(HEADERS) $(DESTDIR)$(INCDIR)
++	$(MKDIR) $(DESTDIR)$(PKGDIR)
++	$(PRINTF) 'prefix=%s\nexec_prefix=$${prefix}\nlibdir=$${exec_prefix}/%s\nincludedir=$${prefix}/%s\n\n' $(PREFIX) $(LIBDIR) $(INCDIR) > $(DESTDIR)$(PKGDIR)/$(PCNAME)
++	$(PRINTF) 'Name: lib%s\nDescription: Open Source aptX codec library\nVersion: %u.%u.%u\n' $(NAME) $(MAJOR) $(MINOR) $(PATCH) >> $(DESTDIR)$(PKGDIR)/$(PCNAME)
++	$(PRINTF) 'Libs: -Wl,-rpath=$${libdir} -L$${libdir} -l%s\nCflags: -I$${includedir}\n' $(NAME) >> $(DESTDIR)$(PKGDIR)/$(PCNAME)
+ 
+ uninstall:
+-	for f in $(SOFILENAME) $(SONAME) $(LIBNAME) $(ANAME); do $(RM) $(DESTDIR)$(PREFIX)/$(LIBDIR)/$$f; done
+-	for f in $(UTILITIES); do $(RM) $(DESTDIR)$(PREFIX)/$(BINDIR)/$$f; done
+-	for f in $(HEADERS); do $(RM) $(DESTDIR)$(PREFIX)/$(INCDIR)/$$f; done
+-	$(RM) $(DESTDIR)$(PREFIX)/$(PKGDIR)/$(PCNAME)
++	for f in $(SOFILENAME) $(SONAME) $(LIBNAME) $(ANAME); do $(RM) $(DESTDIR)$(LIBDIR)/$$f; done
++	for f in $(UTILITIES); do $(RM) $(DESTDIR)$(BINDIR)/$$f; done
++	for f in $(HEADERS); do $(RM) $(DESTDIR)$(INCDIR)/$$f; done
++	$(RM) $(DESTDIR)$(PKGDIR)/$(PCNAME)
+ 
+ $(UTILITIES): $(LIBNAME)
+ 
+-- 
+2.30.0
+

--- a/extra-libs/libopenaptx/spec
+++ b/extra-libs/libopenaptx/spec
@@ -1,0 +1,3 @@
+VER=0.2.0
+SRCS="https://github.com/pali/libopenaptx/releases/download/${VER}/libopenaptx-${VER}.tar.gz"
+CHKSUMS="whirlpool::bc4a90d4d22be2dbeeb5ad6a167af73d58d44285e9a325da1b9de6415dacd3eef77b551cc026c216485f24e3652fecc1f7351c15be1418afc13a920c03839879"

--- a/extra-multimedia/pipewire/autobuild/defines
+++ b/extra-multimedia/pipewire/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=pipewire
 PKGSEC=sound
-PKGDEP="ffmpeg gst-plugins-base-1-0 jack libva v4l-utils libfdk-aac libldac"
-BUILDDEP="doxygen graphviz meson ninja xmltoman gtk-doc vim"
 PKGDES="Server and user space API to deal with multimedia pipelines"
+PKGDEP="ffmpeg gst-plugins-base-1-0 jack libva v4l-utils libfdk-aac libldac libopenaptx"
+BUILDDEP="doxygen graphviz meson ninja xmltoman vim"
 
 MESON_AFTER="-Dvulkan=false"
 ABTYPE=meson

--- a/extra-multimedia/pipewire/autobuild/defines
+++ b/extra-multimedia/pipewire/autobuild/defines
@@ -4,6 +4,5 @@ PKGDEP="ffmpeg gst-plugins-base-1-0 jack libva v4l-utils libfdk-aac libldac"
 BUILDDEP="doxygen graphviz meson ninja xmltoman gtk-doc vim"
 PKGDES="Server and user space API to deal with multimedia pipelines"
 
-MESON_AFTER="-Denable-gtk-doc=true \
-             -Dvulkan=false"
+MESON_AFTER="-Dvulkan=false"
 ABTYPE=meson

--- a/extra-multimedia/pipewire/autobuild/defines
+++ b/extra-multimedia/pipewire/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=pipewire
 PKGSEC=sound
-PKGDEP="ffmpeg gst-plugins-base-1-0 jack libva v4l-utils"
+PKGDEP="ffmpeg gst-plugins-base-1-0 jack libva v4l-utils libfdk-aac libldac"
 BUILDDEP="doxygen graphviz meson ninja xmltoman gtk-doc vim"
 PKGDES="Server and user space API to deal with multimedia pipelines"
 

--- a/extra-multimedia/pipewire/spec
+++ b/extra-multimedia/pipewire/spec
@@ -1,3 +1,3 @@
-VER=0.3.20
+VER=0.3.22
 SRCS="https://github.com/PipeWire/pipewire/archive/$VER.tar.gz"
-CHKSUMS="whirlpool::c1979076c57eb2c9537ac15b1b03d9a6e7e97c196030ced3b92a0c1525f6afa5cc3c40142d4a470bfb50f35b50809f2f4f354409119450059239c3197145beec"
+CHKSUMS="whirlpool::19372572561d9ac055efda8ed3a0f2271cd855b0361eaa7d411cd94b6fa1d7c1ae1c159b9b07f2711bf66ec017d2d7ecaa03c329b193649dd0c5ebbf4914ab2a"


### PR DESCRIPTION
Topic Description
-----------------
- Update `pipewire` to 0.3.22
- Add `libopenaptx`
- Add LDAC, aptX, AAC support for `pipewire`

Package(s) Affected
-------------------
- pipewire
- libopenaptx


Security Update?
----------------
No 

Build Order
-----------
- `libopenaptx` => `pipewire`

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
