### PR TITLE
[ci] zerotier-one: updated to 1.8.3

### DIFF
--- a/extra-network/zerotier-one/spec
+++ b/extra-network/zerotier-one/spec
@@ -1,4 +1,4 @@
-VER=1.4.6
-SRCS="tbl::https://github.com/zerotier/ZeroTierOne/archive/$VER.tar.gz"
-CHKSUMS="sha256::d1a0eeb03acfa446f67adf5901902d17de14b4648c21e160024acf476e3d4fba"
+VER=1.8.3
+SRCS="tbl::https://github.com/zerotier/ZeroTierOne/archive/refs/tags/$VER.tar.gz"
+CHKSUMS="sha256::f0813900c812910db2751bfb43d22a06f11dbcfbe4515e6b24fcad90ca46f665"
 CHKUPDATE="anitya::id=17578"


### PR DESCRIPTION
Topic Description
-----------------

zerotier-one: updated to 1.8.3

Package(s) Affected
-------------------

`zerotier-one`

Security Update?
----------------
No


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->


This is the first time for me to do the package, so there might be somewhere not well. I have tested the Makefile by `make install` on my `AOSC OS on Windows 10 x86_64 `.