### PR TITLE
gnu-efi: update to 3.0.14

### DIFF
--- a/extra-devel/gnu-efi/autobuild/build
+++ b/extra-devel/gnu-efi/autobuild/build
@@ -2,6 +2,7 @@ abinfo "Setting architecture for build ..."
 [[ "${CROSS:-$ARCH}" = "amd64" ]] && export NEWARCH="x86_64"
 [[ "${CROSS:-$ARCH}" = "armhf" ]] && export NEWARCH="arm"
 [[ "${CROSS:-$ARCH}" = "arm64" ]] && export NEWARCH="aarch64"
+[[ "${CROSS:-$ARCH}" = "riscv64" ]] && export NEWARCH="riscv64"
 
 abinfo "Building gnu-efi ..."
 make

--- a/extra-devel/gnu-efi/autobuild/defines
+++ b/extra-devel/gnu-efi/autobuild/defines
@@ -7,4 +7,4 @@ ABSTRIP=0
 NOPARALLEL=1
 NOSTATIC=0
 
-FAIL_ARCH="!(amd64|arm64|armhf)"
+FAIL_ARCH="!(amd64|arm64|armhf|riscv64)"

--- a/extra-devel/gnu-efi/spec
+++ b/extra-devel/gnu-efi/spec
@@ -1,5 +1,4 @@
-VER=3.0.12
-REL=2
+VER=3.0.14
 SRCS="tbl::https://download.sourceforge.net/gnu-efi/gnu-efi-$VER.tar.bz2"
-CHKSUMS="sha256::0196f2e1fd3c334b66e610a608a0e59233474c7a01bec7bc53989639aa327669"
+CHKSUMS="sha256::b73b643a0d5697d1f396d7431448e886dd805668789578e3e1a28277c9528435"
 CHKUPDATE="anitya::id=1202"


### PR DESCRIPTION
Topic Description
-----------------

Update gnu-efi to 3.0.14, which comes with riscv64 .

TODO: check mips64el support in gnu-efi, which seems to be for loongson3.

Package(s) Affected
-------------------

- `gnu-efi`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
