### PR TITLE
Cutefish rework

### DIFF
--- a/extra-bases/cutefish-base/autobuild/defines
+++ b/extra-bases/cutefish-base/autobuild/defines
@@ -6,4 +6,5 @@ PKGDEP="libcutefish fishui cutefish-core cutefish-dock cutefish-kwin-plugins \
 PKGRECOM="cutefish-calculator cutefish-filemanager cutefish-terminal"
 PKGDES="Meta package for Cutefish desktop environment"
 
+ABHOST=noarch
 VER_NONE=1

--- a/extra-cutefish/cutefish-calculator/spec
+++ b/extra-cutefish/cutefish-calculator/spec
@@ -1,4 +1,4 @@
 VER=0.4
 SRCS="https://github.com/cutefishos/calculator/archive/$VER/cutefish-calculator-$VER.tar.gz"
-CHKSUMS="sha256::e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+CHKSUMS="sha256::6c50f80545c4d96f1632541da53cd030e353237177f3de8b014a5d3d469102da"
 CHKUPDATE="anitya::id=234872"

--- a/extra-cutefish/cutefish-launcher/spec
+++ b/extra-cutefish/cutefish-launcher/spec
@@ -1,4 +1,4 @@
 VER=0.4
 SRCS="tbl::https://github.com/cutefishos/launcher/archive/$VER/cutefish-launcher-$VER.tar.gz"
-CHKSUMS="sha256::e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+CHKSUMS="sha256::6824b901197b556b3af5c52d337bb2f47f21a8d14ee97a3e2f6bc9f8a9576c50"
 CHKUPDATE="anitya::id=234857"

--- a/extra-cutefish/cutefish-statusbar/spec
+++ b/extra-cutefish/cutefish-statusbar/spec
@@ -1,4 +1,4 @@
 VER=0.4
 SRCS="tbl::https://github.com/cutefishos/statusbar/archive/$VER/cutefish-statusbar-$VER.tar.gz"
-CHKSUMS="sha256::e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+CHKSUMS="sha256::2cee66f1241882702180f9b14d5986b0e0505a195a2b2030f8db94b2d95f2967"
 CHKUPDATE="anitya::id=234865"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Due to GitHub's some behavior, the sha256sums of following packages have changed when I built them on relay, this PR is to correct them.

Package(s) Affected
-------------------

- `cutefish-calculator`
- `cutefish-launcher`
- `cutefish-statusbar`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
