### PR TITLE
rustc: use bundled libgit2

### DIFF
--- a/extra-rust/rustc/autobuild/prepare
+++ b/extra-rust/rustc/autobuild/prepare
@@ -1,6 +1,8 @@
 export CFLAGS="${CFLAGS} -fPIC --target=${ARCH_TARGET[$ARCH]}"
 export CXXFLAGS="${CXXFLAGS} -fPIC --target=${ARCH_TARGET[$ARCH]}"
 export LDFLAGS="${LDFLAGS} -fPIC --target=${ARCH_TARGET[$ARCH]}"
+# disable system libgit2 and use vendored version
+export LIBGIT2_NO_PKG_CONFIG=1
 
 if [ "$ARCH" != "riscv64" ]; then
 	rust_target="${ARCH_TARGET[$ARCH]/-aosc/-unknown}"

--- a/extra-rust/rustc/spec
+++ b/extra-rust/rustc/spec
@@ -1,4 +1,5 @@
 VER=1.56.1
+REL=1
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.gz"
 CHKSUMS="sha256::c3898dfaadaa193dc88ddbc5345946a163211b58621df1cfff70186b4fc79511"
 CHKUPDATE="anitya::id=7635"


### PR DESCRIPTION
Topic Description
-----------------

Use bundled `libgit2` for `rustc`

Package(s) Affected
-------------------

`rustc`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [X] AMD64 `amd64`   
- [x] AArch64 `arm64`


**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`


Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**


- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

