### PR TITLE
pylint: update to 2.14.4

### DIFF
--- a/extra-python/astroid/autobuild/build
+++ b/extra-python/astroid/autobuild/build
@@ -1,2 +1,2 @@
 abinfo "Installing astroid using pip ..."
-pip install . --prefix="$PKGDIR"/usr
+pip install "$SRCDIR" --prefix="$PKGDIR"/usr

--- a/extra-python/astroid/autobuild/build
+++ b/extra-python/astroid/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Installing astroid using pip ..."
+pip install . --prefix="$PKGDIR"/usr

--- a/extra-python/astroid/spec
+++ b/extra-python/astroid/spec
@@ -1,4 +1,4 @@
-VER=2.8.0
+VER=2.12.2
 SRCS="tbl::https://pypi.io/packages/source/a/astroid/astroid-$VER.tar.gz"
-CHKSUMS="sha256::fe81f80c0b35264acb5653302ffbd935d394f1775c5e4487df745bf9c2442708"
+CHKSUMS="sha256::4675ef501edbbb143b3d9bb4c81d5f6338f08f960beed2ce41a03dc4cd20d777"
 CHKUPDATE="anitya::id=12725"

--- a/extra-python/dill/autobuild/defines
+++ b/extra-python/dill/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=dill
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="Serializing and de-serializing python objects to the majority of the built-in python types"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/dill/spec
+++ b/extra-python/dill/spec
@@ -1,0 +1,3 @@
+VER=0.3.5.1
+SRCS="tbl::https://pypi.io/packages/source/d/dill/dill-$VER.tar.gz"
+CHKSUMS="sha256::d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"

--- a/extra-python/lazy-object-proxy/autobuild/defines
+++ b/extra-python/lazy-object-proxy/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME=lazy-object-proxy
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 BUILDDEP="setuptools"
 PKGDES="A fast and thorough lazy object proxy"
+
+NOPYTHON2=1

--- a/extra-python/lazy-object-proxy/spec
+++ b/extra-python/lazy-object-proxy/spec
@@ -1,5 +1,4 @@
-VER=1.3.1
-REL=3
+VER=1.7.1
 SRCS="tbl::https://pypi.io/packages/source/l/lazy-object-proxy/lazy-object-proxy-$VER.tar.gz"
-CHKSUMS="sha256::eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a"
+CHKSUMS="sha256::d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"
 CHKUPDATE="anitya::id=32988"

--- a/extra-python/platformdirs/autobuild/build
+++ b/extra-python/platformdirs/autobuild/build
@@ -1,2 +1,2 @@
 abinfo "Installing using pip ..."
-pip install . --prefix="$PKGDIR"/usr
+pip install "$SRCDIR" --prefix="$PKGDIR"/usr

--- a/extra-python/platformdirs/autobuild/build
+++ b/extra-python/platformdirs/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Installing using pip ..."
+pip install . --prefix="$PKGDIR"/usr

--- a/extra-python/platformdirs/autobuild/defines
+++ b/extra-python/platformdirs/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=platformdirs
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="A Python module for determining appropriate platform-specific dirs"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/platformdirs/spec
+++ b/extra-python/platformdirs/spec
@@ -1,0 +1,4 @@
+VER=2.5.2
+SRCS="tbl::https://pypi.io/packages/source/p/platformdirs/platformdirs-$VER.tar.gz"
+CHKSUMS="sha256::58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
+CHKUPDATE="anitya::id=200932"

--- a/extra-python/pylint/autobuild/defines
+++ b/extra-python/pylint/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=pylint
 PKGSEC=python
-PKGDEP="astroid backports-functools-lru-cache isort mccabe"
+PKGDEP="platformdirs astroid tomli dill isort mccabe \
+        typing tomlkit"
 BUILDDEP="setuptools"
 PKGDES="Analyzes Python code looking for bugs and signs of poor quality"
 

--- a/extra-python/pylint/spec
+++ b/extra-python/pylint/spec
@@ -1,5 +1,4 @@
-VER=2.2.2
-REL=4
+VER=2.14.4
 SRCS="tbl::https://pypi.io/packages/source/p/pylint/pylint-$VER.tar.gz"
-CHKSUMS="sha256::689de29ae747642ab230c6d37be2b969bf75663176658851f456619aacf27492"
+CHKSUMS="sha256::47705453aa9dce520e123a7d51843d5f0032cbfa06870f89f00927aa1f735a4a"
 CHKUPDATE="anitya::id=5344"

--- a/extra-python/tomli/autobuild/build
+++ b/extra-python/tomli/autobuild/build
@@ -1,2 +1,2 @@
 abinfo "Installing using pip ..."
-pip install . --prefix="$PKGDIR"/usr
+pip install "$SRCDIR" --prefix="$PKGDIR"/usr

--- a/extra-python/tomli/autobuild/build
+++ b/extra-python/tomli/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Installing using pip ..."
+pip install . --prefix="$PKGDIR"/usr

--- a/extra-python/tomli/autobuild/defines
+++ b/extra-python/tomli/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=tomli
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="A lil' TOML parser"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/tomli/spec
+++ b/extra-python/tomli/spec
@@ -1,0 +1,4 @@
+VER=2.0.1
+SRCS="tbl::https://pypi.io/packages/source/t/tomli/tomli-$VER.tar.gz"
+CHKSUMS="sha256::de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+CHKUPDATE="anitya::id=207408"


### PR DESCRIPTION
Topic Description
-----------------

Update `pylint` to 2.14.4, along with the updates to its dependencies

Package(s) Affected
-------------------

`pylint` 2.14.4
`astroid` 2.12.2
`lazy-object-proxy` 1.7.1

New dependencies introduced:
`dill` 0.3.5.1
`platformdirs` 2.5.2
`tomli` 2.0.1

Security Update?
----------------

No

Build Order
-----------

`lazy-object-proxy -> {astroid, dill, platformdirs, tomli} -> pylint`

Test Build(s) Done
------------------

**Primary Architectures**


`lazy-object-proxy`

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Other
- [x] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

`lazy-object-proxy`
- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

`lazy-object-proxy`

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Other
- [ ] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

`lazy-object-proxy`
- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`