### PR TITLE
riscv64 boot-base

### DIFF
--- a/extra-bases/boot-base/autobuild/defines
+++ b/extra-bases/boot-base/autobuild/defines
@@ -5,7 +5,7 @@ PKGDES="Meta package for AOSC OS bootloader support"
 PKGDEP="dosfstools e2fsprogs efibootmgr mtools"
 PKGDEP__AMD64="${PKGDEP} grub intel-ucode plymouth"
 PKGDEP__ARM64="${PKGDEP} uboot-tools"
-PKGDEP__PPC64="${PKGDEP} grub hfsutils plymouth"
+PKGDEP__RISCV64="${PKGDEP} uboot-tools"
 
 PKGDEP__RETRO="grub"
 PKGDEP__ARMEL="${PKGDEP__RETRO} dosfstools mtools uboot-tools"
@@ -16,3 +16,4 @@ PKGDEP__POWERPC="${PKGDEP__RETRO} hfsutils"
 PKGDEP__PPC64="${PKGDEP__RETRO} hfsutils"
 
 VER_NONE=1
+ABSPLITDBG=0

--- a/extra-utils/uboot-tools/autobuild/build
+++ b/extra-utils/uboot-tools/autobuild/build
@@ -1,10 +1,12 @@
-make defconfig
-make
-make tools-all HOSTCC="gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
+abinfo "Building ..."
+make -C "$SRCDIR" defconfig
+make -C "$SRCDIR" tools-all HOSTCC="gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
 
-mkdir -p "$PKGDIR"/usr/{bin,share/man}
-install -m 755 -t "$PKGDIR"/usr/bin/ \
-    tools/{mk{,env}image,env/fw_printenv,img2srec,dumpimage,netconsole,jtagconsole,ncb}
-install -m 644 -D doc/mkimage.1 "$PKGDIR"/usr/share/man/man1/mkimage.1
+abinfo "Installing ..."
+mkdir -pv "$PKGDIR"/usr/{bin,share/man}
+install -v -m 755 -t "$PKGDIR"/usr/bin/ \
+    "$SRCDIR"/tools/{mk{,env}image,env/fw_printenv,img2srec,dumpimage,netconsole,jtagconsole,ncb,mksunxiboot,kwboot,fdtgrep,sunxi-spl-image-builder}
+install -v -m 644 -D "$SRCDIR"/doc/mkimage.1 "$PKGDIR"/usr/share/man/man1/mkimage.1
+install -v -m 644 -D "$SRCDIR"/doc/kwboot.1 "$PKGDIR"/usr/share/man/man1/kwboot.1
 
-ln -s fw_printenv "$PKGDIR"/usr/bin/fw_setenv
+ln -sv fw_printenv "$PKGDIR"/usr/bin/fw_setenv

--- a/extra-utils/uboot-tools/autobuild/defines
+++ b/extra-utils/uboot-tools/autobuild/defines
@@ -1,5 +1,4 @@
 PKGNAME=uboot-tools
 PKGSEC=utils
 PKGDEP="openssl"
-BUILDDEP="sdl"
 PKGDES="U-Boot bootloader utilities"

--- a/extra-utils/uboot-tools/spec
+++ b/extra-utils/uboot-tools/spec
@@ -1,4 +1,4 @@
-VER=2019.10
-SRCS="tbl::https://gitlab.denx.de/u-boot/u-boot/-/archive/v$VER/u-boot-v$VER.tar.gz"
-CHKSUMS="sha256::d550d50b874c9658e4d68c6ee0aa94104ef8dee02f68ac5f506516983ec41ebe"
+VER=2022.01
+SRCS="tbl::https://ftp.denx.de/pub/u-boot/u-boot-$VER.tar.bz2"
+CHKSUMS="sha256::81b4543227db228c03f8a1bf5ddbc813b0bb8f6555ce46064ef721a6fc680413"
 CHKUPDATE="anitya::id=5022"


### PR DESCRIPTION
Topic Description
-----------------

Pack boot-base for riscv64, and for this, bump uboot-tools to fix FTBFS

Package(s) Affected
-------------------

- `boot-base` (no version number change)
- `uboot-tools` v2022.01

Security Update?
----------------

No

Build Order
-----------

`uboot-tools` for architectures other than riscv64, `uboot-tools boot-base` for riscv64

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
