### PR TITLE
zotero: upd to 5.0.95.3

### DIFF
--- a/extra-productivity/zotero/autobuild/build
+++ b/extra-productivity/zotero/autobuild/build
@@ -1,9 +1,28 @@
-mkdir -pv $PKGDIR/usr/{bin,lib/zotero}
+pushd "${SRCDIR}/zotero-client"
+abinfo "Building zotero JavaScript components"
+npm install
+npm run build
+popd
 
-cp -av Zotero_linux-x86_64/* "$PKGDIR"/usr/lib/zotero
-ln -sv /usr/lib/zotero/zotero "$PKGDIR"/usr/bin/zotero
+pushd "${SRCDIR}/zotero-standalone-build"
+abinfo "Building zotero application host"
+./fetch_xulrunner.sh -p l
+./fetch_pdftools
+./scripts/dir_build
+popd
 
+abinfo "Installing zotero"
+mkdir -pv "${PKGDIR}/usr/bin"
+mkdir -pv "${PKGDIR}/usr/lib/zotero"
+cp -rv "${SRCDIR}/zotero-standalone-build/staging/Zotero_linux-x86_64"/* "${PKGDIR}/usr/lib/zotero"
+
+abinfo "Creating symlinks and application entries"
+ln -vs "/usr/lib/zotero/zotero" "${PKGDIR}/usr/bin/zotero"
 for i in 16 32 48 256; do
-    install -Dvm644 "$PKGDIR"/usr/lib/zotero/chrome/icons/default/default${i}.png \
-        "$PKGDIR"/usr/share/icons/hicolor/${i}x${i}/apps/zotero.png
+	install -Dvm644 "${PKGDIR}/usr/lib/zotero/chrome/icons/default/default${i}.png" \
+		"${PKGDIR}/usr/share/icons/hicolor/${i}x${i}/apps/zotero.png"
 done
+
+abinfo "Disabling update checks"
+sed -i '/pref("app.update.enabled", true);/c\pref("app.update.enabled", false);' \
+	"${PKGDIR}"/usr/lib/zotero/defaults/preferences/prefs.js

--- a/extra-productivity/zotero/autobuild/defines
+++ b/extra-productivity/zotero/autobuild/defines
@@ -2,5 +2,7 @@ PKGNAME=zotero
 PKGDES="A free, easy-to-use tool to help you collect, organize, cite, and share your research sources"
 PKGSEC=doc
 PKGDEP="dbus-glib alsa-lib gtk-3 gcc-runtime nss"
+BUILDDEP="nodejs"
 
 FAIL_ARCH="!(amd64)"
+ABSPLITDBG=0

--- a/extra-productivity/zotero/autobuild/prepare
+++ b/extra-productivity/zotero/autobuild/prepare
@@ -1,0 +1,1 @@
+acbs_copy_git

--- a/extra-productivity/zotero/spec
+++ b/extra-productivity/zotero/spec
@@ -1,4 +1,14 @@
-VER=5.0.89
-SRCTBL="https://www.zotero.org/download/client/dl?channel=release&platform=linux-x86_64&version=$VER"
-CHKSUM="sha256::74e1dbe47a3804bccfccdfd1f3d3fb92912c4f0bd30a776676c2a5eeacc5e4a2"
-SUBDIR=.
+VER=5.0.95.3
+_BUILD_REPO_COMMIT=468b2a1f48b736b0d460dccdf8e57bf6edc47aa5
+SRCS="
+	git::commit=${VER};rename=zotero-client::https://github.com/zotero/zotero.git
+	git::commit=${_BUILD_REPO_COMMIT};rename=zotero-build::https://github.com/zotero/zotero-build.git
+	git::commit=${VER};rename=zotero-standalone-build::https://github.com/zotero/zotero-standalone-build.git
+"
+CHKSUMS="
+	SKIP
+	SKIP
+	SKIP
+"
+SUBDIR="."
+


### PR DESCRIPTION
Topic Description
-----------------

This PR updates Zotero to 5.0.95.3. The builld process now at least tries to build the JavaScript component part of it.

Package(s) Affected
-------------------

zotero： 5.0.95.3

Architectural Progress
----------------------

- [x] AMD64 `amd64`   

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   

<!-- TODO: CI to auto-fill architectural progress. -->
