### PR TITLE
redsocks2: new, 0.67+git20201229

### DIFF
--- a/extra-network/redsocks2/autobuild/beyond
+++ b/extra-network/redsocks2/autobuild/beyond
@@ -1,3 +1,0 @@
-abinfo Installing redsocks2...
-install -Dvm755 "${SRCDIR}/redsocks2" "${PKGDIR}/usr/bin/redsocks2"
-install -Dvm644 "${SRCDIR}/redsocks.conf.example" "${PKGDIR}/etc/redsocks2.conf"

--- a/extra-network/redsocks2/autobuild/beyond
+++ b/extra-network/redsocks2/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo Installing redsocks2...
+install -Dvm755 "${SRCDIR}/redsocks2" "${PKGDIR}/usr/bin/redsocks2"
+install -Dvm644 "${SRCDIR}/redsocks.conf.example" "${PKGDIR}/etc/redsocks2.conf"

--- a/extra-network/redsocks2/autobuild/build
+++ b/extra-network/redsocks2/autobuild/build
@@ -1,4 +1,7 @@
 abinfo Building redsocks2...
-cd "${SRCDIR}"
 make V=1 VERBOSE=1 $ABMK DISABLE_SHADOWSOCKS=true ENABLE_HTTPS_PROXY=true
 mkdir "${PKGDIR}"
+
+abinfo Installing redsocks2...
+install -Dvm755 "${SRCDIR}/redsocks2" "${PKGDIR}/usr/bin/redsocks2"
+install -Dvm644 "${SRCDIR}/redsocks.conf.example" "${PKGDIR}/etc/redsocks2.conf"

--- a/extra-network/redsocks2/autobuild/build
+++ b/extra-network/redsocks2/autobuild/build
@@ -1,0 +1,4 @@
+abinfo Building redsocks2...
+cd "${SRCDIR}"
+make V=1 VERBOSE=1 $ABMK DISABLE_SHADOWSOCKS=true ENABLE_HTTPS_PROXY=true
+mkdir "${PKGDIR}"

--- a/extra-network/redsocks2/autobuild/defines
+++ b/extra-network/redsocks2/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=redsocks2
+PKGSEC=net
+PKGDES="A transparent TCP-to-proxy redirector"
+PKGDEP="libevent glibc"
+
+ABTYPE=plainmake
+MAKE_AFTER="ENABLE_HTTPS_PROXY=true DISABLE_SHADOWSOCKS=true"

--- a/extra-network/redsocks2/autobuild/defines
+++ b/extra-network/redsocks2/autobuild/defines
@@ -2,6 +2,3 @@ PKGNAME=redsocks2
 PKGSEC=net
 PKGDES="A transparent TCP-to-proxy redirector"
 PKGDEP="libevent glibc"
-
-ABTYPE=plainmake
-MAKE_AFTER="ENABLE_HTTPS_PROXY=true DISABLE_SHADOWSOCKS=true"

--- a/extra-network/redsocks2/autobuild/overrides/usr/lib/systemd/system/redsocks2.service
+++ b/extra-network/redsocks2/autobuild/overrides/usr/lib/systemd/system/redsocks2.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Transparent redirector of any TCP connection to proxy using your firewall
+
+[Service]
+Type=forking
+PIDFile=/run/redsocks2/redsocks2.pid
+User=redsocks
+ExecStartPre=/usr/bin/redsocks2 -t -c /etc/redsocks2.conf
+ExecStart=/usr/bin/redsocks2 -c /etc/redsocks2.conf \
+  -p /run/redsocks2/redsocks2.pid
+ExecStopPost=/bin/rm /run/redsocks2/redsocks2.pid
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target

--- a/extra-network/redsocks2/autobuild/overrides/usr/lib/systemd/system/redsocks2.service
+++ b/extra-network/redsocks2/autobuild/overrides/usr/lib/systemd/system/redsocks2.service
@@ -2,14 +2,8 @@
 Description=Transparent redirector of any TCP connection to proxy using your firewall
 
 [Service]
-Type=forking
-PIDFile=/run/redsocks2/redsocks2.pid
-User=redsocks
 ExecStartPre=/usr/bin/redsocks2 -t -c /etc/redsocks2.conf
-ExecStart=/usr/bin/redsocks2 -c /etc/redsocks2.conf \
-  -p /run/redsocks2/redsocks2.pid
-ExecStopPost=/bin/rm /run/redsocks2/redsocks2.pid
-Restart=on-abort
+ExecStart=/usr/bin/redsocks2 -c /etc/redsocks2.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/extra-network/redsocks2/spec
+++ b/extra-network/redsocks2/spec
@@ -1,0 +1,4 @@
+VER=0.67+git20201229
+SRCS="git::commit=1951b49b774b0aab702348d0370e26bae1c3a7df::https://github.com/semigodking/redsocks"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=227511"


### PR DESCRIPTION

Topic Description
-----------------
* Introduce `redsocks2`

Package(s) Affected
-------------------
* `redsocks2`

Security Update?
----------------
No

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
