### PR TITLE
Darktable: update to 3.6.0, add zh_CN translation

### DIFF
--- a/extra-creativity/darktable/autobuild/defines
+++ b/extra-creativity/darktable/autobuild/defines
@@ -15,6 +15,7 @@ CMAKE_AFTER="-DBINARY_PACKAGE_BUILD=1 \
              -DUSE_LUA=ON \
              -DUSE_COLORD=ON \
              -DRAWSPEED_ENABLE_LTO=ON \
+             -DCMAKE_SKIP_RPATH=OFF \
              -DDONT_USE_INTERNAL_LUA=OFF"
 CMAKE_AFTER__NONX86=" \
              ${CMAKE_AFTER} \

--- a/extra-creativity/darktable/autobuild/overrides/etc/ld.so.conf.d/darktable.conf
+++ b/extra-creativity/darktable/autobuild/overrides/etc/ld.so.conf.d/darktable.conf
@@ -1,1 +1,0 @@
-/usr/lib/darktable

--- a/extra-creativity/darktable/autobuild/prepare
+++ b/extra-creativity/darktable/autobuild/prepare
@@ -2,3 +2,6 @@ if [[ "${CROSS:-$ARCH}" = "ppc64el" ]]; then
     abinfo "Append -DNO_WARN_X86_INTRINSICS to fix build ..."
     export CFLAGS="${CFLAGS} -DNO_WARN_X86_INTRINSICS"
 fi
+
+abinfo "Copying zh_CN translation"
+cp -v "${SRCDIR}/../zh_CN.po" "${SRCDIR}/po/zh_CN.po"

--- a/extra-creativity/darktable/spec
+++ b/extra-creativity/darktable/spec
@@ -1,3 +1,7 @@
-VER=3.4.0
-SRCS="tbl::https://github.com/darktable-org/darktable/releases/download/release-$VER/darktable-$VER.tar.xz"
-CHKSUMS="sha256::6dd3de1f5ea9f94af92838c0be5ff30fdaa599aa1d737dcb562f9e0b2b2dbdda"
+VER=3.6.0
+SRCS="
+	tbl::https://github.com/darktable-org/darktable/releases/download/release-$VER/darktable-$VER.tar.xz
+	file::rename=zh_CN.po::https://github.com/AOSC-Dev/translations/raw/c9ad079c51b21059860ed2e70bb4a33e3d9471a7/Darktable/3.6.0-zh_CN.po
+"
+CHKSUMS="sha256::86bcd0184af38b93c3688dffd3d5c19cc65f268ecf9358d649fa11fe26c70a39 \
+         sha256::a66f3445a959c978d3345b25d1f17375620df789cd7d244208b0abc30356e9fc"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates darktable to 3.6.0 alongside with translation po for simplified Chinese.

Package(s) Affected
-------------------

* darktable 1:3.4.0 -> 1:3.6.0

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
