### PR TITLE
Cryptography rework for python 3.10

### DIFF
--- a/extra-network/certbot/autobuild/defines
+++ b/extra-network/certbot/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=certbot
 PKGSEC=net
 PKGDEP="acme ca-certs configargparse configobj future josepy mock parsedatetime pyopenssl \
-        pypsutil pyrfc3339 pythondialog pytz requests setuptools six toolbelt zope-component zope-interface"
+        pypsutil pyrfc3339 pythondialog pytz requests setuptools six toolbelt zope-component zope-interface distro"
 PKGDES="A tool to automatically receive and install X.509 certificates to enable TLS on servers"
 
 NOPYTHON2=1

--- a/extra-network/certbot/spec
+++ b/extra-network/certbot/spec
@@ -1,5 +1,4 @@
-VER=1.18.0
+VER=1.21.0
 SRCS="tbl::https://pypi.io/packages/source/c/certbot/certbot-$VER.tar.gz"
-CHKSUMS="sha256::f3e56e18246ba5dc4951132e206844f7191d7b6a97264a005557fff25cd7287b"
+CHKSUMS="sha256::200b490ac303f75919abcf0d1e7e144caca101f1d6f064b4385ad9d240805192"
 CHKUPDATE="anitya::id=10690"
-REL=1

--- a/extra-python/cryptography/spec
+++ b/extra-python/cryptography/spec
@@ -1,5 +1,5 @@
 VER=3.4.8
-REL=4
+REL=5
 SRCS="https://pypi.io/packages/source/c/cryptography/cryptography-$VER.tar.gz"
 CHKSUMS="sha256::94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c"
 CHKUPDATE="anitya::id=5532"

--- a/extra-python/setuptools-rust/spec
+++ b/extra-python/setuptools-rust/spec
@@ -1,5 +1,5 @@
 VER=0.12.1
-REL=4
+REL=5
 SRCS="https://pypi.io/packages/source/s/setuptools-rust/setuptools-rust-$VER.tar.gz"
 CHKSUMS="sha256::647009e924f0ae439c7f3e0141a184a69ad247ecb9044c511dabde232d3d570e"
 CHKUPDATE="anitya::id=122284"


### PR DESCRIPTION
Topic Description
-----------------

This PR rebuilds part of mission critical packages for 3.10.

Package(s) Affected
-------------------

* setuptools-rust [noarch]
* cryptography
* certbot

Build Order
-----------

setuptools-rust cryptography certbot

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
