### PR TITLE
btop: new, 1.2.7

### DIFF
--- a/extra-utils/btop/autobuild/defines
+++ b/extra-utils/btop/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=btop
+PKGSEC=utils
+PKGDES="A monitor of system resources"
+PKGDEP="gcc-runtime"

--- a/extra-utils/btop/autobuild/defines
+++ b/extra-utils/btop/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=btop
 PKGSEC=utils
-PKGDES="A monitor of system resources"
+PKGDES="A terminal system resource and status monitor"
 PKGDEP="gcc-runtime"

--- a/extra-utils/btop/spec
+++ b/extra-utils/btop/spec
@@ -1,0 +1,4 @@
+VER=1.2.7
+SRCS="tbl::https://github.com/aristocratos/btop/archive/refs/tags/v$VER.tar.gz"
+CHKSUMS="sha256::60075824ca4e14c1ca920b76ffb101fc2340c5342f3ba600b5c280389b69bbbf"
+CHKUPDATE="anitya::id=253331"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Introduce `btop`, a monitor of system resources written in C++.

Package(s) Affected
-------------------

`btop` v1.2.7

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
~~- [ ] PowerPC 64-bit (Little Endian) `ppc64el`~~
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
~~- [ ] PowerPC 64-bit (Little Endian) `ppc64el`~~
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
