### PR TITLE
postgresql: update to 13.3

### DIFF
--- a/extra-database/postgresql/autobuild/beyond
+++ b/extra-database/postgresql/autobuild/beyond
@@ -1,3 +1,17 @@
-make -C contrib DESTDIR="$PKGDIR" install
-make -C doc/src/sgml DESTDIR="$PKGDIR" install-man
+abinfo "Installing contrib components ..."
+make -C "$SRCDIR"/contrib \
+    DESTDIR="$PKGDIR" \
+    install
 
+abinfo "Installing SGML documentation ..."
+make -C "$SRCDIR"/doc/src/sgml \
+    DESTDIR="$PKGDIR" \
+    install-man
+
+abinfo "Deploying postgresql-check-db-dir ..."
+export MAJORVER="${PKGVER%.*}"
+sed -e "s|@MAJORVER@|${MAJORVER}|g" \
+    -e "s|@PREVMAJORVER@|$((MAJORVER -1))|g" \
+    "$SRCDIR"/autobuild/postgresql-check-db-dir.in \
+    > "$PKGDIR"/usr/bin/postgresql-check-db-dir
+chmod -v +x "$PKGDIR"/usr/bin/postgresql-check-db-dir

--- a/extra-database/postgresql/autobuild/postgresql-check-db-dir.in
+++ b/extra-database/postgresql/autobuild/postgresql-check-db-dir.in
@@ -16,9 +16,9 @@ then
 fi
 
 # PGMAJORVERSION is major version
-PGMAJORVERSION=12
+PGMAJORVERSION=@MAJORVER@
 # PREVMAJORVERSION is the previous major version, e.g., 8.4, for upgrades
-PREVMAJORVERSION=11
+PREVMAJORVERSION=@PREVMAJORVER@
 
 # Check for the PGDATA structure
 if [ -f "$PGDATA/PG_VERSION" ] && [ -d "$PGDATA/base" ]
@@ -30,7 +30,6 @@ then
     elif [ x`cat "$PGDATA/PG_VERSION"` = x"$PREVMAJORVERSION" ]
     then
         echo $"An old version of the database format was found."
-        echo $"See https://wiki.archlinux.org/index.php/PostgreSQL#Upgrading_PostgreSQL"
         exit 1
     else
         echo $"An old version of the database format was found."

--- a/extra-database/postgresql/autobuild/prepare
+++ b/extra-database/postgresql/autobuild/prepare
@@ -1,4 +1,0 @@
-if [[ "${CROSS:-$ARCH}" = arm64 ]]; then
-    ln -s /usr/bin/ld.bfd "$SRCDIR"/ld
-    export PATH="$SRCDIR:$PATH"
-fi

--- a/extra-database/postgresql/spec
+++ b/extra-database/postgresql/spec
@@ -1,3 +1,3 @@
-VER=13.2
+VER=13.3
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::5fd7fcd08db86f5b2aed28fcfaf9ae0aca8e9428561ac547764c2a2b0f41adfc"
+CHKSUMS="sha256::3cd9454fa8c7a6255b6743b767700925ead1b9ab0d7a0f9dcb1151010f8eb4a1"


### PR DESCRIPTION
Topic Description
-----------------

Update PostgreSQL to 13.3.

- Generate postgresql-check-db-dir during build time.
- Remove ld.bfd hack for arm64.
- Lint scripts in accordance with the Styling Manual.

Package(s) Affected
-------------------

`postgresql` v13.3

Security Update?
----------------

Yes, #3195 

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`