### PR TITLE
aoscdk-rs: update to 0.4.8

### DIFF
--- a/extra-admin/aoscdk-rs/autobuild/patches/0001-disks-fix-new_partition_table-in-ppc64-el.patch
+++ b/extra-admin/aoscdk-rs/autobuild/patches/0001-disks-fix-new_partition_table-in-ppc64-el.patch
@@ -1,0 +1,39 @@
+From 70dc73695af00883ef85e966f764e69910a5c6bc Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Mon, 9 May 2022 15:07:06 +0800
+Subject: [PATCH] disks: fix new_partition_table in ppc64/el
+
+---
+ src/disks.rs | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/src/disks.rs b/src/disks.rs
+index 768ee02..880a4b7 100644
+--- a/src/disks.rs
++++ b/src/disks.rs
+@@ -204,13 +204,15 @@ pub fn new_partition_table() -> Result<()> {
+     use crate::network;
+ 
+     let arch_name = network::get_arch_name();
+-    if libparted::Disk::new(&mut i).is_err() && arch_name == Some("ppc64el") {
+-        let disk = libparted::Disk::new_fresh(
+-            &mut i,
+-            DiskType::get("gpt").ok_or_else(|| anyhow!("Unsupport partition table type!"))?,
+-        );
+-        if let Ok(mut disk) = disk {
+-            disk.commit_to_dev().ok();
++    for mut i in libparted::Device::devices(true) {
++        if libparted::Disk::new(&mut i).is_err() && arch_name == Some("ppc64el") {
++            let disk = libparted::Disk::new_fresh(
++                &mut i,
++                DiskType::get("gpt").ok_or_else(|| anyhow!("Unsupport partition table type!"))?,
++            );
++            if let Ok(mut disk) = disk {
++                disk.commit_to_dev().ok();
++            }
+         }
+     }
+ 
+-- 
+2.35.1
+

--- a/extra-admin/aoscdk-rs/spec
+++ b/extra-admin/aoscdk-rs/spec
@@ -1,4 +1,4 @@
-VER=0.4.7
+VER=0.4.8
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscdk-rs/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226678"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

aoscdk-rs: update to 0.4.8

Package(s) Affected
-------------------

aoscdk-rs: 0.4.8

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
