### PR TITLE
LLVM: LLVM 15 rework

### DIFF
--- a/base-devel/llvm/01-runtime/build
+++ b/base-devel/llvm/01-runtime/build
@@ -28,7 +28,9 @@ fi
 
 abinfo "Running CMake for LLVM ..."
 cmake "$SRCDIR" \
-    ${CMAKE_DEF} ${CMAKE_AFTER} -DLLVM_DEFAULT_TARGET_TRIPLE=${CPP_TRIPLE} \
+    ${CMAKE_DEF} ${CMAKE_AFTER} \
+    -DLLVM_DEFAULT_TARGET_TRIPLE=${CPP_TRIPLE} \
+    -DLLVM_HOST_TRIPLE=${CPP_TRIPLE} \
     -G Ninja
 
 abinfo "Building & Installing LLVM to a temporary installation directory ..."

--- a/base-devel/llvm/01-runtime/defines
+++ b/base-devel/llvm/01-runtime/defines
@@ -56,6 +56,7 @@ CMAKE_AFTER="-DLLVM_BUILD_LLVM_DYLIB=ON \
              -DLLVM_ENABLE_RTTI=ON \
              -DLLVM_ENABLE_FFI=ON \
              -DLLVM_BUILD_DOCS=OFF \
+             -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
              -DFFI_INCLUDE_DIR=$(pkg-config --variable=includedir libffi) \
              -DLLVM_BINUTILS_INCDIR=/usr/include \
              -DLLVM_INSTALL_UTILS=ON \
@@ -78,6 +79,7 @@ CMAKE_AFTER__RETRO=" \
              -DLLVM_ENABLE_FFI=ON \
              -DLLVM_BUILD_DOCS=OFF \
              -DLLVM_ENABLE_PROJECTS=${_LLVM_MIN_SET} \
+             -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
              -DFFI_INCLUDE_DIR=$(pkg-config --variable=includedir libffi) \
              -DLLVM_BINUTILS_INCDIR=/usr/include \
              -DLLVM_INSTALL_UTILS=ON \

--- a/base-devel/llvm/02-compiler/build
+++ b/base-devel/llvm/02-compiler/build
@@ -64,5 +64,7 @@ strip --verbose \
       --remove-section=.note \
       "$PKGDIR"/usr/lib/*.a
 
-abinfo "Dropping conflicting OpenMP GCC-compatible files ..."
-[ -e "$PKGDIR"/usr/lib/libgomp.so ] && rm -fv "$PKGDIR"/usr/lib/libgomp.* || true
+abinfo "Moving conflicting LLVM replacements for GCC-compatible files ..."
+mkdir -pv "$PKGDIR"/usr/lib/llvm/
+mv -v "$PKGDIR"/usr/lib/{libc++,libc++abi,libunwind,libc++experimental}.* "$PKGDIR"/usr/lib/llvm/
+[ -e "$PKGDIR"/usr/lib/libgomp.so ] && mv -v "$PKGDIR"/usr/lib/libgomp.* "$PKGDIR"/usr/lib/llvm/ || true

--- a/base-devel/llvm/spec
+++ b/base-devel/llvm/spec
@@ -1,4 +1,5 @@
 VER=15.0.7
+REL=1
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6"

--- a/extra-libs/llvm-runtime+wasi/autobuild/build
+++ b/extra-libs/llvm-runtime+wasi/autobuild/build
@@ -5,21 +5,18 @@ fi
 
 pushd "$SRCDIR"/..
 # libcxx;libcxxabi;compiler-rt
-for comp in 'compiler-rt/lib/builtins' 'libcxx' 'libcxxabi'; do
 
-mkdir -pv "$SRCDIR"/"build-$comp"
+mkdir -pv "$SRCDIR"/"abbuild"
 
-abinfo "Running CMake for LLVM $comp ..."
-cp -v "$SRCDIR"/autobuild/config.cmake "$SRCDIR"/"build-$comp"/CMakeCache.txt
-[[ "$comp" = compiler-rt* ]] && echo "CMAKE_INSTALL_PREFIX=/usr/lib/clang/${LLVM_VER}" >> "$SRCDIR"/"build-$comp"/CMakeCache.txt
-cmake -B "$SRCDIR"/"build-$comp" \
+abinfo "Running CMake for LLVM runtimes ..."
+cp -v "$SRCDIR"/autobuild/config.cmake "$SRCDIR"/abbuild/CMakeCache.txt
+echo "${CMAKE_AFTER}"
+cmake -B "$SRCDIR"/"abbuild" \
     ${CMAKE_DEF} ${CMAKE_AFTER} \
-    -G Ninja "$SRCDIR"/../"$comp"
+    -G Ninja "$SRCDIR"/../runtimes
 
 abinfo "Building & Installing LLVM $comp to a temporary installation directory ..."
-DESTDIR="$PKGDIR" ninja -C "$SRCDIR"/"build-$comp" install
-
-done
+DESTDIR="$PKGDIR" ninja -C "$SRCDIR"/"abbuild" install
 
 abinfo "Moving compiler-rt files to the linker builtin path ..."
 mkdir -pv "$PKGDIR"/usr/lib/clang/"${LLVM_VER}"/lib/wasi/

--- a/extra-libs/llvm-runtime+wasi/autobuild/config.cmake
+++ b/extra-libs/llvm-runtime+wasi/autobuild/config.cmake
@@ -1,7 +1,7 @@
 // parameters taken from Arch Linux
 CMAKE_C_COMPILER_WORKS:BOOL=ON
 CMAKE_CXX_COMPILER_WORKS:BOOL=ON
-LLVM_ENABLE_PROJECTS=libcxx;libcxxabi;libunwind;compiler-rt
+LLVM_ENABLE_RUNTIMES=libcxx;libcxxabi;compiler-rt
 CMAKE_STAGING_PREFIX=/usr/lib/wasm32-wasi
 // libcxx
 LIBCXX_ENABLE_EXCEPTIONS:BOOL=OFF

--- a/extra-libs/llvm-runtime+wasi/autobuild/defines
+++ b/extra-libs/llvm-runtime+wasi/autobuild/defines
@@ -1,11 +1,13 @@
 PKGNAME=llvm-runtime+wasi
 PKGSEC=libs
 PKGDEP="libc+wasi"
-BUILDDEP="cmake swig doxygen ocaml findlib llvm"
+BUILDDEP="cmake ninja python-3 llvm"
 PKGDES="Low Level Virtual Machine Infrastructure (runtime libraries, WASI)"
 
 CMAKE_AFTER="-DLLVM_ENABLE_RTTI=OFF \
              -DLLVM_ENABLE_FFI=OFF \
+             -DLLVM_INCLUDE_BENCHMARKS=OFF \
+             -DLIBCXX_INCLUDE_BENCHMARKS=OFF \
              -DCMAKE_MODULE_PATH="$SRCDIR"/cmake \
              -DCMAKE_TOOLCHAIN_FILE="$SRCDIR"/../../wasi-sdk.cmake \
              -DLIBCXXABI_LIBCXX_INCLUDES="$SRCDIR"/build-libcxx/include/c++/v1 \

--- a/extra-libs/llvm-runtime+wasi/autobuild/prepare
+++ b/extra-libs/llvm-runtime+wasi/autobuild/prepare
@@ -1,12 +1,6 @@
 abinfo "Unsetting all the flags ..."
 unset CFLAGS CXXFLAGS LDFLAGS
 
-abinfo "Installing sources for libunwind ..."
-mv -v "$SRCDIR"/../libunwind \
-    "$SRCDIR"/tools/libunwind
-ln -sv "$SRCDIR"/tools/libunwind "$SRCDIR"/../libunwind
-ln -sv "$SRCDIR" "$SRCDIR"/../llvm
-
 abinfo "Setting platform parameters ..."
 mkdir -pv "$SRCDIR"/cmake/Platform
 echo "set(WASI 1)" > "$SRCDIR"/cmake/Platform/WASI.cmake

--- a/extra-libs/llvm-runtime+wasi/spec
+++ b/extra-libs/llvm-runtime+wasi/spec
@@ -1,7 +1,7 @@
-VER=15.0.6
+VER=15.0.7
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz \
       file::rename=wasi-sdk.cmake::https://cdn.jsdelivr.net/gh/WebAssembly/wasi-sdk@2cd26ead40830726a4804702c7e8f9069e3eca88/wasi-sdk.cmake"
 SUBDIR="llvm-project-$VER.src/llvm"
-CHKSUMS="sha256::9d53ad04dc60cb7b30e810faf64c5ab8157dadef46c8766f67f286238256ff92 \
+CHKSUMS="sha256::8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6 \
          sha256::cdb8e60f856802000c2026a631942fc42c4aeca1ed24e571b54fc65664aadb62"
 CHKUPDATE="anitya::id=1830"


### PR DESCRIPTION
Topic Description
-----------------

llvm: use non-architectural-specific directory for storing runtime files (compatibility reasons)

Package(s) Affected
-------------------

`llvm`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [X] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

