### PR TITLE
i2pd: update to 2.40.0

### DIFF
--- a/extra-web/i2pd/spec
+++ b/extra-web/i2pd/spec
@@ -1,5 +1,5 @@
-VER=2.39.0
+VER=2.40.0
 SRCS="tbl::https://github.com/PurpleI2P/i2pd/archive/$VER.tar.gz"
-CHKSUMS="sha256::3ffeb614cec826e13b50e8306177018ecb8d873668dfe66aadc733ca9fcaa568"
+CHKSUMS="sha256::4443f484ad40753e892170a26c8ee8126e8338bf416d04eab0c55c1c94a4e193"
 SUBDIR="i2pd-$VER/build"
 CHKUPDATE="anitya::id=21355"


### PR DESCRIPTION
Topic Description
-----------------

Update i2pd to 2.40.0

Package(s) Affected
-------------------

i2pd

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
