### PR TITLE
superslicer: new, 2.4.58.5

### DIFF
--- a/extra-creativity/superslicer/autobuild/beyond
+++ b/extra-creativity/superslicer/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Removing files for bundled AngelScript ..."
+rm -v "$PKGDIR"/usr/include/angelscript.h
+rm -rv "$PKGDIR"/usr/lib/cmake/Angelscript

--- a/extra-creativity/superslicer/autobuild/defines
+++ b/extra-creativity/superslicer/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=superslicer
+PKGDES="G-code generator for 3D printers"
+PKGSEC=graphics
+PKGDEP="dbus boost wxgtk3 tbb curl zlib eigen-3 expat libpng glew nlopt c-blosc openvdb libspnav gmp mpfr cgal"
+BUILDDEP="cereal"
+
+CMAKE_AFTER="-DOPENVDB_FIND_MODULE_PATH=/usr/lib/cmake/OpenVDB \
+             -DCGAL_ROOT=/usr -DSLIC3R_WX_STABLE=1 -DSLIC3R_FHS=1 \
+             -DSLIC3R_GTK=3 -DSLIC3R_GUI=ON"

--- a/extra-creativity/superslicer/autobuild/patches/superslicer-backport-to-tbb-2020.patch
+++ b/extra-creativity/superslicer/autobuild/patches/superslicer-backport-to-tbb-2020.patch
@@ -1,0 +1,50 @@
+diff --git a/src/libslic3r/GCode.cpp b/src/libslic3r/GCode.cpp
+index fe77d52b8..b92f95d56 100644
+--- a/src/libslic3r/GCode.cpp
++++ b/src/libslic3r/GCode.cpp
+@@ -52,9 +52,11 @@
+ #if TBB_VERSION_MAJOR >= 2021
+     #include <tbb/parallel_pipeline.h>
+     using slic3r_tbb_filtermode = tbb::filter_mode;
++    #define slic3r_tbb_filter tbb::filter
+ #else
+     #include <tbb/pipeline.h>
+     using slic3r_tbb_filtermode = tbb::filter;
++    #define slic3r_tbb_filter tbb::interface6::filter_t
+ #endif
+ 
+ #include <Shiny/Shiny.h>
+@@ -2073,13 +2075,13 @@ void GCode::process_layers(
+ 
+     // The pipeline elements are joined using const references, thus no copying is performed.
+     output_stream.find_replace_supress();
+-    tbb::filter<void, GCode::LayerResult> pipeline_to_layerresult = generator;
++    slic3r_tbb_filter<void, GCode::LayerResult> pipeline_to_layerresult = generator;
+     if (m_spiral_vase)
+         pipeline_to_layerresult = pipeline_to_layerresult & spiral_vase;
+-    tbb::filter<void, std::string> pipeline_to_string = pipeline_to_layerresult & cooling & fan_mover;
++    slic3r_tbb_filter<void, std::string> pipeline_to_string = pipeline_to_layerresult & cooling & fan_mover;
+     if (m_find_replace)
+         pipeline_to_string = pipeline_to_string & find_replace;
+-    tbb::filter<void, void> full_pipeline = pipeline_to_string & output;
++    slic3r_tbb_filter<void, void> full_pipeline = pipeline_to_string & output;
+     tbb::parallel_pipeline(12, full_pipeline);
+     output_stream.find_replace_enable();
+ }
+@@ -2147,13 +2149,13 @@ void GCode::process_layers(
+ 
+     // The pipeline elements are joined using const references, thus no copying is performed.
+     output_stream.find_replace_supress();
+-    tbb::filter<void, GCode::LayerResult> pipeline_to_layerresult = generator;
++    slic3r_tbb_filter<void, GCode::LayerResult> pipeline_to_layerresult = generator;
+     if (m_spiral_vase)
+         pipeline_to_layerresult = pipeline_to_layerresult & spiral_vase;
+-    tbb::filter<void, std::string> pipeline_to_string = pipeline_to_layerresult & cooling & fan_mover;
++    slic3r_tbb_filter<void, std::string> pipeline_to_string = pipeline_to_layerresult & cooling & fan_mover;
+     if (m_find_replace)
+         pipeline_to_string = pipeline_to_string & find_replace;
+-    tbb::filter<void, void> full_pipeline = pipeline_to_string & output;
++    slic3r_tbb_filter<void, void> full_pipeline = pipeline_to_string & output;
+     tbb::parallel_pipeline(12, full_pipeline);
+     output_stream.find_replace_enable();
+ }

--- a/extra-creativity/superslicer/spec
+++ b/extra-creativity/superslicer/spec
@@ -1,0 +1,4 @@
+VER=2.4.58.5
+SRCS="git::commit=tags/${VER}::https://github.com/supermerill/SuperSlicer.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=supermerill/SuperSlicer"

--- a/extra-libs/c-blosc/autobuild/defines
+++ b/extra-libs/c-blosc/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=c-blosc
+PKGDES="A high performance compression algorithm in C"
+PKGSEC=libs
+PKGDEP="lz4 zlib zstd"
+
+CMAKE_AFTER="-DBUILD_BENCHMARKS=OFF -DBUILD_FUZZERS=OFF \
+             -DBUILD_SHARED=ON -DBUILD_STATIC=OFF -DBUILD_TESTS=OFF \
+             -DPREFER_EXTERNAL_LZ4=ON -DPREFER_EXTERNAL_ZLIB=ON \
+             -DPREFER_EXTERNAL_ZSTD=ON"
+ABTYPE=cmakeninja

--- a/extra-libs/c-blosc/spec
+++ b/extra-libs/c-blosc/spec
@@ -1,0 +1,4 @@
+VER=1.21.3
+SRCS="git::commit=tags/v${VER}::https://github.com/Blosc/c-blosc.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=205"

--- a/extra-libs/nlopt/autobuild/defines
+++ b/extra-libs/nlopt/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=nlopt
+PKGDES="Library for non-linear optimization"
+PKGSEC=libs
+PKGDEP="python-3"
+BUILDDEP="swig"
+
+AUTOTOOLS_AFTER="-DNLOPT_CXX=ON \
+                 -DNLOPT_FORTRAN=ON \
+                 -DNLOPT_MATLAB=OFF \
+                 -DNLOPT_OCTAVE=OFF \
+                 -DNLOPT_PYTHON=ON \
+                 -DNLOPT_SWIG=ON \
+                 -DNLOPT_TESTS=OFF"

--- a/extra-libs/nlopt/spec
+++ b/extra-libs/nlopt/spec
@@ -1,0 +1,4 @@
+VER=2.7.1
+SRCS="git::commit=tags/v${VER}::https://github.com/stevengj/nlopt.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=2095"

--- a/extra-libs/openvdb/autobuild/defines
+++ b/extra-libs/openvdb/autobuild/defines
@@ -1,0 +1,15 @@
+PKGNAME=openvdb
+PKGDES="C++ library comprising a novel hierarchical data structure"
+PKGSEC=libs
+PKGDEP="boost tbb c-blosc zlib openexr libpng ncurses libffi libxml2 llvm-runtime jemalloc"
+BUILDDEP="doxygen llvm texlive"
+
+CMAKE_AFTER="-DOPENVDB_CORE_SHARED=ON -DOPENVDB_CORE_STATIC=OFF \
+             -DOPENVDB_BUILD_CORE=ON -DOPENVDB_BUILD_BINARIES=ON \
+             -DOPENVDB_BUILD_PYTHON_MODULE=ON -DOPENVDB_BUILD_UNITTESTS=OFF \
+             -DOPENVDB_BUILD_DOCS=ON -DOPENVDB_BUILD_HOUDINI_PLUGIN=OFF \
+             -DOPENVDB_BUILD_MAYA_PLUGIN=OFF -DUSE_HOUDINI=OFF \
+             -DUSE_MAYA=NO -DUSE_TBB=ON -DUSE_BLOSC=ON -DUSE_ZLIB=ON \
+             -DUSE_LOG4CPLUS=OFF -DUSE_EXR=ON -DUSE_IMATH_HALF=ON \
+             -DUSE_PNG=ON -DUSE_AX=ON"
+ABTYPE=cmakeninja

--- a/extra-libs/openvdb/spec
+++ b/extra-libs/openvdb/spec
@@ -1,0 +1,4 @@
+VER=10.0.1
+SRCS="git::commit=tags/v${VER}::https://github.com/AcademySoftwareFoundation/openvdb.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=21124"

--- a/extra-libs/tbb/autobuild/build
+++ b/extra-libs/tbb/autobuild/build
@@ -1,6 +1,8 @@
+abinfo "Building ..."
 make CXXFLAGS="${CXXFLAGS} -fno-lifetime-dse" \
-     tbb_build_prefix=obj cpp0x=1
+     tbb_build_prefix=obj stdver=c++0x
 
+abinfo "Installing binaries ..."
 mkdir -p "$PKGDIR"/usr/{lib,include}
 pushd build/obj_release
     for file in libtbb{,malloc{,_proxy}}; do
@@ -9,13 +11,7 @@ pushd build/obj_release
     done
 popd
 
-pushd build/obj_debug
-    for file in libtbb{,malloc{,_proxy}}_debug; do
-        install -p -D -m 755 ${file}.so.2 "$PKGDIR"/usr/lib
-        ln -s $file.so.2 "$PKGDIR"/usr/lib/$file.so
-    done
-popd
-
+abinfo "Installing include files ..."
 pushd include
     find tbb -type f ! -name \*.htm\* -exec \
         install -p -D -m 644 {} "$PKGDIR"/usr/include/{} \

--- a/extra-libs/tbb/autobuild/defines
+++ b/extra-libs/tbb/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=tbb
 PKGSEC=libs
 PKGDEP="gcc-runtime"
 PKGDES="Intel Threading Building Blocks - high level abstract threading library"
+
+PKGEPOCH=1

--- a/extra-libs/tbb/spec
+++ b/extra-libs/tbb/spec
@@ -1,5 +1,4 @@
-VER=2019u9
-REL=1
-SRCS="tbl::https://github.com/01org/tbb/archive/${VER/u/_U}.tar.gz"
-CHKSUMS="sha256::3f5ea81b9caa195f1967a599036b473b2e7c347117330cda99b79cfcf5b77c84"
+VER=2020.3
+SRCS="git::commit=tags/v${VER}::https://github.com/01org/tbb.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8217"


### PR DESCRIPTION
Topic Description
-----------------

Package `superslicer`, a 3D printing slicer, and some of its dependencies.

`tbb` is also upgraded (but not to the newest version because of soname change).

Package(s) Affected
-------------------

- `tbb`: update to 2020.3
- `nlopt c-blosc openvdb`: new, as dependency
- `superslicer`: new

Security Update?
----------------

No

Build Order
-----------

`tbb nlopt c-blosc openvdb superslicer`

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
