### PR TITLE
cmake: update to 3.21.2

### DIFF
--- a/extra-devel/cmake/autobuild/build
+++ b/extra-devel/cmake/autobuild/build
@@ -24,3 +24,16 @@ install -dv "$PKGDIR"/usr/share/emacs/site-lisp/
 emacs -batch \
      -f batch-byte-compile \
      "$PKGDIR"/usr/share//emacs/site-lisp/cmake-mode.el
+
+abinfo "Generating postinst script ..."
+MMVER="${PKGVER%.*}"
+cat << EOF > "$SRCDIR"/autobuild/postinst
+for i in 3.{1..${MMVER#*.}}; do
+        if [ -d /usr/share/cmake-\$i ]; then
+                cp -rf /usr/share/cmake-\$i/* /usr/share/cmake/
+                rm -r /usr/share/cmake-\$i
+        fi
+done
+
+ln -s /usr/share/cmake /usr/share/cmake-$MMVER
+EOF

--- a/extra-devel/cmake/autobuild/postinst
+++ b/extra-devel/cmake/autobuild/postinst
@@ -1,6 +1,6 @@
 VER=3.18
 
-for i in 3.1 3.2 3.3 3.4 3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14 3.15 3.16 3.17 3.18; do
+for i in 3.{1..18}; do
 	if [ -d /usr/share/cmake-$i ]; then
 		cp -rf /usr/share/cmake-$i/* /usr/share/cmake/
 		rm -r /usr/share/cmake-$i

--- a/extra-devel/cmake/spec
+++ b/extra-devel/cmake/spec
@@ -1,4 +1,4 @@
 VER=3.21.2
 SRCS="tbl::https://cmake.org/files/v${VER:0:4}/cmake-$VER.tar.gz"
-CHKSUMS="sha256::2c89f4e30af4914fd6fb5d00f863629812ada848eee4e2d29ec7e456d7fa32e5"
+CHKSUMS="sha256::94275e0b61c84bb42710f5320a23c6dcb2c6ee032ae7d2a616f53f68b3d21659"
 CHKUPDATE="anitya::id=306"

--- a/extra-devel/cmake/spec
+++ b/extra-devel/cmake/spec
@@ -1,5 +1,4 @@
-VER=3.18.3
-REL=1
+VER=3.21.2
 SRCS="tbl::https://cmake.org/files/v${VER:0:4}/cmake-$VER.tar.gz"
 CHKSUMS="sha256::2c89f4e30af4914fd6fb5d00f863629812ada848eee4e2d29ec7e456d7fa32e5"
 CHKUPDATE="anitya::id=306"

--- a/extra-games/pingus/spec
+++ b/extra-games/pingus/spec
@@ -1,4 +1,5 @@
 VER=0.7.6+git20201009
+REL=1
 SRCS="git::commit=e48a1c25c50abb4080c789eaace930630529b397::https://gitlab.com/Pingus/pingus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8592"

--- a/extra-games/stepmania/autobuild/patches/0001-fix-ppc64-support.patch
+++ b/extra-games/stepmania/autobuild/patches/0001-fix-ppc64-support.patch
@@ -1,0 +1,12 @@
+--- a/src/CMakeLists.txt	2021-09-02 00:53:18.839910999 -0500
++++ b/src/CMakeLists.txt	2021-09-02 00:11:42.318643959 -0500
+@@ -388,6 +388,9 @@
+     elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+       message("Host processor is 64bit ARM")
+       sm_add_compile_definition("${SM_EXE_NAME}" CPU_AARCH64)
++    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc")
++      message("Host processor is PowerPC")
++      sm_add_compile_definition("${SM_EXE_NAME}" CPU_PPC)
+     else()
+       message("Unrecognized host processor type")
+     endif()

--- a/extra-games/stepmania/spec
+++ b/extra-games/stepmania/spec
@@ -1,4 +1,5 @@
 VER=5.1.0+20200915
+REL=1
 SRCS="git::commit=3968c947820bf9978717de0e50c93b2d32495496::https://github.com/stepmania/stepmania/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227682"

--- a/extra-kde/kalzium/spec
+++ b/extra-kde/kalzium/spec
@@ -1,4 +1,5 @@
 VER=21.08.0
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kalzium-$VER.tar.xz"
 CHKSUMS="sha256::d9f2d98376a1bef272915c153b4a596ffcf6b74d7709a193198fd75914661d8c"
 CHKUPDATE="anitya::id=8763"

--- a/extra-libs/avogadrolibs/spec
+++ b/extra-libs/avogadrolibs/spec
@@ -1,4 +1,4 @@
 VER=1.95.1
 SRCS="tbl::https://github.com/OpenChemistry/avogadrolibs/archive/$VER.tar.gz"
-CHKSUMS="sha256::9a387b1c5673640b48aa955c4a38019ed399b6839bd53d92e456f9929f235078"
+CHKSUMS="sha256::52817eebfc0cf700e5f6c0c4455b460618ec0dd7cb4ede5d8fabc5a2d73a7816"
 CHKUPDATE="anitya::id=221504"

--- a/extra-libs/avogadrolibs/spec
+++ b/extra-libs/avogadrolibs/spec
@@ -1,5 +1,4 @@
-VER=1.92.1
-REL=3
+VER=1.95.1
 SRCS="tbl::https://github.com/OpenChemistry/avogadrolibs/archive/$VER.tar.gz"
 CHKSUMS="sha256::9a387b1c5673640b48aa955c4a38019ed399b6839bd53d92e456f9929f235078"
 CHKUPDATE="anitya::id=221504"

--- a/extra-libs/jsoncpp/spec
+++ b/extra-libs/jsoncpp/spec
@@ -1,5 +1,4 @@
-VER=1.8.4
-REL=3
+VER=1.9.4
 SRCS="tbl::https://github.com/open-source-parsers/jsoncpp/archive/$VER.tar.gz"
 CHKSUMS="sha256::c49deac9e0933bcb7044f08516861a2d560988540b23de2ac1ad443b219afdb6"
 CHKUPDATE="anitya::id=7483"

--- a/extra-libs/jsoncpp/spec
+++ b/extra-libs/jsoncpp/spec
@@ -1,4 +1,4 @@
 VER=1.9.4
 SRCS="tbl::https://github.com/open-source-parsers/jsoncpp/archive/$VER.tar.gz"
-CHKSUMS="sha256::c49deac9e0933bcb7044f08516861a2d560988540b23de2ac1ad443b219afdb6"
+CHKSUMS="sha256::e34a628a8142643b976c7233ef381457efad79468c67cb1ae0b83a33d7493999"
 CHKUPDATE="anitya::id=7483"

--- a/extra-libs/spglib/autobuild/prepare
+++ b/extra-libs/spglib/autobuild/prepare
@@ -1,2 +1,0 @@
-touch INSTALL NEWS README AUTHORS
-autoreconf -vi

--- a/extra-libs/spglib/spec
+++ b/extra-libs/spglib/spec
@@ -1,4 +1,4 @@
-VER=1.11.1.2
+VER=1.16.2
 SRCS="tbl::https://github.com/atztogo/spglib/archive/v$VER.tar.gz"
-CHKSUMS="sha256::d99dab24accd269df65c01febd05cb5dd1094a89d7279f8390871f0432df2b56"
+CHKSUMS="sha256::5723789bee7371ebba91d78c729d2a608f198fad5e1c95eebe18fda9f2914ec8"
 CHKUPDATE="anitya::id=14891"

--- a/extra-utils/polybar/spec
+++ b/extra-utils/polybar/spec
@@ -1,4 +1,4 @@
-VER=3.5.3
+VER=3.5.6
 SRCS="https://github.com/polybar/polybar/releases/download/$VER/polybar-$VER.tar.gz"
 CHKSUMS="sha256::d23fbb9a7b7f1cdd334fe0ba3adc0f9602cfc94aa0827c058584059416792680"
 CHKUPDATE="anitya::id=231634"

--- a/extra-utils/polybar/spec
+++ b/extra-utils/polybar/spec
@@ -1,4 +1,4 @@
 VER=3.5.6
 SRCS="https://github.com/polybar/polybar/releases/download/$VER/polybar-$VER.tar.gz"
-CHKSUMS="sha256::d23fbb9a7b7f1cdd334fe0ba3adc0f9602cfc94aa0827c058584059416792680"
+CHKSUMS="sha256::dfe602fc6ac96eac2ae0f5deb2f87e0dd1f81ea5d0f04ad3b3bfd71efd5cc038"
 CHKUPDATE="anitya::id=231634"


### PR DESCRIPTION
Topic Description
-----------------

cmake: update to 3.21.2

Package(s) Affected
-------------------

```
extra-libs/jsoncpp
extra-devel/cmake
extra-libs/spglib
extra-libs/avogadrolibs
extra-kde/kalzium
extra-games/pingus
extra-utils/polybar
extra-games/stepmania
```

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

