### PR TITLE
gegl-0.4: disable luajit on riscv64

### DIFF
--- a/extra-libs/gegl-0.4/autobuild/defines
+++ b/extra-libs/gegl-0.4/autobuild/defines
@@ -5,6 +5,7 @@ PKGDEP="babl ffmpeg gexiv2 glib graphviz jasper json-glib lensfun libopenraw \
         pygobject-3 sdl2 suitesparse v4l-utils"
 BUILDDEP="asciidoc gtk-doc intltool luajit ruby source-highlight vala"
 BUILDDEP__PPC64EL="${BUILDDEP/luajit/}"
+BUILDDEP__RISCV64="${BUILDDEP/luajit/}"
 PKGDES="Graph based image processing framework (0.4)"
 
 MESON_AFTER="-Ddocs=true \
@@ -36,8 +37,11 @@ MESON_AFTER="-Ddocs=true \
              -Dumfpack=enabled \
              -Dwebp=enabled"
 
-# FIXME: No LuaJIT support for ppc64*.
+# FIXME: No LuaJIT support for ppc64* and riscv64.
 MESON_AFTER__PPC64EL=" \
+             ${MESON_AFTER} \
+             -Dlua=disabled"
+MESON_AFTER__RISCV64=" \
              ${MESON_AFTER} \
              -Dlua=disabled"
 


### PR DESCRIPTION
Topic Description
-----------------

Adapt `gegl-0.4` to riscv64 by disabling the non-applicable LuaJIT support.

Package(s) Affected
-------------------

- `gegl-0.4`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
