### PR TITLE
x11-ssh-askpass: install binaries to /usr/libexec

### DIFF
--- a/extra-utils/x11-ssh-askpass/autobuild/defines
+++ b/extra-utils/x11-ssh-askpass/autobuild/defines
@@ -5,5 +5,5 @@ BUILDDEP="imake"
 PKGDES="Lightweight passphrase dialog for SSH"
 
 AUTOTOOLS_AFTER="--mandir=/usr/share/man \
-                 --libexecdir=/usr/lib/ssh \
+                 --libexecdir=/usr/libexec/ssh \
                  --with-app-defaults-dir=/usr/share/X11/app-defaults"

--- a/extra-utils/x11-ssh-askpass/autobuild/overrides/etc/profile.d/x11-ssh-askpass.sh
+++ b/extra-utils/x11-ssh-askpass/autobuild/overrides/etc/profile.d/x11-ssh-askpass.sh
@@ -1,4 +1,4 @@
-if [ -f "/usr/lib/ssh/x11-ssh-askpass" ] ; then
-	SSH_ASKPASS="/usr/lib/ssh/x11-ssh-askpass"
+if [ -f "/usr/libexec/ssh/x11-ssh-askpass" ] ; then
+	SSH_ASKPASS="/usr/libexec/ssh/x11-ssh-askpass"
 	export SSH_ASKPASS
 fi

--- a/extra-utils/x11-ssh-askpass/spec
+++ b/extra-utils/x11-ssh-askpass/spec
@@ -1,5 +1,5 @@
 VER=1.2.4.1
-REL=3
+REL=4
 # FIXME: using Fedora mirror only.
 SRCS="tbl::https://src.fedoraproject.org/repo/pkgs/openssh/x11-ssh-askpass-1.2.4.1.tar.gz/8f2e41f3f7eaa8543a2440454637f3c3/x11-ssh-askpass-1.2.4.1.tar.gz"
 CHKSUMS="sha256::620de3c32ae72185a2c9aeaec03af24242b9621964e38eb625afb6cdb30b8c88"


### PR DESCRIPTION
Signed-off-by: Kaiyang Wu <origincode@aosc.io>

<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Install binaries to `/usr/libexec`

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`x11-ssh-askpass` 1.2.4.1-4

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
