### PR TITLE
fcitx5-pinyin-moegirl: update, 20210815

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/01-fcitx5-pinyin-moegirl/build
+++ b/extra-i18n/fcitx5-pinyin-moegirl/01-fcitx5-pinyin-moegirl/build
@@ -5,5 +5,5 @@ install -vDm644 "$SRCDIR"/moegirl.dict \
 
 abinfo "Installing LICENSE..."
 mkdir -p "$PKGDIR"/usr/share/doc/fcitx5-pinyin-moegirl
-install -vm644 "$SRCDIR"/mw2fcitx-$PKGVER/LICENSE.content \
+install -vm644 "$SRCDIR"/LICENSE \
 	"$PKGDIR"/usr/share/doc/fcitx5-pinyin-moegirl/LICENSE

--- a/extra-i18n/fcitx5-pinyin-moegirl/01-fcitx5-pinyin-moegirl/build
+++ b/extra-i18n/fcitx5-pinyin-moegirl/01-fcitx5-pinyin-moegirl/build
@@ -2,8 +2,3 @@ abinfo "Install fcitx5-pinyin-moegirl dict file to $PKGDIR..."
 mkdir -p "$PKGDIR"/usr/share/fcitx5/pinyin/dictionaries/
 install -vDm644 "$SRCDIR"/moegirl.dict \
 	-t "$PKGDIR"/usr/share/fcitx5/pinyin/dictionaries/
-
-abinfo "Installing LICENSE..."
-mkdir -p "$PKGDIR"/usr/share/doc/fcitx5-pinyin-moegirl
-install -vm644 "$SRCDIR"/LICENSE \
-	"$PKGDIR"/usr/share/doc/fcitx5-pinyin-moegirl/LICENSE

--- a/extra-i18n/fcitx5-pinyin-moegirl/02-rime-pinyin-moegirl/build
+++ b/extra-i18n/fcitx5-pinyin-moegirl/02-rime-pinyin-moegirl/build
@@ -2,9 +2,3 @@ abinfo "Install rime-pinyin-moegirl dict file to $PKGDIR..."
 mkdir -pv "$PKGDIR"/usr/share/rime-data
 install -vDm644 "$SRCDIR"/moegirl.dict.yaml \
 	-t "$PKGDIR"/usr/share/rime-data
-
-abinfo "Installing LICENSE..."
-mkdir -pv "$PKGDIR"/usr/share/doc/rime-pinyin-moegirl
-install -vm644 "$SRCDIR"/LICENSE \
-        "$PKGDIR"/usr/share/doc/rime-pinyin-moegirl/LICENSE
-

--- a/extra-i18n/fcitx5-pinyin-moegirl/02-rime-pinyin-moegirl/build
+++ b/extra-i18n/fcitx5-pinyin-moegirl/02-rime-pinyin-moegirl/build
@@ -5,6 +5,6 @@ install -vDm644 "$SRCDIR"/moegirl.dict.yaml \
 
 abinfo "Installing LICENSE..."
 mkdir -pv "$PKGDIR"/usr/share/doc/rime-pinyin-moegirl
-install -vm644 "$SRCDIR"/mw2fcitx-$PKGVER/LICENSE.content \
+install -vm644 "$SRCDIR"/LICENSE \
         "$PKGDIR"/usr/share/doc/rime-pinyin-moegirl/LICENSE
 

--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20210717
+VER=20210815
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
-      tbl::https://github.com/outloudvi/mw2fcitx/archive/$VER.tar.gz"
-CHKSUMS="sha256::ff527856363c89725a0acf1fef7dae902a1fe9c9a245596762d6067af02c1b6d \
-         sha256::f18996d0a42f24cb5cac523b60c0378977cc7f42acacfbef1f23836755d61594 \
-         sha256::7f974201258d5a616932117f8525006305ff95815c6773aa9a192b56eba26289"
+      file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
+CHKSUMS="sha256::2fdd19dde4d2d2bb472fe98ed03a2938c1343c5dd6a9fe8ffb5461ba33c4b711 \
+         sha256::c23b2e2bfab1511ea2bf991eba0566135c17452eadea3e42a49a739600b4dc59 \
+         sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Upgrade `fcitx5-pinyin-moegirl` to 20210815.

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl
* rime-pinyin-moegirl

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`