### PR TITLE
jemalloc: upgrade to 5.2.1, set page size to max possible for arm64

### DIFF
--- a/extra-libs/jemalloc/autobuild/defines
+++ b/extra-libs/jemalloc/autobuild/defines
@@ -7,3 +7,12 @@ ABSHADOW=0
 NOSTATIC=0
 
 PKGBREAK="blender<=2.75 mariadb<=10.1"
+
+# Note: Apparently jemalloc compiled for a larger page size can operate
+# on a system with a smaller page size.
+# Largest possible page for arm64 is 64K = 2^16.
+# Next level huge page for arm64 is 32M = 2^25.
+AUTOTOOLS_AFTER__ARM64="
+	--with-lg-page=16
+	--with-lg-hugepage=25
+"

--- a/extra-libs/jemalloc/spec
+++ b/extra-libs/jemalloc/spec
@@ -1,5 +1,4 @@
-VER=5.1.0
-REL=3
+VER=5.2.1
 SRCS="tbl::https://github.com/jemalloc/jemalloc/releases/download/$VER/jemalloc-$VER.tar.bz2"
-CHKSUMS="sha256::5396e61cc6103ac393136c309fae09e44d74743c86f90e266948c50f3dbb7268"
+CHKSUMS="sha256::34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6"
 CHKUPDATE="anitya::id=1441"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates jemalloc to 5.2.1 and sets page size and hugepage size on ARM64 to 64K and 32M respectively. jemalloc compiled this way is still fully functional on devices using smaller page sizes.

Package(s) Affected
-------------------

jemalloc

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**


- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
