### PR TITLE
Nvidia Drivers 495.44 + cuda 11.5.1

### DIFF
--- a/extra-devel/cuda/spec
+++ b/extra-devel/cuda/spec
@@ -1,6 +1,6 @@
-MAJOR_VER=11.4.2
-MINOR_VER=470.57.02
+MAJOR_VER=11.5.1
+MINOR_VER=495.29.05
 VER=${MAJOR_VER}+${MINOR_VER}
 SRCS="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${MAJOR_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS="sha256::bbd87ca0e913f837454a796367473513cddef555082e4d86ed9a38659cc81f0a"
+CHKSUMS="sha256::60bea2fc0fac95574015f865355afbf599422ec2c85554f5f052b292711a4bca"
 CHKUPDATE="anitya::id=13462"

--- a/extra-optenv32/nvidia+32/autobuild/beyond
+++ b/extra-optenv32/nvidia+32/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Install LICENSE"
+mkdir -vp "${PKGDIR}/usr/share/doc/nvidia+32/"
+install -Dvm644 "${SRCDIR}/NVIDIA-Linux-x86_64-$PKGVER/LICENSE" "${PKGDIR}"/usr/share/doc/nvidia+32/LICENSE

--- a/extra-optenv32/nvidia+32/autobuild/build
+++ b/extra-optenv32/nvidia+32/autobuild/build
@@ -47,8 +47,6 @@ install -Dvm755 "libnvidia-glsi.so.$PKGVER" \
 
 install -Dvm755 "libnvidia-allocator.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-allocator.so.$PKGVER
-install -Dvm755 "libnvidia-ifr.so.$PKGVER" \
-    "$PKGDIR"/opt/32/lib/libnvidia-ifr.so.$PKGVER
 install -Dvm755 "libnvidia-fbc.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-fbc.so.$PKGVER
 install -Dvm755 "libnvidia-encode.so.$PKGVER" \

--- a/extra-optenv32/nvidia+32/spec
+++ b/extra-optenv32/nvidia+32/spec
@@ -1,8 +1,8 @@
-VER=470.74
-_SETTINGS_VER=470.74
+VER=495.44
+_SETTINGS_VER=495.44
 SRCS="file::rename=NVIDIA-Linux-x86_64-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run \
       tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz"
-CHKSUMS="sha256::33e513dee329f2a9b106882979f1747eccb64eb698952c12cd030987cecadf6a \
-         sha256::73e9d42ff7a419c21682342a9f4fca645497a1c251d51dc8f65eadb7b40abd58"
+CHKSUMS="sha256::f1876a67815b160a67ef94e16d1b87550e4c302b327d98daec4d71dd5c7f8a48 \
+         sha256::55817dde2268edb0f46d63c6d3278d0e42a0e6566b97b851e35839e0ff7e4d6c"
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"

--- a/extra-x11/nvidia/autobuild/build
+++ b/extra-x11/nvidia/autobuild/build
@@ -10,16 +10,27 @@ create_links() {
     done
 }
 
+install_for_all() {
+    MOD="$1"
+    SRC="$2"
+    DESTDIR="$3"
+    install -Dvm${MOD} "$SRC" "$DESTDIR/$(basename ${SRC})"
+    return $?
+}
+
 install_if_amd64() {
     MOD="$1"
     SRC="$2"
     DESTDIR="$3"
     if [[ $NV_ARCH = x86_64 ]]; then
         install -Dvm${MOD} "$SRC" "$DESTDIR/$(basename ${SRC})"
-    else
+        return $?
+    elif [[ -f "${SRC}" ]]; then
         # Make sure the file really doesn't exist
-        [[ -f "${SRC}" ]] && abdie "File $SRC exists for non-amd64. Fix build scripts!"
+        aberr "File $SRC exists for non-amd64. Fix build scripts!"
+        abdie
     fi
+    return 0
 }
 
 sanity_check() {
@@ -125,9 +136,17 @@ install -Dvm755 "libnvidia-cfg.so.$PKGVER" \
 install -Dvm755 "libnvidia-ml.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-ml.so.$PKGVER
 
-install_if_amd64 755 "libnvidia-ifr.so.$PKGVER" "$PKGDIR"/usr/lib
-install_if_amd64 755 "libnvidia-fbc.so.$PKGVER" "$PKGDIR"/usr/lib
-install_if_amd64 755 "libnvidia-ngx.so.$PKGVER" "$PKGDIR"/usr/lib
+install_for_all 755 "libnvidia-fbc.so.$PKGVER" "$PKGDIR"/usr/lib
+install_for_all 755 "libnvidia-ngx.so.$PKGVER" "$PKGDIR"/usr/lib
+
+abinfo "Wayland support libraries and platform files..."
+install -Dvm755 "libnvidia-egl-gbm.so.1.1.0" \
+    "$PKGDIR"/usr/lib/libnvidia-egl-gbm.so.1.1.0
+install -Dvm644 "15_nvidia_gbm.json" \
+    "$PKGDIR"/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
+mkdir -vp "$PKGDIR/usr/lib/gbm"
+ln -svf "/usr/lib/libnvidia-allocator.so.${PKGVER}" \
+    "$PKGDIR"/usr/lib/gbm/nvidia-drm_gbm.so
 
 abinfo "Nvidia VM IR library..."
 install -Dvm755 "libnvidia-nvvm.so.4.0.0" \
@@ -166,8 +185,6 @@ install -Dvm755 "libnvidia-glvkspirv.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-glvkspirv.so.$PKGVER
 
 abinfo 'Vulkan Ray tracing extensions'
-install -Dvm755 "libnvidia-cbl.so.$PKGVER" \
-    "$PKGDIR"/usr/lib/libnvidia-cbl.so.$PKGVER
 install -Dvm755 "libnvidia-rtcore.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-rtcore.so.$PKGVER
 install -Dvm755 "libnvoptix.so.$PKGVER" \
@@ -243,7 +260,7 @@ install -Dvm755 systemd/system-sleep/nvidia "$PKGDIR"/usr/lib/systemd/system-sle
 install -Dvm755 systemd/nvidia-sleep.sh "$PKGDIR"/usr/bin/nvidia-sleep.sh
 
 abinfo "Card Firmware"
-install_if_amd64 644 firmware/gsp.bin "${PKGDIR}"/usr/lib/firmware/nvidia/${PKGVER}
+install_for_all 644 firmware/gsp.bin "${PKGDIR}"/usr/lib/firmware/nvidia/${PKGVER}
 
 sanity_check
 

--- a/extra-x11/nvidia/spec
+++ b/extra-x11/nvidia/spec
@@ -1,21 +1,20 @@
-VER=470.74
-REL=1
-_SETTINGS_VER=470.74
+VER=495.44
+_SETTINGS_VER=495.44
 SRCS__AMD64="
 	file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER-no-compat32.run
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__AMD64="
-	sha256::b1ab5db6bffd5246fc571ef252ca4406332bd204a12e4063d3fe0939224d0b56
-	sha256::73e9d42ff7a419c21682342a9f4fca645497a1c251d51dc8f65eadb7b40abd58
+	sha256::31b9c5b03bdff6fbbe3eea8780c240abe1541ba5c5094fadeae622db2d33c6f9
+	sha256::55817dde2268edb0f46d63c6d3278d0e42a0e6566b97b851e35839e0ff7e4d6c
 "
 SRCS__ARM64="
 	file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/aarch64/$VER/NVIDIA-Linux-aarch64-${VER}.run
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__ARM64="
-	sha256::d5bb2101574aeb0937f5039ff2297241684a9069e51ee54b0f0839fdef542226
-	sha256::73e9d42ff7a419c21682342a9f4fca645497a1c251d51dc8f65eadb7b40abd58
+	sha256::dd1eb463972f00a00c2ed05bdba1a496c88e0d446da95450d2a239097afac313
+	sha256::55817dde2268edb0f46d63c6d3278d0e42a0e6566b97b851e35839e0ff7e4d6c
 "
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates nvidia driver to 495.44 and cuda to 11.5.1. Nvidia seems to have no idea that their arm64 driver referenced a symbol removed in 5.14 (i.e. a while ago) and won't build on 5.15+ mainline arm64 header, thus the drivers are still marked amd64 only.

Package(s) Affected
-------------------

* nvidia, nvidia+32 [amd64 only]
* cuda [amd64 only]

Build Order
-----------

nvidia nvidia+32 cuda

Test Build(s) Done
------------------

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

- [x] AMD64 `amd64`   

<!-- TODO: CI to auto-fill architectural progress. -->
