### PR TITLE
openjdk: security update to 11.0.12

### DIFF
--- a/extra-java/openjdk/autobuild/defines
+++ b/extra-java/openjdk/autobuild/defines
@@ -19,3 +19,4 @@ AB_FLAGS_NOW__POWERPC=0
 
 # FIXME: breaks binary.
 NOLTO=1
+ABSPLITDBG=0

--- a/extra-java/openjdk/spec
+++ b/extra-java/openjdk/spec
@@ -1,3 +1,3 @@
-VER=11.0.11+ga
+VER=11.0.12+ga
 SRCS="tbl::https://openjdk-sources.osci.io/openjdk11/openjdk-${VER/+/-}.tar.xz"
-CHKSUMS="sha256::a00f8cf0c1edbefb767bce893a74b170478cb9bf152224b215aa59e7b431079c"
+CHKSUMS="sha256::5f139e8760d1ea0587d029b3c217654ed3bf6f46d663eb418e19f42f36c061e5"

--- a/extra-java/openjfx/autobuild/defines
+++ b/extra-java/openjfx/autobuild/defines
@@ -5,3 +5,4 @@ BUILDDEP="cmake gperf ruby unzip"
 PKGDES="Open source implementation of JavaFX"
 
 NOLTO=1
+ABSPLITDBG=0

--- a/extra-java/openjfx/spec
+++ b/extra-java/openjfx/spec
@@ -1,3 +1,3 @@
-VER=11.0.11+1
-SRCS="tbl::https://repo.aosc.io/aosc-repacks/openjfx-${VER}.tar.xz"
-CHKSUMS="sha256::ec3fad515e30c7ccadc8381e4dcf1be322834dbd8051aba6a76499cb2afffc3e"
+VER=11.0.12+4
+SRCS="tbl::https://github.com/openjdk/jfx11u/archive/refs/tags/${VER}.tar.gz"
+CHKSUMS="sha256::4efc71bf26993d37b6fdeb6c07146c68092447e79b0d90ca4e60b0d6aff4cc55"


### PR DESCRIPTION
Topic Description
-----------------

openjdk: security update to 11.0.12

Package(s) Affected
-------------------

```
openjdk
openjfx
```

Security Update?
----------------

Yes, #3298 

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
