### PR TITLE
rustc: fix outdated patch from retro

### DIFF
--- a/extra-rust/rustc/autobuild/patches/0003-add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/extra-rust/rustc/autobuild/patches/0003-add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,10 +1,10 @@
---- rustc-1.53.0-src/compiler/rustc_target/src/spec/mod.rs	2021-06-17 03:53:51.000000000 +0000
-+++ rustc-1.53.0-src.i486/compiler/rustc_target/src/spec/mod.rs	2022-01-29 07:02:03.616045440 +0000
-@@ -705,6 +705,7 @@
+--- rustc-1.61.0-src/compiler/rustc_target/src/spec/mod.rs	2022-05-18 01:29:36.000000000 +0000
++++ rustc-1.61.0-src.i486/compiler/rustc_target/src/spec/mod.rs	2022-07-17 06:20:40.334197962 +0000
+@@ -812,6 +812,7 @@
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),
 +    ("i486-unknown-linux-gnu", i486_unknown_linux_gnu),
+     ("m68k-unknown-linux-gnu", m68k_unknown_linux_gnu),
      ("mips-unknown-linux-gnu", mips_unknown_linux_gnu),
      ("mips64-unknown-linux-gnuabi64", mips64_unknown_linux_gnuabi64),
-     ("mips64el-unknown-linux-gnuabi64", mips64el_unknown_linux_gnuabi64),

--- a/extra-rust/rustc/autobuild/prepare
+++ b/extra-rust/rustc/autobuild/prepare
@@ -47,7 +47,8 @@ prefix = "/usr"
 
 [rust]
 EOF
-if [[ "${CROSS:-$ARCH}" != armv* ]]; then
+if [[ "${CROSS:-$ARCH}" != armv* && \
+      "${CROSS:-$ARCH}" != i486 ]]; then
     cat >> "$SRCDIR"/config.toml << EOF
 # LLVM crashes when passing an object through ThinLTO twice.
 # This is triggered when using rust code in cross-language
@@ -59,7 +60,7 @@ debuginfo-level = 2
 EOF
 else
     cat >> "$SRCDIR"/config.toml << EOF
-# Working around limited VM space on arm32
+# Working around limited VM space on arm32, i486
 codegen-units = 1
 codegen-units-std = 1
 debuginfo-level = 0
@@ -81,7 +82,7 @@ llvm-config = "/usr/bin/llvm-config"
 EOF
 fi
 
-if [[ "${CROSS:-$ARCH}" = "i486" ]]; then
+if [[ "${CROSS:-$ARCH}" = "armv7" ]]; then
     cat >> "$SRCDIR"/config.toml << EOF
 [target.thumbv7neon-unknown-linux-gnueabihf]
 llvm-config = "/usr/bin/llvm-config"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Recent retro to stable merge introduced a outdated patch for rustc 1.53, which will make autobuild3 fail to patch the 1.61 version of rustc, leading to a FTBFS. The topic cherry-picks and ports a fix from retro branch which will fix the aforementioned problem.

The topic won't affect/rebuild any existing package.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

rustc

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

No

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->



Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

N/A
