### PR TITLE
libinput 1.17.0 + xf86-input-libinput

### DIFF
--- a/extra-libs/libinput/spec
+++ b/extra-libs/libinput/spec
@@ -1,4 +1,3 @@
-VER=1.14.3
-REL=1
+VER=1.17.0
 SRCTBL="https://www.freedesktop.org/software/libinput/libinput-$VER.tar.xz" 
-CHKSUM="sha256::0feb3a0589709cc1032893bfaf4c49150d5360bd9782bec888f9e4dd9044c5b7"
+CHKSUM="sha256::c560cfca14cb5c50d2a1b7551df06bc5d4306e32c128f3e3d37e137285dedbad"

--- a/extra-x11/xf86-input-libinput/spec
+++ b/extra-x11/xf86-input-libinput/spec
@@ -1,3 +1,3 @@
-VER=0.29.0
+VER=0.30.0
 SRCTBL="https://xorg.freedesktop.org/releases/individual/driver/xf86-input-libinput-$VER.tar.bz2"
-CHKSUM="sha256::c28b56a21754b972db31798e6a4cf4dc9d69208d08f8fe41701a94def5e94bee"
+CHKSUM="sha256::f9c7f9fd41ae14061e0e9c3bd45fa170e5e21027a2bc5810034e1e748db996c0"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates libinput to 1.17.0, xf86-input-libinput to 0.30.0. with a few bug fixes and quirks.

Package(s) Affected
-------------------

* libinput
* xf86-input-libinput

Build Order
-----------

Build in the order of commits.

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
