### PR TITLE
opencc: update to 1.1.2

### DIFF
--- a/extra-i18n/opencc/autobuild/beyond
+++ b/extra-i18n/opencc/autobuild/beyond
@@ -1,8 +1,13 @@
-abinfo "Building opencc python modules..."
-cd $SRCDIR/python
-python3 setup.py build
+abinfo "Building and installing opencc python modules..."
+mkdir -pv "$SRCDIR"/python/opencc/clib
+cp -v "$SRCDIR"/build/opencc_clib.so "$SRCDIR"/python/opencc/clib/
+touch "$SRCDIR"/python/opencc/clib/__init__.py
+python setup.py build
+python setup.py install --root="$PKGDIR" --optimize=1
 
-abinfo "Installing opencc python modules..."
-python3 setup.py install --root="$PKGDIR" --optimize=1
+abinfo "Arch Linux: Hack to make opencc’s python binding to use system opencc’s configs"
+mkdir -pv "$PKGDIR"/usr/lib/python"$ABPY3VER"/site-packages/opencc/clib/share
+ln -sv ../../../../../../share/opencc "$PKGDIR"/usr/lib/python"$ABPY3VER"/site-packages/opencc/clib/share/
 
-cd $SRCDIR
+abinfo "Arch Linux: Remove insecure RPath"
+chrpath --delete "$PKGDIR"/usr/lib/python"$ABPY3VER"/site-packages/opencc/clib/*.so

--- a/extra-i18n/opencc/autobuild/defines
+++ b/extra-i18n/opencc/autobuild/defines
@@ -2,9 +2,16 @@ PKGNAME=opencc
 PKGEPOCH=1
 PKGSEC=localization
 PKGDEP="gcc-runtime"
-BUILDDEP="cmake doxygen wheel"
+BUILDDEP="cmake doxygen wheel rapidjson tclap marisa pybind11 chrpath"
 PKGDES="Open source Chinese conversion library and utilities"
 
-CMAKE_AFTER="-DBUILD_DOCUMENTATION:BOOL=ON \
+
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr \
+             -DBUILD_DOCUMENTATION:BOOL=ON \
+             -DBUILD_PYTHON:BOOL=ON \
+             -DUSE_SYSTEM_MARISA:BOOL=ON \
+             -DUSE_SYSTEM_PYBIND11:BOOL=ON \
+             -DUSE_SYSTEM_RAPIDJSON:BOOL=ON \
+             -DUSE_SYSTEM_TCLAP:BOOL=ON \
              -DCMAKE_SKIP_RPATH=OFF"
 AB_FLAGS_O3=1

--- a/extra-i18n/opencc/autobuild/patches/0001-Follow-upstream-instructions-to-include-system-pybin.patch
+++ b/extra-i18n/opencc/autobuild/patches/0001-Follow-upstream-instructions-to-include-system-pybin.patch
@@ -1,0 +1,31 @@
+From b0ea9eff08065611915b1c14a044281309cb19c3 Mon Sep 17 00:00:00 2001
+From: Felix Yan <felixonmars@archlinux.org>
+Date: Fri, 5 Mar 2021 16:55:18 +0800
+Subject: [PATCH] Follow upstream instructions to include system pybind11
+ (#566)
+
+The previous way doesn't work with Arch Linux's pybind11, but the official recommended way does.
+
+Ref: https://pybind11.readthedocs.io/en/latest/cmake/index.html
+---
+ CMakeLists.txt | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d4b6530..cfc02c7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -219,9 +219,7 @@ endif()
+ 
+ if (BUILD_PYTHON)
+   if(USE_SYSTEM_PYBIND11)
+-    include(pybind11Config)
+-    include(pybind11Common)
+-    include(pybind11Tools)
++    find_package(pybind11 CONFIG)
+   else()
+     add_subdirectory(deps/pybind11-2.5.0)
+   endif()
+-- 
+2.30.2
+

--- a/extra-i18n/opencc/autobuild/prepare
+++ b/extra-i18n/opencc/autobuild/prepare
@@ -1,5 +1,0 @@
-abinfo "Modify python opencc module to using system opencc..."
-sed -i '/BuildPyCommand,/d' python/setup.py
-sed -e "s|os.path.join(_thisdir, 'clib', 'lib', _libopenccfilename)|os.path.join('/usr/lib', _libopenccfilename)|" \
-      -e "s|os.path.join(_thisdir, 'clib', 'share', 'opencc')|'/usr/share/opencc'|" \
-      -i python/opencc/__init__.py

--- a/extra-i18n/opencc/spec
+++ b/extra-i18n/opencc/spec
@@ -1,5 +1,4 @@
-VER=1.1.1
-REL=2
-SRCTBL="https://github.com/BYVoid/OpenCC/archive/ver.$VER.tar.gz"
-CHKSUM="sha256::2d4987dc84275f252d47bc6d8c81b452f6a6e82caa26f284c854a8153ccf5933"
+VER=1.1.2
+SRCS="tbl::https://github.com/BYVoid/OpenCC/archive/ver.$VER.tar.gz"
+CHKSUMS="sha256::8c0f44a210c4ee0cc79972d47829b2f3e1e90a26c4db0949da3ad99a8d1fe375"
 SUBDIR="OpenCC-ver.$VER"

--- a/extra-i18n/rime-emoji/autobuild/defines
+++ b/extra-i18n/rime-emoji/autobuild/defines
@@ -4,5 +4,6 @@ PKGSEC=localization
 PKGRECOM="librime"
 PKGREP="rime-data<=20200814"
 PKGBREAK="rime-data<=20200814"
+PKGEPOCH=1
 
 ABHOST="noarch"

--- a/extra-i18n/rime-emoji/spec
+++ b/extra-i18n/rime-emoji/spec
@@ -1,3 +1,3 @@
-VER=20201113
-SRCS="git::commit=35c9632c34ea29e6d9ed80ff350c05f3d706fdc6::https://github.com/rime/rime-emoji"
+VER=0+git20210329
+SRCS="git::commit=b0becbd90230bb20eb270530079b963df6331fe4::https://github.com/rime/rime-emoji"
 CHKSUMS="SKIP"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

opencc: update to 1.1.2

- Fix python module install (from archlinux)
- Adjust cmake option (from archlinux)
- Add 0001-Follow-upstream-instructions-to-include-system-pybin.patch to fix find pybind11 (from upstream)

Package(s) Affected
-------------------

opencc: 1.1.2
rime-emoji: 0+git20210329

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
