### PR TITLE
PolicyKit 0.119

### DIFF
--- a/extra-admin/polkit/autobuild/beyond
+++ b/extra-admin/polkit/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Setting configuration dir owner to polkitd user and permissions"
+chown -c -R 27:root "${PKGDIR}/etc/polkit-1/rules.d"

--- a/extra-admin/polkit/autobuild/beyond
+++ b/extra-admin/polkit/autobuild/beyond
@@ -1,2 +1,2 @@
 abinfo "Setting configuration dir owner to polkitd user and permissions"
-chown -c -R 27:root "${PKGDIR}/etc/polkit-1/rules.d"
+chown -cvR 27:root "${PKGDIR}/etc/polkit-1/rules.d"

--- a/extra-admin/polkit/autobuild/defines
+++ b/extra-admin/polkit/autobuild/defines
@@ -2,10 +2,14 @@ PKGNAME=polkit
 PKGDES="Application development toolkit for controlling system-wide privileges"
 PKGSEC=admin
 PKGDEP="expat systemd glib linux-pam js-78"
-BUILDDEP="gobject-introspection gtk-doc autoconf-archive intltool"
+BUILDDEP="gobject-introspection gtk-doc autoconf-archive intltool libxslt"
 
-AUTOTOOLS_STRICT=0
-AUTOTOOLS_AFTER="--libexecdir=/usr/lib/polkit-1 \
-                 --enable-libsystemd-login=yes \
-                 --disable-static \
-                 --enable-gtk-doc"
+ABTYPE=meson
+MESON_AFTER="
+	-Db_lto=true
+	-Db_pie=true
+	-Dman=true
+	-Dgtk_doc=true
+	-Dos_type=redhat
+	-Dsession_tracking=libsystemd-login
+"

--- a/extra-admin/polkit/autobuild/postinst
+++ b/extra-admin/polkit/autobuild/postinst
@@ -1,0 +1,1 @@
+chown 27:root /etc/polkit-1/rules.d

--- a/extra-admin/polkit/spec
+++ b/extra-admin/polkit/spec
@@ -1,4 +1,3 @@
-VER=0.118
-SRCS="tbl::https://www.freedesktop.org/software/polkit/releases/polkit-$VER.tar.gz"
-CHKSUMS="sha256::6d54e984e7072339f0d3147179e16e34e5fe0705158f259a765d772dcf78956b"
-REL=1
+VER=0.119
+SRCS="tbl::https://gitlab.freedesktop.org/polkit/polkit/-/archive/${VER}/polkit-${VER}tar.gz"
+CHKSUMS="sha256::a8c7a85ae943bd99d450b7371487a19927289216b5118e04de5da84850e6e3fe"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates Policy Kit to 0.119 with the following fixes:

* Ownership `polkitd:root` enforced on directory `/etc/polkit-1/rules.d` at post-installation
* Resolves CVE-2021-3560

Package(s) Affected
-------------------

* `polkit`: 0.119

Security Update?
----------------

Yesss - Issue / AOSA number pending.

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

---

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
