### PR TITLE
workflows: use Fastly CDN instead of repo

### DIFF
--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -48,6 +48,7 @@ jobs:
           mkdir -p /var/lib/acbs
           ln -s $GITHUB_WORKSPACE /var/lib/acbs/repo
           sed -i 's/Null Packager <null@aosc.xyz>/GitHub Actions <discussions@lists.aosc.io>/' /etc/autobuild/ab3cfg.sh
+          sed -i 's/https:\/\/repo.aosc.io\//https:\/\/aosc-repo.freetls.fastly.net\//' /etc/apt/sources.list
           apt-get update && yes | apt-get -yf full-upgrade && apt-get -y autoremove
 
       - name: Build the package


### PR DESCRIPTION
I don't know why, but this resolves https://github.com/AOSC-Dev/aosc-os-abbs/runs/3777403299?check_suite_focus=true#step:7:135.