### PR TITLE
mesa: disable LTO to prevent artifact with LLVM 15 + AMDGPU

### DIFF
--- a/extra-libs/mesa/autobuild/defines
+++ b/extra-libs/mesa/autobuild/defines
@@ -58,19 +58,16 @@ MESON_AFTER="-Ddri-drivers-path=/usr/lib/xorg/modules/dri \
 
 MESON_AFTER__X86=" \
              ${MESON_AFTER} \
-             -Db_lto=true \
              -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,swrast,svga,iris,d3d12,i915,crocus,zink \
              -Dvulkan-drivers=amd,intel,intel_hasvk,swrast,virtio-experimental"
 MESON_AFTER__ARM=" \
              ${MESON_AFTER} \
-             -Db_lto=true \
              -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,swrast,kmsro,lima,panfrost,freedreno,tegra,vc4,v3d,etnaviv,d3d12,zink \
              -Dvulkan-drivers=amd,broadcom,freedreno,panfrost,swrast,virtio-experimental \
              -Dfreedreno-kgsl=false \
              -Dfreedreno-virtio=false"
 MESON_AFTER__OTHER=" \
              ${MESON_AFTER} \
-             -Db_lto=true \
              -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,swrast,zink \
              -Dvulkan-drivers=amd,swrast,virtio-experimental"
 
@@ -115,7 +112,7 @@ MESON_AFTER__RETRO=" \
              -Dlmsensors=false \
              -Dshared-glapi=true \
              -Dvalgrind=false \
-             -Db_lto=true \
+             -Db_lto=false \
              -Dlibunwind=disabled"
 MESON_AFTER__I486=" \
              ${MESON_AFTER__RETRO} \
@@ -140,3 +137,6 @@ MESON_AFTER__ARMV7HF="${MESON_AFTER__RETRO_ARM}"
 MESON_AFTER__LOONGSON2F="${MESON_AFTER__RETRO_OTHER}"
 MESON_AFTER__POWERPC="${MESON_AFTER__RETRO_OTHER}"
 MESON_AFTER__PPC64="${MESON_AFTER__RETRO_OTHER}"
+
+# FIXME: LLVM + Mesa + LTO + AMDGPU = artifacts.
+NOLTO=1

--- a/extra-libs/mesa/spec
+++ b/extra-libs/mesa/spec
@@ -1,5 +1,5 @@
 VER=22.3.1
-REL=1
+REL=2
 SRCS="tbl::https://mesa.freedesktop.org/archive/mesa-$VER.tar.xz \
       git::commit=tags/v1.608.0;rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
 CHKSUMS="sha256::3c9cd611c0859d307aba0659833386abdca4c86162d3c275ba5be62d16cf31eb \


### PR DESCRIPTION
Topic Description
-----------------

Ref: https://gitlab.freedesktop.org/mesa/mesa/-/issues/6911
Ref: https://bugs.archlinux.org/task/76019

Package(s) Affected
-------------------

`mesa` v1:22.3.1-2

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures*

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures*

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
