### PR TITLE
mcfly: revert init mcfly from /etc/profile

### DIFF
--- a/extra-utils/mcfly/autobuild/beyond
+++ b/extra-utils/mcfly/autobuild/beyond
@@ -1,8 +1,5 @@
-abinfo "Installing mcfly bash script to /etc/profile.d ..."
-mkdir -pv "$PKGDIR"/etc/profile.d
-"$PKGDIR"/usr/bin/mcfly init bash > "$PKGDIR"/etc/profile.d/mcfly.bash
-
-abinfo "Installing mcfly Zsh and Fish scripts ..."
+abinfo "Installing mcfly Bash, Zsh and Fish scripts ..."
 mkdir -pv "$PKGDIR"/usr/share/doc/mcfly
+"$PKGDIR"/usr/bin/mcfly init bash > "$PKGDIR"/usr/share/doc/mcfly/mcfly.bash
 "$PKGDIR"/usr/bin/mcfly init zsh > "$PKGDIR"/usr/share/doc/mcfly/mcfly.zsh
 "$PKGDIR"/usr/bin/mcfly init fish > "$PKGDIR"/usr/share/doc/mcfly/mcfly.fish

--- a/extra-utils/mcfly/autobuild/postinst
+++ b/extra-utils/mcfly/autobuild/postinst
@@ -1,16 +1,15 @@
 cat << EOF
-McFly will be loaded automatically the next time you enter the Bash shell. If
-you would like to load McFly for your current shell session, please input the
-following command:
+If you are using Bash and would like to load McFly automatically, please append the
+following line to ~/.bashrc :
 
 	. /etc/profile.d/mcfly.bash
 
-If you are using Zsh and want to load McFly automatically, please append the 
+If you are using Zsh and would like to load McFly automatically, please append the 
 following line to ~/.zshrc :
 
 	. /usr/share/doc/mcfly/mcfly.zsh
 
-If you are using Fish and want to load McFly automatically, please append the
+If you are using Fish and would like to load McFly automatically, please append the
 following line to ~/.config/fish/config.fish:
 
 	source ~/.config/fish/config.fish

--- a/extra-utils/mcfly/spec
+++ b/extra-utils/mcfly/spec
@@ -2,4 +2,4 @@ VER=0.6.1
 SRCS="git::commit=tags/v$VER::https://github.com/cantino/mcfly/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=179619"
-REL=1
+REL=2


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

FIXME: McFly: /root/.bash_history does not exist or is not readable. Please fix this or set HISTFILE to something else before using McFly.

Package(s) Affected
-------------------

mcfly: 0.6.1-2

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
