### PR TITLE
farstream: add builddep gtk-doc

### DIFF
--- a/extra-network/farstream/autobuild/defines
+++ b/extra-network/farstream/autobuild/defines
@@ -2,7 +2,8 @@ PKGNAME=farstream
 PKGSEC=net
 PKGDEP="gst-plugins-base-1-0 libnice"
 PKGSUG="gst-plugins-bad-1-0 gst-plugins-good-1-0"
-BUILDDEP="gobject-introspection"
+BUILDDEP="gobject-introspection gtk-doc"
 PKGDES="Audio/video communications framework"
 
 NOPARALLEL=1
+AUTOTOOLS_AFTER="--enable-introspection --disable-gtk-doc"

--- a/extra-network/farstream/spec
+++ b/extra-network/farstream/spec
@@ -1,4 +1,5 @@
 VER=0.2.9
+REL=1
 SRCS="tbl::https://freedesktop.org/software/farstream/releases/farstream/farstream-$VER.tar.gz"
 CHKSUMS="sha256::cb7d112433cf7c2e37a8ec918fb24f0ea5cb293cfa1002488e431de26482f47b"
 CHKUPDATE="anitya::id=13757"


### PR DESCRIPTION
Topic Description
-----------------

Add `gtk-doc` as builddep of farstream to fix FTBFS.

Package(s) Affected
-------------------

- `farstream`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
