### PR TITLE
snapd-new: rework

### DIFF
--- a/app-admin/apparmor/autobuild/beyond
+++ b/app-admin/apparmor/autobuild/beyond
@@ -1,0 +1,4 @@
+# We only need profiles in /etc/apparmor.d/{abi,abstractions,tunables}
+abinfo "Removing unsupported vendor profiles ..."
+rm -Rvf "${PKGDIR}"/etc/apparmor.d/!(abi|abstractions|tunables)
+rm -Rvf "${PKGDIR}"/usr/share/apparmor/extra-profiles/*

--- a/app-admin/apparmor/autobuild/build
+++ b/app-admin/apparmor/autobuild/build
@@ -39,9 +39,6 @@ make -C "${SRCDIR}/changehat/pam_apparmor" \
 	SECDIR="${PKGDIR}/usr/lib/security" \
 	install
 
-abinfo "Installing changehat/mod_apparmor..."
-make -C "${SRCDIR}/changehat/mod_apparmor" DESTDIR="${PKGDIR}" install
-
 abinfo "Installing apparmor-binutils..."
 make -C "${SRCDIR}/binutils" \
 	DESTDIR="${PKGDIR}" \

--- a/app-admin/apparmor/spec
+++ b/app-admin/apparmor/spec
@@ -1,4 +1,5 @@
 VER=3.0.8
+REL=1
 SRCS="tbl::https://gitlab.com/apparmor/apparmor/-/archive/v$VER/apparmor-v$VER.tar.gz"
 CHKSUMS="sha256::d68dae9fb7b8b54fa2f9b421e3f11e78233a132ec37bc006ba2ada438b3995ac"
 CHKUPDATE="anitya::id=94819"

--- a/desktop-kde/discover/autobuild/defines
+++ b/desktop-kde/discover/autobuild/defines
@@ -1,11 +1,12 @@
 PKGNAME=discover
 PKGSEC=kde
-PKGDEP="appstream-qt discount flatpak fwupd attica5 karchive kauth kbookmarks \
+PKGDEP="appstream-qt discount fwupd attica5 karchive kauth kbookmarks \
         kcmutils kcodecs kcompletion kconfig kconfigwidgets kcoreaddons \
         kcrash kdbusaddons kdeclarative ki18n kidletime kio kirigami2 \
         kitemviews kjobwidgets knewstuff knotifications kpackage kservice \
-        kwidgetsaddons kxmlgui ostree packagekit-qt purpose snapd-glib solid"
-BUILDDEP="extra-cmake-modules"
+        kwidgetsaddons kxmlgui ostree packagekit-qt purpose solid"
+PKGRECOM="flatpak snapd-glib"
+BUILDDEP="extra-cmake-modules flatpak snapd-glib"
 PKGDES="An all-in-one software and addons manager for the Plasma desktop"
 
 # FIXME: -DCMAKE_SKIP_RPATH=OFF, Discover installs runtime libraries to a

--- a/desktop-kde/discover/spec
+++ b/desktop-kde/discover/spec
@@ -1,4 +1,5 @@
 VER=5.27.2
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/discover-$VER.tar.xz"
 CHKSUMS="sha256::2c1ba279ec15f88472e6d2e13ce10054ba9fad628428f41bdb10f2cd58a8962d"
 CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Remove unsupported policies from AppArmor, move `flatpak` and `snapd(-glib)` from PKGDEP to PKGRECOM.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

apparmor, discover
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

Please describe in what order maintainers should build this pull request.

```
apparmor discover
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
