### PR TITLE
Moonlight survey 20221102

### DIFF
--- a/extra-multimedia/moonlight-embedded/autobuild/beyond
+++ b/extra-multimedia/moonlight-embedded/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Renaming the executable to moonlight-embedded to allow coexistence with moonlight-qt ..."
+mv -v "$PKGDIR"/usr/bin/moonlight{,-embedded}

--- a/extra-multimedia/moonlight-embedded/autobuild/defines
+++ b/extra-multimedia/moonlight-embedded/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=moonlight-embedded
+PKGDES="An open source embedded-Linux-optimized client for NVIDIA GameStream"
+PKGSEC=video
+PKGDEP="alsa-lib pulseaudio opus sdl2 ffmpeg libvdpau libva libglvnd libcec libevdev curl openssl util-linux"
+
+ABTYPE=cmakeninja
+# Override CMAKE_INSTALL_SYSCONFDIR for consistency with manpage
+CMAKE_AFTER="-DENABLE_SDL=ON -DENABLE_FFMPEG=ON -DENABLE_X11=ON \
+             -DENABLE_CEC=ON -DENABLE_PULSE=ON \
+             -DCMAKE_INSTALL_SYSCONFDIR=/etc/moonlight"

--- a/extra-multimedia/moonlight-embedded/autobuild/patch
+++ b/extra-multimedia/moonlight-embedded/autobuild/patch
@@ -1,0 +1,2 @@
+abinfo "Changing the manual file's command name to moonlight-embedded ..."
+sed -i 's/moonlight\.1/moonlight-embedded.1/g' "$SRCDIR"/docs/CMakeLists.txt

--- a/extra-multimedia/moonlight-embedded/spec
+++ b/extra-multimedia/moonlight-embedded/spec
@@ -1,0 +1,5 @@
+VER=2.5.3
+SRCS="tbl::https://github.com/moonlight-stream/moonlight-embedded/releases/download/v${VER}/moonlight-embedded-${VER}.tar.xz"
+CHKSUMS="sha256::2fcd00049f58b0af882f0eec7077013c062bc35c8705f3d6bb7949d44e98fac0"
+# Weird upstream package
+SUBDIR="."

--- a/extra-multimedia/moonlight-qt/autobuild/defines
+++ b/extra-multimedia/moonlight-qt/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=moonlight-qt
+PKGDES="An open source PC client for NVIDIA GameStream"
+PKGDEP="qt-5 libdrm wayland libglvnd libva libvdpau ffmpeg openssl sdl2 sdl2-ttf opus"
+BUILDDEP__AMD64="ffnvcodec"
+PKGSEC=video
+
+ABTYPE=qtproj

--- a/extra-multimedia/moonlight-qt/spec
+++ b/extra-multimedia/moonlight-qt/spec
@@ -1,0 +1,5 @@
+VER=4.3.0
+SRCS="tbl::https://github.com/moonlight-stream/moonlight-qt/releases/download/v4.3.0/MoonlightSrc-4.3.0.tar.gz"
+CHKSUMS="sha256::6ad2e1d9d32758505bb770fe581b84ebc86f63b12ab7002a1ac10d136ec8b747"
+# Weird upstream package...
+SUBDIR="."

--- a/extra-multimedia/sunshine/autobuild/defines
+++ b/extra-multimedia/sunshine/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=sunshine
+PKGDES="A Gamestream host for Moonlight"
+PKGSEC=video
+PKGDEP="pulseaudio libdrm libevdev icu wayland openssl ffmpeg"
+PKGRECOM="avahi"
+ABTYPE=cmakeninja
+
+# SUNSHINE_ASSETS_DIR is set to make data files follow FHS, otherwise it will
+# come at /usr/assets
+CMAKE_AFTER="-DSUNSHINE_ENABLE_CUDA=OFF -DSUNSHINE_ENABLE_DRM=ON \
+             -DSUNSHINE_ENABLE_X11=ON -DSUNSHINE_ENABLE_WAYLAND=ON \
+             -DSUNSHINE_ASSETS_DIR=share/sunshine"

--- a/extra-multimedia/sunshine/spec
+++ b/extra-multimedia/sunshine/spec
@@ -1,0 +1,3 @@
+VER=0.15.0
+SRCS="git::commit=tags/v${VER}::https://github.com/LizardByte/Sunshine"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Add some packages related to open source implementation of NVIDIA GameStream, Moonlight.

This survey includes two clients (one Qt and one SDL only) and one server of NVIDIA GameStream.

Package(s) Affected
-------------------

- `moonlight-qt`
- `moonlight-embedded`
- `sunshine`

Security Update?
----------------

No

Build Order
-----------

Any should be okay.

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
