### PR TITLE
ALSA survey 20210628

### DIFF
--- a/extra-multimedia/alsa-lib/spec
+++ b/extra-multimedia/alsa-lib/spec
@@ -1,4 +1,3 @@
-VER=1.2.1.2
+VER=1.2.5.1
 SRCS="tbl::https://www.alsa-project.org/files/pub/lib/alsa-lib-$VER.tar.bz2"
-CHKSUMS="sha256::958e260e3673f1f6ff6b2d2c0df3fc2e469bea5b2957163ce96ce17f23e87943"
-REL=1
+CHKSUMS="sha256::628421d950cecaf234de3f899d520c0a6923313c964ad751ffac081df331438e"

--- a/extra-multimedia/alsa-plugins/autobuild/defines
+++ b/extra-multimedia/alsa-plugins/autobuild/defines
@@ -2,6 +2,6 @@ PKGNAME=alsa-plugins
 PKGDES="Extra ALSA plugins"
 PKGSEC=libs
 PKGDEP="alsa-lib"
-BUILDDEP="pulseaudio speex jack libsamplerate"
+BUILDDEP="pulseaudio speex jack libsamplerate ffmpeg"
 
 # Soft dependencies used, as the plugins are not loaded at runtime if not specified.

--- a/extra-multimedia/alsa-plugins/spec
+++ b/extra-multimedia/alsa-plugins/spec
@@ -1,3 +1,3 @@
-VER=1.2.2
+VER=1.2.5
 SRCS="tbl::https://www.alsa-project.org/files/pub/plugins/alsa-plugins-$VER.tar.bz2"
-CHKSUMS="sha256::1c0f06450c928d711719686c9dbece2d480184f36fab11b8f0534cb7b41e337d"
+CHKSUMS="sha256::42eef98433d2c8d11f1deeeb459643619215a75aa5a5bbdd06a794e4c413df20"

--- a/extra-multimedia/alsa-ucm-conf/autobuild/build
+++ b/extra-multimedia/alsa-ucm-conf/autobuild/build
@@ -1,0 +1,3 @@
+abinfo "Installing UCM configurations..."
+mkdir -pv "$PKGDIR"/usr/share/alsa
+cp -rv "$SRCDIR"/ucm2 "$PKGDIR"/usr/share/alsa/

--- a/extra-multimedia/alsa-ucm-conf/autobuild/defines
+++ b/extra-multimedia/alsa-ucm-conf/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=alsa-ucm-conf
+PKGSEC=sound
+PKGDES="ALSA Use Case Manager configuration"
+PKGDEP="alsa-lib"
+
+ABHOST=noarch

--- a/extra-multimedia/alsa-ucm-conf/autobuild/overrides/usr/share/alsa/ucm2/Rockchip/es8316-pinebook-pro/HiFi.conf
+++ b/extra-multimedia/alsa-ucm-conf/autobuild/overrides/usr/share/alsa/ucm2/Rockchip/es8316-pinebook-pro/HiFi.conf
@@ -1,0 +1,86 @@
+SectionVerb {
+	Value {
+		MinBufferLevel "512"
+	}
+
+	EnableSequence [
+		# Disable speaker amplifier
+		cset "name='Speaker Switch' off"
+	
+		# Set HP vol to 0 dB (3/3)
+		cset "name='Headphone Playback Volume' 3"
+		# Set HP mixer vol to 0 dB
+		cset "name='Headphone Mixer Volume' 11"
+		# Set DAC vol to 0 dB (192/192)
+		cset "name='DAC Playback Volume' 192"
+	
+		# Disable Auto Level Control
+		cset "name='ALC Capture Switch' off"
+		# Set ADC vol to 0 dB (192/192)
+		cset "name='ADC Capture Volume' 192"
+		# Set Mic amplifier to +16 dB
+		cset "name='ADC PGA Gain Volume' 7"
+	
+		# Setup muxes / switches
+		cset "name='Left Headphone Mixer Left DAC Switch' on"
+		cset "name='Right Headphone Mixer Right DAC Switch' on"
+	]
+}
+
+# In fact, ES8316 codec has only one analog output, which is wired directly to
+# Headphone and via an extra amplifier to Speakers.
+
+SectionDevice."Speaker" {
+	Comment "Speakers"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='Speaker Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Headphone Mixer"
+		PlaybackMasterElem "DAC"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Headphone Mixer"
+		PlaybackMasterElem "DAC"
+		JackControl "Headphones Jack"
+		JackHWMute "Speaker"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	EnableSequence [
+		cset "name='Differential Mux' lin1-rin1"
+	]
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "ADC PGA Gain"
+		CaptureMasterElem "ADC"
+	}
+}

--- a/extra-multimedia/alsa-ucm-conf/autobuild/overrides/usr/share/alsa/ucm2/conf.d/rockchip_es8316/rockchip_es8316.conf
+++ b/extra-multimedia/alsa-ucm-conf/autobuild/overrides/usr/share/alsa/ucm2/conf.d/rockchip_es8316/rockchip_es8316.conf
@@ -1,0 +1,6 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "/Rockchip/es8316-pinebook-pro/HiFi.conf"
+	Comment "Play HiFi quality music"
+}

--- a/extra-multimedia/alsa-ucm-conf/spec
+++ b/extra-multimedia/alsa-ucm-conf/spec
@@ -1,0 +1,3 @@
+VER=1.2.5.1
+SRCS="tbl::https://www.alsa-project.org/files/pub/lib/alsa-ucm-conf-$VER.tar.bz2"
+CHKSUMS="sha256::5841a444166dcbf479db751303dbc3556f685085ac7e00f0c9e7755676195d97"

--- a/extra-multimedia/alsa-utils/autobuild/build
+++ b/extra-multimedia/alsa-utils/autobuild/build
@@ -1,22 +1,28 @@
+abinfo "Configuring..."
 if [[ "${CROSS:-$ARCH}" != "i486" && "${CROSS:-$ARCH}" = "powerpc" ]]; then
     ./configure ${AUTOTOOLS_DEF} --disable-alsaconf \
-                --with-udev-rules-dir=/lib/udev/rules.d \
-                --with-systemdsystemunitdir=/lib/systemd/system
+                --with-udev-rules-dir=/usr/lib/udev/rules.d \
+                --with-systemdsystemunitdir=/usr/lib/systemd/system
 else
     ./configure ${AUTOTOOLS_DEF} --disable-alsaconf \
-                --with-udev-rules-dir=/lib/udev/rules.d \
-                --with-systemdsystemunitdir=/lib/systemd/system \
+                --with-udev-rules-dir=/usr/lib/udev/rules.d \
+                --with-systemdsystemunitdir=/usr/lib/systemd/system \
                 --disable-bat
 fi
-make 
+abinfo "Making the main part..."
+make
 
 cd alsactl
+abinfo "Making udev rule for alsactl restore..."
 make 90-alsa-restore.rules
 cd ..
 
+abinfo "Installing the main part..."
 make DESTDIR="$PKGDIR" install
 
-install -D -m644 alsactl/90-alsa-restore.rules \
-  "$PKGDIR"/lib/udev/rules.d/90-alsa-restore.rules
+abinfo "Installing udev rule for alsactl restore..."
+install -vD -m644 alsactl/90-alsa-restore.rules \
+  "$PKGDIR"/usr/lib/udev/rules.d/90-alsa-restore.rules
 
-install -d "$PKGDIR"/var/lib/alsa
+abinfo "Creating directory for alsactl restore..."
+install -vd "$PKGDIR"/var/lib/alsa

--- a/extra-multimedia/alsa-utils/autobuild/defines
+++ b/extra-multimedia/alsa-utils/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=alsa-utils
 PKGDES="ALSA utilities"
 PKGSEC=utils
-PKGDEP="alsa-lib pciutils ncurses psmisc libsamplerate fftw"
+PKGDEP="alsa-lib pciutils ncurses psmisc libsamplerate systemd"
 PKGDEP__RETRO="alsa-lib pciutils ncurses psmisc libsamplerate"
 PKGDEP__ARMEL="${PKGDEP__RETRO}"
 PKGDEP__ARMHF="${PKGDEP__RETRO}"

--- a/extra-multimedia/alsa-utils/spec
+++ b/extra-multimedia/alsa-utils/spec
@@ -1,3 +1,3 @@
-VER=1.2.3
+VER=1.2.5.1
 SRCS="tbl::https://www.alsa-project.org/files/pub/utils/alsa-utils-$VER.tar.bz2"
-CHKSUMS="sha256::ff19ae48c22938de7a491bdb39db74a2eee2546013f39bf1a86185e426f921aa"
+CHKSUMS="sha256::9c169ae37a49295f9b97b92ace772803daf6b6510a19574e0b78f87e562118d0"

--- a/extra-optenv32/alsa-lib+32/autobuild/build
+++ b/extra-optenv32/alsa-lib+32/autobuild/build
@@ -2,7 +2,7 @@ export PATH=/opt/32/bin:$PATH
 
 ./configure --prefix=/opt/32 --disable-python \
             --disable-static \
-            LDFLAGS="${LDFLAGS} -L/opt/32/lib" \
+            LDFLAGS="${LDFLAGS}" \
             CC=i686-pc-linux-gnu-gcc CXX=i686-pc-linux-gnu-g++ \
             PKG_CONFIG_PATH=/opt/32/lib/pkgconfig
 make

--- a/extra-optenv32/alsa-lib+32/spec
+++ b/extra-optenv32/alsa-lib+32/spec
@@ -1,4 +1,3 @@
-VER=1.2.1.2
+VER=1.2.5.1
 SRCS="tbl::https://www.alsa-project.org/files/pub/lib/alsa-lib-$VER.tar.bz2"
-CHKSUMS="sha256::958e260e3673f1f6ff6b2d2c0df3fc2e469bea5b2957163ce96ce17f23e87943"
-REL=1
+CHKSUMS="sha256::628421d950cecaf234de3f899d520c0a6923313c964ad751ffac081df331438e"

--- a/extra-optenv32/alsa-plugins+32/autobuild/build
+++ b/extra-optenv32/alsa-plugins+32/autobuild/build
@@ -2,7 +2,7 @@ export PATH=/opt/32/bin:$PATH
 
 ./configure --prefix=/opt/32 \
             --disable-jack \
-            --disable-samplerate --disable-avcodec \
+            --disable-samplerate --disable-libav \
             --with-speex=builtin \
             LDFLAGS="${LDFLAGS} -L/opt/32/lib" \
             CC=i686-pc-linux-gnu-gcc CXX=i686-pc-linux-gnu-g++ \

--- a/extra-optenv32/alsa-plugins+32/autobuild/defines
+++ b/extra-optenv32/alsa-plugins+32/autobuild/defines
@@ -2,6 +2,6 @@ PKGNAME=alsa-plugins+32
 PKGDES="Extra ALSA plugins (optenv32)"
 PKGSEC=libs
 PKGDEP="alsa-lib+32 pulseaudio+32"
-BUILDDEP="32subsystem"
+BUILDDEP="32subsystem speex+32"
 NOLTO=1
 ABHOST=noarch

--- a/extra-optenv32/alsa-plugins+32/autobuild/patch
+++ b/extra-optenv32/alsa-plugins+32/autobuild/patch
@@ -1,1 +1,0 @@
-sed -i 's/ && LIBAVCODEC_VERSION_MINOR >= 34//' a52/pcm_a52.c

--- a/extra-optenv32/alsa-plugins+32/spec
+++ b/extra-optenv32/alsa-plugins+32/spec
@@ -1,3 +1,3 @@
-VER=1.2.2
+VER=1.2.5
 SRCS="tbl::https://www.alsa-project.org/files/pub/plugins/alsa-plugins-$VER.tar.bz2"
-CHKSUMS="sha256::1c0f06450c928d711719686c9dbece2d480184f36fab11b8f0534cb7b41e337d"
+CHKSUMS="sha256::42eef98433d2c8d11f1deeeb459643619215a75aa5a5bbdd06a794e4c413df20"


### PR DESCRIPTION
Topic Description
-----------------

A survey targeting  ALSA, including upgrading alsa-{lib,plugins,utils} and introducing alsa-ucm-conf (which benefits some complex sound hardware).

Package(s) Affected
-------------------

- `alsa-lib{,+32}` 1.2.5.1
- `alsa-utils{,+32}` 1.2.5.1
- `alsa-plugins` 1.2.5
- `alsa-ucm-conf` 1.2.5.1 (new)

Security Update?
----------------

No

Build Order
-----------

The same order with "Packages affected" section.

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit Optional Environment `optenv32`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
- [ ] 32-bit Optional Environment `optenv32`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
