### PR TITLE
fcitx5-pinyin-moegirl: update to 20211214

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20211116
+VER=20211214
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::7ed56c4ef26ac204684f3d45c2ff3790f8a286fcaaca8b2571532ecbe7702e92 \
-         sha256::75577e5d48b38bc809b3a02238a106747723bc4b89e6f1ca7f5a1a8c54f4c689 \
+CHKSUMS="sha256::ca30df74ccac0faa07c43c89dc1873ffd42de130fa711b4593e342a6402dcba2 \
+         sha256::7716fa99dff3778c2caaa90d9162a1a0d4c26014bc80021eaf30b7e001e968dd \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fcitx5-pinyin-moegirl: 20211214

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
