### PR TITLE
Jetbrains update (2 IDEs)

### DIFF
--- a/extra-devel/intellij-idea/autobuild/defines
+++ b/extra-devel/intellij-idea/autobuild/defines
@@ -6,4 +6,5 @@ PKGDES="IDE for Java, Groovy and other programming languages with advanced refac
 
 PKGPROV="intellij-idea-community-edition ideaIC ideaic"
 
-TAGVER=203.5981.155
+TAGVER=203.7148.57
+ABSPLITDBG=0

--- a/extra-devel/intellij-idea/spec
+++ b/extra-devel/intellij-idea/spec
@@ -1,6 +1,6 @@
-VER=2020.3
+VER=2020.3.2
 
 SRCTBL="https://download.jetbrains.com/idea/ideaIC-$VER.tar.gz"
-CHKSUM="sha256::c6f78b72cf7b82619685651ae8517c3faf983dc558c4d4f4c171801ab8d43674"
+CHKSUM="sha256::2db84ef019da6157d544c43d780901d6178bd029ce686267eec9ac23e2ae727e"
 SUBDIR=.
 REL=1

--- a/extra-devel/intellij-idea/spec
+++ b/extra-devel/intellij-idea/spec
@@ -3,4 +3,3 @@ VER=2020.3.2
 SRCTBL="https://download.jetbrains.com/idea/ideaIC-$VER.tar.gz"
 CHKSUM="sha256::2db84ef019da6157d544c43d780901d6178bd029ce686267eec9ac23e2ae727e"
 SUBDIR=.
-REL=1

--- a/extra-devel/pycharm/autobuild/defines
+++ b/extra-devel/pycharm/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=pycharm
 PKGDES="Powerful Python IDE by JetBrains"
 PKGSEC=devel
 PKGDEP="giflib python-base"
+
+ABSPLITDBG=0

--- a/extra-devel/pycharm/spec
+++ b/extra-devel/pycharm/spec
@@ -1,4 +1,4 @@
-VER=2020.2
+VER=2020.3.3
 SRCTBL="https://download.jetbrains.com/python/pycharm-community-$VER.tar.gz"
-CHKSUM="sha256::60b2eeea5237f536e5d46351fce604452ce6b16d037d2b7696ef37726e1ff78a"
+CHKSUM="sha256::915a8803db2d47dd0c739da61034eb787f7c9e9e512ebcb02ea1a45cddbb055c"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Update JetBrains IDEs (PyCharm, IntelliJ-IDEA) to the current latest version.

Package(s) Affected
-------------------

- `pycharm`
- `intellij-idea`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
