### PR TITLE
fcitx5-pinyin-moegirl: update to 20220925

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20220714
+VER=20220925
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::71572652b409a71a87ac1a35de539b5021efd1178087116bc33b55d02fe3054b \
-         sha256::54c9500a8ff58a3b184108c4c4ea19ac0afab095510a008d7f945c4338e6d93f \
+CHKSUMS="sha256::714cbd4fe2e8cf86d929c9f56e5a5440f012d3798bb9ca528607b16b6f6072b7 \
+         sha256::461285d15f81394e9938a2bbfaae3f34fab22b652f086204dccb9fce9d04ae0c \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Update fcitx5-pinyin-moegirl to 20220925.

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl
* rime-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`