### PR TITLE
debootstrap: update to 1.0.128

### DIFF
--- a/extra-admin/debian-ports-archive-keyring/autobuild/build
+++ b/extra-admin/debian-ports-archive-keyring/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Installing debian-ports-archive-keyring ..."
+dpkg -x "$SRCDIR"/debian-ports-archive-keyring_${PKGVER}_all.deb \
+    "$PKGDIR"/
+
+abinfo "Removing keys we don't trust ..."
+rm -rv "$PKGDIR"/etc

--- a/extra-admin/debian-ports-archive-keyring/autobuild/defines
+++ b/extra-admin/debian-ports-archive-keyring/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME="debian-ports-archive-keyring"
+PKGDES="GnuPG archive keys of the Debian Ports archive"
+PKGDEP="gnupg"
+BUILDDEP="jetring"
+PKGSEC="admin"
+
+NOPARALLEL=1
+ABHOST=noarch

--- a/extra-admin/debian-ports-archive-keyring/spec
+++ b/extra-admin/debian-ports-archive-keyring/spec
@@ -1,0 +1,5 @@
+VER=2022.02.15~deb11u1
+SRCS="tbl::rename=debian-ports-archive-keyring_${VER}_all.deb::https://mirrors.edge.kernel.org/debian/pool/main/d/debian-ports-archive-keyring/debian-ports-archive-keyring_${VER}_all.deb"
+CHKSUMS="sha256::2918bd81439d56ac193fc031ee225044c7da4983b50438373e80e0495c318f00"
+CHKUPDATE="html::url=https://mirrors.kernel.org/debian/pool/main/d/debian-ports-archive-keyring;pattern=debian-ports-archive-keyring_(.+?).tar.xz"
+SUBDIR=.

--- a/extra-utils/debootstrap/autobuild/defines
+++ b/extra-utils/debootstrap/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=debootstrap
 PKGSEC=utils
 PKGDEP="gnupg wget"
 PKGDES="Bootstrap a basic Debian system"
-PKGRECOM="debian-archive-keyring ubuntu-keyring"
+PKGRECOM="debian-archive-keyring debian-ports-archive-keyring ubuntu-keyring"
 
 ABHOST=noarch
 PKGBREAK="deboostrap<=1.0.93"

--- a/extra-utils/debootstrap/spec
+++ b/extra-utils/debootstrap/spec
@@ -1,4 +1,4 @@
-VER=1.0.123
+VER=1.0.126
 CHKSUMS="SKIP"
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/installer-team/debootstrap"
 CHKSUMS="SKIP"

--- a/extra-utils/debootstrap/spec
+++ b/extra-utils/debootstrap/spec
@@ -1,4 +1,4 @@
-VER=1.0.126
+VER=1.0.128
 CHKSUMS="SKIP"
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/installer-team/debootstrap"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Update debootstrap to 1.0.128 and add debian ports keyring package.

Package(s) Affected
-------------------

- `debian-ports-archive-keyring` (new)
- `debootstrap`

Security Update?
----------------

No

Build Order
-----------

`debian-ports-archive-keyring debootstrap`

Test Build(s) Done
------------------

**Primary Architectures**
- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
