### PR TITLE
qemu: update to 7.0.0

### DIFF
--- a/extra-emulation/qemu/01-shared/build
+++ b/extra-emulation/qemu/01-shared/build
@@ -36,7 +36,7 @@ DYN_CONFIGURE_FLAGS="
 	--enable-jemalloc
 	--enable-smartcard
 	--enable-pie
-	--audio-drv-list=pa,sdl,alsa,try-jack
+	--audio-drv-list=pa,sdl,alsa,jack
 "
 
 STATIC_CONFIGURE_FLAGS="

--- a/extra-emulation/qemu/01-shared/overrides/usr/lib/systemd/system/qemu-ga-virtio@.service
+++ b/extra-emulation/qemu/01-shared/overrides/usr/lib/systemd/system/qemu-ga-virtio@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=QEMU Guest Agent on Virtio Serial Port %I
+BindTo=dev-virtio\x2dports-%i.device
+After=dev-virtio\x2dports-%i.device
+
+[Service]
+Type=simple
+ExecStart=-/usr/bin/qemu-ga --method virtio-serial --path /dev/virtio-ports/%I
+StandardError=journal
+Restart=always
+RestartSec=0

--- a/extra-emulation/qemu/spec
+++ b/extra-emulation/qemu/spec
@@ -1,5 +1,4 @@
-VER=6.0.0
-REL=3
+VER=7.0.0
 SRCS="tbl::https://wiki.qemu-project.org/download/qemu-$VER.tar.xz"
-CHKSUMS="sha256::87bc1a471ca24b97e7005711066007d443423d19aacda3d442558ae032fa30b9"
+CHKSUMS="sha256::f6b375c7951f728402798b0baabb2d86478ca53d44cedbefabbe1c46bf46f839"
 CHKUPDATE="anitya::id=13607"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Updating QEMU to 7.0.0 and add a service template for qemu-ga, supersedes #3999 .

Package(s) Affected
-------------------

- `qemu*`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
