### PR TITLE
rime-schema-manager: upgrade to 0.2.3

### DIFF
--- a/extra-i18n/rime-schema-manager/spec
+++ b/extra-i18n/rime-schema-manager/spec
@@ -1,4 +1,4 @@
-VER=0.2.2
+VER=0.2.3
 SRCS="tbl::https://github.com/AOSC-Dev/rime-schema-manager/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::a25ff3dbf4f4ee5f803a2deda5a9edaf484932e11d02dbae7cb84ae311aab645"
+CHKSUMS="sha256::0238fc2bbdf45828a4f6996d20ee5e268200eb548b75450c3e11627914b47168"
 CHKUPDATE="anitya::id=228939"


### PR DESCRIPTION
Topic Description
-----------------

Get the fix for AOSC-Dev/rime-schema-manager#4 release in order to resume other RIME-related packaging.

Package(s) Affected
-------------------

* rime-schema-manager

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`