### PR TITLE
yubikey-manager-qt: update to 1.2.1

### DIFF
--- a/extra-libs/libcbor/autobuild/defines
+++ b/extra-libs/libcbor/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=libcbor
+PKGSEC=libs
+PKGDES="A CBOR protocol implementation for C"
+PKGDEP="glibc"

--- a/extra-libs/libcbor/autobuild/defines
+++ b/extra-libs/libcbor/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libcbor
 PKGSEC=libs
-PKGDES="A CBOR protocol implementation for C"
+PKGDES="A C implementation for CBOR protocol"
 PKGDEP="glibc"
 
 CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON"

--- a/extra-libs/libcbor/autobuild/defines
+++ b/extra-libs/libcbor/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=libcbor
 PKGSEC=libs
 PKGDES="A CBOR protocol implementation for C"
 PKGDEP="glibc"
+
+CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON"

--- a/extra-libs/libcbor/autobuild/defines
+++ b/extra-libs/libcbor/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libcbor
 PKGSEC=libs
-PKGDES="A C implementation for CBOR protocol"
+PKGDES="A C implementation of the CBOR protocol"
 PKGDEP="glibc"
 
 CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON"

--- a/extra-libs/libcbor/spec
+++ b/extra-libs/libcbor/spec
@@ -1,4 +1,3 @@
 VER=0.8.0
 SRCS="https://github.com/PJK/libcbor/archive/refs/tags/v${VER}.tar.gz"
 CHKSUMS="sha384::16b5e6428f1b709550c43e6076e71bd5723953d14db5b22422a88e08cde5d98fdd4f3c19c564db58e1dbfb694047746b"
-

--- a/extra-libs/libcbor/spec
+++ b/extra-libs/libcbor/spec
@@ -1,0 +1,4 @@
+VER=0.8.0
+SRCS="https://github.com/PJK/libcbor/archive/refs/tags/v${VER}.tar.gz"
+CHKSUMS="sha384::16b5e6428f1b709550c43e6076e71bd5723953d14db5b22422a88e08cde5d98fdd4f3c19c564db58e1dbfb694047746b"
+

--- a/extra-libs/libfido2/autobuild/defines
+++ b/extra-libs/libfido2/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=libfido2
 PKGSEC=libs
-PKGDES="A library which provides FIDO2 functionality over USB."
+PKGDES="A library which provides FIDO2 functionality over USB"
 PKGDEP="hidapi libcbor zlib openssl"

--- a/extra-libs/libfido2/autobuild/defines
+++ b/extra-libs/libfido2/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=libfido2
+PKGSEC=libs
+PKGDES="A library which providing functionality for FIDO 2.0 over USB communications."
+PKGDEP="hidapi libcbor zlib openssl"

--- a/extra-libs/libfido2/autobuild/defines
+++ b/extra-libs/libfido2/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libfido2
 PKGSEC=libs
-PKGDES="A library which providing functionality for FIDO 2.0 over USB communications."
+PKGDES="A library which provides FIDO2 functionality over USB."
 PKGDEP="hidapi libcbor zlib openssl"
 
 CMAKE_AFTER="-Wno-dev"

--- a/extra-libs/libfido2/autobuild/defines
+++ b/extra-libs/libfido2/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=libfido2
 PKGSEC=libs
 PKGDES="A library which providing functionality for FIDO 2.0 over USB communications."
 PKGDEP="hidapi libcbor zlib openssl"
+
+CMAKE_AFTER="-Wno-dev"

--- a/extra-libs/libfido2/autobuild/defines
+++ b/extra-libs/libfido2/autobuild/defines
@@ -2,5 +2,3 @@ PKGNAME=libfido2
 PKGSEC=libs
 PKGDES="A library which provides FIDO2 functionality over USB."
 PKGDEP="hidapi libcbor zlib openssl"
-
-CMAKE_AFTER="-Wno-dev"

--- a/extra-libs/libfido2/spec
+++ b/extra-libs/libfido2/spec
@@ -1,0 +1,3 @@
+VER=1.7.0
+SRCS="https://developers.yubico.com/libfido2/Releases/libfido2-${VER}.tar.gz"
+CHKSUMS="sha384::1aac1d526bf0839e667e9d10091f8cc811ae449ce0e5efae869c37e943a7ab6b610aa83b31ac48baf043765f07c39694"

--- a/extra-security/fido2/spec
+++ b/extra-security/fido2/spec
@@ -1,3 +1,3 @@
 VER=0.9.1
 SRCS="https://github.com/Yubico/python-fido2/releases/download/$VER/fido2-$VER.tar.gz"
-CHKSUM="sha384::ed01f83e8c3a4ca426a7c9baf41cc51b4290f729aa6b1508563d66486badc0fe4d7f42359a7d804c706f33fb09948e63"
+CHKSUMS="sha384::ed01f83e8c3a4ca426a7c9baf41cc51b4290f729aa6b1508563d66486badc0fe4d7f42359a7d804c706f33fb09948e63"

--- a/extra-security/fido2/spec
+++ b/extra-security/fido2/spec
@@ -1,4 +1,3 @@
-VER=0.5.0
-REL=2
-SRCTBL="https://github.com/Yubico/python-fido2/releases/download/$VER/fido2-$VER.tar.gz"
-CHKSUM="sha256::e356c4e2ff136a29ea7f0bf82e679c2251fb246c4d459c3c91f84b93af6888de"
+VER=0.9.1
+SRCS="https://github.com/Yubico/python-fido2/releases/download/$VER/fido2-$VER.tar.gz"
+CHKSUM="sha384::ed01f83e8c3a4ca426a7c9baf41cc51b4290f729aa6b1508563d66486badc0fe4d7f42359a7d804c706f33fb09948e63"

--- a/extra-security/yubikey-manager-qt/autobuild/beyond
+++ b/extra-security/yubikey-manager-qt/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing FD.o desktop entity file and icon..."
+install -vDm644 -t "${PKGDIR}"/usr/share/applications/ "${SRCDIR}/resources/ykman-gui.desktop" 
+install -vDm644 -t "${PKGDIR}"/usr/share/pixmaps/ "${SRCDIR}/resources/icons/ykman.png"

--- a/extra-security/yubikey-manager-qt/spec
+++ b/extra-security/yubikey-manager-qt/spec
@@ -1,3 +1,3 @@
-VER=1.1.5
-SRCTBL="https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-$VER.tar.gz"
-CHKSUM="sha256::9e3fcf8552323591258c585f02bf5b3f758431a0f1e1c90d7f6460b8b1a235fa"
+VER=1.2.1
+SRCS="https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-${VER}.tar.gz"
+CHKSUMS="sha384::aef6a2c35e4735f015cffdec7c0b7c58e64ffe56c27db406637cb64c66a2498afd75c223845572ac3a51de1a69f50faa"

--- a/extra-security/yubikey-manager/autobuild/defines
+++ b/extra-security/yubikey-manager/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=yubikey-manager
 PKGSEC=admin
-PKGDEP="click enum34 pcsclite libu2f-host pyscard pyusb \
+PKGDEP="click enum34 pcsclite ccid swig pyscard pyusb \
         yubikey-personalization fido2 pyopenssl"
 BUILDDEP="setuptools"
 PKGDES="Command line and GUI tool for configuring YubiKeys, over all transports"

--- a/extra-security/yubikey-manager/spec
+++ b/extra-security/yubikey-manager/spec
@@ -1,3 +1,3 @@
-VER=3.1.1
-SRCTBL="https://github.com/Yubico/yubikey-manager/archive/yubikey-manager-$VER.tar.gz"
-CHKSUM="sha256::de32cd8a6b1d30c038bdba806c1d0b9eb9b4540c789bb09b13e65f99f2d4c482"
+VER=4.0.1
+SRCS="https://github.com/Yubico/yubikey-manager/releases/download/${VER}/yubikey-manager-${VER}.tar.gz"
+CHKSUMS="sha384::8619ca211172ab50fcb71eaa61f5ef59a2a0ff970172b9455dcea7de854aa683f00db8d781ab39f15cf97cbe00688dd5"

--- a/extra-security/yubikey-manager/spec
+++ b/extra-security/yubikey-manager/spec
@@ -1,3 +1,3 @@
 VER=4.0.1
-SRCS="https://github.com/Yubico/yubikey-manager/releases/download/${VER}/yubikey-manager-${VER}.tar.gz"
+SRCS="https://pypi.io/packages/source/y/yubikey-manager/yubikey-manager-${VER}.tar.gz"
 CHKSUMS="sha384::8619ca211172ab50fcb71eaa61f5ef59a2a0ff970172b9455dcea7de854aa683f00db8d781ab39f15cf97cbe00688dd5"


### PR DESCRIPTION
Topic Description
-----------------
Update `yubikey-manager-qt` to 1.2.1

Package(s) Affected
-------------------
* `fido2`
* `libfido2`
* `libcbor`
* `yubikey-manager`
* `yubikey-manager-qt`

Security Update?
----------------
No

Build Order
-----------
* `libcbor` -> `libfido2` -> `fido2` ->  `yubikey-manager` -> `yubikey-manager-qt`

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

