### PR TITLE
Bzip2: update build script

### DIFF
--- a/base-utils/bzip2/autobuild/build
+++ b/base-utils/bzip2/autobuild/build
@@ -11,9 +11,9 @@ ln -sfv bzip2 "$PKGDIR"/usr/bin/bzcat
 
 install -vm755 libbz2.a "$PKGDIR"/usr/lib
 install -vm755 libbz2.so.$PKGVER "$PKGDIR"/usr/lib
-ln -sv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so
-ln -sv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1
-ln -sv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1.0
+ln -sfv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so
+ln -sfv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1
+ln -sfv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1.0
 
 install -vm644 bzlib.h "$PKGDIR"/usr/include/
 

--- a/base-utils/bzip2/spec
+++ b/base-utils/bzip2/spec
@@ -1,4 +1,4 @@
 VER=1.0.8
 SRCTBL="https://sourceware.org/pub/bzip2/bzip2-$VER.tar.gz"
 CHKSUM="sha256::ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
-REL=2
+REL=3


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
bzip2: overwrite the .so syslinks
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
none
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
