### PR TITLE
libtommath: disable LTO

### DIFF
--- a/extra-libs/libtommath/autobuild/defines
+++ b/extra-libs/libtommath/autobuild/defines
@@ -4,4 +4,5 @@ PKGDEP="glibc"
 PKGDES="Highly optimized and portable routines for integer based number theoretic applications"
 
 NOSTATIC=0
+NOLTO=1
 NOPARALLEL=1

--- a/extra-libs/libtommath/spec
+++ b/extra-libs/libtommath/spec
@@ -1,4 +1,5 @@
 VER=1.2.0
+REL=1
 SRCS="tbl::https://github.com/libtom/libtommath/releases/download/v$VER/ltm-$VER.tar.xz"
 CHKSUMS="sha256::b7c75eecf680219484055fcedd686064409254ae44bc31a96c5032843c0e18b1"
 CHKUPDATE="anitya::id=15565"


### PR DESCRIPTION
Topic Description
-----------------

Disable LTO for libtommath now because we ship .a file (.a file seems to be used by some package, e.g. clit).

Package(s) Affected
-------------------

- `libtommath`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
