### PR TITLE
Flatpak: update to 1.11.2

### DIFF
--- a/extra-admin/flatpak/autobuild/beyond
+++ b/extra-admin/flatpak/autobuild/beyond
@@ -1,1 +1,3 @@
-install -d -o root -g 27 -m 750 "$PKGDIR"/usr/share/polkit-1/rules.d
+abinfo "Installing FlatHub manifest ..."
+install -Dvm644 "$SRCDIR/../flathub.flatpakrepo" "$PKGDIR/etc/flatpak/remotes.d/"
+install -dv -o root -g 27 -m 750 "$PKGDIR"/usr/share/polkit-1/rules.d

--- a/extra-admin/flatpak/autobuild/beyond
+++ b/extra-admin/flatpak/autobuild/beyond
@@ -1,3 +1,4 @@
 abinfo "Installing FlatHub manifest ..."
+mkdir -pv "$PKGDIR/etc/flatpak/remotes.d/"
 install -Dvm644 "$SRCDIR/../flathub.flatpakrepo" "$PKGDIR/etc/flatpak/remotes.d/"
 install -dv -o root -g 27 -m 750 "$PKGDIR"/usr/share/polkit-1/rules.d

--- a/extra-admin/flatpak/autobuild/defines
+++ b/extra-admin/flatpak/autobuild/defines
@@ -10,6 +10,3 @@ AUTOTOOLS_AFTER="--disable-gtk-doc --with-priv-mode=setuid \
 PKGBREAK="xdg-app<=0.5.2 discover<=5.21.4 gnome-builder<=3.40.0 gnome-software<=40.0 \
           malcontent<=0.10.1 xdg-desktop-portal<=1.8.0"
 PKGREP="xdg-app<=0.5.2"
-
-ABSHADOW=0
-NOLTO=1

--- a/extra-admin/flatpak/spec
+++ b/extra-admin/flatpak/spec
@@ -1,6 +1,7 @@
 VER=1.11.2
 SRCS="tbl::https://github.com/flatpak/flatpak/releases/download/$VER/flatpak-$VER.tar.xz \
       file::rename=flathub.flatpakrepo::https://flathub.org/repo/flathub.flatpakrepo"
-CHKSUMS="sha256::8799cf835d8b11deef5495a91a4cef258d882417c4483fbd594a2c7cc79b6684"
+CHKSUMS="sha256::8799cf835d8b11deef5495a91a4cef258d882417c4483fbd594a2c7cc79b6684 \
+         sha256::3371dd250e61d9e1633630073fefda153cd4426f72f4afa0c3373ae2e8fea03a"
 CHKUPDATE="anitya::id=6377"
 SUBDIR="flatpak-$VER"

--- a/extra-admin/flatpak/spec
+++ b/extra-admin/flatpak/spec
@@ -1,4 +1,4 @@
-VER=1.10.2
-CHKSUMS="SKIP"
-SRCS="git::commit=tags/$VER::https://github.com/flatpak/flatpak"
-CHKSUMS="SKIP"
+VER=1.11.2
+SRCS="tbl::https://github.com/flatpak/flatpak/releases/download/$VER/flatpak-$VER.tar.xz"
+CHKSUMS="sha256sum::"
+CHKUPDATE="anitya::id=6377"

--- a/extra-admin/flatpak/spec
+++ b/extra-admin/flatpak/spec
@@ -1,4 +1,6 @@
 VER=1.11.2
-SRCS="tbl::https://github.com/flatpak/flatpak/releases/download/$VER/flatpak-$VER.tar.xz"
-CHKSUMS="sha256sum::"
+SRCS="tbl::https://github.com/flatpak/flatpak/releases/download/$VER/flatpak-$VER.tar.xz \
+      file::rename=flathub.flatpakrepo::https://flathub.org/repo/flathub.flatpakrepo"
+CHKSUMS="sha256::8799cf835d8b11deef5495a91a4cef258d882417c4483fbd594a2c7cc79b6684"
 CHKUPDATE="anitya::id=6377"
+SUBDIR="flatpak-$VER"

--- a/extra-devel/flatpak-builder/autobuild/defines
+++ b/extra-devel/flatpak-builder/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=flatpak-builder
+PKGSEC=devel
+PKGDEP="flatpak"
+BUILDDEP="docbook-xsl"
+PKGDES="A tool for building flatpaks from sources"

--- a/extra-devel/flatpak-builder/spec
+++ b/extra-devel/flatpak-builder/spec
@@ -1,0 +1,4 @@
+VER=1.0.14
+SRCS="tbl::https://github.com/flatpak/flatpak-builder/releases/download/$VER/flatpak-builder-$VER.tar.xz"
+CHKSUMS="sha256sum::"
+CHKUPDATE="anitya::id=16046"

--- a/extra-devel/flatpak-builder/spec
+++ b/extra-devel/flatpak-builder/spec
@@ -1,4 +1,4 @@
 VER=1.0.14
 SRCS="tbl::https://github.com/flatpak/flatpak-builder/releases/download/$VER/flatpak-builder-$VER.tar.xz"
-CHKSUMS="sha256sum::"
+CHKSUMS="sha256::69b65af4f63804127518c545184f9dfc9a9358cdedaabef2b1e50623ae2b8d8b"
 CHKUPDATE="anitya::id=16046"


### PR DESCRIPTION
Topic Description
-----------------

Flatpak: update to 1.11.2

Package(s) Affected
-------------------

```
flatpak
flatpak-builder
```

Security Update?
----------------
No

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Post-Merge Secondary Architectural Progress
-------------------------------------------


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

