### PR TITLE
miniserve: new, 0.14.0

### DIFF
--- a/extra-web/miniserve/autobuild/defines
+++ b/extra-web/miniserve/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=miniserve
 PKGSEC=net
-PKGDES="A small, self-contained CLI tool that allows you to just grab the binary and serve some files via HTTP"
+PKGDES="A small, self-contained HTTP file server"
 PKGDEP="glibc gcc-runtime"
 BUILDDEP="llvm rustc"
 

--- a/extra-web/miniserve/autobuild/defines
+++ b/extra-web/miniserve/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=miniserve
+PKGSEC=net
+PKGDES="A small, self-contained CLI tool that allows you to just grab the binary and serve some files via HTTP"
+PKGDEP="glibc gcc-runtime"
+BUILDDEP="llvm rustc"
+
+USECLANG=1
+ABSPLITDBG=0

--- a/extra-web/miniserve/spec
+++ b/extra-web/miniserve/spec
@@ -1,0 +1,4 @@
+VER=0.14.0
+SRCS="tbl::https://github.com/svenstaro/miniserve/archive/v$VER.tar.gz"
+CHKSUMS="sha256::68e21c35a4577251f656f3d1ccac2de23abd68432810b11556bcc8976bb19fc5"
+CHKUPDATE="github::repo=svenstaro/miniserve"


### PR DESCRIPTION
Topic Description
-----------------

miniserve: new, 0.14.0

Package(s) Affected
-------------------

`miniserve`

Security Update?
----------------

No

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

