### PR TITLE
vice: update to 3.5

### DIFF
--- a/extra-emulation/vice/autobuild/defines
+++ b/extra-emulation/vice/autobuild/defines
@@ -5,7 +5,8 @@ BUILDDEP="texlive x11-font xa"
 PKGDES="The Versatile Commodore 8-bit Emulator"
 
 AUTOTOOLS_STRICT=0
-AUTOTOOLS_AFTER="--enable-external-ffmpeg"
+AUTOTOOLS_AFTER="--enable-external-ffmpeg \
+                 --enable-x64"
 ABSHADOW=0
 
 NOLTO=1

--- a/extra-emulation/vice/autobuild/defines
+++ b/extra-emulation/vice/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=vice
 PKGSEC=emulation
-PKGDEP="ffmpeg giflib libjpeg-turbo libpcap libpng pulseaudio sdl2"
+PKGDEP="atk ffmpeg flac gdk-pixbuf giflib glew gtk-3 libjpeg-turbo libpcap libpng pulseaudio"
 BUILDDEP="texlive x11-font xa"
 PKGDES="The Versatile Commodore 8-bit Emulator"
 

--- a/extra-emulation/vice/autobuild/defines
+++ b/extra-emulation/vice/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=vice
 PKGSEC=emulation
 PKGDEP="ffmpeg giflib libjpeg-turbo libpcap libpng pulseaudio sdl2"
-BUILDDEP="x11-font xa"
+BUILDDEP="texlive x11-font xa"
 PKGDES="The Versatile Commodore 8-bit Emulator"
 
 AUTOTOOLS_STRICT=0

--- a/extra-emulation/vice/spec
+++ b/extra-emulation/vice/spec
@@ -1,4 +1,3 @@
-VER=3.3
-SRCTBL="https://downloads.sourceforge.net/project/vice-emu/releases/vice-3.3.tar.gz"
-CHKSUM="sha256::1a55b38cc988165b077808c07c52a779d181270b28c14b5c9abf4e569137431d"
-REL=2
+VER=3.5
+SRCTBL="https://downloads.sourceforge.net/project/vice-emu/releases/vice-$VER.tar.gz"
+CHKSUM="sha256::56b978faaeb8b2896032bd604d03c3501002187eef1ca58ceced40f11a65dc0e"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

update vice to v3.5

Package(s) Affected
-------------------

`vice` v3.5

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
