### PR TITLE
fuse-3: disable building examples

### DIFF
--- a/extra-libs/fuse-3/02-fuse-3/defines
+++ b/extra-libs/fuse-3/02-fuse-3/defines
@@ -4,3 +4,4 @@ PKGDEP="fuse-common glibc"
 PKGDES="Filesystem in userspace (version 3)"
 
 NOLTO=1
+MESON_AFTER="-Dexamples=false"

--- a/extra-libs/fuse-3/spec
+++ b/extra-libs/fuse-3/spec
@@ -1,5 +1,5 @@
 VER=3.10.1
-REL=1
+REL=2
 SRCS="tbl::https://github.com/libfuse/libfuse/releases/download/fuse-$VER/fuse-$VER.tar.xz"
 CHKSUMS="sha256::d82d74d4c03e099f806e4bb31483955637c69226576bf0ca9bd142f1d50ae451"
 CHKUPDATE="anitya::id=861"


### PR DESCRIPTION
Topic Description
-----------------

Disable build of not installed examples inside fuse-3, to fix FTBFS.

Package(s) Affected
-------------------

- `fuse-common`
- `fuse-3`

(No content change should happen on both)

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
