### PR TITLE
fortunes-zh: Fix fortune path

### DIFF
--- a/extra-games/fortunes-zh/autobuild/beyond
+++ b/extra-games/fortunes-zh/autobuild/beyond
@@ -1,0 +1,5 @@
+abinfo "Renaming license file so autobuild can find it..."
+mv -v $SRCDIR/debian/copyright $SRCDIR/LICENSE
+abinfo "Installing manpage..."
+install -Dvm0644 $SRCDIR/man/fortune-zh.6 $PKGDIR/usr/share/man/man6/fortune-zh.6
+install -Dvm0644 $SRCDIR/man/fortune-zh.zh_CN.6 $PKGDIR/usr/share/man/zh_CN/man6/fortune-zh.6

--- a/extra-games/fortunes-zh/autobuild/patches/0001-bugfix-fix-path.patch
+++ b/extra-games/fortunes-zh/autobuild/patches/0001-bugfix-fix-path.patch
@@ -1,0 +1,23 @@
+--- a/Makefile
++++ b/Makefile
+@@ -1,6 +1,6 @@
+ DESTDIR=
+-FORTUNES=/usr/share/games/fortunes
+-GAMES=/usr/games
++FORTUNES=/usr/share/fortune
++GAMES=/usr/bin
+ 
+ TEXTS = tang300 song100 chinese
+ DATA  = tang300.dat song100.dat chinese.dat
+
+--- a/fortune-zh
++++ b/fortune-zh
+@@ -2,7 +2,7 @@
+ # fortune-zh
+ set -e
+
++FORTUNE="/usr/bin/fortune"
+-FORTUNE="/usr/games/fortune"
+ [ -x $FORTUNE ] || ( echo "E: Please install package 'fortune-mod'."; false )
+ 
+ # The old version (1.*) of fortune-zh contains only tang300 and song100.

--- a/extra-games/fortunes-zh/spec
+++ b/extra-games/fortunes-zh/spec
@@ -2,4 +2,4 @@ VER=2.97
 SRCS="git::commit=tags/debian/$VER::https://salsa.debian.org/chinese-team/fortunes-zh"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227649"
-REL=1
+REL=2


### PR DESCRIPTION


Topic Description
-----------------
The fortune path on the original Makefile is for Debian/Ubuntu.
This results in `fortune tang300` returning `No fortutnes found` instead of giving me a poem.

This patch fixes the issue of putting fortunes in the wrong location.

Package(s) Affected
-------------------

`fortunes-zh`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**


- [x] Architecture-independent `noarch`

**Secondary Architectures**

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

**Secondary Architectures**

