### PR TITLE
macchina: 0.5.5, new

### DIFF
--- a/extra-utils/macchina/autobuild/defines
+++ b/extra-utils/macchina/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=macchina
+PKGSEC=utils
+PKGDEP="gcc-runtime glibc wmctrl"
+BUILDDEP="cargo llvm"
+PKGDES="Basic system information fetcher"
+
+USECLANG=1

--- a/extra-utils/macchina/autobuild/prepare
+++ b/extra-utils/macchina/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Enabling LTO ..."
+sed -i "s/debug = false/debug = false\nlto = true/g" "$SRCDIR"/Cargo.toml

--- a/extra-utils/macchina/spec
+++ b/extra-utils/macchina/spec
@@ -1,0 +1,3 @@
+VER=0.5.5
+SRCS="tbl::https://github.com/grtcdr/macchina/archive/v${VER}.tar.gz"
+CHKSUMS="sha256::7ef3c5cc63b59a85b21db877f6ecf217b1b1bca8f0c28f610c2071cccc7ce6e4"


### PR DESCRIPTION
Topic Description
-----------------

Add a new package `macchina`

Package(s) Affected
-------------------

macchina

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`