### PR TITLE
polymc: use "AOSC MC" Microsoft MSA Client ID

### DIFF
--- a/extra-games/polymc/autobuild/build
+++ b/extra-games/polymc/autobuild/build
@@ -1,8 +1,11 @@
 abinfo "Building polymc ..."
 mkdir -pv "$BLDDIR"
 cd "$BLDDIR"
+
+# Using "AOSC MC" Microsoft APPID for logging in with Microsoft accounts
 cmake "$SRCDIR" ${CMAKE_DEF} \
       -DLauncher_BUILD_PLATFORM="AOSC OS" \
+      -DLauncher_MSA_CLIENT_ID=81a207c0-a53c-46a3-be07-57d2b28c1643 \
       -DENABLE_LTO=on
 cmake --build "$BLDDIR"
 

--- a/extra-games/polymc/spec
+++ b/extra-games/polymc/spec
@@ -1,4 +1,5 @@
 VER=1.4.2
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/PolyMC/PolyMC"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243161"


### PR DESCRIPTION
Signed-off-by: Kaiyang Wu <origincode@aosc.io>

<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Use "AOSC MC" Microsoft MSA Client ID.

Ref:
https://github.com/PolyMC/PolyMC/commit/ccf282593dcdbe189c99b81b8bc90cb203aed3ee
https://github.com/PolyMC/PolyMC/commit/ebbc1f67e02e62b8024280232cfb936468afd395

The default ID in 1.4.2 is invalid now.

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`polymc` 1.4.2-1

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
