### PR TITLE
atm: "update" to 0.3.1~alpha.1

### DIFF
--- a/extra-admin/atm/spec
+++ b/extra-admin/atm/spec
@@ -1,5 +1,4 @@
-VER=0.3.0
-REL=2
-SRCS="https://github.com/AOSC-Dev/atm/archive/v$VER.tar.gz"
-CHKSUMS="sha256::d650ad89711c83eb28d7ea68794a2dd679083c02f6eb91928c1b4a5a22bfd8ba"
+VER=0.3.1~alpha.1
+SRCS="https://github.com/AOSC-Dev/atm/archive/v${VER/\~/-}.tar.gz"
+CHKSUMS="sha256::0e127b076abd2e424d9798d7b9167c909f2ac04ac460d5928a68219e0f54954d"
 CHKUPDATE="github::repo=AOSC-Dev/atm"


### PR DESCRIPTION
Topic Description
-----------------

This is actually a backtrack version to make ATM at least functional in enabling topics and installing updates automatically - though not very reliably or cleanly, as @liushuyu cautioned.

We will have to return to `libsolv` one day, but as of now, we are a bit burnt out with this whole package manager ordeal.

Package(s) Affected
-------------------

`atm` v0.3.1~alpha.1

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`