### PR TITLE
podman: security update to 4.0.3 ...

### DIFF
--- a/extra-admin/podman/autobuild/build
+++ b/extra-admin/podman/autobuild/build
@@ -14,15 +14,15 @@ abinfo "Making the source directory as the module directory ..."
 mkdir -v _build
 pushd _build
 mkdir -p src/github.com/containers/podman
-ln -sv ../../../../.. src/github.com/containers/podman/v3
+ln -sv ../../../../.. src/github.com/containers/podman/v4
 popd
 
 abinfo "Stage 1: Building podman itself ..."
-go_build -o bin/podman github.com/containers/podman/v3/cmd/podman/
+go_build -o bin/podman github.com/containers/podman/v4/cmd/podman/
 
 abinfo "Stage 2: Building podman remote ..."
 export BUILDTAGS+=" remoteclient"
-go_build -o bin/podman-remote github.com/containers/podman/v3/cmd/podman/
+go_build -o bin/podman-remote github.com/containers/podman/v4/cmd/podman/
 
 abinfo "Stage 3: Building dnsname plugin ..."
 unset BUILDTAGS

--- a/extra-admin/podman/autobuild/build
+++ b/extra-admin/podman/autobuild/build
@@ -51,12 +51,12 @@ make docs
 
 abinfo "Installing binaries ..."
 make PODMAN_VERSION="$PKGVER" PREFIX="$PKGDIR/usr/" ETCDIR="$PKGDIR/etc/" \
-     install.bin-nobuild \
-     install.man-nobuild \
+     install.bin \
+     install.man \
      install.systemd \
      install.completions \
      install.docker \
-     install.remote-nobuild
+     install.remote
 
 abinfo "Installing example configurations ..."
 install -Dvm644 "$SRCDIR"/test/registries.conf \

--- a/extra-admin/podman/autobuild/build
+++ b/extra-admin/podman/autobuild/build
@@ -20,6 +20,9 @@ popd
 abinfo "Stage 1: Building podman itself ..."
 go_build -o bin/podman github.com/containers/podman/v4/cmd/podman/
 
+abinfo "Stage 1.5: Building podman rootlessport ..."
+go_build -o bin/rootlessport github.com/containers/podman/v4/cmd/rootlessport/
+
 abinfo "Stage 2: Building podman remote ..."
 export BUILDTAGS+=" remoteclient"
 go_build -o bin/podman-remote github.com/containers/podman/v4/cmd/podman/

--- a/extra-admin/podman/autobuild/defines
+++ b/extra-admin/podman/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=podman
 PKGSEC=admin
 PKGDES="A tool for managing OCI containers and pods"
-PKGDEP="ostree gpgme conmon crun"
+PKGDEP="ostree gpgme conmon crun slirp4netns"
 PKGRECOM="btrfs-progs"
 PKGPROV="docker"
 PKGCONFL="docker"

--- a/extra-admin/podman/spec
+++ b/extra-admin/podman/spec
@@ -1,9 +1,9 @@
-VER=3.4.4
+VER=4.0.3
 SRCS="tbl::https://github.com/containers/podman/archive/v${VER}.tar.gz \
-      git::commit=c654c95366ac5f309ca3e5727c9b858864247328;rename=dnsname::https://github.com/containers/dnsname
-      git::commit=tags/v1.0.1;rename=cni-plugins::https://github.com/containernetworking/plugins"
-CHKSUMS="sha256::718c9e1e734c2d374fcf3c59e4cc7c1755acb954fc7565093e1d636c04b72e3a \
-         SKIP SKIP"
+      git::commit=tags/v1.3.1;rename=dnsname::https://github.com/containers/dnsname
+      git::commit=tags/v1.1.1;rename=cni-plugins::https://github.com/containernetworking/plugins"
+CHKSUMS="sha256::e3b53fc9142d4f2dc085f17a377d92ffb8bfe7756c4f47b8128b38bcc3540cbc \
+         SKIP \
+         SKIP"
 CHKUPDATE="anitya::id=93284"
 SUBDIR="podman-$VER"
-REL=1

--- a/extra-admin/slirp4netns/autobuild/defines
+++ b/extra-admin/slirp4netns/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=slirp4netns
+PKGSEC=admin
+PKGDES="User-mode networking for unprivileged network namespaces"
+PKGDEP="libslirp libseccomp libcap"

--- a/extra-admin/slirp4netns/spec
+++ b/extra-admin/slirp4netns/spec
@@ -1,0 +1,4 @@
+VER=1.1.12
+SRCS="tbl::https://github.com/rootless-containers/slirp4netns/archive/refs/tags/v${VER}.tar.gz"
+CHKSUMS="sha256::279dfe58a61b9d769f620b6c0552edd93daba75d7761f7c3742ec4d26aaa2962"
+CHKUPDATE="anitya::id=96795"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

During go 1.18 survey, a security issue of `podman` is discovered when checking upstream updates, affecting current `podman` in our repository. Upstream has released v4.0.3 to fix this problem. This topic will update this package and package using current go compiler. 

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

`podman` bump to v4.0.3
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

Yes. #3905 + CVE-2022-27649

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
