### PR TITLE
fcitx5-pinyin-moegirl: update to 20220414

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20220314
+VER=20220414
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::4267d403e5f702d75a0827bc25eaf64723aa223b6edcbc1689e165893110253d \
-         sha256::e66706339dfb75c3f1370d1cde4baa3b77e932d9d59e3b8478ac4105c760383d \
+CHKSUMS="sha256::bcd88afbdf2dca6f94b32a3f6cd2fe8f769e879ff2cd236764a27743dc631a04 \
+         sha256::e149213712a214f8e7d1ca6fae8c6635f9aea5b78fe6d79b174a5bbb4b48b80b \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

fcitx5-pinyin-moegirl: update to 20220414

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`