### PR TITLE
Rework survey 20210517

### DIFF
--- a/extra-devel/gtest/autobuild/defines
+++ b/extra-devel/gtest/autobuild/defines
@@ -5,3 +5,4 @@ BUILDDEP="cmake"
 PKGDES="Google Test - C++ testing utility based on the xUnit framework (like JUnit)"
 
 NOSTATIC=0
+NOLTO=1

--- a/extra-devel/gtest/spec
+++ b/extra-devel/gtest/spec
@@ -1,4 +1,3 @@
-VER=1.10.0
-REL=3
-SRCS="tbl::https://github.com/google/googletest/archive/release-$VER.tar.gz"
-CHKSUMS="sha256::9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb"
+VER=1.10.0+git20210513
+SRCS="git::commit=662fe38e44900c007eccb65a5d2ea19df7bd520e::https://github.com/google/googletest"
+CHKSUMS="SKIP"

--- a/extra-network/wpa-supplicant/autobuild/build
+++ b/extra-network/wpa-supplicant/autobuild/build
@@ -1,23 +1,31 @@
-cd "$SRCDIR"/wpa_supplicant
+abinfo "Building wpa_supplicant ..."
+make -C "$SRCDIR"/wpa_supplicant \
+    LIBDIR=/usr/lib \
+    BINDIR=/usr/bin
 
-make LIBDIR=/usr/lib BINDIR=/usr/bin
-make LIBDIR=/usr/lib BINDIR=/usr/bin DESTDIR="$PKGDIR" install
+abinfo "Installing wpa_supplicant ..."
+make -C "$SRCDIR"/wpa_supplicant install \
+    LIBDIR=/usr/lib \
+    BINDIR=/usr/bin \
+    DESTDIR="$PKGDIR"
 
-install -dvm755 "$PKGDIR"/etc/wpa_supplicant
-install -vm644 wpa_supplicant.conf "$PKGDIR"/etc/wpa_supplicant/wpa_supplicant.conf
+abinfo "Installing default configuration ..."
+install -Dvm644 "$SRCDIR"/wpa_supplicant/wpa_supplicant.conf \
+    "$PKGDIR"/etc/wpa_supplicant/wpa_supplicant.conf
 
-install -dvm755 "$PKGDIR"/usr/share/man/man{5,8}
-install -vm644 doc/docbook/*.5 "$PKGDIR"/usr/share/man/man5/
-install -vm644 doc/docbook/*.8 "$PKGDIR"/usr/share/man/man8/
+abinfo "Installing man pages ..."
+install -Dvm644 "$SRCDIR"/wpa_supplicant/doc/docbook/*.5 \
+    -t "$PKGDIR"/usr/share/man/man5/
+install -Dvm644 "$SRCDIR"/wpa_supplicant/doc/docbook/*.8 \
+    -t "$PKGDIR"/usr/share/man/man8/
 rm -fv "$PKGDIR"/usr/share/man/man8/wpa_{priv,gui}.8
 
-install -dvm755 "$PKGDIR"/usr/share/dbus-1/system-services
-install -vm644 dbus/fi.w1.wpa_supplicant1.service "$PKGDIR"/usr/share/dbus-1/system-services/
+abinfo "Installing D-Bus services ..."
+install -Dvm644 "$SRCDIR"/wpa_supplicant/dbus/fi.w1.wpa_supplicant1.service \
+    "$PKGDIR"/usr/share/dbus-1/system-services/fi.w1.wpa_supplicant1.service
+install -Dvm644 "$SRCDIR"/wpa_supplicant/dbus/dbus-wpa_supplicant.conf \
+    "$PKGDIR"/etc/dbus-1/system.d/wpa_supplicant.conf
 
-install -dvm755 "$PKGDIR"/etc/dbus-1/system.d
-install -vm644 dbus/dbus-wpa_supplicant.conf "$PKGDIR"/etc/dbus-1/system.d/wpa_supplicant.conf
-
-install -dvm755 "$PKGDIR"/lib/systemd/system
-install -vm644 systemd/*.service "$PKGDIR"/lib/systemd/system/
-
-cd "$SRCDIR"
+abinfo "Installing systemd units ..."
+install -Dvm644 "$SRCDIR"/wpa_supplicant/systemd/*.service \
+    -t "$PKGDIR"/usr/lib/systemd/system/

--- a/extra-network/wpa-supplicant/autobuild/prepare
+++ b/extra-network/wpa-supplicant/autobuild/prepare
@@ -1,1 +1,3 @@
-cp -v autobuild/config "$SRCDIR"/wpa_supplicant/.config
+abinfo "Installing build configuration ..."
+cp -v "$SRCDIR"/autobuild/config \
+    "$SRCDIR"/wpa_supplicant/.config

--- a/extra-network/wpa-supplicant/spec
+++ b/extra-network/wpa-supplicant/spec
@@ -1,4 +1,4 @@
 VER=2.9
-REL=3
-SRCTBL="https://w1.fi/releases/wpa_supplicant-$VER.tar.gz"
-CHKSUM="sha256::fcbdee7b4a64bea8177973299c8c824419c413ec2e3a95db63dd6a5dc3541f17"
+REL=4
+SRCS="tbl::https://w1.fi/releases/wpa_supplicant-$VER.tar.gz"
+CHKSUMS="sha256::fcbdee7b4a64bea8177973299c8c824419c413ec2e3a95db63dd6a5dc3541f17"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
