### PR TITLE
gnome-calculator: add libadwaita dep

### DIFF
--- a/extra-gnome/gnome-calculator/autobuild/defines
+++ b/extra-gnome/gnome-calculator/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gnome-calculator
 PKGSEC=gnome
-PKGDEP="dconf gtk-4 gtksourceview-5 mpfr mpc"
+PKGDEP="dconf gtk-4 gtksourceview-5 libadwaita mpfr mpc"
 BUILDDEP="gnome-shell gobject-introspection intltool vala yelp-tools"
 PKGDES="GNOME scientific calculator"
 

--- a/extra-gnome/gnome-calculator/spec
+++ b/extra-gnome/gnome-calculator/spec
@@ -1,4 +1,5 @@
 VER=42.2
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-calculator/${VER%.*}/gnome-calculator-$VER.tar.xz"
 CHKSUMS="sha256::33dab1bca43658d66520958b0f674cb0ad3185cfd30c12e459e7f69481c5c6a0"
 CHKUPDATE="anitya::id=13126"


### PR DESCRIPTION
Topic Description
-----------------

This topic adds missing `libadwaita` dep to `gnome-calculator`.

Package(s) Affected
-------------------

- [x] `gnome-calculator` v42.2-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`