### PR TITLE
Python Toolchain (python-base) Survey 20221213

### DIFF
--- a/base-python/python-2/spec
+++ b/base-python/python-2/spec
@@ -1,5 +1,4 @@
-VER=2.7.17
-REL=6
+VER=2.7.18
 SRCS="tbl::https://www.python.org/ftp/python/$VER/Python-$VER.tar.xz"
-CHKSUMS="md5::b3b6d2c92f42a60667814358ab9f0cfd"
+CHKSUMS="sha256::b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43"
 CHKUPDATE="anitya::id=13255"

--- a/base-python/python-3/spec
+++ b/base-python/python-3/spec
@@ -1,5 +1,4 @@
-VER=3.10.8
-REL=2
+VER=3.10.9
 SRCS="tbl::https://www.python.org/ftp/python/$VER/Python-$VER.tar.xz"
-CHKSUMS="sha256::6a30ecde59c47048013eb5a658c9b5dec277203d2793667f578df7671f7f03f3"
+CHKSUMS="sha256::5ae03e308260164baba39921fdb4dbf8e6d03d8235a939d4582b33f0b5e46a83"
 CHKUPDATE="anitya::id=13254"

--- a/extra-python/pip/spec
+++ b/extra-python/pip/spec
@@ -1,4 +1,4 @@
-VER=22.2
+VER=22.3.1
 SRCS="tbl::https://github.com/pypa/pip/archive/${VER}.tar.gz"
-CHKSUMS="sha256::29f3b99409e8d633167df8c71262675ff7698b9831de45aa17d9221ed97028b6"
+CHKSUMS="sha256::8d9f7cd8ad0d6f0c70e71704fd3f0f6538d70930454f1f21bbc2f8e94f6964ee"
 CHKUPDATE="anitya::id=6529"

--- a/extra-python/virtualenv/autobuild/defines
+++ b/extra-python/virtualenv/autobuild/defines
@@ -7,3 +7,4 @@ PKGDES="A tool to create isolated Python environments"
 ABHOST=noarch
 
 NOPYTHON2=1
+ABTYPE=python

--- a/extra-python/virtualenv/spec
+++ b/extra-python/virtualenv/spec
@@ -1,5 +1,4 @@
-VER=20.2.2
+VER=20.17.1
 SRCS="https://pypi.io/packages/source/v/virtualenv/virtualenv-${VER}.tar.gz"
-CHKSUMS="sha256::b7a8ec323ee02fb2312f098b6b4c9de99559b462775bc8fe3627a73706603c1b"
+CHKSUMS="sha256::f8b927684efc6f1cc206c9db297a570ab9ad0e51c16fa9e45487d36d1905c058"
 CHKUPDATE="anitya::id=6904"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

This topic surveys Python toolchain updates.

Package(s) Affected
-------------------

- [x] `pip` v22.3.1
- [x] `python-2` v2.7.18
- [x] `python-3` v3.10.9
- [x] `virtualenv` v20.17.1

Security Update?
----------------

Yes (`python-3`)

Build Order
-----------

```
python-2 python-3 pip virtualenv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
