### PR TITLE
sway: update to 1.7

### DIFF
--- a/extra-devel/meson/spec
+++ b/extra-devel/meson/spec
@@ -1,5 +1,4 @@
-VER=0.59.1
+VER=0.63.0
 SRCS="tbl::https://github.com/mesonbuild/meson/releases/download/$VER/meson-$VER.tar.gz"
-CHKSUMS="sha256::db586a451650d46bbe10984a87b79d9bcdc1caebf38d8e189f8848f8d502356d"
+CHKSUMS="sha256::3b51d451744c2bc71838524ec8d96cd4f8c4793d5b8d5d0d0a9c8a4f7c94cd6f"
 CHKUPDATE="anitya::id=6472"
-REL=1

--- a/extra-devel/wayland-protocols/spec
+++ b/extra-devel/wayland-protocols/spec
@@ -1,4 +1,4 @@
-VER=1.25
+VER=1.26
 SRCS="tbl::https://wayland.freedesktop.org/releases/wayland-protocols-$VER.tar.xz"
-CHKSUMS="sha256::f1ff0f7199d0a0da337217dd8c99979967808dc37731a1e759e822b75b571460"
+CHKSUMS="sha256::c553384c1c68afd762fa537a2569cc9074fe7600da12d3472761e77a2ba56f13"
 CHKUPDATE="anitya::id=13997"

--- a/extra-libs/wayland/spec
+++ b/extra-libs/wayland/spec
@@ -1,4 +1,4 @@
-VER=1.19.0
+VER=1.21.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wayland/wayland"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10061"

--- a/extra-libs/wlroots/spec
+++ b/extra-libs/wlroots/spec
@@ -1,4 +1,4 @@
-VER=0.14.1
+VER=0.15.1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wlroots/wlroots"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18357"

--- a/extra-wm/sway/autobuild/defines
+++ b/extra-wm/sway/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=sway
 PKGSEC=x11
-PKGDEP="gdk-pixbuf json-c xorg-server pango wlroots xwayland"
+PKGDEP="gdk-pixbuf json-c cairo pcre2 xorg-server pango wlroots xwayland"
 BUILDDEP="asciidoc cmake scdoc"
 PKGDES="An i3-compatible window manager for Wayland"

--- a/extra-wm/sway/spec
+++ b/extra-wm/sway/spec
@@ -1,4 +1,4 @@
-VER=1.6.1
+VER=1.7
 SRCS="git::commit=tags/$VER::https://github.com/swaywm/sway"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11497"


### PR DESCRIPTION
Topic Description
-----------------

Update sway and its dependencies.

Package(s) Affected
-------------------

`sway` 1.7
`meson` 0.63.0
`wayland-protocols` 1.26
`wayland` 1.21.0
`wlroots` 0.15.1

Security Update?
----------------

No

Build Order
-----------

`meson -> wayland -> wayland-protocols -> wlroots -> sway`

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`