### PR TITLE
intel-graphics-compiler: update to 1.0.6812

### DIFF
--- a/extra-devel/intel-graphics-compiler/autobuild/defines
+++ b/extra-devel/intel-graphics-compiler/autobuild/defines
@@ -5,7 +5,7 @@ BUILDDEP="llvm"
 PKGDES="An LLVM based compiler for OpenCL targeting Intel Gen graphics hardware architecture"
 
 CMAKE_AFTER="-DIGC_OPTION__ARCHITECTURE_TARGET=Linux64 \
-             -DIGC_PREFERRED_LLVM_VERSION=11.1.0 \
+             -DIGC_OPTION__LLVM_PREFERRED_VERSION=11.1.0 \
              -DINSTALL_GENX_IR=ON \
              -DVC_INTRINSICS_SRC=$SRCDIR/../vc-intrinsics \
              -DSPIRV_SRC=$SRCDIR/../SPIRV-LLVM-Translator \

--- a/extra-devel/intel-graphics-compiler/autobuild/patches/0002-use-cmake-chaining.patch
+++ b/extra-devel/intel-graphics-compiler/autobuild/patches/0002-use-cmake-chaining.patch
@@ -1,6 +1,6 @@
---- a/IGC/VectorCompiler/cmake/spirv.cmake	2020-12-12 01:29:34.213085053 -0800
-+++ b/IGC/VectorCompiler/cmake/spirv.cmake	2020-12-12 01:35:05.382723646 -0800
-@@ -147,47 +147,18 @@
+--- a/IGC/VectorCompiler/cmake/spirv.cmake	2021-04-08 20:44:44.516300872 -0700
++++ b/IGC/VectorCompiler/cmake/spirv.cmake	2021-04-08 20:51:25.825196118 -0700
+@@ -174,46 +174,18 @@
      message(FATAL_ERROR "[VC] Found unsupported version of LLVM (LLVM_VERSION_MAJOR is set to ${LLVM_VERSION_MAJOR})")
    endif()
  
@@ -15,7 +15,7 @@
 -  ${SPRIV_BRANCH_PATCH}
 -  )
 -
-   if(IGC_OPTION__FORCE_SYSTEM_LLVM)
+   if(${IGC_OPTION__LLVM_FROM_SYSTEM})
 -
 -    ExternalProject_Add(SPIRVDLL_EX
 -        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/SPIRVDLL
@@ -25,7 +25,8 @@
 -        INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/spirv-install
 -      )
 -
-+    add_subdirectory(${SPIRV_COPY})
++    add_subdirectory(${SPIRV_SOURCES} "${SPIRV_COPY}")
++    add_dependencies(SPIRVDLL VCCodeGen)
    else()
 -
 -    ExternalProject_Add(SPIRVDLL_EX
@@ -38,7 +39,7 @@
 -
 +    add_subdirectory(${SPIRV_SOURCES} "${SPIRV_COPY}")
 +    add_dependencies(SPIRVDLL VCCodeGen)
-   endif(IGC_OPTION__FORCE_SYSTEM_LLVM)
+   endif(${IGC_OPTION__LLVM_FROM_SYSTEM})
  
 -  add_dependencies(SPIRVDLL_EX VCCodeGen)
 -
@@ -53,5 +54,4 @@
 +      COMPONENT igc-core
 +    )
  endif(DEFINED SPIRVDLL_SRC)
- 
- elseif(NOT TARGET SPIRVDLL)
+ endif(INSTALL_SPIRVDLL)

--- a/extra-devel/intel-graphics-compiler/autobuild/patches/0004-fix-build-with-llvm-11.patch
+++ b/extra-devel/intel-graphics-compiler/autobuild/patches/0004-fix-build-with-llvm-11.patch
@@ -1,139 +1,80 @@
-From 8e067f5d9d9163ab0fb16f8553f664c0c59da374 Mon Sep 17 00:00:00 2001
-From: liushuyu <liushuyu011@gmail.com>
-Date: Sat, 26 Dec 2020 16:44:01 -0700
-Subject: [PATCH] fix build with llvm 11
-
----
- IGC/Compiler/CISACodeGen/ResolveGAS.cpp                       | 3 ++-
- .../OpenCLPasses/PrivateMemory/PrivateMemoryToSLM.cpp         | 2 +-
- IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp       | 2 +-
- .../lib/GenXCodeGen/GenXThreadPrivateMemory.cpp               | 4 ++--
- IGC/VectorCompiler/lib/GenXCodeGen/GenXUtil.cpp               | 4 ++--
- IGC/VectorCompiler/lib/GenXCodeGen/GenXUtil.h                 | 2 +-
- IGC/WrapperLLVM/include/llvmWrapper/Support/Alignment.h       | 2 +-
- 7 files changed, 10 insertions(+), 9 deletions(-)
-
-diff --git a/IGC/Compiler/CISACodeGen/ResolveGAS.cpp b/IGC/Compiler/CISACodeGen/ResolveGAS.cpp
-index 090d4fbe..a7e4a46a 100644
---- a/IGC/Compiler/CISACodeGen/ResolveGAS.cpp
-+++ b/IGC/Compiler/CISACodeGen/ResolveGAS.cpp
-@@ -38,6 +38,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- #include <llvm/ADT/SmallVector.h>
- #include <llvm/ADT/PostOrderIterator.h>
- #include <llvm/Analysis/LoopInfo.h>
-+#include <llvm/Analysis/AliasAnalysis.h>
- #include <llvm/IR/IRBuilder.h>
- #include <llvm/IR/NoFolder.h>
- #include <llvm/Pass.h>
-@@ -889,4 +890,4 @@ bool GASResolving::checkGenericArguments(Function& F) const {
-         }
-     }
-     return false;
--}
-\ No newline at end of file
-+}
-diff --git a/IGC/Compiler/Optimizer/OpenCLPasses/PrivateMemory/PrivateMemoryToSLM.cpp b/IGC/Compiler/Optimizer/OpenCLPasses/PrivateMemory/PrivateMemoryToSLM.cpp
-index fd1e7656..293fcd5e 100644
---- a/IGC/Compiler/Optimizer/OpenCLPasses/PrivateMemory/PrivateMemoryToSLM.cpp
-+++ b/IGC/Compiler/Optimizer/OpenCLPasses/PrivateMemory/PrivateMemoryToSLM.cpp
-@@ -191,7 +191,7 @@ namespace IGC
+diff -Naur intel-graphics-compiler-igc-1.0.6812/IGC/Compiler/ConvertMSAAPayloadTo16Bit.cpp intel-graphics-compiler-igc-1.0.6812-bak/IGC/Compiler/ConvertMSAAPayloadTo16Bit.cpp
+--- intel-graphics-compiler-igc-1.0.6812/IGC/Compiler/ConvertMSAAPayloadTo16Bit.cpp	2021-03-22 02:55:24.000000000 -0700
++++ intel-graphics-compiler-igc-1.0.6812-bak/IGC/Compiler/ConvertMSAAPayloadTo16Bit.cpp	2021-04-09 15:55:14.670369025 -0700
+@@ -153,15 +153,15 @@
+             // There are uses of ldmcs other then ldms, using vector of int32 type.
+             // Fix them to use newly created 16bit ldmcs.
+             if (ldmcs->getType()->isVectorTy() &&
+-                ldmcs->getType()->getVectorElementType() == m_builder->getInt32Ty())
++                cast<VectorType>(ldmcs->getType())->getElementType() == m_builder->getInt32Ty())
              {
-                 PointerType* ptrType = dyn_cast<PointerType>(offsets.m_Var->getType());
-                 Type* varType = ptrType->getElementType();
--                offset = iSTD::Align(offset, DL.getPreferredAlignment(offsets.m_Var));
-+                offset = iSTD::Align(offset, DL.getPreferredAlign(offsets.m_Var).value());
-                 offset += (unsigned int) DL.getTypeAllocSize(varType);
-             }
+                 m_builder->SetInsertPoint(ldmcs);
  
-diff --git a/IGC/VectorCompiler/lib/GenXCodeGen/GenXThreadPrivateMemory.cpp b/IGC/VectorCompiler/lib/GenXCodeGen/GenXThreadPrivateMemory.cpp
-index e8529e7a..4421a0eb 100644
---- a/IGC/VectorCompiler/lib/GenXCodeGen/GenXThreadPrivateMemory.cpp
-+++ b/IGC/VectorCompiler/lib/GenXCodeGen/GenXThreadPrivateMemory.cpp
-@@ -359,7 +359,7 @@ Value *GenXThreadPrivateMemory::lookForPtrReplacement(Value *Ptr) const {
-   if (isa<UndefValue>(Ptr)) {
-     if (auto PtrVecTy = dyn_cast<VectorType>(PtrTy))
-       return UndefValue::get(
--          VectorType::get(MemTy, PtrVecTy->getNumElements()));
-+          IGCLLVM::FixedVectorType::get(MemTy, PtrVecTy->getNumElements()));
-     return UndefValue::get(MemTy);
-   } else if (auto BC = dyn_cast<BitCastInst>(Ptr))
-     return lookForPtrReplacement(BC->getOperand(0));
-@@ -467,7 +467,7 @@ bool GenXThreadPrivateMemory::replaceShuffleVector(
-   Value *NewVec1 = lookForPtrReplacement(Vec1);
-   Value *NewVec2 = lookForPtrReplacement(Vec2);
-   auto NewShuffleVec = new ShuffleVectorInst(
--      NewVec1, NewVec2, ShuffleVec->getMask(), ShuffleVec->getName() + ".tpm");
-+      NewVec1, NewVec2, ShuffleVec->getOperand(2), ShuffleVec->getName() + ".tpm");
-   NewShuffleVec->insertAfter(ShuffleVec);
+-                uint ldmcsNumOfElements = ldmcs->getType()->getVectorNumElements();
+-                uint newLdmcsNumOfElements = new_mcs_call->getType()->getVectorNumElements();
++                uint ldmcsNumOfElements = cast<VectorType>(ldmcs->getType())->getNumElements();
++                uint newLdmcsNumOfElements = cast<VectorType>(new_mcs_call->getType())->getNumElements();
  
-   auto CastToOldTy =
-diff --git a/IGC/VectorCompiler/lib/GenXCodeGen/GenXUtil.cpp b/IGC/VectorCompiler/lib/GenXCodeGen/GenXUtil.cpp
-index 2de96fb9..f985c13d 100644
---- a/IGC/VectorCompiler/lib/GenXCodeGen/GenXUtil.cpp
-+++ b/IGC/VectorCompiler/lib/GenXCodeGen/GenXUtil.cpp
-@@ -356,7 +356,7 @@ bool genx::isIntNot(Instruction *Inst)
-  * invertCondition : Invert the given predicate value, possibly reusing
-  * an existing copy.
-  */
--Value *genx::invertCondition(Value *Condition)
-+/*Value *genx::invertCondition(Value *Condition)
- {
-   IGC_ASSERT(Condition->getType()->getScalarType()->isIntegerTy(1) &&
-       "Condition is not of predicate type");
-@@ -384,7 +384,7 @@ Value *genx::invertCondition(Value *Condition)
-     Inverted->insertBefore(&*Parent->getFirstInsertionPt());
-   }
-   return Inverted;
--}
-+}*/
+                 // vec of 16bit ints to vec of 32bit ints
+-                Type* newLdmcsVecType = VectorType::get(m_builder->getInt32Ty(), newLdmcsNumOfElements);
++                Type* newLdmcsVecType = VectorType::get(m_builder->getInt32Ty(), newLdmcsNumOfElements, false);
+                 Value* ldmcsExtendedToInt32 = m_builder->CreateSExt(new_mcs_call, newLdmcsVecType);
  
- /***********************************************************************
-  * ShuffleVectorAnalyzer::getAsSlice : see if the shufflevector is a slice on
-diff --git a/IGC/VectorCompiler/lib/GenXCodeGen/GenXUtil.h b/IGC/VectorCompiler/lib/GenXCodeGen/GenXUtil.h
-index 431a6b6c..e1792ea7 100644
---- a/IGC/VectorCompiler/lib/GenXCodeGen/GenXUtil.h
-+++ b/IGC/VectorCompiler/lib/GenXCodeGen/GenXUtil.h
-@@ -203,7 +203,7 @@ Value *getMaskOperand(const Instruction *Inst);
+                 // if ldmcs has fewer elements than new ldmcs, extend vector
+@@ -175,7 +175,7 @@
+                     }
+                     auto* pMask = ConstantDataVector::get(I.getContext(), maskVals);
  
- // invertCondition : Invert the given predicate value, possibly reusing
- //    an existing copy.
--Value *invertCondition(Value *Condition);
-+//Value *invertCondition(Value *Condition);
+-                    ldmcsInt32CorrectlySized = m_builder->CreateShuffleVector(ldmcsExtendedToInt32, UndefValue::get(VectorType::get(m_builder->getInt32Ty(), ldmcsNumOfElements)), pMask);
++                    ldmcsInt32CorrectlySized = m_builder->CreateShuffleVector(ldmcsExtendedToInt32, UndefValue::get(VectorType::get(m_builder->getInt32Ty(), ldmcsNumOfElements, false)), pMask);
+                 }
+                 else
+                 {
+diff -Naur intel-graphics-compiler-igc-1.0.6812/IGC/Compiler/Legalizer/InstPromoter.cpp intel-graphics-compiler-igc-1.0.6812-bak/IGC/Compiler/Legalizer/InstPromoter.cpp
+--- intel-graphics-compiler-igc-1.0.6812/IGC/Compiler/Legalizer/InstPromoter.cpp	2021-03-22 02:55:24.000000000 -0700
++++ intel-graphics-compiler-igc-1.0.6812-bak/IGC/Compiler/Legalizer/InstPromoter.cpp	2021-04-09 15:48:51.001080379 -0700
+@@ -394,10 +394,10 @@
+         unsigned N =
+             Val->getType()->getScalarSizeInBits() / DestTy->getScalarSizeInBits();
+         Value* BC =
+-            IRB->CreateBitCast(Val, VectorType::get(DestTy->getScalarType(), N));
++            IRB->CreateBitCast(Val, VectorType::get(DestTy->getScalarType(), N, false));
  
- // if V is a function pointer return function it points to,
- //    nullptr otherwise
-diff --git a/IGC/WrapperLLVM/include/llvmWrapper/Support/Alignment.h b/IGC/WrapperLLVM/include/llvmWrapper/Support/Alignment.h
-index 6cf5f06d..00079a89 100644
---- a/IGC/WrapperLLVM/include/llvmWrapper/Support/Alignment.h
-+++ b/IGC/WrapperLLVM/include/llvmWrapper/Support/Alignment.h
-@@ -96,7 +96,7 @@ namespace IGCLLVM {
- #elif LLVM_VERSION_MAJOR <= 10
-         return llvm::MaybeAlign(Val.getAlignment());
- #else
--        return Val.getAlign();
-+        return llvm::Align(Val.getAlignment());
- #endif
+         std::vector<Constant*> Vals;
+-        for (unsigned i = 0; i < DestTy->getVectorNumElements(); i++)
++        for (unsigned i = 0; i < cast<VectorType>(DestTy)->getNumElements(); i++)
+             Vals.push_back(IRB->getInt32(i));
+ 
+         Value* Mask = ConstantVector::get(Vals);
+diff -Naur intel-graphics-compiler-igc-1.0.6812/IGC/Compiler/Optimizer/OpenCLPasses/WIFuncs/WIFuncResolution.cpp intel-graphics-compiler-igc-1.0.6812-bak/IGC/Compiler/Optimizer/OpenCLPasses/WIFuncs/WIFuncResolution.cpp
+--- intel-graphics-compiler-igc-1.0.6812/IGC/Compiler/Optimizer/OpenCLPasses/WIFuncs/WIFuncResolution.cpp	2021-03-22 02:55:24.000000000 -0700
++++ intel-graphics-compiler-igc-1.0.6812-bak/IGC/Compiler/Optimizer/OpenCLPasses/WIFuncs/WIFuncResolution.cpp	2021-04-09 15:45:34.096918429 -0700
+@@ -28,6 +28,7 @@
+ #include "common/LLVMWarningsPush.hpp"
+ #include <llvm/IR/Function.h>
+ #include <llvm/IR/Instructions.h>
++#include <llvm/IR/DerivedTypes.h>
+ #include "common/LLVMWarningsPop.hpp"
+ #include "Probe/Assertion.h"
+ #include <llvmWrapper/Support/Alignment.h>
+@@ -303,7 +304,7 @@
+     auto Size = ElemByteSize;
+     if (DataType->isVectorTy())
+     {
+-        Size *= DataType->getVectorNumElements();
++        Size *= cast<VectorType>(DataType)->getNumElements();
      }
+     unsigned int AlignedOffset = (Offset / ElemByteSize) * ElemByteSize;
+     unsigned int LoadByteSize = (Offset == AlignedOffset) ? Size : Size * 2;
+diff -Naur intel-graphics-compiler-igc-1.0.6812/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp intel-graphics-compiler-igc-1.0.6812-bak/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp
+--- intel-graphics-compiler-igc-1.0.6812/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp	2021-03-22 02:55:24.000000000 -0700
++++ intel-graphics-compiler-igc-1.0.6812-bak/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp	2021-04-09 16:09:00.917881444 -0700
+@@ -2233,7 +2233,7 @@
  
---- intel-graphics-compiler-igc-1.0.5964/IGC/VectorCompiler/lib/GenXCodeGen/GenXLegalization.cpp	2020-12-24 05:04:21.000000000 -0800
-+++ intel-graphics-compiler-igc-1.0.5964-bak/IGC/VectorCompiler/lib/GenXCodeGen/GenXLegalization.cpp	2021-01-22 23:10:17.181133688 -0800
-@@ -2105,7 +2105,7 @@
-   if (OldElemSize * OldNumElems % NewElemSize)
-     return nullptr;
-   return VectorType::get(NewScalarType,
--                         OldElemSize * OldNumElems / NewElemSize);
-+                         OldElemSize * OldNumElems / NewElemSize, false);
- }
- 
- /***********************************************************************
---- a/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp	2021-01-22 23:18:20.513033428 -0800
-+++ b/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp	2021-01-22 23:18:36.069213137 -0800
-@@ -2281,7 +2281,7 @@
- 
-   auto createConstant = [](unsigned int OperandWidth, Type *Ty, int Value) {
-     return OperandWidth != 0 ? ConstantDataVector::getSplat(
--                                   IGCLLVM::getElementCount(OperandWidth),
-+                                   OperandWidth,
-                                    ConstantInt::get(Ty, Value))
-                              : ConstantInt::get(Ty, Value);
-     ;
+ bool GenXPatternMatch::clearDeadInstructions(Function &F) {
+   bool Changed = false;
+-  SmallVector<Instruction *, 8> ToErase;
++  SmallVector<WeakTrackingVH, 8> ToErase;
+   for (auto &Inst : instructions(F))
+     if (isInstructionTriviallyDead(&Inst))
+       ToErase.push_back(&Inst);

--- a/extra-devel/intel-graphics-compiler/spec
+++ b/extra-devel/intel-graphics-compiler/spec
@@ -1,10 +1,8 @@
-VER=1.0.5964
+VER=1.0.6812
 SRCS="tbl::https://github.com/intel/intel-graphics-compiler/archive/igc-$VER.tar.gz \
-      git::commit=50326439b1d0733c6af697de856d922273e4cfbe;rename=vc-intrinsics::https://github.com/intel/vc-intrinsics \
+      git::commit=6713229fd8947f4cf200f675d22fb7e9997fa261;rename=vc-intrinsics::https://github.com/intel/vc-intrinsics \
       git::commit=d6dc999eee381158a26f048a333467c9ce7e77f2;rename=SPIRV-LLVM-Translator::https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
-CHKSUMS="sha256::2edc768d3ffa25879dda23766bd1b56d08f3d4db1d51e66ec8195e02e7479f00 \
+CHKSUMS="sha256::9685886963b516c8cbb8af1950389b86c0f4ee5c299dd06563a33cf7ade379f4 \
          SKIP \
          SKIP"
 SUBDIR="intel-graphics-compiler-igc-$VER"
-
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

Update IGC to 1.0.6812

Package(s) Affected
-------------------

`intel-graphics-compiler`

Security Update?
----------------

No

Architectural Progress
----------------------

- [ ] AMD64 `amd64`   


Secondary Architectural Progress
--------------------------------

N/A

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-abbs/2964)
<!-- Reviewable:end -->
