### PR TITLE
bzip2: add pkgconfig

### DIFF
--- a/base-utils/bzip2/autobuild/build
+++ b/base-utils/bzip2/autobuild/build
@@ -21,7 +21,7 @@ install -vm644 "$SRCDIR"/bzip2.pc "$PKGDIR"/usr/lib/pkgconfig
 
 abinfo 'Soft linking soversion files...'
 ln -sv ./libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so
-ln -sv .libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1
+ln -sv ./libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1
 ln -sv ./libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1.0
 
 abinfo 'Installing bzlib header...'

--- a/base-utils/bzip2/autobuild/build
+++ b/base-utils/bzip2/autobuild/build
@@ -9,8 +9,9 @@ install -vm755 bzip2recover bzdiff bzgrep bzmore "$PKGDIR"/usr/bin
 ln -sfv bzip2 "$PKGDIR"/usr/bin/bunzip2
 ln -sfv bzip2 "$PKGDIR"/usr/bin/bzcat
 
-install -vm755 libbz2.a "$PKGDIR"/usr/lib
+install -vm644 libbz2.a "$PKGDIR"/usr/lib
 install -vm755 libbz2.so.$PKGVER "$PKGDIR"/usr/lib
+install -vm644 bzip2.pc "$PKGDIR"/usr/lib/pkgconfig
 ln -sv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so
 ln -sv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1
 ln -sv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1.0

--- a/base-utils/bzip2/autobuild/build
+++ b/base-utils/bzip2/autobuild/build
@@ -11,8 +11,8 @@ install -vm755 "$SRCDIR"/bzip2-shared "$PKGDIR"/usr/bin/bzip2
 install -vm755 "$SRCDIR"/{bzip2recover,bzdiff,bzgrep,bzmore} "$PKGDIR"/usr/bin
 
 abinfo 'Soft linking `bzip2` to PKGDIR as `bunzip2` and `bzcat`...'
-ln -sfv /usr/bin/bzip2 "$PKGDIR"/usr/bin/bunzip2
-ln -sfv /usr/bin/bzip2 "$PKGDIR"/usr/bin/bzcat
+ln -sfv ./bzip2 "$PKGDIR"/usr/bin/bunzip2
+ln -sfv ./bzip2 "$PKGDIR"/usr/bin/bzcat
 
 abinfo 'Installing libraries and pkg-config...'
 install -vm644 "$SRCDIR"/libbz2.a "$PKGDIR"/usr/lib
@@ -20,15 +20,15 @@ install -vm755 "$SRCDIR"/libbz2.so.$PKGVER "$PKGDIR"/usr/lib
 install -vm644 "$SRCDIR"/bzip2.pc "$PKGDIR"/usr/lib/pkgconfig
 
 abinfo 'Soft linking soversion files...'
-ln -sv /usr/lib/libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so
-ln -sv /usr/lib/libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1
-ln -sv /usr/lib/libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1.0
+ln -sv ./libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so
+ln -sv .libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1
+ln -sv ./libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1.0
 
 abinfo 'Installing bzlib header...'
 install -vm644 bzlib.h "$PKGDIR"/usr/include/
 
 abinfo 'Installing man files...'
 install -vm644 "$SRCDIR"/bzip2.1 "$PKGDIR"/usr/share/man/man1/
-ln -sfv /usr/share/man/man1/bzip2.1 "$PKGDIR"/usr/share/man/man1/bunzip2.1
-ln -sfv /usr/share/man/man1/bzip2.1 "$PKGDIR"/usr/share/man/man1/bzcat.1
-ln -sfv /usr/share/man/man1/bzip2.1 "$PKGDIR"/usr/share/man/man1/bzip2recover.1
+ln -sfv ./bzip2.1 "$PKGDIR"/usr/share/man/man1/bunzip2.1
+ln -sfv ./bzip2.1 "$PKGDIR"/usr/share/man/man1/bzcat.1
+ln -sfv ./bzip2.1 "$PKGDIR"/usr/share/man/man1/bzip2recover.1

--- a/base-utils/bzip2/autobuild/build
+++ b/base-utils/bzip2/autobuild/build
@@ -14,10 +14,25 @@ abinfo 'Soft linking `bzip2` to PKGDIR as `bunzip2` and `bzcat`...'
 ln -sfv ./bzip2 "$PKGDIR"/usr/bin/bunzip2
 ln -sfv ./bzip2 "$PKGDIR"/usr/bin/bzcat
 
-abinfo 'Installing libraries and pkg-config...'
+abinfo 'Installing libraries...'
 install -vm644 "$SRCDIR"/libbz2.a "$PKGDIR"/usr/lib
 install -vm755 "$SRCDIR"/libbz2.so.$PKGVER "$PKGDIR"/usr/lib
-install -vm644 "$SRCDIR"/bzip2.pc "$PKGDIR"/usr/lib/pkgconfig
+
+abinfo 'Generating bzip2.pc ...'
+# Contents adapted from Arch Linux
+cat << EOF > "$PKGDIR"/usr/lib/pkgconfig/bzip2.pc
+prefix=/usr
+exec_prefix=/usr
+bindir=\${exec_prefix}/bin
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: bzip2
+Description: A file compression library
+Version: $PKGVER
+Libs: -L\${libdir} -lbz2
+Cflags: -I\${includedir}
+EOF
 
 abinfo 'Soft linking soversion files...'
 ln -sv ./libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so

--- a/base-utils/bzip2/autobuild/build
+++ b/base-utils/bzip2/autobuild/build
@@ -1,24 +1,34 @@
-make -f Makefile-libbz2_so CC="gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -fPIC"
+abinfo 'Making libbz2.so, bzip2 and bzip2recover...'
+make -f "$SRCDIR"/Makefile-libbz2_so \
+     CC="gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -fPIC"
 make bzip2 bzip2recover
 
-install -dvm755 "$PKGDIR"/usr/{bin,lib,lib/pkgconfig,include,share/man/man1}
+abinfo 'Installing directories all we need to PKGDIR...'
+install -dvm755 "$PKGDIR"/usr/{bin,lib/pkgconfig,include,share/man/man1}
 
-install -vm755 bzip2-shared "$PKGDIR"/usr/bin/bzip2
-install -vm755 bzip2recover bzdiff bzgrep bzmore "$PKGDIR"/usr/bin
+abinfo 'Installing binaries to PKGDIR...'
+install -vm755 "$SRCDIR"/bzip2-shared "$PKGDIR"/usr/bin/bzip2
+install -vm755 "$SRCDIR"/{bzip2recover,bzdiff,bzgrep,bzmore} "$PKGDIR"/usr/bin
 
-ln -sfv bzip2 "$PKGDIR"/usr/bin/bunzip2
-ln -sfv bzip2 "$PKGDIR"/usr/bin/bzcat
+abinfo 'Soft linking `bzip2` to PKGDIR as `bunzip2` and `bzcat`...'
+ln -sfv /usr/bin/bzip2 "$PKGDIR"/usr/bin/bunzip2
+ln -sfv /usr/bin/bzip2 "$PKGDIR"/usr/bin/bzcat
 
-install -vm644 libbz2.a "$PKGDIR"/usr/lib
-install -vm755 libbz2.so.$PKGVER "$PKGDIR"/usr/lib
-install -vm644 bzip2.pc "$PKGDIR"/usr/lib/pkgconfig
-ln -sv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so
-ln -sv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1
-ln -sv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1.0
+abinfo 'Installing libraries and pkg-config...'
+install -vm644 "$SRCDIR"/libbz2.a "$PKGDIR"/usr/lib
+install -vm755 "$SRCDIR"/libbz2.so.$PKGVER "$PKGDIR"/usr/lib
+install -vm644 "$SRCDIR"/bzip2.pc "$PKGDIR"/usr/lib/pkgconfig
 
+abinfo 'Soft linking soversion files...'
+ln -sv /usr/lib/libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so
+ln -sv /usr/lib/libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1
+ln -sv /usr/lib/libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1.0
+
+abinfo 'Installing bzlib header...'
 install -vm644 bzlib.h "$PKGDIR"/usr/include/
 
-install -vm644 bzip2.1 "$PKGDIR"/usr/share/man/man1/
-ln -sfv bzip2.1 "$PKGDIR"/usr/share/man/man1/bunzip2.1
-ln -sfv bzip2.1 "$PKGDIR"/usr/share/man/man1/bzcat.1
-ln -sfv bzip2.1 "$PKGDIR"/usr/share/man/man1/bzip2recover.1
+abinfo 'Installing man files...'
+install -vm644 "$SRCDIR"/bzip2.1 "$PKGDIR"/usr/share/man/man1/
+ln -sfv /usr/share/man/man1/bzip2.1 "$PKGDIR"/usr/share/man/man1/bunzip2.1
+ln -sfv /usr/share/man/man1/bzip2.1 "$PKGDIR"/usr/share/man/man1/bzcat.1
+ln -sfv /usr/share/man/man1/bzip2.1 "$PKGDIR"/usr/share/man/man1/bzip2recover.1

--- a/base-utils/bzip2/autobuild/build
+++ b/base-utils/bzip2/autobuild/build
@@ -11,8 +11,8 @@ install -vm755 "$SRCDIR"/bzip2-shared "$PKGDIR"/usr/bin/bzip2
 install -vm755 "$SRCDIR"/{bzip2recover,bzdiff,bzgrep,bzmore} "$PKGDIR"/usr/bin
 
 abinfo 'Soft linking `bzip2` to PKGDIR as `bunzip2` and `bzcat`...'
-ln -sfv ./bzip2 "$PKGDIR"/usr/bin/bunzip2
-ln -sfv ./bzip2 "$PKGDIR"/usr/bin/bzcat
+ln -sfv bzip2 "$PKGDIR"/usr/bin/bunzip2
+ln -sfv bzip2 "$PKGDIR"/usr/bin/bzcat
 
 abinfo 'Installing libraries...'
 install -vm644 "$SRCDIR"/libbz2.a "$PKGDIR"/usr/lib
@@ -35,15 +35,15 @@ Cflags: -I\${includedir}
 EOF
 
 abinfo 'Soft linking soversion files...'
-ln -sv ./libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so
-ln -sv ./libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1
-ln -sv ./libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1.0
+ln -sv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so
+ln -sv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1
+ln -sv libbz2.so.$PKGVER "$PKGDIR"/usr/lib/libbz2.so.1.0
 
 abinfo 'Installing bzlib header...'
 install -vm644 bzlib.h "$PKGDIR"/usr/include/
 
 abinfo 'Installing man files...'
 install -vm644 "$SRCDIR"/bzip2.1 "$PKGDIR"/usr/share/man/man1/
-ln -sfv ./bzip2.1 "$PKGDIR"/usr/share/man/man1/bunzip2.1
-ln -sfv ./bzip2.1 "$PKGDIR"/usr/share/man/man1/bzcat.1
-ln -sfv ./bzip2.1 "$PKGDIR"/usr/share/man/man1/bzip2recover.1
+ln -sfv bzip2.1 "$PKGDIR"/usr/share/man/man1/bunzip2.1
+ln -sfv bzip2.1 "$PKGDIR"/usr/share/man/man1/bzcat.1
+ln -sfv bzip2.1 "$PKGDIR"/usr/share/man/man1/bzip2recover.1

--- a/base-utils/bzip2/autobuild/build
+++ b/base-utils/bzip2/autobuild/build
@@ -1,7 +1,7 @@
 make -f Makefile-libbz2_so CC="gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -fPIC"
 make bzip2 bzip2recover
 
-install -dvm755 "$PKGDIR"/usr/{bin,lib,include,share/man/man1}
+install -dvm755 "$PKGDIR"/usr/{bin,lib,lib/pkgconfig,include,share/man/man1}
 
 install -vm755 bzip2-shared "$PKGDIR"/usr/bin/bzip2
 install -vm755 bzip2recover bzdiff bzgrep bzmore "$PKGDIR"/usr/bin

--- a/base-utils/bzip2/autobuild/prepare
+++ b/base-utils/bzip2/autobuild/prepare
@@ -5,20 +5,3 @@ sed -e 's/^CFLAGS=\(.*\)$/CFLAGS=\1 \$(BIGFILES)/g' \
 abinfo 'Replacing CFLAGS in Makefiles with what Autobuild3 defined...'
 sed -e "s|-O2|${CFLAGS}|g" -i "$SRCDIR"/Makefile
 sed -e "s|-O2|${CFLAGS}|g" -i "$SRCDIR"/Makefile-libbz2_so
-
-abinfo 'Generating bzip2.pc with HERE documents (contents refer from Arch Linux)...'
-cat << EOF > "$SRCDIR"/bzip2.pc
-prefix=/usr
-exec_prefix=/usr
-bindir=\${exec_prefix}/bin
-libdir=\${exec_prefix}/lib
-includedir=\${prefix}/include
-
-Name: bzip2
-Description: A file compression library
-Version: $PKGVER
-Libs: -L\${libdir} -lbz2
-Cflags: -I\${includedir}
-EOF
-
-cat "$SRCDIR"/bzip2.pc

--- a/base-utils/bzip2/autobuild/prepare
+++ b/base-utils/bzip2/autobuild/prepare
@@ -6,6 +6,19 @@ abinfo 'Replacing CFLAGS in Makefiles with what Autobuild3 defined...'
 sed -e "s|-O2|${CFLAGS}|g" -i "$SRCDIR"/Makefile
 sed -e "s|-O2|${CFLAGS}|g" -i "$SRCDIR"/Makefile-libbz2_so
 
-abinfo 'Copying bzip.pc to SRCDIR and patching the version in it...'
-cp -v "$SRCDIR"/../bzip2.pc "$SRCDIR"
-sed -e "s|1.0.6|$PKGVER|" -i "$SRCDIR"/bzip2.pc
+abinfo 'Generating bzip2.pc with HERE documents (contents refer from Arch Linux)...'
+cat << EOF > "$SRCDIR"/bzip2.pc
+prefix=/usr
+exec_prefix=/usr
+bindir=\${exec_prefix}/bin
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: bzip2
+Description: A file compression library
+Version: $PKGVER
+Libs: -L\${libdir} -lbz2
+Cflags: -I\${includedir}
+EOF
+
+cat "$SRCDIR"/bzip2.pc

--- a/base-utils/bzip2/autobuild/prepare
+++ b/base-utils/bzip2/autobuild/prepare
@@ -1,7 +1,11 @@
-sed -e 's/^CFLAGS=\(.*\)$/CFLAGS=\1 \$(BIGFILES)/' -i ./Makefile-libbz2_so
+abinfo 'Patching the CFLAGS in Makefile of libbz2.so...'
+sed -e 's/^CFLAGS=\(.*\)$/CFLAGS=\1 \$(BIGFILES)/g' \
+    -i "$SRCDIR"/Makefile-libbz2_so
 
-sed -e "s|-O2|${CFLAGS}|g" -i Makefile
-sed -e "s|-O2|${CFLAGS}|g" -i Makefile-libbz2_so
+abinfo 'Replacing CFLAGS in Makefiles with what Autobuild3 defined...'
+sed -e "s|-O2|${CFLAGS}|g" -i "$SRCDIR"/Makefile
+sed -e "s|-O2|${CFLAGS}|g" -i "$SRCDIR"/Makefile-libbz2_so
 
+abinfo 'Copying bzip.pc to SRCDIR and patching the version in it...'
 cp -v "$SRCDIR"/../bzip2.pc "$SRCDIR"
-sed -e 's/1.0.6/$PKGVER/g' -i "$SRCDIR"/bzip2.pc
+sed -e "s|1.0.6|$PKGVER|" -i "$SRCDIR"/bzip2.pc

--- a/base-utils/bzip2/autobuild/prepare
+++ b/base-utils/bzip2/autobuild/prepare
@@ -1,4 +1,7 @@
 sed -e 's/^CFLAGS=\(.*\)$/CFLAGS=\1 \$(BIGFILES)/' -i ./Makefile-libbz2_so
 
-sed -i "s|-O2|${CFLAGS}|g" Makefile
-sed -i "s|-O2|${CFLAGS}|g" Makefile-libbz2_so
+sed -e "s|-O2|${CFLAGS}|g" -i Makefile
+sed -e "s|-O2|${CFLAGS}|g" -i Makefile-libbz2_so
+
+cp -v "$SRCDIR"/../bzip2.pc "$SRCDIR"
+sed -e 's/1.0.6/$PKGVER/g' -i "$SRCDIR"/bzip2.pc

--- a/base-utils/bzip2/spec
+++ b/base-utils/bzip2/spec
@@ -1,5 +1,7 @@
 VER=1.0.8
-REL=2
-SRCS="tbl::https://sourceware.org/pub/bzip2/bzip2-$VER.tar.gz"
-CHKSUMS="sha256::ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
+REL=3
+SRCS="tbl::https://sourceware.org/pub/bzip2/bzip2-$VER.tar.gz \
+      file::rename=bzip2.pc::https://src.fedoraproject.org/rpms/bzip2/raw/rawhide/f/bzip2.pc"
+CHKSUMS="sha256::ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269 \
+         sha256::60ce5c6e994aecd25c4e63eeaeb0b20d4f7fc18ec6680dc1818a0e3c7a2a1794"
 CHKUPDATE="anitya::id=237"

--- a/base-utils/bzip2/spec
+++ b/base-utils/bzip2/spec
@@ -1,7 +1,5 @@
 VER=1.0.8
 REL=3
-SRCS="tbl::https://sourceware.org/pub/bzip2/bzip2-$VER.tar.gz \
-      file::rename=bzip2.pc::https://src.fedoraproject.org/rpms/bzip2/raw/rawhide/f/bzip2.pc"
-CHKSUMS="sha256::ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269 \
-         sha256::60ce5c6e994aecd25c4e63eeaeb0b20d4f7fc18ec6680dc1818a0e3c7a2a1794"
+SRCS="tbl::https://sourceware.org/pub/bzip2/bzip2-$VER.tar.gz"
+CHKSUMS="sha256::ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
 CHKUPDATE="anitya::id=237"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Add `bzip2.pc` into the `bzip2` package, so some build system like `meson` will be able to find `bzip2`.

Package(s) Affected
-------------------

`bzip2`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
