### PR TITLE
aoscdk-rs: update to 0.2.0

### DIFF
--- a/extra-admin/aoscdk-rs/spec
+++ b/extra-admin/aoscdk-rs/spec
@@ -1,3 +1,3 @@
-VER=0+git20210605
-SRCS="git::commit=c73f089335d5eb7bb1fd8d595495ffb7f1e546dd::https://github.com/AOSC-Dev/aoscdk-rs/"
+VER=0.2.0
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscdk-rs/"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Update DeployKit (`aoscdk-rs`) to v0.2.0. This is a fully working version.

Package(s) Affected
-------------------

`aoscdk-rs` v0.2.0

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`