### PR TITLE
clit: inject CFLAGS to Makefiles

### DIFF
--- a/extra-utils/clit/autobuild/patch
+++ b/extra-utils/clit/autobuild/patch
@@ -1,3 +1,6 @@
-pushd clit18
-sed -i 's|../libtommath-0.30/|/usr/lib/|' Makefile
-popd
+abinfo "Patching Makefile to use System libtommath ..."
+sed -i 's|../libtommath-0.30/|/usr/lib/|' "$SRCDIR"/clit18/Makefile
+abinfo "Patching Makefiles to inject CFLAGS ..."
+for i in lib clit18; do
+	sed -i "s|CFLAGS=|&${CFLAGS}|g" "$SRCDIR"/$i/Makefile
+done

--- a/extra-utils/clit/spec
+++ b/extra-utils/clit/spec
@@ -1,5 +1,5 @@
 VER=1.8
-REL=5
+REL=6
 SRCS="tbl::http://www.convertlit.com/clit18src.zip"
 CHKSUMS="sha256::d70a85f5b945104340d56f48ec17bcf544e3bb3c35b1b3d58d230be699e557ba"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Inject CFLAGS to Makefiles when building clit, to generate debug info and fix FTBFS due to ABSPLITDBG failure.

Package(s) Affected
-------------------

- `clit`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
