### PR TITLE
aiohttp: update to 3.7.4.post0

### DIFF
--- a/extra-python/aiohttp/spec
+++ b/extra-python/aiohttp/spec
@@ -1,3 +1,3 @@
-VER=3.7.3
+VER=3.7.4.post0
 SRCS="tbl::https://pypi.python.org/packages/source/a/aiohttp/aiohttp-${VER}.tar.gz"
-CHKSUMS="sha256::9c1a81af067e72261c9cbe33ea792893e83bc6aa987bfbd6fdc1e5e7b22777c4"
+CHKSUMS="sha256::493d3299ebe5f5a7c66b9819eacdcfbbaaf1a8e84911ddffcdc48888497afecf"


### PR DESCRIPTION
Topic Description
-----------------

Update aiohttp to 3.7.4.post0

Package(s) Affected
-------------------

aiohttp

Security Update?
----------------

Yes - Issue Number: #3154

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`