### PR TITLE
go: support riscv64

### DIFF
--- a/extra-go/go/autobuild/build
+++ b/extra-go/go/autobuild/build
@@ -16,6 +16,8 @@ case ${CROSS:-$ARCH} in
         buildarch="mips64le" ;;
     ppc64el)
         buildarch="ppc64le" ;;
+    riscv64)
+        buildarch="riscv64" ;;
 esac
 
 abinfo "Setting OS to linux, build architecture to $buildarch ..."
@@ -28,7 +30,7 @@ export GOARCH="$buildarch"
     abinfo "Building Go toolchain ..."
     GO_LDFLAGS="-w -s" bash make.bash --no-clean -v
     if [[ "${CROSS:-$ARCH}" != "ppc64" && "${CROSS:-$ARCH}" != "ppc64el" &&
-          "${CROSS:-$ARCH}" != "loongson3" ]]; then
+          "${CROSS:-$ARCH}" != "loongson3" && "${CROSS:-$ARCH}" != "riscv64" ]]; then
         abinfo "Building and preparing to install Go toolchain with data race detector ..."
         PATH="$GOBIN:$PATH" go install -v -race std
 

--- a/extra-go/go/autobuild/defines
+++ b/extra-go/go/autobuild/defines
@@ -7,7 +7,7 @@ PKGDES="The Go language compiler and tools"
 
 NOSTATIC=no
 ABSTRIP=no
-FAIL_ARCH="!(amd64|armel|arm64|loongson3|ppc64el)"
+FAIL_ARCH="!(amd64|armel|arm64|loongson3|ppc64el|riscv64)"
 
 USECLANG=1
 USECLANG__LOONGSON3=0


### PR DESCRIPTION
Topic Description
-----------------

Build go for riscv64.

Package(s) Affected
-------------------

`go`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
