### PR TITLE
fcitx5-pinyin-moegirl: update to 20210614

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,8 +1,8 @@
-VER=20210415
+VER=20210614
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       tbl::https://github.com/outloudvi/mw2fcitx/archive/$VER.tar.gz"
-CHKSUMS="sha256::a1dba38ffd20725f4f94960a12239de3d4b4e71895bc3cc4604d5ce82be9903f \
-         sha256::5bb2ae411fe5a1838a887204bdb2f5952e37256be7767788bf815f6ff8dfb4e3 \
-         sha256::ff8053636d3dc198531f115fae682616780e0103a6d8e2a4e96e69193c51f9de"
+CHKSUMS="sha256::a2c07ac34fc384fe60a7ef91e17d97a3fa6dc35c6f1792500c91ceada049f31f \
+         sha256::6e9c4bac0253985b187d8844501b1d13bc0e39d79dde462a64ba28a328675c43 \
+         sha256::d761c21c83a9280be4752abea96322dca72b33af56bcda3fa108dfc94af47fc4"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Update package version to 20210614. Sorry for recalling it late.

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl
* rime-pinyin-moegirl

Security Update?
----------------

No

Architectural Progress
----------------------

- [ ] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] Architecture-independent `noarch`
