### PR TITLE
discord: update to 0.0.25

### DIFF
--- a/extra-web/discord/autobuild/build
+++ b/extra-web/discord/autobuild/build
@@ -38,6 +38,9 @@ ln -sfv /usr/lib/libEGL.so \
 ln -sfv /usr/lib/libGLESv2.so \
     "$PKGDIR"/usr/lib/discord/swiftshader/libGLESv2.so
 
+abinfo "Setting executable bits on shared objects ..."
+chmod -v +x "$PKGDIR"/usr/lib/discord/*.so*
+
 abinfo "Downloading license agreements ..."
 wget https://discordapp.com/terms \
     -O "$PKGDIR"/usr/share/doc/discord/LICENSE.html

--- a/extra-web/discord/spec
+++ b/extra-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.24
+VER=0.0.25
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::486fb7e1fb74993aad83dac5888eb437a24838dcaa17c73c4a59d1727e5ae177"
+CHKSUMS="sha256::581726cbd7f018fab756cd7eee520e47b3a25bf7749193482a9e10e4d458042c"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Discord to v0.0.25.

Package(s) Affected
-------------------

`discord` v0.0.25

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64` 

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`  