### PR TITLE
Telegram desktop 3.5.0

### DIFF
--- a/extra-multimedia/libvpx/autobuild/patches/0001-mask-ext-ratectrl-abi-change.patch
+++ b/extra-multimedia/libvpx/autobuild/patches/0001-mask-ext-ratectrl-abi-change.patch
@@ -1,0 +1,13 @@
+diff --git a/vpx/vpx_ext_ratectrl.h b/vpx/vpx_ext_ratectrl.h
+index a193e5595..5ee214123 100644
+--- a/vpx/vpx_ext_ratectrl.h
++++ b/vpx/vpx_ext_ratectrl.h
+@@ -25,7 +25,7 @@ extern "C" {
+  * types, removing or reassigning enums, adding/removing/rearranging
+  * fields to structures.
+  */
+-#define VPX_EXT_RATECTRL_ABI_VERSION (1)
++#define VPX_EXT_RATECTRL_ABI_VERSION (0)
+ 
+ /*!\brief Abstract rate control model handler
+  *

--- a/extra-multimedia/libvpx/spec
+++ b/extra-multimedia/libvpx/spec
@@ -1,4 +1,4 @@
-VER=1.9.0
-SRCS="tbl::https://github.com/webmproject/libvpx/archive/v$VER.tar.gz"
-CHKSUMS="sha256::d279c10e4b9316bf11a570ba16c3d55791e1ad6faa4404c67422eb631782c80a"
+VER=1.10.0
+SRCS="tbl::https://github.com/webmproject/libvpx/archive/v$VER/libvpx-$VER.tar.gz"
+CHKSUMS="sha256::85803ccbdbdd7a3b03d930187cb055f1353596969c1f92ebec2db839fa4f834a"
 CHKUPDATE="anitya::id=11083"

--- a/extra-web/telegram-desktop/autobuild/patches/0001-alpine-small-sizes.patch
+++ b/extra-web/telegram-desktop/autobuild/patches/0001-alpine-small-sizes.patch
@@ -1,0 +1,25 @@
+diff --git a/Telegram/SourceFiles/window/window.style b/Telegram/SourceFiles/window/window.style
+index b3cd3ae83..29bf8bc3c 100644
+--- a/Telegram/SourceFiles/window/window.style
++++ b/Telegram/SourceFiles/window/window.style
+@@ -10,7 +10,7 @@ using "basic.style";
+ using "ui/widgets/widgets.style";
+ using "history/history.style";
+ 
+-windowMinWidth: 380px;
++windowMinWidth: 360px;
+ windowMinHeight: 480px;
+ windowDefaultWidth: 800px;
+ windowDefaultHeight: 600px;
+@@ -19,7 +19,7 @@ windowShadowShift: 1px;
+ 
+ columnMinimalWidthLeft: 260px;
+ columnMaximalWidthLeft: 540px;
+-columnMinimalWidthMain: 380px;
++columnMinimalWidthMain: 360px;
+ columnDesiredWidthMain: 512px;
+ columnMinimalWidthThird: 292px;
+ columnMaximalWidthThird: 392px;
+-- 
+2.24.1
+

--- a/extra-web/telegram-desktop/autobuild/patches/0004-support-phosh.patch
+++ b/extra-web/telegram-desktop/autobuild/patches/0004-support-phosh.patch
@@ -1,0 +1,57 @@
+diff --git a/Telegram/SourceFiles/core/launcher.cpp b/Telegram/SourceFiles/core/launcher.cpp
+index 31e130a97..40baa98e8 100644
+--- a/Telegram/SourceFiles/core/launcher.cpp
++++ b/Telegram/SourceFiles/core/launcher.cpp
+@@ -61,7 +61,8 @@ FilteredCommandLineArguments::FilteredCommandLineArguments(
+ #endif // !Q_OS_WIN
+ 	}
+ #elif defined Q_OS_UNIX
+-	if (Platform::DesktopEnvironment::IsGnome() && qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
++	if (Platform::DesktopEnvironment::IsGnome() && !Platform::DesktopEnvironment::IsPhosh() &&
++	    qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+ 		pushArgument("-platform");
+ 		pushArgument("xcb;wayland");
+ 	}
+diff --git a/Telegram/SourceFiles/platform/linux/linux_desktop_environment.cpp b/Telegram/SourceFiles/platform/linux/linux_desktop_environment.cpp
+index 63865d56f..71a4716f2 100644
+--- a/Telegram/SourceFiles/platform/linux/linux_desktop_environment.cpp
++++ b/Telegram/SourceFiles/platform/linux/linux_desktop_environment.cpp
+@@ -61,6 +61,8 @@ std::vector<Type> Compute() {
+ 			result.push_back(Type::KDE);
+ 		} else if (desktop == qstr("mate")) {
+ 			result.push_back(Type::MATE);
++		} else if (desktop == qstr("phosh")) {
++			result.push_back(Type::Phosh);
+ 		}
+ 	};
+ 
+@@ -110,6 +112,7 @@ std::vector<Type> ComputeAndLog() {
+ 			case Type::KDE: return qsl("KDE, ");
+ 			case Type::Unity: return qsl("Unity, ");
+ 			case Type::MATE: return qsl("MATE, ");
++			case Type::Phosh: return qsl("Phosh, ");
+ 			}
+ 			Unexpected("Type in Platform::DesktopEnvironment::ComputeAndLog");
+ 		}),
+diff --git a/Telegram/SourceFiles/platform/linux/linux_desktop_environment.h b/Telegram/SourceFiles/platform/linux/linux_desktop_environment.h
+index 121c97064..8a0998952 100644
+--- a/Telegram/SourceFiles/platform/linux/linux_desktop_environment.h
++++ b/Telegram/SourceFiles/platform/linux/linux_desktop_environment.h
+@@ -16,6 +16,7 @@ enum class Type {
+ 	KDE,
+ 	Unity,
+ 	MATE,
++	Phosh,
+ };
+ 
+ std::vector<Type> Get();
+@@ -40,5 +41,9 @@ inline bool IsMATE() {
+ 	return ranges::contains(Get(), Type::MATE);
+ }
+ 
++inline bool IsPhosh() {
++	return ranges::contains(Get(), Type::Phosh);
++}
++
+ } // namespace DesktopEnvironment
+ } // namespace Platform

--- a/extra-web/telegram-desktop/autobuild/patches/0006-fix-missing-qtwidgets-private-header.patch
+++ b/extra-web/telegram-desktop/autobuild/patches/0006-fix-missing-qtwidgets-private-header.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/external/qt/CMakeLists.txt b/cmake/external/qt/CMakeLists.txt
+index a4b15d3..c9ada89 100644
+--- a/cmake/external/qt/CMakeLists.txt
++++ b/cmake/external/qt/CMakeLists.txt
+@@ -27,6 +27,7 @@ if (DESKTOP_APP_USE_PACKAGED)
+     INTERFACE
+         ${Qt5Core_PRIVATE_INCLUDE_DIRS}
+         ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
++	${Qt5Widgets_PRIVATE_INCLUDE_DIRS}
+     )
+ 
+     if (Qt5DBus_FOUND)

--- a/extra-web/telegram-desktop/spec
+++ b/extra-web/telegram-desktop/spec
@@ -1,9 +1,9 @@
-VER=3.4.3
+VER=3.5.0
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
-OWTVER=429a6869e4a164e0aad2d8657db341d56f9a6a6f
+OWTVER=d618d0b5ff3e59bea0143e6070481f8f4316a428
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::ad673a434a3ca335789c55f6f555a2482f734d897b6f0798dcd837ce65b79405 \
+CHKSUMS="sha256::3b5742d05a97bd9a9602419293cfeb5023b98fba81fb465db0d881ce811f6706 \
          SKIP"
 SUBDIR="tdesktop-$VER-full"
 CHKUPDATE="anitya::id=16951"


### PR DESCRIPTION
Topic Description
-----------------

Update Telegram Desktop to 3.5.0, which supports video stickers.

Some dependencies are updated for successfully building telegram-desktop, soname breakage is prevented to try to prevent ABI issues.

Package(s) Affected
-------------------
- `libvpx` updated to 1.10.0
- `telegram-desktop` updated to 3.5.0

Security Update?
----------------

No

Build Order
-----------

`libvpx telegram-desktop`

Test Build(s) Done
------------------

**Primary Architectures**


- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
