### PR TITLE
syncthing: update to 1.14.0

### DIFF
--- a/extra-network/syncthing/spec
+++ b/extra-network/syncthing/spec
@@ -1,5 +1,4 @@
-VER=1.10.0
+VER=1.14.0
 SRCS="https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
-CHKSUMS="sha256::6598bc8daaae70e6e11c8df86f1e38a6a286401cfcbec44f25f5aee9f444eb4e" 
+CHKSUMS="sha256::55a6fb08a9dbc1a31a6b429a16abb3a76d8c24b491a86a52170ddaadea33f683" 
 SUBDIR=.
-REL=2


### PR DESCRIPTION
Topic Description
-----------------
Update syncthing to 1.14.0.

Package(s) Affected
-------------------
+ syncthing

Security Update?
----------------
No

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`