### PR TITLE
freetype: enable subpixel rendering

### DIFF
--- a/extra-libs/freetype/autobuild/patches/0001-enable-subpixel-rendering.patch
+++ b/extra-libs/freetype/autobuild/patches/0001-enable-subpixel-rendering.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Mon, 20 Jun 2022 17:18:36 -0700
+Subject: [PATCH] Enable subpixel rendering
+
+---
+ include/freetype/config/ftoption.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/freetype/config/ftoption.h b/include/freetype/config/ftoption.h
+index c5bde243b..77d6efb2e 100644
+--- a/include/freetype/config/ftoption.h
++++ b/include/freetype/config/ftoption.h
+@@ -123,7 +123,7 @@ FT_BEGIN_HEADER
+    * When this macro is not defined, FreeType offers alternative LCD
+    * rendering technology that produces excellent output.
+    */
+-/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
++#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING
+ 
+ 
+   /**************************************************************************
+-- 
+2.36.0
+

--- a/extra-libs/freetype/spec
+++ b/extra-libs/freetype/spec
@@ -1,4 +1,5 @@
 VER=2.10.4
+REL=1
 SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/freetype/freetype-$VER.tar.xz"
 CHKSUMS="sha256::86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784"
 CHKUPDATE="anitya::id=854"


### PR DESCRIPTION
Topic Description
-----------------

Enable Subpixel Rendering in `freetype`

Package(s) Affected
-------------------

`freetype` 2.10.4-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`