### PR TITLE
meta: add riscv64 to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -55,6 +55,7 @@ Architectural progress for "secondary," or experimental ports does not impede on
 
 - [ ] Loongson 3 `loongson3`
 - [ ] PowerPC 64-bit (Little Endian) `ppc64el`
+- [ ] RISC-V 64-bit `riscv64`
 
 <!-- Maintainers should review file changes and, if the build script(s) affected complies with the
      [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
@@ -86,5 +87,6 @@ Architectural progress for "secondary," or experimental ports does not impede on
 
 - [ ] Loongson 3 `loongson3`
 - [ ] PowerPC 64-bit (Little Endian) `ppc64el`
+- [ ] RISC-V 64-bit `riscv64`
 
 <!-- TODO: CI to auto-fill architectural progress. -->


### PR DESCRIPTION
Description
-----------------

Not a topic, but updating PR templates to include RISC-V 64-bit as secondary architecture.