### PR TITLE
rime-prelude: upgrade patch, 0+git20210627:1

### DIFF
--- a/extra-i18n/rime-prelude/autobuild/patches/0001-empty-schema-list.patch
+++ b/extra-i18n/rime-prelude/autobuild/patches/0001-empty-schema-list.patch
@@ -1,20 +1,21 @@
-From 1a457afabc42e889a233f92e34d64185b3a58e21 Mon Sep 17 00:00:00 2001
-From: eatradish <sakiiily@aosc.io>
-Date: Sat, 15 Aug 2020 07:52:35 +0800
+From 20354d7f0d35feb9bc0a698aa06eb6499c6873e1 Mon Sep 17 00:00:00 2001
+From: Outvi V <outloudvi@aosc.io>
+Date: Wed, 15 Sep 2021 13:58:04 +0800
 Subject: [PATCH] empty schema list
 
 ---
- default.yaml | 8 --------
- 1 file changed, 8 deletions(-)
+ default.yaml | 10 +---------
+ 1 file changed, 1 insertion(+), 9 deletions(-)
 
 diff --git a/default.yaml b/default.yaml
-index 7dd0d4d..c0a8dab 100644
+index 7dd0d4d..e20110b 100644
 --- a/default.yaml
 +++ b/default.yaml
-@@ -4,14 +4,6 @@
+@@ -3,15 +3,7 @@
+ 
  config_version: '0.40'
  
- schema_list:
+-schema_list:
 -  - schema: luna_pinyin
 -  - schema: luna_pinyin_simp
 -  - schema: luna_pinyin_fluency
@@ -23,9 +24,10 @@ index 7dd0d4d..c0a8dab 100644
 -  - schema: cangjie5
 -  - schema: stroke
 -  - schema: terra_pinyin
++schema_list: []
  
  switcher:
    caption: 〔方案選單〕
 -- 
-2.27.0
+2.33.0
 

--- a/extra-i18n/rime-prelude/spec
+++ b/extra-i18n/rime-prelude/spec
@@ -1,4 +1,5 @@
 VER=0+git20210627
+REL=1
 SRCS="git::commit=3de303ffaa731dba07b0462ce59f4767e1219ad2::https://github.com/rime/rime-prelude"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=228935"


### PR DESCRIPTION
Topic Description
-----------------

This is to fix the problem that rime-prelude cannot be installed.

Package(s) Affected
-------------------

* rime-prelude

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [x] Architecture-independent `noarch`