### PR TITLE
vaultwarden: new, 1.22.1

### DIFF
--- a/extra-security/vaultwarden/autobuild/beyond
+++ b/extra-security/vaultwarden/autobuild/beyond
@@ -1,0 +1,9 @@
+abinfo "Installing vaultwarden env.template ..."
+install -Dvm644 "$SRCDIR"/.env.template "$PKGDIR"/etc/vaultwarden.env
+
+abinfo "Installing bitwarden web ..."
+mkdir -pv "$PKGDIR"/srv/http
+cp -arv "$SRCDIR"/../web-vault/ "$PKGDIR"/srv/http/web-vault
+
+abinfo "Creating user data directory ..."
+mkdir -pv "$PKGDIR"/var/lib/vaultwarden

--- a/extra-security/vaultwarden/autobuild/defines
+++ b/extra-security/vaultwarden/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME="vaultwarden"
+PKGDES="Unofficial Bitwarden compatible server"
+PKGDEP="glibc sqlite"
+PKGSEC="admin"
+
+CARGO_AFTER="--features sqlite"
+NOLTO=1
+FAIL_ARCH="!(amd64|arm64)"

--- a/extra-security/vaultwarden/autobuild/defines
+++ b/extra-security/vaultwarden/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME="vaultwarden"
 PKGDES="Unofficial Bitwarden compatible server"
-PKGDEP="glibc sqlite"
+PKGDEP="glibc"
+PKGSUG="sqlite postgresql mariadb"
+BUILDDEP="sqlite postgresql mariadb"
 PKGSEC="admin"
 
-CARGO_AFTER="--features sqlite"
+CARGO_AFTER="--features sqlite,postgresql,mysql"
 NOLTO=1
 FAIL_ARCH="!(amd64|arm64)"

--- a/extra-security/vaultwarden/autobuild/overrides/usr/lib/systemd/system/vaultwarden.service
+++ b/extra-security/vaultwarden/autobuild/overrides/usr/lib/systemd/system/vaultwarden.service
@@ -1,0 +1,53 @@
+[Unit]
+Description=Bitwarden Server (Rust Edition)
+Documentation=https://github.com/dani-garcia/vaultwarden
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/vaultwarden
+WorkingDirectory=/var/lib/vaultwarden
+
+# Allow vaultwarden to bind ports in the range of 0-1024 and restrict it to
+# that capability
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# If vaultwarden is run at ports >1024, you should apply these options via a
+# drop-in file
+#CapabilityBoundingSet=
+#AmbientCapabilities=
+#PrivateUsers=yes
+
+NoNewPrivileges=yes
+
+LimitNOFILE=1048576
+LimitNPROC=64
+UMask=0077
+
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/lib/vaultwarden /var/log/vaultwarden.log
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectHostname=yes
+ProtectClock=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RemoveIPC=yes
+
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+SystemCallArchitectures=native
+
+EnvironmentFile=/etc/vaultwarden.env
+
+[Install]
+WantedBy=multi-user.target

--- a/extra-security/vaultwarden/autobuild/prepare
+++ b/extra-security/vaultwarden/autobuild/prepare
@@ -3,3 +3,11 @@ curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
 
 abinfo "Setting rustup variable ..."
 source "$HOME"/.cargo/env
+
+abinfo "Arch Linux: Setting vaultwarden package env ..."
+sed -e "s|# DATA_FOLDER=data|DATA_FOLDER=/var/lib/vaultwarden|" \
+    -e "s|# WEB_VAULT_FOLDER=web-vault/|WEB_VAULT_FOLDER=/srv/http/web-vault|" \
+    -e "s|# WEB_VAULT_ENABLED|WEB_VAULT_ENABLED|" \
+    -e "s|/path/to/log|/var/log/vaultwarden.log|" \
+    -e "/^# ROCKET_TLS/a ROCKET_LIMITS={json=10485760}" \
+    -i "$SRCDIR"/.env.template

--- a/extra-security/vaultwarden/autobuild/prepare
+++ b/extra-security/vaultwarden/autobuild/prepare
@@ -1,0 +1,5 @@
+abinfo "Setting rust version as nightly to fix build ..."
+curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
+
+abinfo "Setting rustup variable ..."
+source "$HOME"/.cargo/env

--- a/extra-security/vaultwarden/spec
+++ b/extra-security/vaultwarden/spec
@@ -1,0 +1,4 @@
+VER=1.22.1
+SRCS="tbl::https://github.com/dani-garcia/vaultwarden/archive/refs/tags/$VER.tar.gz"
+CHKSUMS="sha256::067e0ed02666f679b9a96c92b9bc2d0a4ce671980a50ea8220b7716c74f08061"
+CHKUPDATE="github::repo=dani-garcia/vaultwarden"

--- a/extra-security/vaultwarden/spec
+++ b/extra-security/vaultwarden/spec
@@ -1,4 +1,8 @@
 VER=1.22.1
-SRCS="tbl::https://github.com/dani-garcia/vaultwarden/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::067e0ed02666f679b9a96c92b9bc2d0a4ce671980a50ea8220b7716c74f08061"
+BW_WEB_BUILDS_VER=2.20.4b
+SRCS="tbl::https://github.com/dani-garcia/vaultwarden/archive/refs/tags/$VER.tar.gz \
+      tbl::https://github.com/dani-garcia/bw_web_builds/releases/download/v$BW_WEB_BUILDS_VER/bw_web_v$BW_WEB_BUILDS_VER.tar.gz"
+CHKSUMS="sha256::067e0ed02666f679b9a96c92b9bc2d0a4ce671980a50ea8220b7716c74f08061 \
+         sha256::baa055b385c81d874effd9fe4eaef6a71a6113acd81ff9d2cbebbb715008e820"
 CHKUPDATE="github::repo=dani-garcia/vaultwarden"
+SUBDIR="vaultwarden-$VER"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

vaultwarden: new, 1.22.1

Package(s) Affected
-------------------

vaultwarden: 1.22.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No
<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->


----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->