### PR TITLE
xf86-video-intel: re-enable DRI2

### DIFF
--- a/extra-x11/xf86-video-intel/autobuild/defines
+++ b/extra-x11/xf86-video-intel/autobuild/defines
@@ -5,8 +5,7 @@ PKGDEP="mesa pixman xcb-util xorg-server"
 PKGDES="XF86 driver for Intel GPUs"
 
 AUTOTOOLS_AFTER="--libexecdir=/usr/lib \
-                 --with-default-dri=3 --enable-kms-only \
-                 --disable-dri2"
+                 --with-default-dri=3 --enable-kms-only"
 AUTOTOOLS_AFTER__RETRO=" \
                  --libexecdir=/usr/lib \
                  --with-default-dri=2 --enable-kms-only \

--- a/extra-x11/xf86-video-intel/spec
+++ b/extra-x11/xf86-video-intel/spec
@@ -1,4 +1,4 @@
 VER=20191127
-REL=1
+REL=2
 GITSRC="git://anongit.freedesktop.org/xorg/driver/xf86-video-intel"
 GITCO="0867eea666c654961d6dabe49b9afc3802545f32"


### PR DESCRIPTION
Topic Description
-----------------

Enable DRI2 to allow 3D acceleration on i915.

Package(s) Affected
-------------------

- `xf86-video-intel`

Security Update?
----------------

No

Architectural Progress
----------------------

- [ ] AMD64 `amd64`   

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   

<!-- TODO: CI to auto-fill architectural progress. -->
