### PR TITLE
binserve: new, 0.1.0

### DIFF
--- a/extra-web/binserve/autobuild/defines
+++ b/extra-web/binserve/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=binserve
+PKGSEC=net
+PKGDES="A blazingly fast static web server with routing, templating, and security"
+PKGDEP="glibc gcc-runtime"
+BUILDDEP="llvm rustc"
+
+USECLANG=1
+ABSPLITDBG=0

--- a/extra-web/binserve/autobuild/defines
+++ b/extra-web/binserve/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=binserve
 PKGSEC=net
-PKGDES="A blazingly fast static web server with routing, templating, and security"
+PKGDES="A web server with routing, templating, and security features"
 PKGDEP="glibc gcc-runtime"
 BUILDDEP="llvm rustc"
 

--- a/extra-web/binserve/autobuild/prepare
+++ b/extra-web/binserve/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Generating lock file ..."
+cargo update

--- a/extra-web/binserve/spec
+++ b/extra-web/binserve/spec
@@ -1,0 +1,4 @@
+VER=0.1.0
+SRCS="tbl::https://github.com/mufeedvh/binserve/archive/v$VER.tar.gz"
+CHKSUMS="sha256::311e76bacd5ec3d02d55d991fce0dca1dc14bb6cb665f5292a4ad396cf0eb11e"
+CHKUPDATE="github::repo=mufeedvh/binserve"


### PR DESCRIPTION
Topic Description
-----------------

binserve: new, 0.1.0

Package(s) Affected
-------------------

`binserve`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

