### PR TITLE
unar: rebuild for GNUStep Base 1.28

### DIFF
--- a/extra-utils/unar/spec
+++ b/extra-utils/unar/spec
@@ -1,5 +1,5 @@
 VER=1.10.1
-REL=4
+REL=5
 SRCS="tbl::http://http.debian.net/debian/pool/main/u/unar/unar_$VER.orig.tar.xz"
 CHKSUMS="sha256::963bbb25d0c321c9e022336318aacbaa3197e22063dd639c467453a4af8708ee"
 CHKUPDATE="anitya::id=5041"


### PR DESCRIPTION
Topic Description
-----------------

Rebuild an application that depends on GNUstep.

Package(s) Affected
-------------------

- `unar`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Secondary Architectural Progress
--------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
