### PR TITLE
shadow: comment ERASECHAR in /etc/login.defs, fix backspace in KMSCON

### DIFF
--- a/base-admin/shadow/autobuild/overrides/etc/login.defs
+++ b/base-admin/shadow/autobuild/overrides/etc/login.defs
@@ -111,7 +111,7 @@ TTYPERM		0600
 #
 # Prefix these values with "0" to get octal, "0x" to get hexadecimal.
 #
-ERASECHAR	0177
+#ERASECHAR	0177
 KILLCHAR	025
 UMASK		077
 

--- a/base-admin/shadow/spec
+++ b/base-admin/shadow/spec
@@ -1,5 +1,5 @@
 VER=4.10
-REL=1
+REL=2
 SRCS="tbl::https://github.com/shadow-maint/shadow/releases/download/v$VER/shadow-$VER.tar.xz"
 CHKSUMS="sha256::bd6fbad04d96408b41c788fe8384ed37ba0b826348ff3651733c7e7ae00668fc"
 CHKUPDATE="anitya::id=4802"


### PR DESCRIPTION
Signed-off-by: Kaiyang Wu <origincode@aosc.io>

<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Fix backspace in KMSCON by commenting `ERASECHAR` in /etc/login.defs

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`shadow` 4.10-2

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
