### PR TITLE
pipewire: update to 0.3.51

### DIFF
--- a/extra-libs/libcamera/autobuild/defines
+++ b/extra-libs/libcamera/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=libcamera
 PKGSEC=libs
 PKGDES="A cross-platform camera support library"
-BUILDDEP="boost doxygen gnutls gstreamer-1-0 gtest jinja2 libevent libtiff \
-          libdwarf lttng-ust meson ninja openssl pyyaml qt-5 sphinx systemd"
+BUILDDEP="boost doxygen gnutls gstreamer-1-0 gtest jinja2 ply libevent libtiff \
+          libdwarf lttng-ust meson ninja openssl pyyaml qt-5 sphinx systemd \
+          texlive"
 
 # qcam and cam will crash with LTO,
 # see https://bugs.libcamera.org/show_bug.cgi?id=83

--- a/extra-libs/libcamera/spec
+++ b/extra-libs/libcamera/spec
@@ -1,5 +1,4 @@
-VER=0+git20211111
-REL=1
-SRCS="git::commit=6b288f8f4f53edf90cc7ab22fc41c7edaa69e123::https://github.com/libcamera-org/libcamera"
+VER=0+git20220510
+SRCS="git::commit=226563607ea888c0af49bf3cdc7b3654d6a50089::https://git.libcamera.org/libcamera/libcamera.git"
 CHKSUMS="SKIP"
-CHKUPDATE="git::url=https://github.com/libcamera-org/libcamera.git"
+CHKUPDATE="git::url=https://git.libcamera.org/libcamera/libcamera.git"

--- a/extra-libs/lilv/autobuild/defines
+++ b/extra-libs/lilv/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lilv
 PKGSEC=libs
-PKGDEP="jack numpy sratom"
-BUILDDEP="swig"
+PKGDEP="sord sratom serd libsndfile flac libogg libvorbis lv2"
+BUILDDEP="doxygen graphviz python-3 swig libsndfile sphinx"
 PKGDES="A C library interface to the LV2 plugin standard"

--- a/extra-libs/lilv/spec
+++ b/extra-libs/lilv/spec
@@ -1,4 +1,4 @@
-VER=0.24.6
+VER=0.24.12
 SRCS="tbl::https://download.drobilla.net/lilv-$VER.tar.bz2"
-CHKSUMS="sha256::5f544cf79656e0782a03a2cc7ab1d31a93f36d71d4187bd427ade8d7b55370dc"
+CHKSUMS="sha256::26a37790890c9c1f838203b47f5b2320334fe92c02a4d26ebbe2669dbd769061"
 CHKUPDATE="anitya::id=1818"

--- a/extra-multimedia/lv2/autobuild/defines
+++ b/extra-multimedia/lv2/autobuild/defines
@@ -1,4 +1,3 @@
 PKGNAME=lv2
 PKGSEC=sound
-PKGDEP=""
 PKGDES="An open standard for audio plugins"

--- a/extra-multimedia/lv2/spec
+++ b/extra-multimedia/lv2/spec
@@ -1,4 +1,4 @@
-VER=1.16.0
+VER=1.18.2
 SRCS="tbl::https://lv2plug.in/spec/lv2-$VER.tar.bz2"
-CHKSUMS="sha256::dec3727d7bd34a413a344a820678848e7f657b5c6019a0571c61df76d7bdf1de"
+CHKSUMS="sha256::4e891fbc744c05855beb5dfa82e822b14917dd66e98f82b8230dbd1c7ab2e05e"
 CHKUPDATE="anitya::id=230934"

--- a/extra-multimedia/pipewire/autobuild/defines
+++ b/extra-multimedia/pipewire/autobuild/defines
@@ -2,8 +2,8 @@ PKGNAME=pipewire
 PKGSEC=sound
 PKGDES="Server and user space API to deal with multimedia pipelines"
 PKGDEP="alsa-lib bluez dbus ffmpeg gstreamer-1-0 gst-plugins-base-1-0 \
-        libfdk-aac libldac libfreeaptx libsndfile libusb libva ncurses \
-        readline rtkit sbc systemd v4l-utils vulkan webrtc-audio-processing"
+        libcanberra libfdk-aac libldac libfreeaptx libsndfile libusb libva \
+        lilv ncurses readline rtkit sbc systemd v4l-utils vulkan webrtc-audio-processing"
 PKGDEP__PPC64EL="${PKGDEP}"
 
 PKGDEP__NONPPC64EL="${PKGDEP} libcamera"
@@ -18,6 +18,15 @@ BUILDDEP="avahi doxygen docutils graphviz meson ninja pulseaudio sdl2"
 ABTYPE=meson
 MESON_AFTER="-Ddocs=enabled \
              -Dman=enabled \
+             -Dgstreamer=enabled \
+             -Dsystemd=enabled \
+             -Dgstreamer-device-provider=disabled \
+             -Djack-devel=false \
+             -Dsdl2=disabled \
+             -Daudiotestsrc=disabled \
+             -Dvideotestsrc=disabled \
+             -Dvolume=disabled \
+             -Dbluez5-codec-aptx=enabled \
              -Droc=disabled \
              -Dsession-managers=[] \
              -Dvulkan=enabled \

--- a/extra-multimedia/pipewire/spec
+++ b/extra-multimedia/pipewire/spec
@@ -1,4 +1,4 @@
-VER=0.3.40
+VER=0.3.51
 SRCS="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/$VER/pipewire-$VER.tar.gz"
-CHKSUMS="sha256::a2c8176d757a2ac6db445c61a50802ff1c26f49f5a28174f5eb0278609a887cf"
+CHKSUMS="sha256::f18e7a2cd2fcd75482c3df4e736e01435bd20779ddf63da63b0a086d3a9735ac"
 CHKUPDATE="anitya::id=57357"

--- a/extra-multimedia/wireplumber/autobuild/defines
+++ b/extra-multimedia/wireplumber/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=wireplumber
+PKGSEC=sound
+PKGDES="A modular session/policy manager for PipeWire"
+PKGDEP="glib pipewire lua-5.3 systemd"
+BUILDDEP="meson lua-5.3 gobject-introspection lxml doxygen"
+
+ABTYPE=meson
+MESON_AFTER="-Dsystem-lua=true \
+             -Ddoc=disabled \
+             -Dsystemd=enabled \
+             -Dsystemd-user-service=true \
+             -Dintrospection=enabled \
+             -Delogind=disabled"

--- a/extra-multimedia/wireplumber/spec
+++ b/extra-multimedia/wireplumber/spec
@@ -1,0 +1,4 @@
+VER=0.4.10
+SRCS="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${VER}/wireplumber-${VER}.tar.bz2"
+CHKSUMS="sha256::f96315f1b6b2fa8e837803d7e90932dcae640d239cd867624a78f9cc5511b488"
+CHKUPDATE="anitya::id=235056"


### PR DESCRIPTION
Topic Description
-----------------

Update pipewire to 0.3.51

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

 - lv2: update to 1.18.2
 - lilv: update to 0.24.12
 - libcamera: update to 0+git20220510
 - pipewire: update to 0.3.51 and enable more features.
 - wireplumber: new, 0.4.10

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
