### PR TITLE
p-vector: new, 0.2.0

### DIFF
--- a/extra-admin/p-vector/autobuild/beyond
+++ b/extra-admin/p-vector/autobuild/beyond
@@ -1,0 +1,2 @@
+mkdir -pv "$PKGDIR"/usr/share/p-vector/
+install -Dvm644 "$SRCDIR"/config.toml "$PKGDIR"/usr/share/p-vector/config.toml.example

--- a/extra-admin/p-vector/autobuild/beyond
+++ b/extra-admin/p-vector/autobuild/beyond
@@ -1,2 +1,2 @@
-mkdir -pv "$PKGDIR"/usr/share/p-vector/
+abinfo "Installing example configuration files ..."
 install -Dvm644 "$SRCDIR"/config.toml "$PKGDIR"/usr/share/p-vector/config.toml.example

--- a/extra-admin/p-vector/autobuild/defines
+++ b/extra-admin/p-vector/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=p-vector
+PKGSEC=devel
+PKGDEP="systemd postgresql nettle xz openssl zeromq"
+PKGRECOM="sqlite-fdw gnupg"
+BUILDDEP="rustc llvm"
+PKGDES="An advanced deb package scanner"
+
+USECLANG=1
+USECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1
+ABSPLITDBG=0

--- a/extra-admin/p-vector/autobuild/defines
+++ b/extra-admin/p-vector/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=devel
 PKGDEP="systemd postgresql nettle xz openssl zeromq"
 PKGRECOM="sqlite-fdw gnupg"
 BUILDDEP="rustc llvm"
-PKGDES="A deb package scanner and metadata generator"
+PKGDES="A deb package scanner and APT metadata generator"
 
 USECLANG=1
 USECLANG__LOONGSON3=0

--- a/extra-admin/p-vector/autobuild/defines
+++ b/extra-admin/p-vector/autobuild/defines
@@ -6,6 +6,4 @@ BUILDDEP="rustc llvm"
 PKGDES="A deb package scanner and APT metadata generator"
 
 USECLANG=1
-USECLANG__LOONGSON3=0
-NOLTO__LOONGSON3=1
 ABSPLITDBG=0

--- a/extra-admin/p-vector/autobuild/defines
+++ b/extra-admin/p-vector/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=devel
 PKGDEP="systemd postgresql nettle xz openssl zeromq"
 PKGRECOM="sqlite-fdw gnupg"
 BUILDDEP="rustc llvm"
-PKGDES="An advanced deb package scanner"
+PKGDES="A deb package scanner and metadata generator"
 
 USECLANG=1
 USECLANG__LOONGSON3=0

--- a/extra-admin/p-vector/autobuild/prepare
+++ b/extra-admin/p-vector/autobuild/prepare
@@ -1,0 +1,11 @@
+abinfo "Preparing PostgreSQL ..."
+systemctl start postgresqld
+createdb -U postgres packages
+
+abinfo "Running migrations ..."
+for m in "$SRCDIR"/migrations/*.up.sql; do
+    abinfo "Applying $m ..."
+    psql -U postgres packages < "$m"
+done
+
+export DATABASE_URL="postgres://postgres@localhost/packages"

--- a/extra-admin/p-vector/spec
+++ b/extra-admin/p-vector/spec
@@ -1,0 +1,3 @@
+VER=0.2.0
+SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/p-vector-rs.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

The brand new `p-vector` implementation in Rust

Package(s) Affected
-------------------

`p-vector`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

