### PR TITLE
ntfs-3g: update to 2022.5.17

### DIFF
--- a/extra-admin/partclone/autobuild/patches/0001-failmbr-broken-disabled.patch
+++ b/extra-admin/partclone/autobuild/patches/0001-failmbr-broken-disabled.patch
@@ -1,0 +1,24 @@
+From b5bdacbd75a6894f7e2029aec20f8702fb71e2f5 Mon Sep 17 00:00:00 2001
+From: Kay Lin <kaymw@aosc.io>
+Date: Thu, 16 Jun 2022 19:13:16 -0700
+Subject: [PATCH] failmbr: broken, disabled
+
+Ref: https://src.fedoraproject.org/rpms/partclone/blob/rawhide/f/partclone.spec#_104
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index f24cfc0..11a2657 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,5 +1,5 @@
+ AUTOMAKE_OPTIONS = subdir-objects 
+-SUBDIRS= po src docs tests fail-mbr
++SUBDIRS= po src docs tests
+ 
+ ACLOCAL_AMFLAGS = -I m4
+ 
+-- 
+2.36.0
+

--- a/extra-admin/partclone/spec
+++ b/extra-admin/partclone/spec
@@ -1,4 +1,4 @@
-VER=0.3.18
+VER=0.3.20
 SRCS="tbl::https://github.com/Thomas-Tsai/partclone/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::50070e29c2e00e991a3784f13339347acb46d2a293f43531d1f4f4f0dcb42311"
+CHKSUMS="sha256::a32102452fed7b516494adc98e1bc3b6dbb3a0044f7e84b35ad104ec9277c550"
 CHKUPDATE="anitya::id=141535"

--- a/extra-libs/ntfs-3g/autobuild/beyond
+++ b/extra-libs/ntfs-3g/autobuild/beyond
@@ -1,6 +1,10 @@
+abinfo "Setting environment variables for plugins ..."
+export LIBNTFS_3G_CFLAGS="-I${PKGDIR}/usr/include"
+export LIBNTFS_3G_LIBS="-pthread -L${PKGDIR}/usr/lib -lntfs-3g"
+
 abinfo "Configuring, building, and installing the system compression plugin ..."
 (
-    cd "$SRCDIR"/../ntfs-3g-system-compression-$COMPVER
+    cd "$SRCDIR"/../ntfs-3g-system-compression-1.0
     autoreconf -fvi
     ./configure --prefix=/usr
     make
@@ -20,20 +24,13 @@ done
 
 abinfo "Creating mount.ntfs symlink to ease mounting ..."
 ln -sv ntfs-3g "$PKGDIR"/usr/bin/mount.ntfs
+ln -sv ntfs-3g "$PKGDIR"/usr/bin/mount.ntfs-fuse
 
-abinfo "Moving /bin => /usr/bin ..."
-cp -av "$PKGDIR"/bin/* "$PKGDIR"/usr/bin/
-rm -rv "$PKGDIR"/bin
-
-abinfo "Moving /sbin => /usr/bin ..."
-cp -av "$PKGDIR"/sbin/* "$PKGDIR"/usr/bin/
-rm -rv "$PKGDIR"/sbin
-
-abinfo "Moving /usr/sbin => /usr/bin ..."
-cp -av "$PKGDIR"/usr/sbin/* "$PKGDIR"/usr/bin/
-rm -rv "$PKGDIR"/usr/sbin
+abinfo "Creating symlink for fsck..."
+ln -sv ntfsck "$PKGDIR"/usr/bin/fsck.ntfs
 
 abinfo "Fixing absolute symlinks ..."
+rm -rv "$PKGDIR"/sbin
 ln -sfv lowntfs-3g "$PKGDIR"/usr/bin/mount.lowntfs-3g
 ln -sfv mkntfs "$PKGDIR"/usr/bin/mkfs.ntfs
 ln -sfv ntfs-3g "$PKGDIR"/usr/bin/mount.ntfs-3g

--- a/extra-libs/ntfs-3g/autobuild/defines
+++ b/extra-libs/ntfs-3g/autobuild/defines
@@ -1,13 +1,14 @@
 PKGNAME=ntfs-3g
 PKGSEC=admin
-PKGDEP="util-linux fuse"
-BUILDDEP="ntfs-3g"
+PKGDEP="util-linux fuse gnutls attr libgcrypt libconfig"
 PKGDES="NTFS filesystem driver and utilities"
 
-AUTOTOOLS_AFTER="--disable-ldconfig \
+AUTOTOOLS_AFTER="--disable-static \
+                 --disable-ldconfig \
                  --with-fuse=external \
+                 --exec-prefix=/usr \
                  --enable-posix-acls \
-                 --enable-extras \
                  --enable-crypto \
+                 --enable-extras \
                  --enable-quarantined"
 PKGEPOCH=1

--- a/extra-libs/ntfs-3g/autobuild/patches/0001-fix-add-setu-gid-handling-for-external-libfuse.patch
+++ b/extra-libs/ntfs-3g/autobuild/patches/0001-fix-add-setu-gid-handling-for-external-libfuse.patch
@@ -1,7 +1,7 @@
-From c918fb79f9f340bce1a19dacf4b720d19922450d Mon Sep 17 00:00:00 2001
-From: Mingye Wang <arthur200126@gmail.com>
-Date: Thu, 10 Oct 2019 22:52:21 +0800
-Subject: [PATCH] fix: add setu/gid handling for external libfuse
+From 6b189259e85bf2d83423fc10c1aa908295f18255 Mon Sep 17 00:00:00 2001
+From: Kay Lin <kaymw@aosc.io>
+Date: Thu, 16 Jun 2022 18:10:07 -0700
+Subject: [PATCH 1/2] fix: add setu/gid handling for external libfuse
 
 Many packagers use the external libfuse for new upstream improvements
 and to avoid redundancy. There is no good technical reason to keep the
@@ -11,16 +11,18 @@ I am slightly concerned at not seeing some of the mount point permission
 checks found in upstream libfuse fusermount in our current mount
 implementation. This would be a bug shared with internal libfuse, and I
 do not intend to reach that far now.
+
+Co-authored-by: Mingye Wang <arthur200126@gmail.com>
 ---
  libfuse-lite/fusermount.c | 101 ++---------------------------------
  libfuse-lite/priv.h       | 107 ++++++++++++++++++++++++++++++++++++++
- src/lowntfs-3g.c          |  40 ++------------
- src/ntfs-3g.c             |  36 +------------
- 4 files changed, 114 insertions(+), 170 deletions(-)
+ src/lowntfs-3g.c          |  27 ++--------
+ src/ntfs-3g.c             |  23 +-------
+ 4 files changed, 116 insertions(+), 142 deletions(-)
  create mode 100644 libfuse-lite/priv.h
 
 diff --git a/libfuse-lite/fusermount.c b/libfuse-lite/fusermount.c
-index 680fee1..689d1fe 100644
+index 680fee1c..689d1fee 100644
 --- a/libfuse-lite/fusermount.c
 +++ b/libfuse-lite/fusermount.c
 @@ -45,35 +45,14 @@ static const char *progname = "ntfs-3g-mount";
@@ -153,7 +155,7 @@ index 680fee1..689d1fe 100644
  #endif /* __SOLARIS__ */
 diff --git a/libfuse-lite/priv.h b/libfuse-lite/priv.h
 new file mode 100644
-index 0000000..d43feff
+index 00000000..d43feffa
 --- /dev/null
 +++ b/libfuse-lite/priv.h
 @@ -0,0 +1,107 @@
@@ -265,10 +267,10 @@ index 0000000..d43feff
 +}
 +#endif /* __SOLARIS__ */
 diff --git a/src/lowntfs-3g.c b/src/lowntfs-3g.c
-index 748ba51..6ec2f92 100644
+index 9330500c..3300fd2f 100644
 --- a/src/lowntfs-3g.c
 +++ b/src/lowntfs-3g.c
-@@ -279,30 +279,9 @@ static const char ntfs_bad_reparse[] = "unsupported reparse point";
+@@ -286,13 +286,7 @@ static const char ntfs_bad_reparse[] = "unsupported reparse tag 0x%08lx";
  int drop_privs(void);
  int restore_privs(void);
  #else
@@ -282,25 +284,17 @@ index 748ba51..6ec2f92 100644
 +#include "../libfuse-lite/priv.h"
  #endif
  
--static const char *setuid_msg =
--"Mount is denied because setuid and setgid root ntfs-3g is insecure with the\n"
--"external FUSE library. Either remove the setuid/setgid bit from the binary\n"
--"or rebuild NTFS-3G with integrated FUSE support and make it setuid root.\n"
--"Please see more information at\n"
--"http://tuxera.com/community/ntfs-3g-faq/#unprivileged\n";
--
--static const char *unpriv_fuseblk_msg =
--"Unprivileged user can not mount NTFS block devices using the external FUSE\n"
--"library. Either mount the volume as root, or rebuild NTFS-3G with integrated\n"
--"FUSE support and make it setuid root. Please see more information at\n"
--"http://tuxera.com/community/ntfs-3g-faq/#unprivileged\n";
+ static const char *setuid_msg =
+@@ -307,7 +301,7 @@ static const char *unpriv_fuseblk_msg =
+ "library. Either mount the volume as root, or rebuild NTFS-3G with integrated\n"
+ "FUSE support and make it setuid root. Please see more information at\n"
+ "https://github.com/tuxera/ntfs-3g/wiki/NTFS-3G-FAQ\n";
 -#endif	
--
--
++#endif
+ 
+ 
  static void ntfs_fuse_update_times(ntfs_inode *ni, ntfs_time_update_flags mask)
- {
- 	if (ctx->atime == ATIME_DISABLED)
-@@ -2970,7 +2949,7 @@ static void ntfs_fuse_bmap(fuse_req_t req, fuse_ino_t ino, size_t blocksize,
+@@ -3245,7 +3239,7 @@ static void ntfs_fuse_bmap(fuse_req_t req, fuse_ino_t ino, size_t blocksize,
  	ntfs_attr *na;
  	LCN lcn;
  	uint64_t lidx = 0;
@@ -309,7 +303,7 @@ index 748ba51..6ec2f92 100644
  	int cl_per_bl = ctx->vol->cluster_size / blocksize;
  
  	if (blocksize > ctx->vol->cluster_size) {
-@@ -4282,12 +4261,6 @@ int main(int argc, char *argv[])
+@@ -4621,12 +4615,6 @@ int main(int argc, char *argv[])
  			close(fd);
  	} while (fd >= 0 && fd <= 2);
  
@@ -322,7 +316,7 @@ index 748ba51..6ec2f92 100644
  	if (drop_privs())
  		return NTFS_VOLUME_NO_PRIVILEGE;
          
-@@ -4361,7 +4334,7 @@ int main(int argc, char *argv[])
+@@ -4704,7 +4692,7 @@ int main(int argc, char *argv[])
  
  	if (drop_privs())
  		goto err_out;
@@ -331,7 +325,7 @@ index 748ba51..6ec2f92 100644
  	if (stat(opts.device, &sbuf)) {
  		ntfs_log_perror("Failed to access '%s'", opts.device);
  		err = NTFS_VOLUME_NO_PRIVILEGE;
-@@ -4374,13 +4347,6 @@ int main(int argc, char *argv[])
+@@ -4717,13 +4705,6 @@ int main(int argc, char *argv[])
  		ctx->blkdev = TRUE;
  #endif
  
@@ -346,10 +340,10 @@ index 748ba51..6ec2f92 100644
  	if (err)
  		goto err_out;
 diff --git a/src/ntfs-3g.c b/src/ntfs-3g.c
-index e73eee3..00e88fc 100644
+index d8227e71..1fee91f7 100644
 --- a/src/ntfs-3g.c
 +++ b/src/ntfs-3g.c
-@@ -215,30 +215,9 @@ static const char ntfs_bad_reparse[] = "unsupported reparse point";
+@@ -221,13 +221,7 @@ static const char ntfs_bad_reparse[] = "unsupported reparse tag 0x%08lx";
  int drop_privs(void);
  int restore_privs(void);
  #else
@@ -363,25 +357,17 @@ index e73eee3..00e88fc 100644
 +#include "../libfuse-lite/priv.h"
  #endif
  
--static const char *setuid_msg =
--"Mount is denied because setuid and setgid root ntfs-3g is insecure with the\n"
--"external FUSE library. Either remove the setuid/setgid bit from the binary\n"
--"or rebuild NTFS-3G with integrated FUSE support and make it setuid root.\n"
--"Please see more information at\n"
--"http://tuxera.com/community/ntfs-3g-faq/#unprivileged\n";
--
--static const char *unpriv_fuseblk_msg =
--"Unprivileged user can not mount NTFS block devices using the external FUSE\n"
--"library. Either mount the volume as root, or rebuild NTFS-3G with integrated\n"
--"FUSE support and make it setuid root. Please see more information at\n"
--"http://tuxera.com/community/ntfs-3g-faq/#unprivileged\n";
+ static const char *setuid_msg =
+@@ -242,7 +236,7 @@ static const char *unpriv_fuseblk_msg =
+ "library. Either mount the volume as root, or rebuild NTFS-3G with integrated\n"
+ "FUSE support and make it setuid root. Please see more information at\n"
+ "https://github.com/tuxera/ntfs-3g/wiki/NTFS-3G-FAQ\n";
 -#endif	
--
--
++#endif
+ 
+ 
  /**
-  * ntfs_fuse_is_named_data_stream - check path to be to named data stream
-  * @path:	path to check
-@@ -4082,12 +4061,6 @@ int main(int argc, char *argv[])
+@@ -4349,12 +4343,6 @@ int main(int argc, char *argv[])
  			close(fd);
  	} while (fd >= 0 && fd <= 2);
  
@@ -394,7 +380,7 @@ index e73eee3..00e88fc 100644
  	if (drop_privs())
  		return NTFS_VOLUME_NO_PRIVILEGE;
  	
-@@ -4174,13 +4147,6 @@ int main(int argc, char *argv[])
+@@ -4445,13 +4433,6 @@ int main(int argc, char *argv[])
  		ctx->blkdev = TRUE;
  #endif
  
@@ -409,5 +395,5 @@ index e73eee3..00e88fc 100644
  	if (err)
  		goto err_out;
 -- 
-2.30.2
+2.36.0
 

--- a/extra-libs/ntfs-3g/autobuild/patches/0002-ntfsck-return-on-in-unsupported-filesystem-cases.patch
+++ b/extra-libs/ntfs-3g/autobuild/patches/0002-ntfsck-return-on-in-unsupported-filesystem-cases.patch
@@ -1,0 +1,85 @@
+From f33e91f2db544cd1ae17e1b80612d952e9e42927 Mon Sep 17 00:00:00 2001
+From: Kay Lin <kaymw@aosc.io>
+Date: Thu, 16 Jun 2022 18:16:29 -0700
+Subject: [PATCH 2/2] ntfsck: return on in unsupported filesystem cases
+
+Cherry-picked from Fedora package sources. Prevents unexpected
+failures while fscking on boot.
+
+Co-authored-by: Tom Callaway <spot@fedoraproject.org>
+---
+ ntfsprogs/ntfsck.c |  6 +++++-
+ src/lowntfs-3g.c   | 14 --------------
+ src/ntfs-3g.c      | 14 --------------
+ 3 files changed, 5 insertions(+), 29 deletions(-)
+
+diff --git a/ntfsprogs/ntfsck.c b/ntfsprogs/ntfsck.c
+index 8c126411..cbd163cc 100644
+--- a/ntfsprogs/ntfsck.c
++++ b/ntfsprogs/ntfsck.c
+@@ -878,7 +878,11 @@ int main(int argc, char **argv)
+ 	if (errors)
+ 		return 2;
+ 	if (unsupported)
+-		return 1;
++		ntfs_log_info("ntfsck was unable to run properly.\n");
++		// If we return 1 here, we fail for ntfs services fscking on boot just because
++		// ntfsck isn't smart enough to handle 99% of cases. So, we just return 0.
++		// return 1;
++		return 0;
+ 	return 0;
+ }
+ 
+diff --git a/src/lowntfs-3g.c b/src/lowntfs-3g.c
+index 3300fd2f..34e4dd9a 100644
+--- a/src/lowntfs-3g.c
++++ b/src/lowntfs-3g.c
+@@ -289,20 +289,6 @@ int restore_privs(void);
+ #include "../libfuse-lite/priv.h"
+ #endif
+ 
+-static const char *setuid_msg =
+-"Mount is denied because setuid and setgid root ntfs-3g is insecure with the\n"
+-"external FUSE library. Either remove the setuid/setgid bit from the binary\n"
+-"or rebuild NTFS-3G with integrated FUSE support and make it setuid root.\n"
+-"Please see more information at\n"
+-"https://github.com/tuxera/ntfs-3g/wiki/NTFS-3G-FAQ\n";
+-
+-static const char *unpriv_fuseblk_msg =
+-"Unprivileged user can not mount NTFS block devices using the external FUSE\n"
+-"library. Either mount the volume as root, or rebuild NTFS-3G with integrated\n"
+-"FUSE support and make it setuid root. Please see more information at\n"
+-"https://github.com/tuxera/ntfs-3g/wiki/NTFS-3G-FAQ\n";
+-#endif
+-
+ 
+ static void ntfs_fuse_update_times(ntfs_inode *ni, ntfs_time_update_flags mask)
+ {
+diff --git a/src/ntfs-3g.c b/src/ntfs-3g.c
+index 1fee91f7..a6a85927 100644
+--- a/src/ntfs-3g.c
++++ b/src/ntfs-3g.c
+@@ -224,20 +224,6 @@ int restore_privs(void);
+ #include "../libfuse-lite/priv.h"
+ #endif
+ 
+-static const char *setuid_msg =
+-"Mount is denied because setuid and setgid root ntfs-3g is insecure with the\n"
+-"external FUSE library. Either remove the setuid/setgid bit from the binary\n"
+-"or rebuild NTFS-3G with integrated FUSE support and make it setuid root.\n"
+-"Please see more information at\n"
+-"https://github.com/tuxera/ntfs-3g/wiki/NTFS-3G-FAQ\n";
+-
+-static const char *unpriv_fuseblk_msg =
+-"Unprivileged user can not mount NTFS block devices using the external FUSE\n"
+-"library. Either mount the volume as root, or rebuild NTFS-3G with integrated\n"
+-"FUSE support and make it setuid root. Please see more information at\n"
+-"https://github.com/tuxera/ntfs-3g/wiki/NTFS-3G-FAQ\n";
+-#endif
+-
+ 
+ /**
+  * ntfs_fuse_is_named_data_stream - check path to be to named data stream
+-- 
+2.36.0
+

--- a/extra-libs/ntfs-3g/spec
+++ b/extra-libs/ntfs-3g/spec
@@ -1,10 +1,9 @@
-VER=2017.3.23AR.6
-COMPVER=1.0
-SRCS="tbl::https://jp-andre.pagesperso-orange.fr/ntfs-3g_ntfsprogs-$VER.tgz \
-      tbl::https://github.com/ebiggers/ntfs-3g-system-compression/releases/download/v$COMPVER/ntfs-3g-system-compression-$COMPVER.tar.gz \
+VER=2022.5.17
+SRCS="tbl::https://tuxera.com/opensource/ntfs-3g_ntfsprogs-$VER.tgz \
+      tbl::https://github.com/ebiggers/ntfs-3g-system-compression/releases/download/v1.0/ntfs-3g-system-compression-1.0.tar.gz \
       tbl::https://repo.aosc.io/aosc-repacks/advanced-ntfs-3g/dedup.zip \
       tbl::https://repo.aosc.io/aosc-repacks/advanced-ntfs-3g/onedrive.zip"
-CHKSUMS="sha256::e60556afbe7bc2f5ad710baf0ee954682324d411c324d328c652e731c6b7abd3 \
+CHKSUMS="sha256::0489fbb6972581e1b417ab578d543f6ae522e7fa648c3c9b49c789510fd5eb93 \
          sha256::c4a26f3a704f5503ec1b3af5e4bb569590c6752616e68a3227fc717417efaaae \
          sha256::a435efd5a81c69cf2ff7ba5f93a5672923e8548b9e287e3f3db30902a286be9b \
          sha256::fd5e1b7d58d2590254de176654e7c2b90340dde904ecd2e8640c30bc6b9e6684"

--- a/extra-utils/testdisk/spec
+++ b/extra-utils/testdisk/spec
@@ -1,5 +1,5 @@
 VER=7.0
-REL=2
+REL=3
 SRCS="tbl::https://www.cgsecurity.org/testdisk-$VER.tar.bz2"
 CHKSUMS="sha256::00bb3b6b22e6aba88580eeb887037aef026968c21a87b5f906c6652cbee3442d"
 CHKUPDATE="anitya::id=4955"

--- a/extra-utils/wimlib/spec
+++ b/extra-utils/wimlib/spec
@@ -1,4 +1,5 @@
 VER=1.13.2
+REL=1
 SRCS="tbl::https://wimlib.net/downloads/wimlib-$VER.tar.gz"
 CHKSUMS="sha256::7295be7ef00d265aef4090c9d26af82097db651c5f8399db9d44c60f47f5a945"
 CHKUPDATE="anitya::id=16320"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update `ntfs-3g` to 2022.5.17 and rebuild/update its reverse dependencies.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

ntfs-3g: update to 2022.5.17
partclone: update to 0.3.20; rebuild for ntfs-3g
testdisk: rebuild for ntfs-3g
wimlib: rebuild for ntfs-3g

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

Please describe in what order maintainers should build this pull request.

`ntfs-3g partclone testdisk wimlib`

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
