### PR TITLE
kitty: update to 0.20.1

### DIFF
--- a/extra-utils/kitty/spec
+++ b/extra-utils/kitty/spec
@@ -1,3 +1,3 @@
-VER=0.19.3
+VER=0.20.1
 SRCS="https://github.com/kovidgoyal/kitty/archive/v$VER.tar.gz"
-CHKSUMS="whirlpool::a7cf52e55bd9a71c9dc001946aedb73229a611f1c84a7ed5358cdf1e61d8d418c1900ff943c4cf75f400194abb0f5eb3bc2dbfe6aa1e3d25950c25dfb55ba1d5"
+CHKSUMS="whirlpool::bb93c97103f5165f5ab5d8d52fb84342beaf3f05981cf0b5a0dcb0d18cbd8d91d4e85a8cdb683aead353d16be51a4ea2a531b4ffe4317a30eafb8202b5ac3dcd"


### PR DESCRIPTION
Topic Description
-----------------
Update `kitty` to version 0.20.1

Package(s) Affected
-------------------
*  kitty

Security Update?
----------------
No

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
