### PR TITLE
chisel: new, 1.7.7

### DIFF
--- a/extra-network/chisel/autobuild/build
+++ b/extra-network/chisel/autobuild/build
@@ -1,0 +1,11 @@
+# Enabling buildmode=pie for security features, where Go GC Compiler hasn't supported on MIPS yet.
+if ! ab_match_arch loongson3; then
+    abinfo "Enabling buildmode=pie ..."
+    export GOFLAGS="${GOFLAGS} -buildmode=pie"
+fi
+
+abinfo "Building chisel..."
+go build
+
+abinfo "Installing the binary..."
+install -Dvm755 "$SRCDIR"/chisel "$PKGDIR"/usr/bin/chisel

--- a/extra-network/chisel/autobuild/defines
+++ b/extra-network/chisel/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=chisel
+PKGSEC=net
+PKGDES="A TCP/UDP tunnel over HTTP "
+BUILDDEP="go"
+ABSPLITDBG=0

--- a/extra-network/chisel/spec
+++ b/extra-network/chisel/spec
@@ -1,0 +1,4 @@
+VER="1.7.7"
+SRCS="https://github.com/jpillora/chisel/archive/v$VER.tar.gz"
+CHKSUMS="sha256::82926c7d2b13fa3bdfe0997f6ffdeb7b42709ab328ca07b3b65e97c2827c0d27"
+CHKUPDATE="anitya::id=135401"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Trying to introduce chisel, A fast TCP/UDP tunnel over HTTP.

Package(s) Affected
-------------------

No

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
