### PR TITLE
telegram-desktop: update to 2.8.2

### DIFF
--- a/extra-libs/rnnoise/autobuild/defines
+++ b/extra-libs/rnnoise/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="rnnoise"
+PKGDES="A noise suppression library based on a recurrent neural network"
+PKGDEP="glibc"
+PKGSEC="libs"
+
+PKGEPOCH=1

--- a/extra-libs/rnnoise/autobuild/prepare
+++ b/extra-libs/rnnoise/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Setting rnnoise package version ..."
+echo "PACKAGE_VERSION=\"$PKGVER\"" > "$SRCDIR"/package_version

--- a/extra-libs/rnnoise/spec
+++ b/extra-libs/rnnoise/spec
@@ -1,0 +1,3 @@
+VER=0+git20210312
+SRCS="git::commit=7f449bf8bd3b933891d12c30112268c4090e4d59::https://gitlab.xiph.org/xiph/rnnoise"
+CHKSUMS="SKIP"

--- a/extra-multimedia/noise-suppression-for-voice/autobuild/defines
+++ b/extra-multimedia/noise-suppression-for-voice/autobuild/defines
@@ -1,4 +1,4 @@
-PKGNAME=rnnoise
+PKGNAME=noise-suppression-for-voice
 PKGSEC=sound
 BUILDDEP="cmake"
 PKGDES="Noise suppression plugin based on Xiph's RNNoise"
@@ -8,3 +8,6 @@ AB_FLAGS_O3=1
 CMAKE_AFTER="-DBUILD_LADSPA_PLUGIN=ON \
              -DBUILD_LV2_PLUGIN=ON \
              -DBUILD_VST_PLUGIN=OFF"
+
+PKGBREAK="rnnoise<=0.9"
+PKGREP="rnnoise<=0.9"

--- a/extra-multimedia/noise-suppression-for-voice/spec
+++ b/extra-multimedia/noise-suppression-for-voice/spec
@@ -1,0 +1,3 @@
+VER=0.91
+SRCS="tbl::https://github.com/werman/noise-suppression-for-voice/archive/v${VER}.tar.gz"
+CHKSUMS="sha256::4f3a112534d4abb5ee2b6c328cde89193dbdb2146cffc98505972c3b5397a35e"

--- a/extra-multimedia/rnnoise/spec
+++ b/extra-multimedia/rnnoise/spec
@@ -1,3 +1,0 @@
-VER=0.9
-SRCS="tbl::https://github.com/werman/noise-suppression-for-voice/archive/v${VER}.tar.gz"
-CHKSUMS='sha256::db42eb863082847ce58eeb9395eaaa7ccd84a0dd7153c35a614f35dd0967aab1'

--- a/extra-web/telegram-desktop/autobuild/defines
+++ b/extra-web/telegram-desktop/autobuild/defines
@@ -2,11 +2,11 @@ PKGNAME=telegram-desktop
 PKGSEC=web
 PKGDEP="ffmpeg hicolor-icon-theme libappindicator libnotify minizip \
         openal-soft openssl lz4 qt-5 xxhash hunspell libdbusmenu-qt \
-	libjpeg-turbo opus pulseaudio kwayland webkit2gtk"
+	libjpeg-turbo opus pulseaudio kwayland webkit2gtk rnnoise pipewire"
 PKGDEP__ARM64="${PKGDEP} glibmm"
 PKGDEP__PPC64EL="${PKGDEP} glibmm"
 PKGDEP__LOONGSON3="${PKGDEP} glibmm"
-BUILDDEP="cmake range-v3 python-3 tl-expected microsoft-gsl yasm"
+BUILDDEP="cmake range-v3 python-3 tl-expected microsoft-gsl yasm extra-cmake-modules"
 PKGDES="The official Telegram desktop application"
 
 PKGPROV="telegram tdesktop"

--- a/extra-web/telegram-desktop/autobuild/prepare
+++ b/extra-web/telegram-desktop/autobuild/prepare
@@ -10,7 +10,8 @@ cd "$SRCDIR"/../tg_owt
 cmake -G Ninja \
       -DBUILD_SHARED_LIBS=OFF \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX=/usr .
+      -DCMAKE_INSTALL_PREFIX=/usr \
+      -DTG_OWT_DLOPEN_PIPEWIRE=OFF .
 ninja
 ninja install
 

--- a/extra-web/telegram-desktop/spec
+++ b/extra-web/telegram-desktop/spec
@@ -1,7 +1,8 @@
-VER=2.7.4
+VER=2.8.2
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
-      git::rename=tg_owt;commit=18cb4cd9bb4c2f5f5f5e760ec808f74c302bc1bf::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::97526f0b4adf04cf86b605ae84f3efaacf58eb8f828bab8f4fe752a4fac62fb2 \
+      git::rename=tg_owt;commit=f03ef05abf665437649a4f71886db1343590e862::https://github.com/desktop-app/tg_owt"
+CHKSUMS="sha256::ceff7216cb171af7a0e5c323bd19f97d8ced7e48c62b69e0d7f27bf467471b26 \
          SKIP"
 SUBDIR=tdesktop-$VER-full
+CHKUPDATE="anitya::id=16951"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

telegram-desktop: update to 2.8.2

Package(s) Affected
-------------------

rnnoise: 0+git20210312
noise-suppression-for-voice: 0.91
telegram-desktop:2.8.2

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

rnnoise noise-suppression-for-voice telegram-desktop


Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
