### PR TITLE
discord: update to 0.0.24

### DIFF
--- a/extra-web/discord/autobuild/build
+++ b/extra-web/discord/autobuild/build
@@ -13,9 +13,6 @@ cp -av "$SRCDIR"/Discord/* \
 abinfo "Setting executable bit on Discord binary ..."
 chmod -v +x "$PKGDIR"/usr/lib/discord/Discord
 
-abinfo "Setting executable bit on shared objects ..."
-chmod -v +x "$PKGDIR"/usr/lib/discord/*.so.*
-
 abinfo "Dropping lingering postinst.sh ..."
 rm -v "$PKGDIR"/usr/lib/discord/postinst.sh
 

--- a/extra-web/discord/spec
+++ b/extra-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.23
+VER=0.0.24
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::288c005901f2bf5a1148021e1d22fd297419d43c70b0f989820ab72aa79faa44"
+CHKSUMS="sha256::486fb7e1fb74993aad83dac5888eb437a24838dcaa17c73c4a59d1727e5ae177"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Discord to 0.0.24.

Package(s) Affected
-------------------

`discord` v0.0.24

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   