### PR TITLE
Update phosh-related packages

### DIFF
--- a/extra-gnome/libhandy/autobuild/defines
+++ b/extra-gnome/libhandy/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libhandy
 PKGSEC=gnome
-PKGDEP="gtk-3"
-BUILDDEP="gobject-introspection gtk-doc vala glade"
+PKGDEP="gtk-3 fribidi"
+BUILDDEP="gobject-introspection gtk-doc vala glade libxml2"
 PKGDES="A library full of GTK+ widgets for mobile phones"
 
 MESON_AFTER="-Dgtk_doc=true"

--- a/extra-gnome/libhandy/spec
+++ b/extra-gnome/libhandy/spec
@@ -1,3 +1,3 @@
-VER=1.0.2
+VER=1.2.0
 SRCS="https://download.gnome.org/sources/libhandy/${VER:0:3}/libhandy-$VER.tar.xz"
-CHKSUMS="sha256::3ad78d0594165c7e8150f662506d386552825e693aa3679744af96bd94dc1c2d"
+CHKSUMS="sha256::39f590ae20910e76fe1c0607b2ebe589750f45610d6aeec5c30e2ee602a20b25"

--- a/extra-phosh/calls/autobuild/defines
+++ b/extra-phosh/calls/autobuild/defines
@@ -2,5 +2,5 @@ PKGNAME=calls
 PKGDES="Phone calling application for Phosh"
 PKGSEC=x11
 PKGDEP="wayland gtk-3 gom libpeas gsound folks evolution-data-server \
-        modemmanager libhandy callaudiod"
+        modemmanager libhandy callaudiod feedbackd"
 BUILDDEP="vala"

--- a/extra-phosh/calls/spec
+++ b/extra-phosh/calls/spec
@@ -1,3 +1,3 @@
-VER=0.1.9
+VER=0.2.0
 SRCS="git::commit=tags/v$VER::https://source.puri.sm/Librem5/calls.git"
 CHKSUMS="SKIP"

--- a/extra-phosh/feedbackd/spec
+++ b/extra-phosh/feedbackd/spec
@@ -1,3 +1,3 @@
-VER=0.0.0+git20201114
+VER=0.0.0+git20210125
 SRCS="git::commit=tags/v$VER::https://source.puri.sm/Librem5/feedbackd"
 CHKSUMS="SKIP"

--- a/extra-phosh/phoc/autobuild/defines
+++ b/extra-phosh/phoc/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=phoc
 PKGDES="Wayland compositor for Phosh"
 PKGSEC=misc
-PKGDEP="glib libinput wayland mesa systemd freerdp x11-lib gnome-desktop pixman"
+PKGDEP="glib libinput wayland mesa systemd x11-lib gnome-desktop pixman libxcb"
 
 MESON_AFTER="-Dembed-wlroots=enabled"

--- a/extra-phosh/phoc/spec
+++ b/extra-phosh/phoc/spec
@@ -1,3 +1,3 @@
-VER=0.5.1
+VER=0.6.0
 SRCS="git::commit=tags/v$VER::https://source.puri.sm/Librem5/phoc"
 CHKSUMS="SKIP"

--- a/extra-phosh/phosh/autobuild/beyond
+++ b/extra-phosh/phosh/autobuild/beyond
@@ -1,8 +1,11 @@
-mkdir -p "$PKGDIR"/usr/lib/systemd/system/
-cp debian/phosh.service "$PKGDIR"/usr/lib/systemd/system/
+abinfo "Copying Systemd service for Phosh..."
+mkdir -pv "$PKGDIR"/usr/lib/systemd/system/
+cp -v "$SRCDIR"/data/phosh.service "$PKGDIR"/usr/lib/systemd/system/
 
+abinfo "Adapting Phosh Systemd service for AOSC..."
 sed -i '/^Environment=LANG=/d' "$PKGDIR"/usr/lib/systemd/system/phosh.service
 sed -i 's/User=purism/User=aosc/g' "$PKGDIR"/usr/lib/systemd/system/phosh.service
 sed -i 's@WorkingDirectory=/home/purism@WorkingDirectory=/home/aosc@g' "$PKGDIR"/usr/lib/systemd/system/phosh.service
 
-mv "$PKGDIR"/usr/share/applications/sm.puri.{OSK0,oskstub}.desktop
+abinfo "Renaming the stub on-screen keyboard implementation..."
+mv -v "$PKGDIR"/usr/share/applications/sm.puri.{OSK0,oskstub}.desktop

--- a/extra-phosh/phosh/spec
+++ b/extra-phosh/phosh/spec
@@ -1,3 +1,3 @@
-VER=0.6.0
+VER=0.9.0
 SRCS="git::commit=tags/v$VER::https://source.puri.sm/Librem5/phosh"
 CHKSUMS="SKIP"

--- a/extra-phosh/squeekboard/spec
+++ b/extra-phosh/squeekboard/spec
@@ -1,4 +1,3 @@
-VER=1.11.1
-REL=2
+VER=1.12.0
 SRCS="git::commit=tags/v$VER::https://source.puri.sm/Librem5/squeekboard.git"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Update phosh-related packages from Librem5.

Package(s) Affected
-------------------

- `phoc` 0.6.0
- `libhandy` 1.2.0
- `phosh` 0.9.0
- `calls` 0.2.0
- `feedbackd` 0.0.0+20210125
- `squeekboard` 1.12.0

Security Update?
----------------

No

Build Order
-----------

Build in commit order.

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
