### PR TITLE
aosc-logos: set 'icenowy' as current

### DIFF
--- a/extra-misc/aosc-logos/autobuild/overrides/usr/bin/aosc-logo
+++ b/extra-misc/aosc-logos/autobuild/overrides/usr/bin/aosc-logo
@@ -5,7 +5,7 @@ import subprocess
 
 LOGO_PATH = "/usr/share/aosc-logos/"
 CODENAMES = ['fsck', 'gumblex', 'hotfix', 'icenowy']
-CURRENT = "hotfix"
+CURRENT = "icenowy"
 
 parser = argparse.ArgumentParser(description='Display AOSC OS logo ASCII arts.')
 parser.add_argument('--codename', '-c', type=str, help='Select a specific version of AOSC OS logo', nargs='?', default=CURRENT)

--- a/extra-misc/aosc-logos/spec
+++ b/extra-misc/aosc-logos/spec
@@ -1,2 +1,3 @@
 VER=9
+REL=1
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

Set `CURRENT` to "icenowy"

Package(s) Affected
-------------------

`aosc-logos`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`