### PR TITLE
chromium: fix launch failure

### DIFF
--- a/extra-web/chromium/autobuild/build
+++ b/extra-web/chromium/autobuild/build
@@ -29,7 +29,7 @@ GNFLAGS=(
     'use_ozone=true'
     'ozone_platform_wayland=true'
     'ozone_platform_x11=true'
-    'ozone_auto_platforms=false')
+    'ozone_auto_platforms=true')
 
 abinfo "Running gn to generate build rules ..."
 gn gen "$SRCDIR"/out/Release \
@@ -50,6 +50,7 @@ cp -av \
     "$SRCDIR"/out/Release/{*.bin,chromedriver} \
     "$SRCDIR"/out/Release/locales \
     "$SRCDIR"/out/Release/icudtl.dat \
+    "$SRCDIR"/out/Release/chrome_crashpad_handler \
     "$PKGDIR"/usr/lib/chromium/
 mkdir -pv "$PKGDIR"/usr/bin
 ln -sv /usr/lib/chromium/chromedriver \

--- a/extra-web/chromium/autobuild/patches/0010-Arch-Linux-ozone-x11-fix-VA-API.patch
+++ b/extra-web/chromium/autobuild/patches/0010-Arch-Linux-ozone-x11-fix-VA-API.patch
@@ -1,0 +1,671 @@
+From a4de986102a45e29c3ef596f22704bdca244c26c Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Fri, 17 Sep 2021 08:45:55 +0000
+Subject: [PATCH] ozone/x11: fix VA-API.
+
+This patch fixes VA-API usage with Ozone/X11 backend (which
+is our default backend now as X11 has been deprecated -
+crrev.com/c/3114071)).
+
+non-Ozone X11 is disabled now and Ozone is always used
+on Linux. However, VA-API implementation is not Ozone friendly
+yet and requires major refactoring. But given that VA-API
+implementation on Linux worked only with X11, it's fine for
+now to change USE_X11 and !IsUsingOzonePlatform to
+BUILDFLAG(OZONE_PLATFORM_X11) and fail VA-API initialization
+in VADisplayState::Initialize for Ozone/Linux other than
+non-X11 backends.
+
+Bug: 1121948
+Change-Id: If85d289235e6d358103d9fa2bbe0f741fb599a26
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3141878
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Reviewed-by: Andres Calderon Jaramillo <andrescj@chromium.org>
+Reviewed-by: Robert Kroeger <rjkroege@chromium.org>
+Reviewed-by: Xiaohan Wang <xhwang@chromium.org>
+Reviewed-by: Alexander Dunaev <adunaev@igalia.com>
+Cr-Commit-Position: refs/heads/main@{#922466}
+---
+ media/BUILD.gn                                |  3 -
+ media/gpu/BUILD.gn                            |  5 +-
+ media/gpu/args.gni                            | 13 +++-
+ media/gpu/vaapi/BUILD.gn                      |  8 +-
+ media/gpu/vaapi/va_stub_header.fragment       |  6 +-
+ media/gpu/vaapi/vaapi_picture_factory.cc      | 72 ++++++++----------
+ .../vaapi_picture_native_pixmap_angle.cc      |  2 -
+ media/gpu/vaapi/vaapi_picture_tfp.cc          |  2 -
+ .../vaapi/vaapi_video_decode_accelerator.cc   |  9 +--
+ ...vaapi_video_decode_accelerator_unittest.cc | 11 +--
+ media/gpu/vaapi/vaapi_wrapper.cc              | 76 +++++++++----------
+ media/gpu/vaapi/vaapi_wrapper.h               |  8 +-
+ ui/ozone/platform/x11/ozone_platform_x11.cc   |  3 +
+ ui/ozone/public/ozone_platform.h              | 10 +++
+ 14 files changed, 108 insertions(+), 120 deletions(-)
+
+diff --git a/media/BUILD.gn b/media/BUILD.gn
+index dbee1d4338..d5c158c08f 100644
+--- a/media/BUILD.gn
++++ b/media/BUILD.gn
+@@ -130,9 +130,6 @@ component("media") {
+     public_deps += [ "//media/base/mac" ]
+   }
+ 
+-  if (use_x11) {
+-    deps += [ "//ui/base/x" ]
+-  }
+   if (use_ozone) {
+     deps += [ "//ui/ozone" ]
+   }
+diff --git a/media/gpu/BUILD.gn b/media/gpu/BUILD.gn
+index c7499485ac..3fedc78948 100644
+--- a/media/gpu/BUILD.gn
++++ b/media/gpu/BUILD.gn
+@@ -20,6 +20,7 @@ buildflag_header("buildflags") {
+     "USE_VAAPI_IMAGE_CODECS=$use_vaapi_image_codecs",
+     "USE_V4L2_CODEC=$use_v4l2_codec",
+     "USE_LIBV4L2=$use_v4lplugin",
++    "USE_VAAPI_X11=$use_vaapi_x11",
+   ]
+ }
+ 
+@@ -215,9 +216,7 @@ component("gpu") {
+       "windows/supported_profile_helpers.cc",
+       "windows/supported_profile_helpers.h",
+     ]
+-    configs += [
+-      "//third_party/khronos:khronos_headers",
+-    ]
++    configs += [ "//third_party/khronos:khronos_headers" ]
+     public_deps += [ "//media/base/win:media_foundation_util" ]
+     deps += [
+       "//gpu/ipc/common:common",
+diff --git a/media/gpu/args.gni b/media/gpu/args.gni
+index 4004937949..2f53843918 100644
+--- a/media/gpu/args.gni
++++ b/media/gpu/args.gni
+@@ -3,7 +3,15 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
+-import("//build/config/ui.gni")
++import("//build/config/ozone.gni")
++
++declare_args() {
++  # Indicates if X11 VA-API-based hardware acceleration is to be used.
++  # See also the comment near the |use_vaapi| arg.
++  use_vaapi_x11 =
++      is_linux && ozone_platform_x11 && !is_chromecast && !is_chromeos_lacros &&
++      (target_cpu == "x86" || target_cpu == "x64")
++}
+ 
+ declare_args() {
+   # Indicates if V4L plugin is used.
+@@ -21,8 +29,7 @@ declare_args() {
+   # is typically the case on x86-based ChromeOS devices.
+   # VA-API should also be compiled by default on x11-using linux devices
+   # using x86/x64.
+-  use_vaapi =
+-      is_linux && use_x11 && (target_cpu == "x86" || target_cpu == "x64")
++  use_vaapi = use_vaapi_x11
+ 
+   # Indicates if ChromeOS protected media support exists. This is used
+   # to enable the CDM daemon in Chrome OS as well as support for
+diff --git a/media/gpu/vaapi/BUILD.gn b/media/gpu/vaapi/BUILD.gn
+index b11d2c60fa..0c2520dd6b 100644
+--- a/media/gpu/vaapi/BUILD.gn
++++ b/media/gpu/vaapi/BUILD.gn
+@@ -17,7 +17,7 @@ assert(use_vaapi)
+ generate_stubs("libva_stubs") {
+   extra_header = "va_stub_header.fragment"
+   sigs = [ "va.sigs" ]
+-  if (use_x11) {
++  if (use_vaapi_x11) {
+     sigs += [ "va_x11.sigs" ]
+   }
+   if (is_chromeos_ash) {
+@@ -131,14 +131,14 @@ source_set("vaapi") {
+     ]
+   }
+ 
+-  if (use_x11 || use_ozone || use_egl) {
++  if (use_ozone || use_egl) {
+     sources += [
+       "vaapi_picture_native_pixmap.cc",
+       "vaapi_picture_native_pixmap.h",
+     ]
+   }
+ 
+-  if (use_x11) {
++  if (use_vaapi_x11) {
+     deps += [ "//ui/gfx/x" ]
+     sources += [
+       "vaapi_picture_native_pixmap_angle.cc",
+@@ -197,7 +197,7 @@ source_set("common") {
+     deps += [ "//ui/ozone" ]
+   }
+ 
+-  if (use_x11) {
++  if (use_vaapi_x11) {
+     deps += [ "//ui/gfx/x" ]
+   }
+ 
+diff --git a/media/gpu/vaapi/va_stub_header.fragment b/media/gpu/vaapi/va_stub_header.fragment
+index bed198484d..e8c46c5e81 100644
+--- a/media/gpu/vaapi/va_stub_header.fragment
++++ b/media/gpu/vaapi/va_stub_header.fragment
+@@ -1,12 +1,14 @@
+ // The extra include header needed in the generated stub file for defining
+ // various libva types.
+ 
++#include "media/gpu/buildflags.h"
++
+ extern "C" {
+ 
+ #include <va/va_drm.h>
+ #include <va/va.h>
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+ #include <va/va_x11.h>
+-#endif
++#endif  // BUILDFLAG(USE_VAAPI_X11)
+ 
+ }
+diff --git a/media/gpu/vaapi/vaapi_picture_factory.cc b/media/gpu/vaapi/vaapi_picture_factory.cc
+index 719035b87c..9c7d7387d2 100644
+--- a/media/gpu/vaapi/vaapi_picture_factory.cc
++++ b/media/gpu/vaapi/vaapi_picture_factory.cc
+@@ -10,13 +10,13 @@
+ #include "ui/base/ui_base_features.h"
+ #include "ui/gl/gl_bindings.h"
+ 
+-#if defined(USE_X11)
+-#include "media/gpu/vaapi/vaapi_picture_native_pixmap_angle.h"
+-#include "media/gpu/vaapi/vaapi_picture_tfp.h"
+-#endif
+ #if defined(USE_OZONE)
+ #include "media/gpu/vaapi/vaapi_picture_native_pixmap_ozone.h"
+-#endif
++#endif  // defined(USE_OZONE)
++#if BUILDFLAG(USE_VAAPI_X11)
++#include "media/gpu/vaapi/vaapi_picture_native_pixmap_angle.h"
++#include "media/gpu/vaapi/vaapi_picture_tfp.h"
++#endif  // BUILDFLAG(USE_VAAPI_X11)
+ #if defined(USE_EGL)
+ #include "media/gpu/vaapi/vaapi_picture_native_pixmap_egl.h"
+ #endif
+@@ -46,15 +46,13 @@ VaapiPictureFactory::VaapiPictureFactory() {
+   vaapi_impl_pairs_.insert(
+       std::make_pair(gl::kGLImplementationEGLGLES2,
+                      VaapiPictureFactory::kVaapiImplementationDrm));
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+   vaapi_impl_pairs_.insert(
+       std::make_pair(gl::kGLImplementationEGLANGLE,
+                      VaapiPictureFactory::kVaapiImplementationAngle));
+-  if (!features::IsUsingOzonePlatform()) {
+-    vaapi_impl_pairs_.insert(
+-        std::make_pair(gl::kGLImplementationDesktopGL,
+-                       VaapiPictureFactory::kVaapiImplementationX11));
+-  }
++  vaapi_impl_pairs_.insert(
++      std::make_pair(gl::kGLImplementationDesktopGL,
++                     VaapiPictureFactory::kVaapiImplementationX11));
+ #endif
+ 
+   DeterminePictureCreationAndDownloadingMechanism();
+@@ -96,19 +94,19 @@ VaapiPictureFactory::GetVaapiImplementation(gl::GLImplementation gl_impl) {
+ }
+ 
+ uint32_t VaapiPictureFactory::GetGLTextureTarget() {
+-#if defined(USE_OZONE)
+-  if (features::IsUsingOzonePlatform())
+-    return GL_TEXTURE_EXTERNAL_OES;
+-#endif
++#if BUILDFLAG(USE_VAAPI_X11)
+   return GL_TEXTURE_2D;
++#else
++  return GL_TEXTURE_EXTERNAL_OES;
++#endif
+ }
+ 
+ gfx::BufferFormat VaapiPictureFactory::GetBufferFormat() {
+-#if defined(USE_OZONE)
+-  if (features::IsUsingOzonePlatform())
+-    return gfx::BufferFormat::YUV_420_BIPLANAR;
+-#endif
++#if BUILDFLAG(USE_VAAPI_X11)
+   return gfx::BufferFormat::RGBX_8888;
++#else
++  return gfx::BufferFormat::YUV_420_BIPLANAR;
++#endif
+ }
+ 
+ void VaapiPictureFactory::DeterminePictureCreationAndDownloadingMechanism() {
+@@ -116,51 +114,43 @@ void VaapiPictureFactory::DeterminePictureCreationAndDownloadingMechanism() {
+ #if defined(USE_OZONE)
+     // We can be called without GL initialized, which is valid if we use Ozone.
+     case kVaapiImplementationNone:
+-      if (features::IsUsingOzonePlatform()) {
+-        create_picture_cb_ = base::BindRepeating(
+-            &CreateVaapiPictureNativeImpl<VaapiPictureNativePixmapOzone>);
+-        needs_vpp_for_downloading_ = true;
+-      }
+-
+-      // This is reached by unit tests which don't require create_picture_cb_
+-      // to be initialized or called.
++      create_picture_cb_ = base::BindRepeating(
++          &CreateVaapiPictureNativeImpl<VaapiPictureNativePixmapOzone>);
++      needs_vpp_for_downloading_ = true;
+       break;
+ #endif  // defined(USE_OZONE)
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+     case kVaapiImplementationX11:
+-      DCHECK(!features::IsUsingOzonePlatform());
+       create_picture_cb_ =
+           base::BindRepeating(&CreateVaapiPictureNativeImpl<VaapiTFPPicture>);
+       // Neither VaapiTFPPicture or VaapiPictureNativePixmapAngle needs the VPP.
+       needs_vpp_for_downloading_ = false;
+       break;
+     case kVaapiImplementationAngle:
+-      DCHECK(!features::IsUsingOzonePlatform());
+       create_picture_cb_ = base::BindRepeating(
+           &CreateVaapiPictureNativeImpl<VaapiPictureNativePixmapAngle>);
+       // Neither VaapiTFPPicture or VaapiPictureNativePixmapAngle needs the VPP.
+       needs_vpp_for_downloading_ = false;
+       break;
+-#endif  // defined(USE_X11)
++#endif  // BUILDFLAG(USE_VAAPI_X11)
+     case kVaapiImplementationDrm:
+ #if defined(USE_OZONE)
+-      if (features::IsUsingOzonePlatform()) {
+-        create_picture_cb_ = base::BindRepeating(
+-            &CreateVaapiPictureNativeImpl<VaapiPictureNativePixmapOzone>);
+-        needs_vpp_for_downloading_ = true;
+-        break;
+-      }
+-#endif  // defined(USE_OZONE)
+-#if defined(USE_EGL)
++      create_picture_cb_ = base::BindRepeating(
++          &CreateVaapiPictureNativeImpl<VaapiPictureNativePixmapOzone>);
++      needs_vpp_for_downloading_ = true;
++      break;
++#elif defined(USE_EGL)
+       create_picture_cb_ = base::BindRepeating(
+           &CreateVaapiPictureNativeImpl<VaapiPictureNativePixmapEgl>);
+       needs_vpp_for_downloading_ = true;
+       break;
+-#endif  // defined(USE_EGL)
++#else
+       // ozone or egl must be used to use the DRM implementation.
+-      NOTREACHED();
++      FALLTHROUGH;
++#endif
+     default:
+       NOTREACHED();
++      break;
+   }
+ }
+ 
+diff --git a/media/gpu/vaapi/vaapi_picture_native_pixmap_angle.cc b/media/gpu/vaapi/vaapi_picture_native_pixmap_angle.cc
+index 9de0c93b44..e5b9908490 100644
+--- a/media/gpu/vaapi/vaapi_picture_native_pixmap_angle.cc
++++ b/media/gpu/vaapi/vaapi_picture_native_pixmap_angle.cc
+@@ -6,7 +6,6 @@
+ 
+ #include "media/gpu/vaapi/va_surface.h"
+ #include "media/gpu/vaapi/vaapi_wrapper.h"
+-#include "ui/base/ui_base_features.h"
+ #include "ui/gfx/x/connection.h"
+ #include "ui/gfx/x/future.h"
+ #include "ui/gfx/x/xproto.h"
+@@ -92,7 +91,6 @@ Status VaapiPictureNativePixmapAngle::Allocate(gfx::BufferFormat format) {
+   if (!make_context_current_cb_ || !make_context_current_cb_.Run())
+     return StatusCode::kVaapiBadContext;
+ 
+-  DCHECK(!features::IsUsingOzonePlatform());
+   auto image =
+       base::MakeRefCounted<gl::GLImageEGLPixmap>(visible_size_, format);
+   if (!image)
+diff --git a/media/gpu/vaapi/vaapi_picture_tfp.cc b/media/gpu/vaapi/vaapi_picture_tfp.cc
+index 3f7e221d8a..11914e3640 100644
+--- a/media/gpu/vaapi/vaapi_picture_tfp.cc
++++ b/media/gpu/vaapi/vaapi_picture_tfp.cc
+@@ -6,7 +6,6 @@
+ 
+ #include "media/gpu/vaapi/va_surface.h"
+ #include "media/gpu/vaapi/vaapi_wrapper.h"
+-#include "ui/base/ui_base_features.h"
+ #include "ui/gfx/x/connection.h"
+ #include "ui/gfx/x/future.h"
+ #include "ui/gl/gl_bindings.h"
+@@ -37,7 +36,6 @@ VaapiTFPPicture::VaapiTFPPicture(
+       connection_(x11::Connection::Get()),
+       x_pixmap_(x11::Pixmap::None) {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+-  DCHECK(!features::IsUsingOzonePlatform());
+   DCHECK(texture_id);
+   DCHECK(client_texture_id);
+ }
+diff --git a/media/gpu/vaapi/vaapi_video_decode_accelerator.cc b/media/gpu/vaapi/vaapi_video_decode_accelerator.cc
+index 7514fe4fdd..e4cd7c8d89 100644
+--- a/media/gpu/vaapi/vaapi_video_decode_accelerator.cc
++++ b/media/gpu/vaapi/vaapi_video_decode_accelerator.cc
+@@ -184,12 +184,6 @@ bool VaapiVideoDecodeAccelerator::Initialize(const Config& config,
+                                              Client* client) {
+   DCHECK(task_runner_->BelongsToCurrentThread());
+ 
+-#if defined(USE_X11)
+-  // TODO(crbug/1116701): implement decode acceleration when running with Ozone.
+-  if (features::IsUsingOzonePlatform())
+-    return false;
+-#endif
+-
+   vaapi_picture_factory_ = std::make_unique<VaapiPictureFactory>();
+ 
+   if (config.is_encrypted()) {
+@@ -1213,12 +1207,11 @@ VaapiVideoDecodeAccelerator::GetSupportedProfiles() {
+ 
+ VaapiVideoDecodeAccelerator::BufferAllocationMode
+ VaapiVideoDecodeAccelerator::DecideBufferAllocationMode() {
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+   // The IMPORT mode is used for Android on Chrome OS, so this doesn't apply
+   // here.
+   DCHECK_NE(output_mode_, VideoDecodeAccelerator::Config::OutputMode::IMPORT);
+   // TODO(crbug/1116701): get video decode acceleration working with ozone.
+-  DCHECK(!features::IsUsingOzonePlatform());
+   // For H.264 on older devices, another +1 is experimentally needed for
+   // high-to-high resolution changes.
+   // TODO(mcasas): Figure out why and why only H264, see crbug.com/912295 and
+diff --git a/media/gpu/vaapi/vaapi_video_decode_accelerator_unittest.cc b/media/gpu/vaapi/vaapi_video_decode_accelerator_unittest.cc
+index 5b9a543386..826bb103b1 100644
+--- a/media/gpu/vaapi/vaapi_video_decode_accelerator_unittest.cc
++++ b/media/gpu/vaapi/vaapi_video_decode_accelerator_unittest.cc
+@@ -17,7 +17,6 @@
+ #include "media/gpu/vaapi/vaapi_wrapper.h"
+ #include "testing/gmock/include/gmock/gmock.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+-#include "ui/base/ui_base_features.h"
+ 
+ using base::test::RunClosure;
+ using ::testing::_;
+@@ -416,12 +415,10 @@ TEST_P(VaapiVideoDecodeAcceleratorTest, SupportedPlatforms) {
+             mock_vaapi_picture_factory_->GetVaapiImplementation(
+                 gl::kGLImplementationEGLGLES2));
+ 
+-#if defined(USE_X11)
+-  if (!features::IsUsingOzonePlatform()) {
+-    EXPECT_EQ(VaapiPictureFactory::kVaapiImplementationX11,
+-              mock_vaapi_picture_factory_->GetVaapiImplementation(
+-                  gl::kGLImplementationDesktopGL));
+-  }
++#if BUILDFLAG(USE_VAAPI_X11)
++  EXPECT_EQ(VaapiPictureFactory::kVaapiImplementationX11,
++            mock_vaapi_picture_factory_->GetVaapiImplementation(
++                gl::kGLImplementationDesktopGL));
+ #endif
+ }
+ 
+diff --git a/media/gpu/vaapi/vaapi_wrapper.cc b/media/gpu/vaapi/vaapi_wrapper.cc
+index 754d258848..e528b0f84d 100644
+--- a/media/gpu/vaapi/vaapi_wrapper.cc
++++ b/media/gpu/vaapi/vaapi_wrapper.cc
+@@ -65,7 +65,7 @@
+ #include "ui/gl/gl_bindings.h"
+ #include "ui/gl/gl_implementation.h"
+ 
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+ typedef XID Drawable;
+ 
+ extern "C" {
+@@ -73,7 +73,7 @@ extern "C" {
+ }
+ 
+ #include "ui/gfx/x/connection.h"  // nogncheck
+-#endif
++#endif                            // BUILDFLAG(USE_VAAPI_X11)
+ 
+ #if defined(USE_OZONE)
+ #include "ui/ozone/public/ozone_platform.h"
+@@ -87,14 +87,14 @@ using media_gpu_vaapi::kModuleVa_prot;
+ 
+ using media_gpu_vaapi::kModuleVa;
+ using media_gpu_vaapi::kModuleVa_drm;
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+ using media_gpu_vaapi::kModuleVa_x11;
+-#endif
++#endif  // BUILDFLAG(USE_VAAPI_X11)
+ using media_gpu_vaapi::InitializeStubs;
+ using media_gpu_vaapi::IsVaInitialized;
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+ using media_gpu_vaapi::IsVa_x11Initialized;
+-#endif
++#endif  // BUILDFLAG(USE_VAAPI_X11)
+ using media_gpu_vaapi::IsVa_drmInitialized;
+ using media_gpu_vaapi::StubPathMap;
+ 
+@@ -559,10 +559,20 @@ VADisplayState::VADisplayState()
+ bool VADisplayState::Initialize() {
+   base::AutoLock auto_lock(va_lock_);
+ 
++#if defined(USE_OZONE) && defined(OS_LINUX)
++  // TODO(crbug.com/1116701): add vaapi support for other Ozone platforms on
++  // Linux. See comment in OzonePlatform::PlatformProperties::supports_vaapi
++  // for more details. This will also require revisiting everything that's
++  // guarded by USE_VAAPI_X11. For example, if USE_VAAPI_X11 is true, but the
++  // user chooses the Wayland backend for Ozone at runtime, then many things (if
++  // not all) that we do for X11 won't apply.
++  if (!ui::OzonePlatform::GetInstance()->GetPlatformProperties().supports_vaapi)
++    return false;
++#endif
++
+   bool libraries_initialized = IsVaInitialized() && IsVa_drmInitialized();
+-#if defined(USE_X11)
+-  if (!features::IsUsingOzonePlatform())
+-    libraries_initialized = libraries_initialized && IsVa_x11Initialized();
++#if BUILDFLAG(USE_VAAPI_X11)
++  libraries_initialized = libraries_initialized && IsVa_x11Initialized();
+ #endif
+   if (!libraries_initialized)
+     return false;
+@@ -577,34 +587,25 @@ bool VADisplayState::Initialize() {
+   return success;
+ }
+ 
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+ 
+ absl::optional<VADisplay> GetVADisplayStateX11(const base::ScopedFD& drm_fd) {
+-  bool use_drm_as_fallback = false;
+   switch (gl::GetGLImplementation()) {
+     case gl::kGLImplementationEGLGLES2:
+       return vaGetDisplayDRM(drm_fd.get());
+ 
+     case gl::kGLImplementationNone:
+-      use_drm_as_fallback = true;
+-      FALLTHROUGH;
+ 
+     case gl::kGLImplementationDesktopGL: {
+-      if (!features::IsUsingOzonePlatform()) {
+-        VADisplay display =
+-            vaGetDisplay(x11::Connection::Get()->GetXlibDisplay());
+-        if (vaDisplayIsValid(display))
+-          return display;
+-        return vaGetDisplayDRM(drm_fd.get());
+-      }
+-      break;
++      VADisplay display =
++          vaGetDisplay(x11::Connection::Get()->GetXlibDisplay());
++      if (vaDisplayIsValid(display))
++        return display;
++      return vaGetDisplayDRM(drm_fd.get());
+     }
+ 
+-    case gl::kGLImplementationEGLANGLE: {
+-      if (!features::IsUsingOzonePlatform())
+-        return vaGetDisplay(x11::Connection::Get()->GetXlibDisplay());
+-      break;
+-    }
++    case gl::kGLImplementationEGLANGLE:
++      return vaGetDisplay(x11::Connection::Get()->GetXlibDisplay());
+ 
+     default:
+       LOG(WARNING) << "VAAPI video acceleration not available for "
+@@ -612,10 +613,6 @@ absl::optional<VADisplay> GetVADisplayStateX11(const base::ScopedFD& drm_fd) {
+                           gl::GetGLImplementationParts());
+       return absl::nullopt;
+   }
+-
+-  if (use_drm_as_fallback)
+-    return vaGetDisplayDRM(drm_fd.get());
+-  return absl::nullopt;
+ }
+ 
+ #else
+@@ -633,11 +630,11 @@ absl::optional<VADisplay> GetVADisplayState(const base::ScopedFD& drm_fd) {
+   }
+ }
+ 
+-#endif  // defined(USE_X11)
++#endif  // BUILDFLAG(USE_VAAPI_X11)
+ 
+ bool VADisplayState::InitializeVaDisplay_Locked() {
+   absl::optional<VADisplay> display =
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+       GetVADisplayStateX11(drm_fd_);
+ #else
+       GetVADisplayState(drm_fd_);
+@@ -702,10 +699,9 @@ bool VADisplayState::InitializeOnce() {
+   if (!InitializeVaDisplay_Locked() || !InitializeVaDriver_Locked())
+     return false;
+ 
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+   if (gl::GetGLImplementation() == gl::kGLImplementationEGLANGLE &&
+       implementation_type_ == VAImplementation::kIntelIHD) {
+-    DCHECK(!features::IsUsingOzonePlatform());
+     constexpr char libva_driver_impl_env[] = "LIBVA_DRIVER_NAME";
+     // TODO(crbug/1116703) The libva intel-media driver has a known segfault in
+     // vaPutSurface, so until this is fixed, fall back to the i965 driver. There
+@@ -722,7 +718,7 @@ bool VADisplayState::InitializeOnce() {
+     if (!InitializeVaDisplay_Locked() || !InitializeVaDriver_Locked())
+       return false;
+   }
+-#endif  // USE_X11
++#endif  // BUILDFLAG(USE_VAAPI_X11)
+ 
+   return true;
+ }
+@@ -2452,11 +2448,10 @@ bool VaapiWrapper::MapAndCopyAndExecute(
+   return Execute_Locked(va_surface_id, va_buffer_ids);
+ }
+ 
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+ bool VaapiWrapper::PutSurfaceIntoPixmap(VASurfaceID va_surface_id,
+                                         x11::Pixmap x_pixmap,
+                                         gfx::Size dest_size) {
+-  DCHECK(!features::IsUsingOzonePlatform());
+   base::AutoLock auto_lock(*va_lock_);
+ 
+   VAStatus va_res = vaSyncSurface(va_display_, va_surface_id);
+@@ -2470,7 +2465,7 @@ bool VaapiWrapper::PutSurfaceIntoPixmap(VASurfaceID va_surface_id,
+   VA_SUCCESS_OR_RETURN(va_res, VaapiFunctions::kVAPutSurface, false);
+   return true;
+ }
+-#endif  // USE_X11
++#endif  // BUILDFLAG(USE_VAAPI_X11)
+ 
+ std::unique_ptr<ScopedVAImage> VaapiWrapper::CreateVaImage(
+     VASurfaceID va_surface_id,
+@@ -2844,9 +2839,8 @@ void VaapiWrapper::PreSandboxInitialization() {
+ 
+   paths[kModuleVa].push_back(std::string("libva.so.") + va_suffix);
+   paths[kModuleVa_drm].push_back(std::string("libva-drm.so.") + va_suffix);
+-#if defined(USE_X11)
+-  if (!features::IsUsingOzonePlatform())
+-    paths[kModuleVa_x11].push_back(std::string("libva-x11.so.") + va_suffix);
++#if BUILDFLAG(USE_VAAPI_X11)
++  paths[kModuleVa_x11].push_back(std::string("libva-x11.so.") + va_suffix);
+ #endif
+ #if BUILDFLAG(IS_CHROMEOS_ASH)
+   paths[kModuleVa_prot].push_back(std::string("libva.so.") + va_suffix);
+diff --git a/media/gpu/vaapi/vaapi_wrapper.h b/media/gpu/vaapi/vaapi_wrapper.h
+index 0e3da53624..88ffcd0799 100644
+--- a/media/gpu/vaapi/vaapi_wrapper.h
++++ b/media/gpu/vaapi/vaapi_wrapper.h
+@@ -36,9 +36,9 @@
+ #include "third_party/abseil-cpp/absl/types/optional.h"
+ #include "ui/gfx/geometry/size.h"
+ 
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+ #include "ui/gfx/x/xproto.h"  // nogncheck
+-#endif  // USE_X11
++#endif                        // BUILDFLAG(USE_VAAPI_X11)
+ 
+ namespace gfx {
+ enum class BufferFormat;
+@@ -426,13 +426,13 @@ class MEDIA_GPU_EXPORT VaapiWrapper
+       const std::vector<std::pair<VABufferID, VABufferDescriptor>>& va_buffers)
+       WARN_UNUSED_RESULT;
+ 
+-#if defined(USE_X11)
++#if BUILDFLAG(USE_VAAPI_X11)
+   // Put data from |va_surface_id| into |x_pixmap| of size
+   // |dest_size|, converting/scaling to it.
+   bool PutSurfaceIntoPixmap(VASurfaceID va_surface_id,
+                             x11::Pixmap x_pixmap,
+                             gfx::Size dest_size) WARN_UNUSED_RESULT;
+-#endif  // USE_X11
++#endif  // BUILDFLAG(USE_VAAPI_X11)
+ 
+   // Creates a ScopedVAImage from a VASurface |va_surface_id| and map it into
+   // memory with the given |format| and |size|. If |format| is not equal to the
+diff --git a/ui/ozone/platform/x11/ozone_platform_x11.cc b/ui/ozone/platform/x11/ozone_platform_x11.cc
+index 8889828e0f..963dc7a0cd 100644
+--- a/ui/ozone/platform/x11/ozone_platform_x11.cc
++++ b/ui/ozone/platform/x11/ozone_platform_x11.cc
+@@ -208,6 +208,9 @@ class OzonePlatformX11 : public OzonePlatform,
+       properties->supports_global_application_menus = true;
+       properties->app_modal_dialogs_use_event_blocker = true;
+       properties->fetch_buffer_formats_for_gmb_on_gpu = true;
++#if defined(OS_LINUX)
++      properties->supports_vaapi = true;
++#endif
+ 
+       initialised = true;
+     }
+diff --git a/ui/ozone/public/ozone_platform.h b/ui/ozone/public/ozone_platform.h
+index df95f07486..2d7f44bbfa 100644
+--- a/ui/ozone/public/ozone_platform.h
++++ b/ui/ozone/public/ozone_platform.h
+@@ -15,6 +15,7 @@
+ #include "base/macros.h"
+ #include "base/message_loop/message_pump_type.h"
+ #include "base/single_thread_task_runner.h"
++#include "build/build_config.h"
+ #include "mojo/public/cpp/bindings/binder_map.h"
+ #include "ui/gfx/buffer_types.h"
+ #include "ui/gfx/native_widget_types.h"
+@@ -154,6 +155,15 @@ class COMPONENT_EXPORT(OZONE) OzonePlatform {
+     // Determines whether buffer formats should be fetched on GPU and passed
+     // back via gpu extra info.
+     bool fetch_buffer_formats_for_gmb_on_gpu = false;
++
++#if defined(OS_LINUX)
++    // TODO(crbug.com/1116701): add vaapi support for other Ozone platforms on
++    // Linux. At the moment, VA-API Linux implementation supports only X11
++    // backend. This implementation must be refactored to support Ozone
++    // properly. As a temporary solution, VA-API on Linux checks if vaapi is
++    // supported (which implicitly means that it is Ozone/X11).
++    bool supports_vaapi = false;
++#endif
+   };
+ 
+   // Groups platform properties that can only be known at run time.

--- a/extra-web/chromium/spec
+++ b/extra-web/chromium/spec
@@ -1,4 +1,5 @@
 VER=95.0.4638.54
+REL=1
 LAUNCHERVER=8
 SRCS="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$VER.tar.xz \
       https://github.com/foutrelis/chromium-launcher/archive/v$LAUNCHERVER.tar.gz \


### PR DESCRIPTION
Topic Description
-----------------

Fixes fail-to-launch Chromium 95.0.4638.54.

- Install missing `chrome_crashpad_handler`.
- Enable automatic platform detection for Ozone.
- (Arch Linux patch) Fix VA-API on X11.

Package(s) Affected
-------------------

- `chromium` v95.0.4638.54-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
