### PR TITLE
linux-firmware: update to 20220610

### DIFF
--- a/extra-kernel/linux-firmware/01-nonfree/build
+++ b/extra-kernel/linux-firmware/01-nonfree/build
@@ -6,7 +6,7 @@ cp -v "$SRCDIR"/{WHENCE,LICENSE.*,LICENCE.*,GPL-2,GPL-3} "${PKGDIR}"/usr/lib/fir
 
 abinfo "Separating free firmware ..."
 mkdir -pv "$SRCDIR"/firmware-free
-for i in $(cat autobuild/free-list); do
+for i in $(cat "$SRCDIR"/autobuild/free-list); do
     if echo "$i" | grep -q /; then
         mkdir -pv "$SRCDIR"/firmware-free/$(dirname $i)
     fi
@@ -15,7 +15,7 @@ done
 
 abinfo "Installing free licenses ..."
 mkdir -pv "$SRCDIR"/firmware-free
-for i in $(cat autobuild/free-license-list); do
+for i in $(cat "$SRCDIR"/autobuild/free-license-list); do
     if echo "$i" | grep -q /; then
         mkdir -pv "$SRCDIR"/firmware-free/$(dirname $i)
     fi
@@ -27,7 +27,8 @@ mkdir -pv "$PKGDIR"/usr/lib/firmware/brcm
 for i in brcmfmac43456-sdio.{bin,clm_blob,AP6256.txt} BCM4345C5.hcd; do
 	cp -v "$SRCDIR"/../$i "$PKGDIR"/usr/lib/firmware/brcm
 done
-ln -sv brcmfmac43456-sdio.AP6256.txt "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43456-sdio.pine64,pinebook-pro.txt
+ln -sv brcmfmac43456-sdio.AP6256.txt \
+    "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43456-sdio.pine64,pinebook-pro.txt
 
 abinfo "Compressing AP6256 firmware blob"
 xz -C crc32 "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43456-sdio.bin

--- a/extra-kernel/linux-firmware/01-nonfree/patches/0001-Fedora-Add-support-for-compressing-firmware-in-copy-firmware.patch
+++ b/extra-kernel/linux-firmware/01-nonfree/patches/0001-Fedora-Add-support-for-compressing-firmware-in-copy-firmware.patch
@@ -22,11 +22,11 @@ index e1c362f..9a48471 100644
 +++ b/Makefile
 @@ -11,3 +11,7 @@ check:
  install:
- 	mkdir -p $(DESTDIR)$(FIRMWAREDIR)
+ 	install -d $(DESTDIR)$(FIRMWAREDIR)
  	./copy-firmware.sh $(DESTDIR)$(FIRMWAREDIR)
 +
 +installcompress:
-+	mkdir -p $(DESTDIR)$(FIRMWAREDIR)
++	install -d $(DESTDIR)$(FIRMWAREDIR)
 +	./copy-firmware.sh -C $(DESTDIR)$(FIRMWAREDIR)
 diff --git a/copy-firmware.sh b/copy-firmware.sh
 index 9b46b63..0dd2e5c 100755
@@ -68,11 +68,11 @@ index 9b46b63..0dd2e5c 100755
  grep '^File:' WHENCE | sed -e's/^File: *//g' -e's/"//g' | while read f; do
 -    test -f "$f" || continue
 -    $verbose "copying file $f"
--    mkdir -p $destdir/$(dirname "$f")
+-    install -d $destdir/$(dirname "$f")
 -    cp -d "$f" $destdir/"$f"
 +    test -f "$f$cmpxtn" || continue
 +    $verbose "copying file $f$cmpxtn"
-+    mkdir -p $destdir/$(dirname "$f$cmpxtn")
++    install -d $destdir/$(dirname "$f$cmpxtn")
 +    cp -d "$f$cmpxtn" $destdir/"$f$cmpxtn"
  done
  
@@ -80,11 +80,11 @@ index 9b46b63..0dd2e5c 100755
 -    if test -L "$f"; then
 -        test -f "$destdir/$f" && continue
 -        $verbose "copying link $f"
--        mkdir -p $destdir/$(dirname "$f")
+-        install -d $destdir/$(dirname "$f")
 +    if test -L "$f$cmpxtn"; then
 +        test -f "$destdir/$f$cmpxtn" && continue
 +        $verbose "copying link $f$cmpxtn"
-+        mkdir -p $destdir/$(dirname "$f$cmpxtn")
++        install -d $destdir/$(dirname "$f$cmpxtn")
          cp -d "$f" $destdir/"$f"
  
          if test "x$d" != "x"; then
@@ -110,10 +110,10 @@ index 9b46b63..0dd2e5c 100755
          fi
      else
 -        $verbose "creating link $f -> $d"
--        mkdir -p $destdir/$(dirname "$f")
+-        install -d $destdir/$(dirname "$f")
 -        ln -sf "$d" "$destdir/$f"
 +        $verbose "creating link $f$cmpxtn -> $d$cmpxtn"
-+        mkdir -p $destdir/$(dirname "$f$cmpxtn")
++        install -d $destdir/$(dirname "$f$cmpxtn")
 +        ln -sf "$d$cmpxtn" "$destdir/$f$cmpxtn"
      fi
  done

--- a/extra-kernel/linux-firmware/02-free/build
+++ b/extra-kernel/linux-firmware/02-free/build
@@ -1,3 +1,4 @@
 abinfo "Installing free firmware ..."
 mkdir -pv "$PKGDIR"/usr/lib/firmware
-cp -av "$SRCDIR"/firmware-free/* "$PKGDIR"/usr/lib/firmware/
+cp -av "$SRCDIR"/firmware-free/* \
+    "$PKGDIR"/usr/lib/firmware/

--- a/extra-kernel/linux-firmware/spec
+++ b/extra-kernel/linux-firmware/spec
@@ -1,6 +1,5 @@
-VER=20210405
-REL=1
-SRCS="git::commit=af1ca28f03287b0c60682ab37cc684c773de853f::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
+VER=20220610
+SRCS="git::commit=tags/20220610::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/292e1e5b5bc5756e9314ea6d494d561422d23264/rkwifi/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

Update `linux-firmware` to v20220610, this should fix display issues with AMD Ryzen 6000 series laptops.

Package(s) Affected
-------------------

- `firmware-free`, `firmware-nonfree` v20220610

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
