### PR TITLE
ciel: update to 3.1.3

### DIFF
--- a/extra-devel/ciel/spec
+++ b/extra-devel/ciel/spec
@@ -1,5 +1,4 @@
-VER=3.1.0
-REL=2
+VER=3.1.3
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227000"


### PR DESCRIPTION
Topic Description
-----------------

This update fixes an issue where a system update may result in a "Not a directory" error.

--- From the upstream ---

```
overlayfs: properly handles the cases ...

... where the entity in the lower dir is a file, but the upper dir has a
directory at the same logical location
```

Package(s) Affected
-------------------

- `ciel` v3.1.3

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
