### PR TITLE
NVIDIA drivers 470.63.01

### DIFF
--- a/extra-optenv32/nvidia+32/spec
+++ b/extra-optenv32/nvidia+32/spec
@@ -1,8 +1,8 @@
-VER=465.31
-_SETTINGS_VER=465.27
+VER=470.63.01
+_SETTINGS_VER=470.63.01
 SRCS="file::rename=NVIDIA-Linux-x86_64-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run \
       tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz"
-CHKSUMS="sha256::6008d001c9335863049c338e7ba6ab96406f4f7af31427aa8c18c6d277272cda \
-         sha256::29bd4a745842e22e410a5afe5c09257919de0b2d272e03795bb5772b5bdef75c"
+CHKSUMS="sha256::6f1a44cc4a2ce27dce749ccd1e403c1db0f4791e2d22c05ec966842101d3ed14 \
+         sha256::4cca3f3a25e4c84458839337b18b5d41738e87fea58e68936ea7ef43658f7cb9"
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"

--- a/extra-x11/nvidia/autobuild/amd64/prepare
+++ b/extra-x11/nvidia/autobuild/amd64/prepare
@@ -1,1 +1,7 @@
+abinfo "Extracting archive"
 sh NVIDIA-Linux-x86_64-$PKGVER-no-compat32.run --extract-only
+
+abinfo "Generating postinst and prerm"
+for i in postinst prerm; do
+	sed -e "s/@DRV_VER@/${PKGVER}/g" ${SRCDIR}/autobuild/${i}.in > ${SRCDIR}/autobuild/${i}
+done

--- a/extra-x11/nvidia/autobuild/postinst.in
+++ b/extra-x11/nvidia/autobuild/postinst.in
@@ -1,6 +1,6 @@
 unset ARCH
 
-DRIVER_VER=465.31
+DRIVER_VER=@DRV_VER@
 
 for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
     if [ -f "/usr/lib/modules/${i}/modules.dep" -a -f "/usr/lib/modules/${i}/modules.order" -a -f "/usr/lib/modules/${i}/modules.builtin" ]; then

--- a/extra-x11/nvidia/autobuild/prerm.in
+++ b/extra-x11/nvidia/autobuild/prerm.in
@@ -1,4 +1,4 @@
 unset ARCH
 
-DRIVER_VER=465.31
+DRIVER_VER=@DRV_VER@
 dkms remove nvidia/${DRIVER_VER} --all || true > /dev/null

--- a/extra-x11/nvidia/spec
+++ b/extra-x11/nvidia/spec
@@ -1,8 +1,8 @@
-VER=465.31
-_SETTINGS_VER=465.27
+VER=470.63.01
+_SETTINGS_VER=470.63.01
 SRCS="file::rename=NVIDIA-Linux-x86_64-$VER-no-compat32.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER-no-compat32.run \
       tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz"
-CHKSUMS="sha256::2d423f1299561f770b2c1195f310c0bc9a4ce7b7095327b7cf67a3efc340ea58 \
-         sha256::29bd4a745842e22e410a5afe5c09257919de0b2d272e03795bb5772b5bdef75c"
+CHKSUMS="sha256::f154deca475db09447a6d47af14d1c7b5ee16a78eba45ae5255e61f2e488ec19 \
+         sha256::4cca3f3a25e4c84458839337b18b5d41738e87fea58e68936ea7ef43658f7cb9"
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates nvidia drivers to 470.63.01 to prepare for kernel 5.14.

Package(s) Affected
-------------------

* nvidia
* nvidia+32

Build Order
-----------

nvidia -> nvidia+32

Architectural Progress
----------------------

- [x] AMD64 `amd64`   

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   