### PR TITLE
msr-tools: new, 20170320

### DIFF
--- a/extra-utils/msr-tools/autobuild/defines
+++ b/extra-utils/msr-tools/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=msr-tools
 PKGDEP="glibc"
 PKGDES="Utilities to read and write model-specific registers"
 PKGSEC=utils
+
+RECONF=0

--- a/extra-utils/msr-tools/autobuild/defines
+++ b/extra-utils/msr-tools/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=msr-tools
+PKGDEP="glibc"
+PKGDES="Utilities to read and write model-specific registers"
+PKGSEC=utils

--- a/extra-utils/msr-tools/autobuild/prepare
+++ b/extra-utils/msr-tools/autobuild/prepare
@@ -1,2 +1,2 @@
 abinfo "Removing arbitrary autogen.sh..."
-rm -v ${SRCDIR}/autogen.sh
+rm -v "${SRCDIR}/autogen.sh"

--- a/extra-utils/msr-tools/autobuild/prepare
+++ b/extra-utils/msr-tools/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Removing arbitrary autogen.sh..."
+rm -v ${SRCDIR}/autogen.sh

--- a/extra-utils/msr-tools/autobuild/prepare
+++ b/extra-utils/msr-tools/autobuild/prepare
@@ -1,2 +1,2 @@
-abinfo "Removing arbitrary autogen.sh..."
-rm -v "${SRCDIR}/autogen.sh"
+abinfo "Generating configure script with autotools...";
+autoreconf --force --install --warnings=all

--- a/extra-utils/msr-tools/spec
+++ b/extra-utils/msr-tools/spec
@@ -1,0 +1,3 @@
+VER=20170320
+SRCS="git::commit=eec71d977a83f8dc76bc3ccc6de5cbd3be378572::https://github.com/intel/msr-tools"
+CHKSUMS="SKIP"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Introduce msr-tools by Intel for accessing model-specific registers(MSRs).

Intel changed its build system to autotools without making a new release, so the latest git commit is being used here.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

msr-tools: new, 20170320
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
