### PR TITLE
fcitx5-pinyin-moegirl: upgrade to 20210914

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20210815
+VER=20210914
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::2fdd19dde4d2d2bb472fe98ed03a2938c1343c5dd6a9fe8ffb5461ba33c4b711 \
-         sha256::c23b2e2bfab1511ea2bf991eba0566135c17452eadea3e42a49a739600b4dc59 \
+CHKSUMS="sha256::e583f5f1256759c73ca9c738e7479f58241c2e2df2156ff49c870a8d47f63840 \
+         sha256::d1d056bfa36ade33aa62b187e5c74441821a71fdf87dd378b0f10acc1ac91c77 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
**Note: this is currently blocked by #3462.**

Topic Description
-----------------

Routine update. Note that the build is blocked by aosc-dev/rime-schema-manager#4 (so not tested yet) but this PR is expected to be safe since it is pretty straightforward.

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl
* rime-pinyin-moegirl

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`