### PR TITLE
gitui: new, 0.17.1

### DIFF
--- a/extra-devel/ciel/spec
+++ b/extra-devel/ciel/spec
@@ -1,4 +1,4 @@
-VER=3.0.12
+VER=3.0.13
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227000"

--- a/extra-devel/geany-plugins/spec
+++ b/extra-devel/geany-plugins/spec
@@ -1,4 +1,5 @@
 VER=1.37
+REL=1
 SRCS="tbl::https://plugins.geany.org/geany-plugins/geany-plugins-$VER.tar.bz2"
 CHKSUMS="sha256::c98f9b1303f4ab9bed7587e749cd0b5594d9136a1bf8ba110900d46a17fa9cd8"
 CHKUPDATE="anitya::id=5517"

--- a/extra-electronics/fritzing/autobuild/defines
+++ b/extra-electronics/fritzing/autobuild/defines
@@ -4,4 +4,5 @@ PKGDEP="libgit2 openjdk qt-5 quazip"
 BUILDDEP="boost"
 PKGDES="An Electronic Design Automation software"
 
-QTPROJ_AFTER="DEFINES=QUAZIP_INSTALLED CONFIG+=force_debug_info"
+QTPROJ_AFTER="DEFINES=QUAZIP_INSTALLED \
+              CONFIG+=force_debug_info"

--- a/extra-electronics/fritzing/autobuild/defines
+++ b/extra-electronics/fritzing/autobuild/defines
@@ -4,4 +4,4 @@ PKGDEP="libgit2 openjdk qt-5 quazip"
 BUILDDEP="boost"
 PKGDES="An Electronic Design Automation software"
 
-QTPROJ_AFTER="DEFINES=QUAZIP_INSTALLED"
+QTPROJ_AFTER="DEFINES=QUAZIP_INSTALLED CONFIG+=force_debug_info"

--- a/extra-electronics/fritzing/spec
+++ b/extra-electronics/fritzing/spec
@@ -1,4 +1,5 @@
 VER=0.9.6
+REL=1
 PARTS_COMMIT=6f04697be286768bc9e4d64f8707e8e40cbcafcb
 SRCS="tbl::https://github.com/fritzing/fritzing-app/archive/$VER.tar.gz \
       git::commit=${PARTS_COMMIT};rename=fritzing-parts::https://github.com/fritzing/fritzing-parts"

--- a/extra-gnome/gnome-builder/spec
+++ b/extra-gnome/gnome-builder/spec
@@ -2,4 +2,4 @@ VER=3.40.2
 SRCS="https://download.gnome.org/sources/gnome-builder/${VER:0:4}/gnome-builder-$VER.tar.xz"
 CHKSUMS="sha256::b2844cfde821311939fb6ed3b18a49cd331413aea720393091583ab6a99e719a"
 CHKUPDATE="anitya::id=5574"
-REL=1
+REL=2

--- a/extra-kde/ktexteditor/spec
+++ b/extra-kde/ktexteditor/spec
@@ -1,4 +1,5 @@
 VER=5.86.0
+REL=1
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER:0:4}/ktexteditor-$VER.tar.xz"
 CHKSUMS="sha256::6283fee0dbf2e342b227026a98acfb5eecfe54dc26791e22a77271b07542eeb8"
 CHKUPDATE="anitya::id=8762"

--- a/extra-libs/libgit2-glib/spec
+++ b/extra-libs/libgit2-glib/spec
@@ -1,5 +1,4 @@
-VER=0.28.0.1
-REL=1
+VER=0.99.0.1
 SRCS="tbl::https://download.gnome.org/sources/libgit2-glib/${VER:0:4}/libgit2-glib-$VER.tar.xz"
-CHKSUMS="sha256::e70118481241a841d5261bdd4caa3158b2ffcb5ccf9d4f32b6cf6563b83a0f28"
+CHKSUMS="sha256::e05a75c444d9c8d5991afc4a5a64cd97d731ce21aeb7c1c651ade1a3b465b9de"
 CHKUPDATE="anitya::id=7263"

--- a/extra-libs/libgit2/autobuild/defines
+++ b/extra-libs/libgit2/autobuild/defines
@@ -7,4 +7,5 @@ PKGBREAK="cargo-audit<=0.15.0-1 calligra<=3.2.0 ciel<=3.0.12 exa<=0.10.1-3 \
           ktexteditor<=5.86.0 libgit2-glib<=0.28.0.1-1 pygit2<=1.0.3-1"
 
 CMAKE_AFTER="-DTHREADSAFE=ON \
-             -DUSE_HTTP_PARSER=system"
+             -DUSE_HTTP_PARSER=system \
+             -DUSE_NTLMCLIENT=OFF"

--- a/extra-libs/libgit2/autobuild/defines
+++ b/extra-libs/libgit2/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=libgit2
 PKGSEC=libs
-PKGDEP="zlib openssl libssh2 http-parser"
+PKGDEP="zlib openssl libssh2 http-parser pcre2"
 PKGDES="A linkable library for Git"
+PKGBREAK="cargo-audit<=0.15.0-1 calligra<=3.2.0 ciel<=3.0.12 exa<=0.10.1-3 \
+          fritzing<=0.9.6 geany-plugins<=1.37 gnome-builder<=3.40.2-1 \
+          ktexteditor<=5.86.0 libgit2-glib<=0.28.0.1-1 pygit2<=1.0.3-1"
 
 CMAKE_AFTER="-DTHREADSAFE=ON"
-PKGBREAK="exa<=0.8.0-1 fritzing<=0.9.3b-2 geany-plugins<=1.34 \
-          julia<=1.1.0-1 ktexteditor<=5.55.0 libgit2-glib<=0.26.4-1 pygit2<=0.27.4"

--- a/extra-libs/libgit2/autobuild/defines
+++ b/extra-libs/libgit2/autobuild/defines
@@ -6,4 +6,5 @@ PKGBREAK="cargo-audit<=0.15.0-1 calligra<=3.2.0 ciel<=3.0.12 exa<=0.10.1-3 \
           fritzing<=0.9.6 geany-plugins<=1.37 gnome-builder<=3.40.2-1 \
           ktexteditor<=5.86.0 libgit2-glib<=0.28.0.1-1 pygit2<=1.0.3-1"
 
-CMAKE_AFTER="-DTHREADSAFE=ON"
+CMAKE_AFTER="-DTHREADSAFE=ON \
+             -DUSE_HTTP_PARSER=system"

--- a/extra-libs/libgit2/autobuild/defines
+++ b/extra-libs/libgit2/autobuild/defines
@@ -1,9 +1,8 @@
 PKGNAME=libgit2
 PKGSEC=libs
 PKGDEP="zlib openssl libssh2 http-parser"
-BUILDDEP="cmake"
 PKGDES="A linkable library for Git"
 
-CMAKE_AFTER="-DLIB_INSTALL_DIR=/usr/lib -DTHREADSAFE=ON"
+CMAKE_AFTER="-DTHREADSAFE=ON"
 PKGBREAK="exa<=0.8.0-1 fritzing<=0.9.3b-2 geany-plugins<=1.34 \
           julia<=1.1.0-1 ktexteditor<=5.55.0 libgit2-glib<=0.26.4-1 pygit2<=0.27.4"

--- a/extra-libs/libgit2/autobuild/prepare
+++ b/extra-libs/libgit2/autobuild/prepare
@@ -1,2 +1,5 @@
-sed -i 's/ionline/xonline/' CMakeLists.txt
-rm -frv deps
+abinfo 'Fedora: Patching to disable `online` tests...'
+sed -e '/-sonline/s/^/#/' -i "$SRCDIR"/tests/CMakeLists.txt
+
+abinfo 'Removing bundled libararies...'
+rm -rv "$SRCDIR"/deps

--- a/extra-libs/libgit2/spec
+++ b/extra-libs/libgit2/spec
@@ -1,4 +1,4 @@
-VER=0.28.4
+VER=1.3.0
 SRCS="tbl::https://github.com/libgit2/libgit2/archive/v$VER.tar.gz"
-CHKSUMS="sha256::30f3877469d09f2e4a21be933b4e2800560d16646028dd800744dc5f7fb0c749"
+CHKSUMS="sha256::192eeff84596ff09efb6b01835a066f2df7cd7985e0991c79595688e6b36444e"
 CHKUPDATE="anitya::id=1627"

--- a/extra-productivity/calligra/autobuild/patches/0001-Fix-Freetype-and-FontConfig-Linkage.patch
+++ b/extra-productivity/calligra/autobuild/patches/0001-Fix-Freetype-and-FontConfig-Linkage.patch
@@ -1,12 +1,11 @@
-From 62f510702ef9c34ac50f8d8601a4290ab558464c Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?=C3=96mer=20Fad=C4=B1l=20Usta?= <omerusta@gmail.com>
-Date: Sun, 6 Jun 2021 08:41:05 +0000
-Subject: [PATCH] Update Cmake and deps, Fix Freetype and FontConfig Linkage (Modified)
+From 5ab37c5ff729f30dfd04b762a09d305e5da88bad Mon Sep 17 00:00:00 2001
+From: WhiredPlanck <whiredplanck@outlook.com>
+Date: Wed, 6 Oct 2021 17:07:51 +0800
+Subject: [PATCH] Fix Freetype and FontConfig Linkage
 
-Use Correct Target to link FontConfig and Freetype
 ---
- libs/text/CMakeLists.txt |  4 ++--
- 1 files changed, 2 insertions(+), 2 deletions(-)
+ libs/text/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/libs/text/CMakeLists.txt b/libs/text/CMakeLists.txt
 index 16d7e066fa2..429afe79704 100644
@@ -27,5 +26,5 @@ index 16d7e066fa2..429afe79704 100644
  
  
 -- 
-GitLab
+2.30.2
 

--- a/extra-productivity/calligra/autobuild/patches/0228-Update-Cmake-and-deps-Fix-Freetype-and-FontConfig-Linkage.patch
+++ b/extra-productivity/calligra/autobuild/patches/0228-Update-Cmake-and-deps-Fix-Freetype-and-FontConfig-Linkage.patch
@@ -1,92 +1,13 @@
 From 62f510702ef9c34ac50f8d8601a4290ab558464c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=96mer=20Fad=C4=B1l=20Usta?= <omerusta@gmail.com>
 Date: Sun, 6 Jun 2021 08:41:05 +0000
-Subject: [PATCH] Update Cmake and deps, Fix Freetype and FontConfig Linkage
+Subject: [PATCH] Update Cmake and deps, Fix Freetype and FontConfig Linkage (Modified)
 
-Cmake to 3.16
-KF to 5.76
-QT to 5.12
-ECM follow KF's version
-Update CALLIGRA_YEAR to 2021
-Fix Fontconfig's FOUND variable
-Fix Fontconfig's include_dirs variable
 Use Correct Target to link FontConfig and Freetype
 ---
- CMakeLists.txt           | 20 +++++++-------------
  libs/text/CMakeLists.txt |  4 ++--
- 2 files changed, 9 insertions(+), 15 deletions(-)
+ 1 files changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b237f68fcb6..cdcc02f0236 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -1,4 +1,4 @@
--cmake_minimum_required(VERSION 3.2)
-+cmake_minimum_required(VERSION 3.16)
- 
- project(calligra)
- 
-@@ -35,7 +35,7 @@ set(CALLIGRA_VERSION_RELEASE 89)     # 89 for Alpha, increase for next test rele
- set(CALLIGRA_ALPHA 1) # uncomment only for Alpha
- # set(CALLIGRA_BETA 1) # uncomment only for Beta
- #set(CALLIGRA_RC 1) # uncomment only for RC
--set(CALLIGRA_YEAR 2020) # update every year
-+set(CALLIGRA_YEAR 2021) # update every year
- 
- if(NOT DEFINED CALLIGRA_ALPHA AND NOT DEFINED CALLIGRA_BETA AND NOT DEFINED CALLIGRA_RC)
-     set(CALLIGRA_STABLE 1) # do not edit
-@@ -89,9 +89,6 @@ if(NOT DEFINED RELEASE_BUILD)
- endif()
- message(STATUS "Release build: ${RELEASE_BUILD}")
- 
--# use CPP-11
--set (CMAKE_CXX_STANDARD 11)
--
- ############
- #############
- ## Options ##
-@@ -148,8 +145,10 @@ calligra_set_productset(${PRODUCTSET})
- ## Look for ECM, Qt, KF5 ##
- ###########################
- ##########################
-+set(REQUIRED_KF5_VERSION "5.76.0")
-+set(REQUIRED_QT_VERSION "5.12.0")
- 
--find_package(ECM 5.19 REQUIRED NO_MODULE)
-+find_package(ECM ${REQUIRED_KF5_VERSION} REQUIRED NO_MODULE)
- set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
- 
- # ECM KDE macros (include first, to have their policies and settings effect all other macros)
-@@ -179,9 +178,6 @@ include(MacroOptionalFindPackage)
- include(MacroEnsureVersion)
- include(MacroDesktopToJson)
- 
--
--set(REQUIRED_KF5_VERSION "5.30.0")
--
- find_package(KF5 ${REQUIRED_KF5_VERSION} REQUIRED
-     COMPONENTS
-     Archive
-@@ -224,8 +220,6 @@ if(KF5Activities_FOUND)
-     set(HAVE_KACTIVITIES TRUE)
- endif()
- 
--set(REQUIRED_QT_VERSION "5.6.0")
--
- find_package(Qt5 ${REQUIRED_QT_VERSION} REQUIRED
-     COMPONENTS
-     Core
-@@ -599,8 +593,8 @@ if(NOT WIN32 AND NOT APPLE)
- 	)
- endif()
- 
--if(NOT FONTCONFIG_FOUND OR NOT FREETYPE_FOUND)
--    set(FONTCONFIG_INCLUDE_DIR "")
-+if(NOT Fontconfig_FOUND OR NOT FREETYPE_FOUND)
-+    set(Fontconfig_INCLUDE_DIRS "")
-     set(FREETYPE_INCLUDE_DIRS "")
- else()
-     add_definitions( -DSHOULD_BUILD_FONT_CONVERSION )
 diff --git a/libs/text/CMakeLists.txt b/libs/text/CMakeLists.txt
 index 16d7e066fa2..429afe79704 100644
 --- a/libs/text/CMakeLists.txt

--- a/extra-productivity/calligra/autobuild/patches/0228-Update-Cmake-and-deps-Fix-Freetype-and-FontConfig-Linkage.patch
+++ b/extra-productivity/calligra/autobuild/patches/0228-Update-Cmake-and-deps-Fix-Freetype-and-FontConfig-Linkage.patch
@@ -1,0 +1,110 @@
+From 62f510702ef9c34ac50f8d8601a4290ab558464c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=96mer=20Fad=C4=B1l=20Usta?= <omerusta@gmail.com>
+Date: Sun, 6 Jun 2021 08:41:05 +0000
+Subject: [PATCH] Update Cmake and deps, Fix Freetype and FontConfig Linkage
+
+Cmake to 3.16
+KF to 5.76
+QT to 5.12
+ECM follow KF's version
+Update CALLIGRA_YEAR to 2021
+Fix Fontconfig's FOUND variable
+Fix Fontconfig's include_dirs variable
+Use Correct Target to link FontConfig and Freetype
+---
+ CMakeLists.txt           | 20 +++++++-------------
+ libs/text/CMakeLists.txt |  4 ++--
+ 2 files changed, 9 insertions(+), 15 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b237f68fcb6..cdcc02f0236 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.2)
++cmake_minimum_required(VERSION 3.16)
+ 
+ project(calligra)
+ 
+@@ -35,7 +35,7 @@ set(CALLIGRA_VERSION_RELEASE 89)     # 89 for Alpha, increase for next test rele
+ set(CALLIGRA_ALPHA 1) # uncomment only for Alpha
+ # set(CALLIGRA_BETA 1) # uncomment only for Beta
+ #set(CALLIGRA_RC 1) # uncomment only for RC
+-set(CALLIGRA_YEAR 2020) # update every year
++set(CALLIGRA_YEAR 2021) # update every year
+ 
+ if(NOT DEFINED CALLIGRA_ALPHA AND NOT DEFINED CALLIGRA_BETA AND NOT DEFINED CALLIGRA_RC)
+     set(CALLIGRA_STABLE 1) # do not edit
+@@ -89,9 +89,6 @@ if(NOT DEFINED RELEASE_BUILD)
+ endif()
+ message(STATUS "Release build: ${RELEASE_BUILD}")
+ 
+-# use CPP-11
+-set (CMAKE_CXX_STANDARD 11)
+-
+ ############
+ #############
+ ## Options ##
+@@ -148,8 +145,10 @@ calligra_set_productset(${PRODUCTSET})
+ ## Look for ECM, Qt, KF5 ##
+ ###########################
+ ##########################
++set(REQUIRED_KF5_VERSION "5.76.0")
++set(REQUIRED_QT_VERSION "5.12.0")
+ 
+-find_package(ECM 5.19 REQUIRED NO_MODULE)
++find_package(ECM ${REQUIRED_KF5_VERSION} REQUIRED NO_MODULE)
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
+ 
+ # ECM KDE macros (include first, to have their policies and settings effect all other macros)
+@@ -179,9 +178,6 @@ include(MacroOptionalFindPackage)
+ include(MacroEnsureVersion)
+ include(MacroDesktopToJson)
+ 
+-
+-set(REQUIRED_KF5_VERSION "5.30.0")
+-
+ find_package(KF5 ${REQUIRED_KF5_VERSION} REQUIRED
+     COMPONENTS
+     Archive
+@@ -224,8 +220,6 @@ if(KF5Activities_FOUND)
+     set(HAVE_KACTIVITIES TRUE)
+ endif()
+ 
+-set(REQUIRED_QT_VERSION "5.6.0")
+-
+ find_package(Qt5 ${REQUIRED_QT_VERSION} REQUIRED
+     COMPONENTS
+     Core
+@@ -599,8 +593,8 @@ if(NOT WIN32 AND NOT APPLE)
+ 	)
+ endif()
+ 
+-if(NOT FONTCONFIG_FOUND OR NOT FREETYPE_FOUND)
+-    set(FONTCONFIG_INCLUDE_DIR "")
++if(NOT Fontconfig_FOUND OR NOT FREETYPE_FOUND)
++    set(Fontconfig_INCLUDE_DIRS "")
+     set(FREETYPE_INCLUDE_DIRS "")
+ else()
+     add_definitions( -DSHOULD_BUILD_FONT_CONVERSION )
+diff --git a/libs/text/CMakeLists.txt b/libs/text/CMakeLists.txt
+index 16d7e066fa2..429afe79704 100644
+--- a/libs/text/CMakeLists.txt
++++ b/libs/text/CMakeLists.txt
+@@ -152,11 +152,11 @@ if( SHOULD_BUILD_FEATURE_RDF )
+ endif()
+ 
+ if( FONTCONFIG_FOUND )
+-    target_link_libraries(kotext PRIVATE ${FONTCONFIG_LIBRARIES})
++    target_link_libraries(kotext PRIVATE Fontconfig::Fontconfig)
+ endif()
+ 
+ if( FREETYPE_FOUND )
+-    target_link_libraries(kotext PRIVATE ${FREETYPE_LIBRARIES})
++    target_link_libraries(kotext PRIVATE Freetype::Freetype)
+ endif()
+ 
+ 
+-- 
+GitLab
+

--- a/extra-productivity/calligra/spec
+++ b/extra-productivity/calligra/spec
@@ -1,4 +1,5 @@
 VER=3.2.0
+REL=1
 SRCS="https://download.kde.org/stable/calligra/$VER/calligra-$VER.tar.xz"
 CHKSUMS="sha256::7e556228665d79e67c062fd1173d6676f0b0d7ceefdd6e1b0bcf9a781ea70951"
 CHKUPDATE="anitya::id=250"

--- a/extra-python/pygit2/spec
+++ b/extra-python/pygit2/spec
@@ -1,5 +1,5 @@
 VER=1.0.3
 SRCS="tbl::https://github.com/libgit2/pygit2/archive/v$VER.tar.gz"
 CHKSUMS="sha256::d6428fd4cd5263c76842675519b85874cfbb79db02bc32523eb784573c328a5b"
-REL=1
+REL=2
 CHKUPDATE="anitya::id=3985"

--- a/extra-rust/cargo-audit/spec
+++ b/extra-rust/cargo-audit/spec
@@ -1,5 +1,5 @@
 VER=0.15.0
-REL=1
+REL=2
 SRCS="tbl::https://github.com/RustSec/cargo-audit/archive/cargo-audit/v$VER.tar.gz"
 CHKSUMS="sha256::af5a7d7c681d1956433ec4bc239bfb2c24df90731ae514a7cd3ca909562f9855"
 CHKUPDATE="anitya::id=231457"

--- a/extra-utils/exa/spec
+++ b/extra-utils/exa/spec
@@ -1,5 +1,5 @@
 VER=0.10.1
-REL=3
+REL=4
 SRCS="tbl::https://github.com/ogham/exa/archive/v$VER.tar.gz"
 CHKSUMS="sha256::ff0fa0bfc4edef8bdbbb3cabe6fdbd5481a71abbbcc2159f402dea515353ae7c"
 CHKUPDATE="anitya::id=16575"

--- a/extra-utils/gitui/autobuild/defines
+++ b/extra-utils/gitui/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=gitui
 PKGSEC=devel
 PKGDES="Terminal UI for Git"
 PKGDEP="git gcc-runtime libgit2 libxcb zlib"
-BUILDDEP="rustc llvm python" # Arch Linux: xcb crate needs python
+BUILDDEP="rustc llvm python-3" # Arch Linux: xcb crate needs python
 
 USECLANG=1
 ABSPLITDBG=0

--- a/extra-utils/gitui/autobuild/defines
+++ b/extra-utils/gitui/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gitui
 PKGSEC=devel
-PKGDES="Terminal UI for git written in rust"
+PKGDES="Terminal UI for Git"
 PKGDEP="git"
 BUILDDEP="rustc llvm"
 

--- a/extra-utils/gitui/autobuild/defines
+++ b/extra-utils/gitui/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=gitui
+PKGSEC=devel
+PKGDES="Blazing fast terminal-ui for git written in rust"
+PKGDEP="git"
+BUILDDEP="rustc llvm"
+
+USECLANG=1
+ABSPLITDBG=0

--- a/extra-utils/gitui/autobuild/defines
+++ b/extra-utils/gitui/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=gitui
 PKGSEC=devel
 PKGDES="Terminal UI for Git"
-PKGDEP="git gcc-runtime libgit2 libxcb zlib"
+PKGDEP="git gcc-runtime libgit2>=1.2.0 libxcb zlib"
 BUILDDEP="rustc llvm python-3" # Arch Linux: xcb crate needs python
 
 USECLANG=1

--- a/extra-utils/gitui/autobuild/defines
+++ b/extra-utils/gitui/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=gitui
 PKGSEC=devel
 PKGDES="Terminal UI for Git"
-PKGDEP="git"
-BUILDDEP="rustc llvm"
+PKGDEP="git gcc-runtime libgit2 libxcb zlib"
+BUILDDEP="rustc llvm python" # Arch Linux: xcb crate needs python
 
 USECLANG=1
 ABSPLITDBG=0

--- a/extra-utils/gitui/autobuild/defines
+++ b/extra-utils/gitui/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gitui
 PKGSEC=devel
-PKGDES="Terminal UI for Git"
+PKGDES="Terminal User Interface for Git"
 PKGDEP="git gcc-runtime libgit2 libxcb zlib"
 BUILDDEP="rustc llvm python-3" # Arch Linux: xcb crate needs python
 

--- a/extra-utils/gitui/autobuild/defines
+++ b/extra-utils/gitui/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=gitui
 PKGSEC=devel
 PKGDES="Terminal UI for Git"
-PKGDEP="git gcc-runtime libgit2>=1.2.0 libxcb zlib"
+PKGDEP="git gcc-runtime libgit2 libxcb zlib"
 BUILDDEP="rustc llvm python-3" # Arch Linux: xcb crate needs python
 
 USECLANG=1

--- a/extra-utils/gitui/autobuild/defines
+++ b/extra-utils/gitui/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gitui
 PKGSEC=devel
-PKGDES="Blazing fast terminal-ui for git written in rust"
+PKGDES="Terminal UI for git written in rust"
 PKGDEP="git"
 BUILDDEP="rustc llvm"
 

--- a/extra-utils/gitui/spec
+++ b/extra-utils/gitui/spec
@@ -1,0 +1,4 @@
+VER=0.17.1
+SRCS="tbl::https://github.com/extrawurst/gitui/archive/refs/tags/v$VER.tar.gz"
+CHKSUMS="sha256::36821f83d67a1233e10daa51178c03250618964ca5a5b8c001ac338bf7a355f5"
+CHKUPDATE="anitya::id=187553"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Introduce `gitui`, a blazing fast terminal ui for git written in Rust (as they say).

Package(s) Affected
-------------------

- `gitui`
- `libgit2`
- `libgit2-glib`
- `calligra`
- `cargo-audit`
- `ciel`
- `exa`
- `fritzing`
- `geany-plugins`
- `gnome-builder`
- `ktexteditor`
- `pygit2`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
