### PR TITLE
memtester: update to 4.5.1 and adapt to ABTYPE=self

### DIFF
--- a/extra-benchmarks/memtester/autobuild/beyond
+++ b/extra-benchmarks/memtester/autobuild/beyond
@@ -1,3 +1,0 @@
-abinfo "Moving man pages /usr/man => /usr/share/man ..."
-mkdir -pv "$PKGDIR"/usr/share
-mv -v "$PKGDIR"/usr/{man,share/}

--- a/extra-benchmarks/memtester/autobuild/build
+++ b/extra-benchmarks/memtester/autobuild/build
@@ -1,0 +1,16 @@
+abinfo "Configuring compiler commands ..."
+echo "$CC $CFLAGS $CPPFLAGS" > conf-cc
+echo "$CC $LDFLAGS" > conf-ld
+
+abinfo "Making ..."
+make $ABMK
+
+abinfo "Installing ..."
+make INSTALLPATH="$PKGDIR"/usr install
+
+abinfo "Moving man pages /usr/man => /usr/share/man ..."
+mkdir -pv "$PKGDIR"/usr/share
+mv -v "$PKGDIR"/usr/{man,share/}
+
+abinfo "Uncompressing Gzipped man page file to allow futher compression ..."
+gunzip -v "$PKGDIR"/usr/share/man/man8/memtester.8.gz

--- a/extra-benchmarks/memtester/autobuild/defines
+++ b/extra-benchmarks/memtester/autobuild/defines
@@ -2,6 +2,3 @@ PKGNAME=memtester
 PKGDES="A userspace utility for testing the memory subsystem for faults"
 PKGSEC=utils
 PKGDEP="glibc"
-
-ABTYPE=plainmake
-MAKE_AFTER="INSTALLPATH=$PKGDIR/usr"

--- a/extra-benchmarks/memtester/spec
+++ b/extra-benchmarks/memtester/spec
@@ -1,4 +1,4 @@
-VER=4.5.0
+VER=4.5.1
 SRCS="tbl::http://pyropus.ca/software/memtester/old-versions/memtester-$VER.tar.gz"
-CHKSUMS="sha256::8ed52b0d06d4aeb61954994146e2a5b2d20448a8f3ce3ee995120e6dbde2ae37"
+CHKSUMS="sha256::1c5fc2382576c084b314cfd334d127a66c20bd63892cac9f445bc1d8b4ca5a47"
 CHKUPDATE="anitya::id=1967"


### PR DESCRIPTION
Topic Description
-----------------

Update memtester to 4.5.1 and some build system rework.

Package(s) Affected
-------------------

- `memtester`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
