### PR TITLE
nautilus: fix FTBFS by backporting a patch

### DIFF
--- a/extra-gnome/nautilus/autobuild/patches/0001-build-remove-incorrect-i18n-merge-file-argument.patch
+++ b/extra-gnome/nautilus/autobuild/patches/0001-build-remove-incorrect-i18n-merge-file-argument.patch
@@ -1,0 +1,44 @@
+From 42b0362e9844f4c5114b21464185620eaadcfcaa Mon Sep 17 00:00:00 2001
+From: Albert Vaca Cintora <albertvaka@gmail.com>
+Date: Mon, 25 Oct 2021 00:07:52 +0200
+Subject: [PATCH] build: Remove incorrect i18n.merge_file argument
+
+The positional argument was being silently ignored until meson 0.60.0 where
+it fails with "ERROR: Function does not take positional arguments".
+
+See: https://github.com/mesonbuild/meson/issues/9441
+---
+ data/meson.build | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index f27426a5c..913ffd7b8 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -20,7 +20,6 @@ desktop_conf = configuration_data()
+ desktop_conf.set('icon', application_id)
+ 
+ desktop = i18n.merge_file(
+-  'desktop',
+   input: configure_file(
+     input: files('org.gnome.Nautilus.desktop.in.in'),
+     output: 'org.gnome.Nautilus.desktop.in',
+@@ -34,7 +33,6 @@ desktop = i18n.merge_file(
+ )
+ 
+ desktop_autorun_software = i18n.merge_file(
+-  'desktop-autorun-software',
+   input: 'nautilus-autorun-software.desktop.in',
+   output: 'nautilus-autorun-software.desktop',
+   install: true,
+@@ -48,7 +46,6 @@ appdata_conf = configuration_data()
+ appdata_conf.set('appid', application_id)
+ 
+ appdata = i18n.merge_file(
+-  'appdata',
+   input: configure_file(
+     input: files('org.gnome.Nautilus.appdata.xml.in.in'),
+     output: 'org.gnome.Nautilus.appdata.xml.in',
+-- 
+GitLab
+

--- a/extra-gnome/nautilus/spec
+++ b/extra-gnome/nautilus/spec
@@ -1,4 +1,5 @@
 VER=40.2
+REL=1
 SRCS="https://download.gnome.org/sources/nautilus/${VER%.*}/nautilus-$VER.tar.xz"
 CHKSUMS="sha256::b71ef2fe07e5eea89a2bb1e5bd30947bd18873bfb30f79cbf17edfbd4d20f60d"
 CHKUPDATE="anitya::id=2050"


### PR DESCRIPTION
Topic Description
-----------------

Fixes FTBFS of `nautilus` by backporting a patch that changes meson.build.

Package(s) Affected
-------------------

- `nautilus`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
