### PR TITLE
typing: 3.10.0.0

### DIFF
--- a/extra-doc/sphinx/autobuild/defines
+++ b/extra-doc/sphinx/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=sphinx
 PKGSEC=python
 PKGDEP="alabaster babel docutils jinja2 pygments six snowballstemmer \
-        sphinx-rtd-theme imagesize requests typing \
+        sphinx-rtd-theme imagesize requests \
         sphinxcontrib-applehelp sphinxcontrib-devhelp \
         sphinxcontrib-htmlhelp sphinxcontrib-jsmath sphinxcontrib-qthelp \
         sphinxcontrib-serializinghtml sphinxcontrib-websupport"

--- a/extra-doc/sphinx/spec
+++ b/extra-doc/sphinx/spec
@@ -1,4 +1,4 @@
-VER=3.5.1
+VER=4.1.2
 SRCS="tbl::https://pypi.io/packages/source/S/Sphinx/Sphinx-$VER.tar.gz"
-CHKSUMS="sha256::11d521e787d9372c289472513d807277caafb1684b33eb4f08f7574c405893a9"
+CHKSUMS="sha256::3092d929cd807926d846018f2ace47ba2f3b671b309c7a89cd3306e80c826b13"
 CHKUPDATE="anitya::id=4031"

--- a/extra-python/m2crypto/autobuild/defines
+++ b/extra-python/m2crypto/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=m2crypto
 PKGSEC=python
-PKGDEP="openssl python-3 typing"
+PKGDEP="openssl python-3"
 BUILDDEP="swig"
 PKGDES="A cyptography and SSL toolkit for Python"

--- a/extra-python/m2crypto/spec
+++ b/extra-python/m2crypto/spec
@@ -1,4 +1,4 @@
-VER=0.31.0
+VER=0.38.0
 REL=3
 SRCS="tbl::https://pypi.io/packages/source/M/M2Crypto/M2Crypto-$VER.tar.gz"
 CHKSUMS="sha256::fd59a9705275d609948005f4cbcaf25f28a4271308237eb166169528692ce498"

--- a/extra-python/m2crypto/spec
+++ b/extra-python/m2crypto/spec
@@ -1,5 +1,5 @@
 VER=0.38.0
 REL=3
 SRCS="tbl::https://pypi.io/packages/source/M/M2Crypto/M2Crypto-$VER.tar.gz"
-CHKSUMS="sha256::fd59a9705275d609948005f4cbcaf25f28a4271308237eb166169528692ce498"
+CHKSUMS="sha256::99f2260a30901c949a8dc6d5f82cd5312ffb8abc92e76633baf231bbbcb2decb"
 CHKUPDATE="anitya::id=212340"

--- a/extra-python/poetry-core/spec
+++ b/extra-python/poetry-core/spec
@@ -1,4 +1,4 @@
 VER=1.0.3
 SRCS="https://pypi.io/packages/source/p/poetry-core/poetry-core-${VER}.tar.gz"
-CHKSUMS="sha256::6a664ff389b9f45382536f8fa1611a0cb4d2de7c5a5c885db1f0c600cd11fbd5"
+CHKSUMS="sha256::2315c928249fc3207801a81868b64c66273077b26c8d8da465dccf8f488c90c5"
 CHKUPDATE="anitya::id=71155"

--- a/extra-python/poetry-core/spec
+++ b/extra-python/poetry-core/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.3
 SRCS="https://pypi.io/packages/source/p/poetry-core/poetry-core-${VER}.tar.gz"
 CHKSUMS="sha256::6a664ff389b9f45382536f8fa1611a0cb4d2de7c5a5c885db1f0c600cd11fbd5"
 CHKUPDATE="anitya::id=71155"

--- a/extra-python/typing-extensions/spec
+++ b/extra-python/typing-extensions/spec
@@ -1,4 +1,4 @@
-VER=3.7.4.3
+VER=3.10.0.0
 SRCS="tbl::https://pypi.io/packages/source/t/typing_extensions/typing_extensions-$VER.tar.gz"
-CHKSUMS="sha256::99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"
+CHKSUMS="sha256::50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"
 CHKUPDATE="anitya::id=33844"

--- a/extra-python/typing/autobuild/defines
+++ b/extra-python/typing/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=typing
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 BUILDDEP="setuptools"
 PKGDES="Type Hints for Python"
 
 ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/typing/spec
+++ b/extra-python/typing/spec
@@ -1,4 +1,4 @@
-VER=3.7.4.3
+VER=3.10.0.0
 SRCS="https://pypi.io/packages/source/t/typing/typing-$VER.tar.gz"
-CHKSUMS="sha256::1187fb9c82fd670d10aa07bbb6cfcfe4bdda42d6fab8d5134f04e8c4d0b71cc9"
+CHKSUMS="sha256::13b4ad211f54ddbf93e5901a9967b1e07720c1d1b78d596ac6a439641aa1b130"
 CHKUPDATE="anitya::id=10922"


### PR DESCRIPTION
Topic Description
-----------------
* update `typing` and `typing-extensions` to 3.10.0.0
* update `sphnix`,`poetry-core`, `m2crypto`
* make `typing` de-python2-ized

Package(s) Affected
-------------------
* `typing`, `typing-extensions`, `sphnix`, `poetry-core`, `m2crypto`

Security Update?
----------------
No


Build Order
-----------
* `typing`, `typing-extensions`
* `sphnix` `m2crypto` `poetry-core`

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
