### PR TITLE
oolite: bump rel, rebuild for gnustep-base

### DIFF
--- a/extra-games/oolite/spec
+++ b/extra-games/oolite/spec
@@ -2,4 +2,4 @@ VER=1.90
 SRCS="git::commit=0b1ff49a78653669bfe8e153ae09699ba49cc496::https://github.com/OoliteProject/oolite.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17358"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

Rebuild oolite for gnustep-base

Package(s) Affected
-------------------

oolite

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   