### PR TITLE
osu-lazer: update to 2022.709.1

### DIFF
--- a/extra-games/osu-lazer/autobuild/build
+++ b/extra-games/osu-lazer/autobuild/build
@@ -5,4 +5,4 @@ dotnet publish "$SRCDIR"/osu.Desktop/osu.Desktop.csproj -c Release \
 
 abinfo "Deploy files"
 chmod 0755 "$PKGDIR"/usr/lib/osu-lazer/'osu!'
-install -Dm644 "$SRCDIR"/assets/lazer.png "$PKGDIR"/usr/lib/pixmaps/osu-lazer.png
+install -Dm644 "$SRCDIR"/assets/lazer.png "$PKGDIR"/usr/share/pixmaps/osu-lazer.png

--- a/extra-games/osu-lazer/autobuild/defines
+++ b/extra-games/osu-lazer/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=osu-lazer
 PKGSEC=games
 PKGDES="Rhythm is just a click away!"
-PKGDEP="alsa-lib desktop-file-utils libgdiplus dotnet-runtime-5.0"
-BUILDDEP="dotnet-sdk-5.0.4xx"
+PKGDEP="alsa-lib desktop-file-utils libgdiplus dotnet-runtime-6.0"
+BUILDDEP="dotnet-sdk-6.0"
 
 FAIL_ARCH="!(amd64)"
 NOSTATIC=0

--- a/extra-games/osu-lazer/spec
+++ b/extra-games/osu-lazer/spec
@@ -1,4 +1,4 @@
-VER=2021.1211.0
+VER=2022.709.1
 SRCS="tbl::https://github.com/ppy/osu/archive/$VER.tar.gz"
-CHKSUMS="sha256::0447afdadbaf0e2dd3156596db3cfe6053bce7e415b1ea9f537d31aacbc48ee9"
+CHKSUMS="sha256::fdc73521a394e095767b407882e7f874fed156c94bcdbd4374f56c4c375abeac"
 CHKUPDATE="anitya::id=227666"


### PR DESCRIPTION
Topic Description
-----------------

Update `osu-lazer` to 2022.709.1

Package(s) Affected
-------------------

`osu-lazer` 2022.709.1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   