### PR TITLE
Dnspython dependency resurrect

### DIFF
--- a/extra-python/crashtest/autobuild/defines
+++ b/extra-python/crashtest/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=crashtest
+PKGSEC=python
+PKGDES="A Python library that makes exceptions handling and inspection easier"
+PKGDEP="python-3"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/extra-python/crashtest/spec
+++ b/extra-python/crashtest/spec
@@ -1,0 +1,4 @@
+VER=0.4.1
+SRCS="https://pypi.io/packages/source/c/crashtest/crashtest-${VER}.tar.gz"
+CHKSUMS="sha256::80d7b1f316ebfbd429f648076d6275c877ba30ba48979de4191714a75266f0ce"
+CHKUPDATE="anitya::id=120299"

--- a/extra-python/editables/autobuild/defines
+++ b/extra-python/editables/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=editables
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build setuptools-python3 python-installer wheel"
+PKGDES="A Python library for creating editable wheels"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/editables/spec
+++ b/extra-python/editables/spec
@@ -1,0 +1,4 @@
+VER=0.3
+SRCS="tbl::https://github.com/pfmoore/editables/archive/refs/tags/${VER}.tar.gz"
+CHKSUMS="sha256::42f7240164af1e028ccb7b60e72f54bbd8b639e9409595fbeffac5d3fb610643"
+CHKUPDATE="anitya::id=189881"

--- a/extra-python/hatch-fancy-pypi-readme/autobuild/defines
+++ b/extra-python/hatch-fancy-pypi-readme/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=hatch-fancy-pypi-readme
+PKGSEC=python
+PKGDEP="python-3 hatchling"
+BUILDDEP="python-build setuptools-python3 python-installer wheel"
+PKGDES="Fancy PyPI READMEs with Hatch"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/hatch-fancy-pypi-readme/spec
+++ b/extra-python/hatch-fancy-pypi-readme/spec
@@ -1,0 +1,4 @@
+VER=22.8.0
+SRCS="tbl::https://pypi.io/packages/source/h/hatch-fancy-pypi-readme/hatch_fancy_pypi_readme-$VER.tar.gz"
+CHKSUMS="sha256::da91282ca09601c18aded8e378daf8b578c70214866f0971156ee9bb9ce6c26a"
+CHKUPDATE="anitya::id=274452"

--- a/extra-python/hatchling/autobuild/build
+++ b/extra-python/hatchling/autobuild/build
@@ -1,0 +1,3 @@
+cd "${SRCDIR}"
+python3 -m build --wheel --no-isolation backend
+python3 -m installer --destdir="$PKGDIR" backend/dist/*.whl

--- a/extra-python/hatchling/autobuild/defines
+++ b/extra-python/hatchling/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=hatchling
+PKGSEC=python
+PKGDEP="python-3 packaging pathspec pluggy tomli editables"
+BUILDDEP="python-build setuptools-python3 python-installer wheel"
+PKGDES="Modern, extensible Python build backend"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/hatchling/spec
+++ b/extra-python/hatchling/spec
@@ -1,0 +1,4 @@
+VER=1.13.0
+SRCS="tbl::https://github.com/pypa/hatch/archive/refs/tags/hatchling-v${VER}.tar.gz"
+CHKSUMS="sha256::41e17b56a28fd4e8f69e4cecbea4527491c761998aba8bd2fc71d0d9eadf66b8"
+CHKUPDATE="anitya::id=16137"

--- a/extra-python/httpx/autobuild/defines
+++ b/extra-python/httpx/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=httpx
+PKGSEC=python
+PKGDEP="sniffio rfc3986 httpcore brotlipy hyper-h2"
+BUILDDEP="python-build wheel python-installer hatch-fancy-pypi-readme"
+PKGDES="A next generation HTTP client library for Python"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/httpx/autobuild/patches/0001-use-system-ca-certs.patch
+++ b/extra-python/httpx/autobuild/patches/0001-use-system-ca-certs.patch
@@ -1,0 +1,61 @@
+diff -Naur httpx-0.23.3/httpx/_config.py httpx-0.23.3.modded/httpx/_config.py
+--- httpx-0.23.3/httpx/_config.py	2023-01-04 04:39:43.000000000 -0500
++++ httpx-0.23.3.modded/httpx/_config.py	2023-02-15 23:31:34.492573411 -0500
+@@ -4,8 +4,6 @@
+ import typing
+ from pathlib import Path
+ 
+-import certifi
+-
+ from ._compat import set_minimum_tls_version_1_2
+ from ._models import Headers
+ from ._types import CertTypes, HeaderTypes, TimeoutTypes, URLTypes, VerifyTypes
+@@ -58,7 +56,7 @@
+     SSL Configuration.
+     """
+ 
+-    DEFAULT_CA_BUNDLE_PATH = Path(certifi.where())
++    DEFAULT_CA_BUNDLE_PATH = Path("/etc/ssl/certs/ca-certificates.crt")
+ 
+     def __init__(
+         self,
+diff -Naur httpx-0.23.3/pyproject.toml httpx-0.23.3.modded/pyproject.toml
+--- httpx-0.23.3/pyproject.toml	2023-01-04 04:39:43.000000000 -0500
++++ httpx-0.23.3.modded/pyproject.toml	2023-02-15 23:32:15.577629788 -0500
+@@ -28,7 +28,6 @@
+     "Topic :: Internet :: WWW/HTTP",
+ ]
+ dependencies = [
+-    "certifi",
+     "httpcore>=0.15.0,<0.17.0",
+     "rfc3986[idna2008]>=1.3,<2",
+     "sniffio",
+diff -Naur httpx-0.23.3/tests/test_config.py httpx-0.23.3.modded/tests/test_config.py
+--- httpx-0.23.3/tests/test_config.py	2023-01-04 04:39:43.000000000 -0500
++++ httpx-0.23.3.modded/tests/test_config.py	2023-02-15 23:31:59.783608070 -0500
+@@ -3,7 +3,6 @@
+ import sys
+ from pathlib import Path
+ 
+-import certifi
+ import pytest
+ 
+ import httpx
+@@ -21,7 +20,7 @@
+ 
+ 
+ def test_load_ssl_config_verify_existing_file():
+-    context = httpx.create_ssl_context(verify=certifi.where())
++    context = httpx.create_ssl_context(verify="/etc/ssl/certs/ca-certificates.crt")
+     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
+     assert context.check_hostname is True
+ 
+@@ -44,7 +43,7 @@
+ 
+ 
+ def test_load_ssl_config_verify_directory():
+-    path = Path(certifi.where()).parent
++    path = Path("/etc/ssl/certs/ca-certificates.crt").parent
+     context = httpx.create_ssl_context(verify=str(path))
+     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
+     assert context.check_hostname is True

--- a/extra-python/httpx/spec
+++ b/extra-python/httpx/spec
@@ -1,0 +1,4 @@
+VER=0.23.3
+SRCS="tbl::https://github.com/encode/httpx/archive/${VER}.tar.gz"
+CHKSUMS="sha256::d4ab899be10c968456708b4ea67b66f42eaeeee6c654903646e3b556a8de6096"
+CHKUPDATE="anitya::id=27210"

--- a/extra-python/packaging/autobuild/defines
+++ b/extra-python/packaging/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=packaging
 PKGSEC=python
-PKGDEP="python-2 python-3 pyparsing"
+PKGDEP="python-3 pyparsing"
+BUILDDEP="python-build python-installer"
 PKGDES="Core utilities for Python packaging"
 
 ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/packaging/spec
+++ b/extra-python/packaging/spec
@@ -1,5 +1,4 @@
-VER=20.8
+VER=23.0
 SRCS="tbl::https://github.com/pypa/packaging/archive/$VER.tar.gz"
-CHKSUMS="sha256::9aa4307378c6a1386890844a78344d91fbc07d9ecc14e79d66d6ab8360a2bfc1"
+CHKSUMS="sha256::698f2c072c89a5eb7d9560b64401d52b2d5eaca412bc53f9bddfef214dca71aa"
 CHKUPDATE="anitya::id=11718"
-REL=1

--- a/extra-python/pathspec/autobuild/defines
+++ b/extra-python/pathspec/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=pathspec
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build setuptools-python3 python-installer wheel"
+PKGDES="Utility library for gitignore style pattern matching of file paths"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/pathspec/spec
+++ b/extra-python/pathspec/spec
@@ -1,0 +1,4 @@
+VER=0.11.0
+SRCS="tbl::https://github.com/cpburnz/python-pathspec/archive/refs/tags/v${VER}.tar.gz"
+CHKSUMS="sha256::0bc6556fc96ad60652083190433432f56992b607b081fd35f06b4db0757dd627"
+CHKUPDATE="anitya::id=23424"

--- a/extra-python/pluggy/autobuild/defines
+++ b/extra-python/pluggy/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=pluggy
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools-scm"
+PKGDEP="python-3"
+BUILDDEP="setuptools-scm python-build wheel python-installer"
 PKGDES="Plugin and hook calling mechanisms for Python"
 
 ABHOST=noarch
+NOPYTHON2=1

--- a/extra-python/pluggy/spec
+++ b/extra-python/pluggy/spec
@@ -1,5 +1,4 @@
-VER=0.9.0
-REL=3
+VER=1.0.0
 SRCS="tbl::https://pypi.io/packages/source/p/pluggy/pluggy-$VER.tar.gz"
-CHKSUMS="sha256::19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f"
+CHKSUMS="sha256::4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"
 CHKUPDATE="anitya::id=7500"


### PR DESCRIPTION
Topic Description
-----------------

httpx and crashtest were incorrectly dropped - dnspython directly depends on httpx, poetry and poetry needs crashtest.

While we are at it upgrade all those packages.

Package(s) Affected
-------------------

- crashtest: resurrect and upgrade to 0.4.1. poetry need this shit.
- httpx: resurrect, upgrade to 0.23.3
- hatch-fancy-pypi-readme: new, 22.1.0
- hatchling: 1.13.0
- packaging: upgrade to 23.0
- editables: new, 0.3
- pluggy: upgrade to 1.0.0
- pathspec: new, 0.11.0

Build Order
-----------

Build in the reversed order of commits

Test Build(s) Done
------------------

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------
- [x] Architecture-independent `noarch`
