### PR TITLE
polkit: mark SUID for /usr/bin/pkexec

### DIFF
--- a/extra-admin/polkit/autobuild/beyond
+++ b/extra-admin/polkit/autobuild/beyond
@@ -1,5 +1,8 @@
-abinfo "Setting configuration dir owner to polkitd user and permissions"
-chown -cvR 27:root "${PKGDIR}/etc/polkit-1/rules.d"
+abinfo "Setting configuration dir owner to polkitd user and permissions ..."
+chown -cvR 27:root "$PKGDIR"/etc/polkit-1/rules.d
 
-abinfo "Setting suid bit on polkit agent helper"
-chmod -v u+s "${PKGDIR}/usr/lib/polkit-1/polkit-agent-helper-1"
+abinfo "Setting SUID bit on polkit agent helper ..."
+chmod -v u+s "$PKGDIR"/usr/lib/polkit-1/polkit-agent-helper-1
+
+abinfo "Setting SUID bit on pkexec ..."
+chmod -v 4755 "$PKGDIR"/usr/bin/pkexec

--- a/extra-admin/polkit/spec
+++ b/extra-admin/polkit/spec
@@ -1,5 +1,5 @@
 VER=0.120
-REL=1
+REL=2
 SRCS="tbl::https://gitlab.freedesktop.org/polkit/polkit/-/archive/${VER}/polkit-${VER}tar.gz"
 CHKSUMS="sha256::713150a329bd90ac0541f6bf23d4db0fc105a037437fc6880e5265a2255ffdb5"
 CHKUPDATE="anitya::id=3682"


### PR DESCRIPTION
Topic Description
-----------------

Previously `/usr/bin/pkexec` does not have the SUID bit, rendering PolicyKit unusable. This update addresses this issue.

Package(s) Affected
-------------------

- `polkit` v0.120-2

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`