### PR TITLE
xf86-input-wacom: update to 1.1.0 and drop beyond hack

### DIFF
--- a/extra-x11/xf86-input-wacom/autobuild/beyond
+++ b/extra-x11/xf86-input-wacom/autobuild/beyond
@@ -1,3 +1,0 @@
-# FIXME: dpkg check off, stupid.
-
-chmod -R a-s $SRCDIR

--- a/extra-x11/xf86-input-wacom/spec
+++ b/extra-x11/xf86-input-wacom/spec
@@ -1,5 +1,4 @@
-VER=0.40.0
-REL=1
-SRCS="tbl::https://github.com/linuxwacom/xf86-input-wacom/archive/xf86-input-wacom-${VER}.tar.gz"
-CHKSUMS="sha256::5b0befd0e1270942026813c303ec26fd7ca8955eeb75e2055b37deac92b7c142"
+VER=1.1.0
+SRCS="https://github.com/linuxwacom/xf86-input-wacom/releases/download/xf86-input-wacom-${VER}/xf86-input-wacom-${VER}.tar.bz2"
+CHKSUMS="sha256::23b674067f344de22bcbb4bac885c43df54c5e841f6dade7c9d18ba7ce297a12"
 CHKUPDATE="anitya::id=5248"


### PR DESCRIPTION
Topic Description
-----------------

Update `xf86-input-wacom` to 1.1.0 and try to address its FTBFS.

Package(s) Affected
-------------------

- `xf86-input-wacom`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
