### PR TITLE
kate: rebuild for new version libgit2

### DIFF
--- a/extra-kde/kate/01-kate/defines
+++ b/extra-kde/kate/01-kate/defines
@@ -1,6 +1,6 @@
 PKGNAME=kate
 PKGSEC=kde
-PKGDEP="kactivities kded kitemmodels knewstuff ktexteditor threadweaver"
+PKGDEP="kactivities kded kitemmodels knewstuff ktexteditor threadweaver libgit2"
 BUILDDEP="extra-cmake-modules kdoctools plasma-framework"
 PKGDES="KDE Advanced Text Editor"
 

--- a/extra-kde/kate/02-kwrite/defines
+++ b/extra-kde/kate/02-kwrite/defines
@@ -1,6 +1,6 @@
 PKGNAME=kwrite
 PKGSEC=kde
-PKGDEP="kactivities kded ktexteditor"
+PKGDEP="kactivities kded ktexteditor libgit2"
 PKGDES="A simple text editor for KDE"
 
 PKGREP="kde-l10n<=16.12.3"

--- a/extra-kde/kate/spec
+++ b/extra-kde/kate/spec
@@ -1,4 +1,5 @@
 VER=21.08.1
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kate-$VER.tar.xz"
 CHKSUMS="sha256::1fccbe483c2562fd870288f01ebb39578880e28fd05193edda45ae573a72334d"
 CHKUPDATE="anitya::id=8763"

--- a/extra-libs/libgit2/autobuild/defines
+++ b/extra-libs/libgit2/autobuild/defines
@@ -4,7 +4,8 @@ PKGDEP="zlib openssl libssh2 http-parser pcre2"
 PKGDES="A linkable library for Git"
 PKGBREAK="cargo-audit<=0.15.0-1 calligra<=3.2.0 ciel<=3.0.12 exa<=0.10.1-3 \
           fritzing<=0.9.6 geany-plugins<=1.37 gnome-builder<=3.40.2-1 \
-          ktexteditor<=5.86.0 libgit2-glib<=0.28.0.1-1 pygit2<=1.0.3-1"
+          ktexteditor<=5.86.0 kate<=21.08.1 kwirte<=21.08.1 \
+          libgit2-glib<=0.28.0.1-1 pygit2<=1.0.3-1"
 
 CMAKE_AFTER="-DTHREADSAFE=ON \
              -DUSE_HTTP_PARSER=system \

--- a/extra-libs/libgit2/spec
+++ b/extra-libs/libgit2/spec
@@ -1,4 +1,5 @@
 VER=1.3.0
+REL=1
 SRCS="tbl::https://github.com/libgit2/libgit2/archive/v$VER.tar.gz"
 CHKSUMS="sha256::192eeff84596ff09efb6b01835a066f2df7cd7985e0991c79595688e6b36444e"
 CHKUPDATE="anitya::id=1627"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

As `kate` and `kwrite` is actually depend on `libgit2` directly, which has been updated by #3460 , now they need to be rebuilt.

Package(s) Affected
-------------------

`kate` and `kwrite`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
