### PR TITLE
pytz-2021.1-rework

### DIFF
--- a/extra-security/volatility/autobuild/beyond
+++ b/extra-security/volatility/autobuild/beyond
@@ -1,5 +1,5 @@
+abinfo Moving bundled misc files...
 mkdir -p "$PKGDIR/usr/share/volatility"
-cp -ar "$PKGDIR/usr/tools" "$PKGDIR/usr/share/volatility"
-cp -ar "$PKGDIR/usr/contrib" "$PKGDIR/usr/share/volatility"
-
+mv -v "$PKGDIR/usr/tools" "$PKGDIR/usr/share/volatility"
+mv -v "$PKGDIR/usr/contrib" "$PKGDIR/usr/share/volatility"
 ln -sv "$PKGDIR"/usr/bin/vol{.py,atility}


### PR DESCRIPTION


Topic Description
-----------------
* rework topic for `pytz-2021.1`

Package(s) Affected
-------------------
* volatility

Security Update?
----------------
 No 

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
