### PR TITLE
jack: use the old workaround to fix build

### DIFF
--- a/extra-multimedia/jack/autobuild/build
+++ b/extra-multimedia/jack/autobuild/build
@@ -2,12 +2,15 @@ if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
     export FFADO="--firewire"
 fi
 
-python2 waf configure --prefix=/usr \
+python3 waf configure --prefix=/usr \
                       --alsa \
                       --classic \
                       --dbus \
+                      --systemd-unit \
+                      --clients 256 \
+                      --ports-per-application=2048 \
                       --doxygen ${FFADO}
-python2 waf build -p -j$(nproc)
-python2 waf install --destdir="$PKGDIR"
+python3 waf build -p -j$(nproc)
+python3 waf install --destdir="$PKGDIR"
 
 chmod +x "$PKGDIR"/usr/lib/*.so*

--- a/extra-multimedia/jack/autobuild/defines
+++ b/extra-multimedia/jack/autobuild/defines
@@ -1,6 +1,12 @@
 PKGNAME=jack
 PKGDES="Jack Audio Connection Kit"
 PKGSEC=sound
-PKGDEP="alsa-lib celt libsamplerate opus dbus-python libsndfile readline eigen-3"
+PKGDEP="alsa-lib celt libsamplerate opus dbus-python libsndfile readline"
 PKGDEP__AMD64="${PKGDEP} libffado"
-BUILDDEP="doxygen"
+BUILDDEP="doxygen eigen-3 llvm"
+BUILDDEP__LOONGSON3="doxygen eigen-3"
+
+# NOTE: To assist some of JACK clients to interpose (mess up) with jack binary directly (!!!)
+ABSTRIP=0
+USECLANG=1
+USECLANG__LOONGSON3=0

--- a/extra-multimedia/jack/spec
+++ b/extra-multimedia/jack/spec
@@ -1,4 +1,5 @@
 VER=1.9.19
+REL=1
 SRCS="tbl::https://github.com/jackaudio/jack2/archive/refs/tags/v$VER.tar.gz"
 CHKSUMS="sha256::9030f4dc11773351b6ac96affd9c89803a5587ebc1b091e5ff866f433327e4b0"
 CHKUPDATE="anitya::id=21358"


### PR DESCRIPTION
... seems like there are still softwares doing the old shenanigans

Topic Description
-----------------

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
