### PR TITLE
workflows-build: compare PR with common parent

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -44,6 +44,7 @@ jobs:
         if: ${{github.event.pull_request}}
         with:
           ref: 'stable'
+          fetch-depth: 0
 
       - uses: actions/checkout@v2
         if: ${{github.event.pull_request || github.event.comment.body == '/build'}}
@@ -70,7 +71,12 @@ jobs:
               }
             };
 
-            await exec.exec('git', ['diff', '--name-only', 'origin/stable', 'HEAD', '*/spec'], options);
+            await exec.exec('git', ['merge-base', 'origin/stable', 'HEAD'], options);
+            const parent = args.split('\n');
+
+            args = "";
+            await exec.exec('git', ['diff', '--name-only', parent[0], 'HEAD', '*/spec'], options);
+
             const regex = /.*\/(.*)\/.*/;
             const packages = args.split('\n').map(arg => regex.exec(arg)).filter(arg => Array.isArray(arg)).map(arg => arg[1]);
             if (!Array.isArray(packages) || packages.length == 0) throw "No packages to build in the repository!";


### PR DESCRIPTION
... instead of current HEAD of stable, builds only packages relevant to the PR.