### PR TITLE
joplin: new, 2.1.9

### DIFF
--- a/extra-productivity/joplin/autobuild/build
+++ b/extra-productivity/joplin/autobuild/build
@@ -1,0 +1,22 @@
+cd "${SRCDIR}"
+npm install --cache ${_NPM_CACHE}
+
+cd "${SRCDIR}/packages/app-cli"
+npm run build
+cd "${SRCDIR}/packages/app-cli/build"
+npm pack
+npm install --production --global --user root --prefix "${PKGDIR}/usr" "$PKGNAME-$PKGVER.tgz"
+cd "${PKGDIR}/usr"
+mv "${PKGDIR}/usr/lib/node_modules/joplin" "${PKGDIR}/usr/lib/joplin"
+rm -rv "${PKGDIR}/usr/lib/node_modules"
+find "${PKGDIR}/usr" -type d -exec chmod 755 {} +
+find "${PKGDIR}" -name package.json -print0 | xargs -0 sed -i "/_where/d"
+jq '.|=with_entries(select(.key|test("_.+")|not))' "${PKGDIR}/usr/lib/joplin/package.json" > "${PKGDIR}/usr/lib/joplin/package.json"
+chmod 644 "${PKGDIR}/usr/lib/joplin/package.json"
+
+cd "${SRCDIR}/packages/app-desktop"
+mkdir -p "${SRCDIR}/packages/app-desktop/dist/"
+touch "${SRCDIR}/packages/app-desktop/dist/AppImage"
+USE_HARD_LINKS=false npm run dist -- --publish=never --linux --x64 --dir="${SRCDIR}/packages/app-desktop/dist/"
+mv "${SRCDIR}/packages/app-desktop/dist/linux-unpacked/@joplinapp-desktop" "${SRCDIR}/packages/app-desktop/dist/linux-unpacked/joplin-desktop"
+cp -a "${SRCDIR}/packages/app-desktop/dist/linux-unpacked" "${PKGDIR}/usr/lib/joplin-desktop"

--- a/extra-productivity/joplin/autobuild/build
+++ b/extra-productivity/joplin/autobuild/build
@@ -32,12 +32,12 @@ abinfo "Building Joplin Desktop..."
 cd "${SRCDIR}/packages/app-desktop"
 mkdir -p "${SRCDIR}/packages/app-desktop/dist/"
 touch "${SRCDIR}/packages/app-desktop/dist/AppImage"
-USE_HARD_LINKS=false npm run dist -- --publish=never --linux --x64 --dir="${SRCDIR}/packages/app-desktop/dist/"
-mv "${SRCDIR}/packages/app-desktop/dist/linux-unpacked/@joplinapp-desktop" "${SRCDIR}/packages/app-desktop/dist/linux-unpacked/joplin-desktop"
+USE_HARD_LINKS=false npm run dist -- --publish=never --linux "${ARCH_OPTS}" --dir="${SRCDIR}/packages/app-desktop/dist/"
+mv "${SRCDIR}/packages/app-desktop/dist/${ARCH_DIR}/@joplinapp-desktop" "${SRCDIR}/packages/app-desktop/dist/${ARCH_DIR}/joplin-desktop"
 
 abinfo "Remove duplicated and unpacked electron application files..."
-rm -rv "${SRCDIR}/packages/app-desktop/dist/linux-unpacked/resources/app.asar.unpacked"
-cp -a "${SRCDIR}/packages/app-desktop/dist/linux-unpacked" "${PKGDIR}/usr/lib/joplin-desktop"
+rm -rv "${SRCDIR}/packages/app-desktop/dist/${ARCH_DIR}/resources/app.asar.unpacked"
+cp -a "${SRCDIR}/packages/app-desktop/dist/${ARCH_DIR}" "${PKGDIR}/usr/lib/joplin-desktop"
 
 
 abinfo "Creating the Joplin CLI and Joplin Desktop executable file soft link in /usr/bin..."

--- a/extra-productivity/joplin/autobuild/build
+++ b/extra-productivity/joplin/autobuild/build
@@ -25,7 +25,10 @@ find "${PKGDIR}/usr" -type d -exec chmod -v 755 {} +
 
 abinfo "Remove unneeded dependencies info in package.json..."
 find "${PKGDIR}" -name package.json -print0 | xargs -0 sed -i "/_where/d"
-jq '.|=with_entries(select(.key|test("_.+")|not))' "${PKGDIR}/usr/lib/joplin/package.json" > "${PKGDIR}/usr/lib/joplin/package.json"
+_TMP_META=$(mktemp)
+jq '.|=with_entries(select(.key|test("_.+")|not))' "${PKGDIR}/usr/lib/joplin/package.json" > "${_TMP_META}"
+cat "${_TMP_META}" > "${PKGDIR}/usr/lib/joplin/package.json"
+rm -v ${_TMP_META}
 chmod -v 644 "${PKGDIR}/usr/lib/joplin/package.json"
 
 abinfo "Make all .so library files executable for AutoBuild3 QA checks..."

--- a/extra-productivity/joplin/autobuild/build
+++ b/extra-productivity/joplin/autobuild/build
@@ -1,11 +1,12 @@
 cd "${SRCDIR}"
-npm install --cache ${_NPM_CACHE}
+npm install --unsafe-perm --cache ${_NPM_CACHE}
 
 cd "${SRCDIR}/packages/app-cli"
 npm run build
 cd "${SRCDIR}/packages/app-cli/build"
-npm pack
-npm install --production --global --user root --prefix "${PKGDIR}/usr" "$PKGNAME-$PKGVER.tgz"
+_CLI_PACK=$(npm pack | tail -n 1)
+npm install --production --unsafe-perm --global --user root --cache ${_NPM_CACHE} --prefix "${PKGDIR}/usr" "${SRCDIR}/packages/app-cli/build/${_CLI_PACK}"
+
 cd "${PKGDIR}/usr"
 mv "${PKGDIR}/usr/lib/node_modules/joplin" "${PKGDIR}/usr/lib/joplin"
 rm -rv "${PKGDIR}/usr/lib/node_modules"
@@ -13,10 +14,16 @@ find "${PKGDIR}/usr" -type d -exec chmod 755 {} +
 find "${PKGDIR}" -name package.json -print0 | xargs -0 sed -i "/_where/d"
 jq '.|=with_entries(select(.key|test("_.+")|not))' "${PKGDIR}/usr/lib/joplin/package.json" > "${PKGDIR}/usr/lib/joplin/package.json"
 chmod 644 "${PKGDIR}/usr/lib/joplin/package.json"
+find "${PKGDIR}/usr/lib/joplin/node_modules" -name "*.so.*" -exec chmod +x {} +
 
 cd "${SRCDIR}/packages/app-desktop"
 mkdir -p "${SRCDIR}/packages/app-desktop/dist/"
 touch "${SRCDIR}/packages/app-desktop/dist/AppImage"
 USE_HARD_LINKS=false npm run dist -- --publish=never --linux --x64 --dir="${SRCDIR}/packages/app-desktop/dist/"
 mv "${SRCDIR}/packages/app-desktop/dist/linux-unpacked/@joplinapp-desktop" "${SRCDIR}/packages/app-desktop/dist/linux-unpacked/joplin-desktop"
+rm -rv "${SRCDIR}/packages/app-desktop/dist/linux-unpacked/resources/app.asar.unpacked"
 cp -a "${SRCDIR}/packages/app-desktop/dist/linux-unpacked" "${PKGDIR}/usr/lib/joplin-desktop"
+
+cd "${PKGDIR}/usr/bin"
+ln -svf ../lib/joplin/main.js "${PKGDIR}/usr/bin/joplin"
+ln -svf ../lib/joplin-desktop/joplin-desktop "${PKGDIR}/usr/bin/joplin-desktop"

--- a/extra-productivity/joplin/autobuild/build
+++ b/extra-productivity/joplin/autobuild/build
@@ -1,44 +1,46 @@
+# This build script is modified from https://github.com/alfredopalhares/arch-pkgbuilds
+
 abinfo "Start building Joplin..."
 cd "${SRCDIR}"
 
 abinfo "Building Joplin modules and Downloading dependencies..."
-npm install --unsafe-perm --cache ${_NPM_CACHE}
-
+npm install --verbose --unsafe-perm --cache ${_NPM_CACHE}
 
 abinfo "Building Joplin CLI..."
 cd "${SRCDIR}/packages/app-cli"
 npm run build
 cd "${SRCDIR}/packages/app-cli/build"
 _CLI_PACK=$(npm pack | tail -n 1)
-npm install --production --unsafe-perm --global --user root --cache ${_NPM_CACHE} --prefix "${PKGDIR}/usr" "${SRCDIR}/packages/app-cli/build/${_CLI_PACK}"
+npm install  --production --unsafe-perm --global \
+	--user root --cache ${_NPM_CACHE} \
+	--prefix "${PKGDIR}/usr" \
+	"${SRCDIR}/packages/app-cli/build/${_CLI_PACK}"
 
 cd "${PKGDIR}/usr"
-mv "${PKGDIR}/usr/lib/node_modules/joplin" "${PKGDIR}/usr/lib/joplin"
+mv -v "${PKGDIR}/usr/lib/node_modules/joplin" "${PKGDIR}/usr/lib/joplin"
 rm -rv "${PKGDIR}/usr/lib/node_modules"
 
 abinfo "Fixing npm permissions problem for Joplin CLI..."
-find "${PKGDIR}/usr" -type d -exec chmod 755 {} +
+find "${PKGDIR}/usr" -type d -exec chmod -v 755 {} +
 
 abinfo "Remove unneeded dependencies info in package.json..."
 find "${PKGDIR}" -name package.json -print0 | xargs -0 sed -i "/_where/d"
 jq '.|=with_entries(select(.key|test("_.+")|not))' "${PKGDIR}/usr/lib/joplin/package.json" > "${PKGDIR}/usr/lib/joplin/package.json"
-chmod 644 "${PKGDIR}/usr/lib/joplin/package.json"
+chmod -v 644 "${PKGDIR}/usr/lib/joplin/package.json"
 
 abinfo "Make all .so library files executable for AutoBuild3 QA checks..."
-find "${PKGDIR}/usr/lib/joplin/node_modules" -name "*.so.*" -exec chmod +x {} +
-
+find "${PKGDIR}/usr/lib/joplin/node_modules" -name "*.so.*" -exec chmod -v +x {} +
 
 abinfo "Building Joplin Desktop..."
 cd "${SRCDIR}/packages/app-desktop"
-mkdir -p "${SRCDIR}/packages/app-desktop/dist/"
+mkdir -pv "${SRCDIR}/packages/app-desktop/dist/"
 touch "${SRCDIR}/packages/app-desktop/dist/AppImage"
 USE_HARD_LINKS=false npm run dist -- --publish=never --linux "${ARCH_OPTS}" --dir="${SRCDIR}/packages/app-desktop/dist/"
-mv "${SRCDIR}/packages/app-desktop/dist/${ARCH_DIR}/@joplinapp-desktop" "${SRCDIR}/packages/app-desktop/dist/${ARCH_DIR}/joplin-desktop"
+mv -v "${SRCDIR}/packages/app-desktop/dist/${ARCH_DIR}/@joplinapp-desktop" "${SRCDIR}/packages/app-desktop/dist/${ARCH_DIR}/joplin-desktop"
 
 abinfo "Remove duplicated and unpacked electron application files..."
 rm -rv "${SRCDIR}/packages/app-desktop/dist/${ARCH_DIR}/resources/app.asar.unpacked"
-cp -a "${SRCDIR}/packages/app-desktop/dist/${ARCH_DIR}" "${PKGDIR}/usr/lib/joplin-desktop"
-
+cp -av "${SRCDIR}/packages/app-desktop/dist/${ARCH_DIR}" "${PKGDIR}/usr/lib/joplin-desktop"
 
 abinfo "Creating the Joplin CLI and Joplin Desktop executable file soft link in /usr/bin..."
 cd "${PKGDIR}/usr/bin"

--- a/extra-productivity/joplin/autobuild/build
+++ b/extra-productivity/joplin/autobuild/build
@@ -1,6 +1,11 @@
+abinfo "Start building Joplin..."
 cd "${SRCDIR}"
+
+abinfo "Building Joplin modules and Downloading dependencies..."
 npm install --unsafe-perm --cache ${_NPM_CACHE}
 
+
+abinfo "Building Joplin CLI..."
 cd "${SRCDIR}/packages/app-cli"
 npm run build
 cd "${SRCDIR}/packages/app-cli/build"
@@ -10,20 +15,32 @@ npm install --production --unsafe-perm --global --user root --cache ${_NPM_CACHE
 cd "${PKGDIR}/usr"
 mv "${PKGDIR}/usr/lib/node_modules/joplin" "${PKGDIR}/usr/lib/joplin"
 rm -rv "${PKGDIR}/usr/lib/node_modules"
+
+abinfo "Fixing npm permissions problem for Joplin CLI..."
 find "${PKGDIR}/usr" -type d -exec chmod 755 {} +
+
+abinfo "Remove unneeded dependencies info in package.json..."
 find "${PKGDIR}" -name package.json -print0 | xargs -0 sed -i "/_where/d"
 jq '.|=with_entries(select(.key|test("_.+")|not))' "${PKGDIR}/usr/lib/joplin/package.json" > "${PKGDIR}/usr/lib/joplin/package.json"
 chmod 644 "${PKGDIR}/usr/lib/joplin/package.json"
+
+abinfo "Make all .so library files executable for AutoBuild3 QA checks..."
 find "${PKGDIR}/usr/lib/joplin/node_modules" -name "*.so.*" -exec chmod +x {} +
 
+
+abinfo "Building Joplin Desktop..."
 cd "${SRCDIR}/packages/app-desktop"
 mkdir -p "${SRCDIR}/packages/app-desktop/dist/"
 touch "${SRCDIR}/packages/app-desktop/dist/AppImage"
 USE_HARD_LINKS=false npm run dist -- --publish=never --linux --x64 --dir="${SRCDIR}/packages/app-desktop/dist/"
 mv "${SRCDIR}/packages/app-desktop/dist/linux-unpacked/@joplinapp-desktop" "${SRCDIR}/packages/app-desktop/dist/linux-unpacked/joplin-desktop"
+
+abinfo "Remove duplicated and unpacked electron application files..."
 rm -rv "${SRCDIR}/packages/app-desktop/dist/linux-unpacked/resources/app.asar.unpacked"
 cp -a "${SRCDIR}/packages/app-desktop/dist/linux-unpacked" "${PKGDIR}/usr/lib/joplin-desktop"
 
+
+abinfo "Creating the Joplin CLI and Joplin Desktop executable file soft link in /usr/bin..."
 cd "${PKGDIR}/usr/bin"
 ln -svf ../lib/joplin/main.js "${PKGDIR}/usr/bin/joplin"
 ln -svf ../lib/joplin-desktop/joplin-desktop "${PKGDIR}/usr/bin/joplin-desktop"

--- a/extra-productivity/joplin/autobuild/defines
+++ b/extra-productivity/joplin/autobuild/defines
@@ -4,3 +4,4 @@ PKGDES="A note taking and to-do application based on Node.JS and Electron."
 PKGDEP="nodejs rsync nss libwebp gtk-3 libjpeg-turbo gconf"
 BUILDDEP="jq"
 ABSPLITDBG=0
+FAIL_ARCH="!(amd64|arm64)"

--- a/extra-productivity/joplin/autobuild/defines
+++ b/extra-productivity/joplin/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=joplin
+PKGSEC=doc
+PKGDES="A note taking and to-do application based on Node.JS and Electron."
+PKGDEP="nodejs rsync nss libwebp gtk-3 libjpeg-turbo gconf"
+BUILDDEP="jq"

--- a/extra-productivity/joplin/autobuild/defines
+++ b/extra-productivity/joplin/autobuild/defines
@@ -3,3 +3,4 @@ PKGSEC=doc
 PKGDES="A note taking and to-do application based on Node.JS and Electron."
 PKGDEP="nodejs rsync nss libwebp gtk-3 libjpeg-turbo gconf"
 BUILDDEP="jq"
+ABSPLITDBG=0

--- a/extra-productivity/joplin/autobuild/overrides/usr/share/applications/joplin-desktop.desktop
+++ b/extra-productivity/joplin/autobuild/overrides/usr/share/applications/joplin-desktop.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Joplin
+Comment=Joplin is an open source note-taking app. Capture your thoughts and securely access them from any device.
+Exec=/usr/bin/joplin-desktop
+Icon=/usr/lib/joplin-desktop/resources/build/icons/128x128.png
+Terminal=false
+Type=Application
+Categories=Application;Office;
+

--- a/extra-productivity/joplin/autobuild/overrides/usr/share/applications/joplin-desktop.desktop
+++ b/extra-productivity/joplin/autobuild/overrides/usr/share/applications/joplin-desktop.desktop
@@ -1,9 +1,8 @@
 [Desktop Entry]
 Name=Joplin
-Comment=Joplin is an open source note-taking app. Capture your thoughts and securely access them from any device.
+Comment=Joplin is an open source note-taking application. Capture your thoughts and securely access them from any device.
 Exec=/usr/bin/joplin-desktop
 Icon=/usr/lib/joplin-desktop/resources/build/icons/128x128.png
 Terminal=false
 Type=Application
 Categories=Application;Office;
-

--- a/extra-productivity/joplin/autobuild/prepare
+++ b/extra-productivity/joplin/autobuild/prepare
@@ -1,0 +1,5 @@
+export LANG=en_US.UTF-8
+export _NPM_CACHE="${SRCDIR}/npm_cache"
+mkdir ${_NPM_CACHE}
+sed -i '/"husky": ".*"/d' "${SRCDIR}/package.json"
+(shopt -s extglob;cd "${SRCDIR}/packages"; rm -rv !(app-cli|app-desktop|fork-htmlparser2|fork-sax|lib|renderer|tools|turndown|turndown-plugin-gfm); shopt -u extglob;)

--- a/extra-productivity/joplin/autobuild/prepare
+++ b/extra-productivity/joplin/autobuild/prepare
@@ -1,6 +1,3 @@
-abinfo "Setting Locale Environment Variable for npm..."
-export LANG=en_US.UTF-8
-
 abinfo "Setting the target architecture..."
 if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
     export ARCH_OPTS="--x64"

--- a/extra-productivity/joplin/autobuild/prepare
+++ b/extra-productivity/joplin/autobuild/prepare
@@ -12,7 +12,11 @@ fi
 
 abinfo "Setting npm cache directory..."
 export _NPM_CACHE="${SRCDIR}/npm_cache"
-mkdir ${_NPM_CACHE}
+mkdir -v ${_NPM_CACHE}
+_TMP_LERNA=$(mktemp)
+jq ". += {\"npmClient\": \"npm\", \"npmClientArgs\": [\"--cache $cache\"]}" "${SRCDIR}/lerna.json" > "${_TMP_LERNA}"
+cat "${_TMP_LERNA}" > "${SRCDIR}/lerna.json"
+rm "${_TMP_LERNA}"
 
 abinfo "Disable husky grabbing submodules from git because of using tarball"
 sed -i '/"husky": ".*"/d' "${SRCDIR}/package.json"

--- a/extra-productivity/joplin/autobuild/prepare
+++ b/extra-productivity/joplin/autobuild/prepare
@@ -10,7 +10,6 @@ elif [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
     export ARCH_DIR="linux-arm64-unpacked"
 fi
 
-
 abinfo "Setting npm cache directory..."
 export _NPM_CACHE="${SRCDIR}/npm_cache"
 mkdir ${_NPM_CACHE}
@@ -19,4 +18,4 @@ abinfo "Disable husky grabbing submodules from git because of using tarball"
 sed -i '/"husky": ".*"/d' "${SRCDIR}/package.json"
 
 abinfo "Remove unneeded modules..."
-(shopt -s extglob;cd "${SRCDIR}/packages"; rm -rv !(app-cli|app-desktop|fork-htmlparser2|fork-sax|lib|renderer|tools|turndown|turndown-plugin-gfm); shopt -u extglob;)
+(shopt -s extglob; cd "${SRCDIR}/packages"; rm -rv !(app-cli|app-desktop|fork-htmlparser2|fork-sax|lib|renderer|tools|turndown|turndown-plugin-gfm); shopt -u extglob;)

--- a/extra-productivity/joplin/autobuild/prepare
+++ b/extra-productivity/joplin/autobuild/prepare
@@ -1,6 +1,16 @@
 abinfo "Setting Locale Environment Variable for npm..."
 export LANG=en_US.UTF-8
 
+abinfo "Setting the target architecture..."
+if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
+    export ARCH_OPTS="--x64"
+    export ARCH_DIR="linux-unpacked"
+elif [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
+    export ARCH_OPTS="--arm64"
+    export ARCH_DIR="linux-arm64-unpacked"
+fi
+
+
 abinfo "Setting npm cache directory..."
 export _NPM_CACHE="${SRCDIR}/npm_cache"
 mkdir ${_NPM_CACHE}

--- a/extra-productivity/joplin/autobuild/prepare
+++ b/extra-productivity/joplin/autobuild/prepare
@@ -1,5 +1,12 @@
+abinfo "Setting Locale Environment Variable for npm..."
 export LANG=en_US.UTF-8
+
+abinfo "Setting npm cache directory..."
 export _NPM_CACHE="${SRCDIR}/npm_cache"
 mkdir ${_NPM_CACHE}
+
+abinfo "Disable husky grabbing submodules from git because of using tarball"
 sed -i '/"husky": ".*"/d' "${SRCDIR}/package.json"
+
+abinfo "Remove unneeded modules..."
 (shopt -s extglob;cd "${SRCDIR}/packages"; rm -rv !(app-cli|app-desktop|fork-htmlparser2|fork-sax|lib|renderer|tools|turndown|turndown-plugin-gfm); shopt -u extglob;)

--- a/extra-productivity/joplin/spec
+++ b/extra-productivity/joplin/spec
@@ -1,0 +1,4 @@
+VER=2.1.9
+SRCS="tbl::https://github.com/laurent22/joplin/archive/refs/tags/v${VER}.tar.gz"
+CHKSUMS="sha256::d175f6c2daabf90264b4e6a0f083153a5a82a512d533fbf1a4bb6915da51d6a1"
+CHKUPDATE="github::repo=laurent22/joplin;pattern=v(\d+\.\d+\.\d+)"

--- a/extra-productivity/joplin/spec
+++ b/extra-productivity/joplin/spec
@@ -1,4 +1,4 @@
 VER=2.1.9
 SRCS="tbl::https://github.com/laurent22/joplin/archive/refs/tags/v${VER}.tar.gz"
 CHKSUMS="sha256::d175f6c2daabf90264b4e6a0f083153a5a82a512d533fbf1a4bb6915da51d6a1"
-CHKUPDATE="github::repo=laurent22/joplin;pattern=v(\d+\.\d+\.\d+)"
+CHKUPDATE="anitya::id=227031"


### PR DESCRIPTION
Topic Description
-----------------
Add `joplin`, which is a opensource note taking app.

Package(s) Affected
-------------------
* `joplin`

Security Update?
----------------
No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

