### PR TITLE
aoscbootstrap: update to 0.2.6

### DIFF
--- a/extra-utils/aoscbootstrap/spec
+++ b/extra-utils/aoscbootstrap/spec
@@ -1,4 +1,4 @@
-VER=0.2.4
+VER=0.2.6
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscbootstrap"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231687"


### PR DESCRIPTION
Topic Description
-----------------

This update fixes a critical flaw in assets/cleanup.sh, where /etc/machine-id was not removed, resulting in replicated systemd machine IDs across different devices.

Package(s) Affected
-------------------

`aoscbootstrap` v0.2.6

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`