### PR TITLE
cbindgen: disable LTO on loongson3

### DIFF
--- a/extra-rust/cbindgen/autobuild/defines
+++ b/extra-rust/cbindgen/autobuild/defines
@@ -5,4 +5,5 @@ BUILDDEP="llvm rustc"
 PKGDES="A project for generating C bindings from Rust code"
 
 USECLANG=1
+NOLTO__LOONGSON3=1
 ABSPLITDBG=0


### PR DESCRIPTION
Topic Description
-----------------

cbindgen: disable LTO on loongson3

Package(s) Affected
-------------------

```
cbindgen
firefox
```

Security Update?
----------------

No

Architectural Progress
----------------------

N/A

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [X] Loongson 3 `loongson3`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

N/A

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`

