### PR TITLE
dbus: fix permission for dbus-daemon-launch-helper

### DIFF
--- a/extra-admin/dbus/autobuild/beyond
+++ b/extra-admin/dbus/autobuild/beyond
@@ -1,2 +1,5 @@
 abinfo "Moving /var/run => /run ..."
 mv -v "$PKGDIR"/{var/,}run
+abinfo "Fixing permissions for dbus-daemon-launch-helper ..."
+chown root:dbus "$PKGDIR"/usr/lib/dbus-1.0/dbus-daemon-launch-helper
+chmod 4750 "$PKGDIR"/usr/lib/dbus-1.0/dbus-daemon-launch-helper

--- a/extra-displaymanagers/sddm/autobuild/beyond
+++ b/extra-displaymanagers/sddm/autobuild/beyond
@@ -1,2 +1,2 @@
 mkdir -p "$PKGDIR"/var/lib/sddm
-chown -R 615:615 "$PKGDIR"/var/lib/sddm
+chown -R sddm:sddm "$PKGDIR"/var/lib/sddm


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
Fix permission for dbus-daemon-launch-helper

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`dbus` v1.12.20

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No 

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
