### PR TITLE
arch-install-scripts: update to 24

### DIFF
--- a/extra-admin/archlinux-keyring/spec
+++ b/extra-admin/archlinux-keyring/spec
@@ -1,3 +1,3 @@
-VER=20201210
+VER=20210110
 SRCS="https://sources.archlinux.org/other/archlinux-keyring/archlinux-keyring-${VER}.tar.gz"
-CHKSUMS="sha256::e350246064c36911b7bb816fae4f59bc91e69912309c2ca7ad80caf6f2ba4117"
+CHKSUMS="sha256::af00d6d439192a052aa1ea50325c5e05fbbbfe30b10453873e8f700ed2e3a886"

--- a/extra-utils/arch-install-scripts/spec
+++ b/extra-utils/arch-install-scripts/spec
@@ -1,5 +1,3 @@
-VER=23
-REL=2
-GITCO="tags/v$VER"
-GITSRC="https://git.archlinux.org/arch-install-scripts.git"
-
+VER=24
+SRCS="git::commit=tags/v$VER::https://git.archlinux.org/arch-install-scripts.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

arch-install-scripts (arch-chroot, genfstab, pacstrap): update to 24

Package(s) Affected
-------------------

arch-chroot: 24
genfstab: 24
pacstrap: 24
archlinux-keyring: 20210110

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

archlinux-keyring arch-install-scripts

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

 - [x] Architecture-independent `noarch` 

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch` 