### PR TITLE
workflows-tarballs: work around GH limitations

### DIFF
--- a/.github/workflows/tarballs-monthly.yml
+++ b/.github/workflows/tarballs-monthly.yml
@@ -31,25 +31,58 @@ jobs:
           - Resonance
         include:
           - buildbot: Ry3950X
-            recipe:
-            - base+nvidia
-            - base+nvidia340
-            - base+nvidia390
-            - cinnamon+nvidia
-            - cinnamon+nvidia340
-            - cinnamon+nvidia390
-            - gnome+nvidia
-            - gnome+nvidia340
-            - gnome+nvidia390
-            - kde+nvidia
-            - kde+nvidia340
-            - kde+nvidia390
-            - mate+nvidia
-            - mate+nvidia340
-            - mate+nvidia390
-            - xfce+nvidia
-            - xfce+nvidia340
-            - xfce+nvidia390
+            recipe: base+nvidia
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: base+nvidia340
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: base+nvidia390
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: cinnamon+nvidia
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: cinnamon+nvidia340
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: cinnamon+nvidia390
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: gnome+nvidia
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: gnome+nvidia340
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: gnome+nvidia390
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: kde+nvidia
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: kde+nvidia340
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: kde+nvidia390
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: mate+nvidia
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: mate+nvidia340
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: mate+nvidia390
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: xfce+nvidia
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: xfce+nvidia340
+            architecture: amd64
+          - buildbot: Ry3950X
+            recipe: xfce+nvidia390
             architecture: amd64
           - buildbot: kp920
             architecture: arm64


### PR DESCRIPTION
GitHub doesn't support array in matrix.include.*, so the only way to include multiple combinations is to write code like this... as far as I know.