### PR TITLE
dpkg: update to 1.21.18

### DIFF
--- a/base-admin/dpkg/01-update-alternatives/defines
+++ b/base-admin/dpkg/01-update-alternatives/defines
@@ -1,8 +1,9 @@
 PKGNAME=update-alternatives
 PKGSEC=admin
 PKGDEP="glibc"
-BUILDDEP="bzip2 diffutils glibc ncurses patch perl-locale-gettext xz zlib less"
-BUILDDEP__RETRO="bzip2 diffutils glibc ncurses patch xz zlib less"
+BUILDDEP="bzip2 diffutils doxygen glibc graphviz less libmd ncurses patch \
+          perl-locale-gettext po4a xz zlib zstd"
+BUILDDEP__RETRO="bzip2 diffutils glibc less libmd ncurses patch xz zlib zstd"
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
@@ -12,5 +13,40 @@ BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="A utility for managing different binary-level alternatives"
 
-AUTOTOOLS_AFTER="--with-dpkg-deb-compressor=xz"
+# Note: Disabling unused dselect, start-stop-daemon.
+# Note: Disabling zlib-ng, which is not yet adopted.
+# Note: To enable libselinux support in the future.
+AUTOTOOLS_AFTER="--enable-nls \
+                 --enable-rpath \
+                 --disable-dselect \
+                 --disable-start-stop-daemon \
+                 --enable-update-alternatives \
+                 --enable-devel-docs \
+                 --disable-coverage \
+                 --enable-largefile \
+                 --enable-unicode \
+                 --disable-mmap \
+                 --enable-disk-preallocate \
+                 --enable-compiler-warnings \
+                 --enable-compiler-optimizations \
+                 --enable-linker-optimizations \
+                 --with-dpkg-deb-compressor=xz \
+                 --with-libz \
+                 --without-libz-ng \
+                 --with-libbz2 \
+                 --with-liblzma \
+                 --with-libzstd \
+                 --without-libselinux"
+AUTOTOOLS_AFTER__RETRO=" \
+                 ${AUTOTOOLS_AFTER} \
+                 --disable-devel-docs"
+AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+
 PKGCONFL="dpkg<=1.18.2-1"

--- a/base-admin/dpkg/02-dpkg/defines
+++ b/base-admin/dpkg/02-dpkg/defines
@@ -1,8 +1,9 @@
 PKGNAME=dpkg
 PKGDES="The Debian package manager tools and libraries"
-PKGDEP="bzip2 diffutils glibc ncurses patch perl update-alternatives \
-        xz zlib less"
-PKGDEP__RETRO="bzip2 diffutils glibc ncurses patch update-alternatives xz zlib less"
+PKGDEP="bzip2 diffutils glibc less libmd ncurses patch perl \
+        update-alternatives xz zlib zstd"
+PKGDEP__RETRO="bzip2 diffutils glibc less libmd ncurses patch \
+        update-alternatives xz zlib zstd"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
 PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
@@ -12,7 +13,6 @@ PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGSUG="binutils zlib tar make gnupg perl-timedate"
 PKGSEC=admin
-
 
 PKGREP="dpkg<=1.18.2-1"
 PKGBREAK="dpkg<=1.18.2-1"

--- a/base-admin/dpkg/spec
+++ b/base-admin/dpkg/spec
@@ -1,5 +1,4 @@
-VER=1.21.1
-REL=3
+VER=1.21.18
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/dpkg-team/dpkg"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8127"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates `dpkg` to v1.21.18.

- This release enables multi-threaded XZ decompression support, which should prove beneficial for most mainline architectures.
- Specify options explicitly where applicable.
- Add libmd, zstd deps.
- (Mainline) Add doxygen, graphviz, po4a build deps for documentations.
- Disable unused dselect, start-stop-daemon to avoid user confusion.

Package(s) Affected
-------------------

`dpkg`, `update-alternatives` v1.21.18

Security Update?
----------------

No

Build Order
-----------

```
dpkg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`