### PR TITLE
ykdl: update to 1.8.1~a2

### DIFF
--- a/extra-multimedia/ykdl/spec
+++ b/extra-multimedia/ykdl/spec
@@ -1,4 +1,4 @@
-VER=1.6.3+git20210410
-SRCS="git::commit=85ae82d520ea3d2fa1f9b52d82d052f5157aa4a7::https://github.com/zhangn1985/ykdl.git"
-CHKSUMS="SKIP"
+VER=1.8.0~a2
+SRCS="tbl::https://github.com/SeaHOH/ykdl/archive/refs/tags/v${VER/\~}.tar.gz"
+CHKSUMS="sha256::b5ad62f83ceb191784a369d28bce4f11bd724c227fa584abfed4d01323824574"
 CHKUPDATE="anitya::id=202874"


### PR DESCRIPTION

Topic Description
-----------------
* update `ykdl` to 1.8.1~a2

Package(s) Affected
-------------------
* `ykdl`

Security Update?
----------------
No

Architectural Progress
----------------------
<!-- - [ ] Architecture-independent `noarch` -->


----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
<!-- - [ ] Architecture-independent `noarch` -->
