### PR TITLE
CUPS Filters: upgrade to 1.28.9

### DIFF
--- a/extra-libs/cups-filters/autobuild/defines
+++ b/extra-libs/cups-filters/autobuild/defines
@@ -6,6 +6,7 @@ PKGSUG="foomatic ghostscript php noto-fonts"
 BUILDDEP="ghostscript noto-fonts mupdf"
 
 AUTOTOOLS_AFTER="--with-rcdir=no --enable-avahi \
+                 --enable-static=no
                  --with-browseremoteprotocols=DNSSD,CUPS \
-                 --with-test-font-path=/usr/share/fonts/Noto/NotoSans-Regular.ttf"
+                 --with-test-font-path=/usr/share/fonts/TTF/NotoSans-Regular.ttf"
 ABSHADOW=no

--- a/extra-libs/cups-filters/spec
+++ b/extra-libs/cups-filters/spec
@@ -1,4 +1,3 @@
-VER=1.25.13
-REL=2
+VER=1.28.9
 SRCS="tbl::https://www.openprinting.org/download/cups-filters/cups-filters-$VER.tar.xz"
-CHKSUMS="sha256::5272ed6c58c3291527c6d0dacb719a253b621fc0e9462be8dfdf9b7bcd3d6bfc"
+CHKSUMS="sha256::2f69372a4fa76dc91e54b4c98ab4c65368e3dfbde92456205c98a39573e860ae"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates to CUPS filters to 1.28.9 and fixes linkage with `libqpdf.so.28.2.0`.

Package(s) Affected
-------------------

* `cups-filters`: 1.28.9

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
