### PR TITLE
pushpkg: update to 0+git20210813

### DIFF
--- a/extra-devel/pushpkg/spec
+++ b/extra-devel/pushpkg/spec
@@ -1,7 +1,9 @@
 VER=0+git20210813
-__COMMIT="9cf741a38ce057fae2ee27533d8b8b9bfce8e743"
-SRCS="file::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/pushpkg \
-      file::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/COPYING \
-      file::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/README.md"
-CHKSUMS="SKIP"
+__COMMIT="8e9caca7d560e5bd2c4056d8bf66b5e5b0b0e268"
+SRCS="file::rename=pushpkg::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/pushpkg \
+      file::rename=COPYING::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/COPYING \
+      file::rename=README.md::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/README.md"
+CHKSUMS="sha256::7e0231ddd167870a9a0b3019fbbb3b928b94663638aa7f1747feada362b834b2 \
+         sha256::992c720940396663b52389eea4c6a7409dd26b55ab3bfcd3a17f5da8b6d2a3c9 \
+         sha256::f8fbe6b5cf477e225de20d54ee01cca89b56cebc476b9e4712684ab445afaa21"
 SUBDIR="."

--- a/extra-devel/pushpkg/spec
+++ b/extra-devel/pushpkg/spec
@@ -1,4 +1,7 @@
-VER=0+git20210622
-SRCS="git::commit=517c8169b5e02837e649a82cceadb464934ff719::https://github.com/AOSC-Dev/scriptlets"
+VER=0+git20210813
+__COMMIT="9cf741a38ce057fae2ee27533d8b8b9bfce8e743"
+SRCS="file::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/pushpkg \
+      file::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/COPYING \
+      file::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/README.md"
 CHKSUMS="SKIP"
-SUBDIR="pushpkg/pushpkg"
+SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

pushpkg: update to 0+git20210813

Package(s) Affected
-------------------

`pushpkg`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

N/A

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] Architecture-independent `noarch`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

N/A
