### PR TITLE
suitesparse: manually specify a make target to prevent running demo

### DIFF
--- a/extra-libs/suitesparse/autobuild/build
+++ b/extra-libs/suitesparse/autobuild/build
@@ -1,9 +1,12 @@
 # Adapted from Arch Linux.
 
+abinfo "Building ..."
 BLAS=-lblas TBB=-ltbb SPQR_CONFIG=-DHAVE_TBB \
-    make
+    make library
 
+abinfo "Creating directory skeleton .."
 install -dvm755 "$PKGDIR"/usr/{include,lib}
 
+abinfo "Installing ..."
 BLAS=-lblas TBB=-ltbb SPQR_CONFIG=-DHAVE_TBB \
     make INSTALL_LIB="$PKGDIR"/usr/lib INSTALL_INCLUDE="$PKGDIR"/usr/include install

--- a/extra-libs/suitesparse/spec
+++ b/extra-libs/suitesparse/spec
@@ -1,5 +1,5 @@
 VER=5.4.0
-REL=2
+REL=3
 SRCS="tbl::http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-$VER.tar.gz"
 CHKSUMS="sha256::374dd136696c653e34ef3212dc8ab5b61d9a67a6791d5ec4841efb838e94dbd1"
 CHKUPDATE="anitya::id=4908"


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of `suitesparse` by changing the Makefile.

Package(s) Affected
-------------------

- `suitesparse`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
