### PR TITLE
microsoft-gsl: noarchize

### DIFF
--- a/extra-libs/microsoft-gsl/autobuild/defines
+++ b/extra-libs/microsoft-gsl/autobuild/defines
@@ -4,3 +4,4 @@ BUILDDEP="cmake"
 PKGSEC="libs"
 
 CMAKE_AFTER="-DGSL_TEST=OFF"
+ABHOST=noarch

--- a/extra-libs/microsoft-gsl/spec
+++ b/extra-libs/microsoft-gsl/spec
@@ -1,4 +1,5 @@
 VER=3.0.1
+REL=1
 SRCS="tbl::https://github.com/Microsoft/GSL/archive/v$VER.tar.gz"
 CHKSUMS="sha256::7ceba191e046e5347357c6b605f53e6bed069c974aeda851254cb6962a233572"
 CHKUPDATE="anitya::id=230453"


### PR DESCRIPTION
Topic Description
-----------------

Make `microsoft-gsl`, a header-only C++ library, noarch, to fix FTBFS.

Package(s) Affected
-------------------

- `microsoft-gsl`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
