### PR TITLE
dracut: upgrade to 057, parallelize initrd gen if available

### DIFF
--- a/extra-kernel/dracut/autobuild/beyond
+++ b/extra-kernel/dracut/autobuild/beyond
@@ -1,8 +1,7 @@
 abinfo "Dropping unnecessary modules ..."
-rm -r "$PKGDIR"/usr/lib/dracut/modules.d/01fips
-rm -r "$PKGDIR"/usr/lib/dracut/modules.d/02caps
-rm -r "$PKGDIR"/usr/lib/dracut/modules.d/00dash
-rm -r "$PKGDIR"/usr/lib/dracut/modules.d/50gensplash
+rm -rv "$PKGDIR"/usr/lib/dracut/modules.d/01fips
+rm -rv "$PKGDIR"/usr/lib/dracut/modules.d/02caps
+rm -rv "$PKGDIR"/usr/lib/dracut/modules.d/00dash
 
 abinfo "Creating skeleton files and directories ..."
 mkdir -pv "$PKGDIR"/boot/dracut

--- a/extra-kernel/dracut/autobuild/defines
+++ b/extra-kernel/dracut/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=dracut
 PKGSEC=utils
-PKGDEP="arping coreutils cpio gawk kbd kmod nfs-utils util-linux systemd bash"
-PKGDEP__RETRO="coreutils cpio gawk kbd kmod util-linux systemd bash"
+PKGDEP="arping coreutils cpio gawk kbd kmod nfs-utils util-linux systemd bash parallel"
+PKGDEP__RETRO="coreutils cpio gawk kbd kmod util-linux systemd bash parallel"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
 PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
@@ -18,6 +18,7 @@ BUILDDEP__I486="${BUILDDEP__RETRO}"
 BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
+
 PKGDES="Generic, modular, cross-distribution initramfs generation tool"
 
 AUTOTOOLS_AFTER=""

--- a/extra-kernel/dracut/autobuild/overrides/usr/bin/update-initramfs
+++ b/extra-kernel/dracut/autobuild/overrides/usr/bin/update-initramfs
@@ -5,30 +5,68 @@ if [ "$EUID" -ne 0 ]; then
 	exit
 fi
 
+# $1 = single|parallel   - whether initrd generation is in parallel
+#      single   = print message at start
+#      parallel = print completion notice or error message
+# $2 = <ver>-local-ver e.g. 5.19.0-aosc-main
+generate_initrd_if_needed() {
+	local mode="$1"
+	local version="$2"
+
+	if [ -f "/usr/lib/modules/${version}/modules.dep" ] && [ -f "/usr/lib/modules/${version}/modules.order" ] && [ -f "/usr/lib/modules/${version}/modules.builtin" ]; then
+		[[ "$mode" == "single" ]] && echo -e "\033[36m**\033[0m\tGenerating initrd (Initialization RAM Disk) for kernel version $version ..."
+		dracut -q --force "/boot/initramfs-$version.img" "$version"
+		local dracut_ret=$?
+		if [[ "$mode" == "parallel" ]]; then
+			if [[ $dracut_ret -eq 0 ]]; then
+				echo -e "Successfully generated initrd."
+			else
+				echo -e "\033[31mDracut returned non-zero exit code $dracut_ret.\033[0m"
+				echo -e "\033[31mSee messages for details.\033[0m"
+			fi
+		fi
+	else
+		if [[ "$mode" == "parallel" ]]; then
+			echo -e "\033[33mSkipping incomplete kernel modules tree ...\033[0m"
+		else
+			echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $version ..."
+		fi
+	fi
+
+}
+
+export -f generate_initrd_if_needed
+
 # Generate initrd using Dracut.
 if [ -x /usr/bin/dracut ]; then
-    for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
-	if [ -f "/usr/lib/modules/${i}/modules.dep" ] && [ -f "/usr/lib/modules/${i}/modules.order" ] && [ -f "/usr/lib/modules/${i}/modules.builtin" ]; then
-	        echo -e "\033[36m**\033[0m\tGenerating initrd (Initialization RAM Disk) for kernel version $i ..."
-		dracut -q --force "/boot/initramfs-$i.img" "$i"
+	if [ -x /usr/bin/parallel ]; then
+		task_list=$(ls /usr/lib/modules | grep -v 'extramodules')
+		if [[ "e$task_list" != "e" ]]; then
+			echo -e "\033[36m**\033[0m\tGenerating initrd (Initialization RAM Disk) for $(echo ${task_list} | wc -w) kernel versions ..."
+			parallel --will-cite --tagstring '{=$_=$_ . " " x (20 - length($_))=}' generate_initrd_if_needed parallel ::: ${task_list}
+		else
+			echo -e "\033[36m**\033[0m\tNo kernel module tree found, skipping generation."
+		fi
 	else
-		echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $i ..."
+		echo -e "\033[33m**\033[0m\tGNU parallel is not available, generating initramfs one-by-one..."
+		for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
+			generate_initrd_if_needed single "$i"
+		done
 	fi
-    done
 else
-    echo -e "\033[33m**\033[0m\tCommand \"dracut\" is not installed, skipping generation.\n\tYou may not be able to boot the new kernel on the next boot."
+	echo -e "\033[33m**\033[0m\tCommand \"dracut\" is not installed, skipping generation.\n\tYou may not be able to boot the new kernel on the next boot."
 fi
 
 # Notify bootloader
 if ! systemd-detect-virt -cq; then
-    if [[ -x /usr/bin/grub-mkconfig ]]; then
-	    echo -e "\033[36m**\033[0m\tUpdating GRUB for the new kernel..."
-        grub-mkconfig -o /boot/grub/grub.cfg
-    fi
-    if [[ -x /usr/bin/sbf && -r /etc/systemd-boot-friend.conf ]]; then
-	    echo -e "\033[36m**\033[0m\tUpdating systemd-boot entries ..."
-        sbf update
-    fi
+	if [[ -x /usr/bin/grub-mkconfig ]]; then
+		echo -e "\033[36m**\033[0m\tUpdating GRUB for the new kernel..."
+		grub-mkconfig -o /boot/grub/grub.cfg
+	fi
+	if [[ -x /usr/bin/sbf && -r /etc/systemd-boot-friend.conf ]]; then
+		echo -e "\033[36m**\033[0m\tUpdating systemd-boot entries ..."
+		sbf update
+	fi
 fi
 
 # TODO: Support for multiple other initramfs/initrd manager.

--- a/extra-kernel/dracut/autobuild/patches/0001-fix-multipath-install-multipathd.socket.patch
+++ b/extra-kernel/dracut/autobuild/patches/0001-fix-multipath-install-multipathd.socket.patch
@@ -1,0 +1,24 @@
+From 22581b625125d7f0f34624ebb156c151e8e0d04e Mon Sep 17 00:00:00 2001
+From: Tianhao Chai <cth451@gmail.com>
+Date: Thu, 13 Oct 2022 01:50:06 -0400
+Subject: [PATCH] fix(multipath): install multipathd.socket
+
+---
+ modules.d/90multipath/module-setup.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules.d/90multipath/module-setup.sh b/modules.d/90multipath/module-setup.sh
+index 541e243a..dae7371c 100755
+--- a/modules.d/90multipath/module-setup.sh
++++ b/modules.d/90multipath/module-setup.sh
+@@ -137,6 +137,7 @@ install() {
+             inst_simple "${moddir}/multipathd-configure.service" "${systemdsystemunitdir}/multipathd-configure.service"
+             $SYSTEMCTL -q --root "$initdir" enable multipathd-configure.service
+         fi
++        inst_simple "${systemdsystemunitdir}/multipathd.socket"
+         inst_simple "${moddir}/multipathd.service" "${systemdsystemunitdir}/multipathd.service"
+         $SYSTEMCTL -q --root "$initdir" enable multipathd.service
+     else
+-- 
+2.37.1
+

--- a/extra-kernel/dracut/spec
+++ b/extra-kernel/dracut/spec
@@ -1,5 +1,4 @@
-VER=055
-REL=4
-SRCS="tbl::https://www.kernel.org/pub/linux/utils/boot/dracut/dracut-$VER.tar.xz"
-CHKSUMS="sha256::4baa08206cceeb124dbf1075a0daf774b5a8f144ce2e01d82a144af3020fd65b"
+VER=057
+SRCS="tbl::https://github.com/dracutdevs/dracut/archive/refs/tags/057.tar.gz"
+CHKSUMS="sha256::24f149d683d188c0d25756529b7d1e5cd6be8028e0c1043110f303d0d706757d"
 CHKUPDATE="anitya::id=10627"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates dracut to 057 and `update-initramfs` script to parallelize initrd generation if GNU parallel is available.

Package(s) Affected
-------------------

* dracut

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
