### PR TITLE
rinutils: noarchize

### DIFF
--- a/extra-libs/rinutils/autobuild/defines
+++ b/extra-libs/rinutils/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=rinutils
 PKGDES="C11/gnu11 utilities C library"
 BUILDDEP="cmocka"
 PKGSEC=libs
+
+ABHOST=noarch

--- a/extra-libs/rinutils/spec
+++ b/extra-libs/rinutils/spec
@@ -1,4 +1,5 @@
 VER=0.4.1
+REL=1
 SRCS="tbl::https://github.com/shlomif/rinutils/releases/download/$VER/rinutils-$VER.tar.xz"
 CHKSUMS="sha256::9744fc52f91b817648958b51fca3e331550c6c240308df76b84f512d84a65ef5"
 CHKUPDATE="anitya::id=230526"


### PR DESCRIPTION
Topic Description
-----------------

Make `rinutils` noarch, otherwise it will fail on ABSPLITDBG because of lack of binary files.

Package(s) Affected
-------------------

- `rinutils`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
