### PR TITLE
gnome-user-share: fix FTBFS by backporting a patch

### DIFF
--- a/extra-gnome/gnome-user-share/autobuild/patches/0001-build-fix-build-with-meson-0.61.patch
+++ b/extra-gnome/gnome-user-share/autobuild/patches/0001-build-fix-build-with-meson-0.61.patch
@@ -1,0 +1,28 @@
+From c31b0a8f33b95c0077cd5ee2102a71a49bee8abe Mon Sep 17 00:00:00 2001
+From: Adrian Vovk <adrianvovk@gmail.com>
+Date: Wed, 23 Feb 2022 13:08:06 -0500
+Subject: [PATCH] build: Fix build with meson 0.61
+
+The positional argument was always ignored by meson. It became a
+warning in meson 0.60, and a fatal error in meson 0.61
+
+Closes: https://gitlab.gnome.org/GNOME/gnome-user-share/-/issues/27
+---
+ data/meson.build | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index bedfe11..222c17d 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -7,7 +7,6 @@ desktop_in = configure_file(
+ )
+ 
+ i18n.merge_file(
+-  desktop,
+   type: 'desktop',
+   input: desktop_in,
+   output: '@BASENAME@',
+-- 
+GitLab
+

--- a/extra-gnome/gnome-user-share/spec
+++ b/extra-gnome/gnome-user-share/spec
@@ -2,4 +2,4 @@ VER=3.34.0
 SRCS="tbl::https://download.gnome.org/sources/gnome-user-share/${VER:0:4}/gnome-user-share-$VER.tar.xz"
 CHKSUMS="sha256::1d0c2a8eb4fcc4bff85c5edde9346ba6094e356921d2955f180d44b2d3642913"
 CHKUPDATE="anitya::id=228562"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of `gnome-user-share` by backporting a patch.

Package(s) Affected
-------------------

- `gnome-user-share`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
