### PR TITLE
kmscon: tweaks, default enablement, shadow fixes

### DIFF
--- a/base-admin/shadow/autobuild/overrides/etc/pam.d/login
+++ b/base-admin/shadow/autobuild/overrides/etc/pam.d/login
@@ -1,5 +1,4 @@
 #%PAM-1.0
-auth       required     pam_securetty.so
 auth       requisite    pam_nologin.so
 auth       include      system-local-login
 account    include      system-local-login

--- a/base-admin/shadow/spec
+++ b/base-admin/shadow/spec
@@ -1,4 +1,4 @@
 VER=4.8.1
-REL=3
+REL=4
 SRCTBL="https://github.com/shadow-maint/shadow/releases/download/$VER/shadow-$VER.tar.xz"
 CHKSUM="sha256::a3ad4630bdc41372f02a647278a8c3514844295d36eefe68ece6c3a641c1ae62"

--- a/extra-bases/kmscon-base/autobuild/defines
+++ b/extra-bases/kmscon-base/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=kmscon-base
+PKGSEC=Bases
+PKGDEP="kmscon kmscon-enablement"
+PKGDES="Meta package for AOSC OS KMSCON experience"
+
+VER_NONE=1
+ABHOST=noarch

--- a/extra-bases/kmscon-base/spec
+++ b/extra-bases/kmscon-base/spec
@@ -1,0 +1,2 @@
+VER=0
+DUMMYSRC=1

--- a/extra-utils/kmscon-enablement/autobuild/build
+++ b/extra-utils/kmscon-enablement/autobuild/build
@@ -1,0 +1,4 @@
+abinfo "Creating a symlink to enable KMSCON on all virtual terminals ..."
+mkdir -pv "$PKGDIR"/etc/systemd/system
+ln -sv ../usr/lib/systemd/system/kmsconvt\@.service \
+    "$PKGDIR"/etc/systemd/system/autovt\@.service

--- a/extra-utils/kmscon-enablement/autobuild/build
+++ b/extra-utils/kmscon-enablement/autobuild/build
@@ -1,4 +1,4 @@
 abinfo "Creating a symlink to enable KMSCON on all virtual terminals ..."
 mkdir -pv "$PKGDIR"/etc/systemd/system
-ln -sv ../usr/lib/systemd/system/kmsconvt\@.service \
+ln -sv ../../../usr/lib/systemd/system/kmsconvt\@.service \
     "$PKGDIR"/etc/systemd/system/autovt\@.service

--- a/extra-utils/kmscon-enablement/autobuild/defines
+++ b/extra-utils/kmscon-enablement/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=kmscon-enablement
+PKGSEC=utils
+PKGDEP="kmscon"
+PKGDES="Enables KMSCON on all virtual terminals"
+
+VER_NONE=1
+ABHOST=noarch

--- a/extra-utils/kmscon-enablement/spec
+++ b/extra-utils/kmscon-enablement/spec
@@ -1,0 +1,2 @@
+VER=0
+DUMMYSRC=1

--- a/extra-utils/kmscon/autobuild/defines
+++ b/extra-utils/kmscon/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=kmscon
 PKGSEC=utils
-PKGDEP="libdrm libtsm mesa pango systemd xkeyboard-config"
+PKGDEP="libdrm libtsm mesa pango systemd unifont xkeyboard-config"
 BUILDDEP="docbook-xsl"
 PKGDES="Terminal emulator based on Kernel Mode Setting (KMS)"
 

--- a/extra-utils/kmscon/autobuild/overrides/etc/kmscon/kmscon.conf
+++ b/extra-utils/kmscon/autobuild/overrides/etc/kmscon/kmscon.conf
@@ -1,0 +1,2 @@
+font-name=Unifont
+font-size=12

--- a/extra-utils/kmscon/spec
+++ b/extra-utils/kmscon/spec
@@ -1,3 +1,4 @@
 VER=8+git20201004
+REL=1
 GITSRC="https://github.com/AOSC-Dev/kmscon"
 GITCO="c45b8bccac02c18f9933b5f4875daf823f317b60"


### PR DESCRIPTION
Topic Description
-----------------

Create a default configuration for KMSCON, introduce a package for enabling KMSCON by default (introduced with `kmscon-base`), and drop `securetty` include from `/etc/pam.d/login`.

Package(s) Affected
-------------------

- `kmscon` v8+git20201004-1
- `kmscon-base` v0
- `kmscon-enablement` v0
- `shadow` v4.8.1-4

Security Update?
----------------

No

Build Order
-----------

```
shadow kmscon kmscon-enablement kmscon-base
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`