### PR TITLE
nfs-utils: add builddep rpcsvc-proto

### DIFF
--- a/extra-utils/nfs-utils/autobuild/defines
+++ b/extra-utils/nfs-utils/autobuild/defines
@@ -8,6 +8,7 @@ PKGDEP__I486="${PKGDEP__RETRO}"
 PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
+BUILDDEP="rpcsvc-proto"
 PKGDES="Support programs for Network File Systems"
 
 AUTOTOOLS_AFTER="--enable-gss \

--- a/extra-utils/nfs-utils/spec
+++ b/extra-utils/nfs-utils/spec
@@ -1,5 +1,5 @@
 VER=2.4.2
-REL=6
+REL=7
 SRCS="tbl::https://sourceforge.net/projects/nfs/files/nfs-utils/$VER/nfs-utils-$VER.tar.gz"
 CHKSUMS="sha256::bb08106cd7bd397c6cc34e2461bc7818a664450d2805da08b07e1ced88e5155f"
 CHKUPDATE="anitya::id=2081"


### PR DESCRIPTION
Topic Description
-----------------

Fix build of nfs-utils by adding a now needed builddep.

Package(s) Affected
-------------------

- `nfs-utils`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
