### PR TITLE
pyside2: update to 5.15.1

### DIFF
--- a/extra-libs/pyside2/autobuild/defines
+++ b/extra-libs/pyside2/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=pyside2
 PKGSEC=libs
 PKGDES="Python bindings for the Qt 5 cross-platform application and UI framework"
-PKGDEP="qt-5 python-3"
+PKGDEP="qt-5 python-3 llvm"
 PKGPROV="shiboken2"
-BUILDDEP="sphinx cmake libxml2 libxslt llvm"
+BUILDDEP="sphinx cmake libxml2 libxslt"
 
 CMAKE_AFTER="-DUSE_PYTHON_VERSION=3"

--- a/extra-libs/pyside2/spec
+++ b/extra-libs/pyside2/spec
@@ -1,5 +1,4 @@
 # Version needs to be synchonized with qt-5
-VER=5.14.2.3
-REL=3
+VER=5.15.1
 SRCTBL="https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${VER}-src/pyside-setup-opensource-src-${VER}.tar.xz"
-CHKSUM="sha256::032de309505c78ba52c225aaf5fd717b8d87ae863aa7cee8ba58ba6141c59022"
+CHKSUM="sha256::f175c1d8813257904cf0efeb58e44f68d53b9916f73adaf9ce19514c0271c3fa"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update `pyside2` to match `qt-5`'s version (`5.15.1`).
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

pyside2: Update to 5.15.1
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
