### PR TITLE
Chromium/google-chrome: update to 100.0.4896.75

### DIFF
--- a/extra-web/chromium/spec
+++ b/extra-web/chromium/spec
@@ -1,11 +1,10 @@
-VER=100.0.4896.60
-REL=3
+VER=100.0.4896.75
 LAUNCHERVER=8
 SRCS="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$VER.tar.xz \
       https://github.com/foutrelis/chromium-launcher/archive/v$LAUNCHERVER.tar.gz \
       file::rename=chromium-$VER.txt::https://chromium.googlesource.com/chromium/src/+/$VER?format=TEXT"
-CHKSUMS="sha256::0e5ea5f3061ad090cf6bd57ca037496d95ea8956de021aff902f7d0ded7bffdc \
+CHKSUMS="sha256::244ed352dfaa1ab6b1f0877c4884fd17aa7d7133fa52f129a9fb01325ea0c0c0 \
          sha256::213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a \
-         sha256::c94162c814563dbdd7fbb9076679606894df2460909e5538f5f0656b29ccab6b"
+         sha256::c2eaf06d1ab06086941fafa945238d3d97f1e1ccac4008877a842c595480bc8e"
 SUBDIR="chromium-$VER"
 CHKUPDATE="anitya::id=13344"

--- a/extra-web/google-chrome/spec
+++ b/extra-web/google-chrome/spec
@@ -1,4 +1,4 @@
-VER=100.0.4896.60
+VER=100.0.4896.75
 SRCS="file::rename=google-chrome-stable_current_amd64.deb::https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
-CHKSUMS="sha256::05ba6d17d2704ffff1e1d554b40aaddabca9256b7e63ff73e99c469393de8a1f"
+CHKSUMS="sha256::856934272783e5a48fa63e30eb896040f5b46d6f394c1b3aa2e461cbf89b395b"
 CHKUPDATE="anitya::id=5349"


### PR DESCRIPTION
Topic Description
-----------------

Upstream has released chromium 100.0.4896.75 when #3889 is merged, which will lead to rebuilding failure of unmatched checksums. This update comes with a security fix.

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

CVE-2022-1232

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
