### PR TITLE
curl: update to 7.78.0

### DIFF
--- a/extra-optenv32/curl+32/autobuild/build
+++ b/extra-optenv32/curl+32/autobuild/build
@@ -8,7 +8,7 @@ export LDFLAGS+=" -L/opt/32/lib"
             --disable-ldap --disable-ldaps --enable-ipv6 \
             --enable-manual --enable-versioned-symbols \
             --enable-threaded-resolver --with-gssapi \
-            --without-libidn --with-random=/dev/urandom \
+            --without-libidn --with-openssl --with-random=/dev/urandom \
             --with-ca-bundle=/etc/ssl/ca-bundle.crt \
             CC=i686-pc-linux-gnu-gcc CXX=i686-pc-linux-gnu-g++ \
             PKG_CONFIG_PATH=/opt/32/lib/pkconfig

--- a/extra-optenv32/curl+32/autobuild/defines
+++ b/extra-optenv32/curl+32/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=curl+32
 PKGSEC=utils
 PKGDEP="ca-certs krb5+32 libssh2+32 openssl+32 zlib+32"
 BUILDDEP="32subsystem"
-PKGDES="An URL retrieval utility and library (optenv32, libraries only)"
+PKGDES="A URL retrieval utility and library (optenv32, libraries only)"
 
 NOLTO=1
 ABHOST=noarch

--- a/extra-optenv32/curl+32/spec
+++ b/extra-optenv32/curl+32/spec
@@ -1,3 +1,3 @@
-VER=7.72.0
+VER=7.78.0
 SRCS="tbl::https://curl.haxx.se/download/curl-$VER.tar.xz"
-CHKSUMS="sha256::0ded0808c4d85f2ee0db86980ae610cc9d165e9ca9da466196cc73c346513713"
+CHKSUMS="sha256::be42766d5664a739c3974ee3dfbbcbe978a4ccb1fe628bb1d9b59ac79e445fb5"

--- a/extra-web/curl/autobuild/defines
+++ b/extra-web/curl/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=curl
 PKGSEC=utils
-PKGDEP="ca-certs krb5 libidn2 libssh2 nghttp2 gnutls zlib rtmpdump \
-        brotli libpsl e2fsprogs"
-PKGDES="An URL retrieval utility and library"
+PKGDEP="ca-certs openssl krb5 libidn2 libssh2 nghttp2 gnutls zlib \
+        rtmpdump brotli libpsl e2fsprogs"
+PKGDES="A URL retrieval utility and library"
 
-PKGDEP__RETRO="ca-certs openssl"
+PKGDEP__RETRO="${PKGDEP}"
 PKGDEP__ARMEL="${PKGDEP__RETRO}"
 PKGDEP__ARMHF="${PKGDEP__RETRO}"
 PKGDEP__I486="${PKGDEP__RETRO}"
@@ -16,14 +16,14 @@ AUTOTOOLS_AFTER="--mandir=/usr/share/man --disable-ldap \
                  --disable-ldaps --enable-ipv6 --enable-manual \
                  --enable-versioned-symbols --enable-threaded-resolver \
                  --with-gssapi --with-libidn2 --with-libpsl \
-                 --with-random=/dev/urandom \
+                 --with-openssl --with-random=/dev/urandom \
                  --with-ca-bundle=/etc/ssl/ca-bundle.crt"
 AUTOTOOLS_AFTER__RETRO=" \
                  --mandir=/usr/share/man --disable-ldap \
                  --disable-ldaps --enable-ipv6 --enable-manual \
                  --enable-versioned-symbols --enable-threaded-resolver \
-                 --without-gssapi --without-libidn2 \
-                 --without-libssh2 --without-brotli --without-librtmp \
+                 --without-gssapi --without-libidn2 --without-libssh2 \
+                 --without-brotli --without-librtmp --with-openssl \
                  --with-random=/dev/urandom --with-ca-bundle=/etc/ssl/ca-bundle.crt"
 AUTOTOOLS_AFTER__ARMEL="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__ARMHF="${AUTOTOOLS_AFTER__RETRO}"

--- a/extra-web/curl/spec
+++ b/extra-web/curl/spec
@@ -1,3 +1,3 @@
-VER=7.76.0
+VER=7.78.0
 SRCS="tbl::https://curl.haxx.se/download/curl-$VER.tar.xz"
-CHKSUMS="sha256::6302e2d75c59cdc6b35ce3fbe716481dd4301841bbb5fd71854653652a014fc8"
+CHKSUMS="sha256::be42766d5664a739c3974ee3dfbbcbe978a4ccb1fe628bb1d9b59ac79e445fb5"


### PR DESCRIPTION
Topic Description
-----------------

Update curl, curl+32 to 7.78.0

Package(s) Affected
-------------------

curl, curl+32

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

Yes - Issue Number: #3292 

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

`curl+32`
- [x] 32-bit Optional Environment `optenv32`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

`curl+32`
- [ ] 32-bit Optional Environment `optenv32`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`