### PR TITLE
flameshot: update to 12.0.0

### DIFF
--- a/extra-utils/flameshot/spec
+++ b/extra-utils/flameshot/spec
@@ -1,5 +1,4 @@
-VER=0.10.1
-REL=1
+VER=12.0.0
 SRCS="tbl::https://github.com/flameshot-org/flameshot/archive/v$VER.tar.gz"
-CHKSUMS="sha256::c2d760345d78dd5d2488c6bea54cb10870b09772179f33594a33c8f62ccdeeb9"
+CHKSUMS="sha256::bb2a587ea47ee2eef7cd3f617a15a63d52e502b99a2a78f82e34a271a3027133"
 CHKUPDATE="anitya::id=16948"


### PR DESCRIPTION
Topic Description
-----------------

Update flameshot to 12.0.0

Package(s) Affected
-------------------

`flameshot` 12.0.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`