### PR TITLE
autobuild3: upgrade to 1.6.65

### DIFF
--- a/extra-devel/autobuild3/spec
+++ b/extra-devel/autobuild3/spec
@@ -1,4 +1,4 @@
-VER=1.6.64
+VER=1.6.65
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"


### PR DESCRIPTION
Topic Description
-----------------

Autobuild3 1.6.65 fixed a bug which may cause alternatives file go haywire.
This upgrade is urgent as the bug may breaks packages produced via autobuild3 1.6.62/1.6.64. 

References:
https://github.com/AOSC-Dev/autobuild3/issues/136
https://github.com/AOSC-Dev/autobuild3/pull/137

Package(s) Affected
-------------------

Autobuild3 1.6.65
And possible other packages affected by the bug, if applicable.

Security Update?
----------------

No

Build Order
-----------

`autobuild3`
And more possible affected packages, if applicable.

Test Build(s) Done
------------------

- [ ] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

- [ ] Architecture-independent `noarch`
