### PR TITLE
xorg-server: disable libunwind on arm64 due to segfaults

### DIFF
--- a/extra-x11/xorg-server/autobuild/defines
+++ b/extra-x11/xorg-server/autobuild/defines
@@ -4,6 +4,7 @@ PKGDEP="xkeyboard-config x11-app x11-lib libdrm pixman mesa libgcrypt \
         libepoxy xcb-util-renderutil x11-proto xcb-util-image \
         xcb-util-keysyms xcb-util-wm x11-app x11-font libunwind libxcvt"
 PKGDEP__RISCV64="${PKGDEP/libunwind/}"
+PKGDEP__ARM64="${PKGDEP/libunwind/}"
 BUILDDEP="wayland"
 PKGDES="X.Org display server"
 
@@ -27,6 +28,7 @@ MESON_AFTER="-Dipv6=true \
              -Ddefault_font_path=/usr/share/fonts"
 
 MESON_AFTER__RISCV64="${MESON_AFTER} -Dlibunwind=false"
+MESON_AFTER__ARM64="${MESON_AFTER} -Dlibunwind=false"
 
 PKGDEP__RETRO="xkeyboard-config x11-app x11-lib libdrm pixman mesa \
                xcb-util-renderutil xcb-util-image xcb-util-keysyms \

--- a/extra-x11/xorg-server/spec
+++ b/extra-x11/xorg-server/spec
@@ -1,4 +1,5 @@
 VER=21.1.3
+REL=1
 SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
 CHKSUMS="sha256::61d6aad5b6b47a116b960bd7f0cba4ee7e6da95d6bb0b127bde75d7d1acdebe5"
 CHKUPDATE="anitya::id=5250"


### PR DESCRIPTION
Topic Description
-----------------

This PR disable libunwind integration in Xorg server on arm64 due to unknown reason.

Package(s) Affected
-------------------

* xorg-server

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
