### PR TITLE
libdmapsharing: add missing BUILDDEPs

### DIFF
--- a/extra-libs/libdmapsharing/autobuild/defines
+++ b/extra-libs/libdmapsharing/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=libdmapsharing
 PKGSEC=libs
 PKGDEP="libsoup avahi gst-plugins-base-1-0 gdk-pixbuf"
+BUILDDEP="gtk-doc check"
 PKGDES="A library that implements the DMAP family of protocols"
 
-AUTOTOOLS_AFTER="--with-mdns=avahi LIBS=-lm"
+AUTOTOOLS_AFTER="--with-mdns=avahi --enable-gtk-doc LIBS=-lm"
 ABSHADOW=no
+ABTYPE=autotools

--- a/extra-libs/libdmapsharing/spec
+++ b/extra-libs/libdmapsharing/spec
@@ -1,4 +1,5 @@
 VER=2.9.41
+REL=1
 SRCS="tbl::https://www.flyn.org/projects/libdmapsharing/libdmapsharing-$VER.tar.gz"
 CHKSUMS='sha256::0c1fcf89e9de5489fd9a28c7b5cd7e2538fbcf187b1480c0b74d5a1785fb0154'
 CHKUPDATE="anitya::id=11641"


### PR DESCRIPTION
Topic Description
-----------------

Add missing `gtk-doc` and `check` BUILDDEPs to libdmapsharing to fix FTBFS.

Package(s) Affected
-------------------

- `libdmapsharing`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
