### PR TITLE
android-file-transfer: new, 4.2

### DIFF
--- a/extra-android/android-file-transfer/autobuild/defines
+++ b/extra-android/android-file-transfer/autobuild/defines
@@ -2,7 +2,5 @@ PKGNAME=android-file-transfer
 PKGSEC=utils
 PKGDES="Android MTP client with minimalistic UI"
 PKGDEP="qt-5 fuse libxkbcommon hicolor-icon-theme file"
-BUILDDEP="cmake"
 
-ABTYPE=cmake
 CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr"

--- a/extra-android/android-file-transfer/autobuild/defines
+++ b/extra-android/android-file-transfer/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=android-file-transfer
+PKGSEC=utils
+PKGDES="Android MTP client with minimalistic UI"
+PKGDEP="qt-5 fuse libxkbcommon hicolor-icon-theme file"
+BUILDDEP="cmake"
+
+ABTYPE=cmake
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr"

--- a/extra-android/android-file-transfer/spec
+++ b/extra-android/android-file-transfer/spec
@@ -1,4 +1,3 @@
 VER=4.2
 SRCS="tbl::https://github.com/whoozle/android-file-transfer-linux/archive/v${VER}.tar.gz"
 CHKSUMS="sha256::cc607d68e8a18273c9b56975a70a0e68fbdf9d5b903b2727a345a605ff48a19f"
-SUBDIR="android-file-transfer-linux-${VER}"

--- a/extra-android/android-file-transfer/spec
+++ b/extra-android/android-file-transfer/spec
@@ -1,3 +1,4 @@
 VER=4.2
 SRCS="tbl::https://github.com/whoozle/android-file-transfer-linux/archive/v${VER}.tar.gz"
 CHKSUMS="sha256::cc607d68e8a18273c9b56975a70a0e68fbdf9d5b903b2727a345a605ff48a19f"
+CHKUPDATE="anitya::id=13988"

--- a/extra-android/android-file-transfer/spec
+++ b/extra-android/android-file-transfer/spec
@@ -1,0 +1,4 @@
+VER=4.2
+SRCS="tbl::https://github.com/whoozle/android-file-transfer-linux/archive/v${VER}.tar.gz"
+CHKSUMS="sha256::cc607d68e8a18273c9b56975a70a0e68fbdf9d5b903b2727a345a605ff48a19f"
+SUBDIR="android-file-transfer-linux-${VER}"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Add `android-file-transfer`, a Android MTP client with minimalistic UI

Package(s) Affected
-------------------

- `android-file-transfer`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
