### PR TITLE
Default Settings Survey on 20220121

### DIFF
--- a/extra-mate/mate-terminal/autobuild/patch
+++ b/extra-mate/mate-terminal/autobuild/patch
@@ -1,1 +1,0 @@
-sed -i -E 's/（(_.)）/(\1)/g' po/zh_CN.po

--- a/extra-mate/mate-terminal/autobuild/patches/0001-Fedora-mate-terminal_better_defaults-1.26.0.patch
+++ b/extra-mate/mate-terminal/autobuild/patches/0001-Fedora-mate-terminal_better_defaults-1.26.0.patch
@@ -1,0 +1,115 @@
+diff -uprN mate-terminal-1.26.0-orig/src/org.mate.terminal.gschema.xml.in mate-terminal-1.26.0/src/org.mate.terminal.gschema.xml.in
+--- mate-terminal-1.26.0-orig/src/org.mate.terminal.gschema.xml.in	2021-08-05 18:25:06.000000000 +0200
++++ mate-terminal-1.26.0/src/org.mate.terminal.gschema.xml.in	2021-08-05 20:29:24.919890686 +0200
+@@ -99,22 +99,22 @@
+       <description>True if the menubar should be shown in new windows, for windows/tabs with this profile.</description>
+     </key>
+     <key name="foreground-color" type="s">
+-      <default>'#000000'</default>
++      <default>'#E6E6E6'</default>
+       <summary>Default color of text in the terminal</summary>
+       <description>Default color of text in the terminal, as a color specification (can be HTML-style hex digits, or a color name such as "red").</description>
+     </key>
+     <key name="background-color" type="s">
+-      <default>'#FFFFDD'</default>
++      <default>'#000000'</default>
+       <summary>Default color of terminal background</summary>
+       <description>Default color of terminal background, as a color specification (can be HTML-style hex digits, or a color name such as "red").</description>
+     </key>
+     <key name="bold-color" type="s">
+-      <default>'#000000'</default>
++      <default>'#FFFFFF'</default>
+       <summary>Default color of bold text in the terminal</summary>
+       <description>Default color of bold text in the terminal, as a color specification (can be HTML-style hex digits, or a color name such as "red"). This is ignored if bold_color_same_as_fg is true.</description>
+     </key>
+     <key name="bold-color-same-as-fg" type="b">
+-      <default>true</default>
++      <default>false</default>
+       <summary>Whether bold text should use the same color as normal text</summary>
+       <description>If true, boldface text will be rendered using the same color as normal text.</description>
+     </key>
+@@ -174,7 +174,7 @@
+       <description>Number of scrollback lines to keep around. You can scroll back in the terminal by this number of lines; lines that don't fit in the scrollback are discarded. If scrollback_unlimited is true, this value is ignored.</description>
+     </key>
+     <key name="scrollback-unlimited" type="b">
+-      <default>false</default>
++      <default>true</default>
+       <summary>Whether an unlimited number of lines should be kept in scrollback</summary>
+       <description>If true, scrollback lines will never be discarded. The scrollback history is stored on disk temporarily, so this may cause the system to run out of disk space if there is a lot of output to the terminal.</description>
+     </key>
+@@ -264,7 +264,7 @@
+       <description>Sets what code the delete key generates. Possible values are "ascii-del" for the ASCII DEL character, "control-h" for Control-H (AKA the ASCII BS character), "escape-sequence" for the escape sequence typically  bound to backspace or delete. "escape-sequence" is normally considered the correct setting for the Delete key.</description>
+     </key>
+     <key name="use-theme-colors" type="b">
+-      <default>true</default>
++      <default>false</default>
+       <summary>Whether to use the colors from the theme for the terminal widget</summary>
+       <description>If true, the theme color scheme used for text entry boxes will be used for the terminal, instead of colors provided by the user.</description>
+     </key>
+diff -uprN mate-terminal-1.26.0-orig/src/profile-editor.c mate-terminal-1.26.0/src/profile-editor.c
+--- mate-terminal-1.26.0-orig/src/profile-editor.c	2021-08-05 18:25:06.000000000 +0200
++++ mate-terminal-1.26.0/src/profile-editor.c	2021-08-05 20:30:45.036767966 +0200
+@@ -42,6 +42,11 @@ struct _TerminalColorScheme
+ static const TerminalColorScheme color_schemes[] =
+ {
+ 	{
++		N_("White on black"),
++		{ 1, 1, 1, 1 },
++		{ 0, 0, 0, 1 }
++	},
++	{
+ 		N_("Black on light yellow"),
+ 		{ 0, 0, 0, 1 },
+ 		{ 1, 1, 0.866667, 1 }
+@@ -61,11 +66,6 @@ static const TerminalColorScheme color_s
+ 		{ 0, 1, 0, 1 },
+ 		{ 0, 0, 0, 1 }
+ 	},
+-	{
+-		N_("White on black"),
+-		{ 1, 1, 1, 1 },
+-		{ 0, 0, 0, 1 }
+-	},
+ 	/* Translators: "Solarized" is the name of a colour scheme, "light" can be translated */
+ 	{ N_("Solarized light"),
+ 		{ 0.396078, 0.482352, 0.513725, 1 },
+diff -uprN mate-terminal-1.26.0-orig/src/terminal-profile.c mate-terminal-1.26.0/src/terminal-profile.c
+--- mate-terminal-1.26.0-orig/src/terminal-profile.c	2021-08-05 18:25:06.000000000 +0200
++++ mate-terminal-1.26.0/src/terminal-profile.c	2021-08-05 20:32:43.709577138 +0200
+@@ -130,8 +130,9 @@ enum
+ 
+ /* Keep these in sync with the GSettings schema! */
+ #define DEFAULT_ALLOW_BOLD            (TRUE)
+-#define DEFAULT_BACKGROUND_COLOR      ("#FFFFDD")
+-#define DEFAULT_BOLD_COLOR_SAME_AS_FG (TRUE)
++#define DEFAULT_BACKGROUND_COLOR      ("#000000")
++#define DEFAULT_BOLD_COLOR            ("#FFFFFF")
++#define DEFAULT_BOLD_COLOR_SAME_AS_FG (FALSE)
+ #define DEFAULT_BACKGROUND_DARKNESS   (0.5)
+ #define DEFAULT_BACKGROUND_IMAGE_FILE ("")
+ #define DEFAULT_BACKGROUND_TYPE       (TERMINAL_BACKGROUND_SOLID)
+@@ -145,13 +146,13 @@ enum
+ #define DEFAULT_DELETE_BINDING        (VTE_ERASE_DELETE_SEQUENCE)
+ #define DEFAULT_EXIT_ACTION           (TERMINAL_EXIT_CLOSE)
+ #define DEFAULT_FONT                  ("Monospace 12")
+-#define DEFAULT_FOREGROUND_COLOR      ("#000000")
++#define DEFAULT_FOREGROUND_COLOR      ("#E6E6E6")
+ #define DEFAULT_LOGIN_SHELL           (FALSE)
+ #define DEFAULT_NAME                  (NULL)
+ #define DEFAULT_PALETTE               (terminal_palettes[TERMINAL_PALETTE_TANGO])
+ #define DEFAULT_SCROLL_BACKGROUND     (TRUE)
+ #define DEFAULT_SCROLLBACK_LINES      (512)
+-#define DEFAULT_SCROLLBACK_UNLIMITED  (FALSE)
++#define DEFAULT_SCROLLBACK_UNLIMITED  (TRUE)
+ #define DEFAULT_SCROLLBAR_POSITION    (TERMINAL_SCROLLBAR_RIGHT)
+ #define DEFAULT_SCROLL_ON_KEYSTROKE   (TRUE)
+ #define DEFAULT_SCROLL_ON_OUTPUT      (FALSE)
+@@ -164,7 +165,7 @@ enum
+ #define DEFAULT_USE_SKEY              (TRUE)
+ #define DEFAULT_USE_URLS              (TRUE)
+ #define DEFAULT_USE_SYSTEM_FONT       (TRUE)
+-#define DEFAULT_USE_THEME_COLORS      (TRUE)
++#define DEFAULT_USE_THEME_COLORS      (FALSE)
+ #define DEFAULT_VISIBLE_NAME          (N_("Unnamed"))
+ #define DEFAULT_WORD_CHARS            ("-A-Za-z0-9,./?%&#:_=+@~")
+ 

--- a/extra-mate/mate-terminal/autobuild/prepare
+++ b/extra-mate/mate-terminal/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Dropping incorrect parentheses around accelerators in po/zh_CN.po ..."
+sed -E 's/（(_.)）/(\1)/g' \
+    -i "$SRCDIR"/po/zh_CN.po

--- a/extra-mate/mate-terminal/spec
+++ b/extra-mate/mate-terminal/spec
@@ -1,4 +1,5 @@
 VER=1.26.0
+REL=1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-terminal-$VER.tar.xz"
 CHKSUMS="sha256::7727e714c191c3c55e535e30931974e229ca5128e052b62ce74dcc18f7eaaf22"
 CHKUPDATE="anitya::id=198702"

--- a/extra-misc/gnome-default-settings/spec
+++ b/extra-misc/gnome-default-settings/spec
@@ -1,3 +1,3 @@
-VER=0+git20210519
-SRCS="git::commit=6946332c52278ebda69230815925cb5fa6086783::https://github.com/AOSC-Dev/aosc-default-settings"
+VER=0+git20220121
+SRCS="git::commit=9bd1a05e856dd7ad71714d4de0272120318d1284::https://github.com/AOSC-Dev/aosc-default-settings"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Tweak MATE and GNOME Terminal default settings to use dark colour schemes, originally, both terminals default to a bright background and dark text. We can't allow that in 2022.

Package(s) Affected
-------------------

- `gnome-default-settings` v0+git20220121
- `mate-terminal` v1.26.0-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`


Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`