### PR TITLE
multipathd: upgrade to 0.9.1, fix library dlopen path

### DIFF
--- a/extra-admin/multipath-tools/autobuild/prepare
+++ b/extra-admin/multipath-tools/autobuild/prepare
@@ -5,3 +5,6 @@ sed -e 's/sed -n .*$/head -n1 | cut -d" " -f2\)/g' \
 abinfo "Tweaking Makefile.inc: /usr/sbin => /usr/bin ..."
 sed -e 's|sbin|bin|g' \
     -i "$SRCDIR"/Makefile.inc
+
+abinfo "Unsetting ab3 make install args for proper .so placement"
+unset MAKE_INSTALL_DEF

--- a/extra-admin/multipath-tools/spec
+++ b/extra-admin/multipath-tools/spec
@@ -1,5 +1,4 @@
-VER=0.8.8
-REL=1
+VER=0.9.1
 SRCS="https://github.com/opensvc/multipath-tools/archive/$VER.tar.gz"
-CHKSUMS="sha256::ff45ddb18a1effbfbe5712f513dd3b7146c68141091fc1c2489af8d6197026ef"
+CHKSUMS="sha256::0e856814aa4b2a24eddd918f4be812af40c28956f48b198f51b73e47d0da0d73"
 CHKUPDATE="anitya::id=424"


### PR DESCRIPTION
Topic Description
-----------------

Current multipathd in AOSC has a packaging error where mp modules are installed in a different directory than the one multipathd actually looks for modules in. As a result `multipathd` is completely broken at this point and is unusable.

Package(s) Affected
-------------------

multipathd

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
