### PR TITLE
samba: update to 4.14.2

### DIFF
--- a/extra-admin/sssd/spec
+++ b/extra-admin/sssd/spec
@@ -1,3 +1,4 @@
 VER=2.4.0
 SRCS="https://github.com/SSSD/sssd/releases/download/sssd-${VER//./_}/sssd-$VER.tar.gz"
 CHKSUMS="sha256::13d7eeff15e582279f70a3aad32daeb40d3749ec14947a4eded35adce7490cdd"
+REL=1

--- a/extra-database/ldb/autobuild/defines
+++ b/extra-database/ldb/autobuild/defines
@@ -9,4 +9,4 @@ NOPARALLEL=1
 alias BUILD_FINAL='doxygen Doxyfile'
 
 PKGEPOCH=2
-PKGBREAK="sssd<=2.4.0"
+PKGBREAK="sssd<=2.4.0 samba<=4.10.17-1"

--- a/extra-database/ldb/autobuild/defines
+++ b/extra-database/ldb/autobuild/defines
@@ -9,3 +9,4 @@ NOPARALLEL=1
 alias BUILD_FINAL='doxygen Doxyfile'
 
 PKGEPOCH=2
+PKGBREAK="sssd<=2.4.0"

--- a/extra-database/ldb/spec
+++ b/extra-database/ldb/spec
@@ -1,4 +1,3 @@
-VER=1.5.8
-REL=1
-SRCTBL="https://www.samba.org/ftp/pub/ldb/ldb-$VER.tar.gz"
-CHKSUM="sha256::ddf7f770643e0a0dda60f2818913f883caeed37fa1e8d6eda0dfe9588c1e3a83"
+VER=2.3.0
+SRCS="tbl::https://www.samba.org/ftp/pub/ldb/ldb-$VER.tar.gz"
+CHKSUMS="sha256::a4d308b3d0922ef01f3661a69ebc373e772374defa76cf0979ad21b21f91922d"

--- a/extra-gnome/gnome-control-center/spec
+++ b/extra-gnome/gnome-control-center/spec
@@ -1,3 +1,4 @@
 VER=3.38.2
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-control-center/${VER:0:4}/gnome-control-center-$VER.tar.xz"
 CHKSUMS="sha256::1500e0ec0dbbb3f0b9289d084d6987b9430fe444872adbea5ca7fe0cd5f8476c"

--- a/extra-gnome/gnome-vfs/autobuild/defines
+++ b/extra-gnome/gnome-vfs/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=gnome-vfs
 PKGDES="Virtual file system libraries for GNOME"
 PKGSEC=gnome
 PKGDEP="avahi bzip2 gconf gnome-mime-data krb5 libgcrypt samba openssl"
-BUILDDEP="intltool gtk-doc"
+BUILDDEP="intltool gtk-doc gnome-common"
 
 AUTOTOOLS_AFTER="--enable-samba --with-samba-includes=/usr/include/samba-4.0 \
                  --disable-hal --enable-avahi --disable-howl --enable-openssl"

--- a/extra-gnome/gnome-vfs/spec
+++ b/extra-gnome/gnome-vfs/spec
@@ -1,4 +1,4 @@
 VER=2.24.4
-REL=7
+REL=8
 SRCTBL="https://download.gnome.org/sources/gnome-vfs/${VER%.*}/gnome-vfs-$VER.tar.bz2"
 CHKSUM="sha256::62de64b5b804eb04104ff98fcd6a8b7276d510a49fbd9c0feb568f8996444faa"

--- a/extra-kde/kio-extras/spec
+++ b/extra-kde/kio-extras/spec
@@ -1,3 +1,4 @@
 VER=20.12.3
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kio-extras-$VER.tar.xz"
 CHKSUMS="sha256::ba5b90dbbc08ce1a0aeb456e3bba89a328538a41950e7bfa3e04f24b7f6741e2"

--- a/extra-libs/gvfs/spec
+++ b/extra-libs/gvfs/spec
@@ -1,3 +1,4 @@
 VER=1.46.1
+REL=1
 SRCS="https://download.gnome.org/sources/gvfs/${VER:0:4}/gvfs-$VER.tar.xz"
 CHKSUMS="sha256::621ea6c1b9a60b7ed2893938620d3190725a3d9dc65ce5af0fb6c186ee342503"

--- a/extra-libs/liburing/autobuild/build
+++ b/extra-libs/liburing/autobuild/build
@@ -1,0 +1,9 @@
+abinfo "Arch Linux: Configuring..."
+"$SRCDIR"/configure --prefix=/usr \
+            --mandir=/usr/share/man
+
+abinfo "Making..."
+make
+
+abinfo "Installing..."
+make DESTDIR="$PKGDIR" install

--- a/extra-libs/liburing/autobuild/defines
+++ b/extra-libs/liburing/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME="liburing"
+PKGDES="A Kernel async I/O access library for Linux"
+PKGDEP="glibc"
+PKGSEC="libs"

--- a/extra-libs/liburing/spec
+++ b/extra-libs/liburing/spec
@@ -1,0 +1,3 @@
+VER=2.0
+SRCS="git::commit=tags/liburing-$VER::https://git.kernel.dk/cgit/liburing/"
+CHKSUMS="SKIP"

--- a/extra-libs/talloc/spec
+++ b/extra-libs/talloc/spec
@@ -1,4 +1,3 @@
-VER=2.3.1
-REL=3
-SRCTBL="https://www.samba.org/ftp/pub/talloc/talloc-$VER.tar.gz"
-CHKSUM="sha256::ef4822d2fdafd2be8e0cabc3ec3c806ae29b8268e932c5e9a4cd5585f37f9f77"
+VER=2.3.2
+SRCS="tbl::https://www.samba.org/ftp/pub/talloc/talloc-$VER.tar.gz"
+CHKSUMS="sha256::27a03ef99e384d779124df755deb229cd1761f945eca6d200e8cfd9bf5297bd7"

--- a/extra-libs/xine-lib/spec
+++ b/extra-libs/xine-lib/spec
@@ -1,4 +1,4 @@
 VER=1.2.10
 SRCS="tbl::https://sourceforge.net/projects/xine/files/xine-lib/$VER/xine-lib-$VER.tar.xz"
 CHKSUMS="sha256::9cb3f069d3c1ffb7456ea91a936a85bbb07ac2ab7be1e9d0d2c94ffe4110dc57"
-REL=2
+REL=3

--- a/extra-multimedia/ffmpeg/autobuild/build
+++ b/extra-multimedia/ffmpeg/autobuild/build
@@ -73,6 +73,7 @@ if [[ "${CROSS:-$ARCH}" != "i486" && "${CROSS:-$ARCH}" != "powerpc" && "${CROSS:
                 --enable-vaapi \
                 --enable-lto \
                 --enable-libaom \
+                --enable-libsmbclient \
                 $MIPSCONF $PPCCONF $MFX $NVENC
     make
     make tools/qt-faststart

--- a/extra-multimedia/ffmpeg/autobuild/defines
+++ b/extra-multimedia/ffmpeg/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=sound
 PKGDEP="alsa-lib bzip2 fontconfig freetype fribidi gnutls gsm lame libass libbluray \
         libmodplug pulseaudio libssh libtheora libvdpau libvorbis libvpx libxcb \
         x264 x265 opencore-amr opus schroedinger sdl speex v4l-utils xvidcore \
-        zlib soxr libva sdl2 numactl ladspa-sdk xz aom"
+        zlib soxr libva sdl2 numactl ladspa-sdk xz aom samba"
 PKGDEP__AMD64="${PKGDEP} intel-media-sdk libcrystalhd"
 BUILDDEP__AMD64="${BUILDDEP} yasm ffnvcodec"
 BUILDDEP_ARM64="${BUILDDEP} yasm"

--- a/extra-multimedia/ffmpeg/spec
+++ b/extra-multimedia/ffmpeg/spec
@@ -1,4 +1,4 @@
 VER=4.2.4
-REL=5
+REL=6
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::0d5da81feba073ee78e0f18e0966bcaf91464ae75e18e9a0135186249e3d2a0b"

--- a/extra-multimedia/kodi/spec
+++ b/extra-multimedia/kodi/spec
@@ -1,4 +1,5 @@
 VER=19.0
+REL=1
 CODE=Matrix
 SRCS="tbl::rename=kodi::https://github.com/xbmc/xbmc/archive/$VER-$CODE.tar.gz \
       git::commit=4a733e3f10ee41f0d639376b11706d916974ae94;rename=kodi-res::https://github.com/xbmc/repo-resources"

--- a/extra-multimedia/mpd/autobuild/defines
+++ b/extra-multimedia/mpd/autobuild/defines
@@ -10,3 +10,4 @@ BUILDDEP="boost doxygen"
 PKGDES="Flexible, powerful server-side application for playing music"
 
 ABTYPE=meson
+NOLTO__LOONGSON3=1

--- a/extra-multimedia/mpd/spec
+++ b/extra-multimedia/mpd/spec
@@ -1,3 +1,4 @@
 VER=0.21.26
+REL=1
 SRCTBL="http://www.musicpd.org/download/mpd/${VER%.*}/mpd-${VER}.tar.xz"
 CHKSUM="sha256::f9e68221c7a6829ec02f281eb313b2f24182020f5eb65ab22b337e6169ea4eea"

--- a/extra-multimedia/mplayer/spec
+++ b/extra-multimedia/mplayer/spec
@@ -1,4 +1,4 @@
 VER=1.4
-REL=5
+REL=6
 SRCTBL="http://www.mplayerhq.hu/MPlayer/releases/MPlayer-$VER.tar.xz"
 CHKSUM="sha256::82596ed558478d28248c7bc3828eb09e6948c099bbd76bb7ee745a0e3275b548"

--- a/extra-multimedia/vlc/spec
+++ b/extra-multimedia/vlc/spec
@@ -1,3 +1,4 @@
 VER=3.0.12
+REL=1
 SRCS="tbl::https://get.videolan.org/vlc/$VER/vlc-$VER.tar.xz"
 CHKSUMS="sha256::eff458f38a92126094f44f2263c2bf2c7cdef271b48192d0fe7b1726388cf879"

--- a/extra-network/cifs-utils/spec
+++ b/extra-network/cifs-utils/spec
@@ -1,3 +1,4 @@
 VER=6.10
+REL=1
 SRCTBL="https://download.samba.org/pub/linux-cifs/cifs-utils/cifs-utils-$VER.tar.bz2"
 CHKSUM="sha256::92fc29c8e9039637f3344267500f1fa381e2cccd7d10142f0c1676fa575904a7"

--- a/extra-network/freeradius/spec
+++ b/extra-network/freeradius/spec
@@ -1,4 +1,4 @@
 VER=3.0.21
 SRCTBL="https://github.com/FreeRADIUS/freeradius-server/archive/release_${VER//./_}.tar.gz"
 CHKSUM="sha256::b2014372948a92f86cfe2cf43c58ef47921c03af05666eb9d6416bdc6eeaedc2"
-REL=2
+REL=3

--- a/extra-network/samba/autobuild/build
+++ b/extra-network/samba/autobuild/build
@@ -4,11 +4,12 @@ _samba4_pdb_modules=pdb_tdbsam,pdb_ldap,pdb_ads,pdb_smbpasswd,pdb_wbc_sam,pdb_sa
 _samba4_auth_modules=auth_unix,auth_wbc,auth_server,auth_netlogond,auth_script,auth_samba4
 
 abinfo "Configuring Samba ..."
-./configure --enable-fhs \
+"$SRCDIR"/configure --enable-fhs \
             --prefix=/usr \
+            --sysconfdir=/etc \
+            --sbindir=/usr/bin \
             --libdir=/usr/lib \
             --libexecdir=/usr/lib/samba \
-            --with-modulesdir=/usr/lib/samba \
             --localstatedir=/var \
             --with-configdir=/etc/samba \
             --with-lockdir=/var/cache/samba \
@@ -18,14 +19,15 @@ abinfo "Configuring Samba ..."
             --with-ldap \
             --with-winbind \
             --with-acl-support \
-            --enable-gnutls \
+            --with-systemd \
+            --systemd-install-services \
             --with-pam \
-            --with-pam \
-            --with-pie \
-            --with-relro \
             --with-pammodulesdir=/usr/lib/security \
             --bundled-libraries=!tdb,!talloc,!pytalloc-util,!tevent,!popt,!ldb,!pyldb-util \
-            --with-shared-modules=${_samba4_idmap_modules},${_samba4_pdb_modules},${_samba4_auth_modules}
+            --with-shared-modules=${_samba4_idmap_modules},${_samba4_pdb_modules},${_samba4_auth_modules},vfs_io_uring \
+            --disable-rpath-install \
+            --with-cluster-support \
+            --with-profiling-data
 
 abinfo "Building Samba ..."
 make

--- a/extra-network/samba/autobuild/defines
+++ b/extra-network/samba/autobuild/defines
@@ -7,3 +7,8 @@ BUILDDEP="libxslt rpcsvc-proto"
 PKGDES="SMB Fileserver and AD Domain server"
 
 NOSTATIC=0
+PKGBREAK="ldb<=1.5.8-1 cifs-utils<=6.10 gnome-vfs<=2.24.4-7 \
+          freeradius<=3.0.21-2 gnome-control-center<=3.38.2-1 \
+          gvfs<=1.46.1 kio-extras<=20.12.3 kodi<=1:19.0 mpd<=0.21.26 \
+          mplayer<=1:1.4-5 pysmbc<=1.0.22 tdebase<=14.0.7-5 vlc<=3.0.12 \
+          xine-lib<=1.2.10-2"

--- a/extra-network/samba/autobuild/defines
+++ b/extra-network/samba/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=samba
 PKGSEC=net
 PKGDEP="glibc libbsd popt tdb ldb tevent libgcrypt python-3 talloc readline \
-        gnutls openldap cups gamin libcap iniparser libaio lttng-ust gpgme libnsl2"
+        gnutls openldap cups gamin libcap iniparser libaio lttng-ust gpgme \
+        libnsl2 perl-parse-yapp markdown dnspython liburing"
 BUILDDEP="libxslt rpcsvc-proto"
 PKGDES="SMB Fileserver and AD Domain server"
 

--- a/extra-network/samba/spec
+++ b/extra-network/samba/spec
@@ -1,4 +1,3 @@
-VER=4.10.17
-SRCTBL="https://download.samba.org/pub/samba/stable/samba-$VER.tar.gz"
-CHKSUM="sha256::03dc9758e7bfa2faf7cdeb45b4d40997e2ee16a41e71996aa666bc069e70ba3e"
-REL=1
+VER=4.14.2
+SRCS="tbl::https://download.samba.org/pub/samba/stable/samba-$VER.tar.gz"
+CHKSUMS="sha256::95651da478743f7cb407aec81287536c096e3e18bb4981dbe47ca70bf6181f96"

--- a/extra-perl/perl-parse-yapp/autobuild/defines
+++ b/extra-perl/perl-parse-yapp/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="perl-parse-yapp"
+PKGDES="Perl extension for generating and using LALR parsers"
+PKGDEP="perl"
+PKGSEC="perl"
+
+ABHOST="noarch"

--- a/extra-perl/perl-parse-yapp/autobuild/defines
+++ b/extra-perl/perl-parse-yapp/autobuild/defines
@@ -2,5 +2,7 @@ PKGNAME="perl-parse-yapp"
 PKGDES="Perl extension for generating and using LALR parsers"
 PKGDEP="perl"
 PKGSEC="perl"
+PKGREP="samba<=4.10.17-1"
+PKGBREAK="samba<=4.10.17-1"
 
 ABHOST="noarch"

--- a/extra-perl/perl-parse-yapp/spec
+++ b/extra-perl/perl-parse-yapp/spec
@@ -1,0 +1,3 @@
+VER=1.21
+SRCS="tbl::https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-$VER.tar.gz"
+CHKSUMS="sha256::3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5"

--- a/extra-python/pysmbc/spec
+++ b/extra-python/pysmbc/spec
@@ -1,3 +1,4 @@
 VER=1.0.22
+REL=1
 SRCTBL="https://pypi.io/packages/source/p/pysmbc/pysmbc-$VER.tar.gz"
 CHKSUM="sha256::f9ce6f8cf17a2e7867b3cd87b2a47eca04ed955f37937b617088698c06177eba"

--- a/extra-trinity/tdebase/spec
+++ b/extra-trinity/tdebase/spec
@@ -1,4 +1,4 @@
 VER=14.0.7
-REL=5
+REL=6
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/tdebase-trinity-$VER.tar.xz"
 CHKSUMS="sha256::10d241d15ccbf8e13cf696420d0e638a60a27403a79dbcb6a60165b60efcb80e"

--- a/groups/samba-rebuilds
+++ b/groups/samba-rebuilds
@@ -1,0 +1,15 @@
+extra-network/cifs-utils
+extra-multimedia/ffmpeg
+extra-gnome/gnome-vfs
+extra-network/freeradius
+extra-gnome/gnome-control-center
+extra-libs/gvfs
+extra-kde/kio-extras
+extra-multimedia/kodi
+extra-multimedia/mpd
+extra-multimedia/mplayer
+extra-python/pysmbc
+extra-admin/sssd
+extra-trinity/tdebase
+extra-multimedia/vlc
+extra-libs/xine-lib


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update samba to 4.14.2

Package(s) Affected
-------------------

talloc: 2.3.2
liburing: 2.0
perl-parse-yapp: 1.2.0
ldb: 2.3.0
samba: 4.14.2
ffmpeg: 4.2.4-6
sssd: 2.4.0-1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No
<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

liburing talloc ldb perl-parse-yapp samba groups/samba-rebuilds



Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [x] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
