### PR TITLE
bluez: upgrade to 5.64, bring back old utilities

### DIFF
--- a/extra-libs/bluez/autobuild/beyond
+++ b/extra-libs/bluez/autobuild/beyond
@@ -1,12 +1,16 @@
-install -dm755 "$PKGDIR"/etc/bluetooth
-install -Dm644 src/main.conf "$PKGDIR"/etc/bluetooth/main.conf
+abinfo "Installing configuration files"
+install -dvm755 "$PKGDIR"/etc/bluetooth
+install -Dvm644 "$SRCDIR"/src/main.conf "$PKGDIR"/etc/bluetooth/main.conf
 
-install -dm755 "$PKGDIR"/usr/share/doc/bluez/dbus-apis
-cp -a doc/*.txt "$PKGDIR"/usr/share/doc/bluez/dbus-apis/
+abinfo "Installing API documentation"
+install -dvm755 "$PKGDIR"/usr/share/doc/bluez/dbus-apis
+cp -av "$SRCDIR"/doc/*.txt "$PKGDIR"/usr/share/doc/bluez/dbus-apis/
 
+abinfo "Installing object exchange protocol service"
 ln -s /usr/lib/systemd/user/obex.service "$PKGDIR"/usr/lib/systemd/user/dbus-org.bluez.obex.service
 
 for files in `find tools/ -type f -perm -755`; do
     filename=$(basename $files)
-    install -Dm755 "$SRCDIR"/tools/$filename "$PKGDIR"/usr/bin/$filename
+    abinfo "Installing $filename"
+    install -Dvm755 "$SRCDIR"/tools/$filename "$PKGDIR"/usr/bin/$filename
 done

--- a/extra-libs/bluez/autobuild/defines
+++ b/extra-libs/bluez/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=bluez
 PKGSEC=libs
 PKGDEP="dbus systemd glibc libical"
 PKGSUG="cups"
-BUILDDEP="cups"
+BUILDDEP="cups docutils"
 PKGDES="The Bluetooth protocol stack for Linux"
 
 AUTOTOOLS_AFTER="--libexecdir=/usr/lib \
@@ -11,6 +11,8 @@ AUTOTOOLS_AFTER="--libexecdir=/usr/lib \
                  --enable-experimental \
                  --enable-library \
                  --enable-tools \
+                 --enable-deprecated \
+                 --enable-hid2hci \
                  --enable-cups"
 ABSHADOW=no
 RECONF=0

--- a/extra-libs/bluez/spec
+++ b/extra-libs/bluez/spec
@@ -1,5 +1,4 @@
-VER=5.55
-REL=1
+VER=5.64
 SRCS="tbl::https://www.kernel.org/pub/linux/bluetooth/bluez-$VER.tar.xz"
-CHKSUMS="sha256::8863717113c4897e2ad3271fc808ea245319e6fd95eed2e934fae8e0894e9b88"
+CHKSUMS="sha256::ae437e65b6b3070c198bc5b0109fe9cdeb9eaa387380e2072f9de65fe8a1de34"
 CHKUPDATE="anitya::id=10029"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates bluez to 5.64 and brings back "deprecated" utilities that some programs expect to find.

Package(s) Affected
-------------------

bluez


Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
