### PR TITLE
plasma-workspace: fix plasma-desktop conffict

### DIFF
--- a/extra-kde/plasma-workspace/autobuild/defines
+++ b/extra-kde/plasma-workspace/autobuild/defines
@@ -17,5 +17,5 @@ CMAKE_AFTER="-DCMAKE_INSTALL_LIBEXECDIR=lib \
              -DKDE_INSTALL_USE_QT_SYS_PATHS=ON \
              -DBUILD_TESTING=OFF"
 PKGCONFL="kio-extras<=15.07.90 tde-i18n kwin<=5.4.3"
-PKGBREAK="plasma-desktop<=5.19.5-1 kde-workspace<=5.20.2"
-PKGREP="plasma-desktop<=5.19.5-1 kde-workspace<=5.20.2"
+PKGBREAK="plasma-desktop<=5.21.4 kde-workspace<=5.20.2"
+PKGREP="plasma-desktop<=5.21.4 kde-workspace<=5.20.2"

--- a/extra-kde/plasma-workspace/spec
+++ b/extra-kde/plasma-workspace/spec
@@ -1,3 +1,4 @@
 VER=5.21.5
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-workspace-$VER.tar.xz"
 CHKSUMS="sha256::9cb16ef4bca9ade0ca82d0cc539533ba9f9be47811ae13d154effc085618e90a"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

plasma-workspace: fix plasma-desktop conffict

Package(s) Affected
-------------------

plasma-workspace: 5.21.5-1
plasma-desktop: 5.21.5-1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

plasma-workspace plasma-desktop

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
