### PR TITLE
Libtorrent survey 20221220

### DIFF
--- a/extra-libs/libtorrent-rasterbar/autobuild/defines
+++ b/extra-libs/libtorrent-rasterbar/autobuild/defines
@@ -3,12 +3,11 @@ PKGSEC=libs
 PKGDEP="boost geoip-api-c python-2"
 PKGDES="C++ BitTorrent support library"
 
-AUTOTOOLS_AFTER="--enable-python-binding \
-                 --with-libiconv \
-                 --with-boost-python=boost_python \
-                 PYTHON=/usr/bin/python2"
-ABSHADOW=0
+ABTYPE=cmakeninja
+CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON -Dstatic_runtime=OFF \
+             -Dbuild_tests=OFF -Dbuild_examples=OFF -Dbuild_tools=ON \
+             -Dpython-bindings=ON -Dpython-egg-info=ON \
+             -Ddht=ON -Dencryption=ON -Dexceptions=ON -Dgnutls=OFF
+             -Dboost-python-module-name=python3"
 
-PKGBREAK="deluge<=1.3.15 epour<=0.7.0"
-
-NOLTO__LOONGSON3=1
+PKGBREAK="deluge<=2.0.5 epour<=0.7.0"

--- a/extra-libs/libtorrent-rasterbar/spec
+++ b/extra-libs/libtorrent-rasterbar/spec
@@ -1,4 +1,4 @@
-VER=2.0.5
+VER=2.0.8
 SRCS="tbl::https://github.com/arvidn/libtorrent/releases/download/v${VER}/libtorrent-rasterbar-$VER.tar.gz"
-CHKSUMS="sha256::e965c2e53170c61c0db3a2d898a61769cb7acd541bbf157cbbef97a185930ea5"
+CHKSUMS="sha256::09dd399b4477638cf140183f5f85d376abffb9c192bc2910002988e27d69e13e"
 CHKUPDATE="anitya::id=4166"

--- a/extra-python/rencode/autobuild/defines
+++ b/extra-python/rencode/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=rencode
 PKGSEC=python
-PKGDEP="python-2"
+PKGDEP="python-3"
 BUILDDEP="cython"
 PKGDES="Module similar to bencode from the BitTorrent project"
 
-NOPYTHON3=1
+ABTYPE=python
+PKGBREAK="deluge<=2.0.5"
+NOPYTHON2=1

--- a/extra-python/rencode/spec
+++ b/extra-python/rencode/spec
@@ -1,4 +1,5 @@
 VER=1.0.6
+REL=1
 SRCS="tbl::https://github.com/aresch/rencode/archive/v$VER.tar.gz"
 CHKSUMS="sha256::0ed61111f053ea37511da86ca7aed2a3cfda6bdaa1f54a237c4b86eea52f0733"
 CHKUPDATE="anitya::id=6712"

--- a/extra-web/deluge/autobuild/defines
+++ b/extra-web/deluge/autobuild/defines
@@ -1,9 +1,10 @@
 PKGNAME=deluge
 PKGSEC=web
 PKGDEP="chardet librsvg libtorrent-rasterbar mako notify-python pygtk pyopenssl \
-        pyxdg service-identity simplejson twisted"
-BUILDDEP="intltool setuptools"
+        pyxdg service-identity simplejson twisted rencode python-3"
+BUILDDEP="intltool setuptools python-build python-installer wheel"
 PKGDES="A fully-featured cross-platform BitTorrent client"
 
 ABHOST=noarch
-NOPYTHON3=1
+ABTYPE=pep517
+NOPYTHON2=1

--- a/extra-web/deluge/spec
+++ b/extra-web/deluge/spec
@@ -1,4 +1,4 @@
-VER=2.0.5
+VER=2.1.1
 SRCS="git::commit=tags/deluge-$VER::git://git.deluge-torrent.org/deluge.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=419"

--- a/extra-web/qbittorrent/autobuild/defines
+++ b/extra-web/qbittorrent/autobuild/defines
@@ -4,6 +4,4 @@ PKGDEP="desktop-file-utils libtorrent-rasterbar qt-5 xdg-utils"
 BUILDDEP="boost"
 PKGDES="Free and reliable P2P Bittorrent client"
 
-MAKE_AFTER="INSTALL_ROOT=$PKGDIR"
-RECONF=0
-NOLTO__LOONGSON3=1
+ABTYPE=qtproj

--- a/extra-web/qbittorrent/autobuild/prepare
+++ b/extra-web/qbittorrent/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Running configure script to generate conf.pri ..."
+"$SRCDIR"/configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --enable-stacktrace --enable-gui --enable-systemd --enable-webui --enable-qt-dbus

--- a/extra-web/qbittorrent/spec
+++ b/extra-web/qbittorrent/spec
@@ -1,5 +1,5 @@
-VER=4.4.2
+VER=4.5.0
 REL=1
-SRCS="tbl::https://sourceforge.net/projects/qbittorrent/files/qbittorrent/qbittorrent-$VER/qbittorrent-$VER.tar.xz/download"
-CHKSUMS="sha256::efa580924e96605bae916b9a8ae1f3fce82a5130647ae41d74d689761262463d"
+SRCS="tbl::https://sourceforge.net/projects/qbittorrent/files/qbittorrent/qbittorrent-$VER/qbittorrent-$VER.tar.xz"
+CHKSUMS="sha256::b084b3c9e55c1f36c9cc3e8858905b7ae0eb2eaa3fad37f8b055c37d82d01388"
 CHKUPDATE="anitya::id=6111"


### PR DESCRIPTION
Topic Description
-----------------

Bumping libtorrent and two reverse dependencies (deluge and qbittorrent).

Package(s) Affected
-------------------

- `libtorrent-rasterbar`
- `rencode`
- `deluge`
- `qbittorrent`

Security Update?
----------------

No

Build Order
-----------

`libtorrent-rasterbar rencode deluge qbittorrent`

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
