### PR TITLE
kicad: update to 7.0.0

### DIFF
--- a/extra-electronics/kicad/spec
+++ b/extra-electronics/kicad/spec
@@ -1,14 +1,13 @@
-VER=6.0.10
-REL=1
+VER=7.0.0
 SRCS="tbl::rename=kicad-$VER.tar.bz2::https://gitlab.com/kicad/code/kicad/-/archive/$VER/kicad-$VER.tar.bz2 \
       tbl::rename=kicad-footprints-$VER.tar.bz2::https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/$VER/kicad-footprints-$VER.tar.bz2 \
       tbl::rename=kicad-symbols-$VER.tar.bz2::https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/$VER/kicad-symbols-$VER.tar.bz2 \
       tbl::rename=kicad-packages3D-$VER.tar.bz2::https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/$VER/kicad-packages3D-$VER.tar.bz2 \
       tbl::rename=kicad-doc-$VER.tar.gz::https://kicad-downloads.s3.cern.ch/docs/kicad-doc-$VER.tar.gz"
-CHKSUMS="sha256::b93ee38f968deb6a249e36f35692f1e275c944e90f024884ddfca983325de094 \
-         sha256::6f089d2674f8d5be77f6b550d698de3676c0980d375114f932b72ed093d27521 \
-         sha256::398258563187fc0a6fd72a02623edabca6b9658114eabb220c9e372ebe6b93db \
-         sha256::01fdef32c0c227546e74774cca58c7d5520f345be9faa9899b1d0ed0f98f7c09 \
-         sha256::15aa790890b7880ba94d773e2b8bb1a6421134c8b62f2e05c94307fb2ac2defa"
+CHKSUMS="sha256::f0e188c67a1044c6cc884b66b25717326d93ec896194c0963c2fb79b35943d72 \
+         sha256::c344f1bf92d4161845117757197de83b1722391f2830d7d698a5879f6677e884 \
+         sha256::3042b1d9f64f1d96e276361cc99bd695d8c9a88d0cc34a0815d9cc68e7243dfe \
+         sha256::28e53e23b18b434702bcf0c0462f44e7c866f9dd0fed3ab60291057f8bfd7ff9 \
+         sha256::04cad356fd19b46e70eaa6e3365d94c326e4237d80c09394208fd4662e756465 "
 SUBDIR="kicad-$VER"
 CHKUPDATE="anitya::id=8432"


### PR DESCRIPTION
Topic Description
-----------------

Upgrade our beloved EDA tool, KiCad, to 7.0.0.

Package(s) Affected
-------------------

- `kicad`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
