### PR TITLE
babl: update to 0.1.96

### DIFF
--- a/extra-libs/babl/autobuild/defines
+++ b/extra-libs/babl/autobuild/defines
@@ -13,7 +13,6 @@ MESON_AFTER__AMD64=" \
              -Denable-mmx=true \
              -Denable-sse=true \
              -Denable-sse2=true \
-             -Denable-sse3=true \
              -Denable-sse4_1=false \
              -Denable-avx2=false \
              -Denable-f16c=false"

--- a/extra-libs/babl/spec
+++ b/extra-libs/babl/spec
@@ -1,4 +1,4 @@
-VER=0.1.84
+VER=0.1.96
 SRCS="tbl::https://download.gimp.org/pub/babl/${VER%.*}/babl-$VER.tar.xz"
-CHKSUMS="sha256::e7e38b8441f77feb9dc8231cb434a86190a21f2f3692c281457e99d35e9c34ea"
+CHKSUMS="sha256::33673fe459a983f411245a49f81fd7f1966af1ea8eca9b095a940c542b8545f6"
 CHKUPDATE="anitya::id=7843"


### PR DESCRIPTION
Topic Description
-----------------

Update `babl` to 0.1.96, which does not change soname at all but fixes FTBFS because of Meson.

Package(s) Affected
-------------------

- `babl`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
