### PR TITLE
linux-firmware: apply compression

### DIFF
--- a/extra-kernel/linux-firmware/01-nonfree/build
+++ b/extra-kernel/linux-firmware/01-nonfree/build
@@ -1,5 +1,5 @@
 abinfo "Using shell script supplied to install firmware ..."
-./copy-firmware.sh --verbose "${PKGDIR}"/usr/lib/firmware
+./copy-firmware.sh --verbose --compress "${PKGDIR}"/usr/lib/firmware
 
 abinfo "Copying license details ..."
 cp -v "$SRCDIR"/{WHENCE,LICENSE.*,LICENCE.*,GPL-2,GPL-3} "${PKGDIR}"/usr/lib/firmware/
@@ -7,6 +7,15 @@ cp -v "$SRCDIR"/{WHENCE,LICENSE.*,LICENCE.*,GPL-2,GPL-3} "${PKGDIR}"/usr/lib/fir
 abinfo "Separating free firmware ..."
 mkdir -pv "$SRCDIR"/firmware-free
 for i in $(cat autobuild/free-list); do
+    if echo "$i" | grep -q /; then
+        mkdir -pv "$SRCDIR"/firmware-free/$(dirname $i)
+    fi
+    mv -v "$PKGDIR"/usr/lib/firmware/$i.xz "$SRCDIR"/firmware-free/$i.xz
+done
+
+abinfo "Installing free licenses ..."
+mkdir -pv "$SRCDIR"/firmware-free
+for i in $(cat autobuild/free-license-list); do
     if echo "$i" | grep -q /; then
         mkdir -pv "$SRCDIR"/firmware-free/$(dirname $i)
     fi
@@ -19,3 +28,6 @@ for i in brcmfmac43456-sdio.{bin,clm_blob,AP6256.txt} BCM4345C5.hcd; do
 	cp -v "$SRCDIR"/../$i "$PKGDIR"/usr/lib/firmware/brcm
 done
 ln -sv brcmfmac43456-sdio.AP6256.txt "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43456-sdio.pine64,pinebook-pro.txt
+
+abinfo "Compressing AP6256 firmware blob"
+xz -C crc32 "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43456-sdio.bin

--- a/extra-kernel/linux-firmware/01-nonfree/build
+++ b/extra-kernel/linux-firmware/01-nonfree/build
@@ -1,5 +1,5 @@
 abinfo "Using shell script supplied to install firmware ..."
-./copy-firmware.sh --verbose --compress "${PKGDIR}"/usr/lib/firmware
+"$SRCDIR"/copy-firmware.sh --verbose --compress "${PKGDIR}"/usr/lib/firmware
 
 abinfo "Copying license details ..."
 cp -v "$SRCDIR"/{WHENCE,LICENSE.*,LICENCE.*,GPL-2,GPL-3} "${PKGDIR}"/usr/lib/firmware/

--- a/extra-kernel/linux-firmware/01-nonfree/free-license-list
+++ b/extra-kernel/linux-firmware/01-nonfree/free-license-list
@@ -1,0 +1,3 @@
+LICENCE.open-ath9k-htc-firmware
+GPL-2
+GPL-3

--- a/extra-kernel/linux-firmware/01-nonfree/free-list
+++ b/extra-kernel/linux-firmware/01-nonfree/free-list
@@ -25,6 +25,3 @@ usbduxfast_firmware.bin
 usbduxsigma_firmware.bin
 ath9k_htc/htc_7010-1.4.0.fw
 ath9k_htc/htc_9271-1.4.0.fw
-LICENCE.open-ath9k-htc-firmware
-GPL-2
-GPL-3

--- a/extra-kernel/linux-firmware/01-nonfree/patches/0001-Add-support-for-compressing-firmware-in-copy-firmwar.patch
+++ b/extra-kernel/linux-firmware/01-nonfree/patches/0001-Add-support-for-compressing-firmware-in-copy-firmwar.patch
@@ -1,0 +1,123 @@
+From 7eec2b56f54c778d5bd6e7aea49ee03e3b76e769 Mon Sep 17 00:00:00 2001
+From: Peter Robinson <pbrobinson@gmail.com>
+Date: Fri, 22 Jan 2021 20:36:23 +0000
+Subject: [PATCH v2] Add support for compressing firmware in copy-firmware.sh
+
+As of kernel 5.3 there's initial support for loading compressed firmware.
+At this stage the only supported compression methis is "xz -C crc32" but
+this option brings significant benefits.
+
+Signed-off-by: Peter Robinson <pbrobinson@gmail.com>
+---
+
+v2: quote filename for xz command
+
+ Makefile         |  4 ++++
+ copy-firmware.sh | 47 +++++++++++++++++++++++++++++++----------------
+ 2 files changed, 35 insertions(+), 16 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index e1c362f..9a48471 100644
+--- a/Makefile
++++ b/Makefile
+@@ -11,3 +11,7 @@ check:
+ install:
+ 	mkdir -p $(DESTDIR)$(FIRMWAREDIR)
+ 	./copy-firmware.sh $(DESTDIR)$(FIRMWAREDIR)
++
++installcompress:
++	mkdir -p $(DESTDIR)$(FIRMWAREDIR)
++	./copy-firmware.sh -C $(DESTDIR)$(FIRMWAREDIR)
+diff --git a/copy-firmware.sh b/copy-firmware.sh
+index 9b46b63..0dd2e5c 100755
+--- a/copy-firmware.sh
++++ b/copy-firmware.sh
+@@ -6,6 +6,7 @@
+ 
+ verbose=:
+ prune=no
++compress=no
+ 
+ while test $# -gt 0; do
+     case $1 in
+@@ -19,6 +20,11 @@ while test $# -gt 0; do
+             shift
+             ;;
+ 
++        -C | --compress)
++            compress=yes
++            shift
++            ;;
++
+         *)
+             if test "x$destdir" != "x"; then
+                 echo "ERROR: unknown command-line options: $@"
+@@ -31,40 +37,49 @@ while test $# -gt 0; do
+     esac
+ done
+ 
++if test "x$compress" = "xyes"; then
++    cmpxtn=.xz
++    grep '^File:' WHENCE | sed -e's/^File: *//g' -e's/"//g' | while read f; do
++       test -f "$f" || continue
++       $verbose "compressing $f"
++       xz -C crc32 "$f"
++    done
++fi
++
+ grep '^File:' WHENCE | sed -e's/^File: *//g' -e's/"//g' | while read f; do
+-    test -f "$f" || continue
+-    $verbose "copying file $f"
+-    mkdir -p $destdir/$(dirname "$f")
+-    cp -d "$f" $destdir/"$f"
++    test -f "$f$cmpxtn" || continue
++    $verbose "copying file $f$cmpxtn"
++    mkdir -p $destdir/$(dirname "$f$cmpxtn")
++    cp -d "$f$cmpxtn" $destdir/"$f$cmpxtn"
+ done
+ 
+ grep -E '^Link:' WHENCE | sed -e's/^Link: *//g' -e's/-> //g' | while read f d; do
+-    if test -L "$f"; then
+-        test -f "$destdir/$f" && continue
+-        $verbose "copying link $f"
+-        mkdir -p $destdir/$(dirname "$f")
++    if test -L "$f$cmpxtn"; then
++        test -f "$destdir/$f$cmpxtn" && continue
++        $verbose "copying link $f$cmpxtn"
++        mkdir -p $destdir/$(dirname "$f$cmpxtn")
+         cp -d "$f" $destdir/"$f"
+ 
+         if test "x$d" != "x"; then
+-            target=`readlink "$f"`
++            target=`readlink "$f$cmpxtn"`
+ 
+             if test "x$target" != "x$d"; then
+                 $verbose "WARNING: inconsistent symlink target: $target != $d"
+             else
+                 if test "x$prune" != "xyes"; then
+-                    $verbose "WARNING: unneeded symlink detected: $f"
++                    $verbose "WARNING: unneeded symlink detected: $f$cmpxtn"
+                 else
+-                    $verbose "WARNING: pruning unneeded symlink $f"
+-                    rm -f "$f"
++                    $verbose "WARNING: pruning unneeded symlink $f$cmpxtn"
++                    rm -f "$f$cmpxtn"
+                 fi
+             fi
+         else
+-            $verbose "WARNING: missing target for symlink $f"
++            $verbose "WARNING: missing target for symlink $f$cmpxtn"
+         fi
+     else
+-        $verbose "creating link $f -> $d"
+-        mkdir -p $destdir/$(dirname "$f")
+-        ln -sf "$d" "$destdir/$f"
++        $verbose "creating link $f$cmpxtn -> $d$cmpxtn"
++        mkdir -p $destdir/$(dirname "$f$cmpxtn")
++        ln -sf "$d$cmpxtn" "$destdir/$f$cmpxtn"
+     fi
+ done
+ 
+-- 
+2.29.2
+

--- a/extra-kernel/linux-firmware/02-free/build
+++ b/extra-kernel/linux-firmware/02-free/build
@@ -1,3 +1,3 @@
 abinfo "Installing free firmware ..."
 mkdir -pv "$PKGDIR"/usr/lib/firmware
-cp -av firmware-free/* "$PKGDIR"/usr/lib/firmware/
+cp -av "$SRCDIR"/firmware-free/* "$PKGDIR"/usr/lib/firmware/

--- a/extra-kernel/linux-firmware/spec
+++ b/extra-kernel/linux-firmware/spec
@@ -1,4 +1,5 @@
 VER=20210405
+REL=1
 SRCS="git::commit=af1ca28f03287b0c60682ab37cc684c773de853f::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.clm_blob \


### PR DESCRIPTION
Topic Description
-----------------

This PR enables xz+crc32 compression on firmware blobs, effectively cutting disk space requirements by 50%+. Compressed firmware blob requires `FW_LOADER_COMPRESS` to be set for compressed firmware to load.

Package(s) Affected
-------------------

* `firmware-free`, `firmware-nonfree`: 20210405-1

Interoperability Check
------------------------------

### stable kernel (as of writing, 5.12.6):

- [x] amd64
- [x] arm64 - `FW_LOADER_COMPRESS` not set. Need work.
- [x] loongson3
- [x] ppc64el  - `FW_LOADER_COMPRESS` not set. Need work.

### LTS kernel (currently 5.10.40)

- [x] amd64
- [x] arm64 - `FW_LOADER_COMPRESS` not set. Need work.

Architectural Progress
----------------------
- [x] Architecture-independent `noarch`

Post-Merge Architectural Progress
---------------------------------
- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
