### PR TITLE
firewalld: fix usability + nftables + dependencies

### DIFF
--- a/extra-network/firewalld/autobuild/beyond
+++ b/extra-network/firewalld/autobuild/beyond
@@ -1,0 +1,5 @@
+abinfo "Byte compiling firewalld python modules"
+python3 -m compileall -j 0 "${PKGDIR}/usr/lib/python3.8/site-packages"
+
+abinfo "Disable firewall applet autostart"
+rm -v "${PKGDIR}/etc/xdg/autostart/firewall-applet.desktop"

--- a/extra-network/firewalld/autobuild/conffiles
+++ b/extra-network/firewalld/autobuild/conffiles
@@ -1,3 +1,6 @@
-/etc/sysconfig/firewalld
-/etc/firewalld/firewalld.conf
 /etc/firewall/applet.conf
+/etc/firewalld/firewalld.conf
+/etc/firewalld/lockdown-whitelist.xml
+/etc/logrotate.d/firewalld
+/etc/modprobe.d/firewalld-sysctls.conf
+/etc/sysconfig/firewalld

--- a/extra-network/firewalld/autobuild/defines
+++ b/extra-network/firewalld/autobuild/defines
@@ -1,9 +1,10 @@
 PKGNAME=firewalld
 PKGDES="Firewall daemon with D-Bus interface"
 PKGSEC=net
-PKGDEP="dbus-glib dconf ebtables hicolor-icon-theme ipset iptables slip"
-PKGSUG="bash-completion gtk-3 libnotify pyqt5"
+PKGDEP="dbus-glib dconf ebtables ipset nftables iptables slip python-3 dbus-python"
+PKGSUG="bash-completion gtk-3 libnotify pyqt5 hicolor-icon-theme"
 BUILDDEP="docbook-xsl intltool"
 ABTYPE=autotools
 AUTOTOOLS_AFTER="--disable-schemas-compile"
-ABSHADOW=no
+
+ABHOST=noarch

--- a/extra-network/firewalld/autobuild/overrides/usr/lib/systemd/system-preset/40-firewalld.preset
+++ b/extra-network/firewalld/autobuild/overrides/usr/lib/systemd/system-preset/40-firewalld.preset
@@ -1,0 +1,2 @@
+disable nftables.service
+enable firewalld.service

--- a/extra-network/firewalld/autobuild/postinst
+++ b/extra-network/firewalld/autobuild/postinst
@@ -1,0 +1,3 @@
+systemctl daemon-reload
+systemctl preset nftables.service
+systemctl preset firewalld.service

--- a/extra-network/firewalld/autobuild/prepare
+++ b/extra-network/firewalld/autobuild/prepare
@@ -1,0 +1,1 @@
+export PYTHON=/usr/bin/python3

--- a/extra-network/firewalld/spec
+++ b/extra-network/firewalld/spec
@@ -1,4 +1,3 @@
-VER=0.5.1
-SRCTBL="https://github.com/t-woerner/firewalld/archive/v$VER.tar.gz"
-CHKSUM="sha256::57d0639bed3a845899ea16f52fbd68b2e62fdca75cea50be60d651e4255be00e"
-REL=1
+VER=0.9.3
+SRCTBL="https://github.com/firewalld/firewalld/archive/v$VER.tar.gz"
+CHKSUM="sha256::2c88ce019f2d1215410501a4dd883bd9b5f86e16d68f8882b025ab2c3e320e0b"

--- a/extra-network/nftables/autobuild/defines
+++ b/extra-network/nftables/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=nftables
 PKGSEC=net
-PKGDEP="gmp libnftnl ncurses readline"
+PKGDEP="gmp libnftnl ncurses readline python-3 jsonschema jansson"
 PKGDES="Netfilter tables userspace tools"
 
-AUTOTOOLS_AFTER="--sysconfdir=/usr/share \
-                 --disable-man-doc"
+AUTOTOOLS_AFTER="
+                 PYTHON_BIN=/usr/bin/python3
+                 --sysconfdir=/usr/share
+                 --with-json
+"

--- a/extra-network/nftables/autobuild/postinst
+++ b/extra-network/nftables/autobuild/postinst
@@ -1,1 +1,0 @@
-[ -x /usr/bin/systemctl ] && systemctl enable nftables || true

--- a/extra-network/nftables/spec
+++ b/extra-network/nftables/spec
@@ -1,3 +1,3 @@
-VER=0.9.6
+VER=0.9.7
 SRCTBL="https://netfilter.org/projects/nftables/files/nftables-$VER.tar.bz2"
-CHKSUM="sha256::68d6fdfe8ab02303e6b1f13968a4022da5b0120110eaee3233d806857937b66e"
+CHKSUM="sha256::fe6b8a8c326a2c09c02ca162b840d7d4aadb043ce7a367c166d6455b0e112cb0"

--- a/extra-python/slip/autobuild/build
+++ b/extra-python/slip/autobuild/build
@@ -1,2 +1,0 @@
-make
-python setup.py install --root="${PKGDIR}" --optimize='1'

--- a/extra-python/slip/autobuild/defines
+++ b/extra-python/slip/autobuild/defines
@@ -4,4 +4,4 @@ PKGSEC=python
 PKGDEP="dbus-python decorator polkit pygobject-3 six"
 BUILDDEP="setuptools"
 ABHOST=noarch
-ABTYPE=self
+ABTYPE=python

--- a/extra-python/slip/autobuild/prepare
+++ b/extra-python/slip/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Generating setup.py"
+make

--- a/extra-python/slip/spec
+++ b/extra-python/slip/spec
@@ -1,3 +1,4 @@
 VER=0.6.5
+REL=1
 SRCTBL="https://github.com/nphilipp/python-slip/releases/download/python-slip-${VER}/python-slip-${VER}.tar.bz2"
 CHKSUM="sha256::c726c086f0dd93a0ac7a0176f383a12af91b6657b78a301e3f5b25d9f8d4d10b"


### PR DESCRIPTION
Topic Description
-----------------
This PR updates dependencies `slip` and `nftables` used by `firewalld`. `firewalld` itself is updated to 0.9.3 and is now configured to use python 3.8.

`nftables` were previously missing dependency `jansson`. This effectively crippled management command encapsulated in JSON objects and broke interoperability with `firewalld`. 

`firewalld` does not actually contain architecture specific binaries, thus marked `noarch` in this version. The firewall service will now autostart by default after installation. `nftables.service` will attempt to restore nft state on its own, potentially overwriting existing state provided by `firewalld`, and must be disabled if `firewalld` is enabled.

Package(s) Affected
-------------------

* `nftables` - architecture specific
* `slip` - noarch
* `firewalld` - noarch

Build Order
-----------

`nftables` -> `slip` -> `firewalld`

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
