### PR TITLE
vivaldi-3.8.2259.42-rework

### DIFF
--- a/extra-web/vivaldi/spec
+++ b/extra-web/vivaldi/spec
@@ -5,3 +5,5 @@ CHKSUMS__ARM64="sha384::5bfcac98d4512b928c1d5dac769671e15d7593db9c382cdf869d77fe
 
 SRCS__AMD64="tbl::https://downloads.vivaldi.com/stable/vivaldi-stable-${VER}-1.x86_64.rpm"
 CHKSUMS__AMD64="sha384::2775cd9c3ffc4ca1178988ad0f47ddfe10c80ce13fbfb4beeecdc4cea98f369571cafac59e2173b01dc46914fbd5d148"
+
+SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------
Fixing RPM packages extracting problem for vivaldi 3.8.2259.42

Package(s) Affected
-------------------
* vivaldi

Security Update?
----------------
No

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
