### PR TITLE
aranym: new, 1.1.0

### DIFF
--- a/extra-emulation/aranym/autobuild/build
+++ b/extra-emulation/aranym/autobuild/build
@@ -1,0 +1,36 @@
+_build_aranym() {
+    if [[ "$1" = "jit" ]]; then
+        local _variant=JIT
+    elif [[ "$1" = "mmu" ]]; then
+        local _variant=MMU
+        AUTOTOOLS_AFTER+=" \
+            --enable-fullmmu \
+            --enable-lilo \
+            --disable-jit-compiler"
+    else
+        aberr "Unknown ARAnyM variant: $1 ."
+    fi
+
+    abinfo "Building ARAnyM (with $_variant) ..."
+    mkdir "$SRCDIR"/build$1
+    cd "$SRCDIR"/build$1
+
+    abinfo "Configuring ARAnyM (with $_variant) ..."
+    "$SRCDIR"/configure \
+        ${AUTOTOOLS_DEF} \
+        ${AUTOTOOLS_AFTER}
+
+    abinfo "Building ARAnyM (with $_variant) ..."
+    make
+
+    abinfo "Installing ARAnyM (with $_variant) ..."
+    make install \
+        DESTDIR="$PKGDIR"
+}
+
+_build_aranym jit
+_build_aranym mmu
+
+abinfo "Removing invalid aranym.desktop ..."
+# We shouldn't use alternatives for this package, it's simply too confusing.
+rm -v "$PKGDIR"/usr/share/applications/aranym.desktop

--- a/extra-emulation/aranym/autobuild/defines
+++ b/extra-emulation/aranym/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=aranym
 PKGSEC=utils
-PKGDEP="sdl2"
+PKGDEP="glu sdl2"
 PKGDES="An emulator for Atari ST/TT/Falcon (and clones)"
 
 # FIXME (as of 1.1.0):

--- a/extra-emulation/aranym/autobuild/defines
+++ b/extra-emulation/aranym/autobuild/defines
@@ -1,0 +1,59 @@
+PKGNAME=aranym
+PKGSEC=utils
+PKGDEP="sdl2"
+PKGDES="An emulator for Atari ST/TT/Falcon (and clones)"
+
+# FIXME (as of 1.1.0):
+#     --enable-blitsdlblit was marked experimental.
+#     --enable-jit2 was marked experimental and ARM-only.
+#     --enable-fullmmu conflicts with --enable-jit-compiler.
+#         ... --enable-lilo requires the MMU feature.
+AUTOTOOLS_AFTER=" \
+    --disable-nat-debug \
+    --disable-full-debug \
+    --disable-fullhistory \
+    --enable-flightrecorder \
+    --disable-fullmmu \
+    --enable-atc=full \
+    --enable-realstop \
+    --enable-dsp \
+    --enable-dsp-disasm \
+    --enable-protect2k \
+    --disable-fixedfastram \
+    --disable-fixedvideoram \
+    --enable-blitmemmove \
+    --disable-blitsdlblit \
+    --enable-hostfs \
+    --enable-ctrlkey=both \
+    --enable-gui \
+    --enable-opengl \
+    --enable-nfpci \
+    --enable-usbhost \
+    --disable-nfosmesa \
+    --enable-nfjpeg \
+    --enable-nfclipbrd \
+    --enable-nfvdi \
+    --enable-nfexec \
+    --enable-ata-cdrom \
+    --disable-epslimiter \
+    --disable-lilo \
+    --enable-rtctimer \
+    --enable-parallelx86 \
+    --enable-parport \
+    --enable-serialport \
+    --enable-fpe=auto \
+    --enable-addressing=direct \
+    --enable-addr-check=page \
+    --disable-spcflags-excl \
+    --enable-jit-compiler \
+    --disable-jit2 \
+    --enable-jit-fpu \
+    --disable-jit-debug \
+    --enable-ethernet \
+    --enable-bpf-ethernet \
+    --enable-cxx-exceptions \
+    --enable-disasm=builtin \
+    --enable-sdl2"
+
+# FIXME (as of 1.1.0): ARM support WIP.
+FAIL_ARCH="!(amd64|i486)"

--- a/extra-emulation/aranym/autobuild/overrides/usr/share/applications/aranym-lilo.desktop
+++ b/extra-emulation/aranym/autobuild/overrides/usr/share/applications/aranym-lilo.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=ARAnyM MMU (LiLO)
+Comment=Virtual Machine with MMU for FreeMiNT and Linux-m68k (Linux LOader)
+Exec=aranym-mmu --lilo
+Icon=aranym-mmu
+Terminal=false
+Type=Application
+Categories=System;Emulator;

--- a/extra-emulation/aranym/autobuild/prepare
+++ b/extra-emulation/aranym/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Appending -ffat-lto-objects to fix floating point format detection ..."
+export CFLAGS="${CFLAGS} -ffat-lto-objects"

--- a/extra-emulation/aranym/spec
+++ b/extra-emulation/aranym/spec
@@ -1,0 +1,4 @@
+VER=1.1.0
+SRCS="tbl::https://github.com/aranym/aranym/releases/download/ARANYM_${VER//./_}/aranym_$VER.orig.tar.gz"
+CHKSUMS="sha256::a8f2fcb24254754c0ced74a4de77f7d168eb7aa603ac2585d25abb51002f47cc"
+CHKUPDATE="anitya::id=264207"


### PR DESCRIPTION
Topic Description
-----------------

This topic introduces ARAnyM v1.1.0. Potentially useful for maintaining our Retro m68k port.

Package(s) Affected
-------------------

- `aranym` v1.1.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
