### PR TITLE
shadowsocks-rust: update to 1.11.1

### DIFF
--- a/extra-network/shadowsocks-rust/autobuild/beyond
+++ b/extra-network/shadowsocks-rust/autobuild/beyond
@@ -1,5 +1,3 @@
-make TARGET="release" DESTDIR="$PKGDIR" PREFIX="/usr/bin" install
-
 abinfo "Installing shadowsocks-rust systemd units..."
 mkdir -pv "$PKGDIR"/usr/lib/systemd/system
 for unit in "$SRCDIR"/debian/*.service; do

--- a/extra-network/shadowsocks-rust/autobuild/defines
+++ b/extra-network/shadowsocks-rust/autobuild/defines
@@ -1,15 +1,14 @@
 PKGNAME=shadowsocks-rust
 PKGSEC=net
 PKGDEP="openssl libsodium"
-BUILDDEP="asciidoc pkg-config llvm"
+BUILDDEP="asciidoc pkg-config"
 
 PKGDES="A Rust port of shadowsocks, lightweight yet secured SOCKS5 proxy"
 
-USECLANG=1
 ABTYPE=rust
 ABSPLITDBG=0
 
 # Since ring does not support ppc64el and loongson3 architectures, use local-http-native-tls to avoid this dependency 
-CARGO_AFTER="--features local-http-native-tls"
+CARGO_AFTER="--features local-http-native-tls,local-tunnel,local-redir,local-dns,trust-dns,stream-cipher,aead-cipher-extra"
 
 NOLTO=1

--- a/extra-network/shadowsocks-rust/spec
+++ b/extra-network/shadowsocks-rust/spec
@@ -1,4 +1,4 @@
-VER=1.11.0
+VER=1.11.1
 SRCS="tbl::https://github.com/shadowsocks/shadowsocks-rust/archive/v$VER.tar.gz"
-CHKSUMS="sha256::cd3389b18f4b7d03f25a49665fe37a6ecc4d991c38904760be7c82c08d745d3a"
+CHKSUMS="sha256::c0dcb5cc545b7c552d2942738a0661497f056c5a82abcca8675a95084ce74ef0"
 CHKUPDATE="github::repo=shadowsocks/shadowsocks-rust"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

shadowsocks-rust: update to 1.11.1

- Enable some feature

Package(s) Affected
-------------------

shadowsocks-rust: 1.11.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
