### PR TITLE
boinc: update to 7.16.16

### DIFF
--- a/extra-libs/wxwidgets/03-wxgtk3/beyond
+++ b/extra-libs/wxwidgets/03-wxgtk3/beyond
@@ -1,7 +1,10 @@
+abinfo "Removing unneeded files ..."
 rm -f "$PKGDIR"/usr/bin/wxrc*
 rm -r "$PKGDIR"/usr/include
 rm -f "$PKGDIR"/usr/lib/libwx_baseu*
 rm -r "$PKGDIR"/usr/share/aclocal
 rm -r "$PKGDIR"/usr/share/bakefile
 rm -r "$PKGDIR"/usr/share/locale
-rm -f "$PKGDIR"/usr/bin/wx-config
+
+abinfo "Renaming wx-config to avoid the file conflict with wxgtk2 ..."
+mv -v "$PKGDIR"/usr/bin/wx-config "$PKGDIR"/usr/bin/wx-config-gtk3

--- a/extra-libs/wxwidgets/spec
+++ b/extra-libs/wxwidgets/spec
@@ -1,4 +1,4 @@
 VER=3.0.4
-REL=6
-SRCTBL="https://github.com/wxWidgets/wxWidgets/releases/download/v$VER/wxWidgets-$VER.tar.bz2"
-CHKSUM="sha256::96157f988d261b7368e5340afa1a0cad943768f35929c22841f62c25b17bf7f0"
+REL=7
+SRCS="tbl::https://github.com/wxWidgets/wxWidgets/releases/download/v$VER/wxWidgets-$VER.tar.bz2"
+CHKSUMS="sha256::96157f988d261b7368e5340afa1a0cad943768f35929c22841f62c25b17bf7f0"

--- a/extra-scientific/boinc/autobuild/beyond
+++ b/extra-scientific/boinc/autobuild/beyond
@@ -1,6 +1,6 @@
 # Install icons
-install -Dm644 "$SRCDIR"/packages/generic/sea/boincmgr.48x48.png \
+install -Dvm644 "$SRCDIR"/packages/generic/sea/boincmgr.48x48.png \
                "$PKGDIR"/usr/share/pixmaps/$PKGNAME.png
 
 # Remove initscripts
-rm -rf "$PKGDIR"/etc
+rm -rvf "$PKGDIR"/etc

--- a/extra-scientific/boinc/autobuild/defines
+++ b/extra-scientific/boinc/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=boinc
 PKGSEC=science
 PKGDES="Berkeley Open Infrastructure for Network Computing for desktop"
-PKGDEP="curl x11-lib libnotify sqlite wxgtk2 libunwind"
+PKGDEP="curl x11-lib libnotify sqlite wxgtk3 libunwind webkit2gtk"
 BUILDDEP="freeglut git glu inetutils libxslt mesa perl-xml-sax"
 
 AUTOTOOLS_AFTER="--disable-server --enable-unicode --with-ssl \

--- a/extra-scientific/boinc/autobuild/defines
+++ b/extra-scientific/boinc/autobuild/defines
@@ -6,6 +6,6 @@ BUILDDEP="freeglut git glu inetutils libxslt mesa perl-xml-sax"
 
 AUTOTOOLS_AFTER="--disable-server --enable-unicode --with-ssl \
                  --enable-dynamic-client-linkage \
-                 --with-wxdir=/usr/lib --with-wx-config=wx-config \
+                 --with-wxdir=/usr/lib --with-wx-config=wx-config-gtk3 \
                  --enable-client --enable-manager --with-x"
 ABSHADOW=no

--- a/extra-scientific/boinc/spec
+++ b/extra-scientific/boinc/spec
@@ -1,3 +1,3 @@
-VER=7.16.11
-SRCTBL="https://github.com/BOINC/boinc/archive/client_release/${VER%.*}/$VER.tar.gz"
-CHKSUM="sha256::8a3f9453b16acfd8c636d18b4939c461c751aa1dd9e108cf60b90a3909bfa0a9"
+VER=7.16.16
+SRCS="tbl::https://github.com/BOINC/boinc/archive/client_release/${VER%.*}/$VER.tar.gz"
+CHKSUMS="sha256::0d5656a9f8ed1048936a5764270848b892d63f27bdb863d0ace447f1eaae6002"


### PR DESCRIPTION
Topic Description
-----------------

Update boinc to 7.16.16, fix boincmgr library dep.

Package(s) Affected
-------------------

boinc

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`