### PR TITLE
libquvi-scripts: noarchize

### DIFF
--- a/extra-libs/libquvi-scripts/autobuild/defines
+++ b/extra-libs/libquvi-scripts/autobuild/defines
@@ -3,3 +3,5 @@ PKGSEC=libs
 PKGDEP="lua-socket luabitop lua-expat"
 PKGDES="Library for parsing video download links"
 AUTOTOOLS_AFTER="--with-nsfw --with-geoblocked"
+
+ABHOST=noarch

--- a/extra-libs/libquvi-scripts/spec
+++ b/extra-libs/libquvi-scripts/spec
@@ -1,5 +1,5 @@
 VER=0.9.20131130
-REL=3
+REL=4
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/quvi/libquvi-scripts-$VER.tar.xz"
 CHKSUMS="sha256::17f21f9fac10cf60af2741f2c86a8ffd8007aa334d1eb78ff6ece130cb3777e3"
 CHKUPDATE="anitya::id=230127"


### PR DESCRIPTION
Topic Description
-----------------

Make libquvi-scripts noarch, otherwise it will FTBFS because of current AB QA policy.

Package(s) Affected
-------------------

- `libquvi-scripts`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
