### PR TITLE
workflows: use script to allocate a PTY for acbs

### DIFF
--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -36,6 +36,7 @@ jobs:
         working-directory: ${{env.GITHUB_WORKSPACE}}
         env:
           PACKAGE: ${{steps.get-package.outputs.result}}
+        shell: script -eqc {0}
         run: acbs-build ${{env.PACKAGE}}
 
       - name: Upload artifact


### PR DESCRIPTION
According to actions/runner#241, GitHub Actions runners don't currently allocate a PTY for programs. `script` should be able to work around this.