### PR TITLE
gstreamer-0-10: fix a macro definition incompatible w/ GCC11

### DIFF
--- a/extra-multimedia/gstreamer-0-10/autobuild/patch
+++ b/extra-multimedia/gstreamer-0-10/autobuild/patch
@@ -1,2 +1,8 @@
-patch -Np1 -i autobuild/patches/bison3.patch
+for i in "$SRCDIR"/autobuild/patches/*
+do
+	abinfo "Applying $i ..."
+	patch -Np1 -i $i
+done
+
+abinfo "Fixing outdated configure.ac directive ..."
 sed -e 's/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/' -i configure.ac

--- a/extra-multimedia/gstreamer-0-10/autobuild/patches/0001-fix-for-gcc11.patch
+++ b/extra-multimedia/gstreamer-0-10/autobuild/patches/0001-fix-for-gcc11.patch
@@ -1,0 +1,12 @@
+diff -Naur gstreamer-old/gst/gstutils.h gstreamer/gst/gstutils.h
+--- gstreamer-old/gst/gstutils.h	2020-09-25 09:34:16.000000000 +0800
++++ gstreamer/gst/gstutils.h	2022-08-23 16:28:30.150194228 +0800
+@@ -136,7 +136,7 @@
+   /* The typedef for GType may be gulong or gsize, depending on the	\
+    * system and whether the compiler is c++ or not. The g_once_init_*	\
+    * functions always take a gsize * though ... */			\
+-  static volatile gsize gonce_data = 0;					\
++  static gsize gonce_data = 0;						\
+   if (g_once_init_enter (&gonce_data)) {				\
+     GType _type;							\
+     _type = gst_type_register_static_full (parent_type_macro,           \

--- a/extra-multimedia/gstreamer-0-10/spec
+++ b/extra-multimedia/gstreamer-0-10/spec
@@ -1,3 +1,4 @@
 VER=0.10.36+git20130918
+REL=1
 SRCS="tbl::https://repo.aosc.io/aosc-repacks/gstreamer-0.10.30%2Bgit20130918.tar.xz"
 CHKSUMS="sha256::cff8957a3ad3e6ced2c184ea082cc7225b6bb6e9a7db4e25a32b467eb5e66b36"


### PR DESCRIPTION
Topic Description
-----------------

Fix some GCC11-incompatibility in a header file provided by `gstreamer-0-10`.

This fixes FTBFS of `gst-plugins-good-0-10`.

Package(s) Affected
-------------------

- `gstreamer-0-10`

Security Update?
----------------

No

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
