### PR TITLE
hamlib: update to 4.4

### DIFF
--- a/extra-radio/hamlib/autobuild/beyond
+++ b/extra-radio/hamlib/autobuild/beyond
@@ -1,2 +1,3 @@
+abinfo "Removing unneeded files ..."
 find "$PKGDIR" -name '.packlist' -delete
 find "$PKGDIR" -name '*.pod' -delete

--- a/extra-radio/hamlib/autobuild/defines
+++ b/extra-radio/hamlib/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=hamlib
 PKGSEC=hamradio
 PKGDES="Ham radio control library"
-PKGDEP="libxml2 libusb"
-BUILDDEP="libtool pkg-config swig"
+PKGDEP="libxml2 libusb python-3 tcl"
+BUILDDEP="doxygen libtool perl swig"
 PKGBREAK="qsstv<=9.2.6-2 gpredict<=2.2.1"
 
 # XXX: USRP backend, Perl, TCL, and Lua bindings are not enabled

--- a/extra-radio/hamlib/autobuild/defines
+++ b/extra-radio/hamlib/autobuild/defines
@@ -3,7 +3,6 @@ PKGSEC=hamradio
 PKGDES="Ham radio control library"
 PKGDEP="libxml2 libusb python-3 tcl"
 BUILDDEP="doxygen libtool perl swig"
-PKGBREAK="qsstv<=9.2.6-2 gpredict<=2.2.1"
 
 AUTOTOOLS_AFTER="--with-python-binding \
                  --with-perl-binding \

--- a/extra-radio/hamlib/autobuild/defines
+++ b/extra-radio/hamlib/autobuild/defines
@@ -5,5 +5,6 @@ PKGDEP="libxml2 libusb python-3 tcl"
 BUILDDEP="doxygen libtool perl swig"
 PKGBREAK="qsstv<=9.2.6-2 gpredict<=2.2.1"
 
-# XXX: USRP backend, Perl, TCL, and Lua bindings are not enabled
-AUTOTOOLS_AFTER="--with-python-binding"
+AUTOTOOLS_AFTER="--with-python-binding \
+                 --with-perl-binding \
+                 --with-tcl-binding"

--- a/extra-radio/hamlib/autobuild/prepare
+++ b/extra-radio/hamlib/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Exporting Python 3 interpreter path for hamlib ..."
+export PYTHON=/usr/bin/python3

--- a/extra-radio/hamlib/spec
+++ b/extra-radio/hamlib/spec
@@ -1,4 +1,4 @@
-VER=4.2
+VER=4.4
 SRCS="tbl::https://github.com/Hamlib/Hamlib/releases/download/$VER/hamlib-$VER.tar.gz"
-CHKSUMS="sha256::e200b22f307e9a0c826187c2b08fe81c7d0283cf07056e6db3463d1481580fd5"
+CHKSUMS="sha256::8bf0107b071f52f08587f38e2dee8a7848de1343435b326f8f66d95e1f8a2487"
 CHKUPDATE="anitya::id=1292"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update to `hamlib` to 4.4, and try to not depend on Python 2.

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
