### PR TITLE
Rust: security update to 1.58.1

### DIFF
--- a/base-devel/llvm/spec
+++ b/base-devel/llvm/spec
@@ -1,4 +1,4 @@
-VER=13.0.0
+VER=13.0.1
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-$VER.src.tar.xz \
       https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/clang-$VER.src.tar.xz \
       https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/compiler-rt-$VER.src.tar.xz \

--- a/base-devel/llvm/spec
+++ b/base-devel/llvm/spec
@@ -10,14 +10,14 @@ SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-$
       https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/libunwind-$VER.src.tar.xz \
       https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/polly-$VER.src.tar.xz"
 SUBDIR="llvm-$VER.src"
-CHKSUMS="sha256::408d11708643ea826f519ff79761fcdfc12d641a2510229eec459e72f8163020 \
-         sha256::5d611cbb06cfb6626be46eb2f23d003b2b80f40182898daa54b1c4e8b5b9e17e \
-         sha256::4c3602d76c7868a96b30c36165c4b7643e2a20173fced7e071b4baeb2d74db3f \
-         sha256::428b6060a28b22adf0cdf5d827abbc2ba81809f4661ede3d02b1d3fedaa3ead5 \
-         sha256::24c65bd5ec0d7cbc37bafdd7533b1783352708bf6338c403a72f47884e406dbd \
-         sha256::20d1900bcd64ff62047291f6edb6ba2fed34d782675ff68713bf0c2fc9e69386 \
-         sha256::3682f16ce33bb0a8951fc2c730af2f9b01a13b71b2b0dc1ae1e7034c7d86ca1a \
-         sha256::becd5f1cd2c03cd6187558e9b4dc8a80b6d774ff2829fede88aa1576c5234ce3 \
-         sha256::36f819091216177a61da639244eda67306ccdd904c757d70d135e273278b65e1 \
-         sha256::cd93672c3be35146e199b1e221fb81a39403a0cdeabcad4a47ae878655eea872"
+CHKSUMS="sha256::ec6b80d82c384acad2dc192903a6cf2cdbaffb889b84bfb98da9d71e630fc834 \
+         sha256::787a9e2d99f5c8720aa1773e4be009461cd30d3bd40fdd24591e473467c917c9 \
+         sha256::7b33955031f9a9c5d63077dedb0f99d77e4e7c996266952c1cec55626dca5dfc \
+         sha256::cc2bc8598848513fa2257a270083e986fd61048347eccf1d801926ea709392d0 \
+         sha256::4a0c590bccbb3ce8fcbc1997aaed89a0ddbfd8be4b7f393230a867b2de62db16 \
+         sha256::666af745e8bf7b680533b4d18b7a31dc7cab575b1e6e4d261922bbafd9644cfb \
+         sha256::2f446acc00bb7cfb4e866c2fa46d1b6dbf4e7d2ab62e3c3d84e56f7b9e28110f \
+         sha256::db5fa6093c786051e8b1c85527240924eceb6c95eeff0a2bbc57be8422b3cef1 \
+         sha256::e206dbf1bbe058a113bffe189386ded99a160b2443ee1e2cd41ff810f78551ba \
+         sha256::f4003e03da57b53bf206faadd0cf53f7b198c38498c605dec45743db23c10ad0"
 CHKUPDATE="anitya::id=1830"

--- a/extra-libs/llvm-runtime+wasi/spec
+++ b/extra-libs/llvm-runtime+wasi/spec
@@ -6,10 +6,10 @@ SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-$
       https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/libunwind-$VER.src.tar.xz \
       file::rename=wasi-sdk.cmake::https://cdn.jsdelivr.net/gh/WebAssembly/wasi-sdk@2cd26ead40830726a4804702c7e8f9069e3eca88/wasi-sdk.cmake"
 SUBDIR="llvm-$VER.src"
-CHKSUMS="sha256::408d11708643ea826f519ff79761fcdfc12d641a2510229eec459e72f8163020 \
-         sha256::4c3602d76c7868a96b30c36165c4b7643e2a20173fced7e071b4baeb2d74db3f \
-         sha256::3682f16ce33bb0a8951fc2c730af2f9b01a13b71b2b0dc1ae1e7034c7d86ca1a \
-         sha256::becd5f1cd2c03cd6187558e9b4dc8a80b6d774ff2829fede88aa1576c5234ce3 \
-         sha256::36f819091216177a61da639244eda67306ccdd904c757d70d135e273278b65e1 \
+CHKSUMS="sha256::ec6b80d82c384acad2dc192903a6cf2cdbaffb889b84bfb98da9d71e630fc834 \
+         sha256::7b33955031f9a9c5d63077dedb0f99d77e4e7c996266952c1cec55626dca5dfc \
+         sha256::2f446acc00bb7cfb4e866c2fa46d1b6dbf4e7d2ab62e3c3d84e56f7b9e28110f \
+         sha256::db5fa6093c786051e8b1c85527240924eceb6c95eeff0a2bbc57be8422b3cef1 \
+         sha256::e206dbf1bbe058a113bffe189386ded99a160b2443ee1e2cd41ff810f78551ba \
          sha256::cdb8e60f856802000c2026a631942fc42c4aeca1ed24e571b54fc65664aadb62"
 CHKUPDATE="anitya::id=1830"

--- a/extra-libs/llvm-runtime+wasi/spec
+++ b/extra-libs/llvm-runtime+wasi/spec
@@ -1,4 +1,4 @@
-VER=13.0.0
+VER=13.0.1
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-$VER.src.tar.xz \
       https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/compiler-rt-$VER.src.tar.xz \
       https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/libcxx-$VER.src.tar.xz \

--- a/extra-rust/rustc/spec
+++ b/extra-rust/rustc/spec
@@ -1,4 +1,4 @@
-VER=1.57.0
+VER=1.58.1
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.gz"
-CHKSUMS="sha256::3546f9c3b91b1f8b8efd26c94d6b50312c08210397b4072ed2748e2bd4445c1a"
+CHKSUMS="sha256::a839afdd3625d6f3f3c4c10b79813675d1775c460d14be1feaf33a6c829c07c7"
 CHKUPDATE="anitya::id=7635"


### PR DESCRIPTION
Topic Description
-----------------

Rust: security update to 1.58.1

Package(s) Affected
-------------------

```
llvm
llvm-runtime
llvm-runtime+wasi
rustc
```

Security Update?
----------------

Yes, #3808

Test Build(s) Done
------------------

**Primary Architectures**

- [X] AMD64 `amd64`   
- [X] AArch64 `arm64`
- [X] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [X] Loongson 3 `loongson3`
- [X] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
- [ ] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

