### PR TITLE
fcitx5-pinyin-moegirl: update to 20220218

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20220114
+VER=20220218
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::f1a5e27977b80f04ec5b549e0881b724ee0d038b3a93388ed644a14d792fd74f \
-         sha256::2407ac4855aa1c6f87411a1f6b00e40b1f8aa388748aa8b200f5d1f9f7220c59 \
+CHKSUMS="sha256::d788f20b0a17db13026308a6a693c8e05d2b42f54cef2b32dc0470239b70d0e4 \
+         sha256::badd6859df3c842ab8789d2b2346b862e5449a8ebf9f01bcd2d0bf8bfa3124b0 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

fcitx5-pinyin-moegirl: update to 20220218

The package for this month came a little late due to upstream (zh.moegirl.o.c) reachability problems.

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`