### PR TITLE
discord: Update to 0.0.14

### DIFF
--- a/extra-web/discord/spec
+++ b/extra-web/discord/spec
@@ -1,5 +1,4 @@
-VER=0.0.13
+VER=0.0.14
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::feeca83531607eec1a6231ad8eab88bbf1865c39cf5f82b884e3b5241733bf34"
+CHKSUMS="sha256::c2651aef4b2c078a3d0975b82fd391571decaa636e52343bb4f116da1c4804e7"
 SUBDIR=.
-REL=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update Discord(TM) to 0.0.14. Previous versions now refuse to launch.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

discord: Update to 0.0.14

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
<!-- - [ ] AArch64 `arm64` -->
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

<!-- - [ ] Loongson 3 `loongson3` -->
<!-- - [ ] PowerPC 64-bit (Little Endian) `ppc64el` -->

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
<!-- - [ ] AArch64 `arm64` -->
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

<!-- - [ ] Loongson 3 `loongson3` -->
<!-- - [ ] PowerPC 64-bit (Little Endian) `ppc64el` -->

<!-- TODO: CI to auto-fill architectural progress. -->
