### PR TITLE
tcpdump: update to 4.99.1

### DIFF
--- a/extra-libs/libpcap/spec
+++ b/extra-libs/libpcap/spec
@@ -1,5 +1,4 @@
-VER=1.9.1
-REL=1
+VER=1.10.1
 SRCS="tbl::https://www.tcpdump.org/release/libpcap-$VER.tar.gz"
-CHKSUMS="sha256::635237637c5b619bcceba91900666b64d56ecb7be63f298f601ec786ce087094"
+CHKSUMS="sha256::ed285f4accaf05344f90975757b3dbfe772ba41d1c401c2648b7fa45b711bdd4"
 CHKUPDATE="anitya::id=1702"

--- a/extra-network/tcpdump/autobuild/patches/tcpdump-CVE-2018-19519.patch
+++ b/extra-network/tcpdump/autobuild/patches/tcpdump-CVE-2018-19519.patch
@@ -10,14 +10,14 @@ Subject: [PATCH] CVE-2018-19519 buffer overread. Initialize buf in
 
 Index: tcpdump-4.9.2/print-hncp.c
 ===================================================================
---- tcpdump-4.9.2.orig/print-hncp.c
-+++ tcpdump-4.9.2/print-hncp.c
-@@ -206,6 +206,8 @@ print_prefix(netdissect_options *ndo, co
+--- a/print-hncp.c
++++ b/print-hncp.c
+@@ -207,6 +207,8 @@ print_prefix(netdissect_options *ndo, co
      int plenbytes;
      char buf[sizeof("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx::/128")];
  
 +    buf[0] = '\0';
 +
-     if (prefix[0] >= 96 && max_length >= IPV4_MAPPED_HEADING_LEN + 1 &&
-         is_ipv4_mapped_address(&prefix[1])) {
-         struct in_addr addr;
+     if (GET_U_1(prefix) >= 96 && max_length >= IPV4_MAPPED_HEADING_LEN + 1 &&
+         is_ipv4_mapped_address(prefix + 1)) {
+         nd_ipv4 addr;

--- a/extra-network/tcpdump/spec
+++ b/extra-network/tcpdump/spec
@@ -1,5 +1,4 @@
-VER=4.9.3
-REL=1
+VER=4.99.1
 SRCS="tbl::https://www.tcpdump.org/release/tcpdump-$VER.tar.gz"
-CHKSUMS="sha256::2cd47cb3d460b6ff75f4a9940f594317ad456cfbf2bd2c8e5151e16559db6410"
+CHKSUMS="sha256::79b36985fb2703146618d87c4acde3e068b91c553fb93f021a337f175fd10ebe"
 CHKUPDATE="anitya::id=4947"

--- a/extra-optenv32/libpcap+32/spec
+++ b/extra-optenv32/libpcap+32/spec
@@ -1,5 +1,4 @@
-VER=1.7.4
+VER=1.10.1
 SRCS="tbl::https://www.tcpdump.org/release/libpcap-$VER.tar.gz"
-CHKSUMS="sha256::7ad3112187e88328b85e46dce7a9b949632af18ee74d97ffc3f2b41fe7f448b0"
-REL=4
+CHKSUMS="sha256::ed285f4accaf05344f90975757b3dbfe772ba41d1c401c2648b7fa45b711bdd4"
 CHKUPDATE="anitya::id=1702"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

`tcpdump` has several security fixes between 4.9.3 and 4.99.1 , including fixing for CVE-2020-8037. More details are in links below. 
This topic will update `tcpdump` to 4.99.1 and its related library `libpcap{,+32}` to 1.10.1 to ensure main package's functionality.

Reference: https://github.com/the-tcpdump-group/tcpdump/blob/master/CHANGES
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

`tcpdump` 4.99.1
`libpcap{+32}` 1.10.1 
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

Yes. 

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

1. `libpcap{+32}`
2. `tcpdump`

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
- [x] 32-bit Optional Environment `optenv32`

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Functionality tests done
---------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64` at local nspawn container  
- [x] AArch64 `arm64` at Zifandel's nspawn container
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
~~- [ ] 32-bit Optional Environment `optenv32`~~

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3` at Resonance's nspawn container
- [x] PowerPC 64-bit (Little Endian) `ppc64el` at powernv's nspawn container
- [x] RISC-V 64-bit `riscv64` at lorenz's nspawn container


Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
- [x] 32-bit Optional Environment `optenv32`

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
