### PR TITLE
pipewire-0.3.27

### DIFF
--- a/extra-multimedia/pipewire/autobuild/defines
+++ b/extra-multimedia/pipewire/autobuild/defines
@@ -4,5 +4,5 @@ PKGDES="Server and user space API to deal with multimedia pipelines"
 PKGDEP="ffmpeg gst-plugins-base-1-0 jack libva v4l-utils libfdk-aac libldac libopenaptx"
 BUILDDEP="doxygen graphviz meson ninja xmltoman vim"
 
-MESON_AFTER="-Dvulkan=disabled"
+MESON_AFTER="-Dvulkan=disabled -Dudevrulesdir=/usr/lib/udev/rules.d"
 ABTYPE=meson

--- a/extra-multimedia/pipewire/autobuild/defines
+++ b/extra-multimedia/pipewire/autobuild/defines
@@ -4,5 +4,5 @@ PKGDES="Server and user space API to deal with multimedia pipelines"
 PKGDEP="ffmpeg gst-plugins-base-1-0 jack libva v4l-utils libfdk-aac libldac libopenaptx"
 BUILDDEP="doxygen graphviz meson ninja xmltoman vim"
 
-MESON_AFTER="-Dvulkan=false"
+MESON_AFTER="-Dvulkan=disabled"
 ABTYPE=meson

--- a/extra-multimedia/pipewire/spec
+++ b/extra-multimedia/pipewire/spec
@@ -1,3 +1,3 @@
-VER=0.3.22
+VER=0.3.27
 SRCS="https://github.com/PipeWire/pipewire/archive/$VER.tar.gz"
-CHKSUMS="whirlpool::19372572561d9ac055efda8ed3a0f2271cd855b0361eaa7d411cd94b6fa1d7c1ae1c159b9b07f2711bf66ec017d2d7ecaa03c329b193649dd0c5ebbf4914ab2a"
+CHKSUMS="sha384::462e43e8e18e259fbfa7c47879790f9d63cfb961b13a5439f76272334a4543b264e8996182e61daf3c112e2850a913cb"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
Update `pipewire` to 0.3.27

Package(s) Affected
-------------------
*pipewire

Security Update?
----------------
No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
