### PR TITLE
docbook-dtd: isolate XML and SGML

### DIFF
--- a/extra-doc/docbook-dtd/autobuild/build
+++ b/extra-doc/docbook-dtd/autobuild/build
@@ -3,9 +3,8 @@ _LEGACY_VERSIONS=({3,4}.{0,1})
 XML_VERSIONS=('4.1.2' ${_COMMON_VERSIONS[@]})
 SGML_VERSIONS=(${_LEGACY_VERSIONS[@]} ${_COMMON_VERSIONS[@]})
 
-register_schema() {
-    abinfo "Registering $2-$1 ..."
-    xmlcatalog --noout --sgml --add "$PKGDIR"/etc/sgml/$2-docbook-$1.cat '/usr/share/xml/docbook/xmlcatalog/catalog'
+register_schema_xml() {
+    abinfo "Registering xml-$1 ..."
     while read f desc; do
         xmlcatalog --noout --add public "$desc" "/usr/share/xml/docbook/$f" "$PKGDIR/usr/share/xml/docbook/xmlcatalog"
     done << EOF
@@ -23,18 +22,26 @@ EOF
             xmlcatalog --noout --add public "-//OASIS//ELEMENTS DocBook XML HTML Tables V$1//EN" "/usr/share/xml/docbook/$f" "$PKGDIR/usr/share/xml/docbook/xmlcatalog"
     esac
     for f in System URI; do
-        xmlcatalog --noout --add "rewrite$f" "http://www.oasis-open.org/docbook/xml/$1" "/usr/share/xml/docbook/$2-dtd-$1" "$PKGDIR/usr/share/xml/docbook/xmlcatalog"
+        xmlcatalog --noout --add "rewrite$f" "http://www.oasis-open.org/docbook/xml/$1" "/usr/share/xml/docbook/xml-dtd-$1" "$PKGDIR/usr/share/xml/docbook/xmlcatalog"
     done
+}
+
+register_cat_sgml() {
+    abinfo "Registering sgml-$1 ..."
+    xmlcatalog --sgml --noout --no-super-update --add "$PKGDIR/etc/sgml/sgml-docbook-$1.cat" "/usr/share/sgml/docbook/sgml-dtd-$1/catalog"
+    xmlcatalog --sgml --noout --no-super-update --add "$PKGDIR/etc/sgml/sgml-docbook-$1.cat" "/usr/share/sgml/docbook/sgml-dtd-$1/catalog"
+    xmlcatalog --sgml --noout --no-super-update --add "$PKGDIR/etc/sgml/sgml-docbook-$1.cat" "/etc/sgml/sgml-ent.cat"
+    xmlcatalog --sgml --noout --no-super-update --add "$PKGDIR/etc/sgml/sgml-docbook-$1.cat" "/etc/sgml/dsssl-docbook-stylesheets.cat"
+    xmlcatalog --sgml --noout --no-super-update --add "$PKGDIR/etc/sgml/catalog" "/etc/sgml/sgml-docbook-$1.cat"
 }
 
 abinfo 'Preparing XML catalogs ...'
 mkdir -pv "$PKGDIR/etc/"{xml,sgml}
 mkdir -pv "$PKGDIR/etc/xml/docbook-xml/"
 mkdir -pv "$PKGDIR/usr/share/xml/docbook/"
-mkdir -pv "$PKGDIR/usr/share/sgml/"
+mkdir -pv "$PKGDIR/usr/share/sgml/docbook/"
 xmlcatalog --noout --create "$PKGDIR/usr/share/xml/docbook/xmlcatalog"
 ln -sv ../../../usr/share/xml/docbook/xmlcatalog "$PKGDIR/etc/xml/docbook-xml/xmlcatalog"
-ln -sv ../xml/docbook "$PKGDIR/usr/share/sgml/docbook"
 
 abinfo 'Preparing sources and installation ...'
 # XML
@@ -49,21 +56,20 @@ for i in ${XML_VERSIONS[@]}; do
     cp -v *.dtd *.mod "$TARGETDIR"
     cp -v docbook.cat "$TARGETDIR/catalog/"
     # register schemas
-    register_schema "$i" "xml"
+    register_schema_xml "$i"
     cd ..
 done
-# SGML
 for i in ${SGML_VERSIONS[@]}; do
     abinfo "Processing $i-sgml ..."
     mkdir -v "$SRCDIR/$i-sgml" && cd "$SRCDIR/$i-sgml"
     unzip "$SRCDIR/docbook-$i.zip"
-    TARGETDIR="$PKGDIR/usr/share/xml/docbook/sgml-dtd-$i"
-    mkdir -pv "$TARGETDIR/catalog"
+    TARGETDIR="$PKGDIR/usr/share/sgml/docbook/sgml-dtd-$i"
+    mkdir -pv "$TARGETDIR/"
     cp -v *.dcl "$TARGETDIR"
     cp -v *.dtd *.mod "$TARGETDIR"
-    cp -v docbook.cat "$TARGETDIR/catalog/"
-    # register schemas
-    register_schema "$i" "sgml"
+    cp -v docbook.cat "$TARGETDIR/catalog"
+    # register cats
+    register_cat_sgml "$i"
     cd ..
 done
 for i in ${_COMMON_VERSIONS[@]}; do
@@ -88,6 +94,5 @@ done
 # symlinks
 mkdir -pv "$PKGDIR/etc/sgml/"
 ln -sv "sgml-docbook-4.5.cat" "$PKGDIR/etc/sgml/sgml-docbook.cat"
-ln -sv "xml-docbook-4.5.cat" "$PKGDIR/etc/sgml/xml-docbook.cat"
 
 # vi: ft=bash

--- a/extra-doc/docbook-dtd/autobuild/defines
+++ b/extra-doc/docbook-dtd/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=docbook-dtd
 PKGDES="SGML and XML document type definitions for DocBook"
 PKGSEC=misc
-PKGDEP="libxml2 sgml-common"
+PKGDEP="libxml2 sgml-common docbook-dsssl"
 BUILDDEP="unzip"
 PKGBREAK="docbook-xml<=4.5-4 docbook-sgml<=4.5-3"
 PKGREP="${PKGBREAK}"

--- a/extra-doc/docbook-dtd/spec
+++ b/extra-doc/docbook-dtd/spec
@@ -1,5 +1,5 @@
 VER=4.5
-REL=1
+REL=2
 SRCS="file::rename=docbook-3.0.zip::https://www.oasis-open.org/docbook/sgml/3.0/docbk30.zip \
       file::rename=docbook-3.1.zip::https://www.oasis-open.org/docbook/sgml/3.1/docbk31.zip \
       file::rename=docbook-4.0.zip::https://www.oasis-open.org/docbook/sgml/4.0/docbk40.zip \


### PR DESCRIPTION
Topic Description
-----------------

Fix the mixture of XML and SGML in docbook-dtd, which leads to both failure of XML tools and SGML tools.

Package(s) Affected
-------------------

- `docbook-dtd`

Security Update?
----------------

No

Architectural Progress
------------------

- [ ] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
