### PR TITLE
Blender 2.92 + Open Image Denoise 1.3.0

### DIFF
--- a/extra-creativity/blender/autobuild/defines
+++ b/extra-creativity/blender/autobuild/defines
@@ -4,9 +4,9 @@ PKGDEP="boost desktop-file-utils ffmpeg fftw freetype glew \
         hicolor-icon-theme jack jemalloc libpng libsndfile libspnav libtiff \
         openal-soft opencollada opencolorio openexr openimageio \
         openjpeg opensubdiv libraw opencv numpy libxdg-basedir \
-        ptex requests shared-mime-info xdg-utils libcl python-3"
-PKGDEP__AMD64="${PKGDEP} embree"
-BUILDDEP="cmake"
+        ptex requests shared-mime-info xdg-utils libcl python-3 llvm"
+PKGDEP__AMD64="${PKGDEP} embree openimagedenoise"
+BUILDDEP="cmake jack"
 BUILDDEP__AMD64="${BUILDDEP} cuda"
 PKGDES="A fully integrated 3D graphics creation suite"
 
@@ -27,9 +27,9 @@ CMAKE_AFTER="-C../build_files/cmake/config/blender_full.cmake .. \
              -DWITH_INTERNATIONAL=ON \
              -DWITH_OPENIMAGEIO=ON \
              -DWITH_PLAYER=ON \
-             -DWITH_JACK=OFF \
-             -DWITH_LLVM=OFF
-             -DCYCLES_CUDA_BINARIES_ARCH='sm_30;sm_35;sm_37;sm_50;sm_52;sm_53;sm_60;sm_61;sm_62;sm_70;sm_72;sm_75;sm_80' \
+             -DWITH_JACK_DYNLOAD=ON \
+             -DWITH_LLVM=ON \
+             -DCYCLES_CUDA_BINARIES_ARCH='sm_50;sm_52;sm_53;sm_60;sm_61;sm_62;sm_70;sm_72;sm_75;sm_80;sm_86' \
              -DWITH_PYTHON_INSTALL=OFF \
              -DWITH_PYTHON_INSTALL_NUMPY=OFF \
              -DWITH_PYTHON_INSTALL_REQUESTS=OFF \
@@ -40,6 +40,7 @@ CMAKE_AFTER="-C../build_files/cmake/config/blender_full.cmake .. \
              -DWITH_GAMEENGINE=ON \
              -DWITH_IMAGE_OPENJPEG=ON \
              -DWITH_INPUT_NDOF=ON \
+             -DWITH_LINKER_GOLD=ON \
              -DWITH_MOD_OCEANSIM=ON"
 CMAKE_AFTER__AMD64=" \
              ${CMAKE_AFTER} \
@@ -57,7 +58,14 @@ CMAKE_AFTER__LOONGSON3=" \
 CMAKE_AFTER__PPC64EL=" \
              ${CMAKE_AFTER__NONX86}"
 
-ABSTRIP=0
 AB_FLAGS_O3=1
-
+# FIXME: Blender with LTO crashes with SEGV upon cycles engine initialization.
+# One of the const refs and many functions around the point of crash are
+# incorrectly optimized away. I have attempted various attribute((noinline))
+# magic but it didn't work.
+#
+# At the time of writing we are building on GCC 10.2.1, please recheck if we
+# had a later version of compiler.
+# ~cth451
+NOLTO=1
 NOLTO__LOONGSON3=1

--- a/extra-creativity/blender/autobuild/patches/0001-fix-embree-detection-path.patch
+++ b/extra-creativity/blender/autobuild/patches/0001-fix-embree-detection-path.patch
@@ -1,7 +1,7 @@
-From 8dc127e70b2fadedb41b17e0a0f74f4044711586 Mon Sep 17 00:00:00 2001
+From b3255da96c2a893587c45f9fa3afd2814f93452e Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Tue, 1 Sep 2020 23:18:45 -0500
-Subject: [PATCH] fix embree detection path
+Subject: [PATCH 1/2] fix embree detection path
 
 ---
  build_files/cmake/Modules/FindEmbree.cmake | 15 +++++++++++++--
@@ -61,7 +61,7 @@ index 0716f47ca52..6df29d206d1 100644
  IF(EMBREE_FOUND)
    SET(EMBREE_LIBRARIES ${_embree_LIBRARIES})
 diff --git a/intern/cycles/blender/CMakeLists.txt b/intern/cycles/blender/CMakeLists.txt
-index 0d805dc8683..9384aeee1d5 100644
+index 2d48563d8a6..dd6571ad9f7 100644
 --- a/intern/cycles/blender/CMakeLists.txt
 +++ b/intern/cycles/blender/CMakeLists.txt
 @@ -80,6 +80,12 @@ if(WITH_CYCLES_LOGGING)
@@ -78,5 +78,5 @@ index 0d805dc8683..9384aeee1d5 100644
    addon/__init__.py
    addon/engine.py
 -- 
-2.30.0
+2.30.2
 

--- a/extra-creativity/blender/autobuild/patches/0002-fix-Xxf86vm-linkage.patch
+++ b/extra-creativity/blender/autobuild/patches/0002-fix-Xxf86vm-linkage.patch
@@ -1,0 +1,31 @@
+From 3d7430be3a908083adb8ce5b3018f6a52ae498e3 Mon Sep 17 00:00:00 2001
+From: Tianhao Chai <cth451@gmail.com>
+Date: Thu, 8 Apr 2021 14:46:02 -0500
+Subject: [PATCH 2/2] fix Xxf86vm linkage
+
+---
+ build_files/cmake/platform/platform_unix.cmake | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/build_files/cmake/platform/platform_unix.cmake b/build_files/cmake/platform/platform_unix.cmake
+index a2448829206..70305838705 100644
+--- a/build_files/cmake/platform/platform_unix.cmake
++++ b/build_files/cmake/platform/platform_unix.cmake
+@@ -578,10 +578,10 @@ if(WITH_GHOST_X11)
+ 
+   if(WITH_X11_XF86VMODE)
+     # XXX, why doesn't cmake make this available?
+-    find_library(X11_Xxf86vmode_LIB Xxf86vm   ${X11_LIB_SEARCH_PATH})
+-    mark_as_advanced(X11_Xxf86vmode_LIB)
+-    if(X11_Xxf86vmode_LIB)
+-      list(APPEND PLATFORM_LINKLIBS ${X11_Xxf86vmode_LIB})
++    find_library(X11_Xf86vmode_LIB Xxf86vm   ${X11_LIB_SEARCH_PATH})
++    mark_as_advanced(X11_Xf86vmode_LIB)
++    if(X11_Xf86vmode_LIB)
++      list(APPEND PLATFORM_LINKLIBS ${X11_Xf86vmode_LIB})
+     else()
+       message(FATAL_ERROR "libXxf86vm not found. Disable WITH_X11_XF86VMODE if you
+       want to build without")
+-- 
+2.30.2
+

--- a/extra-creativity/blender/autobuild/prepare
+++ b/extra-creativity/blender/autobuild/prepare
@@ -4,9 +4,6 @@ if [[ "${CROSS:-$ARCH}" = "ppc64" ]]; then
     export CXXFLAGS="${CXXFLAGS/-maltivec -maltivec=be -mabi=altivec/} -mno-altivec -fno-tree-vectorize"
 fi
 
-export CFLAGS="${CFLAGS} -funsigned-char"
-export CXXFLAGS="${CXXFLAGS} -funsigned-char"
-
 if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
     source /etc/profile.d/cuda.sh
 fi

--- a/extra-creativity/blender/spec
+++ b/extra-creativity/blender/spec
@@ -1,4 +1,3 @@
-VER=2.91.0
-REL=1
+VER=2.92.0
 SRCS="tbl::https://download.blender.org/source/blender-$VER.tar.xz"
-CHKSUMS="sha256::557a4afd09fe086ebcb0256b904896f577fe913683655f4248b881591f356974"
+CHKSUMS="sha256::e791cfc403292383577c3c8ce2cd34e5aa2cd8da0a7483041049a1609ddb4595"

--- a/extra-libs/openimagedenoise/spec
+++ b/extra-libs/openimagedenoise/spec
@@ -1,3 +1,3 @@
-VER=1.2.2
+VER=1.3.0
 SRCTBL="https://github.com/OpenImageDenoise/oidn/releases/download/v${VER}/oidn-${VER}.src.tar.gz"
-CHKSUM='sha256::da30dfb8daa21663525124d7e44804251ba578f8c13d2024cdb92bfdda7d8121'
+CHKSUM="sha256::88367b2bbea82d1df45d65141c36b6d86491bc6b397dc70beb3a05dda566f31c"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates blender to 2.92 and its dependency openimagedenoise to 1.3.0.

Fixes:
* Supported list of CUDA architectures now matches CUDA 11.
* Support jack via `dlopen()`. (Should we make it PKGSUG?)
* Ad-hoc patch 0002 is introduced to allow linkage against `libXxf86vm.so`. **Recheck when we have a newer blender version.**

Known issues:

* LTO is disabled for this version. Blender compiled with LTO will crash with SEGV attempting to dereference a null pointer. Multiple variables and functions are unexpectedly inlined around the crashing spot. This is very likely a compiler bug. **Recheck when we have a newer GCC or a newer blender version.**

Package(s) Affected
-------------------

* `openimagedenoise`: 1.3.0 - amd64 only
* `blender`: 2.92

Build Order
-----------

`openimagedenoise` -> `blender`

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`


Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
