### PR TITLE
privoxy: security update to 3.0.32

### DIFF
--- a/extra-network/privoxy/autobuild/build
+++ b/extra-network/privoxy/autobuild/build
@@ -15,8 +15,8 @@ install -Dvm755 "$SRCDIR"/privoxy \
     "$PKGDIR"/usr/bin/privoxy
 
 abinfo "Installing Privoxy man page ..."
-install -Dvm644 "$SRCDIR"/privoxy.1 \
-    "$PKGDIR"/usr/share/man/man1/privoxy.1
+install -Dvm644 "$SRCDIR"/privoxy.8 \
+    "$PKGDIR"/usr/share/man/man1/privoxy.8
 
 abinfo "Installing Privoxy log directory ..."
 install -dvo442 -g442 "$PKGDIR"/var/log/privoxy

--- a/extra-network/privoxy/autobuild/conffiles
+++ b/extra-network/privoxy/autobuild/conffiles
@@ -1,8 +1,9 @@
+/etc/logrotate.d/privoxy
 /etc/privoxy/config
-/etc/privoxy/trust
-/etc/privoxy/match-all.action
 /etc/privoxy/default.action
 /etc/privoxy/default.filter
+/etc/privoxy/match-all.action
+/etc/privoxy/regression-tests.action
+/etc/privoxy/trust
 /etc/privoxy/user.action
 /etc/privoxy/user.filter
-/etc/logrotate.d/privoxy

--- a/extra-network/privoxy/spec
+++ b/extra-network/privoxy/spec
@@ -1,4 +1,3 @@
-VER=3.0.28
-REL=1
-SRCTBL="https://www.privoxy.org/sf-download-mirror/Sources/${VER}%20%28stable%29/privoxy-$VER-stable-src.tar.gz"
-CHKSUM="sha256::b5d78cc036aaadb3b7cf860e9d598d7332af468926a26e2d56167f1cb6f2824a"
+VER=3.0.32
+SRCS="tbl::https://www.privoxy.org/sf-download-mirror/Sources/${VER}%20%28stable%29/privoxy-$VER-stable-src.tar.gz"
+CHKSUMS="sha256::c61de4008c62445ec18f1f270407cbf2372eaba93beaccdc9e3238bb2defeed7"


### PR DESCRIPTION
Topic Description
-----------------

Update Privoxy to v3.0.32 to address security vulnerabilities.

Package(s) Affected
-------------------

`privoxy` v3.0.32

Security Update?
----------------

Yes, #2926 

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`