### PR TITLE
httpie: update to 2.5.0 (noarch) 

### DIFF
--- a/extra-python/defusedxml/spec
+++ b/extra-python/defusedxml/spec
@@ -1,5 +1,4 @@
-VER=0.5.0
-REL=2
-SRCS="tbl::https://pypi.python.org/packages/source/d/defusedxml/defusedxml-$VER.tar.gz"
-CHKSUMS="sha256::24d7f2f94f7f3cb6061acb215685e5125fbcdc40a857eff9de22518820b0a4f4"
+VER=0.7.1
+SRCS="tbl::https://files.pythonhosted.org/packages/source/d/defusedxml/defusedxml-$VER.tar.gz"
+CHKSUMS="sha256::1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"
 CHKUPDATE="anitya::id=3821"

--- a/extra-python/pygments/spec
+++ b/extra-python/pygments/spec
@@ -1,5 +1,4 @@
-VER=2.3.1
-REL=3
-SRCS="tbl::https://pypi.io/packages/source/P/Pygments/Pygments-$VER.tar.gz"
-CHKSUMS="sha256::5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a"
+VER=2.10.0
+SRCS="tbl::https://files.pythonhosted.org/packages/source/P/Pygments/Pygments-$VER.tar.gz"
+CHKSUMS="sha256::f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"
 CHKUPDATE="anitya::id=3986"

--- a/extra-web/httpie/autobuild/defines
+++ b/extra-web/httpie/autobuild/defines
@@ -3,5 +3,6 @@ PKGSEC=utils
 PKGDEP="defusedxml requests toolbelt pygments pysocks"
 PKGDES="cURL for humans"
 
+ABHOST=noarch
 ABTYPE=python
 NOPYTHON2=1

--- a/extra-web/httpie/autobuild/defines
+++ b/extra-web/httpie/autobuild/defines
@@ -4,3 +4,4 @@ PKGDEP="defusedxml requests toolbelt pygments pysocks"
 PKGDES="cURL for humans"
 
 ABTYPE=python
+NOPYTHON2=1

--- a/extra-web/httpie/autobuild/defines
+++ b/extra-web/httpie/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=httpie
 PKGSEC=utils
-PKGDEP="requests pygments"
+PKGDEP="defusedxml requests toolbelt pygments pysocks"
 PKGDES="cURL for humans"
 
 ABTYPE=python

--- a/extra-web/httpie/spec
+++ b/extra-web/httpie/spec
@@ -1,5 +1,5 @@
-VER=1.0.3
-SRCS="tbl::https://github.com/jakubroztocil/httpie/archive/$VER.tar.gz"
-CHKSUMS="sha256::ecfb1ecdfd1468100bd9ffecebe1bea6d7d72c72149ea91f3d0112dc8ef03c7a"
+VER=2.5.0
+SRCS="tbl::https://github.com/httpie/httpie/archive/$VER.tar.gz"
+CHKSUMS="sha256::66af56e0efc1ca6237323f1186ba34bca1be24e67a4319fd5df7228ab986faea"
 REL=1
 CHKUPDATE="anitya::id=1337"


### PR DESCRIPTION
Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>

<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update HTTPie to version 2.5.0.

Package(s) Affected
-------------------

extra-web/httpie

Security Update?
----------------

No.

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

Secondary Architectural Progress
--------------------------------

N/A

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- - [ ] AMD64 `amd64`    -->
<!-- - [ ] AArch64 `arm64` -->
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [x] Architecture-independent `noarch`

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

<!-- - [ ] Loongson 3 `loongson3` -->
<!-- - [ ] PowerPC 64-bit (Little Endian) `ppc64el` -->

<!-- TODO: CI to auto-fill architectural progress. -->
