### PR TITLE
workflows-build: update apt first

### DIFF
--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -116,8 +116,7 @@ jobs:
           mkdir -p /var/lib/acbs
           ln -s $GITHUB_WORKSPACE /var/lib/acbs/repo
           sed -i 's/Null Packager <null@aosc.xyz>/GitHub Actions <discussions@lists.aosc.io>/' /etc/autobuild/ab3cfg.sh
-          sed -i 's/https:\/\/repo.aosc.io\//https:\/\/aosc-repo.freetls.fastly.net\//' /etc/apt/sources.list
-          apt-get update && yes | apt-get -yf full-upgrade && apt-get -y autoremove
+          apt-get update && yes | apt-get -yf install apt && yes | apt-get -yf full-upgrade && apt-get -y autoremove
 
       - name: Build the package
         working-directory: ${{env.GITHUB_WORKSPACE}}


### PR DESCRIPTION
... instead of using a mirror since cache is bad for this scenario.

This is just a work around for AOSC-Dev/infra-wg-tickets#11, will investigate further after AOSC-Dev/aosc-os-docker-files#4 is resolved.