### PR TITLE
zram-generator: new, 1.1.1

### DIFF
--- a/extra-admin/zram-generator/autobuild/beyond
+++ b/extra-admin/zram-generator/autobuild/beyond
@@ -3,3 +3,8 @@ make systemd-service man
 
 abinfo "Installing systemd-service and man ..."
 make install DESTDIR="$PKGDIR" NOBUILD=1
+
+abinfo "Removing binaries from /usr/bin ..."
+# zram-generator is a tool for systemd, it should just lie in
+# /usr/lib/systemd/systemd-generator.
+rm -rv "$PKGDIR"/usr/bin

--- a/extra-admin/zram-generator/autobuild/beyond
+++ b/extra-admin/zram-generator/autobuild/beyond
@@ -1,0 +1,5 @@
+abinfo "Making systemd-service and man ..."
+make systemd-service man
+
+abinfo "Installing systemd-service and man ..."
+make install DESTDIR="$PKGDIR" NOBUILD=1

--- a/extra-admin/zram-generator/autobuild/defines
+++ b/extra-admin/zram-generator/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=zram-generator
+PKGSEC=utils
+PKGDES="Systemd unit generator for zram devices"
+PKGDEP="systemd"
+BUILDDEP="rustc llvm"
+
+USECLANG=1
+ABTYPE=rust

--- a/extra-admin/zram-generator/autobuild/defines
+++ b/extra-admin/zram-generator/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=zram-generator
 PKGSEC=utils
 PKGDES="Systemd unit generator for zram devices"
 PKGDEP="systemd"
-BUILDDEP="rustc llvm"
+BUILDDEP="rustc llvm ronn-ng"
 
 USECLANG=1
 ABTYPE=rust

--- a/extra-admin/zram-generator/autobuild/defines
+++ b/extra-admin/zram-generator/autobuild/defines
@@ -5,4 +5,5 @@ PKGDEP="systemd"
 BUILDDEP="rustc llvm ronn-ng"
 
 USECLANG=1
+ABSPLITDBG=0
 ABTYPE=rust

--- a/extra-admin/zram-generator/autobuild/prepare
+++ b/extra-admin/zram-generator/autobuild/prepare
@@ -1,4 +1,7 @@
-abinfo "Running `cargo update` due to lack of Cargo.lock ..."
+abinfo "Running cargo update due to lack of Cargo.lock ..."
 # Upstream ignores Cargo.lock on purpose to take care of some distribution
 # cases (like Fedora), so we need to run this manually as suggested by Rust.
 cargo update
+
+abinfo "Specifying systemd util directory ..."
+export SYSTEMD_UTIL_DIR=/usr/lib/systemd

--- a/extra-admin/zram-generator/autobuild/prepare
+++ b/extra-admin/zram-generator/autobuild/prepare
@@ -1,0 +1,4 @@
+abinfo "Running `cargo update` due to lack of Cargo.lock ..."
+# Upstream ignores Cargo.lock on purpose to take care of some distribution
+# cases (like Fedora), so we need to run this manually as suggested by Rust.
+cargo update

--- a/extra-admin/zram-generator/spec
+++ b/extra-admin/zram-generator/spec
@@ -1,0 +1,4 @@
+VER=1.1.1
+SRCS="tbl::https://github.com/systemd/zram-generator/archive/v$VER.tar.gz"
+CHKSUMS="sha256::7e411fe5ef4b4f0ba80c30eaaa1c3a0f01a50a95975354c170cc49ff7dbd2463"
+CHKUPDATE="anitya::id=18509"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Introduce `zram-generator`, a systemd unit generator for zram devices.
In addition, this PR will introduce `ronn-ng` and its dependencies in order to generate `zram-generator`'s man pages.

Package(s) Affected
-------------------

- `zram-generator` v1.1.1
- `nokogiri` v1.13.3

**Architecture-independent**
- `ronn-ng` v0.9.1
- `rexml` v3.2.5
- `kramdown` v2.3.1
- `racc` v1.6.0
- `mini-portile` v2.8.0

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

```
extra-ruby/rexml
extra-ruby/kramdown
extra-ruby/mini-portile
extra-ruby/racc
extra-ruby/nokogiri
extra-ruby/ronn-ng
extra-admin/zram-generator
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
