### PR TITLE
Permission rework: some files in `/usr/lib/python3.x` is not world readable

### DIFF
--- a/extra-python/diff-match-patch/spec
+++ b/extra-python/diff-match-patch/spec
@@ -1,5 +1,4 @@
-VER=20121119
+VER=20200713
 SRCS="tbl::https://pypi.io/packages/source/d/diff-match-patch/diff-match-patch-$VER.tar.gz"
-CHKSUMS="sha256::9dba5611fbf27893347349fd51cc1911cb403682a7163373adacc565d11e2e4c"
-REL=2
+CHKSUMS="sha256::da6f5a01aa586df23dfc89f3827e1cafbb5420be9d87769eeb079ddfd9477a18"
 CHKUPDATE="anitya::id=12238"

--- a/extra-python/pynput/autobuild/beyond
+++ b/extra-python/pynput/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Setting sane permission on python modules"
+find "${PKGDIR}"/usr/lib/python${ABPY3VER}/site-packages/pynput-${PKGVER}-py${ABPY3VER}.egg-info \
+	-type f -exec chmod -v 0644 {} \;

--- a/extra-python/pynput/spec
+++ b/extra-python/pynput/spec
@@ -1,4 +1,5 @@
 VER=1.7.6
+REL=1
 SRCS="tbl::https://pypi.io/packages/source/p/pynput/pynput-$VER.tar.gz"
 CHKSUMS="sha256::3a5726546da54116b687785d38b1db56997ce1d28e53e8d22fc656d8b92e533c"
 CHKUPDATE="anitya::id=38490"

--- a/extra-python/sputnik/autobuild/beyond
+++ b/extra-python/sputnik/autobuild/beyond
@@ -1,0 +1,5 @@
+for V in ${ABPY2VER} ${ABPY3VER}; do
+	abinfo "Setting sane permission on python ${V} modules"
+	find "${PKGDIR}"/usr/lib/python${V}/site-packages/${PKGNAME}-${PKGVER}-py${V}.egg-info \
+	-type f -exec chmod -v 0644 {} \;
+done

--- a/extra-python/sputnik/spec
+++ b/extra-python/sputnik/spec
@@ -1,5 +1,5 @@
 VER=0.9.3
-REL=4
+REL=5
 SRCS="tbl::https://pypi.io/packages/source/s/sputnik/sputnik-$VER.tar.gz"
 CHKSUMS="sha256::2a2a506a2d68383f73dc7a546957714d316e23ce558e8d9115674f899d1f1273"
 CHKUPDATE="anitya::id=231397"

--- a/extra-utils/patool/autobuild/beyond
+++ b/extra-utils/patool/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Setting sane permission on python modules"
+find "${PKGDIR}"/usr/lib/python${ABPY3VER}/site-packages/patool-${PKGVER}-py${ABPY3VER}.egg-info \
+	-type f -exec chmod -v 0644 {} \;

--- a/extra-utils/patool/spec
+++ b/extra-utils/patool/spec
@@ -1,4 +1,5 @@
 VER=1.12
+REL=1
 SRCS="tbl::https://pypi.python.org/packages/source/p/patool/patool-$VER.tar.gz"
 CHKSUMS="sha256::e3180cf8bfe13bedbcf6f5628452fca0c2c84a3b5ae8c2d3f55720ea04cb1097"
 CHKUPDATE="anitya::id=19018"


### PR DESCRIPTION
Topic Description
-----------------

This PR fixes an issue where the affected python modules may contain files that are not world readable (but should be world readable). Tools that scan `/usr/lib/python3.10` (i.e. pip) for package info and software that explicitly depend on the following packages will error out as they don't expect unreadable egg-info files.

To prevent this kind of issue in the future, autobuild3 should be augmented to enforce world readable permissions for python packages built by templates `15-python` and `14-pep517`.

Package(s) Affected
-------------------

- diff-match-patch
- patool
- pynput - breaks certbot
- sputnik

Build Order
-----------

Build order is not significant - all of these are noarch packages.

diff-match-patch patool pynput sputnik

Test Build(s) Done
------------------

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

- [x] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
