### PR TITLE
aosc-os-repository-data: update to 20210819

### DIFF
--- a/extra-misc/aosc-os-repository-data/spec
+++ b/extra-misc/aosc-os-repository-data/spec
@@ -1,4 +1,4 @@
-VER=20200929
-SRCS="git::commit=295d8f4dbf571f5945cfc48439be9af18c41220a::https://github.com/AOSC-Dev/aosc-os-repository-data"
+VER=20210819
+SRCS="git::commit=tags/v{$VER}::https://github.com/AOSC-Dev/aosc-os-repository-data"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230634"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Update `aosc-os-repository-data`.

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`aosc-os-repository-data`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- - [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64` -->
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [ ] Architecture-independent `noarch`



----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- - [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64` -->
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [ ] Architecture-independent `noarch`

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- TODO: CI to auto-fill architectural progress. -->
