### PR TITLE
i3 survey 20220710

### DIFF
--- a/extra-python/i3ipc-python/autobuild/defines
+++ b/extra-python/i3ipc-python/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=i3ipc-python
 PKGSEC=python
-PKGDEP="i3 python-2 python-3"
+PKGDEP="i3 python-3 python-xlib"
 BUILDDEP="setuptools"
 PKGDES="An improved Python library to control i3wm"
 
 ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/i3ipc-python/spec
+++ b/extra-python/i3ipc-python/spec
@@ -1,5 +1,4 @@
-VER=1.6.0
-REL=3
+VER=2.2.1
 SRCS="tbl::https://github.com/acrisci/i3ipc-python/archive/v$VER.tar.gz"
-CHKSUMS="sha256::8136db291f004992ef521cf77e9215e37974a768089601db18e642ac01412ca7"
+CHKSUMS="sha256::54af180fac6e3e16c65747884ae4479f0df034c45ed02523f8300f98c99eb29e"
 CHKUPDATE="anitya::id=11050"

--- a/extra-utils/dunst/autobuild/build
+++ b/extra-utils/dunst/autobuild/build
@@ -6,4 +6,4 @@ make "$MAKE_AFTER" dunstify
 
 abinfo "Installing binaries ..."
 make DESTDIR="$PKGDIR" PREFIX=/usr SYSCONFDIR=/etc install
-install -Dvm755 dunstify "$PKGDIR"/usr/bin/dunstify
+install -Dvm755 "$SRCDIR"/dunstify "$PKGDIR"/usr/bin/dunstify

--- a/extra-utils/dunst/autobuild/build
+++ b/extra-utils/dunst/autobuild/build
@@ -6,4 +6,4 @@ make "$MAKE_AFTER" dunstify
 
 abinfo "Installing binaries ..."
 make DESTDIR="$PKGDIR" PREFIX=/usr SYSCONFDIR=/etc install
-install -Dm755 dunstify "$PKGDIR"/usr/bin/dunstify
+install -Dvm755 dunstify "$PKGDIR"/usr/bin/dunstify

--- a/extra-utils/dunst/autobuild/build
+++ b/extra-utils/dunst/autobuild/build
@@ -1,0 +1,9 @@
+abinfo "Building dunst ..."
+make "$MAKE_AFTER"
+
+abinfo "Building dunstify ..."
+make "$MAKE_AFTER" dunstify
+
+abinfo "Installing binaries ..."
+make DESTDIR="$PKGDIR" PREFIX=/usr SYSCONFDIR=/etc install
+install -Dm755 dunstify "$PKGDIR"/usr/bin/dunstify

--- a/extra-utils/dunst/autobuild/defines
+++ b/extra-utils/dunst/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=dunst
 PKGSEC=utils
-PKGDEP="gdk-pixbuf libxdg-basedir pango"
+PKGDEP="dbus x11-lib libnotify gdk-pixbuf libxdg-basedir pango"
 PKGDES="Customizable and lightweight notification-daemon"
 
-ABMK="X11INC=/usr/include/X11 X11LIB=/usr/lib/X11"
+MAKE_AFTER="X11INC=/usr/include/X11 X11LIB=/usr/lib/X11"

--- a/extra-utils/dunst/spec
+++ b/extra-utils/dunst/spec
@@ -1,5 +1,4 @@
-VER=1.3.2
-REL=1
+VER=1.9.0
 SRCS="tbl::https://github.com/dunst-project/dunst/archive/v$VER.tar.gz"
-CHKSUMS="sha256::aab6e8fb1105a64153eee1db85d00ddb807994f03f7222aa46d40e3f3846d28a"
+CHKSUMS="sha256::b7b8d7d6560bb241b1e4d37eba770cdf19b9d5dbfc1d4d47572ad676f3f7c98a"
 CHKUPDATE="anitya::id=12188"

--- a/extra-utils/rofi/autobuild/defines
+++ b/extra-utils/rofi/autobuild/defines
@@ -3,6 +3,6 @@ PKGSEC=utils
 PKGDEP="freetype libxdg-basedir libxkbcommon pango startup-notification \
         xcb-util-wm xcb-util-xrm librsvg cairo xcb-util-cursor glib gdk-pixbuf"
 BUILDDEP="check"
-PKGDES="Popup window switcher"
+PKGDES="A pop-up window switcher"
 
 ABTYPE=autotools

--- a/extra-utils/rofi/autobuild/defines
+++ b/extra-utils/rofi/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=rofi
 PKGSEC=utils
 PKGDEP="freetype libxdg-basedir libxkbcommon pango startup-notification \
-        xcb-util-wm xcb-util-xrm librsvg"
-BUILDDEP="i3 check"
+        xcb-util-wm xcb-util-xrm librsvg cairo xcb-util-cursor glib gdk-pixbuf"
+BUILDDEP="check"
 PKGDES="Popup window switcher"
+
+ABTYPE=autotools

--- a/extra-utils/rofi/spec
+++ b/extra-utils/rofi/spec
@@ -1,4 +1,4 @@
-VER=1.5.4
+VER=1.7.3
 SRCS="tbl::https://github.com/DaveDavenport/rofi/releases/download/$VER/rofi-$VER.tar.xz"
-CHKSUMS="sha256::91a502cc29f964b529cd6228dbe655e82ab4e69c9852d23a24d9c1efb1af54db"
+CHKSUMS="sha256::25868b68ff98338c5421211fa2f8286f9c5b6f900b4bfb7c99e0fe64eb4db67b"
 CHKUPDATE="anitya::id=10146"

--- a/extra-wm/i3-gaps/autobuild/defines
+++ b/extra-wm/i3-gaps/autobuild/defines
@@ -1,11 +1,12 @@
 PKGNAME=i3-gaps
 PKGSEC=x11
-PKGDEP="dmenu libev libxkbcommon pango perl-anyevent-i3 perl-json-xs \
+PKGDEP="dex dmenu libev libxkbcommon pango perl-anyevent-i3 perl-json-xs \
         startup-notification xcb-util-cursor xcb-util-keysyms \
         xcb-util-wm yajl xcb-util-xrm xss-lock"
-PKGSUG="i3lock i3status i3blocks"
+PKGSUG="i3lock i3status"
 BUILDDEP="graphviz doxygen xmlto"
 PKGDES="Improved tiling WM (window manager), with more features"
 
 PKGCONFL="i3"
 PKGPROV="i3"
+ABTYPE=meson

--- a/extra-wm/i3-gaps/spec
+++ b/extra-wm/i3-gaps/spec
@@ -1,5 +1,4 @@
-VER=4.19
+VER=4.20.1
 SRCS="tbl::https://github.com/Airblader/i3/releases/download/$VER/i3-$VER.tar.xz"
-CHKSUMS="sha256::905c8f54cece9fb54a5116792368c2f080aca599d3fb0d8ab44e5e57809c2948"
-REL=1
+CHKSUMS="sha256::fd8e2db66f1da82a23b671404078f8fc1013ebba1aacd4245e5d1c2d331a3ad8"
 CHKUPDATE="anitya::id=231974"

--- a/extra-wm/i3/autobuild/defines
+++ b/extra-wm/i3/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=i3
 PKGSEC=x11
-PKGDEP="dmenu libev libxkbcommon pango perl-anyevent-i3 perl-json-xs \
+PKGDEP="dex dmenu libev libxkbcommon pango perl-anyevent-i3 perl-json-xs \
         startup-notification xcb-util-cursor xcb-util-keysyms \
         xcb-util-wm yajl xcb-util-xrm xss-lock"
 PKGSUG="i3lock i3status"
@@ -8,3 +8,4 @@ BUILDDEP="graphviz doxygen xmlto"
 PKGDES="Improved tiling WM (window manager)"
 
 PKGCONFL="i3-gaps"
+ABTYPE=meson

--- a/extra-wm/i3/spec
+++ b/extra-wm/i3/spec
@@ -1,4 +1,4 @@
-VER=4.19
+VER=4.20.1
 SRCS="tbl::https://i3wm.org/downloads/i3-$VER.tar.xz"
-CHKSUMS="sha256::aca48b03c0c70607826a1a91333065ff44d61774c152ddc9210fbc1627355872"
+CHKSUMS="sha256::23e1ecaf208c1d162a0c8c66c4590b301a424ee5c011227eabb96e36fd6bfce6"
 CHKUPDATE="anitya::id=1348"

--- a/extra-wm/i3lock/autobuild/defines
+++ b/extra-wm/i3lock/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=i3lock
 PKGSEC=x11
-PKGDEP="cairo libev libxkbcommon xcb-util-image mesa xcb-util-xrm"
+PKGDEP="linux-pam cairo libev libxkbcommon xcb-util-image mesa xcb-util-xrm"
 PKGDES="An improved screen locker based upon XCB and PAM"
+
+ABTYPE=meson

--- a/extra-wm/i3lock/spec
+++ b/extra-wm/i3lock/spec
@@ -1,4 +1,4 @@
-VER=2.12
-SRCS="tbl::https://i3wm.org/i3lock/i3lock-$VER.tar.bz2"
-CHKSUMS="sha256::d0b2a1a96ce80649958b27b8d54a6069b3aec9e7ffe07d378f9c51763b56bc09"
+VER=2.14.1
+SRCS="tbl::https://i3wm.org/i3lock/i3lock-$VER.tar.xz"
+CHKSUMS="sha256::062ef27eba0bc5a0c7ae91f7b7cbbf03b316d6a49fe80a58fc9f20c18a4e6843"
 CHKUPDATE="anitya::id=1349"

--- a/extra-wm/i3status/autobuild/defines
+++ b/extra-wm/i3status/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME=i3status
 PKGSEC=x11
-PKGDEP="confuse libnl pulseaudio wireless-tools yajl"
+PKGDEP="confuse libnl alsa-lib pulseaudio wireless-tools yajl"
 BUILDDEP="asciidoc xmlto"
 PKGDES="Generates status bar to use with i3bar, dzen2 or xmobar"
 
-ABMK="EXTRA_CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS}"
-MAKE_AFTER="PREFIX=/usr"
+ABTYPE=meson

--- a/extra-wm/i3status/autobuild/prepare
+++ b/extra-wm/i3status/autobuild/prepare
@@ -1,1 +1,0 @@
-export CFLAGS="${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"

--- a/extra-wm/i3status/spec
+++ b/extra-wm/i3status/spec
@@ -1,4 +1,4 @@
-VER=2.13
-SRCS="tbl::https://i3.zekjur.net/i3status/i3status-$VER.tar.bz2"
-CHKSUMS="sha256::ce89c9ff8565f62e88299f1a611229afdfc356b4e97368a5f8c4f06ad2fa1466"
+VER=2.14
+SRCS="tbl::https://i3wm.org/i3status/i3status-$VER.tar.xz"
+CHKSUMS="sha256::5c4d0273410f9fa3301fd32065deda32e9617fcae8b3cb34793061bf21644924"
 CHKUPDATE="anitya::id=1350"

--- a/extra-x11/picom/autobuild/defines
+++ b/extra-x11/picom/autobuild/defines
@@ -7,4 +7,6 @@ PKGDES="A lightweight compositor for X11"
 
 PKGBREAK="compton<=20160907-2"
 PKGREP="compton<=20160907-2"
+
+MESON_AFTER="-Dwith_docs=true"
 ABTYPE=meson

--- a/extra-x11/picom/autobuild/defines
+++ b/extra-x11/picom/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=picom
 PKGSEC=x11
-PKGDEP="hicolor-icon-theme libconfig dbus libev libglvnd pcre pixman xcb-util-image xcb-util-renderutil"
+PKGDEP="x11-lib hicolor-icon-theme libconfig dbus libev libglvnd \
+        pcre pixman xcb-util-image xcb-util-renderutil"
 BUILDDEP="uthash x11-app asciidoc"
 PKGDES="A lightweight compositor for X11"
 
 PKGBREAK="compton<=20160907-2"
 PKGREP="compton<=20160907-2"
+ABTYPE=meson

--- a/extra-x11/picom/spec
+++ b/extra-x11/picom/spec
@@ -1,4 +1,4 @@
 VER=9.1
-SRCS="https://github.com/yshui/picom/archive/v8.2.tar.gz"
-CHKSUMS="sha256::9d0c2533985e9670ff175e717a42b5bf1a2a00ccde5cac1e1009f5d6ee7912ec"
+SRCS="https://github.com/yshui/picom/archive/v${VER}.tar.gz"
+CHKSUMS="sha256::8700ac71bd496c91262c8576e29cb3aecf2b4ef48c04394a929509d3cb37b87d"
 CHKUPDATE="anitya::id=48078"

--- a/extra-x11/picom/spec
+++ b/extra-x11/picom/spec
@@ -1,5 +1,4 @@
-VER=8.2
-REL=1
+VER=9.1
 SRCS="https://github.com/yshui/picom/archive/v8.2.tar.gz"
 CHKSUMS="sha256::9d0c2533985e9670ff175e717a42b5bf1a2a00ccde5cac1e1009f5d6ee7912ec"
 CHKUPDATE="anitya::id=48078"


### PR DESCRIPTION
Topic Description
-----------------

Update i3wm packages along with `picom`, `dunst` and `rofi` utilities

Package(s) Affected
-------------------

- `i3` 4.20.1
- `i3lock` 2.14.1
- `i3status` 2.14
- `i3-gaps` 4.20.1
- `picom` 9.1
- `rofi` 1.7.3
- `i3ipc-python` 2.2.0
- `dunst` 1.9.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

`i3ipc-python`
- [x] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

`i3ipc-python`
- [ ] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`