### PR TITLE
systemd-boot-friend: update to 0.9.4

### DIFF
--- a/extra-admin/systemd-boot-friend/spec
+++ b/extra-admin/systemd-boot-friend/spec
@@ -1,5 +1,4 @@
-VER=0.9.3
-REL=1
+VER=0.9.4
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/systemd-boot-friend-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226819"


### PR DESCRIPTION
Topic Description
-----------------

Update `systemd-boot-friend` to 0.9.4

Package(s) Affected
-------------------

`systemd-boot-friend`

Security Update?
----------------

No

Architectural Progress
----------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`