### PR TITLE
webkit2gtk: update to 2.30.6

### DIFF
--- a/extra-libs/webkit2gtk/spec
+++ b/extra-libs/webkit2gtk/spec
@@ -1,3 +1,3 @@
-VER=2.30.5
+VER=2.30.6
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
-CHKSUMS="sha256::7d0dab08e3c5ae07bec80b2822ef42e952765d5724cac86eb23999bfed5a7f1f"
+CHKSUMS="sha256::50736ec7a91770b5939d715196e5fe7209b93efcdeef425b24dc51fb8e9d7c1e"


### PR DESCRIPTION
Topic Description
-----------------

Update WebKitGTK+ (`webkit2gtk`) to v2.30.6 for security vulnerabilities.

Package(s) Affected
-------------------

`webkit2gtk` v2.30.6

Security Update?
----------------

Yes - Issue Number: #2892 

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`