### PR TITLE
osu-lazer: update to 2022.723.0

### DIFF
--- a/extra-games/osu-lazer/spec
+++ b/extra-games/osu-lazer/spec
@@ -1,4 +1,4 @@
-VER=2022.709.1
+VER=2022.723.0
 SRCS="tbl::https://github.com/ppy/osu/archive/$VER.tar.gz"
-CHKSUMS="sha256::fdc73521a394e095767b407882e7f874fed156c94bcdbd4374f56c4c375abeac"
+CHKSUMS="sha256::9779b3ae27386c5e7aba8a5cf85d925e4ab3439a3c0820a903cefba17645b0c9"
 CHKUPDATE="anitya::id=227666"


### PR DESCRIPTION
Topic Description
-----------------

Update `osu-lazer` to 2022.723.0

Package(s) Affected
-------------------

`osu-lazer` 2022.723.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   