### PR TITLE
libbsd: add loongarch64 patch

### DIFF
--- a/extra-libs/libbsd/autobuild/patches/0001-port-loongarch64-recognition.patch.loongarch64
+++ b/extra-libs/libbsd/autobuild/patches/0001-port-loongarch64-recognition.patch.loongarch64
@@ -1,17 +1,16 @@
 diff -Naur local-elf.h.ori local-elf.h
 --- a/src/local-elf.h	2021-08-16 17:24:31.189734583 +0400
 +++ b/src/local-elf.h	2021-08-16 17:26:28.619730224 +0400
-@@ -122,6 +122,11 @@
- 
- #define ELF_TARG_MACH	EM_IA_64
+@@ -124,6 +124,12 @@
  #define ELF_TARG_CLASS	ELFCLASS64
  #define ELF_TARG_DATA	ELFDATA2LSB
+ 
++#elif defined(__loongarch64__)
 +
-+#elif defined(__loongarch64)
-+
-+#define ELF_TARG_MACH	EM_LOONGARCH
++#define ELF_TARG_MACH	EM_LOONGARCH64
 +#define ELF_TARG_CLASS	ELFCLASS64
 +#define ELF_TARG_DATA	ELFDATA2LSB
- 
++
  #elif defined(__m32r__)
-
+ 
+ #define ELF_TARG_MACH	EM_M32R

--- a/extra-libs/libbsd/autobuild/patches/0001-port-loongarch64-recognition.patch.loongarch64
+++ b/extra-libs/libbsd/autobuild/patches/0001-port-loongarch64-recognition.patch.loongarch64
@@ -11,7 +11,7 @@ diff -Naur local-elf.h.ori local-elf.h
 +
 +#define ELF_TARG_MACH	EM_LOONGARCH
 +#define ELF_TARG_CLASS	ELFCLASS64
- #define ELF_TARG_DATA	ELFDATA2LSB
++#define ELF_TARG_DATA	ELFDATA2LSB
  
  #elif defined(__m32r__)
 

--- a/extra-libs/libbsd/autobuild/patches/0001-port-loongarch64-recognition.patch.loongarch64
+++ b/extra-libs/libbsd/autobuild/patches/0001-port-loongarch64-recognition.patch.loongarch64
@@ -5,9 +5,9 @@ diff -Naur local-elf.h.ori local-elf.h
  #define ELF_TARG_CLASS	ELFCLASS64
  #define ELF_TARG_DATA	ELFDATA2LSB
  
-+#elif defined(__loongarch64__)
++#elif defined(__loongarch64)
 +
-+#define ELF_TARG_MACH	EM_LOONGARCH64
++#define ELF_TARG_MACH	EM_LOONGARCH
 +#define ELF_TARG_CLASS	ELFCLASS64
 +#define ELF_TARG_DATA	ELFDATA2LSB
 +

--- a/extra-libs/libbsd/autobuild/patches/0001-port-loongarch64-recognition.patch.loongarch64
+++ b/extra-libs/libbsd/autobuild/patches/0001-port-loongarch64-recognition.patch.loongarch64
@@ -5,6 +5,7 @@ diff -Naur local-elf.h.ori local-elf.h
  
  #define ELF_TARG_MACH	EM_IA_64
  #define ELF_TARG_CLASS	ELFCLASS64
+ #define ELF_TARG_DATA	ELFDATA2LSB
 +
 +#elif defined(__loongarch64)
 +

--- a/extra-libs/libbsd/autobuild/patches/0001-port-loongarch64-recognition.patch.loongarch64
+++ b/extra-libs/libbsd/autobuild/patches/0001-port-loongarch64-recognition.patch.loongarch64
@@ -1,4 +1,4 @@
-[yanqi@arch src]$ diff -Naur local-elf.h.ori local-elf.h
+diff -Naur local-elf.h.ori local-elf.h
 --- a/src/local-elf.h	2021-08-16 17:24:31.189734583 +0400
 +++ b/src/local-elf.h	2021-08-16 17:26:28.619730224 +0400
 @@ -122,6 +122,11 @@

--- a/extra-libs/libbsd/autobuild/patches/libbsd-add-loongarch64.patch.loongarch64
+++ b/extra-libs/libbsd/autobuild/patches/libbsd-add-loongarch64.patch.loongarch64
@@ -1,0 +1,16 @@
+[yanqi@arch src]$ diff -Naur local-elf.h.ori local-elf.h
+--- a/src/local-elf.h	2021-08-16 17:24:31.189734583 +0400
++++ b/src/local-elf.h	2021-08-16 17:26:28.619730224 +0400
+@@ -122,6 +122,11 @@
+ 
+ #define ELF_TARG_MACH	EM_IA_64
+ #define ELF_TARG_CLASS	ELFCLASS64
++
++#elif defined(__loongarch64)
++
++#define ELF_TARG_MACH	EM_LOONGARCH
++#define ELF_TARG_CLASS	ELFCLASS64
+ #define ELF_TARG_DATA	ELFDATA2LSB
+ 
+ #elif defined(__m32r__)
+


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Add libbsd LoongArch64 patch written by Yanqi

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
