### PR TITLE
systemd-usb-gadget: new, newest git

### DIFF
--- a/extra-admin/systemd-usb-gadget/autobuild/build
+++ b/extra-admin/systemd-usb-gadget/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Patching service unit ..."
+sed -i 's@/sbin@/usr/libexec@g' "$SRCDIR"/usb-gadget@.service
+
+abinfo "Installing ..."
+make sysconfdir=/usr/lib sbindir=/usr/libexec DESTDIR="$PKGDIR" install

--- a/extra-admin/systemd-usb-gadget/autobuild/defines
+++ b/extra-admin/systemd-usb-gadget/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=systemd-usb-gadget
+PKGDES="Systemd services for initializing USB gadget"
+PKGSEC=admin
+PKGDEP="systemd"
+
+ABHOST=noarch

--- a/extra-admin/systemd-usb-gadget/spec
+++ b/extra-admin/systemd-usb-gadget/spec
@@ -1,0 +1,3 @@
+VER=0+git20191227
+SRCS="git::commit=9d483ce1b8b50749d54bb15f6a0946588704ae63::https://github.com/larsks/systemd-usb-gadget.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Add systemd-usb-gadget package to AOSC OS, which is a systemd unit that controls USB gadget via configfs.

Package(s) Affected
-------------------

- `systemd-usb-gadget` 

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
