### PR TITLE
zfs: update to 2.0.4

### DIFF
--- a/extra-kernel/zfs/autobuild/postinst
+++ b/extra-kernel/zfs/autobuild/postinst
@@ -8,5 +8,3 @@ for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
         echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $i ..."
     fi
 done
-
-sh /var/ab/triggered/dracut

--- a/extra-kernel/zfs/spec
+++ b/extra-kernel/zfs/spec
@@ -1,3 +1,3 @@
-VER=2.0.2
+VER=2.0.4
 SRCS="tbl::https://github.com/zfsonlinux/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
-CHKSUMS="sha256::bde5067ce4577d26cc0f0313a09173ad40d590d01539b92c93f33f06ee150b24"
+CHKSUMS="sha256::7d1344c5433b91823f02c2e40b33d181fa6faf286bea5591f4b1965f23d45f6c"


### PR DESCRIPTION
Topic Description
-----------------

Update ZFS kernel module and userspace tools to v2.0.4. Drop deprecated call to `/var/ab/triggered/dracut`.

Package(s) Affected
-------------------

- `zfs` v2.0.4

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`