### PR TITLE
gdb: enable all targets and languages

### DIFF
--- a/extra-devel/gdb/autobuild/defines
+++ b/extra-devel/gdb/autobuild/defines
@@ -19,7 +19,7 @@ AUTOTOOLS_AFTER="--with-system-readline --with-xxhash \
                  --enable-guile --enable-tui --enable-sim \
                  --enable-source-highlight --enable-threading \
                  --enable-64-bit-bfd \
-                 --enable-targets=aarch64-linux-gnu,alpha-linux-gnu,arm-linux-gnueabi,arm-linux-gnueabihf,i486-linux-gnu,mips64el-linux-gnu,powerpc64le-linux-gnu,x86_64-linux-gnu,riscv64-linux-gnu,loongarch64-linux-gnu"
+                 --enable-targets=all --enable-languages=all"
 # TODO: Re-check this when updating this package in Retro
 AUTOTOOLS_AFTER__RETRO=" \
                  ${AUTOTOOLS_AFTER} \

--- a/extra-devel/gdb/spec
+++ b/extra-devel/gdb/spec
@@ -1,5 +1,5 @@
 VER=12.1
-REL=1
+REL=2
 SRCS="tbl::https://ftp.gnu.org/gnu/gdb/gdb-$VER.tar.xz"
 CHKSUMS="sha256::0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed"
 CHKUPDATE="anitya::id=11798"


### PR DESCRIPTION
Topic Description
-----------------

Enable all possible targets and languages for GDB, to allow to use it anywhere.

Package(s) Affected
-------------------

- `gdb`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
