### PR TITLE
Base Drop Python 2 Survey 20220307

### DIFF
--- a/base-devel/llvm/02-compiler/defines
+++ b/base-devel/llvm/02-compiler/defines
@@ -1,6 +1,7 @@
 PKGNAME=llvm
 PKGSEC=devel
-PKGDEP="llvm-runtime perl python-2"
+PKGDEP="llvm-runtime perl python-3"
+BUILDDEP="pypsutil setuptools"
 PKGDES="Low Level Virtual Machine Infrastructure"
 
 NOSTATIC=0

--- a/base-devel/llvm/spec
+++ b/base-devel/llvm/spec
@@ -1,4 +1,5 @@
 VER=13.0.1
+REL=1
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-$VER.src.tar.xz \
       https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/clang-$VER.src.tar.xz \
       https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/compiler-rt-$VER.src.tar.xz \

--- a/base-libs/cracklib/autobuild/beyond
+++ b/base-libs/cracklib/autobuild/beyond
@@ -1,3 +1,26 @@
+abinfo "Preparing to build Python bindings separately ..."
+# Adpated from Debian
+PYBLDDIR="$SRCDIR"/abpybuild
+mkdir -pv "$PYBLDDIR"
+cd "$PYBLDDIR"
+
+abinfo "Configuring Python binding source tree ..."
+"$SRCDIR"/configure $AUTOTOOLS_DEF ${AUTOTOOLS_AFTER/--without-python/}
+rm -rv "$PYBLDDIR"/lib
+ln -sv "$BLDDIR"/lib "$PYBLDDIR"/lib
+
+abinfo "Building Python bindings using $PYTHON ..."
+"$PYTHON" "$PYBLDDIR"/python/setup.py build
+
+abinfo "Installing Python bindings using $PYTHON ..."
+"$PYTHON" "$PYBLDDIR"/python/setup.py install \
+    --prefix=/usr --root="$PKGDIR" --optimize=1
+
+abinfo "Cleaning Python binding source tree ..."
+"$PYTHON" "$PYBLDDIR"/python/setup.py clean
+
+cd "$SRCDIR"
+
 ./util/cracklib-format cracklib-dicts/* | \
 ./util/cracklib-packer "$PKGDIR"/usr/share/cracklib/pw_dict
 ./util/cracklib-format "$PKGDIR"/usr/share/cracklib/cracklib-small | \

--- a/base-libs/cracklib/autobuild/beyond
+++ b/base-libs/cracklib/autobuild/beyond
@@ -24,9 +24,9 @@ cd "$SRCDIR"
 abinfo "Handling shared resources ..."
 # Adapted from Fedora
 "$BLDDIR"/util/cracklib-format cracklib-dicts/* | \
-"$BLDDIR"/util/cracklib-packer "$PKGDIR"/usr/share/cracklib/pw_dict
+    "$BLDDIR"/util/cracklib-packer "$PKGDIR"/usr/share/cracklib/pw_dict
 "$BLDDIR"/util/cracklib-format "$PKGDIR"/usr/share/cracklib/cracklib-small | \
-"$BLDDIR"/util/cracklib-packer "$PKGDIR"/usr/share/cracklib/cracklib-small
+    "$BLDDIR"/util/cracklib-packer "$PKGDIR"/usr/share/cracklib/cracklib-small
 rm -v "$PKGDIR"/usr/share/cracklib/cracklib-small
 
 abinfo "Generating patched headers ..."

--- a/base-libs/cracklib/autobuild/beyond
+++ b/base-libs/cracklib/autobuild/beyond
@@ -9,15 +9,15 @@ abinfo "Configuring Python binding source tree ..."
 rm -rv "$PYBLDDIR"/lib
 ln -sv "$BLDDIR"/lib "$PYBLDDIR"/lib
 
-abinfo "Building Python bindings using $PYTHON ..."
-"$PYTHON" "$PYBLDDIR"/python/setup.py build
+abinfo "Building Python 3.x bindings ..."
+python3 "$PYBLDDIR"/python/setup.py build
 
-abinfo "Installing Python bindings using $PYTHON ..."
-"$PYTHON" "$PYBLDDIR"/python/setup.py install \
+abinfo "Installing Python 3.x bindings ..."
+python3 "$PYBLDDIR"/python/setup.py install \
     --prefix=/usr --root="$PKGDIR" --optimize=1
 
-abinfo "Cleaning Python binding source tree ..."
-"$PYTHON" "$PYBLDDIR"/python/setup.py clean
+abinfo "Cleaning Python 3.x binding source tree ..."
+python3 "$PYBLDDIR"/python/setup.py clean
 
 cd "$SRCDIR"
 

--- a/base-libs/cracklib/autobuild/beyond
+++ b/base-libs/cracklib/autobuild/beyond
@@ -21,17 +21,23 @@ abinfo "Cleaning Python binding source tree ..."
 
 cd "$SRCDIR"
 
-./util/cracklib-format cracklib-dicts/* | \
-./util/cracklib-packer "$PKGDIR"/usr/share/cracklib/pw_dict
-./util/cracklib-format "$PKGDIR"/usr/share/cracklib/cracklib-small | \
-./util/cracklib-packer "$PKGDIR"/usr/share/cracklib/cracklib-small
-rm -f "$PKGDIR"/usr/share/cracklib/cracklib-small
+abinfo "Handling shared resources ..."
+# Adapted from Fedora
+"$BLDDIR"/util/cracklib-format cracklib-dicts/* | \
+"$BLDDIR"/util/cracklib-packer "$PKGDIR"/usr/share/cracklib/pw_dict
+"$BLDDIR"/util/cracklib-format "$PKGDIR"/usr/share/cracklib/cracklib-small | \
+"$BLDDIR"/util/cracklib-packer "$PKGDIR"/usr/share/cracklib/cracklib-small
+rm -v "$PKGDIR"/usr/share/cracklib/cracklib-small
 
+abinfo "Generating patched headers ..."
 sed -e 's|/usr/lib/cracklib_dict|/usr/share/cracklib/pw_dict|g' \
-    lib/crack.h > "$PKGDIR"/usr/include/crack.h
-ln -s cracklib-format "$PKGDIR"/usr/bin/mkdict
-ln -s cracklib-packer "$PKGDIR"/usr/bin/packer
+    "$SRCDIR"/lib/crack.h > "$PKGDIR"/usr/include/crack.h
 
-ln -s ../share/cracklib/pw_dict.hwm "$PKGDIR"/usr/lib/cracklib_dict.hwm
-ln -s ../share/cracklib/pw_dict.pwd "$PKGDIR"/usr/lib/cracklib_dict.pwd
-ln -s ../share/cracklib/pw_dict.pwi "$PKGDIR"/usr/lib/cracklib_dict.pwi
+abinfo "Creating application binary symlinks ..."
+ln -sv cracklib-format "$PKGDIR"/usr/bin/mkdict
+ln -sv cracklib-packer "$PKGDIR"/usr/bin/packer
+
+abinfo "Creating application library symlinks ..."
+ln -sv ../share/cracklib/pw_dict.hwm "$PKGDIR"/usr/lib/cracklib_dict.hwm
+ln -sv ../share/cracklib/pw_dict.pwd "$PKGDIR"/usr/lib/cracklib_dict.pwd
+ln -sv ../share/cracklib/pw_dict.pwi "$PKGDIR"/usr/lib/cracklib_dict.pwi

--- a/base-libs/cracklib/autobuild/defines
+++ b/base-libs/cracklib/autobuild/defines
@@ -4,6 +4,5 @@ PKGDEP="gzip python-3"
 BUILDDEP="setuptools"
 PKGDES="A library used to enforce strong passwords"
 
-ABSHADOW=no
-AUTOTOOLS_AFTER="--with-python \
+AUTOTOOLS_AFTER="--without-python \
                  --with-default-dict=/usr/share/cracklib/pw_dict"

--- a/base-libs/cracklib/autobuild/defines
+++ b/base-libs/cracklib/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=cracklib
 PKGSEC=libs
-PKGDEP="gzip python-2"
+PKGDEP="gzip python-3"
+BUILDDEP="setuptools"
 PKGDES="A library used to enforce strong passwords"
 
 ABSHADOW=no

--- a/base-libs/cracklib/autobuild/prepare
+++ b/base-libs/cracklib/autobuild/prepare
@@ -4,3 +4,6 @@ cp -v "$SRCDIR/../cracklib-words-$PKGVER.gz" "$SRCDIR"/cracklib-dicts/
 
 abinfo "Appending executable bit to util/cracklib-format ..."
 chmod +x -v "$SRCDIR"/util/cracklib-format
+
+abinfo "Specifying Python 3 interpreter path ..."
+export PYTHON=/usr/bin/python3

--- a/base-libs/cracklib/autobuild/prepare
+++ b/base-libs/cracklib/autobuild/prepare
@@ -4,6 +4,3 @@ cp -v "$SRCDIR/../cracklib-words-$PKGVER.gz" "$SRCDIR"/cracklib-dicts/
 
 abinfo "Appending executable bit to util/cracklib-format ..."
 chmod +x -v "$SRCDIR"/util/cracklib-format
-
-abinfo "Specifying Python 3 interpreter path ..."
-export PYTHON=/usr/bin/python3

--- a/base-libs/cracklib/autobuild/prepare
+++ b/base-libs/cracklib/autobuild/prepare
@@ -1,6 +1,6 @@
-mkdir cracklib-dicts/
-cd cracklib-dicts/
-wget https://github.com/cracklib/cracklib/releases/download/v$PKGVER/cracklib-words-$PKGVER.gz
-cd ..
+abinfo "Installing cracklib-word package ..."
+mkdir -pv "$SRCDIR"/cracklib-dicts
+cp -v "$SRCDIR/../cracklib-words-$PKGVER.gz" "$SRCDIR"/cracklib-dicts/
 
-chmod +x util/cracklib-format
+abinfo "Appending executable bit to util/cracklib-format ..."
+chmod +x -v "$SRCDIR"/util/cracklib-format

--- a/base-libs/cracklib/spec
+++ b/base-libs/cracklib/spec
@@ -1,5 +1,7 @@
 VER=2.9.7
-REL=1
-SRCS="tbl::https://github.com/cracklib/cracklib/releases/download/v$VER/cracklib-$VER.tar.bz2"
-CHKSUMS="sha256::fe82098509e4d60377b998662facf058dc405864a8947956718857dbb4bc35e6"
+REL=2
+SRCS="tbl::https://github.com/cracklib/cracklib/releases/download/v$VER/cracklib-$VER.tar.bz2 \
+      file::rename=cracklib-words-$VER.gz::https://github.com/cracklib/cracklib/releases/download/v$VER/cracklib-words-$VER.gz"
+CHKSUMS="sha256::fe82098509e4d60377b998662facf058dc405864a8947956718857dbb4bc35e6
+         sha256::7f0c45faf84a2494f15d1e2720394aca4a379163a70c4acad948186c0047d389"
 CHKUPDATE="anitya::id=362"

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -714,3 +714,4 @@ calibre
 tortoisehg
 cadence
 carla
+cracklib


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

This PR is to drop Python 2 dependency (and switch to Python 3) of the applications in `base-*` categories (excluding `python-2`).

Package(s) Affected
-------------------

```
llvm
cracklib
```

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
