### PR TITLE
systemd: backport hwdb resolution override for Pinebook Pro patch

### DIFF
--- a/extra-admin/systemd/autobuild/patches/0002-hwdb-add-resolution-override-for-Pinebook-Pro-touchpad.patch
+++ b/extra-admin/systemd/autobuild/patches/0002-hwdb-add-resolution-override-for-Pinebook-Pro-touchpad.patch
@@ -1,0 +1,42 @@
+From 3e65261afafaa145811a2cf27142c2297ce594b3 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <icenowy@aosc.io>
+Date: Sun, 4 Jul 2021 17:20:25 +0800
+Subject: [PATCH] hwdb: add resolution override for Pinebook Pro touchpad
+
+The Pinebook Pro touchpad returns a resolution data that is 2 times of
+the real value, which makes libinput think the touchpad is only 1/4 the
+real size.
+
+Add a resolution override value for it, to allow libinput to calculate
+the distance moved on it correctly.
+
+Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
+---
+ hwdb.d/60-evdev.hwdb | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/hwdb.d/60-evdev.hwdb b/hwdb.d/60-evdev.hwdb
+index 78afa0c054..96c5da1104 100644
+--- a/hwdb.d/60-evdev.hwdb
++++ b/hwdb.d/60-evdev.hwdb
+@@ -591,6 +591,17 @@ evdev:input:b0003v6161p4D15*
+  EVDEV_ABS_00=::152
+  EVDEV_ABS_01=::244
+ 
++###########################################################
++# Pine64
++###########################################################
++
++# Pinebook Pro
++evdev:input:b0003v258Ap001E*
++ EVDEV_ABS_00=::15
++ EVDEV_ABS_01=::15
++ EVDEV_ABS_35=::15
++ EVDEV_ABS_36=::15
++
+ #########################################
+ # Razer
+ #########################################
+-- 
+2.30.2
+

--- a/extra-admin/systemd/spec
+++ b/extra-admin/systemd/spec
@@ -1,3 +1,4 @@
 VER=248.3
+REL=1
 SRCS="tbl::https://github.com/systemd/systemd-stable/archive/v$VER.tar.gz"
 CHKSUMS="sha256::cc372aeed563379a734901ed73d6fbb6b75c171251e1d69c0b5650aaf9c15d06"


### PR DESCRIPTION
Topic Description
-----------------

Backport hwdb resolution override for Pinebook Pro patch.

Package(s) Affected
-------------------

systemd

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`