### PR TITLE
fcitx5-pinyin-moegirl: update to 20230114

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20221214
+VER=20230114
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::8353b1813e43cbd5b23ba43f72e568b45ad423c95d0f6a172e8fc0e43aaf84da \
-         sha256::a6c8b651fc005cd9421c9e9ad69b4c428e6eb04c65e9598bdd4c1c1feec2ad3a \
+CHKSUMS="sha256::4e95b19b5265e96c5d02a068db6bb977bc50bffdcfd383c33042df40e5fb2244 \
+         sha256::3e9cfa1a6edc28bee22ec3a113deddbd004c16f6839438c80fed13dc7488754c \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Update fcitx5-pinyin-moegirl to 20230114

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`