### PR TITLE
samba: fix gnome-control-center install

### DIFF
--- a/extra-network/samba/autobuild/defines
+++ b/extra-network/samba/autobuild/defines
@@ -8,7 +8,7 @@ PKGDES="SMB Fileserver and AD Domain server"
 
 NOSTATIC=0
 PKGBREAK="ldb<=1.5.8-1 cifs-utils<=6.10 gnome-vfs<=2.24.4-7 \
-          freeradius<=3.0.21-2 gnome-control-center<=3.38.2-1 \
+          freeradius<=3.0.21-2 gnome-control-center<=3.38.2 \
           gvfs<=1.46.1 kio-extras<=20.12.3 kodi<=1:19.0 mpd<=0.21.26 \
           mplayer<=1:1.4-5 pysmbc<=1.0.22 tdebase<=14.0.7-5 vlc<=3.0.12 \
           xine-lib<=1.2.10-2"

--- a/extra-network/samba/spec
+++ b/extra-network/samba/spec
@@ -1,3 +1,4 @@
 VER=4.14.2
+REL=1
 SRCS="tbl::https://download.samba.org/pub/samba/stable/samba-$VER.tar.gz"
 CHKSUMS="sha256::95651da478743f7cb407aec81287536c096e3e18bb4981dbe47ca70bf6181f96"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

samba: fix gnome-control-center install

Package(s) Affected
-------------------

samba: 4.14.2-1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
