### PR TITLE
.net runtime 5.0.11 + SDK 5.0.402

### DIFF
--- a/extra-devel/aspnetcore-runtime-5.0/spec
+++ b/extra-devel/aspnetcore-runtime-5.0/spec
@@ -1,11 +1,9 @@
-VER=5.0.3
+VER=5.0.11
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$VER/aspnetcore-runtime-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::188618b07cd5c97a34c77efccc7c4eba10a52681592ef711a005c82d243e601891418e0dcc27a22aae7dd6ae33d35e0bb7aa9b9fc022746c6c2414bd25cdb110"
+CHKSUMS__AMD64="sha512::2843b60a599fcb269bf700ea6233653264529d6522808c1b6ae0dc119e52e2c3203f3050dfef441dcb44130031a9ae03adbf25f1a51605ddc6f696b91433a667"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$VER/aspnetcore-runtime-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::4eaf1b0120479102b342f1f3a8ad8f40b7326e3657d2b7359c09fd1951c5169ca02d1ead4d4d01f6e594adbe0cb21f135f4c61ff90613219596f6cc222161717"
+CHKSUMS__ARM64="sha512::70844c1c1ca12dbdef3c459ce9a27d5ac91c893891473efb7b2184596210008674078c9d9833d6a2d5114b680a182a3e83d135b3d175bb373b439fcf22f4fc02"
 
 SUBDIR=.
-REL=1
-CHKSUM="sha256::c220edde6058fd749fb22cfe7bb432378659c2941f60f0a9865998767d63e95d"
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(5\..+?)\""

--- a/extra-devel/dotnet-sdk-5.0.4xx/autobuild/build
+++ b/extra-devel/dotnet-sdk-5.0.4xx/autobuild/build
@@ -1,0 +1,3 @@
+abinfo "Deploying files ..."
+mkdir -pv "$PKGDIR"/usr/lib/dotnet
+cp -rv "$SRCDIR"/sdk "$PKGDIR"/usr/lib/dotnet

--- a/extra-devel/dotnet-sdk-5.0.4xx/autobuild/defines
+++ b/extra-devel/dotnet-sdk-5.0.4xx/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=dotnet-sdk-5.0.4xx
+PKGSEC=devel
+PKGDES=".NET Core is a cross-platform .NET implementation for websites, servers, and console apps on Windows, Linux, and macOS"
+PKGDEP="dotnet-runtime-5.0 gcc-runtime glibc"
+PKGDEP__AMD64="$PKGDEP aspnetcore-runtime-5.0"
+PKGDEP__ARMEL="$PKGDEP aspnetcore-runtime-5.0"
+
+FAIL_ARCH="!(amd64|arm64)"
+NOSTATIC=0
+
+ABSPLITDBG=0

--- a/extra-devel/dotnet-sdk-5.0.4xx/spec
+++ b/extra-devel/dotnet-sdk-5.0.4xx/spec
@@ -1,0 +1,9 @@
+VER=5.0.402
+
+SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Sdk/$VER/dotnet-sdk-$VER-linux-x64.tar.gz"
+CHKSUMS__AMD64="sha512::6b2937ad1f026fd91d0c8e6101b0422a8d19ead022055021b55a722c34dcc3697b592592eacc6def8748981bd996bc2a511d7c3f05b0ae431c00ede0376deacc"
+SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Sdk/$VER/dotnet-sdk-$VER-linux-arm64.tar.gz"
+CHKSUMS__ARM64="sha512::9681da343f72998590541e0ee454a3d68aa4caff761ecc727c837fdbe8645c11487d8e8c4f6f9d3cda35373cee046b4857289a2307aa4929878633d13443e5bf"
+
+SUBDIR=.
+CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-sdk\": \"(5\..+?)\""

--- a/extra-devel/dotnet-sdk-5.0/autobuild/defines
+++ b/extra-devel/dotnet-sdk-5.0/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=dotnet-sdk-5.0
 PKGSEC=devel
 PKGDES="Transitional package for most recent .NET Core platform SDK 5.0"
-PKGDEP="dotnet-sdk-5.0.1xx"
+PKGDEP="dotnet-sdk-5.0.4xx"
 
 FAIL_ARCH="!(arm64|amd64)"
 ABSPLITDBG=0

--- a/extra-devel/dotnet-sdk-5.0/spec
+++ b/extra-devel/dotnet-sdk-5.0/spec
@@ -1,5 +1,4 @@
-VER=5.0.103
+VER=5.0.402
 DUMMYSRC=1
-REL=1
 CHKSUMS="SKIP"
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-sdk\": \"(5\..+?)\""

--- a/extra-devel/dotnet-sdk-5/spec
+++ b/extra-devel/dotnet-sdk-5/spec
@@ -1,5 +1,4 @@
-VER=5.0.103
+VER=5.0.402
 DUMMYSRC=1
-REL=1
 CHKSUMS="SKIP"
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-sdk\": \"(5\..+?)\""

--- a/extra-libs/dotnet-host-fxr/spec
+++ b/extra-libs/dotnet-host-fxr/spec
@@ -1,9 +1,9 @@
-VER=5.0.3
+VER=5.0.11
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::263dbe260123c3d6d706ed8b5f4d510d9384216422e9af0d293df87ed98e84e1e0ffbf0c7dd543c40c5ccc95bd7cd006c8bbbe9f1cd1f060b1eaa2f7a60fea74"
+CHKSUMS__AMD64="sha512::4eef891385288e5ab35beea79e2e6ca13615afe2e90da7a7a14417119bdbeb42980dda5f1cbe5b6d8e05a728d0db4256abb54cd00a63aa621a70090bddbe9f69"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::f4d176b48714121040470a25f76a1b3554edb358953c1bfb39bd111cf0dcc85cb8a5ebcd617efd207b3cfaef0a2d242f94e9f018a186828a750c5c0dc9bd7da5"
+CHKSUMS__ARM64="sha512::b296a79f655ad22db405f24c1549b6cd610c57dae917c89b91ddcb4b053a7613952261cca7d7c79e6fda72026fd4bbbcf74751cb6529a55504a67223cabc0451"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-release\": \"(5\..+?)\""

--- a/extra-libs/dotnet-host/spec
+++ b/extra-libs/dotnet-host/spec
@@ -1,9 +1,9 @@
-VER=5.0.3
+VER=5.0.11
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::263dbe260123c3d6d706ed8b5f4d510d9384216422e9af0d293df87ed98e84e1e0ffbf0c7dd543c40c5ccc95bd7cd006c8bbbe9f1cd1f060b1eaa2f7a60fea74"
+CHKSUMS__AMD64="sha512::4eef891385288e5ab35beea79e2e6ca13615afe2e90da7a7a14417119bdbeb42980dda5f1cbe5b6d8e05a728d0db4256abb54cd00a63aa621a70090bddbe9f69"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::f4d176b48714121040470a25f76a1b3554edb358953c1bfb39bd111cf0dcc85cb8a5ebcd617efd207b3cfaef0a2d242f94e9f018a186828a750c5c0dc9bd7da5"
+CHKSUMS__ARM64="sha512::b296a79f655ad22db405f24c1549b6cd610c57dae917c89b91ddcb4b053a7613952261cca7d7c79e6fda72026fd4bbbcf74751cb6529a55504a67223cabc0451"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-release\": \"(5\..+?)\""

--- a/extra-libs/dotnet-runtime-5.0/spec
+++ b/extra-libs/dotnet-runtime-5.0/spec
@@ -1,9 +1,9 @@
-VER=5.0.3
+VER=5.0.11
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::263dbe260123c3d6d706ed8b5f4d510d9384216422e9af0d293df87ed98e84e1e0ffbf0c7dd543c40c5ccc95bd7cd006c8bbbe9f1cd1f060b1eaa2f7a60fea74"
+CHKSUMS__AMD64="sha512::4eef891385288e5ab35beea79e2e6ca13615afe2e90da7a7a14417119bdbeb42980dda5f1cbe5b6d8e05a728d0db4256abb54cd00a63aa621a70090bddbe9f69"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::f4d176b48714121040470a25f76a1b3554edb358953c1bfb39bd111cf0dcc85cb8a5ebcd617efd207b3cfaef0a2d242f94e9f018a186828a750c5c0dc9bd7da5"
+CHKSUMS__ARM64="sha512::b296a79f655ad22db405f24c1549b6cd610c57dae917c89b91ddcb4b053a7613952261cca7d7c79e6fda72026fd4bbbcf74751cb6529a55504a67223cabc0451"
 
 SUBDIR=.
-CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(5\..+?)\""
+CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-release\": \"(5\..+?)\""


### PR DESCRIPTION
Topic Description
-----------------

This PR updates dotnet runtime (dotnet host, fxr, runtime, aspnetcore) to 5.0.11 and 5.0.x SDK to 5.0.402. This fixes https://github.com/NuGet/Home/issues/10491 where a change in CA certificates broke nuget restore.

Package(s) Affected
-------------------

* dotnet-{host,host-fxr,runtime-5.0}, aspnetcore-runtime-5.0: 5.0.11
* dotnet-sdk-5.0.4xx, dotnet-sdk-5.0, dotnet-sdk-5: 5.0.402

Build Order
-----------

dotnet-host dotnet-host-fxr dotnet-runtime-5.0 aspnetcore-runtime-5.0 dotnet-sdk-5.0.4xx dotnet-sdk-5.0 dotnet-sdk-5

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

<!-- TODO: CI to auto-fill architectural progress. -->
