### PR TITLE
ykdl: update to 1.7.0+git20210410

### DIFF
--- a/extra-multimedia/ykdl/spec
+++ b/extra-multimedia/ykdl/spec
@@ -1,3 +1,3 @@
 VER=1.6.3+git20210217
-GITSRC="https://github.com/zhangn1985/ykdl.git"
-GITCO="85ae82d520ea3d2fa1f9b52d82d052f5157aa4a7"
+SRCS="commit=85ae82d520ea3d2fa1f9b52d82d052f5157aa4a7::https://github.com/zhangn1985/ykdl.git"
+

--- a/extra-multimedia/ykdl/spec
+++ b/extra-multimedia/ykdl/spec
@@ -1,3 +1,3 @@
-VER=1.6.3+git20210217
+VER=1.6.3+git20210410
 SRCS="commit=85ae82d520ea3d2fa1f9b52d82d052f5157aa4a7::https://github.com/zhangn1985/ykdl.git"
-
+CHKSUMS="SKIP"

--- a/extra-multimedia/ykdl/spec
+++ b/extra-multimedia/ykdl/spec
@@ -1,3 +1,3 @@
 VER=1.6.3+git20210217
 GITSRC="https://github.com/zhangn1985/ykdl.git"
-GITCO="e95d9436198957997745a2ad193a7d2ea41f2b2b"
+GITCO="85ae82d520ea3d2fa1f9b52d82d052f5157aa4a7"


### PR DESCRIPTION
Topic Description
-----------------
Update `ykdl` to  1.7.0+git20210410


Package(s) Affected
-------------------
* `ykdl`


Security Update?
----------------
No

Architectural Progress
----------------------
- [x] Architecture-independent `noarch` -->

Post-Merge Architectural Progress
---------------------------------
 - [ ] 32-bit Optional Environment `optenv32` -->

