### PR TITLE
kwin: drop dependency kwayland-server

### DIFF
--- a/extra-kde/kwin/autobuild/defines
+++ b/extra-kde/kwin/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=kwin
 PKGSEC=kde
 PKGDEP="breeze hicolor-icon-theme knewstuff kscreenlocker plasma-framework \
-        xcb-util-cursor attica5 xorg-server kwayland-server \
+        xcb-util-cursor attica5 xorg-server \
         krunner libqaccessibilityclient"
 BUILDDEP="extra-cmake-modules kdoctools plasma-wayland-protocols"
 PKGDES="The KDE Window Manager"

--- a/extra-kde/kwin/spec
+++ b/extra-kde/kwin/spec
@@ -1,4 +1,5 @@
 VER=5.25.3
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwin-$VER.tar.xz"
 CHKSUMS="sha256::52927c7b6a2f28c6b8a515b1eb6f7faeacdc0d53321290887ebaffb9ab2fd0ef"
 CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
Topic Description
-----------------

Drop kwin's dependency on now nonexistent kwayland-server package.

Package(s) Affected
-------------------

- `kwin`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
