### PR TITLE
armips: new, 0.11.0+git20210225

### DIFF
--- a/extra-devel/armips/autobuild/beyond
+++ b/extra-devel/armips/autobuild/beyond
@@ -1,0 +1,6 @@
+abinfo "Moving files to the correct locations ..."
+install -dv "$PKGDIR/usr/bin"
+install -dv "$PKGDIR/usr/share/armips"
+
+mv -v "$PKGDIR/usr/armips" "$PKGDIR/usr/bin/armips"
+mv -v "$PKGDIR/usr/Readme.md" "$PKGDIR/usr/share/armips"

--- a/extra-devel/armips/autobuild/defines
+++ b/extra-devel/armips/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=armips
+PKGSEC=devel
+PKGDEP="gcc-runtime"
+BUILDDEP="cmake ninja"
+PKGDES="A rom-hacking friendly assembler for ARM and MIPS"

--- a/extra-devel/armips/spec
+++ b/extra-devel/armips/spec
@@ -1,0 +1,3 @@
+VER=0.11.0+git20210225
+SRCS="git::commit=910b23de757d72e69b54da5d0d1157f1b3abfe42::https://github.com/Kingcom/armips"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Add a new package `armips`.

Package(s) Affected
-------------------

`armips`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2886)
<!-- Reviewable:end -->
