### PR TITLE
MPD Survey 20220411

### DIFF
--- a/extra-libs/intel-media-sdk/autobuild/patches/0001-fix-build-with-newer-cpp-standard.patch
+++ b/extra-libs/intel-media-sdk/autobuild/patches/0001-fix-build-with-newer-cpp-standard.patch
@@ -1,0 +1,58 @@
+From 51602d7a5f5e63b21d7e036880ee57911da2c653 Mon Sep 17 00:00:00 2001
+From: Arseniy Obolenskiy <arseniy.obolenskiy@intel.com>
+Date: Tue, 14 Jul 2020 10:24:54 +0300
+Subject: [PATCH] [tracer] Fix build with libc++
+
+Fix #2209
+---
+ tools/tracer/dumps/dump.h | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/tools/tracer/dumps/dump.h b/tools/tracer/dumps/dump.h
+index 71a4806a53..0473e0e9ae 100644
+--- a/tools/tracer/dumps/dump.h
++++ b/tools/tracer/dumps/dump.h
+@@ -67,18 +67,19 @@ bool _IsBadReadPtr(void *ptr, size_t size);
+ #define DUMP_FIELD_RESERVED(_field) \
+     str += structName + "." #_field "[]=" + DUMP_RESERVED_ARRAY(_struct._field) + "\n";
+ 
+-    #define ToString( x )  dynamic_cast< std::ostringstream & >( \
++    #define ToString( x )  static_cast< std::ostringstream const & >( \
+         ( std::ostringstream() << std::dec << x ) ).str()
+ 
+-    #define TimeToString( x ) dynamic_cast< std::ostringstream & >( \
++    #define TimeToString( x ) static_cast< std::ostringstream const & >( \
+             ( std::ostringstream() << std::left << std::setw(4) << std::dec << x <<" msec") ).str()
+ 
+     /*
+-    #define ToHexFormatString( x ) dynamic_cast< std::ostringstream & >( \
++    #define ToHexFormatString( x ) static_cast< std::ostringstream const & >( \
+             ( std::ostringstream() << std::hex << x ) ).str()
+     */
+ 
+-    #define ToHexFormatString( x ) (dynamic_cast< std::ostringstream & >( ( std::ostringstream() << std::hex << pVoidToHexString((void*)x) ) ).str() )
++    #define ToHexFormatString( x ) (static_cast< std::ostringstream const & >( \
++            ( std::ostringstream() << std::hex << pVoidToHexString((void*)x) ) ).str() )
+ /*
+ #define DEFINE_GET_TYPE(type) \
+     template<> \
+@@ -118,7 +119,8 @@ class DumpContext
+ 
+     template<typename T>
+     inline std::string toString( T x, eDumpFormat format = DUMP_DEC){
+-        return dynamic_cast< std::ostringstream & >(( std::ostringstream() << ((format == DUMP_DEC) ? std::dec : std::hex) << x )).str();
++        return static_cast< std::ostringstream const & >(
++            ( std::ostringstream() << ((format == DUMP_DEC) ? std::dec : std::hex) << x )).str();
+     }
+ 
+     const char* get_bufferid_str(mfxU32 bufferid);
+--- a/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp	2022-04-12 04:20:55.328283909 +0000
++++ b/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp	2022-04-12 04:21:07.470455354 +0000
+@@ -43,6 +43,7 @@
+ 
+ #include <algorithm>
+ #include <climits>
++#include <limits>
+ #include <cmath>
+ #include "cmrt_cross_platform.h"
+ 

--- a/extra-libs/intel-media-sdk/spec
+++ b/extra-libs/intel-media-sdk/spec
@@ -1,4 +1,5 @@
 VER=20.2.1
+REL=1
 SRCS="tbl::https://github.com/Intel-Media-SDK/MediaSDK/archive/intel-mediasdk-$VER.tar.gz"
 CHKSUMS="sha256::e13d7d0cf8a4e455ef4032e0cacff63bbbe934a13652ee236ff95d3b9bbb7154"
 CHKUPDATE="anitya::id=21814"

--- a/extra-libs/libmpdclient/spec
+++ b/extra-libs/libmpdclient/spec
@@ -1,4 +1,4 @@
-VER=2.17
+VER=2.20
 SRCS="tbl::https://www.musicpd.org/download/libmpdclient/${VER%.*}/libmpdclient-${VER}.tar.xz"
-CHKSUMS="sha256::ee9b8f1c7e95b65c8f18a354daf7b16bfcd455fc52a0f3b5abe402316bce3559"
+CHKSUMS="sha256::18793f68e939c3301e34d8fcadea1f7daa24143941263cecadb80126194e277d"
 CHKUPDATE="anitya::id=21364"

--- a/extra-multimedia/cantata/spec
+++ b/extra-multimedia/cantata/spec
@@ -1,5 +1,4 @@
-VER=2.3.3
+VER=2.5.0
 SRCS="tbl::https://github.com/CDrummond/cantata/releases/download/v$VER/cantata-$VER.tar.bz2"
-CHKSUMS="sha256::0d7f90c8f448adcdb1e013a6eb95147d9169d5b2023357ff8e34c29ab803ed1d"
-REL=3
+CHKSUMS="sha256::eb7e00ab3f567afaa02ea2c86e2fe811a475afab93182b95922c6eb126821724"
 CHKUPDATE="anitya::id=251"

--- a/extra-multimedia/mpd-mpc/spec
+++ b/extra-multimedia/mpd-mpc/spec
@@ -1,4 +1,4 @@
-VER=0.33
+VER=0.34
 SRCS="tbl::https://www.musicpd.org/download/mpc/0/mpc-$VER.tar.xz"
-CHKSUMS="sha256::4f40ccbe18f5095437283cfc525a97815e983cbfd3a29e48ff610fa4f1bf1296"
+CHKSUMS="sha256::691e3f3654bc10d022bb0310234d0bc2d8c075a698f09924d9ebed8f506fda20"
 CHKUPDATE="anitya::id=9784"

--- a/extra-multimedia/mpd/autobuild/prepare
+++ b/extra-multimedia/mpd/autobuild/prepare
@@ -1,0 +1,2 @@
+export CFLAGS="${CFLAGS} -fuse-ld=gold"
+export CXXFLAGS="${CXXFLAGS} -fuse-ld=gold"

--- a/extra-multimedia/mpd/spec
+++ b/extra-multimedia/mpd/spec
@@ -1,5 +1,4 @@
-VER=0.22.11
-REL=1
+VER=0.23.6
 SRCS="tbl::http://www.musicpd.org/download/mpd/${VER%.*}/mpd-${VER}.tar.xz"
-CHKSUMS="sha256::143f7f34aaee6e87888f3dd35d49aade6656052651b960ca42b46cbb518ca0a0"
+CHKSUMS="sha256::cbc5928ee3ee1ef7ff6a58f6ba4afaee16c07e9eb42d0107bcc098010f4f26ed"
 CHKUPDATE="anitya::id=14864"

--- a/extra-multimedia/mpdris2/autobuild/defines
+++ b/extra-multimedia/mpdris2/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=mpdris2
 PKGSEC=sound
-PKGDEP="dbus-python mutagen notify-python pygobject-3 python-mpd2"
+PKGDEP="dbus-python mutagen pygobject-3 python-mpd2"
 BUILDDEP="intltool"
 PKGDES="MPRIS2 support for MPD"
 

--- a/extra-multimedia/mpdris2/autobuild/defines
+++ b/extra-multimedia/mpdris2/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=mpdris2
 PKGSEC=sound
-PKGDEP="dbus-python mutagen notify-python pygobject python-mpd2"
+PKGDEP="dbus-python mutagen notify-python pygobject-3 python-mpd2"
 BUILDDEP="intltool"
 PKGDES="MPRIS2 support for MPD"
 

--- a/extra-multimedia/mpdris2/autobuild/defines
+++ b/extra-multimedia/mpdris2/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=mpdris2
 PKGSEC=sound
-PKGDEP="dbus-python mutagen notify-python pygobject-2 python-mpd"
+PKGDEP="dbus-python mutagen notify-python pygobject python-mpd2"
 BUILDDEP="intltool"
 PKGDES="MPRIS2 support for MPD"
 
-AUTOTOOLS_AFTER="PYTHON=/usr/bin/python3"
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-multimedia/mpdris2/autobuild/defines
+++ b/extra-multimedia/mpdris2/autobuild/defines
@@ -4,5 +4,6 @@ PKGDEP="dbus-python mutagen notify-python pygobject-3 python-mpd2"
 BUILDDEP="intltool"
 PKGDES="MPRIS2 support for MPD"
 
+AUTOTOOLS_AFTER="PYTHON=/usr/bin/python3"
 ABHOST=noarch
 NOPYTHON2=1

--- a/extra-multimedia/mpdris2/spec
+++ b/extra-multimedia/mpdris2/spec
@@ -1,4 +1,4 @@
-VER=0.8
+VER=0.9.1
 SRCS="tbl::https://github.com/eonpatapon/mpDris2/archive/$VER.tar.gz"
-CHKSUMS="sha256::b6b15c1fdddf16a6d74485ad09f56ed353a317e149c37475c00a279186da4391"
+CHKSUMS="sha256::d0f0467841e7866310cff44a1063334a9c776a64fd594815d926670b765fbee6"
 CHKUPDATE="anitya::id=9937"

--- a/extra-multimedia/ncmpc/spec
+++ b/extra-multimedia/ncmpc/spec
@@ -1,4 +1,4 @@
-VER=0.45
+VER=0.46
 SRCS="https://www.musicpd.org/download/ncmpc/${VER%.*}/ncmpc-${VER}.tar.xz"
-CHKSUMS="sha256::17ff446447e002f2ed4342b7324263a830df7d76bcf177dce928f7d3a6f1f785"
+CHKSUMS="sha256::177f77cf09dd4ab914e8438be399cdd5d83c9aa992abc8d9abac006bb092934e"
 CHKUPDATE="anitya::id=2055"

--- a/extra-python/python-mpd2/autobuild/defines
+++ b/extra-python/python-mpd2/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=python-mpd2
+PKGSEC=python
+BUILDDEP="setuptools"
+PKGDEP="python-3"
+PKGDES="A Python library which provides a client interface for the Music Player Daemon"
+
+NOPYTHON2=1

--- a/extra-python/python-mpd2/autobuild/defines
+++ b/extra-python/python-mpd2/autobuild/defines
@@ -4,4 +4,5 @@ BUILDDEP="setuptools"
 PKGDEP="python-3"
 PKGDES="A Python library which provides a client interface for the Music Player Daemon"
 
+ABHOST=noarch
 NOPYTHON2=1

--- a/extra-python/python-mpd2/spec
+++ b/extra-python/python-mpd2/spec
@@ -1,0 +1,4 @@
+VER=3.0.5
+SRCS="tbl::https://github.com/Mic92/python-mpd2/archive/v${VER}.tar.gz"
+CHKSUMS="sha256::f0ff8e421fa40a2ad92f6b7420385847cf27076b1d000fb1cbaec7f5f456821d"
+CHKUPDATE="anitya::id=19721"


### PR DESCRIPTION
Topic Description
-----------------

Update MPD-related packages, including the fix for `mpdris2` and introducing `python-mpd2`.

Package(s) Affected
-------------------

`mpd` 0.23.6
`python-mpd2` 3.0.5
`mpdris2` 0.9.1
`mpd-mpc` 0.34
`ncmpc` 0.46
`libmpdclient` 2.20
`cantata` 2.5.0
`intel-media-sdk` 20.2.1-1

Security Update?
----------------

No

Build Order
-----------

`intel-media-sdk mpd libmpdclient ncmpc mpd-mpc cantata python-mpd2 mpdris2`

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**


- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
- [ ] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`