### PR TITLE
osu-lazer: update to 2021.226.0

### DIFF
--- a/extra-games/osu-lazer/autobuild/defines
+++ b/extra-games/osu-lazer/autobuild/defines
@@ -6,3 +6,5 @@ BUILDDEP="dotnet-sdk-5.0.1xx"
 
 FAIL_ARCH="!(amd64)"
 NOSTATIC=0
+ABSTRIP=0
+ABSPLITDBG=0

--- a/extra-games/osu-lazer/spec
+++ b/extra-games/osu-lazer/spec
@@ -1,3 +1,3 @@
-VER=2021.220.0
+VER=2021.226.0
 SRCS="tbl::https://github.com/ppy/osu/archive/$VER.tar.gz"
-CHKSUMS="sha256::d7ad8e89e0ad57b64eb324708cc5d6d7e497183e0e3b10dda4498e58cb54900c"
+CHKSUMS="sha256::6bf09a65b09e699928b5c0c2d8555ab0c4e0265a5359f2798968d5b89d7a921e"


### PR DESCRIPTION
Topic Description
-----------------

Update `osu-lazer` to 2021.226.0

Package(s) Affected
-------------------

osu-lazer

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   