### PR TITLE
intel-graphics-compiler: update to 1.0.7423

### DIFF
--- a/extra-devel/intel-graphics-compiler/autobuild/patches/0002-use-cmake-chaining.patch
+++ b/extra-devel/intel-graphics-compiler/autobuild/patches/0002-use-cmake-chaining.patch
@@ -1,6 +1,6 @@
---- a/IGC/VectorCompiler/cmake/spirv.cmake	2021-04-08 20:44:44.516300872 -0700
-+++ b/IGC/VectorCompiler/cmake/spirv.cmake	2021-04-08 20:51:25.825196118 -0700
-@@ -174,46 +174,18 @@
+--- a/IGC/VectorCompiler/cmake/spirv.cmake	2021-05-20 00:59:35.680328905 -0700
++++ b/IGC/VectorCompiler/cmake/spirv.cmake	2021-05-20 01:08:15.551198760 -0700
+@@ -174,45 +174,21 @@
      message(FATAL_ERROR "[VC] Found unsupported version of LLVM (LLVM_VERSION_MAJOR is set to ${LLVM_VERSION_MAJOR})")
    endif()
  
@@ -15,8 +15,8 @@
 -  ${SPRIV_BRANCH_PATCH}
 -  )
 -
-   if(${IGC_OPTION__LLVM_FROM_SYSTEM})
--
+   if(IGC_BUILD__LLVM_PREBUILDS)
+ 
 -    ExternalProject_Add(SPIRVDLL_EX
 -        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/SPIRVDLL
 -        SOURCE_DIR ${SPIRV_COPY}
@@ -24,11 +24,11 @@
 -        BUILD_COMMAND ${MAKE_EXEC} SPIRVDLL
 -        INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/spirv-install
 -      )
--
 +    add_subdirectory(${SPIRV_SOURCES} "${SPIRV_COPY}")
 +    add_dependencies(SPIRVDLL VCCodeGen)
+ 
    else()
--
+ 
 -    ExternalProject_Add(SPIRVDLL_EX
 -        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/SPIRVDLL
 -        SOURCE_DIR ${SPIRV_COPY}
@@ -39,7 +39,7 @@
 -
 +    add_subdirectory(${SPIRV_SOURCES} "${SPIRV_COPY}")
 +    add_dependencies(SPIRVDLL VCCodeGen)
-   endif(${IGC_OPTION__LLVM_FROM_SYSTEM})
+   endif(IGC_BUILD__LLVM_PREBUILDS)
  
 -  add_dependencies(SPIRVDLL_EX VCCodeGen)
 -
@@ -47,11 +47,9 @@
 -    ${CMAKE_CURRENT_BINARY_DIR}/spirv-install/lib/libSPIRVDLL.so
 -    DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
 -    COMPONENT igc-core
--  )
--
 +      $<TARGET_FILE:SPIRVDLL>
 +      DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
 +      COMPONENT igc-core
-+    )
+   )
+ 
  endif(DEFINED SPIRVDLL_SRC)
- endif(INSTALL_SPIRVDLL)

--- a/extra-devel/intel-graphics-compiler/autobuild/patches/0004-fix-build-with-llvm-11.patch
+++ b/extra-devel/intel-graphics-compiler/autobuild/patches/0004-fix-build-with-llvm-11.patch
@@ -66,15 +66,14 @@ diff -Naur intel-graphics-compiler-igc-1.0.6812/IGC/Compiler/Optimizer/OpenCLPas
      }
      unsigned int AlignedOffset = (Offset / ElemByteSize) * ElemByteSize;
      unsigned int LoadByteSize = (Offset == AlignedOffset) ? Size : Size * 2;
-diff -Naur intel-graphics-compiler-igc-1.0.6812/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp intel-graphics-compiler-igc-1.0.6812-bak/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp
---- intel-graphics-compiler-igc-1.0.6812/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp	2021-03-22 02:55:24.000000000 -0700
-+++ intel-graphics-compiler-igc-1.0.6812-bak/IGC/VectorCompiler/lib/GenXCodeGen/GenXPatternMatch.cpp	2021-04-09 16:09:00.917881444 -0700
-@@ -2233,7 +2233,7 @@
+--- a/IGC/VectorCompiler/igcdeps/src/ShaderOverride.cpp	2021-05-20 01:17:49.643935000 -0700
++++ b/IGC/VectorCompiler/igcdeps/src/ShaderOverride.cpp	2021-05-20 01:17:57.074021061 -0700
+@@ -78,7 +78,7 @@
+ bool VC_IGCShaderOverrider::override(void *&GenXBin, int &GenXBinSize,
+                                      llvm::StringRef ShaderName,
+                                      Extensions Ext) const {
+-  std::string const LegalizedShaderName = legalizeName(ShaderName);
++  std::string const LegalizedShaderName = legalizeName(ShaderName.str());
+   std::string const FullPath = path(LegalizedShaderName, Ext);
+   bool Status = false;
  
- bool GenXPatternMatch::clearDeadInstructions(Function &F) {
-   bool Changed = false;
--  SmallVector<Instruction *, 8> ToErase;
-+  SmallVector<WeakTrackingVH, 8> ToErase;
-   for (auto &Inst : instructions(F))
-     if (isInstructionTriviallyDead(&Inst))
-       ToErase.push_back(&Inst);

--- a/extra-devel/intel-graphics-compiler/spec
+++ b/extra-devel/intel-graphics-compiler/spec
@@ -1,9 +1,8 @@
-VER=1.0.6812
-REL=1
+VER=1.0.7423
 SRCS="tbl::https://github.com/intel/intel-graphics-compiler/archive/igc-$VER.tar.gz \
-      git::commit=6713229fd8947f4cf200f675d22fb7e9997fa261;rename=vc-intrinsics::https://github.com/intel/vc-intrinsics \
+      git::commit=069ced1e8a408d8b602b3b210017603792df6260;rename=vc-intrinsics::https://github.com/intel/vc-intrinsics \
       git::commit=d6dc999eee381158a26f048a333467c9ce7e77f2;rename=SPIRV-LLVM-Translator::https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
-CHKSUMS="sha256::9685886963b516c8cbb8af1950389b86c0f4ee5c299dd06563a33cf7ade379f4 \
+CHKSUMS="sha256::4213710fcb5a299a1fc4c7429375312f7875b9efab2323e6e180ba908ba4cb00 \
          SKIP \
          SKIP"
 SUBDIR="intel-graphics-compiler-igc-$VER"


### PR DESCRIPTION
Topic Description
-----------------

intel-graphics-compiler: update to 1.0.7423

Package(s) Affected
-------------------

`intel-graphics-compiler`

Security Update?
----------------

No


Architectural Progress
----------------------

- [X] AMD64 `amd64`

Secondary Architectural Progress
--------------------------------

N/A

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

N/A