### PR TITLE
libass{,+32}: security update to 0.15.1

### DIFF
--- a/extra-multimedia/libass/autobuild/defines
+++ b/extra-multimedia/libass/autobuild/defines
@@ -12,10 +12,8 @@ BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
-AUTOTOOLS_AFTER="--enable-harfbuzz \
-                 --enable-fontconfig"
+AUTOTOOLS_AFTER="--enable-fontconfig"
 AUTOTOOLS_AFTER__RETRO=" \
-                 --disable-harfbuzz \
                  --enable-fontconfig"
 AUTOTOOLS_AFTER__ARMEL="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__ARMHF="${AUTOTOOLS_AFTER__RETRO}"

--- a/extra-multimedia/libass/spec
+++ b/extra-multimedia/libass/spec
@@ -1,4 +1,3 @@
-VER=0.14.0
-REL=3
-SRCTBL="https://github.com/libass/libass/releases/download/$VER/libass-$VER.tar.xz"
-CHKSUM="sha256::881f2382af48aead75b7a0e02e65d88c5ebd369fe46bc77d9270a94aa8fd38a2"
+VER=0.15.1
+SRCS="tbl::https://github.com/libass/libass/releases/download/$VER/libass-$VER.tar.xz"
+CHKSUMS="sha256::1cdd39c9d007b06e737e7738004d7f38cf9b1e92843f37307b24e7ff63ab8e53"

--- a/extra-optenv32/libass+32/autobuild/defines
+++ b/extra-optenv32/libass+32/autobuild/defines
@@ -4,7 +4,8 @@ PKGSEC=libs
 PKGDEP="enca+32 fontconfig+32 fribidi+32"
 BUILDDEP="yasm 32subsystem"
 
-AUTOTOOLS_AFTER="--enable-enca --enable-harfbuzz --enable-fontconfig"
+AUTOTOOLS_AFTER="--enable-enca \
+                 --enable-fontconfig"
 NOLTO=1
 ABHOST=noarch
 PKGBREAK="ffmpeg+32<=3.2.2-1"

--- a/extra-optenv32/libass+32/spec
+++ b/extra-optenv32/libass+32/spec
@@ -1,4 +1,3 @@
-VER=0.14.0
-REL=2
-SRCTBL="https://github.com/libass/libass/releases/download/$VER/libass-$VER.tar.xz"
-CHKSUM="sha256::881f2382af48aead75b7a0e02e65d88c5ebd369fe46bc77d9270a94aa8fd38a2"
+VER=0.15.1
+SRCS="tbl::https://github.com/libass/libass/releases/download/$VER/libass-$VER.tar.xz"
+CHKSUMS="sha256::1cdd39c9d007b06e737e7738004d7f38cf9b1e92843f37307b24e7ff63ab8e53"


### PR DESCRIPTION
Topic Description
-----------------

Update libass to v0.15.1 to address security vulnerabilities.

Package(s) Affected
-------------------

`libass`, `libass+32` v0.15.1

Security Update?
----------------

Yes, #2928 

Build Order
-----------

```
libass libass+32
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit Optional Environment `optenv32`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit Optional Environment `optenv32`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
