### PR TITLE
autobuild3: update to 1.6.62

### DIFF
--- a/extra-devel/autobuild3/spec
+++ b/extra-devel/autobuild3/spec
@@ -1,4 +1,4 @@
-VER=1.6.60
+VER=1.6.62
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"


### PR DESCRIPTION
Topic Description
-----------------

The topic will upgrade autobuild3 to version/tag v1.6.62

References:
- Changelog: https://github.com/AOSC-Dev/autobuild3/compare/v1.6.60...v1.6.62
- https://github.com/AOSC-Dev/autobuild3/pull/133/

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

`autobuild3`

Security Update?
----------------

No

Test Build(s) Done
------------------

- [ ] Architecture-independent `noarch` 



Update(s) Uploaded to Stable
----------------------------

- [ ] Architecture-independent `noarch`
