### PR TITLE
flameshot: update to 12.1.0

### DIFF
--- a/extra-utils/flameshot/spec
+++ b/extra-utils/flameshot/spec
@@ -1,4 +1,4 @@
-VER=12.0.0
+VER=12.1.0
 SRCS="tbl::https://github.com/flameshot-org/flameshot/archive/v$VER.tar.gz"
-CHKSUMS="sha256::bb2a587ea47ee2eef7cd3f617a15a63d52e502b99a2a78f82e34a271a3027133"
+CHKSUMS="sha256::c82c05d554e7a6d810aca8417ca12b21e4f74864455ab4ac94602668f85ac22a"
 CHKUPDATE="anitya::id=16948"


### PR DESCRIPTION
Topic Description
-----------------

Update `flameshot` to 12.1.0

Package(s) Affected
-------------------

`flameshot` 12.1.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`