### PR TITLE
frescobaldi: update to 3.2

### DIFF
--- a/extra-multimedia/frescobaldi/autobuild/defines
+++ b/extra-multimedia/frescobaldi/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=frescobaldi
 PKGSEC=utils
-PKGDEP="hyphen poppler python-3 python-ly python-poppler-qt5 pyqt5 lilypond pygame"
+PKGDEP="hyphen poppler python-3 python-ly python-poppler-qt5 pyqt5 lilypond pygame qpageview"
 PKGDES="LilyPond sheet music text editor"
 
 NOPYTHON2=1

--- a/extra-multimedia/frescobaldi/spec
+++ b/extra-multimedia/frescobaldi/spec
@@ -1,5 +1,4 @@
-VER=3.1.2
+VER=3.2
 SRCS="tbl::https://github.com/wbsoft/frescobaldi/releases/download/v$VER/frescobaldi-$VER.tar.gz"
-CHKSUMS="sha256::5c2cffb8282cd9faef1585808bd800d1eb3c0db4cc464a61ce8576dbf7ef9b20"
+CHKSUMS="sha256::4d707b5b35392f84d904d1cc7ecc36992f8e85f6868fdc5a4983c78a0e850acf"
 CHKUPDATE="anitya::id=10249"
-REL=1

--- a/extra-python/qpageview/autobuild/defines
+++ b/extra-python/qpageview/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME="qpageview"
+PKGDES="Page-based viewer widget for Qt5/PyQt5"
+PKGDEP="python-3 pyqt5 qt-5"
+BUILDDEP="setuptools"
+PKGSEC="x11"
+
+NOPYTHON2=1
+ABHOST="noarch"

--- a/extra-python/qpageview/spec
+++ b/extra-python/qpageview/spec
@@ -1,0 +1,4 @@
+VER="0.6.2"
+SRCS="tbl::https://github.com/frescobaldi/qpageview/archive/refs/tags/v$VER.tar.gz"
+CHKUPDATE="aniyta::id=94536"
+CHKSUMS="sha256::5ac3140396f11b15d6438ce34d5ce77f8b7e76f7dcd4c0439c85740d9e5d3674"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

This topic updates Frescobaldi to 3.2.

Package(s) Affected
-------------------

- `frescobaldi` v3.2
- `qpageview` v0.6.2 (new)

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->


Build Order
-----------

```
qpageview frescobaldi
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch` 

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

 - [ ] Architecture-independent `noarch` 