### PR TITLE
MATE Desktop Survey on 20211222

### DIFF
--- a/extra-mate/mate-dock-applet/autobuild/defines
+++ b/extra-mate/mate-dock-applet/autobuild/defines
@@ -4,5 +4,8 @@ PKGDEP="bamf libnotify mate-panel pycairo dbus-python pygobject-3 pillow \
         pyxdg python-xlib"
 PKGDES="Application dock for the MATE panel"
 
-AUTOTOOLS_AFTER="--with-gtk3 PYTHON=/usr/bin/python3"
+ABSHADOW=0
+AUTOTOOLS_AFTER="--with-gtk3 \
+                 PYTHON=/usr/bin/python3"
+
 ABHOST=noarch

--- a/extra-mate/mate-dock-applet/spec
+++ b/extra-mate/mate-dock-applet/spec
@@ -1,4 +1,4 @@
-VER=20.04.0
+VER=21.10.0
 SRCS="tbl::https://github.com/robint99/mate-dock-applet/archive/$VER.tar.gz"
-CHKSUMS="sha256::8c89b2d4041fa907b3f3104a4deb53ec48412996b817fef1b931d05450273059"
+CHKSUMS="sha256::42f06dcac13aae19a9bbd16272854c896044aa0301a69319cab86ef4ffd8b09c"
 CHKUPDATE="anitya::id=230611"

--- a/extra-mate/mate-media/autobuild/beyond
+++ b/extra-mate/mate-media/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Symlinking mate-volume-control-applet to /usr/bin ..."
+ln -sv ../libexec/mate-volume-control-applet \
+    "$PKGDIR"/usr/bin/mate-volume-control-applet

--- a/extra-mate/mate-media/spec
+++ b/extra-mate/mate-media/spec
@@ -1,4 +1,5 @@
 VER=1.26.0
+REL=1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-media-$VER.tar.xz"
 CHKSUMS="sha256::8b731b203fd8219ccc2f2ced40e4301823a17f7940acf3cec72b4494a3fe3c3a"
 CHKUPDATE="anitya::id=230614"

--- a/extra-mate/mate-menu/autobuild/defines
+++ b/extra-mate/mate-menu/autobuild/defines
@@ -6,5 +6,6 @@ BUILDDEP="python-distutils-extra setuptools intltool"
 PKGDES="Advanced menu for MATE Panel"
 
 ABTYPE=python
-NOPYTHON3=1
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/extra-mate/mate-menu/spec
+++ b/extra-mate/mate-menu/spec
@@ -1,4 +1,5 @@
 VER=20.04.3
+REL=1
 SRCS="tbl::https://github.com/ubuntu-mate/mate-menu/archive/$VER.tar.gz"
 CHKSUMS="sha256::7cba18164cf52e11c2ab8d11b0861a54e9f9f495f66df3f491c1b2edab0c49e4"
 CHKUPDATE="anitya::id=230615"

--- a/extra-mate/mate-panel/spec
+++ b/extra-mate/mate-panel/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-panel-$VER.tar.xz"
-CHKSUMS="sha256::092e1ed2177b3a13cfb7df19667b06083009210e48294c18c8a68b9b3c47ea64"
+CHKSUMS="sha256::683038c483456e5068f5bb20c3d565936700c9898005c7149ee7aa44e5cc110d"
 CHKUPDATE="anitya::id=230619"

--- a/extra-mate/mate-screensaver/spec
+++ b/extra-mate/mate-screensaver/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-screensaver-$VER.tar.xz"
-CHKSUMS="sha256::41514032206da2a62105ead90fdce95639d5ea234d1e67d533fd4c5b56feaf76"
+CHKSUMS="sha256::4fbdb21ea4a59ea8de33ea9bf776d869753e49295604664c30e220e09659b8bc"
 CHKUPDATE="anitya::id=230622"

--- a/extra-mate/mate-themes/spec
+++ b/extra-mate/mate-themes/spec
@@ -1,5 +1,5 @@
-VER=3.22.22
+VER=3.22.23
 
 SRCS="tbl::https://github.com/mate-desktop/mate-themes/archive/v$VER.tar.gz"
-CHKSUMS="sha256::f17902ba2933e55d05fb3a77313551e8de0dc6893bb3129d2972ce703b3d13f4"
+CHKSUMS="sha256::004ae5ed5bb55798d8da3cca936442f386476eb5710b92b15f7bddb93a7a23c8"
 CHKUPDATE="anitya::id=10938"

--- a/extra-mate/mate-tweak/spec
+++ b/extra-mate/mate-tweak/spec
@@ -1,5 +1,5 @@
 VER=21.04.3
-REL=1
+REL=2
 SRCS="tbl::https://github.com/ubuntu-mate/mate-tweak/archive/$VER.tar.gz"
-CHKSUMS="sha256::936a196c51f61ea1c3ef06531a5f3189b6739ff0c18783809bf7d2ebc2a057f6"
+CHKSUMS="sha256::1bacc9b92960c712697e0c44fbcaaebed9683b4ff899af5af88506f7e13e1aff"
 CHKUPDATE="anitya::id=230627"

--- a/extra-mate/mozo/spec
+++ b/extra-mate/mozo/spec
@@ -1,5 +1,5 @@
 VER=1.26.0
-REL=1
+REL=2
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mozo-$VER.tar.xz"
-CHKSUMS="sha256::4642cbf985fa0d72e205ad7f6abfb7d008e3117e2c5e331340f2bc6466c3ddc2"
+CHKSUMS="sha256::0f24429a3b037bd0688ec4c391d9d8781e42b23ef345f5e50af1e72c5ef2fa39"
 CHKUPDATE="anitya::id=230632"


### PR DESCRIPTION
Topic Description
-----------------

Survey application and component updates for MATE Desktop (`extra-mate/*`).

Package(s) Affected
-------------------

- `mate-dock-applet` v21.10.0
- `mate-panel` v1.26.1
- `mate-screensaver` v1.26.1
- `mate-themes` v3.22.23
- `mate-tweak` v21.10.0
- `mozo` v1.26.1

Security Update?
----------------

No

Build Order
-----------

```
extra-mate/mate-media
extra-mate/mate-menu
extra-mate/mate-dock-applet
extra-mate/mate-panel
extra-mate/mate-screensaver
extra-mate/mate-themes
extra-mate/mate-tweak
extra-mate/mozo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`