### PR TITLE
gobject-introspection 1.68 rollback

### DIFF
--- a/extra-libs/gobject-introspection/autobuild/defines
+++ b/extra-libs/gobject-introspection/autobuild/defines
@@ -3,6 +3,7 @@ PKGSEC=gnome
 PKGDEP="glib mako"
 BUILDDEP="cairo gtk-doc vim markdown sphinx meson"
 PKGDES="Introspection system for GObject-based libraries"
+PKGEPOCH=1
 
 ABTYPE=meson
 MESON_AFTER="-Dcairo=enabled \

--- a/extra-libs/gobject-introspection/autobuild/patches/0001-doctool-Add-templates_dir-CLI-argument.patch
+++ b/extra-libs/gobject-introspection/autobuild/patches/0001-doctool-Add-templates_dir-CLI-argument.patch
@@ -1,0 +1,79 @@
+From 1beb5832c7e2b6f98abd2378add4b0abf7627af6 Mon Sep 17 00:00:00 2001
+From: Emmanuele Bassi <ebassi@gnome.org>
+Date: Tue, 11 Jan 2022 15:47:50 +0000
+Subject: [PATCH 1/3] doctool: Add templates_dir CLI argument
+
+We can find the templates directory using the module file once
+installed, but when running uninstalled we need to have a way to specify
+where the templates can be found in the sources directory.
+
+Signed-off-by: Camber Huang <camber@poi.science>
+---
+ giscanner/docmain.py   |  4 +++-
+ giscanner/docwriter.py | 14 ++++++++------
+ 2 files changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/giscanner/docmain.py b/giscanner/docmain.py
+index dab063ef..88430f05 100644
+--- a/giscanner/docmain.py
++++ b/giscanner/docmain.py
+@@ -51,6 +51,8 @@ def doc_main(args):
+     parser.add_argument("-s", "--write-sections-file",
+                         action="store_const", dest="format", const="sections",
+                         help="Backwards-compatible equivalent to -f sections")
++    parser.add_argument("--templates-dir",
++                        action="store")
+ 
+     args = parser.parse_args(args[1:])
+     if not args.output:
+@@ -74,7 +76,7 @@ def doc_main(args):
+         with open(args.output, 'w', encoding='utf-8') as fp:
+             write_sections_file(fp, sections_file)
+     else:
+-        writer = DocWriter(transformer, args.language, args.format)
++        writer = DocWriter(transformer, args.language, args.format, args.templates_dir)
+         writer.write(args.output)
+ 
+     return 0
+diff --git a/giscanner/docwriter.py b/giscanner/docwriter.py
+index 786da80d..ce75a28b 100644
+--- a/giscanner/docwriter.py
++++ b/giscanner/docwriter.py
+@@ -1288,7 +1288,7 @@ LANGUAGES = {
+ 
+ 
+ class DocWriter(object):
+-    def __init__(self, transformer, language, output_format):
++    def __init__(self, transformer, language, output_format, templates_dir=None):
+         self._transformer = transformer
+ 
+         try:
+@@ -1300,18 +1300,20 @@ class DocWriter(object):
+         self._formatter = formatter_class(self._transformer)
+         self._language = self._formatter.language
+         self._output_format = output_format
++        self._templates_dir = templates_dir
+ 
+         self._lookup = self._get_template_lookup()
+ 
+     def _get_template_lookup(self):
+-        if 'UNINSTALLED_INTROSPECTION_SRCDIR' in os.environ:
++        if self._templates_dir is not None:
++            srcdir = self._templates_dir
++        elif 'UNINSTALLED_INTROSPECTION_SRCDIR' in os.environ:
+             top_srcdir = os.environ['UNINSTALLED_INTROSPECTION_SRCDIR']
+-            srcdir = os.path.join(top_srcdir, 'giscanner')
++            srcdir = os.path.join(top_srcdir, 'giscanner', 'doctemplates')
+         else:
+-            srcdir = os.path.dirname(__file__)
++            srcdir = os.path.join(os.path.dirname(__file__), 'doctemplates')
+ 
+-        template_dir = os.path.join(srcdir, 'doctemplates',
+-                                    self._formatter.output_format)
++        template_dir = os.path.join(srcdir, self._formatter.output_format)
+ 
+         return TemplateLookup(directories=[template_dir],
+                               module_directory=tempfile.mkdtemp(),
+-- 
+2.37.2
+

--- a/extra-libs/gobject-introspection/autobuild/patches/0002-build-Avoid-the-doctemplates-hack.patch
+++ b/extra-libs/gobject-introspection/autobuild/patches/0002-build-Avoid-the-doctemplates-hack.patch
@@ -1,0 +1,218 @@
+From 62a8388a2548f44bdaa3028f721283bfb84a898b Mon Sep 17 00:00:00 2001
+From: Emmanuele Bassi <ebassi@gnome.org>
+Date: Tue, 11 Jan 2022 15:51:10 +0000
+Subject: [PATCH 2/3] build: Avoid the doctemplates hack
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The hack that copies the doctemplates directory into the build
+directory has stopped working with newer versions of Meson; while it's
+possible to copy files, custom_target() cannot depend on a directory.
+Additionally, the dependency has always been broken.
+
+Instead, we enumerate the template files—after all, it's not like they
+change a lot—and then we list them as dependencies for the test targets.
+
+Fixes: #414
+Signed-off-by: Camber Huang <camber@poi.science>
+---
+ giscanner/doctemplates/devdocs/meson.build | 19 +++++++
+ giscanner/doctemplates/mallard/meson.build | 63 ++++++++++++++++++++++
+ giscanner/meson.build                      | 14 ++---
+ tests/scanner/meson.build                  | 24 +++++----
+ 4 files changed, 98 insertions(+), 22 deletions(-)
+ create mode 100644 giscanner/doctemplates/devdocs/meson.build
+ create mode 100644 giscanner/doctemplates/mallard/meson.build
+
+diff --git a/giscanner/doctemplates/devdocs/meson.build b/giscanner/doctemplates/devdocs/meson.build
+new file mode 100644
+index 00000000..2037182a
+--- /dev/null
++++ b/giscanner/doctemplates/devdocs/meson.build
+@@ -0,0 +1,19 @@
++doc_templates += files([
++  'Gjs/_doc.tmpl',
++  'Gjs/_index.tmpl',
++  'Gjs/_method.tmpl',
++  'Gjs/_methods.tmpl',
++  'Gjs/_properties.tmpl',
++  'Gjs/_signals.tmpl',
++  'Gjs/_staticmethods.tmpl',
++  'Gjs/_vfuncs.tmpl',
++  'Gjs/base.tmpl',
++  'Gjs/callback.tmpl',
++  'Gjs/class.tmpl',
++  'Gjs/default.tmpl',
++  'Gjs/enum.tmpl',
++  'Gjs/function.tmpl',
++  'Gjs/interface.tmpl',
++  'Gjs/method.tmpl',
++  'Gjs/namespace.tmpl',
++])
+diff --git a/giscanner/doctemplates/mallard/meson.build b/giscanner/doctemplates/mallard/meson.build
+new file mode 100644
+index 00000000..5fe4e2af
+--- /dev/null
++++ b/giscanner/doctemplates/mallard/meson.build
+@@ -0,0 +1,63 @@
++base_templates = files([
++  'base.tmpl',
++  'class.tmpl',
++  'namespace.tmpl',
++])
++
++c_templates = files([
++  'C/callback.tmpl',
++  'C/class.tmpl',
++  'C/constructor.tmpl',
++  'C/default.tmpl',
++  'C/enum.tmpl',
++  'C/field.tmpl',
++  'C/function.tmpl',
++  'C/interface.tmpl',
++  'C/method.tmpl',
++  'C/namespace.tmpl',
++  'C/property.tmpl',
++  'C/record.tmpl',
++  'C/signal.tmpl',
++  'C/vfunc.tmpl',
++])
++
++gjs_templates = files([
++  'Gjs/callback.tmpl',
++  'Gjs/class.tmpl',
++  'Gjs/constructor.tmpl',
++  'Gjs/default.tmpl',
++  'Gjs/enum.tmpl',
++  'Gjs/field.tmpl',
++  'Gjs/function.tmpl',
++  'Gjs/interface.tmpl',
++  'Gjs/method.tmpl',
++  'Gjs/namespace.tmpl',
++  'Gjs/property.tmpl',
++  'Gjs/record.tmpl',
++  'Gjs/signal.tmpl',
++  'Gjs/vfunc.tmpl',
++])
++
++py_templates = files([
++  'Python/callback.tmpl',
++  'Python/class.tmpl',
++  'Python/constructor.tmpl',
++  'Python/default.tmpl',
++  'Python/enum.tmpl',
++  'Python/field.tmpl',
++  'Python/function.tmpl',
++  'Python/interface.tmpl',
++  'Python/method.tmpl',
++  'Python/namespace.tmpl',
++  'Python/property.tmpl',
++  'Python/record.tmpl',
++  'Python/signal.tmpl',
++  'Python/vfunc.tmpl',
++])
++
++doc_templates += [
++  base_templates,
++  c_templates,
++  gjs_templates,
++  py_templates,
++]
+diff --git a/giscanner/meson.build b/giscanner/meson.build
+index 098b7b6b..6edba5a9 100644
+--- a/giscanner/meson.build
++++ b/giscanner/meson.build
+@@ -46,17 +46,9 @@ endforeach
+ 
+ install_subdir('doctemplates', install_dir: giscannerdir)
+ 
+-# XXX: this doesn't track the input, but there is nothing to copy many files
+-# in meson.
+-doc_templates = custom_target('copy-templates',
+-  input : 'doctemplates',
+-  output : 'doctemplates',
+-  command : [
+-    python, '-c',
+-      'import sys, shutil;' +
+-      'shutil.rmtree(sys.argv[2], ignore_errors=True);' +
+-      'shutil.copytree(sys.argv[1], sys.argv[2])',
+-    '@INPUT@', '@OUTPUT@'])
++doc_templates = []
++subdir('doctemplates/devdocs')
++subdir('doctemplates/mallard')
+ 
+ flex = find_program('flex', 'win_flex')
+ bison = find_program('bison', 'win_bison')
+diff --git a/tests/scanner/meson.build b/tests/scanner/meson.build
+index fa7f7eca..e86b2443 100644
+--- a/tests/scanner/meson.build
++++ b/tests/scanner/meson.build
+@@ -533,19 +533,26 @@ foreach gir : test_girs
+ endforeach
+ 
+ if has_girdoctool and glib_dep.type_name() == 'pkgconfig'
++  doctool_env = environment()
++  doctool_env.set('srcdir', meson.current_source_dir())
++  doctool_env.set('builddir', meson.current_build_dir())
++
+   foreach language : ['C', 'Python', 'Gjs']
+     regress_docs = custom_target(
+       'generate-docs-' + language,
+       input: regress_gir,
+-      depends: [doc_templates],
++      depend_files: doc_templates,
+       build_by_default: not cairo_deps_found,
++      env: doctool_env,
+       output: 'Regress-1.0-' + language,
+       command: [
+         python, girdoctool,
+         '--add-include-path=' + join_paths(build_root, 'gir'),
+         '--add-include-path=' + meson.current_build_dir(),
+         '--language', language,
+-        '@INPUT@', '-o', '@OUTPUT@'],
++        '--templates-dir=' + join_paths(meson.current_source_dir(), '../../giscanner/doctemplates'),
++        '@INPUT@', '-o', '@OUTPUT@',
++      ],
+     )
+ 
+     if cairo_deps_found
+@@ -554,10 +561,7 @@ if has_girdoctool and glib_dep.type_name() == 'pkgconfig'
+         python,
+         args: [gi_tester, 'Regress-1.0-' + language],
+         depends: [regress_docs],
+-        env: [
+-          'srcdir=' + meson.current_source_dir(),
+-          'builddir=' + meson.current_build_dir(),
+-        ],
++        env: doctool_env,
+       )
+     endif
+   endforeach
+@@ -565,9 +569,10 @@ if has_girdoctool and glib_dep.type_name() == 'pkgconfig'
+   regress_sections = custom_target(
+     'generate-docs-sections',
+     input: regress_gir,
+-    depends: [doc_templates],
++    depend_files: [doc_templates],
+     build_by_default: not cairo_deps_found,
+     output: 'Regress-1.0-sections.txt',
++    env: doctool_env,
+     command: [
+       python, girdoctool,
+       '--add-include-path=' + join_paths(build_root, 'gir'),
+@@ -582,10 +587,7 @@ if has_girdoctool and glib_dep.type_name() == 'pkgconfig'
+       python,
+       args: [gi_tester, 'Regress-1.0-sections.txt'],
+       depends: [regress_sections],
+-      env: [
+-        'srcdir=' + meson.current_source_dir(),
+-        'builddir=' + meson.current_build_dir(),
+-      ],
++      env: doctool_env,
+     )
+   endif
+ endif
+-- 
+2.37.2
+

--- a/extra-libs/gobject-introspection/autobuild/patches/0003-build-Do-not-use-deprecated-API.patch
+++ b/extra-libs/gobject-introspection/autobuild/patches/0003-build-Do-not-use-deprecated-API.patch
@@ -1,0 +1,105 @@
+From 334b17968da44c22ca21041186cfe8b42d409729 Mon Sep 17 00:00:00 2001
+From: Emmanuele Bassi <ebassi@gnome.org>
+Date: Tue, 11 Jan 2022 15:57:37 +0000
+Subject: [PATCH 3/3] build: Do not use deprecated API
+
+Signed-off-by: Camber Huang <camber@poi.science>
+---
+ gir/meson.build   | 37 +++++++++++++++++++++++++++++--------
+ tests/meson.build |  4 ++--
+ 2 files changed, 31 insertions(+), 10 deletions(-)
+
+diff --git a/gir/meson.build b/gir/meson.build
+index 557e5517..0da3094d 100644
+--- a/gir/meson.build
++++ b/gir/meson.build
+@@ -94,8 +94,8 @@ glib_command = scanner_command + [
+ 
+ if dep_type == 'pkgconfig'
+   glib_command += ['--external-library', '--pkg=glib-2.0']
+-  glib_libdir = get_option('gi_cross_pkgconfig_sysroot_path') + glib_dep.get_pkgconfig_variable('libdir')
+-  glib_incdir = get_option('gi_cross_pkgconfig_sysroot_path') + join_paths(glib_dep.get_pkgconfig_variable('includedir'), 'glib-2.0')
++  glib_libdir = get_option('gi_cross_pkgconfig_sysroot_path') + glib_dep.get_variable(pkgconfig: 'libdir')
++  glib_incdir = get_option('gi_cross_pkgconfig_sysroot_path') + join_paths(glib_dep.get_variable(pkgconfig: 'includedir'), 'glib-2.0')
+   glib_libincdir = join_paths(glib_libdir, 'glib-2.0', 'include')
+   glib_files += join_paths(glib_incdir, 'gobject', 'glib-types.h')
+   glib_files += join_paths(glib_libincdir, 'glibconfig.h')
+@@ -134,6 +134,24 @@ elif dep_type == 'internal'
+   endif
+   # We know exactly what headers will be installed, so just fetch that
+   glib_subproject = subproject('glib')
++
++  glibproj_sourcedir = join_paths(meson.project_source_root(), subprojdir, 'glib')
++  glibproj_builddir = join_paths(meson.project_build_root(), subprojdir, 'glib')
++
++  glib_files += join_paths(glibproj_sourcedir, 'gobject', 'glib-types.h')
++
++  # Generated files, relative to the build directory
++  glib_files += [
++    join_paths(glibproj_builddir, 'glib', 'glibconfig.h'),
++    glib_subproject.get_variable('glib_enumtypes_h'),
++  ]
++
++  if giounix_dep.found()
++    glib_files += [
++      join_paths(glibproj_sourcedir, 'glib', 'glib-unix.h'),
++    ]
++  endif
++
+   glib_headers = glib_subproject.get_variable('glib_sub_headers')
+   glib_files += glib_subproject.get_variable('glib_sources')
+   # XXX: Assumes that the builddir layout is 'mirror'
+@@ -151,14 +169,17 @@ elif dep_type == 'internal'
+   # XXX: We need include paths to all glib dependencies too. We assume that the
+   # dependencies are only libffi and proxy-libintl, and that they are used as
+   # subprojects. In the worst case we add paths to non-existent directories.
+-  ffi_incdir = join_paths(meson.build_root(), subprojdir, 'libffi', 'include')
++  ffi_incdir = join_paths(meson.project_build_root(), subprojdir, 'libffi', 'include')
+   glib_includes += ['-I' + ffi_incdir]
+-  intl_incdir = join_paths(meson.source_root(), subprojdir, 'proxy-libintl')
++  intl_incdir = join_paths(meson.project_source_root(), subprojdir, 'proxy-libintl')
+   glib_includes += ['-I' + intl_incdir]
+ 
+-  ffi_libdir = join_paths(meson.build_root(), subprojdir, 'libffi', 'src')
+-  intl_libdir = join_paths(meson.build_root(), subprojdir, 'proxy-libintl')
+-  glib_libpaths = ['-L' + ffi_libdir, '-L' + intl_libdir] + glib_libpaths
++  ffi_libdir = join_paths(meson.project_build_root(), subprojdir, 'libffi', 'src')
++  intl_libdir = join_paths(meson.project_build_root(), subprojdir, 'proxy-libintl')
++  glib_libpaths = [
++    '-L' + ffi_libdir,
++    '-L' + intl_libdir,
++  ] + glib_libpaths
+ 
+   glib_command += glib_libpaths
+ 
+@@ -350,7 +371,7 @@ if giounix_dep.found()
+   dep_type = giounix_dep.type_name()
+   if dep_type == 'pkgconfig'
+     gio_command += ['--pkg=gio-unix-2.0']
+-    giounix_includedir = get_option('gi_cross_pkgconfig_sysroot_path') + join_paths(giounix_dep.get_pkgconfig_variable('includedir'), 'gio-unix-2.0')
++    giounix_includedir = get_option('gi_cross_pkgconfig_sysroot_path') + join_paths(giounix_dep.get_variable(pkgconfig: 'includedir'), 'gio-unix-2.0')
+     # Get the installed gio-unix header list
+     ret = run_command(python, '-c', globber.format(join_paths(giounix_includedir, 'gio', '*.h')))
+     if ret.returncode() != 0
+diff --git a/tests/meson.build b/tests/meson.build
+index b240749e..3fc1e212 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -1,4 +1,4 @@
+-sub_build_root = join_paths(meson.build_root(), 'subprojects')
++sub_build_root = join_paths(meson.project_build_root(), 'subprojects')
+ test_env_common_path = []
+ if glib_dep.type_name() == 'internal' and host_system == 'windows'
+   test_env_common_path += [
+@@ -13,7 +13,7 @@ endif
+ if libffi_dep.type_name() == 'internal' and host_system == 'windows'
+   test_env_common_path += [join_paths(sub_build_root, 'libffi',  'src')]
+ endif
+-test_env_common_pypath = [meson.build_root()]
++test_env_common_pypath = [meson.project_build_root()]
+ 
+ 
+ test_regress_sources = files('scanner/regress.c')
+-- 
+2.37.2
+

--- a/extra-libs/gobject-introspection/spec
+++ b/extra-libs/gobject-introspection/spec
@@ -1,5 +1,4 @@
 VER=1.68.0
-REL=1
 SRCS="https://download.gnome.org/sources/gobject-introspection/${VER:0:4}/gobject-introspection-$VER.tar.xz"
 CHKSUMS="sha256::d229242481a201b84a0c66716de1752bca41db4133672cfcfb37c93eb6e54a27"
 CHKUPDATE="anitya::id=1223"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

The gobject-introspection's amd64 version on the repository differs from version in the ABBS's tree, stable branch. The topic will fix this issue by rolling back the version on amd64 via bumping EPOCH, along with some patches from upstream to fix version 1.68 is failed to build against meson 0.63.0. Patches can be dropped when upgrading to version 1.72.

These patches is tested in my local container environment.
![image](https://user-images.githubusercontent.com/22998116/185740279-c732de4d-d6f6-4b8a-a362-908902f41495.png)

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

gobject-introspection

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

No

Test Build(s) Done
------------------

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [ ] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`
