### PR TITLE
keybinder-3.0: add missing builddep gtk-doc and gobject-introspection

### DIFF
--- a/extra-libs/keybinder-3.0/autobuild/defines
+++ b/extra-libs/keybinder-3.0/autobuild/defines
@@ -1,4 +1,7 @@
 PKGNAME=keybinder-3.0
 PKGSEC=libs
 PKGDEP="gtk-3"
+BUILDDEP="gtk-doc gobject-introspection"
 PKGDES="A library for registering global keyboard shortcuts"
+
+AUTOTOOLS_AFTER="--disable-gtk-doc --enable-introspection"


### PR DESCRIPTION
Topic Description
-----------------

Add two missing builddeps to `keybinder-3.0`, both as FTBFS fix and being explicit.

Package(s) Affected
-------------------

- `keybinder-3.0`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
