### PR TITLE
docbook-dtd: tweak conffiles

### DIFF
--- a/extra-doc/docbook-dtd/spec
+++ b/extra-doc/docbook-dtd/spec
@@ -1,5 +1,5 @@
 VER=4.5
-REL=2
+REL=3
 SRCS="file::rename=docbook-3.0.zip::https://www.oasis-open.org/docbook/sgml/3.0/docbk30.zip \
       file::rename=docbook-3.1.zip::https://www.oasis-open.org/docbook/sgml/3.1/docbk31.zip \
       file::rename=docbook-4.0.zip::https://www.oasis-open.org/docbook/sgml/4.0/docbk40.zip \


### PR DESCRIPTION
Topic Description
-----------------

Create `autobuild/conffiles` to inhibit Autobuild3 auto-generation for `conffiles`, `/etc/sgml/catalog` should not be considered a configuration file.

Package(s) Affected
-------------------

- `docbook-dtd` v4.5-3

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`