### PR TITLE
groups/lxde: PKGSEC rework

### DIFF
--- a/extra-lxde/gpicview/autobuild/defines
+++ b/extra-lxde/gpicview/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=gpicview
-PKGSEC=x11
+PKGSEC=LXDE
 PKGDEP="desktop-file-utils gtk-2 librsvg xdg-utils"
 BUILDDEP="intltool"
 PKGDES="Lightweight image viewer (a LXDE project)"

--- a/extra-lxde/gpicview/spec
+++ b/extra-lxde/gpicview/spec
@@ -1,4 +1,4 @@
 VER=0.2.5
-SRCTBL="https://downloads.sourceforge.net/sourceforge/lxde/gpicview-$VER.tar.xz"
-CHKSUM="sha256::38466058e53702450e5899193c4b264339959b563dd5cd81f6f690de32d82942"
+SRCS="tbl::https://downloads.sourceforge.net/sourceforge/lxde/gpicview-$VER.tar.xz"
+CHKSUMS="sha256::38466058e53702450e5899193c4b264339959b563dd5cd81f6f690de32d82942"
 REL=2

--- a/extra-lxde/gpicview/spec
+++ b/extra-lxde/gpicview/spec
@@ -1,4 +1,4 @@
 VER=0.2.5
 SRCTBL="https://downloads.sourceforge.net/sourceforge/lxde/gpicview-$VER.tar.xz"
 CHKSUM="sha256::38466058e53702450e5899193c4b264339959b563dd5cd81f6f690de32d82942"
-REL=1
+REL=2

--- a/extra-lxde/lxappearance-obconf/autobuild/defines
+++ b/extra-lxde/lxappearance-obconf/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxappearance-obconf
-PKGSEC=x11
+PKGSEC=LXDE
 PKGDEP="lxappearance openbox"
 BUILDDEP="intltool"
 PKGDES="A plugin for LXAppearance for configuring OpenBox WM"

--- a/extra-lxde/lxappearance-obconf/spec
+++ b/extra-lxde/lxappearance-obconf/spec
@@ -1,4 +1,4 @@
 VER=0.2.3
 REL=3
-SRCTBL="https://downloads.sourceforge.net/lxde/lxappearance-obconf-$VER.tar.xz"
-CHKSUM="sha256::3150b33b4b7beb71c1803aee2be21c94767d73b70dfc8d2bcaafe2650ea83149"
+SRCS="tbl::https://downloads.sourceforge.net/lxde/lxappearance-obconf-$VER.tar.xz"
+CHKSUMS="sha256::3150b33b4b7beb71c1803aee2be21c94767d73b70dfc8d2bcaafe2650ea83149"

--- a/extra-lxde/lxappearance-obconf/spec
+++ b/extra-lxde/lxappearance-obconf/spec
@@ -1,4 +1,4 @@
 VER=0.2.3
-REL=2
+REL=3
 SRCTBL="https://downloads.sourceforge.net/lxde/lxappearance-obconf-$VER.tar.xz"
 CHKSUM="sha256::3150b33b4b7beb71c1803aee2be21c94767d73b70dfc8d2bcaafe2650ea83149"

--- a/extra-lxde/lxappearance/autobuild/defines
+++ b/extra-lxde/lxappearance/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxappearance
-PKGSEC=x11
+PKGSEC=LXDE
 PKGDEP="dbus-glib gtk-2"
 BUILDDEP="intltool"
 PKGDES="Feature-rich GTK+ theme switcher of the LXDE Desktop"

--- a/extra-lxde/lxappearance/spec
+++ b/extra-lxde/lxappearance/spec
@@ -1,4 +1,4 @@
 VER=0.6.2
 REL=2
-SRCTBL="https://downloads.sourceforge.net/lxde/lxappearance-$VER.tar.xz"
-CHKSUM="sha256::4462136e01f991d4c546f23a8cf59a4092f88ecdff587597959f8062e2ea201f"
+SRCS="tbl::https://downloads.sourceforge.net/lxde/lxappearance-$VER.tar.xz"
+CHKSUMS="sha256::4462136e01f991d4c546f23a8cf59a4092f88ecdff587597959f8062e2ea201f"

--- a/extra-lxde/lxappearance/spec
+++ b/extra-lxde/lxappearance/spec
@@ -1,4 +1,4 @@
 VER=0.6.2
-REL=1
+REL=2
 SRCTBL="https://downloads.sourceforge.net/lxde/lxappearance-$VER.tar.xz"
 CHKSUM="sha256::4462136e01f991d4c546f23a8cf59a4092f88ecdff587597959f8062e2ea201f"

--- a/extra-lxde/lxde-common/autobuild/defines
+++ b/extra-lxde/lxde-common/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxde-common
-PKGSEC=lxde
+PKGSEC=LXDE
 PKGDEP="lxsession gnome-themes-standard lxde-icon-theme"
 BUILDDEP="intltool"
 PKGDES="Common files for the LXDE desktop"

--- a/extra-lxde/lxde-common/spec
+++ b/extra-lxde/lxde-common/spec
@@ -1,4 +1,4 @@
 VER=0.99.2
 SRCTBL="https://downloads.sourceforge.net/lxde/lxde-common-$VER.tar.xz"
 CHKSUM="sha256::1cd9bc900960c995d48ffbbdc86ecffda7c806168c67aaa50c53113794234856"
-REL=1
+REL=2

--- a/extra-lxde/lxde-common/spec
+++ b/extra-lxde/lxde-common/spec
@@ -1,4 +1,4 @@
 VER=0.99.2
-SRCTBL="https://downloads.sourceforge.net/lxde/lxde-common-$VER.tar.xz"
-CHKSUM="sha256::1cd9bc900960c995d48ffbbdc86ecffda7c806168c67aaa50c53113794234856"
+SRCS="tbl::https://downloads.sourceforge.net/lxde/lxde-common-$VER.tar.xz"
+CHKSUMS="sha256::1cd9bc900960c995d48ffbbdc86ecffda7c806168c67aaa50c53113794234856"
 REL=2

--- a/extra-lxde/lxde-icon-theme/autobuild/defines
+++ b/extra-lxde/lxde-icon-theme/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxde-icon-theme
-PKGSEC=lxde
+PKGSEC=LXDE
 PKGDEP=""
 PKGDES="Default icon theme for LXDE"
 

--- a/extra-lxde/lxde-icon-theme/spec
+++ b/extra-lxde/lxde-icon-theme/spec
@@ -1,4 +1,4 @@
 VER=0.5.1
 REL=2
-SRCTBL="https://downloads.sourceforge.net/lxde/lxde-icon-theme-$VER.tar.xz"
-CHKSUM="sha256::e3d0b7399f28a360a3755171c9a08147d68f853f518be5485f5064675037916c"
+SRCS="tbl::https://downloads.sourceforge.net/lxde/lxde-icon-theme-$VER.tar.xz"
+CHKSUMS="sha256::e3d0b7399f28a360a3755171c9a08147d68f853f518be5485f5064675037916c"

--- a/extra-lxde/lxde-icon-theme/spec
+++ b/extra-lxde/lxde-icon-theme/spec
@@ -1,4 +1,4 @@
 VER=0.5.1
-REL=1
+REL=2
 SRCTBL="https://downloads.sourceforge.net/lxde/lxde-icon-theme-$VER.tar.xz"
 CHKSUM="sha256::e3d0b7399f28a360a3755171c9a08147d68f853f518be5485f5064675037916c"

--- a/extra-lxde/lxdm/autobuild/defines
+++ b/extra-lxde/lxdm/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=lxdm
 PKGDES="Display Manager of LXDE"
-PKGSEC=lxde
+PKGSEC=LXDE
 PKGDEP="iso-codes gtk-3 xorg-server"
 BUILDDEP="intltool"
 

--- a/extra-lxde/lxdm/spec
+++ b/extra-lxde/lxdm/spec
@@ -1,4 +1,4 @@
 VER=0.5.3
-REL=1
+REL=2
 SRCTBL="https://downloads.sourceforge.net/lxdm/lxdm-$VER.tar.xz"
 CHKSUM="sha256::4891efee81c72a400cc6703e40aa76f3f3853833d048b72ec805da0f93567f2f"

--- a/extra-lxde/lxdm/spec
+++ b/extra-lxde/lxdm/spec
@@ -1,4 +1,4 @@
 VER=0.5.3
 REL=2
-SRCTBL="https://downloads.sourceforge.net/lxdm/lxdm-$VER.tar.xz"
-CHKSUM="sha256::4891efee81c72a400cc6703e40aa76f3f3853833d048b72ec805da0f93567f2f"
+SRCS="tbl::https://downloads.sourceforge.net/lxdm/lxdm-$VER.tar.xz"
+CHKSUMS="sha256::4891efee81c72a400cc6703e40aa76f3f3853833d048b72ec805da0f93567f2f"

--- a/extra-lxde/lxinput/autobuild/defines
+++ b/extra-lxde/lxinput/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxinput
-PKGSEC=lxde
+PKGSEC=LXDE
 PKGDEP="gtk-3"
 BUILDDEP="intltool"
 PKGDES="Configure keyboard and mouse for LXDE"

--- a/extra-lxde/lxinput/spec
+++ b/extra-lxde/lxinput/spec
@@ -1,4 +1,4 @@
 VER=0.3.5
-REL=1
+REL=2
 SRCTBL="https://downloads.sourceforge.net/lxde/lxinput-$VER.tar.xz"
 CHKSUM="sha256::4e8f778a65a4afe2365b47e7899358aa4fab535343aa62c72a3cdc4cac1f6e88"

--- a/extra-lxde/lxinput/spec
+++ b/extra-lxde/lxinput/spec
@@ -1,4 +1,4 @@
 VER=0.3.5
 REL=2
-SRCTBL="https://downloads.sourceforge.net/lxde/lxinput-$VER.tar.xz"
-CHKSUM="sha256::4e8f778a65a4afe2365b47e7899358aa4fab535343aa62c72a3cdc4cac1f6e88"
+SRCS="tbl::https://downloads.sourceforge.net/lxde/lxinput-$VER.tar.xz"
+CHKSUMS="sha256::4e8f778a65a4afe2365b47e7899358aa4fab535343aa62c72a3cdc4cac1f6e88"

--- a/extra-lxde/lxlauncher/autobuild/defines
+++ b/extra-lxde/lxlauncher/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxlauncher
-PKGSEC=lxde
+PKGSEC=LXDE
 PKGDEP="gtk-2 lxmenu-data menu-cache startup-notification"
 BUILDDEP="intltool"
 PKGDES="A full screen launcher for LXDE (clone of the Asus launcher for EeePC)"

--- a/extra-lxde/lxlauncher/spec
+++ b/extra-lxde/lxlauncher/spec
@@ -1,4 +1,4 @@
 VER=0.2.5
-SRCTBL="https://downloads.sourceforge.net/lxde/lxlauncher-$VER.tar.xz"
-CHKSUM="sha256::cd14b59cf337e7ba0d67efc95cd79859ab5f0f85af5a84c7aff771f868c3dca7"
+SRCS="tbl::https://downloads.sourceforge.net/lxde/lxlauncher-$VER.tar.xz"
+CHKSUMS="sha256::cd14b59cf337e7ba0d67efc95cd79859ab5f0f85af5a84c7aff771f868c3dca7"
 REL=1

--- a/extra-lxde/lxlauncher/spec
+++ b/extra-lxde/lxlauncher/spec
@@ -1,3 +1,4 @@
 VER=0.2.5
 SRCTBL="https://downloads.sourceforge.net/lxde/lxlauncher-$VER.tar.xz"
 CHKSUM="sha256::cd14b59cf337e7ba0d67efc95cd79859ab5f0f85af5a84c7aff771f868c3dca7"
+REL=1

--- a/extra-lxde/lxmenu-data/autobuild/defines
+++ b/extra-lxde/lxmenu-data/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxmenu-data
-PKGSEC=x11
+PKGSEC=LXDE
 PKGDEP=""
 BUILDDEP="intltool"
 PKGDES="Freedesktop.org desktop menus for LXDE"

--- a/extra-lxde/lxmenu-data/spec
+++ b/extra-lxde/lxmenu-data/spec
@@ -1,4 +1,4 @@
 VER=0.1.5
 REL=3
-SRCTBL="https://sourceforge.net/projects/lxde/files/lxmenu-data%20%28desktop%20menu%29/lxmenu-data-$VER.tar.xz"
-CHKSUM="sha256::9fe3218d2ef50b91190162f4f923d6524c364849f87bcda8b4ed8eb59b80bab8"
+SRCS="tbl::https://sourceforge.net/projects/lxde/files/lxmenu-data%20%28desktop%20menu%29/lxmenu-data-$VER.tar.xz"
+CHKSUMS="sha256::9fe3218d2ef50b91190162f4f923d6524c364849f87bcda8b4ed8eb59b80bab8"

--- a/extra-lxde/lxmenu-data/spec
+++ b/extra-lxde/lxmenu-data/spec
@@ -1,4 +1,4 @@
 VER=0.1.5
-REL=2
+REL=3
 SRCTBL="https://sourceforge.net/projects/lxde/files/lxmenu-data%20%28desktop%20menu%29/lxmenu-data-$VER.tar.xz"
 CHKSUM="sha256::9fe3218d2ef50b91190162f4f923d6524c364849f87bcda8b4ed8eb59b80bab8"

--- a/extra-lxde/lxpanel/autobuild/defines
+++ b/extra-lxde/lxpanel/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxpanel
-PKGSEC=lxde
+PKGSEC=LXDE
 PKGDEP="alsa-lib gtk-3 libfm lxmenu-data menu-cache keybinder-3.0 libwnck-3"
 BUILDDEP="wireless-tools docbook-xml docbook-xsl intltool"
 PKGSUG="wireless-tools"

--- a/extra-lxde/lxpanel/autobuild/defines
+++ b/extra-lxde/lxpanel/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=lxpanel
 PKGSEC=LXDE
-PKGDEP="alsa-lib gtk-3 libfm lxmenu-data menu-cache keybinder-3.0 libwnck-3"
+PKGDEP="alsa-lib gdk-pixbuf-xlib gtk-3 libfm lxmenu-data menu-cache keybinder-3.0 libwnck-3"
 BUILDDEP="wireless-tools docbook-xml docbook-xsl intltool"
 PKGSUG="wireless-tools"
 PKGDES="Lightweight X11 desktop panel"

--- a/extra-lxde/lxpanel/spec
+++ b/extra-lxde/lxpanel/spec
@@ -1,4 +1,4 @@
 VER=0.9.3
 REL=4
-SRCTBL="https://downloads.sourceforge.net/sourceforge/lxde/lxpanel-$VER.tar.xz"
-CHKSUM="sha256::342cfa205f255acf69c76ba0ca6c77c890f3955a879b755931c80ffae4d98fb1"
+SRCS="tbl::https://downloads.sourceforge.net/sourceforge/lxde/lxpanel-$VER.tar.xz"
+CHKSUMS="sha256::342cfa205f255acf69c76ba0ca6c77c890f3955a879b755931c80ffae4d98fb1"

--- a/extra-lxde/lxpanel/spec
+++ b/extra-lxde/lxpanel/spec
@@ -1,4 +1,4 @@
 VER=0.9.3
-REL=3
+REL=4
 SRCTBL="https://downloads.sourceforge.net/sourceforge/lxde/lxpanel-$VER.tar.xz"
 CHKSUM="sha256::342cfa205f255acf69c76ba0ca6c77c890f3955a879b755931c80ffae4d98fb1"

--- a/extra-lxde/lxrandr/autobuild/defines
+++ b/extra-lxde/lxrandr/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxrandr
-PKGSEC=lxde
+PKGSEC=LXDE
 PKGDEP="gtk-3 x11-app"
 PKGDEP__RETRO="gtk-2 x11-app"
 PKGDEP__ARMEL="${PKGDEP__RETRO}"

--- a/extra-lxde/lxrandr/spec
+++ b/extra-lxde/lxrandr/spec
@@ -1,4 +1,4 @@
 VER=0.3.2
-SRCTBL="https://downloads.sourceforge.net/project/lxde/LXRandR%20%28monitor%20config%20tool%29/LXRandR%200.3.x/lxrandr-$VER.tar.xz"
-CHKSUM="sha256::8b5edfc9718061bc161fe51d388697cbaa819d6f8013ed24ba22f438e0dbc312"
+SRCS="tbl::https://downloads.sourceforge.net/project/lxde/LXRandR%20%28monitor%20config%20tool%29/LXRandR%200.3.x/lxrandr-$VER.tar.xz"
+CHKSUMS="sha256::8b5edfc9718061bc161fe51d388697cbaa819d6f8013ed24ba22f438e0dbc312"
 REL=1

--- a/extra-lxde/lxrandr/spec
+++ b/extra-lxde/lxrandr/spec
@@ -1,3 +1,4 @@
 VER=0.3.2
 SRCTBL="https://downloads.sourceforge.net/project/lxde/LXRandR%20%28monitor%20config%20tool%29/LXRandR%200.3.x/lxrandr-$VER.tar.xz"
 CHKSUM="sha256::8b5edfc9718061bc161fe51d388697cbaa819d6f8013ed24ba22f438e0dbc312"
+REL=1

--- a/extra-lxde/lxsession/autobuild/defines
+++ b/extra-lxde/lxsession/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxsession
-PKGSEC=lxde
+PKGSEC=LXDE
 PKGDEP="dbus-glib gtk-2 libappindicator libindicator libnotify \
         libunique polkit"
 BUILDDEP="docbook-xsl intltool vala"

--- a/extra-lxde/lxsession/spec
+++ b/extra-lxde/lxsession/spec
@@ -1,4 +1,4 @@
 VER=0.5.5
-SRCTBL="https://downloads.sourceforge.net/lxde/lxsession-$VER.tar.xz"
-CHKSUM="sha256::e43e0d9c033095559ab57c8821c2b84fea58009d267db1324d32dca8bd4dbb46"
+SRCS="tbl::https://downloads.sourceforge.net/lxde/lxsession-$VER.tar.xz"
+CHKSUMS="sha256::e43e0d9c033095559ab57c8821c2b84fea58009d267db1324d32dca8bd4dbb46"
 REL=1

--- a/extra-lxde/lxsession/spec
+++ b/extra-lxde/lxsession/spec
@@ -1,3 +1,4 @@
 VER=0.5.5
 SRCTBL="https://downloads.sourceforge.net/lxde/lxsession-$VER.tar.xz"
 CHKSUM="sha256::e43e0d9c033095559ab57c8821c2b84fea58009d267db1324d32dca8bd4dbb46"
+REL=1

--- a/extra-lxde/lxtask/autobuild/defines
+++ b/extra-lxde/lxtask/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxtask
-PKGSEC=lxde
+PKGSEC=LXDE
 PKGDEP="gtk-3"
 BUILDDEP="intltool"
 PKGDES="Task manager for LXDE"

--- a/extra-lxde/lxtask/spec
+++ b/extra-lxde/lxtask/spec
@@ -1,3 +1,4 @@
 VER=0.1.9
 SRCTBL="https://downloads.sourceforge.net/lxde/lxtask-$VER.tar.xz"
 CHKSUM="sha256::41ea88f0adf31a840e4b9d137ca5ea802860d1a117845ba25f3080d74a876433"
+REL=1

--- a/extra-lxde/lxtask/spec
+++ b/extra-lxde/lxtask/spec
@@ -1,4 +1,3 @@
-VER=0.1.9
+VER=0.1.10
 SRCTBL="https://downloads.sourceforge.net/lxde/lxtask-$VER.tar.xz"
-CHKSUM="sha256::41ea88f0adf31a840e4b9d137ca5ea802860d1a117845ba25f3080d74a876433"
-REL=1
+CHKSUM="sha256::2216df9bc4bb2d80733e788966512ac58c421e0a0a1ff85210f34a29d1eb4e2c"

--- a/extra-lxde/lxtask/spec
+++ b/extra-lxde/lxtask/spec
@@ -1,3 +1,3 @@
 VER=0.1.10
-SRCTBL="https://downloads.sourceforge.net/lxde/lxtask-$VER.tar.xz"
-CHKSUM="sha256::2216df9bc4bb2d80733e788966512ac58c421e0a0a1ff85210f34a29d1eb4e2c"
+SRCS="tbl::https://downloads.sourceforge.net/lxde/lxtask-$VER.tar.xz"
+CHKSUMS="sha256::2216df9bc4bb2d80733e788966512ac58c421e0a0a1ff85210f34a29d1eb4e2c"

--- a/extra-lxde/lxterminal/autobuild/defines
+++ b/extra-lxde/lxterminal/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lxterminal
-PKGSEC=lxde
+PKGSEC=LXDE
 PKGDEP="vte-gtk3"
 BUILDDEP="intltool"
 PKGDES="VTE-based terminal emulator for LXDE"

--- a/extra-lxde/lxterminal/spec
+++ b/extra-lxde/lxterminal/spec
@@ -1,4 +1,4 @@
 VER=0.3.2
 REL=2
-SRCTBL="https://downloads.sourceforge.net/lxde/lxterminal-$VER.tar.xz"
-CHKSUM="sha256::3166b18493a8e55811b02aa0de825cbbea65e2b628e69006c1a65b98e1bb4484"
+SRCS="tbl::https://downloads.sourceforge.net/lxde/lxterminal-$VER.tar.xz"
+CHKSUMS="sha256::3166b18493a8e55811b02aa0de825cbbea65e2b628e69006c1a65b98e1bb4484"

--- a/extra-lxde/lxterminal/spec
+++ b/extra-lxde/lxterminal/spec
@@ -1,4 +1,4 @@
 VER=0.3.2
-REL=1
+REL=2
 SRCTBL="https://downloads.sourceforge.net/lxde/lxterminal-$VER.tar.xz"
 CHKSUM="sha256::3166b18493a8e55811b02aa0de825cbbea65e2b628e69006c1a65b98e1bb4484"

--- a/extra-lxde/pcmanfm/autobuild/defines
+++ b/extra-lxde/pcmanfm/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=pcmanfm
-PKGSEC=x11
+PKGSEC=LXDE
 PKGDEP="desktop-file-utils gtk-3 gvfs libfm lxmenu-data udisks menu-cache"
 BUILDDEP="intltool"
 PKGDES="Lightweight X11 file manager"

--- a/extra-lxde/pcmanfm/spec
+++ b/extra-lxde/pcmanfm/spec
@@ -1,4 +1,4 @@
 VER=1.3.1
-SRCTBL="https://downloads.sourceforge.net/pcmanfm/pcmanfm-$VER.tar.xz"
-CHKSUM="sha256::6804043b3ee3a703edde41c724946174b505fe958703eadbd7e0876ece836855"
+SRCS="tbl::https://downloads.sourceforge.net/pcmanfm/pcmanfm-$VER.tar.xz"
+CHKSUMS="sha256::6804043b3ee3a703edde41c724946174b505fe958703eadbd7e0876ece836855"
 REL=1

--- a/extra-lxde/pcmanfm/spec
+++ b/extra-lxde/pcmanfm/spec
@@ -1,3 +1,4 @@
 VER=1.3.1
 SRCTBL="https://downloads.sourceforge.net/pcmanfm/pcmanfm-$VER.tar.xz"
 CHKSUM="sha256::6804043b3ee3a703edde41c724946174b505fe958703eadbd7e0876ece836855"
+REL=1

--- a/groups/lxde
+++ b/groups/lxde
@@ -1,0 +1,15 @@
+extra-lxde/lxde-common
+extra-lxde/lxde-icon-theme
+extra-lxde/lxmenu-data
+extra-lxde/pcmanfm
+extra-lxde/lxpanel
+extra-lxde/lxappearance
+extra-lxde/lxappearance-obconf
+extra-lxde/lxsession
+extra-lxde/lxrandr
+extra-lxde/lxtask 
+extra-lxde/lxterminal
+extra-lxde/lxdm   
+extra-lxde/lxinput
+extra-lxde/lxlauncher
+extra-lxde/gpicview


### PR DESCRIPTION
Topic Description
-----------------

Rebuild all `groups/lxde` packages to use the new `LXDE` PKGSEC, as defined in Autobuild3 >= v1.6. Update LXTask (`lxtask`) to v0.1.10 due to GCC 10 incompatibility.

Package(s) Affected
-------------------

See `groups/lxde`.

Security Update?
----------------

No

Build Order
-----------

```
groups/lxde
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`