### PR TITLE
okteta: import a patch from Fedora to fix FTBFS

### DIFF
--- a/extra-kde/okteta/autobuild/patches/0001-fedora-okteta-gcc11.patch
+++ b/extra-kde/okteta/autobuild/patches/0001-fedora-okteta-gcc11.patch
@@ -1,0 +1,29 @@
+diff --git a/kasten/controllers/view/structures/allprimitivetypes.cpp b/kasten/controllers/view/structures/allprimitivetypes.cpp
+index c4f6185..60c3fd2 100644
+--- a/kasten/controllers/view/structures/allprimitivetypes.cpp
++++ b/kasten/controllers/view/structures/allprimitivetypes.cpp
+@@ -6,6 +6,7 @@
+     SPDX-License-Identifier: LGPL-2.1-only OR LGPL-3.0-only OR LicenseRef-KDE-Accepted-LGPL
+ */
+ 
++#include <limits>
+ #include "allprimitivetypes.hpp"
+ #include "datatypes/primitive/primitivedatainformation.hpp"
+ 
+diff --git a/kasten/controllers/view/structures/datatypes/primitive/enumdefinition.cpp b/kasten/controllers/view/structures/datatypes/primitive/enumdefinition.cpp
+index 384e0f7..cafedc1 100644
+--- a/kasten/controllers/view/structures/datatypes/primitive/enumdefinition.cpp
++++ b/kasten/controllers/view/structures/datatypes/primitive/enumdefinition.cpp
+@@ -6,11 +6,11 @@
+     SPDX-License-Identifier: LGPL-2.1-only OR LGPL-3.0-only OR LicenseRef-KDE-Accepted-LGPL
+ */
+ 
++#include <limits>
+ #include "enumdefinition.hpp"
+ 
+ #include <QScriptValue>
+ #include <QScriptValueIterator>
+-#include <limits>
+ 
+ #include "../../script/scriptlogger.hpp"
+ 

--- a/extra-kde/okteta/spec
+++ b/extra-kde/okteta/spec
@@ -1,4 +1,5 @@
 VER=0.26.9
+REL=1
 SRCS="tbl::https://download.kde.org/stable/okteta/$VER/src/okteta-$VER.tar.xz"
 CHKSUMS="sha256::16854c4d4e94838219ae3115a42ba385fda5c87dc6c9865ac90d3774f8d05ffb"
 CHKUPDATE="anitya::id=229042"


### PR DESCRIPTION
Topic Description
-----------------

Introduce a patch to fix FTBFS of `okteta` because of #include directive sequence.

Package(s) Affected
-------------------

- `okteta`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
