### PR TITLE
fcitx5-pinyin-moegirl: update to 20211116

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,10 +1,9 @@
-VER=20211014
+VER=20211116
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::631e38158a662ff0a2c48fbfbb364c03ebea90cf252d867c907eddc23e207913 \
-         sha256::350c08b7d8d34018c96f44e6d867446d822a7c83e501e66cacafcfc977440d8e \
+CHKSUMS="sha256::7ed56c4ef26ac204684f3d45c2ff3790f8a286fcaaca8b2571532ecbe7702e92 \
+         sha256::75577e5d48b38bc809b3a02238a106747723bc4b89e6f1ca7f5a1a8c54f4c689 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

fcitx5-pinyin-moegirl: 20211116

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`