### PR TITLE
KDE survey 20210608

### DIFF
--- a/extra-kde/bluedevil/spec
+++ b/extra-kde/bluedevil/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/bluedevil-$VER.tar.xz"
-CHKSUMS="sha256::26b03747e997fc2e7d734ea583a2a81174f0d982a965e0254c8ba690721f6289"
+CHKSUMS="sha256::cc775a3cb3c292966eeaa4b2ad936e74e1ba25867599e88e271952cdf450df3a"

--- a/extra-kde/breeze-grub/spec
+++ b/extra-kde/breeze-grub/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/breeze-grub-$VER.tar.xz"
-CHKSUMS="sha256::e727c98cfce3fac49a3d97d6ff76150901b200105776c1c2f02dfbdfa7c00def"
+CHKSUMS="sha256::0210a278d402e12d3267a8e688dd70fce7aef3358eb6f3937de26aea8785edc3"

--- a/extra-kde/breeze-gtk/spec
+++ b/extra-kde/breeze-gtk/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/breeze-gtk-$VER.tar.xz"
-CHKSUMS="sha256::0fab052f237447df0de55701ab8fb2edce968c865fbba2f2c934d9dc53f0c719"
+CHKSUMS="sha256::2ce1f92d7cb3846f4b9ad6eb34fc1f7412f1b0e7cb75de38abed7c7e6a2a610f"

--- a/extra-kde/breeze-plymouth/spec
+++ b/extra-kde/breeze-plymouth/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/breeze-plymouth-$VER.tar.xz"
-CHKSUMS="sha256::f3ad283298c6818a660ab69487695f726ed6582adeb7f4c70195f867eb5e4b66"
+CHKSUMS="sha256::f1ee3b2c439f1674c37139fc7ffc94fda2035f9402a9230758feda0b93409da1"

--- a/extra-kde/breeze/spec
+++ b/extra-kde/breeze/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/breeze-$VER.tar.xz"
-CHKSUMS="sha256::9774c695da7d51c45116f85358e002663a1ccc5681b04c9afc7a57e8b075980c"
+CHKSUMS="sha256::1b3d2d00bfbafe7cfb6f540809cd89447a52e00c6c435bb671c944af0f2f96ef"

--- a/extra-kde/discover/autobuild/defines
+++ b/extra-kde/discover/autobuild/defines
@@ -7,4 +7,5 @@ PKGDEP="aosc-appstream-data appstream-qt attica5 glib kconfig \
 BUILDDEP="extra-cmake-modules plasma-framework"
 PKGDES="The KDE Plasma interface for desktop computers"
 
-CMAKE_AFTER="-DKDE_INSTALL_USE_QT_SYS_PATHS=ON"
+CMAKE_AFTER="-DKDE_INSTALL_USE_QT_SYS_PATHS=ON \
+             -DCMAKE_SKIP_RPATH=OFF"

--- a/extra-kde/discover/autobuild/overrides/etc/ld.so.conf.d/discover.conf
+++ b/extra-kde/discover/autobuild/overrides/etc/ld.so.conf.d/discover.conf
@@ -1,0 +1,1 @@
+/usr/lib/plasma-discover

--- a/extra-kde/discover/autobuild/overrides/etc/ld.so.conf.d/discover.conf
+++ b/extra-kde/discover/autobuild/overrides/etc/ld.so.conf.d/discover.conf
@@ -1,1 +1,0 @@
-/usr/lib/plasma-discover

--- a/extra-kde/discover/autobuild/postinst
+++ b/extra-kde/discover/autobuild/postinst
@@ -1,1 +1,0 @@
-ldconfig

--- a/extra-kde/discover/spec
+++ b/extra-kde/discover/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/discover-$VER.tar.xz"
-CHKSUMS="sha256::29b8d510a25d997b133aa4d5d3ed0e8f101c61436d5f540b9c5f5df7622f4f84"
+CHKSUMS="sha256::a605d3f9d2f35c604da9a36654bf7c8828312c00b3610a25969101f27186a812"

--- a/extra-kde/drkonqi/spec
+++ b/extra-kde/drkonqi/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/drkonqi-$VER.tar.xz"
-CHKSUMS="sha256::4095e57419a855a33bb665f6696b83eccfebe7e464a463d298c71062524cc6ae"
+CHKSUMS="sha256::b3a2e5c27ce50a7aa8d0e2575eb1746fb0c8f0e84853377483a87d7a66012883"

--- a/extra-kde/kactivitymanagerd/spec
+++ b/extra-kde/kactivitymanagerd/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kactivitymanagerd-$VER.tar.xz"
-CHKSUMS="sha256::77b5394cae27d68c55eaa02e7b9be524b6d8fee9a088e505830347b8289ef0c8"
+CHKSUMS="sha256::b8882b792086e94b7e1a1130417bdf4c0e08a7af84119812997318c62dfc2950"

--- a/extra-kde/kde-cli-tools/spec
+++ b/extra-kde/kde-cli-tools/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kde-cli-tools-$VER.tar.xz"
-CHKSUMS="sha256::369fe177a33fcd45ab4d81b5b535e4f321c00d2e9c7d1f4b2bd42f4c02da1e49"
+CHKSUMS="sha256::28becb598d8aa180c045b7299fd5a0454df1ab355ff570e2584e2faa17ba47e4"

--- a/extra-kde/kde-gtk-config/spec
+++ b/extra-kde/kde-gtk-config/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kde-gtk-config-$VER.tar.xz"
-CHKSUMS="sha256::f39178aa9cbfdcd9e6c1663058f3ff74d658e87b29f9b765f67a5bdc7c46ec1d"
+CHKSUMS="sha256::1f50babdd3425fc0a2a241fc0af15cf72cc441c2decc5dfb0544e92c247fb17e"

--- a/extra-kde/kdecoration/spec
+++ b/extra-kde/kdecoration/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kdecoration-$VER.tar.xz"
-CHKSUMS="sha256::bc550b7bfde5b5762e76b33ac53f8268b6178ae389c953d729b864b22787d54c"
+CHKSUMS="sha256::5e27326b22d899e742606f7bd3493651dc51cd92b5616e30cd4dab3e5356d5b4"

--- a/extra-kde/kdeplasma-addons/spec
+++ b/extra-kde/kdeplasma-addons/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kdeplasma-addons-$VER.tar.xz"
-CHKSUMS="sha256::3c6dd7266c9bb2b89b7ec6831936afb12e32cb00eca19baaa0706cf251617d7d"
+CHKSUMS="sha256::42e399342b4f979ef1aa2e20542ce8308a49369b922aef8cc70b1667733583ec"

--- a/extra-kde/kgamma/spec
+++ b/extra-kde/kgamma/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kgamma5-$VER.tar.xz"
-CHKSUMS="sha256::e64b41468ee5ac77b2b26b009a2e491c79ca6b7b031e2bafe19dda4eb46558e1"
+CHKSUMS="sha256::396e7650914b7473fb453d5e8808b6cd4de697d027aade01d2ec2ee5c814932c"

--- a/extra-kde/khotkeys/spec
+++ b/extra-kde/khotkeys/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/khotkeys-$VER.tar.xz"
-CHKSUMS="sha256::2d58299f705f928f877718c1766a6dce201d728a24e88b9a24ca5e12a5f99c13"
+CHKSUMS="sha256::689a9a605df33c595bf650bbaca9277c25b3defe6b5077cfe45280e931dd3699"

--- a/extra-kde/kinfocenter/spec
+++ b/extra-kde/kinfocenter/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kinfocenter-$VER.tar.xz"
-CHKSUMS="sha256::715a871f6d761515d804049672d58f78cfc04fd8c5db645c489a940979a6f49c"
+CHKSUMS="sha256::1f853c864adab4b4e961d09f2321a861c830322c9f5425d80b8d1453f4559a22"

--- a/extra-kde/kmenuedit/spec
+++ b/extra-kde/kmenuedit/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kmenuedit-$VER.tar.xz"
-CHKSUMS="sha256::e044970df84b889e51465270ee7108f898774309f52434ede12aca2701eaed7b"
+CHKSUMS="sha256::810efc35661b45c61f521fc878251ccc5b290bed1109451a50c58a89c72d9f3f"

--- a/extra-kde/kscreen/spec
+++ b/extra-kde/kscreen/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kscreen-$VER.tar.xz"
-CHKSUMS="sha256::46698bd55ad08e0b833767f2c679832a276826abc37fd9c037614589101a84da"
+CHKSUMS="sha256::5f805e8d3b269fc1f7a9d2f582e49c9b173bd3eb0fd7393ff3b4d7980335519f"

--- a/extra-kde/kscreenlocker/autobuild/defines
+++ b/extra-kde/kscreenlocker/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=kscreenlocker
 PKGSEC=kde
-PKGDEP="kdelibs4support kidletime kwayland plasma-framework"
+PKGDEP="kdelibs4support kidletime kwayland plasma-framework layer-shell-qt"
 BUILDDEP="extra-cmake-modules kdoctools"
 PKGDES="Library and components for secure lock screen architecture"
 

--- a/extra-kde/kscreenlocker/spec
+++ b/extra-kde/kscreenlocker/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kscreenlocker-$VER.tar.xz"
-CHKSUMS="sha256::1dad76b7c791e1077777bc9e1b309a6778c4e2124a1211105f2ca9dffa903637"
+CHKSUMS="sha256::9feacfa447b64bd039e6bb0e339d723927754f2c53161bfd915fe5b1b30fdc75"

--- a/extra-kde/ksshaskpass/spec
+++ b/extra-kde/ksshaskpass/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/ksshaskpass-$VER.tar.xz"
-CHKSUMS="sha256::a2f963a9991cbe639a63664a820b4c55c1bd75be6a209a8b439911ec4911f119"
+CHKSUMS="sha256::61f856613833df7fb3285fb19e5db6ce6f832392369394058fcc6337db6bf497"

--- a/extra-kde/ksysguard/spec
+++ b/extra-kde/ksysguard/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
-SRCS="tbl::https://download.kde.org/stable/plasma/$VER/ksysguard-$VER.tar.xz"
-CHKSUMS="sha256::103b34b83fd2ea1af1cb01b67de70be2ad5362e22270d23cd437ac210bca1bb0"
+VER=5.22.0
+SRCS="tbl::https://download.kde.org/stable/ksysguard/$VER/ksysguard-$VER.tar.xz"
+CHKSUMS="sha256::0f9c624e5fbb2aee906d8d9563c5a7eb09eaf38bc8e4382c072f9e6d8854622d"

--- a/extra-kde/ksystemstats/autobuild/defines
+++ b/extra-kde/ksystemstats/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=ksystemstats
+PKGDES="A plugin based system monitoring daemon"
+PKGDEP="libksysguard"
+BUILDDEP="extra-cmake-modules networkmanager-qt"
+PKGSEC="kde"

--- a/extra-kde/ksystemstats/spec
+++ b/extra-kde/ksystemstats/spec
@@ -1,0 +1,3 @@
+VER=5.22.0
+SRCS="tbl::https://download.kde.org/stable/plasma/$VER/ksystemstats-$VER.tar.xz"
+CHKSUMS="sha256::e0722f1a464983e6b75f142f8804e4ba346645a75fcd5b5305824d2683ed9007"

--- a/extra-kde/kwallet-pam/spec
+++ b/extra-kde/kwallet-pam/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwallet-pam-$VER.tar.xz"
-CHKSUMS="sha256::bf3f30e990bf5c79b0fd2e24d82d01f99c226c5f2c64f57ed4a0bab754046e6b"
+CHKSUMS="sha256::461c01bb2f1d534222839698e9b677a288c8deea00514f9d3a0df43d5614d655"

--- a/extra-kde/kwayland-integration/spec
+++ b/extra-kde/kwayland-integration/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwayland-integration-$VER.tar.xz"
-CHKSUMS="sha256::bd1c713ea584c56f1d3551b08f7d5cd9fd9f66dff85e89de2436d71a3c2404f2"
+CHKSUMS="sha256::2348533e520ab38e094d71ed07f35f33339af996a97088a2b8d3fb64ad516949"

--- a/extra-kde/kwayland-server/spec
+++ b/extra-kde/kwayland-server/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwayland-server-$VER.tar.xz"
-CHKSUMS="sha256::2fcfc16e8bda1f85db8148715ec08a1b36a0738c3796cf886faadc983f8e21c9"
+CHKSUMS="sha256::84617871c47f7e5060462728a82bfcdad14fd0bb2f1f8252bee077e28deb1694"

--- a/extra-kde/kwin/spec
+++ b/extra-kde/kwin/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwin-$VER.tar.xz"
-CHKSUMS="sha256::a286edfaa13bf73565514ee3edb092cfbccac2307c48058a7302a4676c808331"
+CHKSUMS="sha256::56e6cfe23d445b1ee0650c5ac484e8cc63ba39e2f2d77a0d32c4c23905cc0e01"

--- a/extra-kde/kwrited/spec
+++ b/extra-kde/kwrited/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwrited-$VER.tar.xz"
-CHKSUMS="sha256::e1e79046b9657defa5074e46f7bcb09e9000f6e4bc3504eda9363fc60891294e"
+CHKSUMS="sha256::069eeb75d8c8a23f4b8524f94d980129099a8fb076c3f09c086fca6046980319"

--- a/extra-kde/layer-shell-qt/autobuild/defines
+++ b/extra-kde/layer-shell-qt/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME="layer-shell-qt"
+PKGDES="Qt component to allow applications to make use of the Wayland wl-layer-shell protocol"
+PKGDEP="qt-5"
+BUILDDEP="extra-cmake-modules wayland-protocols"
+PKGSEC="kde"

--- a/extra-kde/layer-shell-qt/spec
+++ b/extra-kde/layer-shell-qt/spec
@@ -1,0 +1,3 @@
+VER=5.22.0
+SRCS="https://download.kde.org/stable/plasma/$VER/layer-shell-qt-$VER.tar.xz"
+CHKSUMS="sha256::7e08f39716885aa43a3f2f1bfb29441ef9ee4b07b2928a9680ae8e4c28adcaf7"

--- a/extra-kde/libkscreen/spec
+++ b/extra-kde/libkscreen/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/libkscreen-$VER.tar.xz"
-CHKSUMS="sha256::13059ff71a395efbbb6231a4a796a174adb6a16433051e03db9bc83b7d1e7cba"
+CHKSUMS="sha256::0630ca1dff1dfc7ba74d508c3ff2cb82fd8642281890ded095dff97206299aeb"

--- a/extra-kde/libksysguard/autobuild/defines
+++ b/extra-kde/libksysguard/autobuild/defines
@@ -7,3 +7,6 @@ PKGDES="Runtime libraries for KDE System Guard"
 CMAKE_AFTER="-DKDE_INSTALL_USE_QT_SYS_PATHS=ON \
              -DLIBEXEC_INSTALL_DIR=lib \
              -DBUILD_TESTING=OFF"
+
+PKGBREAK="ksysguard<=5.21.5"
+PKGREP="ksysguard<=5.21.5"

--- a/extra-kde/libksysguard/spec
+++ b/extra-kde/libksysguard/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/libksysguard-$VER.tar.xz"
-CHKSUMS="sha256::5ff8c687a9d245d28ec4b92c019d2234cd931796c619ebb096de6e49cd18ebe8"
+CHKSUMS="sha256::a2d3973aaf7d5c4a1cb6dd463ec8183dd4e9a6c6b851df4b8824f8dd562607a9"

--- a/extra-kde/milou/spec
+++ b/extra-kde/milou/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/milou-$VER.tar.xz"
-CHKSUMS="sha256::31c0db3b48aa4c081b748b999deb428e3c15e99fbf6b2128a900864975683b18"
+CHKSUMS="sha256::ee38467ef60e5d9090874820e15548c84c92c0d86491492671d48bb797354ffd"

--- a/extra-kde/oxygen/spec
+++ b/extra-kde/oxygen/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/oxygen-$VER.tar.xz"
-CHKSUMS="sha256::ac0ad3b62438d08b7103e49871b6751e22bb2308c42072b830f4f8ee00d83649"
+CHKSUMS="sha256::1a9e016dd70e5e6d0a282c786a4db93a0d212a7a91d563ff27a8927864d5a745"

--- a/extra-kde/plasma-browser-integration/spec
+++ b/extra-kde/plasma-browser-integration/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://github.com/KDE/plasma-browser-integration/archive/v$VER.tar.gz"
-CHKSUMS="sha256::48673cf063179a3ea3d8a0990132ed52028d018a024decb14110e1aaa7572d9e"
+CHKSUMS="sha256::df163582ef2d89d579704cd1dcd63f20aee853b97d677eccfd03404e05870126"

--- a/extra-kde/plasma-desktop/autobuild/defines
+++ b/extra-kde/plasma-desktop/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=plasma-desktop
 PKGSEC=kde
-PKGDEP="appstream-qt baloo kactivities-stats kmenuedit kpeople ksysguard \
+PKGDEP="appstream-qt baloo kactivities-stats kmenuedit kpeople libksysguard \
         libcanberra plasma-nm polkit-kde-agent-1 powerdevil systemsettings"
 BUILDDEP="boost extra-cmake-modules ibus intltool kdesignerplugin kdoctools scim \
           xf86-input-evdev xf86-input-synaptics xf86-input-libinput"

--- a/extra-kde/plasma-desktop/spec
+++ b/extra-kde/plasma-desktop/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-desktop-$VER.tar.xz"
-CHKSUMS="sha256::de507e305c8021d9226381e2beded1cf45d1b224e9a5201529924cd60eb31a27"
+CHKSUMS="sha256::f4f8980036157e84aba53181f188bbd45c455408ee411c1df1b12dbac1c0d8a9"

--- a/extra-kde/plasma-disks/spec
+++ b/extra-kde/plasma-disks/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-disks-$VER.tar.xz"
-CHKSUMS="sha256::211d8273aea5146bc6ecb0511d0d4c3bea731c956b35a81dadc4b96a8daea0a0"
+CHKSUMS="sha256::8b591f0c557f622532492dbba46041dabcd6d6384c796eaf5d354d4a933feb60"

--- a/extra-kde/plasma-integration/spec
+++ b/extra-kde/plasma-integration/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-integration-$VER.tar.xz"
-CHKSUMS="sha256::1e745570c9a4526a52a1fd7fc46b4cd5973c2b6047c4577b277bc5910d830c75"
+CHKSUMS="sha256::48f7873e6b882cbba93d6297a119ba1a1c090b6f42f4f03fe13bb4e5632e308e"

--- a/extra-kde/plasma-nano/spec
+++ b/extra-kde/plasma-nano/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-nano-$VER.tar.xz"
-CHKSUMS="sha256::4674ccd3255fae758f7493b9831de047e0e0f99b369601042a441a1f88c23912"
+CHKSUMS="sha256::39f2098329fe44a298bf4b30ab4d2268074c7e1f86d986d3190fc38cb8332f6b"

--- a/extra-kde/plasma-nm/spec
+++ b/extra-kde/plasma-nm/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-nm-$VER.tar.xz"
-CHKSUMS="sha256::9098e660a391e821161ed9ad2361b568297df2b53742a8afe18d6104ac700ba3"
+CHKSUMS="sha256::1b04f0a9d595caa243979bdbe1dfccc600bd9b7f163e193b2d7d0075c637a975"

--- a/extra-kde/plasma-pa/spec
+++ b/extra-kde/plasma-pa/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-pa-$VER.tar.xz"
-CHKSUMS="sha256::f6ef1ea24bc8ef8717a09fc4396e8611c315da3175ffa69d873d485524ca9002"
+CHKSUMS="sha256::6d6f3ba2303c6f640fa2c8c3c648e10021651a00f5ab10d5d78dc7e3ed9d4741"

--- a/extra-kde/plasma-phone-components/spec
+++ b/extra-kde/plasma-phone-components/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-phone-components-$VER.tar.xz"
-CHKSUMS="sha256::811bd9986f0cbcb2f24ce6a99005868340184c33c655009330168dec8a45e769"
+CHKSUMS="sha256::9126c165a1a647e8753bf602d4a7b419beffe89223a5c53801c78b63f7bbe1af"

--- a/extra-kde/plasma-sdk/spec
+++ b/extra-kde/plasma-sdk/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-sdk-$VER.tar.xz"
-CHKSUMS="sha256::01aac092b7c98e3fe5b74fab21cb94781960a8957d5b4a7811503cefa3445e95"
+CHKSUMS="sha256::90364c190090e19c8099f3856f1cc6ff83e274b8a5a40f14d25bd47feab77552"

--- a/extra-kde/plasma-systemmonitor/autobuild/defines
+++ b/extra-kde/plasma-systemmonitor/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME="plasma-systemmonitor"
 PKGDES="An interface for monitoring system sensors, process information and other system resources"
-PKGDEP="ksysguard kirigami2 kitemmodels"
+PKGDEP="libksysguard kirigami2 kitemmodels"
 BUILDDEP="extra-cmake-modules"

--- a/extra-kde/plasma-systemmonitor/spec
+++ b/extra-kde/plasma-systemmonitor/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="https://download.kde.org/stable/plasma/$VER/plasma-systemmonitor-$VER.tar.xz"
-CHKSUMS="sha256::3c4d7facd472fd68eee6c7f7175539eeae42bf8a6d6c8e41925a0b0fd6988ecf"
+CHKSUMS="sha256::6fa0c22f0754f57ce5ab7d43398d5e35217598db34d9fa9e4ad01203cfe375ca"

--- a/extra-kde/plasma-thunderbolt/spec
+++ b/extra-kde/plasma-thunderbolt/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-thunderbolt-$VER.tar.xz"
-CHKSUMS="sha256::a1b85d9e997a7e202972212a79fc026da65509246952b096dd474ba520492c98"
+CHKSUMS="sha256::fa9047a7666bd2769978d3f29be0881bcd26bdc744cda74625135f1c52b92df8"

--- a/extra-kde/plasma-vault/spec
+++ b/extra-kde/plasma-vault/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-vault-$VER.tar.xz"
-CHKSUMS="sha256::7519b5da20e59f571128b66fc22e5d2b2027752e01caa1c70574b12dcfd8979b"
+CHKSUMS="sha256::1f3bbabc5e29b88e85276894020f881360cafaf756f929ec2ae96dba612e96ab"

--- a/extra-kde/plasma-wayland-protocols/spec
+++ b/extra-kde/plasma-wayland-protocols/spec
@@ -1,3 +1,3 @@
-VER=1.2.1
-SRCS="tbl::https://download.kde.org/stable/plasma-wayland-protocols/plasma-wayland-protocols-v$VER.tar.xz"
-CHKSUMS="sha256::287b90903f9a7f394c75e75cb187426862eaf64a92f1be7e2ef68e99fd8cbaaa"
+VER=1.3.0
+SRCS="tbl::https://download.kde.org/stable/plasma-wayland-protocols/plasma-wayland-protocols-$VER.tar.xz"
+CHKSUMS="sha256::0daa2362f2e0d15f79e0e006e8d7f1908e88e37b5c5208b40c9cb0d4d6dca9b5"

--- a/extra-kde/plasma-workspace-wallpapers/spec
+++ b/extra-kde/plasma-workspace-wallpapers/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-workspace-wallpapers-$VER.tar.xz"
-CHKSUMS="sha256::759acd1b6de1e272c751d9366002038fef6617d6717d82262ec459584502404a"
+CHKSUMS="sha256::1d057d38de293ef59f2ecfe37b5edb2eb4572c008cf694e61f17634d4442cf14"

--- a/extra-kde/plasma-workspace/autobuild/defines
+++ b/extra-kde/plasma-workspace/autobuild/defines
@@ -17,5 +17,5 @@ CMAKE_AFTER="-DCMAKE_INSTALL_LIBEXECDIR=lib \
              -DKDE_INSTALL_USE_QT_SYS_PATHS=ON \
              -DBUILD_TESTING=OFF"
 PKGCONFL="kio-extras<=15.07.90 tde-i18n kwin<=5.4.3"
-PKGBREAK="plasma-desktop<=5.21.4 kde-workspace<=5.20.2"
-PKGREP="plasma-desktop<=5.21.4 kde-workspace<=5.20.2"
+PKGBREAK="plasma-desktop<=5.21.5 kde-workspace<=5.20.2"
+PKGREP="plasma-desktop<=5.21.5 kde-workspace<=5.20.2"

--- a/extra-kde/plasma-workspace/spec
+++ b/extra-kde/plasma-workspace/spec
@@ -1,4 +1,3 @@
-VER=5.21.5
-REL=1
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-workspace-$VER.tar.xz"
-CHKSUMS="sha256::9cb16ef4bca9ade0ca82d0cc539533ba9f9be47811ae13d154effc085618e90a"
+CHKSUMS="sha256::1ed41a30208d87f7586734fa0ee84eb308f5da57ea614ef537171eac8bbbb77c"

--- a/extra-kde/plymouth-kcm/spec
+++ b/extra-kde/plymouth-kcm/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plymouth-kcm-$VER.tar.xz"
-CHKSUMS="sha256::607f8c569a15938ccde869f836725d5af53dcc15605e3bd0ff978c84fecb56c9"
+CHKSUMS="sha256::b986d78434c9a5ee60835e818e4f56cb9fca8f4b40b5dd4099840f2da6a1dd0e"

--- a/extra-kde/polkit-kde-agent-1/spec
+++ b/extra-kde/polkit-kde-agent-1/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/polkit-kde-agent-1-$VER.tar.xz"
-CHKSUMS="sha256::e68bad084d9144092c8aef68552434c9dba702caf953ea8fa7dcf7731ed689ad"
+CHKSUMS="sha256::83caf23430e2ebba52163d523455f66e18c58fa74489bc0f93c7adec0df3d240"

--- a/extra-kde/powerdevil/spec
+++ b/extra-kde/powerdevil/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/powerdevil-$VER.tar.xz"
-CHKSUMS="sha256::fdb0305b576345f17d21e2f3a3604e55b0413456cc8b58017e354d5c42d0dda3"
+CHKSUMS="sha256::cdaac1a0cad2ec5cc0c60d2ea8ce9df143ed2b29791ab32acb0abea680763bc1"

--- a/extra-kde/sddm-kcm/spec
+++ b/extra-kde/sddm-kcm/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/sddm-kcm-$VER.tar.xz"
-CHKSUMS="sha256::5280c8e75167233808d44ce0091f66020a3f8f12590fd9272d3b3fda12ce2d6d"
+CHKSUMS="sha256::c1fec113d99159834d322286ac1625dd7dbe11ba39ea137e488774bf4e388d4d"

--- a/extra-kde/systemsettings/spec
+++ b/extra-kde/systemsettings/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/systemsettings-$VER.tar.xz"
-CHKSUMS="sha256::95784e6f0dc89778ebbd0bc4536f690cd8454001c7665eb853c0c6eace987acd"
+CHKSUMS="sha256::668e69eecc5f7dc83d3e796c4233cc81696cda398d034c1adf490e4bafb9d9ef"

--- a/extra-kde/xdg-desktop-portal-kde/spec
+++ b/extra-kde/xdg-desktop-portal-kde/spec
@@ -1,3 +1,3 @@
-VER=5.21.5
+VER=5.22.0
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/xdg-desktop-portal-kde-$VER.tar.xz"
-CHKSUMS="sha256::b0a7ea220d9b1913618a937b7364f7d88156998fd4d76df923520cb26ab38285"
+CHKSUMS="sha256::5b930f68ef54ad9c736e68c01418f091678c0479fc30f329ab14c77d9e44dac8"

--- a/groups/plasma
+++ b/groups/plasma
@@ -1,4 +1,5 @@
 extra-kde/kactivitymanagerd
+extra-kde/layer-shell-qt
 extra-kde/kscreenlocker
 extra-kde/kdecoration
 extra-kde/oxygen
@@ -7,6 +8,7 @@ extra-kde/breeze-gtk
 extra-kde/kwayland-server
 extra-kde/kwin
 extra-kde/libksysguard
+extra-kde/ksystemstats
 extra-kde/libkscreen
 extra-kde/milou
 extra-kde/plasma-integration
@@ -15,7 +17,6 @@ extra-kde/plasma-workspace
 extra-kde/kde-cli-tools
 extra-kde/khotkeys
 extra-kde/kinfocenter
-extra-kde/ksysguard
 extra-kde/systemsettings
 extra-kde/kmenuedit
 extra-kde/powerdevil


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

KDE survey 20210608

Package(s) Affected
-------------------

groups/plasma: 5.22.0

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No
<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

plasma-wayland-protocols groups/plasma ksysguard


Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
