### PR TITLE
fish: update to 3.3.1

### DIFF
--- a/extra-shells/fish/autobuild/defines
+++ b/extra-shells/fish/autobuild/defines
@@ -4,7 +4,8 @@ PKGDEP="bc gcc-runtime inetutils ncurses which"
 BUILDDEP="sphinx"
 PKGDES="A smart and user-friendly shell intended mostly for interactive use"
 
-CMAKE_AFTER="-DBUILD_DOCS=True"
+CMAKE_AFTER="-DBUILD_DOCS=True \
+             -DCMAKE_INSTALL_SYSCONFDIR=/etc"
 
-ABSHADOW=no
+ABSHADOW=0
 RECONF=0

--- a/extra-shells/fish/spec
+++ b/extra-shells/fish/spec
@@ -1,3 +1,4 @@
-VER=3.2.2
+VER=3.3.1
 SRCS="tbl::https://github.com/fish-shell/fish-shell/archive/$VER.tar.gz"
-CHKSUMS="sha256::9bfe00484df433e89daec82f43cda8c2d5385941347413da4cfd80a6693a4837"
+CHKSUMS="sha256::cc8b6dae684407190cbc9d2b327f0272e8a235f7f60614e0ac2f7d24fdbcde24"
+CHKUPDATE="anitya::id=815"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fish: update to 3.3.1

- Use -DCMAKE_INSTALL_SYSCONFDIR=/etc to fix install /etc/ to wrong path
- Lint
- Adapt to aosc-findupdate

Package(s) Affected
-------------------

fish: 3.3.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
