### PR TITLE
unrar: update to 6.0.7

### DIFF
--- a/extra-utils/unrar/autobuild/build
+++ b/extra-utils/unrar/autobuild/build
@@ -1,19 +1,30 @@
-wget -c http://www.rarlab.com/rar/unrarsrc-$PKGVER.tar.gz
+# STRIP="true" below disables stripping at build-time, which prevents
+# -dbg package from being produced.
 
-tar xf unrarsrc-$PKGVER.tar.gz
+abinfo "Building libunrar ..."
+make lib \
+    STRIP="true" \
+    -C "$SRCDIR"/libunrar
 
-cp -r unrar libunrar
-cd unrar
+abinfo "Building UnRAR ..."
+make \
+    STRIP="true" \
+    -C "$SRCDIR"/unrar
 
-make -C "$SRCDIR"/libunrar lib libversion=$PKGVER \
-    CXXFLAGS="${CPPFLAGS} ${CXXFLAGS} -fPIC"
-make CXXFLAGS="${CPPFLAGS} ${CXXFLAGS} -fPIC" STRIP="true"
+abinfo "Installing unrar executable ..."
+install -Dvm755 "$SRCDIR"/unrar/unrar \
+    "$PKGDIR"/usr/bin/unrar
 
-install -Dm755 unrar "$PKGDIR"/usr/bin/unrar
+abinfo "Installing libunrar shared library ..."
+install -Dvm755 "$SRCDIR"/libunrar/libunrar.so \
+    "$PKGDIR"/usr/lib/libunrar.so.$PKGVER
 
-cd "$SRCDIR"/libunrar
+abinfo "Creating compatibility symlinks for libunrar.so.$PKGVER ..."
+ln -sv libunrar.so.$PKGVER \
+    "$PKGDIR"/usr/lib/libunrar.so.5
+ln -sv libunrar.so.$PKGVER \
+    "$PKGDIR"/usr/lib/libunrar.so
 
-install -Dm755 libunrar.so "$PKGDIR"/usr/lib/libunrar.so.$PKGVER
-install -Dm644 dll.hpp "$PKGDIR"/usr/include/unrar/dll.hpp
-ln -s libunrar.so.$PKGVER "$PKGDIR"/usr/lib/libunrar.so.5
-ln -s libunrar.so.$PKGVER "$PKGDIR"/usr/lib/libunrar.so
+abinfo "Installing development header ..."
+install -Dvm644 "$SRCDIR"/libunrar/dll.hpp \
+    "$PKGDIR"/usr/include/unrar/dll.hpp

--- a/extra-utils/unrar/autobuild/prepare
+++ b/extra-utils/unrar/autobuild/prepare
@@ -1,0 +1,10 @@
+abinfo "Arch Linux: Tweaking Makefile to use system compiler and linker flags ..."
+sed -e '/CXXFLAGS=/d' \
+    -e '/LDFLAGS=/d' \
+    -i "$SRCDIR"/unrar/makefile
+
+abinfo "Preparing a separate source root for runtime library ..."
+cp -rv "$SRCDIR"/{,lib}unrar
+
+abinfo "Arch Linux: Appending -pthread to LDFLAGS to fix build ..."
+export LDFLAGS="${LDFLAGS} -pthread"

--- a/extra-utils/unrar/autobuild/prepare
+++ b/extra-utils/unrar/autobuild/prepare
@@ -1,4 +1,4 @@
-abinfo "Arch Linux: Tweaking Makefile to use system compiler and linker flags ..."
+abinfo "AOSC OS: Tweaking Makefile to use system compiler and linker flags ..."
 sed -e '/CXXFLAGS=/d' \
     -e '/LDFLAGS=/d' \
     -i "$SRCDIR"/unrar/makefile
@@ -6,5 +6,5 @@ sed -e '/CXXFLAGS=/d' \
 abinfo "Preparing a separate source root for runtime library ..."
 cp -rv "$SRCDIR"/{,lib}unrar
 
-abinfo "Arch Linux: Appending -pthread to LDFLAGS to fix build ..."
+abinfo "AOSC OS: Appending -pthread to LDFLAGS to fix build ..."
 export LDFLAGS="${LDFLAGS} -pthread"

--- a/extra-utils/unrar/autobuild/prepare
+++ b/extra-utils/unrar/autobuild/prepare
@@ -1,4 +1,4 @@
-abinfo "AOSC OS: Tweaking Makefile to use system compiler and linker flags ..."
+abinfo "Arch Linux: Tweaking Makefile to use system compiler and linker flags ..."
 sed -e '/CXXFLAGS=/d' \
     -e '/LDFLAGS=/d' \
     -i "$SRCDIR"/unrar/makefile
@@ -6,5 +6,5 @@ sed -e '/CXXFLAGS=/d' \
 abinfo "Preparing a separate source root for runtime library ..."
 cp -rv "$SRCDIR"/{,lib}unrar
 
-abinfo "AOSC OS: Appending -pthread to LDFLAGS to fix build ..."
+abinfo "Arch Linux: Appending -pthread to LDFLAGS to fix build ..."
 export LDFLAGS="${LDFLAGS} -pthread"

--- a/extra-utils/unrar/spec
+++ b/extra-utils/unrar/spec
@@ -1,3 +1,5 @@
-VER=5.7.3
-DUMMYSRC=1
-REL=2
+VER=6.0.7
+SRCS="tbl::http://www.rarlab.com/rar/unrarsrc-$VER.tar.gz"
+CHKSUMS="sha256::a7029942006cbcced3f3b7322ec197683f8e7be408972ca08099b196c038f518"
+CHKUPDATE="anitya::id=13306"
+SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Update UnRAR to v6.0.7, lint scripts in accordance with the Styling Manual.

Package(s) Affected
-------------------

`unrar` v6.0.7

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`