### PR TITLE
glib: drop sysprof dep

### DIFF
--- a/base-libs/glib/autobuild/defines
+++ b/base-libs/glib/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=glib
 PKGSEC=libs
-PKGDEP="glibc pcre libffi elfutils util-linux sysprof"
+PKGDEP="glibc pcre libffi elfutils util-linux"
 PKGDEP__RETRO="pcre libffi"
 PKGDEP__ARMEL="${PKGDEP__RETRO}"
 PKGDEP__ARMHF="${PKGDEP__RETRO}"
@@ -24,7 +24,7 @@ MESON_AFTER="-Dfam=false \
              -Dgtk_doc=true \
              -Dglib_debug=disabled \
              -Dselinux=disabled \
-             -Dsysprof=enabled \
+             -Dsysprof=disabled \
              -Dinstalled_tests=false \
              --default-library=both"
 MESON_AFTER__RETRO=" \

--- a/base-libs/glib/spec
+++ b/base-libs/glib/spec
@@ -1,5 +1,5 @@
 VER=2.70.2
-REL=1
+REL=2
 SRCS="https://download.gnome.org/sources/glib/${VER:0:4}/glib-$VER.tar.xz"
 CHKSUMS="sha256::0551459c85cd3da3d58ddc9016fd28be5af503f5e1615a71ba5b512ac945806f"
 CHKUPDATE="anitya::id=10024"


### PR DESCRIPTION
Topic Description
-----------------

Drop `sysprof` dependency from `glib`, which is a GNOME application, introducing half of a GNOME stack into a base system. Let's not.

Package(s) Affected
-------------------

- `glib` v2.70.2-2

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`