### PR TITLE
xorg-server: security update to 21.1.4

### DIFF
--- a/extra-libs/eglexternalplatform/autobuild/defines
+++ b/extra-libs/eglexternalplatform/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=eglexternalplatform
 PKGSEC=libs
-PKGDEP="mesa"
+PKGDEP="libglvnd"
 PKGDES="The EGL External Platform interface"
+
+ABHOST=noarch

--- a/extra-libs/eglexternalplatform/spec
+++ b/extra-libs/eglexternalplatform/spec
@@ -1,4 +1,5 @@
 VER=1.1
+REL=1
 SRCS="tbl::https://github.com/NVIDIA/eglexternalplatform/archive/$VER.tar.gz"
 CHKSUMS="sha256::72725c4c9dd06b4d44bceb8794e1e78f75ed8702be23201282f8f937252a6b32"
 CHKUPDATE="anitya::id=12877"

--- a/extra-x11/xorg-server/autobuild/defines
+++ b/extra-x11/xorg-server/autobuild/defines
@@ -48,7 +48,6 @@ BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
-<<<<<<< HEAD
 MESON_AFTER__RETRO=" \
              -Dipv6=fales \
              -Ddri1=true \

--- a/extra-x11/xorg-server/spec
+++ b/extra-x11/xorg-server/spec
@@ -1,12 +1,4 @@
-<<<<<<< HEAD
-VER=21.1.3
-REL=1
+VER=21.1.4
 SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
-CHKSUMS="sha256::61d6aad5b6b47a116b960bd7f0cba4ee7e6da95d6bb0b127bde75d7d1acdebe5"
+CHKSUMS="sha256::5cc4be8ee47edb58d4a90e603a59d56b40291ad38371b0bd2471fc3cbee1c587"
 CHKUPDATE="anitya::id=5250"
-=======
-VER=1.20.11
-REL=4
-SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.bz2"
-CHKSUMS="sha256::914c796e3ffabe1af48071d40ccc85e92117c97a9082ed1df29e4d64e3c34c49"
->>>>>>> 2d64ec9c22 (xorg-server: enable DRI3 for Retro)

--- a/extra-x11/xwayland/autobuild/defines
+++ b/extra-x11/xwayland/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=xwayland
 PKGSEC=x11
 PKGDEP="libepoxy libgcrypt libunwind pixman systemd wayland \
-        x11-font x11-lib"
+        x11-font x11-lib libxcvt"
 BUILDDEP="egl-wayland wayland-protocols"
 PKGDES="X11 compatibility layer for Wayland"
 

--- a/extra-x11/xwayland/spec
+++ b/extra-x11/xwayland/spec
@@ -1,4 +1,4 @@
-VER=21.1.1
+VER=22.1.3
 SRCS="tbl::https://xorg.freedesktop.org/archive/individual/xserver/xwayland-$VER.tar.xz"
-CHKSUMS="sha256::31f261ce51bbee76a6ca3ec02aa367ffa2b5efa2b98412df57ccefd7a19003ce"
+CHKSUMS="sha256::a712eb7bce32cd934df36814b5dd046aa670899c16fe98f2afb003578f86a1c5"
 CHKUPDATE="anitya::id=180949"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Security update `xorg-server` to 21.1.4 due to the [vulnerabilities](https://lists.x.org/archives/xorg/2022-July/061035.html). [The vulnerabilities also influence `xwayland`](https://www.phoronix.com/scan.php?page=news_item&px=XWayland-22.1.3-Released), so we need to update it as well to 22.1.3 to fix the security breach.

In addition, `riscv64` misses `eglexternalplatform` during building `xwayland`, and I find it should be `noarch` because it only contains the headers and pkg-config file, and it should depend on `libglvnd` which provides the headers it needs, so it's affected as well.

Package(s) Affected
-------------------

- `xorg-server` v21.1.4
- `xwayland` v22.1.3
- `eglexternalplatform` v1.1-1 (noarch)

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Yes - Issue Number: #4066 #4067 
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
~~- [ ] PowerPC 64-bit (Little Endian) `ppc64el~~ (suspended) 
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
~~- [ ] PowerPC 64-bit (Little Endian) `ppc64el~~ (suspended) 
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
