### PR TITLE
KDE survey 20210409

### DIFF
--- a/extra-kde/bluedevil/spec
+++ b/extra-kde/bluedevil/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/bluedevil-$VER.tar.xz"
-CHKSUMS="sha256::1b1ff32ed88ff087fe33992aaa56ddfcb03361ad3b17ee09a351ab93ec2215f7"
+CHKSUMS="sha256::e115d1851f6ce251fc7447936cd929c6c222c91fd832ce7c39f15d10a68c4653"

--- a/extra-kde/breeze-grub/spec
+++ b/extra-kde/breeze-grub/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/breeze-grub-$VER.tar.xz"
-CHKSUMS="sha256::dfd229b90f2a7d1bbfb9971ca6452f410eaeadfda5bd001587bcdfb22f9917c8"
+CHKSUMS="sha256::a27e5be18e9155fb3af5bf734eaac1f7a430baa10bf723540bbbb2b29277a8c9"

--- a/extra-kde/breeze-gtk/spec
+++ b/extra-kde/breeze-gtk/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/breeze-gtk-$VER.tar.xz"
-CHKSUMS="sha256::ac45fe545269a70aba4878fdae306d7c6a621e9f7478981f9c0b3a5a42f2abf4"
+CHKSUMS="sha256::912c425f9b9c39af02458c63f93704b274f0324c4b4b23ea30461a027b46520d"

--- a/extra-kde/breeze-plymouth/spec
+++ b/extra-kde/breeze-plymouth/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/breeze-plymouth-$VER.tar.xz"
-CHKSUMS="sha256::bd5e44d55628cfd3f53eccd24efbd3fea7144cd8573ad9ec8be119e9ee502d06"
+CHKSUMS="sha256::a759843c3d6eb156484a6ebc9e142d8da26d824067dd50d03ca4c01995a07c45"

--- a/extra-kde/breeze/spec
+++ b/extra-kde/breeze/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/breeze-$VER.tar.xz"
-CHKSUMS="sha256::838ad341c16a32331574d6c2588c48cba54033dd95ff33e56f17d880911b353b"
+CHKSUMS="sha256::d52db46df07302ea3f139ae88dd3b3b15aaab7d632b9910b87c3dac5eee5d0d8"

--- a/extra-kde/discover/spec
+++ b/extra-kde/discover/spec
@@ -1,4 +1,3 @@
-VER=5.21.3
-REL=1
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/discover-$VER.tar.xz"
-CHKSUMS="sha256::ddea3878522968a8e6d923ea7749cee77ad7ba1edfb3f37091bb12c933ec139c"
+CHKSUMS="sha256::6064cffde175ca7aae3a709025aee94fbddecf505115cb7d506f0ae79dda70b8"

--- a/extra-kde/drkonqi/spec
+++ b/extra-kde/drkonqi/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/drkonqi-$VER.tar.xz"
-CHKSUMS="sha256::443759b6aae600fabbeb9ca482c90b9d45bacaa9572f458df1b0d90de23e03c3"
+CHKSUMS="sha256::5831bad85f1f253844747e5c257996ab0a277ce20887abd58e72eaef3d047488"

--- a/extra-kde/kactivitymanagerd/spec
+++ b/extra-kde/kactivitymanagerd/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kactivitymanagerd-$VER.tar.xz"
-CHKSUMS="sha256::83a1241edd4b3fb50545eb62d4dd2a73bfb8367d71e65af2017f26275736b7f4"
+CHKSUMS="sha256::2684b61713223f7d8f1e064689fef13e54f2ade6b767a6229294e25bfce54a71"

--- a/extra-kde/kde-cli-tools/spec
+++ b/extra-kde/kde-cli-tools/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kde-cli-tools-$VER.tar.xz"
-CHKSUMS="sha256::f72ed4e939a85fc1643784f2fe413b743f3e9f8ce7c8a7ef0dd792d7ffc87542"
+CHKSUMS="sha256::01426b8c6be7cec804a44b74c3d79354f6f5509cbc176360f4ab43f330586ec3"

--- a/extra-kde/kde-gtk-config/spec
+++ b/extra-kde/kde-gtk-config/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kde-gtk-config-$VER.tar.xz"
-CHKSUMS="sha256::30e88dded1de4f5d096afa20c6ce148da800123c5e8318e44c0540258555de9d"
+CHKSUMS="sha256::c8034212a9a10877e61917084003bece052e3b65aac0197014b1c1840b0df03c"

--- a/extra-kde/kdecoration/spec
+++ b/extra-kde/kdecoration/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kdecoration-$VER.tar.xz"
-CHKSUMS="sha256::c5d14b8dd6983f22cbf4d34461e912fd38cd49114d01fb25635d7a1a9c7e4319"
+CHKSUMS="sha256::0a5db022018b958934dd678bf47eceb4233808808b06be2cfd5adb3700ba7e00"

--- a/extra-kde/kdeplasma-addons/spec
+++ b/extra-kde/kdeplasma-addons/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kdeplasma-addons-$VER.tar.xz"
-CHKSUMS="sha256::6121ed8b1ad433cdb531aaf8658b41f4b4744c869bae72c109c46a6652570185"
+CHKSUMS="sha256::2de617d0a750224d73a6a2d91d99508a6d725fab0f2be7b0b3c47dc3cdf056a2"

--- a/extra-kde/kgamma/spec
+++ b/extra-kde/kgamma/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kgamma5-$VER.tar.xz"
-CHKSUMS="sha256::892c0cf1cc988c8291da4ef080d70df3211920a5dbe99275afdf796a1ae71941"
+CHKSUMS="sha256::544387a3ab1fa630c979f8b447d3779f1f86e5d6ab7967935a8b44114f1bf6e7"

--- a/extra-kde/khotkeys/spec
+++ b/extra-kde/khotkeys/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/khotkeys-$VER.tar.xz"
-CHKSUMS="sha256::74051ad637ab49bab81391f8789253e1e0e275a0aa7971ca553dff5a56866ad8"
+CHKSUMS="sha256::a3f42777930145b2757eff95d468fd945c34db111d144d823e89521a3f5a6616"

--- a/extra-kde/kinfocenter/spec
+++ b/extra-kde/kinfocenter/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kinfocenter-$VER.tar.xz"
-CHKSUMS="sha256::e2cc48fdd873a16baea5e8b8c20e1e97a5c14acfae00458ff261f52abaad44c2"
+CHKSUMS="sha256::3e5c3fed0156f3464bb30ebb9e0822c4141d71802dfa8995961f84c548771394"

--- a/extra-kde/kmenuedit/spec
+++ b/extra-kde/kmenuedit/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kmenuedit-$VER.tar.xz"
-CHKSUMS="sha256::524aeb87739b0320bcd38551b367cff017c26a830669de7c91aaaa10a8d28339"
+CHKSUMS="sha256::d022bb6486663fd1db8b627794be5eb557fa0daa45b27bb69d834fa84494b8c2"

--- a/extra-kde/kscreen/spec
+++ b/extra-kde/kscreen/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kscreen-$VER.tar.xz"
-CHKSUMS="sha256::95e20c0967c1dcb5521dddcd6444f3a51a8b6ab5a1bd1e586d6d202469eb2fb9"
+CHKSUMS="sha256::d9d1225d5e4d5e062275c88bb879b96bde0167783d1a3722e737baa67dad3ed9"

--- a/extra-kde/kscreenlocker/spec
+++ b/extra-kde/kscreenlocker/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kscreenlocker-$VER.tar.xz"
-CHKSUMS="sha256::0012c4f0394bc6cd522a8fc4ed78f02e641b55d1baf8a81f6fd926c538bf54c2"
+CHKSUMS="sha256::6492531abacf0078936247090d1c3038c44d5ae3a61593fe474b503847ba24fd"

--- a/extra-kde/ksshaskpass/spec
+++ b/extra-kde/ksshaskpass/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/ksshaskpass-$VER.tar.xz"
-CHKSUMS="sha256::da0e1b06673afb12789fd028f2d428d980b85912ceb5e715bc710f5edb9f8299"
+CHKSUMS="sha256::c1b0479dc4ae0a183c41e4e546801df5332387026b101b735a8024dd8109447e"

--- a/extra-kde/ksysguard/spec
+++ b/extra-kde/ksysguard/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/ksysguard-$VER.tar.xz"
-CHKSUMS="sha256::4ee3595e30a932846dd2ad668231c2fdc7086135ba51d83e3bc6a685658b417b"
+CHKSUMS="sha256::cd1482653c35c5e04e6940346836fcd0655c213fc191da30685cb10cd05ae582"

--- a/extra-kde/kwallet-pam/spec
+++ b/extra-kde/kwallet-pam/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwallet-pam-$VER.tar.xz"
-CHKSUMS="sha256::4372d688ccc5e996e8bc1683939786f40dce3f21113067a5ab21f84ca688d6b6"
+CHKSUMS="sha256::6fce31384897e4913f03cffe6719c7f69618893676a2f44ca62bb21971f27c68"

--- a/extra-kde/kwayland-integration/spec
+++ b/extra-kde/kwayland-integration/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwayland-integration-$VER.tar.xz"
-CHKSUMS="sha256::0c7641e27a38094077a204ca10c410b2f4f92c0a077b32a22bb5d5ae572b1c4f"
+CHKSUMS="sha256::139cefb81cb852a699b15e77724cf4fb17adf9d8724b0d4955cdf9567fad6ee4"

--- a/extra-kde/kwayland-server/spec
+++ b/extra-kde/kwayland-server/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwayland-server-$VER.tar.xz"
-CHKSUMS="sha256::4409119a0e8c6dae5295490f965b26c1160b8df863cce6e46287a5ffe9d26a34"
+CHKSUMS="sha256::ff32f4e6b92fc900db41780cb2f2645c472e6ec5d3999aa17fb0fba807df71d6"

--- a/extra-kde/kwin/spec
+++ b/extra-kde/kwin/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwin-$VER.tar.xz"
-CHKSUMS="sha256::7c38049930f63875719c4405991c13ab436d2a2d2ad401b006e94250dd8d205a"
+CHKSUMS="sha256::a9cbcf293c58bef10650399a7fe15c08b54fd009a0d9d859f75b54bc6c87232f"

--- a/extra-kde/kwrited/spec
+++ b/extra-kde/kwrited/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwrited-$VER.tar.xz"
-CHKSUMS="sha256::ddccbb23c1ce510efc4f84cf4a59fc1aaa7f344e8d24b35b4603a3583149d606"
+CHKSUMS="sha256::8708c5f41dd32531a25bd9099cd15c39439769f7c17e4481b44f9f7572f03ac3"

--- a/extra-kde/libkscreen/spec
+++ b/extra-kde/libkscreen/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/libkscreen-$VER.tar.xz"
-CHKSUMS="sha256::6a6809a3db3a8c0b86869eae8df37b80ad017292dbee9d26077a22626f0f4dc8"
+CHKSUMS="sha256::ac09ad2e30920f4fbbb44d061cae5114d75ef0d1a765a4fbbf73b94f03a3152c"

--- a/extra-kde/libksysguard/spec
+++ b/extra-kde/libksysguard/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/libksysguard-$VER.tar.xz"
-CHKSUMS="sha256::c35218190c7af1e8cb144fbfdd9b15eb19479aef6e3182596cd2de8efc582742"
+CHKSUMS="sha256::ec094b59a7e111359b550731dafe4d9b92f17ae2c4d663275d97332e1bc5f16b"

--- a/extra-kde/milou/spec
+++ b/extra-kde/milou/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/milou-$VER.tar.xz"
-CHKSUMS="sha256::ce070712259d601915b327fbf2747d39d3e5b728a24f05e83deed8818e077361"
+CHKSUMS="sha256::6a72ab3cbadff8bb7999abc1fcdef30ec067cf0afb3ff18f0defe55bd8dfd578"

--- a/extra-kde/oxygen/spec
+++ b/extra-kde/oxygen/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/oxygen-$VER.tar.xz"
-CHKSUMS="sha256::0afcd178aaaedba660603f1177055db395af4d6693233bf31226ae4a3a0ed29b"
+CHKSUMS="sha256::f2039dd6ccd251c12651f3da77ed890b62360e115f1a6be678fe9f39fc6decb4"

--- a/extra-kde/plasma-browser-integration/spec
+++ b/extra-kde/plasma-browser-integration/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://github.com/KDE/plasma-browser-integration/archive/v$VER.tar.gz"
-CHKSUMS="sha256::bb22ccad28840ac9cd778717472c3fc088a31500b5a0112a3cb69f3d9ff1b5a5"
+CHKSUMS="sha256::182acb6d68e52ef5ef2754f0ca492b19d87444310d86ad79826470b7a73e2f2e"

--- a/extra-kde/plasma-desktop/spec
+++ b/extra-kde/plasma-desktop/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-desktop-$VER.tar.xz"
-CHKSUMS="sha256::de4f62f6e4612fd796387825cd755edde4784c0386c0d0552deb3b3c44993e2f"
+CHKSUMS="sha256::c9635c82ffa8fa9b22aa474e8aa2e8f9d912615137f039f5ee6080000c283bb7"

--- a/extra-kde/plasma-disks/spec
+++ b/extra-kde/plasma-disks/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-disks-$VER.tar.xz"
-CHKSUMS="sha256::58850de94434f61925bb579fdf9eff54f66512f6ca42a7cfba5c2ce8ee6d47a1"
+CHKSUMS="sha256::af186ba88170fe832f218a1438d142ed2ee6aff9ec967fe9003c6c84008451c2"

--- a/extra-kde/plasma-integration/spec
+++ b/extra-kde/plasma-integration/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-integration-$VER.tar.xz"
-CHKSUMS="sha256::c1e34f98af9e17062cc10897d49b62867a4957f40469bd2ca01cb546a35bb425"
+CHKSUMS="sha256::1cc280a93fab2c9c461deb172ee22da34a5100c3cd31ad8ebf0a9c405899422e"

--- a/extra-kde/plasma-nano/spec
+++ b/extra-kde/plasma-nano/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-nano-$VER.tar.xz"
-CHKSUMS="sha256::7288fc02939c2dc8284e3dcded09fe6eeefe012b61df857d84ceda644e1216fb"
+CHKSUMS="sha256::1397061ce968adad97b08002765b4d41a4ed91c48290d8c53b65ae145bc9bb6c"

--- a/extra-kde/plasma-nm/spec
+++ b/extra-kde/plasma-nm/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-nm-$VER.tar.xz"
-CHKSUMS="sha256::771c9a4d3f3acdf8c66f7ff1891790c8a7cfa4053500f1e96617b43f4f39fb34"
+CHKSUMS="sha256::e3d01fdd78ee6d1b0bc9753e1386ffb03c318498feac856fae377a397d6ec1bf"

--- a/extra-kde/plasma-pa/spec
+++ b/extra-kde/plasma-pa/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-pa-$VER.tar.xz"
-CHKSUMS="sha256::77453789506c489b36d8b23ba874834f240daf9c9ea2e60dfa3f735decefe99b"
+CHKSUMS="sha256::e9575c6bb4d73e3b45f9bdd256ed0cdc0e36014a1676abe2ad8d6ab5f1838fe5"

--- a/extra-kde/plasma-phone-components/spec
+++ b/extra-kde/plasma-phone-components/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-phone-components-$VER.tar.xz"
-CHKSUMS="sha256::c0324d46d21eb89f05fb2e7a772f69e25749d06f927f4323a2ed90e9db031bb6"
+CHKSUMS="sha256::6df1dac713e07a4a32e7af631e22340825e0270c9c58a27d62a960c30864b721"

--- a/extra-kde/plasma-sdk/spec
+++ b/extra-kde/plasma-sdk/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-sdk-$VER.tar.xz"
-CHKSUMS="sha256::9c20dec0545a5d1bb4e362b5778acbf2a1e65dabc7f9c07b9c84a155e4594b2b"
+CHKSUMS="sha256::40037c485cb4bbd9afbd237d96b65cdef41b8b3e35ab2f27a7f5c6d206a6c0b2"

--- a/extra-kde/plasma-systemmonitor/spec
+++ b/extra-kde/plasma-systemmonitor/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="https://download.kde.org/stable/plasma/$VER/plasma-systemmonitor-$VER.tar.xz"
-CHKSUMS="sha256::941e7a48d8c68ed072848110764e80e3596aea66a6fb99913301cc7f2bfe3df0"
+CHKSUMS="sha256::849407cf2b9333140cee9ca18ca34e1c4351a8597fea47a475eec68c8dc1b99a"

--- a/extra-kde/plasma-thunderbolt/spec
+++ b/extra-kde/plasma-thunderbolt/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-thunderbolt-$VER.tar.xz"
-CHKSUMS="sha256::b559889b8569ef7d11cd48efac480644fb146dfabaaf147cd7f32d5e6e5a16c8"
+CHKSUMS="sha256::0dc69a2e9c5fe692457771e503894f70ade69951b6cd838a7f71fa5025042983"

--- a/extra-kde/plasma-vault/spec
+++ b/extra-kde/plasma-vault/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-vault-$VER.tar.xz"
-CHKSUMS="sha256::323d3d025546524b82b0258e861d5392b65c3f7a7ad9a2c25d98f487bcc1a9e0"
+CHKSUMS="sha256::c577135b04d7b35227183100fcae08eaf6df5ef41c4ecf43e0706a329ef8a48d"

--- a/extra-kde/plasma-workspace-wallpapers/spec
+++ b/extra-kde/plasma-workspace-wallpapers/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-workspace-wallpapers-$VER.tar.xz"
-CHKSUMS="sha256::95a6e9da0a652e6584f3727227813fe79a9c4defa7d789126a31fceff09853e2"
+CHKSUMS="sha256::c706e4293b3c0552503abc55eaa0d971203b23ad252804f0fb95b9b040fad8d7"

--- a/extra-kde/plasma-workspace/spec
+++ b/extra-kde/plasma-workspace/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-workspace-$VER.tar.xz"
-CHKSUMS="sha256::80602e458ebabbf1685c918485bff4cb30eaae71cfd2bf2c4c9cea7a58b74ab6"
+CHKSUMS="sha256::ba0b184570b62be84be2f8108fccadd08de8f3abf8a0f615a6f06f829bd628d5"

--- a/extra-kde/plymouth-kcm/spec
+++ b/extra-kde/plymouth-kcm/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plymouth-kcm-$VER.tar.xz"
-CHKSUMS="sha256::6fe9c43ad461e84e76d1bf455a5c703af5d5a90c665f9918285a826fc0dab772"
+CHKSUMS="sha256::c07c80b8099e66548a2782b70b83b6c5c311052ae8c8610950f3ab30505116b4"

--- a/extra-kde/polkit-kde-agent-1/spec
+++ b/extra-kde/polkit-kde-agent-1/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/polkit-kde-agent-1-$VER.tar.xz"
-CHKSUMS="sha256::1b6802f688a8c0e83dc065503447a2e79967c67083799e4896b51813809b171b"
+CHKSUMS="sha256::b236f87213247a858acb9a7b82dba71f579c3febb3cee189b96584e588a6e251"

--- a/extra-kde/powerdevil/spec
+++ b/extra-kde/powerdevil/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/powerdevil-$VER.tar.xz"
-CHKSUMS="sha256::ffcbc2ca715377e6652f65744601c95ba0babbde7a15d4f4e8a3fa0ad85e6652"
+CHKSUMS="sha256::c6f1729dff9ce611c2094d930067fb4f364f6f3d4d78ea2ee07c5bb4db990445"

--- a/extra-kde/sddm-kcm/spec
+++ b/extra-kde/sddm-kcm/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/sddm-kcm-$VER.tar.xz"
-CHKSUMS="sha256::5f52bc7dd194f26c9f6fec8a0872026a1eb972fb25cdc0753bda981faf7b98ba"
+CHKSUMS="sha256::3396f33e7ae12661fc9722d96a37ee274588212bae886538423a9e4ee2052401"

--- a/extra-kde/systemsettings/spec
+++ b/extra-kde/systemsettings/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/systemsettings-$VER.tar.xz"
-CHKSUMS="sha256::1d9518fa792970859d49965209138ee9944a9e1db00ed2eea3337481c4a3d623"
+CHKSUMS="sha256::034b0c384cdbf38d126daf4dced6f2d42995b76f9b9268b30eb6a1d59c20ed04"

--- a/extra-kde/xdg-desktop-portal-kde/spec
+++ b/extra-kde/xdg-desktop-portal-kde/spec
@@ -1,3 +1,3 @@
-VER=5.21.3
+VER=5.21.4
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/xdg-desktop-portal-kde-$VER.tar.xz"
-CHKSUMS="sha256::3012df6b6127bf7800b7be1fd8674213d0748e17050862dd13b2ca34f89a2117"
+CHKSUMS="sha256::efbf69b0623db15d1a44725a88b3e6b5d0631bc0ebc88d0e695ff01df7da7406"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

KDE survey 20210409

groups/plasma: update to 5.21.4

Package(s) Affected
-------------------

See groups/plasma

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------
See groups/plasma

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
