### PR TITLE
openssl: security update to 1.1.1l

### DIFF
--- a/base-libs/openssl/spec
+++ b/base-libs/openssl/spec
@@ -1,4 +1,4 @@
-VER=1.1.1k
+VER=1.1.1l
 SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5"
+CHKSUMS="sha256::0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1"
 CHKUPDATE="anitya::id=2566"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

openssl: security update to 1.1.1l

Package(s) Affected
-------------------

`openssl`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

Yes - Issue Number: #3406
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
