### PR TITLE
Rework of bsc-2022.01 (add missing builddep)

### DIFF
--- a/extra-electronics/bsc/autobuild/defines
+++ b/extra-electronics/bsc/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=bsc
 PKGDES="BlueSpec Compiler"
 PKGSEC=electronics
 PKGDEP="tcl numactl libffi gmp gcc"
-BUILDDEP="ghc texlive"
+BUILDDEP="ghc texlive cabal-install gperf"
 
 # Bluesim contains .a files
 NOLTO=1


### PR DESCRIPTION
Topic Description
-----------------

Fixing build of bsc-2022.01.

Package(s) Affected
-------------------

- `bsc`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   

<!-- TODO: CI to auto-fill architectural progress. -->
