### PR TITLE
perl-net-ssleay: rebuild for Perl 5.36

### DIFF
--- a/extra-perl/perl-net-ssleay/spec
+++ b/extra-perl/perl-net-ssleay/spec
@@ -1,5 +1,5 @@
 VER=1.85
-REL=5
+REL=6
 SRCS="tbl::https://search.cpan.org/CPAN/authors/id/M/MI/MIKEM/Net-SSLeay-$VER.tar.gz"
 CHKSUMS="sha256::9d8188b9fb1cae3bd791979c20554925d5e94a138d00414f1a6814549927b0c8"
 CHKUPDATE="anitya::id=6575"


### PR DESCRIPTION
Topic Description
-----------------

Rebuild `perl-net-ssleay` for broken ABI.

Package(s) Affected
-------------------

- `perl-net-ssleay`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
