### PR TITLE
Blender OpenColorIO linkage rework

### DIFF
--- a/extra-creativity/blender/autobuild/defines
+++ b/extra-creativity/blender/autobuild/defines
@@ -6,8 +6,10 @@ PKGDEP="boost desktop-file-utils ffmpeg fftw freetype glew \
         openjpeg opensubdiv libraw opencv numpy libxdg-basedir \
         ptex requests shared-mime-info xdg-utils libcl python-3 llvm"
 PKGDEP__AMD64="${PKGDEP} embree openimagedenoise"
+# amd64 and arm64 both have cuda support now
 BUILDDEP="cmake jack"
 BUILDDEP__AMD64="${BUILDDEP} cuda"
+BUILDDEP__ARM64="${BUILDDEP} cuda"
 PKGDES="A fully integrated 3D graphics creation suite"
 
 PYVER="$(python3 -c 'import sys; print("%s.%s" %sys.version_info[0:2])')"
@@ -29,7 +31,6 @@ CMAKE_AFTER="-C../build_files/cmake/config/blender_full.cmake .. \
              -DWITH_PLAYER=ON \
              -DWITH_JACK_DYNLOAD=ON \
              -DWITH_LLVM=ON \
-             -DCYCLES_CUDA_BINARIES_ARCH='sm_50;sm_52;sm_53;sm_60;sm_61;sm_62;sm_70;sm_72;sm_75;sm_80;sm_86' \
              -DWITH_PYTHON_INSTALL=OFF \
              -DWITH_PYTHON_INSTALL_NUMPY=OFF \
              -DWITH_PYTHON_INSTALL_REQUESTS=OFF \
@@ -42,16 +43,22 @@ CMAKE_AFTER="-C../build_files/cmake/config/blender_full.cmake .. \
              -DWITH_INPUT_NDOF=ON \
              -DWITH_LINKER_GOLD=ON \
              -DWITH_MOD_OCEANSIM=ON"
+
+CMAKE_AFTER__CUDA_ENABLED="
+	-DCYCLES_CUDA_BINARIES_ARCH='sm_50;sm_52;sm_53;sm_60;sm_61;sm_62;sm_70;sm_72;sm_75;sm_80;sm_86'
+	-DWITH_CYCLES_CUDA_BINARIES=ON
+"
+
 CMAKE_AFTER__AMD64=" \
              ${CMAKE_AFTER} \
-             -DWITH_CYCLES_CUDA_BINARIES=ON \
+             ${CMAKE_AFTER__CUDA_ENABLED} \
              -DWITH_CYCLES_EMBREE=ON"
 
 CMAKE_AFTER__NONX86=" \
              ${CMAKE_AFTER} \
-             -DWITH_CYCLES_CUDA_BINARIES=OFF \
              -DWITH_CYCLES_EMBREE=OFF"
 CMAKE_AFTER__ARM64=" \
+             ${CMAKE_AFTER__CUDA_ENABLED} \
              ${CMAKE_AFTER__NONX86}"
 CMAKE_AFTER__LOONGSON3=" \
              ${CMAKE_AFTER__NONX86}"
@@ -59,6 +66,7 @@ CMAKE_AFTER__PPC64EL=" \
              ${CMAKE_AFTER__NONX86}"
 
 AB_FLAGS_O3=1
+
 # FIXME: Blender with LTO crashes with SEGV upon cycles engine initialization.
 # One of the const refs and many functions around the point of crash are
 # incorrectly optimized away. I have attempted various attribute((noinline))
@@ -67,5 +75,4 @@ AB_FLAGS_O3=1
 # At the time of writing we are building on GCC 10.2.1, please recheck if we
 # had a later version of compiler.
 # ~cth451
-NOLTO=1
 NOLTO__LOONGSON3=1

--- a/extra-creativity/blender/autobuild/patches/0001-cmake-link-against-embree-avx512.patch
+++ b/extra-creativity/blender/autobuild/patches/0001-cmake-link-against-embree-avx512.patch
@@ -1,17 +1,17 @@
-From fe927ddb39f68b51a26f76d92df9dda29a05d65a Mon Sep 17 00:00:00 2001
+From e03df09d8277e2b11e4a1e317ac0a47692dd77c0 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 28 Oct 2021 23:43:51 -0500
-Subject: [PATCH] cmake: link against embree avx512
+Subject: [PATCH 1/3] cmake: link against embree avx512
 
 ---
  build_files/cmake/Modules/FindEmbree.cmake | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/build_files/cmake/Modules/FindEmbree.cmake b/build_files/cmake/Modules/FindEmbree.cmake
-index 7f7f2ae0fb3..8851d2cf607 100644
+index bb65a24c4b5..93f30815044 100644
 --- a/build_files/cmake/Modules/FindEmbree.cmake
 +++ b/build_files/cmake/Modules/FindEmbree.cmake
-@@ -39,6 +39,7 @@ IF(NOT (APPLE AND ("${CMAKE_OSX_ARCHITECTURES}" STREQUAL "arm64")))
+@@ -35,6 +35,7 @@ IF(NOT (("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64") OR (APPLE AND ("${CMAKE
      embree_sse42
      embree_avx
      embree_avx2
@@ -20,5 +20,5 @@ index 7f7f2ae0fb3..8851d2cf607 100644
  ENDIF()
  
 -- 
-2.30.2
+2.37.1
 

--- a/extra-creativity/blender/autobuild/patches/0002-fix-Xxf86vm-linkage.patch
+++ b/extra-creativity/blender/autobuild/patches/0002-fix-Xxf86vm-linkage.patch
@@ -1,17 +1,17 @@
-From 3d7430be3a908083adb8ce5b3018f6a52ae498e3 Mon Sep 17 00:00:00 2001
+From d93c6553ed253254208c3044ba28e3989379db49 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 8 Apr 2021 14:46:02 -0500
-Subject: [PATCH 2/2] fix Xxf86vm linkage
+Subject: [PATCH 2/3] fix Xxf86vm linkage
 
 ---
  build_files/cmake/platform/platform_unix.cmake | 8 ++++----
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/build_files/cmake/platform/platform_unix.cmake b/build_files/cmake/platform/platform_unix.cmake
-index a2448829206..70305838705 100644
+index 6750c23d548..61e1b4ff102 100644
 --- a/build_files/cmake/platform/platform_unix.cmake
 +++ b/build_files/cmake/platform/platform_unix.cmake
-@@ -578,10 +578,10 @@ if(WITH_GHOST_X11)
+@@ -645,10 +645,10 @@ if(WITH_GHOST_X11)
  
    if(WITH_X11_XF86VMODE)
      # XXX, why doesn't cmake make this available?
@@ -27,5 +27,5 @@ index a2448829206..70305838705 100644
        message(FATAL_ERROR "libXxf86vm not found. Disable WITH_X11_XF86VMODE if you
        want to build without")
 -- 
-2.30.2
+2.37.1
 

--- a/extra-creativity/blender/autobuild/patches/0003-cycles-math.h-preprocess-cuda-built-in-before-arm64.patch
+++ b/extra-creativity/blender/autobuild/patches/0003-cycles-math.h-preprocess-cuda-built-in-before-arm64.patch
@@ -1,0 +1,46 @@
+From 838e8d22ee5b6c85cf368e3fbc1e5c5760407501 Mon Sep 17 00:00:00 2001
+From: Tianhao Chai <cth451@gmail.com>
+Date: Thu, 28 Jul 2022 17:45:43 -0400
+Subject: [PATCH 3/3] cycles math.h: preprocess cuda built-in before arm64
+
+Currently arm64 assembly support is checked before cuda. This will cause
+C++ preprocessor to pass inline arm64 assembly into nvcc (which will
+error out due to unrecognized register modifier %wN) on arm64.
+
+Make sure CUDA / Metal presence is checked first before checking CPU
+native instructions.
+---
+ intern/cycles/util/math.h | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/intern/cycles/util/math.h b/intern/cycles/util/math.h
+index 555a5304764..e79fd5779d9 100644
+--- a/intern/cycles/util/math.h
++++ b/intern/cycles/util/math.h
+@@ -925,7 +925,11 @@ ccl_device_inline uint prev_power_of_two(uint x)
+ ccl_device_inline uint32_t reverse_integer_bits(uint32_t x)
+ {
+   /* Use a native instruction if it exists. */
+-#if defined(__aarch64__) || defined(_M_ARM64)
++#if defined(__KERNEL_CUDA__)
++  return __brev(x);
++#elif defined(__KERNEL_METAL__)
++  return reverse_bits(x);
++#elif defined(__aarch64__) || defined(_M_ARM64)
+   /* Assume the rbit is always available on 64bit ARM architecture. */
+   __asm__("rbit %w0, %w1" : "=r"(x) : "r"(x));
+   return x;
+@@ -934,10 +938,6 @@ ccl_device_inline uint32_t reverse_integer_bits(uint32_t x)
+    * This 32-bit Thumb instruction is available in ARMv6T2 and above. */
+   __asm__("rbit %0, %1" : "=r"(x) : "r"(x));
+   return x;
+-#elif defined(__KERNEL_CUDA__)
+-  return __brev(x);
+-#elif defined(__KERNEL_METAL__)
+-  return reverse_bits(x);
+ #elif __has_builtin(__builtin_bitreverse32)
+   return __builtin_bitreverse32(x);
+ #else
+-- 
+2.37.1
+

--- a/extra-creativity/blender/spec
+++ b/extra-creativity/blender/spec
@@ -1,4 +1,5 @@
 VER=3.2.1
+REL=1
 SRCS="tbl::https://download.blender.org/source/blender-$VER.tar.xz"
 CHKSUMS="sha256::f6912f2f62e4007272802e56de95c21cadd994b548a9088fdf4ee96554ae8278"
 CHKUPDATE="anitya::id=201"

--- a/extra-libs/opencolorio/autobuild/defines
+++ b/extra-libs/opencolorio/autobuild/defines
@@ -5,7 +5,7 @@ PKGDES="A color management framework for visual effects and animation"
 
 CMAKE_AFTER="
 	-Dexpat_DIR=/usr/lib/cmake/expat-2.4.6
-	-DOCIO_PYTHON_VERSION=${ABPY3VER}
+	-DOCIO_PYTHON_VERSION=3
 	-Dexpat_ROOT=/usr'
 	-DUSE_EXTERNAL_YAML=ON
 	-DOCIO_BUILD_DOCS=ON
@@ -20,3 +20,4 @@ CMAKE_AFTER__LOONGSON3="${CMAKE_AFTER__OTHER}"
 CMAKE_AFTER__PPC64EL="${CMAKE_AFTER__OTHER}"
 
 ABTYPE=cmake
+NOSTATIC=0

--- a/extra-libs/opencolorio/autobuild/prepare
+++ b/extra-libs/opencolorio/autobuild/prepare
@@ -1,4 +1,4 @@
 export CXXFLAGS="${CXXFLAGS} -Wno-error=deprecated-declarations -Wno-error=unused-function"
 
 abinfo "FIXME: cmake really likes /lib64/cmake/expat-VER, but there's no /include"
-sudo rm -rv /usr/lib/cmake/expat-*
+sudo rm -rfv /usr/lib/cmake/expat-*

--- a/extra-libs/opencolorio/spec
+++ b/extra-libs/opencolorio/spec
@@ -1,4 +1,5 @@
 VER=2.1.2
+REL=1
 SRCS="tbl::https://github.com/imageworks/OpenColorIO/archive/v$VER.tar.gz"
 CHKSUMS="sha256::6c6d153470a7dbe56136073e7abea42fa34d06edc519ffc0a159daf9f9962b0b"
 CHKUPDATE="anitya::id=9631"

--- a/extra-libs/openimageio/autobuild/defines
+++ b/extra-libs/openimageio/autobuild/defines
@@ -1,24 +1,23 @@
 PKGNAME=openimageio
 PKGSEC=libs
 PKGDEP="boost glew jasper libraw libtiff opencolorio opencv \
-        openexr openssl pugixml libheif"
+        openexr openssl pugixml libheif tbb"
 BUILDDEP="cmake pybind11"
 PKGDES="A library for reading and writing images, including classes, utilities, and applications"
 
-CMAKE_AFTER="-DUSE_EXTERNAL_PUGIXML=ON \
-             -DPUGIXML_HOME=/usr \
-             -DOIIO_BUILD_TOOLS=ON \
-             -DUSE_PYTHON=ON \
-             -DJPEG_PATH=/usr/lib/libjpeg.so.8 \
-             -DJPEGTURBO_PATH=/usr/lib/libturbojpeg.so.0 \
-             -DLIBRAW_PATH=/usr/libraw.so.16 \
-             -DUSE_FFMPEG=OFF \
-             -DINSTALL_DOCS=OFF \
-             -DINSTALL_FONTS=OFF \
-             -DUSE_QT=OFF \
-             -DUSE_OPENSSL=ON \
-             -DUSE_PTEX=OFF \
-             -DUSE_fPIC=on"
+CMAKE_AFTER="
+	-DUSE_EXTERNAL_PUGIXML=ON
+	-DOIIO_BUILD_TOOLS=ON
+	-DUSE_PYTHON=ON
+	-DUSE_FFMPEG=OFF
+	-DINSTALL_DOCS=OFF
+	-DINSTALL_FONTS=OFF
+	-DUSE_QT=OFF
+	-DUSE_PTEX=OFF
+	-DBUILD_TESTING=OFF
+	-DOIIO_BUILD_TESTS=OFF
+	-DOIIO_DOWNLOAD_MISSING_TESTDATA=OFF
+"
 PKGBREAK="blender<=2.80-1 luxrays<=1.6-7 luxrender<=1.6-5"
 
 ABTYPE=cmakeninja

--- a/extra-libs/openimageio/autobuild/prepare
+++ b/extra-libs/openimageio/autobuild/prepare
@@ -1,6 +1,1 @@
 export CXXFLAGS="${CXXFLAGS} -Wno-error=aligned-new= -Wno-error=noexcept-type -Wno-error=maybe-uninitialized -Wno-error=format-truncation= -Wno-error=deprecated-declarations"
-
-abinfo "HACK: Cmake really likes looking for configs in /lib64."
-abinfo "HACK: Nuking /usr/lib/cmake/opencolorio"
-abinfo "HACK: Forcing cmake to find opencolorio with pkg-config"
-rm -vr /usr/lib/cmake/OpenColorIO/

--- a/extra-libs/openimageio/spec
+++ b/extra-libs/openimageio/spec
@@ -1,4 +1,5 @@
 VER=2.3.17.0
+REL=1
 SRCS="tbl::https://github.com/OpenImageIO/oiio/archive/refs/tags/v${VER}.tar.gz"
 CHKSUMS="sha256::22d38347b40659d218fcafcadc9258d3f6eda0be02029b11969361c9a6fa9f5c"
 CHKUPDATE="anitya::id=2548"


### PR DESCRIPTION
Topic Description
-----------------

This PR fixes an issue where OpenColorIO is built with python 2 bindings - which causes downstream dependency problems and missing features in blender. CUDA support has also been enabled for blender on arm64.

Package(s) Affected
-------------------

* opencolorio
* openimageio
* blender

Build Order
-----------

opencolorio openimageio blender

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
