### PR TITLE
Migrate ibus-libpinyin to python 3

### DIFF
--- a/extra-database/kyotocabinet/spec
+++ b/extra-database/kyotocabinet/spec
@@ -1,3 +1,3 @@
-VER=1.2.78
+VER=1.2.79
 SRCTBL="https://fallabs.com/kyotocabinet/pkg/kyotocabinet-$VER.tar.gz"
-CHKSUM="sha256::494c6383a94bd7a64425223a770821128e99ebae68b598714e782b566772b3af"
+CHKSUM="sha256::67fb1da4ae2a86f15bb9305f26caa1a7c0c27d525464c71fd732660a95ae3e1d"

--- a/extra-i18n/ibus-libpinyin/autobuild/defines
+++ b/extra-i18n/ibus-libpinyin/autobuild/defines
@@ -4,6 +4,5 @@ PKGDEP="libpinyin ibus pyxdg"
 BUILDDEP="gnome-common intltool"
 PKGDES="Intelligent Pinyin input engine based on libpinyin"
 
-ABMK="$ABMK NO_INDEX=true"
 AUTOTOOLS_AFTER="--disable-lua-extension"
 ABSHADOW=0

--- a/extra-i18n/ibus-libpinyin/autobuild/prepare
+++ b/extra-i18n/ibus-libpinyin/autobuild/prepare
@@ -1,0 +1,1 @@
+export PYTHON=/usr/bin/python3

--- a/extra-i18n/ibus-libpinyin/spec
+++ b/extra-i18n/ibus-libpinyin/spec
@@ -1,4 +1,4 @@
-VER=1.11.1
-SRCTBL="https://github.com/epico/ibus-libpinyin/archive/$VER.tar.gz"
-CHKSUM="sha256::a30d5cd15920c669df296593ffd9747f07faeb0edf752bc83ebf8a5db608ea76"
+VER=1.12.0
+SRCTBL="https://github.com/libpinyin/ibus-libpinyin/archive/$VER.tar.gz"
+CHKSUM="sha256::1fe023d3416f1be6284e23fd977cae58e3e5eddbc5582e6e8aa7bb82b3751ddd"
 SUBDIR=ibus-libpinyin-$VER

--- a/extra-i18n/libpinyin/spec
+++ b/extra-i18n/libpinyin/spec
@@ -1,3 +1,3 @@
-VER=2.3.0
+VER=2.6.0
 SRCTBL="https://github.com/libpinyin/libpinyin/archive/$VER.tar.gz"
-CHKSUM="sha256::00cb09f267031fb528bebc4621268037fca64677040123ebb184a50afcb43430"
+CHKSUM="sha256::2b52f617a99567a8ace478ee82ccc62d1761e3d1db2f1e05ba05b416708c35d2"


### PR DESCRIPTION
Topic Description
-----------------

At the time of writing, `pygobject-3` has dropped support for python 2. This leads to the following error when trying to open the configuration window for `ibus-libpinyin`:

```
Traceback (most recent call last):
  File "main2.py", line 32, in <module>
    from gi import require_version as gi_require_version
  File "/usr/lib/python2.7/site-packages/gi/__init__.py", line 42, in <module>
ImportError: cannot import name _gi
```

This PR updates the ibus-pinyin and its dependencies and migrate to python 3 as needed.

Package(s) Affected
-------------------

* `kyotocabinet`: 1.2.79
* `libpinyin`: 2.6.0
* `ibus-libpinyin`: 1.12.0

Build Order
-----------

Build in the order of commits.

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
