### PR TITLE
Nvidia Drivers Survey July '22

### DIFF
--- a/extra-devel/cuda/autobuild/build
+++ b/extra-devel/cuda/autobuild/build
@@ -11,10 +11,6 @@ rm -frv "$SRCDIR"/builds/bin
 abinfo "Creating installation directories ..."
 mkdir -pv "$PKGDIR"/"$CUDA_ROOT"/extras
 
-abinfo "Copying samples"
-cp -rv "$SRCDIR"/builds/cuda_samples \
-    "${PKGDIR}${CUDA_ROOT}/samples"
-
 abinfo "Copying integration and nsight libraries ..."
 cp -rv "$SRCDIR"/builds/{integration,nsight_compute,nsight_systems,EULA.txt} \
     "${PKGDIR}${CUDA_ROOT}"

--- a/extra-devel/cuda/autobuild/defines
+++ b/extra-devel/cuda/autobuild/defines
@@ -3,6 +3,6 @@ PKGSEC=non-free/devel
 PKGDEP="gcc-runtime gdb nvidia gcc glu pulseaudio qt-5"
 PKGDES="NVIDIA parallel computing platform and programming model"
 
-FAIL_ARCH="!(amd64)"
+FAIL_ARCH="!(amd64|arm64)"
 ABSTRIP=0
 NOSTATIC=0

--- a/extra-devel/cuda/spec
+++ b/extra-devel/cuda/spec
@@ -1,7 +1,10 @@
-MAJOR_VER=11.5.1
-MINOR_VER=495.29.05
-VER=${MAJOR_VER}+${MINOR_VER}
-REL=1
-SRCS="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${MAJOR_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS="sha256::60bea2fc0fac95574015f865355afbf599422ec2c85554f5f052b292711a4bca"
+CUDA_VER=11.7.0
+MIN_DRIVER_VER=515.43.04
+VER=${CUDA_VER}+${MIN_DRIVER_VER}
+
+SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${VER/+/_}_linux.run"
+CHKSUMS__AMD64="sha256::087fdfcbba1f79543b1f78e43a8dfdac5f6db242d042dde820e16dc185892f26"
+SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
+CHKSUMS__ARM64="sha256::e777839a618ca9a3d5ad42ded43a1b6392af2321a7327635a4afcc986876a21b"
+
 CHKUPDATE="anitya::id=13462"

--- a/extra-libs/libglvnd/autobuild/defines
+++ b/extra-libs/libglvnd/autobuild/defines
@@ -2,6 +2,11 @@ PKGNAME=libglvnd
 PKGSEC=libs
 PKGDEP="x11-lib"
 PKGDES="The GL Vendor-Neutral Dispatch library"
+BUILDDEP="python-3"
 
 PKGBREAK="mesa<=1:20.1.8-3 nvidia<=390.25-2 nvidia-libgl<=390.25-2 nvidia-libgl+340<=340.106-1"
 PKGREP="mesa<=1:20.1.8-3 nvidia<=390.25-2 nvidia-libgl<=390.25-2 nvidia-libgl+340<=340.106-1"
+
+AUTOTOOLS_AFTER="
+	PYTHON=/usr/bin/python3
+"

--- a/extra-libs/libglvnd/spec
+++ b/extra-libs/libglvnd/spec
@@ -1,5 +1,4 @@
-VER=1.3.2
-REL=1
+VER=1.4.0
 SRCS="tbl::https://github.com/NVIDIA/libglvnd/archive/v$VER.tar.gz"
-CHKSUMS="sha256::6f41ace909302e6a063fd9dc04760b391a25a670ba5f4b6edf9e30f21410b673"
+CHKSUMS="sha256::1eb5c2be8d213ad5d31cfb4efbb331d42f3d9f5617c885ce7e89f572ec2bb4b8"
 CHKUPDATE="anitya::id=12098"

--- a/extra-optenv32/libglvnd+32/autobuild/defines
+++ b/extra-optenv32/libglvnd+32/autobuild/defines
@@ -1,10 +1,14 @@
 PKGNAME=libglvnd+32
 PKGSEC=libs
 PKGDEP="x11-lib+32"
-BUILDDEP="32subsystem"
+BUILDDEP="32subsystem python-3"
 PKGDES="The GL Vendor-Neutral Dispatch library (optenv32)"
 
 PKGBREAK="mesa+32<=19.3.1 nvidia+32<=390.25 nvidia-libgl+32<=390.25"
 PKGREP="$PKGBREAK"
 NOLTO=1
 ABHOST=noarch
+
+AUTOTOOLS_AFTER="
+	PYTHON=/usr/bin/python3
+"

--- a/extra-optenv32/libglvnd+32/spec
+++ b/extra-optenv32/libglvnd+32/spec
@@ -1,4 +1,4 @@
-VER=1.3.2
+VER=1.4.0
 SRCS="tbl::https://github.com/NVIDIA/libglvnd/archive/v$VER.tar.gz"
-CHKSUMS="sha256::6f41ace909302e6a063fd9dc04760b391a25a670ba5f4b6edf9e30f21410b673"
+CHKSUMS="sha256::1eb5c2be8d213ad5d31cfb4efbb331d42f3d9f5617c885ce7e89f572ec2bb4b8"
 CHKUPDATE="anitya::id=12098"

--- a/extra-x11/nvidia/autobuild/build
+++ b/extra-x11/nvidia/autobuild/build
@@ -105,7 +105,6 @@ install -Dvm644 nvidia.icd "$PKGDIR"/etc/OpenCL/vendors/nvidia.icd
 install -Dvm755 "libnvidia-opencl.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-opencl.so.$PKGVER
 install_if_amd64 755 "libnvidia-compiler.so.$PKGVER" "$PKGDIR"/usr/lib
-install_if_amd64 755 "libnvidia-compiler-next.so.$PKGVER" "$PKGDIR"/usr/lib
 
 abinfo "NVIDIA Xorg driver..."
 install -Dvm755 nvidia_drv.so \
@@ -149,8 +148,8 @@ install_for_all 755 "libnvidia-fbc.so.$PKGVER" "$PKGDIR"/usr/lib
 install_for_all 755 "libnvidia-ngx.so.$PKGVER" "$PKGDIR"/usr/lib
 
 abinfo "Wayland support libraries and platform files..."
-install -Dvm755 "libnvidia-egl-gbm.so.1.1.0" \
-    "$PKGDIR"/usr/lib/libnvidia-egl-gbm.so.1.1.0
+install_for_all 755 "libnvidia-egl-gbm.so.1.1.0" "$PKGDIR"/usr/lib
+install_if_amd64 755 "libnvidia-wayland-client.so.$PKGVER" "$PKGDIR"/usr/lib
 install -Dvm644 "15_nvidia_gbm.json" \
     "$PKGDIR"/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
 mkdir -vp "$PKGDIR/usr/lib/gbm"
@@ -158,8 +157,7 @@ ln -svf "/usr/lib/libnvidia-allocator.so.${PKGVER}" \
     "$PKGDIR"/usr/lib/gbm/nvidia-drm_gbm.so
 
 abinfo "Nvidia VM IR library..."
-install -Dvm755 "libnvidia-nvvm.so.4.0.0" \
-    "$PKGDIR"/usr/lib/libnvidia-nvvm.so.4.0.0
+install_for_all 755 "libnvidia-nvvm.so.$PKGVER" "$PKGDIR"/usr/lib
 
 abinfo "Vulkan ICD data..."
 install -Dvm644 "nvidia_icd.json" \

--- a/extra-x11/nvidia/autobuild/build-optenv32
+++ b/extra-x11/nvidia/autobuild/build-optenv32
@@ -33,6 +33,8 @@ install -Dvm755 "libnvidia-ml.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-ml.so.$PKGVER
 install -Dvm755 "libnvidia-opticalflow.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-opticalflow.so.$PKGVER
+install -Dvm755 "libnvidia-nvvm.so.$PKGVER" \
+    "$PKGDIR"/opt/32/lib/libnvidia-nvvm.so.$PKGVER
 
 install -Dvm755 "libvdpau_nvidia.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/vdpau/libvdpau_nvidia.so.$PKGVER

--- a/extra-x11/nvidia/spec
+++ b/extra-x11/nvidia/spec
@@ -1,20 +1,20 @@
-VER=510.60.02
-_SETTINGS_VER=510.60.02
+VER=515.57
+_SETTINGS_VER=515.57
 SRCS__AMD64="
 	file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__AMD64="
-	sha256::a800dfc0549078fd8c6e8e6780efb8eee87872e6055c7f5f386a4768ce07e003
-	sha256::73db34954be6d219dbd8493b0ef28b73f35dcaffbe336e153c3ae8a3a30952e9
+	sha256::841d69fe1426883647112bb070fe2f29a1f849c64ac80a8d61c70970d8d3d522
+	sha256::150ac38a0f1ea49db4fd829206aeefadb97fe2b0bb41835f51475ac78220bc01
 "
 SRCS__ARM64="
 	file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/aarch64/$VER/NVIDIA-Linux-aarch64-${VER}.run
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__ARM64="
-	sha256::931521e4fc8175411f2a232e2d3704f8369c21e530283b4fdc4cacb323acc568
-	sha256::73db34954be6d219dbd8493b0ef28b73f35dcaffbe336e153c3ae8a3a30952e9
+	sha256::e45e1bd5c6fef6af17caf70b4250b3e1dc2669e1eceec4a21afd4f3aa2899c06
+	sha256::150ac38a0f1ea49db4fd829206aeefadb97fe2b0bb41835f51475ac78220bc01
 "
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates Nvidia graphics / GPU compute software stack to their respective latest stable version. From this point CUDA is also provided for arm64 should anyone wish to use CUDA compatible GPUs on a SBSA compliant arm64 system.

Package(s) Affected
-------------------

* `libglvnd`, `libglvnd+32`: 1.4.0
* `nvidia`: 515.57 [amd64 arm64]
* `cuda`: 11.7.0+515.43.04 [amd64 arm64]

Build Order
-----------

libglvnd libglvnd+32 nvidia cuda

Test Build(s) Done
------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64` - unable to test functionality due to lack of compatible hardware

Update(s) Uploaded to Stable
----------------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

<!-- TODO: CI to auto-fill architectural progress. -->
