### PR TITLE
virtualbox: update to 6.1.32

### DIFF
--- a/extra-emulation/virtualbox/01-host/patches/0002-fix-build-with-python-3.10.patch
+++ b/extra-emulation/virtualbox/01-host/patches/0002-fix-build-with-python-3.10.patch
@@ -1,0 +1,143 @@
+# https://www.virtualbox.org/changeset/90537/vbox
+
+Index: trunk/configure
+===================================================================
+--- trunk/configure	(revision 90536)
++++ trunk/configure	(revision 90537)
+@@ -3,7 +3,7 @@
+ # libraries VBox OSE depends on.
+ 
+ #
+-# Copyright (C) 2006-2020 Oracle Corporation
++# Copyright (C) 2006-2021 Oracle Corporation
+ #
+ # This file is part of VirtualBox Open Source Edition (OSE), as
+ # available from http://www.virtualbox.org. This file is free software;
+@@ -2043,7 +2043,7 @@
+ }
+ EOF
+   found=
+-  SUPPYTHONLIBS="python2.7 python2.6 python3.1 python3.2 python3.3 python3.4 python3.4m python3.5 python3.5m python3.6 python3.6m python3.7 python3.7m python3.8 python3.8m python3.9 python3.9m"
++  SUPPYTHONLIBS="python2.7 python2.6 python3.1 python3.2 python3.3 python3.4 python3.4m python3.5 python3.5m python3.6 python3.6m python3.7 python3.7m python3.8 python3.8m python3.9 python3.9m python3.10 python3.10m"
+   for p in $PYTHONDIR; do
+     for d in $SUPPYTHONLIBS; do
+       for b in lib/x86_64-linux-gnu lib/i386-linux-gnu lib64 lib/64 lib; do
+Index: trunk/src/libs/xpcom18a4/python/src/module/_xpcom.cpp
+===================================================================
+--- trunk/src/libs/xpcom18a4/python/src/module/_xpcom.cpp	(revision 90536)
++++ trunk/src/libs/xpcom18a4/python/src/module/_xpcom.cpp	(revision 90537)
+@@ -84,7 +84,11 @@
+ #  define MANGLE_MODULE_INIT(a_Name)    RT_CONCAT(a_Name, MODULE_NAME_SUFFIX)
+ # endif
+ # ifdef VBOX_PYXPCOM_VERSIONED
+-#  if   PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000
++#  if   PY_VERSION_HEX >= 0x030a0000 && PY_VERSION_HEX < 0x030b0000
++#   define MODULE_NAME    MANGLE_MODULE_NAME("VBoxPython3_10")
++#   define initVBoxPython MANGLE_MODULE_INIT(PyInit_VBoxPython3_10)
++
++#  elif   PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000
+ #   define MODULE_NAME    MANGLE_MODULE_NAME("VBoxPython3_9")
+ #   define initVBoxPython MANGLE_MODULE_INIT(PyInit_VBoxPython3_9)
+ 
+Index: trunk/src/libs/xpcom18a4/python/Makefile.kmk
+===================================================================
+--- trunk/src/libs/xpcom18a4/python/Makefile.kmk	(revision 90536)
++++ trunk/src/libs/xpcom18a4/python/Makefile.kmk	(revision 90537)
+@@ -4,7 +4,7 @@
+ #
+ 
+ #
+-# Copyright (C) 2009-2017 Oracle Corporation
++# Copyright (C) 2009-2021 Oracle Corporation
+ #
+ # This file is part of VirtualBox Open Source Edition (OSE), as
+ # available from http://www.virtualbox.org. This file is free software;
+@@ -20,7 +20,7 @@
+ 
+ #
+ # List of supported Python versions, defining a number of
+-# VBOX_PYTHON[26|27|31|32|32M|33|33M|34|34M|35|35M|36|36M|37|37M|38|38M|39|39M|DEF]_[INC|LIB] variables
++# VBOX_PYTHON[26|27|31|32|32M|33|33M|34|34M|35|35M|36|36M|37|37M|38|38M|39|39M|310|310M|DEF]_[INC|LIB] variables
+ # which get picked up below.
+ #
+ ifeq ($(KBUILD_TARGET),darwin) # Relatively predictable, don't script.
+@@ -646,6 +646,52 @@
+  endif
+ endif
+ 
++ifdef VBOX_PYTHON310_INC
++#
++# Python 3.10 version
++#
++DLLS += VBoxPython3_10
++VBoxPython3_10_EXTENDS    = VBoxPythonBase
++VBoxPython3_10_EXTENDS_BY = appending
++VBoxPython3_10_TEMPLATE   = XPCOM
++VBoxPython3_10_INCS       = $(VBOX_PYTHON310_INC)
++VBoxPython3_10_LIBS       = $(VBOX_PYTHON310_LIB)
++
++ ifdef VBOX_WITH_32_ON_64_MAIN_API
++  ifdef VBOX_PYTHON310_LIB_X86
++DLLS += VBoxPython3_10_x86
++VBoxPython3_10_x86_EXTENDS    = VBoxPythonBase_x86
++VBoxPython3_10_x86_EXTENDS_BY = appending
++VBoxPython3_10_x86_TEMPLATE   = XPCOM
++VBoxPython3_10_x86_INCS       = $(VBOX_PYTHON310_INC)
++VBoxPython3_10_x86_LIBS       = $(VBOX_PYTHON310_LIB_X86)
++  endif
++ endif
++endif
++
++ifdef VBOX_PYTHON310M_INC
++#
++# Python 3.10 version with pymalloc
++#
++DLLS += VBoxPython3_10m
++VBoxPython3_10m_EXTENDS    = VBoxPythonBase_m
++VBoxPython3_10m_EXTENDS_BY = appending
++VBoxPython3_10m_TEMPLATE   = XPCOM
++VBoxPython3_10m_INCS       = $(VBOX_PYTHON310M_INC)
++VBoxPython3_10m_LIBS       = $(VBOX_PYTHON310M_LIB)
++
++ ifdef VBOX_WITH_32_ON_64_MAIN_API
++  ifdef VBOX_PYTHON310M_LIB_X86
++DLLS += VBoxPython3_10m_x86
++VBoxPython3_10m_x86_EXTENDS    = VBoxPythonBase_x86_m
++VBoxPython3_10m_x86_EXTENDS_BY = appending
++VBoxPython3_10m_x86_TEMPLATE_  = XPCOM
++VBoxPython3_10m_x86_INCS       = $(VBOX_PYTHON310M_INC)
++VBoxPython3_10m_x86_LIBS       = $(VBOX_PYTHON310M_LIB_X86)
++  endif
++ endif
++endif
++
+ ifdef VBOX_PYTHONDEF_INC
+ #
+ # Python without versioning
+@@ -730,4 +776,3 @@
+ 
+ 
+ include $(FILE_KBUILD_SUB_FOOTER)
+-
+Index: trunk/src/libs/xpcom18a4/python/gen_python_deps.py
+===================================================================
+--- trunk/src/libs/xpcom18a4/python/gen_python_deps.py	(revision 90536)
++++ trunk/src/libs/xpcom18a4/python/gen_python_deps.py	(revision 90537)
+@@ -1,7 +1,7 @@
+ #!/usr/bin/python
+ 
+ """
+-Copyright (C) 2009-2016 Oracle Corporation
++Copyright (C) 2009-2021 Oracle Corporation
+ 
+ This file is part of VirtualBox Open Source Edition (OSE), as
+ available from http://www.virtualbox.org. This file is free software;
+@@ -16,7 +16,7 @@
+ import os,sys
+ from distutils.version import StrictVersion
+ 
+-versions = ["2.6", "2.7", "3.1", "3.2", "3.2m", "3.3", "3.3m", "3.4", "3.4m", "3.5", "3.5m", "3.6", "3.6m", "3.7", "3.7m", "3.8", "3.8m", "3.9", "3.9m" ]
++versions = ["2.6", "2.7", "3.1", "3.2", "3.2m", "3.3", "3.3m", "3.4", "3.4m", "3.5", "3.5m", "3.6", "3.6m", "3.7", "3.7m", "3.8", "3.8m", "3.9", "3.9m", "3.10", "3.10m" ]
+ prefixes = ["/usr", "/usr/local", "/opt", "/opt/local"]
+ known = {}
+ 

--- a/extra-emulation/virtualbox/01-host/patches/0003-fix-pyunicode-problem.patch
+++ b/extra-emulation/virtualbox/01-host/patches/0003-fix-pyunicode-problem.patch
@@ -1,0 +1,26 @@
+# https://www.virtualbox.org/changeset/86623/vbox
+
+Index: trunk/src/libs/xpcom18a4/python/src/PyXPCOM.h
+===================================================================
+--- trunk/src/libs/xpcom18a4/python/src/PyXPCOM.h	(revision 86622)
++++ trunk/src/libs/xpcom18a4/python/src/PyXPCOM.h	(revision 86623)
+@@ -137,12 +137,14 @@
+ #  define PyInt_Check(o) PyLong_Check(o)
+ #  define PyInt_AsLong(o) PyLong_AsLong(o)
+ #  define PyNumber_Int(o) PyNumber_Long(o)
+-#  ifndef PyUnicode_AsUTF8
+-#   define PyUnicode_AsUTF8(o) _PyUnicode_AsString(o)
++#  if !defined(Py_LIMITED_API) && PY_VERSION_HEX <= 0x03030000 /* 3.3 added PyUnicode_AsUTF8AndSize */
++#   ifndef PyUnicode_AsUTF8
++#    define PyUnicode_AsUTF8(o) _PyUnicode_AsString(o)
++#   endif
++#   ifndef PyUnicode_AsUTF8AndSize
++#    define PyUnicode_AsUTF8AndSize(o,s) _PyUnicode_AsStringAndSize(o,s)
++#   endif
+ #  endif
+-#  ifndef PyUnicode_AsUTF8AndSize
+-#   define PyUnicode_AsUTF8AndSize(o,s) _PyUnicode_AsStringAndSize(o,s)
+-#  endif
+ typedef struct PyMethodChain
+ {
+     PyMethodDef *methods;

--- a/extra-emulation/virtualbox/spec
+++ b/extra-emulation/virtualbox/spec
@@ -1,5 +1,4 @@
-VER=6.1.30
-REL=1
+VER=6.1.32
 SRCS="tbl::https://download.virtualbox.org/virtualbox/$VER/VirtualBox-${VER}.tar.bz2"
-CHKSUMS="sha256::3c60a29375549ffc148aaebe859be91b27c19d6fa2deefde1373c4f6da8f18ef"
+CHKSUMS="sha256::5d11384200b4e943ad0056d2cf75980ae4bee852c89650e2914e1b34eedc2d2c"
 CHKUPDATE="anitya::id=14449"

--- a/extra-libs/gsoap/autobuild/beyond
+++ b/extra-libs/gsoap/autobuild/beyond
@@ -1,4 +1,3 @@
-mkdir -p "$PKGDIR"/usr/share/gsoap/import
-mkdir -p "$PKGDIR"/usr/share/gsoap/WS
-cp -R gsoap/import "$PKGDIR"/usr/share/gsoap/
-cp -R gsoap/WS "$PKGDIR"/usr/share/gsoap/
+abinfo "Installing necessary resources ..."
+mkdir -pv "$PKGDIR"/usr/share/gsoap
+cp -Rv "$SRCDIR"/gsoap/{import,WS} "$PKGDIR"/usr/share/gsoap/

--- a/extra-libs/gsoap/autobuild/defines
+++ b/extra-libs/gsoap/autobuild/defines
@@ -3,6 +3,4 @@ PKGSEC=devel
 PKGDEP="openssl zlib"
 PKGDES="Development toolkit for Web Services and XML data bindings for C & C++"
 
-NOPARALLEL=1
-ABSHADOW=0
 NOSTATIC=0

--- a/extra-libs/gsoap/autobuild/defines
+++ b/extra-libs/gsoap/autobuild/defines
@@ -3,4 +3,7 @@ PKGSEC=devel
 PKGDEP="openssl zlib"
 PKGDES="Development toolkit for Web Services and XML data bindings for C & C++"
 
-NOSTATIC=0
+# Note: flag controling whether create shared libraries or not is established
+# by Fedora patch.
+# Reference link: https://src.fedoraproject.org/rpms/gsoap/blob/rawhide/f/gsoap-libtool.patch
+AUTOTOOLS_AFTER="--disable-static"

--- a/extra-libs/gsoap/autobuild/defines
+++ b/extra-libs/gsoap/autobuild/defines
@@ -5,5 +5,5 @@ PKGDES="Development toolkit for Web Services and XML data bindings for C & C++"
 
 # Note: flag controling whether create shared libraries or not is established
 # by Fedora patch.
-# Reference link: https://src.fedoraproject.org/rpms/gsoap/blob/rawhide/f/gsoap-libtool.patch
+# Reference link: https://src.fedoraproject.org/rpms/gsoap/blob/577958/f/gsoap-libtool.patch
 AUTOTOOLS_AFTER="--disable-static"

--- a/extra-libs/gsoap/autobuild/patches/0001-Fedora-gsoap-libtool.patch
+++ b/extra-libs/gsoap/autobuild/patches/0001-Fedora-gsoap-libtool.patch
@@ -1,0 +1,135 @@
+diff -ur gsoap-2.8.orig/configure.ac gsoap-2.8/configure.ac
+--- gsoap-2.8.orig/configure.ac	2020-06-30 21:02:21.000000000 +0200
++++ gsoap-2.8/configure.ac	2020-07-21 22:24:34.231537804 +0200
+@@ -16,8 +16,7 @@
+ AM_PROG_LEX
+ AC_PROG_YACC
+ AC_PROG_CPP
+-AC_PROG_RANLIB
+-#AM_PROG_LIBTOOL
++AM_PROG_LIBTOOL
+ AC_PROG_LN_S
+ AC_PROG_AWK
+ AC_PROG_INSTALL
+@@ -307,15 +306,15 @@
+     WSDL2H_EXTRA_LIBS="${WSDL2H_EXTRA_LIBS} -lgnutls -lgcrypt -lgpg-error -lz"
+     SAMPLE_INCLUDES=
+     SAMPLE_SSL_LIBS="-lgnutls -lgcrypt -lgpg-error -lz"
+-    WSDL2H_SOAP_CPP_LIB="libgsoapssl++.a"
++    WSDL2H_SOAP_CPP_LIB="libgsoapssl++.la"
+   else
+     AC_MSG_RESULT(no)
+     WSDL2H_EXTRA_FLAGS="-DWITH_OPENSSL -DWITH_GZIP"
+     # compile with wsdl2h when OPENSSL is available
+-    WSDL2H_EXTRA_LIBS="${WSDL2H_EXTRA_LIBS} -lssl -lcrypto -lz"
++    WSDL2H_EXTRA_LIBS="${WSDL2H_EXTRA_LIBS} -lcrypto"
+     SAMPLE_INCLUDES=
+     SAMPLE_SSL_LIBS="-lssl -lcrypto -lz"
+-    WSDL2H_SOAP_CPP_LIB="libgsoapssl++.a"
++    WSDL2H_SOAP_CPP_LIB="libgsoapssl++.la"
+   fi
+   if test -n "$ZLIB"; then
+     WSDL2H_EXTRA_FLAGS="-I${ZLIB}/include ${WSDL2H_EXTRA_FLAGS}"
+@@ -334,7 +333,7 @@
+   WSDL2H_EXTRA_FLAGS=
+   SAMPLE_SSL_LIBS=
+   SAMPLE_INCLUDES=
+-  WSDL2H_SOAP_CPP_LIB="libgsoap++.a"
++  WSDL2H_SOAP_CPP_LIB="libgsoap++.la"
+ fi
+ AM_CONDITIONAL([WITH_OPENSSL], [test "x$with_openssl" = "xyes" -a "x$with_gnutls" != "xyes"])
+ AC_SUBST(WSDL2H_EXTRA_FLAGS)
+diff -ur gsoap-2.8.orig/gsoap/Makefile.am gsoap-2.8/gsoap/Makefile.am
+--- gsoap-2.8.orig/gsoap/Makefile.am	2020-06-30 21:02:23.000000000 +0200
++++ gsoap-2.8/gsoap/Makefile.am	2020-07-21 22:24:34.231537804 +0200
+@@ -34,20 +34,30 @@
+ dom_cpp.cpp: dom.cpp
+ 	$(LN_S) -f $(top_srcdir)/gsoap/dom.cpp dom_cpp.cpp
+ 
+-lib_LIBRARIES = libgsoap.a libgsoap++.a libgsoapck.a libgsoapck++.a libgsoapssl.a libgsoapssl++.a
++lib_LTLIBRARIES = libgsoap.la libgsoap++.la libgsoapck.la libgsoapck++.la libgsoapssl.la libgsoapssl++.la
+ 
+-libgsoap_a_SOURCES = stdsoap2.c dom.c
+-libgsoap_a_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform)
+-libgsoap___a_SOURCES = stdsoap2_cpp.cpp dom_cpp.cpp
+-libgsoap___a_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform)
+-libgsoapck_a_SOURCES = stdsoap2_ck.c dom.c
+-libgsoapck_a_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) -DWITH_COOKIES
+-libgsoapck___a_SOURCES = stdsoap2_ck_cpp.cpp dom_cpp.cpp
+-libgsoapck___a_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) -DWITH_COOKIES
+-libgsoapssl_a_SOURCES = stdsoap2_ssl.c dom.c
+-libgsoapssl_a_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) $(WSDL2H_EXTRA_FLAGS) -DWITH_DOM -DWITH_COOKIES
+-libgsoapssl___a_SOURCES = stdsoap2_ssl_cpp.cpp dom_cpp.cpp
+-libgsoapssl___a_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) $(WSDL2H_EXTRA_FLAGS) -DWITH_DOM -DWITH_COOKIES
++SOVERSION = $(shell grep 'define VERSION' $(srcdir)/src/soapcpp2.h | cut -d '"' -f 2)
++
++libgsoap_la_SOURCES = stdsoap2.c dom.c
++libgsoap_la_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform)
++libgsoap_la_LDFLAGS = -release $(SOVERSION)
++libgsoap___la_SOURCES = stdsoap2_cpp.cpp dom_cpp.cpp
++libgsoap___la_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform)
++libgsoap___la_LDFLAGS = -release $(SOVERSION)
++libgsoapck_la_SOURCES = stdsoap2_ck.c dom.c
++libgsoapck_la_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) -DWITH_COOKIES
++libgsoapck_la_LDFLAGS = -release $(SOVERSION)
++libgsoapck___la_SOURCES = stdsoap2_ck_cpp.cpp dom_cpp.cpp
++libgsoapck___la_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) -DWITH_COOKIES
++libgsoapck___la_LDFLAGS = -release $(SOVERSION)
++libgsoapssl_la_SOURCES = stdsoap2_ssl.c dom.c
++libgsoapssl_la_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) $(WSDL2H_EXTRA_FLAGS) -DWITH_DOM -DWITH_COOKIES
++libgsoapssl_la_LDFLAGS = -release $(SOVERSION)
++libgsoapssl_la_LIBADD = -lssl -lcrypto -lz
++libgsoapssl___la_SOURCES = stdsoap2_ssl_cpp.cpp dom_cpp.cpp
++libgsoapssl___la_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) $(WSDL2H_EXTRA_FLAGS) -DWITH_DOM -DWITH_COOKIES
++libgsoapssl___la_LDFLAGS = -release $(SOVERSION)
++libgsoapssl___la_LIBADD = -lssl -lcrypto -lz
+ 
+ BUILT_SOURCES = stdsoap2_cpp.cpp dom_cpp.cpp stdsoap2_ck.c stdsoap2_ck_cpp.cpp stdsoap2_ssl.c stdsoap2_ssl_cpp.cpp
+ 
+diff -ur gsoap-2.8.orig/gsoap/samples/autotest/Makefile.am gsoap-2.8/gsoap/samples/autotest/Makefile.am
+--- gsoap-2.8.orig/gsoap/samples/autotest/Makefile.am	2020-06-30 21:02:24.000000000 +0200
++++ gsoap-2.8/gsoap/samples/autotest/Makefile.am	2020-07-21 22:24:34.231537804 +0200
+@@ -14,7 +14,7 @@
+ WSDLINPUT=$(top_srcdir)/gsoap/samples/autotest/examples.wsdl
+ SOAPHEADER=$(top_srcdir)/gsoap/samples/autotest/examples.h
+ SOAP_CPP_SRC=soapC.cpp soapServer.cpp
+-SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.a
++SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.la
+ 
+ $(SOAP_CPP_SRC) : $(WSDLINPUT)
+ 	$(WSDL) $(WSDL_FLAGS) $(WSDLINPUT)
+diff -ur gsoap-2.8.orig/gsoap/samples/databinding/Makefile.am gsoap-2.8/gsoap/samples/databinding/Makefile.am
+--- gsoap-2.8.orig/gsoap/samples/databinding/Makefile.am	2020-06-30 21:02:25.000000000 +0200
++++ gsoap-2.8/gsoap/samples/databinding/Makefile.am	2020-07-21 22:24:34.232537807 +0200
+@@ -14,7 +14,7 @@
+ WSDLINPUT=$(top_srcdir)/gsoap/samples/databinding/address.xsd
+ SOAPHEADER=$(top_srcdir)/gsoap/samples/databinding/address.h
+ SOAP_CPP_SRC=addressC.cpp
+-SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.a
++SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.la
+ 
+ $(SOAP_CPP_SRC) : $(WSDLINPUT)
+ 	$(WSDL) $(WSDL_FLAGS) $(WSDLINPUT)
+diff -ur gsoap-2.8.orig/gsoap/samples/Makefile.defines gsoap-2.8/gsoap/samples/Makefile.defines
+--- gsoap-2.8.orig/gsoap/samples/Makefile.defines	2020-06-30 21:02:25.000000000 +0200
++++ gsoap-2.8/gsoap/samples/Makefile.defines	2020-07-21 22:24:34.232537807 +0200
+@@ -13,13 +13,13 @@
+ SOAP_C_CORE=soapC.c
+ SOAP_C_CLIENT=soapClient.c $(SOAP_C_CORE)
+ SOAP_C_SERVER=soapServer.c $(SOAP_C_CORE)
+-SOAP_C_LIB=$(top_builddir)/gsoap/libgsoap.a
+-SOAP_C_LIB_CK=$(top_builddir)/gsoap/libgsoapck.a
+-SOAP_C_LIB_SSL=$(top_builddir)/gsoap/libgsoapssl.a
++SOAP_C_LIB=$(top_builddir)/gsoap/libgsoap.la
++SOAP_C_LIB_CK=$(top_builddir)/gsoap/libgsoapck.la
++SOAP_C_LIB_SSL=$(top_builddir)/gsoap/libgsoapssl.la
+ 
+ SOAP_CPP_CORE=soapC.cpp
+ SOAP_CPP_CLIENT=soapClient.cpp $(SOAP_CPP_CORE)
+ SOAP_CPP_SERVER=soapServer.cpp $(SOAP_CPP_CORE)
+-SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.a
+-SOAP_CPP_LIB_CK=$(top_builddir)/gsoap/libgsoapck++.a
+-SOAP_CPP_LIB_SSL=$(top_builddir)/gsoap/libgsoapssl++.a
++SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.la
++SOAP_CPP_LIB_CK=$(top_builddir)/gsoap/libgsoapck++.la
++SOAP_CPP_LIB_SSL=$(top_builddir)/gsoap/libgsoapssl++.la

--- a/extra-libs/gsoap/autobuild/prepare
+++ b/extra-libs/gsoap/autobuild/prepare
@@ -1,3 +1,0 @@
-abinfo "Setting flags so ld also generates normal ELF symbols during LTO"
-export CFLAGS="${CFLAGS} -ffat-lto-objects"
-export CXXFLAGS="${CXXFLAGS} -ffat-lto-objects"

--- a/extra-libs/gsoap/spec
+++ b/extra-libs/gsoap/spec
@@ -1,4 +1,4 @@
-VER=2.8.118
+VER=2.8.119
 SRCS="tbl::https://sourceforge.net/projects/gsoap2/files/gsoap_$VER.zip"
-CHKSUMS="sha256::f233f06a307a664ab1ecafd8f6d87b9c905a98c497c9f5da9083790e5b921f50"
+CHKSUMS="sha256::8997c43b599a2bfe4a788e303a5dd24bbf5992fd06d56f606ca680ca5b0070cf"
 CHKUPDATE="anitya::id=1260"

--- a/extra-libs/gsoap/spec
+++ b/extra-libs/gsoap/spec
@@ -1,4 +1,4 @@
-VER=2.8.114
-SRCTBL="https://sourceforge.net/projects/gsoap2/files/gsoap_$VER.zip"
-CHKSUM="sha256::aa70a999258100c170a3f8750c1f91318a477d440f6a28117f68bc1ded32327f"
+VER=2.8.118
+SRCS="tbl::https://sourceforge.net/projects/gsoap2/files/gsoap_$VER.zip"
+CHKSUMS="sha256::f233f06a307a664ab1ecafd8f6d87b9c905a98c497c9f5da9083790e5b921f50"
 CHKUPDATE="anitya::id=1260"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update `virtualbox` to 6.1.32.

Package(s) Affected
-------------------

```
virtualbox
gsoap
```

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

<!-- TODO: CI to auto-fill architectural progress. -->
