### PR TITLE
vscode: update to 1.58.0

### DIFF
--- a/extra-editors/vscode/autobuild/prepare
+++ b/extra-editors/vscode/autobuild/prepare
@@ -1,10 +1,3 @@
-abinfo "Unsetting PREFIX to fix nvm..."
-unset PREFIX
-
-abinfo "Switching nodejs to 12..."
-nvm install 12
-nvm use 12
-
 if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
   CODEPLATFORM="linux-x64"
 elif [[ "${CROSS:-$ARCH}" = "arm64" ]]; then

--- a/extra-editors/vscode/spec
+++ b/extra-editors/vscode/spec
@@ -1,4 +1,4 @@
-VER=1.57.1
+VER=1.58.0
 SRCS="git::commit=tags/$VER::https://github.com/microsoft/vscode/"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=microsoft/vscode;pattern=^\d\.\d+\.\d+$"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

vscode: update to 1.58.0

- Use system nodejs to fix build

Package(s) Affected
-------------------

vscode: 1.58.0

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->