### PR TITLE
scrcpy: update to 1.18

### DIFF
--- a/extra-android/scrcpy/autobuild/defines
+++ b/extra-android/scrcpy/autobuild/defines
@@ -9,3 +9,4 @@ MESON_AFTER="-Dprebuilt_server=scrcpy-server \
 	--prefix /usr \
 	--buildtype release"
 ABTYPE="meson"
+ABSPLITDBG=0

--- a/extra-android/scrcpy/spec
+++ b/extra-android/scrcpy/spec
@@ -4,3 +4,4 @@ SRCS="git::commit=tags/v$VER::https://github.com/Genymobile/scrcpy \
 CHKSUMS="SKIP \
          sha256::641c5c6beda9399dfae72d116f5ff43b5ed1059d871c9ebc3f47610fd33c51a3"
 SUBDIR="scrcpy"
+CHKUPDATE="github::repo=Genymobile/scrcpy"

--- a/extra-android/scrcpy/spec
+++ b/extra-android/scrcpy/spec
@@ -1,7 +1,6 @@
-VER=1.17
+VER=1.18
 SRCS="git::commit=tags/v$VER::https://github.com/Genymobile/scrcpy \
       file::rename=scrcpy-server::https://github.com/Genymobile/scrcpy/releases/download/v$VER/scrcpy-server-v$VER"
 CHKSUMS="SKIP \
-         sha256::11b5ad2d1bc9b9730fb7254a78efd71a8ff46b1938ff468e47a21b653a1b6725"
+         sha256::641c5c6beda9399dfae72d116f5ff43b5ed1059d871c9ebc3f47610fd33c51a3"
 SUBDIR="scrcpy"
-REL=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

scrcpy: update to 1.18

Package(s) Affected
-------------------

scrcpy: 1.18

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
