### PR TITLE
OpenSSH rework: turn off strip, let ab3 reap debug symbols

### DIFF
--- a/extra-network/openssh/autobuild/defines
+++ b/extra-network/openssh/autobuild/defines
@@ -16,6 +16,7 @@ AUTOTOOLS_AFTER="--sysconfdir=/etc/ssh --with-ldns --with-libedit \
                  --with-ssl-engine --with-pam \
                  --with-pam-service=system-remote-login \
                  --with-security-key-builtin \
+                 --disable-strip \
                  --with-privsep-user=nobody --with-kerberos5=/usr \
                  --with-xauth=/usr/bin/xauth --with-mantype=man \
                  --with-md5-passwords --with-pid-dir=/run"
@@ -23,6 +24,7 @@ AUTOTOOLS_AFTER__RETRO=" \
                  --sysconfdir=/etc/ssh --without-ldns --without-libedit \
                  --with-ssl-engine --with-pam \
                  --with-pam-service=system-remote-login \
+                 --disable-strip \
                  --with-privsep-user=nobody --without-kerberos5 \
                  --with-xauth=/usr/bin/xauth --with-mantype=man \
                  --with-md5-passwords --with-pid-dir=/run"

--- a/extra-network/openssh/spec
+++ b/extra-network/openssh/spec
@@ -1,3 +1,4 @@
 VER=8.6p1
+REL=1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
 CHKSUMS="sha256::c3e6e4da1621762c850d03b47eed1e48dff4cc9608ddeb547202a234df8ed7ae"


### PR DESCRIPTION
Topic Description
-----------------

This PR disables stripping within openssh build system, so that autobuild3 can extract debug symbol files from binaries.

Package(s) Affected
-------------------

* openssh: 8.6p1-1

Build Order
-----------

Build as part of #3220 

<!-- TODO: CI to auto-fill architectural progress. -->
