### PR TITLE
ciel: update to 3.0.9

### DIFF
--- a/extra-devel/autobuild3/autobuild/build
+++ b/extra-devel/autobuild3/autobuild/build
@@ -1,16 +1,29 @@
-rm -r autobuild3/.git*
+abinfo "Dropping .git* ..."
+rm -rv autobuild3/.git*
 
-mkdir -p "$PKGDIR"/usr/{lib,share/doc}/autobuild3
-cp -ar autobuild3 "$PKGDIR"/usr/lib/
-mv "$PKGDIR"/usr/lib/autobuild3/*.md "$PKGDIR"/usr/share/doc/autobuild3/
+abinfo "Installing Autobuild3 program files ..."
+mkdir -pv "$PKGDIR"/usr/{lib,share/doc}/autobuild3
+cp -arv autobuild3 "$PKGDIR"/usr/lib/
 
-mkdir -p "$PKGDIR"/etc
-ln -sv ../usr/lib/autobuild3/etc/autobuild "$PKGDIR"/etc/autobuild
-echo '/usr/lib/autobuild3' > "$PKGDIR"/etc/autobuild/prefix
+abinfo "Installing documentation ..."
+mv -v "$PKGDIR"/usr/lib/autobuild3/*.md \
+    "$PKGDIR"/usr/share/doc/autobuild3/
 
-mkdir -p "$PKGDIR"/usr/bin
-cd "$PKGDIR"/usr/bin
-ln -sv ../lib/autobuild3/ab3.sh autobuild
-ln -sv ../lib/autobuild3/contrib/* .
+abinfo "Setting prefix in configuration ..."
+echo '/usr/lib/autobuild3' \
+    > "$PKGDIR"/usr/lib/autobuild3/etc/autobuild/prefix
 
-cd "$SRCDIR"
+abinfo "Installing a symlink for /etc/autobuild ..."
+mkdir -pv "$PKGDIR"/etc
+ln -sv ../usr/lib/autobuild3/etc/autobuild \
+    "$PKGDIR"/etc/autobuild
+
+abinfo "Installing executable symlinks ..."
+mkdir -pv "$PKGDIR"/usr/bin
+(
+    cd "$PKGDIR"/usr/bin
+    ln -sv ../lib/autobuild3/ab3.sh \
+        "$PKGDIR"/usr/bin/autobuild
+    ln -sv ../lib/autobuild3/contrib/* \
+        "$PKGDIR"/usr/bin/
+)

--- a/extra-devel/autobuild3/autobuild/conffiles
+++ b/extra-devel/autobuild3/autobuild/conffiles
@@ -1,2 +1,3 @@
+/usr/lib/autobuild3/etc/autobuild/ab3_defcfg.sh
 /usr/lib/autobuild3/etc/autobuild/ab3cfg.sh
-/etc/autobuild/prefix
+/usr/lib/autobuild3/etc/autobuild/prefix

--- a/extra-devel/autobuild3/spec
+++ b/extra-devel/autobuild3/spec
@@ -1,4 +1,5 @@
 VER=1.6.11
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 SUBDIR=.

--- a/extra-devel/ciel/spec
+++ b/extra-devel/ciel/spec
@@ -1,4 +1,4 @@
-VER=3.0.7
+VER=3.0.9
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=AOSC-Dev/ciel-rs"


### PR DESCRIPTION
Topic Description
-----------------

Update Ciel to v3.0.9, and change Autobuild3 build script according to this plan:

```
src/config: write Autobuild3 config to /usr/lib/autobuild3/etc/autobuild
    
    This prevents a possible issue where OverlayFS considers /etc/autobuild
    not as a symlink, but a standalone directory. An Autobuild3 update will be
    pushed in tandem to make sure that /usr/lib/autobuild3/etc/autobuild/*
    are considered conffiles.
    
    Probably a good idea to make Autobuild3 recognise /etc, or sysconfdir.
```

Package(s) Affected
-------------------

- `autobuild3` v1.6.11-1
- `ciel` v3.0.9

Security Update?
----------------

No

Build Order
-----------

```
autobuild3 ciel
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`