### PR TITLE
hpl: new, 2.3

### DIFF
--- a/extra-benchmarks/hpl/autobuild/beyond
+++ b/extra-benchmarks/hpl/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Installing a shipped HPL.dat as example ..."
+mkdir -p "$PKGDIR"/usr/share/doc/hpl
+cp "$SRCDIR"/testing/ptest/HPL.dat "$PKGDIR"/usr/share/doc/hpl/
+

--- a/extra-benchmarks/hpl/autobuild/beyond
+++ b/extra-benchmarks/hpl/autobuild/beyond
@@ -1,4 +1,3 @@
-abinfo "Installing a shipped HPL.dat as example ..."
-mkdir -p "$PKGDIR"/usr/share/doc/hpl
-cp "$SRCDIR"/testing/ptest/HPL.dat "$PKGDIR"/usr/share/doc/hpl/
-
+abinfo "Installing HPL.dat as example ..."
+install -Dvm644 "$SRCDIR"/testing/ptest/HPL.dat \
+    -t "$PKGDIR"/usr/share/doc/hpl/

--- a/extra-benchmarks/hpl/autobuild/beyond
+++ b/extra-benchmarks/hpl/autobuild/beyond
@@ -1,3 +1,3 @@
 abinfo "Installing HPL.dat as example ..."
 install -Dvm644 "$SRCDIR"/testing/ptest/HPL.dat \
-    -t "$PKGDIR"/usr/share/doc/hpl/
+    -t "$PKGDIR"/etc/hpl/

--- a/extra-benchmarks/hpl/autobuild/defines
+++ b/extra-benchmarks/hpl/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=hpl
+PKGDES="High-performance Linpack implementation"
+PKGSEC=utils
+PKGDEP="openmpi openblas"
+
+ABSHADOW=0

--- a/extra-benchmarks/hpl/autobuild/defines
+++ b/extra-benchmarks/hpl/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=hpl
-PKGDES="High-performance Linpack implementation"
 PKGSEC=utils
 PKGDEP="openmpi openblas"
+PKGDES="A portable implementation of the High-Performance Linpack benchmark"
 
 ABSHADOW=0

--- a/extra-benchmarks/hpl/autobuild/patches/0001-Fedora-hpl-fix-paths.patch
+++ b/extra-benchmarks/hpl/autobuild/patches/0001-Fedora-hpl-fix-paths.patch
@@ -1,0 +1,88 @@
+diff --git a/setup/Make.Linux_PII_CBLAS_gm b/setup/Make.Linux_PII_CBLAS_gm
+index b1c6401..997177b 100644
+--- a/setup/Make.Linux_PII_CBLAS_gm
++++ b/setup/Make.Linux_PII_CBLAS_gm
+@@ -56,6 +56,14 @@ LN_S         = ln -s
+ MKDIR        = mkdir
+ RM           = /bin/rm -f
+ TOUCH        = touch
++
++LBITS := $(shell getconf LONG_BIT)
++ifeq ($(LBITS),64)
++  SYSLIBDIR=/usr/lib64
++else
++  SYSLIBDIR=/usr/lib
++endif
++
+ #
+ # ----------------------------------------------------------------------
+ # - Platform identifier ------------------------------------------------
+@@ -92,9 +100,9 @@ MPlib        =
+ # header files,  LAlib  is defined  to be the name of  the library to be
+ # used. The variable LAdir is only used for defining LAinc and LAlib.
+ #
+-LAdir        = $(HOME)/netlib/ARCHIVES/Linux_PII
++LAdir        = $(SYSLIBDIR)/atlas
+ LAinc        =
+-LAlib        = $(LAdir)/libcblas.a $(LAdir)/libatlas.a
++LAlib        = -L$(LAdir) -lsatlas
+ #
+ # ----------------------------------------------------------------------
+ # - F77 / C interface --------------------------------------------------
+@@ -168,7 +176,7 @@ HPL_DEFS     = $(F2CDEFS) $(HPL_OPTS) $(HPL_INCLUDES)
+ #
+ CC           = mpicc
+ CCNOOPT      = $(HPL_DEFS)
+-CCFLAGS      = $(HPL_DEFS) -fomit-frame-pointer -O3 -funroll-loops -W -Wall
++CCFLAGS      = $(HPL_DEFS) $(CFLAGS) -fomit-frame-pointer -O3 -funroll-loops -W -Wall
+ #
+ # On some platforms,  it is necessary  to use the Fortran linker to find
+ # the Fortran internals used in the BLAS library.
+diff --git a/testing/ptest/HPL_pdinfo.c b/testing/ptest/HPL_pdinfo.c
+index e24530e..fd1ec80 100644
+--- a/testing/ptest/HPL_pdinfo.c
++++ b/testing/ptest/HPL_pdinfo.c
+@@ -48,6 +48,8 @@
+  * Include files
+  */
+ #include "hpl.h"
++#include <stdlib.h>
++#include <string.h>
+ 
+ #ifdef STDC_HEADERS
+ void HPL_pdinfo
+@@ -275,6 +277,8 @@ void HPL_pdinfo
+    char                       * lineptr;
+    int                        error=0, fid, i, j, lwork, maxp, nprocs,
+                               rank, size;
++   char                       * confdir = NULL;
++   char                       conffile[1024] = {0};
+ /* ..
+  * .. Executable Statements ..
+  */
+@@ -291,14 +295,22 @@ void HPL_pdinfo
+  */
+    if( rank == 0 )
+    {
++      if ( ( confdir = getenv("MPI_SYSCONFIG") ) == NULL )
++         strcpy(conffile, "/etc");
++      else
++         strncpy(conffile, confdir, 1023);
++
++      strncat(conffile, "/hpl/HPL.dat", 1023);
++
+ /*
+  * Open file and skip data file header
+  */
+-      if( ( infp = fopen( "HPL.dat", "r" ) ) == NULL )
++      if( ( infp = fopen( "HPL.dat", "r" ) ) == NULL &&
++          ( infp = fopen( conffile, "r" ) ) == NULL )
+       { 
+          HPL_pwarn( stderr, __LINE__, "HPL_pdinfo",
+                     "cannot open file HPL.dat" );
+-         error = 1; goto label_error;
++         exit( 1 );
+       }
+ 
+       (void) fgets( line, HPL_LINE_MAX - 2, infp );
+

--- a/extra-benchmarks/hpl/autobuild/prepare
+++ b/extra-benchmarks/hpl/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Injecting MPI flags ..."
+export CFLAGS="$CFLAGS $(pkg-config ompi-c --cflags)"
+export LIBS="$LIBS $(pkg-config ompi-c --libs)"

--- a/extra-benchmarks/hpl/autobuild/prepare
+++ b/extra-benchmarks/hpl/autobuild/prepare
@@ -1,3 +1,3 @@
 abinfo "Injecting MPI flags ..."
-export CFLAGS="$CFLAGS $(pkg-config ompi-c --cflags)"
-export LIBS="$LIBS $(pkg-config ompi-c --libs)"
+export CFLAGS="${CFLAGS} $(pkg-config ompi-c --cflags)"
+export LIBS="${LIBS} $(pkg-config ompi-c --libs)"

--- a/extra-benchmarks/hpl/spec
+++ b/extra-benchmarks/hpl/spec
@@ -1,0 +1,4 @@
+VER=2.3
+SRCS="tbl::http://www.netlib.org/benchmark/hpl/hpl-${VER}.tar.gz"
+CHKSUMS="sha256::32c5c17d22330e6f2337b681aded51637fb6008d3f0eb7c277b163fadd612830"
+CHKUPDATE="anitya::id=6379"


### PR DESCRIPTION
Topic Description
-----------------

Introduce HPL, a High-performeance Linpack implementation.

Package(s) Affected
-------------------

- `hpl` (new, 2.3)

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
