### PR TITLE
Certbot 1.12.0 + dependencies and utilities

### DIFF
--- a/extra-network/certbot-apache/autobuild/defines
+++ b/extra-network/certbot-apache/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=certbot-apache
 PKGSEC=net
-PKGDEP="certbot python-augeas"
+PKGDEP="certbot python-augeas acme mock setuptools zope-interface"
 PKGDES="Apache plugin for CertBot"
 
-NOPYTHON3=1
+NOPYTHON2=1
 PKGREP="letsencrypt-apache"
 ABHOST=noarch

--- a/extra-network/certbot-apache/spec
+++ b/extra-network/certbot-apache/spec
@@ -1,4 +1,3 @@
-VER=0.31.0
+VER=1.12.0
 SRCTBL="https://pypi.io/packages/source/c/certbot-apache/certbot-apache-$VER.tar.gz"
-CHKSUM="sha256::cc4b840b2a439a63e2dce809272c3c3cd4b1aeefc4053cd188935135be137edd"
-REL=1
+CHKSUM="sha256::e5679b40d99bd241f4fcd9fe44b73e6e25ccc969a617131ff6ebc90d562a49f2"

--- a/extra-network/certbot-dns-cloudflare/autobuild/defines
+++ b/extra-network/certbot-dns-cloudflare/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=certbot-dns-cloudflare
+PKGSEC=python
+PKGDEP="certbot acme mock python-cloudflare setuptools zope-interface"
+PKGDES="Cloudflare DNS challenge plugin for Certbot"
+
+NOPYTHON2=1
+PKGREP="letsencrypt-nginx"
+ABHOST=noarch

--- a/extra-network/certbot-dns-cloudflare/autobuild/prepare
+++ b/extra-network/certbot-dns-cloudflare/autobuild/prepare
@@ -1,0 +1,1 @@
+chmod a-s "$SRCDIR"

--- a/extra-network/certbot-dns-cloudflare/spec
+++ b/extra-network/certbot-dns-cloudflare/spec
@@ -1,0 +1,3 @@
+VER=1.12.0
+SRCTBL="https://pypi.io/packages/source/c/certbot-dns-cloudflare/certbot-dns-cloudflare-$VER.tar.gz"
+CHKSUM="sha256::5fc6f3e55c3174e41f9bb79bb02fabe9a0c5679d2ac950ea454b3e979da4a823"

--- a/extra-network/certbot-nginx/autobuild/defines
+++ b/extra-network/certbot-nginx/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=certbot-nginx
 PKGSEC=python
-PKGDEP="certbot pyparsing"
+PKGDEP="certbot pyparsing acme mock setuptools zope-interface"
 PKGDES="Nginx plugin for CertBot"
 
-NOPYTHON3=1
+NOPYTHON2=1
 PKGREP="letsencrypt-nginx"
 ABHOST=noarch

--- a/extra-network/certbot-nginx/spec
+++ b/extra-network/certbot-nginx/spec
@@ -1,4 +1,3 @@
-VER=0.31.0
+VER=1.12.0
 SRCTBL="https://pypi.io/packages/source/c/certbot-nginx/certbot-nginx-$VER.tar.gz"
-CHKSUM="sha256::d450d75650384f74baccb7673c89e2f52468afa478ed354eb6d4b99aa33bf865"
-REL=1
+CHKSUM="sha256::3fb6a55290d37ad466681a89a85ceca4c4026fdd8702f3010b87a74266a6fe7b"

--- a/extra-network/certbot/autobuild/defines
+++ b/extra-network/certbot/autobuild/defines
@@ -4,6 +4,6 @@ PKGDEP="acme ca-certs configargparse configobj future josepy mock parsedatetime 
         pypsutil pyrfc3339 pythondialog pytz requests setuptools six toolbelt zope-component zope-interface"
 PKGDES="A tool to automatically receive and install X.509 certificates to enable TLS on servers"
 
-NOPYTHON3=1
+NOPYTHON2=1
 PKGREP="letsencrypt"
 ABHOST=noarch

--- a/extra-network/certbot/spec
+++ b/extra-network/certbot/spec
@@ -1,4 +1,3 @@
-VER=0.31.0
+VER=1.12.0
 SRCTBL="https://pypi.io/packages/source/c/certbot/certbot-$VER.tar.gz"
-CHKSUM="sha256::0c3196f80a102c0f9d82d566ba859efe3b70e9ed4670520224c844fafd930473"
-REL=1
+CHKSUM="sha256::5ee738773479bcb7794e43fedd2415acc0969b75bdd2a21f451e3bff9d99df59"

--- a/extra-python/acme/autobuild/defines
+++ b/extra-python/acme/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=acme
 PKGSEC=python
-PKGDEP="mock ndg-httpsclient pyopenssl pyrfc3339 pytz toolbelt setuptools six"
+PKGDEP="cryptography josepy pyopenssl pyrfc3339 pytz toolbelt setuptools"
 PKGDES="ACME protocol implementation in Python"
 
-NOPYTHON3=1
+NOPYTHON2=1
 PKGBREAK="letencrypt<=0.2.0"
 ABHOST=noarch

--- a/extra-python/acme/spec
+++ b/extra-python/acme/spec
@@ -1,4 +1,3 @@
-VER=0.31.0
+VER=1.12.0
 SRCTBL="https://pypi.io/packages/source/a/acme/acme-$VER.tar.gz"
-CHKSUM="sha256::7e5c2d01986e0f34ca08fee58981892704c82c48435dcd3592b424c312d8b2bf"
-REL=1
+CHKSUM="sha256::aa363474d50e9fdda27acb8b1aa7efb26fecc5650e02039a0de3a3f0e696c2f2"

--- a/extra-python/configargparse/autobuild/defines
+++ b/extra-python/configargparse/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=configargparse
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="pyyaml"
 BUILDDEP="setuptools"
 PKGDES="A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables"
 

--- a/extra-python/configargparse/spec
+++ b/extra-python/configargparse/spec
@@ -1,5 +1,4 @@
-VER=0.14.0
-REL=2
+VER=1.3
 SRCTBL="https://github.com/bw2/ConfigArgParse/archive/$VER.tar.gz"
-CHKSUM="sha256::b52a859838c90f4d662f824e4b2dc25395cd32abab9bc8f4c4d64725197dd517"
+CHKSUM="sha256::aee4156db260051207d4757548b524bcb56ed0988cdf23cf7c69fa7afca6d382"
 SUBDIR="ConfigArgParse-$VER"

--- a/extra-python/josepy/autobuild/defines
+++ b/extra-python/josepy/autobuild/defines
@@ -6,3 +6,4 @@ PKGDES="JOSE protocol implementation in Python using cryptography"
 
 ABHOST=noarch
 ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/josepy/spec
+++ b/extra-python/josepy/spec
@@ -1,4 +1,3 @@
-VER=1.1.0
-REL=2
+VER=1.7.0
 SRCTBL="https://github.com/certbot/josepy/archive/v$VER.tar.gz"
-CHKSUM="sha256::9c372c814c1d2c9970f3bf2b9bd20bfeeb6fb62b54c4f7ceab99d01eef722a49"
+CHKSUM="sha256::c34fa80254b72caf370670ca85c283a55d4b40c62e4ed1734ffc7c2fe07036ad"

--- a/extra-python/jsonlines/autobuild/defines
+++ b/extra-python/jsonlines/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=jsonlines
+PKGSEC=python
+PKGDES="Python library for manipulating jsonlines markup format"
+BUILDDEP="setuptools"
+PKGDEP="six"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/jsonlines/spec
+++ b/extra-python/jsonlines/spec
@@ -1,0 +1,3 @@
+VER=1.2.0
+SRCTBL="https://pypi.io/packages/source/j/jsonlines/jsonlines-$VER.tar.gz"
+CHKSUM="sha256::43b8d5588a9d4862c8a4a49580e38e20ec595aee7ad6fe469b10fb83fbefde88"

--- a/extra-python/python-cloudflare/autobuild/defines
+++ b/extra-python/python-cloudflare/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=python-cloudflare
+PKGSEC=python
+PKGDEP="beautifulsoup4 future jsonlines requests pyyaml"
+BUILDDEP="setuptools"
+PKGDES="Python bindings for Cloudflare v4 API"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/python-cloudflare/spec
+++ b/extra-python/python-cloudflare/spec
@@ -1,0 +1,3 @@
+VER=2.8.15
+SRCTBL="https://pypi.io/packages/source/c/cloudflare/cloudflare-$VER.tar.gz"
+CHKSUM="sha256::1f47bd324f80e91487dea2c79be934b1dc612bcfa63e784dcf74c6a2f52a41cc"


### PR DESCRIPTION
Topic Description
-----------------

Let's Encrypt ACME procotol client Certbot is now updated to 1.12.0 alongside with the ACME python bindings and web server integration plugins. This PR also introduces a new plugin for completing challenge over DNS TXT records with cloudflare API.

Package(s) Affected
-------------------

* `josepy`: 1.7.0
* `jsonlines`: 1.2.0
* `configargparse`: 1.3
* `python-cloudflare`: 2.8.15
* `acme`: 1.12.0
* `certbot`: 1.12.0
* `certbot-{apache,nginx,dns-cloudflare}`: 1.12.0

Build Order
-----------

Build in the order of commits.

Architectural Progress
----------------------
- [x] Architecture-independent `noarch

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
