### PR TITLE
networkmanager: fix dns issue

### DIFF
--- a/extra-network/networkmanager/autobuild/defines
+++ b/extra-network/networkmanager/autobuild/defines
@@ -73,7 +73,9 @@ MESON_AFTER="-Dsession_tracking_consolekit=false \
              -Dlibpsl=true \
              -Dcrypto=nss \
              -Dqt=false \
-             -Dreadline=auto"
+             -Dreadline=auto \
+             -Dconfig_dns_rc_manager_default=auto \
+             -Dresolvconf=no"
 MESON_AFTER__RETRO=" \
              ${MESON_AFTER} \
              -Dofono=false \

--- a/extra-network/networkmanager/spec
+++ b/extra-network/networkmanager/spec
@@ -1,4 +1,5 @@
 VER=1.38.2
+REL=1
 SRCS="https://download.gnome.org/sources/NetworkManager/${VER:0:4}/NetworkManager-$VER.tar.xz"
 CHKSUMS="sha256::9cffd2adc68651316df2d2f8a09e1717bb1d0c2ea389cfc721a0109db9b35826"
 CHKUPDATE="anitya::id=21197"


### PR DESCRIPTION
Topic Description
-----------------

The most recent update to networkmanager introduced an issue where Networkmanager generates empty file in `/etc/resolv.conf` due to the expectation that systemd-resolved is in charge of `/etc/resolv.conf`, effectively causing all DNS requests to fail. This PR addresses this issue.

Upstream report: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/629

Package(s) Affected
-------------------

networkmanager: 1.38.2-1

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
