### PR TITLE
libqzeigeist: drop

### DIFF
--- a/extra-kde/phonon/autobuild/defines
+++ b/extra-kde/phonon/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=phonon
 PKGEPOCH=1
 PKGSEC=kde
-PKGDEP="qt-4 qt-5 pulseaudio libqzeitgeist"
+PKGDEP="qt-4 qt-5 pulseaudio"
 BUILDDEP="automoc4 extra-cmake-modules"
 PKGDES="The KDE multimedia framework"

--- a/extra-kde/phonon/spec
+++ b/extra-kde/phonon/spec
@@ -1,5 +1,5 @@
 VER=4.11.1
-REL=3
+REL=4
 SRCS="tbl::https://download.kde.org/stable/phonon/$VER/phonon-$VER.tar.xz"
 CHKSUMS="sha256::b4431ea2600df8137a717741ad9ebc7f7ec1649fa3e138541d8f42597144de2d"
 CHKUPDATE="anitya::id=229047"

--- a/extra-libs/libqzeitgeist/autobuild/defines
+++ b/extra-libs/libqzeitgeist/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=libqzeitgeist
-PKGSEC=libs
-PKGDEP="qt-4 zeitgeist"
-BUILDDEP="automoc4 cmake"
-PKGDES="A Qt interface to the Zeitgeist event tracking system"
-
-CMAKE_AFTER="-DQT_QMAKE_EXECUTABLE=/usr/bin/qmake-qt4"

--- a/extra-libs/libqzeitgeist/spec
+++ b/extra-libs/libqzeitgeist/spec
@@ -1,5 +1,0 @@
-VER=0.8.0
-REL=4
-SRCS="tbl::https://download.kde.org/stable/libqzeitgeist/$VER/src/libqzeitgeist-$VER.tar.bz2"
-CHKSUMS="sha256::0a8aa980d64549cce93691705807681fd7e3e079a48aee68fc4b2653f17d61ad"
-CHKUPDATE="anitya::id=230134"


### PR DESCRIPTION
Topic Description
-----------------

Drop libqzeigeist and remove phonon's dependency on it.

Package(s) Affected
-------------------

- `libqzeigeist` dropped
- `phonon` defines dependency removed (should not affect the real binary)

Security Update?
----------------

No

Build Order
-----------

`phonon`

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
