### PR TITLE
docbook-dtd: mark PKGBREAK and PKGREP

### DIFF
--- a/extra-doc/docbook-dtd/autobuild/defines
+++ b/extra-doc/docbook-dtd/autobuild/defines
@@ -3,5 +3,7 @@ PKGDES="SGML and XML document type definitions for DocBook"
 PKGSEC=misc
 PKGDEP="libxml2 sgml-common"
 BUILDDEP="unzip"
+PKGBREAK="docbook-xml<=4.5-4 docbook-sgml<=4.5-3"
+PKGREP="${PKGBREAK}"
 
 ABHOST=noarch

--- a/extra-doc/docbook-dtd/spec
+++ b/extra-doc/docbook-dtd/spec
@@ -1,4 +1,5 @@
 VER=4.5
+REL=1
 SRCS="file::rename=docbook-3.0.zip::https://www.oasis-open.org/docbook/sgml/3.0/docbk30.zip \
       file::rename=docbook-3.1.zip::https://www.oasis-open.org/docbook/sgml/3.1/docbk31.zip \
       file::rename=docbook-4.0.zip::https://www.oasis-open.org/docbook/sgml/4.0/docbk40.zip \


### PR DESCRIPTION
Topic Description
-----------------

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
