### PR TITLE
LLVM: strip static libraries

### DIFF
--- a/base-devel/llvm/02-compiler/build
+++ b/base-devel/llvm/02-compiler/build
@@ -33,4 +33,9 @@ abinfo "Dropping six.py ..."
 rm -fv "$PKGDIR"/usr/lib/python*/site-packages/six.py
 
 abinfo "Stripping static libraries ..."
-strip --verbose --strip-all "$PKGDIR"/usr/lib/*.a
+strip --verbose \
+      --strip-debug \
+      --enable-deterministic-archives \
+      --remove-section=.comment \
+      --remove-section=.note \
+      "$PKGDIR"/usr/lib/*.a

--- a/base-devel/llvm/02-compiler/build
+++ b/base-devel/llvm/02-compiler/build
@@ -31,3 +31,6 @@ rm -fv "$PKGDIR"/usr/lib/libc++*.so*
 
 abinfo "Dropping six.py ..."
 rm -fv "$PKGDIR"/usr/lib/python*/site-packages/six.py
+
+abinfo "Stripping static libraries ..."
+strip --verbose --strip-all "$PKGDIR"/usr/lib/*.a

--- a/base-devel/llvm/spec
+++ b/base-devel/llvm/spec
@@ -1,4 +1,5 @@
 VER=11.1.0
+REL=1
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-$VER.src.tar.xz \
       https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/clang-$VER.src.tar.xz \
       https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/compiler-rt-$VER.src.tar.xz \


### PR DESCRIPTION
Topic Description
-----------------

Strip static libraries from LLVM. This is only meant as a temporary workaround before Autobuild3 v1.6.0.

Package(s) Affected
-------------------

- `llvm-runtime`, `llvm` v11.1.0

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`