### PR TITLE
packagekit: update to 1.2.3

### DIFF
--- a/extra-admin/atm/autobuild/defines
+++ b/extra-admin/atm/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=atm
 PKGSEC=admin
-PKGDEP="apt gcc-runtime glibc ncurses"
-BUILDDEP="llvm rustc cmake"
+PKGDEP="apt gcc-runtime glibc packagekit"
+BUILDDEP="llvm rustc"
 PKGDES="APT Topic Manager for AOSC OS"
 
 USECLANG=1

--- a/extra-admin/atm/spec
+++ b/extra-admin/atm/spec
@@ -1,4 +1,4 @@
-VER=0.4.0~alpha.1
+VER=0.4.0~alpha.2
 SRCS="https://github.com/AOSC-Dev/atm/archive/v${VER/\~/-}.tar.gz"
 CHKSUMS="sha256::0e127b076abd2e424d9798d7b9167c909f2ac04ac460d5928a68219e0f54954d"
 CHKUPDATE="github::repo=AOSC-Dev/atm"

--- a/extra-admin/atm/spec
+++ b/extra-admin/atm/spec
@@ -1,4 +1,4 @@
 VER=0.4.0~alpha.2
 SRCS="https://github.com/AOSC-Dev/atm/archive/v${VER/\~/-}.tar.gz"
-CHKSUMS="sha256::0e127b076abd2e424d9798d7b9167c909f2ac04ac460d5928a68219e0f54954d"
+CHKSUMS="sha256::339a643f5f47d99fc7c989a5c3a91f2641e669daeb39a7d6d680c1761256726a"
 CHKUPDATE="github::repo=AOSC-Dev/atm"

--- a/extra-admin/atm/spec
+++ b/extra-admin/atm/spec
@@ -1,4 +1,4 @@
-VER=0.3.1~alpha.1
+VER=0.4.0~alpha.1
 SRCS="https://github.com/AOSC-Dev/atm/archive/v${VER/\~/-}.tar.gz"
 CHKSUMS="sha256::0e127b076abd2e424d9798d7b9167c909f2ac04ac460d5928a68219e0f54954d"
 CHKUPDATE="github::repo=AOSC-Dev/atm"

--- a/extra-admin/atm/spec
+++ b/extra-admin/atm/spec
@@ -1,4 +1,4 @@
-VER=0.4.0~alpha.2
+VER=0.4.1
 SRCS="https://github.com/AOSC-Dev/atm/archive/v${VER/\~/-}.tar.gz"
 CHKSUMS="sha256::339a643f5f47d99fc7c989a5c3a91f2641e669daeb39a7d6d680c1761256726a"
 CHKUPDATE="github::repo=AOSC-Dev/atm"

--- a/extra-admin/atm/spec
+++ b/extra-admin/atm/spec
@@ -1,4 +1,4 @@
 VER=0.4.1
 SRCS="https://github.com/AOSC-Dev/atm/archive/v${VER/\~/-}.tar.gz"
-CHKSUMS="sha256::339a643f5f47d99fc7c989a5c3a91f2641e669daeb39a7d6d680c1761256726a"
+CHKSUMS="sha256::4adc5ee543f00e1579edfbe2028518693a117caf87f2195ee031f973ff271c35"
 CHKUPDATE="github::repo=AOSC-Dev/atm"

--- a/extra-admin/packagekit/autobuild/defines
+++ b/extra-admin/packagekit/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=packagekit
 PKGSEC=utils
-PKGDEP="glib fcron dbus-glib linux-pam sqlite polkit systemd python-3"
+PKGDEP="glib fcron dbus-glib linux-pam sqlite polkit systemd python-3 gst-plugins-base-1-0"
 PKGSUG="appstream gtk-3"
 BUILDDEP="gobject-introspection intltool gtk-doc apt vala \
           autoconf-archive ${PKGSUG}"

--- a/extra-admin/packagekit/autobuild/defines
+++ b/extra-admin/packagekit/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=packagekit
 PKGSEC=utils
-PKGDEP="glib fcron dbus-glib linux-pam sqlite polkit systemd python-3 gst-plugins-base-1-0"
-PKGSUG="appstream gtk-3"
+PKGDEP="glib fcron dbus-glib linux-pam sqlite polkit systemd python-3 gst-plugins-base-1-0 appstream"
+PKGSUG="gtk-3"
 BUILDDEP="gobject-introspection intltool gtk-doc apt vala \
           autoconf-archive ${PKGSUG}"
 PKGDES="An abstraction layer for package managers for installing and updating packages"

--- a/extra-admin/packagekit/autobuild/defines
+++ b/extra-admin/packagekit/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=packagekit
 PKGSEC=utils
-PKGDEP="glib fcron dbus-glib linux-pam sqlite polkit systemd python-3 gst-plugins-base-1-0 appstream"
+PKGDEP="glib fcron dbus-glib linux-pam sqlite polkit systemd python-3 appstream"
 PKGSUG="gtk-3"
 BUILDDEP="gobject-introspection intltool gtk-doc apt vala \
           autoconf-archive ${PKGSUG}"

--- a/extra-admin/packagekit/autobuild/defines
+++ b/extra-admin/packagekit/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=packagekit
 PKGSEC=utils
-PKGDEP="appstream glib fcron dbus-glib linux-pam sqlite polkit systemd \
-        python-3 gst-plugins-base-1-0"
+PKGDEP="glib fcron dbus-glib linux-pam sqlite polkit systemd python-3"
+PKGSUG="appstream gst-plugins-base-1-0 gtk-3"
 BUILDDEP="gobject-introspection intltool gtk-doc apt vala \
-          gtk-3 autoconf-archive"
+          autoconf-archive ${PKGSUG}"
 PKGDES="An abstraction layer for package managers for installing and updating packages"
 
 MESON_AFTER="-Dpackaging_backend=aptcc \

--- a/extra-admin/packagekit/autobuild/defines
+++ b/extra-admin/packagekit/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=packagekit
 PKGSEC=utils
 PKGDEP="glib fcron dbus-glib linux-pam sqlite polkit systemd python-3"
-PKGSUG="appstream gst-plugins-base-1-0 gtk-3"
+PKGSUG="appstream gtk-3"
 BUILDDEP="gobject-introspection intltool gtk-doc apt vala \
           autoconf-archive ${PKGSUG}"
 PKGDES="An abstraction layer for package managers for installing and updating packages"
@@ -15,7 +15,7 @@ MESON_AFTER="-Dpackaging_backend=aptcc \
              -Dgtk_doc=true \
              -Dbash_completion=true \
              -Dbash_command_not_found=false \
-             -Dgstreamer_plugin=true \
+             -Dgstreamer_plugin=false \
              -Dgtk_module=true \
              -Dcron=true"
 

--- a/extra-admin/packagekit/autobuild/patches/0003-fix-aptcc-bugs.patch
+++ b/extra-admin/packagekit/autobuild/patches/0003-fix-aptcc-bugs.patch
@@ -1,0 +1,155 @@
+From 3947fdc5157f546c1af3746850686200662d6f91 Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Sun, 4 Jul 2021 19:20:01 -0600
+Subject: [PATCH 1/3] aptcc: fix a bug where downgrade is not working ...
+
+this bug is actually a combination of two issues:
+* aptcc backend wasn't able to check all the available package versions
+* aptcc backend previous used the wrong function to fetch the package
+  version  because it incorrectly used the current package version for
+  the downgrade to version
+---
+ backends/aptcc/apt-cache-file.cpp | 10 ++++++----
+ backends/aptcc/apt-intf.cpp       |  2 +-
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/backends/aptcc/apt-cache-file.cpp b/backends/aptcc/apt-cache-file.cpp
+index 62d0e2f3b..a07a2f284 100644
+--- a/backends/aptcc/apt-cache-file.cpp
++++ b/backends/aptcc/apt-cache-file.cpp
+@@ -379,10 +379,12 @@ pkgCache::VerIterator AptCacheFile::resolvePkgID(const gchar *packageId)
+ 
+     const pkgCache::VerIterator &candidateVer = findCandidateVer(pkg);
+     // check to see if the provided package isn't virtual too
+-    if (candidateVer.end() == false &&
+-            strcmp(candidateVer.VerStr(), parts[PK_PACKAGE_ID_VERSION]) == 0) {
+-        g_strfreev(parts);
+-        return candidateVer;
++    // also iterate through all the available versions
++    for (auto candidate = candidateVer; !candidate.end(); candidate++) {
++        if (strcmp(candidate.VerStr(), parts[PK_PACKAGE_ID_VERSION]) == 0) {
++            g_strfreev(parts);
++            return candidate;
++        }
+     }
+ 
+     g_strfreev (parts);
+diff --git a/backends/aptcc/apt-intf.cpp b/backends/aptcc/apt-intf.cpp
+index c13751fe1..d1b8f0152 100644
+--- a/backends/aptcc/apt-intf.cpp
++++ b/backends/aptcc/apt-intf.cpp
+@@ -1692,7 +1692,7 @@ PkgList AptIntf::checkChangedPackages(bool emitChanged)
+             }
+         } else if ((*m_cache)[pkg].Downgrade() == true) {
+             // downgrading
+-            const pkgCache::VerIterator &ver = m_cache->findVer(pkg);
++            const pkgCache::VerIterator &ver = m_cache->findCandidateVer(pkg);
+             if (!ver.end()) {
+                 ret.push_back(ver);
+                 downgrading.push_back(ver);
+
+From 4f1f31fdbc95edaf95650d6610873db08bfc84a4 Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Sun, 4 Jul 2021 19:59:15 -0600
+Subject: [PATCH 2/3] aptcc: correctly lists all the available package versions
+ ...
+
+... this should fix #441
+---
+ backends/aptcc/apt-intf.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/backends/aptcc/apt-intf.cpp b/backends/aptcc/apt-intf.cpp
+index d1b8f0152..bf0d79c71 100644
+--- a/backends/aptcc/apt-intf.cpp
++++ b/backends/aptcc/apt-intf.cpp
+@@ -459,7 +459,9 @@ void AptIntf::emitPackages(PkgList &output, PkBitfield filters, PkInfoEnum state
+             break;
+         }
+ 
+-        emitPackage(verIt, state);
++        for (auto ver = verIt; !ver.end(); ver++) {
++            emitPackage(ver, state);
++        }
+     }
+ }
+ 
+
+From 08d2ada6e435d39a37673693d140fca4c4c4440b Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Sun, 4 Jul 2021 22:07:13 -0600
+Subject: [PATCH 3/3] aptcc: fix a regression introduced in the last commit
+
+---
+ backends/aptcc/apt-intf.cpp         | 13 +++++++++++--
+ backends/aptcc/apt-intf.h           |  3 ++-
+ backends/aptcc/pk-backend-aptcc.cpp |  4 ++--
+ 3 files changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/backends/aptcc/apt-intf.cpp b/backends/aptcc/apt-intf.cpp
+index bf0d79c71..7777943a3 100644
+--- a/backends/aptcc/apt-intf.cpp
++++ b/backends/aptcc/apt-intf.cpp
+@@ -445,7 +445,7 @@ void AptIntf::emitPackageProgress(const pkgCache::VerIterator &ver, PkStatusEnum
+     g_free(package_id);
+ }
+ 
+-void AptIntf::emitPackages(PkgList &output, PkBitfield filters, PkInfoEnum state)
++void AptIntf::emitPackages(PkgList &output, PkBitfield filters, PkInfoEnum state, bool multiversion)
+ {
+     // Sort so we can remove the duplicated entries
+     output.sort();
+@@ -459,7 +459,16 @@ void AptIntf::emitPackages(PkgList &output, PkBitfield filters, PkInfoEnum state
+             break;
+         }
+ 
+-        for (auto ver = verIt; !ver.end(); ver++) {
++        auto ver = verIt;
++        // emit only the latest/chosen version if newest is requested
++        if (!multiversion || pk_bitfield_contain(filters, PK_FILTER_ENUM_NEWEST)) {
++            emitPackage(verIt, state);
++            continue;
++        } else if (pk_bitfield_contain(filters, PK_FILTER_ENUM_NOT_NEWEST) && !ver.end()) {
++            ver++;
++        }
++
++        for (; !ver.end(); ver++) {
+             emitPackage(ver, state);
+         }
+     }
+diff --git a/backends/aptcc/apt-intf.h b/backends/aptcc/apt-intf.h
+index 791ab5983..39b0376c7 100644
+--- a/backends/aptcc/apt-intf.h
++++ b/backends/aptcc/apt-intf.h
+@@ -163,7 +163,8 @@ class AptIntf
+       */
+     void emitPackages(PkgList &output,
+                       PkBitfield filters = PK_FILTER_ENUM_NONE,
+-                      PkInfoEnum state = PK_INFO_ENUM_UNKNOWN);
++                      PkInfoEnum state = PK_INFO_ENUM_UNKNOWN,
++                      bool multiversion = false);
+ 
+     void emitRequireRestart(PkgList &output);
+ 
+diff --git a/backends/aptcc/pk-backend-aptcc.cpp b/backends/aptcc/pk-backend-aptcc.cpp
+index e289d21d6..4f6223711 100644
+--- a/backends/aptcc/pk-backend-aptcc.cpp
++++ b/backends/aptcc/pk-backend-aptcc.cpp
+@@ -608,7 +608,7 @@ static void pk_backend_resolve_thread(PkBackendJob *job, GVariant *params, gpoin
+     PkgList pkgs = apt->resolvePackageIds(search);
+ 
+     // It's faster to emit the packages here rather than in the matching part
+-    apt->emitPackages(pkgs, filters);
++    apt->emitPackages(pkgs, filters, PK_INFO_ENUM_UNKNOWN, true);
+ }
+ 
+ void pk_backend_resolve(PkBackend *backend, PkBackendJob *job, PkBitfield filters, gchar **packages)
+@@ -717,7 +717,7 @@ static void backend_search_package_thread(PkBackendJob *job, GVariant *params, g
+     }
+ 
+     // It's faster to emit the packages here than in the matching part
+-    apt->emitPackages(output, filters);
++    apt->emitPackages(output, filters, PK_INFO_ENUM_UNKNOWN, true);
+ 
+     pk_backend_job_set_percentage(job, 100);
+ }

--- a/extra-admin/packagekit/autobuild/patches/0004-aptcc-allow-disable-gst-matcher.patch
+++ b/extra-admin/packagekit/autobuild/patches/0004-aptcc-allow-disable-gst-matcher.patch
@@ -1,0 +1,118 @@
+From b2672ab92dd7490f4346fe999b79e33fcbe45f34 Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Thu, 15 Jul 2021 03:28:21 -0600
+Subject: [PATCH] aptcc: allow disable gst matcher
+
+---
+ backends/aptcc/apt-intf.cpp |  2 ++
+ backends/aptcc/meson.build  | 51 +++++++++++++++++++++++++------------
+ 2 files changed, 37 insertions(+), 16 deletions(-)
+
+diff --git a/backends/aptcc/apt-intf.cpp b/backends/aptcc/apt-intf.cpp
+index c13751fe1..cf759f928 100644
+--- a/backends/aptcc/apt-intf.cpp
++++ b/backends/aptcc/apt-intf.cpp
+@@ -524,6 +524,7 @@ void AptIntf::emitUpdates(PkgList &output, PkBitfield filters)
+ // search packages which provide a codec (specified in "values")
+ void AptIntf::providesCodec(PkgList &output, gchar **values)
+ {
++#ifdef HAVE_GST_DEPS
+     string arch;
+     GstMatcher matcher(values);
+     if (!matcher.hasMatches()) {
+@@ -567,6 +568,7 @@ void AptIntf::providesCodec(PkgList &output, gchar **values)
+             output.push_back(ver);
+         }
+     }
++#endif
+ }
+ 
+ // search packages which provide the libraries specified in "values"
+diff --git a/backends/aptcc/meson.build b/backends/aptcc/meson.build
+index 3b8354d4b..f5869a06d 100644
+--- a/backends/aptcc/meson.build
++++ b/backends/aptcc/meson.build
+@@ -2,9 +2,11 @@ add_languages('cpp')
+ 
+ cpp_compiler = meson.get_compiler('cpp')
+ 
+-gstreamer_dep = dependency('gstreamer-1.0')
+-gstreamer_base_dep = dependency('gstreamer-base-1.0')
+-gstreamer_plugins_base_dep = dependency('gstreamer-plugins-base-1.0')
++if get_option('gstreamer_plugin')
++  gstreamer_dep = dependency('gstreamer-1.0')
++  gstreamer_base_dep = dependency('gstreamer-base-1.0')
++  gstreamer_plugins_base_dep = dependency('gstreamer-plugins-base-1.0')
++endif
+ appstream_dep = dependency('appstream', version: '>=0.12')
+ apt_pkg_dep = dependency('apt-pkg', version: '>=1.9.2')
+ 
+@@ -25,12 +27,11 @@ if cpp_compiler.compiles(
+   ddtp_flag = ['-DHAVE_DDTP']
+ endif
+ 
+-shared_module(
+-  'pk_backend_aptcc',
++aptcc_args = []
++
++aptcc_sources = [
+   'acqpkitstatus.cpp',
+   'acqpkitstatus.h',
+-  'gst-matcher.cpp',
+-  'gst-matcher.h',
+   'apt-messages.cpp',
+   'apt-messages.h',
+   'apt-utils.cpp',
+@@ -45,22 +46,40 @@ shared_module(
+   'pkg-list.h',
+   'deb-file.cpp',
+   'deb-file.h',
+-  'pk-backend-aptcc.cpp',
+-  include_directories: packagekit_src_include,
+-  dependencies: [
+-    packagekit_glib2_dep,
+-    gmodule_dep,
+-    apt_pkg_dep,
++  'pk-backend-aptcc.cpp'
++]
++
++aptcc_deps = [
++  packagekit_glib2_dep,
++  gmodule_dep,
++  apt_pkg_dep,
++  appstream_dep
++]
++
++if get_option('gstreamer_plugin')
++  aptcc_sources += [
++    'gst-matcher.cpp',
++    'gst-matcher.h'
++  ]
++  aptcc_deps += [
+     gstreamer_dep,
+     gstreamer_base_dep,
+-    gstreamer_plugins_base_dep,
+-    appstream_dep,
+-  ],
++    gstreamer_plugins_base_dep
++  ]
++  aptcc_args = ['-DHAVE_GST_DEPS']
++endif
++
++shared_module(
++  'pk_backend_aptcc',
++  aptcc_sources,
++  include_directories: packagekit_src_include,
++  dependencies: aptcc_deps,
+   cpp_args: [
+     '-DG_LOG_DOMAIN="PackageKit-APTcc"',
+     '-DPK_COMPILATION=1',
+     '-DDATADIR="@0@"'.format(join_paths(get_option('prefix'), get_option('datadir'))),
+     ddtp_flag,
++    aptcc_args,
+   ],
+   link_args: [
+     '-lutil',
+-- 
+2.32.0
+

--- a/extra-admin/packagekit/spec
+++ b/extra-admin/packagekit/spec
@@ -1,3 +1,4 @@
-VER=1.2.2
-SRCS="https://github.com/hughsie/PackageKit/archive/PACKAGEKIT_${VER//./_}.tar.gz"
+VER=1.2.3
+SRCS="https://github.com/PackageKit/PackageKit/archive/PACKAGEKIT_${VER//./_}.tar.gz"
 CHKSUMS="sha256::e87e95ce7423f49eff6dad054c86ba6f922e52d0a757f822e0343da0f44d3dbb"
+CHKUPDATE="github::repo=PackageKit/PackageKit;pattern=PACKAGEKIT_(\d+_\d+_\d+)"

--- a/extra-admin/packagekit/spec
+++ b/extra-admin/packagekit/spec
@@ -1,4 +1,4 @@
 VER=1.2.3
 SRCS="https://github.com/PackageKit/PackageKit/archive/PACKAGEKIT_${VER//./_}.tar.gz"
-CHKSUMS="sha256::e87e95ce7423f49eff6dad054c86ba6f922e52d0a757f822e0343da0f44d3dbb"
+CHKSUMS="sha256::9dadb1db9cfd5d3e106e6976c5296bee5d0fc846d0b288f8f07971c417d1f5a1"
 CHKUPDATE="github::repo=PackageKit/PackageKit;pattern=PACKAGEKIT_(\d+_\d+_\d+)"


### PR DESCRIPTION
Topic Description
-----------------

Update PackageKit to 1.2.3

Package(s) Affected
-------------------

```
packagekit
atm
```

Security Update?
----------------

No

Architectural Progress
----------------------


- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------


- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`



Post-Merge Secondary Architectural Progress
-------------------------------------------


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

