### PR TITLE
Fix KDE chkupdate 20210814

### DIFF
--- a/extra-kde/kweather/spec
+++ b/extra-kde/kweather/spec
@@ -1,4 +1,4 @@
 VER=0.4
 SRCS="tbl::https://invent.kde.org/plasma-mobile/kweather/-/archive/$VER/kweather-$VER.tar.gz"
 CHKSUMS="sha256::94db92197a871d32a64117a4639e905f874f65f64e8975bf92c32f3fd31c70bd"
-CHKUPDATE="gitlab::repo=plasma-mobile/kweather;instance=https://invent.kde.org"
+CHKUPDATE="anitya::id=232020"

--- a/extra-kde/kweather/spec
+++ b/extra-kde/kweather/spec
@@ -1,4 +1,4 @@
 VER=0.4
 SRCS="tbl::https://invent.kde.org/plasma-mobile/kweather/-/archive/$VER/kweather-$VER.tar.gz"
 CHKSUMS="sha256::94db92197a871d32a64117a4639e905f874f65f64e8975bf92c32f3fd31c70bd"
-CHKUPDATE="gitlab::repo=plasma-mobile/kweather;intense=https://invent.kde.org"
+CHKUPDATE="gitlab::repo=plasma-mobile/kweather;instance=https://invent.kde.org"

--- a/extra-kde/kweathercore/spec
+++ b/extra-kde/kweathercore/spec
@@ -1,4 +1,4 @@
 VER=0.4
 SRCS="tbl::https://invent.kde.org/libraries/kweathercore/-/archive/v$VER/kweathercore-v$VER.tar.gz"
 CHKSUMS="sha256::cf2a9ea5fbf6d2507e0385f38de56232f7b977fa435cb0335a2e4a135b050de0"
-CHKUPDATE="gitlab::repo=libraries/kweathercore;intense=https://invent.kde.org"
+CHKUPDATE="anitya::id=232018"

--- a/extra-kde/qmlkonsole/spec
+++ b/extra-kde/qmlkonsole/spec
@@ -1,4 +1,3 @@
 VER=0+git20190224
 SRCS="git::commit=eac8318020e3881dac6d930fefd278b1f4a98617::https://invent.kde.org/jbbgameich/qmlkonsole.git"
 CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=229052"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Fix KDE chkupdate 20210814

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
