### PR TITLE
fuse-3: make fuse-common noarch

### DIFF
--- a/extra-libs/fuse-3/01-fuse-common/defines
+++ b/extra-libs/fuse-3/01-fuse-common/defines
@@ -5,3 +5,5 @@ PKGDES="Common configuration for FUSE"
 
 PKGBREAK="fuse<=2.9.8-1"
 PKGREP="fuse<=2.9.8-1"
+
+ABHOST=noarch

--- a/extra-libs/fuse-3/spec
+++ b/extra-libs/fuse-3/spec
@@ -1,4 +1,5 @@
 VER=3.10.1
+REL=1
 SRCS="tbl::https://github.com/libfuse/libfuse/releases/download/fuse-$VER/fuse-$VER.tar.xz"
 CHKSUMS="sha256::d82d74d4c03e099f806e4bb31483955637c69226576bf0ca9bd142f1d50ae451"
 CHKUPDATE="anitya::id=861"


### PR DESCRIPTION
Topic Description
-----------------

Noarchize a subpackage of fuse-3, which contains only a configuration file shared by fuse-3 and fuse (2.x).

Package(s) Affected
-------------------

- `fuse-common`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
