### PR TITLE
nvidia: workaround dbus DoS from libnvidia-glcore

### DIFF
--- a/extra-optenv32/nvidia+32/spec
+++ b/extra-optenv32/nvidia+32/spec
@@ -1,8 +1,8 @@
-VER=495.44
-_SETTINGS_VER=495.44
+VER=495.46
+_SETTINGS_VER=495.46
 SRCS="file::rename=NVIDIA-Linux-x86_64-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run \
       tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz"
-CHKSUMS="sha256::f1876a67815b160a67ef94e16d1b87550e4c302b327d98daec4d71dd5c7f8a48 \
-         sha256::55817dde2268edb0f46d63c6d3278d0e42a0e6566b97b851e35839e0ff7e4d6c"
+CHKSUMS="sha256::d83b77d17da0c54667aa5b13d6ea95a5c51304257b1ecf2f8d4a3b5ae31c62f5 \
+         sha256::a368070d496ee24303a10ded2fc9395e10c92694db46fdd6e094dddbd37b10c3"
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"

--- a/extra-x11/nvidia/autobuild/build
+++ b/extra-x11/nvidia/autobuild/build
@@ -67,6 +67,12 @@ esac
 
 cd NVIDIA-Linux-${NV_ARCH}-${PKGVER}${NV_DIR_SUFFIX}
 
+abinfo "Patching kernel driver"
+for i in "${SRCDIR}/autobuild/patches/"*.patch; do
+	abinfo "Applying $(basename $i)"
+	patch -Np1 -i "$i"
+done
+
 cd kernel
 
 abinfo "Processing DKMS configuration file..."

--- a/extra-x11/nvidia/autobuild/overrides/usr/lib/systemd/system/multi-user.target.wants/nvidia-fake-powerd.service
+++ b/extra-x11/nvidia/autobuild/overrides/usr/lib/systemd/system/multi-user.target.wants/nvidia-fake-powerd.service
@@ -1,0 +1,1 @@
+../nvidia-fake-powerd.service

--- a/extra-x11/nvidia/autobuild/overrides/usr/lib/systemd/system/nvidia-fake-powerd.service
+++ b/extra-x11/nvidia/autobuild/overrides/usr/lib/systemd/system/nvidia-fake-powerd.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=NVIDIA fake powerd service
+
+[Service]
+Type=dbus
+BusName=nvidia.powerd.server
+ExecStart=/usr/bin/dbus-test-tool black-hole --system --name=nvidia.powerd.server
+User=dbus
+Group=dbus
+LimitNPROC=2
+ProtectHome=true
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target
+Alias=dbus-nvidia.fake-powerd.service

--- a/extra-x11/nvidia/autobuild/overrides/usr/share/dbus-1/system.d/nvidia-fake-powerd.conf
+++ b/extra-x11/nvidia/autobuild/overrides/usr/share/dbus-1/system.d/nvidia-fake-powerd.conf
@@ -1,0 +1,12 @@
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+	<policy user="dbus">
+		<allow own="nvidia.powerd.server"/>
+	</policy>
+	<policy context="default">
+		<allow send_destination="nvidia.powerd.server"/>
+		<allow receive_sender="nvidia.powerd.server"/>
+	</policy>
+</busconfig>

--- a/extra-x11/nvidia/autobuild/patch
+++ b/extra-x11/nvidia/autobuild/patch
@@ -1,0 +1,1 @@
+abinfo "Skipping patches to apply during build"

--- a/extra-x11/nvidia/autobuild/patches/0001-5.16-remove-pfn-locked.patch
+++ b/extra-x11/nvidia/autobuild/patches/0001-5.16-remove-pfn-locked.patch
@@ -1,0 +1,27 @@
+diff -Naur a/kernel/nvidia-uvm/uvm_migrate_pageable.c b/kernel/nvidia-uvm/uvm_migrate_pageable.c
+--- a/kernel/nvidia-uvm/uvm_migrate_pageable.c	2021-10-27 12:14:51.000000000 -0500
++++ b/kernel/nvidia-uvm/uvm_migrate_pageable.c	2022-01-18 16:30:57.725084398 -0600
+@@ -406,7 +406,11 @@
+         uvm_push_set_flag(&push, UVM_PUSH_FLAG_CE_NEXT_MEMBAR_NONE);
+         copying_gpu->parent->ce_hal->memset_8(&push, dst_address, 0, PAGE_SIZE);
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
+         dst[i] = migrate_pfn(page_to_pfn(dst_page)) | MIGRATE_PFN_LOCKED;
++#else
++        dst[i] = migrate_pfn(page_to_pfn(dst_page));
++#endif
+     }
+ 
+     if (copying_gpu) {
+@@ -490,7 +494,11 @@
+         uvm_push_set_flag(&push, UVM_PUSH_FLAG_CE_NEXT_MEMBAR_NONE);
+         copying_gpu->parent->ce_hal->memcopy(&push, dst_address, src_address, PAGE_SIZE);
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
+         dst[i] = migrate_pfn(page_to_pfn(dst_page)) | MIGRATE_PFN_LOCKED;
++#else
++        dst[i] = migrate_pfn(page_to_pfn(dst_page));
++#endif
+     }
+ 
+     // TODO: Bug 1766424: If the destination is a GPU and the copy was done by

--- a/extra-x11/nvidia/spec
+++ b/extra-x11/nvidia/spec
@@ -1,20 +1,20 @@
-VER=495.44
-_SETTINGS_VER=495.44
+VER=495.46
+_SETTINGS_VER=495.46
 SRCS__AMD64="
 	file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER-no-compat32.run
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__AMD64="
-	sha256::31b9c5b03bdff6fbbe3eea8780c240abe1541ba5c5094fadeae622db2d33c6f9
-	sha256::55817dde2268edb0f46d63c6d3278d0e42a0e6566b97b851e35839e0ff7e4d6c
+	sha256::c9a5ce182c52de2a24ad0f4d66d9f64cc8b79c761e1cb47e38fad917f46e572e
+	sha256::a368070d496ee24303a10ded2fc9395e10c92694db46fdd6e094dddbd37b10c3
 "
 SRCS__ARM64="
 	file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/aarch64/$VER/NVIDIA-Linux-aarch64-${VER}.run
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__ARM64="
-	sha256::dd1eb463972f00a00c2ed05bdba1a496c88e0d446da95450d2a239097afac313
-	sha256::55817dde2268edb0f46d63c6d3278d0e42a0e6566b97b851e35839e0ff7e4d6c
+	sha256::4d343e05ad435142aa72ce024a15467da0590465f31de9c6411f069f37b25688
+	sha256::a368070d496ee24303a10ded2fc9395e10c92694db46fdd6e094dddbd37b10c3
 "
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"


### PR DESCRIPTION
# Issue Description

Nvidia driver 495.xx has a known issue where a process using GL via `libnvidia-glcore.so` or `libnvidia-eglcore.so` will frequently send request to dbus endpoint `nvidia.powerd.server`, which is apparently not implemented in this particular driver version and seems to only exist in 510.xx beta branch.

dbus will respond with `org.freedesktop.DBus.Error.ServiceUnknown` for every incoming request to the sending process, which itself is also a dbus message and requires acknowledgement from the offending process. After sufficiently long time after processes choking at loads of `ServiceUnknown` and have their receiving buffers filled up, dbus daemon will begin spamming system journal with something like the following:
```
Rejected: destination has a full message queue, 0 matched rules; type="error", sender="(unset)" ((bus)) interface="(unset)" member="(unset)" error name="org.freedesktop.DBus.Error.ServiceUnknown" requested_reply="1" destination=":1.72" (uid=1000 pid=3450 comm="/usr/bin/gnome-shell ")
```

At this stage dbus daemon is in an unstable state and may cause processes connected to dbus to dump core. In the worst case dbus daemon itself may crash and effectively bring down entire user sessions and other key services (say NetworkManager) with it.

Reference: https://forums.developer.nvidia.com/t/bug-nvidia-v495-29-05-driver-spamming-dbus-enabled-applications-with-invalid-messages/192892

# Workaround

The package now ships three additional files:

* `/usr/lib/systemd/system/nvidia-fake-powerd.service`, a fake service on the endpoint that uses `dbus-test-tool` to discard all the requests coming in
* `/usr/lib/systemd/system/multi-user.target.wants/nvidia-fake-powerd.service`, a symlink to the service file so that this will always start on boot
* `/usr/share/dbus-1/system.d/nvidia-fake-powerd.conf` so that user `dbus` will be allowed to own bus endpoint `nvidia.powerd.server`

The three files should be removed from overrides when nvidia (hopefully) provides a permanent fix.

Package(s) Affected
-------------------

* nvidia

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
