### PR TITLE
bottles: new, 2022.2.28+trento+4

### DIFF
--- a/extra-utils/bottles/autobuild/defines
+++ b/extra-utils/bottles/autobuild/defines
@@ -2,5 +2,6 @@ PKGNAME=bottles
 PKGSEC=utils
 PKGDES="A Wine prefix manager"
 PKGDEP="cabextract gtk-3 libhandy markdown patool pygobject-3 python-3 pyyaml"
+PKGRECOM="wine lutris"
 
 ABHOST=noarch

--- a/extra-utils/bottles/autobuild/defines
+++ b/extra-utils/bottles/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=bottles
+PKGSEC=utils
+PKGDES="A Wine prefix manager"
+PKGDEP="cabextract gtk-3 libhandy markdown patool pygobject-3 python-3 pyyaml"

--- a/extra-utils/bottles/autobuild/defines
+++ b/extra-utils/bottles/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=bottles
 PKGSEC=utils
 PKGDES="A Wine prefix manager"
 PKGDEP="cabextract gtk-3 libhandy markdown patool pygobject-3 python-3 pyyaml"
+
+ABHOST=noarch

--- a/extra-utils/bottles/spec
+++ b/extra-utils/bottles/spec
@@ -1,0 +1,4 @@
+VER=2022.2.28+trento+4
+SRCS="tbl::https://github.com/bottlesdevs/Bottles/archive/refs/tags/${VER//+/-}.tar.gz"
+CHKSUMS="sha256::fb54db4114b0abbe8376af4008b6ccd06c41eb2e5d64e372c75f5d2f8e24deff"
+CHKUPDATE="anitya::id=155688"

--- a/extra-utils/patool/autobuild/defines
+++ b/extra-utils/patool/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=patool
+PKGSEC=utils
+PKGDES="Command line archive file manager"
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/extra-utils/patool/spec
+++ b/extra-utils/patool/spec
@@ -1,0 +1,4 @@
+VER=1.12
+SRCS="tbl::https://pypi.python.org/packages/source/p/patool/patool-$VER.tar.gz"
+CHKSUMS="sha256::e3180cf8bfe13bedbcf6f5628452fca0c2c84a3b5ae8c2d3f55720ea04cb1097"
+CHKUPDATE="anitya::id=19018"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Introduce `bottles`, a Wine prefixes manager supporting various runners.

Package(s) Affected
-------------------

- `bottles` v2022.2.28+trento+4
- `patool` v1.12

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

```
extra-utils/patool
extra-utils/bottles
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [x] Architecture-independent `noarch`

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
- [x] Architecture-independent `noarch`

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

<!-- TODO: CI to auto-fill architectural progress. -->
