### PR TITLE
Retroarch: update to 1.9.6

### DIFF
--- a/extra-libretro/retroarch/autobuild/build
+++ b/extra-libretro/retroarch/autobuild/build
@@ -13,17 +13,12 @@ make DESTDIR="$PKGDIR" install
 make -C libretro-common/audio/dsp_filters
 make -C gfx/video_filters
 
-pushd "$SRCDIR"/../retroarch-assets
-mkdir -p "$PKGDIR"/usr/share/libretro/assets
-cp -r * "$PKGDIR"/usr/share/libretro/assets
-popd
-
 install -Dm644 libretro-common/audio/dsp_filters/*.{dsp,so} -t \
     "$PKGDIR"/usr/lib/retroarch/filters/audio/
 install -Dm644 gfx/video_filters/*.{filt,so} -t \
     "$PKGDIR"/usr/lib/retroarch/filters/video/
 
-cd "$SRCDIR"/retroarch-assets
+cd "$SRCDIR"/../retroarch-assets
 make install DESTDIR="$PKGDIR" \
     INSTALLDIR=/usr/share/retroarch/assets
 

--- a/extra-libretro/retroarch/autobuild/build
+++ b/extra-libretro/retroarch/autobuild/build
@@ -13,7 +13,6 @@ make DESTDIR="$PKGDIR" install
 make -C libretro-common/audio/dsp_filters
 make -C gfx/video_filters
 
-git clone https://github.com/libretro/retroarch-assets
 pushd retroarch-assets
 git checkout 505ad6205e5fd8a155daad02ab39953a0b15b0a9
 mkdir -p "$PKGDIR"/usr/share/libretro/assets

--- a/extra-libretro/retroarch/autobuild/build
+++ b/extra-libretro/retroarch/autobuild/build
@@ -13,8 +13,7 @@ make DESTDIR="$PKGDIR" install
 make -C libretro-common/audio/dsp_filters
 make -C gfx/video_filters
 
-pushd retroarch-assets
-git checkout 505ad6205e5fd8a155daad02ab39953a0b15b0a9
+pushd "$SRCDIR"/../retroarch-assets
 mkdir -p "$PKGDIR"/usr/share/libretro/assets
 cp -r * "$PKGDIR"/usr/share/libretro/assets
 popd

--- a/extra-libretro/retroarch/autobuild/build
+++ b/extra-libretro/retroarch/autobuild/build
@@ -13,9 +13,9 @@ make DESTDIR="$PKGDIR" install
 make -C libretro-common/audio/dsp_filters
 make -C gfx/video_filters
 
-install -Dm644 libretro-common/audio/dsp_filters/*.{dsp,so} -t \
+install -Dvm644 libretro-common/audio/dsp_filters/*.{dsp,so} -t \
     "$PKGDIR"/usr/lib/retroarch/filters/audio/
-install -Dm644 gfx/video_filters/*.{filt,so} -t \
+install -Dvm644 gfx/video_filters/*.{filt,so} -t \
     "$PKGDIR"/usr/lib/retroarch/filters/video/
 
 cd "$SRCDIR"/../retroarch-assets

--- a/extra-libretro/retroarch/autobuild/build
+++ b/extra-libretro/retroarch/autobuild/build
@@ -5,17 +5,30 @@ case "$ARCH" in
 	*) OPT="" ;;
 esac
 
-./configure --prefix=/usr --enable-al --enable-dylib \
-            --enable-sdl2 --enable-materialui $OPT --enable-xvideo \
-            --enable-v4l2 --enable-freetype --enable-pulse --enable-xmb
+abinfo 'Running configure ...'
+./configure --prefix=/usr \
+            --enable-al \
+            --enable-dylib \
+            --enable-sdl2 \
+            --enable-materialui $OPT \
+            --enable-xvideo \
+            --enable-v4l2 \
+            --enable-freetype \
+            --enable-pulse \
+            --enable-xmb
+
+abinfo 'Building main components ...'
 make
 make DESTDIR="$PKGDIR" install
-make -C libretro-common/audio/dsp_filters
-make -C gfx/video_filters
 
-install -Dvm644 libretro-common/audio/dsp_filters/*.{dsp,so} -t \
+abinfo 'Building filters ...'
+make -C "$SRCDIR"/libretro-common/audio/dsp_filters
+make -C "$SRCDIR"/gfx/video_filters
+
+abinfo 'Installing filters ...'
+install -Dvm644 "$SRCDIR"/libretro-common/audio/dsp_filters/*.{dsp,so} -t \
     "$PKGDIR"/usr/lib/retroarch/filters/audio/
-install -Dvm644 gfx/video_filters/*.{filt,so} -t \
+install -Dvm644 "$SRCDIR"/gfx/video_filters/*.{filt,so} -t \
     "$PKGDIR"/usr/lib/retroarch/filters/video/
 
 cd "$SRCDIR"/../retroarch-assets

--- a/extra-libretro/retroarch/autobuild/prepare
+++ b/extra-libretro/retroarch/autobuild/prepare
@@ -1,2 +1,0 @@
-# FIXME: no version anchor.
-git clone https://github.com/libretro/retroarch-assets

--- a/extra-libretro/retroarch/spec
+++ b/extra-libretro/retroarch/spec
@@ -1,4 +1,6 @@
 VER=1.9.6
-SRCS="tbl::https://github.com/libretro/RetroArch/archive/v$VER.tar.gz"
-CHKSUMS="sha256::2b7c81df4c742cc1bcd00297bc0bd9f1f4ea4bf9518d161fb013f008c26f92b9"
+SRCS="tbl::https://github.com/libretro/RetroArch/archive/v$VER.tar.gz \
+      git::commit=8d114dd55b0a357efec12d34d02dfe190a6ccc3a;rename=retroarch-assets::https://github.com/libretro/retroarch-assets"
+CHKSUMS="sha256::2b7c81df4c742cc1bcd00297bc0bd9f1f4ea4bf9518d161fb013f008c26f92b9 SKIP"
 CHKUPDATE="anitya::id=176085"
+SUBDIR="RetroArch-$VER"

--- a/extra-libretro/retroarch/spec
+++ b/extra-libretro/retroarch/spec
@@ -1,4 +1,4 @@
 VER=1.9.6
 SRCS="tbl::https://github.com/libretro/RetroArch/archive/v$VER.tar.gz"
-CHKSUMS="sha256::cd4e403042fd923e0669014bd716c4beef340d60001007f8cfacff11f33cb0e7"
+CHKSUMS="sha256::2b7c81df4c742cc1bcd00297bc0bd9f1f4ea4bf9518d161fb013f008c26f92b9"
 CHKUPDATE="anitya::id=176085"

--- a/extra-libretro/retroarch/spec
+++ b/extra-libretro/retroarch/spec
@@ -1,4 +1,4 @@
-VER=1.8.1
+VER=1.9.6
 SRCS="tbl::https://github.com/libretro/RetroArch/archive/v$VER.tar.gz"
 CHKSUMS="sha256::cd4e403042fd923e0669014bd716c4beef340d60001007f8cfacff11f33cb0e7"
 CHKUPDATE="anitya::id=176085"


### PR DESCRIPTION
Topic Description
-----------------

Retroarch: update to 1.9.6

Package(s) Affected
-------------------

`retroarch`

Security Update?
----------------

No


Architectural Progress
----------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

