### PR TITLE
libpeas: use lua instead of luajit on riscv64

### DIFF
--- a/extra-libs/libpeas/autobuild/defines
+++ b/extra-libs/libpeas/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=libpeas
 PKGSEC=libs
 PKGDEP="gobject-introspection gtk-3 luajit python-2 python-3"
 PKGDEP__PPC64EL="${PKGDEP/luajit/lua}"
+PKGDEP__RISCV64="${PKGDEP/luajit/lua}"
 BUILDDEP="glade gobject-introspection gtk-doc intltool pygobject-3 vala"
 PKGDES="A GObject-based plugins engine"
 


### PR DESCRIPTION
Topic Description
-----------------

Use lua w/o jit for libpeas on riscv64 to make it buildable, as ppc64el already does.

Package(s) Affected
-------------------

- `libpeas`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
