### PR TITLE
MIPS64r6el Bring Up Rework (2)

### DIFF
--- a/base-admin/dpkg/01-update-alternatives/build
+++ b/base-admin/dpkg/01-update-alternatives/build
@@ -2,10 +2,16 @@ abinfo "Generating autotools files ..."
 autoreconf -fvi
 
 abinfo "Building DPKG and installing to a fake rootfs ..."
-"$SRCDIR"/configure \
-    --build=${ARCH_TARGET[$ARCH]} \
-    ${AUTOTOOLS_DEF/--enable-shared/} \
-    ${AUTOTOOLS_AFTER}
+if ! ab_match_arch loongson3; then
+    "$SRCDIR"/configure \
+        --build=${ARCH_TARGET[$ARCH]} \
+        ${AUTOTOOLS_DEF/--enable-shared/} \
+        ${AUTOTOOLS_AFTER}
+else
+    "$SRCDIR"/configure \
+        ${AUTOTOOLS_DEF/--enable-shared/} \
+        ${AUTOTOOLS_AFTER}
+fi
 make
 make install DESTDIR="$SRCDIR"/temp-install
 

--- a/base-admin/dpkg/spec
+++ b/base-admin/dpkg/spec
@@ -1,5 +1,5 @@
 VER=1.21.1
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/dpkg-team/dpkg"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8127"


### PR DESCRIPTION
Topic Description
-----------------

dpkg: do not specify the `--build=` option on `loongson3`. Dpkg's architecture/os detection system is quite clunky when it comes to using non-standard dpkg architecture names.

Package(s) Affected
-------------------

`dpkg` v1.12.1-2

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->