### PR TITLE
workflows: use debs as archive name

### DIFF
--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -60,5 +60,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: Packages
+          name: debs
           path: /debs


### PR DESCRIPTION
To satisfy pushpkg.