### PR TITLE
vivaldi-3.8.2259.42

### DIFF
--- a/extra-web/vivaldi/autobuild/build
+++ b/extra-web/vivaldi/autobuild/build
@@ -12,6 +12,11 @@ for res in 16 22 24 32 48 64 128 256; do
         "$PKGDIR"/usr/share/icons/hicolor/${res}x${res}/apps/vivaldi.png
 done
 
+if [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
+    rm -rv "${PKGDIR}"/usr/lib/vivaldi/{cron,WidevineCdm,update-widevine}
+fi
+
 install -dvm755 "$PKGDIR"/usr/share/doc/vivaldi
 ln -sv "${PKGDIR}"/usr/lib/vivaldi/LICENSE.html "${PKGDIR}"/usr/share/doc/vivaldi/LICENSE.html
 ln -sv "${PKGDIR}"/usr/lib/vivaldi/resources/vivaldi/adblocker_resources/LICENSE.txt "${PKGDIR}"/usr/share/doc/vivaldi/LICENSE-adblocker_resources.html
+

--- a/extra-web/vivaldi/autobuild/build
+++ b/extra-web/vivaldi/autobuild/build
@@ -1,22 +1,26 @@
-rm -rv "$PKGDIR"/etc
+abinfo "Changing permissions for 'vivaldi-sandbox' "
 chmod -v 4755 "$PKGDIR"/opt/vivaldi/vivaldi-sandbox
 
+abinfo "Installing Vivaldi..."
 mkdir -pv "$PKGDIR"/usr/lib
 mv -v "$PKGDIR"/opt/vivaldi "$PKGDIR"/usr/lib/
 rm -v "$PKGDIR"/usr/bin/vivaldi-stable
 ln -sv ../lib/vivaldi/vivaldi "$PKGDIR"/usr/bin/vivaldi-stable
-rm -rv "$PKGDIR"/opt
 
+abinfo "Installing Vivaldi icons..."
 for res in 16 22 24 32 48 64 128 256; do
     install -Dvm644 "$PKGDIR"/usr/lib/vivaldi/product_logo_${res}.png \
         "$PKGDIR"/usr/share/icons/hicolor/${res}x${res}/apps/vivaldi.png
 done
 
-if [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
-    rm -rv "${PKGDIR}"/usr/lib/vivaldi/{cron,WidevineCdm,update-widevine}
-fi
-
+abinfo "Installing Vivaldi Licenses..."
 install -dvm755 "$PKGDIR"/usr/share/doc/vivaldi
 ln -sv "${PKGDIR}"/usr/lib/vivaldi/LICENSE.html "${PKGDIR}"/usr/share/doc/vivaldi/LICENSE.html
 ln -sv "${PKGDIR}"/usr/lib/vivaldi/resources/vivaldi/adblocker_resources/LICENSE.txt "${PKGDIR}"/usr/share/doc/vivaldi/LICENSE-adblocker_resources.html
 
+abinfo "Removing unneed files.."
+rm -rv "$PKGDIR"/etc
+rm -rv "$PKGDIR"/opt
+if [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
+    rm -rv "${PKGDIR}"/usr/lib/vivaldi/{cron,WidevineCdm,update-widevine}
+fi

--- a/extra-web/vivaldi/autobuild/build
+++ b/extra-web/vivaldi/autobuild/build
@@ -13,8 +13,5 @@ for res in 16 22 24 32 48 64 128 256; do
 done
 
 install -dvm755 "$PKGDIR"/usr/share/doc/vivaldi
-strings "$PKGDIR"/usr/lib/vivaldi/locales/en-US.pak \
-    | tr '\n' ' ' \
-    | sed -rne 's/.*(<html lang.*>.*html>).*/\1/p' \
-    | w3m -I 'utf-8' -T 'text/html' \
-    > "$PKGDIR"/usr/share/doc/vivaldi/eula.txt
+ln -sv "${PKGDIR}"/usr/lib/vivaldi/LICENSE.html "${PKGDIR}"/usr/share/doc/vivaldi/LICENSE.html
+ln -sv "${PKGDIR}"/usr/lib/vivaldi/resources/vivaldi/adblocker_resources/LICENSE.txt "${PKGDIR}"/usr/share/doc/vivaldi/LICENSE-adblocker_resources.html

--- a/extra-web/vivaldi/autobuild/defines
+++ b/extra-web/vivaldi/autobuild/defines
@@ -5,4 +5,4 @@ BUILDDEP="ninja python-2 libexif pulseaudio nss pciutils xdg-utils gperf"
 PKGDES="An advanced browser made with the power user in mind."
 
 ABSTRIP=no
-FAIL_ARCH="!(amd64)"
+FAIL_ARCH="!(amd64|arm64)"

--- a/extra-web/vivaldi/autobuild/prepare
+++ b/extra-web/vivaldi/autobuild/prepare
@@ -1,6 +1,6 @@
 mkdir -pv "${PKGDIR}"
-abinfo "Extracting upstream tarball..."
 
+abinfo "Extracting upstream tarball..."
 if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
     bsdtar xvf "${SRCDIR}"/vivaldi-$PKGVER.rpm -C "${PKGDIR}"
 elif [[ "${CROSS:-$ARCH}" = "arm64" ]]; then

--- a/extra-web/vivaldi/autobuild/prepare
+++ b/extra-web/vivaldi/autobuild/prepare
@@ -1,2 +1,8 @@
 mkdir -pv "${PKGDIR}"
-bsdtar xvf vivaldi-$PKGVER.rpm -C "${PKGDIR}"
+abinfo "Extracting upstream tarball..."
+
+if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
+    bsdtar xvf "${SRCDIR}"/vivaldi-$PKGVER.rpm -C "${PKGDIR}"
+elif [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
+    dpkg -x "${SRCDIR}"/vivaldi-$PKGVER.deb "${PKGDIR}"
+fi

--- a/extra-web/vivaldi/spec
+++ b/extra-web/vivaldi/spec
@@ -1,4 +1,7 @@
 VER=3.8.2259.42
-SRCS="tbl::https://downloads.vivaldi.com/stable/vivaldi-stable-${VER}-1.x86_64.rpm"
-CHKSUMS="sha384::2775cd9c3ffc4ca1178988ad0f47ddfe10c80ce13fbfb4beeecdc4cea98f369571cafac59e2173b01dc46914fbd5d148"
-SUBDIR=.
+
+SRCS__ARM64="tbl::https://downloads.vivaldi.com/stable/vivaldi-stable_${VER}-1_arm64.deb"
+CHKSUMS__ARM64="sha384::5bfcac98d4512b928c1d5dac769671e15d7593db9c382cdf869d77fe7ae8ce8b55aa40061396f9e7deb36dc02842636b"
+
+SRCS__AMD64="tbl::https://downloads.vivaldi.com/stable/vivaldi-stable-${VER}-1.x86_64.rpm"
+CHKSUMS__AMD64="sha384::2775cd9c3ffc4ca1178988ad0f47ddfe10c80ce13fbfb4beeecdc4cea98f369571cafac59e2173b01dc46914fbd5d148"

--- a/extra-web/vivaldi/spec
+++ b/extra-web/vivaldi/spec
@@ -1,4 +1,4 @@
-VER=3.6.2165.40
-SRCTBL="https://downloads.vivaldi.com/stable/vivaldi-stable-${VER}-1.x86_64.rpm"
-CHKSUM="sha384::b9c9b7416bb6e0c39b3334ec8a1d3796724a64aa49bfa7a9de5f0e6947aad237336b8cb34aef71b578a0dd23c51d3fe7"
+VER=3.8.2259.42
+SRCS="tbl::https://downloads.vivaldi.com/stable/vivaldi-stable-${VER}-1.x86_64.rpm"
+CHKSUMS="sha384::2775cd9c3ffc4ca1178988ad0f47ddfe10c80ce13fbfb4beeecdc4cea98f369571cafac59e2173b01dc46914fbd5d148"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------
* Update vivaldi to 3.8.2259.42 (Chromium 90,  security related ref: #2990)

Package(s) Affected
-------------------
* vivaldi

Security Update?
----------------
No

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
