### PR TITLE
starship: add postinst, remove PKGSUG

### DIFF
--- a/extra-utils/starship/autobuild/defines
+++ b/extra-utils/starship/autobuild/defines
@@ -2,7 +2,6 @@ PKGNAME=starship
 PKGSEC=utils
 PKGDES="A customizable shell prompt"
 PKGDEP="glibc openssl libgit2"
-PKGSUG="bash zsh fish powershell tcsh elvish"
 BUILDDEP="rustc llvm python-3"
 
 ABTYPE=rust

--- a/extra-utils/starship/autobuild/postinst
+++ b/extra-utils/starship/autobuild/postinst
@@ -1,0 +1,1 @@
+echo "Visit https://starship.rs/guide/#step-2-setup-your-shell-to-use-starship for information on setting up your shell for Starship."

--- a/extra-utils/starship/spec
+++ b/extra-utils/starship/spec
@@ -1,4 +1,5 @@
 VER=1.3.0
+REL=1
 SRCS="tbl::https://github.com/starship/starship/archive/v$VER.tar.gz"
 CHKSUMS="sha256::3f29cb6e5cb7c673cbc1f8e91ceb4a0d1317d235b147db15e461ffec22be13a5"
 CHKUPDATE="anitya::id=55456"


### PR DESCRIPTION
Topic Description
-----------------

- postinst: add postinst to instruct users on shell configuration
- defines: remove PKGSUG, Starship does not actually require specific
  shells to run, the original PKGSUG confuses users as though it is
  recommending users to install other shells to enhance Starship's
  functionalities

Package(s) Affected
-------------------

`starship` v1.3.0-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`