### PR TITLE
libquvi: fix FTBFS by importing a patch from Gentoo

### DIFF
--- a/extra-libs/libquvi/autobuild/patches/0001-gentoo-autoconf-2.70.patch
+++ b/extra-libs/libquvi/autobuild/patches/0001-gentoo-autoconf-2.70.patch
@@ -1,0 +1,11 @@
+--- libquvi-0.9.4/configure.ac
++++ libquvi-0.9.4/configure.ac
+@@ -8,7 +8,7 @@
+ AC_INIT([libquvi], m4_esyscmd([./gen-ver.sh -c | tr -d '\n']),
+         [http://quvi.sf.net/bugs/],[],[http://quvi.sf.net/])
+ 
+-AC_DEFINE_UNQUOTED([BUILD_OPTS], "$@",
++AC_DEFINE_UNQUOTED([BUILD_OPTS], "$*",
+   [Define to configure invocation command line options])
+ 
+ # Interface

--- a/extra-libs/libquvi/spec
+++ b/extra-libs/libquvi/spec
@@ -1,5 +1,5 @@
 VER=0.9.4
-REL=3
+REL=4
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/quvi/libquvi-$VER.tar.xz"
 CHKSUMS="sha256::2d3fe28954a68ed97587e7b920ada5095c450105e993ceade85606dadf9a81b2"
 CHKUPDATE="anitya::id=230130"


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of `libquvi` related to new Autoconf by introducing a patch from Gentoo.

Supersedes #4136 .

Package(s) Affected
-------------------

- `libquvi`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
