### PR TITLE
vscode: update to 1.59.1

### DIFF
--- a/extra-editors/vscode/autobuild/defines
+++ b/extra-editors/vscode/autobuild/defines
@@ -5,5 +5,5 @@ PKGDEP="alsa-lib at-spi2-atk cups desktop-file-utils fontconfig gtk-3 gconf libn
 BUILDDEP="gcc nvm gulp make pkg-config python-2 yarn"
 PKGPROV="code"
 
-FAIL_ARCH="!(amd64||arm64)"
+FAIL_ARCH="!(amd64|arm64)"
 ABSPLITDBG=0

--- a/extra-editors/vscode/autobuild/patches/0003-disable-crash-reporter.patch
+++ b/extra-editors/vscode/autobuild/patches/0003-disable-crash-reporter.patch
@@ -1,0 +1,63 @@
+From 4cbe9d2a8f8a8f9b094e76d83f284dc19679382f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?F=C3=A1bio=20Cabral=20Pacheco?= <fcabralpacheco@gmail.com>
+Date: Mon, 16 Aug 2021 03:44:40 -0300
+Subject: [PATCH] Move the crash reporter config registration to telemetry
+ service and change the default value.
+
+---
+ .../telemetry/common/telemetryService.ts        | 17 +++++++++++++++++
+ .../electron-sandbox/desktop.contribution.ts    | 16 ----------------
+ 2 files changed, 17 insertions(+), 16 deletions(-)
+
+diff --git a/src/vs/platform/telemetry/common/telemetryService.ts b/src/vs/platform/telemetry/common/telemetryService.ts
+index 3759838daabf..45ec80b93fc3 100644
+--- a/src/vs/platform/telemetry/common/telemetryService.ts
++++ b/src/vs/platform/telemetry/common/telemetryService.ts
+@@ -229,3 +229,20 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
+ 		}
+ 	}
+ });
++
++Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
++	'id': TELEMETRY_SECTION_ID,
++	'order': 110,
++	title: localize('telemetryConfigurationTitle', "Telemetry"),
++	'type': 'object',
++	'properties': {
++		'telemetry.enableCrashReporter': {
++			'type': 'boolean',
++			'description': localize('telemetry.enableCrashReporting', "Enable crash reports to be collected. This helps us improve stability. \nThis option requires restart to take effect."),
++			'default': false,
++			'restricted': true,
++			'scope': ConfigurationScope.APPLICATION,
++			'tags': ['usesOnlineServices', 'telemetry']
++		}
++	}
++});
+diff --git a/src/vs/workbench/electron-sandbox/desktop.contribution.ts b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+index 0d5532643edd..9415eb034bab 100644
+--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
++++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+@@ -222,22 +222,6 @@ import { EditorsVisibleContext, SingleEditorGroupsContext } from 'vs/workbench/c
+ 		}
+ 	});
+ 
+-	// Telemetry
+-	registry.registerConfiguration({
+-		'id': 'telemetry',
+-		'order': 110,
+-		title: localize('telemetryConfigurationTitle', "Telemetry"),
+-		'type': 'object',
+-		'properties': {
+-			'telemetry.enableCrashReporter': {
+-				'type': 'boolean',
+-				'description': localize('telemetry.enableCrashReporting', "Enable crash reports to be collected. This helps us improve stability. \nThis option requires restart to take effect."),
+-				'default': true,
+-				'tags': ['usesOnlineServices', 'telemetry']
+-			}
+-		}
+-	});
+-
+ 	// Keybinding
+ 	registry.registerConfiguration({
+ 		'id': 'keyboard',

--- a/extra-editors/vscode/spec
+++ b/extra-editors/vscode/spec
@@ -1,4 +1,4 @@
-VER=1.58.2
+VER=1.59.1
 SRCS="git::commit=tags/$VER::https://github.com/microsoft/vscode/"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=microsoft/vscode;pattern=^\d\.\d+\.\d+$"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

vscode: update to 1.59.1

Package(s) Affected
-------------------

vscode: 1.59.1

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

N/A

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

N/A
