### PR TITLE
discord: update to 0.0.23

### DIFF
--- a/extra-web/discord/autobuild/build
+++ b/extra-web/discord/autobuild/build
@@ -11,7 +11,10 @@ cp -av "$SRCDIR"/Discord/* \
     "$PKGDIR"/usr/lib/discord
 
 abinfo "Setting executable bit on Discord binary ..."
-chmod -v 755 "$PKGDIR"/usr/lib/discord/Discord
+chmod -v +x "$PKGDIR"/usr/lib/discord/Discord
+
+abinfo "Setting executable bit on shared objects ..."
+chmod -v +x "$PKGDIR"/usr/lib/discord/*.so.*
 
 abinfo "Dropping lingering postinst.sh ..."
 rm -v "$PKGDIR"/usr/lib/discord/postinst.sh

--- a/extra-web/discord/spec
+++ b/extra-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.22
+VER=0.0.23
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::175c73771e049ba45e7fb1d37bd107ef0871e3d8857340c5a5a40a745aaeaba7"
+CHKSUMS="sha256::288c005901f2bf5a1148021e1d22fd297419d43c70b0f989820ab72aa79faa44"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Discord to 0.0.23.

Package(s) Affected
-------------------

`discord` v0.0.23

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
