### PR TITLE
VSCode Survey 20220114

### DIFF
--- a/extra-devel/autobuild3/spec
+++ b/extra-devel/autobuild3/spec
@@ -1,4 +1,4 @@
-VER=1.6.39
+VER=1.6.41
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"

--- a/extra-editors/vscode/spec
+++ b/extra-editors/vscode/spec
@@ -1,4 +1,4 @@
-VER=1.62.3
+VER=1.63.2
 SRCS="git::commit=tags/$VER::https://github.com/microsoft/vscode/"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=microsoft/vscode;pattern=^\d\.\d+\.\d+$"

--- a/extra-utils/code-server/autobuild/build
+++ b/extra-utils/code-server/autobuild/build
@@ -1,3 +1,10 @@
+abinfo "FIXME: nvm is not compatible with the \"PREFIX\" environment variable: currently set to \"/usr\" ..."
+unset PREFIX
+
+abinfo "Switching Node.js version to v14 ..."
+nvm install 14
+nvm use 14
+
 abinfo "Installing build dependency ..."
 yarn
 
@@ -13,10 +20,6 @@ yarn release:standalone
 abinfo "Installing code-server ..."
 mkdir -pv "$PKGDIR"/usr/lib/code-server
 cp -avr "$SRCDIR"/release-standalone/* "$PKGDIR"/usr/lib/code-server
-
-abinfo "Removing bundle nodejs and use system nodejs ..."
-rm -v "$PKGDIR"/usr/lib/code-server/lib/node
-ln -sv ../../../bin/node "$PKGDIR"/usr/lib/code-server/lib/node
 
 abinfo "linking code-server to /usr/bin ..."
 mkdir -pv "$PKGDIR"/usr/bin

--- a/extra-utils/code-server/autobuild/defines
+++ b/extra-utils/code-server/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME=code-server
 PKGDES="Run VS Code on a remote server"
 PKGSEC=utils
-PKGDEP="nodejs"
-BUILDDEP="yarn jq"
+BUILDDEP="yarn jq nvm"
 
 ABSTRIP=0
 

--- a/extra-utils/code-server/spec
+++ b/extra-utils/code-server/spec
@@ -1,4 +1,4 @@
-VER=3.11.0
+VER=4.0.1
 SRCS="git::commit=tags/v$VER::https://github.com/cdr/code-server"
 CHKSUMS="sha256::13ab71229e41cc8d449a4dbc73cfb092b1dcbfcba0089e136f1471705f766cd9"
 CHKUPDATE="anitya::id=231692"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

VSCode Survey 20220114

- vscode
- code-server

Package(s) Affected
-------------------

- autobuild 1.6.14
- vscode 1.63.2
- code-server 4.0.1

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No
<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->


Build Order
-----------

autobuild3 code-server vscode

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->


Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->