### PR TITLE
inkscape: update to 1.1.2

### DIFF
--- a/extra-creativity/inkscape/spec
+++ b/extra-creativity/inkscape/spec
@@ -1,4 +1,4 @@
-VER=1.1.1
-SRCS="tbl::https://gitlab.com/inkscape/inkscape/-/archive/INKSCAPE_${VER//./_}/inkscape-INKSCAPE_${VER//./_}.tar.gz"
-CHKSUMS="sha256::d98777213b0d6c6b56d9b3a18b8c41b447d22a7dd1c1b5e8ef74ecd3bf439daa"
+VER=1.1.2
+SRCS="tbl::https://media.inkscape.org/dl/resources/file/inkscape-${VER}.tar.xz"
+CHKSUMS="sha256::3ffe54a06d0b25a4cd8b6eb424536ef1ed205be13443a39cd437c8c7b89b96d1"
 CHKUPDATE="anitya::id=1381"

--- a/extra-creativity/inkscape/spec
+++ b/extra-creativity/inkscape/spec
@@ -1,4 +1,4 @@
-VER=1.0.1
+VER=1.1.1
 SRCS="tbl::https://gitlab.com/inkscape/inkscape/-/archive/INKSCAPE_${VER//./_}/inkscape-INKSCAPE_${VER//./_}.tar.gz"
 CHKSUMS="sha256::a73f4985b23ea68cba0a1a97184c0a02bfcc6c0659db3dd8a0637af07fec287e"
 CHKUPDATE="anitya::id=1381"

--- a/extra-creativity/inkscape/spec
+++ b/extra-creativity/inkscape/spec
@@ -1,4 +1,4 @@
 VER=1.1.1
 SRCS="tbl::https://gitlab.com/inkscape/inkscape/-/archive/INKSCAPE_${VER//./_}/inkscape-INKSCAPE_${VER//./_}.tar.gz"
-CHKSUMS="sha256::a73f4985b23ea68cba0a1a97184c0a02bfcc6c0659db3dd8a0637af07fec287e"
+CHKSUMS="sha256::d98777213b0d6c6b56d9b3a18b8c41b447d22a7dd1c1b5e8ef74ecd3bf439daa"
 CHKUPDATE="anitya::id=1381"


### PR DESCRIPTION

Topic Description
-----------------
* update inkscape to 1.1.2

Package(s) Affected
-------------------
* inkscape

Security Update?
----------------
 No 

Test Build(s) Done
------------------

**Primary Architectures**
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


**Secondary Architectures**
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.
- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`


**Secondary Architectures**
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.
- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
