### PR TITLE
autobuild: update to 1.6.47

### DIFF
--- a/extra-devel/autobuild3/spec
+++ b/extra-devel/autobuild3/spec
@@ -1,4 +1,4 @@
-VER=1.6.46
+VER=1.6.47
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"


### PR DESCRIPTION
Topic Description
-----------------

autobuild3: update to 1.6.47

Package(s) Affected
-------------------

`autobuild3`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

N/A

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

N/A
