### PR TITLE
mesa: Rework to fix FTBFS

### DIFF
--- a/extra-libs/mesa/autobuild/beyond
+++ b/extra-libs/mesa/autobuild/beyond
@@ -1,3 +1,6 @@
 abinfo "Making a symlink from libGLX_mesa to libGLX_indirect ..."
 ln -sv libGLX_mesa.so.0 \
     "$PKGDIR"/usr/lib/libGLX_indirect.so.0
+
+abinfo "Removing unused pkg-config entry..."
+rm -v "$PKGDIR/usr/lib/pkgconfig/DirectX-Headers.pc"

--- a/extra-libs/mesa/spec
+++ b/extra-libs/mesa/spec
@@ -1,4 +1,5 @@
 VER=21.1.4
+REL=1
 SRCS="tbl::https://mesa.freedesktop.org/archive/mesa-$VER.tar.xz git::commit=65950461b599568b1f6ede8feaa1668f6a6e07bb;rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
 CHKSUMS="sha256::1f177f44098164b65731c5ded4c928fd58b14f6c9d2087aa0e37bc79bf79e90b SKIP"
 SUBDIR=mesa-$VER


### PR DESCRIPTION

Topic Description
-----------------

Remove unused pkgconfig entry DirectX-Headers to prevent Meson from fetching invalid linking options from pkg-config in further build

Package(s) Affected
-------------------

- `mesa`

Security Update?
----------------

No

Architectural Progress
----------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

