### PR TITLE
Gnome shell: dependencies fix

### DIFF
--- a/extra-gnome/gnome-control-center/autobuild/defines
+++ b/extra-gnome/gnome-control-center/autobuild/defines
@@ -6,7 +6,7 @@ PKGDEP="accountsservice cheese clutter-gtk clutter-gst-3.0 \
         gsettings-desktop-schemas libibus libgnomekbd libgtop \
         libpwquality modemmanager network-manager-applet openssh samba \
         upower colord-gtk rygel system-config-printer gnome-keyring \
-        gnome-color-manager vino sound-theme-freedesktop udisks-2 \
+        gnome-color-manager vinagre sound-theme-freedesktop udisks-2 \
         libhandy gsound malcontent libgudev"
 BUILDDEP="docbook-xsl gtk-doc intltool modemmanager meson ninja"
 PKGDES="An aggregated settings utility for GNOME"

--- a/extra-gnome/gnome-control-center/spec
+++ b/extra-gnome/gnome-control-center/spec
@@ -1,5 +1,5 @@
 VER=40.0
-REL=2
+REL=3
 SRCS="https://download.gnome.org/sources/gnome-control-center/${VER%.*}/gnome-control-center-$VER.tar.xz"
 CHKSUMS="sha256::ccc9a5736517385109ae5a59906c258244dd879b7503ad5984cf41655cb302f1"
 CHKUPDATE="anitya::id=5408"

--- a/extra-gnome/gnome-shell/autobuild/defines
+++ b/extra-gnome/gnome-shell/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gnome-shell
 PKGSEC=gnome
-PKGDEP="accountsservice caribou gcr gjs gnome-bluetooth gnome-menus \
+PKGDEP="accountsservice gcr gjs gnome-bluetooth gnome-menus \
         upower gnome-session gnome-settings-daemon \
         gsettings-desktop-schemas libcanberra libcroco libsecret \
         mutter network-manager-applet telepathy-logger \

--- a/extra-gnome/gnome-shell/spec
+++ b/extra-gnome/gnome-shell/spec
@@ -2,3 +2,4 @@ VER=40.4
 SRCS="https://download.gnome.org/sources/gnome-shell/${VER%.*}/gnome-shell-$VER.tar.xz"
 CHKSUMS="sha256::2bc5919305652b3c95ec42c67193512bd10cf6544f684694d1b9e229fe421f98"
 CHKUPDATE="anitya::id=5409"
+REL=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Fix missing/replaced dependencies of gnome.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

`gnome-shell` v40.4 -> v40.4-1
`gnome-control-center` v40.0-2 -> v40.0-3
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

No

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
