### PR TITLE
Network Authentication Integration Survey - 21' Jun 24

### DIFF
--- a/base-network/openldap/spec
+++ b/base-network/openldap/spec
@@ -1,5 +1,4 @@
-VER=2.4.53
-REL=3
+VER=2.4.59
 SRCS="tbl::https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-$VER.tgz"
-CHKSUMS="sha256::035860e2fb812f2e294ea3e9914944691e4e4f52521b8945a5aacdcd088d8ae8"
+CHKSUMS="sha256::99f37d6747d88206c470067eda624d5e48c1011e943ec0ab217bae8712e22f34"
 CHKUPDATE="anitya::id=2551"

--- a/extra-admin/sssd/autobuild/postinst
+++ b/extra-admin/sssd/autobuild/postinst
@@ -1,0 +1,1 @@
+chmod u=rwX,go-rwx -R /etc/sssd

--- a/extra-admin/sssd/spec
+++ b/extra-admin/sssd/spec
@@ -1,4 +1,3 @@
-VER=2.4.0
-SRCS="https://github.com/SSSD/sssd/releases/download/sssd-${VER//./_}/sssd-$VER.tar.gz"
-CHKSUMS="sha256::13d7eeff15e582279f70a3aad32daeb40d3749ec14947a4eded35adce7490cdd"
-REL=1
+VER=2.5.1
+SRCS="https://github.com/SSSD/sssd/releases/download/${VER}/sssd-$VER.tar.gz"
+CHKSUMS="sha256::ce2f5d84a3f1750093318afd27f4fd75b1e3e75f7d80fc42d21a40cc54b58ea4"

--- a/extra-network/openssh/autobuild/defines
+++ b/extra-network/openssh/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=openssh
 PKGSEC=net
 PKGDES="A SSH client and server"
-PKGDEP="openssl linux-pam ldns krb5 libedit"
+PKGDEP="openssl linux-pam ldns krb5 libedit libfido2"
 PKGSUG="x11-app"
 
 PKGDEP__RETRO="openssl linux-pam"
@@ -14,12 +14,15 @@ PKGDEP__PPC64="$PKGDEP__RETRO"
 
 AUTOTOOLS_AFTER="--sysconfdir=/etc/ssh --with-ldns --with-libedit \
                  --with-ssl-engine --with-pam \
+                 --with-pam-service=system-remote-login \
+                 --with-security-key-builtin \
                  --with-privsep-user=nobody --with-kerberos5=/usr \
                  --with-xauth=/usr/bin/xauth --with-mantype=man \
                  --with-md5-passwords --with-pid-dir=/run"
 AUTOTOOLS_AFTER__RETRO=" \
                  --sysconfdir=/etc/ssh --without-ldns --without-libedit \
                  --with-ssl-engine --with-pam \
+                 --with-pam-service=system-remote-login \
                  --with-privsep-user=nobody --without-kerberos5 \
                  --with-xauth=/usr/bin/xauth --with-mantype=man \
                  --with-md5-passwords --with-pid-dir=/run"

--- a/extra-network/openssh/spec
+++ b/extra-network/openssh/spec
@@ -1,4 +1,3 @@
-VER=8.3p1
-REL=1
+VER=8.6p1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
-CHKSUMS="sha256::f2befbe0472fe7eb75d23340eb17531cb6b3aac24075e2066b41f814e12387b2"
+CHKSUMS="sha256::c3e6e4da1621762c850d03b47eed1e48dff4cc9608ddeb547202a234df8ed7ae"

--- a/extra-optenv32/openldap+32/spec
+++ b/extra-optenv32/openldap+32/spec
@@ -1,3 +1,3 @@
-VER=2.4.53
+VER=2.4.59
 SRCS="tbl::https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-$VER.tgz"
-CHKSUMS="sha256::035860e2fb812f2e294ea3e9914944691e4e4f52521b8945a5aacdcd088d8ae8"
+CHKSUMS="sha256::99f37d6747d88206c470067eda624d5e48c1011e943ec0ab217bae8712e22f34"

--- a/extra-security/sudo/autobuild/build
+++ b/extra-security/sudo/autobuild/build
@@ -1,14 +1,15 @@
-./configure \
-    --prefix=/usr \
-    --sbindir=/usr/bin \
-    --libexecdir=/usr/lib \
-    --with-rundir=/run/sudo \
-    --with-vardir=/var/db/sudo \
-    --with-logfac=auth \
-    --with-pam \
-    --without-ldap \
-    --with-env-editor \
-    --with-passprompt="[sudo] password for %p: " \
-    --with-all-insults
+mkdir -v "${SRCDIR}/abbuild"
+cd "${SRCDIR}/abbuild"
+
+abinfo "Running configure..."
+"${SRCDIR}/configure" \
+	${AUTOTOOLS_DEF} \
+	${AUTOTOOLS_AFTER} \
+	--with-passprompt="[sudo] password for %p: "
+
+abinfo "Building..."
 make
-make install DESTDIR="$PKGDIR"
+
+abinfo "Installing..."
+make DESTDIR="${PKGDIR}" install
+cd "${SRCDIR}"

--- a/extra-security/sudo/autobuild/conffiles
+++ b/extra-security/sudo/autobuild/conffiles
@@ -1,1 +1,4 @@
+/etc/pam.d/sudo
+/etc/sudo.conf
+/etc/sudo_logsrvd.conf
 /etc/sudoers

--- a/extra-security/sudo/autobuild/defines
+++ b/extra-security/sudo/autobuild/defines
@@ -1,4 +1,19 @@
 PKGNAME=sudo
 PKGSEC=admin
 PKGDEP="linux-pam"
+PKGSUG="sssd"
 PKGDES="Give certain users the ability to run some commands as root"
+
+AUTOTOOLS_AFTER=(
+	"--sbindir=/usr/bin"
+	"--with-rundir=/run/sudo"
+	"--with-vardir=/var/db/sudo"
+	"--with-logfac=auth"
+	"--with-pam"
+	"--with-ignore-dot"
+	"--with-sssd"
+	"--without-ldap"
+	"--with-env-editor"
+	"--with-all-insults"
+)
+RECONF=0

--- a/extra-security/sudo/spec
+++ b/extra-security/sudo/spec
@@ -1,3 +1,3 @@
-VER=1.9.5p2
+VER=1.9.7p1
 SRCS="tbl::https://www.sudo.ws/dist/sudo-$VER.tar.gz"
-CHKSUMS="sha256::539e2ef43c8a55026697fb0474ab6a925a11206b5aa58710cb42a0e1c81f0978"
+CHKSUMS="sha256::391431f454e55121b60c6ded0fcf30ddb80d623d7d16a6d1907cfa6a0b91d8cf"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates `sssd`, `openldap`, `openssh` and `sudo` to their respective latest versions and introduces some feature fixes:

* `sssd`: Fixed ownership and permission for `/etc/sssd`
* `openssh`: Login access check now uses `/etc/pam.d/system-remote-login` instead of `/etc/pam.d/other`.
* `sudo`: Add integration with `sssd`

Package(s) Affected
-------------------

* `sssd`: 2.4.0 -> 2.5.1
* `openldap`: 2.4.53 -> 2.4.59
* `openldap+32`: 2.4.53 -> 2.4.59 (optenv32)
* `openssh`: 8,3p1 -> 8.6p1
* `sudo`: 1.9.5p2 -> 1.9.7p1

Security Update?
----------------

* `openldap`: A ton of CVEs.
* `openssh`: A handful of CVEs.
* `sudo`: Privilege escalation via `sudoedit` CVE-2021-3156

Build Order
-----------

Build in the order of commits.

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
