### PR TITLE
snapper: update to 0.9.0

### DIFF
--- a/extra-admin/snapper/autobuild/patches/0004-Arch-Linux-use-usr-path.patch
+++ b/extra-admin/snapper/autobuild/patches/0004-Arch-Linux-use-usr-path.patch
@@ -1,16 +1,3 @@
-diff --git a/data/Makefile.am b/data/Makefile.am
-index e2036ba..c80b269 100644
---- a/data/Makefile.am
-+++ b/data/Makefile.am
-@@ -18,7 +18,7 @@ install-data-local:
- 	install -D -m 644 lvm.txt $(DESTDIR)/etc/snapper/filters/lvm.txt
- 	install -D -m 644 x11.txt $(DESTDIR)/etc/snapper/filters/x11.txt
- 
--	install -D -m 644 org.opensuse.Snapper.conf $(DESTDIR)/etc/dbus-1/system.d/org.opensuse.Snapper.conf
-+	install -D -m 644 org.opensuse.Snapper.conf $(DESTDIR)/usr/share/dbus-1/system.d/org.opensuse.Snapper.conf
- 	install -D -m 644 org.opensuse.Snapper.service $(DESTDIR)/usr/share/dbus-1/system-services/org.opensuse.Snapper.service
- 
- 	install -D -m 644 timeline.service $(DESTDIR)/usr/lib/systemd/system/snapper-timeline.service
 diff --git a/data/org.opensuse.Snapper.service b/data/org.opensuse.Snapper.service
 index 39d7333..6c49474 100644
 --- a/data/org.opensuse.Snapper.service

--- a/extra-admin/snapper/spec
+++ b/extra-admin/snapper/spec
@@ -1,3 +1,3 @@
-VER=0.8.16
+VER=0.9.0
 SRCS="tbl::https://github.com/openSUSE/snapper/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::391aeca9f95b1da64833a844e6e3779a8e5d955d74eba59e314dbb591bd215cd"
+CHKSUMS="sha256::ca7b17d0213aa5281ff08d968b4e029b78bb3870eb79fd7bc7f879b17f5c969e"


### PR DESCRIPTION
Topic Description
-----------------

Update snapper to 0.9.0

Package(s) Affected
-------------------

snapper

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
