### PR TITLE
libdrm: update to 2.4.111

### DIFF
--- a/extra-libs/libdrm/autobuild/defines
+++ b/extra-libs/libdrm/autobuild/defines
@@ -3,7 +3,7 @@ PKGDES="Direct Rendering Manager runtime library"
 PKGDEP="x11-lib"
 PKGSEC=libs
 
-MESON_AFTER="-Dudev=true"
+MESON_AFTER="-Dudev=true -Dvalgrind=false"
 MESON_AFTER__ARM="${MESON_AFTER} \
                   -Domap=true \
                   -Dexynos=true \

--- a/extra-libs/libdrm/spec
+++ b/extra-libs/libdrm/spec
@@ -1,4 +1,4 @@
-VER=2.4.110
+VER=2.4.111
 SRCS="tbl::https://dri.freedesktop.org/libdrm/libdrm-$VER.tar.xz"
-CHKSUMS="sha256::eecee4c4b47ed6d6ce1a9be3d6d92102548ea35e442282216d47d05293cf9737"
+CHKSUMS="sha256::1ad7164f77424de6f4ecba7c262bde196a214c6e19a6fbf497f0815f4d7ab2a9"
 CHKUPDATE="anitya::id=1596"


### PR DESCRIPTION
Topic Description
-----------------

Update libdrm to newest and fix its unwanted valgrind dependency.

Package(s) Affected
-------------------

- `libdrm`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
