### PR TITLE
shadow: (fix #4045) chmod /etc/shadow to 0000 in postinst

### DIFF
--- a/base-admin/shadow/autobuild/postinst
+++ b/base-admin/shadow/autobuild/postinst
@@ -1,6 +1,12 @@
 #! /bin/bash
 pwconv
 grpconv
+
 [ -f /etc/login.access ] && mv -v /etc/login.access{,.NOUSE}
 [ -f /etc/limits ] && mv -v /etc/limits{,.NOUSE}
+
+# Issue 4045: Fix up /etc/shadow permissions for existing installations.
+# Follow Fedora to set it to 0000.
+chmod 0000 /etc/shadow
+
 exit 0

--- a/base-admin/shadow/spec
+++ b/base-admin/shadow/spec
@@ -1,4 +1,5 @@
 VER=4.10
+REL=1
 SRCS="tbl::https://github.com/shadow-maint/shadow/releases/download/v$VER/shadow-$VER.tar.xz"
 CHKSUMS="sha256::bd6fbad04d96408b41c788fe8384ed37ba0b826348ff3651733c7e7ae00668fc"
 CHKUPDATE="anitya::id=4802"


### PR DESCRIPTION
Topic Description
-----------------

This topic fixes an issue introduced with a bug in aoscbootstrap, in which `/etc/shadow` was created without permission settings (defaulted to 0644) - the revised `postinst` attempts to fix /etc/shadow permissions for existing and future installations.

Package(s) Affected
-------------------

- `shadow` v4.10-1

Security Update?
----------------

Yes

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`