### PR TITLE
thermald: update to 2.5.2

### DIFF
--- a/extra-admin/thermald/spec
+++ b/extra-admin/thermald/spec
@@ -1,4 +1,4 @@
-VER=2.4.6
+VER=2.5.2
 SRCS="https://github.com/intel/thermal_daemon/archive/v$VER.tar.gz"
-CHKSUMS="sha256::80c92902a89b72a9df85c51a8b5fc472cc01b4410600ef1f56d62c4ac23890c1"
+CHKSUMS="sha256::9c69588b94a98b4843cd46e3bae570f55020b5e2bf1b417a0c6990f6519070c9"
 CHKUPDATE="anitya::id=14500"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

thermald 2.5.2 is now capable of removing the 10W CPU power on certain Intel TigerLake-based systems that the previous version (2.4.6) has failed to do. Half of the Panasonic Let's Note CF-SV2 owned by community members[1] was affected by this issue.

Ref: https://github.com/intel/thermal_daemon/blob/397d4e8f61ebb7471a7920a043d77fedc1f41a9a/README.txt#L119-L148

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

thermald: update to 2.5.2
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

<!-- TODO: CI to auto-fill architectural progress. -->
