### PR TITLE
exempi: fix FTBFS because of GCC 11

### DIFF
--- a/extra-libs/exempi/autobuild/patches/0001-gentoo-exempi-2.4.5-gcc11.patch
+++ b/extra-libs/exempi/autobuild/patches/0001-gentoo-exempi-2.4.5-gcc11.patch
@@ -1,0 +1,11 @@
+--- a/XMPFiles/source/FormatSupport/P2_Support.hpp
++++ b/XMPFiles/source/FormatSupport/P2_Support.hpp
+@@ -79,7 +79,7 @@
+ }; // class P2_Clip
+ struct P2SpannedClip_Order
+ {
+-	bool operator()( P2_Clip* lhs,  P2_Clip* rhs)   
++	bool operator()( P2_Clip* lhs,  P2_Clip* rhs) const
+ 	{  
+ 		return lhs->GetOffsetInShot() < rhs->GetOffsetInShot();
+ 	}

--- a/extra-libs/exempi/spec
+++ b/extra-libs/exempi/spec
@@ -1,4 +1,5 @@
 VER=2.5.1
+REL=1
 SRCS="tbl::https://github.com/hfiguiere/exempi/archive/$VER.tar.gz"
 CHKSUMS="sha256::db4a5d861e37c7c71288c9284934bcd3f1244724a1a0625512f23ec0134f71a5"
 CHKUPDATE="anitya::id=767"


### PR DESCRIPTION
Topic Description
-----------------

Fix exempi's FTBFS that happens after updating to GCC 11 by introducing a patch from Gentoo portage.

Package(s) Affected
-------------------

- `exempi`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
