### PR TITLE
linux+kernel: bump to 5.16.11

### DIFF
--- a/extra-kernel/linux+kernel/autobuild/defines
+++ b/extra-kernel/linux+kernel/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=linux+kernel
 PKGSEC=kernel
-PKGDEP="linux-kernel-5.16.3"
+PKGDEP="linux-kernel-5.16.11"
 PKGDES="Generic Linux Kernel for AOSC OS (Mainline)"
 
 PKGREP="linux+image+new linux+header+new linux+image linux+header linux+image+old linux+header+old"

--- a/extra-kernel/linux+kernel/spec
+++ b/extra-kernel/linux+kernel/spec
@@ -1,3 +1,3 @@
-VER=5.16.3
+VER=5.16.11
 DUMMYSRC=1
 CHKUPDATE="anitya::id=6501"


### PR DESCRIPTION
Topic Description
-----------------

Bump linux+kernel for 5.16.11 kernel.

Package(s) Affected
-------------------

`linux+kernel`

Security Update?
----------------

No

Test Build(s) Done
------------------

- [ ] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
