### PR TITLE
Fcitx5 survey 20210323

### DIFF
--- a/extra-bases/fcitx5-base/spec
+++ b/extra-bases/fcitx5-base/spec
@@ -1,2 +1,2 @@
-VER=2
+VER=3
 DUMMYSRC=1

--- a/extra-i18n/fcitx5-anthy/spec
+++ b/extra-i18n/fcitx5-anthy/spec
@@ -1,4 +1,3 @@
-VER=5.0.3
-REL=1
+VER=5.0.4
 SRCS="tbl::https://github.com/fcitx/fcitx5-anthy/archive/$VER.tar.gz"
-CHKSUMS="sha256::73a8daaf193af2102b75e21a436b30ce3e7b2a49eb6615e664075bf7cc36a41e"
+CHKSUMS="sha256::d952b01ea40b38328089c8a372d9a6776c9b42e4b2d0a02c748fd5be0c75df43"

--- a/extra-i18n/fcitx5-chewing/spec
+++ b/extra-i18n/fcitx5-chewing/spec
@@ -1,3 +1,3 @@
-VER=5.0.4
+VER=5.0.5
 SRCS="tbl::https://github.com/fcitx/fcitx5-chewing/archive/$VER.tar.gz"
-CHKSUMS="sha256::4af25b2f0331b5eccd5dfa7caea9a9dfa708ff73e4e4b42fdefdd5e1f4c56cbf"
+CHKSUMS="sha256::ef6676ad088d7595b0ad0f8c6e3f5653525719e86352709c7c1e842bc9e425ad"

--- a/extra-i18n/fcitx5-chinese-addons/spec
+++ b/extra-i18n/fcitx5-chinese-addons/spec
@@ -1,7 +1,6 @@
-VER=5.0.4
+VER=5.0.5
 SRCS="tbl::https://github.com/fcitx/fcitx5-chinese-addons/archive/$VER.tar.gz \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5-chinese-addons/fcitx5-chinese-addons-${VER}_dict.tar.xz"
-CHKSUMS="sha256::9c406bc145d26c06376c6c7f1a0e5483cdb6e366c2a13674cbc551f865c57553 \
-         sha256::3e77872124d5f98c43b20b9118e175fa06b2ac38a7c2a6249bd4f6b6ec6e64c0"
+CHKSUMS="sha256::33df65ece897a8d2960839e7abf5df9fdcbdbc1c54bcaa12b162fb6cd37a4cb1 \
+         sha256::39e6256a13e95bd58fae010358d35bca7535726e4b59015dd587d84a1a39b62c"
 SUBDIR="fcitx5-chinese-addons-$VER"
-REL=1

--- a/extra-i18n/fcitx5-configtool/spec
+++ b/extra-i18n/fcitx5-configtool/spec
@@ -1,3 +1,3 @@
-VER=5.0.3
+VER=5.0.4
 SRCS="tbl::https://github.com/fcitx/fcitx5-configtool/archive/$VER.tar.gz"
-CHKSUMS="sha256::aeac9b4ce4df5b6505cb19ad0711eeffe9dec7d808fc7d53b5dee3d8cd559e5e"
+CHKSUMS="sha256::549c96c44f37775a0b2497aad3abd907812485596813412fedb8132a11fc04d8"

--- a/extra-i18n/fcitx5-gtk/spec
+++ b/extra-i18n/fcitx5-gtk/spec
@@ -1,3 +1,3 @@
-VER=5.0.4
+VER=5.0.6
 SRCS="tbl::https://github.com/fcitx/fcitx5-gtk/archive/$VER.tar.gz"
-CHKSUMS="sha256::e8a58f4a30231b1f0fce9b3d3aa101a9cd685df96b8992b1bcb63b5e46b6591b"
+CHKSUMS="sha256::ad7e8b3c5ffe5de7611cf093c3c6261362074c8764caba5205025a290711cdba"

--- a/extra-i18n/fcitx5-hangul/spec
+++ b/extra-i18n/fcitx5-hangul/spec
@@ -1,3 +1,3 @@
-VER=5.0.2
+VER=5.0.3
 SRCS="tbl::https://github.com/fcitx/fcitx5-hangul/archive/$VER.tar.gz"
-CHKSUMS="sha256::55028fdcd9232330495800f29731dcbbc6baa9e66a429a9b8f9ac444c1f1bc6c"
+CHKSUMS="sha256::8f490bc2c5abed8a50857f19d9190c5798cf2ed14cf140dd705510fbb951be6d"

--- a/extra-i18n/fcitx5-kkc/spec
+++ b/extra-i18n/fcitx5-kkc/spec
@@ -1,3 +1,3 @@
-VER=5.0.3
+VER=5.0.5
 SRCS="tbl::https://github.com/fcitx/fcitx5-kkc/archive/$VER.tar.gz"
-CHKSUMS="sha256::ba4ac6665c4221d115e71b4b2bff69e3b70f8e02d03b342323c02e0946091304"
+CHKSUMS="sha256::5268a5be04c7d4803bf21c4646e22694d1a3c9c3ae2132a7a436a86ba0e1563e"

--- a/extra-i18n/fcitx5-libthai/spec
+++ b/extra-i18n/fcitx5-libthai/spec
@@ -1,3 +1,3 @@
-VER=5.0.2
+VER=5.0.3
 SRCS="tbl::https://github.com/fcitx/fcitx5-libthai/archive/$VER.tar.gz"
-CHKSUMS="sha256::6a4d9669a5737bd30a7a27dc33660f919d240b88d2e8b366424307cd867945fb"
+CHKSUMS="sha256::0be38c523c613dd66c3795b12235bba9ee8db863b5f387ca2254d9162d01c35c"

--- a/extra-i18n/fcitx5-lua/spec
+++ b/extra-i18n/fcitx5-lua/spec
@@ -1,3 +1,3 @@
-VER=5.0.3
+VER=5.0.4
 SRCS="tbl::https://github.com/fcitx/fcitx5-lua/archive/$VER.tar.gz"
-CHKSUMS="sha256::0967c7b56c4013a51c7d41954031f671e1d75d2031e13c0a6dea9b3a7df5794b"
+CHKSUMS="sha256::47173febde520245fcdeae9a4f9288bd1a15ea7785a8da8f296039937ec52107"

--- a/extra-i18n/fcitx5-m17n/spec
+++ b/extra-i18n/fcitx5-m17n/spec
@@ -1,3 +1,3 @@
-VER=5.0.3
+VER=5.0.4
 SRCS="tbl::https://github.com/fcitx/fcitx5-m17n/archive/$VER.tar.gz"
-CHKSUMS="sha256::6aaa74713df41737fcca49f35db6d23f6c8dd08e63d7502dd7a4e7097b9c579f"
+CHKSUMS="sha256::6cca12c81e86ec74b42c7c09fbfeca2c9c753f0fad1472472d4b7dcec6b9ee9b"

--- a/extra-i18n/fcitx5-qt/spec
+++ b/extra-i18n/fcitx5-qt/spec
@@ -1,3 +1,3 @@
-VER=5.0.3
+VER=5.0.5
 SRCS="https://github.com/fcitx/fcitx5-qt/archive/$VER.tar.gz"
-CHKSUMS="sha256::e847b0885f5a1ae6c686cad0a6c8a0269d4c41b840dcfe75985fcf2911805082"
+CHKSUMS="sha256::d53029cbbe70672738de29e6ad58c5efd46e87e5aa9e491cb0324bf7d188def0"

--- a/extra-i18n/fcitx5-rime/spec
+++ b/extra-i18n/fcitx5-rime/spec
@@ -1,4 +1,3 @@
-VER=5.0.4
-REL=1
+VER=5.0.5
 SRCS="tbl::https://github.com/fcitx/fcitx5-rime/archive/$VER.tar.gz"
-CHKSUMS="sha256::2a429b25b180b27de589be30cf14c7c986daf6823efa93f88b124fa331df6020"
+CHKSUMS="sha256::7ead95dddbec13b4bebb256fc2b3e44a02364354d631a1d52166f60e3e847d3d"

--- a/extra-i18n/fcitx5-sayura/spec
+++ b/extra-i18n/fcitx5-sayura/spec
@@ -1,3 +1,3 @@
-VER=5.0.2
+VER=5.0.3
 SRCS="tbl::https://github.com/fcitx/fcitx5-sayura/archive/$VER.tar.gz"
-CHKSUMS="sha256::4705e1b7e6ed56608358b4d939705555570e18dee3d31e2c05498c21c99449ee"
+CHKSUMS="sha256::ebbf1658e2d3611944c013c90dba5123a0e8f33a6ac3cb7de2115005630afd5c"

--- a/extra-i18n/fcitx5-skk/spec
+++ b/extra-i18n/fcitx5-skk/spec
@@ -1,3 +1,3 @@
-VER=5.0.4
+VER=5.0.5
 SRCS="tbl::https://github.com/fcitx/fcitx5-skk/archive/$VER.tar.gz"
-CHKSUMS="sha256::c9d53ca1193cd083f88cd4620174f41370e033a72b8505c050f500e683ba55ee"
+CHKSUMS="sha256::d6038a627eab53aa156ca8e16045d14248df38014b15a65c8d1c292be4479fe7"

--- a/extra-i18n/fcitx5-unikey/spec
+++ b/extra-i18n/fcitx5-unikey/spec
@@ -1,3 +1,3 @@
-VER=5.0.3
+VER=5.0.4
 SRCS="tbl::https://github.com/fcitx/fcitx5-unikey/archive/$VER.tar.gz"
-CHKSUMS="sha256::7967b7b1a6ac2c5f1bc5922f0727499ec674748b935c0d2c48c04a4f51c4bd2f"
+CHKSUMS="sha256::4fba41650bc4a855a6f181369af789ef955ed5b98425a661af8e3c1e28b23292"

--- a/extra-i18n/fcitx5/spec
+++ b/extra-i18n/fcitx5/spec
@@ -1,6 +1,6 @@
-VER=5.0.5
+VER=5.0.7
 SRCS="tbl::https://github.com/fcitx/fcitx5/archive/$VER.tar.gz \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5/fcitx5-${VER}_dict.tar.xz"
-CHKSUMS="sha256::9de956940c224ef0fcf1cd0994c0c13ccffa64707566b21710e2fb402521db0f \
-         sha256::56992bcee56b7bb71293336a3fb703f033a282faedfeeec69a5f2faeba09479a"
+CHKSUMS="sha256::aa5ee84c88c5027749d7dc6d37ff868aa7683f8e04d0f6f55a38f36381ef8035 \
+         sha256::57b80b806ed2555cea156cd130f5552efd3fef19cab197ade79e9157b99ebf49"
 SUBDIR="fcitx5-$VER"

--- a/extra-i18n/libime/spec
+++ b/extra-i18n/libime/spec
@@ -1,7 +1,6 @@
-VER=1.0.4
+VER=1.0.5
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/libime/ \
       tbl::https://download.fcitx-im.org/fcitx5/libime/libime-${VER}_dict.tar.xz"
 CHKSUMS="SKIP \
-         sha256::59426b865eca13f301b26cbf47a50eae919d53b23819e3847137b3e39908942f"
+         sha256::18d20cb5ecadb24ee113411622846f662bf71149b8ef68f5f9d5ad19c2ec6cf0"
 SUBDIR="libime-$VER"
-REL=1

--- a/extra-libs/xcb-imdkit/spec
+++ b/extra-libs/xcb-imdkit/spec
@@ -1,3 +1,3 @@
-VER=1.0.2
+VER=1.0.3
 SRCS="tbl::https://github.com/fcitx/xcb-imdkit/archive/$VER.tar.gz"
-CHKSUMS="sha256::a9b1df432202cf5b563324236967d81c9b4a7df1894cef2be9dc969bd60b0e58"
+CHKSUMS="sha256::432452c092951f65fb738f19dfd28874ab971852cccfba0abef972699416a535"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Fcitx5 survey 20210323

Package(s) Affected
-------------------

See `groups/fcitx5`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

See `groups/fcitx5`

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
