### PR TITLE
openrgb: update to 0.6

### DIFF
--- a/extra-utils/openrgb/autobuild/beyond
+++ b/extra-utils/openrgb/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "moving udev rules to /usr/lib ..."
+mv -v "$PKGDIR"/lib "$PKGDIR"/usr

--- a/extra-utils/openrgb/autobuild/beyond
+++ b/extra-utils/openrgb/autobuild/beyond
@@ -1,2 +1,2 @@
-abinfo "moving udev rules to /usr/lib ..."
+abinfo "Moving udev rules to /usr/lib ..."
 mv -v "$PKGDIR"/lib "$PKGDIR"/usr

--- a/extra-utils/openrgb/autobuild/patches/0001-nostrip.patch
+++ b/extra-utils/openrgb/autobuild/patches/0001-nostrip.patch
@@ -1,0 +1,12 @@
+diff --git a/OpenRGB.pro b/OpenRGB.pro
+index ef5a4f2..d6c8f8c 100644
+--- a/OpenRGB.pro
++++ b/OpenRGB.pro
+@@ -14,7 +14,7 @@ QT +=
+ #-----------------------------------------------------------------------------------------------#
+ # Set compiler to use C++17 to make std::filesystem available                                   #
+ #-----------------------------------------------------------------------------------------------#
+-CONFIG += c++17
++CONFIG += c++17 nostrip
+
+ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets

--- a/extra-utils/openrgb/spec
+++ b/extra-utils/openrgb/spec
@@ -1,3 +1,3 @@
-VER=0.4
+VER=0.6
 SRCS="tbl::https://gitlab.com/CalcProgrammer1/OpenRGB/-/archive/release_$VER/OpenRGB-release_$VER.tar.bz2"
-CHKSUMS="sha256::68cb84bdfb7ac657b790d688954b6ea14fec6855203ed2e8005991a88413bfa6"
+CHKSUMS="sha256::1b0ffb9755282b893563535d7275781044144d02033a8b9edf80b64d6214ac72"


### PR DESCRIPTION

Topic Description
-----------------

update openrgb to v0.6

Package(s) Affected
-------------------

`openrgb` v0.6

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
