### PR TITLE
fish: update to 3.2.1

### DIFF
--- a/extra-shells/fish/autobuild/defines
+++ b/extra-shells/fish/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=fish
 PKGSEC=shells
 PKGDEP="bc gcc-runtime inetutils ncurses which"
-BUILDDEP="doxygen"
+BUILDDEP="sphinx"
 PKGDES="A smart and user-friendly shell intended mostly for interactive use"
+
+CMAKE_AFTER="-DBUILD_DOCS=True"
 
 ABSHADOW=no
 RECONF=0

--- a/extra-shells/fish/spec
+++ b/extra-shells/fish/spec
@@ -1,3 +1,3 @@
-VER=3.2.0
+VER=3.2.1
 SRCS="tbl::https://github.com/fish-shell/fish-shell/archive/$VER.tar.gz"
-CHKSUMS="sha256::9f7b892ca1f835f1aa615230334b0805c6c043895d55da9a0c0282c088c0abaf"
+CHKSUMS="sha256::31482435dd0cb2ed05bb9ebe0702ccdbb76577ec2c3141ad89aca3a0608fa247"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fish: update to 3.2.1

- It seems that upstream does not use doxygen and uses sphinx to generate documentation, so use sphinx instead of doxygen as a build dependency

Package(s) Affected
-------------------

fish: 3.2.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
