### PR TITLE
gpredict: rebuild

### DIFF
--- a/extra-radio/gpredict/autobuild/build
+++ b/extra-radio/gpredict/autobuild/build
@@ -1,6 +1,0 @@
-# autogen.sh will configure the project for us, so we slightly change the
-# build process
-# the below are copied from autobuild3/build/10-autotools.sh
-"$SRCDIR"/autogen.sh --host=$HOST $AUTOTOOLS_DEF $AUTOTOOLS_AFTER
-make $ABMK $MAKE_AFTER
-make install BUILDROOT=$PKGDIR DESTDIR=$PKGDIR $MAKE_AFTER

--- a/extra-radio/gpredict/autobuild/defines
+++ b/extra-radio/gpredict/autobuild/defines
@@ -3,3 +3,5 @@ PKGSEC=hamradio
 PKGDES="Real time satellite tracking and orbit prediction program"
 PKGDEP="curl glib goocanvas gtk-3 hamlib"
 BUILDDEP="intltool"
+
+ABSHADOW=0

--- a/extra-radio/gpredict/autobuild/patches/0001-fix-build.patch
+++ b/extra-radio/gpredict/autobuild/patches/0001-fix-build.patch
@@ -1,0 +1,12 @@
+diff -upr gpredict-2.2.1/src/qth-data.h gpredict-2.2.1.fix/src/qth-data.h
+--- gpredict-2.2.1/src/qth-data.h	2017-12-29 18:28:07.000000000 +0800
++++ gpredict-2.2.1.fix/src/qth-data.h	2020-06-22 21:39:47.101031753 +0800
+@@ -30,7 +30,7 @@ typedef struct {
+     gint            alt;        /*!< Altitude above sea level in meters. */
+ } qth_small_t;
+ 
+-enum {
++typedef enum {
+     QTH_STATIC_TYPE = 0,
+     QTH_GPSD_TYPE
+ } qth_data_type;


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Rebuild `gpredict` due to the outdated build script.

Package(s) Affected
-------------------

`gpredict`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
