### PR TITLE
supertuxkart: update to 1.4

### DIFF
--- a/extra-games/supertuxkart/autobuild/beyond
+++ b/extra-games/supertuxkart/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Removing files from bundled libraries ..."
+rm -rv "$PKGDIR"/usr/lib/cmake/
+rm -rv "$PKGDIR"/usr/include/

--- a/extra-games/supertuxkart/spec
+++ b/extra-games/supertuxkart/spec
@@ -1,4 +1,4 @@
-VER=1.2
+VER=1.4
 SRCS="tbl::https://sourceforge.net/projects/supertuxkart/files/SuperTuxKart/$VER/SuperTuxKart-$VER-src.tar.xz"
-CHKSUMS="sha256::052edf0afdbeb99583fe8676fb0ab80ecb6103fb88b7540f858d1b5fa1297d37"
+CHKSUMS="sha256::9890392419baf4715313f14d5ad60746f276eed36eb580636caf44e2532c0f03"
 CHKUPDATE="anitya::id=4912"


### PR DESCRIPTION
Topic Description
-----------------

Update `supertuxkart` to newest stable release.

Package(s) Affected
-------------------

- `supertuxkart`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
