### PR TITLE
aoscbootstrap: update to 0.1.6

### DIFF
--- a/extra-utils/aoscbootstrap/spec
+++ b/extra-utils/aoscbootstrap/spec
@@ -1,5 +1,4 @@
-VER=0.1.4
-REL=1
+VER=0.1.6
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscbootstrap"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=AOSC-Dev/aoscbootstrap"


### PR DESCRIPTION
Topic Description
-----------------

Update `aoscbootstrap` to v0.1.6.

Package(s) Affected
-------------------

`aoscbootstrap` v0.1.6

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`