### PR TITLE
libva-nvidia-driver: add missing dependency gstreamer

### DIFF
--- a/extra-libs/libva-nvidia-driver/autobuild/defines
+++ b/extra-libs/libva-nvidia-driver/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=libva-nvidia-driver
 PKGDES="NVDEC backend for VA-API"
 PKGSEC=libs
-PKGDEP="libva"
+PKGDEP="libva gstreamer"
 BUILDDEP="ffnvcodec"
 
 PKGBREAK="libva-vdpau-driver<=0.7.4-6"
+FAIL_ARCH="!(amd64|arm64)"

--- a/extra-libs/libva-nvidia-driver/spec
+++ b/extra-libs/libva-nvidia-driver/spec
@@ -1,4 +1,5 @@
 VER=0.0.6
+REL=1
 SRCS="tbl::https://github.com/elFarto/nvidia-vaapi-driver/archive/refs/tags/v0.0.6.tar.gz"
 CHKSUMS="sha256::8a64c069200750f12d013c79547e459cbb87b498357478c5f36cb97f710294e0"
 CHKUPDATE="anitya::id=1754"


### PR DESCRIPTION

Topic Description
-----------------

- libva-nvidia-driver depends on `libgstcodecparsers-1.0.so.0`. `gstreamer` is now a PKGDEP of libva-nvidia-driver.
- This package doesn't seem to make sense on architecture w/o nvidia official driver support. Should only build this on amd64/arm64.

Package(s) Affected
-------------------

libva-nvidia-driver

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

<!-- TODO: CI to auto-fill architectural progress. -->
