### PR TITLE
nix-user-chroot: update to 1.2.2

### DIFF
--- a/extra-utils/nix-user-chroot/spec
+++ b/extra-utils/nix-user-chroot/spec
@@ -1,3 +1,3 @@
-VER=1.2.1
+VER=1.2.2
 SRCS="tbl::https://github.com/nix-community/nix-user-chroot/archive/$VER.tar.gz"
-CHKSUMS="sha256::fb653d41f5505baa9b265f5007cf472031c98231a9cdd86dc5d1c0fc2f244c04"
+CHKSUMS="sha256::ef5fb2efae28ea4e9f9fbe9b4d4c021bc6edcd87f73a63624ad81c239df517e3"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

nix-user-chroot: update to 1.2.2

Package(s) Affected
-------------------

nix-user-chroot: 1.2.2

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->