### PR TITLE
systemd-boot-friend: remove the empty `BOOTARG` in ...

### DIFF
--- a/extra-admin/systemd-boot-friend/autobuild/amd64/overrides/etc/systemd-boot-friend.conf
+++ b/extra-admin/systemd-boot-friend/autobuild/amd64/overrides/etc/systemd-boot-friend.conf
@@ -1,15 +1,16 @@
-# VMLINUX: vmlinux filename format
-VMLINUX="vmlinuz-{VERSION}"
+# vmlinux: vmlinux filename format
+vmlinux = "vmlinuz-{VERSION}"
 
-# INITRD: initrd filename format
-INITRD="initramfs-{VERSION}.img"
+# initrd: initrd filename format
+INITRD = "initramfs-{VERSION}.img"
 
-# DISTRO: distro name
-DISTRO="AOSC OS"
+# distro: distro name
+distro = "AOSC OS"
 
-# ESP_MOUNTPOINT: defines where the EFI System Partition is located.
+# esp_mountpoint: defines where the EFI System Partition is located.
 # Notice: no tailing /
-ESP_MOUNTPOINT="/efi"
+esp_mountpoint = "/efi"
 
-# BOOTARG: your boot argument
-BOOTARG=""
+# bootargs: your boot argument
+[bootargs]
+#default = ""

--- a/extra-admin/systemd-boot-friend/autobuild/arm64/overrides/etc/systemd-boot-friend.conf
+++ b/extra-admin/systemd-boot-friend/autobuild/arm64/overrides/etc/systemd-boot-friend.conf
@@ -1,15 +1,16 @@
-# VMLINUX: vmlinux filename format
-VMLINUX="vmlinux-{VERSION}"
+# vmlinux: vmlinux filename format
+vmlinux = "vmlinux-{VERSION}"
 
-# INITRD: initrd filename format
-INITRD="initramfs-{VERSION}.img"
+# initrd: initrd filename format
+INITRD = "initramfs-{VERSION}.img"
 
-# DISTRO: distro name
-DISTRO="AOSC OS"
+# distro: distro name
+distro = "AOSC OS"
 
-# ESP_MOUNTPOINT: defines where the EFI System Partition is located.
+# esp_mountpoint: defines where the EFI System Partition is located.
 # Notice: no tailing /
-ESP_MOUNTPOINT="/efi"
+esp_mountpoint = "/efi"
 
-# BOOTARG: your boot argument
-BOOTARG=""
+# bootargs: your boot argument
+[bootargs]
+#default = ""

--- a/extra-admin/systemd-boot-friend/spec
+++ b/extra-admin/systemd-boot-friend/spec
@@ -1,4 +1,5 @@
 VER=0.24.0
+REL=1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/systemd-boot-friend-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226819"


### PR DESCRIPTION
... the shipped configuration

Signed-off-by: Kaiyang Wu <origincode@aosc.io>

<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Remove the empty `BOOTARG` section in the shipped configuration to prevent empty kernel command line being used by `systemd-boot-friend`

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`systemd-boot-friend` 0.24.0-1

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

<!-- TODO: CI to auto-fill architectural progress. -->
