### PR TITLE
eog: add missing runtime dependency

### DIFF
--- a/extra-gnome/eog/autobuild/defines
+++ b/extra-gnome/eog/autobuild/defines
@@ -2,6 +2,6 @@ PKGNAME=eog
 PKGSEC=gnome
 PKGDEP="gnome-desktop libexif lcms2 desktop-file-utils exempi \
         libpeas librsvg dconf cairo gdk-pixbuf gobject-introspection \
-        gtk-3 libjpeg-turbo x11-lib"
+        gtk-3 libjpeg-turbo x11-lib libportal"
 BUILDDEP="gobject-introspection intltool itstool gtk-doc meson ninja"
 PKGDES="Eye of Gnome: An image viewing and cataloging program"

--- a/extra-gnome/eog/spec
+++ b/extra-gnome/eog/spec
@@ -2,4 +2,3 @@ VER=3.38.1
 REL=1
 SRCS="https://download.gnome.org/sources/eog/${VER:0:4}/eog-$VER.tar.xz"
 CHKSUMS="sha256::b71dc961c277effa70dbd466657a81585f52ee8b35bc6e9da20c993568740cf7"
-

--- a/extra-gnome/eog/spec
+++ b/extra-gnome/eog/spec
@@ -1,3 +1,5 @@
 VER=3.38.1
+REL=1
 SRCS="https://download.gnome.org/sources/eog/${VER:0:4}/eog-$VER.tar.xz"
 CHKSUMS="sha256::b71dc961c277effa70dbd466657a81585f52ee8b35bc6e9da20c993568740cf7"
+


### PR DESCRIPTION
Topic Description
-----------------

Add a missing runtime dependency for `eog` .

Package(s) Affected
-------------------

- `eog`

Security Update?
----------------

No
Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

