### PR TITLE
libcryptui: add missing BUILDDEP gtk-doc

### DIFF
--- a/extra-libs/libcryptui/autobuild/defines
+++ b/extra-libs/libcryptui/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=libcryptui
 PKGSEC=gnome
 PKGDEP="dbus-glib dconf gtk-3 gpgme libgnome-keyring libnotify"
-BUILDDEP="intltool"
+BUILDDEP="intltool gtk-doc"
 PKGDES="Library for OpenPGP prompts"
 
-AUTOTOOLS_AFTER="--disable-schemas-compile"
+AUTOTOOLS_AFTER="--disable-schemas-compile --enable-gtk-doc"
+ABTYPE=autotools


### PR DESCRIPTION
Topic Description
-----------------

Fix `libcryptui` FTBFS by adding a missing BUILDDEP gtk-doc. Also explicitly enable gtk-doc generation.

Package(s) Affected
-------------------

- `libcryptui`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
