### PR TITLE
GNOME 40 Reworks

### DIFF
--- a/extra-gnome/adwaita-icon-theme/spec
+++ b/extra-gnome/adwaita-icon-theme/spec
@@ -1,3 +1,3 @@
-VER=40
+VER=40.0
 SRCS="https://download.gnome.org/sources/adwaita-icon-theme/${VER:0:2}/adwaita-icon-theme-${VER/\~/.}.tar.xz"
 CHKSUMS="sha256::1f2bca34f60357ab91b7db91c5e919ad36775e094138dffc870bb5f97b0dbbb2"

--- a/extra-gnome/gnome-themes-standard/autobuild/defines
+++ b/extra-gnome/gnome-themes-standard/autobuild/defines
@@ -2,6 +2,6 @@ PKGNAME=gnome-themes-standard
 PKGSEC=gnome
 PKGDEP="cantarell-fonts librsvg"
 PKGSUG="gtk-engines-2"
-BUILDDEP="gtk-2 gtk-3 intltool"
+BUILDDEP="gtk-2 gtk-3 gtk-4 intltool"
 PKGDES="Default themes for the GNOME desktop"
 

--- a/extra-gnome/gnome-themes-standard/spec
+++ b/extra-gnome/gnome-themes-standard/spec
@@ -1,4 +1,4 @@
 VER=3.27.90
-SRCTBL="https://download.gnome.org/sources/gnome-themes-standard/${VER:0:4}/gnome-themes-standard-$VER.tar.xz"
-CHKSUM="sha256::ffc7ccb5458ae4ef2501c49d84d3af150ca3b70c9b239e7ba6c05fe1405d31dc"
-REL=1
+REL=2
+SRCS="tbl::https://download.gnome.org/sources/gnome-themes-standard/${VER:0:4}/gnome-themes-standard-$VER.tar.xz"
+CHKSUMS="sha256::ffc7ccb5458ae4ef2501c49d84d3af150ca3b70c9b239e7ba6c05fe1405d31dc"


### PR DESCRIPTION
Topic Description
-----------------

Rework `adwaita-icon-theme` and `gnome-themes-standard` to fix build.

Package(s) Affected
-------------------

- `adwaita-icon-theme` v40.0
- `gnome-themes-standard` v3.27.90-1

Security Update?
----------------

No

Architectural Progress
----------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`