### PR TITLE
mpv: update to 0.33.1

### DIFF
--- a/extra-multimedia/mpv/spec
+++ b/extra-multimedia/mpv/spec
@@ -1,6 +1,7 @@
-VER=0.33.0
+VER=0.33.1
 COMPLETION_GEN_VER=3.3.18
 SRCS="tbl::https://github.com/mpv-player/mpv/archive/v$VER.tar.gz \
       tbl::https://github.com/2ion/mpv-bash-completion/archive/${COMPLETION_GEN_VER}.tar.gz"
-CHKSUMS="sha256::f1b9baf5dc2eeaf376597c28a6281facf6ed98ff3d567e3955c95bf2459520b4 sha256::23eaaa131eda36e17562efa6c67d9b64eff93d6d80a88f4effe8786e91cc97df"
+CHKSUMS="sha256::100a116b9f23bdcda3a596e9f26be3a69f166a4f1d00910d1789b6571c46f3a9 \
+         sha256::23eaaa131eda36e17562efa6c67d9b64eff93d6d80a88f4effe8786e91cc97df"
 SUBDIR="mpv-$VER"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

mpv: update to 0.33.1

Package(s) Affected
-------------------

mpv: 0.33.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
