### PR TITLE
yubioath-desktop: update to 5.0.5

### DIFF
--- a/extra-security/yubioath-desktop/spec
+++ b/extra-security/yubioath-desktop/spec
@@ -1,3 +1,3 @@
-VER=5.0.4
+VER=5.0.5
 SRCS="tbl::https://github.com/Yubico/yubioath-desktop/archive/yubioath-desktop-$VER.tar.gz"
-CHKSUMS="sha256::b47c8715e415b0e0ea0237e6f56d328fc8d3303a87ad89d4540d4f4a93138bd7"
+CHKSUMS="sha384::50dd9a606dab918826696cb040fb41dcce57d1e9b09988b3f19ba13fe736e2e95f93d88db7580b4e3e46965675cc7001"


### PR DESCRIPTION

Topic Description
-----------------
* Updatev `yubioath-desktop` to 5.0.5

Package(s) Affected
-------------------
* `yubioath-desktop`

Security Update?
----------------
No

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
