### PR TITLE
typing: update to 3.10.0.0, rework

### DIFF
--- a/extra-python/m2crypto/spec
+++ b/extra-python/m2crypto/spec
@@ -1,5 +1,4 @@
 VER=0.38.0
-REL=3
 SRCS="tbl::https://pypi.io/packages/source/M/M2Crypto/M2Crypto-$VER.tar.gz"
 CHKSUMS="sha256::99f2260a30901c949a8dc6d5f82cd5312ffb8abc92e76633baf231bbbcb2decb"
 CHKUPDATE="anitya::id=212340"


### PR DESCRIPTION
Topic Description
-----------------

* rework for `typing 3.10.0.0`
* remove REL for `m2crypto`

Package(s) Affected
-------------------

* m2crypto

Security Update?
----------------
No

Architectural Progress
----------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
