### PR TITLE
crow-translate: new, 2.8.4

### DIFF
--- a/extra-i18n/crow-translate/autobuild/defines
+++ b/extra-i18n/crow-translate/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=crow-translate
+PKGSEC=utils
+PKGDES="A simple and lightweight translator that allows to translate and say selected text using Google, Yandex and Bing translate API"
+PKGDEP="qt-5 gst-plugins-good-1-0 openssl tesseract"
+BUILDDEP="git extra-cmake-modules"
+
+CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCPACK_GENERATOR=DEB"

--- a/extra-i18n/crow-translate/spec
+++ b/extra-i18n/crow-translate/spec
@@ -1,0 +1,4 @@
+VER=2.8.4
+SRCS="tbl::https://github.com/crow-translate/crow-translate/archive/${VER}.tar.gz"
+CHKSUMS="sha256::119454f975c77de013b732323d7ba9121d85be73614fb0d34d0f14fdff6bf52a"
+CHKUPDATE="anitya::id=232133"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Add `crow-translate`, A simple and lightweight translator that allows you to translate and speak text using Google, Yandex and Bing. 

Package(s) Affected
-------------------

- `crow-translate`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

`tesseract` ( #3350 ) -> `crow-translate`


Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
