### PR TITLE
Dependencies for libinput

### DIFF
--- a/extra-libs/libevdev/autobuild/defines
+++ b/extra-libs/libevdev/autobuild/defines
@@ -10,3 +10,6 @@ BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="Wrapper library for event devices"
+
+ABTYPE=meson
+MESON_AFTER="-Dtests=disabled"

--- a/extra-libs/libevdev/spec
+++ b/extra-libs/libevdev/spec
@@ -1,3 +1,3 @@
-VER=1.8.0
+VER=1.11.0
 SRCTBL="https://www.freedesktop.org/software/libevdev/libevdev-$VER.tar.xz"
-CHKSUM="sha256::20d3cae4efd277f485abdf8f2a7c46588e539998b5a08c2c4d368218379d4211"
+CHKSUM="sha256::63f4ea1489858a109080e0b40bd43e4e0903a1e12ea888d581db8c495747c2d0"

--- a/extra-libs/libwacom/autobuild/defines
+++ b/extra-libs/libwacom/autobuild/defines
@@ -4,4 +4,5 @@ PKGDEP="glib systemd"
 BUILDDEP="doxygen"
 PKGDES="Library to identify Wacom tablets and their features"
 
-ABSHADOW=no
+ABTYPE=meson
+MESON_AFTER="-Dtests=disabled"

--- a/extra-libs/libwacom/autobuild/prepare
+++ b/extra-libs/libwacom/autobuild/prepare
@@ -1,1 +1,1 @@
-chmod a-s "$SRCDIR"
+export PYTHON=/usr/bin/python3

--- a/extra-libs/libwacom/spec
+++ b/extra-libs/libwacom/spec
@@ -1,3 +1,3 @@
-VER=0.29
-SRCTBL="https://downloads.sourceforge.net/linuxwacom/libwacom-$VER.tar.bz2"
-CHKSUM="sha256::9cea00e68ddf342c3f749f6628d33fd3646f1937d7c57053ec6c5728d9a333b6"
+VER=1.9
+SRCTBL="https://github.com/linuxwacom/libwacom/releases/download/libwacom-${VER}/libwacom-${VER}.tar.bz2"
+CHKSUM="sha256::68b14d4e3b75fed9f590bf6eaea361a72dc23e933b7725094c779477acf665c7"

--- a/extra-python/python-evdev/spec
+++ b/extra-python/python-evdev/spec
@@ -1,4 +1,3 @@
-VER=1.1.2
-REL=4
+VER=1.4.0
 SRCTBL="https://pypi.io/packages/source/e/evdev/evdev-$VER.tar.gz"
-CHKSUM="sha256::2dd67291be20e70643e8ef6f2381efc10e0c6e44a32abb3c1db74996ea3b0351"
+CHKSUM="sha256::8782740eb1a86b187334c07feb5127d3faa0b236e113206dfe3ae8f77fb1aaf1"

--- a/extra-x11/xf86-input-wacom/autobuild/defines
+++ b/extra-x11/xf86-input-wacom/autobuild/defines
@@ -5,3 +5,4 @@ PKGDEP="xorg-server systemd"
 
 AB_FLAGS_RRO=0
 AB_FLAGS_NOW=0
+RECONF=0

--- a/extra-x11/xf86-input-wacom/autobuild/prepare
+++ b/extra-x11/xf86-input-wacom/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Working around bad autogen.sh"
+(cd "$SRCDIR"; autoreconf -fvi)

--- a/extra-x11/xf86-input-wacom/spec
+++ b/extra-x11/xf86-input-wacom/spec
@@ -1,3 +1,3 @@
-VER=0.37.0
-SRCTBL="https://github.com/linuxwacom/xf86-input-wacom/releases/download/xf86-input-wacom-$VER/xf86-input-wacom-$VER.tar.bz2"
-CHKSUM="sha256::9311cd1ff2a284a429a04c3c5d03ccbad83e76a58770668ac0f2d22740e05881"
+VER=0.40.0
+SRCTBL="https://github.com/linuxwacom/xf86-input-wacom/archive/xf86-input-wacom-${VER}.tar.gz"
+CHKSUM="sha256::5b0befd0e1270942026813c303ec26fd7ca8955eeb75e2055b37deac92b7c142"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates userspace input drivers used by libinput to their latest versions.

Package(s) Affected
-------------------

* libwacom: 1.9
* xf86-input-wacom: 0.40.0
* libevdev: 1.11.0
* python-evdev: 1.4.0

Build Order
-----------

Build in the order of commits

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
