### PR TITLE
fwupd: fix deps

### DIFF
--- a/extra-admin/fwupd/autobuild/defines
+++ b/extra-admin/fwupd/autobuild/defines
@@ -3,11 +3,11 @@ PKGSEC=admin
 PKGDEP="appstream-glib colord dbus efivar elfutils gcab glib gnutls \
         gpgme json-glib libarchive libgpg-error libgudev libgusb libsoup \
         libxmlb modemmanager pango pillow polkit pycairo pygobject-3 python-3 \
-        shared-mime-info sqlite systemd tpm2-tss"
+        shared-mime-info sqlite systemd tpm2-tss libjcat"
+PKGDEP__AMD64="${PKGDEP} libsmbios thunderbolt-software-user-space"
 BUILDDEP="docbook-sgml gobject-introspection gtk-doc intltool meson \
           ninja pkg-config vala valgrind cairo dejavu-fonts fontconfig \
           freetype gnu-efi"
-BUILDDEP__AMD64="${BUILDDEP} libsmbios thunderbolt-software-user-space"
 BUILDDEP__LOONGSON3="${BUILDDEP/gnu-efi/}"
 BUILDDEP__PPC64EL="${BUILDDEP/gnu-efi/}"
 PKGDES="Firmware update daemon and utilities"

--- a/extra-admin/fwupd/spec
+++ b/extra-admin/fwupd/spec
@@ -1,4 +1,4 @@
 VER=1.5.4
+REL=2
 SRCS="https://github.com/hughsie/fwupd/archive/$VER.tar.gz"
 CHKSUMS="sha256::de97bf9d89b8d230a9e8fc86951ad037123a6ba252a2e1c83cfebb818a989c46"
-REL=1

--- a/extra-libs/libjcat/autobuild/defines
+++ b/extra-libs/libjcat/autobuild/defines
@@ -1,0 +1,15 @@
+PKGNAME=libjcat
+PKGSEC=libs
+PKGDEP="json-glib gpgme"
+BUILDDEP="gtk-doc gobject-introspection vala"
+PKGDES="Library for reading and writing JSON catalog (Jcat) files"
+
+MESON_AFTER="-Dgtkdoc=true \
+             -Dintrospection=true \
+             -Dvapi=true \
+             -Dgpg=true \
+             -Dpkcs7=true \
+             -Dman=true"
+
+PKGBREAK="fwupd<=1.5.4-1"
+PKGREP="fwupd<=1.5.4-1"

--- a/extra-libs/libjcat/spec
+++ b/extra-libs/libjcat/spec
@@ -1,0 +1,3 @@
+VER=0.1.8
+SRCS="https://github.com/hughsie/libjcat/archive/refs/tags/$VER.tar.gz"
+CHKSUMS="sha256::aedb6e508120ace7cfc2c03f2972e8a422f0e0b01ee00654a093ea3b7e2e35d1"


### PR DESCRIPTION
Topic Description
-----------------

Fix dependencies for `fwupd`, debundle `libjcat`.

Package(s) Affected
-------------------

- `fwupd` v1.5.4-2
- `libjcat` v0.1.8

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`