### PR TITLE
spamassassin: security update to 3.4.6

### DIFF
--- a/extra-network/spamassassin/autobuild/build
+++ b/extra-network/spamassassin/autobuild/build
@@ -1,8 +1,18 @@
+abinfo "Configuring $PKGNAME ..."
 export PERL_USE_UNSAFE_INC=1
-PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor \
-    CONTACT_ADDRESS=root@localhost ENABLE_SSL=yes PERL_TAINT=no
+PERL_MM_USE_DEFAULT=1 \
+perl Makefile.PL \
+    INSTALLDIRS=vendor \
+    CONTACT_ADDRESS=root@localhost \
+    ENABLE_SSL=yes \
+    PERL_TAINT=no
+
+abinfo "Building $PKGNAME ..."
 make 
 
-make DESTDIR="$PKGDIR" install
+abinfo "Installing $PKGNAME ..."
+make install DESTDIR="$PKGDIR"
 
-install -d -o 182 -g 182 -m 755 "$PKGDIR"/var/lib/spamassassin
+abinfo "Creating daemon directory ..."
+install -dv -o 182 -g 182 -m 755 \
+    "$PKGDIR"/var/lib/spamassassin

--- a/extra-network/spamassassin/autobuild/patch
+++ b/extra-network/spamassassin/autobuild/patch
@@ -1,7 +1,0 @@
-sed -i t/sa_compile.t \
-	  -e 's#/foo/bin/spamassassin#/foo/bin/site_perl/spamassassin#' \
-	  -e 's#/foo/bin/sa-compile#/foo/bin/site_perl/sa-compile#'
-
-for i in autobuild/patches/*; do
-    patch -Np1 -i $i
-done

--- a/extra-network/spamassassin/autobuild/postinst
+++ b/extra-network/spamassassin/autobuild/postinst
@@ -1,1 +1,2 @@
+sa-update --verbose
 chown 182:182 /var/lib/spamassassin

--- a/extra-network/spamassassin/spec
+++ b/extra-network/spamassassin/spec
@@ -1,3 +1,3 @@
-VER=3.4.4
-SRCTBL="http://www.us.apache.org/dist/spamassassin/source/Mail-SpamAssassin-$VER.tar.gz"
-CHKSUM="sha256::8ea27a165b81e3ce8c84ae85c3ecba1f2edfa04ef4a86f07fe28ab612fc8ff60"
+VER=3.4.6
+SRCS="tbl::http://www.us.apache.org/dist/spamassassin/source/Mail-SpamAssassin-$VER.tar.gz"
+CHKSUMS="sha256::500c7e2a7cdf3aa4dd822d97aaff2ab22235a60cf17a68ab817861d215a4e568"


### PR DESCRIPTION
Topic Description
-----------------

Update SpamAssassin to v3.4.6 to address a security vulnerability.

Package(s) Affected
-------------------

`spamassassin` v3.4.6

Security Update?
----------------

Yes, #2924 

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`