### PR TITLE
openjdk-8: security update to 8u302

### DIFF
--- a/extra-java/openjdk-8/spec
+++ b/extra-java/openjdk-8/spec
@@ -1,7 +1,7 @@
-VER=8u292+ga
+VER=8u302+ga
 # loongson3 specific tarball
 SRCS__LOONGSON3="https://repo.aosc.io/aosc-repacks/ls3-java/openjdk-${VER/+/-}.tar.xz"
 CHKSUMS__LOONGSON3="sha256::64f12078dcf69274ab16ca1e3b80d1f24b7c2d921176c594c10e8e23802ebf2c"
 
 SRCS="https://openjdk-sources.osci.io/openjdk8/openjdk${VER/+/-}.tar.xz"
-CHKSUMS="sha256::9008c700c699739e185ee5b1b4554b769a81492f9b3358634cd693ce75668b3f"
+CHKSUMS="sha256::ab50669afd85086ba451cbc1560ae76e9bc7fc3c9c46e3d37ee5c6a48bb30124"

--- a/extra-java/openjfx-8/spec
+++ b/extra-java/openjfx-8/spec
@@ -1,4 +1,4 @@
 VER=8u202+ga
-REL=7
+REL=8
 SRCS="tbl::https://repo.aosc.io/aosc-repacks/openjfx-8u202-ga.tar.bz2"
 CHKSUMS="sha256::12b0538d04c4bd451e4692ee06357ac36233ff4ec2af9fa3b9bbdbab48c3f2fc"


### PR DESCRIPTION
Topic Description
-----------------

openjdk-8: security update to 8u302

Package(s) Affected
-------------------

```
openjdk-8
openjfx-8
```

Security Update?
----------------

Yes, #3297 

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [X] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------


- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

