### PR TITLE
rsync: upgrade to 3.2.5~pre1 fixing CVE-2022-29154

### DIFF
--- a/extra-network/rsync/spec
+++ b/extra-network/rsync/spec
@@ -1,4 +1,4 @@
-VER=3.2.3
+VER=3.2.6
 SRCS="tbl::https://download.samba.org/pub/rsync/src/rsync-$VER.tar.gz"
-CHKSUMS="sha256::becc3c504ceea499f4167a260040ccf4d9f2ef9499ad5683c179a697146ce50e"
+CHKSUMS="sha256::fb3365bab27837d41feaf42e967c57bd3a47bc8f10765a3671efd6a3835454d3"
 CHKUPDATE="anitya::id=4217"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates rsync to 3.2.6, fixing an oversight that allows malicious servers to write arbitrary data to arbitrary location on the client filesystem within access permissions of the local rsync process. The resulting scope access would normally include `.ssh/authorized_keys` and may lead to further compromises.

Package(s) Affected
-------------------

rsync

Security Update?
----------------

Yes - Issue Number: #4092 

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`
