### PR TITLE
gvfs: fix FTBFS by backporting a patch

### DIFF
--- a/extra-libs/gvfs/autobuild/patches/0001-build-remove-incorrect-i18n-merge-file-argument.patch
+++ b/extra-libs/gvfs/autobuild/patches/0001-build-remove-incorrect-i18n-merge-file-argument.patch
@@ -1,0 +1,10 @@
+--- a/daemon/meson.build  2022-08-22 01:26:09.621268600 +0800
++++ b/daemon/meson.build  2022-08-22 01:26:28.178757034 +0800
+@@ -366,7 +366,6 @@
+   )
+ 
+   i18n.merge_file(
+-    policy,
+     input: policy_in,
+     output: '@BASENAME@',
+     po_dir: po_dir,

--- a/extra-libs/gvfs/spec
+++ b/extra-libs/gvfs/spec
@@ -1,5 +1,5 @@
 VER=1.48.0
-REL=2
+REL=3
 SRCS="https://download.gnome.org/sources/gvfs/${VER:0:4}/gvfs-$VER.tar.xz"
 CHKSUMS="sha256::3834797751c4e9f8729e774dee142a474f3361cbc0c12b647606433793eae939"
 CHKUPDATE="anitya::id=5496"


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of gvfs by backporting a patch that fixes some meson.build issue.

Package(s) Affected
-------------------

- `gvfs`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
