### PR TITLE
workflows: remove usage of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -21,26 +21,28 @@ jobs:
             package = regex.exec(context.payload.comment.body);
             if (package == null) throw "No package found in the command!";
             return package[1];
-          result-encoding: string
-
-      - uses: actions/checkout@v2
+          result-encoding: string\
       
-      - name: Install GitHub CLI
-        env:
-          GH_VERSION: 2.0.0
-          GH_ARCH: amd64
-        run: |
-          curl -LO https://github.com/cli/cli/releases/download/v${{env.GH_VERSION}}/gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}.tar.gz
-          tar -xf gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}.tar.gz
-          ln -s ${PWD}/gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}/bin/gh /usr/bin/gh
-
+      - name: Get the metadata of PR
+        uses: actions/github-script@v5
+        id: get-head-sha
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            })
+            return {
+              sha: pr.data.head.sha,
+              repo: pr.data.head.repo.full_name
+            }
+      
       - name: Prepare for building the package
         working-directory: ${{env.GITHUB_WORKSPACE}}
-        env:
-          PR_NUMBER: ${{github.event.issue.number}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
-          gh pr checkout ${{env.PR_NUMBER}}
+          git clone https://github.com/${{ fromJson(steps.get-head-sha.outputs.result).repo }} .
+          git checkout ${{ fromJson(steps.get-head-sha.outputs.result).sha }}
           mkdir -p /var/lib/acbs
           ln -s $PWD /var/lib/acbs/repo
           sed -i 's/Null Packager <null@aosc.xyz>/GitHub Actions <discussions@lists.aosc.io>/' /etc/autobuild/ab3cfg.sh

--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -21,7 +21,7 @@ jobs:
             package = regex.exec(context.payload.comment.body);
             if (package == null) throw "No package found in the command!";
             return package[1];
-          result-encoding: string\
+          result-encoding: string
       
       - name: Get the metadata of PR
         uses: actions/github-script@v5


### PR DESCRIPTION
#3502 introduces the use of `GITHUB_TOKEN` into the workflow (because of `gh`), but the token comes with a write permission to the repository when used by a maintainer, which may be a potential threat since build processes apparently does not require writing to the repository.

This PR aims to replace `gh` and thus remove the usage of `GITHUB_TOKEN`.

[Check the workflow run](https://github.com/outloudvi/aosc-os-abbs/runs/3775119498).