### PR TITLE
Intel driver survey 20221102

### DIFF
--- a/extra-libs/intel-gmmlib/spec
+++ b/extra-libs/intel-gmmlib/spec
@@ -1,4 +1,4 @@
-VER=21.2.1
+VER=22.3.0
 SRCS="tbl::https://github.com/intel/gmmlib/archive/intel-gmmlib-$VER.tar.gz"
-CHKSUMS="sha256::912cd86e4cb564b6fa549d69a28b72b9cdcb5a3eab9320955ed70ac37381fc2f"
+CHKSUMS="sha256::c1f33e1519edfc527127baeb0436b783430dfd256c643130169a3a71dc86aff9"
 CHKUPDATE="anitya::id=20342"

--- a/extra-libs/intel-media-driver/spec
+++ b/extra-libs/intel-media-driver/spec
@@ -1,4 +1,4 @@
-VER=20.2.0
+VER=22.6.0
 SRCS="tbl::https://github.com/intel/media-driver/archive/intel-media-$VER.tar.gz"
-CHKSUMS="sha256::1cdd40517d9fee51e3760beea23d2a19c2d5fcb1d6a9ed2bc0af7318d0d3100f"
+CHKSUMS="sha256::bee655102b0c56ea3eee6e8d1d203a67bf7e0c4696ebde2b8ae40067eb12b23f"
 CHKUPDATE="anitya::id=20341"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Intel media driver to 22.6, which supports Alder lake (12th gen), Raptor Lake, and its DG2 (Arc) platform.

Package(s) Affected
-------------------

- `intel-gmmlib`
- `intel-media-driver`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
