### PR TITLE
dog: new, 0.1.0

### DIFF
--- a/extra-network/dog/autobuild/beyond
+++ b/extra-network/dog/autobuild/beyond
@@ -1,4 +1,18 @@
-abinfo "Installing manpage ..."
-mkdir -pv "$PKGDIR"/usr/share/man/man1 
-pandoc --standalone -f markdown -t man man/dog.1.md --verbose \
-    --output="$PKGDIR"/usr/share/man/man1/dog.1
+# The following lines is commented as it is not possible to build 
+# manpage file in certain architecture such as riscv-64 
+# abinfo "Installing manpage ..."
+# mkdir -pv "$PKGDIR"/usr/share/man/man1 
+# pandoc --standalone -f markdown -t man man/dog.1.md --verbose \
+#    --output="$PKGDIR"/usr/share/man/man1/dog.1
+
+abinfo "Installing shell completions for bash/zsh/fish ..."
+mkdir -vp "$PKGDIR"/usr/share/bash-completion/completions/
+install -Dvm644 "$SRCDIR"/completions/"$PKGNAME".bash \
+    "$PKGDIR"/usr/share/bash-completion/completions/"$PKGNAME"
+mkdir -vp "$PKGDIR"/usr/share/zsh/site-functions/
+install -Dvm644 "$SRCDIR"/completions/"$PKGNAME".zsh \
+    "$PKGDIR"/usr/share/zsh/site-functions/_"$PKGNAME"
+mkdir -vp "$PKGDIR"/usr/share/fish/completions/
+install -Dvm644 "$SRCDIR"/completions/"$PKGNAME".fish \
+    "$PKGDIR"/usr/share/fish/completions/"$PKGNAME".fish
+# TODO: add powershell auto-completion support

--- a/extra-network/dog/autobuild/beyond
+++ b/extra-network/dog/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Installing manpage ..."
+mkdir -pv "$PKGDIR"/usr/share/man/man1 
+pandoc --standalone -f markdown -t man man/dog.1.md --verbose \
+    --output="$PKGDIR"/usr/share/man/man1/dog.1

--- a/extra-network/dog/autobuild/beyond
+++ b/extra-network/dog/autobuild/beyond
@@ -1,9 +1,15 @@
-# The following lines is commented as it is not possible to build 
-# manpage file in certain architecture such as riscv-64 
-# abinfo "Installing manpage ..."
-# mkdir -pv "$PKGDIR"/usr/share/man/man1 
-# pandoc --standalone -f markdown -t man man/dog.1.md --verbose \
-#    --output="$PKGDIR"/usr/share/man/man1/dog.1
+mkdir -pv "$PKGDIR"/usr/share/man/man1 
+if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
+    abinfo "Generating manpage via pandoc ..."
+    pandoc --standalone -f markdown -t man "$SRCDIR"/man/dog.1.md --verbose \
+        --output="$SRCDIR"/man/dog.1
+else
+    abinfo "Generating manpage via ronn-ng ..."
+    ronn -r "$SRCDIR"/man/dog.1.md
+fi
+
+abinfo "Installing generated manpage ..."
+install -Dvm644 "$SRCDIR"/man/dog.1 "$PKGDIR"/usr/share/man/man1/dog.1
 
 abinfo "Installing shell completions for bash/zsh/fish ..."
 mkdir -vp "$PKGDIR"/usr/share/bash-completion/completions/

--- a/extra-network/dog/autobuild/defines
+++ b/extra-network/dog/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=dog
 PKGSEC=net
 PKGDEP="openssl"
-BUILDDEP="pandoc rustc llvm"
+# Removed `pandoc` in BUILDDEP as not available other than amd64
+BUILDDEP="rustc llvm"
 USECLANG=1
 
 PKGDES="Command-line DNS client like dig"

--- a/extra-network/dog/autobuild/defines
+++ b/extra-network/dog/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=dog
+PKGSEC=net
+PKGDEP="openssl"
+BUILDDEP="pandoc rustc llvm"
+USECLANG=1
+
+PKGDES="Command-line DNS client like dig"

--- a/extra-network/dog/autobuild/defines
+++ b/extra-network/dog/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=dog
 PKGSEC=net
 PKGDEP="openssl"
-# Removed `pandoc` in BUILDDEP as not available other than amd64
-BUILDDEP="rustc llvm"
+BUILDDEP="rustc llvm ronn-ng"
+BUILDDEP__AMD64="rustc llvm pandoc"
 USECLANG=1
 
 PKGDES="Command-line DNS client like dig"

--- a/extra-network/dog/spec
+++ b/extra-network/dog/spec
@@ -1,7 +1,4 @@
 VER=0.1.0
-
-# TO-DO: find a way to build manpage in all architecture 
-# or include external manpage file for `dog` in `SRCS` 
 SRCS="tbl::https://github.com/ogham/dog/archive/refs/tags/v$VER.tar.gz"
 CHKSUMS="sha1::ac78a278a6a4610045876a431dc456e7ceed1707"
 CHKUPDATE="anitya::id=140394"

--- a/extra-network/dog/spec
+++ b/extra-network/dog/spec
@@ -1,0 +1,5 @@
+VER=0.1.0
+
+SRCS="tbl::https://github.com/ogham/dog/archive/refs/tags/v$VER.tar.gz"
+CHKSUMS="sha1::ac78a278a6a4610045876a431dc456e7ceed1707"
+CHKUPDATE="anitya::id=140394"

--- a/extra-network/dog/spec
+++ b/extra-network/dog/spec
@@ -1,5 +1,7 @@
 VER=0.1.0
 
+# TO-DO: find a way to build manpage in all architecture 
+# or include external manpage file for `dog` in `SRCS` 
 SRCS="tbl::https://github.com/ogham/dog/archive/refs/tags/v$VER.tar.gz"
 CHKSUMS="sha1::ac78a278a6a4610045876a431dc456e7ceed1707"
 CHKUPDATE="anitya::id=140394"

--- a/extra-ruby/kramdown/autobuild/defines
+++ b/extra-ruby/kramdown/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=kramdown
+PKGSEC=ruby
+PKGDES="A Markdown superset converter"
+PKGDEP="ruby rexml"
+
+ABHOST=noarch
+ABTYPE=ruby

--- a/extra-ruby/kramdown/spec
+++ b/extra-ruby/kramdown/spec
@@ -1,0 +1,5 @@
+VER=2.3.1
+SRCS="tbl::https://rubygems.org/downloads/kramdown-$VER.gem"
+CHKSUMS="sha256::59e938cfa42a3d6169b295727fe09c4c91d742336c8fbd1042529f4db664ab49"
+CHKUPDATE="anitya::4451"
+SUBDIR="."

--- a/extra-ruby/mini-portile/autobuild/defines
+++ b/extra-ruby/mini-portile/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=mini-portile
 PKGSEC=ruby
-PKGDES="A autoconf builder"
+PKGDES="An autoconf builder"
 PKGDEP="ruby"
 
 ABHOST=noarch

--- a/extra-ruby/mini-portile/autobuild/defines
+++ b/extra-ruby/mini-portile/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=mini-portile
+PKGSEC=ruby
+PKGDES="A autoconf builder"
+PKGDEP="ruby"
+
+ABHOST=noarch
+ABTYPE=ruby

--- a/extra-ruby/mini-portile/spec
+++ b/extra-ruby/mini-portile/spec
@@ -1,0 +1,5 @@
+VER=2.8.0
+SRCS="tbl::https://rubygems.org/downloads/mini_portile2-$VER.gem"
+CHKSUMS="sha256::1e06b286ff19b73cfc9193cb3dd2bd80416f8262443564b25b23baea74a05765"
+CHKUPDATE="anitya::id"
+SUBDIR="."

--- a/extra-ruby/nokogiri/autobuild/beyond
+++ b/extra-ruby/nokogiri/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Removing unneeded sources from $PKGDIR/$GEMDIR ..."
+find "$PKGDIR/$GRMDIR" -type f \
+    \( -name "*.c" -o -name "*.h" -o -name "*.o" \) \
+    -exec rm -v {} \;

--- a/extra-ruby/nokogiri/autobuild/defines
+++ b/extra-ruby/nokogiri/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=nokogiri
+PKGSEC=ruby
+PKGDES="An HTML, XML, SAX and Reader parser"
+PKGDEP="libxml2 libxslt mini-portile racc ruby"
+
+ABHOST=noarch
+ABTYPE=ruby

--- a/extra-ruby/nokogiri/autobuild/defines
+++ b/extra-ruby/nokogiri/autobuild/defines
@@ -3,5 +3,4 @@ PKGSEC=ruby
 PKGDES="An HTML, XML, SAX and Reader parser"
 PKGDEP="libxml2 libxslt mini-portile racc ruby"
 
-ABHOST=noarch
 ABTYPE=ruby

--- a/extra-ruby/nokogiri/autobuild/prepare
+++ b/extra-ruby/nokogiri/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Setting NOKOGIRI_USE_SYSTEM_LIBRARIES=1 to use system libraries ..."
+export NOKOGIRI_USE_SYSTEM_LIBRARIES=1

--- a/extra-ruby/nokogiri/spec
+++ b/extra-ruby/nokogiri/spec
@@ -1,0 +1,5 @@
+VER=1.13.3
+SRCS="tbl::https://rubygems.org/downloads/nokogiri-$VER.gem"
+CHKSUMS="sha256::bf1b1bceff910abb0b7ad825535951101a0361b859c2ad1be155c010081ecbdc"
+CHKUPDATE="anitya::id=4641"
+SUBDIR="."

--- a/extra-ruby/racc/autobuild/defines
+++ b/extra-ruby/racc/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=racc
+PKGSEC=ruby
+PKGDES="An LALR(1) parser generator"
+PKGDEP="ruby"
+
+ABHOST=noarch
+ABTYPE=ruby

--- a/extra-ruby/racc/spec
+++ b/extra-ruby/racc/spec
@@ -1,0 +1,5 @@
+VER=1.6.0
+SRCS="tbl::https://rubygems.org/downloads/racc-$VER.gem"
+CHKSUMS="sha256::2dede3b136eeabd0f7b8c9356b958b3d743c00158e2615acab431af141354551"
+CHKUPDATE="anitya::9140"
+SUBDIR="."

--- a/extra-ruby/rexml/autobuild/defines
+++ b/extra-ruby/rexml/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=rexml
+PKGSEC=ruby
+PKGDES="An XML toolkit for Ruby"
+PKGDEP="ruby"
+
+ABHOST=noarch
+ABTYPE=ruby

--- a/extra-ruby/rexml/spec
+++ b/extra-ruby/rexml/spec
@@ -1,0 +1,5 @@
+VER=3.2.5
+SRCS="tbl::https://rubygems.org/downloads/rexml-$VER.gem"\
+CHKSUMS="sha256::a33c3bf95fda7983ec7f05054f3a985af41dbc25a0339843bd2479e93cabb123"
+CHKUPDATE="anitya::id=68589"
+SUBDIR="."

--- a/extra-ruby/rexml/spec
+++ b/extra-ruby/rexml/spec
@@ -1,5 +1,5 @@
 VER=3.2.5
-SRCS="tbl::https://rubygems.org/downloads/rexml-$VER.gem"\
+SRCS="tbl::https://rubygems.org/downloads/rexml-$VER.gem"
 CHKSUMS="sha256::a33c3bf95fda7983ec7f05054f3a985af41dbc25a0339843bd2479e93cabb123"
 CHKUPDATE="anitya::id=68589"
 SUBDIR="."

--- a/extra-ruby/ronn-ng/autobuild/build
+++ b/extra-ruby/ronn-ng/autobuild/build
@@ -1,0 +1,10 @@
+abinfo "Generating gem package via patches gemspec ..."
+gem build "$PKGNAME".gemspec
+
+GEMDIR="$(ruby -e'puts Gem.default_dir')"
+abinfo "Building and installing Ruby (Gem) package ..."
+gem install --ignore-dependencies --no-user-install \
+    -i "$PKGDIR/$GEMDIR" -n "$PKGDIR/usr/bin" "$PKGNAME-$PKGVER.gem"
+
+abinfo 'Removing Gem cache from $PKGDIR ...'
+rm -v "$PKGDIR/$GEMDIR/cache/"*

--- a/extra-ruby/ronn-ng/autobuild/defines
+++ b/extra-ruby/ronn-ng/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=ronn-ng
-PKGSRC=ruby
+PKGSEC=ruby
 PKGDES="An updated fork of ronn, build man pages from Markdown"
 PKGDEP="ruby mustache kramdown nokogiri"
 

--- a/extra-ruby/ronn-ng/autobuild/defines
+++ b/extra-ruby/ronn-ng/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=ronn-ng
+PKGSRC=ruby
+PKGDES="An updated fork of ronn, build man pages from Markdown"
+PKGDEP="ruby mustache kramdown nokogiri"
+
+ABHOST=noarch
+ABTYPE=ruby

--- a/extra-ruby/ronn-ng/autobuild/defines
+++ b/extra-ruby/ronn-ng/autobuild/defines
@@ -4,4 +4,3 @@ PKGDES="An updated fork of ronn, build man pages from Markdown"
 PKGDEP="ruby mustache kramdown nokogiri"
 
 ABHOST=noarch
-ABTYPE=ruby

--- a/extra-ruby/ronn-ng/autobuild/defines
+++ b/extra-ruby/ronn-ng/autobuild/defines
@@ -3,4 +3,7 @@ PKGSEC=ruby
 PKGDES="An updated fork of ronn, build man pages from Markdown"
 PKGDEP="ruby mustache kramdown nokogiri"
 
+PKGCONFL="ronn"
+PKGREP="ronn"
+
 ABHOST=noarch

--- a/extra-ruby/ronn-ng/autobuild/patches/0001-Debian-relax-dependencies.patch
+++ b/extra-ruby/ronn-ng/autobuild/patches/0001-Debian-relax-dependencies.patch
@@ -1,0 +1,22 @@
+Description: Relax gem dependencies
+  as Debian unstable has already newer version of them...
+Author: Cédric Boutillier <boutil@debian.org>
+Last-Update: 2019-02-06
+Forwarded: not-needed
+
+
+--- a/ronn-ng.gemspec
++++ b/ronn-ng.gemspec
+@@ -111,9 +111,9 @@
+   s.test_files = s.files.select { |path| path =~ /^test\/.*_test.rb/ }
+
+   s.extra_rdoc_files = %w[LICENSE.txt AUTHORS]
+-  s.add_dependency 'kramdown',    '~> 2.1'
+-  s.add_dependency 'mustache',    '~> 0.7', '>= 0.7.0'
+-  s.add_dependency 'nokogiri',    '~> 1.9', '>= 1.9.0'
++  s.add_dependency 'kramdown',    '>= 1.17.0'
++  s.add_dependency 'mustache',    '>= 0.7.0'
++  s.add_dependency 'nokogiri',    '>= 1.9.0'
+   s.add_development_dependency 'rack',      '~> 2.0',  '>= 2.0.6'
+   s.add_development_dependency 'rake',      '~> 12.3', '>= 12.3.0'
+   s.add_development_dependency 'rubocop',   '~> 0.60', '>= 0.57.1'

--- a/extra-ruby/ronn-ng/spec
+++ b/extra-ruby/ronn-ng/spec
@@ -1,5 +1,4 @@
 VER=0.9.1
-SRCS="tbl::https://rubygems.org/downloads/ronn-ng-$VER.gem"
-CHKSUMS="sha256::d04d8fe205e018dea9bb97e3bcf60d9853a326f90714ee5082752976ca739dea"
+SRCS="tbl::https://github.com/apjanke/ronn-ng/archive/v$VER.tar.gz"
+CHKSUMS="sha256::48dc2e82e34ada6299695914bb9d4a1ba9ed8e7f58c91c7371b0d9650a3dca88"
 CHKUPDATE="anitya::id=90983"
-SUBDIR="."

--- a/extra-ruby/ronn-ng/spec
+++ b/extra-ruby/ronn-ng/spec
@@ -1,0 +1,5 @@
+VER=0.9.1
+SRCS="tbl::https://rubygems.org/downloads/ronn-ng-$VER.gem"
+CHKSUMS="sha256::48dc2e82e34ada6299695914bb9d4a1ba9ed8e7f58c91c7371b0d9650a3dca88"
+CHKUPDATE="anitya::id=90983"
+SUBDIR="."

--- a/extra-ruby/ronn-ng/spec
+++ b/extra-ruby/ronn-ng/spec
@@ -1,5 +1,5 @@
 VER=0.9.1
 SRCS="tbl::https://rubygems.org/downloads/ronn-ng-$VER.gem"
-CHKSUMS="sha256::48dc2e82e34ada6299695914bb9d4a1ba9ed8e7f58c91c7371b0d9650a3dca88"
+CHKSUMS="sha256::d04d8fe205e018dea9bb97e3bcf60d9853a326f90714ee5082752976ca739dea"
 CHKUPDATE="anitya::id=90983"
 SUBDIR="."


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Add new package `dog` in response to [pakreq 1001](https://pakreq.aosc.io/detail/1001)
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

`dog` v0.1.0
<!-- Please list all package(s) affected by this topic here. -->
`rexml` v3.2.5
`kramdown` v2.3.1
`nokogiri` v1.13.3
`racc` v1.6.0
`mini-portile` v2.8.0
`ronn-ng` v0.9.1

Security Update?
----------------

No.

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
