### PR TITLE
uhttpmock: drop beyond hack

### DIFF
--- a/extra-libs/uhttpmock/autobuild/beyond
+++ b/extra-libs/uhttpmock/autobuild/beyond
@@ -1,1 +1,0 @@
-chmod -R a-s $SRCDIR

--- a/extra-libs/uhttpmock/spec
+++ b/extra-libs/uhttpmock/spec
@@ -1,4 +1,5 @@
 VER=0.5.3
+REL=1
 SRCS="tbl::https://tecnocode.co.uk/downloads/uhttpmock/uhttpmock-$VER.tar.xz"
 CHKSUMS="sha256::90843223c3a30bdb7f1eb3442373a03fee425af85a9df289cd687698ccff112f"
 CHKUPDATE="anitya::id=5036"


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of uhttpmock by dropping a 7 yrs old beyond script hack that fails (and should be not necessary).

Package(s) Affected
-------------------

- `uhttpmock`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
