### PR TITLE
Go 1.17 Survey

### DIFF
--- a/extra-admin/gotop/spec
+++ b/extra-admin/gotop/spec
@@ -1,5 +1,5 @@
 VER=4.0.1
-REL=3
+REL=4
 SRCS="https://github.com/xxxserxxx/gotop/archive/v$VER.tar.gz"
 CHKSUMS="sha256::38a34543ed828ed8cedd93049d9634c2e578390543d4068c19f0d0c20aaf7ba0"
 CHKUPDATE="anitya::id=226757"

--- a/extra-admin/podman/spec
+++ b/extra-admin/podman/spec
@@ -1,5 +1,5 @@
 VER=2.2.1
-REL=3
+REL=4
 SRCS="tbl::https://github.com/containers/podman/archive/v${VER}.tar.gz \
       git::commit=c654c95366ac5f309ca3e5727c9b858864247328;rename=dnsname::https://github.com/containers/dnsname"
 CHKSUMS="sha256::3212bad60d945c1169b27da03959f36d92d1d8964645c701a5a82a89118e96d1 \

--- a/extra-android/android-platform-tools/spec
+++ b/extra-android/android-platform-tools/spec
@@ -2,3 +2,4 @@ VER=31.0.0
 SRCS="https://github.com/nmeum/android-tools/releases/download/$VER/android-tools-$VER.tar.xz"
 CHKSUMS="sha256::0b8f16370072d03e9f26de17ecba7dd44771cb042a23e86869108d57eb22f20d"
 CHKUPDATE="anitya::id=226905"
+REL=1

--- a/extra-database/mongodb/spec
+++ b/extra-database/mongodb/spec
@@ -1,5 +1,5 @@
 VER=4.4.4
-REL=1
+REL=2
 SRCS="https://fastdl.mongodb.org/src/mongodb-src-r$VER.tar.gz"
 CHKSUMS="sha256::33b15c80c61800a7bb73999159dfff374ba4fcc0b56b9949c81ff5e411a76956"
 CHKUPDATE="anitya::id=2008"

--- a/extra-devel/git-lfs/spec
+++ b/extra-devel/git-lfs/spec
@@ -1,5 +1,5 @@
 VER=2.13.2
-REL=1
+REL=2
 SRCS=git::commit=tags/v${VER}::https://github.com/git-lfs/git-lfs.git
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11551"

--- a/extra-devel/pup/spec
+++ b/extra-devel/pup/spec
@@ -1,5 +1,5 @@
 VER=0.4.0
-REL=12
+REL=13
 SRCS="tbl::https://github.com/ericchiang/pup/archive/v$VER.tar.gz"
 CHKSUMS="sha256::0d546ab78588e07e1601007772d83795495aa329b19bd1c3cde589ddb1c538b0"
 CHKUPDATE="anitya::id=227247"

--- a/extra-doc/go-md2man/spec
+++ b/extra-doc/go-md2man/spec
@@ -2,3 +2,4 @@ VER=2.0.0+git20201216
 SRCS="git::commit=af8da765f0460ccb1d91003b4945a792363a94ca::https://github.com/cpuguy83/go-md2man"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14461"
+REL=1

--- a/extra-go/delve/autobuild/defines
+++ b/extra-go/delve/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=delve
-PKGSEC=go
+PKGSEC=devel
 PKGDEP="glibc"
 BUILDDEP="go"
 PKGDES="Debugger for the Go programming language"

--- a/extra-go/delve/spec
+++ b/extra-go/delve/spec
@@ -1,6 +1,5 @@
-VER=1.3.2
-REL=7
-SRCS="https://github.com/derekparker/delve/archive/v$VER.tar.gz"
-CHKSUMS="sha256::a1879caba7caee970e38b57aa81575b9b3e5a17f0ceef05e1f3d09d94f296e5c"
+VER=1.7.1
+SRCS="https://github.com/go-delve/delve/archive/refs/tags/v$VER.tar.gz"
+CHKSUMS="sha256::0734b86d48291749ba2537fa6c03e4c3451628f630055c877789e0346db8d67d"
 CHKUPDATE="anitya::id=40149"
 SUBDIR=.

--- a/extra-go/dep/autobuild/build
+++ b/extra-go/dep/autobuild/build
@@ -23,5 +23,5 @@ abinfo "Building Dep ..."
 )
 
 abinfo "Installing Dep ..."
-install -Dvm755 "$SRCDIR"/src/github.com/golang/dep/cmd/dep/bin/dep \
+install -Dvm755 "$SRCDIR"/bin/dep \
     "$PKGDIR"/usr/bin/dep

--- a/extra-go/dep/spec
+++ b/extra-go/dep/spec
@@ -1,5 +1,5 @@
 VER=0.5.4
-REL=11
+REL=12
 SRCS="https://github.com/golang/dep/archive/v$VER.tar.gz"
 CHKSUMS="sha256::929c8f759838f98323211ba408a831ea80d93b75beda8584b6d950f393a3298a"
 CHKUPDATE="anitya::id=18652"

--- a/extra-go/glide/spec
+++ b/extra-go/glide/spec
@@ -1,5 +1,5 @@
 VER=0.13.3
-REL=11
+REL=12
 SRCS="git::commit=tags/v$VER::https://github.com/Masterminds/glide"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11625"

--- a/extra-go/go/autobuild/build
+++ b/extra-go/go/autobuild/build
@@ -86,10 +86,6 @@ install -Dvm755 "$SRCDIR"/src/run.bash \
 cp -rv "$SRCDIR"/misc \
     "$PKGDIR/usr/lib/go/"
 
-abinfo "Installing documentation favicon ..."
-install -Dvm644 "$SRCDIR"/favicon.ico \
-    "$PKGDIR/usr/lib/go/favicon.ico"
-
 abinfo "Removing CGI bin in Go documentation ..."
 rm -fv "$PKGDIR/usr/share/go/doc/articles/wiki/get.bin"
 

--- a/extra-go/go/spec
+++ b/extra-go/go/spec
@@ -1,9 +1,9 @@
-VER=1.16
+VER=1.17
 # FIXME: Using release-branch.go.${PKGVER:0:4} branch, 1.16 not yet ready?
 SRCS="tbl::https://dl.google.com/go/go$VER.src.tar.gz \
-      git::commit=c1934b75d054975b79a8179cb6f0a9b8b3fa33cd;rename=tools::https://go.googlesource.com/tools \
-      git::commit=a5fa9d4b7c91aa1c3fecbeb6358ec1127b910dd6;rename=net::https://github.com/golang/net"
-CHKSUMS="sha256::7688063d55656105898f323d90a79a39c378d86fe89ae192eb3b7fc46347c95a \
+      git::commit=49064d2332f958d307bd213367033e5a74513995;rename=tools::https://go.googlesource.com/tools \
+      git::commit=6d2eada6345e1621bdc51e3311439576848c7ef5;rename=net::https://github.com/golang/net"
+CHKSUMS="sha256::3a70e5055509f347c0fb831ca07a2bf3b531068f349b14a3c652e9b5b67beb5d \
          SKIP \
          SKIP"
 CHKUPDATE="anitya::id=1227"

--- a/extra-libs/flatbuffers/spec
+++ b/extra-libs/flatbuffers/spec
@@ -1,5 +1,5 @@
 VER=1.11.0
-REL=8
+REL=9
 SRCS="https://github.com/google/flatbuffers/archive/v$VER.tar.gz"
 CHKSUMS="sha256::3f4a286642094f45b1b77228656fbd7ea123964f19502f9ecfd29933fd23a50b"
 CHKUPDATE="anitya::id=16642"

--- a/extra-libs/libguestfs/autobuild/beyond
+++ b/extra-libs/libguestfs/autobuild/beyond
@@ -1,2 +1,5 @@
 abinfo "Creating daemon directories ..."
 mkdir -pv "$PKGDIR"/{usr/lib,var/cache}/guestfs
+
+abinfo "Setting executable bits on /usr/lib/**/*.so.*"
+chmod -v +x "$PKGDIR"/usr/lib/**/*.so.*

--- a/extra-libs/libguestfs/spec
+++ b/extra-libs/libguestfs/spec
@@ -1,5 +1,5 @@
 VER=1.38.6
-REL=14
+REL=15
 SRCS="tbl::http://download.libguestfs.org/${VER:0:4}-stable/libguestfs-$VER.tar.gz"
 CHKSUMS="sha256::f7e808b0e9a77d6f1bb7201b05bd52751ff79f210cea724725585129fa7b55ec"
 CHKUPDATE="anitya::id=229572"

--- a/extra-network/clash/spec
+++ b/extra-network/clash/spec
@@ -2,3 +2,4 @@ VER=1.5.0
 SRCS="https://github.com/Dreamacro/clash/archive/v$VER.tar.gz"
 CHKSUMS="sha256::766fa180c0d95cdbaaf0383c0f1f5b9129643a30166155cdab30922ebfbbee7d"
 CHKUPDATE="anitya::id=211719"
+REL=1

--- a/extra-network/dnscrypt/spec
+++ b/extra-network/dnscrypt/spec
@@ -1,5 +1,5 @@
 VER=2.0.44
-REL=4
+REL=5
 SRCS="https://github.com/jedisct1/dnscrypt-proxy/archive/$VER.tar.gz"
 CHKSUMS="sha256::c2c9968f07a414e973ec5734f4598d756a35c32beedb18268590ea1355794237"
 CHKUPDATE="anitya::id=15546"

--- a/extra-network/frp/spec
+++ b/extra-network/frp/spec
@@ -1,5 +1,5 @@
 VER=0.34.3
 SRCS="tbl::https://github.com/fatedier/frp/archive/v${VER}.tar.gz"
 CHKSUMS="sha256::f03e280d9e8fdd4948ed6a5d141e927bf9b5168d7a47a4f3e90a08065e5f192d"
-REL=2
+REL=3
 CHKUPDATE="anitya::id=230969"

--- a/extra-network/geoipupdate/spec
+++ b/extra-network/geoipupdate/spec
@@ -1,5 +1,5 @@
 VER=4.0.2
-REL=12
+REL=13
 SRCS="https://github.com/maxmind/geoipupdate/archive/v$VER.tar.gz"
 CHKSUMS="sha256::76a2bd8e75fbe1d88cfdf0ab7f00e90cfea7c87b8757d6f5147a3d4d2d9773b3"
 CHKUPDATE="anitya::id=230971"

--- a/extra-network/gost/spec
+++ b/extra-network/gost/spec
@@ -1,5 +1,5 @@
 VER=2.11.1
-REL=4
+REL=5
 SRCS="https://github.com/ginuerzh/gost/archive/v$VER.tar.gz"
 CHKSUMS="sha256::d94b570a7a84094376b8c299d740528f51b540d9162f1db562247a15a89340bf"
 SUBDIR=.

--- a/extra-network/graftcp/spec
+++ b/extra-network/graftcp/spec
@@ -2,3 +2,4 @@ VER=0.3.1
 SRCS="https://github.com/hmgle/graftcp/archive/v$VER.tar.gz"
 CHKSUMS="sha256::9014a540913a14c696c45145174052027214919d1762c5bd13875d61f41b23d9"
 CHKUPDATE="anitya::id=230973"
+REL=1

--- a/extra-network/kcptun/spec
+++ b/extra-network/kcptun/spec
@@ -1,5 +1,5 @@
 VER=20200930
 SRCS="https://github.com/xtaci/kcptun/archive/v$VER.tar.gz"
 CHKSUMS="sha256::90d0851e96ff723d4bcd7fd00795e926418ce5cf17c841e1e0185b0770b84874"
-REL=2
+REL=3
 CHKUPDATE="anitya::id=14970"

--- a/extra-network/obfs4proxy/spec
+++ b/extra-network/obfs4proxy/spec
@@ -1,5 +1,5 @@
 VER=0.0.11
-REL=10
+REL=11
 SRCS="git::commit=tags/obfs4proxy-$VER::https://git.torproject.org/pluggable-transports/obfs4.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=195186"

--- a/extra-network/popub/spec
+++ b/extra-network/popub/spec
@@ -2,3 +2,4 @@ VER=0+git20171007
 SRCS="git::commit=6ffa11c634c1aa877d3f4b79ada19b8e6a92dae9::https://github.com/m13253/popub"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230985"
+REL=1

--- a/extra-network/syncthing/spec
+++ b/extra-network/syncthing/spec
@@ -3,3 +3,4 @@ SRCS="https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-s
 CHKSUMS="sha256::55a6fb08a9dbc1a31a6b429a16abb3a76d8c24b491a86a52170ddaadea33f683" 
 CHKUPDATE="anitya::id=11814"
 SUBDIR=.
+REL=1

--- a/extra-network/v2ray-plugin/spec
+++ b/extra-network/v2ray-plugin/spec
@@ -1,5 +1,5 @@
 VER=1.3.1
 SRCS="https://github.com/shadowsocks/v2ray-plugin/archive/v$VER.tar.gz"
 CHKSUMS="sha256::86d37a8ecef82457b4750a1af9e8d093b25ae0d32ea7dcc2ad5c0068fe2d3d74"
-REL=2
+REL=3
 CHKUPDATE="anitya::id=231002"

--- a/extra-network/v2ray/spec
+++ b/extra-network/v2ray/spec
@@ -2,3 +2,4 @@ VER=4.41.0
 SRCS="https://github.com/v2fly/v2ray-core/archive/v$VER.tar.gz"
 CHKSUMS="sha256::3752a9c1c10e1435a0af49266e299621311b91983afff616cbf604c82ca29233"
 CHKUPDATE="anitya::id=134851"
+REL=1

--- a/extra-network/xray/autobuild/defines
+++ b/extra-network/xray/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME="xray"
+PKGSEC=net
 PKGDES="V2Ray with XTLS support"
 PKGDEP="gcc-runtime"
 BUILDDEP="go"

--- a/extra-network/xray/spec
+++ b/extra-network/xray/spec
@@ -2,3 +2,4 @@ VER=1.4.2
 SRCS="tbl::https://github.com/XTLS/Xray-core/archive/v$VER.tar.gz"
 CHKSUMS="sha256::565255d8c67b254f403d498b9152fa7bc097d649c50cb318d278c2be644e92cc"
 CHKUPDATE="anitya::id=231005"
+REL=1

--- a/extra-security/keybase/spec
+++ b/extra-security/keybase/spec
@@ -1,5 +1,5 @@
 VER=5.1.0
 SRCS="git::commit=tags/v${VER}::https://github.com/keybase/client"
-REL=6
+REL=7
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17739"

--- a/extra-shells/elvish/spec
+++ b/extra-shells/elvish/spec
@@ -1,5 +1,5 @@
 VER=0.14.1
 SRCS="git::commit=tags/v$VER::https://github.com/elves/elvish"
 CHKSUMS="SKIP"
-REL=1
+REL=2
 CHKUPDATE="anitya::id=205529"

--- a/extra-utils/ccat/spec
+++ b/extra-utils/ccat/spec
@@ -2,3 +2,4 @@ VER=1.1.0+git20181115
 SRCS="git::commit=7cf6d903b93052e24cb6c1c4b02a324ead744fa5::https://github.com/jingweno/ccat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231556"
+REL=1

--- a/extra-utils/direnv/spec
+++ b/extra-utils/direnv/spec
@@ -2,3 +2,4 @@ VER=2.28.0
 SRCS="https://github.com/direnv/direnv/archive/v$VER.tar.gz"
 CHKSUMS="sha256::fa539c63034b6161d8238299bb516dcec79e8905cd43ff2b9559ad6bf047cc93"
 CHKUPDATE="anitya::id=11598"
+REL=1

--- a/extra-utils/fzf/spec
+++ b/extra-utils/fzf/spec
@@ -1,5 +1,5 @@
 VER=0.20.0
 SRCS="https://github.com/junegunn/fzf/archive/$VER.tar.gz"
 CHKSUMS="sha256::fe6a7d07bdf999324a4f90fa97a4d2e8416c89bc92f19c9848c1cbcf365b59dc"
-REL=6
+REL=7
 CHKUPDATE="anitya::id=15856"

--- a/extra-utils/github-cli/spec
+++ b/extra-utils/github-cli/spec
@@ -1,5 +1,5 @@
 VER=1.0.0
 SRCS="https://github.com/cli/cli/archive/v$VER.tar.gz"
 CHKSUMS="sha256::e3d1c341829f5b885dce9aa2bf4bc84db48072752250f6fdb2d62903caf07cfb"
-REL=2
+REL=3
 CHKUPDATE="anitya::id=135615"

--- a/extra-utils/pcstat/spec
+++ b/extra-utils/pcstat/spec
@@ -2,3 +2,4 @@ VER=0+git20200823
 SRCS="git::commit=32b9e8fbb531ed806fa277c973f603afc7af0312::https://github.com/tobert/pcstat.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231629"
+REL=1

--- a/extra-utils/restic/spec
+++ b/extra-utils/restic/spec
@@ -1,5 +1,5 @@
 VER=0.9.4
-REL=11
+REL=12
 SRCS="https://github.com/restic/restic/archive/v$VER.tar.gz"
 CHKSUMS="sha256::c7dca90fb6fd83cee8b9f6a2776f5839794341af1953d251bf06a91870be7a8e"
 CHKUPDATE="anitya::id=16643"

--- a/extra-vcs/gogs/spec
+++ b/extra-vcs/gogs/spec
@@ -1,5 +1,5 @@
 VER=0.11.91
-REL=4
+REL=5
 SRCS="https://github.com/gogits/gogs/archive/v$VER.tar.gz"
 CHKSUMS="sha256::6808db68a5952504b81f35fda29ddadde676a91d792262dcf7c3d90be85453eb"
 SUBDIR=.

--- a/extra-vcs/hub/spec
+++ b/extra-vcs/hub/spec
@@ -2,5 +2,5 @@ VER=2.13.0
 SRCS="https://github.com/github/hub/archive/v$VER.tar.gz"
 CHKSUMS="sha256::0b5147a25aa8dff37d6c88b2a30ed38c05d35e03c64d79039925dcb49de80940"
 SUBDIR=.
-REL=7
+REL=8
 CHKUPDATE="anitya::id=5368"

--- a/extra-web/baidupcs-go/spec
+++ b/extra-web/baidupcs-go/spec
@@ -2,3 +2,4 @@ VER=3.8.0
 SRCS="tbl::https://github.com/qjfoidnh/BaiduPCS-Go/archive/v$VER.tar.gz"
 CHKSUMS="sha256::ac2828476474506cd5bb2f4e91a1015594684c21776524ab34f90e25bca3d252"
 CHKUPDATE="anitya::id=231940"
+REL=1

--- a/extra-web/hugo/spec
+++ b/extra-web/hugo/spec
@@ -2,3 +2,4 @@ VER=0.84.0
 SRCS="https://github.com/gohugoio/hugo/archive/v$VER.tar.gz"
 CHKSUMS="sha256::4d5bf4888c3a652bec85b6a1dc05a55d9e26f9e315fc7e98bd720c0a36a405b8"
 CHKUPDATE="anitya::id=12959"
+REL=1

--- a/extra-web/proton-bridge/autobuild/build
+++ b/extra-web/proton-bridge/autobuild/build
@@ -35,6 +35,9 @@ rm -rfv "$SRCDIR"/vendor/github.com/therecipe/env_linux_amd64_513
 ln -sv "$SRCDIR"/qt5_dir/env_linux_amd64_513 vendor/github.com/therecipe/env_linux_amd64_513
 export QT_DIR="$SRCDIR/qt5_dir/env_linux_amd64_513/"
 
+abinfo "Generating necessary source files ..."
+make gofiles
+
 abinfo "Building main executable ..."
 cp -v "$SRCDIR"/cmd/Desktop-Bridge/main.go .
 qtdeploy -tags='pmapi_prod' -ldflags "-X github.com/ProtonMail/proton-bridge/pkg/constants.Version=$PKGVER-git -X github.com/ProtonMail/proton-bridge/pkg/constants.Revision=$(git rev-parse --short=10 HEAD) -X github.com/ProtonMail/proton-bridge/pkg/constants.BuildTime=$(date -uIs) -w -s -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/gcc/specs/hardened-ld'" build desktop

--- a/extra-web/proton-bridge/autobuild/defines
+++ b/extra-web/proton-bridge/autobuild/defines
@@ -3,3 +3,5 @@ PKGSEC=web
 PKGDES="ProtonMail Bridge for e-mail clients"
 PKGDEP="qt-5 desktop-file-utils"
 BUILDDEP="go"
+
+ABSPLITDBG=0

--- a/extra-web/proton-bridge/spec
+++ b/extra-web/proton-bridge/spec
@@ -2,3 +2,4 @@ VER=1.5.7
 SRCS="git::commit=tags/v$VER::https://github.com/ProtonMail/proton-bridge.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231962"
+REL=1

--- a/extra-web/proton-bridge/spec
+++ b/extra-web/proton-bridge/spec
@@ -1,5 +1,4 @@
-VER=1.5.7
+VER=1.8.9
 SRCS="git::commit=tags/v$VER::https://github.com/ProtonMail/proton-bridge.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231962"
-REL=1

--- a/extra-web/rclone/spec
+++ b/extra-web/rclone/spec
@@ -2,3 +2,4 @@ VER=1.55.1
 SRCS="git::commit=tags/v$VER::https://github.com/rclone/rclone/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11750"
+REL=1

--- a/groups/go-rebuilds
+++ b/groups/go-rebuilds
@@ -22,6 +22,7 @@ extra-network/popub
 extra-network/syncthing
 extra-network/v2ray
 extra-network/v2ray-plugin
+extra-network/xray
 extra-security/keybase
 extra-shells/elvish
 extra-utils/ccat


### PR DESCRIPTION
Topic Description
-----------------

Update Go to 1.17, check updates for `extra-go/*`, rebuild otherwise.

Package(s) Affected
-------------------

- `go` v1.17
- `delve` v1.7.1
- ...
- See `groups/go-rebuilds`.

Security Update?
----------------

No

Build Order
-----------

```
go groups/go-rebuilds
```

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`