### PR TITLE
unnamed-sdvx-clone: add patches...

### DIFF
--- a/extra-games/unnamed-sdvx-clone/autobuild/patches/0002-separate-user-and-system-folders.patch
+++ b/extra-games/unnamed-sdvx-clone/autobuild/patches/0002-separate-user-and-system-folders.patch
@@ -1,0 +1,141 @@
+From c807e8782ea2a0ab087bf6911f9ab46514283d08 Mon Sep 17 00:00:00 2001
+From: Henry Chen <chenx97@aosc.io>
+Date: Sat, 18 Sep 2021 18:57:25 +0800
+Subject: [PATCH] separate user and system folders
+
+---
+ .gitignore                     |  1 +
+ CMakeLists.txt                 |  1 +
+ Shared/CMakeLists.txt          |  7 ++++++-
+ Shared/include/Shared/Path.hpp |  2 ++
+ Shared/src/Path.cpp            | 11 +++++++++++
+ Shared/src/Unix/Path.cpp       | 25 ++++++++++++++++++++++++-
+ 6 files changed, 45 insertions(+), 2 deletions(-)
+
+diff --git a/.gitignore b/.gitignore
+index 25114877..63e9fce7 100755
+--- a/.gitignore
++++ b/.gitignore
+@@ -6,6 +6,7 @@
+ *.lib
+ *.exe
+ *.a
++/build
+ 
+ # Memory dump files
+ *.dmp
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5da7ed4c..e1f2970b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,6 +66,7 @@ if(WIN32)
+ endif()
+ 
+ OPTION(EMBEDDED "Enable embedded build" OFF)
++OPTION(USE_SYSTEM_PATH "Use system path to search for resources" ON)
+ 
+ if(EMBEDDED)
+ 	message("Enabling embedded build")
+diff --git a/Shared/CMakeLists.txt b/Shared/CMakeLists.txt
+index 6d58ae59..f309e925 100644
+--- a/Shared/CMakeLists.txt
++++ b/Shared/CMakeLists.txt
+@@ -57,4 +57,9 @@ target_link_libraries(Shared cc-common)
+ # Enable multiprocess compiling
+ if(MSVC)
+     target_compile_options(Shared PRIVATE /MP)
+-endif(MSVC)
+\ No newline at end of file
++endif(MSVC)
++
++# Define data prefix
++if(USE_SYSTEM_PATH)
++    target_compile_definitions(Shared PRIVATE DATA_PREFIX="${CMAKE_INSTALL_PREFIX}/share/usc/")
++endif()
+diff --git a/Shared/include/Shared/Path.hpp b/Shared/include/Shared/Path.hpp
+index 76cef869..f80dda33 100644
+--- a/Shared/include/Shared/Path.hpp
++++ b/Shared/include/Shared/Path.hpp
+@@ -90,4 +90,6 @@ public:
+ 	// used to create absolute paths to game directories
+ 	// If not set, it will default to the game binary directory
+ 	static String gameDir;
++private:
++	static String GetUserDataDirectory();
+ };
+diff --git a/Shared/src/Path.cpp b/Shared/src/Path.cpp
+index 961e6553..4e5e3a15 100644
+--- a/Shared/src/Path.cpp
++++ b/Shared/src/Path.cpp
+@@ -5,14 +5,25 @@
+ /*
+ 	Common
+ */
++#ifdef DATA_PREFIX
++String Path::gameDir = Path::GetUserDataDirectory() + sep + "usc";
++#else
+ String Path::gameDir = "";
++#endif
+ 
+ String Path::Absolute(const String& path)
+ {
+ 	if(IsAbsolute(path))
+ 		return path;
+ 
++#ifdef DATA_PREFIX
++	String baseDir = String(DATA_PREFIX);
++	if (path.find("skins/Default") == String::npos && path.find("fonts") == String::npos) {
++		baseDir = !gameDir.empty() ? gameDir : RemoveLast(GetExecutablePath());
++	}
++#else
+ 	String baseDir = !gameDir.empty() ? gameDir : RemoveLast(GetExecutablePath());
++#endif
+ 	return baseDir + sep + path;
+ }
+ String Path::RemoveLast(const String& path, String* lastOut /*= nullptr*/)
+diff --git a/Shared/src/Unix/Path.cpp b/Shared/src/Unix/Path.cpp
+index 1011cb14..9c3de24c 100644
+--- a/Shared/src/Unix/Path.cpp
++++ b/Shared/src/Unix/Path.cpp
+@@ -17,14 +17,37 @@
+ #include <dirent.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <pwd.h>
++#include <filesystem>
+ // Convenience
+ #define MAX_PATH PATH_MAX
+ 
+ char Path::sep = '/';
+ 
++String Path::GetUserDataDirectory()
++{
++	size_t bufsize;
++	char *buf;
++	struct passwd *result;
++	struct passwd pwd;
++	int ret;
++	const char *datadir = getenv("XDG_DATA_HOME");
++	if (datadir) return String(datadir);
++	const char *homedir = getenv("HOME");
++	if (homedir) return String(homedir) + "/.local/share";
++	bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
++	if (bufsize == -1)
++		bufsize = 16384;
++	buf = (char*)malloc(bufsize);
++	if (!buf) return "";
++	ret = getpwuid_r(geteuid(), &pwd, buf, bufsize, &result);
++	if (!result) return "";
++
++	return String(result->pw_dir) + "/.local/share";
++}
+ bool Path::CreateDir(const String& path)
+ {
+-	return mkdir(*path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == 0;
++	return std::filesystem::create_directories(path.c_str());
+ }
+ bool Path::Delete(const String& path)
+ {
+-- 
+2.30.2
+

--- a/extra-games/unnamed-sdvx-clone/spec
+++ b/extra-games/unnamed-sdvx-clone/spec
@@ -1,4 +1,5 @@
 VER=0.5.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/Drewol/unnamed-sdvx-clone"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227692"


### PR DESCRIPTION
Topic Description
-----------------

rebase an old patch to fix `unnamed-sdvx-clone` v0.5.0

Package(s) Affected
-------------------

`unnamed-sdvx-clone` v0.5.0-1

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
