### PR TITLE
workflows-build: fail if nothing to upload

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -146,6 +146,7 @@ jobs:
         with:
           name: debs_${{matrix.package}}
           path: /debs
+          if-no-files-found: error
 
       - name: Update comment when succeed
         uses: peter-evans/create-or-update-comment@v1


### PR DESCRIPTION
Assume no file found in `/debs` is an error.