### PR TITLE
Qt 6.4.2

### DIFF
--- a/extra-libs/qt-6/autobuild/beyond
+++ b/extra-libs/qt-6/autobuild/beyond
@@ -1,5 +1,5 @@
 abinfo "Creating application symlinks in /usr/bin ..."
 mkdir -pv "$PKGDIR"/usr/bin
 for b in "$PKGDIR"/usr/lib/qt6/bin/*; do
-    ln -sv $(basename $b) "$PKGDIR"/usr/bin/$(basename $b)-qt6
+    ln -sv ../lib/qt6/bin/"$(basename "$b")" "$PKGDIR"/usr/bin/"$(basename "$b")"-qt6
 done

--- a/extra-libs/qt-6/autobuild/defines
+++ b/extra-libs/qt-6/autobuild/defines
@@ -32,8 +32,6 @@ PKGDEP__MIPS64R6EL="${PKGDEP__NOWEBENGINE}"
 PKGDEP__PPC64EL="${PKGDEP__NOWEBENGINE}"
 PKGDEP__RISCV64="${PKGDEP__NOWEBENGINE}"
 
-# FIXME: LTO breaks WebEngine build.
-NOLTO=1
 
 ABTYPE=cmakeninja
 # To query possible build options, you may want to check following files in
@@ -51,6 +49,7 @@ CMAKE_AFTER="-DINSTALL_BINDIR=lib/qt6/bin \
              -DINSTALL_EXAMPLESDIR=share/doc/qt-6/examples \
              -DBUILD_SHARED_LIB=ON \
              -DCMAKE_SKIP_RPATH=OFF \
+             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
              -DQT_BUILD_TESTS=OFF \
              -DQT_FEATURE_use_gold_linker=OFF \
              -DQT_FEATURE_reduce_relocations=OFF \

--- a/extra-libs/qt-6/autobuild/defines
+++ b/extra-libs/qt-6/autobuild/defines
@@ -74,6 +74,7 @@ CMAKE_AFTER="-DINSTALL_BINDIR=lib/qt6/bin \
              -DQT_FEATURE_libproxy=ON \
              -DQT_FEATURE_vulkan=ON \
              -DQT_FEATURE_qtpdf_build=ON \
+             -DQT_FEATURE_webengine_full_debug_info=ON \
              -DQT_FEATURE_webengine_extensions=ON \
              -DQT_FEATURE_webengine_system_ffmpeg=ON \
              -DQT_FEATURE_webengine_system_libevent=ON \

--- a/extra-libs/qt-6/autobuild/defines
+++ b/extra-libs/qt-6/autobuild/defines
@@ -75,7 +75,7 @@ CMAKE_AFTER="-DINSTALL_BINDIR=lib/qt6/bin \
              -DQT_FEATURE_qtpdf_build=ON \
              -DQT_FEATURE_webengine_full_debug_info=ON \
              -DQT_FEATURE_webengine_extensions=ON \
-             -DQT_FEATURE_webengine_system_ffmpeg=ON \
+             -DQT_FEATURE_webengine_system_ffmpeg=OFF \
              -DQT_FEATURE_webengine_system_libevent=ON \
              -DQT_FEATURE_webengine_system_libxslt=ON \
              -DQT_FEATURE_webengine_proprietary_codecs=ON \

--- a/extra-libs/qt-6/autobuild/defines
+++ b/extra-libs/qt-6/autobuild/defines
@@ -77,6 +77,7 @@ CMAKE_AFTER="-DINSTALL_BINDIR=lib/qt6/bin \
              -DQT_FEATURE_webengine_extensions=ON \
              -DQT_FEATURE_webengine_system_ffmpeg=ON \
              -DQT_FEATURE_webengine_system_libevent=ON \
+             -DQT_FEATURE_webengine_system_libxslt=ON \
              -DQT_FEATURE_webengine_proprietary_codecs=ON \
              -DQT_FEATURE_webengine_kerberos=ON \
              -DQT_FEATURE_webengine_webrtc=ON \

--- a/extra-libs/qt-6/spec
+++ b/extra-libs/qt-6/spec
@@ -1,4 +1,4 @@
-VER=6.3.1
+VER=6.4.1
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
-CHKSUMS="sha256::51114e789485fdb6b35d112dfd7c7abb38326325ac51221b6341564a1c3cc726"
+CHKSUMS="sha256::e20b850b6134098a7f2e7701cfddfb213c6cf394b9e848e6fbc5b0e89dcfcc09"
 CHKUPDATE="anitya::id=230518"

--- a/extra-libs/qt-6/spec
+++ b/extra-libs/qt-6/spec
@@ -1,4 +1,4 @@
-VER=6.4.1
+VER=6.4.2
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
-CHKSUMS="sha256::e20b850b6134098a7f2e7701cfddfb213c6cf394b9e848e6fbc5b0e89dcfcc09"
+CHKSUMS="sha256::689f53e6652da82fccf7c2ab58066787487339f28d1ec66a8765ad357f4976be"
 CHKUPDATE="anitya::id=230518"

--- a/extra-libs/qt-6/spec
+++ b/extra-libs/qt-6/spec
@@ -1,5 +1,4 @@
-VER=6.2.2
-REL=3
+VER=6.3.1
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
-CHKSUMS="sha256::907994f78d42b30bdea95e290e91930c2d9b593f3f8dd994f44157e387feee0f"
+CHKSUMS="sha256::51114e789485fdb6b35d112dfd7c7abb38326325ac51221b6341564a1c3cc726"
 CHKUPDATE="anitya::id=230518"

--- a/extra-python/html5lib-python/spec
+++ b/extra-python/html5lib-python/spec
@@ -1,6 +1,4 @@
-VER=1.0.1
-REL=3
+VER=1.1
 SRCS="tbl::https://github.com/html5lib/html5lib-python/archive/$VER.tar.gz"
-CHKSUMS="sha256::fabbebd6a55d07842087f13849076eeed350aa8bb6c9ec840f6a6aba9388db06"
-SUBDIR="html5lib-python-$VER"
+CHKSUMS="sha256::66e9e24a53c10c27abb6be8a3cf2cf55824c6ea1cef8570a633cb223ec46e894"
 CHKUPDATE="anitya::id=8053"

--- a/extra-utils/qt6ct/autobuild/defines
+++ b/extra-utils/qt6ct/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=qt6ct
+PKGSEC=x11
+PKGDEP="qt-6"
+PKGDES="Qt6 configuration tool"

--- a/extra-utils/qt6ct/spec
+++ b/extra-utils/qt6ct/spec
@@ -1,0 +1,4 @@
+VER=0.5
+SRCS="tbl::https://github.com/trialuser02/qt6ct/releases/download/0.5/qt6ct-$VER.tar.xz"
+CHKSUMS="sha256::db3cbed576e90a41babf24827886451ff0c6d9baee337b2a1b058e90441f9bbd"
+CHKUPDATE="anitya::id=288166"


### PR DESCRIPTION
Topic Description
-----------------

This PR is to update `qt-6` to 6.3.1 and fine tune some parameters.

Package(s) Affected
-------------------

- `qt-6` v6.4.2
- `html5lib-python` v1.1
- `qt6ct` v0.5 (new)

Security Update?
----------------

No

Build Order
-----------

```
html5lib-python qt-6 qt6ct
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
