### PR TITLE
gifski: new, 1.5.0

### DIFF
--- a/extra-graphics/gifski/autobuild/defines
+++ b/extra-graphics/gifski/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=gifski
+PKGSEC=graphics
+PKGDES="GIF encoder based on libimagequant (pngquant). Squeezes maximum possible quality from the awful GIF format"
+BUILDDEP="rustc llvm"
+
+ABTYPE=rust
+USECLANG=1

--- a/extra-graphics/gifski/autobuild/defines
+++ b/extra-graphics/gifski/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=gifski
 PKGSEC=graphics
 PKGDES="GIF encoder based on libimagequant (pngquant). Squeezes maximum possible quality from the awful GIF format"
+PKGBREAK="peek<=1.5.1"
 BUILDDEP="rustc llvm"
 
 ABTYPE=rust

--- a/extra-graphics/gifski/spec
+++ b/extra-graphics/gifski/spec
@@ -1,0 +1,4 @@
+VER=1.5.0
+SRCS="tbl::https://github.com/ImageOptim/gifski/archive/${VER}.tar.gz"
+CHKSUMS="sha256::a55b285410c1558a5b6489b01d8dea1e28206220d383e6a2aa710378dfdc182c"
+CHKUPDATE="anitya::id=232227"

--- a/extra-graphics/peek/autobuild/defines
+++ b/extra-graphics/peek/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=peek
+REL=1
 PKGSEC=graphics
 PKGDES="Simple animated GIF screen recorder with an easy to use interface"
 PKGDEP="gtk-3 keybinder-3.0 ffmpeg which gst-plugins-good-1-0 gst-plugins-ugly-1-0 gifski"

--- a/extra-graphics/peek/autobuild/defines
+++ b/extra-graphics/peek/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME=peek
 PKGSEC=graphics
 PKGDES="Simple animated GIF screen recorder with an easy to use interface"
-PKGDEP="gtk-3 keybinder-3.0 ffmpeg which"
-BUILDDEP="git meson vala appstream-glib txt2man gst-plugins-good-1-0 gst-plugins-ugly-1-0"
-PKGRECOM="gst-plugins-good-1-0 gst-plugins-ugly-1-0 gifski"
+PKGDEP="gtk-3 keybinder-3.0 ffmpeg which gst-plugins-good-1-0 gst-plugins-ugly-1-0 gifski"
+BUILDDEP="git meson vala appstream-glib txt2man"
 
 ABTYPE=meson

--- a/extra-graphics/peek/autobuild/defines
+++ b/extra-graphics/peek/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=peek
 PKGSEC=graphics
 PKGDES="Simple animated GIF screen recorder with an easy to use interface"
-PKGDEP="gtk-3 keybinder-3.0 ffmpeg which gst-plugins-good-1-0 gst-plugins-ugly-1-0 gifski"
+PKGDEP="gtk-3 keybinder-3.0 ffmpeg which gst-plugins-good-1-0 gst-plugins-ugly-1-0 gifski xapps"
 BUILDDEP="git meson vala appstream-glib txt2man"
 
 ABTYPE=meson

--- a/extra-graphics/peek/autobuild/defines
+++ b/extra-graphics/peek/autobuild/defines
@@ -1,5 +1,4 @@
 PKGNAME=peek
-REL=1
 PKGSEC=graphics
 PKGDES="Simple animated GIF screen recorder with an easy to use interface"
 PKGDEP="gtk-3 keybinder-3.0 ffmpeg which gst-plugins-good-1-0 gst-plugins-ugly-1-0 gifski"

--- a/extra-graphics/peek/spec
+++ b/extra-graphics/peek/spec
@@ -1,4 +1,5 @@
 VER=1.5.1
+REL=1
 SRCS="tbl::https://github.com/phw/peek/archive/${VER}.tar.gz"
 CHKSUMS="sha256::d2b52297d3941db2f10ad4dd00a6d5606728c0fee6af5f1594a036f88e478237"
 CHKUPDATE="anitya::id=27551"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Add `gidski`, a GIF encoder based on libimagequant (pngquant). Squeezes maximum possible quality from the awful GIF format.

Package(s) Affected
-------------------

- `gifski`
- `peek`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

`gifski` -> `peek`


Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
