### PR TITLE
nbd: update to 3.23 and fix PKGSEC QA problem

### DIFF
--- a/extra-network/nbd/autobuild/defines
+++ b/extra-network/nbd/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=nbd
 PKGDES="Network block device support package"
-PKGSEC=network
+PKGSEC=net
 PKGDEP="gnutls glib zlib libnl"
 
 AUTOTOOLS_AFTER="--enable-syslog --enable-lfs --enable-gznbd"

--- a/extra-network/nbd/spec
+++ b/extra-network/nbd/spec
@@ -1,5 +1,4 @@
-VER=3.20
-REL=1
+VER=3.23
 SRCS="tbl::https://sourceforge.net/projects/nbd/files/nbd/$VER/nbd-$VER.tar.xz"
-CHKSUMS="sha256::e0e1b3538ab7ae5accf56180afd1a9887d415b98d21223b8ad42592b4af7d6cd"
+CHKSUMS="sha256::def470ec566ac4e3a34d56f391f0a670e520e1bc2eedd67eba62f454418457b4"
 CHKUPDATE="anitya::id=2052"


### PR DESCRIPTION
Topic Description
-----------------

Update `nbd` to 3.23, and fix its QA problem on PKGSEC (should be `net` instead of `network` )

Package(s) Affected
-------------------
- `nbd`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
