### PR TITLE
rtl8723ds: new, 5.1.1.5+git20220407

### DIFF
--- a/extra-kernel/rtl8723ds/autobuild/build
+++ b/extra-kernel/rtl8723ds/autobuild/build
@@ -1,0 +1,11 @@
+abinfo "Installing source ..."
+install -dvm755 "$PKGDIR"/usr/src/
+cp -rv rtl8723ds "$PKGDIR"/usr/src/rtl8723ds-"$PKGVER"
+
+abinfo "Generating dkms.conf ..."
+sed -e "s|@PKGVER@|${PKGVER}|g" "$SRCDIR"/autobuild/dkms.conf \
+    > "$PKGDIR"/usr/src/rtl8723ds-"$PKGVER"/dkms.conf
+
+abinfo "Generating dpkg scripts ..."
+sed -e "s|@PKGVER@|${PKGVER}|g" autobuild/postinst.in > autobuild/postinst
+sed -e "s|@PKGVER@|${PKGVER}|g" autobuild/prerm.in > autobuild/prerm

--- a/extra-kernel/rtl8723ds/autobuild/defines
+++ b/extra-kernel/rtl8723ds/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=rtl8723ds
+PKGSEC=kernel
+PKGDEP="dkms"
+PKGDES="Driver and firmware for Realtek RTL8723DS wireless module, packed for dkms support"
+
+ABHOST=noarch

--- a/extra-kernel/rtl8723ds/autobuild/dkms.conf
+++ b/extra-kernel/rtl8723ds/autobuild/dkms.conf
@@ -1,0 +1,12 @@
+# Derived from Arch Linux User Repository: rtl8723ds-dkms-git
+# Reference: https://aur.archlinux.org/cgit/aur.git/tree/dkms.conf?h=rtl8723ds-dkms-git&id=48ee41341c9a29c4f1e422780a92bfd967f46910
+PACKAGE_NAME="rtl8723ds"
+PACKAGE_VERSION="@PKGVER@"
+BUILT_MODULE_NAME="8723ds"
+DEST_MODULE_LOCATION="/kernel/drivers/net/wireless"
+
+PROCS_NUM=$(nproc)
+MAKE="'make' -j$PROCS_NUM KVER=${kernelver} KSRC=/lib/modules/${kernelver}/build"
+CLEAN="'make' clean"
+
+AUTOINSTALL="yes"

--- a/extra-kernel/rtl8723ds/autobuild/postinst.in
+++ b/extra-kernel/rtl8723ds/autobuild/postinst.in
@@ -1,0 +1,10 @@
+unset ARCH
+
+for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
+    if [ -f "/usr/lib/modules/${i}/modules.dep" -a -f "/usr/lib/modules/${i}/modules.order" -a -f "/usr/lib/modules/${i}/modules.builtin" ]; then
+	echo -e "\033[36m**\033[0m\tBuilding rtl8723ds kernel modules for $i ..."
+        dkms install rtl8723ds/@PKGVER@ -k $i > /dev/null
+    else
+        echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $i ..."
+    fi
+done

--- a/extra-kernel/rtl8723ds/autobuild/prerm.in
+++ b/extra-kernel/rtl8723ds/autobuild/prerm.in
@@ -1,0 +1,2 @@
+unset ARCH
+dkms remove rtl8723ds/@PKGVER@ --all || true > /dev/null

--- a/extra-kernel/rtl8723ds/spec
+++ b/extra-kernel/rtl8723ds/spec
@@ -1,0 +1,5 @@
+VER=5.1.1.5+git20220407
+SRCS="git::commit=76146e85847beb2427b1d4958fa275822f2b04ab::https://github.com/lwfinger/rtl8723ds.git"
+CHKSUMS="SKIP"
+SUBDIR=.
+CHKUPDATE="anitya::id=248257"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

This topic will introduce a new package that enables kernel support for Realtek's RTL8723DS wireless module, which is used by SBCs including Lichee RV (Dock).

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

`rtl8723ds` 5.1.1.5+git20220407

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

No

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

- [ ] Architecture-independent `noarch`
<!-- TODO: CI to auto-fill architectural progress. -->
