### PR TITLE
libgtop: add missing builddep gnome-common

### DIFF
--- a/extra-libs/libgtop/autobuild/defines
+++ b/extra-libs/libgtop/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libgtop
 PKGSEC=libs
 PKGDEP="glib x11-lib"
-BUILDDEP="gobject-introspection gtk-doc intltool"
+BUILDDEP="gobject-introspection gtk-doc intltool gnome-common"
 PKGDES="A library that reads information about processes and the running system"
 
 AUTOTOOLS_AFTER="--enable-gtk-doc"

--- a/extra-libs/libgtop/spec
+++ b/extra-libs/libgtop/spec
@@ -1,5 +1,5 @@
 VER=2.38.0
-REL=1
+REL=2
 SRCS="tbl::https://download.gnome.org/sources/libgtop/${VER:0:4}/libgtop-$VER.tar.xz"
 CHKSUMS="sha256::4f6c0e62bb438abfd16b4559cd2eca0251de19e291c888cdc4dc88e5ffebb612"
 CHKUPDATE="anitya::id=13146"


### PR DESCRIPTION
Topic Description
-----------------

Fix libgtop FTBFS by missing builddep gnome-common.

Package(s) Affected
-------------------

- `libgtop`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
