### PR TITLE
kernel-base for riscv64

### DIFF
--- a/extra-bases/kernel-base/autobuild/defines
+++ b/extra-bases/kernel-base/autobuild/defines
@@ -9,3 +9,4 @@ PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGDES="Meta package for AOSC OS Linux Kernel support"
 
 VER_NONE=1
+ABSPLITDBG=0


### PR DESCRIPTION
Topic Description
-----------------

Package kernel-base for riscv64

Package(s) Affected
-------------------

- `kernel-base` (no version number change)

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
