### PR TITLE
fcitx5-pinyin-moegirl: update to 20220314

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20220218
+VER=20220314
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::d788f20b0a17db13026308a6a693c8e05d2b42f54cef2b32dc0470239b70d0e4 \
-         sha256::badd6859df3c842ab8789d2b2346b862e5449a8ebf9f01bcd2d0bf8bfa3124b0 \
+CHKSUMS="sha256::4267d403e5f702d75a0827bc25eaf64723aa223b6edcbc1689e165893110253d \
+         sha256::e66706339dfb75c3f1370d1cde4baa3b77e932d9d59e3b8478ac4105c760383d \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

fcitx5-pinyin-moegirl: update to 20220314

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`


Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`