### PR TITLE
httpd: security update to 2.4.55

### DIFF
--- a/extra-web/httpd/spec
+++ b/extra-web/httpd/spec
@@ -1,4 +1,4 @@
-VER=2.4.54
+VER=2.4.55
 SRCS="tbl::https://apache.org/dist/httpd/httpd-$VER.tar.bz2"
-CHKSUMS="sha256::eb397feeefccaf254f8d45de3768d9d68e8e73851c49afd5b7176d1ecf80c340"
+CHKSUMS="sha256::11d6ba19e36c0b93ca62e47e6ffc2d2f2884942694bce0f23f39c71bdc5f69ac"
 CHKUPDATE="anitya::id=1335"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates `httpd` to v2.4.55, addressing multiple security vulnerabilities.

Package(s) Affected
-------------------

`httpd` v2.4.55

Security Update?
----------------

Yes, #4373 

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`