### PR TITLE
Adobe source font survey 20210708

### DIFF
--- a/extra-fonts/adobe-source-sans-pro/autobuild/build
+++ b/extra-fonts/adobe-source-sans-pro/autobuild/build
@@ -1,2 +1,0 @@
-mkdir -p "$PKGDIR"/usr/share/fonts/OTF
-cp -v OTF/*.otf "$PKGDIR"/usr/share/fonts/OTF

--- a/extra-fonts/adobe-source-sans-pro/autobuild/defines
+++ b/extra-fonts/adobe-source-sans-pro/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=adobe-source-sans-pro
 PKGSEC=fonts
-PKGDES="Sans Serif font family for user interfaces"
-PKGDEP="fontconfig"
+PKGDES="Transitional package for adobe-source-sans"
+PKGDEP="adobe-source-sans"
+PKGEPOCH=1
 
 ABHOST=noarch

--- a/extra-fonts/adobe-source-sans-pro/autobuild/preinst
+++ b/extra-fonts/adobe-source-sans-pro/autobuild/preinst
@@ -1,1 +1,0 @@
-rm -rf /usr/share/fonts/adobe-source-sans-pro

--- a/extra-fonts/adobe-source-sans-pro/spec
+++ b/extra-fonts/adobe-source-sans-pro/spec
@@ -1,4 +1,2 @@
-VER=2.045
-SRCS="tbl::https://github.com/adobe-fonts/source-sans-pro/archive/2.045R-ro/1.095R-it.tar.gz"
-CHKSUMS="sha256::01e78d7ff451545ff1eec6cf14b28f62135e430a7ba80d74a90efd5334fef7eb"
-SUBDIR="source-sans-pro-2.045R-ro-1.095R-it"
+VER=0
+DUMMYSRC=1

--- a/extra-fonts/adobe-source-sans/autobuild/build
+++ b/extra-fonts/adobe-source-sans/autobuild/build
@@ -1,0 +1,3 @@
+abinfo "Installing font ..."
+mkdir -pv "$PKGDIR"/usr/share/fonts/OTF
+cp -v "$SRCDIR"/OTF/*.otf "$PKGDIR"/usr/share/fonts/OTF

--- a/extra-fonts/adobe-source-sans/autobuild/defines
+++ b/extra-fonts/adobe-source-sans/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=adobe-source-sans
+PKGSEC=fonts
+PKGDES="Sans Serif font family for user interfaces"
+PKGDEP="fontconfig"
+PKGREP="adobe-source-sans-pro<=2.045"
+PKGBREAK="adobe-source-sans-pro<=2.045"
+
+ABHOST=noarch

--- a/extra-fonts/adobe-source-sans/autobuild/overrides/etc/fonts/conf.avail/20-adobe-source-sans.conf
+++ b/extra-fonts/adobe-source-sans/autobuild/overrides/etc/fonts/conf.avail/20-adobe-source-sans.conf
@@ -2,7 +2,7 @@
 <!DOCTYPE fontconfig SYSTEM "../fonts.dtd">
 <fontconfig>
   <alias>
-    <family>Source Sans Pro</family>
+    <family>Source Sans 3</family>
     <default>
       <family>sans-serif</family>
     </default>
@@ -10,7 +10,7 @@
   <alias>
     <family>sans-serif</family>
     <prefer>
-      <family>Source Sans Pro</family>
+      <family>Source Sans 3</family>
     </prefer>
   </alias>
 </fontconfig>

--- a/extra-fonts/adobe-source-sans/autobuild/overrides/usr/share/appdata/adobe-source-sans.metainfo.xml
+++ b/extra-fonts/adobe-source-sans/autobuild/overrides/usr/share/appdata/adobe-source-sans.metainfo.xml
@@ -2,9 +2,9 @@
 <!-- Copyright 2014 Richard Hughes <richard@hughsie.com> -->
 <!-- Copyright 2016 Jeff Bai <jeffbai@aosc.xyz> -->
 <component type="font">
-  <id>adobe-source-sans-pro</id>
+  <id>adobe-source-sans</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>Adobe Source Sans Pro</name>
+  <name>Adobe Source Sans</name>
   <summary>A sans serif font family designed for user interfaces</summary>
 </component>
 

--- a/extra-fonts/adobe-source-sans/spec
+++ b/extra-fonts/adobe-source-sans/spec
@@ -1,0 +1,4 @@
+VER=3.042
+SRCS="tbl::https://github.com/adobe-fonts/source-sans/releases/download/${VER}R/source-sans-${VER}R.zip"
+CHKSUMS="sha256::604d99a42b871e19de3654b936fb145db7094941efcdca4981d742d291382b94"
+SUBDIR="."

--- a/extra-fonts/adobe-source-serif-pro/autobuild/build
+++ b/extra-fonts/adobe-source-serif-pro/autobuild/build
@@ -1,2 +1,0 @@
-mkdir -p "$PKGDIR"/usr/share/fonts/OTF
-cp -v OTF/*.otf "$PKGDIR"/usr/share/fonts/OTF

--- a/extra-fonts/adobe-source-serif-pro/autobuild/defines
+++ b/extra-fonts/adobe-source-serif-pro/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=adobe-source-serif-pro
 PKGSEC=fonts
-PKGDES="A Serif OpenType font family"
-PKGDEP="fontconfig"
+PKGDES="Transitional package for adobe-source-serif"
+PKGDEP="adobe-source-serif"
+PKGEPOCH=1
 
 ABHOST=noarch

--- a/extra-fonts/adobe-source-serif-pro/autobuild/preinst
+++ b/extra-fonts/adobe-source-serif-pro/autobuild/preinst
@@ -1,1 +1,0 @@
-rm -rf /usr/share/fonts/adobe-source-serif-pro

--- a/extra-fonts/adobe-source-serif-pro/spec
+++ b/extra-fonts/adobe-source-serif-pro/spec
@@ -1,5 +1,2 @@
-VER=2.000
-RELVER=${VER}R
-SRCS="tbl::https://github.com/adobe-fonts/source-serif-pro/archive/$RELVER.tar.gz"
-CHKSUMS="sha256::d40a963da859b0e3bade1b2d465b3ed107a523b66e481efc593b60d391ceef56"
-SUBDIR="source-serif-pro-$RELVER"
+VER=0
+DUMMYSRC=1

--- a/extra-fonts/adobe-source-serif/autobuild/build
+++ b/extra-fonts/adobe-source-serif/autobuild/build
@@ -1,0 +1,3 @@
+abinfo "Installing fonts..."
+mkdir -pv "$PKGDIR"/usr/share/fonts/OTF
+cp -v "$SRCDIR"/OTF/*.otf "$PKGDIR"/usr/share/fonts/OTF

--- a/extra-fonts/adobe-source-serif/autobuild/defines
+++ b/extra-fonts/adobe-source-serif/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=adobe-source-serif
+PKGSEC=fonts
+PKGDES="A Serif OpenType font family"
+PKGDEP="fontconfig"
+PKGREP="adobe-source-serif-pro<=2.000"
+PKGBREAK="adobe-source-serif-pro<=2.000"
+
+ABHOST=noarch

--- a/extra-fonts/adobe-source-serif/autobuild/overrides/etc/fonts/conf.avail/20-adobe-source-serif.conf
+++ b/extra-fonts/adobe-source-serif/autobuild/overrides/etc/fonts/conf.avail/20-adobe-source-serif.conf
@@ -2,7 +2,7 @@
 <!DOCTYPE fontconfig SYSTEM "../fonts.dtd">
 <fontconfig>
   <alias>
-    <family>Source Serif Pro</family>
+    <family>Source Serif 4</family>
     <default>
       <family>serif</family>
     </default>
@@ -10,7 +10,7 @@
   <alias>
     <family>serif</family>
     <prefer>
-      <family>Source Serif Pro</family>
+      <family>Source Serif 4</family>
     </prefer>
   </alias>
 </fontconfig>

--- a/extra-fonts/adobe-source-serif/autobuild/overrides/usr/share/appdata/adobe-source-serif.metainfo.xml
+++ b/extra-fonts/adobe-source-serif/autobuild/overrides/usr/share/appdata/adobe-source-serif.metainfo.xml
@@ -4,7 +4,7 @@
 <component type="font">
   <id>adobe-source-serif-pro</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>Adobe Source Serif Pro</name>
+  <name>Adobe Source Serif</name>
   <summary>A Serif OpenType font family</summary>
 </component>
 

--- a/extra-fonts/adobe-source-serif/spec
+++ b/extra-fonts/adobe-source-serif/spec
@@ -1,0 +1,4 @@
+VER=4.004
+SRCS="tbl::https://github.com/adobe-fonts/source-serif/archive/refs/tags/${VER}R.tar.gz"
+CHKSUMS="sha256::dfb364735699cb830caad534cf7741234804d28e4b6fc5e4736b2401f6131aba"
+SUBDIR="source-serif-${VER}R"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Adobe source font survey 20210708

Package(s) Affected
-------------------

adobe-source-sans: 3.042
adobe-source-sans-pro: 1:0
adobe-source-serif: 4.004
adobe-source-serif-pro: 1:0

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

 - [x] Architecture-independent `noarch` 

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

 - [x] Architecture-independent `noarch` 