### PR TITLE
i2pd: update to 2.38.0

### DIFF
--- a/extra-web/i2pd/autobuild/defines
+++ b/extra-web/i2pd/autobuild/defines
@@ -4,9 +4,7 @@ PKGDEP="boost miniupnpc openssl"
 PKGDES="End-to-End encrypted and anonymous Internet"
 
 ABSHADOW=0
-CMAKE_AFTER="-DWITH_AESNI=OFF \
-             -DWITH_AVX=OFF \
-             -DWITH_HARDENING=ON \
+CMAKE_AFTER="-DWITH_HARDENING=ON \
              -DWITH_UPNP=ON \
              -DWITH_THREADSANITIZER=OFF"
 

--- a/extra-web/i2pd/spec
+++ b/extra-web/i2pd/spec
@@ -1,4 +1,4 @@
-VER=2.35.0
+VER=2.38.0
 SRCTBL="https://github.com/PurpleI2P/i2pd/archive/$VER.tar.gz"
-CHKSUM="sha256::d041fd4e7a88ac168e76f66fdab40174ad093cdc13451cdbd0dd1216e5581f8a"
+CHKSUM="sha256::8452f5323795a1846d554096c08fffe5ac35897867b93a5079605df8f80a3089"
 SUBDIR="i2pd-$VER/build"


### PR DESCRIPTION
Signed-off-by: R4SAS <r4sas@i2pmail.org>

<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
i2pd: update to 2.38.0

Package(s) Affected
-------------------
i2pd

Security Update?
----------------
No

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
