### PR TITLE
dependabot: enable GH Actions update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    assignees:
+      - "KexyBiscuit"
+    commit-message:
+      prefix: "workflows"
+      include: "scope"
     labels:
       - "workflow"
+    reviewers:
+      - "KexyBiscuit"
+      - "outloudvi"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "workflow"


### PR DESCRIPTION
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot