### PR TITLE
Gnome 42 relink against libwacom.so.9

### DIFF
--- a/extra-gnome/gnome-control-center/autobuild/defines
+++ b/extra-gnome/gnome-control-center/autobuild/defines
@@ -6,7 +6,7 @@ PKGDEP="accountsservice cheese clutter-gtk clutter-gst-3.0 gnome-bluetooth \
         libgtop libpwquality modemmanager network-manager-applet openssh \
         samba upower colord-gtk rygel system-config-printer gnome-keyring \
         gnome-color-manager vinagre sound-theme-freedesktop udisks-2 libhandy \
-        gsound malcontent libgudev"
+        gsound malcontent libgudev libwacom"
 BUILDDEP="docbook-xsl gtk-doc intltool modemmanager"
 PKGDES="An aggregated settings utility for GNOME"
 

--- a/extra-gnome/gnome-control-center/spec
+++ b/extra-gnome/gnome-control-center/spec
@@ -1,4 +1,5 @@
 VER=42.3
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-control-center/${VER%.*}/gnome-control-center-$VER.tar.xz"
 CHKSUMS="sha256::ce0ae3650de2af7ebcb0a7e1fc9912eddb6eff8d257f3fe50ff8b29c19341c7e"
 CHKUPDATE="anitya::id=5408"

--- a/extra-gnome/gnome-settings-daemon/autobuild/defines
+++ b/extra-gnome/gnome-settings-daemon/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=gnome
 PKGDEP="colord cups dconf gcr geoclue2 geocode-glib gnome-desktop \
         gsettings-desktop-schemas hicolor-icon-theme libcanberra libgudev \
         libgweather libibus libnotify librsvg libwacom networkmanager nss \
-        pcsclite pulseaudio rfkill systemd upower"
+        pcsclite pulseaudio rfkill systemd upower libwacom"
 BUILDDEP="docbook-xsl gtk-doc intltool libxslt"
 PKGDES="Manages GNOME session and applications parameters"
 

--- a/extra-gnome/gnome-settings-daemon/spec
+++ b/extra-gnome/gnome-settings-daemon/spec
@@ -1,4 +1,5 @@
 VER=42.2
+REL=1
 SRCS="tbl::https://download.gnome.org/sources/gnome-settings-daemon/${VER%%.*}/gnome-settings-daemon-$VER.tar.xz"
 CHKSUMS="sha256::9c449714aa8ec1271c0db5137df3458195943f05ccd0ac8935d93397770bab00"
 CHKUPDATE="anitya::id=12860"

--- a/extra-gnome/mutter/autobuild/defines
+++ b/extra-gnome/mutter/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=gnome
 PKGDEP="dconf gobject-introspection gsettings-desktop-schemas libcanberra \
         startup-notification zenity gnome-desktop upower libinput \
         gnome-settings-daemon egl-wayland pipewire xorg-server graphene \
-        wayland-protocols xwayland libgudev"
+        wayland-protocols xwayland libgudev libwacom"
 BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool tdb"
 PKGDES="Window manager for GNOME"
 

--- a/extra-gnome/mutter/spec
+++ b/extra-gnome/mutter/spec
@@ -1,4 +1,5 @@
 VER=42.4
+REL=1
 SRCS="https://download.gnome.org/sources/mutter/${VER%.*}/mutter-$VER.tar.xz"
 CHKSUMS="sha256::c22c7fa3d187061dbf280c3850e118b7b5009065d01de31616acd500c4982a40"
 CHKUPDATE="anitya::id=13154"


### PR DESCRIPTION
Topic Description
-----------------

This topic rebuilds a few packages that hard-link against libwacom but was omitted from rebuild queue in #4198.

Package(s) Affected
-------------------

mutter gnome-settings-daemon gnome-control-center

Build Order
-----------

mutter gnome-settings-daemon gnome-control-center

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
