### PR TITLE
openjdk: security update to 11.0.11

### DIFF
--- a/extra-java/openjdk/spec
+++ b/extra-java/openjdk/spec
@@ -1,3 +1,3 @@
-VER=11.0.10+ga
+VER=11.0.11+ga
 SRCS="tbl::https://openjdk-sources.osci.io/openjdk11/openjdk-${VER/+/-}.tar.xz"
-CHKSUMS="sha256::0a47ab9df5169bbcaec0c96063caa5912d6be1aa75349c93bf970e7ce34869de"
+CHKSUMS="sha256::a00f8cf0c1edbefb767bce893a74b170478cb9bf152224b215aa59e7b431079c"

--- a/extra-java/openjfx/autobuild/patches/0003-fix-fxpackager-include.patch
+++ b/extra-java/openjfx/autobuild/patches/0003-fix-fxpackager-include.patch
@@ -1,0 +1,14 @@
+--- rt-81e1980f9d54/modules/jdk.packager/src/main/native/library/common/PosixPlatform.cpp	2021-02-15 00:11:13.000000000 -0800
++++ rt-81e1980f9d54-new/modules/jdk.packager/src/main/native/library/common/PosixPlatform.cpp	2021-05-10 02:28:42.581351966 -0700
+@@ -43,7 +43,11 @@
+ #include <stdbool.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#ifdef linux
++#include <linux/sysctl.h>
++#else
+ #include <sys/sysctl.h>
++#endif
+ #include <sys/file.h>
+ #include <sys/stat.h>
+ #include <sys/wait.h>

--- a/extra-java/openjfx/spec
+++ b/extra-java/openjfx/spec
@@ -1,3 +1,3 @@
-VER=11.0.9+4
+VER=11.0.11+1
 SRCTBL="https://repo.aosc.io/aosc-repacks/openjfx-${VER}.tar.xz"
-CHKSUM="sha256::026535f717de40c34c31a799b7765046f9e6162bcd2338c5b38ff57d7149b189"
+CHKSUM="sha256::ec3fad515e30c7ccadc8381e4dcf1be322834dbd8051aba6a76499cb2afffc3e"


### PR DESCRIPTION
Topic Description
-----------------

Security update for OpenJDK 11u branch

Package(s) Affected
-------------------

```
openjdk
openjfx
```

Security Update?
----------------

Yes, #3066 

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

