### PR TITLE
opencc: fix pkg-config libdir path

### DIFF
--- a/extra-i18n/opencc/autobuild/beyond
+++ b/extra-i18n/opencc/autobuild/beyond
@@ -1,6 +1,6 @@
 abinfo "Building and installing opencc python modules..."
 mkdir -pv "$SRCDIR"/python/opencc/clib
-cp -v "$SRCDIR"/build/opencc_clib.so "$SRCDIR"/python/opencc/clib/
+cp -v "$SRCDIR"/abbuild/opencc_clib.so "$SRCDIR"/python/opencc/clib/
 touch "$SRCDIR"/python/opencc/clib/__init__.py
 
 abinfo "Building and installing Python3 modules ..."

--- a/extra-i18n/opencc/autobuild/defines
+++ b/extra-i18n/opencc/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=opencc
 PKGEPOCH=1
 PKGSEC=localization
-PKGDEP="gcc-runtime"
-BUILDDEP="cmake doxygen wheel rapidjson tclap marisa pybind11 chrpath"
+PKGDEP="gcc-runtime marisa"
+BUILDDEP="cmake doxygen wheel rapidjson tclap pybind11 chrpath"
 PKGDES="Open source Chinese conversion library and utilities"
 
 # Need to set LIB_INSTALL_DIR so that the .pc file has the correct libdir.

--- a/extra-i18n/opencc/autobuild/defines
+++ b/extra-i18n/opencc/autobuild/defines
@@ -5,8 +5,9 @@ PKGDEP="gcc-runtime"
 BUILDDEP="cmake doxygen wheel rapidjson tclap marisa pybind11 chrpath"
 PKGDES="Open source Chinese conversion library and utilities"
 
-
-CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr \
+# Need to set LIB_INSTALL_DIR so that the .pc file has the correct libdir.
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr 
+             -DLIB_INSTALL_DIR=/usr/lib \
              -DBUILD_DOCUMENTATION:BOOL=ON \
              -DBUILD_PYTHON:BOOL=ON \
              -DUSE_SYSTEM_MARISA:BOOL=ON \

--- a/extra-i18n/opencc/spec
+++ b/extra-i18n/opencc/spec
@@ -1,5 +1,5 @@
 VER=1.1.2
-REL=1
+REL=2
 SRCS="tbl::https://github.com/BYVoid/OpenCC/archive/ver.$VER.tar.gz"
 CHKSUMS="sha256::8c0f44a210c4ee0cc79972d47829b2f3e1e90a26c4db0949da3ad99a8d1fe375"
 SUBDIR="OpenCC-ver.$VER"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

opencc: fix pkg-config libdir path

Fix some application could not find opencc libdir, e.g opencc-rust:

```
[build.rs:75] run_pkg_config().link_paths = [
    "lib",
]
thread 'main' panicked at 'OpenCC library directory does not exist: lib', build.rs:22:13
```

And:

```
saki@Mag230 [ opencc-rust@master ] $ cat /usr/lib/pkgconfig/opencc.pc 
prefix=/usr
exec_prefix=${prefix}
libdir=lib
includedir=/usr/include/

Name: opencc
Description: Open Chinese Convert
Version: 1.1.2
Requires:
Libs: -L${libdir} -lopencc
Cflags: -I${includedir}/opencc
```

This commit to set `libdir` value as `/usr/lib`

Package(s) Affected
-------------------

opencc: 1.1.2-2

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
