### PR TITLE
nano: fix nanorc import path

### DIFF
--- a/base-editors/nano/autobuild/beyond
+++ b/base-editors/nano/autobuild/beyond
@@ -1,4 +1,7 @@
-abinfo "Installing nanorc..."
+abinfo "Installing nanorc ..."
 install -Dvm644 "$SRCDIR"/../nanorc/* -t "$PKGDIR"/usr/share/nano
 install -Dvm644 "$SRCDIR"/../nanorc/nanorc "$PKGDIR"/etc/nanorc
 rm -v "$PKGDIR"/usr/share/nano/nanorc
+
+abinfo "Setting nanorc import as /usr/share/nano ..."
+sed -i "s|~/.nano|/usr/share/nano|g" "$PKGDIR"/etc/nanorc

--- a/base-editors/nano/spec
+++ b/base-editors/nano/spec
@@ -1,4 +1,5 @@
 VER=5.7
+REL=1
 SRCS="tbl::https://www.nano-editor.org/dist/v${VER:0:1}/nano-$VER.tar.xz \
       git::rename=nanorc;commit=1aa64a86cf4c750e4d4788ef1a19d7a71ab641dd::https://github.com/scopatz/nanorc"
 CHKSUMS="sha256::d4b181cc2ec11def3711b4649e34f2be7a668e70ab506860514031d069cccafa \


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

nano: fix nanorc import path

Package(s) Affected
-------------------

nano: 5.7-1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
