### PR TITLE
expat: update to 2.4.6

### DIFF
--- a/base-libs/expat/spec
+++ b/base-libs/expat/spec
@@ -1,4 +1,4 @@
-VER=2.4.1
+VER=2.4.6
 SRCS="tbl::https://sourceforge.net/projects/expat/files/expat/$VER/expat-$VER.tar.bz2"
-CHKSUMS="sha256::2f9b6a580b94577b150a7d5617ad4643a4301a6616ff459307df3e225bcfbf40"
+CHKSUMS="sha256::ce317706b07cae150f90cddd4253f5b4fba929607488af5ac47bf2bc08e31f09"
 CHKUPDATE="anitya::id=770"


### PR DESCRIPTION
Topic Description
-----------------

Update expat to 2.4.6.

Package(s) Affected
-------------------

- `expat` 2.4.6

Security Update?
----------------

Yes, see #3753

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
