### PR TITLE
gtk-doc: fix saved triplet in pkg-config path

### DIFF
--- a/extra-doc/gtk-doc/autobuild/prepare
+++ b/extra-doc/gtk-doc/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Setting PKG_CONFIG environment variable to prevent triplet in resulting python files ..."
+export PKG_CONFIG=/usr/bin/pkg-config

--- a/extra-doc/gtk-doc/spec
+++ b/extra-doc/gtk-doc/spec
@@ -1,5 +1,5 @@
 VER=1.33.2
-REL=1
+REL=2
 SRCS="https://download.gnome.org/sources/gtk-doc/${VER:0:4}/gtk-doc-$VER.tar.xz"
 CHKSUMS="sha256::cc1b709a20eb030a278a1f9842a362e00402b7f834ae1df4c1998a723152bf43"
 CHKUPDATE="anitya::id=13140"


### PR DESCRIPTION
Topic Description
-----------------

Remove saved triplet in gtk-doc, which makes it fully noarch.

Package(s) Affected
-------------------

- `gtk-doc`

Security Update?
----------------

No

Architectural Progress
----------------------

- [x] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
