### PR TITLE
sqlite-fdw: new, 2.0.0

### DIFF
--- a/extra-database/sqlite-fdw/autobuild/defines
+++ b/extra-database/sqlite-fdw/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=sqlite-fdw
+PKGSEC=database
+PKGDEP="postgresql sqlite libxml2"
+BUILDDEP="llvm"
+PKGDES="PostgreSQL extension which implements a Foreign Data Wrapper (FDW) for SQLite databases"
+
+ABTYPE=plainmake
+MAKE_AFTER="USE_PGXS=1"

--- a/extra-database/sqlite-fdw/spec
+++ b/extra-database/sqlite-fdw/spec
@@ -1,3 +1,4 @@
 VER=2.0.0
 SRCS="tbl::https://api.pgxn.org/dist/sqlite_fdw/$VER/sqlite_fdw-$VER.zip"
+CHKSUMS="sha256::c2ff7b5398343d9440ad1bf72aca2cf23bd1aca32c6c7f3ce5e21503016282f2"
 CHKUPDATE="github::repo=pgspider/sqlite_fdw"

--- a/extra-database/sqlite-fdw/spec
+++ b/extra-database/sqlite-fdw/spec
@@ -1,0 +1,3 @@
+VER=2.0.0
+SRCS="tbl::https://api.pgxn.org/dist/sqlite_fdw/$VER/sqlite_fdw-$VER.zip"
+CHKUPDATE="github::repo=pgspider/sqlite_fdw"


### PR DESCRIPTION
Topic Description
-----------------

sqlite-fdw: new, 2.0.0

Package(s) Affected
-------------------

`sqlite-fdw`

Security Update?
----------------

No

Architectural Progress
----------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`



Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`


