### PR TITLE
workflows-tarballs: reduce number of recipes

### DIFF
--- a/.github/workflows/tarballs-monthly.yml
+++ b/.github/workflows/tarballs-monthly.yml
@@ -21,7 +21,6 @@ jobs:
           - container
           - gnome
           - kde
-          - lxde
           - mate
           - server
           - xfce
@@ -45,9 +44,6 @@ jobs:
             - kde+nvidia
             - kde+nvidia340
             - kde+nvidia390
-            - lxde+nvidia
-            - lxde+nvidia340
-            - lxde+nvidia390
             - mate+nvidia
             - mate+nvidia340
             - mate+nvidia390

--- a/.github/workflows/tarballs-monthly.yml
+++ b/.github/workflows/tarballs-monthly.yml
@@ -14,38 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        recipe: 
+        recipe:
           - base
-          - base+nvidia
-          - base+nvidia340
-          - base+nvidia390
           - buildkit
           - cinnamon
-          - cinnamon+nvidia
-          - cinnamon+nvidia340
-          - cinnamon+nvidia390
           - container
           - gnome
-          - gnome+nvidia
-          - gnome+nvidia340
-          - gnome+nvidia390
           - kde
-          - kde+nvidia
-          - kde+nvidia340
-          - kde+nvidia390
           - lxde
-          - lxde+nvidia
-          - lxde+nvidia340
-          - lxde+nvidia390
           - mate
-          - mate+nvidia
-          - mate+nvidia340
-          - mate+nvidia390
           - server
           - xfce
-          - xfce+nvidia
-          - xfce+nvidia340
-          - xfce+nvidia390
         buildbot:
           - Ry3950X
           - kp920
@@ -53,6 +32,28 @@ jobs:
           - Resonance
         include:
           - buildbot: Ry3950X
+            recipe:
+            - base+nvidia
+            - base+nvidia340
+            - base+nvidia390
+            - cinnamon+nvidia
+            - cinnamon+nvidia340
+            - cinnamon+nvidia390
+            - gnome+nvidia
+            - gnome+nvidia340
+            - gnome+nvidia390
+            - kde+nvidia
+            - kde+nvidia340
+            - kde+nvidia390
+            - lxde+nvidia
+            - lxde+nvidia340
+            - lxde+nvidia390
+            - mate+nvidia
+            - mate+nvidia340
+            - mate+nvidia390
+            - xfce+nvidia
+            - xfce+nvidia340
+            - xfce+nvidia390
             architecture: amd64
           - buildbot: kp920
             architecture: arm64


### PR DESCRIPTION
Non-AMD64 architectures don't support NVIDIA GPU driver.