### PR TITLE
PHP7: security update to 7.4.19

### DIFF
--- a/extra-devel/composer/autobuild/build
+++ b/extra-devel/composer/autobuild/build
@@ -1,3 +1,3 @@
 abinfo "Installing composer ..."
-install -d "$PKGDIR"/usr/bin
+install -dv "$PKGDIR"/usr/bin
 install -Dvm755 "$SRCDIR"/composer.phar "$PKGDIR"/usr/bin/composer

--- a/extra-devel/composer/autobuild/build
+++ b/extra-devel/composer/autobuild/build
@@ -1,0 +1,3 @@
+abinfo "Installing composer ..."
+install -d "$PKGDIR"/usr/bin
+install -Dvm755 "$SRCDIR"/composer.phar "$PKGDIR"/usr/bin/composer

--- a/extra-devel/composer/autobuild/defines
+++ b/extra-devel/composer/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=composer
+PKGSEC=devel
+PKGDES="A dependency manager for PHP"
+PKGDEP=php
+
+ABHOST=noarch

--- a/extra-devel/composer/spec
+++ b/extra-devel/composer/spec
@@ -1,6 +1,6 @@
 VER=2.0.13
-SRCS="file::https://getcomposer.org/download/$VER/composer.phar \
-      file::https://github.com/composer/composer/raw/$VER/LICENSE"
+SRCS="file::rename=composer.phar::https://getcomposer.org/download/$VER/composer.phar \
+      file::rename=LICENSE::https://github.com/composer/composer/raw/$VER/LICENSE"
 CHKSUMS="sha256::116fdf07cc926af646635a6abc92d88aff7b02a5dc36538f81c50a7d27366dbf \
          sha256::7855ac293067aebe7e51afdd23b9dea54b8be24187dbecc9b9142581c37f596c"
 SUBDIR=.

--- a/extra-devel/composer/spec
+++ b/extra-devel/composer/spec
@@ -1,0 +1,6 @@
+VER=2.0.13
+SRCS="file::https://getcomposer.org/download/$VER/composer.phar \
+      file::https://github.com/composer/composer/raw/$VER/LICENSE"
+CHKSUMS="sha256::116fdf07cc926af646635a6abc92d88aff7b02a5dc36538f81c50a7d27366dbf \
+         sha256::7855ac293067aebe7e51afdd23b9dea54b8be24187dbecc9b9142581c37f596c"
+SUBDIR=.

--- a/extra-devel/php7/spec
+++ b/extra-devel/php7/spec
@@ -1,4 +1,3 @@
-VER=7.4.10
-REL=4
+VER=7.4.19
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::c2d90b00b14284588a787b100dee54c2400e7db995b457864d66f00ad64fb010"
+CHKSUMS="sha256::6c17172c4a411ccb694d9752de899bb63c72a0a3ebe5089116bc13658a1467b2"


### PR DESCRIPTION
Topic Description
-----------------

PHP7: security update to 7.4.19

Package(s) Affected
-------------------

```
php7
composer
```

Security Update?
----------------

Yes, #3088 

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
