### PR TITLE
fisher: update to 4.3.0, rename from fisherman

### DIFF
--- a/extra-shells/fisher/autobuild/build
+++ b/extra-shells/fisher/autobuild/build
@@ -1,0 +1,2 @@
+install -Dvm644 functions/fisher.fish "$PKGDIR"/usr/share/fish/vendor_functions.d/fisher.fish
+install -Dvm644 completions/fisher.fish "$PKGDIR"/usr/share/fish/vendor_completions.d/fisher.fish

--- a/extra-shells/fisher/autobuild/defines
+++ b/extra-shells/fisher/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=fisher
+PKGSEC=shells
+PKGDEP="fish"
+PKGDES="A plugin manager for the Fish shell"
+
+PKGREP="fisherman<=3.2.7"
+PKGBREAK="fisherman<=3.2.7"
+
+ABHOST=noarch

--- a/extra-shells/fisher/spec
+++ b/extra-shells/fisher/spec
@@ -1,0 +1,4 @@
+VER=4.3.0
+SRCS="tbl::https://github.com/jorgebucaran/fisher/archive/$VER.tar.gz"
+CHKSUMS="sha256::6235cfc636c8d52f11feca9f4931656a9c6602659b06df8dba5a3606d37f8c28"
+CHKUPDATE="anitya::id=231509"

--- a/extra-shells/fisherman/autobuild/build
+++ b/extra-shells/fisherman/autobuild/build
@@ -1,1 +1,0 @@
-install -Dm644 fisher.fish "$PKGDIR"/usr/share/fish/functions/fisher.fish

--- a/extra-shells/fisherman/autobuild/defines
+++ b/extra-shells/fisherman/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=fisherman
 PKGSEC=shells
-PKGDEP="fish"
-PKGDES="A plugin manager for the Fish shell"
+PKGDEP="fisher"
+PKGDES="Transitional package for fisher"
 
+PKGEPOCH=1
 ABHOST=noarch
+ABTYPE=dummy

--- a/extra-shells/fisherman/spec
+++ b/extra-shells/fisherman/spec
@@ -1,4 +1,2 @@
-VER=3.2.7
-SRCS="tbl::https://github.com/fisherman/fisherman/archive/$VER.tar.gz"
-CHKSUMS="sha256::2c9813d2e116475701368cbaa455f7919ad6d3807a1e9df94b30b75afaf65102"
-CHKUPDATE="anitya::id=231509"
+VER=0
+DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

rename `fisherman` to `fisher`, update `fisher` to 4.3.0, 

Package(s) Affected
-------------------

fisherman, fisher

Security Update?
----------------

No

Architectural Progress
----------------------

- [ ] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] Architecture-independent `noarch`