### PR TITLE
multimc5: update to 0.6.13

### DIFF
--- a/extra-games/multimc5/autobuild/beyond
+++ b/extra-games/multimc5/autobuild/beyond
@@ -1,4 +1,4 @@
-install -Dvm0644 "$SRCDIR"/application/resources/multimc/scalable/multimc.svg \
+install -Dvm0644 "$SRCDIR"/launcher/resources/multimc/scalable/multimc.svg \
     "$PKGDIR"/usr/share/pixmaps/multimc.svg
-install -Dvm0644 "$SRCDIR"/application/package/linux/multimc.desktop \
+install -Dvm0644 "$SRCDIR"/launcher/package/linux/multimc.desktop \
     "$PKGDIR"/usr/share/applications/multimc.desktop

--- a/extra-games/multimc5/autobuild/patches/0001-Add-AOSC-MC-Custom-MSA-Client-ID.patch
+++ b/extra-games/multimc5/autobuild/patches/0001-Add-AOSC-MC-Custom-MSA-Client-ID.patch
@@ -1,0 +1,25 @@
+From 70efbd3a1c18323c2e734e954d45067360935789 Mon Sep 17 00:00:00 2001
+From: OriginCode <self@origincode.me>
+Date: Sun, 12 Sep 2021 08:46:38 +0800
+Subject: [PATCH] Add AOSC MC Custom MSA Client ID
+
+---
+ notsecrets/Secrets.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/notsecrets/Secrets.cpp b/notsecrets/Secrets.cpp
+index 88995635..e7719009 100644
+--- a/notsecrets/Secrets.cpp
++++ b/notsecrets/Secrets.cpp
+@@ -28,7 +28,7 @@ namespace {
+  * If you intend to base your own launcher on this code, take care and customize this to obfuscate the client ID, so it cannot be trivially found by casual attackers.
+  */
+ 
+-QString MSAClientID = "";
++QString MSAClientID = "81a207c0-a53c-46a3-be07-57d2b28c1643";
+ }
+ 
+ namespace Secrets {
+-- 
+2.30.2
+

--- a/extra-games/multimc5/spec
+++ b/extra-games/multimc5/spec
@@ -1,4 +1,4 @@
-VER=0.6.12
+VER=0.6.13
 SRCS="git::commit=tags/$VER::https://github.com/MultiMC/MultiMC5"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227662"


### PR DESCRIPTION
Topic Description
-----------------

Update `multimc5` to 0.6.13

Package(s) Affected
-------------------

`multimc`

Security Update?
----------------

No

Architectural Progress
----------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`