### PR TITLE
openssl: security update to 1.1.1n

### DIFF
--- a/base-libs/openssl/spec
+++ b/base-libs/openssl/spec
@@ -1,4 +1,4 @@
-VER=1.1.1l
+VER=1.1.1n
 SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1"
+CHKSUMS="sha256::40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a"
 CHKUPDATE="anitya::id=2566"

--- a/extra-optenv32/openssl+32/spec
+++ b/extra-optenv32/openssl+32/spec
@@ -1,4 +1,4 @@
-VER=1.1.1k
+VER=1.1.1n
 SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5"
+CHKSUMS="sha256::40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a"
 CHKUPDATE="anitya::id=2566"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

OpenSSL 1.1.1l has two security holes. This topic will fix CVEs: CVE-2022-0778, CVE-2021-4160
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

`openssl` v1.1.1l -> v1.1.1n
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

Yes. 
Closes #3915 . + https://www.openssl.org/news/vulnerabilities.html
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`   
- [x] 32-bit Optional Environment `optenv32`

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit Optional Environment `optenv32`

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
