### PR TITLE
linux-firmware: update to newest git and refactor build script

### DIFF
--- a/extra-kernel/linux-firmware/01-nonfree/build
+++ b/extra-kernel/linux-firmware/01-nonfree/build
@@ -1,32 +1,21 @@
-abinfo "Creating installation directories ..."
-mkdir -pv "$PKGDIR"/usr/lib/firmware
+abinfo "Using shell script supplied to install firmware ..."
+./copy-firmware.sh --verbose "${PKGDIR}"/usr/lib/firmware
 
-abinfo "Dropping Makefile ..."
-rm -rv "$SRCDIR"/linux-firmware/Makefile
-
-abinfo "Downloading AP6256 firmware for PineBook Pro ..."
-mkdir -pv "$SRCDIR"/linux-firmware/brcm
-wget https://github.com/armbian/firmware/raw/master/rkwifi/fw_bcm43456c5_ag.bin \
-    -O "$SRCDIR"/linux-firmware/brcm/brcmfmac43456-sdio.bin
-wget https://github.com/armbian/firmware/raw/master/rkwifi/nvram_ap6256.txt \
-    -O "$SRCDIR"/linux-firmware/brcm/brcmfmac43456-sdio.pine64,pinebook-pro.txt
-
-abinfo "Dropping carl9170fw sources ..."
-rm -rv "$SRCDIR"/linux-firmware/carl9170fw/
-
-abinfo "Removing GPL copies for non-free firmware ..."
-rm -v "$SRCDIR"/linux-firmware/GPL-[23]
+abinfo "Copying license details ..."
+cp -v "$SRCDIR"/{WHENCE,LICENSE.*,LICENCE.*,GPL-2,GPL-3} "${PKGDIR}"/usr/lib/firmware/
 
 abinfo "Separating free firmware ..."
 mkdir -pv "$SRCDIR"/firmware-free
-mv -v "$SRCDIR"/{linux-firmware,firmware-nonfree}
 for i in $(cat autobuild/free-list); do
     if echo "$i" | grep -q /; then
         mkdir -pv "$SRCDIR"/firmware-free/$(dirname $i)
     fi
-    mv -v "$SRCDIR"/firmware-{non,}free/$i
+    mv -v "$PKGDIR"/usr/lib/firmware/$i "$SRCDIR"/firmware-free/$i
 done
 
-abinfo "Installing non-free firmware ..."
-cp -av "$SRCDIR"/firmware-nonfree/* \
-    "$PKGDIR"/usr/lib/firmware/
+abinfo "Inserting AP6256 firmware for PineBook Pro ..."
+mkdir -pv "$PKGDIR"/usr/lib/firmware/brcm
+for i in brcmfmac43456-sdio.{bin,clm_blob,AP6256.txt} BCM4345C5.hcd; do
+	cp -v "$SRCDIR"/../$i "$PKGDIR"/usr/lib/firmware/brcm
+done
+ln -sv brcmfmac43456-sdio.AP6256.txt "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43456-sdio.pine64,pinebook-pro.txt

--- a/extra-kernel/linux-firmware/01-nonfree/free-list
+++ b/extra-kernel/linux-firmware/01-nonfree/free-list
@@ -26,3 +26,5 @@ usbduxsigma_firmware.bin
 ath9k_htc/htc_7010-1.4.0.fw
 ath9k_htc/htc_9271-1.4.0.fw
 LICENCE.open-ath9k-htc-firmware
+GPL-2
+GPL-3

--- a/extra-kernel/linux-firmware/spec
+++ b/extra-kernel/linux-firmware/spec
@@ -1,5 +1,12 @@
-VER=20210208
-GITSRC="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git"
-GITCO="b79d2396bc630bfd9b4058459d3e82d7c3428599"
-SUBDIR=.
-CHKSUMS="SKIP"
+VER=20210405
+SRCS="git::commit=af1ca28f03287b0c60682ab37cc684c773de853f::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
+      file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.bin \
+      file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.clm_blob \
+      file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/292e1e5b5bc5756e9314ea6d494d561422d23264/rkwifi/nvram_ap6256.txt \
+      file::rename=BCM4345C5.hcd::https://github.com/armbian/firmware/raw/292e1e5b5bc5756e9314ea6d494d561422d23264/brcm/BCM4345C5.hcd"
+CHKSUMS="SKIP \
+         sha256::ddf83f2100885b166be52d21c8966db164fdd4e1d816aca2acc67ee9cc28d726 \
+         sha256::2dbd7d22fc9af0eb560ceab45b19646d211bc7b34a1dd00c6bfac5dd6ba25e8a \
+         sha256::66c71eb53b47c49d42386b66735134578640b0946f3f46e44f384fef5aacfd9e \
+         sha256::f67164f0eda8d4ca96305e177a61542bf8b470f2f1c456b66fe8c660650f1c7a"
+SUBDIR="linux-firmware"


### PR DESCRIPTION
Topic Description
-----------------

Update linux-firmware to newest git, refactor the build script to correctly create symlinks and update injected AP6256 firmwares.

Package(s) Affected
-------------------

- `firmware-nonfree` 20210405
- `firmware-free` 20210405

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
