### PR TITLE
Misaki 8-bit Pixelated Font Family - new, 20191019

### DIFF
--- a/extra-fonts/ttf-misaki/autobuild/build
+++ b/extra-fonts/ttf-misaki/autobuild/build
@@ -1,0 +1,10 @@
+mkdir -p "$PKGDIR"/usr/share/fonts/TTF/
+
+pushd "$PKGDIR"/usr/share/fonts/TTF/
+	abinfo "Extracting archive"
+	unzip "${SRCDIR}/misaki-${PKGVER}.zip"
+	abinfo "Moving readme"
+	mkdir -p "${PKGDIR}/usr/share/doc/${PKGNAME}/"
+	mv misaki.txt "${PKGDIR}/usr/share/doc/${PKGNAME}/"
+	mv readme.txt "${PKGDIR}/usr/share/doc/${PKGNAME}/COPYING"
+popd

--- a/extra-fonts/ttf-misaki/autobuild/build
+++ b/extra-fonts/ttf-misaki/autobuild/build
@@ -1,10 +1,10 @@
-mkdir -p "$PKGDIR"/usr/share/fonts/TTF/
+mkdir -pv "$PKGDIR"/usr/share/fonts/TTF/
 
 pushd "$PKGDIR"/usr/share/fonts/TTF/
 	abinfo "Extracting archive"
 	unzip "${SRCDIR}/misaki-${PKGVER}.zip"
 	abinfo "Moving readme"
-	mkdir -p "${PKGDIR}/usr/share/doc/${PKGNAME}/"
-	mv misaki.txt "${PKGDIR}/usr/share/doc/${PKGNAME}/"
-	mv readme.txt "${PKGDIR}/usr/share/doc/${PKGNAME}/COPYING"
+	mkdir -pv "${PKGDIR}/usr/share/doc/${PKGNAME}/"
+	mv -v misaki.txt "${PKGDIR}/usr/share/doc/${PKGNAME}/"
+	mv -v readme.txt "${PKGDIR}/usr/share/doc/${PKGNAME}/COPYING"
 popd

--- a/extra-fonts/ttf-misaki/autobuild/conffiles
+++ b/extra-fonts/ttf-misaki/autobuild/conffiles
@@ -1,0 +1,1 @@
+/etc/fonts/conf.d/69-misaki.conf

--- a/extra-fonts/ttf-misaki/autobuild/defines
+++ b/extra-fonts/ttf-misaki/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=ttf-misaki
+PKGSEC=fonts
+PKGDES="A 8x8 bitmap font covering JIS Level 1 and 2 characters"
+PKGDEP="fontconfig"
+
+PKGPROV="ttf-misaki-gothic ttf-misaki-mincho ttf-misaki-gothic-2nd"
+ABHOST=noarch

--- a/extra-fonts/ttf-misaki/autobuild/overrides/etc/fonts/conf.avail/69-misaki.conf
+++ b/extra-fonts/ttf-misaki/autobuild/overrides/etc/fonts/conf.avail/69-misaki.conf
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+        <match target="font">
+                <test qual="any" name="family"><string>MisakiGothic2nd</string></test>
+                <test name="size" compare="less">
+                        <double>13</double>
+                </test>
+                <edit name="antialias" mode="assign_replace"><bool>false</bool></edit>
+        </match>
+        <match target="font">
+                <test qual="any" name="family"><string>MisakiGothic</string></test>
+                <test name="size" qual="any" compare="less">
+                        <double>13</double>
+                </test>
+                <edit name="antialias" mode="assign_replace"><bool>false</bool></edit>
+        </match>
+        <match target="font">
+                <test qual="any" name="family"><string>MisakiMincho</string></test>
+                <test name="size" qual="any" compare="less">
+                        <double>13</double>
+                </test>
+                <edit name="antialias" mode="assign_replace"><bool>false</bool></edit>
+        </match>
+</fontconfig>

--- a/extra-fonts/ttf-misaki/autobuild/overrides/etc/fonts/conf.d/69-misaki.conf
+++ b/extra-fonts/ttf-misaki/autobuild/overrides/etc/fonts/conf.d/69-misaki.conf
@@ -1,0 +1,1 @@
+../conf.avail/69-misaki.conf

--- a/extra-fonts/ttf-misaki/spec
+++ b/extra-fonts/ttf-misaki/spec
@@ -1,0 +1,4 @@
+_URL_VER=2019-10-19
+VER=${_URL_VER//-/}
+SRCS="file::rename=misaki-${VER}.zip::https://littlelimit.net/arc/misaki/misaki_ttf_${_URL_VER}.zip"
+CHKSUMS="sha256::a3bb61d161f1fd1bd09ea57e3a923ca54397a469d2ccba7be3119688c5024e88"

--- a/extra-fonts/ttf-misaki/spec
+++ b/extra-fonts/ttf-misaki/spec
@@ -1,4 +1,4 @@
 _URL_VER=2019-10-19
-VER=${_URL_VER//-/}
+VER=${_URL_VER//-/.}
 SRCS="file::rename=misaki-${VER}.zip::https://littlelimit.net/arc/misaki/misaki_ttf_${_URL_VER}.zip"
 CHKSUMS="sha256::a3bb61d161f1fd1bd09ea57e3a923ca54397a469d2ccba7be3119688c5024e88"


### PR DESCRIPTION
Topic Description
-----------------

This single package provides two sans-serif ("gothic") variants and one serif ("mincho") variant in TTF format. The default font configuation turns off anti-aliasing for use case under 12 pt to improve sharpness and readability.

Package(s) Affected
-------------------

+ ttf-misaki: 20191019

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

Post-Merge Architectural Progress
---------------------------------

- [ ] Architecture-independent `noarch`
