### PR TITLE
osu-lazer: update to 2021.1206.0

### DIFF
--- a/extra-games/osu-lazer/spec
+++ b/extra-games/osu-lazer/spec
@@ -1,4 +1,4 @@
-VER=2021.1113.0
+VER=2021.1206.0
 SRCS="tbl::https://github.com/ppy/osu/archive/$VER.tar.gz"
-CHKSUMS="sha256::bed6036c7b856a1f88e414de7ebfaf566f3be77d68b36af925d3bdc348995ed5"
+CHKSUMS="sha256::17726c812ed4a382ce773ebd003ebc4b90770abb35cdd0d7406a5246263ef031"
 CHKUPDATE="anitya::id=227666"


### PR DESCRIPTION
Topic Description
-----------------

Update `osu-lazer` to 2021.1206.0

Package(s) Affected
-------------------

`osu-lazer`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   