### PR TITLE
systemd-boot-friend: update to 0.18.1

### DIFF
--- a/extra-admin/systemd-boot-friend/autobuild/overrides/etc/systemd-boot-friend.conf
+++ b/extra-admin/systemd-boot-friend/autobuild/overrides/etc/systemd-boot-friend.conf
@@ -9,7 +9,7 @@ DISTRO="AOSC OS"
 
 # ESP_MOUNTPOINT: defines where the EFI System Partition is located.
 # Notice: no tailing /
-ESP_MOUNTPOINT = "/efi"
+ESP_MOUNTPOINT="/efi"
 
 # BOOTARG: your boot argument
-BOOTARG = ""
+BOOTARG=""

--- a/extra-admin/systemd-boot-friend/spec
+++ b/extra-admin/systemd-boot-friend/spec
@@ -1,5 +1,4 @@
-VER=0.18.0
-REL=1
+VER=0.18.1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/systemd-boot-friend-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226819"


### PR DESCRIPTION
Topic Description
-----------------

Update `systemd-boot-friend` to 0.18.1

Package(s) Affected
-------------------

`systemd-boot-friend` v0.18.1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`