### PR TITLE
p7zip: fix ftbfs

### DIFF
--- a/extra-utils/p7zip/autobuild/build
+++ b/extra-utils/p7zip/autobuild/build
@@ -13,3 +13,6 @@ make install \
      DEST_SHARE=/usr/lib/p7zip \
      DEST_MAN=/usr/share/man \
      DEST_DIR="$PKGDIR"
+
+abinfo "Fixing permission ..."
+chmod a+x "$PKGDIR"/usr/bin/p7zipForFilemanager

--- a/extra-utils/p7zip/autobuild/patches/15-fix-gcc11-build.patch
+++ b/extra-utils/p7zip/autobuild/patches/15-fix-gcc11-build.patch
@@ -1,0 +1,12 @@
+diff -Naur p7zip_16.02.old/CPP/7zip/Archive/Wim/WimHandler.cpp p7zip_16.02/CPP/7zip/Archive/Wim/WimHandler.cpp
+--- p7zip_16.02.old/CPP/7zip/Archive/Wim/WimHandler.cpp	2016-06-11 16:08:06.000000000 +0800
++++ p7zip_16.02/CPP/7zip/Archive/Wim/WimHandler.cpp	2022-02-17 19:24:50.304501024 +0800
+@@ -298,7 +298,7 @@
+ 
+       AString res;
+ 
+-      bool numMethods = 0;
++      unsigned numMethods = 0;
+       for (unsigned i = 0; i < ARRAY_SIZE(k_Methods); i++)
+       {
+         if (methodMask & ((UInt32)1 << i))

--- a/extra-utils/p7zip/autobuild/patches/series
+++ b/extra-utils/p7zip/autobuild/patches/series
@@ -9,3 +9,4 @@
 12-CVE-2016-9296.patch
 13-CVE-2017-17969.patch
 14-CVE-2018-10115.patch
+15-fix-gcc11-build.patch

--- a/extra-utils/p7zip/spec
+++ b/extra-utils/p7zip/spec
@@ -1,5 +1,5 @@
 VER=16.02
-REL=6
+REL=7
 SRCS="tbl::https://sourceforge.net/projects/p7zip/files/p7zip/$VER/p7zip_${VER}_src_all.tar.bz2"
 CHKSUMS="sha256::5eb20ac0e2944f6cb9c2d51dd6c4518941c185347d4089ea89087ffdd6e2341f"
 CHKUPDATE="anitya::id=2583"


### PR DESCRIPTION
Topic Description
-----------------

Fix p7zip FTBFS on GCC 11 and newest AB.

Package(s) Affected
-------------------

- `p7zip`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
