### PR TITLE
autobuild3: update to 1.6.64

### DIFF
--- a/extra-devel/autobuild3/spec
+++ b/extra-devel/autobuild3/spec
@@ -1,4 +1,4 @@
-VER=1.6.62
+VER=1.6.64
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"


### PR DESCRIPTION
Topic Description
-----------------

This topic fixes a bug introduced in autobuild3 version 1.6.62, which may break build process for other topics.
See references for more details.

References:
- https://github.com/AOSC-Dev/autobuild3/issues/134
- https://github.com/AOSC-Dev/autobuild3/pull/135

Package(s) Affected
-------------------

autobuild3

Security Update?
----------------

No

Test Build(s) Done
------------------

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

- [ ] Architecture-independent `noarch`