### PR TITLE
nvidia: manually create symlink for libglxserver_nvidia.so

### DIFF
--- a/extra-x11/nvidia/autobuild/build
+++ b/extra-x11/nvidia/autobuild/build
@@ -1,11 +1,12 @@
 set +e
 
 create_links() {
+    # FIXME: libglxserver_nvidia.so has no soname so this function won't create a symlink for it
     find "$PKGDIR" -type f -name '*.so*' ! -path '*xorg/*' -print0 | while read -d $'\0' _lib; do
         _soname=$(dirname "${_lib}")/$(readelf -d "${_lib}" | grep -Po 'SONAME.*: \[\K[^]]*' || true)
         _base=$(echo ${_soname} | sed -r 's/(.*).so.*/\1.so/')
-        [[ -e "${_soname}" ]] || ln -s $(basename "${_lib}") "${_soname}"
-        [[ -e "${_base}" ]] || ln -s $(basename "${_soname}") "${_base}"
+        [[ -e "${_soname}" ]] || ln -sv $(basename "${_lib}") "${_soname}"
+        [[ -e "${_base}" ]] || ln -sv $(basename "${_soname}") "${_base}"
     done
 }
 
@@ -246,7 +247,14 @@ install_if_amd64 644 firmware/gsp.bin "${PKGDIR}"/usr/lib/firmware/nvidia/${PKGV
 
 sanity_check
 
+abinfo "Creating symbolic links for shared objects"
 create_links
+
+abinfo "Manually symlinking glxserver_nvidia as it has no SONAME"
+ln -sv "libglxserver_nvidia.so.$PKGVER" \
+    "$PKGDIR"/usr/lib/nvidia/xorg/libglxserver_nvidia.so.1
+ln -sv "libglxserver_nvidia.so.$PKGVER" \
+    "$PKGDIR"/usr/lib/nvidia/xorg/libglxserver_nvidia.so
 
 abinfo "License and help texts"
 for i in README.txt LICENSE NVIDIA_Changelog; do

--- a/extra-x11/nvidia/spec
+++ b/extra-x11/nvidia/spec
@@ -1,4 +1,5 @@
 VER=470.74
+REL=1
 _SETTINGS_VER=470.74
 SRCS__AMD64="
 	file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER-no-compat32.run


### PR DESCRIPTION
Topic Description
-----------------

This PR fixed an issue introduced in nvidia 470.74 where `/usr/lib/nvidia/xorg/libglxserver_nvidia.so.470.74` is not correctly symlinked. X server will error out during start up due to `libglxserver_nvidia.so` not found.

Package(s) Affected
-------------------

* nvidia: 470.74-1

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
