### PR TITLE
autobuild3: update to 1.6.30

### DIFF
--- a/extra-devel/autobuild3/spec
+++ b/extra-devel/autobuild3/spec
@@ -1,4 +1,4 @@
-VER=1.6.28
+VER=1.6.30
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"


### PR DESCRIPTION
Topic Description
-----------------

Update Autobuild3 to 1.6.30. This should resolve issues when building with Ciel, link-time optimisation may
result in depleted tmpfs space.

Package(s) Affected
-------------------

`autobuild3` v1.6.30

Security Update?
----------------

No

Architectural Progress
----------------------

- [ ] Architecture-independent `noarch`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

- [ ] Architecture-independent `noarch`