### PR TITLE
meowdict: update to 0.6.1

### DIFF
--- a/extra-i18n/meowdict/autobuild/defines
+++ b/extra-i18n/meowdict/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME="meowdict"
 PKGDES="CLI Web client for moedict.tw"
-PKGDEP="glibc"
+PKGDEP="glibc opencc"
 BUILDDEP="rustc llvm"
 PKGSEC="localization"
 

--- a/extra-i18n/meowdict/spec
+++ b/extra-i18n/meowdict/spec
@@ -1,3 +1,3 @@
-VER=0.5.2
+VER=0.6.1
 SRCS="tbl::https://github.com/eatradish/meowdict/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::76e29dd0703a359558de9a176844bc70cd01f9e9c1e8f66027ed07617e68de1a"
+CHKSUMS="sha256::9a81c64213a9aa8a186e261c8514e46374c8d5ded774e592ae274615ff5b6325"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

meowdict: update to 0.6.1

Package(s) Affected
-------------------

meowdict: 0.6.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
