### PR TITLE
Font survey 20210829

### DIFF
--- a/extra-fonts/lxgwcleargothic-font/autobuild/build
+++ b/extra-fonts/lxgwcleargothic-font/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Installing font file..."
+install -Dvm644 "$SRCDIR"/TTF/*.ttf -t "$PKGDIR"/usr/share/fonts/TTF
+
+abinfo "Installing LICENSE..."
+install -Dvm644 "$SRCDIR"/LICENSE.txt -t "$PKGDIR"/usr/share/doc/lxgwcleargothic-font

--- a/extra-fonts/lxgwcleargothic-font/autobuild/defines
+++ b/extra-fonts/lxgwcleargothic-font/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="lxgwcleargothic-font"
+PKGDES="A Sans Serif font derived from IPAex Gothic"
+PKGDEP="fontconfig"
+PKGSEC="fonts"
+
+ABHOST="noarch"

--- a/extra-fonts/lxgwcleargothic-font/spec
+++ b/extra-fonts/lxgwcleargothic-font/spec
@@ -1,0 +1,4 @@
+VER=0.206
+SRCS="tbl::https://github.com/lxgw/LxgwClearGothic/archive/refs/tags/v$VER.tar.gz"
+CHKSUMS="sha256::6989865b8da2993cd124c408115a9d4603d8bf30c686e18ec4ff2d41136fbdac"
+CHKUPDATE="anitya::id=234782"

--- a/extra-fonts/lxgwnewcleargothic-font/autobuild/build
+++ b/extra-fonts/lxgwnewcleargothic-font/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Installing font file..."
+install -Dvm644 "$SRCDIR"/*.ttf -t "$PKGDIR"/usr/share/fonts/TTF
+
+abinfo "Installing LICENSE..."
+install -Dvm644 "$SRCDIR"/LxgwNewClearGothic-"$PKGVER"/LICENSE.txt \
+	-t "$PKGDIR"/usr/share/doc/lxgwwenkai-font

--- a/extra-fonts/lxgwnewcleargothic-font/autobuild/defines
+++ b/extra-fonts/lxgwnewcleargothic-font/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="lxgwnewcleargothic-font"
+PKGDES="A Sans Serif font derived from IPAex Gothic (optimized for Simplified Chinese)"
+PKGDEP="fontconfig"
+PKGSEC="fonts"
+
+ABHOST="noarch"

--- a/extra-fonts/lxgwnewcleargothic-font/spec
+++ b/extra-fonts/lxgwnewcleargothic-font/spec
@@ -1,0 +1,11 @@
+VER=0.235
+SRCS="file::rename=LXGWFasmartGothic.ttf::https://github.com/lxgw/LxgwNewClearGothic/releases/download/v$VER/LXGWFasmartGothic.ttf \
+      file::rename=LXGWNewClearGothic-Book.ttf::https://github.com/lxgw/LxgwNewClearGothic/releases/download/v$VER/LXGWNewClearGothic-Book.ttf \
+      file::rename=LXGWNewClearGothic-Regular.ttf::https://github.com/lxgw/LxgwNewClearGothic/releases/download/v$VER/LXGWNewClearGothic-Regular.ttf \
+      tbl::https://github.com/lxgw/LxgwNewClearGothic/archive/refs/tags/v$VER.tar.gz"
+CHKSUMS="sha256::f2cdf6caf1c305f4048f5cf5bc56f251288408b4a31b6dfa0cc7db5e10e1db92 \
+         sha256::6128153f595f18cf15f97b99b008d60c957712ac6fdbff6e91e64d7845741963 \
+         sha256::b25db58ca4cfbcd8774a84563e9728e4481075ca22ad139d9fbfed68c64e82a8 \
+         sha256::ea5d87a6a32139e3c0b43f8b35fe736c3b3dac0e34242e7e1c795f4b0039de44"
+CHKUPDATE="anitya::id=234778"
+SUBDIR="."

--- a/extra-fonts/lxgwwenkai-font/spec
+++ b/extra-fonts/lxgwwenkai-font/spec
@@ -1,17 +1,17 @@
-VER=1.006
+VER=1.007
 SRCS="file::rename=LXGWWenKai-Bold.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/LXGWWenKai-Bold.ttf \
       file::rename=LXGWWenKai-Light.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/LXGWWenKai-Light.ttf \
       file::rename=LXGWWenKai-Regular.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/LXGWWenKai-Regular.ttf \
       file::rename=LXGWWenKaiMono-Bold.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/LXGWWenKaiMono-Bold.ttf \
       file::rename=LXGWWenKaiMono-Light.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/LXGWWenKaiMono-Light.ttf \
-      file::rename=LXGWWenKaiMono-Regular.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v1.005/LXGWWenKaiMono-Regular.ttf \
+      file::rename=LXGWWenKaiMono-Regular.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/LXGWWenKaiMono-Regular.ttf \
       tbl::https://github.com/lxgw/LxgwWenKai/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::4f92cf0445dd1683dc56934bed3cfe322ae803d0c7e9c76b7049d774abb58abb \
-         sha256::98146eeef4b129397271d12fcf923097e560fd8c30759b80f612ffa2cbfadd41 \
-         sha256::04fd673a4c38eca98a81c467c318db3e07a5926fe4207b1b8c8695ca6cb86822 \
-         sha256::d4e93f6e1e1ed49105d346f4e01839d3f70a3b3bc1074171f92d1f89888173fb \
-         sha256::46cd3e47e8c31adf90ee835c94dbd42ee36b500b963f7a534750147fe0087b8f \
-         sha256::73c24eea54a9007920831f440aebf8e2841a2eb684e288a3b90b418fce822cd1 \
-         sha256::80fe056c7e77746581a64076b314d9cd82676521af4a934b6ad758238cd4feb7"
+CHKSUMS="sha256::f58614455590e6bdc8d1e8e2e163c454f5b96bb5e581e8eeab622e60407b72a9 \
+         sha256::f4e7360fb3f828eca103e9da5a8f38c3a1bef7ada279c0386c39a213af3b40a0 \
+         sha256::c6b0d8108208050b743c341df00fb3585009012362713ef9139d86d885d2fd98 \
+         sha256::17e697af2fd7050135ae793a8a62160ecc9afe3a928b1f260f3e1cee81b43b6c \
+         sha256::75fd6dc590445aa16aeb43c112c9473528f37108262b24b2351bc2970ff829ed \
+         sha256::85ee50588d379a141f26eaf38f1321e96762fd3e55d42cc025f641c2883051a2 \
+         sha256::c998d4204df4607cb076689cb74c4cd917246dd913a04a83761c087916e5e46e"
 CHKUPDATE="anitya::id=227594"
 SUBDIR="."

--- a/extra-fonts/qiji-font/spec
+++ b/extra-fonts/qiji-font/spec
@@ -1,11 +1,11 @@
-VER=0.0.3
-SRCS="file::rename=qiji.ttf::https://github.com/LingDong-/qiji-font/releases/download/v$VER/qiji.ttf \
-      file::rename=qiji-fallback.ttf::https://github.com/LingDong-/qiji-font/releases/download/v$VER/qiji-fallback.ttf \
-      file::rename=qiji-combo.ttf::https://github.com/LingDong-/qiji-font/releases/download/v$VER/qiji-combo.ttf \
-      tbl::https://github.com/LingDong-/qiji-font/archive/v$VER.tar.gz"
-CHKSUMS="sha256::4f5a335ab04ca3a24dbd7b3eaa10bc259dcc2543f51b237532be5e690d42d372 \
+VER=0.0.4
+SRCS="file::rename=qiji.ttf::https://github.com/LingDong-/qiji-font/releases/download/$VER/qiji-combo.ttf \
+      file::rename=qiji-fallback.ttf::https://github.com/LingDong-/qiji-font/releases/download/$VER/qiji-fallback.ttf \
+      file::rename=qiji-combo.ttf::https://github.com/LingDong-/qiji-font/releases/download/$VER/qiji-combo.ttf \
+      tbl::https://github.com/LingDong-/qiji-font/archive/$VER.tar.gz"
+CHKSUMS="sha256::f842291b039e9c5ae69edfe924edbe28b3cfba91bcac95791bf1fbc11db330cf \
          sha256::01c1e4fab1e92b27e61a54adfdbf40b242d3e70ca535339ef2eb3a02bd6fd7a4 \
-         sha256::5b389f463dd2710345364e024f4b1f5414a58c4fd0d6f8f16f404eea99e3bbc1 \
-         sha256::8874a748054e9e4482be99bd546b562b139d9ce715fbff0c950c9e3524822d06"
+         sha256::f842291b039e9c5ae69edfe924edbe28b3cfba91bcac95791bf1fbc11db330cf \
+         sha256::05e866a893091ea73748403b7404cd6b979538421ee1a3622d2361fdc2c03a86"
 CHKUPDATE="anitya::id=227598"
 SUBDIR=.

--- a/extra-fonts/yozai-font/autobuild/build
+++ b/extra-fonts/yozai-font/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Installing font file..."
+install -Dvm644 "$SRCDIR"/ttf/*.ttf -t "$PKGDIR"/usr/share/fonts/TTF
+
+abinfo "Installing LICENSE..."
+install -Dvm644 "$SRCDIR"/SIL_Open_Font_License_1.1.txt \
+	-t "$PKGDIR"/usr/share/doc/yozai-font

--- a/extra-fonts/yozai-font/autobuild/defines
+++ b/extra-fonts/yozai-font/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="yozai-font"
+PKGDES="A Chinese handwriting font derived from YozFont"
+PKGDEP="fontconfig"
+PKGSEC="fonts"
+
+ABHOST="noarch"

--- a/extra-fonts/yozai-font/spec
+++ b/extra-fonts/yozai-font/spec
@@ -1,0 +1,4 @@
+# No tag is issued upstream, the version number is obtained from the commit information
+VER=0.85
+SRCS="git::commit=58e650db01d8abbe11050e4fb4b9929e47262053::https://github.com/lxgw/yozai-font"
+CHKSUMS="SKIP"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Font survey 20210829

Package(s) Affected
-------------------

l/lxgwcleargothic-font_0.206-0_noarch.deb
l/lxgwnewcleargothic-font_0.235-0_noarch.deb
l/lxgwwenkai-font_1.007-0_noarch.deb
q/qiji-font_0.0.4-0_noarch.deb
y/yozai-font_0.85-0_noarch.deb


Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

 - [x] Architecture-independent `noarch` 

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch` 
