### PR TITLE
NVDEC based VAAPI driver to replace vdpau based driver.

### DIFF
--- a/extra-libs/libva-nvidia-driver/autobuild/defines
+++ b/extra-libs/libva-nvidia-driver/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=libva-nvidia-driver
+PKGDES="NVDEC backend for VA-API"
+PKGSEC=libs
+PKGDEP="libva"
+BUILDDEP="ffnvcodec"
+
+PKGBREAK="libva-vdpau-driver<=0.7.4-6"

--- a/extra-libs/libva-nvidia-driver/spec
+++ b/extra-libs/libva-nvidia-driver/spec
@@ -1,0 +1,4 @@
+VER=0.0.6
+SRCS="tbl::https://github.com/elFarto/nvidia-vaapi-driver/archive/refs/tags/v0.0.6.tar.gz"
+CHKSUMS="sha256::8a64c069200750f12d013c79547e459cbb87b498357478c5f36cb97f710294e0"
+CHKUPDATE="anitya::id=1754"

--- a/extra-libs/libva-vdpau-driver/autobuild/beyond
+++ b/extra-libs/libva-vdpau-driver/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Nuking old and broken nvidia_drv_video.so"
+rm -vf "${PKGDIR}/usr/lib/dri/nvidia_drv_video.so"

--- a/extra-libs/libva-vdpau-driver/spec
+++ b/extra-libs/libva-vdpau-driver/spec
@@ -1,5 +1,5 @@
 VER=0.7.4
-REL=6
+REL=7
 SRCS="tbl::https://freedesktop.org/software/vaapi/releases/libva-vdpau-driver/libva-vdpau-driver-$VER.tar.bz2"
 CHKSUMS="sha256::155c1982f0ac3f5435ba20b221bcaa11be212c37db548cd1f2a030ffa17e9bb9"
 CHKUPDATE="anitya::id=1754"


### PR DESCRIPTION
Topic Description
-----------------

This PR introduces `libva-nvidia-driver` to resolve an regression where firefox crashes during vdpau-libva initialization on systems with nvidia cards.

Package(s) Affected
-------------------

libva-nvidia-driver libva-vdpau-driver

Build Order
-----------

libva-nvidia-driver libva-vdpau-driver

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
