### PR TITLE
libgpod: add missing builddep gtk-doc

### DIFF
--- a/extra-libs/libgpod/autobuild/defines
+++ b/extra-libs/libgpod/autobuild/defines
@@ -14,12 +14,13 @@ PKGDEP__I486="${PKGDEP__RETRO}"
 PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
-BUILDDEP="intltool"
+BUILDDEP="intltool gtk-doc"
 BUILDDEP__AMD64="${BUILDDEP} mono"
 BUILDDEP__ARM64="${BUILDDEP} mono"
 
 AUTOTOOLS_AFTER="--with-udev-dir=/usr/lib/udev \
                  --enable-udev \
+                 --enable-gtk-doc \
                  --with-python=/usr/bin/python2"
 AUTOTOOLS_AFTER__AMD64=" \
                  ${AUTOTOOLS_AFTER} \

--- a/extra-libs/libgpod/spec
+++ b/extra-libs/libgpod/spec
@@ -1,5 +1,5 @@
 VER=0.8.3
-REL=9
+REL=10
 SRCS="tbl::https://sourceforge.net/projects/gtkpod/files/libgpod/libgpod-${VER:0:3}/libgpod-$VER.tar.bz2"
 CHKSUMS="sha256::638a7959d04e95f1e62abad02bd33702e4e8dfef98485ac7d9d50395c37e955d"
 CHKUPDATE="anitya::id=229568"


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of libgpod by adding missing builddep gtk-doc.

Package(s) Affected
-------------------

- `libgpod`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
