### PR TITLE
fcitx5-pinyin-zhwiki update to 0.2.2+20210401

### DIFF
--- a/extra-i18n/fcitx5-pinyin-zhwiki/01-fcitx5-pinyin-zhwiki/build
+++ b/extra-i18n/fcitx5-pinyin-zhwiki/01-fcitx5-pinyin-zhwiki/build
@@ -1,4 +1,5 @@
 dict_ver=$(echo "${PKGVER}" | cut -d '+' -f2)
+dict_ver=${dict_ver/dict/}
 
 abinfo "Conventing dict..."
 make VERSION=${dict_ver}

--- a/extra-i18n/fcitx5-pinyin-zhwiki/01-fcitx5-pinyin-zhwiki/prepare
+++ b/extra-i18n/fcitx5-pinyin-zhwiki/01-fcitx5-pinyin-zhwiki/prepare
@@ -1,2 +1,3 @@
 abinfo "Copy dict file to fcitx5-pinyin-zhwiki directory..."
 cp "$SRCDIR"/../zhwiki-*-all-titles-in-ns0.gz "$SRCDIR"
+

--- a/extra-i18n/fcitx5-pinyin-zhwiki/02-rime-pinyin-zhwiki/build
+++ b/extra-i18n/fcitx5-pinyin-zhwiki/02-rime-pinyin-zhwiki/build
@@ -1,4 +1,5 @@
 dict_ver=$(echo "${PKGVER}" | cut -d '+' -f2)
+dict_ver=${dict_ver/dict/}
 
 abinfo "Installing rime dict to $PKGDIR..."
 make DESTDIR="$PKGDIR" VERSION=${dict_ver} install_rime_dict

--- a/extra-i18n/fcitx5-pinyin-zhwiki/spec
+++ b/extra-i18n/fcitx5-pinyin-zhwiki/spec
@@ -1,8 +1,8 @@
-dict_ver=20210301
+dict_ver=20210401
 package_ver=0.2.2
 VER="${package_ver}"+"${dict_ver}"
 SRCS="tbl::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/archive/${package_ver}.tar.gz \
       file::rename=zhwiki-${dict_ver}-all-titles-in-ns0.gz::https://dumps.wikimedia.org/zhwiki/${dict_ver}/zhwiki-${dict_ver}-all-titles-in-ns0.gz"
 CHKSUMS="sha256::a06cc5e6a3630de229cbe0d7093caa2142d740daca681ee7c6aefe541d4a6e86 \
-         sha256::f35f3211a058b203774f7f145ff00bfbb53d16227fa6648836a9d69f293556d8"
+         sha256::6e08a8bbeb76e75fd8aa5c65379d840cf9ce4caa51d06086e471b9130d911025"
 SUBDIR="fcitx5-pinyin-zhwiki-$package_ver"

--- a/extra-i18n/fcitx5-pinyin-zhwiki/spec
+++ b/extra-i18n/fcitx5-pinyin-zhwiki/spec
@@ -1,8 +1,8 @@
 dict_ver=20210401
-package_ver=0.2.2
-VER="${package_ver}"+"${dict_ver}"
-SRCS="tbl::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/archive/${package_ver}.tar.gz \
+script_ver=0.2.2
+VER="${script_ver}"+dict"${dict_ver}"
+SRCS="tbl::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/archive/${script_ver}.tar.gz \
       file::rename=zhwiki-${dict_ver}-all-titles-in-ns0.gz::https://dumps.wikimedia.org/zhwiki/${dict_ver}/zhwiki-${dict_ver}-all-titles-in-ns0.gz"
 CHKSUMS="sha256::a06cc5e6a3630de229cbe0d7093caa2142d740daca681ee7c6aefe541d4a6e86 \
          sha256::6e08a8bbeb76e75fd8aa5c65379d840cf9ce4caa51d06086e471b9130d911025"
-SUBDIR="fcitx5-pinyin-zhwiki-$package_ver"
+SUBDIR="fcitx5-pinyin-zhwiki-${script_ver}"

--- a/extra-i18n/opencc/autobuild/beyond
+++ b/extra-i18n/opencc/autobuild/beyond
@@ -2,12 +2,14 @@ abinfo "Building and installing opencc python modules..."
 mkdir -pv "$SRCDIR"/python/opencc/clib
 cp -v "$SRCDIR"/build/opencc_clib.so "$SRCDIR"/python/opencc/clib/
 touch "$SRCDIR"/python/opencc/clib/__init__.py
-python setup.py build
-python setup.py install --root="$PKGDIR" --optimize=1
+
+abinfo "Building and installing Python3 modules ..."
+python3 setup.py build
+python3 setup.py install --root="$PKGDIR" --optimize=1
 
 abinfo "Arch Linux: Hack to make opencc’s python binding to use system opencc’s configs"
-mkdir -pv "$PKGDIR"/usr/lib/python"$ABPY3VER"/site-packages/opencc/clib/share
-ln -sv ../../../../../../share/opencc "$PKGDIR"/usr/lib/python"$ABPY3VER"/site-packages/opencc/clib/share/
+rm -rv  "$PKGDIR"/usr/lib/python"$ABPY3VER"/site-packages/opencc/clib/share/*
+ln -sfv ../../../../../../share/opencc "$PKGDIR"/usr/lib/python"$ABPY3VER"/site-packages/opencc/clib/share/
 
 abinfo "Arch Linux: Remove insecure RPath"
 chrpath --delete "$PKGDIR"/usr/lib/python"$ABPY3VER"/site-packages/opencc/clib/*.so

--- a/extra-i18n/opencc/spec
+++ b/extra-i18n/opencc/spec
@@ -1,4 +1,5 @@
 VER=1.1.2
+REL=1
 SRCS="tbl::https://github.com/BYVoid/OpenCC/archive/ver.$VER.tar.gz"
 CHKSUMS="sha256::8c0f44a210c4ee0cc79972d47829b2f3e1e90a26c4db0949da3ad99a8d1fe375"
 SUBDIR="OpenCC-ver.$VER"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Fcitx5 pinyin zhwiki : update to 0.2.2+20210401
opencc: fix python3 modules

Package(s) Affected
-------------------


Fcitx5 pinyin zhwiki:  0.2.2+20210401
opencc: 1.1.2-1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
 - [x] Architecture-independent `noarch`

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [x] Architecture-independent `noarch`

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
