### PR TITLE
wine: update to 6.7

### DIFF
--- a/extra-emulation/wine/autobuild/amd64/build
+++ b/extra-emulation/wine/autobuild/amd64/build
@@ -1,3 +1,7 @@
+abinfo "Applying Wine Staging patches ..."
+ln -sv "$SRCDIR" "$SRCDIR"/../wine-staging/patches/wine
+"$SRCDIR"/../wine-staging/patches/patchinstall.sh DESTDIR="$SRCDIR" --all
+
 export CC="gcc-multilib-wrapper" CXX="g++-multilib-wrapper"
 
 abinfo "Building Wine (64-bit runtime) ..."

--- a/extra-emulation/wine/autobuild/prepare
+++ b/extra-emulation/wine/autobuild/prepare
@@ -1,7 +1,3 @@
-abinfo "Applying Wine Staging patches ..."
-ln -sv "$SRCDIR" "$SRCDIR"/../wine-staging/patches/wine
-"$SRCDIR"/../wine-staging/patches/patchinstall.sh DESTDIR="$SRCDIR" --all
-
 abinfo "Setting -fPIC ..."
 export CFLAGS="${CFLAGS} -fPIC"
 export LDFLAGS="${LDFLAGS} -fPIC"

--- a/extra-emulation/wine/spec
+++ b/extra-emulation/wine/spec
@@ -1,6 +1,6 @@
-VER=6.4
+VER=6.7
 SRCS="tbl::https://dl.winehq.org/wine/source/${VER:0:1}.x/wine-$VER.tar.xz \
       git::rename=wine-staging;commit=tags/v$VER::https://github.com/wine-staging/wine-staging"
-CHKSUMS="sha256::1b2d2b453d90d6c2d7124e47faeae50e5c54c25f69bee1d06531843261024c8f \
+CHKSUMS="sha256::c30514b7761d4611514ae021cb1e354128d77eff54a283f1401ee702277bbea4 \
          SKIP"
 SUBDIR="wine-$VER"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

wine: update to 6.7

Package(s) Affected
-------------------

wine: 6.7

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->