### PR TITLE
Arduino Toolkits Survey Sep'21

### DIFF
--- a/extra-devel/arduino-avr-core/autobuild/build
+++ b/extra-devel/arduino-avr-core/autobuild/build
@@ -1,0 +1,3 @@
+abinfo "Copying arduino core headers and libraries"
+mkdir -vp "${PKGDIR}/usr/share/arduino/hardware"
+cp -vr "ArduinoCore-avr-${PKGVER}" "${PKGDIR}/usr/share/arduino/hardware/arduino"

--- a/extra-devel/arduino-avr-core/autobuild/defines
+++ b/extra-devel/arduino-avr-core/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=arduino-avr-core
+PKGSEC=devel
+PKGDEP="avr-gcc avr-libc"
+PKGDES="Platform source code and configuration files for arduino and other AVR microcontrollers"
+
+_PREFIX=/opt/abcross/avr
+
+ABHOST=noarch

--- a/extra-devel/arduino-avr-core/autobuild/patches/0001-use-distro-toolchain.diff
+++ b/extra-devel/arduino-avr-core/autobuild/patches/0001-use-distro-toolchain.diff
@@ -1,0 +1,12 @@
+diff -Naur a/ArduinoCore-avr-1.8.3/platform.txt b/ArduinoCore-avr-1.8.3/platform.txt
+--- a/ArduinoCore-avr-1.8.3/platform.txt	2020-06-11 10:12:12.000000000 -0500
++++ b/ArduinoCore-avr-1.8.3/platform.txt	2021-09-08 15:10:02.054220085 -0500
+@@ -18,7 +18,7 @@
+ compiler.warning_flags.all=-Wall -Wextra
+ 
+ # Default "compiler.path" is correct, change only if you want to override the initial value
+-compiler.path={runtime.tools.avr-gcc.path}/bin/
++compiler.path=/usr/bin
+ compiler.c.cmd=avr-gcc
+ compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -MMD -flto -fno-fat-lto-objects
+ compiler.c.elf.flags={compiler.warning_flags} -Os -g -flto -fuse-linker-plugin -Wl,--gc-sections

--- a/extra-devel/arduino-avr-core/spec
+++ b/extra-devel/arduino-avr-core/spec
@@ -1,0 +1,5 @@
+VER=1.8.3
+SRCS="tbl::https://github.com/arduino/ArduinoCore-avr/releases/download/${VER}/ArduinoCore-avr-${VER}.tar.xz"
+CHKSUMS="sha256::6a434f5568ecdc4529489497f757cbbae6da6c886c95d3327bcb48a5eb55e729"
+SUBDIR="."
+CHKUPDATE="anitya::id=15320"

--- a/extra-devel/arduino-mk/autobuild/build
+++ b/extra-devel/arduino-mk/autobuild/build
@@ -1,0 +1,24 @@
+_MAKEFILE_DIR=/usr/share/arduino
+_BIN_DIR=/usr/bin
+_MAN1_DIR=/usr/share/man/man1
+
+abinfo "Copying makefiles"
+for i in "${SRCDIR}"/*.mk; do
+	file=$(basename "$i")
+	install -Dvm644 ${file} "${PKGDIR}${_MAKEFILE_DIR}/${file}"
+done
+
+abinfo "Copying exmaple programs"
+cp -vr "${SRCDIR}/examples" -t "${PKGDIR}${_MAKEFILE_DIR}/"
+
+abinfo "Copying tools"
+pushd "${SRCDIR}/bin"
+for i in *; do
+	install -Dvm755 "$i" "${PKGDIR}${_BIN_DIR}/$i"
+done
+popd
+
+abinfo "Copying manuals"
+for i in ard-reset-arduino.1 robotis-loader.1; do
+	install -Dvm644 "${SRCDIR}/$i" "${PKGDIR}${_MAN1_DIR}/$i"
+done

--- a/extra-devel/arduino-mk/autobuild/defines
+++ b/extra-devel/arduino-mk/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=arduino-mk
+PKGSEC=devel
+PKGDEP="avr-binutils avr-gcc avr-libc pyserial arduino-avr-core"
+PKGDES="Makefile workflow for arduino and other AVR microcontrollers"
+
+ABHOST=noarch

--- a/extra-devel/arduino-mk/autobuild/overrides/etc/profile.d/90-arduino-mk
+++ b/extra-devel/arduino-mk/autobuild/overrides/etc/profile.d/90-arduino-mk
@@ -1,0 +1,2 @@
+export AVR_TOOLS_DIR=/
+export ARDMK_DIR=/usr/share/arduino

--- a/extra-devel/arduino-mk/spec
+++ b/extra-devel/arduino-mk/spec
@@ -1,0 +1,4 @@
+VER=1.6.0
+SRCS="tbl::https://github.com/sudar/Arduino-Makefile/archive/refs/tags/${VER}.tar.gz"
+CHKSUMS="sha256::113f68cd2224c8014c10e04e0f3a49ad6d41520a44556942f11aa69cd0046b17"
+CHKUPDATE="anitya::id=234937"

--- a/extra-devel/avr-binutils/autobuild/beyond
+++ b/extra-devel/avr-binutils/autobuild/beyond
@@ -1,0 +1,26 @@
+abinfo "Remove executables with default names"
+for elf in ar as nm objcopy objdump ranlib strip readelf; do
+	rm -v "${PKGDIR}${_PREFIX}/bin/${elf}"
+done
+
+abinfo "Remove bfd libdep for avr"
+rm -v "${PKGDIR}${_PREFIX}"/lib/bfd-plugins/libdep.so
+
+abinfo "Renaming documentation"
+for info in as bfd binutils gprof ld; do
+	mv -v \
+		"${PKGDIR}${_PREFIX}/share/info/${info}.info" \
+		"${PKGDIR}${_PREFIX}/share/info/avr-${info}.info"
+done
+
+abinfo "Removing locale"
+rm -rv "${PKGDIR}${_PREFIX}/share/locale"
+
+abinfo "Creating symlinks in /usr/bin"
+mkdir -vp "${PKGDIR}/usr/bin"
+pushd "${PKGDIR}${_PREFIX}/bin"
+for i in avr-*; do
+        ln -sv "${_PREFIX}/bin/${i}" "${PKGDIR}/usr/bin/$i"
+done
+popd
+

--- a/extra-devel/avr-binutils/autobuild/defines
+++ b/extra-devel/avr-binutils/autobuild/defines
@@ -1,0 +1,32 @@
+PKGNAME=avr-binutils
+PKGSEC=devel
+PKGDEP="glibc zlib"
+PKGDES="A set of programs to assemble and manipulate binary and object files for AVR micro-controllers"
+
+NOSTATIC=0
+#NOLTO=1
+AB_FLAGS_O3=1
+
+_PREFIX=/opt/abcross/avr
+
+AUTOTOOLS_STRICT=0
+AUTOTOOLS_AFTER="--prefix=${_PREFIX} \
+                 --with-lib-path=${_PREFIX}/lib \
+                 --with-bugurl=https://github.com/AOSC-Dev/aosc-os-abbs \
+                 --enable-threads \
+                 --with-pic \
+                 --enable-ld \
+                 --enable-gold \
+                 --enable-plugins \
+                 --disable-werror \
+                 --enable-lto \
+                 --enable-deterministic-archives \
+                 --target=avr"
+
+MAKE_AFTER="prefix=${PKGDIR}${_PREFIX} \
+            tooldir=${PKGDIR}${_PREFIX} \
+            BUILDROOT=
+            DESTDIR=
+"
+
+RECONF=0

--- a/extra-devel/avr-binutils/autobuild/patches/0001-avr-format.patch
+++ b/extra-devel/avr-binutils/autobuild/patches/0001-avr-format.patch
@@ -1,0 +1,435 @@
+diff --git a/binutils/size.c b/binutils/size.c
+index 3697087714..f99d45a6bf 100644
+--- a/binutils/size.c
++++ b/binutils/size.c
+@@ -51,7 +51,8 @@ enum output_format
+   {
+    FORMAT_BERKLEY,
+    FORMAT_SYSV,
+-   FORMAT_GNU
++   FORMAT_GNU,
++   FORMAT_AVR
+   };
+ static enum output_format selected_output_format =
+ #if BSD_DEFAULT
+@@ -74,6 +75,246 @@ static bfd_size_type total_textsize;
+ /* Program exit status.  */
+ static int return_code = 0;
+ 
++
++/* AVR Size specific stuff */
++
++#define AVR64 64UL
++#define AVR128 128UL
++#define AVR256 256UL
++#define AVR512 512UL
++#define AVR1K 1024UL
++#define AVR2K 2048UL
++#define AVR4K 4096UL
++#define AVR8K 8192UL
++#define AVR16K 16384UL
++#define AVR20K 20480UL
++#define AVR24K 24576UL
++#define AVR32K 32768UL
++#define AVR36K 36864UL
++#define AVR40K 40960UL
++#define AVR64K 65536UL
++#define AVR68K 69632UL
++#define AVR128K 131072UL
++#define AVR136K 139264UL
++#define AVR200K 204800UL
++#define AVR256K 262144UL
++#define AVR264K 270336UL
++
++typedef struct
++{
++    char *name;
++	long flash;
++	long ram;
++	long eeprom;
++} avr_device_t;
++
++avr_device_t avr[] =
++{
++	{"atxmega256a3",  AVR264K, AVR16K, AVR4K},
++	{"atxmega256a3b", AVR264K, AVR16K, AVR4K},
++	{"atxmega256d3",  AVR264K, AVR16K, AVR4K},
++
++	{"atmega2560",    AVR256K, AVR8K,  AVR4K},
++	{"atmega2561",    AVR256K, AVR8K,  AVR4K},
++
++	{"atxmega192a3",  AVR200K, AVR16K, AVR2K},
++	{"atxmega192d3",  AVR200K, AVR16K, AVR2K},
++
++	{"atxmega128a1",  AVR136K, AVR8K,  AVR2K},
++	{"atxmega128a1u", AVR136K, AVR8K,  AVR2K},
++	{"atxmega128a3",  AVR136K, AVR8K,  AVR2K},
++	{"atxmega128d3",  AVR136K, AVR8K,  AVR2K},
++
++	{"at43usb320",    AVR128K, 608UL,  0UL},
++	{"at90can128",    AVR128K, AVR4K,  AVR4K},
++	{"at90usb1286",   AVR128K, AVR8K,  AVR4K},
++	{"at90usb1287",   AVR128K, AVR8K,  AVR4K},
++	{"atmega128",     AVR128K, AVR4K,  AVR4K},
++	{"atmega1280",    AVR128K, AVR8K,  AVR4K},
++	{"atmega1281",    AVR128K, AVR8K,  AVR4K},
++	{"atmega1284p",   AVR128K, AVR16K, AVR4K},
++	{"atmega128rfa1", AVR128K, AVR16K, AVR4K},
++	{"atmega103",     AVR128K, 4000UL, AVR4K},
++
++	{"atxmega64a1",   AVR68K,  AVR4K,  AVR2K},
++	{"atxmega64a1u",  AVR68K,  AVR4K,  AVR2K},
++	{"atxmega64a3",   AVR68K,  AVR4K,  AVR2K},
++	{"atxmega64d3",   AVR68K,  AVR4K,  AVR2K},
++
++	{"at90can64",     AVR64K,  AVR4K,  AVR2K},
++	{"at90scr100",    AVR64K,  AVR4K,  AVR2K},
++	{"at90usb646",    AVR64K,  AVR4K,  AVR2K},
++	{"at90usb647",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega64",      AVR64K,  AVR4K,  AVR2K},
++	{"atmega640",     AVR64K,  AVR8K,  AVR4K},
++	{"atmega644",     AVR64K,  AVR4K,  AVR2K},
++	{"atmega644a",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega644p",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega644pa",   AVR64K,  AVR4K,  AVR2K},
++	{"atmega645",     AVR64K,  AVR4K,  AVR2K},
++	{"atmega645a",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega645p",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega6450",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega6450a",   AVR64K,  AVR4K,  AVR2K},
++	{"atmega6450p",   AVR64K,  AVR4K,  AVR2K},
++	{"atmega649",     AVR64K,  AVR4K,  AVR2K},
++	{"atmega649a",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega649p",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega6490",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega6490a",   AVR64K,  AVR4K,  AVR2K},
++	{"atmega6490p",   AVR64K,  AVR4K,  AVR2K},
++	{"atmega64c1",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega64hve",   AVR64K,  AVR4K,  AVR1K},
++	{"atmega64m1",    AVR64K,  AVR4K,  AVR2K},
++	{"m3000",         AVR64K,  AVR4K,  0UL},
++
++	{"atmega406",     AVR40K,  AVR2K,  AVR512},
++
++	{"atxmega32a4",   AVR36K,  AVR4K,  AVR1K},
++	{"atxmega32d4",   AVR36K,  AVR4K,  AVR1K},
++
++	{"at90can32",     AVR32K,  AVR2K,  AVR1K},
++	{"at94k",         AVR32K,  AVR4K,  0UL},
++	{"atmega32",      AVR32K,  AVR2K,  AVR1K},
++	{"atmega323",     AVR32K,  AVR2K,  AVR1K},
++	{"atmega324a",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega324p",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega324pa",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega325",     AVR32K,  AVR2K,  AVR1K},
++	{"atmega325a",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega325p",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega3250",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega3250a",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega3250p",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega328",     AVR32K,  AVR2K,  AVR1K},
++	{"atmega328p",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega329",     AVR32K,  AVR2K,  AVR1K},
++	{"atmega329a",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega329p",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega329pa",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega3290",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega3290a",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega3290p",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega32hvb",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega32c1",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega32hvb",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega32m1",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega32u2",    AVR32K,  AVR1K,  AVR1K},
++	{"atmega32u4",    AVR32K,  2560UL, AVR1K},
++	{"atmega32u6",    AVR32K,  2560UL, AVR1K},
++
++	{"at43usb355",    AVR24K,  1120UL,   0UL},
++
++	{"atxmega16a4",   AVR20K,  AVR2K,  AVR1K},
++	{"atxmega16d4",   AVR20K,  AVR2K,  AVR1K},
++
++	{"at76c711",      AVR16K,  AVR2K,  0UL},
++	{"at90pwm216",    AVR16K,  AVR1K,  AVR512},
++	{"at90pwm316",    AVR16K,  AVR1K,  AVR512},
++	{"at90usb162",    AVR16K,  AVR512, AVR512},
++	{"atmega16",      AVR16K,  AVR1K,  AVR512},
++	{"atmega16a",     AVR16K,  AVR1K,  AVR512},
++	{"atmega161",     AVR16K,  AVR1K,  AVR512},
++	{"atmega162",     AVR16K,  AVR1K,  AVR512},
++	{"atmega163",     AVR16K,  AVR1K,  AVR512},
++	{"atmega164",     AVR16K,  AVR1K,  AVR512},
++	{"atmega164a",    AVR16K,  AVR1K,  AVR512},
++	{"atmega164p",    AVR16K,  AVR1K,  AVR512},
++	{"atmega165a",    AVR16K,  AVR1K,  AVR512},
++	{"atmega165",     AVR16K,  AVR1K,  AVR512},
++	{"atmega165p",    AVR16K,  AVR1K,  AVR512},
++	{"atmega168",     AVR16K,  AVR1K,  AVR512},
++	{"atmega168a",    AVR16K,  AVR1K,  AVR512},
++	{"atmega168p",    AVR16K,  AVR1K,  AVR512},
++	{"atmega169",     AVR16K,  AVR1K,  AVR512},
++	{"atmega169a",    AVR16K,  AVR1K,  AVR512},
++	{"atmega169p",    AVR16K,  AVR1K,  AVR512},
++	{"atmega169pa",   AVR16K,  AVR1K,  AVR512},
++	{"atmega16hva",   AVR16K,  768UL,  AVR256},
++	{"atmega16hva2",  AVR16K,  AVR1K,  AVR256},
++	{"atmega16hvb",   AVR16K,  AVR1K,  AVR512},
++	{"atmega16m1",    AVR16K,  AVR1K,  AVR512},
++	{"atmega16u2",    AVR16K,  AVR512, AVR512},
++	{"atmega16u4",    AVR16K,  1280UL, AVR512},
++	{"attiny167",     AVR16K,  AVR512, AVR512},
++
++	{"at90c8534",     AVR8K,   352UL,  AVR512},
++	{"at90pwm1",      AVR8K,   AVR512, AVR512},
++	{"at90pwm2",      AVR8K,   AVR512, AVR512},
++	{"at90pwm2b",     AVR8K,   AVR512, AVR512},
++	{"at90pwm3",      AVR8K,   AVR512, AVR512},
++	{"at90pwm3b",     AVR8K,   AVR512, AVR512},
++	{"at90pwm81",     AVR8K,   AVR256, AVR512},
++	{"at90s8515",     AVR8K,   AVR512, AVR512},
++	{"at90s8535",     AVR8K,   AVR512, AVR512},
++	{"at90usb82",     AVR8K,   AVR512, AVR512},
++	{"ata6289",       AVR8K,   AVR512, 320UL},
++	{"atmega8",       AVR8K,   AVR1K,  AVR512},
++	{"atmega8515",    AVR8K,   AVR512, AVR512},
++	{"atmega8535",    AVR8K,   AVR512, AVR512},
++	{"atmega88",      AVR8K,   AVR1K,  AVR512},
++	{"atmega88a",     AVR8K,   AVR1K,  AVR512},
++	{"atmega88p",     AVR8K,   AVR1K,  AVR512},
++	{"atmega88pa",    AVR8K,   AVR1K,  AVR512},
++	{"atmega8hva",    AVR8K,   768UL,  AVR256},
++	{"atmega8u2",     AVR8K,   AVR512, AVR512},
++	{"attiny84",      AVR8K,   AVR512, AVR512},
++	{"attiny84a",     AVR8K,   AVR512, AVR512},
++	{"attiny85",      AVR8K,   AVR512, AVR512},
++	{"attiny861",     AVR8K,   AVR512, AVR512},
++	{"attiny861a",    AVR8K,   AVR512, AVR512},
++	{"attiny87",      AVR8K,   AVR512, AVR512},
++	{"attiny88",      AVR8K,   AVR512, AVR64},
++
++	{"at90s4414",     AVR4K,   352UL,  AVR256},
++	{"at90s4433",     AVR4K,   AVR128, AVR256},
++	{"at90s4434",     AVR4K,   352UL,  AVR256},
++	{"atmega48",      AVR4K,   AVR512, AVR256},
++	{"atmega48a",     AVR4K,   AVR512, AVR256},
++	{"atmega48p",     AVR4K,   AVR512, AVR256},
++	{"attiny4313",    AVR4K,   AVR256, AVR256},
++	{"attiny43u",     AVR4K,   AVR256, AVR64},
++	{"attiny44",      AVR4K,   AVR256, AVR256},
++	{"attiny44a",     AVR4K,   AVR256, AVR256},
++	{"attiny45",      AVR4K,   AVR256, AVR256},
++	{"attiny461",     AVR4K,   AVR256, AVR256},
++	{"attiny461a",    AVR4K,   AVR256, AVR256},
++	{"attiny48",      AVR4K,   AVR256, AVR64},
++
++	{"at86rf401",     AVR2K,   224UL,  AVR128},
++	{"at90s2313",     AVR2K,   AVR128, AVR128},
++	{"at90s2323",     AVR2K,   AVR128, AVR128},
++	{"at90s2333",     AVR2K,   224UL,  AVR128},
++	{"at90s2343",     AVR2K,   AVR128, AVR128},
++	{"attiny20",      AVR2K,   AVR128, 0UL},
++	{"attiny22",      AVR2K,   224UL,  AVR128},
++	{"attiny2313",    AVR2K,   AVR128, AVR128},
++	{"attiny2313a",   AVR2K,   AVR128, AVR128},
++	{"attiny24",      AVR2K,   AVR128, AVR128},
++	{"attiny24a",     AVR2K,   AVR128, AVR128},
++	{"attiny25",      AVR2K,   AVR128, AVR128},
++	{"attiny26",      AVR2K,   AVR128, AVR128},
++	{"attiny261",     AVR2K,   AVR128, AVR128},
++	{"attiny261a",    AVR2K,   AVR128, AVR128},
++	{"attiny28",      AVR2K,   0UL,    0UL},
++	{"attiny40",      AVR2K,   AVR256, 0UL},
++
++	{"at90s1200",     AVR1K,   0UL,    AVR64},
++	{"attiny9",       AVR1K,   32UL,   0UL},
++	{"attiny10",      AVR1K,   32UL,   0UL},
++	{"attiny11",      AVR1K,   0UL,    AVR64},
++	{"attiny12",      AVR1K,   0UL,    AVR64},
++	{"attiny13",      AVR1K,   AVR64,  AVR64},
++	{"attiny13a",     AVR1K,   AVR64,  AVR64},
++	{"attiny15",      AVR1K,   0UL,    AVR64},
++
++	{"attiny4",       AVR512,  32UL,   0UL},
++	{"attiny5",       AVR512,  32UL,   0UL},
++};
++
++static char *avrmcu = NULL;
++
++
+ static char *target = NULL;
+ 
+ /* Forward declarations.  */
+@@ -89,7 +330,8 @@ usage (FILE *stream, int status)
+   fprintf (stream, _(" Displays the sizes of sections inside binary files\n"));
+   fprintf (stream, _(" If no input file(s) are specified, a.out is assumed\n"));
+   fprintf (stream, _(" The options are:\n\
+-  -A|-B|-G  --format={sysv|berkeley|gnu}  Select output style (default is %s)\n\
++  -A|-B|-G|-C  --format={sysv|berkeley|gnu|avr}  Select output style (default is %s)\n\
++            --mcu=<avrmcu>            MCU name for AVR format only\n\
+   -o|-d|-x  --radix={8|10|16}         Display numbers in octal, decimal or hex\n\
+   -t        --totals                  Display the total sizes (Berkeley only)\n\
+             --common                  Display total size for *COM* syms\n\
+@@ -113,6 +355,7 @@ usage (FILE *stream, int status)
+ #define OPTION_FORMAT (200)
+ #define OPTION_RADIX (OPTION_FORMAT + 1)
+ #define OPTION_TARGET (OPTION_RADIX + 1)
++#define OPTION_MCU (OPTION_TARGET + 1)
+ 
+ static struct option long_options[] =
+ {
+@@ -120,6 +363,7 @@ static struct option long_options[] =
+   {"format", required_argument, 0, OPTION_FORMAT},
+   {"radix", required_argument, 0, OPTION_RADIX},
+   {"target", required_argument, 0, OPTION_TARGET},
++  {"mcu", required_argument, 0, 203},
+   {"totals", no_argument, &show_totals, 1},
+   {"version", no_argument, &show_version, 1},
+   {"help", no_argument, &show_help, 1},
+@@ -153,7 +397,7 @@ main (int argc, char **argv)
+     fatal (_("fatal error: libbfd ABI mismatch"));
+   set_default_bfd_target ();
+ 
+-  while ((c = getopt_long (argc, argv, "ABGHhVvdfotx", long_options,
++  while ((c = getopt_long (argc, argv, "ABCGHhVvdfotx", long_options,
+ 			   (int *) 0)) != EOF)
+     switch (c)
+       {
+@@ -172,12 +416,20 @@ main (int argc, char **argv)
+ 	  case 'g':
+ 	    selected_output_format = FORMAT_GNU;
+ 	    break;
++	  case 'A':
++	  case 'a':
++	    selected_output_format = FORMAT_AVR;
++	    break;
+ 	  default:
+ 	    non_fatal (_("invalid argument to --format: %s"), optarg);
+ 	    usage (stderr, 1);
+ 	  }
+ 	break;
+ 
++      case OPTION_MCU:
++	avrmcu = optarg;
++	break;
++
+       case OPTION_TARGET:
+ 	target = optarg;
+ 	break;
+@@ -214,6 +466,9 @@ main (int argc, char **argv)
+       case 'G':
+ 	selected_output_format = FORMAT_GNU;
+ 	break;
++      case 'C':
++	selected_output_format = FORMAT_AVR;
++    break;
+       case 'v':
+       case 'V':
+ 	show_version = 1;
+@@ -656,6 +911,98 @@ print_sysv_format (bfd *file)
+   printf ("\n\n");
+ }
+ 
++static avr_device_t *
++avr_find_device (void)
++{
++  unsigned int i;
++  if (avrmcu != NULL)
++  {
++    for (i = 0; i < sizeof(avr) / sizeof(avr[0]); i++)
++    {
++      if (strcmp(avr[i].name, avrmcu) == 0)
++      {
++        /* Match found */
++        return (&avr[i]);
++      }
++    }
++  }
++  return (NULL);
++}
++
++static void
++print_avr_format (bfd *file)
++{
++  char *avr_name = "Unknown";
++  int flashmax = 0;
++  int rammax = 0;
++  int eeprommax = 0;
++  asection *section;
++  bfd_size_type my_datasize = 0;
++  bfd_size_type my_textsize = 0;
++  bfd_size_type my_bsssize = 0;
++  bfd_size_type bootloadersize = 0;
++  bfd_size_type noinitsize = 0;
++  bfd_size_type eepromsize = 0;
++
++  avr_device_t *avrdevice = avr_find_device();
++  if (avrdevice != NULL)
++  {
++    avr_name = avrdevice->name;
++    flashmax = avrdevice->flash;
++    rammax = avrdevice->ram;
++    eeprommax = avrdevice->eeprom;
++  }
++
++  if ((section = bfd_get_section_by_name (file, ".data")) != NULL)
++    my_datasize = bfd_section_size (section);
++  if ((section = bfd_get_section_by_name (file, ".text")) != NULL)
++    my_textsize = bfd_section_size (section);
++  if ((section = bfd_get_section_by_name (file, ".bss")) != NULL)
++    my_bsssize = bfd_section_size (section);
++  if ((section = bfd_get_section_by_name (file, ".bootloader")) != NULL)
++    bootloadersize = bfd_section_size (section);
++  if ((section = bfd_get_section_by_name (file, ".noinit")) != NULL)
++    noinitsize = bfd_section_size (section);
++  if ((section = bfd_get_section_by_name (file, ".eeprom")) != NULL)
++    eepromsize = bfd_section_size (section);
++
++  bfd_size_type text = my_textsize + my_datasize + bootloadersize;
++  bfd_size_type data = my_datasize + my_bsssize + noinitsize;
++  bfd_size_type eeprom = eepromsize;
++
++  printf ("AVR Memory Usage\n"
++          "----------------\n"
++          "Device: %s\n\n", avr_name);
++
++  /* Text size */
++  printf ("Program:%8ld bytes", text);
++  if (flashmax > 0)
++  {
++    printf (" (%2.1f%% Full)", ((float)text / flashmax) * 100);
++  }
++  printf ("\n(.text + .data + .bootloader)\n\n");
++
++  /* Data size */
++  printf ("Data:   %8ld bytes", data);
++  if (rammax > 0)
++  {
++    printf (" (%2.1f%% Full)", ((float)data / rammax) * 100);
++  }
++  printf ("\n(.data + .bss + .noinit)\n\n");
++
++  /* EEPROM size */
++  if (eeprom > 0)
++  {
++    printf ("EEPROM: %8ld bytes", eeprom);
++    if (eeprommax > 0)
++    {
++      printf (" (%2.1f%% Full)", ((float)eeprom / eeprommax) * 100);
++    }
++    printf ("\n(.eeprom)\n\n");
++  }
++}
++
++
+ static void
+ print_sizes (bfd *file)
+ {
+@@ -663,6 +1010,8 @@ print_sizes (bfd *file)
+     calculate_common_size (file);
+   if (selected_output_format == FORMAT_SYSV)
+     print_sysv_format (file);
++  else if (selected_output_format == FORMAT_AVR)
++    print_avr_format (file);
+   else
+     print_berkeley_or_gnu_format (file);
+ }

--- a/extra-devel/avr-binutils/autobuild/prepare
+++ b/extra-devel/avr-binutils/autobuild/prepare
@@ -1,0 +1,11 @@
+abinfo "Disable gold testsuite"
+sed -i 's/testsuite//g' "$SRCDIR"/gold/Makefile.in
+
+abinfo "Set CPPFLAGS for libiberty"
+sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" "$SRCDIR"/libiberty/configure
+
+abinfo "Do not use ab3 provided default prefix & paths etc"
+export AUTOTOOLS_DEF=""
+
+abinfo "Hack BUILD_READY to run configure-host"
+alias BUILD_READY="make configure-host"

--- a/extra-devel/avr-binutils/spec
+++ b/extra-devel/avr-binutils/spec
@@ -1,0 +1,4 @@
+VER=2.37
+SRCS="tbl::https://ftp.gnu.org/gnu/binutils/binutils-${VER}.tar.bz2"
+CHKUPDATE="anitya::id=7981"
+CHKSUMS="sha256::67fc1a4030d08ee877a4867d3dcab35828148f87e1fd05da6db585ed5a166bd4"

--- a/extra-devel/avr-gcc/autobuild/beyond
+++ b/extra-devel/avr-gcc/autobuild/beyond
@@ -1,0 +1,24 @@
+abinfo "Strip debug symbols from libraries"
+find "${PKGDIR}${_PREFIX}"/lib -type f -name "*.a" -exec /usr/bin/avr-strip --strip-debug {} \;
+
+abinfo "Install runtime library license exception"
+install -Dvm644 "${SRCDIR}/COPYING.RUNTIME" "${PKGDIR}/usr/share/licenses/avr-gcc/RUNTIME.LIBRARY.EXCEPTION"
+
+abinfo "Removing stray manuals"
+rm -vr "${PKGDIR}${_PREFIX}/share/man/man7"
+rm -vr "${PKGDIR}${_PREFIX}/share/info"
+
+abinfo "Removing locale"
+rm -vr "${PKGDIR}${_PREFIX}/share/locale"
+
+abinfo "Removing stray libcc1"
+rm -vr "${PKGDIR}${_PREFIX}/lib64"/libcc1.*
+rmdir -v "${PKGDIR}${_PREFIX}/lib64"
+
+abinfo "Creating symlinks in /usr/bin"
+mkdir -vp "${PKGDIR}/usr/bin"
+pushd "${PKGDIR}${_PREFIX}/bin"
+for i in avr-*; do
+	ln -sv "${_PREFIX}/bin/${i}" "${PKGDIR}/usr/bin/$i"
+done
+popd

--- a/extra-devel/avr-gcc/autobuild/defines
+++ b/extra-devel/avr-gcc/autobuild/defines
@@ -1,0 +1,62 @@
+PKGNAME=avr-gcc
+PKGSEC=devel
+PKGDEP="avr-binutils gcc-runtime isl mpc mpfr texinfo zlib zstd"
+PKGDES="GNU Compiler Collection for AVR micro-controllers (compilers and development tools)"
+
+NOSTATIC=0
+# The resulting libraries can only be stripped with avr-strip
+# So we are doing this ourselves
+ABSTRIP=0
+NOLTO=1
+AB_FLAGS_SPECS=0
+AB_FLAGS_O3=1
+
+_PREFIX=/opt/abcross/avr
+
+AUTOTOOLS_STRICT=0
+AUTOTOOLS_AFTER="
+	AR_FOR_TARGET=${_PREFIX}/bin/avr-ar
+	AS_FOR_TARGET=${_PREFIX}/bin/avr-as
+	LD_FOR_TARGET=${_PREFIX}/bin/avr-ld
+	NM_FOR_TARGET=${_PREFIX}/bin/avr-nm
+	OBJCOPY_FOR_TARGET=${_PREFIX}/bin/avr-objcopy
+	OBJDUMP_FOR_TARGET=${_PREFIX}/bin/avr-objdump
+	RANLIB_FOR_TARGET=${_PREFIX}/bin/avr-ranlib
+	READELF_FOR_TARGET=${_PREFIX}/bin/avr-readelf
+	STRIP_FOR_TARGET=${_PREFIX}/bin/avr-strip
+	--target=avr
+	--with-gnu-as
+	--with-gnu-ld
+	--with-as=${_PREFIX}/bin/avr-as
+	--with-ld=${_PREFIX}/bin/avr-ld
+	--prefix=${_PREFIX}
+	--bindir=${_PREFIX}/bin
+	--libdir=${_PREFIX}/lib
+	--libexecdir=${_PREFIX}/lib
+	--mandir=${_PREFIX}/share/man
+	--infodir=${_PREFIX}/share/info
+	--with-bugurl=https://github.com/AOSC-Dev/aosc-os-abbs
+	--with-system-zlib
+	--with-isl=/usr
+	--with-plugin-ld=ld.gold
+	--enable-shared
+	--enable-gnu-indirect-function
+	--enable-clocale=gnu
+	--enable-fixed-point
+	--enable-gnu-unique-object
+	--enable-plguin
+	--enable-gold
+	--enable-lto
+	--disable-libunwind-exceptions
+	--disable-libstdcxx-pch
+	--disable-linker-build-id
+	--disable-libada
+	--disable-libssp
+	--disable-install-libiberty
+	--disable-werror
+	--disable-__cxa_atexit
+	--enable-checking=release
+	--enable-languages=c,c++,lto
+"
+
+RECONF=0

--- a/extra-devel/avr-gcc/autobuild/prepare
+++ b/extra-devel/avr-gcc/autobuild/prepare
@@ -1,0 +1,9 @@
+abinfo "Setting CPPFLAGS for libiberty and gcc"
+sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" "${SRCDIR}"/{libiberty,gcc}/configure
+
+abinfo "Removing +gitblahblah fron version number to appease arduino-mk"
+echo ${PKGVER/+git*/} > ${SRCDIR}/gcc/BASE-VER
+
+abinfo "Setting default CFLAGS when building target static libraries"
+export CFLAGS_FOR_TARGET='-O2 -pipe'
+export CXXFLAGS_FOR_TARGET='-O2 -pipe -fno-threadsafe-statics'

--- a/extra-devel/avr-gcc/spec
+++ b/extra-devel/avr-gcc/spec
@@ -1,0 +1,4 @@
+VER=10.3.1+git20210510
+SRCS="git::commit=5f665c1ca452673e9812cd92b07bd31441c0ac5b::https://github.com/gcc-mirror/gcc"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=6502"

--- a/extra-devel/avr-libc/autobuild/beyond
+++ b/extra-devel/avr-libc/autobuild/beyond
@@ -1,0 +1,8 @@
+abinfo "Removing man executable"
+rm -v "${PKGDIR}${_PREFIX}/bin/avr-man"
+rmdir -v "${PKGDIR}${_PREFIX}/bin"
+
+abinfo "Installing man pages"
+tar -xvf "${SRCDIR}/../man.tar.bz2"
+mkdir -p "${PKGDIR}${_PREFIX}/share"
+cp -rv "${SRCDIR}/man" "${PKGDIR}${_PREFIX}/share/"

--- a/extra-devel/avr-libc/autobuild/defines
+++ b/extra-devel/avr-libc/autobuild/defines
@@ -1,0 +1,20 @@
+PKGNAME=avr-libc
+PKGSEC=devel
+PKGDEP="avr-gcc"
+PKGDES="C runtime-libraries for AVR micro-controllers"
+
+NOSTATIC=0
+ABSTRIP=0
+AB_FLAGS_O3=1
+
+_PREFIX=/opt/abcross/avr
+
+AUTOTOOLS_STRICT=0
+AUTOTOOLS_AFTER="
+	CC=${_PREFIX}/bin/avr-gcc
+	--prefix=${_PREFIX}
+	--host=avr
+"
+
+RECONF=0
+ABHOST=noarch

--- a/extra-devel/avr-libc/autobuild/prepare
+++ b/extra-devel/avr-libc/autobuild/prepare
@@ -1,0 +1,5 @@
+abinfo "Unset compiler options since avr-libc is not targeting AOSC OS"
+unset CFLAGS
+unset LDFLAGS
+unset CPPFLAGS
+unset CXXFLAGS

--- a/extra-devel/avr-libc/spec
+++ b/extra-devel/avr-libc/spec
@@ -1,0 +1,8 @@
+VER=2.0.0
+SRCS="
+	tbl::rename=src.tar.bz2::http://download.savannah.gnu.org/releases/avr-libc/avr-libc-${VER}.tar.bz2
+	file::rename=man.tar.bz2::http://download.savannah.gnu.org/releases/avr-libc/avr-libc-manpages-${VER}.tar.bz2
+"
+CHKSUMS="sha256::b2dd7fd2eefd8d8646ef6a325f6f0665537e2f604ed02828ced748d49dc85b97 \
+         sha256::f1086ff15cbe341eda0286a7191c563a10127343573e01aad66a97924d7b41b5"
+CHKUPDATE="anitya::id=14912"


### PR DESCRIPTION
Topic Description
-----------------

This PR adds compiler toolchains and makefile support to enable basic local arduino development workflow.

Package(s) Affected
-------------------

* avr-binutils
* avr-gcc
* avr-libc [noarch - contains static files targeting AVR ICs]
* arduino-avr-core [noarch - contains static files targeting AVR ICs]
* arduino-mk [noarch]

Build Order
-----------

avr-binutils -> avr-gcc -> avr-libc -> arduino-avr-core -> arduino-mk

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
