### PR TITLE
aoscbootstrap: new, 0.1.0

### DIFF
--- a/extra-utils/aoscbootstrap/autobuild/beyond
+++ b/extra-utils/aoscbootstrap/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo 'Installing assets ...'
+
+install -d "$PKGDIR/usr/share/aoscbootstrap"
+cp -rv "$SRCDIR/"{scripts,config,recipes} "$PKGDIR/usr/share/aoscbootstrap/"

--- a/extra-utils/aoscbootstrap/autobuild/beyond
+++ b/extra-utils/aoscbootstrap/autobuild/beyond
@@ -1,4 +1,4 @@
 abinfo 'Installing assets ...'
 
-install -d "$PKGDIR/usr/share/aoscbootstrap"
+install -dv "$PKGDIR/usr/share/aoscbootstrap"
 cp -rv "$SRCDIR/"{scripts,config,recipes} "$PKGDIR/usr/share/aoscbootstrap/"

--- a/extra-utils/aoscbootstrap/autobuild/defines
+++ b/extra-utils/aoscbootstrap/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=aoscbootstrap
+PKGSEC=utils
+PKGDES="An utility to bootstrap an AOSC OS rootfs"
+PKGDEP="xz openssl"
+BUILDDEP="cmake cargo llvm"
+
+USECLANG=1

--- a/extra-utils/aoscbootstrap/autobuild/defines
+++ b/extra-utils/aoscbootstrap/autobuild/defines
@@ -4,4 +4,4 @@ PKGDES="An utility to bootstrap an AOSC OS rootfs"
 PKGDEP="xz openssl"
 BUILDDEP="cmake cargo llvm"
 
-USECLANG=1
+NOLTO=1

--- a/extra-utils/aoscbootstrap/spec
+++ b/extra-utils/aoscbootstrap/spec
@@ -1,0 +1,3 @@
+VER=0.1.0
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscbootstrap"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

New package: `aoscbootstrap`

Package(s) Affected
-------------------

```
aoscbootstrap
```

Security Update?
----------------

No

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [X] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [X] Loongson 3 `loongson3`
- [X] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Post-Merge Secondary Architectural Progress
-------------------------------------------


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2943)
<!-- Reviewable:end -->
