### PR TITLE
XDG Desktop Portal Backends Update

### DIFF
--- a/extra-admin/flatpak/autobuild/defines
+++ b/extra-admin/flatpak/autobuild/defines
@@ -8,6 +8,6 @@ PKGDES="Application deployment framework for desktop applications"
 AUTOTOOLS_AFTER="--disable-gtk-doc --with-priv-mode=setuid \
                  --with-dbus-config-dir=/usr/share/dbus-1/system.d \
                  --libexecdir=/usr/lib/flatpak"
-PKGBREAK="xdg-app<=0.5.2 discover<=5.21.4 gnome-builder<=3.40.0 gnome-software<=40.0 \
-          malcontent<=0.10.1 xdg-desktop-portal<=1.8.0"
+PKGBREAK="xdg-app<=0.5.2 discover<=5.21.4 gnome-builder<=41.2 gnome-software<=40.4 \
+          malcontent<=0.10.1-1 xdg-desktop-portal<=1.8.0"
 PKGREP="xdg-app<=0.5.2"

--- a/extra-admin/flatpak/spec
+++ b/extra-admin/flatpak/spec
@@ -1,8 +1,7 @@
-VER=1.11.2
-REL=1
+VER=1.12.2
 SRCS="tbl::https://github.com/flatpak/flatpak/releases/download/$VER/flatpak-$VER.tar.xz \
       file::rename=flathub.flatpakrepo::https://flathub.org/repo/flathub.flatpakrepo"
-CHKSUMS="sha256::8799cf835d8b11deef5495a91a4cef258d882417c4483fbd594a2c7cc79b6684 \
+CHKSUMS="sha256::df1eb464f9142c11627f99f04f6a5c02c868bbb145489b8902cb6c105e774b75 \
          sha256::3371dd250e61d9e1633630073fefda153cd4426f72f4afa0c3373ae2e8fea03a"
 CHKUPDATE="anitya::id=6377"
 SUBDIR="flatpak-$VER"

--- a/extra-admin/xdg-desktop-portal-gtk/autobuild/defines
+++ b/extra-admin/xdg-desktop-portal-gtk/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=xdg-desktop-portal-gtk
 PKGSEC=admin
-PKGDEP="gnome-desktop gtk-3 xdg-desktop-portal"
+PKGDEP="dbus gsettings-desktop-schemas gtk-3 xdg-desktop-portal"
 BUILDDEP="xmlto docbook-xsl"
 PKGDES="Portal frontend service to flatpak (GTK+ interface)"

--- a/extra-admin/xdg-desktop-portal-gtk/spec
+++ b/extra-admin/xdg-desktop-portal-gtk/spec
@@ -1,5 +1,4 @@
-VER=1.8.0
-REL=2
+VER=1.12.0
 SRCS="tbl::https://github.com/flatpak/xdg-desktop-portal-gtk/releases/download/$VER/xdg-desktop-portal-gtk-$VER.tar.xz"
-CHKSUMS="sha256::a52529ed321e044ca9adca5e9718d9ba57c414a2634dd4109df344c5b9eed77f"
+CHKSUMS="sha256::aa0220edf9ceeadbb915f72ed981e16adaaebf8789f79b513c328ee2083b68a1"
 CHKUPDATE="anitya::id=11108"

--- a/extra-admin/xdg-desktop-portal-wlr/autobuild/defines
+++ b/extra-admin/xdg-desktop-portal-wlr/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=xdg-desktop-portal-wlr
+PKGSEC=admin
+PKGDES="A xdg-desktop-portal backend for wlroots"
+PKGDEP="dbus grim inih pipewire wayland xdg-desktop-portal"
+BUILDDEP="scdoc"
+
+MESON_AFTER="-Dsd-bus-provider=libsystemd"

--- a/extra-admin/xdg-desktop-portal-wlr/spec
+++ b/extra-admin/xdg-desktop-portal-wlr/spec
@@ -1,0 +1,4 @@
+VER=0.5.0
+SRCS="tbl::https://github.com/emersion/xdg-desktop-portal-wlr/releases/download/v$VER/xdg-desktop-portal-wlr-$VER.tar.gz"
+CHKSUMS="sha256::961cdfbaf7873124f96c86f41e90d304888e93a1da7ebe4a6ea2f1a824788307"
+CHKUPDATE="anitya::id=98352"

--- a/extra-admin/xdg-desktop-portal/autobuild/defines
+++ b/extra-admin/xdg-desktop-portal/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=xdg-desktop-portal
 PKGSEC=admin
-PKGDEP="flatpak geoclue2 libportal pipewire"
-BUILDDEP="xmlto docbook-xsl"
+PKGDEP="fuse geoclue2 glib pipewire"
+BUILDDEP="flatpak xmlto docbook-xsl libportal"
 PKGDES="Portal frontend service to flatpak"

--- a/extra-admin/xdg-desktop-portal/spec
+++ b/extra-admin/xdg-desktop-portal/spec
@@ -1,5 +1,4 @@
-VER=1.8.0
-REL=2
+VER=1.12.1
 SRCS="tbl::https://github.com/flatpak/xdg-desktop-portal/releases/download/$VER/xdg-desktop-portal-$VER.tar.xz"
-CHKSUMS="sha256::a2fc5681b3a35078239072a98d6435a4c8404016730cab17c9febfd4ecec3610"
+CHKSUMS="sha256::f83e3f37c19d423e7dd5e205deca8560bffb00b1620023bd2536c1d4ff8b4358"
 CHKUPDATE="anitya::id=11089"

--- a/extra-gnome/gnome-builder/spec
+++ b/extra-gnome/gnome-builder/spec
@@ -1,4 +1,5 @@
 VER=41.2
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-builder/${VER%.*}/gnome-builder-$VER.tar.xz"
 CHKSUMS="sha256::56317b567f7861dda0373295b24e94edf4919cc955fb45ed62aca5946218e012"
 CHKUPDATE="anitya::id=5574"

--- a/extra-gnome/gnome-software/spec
+++ b/extra-gnome/gnome-software/spec
@@ -1,4 +1,5 @@
 VER=40.4
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-software/${VER%.*}/gnome-software-$VER.tar.xz"
 CHKSUMS="sha256::be8c611a802f71718dccbbd4544ed968873119846fd37b7b76a7aad72c7998bf"
 CHKUPDATE="anitya::id=10902"

--- a/extra-gnome/libadwaita/spec
+++ b/extra-gnome/libadwaita/spec
@@ -1,4 +1,4 @@
-VER=1.0.0~alpha2
-SRCS="tbl::https://gitlab.gnome.org/GNOME/libadwaita/-/archive/1.0.0-alpha.2/libadwaita-1.0.0${VER/-alpha./~alpha}.tar.gz"
-CHKSUMS="sha256::07800011d30a498f45aaf06934465579f6beb38ef1d6361ceb9afc208d0bd845"
+VER=1.0.0~alpha4
+SRCS="tbl::https://gitlab.gnome.org/GNOME/libadwaita/-/archive/${VER/\~alpha/.alpha.}/libadwaita-${VER/~alpha/.alpha.}.tar.gz"
+CHKSUMS="sha256::f9a18952ec96fc5dc4d0827a4873c776a56c4dc236f7924aecb83f6f961a48d1"
 CHKUPDATE="anitya::id=234898"

--- a/extra-gnome/xdg-desktop-portal-gnome/autobuild/defines
+++ b/extra-gnome/xdg-desktop-portal-gnome/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=xdg-desktop-portal-gnome
+PKGSEC=gnome
+PKGDES="Backend implementation for xdg-desktop-portal using GNOME"
+PKGDEP="dbus fontconfig gsettings-desktop-schemas gtk-4 xdg-desktop-portal \
+        xdg-desktop-portal-gtk"

--- a/extra-gnome/xdg-desktop-portal-gnome/spec
+++ b/extra-gnome/xdg-desktop-portal-gnome/spec
@@ -1,0 +1,4 @@
+VER=41.1
+SRCS="tbl::https://download.gnome.org/sources/xdg-desktop-portal-gnome/${VER:0:-2}/xdg-desktop-portal-gnome-$VER.tar.xz"
+CHKSUMS="sha256::bba144199e7ed4b9490b249c1af645a869d62993265deac38f219bf042fffdf2"
+CHKUPDATE="anitya::id=235013"

--- a/extra-libs/malcontent/spec
+++ b/extra-libs/malcontent/spec
@@ -1,5 +1,5 @@
 VER=0.10.1
-REL=1
+REL=2
 SRCS="https://gitlab.freedesktop.org/pwithnall/malcontent/-/archive/$VER/malcontent-$VER.tar.gz"
 CHKSUMS="sha256::8e80ee7154d3d0b08417d4db9bfcb6dab873967d6e8864e48de282eb6a66f1b8"
 CHKUPDATE="anitya::id=230451"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update or new `xdg-desktop-portal*`, and `libadwaita` by the way.
Cherry pick from `kooha-2.0.1` branch (#3675 ), and update to their latest version.

Package(s) Affected
-------------------

```
xdg-desktop-portal{,-gtk,-gnome,-wlr}
libadwaita
```

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
