### PR TITLE
libvirt: adjust dep list

### DIFF
--- a/extra-emulation/libvirt/autobuild/defines
+++ b/extra-emulation/libvirt/autobuild/defines
@@ -4,9 +4,11 @@ PKGDEP="avahi bridge-utils curl cyrus-sasl dbus dmidecode dnsmasq \
         e2fsprogs ebtables gcc-runtime gettext gnutls iproute2 iptables \
         libcap-ng libgcrypt libgpg-error libnl libpcap libssh2 libxml2 \
         lxc netcat netcf numactl openssl parted pm-utils polkit python-2 \
-        radvd systemd yajl x11-lib libssh edk2 open-iscsi perl-xml-xpath"
+        radvd systemd yajl x11-lib libssh edk2 open-iscsi perl-xml-xpath \
+        libiscsi"
 BUILDDEP="docutils qemu zfs rpcsvc-proto"
-PKGSUG="qemu zfs"
+PKGSUG="zfs"
+PKGRECOM="qemu"
 PKGDES="API for controlling virtualization engines"
 
 MESON_AFTER="-Dlibexecdir=/usr/lib/libvirt"

--- a/extra-emulation/libvirt/spec
+++ b/extra-emulation/libvirt/spec
@@ -2,3 +2,4 @@ VER=7.4.0
 SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
 CHKSUMS="sha256::b366d73dee6ce77a226bedef592e0620ceb8e22e5998f60768017f79fc4ead26"
 CHKUPDATE="anitya::id=13830"
+REL=1


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

libvirt: adjust dep list

- Move qemu from PKGSUG to PKGRECOM
- Add libiscsi to PKGDEP to fix run

Package(s) Affected
-------------------

libvirt: 7.4.0-1

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
