### PR TITLE
ncdu: update to 1.16

### DIFF
--- a/extra-utils/ncdu/spec
+++ b/extra-utils/ncdu/spec
@@ -1,4 +1,4 @@
-VER=1.14.1
+VER=1.16
 SRCS="tbl::https://dev.yorhel.nl/download/ncdu-$VER.tar.gz"
-CHKSUMS="sha256::be31e0e8c13a0189f2a186936f7e298c6390ebdc573bb4a1330bc1fcbf56e13e"
+CHKSUMS="sha256::2b915752a183fae014b5e5b1f0a135b4b408de7488c716e325217c2513980fd4"
 CHKUPDATE="anitya::id=6045"


### PR DESCRIPTION
Topic Description
-----------------

Update ncdu to 1.16

Package(s) Affected
-------------------

ncdu

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`