### PR TITLE
libquvi: disable RECONF to fix FTBFS

### DIFF
--- a/extra-libs/libquvi/autobuild/defines
+++ b/extra-libs/libquvi/autobuild/defines
@@ -4,3 +4,4 @@ PKGDEP="libquvi-scripts curl lua libproxy libgcrypt glib"
 PKGDES="Library for parsing video download links"
 
 NOPARALLEL=1
+RECONF=0

--- a/extra-libs/libquvi/spec
+++ b/extra-libs/libquvi/spec
@@ -1,5 +1,5 @@
 VER=0.9.4
-REL=3
+REL=4
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/quvi/libquvi-$VER.tar.xz"
 CHKSUMS="sha256::2d3fe28954a68ed97587e7b920ada5095c450105e993ceade85606dadf9a81b2"
 CHKUPDATE="anitya::id=230130"


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of libquvi by disabling RECONF.

Package(s) Affected
-------------------

- `libquvi`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
