### PR TITLE
tl-expected: noarchize and disable test

### DIFF
--- a/extra-libs/tl-expected/autobuild/defines
+++ b/extra-libs/tl-expected/autobuild/defines
@@ -2,3 +2,6 @@ PKGNAME="tl-expected"
 PKGDES="C++11/14/17 std::expected with functional-style extensions"
 BUILDDEP="cmake catch2"
 PKGSEC="libs"
+
+CMAKE_AFTER="-DEXPECTED_ENABLE_TESTS=OFF"
+ABHOST=noarch

--- a/extra-libs/tl-expected/spec
+++ b/extra-libs/tl-expected/spec
@@ -1,4 +1,5 @@
 VER=1.0.0
+REL=1
 SRCS="tbl::https://github.com/TartanLlama/expected/archive/v$VER.tar.gz"
 CHKSUMS="sha256::8f5124085a124113e75e3890b4e923e3a4de5b26a973b891b3deb40e19c03cee"
 CHKUPDATE="anitya::id=112689"


### PR DESCRIPTION
Topic Description
-----------------

Fixes FTBFS of `tl-expected` by marking it noarch and disabling its test suite.

Package(s) Affected
-------------------

- `tl-expected`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
