### PR TITLE
Python 3.10 Rework

### DIFF
--- a/extra-admin/packagekit/autobuild/beyond
+++ b/extra-admin/packagekit/autobuild/beyond
@@ -6,3 +6,6 @@ install -dv \
     -o root -g 27 \
     -m 750 \
     "$PKGDIR"/usr/share/polkit-1/rules.d
+
+abinfo "Byte-compiling python bindings"
+python3 -m compileall -o 2 -j 0 "${PKGDIR}/usr/lib/python${ABPY3VER}/site-packages"

--- a/extra-admin/packagekit/autobuild/defines
+++ b/extra-admin/packagekit/autobuild/defines
@@ -7,8 +7,9 @@ BUILDDEP="gobject-introspection intltool gtk-doc apt vala \
 PKGDES="An abstraction layer for package managers for installing and updating packages"
 
 MESON_AFTER="-Dpackaging_backend=aptcc \
-             -Dsysetmd=true \
+             -Dsystemd=true \
              -Dsystemdsystemunitdir=/usr/lib/systemd/system \
+             -Dsystemduserunitdir=/usr/lib/systemd/user \
              -Doffline_update=true \
              -Dgobject_introspection=true \
              -Dman_pages=true \

--- a/extra-admin/packagekit/spec
+++ b/extra-admin/packagekit/spec
@@ -1,5 +1,4 @@
-VER=1.2.3
-REL=1
+VER=1.2.4
 SRCS="https://github.com/PackageKit/PackageKit/archive/PACKAGEKIT_${VER//./_}.tar.gz"
-CHKSUMS="sha256::9dadb1db9cfd5d3e106e6976c5296bee5d0fc846d0b288f8f07971c417d1f5a1"
+CHKSUMS="sha256::4a7b0a41ffa56ad8af67156c46ecb9d4eb439b31a4cb581d959bd5480444954b"
 CHKUPDATE="anitya::id=8932"

--- a/extra-cinnamon/cinnamon/autobuild/beyond
+++ b/extra-cinnamon/cinnamon/autobuild/beyond
@@ -1,0 +1,9 @@
+abinfo "Moving python module to the right place"
+MODULE_DIR="${PKGDIR}/usr/lib/python${ABPY3VER}/site-packages"
+mkdir -p "${MODULE_DIR}"
+mv -v "${PKGDIR}/usr/lib/python3/dist-packages/cinnamon" -t "${MODULE_DIR}"
+rmdir -v "${PKGDIR}/usr/lib/python3/dist-packages"
+rmdir -v "${PKGDIR}/usr/lib/python3"
+
+abinfo "Byte-compiling modules"
+(cd "${MODULE_DIR}"; python3 -m compileall -o 2 -j 0 .)

--- a/extra-cinnamon/cinnamon/spec
+++ b/extra-cinnamon/cinnamon/spec
@@ -1,4 +1,5 @@
 VER=5.0.2
+REL=1
 SRCS="tbl::https://github.com/linuxmint/Cinnamon/archive/$VER.tar.gz"
 CHKSUMS="sha256::9ae7043a56eedd9fb0ec253d7f4513087cc431179824341d87a1828d2e094b13"
 CHKUPDATE="anitya::id=6265"

--- a/extra-cinnamon/nemo-extensions/spec
+++ b/extra-cinnamon/nemo-extensions/spec
@@ -1,4 +1,5 @@
 VER=5.0.0+git20210623
+REL=1
 SRCS="git::commit=120575909a00387b53bbc588c2340996a71a1918::https://github.com/linuxmint/nemo-extensions"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6392"

--- a/extra-devel/conan/spec
+++ b/extra-devel/conan/spec
@@ -1,4 +1,4 @@
-VER=1.39.0
+VER=1.43.2
 SRCS="tbl::https://github.com/conan-io/conan/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::4ee6daadf2fc19f9f311cb9a187d90e7ea3eb90674c86fad607f77ccaace6203"
+CHKSUMS="sha256::181ab990eacd070936ef66c3e06c6ef5a1e40bfb96ddb52a59da042e14dec61b"
 CHKUPDATE="anitya::id=234751"

--- a/extra-enlightenment/python-efl/spec
+++ b/extra-enlightenment/python-efl/spec
@@ -1,4 +1,5 @@
 VER=1.25.0
+REL=1
 SRCS="tbl::https://download.enlightenment.org/rel/bindings/python/python-efl-$VER.tar.xz"
 CHKSUMS="sha256::99e06df773647acfb8e04786d6958bee5b8deae41d996ccaa68d7cca7b30612e"
 CHKUPDATE="anitya::id=24623"

--- a/extra-fonts/fonttools/autobuild/defines
+++ b/extra-fonts/fonttools/autobuild/defines
@@ -6,4 +6,3 @@ PKGDES="A library for manipulating fonts"
 
 NOPYTHON2=1
 ABTYPE=python
-ABHOST=noarch

--- a/extra-fonts/fonttools/spec
+++ b/extra-fonts/fonttools/spec
@@ -1,4 +1,4 @@
-VER=4.26.2
+VER=4.28.5
 SRCS="tbl::https://github.com/fonttools/fonttools/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::89046803aeb717209be15c1edbd24ba1c36797508ed89707b0dc879c8ec29b4c"
+CHKSUMS="sha256::77d22ec2684d75f48176fe21f317c8f13a5abed3f00e2d4772b2f4a3acc012d1"
 CHKUPDATE="anitya::id=7388"

--- a/extra-games/m64py/autobuild/beyond
+++ b/extra-games/m64py/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Byte-compiling python modules"
+python3 -m compileall -o 2 -j 0 "${PKGDIR}/usr/lib/python${ABPY3VER}/site-packages"

--- a/extra-games/m64py/spec
+++ b/extra-games/m64py/spec
@@ -2,4 +2,4 @@ VER=0.2.5
 SRCS="tbl::https://downloads.sourceforge.net/m64py/m64py-$VER.tar.gz"
 CHKSUMS="sha256::0223569ec031b6e6c1d96ac51a19b9262cccce7705c84b5ca5044c94afb75fca"
 CHKUPDATE="anitya::id=12271"
-REL=1
+REL=2

--- a/extra-gis/owslib/spec
+++ b/extra-gis/owslib/spec
@@ -1,5 +1,0 @@
-VER=0.25.0
-REL=3
-SRCS="tbl::https://pypi.io/packages/source/O/OWSLib/OWSLib-$VER.tar.gz"
-CHKSUMS="sha256::20d79bce0be10277caa36f3134826bd0065325df0301a55b2c8b1c338d8d8f0a"
-CHKUPDATE="anitya::id=3945"

--- a/extra-gnome/meld/autobuild/beyond
+++ b/extra-gnome/meld/autobuild/beyond
@@ -1,3 +1,2 @@
-abinfo "Dropping icon, schema caches ..."
-rm -v "$PKGDIR"/usr/share/icons/hicolor/icon-theme.cache
-rm -v "$PKGDIR"/usr/share/glib-2.0/schemas/gschemas.compiled
+abinfo "Byte-compiling python modules"
+python3 -m compileall -j 0 "${PKGDIR}/usr/lib/python3.10/site-packages"

--- a/extra-gnome/meld/autobuild/defines
+++ b/extra-gnome/meld/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=meld
 PKGSEC=gnome
-PKGDEP="gsettings-desktop-schemas gtksourceview-3 py2cairo \
+PKGDEP="gsettings-desktop-schemas gtksourceview-4 py2cairo \
         pygobject-3 dbus-python"
 BUILDDEP="appstream-glib gtk-4 intltool itstool"
 PKGDES="A visual diff and merge tool targeted at developers"

--- a/extra-gnome/meld/spec
+++ b/extra-gnome/meld/spec
@@ -1,5 +1,5 @@
-VER=3.20.4
+VER=3.21.0
 SRCS="tbl::https://download.gnome.org/sources/meld/${VER:0:4}/meld-$VER.tar.xz"
-CHKSUMS="sha256::f48e10eec606f687a87061e78668f6bb40e63e032175c4c7033636b65a157d13"
+CHKSUMS="sha256::b680114d5ab793324549fd58f4eb202d8e280c0633a0b765ede6dfb34160a81b"
 CHKUPDATE="anitya::id=5520"
 REL=1

--- a/extra-graphics/graphviz/spec
+++ b/extra-graphics/graphviz/spec
@@ -1,4 +1,4 @@
-VER=2.49.0
-SRCS="tbl::https://ftp.osuosl.org/pub/blfs/conglomeration/graphviz/graphviz-$VER.tar.gz"
-CHKSUMS="sha256::a062ccd940abbde6e3c45462323b2ede54b9374fed86f464c11bc4c0bd57fd04"
+VER=2.50.0
+SRCS="tbl::https://gitlab.com/graphviz/graphviz/-/archive/${VER}/graphviz-${VER}.tar.gz"
+CHKSUMS="sha256::afa48581f764a35e148909cc96a0308ec2356b5225b64af12492f3392f20ef1c"
 CHKUPDATE="anitya::id=1249"

--- a/extra-i18n/ibus/spec
+++ b/extra-i18n/ibus/spec
@@ -1,4 +1,5 @@
 VER=1.5.25
+REL=1
 SRCS="tbl::https://github.com/ibus/ibus/archive/$VER.tar.gz"
 CHKSUMS="sha256::cb6fbb166e19ccd5a179ec3c0bda4fcfe8676980271993e0c3fce2e0a9d64c16"
 CHKUPDATE="anitya::id=1352"

--- a/extra-mate/mate-tweak/spec
+++ b/extra-mate/mate-tweak/spec
@@ -1,5 +1,5 @@
 VER=21.04.3
-
+REL=1
 SRCS="tbl::https://github.com/ubuntu-mate/mate-tweak/archive/$VER.tar.gz"
 CHKSUMS="sha256::936a196c51f61ea1c3ef06531a5f3189b6739ff0c18783809bf7d2ebc2a057f6"
 CHKUPDATE="anitya::id=230627"

--- a/extra-mate/mozo/spec
+++ b/extra-mate/mozo/spec
@@ -1,5 +1,5 @@
 VER=1.26.0
-
+REL=1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mozo-$VER.tar.xz"
 CHKSUMS="sha256::4642cbf985fa0d72e205ad7f6abfb7d008e3117e2c5e331340f2bc6466c3ddc2"
 CHKUPDATE="anitya::id=230632"

--- a/extra-multimedia/mlt-6/autobuild/beyond
+++ b/extra-multimedia/mlt-6/autobuild/beyond
@@ -1,2 +1,4 @@
 abinfo "Setting binary name as melt6 to fix conflicts with mlt 7 ..."
 mv -v "$PKGDIR"/usr/bin/melt{,6}
+abinfo "Byte-compiling python modules"
+python3 -m compileall -o 2 -j 0 "${PKGDIR}/usr/lib/python${ABPY3VER}/site-packages"

--- a/extra-multimedia/mlt-6/spec
+++ b/extra-multimedia/mlt-6/spec
@@ -1,4 +1,4 @@
 VER=6.26.1
-REL=1
+REL=2
 SRCS="https://github.com/mltframework/mlt/archive/v$VER.tar.gz"
 CHKSUMS="sha256::8a484bbbf51f33e25312757531f3ad2ce20607149d20fcfcb40a3c1e60b20b4e"

--- a/extra-multimedia/you-get/spec
+++ b/extra-multimedia/you-get/spec
@@ -1,4 +1,4 @@
-VER=0.4.1545
+VER=0.4.1555
 SRCS="tbl::https://github.com/soimort/you-get/archive/v$VER.tar.gz"
-CHKSUMS="sha256::3c600486774ceb81e6aa3946d3138a4bb47fd2f2a3da50b5293de359ab78b162"
+CHKSUMS="sha256::5590b4c2c8c45985182f211ac7419faa9142f4a09cd5fcd10f13fa43c16de67e"
 CHKUPDATE="anitya::id=13697"

--- a/extra-network/libteam/spec
+++ b/extra-network/libteam/spec
@@ -1,4 +1,5 @@
 VER=1.31
+REL=1
 SRCS="https://github.com/jpirko/libteam/archive/refs/tags/v${VER}.tar.gz"
 CHKSUMS="sha256::c69f7cf5a98203d66db10e67b396fe325b77a5a9491d1e07e8a07cba3ba841bb"
 CHKUPDATE="anitya::id=231716"

--- a/extra-python/async-timeout/spec
+++ b/extra-python/async-timeout/spec
@@ -1,5 +1,4 @@
-VER=3.0.1
+VER=4.0.2
 SRCS="tbl::https://github.com/aio-libs/async-timeout/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::d0a7a927ed6b922835e1b014dfcaa9982caccbb25131320582cc660af7c93949"
-CHKUPDATE="anitya::id=37104"
-REL=1
+CHKSUMS="sha256::1eb41fc35a0a24461b00f3479553972c99300e194eb212ff8b816c90c084d1d4"
+CcHKUPDATE="anitya::id=37104"

--- a/extra-python/deprecation/spec
+++ b/extra-python/deprecation/spec
@@ -1,4 +1,4 @@
-VER=2.0.7
+VER=2.1.0
 SRCS="tbl::https://pypi.io/packages/source/d/deprecation/deprecation-$VER.tar.gz"
-CHKSUMS="sha256::c0392f676a6146f0238db5744d73e786a43510d54033f80994ef2f4c9df192ed"
+CHKSUMS="sha256::72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff"
 CHKUPDATE="anitya::id=19902"

--- a/extra-python/distro/spec
+++ b/extra-python/distro/spec
@@ -1,5 +1,4 @@
-VER=1.4.0
+VER=1.6.0
 SRCS="tbl::https://pypi.io/packages/source/d/distro/distro-$VER.tar.gz"
-CHKSUMS="sha256::362dde65d846d23baee4b5c058c8586f219b5a54be1cf5fc6ff55c4578392f57"
-REL=2
+CHKSUMS="sha256::83f5e5a09f9c5f68f60173de572930effbcc0287bb84fdc4426cb4168c088424"
 CHKUPDATE="anitya::id=12202"

--- a/extra-python/grpcio/autobuild/prepare
+++ b/extra-python/grpcio/autobuild/prepare
@@ -3,7 +3,7 @@ _gtestver=c9ccac7cb7345901884aabf5d1a786cfa6e2f397
 wget "https://github.com/google/googletest/archive/$_gtestver/googletest-$_gtestver.tar.gz"
 
 abinfo "Dwonloading abseil-cpp..."
-_abseilcppver=20210324.2
+_abseilcppver=20211102.0
 wget "https://github.com/abseil/abseil-cpp/archive/$_abseilcppver/abseil-cpp-$_abseilcppver.tar.gz"
 
 

--- a/extra-python/grpcio/spec
+++ b/extra-python/grpcio/spec
@@ -1,4 +1,4 @@
-VER=1.38.1
+VER=1.43.0
 SRCS="tbl::https://github.com/grpc/grpc/archive/v$VER/grpc-$VER.tar.gz"
-CHKSUMS="sha256::f60e5b112913bf776a22c16a3053cc02cf55e60bf27a959fd54d7aaf8e2da6e8"
+CHKSUMS="sha256::9647220c699cea4dafa92ec0917c25c7812be51a18143af047e20f3fb05adddc"
 CHKUPDATE="anitya::id=18429"

--- a/extra-python/jedi/autobuild/defines
+++ b/extra-python/jedi/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=jedi
 PKGSEC=python
 PKGDEP="parso"
-BUILDDEP="setuptools"
+BUILDDEP="setuptools-python3"
 PKGDES="Awesome autocompletion for Python"
 
+NOPYTHON2=1
 ABHOST=noarch

--- a/extra-python/jedi/spec
+++ b/extra-python/jedi/spec
@@ -1,4 +1,4 @@
-VER=0.18.0
+VER=0.18.1
 SRCS="tbl::https://pypi.io/packages/source/j/jedi/jedi-$VER.tar.gz"
-CHKSUMS="sha256::92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707"
+CHKSUMS="sha256::74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"
 CHKUPDATE="anitya::id=3893"

--- a/extra-python/patch-ng/spec
+++ b/extra-python/patch-ng/spec
@@ -1,4 +1,5 @@
 VER=1.17.4
+REL=1
 SRCS="tbl::https://pypi.io/packages/source/p/patch-ng/patch-ng-$VER.tar.gz"
 CHKSUMS="sha256::627abc5bd723c8b481e96849b9734b10065426224d4d22cd44137004ac0d4ace"
 CHKUPDATE="anitya::id=27132"

--- a/extra-python/pluginbase/spec
+++ b/extra-python/pluginbase/spec
@@ -1,4 +1,5 @@
 VER=1.0.1
+REL=1
 SRCS="tbl::https://pypi.io/packages/source/p/pluginbase/pluginbase-$VER.tar.gz"
 CHKSUMS="sha256::ff6c33a98fce232e9c73841d787a643de574937069f0d18147028d70d7dee287"
 CHKUPDATE="anitya::id=201798"

--- a/extra-python/pyjwt/autobuild/defines
+++ b/extra-python/pyjwt/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=pyjwt
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 BUILDDEP="setuptools"
 PKGDES="JSON Web Token implementation in Python"
 

--- a/extra-python/pyjwt/spec
+++ b/extra-python/pyjwt/spec
@@ -1,4 +1,4 @@
-VER=1.7.1
+VER=2.3.0
 SRCS="tbl::https://pypi.io/packages/source/P/PyJWT/PyJWT-$VER.tar.gz"
-CHKSUMS="sha256::8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"
+CHKSUMS="sha256::b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41"
 CHKUPDATE="anitya::id=anitya::id=5653"

--- a/extra-python/pyserial/spec
+++ b/extra-python/pyserial/spec
@@ -1,5 +1,4 @@
-VER=3.4
-REL=3
-SRCS="tbl::https://files.pythonhosted.org/packages/cc/74/11b04703ec416717b247d789103277269d567db575d2fd88f25d9767fe3d/pyserial-3.4.tar.gz"
-CHKSUMS="sha256::6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627"
+VER=3.5
+SRCS="tbl::https://pypi.io/packages/source/p/pyserial/pyserial-$VER.tar.gz"
+CHKSUMS="sha256::3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb"
 CHKUPDATE="anitya::id=135906"

--- a/extra-python/pysol-cards/spec
+++ b/extra-python/pysol-cards/spec
@@ -1,4 +1,4 @@
-VER=0.10.2
+VER=0.14.2
 SRCS="tbl::https://pypi.io/packages/source/p/pysol-cards/pysol_cards-$VER.tar.gz"
-CHKSUMS="sha256::2e9f5bfe5b6df3760ca274731e92820423066831df6351bbfdf832e32bbcc76e"
+CHKSUMS="sha256::c08de857577bc3eec970c3add3c45b365316cc2844acd6083bb56ea31d40eaf0"
 CHKUPDATE="anitya::id=19639"

--- a/extra-python/python-node-semver/spec
+++ b/extra-python/python-node-semver/spec
@@ -1,4 +1,4 @@
-VER=0.6.1
-SRCS="tbl::https://github.com/podhmo/python-semver/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::442252eea5feb6ad797a3443609010cf5af26201681597283759060bfa3588ef"
+VER=0.8.0
+SRCS="tbl::https://github.com/podhmo/python-node-semver/archive/refs/tags/$VER.tar.gz"
+CHKSUMS="sha256::6cd24f3a71b263e814b1ad9f248913a72751ffb5d142af3cb704b1d31828cdb6"
 CHKUPDATE="anitya::id=50150"

--- a/extra-python/ruamel-yaml/spec
+++ b/extra-python/ruamel-yaml/spec
@@ -1,5 +1,4 @@
-VER=0.17.4
+VER=0.17.19
 SRCS="https://pypi.io/packages/source/r/ruamel.yaml/ruamel.yaml-$VER.tar.gz"
-CHKSUMS="sha256::44bc6b54fddd45e4bc0619059196679f9e8b79c027f4131bb072e6a22f4d5e28"
+CHKSUMS="sha256::b9ce9a925d0f0c35a1dbba56b40f253c53cd526b0fa81cf7b1d24996f28fb1d7"
 CHKUPDATE="anitya::id=66067"
-REL=1

--- a/extra-scientific/caffe-cpu/autobuild/build
+++ b/extra-scientific/caffe-cpu/autobuild/build
@@ -35,7 +35,9 @@ abinfo "Installing Python bindings ..."
 install -Dvm755 "$SRCDIR"/distribute/python/*.py \
     "$PKGDIR"/usr/bin
 cp -av "$SRCDIR"/distribute/python/caffe \
-    "$PKGDIR"/usr/lib/python${PYVER}/site-packages/
+    "$PKGDIR"/usr/lib/python${ABPY3VER}/site-packages/
+abinfo "Byte-compiling modules"
+(cd "$PKGDIR/usr/lib/python${ABPY3VER}"; python3 -m compileall -o 2 -j 0 .)
 
 abinfo "Installing caffe.proto ..."
 install -Dvm644 "$SRCDIR"/distribute/proto/caffe.proto \

--- a/extra-scientific/caffe-cpu/spec
+++ b/extra-scientific/caffe-cpu/spec
@@ -1,5 +1,5 @@
 VER=1.0
-REL=14
+REL=15
 SRCS="https://github.com/BVLC/caffe/archive/$VER.tar.gz"
 CHKSUMS="sha256::71d3c9eb8a183150f965a465824d01fe82826c22505f7aa314f700ace03fa77f"
 CHKUPDATE="anitya::id=231461"

--- a/extra-utils/hydrapaper/autobuild/beyond
+++ b/extra-utils/hydrapaper/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Byte-compiling python modules"
+python3 -m compileall -j 0 "${PKGDIR}/usr/lib/python3.10/site-packages"

--- a/extra-utils/hydrapaper/spec
+++ b/extra-utils/hydrapaper/spec
@@ -2,4 +2,4 @@ VER=1.12
 SRCS="tbl::https://gitlab.com/gabmus/HydraPaper/-/archive/$VER/HydraPaper-$VER.tar.gz"
 CHKSUMS="sha256::6e11486d796a3c829e6ff059a07036a5bfd16fc6ac44ab51b80e28fc5bc2ac07"
 CHKUPDATE="anitya::id=27563"
-REL=1
+REL=2

--- a/extra-utils/mat/spec
+++ b/extra-utils/mat/spec
@@ -1,4 +1,4 @@
-VER=0.12.1
+VER=0.12.2
 SRCS="tbl::https://0xacab.org/jvoisin/mat2/-/archive/${VER}/mat2-${VER}.tar.gz"
-CHKSUMS="sha256::5f1cf47c61cc137b5a3d0520c4d4db27706b045f2425ee3837148b2397a26e65"
+CHKSUMS="sha256::f3ef46fc0ccc13fd055991841c7fbee8a1322ba895d83a8da404bdaf0c638b98"
 CHKUPDATE="anitya::id=231612"

--- a/extra-utils/piper/autobuild/beyond
+++ b/extra-utils/piper/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Byte compiling python modules"
+python3 -m compileall -o 2 -j 0 "${PKGDIR}/usr/lib/python${ABPY3VER}/site-packages"

--- a/extra-utils/piper/autobuild/defines
+++ b/extra-utils/piper/autobuild/defines
@@ -4,4 +4,7 @@ PKGDEP="libratbag lxml pycairo pygobject-3 python-evdev"
 BUILDDEP="meson ninja"
 PKGDES="GTK+ interface to configure gaming mice"
 
+MESON_AFTER="
+	-Dtests=false
+"
 ABHOST=noarch

--- a/extra-utils/piper/spec
+++ b/extra-utils/piper/spec
@@ -1,5 +1,4 @@
-VER=0.5.1
+VER=0.6
 SRCS="https://github.com/libratbag/piper/archive/$VER.tar.gz"
-CHKSUMS="sha256::6a5f4ecfd8f9883a2db9c9692adbf2a3c43d3a6485929428ee9bfe2d421d3cce"
+CHKSUMS="sha256::aa2fb9b63cd926067bdf2842013169e279fe2a159e8575f392fc1f042cdec001"
 CHKUPDATE="anitya::id=18304"
-REL=1

--- a/extra-utils/zbar/spec
+++ b/extra-utils/zbar/spec
@@ -1,4 +1,5 @@
 VER=0.23.90
+REL=1
 SRCS="tbl::https://www.linuxtv.org/downloads/zbar/zbar-$VER.tar.gz"
 CHKSUMS="sha256::ff857dd7e3dbe043dac3765b5182c91dfd0477800713a75d15287d797cee60fa"
 CHKUPDATE="anitya::id=13689"

--- a/extra-x11/xapps/spec
+++ b/extra-x11/xapps/spec
@@ -1,4 +1,4 @@
-VER=2.2.2
+VER=2.2.6
 SRCS="tbl::https://github.com/linuxmint/xapps/archive/$VER.tar.gz"
-CHKSUMS="sha256::1384eb5c3ef395aa7736346521639c7b7904f471f4a55ccd415a66c1031e8f75"
+CHKSUMS="sha256::f3f5ab006383b9c0e231d30f8a0be727d0352fd4733ca3ea168883205793fcfd"
 CHKUPDATE="anitya::id=12203"

--- a/extra-x11/xpra/autobuild/defines
+++ b/extra-x11/xpra/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=xpra
 PKGSEC=x11
-PKGDEP="cryptography dbus-python ffmpeg libvpx netifaces numpy pillow \
+PKGDEP="cryptography dbus-python ffmpeg libvpx netifaces numpy pillow gtk-3 \
         pycups pygtkglext python-lz4 rencode x264 x265 xf86-video-dummy pygobject-3"
 BUILDDEP="cython setuptools"
 PKGDES="An open-source multi-platform persistent remote display server and client"

--- a/extra-x11/xpra/spec
+++ b/extra-x11/xpra/spec
@@ -1,4 +1,4 @@
-VER=4.2.2
+VER=4.3
 SRCS="tbl::https://github.com/Xpra-org/xpra/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::e1928b5ac2d25c7cad8ad8965b507552097d45fea30b7d0e9f6eb14da4d78bac"
+CHKSUMS="sha256::d9ec407a514e0dba650196b90103eb47ec9c6b09acefc1ab71bbd3e9d6663c10"
 CHKUPDATE="anitya::id=5445"

--- a/extra-xfce/catfish/spec
+++ b/extra-xfce/catfish/spec
@@ -1,4 +1,4 @@
-VER=4.16.0
+VER=4.16.3
 SRCS="https://archive.xfce.org/src/apps/catfish/${VER%.*}/catfish-$VER.tar.bz2"
-CHKSUMS="sha256::1f6facee57a659af560f06024ca6f98aa4d638bf57a8bcfb613b4dc70fcc3b47"
+CHKSUMS="sha256::e9a99a62d10981391508dd43f3cbfa2d50a69bd6b7d1eeef7d30ba4c673dcfda"
 CHKUPDATE="anitya::id=255"


### PR DESCRIPTION
Topic Description
-----------------

This PR fixes various issues that eluded initial python 3.10 survey #3531 .

Package(s) Affected
-------------------

xapps cinnamon caffe-cpu libibus ibus pluginbase nemo-extensions hydrapaper pyjwt distro meld python-efl grpcio catfish pyserial deprecation patch-ng python-node-semver conan jedi async-timeout mate-tweak mozo mlt-6 you-get graphviz piper pysol-cards packagekit zbar m64py mat doxyqml libteam fonttools ruamel-yaml xpra

Build Order
-----------

Build in the order listed above. mat and m64py fail on mips.

Test Build(s) Done
------------------
**Primary Architectures**
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
