### PR TITLE
fcitx5-pinyin-moegirl: upgrade to 20221214

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20221114
+VER=20221214
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::8791f8614966f111ec4a0d33fdf4e6a1e6a5c458dc2ea488525525a0d0941d6e \
-         sha256::0078f98e234a06ef2a8b9cc710320f8b613d8d414de55dae04b445c9cf12e623 \
+CHKSUMS="sha256::8353b1813e43cbd5b23ba43f72e568b45ad423c95d0f6a172e8fc0e43aaf84da \
+         sha256::a6c8b651fc005cd9421c9e9ad69b4c428e6eb04c65e9598bdd4c1c1feec2ad3a \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

fcitx5-pinyin-moegirl: upgrade to 20221214

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`