### PR TITLE
gnome-software: adapt for riscv64 by masking valgrind

### DIFF
--- a/extra-gnome/gnome-software/autobuild/defines
+++ b/extra-gnome/gnome-software/autobuild/defines
@@ -7,6 +7,7 @@ PKGDEP="appstream appstream-glib desktop-file-utils flatpak gnome-desktop \
 PKGDEP__AMD64="${PKGDEP} fwupd"
 PKGDEP__ARM64="${PKGDEP} fwupd"
 BUILDDEP="docbook-utils gtk-doc gperf intltool valgrind"
+BUILDDEP__RISCV64="${BUILDDEP/valgrind/}"
 PKGDES="A software store for GNOME"
 
 MESON_AFTER="-Dgsettings_desktop_schemas=enabled \
@@ -36,3 +37,7 @@ MESON_AFTER__LOONGSON3=" \
 MESON_AFTER__PPC64EL=" \
              ${MESON_AFTER} \
              -Dfwupd=false"
+MESON_AFTER__RISCV64=" \
+             ${MESON_AFTER} \
+             -Dfwupd=false \
+             -Dvalgrind=false"


### PR DESCRIPTION
Topic Description
-----------------

Adapt `gnome-software` for riscv64 by disabling Valgrind support.

Package(s) Affected
-------------------

- `gnome-software`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
