### PR TITLE
adobe-source-han-sans: update to 2.004

### DIFF
--- a/extra-fonts/adobe-source-han-sans/spec
+++ b/extra-fonts/adobe-source-han-sans/spec
@@ -1,3 +1,3 @@
-VER=2.003
+VER=2.004
 SRCS="tbl::https://github.com/adobe-fonts/source-han-sans/archive/${VER}R.tar.gz"
-CHKSUMS="sha256::e45dbc130643e5dd3736940bdf77a09c4b79ea399dc20f2a5e86225f2995f2b1"
+CHKSUMS="sha256::843ea10b498156115a1fe5c524a00fa99dfda63e05f47a0ea1752852ecd90a9c"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

adobe-source-han-sans: update to 2.004

Package(s) Affected
-------------------

adobe-source-han-sans: 2.004

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->
No
<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch` 

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

 - [x] Architecture-independent `noarch` 