### PR TITLE
weston: update to 10.0.2

### DIFF
--- a/extra-x11/weston/autobuild/defines
+++ b/extra-x11/weston/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=weston
 PKGSEC=misc
 PKGDEP="poppler glu mtdev libinput libunwind pango colord wayland \
-        freerdp pipewire"
-BUILDDEP="doxygen xmlto wayland-protocols graphviz"
+        freerdp pipewire xwayland"
+BUILDDEP="wayland-protocols"
 PKGDES="A wayland compositor"
 
-MESON_AFTER="-Dsimple-dmabuf-drm=auto"
+MESON_AFTER="-Ddeprecated-backend-fbdev=true -Ddeprecated-wl-shell=true"
+NOLTO=1

--- a/extra-x11/weston/spec
+++ b/extra-x11/weston/spec
@@ -1,4 +1,4 @@
-VER=7.0.0
-SRCS="tbl::https://wayland.freedesktop.org/releases/weston-$VER.tar.xz"
-CHKSUMS="sha256::a00a6d207b6a45f95f4401c604772a307c3767e5e2beecf3d879110c43909a64"
+VER=10.0.2
+SRCS="tbl::https://gitlab.freedesktop.org/wayland/weston/-/releases/$VER/downloads/weston-$VER.tar.xz"
+CHKSUMS="sha256::89646ca0d9f8d413c2767e5c3828eaa3fa149c2a105b3729a6894fa7cf1549e7"
 CHKUPDATE="anitya::id=13745"


### PR DESCRIPTION
Topic Description
-----------------

Update weston to 10.0.2 and add some build parameters.

Package(s) Affected
-------------------

- `weston`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
