### PR TITLE
dracut: update to 053

### DIFF
--- a/extra-kernel/dracut/autobuild/overrides/usr/bin/update-initramfs
+++ b/extra-kernel/dracut/autobuild/overrides/usr/bin/update-initramfs
@@ -8,9 +8,9 @@ fi
 # Generate initrd using Dracut.
 if [ -x /usr/bin/dracut ]; then
     for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
-	if [ -f "/usr/lib/modules/${i}/modules.dep" -a -f "/usr/lib/modules/${i}/modules.order" -a -f "/usr/lib/modules/${i}/modules.builtin" ]; then
+	if [ -f "/usr/lib/modules/${i}/modules.dep" ] && [ -f "/usr/lib/modules/${i}/modules.order" ] && [ -f "/usr/lib/modules/${i}/modules.builtin" ]; then
 	        echo -e "\033[36m**\033[0m\tGenerating initrd (Initialization RAM Disk) for kernel version $i ..."
-		dracut -q --force /boot/initramfs-$i.img $i
+		dracut -q --force "/boot/initramfs-$i.img" "$i"
 	else
 		echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $i ..."
 	fi
@@ -20,7 +20,7 @@ else
 fi
 
 # Notify bootloader
-if [[ ! $(grep 'machine' /proc/1/cgroup) && ! $(grep 'docker' /proc/1/cgroup) ]]; then
+if ! systemd-detect-virt -cq; then
     if [[ -x /usr/bin/grub-mkconfig ]]; then
 	    echo -e "\033[36m**\033[0m\tUpdating GRUB for the new kernel..."
         grub-mkconfig -o /boot/grub/grub.cfg

--- a/extra-kernel/dracut/spec
+++ b/extra-kernel/dracut/spec
@@ -1,4 +1,3 @@
-VER=052
-SRCTBL="https://www.kernel.org/pub/linux/utils/boot/dracut/dracut-$VER.tar.gz"
-CHKSUM="sha256::e1baf2af10aeff1130bc241b9cfb5114341e8da3934ac217668ffe80f5af95f7"
-REL=1
+VER=053
+SRCS="tbl::https://www.kernel.org/pub/linux/utils/boot/dracut/dracut-$VER.tar.xz"
+CHKSUMS="sha256::d5a1b47cdb07919d8225d5b5f538e6ae604988f3df0afbde99a8dc775277b726"


### PR DESCRIPTION
Topic Description
-----------------

Update `dracut` to 053.

Package(s) Affected
-------------------

```
dracut
```

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2942)
<!-- Reviewable:end -->
