### PR TITLE
makemkv: new, 1.16.4

### DIFF
--- a/extra-multimedia/makemkv/autobuild/beyond
+++ b/extra-multimedia/makemkv/autobuild/beyond
@@ -1,0 +1,20 @@
+abinfo "Installing closed-source parts ..."
+pushd "$SRCDIR/../makemkv-bin-$PKGVER"
+
+abinfo "Accepting to the EULA ..."
+mkdir -pv tmp/
+# set the flag for unattended installation
+echo "accepted" | tee tmp/eula_accepted
+
+abinfo "Copying files ..."
+make install DESTDIR="$PKGDIR" PREFIX=/usr
+
+abinfo "Copying licenses ..."
+mkdir -pv "$PKGDIR/usr/share/makemkv/"
+install -Dvm644 "$SRCDIR/../makemkv-bin-$PKGVER/src/eula_en_linux.txt" "$PKGDIR/usr/share/makemkv/"
+install -Dvm644 "$SRCDIR/License.txt" "$SRCDIR/LICENSE"
+
+abinfo "Fixing permission bits ..."
+chmod -v a+x "$PKGDIR/usr/lib/"*
+
+popd

--- a/extra-multimedia/makemkv/autobuild/beyond
+++ b/extra-multimedia/makemkv/autobuild/beyond
@@ -17,4 +17,8 @@ install -Dvm644 "$SRCDIR/License.txt" "$SRCDIR/LICENSE"
 abinfo "Fixing permission bits ..."
 chmod -v a+x "$PKGDIR/usr/lib/"*
 
+abinfo "Installing modprobe hooks ..."
+mkdir -pv "$PKGDIR/usr/lib/modules-load.d/"
+echo 'sg' > "$PKGDIR/usr/lib/modules-load.d/makemkv-sg.conf"
+
 popd

--- a/extra-multimedia/makemkv/autobuild/defines
+++ b/extra-multimedia/makemkv/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=makemkv
+PKGSEC="non-free/video"
+PKGDES="A converter to convert video clips from proprietary discs into a set of MKV files"
+PKGDEP="zlib qt-5 mesa openssl ffmpeg expat"
+
+# License issues
+ABSTRIP=0
+ABSPLITDBG=0
+ABSHADOW=0
+RECONF=0

--- a/extra-multimedia/makemkv/autobuild/defines
+++ b/extra-multimedia/makemkv/autobuild/defines
@@ -6,5 +6,6 @@ PKGDEP="zlib qt-5 mesa openssl ffmpeg expat"
 # License issues
 ABSTRIP=0
 ABSPLITDBG=0
+
 ABSHADOW=0
 RECONF=0

--- a/extra-multimedia/makemkv/autobuild/postinst
+++ b/extra-multimedia/makemkv/autobuild/postinst
@@ -1,0 +1,4 @@
+cat << EOF
+By installing MakeMKV, you agree to the EULA of this software.
+A copy of the EULA is available at /usr/share/makemkv/eula_en_linux.txt. If you do not read and agree to this EULA, please uninstall this package.
+EOF

--- a/extra-multimedia/makemkv/autobuild/postinst
+++ b/extra-multimedia/makemkv/autobuild/postinst
@@ -1,3 +1,6 @@
+echo "Loading necessary kernel modules ..."
+modprobe -v sg
+
 cat << EOF
 By installing MakeMKV, you agree to the EULA of this software.
 A copy of the EULA is available at /usr/share/makemkv/eula_en_linux.txt.

--- a/extra-multimedia/makemkv/autobuild/postinst
+++ b/extra-multimedia/makemkv/autobuild/postinst
@@ -1,4 +1,5 @@
 cat << EOF
 By installing MakeMKV, you agree to the EULA of this software.
-A copy of the EULA is available at /usr/share/makemkv/eula_en_linux.txt. If you do not read and agree to this EULA, please uninstall this package.
+A copy of the EULA is available at /usr/share/makemkv/eula_en_linux.txt.
+If you do not read and agree to this EULA, please uninstall this package.
 EOF

--- a/extra-multimedia/makemkv/spec
+++ b/extra-multimedia/makemkv/spec
@@ -1,0 +1,7 @@
+VER=1.16.4
+SRCS="tbl::https://www.makemkv.com/download/makemkv-bin-$VER.tar.gz \
+      tbl::https://www.makemkv.com/download/makemkv-oss-$VER.tar.gz"
+# package oss parts first
+SUBDIR="makemkv-oss-$VER"
+CHKSUMS="sha256::22fbd3f57e93f3c79a76c878202fb27e85f2d66de26b3be87b69198228a66aa2 \
+         sha256::e6b0d391159e60c48c115cdf6938eb02f5aeef3c3fecf94813c500f4031e4f6b"


### PR DESCRIPTION
Topic Description
-----------------

makemkv: new, 1.16.4

Package(s) Affected
-------------------

`makemkv`

Security Update?
----------------

No

Architectural Progress
----------------------

- [X] AMD64 `amd64`   
- [X] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

N/A

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`



Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

N/A
