### PR TITLE
Nvidia Drivers 460.73.01

### DIFF
--- a/extra-optenv32/nvidia+32/spec
+++ b/extra-optenv32/nvidia+32/spec
@@ -1,6 +1,6 @@
-VER=460.39
+VER=460.73.01
 SRCS="file::rename=NVIDIA-Linux-x86_64-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run \
       tbl::https://github.com/NVIDIA/nvidia-settings/archive/$VER.tar.gz"
-CHKSUMS="sha256::0bf0664078013aa62ed6840caed0637b226884b9398e1fb647e127ad3ad9a37f \
-         sha256::ea4183fcf38f4cdfedbf782f101de57a88e2c38fc25b9bd691b101087da0e5e2"
+CHKSUMS="sha256::11b1c918de26799e9ee3dc5db13d8630922b6aa602b9af3fbbd11a9a8aab1e88 \
+         sha256::2a23283adf30368992e246755b252500f7aba94900b16454f2ae7f4f14eb98b9"
 SUBDIR=.

--- a/extra-x11/nvidia/autobuild/postinst
+++ b/extra-x11/nvidia/autobuild/postinst
@@ -1,6 +1,6 @@
 unset ARCH
 
-DRIVER_VER=460.39
+DRIVER_VER=460.73.01
 
 for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
     if [ -f "/usr/lib/modules/${i}/modules.dep" -a -f "/usr/lib/modules/${i}/modules.order" -a -f "/usr/lib/modules/${i}/modules.builtin" ]; then

--- a/extra-x11/nvidia/autobuild/prerm
+++ b/extra-x11/nvidia/autobuild/prerm
@@ -1,4 +1,4 @@
 unset ARCH
 
-DRIVER_VER=460.39
+DRIVER_VER=460.73.01
 dkms remove nvidia/${DRIVER_VER} --all || true > /dev/null

--- a/extra-x11/nvidia/spec
+++ b/extra-x11/nvidia/spec
@@ -1,6 +1,6 @@
-VER=460.39
+VER=460.73.01
 SRCS="file::rename=NVIDIA-Linux-x86_64-$VER-no-compat32.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER-no-compat32.run \
       tbl::https://github.com/NVIDIA/nvidia-settings/archive/$VER.tar.gz"
-CHKSUMS="sha256::07042bd0c2f5c37b455a973f15561450f789590b8650a6ea573c819591d572a9 \
-         sha256::ea4183fcf38f4cdfedbf782f101de57a88e2c38fc25b9bd691b101087da0e5e2"
+CHKSUMS="sha256::aed95f08df638025b68e9f6551ebf7c31d802fe5c87588219fb602f5a4ea0544 \
+         sha256::2a23283adf30368992e246755b252500f7aba94900b16454f2ae7f4f14eb98b9"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------
The update added support for a few new cards and most importantly works on 5.12rc kernels.

Package(s) Affected
-------------------

* nvidia, nvidia+32: 460.73.0.1

Build Order
-----------

nvidia -> nvidia+32

Architectural Progress
----------------------

- [x] AMD64 `amd64`   

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   

<!-- TODO: CI to auto-fill architectural progress. -->
