### PR TITLE
fcitx5-pinyin-moegirl: update to 20221114

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20220925
+VER=20221114
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::714cbd4fe2e8cf86d929c9f56e5a5440f012d3798bb9ca528607b16b6f6072b7 \
-         sha256::461285d15f81394e9938a2bbfaae3f34fab22b652f086204dccb9fce9d04ae0c \
+CHKSUMS="sha256::8791f8614966f111ec4a0d33fdf4e6a1e6a5c458dc2ea488525525a0d0941d6e \
+         sha256::0078f98e234a06ef2a8b9cc710320f8b613d8d414de55dae04b445c9cf12e623 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

fcitx5-pinyin-moegirl: update to 20221114

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`