### PR TITLE
workflows-build: support workflow dispatch

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,6 +19,8 @@ If packages are specified, only these packages will be built. If no packages are
 
 If you would like for the workflow to run as a status check, prefix your pull request title with [ci].
 
+It's also possible to run this workflow manually[^1] or using the REST API[^2].
+
 ## Examples
 
 ### Example 1: Building One Package
@@ -49,7 +51,7 @@ If you would like for the workflow to run as a status check, prefix your pull re
 
 - Currently, this command only supports GitHub-hosted runners.
   - Microsoft Azure's Standard_DS2_v2 virtual machines only support x86-64 (`amd64`) architecture and may not have sufficient performance or storage to build some packages.
-  - GitHub-hosted runners currently provide no TTY device[^1], any build that relies on this will fail.
+  - GitHub-hosted runners currently provide no TTY device[^3], any build that relies on this will fail.
 - Up to 256 packages could be built at a time.
 
 ## Further Reading
@@ -58,8 +60,10 @@ If you would like for the workflow to run as a status check, prefix your pull re
 
 ## Explanation on the codename
 
-The cake is a lie[^2]! Though Project Cake is an effort to augment AOSC OS's ongoing maintenance automation project[^3], it will only work in simple scenarios.
+The cake is a lie[^4]! Though Project Cake is an effort to augment AOSC OS's ongoing maintenance automation project[^5], it will only work in simple scenarios.
 
-[^1]: https://github.com/actions/runner/issues/241#issuecomment-556845290
-[^2]: https://en.wikipedia.org/wiki/The_cake_is_a_lie
-[^3]: https://wiki.aosc.io/developer/automation/
+[^1]: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+[^2]: https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event
+[^3]: https://github.com/actions/runner/issues/241#issuecomment-556845290
+[^4]: https://en.wikipedia.org/wiki/The_cake_is_a_lie
+[^5]: https://wiki.aosc.io/developer/automation/

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -10,8 +10,14 @@ on:
   issue_comment:
     types: [created]
 
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: 'Packages to build'
+        required: true
+
 concurrency: 
-  group: ${{github.event.pull_request.number || github.event.issue.number}}
+  group: ${{github.event.pull_request.number || github.event.issue.number || github.event.inputs.packages}}
   cancel-in-progress: true
 
 permissions:
@@ -20,13 +26,13 @@ permissions:
 
 jobs:
   get-packages:
-    if: ${{(github.event.pull_request && startsWith(github.event.pull_request.title, '[ci]')) || (github.event.comment.body == '/build' && github.event.issue.pull_request) || startsWith(github.event.comment.body, '/build ')}}
+    if: ${{((github.event.pull_request && startsWith(github.event.pull_request.title, '[ci]')) || (github.event.comment.body == '/build' && github.event.issue.pull_request) || startsWith(github.event.comment.body, '/build ')) || github.event.inputs.packages}}
     runs-on: ubuntu-latest
 
     steps:
       - name: Add reaction to invocation comment
         uses: peter-evans/create-or-update-comment@v1
-        if: ${{!github.event.pull_request}}
+        if: ${{github.event.comment}}
         with:
           comment-id: ${{github.event.comment.id}}
           reactions: rocket
@@ -34,7 +40,7 @@ jobs:
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v1
         id: create-comment
-        if: ${{!github.event.pull_request}}
+        if: ${{github.event.comment}}
         with:
           issue-number: ${{github.event.issue.number}}
           body: |
@@ -89,16 +95,29 @@ jobs:
             const packages = args.split('/build ')[1].split(' ');
             return packages;
 
+      - name: Get packages to build from input
+        uses: actions/github-script@v5
+        id: get-packages-from-input
+        if: ${{github.event.inputs.packages}}
+        with:
+          script: |
+            const args = context.payload.inputs.packages;
+            const regex = /([a-z\d\/\.\-\+ ]+)/;
+            const isMatched = args.match(regex);
+            if (!isMatched) throw "No packages found in the command!";
+            const packages = args.split(' ');
+            return packages;
+
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v1
-        if: ${{failure() && !github.event.pull_request}}
+        if: ${{failure() && github.event.comment}}
         with:
           comment-id: ${{steps.create-comment.outputs.comment-id}}
           body: |
             ❌ Nothing to do!
 
     outputs:
-      matrix: ${{steps.get-packages-from-repo.outputs.result || steps.get-packages-from-command-line.outputs.result}}
+      matrix: ${{steps.get-packages-from-repo.outputs.result || steps.get-packages-from-command-line.outputs.result || steps.get-packages-from-input.outputs.result}}
       comment-id: ${{steps.create-comment.outputs.comment-id}}
 
   build:


### PR DESCRIPTION
It really hurts debugging GitHub Actions.

Anyway. This update adds workflow dispatch support. User could manually or programmatically dispatch the workflow with package names as input. As always, package names are spitted by whitespace ` `.