### PR TITLE
gegl-0.4: add dependency graphviz

### DIFF
--- a/extra-libs/gegl-0.4/autobuild/defines
+++ b/extra-libs/gegl-0.4/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=gegl-0.4
 PKGSEC=libs
 PKGDEP="babl libspiro openexr ffmpeg librsvg jasper suitesparse \
         libopenraw libraw gexiv2 json-glib libwebp sdl sdl2 libwebp \
-        lensfun libtiff v4l-utils poppler pygobject-3"
+        lensfun libtiff v4l-utils poppler pygobject-3 graphviz"
 BUILDDEP="asciidoc vala intltool ruby luajit"
 BUILDDEP__PPC64EL="asciidoc vala intltool ruby"
 PKGDES="Graph based image processing framework (0.4)"

--- a/extra-libs/gegl-0.4/spec
+++ b/extra-libs/gegl-0.4/spec
@@ -1,3 +1,4 @@
 VER=0.4.28
+REL=1
 SRCS="tbl::https://download.gimp.org/pub/gegl/${VER:0:3}/gegl-$VER.tar.xz"
 CHKSUMS="sha256::1d110d8577d54cca3b34239315bd37c57ccb27dd4355655074a2d2b3fd897900"


### PR DESCRIPTION
Topic Description
-----------------

GIMP requires gegl:introspect operation, but gegl:introspect requires dot to
work, which is provided by graphviz.

Thanks to `@o0_0b` , who helped to analyze this problem.

Package(s) Affected
-------------------

- `gegl`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

