### PR TITLE
eigen-3: noarchize

### DIFF
--- a/extra-devel/eigen-3/autobuild/defines
+++ b/extra-devel/eigen-3/autobuild/defines
@@ -5,3 +5,5 @@ BUILDDEP="cmake fftw freeglut glew pkg-config gsl suitesparse doxygen"
 PKGDES="Lightweight C++ template library for vector and matrix math, a.k.a. linear algebra"
 
 CMAKE_AFTER="-DCUDA_TOOLKIT_ROOT_DIR=/usr/lib/cuda/"
+
+ABHOST=noarch

--- a/extra-devel/eigen-3/spec
+++ b/extra-devel/eigen-3/spec
@@ -1,4 +1,7 @@
 VER=3.3.9
-SRCS="tbl::https://gitlab.com/libeigen/eigen/-/archive/$VER/eigen-$VER.tar.gz"
+REL=1
+# Gitlab is broken when updating this package for the last time, use repo.aosc.io instead now
+# SRCS="tbl::https://gitlab.com/libeigen/eigen/-/archive/$VER/eigen-$VER.tar.gz"
+SRCS="tbl::https://repo.aosc.io/aosc-repacks/eigen-3.3.9.tar.gz"
 CHKSUMS="sha256::7985975b787340124786f092b3a07d594b2e9cd53bbfe5f3d9b1daee7d55f56f"
 CHKUPDATE="anitya::id=13751"


### PR DESCRIPTION
Topic Description
-----------------

Make `eigen-3` noarch, because it really has no binaries.

Package(s) Affected
-------------------
- `eigen-3`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
