### PR TITLE
RDMA userspace support

### DIFF
--- a/extra-admin/mstflint/autobuild/beyond
+++ b/extra-admin/mstflint/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Byte compiling python stuff"
+(cd "${PKGDIR}"/usr/lib/mstflint/python_tools; python3 -m compileall -j 0 .)

--- a/extra-admin/mstflint/autobuild/defines
+++ b/extra-admin/mstflint/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=mstflint
+PKGSEC=admin
+PKGDEP="python-3 sqlite rdma-core"
+PKGDES="OpenFabrics Firmware Utility for Mellanox HCA/NIC"
+
+ABSHADOW=0
+# No upstream support
+FAIL_ARCH="loongson3"

--- a/extra-admin/mstflint/spec
+++ b/extra-admin/mstflint/spec
@@ -1,0 +1,4 @@
+VER=4.18.0+1
+SRCS="tbl::https://github.com/Mellanox/mstflint/releases/download/v${VER/+/-}/mstflint-${VER/+/-}.tar.gz"
+CHKSUMS="sha256::b5e98bb3c97a1d7cea2f4bd7a719b7d7af4765d576cf7e8198a8a88784a66641"
+CHKUPDATE="anitya::id=13357"

--- a/extra-admin/opensm/autobuild/beyond
+++ b/extra-admin/opensm/autobuild/beyond
@@ -1,0 +1,6 @@
+abinfo "Remove legacy sysvinit script"
+rm -rv "${PKGDIR}"/etc/init.d
+
+abinfo "Generating default configuration template"
+mkdir -pv "${PKGDIR}"/etc/rdma
+"${SRCDIR}"/abbuild/opensm/opensm -c "${PKGDIR}"/etc/rdma/opensm.conf

--- a/extra-admin/opensm/autobuild/conffiles
+++ b/extra-admin/opensm/autobuild/conffiles
@@ -1,0 +1,4 @@
+/etc/logrotate.d/opensm
+/etc/rdma/opensm.conf
+/etc/rdma/partitions.conf
+/etc/sysconfig/opensm

--- a/extra-admin/opensm/autobuild/defines
+++ b/extra-admin/opensm/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=opensm
+PKGSEC=admin
+PKGDEP="rdma-core gcc-runtime"
+BUILDDEP="systemd bison flex"
+PKGDES="OpenIB InfiniBand Subnet Manager and Management Utilities"
+
+AUTOTOOLS_AFTER="-with-opensm-conf-sub-dir=rdma"

--- a/extra-admin/opensm/autobuild/overrides/etc/logrotate.d/opensm
+++ b/extra-admin/opensm/autobuild/overrides/etc/logrotate.d/opensm
@@ -1,0 +1,7 @@
+/var/log/opensm.log {
+    missingok
+    notifempty
+    copytruncate
+    weekly
+    compress
+}

--- a/extra-admin/opensm/autobuild/overrides/etc/rdma/partitions.conf
+++ b/extra-admin/opensm/autobuild/overrides/etc/rdma/partitions.conf
@@ -1,0 +1,74 @@
+# For reference:
+# IPv4 IANA reserved multicast addresses:
+#   http://www.iana.org/assignments/multicast-addresses/multicast-addresses.txt
+# IPv6 IANA reserved multicast addresses:
+#   http://www.iana.org/assignments/ipv6-multicast-addresses/ipv6-multicast-addresses.xml
+#
+# mtu = 
+#   1 = 256
+#   2 = 512
+#   3 = 1024
+#   4 = 2048
+#   5 = 4096
+#
+# rate =
+#   2  = 2.5   GBit/s (SDR 1x)
+#   3  =  10   GBit/s (SDR 4x/QDR 1x)
+#   4  =  30   GBit/s (SDR 12x)
+#   5  =   5   GBit/s (DDR 1x)
+#   6  =  20   GBit/s (DDR 4x)
+#   7  =  40   GBit/s (QDR 4x)
+#   8  =  60   GBit/s (DDR 12x)
+#   9  =  80   GBit/s (QDR 8x)
+#   10 = 120   GBit/s (QDR 12x)
+# If ExtendedLinkSpeeds are supported, then these rate values are valid too
+#   11 =  14   GBit/s (FDR 1x)
+#   12 =  56   GBit/s (FDR 4x)
+#   13 = 112   GBit/s (FDR 8x)
+#   14 = 168   GBit/s (FDR 12x)
+#   15 =  25   GBit/s (EDR 1x)
+#   16 = 100   GBit/s (EDR 4x)
+#   17 = 200   GBit/s (EDR 8x)
+#   18 = 300   GBit/s (EDR 12x)
+
+Default=0x7fff, rate=3, mtu=4, scope=2, defmember=full:
+	ALL, ALL_SWITCHES=full;
+Default=0x7fff, ipoib, rate=3, mtu=4, scope=2:
+	mgid=ff12:401b::ffff:ffff	# IPv4 Broadcast address
+	mgid=ff12:401b::1		# IPv4 All Hosts group
+	mgid=ff12:401b::2		# IPv4 All Routers group
+	mgid=ff12:401b::16		# IPv4 IGMP group
+	mgid=ff12:401b::fb		# IPv4 mDNS group
+	mgid=ff12:401b::fc		# IPv4 Multicast Link Local Name Resolution group
+	mgid=ff12:401b::101		# IPv4 NTP group
+	mgid=ff12:401b::202		# IPv4 Sun RPC
+	mgid=ff12:601b::1		# IPv6 All Hosts group
+	mgid=ff12:601b::2		# IPv6 All Routers group
+	mgid=ff12:601b::16		# IPv6 MLDv2-capable Routers group
+	mgid=ff12:601b::fb		# IPv6 mDNS group
+	mgid=ff12:601b::101		# IPv6 NTP group
+	mgid=ff12:601b::202		# IPv6 Sun RPC group
+	mgid=ff12:601b::1:3		# IPv6 Multicast Link Local Name Resolution group
+	ALL=full, ALL_SWITCHES=full;
+
+# 40GBit, 4K MTU IPoIB example
+#ib0_2=0x0002, rate=7, mtu=5, scope=2, defmember=full:
+#	ALL, ALL_SWITCHES=full;
+#ib0_2=0x0002, ipoib, rate=7, mtu=5, scope=2:
+#	mgid=ff12:401b::ffff:ffff	# IPv4 Broadcast address
+#	mgid=ff12:401b::1		# IPv4 All Hosts group
+#	mgid=ff12:401b::2		# IPv4 All Routers group
+#	mgid=ff12:401b::16		# IPv4 IGMP group
+#	mgid=ff12:401b::fb		# IPv4 mDNS group
+#	mgid=ff12:401b::fc		# IPv4 Multicast Link Local Name Resolution group
+#	mgid=ff12:401b::101		# IPv4 NTP group
+#	mgid=ff12:401b::202		# IPv4 Sun RPC
+#	mgid=ff12:601b::1		# IPv6 All Hosts group
+#	mgid=ff12:601b::2		# IPv6 All Routers group
+#	mgid=ff12:601b::16		# IPv6 MLDv2-capable Routers group
+#	mgid=ff12:601b::fb		# IPv6 mDNS group
+#	mgid=ff12:601b::101		# IPv6 NTP group
+#	mgid=ff12:601b::202		# IPv6 Sun RPC group
+#	mgid=ff12:601b::1:3		# IPv6 Multicast Link Local Name Resolution group
+#	ALL=full, ALL_SWITCHES=full;
+

--- a/extra-admin/opensm/autobuild/overrides/etc/sysconfig/opensm
+++ b/extra-admin/opensm/autobuild/overrides/etc/sysconfig/opensm
@@ -1,0 +1,72 @@
+# Problem #1: Multiple IB fabrics needing a subnet manager
+#
+# In the event that a machine has more than one IB subnet attached,
+# and that machine is an opensm server, by default, opensm will
+# only attach to one port and will not manage the fabric on the
+# other port.  There are two ways to solve this problem:
+#
+# 1) Start opensm on multiple machines and configure it to manage
+#    different fabrics on each machine
+# 2) Configure opensm to start multiple instances on a single
+#    machine
+#
+# Both solutions to this problem require non-standard configurations.
+# In other words, you would normally have to modify /etc/rdma/opensm.conf
+# and once you do that, the file will no longer be updated for new
+# options when opensm is upgraded.  In an effort to allow people to
+# have more than one subnet managed by opensm without having to modify
+# the system default opensm.conf file, we have enabled two methods
+# for modifying the default opensm config items needed to enable
+# multiple fabric management.
+#
+# Method #1: Create multiple opensm.conf files in non-standard locations
+#   Copy /etc/rdma/opensm.conf to /etc/rdma/opensm.conf.<number>
+#     (do this once for each instance you want started)
+#   Edit each copy of the opensm.conf file to reflect the necessary changes
+#     for a multiple instance startup.  If you need to manage more than
+#     one fabric, you will have to change the guid option in each file
+#     to specify the guid of the specific port you want opensm attached
+#     to.
+#
+# The advantage to method #1 is that, on the off chance you want to do
+# really special custom things on different ports, like have different
+# QoS settings depending on which port you are attached to, you have the
+# freedom to edit any and all settings for each instance without those
+# changes affecting other instances or being lost when opensm upgrades.
+#
+# Method #2: Specify multiple GUIDS variable entries in this file
+#   Uncomment the below GUIDS variable and enter each guid you need to attach
+#     to into the list.  If using this method you need to enter each
+#     guid into the list as we won't attach to any default ports, only
+#     those specified in the list.
+#
+#GUIDS="0x0002c90300048ca1 0x0002c90300048ca2"
+#
+# The obvious advantage to method #2 is that it's simple and doesn't
+# clutter up your file system, but it is far more limited in what you
+# can do.  If you enable method #2, then even if you create the files
+# referenced in method #1, they will be ignored.
+#
+# Problem #2: Activating a backup subnet manager
+#
+# The default priority of opensm is set so that it wants to be the
+# primary subnet manager.  This is great when you are only running
+# opensm on one server, but if you want to have a non-primary opensm
+# instance for failover, then you have to manually edit the opensm.conf
+# file like for problem #1.  This carries with it all the problems
+# listed above.  If you wish to enable opensm as a non-primary manager,
+# then you can uncomment the PRIORITY variable below and set it to
+# some number between 0 and 15, where 15 is the highest priority and
+# the primary manager, with 0 being the lowest backup server.  This method
+# will work with the GUIDS option above, and also with the multiple
+# config files in method #1 above.  However, only a single priority is
+# supported here.  If you wanted more than one priority (say this machine
+# is the primary on the first fabric, and second on the second fabric,
+# while the other opensm server is primary on the second fabric and
+# second on the primary), then the only way to do that is to use method #1
+# above and individually edit the config files.  If you edit the config
+# files to set the priority and then also set the priority here, then
+# this setting will override the config files and render that particular
+# edit useless.
+#
+#PRIORITY=15

--- a/extra-admin/opensm/autobuild/overrides/usr/lib/systemd/system/opensm-cache.mount
+++ b/extra-admin/opensm/autobuild/overrides/usr/lib/systemd/system/opensm-cache.mount
@@ -1,0 +1,14 @@
+[Unit]
+Description=OpenSM Cache directory (/var/cache/opensm)
+ConditionPathIsSymbolicLink=!/var/cache/opensm
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=swap.target
+
+[Mount]
+What=tmpfs
+Where=/var/cache/opensm
+Type=tmpfs
+Options=mode=1777,strictatime,nosuid,nodev,size=50%,nr_inodes=400k
+

--- a/extra-admin/opensm/autobuild/overrides/usr/lib/systemd/system/opensm.service
+++ b/extra-admin/opensm/autobuild/overrides/usr/lib/systemd/system/opensm.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Starts the OpenSM InfiniBand fabric Subnet Manager
+Documentation=man:opensm
+DefaultDependencies=false
+Before=network.target remote-fs-pre.target
+After=rdma-hw.target
+[Service]
+Type=forking
+ExecStart=/usr/libexec/opensm-launch
+[Install]
+WantedBy=network.target

--- a/extra-admin/opensm/autobuild/overrides/usr/libexec/opensm-launch
+++ b/extra-admin/opensm/autobuild/overrides/usr/libexec/opensm-launch
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Launch the necessary OpenSM daemons for systemd
+#
+# sysconfig: /etc/sysconfig/opensm
+# config: /etc/rdma/opensm.conf
+#
+
+shopt -s nullglob
+
+prog=/usr/sbin/opensm
+[ -f /etc/sysconfig/opensm ] && . /etc/sysconfig/opensm
+
+[ -n "$PRIORITY" ] && prio="-p $PRIORITY"
+
+if [ -z "$GUIDS" ]; then
+	CONFIGS=""
+	CONFIG_CNT=0
+	for conf in /etc/rdma/opensm.conf.[0-9]*; do
+		CONFIGS="$CONFIGS $conf"
+		let CONFIG_CNT++
+	done
+else
+	GUID_CNT=0
+	for guid in $GUIDS; do
+		let GUID_CNT++
+	done
+fi
+# Start opensm
+if [ -n "$GUIDS" ]; then
+	SUBNET_COUNT=0
+	for guid in $GUIDS; do
+		SUBNET_PREFIX=`printf "0xfe800000000000%02d" $SUBNET_COUNT`
+		(while true; do $prog $prio -g $guid --subnet_prefix $SUBNET_PREFIX; sleep 30; done) &
+		let SUBNET_COUNT++
+	done
+elif [ -n "$CONFIGS" ]; then
+	for config in $CONFIGS; do
+		(while true; do $prog $prio -F $config; sleep 30; done) &
+	done
+else
+	(while true; do $prog $prio; sleep 30; done) &
+fi
+exit 0

--- a/extra-admin/opensm/spec
+++ b/extra-admin/opensm/spec
@@ -1,0 +1,4 @@
+VER=3.3.24
+SRCS="tbl::https://github.com/linux-rdma/opensm/releases/download/${VER}/opensm-${VER}.tar.gz"
+CHKSUMS="sha256::a3335e371a4b044427574dff9d324c6c334e502e8facdf58bc070ee151d7e460"
+CHKUPDATE="anitya::id=2563"

--- a/extra-admin/rdma-core/autobuild/beyond
+++ b/extra-admin/rdma-core/autobuild/beyond
@@ -1,0 +1,16 @@
+abinfo "Installing misc setup scripts"
+pushd ${SRCDIR}/redhat
+	install -Dvm644 rdma.conf "${PKGDIR}/etc/rdma/rdma.conf"
+	install -Dvm755 rdma.mlx4-setup.sh "${PKGDIR}/usr/lib/rdma/mlx4-setup.sh"
+	install -Dvm644 rdma.mlx4.conf "${PKGDIR}/etc/rdma/mlx4.conf"
+	install -Dvm644 rdma.mlx4.sys.modprobe "${PKGDIR}/usr/lib/modprobe.d/libmlx4.conf"
+	install -Dvm755 rdma.modules-setup.sh "${PKGDIR}/usr/lib/dracut/modules.d/05rdma/module-setup.sh"
+popd
+
+abinfo "Moving udev rules to the right place"
+mkdir -vp "${PKGDIR}/usr/lib/udev/rules.d"
+mv -v "${PKGDIR}/etc/udev/rules.d/"* "${PKGDIR}/usr/lib/udev/rules.d"
+rm -rvf "${PKGDIR}/etc/udev"
+
+abinfo "We don't need /etc/init.d stuff"
+rm -rvf "${PKGDIR}/etc/init.d"

--- a/extra-admin/rdma-core/autobuild/conffiles
+++ b/extra-admin/rdma-core/autobuild/conffiles
@@ -1,0 +1,15 @@
+/etc/infiniband-diags/error_thresholds
+/etc/infiniband-diags/ibdiag.conf
+/etc/iwpmd.conf
+/etc/modprobe.d/mlx4.conf
+/etc/modprobe.d/truescale.conf
+/etc/rdma/mlx4.conf
+/etc/rdma/modules/infiniband.conf
+/etc/rdma/modules/iwarp.conf
+/etc/rdma/modules/iwpmd.conf
+/etc/rdma/modules/opa.conf
+/etc/rdma/modules/rdma.conf
+/etc/rdma/modules/roce.conf
+/etc/rdma/modules/srp_daemon.conf
+/etc/rdma/rdma.conf
+/etc/srp_daemon.conf

--- a/extra-admin/rdma-core/autobuild/defines
+++ b/extra-admin/rdma-core/autobuild/defines
@@ -1,0 +1,17 @@
+PKGNAME=rdma-core
+PKGSEC=admin
+PKGDEP="ethtool libnl"
+BUILDDEP="systemd python-3 docutils cython"
+PKGDES="RDMA userspace libraries and utilites"
+
+PKGPROV="rdma infiniband-diags"
+
+NOLTO=1
+
+CMAKE_AFTER="-DCMAKE_INSTALL_SYSTEMD_BINDIR=/usr/lib/systemd \
+             -DCMAKE_INSTALL_RUNDIR=/run \
+             -DCMAKE_INSTALL_SBINDIR=/usr/bin \
+             -DCMAKE_INSTALL_LIBEXECDIR=/usr/lib/rdma \
+             -DCMAKE_INSTALL_PYTHON_ARCH_LIB=/usr/lib/python3.10 \
+             -DCMAKE_INSTALL_PERLDIR=/usr/share/perl5/vendor_perl \
+             -DCMAKE_INSTALL_SYSCONFDIR=/etc"

--- a/extra-admin/rdma-core/autobuild/patches/0001-provide-memory-barrier-on-loongson3.patch
+++ b/extra-admin/rdma-core/autobuild/patches/0001-provide-memory-barrier-on-loongson3.patch
@@ -1,0 +1,30 @@
+diff -Naur rdma-core-38.0/util/udma_barrier.h rdma-core-38.0-modded/util/udma_barrier.h
+--- rdma-core-38.0/util/udma_barrier.h	2021-11-18 19:40:18.000000000 +0000
++++ rdma-core-38.0-modded/util/udma_barrier.h	2021-12-22 04:56:05.849477469 +0000
+@@ -98,6 +98,8 @@
+ #define udma_to_device_barrier() asm volatile("" ::: "memory")
+ #elif defined(__loongarch__)
+ #define udma_to_device_barrier() asm volatile("dbar 0" ::: "memory")
++#elif defined(__MIPSEL__) && defined(__mips64)
++#define udma_to_device_barrier() asm volatile("sync 0" ::: "memory")
+ #else
+ #error No architecture specific memory barrier defines found!
+ #endif
+@@ -132,6 +134,8 @@
+ #define udma_from_device_barrier() asm volatile("" ::: "memory")
+ #elif defined(__loongarch__)
+ #define udma_from_device_barrier() asm volatile("dbar 0" ::: "memory")
++#elif defined(__MIPSEL__) && defined(__mips64)
++#define udma_from_device_barrier() asm volatile("sync 0" ::: "memory")
+ #else
+ #error No architecture specific memory barrier defines found!
+ #endif
+@@ -198,6 +202,8 @@
+ #define mmio_flush_writes() asm volatile("" ::: "memory")
+ #elif defined(__loongarch__)
+ #define mmio_flush_writes() asm volatile("dbar 0" ::: "memory")
++#elif defined(__MIPSEL__) && defined(__mips64)
++#define mmio_flush_writes() asm volatile("sync 0" ::: "memory")
+ #else
+ #error No architecture specific memory barrier defines found!
+ #endif

--- a/extra-admin/rdma-core/autobuild/prepare
+++ b/extra-admin/rdma-core/autobuild/prepare
@@ -1,0 +1,5 @@
+find ${SRCDIR}/redhat -type f -exec sed --in-place \
+	--expression='s|/usr/libexec|/usr/lib/rdma|g' \
+	--expression='s|/usr/sbin|/usr/bin|g' \
+	--expression='s|/sbin|/usr/bin|g' \
+	'{}' '+'

--- a/extra-admin/rdma-core/spec
+++ b/extra-admin/rdma-core/spec
@@ -1,0 +1,4 @@
+VER=38.0
+SRCS="tbl::https://github.com/linux-rdma/rdma-core/releases/download/v${VER}/rdma-core-${VER}.tar.gz"
+CHKSUMS="sha256::9a8dcc9fae13c7d8a41fb2303927fc5b00aefffc12485bd7aae4cfd4f9f27b10"
+CHKUPDATE="anitya::id=12907"


### PR DESCRIPTION
Topic Description
-----------------

This PR adds RDMA / Infiniband userspace utilities.

Package(s) Affected
-------------------

- rdma-core: basic utilities - `ibstat`, `ibportstate` and such
- opensm: Infiniband Subnet Manager, central routing / partition controller within a physically connected Infiniband network
- mstflint: Open source version of Mellanox firmware tool, used to burn firmware updates onto IB HCA cards - unbuilable on loongson3

Build Order
-----------

rdma-core opensm mstflint

Test Build(s) Done
------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
