### PR TITLE
xmrig: update to 6.12.1

### DIFF
--- a/extra-cryptocurrency/xmrig/autobuild/build
+++ b/extra-cryptocurrency/xmrig/autobuild/build
@@ -1,8 +1,8 @@
 abinfo "Running CMake for $PKGNAME ..."
-cmake "$SRCDIR" ${CMAKE_DEF}
+cmake "$SRCDIR" -GNinja ${CMAKE_DEF}
 
 abinfo "Building $PKGNAME ..."
-make
+ninja
 
 abinfo "Installing $PKGNAME executable ..."
 install -Dvm755 "$SRCDIR"/xmrig \

--- a/extra-cryptocurrency/xmrig/spec
+++ b/extra-cryptocurrency/xmrig/spec
@@ -1,3 +1,3 @@
-VER=6.7.1
+VER=6.12.1
 SRCS="tbl::https://github.com/xmrig/xmrig/archive/v$VER.tar.gz"
-CHKSUMS="sha256::72202ba211a7554b9a45bb1f633dcf132656fcdb83a778f1754d08d6988ec672"
+CHKSUMS="sha256::7570030c4b3e257bda190a100dc59f78b74c823af7561222a99b296f5e7b1ac2"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

update xmrig to v6.12.1

Package(s) Affected
-------------------

`xmrig` v6.12.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

<!-- TODO: CI to auto-fill architectural progress. -->
