### PR TITLE
kitty: update to 0.24.2

### DIFF
--- a/extra-libs/librsync/spec
+++ b/extra-libs/librsync/spec
@@ -1,4 +1,4 @@
-VER=2.0.2
+VER=2.3.2
 SRCS="tbl::https://github.com/librsync/librsync/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::e67b9520ee84f7239be6e948795803bd95495091cc00bf6d0e8c6976032a4af1"
+CHKSUMS="sha256::ef8ce23df38d5076d25510baa2cabedffbe0af460d887d86c2413a1c2b0c676f"
 CHKUPDATE="anitya::id=6309"

--- a/extra-utils/kitty/autobuild/defines
+++ b/extra-utils/kitty/autobuild/defines
@@ -1,5 +1,4 @@
 PKGNAME=kitty
 PKGSEC=utils
 PKGDEP="fontconfig glew glfw python-3 x11-app lcms2 librsync"
-BUILDDEP="sphinx"
 PKGDES="A modern, hackable, featureful, OpenGL based terminal emulator"

--- a/extra-utils/kitty/autobuild/defines
+++ b/extra-utils/kitty/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=kitty
 PKGSEC=utils
-PKGDEP="fontconfig glew glfw python-3 x11-app lcms2"
+PKGDEP="fontconfig glew glfw python-3 x11-app lcms2 librsync"
 BUILDDEP="sphinx"
 PKGDES="A modern, hackable, featureful, OpenGL based terminal emulator"

--- a/extra-utils/kitty/spec
+++ b/extra-utils/kitty/spec
@@ -1,5 +1,4 @@
-VER=0.20.1
+VER=0.24.2
 SRCS="https://github.com/kovidgoyal/kitty/archive/v$VER.tar.gz"
-CHKSUMS="whirlpool::bb93c97103f5165f5ab5d8d52fb84342beaf3f05981cf0b5a0dcb0d18cbd8d91d4e85a8cdb683aead353d16be51a4ea2a531b4ffe4317a30eafb8202b5ac3dcd"
+CHKSUMS="sha256::6edf5cb7f4f24afe4fef7d209cb7a2bb479438a90919610b0147f48d57b34fc0"
 CHKUPDATE="anitya::id=17405"
-REL=1

--- a/extra-utils/kitty/spec
+++ b/extra-utils/kitty/spec
@@ -1,4 +1,4 @@
 VER=0.24.2
-SRCS="https://github.com/kovidgoyal/kitty/archive/v$VER.tar.gz"
+SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
 CHKSUMS="sha256::6edf5cb7f4f24afe4fef7d209cb7a2bb479438a90919610b0147f48d57b34fc0"
 CHKUPDATE="anitya::id=17405"

--- a/extra-utils/kitty/spec
+++ b/extra-utils/kitty/spec
@@ -1,4 +1,4 @@
 VER=0.24.2
 SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
-CHKSUMS="sha256::6edf5cb7f4f24afe4fef7d209cb7a2bb479438a90919610b0147f48d57b34fc0"
+CHKSUMS="sha256::66a99fcfeae481db65b94b0bc5fdb4bb28b099fe4fa94b9c0fb0284f34c7b9c7"
 CHKUPDATE="anitya::id=17405"


### PR DESCRIPTION
Topic Description
-----------------
Update `kitty` to 0.24.2

Package(s) Affected
-------------------
* `kitty`
* `librsync`

Build Order
-----------
* `librsync` -> `kitty`

Security Update?
----------------
No 

Test Build(s) Done
------------------

**Primary Architectures**
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


**Secondary Architectures**
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`


**Secondary Architectures**
Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
