### PR TITLE
libunique3: explicitly enable gtk-doc and introspection

### DIFF
--- a/extra-libs/libunique3/autobuild/defines
+++ b/extra-libs/libunique3/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=libunique3
 PKGSEC=libs
 PKGDEP="gtk-3 dbus"
+# Note: gtk-doc is always required for reconf even if no documentation is wanted
+BUILDDEP="gtk-doc gobject-introspection"
 PKGDES="Library for writing single instance applications for GTK+3"
 
-AUTOTOOLS_AFTER="--enable-dbus"
+AUTOTOOLS_AFTER="--enable-dbus --enable-gtk-doc --enable-introspection"
 ABSHADOW=no

--- a/extra-libs/libunique3/spec
+++ b/extra-libs/libunique3/spec
@@ -1,5 +1,5 @@
 VER=3.0.2
-REL=2
+REL=3
 SRCS="tbl::https://download.gnome.org/sources/libunique/3.0/libunique-$VER.tar.xz"
 CHKSUMS="sha256::a8f02ce073e2b920cca8ac45d418e7cb64438ad0814780c5912c6d63f8a4e038"
 CHKUPDATE="anitya::id=230184"


### PR DESCRIPTION
Topic Description
-----------------

Explicitly add gtk-doc introspection to AUTOTOOLS_AFTER and BUILDDEP on libunique3.

Adding gtk-doc also fixes FTBFS by reconfiguration (this requires gtk-doc).

Package(s) Affected
-------------------

- `libunique3`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
