### PR TITLE
libspice-gtk: update to 0.41

### DIFF
--- a/extra-libs/libspice-gtk/autobuild/defines
+++ b/extra-libs/libspice-gtk/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libspice-gtk
 PKGSEC=libs
-PKGDEP="libcacard celt-0.5 gtk-3 pulseaudio usbredir libsoup lz4 phodav usbutils \
+PKGDEP="libcacard gtk-3 pulseaudio usbredir libsoup lz4 phodav usbutils \
         gst-plugins-base-1-0 json-glib"
 BUILDDEP="gobject-introspection vala spice-protocol intltool"
 PKGDES="GTK+ client and libraries for SPICE remote desktop servers"

--- a/extra-libs/libspice-gtk/spec
+++ b/extra-libs/libspice-gtk/spec
@@ -1,4 +1,4 @@
-VER=0.38
+VER=0.41
 SRCS="tbl::https://www.spice-space.org/download/gtk/spice-gtk-$VER.tar.xz"
-CHKSUMS="sha256::5ae974731baf2b41316d4f0b3ae0c2e47f00bff91a5a617e189cd3dedcd96d8e"
+CHKSUMS="sha256::d8f8b5cbea9184702eeb8cc276a67d72acdb6e36e7c73349fb8445e5bca0969f"
 CHKUPDATE="anitya::id=11576"

--- a/extra-network/spice-protocol/spec
+++ b/extra-network/spice-protocol/spec
@@ -1,5 +1,4 @@
-VER=0.14.2
-REL=1
+VER=0.14.4
 SRCS="tbl::https://spice-space.org/download/releases/spice-protocol-$VER.tar.xz"
-CHKSUMS="sha256::8f3a63c8b68300dffe36f2e75eac57afa1e76d5d80af760fd138a0b3f44cf1e9"
+CHKSUMS="sha256::04ffba610d9fd441cfc47dfaa135d70096e60b1046d2119d8db2f8ea0d17d912"
 CHKUPDATE="anitya::id=14892"


### PR DESCRIPTION
Topic Description
-----------------

Update `libspice-gtk` to 0.41 to fix FTBFS.

Also, as a dependency, update `spice-protocol` to 0.14.4.

Package(s) Affected
-------------------

- `libspice-gtk`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
