### PR TITLE
qt-5: small adaptions for riscv64

### DIFF
--- a/extra-libs/qt-5/autobuild/build
+++ b/extra-libs/qt-5/autobuild/build
@@ -21,6 +21,11 @@ if [[ "${CROSS:-$ARCH}" = "armv4" || \
     OPENGL="-opengl es2"
 fi
 
+if [[ "${CROSS:-$ARCH}" != "riscv64" ]]; then
+    abinfo "Using Gold linker on non riscv64 ..."
+    GOLD="-use-gold-linker"
+fi
+
 abinfo "Configuring Qt 5 ..."
 "$SRCDIR"/configure \
         -release \
@@ -40,7 +45,6 @@ abinfo "Configuring Qt 5 ..."
         -shared \
         -nomake tests \
         -no-rpath \
-        -use-gold-linker \
         -no-reduce-relocations \
         -accessibility \
         -fontconfig \
@@ -62,7 +66,7 @@ abinfo "Configuring Qt 5 ..."
         -libinput \
         -libproxy \
         -feature-vulkan \
-        $QTWEOPT $SSEOPT $OPENGL
+        $QTWEOPT $SSEOPT $OPENGL $GOLD
 
 abinfo "Building Qt 5 ..."
 make V=1 VERBOSE=1

--- a/extra-libs/qt-5/autobuild/defines
+++ b/extra-libs/qt-5/autobuild/defines
@@ -22,6 +22,7 @@ PKGDEP_NOWEBENGINE="alsa-lib bluez cups dbus desktop-file-utils \
         xcb-util-wm xdg-utils zlib"
 PKGDEP__LOONGSON3="${PKGDEP_NOWEBENGINE}"
 PKGDEP__PPC64EL="${PKGDEP_NOWEBENGINE}"
+PKGDEP__RISCV64="${PKGDEP_NOWEBENGINE}"
 
 ABTYPE=self
 

--- a/extra-libs/qt-5/spec
+++ b/extra-libs/qt-5/spec
@@ -1,4 +1,5 @@
 VER=5.15.5+webengine5.15.10+webkit5.212.0+kde20220705
+REL=1
 SRCS="https://repo.aosc.io/aosc-repacks/qt-5-$VER.tar.xz"
 CHKSUMS="sha256::724101b5dbb845579b636bca4f89e12bacee736af57dbc78e30fe83a62092165"
 SUBDIR="qt-${VER:0:1}"


### PR DESCRIPTION
Topic Description
-----------------

Disables Gold and use dependency w/o WebEngine for qt-5 on riscv64.

Package(s) Affected
-------------------

- `qt-5`

(Some rebuild may be needed after this on riscv64, for already being built and linked to old qt-5, but they will come as another topic)

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
