### PR TITLE
discord: add a configurable launcher script

### DIFF
--- a/extra-web/discord/autobuild/build
+++ b/extra-web/discord/autobuild/build
@@ -18,12 +18,12 @@ rm -v "$PKGDIR"/usr/lib/discord/postinst.sh
 
 abinfo "Installing executable symlink, icon, and .desktop entry ..."
 install -dv "$PKGDIR"/usr/{bin,share/{pixmaps,applications,doc/discord}}
-ln -sv ../lib/discord/Discord \
-    "$PKGDIR"/usr/bin/discord
 ln -sv ../../lib/discord/discord.png \
     "$PKGDIR"/usr/share/pixmaps/discord.png
 ln -sv ../../lib/discord/discord.desktop \
     "$PKGDIR"/usr/share/applications/discord.desktop
+sed -e 's|/usr/lib/discord/Discord|/usr/bin/discord|g' \
+    -i "$PKGDIR"/usr/lib/discord/discord.desktop
 
 abinfo "Setting SUID on chrome-sandbox ..."
 chmod -v u+s "$PKGDIR"/usr/lib/discord/chrome-sandbox

--- a/extra-web/discord/autobuild/overrides/etc/discord-launcher.conf
+++ b/extra-web/discord/autobuild/overrides/etc/discord-launcher.conf
@@ -1,0 +1,14 @@
+# /etc/discord.conf - Options for Discord launcher script /usr/bin/discord.
+
+# DO NOT EDIT DISCORD_LAUNCH_OPTIONS_DISTRO unless you know what you are doing.
+#
+# Distribution-defined options
+#
+# --use-gl=desktop is Necessary to fix launch issues.
+DISCORD_LAUNCH_OPTIONS_DISTRO="--use-gl=desktop"
+
+# NVIDIA-specific hacks.
+DISCORD_LAUNCH_OPTIONS_NVIDIA="--no-sandbox"
+
+# Please input your custom launch options here.
+DISCORD_LAUNCH_OPTIONS=""

--- a/extra-web/discord/autobuild/overrides/usr/bin/discord
+++ b/extra-web/discord/autobuild/overrides/usr/bin/discord
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Read DISCORD_LAUNCH_OPTIONS from /etc/discord-launcher.conf
+source /etc/discord-launcher.conf
+
+# Launch Discord ...
+if [ ! -c /dev/nvidiactl ]; then
+    /usr/lib/discord/Discord \
+        "$DISCORD_LAUNCH_OPTIONS_DISTRO" "$DISCORD_LAUNCH_OPTIONS" "$@"
+else
+    echo 'NVIDIA proprietary driver detected, disabling sandbox ...'
+    /usr/lib/discord/Discord \
+        "$DISCORD_LAUNCH_OPTIONS_NVIDIA" "$DISCORD_LAUNCH_OPTIONS_DISTRO" "$DISCORD_LAUNCH_OPTIONS" "$@"
+fi

--- a/extra-web/discord/spec
+++ b/extra-web/discord/spec
@@ -1,4 +1,5 @@
 VER=0.0.16
+REL=1
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
 CHKSUMS="sha256::51354a8ecfe2ec2fe6f35e356d706c6a441115dfdcfff126aaa84a864af538e9"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Introduce a launcher facility for Discord.

- Make /usr/bin a wrapper script that reads parameters from /etc/discord-launcher.conf and calls /usr/lib/discord/Discord.
- Make discord.desktop reference /usr/bin/discord (previously /usr/lib/discord/Discord).
- Include DISCORD_LAUNCH_OPTIONS_NVIDIA for that little something that Just Works(R).

Package(s) Affected
-------------------

- `discord` v0.0.16-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
