### PR TITLE
systemd-boot-friend: update to 0.7.2

### DIFF
--- a/extra-admin/systemd-boot-friend/spec
+++ b/extra-admin/systemd-boot-friend/spec
@@ -1,5 +1,4 @@
-VER=0.7.1
-REL=1
+VER=0.7.2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/systemd-boot-friend-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226819"

--- a/extra-kernel/dracut/autobuild/overrides/usr/bin/update-initramfs
+++ b/extra-kernel/dracut/autobuild/overrides/usr/bin/update-initramfs
@@ -24,7 +24,7 @@ if ! systemd-detect-virt -cq; then
     if [[ -x /usr/bin/grub-mkconfig ]]; then
 	    echo -e "\033[36m**\033[0m\tUpdating GRUB for the new kernel..."
         grub-mkconfig -o /boot/grub/grub.cfg
-    elif [[ -x /usr/bin/systemd-boot-friend && -r /etc/systemd-boot-friend.conf ]]; then
+    elif [[ -x /usr/bin/systemd-boot-friend && -r /etc/systemd-boot-friend.conf && -e /usr/lib/modules/* ]]; then
 	    echo -e "\033[36m**\033[0m\tUpdating systemd-boot for the new kernel..."
         systemd-boot-friend install
     else

--- a/extra-kernel/dracut/spec
+++ b/extra-kernel/dracut/spec
@@ -1,5 +1,5 @@
 VER=055
-REL=1
+REL=2
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/boot/dracut/dracut-$VER.tar.xz"
 CHKSUMS="sha256::4baa08206cceeb124dbf1075a0daf774b5a8f144ce2e01d82a144af3020fd65b"
 CHKUPDATE="anitya::id=10627"


### PR DESCRIPTION
Topic Description
-----------------

Update systemd-boot-friend to 0.7.2

Package(s) Affected
-------------------

dracut, systemd-boot-friend

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

`dracut`
- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

`dracut`
- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`