### PR TITLE
glew: fix QA errors when building

### DIFF
--- a/extra-libs/glew/autobuild/build
+++ b/extra-libs/glew/autobuild/build
@@ -1,6 +1,13 @@
+abinfo "Injecting CFLAGS to build config ..."
+echo "CFLAGS.EXTRA += $CFLAGS" >> config/Makefile.linux
+
+abinfo "Making and installing ..."
 make \
     STRIP= \
     LIBDIR=/usr/lib
 make install.all \
     DESTDIR="$PKGDIR" \
     LIBDIR=/usr/lib
+
+abinfo "Fixing permission of shared library ..."
+chmod -v a+x "$PKGDIR"/usr/lib/libGLEW.so.2.*

--- a/extra-libs/glew/spec
+++ b/extra-libs/glew/spec
@@ -1,5 +1,5 @@
 VER=2.2.0
-REL=2
+REL=3
 SRCS="tbl::https://sourceforge.net/projects/glew/files/glew/$VER/glew-$VER.tgz"
 CHKSUMS="sha256::d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1"
 CHKUPDATE="anitya::id=7878"


### PR DESCRIPTION
Topic Description
-----------------

Fix QA-related FTBFS of `glew` .

Package(s) Affected
-------------------

- `glew`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**


- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
