### PR TITLE
wine: update to 6.4

### DIFF
--- a/extra-emulation/wine/spec
+++ b/extra-emulation/wine/spec
@@ -1,6 +1,6 @@
-VER=6.3
+VER=6.4
 SRCS="tbl::https://dl.winehq.org/wine/source/${VER:0:1}.x/wine-$VER.tar.xz \
       git::rename=wine-staging;commit=tags/v$VER::https://github.com/wine-staging/wine-staging"
-CHKSUMS="whirlpool::e14763dd886b37cabfa6a04312f969af41d0ce4b6b78306ea0b15985d0925bd1baefa567a1ad1f21e622a383f7874ba8f3ec0c4183cf6041b6f1c1b02f890279 \
+CHKSUMS="whirlpool::30ee11275d5c7d46b41783921588e3cde96c2ef77aca182f44db67b187eb01a7b56316cf39d6dd5ebd4be21bac8398fc2ee9b8e66d35721a20285b18773e889b \
          SKIP"
 SUBDIR="wine-$VER"


### PR DESCRIPTION
Topic Description
-----------------
- Update `wine` to 6.4
- (Note: It seems still run unbearable slowly in ARM64 due to the unknown reason.) 

Package(s) Affected
-------------------
- wine

Security Update?
----------------
No


Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
