### PR TITLE
MPD survey 20230213

### DIFF
--- a/extra-multimedia/gmpc/autobuild/defines
+++ b/extra-multimedia/gmpc/autobuild/defines
@@ -1,5 +1,0 @@
-PKGNAME=gmpc
-PKGSEC=sound
-PKGDEP="libmpd libsoup libunique sqlite xdg-utils"
-BUILDDEP="gob2 intltool vala"
-PKGDES="A cross-platform music player using close to non resources"

--- a/extra-multimedia/gmpc/autobuild/prepare
+++ b/extra-multimedia/gmpc/autobuild/prepare
@@ -1,1 +1,0 @@
-export LDFLAGS="${LDFLAGS} -lm"

--- a/extra-multimedia/gmpc/spec
+++ b/extra-multimedia/gmpc/spec
@@ -1,4 +1,0 @@
-VER=11.8.16
-SRCS="tbl::https://src.fedoraproject.org/repo/pkgs/gmpc/gmpc-11.8.16.tar.gz/223aeb000e41697d8fdf54ccedee89d5/gmpc-11.8.16.tar.gz"
-CHKSUMS="sha256::a69414f35396846733632ca9619921d7acda537ffd6d49bd84b444945cb76b2c"
-CHKUPDATE="anitya::id=8690"

--- a/extra-multimedia/mpd/spec
+++ b/extra-multimedia/mpd/spec
@@ -1,4 +1,4 @@
-VER=0.23.6
+VER=0.23.12
 SRCS="tbl::http://www.musicpd.org/download/mpd/${VER%.*}/mpd-${VER}.tar.xz"
-CHKSUMS="sha256::cbc5928ee3ee1ef7ff6a58f6ba4afaee16c07e9eb42d0107bcc098010f4f26ed"
+CHKSUMS="sha256::b7fca62284ecc25a681ea6a07abc49200af5353be42cb5a31e3173be9d8702e7"
 CHKUPDATE="anitya::id=14864"

--- a/extra-multimedia/ncmpc/spec
+++ b/extra-multimedia/ncmpc/spec
@@ -1,4 +1,4 @@
-VER=0.46
+VER=0.47
 SRCS="https://www.musicpd.org/download/ncmpc/${VER%.*}/ncmpc-${VER}.tar.xz"
-CHKSUMS="sha256::177f77cf09dd4ab914e8438be399cdd5d83c9aa992abc8d9abac006bb092934e"
+CHKSUMS="sha256::61da23b1bc6c7a593fdc28611932cd7a30fcf6803830e01764c29b8abed2249c"
 CHKUPDATE="anitya::id=2055"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Update mpd related packages, drop `gmpc` (Nobody's using it I believe, last update 4 years ago)

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`mpd` 0.23.12
`ncmpc` 0.47
`gmpc` drop, orphaned

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
