### PR TITLE
systemd-boot-friend: update to 0.10.0

### DIFF
--- a/extra-admin/systemd-boot-friend/spec
+++ b/extra-admin/systemd-boot-friend/spec
@@ -1,4 +1,4 @@
-VER=0.9.4
+VER=0.10.0
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/systemd-boot-friend-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226819"


### PR DESCRIPTION
Topic Description
-----------------

Update systemd-boot-friend to 0.10.0, this version includes updates for stateless design and shell completions.

Package(s) Affected
-------------------

systemd-boot-friend

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`