### PR TITLE
workflows: install GitHub CLI in container

### DIFF
--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -24,6 +24,15 @@ jobs:
           result-encoding: string
 
       - uses: actions/checkout@v2
+      
+      - name: Install GitHub CLI
+        env:
+          GH_VERSION: 2.0.0
+          GH_ARCH: amd64
+        run: |
+          curl -LO https://github.com/cli/cli/releases/download/v${{env.GH_VERSION}}/gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}.tar.gz
+          tar -xf gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}.tar.gz
+          ln -s gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}/bin/gh /usr/bin/gh
 
       - name: Prepare for building the package
         working-directory: ${{env.GITHUB_WORKSPACE}}


### PR DESCRIPTION
GitHub CLI is already installed in container host, but not in our container.

[Using GitHub CLI in workflows](https://docs.github.com/en/actions/advanced-guides/using-github-cli-in-workflows)