### PR TITLE
cppcheck: update to 2.8

### DIFF
--- a/extra-devel/cppcheck/spec
+++ b/extra-devel/cppcheck/spec
@@ -1,4 +1,4 @@
-VER=2.3
+VER=2.8
 SRCS="tbl::https://sourceforge.net/projects/cppcheck/files/cppcheck/$VER/cppcheck-${VER}.tar.gz"
-CHKSUMS="sha256::695ab99ade350c89f41e730c6de87b611e5d0a0cdde5bb0abaf9241fc6d7c483"
+CHKSUMS="sha256::57298f3b805f0eb816a04115fbc70e701f75083cfb0305a44246e365cf27606a"
 CHKUPDATE="anitya::id=357"


### PR DESCRIPTION
Topic Description
-----------------

Update `cppcheck` to 2.8, as the version in ABBS tree (2.3) could no longer be built with current GCC.

Package(s) Affected
-------------------

- `cppcheck`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
