### PR TITLE
onefetch: new, 2.11.0

### DIFF
--- a/extra-utils/onefetch/autobuild/defines
+++ b/extra-utils/onefetch/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=onefetch
+PKGSEC="utils"
+PKGDEP="git"
+BUILDDEP="rustc llvm"
+PKGDES="A command-line Git information tool"
+
+USECLANG=1

--- a/extra-utils/onefetch/autobuild/defines
+++ b/extra-utils/onefetch/autobuild/defines
@@ -5,3 +5,4 @@ BUILDDEP="rustc llvm"
 PKGDES="A command-line Git information tool"
 
 USECLANG=1
+ABSPLITDBG=0

--- a/extra-utils/onefetch/autobuild/defines
+++ b/extra-utils/onefetch/autobuild/defines
@@ -6,3 +6,4 @@ PKGDES="A command-line Git information tool"
 
 USECLANG=1
 ABSPLITDBG=0
+NOLTO__RISCV64=1

--- a/extra-utils/onefetch/autobuild/defines
+++ b/extra-utils/onefetch/autobuild/defines
@@ -6,4 +6,6 @@ PKGDES="A command-line tool to show local Git repository summary"
 
 USECLANG=1
 ABSPLITDBG=0
+
+# FIXME: LTO breaks build on riscv64 when linking zstd.
 NOLTO__RISCV64=1

--- a/extra-utils/onefetch/autobuild/defines
+++ b/extra-utils/onefetch/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=onefetch
 PKGSEC="utils"
 PKGDEP="git"
 BUILDDEP="rustc llvm"
-PKGDES="A command-line Git information tool"
+PKGDES="A command-line tool to show local Git repository summary"
 
 USECLANG=1
 ABSPLITDBG=0

--- a/extra-utils/onefetch/spec
+++ b/extra-utils/onefetch/spec
@@ -1,0 +1,4 @@
+VER=2.11.0
+SRCS="https://github.com/o2sh/onefetch/archive/v$VER.tar.gz"
+CHKSUMS="sha256::ffd3cc3bd24e299ede1fada2b2da8bf066d59219da167477e1997c860650c192"
+CHKUPDATE="anitya::id=141703"


### PR DESCRIPTION
Topic Description
-----------------

Add `onefetch` package

Package(s) Affected
-------------------

`onefetch` v2.11.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`