### PR TITLE
sddm: clean up scripts with fixed gid and uid

### DIFF
--- a/extra-displaymanagers/sddm/autobuild/beyond
+++ b/extra-displaymanagers/sddm/autobuild/beyond
@@ -1,2 +1,0 @@
-mkdir -p "$PKGDIR"/var/lib/sddm
-chown -R 615:615 "$PKGDIR"/var/lib/sddm

--- a/extra-displaymanagers/sddm/autobuild/postinst
+++ b/extra-displaymanagers/sddm/autobuild/postinst
@@ -2,8 +2,8 @@ if ! getent group sddm > /dev/null; then
 	groupadd sddm -r
 fi
 if ! getent passwd sddm > /dev/null; then
-	useradd -c "Simple Desktop Display Manager daemon owner" --system -d /var/lib/sddm -s /usr/bin/nologin -r -g sddm sddm
+	useradd -c "Simple Desktop Display Manager daemon owner" --system -m -d /var/lib/sddm -s /usr/bin/nologin -r -g sddm sddm
 	passwd -l sddm > /dev/null
 fi
 
-chown sddm:sddm /var/lib/sddm
+chown -Rv sddm:sddm /var/lib/sddm

--- a/extra-displaymanagers/sddm/spec
+++ b/extra-displaymanagers/sddm/spec
@@ -1,3 +1,4 @@
 VER=0.19.0
+REL=1
 SRCS="tbl::https://github.com/sddm/sddm/releases/download/v$VER/sddm-$VER.tar.xz"
 CHKSUMS="sha256::e254f14048c275c12a3084ec6330855bc6b20135659f88e63626af88b8f68d41"


### PR DESCRIPTION
Topic Description
-----------------

sddm: clean up scripts with fixed gid and uid
remove leftover fixed gid and uids in the build script

Package(s) Affected
-------------------

`sddm` 0.19.0

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
