### PR TITLE
grub: backport a patch to fix riscv64 build

### DIFF
--- a/extra-admin/grub/autobuild/patches/0225-RISC-V-adjust-march-flags-for-binutils-2.28.patch
+++ b/extra-admin/grub/autobuild/patches/0225-RISC-V-adjust-march-flags-for-binutils-2.28.patch
@@ -1,0 +1,49 @@
+From 049efdd72eb7baa7b2bf8884391ee7fe650da5a0 Mon Sep 17 00:00:00 2001
+From: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
+Date: Sat, 29 Jan 2022 13:36:55 +0100
+Subject: RISC-V: Adjust -march flags for binutils 2.38
+
+As of version 2.38 binutils defaults to ISA specification version
+2019-12-13. This version of the specification has has separated the
+the csr read/write (csrr*/csrw*) instructions and the fence.i from
+the I extension and put them into separate Zicsr and Zifencei
+extensions.
+
+This implies that we have to adjust the -march flag passed to the
+compiler accordingly.
+
+Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ configure.ac | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+(limited to 'configure.ac')
+
+diff --git a/configure.ac b/configure.ac
+index 4f649ed..5c01af0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -870,11 +870,19 @@ if test x"$platform" != xemu ; then
+        CFLAGS="$TARGET_CFLAGS -march=rv32imac -mabi=ilp32 -Werror"
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
+ 		         [grub_cv_target_cc_soft_float="-march=rv32imac -mabi=ilp32"], [])
++       # ISA spec version 20191213 factored out extensions Zicsr and Zifencei
++       CFLAGS="$TARGET_CFLAGS -march=rv32imac_zicsr_zifencei -mabi=ilp32 -Werror"
++       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
++		         [grub_cv_target_cc_soft_float="-march=rv32imac_zicsr_zifencei -mabi=ilp32"], [])
+     fi
+     if test "x$target_cpu" = xriscv64; then
+        CFLAGS="$TARGET_CFLAGS -march=rv64imac -mabi=lp64 -Werror"
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
+ 		         [grub_cv_target_cc_soft_float="-march=rv64imac -mabi=lp64"], [])
++       # ISA spec version 20191213 factored out extensions Zicsr and Zifencei
++       CFLAGS="$TARGET_CFLAGS -march=rv64imac_zicsr_zifencei -mabi=lp64 -Werror"
++       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
++		         [grub_cv_target_cc_soft_float="-march=rv64imac_zicsr_zifencei -mabi=lp64"], [])
+     fi
+     if test "x$target_cpu" = xia64; then
+        CFLAGS="$TARGET_CFLAGS -mno-inline-float-divide -mno-inline-sqrt -Werror"
+-- 
+cgit v1.1
+

--- a/extra-admin/grub/spec
+++ b/extra-admin/grub/spec
@@ -1,5 +1,5 @@
 VER=2.06
-REL=3
+REL=4
 UNIFONTVER=14.0.04
 RETROFONTVER=20200402
 SRCS="tbl::https://ftp.gnu.org/gnu/grub/grub-$VER.tar.xz \


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of `grub` on riscv64 by backporting a patch from git master.

Package(s) Affected
-------------------

- `grub`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
