### PR TITLE
zellij: update to 0.29.1

### DIFF
--- a/extra-utils/zellij/spec
+++ b/extra-utils/zellij/spec
@@ -1,3 +1,3 @@
-VER=0.25.0
+VER=0.29.1
 SRCS="tbl::https://github.com/zellij-org/zellij/archive/v$VER.tar.gz"
-CHKSUMS="sha256::5bd4e6a726cf32e096f9c90d7dc414e63dee0613a56f5b665f4bfc6376dcf20a"
+CHKSUMS="sha256::340f5241c9b1abb5652b1531167f837fc573b9cfdefa551363a48930f8f1d4dd"


### PR DESCRIPTION
Topic Description
-----------------

Update `zellij` to 0.29.1

Package(s) Affected
-------------------

`zellij` v0.29.1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`