### PR TITLE
freerdp: update to 2.7.0 and bugfixes

### DIFF
--- a/extra-network/freerdp/autobuild/defines
+++ b/extra-network/freerdp/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=freerdp
 PKGSEC=net
 PKGDEP="alsa-lib cups faac faad2 ffmpeg gsm gst-plugins-base-1-0 krb5 lame \
         libcl libusb linux-pam openh264 openssl pcsclite pulseaudio soxr \
-        wayland x11-lib x264"
+        wayland x11-lib"
 BUILDDEP="docbook-xsl opencl-registry-api"
 PKGDES="A free implementation of the Remote Desktop Protocol (RDP)"
 
@@ -26,7 +26,7 @@ CMAKE_AFTER="-DWITH_ALSA=ON \
              -DWITH_LAME=ON \
              -DWITH_LIBSYSTEMD=ON \
              -DWITH_MANPAGES=ON \
-             -DWITH_OPENCL=ON \
+             -DWITH_OPENCL=OFF \
              -DWITH_OPENH264=ON \
              -DWITH_OPENSLES=OFF \
              -DWITH_OPENSSL=ON \
@@ -47,7 +47,6 @@ CMAKE_AFTER="-DWITH_ALSA=ON \
              -DWITH_WAYLAND=ON \
              -DWITH_WINPR_TOOLS=ON \
              -DWITH_X11=ON \
-             -DWITH_X264=OFF \
              -DWITH_XCURSOR=ON \
              -DWITH_XDAMAGE=ON \
              -DWITH_XEXT=ON \

--- a/extra-network/freerdp/autobuild/patches/001-fix-xsl-manpage.patch
+++ b/extra-network/freerdp/autobuild/patches/001-fix-xsl-manpage.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/FindDocBookXSL.cmake b/cmake/FindDocBookXSL.cmake
+index 9192ef9..fb905d6 100644
+--- a/cmake/FindDocBookXSL.cmake
++++ b/cmake/FindDocBookXSL.cmake
+@@ -30,7 +30,7 @@ if (NOT DOCBOOKXSL_DIR)
+    set (STYLESHEET_PATH_LIST)
+    foreach (STYLESHEET_PREFIX_ITER ${CMAKE_SYSTEM_PREFIX_PATH})
+       file(GLOB STYLESHEET_SUFFIX_ITER RELATIVE ${STYLESHEET_PREFIX_ITER}
+-           ${STYLESHEET_PREFIX_ITER}/share/xml/docbook/xsl-stylesheets-*
++           ${STYLESHEET_PREFIX_ITER}/share/xml/docbook/xsl-stylesheets-*-nons
+       )
+       if (STYLESHEET_SUFFIX_ITER)
+          list (APPEND STYLESHEET_PATH_LIST ${STYLESHEET_SUFFIX_ITER})

--- a/extra-network/freerdp/spec
+++ b/extra-network/freerdp/spec
@@ -1,4 +1,4 @@
-VER=2.3.2
-SRCS="tbl::https://github.com/FreeRDP/FreeRDP/archive/${VER/rc/-rc}.tar.gz"
-CHKSUMS="sha256::a1f52f0d9569b418a555ffe4d15a3782712198be47308e9514d20ca5af41a1b1"
+VER=2.7.0
+SRCS="tbl::https://pub.freerdp.com/releases/freerdp-${VER/rc/-rc}.tar.gz"
+CHKSUMS="sha256::89000728b6e66ac37db018d6dc5f0981b530fd550ab748877ff42892dd0c166b"
 CHKUPDATE="anitya::id=10442"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

update freerdp to 2.7.0

Fix man page generation as well.

Remove dependency for x264 as such codec is removed fro upstream package.

Disable experimental feature OpenCL so it runs on my Thinkpad without dumping core.

Package(s) Affected
-------------------

freerdp

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
