### PR TITLE
Remmina remote desktop client 1.4.11

### DIFF
--- a/extra-network/remmina/autobuild/defines
+++ b/extra-network/remmina/autobuild/defines
@@ -8,6 +8,7 @@ PKGSUG="gnome-keyring kwallet"
 PKGDES="A remote desktop client written in GTK+"
 
 CMAKE_AFTER="
+	-DWITH_NEWS=OFF
 	-DWITH_APPINDICATOR=ON
 	-DWITH_KF5WALLET=ON
 "

--- a/extra-network/remmina/autobuild/defines
+++ b/extra-network/remmina/autobuild/defines
@@ -1,8 +1,13 @@
 PKGNAME=remmina
 PKGSEC=net
 PKGDEP="gtk-3 zlib libjpeg-turbo libssh libunique avahi vte-gtk3 libgcrypt \
-        freerdp telepathy-glib gnome-keyring libvncserver libappindicator \
-        webkit2gtk"
+	freerdp telepathy-glib libvncserver libappindicator webkit2gtk \
+	libsodium libspice-gtk "
+BUILDDEP="gnome-keyring kwallet"
+PKGSUG="gnome-keyring kwallet"
 PKGDES="A remote desktop client written in GTK+"
 
-CMAKE_AFTER="-DWITH_APPINDICATOR=ON"
+CMAKE_AFTER="
+	-DWITH_APPINDICATOR=ON
+	-DWITH_KF5WALLET=ON
+"

--- a/extra-network/remmina/spec
+++ b/extra-network/remmina/spec
@@ -1,4 +1,3 @@
-VER=1.3.2
-REL=2
+VER=1.4.11
 SRCTBL="https://gitlab.com/Remmina/Remmina/-/archive/v${VER}/Remmina-v{VER}.tar.gz"
-CHKSUM="sha256::64ee93eab4e42b4d61e2a4adde94cd93a85fe5fce057b7754b8118d75b09ff7e"
+CHKSUM="sha256::3991bb41ccc73e4183f8b786048fcbfcaf8b825d82f6fd168886a0151a781b76"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates remmina to 1.4.11 and fixes a segmentation fault when closing connection manager window.

Package(s) Affected
-------------------

* reminna: 1.4.11

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
