### PR TITLE
pytz: update to 2021.1

### DIFF
--- a/extra-cinnamon/cinnamon-control-center/spec
+++ b/extra-cinnamon/cinnamon-control-center/spec
@@ -1,4 +1,4 @@
-VER=5.0.1
+VER=5.0.2
 SRCS="tbl::https://github.com/linuxmint/cinnamon-control-center/archive/$VER.tar.gz"
-CHKSUMS="sha256::170ac90d3a11ac10258b1fff20f4ee792078520e8eb4e18e13a2c4caf8de3ede"
+CHKSUMS="sha256::30f697ebbf3d3d267b8ea09cdbfd358c994bf4b60a458f124dcfd415d2cb58a7"
 CHKUPDATE="anitya::id=15189"

--- a/extra-gis/owslib/spec
+++ b/extra-gis/owslib/spec
@@ -1,5 +1,5 @@
-VER=0.17.1
+VER=0.25.0
 REL=2
 SRCS="tbl::https://pypi.io/packages/source/O/OWSLib/OWSLib-$VER.tar.gz"
-CHKSUMS="sha256::b2e7fd694d3cffcee79317bad492d60c0aa887aea6916517c051c3247b33b5a5"
+CHKSUMS="sha256::20d79bce0be10277caa36f3134826bd0065325df0301a55b2c8b1c338d8d8f0a"
 CHKUPDATE="anitya::id=3945"

--- a/extra-gnome/cheese/autobuild/patches/0001-fedora-cheese-3.38.0-vala-genericarray.patch
+++ b/extra-gnome/cheese/autobuild/patches/0001-fedora-cheese-3.38.0-vala-genericarray.patch
@@ -1,0 +1,177 @@
+From 7cf6268e54620bbbe5e6e61800c50fb0cb4bea57 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Corentin=20No=C3=ABl?= <corentin@elementary.io>
+Date: Fri, 16 Oct 2020 19:56:26 +0200
+Subject: [PATCH] Change GLib.PtrArray into GLib.GenericArray
+
+This is the vala-friendly way of handling GPtrArray.
+Fix several memory leaks on the go and unnecessary reference increase.
+---
+ src/cheese-preferences.vala | 26 ++++++++++++--------------
+ src/cheese-window.vala      | 22 +++++++++++-----------
+ src/vapi/cheese-common.vapi |  2 +-
+ 3 files changed, 24 insertions(+), 26 deletions(-)
+
+diff --git a/src/cheese-preferences.vala b/src/cheese-preferences.vala
+index f56af7e0..80a92431 100644
+--- a/src/cheese-preferences.vala
++++ b/src/cheese-preferences.vala
+@@ -100,7 +100,7 @@ public PreferencesDialog (Cheese.Camera camera)
+    */
+   private void initialize_camera_devices ()
+   {
+-    unowned GLib.PtrArray devices = camera.get_camera_devices ();
++    GLib.GenericArray<unowned Cheese.CameraDevice> devices = camera.get_camera_devices ();
+     camera_model = new Gtk.ListStore (2, typeof (string), typeof (Cheese.CameraDevice));
+ 
+     source_combo.model = camera_model;
+@@ -357,13 +357,13 @@ public PreferencesDialog (Cheese.Camera camera)
+    */
+   private void on_camera_update_num_camera_devices ()
+   {
+-    unowned GLib.PtrArray devices = camera.get_camera_devices ();
+-    Cheese.CameraDevice   dev;
++    GLib.GenericArray<unowned Cheese.CameraDevice> devices = camera.get_camera_devices ();
++    unowned Cheese.CameraDevice   dev;
+ 
+     // Add (if) / Remove (else) a camera device.
+-    if (devices.len > camera_model.iter_n_children (null))
++    if (devices.length > camera_model.iter_n_children (null))
+     {
+-      dev = (Cheese.CameraDevice) devices.index (devices.len - 1);
++      dev = devices.get (devices.length - 1);
+       add_camera_device(dev);
+     }
+     else
+@@ -382,12 +382,11 @@ public PreferencesDialog (Cheese.Camera camera)
+       bool device_removed = false;
+       devices.foreach ((device) =>
+       {
+-        var old_device = (Cheese.CameraDevice) device;
+         Cheese.CameraDevice new_device;
+         camera_model.get (iter, 1, out new_device, -1);
+ 
+         // Found the device that was removed.
+-        if (old_device != new_device)
++        if (device != new_device)
+         {
+             remove_camera_device (iter, new_device, active_device);
+             device_removed = true;
+@@ -418,17 +417,16 @@ public PreferencesDialog (Cheese.Camera camera)
+    *
+    * @param device a Cheese.CameraDevice to add to the device combo box model
+    */
+-  private void add_camera_device (void *device)
++  private void add_camera_device (Cheese.CameraDevice device)
+   {
+     TreeIter iter;
+-    Cheese.CameraDevice dev = (Cheese.CameraDevice) device;
+ 
+     camera_model.append (out iter);
+     camera_model.set (iter,
+-                      0, dev.get_name (),
+-                      1, dev);
++                      0, device.get_name (),
++                      1, device);
+ 
+-    if (camera.get_selected_device () == dev)
++    if (camera.get_selected_device () == device)
+         source_combo.set_active_iter (iter);
+ 
+     if (camera_model.iter_n_children (null) > 1)
+@@ -445,12 +443,12 @@ public PreferencesDialog (Cheese.Camera camera)
+   private void remove_camera_device (TreeIter iter, Cheese.CameraDevice device_node,
+                              Cheese.CameraDevice active_device_node)
+   {
+-      unowned GLib.PtrArray devices = camera.get_camera_devices ();
++      GLib.GenericArray<unowned Cheese.CameraDevice> devices = camera.get_camera_devices ();
+ 
+       // Check if the camera that we want to remove, is the active one
+       if (device_node == active_device_node)
+       {
+-        if (devices.len > 0)
++        if (devices.length > 0)
+           set_new_available_camera_device (iter);
+         else
+           this.hide ();
+diff --git a/src/cheese-window.vala b/src/cheese-window.vala
+index ff069808..cc119b68 100644
+--- a/src/cheese-window.vala
++++ b/src/cheese-window.vala
+@@ -1216,9 +1216,9 @@ public class Cheese.MainWindow : Gtk.ApplicationWindow
+    */
+   public void on_switch_camera_clicked ()
+   {
+-      Cheese.CameraDevice selected;
+-      Cheese.CameraDevice next = null;
+-      GLib.PtrArray cameras;
++      unowned Cheese.CameraDevice selected;
++      unowned Cheese.CameraDevice next = null;
++      GLib.GenericArray<unowned Cheese.CameraDevice> cameras;
+       uint i;
+ 
+       if (camera == null)
+@@ -1235,9 +1235,9 @@ public class Cheese.MainWindow : Gtk.ApplicationWindow
+ 
+       cameras = camera.get_camera_devices ();
+ 
+-      for (i = 0; i < cameras.len; i++)
++      for (i = 0; i < cameras.length; i++)
+       {
+-          next = (Cheese.CameraDevice )cameras.index (i);
++          next = cameras.get (i);
+ 
+           if (next == selected)
+           {
+@@ -1245,13 +1245,13 @@ public class Cheese.MainWindow : Gtk.ApplicationWindow
+           }
+       }
+ 
+-      if (i + 1 < cameras.len)
++      if (i + 1 < cameras.length)
+       {
+-          next = (Cheese.CameraDevice )cameras.index (i + 1);
++          next = cameras.get (i + 1);
+       }
+       else
+       {
+-          next = (Cheese.CameraDevice )cameras.index (0);
++          next = cameras.get (0);
+       }
+ 
+       if (next == selected)
+@@ -1269,8 +1269,8 @@ public class Cheese.MainWindow : Gtk.ApplicationWindow
+    */
+   public void set_switch_camera_button_state ()
+   {
+-      Cheese.CameraDevice selected;
+-      GLib.PtrArray cameras;
++      unowned Cheese.CameraDevice selected;
++      GLib.GenericArray<unowned Cheese.CameraDevice> cameras;
+ 
+       if (camera == null)
+       {
+@@ -1288,7 +1288,7 @@ public class Cheese.MainWindow : Gtk.ApplicationWindow
+ 
+       cameras = camera.get_camera_devices ();
+ 
+-      if (cameras.len > 1)
++      if (cameras.length > 1)
+       {
+          switch_camera_button.set_visible (true);
+          return;
+diff --git a/src/vapi/cheese-common.vapi b/src/vapi/cheese-common.vapi
+index 6517cdfc..e4ae7ad3 100644
+--- a/src/vapi/cheese-common.vapi
++++ b/src/vapi/cheese-common.vapi
+@@ -35,7 +35,7 @@ namespace Cheese
+     [CCode (has_construct_function = false)]
+     public Camera (Clutter.Actor video_texture, string camera_device_node, int x_resolution, int y_resolution);
+     public bool                        get_balance_property_range (string property, double min, double max, double def);
+-    public unowned GLib.PtrArray       get_camera_devices ();
++    public GLib.GenericArray<unowned Cheese.CameraDevice> get_camera_devices ();
+     public unowned Cheese.VideoFormat  get_current_video_format ();
+     public int                         get_num_camera_devices ();
+     public unowned Cheese.CameraDevice get_selected_device ();
+-- 
+GitLab
+

--- a/extra-network/certbot/spec
+++ b/extra-network/certbot/spec
@@ -1,4 +1,4 @@
-VER=1.12.0
+VER=1.18.0
 SRCS="tbl::https://pypi.io/packages/source/c/certbot/certbot-$VER.tar.gz"
-CHKSUMS="sha256::5ee738773479bcb7794e43fedd2415acc0969b75bdd2a21f451e3bff9d99df59"
+CHKSUMS="sha256::f3e56e18246ba5dc4951132e206844f7191d7b6a97264a005557fff25cd7287b"
 CHKUPDATE="anitya::id=10690"

--- a/extra-python/acme/spec
+++ b/extra-python/acme/spec
@@ -1,4 +1,4 @@
-VER=1.12.0
+VER=1.18.0
 SRCS="tbl::https://pypi.io/packages/source/a/acme/acme-$VER.tar.gz"
-CHKSUMS="sha256::aa363474d50e9fdda27acb8b1aa7efb26fecc5650e02039a0de3a3f0e696c2f2"
+CHKSUMS="sha256::9ae06031bbcc492d4ea20aec36bb2ead08b40ccb70d980ade8ecfe8a15d762af"
 CHKUPDATE="anitya::id=8231"

--- a/extra-python/babel/spec
+++ b/extra-python/babel/spec
@@ -1,6 +1,6 @@
-VER=2.6.0
+VER=2.9.1
 REL=2
 SRCS="tbl::https://pypi.io/packages/source/B/Babel/Babel-$VER.tar.gz"
-CHKSUMS="sha256::8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
+CHKSUMS="sha256::bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"
 SUBDIR="Babel-$VER"
 CHKUPDATE="anitya::id=11984"

--- a/extra-python/django/spec
+++ b/extra-python/django/spec
@@ -1,4 +1,4 @@
-VER=3.2.2
+VER=3.2.6
 SRCS="tbl::https://github.com/django/django/archive/$VER.tar.gz"
-CHKSUMS="sha256::20723bbad6c7206d128894926e5d694f3a5041ae76c81949ce9b622c723730a9"
+CHKSUMS="sha256::5a17c7295ddd434db2b2a0193c4fc9e8290bff976b4353c8dbb02c20809bfd68"
 CHKUPDATE="anitya::id=3828"

--- a/extra-python/flask-babel/spec
+++ b/extra-python/flask-babel/spec
@@ -1,5 +1,5 @@
-VER=0.12.2
+VER=2.0.0
 REL=2
 SRCS="tbl::https://pypi.io/packages/source/F/Flask-Babel/Flask-Babel-$VER.tar.gz"
-CHKSUMS="sha256::316ad183e42003f3922957fa643d0a1e8e34a0f0301a88c3a8f605bc37ba5c86"
+CHKSUMS="sha256::f9faf45cdb2e1a32ea2ec14403587d4295108f35017a7821a2b1acb8cfd9257d"
 CHKUPDATE="anitya::id=20024"

--- a/extra-python/matplotlib/spec
+++ b/extra-python/matplotlib/spec
@@ -1,5 +1,5 @@
-VER=3.0.2
+VER=3.4.3
 REL=5
 SRCS="tbl::https://pypi.io/packages/source/m/matplotlib/matplotlib-$VER.tar.gz"
-CHKSUMS="sha256::c94b792af431f6adb6859eb218137acd9a35f4f7442cea57e4a59c54751c36af"
+CHKSUMS="sha256::fc4f526dfdb31c9bd6b8ca06bf9fab663ca12f3ec9cdf4496fb44bc680140318"
 CHKUPDATE="anitya::id=3919"

--- a/extra-python/pythondialog/autobuild/defines
+++ b/extra-python/pythondialog/autobuild/defines
@@ -4,3 +4,4 @@ PKGDEP="python-2 dialog"
 PKGDES="Python package for interfacing with dialog (a CLI graphical framework)"
 
 NOPYTHON3=1
+ABHOST=noarch

--- a/extra-python/pytz/spec
+++ b/extra-python/pytz/spec
@@ -1,5 +1,5 @@
-VER=2019.1
+VER=2021.1
 SRCS="tbl::https://pypi.io/packages/source/p/pytz/pytz-$VER.tar.gz"
-CHKSUMS="sha256::d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
+CHKSUMS="sha256::83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"
 REL=1
 CHKUPDATE="anitya::id=6537"

--- a/extra-security/volatility/spec
+++ b/extra-security/volatility/spec
@@ -1,6 +1,6 @@
-VER=2.6
+VER=2.6.1
 REL=3
 SRCS="tbl::https://github.com/volatilityfoundation/volatility/archive/$VER.tar.gz"
-CHKSUMS="sha256::6e81c3e6023e7a90953948907448d40ce02e6806275b6fdf6769b01dc9acd7af"
+CHKSUMS="sha256::a8dfdbdb2aaa0885387b709b821bb8250e698086fb32015bc2896ea55f359058"
 SUBDIR="volatility-$VER"
 CHKUPDATE="anitya::id=4084"


### PR DESCRIPTION
Topic Description
-----------------
* Update `pytz` to 2021.1
* and update the revdeps of `pytz`

Package(s) Affected
-------------------
* volatility
* pytz
* matplotlib
* flask-babel
* django
* babel
* acme
* certbot
* owslib
* cinnamon-control-center

Security Update?
----------------
No


Build Order
-----------
* `pytz volatility matplotlib flask-babel django babel acme certbot owslib cinnamon-control-center`
* `pytz volatility matplotlib flask-babel django babel acme certbot owslib gst-plugins-bad-1-0 cheese cinnamon-control-center` (only for second architectures)

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

