### PR TITLE
cmake: backport an upstream patch to fix FindOpenMP on riscv64

### DIFF
--- a/extra-devel/cmake/autobuild/patches/0001-find-openmp-from-system-paths.patch
+++ b/extra-devel/cmake/autobuild/patches/0001-find-openmp-from-system-paths.patch
@@ -1,0 +1,34 @@
+From 09b4e870a5f4725f1529e2f4a998d563d8796b19 Mon Sep 17 00:00:00 2001
+From: Sprite <SpriteOvO@gmail.com>
+Date: Sun, 31 Jul 2022 16:45:50 +0800
+Subject: [PATCH] FindOpenMP: Restore searching system paths
+
+In commit 98314d536e (FindOpenMP: Use NO_DEFAULT_PATH where appropriate,
+2017-11-15, v3.11.0-rc1~334^2) we added `NO_DEFAULT_PATH` so that it no
+longer searches in `CMAKE_PREFIX_PATH`, but this also excludes searching
+in system paths, which are needed on RISC-V platforms.  Use more granular
+exclusions instead.
+
+Fixes: #23469
+---
+ Modules/FindOpenMP.cmake | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/Modules/FindOpenMP.cmake b/Modules/FindOpenMP.cmake
+index 0590a28e05..844ceb36a4 100644
+--- a/Modules/FindOpenMP.cmake
++++ b/Modules/FindOpenMP.cmake
+@@ -279,7 +279,9 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
+                 DOC "Path to the ${_OPENMP_IMPLICIT_LIB_PLAIN} library for OpenMP"
+                 HINTS ${OpenMP_${LANG}_IMPLICIT_LINK_DIRS}
+                 CMAKE_FIND_ROOT_PATH_BOTH
+-                NO_DEFAULT_PATH
++                NO_PACKAGE_ROOT_PATH
++                NO_CMAKE_PATH
++                NO_CMAKE_ENVIRONMENT_PATH
+               )
+             endif()
+             mark_as_advanced(OpenMP_${_OPENMP_IMPLICIT_LIB_PLAIN}_LIBRARY)
+-- 
+GitLab
+

--- a/extra-devel/cmake/spec
+++ b/extra-devel/cmake/spec
@@ -1,4 +1,5 @@
 VER=3.23.0
+REL=1
 SRCS="tbl::https://cmake.org/files/v${VER:0:4}/cmake-$VER.tar.gz"
 CHKSUMS="sha256::5ab0a12f702f44013be7e19534cd9094d65cc9fe7b2cd0f8c9e5318e0fe4ac82"
 CHKUPDATE="anitya::id=306"


### PR DESCRIPTION
Topic Description
-----------------

Backport a patch for `cmake` to fix FindOpenMP on riscv64.

A test case could be building the `cryfs` package.

Package(s) Affected
-------------------

- `cmake`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
