### PR TITLE
systemd-boot-friend: update to 0.2.3, use version sort

### DIFF
--- a/extra-admin/systemd-boot-friend/autobuild/overrides/usr/bin/systemd-boot-friend
+++ b/extra-admin/systemd-boot-friend/autobuild/overrides/usr/bin/systemd-boot-friend
@@ -21,7 +21,7 @@ if [[ -d "$ESP_MOUNTPOINT"/EFI/aosc ]]; then
     rm "$ESP_MOUNTPOINT"/EFI/aosc/initramfs-"$DISTRO_NAME"-*.img || true # It is possibel there's nothing yet
     rm "$ESP_MOUNTPOINT"/EFI/aosc/vmlinuz-"$DISTRO_NAME"-* || true
 
-    for i in $(ls /usr/lib/modules | grep -v 'extramodules' | sort -r); do
+    for i in $(ls /usr/lib/modules | grep -v 'extramodules' | sort -V); do
         KERNEL_VER=$(echo $i | cut -d'-' -f1)
         DISTRO_NAME=$(echo $i | cut -d'-' -f2)
         KERNEL_FLAVOR=$(echo $i | cut -d'-' -f3)

--- a/extra-admin/systemd-boot-friend/spec
+++ b/extra-admin/systemd-boot-friend/spec
@@ -1,2 +1,2 @@
-VER=0.2.2
+VER=0.2.3
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

Use version sort in `systemd-boot-friend`

Package(s) Affected
-------------------

`systemd-boot-friend`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] Architecture-independent `noarch`