### PR TITLE
workflows: enable building on issue comments

### DIFF
--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -2,11 +2,11 @@ name: Build package on request
 
 on:
   issue_comment:
-    types: [created, edited]
+    types: [created]
 
 jobs:
   build:
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/build ') }}
+    if: ${{startsWith(github.event.comment.body, '/build ')}}
     runs-on: ubuntu-latest
     container: aosc/aosc-os-buildkit:latest
 
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: Install GitHub CLI
+        if: ${{github.event.issue.pull_request}}
         env:
           GH_VERSION: 2.0.0
           GH_ARCH: amd64
@@ -34,15 +35,18 @@ jobs:
           tar -xf gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}.tar.gz
           ln -s ${PWD}/gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}/bin/gh /usr/bin/gh
 
-      - name: Prepare for building the package
-        working-directory: ${{env.GITHUB_WORKSPACE}}
+      - name: Checkout PR
+        if: ${{github.event.issue.pull_request}}
         env:
           PR_NUMBER: ${{github.event.issue.number}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           gh pr checkout ${{env.PR_NUMBER}}
+
+      - name: Prepare for building the package
+        run: |
           mkdir -p /var/lib/acbs
-          ln -s $PWD /var/lib/acbs/repo
+          ln -s $GITHUB_WORKSPACE /var/lib/acbs/repo
           sed -i 's/Null Packager <null@aosc.xyz>/GitHub Actions <discussions@lists.aosc.io>/' /etc/autobuild/ab3cfg.sh
 
       - name: Build the package


### PR DESCRIPTION
- Install GitHub CLI and checkout PR only if the comment was from PR; #3503.
- Starts the job only if the comment starts with /build, not contains to avoid accidental invocation.
- Tweaks.