### PR TITLE
openjdk-8: security update to 8u292

### DIFF
--- a/extra-java/icedtea-web/spec
+++ b/extra-java/icedtea-web/spec
@@ -1,4 +1,3 @@
-VER=1.8.4
-REL=3
+VER=1.8.6
 SRCTBL="https://github.com/AdoptOpenJDK/IcedTea-Web/archive/icedtea-web-$VER.tar.gz"
-CHKSUM="sha256::a0c12cd2d7793f05428a02e49159c7f3f70694f48e23787ffdb6588b0db7c862"
+CHKSUM="sha256::a53d79e165e8a0c9f321f754cdc48f2e8a81978f9502ab454fdbb1134a650134"

--- a/extra-java/openjdk-8/autobuild/defines
+++ b/extra-java/openjdk-8/autobuild/defines
@@ -1,11 +1,11 @@
 PKGNAME=openjdk-8
 PKGSEC=java
 PKGDEP="ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 cups fontconfig unzip zip cpio"
-BUILDDEP="npapi-sdk openjdk-8 rustc"
+BUILDDEP="npapi-sdk openjdk-8"
 BUILDDEP__POWERPC="${BUILDDEP} libffi"
 PKGDES="OpenJDK Java Runtime Environment (JRE), Java Development Environment (JDK), and IcedTea-Web"
 
-PKGPROV="icedtea icedtea-web jre-openjdk jre8-openjdk openjdk8"
+PKGPROV="icedtea jre-openjdk jre8-openjdk openjdk8"
 PKGREP="openjdk<=9u00b00"
 PKGBREAK="openjdk<=9u00b00"
 NOPARALLEL=1

--- a/extra-java/openjdk-8/spec
+++ b/extra-java/openjdk-8/spec
@@ -1,11 +1,7 @@
-VER=8u282+ga
-# aarch64 specific tarball
-SRCS__ARM64="https://repo.aosc.io/aosc-repacks/aarch64-java/openjdk-${VER/+/-}.tar.xz"
-CHKSUMS__ARM64="sha256::37d7218f27377638c17978cbfb4f7bbd2c1e80f2d925f68dc46267cad5f29532"
+VER=8u292+ga
 # loongson3 specific tarball
 SRCS__LOONGSON3="https://repo.aosc.io/aosc-repacks/ls3-java/openjdk-${VER/+/-}.tar.xz"
 CHKSUMS__LOONGSON3="sha256::64f12078dcf69274ab16ca1e3b80d1f24b7c2d921176c594c10e8e23802ebf2c"
 
 SRCS="https://openjdk-sources.osci.io/openjdk8/openjdk${VER/+/-}.tar.xz"
-CHKSUMS="sha256::e5c0000d54fea680375ab06e6d477713fb5c294d84baf0ed6224498bde811b7c"
-REL=1
+CHKSUMS="sha256::9008c700c699739e185ee5b1b4554b769a81492f9b3358634cd693ce75668b3f"

--- a/extra-java/openjfx-8/spec
+++ b/extra-java/openjfx-8/spec
@@ -1,4 +1,4 @@
 VER=8u202+ga
-REL=6
+REL=7
 SRCTBL="https://repo.aosc.io/aosc-repacks/openjfx-8u202-ga.tar.bz2"
 CHKSUM="sha256::12b0538d04c4bd451e4692ee06357ac36233ff4ec2af9fa3b9bbdbab48c3f2fc"


### PR DESCRIPTION
Topic Description
-----------------

Security update for OpenJDK 8u LTS branch

Package(s) Affected
-------------------

```
openjdk-8
icedtea-web
openjfx-8
```

Security Update?
----------------

**Yes** - Issue Number: #3049 

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

