### PR TITLE
vaultwarden: update to 1.22.2

### DIFF
--- a/extra-security/vaultwarden/spec
+++ b/extra-security/vaultwarden/spec
@@ -1,8 +1,8 @@
-VER=1.22.1
-BW_WEB_BUILDS_VER=2.20.4b
+VER=1.22.2
+BW_WEB_BUILDS_VER=2.21.1
 SRCS="tbl::https://github.com/dani-garcia/vaultwarden/archive/refs/tags/$VER.tar.gz \
       tbl::https://github.com/dani-garcia/bw_web_builds/releases/download/v$BW_WEB_BUILDS_VER/bw_web_v$BW_WEB_BUILDS_VER.tar.gz"
-CHKSUMS="sha256::067e0ed02666f679b9a96c92b9bc2d0a4ce671980a50ea8220b7716c74f08061 \
-         sha256::baa055b385c81d874effd9fe4eaef6a71a6113acd81ff9d2cbebbb715008e820"
+CHKSUMS="sha256::3aa307d1fd705f02ebd3f3ddda3b8ea0709db8a8fb47aeead3b54f0764923d79 \
+         sha256::84a1ce9d0895ab6b92a899a14d63c95dacf617a18ef7f6cccbb1bd064676a6e2"
 CHKUPDATE="github::repo=dani-garcia/vaultwarden"
 SUBDIR="vaultwarden-$VER"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

vaultwarden: update to 1.22.2

Package(s) Affected
-------------------

vaultwarden: 1.22.2

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->