### PR TITLE
Google Chrome 97.0.4692.99

### DIFF
--- a/extra-web/google-chrome/spec
+++ b/extra-web/google-chrome/spec
@@ -1,4 +1,4 @@
-VER=97.0.4692.71
+VER=97.0.4692.99
 SRCS="file::rename=google-chrome-stable_current_amd64.deb::https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
-CHKSUMS="sha256::5f2bdd7cbfc65322f40a76e88d10df1e5ec194f69d28d3db6d2b5f0691cbdd84"
+CHKSUMS="sha256::48334071fa2462698301231e9d63b647f558eecc6e60a6d9cfc71805a1564ea1"
 CHKUPDATE="anitya::id=5349"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates google chrome to 97.0.4692.99 and resolves the issue where google-chrome/stable 97.0.4692.71 some how shipped old 94.x binaries.

Package(s) Affected
-------------------

* google-chrome

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

<!-- TODO: CI to auto-fill architectural progress. -->
