### PR TITLE
aosc-os-presets-base: fix FTBFS

### DIFF
--- a/extra-misc/aosc-os-presets-base/autobuild/defines
+++ b/extra-misc/aosc-os-presets-base/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=aosc-os-presets-base
 PKGSEC=misc
 PKGDEP=""
 PKGDES="Systemd presets for AOSC OS Base/Non-Desktop distributions"
+
+ABSPLITDBG=0


### PR DESCRIPTION
Topic Description
-----------------

Fix a simple FTBFS of aosc-os-presets-base by adding ABSPLITDBG=0.

Package(s) Affected
-------------------

- `aosc-os-presets-base` (no version number change)

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
