### PR TITLE
General survey 20210513 rework

### DIFF
--- a/extra-devel/antlr/autobuild/defines
+++ b/extra-devel/antlr/autobuild/defines
@@ -1,11 +1,16 @@
 PKGNAME=antlr
 PKGSEC=devel
 PKGDEP="openjdk python-2 mono"
+PKGDEP__LOONGSON3="${PKGDEP/mono/}"
 PKGDES="Language recognition tool providing a framework to build grammatical parsers"
 
 AUTOTOOLS_DEF=""
 AUTOTOOLS_AFTER="--prefix=/usr \
                  --enable-examples \
                  --enable-csharp"
+AUTOTOOLS_AFTER__LOONGSON3=" \
+                 --prefix=/usr \
+                 --enable-examples \
+                 --disable-csharp"
 MAKE_AFTER="prefix=$PKGDIR/usr"
 NOSTATIC=0

--- a/extra-doc/audiveris/autobuild/defines
+++ b/extra-doc/audiveris/autobuild/defines
@@ -4,4 +4,4 @@ PKGDEP="openjdk-8 tesseract"
 BUILDDEP="gradle"
 PKGDES="Audiveris optical music recognition (OMR) engine"
 
-FAIL_ARCH="!(amd64|arm64|ppc64el)"
+FAIL_ARCH="!(amd64|ppc64el)"

--- a/extra-erlang/erlang-22/autobuild/beyond
+++ b/extra-erlang/erlang-22/autobuild/beyond
@@ -1,2 +1,5 @@
 abinfo "Installing man pages ..."
 cp -rv "$SRCDIR"/../man "$PKGDIR"/usr/lib/erlang/
+
+abinfo "Dropping executable bits from /usr/lib/**/*.o ..."
+chmod -v -x "$PKGDIR"/usr/lib/**/*.o

--- a/extra-erlang/erlang-22/spec
+++ b/extra-erlang/erlang-22/spec
@@ -1,4 +1,5 @@
 VER=22.3.4.11
+REL=1
 SRCS="tbl::https://github.com/erlang/otp/archive/OTP-$VER.tar.gz \
       tbl::http://www.erlang.org/download/otp_doc_man_${VER:0:4}.tar.gz"
 CHKSUMS="sha256::87a6ae1678d41c2a358bac7a2f4311ca37b6bdba6b239e85099c3a9bbb9d5d4d \


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
