### PR TITLE
xarchiver: disable RECONF

### DIFF
--- a/extra-utils/xarchiver/autobuild/defines
+++ b/extra-utils/xarchiver/autobuild/defines
@@ -3,3 +3,5 @@ PKGSEC=utils
 PKGDEP="cpio gtk-3 lzop p7zip unrar unzip zip"
 BUILDDEP="docbook-xsl intltool xmlto"
 PKGDES="GTK+ frontend to various command line archivers"
+
+RECONF=0

--- a/extra-utils/xarchiver/spec
+++ b/extra-utils/xarchiver/spec
@@ -1,4 +1,5 @@
 VER=0.5.4.15
+REL=1
 SRCS="tbl::https://github.com/ib/xarchiver/archive/$VER.tar.gz"
 CHKSUMS="sha256::2a18f5a8932516ecc5c50152ff6ce77bc3f58a0b221d6db9c70d089cf90d7182"
 CHKUPDATE="anitya::id=5157"


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of `xarchiver` by disabling RECONF.

Package(s) Affected
-------------------

- `xarchiver`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
