### PR TITLE
telegram-desktop: update to 2.7.0

### DIFF
--- a/extra-web/telegram-desktop/autobuild/defines
+++ b/extra-web/telegram-desktop/autobuild/defines
@@ -3,6 +3,9 @@ PKGSEC=web
 PKGDEP="ffmpeg hicolor-icon-theme libappindicator libnotify minizip \
         openal-soft openssl lz4 qt-5 xxhash hunspell libdbusmenu-qt \
 	libjpeg-turbo opus pulseaudio kwayland"
+PKGDEP__ARM64="${PKGDEP} glibmm"
+PKGDEP__PPC64EL="${PKGDEP} glibmm"
+PKGDEP__LOONGSON3="${PKGDEP} glibmm"
 BUILDDEP="cmake range-v3 python-3 tl-expected microsoft-gsl yasm"
 PKGDES="The official Telegram desktop application"
 

--- a/extra-web/telegram-desktop/autobuild/patches/0001-Fix-missing-include.patch
+++ b/extra-web/telegram-desktop/autobuild/patches/0001-Fix-missing-include.patch
@@ -1,0 +1,25 @@
+From da141349a50483e4822e9cf0872d8ac91551f4dc Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Fri, 19 Mar 2021 18:25:30 -0700
+Subject: [PATCH] Fix missing include
+
+---
+ Telegram/ThirdParty/tgcalls/tgcalls/group/StreamingPart.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Telegram/ThirdParty/tgcalls/tgcalls/group/StreamingPart.h b/Telegram/ThirdParty/tgcalls/tgcalls/group/StreamingPart.h
+index 08859d6..1228cff 100644
+--- a/Telegram/ThirdParty/tgcalls/tgcalls/group/StreamingPart.h
++++ b/Telegram/ThirdParty/tgcalls/tgcalls/group/StreamingPart.h
+@@ -4,6 +4,8 @@
+ #include "absl/types/optional.h"
+ #include <vector>
+ 
++#include <stdint.h>
++
+ namespace tgcalls {
+ 
+ class StreamingPartState;
+-- 
+2.30.2
+

--- a/extra-web/telegram-desktop/spec
+++ b/extra-web/telegram-desktop/spec
@@ -1,7 +1,7 @@
-VER=2.6.1
+VER=2.7.0
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
-      git::rename=tg_owt;commit=a19877363082da634a3c851a4698376504d2eaee::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::c7878c4d7c621a175b3b27895b3fb8c20a56319214d5030d734b2768390a8b73 \
+      git::rename=tg_owt;commit=7f965710b93c4dadd7e6f1ac739e708694df7929::https://github.com/desktop-app/tg_owt"
+CHKSUMS="sha256::ee50aa82e0c0515c2082a37496ffb65c7f83bd117805ee5bf9147c1777770337 \
          SKIP"
 SUBDIR=tdesktop-$VER-full


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

telegram-desktop: update to 2.7.0

- Add 0001-Fix-missing-include.patch to fix build

Package(s) Affected
-------------------

telegram-desktop: 2.7.0

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
