### PR TITLE
pahole: revert to 1.22 from 1.24

### DIFF
--- a/extra-utils/pahole/autobuild/defines
+++ b/extra-utils/pahole/autobuild/defines
@@ -2,5 +2,6 @@ PKGNAME=pahole
 PKGSEC=utils
 PKGDEP="elfutils zlib"
 PKGDES="Object file and debug information analysis utility"
+PKGEPOCH=1
 
 CMAKE_AFTER="-DLIB_INSTALL_DIR=/usr/lib"

--- a/extra-utils/pahole/spec
+++ b/extra-utils/pahole/spec
@@ -1,4 +1,4 @@
-VER=1.24
+VER=1.22
 SRCS="git::commit=tags/v$VER::https://git.kernel.org/pub/scm/devel/pahole/pahole.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231624"


### PR DESCRIPTION
Topic Description
-----------------

This reverts commit c9f9808c3c7eecab27ee5bd7ef41e658cea95c6d.
Kernel build fails with pahole 1.24 with "invalid argument". Reverting
until kernel devs handle this change.

Package(s) Affected
-------------------

pahole


Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
