### PR TITLE
bsc: new, 2022.01

### DIFF
--- a/extra-electronics/bsc/autobuild/build
+++ b/extra-electronics/bsc/autobuild/build
@@ -1,0 +1,27 @@
+abinfo "Install dependencies ..."
+cabal v1-update
+cabal v1-install regex-compat syb old-time split
+
+abinfo "Building ..."
+make release NOASCIIDOCTOR=1
+
+abinfo "Installing the main part ..."
+mkdir -pv "$PKGDIR"/usr/lib
+cp -r "$SRCDIR"/inst/lib "$PKGDIR"/usr/lib/bsc
+cp -r "$SRCDIR"/inst/bin/core "$PKGDIR"/usr/lib/bsc/core
+
+abinfo "Installing document ..."
+mkdir -pv "$PKGDIR"/usr/share/doc
+cp -r "$SRCDIR"/inst/doc "$PKGDIR"/usr/share/doc/bsc
+
+mkdir -pv "$PKGDIR"/usr/bin
+for i in bsc bluetcl; do
+    abinfo "Generating wrapper script $i ..."
+    sed -e 's@^BLUESPECDIR=.*@BLUESPECDIR=/usr/lib/bsc@g' \
+        -e 's@^BINDIR=.*@BINDIR=/usr/lib/bsc@g' \
+        < "$SRCDIR"/src/comp/wrapper.sh > "$PKGDIR"/usr/bin/$i
+    chmod -v 755 "$PKGDIR"/usr/bin/$i
+done
+
+abinfo "Setting shipped SOs' executable permission ..."
+chmod -v a+x "$PKGDIR"/usr/lib/bsc/SAT/*

--- a/extra-electronics/bsc/autobuild/defines
+++ b/extra-electronics/bsc/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=bsc
+PKGDES="BlueSpec Compiler"
+PKGSEC=electronics
+PKGDEP="tcl numactl libffi gmp gcc"
+BUILDDEP="ghc texlive"
+
+# Bluesim contains .a files
+NOLTO=1
+NOSTATIC=0

--- a/extra-electronics/bsc/autobuild/prepare
+++ b/extra-electronics/bsc/autobuild/prepare
@@ -1,0 +1,1 @@
+acbs_copy_git

--- a/extra-electronics/bsc/spec
+++ b/extra-electronics/bsc/spec
@@ -1,0 +1,4 @@
+VER=2022.01
+SRCS="git::commit=tags/$VER::git://github.com/B-Lang-org/bsc.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=B-Lang-org/bsc"


### PR DESCRIPTION
Topic Description
-----------------

Introduce a new package `bsc`, which is the compiler of Bluespec SystemVerilog.

Package(s) Affected
-------------------

- `bsv`

Security Update?
----------------

No

Test Build(s) Done
------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
