### PR TITLE
vivaldi: update to 4.0.2312.27

### DIFF
--- a/extra-web/vivaldi/spec
+++ b/extra-web/vivaldi/spec
@@ -1,9 +1,9 @@
-VER=3.8.2259.42
+VER=4.0.2312.27
 
 SRCS__ARM64="tbl::https://downloads.vivaldi.com/stable/vivaldi-stable_${VER}-1_arm64.deb"
-CHKSUMS__ARM64="sha384::5bfcac98d4512b928c1d5dac769671e15d7593db9c382cdf869d77fe7ae8ce8b55aa40061396f9e7deb36dc02842636b"
+CHKSUMS__ARM64="sha384::cf85176e9b99e2ee9edded6f711b50a8f627dbe7933890dbc6e73b0fa3c98b046a6483d190b5d0f0af40fc06b0bc1935"
 
 SRCS__AMD64="tbl::https://downloads.vivaldi.com/stable/vivaldi-stable-${VER}-1.x86_64.rpm"
-CHKSUMS__AMD64="sha384::2775cd9c3ffc4ca1178988ad0f47ddfe10c80ce13fbfb4beeecdc4cea98f369571cafac59e2173b01dc46914fbd5d148"
+CHKSUMS__AMD64="sha384::7c45a75d3682d14223170b6e791e128ce2c8187d607ea9ef1e4caad3e3fe0141cb24ac9ea846a577a5d25c58639970a1"
 
 SUBDIR=.


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
* Update `vivaldi` to 4.0.2312.27

Package(s) Affected
-------------------
* `vivaldi`

Security Update?
----------------
 Yes, #3190

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
