### PR TITLE
aoscdk-rs: new, 0+git20210605

### DIFF
--- a/extra-admin/aoscdk-rs/autobuild/beyond
+++ b/extra-admin/aoscdk-rs/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Symlinking deploykit => aoscdk-rs ..."
+ln -sv aoscdk-rs \
+    "$PKGDIR"/usr/bin/deploykit

--- a/extra-admin/aoscdk-rs/autobuild/defines
+++ b/extra-admin/aoscdk-rs/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=aoscdk-rs
+PKGSEC=admin
+PKGDEP="gcc-runtime lvm2 ncurses openssl parted systemd xz"
+BUILDDEP="llvm rustc"
+PKGDES="AOSC OS system installer"
+
+USECLANG=1

--- a/extra-admin/aoscdk-rs/spec
+++ b/extra-admin/aoscdk-rs/spec
@@ -1,0 +1,3 @@
+VER=0+git20210605
+SRCS="git::commit=c73f089335d5eb7bb1fd8d595495ffb7f1e546dd::https://github.com/AOSC-Dev/aoscdk-rs/"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Introduces DeployKit, an AOSC OS installer.

Package(s) Affected
-------------------

`aoscdk-rs` v0+git20210605

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`