### PR TITLE
intellij-idea: update to 2021.1.3

### DIFF
--- a/extra-devel/intellij-idea/autobuild/defines
+++ b/extra-devel/intellij-idea/autobuild/defines
@@ -6,5 +6,5 @@ PKGDES="IDE for Java, Groovy and other programming languages with advanced refac
 
 PKGPROV="intellij-idea-community-edition ideaIC ideaic"
 
-TAGVER=211.7142.45
+TAGVER=211.7628.21
 ABSPLITDBG=0

--- a/extra-devel/intellij-idea/spec
+++ b/extra-devel/intellij-idea/spec
@@ -1,6 +1,6 @@
-VER=2021.1.1
+VER=2021.1.3
 
 SRCS="tbl::https://download.jetbrains.com/idea/ideaIC-$VER.tar.gz"
-CHKSUMS="sha256::8505ba8ff24f595654b82eb45c1fa2f0530a6f307b25cd9858a4bf796e0a5ee9"
+CHKSUMS="sha256::b14ed5fbd9c7523a1fd2e689b0ac8bc990c046b92bd6699548efcc11937217de"
 SUBDIR=.
 CHKUPDATE="html::url=https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&type=release&build;pattern=ideaIU-(\d+\.\d+\.\d+)\.tar\.gz"


### PR DESCRIPTION
Topic Description
-----------------

update intellij-idea to v2021.1.3

Package(s) Affected
-------------------

`intellij-idea` v2021.1.3

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
