### PR TITLE
workflows-build: allow only one run WIP per PR

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -18,6 +18,9 @@ jobs:
   get-packages:
     if: ${{(github.event.pull_request && startsWith(github.event.pull_request.title, '[ci]')) || (github.event.comment.body == '/build' && github.event.issue.pull_request) || startsWith(github.event.comment.body, '/build ')}}
     runs-on: ubuntu-latest
+    concurrency: 
+      group: ${{github.event.pull_request.number || github.event.issue.number}}
+      cancel-in-progress: true
 
     steps:
       - name: Add reaction to invocation comment

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -10,6 +10,10 @@ on:
   issue_comment:
     types: [created]
 
+concurrency: 
+  group: ${{github.event.pull_request.number || github.event.issue.number}}
+  cancel-in-progress: true
+
 permissions:
   issues: write
   pull-requests: write
@@ -18,9 +22,6 @@ jobs:
   get-packages:
     if: ${{(github.event.pull_request && startsWith(github.event.pull_request.title, '[ci]')) || (github.event.comment.body == '/build' && github.event.issue.pull_request) || startsWith(github.event.comment.body, '/build ')}}
     runs-on: ubuntu-latest
-    concurrency: 
-      group: ${{github.event.pull_request.number || github.event.issue.number}}
-      cancel-in-progress: true
 
     steps:
       - name: Add reaction to invocation comment


### PR DESCRIPTION
https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run-1