### PR TITLE
cpeditor: new, 6.8.4

### DIFF
--- a/extra-devel/cf-tool/autobuild/build
+++ b/extra-devel/cf-tool/autobuild/build
@@ -1,0 +1,11 @@
+# Adapted from AUR
+abinfo 'Preparing GOPATH...'
+mkdir -pv "$SRCDIR"/gopath/src/github.com/xalanq
+ln -rTsfv "$SRCDIR" "$SRCDIR"/gopath/src/github.com/xalanq/cf-tool
+export GOPATH="$SRCDIR"/gopath
+export GO111MODULE=auto
+
+abinfo 'Building cf-tool...'
+go build \
+    -o "$PKGDIR"/usr/bin/cf \
+    "$SRCDIR"/gopath/src/github.com/xalanq/cf-tool/cf.go

--- a/extra-devel/cf-tool/autobuild/defines
+++ b/extra-devel/cf-tool/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=cf-tool
+PKGSEC=devel
+PKGDES="A command-line tool for Codeforces contests"
+PKGDEP="glibc"
+BUILDDEP="go"
+
+ABSPLITDBG=0

--- a/extra-devel/cf-tool/spec
+++ b/extra-devel/cf-tool/spec
@@ -1,0 +1,4 @@
+VER=1.0.0
+SRCS="tbl::https://github.com/xalanq/cf-tool/archive/refs/tags/v$VER.tar.gz"
+CHKSUMS="sha256::6671392df969e7decf9bf6b89a43a93c2bde978e005e99ddb7fd84b0c513df9f"
+CHKUPDATE="anitya::id=235020"

--- a/extra-devel/cpeditor/autobuild/defines
+++ b/extra-devel/cpeditor/autobuild/defines
@@ -2,4 +2,3 @@ PKGNAME=cpeditor
 PKGSEC=devel
 PKGDES="The IDE for competitive programming"
 PKGDEP="qt-5 python-3 openjdk llvm cf-tool"
-PKGPROV="cp-editor"

--- a/extra-devel/cpeditor/autobuild/defines
+++ b/extra-devel/cpeditor/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=cpeditor
+PKGSEC=devel
+PKGDES="The IDE for competitive programming"
+PKGDEP="qt-5 python-3 openjdk llvm cf-tool"
+PKGPROV="cp-editor"

--- a/extra-devel/cpeditor/spec
+++ b/extra-devel/cpeditor/spec
@@ -1,0 +1,4 @@
+VER=6.8.4
+SRCS="tbl::https://github.com/cpeditor/cpeditor/releases/download/$VER/cpeditor-$VER-full-source.tar.gz"
+CHKSUMS="sha256::d1f033a84ed2599bfcfe9d285172772bd7705ec69d16f0a37fbc34bbfc5be542"
+CHKUPDATE="anitya::id=235018"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Introduce `cpeditor`, a IDE specially designed for competitive programming.

Package(s) Affected
-------------------

- `cf-tool`
- `cpeditor`

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->


Build Order
-----------

`cf-tool` -> `cpeditor`


Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
