### PR TITLE
PyOpenSSL and certbot survey Nov'11

### DIFF
--- a/extra-network/certbot/spec
+++ b/extra-network/certbot/spec
@@ -1,4 +1,4 @@
-VER=1.21.0
+VER=1.31.0
 SRCS="tbl::https://pypi.io/packages/source/c/certbot/certbot-$VER.tar.gz"
-CHKSUMS="sha256::200b490ac303f75919abcf0d1e7e144caca101f1d6f064b4385ad9d240805192"
+CHKSUMS="sha256::29af531d33aaa87c8104864cd31ac2af541f0ec973a7252d7f7f5b15e10479db"
 CHKUPDATE="anitya::id=10690"

--- a/extra-python/acme/spec
+++ b/extra-python/acme/spec
@@ -1,4 +1,4 @@
-VER=1.22.0
+VER=1.31.0
 SRCS="tbl::https://pypi.io/packages/source/a/acme/acme-$VER.tar.gz"
-CHKSUMS="sha256::05434e486a0e0958e197bd5eb28a07d87d930e0045bf00a190cf645d253a0dd9"
+CHKSUMS="sha256::f5e13262fa1101c38dd865378ac8b4639f819120eb66c5538fc6c09b7576fc53"
 CHKUPDATE="anitya::id=8231"

--- a/extra-python/josepy/spec
+++ b/extra-python/josepy/spec
@@ -1,4 +1,4 @@
-VER=1.11.0
+VER=1.13.0
 SRCS="tbl::https://github.com/certbot/josepy/archive/v$VER.tar.gz"
-CHKSUMS="sha256::a18eb19824b9e98be4d8fc56b37ceac2117ac72a873acdf1b0a242744dd62473"
+CHKSUMS="sha256::708208a9523f1512ecc79cb7cd581a469f3142b68d88100a55fd010c82549d76"
 CHKUPDATE="anitya::id=17050"

--- a/extra-python/pyopenssl/autobuild/defines
+++ b/extra-python/pyopenssl/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=pyopenssl
 PKGSEC=python
 PKGDEP="cryptography six"
-BUILDDEP="setuptools"
+BUILDDEP="setuptools python-build wheel python-installer"
 PKGDES="Python wrapper around the OpenSSL library"
 
 ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/pyopenssl/spec
+++ b/extra-python/pyopenssl/spec
@@ -1,5 +1,4 @@
-VER=20.0.1
+VER=22.1.0
 SRCS="https://pypi.io/packages/source/p/pyOpenSSL/pyOpenSSL-$VER.tar.gz"
-CHKSUMS="sha256::4c231c759543ba02560fcd2480c48dcec4dae34c9da7d3747c508227e0624b51"
+CHKSUMS="sha256::7a83b7b272dd595222d672f5ce29aa030f1fb837630ef229f62e72e395ce8968"
 CHKUPDATE="anitya::id=5535"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

This PR fixes an error on PyOpenSSL import and upgrades a few packages used by certbot.

Package(s) Affected
-------------------

pyopenssl josepy acme certbot

Build Order
-----------

pyopenssl josepy acme certbot

Test Build(s) Done
------------------

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

- [x] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
