### PR TITLE
Fish survey 20220531

### DIFF
--- a/extra-shells/fish/spec
+++ b/extra-shells/fish/spec
@@ -1,4 +1,4 @@
-VER=3.3.1
+VER=3.4.1
 SRCS="tbl::https://github.com/fish-shell/fish-shell/archive/$VER.tar.gz"
-CHKSUMS="sha256::cc8b6dae684407190cbc9d2b327f0272e8a235f7f60614e0ac2f7d24fdbcde24"
+CHKSUMS="sha256::5047c50180b564f24dbd4100e0249924d75c15447852f34279c59080c834ead5"
 CHKUPDATE="anitya::id=815"

--- a/extra-shells/fisher/spec
+++ b/extra-shells/fisher/spec
@@ -1,4 +1,4 @@
-VER=4.3.0
+VER=4.3.2
 SRCS="tbl::https://github.com/jorgebucaran/fisher/archive/$VER.tar.gz"
-CHKSUMS="sha256::6235cfc636c8d52f11feca9f4931656a9c6602659b06df8dba5a3606d37f8c28"
+CHKSUMS="sha256::202ca657f6b43c5f89ab361447a6045ca7bbe7291a75f814f1fbce3d897bc345"
 CHKUPDATE="anitya::id=231509"

--- a/extra-utils/starship/spec
+++ b/extra-utils/starship/spec
@@ -1,4 +1,4 @@
-VER=1.5.4
+VER=1.7.1
 SRCS="tbl::https://github.com/starship/starship/archive/v$VER.tar.gz"
-CHKSUMS="sha256::158003cd192f9375e504b9ab84d9239a06a8f9732cdd201243ab2fdcd38043f8"
+CHKSUMS="sha256::364b8222e097a8c671a9d03788ffc745982f4e62ee59e75687eb75310fae64e0"
 CHKUPDATE="anitya::id=55456"


### PR DESCRIPTION
Topic Description
-----------------

Update `fish` and related packages

Package(s) Affected
-------------------

`fish` 3.4.1
`fisher` 4.3.2
`starship` 1.7.1

Security Update?
----------------

No

Build Order
-----------

`fish -> {fisher, starship}`

Test Build(s) Done
------------------

**Primary Architectures**

`fish, starship`
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

`fisher`
- [x] Architecture-independent `noarch` -->

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

`fish, starship`
- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------
**Primary Architectures**

`fish, starship`
- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

`fisher`
- [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

`fish, starship`
- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`