### PR TITLE
kalarmcal: drop

### DIFF
--- a/extra-kde/kalarm/autobuild/defines
+++ b/extra-kde/kalarm/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=kalarm
 PKGSEC=kde
-PKGDEP="kalarmcal kidletime kmailtransport knotifyconfig perl phonon pimcommon"
+PKGDEP="kidletime kmailtransport knotifyconfig perl phonon pimcommon kholidays kcalutils"
 BUILDDEP="boost extra-cmake-modules kdesignerplugin kdoctools"
 PKGDES="Personal alarm scheduler"
 

--- a/extra-kde/kalarm/spec
+++ b/extra-kde/kalarm/spec
@@ -1,4 +1,5 @@
 VER=22.04.3
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kalarm-$VER.tar.xz"
 CHKSUMS="sha256::5b5987ab64e6d226311de0ba98dfc3408b311476d4d7a007a7ce13edf1ccaad8"
 CHKUPDATE="anitya::id=8763"

--- a/extra-kde/kalarmcal/autobuild/defines
+++ b/extra-kde/kalarmcal/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=kalarmcal
-PKGSEC=kde
-PKGDEP="akonadi kcalendarcore kholidays kidentitymanagement kcalutils"
-BUILDDEP="boost extra-cmake-modules kdesignerplugin kdoctools"
-PKGDES="KDE Alarm and Calendar library"
-
-PKGREP="kde-l10n<=16.12.3"
-PKGBREAK="kde-l10n<=16.12.3"

--- a/extra-kde/kalarmcal/spec
+++ b/extra-kde/kalarmcal/spec
@@ -1,4 +1,0 @@
-VER=21.12.3
-SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kalarmcal-$VER.tar.xz"
-CHKSUMS="sha256::194f97ee30c8382ac7fd80432e72f04f5db3f3fe4a009ab487c82c014eae1798"
-CHKUPDATE="anitya::id=8763"

--- a/extra-kde/kdepim-runtime/autobuild/defines
+++ b/extra-kde/kdepim-runtime/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=kdepim-runtime
 PKGSEC=kde
-PKGDEP="akonadi-calendar akonadi-notes kalarmcal kimap kmbox knotifyconfig \
-        kross libkgapi syndication kdav pimcommon qca"
+PKGDEP="akonadi-calendar akonadi-notes kimap kmbox knotifyconfig \
+        kross libkgapi syndication kdav pimcommon qca kholidays"
 PKGDEP__NOWEBENGINE="${PKGDEP/libkgapi/}"
 PKGDEP__LOONGSON3="${PKGDEP__NOWEBENGINE}"
 PKGDEP__PPC64EL="${PKGDEP__NOWEBENGINE}"

--- a/extra-kde/kdepim-runtime/spec
+++ b/extra-kde/kdepim-runtime/spec
@@ -1,4 +1,5 @@
 VER=22.04.3
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kdepim-runtime-$VER.tar.xz"
 CHKSUMS="sha256::475845d0321af2507e90ec9876434998e61748bc847fe6aa4295762b9b6313d2"
 CHKUPDATE="anitya::id=8763"

--- a/extra-kde/pim-data-exporter/autobuild/defines
+++ b/extra-kde/pim-data-exporter/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=pim-data-exporter
 PKGSEC=kde
-PKGDEP="calendarsupport kalarmcal mailcommon"
+PKGDEP="calendarsupport mailcommon"
 BUILDDEP="boost extra-cmake-modules kdesignerplugin kdoctools"
 PKGDES="Import and export KDE PIM settings"
 

--- a/extra-kde/pim-data-exporter/spec
+++ b/extra-kde/pim-data-exporter/spec
@@ -1,4 +1,5 @@
 VER=22.04.3
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/pim-data-exporter-$VER.tar.xz"
 CHKSUMS="sha256::3680f8ca81de2bb81652bf8dd3041ee734f68273c1bab28cae7120fa5b42dab9"
 CHKUPDATE="anitya::id=8763"


### PR DESCRIPTION
Topic Description
-----------------

This topic drops an upstream dropped package, kalarmcal. The functionality of this is merged into the packages that used to depend on it.

Package(s) Affected
-------------------

- `kdepim-runtime`
- `pim-data-exporter`
- `kalarm`

Security Update?
----------------

No

Build Order
-----------

`kdepim-runtime pim-data-exporter kalarm`

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
