### PR TITLE
openjfx: strip symbols for amd64

### DIFF
--- a/extra-java/openjfx/autobuild/build
+++ b/extra-java/openjfx/autobuild/build
@@ -22,6 +22,13 @@ BUILD_SRC_ZIP=true
 CONF=Release
 COMPANY_NAME="AOSC"
 EOF
+
+if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
+    ./gradlew web:compileNativeLinux
+fi
+
+abinfo 'Stripping all the native libraries to make diet jmods ...'
+find "$SRCDIR"/modules -name '*.so' -exec 'strip' '-v' '{}' ';'
 ./gradlew "$SINGLE" jmods
 
 _builddir="$SRCDIR"/build
@@ -42,3 +49,6 @@ echo 'BUILD_FXPACKAGER=true' >> gradle.properties
 install -m644 "${_sdkdir}"/lib/* "$PKGDIR"/usr/share/openjfx/lib/
 chmod 0777 "$PKGDIR"/usr/share/openjfx/lib/*.so
 cp -arv "${_builddir}"/javadoc/* "$PKGDIR"/usr/share/doc/openjfx
+
+abinfo 'Stripping all the native libraries ...'
+strip -v "$PKGDIR"/usr/share/openjfx/lib/*.so

--- a/extra-java/openjfx/autobuild/build
+++ b/extra-java/openjfx/autobuild/build
@@ -24,18 +24,18 @@ COMPANY_NAME="AOSC"
 EOF
 
 if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
-    ./gradlew web:compileNativeLinux
+    "$SRCDIR"/gradlew web:compileNativeLinux
 fi
 
 abinfo 'Stripping all the native libraries to make diet jmods ...'
 find "$SRCDIR"/modules -name '*.so' -exec 'strip' '-v' '{}' ';'
-./gradlew "$SINGLE" jmods
+"$SRCDIR"/gradlew "$SINGLE" jmods
 
 _builddir="$SRCDIR"/build
 _sdkdir="${_builddir}"/sdk
-install -d "$PKGDIR"/usr/share/openjfx/{lib,jmods}
-install -d "$PKGDIR"/usr/share/doc/openjfx
-install -m644 "${_builddir}"/jmods/* "$PKGDIR"/usr/share/openjfx/jmods/
+install -dv "$PKGDIR"/usr/share/openjfx/{lib,jmods}
+install -dv "$PKGDIR"/usr/share/doc/openjfx
+install -vm644 "${_builddir}"/jmods/* "$PKGDIR"/usr/share/openjfx/jmods/
 cp -rv "${_sdkdir}"/lib/ $(pwd)/bootstrap-lib/
 
 abinfo 'Stopping all Java processes...'
@@ -44,9 +44,9 @@ killall java || true
 abinfo 'Building final OpenJFX...'
 export _JAVA_OPTIONS="--module-path="$(pwd)/bootstrap-lib/
 echo 'BUILD_FXPACKAGER=true' >> gradle.properties
-./gradlew "$SINGLE" sdk javadoc
+"$SRCDIR"/gradlew "$SINGLE" sdk javadoc
 
-install -m644 "${_sdkdir}"/lib/* "$PKGDIR"/usr/share/openjfx/lib/
+install -vm644 "${_sdkdir}"/lib/* "$PKGDIR"/usr/share/openjfx/lib/
 chmod 0777 "$PKGDIR"/usr/share/openjfx/lib/*.so
 cp -arv "${_builddir}"/javadoc/* "$PKGDIR"/usr/share/doc/openjfx
 


### PR DESCRIPTION
Topic Description
-----------------

OpenJFX: strip debug symbols for `amd64`

Package(s) Affected
-------------------

`openjfx`

Security Update?
----------------

No

Architectural Progress
----------------------

- [X] AMD64 `amd64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

N/A

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`

Post-Merge Secondary Architectural Progress
-------------------------------------------


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

N/A

