### PR TITLE
wireless-regdb: upgrade to 2022.08.12, install regulatory.db

### DIFF
--- a/extra-network/wireless-regdb/autobuild/build
+++ b/extra-network/wireless-regdb/autobuild/build
@@ -1,8 +1,12 @@
-install -D -m644 regulatory.bin "$PKGDIR"/usr/lib/crda/regulatory.bin
+abinfo "Copying shipped files..."
+make install \
+	LSB_ID="AOSC OS" \
+	REGDB_AUTHOR="AOSC OS" \
+	DESTDIR="${PKGDIR}" \
+	MANDIR=usr/share/man \
+	FIRMWARE_PATH=usr/lib/firmware
 
-install -D -m644 sforshee.key.pub.pem "$PKGDIR"/usr/lib/crda/pubkeys/sforshee.key.pub.pem
-install -D -m644 regulatory.bin.5 "$PKGDIR"/usr/share/man/man5/regulatory.bin.5
-
+abinfo "Creating wireless registry domain file"
 mkdir -p "$PKGDIR"/etc/conf.d/
 
 for dom in $(grep ^country db.txt | cut -d' ' -f2 | sed 's|:||g'); do

--- a/extra-network/wireless-regdb/spec
+++ b/extra-network/wireless-regdb/spec
@@ -1,4 +1,4 @@
-VER=2019.06.03
+VER=2022.08.12
 SRCS="tbl::https://www.kernel.org/pub/software/network/wireless-regdb/wireless-regdb-$VER.tar.xz"
-CHKSUMS="sha256::cd917ed86b63ce8d93947979f1f18948f03a4ac0ad89ec25227b36ac00dc54bf"
+CHKSUMS="sha256::59c8f7d17966db71b27f90e735ee8f5b42ca3527694a8c5e6e9b56bd379c3b84"
 CHKUPDATE="anitya::id=15257"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates wireless registry database to `2022.08.12` and ship `regulatory.db` (which a modern kernel would expect).

Package(s) Affected
-------------------

wireless-regdb

Test Build(s) Done
------------------

- [ ] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

- [ ] Architecture-independent `noarch`

