### PR TITLE
enblend-enfuse: fix FTBFS by explicitly specify C++14

### DIFF
--- a/extra-creativity/enblend-enfuse/autobuild/prepare
+++ b/extra-creativity/enblend-enfuse/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Injecting flags for C++14 ..."
+export CXXFLAGS="$CXXFLAGS -std=gnu++14"

--- a/extra-creativity/enblend-enfuse/spec
+++ b/extra-creativity/enblend-enfuse/spec
@@ -1,5 +1,5 @@
 VER=4.2
-REL=7
+REL=8
 SRCS="tbl::https://sourceforge.net/projects/enblend/files/enblend-enfuse/enblend-enfuse-${VER:0:3}/enblend-enfuse-$VER.tar.gz"
 CHKSUMS="sha256::8703e324939ebd70d76afd350e56800f5ea2c053a040a5f5218b2a1a4300bd48"
 CHKUPDATE="anitya::id=17784"


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of enblend-enfuse, some out-of-date code that targets at most c++14.

Package(s) Affected
-------------------

`enblend-enfuse`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
