### PR TITLE
brasero: rebuild for libtracker-sparql-3.0.so

### DIFF
--- a/extra-gnome/brasero/spec
+++ b/extra-gnome/brasero/spec
@@ -1,5 +1,5 @@
 VER=3.12.2
-REL=1
+REL=2
 SRCTBL="https://download.gnome.org/sources/brasero/${VER:0:4}/brasero-$VER.tar.xz"
 CHKSUM="sha256::6822166f9d08efcf8d900cab6f563e87f49f0e078ca10595dcd908498ef12041"
 


### PR DESCRIPTION
Topic Description
-----------------

`tracker` has been updated to 3.0.1 quite a while ago shipping a so with different name, but brasero wasn't relinked against that. It is now.

Package(s) Affected
-------------------

* brasero: `1:3.12.2-2`

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
