### PR TITLE
minicom: update to 2.8

### DIFF
--- a/extra-utils/minicom/autobuild/defines
+++ b/extra-utils/minicom/autobuild/defines
@@ -1,6 +1,5 @@
 PKGNAME=minicom
 PKGSEC=utils
-PKGDEP="glibc"
+PKGDEP="glibc ncurses"
+PKGRECOM="lrzsz"
 PKGDES="A text-based modem control and terminal emulation program"
-
-RECONF=0

--- a/extra-utils/minicom/spec
+++ b/extra-utils/minicom/spec
@@ -1,5 +1,4 @@
-VER=2.7.1
-REL=1
-SRCS="tbl::https://alioth-archive.debian.org/releases/minicom/Source/$VER/minicom-$VER.tar.gz"
-CHKSUMS="sha256::532f836b7a677eb0cb1dca8d70302b73729c3d30df26d58368d712e5cca041f1"
+VER=2.8
+SRCS="git::commit=tags/v${VER}::https://salsa.debian.org/minicom-team/minicom.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1983"


### PR DESCRIPTION
Topic Description
-----------------

Update minicom because the original version does now FTBFS.

Package(s) Affected
-------------------

- `minicom`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
