### PR TITLE
zerotier-one: update to 1.10.1

### DIFF
--- a/extra-network/zerotier-one/autobuild/build
+++ b/extra-network/zerotier-one/autobuild/build
@@ -3,7 +3,13 @@ sed -e 's/sbin/bin/' \
     -i "$SRCDIR"/make-linux.mk \
     -i "$SRCDIR"/debian/zerotier-one.service
 
+
+# sed -e 's/RUSTFLAGS/_RUSTFLAGS/g' \
+#     -i "$SRCDIR"/make-linux.mk 
+
+
 abinfo "Making zerotier-one..."
+export ZT_DEBUG=1
 make
 
 abinfo "Installing zerotier-one..."

--- a/extra-network/zerotier-one/autobuild/defines
+++ b/extra-network/zerotier-one/autobuild/defines
@@ -1,5 +1,6 @@
 PKGNAME="zerotier-one"
 PKGDES="ZeroTier creates secure networks between on-premise, cloud, desktop, and mobile devices"
 PKGSEC=net
-PKGDEP="gcc-runtime miniupnpc"
-BUILDDEP="ronn"
+PKGDEP="llvm-runtime miniupnpc cargo"
+BUILDDEP="llvm ronn cargo"
+USECLANG=1

--- a/extra-network/zerotier-one/autobuild/patches/0001-support-clang-lto.patch
+++ b/extra-network/zerotier-one/autobuild/patches/0001-support-clang-lto.patch
@@ -1,0 +1,91 @@
+From 91db717ac1048949bc677d2c266a62261240867b Mon Sep 17 00:00:00 2001
+From: Canarypwn <canarypwn@aosc.io>
+Date: Sat, 2 Jul 2022 14:01:53 +0800
+Subject: [PATCH] test
+
+---
+ make-linux.mk | 22 ++++++++++++++++++----
+ 1 file changed, 18 insertions(+), 4 deletions(-)
+
+diff --git a/make-linux.mk b/make-linux.mk
+index 3941573..4a2abb6 100644
+--- a/make-linux.mk
++++ b/make-linux.mk
+@@ -64,14 +64,15 @@ ifeq ($(ZT_DEBUG),1)
+ 	RUSTFLAGS=
+ 	# The following line enables optimization for the crypto code, since
+ 	# C25519 in particular is almost UNUSABLE in -O0 even on a 3ghz box!
+-node/Salsa20.o node/SHA512.o node/C25519.o node/Poly1305.o: CXXFLAGS=-Wall -O2 -g -pthread $(INCLUDES) $(DEFS)
++    node/Salsa20.o node/SHA512.o node/C25519.o node/Poly1305.o: CXXFLAGS=-Wall -O2 -g -flto -fPIC -fPIE -pthread $(INCLUDES) $(DEFS)
+ else
+ 	CFLAGS?=-O3 -fstack-protector
+ 	override CFLAGS+=-Wall -Wno-deprecated -pthread $(INCLUDES) -DNDEBUG $(DEFS)
+ 	CXXFLAGS?=-O3 -fstack-protector
+ 	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++17 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
+ 	LDFLAGS=-pie -Wl,-z,relro,-z,now
+-	RUSTFLAGS=--release
++	# RUSTFLAGS=--release
++	# RUSTFLAGS=-Clinker-plugin-lto
+ endif
+ 
+ ifeq ($(ZT_QNAP), 1)
+@@ -126,6 +127,7 @@ ifeq ($(CC_MACH),amd64)
+ 	ZT_USE_X64_ASM_ED25519=1
+ 	override CFLAGS+=-msse -msse2
+ 	override CXXFLAGS+=-msse -msse2
++	override LDFLAGS+=-fuse-ld=lld
+ 	ZT_SSO_SUPPORTED=1
+ endif
+ ifeq ($(CC_MACH),powerpc64le)
+@@ -222,6 +224,7 @@ ifeq ($(CC_MACH),arm64)
+ 	ZT_ARCHITECTURE=4
+ 	ZT_SSO_SUPPORTED=1
+ 	override DEFS+=-DZT_NO_TYPE_PUNNING -DZT_ARCH_ARM_HAS_NEON -march=armv8-a+crypto -mtune=generic -mstrict-align
++	override LDFLAGS+=-fuse-ld=lld
+ endif
+ ifeq ($(CC_MACH),aarch64)
+ 	ZT_ARCHITECTURE=4
+@@ -249,11 +252,17 @@ ifeq ($(CC_MACH),s390x)
+ endif
+ ifeq ($(CC_MACH),riscv64)
+ 	ZT_ARCHITECTURE=0
++	override LDFLAGS+=-fuse-ld=bfd
+ endif
+ ifeq ($(CC_MACH),loongarch64)
+ 	ZT_ARCHITECTURE=17
+ 	override DEFS+=-DZT_NO_TYPE_PUNNING
+ endif
++ifeq ($(CC_MACH),loongson3)
++	ZT_ARCHITECTURE=17
++	override DEFS+=-DZT_NO_TYPE_PUNNING
++	override LDFLAGS+=-fuse-ld=bfd
++endif
+ 
+ # Fail if system architecture could not be determined
+ ifeq ($(ZT_ARCHITECTURE),999)
+@@ -278,7 +287,7 @@ ifeq ($(ZT_SSO_SUPPORTED), 1)
+ 		ifeq ($(ZT_DEBUG),1)
+ 			LDLIBS+=zeroidc/target/debug/libzeroidc.a -ldl -lssl -lcrypto
+ 		else
+-			LDLIBS+=zeroidc/target/release/libzeroidc.a -ldl -lssl -lcrypto
++			LDLIBS+=zeroidc/target/debug/libzeroidc.a -ldl -lssl -lcrypto
+ 		endif
+ 	endif
+ endif
+@@ -403,7 +412,12 @@ ifeq ($(ZT_SSO_SUPPORTED), 1)
+ ifeq ($(ZT_EMBEDDED),)
+ zeroidc:	FORCE
+ #	export PATH=/root/.cargo/bin:$$PATH; cd zeroidc && cargo build -j1 $(RUSTFLAGS)
+-	export PATH=/${HOME}/.cargo/bin:$$PATH; cd zeroidc && cargo build $(RUSTFLAGS)
++	# ifeq ($(ZT_DEBUG),1)
++	# 	export PATH=/${HOME}/.cargo/bin:$$PATH; cd zeroidc && cargo build
++	# else
++	# 	export PATH=/${HOME}/.cargo/bin:$$PATH; cd zeroidc && cargo build --release
++	# endif
++	export PATH=/${HOME}/.cargo/bin:$$PATH; cd zeroidc && cargo build
+ endif
+ else
+ zeroidc:
+-- 
+2.36.0
+

--- a/extra-network/zerotier-one/spec
+++ b/extra-network/zerotier-one/spec
@@ -1,4 +1,6 @@
-VER=1.8.4
-SRCS="tbl::https://github.com/zerotier/ZeroTierOne/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::61b8c1ea5904cc87431939212033bb4d05d11f517860a01cac75f0090d94272b"
-CHKUPDATE="anitya::id=17578"
+PKGNAME="zerotier-one"
+PKGDES="ZeroTier creates secure networks between on-premise, cloud, desktop, and mobile devices"
+PKGSEC=net
+PKGDEP="llvm-runtime miniupnpc cargo"
+BUILDDEP="llvm ronn cargo"
+USECLANG=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
zerotier-one: update to `1.10.1`

The thing is, since AOSC opened LTO feature for clang, the linker of cargo build files may encounter failures when linking. I have tried may solutions, but have to turn on DEBUG options. **I may need some help to build without DEBUG and tests on other architectures.**

However, I am sure that this commit can work find on my amd64 devices with acceptable performance. The tests are http proxy over zerotier tunnel to a remote devices under complex NAT across city, zerotier version confirmation and iperf3 tests between devices under the same 5Ghz WiFi, which proved that zerotier tunnel can approach my physical limits.
![image](https://user-images.githubusercontent.com/18253926/176990284-1d0c75b0-b38d-48c7-9ec5-bcbbe3697f8f.png)
![image](https://user-images.githubusercontent.com/18253926/176990285-3fbcbabd-e04b-42f8-9d00-d63b7c625ce1.png)
![image](https://user-images.githubusercontent.com/18253926/176990290-05d8f3bc-56fc-48d5-bc75-022bce34ad6c.png)


Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
