### PR TITLE
xxhash: update to 0.8.1

### DIFF
--- a/extra-libs/xxhash/spec
+++ b/extra-libs/xxhash/spec
@@ -1,4 +1,4 @@
-VER=0.8.0
-SRCS="tbl::https://github.com/Cyan4973/xxHash/archive/v$VER.tar.gz"
-CHKSUMS="sha256::7054c3ebd169c97b64a92d7b994ab63c70dd53a06974f1f630ab782c28db0f4f"
+VER=0.8.1
+SRCS="git::commit=tags/v$VER::https://github.com/Cyan4973/xxHash"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17583"


### PR DESCRIPTION
Topic Description
-----------------

Update xxhash to newest 0.8.1 version, mainly for getting cherry-picked from Retro to fix Retro armv6hf binary on armv8 host.

Package(s) Affected
-------------------

- `xxhash`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
