### PR TITLE
autobuild3: update to 1.6.12

### DIFF
--- a/extra-devel/autobuild3/spec
+++ b/extra-devel/autobuild3/spec
@@ -1,5 +1,4 @@
-VER=1.6.11
-REL=1
+VER=1.6.12
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Update Autobuild3 to v1.6.12. This fixes Autobuild3 behaviour when `ABSTRIP=0` and `ABSPLITDBG=` is not specified.

Package(s) Affected
-------------------

`autobuild3` v1.6.12

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`