### PR TITLE
AOSC tools update 20210605

### DIFF
--- a/extra-devel/acbs/spec
+++ b/extra-devel/acbs/spec
@@ -1,3 +1,3 @@
-VER=20210604
+VER=20210605
 SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/acbs"
 CHKSUMS="SKIP"

--- a/extra-devel/acbs/spec
+++ b/extra-devel/acbs/spec
@@ -1,4 +1,3 @@
-VER=20210403
-REL=1
+VER=20210604
 SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/acbs"
 CHKSUMS="SKIP"

--- a/extra-devel/ciel/spec
+++ b/extra-devel/ciel/spec
@@ -1,5 +1,4 @@
-VER=3.0.3
-REL=1
+VER=3.0.4
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=AOSC-Dev/ciel-rs"


### PR DESCRIPTION
Topic Description
-----------------

AOSC tools update 20210605

Package(s) Affected
-------------------

```
acbs
ciel
```

Security Update?
----------------

No

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------


- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

