### PR TITLE
Kodi survey 20221204

### DIFF
--- a/extra-multimedia/kodi-pvr-iptvsimple/autobuild/build
+++ b/extra-multimedia/kodi-pvr-iptvsimple/autobuild/build
@@ -7,7 +7,7 @@ cmake \
 	-DBUILD_SHARED_LIBS=1 \
 	-DADDONS_TO_BUILD=pvr.iptvsimple \
 	-DADDONS_SRC_PREFIX="$SRCDIR" \
-	"$SRCDIR"/../xbmc*/cmake/addons
+	"$SRCDIR"/../xbmc/cmake/addons
 ninja
 
 abinfo "Installing file to PKGDIR..."

--- a/extra-multimedia/kodi-pvr-iptvsimple/spec
+++ b/extra-multimedia/kodi-pvr-iptvsimple/spec
@@ -1,9 +1,9 @@
-KODI_VER=19.2
-VER=19.0.0
+KODI_VER=19.4
+VER=19.2.2
 CODE=Matrix
-SRCS="tbl::https://github.com/kodi-pvr/pvr.iptvsimple/archive/${VER}-${CODE}.tar.gz \
-      tbl::https://github.com/xbmc/xbmc/archive/refs/tags/${KODI_VER}-${CODE}.tar.gz"
-CHKSUMS="sha256::665441cfe6a83a72d1cbbe3e8adf2a121e5c78a1156830a0036496702a4fce3e \
-         sha256::e8f5e50767ddd1b8f0399016dcf5ba762315c16c0568cb06e659c493376f99d5"
-SUBDIR="pvr.iptvsimple-${VER}-${CODE}"
+SRCS="git::rename=xbmc;commit=tags/${KODI_VER}-${CODE}::https://github.com/xbmc/xbmc.git \
+      git::rename=pvr.iptvsimple;commit=tags/${VER}-${CODE}::https://github.com/kodi-pvr/pvr.iptvsimple.git"
+CHKSUMS="SKIP \
+         SKIP"
+SUBDIR="pvr.iptvsimple"
 CHKUPDATE="anitya::id=21782"

--- a/extra-multimedia/kodi/autobuild/beyond
+++ b/extra-multimedia/kodi/autobuild/beyond
@@ -16,3 +16,26 @@ for i in ${KODI_DEV_HEADERS}; do
 	DESTDIR="${PKGDIR}" cmake -DCMAKE_INSTALL_COMPONENT="$i" -P cmake_install.cmake
 done
 cd "$SRCDIR"
+
+for i in peripheral.joystick; do
+	abinfo "Building extra addon $i ..."
+	cd "$SRCDIR"/../$i
+	cmake \
+	        -G Ninja \
+	        -DCMAKE_INSTALL_PREFIX=/usr \
+	        -DCMAKE_INSTALL_LIBDIR=/usr/lib/kodi \
+	        -DCMAKE_BUILD_TYPE=Release \
+	        -DBUILD_SHARED_LIBS=1 \
+	        -DADDONS_TO_BUILD="$i" \
+	        -DADDONS_SRC_PREFIX="$SRCDIR"/../"$i" \
+	        "$SRCDIR"/cmake/addons
+	ninja
+	abinfo "Installing extra addon $i ..."
+	mkdir -pv "$PKGDIR"/usr/share/kodi/addons/"$i"
+	cp -rv "$SRCDIR"/../"$i"/build/depends/share/kodi/addons/"$i"/* \
+	        "$PKGDIR"/usr/share/kodi/addons/"$i"/
+	mkdir -pv "$PKGDIR"/usr/lib/kodi/addons/"$i"
+	cp -rv "$SRCDIR"/../"$i"/build/depends/lib/kodi/addons/"$i"/*  \
+	        "$PKGDIR"/usr/lib/kodi/addons/"$i"/
+	cd "$SRCDIR"
+done

--- a/extra-multimedia/kodi/autobuild/defines
+++ b/extra-multimedia/kodi/autobuild/defines
@@ -40,6 +40,3 @@ CMAKE_AFTER="-DMARIADBCLIENT_INCLUDE_DIR=/usr/include/ \
         -DAPP_RENDER_SYSTEM=gl"
 
 NOLTO=1
-
-# FIXME: Try building for Loongson3 again with Core 9.
-FAIL_ARCH="!(amd64|arm64|ppc64el)"

--- a/extra-multimedia/kodi/autobuild/prepare
+++ b/extra-multimedia/kodi/autobuild/prepare
@@ -1,2 +1,2 @@
 abinfo "Copying l10n addons..."
-tar --strip-components=1 -xvf "$SRCDIR/../kodi-res.tar.gz" --exclude=".*" -C "$SRCDIR/addons"
+cp -r "$SRCDIR"/../kodi-res/* "$SRCDIR/addons/"

--- a/extra-multimedia/kodi/spec
+++ b/extra-multimedia/kodi/spec
@@ -1,10 +1,12 @@
-VER=19.3
+VER=19.4
+PERIPHERAL_JOYSTICK_VER=19.0.1
 CODE=Matrix
-REL=1
-RSRC_COMMIT=bfd769ab1bb8b8589e258c6c367899dd7d0b2067
-SRCS="tbl::rename=kodi::https://github.com/xbmc/xbmc/archive/refs/tags/${VER}-${CODE}.tar.gz \
-      tbl::rename=kodi-res.tar.gz::https://github.com/xbmc/repo-resources/archive/${RSRC_COMMIT}.tar.gz"
-CHKSUMS="sha256::440f47e475dd8a48e0a6d41349e83b74890f3fbe8275d3e401d3c50f5b9ea09b \
-         sha256::f629d0fcc5e3a097c3804d17029cbbc4c26e79b3515238db435656efdac1b62a"
-SUBDIR="xbmc-$VER-$CODE"
+RSRC_COMMIT=3d451299d41c1232c53ccf8329a0e843012f82cf
+SRCS="git::rename=xbmc;commit=tags/${VER}-${CODE}::https://github.com/xbmc/xbmc.git \
+      git::rename=kodi-res;commit=${RSRC_COMMIT}::https://github.com/xbmc/repo-resources.git \
+      git::rename=peripheral.joystick;commit=tags/${PERIPHERAL_JOYSTICK_VER}-${CODE}::https://github.com/xbmc/peripheral.joystick.git"
+CHKSUMS="SKIP \
+         SKIP \
+         SKIP"
+SUBDIR="xbmc"
 CHKUPDATE="anitya::id=5511"


### PR DESCRIPTION
Topic Description
-----------------

Update Kodi and its pvr.iptvsimple addon.

Package(s) Affected
-------------------

- `kodi`
- `kodi-pvr-iptvsimple`

Security Update?
----------------

No

Build Order
-----------

`kodi kodi-pvr-iptvsimple`

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
