### PR TITLE
colord: Remove dependency hell

### DIFF
--- a/extra-admin/colord/autobuild/defines
+++ b/extra-admin/colord/autobuild/defines
@@ -1,13 +1,13 @@
 PKGNAME=colord
 PKGSEC=admin
-PKGDEP="argyllcms colord-gtk dconf dbus gnome-desktop lcms2 libgudev libgusb \
-        polkit sqlite systemd sane-backends"
+PKGDEP="argyllcms dconf dbus lcms2 libgudev libgusb \
+        polkit sqlite systemd"
 BUILDDEP="bash-completion docbook-utils gobject-introspection gtk-doc \
-          intltool vala"
+          intltool vala sane-backends"
 PKGDES="System daemon for managing color devices"
 
 MESON_AFTER="-Ddaemon=true \
-             -Dsession_example=true \
+             -Dsession_example=false \
              -Dbash_completion=true \
              -Dudev_rules=true \
              -Dsystemd=true \

--- a/extra-admin/colord/spec
+++ b/extra-admin/colord/spec
@@ -1,4 +1,5 @@
 VER=1.4.6
+REL=1
 SRCS="tbl::https://github.com/hughsie/colord/archive/refs/tags/$VER.tar.gz"
 CHKSUMS="sha256::a1d1ccbd301a75aa79df59c8cda69521db0099db30dc5d297ccc587dd13a37e6"
 CHKUPDATE="anitya::id=10190"

--- a/extra-python/automat/autobuild/defines
+++ b/extra-python/automat/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=automat
 PKGSEC=python
-PKGDEP="attrs python-graphviz six"
+PKGDEP="attrs six"
 BUILDDEP="setuptools setuptools-scm m2r"
 PKGDES="Self-service finite-state machines for the programmer on the go"
+PKGSUG="python-graphviz"
 
 ABHOST=noarch

--- a/extra-python/automat/spec
+++ b/extra-python/automat/spec
@@ -1,5 +1,5 @@
 VER=20.2.0
+REL=2
 SRCS="tbl::https://pypi.io/packages/source/A/Automat/Automat-$VER.tar.gz"
 CHKSUMS="sha256::7979803c74610e11ef0c0d68a2942b152df52da55336e0c9d58daf1831cbdf33"
 CHKUPDATE="anitya::id=75843"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

This topic removes unnecessary `gnome-desktop` from its dependencies.
From now on, installing `vim` will not bring up half of the GNOME suite.

Package(s) Affected
-------------------

- `colord`
- `automat`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
