### PR TITLE
fcitx5: update to 5.0.15

### DIFF
--- a/extra-i18n/fcitx5-anthy/spec
+++ b/extra-i18n/fcitx5-anthy/spec
@@ -1,4 +1,4 @@
-VER=5.0.8
+VER=5.0.10
 SRCS="tbl::https://github.com/fcitx/fcitx5-anthy/archive/$VER.tar.gz"
-CHKSUMS="sha256::a5c08ccf28eea593746ced63b4d22c046b2614870296832e78ddfb3237e185ee"
+CHKSUMS="sha256::0a7667930c2fc2efa991060d728f9002479185ee186b91c7745323131f65cf58"
 CHKUPDATE="anitya::id=174357"

--- a/extra-i18n/fcitx5-chewing/spec
+++ b/extra-i18n/fcitx5-chewing/spec
@@ -1,4 +1,4 @@
-VER=5.0.8
+VER=5.0.10
 SRCS="tbl::https://github.com/fcitx/fcitx5-chewing/archive/$VER.tar.gz"
-CHKSUMS="sha256::d2c288c149b042a20694dc4ba2aafc27b8a7293f846ff515b6c0927214fd51af"
+CHKSUMS="sha256::5f4802998e33649bd1c0b291be46ba4778e48dfc1067ced360b1241d73be263d"
 CHKUPDATE="anitya::id=138243"

--- a/extra-i18n/fcitx5-chinese-addons/spec
+++ b/extra-i18n/fcitx5-chinese-addons/spec
@@ -1,8 +1,7 @@
-VER=5.0.10
-REL=1
+VER=5.0.12
 SRCS="tbl::https://github.com/fcitx/fcitx5-chinese-addons/archive/$VER.tar.gz \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5-chinese-addons/fcitx5-chinese-addons-${VER}_dict.tar.xz"
-CHKSUMS="sha256::fb3facf05882e7e86b22f53f565ee4578fb6791c8a4dbb07c560115ba8d11b9a \
-         sha256::750996383ceeaa39994ac5796389a2d81300d4c80186232bd0b0d131cfca399e"
+CHKSUMS="sha256::98234f7c52cca6e326e839b4001c1fe425a89c31cce3d122742ffc2929cb6e12 \
+         sha256::66baebe7cf06cf73a52bbd96aad46e6d6ebd0c4b126b8ee2da7124bcdcb5207c"
 CHKUPDATE="anitya::id=138238"
 SUBDIR="fcitx5-chinese-addons-$VER"

--- a/extra-i18n/fcitx5-configtool/spec
+++ b/extra-i18n/fcitx5-configtool/spec
@@ -1,5 +1,4 @@
-VER=5.0.10
-REL=1
+VER=5.0.12
 SRCS="tbl::https://github.com/fcitx/fcitx5-configtool/archive/$VER.tar.gz"
-CHKSUMS="sha256::5189d3a65144f47da1c495742735df2d239052ff330d31a1ba2d623f283454af"
+CHKSUMS="sha256::41216ca8d15b8cfd1e4a2aa64175650093d6daa34db7da8d3eb15b96023d30b8"
 CHKUPDATE="anitya::id=138233"

--- a/extra-i18n/fcitx5-gtk/spec
+++ b/extra-i18n/fcitx5-gtk/spec
@@ -1,4 +1,4 @@
-VER=5.0.11
+VER=5.0.13
 SRCS="tbl::https://github.com/fcitx/fcitx5-gtk/archive/$VER.tar.gz"
-CHKSUMS="sha256::da7aff8dfdad0c22c7a98805e8d2aae8fe25e01e49747808a46243c1a32c717f"
+CHKSUMS="sha256::40912698baca050bf06b6f5ce55a91cc14d852519aacb39b293c9f542a708250"
 CHKUPDATE="anitya::id=138235"

--- a/extra-i18n/fcitx5-hangul/spec
+++ b/extra-i18n/fcitx5-hangul/spec
@@ -1,4 +1,4 @@
-VER=5.0.6
+VER=5.0.8
 SRCS="tbl::https://github.com/fcitx/fcitx5-hangul/archive/$VER.tar.gz"
-CHKSUMS="sha256::337aea52fbc59c94d6f1892a21872cf55a38a6dc89a44ac848efec64cd087051"
+CHKSUMS="sha256::4815f6193b2356ce71f9ccc71a6ab6d2e4c4db33a2b07bab221594b25723090b"
 CHKUPDATE="anitya::id=174360"

--- a/extra-i18n/fcitx5-kkc/spec
+++ b/extra-i18n/fcitx5-kkc/spec
@@ -1,5 +1,4 @@
-VER=5.0.6
-REL=1
+VER=5.0.8
 SRCS="tbl::https://github.com/fcitx/fcitx5-kkc/archive/$VER.tar.gz"
-CHKSUMS="sha256::1c7a725b92ced85c2b17214927eec08cc47be0fa2cbc421b4f4ef8b940e8cc2a"
+CHKSUMS="sha256::bcc2ce56ff01f3fcc396c4637793493b2aa2a71eea364630b75ee23ddf1092a8"
 CHKUPDATE="anitya::id=138241"

--- a/extra-i18n/fcitx5-libthai/spec
+++ b/extra-i18n/fcitx5-libthai/spec
@@ -1,4 +1,4 @@
-VER=5.0.6
+VER=5.0.7
 SRCS="tbl::https://github.com/fcitx/fcitx5-libthai/archive/$VER.tar.gz"
-CHKSUMS="sha256::109fe9d0d1ae37d3c12e9678648202c5860669f32f2309a76837d994a50954dd"
+CHKSUMS="sha256::c6df6a1c2d1cc610bdf1f09dee147ed42f2b46d1db416a95aee49d72d64c9a7f"
 CHKUPDATE="anitya::id=174358"

--- a/extra-i18n/fcitx5-lua/spec
+++ b/extra-i18n/fcitx5-lua/spec
@@ -1,4 +1,4 @@
-VER=5.0.5
+VER=5.0.7
 SRCS="tbl::https://github.com/fcitx/fcitx5-lua/archive/$VER.tar.gz"
-CHKSUMS="sha256::ac8db4865fa512375340a159a3ee04cf2b439d553756c4153d32cd1d3ed83abc"
+CHKSUMS="sha256::cb0cf1e5fd3d4dd906e482ae0cc50944e804b4ce10515968334f9530dbdfa3b4"
 CHKUPDATE="anitya::id=138242"

--- a/extra-i18n/fcitx5-m17n/spec
+++ b/extra-i18n/fcitx5-m17n/spec
@@ -1,4 +1,4 @@
-VER=5.0.7
+VER=5.0.8
 SRCS="tbl::https://github.com/fcitx/fcitx5-m17n/archive/$VER.tar.gz"
-CHKSUMS="sha256::3f42d50bcc5425bad5463a5f9bc9a238eab8608315e9d4aa870a09cdc16d610c"
+CHKSUMS="sha256::af3e77e49a7b373db1d49002679d95853c5a05e800177893e64ae83ba9794441"
 CHKUPDATE="anitya::id=174359"

--- a/extra-i18n/fcitx5-qt/spec
+++ b/extra-i18n/fcitx5-qt/spec
@@ -1,5 +1,4 @@
-VER=5.0.9
-REL=1
+VER=5.0.11
 SRCS="https://github.com/fcitx/fcitx5-qt/archive/$VER.tar.gz"
-CHKSUMS="sha256::56ab8dfe689077f1c25570a0accc4d55b255f8261d738af911a1fdfe8516c5f3"
+CHKSUMS="sha256::426748e8e6514d48e0bbbb0bb85a76e786db1dd4a7cb8ed276c0d23179642882"
 CHKUPDATE="anitya::id=138234"

--- a/extra-i18n/fcitx5-rime/spec
+++ b/extra-i18n/fcitx5-rime/spec
@@ -1,4 +1,4 @@
-VER=5.0.10
+VER=5.0.12
 SRCS="tbl::https://github.com/fcitx/fcitx5-rime/archive/$VER.tar.gz"
-CHKSUMS="sha256::390f0de9d4d71b226b5568b7485bac8694dfb8f61d4a03b1c24efa91baf4793d"
+CHKSUMS="sha256::549da0d08681ada3cb4148a03e867764d16a514eb021c9bbdd8a2336f2626556"
 CHKUPDATE="anitya::id=138239"

--- a/extra-i18n/fcitx5-sayura/spec
+++ b/extra-i18n/fcitx5-sayura/spec
@@ -1,4 +1,4 @@
-VER=5.0.4
+VER=5.0.6
 SRCS="tbl::https://github.com/fcitx/fcitx5-sayura/archive/$VER.tar.gz"
-CHKSUMS="sha256::57ca242f396d91252005ff95248d7606da009c1e47e9fc1f216846d906fdb434"
+CHKSUMS="sha256::d51b821f437a275d0bf13a8efb07d7195886080d229411da1df3c2acb23acf8a"
 CHKUPDATE="anitya::id=174361"

--- a/extra-i18n/fcitx5-skk/spec
+++ b/extra-i18n/fcitx5-skk/spec
@@ -1,5 +1,4 @@
-VER=5.0.9
-REL=1
+VER=5.0.11
 SRCS="tbl::https://github.com/fcitx/fcitx5-skk/archive/$VER.tar.gz"
-CHKSUMS="sha256::34e62e0dd74f2c242bbde412836c3ffa00101a50d35735392abb63721d6d003d"
+CHKSUMS="sha256::d5f2de809ceb19f3e3796afa9e2616d453ae85ec6299874cc8c86ec76951a9c5"
 CHKUPDATE="anitya::id=138240"

--- a/extra-i18n/fcitx5-unikey/spec
+++ b/extra-i18n/fcitx5-unikey/spec
@@ -1,5 +1,4 @@
-VER=5.0.7
-REL=1
+VER=5.0.9
 SRCS="tbl::https://github.com/fcitx/fcitx5-unikey/archive/$VER.tar.gz"
-CHKSUMS="sha256::6c4ac98348bc1279ba5fc82de66bfc592e7330eb544f064bddfc224978fb2607"
+CHKSUMS="sha256::e16fc7ef34716f634163af82e999f0f260196fbf4bbefaa7a382a5d3864c1073"
 CHKUPDATE="anitya::id=180082"

--- a/extra-i18n/fcitx5/spec
+++ b/extra-i18n/fcitx5/spec
@@ -1,8 +1,7 @@
-VER=5.0.13
-REL=1
+VER=5.0.15
 SRCS="tbl::https://github.com/fcitx/fcitx5/archive/$VER.tar.gz \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5/fcitx5-${VER}_dict.tar.xz"
-CHKSUMS="sha256::eee26371b1ecbdd9e82152e8f372f802a1f761fe9cbbc4d0b28ad705f7dfdd0b \
-         sha256::b5926b95e3144c62e3d36039b9e19518e138606e523c4ba7a670bc23eee5af90"
+CHKSUMS="sha256::11d077b6f92d0279cae93e889a4c9efe7408e50420d17a90c6c20322b05c27f4 \
+         sha256::f2ee4f946a363bfe806ba9a6e9d610a45eb4389603a473d1e8b3d9fbada551e5"
 CHKUPDATE="anitya::id=138232"
 SUBDIR="fcitx5-$VER"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

fcitx5: update to 5.0.15

Package(s) Affected
-------------------

```
* 83d314477e (HEAD -> fcitx5-5.0.15, origin/fcitx5-5.0.15) fcitx5-chewing: update to 5.0.10
* 6781a4e922 fcitx5-m17n: update to 5.0.8
* 377f4c43b7 fcitx5-hangul: update to 5.0.8
* dd5aa2d067 fcitx5-unikey: update to 5.0.9
* 1e4d6a5210 fcitx5-libthai: update to 5.0.7
* 7ba34cdcc4 fcitx5-sayura: update to 5.0.6
* 918ebe183e fcitx5-skk: update to 5.0.11
* e5e0372766 fcitx5-lua: update to 5.0.7
* c1fda08941 fcitx5-configtool: update to 5.0.12
* 4d9cca8ff1 fcitx5-kkc: update to 5.0.8
* a51172f4b6 fcitx5-anthy: update to 5.0.10
* a687178105 fcitx5-rime: update to 5.0.12
* 8e03be50aa fcitx5-chinese-addons: update to 5.0.12
* 643e7c665d fcitx5-gtk: update to 5.0.13
* 0b8dd7459a fcitx5-qt: update to 5.0.11
* a52cc3ec36 fcitx5: update to 5.0.15
```

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->


Build Order
-----------

fcitx5 fcitx5-qt fcitx5-gtk fcitx5-configtool fcitx5-chewing fcitx5-m17n fcitx5-hangul fcitx5-unikey fcitx5-libthai fcitx5-sayura fcitx5-skk fcitx5-lua fcitx5-kkc fcitx5-anthy fcitx5-rime fcitx5-chinese-addons


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
