### PR TITLE
openfpgaloader: update to 0.9.1

### DIFF
--- a/extra-electronics/openfpgaloader/autobuild/defines
+++ b/extra-electronics/openfpgaloader/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=openfpgaloader
 PKGDES="Open-source FPGA programmer that supports multiple FPGAs and cables"
 PKGSEC=electronics
-PKGDEP="libftdi libusb hidapi systemd"
+PKGDEP="libftdi libusb hidapi libgpiod systemd"

--- a/extra-electronics/openfpgaloader/spec
+++ b/extra-electronics/openfpgaloader/spec
@@ -1,4 +1,4 @@
-VER=0.5.0
+VER=0.9.1
 SRCS="git::commit=tags/v${VER}::https://github.com/trabucayre/openFPGALoader"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=trabucayre/openFPGALoader"


### PR DESCRIPTION
Topic Description
-----------------

Update openFPGALoader to 0.9.1.

Package(s) Affected
-------------------

- `openfpgaloader`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
