### PR TITLE
ipt2socks: fix QA error 321

### DIFF
--- a/extra-network/ipt2socks/autobuild/defines
+++ b/extra-network/ipt2socks/autobuild/defines
@@ -4,3 +4,4 @@ PKGDES="Utility for converting Socks5 proxy to transparent proxy"
 PKGDEP="libev"
 
 ABTYPE=plainmake
+MAKE_AFTER="DESTDIR=$PKGDIR/usr/bin"

--- a/extra-network/ipt2socks/autobuild/patches/0002-ipt2socks-no-strip.patch
+++ b/extra-network/ipt2socks/autobuild/patches/0002-ipt2socks-no-strip.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 7a16ecc..2f709cf 100644
+--- a/Makefile
++++ b/Makefile
+@@ -18,7 +18,7 @@ clean:
+ 	$(RM) *.o $(MAIN)
+ 
+ $(MAIN): $(OBJS)
+-	$(CC) $(CFLAGS) -s -o $(MAIN) $(OBJS) $(EVOBJFILE) $(LIBS)
++	$(CC) $(CFLAGS) -o $(MAIN) $(OBJS) $(EVOBJFILE) $(LIBS)
+ 
+ .c.o:
+ 	$(CC) $(CFLAGS) -c $< -o $@

--- a/extra-network/ipt2socks/spec
+++ b/extra-network/ipt2socks/spec
@@ -1,3 +1,4 @@
 VER=1.1.3
+REL=1
 SRCS="https://github.com/zfl9/ipt2socks/archive/v${VER}.tar.gz"
 CHKSUMS="whirlpool::34e1b4e96b11ce69ab574faf75f8121faf63517b1b965487422935e472b0ab18f6bc6d6d6d48685d8ad369f43a6cde7c53833a4d569da75e67139987e5e35a3f"


### PR DESCRIPTION
Topic Description
-----------------

fix lingering files (E321) of ipt2socks v1.1.3

Package(s) Affected
-------------------

ipt2socks v1.1.3

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
