### PR TITLE
scipy: update to 1.6.3

### DIFF
--- a/extra-python/scipy/spec
+++ b/extra-python/scipy/spec
@@ -1,4 +1,3 @@
-VER=1.4.1
-SRCTBL="https://github.com/scipy/scipy/archive/v$VER.tar.gz"
-CHKSUM="sha256::fd8c7b907c3fc4df1830cdce1608057248deb30afa34ac4f8f31c3784b3e4e53"
-REL=1
+VER=1.6.3
+SRCS="tbl::https://github.com/scipy/scipy/archive/v${VER}.tar.gz"
+CHKSUMS="sha256::6cdb9d3aabe46c1602d9fd2f34812700068eddfe3ffd1dafcbd7e7960a874e1c"


### PR DESCRIPTION
Topic Description
-----------------

Update `scipy` to 1.6.3

Package(s) Affected
-------------------

`scipy`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`