### PR TITLE
boinctui: fix manpage location

### DIFF
--- a/extra-scientific/boinctui/autobuild/beyond
+++ b/extra-scientific/boinctui/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Moving the incorrectly positioned manpage to /usr/share ..."
+mv -v "$PKGDIR"/man "$PKGDIR"/usr/share/

--- a/extra-scientific/boinctui/spec
+++ b/extra-scientific/boinctui/spec
@@ -1,3 +1,4 @@
 VER=2.5.1
+REL=1
 SRCS="tbl::https://sourceforge.net/projects/boinctui/files/boinctui_${VER}.tar.gz"
 CHKSUMS="sha256::319f539535f3af342ec0bafc5228673bf12f2d7a7addf5851f2c003200e51da9"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Bugfix: for some reason the boinctui will put the manpage to `/man/man1` instead of `/usr/share/man/man1`.

While the real cause of such behavior is still unknown, this bugfix uses a beyond to move the manpage to the correct location, thus fixing the bug.

For future reference, during the configuration process, the location of the man page becomes `${DESTDIR}${datarootdir}/man/man1` instead of `${DOCDIR}` or `${DATAROOTDIR}`. This may be the root cause of the bug, but I have no idea what caused it.

Package(s) Affected
-------------------

boinctui

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
