### PR TITLE
pushpkg: update to 0+git20220319

### DIFF
--- a/extra-devel/pushpkg/spec
+++ b/extra-devel/pushpkg/spec
@@ -1,9 +1,9 @@
-VER=0+git20210813
-__COMMIT="8e9caca7d560e5bd2c4056d8bf66b5e5b0b0e268"
+VER=0+git20220319
+__COMMIT="32eef594a2464656c87f1caea4ce621855dfc75d"
 SRCS="file::rename=pushpkg::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/pushpkg \
       file::rename=COPYING::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/COPYING \
       file::rename=README.md::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/README.md"
-CHKSUMS="sha256::7e0231ddd167870a9a0b3019fbbb3b928b94663638aa7f1747feada362b834b2 \
+CHKSUMS="sha256::5f304e21aa42cfc44e644f957e861acdbf9a0ee51361ac472e1d1b20d2d041c9 \
          sha256::992c720940396663b52389eea4c6a7409dd26b55ab3bfcd3a17f5da8b6d2a3c9 \
-         sha256::f8fbe6b5cf477e225de20d54ee01cca89b56cebc476b9e4712684ab445afaa21"
+         sha256::f3e3eaabde4b0391de1de64ab574d4cdb202d2715851ff6767aa8ce5a7737aa7"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

Update `pushpkg` to 0+git20220319, commit 32eef594a2464656c87f1caea4ce621855dfc75d 

Package(s) Affected
-------------------

`pushpkg` v0+git20220319

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`