### PR TITLE
gdb: switch the scripting system to Python 3

### DIFF
--- a/extra-devel/gdb/autobuild/defines
+++ b/extra-devel/gdb/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gdb
 PKGSEC=devel
-PKGDEP="babeltrace elfutils expat glibc-dbg guile isl python-2 readline xz xxhash source-highlight ncurses"
+PKGDEP="babeltrace elfutils expat glibc-dbg guile isl python-3 readline xz xxhash source-highlight ncurses"
 PKGDEP__RETRO="expat glibc-dbg isl readline"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
@@ -14,7 +14,7 @@ PKGDES="GNU source-level debugger for multiple programming languages"
 AUTOTOOLS_STRICT=0
 AUTOTOOLS_DEF="--prefix=/usr"
 AUTOTOOLS_AFTER="--with-system-readline --with-xxhash \
-                 --with-python=/usr/bin/python2 \
+                 --with-python=/usr/bin/python3 \
                  --with-system-gdbinit=/etc/gdb/gdbinit \
                  --enable-guile --enable-tui --enable-sim \
                  --enable-source-highlight --enable-threading \

--- a/extra-devel/gdb/spec
+++ b/extra-devel/gdb/spec
@@ -1,4 +1,5 @@
 VER=12.1
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/gdb/gdb-$VER.tar.xz"
 CHKSUMS="sha256::0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed"
 CHKUPDATE="anitya::id=11798"

--- a/extra-libs/source-highlight/autobuild/patches/0001-adapt-to-cxx-17.patch
+++ b/extra-libs/source-highlight/autobuild/patches/0001-adapt-to-cxx-17.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/srchilite/fileutil.cc b/lib/srchilite/fileutil.cc
+index 59a6d64..b7aa3a9 100644
+--- a/lib/srchilite/fileutil.cc
++++ b/lib/srchilite/fileutil.cc
+@@ -48,7 +48,7 @@ void set_file_util_verbose(bool b) {
+ // FIXME avoid using a global variable
+ std::string start_path;
+ 
+-string readFile(const string &fileName) throw (IOException) {
++string readFile(const string &fileName) noexcept(false) {
+     ifstream file(fileName.c_str());
+ 
+     if (!file.is_open()) {
+diff --git a/lib/srchilite/fileutil.h b/lib/srchilite/fileutil.h
+index 7335a9b..456386c 100644
+--- a/lib/srchilite/fileutil.h
++++ b/lib/srchilite/fileutil.h
+@@ -27,7 +27,7 @@ extern std::string start_path;
+  * @return the contents of the file
+  * @throw IOException
+  */
+-string readFile(const string &fileName) throw (IOException);
++string readFile(const string &fileName) noexcept(false);
+ 
+ //char *read_file(const string &fileName);
+ 


### PR DESCRIPTION
Topic Description
-----------------

gdb: switch the scripting system to Python 3

Package(s) Affected
-------------------

`gdb`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [X] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

