### PR TITLE
Cross toolchain for riscv64

### DIFF
--- a/extra-cross/binutils+cross-riscv64/autobuild/beyond
+++ b/extra-cross/binutils+cross-riscv64/autobuild/beyond
@@ -1,0 +1,1 @@
+rm $PKGDIR/opt/abcross/riscv64/share/info/dir

--- a/extra-cross/binutils+cross-riscv64/autobuild/build
+++ b/extra-cross/binutils+cross-riscv64/autobuild/build
@@ -1,0 +1,9 @@
+unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
+
+mkdir -p build
+cd build
+../configure --prefix=/opt/abcross/riscv64 --target=riscv64-aosc-linux-gnu \
+             --with-sysroot=/var/ab/cross-root/riscv64 --enable-shared --disable-multilib --disable-werror --with-isa-spec=2.2
+make configure-host
+make 
+make DESTDIR=$PKGDIR install

--- a/extra-cross/binutils+cross-riscv64/autobuild/defines
+++ b/extra-cross/binutils+cross-riscv64/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=binutils+cross-riscv64
+PKGDEP="glibc"
+PKGSEC=devel
+PKGDES="Binutils for riscv64 cross build"

--- a/extra-cross/binutils+cross-riscv64/autobuild/patches/0001-ld-Keep-indirect-symbol-from-IR-if-referenced-from-s.patch
+++ b/extra-cross/binutils+cross-riscv64/autobuild/patches/0001-ld-Keep-indirect-symbol-from-IR-if-referenced-from-s.patch
@@ -1,0 +1,114 @@
+From 20ea3acc727f3be6322dfbd881e506873535231d Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Fri, 11 Feb 2022 15:13:19 -0800
+Subject: [PATCH] ld: Keep indirect symbol from IR if referenced from shared
+ object
+
+Don't change indirect symbol defined in IR to undefined if it is
+referenced from shared object.
+
+bfd/
+
+	PR ld/28879
+	* elflink.c (_bfd_elf_merge_symbol): Don't change indirect
+	symbol defined in IR to undefined if it is referenced from
+	shared object.
+
+ld/
+
+	PR ld/28879
+	* testsuite/ld-plugin/lto.exp: Run PR ld/28879 tests.
+	* testsuite/ld-plugin/pr28879a.cc: New file.
+	* testsuite/ld-plugin/pr28879b.cc: Likewise.
+---
+ bfd/elflink.c                      |  5 ++---
+ ld/testsuite/ld-plugin/lto.exp     | 26 ++++++++++++++++++++++++++
+ ld/testsuite/ld-plugin/pr28879a.cc |  7 +++++++
+ ld/testsuite/ld-plugin/pr28879b.cc |  8 ++++++++
+ 4 files changed, 43 insertions(+), 3 deletions(-)
+ create mode 100644 ld/testsuite/ld-plugin/pr28879a.cc
+ create mode 100644 ld/testsuite/ld-plugin/pr28879b.cc
+
+diff --git a/bfd/elflink.c b/bfd/elflink.c
+index 6fa18d92007..f8521426cad 100644
+--- a/bfd/elflink.c
++++ b/bfd/elflink.c
+@@ -1294,9 +1294,8 @@ _bfd_elf_merge_symbol (bfd *abfd,
+ 	  h->root.non_ir_ref_dynamic = true;
+ 	  hi->root.non_ir_ref_dynamic = true;
+ 	}
+-
+-      if ((oldbfd->flags & BFD_PLUGIN) != 0
+-	  && hi->root.type == bfd_link_hash_indirect)
++      else if ((oldbfd->flags & BFD_PLUGIN) != 0
++	       && hi->root.type == bfd_link_hash_indirect)
+ 	{
+ 	  /* Change indirect symbol from IR to undefined.  */
+ 	  hi->root.type = bfd_link_hash_undefined;
+diff --git a/ld/testsuite/ld-plugin/lto.exp b/ld/testsuite/ld-plugin/lto.exp
+index a70a84562b8..64b880265ee 100644
+--- a/ld/testsuite/ld-plugin/lto.exp
++++ b/ld/testsuite/ld-plugin/lto.exp
+@@ -471,6 +471,32 @@ set lto_link_elf_tests [list \
+   [list {pr27441c.so} \
+    {-shared -fPIC -Wl,--as-needed tmpdir/pr27441c.o tmpdir/pr27441b.so tmpdir/pr27441a.so} {-fPIC} \
+    {dummy.c} {{readelf {-dW} pr27441c.d}} {pr27441c.so}] \
++  [list \
++   "Build libpr28879a.so" \
++   "-shared" \
++   "-O0 -fpic" \
++   {pr28879a.cc} \
++   {} \
++   "libpr28879a.so" \
++   "c++" \
++  ] \
++  [list \
++   "Build libpr28879b.so" \
++   "-shared -Wl,--no-as-needed tmpdir/libpr28879a.so" \
++   "-O2 -fpic" \
++   {dummy.c} \
++   {} \
++   "libpr28879b.so" \
++  ] \
++  [list \
++   "Build pr28879" \
++   "-Wl,--no-as-needed tmpdir/libpr28879b.so -Wl,-rpath-link,." \
++   "-O0 -flto -D_GLIBCXX_ASSERTIONS" \
++   {pr28879b.cc} \
++   {} \
++   "pr28879" \
++   "c++" \
++  ] \
+ ]
+ 
+ # PR 14918 checks that libgcc is not spuriously included in a shared link of
+diff --git a/ld/testsuite/ld-plugin/pr28879a.cc b/ld/testsuite/ld-plugin/pr28879a.cc
+new file mode 100644
+index 00000000000..8307a42e2fb
+--- /dev/null
++++ b/ld/testsuite/ld-plugin/pr28879a.cc
+@@ -0,0 +1,7 @@
++#include <string>
++
++void
++func (std::string *s)
++{
++  delete s;
++}
+diff --git a/ld/testsuite/ld-plugin/pr28879b.cc b/ld/testsuite/ld-plugin/pr28879b.cc
+new file mode 100644
+index 00000000000..02fc351366c
+--- /dev/null
++++ b/ld/testsuite/ld-plugin/pr28879b.cc
+@@ -0,0 +1,8 @@
++#include <string>
++
++int
++main (void)
++{
++  std::string header;
++  return 0;
++}
+-- 
+2.35.1
+

--- a/extra-cross/binutils+cross-riscv64/spec
+++ b/extra-cross/binutils+cross-riscv64/spec
@@ -1,0 +1,4 @@
+VER=2.38
+SRCS="tbl::https://ftp.gnu.org/gnu/binutils/binutils-$VER.tar.xz"
+CHKSUMS="sha256::e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024"
+CHKUPDATE="anitya::id=7981"

--- a/extra-cross/gcc+cross-riscv64/autobuild/beyond
+++ b/extra-cross/gcc+cross-riscv64/autobuild/beyond
@@ -1,0 +1,1 @@
+rm $PKGDIR/opt/abcross/riscv64/share/info/dir

--- a/extra-cross/gcc+cross-riscv64/autobuild/beyond
+++ b/extra-cross/gcc+cross-riscv64/autobuild/beyond
@@ -1,1 +1,2 @@
-rm $PKGDIR/opt/abcross/riscv64/share/info/dir
+abinfo "Removing unneeded files from the sysroot ..."
+rm -v "$PKGDIR"/opt/abcross/riscv64/share/info/dir

--- a/extra-cross/gcc+cross-riscv64/autobuild/build
+++ b/extra-cross/gcc+cross-riscv64/autobuild/build
@@ -1,0 +1,14 @@
+unset CFLAGS CXXFLAGS LDFLAGS CPPFLAGS
+
+mkdir -p build
+cd build
+export PATH="/opt/abcross/riscv64/bin:$PATH"
+AR=ar ../configure --prefix=/opt/abcross/riscv64 --target=riscv64-aosc-linux-gnu \
+                   --with-sysroot=/var/ab/cross-root/riscv64 --enable-shared --disable-multilib \
+                   --enable-c99 --enable-long-long --enable-threads=posix \
+                   --enable-languages=c,c++,fortran,lto --enable-__cxa_atexit --disable-altivec --disable-fixed-point --with-arch=rv64gc --with-abi=lp64d --enable-lto --enable-gnu-unique-object \
+                   --enable-linker-build-id --enable-libstdcxx-dual-abi --with-default-libstdcxx-abi=new
+
+make AS_FOR_TARGET=/opt/abcross/riscv64/bin/riscv64-aosc-linux-gnu-as \
+     LD_FOR_TARGET=/opt/abcross/riscv64/bin/riscv64-aosc-linux-gnu-ld
+make DESTDIR=$PKGDIR install

--- a/extra-cross/gcc+cross-riscv64/autobuild/build
+++ b/extra-cross/gcc+cross-riscv64/autobuild/build
@@ -1,6 +1,8 @@
+abinfo "Building RISC-V cross GCC ..."
+abinfo "Unsetting compilation flags to avoid interference ..."
 unset CFLAGS CXXFLAGS LDFLAGS CPPFLAGS
 
-mkdir -p build
+mkdir -pv build
 cd build
 export PATH="/opt/abcross/riscv64/bin:$PATH"
 AR=ar ../configure --prefix=/opt/abcross/riscv64 --target=riscv64-aosc-linux-gnu \

--- a/extra-cross/gcc+cross-riscv64/autobuild/defines
+++ b/extra-cross/gcc+cross-riscv64/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=gcc+cross-riscv64
+PKGSEC=devel
+PKGDEP="binutils+cross-riscv64"
+PKGDES="GCC for riscv64 build"
+NOSTATIC=no

--- a/extra-cross/gcc+cross-riscv64/autobuild/prepare
+++ b/extra-cross/gcc+cross-riscv64/autobuild/prepare
@@ -1,5 +1,5 @@
 if [ ! -d /var/ab/cross-root/riscv64 ]; then
         abinfo "Extracting RISC-V 64 sysroot ..."
-	mkdir -p /var/ab/cross-root/riscv64
+	mkdir -pv /var/ab/cross-root/riscv64
 	tar xfpJ "$SRCDIR"/../sysroot.tar.xz -C /var/ab/cross-root/riscv64/ || true
 fi

--- a/extra-cross/gcc+cross-riscv64/autobuild/prepare
+++ b/extra-cross/gcc+cross-riscv64/autobuild/prepare
@@ -1,0 +1,4 @@
+if [ ! -d /var/ab/cross-root/riscv64 ]; then
+	mkdir -p /var/ab/cross-root/riscv64
+	wget https://releases.aosc.io/os-riscv64/buildkit/aosc-os_buildkit_20220219_riscv64.tar.xz -O - | tar xfpJ - -C /var/ab/cross-root/riscv64/
+fi

--- a/extra-cross/gcc+cross-riscv64/autobuild/prepare
+++ b/extra-cross/gcc+cross-riscv64/autobuild/prepare
@@ -1,4 +1,5 @@
 if [ ! -d /var/ab/cross-root/riscv64 ]; then
+        abinfo "Extracting RISC-V 64 sysroot ..."
 	mkdir -p /var/ab/cross-root/riscv64
-	wget https://releases.aosc.io/os-riscv64/buildkit/aosc-os_buildkit_20220219_riscv64.tar.xz -O - | tar xfpJ - -C /var/ab/cross-root/riscv64/
+	tar xfpJ "$SRCDIR"/../sysroot.tar.xz -C /var/ab/cross-root/riscv64/ || true
 fi

--- a/extra-cross/gcc+cross-riscv64/spec
+++ b/extra-cross/gcc+cross-riscv64/spec
@@ -1,0 +1,4 @@
+VER=11.2.0
+SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-$VER/gcc-$VER.tar.xz"
+CHKSUMS="sha256::d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
+CHKUPDATE="anitya::id=6502"

--- a/extra-cross/gcc+cross-riscv64/spec
+++ b/extra-cross/gcc+cross-riscv64/spec
@@ -1,4 +1,7 @@
 VER=11.2.0
-SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-$VER/gcc-$VER.tar.xz"
-CHKSUMS="sha256::d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
+SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-$VER/gcc-$VER.tar.xz \
+      file::rename=sysroot.tar.xz::https://releases.aosc.io/os-riscv64/buildkit/aosc-os_buildkit_20220508_riscv64.tar.xz"
+CHKSUMS="sha256::d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b \
+         sha256::b277e217e34dedc690da144cc88d92a631c303fd5977a95e38bd3b193ccaeccf"
 CHKUPDATE="anitya::id=6502"
+SUBDIR="gcc-$VER"


### PR DESCRIPTION
Topic Description
-----------------

Cross toolchain for riscv64, based on versions in Core 9.1 .

Package(s) Affected
-------------------

- `{binutils,gcc}+cross-ricsv64`: new

Security Update?
----------------

No

Build Order
-----------

`{binutils,gcc}+cross-riscv64`

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
