### PR TITLE
systemd-boot-friend: update to 0.2.4, systemd-boot-friend-init use ES…

### DIFF
--- a/extra-admin/systemd-boot-friend/autobuild/overrides/usr/bin/systemd-boot-friend-init
+++ b/extra-admin/systemd-boot-friend/autobuild/overrides/usr/bin/systemd-boot-friend-init
@@ -15,7 +15,7 @@ source /etc/systemd-boot-friend.conf
 linfo "This script helps you to initialize systemd-boot on AOSC OS."
 
 # Check if /boot/efi is mounted and has a vfat filesystem, according to UEFI specification.
-if ! cat /proc/mounts | grep "/boot/efi vfat" > /dev/null 2>&1 ; then
+if ! cat /proc/mounts | grep "$ESP_MOUNTPOINT vfat" > /dev/null 2>&1 ; then
     linfo "It seems that /boot/efi is not mounted or does not have vfat filesystem. Please mount your ESP to /boot/efi and make sure it has correct filesystem."
     exit 1
 fi

--- a/extra-admin/systemd-boot-friend/spec
+++ b/extra-admin/systemd-boot-friend/spec
@@ -1,2 +1,2 @@
-VER=0.2.3
+VER=0.2.4
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

Use ESP_MOUNTPOINT from config in `systemd-boot-friend-init`

Package(s) Affected
-------------------

`systemd-boot-friend`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] Architecture-independent `noarch`