### PR TITLE
QEMU: Upgrade to 6.0.0, enable LTO

### DIFF
--- a/extra-emulation/qemu/01-shared/build
+++ b/extra-emulation/qemu/01-shared/build
@@ -4,6 +4,7 @@ COMMON_CONFIGURE_FLAGS="
 	--localstatedir=/var
 	--python=/usr/bin/python3
 	--disable-strip
+	--enable-lto
 "
 
 DYN_CONFIGURE_FLAGS="

--- a/extra-emulation/qemu/spec
+++ b/extra-emulation/qemu/spec
@@ -1,3 +1,3 @@
-VER=5.2.0
+VER=6.0.0
 SRCS="tbl::https://wiki.qemu-project.org/download/qemu-$VER.tar.xz"
-CHKSUMS="sha256::cb18d889b628fbe637672b0326789d9b0e3b8027e0445b936537c78549df17bc"
+CHKSUMS="sha256::87bc1a471ca24b97e7005711066007d443423d19aacda3d442558ae032fa30b9"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates qemu system virtualization and userspace loader to 6.0.0. This version now includes upstream LTO support, which should improve performance by some degree.

Package(s) Affected
-------------------
* `qemu`: 6.0.0

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
