### PR TITLE
libinput: update to 1.20.1

### DIFF
--- a/extra-libs/exempi/spec
+++ b/extra-libs/exempi/spec
@@ -1,4 +1,4 @@
-VER=2.5.1
-SRCS="tbl::https://github.com/hfiguiere/exempi/archive/$VER.tar.gz"
-CHKSUMS="sha256::db4a5d861e37c7c71288c9284934bcd3f1244724a1a0625512f23ec0134f71a5"
+VER=2.6.1
+SRCS="tbl::https://gitlab.freedesktop.org/libopenraw/exempi/-/archive/${VER}/exempi-${VER}.tar.gz"
+CHKSUMS="sha256::068b449fa24cdb0d3c9f553166c69eefb0c723860370b9e1099df20613154af1"
 CHKUPDATE="anitya::id=767"

--- a/extra-libs/libevdev/spec
+++ b/extra-libs/libevdev/spec
@@ -1,4 +1,4 @@
-VER=1.11.0
+VER=1.12.1
 SRCS="tbl::https://www.freedesktop.org/software/libevdev/libevdev-$VER.tar.xz"
-CHKSUMS="sha256::63f4ea1489858a109080e0b40bd43e4e0903a1e12ea888d581db8c495747c2d0"
+CHKSUMS="sha256::1dbba41bc516d3ca7abc0da5b862efe3ea8a7018fa6e9b97ce9d39401b22426c"
 CHKUPDATE="anitya::id=20540"

--- a/extra-libs/libgudev/spec
+++ b/extra-libs/libgudev/spec
@@ -1,4 +1,4 @@
-VER=236
+VER=237
 SRCS="tbl::https://download.gnome.org/sources/libgudev/$VER/libgudev-$VER.tar.xz"
-CHKSUMS="sha256::e50369d06d594bae615eb7aeb787de304ebaad07a26d1043cef8e9c7ab7c9524"
+CHKSUMS="sha256::0d06b21170d20c93e4f0534dbb9b0a8b4f1119ffb00b4031aaeb5b9148b686aa"
 CHKUPDATE="anitya::id=7735"

--- a/extra-libs/libinput/autobuild/defines
+++ b/extra-libs/libinput/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=libinput
 PKGSEC=libs
-PKGDEP="mtdev systemd libevdev libwacom gtk-3"
+PKGDEP="mtdev systemd libevdev libwacom gtk-3 \
+        python-3 pyudev python-evdev"
+PKGRECOM="gtk-4"
 BUILDDEP="doxygen graphviz check meson ninja recommonmark"
 PKGDES="Library that handles input devices for display servers and other applications"
 

--- a/extra-libs/libinput/autobuild/defines
+++ b/extra-libs/libinput/autobuild/defines
@@ -1,9 +1,11 @@
 PKGNAME=libinput
 PKGSEC=libs
-PKGDEP="mtdev systemd libevdev libwacom gtk-3 \
+PKGDEP="mtdev systemd libevdev libwacom gtk-4 \
         python-3 pyudev python-evdev"
-PKGRECOM="gtk-4"
 BUILDDEP="doxygen graphviz check meson ninja recommonmark"
 PKGDES="Library that handles input devices for display servers and other applications"
 
 ABTYPE=meson
+# Disabling compiling for test cases will accerate the build process.
+# Comment the following line in case of testing purpose.
+MESON_AFTER="-Dtests=false"

--- a/extra-libs/libinput/spec
+++ b/extra-libs/libinput/spec
@@ -1,4 +1,4 @@
-VER=1.19.3
-SRCS="tbl::https://www.freedesktop.org/software/libinput/libinput-$VER.tar.xz" 
-CHKSUMS="sha256::3cae78ccde19d7d0f387e58bc734d4d17ab5f6426f54a9e8b728c90b17baa068"
+VER=1.20.1
+SRCS="tbl::https://gitlab.freedesktop.org/libinput/libinput/-/archive/${VER}/libinput-${ver}.tar.gz" 
+CHKSUMS="sha256::4180a84b98515a6210b55605ca58e7f7f3f7fe5b30c05cbec961bbea0cd410fa"
 CHKUPDATE="anitya::id=5781"

--- a/extra-libs/libiptcdata/autobuild/defines
+++ b/extra-libs/libiptcdata/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=libiptcdata
 PKGSEC=libs
 PKGDEP="glibc"
+BUILDDEP="gtk-doc"
 PKGDES="Library for manipulating the IPTC metadata"

--- a/extra-libs/libiptcdata/spec
+++ b/extra-libs/libiptcdata/spec
@@ -1,5 +1,5 @@
 VER=1.0.4
-REL=2
+REL=3
 SRCS="tbl::https://prdownloads.sourceforge.net/libiptcdata/libiptcdata-$VER.tar.gz"
 CHKSUMS="sha256::79f63b8ce71ee45cefd34efbb66e39a22101443f4060809b8fc29c5eebdcee0e"
 CHKUPDATE="anitya::id=229582"

--- a/extra-libs/libquvi-scripts/autobuild/defines
+++ b/extra-libs/libquvi-scripts/autobuild/defines
@@ -3,3 +3,4 @@ PKGSEC=libs
 PKGDEP="lua-socket luabitop lua-expat"
 PKGDES="Library for parsing video download links"
 AUTOTOOLS_AFTER="--with-nsfw --with-geoblocked"
+ABSPLITDBG=0

--- a/extra-libs/libquvi-scripts/spec
+++ b/extra-libs/libquvi-scripts/spec
@@ -1,5 +1,5 @@
 VER=0.9.20131130
-REL=3
+REL=4
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/quvi/libquvi-scripts-$VER.tar.xz"
 CHKSUMS="sha256::17f21f9fac10cf60af2741f2c86a8ffd8007aa334d1eb78ff6ece130cb3777e3"
 CHKUPDATE="anitya::id=230127"

--- a/extra-libs/libquvi/autobuild/patches/0001-gentoo-libquvi-0.9.4-autoconf-2.70.patch
+++ b/extra-libs/libquvi/autobuild/patches/0001-gentoo-libquvi-0.9.4-autoconf-2.70.patch
@@ -1,0 +1,14 @@
+Original URL: https://gitweb.gentoo.org/repo/gentoo.git/tree/media-libs/libquvi/files/libquvi-0.9.4-autoconf-2.70.patch
+
+This patch will fix an FTBFS problem caused by update of GNU autoconf.
+--- libquvi-0.9.4/configure.ac
++++ libquvi-0.9.4/configure.ac
+@@ -8,7 +8,7 @@
+ AC_INIT([libquvi], m4_esyscmd([./gen-ver.sh -c | tr -d '\n']),
+         [http://quvi.sf.net/bugs/],[],[http://quvi.sf.net/])
+ 
+-AC_DEFINE_UNQUOTED([BUILD_OPTS], "$@",
++AC_DEFINE_UNQUOTED([BUILD_OPTS], "$*",
+   [Define to configure invocation command line options])
+ 
+ # Interface

--- a/extra-libs/libquvi/spec
+++ b/extra-libs/libquvi/spec
@@ -1,5 +1,5 @@
 VER=0.9.4
-REL=3
+REL=4
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/quvi/libquvi-$VER.tar.xz"
 CHKSUMS="sha256::2d3fe28954a68ed97587e7b920ada5095c450105e993ceade85606dadf9a81b2"
 CHKUPDATE="anitya::id=230130"

--- a/extra-libs/libwacom/spec
+++ b/extra-libs/libwacom/spec
@@ -1,5 +1,4 @@
-VER=1.9
-REL=1
-SRCS="tbl::https://github.com/linuxwacom/libwacom/releases/download/libwacom-${VER}/libwacom-${VER}.tar.bz2"
-CHKSUMS="sha256::68b14d4e3b75fed9f590bf6eaea361a72dc23e933b7725094c779477acf665c7"
+VER=2.2.0
+SRCS="tbl::https://github.com/linuxwacom/libwacom/releases/download/libwacom-${VER}/libwacom-${VER}.tar.xz"
+CHKSUMS="sha256::e62ac9edb522d36ad2fa99adca35ddc02067383d4668eeaa13d7efccc30bb8c8"
 CHKUPDATE="anitya::id=16887"

--- a/extra-lua/lua-expat/autobuild/build
+++ b/extra-lua/lua-expat/autobuild/build
@@ -1,3 +1,2 @@
 make LUA_V=5.3 CFLAGS='-DLUA_32BITS'
 make LUA_V=5.3 DESTDIR="$PKGDIR" install
-install -Dm0644 doc/us/license.html "$PKGDIR/usr/share/licenses/$PKGNAME/license.html"

--- a/extra-lua/lua-expat/spec
+++ b/extra-lua/lua-expat/spec
@@ -1,5 +1,4 @@
-VER=1.3.0
-REL=5
-SRCS="tbl::https://matthewwild.co.uk/projects/luaexpat/luaexpat-$VER.tar.gz"
-CHKSUMS="sha256::d060397960d87b2c89cf490f330508b7def1a0677bdc120531c571609fc57dc3"
+VER=1.4.1
+SRCS="tbl::https://github.com/lunarmodules/luaexpat/archive/refs/tags/${VER}.tar.gz"
+CHKSUMS="sha256::d528060d45865b44bef7215ef8a440165b668f363a4af53358389f0315a8593c"
 CHKUPDATE="anitya::id=11782"

--- a/extra-python/python-evdev/spec
+++ b/extra-python/python-evdev/spec
@@ -1,5 +1,4 @@
-VER=1.4.0
+VER=1.5.0
 SRCS="tbl::https://pypi.io/packages/source/e/evdev/evdev-$VER.tar.gz"
-CHKSUMS="sha256::8782740eb1a86b187334c07feb5127d3faa0b236e113206dfe3ae8f77fb1aaf1"
+CHKSUMS="sha256::5b33b174f7c84576e7dd6071e438bf5ad227da95efd4356a39fe4c8355412fe6"
 CHKUPDATE="anitya::id=12300"
-REL=1

--- a/extra-python/pyudev/spec
+++ b/extra-python/pyudev/spec
@@ -1,4 +1,4 @@
-VER=0.22
+VER=0.23.2
 SRCS="tbl::https://github.com/pyudev/pyudev/archive/v$VER.tar.gz"
-CHKSUMS="sha256::245b5717923bed83993cd50761c3f8f1a1a68e2cd09031adbd30beed4dc60077"
+CHKSUMS="sha256::081f06749dba82ed421f332d912a20ecfa079c4bb5200ed4119ad98d0b4a3ec2"
 CHKUPDATE="anitya::id=8485"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

It is discovered that `libinput` is vulnerable to CVE-2022-1215 , and upstream has released version 1.20.1 to fix aforementioned vulnerability. This topic will update `libinput` to 1.20.1 , and along with updates of dependencies list.

UPDATE on 04/24/2022: This topic also involves several updates of `libinput`'s dependencies.
UPDATE-2 on 04/24/2022: Since gtk-4 replaces gtk-3 for this package, which is not available in current riscv64 repo, this topic will also involve several updates to adopt support of gtk-4 for riscv64.

Details can be found in commit messages. https://github.com/AOSC-Dev/aosc-os-abbs/pull/3940/commits/e9a1a61db2f0e7ee4daa3db877ac8ce5b7e6a1f3

References: 
Ubuntu security advisory: [USN-5382-1]()
Upstream commit msg: https://gitlab.freedesktop.org/libinput/libinput/-/commit/a423d7d3269dc32a87384f79e29bb5ac021c83d1 | https://github.com/wayland-project/libinput/commit/2a8b8fde90d63d48ce09ddae44142674bbca1c28
Upstream issue: https://gitlab.freedesktop.org/libinput/libinput/-/issues/752

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

Main package:
- `libinput` 1.19.3 -> 1.20.1

Dependencies:
- `libevdev`
- `libgudev`
- `libwacom`
- `pyudev`
- `python-evdev`

Dependencies (gtk-4):
- `exempi`
- `libiptcdata`
- `lua-expat`
- `libquvi{,-scripts}`

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

Yes. See references above.

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

Affected dependencies -> `libinput`
`ciel build -i {instance} libquvi libquvi-scripts lua-expat libiptcdata exempi libevdev libgudev libwacom pyudev python-evdev libinput`

For riscv64:
`ciel build -i {instance} libplist libquvi libquvi-scripts lua-expat libiptcdata exempi libevdev libgudev libwacom pyudev python-evdev libinput`

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
