### PR TITLE
PolicyKit: setuid bit on polkit-agent-helper-1

### DIFF
--- a/extra-admin/polkit/autobuild/beyond
+++ b/extra-admin/polkit/autobuild/beyond
@@ -1,2 +1,5 @@
 abinfo "Setting configuration dir owner to polkitd user and permissions"
 chown -cvR 27:root "${PKGDIR}/etc/polkit-1/rules.d"
+
+abinfo "Setting suid bit on polkit agent helper"
+chmod -v u+s "${PKGDIR}/usr/lib/polkit-1/polkit-agent-helper-1"

--- a/extra-admin/polkit/spec
+++ b/extra-admin/polkit/spec
@@ -1,3 +1,4 @@
 VER=0.119
+REL=1
 SRCS="tbl::https://gitlab.freedesktop.org/polkit/polkit/-/archive/${VER}/polkit-${VER}tar.gz"
 CHKSUMS="sha256::a8c7a85ae943bd99d450b7371487a19927289216b5118e04de5da84850e6e3fe"


### PR DESCRIPTION
Topic Description
-----------------

This PR fixes an issue where `/usr/lib/polkit-1/polkit-agent-helper-1` does not have setuid bit. Certain programs request privilege escalation via `polkit-agent-helper-1` and will fail without setuid bit.

Package(s) Affected
-------------------

* `polkit`: 0.119-1

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
