### PR TITLE
yt-dlp: update to 2023.02.17

### DIFF
--- a/extra-multimedia/yt-dlp/spec
+++ b/extra-multimedia/yt-dlp/spec
@@ -1,4 +1,4 @@
-VER=2023.01.06
+VER=2023.02.17
 SRCS="git::commit=tags/$VER::https://github.com/yt-dlp/yt-dlp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=143399"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates `yt-dlp` to v2023.02.17.

Package(s) Affected
-------------------

`yt-dlp` v2023.02.17.

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`