### PR TITLE
[ci] fcitx5-pinyin-moegirl: update to 20211014

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20210914
+VER=20211014
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::e583f5f1256759c73ca9c738e7479f58241c2e2df2156ff49c870a8d47f63840 \
-         sha256::d1d056bfa36ade33aa62b187e5c74441821a71fdf87dd378b0f10acc1ac91c77 \
+CHKSUMS="sha256::631e38158a662ff0a2c48fbfbb364c03ebea90cf252d867c907eddc23e207913 \
+         sha256::350c08b7d8d34018c96f44e6d867446d822a7c83e501e66cacafcfc977440d8e \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

fcitx5-pinyin-moegirl: update to 20211014

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`