### PR TITLE
workflows-tarballs: add arch info back

### DIFF
--- a/.github/workflows/tarballs-monthly.yml
+++ b/.github/workflows/tarballs-monthly.yml
@@ -31,6 +31,8 @@ jobs:
           - Resonance
         include:
           - buildbot: Ry3950X
+            architecture: amd64
+          - buildbot: Ry3950X
             recipe: base+nvidia
             architecture: amd64
           - buildbot: Ry3950X


### PR DESCRIPTION
... for AMD64 tarballs with no NVIDIA GPU driver.