### PR TITLE
libstoragemgmt: disable Valgrind on riscv64

### DIFF
--- a/extra-libs/libstoragemgmt/autobuild/defines
+++ b/extra-libs/libstoragemgmt/autobuild/defines
@@ -5,3 +5,4 @@ BUILDDEP="check chrpath"
 PKGDES="Storage array management library"
 
 AUTOTOOLS_AFTER="--with-python3 PYTHON=/usr/bin/python3"
+AUTOTOOLS_AFTER__RISCV64="$AUTOTOOLS_AFTER --without-mem-leak-test"


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of libstoragemgmt on riscv64 by disabling valgrind.

As only per-architecture AUTOTOOLS_AFTER is altered, REL is not bumped and only riscv64 is considered now.

Package(s) Affected
-------------------

- `libstoragemgmt`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
