### PR TITLE
feh: update to 3.8

### DIFF
--- a/extra-graphics/feh/spec
+++ b/extra-graphics/feh/spec
@@ -1,4 +1,4 @@
-VER=3.7.1
+VER=3.8
 SRCS="tbl::https://feh.finalrewind.org/feh-$VER.tar.bz2"
-CHKSUMS="sha256::57ab1ca61f57c96595878069f550d36f518530f88fa31b74cc39cd739f9258b6"
+CHKSUMS="sha256::7f3c34552b39336d7ebee2d7c4bf5697aaaa2c6c102c357f6e82ea240bd62ba9"
 CHKUPDATE="anitya::id=790"


### PR DESCRIPTION
Topic Description
-----------------

Update `feh` to 3.8

Package(s) Affected
-------------------

`feh` v3.8

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`