### PR TITLE
git: enable PCRE2 JIT on RISC-V

### DIFF
--- a/extra-vcs/git/autobuild/build
+++ b/extra-vcs/git/autobuild/build
@@ -13,11 +13,6 @@ MAKE_AFTER=(
     DEFAULT_EDITOR='/usr/bin/editor'
 )
 
-if [[ "${CROSS:-$ARCH}" = "riscv64" ]]; then
-    abinfo "RISC-V: Disabling LIBPCRE2 JIT ..."
-    MAKE_AFTER+=" NO_LIBPCRE2_JIT=1"
-fi
-
 abinfo "Building main binaries and documents ..."
 make "${MAKE_DEF[@]}" \
      "${MAKE_AFTER[@]}" all man


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Enable PCRE2 JIT on RISC-V, whereas it wasn't supported. Note that `git` now requires PCRE2 JIT, otherwise the build will end up with failure.

Package(s) Affected
-------------------

`git` v2.37.1 (only for `riscv64`)

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
