### PR TITLE
ibm-plex-fonts: update to 5.2.1

### DIFF
--- a/extra-fonts/ibm-plex-fonts/autobuild/build
+++ b/extra-fonts/ibm-plex-fonts/autobuild/build
@@ -1,6 +1,7 @@
 abinfo "Installing fonts and LICENSE..."
-install -dvm755 "$PKGDIR"/usr/share/fonts/TTF
+install -dvm755 "$PKGDIR"/usr/share/fonts/OTF
 install -dvm755 "$PKGDIR"/usr/share/doc/ibm-plex-fonts
-install -vm644 "$SRCDIR"/*/*.otf "$PKGDIR"/usr/share/fonts/TTF
+install -vm644 "$SRCDIR"/*/*.otf "$PKGDIR"/usr/share/fonts/OTF
+install -vm644 "$SRCDIR"/IBM-Plex-Sans-JP/hinted/*.otf "$PKGDIR"/usr/share/fonts/OTF
 install -vm644 "$SRCDIR"/IBM-Plex-Mono/license.txt \
 	"$PKGDIR"/usr/share/doc/ibm-plex-fonts/license.txt

--- a/extra-fonts/ibm-plex-fonts/spec
+++ b/extra-fonts/ibm-plex-fonts/spec
@@ -1,3 +1,4 @@
-VER=5.1.3
+VER=5.2.1
 SRCS="tbl::https://github.com/IBM/plex/releases/download/v$VER/OpenType.zip"
-CHKSUMS="sha256::61085afbb80992cfcc9c529efb48e0c56e1a174826dda8de852492d2fb449f7e"
+CHKSUMS="sha256::12cb0cde34b718304f87156ddf134b343a0e0503e6248497dd3e6015a2b76135"
+CHKUPDATE="github::repo=IBM/plex"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

ibm-plex-fonts: update to 5.2.1

- Adapt to aosc-findupdate
- Fix wrong install path

Package(s) Affected
-------------------

ibm-plex-fonts:  5.2.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch` 

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->
 - [x] Architecture-independent `noarch` 