### PR TITLE
workflows: use buildkit daily container

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+ADD aosc-os_buildkit_amd64.tar.xz /
+CMD ["bash"]

--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -4,6 +4,10 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   get-packages:
     if: ${{(github.event.comment.body == '/build' && github.event.issue.pull_request) || startsWith(github.event.comment.body, '/build ')}}

--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -48,7 +48,6 @@ jobs:
                 args += data.toString();
               }
             };
-            options.cwd = process.env.GITHUB_WORKSPACE;
 
             await exec.exec('git', ['diff', '--name-only', 'stable', 'HEAD', '*/spec'], options);
             const regex = /.*\/(.*)\/.*/gm;
@@ -101,7 +100,7 @@ jobs:
         run: |
           curl -LO https://github.com/cli/cli/releases/download/v${{env.GH_VERSION}}/gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}.tar.gz
           tar -xf gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}.tar.gz
-          ln -s ${PWD}/gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}/bin/gh /usr/bin/gh
+          ln -s ${GITHUB_WORKSPACE}/gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}/bin/gh /usr/bin/gh
 
       - name: Checkout pull request
         if: ${{github.event.issue.pull_request}}
@@ -120,7 +119,6 @@ jobs:
           apt-get update && yes | apt-get -yf full-upgrade && apt-get -y autoremove
 
       - name: Build the package
-        working-directory: ${{env.GITHUB_WORKSPACE}}
         shell: 'script -eqc "bash --noprofile --norc -eo pipefail {0}"'
         env:
           PACKAGE: ${{matrix.package}}

--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -83,7 +83,7 @@ jobs:
   build:
     needs: get-packages
     runs-on: ubuntu-latest
-    container: aosc/aosc-os-buildkit:latest
+    container: ghcr.io/aosc-dev/aosc-os-buildkit-daily:latest
     strategy:
       matrix:
         package: ${{fromJson(needs.get-packages.outputs.matrix)}}
@@ -115,7 +115,6 @@ jobs:
           mkdir -p /var/lib/acbs
           ln -s $GITHUB_WORKSPACE /var/lib/acbs/repo
           sed -i 's/Null Packager <null@aosc.xyz>/GitHub Actions <discussions@lists.aosc.io>/' /etc/autobuild/ab3cfg.sh
-          sed -i 's/https:\/\/repo.aosc.io\//https:\/\/aosc-repo.freetls.fastly.net\//' /etc/apt/sources.list
           apt-get update && yes | apt-get -yf full-upgrade && apt-get -y autoremove
 
       - name: Build the package

--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -122,6 +122,7 @@ jobs:
         shell: 'script -eqc "bash --noprofile --norc -eo pipefail {0}"'
         env:
           PACKAGE: ${{matrix.package}}
+          CARGO_TERM_COLOR: always
         run: acbs-build "${{env.PACKAGE}}"
 
       - name: Upload the package

--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
         if: ${{github.event.comment.body == '/build'}}
 
-      - name: Checkout PR
+      - name: Checkout pull request
         if: ${{github.event.comment.body == '/build'}}
         env:
           PR_NUMBER: ${{github.event.issue.number}}
@@ -103,7 +103,7 @@ jobs:
           tar -xf gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}.tar.gz
           ln -s ${PWD}/gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}/bin/gh /usr/bin/gh
 
-      - name: Checkout PR
+      - name: Checkout pull request
         if: ${{github.event.issue.pull_request}}
         env:
           PR_NUMBER: ${{github.event.issue.number}}
@@ -111,7 +111,7 @@ jobs:
         run: |
           gh pr checkout ${{env.PR_NUMBER}}
 
-      - name: Prepare for building the package
+      - name: Configure the container
         run: |
           mkdir -p /var/lib/acbs
           ln -s $GITHUB_WORKSPACE /var/lib/acbs/repo
@@ -126,7 +126,7 @@ jobs:
           PACKAGE: ${{matrix.package}}
         run: acbs-build "${{env.PACKAGE}}"
 
-      - name: Upload artifact
+      - name: Upload the package
         uses: actions/upload-artifact@v2
         with:
           name: debs_${{matrix.package}}

--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -33,7 +33,7 @@ jobs:
           PR_NUMBER: ${{github.event.issue.number}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
-          gh pr checkout ${{env.PR_NUMBER}}
+          gh pr checkout $PR_NUMBER
 
       - name: Get packages to build from repository
         uses: actions/github-script@v5
@@ -98,9 +98,9 @@ jobs:
           GH_VERSION: 2.0.0
           GH_ARCH: amd64
         run: |
-          curl -LO https://github.com/cli/cli/releases/download/v${{env.GH_VERSION}}/gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}.tar.gz
-          tar -xf gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}.tar.gz
-          ln -s ${GITHUB_WORKSPACE}/gh_${{env.GH_VERSION}}_linux_${{env.GH_ARCH}}/bin/gh /usr/bin/gh
+          curl -LO https://github.com/cli/cli/releases/download/v$GH_VERSION/gh_${GH_VERSION}_linux_$GH_ARCH.tar.gz
+          tar -xf gh_${GH_VERSION}_linux_$GH_ARCH.tar.gz
+          ln -s $GITHUB_WORKSPACE/gh_${GH_VERSION}_linux_$GH_ARCH/bin/gh /usr/bin/gh
 
       - name: Checkout pull request
         if: ${{github.event.issue.pull_request}}
@@ -108,7 +108,7 @@ jobs:
           PR_NUMBER: ${{github.event.issue.number}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
-          gh pr checkout ${{env.PR_NUMBER}}
+          gh pr checkout $PR_NUMBER
 
       - name: Configure the container
         run: |
@@ -123,7 +123,7 @@ jobs:
         env:
           PACKAGE: ${{matrix.package}}
           CARGO_TERM_COLOR: always
-        run: acbs-build "${{env.PACKAGE}}"
+        run: acbs-build "$PACKAGE"
 
       - name: Upload the package
         uses: actions/upload-artifact@v2

--- a/.github/workflows/buildkit-daily.yml
+++ b/.github/workflows/buildkit-daily.yml
@@ -35,7 +35,6 @@ jobs:
     needs: tarball
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: write
 
     steps:

--- a/.github/workflows/buildkit-daily.yml
+++ b/.github/workflows/buildkit-daily.yml
@@ -1,0 +1,95 @@
+name: Publish buildkit daily container
+
+on:
+  schedule:
+    - cron: '0 17 * * *'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{github.repository_owner}}/aosc-os-buildkit-daily
+
+jobs:
+  tarball:
+    runs-on: [self-hosted, aosc-os, x64]
+
+    steps:
+      - name: Install aoscbootstrap
+        run: yes | sudo apt install -yf aoscbootstrap
+
+      - name: Build tarball
+        shell: 'script -eqc "bash --noprofile --norc -eo pipefail {0}"'
+        run: sudo generate-releases buildkit
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v2
+        with:
+          name: os-amd64-buildkit
+          path: os-amd64/buildkit
+
+      - name: Remove artifact
+        if: always()
+        run: sudo rm -rf os-amd64
+
+  docker:
+    needs: tarball
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download tarball
+        uses: actions/download-artifact@v2
+        with:
+          name: os-amd64-buildkit
+
+      - name: Get tarball date
+        uses: actions/github-script@v5
+        id: get-tarball-date
+        with:
+          script: |
+            let args = "";
+            const options = {};
+            options.listeners = {
+              stdout: (data) => {
+                args += data.toString();
+              }
+            };
+            await exec.exec('find', ['-maxdepth', '1', '-name', 'aosc-os_buildkit_*_amd64.tar.xz'], options);
+            const regex = /\.\/aosc-os_buildkit_(\d+)_amd64\.tar\.xz/gm;
+            const date = args.split('\n').map(arg => regex.exec(arg)).filter(arg => Array.isArray(arg)).map(arg => arg[1]);
+            if (!Array.isArray(date) || date.length != 1) throw "Too many tarballs!";
+            return Number(date[0]);
+
+      - name: Rename tarball
+        env:
+          DATE: ${{steps.get-tarball-date.outputs.result}}
+        run: mv aosc-os_buildkit_${DATE}_amd64.tar.xz .github/workflows/aosc-os_buildkit_amd64.tar.xz
+
+      - name: Log into registry ${{env.REGISTRY}}
+        uses: docker/login-action@v1
+        with:
+          registry: ${{env.REGISTRY}}
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{env.REGISTRY}}/${{env.IMAGE_NAME}}
+          tags: |
+            type=raw,latest
+            type=raw,${{steps.get-tarball-date.outputs.result}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .github/workflows
+          push: true
+          tags: ${{steps.meta.outputs.tags}}
+          labels: ${{steps.meta.outputs.labels}}


### PR DESCRIPTION
Add a new workflow to build buildkit containers every day, upload to GitHub Container Registry for consumption.

Supersedes #3525, #3527, closes AOSC-Dev/aosc-os-docker-files#4.