### PR TITLE
lua-expat: Update to 1.4.1

### DIFF
--- a/extra-lua/lua-expat/autobuild/build
+++ b/extra-lua/lua-expat/autobuild/build
@@ -1,3 +1,2 @@
 make LUA_V=5.3 CFLAGS='-DLUA_32BITS'
 make LUA_V=5.3 DESTDIR="$PKGDIR" install
-install -Dm0644 doc/us/license.html "$PKGDIR/usr/share/licenses/$PKGNAME/license.html"

--- a/extra-lua/lua-expat/autobuild/build
+++ b/extra-lua/lua-expat/autobuild/build
@@ -1,2 +1,5 @@
-make LUA_V=5.3 CFLAGS='-DLUA_32BITS'
-make LUA_V=5.3 DESTDIR="$PKGDIR" install
+abinfo "Making binaries ..."
+make LUA_V=5.1 CFLAGS='-DLUA_32BITS'
+
+abinfo "Installing files ..."
+make LUA_V=5.1 DESTDIR="$PKGDIR" install

--- a/extra-lua/lua-expat/spec
+++ b/extra-lua/lua-expat/spec
@@ -1,5 +1,4 @@
-VER=1.3.0
-REL=5
-SRCS="tbl::https://matthewwild.co.uk/projects/luaexpat/luaexpat-$VER.tar.gz"
-CHKSUMS="sha256::d060397960d87b2c89cf490f330508b7def1a0677bdc120531c571609fc57dc3"
+VER=1.4.1
+SRCS="tbl::https://github.com/lunarmodules/luaexpat/archive/refs/tags/${VER}.tar.gz"
+CHKSUMS="sha256::d528060d45865b44bef7215ef8a440165b668f363a4af53358389f0315a8593c"
 CHKUPDATE="anitya::id=11782"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update lua-expat to 1.4.1. Closes #4138 .

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- `lua-expat `

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
