### PR TITLE
clash-premium: update to 2023.01.29

### DIFF
--- a/extra-network/clash-premium/autobuild/defines
+++ b/extra-network/clash-premium/autobuild/defines
@@ -3,4 +3,4 @@ PKGSEC=net
 PKGDEP="glibc"
 PKGDES="Close-source version of Clash with additional features."
 ABSPLITDBG=0
-FAIL_ARCH="!(amd64|arm64|loongson3)"
+FAIL_ARCH="!(amd64|arm64|loongson3|riscv64)"

--- a/extra-network/clash-premium/spec
+++ b/extra-network/clash-premium/spec
@@ -1,10 +1,12 @@
-VER=2022.08.26
+VER=2023.01.29
 SRCS__AMD64="file::rename=clash.gz::https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-amd64-$VER.gz"
-SRCS__ARM64="file::rename=clash.gz::https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-armv8-$VER.gz"
+SRCS__ARM64="file::rename=clash.gz::https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-arm64-$VER.gz"
 SRCS__LOONGSON3="file::rename=clash.gz::https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-mips64le-$VER.gz"
-CHKSUMS__AMD64="sha256::1771a7d9be7386077e81a964248b791f0d9f0ecf5218a3c4eefc62f86451de1d"
-CHKSUMS__ARM64="sha256::c38651ac715e8d719481043f378e80a957bff3e068e72d7346403da7538c405d"
-CHKSUMS__LOONGSON3="sha256::bcb5c528309965a7f550fcb1a4168f7a220b93e2700c90847a356d109a818e92"
+SRCS__RISCV64="file::rename=clash.gz::https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-riscv64-$VER.gz"
+CHKSUMS__AMD64="sha256::2c237d1cd059675a0021e2f19bf36731d9c3e47af0d524e08ac5ce51d4983da6"
+CHKSUMS__ARM64="sha256::eeafdbba67da5b804d0c102951c96525ad39cc28e121764cad4d08ce91987682"
+CHKSUMS__LOONGSON3="sha256::b35822c395a30ee56fd20101704f6d5fc36d7803b25ce3d0af1e58ba604328af"
+CHKSUMS__RISCV64="sha256::6568805ee90598b34cd1d847669613a0b4c63d9ee8becd1bd9b01e5b93180ad7"
 CHKUPDATE="html::url=https://github.com/Dreamacro/clash/releases/tag/premium;\
     pattern=<title>Release Premium (\d\d\d\d\.\d\d\.\d\d) · Dreamacro/clash</title>"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Upstream has begun to release riscv64 build of closed-source clash since January 2023, tagged 2023.01.29. The topic will upgrade clash-premium to version 2023.01.29, along with supports for riscv64 platform.

See also: https://github.com/Dreamacro/clash/issues/2032

Package(s) Affected
-------------------

- `clash-premium`: update to 2023.01.29; Enable for riscv64 platform

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**


- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
