### PR TITLE
pushpkg: update to 0+git20220722

### DIFF
--- a/extra-devel/pushpkg/spec
+++ b/extra-devel/pushpkg/spec
@@ -1,9 +1,9 @@
-VER=0+git20220319
-__COMMIT="32eef594a2464656c87f1caea4ce621855dfc75d"
+VER=0+git20220722
+__COMMIT="7f0a4571b9a7dd10bcf8890f3f403d37ffc3f756"
 SRCS="file::rename=pushpkg::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/pushpkg \
       file::rename=COPYING::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/COPYING \
       file::rename=README.md::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/README.md"
-CHKSUMS="sha256::5f304e21aa42cfc44e644f957e861acdbf9a0ee51361ac472e1d1b20d2d041c9 \
+CHKSUMS="sha256::04b0a6646b470646d52f6fd46462e9cda28d3cfddd2eebe90041aae8b61fe2ba \
          sha256::992c720940396663b52389eea4c6a7409dd26b55ab3bfcd3a17f5da8b6d2a3c9 \
          sha256::f3e3eaabde4b0391de1de64ab574d4cdb202d2715851ff6767aa8ce5a7737aa7"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

Update `pushpkg` to 0+git20220722

Package(s) Affected
-------------------

`pushpkg` 0+git20220722

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
