### PR TITLE
Blender OpenColorIO Linkage Rework 2

### DIFF
--- a/extra-creativity/blender/spec
+++ b/extra-creativity/blender/spec
@@ -1,5 +1,5 @@
 VER=3.2.1
-REL=1
+REL=2
 SRCS="tbl::https://download.blender.org/source/blender-$VER.tar.xz"
 CHKSUMS="sha256::f6912f2f62e4007272802e56de95c21cadd994b548a9088fdf4ee96554ae8278"
 CHKUPDATE="anitya::id=201"

--- a/extra-creativity/blender/spec
+++ b/extra-creativity/blender/spec
@@ -1,5 +1,4 @@
-VER=3.2.1
-REL=2
+VER=3.2.2
 SRCS="tbl::https://download.blender.org/source/blender-$VER.tar.xz"
-CHKSUMS="sha256::f6912f2f62e4007272802e56de95c21cadd994b548a9088fdf4ee96554ae8278"
+CHKSUMS="sha256::0c4a6b571863fd5423c62f6a03d2a415babff83dd21a321b52deb5826962d803"
 CHKUPDATE="anitya::id=201"

--- a/extra-libs/opencolorio/spec
+++ b/extra-libs/opencolorio/spec
@@ -1,5 +1,5 @@
 VER=2.1.2
-REL=1
+REL=2
 SRCS="tbl::https://github.com/imageworks/OpenColorIO/archive/v$VER.tar.gz"
 CHKSUMS="sha256::6c6d153470a7dbe56136073e7abea42fa34d06edc519ffc0a159daf9f9962b0b"
 CHKUPDATE="anitya::id=9631"

--- a/extra-libs/openimageio/spec
+++ b/extra-libs/openimageio/spec
@@ -1,5 +1,5 @@
 VER=2.3.17.0
-REL=1
+REL=2
 SRCS="tbl::https://github.com/OpenImageIO/oiio/archive/refs/tags/v${VER}.tar.gz"
 CHKSUMS="sha256::22d38347b40659d218fcafcadc9258d3f6eda0be02029b11969361c9a6fa9f5c"
 CHKUPDATE="anitya::id=2548"


### PR DESCRIPTION
Topic Description
-----------------

This rework makes another round to rebuild to account for a merging mistake with the recent KDE topic. Also updates Blender to 3.2.2.