### PR TITLE
ghidra: update to 10.0.2, re-enable arm64

### DIFF
--- a/extra-devel/ghidra/autobuild/build
+++ b/extra-devel/ghidra/autobuild/build
@@ -5,10 +5,6 @@ sed -i 's/application.release.name=.*$/application.release.name=PUBLIC/' Ghidra/
 abinfo "Downloading dependencies ..."
 gradle --init-script gradle/support/fetchDependencies.gradle init
 
-abinfo "Moving Function ID database to the unpacking position ..."
-mkdir -p "$SRCDIR/../ghidra.bin/Ghidra/Features/FunctionID/src/main"
-mv -v "$SRCDIR/../ghidra-data" "$SRCDIR/../ghidra.bin/Ghidra/Features/FunctionID/src/main/fidb"
-
 abinfo "Compiling language module caches ..."
 gradle sleighCompile
 

--- a/extra-devel/ghidra/autobuild/defines
+++ b/extra-devel/ghidra/autobuild/defines
@@ -2,6 +2,8 @@ PKGNAME=ghidra
 PKGSEC=devel
 PKGDEP="openjdk"
 BUILDDEP="bison flex gradle"
+BUILDDEP__ARM64="${BUILDDEP} llvm"
 PKGDES="A suite of software reverse engineering (SRE) tools developed by NSA's Research Directorate"
 
-FAIL_ARCH="!(amd64)"
+FAIL_ARCH="!(amd64|arm64)"
+ABSPLITDBG=0

--- a/extra-devel/ghidra/autobuild/patches/0001-fix-build-arm64.patch
+++ b/extra-devel/ghidra/autobuild/patches/0001-fix-build-arm64.patch
@@ -1,22 +1,98 @@
---- a/build.gradle	2020-02-11 14:52:10.000000000 -0600
-+++ b/build.gradle	2020-10-17 20:55:12.870240241 -0500
-@@ -263,7 +263,7 @@
- 	String archName = System.getProperty("os.arch")
- 		
- 	boolean isX86_32 = archName.equals("x86") || archName.equals("i386");
--	boolean isX86_64 = archName.equals("x86_64") || archName.equals("amd64");
-+	boolean isX86_64 = archName.equals("x86_64") || archName.equals("amd64") || archName.equals("aarch64");
- 
- 	if (osName.startsWith("Windows")) {
- 		if (isX86_32) {
---- a/Ghidra/Features/Decompiler/src/decompile/cpp/types.h	2020-02-11 14:52:10.000000000 -0600
-+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/types.h	2020-10-17 21:27:15.310873475 -0500
-@@ -86,7 +86,7 @@
- typedef uint4 uintp;
+diff --git a/Ghidra/Features/Decompiler/src/decompile/cpp/types.h b/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
+index d10906637..3c374556a 100644
+--- a/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
++++ b/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
+@@ -101,6 +101,21 @@ typedef char int1;
+ typedef uint8 uintp;
  #endif
  
--#if defined (__linux__) && defined (__x86_64__)
-+#if defined (__linux__) && (defined (__x86_64__) || defined (__aarch64__))
- #define HOST_ENDIAN 0
- typedef unsigned int uintm;
- typedef int intm;
++#if defined (__linux__) && defined (__aarch64__) && defined(__LP64__)
++#define HOST_ENDIAN 0
++typedef unsigned int uintm;
++typedef int intm;
++typedef unsigned long uint8;
++typedef long int8;
++typedef unsigned int uint4;
++typedef int int4;
++typedef unsigned short uint2;
++typedef short int2;
++typedef unsigned char uint1;
++typedef char int1;
++typedef uint8 uintp;
++#endif
++
+ #if defined(_WINDOWS)
+ 
+ #if defined(_WIN64)
+diff --git a/build.gradle b/build.gradle
+index 0df62fc36..2251b6041 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -295,6 +295,9 @@ String getCurrentPlatformName() {
+ 		if (isX86_64) {
+ 			return 'linux64'
+ 		}
++		if (isAARCH_64) {
++			return 'linux64'
++		}
+ 	}
+ 	else if (osName.startsWith("Mac OS X")) {
+ 		if (isX86_64) {
+diff --git a/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile b/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile
+index a19dfe4a9..b4496f998 100644
+--- a/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile
++++ b/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile
+@@ -18,7 +18,7 @@ ifndef ARCH
+   ARCH=$(CPU)
+ endif
+ ifeq ($(ARCH),x86_64)
+-  ARCH_TYPE=-m64
++  ARCH_TYPE=
+   OSDIR=linux64
+ else
+   ARCH_TYPE=-m32
+diff --git a/Ghidra/Debug/Debugger-gadp/build.gradle b/Ghidra/Debug/Debugger-gadp/build.gradle
+index 86185f5b4..c45da9f02 100644
+--- a/Ghidra/Debug/Debugger-gadp/build.gradle
++++ b/Ghidra/Debug/Debugger-gadp/build.gradle
+@@ -33,7 +33,11 @@ configurations {
+ def os = org.gradle.internal.os.OperatingSystem.current()
+ 
+ dependencies {
++	String archName = System.getProperty("os.arch")
++	boolean isAARCH_64 = archName.equals("aarch64")
++
+ 	allProtocArtifacts 'com.google.protobuf:protoc:3.11.1:windows-x86_64@exe'
++    allProtocArtifacts 'com.google.protobuf:protoc:3.11.1:linux-aarch_64@exe'
+     allProtocArtifacts 'com.google.protobuf:protoc:3.11.1:linux-x86_64@exe'
+     allProtocArtifacts 'com.google.protobuf:protoc:3.11.1:osx-x86_64@exe'
+ 
+@@ -41,7 +45,11 @@ dependencies {
+     	protocArtifact 'com.google.protobuf:protoc:3.11.1:windows-x86_64@exe'
+ 	}
+ 	if (os.isLinux()) {
+-    	protocArtifact 'com.google.protobuf:protoc:3.11.1:linux-x86_64@exe'
++		if (isAARCH_64) {
++		    	protocArtifact 'com.google.protobuf:protoc:3.11.1:linux-aarch_64@exe'
++		} else {
++		    	protocArtifact 'com.google.protobuf:protoc:3.11.1:linux-x86_64@exe'
++		}
+ 	}
+ 	if (os.isMacOsX()) {
+     	protocArtifact 'com.google.protobuf:protoc:3.11.1:osx-x86_64@exe'
+diff --git a/Ghidra/Debug/Framework-Debugging/build.gradle b/Ghidra/Debug/Framework-Debugging/build.gradle
+index 841b955a2..413073c22 100644
+--- a/Ghidra/Debug/Framework-Debugging/build.gradle
++++ b/Ghidra/Debug/Framework-Debugging/build.gradle
+@@ -134,6 +134,11 @@ model {
+ 				linker.args("-lpthread")
+ 				linker.args("-lutil")
+ 			}
++			if (toolChain in Clang) {
++				cCompiler.args("-std=c99")
++				linker.args("-lpthread")
++				linker.args("-lutil")
++			}
+ 			if (toolChain in VisualCpp) {
+ 				cppCompiler.define("VS_PROJECT")
+ 				// NB. No /SUBSYSTEM:CONSOLE

--- a/extra-devel/ghidra/spec
+++ b/extra-devel/ghidra/spec
@@ -1,7 +1,5 @@
-VER=9.2.2
-SRCS="tbl::https://github.com/NationalSecurityAgency/ghidra/archive/Ghidra_${VER}_build.tar.gz \
-      git::commit=60529abb6c1e28b689f539384a1ebd1fe13d6528;rename=ghidra-data::https://github.com/NationalSecurityAgency/ghidra-data"
-CHKSUMS="sha256::2db5d3b7a09d097b1d0003630ec0042744eba3b9bed8a60e8b0f8c77dc433391 \
-         SKIP"
+VER=10.0.2
+SRCS="git::commit=tags/Ghidra_${VER}_build;rename=ghidra::https://github.com/NationalSecurityAgency/ghidra"
+SUBDIR="ghidra"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227013"
-SUBDIR="ghidra-Ghidra_${VER}_build"


### PR DESCRIPTION
Topic Description
-----------------

Update Ghidra to newest (10.0.2) and patch it to be able to be built on ARM64.

Package(s) Affected
-------------------

- `ghidra`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

<!-- TODO: CI to auto-fill architectural progress. -->
