### PR TITLE
Web Applications Survey 20220109

### DIFF
--- a/extra-libs/libtorrent-rasterbar/spec
+++ b/extra-libs/libtorrent-rasterbar/spec
@@ -1,4 +1,4 @@
-VER=2.0.2
+VER=2.0.5
 SRCS="tbl::https://github.com/arvidn/libtorrent/releases/download/v${VER}/libtorrent-rasterbar-$VER.tar.gz"
-CHKSUMS="sha256::3af22ea1b60e04a7cf357a3d770470ea5df15e968501782bd1414634a2b42cb7"
+CHKSUMS="sha256::e965c2e53170c61c0db3a2d898a61769cb7acd541bbf157cbbef97a185930ea5"
 CHKUPDATE="anitya::id=4166"

--- a/extra-web/qbittorrent/spec
+++ b/extra-web/qbittorrent/spec
@@ -1,4 +1,4 @@
-VER=4.3.9
+VER=4.4.0
 SRCS="tbl::https://sourceforge.net/projects/qbittorrent/files/qbittorrent/qbittorrent-$VER/qbittorrent-$VER.tar.xz/download"
-CHKSUMS="sha256::16ebe2e761922b3fb21c35d2bccc5d4b4b0a3e853434bcaddbbc00c72003d880"
+CHKSUMS="sha256::6b783a88c7bd567e48cd9f20c67b788776ee2a6d474fe3df4af216acbdfe501b"
 CHKUPDATE="anitya::id=6111"

--- a/extra-web/qownnotes/spec
+++ b/extra-web/qownnotes/spec
@@ -1,4 +1,4 @@
-VER=22.1.3
+VER=22.1.4
 SRCS="tbl::https://download.tuxfamily.org/qownnotes/src/qownnotes-$VER.tar.xz"
-CHKSUMS="sha256::bf54042007af4b1bed543c8ff2d40f8496b99f92c21ce340a15c6ba96e27bd05"
+CHKSUMS="sha256::bf560c88852d352c0677f8271c97f5413aefb5d1cbe5b69eb6d195854dd19984"
 CHKUPDATE="anitya::id=27552"

--- a/extra-web/vivaldi/spec
+++ b/extra-web/vivaldi/spec
@@ -1,10 +1,10 @@
-VER=5.0.2497.32
+VER=5.0.2497.35
 
 SRCS__ARM64="tbl::https://downloads.vivaldi.com/stable/vivaldi-stable_${VER}-1_arm64.deb"
-CHKSUMS__ARM64="sha256::97f00a7c3d63e74376af5e29d9b6411fe516556b4785e06264b30915944f0bd2"
+CHKSUMS__ARM64="sha256::b8e9a9e41d20781f0651685cafa94d87cc1832cfb529099cd62936d455e8b515"
 
 SRCS__AMD64="tbl::https://downloads.vivaldi.com/stable/vivaldi-stable-${VER}-1.x86_64.rpm"
-CHKSUMS__AMD64="sha256::a4a3762cd2110d673c0398e54cb12a455fc5a8399eae3c8b933af5f1dd5f24e4"
+CHKSUMS__AMD64="sha256::6303949cec806f530af131ebf6a77281e597b6981b037bf9ad6560d41fd44f28"
 
 SUBDIR=.
 CHKUPDATE="anitya::id=9036"


### PR DESCRIPTION
Topic Description
-----------------

Survey for Web application updates in `base-web` and `extra-web`.

Package(s) Affected
-------------------

- `libtorrent-rasterbar` v2.0.5
- `qbittorrent` v4.4.0
- `qownnotes` v22.1.4
- `vivaldi` v5.0.2497.35

Security Update?
----------------

No

Build Order
-----------

```
extra-libs/libtorrent-rasterbar
extra-web/qbittorrent
extra-web/qownnotes
extra-web/vivaldi
```

Test Build(s) Done
------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`