### PR TITLE
AOSC buildtools update 20210511

### DIFF
--- a/extra-devel/ciel/spec
+++ b/extra-devel/ciel/spec
@@ -1,4 +1,3 @@
-VER=3.0.0~rc9
-REL=1
+VER=3.0.1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"

--- a/extra-devel/ciel/spec
+++ b/extra-devel/ciel/spec
@@ -1,3 +1,3 @@
-VER=3.0.2
+VER=3.0.3
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"

--- a/extra-devel/ciel/spec
+++ b/extra-devel/ciel/spec
@@ -1,3 +1,3 @@
-VER=3.0.1
+VER=3.0.2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"

--- a/extra-utils/aoscbootstrap/spec
+++ b/extra-utils/aoscbootstrap/spec
@@ -1,3 +1,3 @@
-VER=0.1.0
+VER=0.1.2
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscbootstrap"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

AOSC buildtools update 20210511

Package(s) Affected
-------------------

```
ciel
aoscbootstrap
```

Security Update?
----------------

No

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

