### PR TITLE
CD Ripping Survey - 2021 Jul

### DIFF
--- a/extra-libs/chromaprint/autobuild/defines
+++ b/extra-libs/chromaprint/autobuild/defines
@@ -3,6 +3,9 @@ PKGSEC=libs
 PKGDEP="ffmpeg"
 PKGDES="Library that implements a custom algorithm for extracting fingerprints from any audio source"
 
-CMAKE_AFTER="-DBUILD_EXAMPLES=OFF"
+CMAKE_AFTER="
+	-DBUILD_EXAMPLES=OFF
+	-DBUILD_TOOLS=ON
+"
 PKGBREAK="clementine<=1.3.1-2 gst-plugins-bad-1-0<=1.10.2 pyacoustid<=1.1.2 \
           vlc<=2.2.4-3"

--- a/extra-libs/chromaprint/spec
+++ b/extra-libs/chromaprint/spec
@@ -1,5 +1,4 @@
-VER=1.4.3
-REL=3
+VER=1.5.0
 SRCS="tbl::https://github.com/acoustid/chromaprint/releases/download/v$VER/chromaprint-$VER.tar.gz"
-CHKSUMS="sha256::ea18608b76fb88e0203b7d3e1833fb125ce9bb61efe22c6e169a50c52c457f82"
+CHKSUMS="sha256::573a5400e635b3823fc2394cfa7a217fbb46e8e50ecebd4a61991451a8af766a"
 CHKUPDATE="anitya::id=286"

--- a/extra-multimedia/accuraterip-checksum/autobuild/build
+++ b/extra-multimedia/accuraterip-checksum/autobuild/build
@@ -1,4 +1,2 @@
-cc ${CPPFLAGS} ${CFLAGS} ${CXXFLAGS} -lsndfile accuraterip-checksum.c \
-   -o "accuraterip-checksum"
-install -Dvm0755 "$SRCDIR"/accuraterip-checksum \
-    "$PKGDIR"/usr/bin/accuraterip-checksum
+abinfo "Do nothing"
+mkdir -vp "${PKGDIR}"

--- a/extra-multimedia/accuraterip-checksum/autobuild/defines
+++ b/extra-multimedia/accuraterip-checksum/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=accuraterip-checksum
 PKGSEC=sound
-PKGDEP="libsndfile"
-PKGDES="commandline program to compute the AccurateRip checksum of singletrack WAV"
+PKGDEP="whipper"
+PKGDES="Transitional package for whipper"
 
-AB_FLAGS_O3=1
-NOLTO=1
+PKGEPOCH=1
+ABHOST=noarch

--- a/extra-multimedia/accuraterip-checksum/spec
+++ b/extra-multimedia/accuraterip-checksum/spec
@@ -1,5 +1,2 @@
-VER=1.5
-REL=1
-SRCTBL=https://github.com/leo-bogert/accuraterip-checksum/archive/version${VER}.tar.gz
-CHKSUMS="sha256::ffbf84c5e53ac6a4014ffca52669f471b2cd2018adecd2ca5e29db905fcc4c9a"
-CHKUPDATE="anitya::id=15312"
+VER=0
+DUMMYSRC=1

--- a/extra-multimedia/mutagen/autobuild/defines
+++ b/extra-multimedia/mutagen/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=mutagen
 PKGSEC=libs
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 PKGDES="An audio metadata tag reader and writer"
 
+NOPYTHON2=1
 ABHOST=noarch
+PKGBREAK="mat<=0.6.1-1"

--- a/extra-multimedia/mutagen/spec
+++ b/extra-multimedia/mutagen/spec
@@ -1,5 +1,4 @@
-VER=1.43.0
+VER=1.45.1
 SRCS="tbl::https://pypi.io/packages/source/m/mutagen/mutagen-$VER.tar.gz"
-CHKSUMS="sha256::3a982d39f1b800520a32afdebe3543f972e83a6ddd0c0198739a161ee705b588"
-REL=1
+CHKSUMS="sha256::6397602efb3c2d7baebd2166ed85731ae1c1d475abca22090b7141ff5034b3e1"
 CHKUPDATE="anitya::id=3931"

--- a/extra-multimedia/picard/autobuild/defines
+++ b/extra-multimedia/picard/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=picard
+PKGSEC=sound
+PKGDES="MusicBrainz Picard Music Tagging Suite"
+PKGDEP="python-3 pyqt5 qt-5 mutagen dateutil python-discid markdown chromaprint"
+BUILDEP="setuptools"
+
+NOPYTHON2=1
+

--- a/extra-multimedia/picard/spec
+++ b/extra-multimedia/picard/spec
@@ -1,0 +1,3 @@
+VER=2.6.3
+SRCTBL="https://github.com/metabrainz/picard/archive/release-${VER}.tar.gz"
+CHKSUM="sha256::129700d717968c5e192152c7b77595e58a4e1c4804460c2342de721de8d56b95"

--- a/extra-multimedia/whipper/autobuild/defines
+++ b/extra-multimedia/whipper/autobuild/defines
@@ -1,9 +1,13 @@
 PKGNAME=whipper
 PKGSEC=sound
-PKGDEP="cdparanoia cdrdao pygobject-2 python-musicbrainzngs mutagen setuptools \
-        cddb pycdio libsndfile flac sox accuraterip-checksum idna requests"
+PKGDEP="cdparanoia pygobject-3 cdrdao python-musicbrainzngs mutagen \
+        cddb pycdio libsndfile flac sox idna requests ruamel-yaml"
+BUILDDEP="setuptools wheel"
 PKGDES="Python CD-DA ripper preferring accuracy over speed"
+PKGPROV="accuraterip-checksum"
+PKGREP="accuraterip-checksum"
 
 ABTYPE=python
-NOPYTHON3=1
-ABHOST=noarch
+NOPYTHON2=1
+
+PKGBREAK="accuraterip-checksum<=1.5-1"

--- a/extra-multimedia/whipper/spec
+++ b/extra-multimedia/whipper/spec
@@ -1,5 +1,4 @@
-VER=0.7.3
-REL=2
-SRCTBL=https://github.com/JoeLametta/whipper/archive/v${VER}.tar.gz
-CHKSUMS="sha256::cce85e1d8946830834ded8fc130fd41d4b7f69037c187f46a8be662c3d43957e"
+VER=0.10.0
+SRCTBL=https://github.com/whipper-team/whipper/archive/v${VER}.tar.gz
+CHKSUM="sha256::a6fba11f4460854267c610f066c185e859d7177699b50ef584fc4f705962d356"
 CHKUPDATE="anitya::id=15722"

--- a/extra-python/python-discid/autobuild/defines
+++ b/extra-python/python-discid/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=python-discid
+PKGSEC=python
+PKGDES="Python bindings of libdiscid"
+PKGDEP="python-3 libdiscid"
+
+NOPYTHON2=1
+USE_PYTHON_BUILD_FIRST=1
+ABHOST=noarch

--- a/extra-python/python-discid/spec
+++ b/extra-python/python-discid/spec
@@ -1,0 +1,3 @@
+VER=1.2.0
+SRCTBL="https://files.pythonhosted.org/packages/source/d/discid/discid-${VER}.tar.gz"
+CHKSUM="sha256::cd9630bc53f5566df92819641040226e290b2047573f2c74a6e92b8eed9e86b9"

--- a/extra-python/python-musicbrainzngs/autobuild/defines
+++ b/extra-python/python-musicbrainzngs/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=python-musicbrainzngs
 PKGSEC=python
-PKGDEP="python-2"
+PKGDEP="python-3"
+PKGSUG="python-2"
+BUILDDEP="$PKGSUG"
 PKGDES="Python bindings for the MusicBrainz NGS service"
 
-NOPYTHON3=1
 ABHOST=noarch

--- a/extra-python/python-musicbrainzngs/spec
+++ b/extra-python/python-musicbrainzngs/spec
@@ -1,5 +1,4 @@
-VER=0.6
-REL=2
+VER=0.7.1
 SRCS="tbl::https://pypi.python.org/packages/source/m/musicbrainzngs/musicbrainzngs-$VER.tar.gz"
-CHKSUMS="sha256::28ef261a421dffde0a25281dab1ab214e1b407eec568cd05a53e73256f56adb5"
+CHKSUMS="sha256::ab1c0100fd0b305852e65f2ed4113c6de12e68afd55186987b8ed97e0f98e627"
 CHKUPDATE="anitya::id=8458"

--- a/extra-utils/mat/autobuild/defines
+++ b/extra-utils/mat/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=mat
 PKGSEC=utils
-PKGDEP="hachoir-parser pygobject-2 pdfrw pillow pypoppler mutagen perl-image-exiftool"
+PKGDEP="hachoir-parser pygobject-3 pdfrw pillow pypoppler mutagen perl-image-exiftool"
 BUILDDEP="python-distutils-extra intltool"
 PKGDES="Metadata anonymisation toolkit"
 
 ABHOST=noarch
-NOPYTHON3=1
+NOPYTHON2=1

--- a/extra-utils/mat/spec
+++ b/extra-utils/mat/spec
@@ -1,5 +1,4 @@
-VER=0.6.1
-REL=2
-SRCS="tbl::https://mat.boum.org/files/mat-$VER.tar.xz"
-CHKSUMS="sha256::0782e7db554ad1dddefd71c9c81e36a05464d73ab54ee2a474ea6ac90e8e51b9"
+VER=0.12.1
+SRCS="tbl::https://0xacab.org/jvoisin/mat2/-/archive/${VER}/mat2-${VER}.tar.gz"
+CHKSUMS="sha256::5f1cf47c61cc137b5a3d0520c4d4db27706b045f2425ee3837148b2397a26e65"
 CHKUPDATE="anitya::id=231612"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates the following packages and migrates them to python 3 where applicable.

Package(s) Affected
-------------------

* `python-musicbrainzngs [noarch]`
* `mutagen [noarch]`
* `whipper`
* `accuraterip-checksum [demoted to noarch]`
* `mat`
* `python-discid [noarch]`
* `chromaprint`
* `picard`

Build Order
-----------

Build in the order of update listing above.

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
