### PR TITLE
fcitx5-pinyin-moegirl: update to 20230214

### DIFF
--- a/extra-i18n/fcitx5-pinyin-moegirl/spec
+++ b/extra-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20230114
+VER=20230214
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::4e95b19b5265e96c5d02a068db6bb977bc50bffdcfd383c33042df40e5fb2244 \
-         sha256::3e9cfa1a6edc28bee22ec3a113deddbd004c16f6839438c80fed13dc7488754c \
+CHKSUMS="sha256::2567b802f69eedc434bbe5a3fa59adc5b7ab0be843ff49f0c4f5e5ecb333362e \
+         sha256::bfead0bdfc9f2f5261475e8b72490c4d5b56ef7b2ce5782ac924306d9a21cf02 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Upgrade: fcitx5-pinyin-moegirl - 20230214

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`