### PR TITLE
Zdoom survey 20210911

### DIFF
--- a/extra-games/gzdoom/autobuild/beyond
+++ b/extra-games/gzdoom/autobuild/beyond
@@ -5,7 +5,9 @@ cat << EOF > "$PKGDIR"/usr/share/applications/gzdoom.desktop
 [Desktop Entry]
 Type=Application
 Name=GZDoom
-Comment=Advanced Doom source port with OpenGL support
+Comment=A DOOM source port with graphic and modding extensions
+Comment[zh_CN]=含图形增强和模组扩展性的源码移植版 DOOM
+Comment[zh_TW]=含視頻增強和模組擴充性的原始碼移植版 DOOM
 Icon=gzdoom
 Exec=gzdoom %F
 Terminal=false
@@ -16,4 +18,4 @@ EOF
 
 abinfo 'Installing icon...'
 install -Dvm644 "$SRCDIR"/src/posix/zdoom.xpm \
-                "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/gzdoom.xpm
+                "$PKGDIR"/usr/share/pixmaps/gzdoom.xpm

--- a/extra-games/gzdoom/autobuild/beyond
+++ b/extra-games/gzdoom/autobuild/beyond
@@ -1,19 +1,19 @@
-abinfo 'Generating .desktop file...'
+abinfo 'Generating and installing .desktop file...'
 # adapted from AUR
 mkdir -pv "$PKGDIR"/usr/share/applications
 cat << EOF > "$PKGDIR"/usr/share/applications/gzdoom.desktop
 [Desktop Entry]
 Type=Application
-Version=1.0
 Name=GZDoom
-GenericName=Advanced Doom source port with OpenGL support
+Comment=Advanced Doom source port with OpenGL support
 Icon=gzdoom
 Exec=gzdoom %F
 Terminal=false
+StartupWMClass=GZDoom
 MimeType=application/x-doom-wad;
 Categories=Game;ActionGame;
 EOF
 
 abinfo 'Installing icon...'
 install -Dvm644 "$SRCDIR"/src/posix/zdoom.xpm \
-                "$PKGDIR"/usr/share/icons/hicolor/256x256/apps/gzdoom.xpm
+                "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/gzdoom.xpm

--- a/extra-games/gzdoom/autobuild/beyond
+++ b/extra-games/gzdoom/autobuild/beyond
@@ -1,0 +1,15 @@
+abinfo 'Generating .desktop file...'
+# adapted from AUR
+mkdir -p "$PKGDIR"/usr/share/applications
+cat << EOF > "$PKGDIR"/usr/share/applications/gzdoom.desktop
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=GZDoom
+GenericName=Advanced Doom source port with OpenGL support
+Icon=gzdoom
+Exec=gzdoom %F
+Terminal=false
+MimeType=application/x-doom-wad;
+Categories=Game;ActionGame;
+EOF

--- a/extra-games/gzdoom/autobuild/beyond
+++ b/extra-games/gzdoom/autobuild/beyond
@@ -1,6 +1,6 @@
 abinfo 'Generating .desktop file...'
 # adapted from AUR
-mkdir -p "$PKGDIR"/usr/share/applications
+mkdir -pv "$PKGDIR"/usr/share/applications
 cat << EOF > "$PKGDIR"/usr/share/applications/gzdoom.desktop
 [Desktop Entry]
 Type=Application
@@ -13,3 +13,7 @@ Terminal=false
 MimeType=application/x-doom-wad;
 Categories=Game;ActionGame;
 EOF
+
+abinfo 'Installing icon...'
+install -Dvm644 "$SRCDIR"/src/posix/zdoom.xpm \
+                "$PKGDIR"/usr/share/icons/hicolor/256x256/apps/gzdoom.xpm

--- a/extra-games/gzdoom/autobuild/defines
+++ b/extra-games/gzdoom/autobuild/defines
@@ -2,7 +2,8 @@ PKGNAME=gzdoom
 PKGSEC=games
 PKGDES="A feature centric port for all Doom engine games, based on ZDoom"
 PKGDEP="sdl2 zlib bzip2 libjpeg-turbo fluidsynth game-music-emu openal-soft \
-        mpg123 libsndfile gtk-3 timidity++ nasm mesa glu tar sdl glew zmusic"
+        mpg123 libsndfile gtk-3 timidity++ nasm mesa glu tar sdl glew zmusic \
+        qzdl"
 BUILDDEP="git gcc"
 PKGPROV="zdoom"
 

--- a/extra-games/gzdoom/autobuild/defines
+++ b/extra-games/gzdoom/autobuild/defines
@@ -1,12 +1,12 @@
 PKGNAME=gzdoom
 PKGSEC=games
-PKGDES="A feature centric port for all Doom engine games, based on ZDoom"
+PKGDES="A DOOM source port with graphic and modding extensions"
 PKGDEP="sdl2 zlib bzip2 libjpeg-turbo fluidsynth game-music-emu openal-soft \
         mpg123 libsndfile gtk-3 timidity++ nasm mesa glu tar sdl glew zmusic \
-        qzdl"
-BUILDDEP="git gcc"
+        vulkan glslang qzdl"
 PKGPROV="zdoom"
 
-ABTYPE=cmake
-CMAKE_AFTER="-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+CMAKE_AFTER="-DCMAKE_BUILD_TYPE=RelWithDebInfo
+             -DDYN_OPENAL=OFF"
+# openSUSE: There is handcrafted assembler, which LTO does not play nice with
 NOLTO=1

--- a/extra-games/gzdoom/autobuild/defines
+++ b/extra-games/gzdoom/autobuild/defines
@@ -2,4 +2,10 @@ PKGNAME=gzdoom
 PKGSEC=games
 PKGDES="A feature centric port for all Doom engine games, based on ZDoom"
 PKGDEP="sdl2 zlib bzip2 libjpeg-turbo fluidsynth game-music-emu openal-soft \
-        mpg123 libsndfile gtk-3 timidity++ nasm mesa glu tar sdl glew"
+        mpg123 libsndfile gtk-3 timidity++ nasm mesa glu tar sdl glew zmusic"
+BUILDDEP="git gcc"
+PKGPROV="zdoom"
+
+ABTYPE=cmake
+CMAKE_AFTER="-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+NOLTO=1

--- a/extra-games/gzdoom/autobuild/defines
+++ b/extra-games/gzdoom/autobuild/defines
@@ -2,4 +2,4 @@ PKGNAME=gzdoom
 PKGSEC=games
 PKGDES="A feature centric port for all Doom engine games, based on ZDoom"
 PKGDEP="sdl2 zlib bzip2 libjpeg-turbo fluidsynth game-music-emu openal-soft \
-        mpg123 libsndfile gtk3 timidity++ nasm mesa glu tar sdl glew"
+        mpg123 libsndfile gtk-3 timidity++ nasm mesa glu tar sdl glew"

--- a/extra-games/gzdoom/autobuild/defines
+++ b/extra-games/gzdoom/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=gzdoom
+PKGSEC=games
+PKGDES="A feature centric port for all Doom engine games, based on ZDoom"
+PKGDEP="sdl2 zlib bzip2 libjpeg-turbo fluidsynth game-music-emu openal-soft \
+        mpg123 libsndfile gtk3 timidity++ nasm mesa glu tar sdl glew"

--- a/extra-games/gzdoom/autobuild/patches/0001-openSUSE-use-appropriate-WAD-dir.patch
+++ b/extra-games/gzdoom/autobuild/patches/0001-openSUSE-use-appropriate-WAD-dir.patch
@@ -1,0 +1,22 @@
+From: Jan Engelhardt <jengelh@inai.de>
+Date: 2018-01-02 15:25:05.669125932 +0100
+
+Ensure same IWAD directory across all Doom source ports in openSUSE
+
+---
+ src/common/platform/posix/i_system.h |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: gzdoom-g4.4.0/src/common/platform/posix/i_system.h
+===================================================================
+--- gzdoom-g4.4.0.orig/src/common/platform/posix/i_system.h
++++ gzdoom-g4.4.0/src/common/platform/posix/i_system.h
+@@ -17,7 +17,7 @@ struct ticcmd_t;
+ struct WadStuff;
+
+ #ifndef SHARE_DIR
+-#define SHARE_DIR "/usr/local/share/"
++#define SHARE_DIR "/usr/share/doom/"
+ #endif
+
+ void CalculateCPUSpeed(void);

--- a/extra-games/gzdoom/autobuild/patches/0002-openSUSE-fix-SDL-bug.patch
+++ b/extra-games/gzdoom/autobuild/patches/0002-openSUSE-fix-SDL-bug.patch
@@ -1,0 +1,35 @@
+From: Jan Engelhardt <jengelh@inai.de>
+Date: 2020-06-12 02:05:34.009865606 +0200
+
+When a SDL_PollEvent is sandwiched between SDL_CreateWindow and
+SDL_CreateRenderer, SDL crashes during SDL_IME_PumpEvents because dbus message
+still references the old window (still exists and pointer is non-NULL) and
+tries to access members of window->driverdata (block was freed and pointer is
+NULL.)
+
+Workaround this by recreating the SDL_Window object and immediately afterwards
+creating the renderer.
+
+This crash only happens for gzdoom when running with the SoftPoly rasterizer,
+as that is the only place that issues SDL_CreateRenderer after the mainloop has
+started.
+
+Needs a bugreport on libsdl.org.
+
+---
+ src/common/platform/posix/sdl/sdlglvideo.cpp |    2 ++
+ 1 file changed, 2 insertions(+)
+
+Index: gzdoom-g4.4.1/src/common/platform/posix/sdl/sdlglvideo.cpp
+===================================================================
+--- gzdoom-g4.4.1.orig/src/common/platform/posix/sdl/sdlglvideo.cpp
++++ gzdoom-g4.4.1/src/common/platform/posix/sdl/sdlglvideo.cpp
+@@ -294,6 +294,8 @@ uint8_t *I_PolyPresentLock(int w, int h,
+ 	{
+ 		polyvsync = vsync;
+ 
++		Priv::DestroyWindow();
++		Priv::CreateWindow(Priv::VulkanWindowFlag | (Priv::softpolyEnabled ? SDL_WINDOW_HIDDEN : 0));
+ 		polyrendertarget = SDL_CreateRenderer(Priv::window, -1, vsync ? SDL_RENDERER_PRESENTVSYNC : 0);
+ 		if (!polyrendertarget)
+ 		{

--- a/extra-games/gzdoom/spec
+++ b/extra-games/gzdoom/spec
@@ -1,0 +1,4 @@
+VER=4.6.1
+SRCS="tbl::https://github.com/coelckers/gzdoom/archive/g$VER.zip"
+CHKSUMS="sha256::d46e85da74c77d780abfc9fd3ce65112b8774528def7b2d64c2bba778cc1dddd"
+CHKUPDATE="anitya::id=17531"

--- a/extra-games/qzdl/autobuild/beyond
+++ b/extra-games/qzdl/autobuild/beyond
@@ -1,0 +1,18 @@
+abinfo 'Generating and installing .desktop file...'
+mkdir -pv "$PKGDIR"/usr/share/applications
+cat << EOF > "$PKGDIR"/usr/share/applications/zdl.desktop
+[Desktop Entry]
+Type=Application
+Name=ZDL
+Comment=A ZDoom Launcher using Qt
+Icon=zdl
+Exec=zdl %F
+Terminal=false
+StartupWMClass=ZDL
+MimeType=application/x-doom-wad;
+Categories=Game;ActionGame;
+EOF
+
+abinfo 'Installing icons...'
+install -Dvm644 "$SRCDIR"/res/zdl3.svg \
+                "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/zdl.svg

--- a/extra-games/qzdl/autobuild/beyond
+++ b/extra-games/qzdl/autobuild/beyond
@@ -3,16 +3,14 @@ mkdir -pv "$PKGDIR"/usr/share/applications
 cat << EOF > "$PKGDIR"/usr/share/applications/zdl.desktop
 [Desktop Entry]
 Type=Application
-Name=ZDL
+Name=ZDL3
 Comment=A ZDoom Launcher using Qt
-Icon=zdl
+Comment[zh_CN]=ZDoom 启动器（使用 Qt）
+Comment[zh_TW]=ZDoom 啟動器（使用 Qt）
+Icon=zdl3
 Exec=zdl %F
 Terminal=false
 StartupWMClass=ZDL
 MimeType=application/x-doom-wad;
 Categories=Game;ActionGame;
 EOF
-
-abinfo 'Installing icons...'
-install -Dvm644 "$SRCDIR"/res/zdl3.svg \
-                "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/zdl.svg

--- a/extra-games/qzdl/autobuild/defines
+++ b/extra-games/qzdl/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=qzdl
+PKGSEC=games
+PKGDES="A popular launcher for GZDoom with user friendly interface"
+PKGDEP="qt-5"
+BUILDDEP="git"
+
+ABTYPE=cmake

--- a/extra-games/qzdl/autobuild/defines
+++ b/extra-games/qzdl/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=qzdl
 PKGSEC=games
-PKGDES="A popular launcher for GZDoom using Qt"
+PKGDES="A launcher for GZDoom"
 PKGDEP="qt-5"

--- a/extra-games/qzdl/autobuild/defines
+++ b/extra-games/qzdl/autobuild/defines
@@ -1,7 +1,4 @@
 PKGNAME=qzdl
 PKGSEC=games
-PKGDES="A popular launcher for GZDoom with user friendly interface"
+PKGDES="A popular launcher for GZDoom using Qt"
 PKGDEP="qt-5"
-BUILDDEP="git"
-
-ABTYPE=cmake

--- a/extra-games/qzdl/autobuild/patch
+++ b/extra-games/qzdl/autobuild/patch
@@ -1,3 +1,0 @@
-abinfo 'Patching CMakeList.txt to install binaries automatically...'
-sed -e '53a install(TARGETS zdl DESTINATION ${CMAKE_INSTALL_BINDIR})' \
-    -i "$SRCDIR"/CMakeLists.txt

--- a/extra-games/qzdl/autobuild/patch
+++ b/extra-games/qzdl/autobuild/patch
@@ -1,0 +1,3 @@
+abinfo 'Patching CMakeList.txt to install binaries automatically...'
+sed -e '53a install(TARGETS zdl DESTINATION ${CMAKE_INSTALL_BINDIR})' \
+    -i "$SRCDIR"/CMakeLists.txt

--- a/extra-games/qzdl/autobuild/patches/0001-Install-binaries-and-icons-after-building.patch
+++ b/extra-games/qzdl/autobuild/patches/0001-Install-binaries-and-icons-after-building.patch
@@ -1,0 +1,23 @@
+From bbaf03f6fdc9e9160f75626a8dd6c85824b6e186 Mon Sep 17 00:00:00 2001
+From: WhiredPlanck <whiredplanck@outlook.com>
+Date: Wed, 15 Sep 2021 20:59:12 +0800
+Subject: [PATCH] Install binaries and icons after building
+
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 10a8fb6..b527d6d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -51,3 +51,6 @@ add_executable(
+ target_include_directories(zdl PRIVATE ${PROJECT_SOURCE_DIR}/zdlconf)
+ target_include_directories(zdl PRIVATE ${inih_SOURCE_DIR})
+ target_link_libraries(zdl Qt5::Core Qt5::Widgets)
++
++install(TARGETS zdl DESTINATION ${CMAKE_INSTALL_BINDIR})
++install(FILES res/zdl3.svg DESTINATION share/icons/hicolor/scalable/apps)
+-- 
+2.30.2
+

--- a/extra-games/qzdl/spec
+++ b/extra-games/qzdl/spec
@@ -1,0 +1,4 @@
+VER=3.2.2.3+git20210516
+SRCS="git::commit=5425be932982544dd3c796c4317b6767796a3dfe::https://github.com/qbasicer/qzdl"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=234978"

--- a/extra-games/zmusic/autobuild/beyond
+++ b/extra-games/zmusic/autobuild/beyond
@@ -1,3 +1,3 @@
 abinfo 'Installing the licenses...'
 install -Dvm644 "$SRCDIR"/licenses/{bsd,dumb,legal,zmusic}.txt \
-        -t "$PKGDIR"/usr/share/doc/zmusic/licenses
+        -t "$PKGDIR"/usr/share/doc/zmusic

--- a/extra-games/zmusic/autobuild/beyond
+++ b/extra-games/zmusic/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo 'Installing the licenses...'
+install -Dvm644 "$SRCDIR"/licenses/{bsd,dumb,legal,zmusic}.txt \
+        -t "$PKGDIR"/usr/share/doc/zmusic/licenses

--- a/extra-games/zmusic/autobuild/defines
+++ b/extra-games/zmusic/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=zmusic
+PKGSEC=libs
+PKGDES="GZDoom's music system as a standalone library"
+PKGDEP="fluidsynth game-music-emu mpg123 libsndfile zlib alsa-lib"
+
+ABTYPE=cmake

--- a/extra-games/zmusic/autobuild/defines
+++ b/extra-games/zmusic/autobuild/defines
@@ -1,6 +1,4 @@
 PKGNAME=zmusic
 PKGSEC=libs
-PKGDES="GZDoom's music system as a standalone library"
+PKGDES="A standalone music system library, used by GZDoom and other similar projects"
 PKGDEP="fluidsynth game-music-emu mpg123 libsndfile zlib alsa-lib"
-
-ABTYPE=cmake

--- a/extra-games/zmusic/spec
+++ b/extra-games/zmusic/spec
@@ -1,0 +1,4 @@
+VER=1.1.8
+SRCS="tbl::https://github.com/coelckers/ZMusic/archive/refs/tags/$VER.tar.gz"
+CHKSUMS="sha256::73082f661b7b0bb33348d1d186c132deec9132a1613480348a00172b49c9fd68"
+CHKUPDATE="anitya::id=153600"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Introduce `gzdoom`, a A feature centric port for all Doom engine games, based on ZDoom

Package(s) Affected
-------------------

- `gzdoom`
- `zmusic`
- `qzdl`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

`zmusic` -> `gzdoom`


Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
