### PR TITLE
file-roller: add libhandy dep

### DIFF
--- a/extra-gnome/file-roller/autobuild/defines
+++ b/extra-gnome/file-roller/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=file-roller
 PKGSEC=gnome
 PKGDEP="desktop-file-utils gtk-3 hicolor-icon-theme dconf libarchive file \
-        json-glib libnotify p7zip lrzip"
+        json-glib libnotify p7zip lrzip libhandy"
 BUILDDEP="intltool itstool nautilus"
 PKGDES="Archive manager for GNOME"
 

--- a/extra-gnome/file-roller/spec
+++ b/extra-gnome/file-roller/spec
@@ -1,4 +1,5 @@
 VER=3.42.0
+REL=1
 SRCS="https://download.gnome.org/sources/file-roller/${VER:0:4}/file-roller-$VER.tar.xz"
 CHKSUMS="sha256::1c438e6d53ec10ff4f2eb5b22d7bbf28a7c2a84957ab64a751c1cdf3c52302c7"
 CHKUPDATE="anitya::id=5392"


### PR DESCRIPTION
Topic Description
-----------------

Add missing `libhandy` dep to `file-roller`.

Package(s) Affected
-------------------

`file-roller` v3.42.0-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
