### PR TITLE
Libcork rebuild

### DIFF
--- a/extra-libs/libcork/autobuild/defines
+++ b/extra-libs/libcork/autobuild/defines
@@ -13,3 +13,5 @@ BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="A simple, easily embeddable cross-platform C library"
 
 ABTYPE=cmakeninja
+
+PKGBREAK="libipset<=20160621-3 shadowsocks-libev<=3.3.5 simple-obfs<=0.0.5"

--- a/extra-libs/libcork/spec
+++ b/extra-libs/libcork/spec
@@ -1,5 +1,5 @@
 VER=1.0.0~rc3
-REL=1
+REL=2
 SRCS="git::commit=tags/${VER/\~/--}::https://github.com/redjack/libcork"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229558"

--- a/extra-libs/libipset/spec
+++ b/extra-libs/libipset/spec
@@ -1,4 +1,5 @@
 VER=1.1.1+git20150311
+REL=1
 SRCS="tbl::http://deb.debian.org/debian/pool/main/libc/libcorkipset/libcorkipset_${VER/git/}.orig.tar.xz"
 CHKSUMS="sha256::6ff060e78d3265bb1bf4f53eee2a46b68b718901de3596dd36fac1e8a75ca341"
 CHKUPDATE="anitya::id=229581"

--- a/extra-network/shadowsocks-libev/spec
+++ b/extra-network/shadowsocks-libev/spec
@@ -1,4 +1,5 @@
 VER=3.3.5
+REL=1
 SRCS="tbl::https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$VER/shadowsocks-libev-$VER.tar.gz"
 CHKSUMS="sha256::cfc8eded35360f4b67e18dc447b0c00cddb29cc57a3cec48b135e5fb87433488"
 CHKUPDATE="anitya::id=21654"

--- a/extra-network/simple-obfs/autobuild/defines
+++ b/extra-network/simple-obfs/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME="simple-obfs"
-PKGSEC=network
+PKGSEC=net
 PKGDES="a simple obfusacting tool, designed as plugin server of shadowsocks."
 PKGDEP="udns libsodium libev libcork"
 BUILDDEP="autogen automake asciidoc xmlto"

--- a/extra-network/simple-obfs/spec
+++ b/extra-network/simple-obfs/spec
@@ -1,4 +1,5 @@
 VER=0.0.5
+REL=1
 SRCS="tbl::https://github.com/shadowsocks/simple-obfs/archive/v${VER}.tar.gz"
 CHKSUMS="sha256::0de9b551b67ec82d0af9d09bcb74c9e8d047f0082ae07db8e4f5f3defeb2ce4c"
 CHKUPDATE="anitya::id=230994"


### PR DESCRIPTION
Topic Description
-----------------

This PR rebuilds reverse dependencies of `libcork`, due to an update.

Package(s) Affected
-------------------

- `libcork`
- `libipset`
- `shadowsocks-libev`
- `simple-obfs`

Security Update?
----------------

No

Build Order
-----------

```
libcork libipset shadowsocks-libev simple-obfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
