### PR TITLE
PKGSEC Survey 20210824

### DIFF
--- a/extra-admin/archlinux-keyring/autobuild/defines
+++ b/extra-admin/archlinux-keyring/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=archlinux-keyring
-PKGDES="Arch Linux PGP keyring"
+PKGSEC=admin
 PKGDEP="gnupg pacman"
-PKGSEC="admin"
+PKGDES="Arch Linux PGP keyring"
 
 ABHOST=noarch

--- a/extra-admin/archlinux-keyring/spec
+++ b/extra-admin/archlinux-keyring/spec
@@ -2,3 +2,4 @@ VER=20210616
 SRCS="https://sources.archlinux.org/other/archlinux-keyring/archlinux-keyring-${VER}.tar.gz"
 CHKSUMS="sha256::2dba395bc41cb3fb92256ae715d54d57b39f1f909e2f5f5160cdcc3cd8b0a8a9"
 CHKUPDATE="anitya::id=103"
+REL=1

--- a/extra-admin/bolt/autobuild/defines
+++ b/extra-admin/bolt/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=bolt
-PKGDES="Thunderbolt 3 device manager"
+PKGSEC=admin
 PKGDEP="polkit systemd"
 BUILDDEP="asciidoc"
+PKGDES="Thunderbolt 3 device manager"

--- a/extra-admin/bolt/spec
+++ b/extra-admin/bolt/spec
@@ -1,5 +1,5 @@
 VER=0.9
-REL=1
+REL=2
 SRCS="tbl::https://gitlab.freedesktop.org/bolt/bolt/-/archive/${VER}/bolt-${VER}.tar.gz"
 CHKSUMS="sha256::49fe4cb2cd3361fd104f9c2cd7cbbf791e867038590a968dc39377b27008969a"
 CHKUPDATE="anitya::id=17645"

--- a/extra-devel/gammaray/autobuild/defines
+++ b/extra-devel/gammaray/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=gammaray
-PKGDES="A Qt introspection tool"
+PKGSEC=devel
 PKGDEP="qt-5 graphviz kdsme syntax-highlighting kcoreaddons"
 BUILDDEP="doxygen llvm gdb glslang"
+PKGDES="A Qt introspection tool"
 
 CMAKE_AFTER="-DBGAMMARAY_INSTALL_QT_LAYOU=ON \
              -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt5/mkspecs/modules \
              -DPLUGIN_INSTALL_DIR=/usr/lib/qt5/plugins/gammaray"
-
-ABSHADOW=no
+ABSHADOW=0

--- a/extra-devel/gammaray/spec
+++ b/extra-devel/gammaray/spec
@@ -1,5 +1,5 @@
 VER=2.11.2
-REL=1
+REL=2
 SRCS="tbl::https://github.com/KDAB/GammaRay/releases/download/v${VER}/gammaray-${VER}.tar.gz"
 CHKSUMS="sha256::bba4f21a2bc81ec8ab50dce5218c7a375b92d64253c690490a6fcb384c2ff9f3"
 CHKUPDATE="anitya::id=5320"

--- a/extra-devel/kdsme/autobuild/defines
+++ b/extra-devel/kdsme/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=kdsme
+PKGSEC=devel
 PKGDES="KDAB State Machine Editor, a state machine editing library"
 PKGDEP="qt-5 graphviz"
 BUILDDEP="doxygen"

--- a/extra-devel/kdsme/spec
+++ b/extra-devel/kdsme/spec
@@ -1,5 +1,5 @@
 VER=1.2.8
-REL=2
+REL=3
 SRCS="tbl::https://github.com/KDAB/KDStateMachineEditor/releases/download/v${VER}/kdstatemachineeditor-${VER}.tar.gz"
 CHKSUMS="sha256::8676276debd1f8333794aba08d643660f36b698ca4c9711ce0a03c7a84f03e0c"
 CHKUPDATE="anitya::id=227020"

--- a/extra-libs/clblas/autobuild/beyond
+++ b/extra-libs/clblas/autobuild/beyond
@@ -1,0 +1,4 @@
+if [ -d "$PKGDIR"/usr/lib64 ]; then
+    abinfo "Moving /usr/lib64 => /usr/lib ..."
+    mv -v "$PKGDIR"/usr/lib{64,}
+fi

--- a/extra-libs/clblas/autobuild/build
+++ b/extra-libs/clblas/autobuild/build
@@ -1,9 +1,0 @@
-cd $SRCDIR/src
-
-mkdir -p build
-cd build
-
-cmake .. -DBUILD_TEST=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
-
-make
-make install DESTDIR="$PKGDIR"

--- a/extra-libs/clblas/autobuild/defines
+++ b/extra-libs/clblas/autobuild/defines
@@ -1,3 +1,4 @@
 PKGNAME=clblas
-PKGDES="The OpenCL BLAS portion of clMath."
+PKGSEC=libs
 PKGDEP="libcl boost opencl-registry-api"
+PKGDES="Library containing BLAS functions written in OpenCL"

--- a/extra-libs/clblas/autobuild/defines
+++ b/extra-libs/clblas/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=clblas
 PKGSEC=libs
 PKGDEP="libcl boost opencl-registry-api"
 PKGDES="Library containing BLAS functions written in OpenCL"
+
+CMAKE_AFTER="-DBUILD_TEST=OFF"

--- a/extra-libs/clblas/spec
+++ b/extra-libs/clblas/spec
@@ -2,4 +2,5 @@ VER=2.12
 REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/clMathLibraries/clBLAS"
 CHKSUMS="SKIP"
+SUBDIR="clblas/src"
 CHKUPDATE="anitya::id=229367"

--- a/extra-libs/clblas/spec
+++ b/extra-libs/clblas/spec
@@ -1,5 +1,5 @@
 VER=2.12
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/clMathLibraries/clBLAS"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229367"


### PR DESCRIPTION
Topic Description
-----------------

Mark `PKGSEC` in packages lacking it.

Package(s) Affected
-------------------

- `archlinux-keyring` v20210616-1
- `bolt` v0.9-2
- `clblas` v2.12-3
- `gammaray` v2.11.2-2
- `kdsme` v1.2.8-3

Security Update?
----------------

No

Build Order
-----------

```
archlinux-keyring bolt clblas gammaray kdsme
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`