### PR TITLE
celt-0.5: fix FTBFS by disabling RECONF

### DIFF
--- a/extra-multimedia/celt-0.5/autobuild/defines
+++ b/extra-multimedia/celt-0.5/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=celt-0.5
 PKGSEC=sound
 PKGDEP="libogg"
 PKGDES="Low-latency audio communication codec - SPICE version"
+
+RECONF=0

--- a/extra-multimedia/celt-0.5/spec
+++ b/extra-multimedia/celt-0.5/spec
@@ -1,5 +1,5 @@
 VER=0.5.1.3
-REL=2
+REL=3
 SRCS="tbl::https://downloads.xiph.org/releases/celt/celt-0.5.1.3.tar.gz"
 CHKSUMS="sha256::fc2e5b68382eb436a38c3104684a6c494df9bde133c139fbba3ddb5d7eaa6a2e"
 CHKUPDATE="anitya::id=15311"


### PR DESCRIPTION
Topic Description
-----------------

Fix `celt-0.5` FTBFS because of broken configure script generated.

Package(s) Affected
-------------------

- `celt-0.5`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
