### PR TITLE
texworks: fix to find Python 3 correctly

### DIFF
--- a/extra-tex/texworks/autobuild/defines
+++ b/extra-tex/texworks/autobuild/defines
@@ -5,6 +5,4 @@ PKGDES="A Qt based TeX editor endorsed by the TUG"
 
 CMAKE_AFTER="-DTW_BUILD_ID=AOSC \
              -DWITH_LUA=ON \
-             -DWITH_PYTHON=ON \
-             -DPYTHON_LIBRARIES=$LIBDIR/python${ABPY3VER} \
-             -DPYTHON_INCLUDE_DIR=$INCLUDE/python${ABPY3VER}"
+             -DWITH_PYTHON=ON"

--- a/extra-tex/texworks/autobuild/patches/0001-actions-Fix-to-find-Python-3-correctly.patch
+++ b/extra-tex/texworks/autobuild/patches/0001-actions-Fix-to-find-Python-3-correctly.patch
@@ -1,0 +1,97 @@
+From 4487808d1cb7424f69356b4d463432fa5fec605b Mon Sep 17 00:00:00 2001
+From: WhiredPlanck <whiredplanck@outlook.com>
+Date: Sun, 7 Nov 2021 11:48:33 +0800
+Subject: [PATCH] <actions> Fix to find Python 3 correctly
+
+---
+ CMakeLists.txt                            | 21 ++++++++++-----------
+ plugins-src/TWPythonPlugin/CMakeLists.txt |  4 ++--
+ 2 files changed, 12 insertions(+), 13 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 27f46440..d0ecc8be 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -337,17 +337,16 @@ ENDIF()
+ 
+ IF ( WITH_PYTHON )
+   IF ( USE_SYSTEM_PYTHON )
+-    SET(PYTHON_LIBRARIES "-F/System/Library/Frameworks -framework Python" CACHE PATH "Python library.")
+-    SET(PYTHON_INCLUDE_DIR "/System/Library/Framework/Python.framework/Headers" CACHE PATH "Python framework.")
+-    MARK_AS_ADVANCED(PYTHON_LIBRARIES)
+-    MARK_AS_ADVANCED(PYTHON_INCLUDE_DIR)
+-    SET(PYTHONLIBS_FOUND TRUE)
++    SET(Python3_LIBRARIES "-F/System/Library/Frameworks -framework Python" CACHE PATH "Python library.")
++    SET(Python3_INCLUDE_DIR "/System/Library/Framework/Python.framework/Headers" CACHE PATH "Python framework.")
++    MARK_AS_ADVANCED(Python3_LIBRARIES)
++    MARK_AS_ADVANCED(Python3_INCLUDE_DIR)
++    SET(Python3_Development_FOUND TRUE)
+   ELSE ()
+     # **NOTE**
+     # In order to find the correct version of 'PythonLibs', it seems that we need to run 'FIND_PACKAGE(PythonInterp)' firstly.
+     # In order to find the correct version of 'PythonInterp', we need to set 'PYTHONHOME' environment variable
+-    FIND_PACKAGE(PythonInterp)
+-    FIND_PACKAGE(PythonLibs)
++    FIND_PACKAGE(Python3 COMPONENTS Interpreter Development)
+   ENDIF ()
+ ENDIF()
+ 
+@@ -355,7 +354,7 @@ IF ( LUA_FOUND AND WITH_LUA AND NOT ${BUILD_SHARED_PLUGINS})
+   ADD_DEFINITIONS(-DQT_STATICPLUGIN -DSTATIC_LUA_SCRIPTING_PLUGIN)
+ ENDIF ()
+ 
+-IF ( PYTHONLIBS_FOUND AND WITH_PYTHON AND NOT ${BUILD_SHARED_PLUGINS})
++IF ( Python3_Development_FOUND AND WITH_PYTHON AND NOT ${BUILD_SHARED_PLUGINS})
+   ADD_DEFINITIONS(-DQT_STATICPLUGIN -DSTATIC_PYTHON_SCRIPTING_PLUGIN)
+ ENDIF ()
+ 
+@@ -417,7 +416,7 @@ IF ( LUA_FOUND AND WITH_LUA )
+   ADD_SUBDIRECTORY(${TeXworks_SOURCE_DIR}/plugins-src/TWLuaPlugin)
+ ENDIF ()
+ 
+-IF ( PYTHONLIBS_FOUND AND WITH_PYTHON )
++IF ( Python3_Development_FOUND AND WITH_PYTHON )
+   ADD_SUBDIRECTORY(${TeXworks_SOURCE_DIR}/plugins-src/TWPythonPlugin)
+ ENDIF ()
+ 
+@@ -520,7 +519,7 @@ IF ( WITH_LUA )
+   CONFIG_VERSION("Lua" "${LUA_VERSION_STRING}")
+ ENDIF()
+ if (WITH_PYTHON)
+-  CONFIG_VERSION("Python" "${PYTHON_VERSION_STRING}")
++  CONFIG_VERSION("Python" "${Python3_VERSION}")
+ endif()
+ CONFIG_VERSION("Qt" ${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}.${QT_VERSION_PATCH})
+ CONFIG_VERSION("SyncTeX" "${SYNCTEX_VERSION_STRING}")
+@@ -531,7 +530,7 @@ message("  Scripting")
+ CONFIG_YESNO("  ECMA scripting" ON)
+ CONFIG_YESNO("  QtScript scripting" WITH_QTSCRIPT)
+ CONFIG_YESNO("  Lua scripting plugin" LUA_FOUND)
+-CONFIG_YESNO("  Python scripting plugin" PYTHONLIBS_FOUND)
++CONFIG_YESNO("  Python scripting plugin" Python3_Development_FOUND)
+ message("")
+ 
+ CONFIG_INFO("Build ID" ${TW_BUILD_ID})
+diff --git a/plugins-src/TWPythonPlugin/CMakeLists.txt b/plugins-src/TWPythonPlugin/CMakeLists.txt
+index 07207a72..e0439ffe 100644
+--- a/plugins-src/TWPythonPlugin/CMakeLists.txt
++++ b/plugins-src/TWPythonPlugin/CMakeLists.txt
+@@ -28,13 +28,13 @@ if (NOT MSVC)
+ 	target_compile_options(TWPythonPlugin PRIVATE -Wno-old-style-cast)
+ endif ()
+ 
+-target_include_directories(TWPythonPlugin SYSTEM PRIVATE ${PYTHON_INCLUDE_DIRS})
++target_include_directories(TWPythonPlugin SYSTEM PRIVATE ${Python3_INCLUDE_DIRS})
+ target_include_directories(TWPythonPlugin PRIVATE ${TeXworks_SOURCE_DIR}/src)
+ 
+ # Specify link libraries even if the plugin is built statically so all the
+ # interface properties of the Qt targets (include directories, lib directories,
+ # etc.) are available
+-TARGET_LINK_LIBRARIES(TWPythonPlugin ${QT_LIBRARIES} ${PYTHON_LIBRARIES} ${TEXWORKS_ADDITIONAL_LIBS})
++TARGET_LINK_LIBRARIES(TWPythonPlugin ${QT_LIBRARIES} ${Python3_LIBRARIES} ${TEXWORKS_ADDITIONAL_LIBS})
+ IF (${BUILD_SHARED_PLUGINS})
+   INSTALL(TARGETS TWPythonPlugin
+     LIBRARY DESTINATION ${TeXworks_PLUGIN_DIR}
+-- 
+2.30.2
+

--- a/extra-tex/texworks/spec
+++ b/extra-tex/texworks/spec
@@ -1,4 +1,5 @@
 VER=0.6.6
+REL=1
 SRCS="tbl::https://github.com/TeXworks/texworks/archive/release-$VER.tar.gz"
 CHKSUMS="sha256::c0742fd76de0cacdd52bbf406788a4fe30ee281df2cf085531d98ee4b7f9b72f"
 CHKUPDATE="anitya::id=4961"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Modified the build script (CMakeLists.txt) of `texworks` to let it can find Python 3 correctly. Because the plugin of `texworks` related to Python now links to `libpython2.*.so*`...

Package(s) Affected
-------------------

`texworks`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
