### PR TITLE
pcre2: fix of lack of MB ver on riscv64 and fix 404

### DIFF
--- a/extra-libs/pcre2/autobuild/defines
+++ b/extra-libs/pcre2/autobuild/defines
@@ -13,16 +13,16 @@ AUTOTOOLS_AFTER="--enable-pcre2-16 \
                  --enable-unicode \
                  --enable-jit \
                  --enable-pcre2grep-jit"
-AUTOTOOLS_AFTER__ARMV4=" \
+AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER} \
                  --disable-jit \
                  --disable-pcre2grep-jit"
-AUTOTOOLS_AFTER__ARMV6HF=" \
+AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER} \
                  --disable-jit \
                  --disable-pcre2grep-jit"
-AUTOTOOLS_AFTER__ARMV7HF=" \
+AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER} \
                  --disable-jit \
                  --disable-pcre2grep-jit"
-AUTOTOOLS_AFTER__RISCV64=" \
+AUTOTOOLS_AFTER__RISCV64="${AUTOTOOLS_AFTER} \
                  --disable-jit \
                  --disable-pcre2grep-jit"
 

--- a/extra-libs/pcre2/spec
+++ b/extra-libs/pcre2/spec
@@ -1,5 +1,5 @@
 VER=10.34
-REL=1
+REL=2
 SRCS="tbl::https://ftp.pcre.org/pub/pcre/pcre2-$VER.tar.gz"
 CHKSUMS="sha256::da6aba7ba2509e918e41f4f744a59fa41a2425c59a298a232e7fe85691e00379"
 CHKUPDATE="anitya::id=5832"

--- a/extra-libs/pcre2/spec
+++ b/extra-libs/pcre2/spec
@@ -1,5 +1,5 @@
 VER=10.34
 REL=2
-SRCS="tbl::https://ftp.pcre.org/pub/pcre/pcre2-$VER.tar.gz"
+SRCS="tbl::https://sourceforge.net/projects/pcre/files/pcre2/10.34/pcre2-10.34.tar.gz"
 CHKSUMS="sha256::da6aba7ba2509e918e41f4f744a59fa41a2425c59a298a232e7fe85691e00379"
 CHKUPDATE="anitya::id=5832"


### PR DESCRIPTION
Topic Description
-----------------

Fixes pcre2's lack of multibyte versions on riscv64, which prevented qt-6 from using it.

Package(s) Affected
-------------------

`pcre2`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
