### PR TITLE
telepathy-logger: sanitize

### DIFF
--- a/extra-telepathy/telepathy-logger/autobuild/build
+++ b/extra-telepathy/telepathy-logger/autobuild/build
@@ -1,9 +1,0 @@
-./configure --prefix=/usr \
-    --sysconfdir=/etc \
-    --libexecdir=/usr/lib/telepathy \
-    --enable-call \
-    --disable-static \
-    --disable-scrollkeeper \
-    --disable-schemas-compile
-make
-make install DESTDIR=`pwd`/abdist

--- a/extra-telepathy/telepathy-logger/autobuild/defines
+++ b/extra-telepathy/telepathy-logger/autobuild/defines
@@ -5,7 +5,7 @@ BUILDDEP="libxslt intltool gobject-introspection"
 PKGDES="Telepathy framework logging daemon"
 
 AUTOTOOLS_AFTER="--libexecdir=/usr/lib/telepathy \
-                 --enable-call \
                  --disable-static \
-                 --disable-scrollkeeper \
                  --disable-schemas-compile"
+RECONF=0
+ABTYPE=autotools

--- a/extra-telepathy/telepathy-logger/spec
+++ b/extra-telepathy/telepathy-logger/spec
@@ -1,5 +1,5 @@
 VER=0.8.2
-REL=1
+REL=2
 SRCS="tbl::https://telepathy.freedesktop.org/releases/telepathy-logger/telepathy-logger-$VER.tar.bz2"
 CHKSUMS="sha256::8fcad534d653b1b365132c5b158adae947810ffbae9843f72dd1797966415dae"
 CHKUPDATE="anitya::id=6067"


### PR DESCRIPTION
Topic Description
-----------------

Sanitizing build recipe for `telepathy-logger` to make use of ab3's autotools ABTYPE, and thus fix FTBFS on riscv64 because of out-of-date config.* files.

Package(s) Affected
-------------------

- `telepathy-logger`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
