### PR TITLE
file: fix seccomp on arm64

### DIFF
--- a/base-utils/file/autobuild/patches/0001-Fix-seccomp-on-ARM64-Linux.patch
+++ b/base-utils/file/autobuild/patches/0001-Fix-seccomp-on-ARM64-Linux.patch
@@ -1,0 +1,32 @@
+From 1938b7d34253c80f39b92da63b53854e23cbbab4 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <icenowy@aosc.io>
+Date: Wed, 7 Apr 2021 02:05:50 +0800
+Subject: [PATCH] Fix seccomp on ARM64 Linux
+
+On ARM64 Linux access() syscall is no longer a real syscall to the
+kernel. Instead it's emulated by glibc with a new faccessat() syscall.
+
+faccessat() adds the functionality to do access permission check for a
+path relative to a file descriptor. As this seems to be not granting
+too much permission, add it to the whilelist of seccomp, to allow file
+command to run correctly on ARM64 Linux machines.
+---
+ src/seccomp.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/seccomp.c b/src/seccomp.c
+index 0da907ff..d812e262 100644
+--- a/src/seccomp.c
++++ b/src/seccomp.c
+@@ -171,6 +171,9 @@ enable_sandbox_full(void)
+ 	ALLOW_RULE(dup2);
+ 	ALLOW_RULE(exit);
+ 	ALLOW_RULE(exit_group);
++#ifdef __NR_faccessat
++	ALLOW_RULE(faccessat);
++#endif
+ 	ALLOW_RULE(fcntl);
+  	ALLOW_RULE(fcntl64);
+ 	ALLOW_RULE(fstat);
+-- 
+2.30.2

--- a/base-utils/file/spec
+++ b/base-utils/file/spec
@@ -1,4 +1,4 @@
 VER=5.39
-REL=2
+REL=3
 SRCTBL="http://download.openpkg.org/components/cache/file/file-$VER.tar.gz"
 CHKSUM="sha256::f05d286a76d9556243d0cb05814929c2ecf3a5ba07963f8f70bfaaa70517fad1"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fix file's absurd behavior on ARM64

Package(s) Affected
-------------------

`file` v5.39-3

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
