### PR TITLE
gstreamer: disable rust binding on riscv64 now

### DIFF
--- a/extra-multimedia/gstreamer/autobuild/defines
+++ b/extra-multimedia/gstreamer/autobuild/defines
@@ -20,7 +20,9 @@ BUILDDEP="bash-completion cargo-c gobject-introspection gtk-doc \
           hotdoc mono nasm rustc shaderc vulkan-headers vulkan-loader \
           vulkan-validationlayers wayland-protocols"
 BUILDDEP__LOONGSON3="${BUILDDEP/mono/}"
-BUILDDEP__RISCV64="${BUILDDEP/mono/}"
+BUILDDEP__RISCV64="bash-completion gobject-introspection gtk-doc \
+                   hotdoc shaderc vulkan-headers vulkan-loader \
+                   vulkan-validationlayers wayland-protocols"
 PKGDES="A modular and extensible multimedia framework"
 
 PKGBREAK="gst-editing-services<=1.18.4-1 gst-libav-1-0<=1.18.4 \
@@ -69,4 +71,4 @@ MESON_AFTER__LOONGSON3=" \
              -Dsharp=disabled"
 MESON_AFTER__RISCV64=" \
              ${MESON_AFTER} \
-             -Dsharp=disabled"
+             -Dsharp=disabled -Drs=disabled"


### PR DESCRIPTION
Topic Description
-----------------

Disable gst-plugins-rs on riscv64 to fix `gstreamer` build

Package(s) Affected
-------------------

- `gstreamer`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
