### PR TITLE
sqlparse: actually update to 0.4.1

### DIFF
--- a/extra-python/sqlparse/autobuild/defines
+++ b/extra-python/sqlparse/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=sqlparse
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 BUILDDEP="setuptools"
-PKGDES="Non-validating SQL parser for Python"
+PKGDES="A non-validating SQL parser for Python"
 
 ABHOST=noarch
-ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/sqlparse/spec
+++ b/extra-python/sqlparse/spec
@@ -1,4 +1,3 @@
-VER=0.2.4
-REL=2
-SRCTBL="https://pypi.io/packages/source/s/sqlparse/sqlparse-$VER.tar.gz"
-CHKSUM="sha256::ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec"
+VER=0.4.1
+SRCS="tbl::https://pypi.io/packages/source/s/sqlparse/sqlparse-$VER.tar.gz"
+CHKSUMS="sha256::0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8"

--- a/extra-python/sqlparse/sqlsparse/autobuild/defines
+++ b/extra-python/sqlparse/sqlsparse/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=sqlparse
-PKGSEC=python
-PKGDEP="python-3"
-BUILDDEP="setuptools"
-PKGDES="A non-validating SQL parser for Python"
-
-ABHOST=noarch

--- a/extra-python/sqlparse/sqlsparse/spec
+++ b/extra-python/sqlparse/sqlsparse/spec
@@ -1,3 +1,0 @@
-VER=0.4.1
-SRCS="tbl::https://pypi.io/packages/source/s/sqlparse/sqlparse-$VER.tar.gz"
-CHKSUMS="sha256::1e0fd23e81e27fe57c627b7c00684064741e8cad526f082fe4e252bb5e1d411d"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
