### PR TITLE
fcitx-pinyin-moegirl: update to 20210717

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/01-fcitx5-pinyin-moegirl/build
+++ b/extra-i18n/fcitx5-pinyin-moegirl/01-fcitx5-pinyin-moegirl/build
@@ -5,5 +5,5 @@ install -vDm644 "$SRCDIR"/moegirl.dict \
 
 abinfo "Installing LICENSE..."
 mkdir -p "$PKGDIR"/usr/share/doc/fcitx5-pinyin-moegirl
-install -vm644 "$SRCDIR"/mw2fcitx-$PKGVER/LICENSE \
-	"$PKGDIR"/usr/share/doc/fcitx5-pinyin-moegirl
+install -vm644 "$SRCDIR"/mw2fcitx-$PKGVER/LICENSE.content \
+	"$PKGDIR"/usr/share/doc/fcitx5-pinyin-moegirl/LICENSE

--- a/extra-i18n/fcitx5-pinyin-moegirl/02-rime-pinyin-moegirl/build
+++ b/extra-i18n/fcitx5-pinyin-moegirl/02-rime-pinyin-moegirl/build
@@ -5,6 +5,6 @@ install -vDm644 "$SRCDIR"/moegirl.dict.yaml \
 
 abinfo "Installing LICENSE..."
 mkdir -pv "$PKGDIR"/usr/share/doc/rime-pinyin-moegirl
-install -vm644 "$SRCDIR"/mw2fcitx-$PKGVER/LICENSE \
-        "$PKGDIR"/usr/share/doc/rime-pinyin-moegirl
+install -vm644 "$SRCDIR"/mw2fcitx-$PKGVER/LICENSE.content \
+        "$PKGDIR"/usr/share/doc/rime-pinyin-moegirl/LICENSE
 

--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,8 +1,8 @@
-VER=20210614
+VER=20210717
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       tbl::https://github.com/outloudvi/mw2fcitx/archive/$VER.tar.gz"
-CHKSUMS="sha256::a2c07ac34fc384fe60a7ef91e17d97a3fa6dc35c6f1792500c91ceada049f31f \
-         sha256::6e9c4bac0253985b187d8844501b1d13bc0e39d79dde462a64ba28a328675c43 \
-         sha256::d761c21c83a9280be4752abea96322dca72b33af56bcda3fa108dfc94af47fc4"
+CHKSUMS="sha256::ff527856363c89725a0acf1fef7dae902a1fe9c9a245596762d6067af02c1b6d \
+         sha256::f18996d0a42f24cb5cac523b60c0378977cc7f42acacfbef1f23836755d61594 \
+         sha256::7f974201258d5a616932117f8525006305ff95815c6773aa9a192b56eba26289"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Update to 20210717.
Also, the LICENSE file is updated to CC-BY-NC-SA.

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl
* rime-pinyin-moegirl

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`