### PR TITLE
hotspot: 1.3.0, new

### DIFF
--- a/extra-devel/hotspot/autobuild/beyond
+++ b/extra-devel/hotspot/autobuild/beyond
@@ -1,0 +1,7 @@
+abinfo "Installing desktop icon..."
+desktop-file-install "${SRCDIR}/hotspot.desktop" \
+	--dir="${PKGDIR}/usr/share/applications/"
+
+abinfo "Installing AppStream metadata..."
+install -Dvm644 "${SRCDIR}/com.kdab.Hotspot.appdata.xml" \
+	--target-directory "${PKGDIR}/usr/share/appdata/"

--- a/extra-devel/hotspot/autobuild/defines
+++ b/extra-devel/hotspot/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME=hotspot
 PKGSEC=devel
 PKGDES="Perf GUI for performance analysis"
-PKGDEP="qt-5 elfutils gettext threadweaver ki18n kconfigwidgets kcoreaddons kitemviews kitemmodels kio solid kwindowsystem knotifications kiconthemes kddockwidgets"
+PKGDEP="qt-5 elfutils gettext threadweaver ki18n kconfigwidgets kcoreaddons \
+        kitemviews kitemmodels kio solid kwindowsystem knotifications \
+        kiconthemes kddockwidgets"
 BUILDDEP="cmake ninja extra-cmake-modules"

--- a/extra-devel/hotspot/autobuild/defines
+++ b/extra-devel/hotspot/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=hotspot
+PKGSEC=devel
+PKGDEP="qt-5 elfutils gettext threadweaver ki18n kconfigwidgets kcoreaddons kitemviews kitemmodels kio solid kwindowsystem knotifications kiconthemes"
+BUILDDEP="cmake ninja extra-cmake-modules"

--- a/extra-devel/hotspot/autobuild/defines
+++ b/extra-devel/hotspot/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=hotspot
 PKGSEC=devel
 PKGDES="Perf GUI for performance analysis"
-PKGDEP="qt-5 elfutils gettext threadweaver ki18n kconfigwidgets kcoreaddons kitemviews kitemmodels kio solid kwindowsystem knotifications kiconthemes"
+PKGDEP="qt-5 elfutils gettext threadweaver ki18n kconfigwidgets kcoreaddons kitemviews kitemmodels kio solid kwindowsystem knotifications kiconthemes kddockwidgets"
 BUILDDEP="cmake ninja extra-cmake-modules"

--- a/extra-devel/hotspot/autobuild/defines
+++ b/extra-devel/hotspot/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=hotspot
 PKGSEC=devel
+PKGDES="Perf GUI for performance analysis"
 PKGDEP="qt-5 elfutils gettext threadweaver ki18n kconfigwidgets kcoreaddons kitemviews kitemmodels kio solid kwindowsystem knotifications kiconthemes"
 BUILDDEP="cmake ninja extra-cmake-modules"

--- a/extra-devel/hotspot/autobuild/defines
+++ b/extra-devel/hotspot/autobuild/defines
@@ -3,5 +3,9 @@ PKGSEC=devel
 PKGDES="Perf GUI for performance analysis"
 PKGDEP="qt-5 elfutils gettext threadweaver ki18n kconfigwidgets kcoreaddons \
         kitemviews kitemmodels kio solid kwindowsystem knotifications \
-        kiconthemes kddockwidgets"
+        kiconthemes kddockwidgets zstd binutils rustc-demangle"
 BUILDDEP="cmake ninja extra-cmake-modules"
+
+CMAKE_AFTER="\
+	-DRUSTC_DEMANGLE_INCLUDE_DIR=/usr/include \
+	-DRUSTC_DEMANGLE_LIBRARY=/usr/lib/librustc_demangle.so"

--- a/extra-devel/hotspot/autobuild/patches/0001-Fix-build-on-MIPS.patch
+++ b/extra-devel/hotspot/autobuild/patches/0001-Fix-build-on-MIPS.patch
@@ -1,0 +1,35 @@
+From ea953b501219fcfff945fc36383012f427f5c771 Mon Sep 17 00:00:00 2001
+From: Dmitry Shachnev <mitya57@gmail.com>
+Date: Sat, 27 Jun 2020 17:03:35 +0300
+Subject: [PATCH] Fix build on MIPS
+
+On MIPS systems, "mips" is a built-in compiler macro. Undefine it to fix
+compilation errors:
+
+app/perfregisterinfo.cpp:55:12: error: expected unqualified-id before numeric constant
+   55 | static int mips[] = { 32,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17,
+      |            ^~~~
+
+Change-Id: I80680337a019629e53828d60fc8a233a7cc819d2
+Reviewed-by: Ulf Hermann <ulf.hermann@qt.io>
+---
+ app/perfregisterinfo.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/3rdparty/perfparser/app/perfregisterinfo.cpp b/3rdparty/perfparser/app/perfregisterinfo.cpp
+index 2e69d5e..bc0831d 100644
+--- a/3rdparty/perfparser/app/perfregisterinfo.cpp
++++ b/3rdparty/perfparser/app/perfregisterinfo.cpp
+@@ -52,6 +52,10 @@ static int aarch64[] = { 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
+ static int x86[] = {0, 2, 3, 1, 7, 6, 4, 5, 8};
+ static int x86_64[] = {0, 3, 2, 1, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23, 8};
+ 
++#ifdef mips
++// On MIPS systems, "mips" is a built-in compiler macro.
++#undef mips
++#endif
+ static int mips[] = { 32,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17,
+                         18, 19, 20, 21, 22, 23, 24, 25, 28, 29, 30, 31};
+ 
+-- 
+2.30.2

--- a/extra-devel/hotspot/spec
+++ b/extra-devel/hotspot/spec
@@ -1,0 +1,3 @@
+VER="1.3.0"
+SRCS="https://github.com/KDAB/hotspot/releases/download/v${VER}/hotspot-v${VER}.tar.gz"
+CHKSUMS="sha256::7651c5f504138f6438d0cacaea041550bddb30a4ab2128abe3111fc827af4fc8"

--- a/extra-libs/kddockwidgets/autobuild/defines
+++ b/extra-libs/kddockwidgets/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=kddockwidgets
+PKGSEC=libs
+PKGDEP="qt-5"
+BUILDDEP="cmake ninja extra-cmake-modules doxygen"
+PKGDES="A Qt dock widget library suitable for replacing QDockWidget"
+
+CMAKE_AFTER="-DKDDockWidgets_DOCS=true"

--- a/extra-libs/kddockwidgets/spec
+++ b/extra-libs/kddockwidgets/spec
@@ -1,0 +1,3 @@
+VER="1.3.0"
+SRCS="https://github.com/KDAB/KDDockWidgets/releases/download/v${VER}/kddockwidgets-${VER}.tar.gz"
+CHKSUMS="sha256::09149e5065dc07a528e468cecf2d7da766476b7cadd820afaad46a3161f2e934"

--- a/extra-libs/kddockwidgets/spec
+++ b/extra-libs/kddockwidgets/spec
@@ -1,3 +1,3 @@
-VER="1.3.0"
+VER="1.3.1"
 SRCS="https://github.com/KDAB/KDDockWidgets/releases/download/v${VER}/kddockwidgets-${VER}.tar.gz"
-CHKSUMS="sha256::09149e5065dc07a528e468cecf2d7da766476b7cadd820afaad46a3161f2e934"
+CHKSUMS="sha256::5b1a532590ce4bf01147450f946d7460754d0424487ce4eb4f563d1b8e8c4449"

--- a/extra-libs/rustc-demangle/autobuild/beyond
+++ b/extra-libs/rustc-demangle/autobuild/beyond
@@ -1,0 +1,15 @@
+abinfo "Installing static library..."
+install -Dvm644 "${SRCDIR}/target/release/librustc_demangle.a" \
+	--target-directory "${PKGDIR}/usr/lib/"
+
+abinfo "Installing shared library..."
+install -Dvm644 "${SRCDIR}/target/release/librustc_demangle.so" \
+	--target-directory "${PKGDIR}/usr/lib/"
+
+abinfo "Installing header file..."
+install -Dvm644 "${SRCDIR}/crates/capi/include/rustc_demangle.h" \
+	--target-directory "${PKGDIR}/usr/include/"
+
+abinfo "Installing license files..."
+install -Dvm644 "${SRCDIR}/LICENSE-APACHE" "${SRCDIR}/LICENSE-MIT" \
+	--target-directory "${PKGDIR}/usr/share/licenses/rustc-demangle/"

--- a/extra-libs/rustc-demangle/autobuild/defines
+++ b/extra-libs/rustc-demangle/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=rustc-demangle
+PKGSEC=libs
+PKGDES="Library for Rust symbol demangling"
+PKGDEP="glibc gcc-runtime llvm"
+BUILDDEP="rustc"
+
+USECLANG=1
+CARGO_AFTER="--package rustc-demangle-capi"

--- a/extra-libs/rustc-demangle/autobuild/prepare
+++ b/extra-libs/rustc-demangle/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Generating Cargo.lock..."
+cargo update

--- a/extra-libs/rustc-demangle/spec
+++ b/extra-libs/rustc-demangle/spec
@@ -1,0 +1,3 @@
+VER=0.1.18
+SRCS="https://github.com/alexcrichton/rustc-demangle/archive/refs/tags/${VER}.tar.gz"
+CHKSUMS="sha256::97499012093f2f271be582dec17320b137efc8c6ed5e7a920e73ee99a5388452"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Introduce hotspot, a GUI tool for performance analysis.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

kddockwidgets: 1.3.1, new

hotspot: 1.3.0, new (WIP, [file selection dialog cannot filter executables correctly with GTK](https://github.com/KDAB/hotspot/issues/286))

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

Build Order
-----------

Please describe in what order this pull request should be built.

1. kddockwidgets
2. hotspot

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
Signed-off-by: Kay Lin <i@v2bv.net>