### PR TITLE
speech-dispatcher: fix build by add -fcommon

### DIFF
--- a/extra-libs/speech-dispatcher/autobuild/prepare
+++ b/extra-libs/speech-dispatcher/autobuild/prepare
@@ -1,1 +1,2 @@
-autoreconf -vi
+abinfo "Appending -fcommon to fix build ..."
+export CFLAGS="${CFLAGS} -fcommon"

--- a/extra-libs/speech-dispatcher/spec
+++ b/extra-libs/speech-dispatcher/spec
@@ -1,5 +1,5 @@
 VER=0.8.8
-REL=2
+REL=3
 SRCS="tbl::https://devel.freebsoft.org/pub/projects/speechd/speech-dispatcher-$VER.tar.gz"
 CHKSUMS="sha256::3c2a89800d73403192b9d424a604f0e614c58db390428355a3b1c7c401986cf3"
 CHKUPDATE="anitya::id=13411"


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of speech-dispatcher because of being not compatible w/ newest GCC.

Package(s) Affected
-------------------

- `speech-dispatcher`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**


- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
