### PR TITLE
code-server: update to 3.11.0

### DIFF
--- a/extra-utils/code-server/autobuild/build
+++ b/extra-utils/code-server/autobuild/build
@@ -1,2 +1,23 @@
-abinfo "Installing binary file..."
-install -vDm755 "$SRCDIR"/code-server "$PKGDIR"/usr/bin/code-server
+abinfo "Installing build dependency ..."
+yarn
+
+abinfo "Building code-server ..."
+yarn build
+yarn build:vscode
+yarn release
+cd "$SRCDIR"/release
+yarn --production
+cd "$SRCDIR"
+yarn release:standalone
+
+abinfo "Installing code-server ..."
+mkdir -pv "$PKGDIR"/usr/lib/code-server
+cp -avr "$SRCDIR"/release-standalone/* "$PKGDIR"/usr/lib/code-server
+
+abinfo "Removing bundle nodejs and use system nodejs ..."
+rm -v "$PKGDIR"/usr/lib/code-server/lib/node
+ln -sv ../../../bin/node "$PKGDIR"/usr/lib/code-server/lib/node
+
+abinfo "linking code-server to /usr/bin ..."
+mkdir -pv "$PKGDIR"/usr/bin
+ln -sv ../lib/code-server/bin/code-server "$PKGDIR"/usr/bin/code-server

--- a/extra-utils/code-server/autobuild/defines
+++ b/extra-utils/code-server/autobuild/defines
@@ -1,5 +1,10 @@
 PKGNAME=code-server
 PKGDES="Run VS Code on a remote server"
 PKGSEC=utils
+PKGDEP="nodejs"
+BUILDDEP="yarn jq"
 
 ABSTRIP=0
+
+# VSCode is currently not available for Loongson and POWER.
+FAIL_ARCH="!(amd64|arm64)"

--- a/extra-utils/code-server/autobuild/prepare
+++ b/extra-utils/code-server/autobuild/prepare
@@ -1,0 +1,1 @@
+acbs_copy_git

--- a/extra-utils/code-server/spec
+++ b/extra-utils/code-server/spec
@@ -1,4 +1,4 @@
-VER=3.5.0
-REL=1
-SRCS="tbl::https://github.com/cdr/code-server/releases/download/v$VER/code-server-${VER}-linux-amd64.tar.gz"
-CHKSUMS="sha256::90c19c84611becac4af1fb0bd5324ab30f9200769fa7914cd10ccb6b88c657bb"
+VER=3.11.0
+SRCS="git::commit=tags/v$VER::https://github.com/cdr/code-server"
+CHKSUMS="sha256::13ab71229e41cc8d449a4dbc73cfb092b1dcbfcba0089e136f1471705f766cd9"
+CHKUPDATE="github::repo=cdr/code-server"


### PR DESCRIPTION

<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

code-server: update to 3.11.0

- Build binary from source code
- mark !(amd64|arm64) as FAIL_ARCH

Package(s) Affected
-------------------

code-server: 3.11.0

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->
