### PR TITLE
aoscdk-rs: update to 0.5.4

### DIFF
--- a/extra-admin/aoscdk-rs/spec
+++ b/extra-admin/aoscdk-rs/spec
@@ -1,4 +1,4 @@
-VER=0.5.3
+VER=0.5.4
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscdk-rs/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226678"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates `aoscdk-rs` to v0.5.4, this version addresses a bug in which user names with numbers were incorrectly deemed invalid.

Package(s) Affected
-------------------

`aoscdk-rs` v0.5.4

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
