### PR TITLE
fcitx5-pinyin-moegirl: upgrade to 20220714

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20220614
+VER=20220714
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::33e82a30393aabcbb66aee114d7493fe96fb94dfed361d93759d850e611ba46c \
-         sha256::e4cf3f88b05e3ae7823bebe4993074255cd6b1d40521e333dca9d3f342fa555a \
+CHKSUMS="sha256::71572652b409a71a87ac1a35de539b5021efd1178087116bc33b55d02fe3054b \
+         sha256::54c9500a8ff58a3b184108c4c4ea19ac0afab095510a008d7f945c4338e6d93f \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

fcitx5-pinyin-moegirl: update to 20220714

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`