### PR TITLE
openjdk: add riscv64 support

### DIFF
--- a/extra-java/openjdk/autobuild/defines
+++ b/extra-java/openjdk/autobuild/defines
@@ -9,9 +9,6 @@ PKGPROV="icedtea icedtea-web jre-openjdk jre17-openjdk openjdk17"
 NOPARALLEL=1
 PKGEPOCH=3
 
-## FIXME: Bootstrap openjdk in riscv64
-FAIL_ARCH="riscv64"
-
 # FIXME: Zero issue with hardened builds.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1290936
 AB_FLAGS_SSP__POWERPC=0

--- a/extra-java/openjdk/autobuild/prepare
+++ b/extra-java/openjdk/autobuild/prepare
@@ -1,3 +1,6 @@
+abinfo "Overriding GNU config files ..."
+cp -v /usr/share/automake-*/config.* "$SRCDIR"/make/autoconf/build-aux/
+
 abinfo "Setting compilation flags ..."
 
 export EXTRA_CFLAGS="${CPPFLAGS} ${CFLAGS/-fexceptions/}"

--- a/extra-java/openjdk/spec
+++ b/extra-java/openjdk/spec
@@ -1,4 +1,4 @@
 VER=17.0.4.1+ga
-REL=1
+REL=2
 SRCS="tbl::https://openjdk-sources.osci.io/openjdk17/openjdk-${VER/+/-}.tar.xz"
 CHKSUMS="sha256::47e0dade506e8a4b6f73b698c38f96ee3543084b25f56740941305d1ce488b46"


### PR DESCRIPTION
Topic Description
-----------------
Get OpenJDK packed on riscv64 by just dropping the FAIL_ARCH and update config.* files.

Package(s) Affected
-------------------

` openjdk`

Security Update?
----------------

No

Build Order
-----------

Despite technically this topic contains only `openjdk`, `zlib` must be updated for `openjdk` to be built properly.

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
