### PR TITLE
wine: update to 6.13

### DIFF
--- a/extra-emulation/wine/autobuild/patches/0001-Revert-winegcc-Support-Wl-foo-.-style-linker-options.patch
+++ b/extra-emulation/wine/autobuild/patches/0001-Revert-winegcc-Support-Wl-foo-.-style-linker-options.patch
@@ -1,0 +1,26 @@
+From 55d803ee64e72ece30bb86b28f6cd9010355e147 Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Sun, 25 Jul 2021 20:51:52 -0700
+Subject: [PATCH] Revert "winegcc: Support -Wl,foo=... style linker options."
+
+This reverts commit fcda0afdd429e11d75dc61f628e40a6c8973ce44.
+---
+ tools/winegcc/winegcc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/winegcc/winegcc.c b/tools/winegcc/winegcc.c
+index 8c1e0d088ac..fd2d2c2a794 100644
+--- a/tools/winegcc/winegcc.c
++++ b/tools/winegcc/winegcc.c
+@@ -1982,7 +1982,7 @@ int main(int argc, char **argv)
+                     if (strncmp("-Wl,", opts.args->base[i], 4) == 0)
+ 		    {
+                         unsigned int j;
+-                        strarray* Wl = strarray_fromstring(opts.args->base[i] + 4, ",=");
++                        strarray* Wl = strarray_fromstring(opts.args->base[i] + 4, ",");
+                         for (j = 0; j < Wl->size; j++)
+                         {
+                             if (!strcmp(Wl->base[j], "--image-base") && j < Wl->size - 1)
+-- 
+2.30.2
+

--- a/extra-emulation/wine/spec
+++ b/extra-emulation/wine/spec
@@ -1,8 +1,7 @@
-VER=6.11
-REL=1
+VER=6.13
 SRCS="tbl::https://dl.winehq.org/wine/source/${VER:0:1}.x/wine-$VER.tar.xz \
       git::rename=wine-staging;commit=tags/v$VER::https://github.com/wine-staging/wine-staging"
-CHKSUMS="sha256::c952bc2d7e3ea349944162a074aead74b7948261ba43d394d971452d7111670b \
+CHKSUMS="sha256::e03a21a011d45d2ae9f222040fb7690b97156376e7431f861f20073eaf24f28a \
          SKIP"
 CHKUPDATE="anitya::id=15657"
 SUBDIR="wine-$VER"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

wine: update to 6.13

- Revert https://github.com/wine-mirror/wine/commit/fcda0afdd429e11d75dc61f628e40a6c8973ce44 to fix build

Package(s) Affected
-------------------

wine: 6.13

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->