### PR TITLE
polymc: update to 1.3.0

### DIFF
--- a/extra-games/polymc/spec
+++ b/extra-games/polymc/spec
@@ -1,4 +1,4 @@
-VER=1.2.2
+VER=1.3.0
 SRCS="git::commit=tags/$VER::https://github.com/PolyMC/PolyMC"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243161"


### PR DESCRIPTION
Topic Description
-----------------

Update `polymc` to 1.3.0

Package(s) Affected
-------------------

`polymc` 1.3.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`