### PR TITLE
cpio: (Fedora patch) revert CVE-2015-1197 to fix dracut

### DIFF
--- a/base-utils/cpio/autobuild/defines
+++ b/base-utils/cpio/autobuild/defines
@@ -3,5 +3,4 @@ PKGSEC=utils
 PKGDEP="glibc"
 PKGDES="A GNU archiving program"
 
-RECONF=0
 ABSHADOW=0

--- a/base-utils/cpio/autobuild/patches/0002-Fedora-cpio-2.13-revert-CVE-2015-1197-fix.patch
+++ b/base-utils/cpio/autobuild/patches/0002-Fedora-cpio-2.13-revert-CVE-2015-1197-fix.patch
@@ -1,0 +1,91 @@
+revert fix for CVE-2015-1197 as it causes shutdown issues
+
+revert suggested as a workaround by upstream:
+https://lists.gnu.org/archive/html/bug-cpio/2019-11/msg00016.html
+
+--- b/src/copyin.c
++++ a/src/copyin.c
+@@ -645,14 +645,13 @@
+       link_name = xstrdup (file_hdr->c_tar_linkname);
+     }
+ 
+-  cpio_safer_name_suffix (link_name, true, !no_abs_paths_flag, false);
+-  
+   res = UMASKED_SYMLINK (link_name, file_hdr->c_name,
+ 			 file_hdr->c_mode);
+   if (res < 0 && create_dir_flag)
+     {
+       create_all_directories (file_hdr->c_name);
++      res = UMASKED_SYMLINK (link_name, file_hdr->c_name,
++			     file_hdr->c_mode);
+-      res = UMASKED_SYMLINK (link_name, file_hdr->c_name, file_hdr->c_mode);
+     }
+   if (res < 0)
+     {
+--- b/tests/CVE-2015-1197.at
++++ /dev/null
+@@ -1,43 +0,0 @@
+-# Process this file with autom4te to create testsuite.  -*- Autotest -*-
+-# Copyright (C) 2009-2019 Free Software Foundation, Inc.
+-#
+-# This program is free software; you can redistribute it and/or modify
+-# it under the terms of the GNU General Public License as published by
+-# the Free Software Foundation; either version 3, or (at your option)
+-# any later version.
+-#
+-# This program is distributed in the hope that it will be useful,
+-# but WITHOUT ANY WARRANTY; without even the implied warranty of
+-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-# GNU General Public License for more details.
+-#
+-# You should have received a copy of the GNU General Public License
+-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-
+-AT_SETUP([CVE-2015-1197 (--no-absolute-filenames for symlinks)])
+-AT_CHECK([
+-tempdir=$(pwd)/tmp
+-mkdir $tempdir
+-touch $tempdir/file
+-ln -s $tempdir dir
+-AT_DATA([filelist],
+-[dir
+-dir/file
+-])
+-ln -s /tmp dir
+-touch /tmp/file
+-cpio -o < filelist > test.cpio
+-rm dir /tmp/file
+-cpio --no-absolute-filenames -iv < test.cpio
+-],
+-[2],
+-[],
+-[1 block
+-cpio: Removing leading `/' from hard link targets
+-dir
+-cpio: dir/file: Cannot open: No such file or directory
+-dir/file
+-1 block
+-])
+-AT_CLEANUP
+-
+--- b/tests/Makefile.am
++++ a/tests/Makefile.am
+@@ -56,9 +56,8 @@
+  symlink-long.at\
+  symlink-to-stdout.at\
+  version.at\
+  big-block-size.at\
+- CVE-2015-1197.at\
+  CVE-2019-14866.at
+ 
+ TESTSUITE = $(srcdir)/testsuite
+
+--- b/tests/testsuite.at
++++ a/tests/testsuite.at
+@@ -43,6 +43,5 @@
+ m4_include([setstat04.at])
+ m4_include([setstat05.at])
+ m4_include([big-block-size.at])
+
+-m4_include([CVE-2015-1197.at])
+ m4_include([CVE-2019-14866.at])

--- a/base-utils/cpio/spec
+++ b/base-utils/cpio/spec
@@ -1,4 +1,4 @@
 VER=2.13
-REL=4
+REL=5
 SRCS="tbl::https://ftp.gnu.org/gnu/cpio/cpio-$VER.tar.gz"
 CHKSUMS="sha256::e87470d9c984317f658567c03bfefb6b0c829ff17dbf6b0de48d71a4c8f3db88"


### PR DESCRIPTION
Topic Description
-----------------

Revert cpio's fix for CVE-2015-1197, which resulted in dracut drop-out (to emergency initramfs shell) during shutdown/reboot on systems installed on LVM/LUKS configurations.

Package(s) Affected
-------------------

`cpio` v2.13-5

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`