### PR TITLE
cheese: fix FTBFS by backporting a patch

### DIFF
--- a/extra-gnome/cheese/autobuild/patches/0002-meson-avoid-positional-arguments-in-merge_file.patch
+++ b/extra-gnome/cheese/autobuild/patches/0002-meson-avoid-positional-arguments-in-merge_file.patch
@@ -1,0 +1,40 @@
+From 5bf958f1d2f67b11ba050aa210a6224e02d499a5 Mon Sep 17 00:00:00 2001
+From: David King <amigadave@amigadave.com>
+Date: Mon, 1 Nov 2021 15:34:26 +0000
+Subject: [PATCH] meson: avoid positional arguments in merge_file
+
+https://gitlab.gnome.org/GNOME/cheese/-/issues/124
+---
+ data/meson.build | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index a355fdec..c877de0c 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -23,10 +23,9 @@ resource_sources = gnome.compile_resources(
+ desktop = cheese_namespace + '.desktop'
+ 
+ i18n.merge_file(
+-  desktop,
+   type: 'desktop',
+   input: desktop + '.in',
+-  output: '@BASENAME@',
++  output: desktop,
+   po_dir: po_dir,
+   install: true,
+   install_dir: cheese_datadir / 'applications',
+@@ -35,9 +34,8 @@ i18n.merge_file(
+ appdata = cheese_namespace + '.appdata.xml'
+ 
+ i18n.merge_file(
+-  appdata,
+   input: appdata + '.in',
+-  output: '@BASENAME@',
++  output: appdata,
+   po_dir: po_dir,
+   install: true,
+   install_dir: cheese_datadir / 'metainfo',
+-- 
+GitLab
+

--- a/extra-gnome/cheese/spec
+++ b/extra-gnome/cheese/spec
@@ -2,4 +2,4 @@ VER=3.38.0
 SRCS="https://download.gnome.org/sources/cheese/${VER:0:4}/cheese-$VER.tar.xz"
 CHKSUMS="sha256::88d2732b421b903110a2628db25c0d61e219c42bdfb5971151033fba95a8d16f"
 CHKUPDATE="anitya::id=5577"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of cheese on current stable.

(Yes, I know GNOME 42 topic will solve this, but how can we wait for that)

Package(s) Affected
-------------------

- `cheese`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
