### PR TITLE
nvidia: upgrade to 515.65.01

### DIFF
--- a/extra-x11/nvidia/spec
+++ b/extra-x11/nvidia/spec
@@ -1,11 +1,11 @@
-VER=515.57
+VER=515.65.01
 _SETTINGS_VER=515.57
 SRCS__AMD64="
 	file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__AMD64="
-	sha256::841d69fe1426883647112bb070fe2f29a1f849c64ac80a8d61c70970d8d3d522
+	sha256::0492ddc5b5e65aa00cbc762e8d6680205c8d08e103b7131087a15126aee495e9
 	sha256::150ac38a0f1ea49db4fd829206aeefadb97fe2b0bb41835f51475ac78220bc01
 "
 SRCS__ARM64="
@@ -13,7 +13,7 @@ SRCS__ARM64="
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__ARM64="
-	sha256::e45e1bd5c6fef6af17caf70b4250b3e1dc2669e1eceec4a21afd4f3aa2899c06
+	sha256::0d2ac6c6ca144c8c7bbf1a62034998463b21f2660a793607d88c031650d93e93
 	sha256::150ac38a0f1ea49db4fd829206aeefadb97fe2b0bb41835f51475ac78220bc01
 "
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This PR updates nvidia to 515.65.01 - this will enable nvidia driver support on linux kernel 5.19+.

Package(s) Affected
-------------------

* nvidia

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

<!-- TODO: CI to auto-fill architectural progress. -->
