### PR TITLE
git: security update to 2.39.1

### DIFF
--- a/extra-vcs/git/spec
+++ b/extra-vcs/git/spec
@@ -1,5 +1,4 @@
-VER=2.38.1
+VER=2.39.1
 SRCS="https://www.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
-CHKSUMS="sha256::620ed3df572a34e782a2be4c7d958d443469b2665eac4ae33f27da554d88b270"
+CHKSUMS="sha256::ae8d3427e4ccd677abc931f16183c0ec953e3bfcd866493601351e04a2b97398"
 CHKUPDATE="anitya::id=5350"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

This topic updates `git` to v2.39.1, addressing multiple security vulnerabilities.

Package(s) Affected
-------------------

`git` v2.39.1

Security Update?
----------------

Yes, #4372 

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`