### PR TITLE
archlinux-keyring: update to 20220727

### DIFF
--- a/extra-admin/archlinux-keyring/autobuild/defines
+++ b/extra-admin/archlinux-keyring/autobuild/defines
@@ -1,6 +1,9 @@
 PKGNAME=archlinux-keyring
 PKGSEC=admin
 PKGDEP="gnupg pacman"
+BUILDDEP="sequoia-sq"
 PKGDES="Arch Linux PGP keyring"
 
 ABHOST=noarch
+ABTYPE="plainmake"
+ABMK="build"

--- a/extra-admin/archlinux-keyring/spec
+++ b/extra-admin/archlinux-keyring/spec
@@ -1,4 +1,4 @@
-VER=20211028
-SRCS="https://sources.archlinux.org/other/archlinux-keyring/archlinux-keyring-${VER}.tar.gz"
-CHKSUMS="sha256::3d7fba47441173dfab6eec1cebf9fce4151277f6e06513e2150ccd9d71691cbc"
+VER=20220727
+SRCS="git::commit=tags/$VER::https://gitlab.archlinux.org/archlinux/archlinux-keyring"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=103"

--- a/extra-security/sequoia-sq/autobuild/defines
+++ b/extra-security/sequoia-sq/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME="sequoia-sq"
+PKGDES="Command-line frontends for Sequoia, Sequoia is a cool new OpenPGP implementation"
+PKGDEP="glibc"
+BUILDDEP="rustc llvm"
+PKGSEC="admin"
+
+CARGO_AFTER="--features crypto-nettle,compression-bzip2,autocrypt,sequoia-autocrypt"
+USECLANG=1

--- a/extra-security/sequoia-sq/autobuild/patches/0001-inject-lto.patch
+++ b/extra-security/sequoia-sq/autobuild/patches/0001-inject-lto.patch
@@ -1,0 +1,7 @@
+--- a/Cargo.toml	2022-08-10 03:27:37.152222052 +0000
++++ b/Cargo.toml	2022-08-10 03:31:49.115242729 +0000
+@@ -11,3 +11,4 @@
+ 
+ [profile.release]
+ debug = true
++lto = true

--- a/extra-security/sequoia-sq/spec
+++ b/extra-security/sequoia-sq/spec
@@ -1,0 +1,4 @@
+VER=0.27.0
+SRCS="git::commit=tags/sq/v$VER::https://gitlab.com/sequoia-pgp/sequoia"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=191617"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

archlinux-keyring: update to 20220727

Package(s) Affected
-------------------

archlinux-keyring: update to 20220727

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
