### PR TITLE
groovy: mark as noarch

### DIFF
--- a/extra-java/groovy/autobuild/defines
+++ b/extra-java/groovy/autobuild/defines
@@ -3,3 +3,5 @@ PKGSEC=java
 PKGDEP="openjdk"
 BUILDDEP="gradle"
 PKGDES="A multi-faceted language for the Java platform"
+
+ABHOST=noarch

--- a/extra-java/groovy/spec
+++ b/extra-java/groovy/spec
@@ -1,3 +1,4 @@
 VER=3.0.8
+REL=1
 SRCS="tbl::https://downloads.apache.org/groovy/$VER/sources/apache-groovy-src-$VER.zip"
 CHKSUMS="sha256::4ee3981cac74d045b1908a26a7f091e1802d040eac5b478e11a6c1efc6ec8996"


### PR DESCRIPTION
Topic Description
-----------------

Mark `groovy` as noarch.

Package(s) Affected
-------------------

`groovy` v3.0.8-1

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`