### PR TITLE
handbrake: (ppc64el) disable x265 on due to build failure

### DIFF
--- a/extra-multimedia/handbrake/autobuild/build
+++ b/extra-multimedia/handbrake/autobuild/build
@@ -1,11 +1,20 @@
-abinfo "Configuring Handbrake ..."
 if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
-    ./configure --prefix=/usr \
-                --enable-nvenc
+    export NVENC="--enable-nvenc"
 else
-    ./configure --prefix=/usr \
-		--disable-nvenc
+    export NVENC="--disable-nvenc"
 fi
+
+if [[ "${CROSS:-$ARCH}" = "ppc64el" ]]; then
+    export NVENC="--disable-x265"
+else
+    export NVENC="--enable-x265"
+fi
+
+abinfo "Configuring Handbrake ..."
+"$SRCDIR"/configure \
+     --prefix=/usr \
+     ${X265} \
+     ${NVENC}
 
 abinfo "Building Handbrake ..."
 make -C "$SRCDIR"/build

--- a/extra-multimedia/handbrake/autobuild/defines
+++ b/extra-multimedia/handbrake/autobuild/defines
@@ -4,6 +4,7 @@ PKGDEP="bzip2 dbus-glib desktop-file-utils fontconfig fribidi gst-libav-1-0 \
         gst-plugins-good-1-0 gtk-3 hicolor-icon-theme jansson lame libass \
         libdvdnav libgudev libnotify libogg librsvg libsamplerate libtheora \
         libvorbis libxml2 x264 x265 fdkaac ffmpeg libbluray"
+PKGDEP__PPC64EL="${PKGDEP/x265/}"
 BUILDDEP="nasm intltool"
 BUILDDEP__AMD64="${BUILDDEP} yasm"
 PKGDES="A tool for converting video from nearly any format to a selection of modern, widely supported codecs"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
