### PR TITLE
Subversion: security update to 1.14.2

### DIFF
--- a/extra-vcs/subversion/autobuild/patches/0001-fix-libtoolize-link.patch
+++ b/extra-vcs/subversion/autobuild/patches/0001-fix-libtoolize-link.patch
@@ -1,0 +1,22 @@
+This patch is introduced to resolve an autogen failure. 
+
+In AOSC, when generating autotool's configutration files, autogen will try to
+search libtool's executable in the PATH, which returns `/bin/libtool` instead
+of `/usr/bin/libtool`, leading to a failure when trying to access a file via 
+relate path. This is caused by our configutration of bash-startup. Since 
+modifying it may cause other problems, this patch is introduced as
+a workaround.
+
+Signed-off by: Camber Huang <camber@aosc.io>
+
+diff autogen.sh.rejected autogen.sh -pu
+--- a/autogen.sh.rejected 2020-07-12 12:00:17.000000000 +0800
++++ b/autogen.sh  2022-04-13 16:52:03.814926709 +0800
+@@ -65,6 +65,7 @@ done
+ 
+ # Much like APR except we do not prefer libtool 1 over libtool 2.
+ libtoolize="`./build/PrintPath glibtoolize libtoolize glibtoolize1 libtoolize15 libtoolize14`"
++libtoolize="$(readlink -f ${libtoolize})"
+ lt_major_version=`$libtoolize --version 2>/dev/null | sed -e 's/^[^0-9]*//' -e 's/\..*//' -e '/^$/d' -e 1q`
+ 
+ if [ "x$libtoolize" = "x" ]; then

--- a/extra-vcs/subversion/spec
+++ b/extra-vcs/subversion/spec
@@ -1,4 +1,4 @@
-VER=1.14.1
+VER=1.14.2
 SRCS="tbl::https://archive.apache.org/dist/subversion/subversion-$VER.tar.gz"
-CHKSUMS="sha256::dee2796abaa1f5351e6cc2a60b1917beb8238af548b20d3e1ec22760ab2f0cad"
+CHKSUMS="sha256::fd826afad03db7a580722839927dc664f3e93398fe88b66905732c8530971353"
 CHKUPDATE="anitya::id=4905"

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -715,3 +715,4 @@ tortoisehg
 cadence
 carla
 cracklib
+subversion


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Subversion 1.14.1 is vulnerable to CVE-2021-28544 and CVE-2022-24070. Upstream has released 1.14.2 to fix these vulnerabilities. This topic will update `subversion` to 1.14.2.

This topic involves a patch to fix FTBFS-in-AOSC problem.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

`subversion` 1.14.2
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

Yes. Close #3926 .
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
