### PR TITLE
squashfs-tools: fix bindir

### DIFF
--- a/extra-admin/squashfs-tools/autobuild/build
+++ b/extra-admin/squashfs-tools/autobuild/build
@@ -6,4 +6,4 @@ make XZ_SUPPORT=1 \
 
 abinfo "Installing {mk,un}squashfs ..."
 install -Dvm755 "$SRCDIR"/{mk,un}squashfs \
-    -t "$PKGDIR"/usr/bin/mksquashfs
+    -t "$PKGDIR"/usr/bin/

--- a/extra-admin/squashfs-tools/spec
+++ b/extra-admin/squashfs-tools/spec
@@ -1,4 +1,5 @@
 VER=4.4
+REL=1
 SRCS="https://sourceforge.net/projects/squashfs/files/squashfs/squashfs$VER/squashfs$VER.tar.gz"
 SUBDIR="squashfs$VER/squashfs-tools"
 CHKSUMS="sha256::a981b3f3f2054b5a2e658851a3c06a2460ad04a9a8a645e0afe063a63fdbb07e"


### PR DESCRIPTION
Topic Description
-----------------

Fix executable installation path in `squashfs-tools`.

Package(s) Affected
-------------------

`squashfs-tools` v4.4-1

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`