### PR TITLE
libxml2: rework python2/3 bindings

### DIFF
--- a/base-libs/libxml2/autobuild/beyond
+++ b/base-libs/libxml2/autobuild/beyond
@@ -1,0 +1,35 @@
+abinfo "Configuring libxml2 for python 2 bindings...."
+mkdir -v "${SRCDIR}/abbuild-python2"
+(cd "${SRCDIR}/abbuild-python2"; ../configure ${AUTOTOOLS_DEF} PYTHON=/usr/bin/python2 "${AUTOTOOLS_AFTER_COMMON[@]}")
+
+abinfo "Building and installing python 2 bindings...."
+make ${ABMK} -C "${SRCDIR}/abbuild-python2"
+make ${ABMK} DESTDIR="${PKGDIR}" \
+	-C "${SRCDIR}/abbuild-python2/python" \
+	install-pythonPYTHON \
+	install-nodist_pythonPYTHON \
+	install-pyexecLTLIBRARIES
+
+abinfo "Byte-compiling python 2 bindings...."
+python2 -m compileall "${PKGDIR}/usr/lib/python2*"
+
+sancheck_f() {
+	abinfo "Sanity check: File $1"
+	[ -f "${PKGDIR}/$1" ] || (aberr "$1 is not found"; abdie)
+}
+sancheck_cmd() {
+	abinfo "Sanity check: Running command $@"
+	$@ || (aberr "$@ failed to execute"; abdie)
+}
+sancheck_f /usr/lib/libxml2.so
+sancheck_f /usr/lib/cmake/libxml2/libxml2-config.cmake
+sancheck_f /usr/lib/pkgconfig/libxml-2.0.pc
+__TESTENV=(
+	LD_LIBRARY_PATH="${PKGDIR}/usr/lib"
+)
+sancheck_cmd env "${__TESTENV[@]}" PYTHONPATH="${PKGDIR}/usr/lib/python${ABPY2VER}/site-packages" python2 -m libxml2
+sancheck_cmd env "${__TESTENV[@]}" PYTHONPATH="${PKGDIR}/usr/lib/python${ABPY3VER}/site-packages" python3 -m libxml2
+
+unset sancheck_f
+unset sancheck_cmd
+unset __TESTENV

--- a/base-libs/libxml2/autobuild/defines
+++ b/base-libs/libxml2/autobuild/defines
@@ -12,7 +12,8 @@ PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 
-BUILDDEP__RETRO="python-3"
+BUILDDEP="python-2"
+BUILDDEP__RETRO="python-3 python-2"
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
@@ -21,6 +22,11 @@ BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
-AUTOTOOLS_AFTER="--with-history \
-                 --with-threads \
-                 --with-python=/usr/bin/python3"
+AUTOTOOLS_AFTER_COMMON=(
+	--with-history
+	--with-threads
+)
+AUTOTOOLS_AFTER=(
+	PYTHON=/usr/bin/python3
+	"${AUTOTOOLS_AFTER_COMMON[@]}"
+)

--- a/base-libs/libxml2/spec
+++ b/base-libs/libxml2/spec
@@ -1,4 +1,5 @@
 VER=2.10.3
+REL=1
 SRCS="tbl::https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${VER}/libxml2-v${VER}.tar.gz"
 CHKSUMS="sha256::497f12e34790d407ec9e2a190d576c0881a1cd78ff3c8991d1f9e40281a5ff57"
 CHKUPDATE="anitya::id=1783"


### PR DESCRIPTION
Topic Description
-----------------

The most recent version (2.10.3-0)  shipped without python 3 bindings, effectively breaking virt-manager and any python program that relies on libxml2 for XML parsing. Sanity checks have been added to make sure that the bindings exist and work when imported into their respective python versions.

Package(s) Affected
-------------------

libxml2

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
