### PR TITLE
workflows: use absolute path on linking

### DIFF
--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           curl -LO https://github.com/cli/cli/releases/download/v${{env.GH_VERSION}}/gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}.tar.gz
           tar -xf gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}.tar.gz
-          ln -s gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}/bin/gh /usr/bin/gh
+          ln -s ${{env.PWD}}gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}/bin/gh /usr/bin/gh
 
       - name: Prepare for building the package
         working-directory: ${{env.GITHUB_WORKSPACE}}


### PR DESCRIPTION
> Symbolic links can hold arbitrary text; if later resolved, a relative link is interpreted in relation to its parent directory.