### PR TITLE
mesa: update to 21.1.4

### DIFF
--- a/extra-libs/mesa/autobuild/defines
+++ b/extra-libs/mesa/autobuild/defines
@@ -49,13 +49,13 @@ MESON_AFTER__X86=" \
              ${MESON_AFTER} \
              -Db_lto=true \
              -Ddri-drivers=r100,r200,nouveau,i915,i965 \
-             -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,swrast,svga,iris \
+             -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,swrast,svga,iris,d3d12 \
              -Dvulkan-drivers=amd,intel"
 MESON_AFTER__ARM=" \
              ${MESON_AFTER} \
              -Db_lto=true \
              -Ddri-drivers=r100,r200,nouveau \
-             -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,swrast,kmsro,lima,panfrost,freedreno,tegra,vc4,v3d,etnaviv \
+             -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,swrast,kmsro,lima,panfrost,freedreno,tegra,vc4,v3d,etnaviv,d3d12 \
              -Dvulkan-drivers=amd"
 MESON_AFTER__OTHER=" \
              ${MESON_AFTER} \

--- a/extra-libs/mesa/autobuild/prepare
+++ b/extra-libs/mesa/autobuild/prepare
@@ -1,1 +1,3 @@
+abinfo "Importing DirectX-Headers as subproject."
+cp -r "$SRCDIR"/../dxheaders $SRCDIR/subprojects/DirectX-Headers-1.0
 unset CPPFLAGS CFLAGS CXXFLAGS LDFLAGS

--- a/extra-libs/mesa/spec
+++ b/extra-libs/mesa/spec
@@ -1,4 +1,4 @@
-VER=21.1.1
+VER=21.1.4
 SRCS="tbl::https://mesa.freedesktop.org/archive/mesa-$VER.tar.xz"
-CHKSUMS="sha256::eec25ea379054e8911bc5de816aeb50f581b5b708414725003d2f00386b38dd2"
+CHKSUMS="sha256::1f177f44098164b65731c5ded4c928fd58b14f6c9d2087aa0e37bc79bf79e90b"
 CHKUPDATE="anitya::id=1970"

--- a/extra-libs/mesa/spec
+++ b/extra-libs/mesa/spec
@@ -1,4 +1,5 @@
 VER=21.1.4
-SRCS="tbl::https://mesa.freedesktop.org/archive/mesa-$VER.tar.xz"
-CHKSUMS="sha256::1f177f44098164b65731c5ded4c928fd58b14f6c9d2087aa0e37bc79bf79e90b"
+SRCS="tbl::https://mesa.freedesktop.org/archive/mesa-$VER.tar.xz git::commit=65950461b599568b1f6ede8feaa1668f6a6e07bb;rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
+CHKSUMS="sha256::1f177f44098164b65731c5ded4c928fd58b14f6c9d2087aa0e37bc79bf79e90b SKIP"
+SUBDIR=mesa-$VER
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION

<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

mesa: update to 21.1.4

- Add gallium driver d3d12 support on x86 and ARM


Package(s) Affected
-------------------

mesa: 21.1.4

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
