### PR TITLE
qemu: Add systemd service file for Guest Agent

### DIFF
--- a/extra-emulation/qemu/01-shared/overrides/usr/lib/systemd/system/qemu-guest-agent.service
+++ b/extra-emulation/qemu/01-shared/overrides/usr/lib/systemd/system/qemu-guest-agent.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=QEMU Guest Agent
+BindsTo=dev-virtio\x2dports-org.qemu.guest_agent.0.device
+After=dev-virtio\x2dports-org.qemu.guest_agent.0.device
+IgnoreOnIsolate=True
+
+[Service]
+UMask=0077
+ExecStart=/usr/bin/qemu-ga \
+  --method=virtio-serial \
+  --path=/dev/virtio-ports/org.qemu.guest_agent.0 \
+StandardError=syslog
+Restart=always
+RestartSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/extra-emulation/qemu/spec
+++ b/extra-emulation/qemu/spec
@@ -1,5 +1,5 @@
 VER=6.0.0
-REL=3
+REL=4
 SRCS="tbl::https://wiki.qemu-project.org/download/qemu-$VER.tar.xz"
 CHKSUMS="sha256::87bc1a471ca24b97e7005711066007d443423d19aacda3d442558ae032fa30b9"
 CHKUPDATE="anitya::id=13607"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Add systemd service file for qemu-guest-agent

This allows easier handling of the qemu-guest-agent daemon (`qemu-ga`) through systemd when AOSC is running inside QEMU container as guest.

Usage:

When AOSC is running within a Qemu emulator, after installing this package, use `systemctl enable --now qemu-guest-agent` to start the Qemu Guest Agent daemon and let it run when the system is booted up.

In the unlikely event of you don't want it to be running inside the VM anymore, you can stop it with `systemctl stop qemu-guest-agent` and disable it with `systemctl disable qemu-guest-agent`.

With this service running, the host can obtain certain level of control over the guest OS (AOSC) that runs on it through QMP commands and events. Check qemu-ga man page for what this service is capable of and other usage related information.

Package(s) Affected
-------------------

qemu

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
