### PR TITLE
gstreamer: fix up for adapting for riscv64

### DIFF
--- a/extra-multimedia/gstreamer/autobuild/defines
+++ b/extra-multimedia/gstreamer/autobuild/defines
@@ -67,3 +67,6 @@ MESON_AFTER="-Dpython=enabled \
 MESON_AFTER__LOONGSON3=" \
              ${MESON_AFTER} \
              -Dsharp=disabled"
+MESON_AFTER__RISCV64=" \
+             ${MESON_AFTER} \
+             -Dsharp=disabled"


### PR DESCRIPTION
Topic Description
-----------------

Adapt `gstreamer` for riscv64, again, as fixup.

Package(s) Affected
-------------------

- `gstreamer`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
