### PR TITLE
lxgwwenkai-font: update to 1.233.2

### DIFF
--- a/extra-fonts/lxgwwenkai-font/autobuild/build
+++ b/extra-fonts/lxgwwenkai-font/autobuild/build
@@ -1,6 +1,3 @@
 abinfo "Installing font file..."
 install -Dvm644 "$SRCDIR"/*.ttf -t "$PKGDIR"/usr/share/fonts/TTF
 
-abinfo "Installing LICENSE..."
-install -Dvm644 "$SRCDIR"/LxgwWenKai-"$PKGVER"/SIL_Open_Font_License_1.1.txt \
-	-t "$PKGDIR"/usr/share/doc/lxgwwenkai-font

--- a/extra-fonts/lxgwwenkai-font/spec
+++ b/extra-fonts/lxgwwenkai-font/spec
@@ -1,17 +1,17 @@
-VER=1.100
+VER=1.233.2
 SRCS="file::rename=LXGWWenKai-Bold.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/LXGWWenKai-Bold.ttf \
       file::rename=LXGWWenKai-Light.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/LXGWWenKai-Light.ttf \
       file::rename=LXGWWenKai-Regular.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/LXGWWenKai-Regular.ttf \
       file::rename=LXGWWenKaiMono-Bold.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/LXGWWenKaiMono-Bold.ttf \
       file::rename=LXGWWenKaiMono-Light.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/LXGWWenKaiMono-Light.ttf \
       file::rename=LXGWWenKaiMono-Regular.ttf::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/LXGWWenKaiMono-Regular.ttf \
-      tbl::https://github.com/lxgw/LxgwWenKai/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::1778f25ff2b3bd138a565a4e98c1e957702b989388ebdf7c2343d2ac3606ca47 \
-         sha256::fae31363dc42a4b381fff413858edcc88e892496e4959cb73814ba1d6801a00c \
-         sha256::8446e9aed602d2510b0d3e4f695fd117a7bbd064e8cf578309832c1794adaf82 \
-         sha256::b17beace8434f91e17a348248df3e63b64f46ba5711af71732a93fc15f2e33a5 \
-         sha256::4dc97abed304f0807b4a6a73c7285ee5aefcc8c66596394e30cf8b43721dbbce \
-         sha256::76b08bda637465b2b5706c751d0813861290c1c3d8b9897f653267b2d2b27125 \
-         sha256::56bd7ecc4a79e712b6b584ae32e581050968e1b4513b85aa4a34e774a112f1dd"
+      file::rename=LICENSE.txt::https://raw.githubusercontent.com/lxgw/LxgwWenKai/v$VER/License.txt"
+CHKSUMS="sha256::7ee88cf8ac316f81d9c7b8bd0434f853271d2ee2f9a07e08484e96d9daf18125 \
+         sha256::fcd5e050e342472a7811714d1140380a8f7be56d4708db86381ddb3ef49343f5 \
+         sha256::ba4bff597a290f8c1604251cfd832ec6ff17cd90a0c11b14bc8022b5290d716b \
+         sha256::4efb4ede0fb19fcf4c96e0faa5cd483dfb095b7d3476ae6d0c65f8f645c5eb15 \
+         sha256::a96fb7443b013f2c6efb4cf5fd52b0d248283a9d249b2740a406ea8982426a11 \
+         sha256::f6e0b0a867c137e0ca36f0c3d69ae6b28b56e1bf9ace2a70d471dc204926091f \
+         sha256::e564f06d018e7b95bc3594c96a17f1d41865af4038c375e7aa974dd69df38602"
 CHKUPDATE="anitya::id=227594"
 SUBDIR="."


### PR DESCRIPTION

<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
lxgwwenkai-font: update to 1.233.2

- Fix license file name

Package(s) Affected
-------------------

lxgwwenkai-font: update to 1.233.2

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
 - [x] Architecture-independent `noarch` 