### PR TITLE
Pillow: upgrade to 8.3.1, install headers

### DIFF
--- a/extra-python/pillow/autobuild/beyond
+++ b/extra-python/pillow/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing headers"
+mkdir -vp "${PKGDIR}/usr/include/python${ABPY3VER}"
+install -vm644 -t "${PKGDIR}/usr/include/python${ABPY3VER}/" "${SRCDIR}/src/libImaging/"*.h

--- a/extra-python/pillow/spec
+++ b/extra-python/pillow/spec
@@ -1,3 +1,3 @@
-VER=8.1.2
+VER=8.3.1
 SRCS="tbl::https://github.com/python-pillow/Pillow/archive/$VER.tar.gz"
-CHKSUMS="sha256::4b99c0a07e8bc4048b4f37ee515d02cc2f895453afe534e4b00bfe2f2a2dbe39"
+CHKSUMS="sha256::7e9c5b0de75ea2618527245a2d836f4880b790b9c1424c548d89f3e61b5df8e1"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates 8.3.1 and installs missing PIL headers.

Package(s) Affected
-------------------

* `pillow`: 8.3.1

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
