### PR TITLE
samtools: update to 1.16.1

### DIFF
--- a/extra-scientific/htslib/autobuild/patches/0001-fix-so-permission.patch
+++ b/extra-scientific/htslib/autobuild/patches/0001-fix-so-permission.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index bb84a25..6ed49a0 100644
+--- a/Makefile
++++ b/Makefile
+@@ -58,7 +58,7 @@ MKDIR_P = mkdir -p
+ INSTALL = install -p
+ INSTALL_DATA    = $(INSTALL) -m 644
+ INSTALL_DIR     = $(MKDIR_P) -m 755
+-INSTALL_LIB     = $(INSTALL_DATA)
++INSTALL_LIB     = $(INSTALL)
+ INSTALL_MAN     = $(INSTALL_DATA)
+ INSTALL_PROGRAM = $(INSTALL)

--- a/extra-scientific/htslib/spec
+++ b/extra-scientific/htslib/spec
@@ -1,6 +1,5 @@
-VER=1.9
-REL=1
+VER=1.16
 SRCS="tbl::https://github.com/samtools/htslib/releases/download/$VER/htslib-$VER.tar.bz2"
-CHKSUMS="sha256::e04b877057e8b3b8425d957f057b42f0e8509173621d3eccaedd0da607d9929a"
+CHKSUMS="sha256::606b7c7aff73734cf033ecd156f40529fa5792f54524952a28938ca0890d7924"
 
 CHKUPDATE="anitya::id=13500"

--- a/extra-scientific/samtools/spec
+++ b/extra-scientific/samtools/spec
@@ -1,4 +1,4 @@
-VER=1.9
+VER=1.16.1
 SRCS="tbl::https://github.com/samtools/samtools/releases/download/$VER/samtools-$VER.tar.bz2"
-CHKSUMS="sha256::083f688d7070082411c72c27372104ed472ed7a620591d06f928e653ebc23482"
+CHKSUMS="sha256::2fa0a25f78594cf23d07c9d32d5060a14f1c5ee14d7b0af7a8a71abc9fdf1d07"
 CHKUPDATE="anitya::id=4759"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- upgrade to 1.16.1
- upgrade dependency htslib to 1.16
- also fixes htslib so permission issue (https://github.com/samtools/htslib/pull/1525)

Package(s) Affected
-------------------
- samtools: 1.16.1
- htslib: 1.16
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

1. htslib
2. samtools

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
