### PR TITLE
adobe-source-han-serif: update to 2.001

### DIFF
--- a/extra-fonts/adobe-source-han-serif/spec
+++ b/extra-fonts/adobe-source-han-serif/spec
@@ -1,6 +1,6 @@
-VER=2.000
-SRCS="tbl::https://github.com/adobe-fonts/source-han-serif/releases/download/${VER}R/SourceHanSerif.ttc.zip \
+VER=2.001
+SRCS="tbl::https://github.com/adobe-fonts/source-han-serif/releases/download/${VER}R/01_SourceHanSerif.ttc.zip \
       file::rename=LICENSE::https://raw.githubusercontent.com/adobe-fonts/source-han-serif/${VER}R/LICENSE.txt"
-CHKSUMS="sha256::443832c1a6fb8304fe6013bb175289bca3afd04ff7fbb662fe9425f940ec19c3 \
+CHKSUMS="sha256::50b76bb4f2edcec81f6441d692be1e6c2fc5491387056249543f8fcdd209e8e8 \
          sha256::6a73f9541c2de74158c0e7cf6b0a58ef774f5a780bf191f2d7ec9cc53efe2bf2"
 CHKUPDATE="anitya::id=14493"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

adobe-source-han-serif: update to 2.001

Package(s) Affected
-------------------

adobe-source-han-serif: 2.001

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch` 


<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch` 