### PR TITLE
libxkbcommon 1.2.1 + xkeyboard-config 2.30

### DIFF
--- a/extra-libs/libxkbcommon/autobuild/defines
+++ b/extra-libs/libxkbcommon/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libxkbcommon
 PKGDES="Keyboard handling library using XKB data for X11 XCB clients"
-PKGDEP="libxcb"
+PKGDEP="libxcb xkeyboard-config"
 BUILDDEP="doxygen util-macros"
 BUILDDEP__RETRO="util-macros"
 BUILDDEP__ARMEL="${BUILDDEP__RETRO}"

--- a/extra-libs/libxkbcommon/spec
+++ b/extra-libs/libxkbcommon/spec
@@ -1,3 +1,3 @@
-VER=0.9.1
+VER=1.2.1
 SRCTBL="https://xkbcommon.org/download/libxkbcommon-$VER.tar.xz"
-CHKSUM="sha256::d4c6aabf0a5c1fc616f8a6a65c8a818c03773b9a87da9fbc434da5acd1199be0"
+CHKSUM="sha256::e833a7d3024c9bb9d5eb2b20f6d5de08865541f21bb7ba227c83cbd236691fb3"

--- a/extra-x11/xkeyboard-config/autobuild/defines
+++ b/extra-x11/xkeyboard-config/autobuild/defines
@@ -5,5 +5,7 @@ PKGDEP="x11-lib"
 BUILDDEP="intltool x11-app"
 
 AUTOTOOLS_AFTER="--with-xkb-rules-symlink=xorg \
-                 --enable-compat-rules=yes"
+                 --enable-compat-rules=yes \
+                 PYTHON=/usr/bin/python3
+                 "
 ABHOST=noarch

--- a/extra-x11/xkeyboard-config/spec
+++ b/extra-x11/xkeyboard-config/spec
@@ -1,3 +1,3 @@
-VER=2.28
+VER=2.30
 SRCTBL="https://xorg.freedesktop.org/archive/individual/data/xkeyboard-config/xkeyboard-config-$VER.tar.gz"
-CHKSUM="sha256::4424ffaafdf9f09dea69a317709353c4e2b19f69b2405effadce0bac3bdebdff"
+CHKSUM="sha256::105e9cd81999a67001a9e610034a3cb00b7fd3c29b8a32f85c68455b1cc31add"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates `libxkbcommon` to 1.2.1 and `xkeyboard-config` to 2.30. The former now depends on the latter, as `xkbcomp` and other utilities paniks when `/usr/share/X11/xkb` is missing.

Package(s) Affected
-------------------

* `xkeyboard-config`: 2.30 (noarch)
* `libxkbcommon`: 1.2.1

Build Order
-----------

`xkeyboard-config` -> `libxkbcommon`

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
