### PR TITLE
telegram-desktop: backport file dialog/global menu fixes

### DIFF
--- a/extra-web/telegram-desktop/autobuild/patches/1001-backport-file-dialog-global-menu-fix.patch
+++ b/extra-web/telegram-desktop/autobuild/patches/1001-backport-file-dialog-global-menu-fix.patch
@@ -1,0 +1,536 @@
+From 1f92101ffc6013dfcd9d495e6eeb269a5f7e9020 Mon Sep 17 00:00:00 2001
+From: Ilya Fedin <fedin-ilja2010@ya.ru>
+Date: Fri, 2 Jul 2021 16:50:34 +0400
+Subject: [PATCH 1/3] Fix freeze after creating file dialog
+
+---
+ .../platform/linux/linux_xdp_file_dialog.cpp       | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/Telegram/SourceFiles/platform/linux/linux_xdp_file_dialog.cpp b/Telegram/SourceFiles/platform/linux/linux_xdp_file_dialog.cpp
+index 7bbd7e218..96d5b2102 100644
+--- a/Telegram/SourceFiles/platform/linux/linux_xdp_file_dialog.cpp
++++ b/Telegram/SourceFiles/platform/linux/linux_xdp_file_dialog.cpp
+@@ -569,13 +569,6 @@ int XDPFileDialog::exec() {
+ 	setAttribute(Qt::WA_ShowModal, true);
+ 	setResult(0);
+ 
+-	show();
+-	if (failedToOpen()) {
+-		return result();
+-	}
+-
+-	QPointer<QDialog> guard = this;
+-
+ 	// HACK we have to avoid returning until we emit
+ 	// that the dialog was accepted or rejected
+ 	const auto context = Glib::MainContext::create();
+@@ -593,6 +586,13 @@ int XDPFileDialog::exec() {
+ 		loop->quit();
+ 	}, lifetime);
+ 
++	show();
++	if (failedToOpen()) {
++		return result();
++	}
++
++	QPointer<QDialog> guard = this;
++
+ 	loop->run();
+ 	g_main_context_pop_thread_default(context->gobj());
+ 
+-- 
+2.30.2
+
+From 904b486120470153eae77cca64beee4e7f876e83 Mon Sep 17 00:00:00 2001
+From: Ilya Fedin <fedin-ilja2010@ya.ru>
+Date: Fri, 2 Jul 2021 20:29:46 +0400
+Subject: [PATCH 2/3] Use gsl::finally to pop thread context where appropriate
+
+---
+ .../SourceFiles/platform/linux/linux_xdp_file_dialog.cpp     | 5 ++++-
+ .../platform/linux/linux_xdp_open_with_dialog.cpp            | 4 +++-
+ Telegram/SourceFiles/platform/linux/specific_linux.cpp       | 4 +++-
+ 3 files changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/Telegram/SourceFiles/platform/linux/linux_xdp_file_dialog.cpp b/Telegram/SourceFiles/platform/linux/linux_xdp_file_dialog.cpp
+index 96d5b2102..47622c2d5 100644
+--- a/Telegram/SourceFiles/platform/linux/linux_xdp_file_dialog.cpp
++++ b/Telegram/SourceFiles/platform/linux/linux_xdp_file_dialog.cpp
+@@ -574,6 +574,10 @@ int XDPFileDialog::exec() {
+ 	const auto context = Glib::MainContext::create();
+ 	const auto loop = Glib::MainLoop::create(context);
+ 	g_main_context_push_thread_default(context->gobj());
++	const auto contextGuard = gsl::finally([&] {
++		g_main_context_pop_thread_default(context->gobj());
++	});
++
+ 	rpl::lifetime lifetime;
+ 
+ 	accepted(
+@@ -594,7 +598,6 @@ int XDPFileDialog::exec() {
+ 	QPointer<QDialog> guard = this;
+ 
+ 	loop->run();
+-	g_main_context_pop_thread_default(context->gobj());
+ 
+ 	if (guard.isNull()) {
+ 		return QDialog::Rejected;
+diff --git a/Telegram/SourceFiles/platform/linux/linux_xdp_open_with_dialog.cpp b/Telegram/SourceFiles/platform/linux/linux_xdp_open_with_dialog.cpp
+index de8e02bcf..dddf1b54a 100644
+--- a/Telegram/SourceFiles/platform/linux/linux_xdp_open_with_dialog.cpp
++++ b/Telegram/SourceFiles/platform/linux/linux_xdp_open_with_dialog.cpp
+@@ -108,6 +108,9 @@ bool ShowXDPOpenWithDialog(const QString &filepath) {
+ 		const auto context = Glib::MainContext::create();
+ 		const auto loop = Glib::MainLoop::create(context);
+ 		g_main_context_push_thread_default(context->gobj());
++		const auto contextGuard = gsl::finally([&] {
++			g_main_context_pop_thread_default(context->gobj());
++		});
+ 
+ 		const auto signalId = connection->signal_subscribe(
+ 			[&](
+@@ -163,7 +166,6 @@ bool ShowXDPOpenWithDialog(const QString &filepath) {
+ 			QWindow window;
+ 			QGuiApplicationPrivate::showModalWindow(&window);
+ 			loop->run();
+-			g_main_context_pop_thread_default(context->gobj());
+ 			QGuiApplicationPrivate::hideModalWindow(&window);
+ 		}
+ 
+diff --git a/Telegram/SourceFiles/platform/linux/specific_linux.cpp b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+index 6fd38f5c7..73df0b0e7 100644
+--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
++++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+@@ -147,6 +147,9 @@ void PortalAutostart(bool start, bool silent) {
+ 		const auto context = Glib::MainContext::create();
+ 		const auto loop = Glib::MainLoop::create(context);
+ 		g_main_context_push_thread_default(context->gobj());
++		const auto contextGuard = gsl::finally([&] {
++			g_main_context_pop_thread_default(context->gobj());
++		});
+ 
+ 		const auto signalId = connection->signal_subscribe(
+ 			[&](
+@@ -199,7 +202,6 @@ void PortalAutostart(bool start, bool silent) {
+ 			QWindow window;
+ 			QGuiApplicationPrivate::showModalWindow(&window);
+ 			loop->run();
+-			g_main_context_pop_thread_default(context->gobj());
+ 			QGuiApplicationPrivate::hideModalWindow(&window);
+ 		}
+ 	} catch (const Glib::Error &e) {
+-- 
+2.30.2
+
+From 359e9716fc38a7591a10e8afe25ba2efa2543bae Mon Sep 17 00:00:00 2001
+From: Ilya Fedin <fedin-ilja2010@ya.ru>
+Date: Mon, 5 Jul 2021 20:16:09 +0400
+Subject: [PATCH 3/3] Revert "Use QMenuBar instead of own global menu
+ implementation on Linux"
+
+This reverts commit 79f96480c2e8265d591818173015690f7de4bc5a.
+---
+ Telegram/CMakeLists.txt                       |   1 +
+ .../linux/linux_wayland_integration.cpp       |  43 +++++
+ .../linux/linux_wayland_integration.h         |   4 +
+ .../linux/linux_wayland_integration_dummy.cpp |   6 +
+ .../platform/linux/main_window_linux.cpp      | 150 +++++++++++++++++-
+ .../platform/linux/main_window_linux.h        |   4 +-
+ 6 files changed, 202 insertions(+), 6 deletions(-)
+
+diff --git a/Telegram/CMakeLists.txt b/Telegram/CMakeLists.txt
+index f466ec1af..e7ffe0af2 100644
+--- a/Telegram/CMakeLists.txt
++++ b/Telegram/CMakeLists.txt
+@@ -94,6 +94,7 @@ if (LINUX)
+         target_link_libraries(Telegram
+         PRIVATE
+             desktop-app::external_statusnotifieritem
++            desktop-app::external_dbusmenu_qt
+         )
+     endif()
+ 
+diff --git a/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp b/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp
+index ba521184b..16db763d8 100644
+--- a/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp
++++ b/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp
+@@ -14,6 +14,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include <surface.h>
+ #include <xdgforeign.h>
+ #include <plasmashell.h>
++#include <appmenu.h>
+ 
+ using namespace KWayland::Client;
+ 
+@@ -36,6 +37,10 @@ public:
+ 		return _plasmaShell.get();
+ 	}
+ 
++	[[nodiscard]] AppMenuManager *appMenuManager() {
++		return _appMenuManager.get();
++	}
++
+ 	[[nodiscard]] QEventLoop &interfacesLoop() {
+ 		return _interfacesLoop;
+ 	}
+@@ -51,6 +56,7 @@ private:
+ 	Registry _applicationRegistry;
+ 	std::unique_ptr<XdgExporter> _xdgExporter;
+ 	std::unique_ptr<PlasmaShell> _plasmaShell;
++	std::unique_ptr<AppMenuManager> _appMenuManager;
+ 	QEventLoop _interfacesLoop;
+ 	bool _interfacesAnnounced = false;
+ };
+@@ -117,6 +123,21 @@ WaylandIntegration::Private::Private()
+ 				&PlasmaShell::destroy);
+ 		});
+ 
++	connect(
++		&_applicationRegistry,
++		&Registry::appMenuAnnounced,
++		[=](uint name, uint version) {
++			_appMenuManager = std::unique_ptr<AppMenuManager>{
++				_applicationRegistry.createAppMenuManager(name, version),
++			};
++
++			connect(
++				_applicationConnection,
++				&ConnectionThread::connectionDied,
++				_appMenuManager.get(),
++				&AppMenuManager::destroy);
++		});
++
+ 	_connection.initConnection();
+ }
+ 
+@@ -187,5 +208,27 @@ void WaylandIntegration::skipTaskbar(QWindow *window, bool skip) {
+ 	plasmaSurface->setSkipTaskbar(skip);
+ }
+ 
++void WaylandIntegration::registerAppMenu(
++		QWindow *window,
++		const QString &serviceName,
++		const QString &objectPath) {
++	const auto manager = _private->appMenuManager();
++	if (!manager) {
++		return;
++	}
++
++	const auto surface = Surface::fromWindow(window);
++	if (!surface) {
++		return;
++	}
++
++	const auto appMenu = manager->create(surface, surface);
++	if (!appMenu) {
++		return;
++	}
++
++	appMenu->setAddress(serviceName, objectPath);
++}
++
+ } // namespace internal
+ } // namespace Platform
+diff --git a/Telegram/SourceFiles/platform/linux/linux_wayland_integration.h b/Telegram/SourceFiles/platform/linux/linux_wayland_integration.h
+index 3c6cd04a2..a37f10e34 100644
+--- a/Telegram/SourceFiles/platform/linux/linux_wayland_integration.h
++++ b/Telegram/SourceFiles/platform/linux/linux_wayland_integration.h
+@@ -18,6 +18,10 @@ public:
+ 	[[nodiscard]] QString nativeHandle(QWindow *window);
+ 	[[nodiscard]] bool skipTaskbarSupported();
+ 	void skipTaskbar(QWindow *window, bool skip);
++	void registerAppMenu(
++		QWindow *window,
++		const QString &serviceName,
++		const QString &objectPath);
+ 
+ private:
+ 	WaylandIntegration();
+diff --git a/Telegram/SourceFiles/platform/linux/linux_wayland_integration_dummy.cpp b/Telegram/SourceFiles/platform/linux/linux_wayland_integration_dummy.cpp
+index 74e6485dc..7ab26b1e2 100644
+--- a/Telegram/SourceFiles/platform/linux/linux_wayland_integration_dummy.cpp
++++ b/Telegram/SourceFiles/platform/linux/linux_wayland_integration_dummy.cpp
+@@ -44,5 +44,11 @@ bool WaylandIntegration::skipTaskbarSupported() {
+ void WaylandIntegration::skipTaskbar(QWindow *window, bool skip) {
+ }
+ 
++void WaylandIntegration::registerAppMenu(
++		QWindow *window,
++		const QString &serviceName,
++		const QString &objectPath) {
++}
++
+ } // namespace internal
+ } // namespace Platform
+diff --git a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+index fa200ddb8..f44390860 100644
+--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
++++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+@@ -43,12 +43,15 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include <QtCore/QSize>
+ #include <QtCore/QTemporaryFile>
+ #include <QtGui/QWindow>
+-#include <QtWidgets/QMenuBar>
+ 
+ #ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
++#include <QtDBus/QDBusConnection>
++#include <QtDBus/QDBusMessage>
++#include <QtDBus/QDBusObjectPath>
+ #include <QtDBus/QDBusMetaType>
+ 
+ #include <statusnotifieritem.h>
++#include <dbusmenuexporter.h>
+ 
+ #include <glibmm.h>
+ #include <giomm.h>
+@@ -71,6 +74,12 @@ constexpr auto kSNIWatcherService = "org.kde.StatusNotifierWatcher"_cs;
+ constexpr auto kSNIWatcherObjectPath = "/StatusNotifierWatcher"_cs;
+ constexpr auto kSNIWatcherInterface = kSNIWatcherService;
+ 
++constexpr auto kAppMenuService = "com.canonical.AppMenu.Registrar"_cs;
++constexpr auto kAppMenuObjectPath = "/com/canonical/AppMenu/Registrar"_cs;
++constexpr auto kAppMenuInterface = kAppMenuService;
++
++constexpr auto kMainMenuObjectPath = "/MenuBar"_cs;
++
+ bool TrayIconMuted = true;
+ int32 TrayIconCount = 0;
+ base::flat_map<int, QImage> TrayIconImageBack;
+@@ -536,6 +545,65 @@ uint djbStringHash(const std::string &string) {
+ 	}
+ 	return hash;
+ }
++
++bool IsAppMenuSupported() {
++	try {
++		const auto connection = Gio::DBus::Connection::get_sync(
++			Gio::DBus::BusType::BUS_TYPE_SESSION);
++
++		return base::Platform::DBus::NameHasOwner(
++			connection,
++			std::string(kAppMenuService));
++	} catch (...) {
++	}
++
++	return false;
++}
++
++// This call must be made from the same bus connection as DBusMenuExporter
++// So it must use QDBusConnection
++void RegisterAppMenu(QWindow *window, const QString &menuPath) {
++	if (const auto integration = WaylandIntegration::Instance()) {
++		integration->registerAppMenu(
++			window,
++			QDBusConnection::sessionBus().baseService(),
++			menuPath);
++		return;
++	}
++
++	auto message = QDBusMessage::createMethodCall(
++		kAppMenuService.utf16(),
++		kAppMenuObjectPath.utf16(),
++		kAppMenuInterface.utf16(),
++		qsl("RegisterWindow"));
++
++	message.setArguments({
++		window->winId(),
++		QVariant::fromValue(QDBusObjectPath(menuPath))
++	});
++
++	QDBusConnection::sessionBus().send(message);
++}
++
++// This call must be made from the same bus connection as DBusMenuExporter
++// So it must use QDBusConnection
++void UnregisterAppMenu(QWindow *window) {
++	if (const auto integration = WaylandIntegration::Instance()) {
++		return;
++	}
++
++	auto message = QDBusMessage::createMethodCall(
++		kAppMenuService.utf16(),
++		kAppMenuObjectPath.utf16(),
++		kAppMenuInterface.utf16(),
++		qsl("UnregisterWindow"));
++
++	message.setArguments({
++		window->winId()
++	});
++
++	QDBusConnection::sessionBus().send(message);
++}
+ #endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+ 
+ } // namespace
+@@ -554,6 +622,10 @@ public:
+ 	uint sniWatcherId = 0;
+ 	std::unique_ptr<QTemporaryFile> trayIconFile;
+ 
++	bool appMenuSupported = false;
++	uint appMenuWatcherId = 0;
++	DBusMenuExporter *mainMenuExporter = nullptr;
++
+ 	void setSNITrayIcon(int counter, bool muted);
+ 	void attachToSNITrayIcon();
+ 	void handleSNIHostRegistered();
+@@ -562,6 +634,11 @@ public:
+ 		const QString &service,
+ 		const QString &oldOwner,
+ 		const QString &newOwner);
++
++	void handleAppMenuOwnerChanged(
++		const QString &service,
++		const QString &oldOwner,
++		const QString &newOwner);
+ #endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+ 
+ private:
+@@ -686,6 +763,25 @@ void MainWindow::Private::handleSNIOwnerChanged(
+ 		(Core::App().settings().workMode() == WorkMode::TrayOnly)
+ 			&& _public->trayAvailable());
+ }
++
++void MainWindow::Private::handleAppMenuOwnerChanged(
++		const QString &service,
++		const QString &oldOwner,
++		const QString &newOwner) {
++	if (oldOwner.isEmpty() && !newOwner.isEmpty()) {
++		appMenuSupported = true;
++		LOG(("Using D-Bus global menu."));
++	} else if (!oldOwner.isEmpty() && newOwner.isEmpty()) {
++		appMenuSupported = false;
++		LOG(("Not using D-Bus global menu."));
++	}
++
++	if (appMenuSupported && mainMenuExporter) {
++		RegisterAppMenu(_public->windowHandle(), kMainMenuObjectPath.utf16());
++	} else {
++		UnregisterAppMenu(_public->windowHandle());
++	}
++}
+ #endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+ 
+ MainWindow::MainWindow(not_null<Window::Controller*> controller)
+@@ -722,6 +818,7 @@ void MainWindow::initHook() {
+ 
+ #ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+ 	_sniAvailable = IsSNIAvailable();
++	_private->appMenuSupported = IsAppMenuSupported();
+ 
+ 	try {
+ 		_private->dbusConnection = Gio::DBus::Connection::get_sync(
+@@ -760,9 +857,28 @@ void MainWindow::initHook() {
+ 					QString::fromStdString(oldOwner),
+ 					QString::fromStdString(newOwner));
+ 			});
++
++		_private->appMenuWatcherId = base::Platform::DBus::RegisterServiceWatcher(
++			_private->dbusConnection,
++			std::string(kAppMenuService),
++			[=](
++				const Glib::ustring &service,
++				const Glib::ustring &oldOwner,
++				const Glib::ustring &newOwner) {
++				_private->handleAppMenuOwnerChanged(
++					QString::fromStdString(service),
++					QString::fromStdString(oldOwner),
++					QString::fromStdString(newOwner));
++			});
+ 	} catch (...) {
+ 	}
+ 
++	if (_private->appMenuSupported) {
++		LOG(("Using D-Bus global menu."));
++	} else {
++		LOG(("Not using D-Bus global menu."));
++	}
++
+ 	if (UseUnityCounter()) {
+ 		LOG(("Using Unity launcher counter."));
+ 	} else {
+@@ -926,8 +1042,7 @@ void MainWindow::createGlobalMenu() {
+ 		}
+ 	};
+ 
+-	psMainMenu = new QMenuBar(this);
+-	psMainMenu->hide();
++	psMainMenu = new QMenu(this);
+ 
+ 	auto file = psMainMenu->addMenu(tr::lng_mac_menu_file(tr::now));
+ 
+@@ -1104,6 +1219,16 @@ void MainWindow::createGlobalMenu() {
+ 
+ 	about->setMenuRole(QAction::AboutQtRole);
+ 
++#ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
++	_private->mainMenuExporter = new DBusMenuExporter(
++		kMainMenuObjectPath.utf16(),
++		psMainMenu);
++
++	if (_private->appMenuSupported) {
++		RegisterAppMenu(windowHandle(), kMainMenuObjectPath.utf16());
++	}
++#endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
++
+ 	updateGlobalMenu();
+ }
+ 
+@@ -1229,6 +1354,16 @@ void MainWindow::handleNativeSurfaceChanged(bool exist) {
+ 			(Core::App().settings().workMode() == WorkMode::TrayOnly)
+ 				&& trayAvailable());
+ 	}
++
++#ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
++	if (_private->appMenuSupported && _private->mainMenuExporter) {
++		if (exist) {
++			RegisterAppMenu(windowHandle(), kMainMenuObjectPath.utf16());
++		} else {
++			UnregisterAppMenu(windowHandle());
++		}
++	}
++#endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+ }
+ 
+ MainWindow::~MainWindow() {
+@@ -1243,6 +1378,15 @@ MainWindow::~MainWindow() {
+ 			_private->dbusConnection->signal_unsubscribe(
+ 				_private->sniWatcherId);
+ 		}
++
++		if (_private->appMenuWatcherId != 0) {
++			_private->dbusConnection->signal_unsubscribe(
++				_private->appMenuWatcherId);
++		}
++	}
++
++	if (_private->appMenuSupported) {
++		UnregisterAppMenu(windowHandle());
+ 	}
+ #endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+ }
+diff --git a/Telegram/SourceFiles/platform/linux/main_window_linux.h b/Telegram/SourceFiles/platform/linux/main_window_linux.h
+index ebdf560e6..7bfb6f0cf 100644
+--- a/Telegram/SourceFiles/platform/linux/main_window_linux.h
++++ b/Telegram/SourceFiles/platform/linux/main_window_linux.h
+@@ -10,8 +10,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include "platform/platform_main_window.h"
+ #include "base/unique_qptr.h"
+ 
+-class QMenuBar;
+-
+ namespace Ui {
+ class PopupMenu;
+ } // namespace Ui
+@@ -72,7 +70,7 @@ private:
+ 	bool _sniAvailable = false;
+ 	base::unique_qptr<Ui::PopupMenu> _trayIconMenuXEmbed;
+ 
+-	QMenuBar *psMainMenu = nullptr;
++	QMenu *psMainMenu = nullptr;
+ 	QAction *psLogout = nullptr;
+ 	QAction *psUndo = nullptr;
+ 	QAction *psRedo = nullptr;
+-- 
+2.30.2
+

--- a/extra-web/telegram-desktop/spec
+++ b/extra-web/telegram-desktop/spec
@@ -1,4 +1,5 @@
 VER=2.8.4
+REL=1
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=91d836dc84a16584c6ac52b36c04c0de504d9c34::https://github.com/desktop-app/tg_owt"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

telegram-desktop: backport file dialog/global menu fixes

This PR will try to fix the open file selection crash and the conflict with Ctrl + A shortcut under the global menu

Package(s) Affected
-------------------

telegram-desktop: 2.8.4-1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
