### PR TITLE
firefox: workaround libdrm permission errors on video playback with AMDGPU

### DIFF
--- a/extra-web/firefox/autobuild/overrides/usr/lib/firefox/browser/defaults/preferences/vendor.js
+++ b/extra-web/firefox/autobuild/overrides/usr/lib/firefox/browser/defaults/preferences/vendor.js
@@ -69,3 +69,6 @@ pref("security.app_menu.recordEventTelemetry",			false);
 pref("dom.security.unexpected_system_load_telemetry_enabled",	false);
 pref("toolkit.telemetry.pioneer-new-studies-available",		false);
 pref("datareporting.healthreport.uploadEnabled",		false);
+
+// FIXME: Fix libdrm permissions during video playback with AMDGPU.
+pref("media.rdd-process.enabled",				false);

--- a/extra-web/firefox/spec
+++ b/extra-web/firefox/spec
@@ -1,4 +1,5 @@
 VER=98.0.1
+REL=1
 CHKUPDATE="anitya::id=5506"
 SRCS="tbl::https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz \
       file::rename=ach.xpi::https://archive.mozilla.org/pub/firefox/releases/$VER/linux-x86_64/xpi/ach.xpi \


### PR DESCRIPTION
Topic Description
-----------------

This is not a permanent solution for a known issue with Firefox's RDD sandboxing.

Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1506291

Package(s) Affected
-------------------

- `firefox` v98.0.1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`