### PR TITLE
gstreamer: adapt for riscv64

### DIFF
--- a/extra-multimedia/gstreamer/autobuild/defines
+++ b/extra-multimedia/gstreamer/autobuild/defines
@@ -20,6 +20,7 @@ BUILDDEP="bash-completion cargo-c gobject-introspection gtk-doc \
           hotdoc mono nasm rustc shaderc vulkan-headers vulkan-loader \
           vulkan-validationlayers wayland-protocols"
 BUILDDEP__LOONGSON3="${BUILDDEP/mono/}"
+BUILDDEP__RISCV64="${BUILDDEP/mono/}"
 PKGDES="A modular and extensible multimedia framework"
 
 PKGBREAK="gst-editing-services<=1.18.4-1 gst-libav-1-0<=1.18.4 \


### PR DESCRIPTION
Topic Description
-----------------

Change BUILDDEP for gstreamer on riscv64, to prevent unbuilt `mono`.

Package(s) Affected
-------------------

- `gstreamer`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
