### PR TITLE
spirv-llvm-translator: rework to fix conflics with spirv-headers

### DIFF
--- a/extra-devel/spirv-llvm-translator/autobuild/beyond
+++ b/extra-devel/spirv-llvm-translator/autobuild/beyond
@@ -1,2 +1,0 @@
-abinfo "Removing bundled SPIR-V headers ..."
-rm -rv "$PKGDIR"/usr/include/spirv

--- a/extra-devel/spirv-llvm-translator/autobuild/defines
+++ b/extra-devel/spirv-llvm-translator/autobuild/defines
@@ -1,10 +1,9 @@
 PKGNAME=spirv-llvm-translator
 PKGSEC=devel
-PKGDEP="gcc-runtime libedit libxml2 llvm-runtime ncurses xz zlib"
+PKGDEP="llvm-runtime"
 BUILDDEP="llvm spirv-tools spirv-headers"
 PKGDES="A tool and a library for bi-directional translation between SPIR-V and LLVM IR"
 
 CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON \
              -DLLVM_BUILD_TOOLS=ON \
-             -DLLVM_EXTERNAL_PROJECTS=SPIRV-Headers \
              -DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=/usr/include/spirv/1.2/"

--- a/extra-devel/spirv-llvm-translator/autobuild/defines
+++ b/extra-devel/spirv-llvm-translator/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=spirv-llvm-translator
 PKGSEC=devel
 PKGDEP="gcc-runtime libedit libxml2 llvm-runtime ncurses xz zlib"
-BUILDDEP="llvm spirv-tools"
+BUILDDEP="llvm spirv-tools spirv-headers"
 PKGDES="A tool and a library for bi-directional translation between SPIR-V and LLVM IR"
 
-CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON"
+CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON \
+             -DLLVM_BUILD_TOOLS=ON \
+             -DLLVM_EXTERNAL_PROJECTS=SPIRV-Headers \
+             -DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=/usr/include/spirv/1.2/"

--- a/extra-devel/spirv-llvm-translator/autobuild/patches/0001-Gentoo-rename-OpConstFunctionPointerINTEL.patch
+++ b/extra-devel/spirv-llvm-translator/autobuild/patches/0001-Gentoo-rename-OpConstFunctionPointerINTEL.patch
@@ -1,0 +1,310 @@
+Source: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1265
+
+From b2973ea08d2148ca8adff793439950ff9aaeb801 Mon Sep 17 00:00:00 2001
+From: Dmitry Sidorov <dmitry.sidorov@intel.com>
+Date: Wed, 3 Nov 2021 13:05:23 +0300
+Subject: [PATCH 1/2] Rename OpConstFunctionPointerINTEL to
+ OpConstantFunctionPointerINTEL
+
+Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>
+---
+ lib/SPIRV/SPIRVReader.cpp            |  6 +++---
+ lib/SPIRV/SPIRVWriter.cpp            |  2 +-
+ lib/SPIRV/SPIRVWriter.h              |  3 ++-
+ lib/SPIRV/libSPIRV/SPIRVFunction.h   | 10 +++++-----
+ lib/SPIRV/libSPIRV/SPIRVModule.cpp   | 11 ++++++-----
+ lib/SPIRV/libSPIRV/SPIRVModule.h     |  4 ++--
+ lib/SPIRV/libSPIRV/SPIRVOpCode.h     |  2 +-
+ lib/SPIRV/libSPIRV/SPIRVOpCodeEnum.h |  2 +-
+ spirv-headers-tag.conf               |  2 +-
+ 9 files changed, 22 insertions(+), 20 deletions(-)
+
+diff --git a/lib/SPIRV/SPIRVReader.cpp b/lib/SPIRV/SPIRVReader.cpp
+index d23bf4395..d01af93f7 100644
+--- a/lib/SPIRV/SPIRVReader.cpp
++++ b/lib/SPIRV/SPIRVReader.cpp
+@@ -1454,9 +1454,9 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
+     return mapValue(BV, transValue(BI, nullptr, nullptr, false));
+   }
+ 
+-  case OpConstFunctionPointerINTEL: {
+-    SPIRVConstFunctionPointerINTEL *BC =
+-        static_cast<SPIRVConstFunctionPointerINTEL *>(BV);
++  case OpConstantFunctionPointerINTEL: {
++    SPIRVConstantFunctionPointerINTEL *BC =
++        static_cast<SPIRVConstantFunctionPointerINTEL *>(BV);
+     SPIRVFunction *F = BC->getFunction();
+     BV->setName(F->getName());
+     return mapValue(BV, transFunction(F));
+diff --git a/lib/SPIRV/SPIRVWriter.cpp b/lib/SPIRV/SPIRVWriter.cpp
+index 6263a87a1..ce2c0bff2 100644
+--- a/lib/SPIRV/SPIRVWriter.cpp
++++ b/lib/SPIRV/SPIRVWriter.cpp
+@@ -1414,7 +1414,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
+     if (!BM->checkExtension(ExtensionID::SPV_INTEL_function_pointers,
+                             SPIRVEC_FunctionPointers, toString(V)))
+       return nullptr;
+-    return BM->addConstFunctionPointerINTEL(
++    return BM->addConstantFunctionPointerINTEL(
+         transType(F->getType()),
+         static_cast<SPIRVFunction *>(transValue(F, nullptr)));
+   }
+diff --git a/lib/SPIRV/SPIRVWriter.h b/lib/SPIRV/SPIRVWriter.h
+index 08e23e333..78ba39e36 100644
+--- a/lib/SPIRV/SPIRVWriter.h
++++ b/lib/SPIRV/SPIRVWriter.h
+@@ -75,7 +75,8 @@ class LLVMToSPIRVBase {
+   // a function, that is necessary for a convenient function pointers handling.
+   // By default transValue uses 'Decl' mode, which means every function
+   // we meet during the translation should result in its declaration generated.
+-  // In 'Pointer' mode we generate OpConstFunctionPointerINTEL constant instead.
++  // In 'Pointer' mode we generate OpConstantFunctionPointerINTEL constant
++  // instead.
+   enum class FuncTransMode { Decl, Pointer };
+ 
+   SPIRVType *transType(Type *T);
+diff --git a/lib/SPIRV/libSPIRV/SPIRVFunction.h b/lib/SPIRV/libSPIRV/SPIRVFunction.h
+index bf126d402..35cab862b 100644
+--- a/lib/SPIRV/libSPIRV/SPIRVFunction.h
++++ b/lib/SPIRV/libSPIRV/SPIRVFunction.h
+@@ -171,18 +171,18 @@ class SPIRVFunction : public SPIRVValue, public SPIRVComponentExecutionModes {
+ 
+ typedef SPIRVEntryOpCodeOnly<OpFunctionEnd> SPIRVFunctionEnd;
+ 
+-class SPIRVConstFunctionPointerINTEL : public SPIRVValue {
+-  const static Op OC = OpConstFunctionPointerINTEL;
++class SPIRVConstantFunctionPointerINTEL : public SPIRVValue {
++  const static Op OC = OpConstantFunctionPointerINTEL;
+   const static SPIRVWord FixedWordCount = 4;
+ 
+ public:
+-  SPIRVConstFunctionPointerINTEL(SPIRVId TheId, SPIRVType *TheType,
+-                                 SPIRVFunction *TheFunction, SPIRVModule *M)
++  SPIRVConstantFunctionPointerINTEL(SPIRVId TheId, SPIRVType *TheType,
++                                    SPIRVFunction *TheFunction, SPIRVModule *M)
+       : SPIRVValue(M, FixedWordCount, OC, TheType, TheId),
+         TheFunction(TheFunction->getId()) {
+     validate();
+   }
+-  SPIRVConstFunctionPointerINTEL()
++  SPIRVConstantFunctionPointerINTEL()
+       : SPIRVValue(OC), TheFunction(SPIRVID_INVALID) {}
+   SPIRVFunction *getFunction() const { return get<SPIRVFunction>(TheFunction); }
+   _SPIRV_DEF_ENCDEC3(Type, Id, TheFunction)
+diff --git a/lib/SPIRV/libSPIRV/SPIRVModule.cpp b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+index 9cd9249a7..afa912af8 100644
+--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
++++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+@@ -272,8 +272,8 @@ class SPIRVModuleImpl : public SPIRVModule {
+                            const std::vector<SPIRVValue *> &Elements) override;
+   SPIRVEntry *addSpecConstantCompositeContinuedINTEL(
+       const std::vector<SPIRVValue *> &) override;
+-  SPIRVValue *addConstFunctionPointerINTEL(SPIRVType *Ty,
+-                                           SPIRVFunction *F) override;
++  SPIRVValue *addConstantFunctionPointerINTEL(SPIRVType *Ty,
++                                              SPIRVFunction *F) override;
+   SPIRVValue *addConstant(SPIRVValue *) override;
+   SPIRVValue *addConstant(SPIRVType *, uint64_t) override;
+   SPIRVValue *addConstant(SPIRVType *, llvm::APInt) override;
+@@ -1153,9 +1153,10 @@ SPIRVEntry *SPIRVModuleImpl::addSpecConstantCompositeContinuedINTEL(
+   return add(new SPIRVSpecConstantCompositeContinuedINTEL(this, Elements));
+ }
+ 
+-SPIRVValue *SPIRVModuleImpl::addConstFunctionPointerINTEL(SPIRVType *Ty,
+-                                                          SPIRVFunction *F) {
+-  return addConstant(new SPIRVConstFunctionPointerINTEL(getId(), Ty, F, this));
++SPIRVValue *SPIRVModuleImpl::addConstantFunctionPointerINTEL(SPIRVType *Ty,
++                                                             SPIRVFunction *F) {
++  return addConstant(
++      new SPIRVConstantFunctionPointerINTEL(getId(), Ty, F, this));
+ }
+ 
+ SPIRVValue *SPIRVModuleImpl::addUndef(SPIRVType *TheType) {
+diff --git a/lib/SPIRV/libSPIRV/SPIRVModule.h b/lib/SPIRV/libSPIRV/SPIRVModule.h
+index d65e9a600..33c85289f 100644
+--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
++++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
+@@ -267,8 +267,8 @@ class SPIRVModule {
+                            const std::vector<SPIRVValue *> &Elements) = 0;
+   virtual SPIRVEntry *
+   addSpecConstantCompositeContinuedINTEL(const std::vector<SPIRVValue *> &) = 0;
+-  virtual SPIRVValue *addConstFunctionPointerINTEL(SPIRVType *Ty,
+-                                                   SPIRVFunction *F) = 0;
++  virtual SPIRVValue *addConstantFunctionPointerINTEL(SPIRVType *Ty,
++                                                      SPIRVFunction *F) = 0;
+   virtual SPIRVValue *addConstant(SPIRVValue *) = 0;
+   virtual SPIRVValue *addConstant(SPIRVType *, uint64_t) = 0;
+   virtual SPIRVValue *addConstant(SPIRVType *, llvm::APInt) = 0;
+diff --git a/lib/SPIRV/libSPIRV/SPIRVOpCode.h b/lib/SPIRV/libSPIRV/SPIRVOpCode.h
+index ce5c3dfda..045f41b02 100644
+--- a/lib/SPIRV/libSPIRV/SPIRVOpCode.h
++++ b/lib/SPIRV/libSPIRV/SPIRVOpCode.h
+@@ -227,7 +227,7 @@ inline bool isSpecConstantOpCode(Op OpCode) {
+ inline bool isConstantOpCode(Op OpCode) {
+   unsigned OC = OpCode;
+   return (OpConstantTrue <= OC && OC <= OpSpecConstantOp) || OC == OpUndef ||
+-         OC == OpConstantPipeStorage || OC == OpConstFunctionPointerINTEL;
++         OC == OpConstantPipeStorage || OC == OpConstantFunctionPointerINTEL;
+ }
+ 
+ inline bool isModuleScopeAllowedOpCode(Op OpCode) {
+diff --git a/lib/SPIRV/libSPIRV/SPIRVOpCodeEnum.h b/lib/SPIRV/libSPIRV/SPIRVOpCodeEnum.h
+index 0b8267dbc..748257b9e 100644
+--- a/lib/SPIRV/libSPIRV/SPIRVOpCodeEnum.h
++++ b/lib/SPIRV/libSPIRV/SPIRVOpCodeEnum.h
+@@ -344,7 +344,7 @@ _SPIRV_OP(SubgroupImageBlockReadINTEL, 5577)
+ _SPIRV_OP(SubgroupImageBlockWriteINTEL, 5578)
+ _SPIRV_OP(SubgroupImageMediaBlockReadINTEL, 5580)
+ _SPIRV_OP(SubgroupImageMediaBlockWriteINTEL, 5581)
+-_SPIRV_OP(ConstFunctionPointerINTEL, 5600)
++_SPIRV_OP(ConstantFunctionPointerINTEL, 5600)
+ _SPIRV_OP(FunctionPointerCallINTEL, 5601)
+ _SPIRV_OP(AsmTargetINTEL, 5609)
+ _SPIRV_OP(AsmINTEL, 5610)
+diff --git a/spirv-headers-tag.conf b/spirv-headers-tag.conf
+index 1ea6e6c77..bb8d1c4ec 100644
+--- a/spirv-headers-tag.conf
++++ b/spirv-headers-tag.conf
+@@ -1 +1 @@
+-ddf3230c14c71e81fc0eae9b781cc4bcc2d1f0f5
++814e728b30ddd0f4509233099a3ad96fd4318c07
+
+From 32b7d2408b87540f97d8bc792403c02b9ed2a290 Mon Sep 17 00:00:00 2001
+From: Dmitry Sidorov <dmitry.sidorov@intel.com>
+Date: Thu, 18 Nov 2021 16:09:52 +0300
+Subject: [PATCH 2/2] Fix tests
+
+Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>
+---
+ test/constexpr_vector.ll                                  | 8 ++++----
+ test/transcoding/SPV_INTEL_function_pointers/bitcast.ll   | 2 +-
+ .../SPV_INTEL_function_pointers/const-function-pointer.ll | 4 ++--
+ .../SPV_INTEL_function_pointers/function-pointer.ll       | 2 +-
+ .../SPV_INTEL_function_pointers/global_ctor_dtor.ll       | 4 ++--
+ .../non-uniform-function-pointer.ll                       | 4 ++--
+ test/transcoding/SPV_INTEL_function_pointers/select.ll    | 4 ++--
+ .../SPV_INTEL_function_pointers/vector_elem.ll            | 4 ++--
+ 8 files changed, 16 insertions(+), 16 deletions(-)
+
+diff --git a/test/constexpr_vector.ll b/test/constexpr_vector.ll
+index 2a5b42832..eaca3f41e 100644
+--- a/test/constexpr_vector.ll
++++ b/test/constexpr_vector.ll
+@@ -62,10 +62,10 @@
+ ; CHECK-SPIRV-DAG: 4 TypePointer [[StorePtr:[0-9]+]] 7 [[TypeVec16]]
+ ; CHECK-SPIRV-DAG: 3 Undef [[TypeVec16]] [[TypeUndefV16:[0-9]+]]
+ ; CHECK-SPIRV-DAG: 3 Undef [[TypeVec64]] [[TypeUndefV64:[0-9]+]]
+-; CHECK-SPIRV-DAG: 4 ConstFunctionPointerINTEL [[FuncPtrTy:[0-9]+]] [[F1Ptr:[0-9]+]] [[F1]]
+-; CHECK-SPIRV-DAG: 4 ConstFunctionPointerINTEL [[FuncPtrTy]] [[F2Ptr:[0-9]+]] [[F2]]
+-; CHECK-SPIRV-DAG: 4 ConstFunctionPointerINTEL [[FuncPtrTy]] [[F11Ptr:[0-9]+]] [[F1]]
+-; CHECK-SPIRV-DAG: 4 ConstFunctionPointerINTEL [[FuncPtrTy]] [[F21Ptr:[0-9]+]] [[F2]]
++; CHECK-SPIRV-DAG: 4 ConstantFunctionPointerINTEL [[FuncPtrTy:[0-9]+]] [[F1Ptr:[0-9]+]] [[F1]]
++; CHECK-SPIRV-DAG: 4 ConstantFunctionPointerINTEL [[FuncPtrTy]] [[F2Ptr:[0-9]+]] [[F2]]
++; CHECK-SPIRV-DAG: 4 ConstantFunctionPointerINTEL [[FuncPtrTy]] [[F11Ptr:[0-9]+]] [[F1]]
++; CHECK-SPIRV-DAG: 4 ConstantFunctionPointerINTEL [[FuncPtrTy]] [[F21Ptr:[0-9]+]] [[F2]]
+ 
+ ; CHECK-SPIRV: 4 ConvertPtrToU [[TypeInt64]] [[Ptr1:[0-9]+]] [[F1Ptr]]
+ ; CHECK-SPIRV: 4 Bitcast [[TypeVec8]] [[Vec1:[0-9]+]] [[Ptr1]]
+diff --git a/test/transcoding/SPV_INTEL_function_pointers/bitcast.ll b/test/transcoding/SPV_INTEL_function_pointers/bitcast.ll
+index bf65f6a78..748331be9 100644
+--- a/test/transcoding/SPV_INTEL_function_pointers/bitcast.ll
++++ b/test/transcoding/SPV_INTEL_function_pointers/bitcast.ll
+@@ -18,7 +18,7 @@
+ ; CHECK-SPIRV: TypeFunction [[#DEST_TY:]] [[#]] [[#]]
+ ; CHECK-SPIRV: TypePointer [[#DEST_TY_PTR:]] [[#]] [[#DEST_TY]]
+ ; CHECK-SPIRV: TypePointer [[#FOO_TY_PTR:]] [[#]] [[#FOO_TY]]
+-; CHECK-SPIRV: ConstFunctionPointerINTEL [[#FOO_TY_PTR]] [[#FOO_PTR:]] [[#FOO:]]
++; CHECK-SPIRV: ConstantFunctionPointerINTEL [[#FOO_TY_PTR]] [[#FOO_PTR:]] [[#FOO:]]
+ ; CHECK-SPIRV: Function [[#]] [[#FOO]] [[#]] [[#FOO_TY]]
+ 
+ ; CHECK-SPIRV: Bitcast [[#DEST_TY_PTR]] [[#]] [[#FOO_PTR]]
+diff --git a/test/transcoding/SPV_INTEL_function_pointers/const-function-pointer.ll b/test/transcoding/SPV_INTEL_function_pointers/const-function-pointer.ll
+index df263048a..3898ad5b9 100644
+--- a/test/transcoding/SPV_INTEL_function_pointers/const-function-pointer.ll
++++ b/test/transcoding/SPV_INTEL_function_pointers/const-function-pointer.ll
+@@ -14,8 +14,8 @@
+ ; CHECK-SPIRV-DAG: Constant [[Int32]] [[XArg:[0-9]+]] 32
+ ; CHECK-SPIRV-DAG: Constant [[Int32]] [[YArg:[0-9]+]] 2
+ 
+-; CHECK-SPIRV: ConstFunctionPointerINTEL {{[0-9]+}} [[F1:[0-9]+]] [[F1Name]]
+-; CHECK-SPIRV: ConstFunctionPointerINTEL {{[0-9]+}} [[F2:[0-9]+]] [[F2Name]]
++; CHECK-SPIRV: ConstantFunctionPointerINTEL {{[0-9]+}} [[F1:[0-9]+]] [[F1Name]]
++; CHECK-SPIRV: ConstantFunctionPointerINTEL {{[0-9]+}} [[F2:[0-9]+]] [[F2Name]]
+ ; CHECK-SPIRV: ConstantComposite {{[0-9]+}} [[ConstComp:[0-9]+]] [[F1]] [[F2]]
+ ; CHECK-SPIRV: Variable {{[0-9]+}} [[Var:[0-9]+]] {{[0-9]+}} [[ConstComp]]
+ 
+diff --git a/test/transcoding/SPV_INTEL_function_pointers/function-pointer.ll b/test/transcoding/SPV_INTEL_function_pointers/function-pointer.ll
+index deeb8b5fa..84a97255f 100644
+--- a/test/transcoding/SPV_INTEL_function_pointers/function-pointer.ll
++++ b/test/transcoding/SPV_INTEL_function_pointers/function-pointer.ll
+@@ -24,7 +24,7 @@
+ ; CHECK-SPIRV: TypeFunction [[FOO_TYPE_ID:[0-9]+]] [[TYPE_INT_ID]] [[TYPE_INT_ID]]
+ ; CHECK-SPIRV: TypePointer [[FOO_PTR_ID:[0-9]+]] {{[0-9]+}} [[FOO_TYPE_ID]]
+ ; CHECK-SPIRV: TypePointer [[FOO_PTR_ALLOCA_ID:[0-9]+]] 7 [[FOO_PTR_ID]]
+-; CHECK-SPIRV: ConstFunctionPointerINTEL [[FOO_PTR_ID]] [[FOO_PTR:[0-9]+]] [[FOO_ID:[0-9]+]]
++; CHECK-SPIRV: ConstantFunctionPointerINTEL [[FOO_PTR_ID]] [[FOO_PTR:[0-9]+]] [[FOO_ID:[0-9]+]]
+ ;
+ ; CHECK-SPIRV: Function {{[0-9]+}} [[FOO_ID]] {{[0-9]+}} [[FOO_TYPE_ID]]
+ ; CHECK-SPIRV: Function {{[0-9]+}} [[KERNEL_ID]]
+diff --git a/test/transcoding/SPV_INTEL_function_pointers/global_ctor_dtor.ll b/test/transcoding/SPV_INTEL_function_pointers/global_ctor_dtor.ll
+index 50b349432..af909bf0f 100644
+--- a/test/transcoding/SPV_INTEL_function_pointers/global_ctor_dtor.ll
++++ b/test/transcoding/SPV_INTEL_function_pointers/global_ctor_dtor.ll
+@@ -22,9 +22,9 @@ target triple = "spir64-unknown-unknown"
+ ; CHECK: TypeFunction {{[0-9]+}} [[TF:[0-9]+]]
+ 
+ ; CHECK: TypePointer [[TP:[0-9]+]]
+-; CHECK: ConstFunctionPointerINTEL [[TP]] [[FPCtor:[0-9]+]] [[NameCtor]]
++; CHECK: ConstantFunctionPointerINTEL [[TP]] [[FPCtor:[0-9]+]] [[NameCtor]]
+ ; CHECK: ConstantComposite {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[FPCtor]]
+-; CHECK: ConstFunctionPointerINTEL [[TP]] [[FPDtor:[0-9]+]] [[NameDtor]]
++; CHECK: ConstantFunctionPointerINTEL [[TP]] [[FPDtor:[0-9]+]] [[NameDtor]]
+ ; CHECK: ConstantComposite {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[FPDtor]]
+ 
+ ; CHECK: 5 Function [[TF]] [[NameCtor]] 0
+diff --git a/test/transcoding/SPV_INTEL_function_pointers/non-uniform-function-pointer.ll b/test/transcoding/SPV_INTEL_function_pointers/non-uniform-function-pointer.ll
+index 96d0d961c..fd7afc0dd 100644
+--- a/test/transcoding/SPV_INTEL_function_pointers/non-uniform-function-pointer.ll
++++ b/test/transcoding/SPV_INTEL_function_pointers/non-uniform-function-pointer.ll
+@@ -34,8 +34,8 @@
+ ; CHECK-SPIRV: TypeFunction [[FOO_TYPE_ID:[0-9]+]] [[TYPE_INT32_ID]] [[TYPE_INT32_ID]]
+ ; CHECK-SPIRV: TypePointer [[FOO_PTR_TYPE_ID:[0-9]+]] {{[0-9]+}} [[FOO_TYPE_ID]]
+ ; CHECK-SPIRV: TypePointer [[FOO_PTR_ALLOCA_TYPE_ID:[0-9]+]] 7 [[FOO_PTR_TYPE_ID]]
+-; CHECK-SPIRV: ConstFunctionPointerINTEL [[FOO_PTR_TYPE_ID]] [[FOO_PTR_ID:[0-9]+]] [[FOO_ID:[0-9]+]]
+-; CHECK-SPIRV: ConstFunctionPointerINTEL [[FOO_PTR_TYPE_ID]] [[BAR_PTR_ID:[0-9]+]] [[BAR_ID:[0-9]+]]
++; CHECK-SPIRV: ConstantFunctionPointerINTEL [[FOO_PTR_TYPE_ID]] [[FOO_PTR_ID:[0-9]+]] [[FOO_ID:[0-9]+]]
++; CHECK-SPIRV: ConstantFunctionPointerINTEL [[FOO_PTR_TYPE_ID]] [[BAR_PTR_ID:[0-9]+]] [[BAR_ID:[0-9]+]]
+ ;
+ ; CHECK-SPIRV: Function {{[0-9]+}} [[FOO_ID]] {{[0-9]+}} [[FOO_TYPE_ID]]
+ ; CHECK-SPIRV: Function {{[0-9]+}} [[BAR_ID]] {{[0-9]+}} [[FOO_TYPE_ID]]
+diff --git a/test/transcoding/SPV_INTEL_function_pointers/select.ll b/test/transcoding/SPV_INTEL_function_pointers/select.ll
+index 59904f1f2..2375aa3d8 100644
+--- a/test/transcoding/SPV_INTEL_function_pointers/select.ll
++++ b/test/transcoding/SPV_INTEL_function_pointers/select.ll
+@@ -13,8 +13,8 @@
+ ; CHECK-SPIRV: TypeFunction [[#FUNC_TYPE:]] [[#INT32]] [[#INT32]]
+ ; CHECK-SPIRV: TypePointer [[#FUNC_PTR_TYPE:]] [[#]] [[#FUNC_TYPE]]
+ ; CHECK-SPIRV: TypePointer [[#FUNC_PTR_ALLOCA_TYPE:]] [[#]] [[#FUNC_PTR_TYPE]]
+-; CHECK-SPIRV-DAG: ConstFunctionPointerINTEL [[#FUNC_PTR_TYPE]] [[#BARPTR:]] [[#BAR]]
+-; CHECK-SPIRV-DAG: ConstFunctionPointerINTEL [[#FUNC_PTR_TYPE]] [[#BAZPTR:]] [[#BAZ]]
++; CHECK-SPIRV-DAG: ConstantFunctionPointerINTEL [[#FUNC_PTR_TYPE]] [[#BARPTR:]] [[#BAR]]
++; CHECK-SPIRV-DAG: ConstantFunctionPointerINTEL [[#FUNC_PTR_TYPE]] [[#BAZPTR:]] [[#BAZ]]
+ ; CHECK-SPIRV: Function [[#]] [[#KERNEL_ID]]
+ ; CHECK-SPIRV: Variable [[#FUNC_PTR_ALLOCA_TYPE]] [[#FPTR:]]
+ ; CHECK-SPIRV: Select [[#FUNC_PTR_TYPE]] [[#SELECT:]] [[#]] [[#BARPTR]] [[#BAZPTR]]
+diff --git a/test/transcoding/SPV_INTEL_function_pointers/vector_elem.ll b/test/transcoding/SPV_INTEL_function_pointers/vector_elem.ll
+index d982a097b..ab832f9d5 100644
+--- a/test/transcoding/SPV_INTEL_function_pointers/vector_elem.ll
++++ b/test/transcoding/SPV_INTEL_function_pointers/vector_elem.ll
+@@ -9,8 +9,8 @@
+ ; CHECK-SPIRV: 4 TypePointer [[TypePtr:[0-9]+]] {{[0-9]+}} [[TypeFunc]]
+ ; CHECK-SPIRV: 4 TypeVector [[TypeVec:[0-9]+]] [[TypePtr]] [[TypeInt32]]
+ ; CHECK-SPIRV-DAG: 3 Undef [[TypeVec]] [[TypeUndef:[0-9]+]]
+-; CHECK-SPIRV-DAG: 4 ConstFunctionPointerINTEL [[TypePtr]] [[F1Ptr:[0-9]+]] [[F1]]
+-; CHECK-SPIRV-DAG: 4 ConstFunctionPointerINTEL [[TypePtr]] [[F2Ptr:[0-9]+]] [[F2]]
++; CHECK-SPIRV-DAG: 4 ConstantFunctionPointerINTEL [[TypePtr]] [[F1Ptr:[0-9]+]] [[F1]]
++; CHECK-SPIRV-DAG: 4 ConstantFunctionPointerINTEL [[TypePtr]] [[F2Ptr:[0-9]+]] [[F2]]
+ 
+ ; CHECK-SPIRV: 6 CompositeInsert [[TypeVec]] [[NewVec0:[0-9]+]] [[F1Ptr]] [[TypeUndef]] 0
+ ; CHECK-SPIRV: 6 CompositeInsert [[TypeVec]] [[NewVec1:[0-9]+]] [[F2Ptr]] [[NewVec0]] 1
+

--- a/extra-devel/spirv-llvm-translator/spec
+++ b/extra-devel/spirv-llvm-translator/spec
@@ -1,4 +1,5 @@
 VER=13.0.0
+REL=1
 SRCS="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v${VER/+/-}.tar.gz"
 CHKSUMS="sha256::b416c06525c8724be628327565956c418755fbb471b4fe23d040ca56e1a79061"
 CHKUPDATE="anitya::id=227273"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Rework `spirv-llvm-translator` to fix CMake modules conflics with `spirv-headers`.

Package(s) Affected
-------------------

`spirv-llvm-translator`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
