### PR TITLE
wine: update to 6.11

### DIFF
--- a/extra-emulation/wine/spec
+++ b/extra-emulation/wine/spec
@@ -1,6 +1,7 @@
-VER=6.8
+VER=6.11
+CHKUPDATE="antiya::id=15657"
 SRCS="tbl::https://dl.winehq.org/wine/source/${VER:0:1}.x/wine-$VER.tar.xz \
       git::rename=wine-staging;commit=tags/v$VER::https://github.com/wine-staging/wine-staging"
-CHKSUMS="sha256::5b422dde67d8412871152ce315875efb494507ad38a0f4d710f13938a769ebd8 \
+CHKSUMS="sha384::1bb01c222aecb899ef8679248240505dee74dba32df764c8a5648ad027a519ea1717aa563f454103d0860e736ce12a94 \
          SKIP"
 SUBDIR="wine-$VER"


### PR DESCRIPTION
Topic Description
-----------------
* Update `wine` to 5.11

Package(s) Affected
-------------------
* `wine`

Security Update?
----------------
No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
