### PR TITLE
catdoc: disable parallelism when installing

### DIFF
--- a/extra-productivity/catdoc/autobuild/build
+++ b/extra-productivity/catdoc/autobuild/build
@@ -1,6 +1,9 @@
+abinfo "Configuring ..."
 ./configure --prefix=/usr
+abinfo "Making ..."
 make
-
-make installroot="$PKGDIR" mandir=/usr/share/man/man1 install
+abinfo "Installing ..."
+make installroot="$PKGDIR" mandir=/usr/share/man/man1 install -j1
+abinfo "Installint manpages ..."
 install -d "$PKGDIR"/usr/share/man/man1
-install -m644 doc/*.1 "$PKGDIR"/usr/share/man/man1
+install -m644 "$SRCDIR"/doc/*.1 "$PKGDIR"/usr/share/man/man1

--- a/extra-productivity/catdoc/spec
+++ b/extra-productivity/catdoc/spec
@@ -1,4 +1,5 @@
 VER=0.95
+REL=1
 SRCS="tbl::http://http.debian.net/debian/pool/main/c/catdoc/catdoc_0.94.4.orig.tar.gz"
 CHKSUMS="sha256::c06fd69d2a218fcc2ed1320988cef07a67cf5555a12f25752766d746e25758ee"
 CHKUPDATE="anitya::id=13398"


### PR DESCRIPTION
Topic Description
-----------------

Disable parallelism when installing catdoc, to prevent random failure.

Package(s) Affected
-------------------

- `catdoc`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
