### PR TITLE
ncbi-blast: update to 2.13.0

### DIFF
--- a/extra-scientific/ncbi-blast+/autobuild/defines
+++ b/extra-scientific/ncbi-blast+/autobuild/defines
@@ -2,8 +2,6 @@ PKGNAME=ncbi-blast+
 PKGSEC=science
 PKGDES="NCBI Blast+ for Basic Local Alignment Search Tool running on your machine."
 
-# FIXME: takes too long to build.
-NOLTO=1
 RECONF=0
 AUTOTOOLS_STRICT=0
 ABSHADOW=0

--- a/extra-scientific/ncbi-blast+/autobuild/patches/0001-feature-enable-debug.patch
+++ b/extra-scientific/ncbi-blast+/autobuild/patches/0001-feature-enable-debug.patch
@@ -1,0 +1,9 @@
+diff --git a/configure b/configure
+index 82053df..cf6ceea 100755
+--- a/configure
++++ b/configure
+@@ -1,3 +1,3 @@
+ #!/bin/sh
+ srcdir=`dirname $0`
+-exec $srcdir/configure.orig --without-debug --with-strip --with-openmp --with-mt --without-vdb --without-gnutls --without-gcrypt --with-build-root=$srcdir/ReleaseMT --with-experimental=Int8GI ${1+"$@"}
++exec $srcdir/configure.orig --with-openmp --with-mt --without-vdb --without-gnutls --without-gcrypt --with-build-root=$srcdir/ReleaseMT --with-experimental=Int8GI ${1+"$@"}

--- a/extra-scientific/ncbi-blast+/spec
+++ b/extra-scientific/ncbi-blast+/spec
@@ -1,6 +1,5 @@
-VER=2.9.0
-REL=1
+VER=2.13.0
 SRCS="tbl::https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${VER}/ncbi-blast-${VER}+-src.tar.gz"
 SUBDIR="ncbi-blast-${VER}+-src/c++"
-CHKSUMS="sha256::a390cc2d7a09422759fc178db84de9def822cbe485916bbb2ec0d215dacdc257"
+CHKSUMS="sha256::89553714d133daf28c477f83d333794b3c62e4148408c072a1b4620e5ec4feb2"
 CHKUPDATE="anitya::id=21036"


### PR DESCRIPTION
Topic Description
-----------------

Upgrade `ncbi-blast+` to 2.13.0

- Enable LTO as even though it takes a lot of time, it does indeed compile
- Disable `ABSPLITDBG` as it does not produce debug symbols

Package(s) Affected
-------------------
`ncbi-blast+`: 2.13.0

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
