### PR TITLE
foliate: update to 2.6.1

### DIFF
--- a/extra-doc/foliate/autobuild/defines
+++ b/extra-doc/foliate/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=foliate
 PKGDES="A simple and modern GTK eBook reader"
-PKGDEP="gjs webkit2gtk"
+PKGDEP="gjs webkit2gtk iso-codes"
 BUILDDEP="meson ninja gettext"
 PKGSEC=doc

--- a/extra-doc/foliate/autobuild/defines
+++ b/extra-doc/foliate/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=foliate
 PKGDES="A simple and modern GTK eBook reader"
-PKGDEP="gjs webkit2gtk iso-codes"
+PKGDEP="gjs webkit2gtk iso-codes appstream-glib"
 BUILDDEP="meson ninja gettext"
 PKGSEC=doc

--- a/extra-doc/foliate/spec
+++ b/extra-doc/foliate/spec
@@ -1,3 +1,3 @@
-VER=2.5.0
+VER=2.6.1
 SRCS="tbl::https://github.com/johnfactotum/foliate/archive/$VER.tar.gz"
-CHKSUMS="sha256::3b5317b96ccb19aaa79a1ff0a751a7cc5f8607649681c42900daf0f02a4da672"
+CHKSUMS="sha256::2fc2257401691cc5adb93ce6014cdf2d148a8837e5ee5ad40e5e2f6eb371fd77"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

foliate: update to 2.6.1

Package(s) Affected
-------------------

foliate: 2.6.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
