### PR TITLE
Duplicity 0.8.21 + dependency survey

### DIFF
--- a/extra-python/b2sdk/spec
+++ b/extra-python/b2sdk/spec
@@ -1,5 +1,4 @@
-VER=1.4.0
+VER=1.14.0
 SRCS="tbl::https://pypi.io/packages/source/b/b2sdk/b2sdk-$VER.tar.gz"
-CHKSUMS="sha256::fb82cbaef5dd7499b62622010fc8e328944ca8cbdd00b485530ab6600de1129d"
+CHKSUMS="sha256::900da60f9e569e02405b85db35541a79e1cac776ace5d054498b107982ea443c"
 CHKUPDATE="anitya::id=23387"
-REL=1

--- a/extra-python/boto3/spec
+++ b/extra-python/boto3/spec
@@ -1,5 +1,4 @@
-VER=1.17.27
+VER=1.20.26
 SRCS="tbl::https://pypi.io/packages/source/b/boto3/boto3-$VER.tar.gz"
-CHKSUMS="sha256::fa41987f9f71368013767306d9522b627946a01b4843938a26fb19cc8adb06c0"
+CHKSUMS="sha256::9c13f5c8fadf29088fac5feab849399169b6e8438c3b9a2310abdb7e5013ab65"
 CHKUPDATE="anitya::id=29737"
-REL=1

--- a/extra-python/botocore/spec
+++ b/extra-python/botocore/spec
@@ -1,5 +1,4 @@
-VER=1.20.21
+VER=1.23.26
 SRCS="tbl::https://pypi.io/packages/source/b/botocore/botocore-$VER.tar.gz"
-CHKSUMS="sha256::b604bbda4205b1a463c20d8434c7ddce1abbc3f6a4d5bf911e2b7774b2807f03"
-CHKUPDATE="anitya::id=29738"
-REL=1
+CHKSUMS="sha256::0a933e3af6ecf79666beb2dfcb52a60f8ad1fee7df507f2a9202fe26fe569483"
+CcHKUPDATE="anitya::id=29738"

--- a/extra-python/logfury/spec
+++ b/extra-python/logfury/spec
@@ -1,5 +1,4 @@
-VER=0.1.2
+VER=1.0.1
 SRCS="tbl::https://pypi.io/packages/source/l/logfury/logfury-$VER.tar.gz"
-CHKSUMS="sha256::42da58fbbd4e6fdb9e5b6b9098e94c249ba9cebfae125643329c8636768edcd3"
+CHKSUMS="sha256::130a5daceab9ad534924252ddf70482aa2c96662b3a3825a7d30981d03b76a26"
 CHKUPDATE="anitya::id=231357"
-REL=1

--- a/extra-python/s3transfer/spec
+++ b/extra-python/s3transfer/spec
@@ -1,5 +1,4 @@
-VER=0.3.4
+VER=0.5.0
 SRCS="tbl::https://pypi.io/packages/source/s/s3transfer/s3transfer-$VER.tar.gz"
-CHKSUMS="sha256::7fdddb4f22275cf1d32129e21f056337fd2a80b6ccef1664528145b72c49e6d2"
+CHKSUMS="sha256::50ed823e1dc5868ad40c8dc92072f757aa0e653a192845c94a3b676f4a62da4c"
 CHKUPDATE="anitya::id=62534"
-REL=1

--- a/extra-python/tqdm/autobuild/defines
+++ b/extra-python/tqdm/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=tqdm
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 BUILDDEP="setuptools"
 PKGDES="Fast, extensible progress meter"
 
 ABHOST=noarch
 ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/tqdm/spec
+++ b/extra-python/tqdm/spec
@@ -1,5 +1,4 @@
-VER=4.40.2
+VER=4.62.3
 SRCS="tbl::https://pypi.io/packages/source/t/tqdm/tqdm-$VER.tar.gz"
-CHKSUMS="sha256::f0ab01cf3ae5673d18f918700c0165e5fad0f26b5ebe4b34f62ead92686b5340"
-REL=2
+CHKSUMS="sha256::d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d"
 CHKUPDATE="anitya::id=36051"

--- a/extra-utils/duplicity/spec
+++ b/extra-utils/duplicity/spec
@@ -1,5 +1,4 @@
-VER=0.8.18
+VER=0.8.21
 SRCS="tbl::https://launchpad.net/duplicity/${VER%.*}-series/${VER}/+download/duplicity-${VER}.tar.gz"
-CHKSUMS="sha256::2643fea0f52920a0fb114069c78389f9621f1c24db7f26bda77bbc239b01ae53"
+CHKSUMS="sha256::57fea6764674718cd6f6d499e6de92c973ba4f5e74dd94fc5e644713355ca451"
 CHKUPDATE="anitya::id=635"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

This PR updates duplicity to 0.8.21 and a bunch of its dependencies.

Package(s) Affected
-------------------

#### AWS/S3 access libraries

* botocore: 1.23.26 [noarch]
* s3transfer: 0.5.0 [noarch]
* boto3 1.20.26 [noarch]

#### B2 access libraries + dependencies

* logfury: 1.0.1 [noarch]
* tqdm: 4.62.3 [noarch] [python2 support dropped]
* b2sdk: 1.14.0 [noarch]

#### 本体

* duplicity: 0.8.21 

Build Order
-----------

botocore s3transfer boto3 logfury tqdm b2sdk duplicity

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
