### PR TITLE
qt-4: fix FTBFS on GCC11 (with autobuild update)

### DIFF
--- a/extra-devel/autobuild3/spec
+++ b/extra-devel/autobuild3/spec
@@ -1,4 +1,4 @@
-VER=1.6.41
+VER=1.6.42
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"

--- a/extra-libs/qt-4/autobuild/patches/qt-everywhere-opensource-src-4.8.7-gcc6.patch
+++ b/extra-libs/qt-4/autobuild/patches/qt-everywhere-opensource-src-4.8.7-gcc6.patch
@@ -1,24 +1,3 @@
-diff -up qt-everywhere-opensource-src-4.8.7/configure.gcc6 qt-everywhere-opensource-src-4.8.7/configure
---- qt-everywhere-opensource-src-4.8.7/configure.gcc6	2016-04-15 07:04:19.430268222 -0500
-+++ qt-everywhere-opensource-src-4.8.7/configure	2016-04-15 07:05:22.157568689 -0500
-@@ -7744,7 +7744,7 @@ case "$XPLATFORM" in
-     *-g++*)
- 	# Check gcc's version
- 	case "$(${QMAKE_CONF_COMPILER} -dumpversion)" in
--	    5*|4*|3.4*)
-+	    10*|9*|8*|7*|6*|5*|4*|3.4*)
- 		;;
-             3.3*)
-                 canBuildWebKit="no"
-@@ -8060,7 +8060,7 @@ g++*)
-     3.*)
-         COMPILER_VERSION="3.*"
-         ;;
--    5*|4.*)
-+    10*|9*|8*|7*|6*|5*|4.*)
-         COMPILER_VERSION="4"
-         ;;
-     *)
 diff -up qt-everywhere-opensource-src-4.8.7/src/xmlpatterns/api/qcoloroutput_p.h.gcc6 qt-everywhere-opensource-src-4.8.7/src/xmlpatterns/api/qcoloroutput_p.h
 --- qt-everywhere-opensource-src-4.8.7/src/xmlpatterns/api/qcoloroutput_p.h.gcc6	2015-05-07 09:14:48.000000000 -0500
 +++ qt-everywhere-opensource-src-4.8.7/src/xmlpatterns/api/qcoloroutput_p.h	2016-04-15 07:04:19.431268227 -0500

--- a/extra-libs/qt-4/autobuild/patches/series
+++ b/extra-libs/qt-4/autobuild/patches/series
@@ -33,6 +33,8 @@ qt-everywhere-opensource-src-4.8.6-QTBUG-38585.patch
 qt-everywhere-opensource-src-4.8.7-mips64.patch
 qt-everywhere-opensource-src-4.8.7-gcc6.patch
 qt-everywhere-opensource-src-4.8.7-alsa-1.1.patch
+qt-everywhere-opensource-src-4.8.7-gcc11.patch
+qt-everywhere-opensource-src-4.8.7-hardcode-buildkey.patch
 qt-everywhere-opensource-src-4.8.5-qgtkstyle_disable_gtk_theme_check.patch
 qt-everywhere-opensource-src-4.8.6-QTBUG-22829.patch
 qt-aarch64.patch

--- a/extra-libs/qt-4/spec
+++ b/extra-libs/qt-4/spec
@@ -1,5 +1,5 @@
 VER=4.8.7
-REL=15
+REL=16
 SRCS="tbl::https://download.qt.io/archive/qt/${VER:0:3}/$VER/qt-everywhere-opensource-src-$VER.tar.gz"
 CHKSUMS="sha256::e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0"
 CHKUPDATE="html::url=https://download.qt.io/archive/qt/${VER:0:3}/$VER/;pattern=qt-everywhere-opensource-src-(.+?).tar.gz"


### PR DESCRIPTION
Topic Description
-----------------

Fix Qt 4 FTBFS on GCC11

Package(s) Affected
-------------------

- `autobuild3`
- `qt-4`

Security Update?
----------------

No

Build Order
-----------

`autobuild3 qt-4`

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`