### PR TITLE
dpkg: add support for LoongArch64

### DIFF
--- a/base-admin/dpkg/01-update-alternatives/patches/0001-Hack-loongarch64-recognition.patch.loongarch64
+++ b/base-admin/dpkg/01-update-alternatives/patches/0001-Hack-loongarch64-recognition.patch.loongarch64
@@ -1,0 +1,11 @@
+diff -Naur dpkg-1.20.9/data/cputable dpkg-1.20.9.loongarch64/data/cputable
+--- dpkg-1.20.9/data/cputable	2021-07-24 16:27:34.120009451 +0800
++++ dpkg-1.20.9.loongarch64/data/cputable	2021-07-24 16:28:50.683849503 +0800
+@@ -25,6 +25,7 @@
+ arm64		aarch64		aarch64			64	little
+ avr32		avr32		avr32			32	big
+ hppa		hppa		hppa.*			32	big
++loongarch64	loongarch64	loongarch64		64	little
+ m32r		m32r		m32r			32	big
+ m68k		m68k		m68k			32	big
+ mips		mips		mips(eb)?		32	big


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

add dpkg support for LoongArch64 patch

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
