### PR TITLE
systemd-boot-friend: update to 0.12.2

### DIFF
--- a/extra-admin/systemd-boot-friend/autobuild/overrides/etc/systemd-boot-friend.conf
+++ b/extra-admin/systemd-boot-friend/autobuild/overrides/etc/systemd-boot-friend.conf
@@ -1,8 +1,8 @@
 # VMLINUZ: vmlinuz filename format
-VMLINUZ="vmlinuz-{VERSION}-{LOCALVERSION}"
+VMLINUZ="vmlinuz-{VERSION}"
 
 # INITRD: initrd filename format
-INITRD="initramfs-{VERSION}-{LOCALVERSION}.img"
+INITRD="initramfs-{VERSION}.img"
 
 # DISTRO: distro name
 DISTRO="AOSC OS"

--- a/extra-admin/systemd-boot-friend/spec
+++ b/extra-admin/systemd-boot-friend/spec
@@ -1,5 +1,4 @@
-VER=0.11.0
-REL=1
+VER=0.12.2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/systemd-boot-friend-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226819"


### PR DESCRIPTION
Topic Description
-----------------

Update `systemd-boot-friend` to 0.12.2

Package(s) Affected
-------------------

`systemd-boot-friend`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`