### PR TITLE
Nvidia survey Oct'22

### DIFF
--- a/extra-devel/cuda/autobuild/build
+++ b/extra-devel/cuda/autobuild/build
@@ -41,7 +41,13 @@ mkdir -pv "$PKGDIR"/usr/share/doc/"$PKGNAME"
 ln -sv ../../lib/cuda/doc/pdf/EULA.pdf \
     "$PKGDIR"/usr/share/doc/"$PKGNAME"/EULA.pdf
 
-abinfo "Adding executable bits to all shared libraries ..."
+abinfo "Setting executable bits to all shared libraries ..."
 for i in "$PKGDIR"/**/*.so*; do
-    chmod -v +x $i
+    chmod -v 0755 $i
 done
+
+abinfo "Setting executable bits to all static libraries ..."
+for i in "$PKGDIR"/**/*.a; do
+    chmod -v 0644 $i
+done
+

--- a/extra-devel/cuda/spec
+++ b/extra-devel/cuda/spec
@@ -1,9 +1,10 @@
-CUDA_VER=11.7.0
-MIN_DRIVER_VER=515.43.04
+CUDA_VER=11.8.0
+MIN_DRIVER_VER=520.61.05
 VER=${CUDA_VER}+${MIN_DRIVER_VER}
-REL=1
-SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS__AMD64="sha256::087fdfcbba1f79543b1f78e43a8dfdac5f6db242d042dde820e16dc185892f26"
-SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
-CHKSUMS__ARM64="sha256::e777839a618ca9a3d5ad42ded43a1b6392af2321a7327635a4afcc986876a21b"
 CHKUPDATE="anitya::id=13462"
+
+SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${VER/+/_}_linux.run"
+CHKSUMS__AMD64="sha256::9223c4af3aebe4a7bbed9abd9b163b03a1b34b855fbc2b4a0d1b706ac09a5a16"
+
+SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
+CHKSUMS__ARM64="sha256::e6e9a8d31163c9776b5e313fd7590877c5684e1ecddee741154f95704d4ed27c"

--- a/extra-x11/nvidia/autobuild/build
+++ b/extra-x11/nvidia/autobuild/build
@@ -178,10 +178,9 @@ install -Dvm755 "libnvidia-tls.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-tls.so.$PKGVER
 
 abinfo "CUDA interface libraries..."
-install -Dvm755 "libcuda.so.$PKGVER" \
-    "$PKGDIR"/usr/lib/libcuda.so.$PKGVER
-install -Dvm755 "libnvcuvid.so.$PKGVER" \
-    "$PKGDIR"/usr/lib/libnvcuvid.so.$PKGVER
+install_for_all 755 "libcuda.so.$PKGVER" "$PKGDIR"/usr/lib
+install_for_all 755 "libnvcuvid.so.$PKGVER" "$PKGDIR"/usr/lib
+install_for_all 755 "libcudadebugger.so.$PKGVER" "$PKGDIR"/usr/lib
 
 abinfo "PTX JIT Compiler library..."
 install -Dvm755 "libnvidia-ptxjitcompiler.so.$PKGVER" \

--- a/extra-x11/nvidia/autobuild/patches/0001-kernel-6.0-separate-framebuffer-h.patch
+++ b/extra-x11/nvidia/autobuild/patches/0001-kernel-6.0-separate-framebuffer-h.patch
@@ -1,6 +1,6 @@
-diff -Naur nvidia-515.65.01/kernel/nvidia-drm/nvidia-drm-helper.c nvidia-515.65.01.modded/kernel/nvidia-drm/nvidia-drm-helper.c
---- nvidia-515.65.01/kernel/nvidia-drm/nvidia-drm-helper.c	2022-09-13 18:41:10.235610460 -0400
-+++ nvidia-515.65.01.modded/kernel/nvidia-drm/nvidia-drm-helper.c	2022-09-13 19:06:23.599321167 -0400
+diff -Naur nvidia-520.56.06/kernel/nvidia-drm/nvidia-drm-helper.c nvidia-520.56.06.modded/kernel/nvidia-drm/nvidia-drm-helper.c
+--- nvidia-520.56.06/kernel/nvidia-drm/nvidia-drm-helper.c	2022-09-13 18:41:10.235610460 -0400
++++ nvidia-520.56.06.modded/kernel/nvidia-drm/nvidia-drm-helper.c	2022-09-13 19:06:23.599321167 -0400
 @@ -41,6 +41,11 @@
  #include <drm/drm_atomic_uapi.h>
  #endif

--- a/extra-x11/nvidia/spec
+++ b/extra-x11/nvidia/spec
@@ -1,22 +1,20 @@
-VER=515.65.01
-_SETTINGS_VER=515.57
+VER=520.56.06
+_SETTINGS_VER=520.56.06
 SRCS__AMD64="
 	file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__AMD64="
-	sha256::0492ddc5b5e65aa00cbc762e8d6680205c8d08e103b7131087a15126aee495e9
-	sha256::150ac38a0f1ea49db4fd829206aeefadb97fe2b0bb41835f51475ac78220bc01
+	sha256::51674b00bed6766ec43d41ca84d18d693906234f85519069b6a341f76c113c46
+	sha256::710a613c6a93a5b90cf48a02530ffd542e4a33b370567bc425d738652b6f87e9
 "
 SRCS__ARM64="
 	file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/aarch64/$VER/NVIDIA-Linux-aarch64-${VER}.run
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__ARM64="
-	sha256::0d2ac6c6ca144c8c7bbf1a62034998463b21f2660a793607d88c031650d93e93
-	sha256::150ac38a0f1ea49db4fd829206aeefadb97fe2b0bb41835f51475ac78220bc01
+	sha256::e3319a184bd1a2813f653691d2c8113e7a79fb25857a3920661d7fa61f6539c3
+	sha256::710a613c6a93a5b90cf48a02530ffd542e4a33b370567bc425d738652b6f87e9
 "
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"
-
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

This PR updates nvidia to 520.56.06 and cuda to 11.8.0+520.61.05

Package(s) Affected
-------------------

nvidia cuda

Build Order
-----------

nvidia cuda

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
