### PR TITLE
autobuild3: update to 1.6.13

### DIFF
--- a/extra-devel/autobuild3/spec
+++ b/extra-devel/autobuild3/spec
@@ -1,4 +1,4 @@
-VER=1.6.12
+VER=1.6.13
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Update Autobuild3 to v1.6.13:

- Fix a bug where `noarch` packages could not be built due to a coupling of `ABHOST=noarch` and `ABSPLITDBG=1` (defined in `/etc/autobuild3/ab3_defcfg.sh`).
- Old (pre-1.6.13) `proc/10-core_defines` routine defines `ABSPLITDBG` in case of a noarch package by `ABSPLITDBG_NOARCH` and `ABSPLITDBG_OTHERS` variables, resulting in an incomplete variable value substitution.


Package(s) Affected
-------------------

`autobuild3` v1.6.13

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`