### PR TITLE
nano: use old nanorc

### DIFF
--- a/base-editors/nano/autobuild/beyond
+++ b/base-editors/nano/autobuild/beyond
@@ -1,7 +1,4 @@
 abinfo "Installing nanorc ..."
-install -Dvm644 "$SRCDIR"/../nanorc/* -t "$PKGDIR"/usr/share/nano
-install -Dvm644 "$SRCDIR"/../nanorc/nanorc "$PKGDIR"/etc/nanorc
+install -Dvm644 "$SRCDIR"/nanorc/* -t "$PKGDIR"/usr/share/nano
+install -Dvm644 "$SRCDIR"/nanorc/nanorc "$PKGDIR"/etc/nanorc
 rm -v "$PKGDIR"/usr/share/nano/nanorc
-
-abinfo "Setting nanorc import as /usr/share/nano ..."
-sed -i "s|~/.nano|/usr/share/nano|g" "$PKGDIR"/etc/nanorc

--- a/base-editors/nano/autobuild/patch
+++ b/base-editors/nano/autobuild/patch
@@ -1,0 +1,7 @@
+abinfo "Copying nanorc source to $SRCDIR ..."
+cp -rv "$SRCDIR"/../nanorc "$SRCDIR"/nanorc
+
+for i in "$SRCDIR"/autobuild/patches/*; do
+    abinfo "Apply $i ..."
+    patch -Np1 -i $i
+done

--- a/base-editors/nano/autobuild/patches/0001-Use-AOSC-OS-nanorc.patch
+++ b/base-editors/nano/autobuild/patches/0001-Use-AOSC-OS-nanorc.patch
@@ -1,0 +1,354 @@
+From 84cfde73cbc1d7b44cfdb71cefeb93eff17cf21a Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@outlook.com>
+Date: Mon, 17 May 2021 22:18:36 -0700
+Subject: [PATCH] Use AOSC OS nanorc
+
+---
+ nanorc | 337 ++++++++++++++++++++++++++++++++++++++++++---------------
+ 1 file changed, 247 insertions(+), 90 deletions(-)
+
+diff --git a/nanorc/nanorc b/nanorc/nanorc
+index 0300957..6b412f7 100644
+--- a/nanorc/nanorc
++++ b/nanorc/nanorc
+@@ -1,90 +1,247 @@
+-include "~/.nano/apacheconf.nanorc"
+-include "~/.nano/arduino.nanorc"
+-include "~/.nano/asciidoc.nanorc"
+-include "~/.nano/asm.nanorc"
+-include "~/.nano/awk.nanorc"
+-include "~/.nano/c.nanorc"
+-include "~/.nano/clojure.nanorc"
+-include "~/.nano/cmake.nanorc"
+-include "~/.nano/coffeescript.nanorc"
+-include "~/.nano/colortest.nanorc"
+-include "~/.nano/conf.nanorc"
+-include "~/.nano/csharp.nanorc"
+-include "~/.nano/css.nanorc"
+-include "~/.nano/cython.nanorc"
+-include "~/.nano/dot.nanorc"
+-include "~/.nano/dotenv.nanorc"
+-include "~/.nano/email.nanorc"
+-include "~/.nano/Dockerfile.nanorc"
+-include "~/.nano/etc-hosts.nanorc"
+-include "~/.nano/fish.nanorc"
+-include "~/.nano/fortran.nanorc"
+-include "~/.nano/gentoo.nanorc"
+-include "~/.nano/git.nanorc"
+-include "~/.nano/gitcommit.nanorc"
+-include "~/.nano/glsl.nanorc"
+-include "~/.nano/go.nanorc"
+-include "~/.nano/gradle.nanorc"
+-include "~/.nano/groff.nanorc"
+-include "~/.nano/haml.nanorc"
+-include "~/.nano/haskell.nanorc"
+-include "~/.nano/html.nanorc"
+-include "~/.nano/html.j2.nanorc"
+-include "~/.nano/ical.nanorc"
+-include "~/.nano/ini.nanorc"
+-include "~/.nano/inputrc.nanorc"
+-include "~/.nano/jade.nanorc"
+-include "~/.nano/java.nanorc"
+-include "~/.nano/javascript.nanorc"
+-include "~/.nano/js.nanorc"
+-include "~/.nano/json.nanorc"
+-include "~/.nano/keymap.nanorc"
+-include "~/.nano/kickstart.nanorc"
+-include "~/.nano/kotlin.nanorc"
+-include "~/.nano/ledger.nanorc"
+-include "~/.nano/lisp.nanorc"
+-include "~/.nano/lua.nanorc"
+-include "~/.nano/makefile.nanorc"
+-include "~/.nano/man.nanorc"
+-include "~/.nano/markdown.nanorc"
+-include "~/.nano/mpdconf.nanorc"
+-include "~/.nano/mutt.nanorc"
+-include "~/.nano/nanorc.nanorc"
+-include "~/.nano/nginx.nanorc"
+-include "~/.nano/nmap.nanorc"
+-include "~/.nano/ocaml.nanorc"
+-include "~/.nano/patch.nanorc"
+-include "~/.nano/peg.nanorc"
+-include "~/.nano/perl.nanorc"
+-include "~/.nano/perl6.nanorc"
+-include "~/.nano/php.nanorc"
+-include "~/.nano/pkg-config.nanorc"
+-include "~/.nano/pkgbuild.nanorc"
+-include "~/.nano/po.nanorc"
+-include "~/.nano/pov.nanorc"
+-include "~/.nano/privoxy.nanorc"
+-include "~/.nano/puppet.nanorc"
+-include "~/.nano/pug.nanorc"
+-include "~/.nano/python.nanorc"
+-include "~/.nano/reST.nanorc"
+-include "~/.nano/rpmspec.nanorc"
+-include "~/.nano/ruby.nanorc"
+-include "~/.nano/rust.nanorc"
+-include "~/.nano/scala.nanorc"
+-include "~/.nano/sed.nanorc"
+-include "~/.nano/sh.nanorc"
+-include "~/.nano/sls.nanorc"
+-include "~/.nano/sql.nanorc"
+-include "~/.nano/svn.nanorc"
+-include "~/.nano/swift.nanorc"
+-include "~/.nano/systemd.nanorc"
+-include "~/.nano/tcl.nanorc"
+-include "~/.nano/tex.nanorc"
+-include "~/.nano/vala.nanorc"
+-include "~/.nano/verilog.nanorc"
+-include "~/.nano/vi.nanorc"
+-include "~/.nano/xml.nanorc"
+-include "~/.nano/xresources.nanorc"
+-include "~/.nano/yaml.nanorc"
+-include "~/.nano/yum.nanorc"
+-include "~/.nano/zsh.nanorc"
++## Sample initialization file for GNU nano.
++##
++## Please note that you must have configured nano with --enable-nanorc
++## for this file to be read!  Also note that this file should not be in
++## DOS or Mac format, and that characters specially interpreted by the
++## shell should not be escaped here.
++##
++## To make sure an option is disabled, use "unset <option>".
++##
++## For the options that take parameters, the default value is given.
++## Other options are unset by default.
++##
++## Quotes inside string parameters don't have to be escaped with
++## backslashes.  The last double quote in the string will be treated as
++## its end.  For example, for the "brackets" option, ""')>]}" will match
++## ", ', ), >, ], and }.
++
++## Silently ignore problems with unknown directives in the nanorc file.
++## Useful when your nanorc file might be read on systems with multiple
++## versions of nano installed (e.g. your home directory is on NFS).
++# set quiet
++
++## Use auto-indentation.
++# set autoindent
++
++## Back up files to the current filename plus a tilde.
++# set backup
++
++## The directory to put unique backup files in.
++# set backupdir ""
++
++## Do backwards searches by default.
++# set backwards
++
++## Use bold text instead of reverse video text.
++# set boldtext
++
++## The characters treated as closing brackets when justifying
++## paragraphs.  They cannot contain blank characters.  Only closing
++## punctuation, optionally followed by closing brackets, can end
++## sentences.
++# set brackets ""')>]}"
++
++## Do case-sensitive searches by default.
++# set casesensitive
++
++## Constantly display the cursor position in the statusbar.  Note that
++## this overrides "quickblank".
++# set const
++
++## Use cut-to-end-of-line by default.
++# set cut
++
++## Set the line length for wrapping text and justifying paragraphs.
++## If the value is 0 or less, the wrapping point will be the screen
++## width less this number.
++# set fill -8
++
++## Enable ~/.nano_history for saving and reading search/replace strings.
++set historylog
++
++## Enable vim-style lock-files.  This is just to let a vim user know you
++## are editing a file [s]he is trying to edit and vice versa. There are
++## no plans to implement vim-style undo state in these files.
++set locking
++
++## The opening and closing brackets that can be found by bracket
++## searches.  They cannot contain blank characters.  The former set must
++## come before the latter set, and both must be in the same order.
++# set matchbrackets "(<[{)>]}"
++
++## Use the blank line below the titlebar as extra editing space.
++# set morespace
++
++## Enable mouse support, if available for your system.  When enabled,
++## mouse clicks can be used to place the cursor, set the mark (with a
++## double click), and execute shortcuts.  The mouse will work in the X
++## Window System, and on the console when gpm is running.
++# set mouse
++
++## Switch on multiple file buffers (inserting a file will put it into
++## a separate buffer).
++# set multibuffer
++
++## Don't convert files from DOS/Mac format.
++# set noconvert
++
++## Don't follow symlinks when writing files.
++# set nofollow
++
++## Don't display the helpful shortcut lists at the bottom of the screen.
++# set nohelp
++
++## Don't add newlines to the ends of files.
++# set nonewlines
++
++## Don't wrap text at all.
++set nowrap
++
++## Set operating directory.  nano will not read or write files outside
++## this directory and its subdirectories.  Also, the current directory
++## is changed to here, so any files are inserted from this dir.  A blank
++## string means the operating-directory feature is turned off.
++# set operatingdir ""
++
++## Remember the cursor position in each file for the next editing session.
++# set poslog
++
++## Preserve the XON and XOFF keys (^Q and ^S).
++# set preserve
++
++## The characters treated as closing punctuation when justifying
++## paragraphs.  They cannot contain blank characters.  Only closing
++## punctuation, optionally followed by closing brackets, can end
++## sentences.
++# set punct "!.?"
++
++## Do quick statusbar blanking.  Statusbar messages will disappear after
++## 1 keystroke instead of 26.  Note that "const" overrides this.
++# set quickblank
++
++## The email-quote string, used to justify email-quoted paragraphs.
++## This is an extended regular expression if your system supports them,
++## otherwise a literal string.
++## If you have extended regular expression support, the default is:
++# set quotestr "^([ 	]*[#:>\|}])+"
++## Otherwise:
++# set quotestr "> "
++
++## Fix Backspace/Delete confusion problem.
++# set rebinddelete
++
++## Fix numeric keypad key confusion problem.
++# set rebindkeypad
++
++## Do extended regular expression searches by default.
++# set regexp
++
++## Make the Home key smarter.  When Home is pressed anywhere but at the
++## very beginning of non-whitespace characters on a line, the cursor
++## will jump to that beginning (either forwards or backwards).  If the
++## cursor is already at that position, it will jump to the true
++## beginning of the line.
++# set smarthome
++
++## Use smooth scrolling as the default.
++# set smooth
++
++## Enable soft line wrapping (AKA full-line display).
++# set softwrap
++
++## Use this spelling checker instead of the internal one.  This option
++## does not properly have a default value.
++# set speller "aspell -x -c"
++
++## Allow nano to be suspended.
++set suspend
++
++## Use this tab size instead of the default; it must be greater than 0.
++# set tabsize 8
++
++## Convert typed tabs to spaces.
++# set tabstospaces
++
++## Save automatically on exit; don't prompt.
++# set tempfile
++
++## Disallow file modification.  Why would you want this in an rcfile? ;)
++# set view
++
++## The two single-column characters used to display the first characters
++## of tabs and spaces.  187 in ISO 8859-1 (0000BB in Unicode) and 183 in
++## ISO-8859-1 (0000B7 in Unicode) seem to be good values for these.
++## The default when in a UTF-8 locale:
++# set whitespace "»·"
++## The default otherwise:
++# set whitespace ">."
++
++## Detect word boundaries more accurately by treating punctuation
++## characters as parts of words.
++# set wordbounds
++
++
++## Paint the interface elements of nano.
++## This is an example; by default there are no colors.
++# set titlecolor brightwhite,blue
++# set statuscolor brightwhite,green
++# set keycolor green
++# set functioncolor yellow
++
++
++## Setup of syntax coloring.
++##
++## Format:
++##
++## syntax "short description" ["filename regex" ...]
++##
++## The "none" syntax is reserved; specifying it on the command line is
++## the same as not having a syntax at all.  The "default" syntax is
++## special: it takes no filename regexes, and applies to files that
++## don't match any other syntax's filename regexes.
++##
++## color foreground,background "regex" ["regex"...]
++## or
++## icolor foreground,background "regex" ["regex"...]
++##
++## "color" will do case-sensitive matches, while "icolor" will do
++## case-insensitive matches.
++##
++## Valid colors: white, black, red, blue, green, yellow, magenta, cyan.
++## For foreground colors, you may use the prefix "bright" to get a
++## stronger highlight.
++##
++## To use multi-line regexes, use the start="regex" end="regex"
++## [start="regex" end="regex"...] format.
++##
++## If your system supports transparency, not specifying a background
++## color will use a transparent color.  If you don't want this, be sure
++## to set the background color to black or white.
++##
++## All regexes should be extended regular expressions.
++##
++## If you wish, you may put your syntax definitions in separate files.
++## You can make use of such files as follows:
++##
++## include "/path/to/syntax_file.nanorc"
++##
++## Unless otherwise noted, the name of the syntax file (without the
++## ".nanorc" extension) should be the same as the "short description"
++## name inside that file.  These names are kept fairly short to make
++## them easier to remember and faster to type using nano's -Y option.
++##
++## To include all existing syntax definitions, you can do:
++include "/usr/share/nano/*.nanorc"
++
++
++## Key bindings.
++## See nanorc(5) for more details on this.
++##
++## Here are a few samples to get you going.
++##
++# bind M-W nowrap main
++# bind M-A casesens search
++# bind ^S research main
++
++## Set this if your backspace key sends Del most of the time.
++# bind Del backspace all
+-- 
+2.30.2
+

--- a/base-editors/nano/spec
+++ b/base-editors/nano/spec
@@ -1,5 +1,5 @@
 VER=5.7
-REL=1
+REL=2
 SRCS="tbl::https://www.nano-editor.org/dist/v${VER:0:1}/nano-$VER.tar.xz \
       git::rename=nanorc;commit=1aa64a86cf4c750e4d4788ef1a19d7a71ab641dd::https://github.com/scopatz/nanorc"
 CHKSUMS="sha256::d4b181cc2ec11def3711b4649e34f2be7a668e70ab506860514031d069cccafa \


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

nano: use old nanorc

Package(s) Affected
-------------------

nano: 5.7-2

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
