### PR TITLE
zellij: update to 0.30.0

### DIFF
--- a/extra-utils/zellij/autobuild/defines
+++ b/extra-utils/zellij/autobuild/defines
@@ -5,4 +5,5 @@ BUILDDEP="rustc llvm"
 PKGDES="A terminal workspace and a terminal multiplexer"
 
 USECLANG=1
+ABSPLITDBG=0
 FAIL_ARCH="!(amd64|arm64)"

--- a/extra-utils/zellij/spec
+++ b/extra-utils/zellij/spec
@@ -1,3 +1,3 @@
-VER=0.29.1
+VER=0.30.0
 SRCS="tbl::https://github.com/zellij-org/zellij/archive/v$VER.tar.gz"
-CHKSUMS="sha256::340f5241c9b1abb5652b1531167f837fc573b9cfdefa551363a48930f8f1d4dd"
+CHKSUMS="sha256::52253271dd954e2705571a9bf2b2f7873fe47e0e5b7a2e85aac1b1c73152914c"


### PR DESCRIPTION
Topic Description
-----------------

Update `zellij` to 0.30.0

Package(s) Affected
-------------------

`zellij` 0.30.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`