### PR TITLE
openixcard: new, 1.0.1

### DIFF
--- a/extra-devel/openixcard/autobuild/beyond
+++ b/extra-devel/openixcard/autobuild/beyond
@@ -1,2 +1,2 @@
 abinfo "Fixing wrong permissions ..."
-chmod +x "$PKGDIR"/usr/libexec/openixcard/genimage
+chmod --verbose +x "$PKGDIR"/usr/libexec/openixcard/genimage

--- a/extra-devel/openixcard/autobuild/beyond
+++ b/extra-devel/openixcard/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Fixing wrong permissions ..."
+chmod +x "$PKGDIR"/usr/libexec/openixcard/genimage

--- a/extra-devel/openixcard/autobuild/defines
+++ b/extra-devel/openixcard/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=openixcard
+PKGSEC=devel
+PKGDES="Open Source Version of Allwinner PhoenixCard on Linux to manipulate sunxi's .img file"
+
+BUILDDEP="cmake"
+PKGDEP="glibc confuse"
+
+ABTYPE=cmake

--- a/extra-devel/openixcard/autobuild/defines
+++ b/extra-devel/openixcard/autobuild/defines
@@ -4,4 +4,4 @@ PKGDES="Open source implementation of PhoenixCard - Allwinner's image manipulati
 
 PKGDEP="glibc confuse"
 
-ABTYPE=cmake
+ABTYPE=cmakeninja

--- a/extra-devel/openixcard/autobuild/defines
+++ b/extra-devel/openixcard/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=openixcard
 PKGSEC=devel
-PKGDES="Open Source Version of Allwinner PhoenixCard on Linux to manipulate sunxi's .img file"
+PKGDES="Open Source Implementation of Allwinner/sunxi's Image Manipulation Tool PhoenixCard"
 
 BUILDDEP="cmake"
 PKGDEP="glibc confuse"

--- a/extra-devel/openixcard/autobuild/defines
+++ b/extra-devel/openixcard/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME=openixcard
 PKGSEC=devel
-PKGDES="Open Source Implementation of Allwinner/sunxi's Image Manipulation Tool PhoenixCard"
+PKGDES="Open source implementation of PhoenixCard - Allwinner's image manipulation tool"
 
-BUILDDEP="cmake"
 PKGDEP="glibc confuse"
 
 ABTYPE=cmake

--- a/extra-devel/openixcard/autobuild/patches/0001-DO-NOT-MERGE-Workaround-for-3.patch
+++ b/extra-devel/openixcard/autobuild/patches/0001-DO-NOT-MERGE-Workaround-for-3.patch
@@ -1,0 +1,59 @@
+From b4bbce879c44f6a7f01063a585e2e0d445f6d848 Mon Sep 17 00:00:00 2001
+From: Camber Huang <camber@poi.science>
+Date: Tue, 24 May 2022 01:17:03 +0800
+Subject: [PATCH] [DO NOT MERGE] Workaround for #3 - alter the searching path
+ of genimage - alter the installation path in CMakeList.txt
+
+Signed-off-by: Camber Huang <camber@poi.science>
+---
+ CMakeLists.txt              | 4 ++--
+ src/OpenixCard/Genimage.cpp | 6 +++++-
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d2afa55..da5f928 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -72,13 +72,13 @@ else ()
+     install(
+             TARGETS OpenixCard
+             COMPONENT applications
+-            DESTINATION "opt/openixcard/bin"
++            DESTINATION "bin"
+     )
+ 
+     install(
+             FILES "${EXECUTABLE_OUTPUT_PATH}/bin/genimage"
+             COMPONENT applications
+-            DESTINATION "opt/openixcard/bin/bin"
++            DESTINATION "libexec/openixcard"
+     )
+ 
+     include(CMake/cpack.cmake)
+diff --git a/src/OpenixCard/Genimage.cpp b/src/OpenixCard/Genimage.cpp
+index 22f313e..b922b14 100644
+--- a/src/OpenixCard/Genimage.cpp
++++ b/src/OpenixCard/Genimage.cpp
+@@ -13,6 +13,8 @@
+ #include <filesystem>
+ #include <fstream>
+ #include <iostream>
++#include <cstdlib>
++#include <string>
+ 
+ #include <subprocess.hpp>
+ 
+@@ -22,7 +24,9 @@
+ 
+ [[maybe_unused]] Genimage::Genimage(std::string config_path, std::string image_path, std::string output_path)
+         : config_path(std::move(config_path)), image_path(std::move(image_path)), output_path(std::move(output_path)) {
+-    this->genimage_bin = std::filesystem::current_path() / "bin/genimage";
++    // this->genimage_bin = std::filesystem::current_path() / "bin/genimage";
++    // A temporary workaround for #3
++    this->genimage_bin = std::string("/usr/libexec/openixcard/genimage");
+     // generate blank.fex file for commented partition
+     generate_blank_fex();
+     // call genimage
+-- 
+2.36.1
+

--- a/extra-devel/openixcard/autobuild/prepare
+++ b/extra-devel/openixcard/autobuild/prepare
@@ -1,4 +1,4 @@
 abinfo "Patching submodule lib/argparse ..."
-pushd lib/argparse
+pushd "$SRCDIR"/lib/argparse
     git checkout 95d4850 include/argparse/argparse.hpp
 popd

--- a/extra-devel/openixcard/autobuild/prepare
+++ b/extra-devel/openixcard/autobuild/prepare
@@ -1,0 +1,4 @@
+abinfo "Patching submodule lib/argparse ..."
+pushd lib/argparse
+    git checkout 95d4850 include/argparse/argparse.hpp
+popd

--- a/extra-devel/openixcard/spec
+++ b/extra-devel/openixcard/spec
@@ -1,0 +1,4 @@
+VER=1.0.1
+SRCS="git::commit=tags/${VER}::https://github.com/YuzukiTsuru/OpenixCard"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=247325"

--- a/extra-devel/openixcard/spec
+++ b/extra-devel/openixcard/spec
@@ -1,4 +1,4 @@
 VER=1.0.1
-SRCS="git::commit=tags/${VER}::https://github.com/YuzukiTsuru/OpenixCard"
+SRCS="git::commit=tags/${VER};copy-repo=true::https://github.com/YuzukiTsuru/OpenixCard"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=247325"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

The topic will introduce a new package `openixcard`, which is helpful for developing BSP for sunxi target.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

`openixcard`: 1.0.1

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

No.

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
