### PR TITLE
ykdl: add missing git identifier in ACBS spec file

### DIFF
--- a/extra-multimedia/ykdl/spec
+++ b/extra-multimedia/ykdl/spec
@@ -1,3 +1,3 @@
 VER=1.6.3+git20210410
-SRCS="commit=85ae82d520ea3d2fa1f9b52d82d052f5157aa4a7::https://github.com/zhangn1985/ykdl.git"
+SRCS="git::commit=85ae82d520ea3d2fa1f9b52d82d052f5157aa4a7::https://github.com/zhangn1985/ykdl.git"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------
* Rework for `ykdl-1.7.0+git20210410`

Package(s) Affected
-------------------
* `ykdl`

Security Update?
----------------
No 

Architectural Progress
----------------------
- [x] Architecture-independent `noarch` -->

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [x] Architecture-independent `noarch` -->
