### PR TITLE
Duplicity 0.8.18, b2 backend support and deja-dup fixes

### DIFF
--- a/extra-gnome/deja-dup/autobuild/defines
+++ b/extra-gnome/deja-dup/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=deja-dup
 PKGSEC=gnome
 PKGDES="Simple backup tool with duplicity backend"
-PKGDEP="duplicity gnome-online-accounts gvfs libpeas libnotify pygobject-3 nautilus gnome-keyring"
+PKGDEP="duplicity gnome-online-accounts gvfs libhandy libsecret pygobject-3 nautilus gnome-keyring json-glib packagekit"
 BUILDDEP="gobject-introspection intltool itstool vala appstream-glib"
 
 ABTYPE=meson

--- a/extra-gnome/deja-dup/spec
+++ b/extra-gnome/deja-dup/spec
@@ -1,3 +1,3 @@
-VER=40.6
+VER=42.7
 SRCTBL="https://gitlab.gnome.org/World/deja-dup/-/archive/$VER/deja-dup-$VER.tar.gz"
-CHKSUM="sha256::05a7de827d3a0e687230fcff1b236f79a3d5a1300bee39d1b2542b76f89b8725"
+CHKSUM="sha256::e4c4986644f829e72b242278eb4298a54c9264be480d854aac8fd72e492b5593"

--- a/extra-python/arrow/autobuild/defines
+++ b/extra-python/arrow/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=arrow
+PKGSEC=python
+PKGDEP="python-3 dateutil"
+BUILDDEP="setuptools"
+PKGDES="Enhanced date and time for python"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/extra-python/arrow/spec
+++ b/extra-python/arrow/spec
@@ -1,0 +1,3 @@
+VER=1.0.3
+SRCTBL="https://pypi.io/packages/source/a/arrow/arrow-$VER.tar.gz"
+CHKSUM="sha256::399c9c8ae732270e1aa58ead835a79a40d7be8aa109c579898eb41029b5a231d"

--- a/extra-python/b2sdk/autobuild/defines
+++ b/extra-python/b2sdk/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=b2sdk
+PKGSEC=python
+PKGDEP="python-3 logfury arrow requests tqdm"
+BUILDDEP="setuptools"
+PKGDES="Python bindings for Backblaze B2 storage APIs"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/extra-python/b2sdk/spec
+++ b/extra-python/b2sdk/spec
@@ -1,0 +1,3 @@
+VER=1.4.0
+SRCTBL="https://pypi.io/packages/source/b/b2sdk/b2sdk-$VER.tar.gz"
+CHKSUM="sha256::fb82cbaef5dd7499b62622010fc8e328944ca8cbdd00b485530ab6600de1129d"

--- a/extra-python/boto3/autobuild/defines
+++ b/extra-python/boto3/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=boto3
+PKGSEC=python
+PKGDEP="python-3 s3transfer botocore jmespath"
+BUILDDEP="setuptools"
+PKGDES="A Python interface to Amazon Web Services"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/extra-python/boto3/spec
+++ b/extra-python/boto3/spec
@@ -1,0 +1,3 @@
+VER=1.17.27
+SRCTBL="https://pypi.io/packages/source/b/boto3/boto3-$VER.tar.gz"
+CHKSUM="sha256::fa41987f9f71368013767306d9522b627946a01b4843938a26fb19cc8adb06c0"

--- a/extra-python/botocore/autobuild/defines
+++ b/extra-python/botocore/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=botocore
+PKGSEC=python
+PKGDEP="python-3 dateutil docutils jmespath urllib3"
+BUILDDEP="setuptools"
+PKGDES="A low-level interface to Amazon Web Services API endpoints"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/extra-python/botocore/spec
+++ b/extra-python/botocore/spec
@@ -1,0 +1,3 @@
+VER=1.20.21
+SRCTBL="https://pypi.io/packages/source/b/botocore/botocore-$VER.tar.gz"
+CHKSUM="sha256::b604bbda4205b1a463c20d8434c7ddce1abbc3f6a4d5bf911e2b7774b2807f03"

--- a/extra-python/jmespath/autobuild/defines
+++ b/extra-python/jmespath/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=jmespath
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="A declarative element extractor for JSON objects"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/extra-python/jmespath/spec
+++ b/extra-python/jmespath/spec
@@ -1,0 +1,3 @@
+VER=0.10.0
+SRCTBL="https://pypi.io/packages/source/j/jmespath/jmespath-$VER.tar.gz"
+CHKSUM="sha256::b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"

--- a/extra-python/logfury/autobuild/defines
+++ b/extra-python/logfury/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=logfury
+PKGSEC=python
+PKGDEP="python-3 funcsigs six"
+BUILDDEP="setuptools"
+PKGDES="Responsible, reusable logging toolkit"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/extra-python/logfury/spec
+++ b/extra-python/logfury/spec
@@ -1,0 +1,3 @@
+VER=0.1.2
+SRCTBL="https://pypi.io/packages/source/l/logfury/logfury-$VER.tar.gz"
+CHKSUM="sha256::42da58fbbd4e6fdb9e5b6b9098e94c249ba9cebfae125643329c8636768edcd3"

--- a/extra-python/s3transfer/autobuild/defines
+++ b/extra-python/s3transfer/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=s3transfer
+PKGSEC=python
+PKGDEP="python-3 botocore"
+BUILDDEP="setuptools"
+PKGDES="AWS Simple Storage Service Transfer Manager"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/extra-python/s3transfer/spec
+++ b/extra-python/s3transfer/spec
@@ -1,0 +1,3 @@
+VER=0.3.4
+SRCTBL="https://pypi.io/packages/source/s/s3transfer/s3transfer-$VER.tar.gz"
+CHKSUM="sha256::7fdddb4f22275cf1d32129e21f056337fd2a80b6ccef1664528145b72c49e6d2"

--- a/extra-utils/duplicity/autobuild/defines
+++ b/extra-utils/duplicity/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=duplicity
 PKGSEC=util
-PKGDEP="boto pygobject-3 gvfs gdata-python-client librsync gnupg paramiko \
-        fasteners"
+PKGDEP="boto3 pygobject-3 gdata-python-client librsync gnupg \
+        fasteners future requests b2sdk"
 PKGDES="A utility for encrypted, bandwidth-efficient backups using the rsync algorithm."
 
 ABTYPE=python
-NOPYTHON3=1
+NOPYTHON2=1

--- a/extra-utils/duplicity/spec
+++ b/extra-utils/duplicity/spec
@@ -1,4 +1,3 @@
-VER=0.7.18.2
-SRCTBL="https://launchpad.net/duplicity/0.7-series/${VER}/+download/duplicity-${VER}.tar.gz"
-CHKSUM="sha256::c236888f43128e96cd33017b01a2855c0e24738195fed5cadad08c28fd6b6748"
-REL=1
+VER=0.8.18
+SRCTBL="https://launchpad.net/duplicity/${VER%.*}-series/${VER}/+download/duplicity-${VER}.tar.gz"
+CHKSUM="sha256::2643fea0f52920a0fb114069c78389f9621f1c24db7f26bda77bbc239b01ae53"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates duplicity and its dependencies, which eventually moved on to Python 3. Proper dependencies are introduced for duplicity to backup to and restore from Backblaze B2 storage.

The gtk front-end deja-dup is also updated along the way.

Package(s) Affected
-------------------

New packages:

+ noarch - jmespath 0.10.0
+ noarch - botocore 1.20.21
+ noarch - boto3 1.27.27
+ noarch - s3transfer 0.3.4
+ noarch - arrow 1.0.3
+ noarch - logfury 0.1.2
+ noarch - b2sdk 1.4.0

Updated:

* duplicity 0.8.18
* deja-dup 42.7

Build Order
-----------

Build in the order of commits.

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
