### PR TITLE
Gnome ffi segv rework

### DIFF
--- a/extra-gnome/gjs/autobuild/defines
+++ b/extra-gnome/gjs/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gjs
 PKGSEC=gnome
-PKGDEP="cairo gobject-introspection js-91 gtk-3"
+PKGDEP="cairo gobject-introspection js-102 gtk-3"
 PKGDES="JavaScript bindings for GNOME"
 
 MESON_AFTER="-Dcairo=enabled \

--- a/extra-gnome/gjs/spec
+++ b/extra-gnome/gjs/spec
@@ -1,5 +1,4 @@
-VER=1.72.2
-REL=1
+VER=1.74.0
 SRCS="https://download.gnome.org/sources/gjs/${VER:0:4}/gjs-$VER.tar.xz"
-CHKSUMS="sha256::ddee379bdc5a7d303a5d894be2b281beb8ac54508604e7d3f20781a869da3977"
+CHKSUMS="sha256::7d6418af62cc73556ab2c25b4adf67f45238ab8925888f7a57251359d4ebed1e"
 CHKUPDATE="anitya::id=9532"

--- a/extra-gnome/gtk-3/autobuild/defines
+++ b/extra-gnome/gtk-3/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=gtk-3
 PKGSEC=x11
 PKGDEP="adwaita-icon-theme at-spi2-atk cairo colord x11-lib pango libepoxy shared-mime-info \
-        wayland libxkbcommon rest gdk-pixbuf wayland-protocols"
+        wayland libxkbcommon rest gdk-pixbuf wayland-protocols libffi"
 PKGDEP__RETRO=" \
         adwaita-icon-theme at-spi2-atk cairo x11-lib pango libepoxy shared-mime-info \
         libxkbcommon gdk-pixbuf"

--- a/extra-gnome/gtk-3/spec
+++ b/extra-gnome/gtk-3/spec
@@ -1,4 +1,5 @@
 VER=3.24.34
+REL=1
 SRCS="https://download.gnome.org/sources/gtk+/${VER:0:4}/gtk+-$VER.tar.xz"
 CHKSUMS="sha256::dbc69f90ddc821b8d1441f00374dc1da4323a2eafa9078e61edbe5eeefa852ec"
 CHKUPDATE="anitya::id=10018"

--- a/extra-libs/js-102/autobuild/build
+++ b/extra-libs/js-102/autobuild/build
@@ -1,0 +1,36 @@
+export M4=m4
+export AWK=awk
+export AC_MACRODIR="$SRCDIR"/build/autoconf/
+
+# adapted from Fedora F36
+abinfo "Generating configure script ..."
+# this autoconf.sh is sensitive to the current working directory
+# we need to enter js/src in order to make the script generated correctly
+cd "$SRCDIR"/js/src
+sh "$SRCDIR"/build/autoconf/autoconf.sh --localdir="$SRCDIR"/js/src configure.in > ./configure
+chmod a+x "$SRCDIR"/js/src/configure
+
+cd "$SRCDIR"/build
+
+abinfo "Configuring MozJS 102 ..."
+sh "$SRCDIR"/js/src/configure \
+    --prefix=/usr \
+    ${AUTOTOOLS_AFTER}
+
+abinfo "Building MozJS 102 ..."
+make
+
+abinfo "Installing MozJS 102 ..."
+make DESTDIR="$PKGDIR" install
+
+abinfo "Removing all .ajs files from /usr/lib ..."
+rm -v "$PKGDIR"/usr/lib/*.ajs
+
+abinfo "Dropping executable bits from pkgconfig, include ..."
+find "$PKGDIR"/usr/{lib/pkgconfig,include} -type f \
+    -exec chmod -v -c a-x {} +
+
+abinfo "Removing /usr/bin ..."
+rm -rv "$PKGDIR"/usr/bin
+
+cd "$SRCDIR"

--- a/extra-libs/js-102/autobuild/defines
+++ b/extra-libs/js-102/autobuild/defines
@@ -1,0 +1,39 @@
+PKGNAME=js-102
+PKGSEC=libs
+PKGDEP="nspr readline zlib"
+BUILDDEP="autoconf-2.13 rustc llvm"
+PKGDES="Mozilla JavaScript interpreter library (mainline, 102)"
+
+AUTOTOOLS_AFTER="--disable-debug
+                 --disable-debug-symbols
+                 --disable-jemalloc
+                 --disable-strip
+                 --enable-hardening
+                 --enable-linker=gold
+                 --enable-optimize
+                 --enable-readline
+                 --enable-release
+                 --enable-shared-js
+                 --disable-tests
+                 --with-intl-api
+                 --with-system-zlib
+                 --without-system-icu"
+AUTOTOOLS_AFTER__LOONGSON3=" \
+                 ${AUTOTOOLS_AFTER} \
+                 --target=mips64el-aosc-linux-gnuabi64 \
+                 --host=mips64el-aosc-linux-gnuabi64 \
+                 --disable-jit \
+                 --enable-linker=bfd"
+AUTOTOOLS_AFTER__RISCV64=" \
+                 ${AUTOTOOLS_AFTER} \
+                 --disable-jit \
+                 --enable-linker=bfd"
+
+AB_FLAGS_SPECS__ARMV4=0
+AB_FLAGS_SPECS__ARMV6HF=0
+AB_FLAGS_SPECS__ARMV7HF=0
+AB_FLAGS_SPECS__POWERPC=0
+AB_FLAGS_SPECS__PPC64=0
+
+NOLTO=1
+ABSPLITDBG=0

--- a/extra-libs/js-102/autobuild/prepare
+++ b/extra-libs/js-102/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo 'Declaring $SHELL as /bin/bash ...'
+export SHELL=/bin/bash
+
+abinfo "Removing bundled zlib ..."
+rm -rv "$SRCDIR"/modules/zlib
+
+abinfo "Appending LDFLAGS to LINKFLAGS ..."
+export LINKFLAGS="${LDFLAGS}"

--- a/extra-libs/js-102/spec
+++ b/extra-libs/js-102/spec
@@ -1,0 +1,4 @@
+VER=102.3.0
+SRCS="https://ftp.mozilla.org/pub/firefox/releases/${VER}esr/source/firefox-${VER}esr.source.tar.xz"
+CHKSUMS="sha256::308e23b6dcf964e342cf95fd0c8a386127371b620a489ae26e537d728341b55a"
+CHKUPDATE="html::url=https://ftp.mozilla.org/pub/firefox/releases/;pattern=(102\.\d+\.\d+)esr"

--- a/groups/libffi-rebuilds.amd64
+++ b/groups/libffi-rebuilds.amd64
@@ -31,6 +31,7 @@ extra-devel/php7
 ## Fixme: Cabal is FTBFS
 ## extra-haskell/cabal-install
 extra-lua/lgi
+extra-gnome/gtk-3
 ##
 ## Stage 3: Non-essential packages
 extra-admin/tahoe-lafs

--- a/groups/libffi-rebuilds.arm64
+++ b/groups/libffi-rebuilds.arm64
@@ -30,6 +30,7 @@ extra-devel/php7
 ## Fixme: Cabal is FTBFS
 ## extra-haskell/cabal-install
 extra-lua/lgi
+extra-gnome/gtk-3
 ##
 ## Stage 3: Non-essential packages
 extra-admin/tahoe-lafs

--- a/groups/libffi-rebuilds.loongson3
+++ b/groups/libffi-rebuilds.loongson3
@@ -31,6 +31,7 @@ extra-devel/php7
 ## Fixme: Cabal is FTBFS
 ### extra-haskell/cabal-install
 extra-lua/lgi
+extra-gnome/gtk-3
 ##
 ## Stage 3: Non-essential packages
 extra-admin/tahoe-lafs

--- a/groups/libffi-rebuilds.riscv64
+++ b/groups/libffi-rebuilds.riscv64
@@ -32,6 +32,7 @@ extra-devel/php7
 ## Fixme: Cabal is FTBFS
 ### extra-haskell/cabal-install
 extra-lua/lgi
+extra-gnome/gtk-3
 ##
 ## Stage 3: Non-essential packages
 extra-admin/tahoe-lafs


### PR DESCRIPTION
Topic Description
-----------------

This is a follow up topic of #4205 . 
After merging of #4205 , gnome user experience may break due to an issue regarding to gjs. The topic will update gjs to 1.74.0, with a new dependency js-102;
The topic also fixes an issue which gtk-3 does not include libffi as a runtime dependency, which may prevent potential further issue.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- js-102: new
- gjs: upgrade to 1.74.0
- gtk-3: rebuild
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

No

Build Order
-----------

`js-102 gjs gtk-3`

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`
