### PR TITLE
dbus-deviation: add sphinx as build dependency

### DIFF
--- a/extra-python/dbus-deviation/autobuild/defines
+++ b/extra-python/dbus-deviation/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=dbus-deviation
 PKGSEC=python
 PKGDEP="lxml markupsafe"
-BUILDDEP="setuptools pip"
+BUILDDEP="setuptools pip sphinx"
 PKGDES="A D-Bus Introspection XML parser module for Python"
 
 ABHOST=noarch

--- a/extra-python/dbus-deviation/spec
+++ b/extra-python/dbus-deviation/spec
@@ -1,5 +1,5 @@
 VER=0.6.1
-REL=2
+REL=3
 SRCS="tbl::https://pypi.io/packages/source/d/dbus-deviation/dbus-deviation-$VER.tar.gz"
 CHKSUMS="sha256::e06b88efe223885d2725df51cf7c9b7b463d1c6f04ea49d4690874318d0eb7a3"
 CHKUPDATE="anitya::id=146064"


### PR DESCRIPTION
Topic Description
-----------------

- Add `sphinx` as build dependency to `dbus-deviation`

Package(s) Affected
-------------------

- `dbus-deviation`

Security Update?
----------------
 No


Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

**Secondary Architectures**


Update(s) Uploaded to Stable
----------------------------

- [ ] Architecture-independent `noarch`
