### PR TITLE
networkmanager-openconnect: update to 1.2.6+git20210918

### DIFF
--- a/extra-network/networkmanager-openconnect/spec
+++ b/extra-network/networkmanager-openconnect/spec
@@ -1,5 +1,4 @@
-VER=1.2.6
-REL=1
-SRCS="tbl::https://download.gnome.org/sources/NetworkManager-openconnect/${VER%.*}/NetworkManager-openconnect-$VER.tar.xz"
-CHKSUMS="sha256::95109803596a9782680a5dca3b51c4ad8ff7e126169d5431278cab694112975a"
+VER=1.2.6+git20210918
+SRCS="git::commit=f9eadfe2ce44a4ac8d1834315ce33f52f5d57bdc::https://github.com/NetworkManager/NetworkManager-openconnect"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230978"

--- a/extra-network/networkmanager-vpnc/autobuild/defines
+++ b/extra-network/networkmanager-vpnc/autobuild/defines
@@ -4,5 +4,5 @@ PKGDEP="network-manager-applet vpnc hicolor-icon-theme gtk-3 libsecret"
 BUILDDEP="intltool appstream-glib"
 PKGDES="VPNC plugin for NetworkManager"
 
-AUTOTOOLS_AFTER="--enable-more-warnings=yes"
+AUTOTOOLS_AFTER="--without-libnm-glib --enable-more-warnings=yes"
 ABSHADOW=0

--- a/extra-network/networkmanager-vpnc/spec
+++ b/extra-network/networkmanager-vpnc/spec
@@ -1,4 +1,5 @@
 VER=1.2.6
+REL=1
 SRCS="tbl::https://download.gnome.org/sources/NetworkManager-vpnc/${VER%.*}/NetworkManager-vpnc-$VER.tar.xz"
 CHKSUMS="sha256::de4fd059c4c08365a40b32b6f6fad9674f556724b4bbeb1f9d4473ac19a745cb"
 CHKUPDATE="anitya::id=230981"


### PR DESCRIPTION
Topic Description
-----------------
* Update `networkmanager-openconnect` to `1.2.6+git20210918`
* Due to [this bug](https://bugs.archlinux.org/task/70710), networkmanager-openconnect can not connect to VPN because of the prefix of 0 in the routing. This update will solve this problem.

Package(s) Affected
-------------------
* networkmanager-openconnect

Security Update?
----------------
No 

Architectural Progress
----------------------
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


Secondary Architectural Progress
--------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Post-Merge Secondary Architectural Progress
-------------------------------------------
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
