### PR TITLE
workflows: add new workflow for building packages

### DIFF
--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -1,0 +1,45 @@
+name: Build package on request
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  build:
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/build ') }}
+    runs-on: ubuntu-latest
+    container: aosc/aosc-os-buildkit:latest
+
+    steps:
+      # https://github.com/dotnet/runtime/blob/main/.github/workflows/backport.yml
+      - name: Get the package to build
+        uses: actions/github-script@v5
+        id: get-package
+        with:
+          script: |
+            const regex = /\/build ([a-z\d\/\.\-]+)/;
+            package = regex.exec(context.payload.comment.body);
+            if (package == null) throw "No package found in the command!";
+            return package[1];
+          result-encoding: string
+
+      - uses: actions/checkout@v2
+
+      - name: Prepare for building the package
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        run: |
+          mkdir -p /var/lib/acbs
+          ln -s $PWD /var/lib/acbs/repo
+          sed -i 's/Null Packager <null@aosc.xyz>/GitHub Actions <discussions@lists.aosc.io>/' /etc/autobuild/ab3cfg.sh
+
+      - name: Build the package
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        env:
+          PACKAGE: ${{steps.get-package.outputs.result}}
+        run: acbs-build ${{env.PACKAGE}}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Packages
+          path: /debs


### PR DESCRIPTION
### Purpose

Run `acbs-build` in a new buildkit container to build packages immediately from Pull Requests, effectively smoke-testing them.

### Usage

```
/build <package>
```

Where `package` will be directly passed to `acbs-build`.