### PR TITLE
django: security update to 3.2.2

### DIFF
--- a/extra-python/django/autobuild/defines
+++ b/extra-python/django/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=django
 PKGSEC=python
 PKGDES="A high-level Python Web framework that encourages rapid development and clean design"
-PKGDEP="psycopg2 pytz"
+PKGDEP="asgiref psycopg2 pytz sqlparse"
 BUILDDEP="setuptools"
 
 ABTYPE=python

--- a/extra-python/django/spec
+++ b/extra-python/django/spec
@@ -1,3 +1,3 @@
-VER=3.0.7
-SRCTBL="https://github.com/django/django/archive/$VER.tar.gz"
-CHKSUM="sha256::a62c53a42a354516cbaa630a01db732fff3f1720a25bd429482f9b5397521fdf"
+VER=3.2.2
+SRCS="tbl::https://github.com/django/django/archive/$VER.tar.gz"
+CHKSUMS="sha256::20723bbad6c7206d128894926e5d694f3a5041ae76c81949ce9b622c723730a9"

--- a/extra-python/sqlparse/autobuild/patch
+++ b/extra-python/sqlparse/autobuild/patch
@@ -1,1 +1,0 @@
-sed -i '/argparse/d' requirements.txt

--- a/extra-python/sqlparse/sqlsparse/autobuild/defines
+++ b/extra-python/sqlparse/sqlsparse/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=sqlparse
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="A non-validating SQL parser for Python"
+
+ABHOST=noarch

--- a/extra-python/sqlparse/sqlsparse/spec
+++ b/extra-python/sqlparse/sqlsparse/spec
@@ -1,0 +1,3 @@
+VER=0.4.1
+SRCS="tbl::https://pypi.io/packages/source/s/sqlparse/sqlparse-$VER.tar.gz"
+CHKSUMS="sha256::1e0fd23e81e27fe57c627b7c00684064741e8cad526f082fe4e252bb5e1d411d"


### PR DESCRIPTION
Topic Description
-----------------

Update Django to v3.2.2 to address security vulnerabilities.

Package(s) Affected
-------------------

- `sqlparse` v0.4.1
- `django` v3.2.2

Security Update?
----------------

Yes, #2925 

Build Order
-----------

```
sqlparse django
```

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`