### PR TITLE
xray: new, 1.4.2

### DIFF
--- a/extra-network/xray/autobuild/build
+++ b/extra-network/xray/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building xray ..."
+go build -o xray -trimpath -ldflags "-s -w -buildid=" "$SRCDIR"/main
+
+abinfo "Installing xray ..."
+install -Dvm755 "$SRCDIR"/xray -t "$PKGDIR"/usr/bin/
+install -dv "$PKGDIR"/etc/xray

--- a/extra-network/xray/autobuild/defines
+++ b/extra-network/xray/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="xray"
+PKGDES="V2Ray with XTLS support"
+PKGDEP="gcc-runtime"
+BUILDDEP="go"
+
+ABSPLITDBG=0

--- a/extra-network/xray/autobuild/overrides/usr/lib/systemd/system/xray.service
+++ b/extra-network/xray/autobuild/overrides/usr/lib/systemd/system/xray.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Xray Service
+After=network.target nss-lookup.target
+
+[Service]
+User=nobody
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+ExecStart=/usr/bin/xray run -confdir /etc/xray/
+Restart=on-failure
+RestartPreventExitStatus=23
+
+[Install]
+WantedBy=multi-user.target

--- a/extra-network/xray/autobuild/overrides/usr/lib/systemd/system/xray@.service
+++ b/extra-network/xray/autobuild/overrides/usr/lib/systemd/system/xray@.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Xray Service
+After=network.target nss-lookup.target
+
+[Service]
+User=nobody
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+ExecStart=/usr/bin/xray run -config /etc/xray/%i.json
+Restart=on-failure
+RestartPreventExitStatus=23
+
+[Install]
+WantedBy=multi-user.target

--- a/extra-network/xray/spec
+++ b/extra-network/xray/spec
@@ -1,0 +1,3 @@
+VER=1.4.2
+SRCS="tbl::https://github.com/XTLS/Xray-core/archive/v$VER.tar.gz"
+CHKSUMS="sha256::565255d8c67b254f403d498b9152fa7bc097d649c50cb318d278c2be644e92cc"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

xray: new, 1.4.2

Package(s) Affected
-------------------

xray: 1.4.2

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
