### PR TITLE
i3status-rust: update to 0.22.0

### DIFF
--- a/extra-wm/i3status-rust/autobuild/beyond
+++ b/extra-wm/i3status-rust/autobuild/beyond
@@ -1,21 +1,16 @@
-# From: https://www.archlinux.org/packages/community/x86_64/i3status-rust
-
 abinfo "Installing man page"
-install -Dvm644 "${SRCDIR}"/man/i3status-rs.1 "${PKGDIR}"/usr/share/man/man1/i3status-rs.1
+install -Dvm644 "$SRCDIR"/man/i3status-rs.1 "$PKGDIR"/usr/share/man/man1/i3status-rs.1
 
 abinfo "Installing example configuration file"
-install -dv "${PKGDIR}/usr/share/doc/${PKGNAME}/examples/"
-install -Dvm644 "${SRCDIR}/examples/"*.toml "${PKGDIR}/usr/share/doc/${PKGNAME}/examples/"
+for example in "$SRCDIR"/examples/*.toml; do
+    install -Dvm644 -t "$PKGDIR"/usr/share/doc/"$PKGNAME"/examples/ "$example"
+done
 
 abinfo "Installing additional assets"
-for icon in files/icons/*.toml; do
-    install -Dvm644 -t "${PKGDIR}"/usr/share/"${PKGNAME}"/icons "${icon}"
+for icon in "$SRCDIR"/files/icons/*.toml; do
+    install -Dvm644 -t "$PKGDIR"/usr/share/"$PKGNAME"/icons/ "$icon"
 done
 
-for theme in files/themes/*.toml; do
-    install -Dvm644 -t "${PKGDIR}"/usr/share/"${PKGNAME}"/themes "${theme}"
-done
-
-for example in examples/*.toml; do
-    install -Dvm644 -t "${PKGDIR}"/usr/share/doc/"${PKGNAME}"/examples/ ${example}
+for theme in "$SRCDIR"/files/themes/*.toml; do 
+    install -Dvm644 -t "$PKGDIR"/usr/share/"$PKGNAME"/themes/ "$theme"
 done

--- a/extra-wm/i3status-rust/autobuild/defines
+++ b/extra-wm/i3status-rust/autobuild/defines
@@ -7,3 +7,4 @@ PKGDES="A Rust re-implementation of i3status"
 USECLANG=1
 NOLTO__LOONGSON3=1
 ABSPLITDBG=0
+ABTYPE=rust

--- a/extra-wm/i3status-rust/autobuild/defines
+++ b/extra-wm/i3status-rust/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=x11
 PKGDEP="pulseaudio"
 BUILDDEP="rustc llvm"
 PKGDES="A Rust re-implementation of i3status"
+
 USECLANG=1
 NOLTO__LOONGSON3=1
-ABTYPE=rust
 ABSPLITDBG=0

--- a/extra-wm/i3status-rust/spec
+++ b/extra-wm/i3status-rust/spec
@@ -1,4 +1,4 @@
-VER=0.21.10
-SRCS="tbl::https://github.com/greshake/i3status-rust/archive/v$VER.tar.gz"
-CHKSUMS="sha256::d20d883dbd02026cd396ee5797f33606bcebbe0185cf8ca06b76bc325d854bb6"
+VER=0.22.0
+SRCS="git::commit=tags/v${VER}::https://github.com/greshake/i3status-rust"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231979"


### PR DESCRIPTION
Topic Description
-----------------

Update `i3status-rust` to 0.22.0

Package(s) Affected
-------------------

`i3status-rust` 0.22.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`