### PR TITLE
workflows-container: use apt-get instead of apt

### DIFF
--- a/.github/workflows/buildkit-daily.yml
+++ b/.github/workflows/buildkit-daily.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Install aoscbootstrap
-        run: yes | sudo apt install -yf aoscbootstrap
+        run: yes | sudo apt-get install -yf aoscbootstrap
 
       - name: Build tarball
         shell: 'script -eqc "bash --noprofile --norc -eo pipefail {0}"'


### PR DESCRIPTION
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.