### PR TITLE
paramiko Survey 20220410

### DIFF
--- a/extra-python/paramiko/spec
+++ b/extra-python/paramiko/spec
@@ -1,5 +1,4 @@
-VER=2.7.2
+VER=2.10.3
 SRCS="tbl::https://pypi.io/packages/source/p/paramiko/paramiko-$VER.tar.gz"
-CHKSUMS="sha256::7f36f4ba2c0d81d219f4595e35f70d56cc94f9ac40a6acdf51d6ca210ce65035"
+CHKSUMS="sha256::ddb1977853aef82804b35d72a0e597b244fa326c404c350bd00c5b01dbfee71a"
 CHKUPDATE="anitya::id=52349"
-REL=1

--- a/extra-python/pytest/spec
+++ b/extra-python/pytest/spec
@@ -1,5 +1,4 @@
-VER=4.3.0
-REL=3
+VER=7.1.1
 SRCS="tbl::https://pypi.io/packages/source/p/pytest/pytest-$VER.tar.gz"
-CHKSUMS="sha256::067a1d4bf827ffdd56ad21bd46674703fce77c5957f6c1eef731f6146bfcef1c"
+CHKSUMS="sha256::841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63"
 CHKUPDATE="anitya::id=3765"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

It is found that paramiko < 2.10.1 are vulnerable to CVE-2022-24302 . However during testing, `pytest` reports `paramiko` cannot be tested as `pytest` in our repository is too old. 

This topic will update `paramiko` to 2.10.3 and related testing tools needed by it.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

`paramiko` bump to 2.10.1
`pytest` 7.1.1 
More to be filled


<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

Yes. CVE-2022-24302
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch` 

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch` 