### PR TITLE
postgresql: enable JIT and use Python 3

### DIFF
--- a/extra-database/postgresql/autobuild/defines
+++ b/extra-database/postgresql/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=postgresql
 PKGSEC=database
-PKGDEP="krb5 libxml2 linux-pam openssl python-2 readline tcl util-linux"
-BUILDDEP="docbook2x python-2 perl tcl"
+PKGDEP="krb5 libxml2 linux-pam openssl python-3 readline tcl util-linux llvm-runtime libxslt"
+BUILDDEP="docbook2x python-2 perl tcl llvm"
 PKGDES="A sophisticated object-relational DBMS"
 
 AUTOTOOLS_AFTER="--datadir=/usr/share/postgresql \
@@ -11,11 +11,15 @@ AUTOTOOLS_AFTER="--datadir=/usr/share/postgresql \
                  --with-perl \
                  --with-python \
                  --with-tcl \
+                 --with-llvm \
                  --with-pam \
+                 --with-libxslt \
+                 --with-icu \
                  --with-system-tzdata=/usr/share/zoneinfo \
                  --with-uuid=e2fs \
                  --enable-nls \
-                 --enable-thread-safety"
+                 --enable-thread-safety \
+                 PYTHON=/usr/bin/python3"
 AUTOTOOLS_AFTER__RISCV64=" \
                  ${AUTOTOOLS_AFTER} \
                  --disable-spinlocks"

--- a/extra-database/postgresql/spec
+++ b/extra-database/postgresql/spec
@@ -1,3 +1,4 @@
 VER=13.3
+REL=1
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
 CHKSUMS="sha256::3cd9454fa8c7a6255b6743b767700925ead1b9ab0d7a0f9dcb1151010f8eb4a1"


### PR DESCRIPTION
Topic Description
-----------------

postgresql: enable JIT and use Python 3

Package(s) Affected
-------------------

`postgresql`

Security Update?
----------------

No

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

