### PR TITLE
qt-6: made buildable on RISC-V64 w/o WebEngine

### DIFF
--- a/extra-libs/qt-6/autobuild/defines
+++ b/extra-libs/qt-6/autobuild/defines
@@ -21,6 +21,7 @@ PKGDEP_NOWEBENGINE="alsa-lib bluez cups dbus desktop-file-utils
         xcb-util-image xcb-util-keysyms xcb-util-wm xdg-utils zlib"
 PKGDEP__LOONGSON3="${PKGDEP_NOWEBENGINE}"
 PKGDEP__PPC64EL="${PKGDEP_NOWEBENGINE}"
+PKGDEP__RISCV64="${PKGDEP_NOWEBENGINE}"
 
 # FIXME: LTO breaks WebEngine build.
 NOLTO=1
@@ -81,3 +82,4 @@ CMAKE_AFTER__NOWEBENGINE=" \
              -DBUILD_qtwebengine=OFF"
 CMAKE_AFTER__LOONGSON3="${CMAKE_AFTER__NOWEBENGINE}"
 CMAKE_AFTER__PPC64EL="${CMAKE_AFTER__NOWEBENGINE}"
+CMAKE_AFTER__RISCV64="${CMAKE_AFTER__NOWEBENGINE}"

--- a/extra-libs/qt-6/autobuild/prepare
+++ b/extra-libs/qt-6/autobuild/prepare
@@ -2,3 +2,8 @@ abinfo "Preparing build environment ..."
 export QTDIR="$SRCDIR"
 export LD_LIBRARY_PATH="${QTDIR}/qtbase/lib:${QTDIR}/qttools/lib:${LD_LIBRARY_PATH}"
 export QT_PLUGIN_PATH="${QTDIR}/qtbase/plugins"
+
+if [[ "${CROSS:-$ARCH}" = "riscv64" ]]; then
+    abinfo "RISC-V: injecting -pthread ..."
+    export LDFLAGS+=" -pthread"
+fi


### PR DESCRIPTION
Topic Description
-----------------

Makes Qt 6 buildable on RISC-V 64 with WebEngine omitted (and a flag for -latomic).

Package(s) Affected
-------------------

- `qt-6` only riscv64 related change

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
