### PR TITLE
AOSC buildtools update 20210306

### DIFF
--- a/extra-devel/acbs/spec
+++ b/extra-devel/acbs/spec
@@ -1,3 +1,2 @@
-VER=20201112
-GITSRC="https://github.com/AOSC-Dev/acbs"
-GITCO="64c31838471a7a4097a93f4e905a06c8601830ae"
+VER=20210303
+SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/acbs"

--- a/extra-devel/ciel/spec
+++ b/extra-devel/ciel/spec
@@ -1,3 +1,3 @@
-VER=3.0.0~rc4
+VER=3.0.0~rc6
 GITSRC="https://github.com/AOSC-Dev/ciel-rs"
 GITCO="tags/v${VER/\~/-}"


### PR DESCRIPTION
Topic Description
-----------------

Updates for AOSC OS build tools.

Package(s) Affected
-------------------

```
acbs
ciel
```

Security Update?
----------------

No


Architectural Progress
----------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2840)
<!-- Reviewable:end -->
