### PR TITLE
hplip: fix cups daemon service name org.cups.cupsd => cups

### DIFF
--- a/extra-doc/hplip/autobuild/postinst
+++ b/extra-doc/hplip/autobuild/postinst
@@ -1,3 +1,2 @@
 # Avoid hp-check error.
-systemctl enable org.cups.cupsd
-systemctl start org.cups.cupsd
+systemctl enable cups --now

--- a/extra-doc/hplip/spec
+++ b/extra-doc/hplip/spec
@@ -1,5 +1,5 @@
 VER=3.21.2
-REL=2
+REL=3
 SRCS="tbl::https://prdownloads.sourceforge.net/hplip/hplip-$VER.tar.gz"
 CHKSUMS="sha256::410421a13e62205d41bacd3215993c89e513fb4d7fab07e23e2720465aea7c41"
 CHKUPDATE="anitya::id=1327"


### PR DESCRIPTION
Topic Description
-----------------

Recent CUPS update changed its service name from `org.cups.cupsd.service` to `cups.service`. HPLIP references this service name in `postinst`, which was broken. This topic fixes this issue.

Package(s) Affected
-------------------

- `hplip` v3.21.2-3

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`