### PR TITLE
libunity: import a patch from Fedora to fix FTBFS

### DIFF
--- a/extra-libs/libunity/autobuild/patches/0002-Fedora-libunity-7.1.4-vala-053.patch
+++ b/extra-libs/libunity/autobuild/patches/0002-Fedora-libunity-7.1.4-vala-053.patch
@@ -1,0 +1,22 @@
+--- libunity-7.1.4/protocol/protocol-icon.vala.debug	2019-03-19 19:17:56.000000000 +0900
++++ libunity-7.1.4/protocol/protocol-icon.vala	2021-09-13 22:11:06.634930969 +0900
+@@ -185,7 +185,7 @@ public class AnnotatedIcon : Object, GLi
+   }
+ 
+   /* Added to GIcon interface in 2.37 */
+-  private Variant serialize ()
++  private Variant? serialize ()
+   {
+     Variant? ret = null;
+     return ret;
+--- libunity-7.1.4/src/unity-scope-channel.vala.debug	2019-03-19 19:18:05.000000000 +0900
++++ libunity-7.1.4/src/unity-scope-channel.vala	2021-09-13 22:16:25.440323188 +0900
+@@ -312,7 +312,7 @@ internal class ScopeChannel : Object
+           DBusSignalFlags.NONE, this.owner_changed);
+     }
+ 
+-    private void owner_changed (DBusConnection con, string sender_name,
++    private void owner_changed (DBusConnection con, string? sender_name,
+                                 string obj_path, string ifc_name,
+                                 string sig_name, Variant parameters)
+     {

--- a/extra-libs/libunity/spec
+++ b/extra-libs/libunity/spec
@@ -1,7 +1,7 @@
 VER=7.1.4
 UBUNTUVER=19.04.20190319
 UBUNTUREL=0ubuntu1
-REL=4
+REL=5
 SRCS="tbl::https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/libunity/${VER}+${UBUNTUVER}-${UBUNTUREL}/libunity_$VER+${UBUNTUVER}.orig.tar.gz"
 CHKSUMS="sha256::56ecb380d74bf74caba193d9e8ad6b0c85ccf9eeb461bc9731c2b8636e1f1492"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Fix FTBFS of `libunity` by importing a patch from Fedora that fixes new Vala compatibility.

Package(s) Affected
-------------------

- `libunity`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
