### PR TITLE
solaar: new, 1.0.5

### DIFF
--- a/extra-utils/solaar/autobuild/beyond
+++ b/extra-utils/solaar/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing udev rules..."
+install -Dvm644 rules.d/42-logitech-unify-permissions.rules \
+	-t "${PKGDIR}/usr/lib/udev/rules.d/"

--- a/extra-utils/solaar/autobuild/beyond
+++ b/extra-utils/solaar/autobuild/beyond
@@ -1,3 +1,3 @@
 abinfo "Installing udev rules..."
-install -Dvm644 rules.d/42-logitech-unify-permissions.rules \
-	-t "${PKGDIR}/usr/lib/udev/rules.d/"
+install -Dvm644 "${SRCDIR}/rules.d/42-logitech-unify-permissions.rules" \
+	"${PKGDIR}/usr/lib/udev/rules.d/42-logitech-unify-permissions.rules"

--- a/extra-utils/solaar/autobuild/defines
+++ b/extra-utils/solaar/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=solaar
+PKGSEC=utils
+PKGDES="Linux device manager for Logitech devices"
+PKGDEP="python-3 gtk-3 libnotify dbus-python pygobject-3 pyudev pypsutil
+        python-xlib pyyaml"
+
+NOPYTHON2=1
+ABTYPE=python
+ABHOST=noarch

--- a/extra-utils/solaar/spec
+++ b/extra-utils/solaar/spec
@@ -1,0 +1,3 @@
+VER=1.0.5
+SRCS="https://github.com/pwr-Solaar/Solaar/archive/refs/tags/${VER}.tar.gz"
+CHKSUMS="sha256::6514f278da3f3a96dda6f254b786a2b106e1a5c20e0c20e61c8273b3e5c33973"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Introduces `solaar`, a manager for Logitech devices.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

solaar: new, 1.0.5
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- - [ ] AMD64 `amd64` -->
<!-- - [ ] AArch64 `arm64` -->
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [x] Architecture-independent `noarch`

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

<!-- - [ ] Loongson 3 `loongson3` -->
<!-- - [ ] PowerPC 64-bit (Little Endian) `ppc64el` -->

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- - [ ] AMD64 `amd64` -->
<!-- - [ ] AArch64 `arm64` -->
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [ ] Architecture-independent `noarch`

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

<!-- - [ ] Loongson 3 `loongson3` -->
<!-- - [ ] PowerPC 64-bit (Little Endian) `ppc64el` -->

<!-- TODO: CI to auto-fill architectural progress. -->
