### PR TITLE
mpv: update to 0.35.1

### DIFF
--- a/extra-kde/haruna/spec
+++ b/extra-kde/haruna/spec
@@ -2,3 +2,4 @@ VER=0.9.1
 SRCS="tbl::https://download.kde.org/stable/haruna/haruna-$VER.tar.xz"
 CHKSUMS="sha256::9131f2d3a44332ff65c15c77b243a9897cd7acc1d7fe77d75180bb519344840d"
 CHKUPDATE="anitya::id=267594"
+REL=1

--- a/extra-multimedia/celluloid/spec
+++ b/extra-multimedia/celluloid/spec
@@ -1,5 +1,5 @@
 VER=0.18
 SRCS="tbl::https://github.com/celluloid-player/celluloid/archive/v$VER.tar.gz"
 CHKSUMS="sha256::3ce6158097d94786a62de5f26ab2cb71301e9fd0841ede8381e1535489cf0de8"
-REL=1
+REL=2
 CHKUPDATE="anitya::id=193876"

--- a/extra-multimedia/mpv/autobuild/defines
+++ b/extra-multimedia/mpv/autobuild/defines
@@ -28,4 +28,4 @@ BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="Video player based on MPlayer/mplayer2"
 
-PKGBREAK="celluloid<=0.17"
+PKGBREAK="celluloid<=0.18-1 haruna<=0.9.1 minitube<=3.9.3-1"

--- a/extra-multimedia/mpv/spec
+++ b/extra-multimedia/mpv/spec
@@ -1,4 +1,4 @@
-VER=0.34.1
+VER=0.35.1
 SRCS="tbl::https://github.com/mpv-player/mpv/archive/v$VER.tar.gz"
-CHKSUMS="sha256::32ded8c13b6398310fa27767378193dc1db6d78b006b70dbcbd3123a1445e746"
+CHKSUMS="sha256::41df981b7b84e33a2ef4478aaf81d6f4f5c8b9cd2c0d337ac142fc20b387d1a9"
 CHKUPDATE="anitya::id=5348"


### PR DESCRIPTION
Topic Description
-----------------

Update `mpv` to v0.35.1 and rebuild reverse dependencies.

Package(s) Affected
-------------------

- `celluloid` v0.18-2
- `haruna` v0.9.1-1
- `mpv` v0.35.1

Security Update?
----------------

No

Build Order
-----------

```
mpv celluloid haruna
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`