### PR TITLE
uboot-tools: update to 2022.10

### DIFF
--- a/extra-utils/uboot-tools/autobuild/build
+++ b/extra-utils/uboot-tools/autobuild/build
@@ -1,5 +1,5 @@
 abinfo "Building ..."
-make -C "$SRCDIR" defconfig
+make -C "$SRCDIR" tools-only_defconfig
 make -C "$SRCDIR" tools-all HOSTCC="gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
 
 abinfo "Installing ..."

--- a/extra-utils/uboot-tools/autobuild/defines
+++ b/extra-utils/uboot-tools/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=uboot-tools
 PKGSEC=utils
 PKGDEP="openssl"
+BUILDDEP="python-3 swig"
 PKGDES="U-Boot bootloader utilities"

--- a/extra-utils/uboot-tools/spec
+++ b/extra-utils/uboot-tools/spec
@@ -1,4 +1,4 @@
-VER=2022.01
+VER=2022.10
 SRCS="tbl::https://ftp.denx.de/pub/u-boot/u-boot-$VER.tar.bz2"
-CHKSUMS="sha256::81b4543227db228c03f8a1bf5ddbc813b0bb8f6555ce46064ef721a6fc680413"
+CHKSUMS="sha256::50b4482a505bc281ba8470c399a3c26e145e29b23500bc35c50debd7fa46bdf8"
 CHKUPDATE="anitya::id=5022"


### PR DESCRIPTION
Topic Description
-----------------

Update uboot-tools to 2022.10 and fix its FTBFS on non-x86-arm architectures.

Package(s) Affected
-------------------

- `uboot-tools`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
