### PR TITLE
v2ray: update to 4.39.0

### DIFF
--- a/extra-network/v2ray/spec
+++ b/extra-network/v2ray/spec
@@ -1,3 +1,3 @@
-VER=4.38.3
+VER=4.39.0
 SRCS="https://github.com/v2fly/v2ray-core/archive/v$VER.tar.gz"
-CHKSUMS="sha256::b06d2bf63fd08d8a92d51824f69e41345bd90d747d444ca37770b2017a2a5a00"
+CHKSUMS="sha256::a974640ba34c83945e608ec7222f0dce25487b2c10703ac617242c0fd8149507"

--- a/extra-network/v2ray/spec
+++ b/extra-network/v2ray/spec
@@ -1,3 +1,3 @@
-VER=4.39.0
+VER=4.39.1
 SRCS="https://github.com/v2fly/v2ray-core/archive/v$VER.tar.gz"
-CHKSUMS="sha256::a974640ba34c83945e608ec7222f0dce25487b2c10703ac617242c0fd8149507"
+CHKSUMS="sha256::461964e374f04c9f7a593d819c09c16b3ecb10a1456a1f375c19aa7ca2c3f2ab"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

v2ray: update to 4.39.0

Package(s) Affected
-------------------

v2ray: 4.39.0

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
