### PR TITLE
mips64r6el Cross Toolchain: new

### DIFF
--- a/app-devel/binutils+cross-mips64r6el/autobuild/beyond
+++ b/app-devel/binutils+cross-mips64r6el/autobuild/beyond
@@ -1,0 +1,1 @@
+rm $PKGDIR/opt/abcross/mips64r6el/share/info/dir

--- a/app-devel/binutils+cross-mips64r6el/autobuild/beyond
+++ b/app-devel/binutils+cross-mips64r6el/autobuild/beyond
@@ -1,1 +1,2 @@
-rm $PKGDIR/opt/abcross/mips64r6el/share/info/dir
+abinfo "Removing unnedded file..."
+rm -v "$PKGDIR"/opt/abcross/mips64r6el/share/info/dir

--- a/app-devel/binutils+cross-mips64r6el/autobuild/build
+++ b/app-devel/binutils+cross-mips64r6el/autobuild/build
@@ -1,11 +1,23 @@
+abinfo "Clearing compiler flags in environment..."
 unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
 
+abinfo "Configuring binutils..."
 mkdir -p build
 cd build
-../configure --prefix=/opt/abcross/mips64r6el --target=mipsisa64r6el-aosc-linux-gnuabi64 \
-             --with-sysroot=/var/ab/cross-root/mips64r6el --enable-shared --disable-multilib --with-arch=mips64r6 --with-tune=mips64r6  --disable-werror \
-	     --enable-gold
+../configure \
+	    --prefix=/opt/abcross/mips64r6el \
+	    --target=mipsisa64r6el-aosc-linux-gnuabi64 \
+	    --with-sysroot=/var/ab/cross-root/mips64r6el \
+	    --enable-shared \
+	    --disable-multilib \
+	    --with-arch=mips64r6 \
+	    --with-tune=mips64r6 \
+	    --disable-werror \
+	    --enable-gold
 
+abinfo "Building binutils..."
 make configure-host
-make 
+make
+
+abinfo "Installing binutils to target directory..."
 make DESTDIR=$PKGDIR install

--- a/app-devel/binutils+cross-mips64r6el/autobuild/build
+++ b/app-devel/binutils+cross-mips64r6el/autobuild/build
@@ -2,12 +2,13 @@ abinfo "Clearing compiler flags in environment..."
 unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
 
 abinfo "Configuring binutils..."
-mkdir -p build
-cd build
+mkdir -pv "$SRCDIR"/build
+cd "$SRCDIR"/build
+
 ../configure \
-	    --prefix=/opt/abcross/mips64r6el \
+	    --prefix=/opt/abcross/${__CROSS} \
 	    --target=mipsisa64r6el-aosc-linux-gnuabi64 \
-	    --with-sysroot=/var/ab/cross-root/mips64r6el \
+	    --with-sysroot=/var/ab/cross-root/${__CROSS} \
 	    --enable-shared \
 	    --disable-multilib \
 	    --with-arch=mips64r6 \

--- a/app-devel/binutils+cross-mips64r6el/autobuild/build
+++ b/app-devel/binutils+cross-mips64r6el/autobuild/build
@@ -1,0 +1,11 @@
+unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
+
+mkdir -p build
+cd build
+../configure --prefix=/opt/abcross/mips64r6el --target=mipsisa64r6el-aosc-linux-gnuabi64 \
+             --with-sysroot=/var/ab/cross-root/mips64r6el --enable-shared --disable-multilib --with-arch=mips64r6 --with-tune=mips64r6  --disable-werror \
+	     --enable-gold
+
+make configure-host
+make 
+make DESTDIR=$PKGDIR install

--- a/app-devel/binutils+cross-mips64r6el/autobuild/defines
+++ b/app-devel/binutils+cross-mips64r6el/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=binutils+cross-mips64r6el
+PKGDEP="glibc"
+PKGSEC=devel
+PKGDES="Binutils for mips64r6el cross build"

--- a/app-devel/binutils+cross-mips64r6el/spec
+++ b/app-devel/binutils+cross-mips64r6el/spec
@@ -1,0 +1,4 @@
+VER=2.40
+SRCS="git::commit=b5624945ea67525c0ba4ffec7a9d3f9366bf9071::https://sourceware.org/git/binutils-gdb.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=7981"

--- a/app-devel/gcc+cross-mips64r6el/autobuild/beyond
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/beyond
@@ -1,2 +1,2 @@
 abinfo "Removing unnedded files..."
-rm $PKGDIR/opt/abcross/mips64r6el/share/info/dir
+rm -v "$PKGDIR"/opt/abcross/mips64r6el/share/info/dir

--- a/app-devel/gcc+cross-mips64r6el/autobuild/beyond
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/beyond
@@ -1,1 +1,2 @@
+abinfo "Removing unnedded files..."
 rm $PKGDIR/opt/abcross/mips64r6el/share/info/dir

--- a/app-devel/gcc+cross-mips64r6el/autobuild/beyond
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/beyond
@@ -1,0 +1,1 @@
+rm $PKGDIR/opt/abcross/mips64r6el/share/info/dir

--- a/app-devel/gcc+cross-mips64r6el/autobuild/build
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/build
@@ -2,12 +2,13 @@ abinfo "Clearing compiler flags in environment..."
 unset CFLAGS CXXFLAGS LDFLAGS CPPFLAGS
 
 abinfo "Configuring GCC..."
-mkdir -p build
-cd build
+mkdir -pv "$SRCDIR"/build
+cd "$SRCDIR"/build
+
 ../configure \
-	    --prefix=/opt/abcross/mips64r6el \
+	    --prefix=/opt/abcross/${__CROSS} \
 	    --target=mipsisa64r6el-aosc-linux-gnuabi64 \
-	    --with-sysroot=/var/ab/cross-root/mips64r6el \
+	    --with-sysroot=/var/ab/cross-root/${__CROSS} \
 	    --enable-shared \
 	    --disable-multilib \
 	    --enable-c99 \
@@ -29,8 +30,8 @@ make AS_FOR_TARGET=/opt/abcross/mips64r6el/bin/mipsisa64r6el-aosc-linux-gnuabi64
      LD_FOR_TARGET=/opt/abcross/mips64r6el/bin/mipsisa64r6el-aosc-linux-gnuabi64-ld
 
 abinfo "Installing gcc into PKGDIR..."
-make DESTDIR=$PKGDIR install
+make DESTDIR="$PKGDIR" install
 
 abinfo "Installing minimal sysroot into PKGDIR..."
-mkdir -pv $PKGDIR/var/ab/cross-root
+mkdir -pv "$PKGDIR"/var/ab/cross-root
 cp -avP /var/ab/cross-root/${__CROSS} ${PKGDIR}/var/ab/cross-root/

--- a/app-devel/gcc+cross-mips64r6el/autobuild/build
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/build
@@ -1,0 +1,14 @@
+unset CFLAGS CXXFLAGS LDFLAGS CPPFLAGS
+
+mkdir -p build
+cd build
+AR=ar ../configure --prefix=/opt/abcross/mips64r6el --target=mipsisa64r6el-aosc-linux-gnuabi64 \
+	--with-sysroot=/var/ab/cross-root/mips64r6el --enable-shared --disable-multilib \
+	--enable-c99 --enable-long-long --enable-threads=posix --enable-languages=c,c++,fortran,lto \
+	--enable-__cxa_atexit --disable-altivec --disable-fixed-point --with-arch=mips64r6 --with-tune=mips64r6 \
+	--enable-lto --enable-gnu-unique-object --enable-linker-build-id --enable-libstdcxx-dual-abi \
+	--with-default-libstdcxx-abi=new
+
+make AS_FOR_TARGET=/opt/abcross/mips64r6el/bin/mipsisa64r6el-aosc-linux-gnuabi64-as \
+     LD_FOR_TARGET=/opt/abcross/mips64r6el/bin/mipsisa64r6el-aosc-linux-gnuabi64-ld
+make DESTDIR=$PKGDIR install

--- a/app-devel/gcc+cross-mips64r6el/autobuild/build
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/build
@@ -1,5 +1,7 @@
+abinfo "Clearing compiler flags in environment..."
 unset CFLAGS CXXFLAGS LDFLAGS CPPFLAGS
 
+abinfo "Configuring GCC..."
 mkdir -p build
 cd build
 AR=ar ../configure --prefix=/opt/abcross/mips64r6el --target=mipsisa64r6el-aosc-linux-gnuabi64 \
@@ -9,6 +11,9 @@ AR=ar ../configure --prefix=/opt/abcross/mips64r6el --target=mipsisa64r6el-aosc-
 	--enable-lto --enable-gnu-unique-object --enable-linker-build-id --enable-libstdcxx-dual-abi \
 	--with-default-libstdcxx-abi=new
 
+abinfo "Building gcc..."
 make AS_FOR_TARGET=/opt/abcross/mips64r6el/bin/mipsisa64r6el-aosc-linux-gnuabi64-as \
      LD_FOR_TARGET=/opt/abcross/mips64r6el/bin/mipsisa64r6el-aosc-linux-gnuabi64-ld
+
+abinfo "Installing gcc into PKGDIR..."
 make DESTDIR=$PKGDIR install

--- a/app-devel/gcc+cross-mips64r6el/autobuild/build
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/build
@@ -4,12 +4,25 @@ unset CFLAGS CXXFLAGS LDFLAGS CPPFLAGS
 abinfo "Configuring GCC..."
 mkdir -p build
 cd build
-AR=ar ../configure --prefix=/opt/abcross/mips64r6el --target=mipsisa64r6el-aosc-linux-gnuabi64 \
-	--with-sysroot=/var/ab/cross-root/mips64r6el --enable-shared --disable-multilib \
-	--enable-c99 --enable-long-long --enable-threads=posix --enable-languages=c,c++,fortran,lto \
-	--enable-__cxa_atexit --disable-altivec --disable-fixed-point --with-arch=mips64r6 --with-tune=mips64r6 \
-	--enable-lto --enable-gnu-unique-object --enable-linker-build-id --enable-libstdcxx-dual-abi \
-	--with-default-libstdcxx-abi=new
+../configure \
+	    --prefix=/opt/abcross/mips64r6el \
+	    --target=mipsisa64r6el-aosc-linux-gnuabi64 \
+	    --with-sysroot=/var/ab/cross-root/mips64r6el \
+	    --enable-shared \
+	    --disable-multilib \
+	    --enable-c99 \
+	    --enable-long-long \
+	    --enable-threads=posix \
+	    --enable-languages=c,c++,fortran,lto \
+	    --enable-__cxa_atexit \
+	    --disable-fixed-point \
+	    --with-arch=mips64r6 \
+	    --with-tune=mips64r6 \
+	    --enable-lto \
+	    --enable-gnu-unique-object \
+	    --enable-linker-build-id \
+	    --enable-libstdcxx-dual-abi \
+	    --with-default-libstdcxx-abi=new
 
 abinfo "Building gcc..."
 make AS_FOR_TARGET=/opt/abcross/mips64r6el/bin/mipsisa64r6el-aosc-linux-gnuabi64-as \

--- a/app-devel/gcc+cross-mips64r6el/autobuild/build
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/build
@@ -30,3 +30,7 @@ make AS_FOR_TARGET=/opt/abcross/mips64r6el/bin/mipsisa64r6el-aosc-linux-gnuabi64
 
 abinfo "Installing gcc into PKGDIR..."
 make DESTDIR=$PKGDIR install
+
+abinfo "Installing minimal sysroot into PKGDIR..."
+mkdir -pv $PKGDIR/var/ab/cross-root
+cp -avP /var/ab/cross-root/${__CROSS} ${PKGDIR}/var/ab/cross-root/

--- a/app-devel/gcc+cross-mips64r6el/autobuild/defines
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=gcc+cross-mips64r6el
+PKGSEC=devel
+PKGDEP="binutils+cross-mips64r6el"
+PKGDES="GCC for mips64r6el build"
+NOSTATIC=no

--- a/app-devel/gcc+cross-mips64r6el/autobuild/patches/0003-MIPS-fix-building-on-multiarch-platform.patch.mips64r6el
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/patches/0003-MIPS-fix-building-on-multiarch-platform.patch.mips64r6el
@@ -1,0 +1,135 @@
+From 354c97ee05b23707efbfc7ff6640dcec7336ac7a Mon Sep 17 00:00:00 2001
+From: YunQiang Su <yunqiang.su@cipunited.com>
+Date: Wed, 21 Sep 2022 11:13:03 +0000
+Subject: [PATCH] MIPS: fix building on multiarch platform
+
+On platforms that support multiarch, such as Debian,
+the filesystem hierarchy doesn't fellow the old Irix style:
+	lib & lib/<multiarch> for native
+	lib64 for N64 on N32/O32 systems
+	lib32 for N32 on N64/O32 systems
+	libo32 for O32 on N64/N32 systems
+
+Thus we cannot
+ #define STANDARD_STARTFILE_PREFIX_1
+ #define STANDARD_STARTFILE_PREFIX_2
+on N32 or N64 systems, else collect2 won't look for libraries
+on /lib/<multiarch>.
+
+gcc/ChangeLog:
+	* configure.ac: AC_DEFINE(ENABLE_MULTIARCH, 1)
+	* configure: Regenerated.
+	* config.in: Regenerated.
+	* config/mips/mips.h: don't define STANDARD_STARTFILE_PREFIX_1
+	  if ENABLE_MULTIARCH is defined.
+	* config/mips/t-linux64: define correct multiarch path when
+	  multiarch is enabled.
+---
+ gcc/config.in             |  6 ++++++
+ gcc/config/mips/mips.h    |  2 ++
+ gcc/config/mips/t-linux64 | 21 ++++++++++++++++++++-
+ gcc/configure             |  4 ++++
+ gcc/configure.ac          |  3 +++
+ 5 files changed, 35 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config.in b/gcc/config.in
+index 5e41748a354..38ef792bd67 100644
+--- a/gcc/config.in
++++ b/gcc/config.in
+@@ -2324,6 +2324,12 @@
+ #endif
+ 
+ 
++/* Specify if mutliarch is enabled. */
++#ifndef USED_FOR_TARGET
++#undef ENABLE_MULTIARCH
++#endif
++
++
+ /* The size of `dev_t', as computed by sizeof. */
+ #ifndef USED_FOR_TARGET
+ #undef SIZEOF_DEV_T
+diff --git a/gcc/config/mips/mips.h b/gcc/config/mips/mips.h
+index 74b6e11aabb..fe7f5b274b9 100644
+--- a/gcc/config/mips/mips.h
++++ b/gcc/config/mips/mips.h
+@@ -3427,6 +3427,7 @@ struct GTY(())  machine_function {
+ 
+ /* If we are *not* using multilibs and the default ABI is not ABI_32 we
+    need to change these from /lib and /usr/lib.  */
++#ifndef ENABLE_MULTIARCH
+ #if MIPS_ABI_DEFAULT == ABI_N32
+ #define STANDARD_STARTFILE_PREFIX_1 "/lib32/"
+ #define STANDARD_STARTFILE_PREFIX_2 "/usr/lib32/"
+@@ -3434,6 +3435,7 @@ struct GTY(())  machine_function {
+ #define STANDARD_STARTFILE_PREFIX_1 "/lib64/"
+ #define STANDARD_STARTFILE_PREFIX_2 "/usr/lib64/"
+ #endif
++#endif
+ 
+ /* Load store bonding is not supported by micromips and fix_24k.  The
+    performance can be degraded for those targets.  Hence, do not bond for
+diff --git a/gcc/config/mips/t-linux64 b/gcc/config/mips/t-linux64
+index 2fdd8e00407..37d176ea309 100644
+--- a/gcc/config/mips/t-linux64
++++ b/gcc/config/mips/t-linux64
+@@ -20,7 +20,26 @@ MULTILIB_OPTIONS = mabi=n32/mabi=32/mabi=64
+ MULTILIB_DIRNAMES = n32 32 64
+ MIPS_EL = $(if $(filter %el, $(firstword $(subst -, ,$(target)))),el)
+ MIPS_SOFT = $(if $(strip $(filter MASK_SOFT_FLOAT_ABI, $(target_cpu_default)) $(filter soft, $(with_float))),soft)
+-MULTILIB_OSDIRNAMES = \
++ifeq (yes,$(enable_multiarch))
++  ifneq (,$(findstring gnuabi64,$(target)))
++    MULTILIB_OSDIRNAMES = \
++	../lib32$(call if_multiarch,:mips64$(MIPS_EL)-linux-gnuabin32$(MIPS_SOFT)) \
++	../libo32$(call if_multiarch,:mips$(MIPS_EL)-linux-gnu$(MIPS_SOFT)) \
++	../lib$(call if_multiarch,:mips64$(MIPS_EL)-linux-gnuabi64$(MIPS_SOFT))
++  else ifneq (,$(findstring gnuabin32,$(target)))
++    MULTILIB_OSDIRNAMES = \
++	../lib$(call if_multiarch,:mips64$(MIPS_EL)-linux-gnuabin32$(MIPS_SOFT)) \
++	../libo32$(call if_multiarch,:mips$(MIPS_EL)-linux-gnu$(MIPS_SOFT)) \
++	../lib64$(call if_multiarch,:mips64$(MIPS_EL)-linux-gnuabi64$(MIPS_SOFT))
++  else
++    MULTILIB_OSDIRNAMES = \
++	../lib32$(call if_multiarch,:mips64$(MIPS_EL)-linux-gnuabin32$(MIPS_SOFT)) \
++	../lib$(call if_multiarch,:mips$(MIPS_EL)-linux-gnu$(MIPS_SOFT)) \
++	../lib64$(call if_multiarch,:mips64$(MIPS_EL)-linux-gnuabi64$(MIPS_SOFT))
++  endif
++else
++  MULTILIB_OSDIRNAMES = \
+ 	../lib32$(call if_multiarch,:mips64$(MIPS_EL)-linux-gnuabin32$(MIPS_SOFT)) \
+ 	../lib$(call if_multiarch,:mips$(MIPS_EL)-linux-gnu$(MIPS_SOFT)) \
+ 	../lib64$(call if_multiarch,:mips64$(MIPS_EL)-linux-gnuabi64$(MIPS_SOFT))
++endif
+diff --git a/gcc/configure b/gcc/configure
+index c6def4c88e5..8e3c89b609e 100755
+--- a/gcc/configure
++++ b/gcc/configure
+@@ -7842,6 +7842,10 @@ if test x${enable_multiarch} = xauto; then
+     enable_multiarch=no
+   fi
+ fi
++if test x${enable_multiarch} = xyes; then
++  $as_echo "#define ENABLE_MULTIARCH 1" >>confdefs.h
++
++fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for multiarch configuration" >&5
+ $as_echo_n "checking for multiarch configuration... " >&6; }
+ 
+diff --git a/gcc/configure.ac b/gcc/configure.ac
+index 45bf7560e6f..eb92a37cd46 100644
+--- a/gcc/configure.ac
++++ b/gcc/configure.ac
+@@ -887,6 +887,9 @@ if test x${enable_multiarch} = xauto; then
+     enable_multiarch=no
+   fi
+ fi
++if test x${enable_multiarch} = xyes; then
++  AC_DEFINE(ENABLE_MULTIARCH, 1)
++fi
+ AC_MSG_CHECKING(for multiarch configuration)
+ AC_SUBST(enable_multiarch)
+ AC_MSG_RESULT($enable_multiarch$ma_msg_suffix)
+-- 
+2.37.1
+

--- a/app-devel/gcc+cross-mips64r6el/autobuild/patches/0004-MIPS-Not-trigger-error-for-pre-R6-and-mcompact-branc.patch.mips64r6el
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/patches/0004-MIPS-Not-trigger-error-for-pre-R6-and-mcompact-branc.patch.mips64r6el
@@ -1,0 +1,199 @@
+From 4479f1dc79fc4f1b5e0fed209df35f405bc94589 Mon Sep 17 00:00:00 2001
+From: YunQiang Su <yunqiang.su@cipunited.com>
+Date: Sat, 8 May 2021 05:45:53 -0400
+Subject: [PATCH] MIPS: Not trigger error for pre-R6 and
+ -mcompact-branches=always
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+For MIPSr6, we may wish to use compact-branches only.
+Currently, we have to use `always' option, while it is mark as conflict
+with pre-R6.
+  cc1: error: unsupported combination: ‘mips32r2’ -mcompact-branches=always
+Just ignore -mcompact-branches=always for pre-R6.
+
+This patch also defines
+    __mips_compact_branches_never
+    __mips_compact_branches_always
+    __mips_compact_branches_optimal
+predefined macros
+
+gcc/ChangeLog:
+	* config/mips/mips.cc (mips_option_override): not trigger error
+	for compact-branches=always for pre-R6.
+	* config/mips/mips.h (TARGET_RTP_PIC): not trigger error for
+	compact-branches=always for pre-R6.
+	(TARGET_CB_NEVER): Likewise.
+	(TARGET_CB_ALWAYS): Likewise.
+	(struct mips_cpu_info): define macros for compact branch policy.
+	* doc/invoke.texi: Document "always" with pre-R6.
+
+gcc/testsuite/ChangeLog:
+	* gcc.target/mips/compact-branches-1.c: add isa_rev>=6.
+	* gcc.target/mips/mips.exp: don't add -mipsXXr6 option for
+	-mcompact-branches=always. It is usable for pre-R6 now.
+	* gcc.target/mips/compact-branches-8.c: New test.
+	* gcc.target/mips/compact-branches-9.c: New test.
+---
+ gcc/config/mips/mips.cc                       |  8 +------
+ gcc/config/mips/mips.h                        | 22 ++++++++++++-------
+ gcc/doc/invoke.texi                           | 10 +++++----
+ .../gcc.target/mips/compact-branches-1.c      |  2 +-
+ .../gcc.target/mips/compact-branches-8.c      | 10 +++++++++
+ .../gcc.target/mips/compact-branches-9.c      | 10 +++++++++
+ gcc/testsuite/gcc.target/mips/mips.exp        |  4 +---
+ 7 files changed, 43 insertions(+), 23 deletions(-)
+ create mode 100644 gcc/testsuite/gcc.target/mips/compact-branches-8.c
+ create mode 100644 gcc/testsuite/gcc.target/mips/compact-branches-9.c
+
+diff --git a/gcc/config/mips/mips.cc b/gcc/config/mips/mips.cc
+index 387376b3df8..699ea6cc128 100644
+--- a/gcc/config/mips/mips.cc
++++ b/gcc/config/mips/mips.cc
+@@ -20277,13 +20277,7 @@ mips_option_override (void)
+       target_flags |= MASK_ODD_SPREG;
+     }
+ 
+-  if (!ISA_HAS_COMPACT_BRANCHES && mips_cb == MIPS_CB_ALWAYS)
+-    {
+-      error ("unsupported combination: %qs%s %s",
+-	      mips_arch_info->name, TARGET_MICROMIPS ? " -mmicromips" : "",
+-	      "-mcompact-branches=always");
+-    }
+-  else if (!ISA_HAS_DELAY_SLOTS && mips_cb == MIPS_CB_NEVER)
++  if (!ISA_HAS_DELAY_SLOTS && mips_cb == MIPS_CB_NEVER)
+     {
+       error ("unsupported combination: %qs%s %s",
+ 	      mips_arch_info->name, TARGET_MICROMIPS ? " -mmicromips" : "",
+diff --git a/gcc/config/mips/mips.h b/gcc/config/mips/mips.h
+index fe7f5b274b9..ed058b5db5f 100644
+--- a/gcc/config/mips/mips.h
++++ b/gcc/config/mips/mips.h
+@@ -120,11 +120,9 @@ struct mips_cpu_info {
+ #define TARGET_RTP_PIC (TARGET_VXWORKS_RTP && flag_pic)
+ 
+ /* Compact branches must not be used if the user either selects the
+-   'never' policy or the 'optimal' policy on a core that lacks
++   'never' policy or the 'optimal' / 'always' policy on a core that lacks
+    compact branch instructions.  */
+-#define TARGET_CB_NEVER (mips_cb == MIPS_CB_NEVER	\
+-			 || (mips_cb == MIPS_CB_OPTIMAL \
+-			     && !ISA_HAS_COMPACT_BRANCHES))
++#define TARGET_CB_NEVER (mips_cb == MIPS_CB_NEVER || !ISA_HAS_COMPACT_BRANCHES)
+ 
+ /* Compact branches may be used if the user either selects the
+    'always' policy or the 'optimal' policy on a core that supports
+@@ -134,10 +132,11 @@ struct mips_cpu_info {
+ 			     && ISA_HAS_COMPACT_BRANCHES))
+ 
+ /* Compact branches must always be generated if the user selects
+-   the 'always' policy or the 'optimal' policy om a core that
+-   lacks delay slot branch instructions.  */
+-#define TARGET_CB_ALWAYS (mips_cb == MIPS_CB_ALWAYS	\
+-			 || (mips_cb == MIPS_CB_OPTIMAL \
++   the 'always' policy on a core support compact branches,
++   or the 'optimal' policy on a core that lacks delay slot branch instructions.  */
++#define TARGET_CB_ALWAYS ((mips_cb == MIPS_CB_ALWAYS	  \
++			     && ISA_HAS_COMPACT_BRANCHES) \
++			 || (mips_cb == MIPS_CB_OPTIMAL   \
+ 			     && !ISA_HAS_DELAY_SLOTS))
+ 
+ /* Special handling for JRC that exists in microMIPSR3 as well as R6
+@@ -677,6 +676,13 @@ struct mips_cpu_info {
+ 	builtin_define ("__mips_no_lxc1_sxc1");				\
+       if (!ISA_HAS_UNFUSED_MADD4 && !ISA_HAS_FUSED_MADD4)		\
+ 	builtin_define ("__mips_no_madd4");				\
++									\
++      if (TARGET_CB_NEVER)						\
++	builtin_define ("__mips_compact_branches_never");		\
++      else if (TARGET_CB_ALWAYS)					\
++	builtin_define ("__mips_compact_branches_always");		\
++      else 								\
++	builtin_define ("__mips_compact_branches_optimal");		\
+     }									\
+   while (0)
+ 
+diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
+index d49c1374d06..64f77e8367a 100644
+--- a/gcc/doc/invoke.texi
++++ b/gcc/doc/invoke.texi
+@@ -27091,11 +27091,13 @@ The @option{-mcompact-branches=never} option ensures that compact branch
+ instructions will never be generated.
+ 
+ The @option{-mcompact-branches=always} option ensures that a compact
+-branch instruction will be generated if available.  If a compact branch
+-instruction is not available, a delay slot form of the branch will be
+-used instead.
++branch instruction will be generated if available for MIPS Release 6 onwards.
++If a compact branch instruction is not available (or pre-R6),
++a delay slot form of the branch will be used instead.
+ 
+-This option is supported from MIPS Release 6 onwards.
++If it is used for MIPS16/microMIPS targets, it will be just ignored now.
++The behaviour for MIPS16/microMIPS may change in future,
++since they do have some compact branch instructions.
+ 
+ The @option{-mcompact-branches=optimal} option will cause a delay slot
+ branch to be used if one is available in the current ISA and the delay
+diff --git a/gcc/testsuite/gcc.target/mips/compact-branches-1.c b/gcc/testsuite/gcc.target/mips/compact-branches-1.c
+index 9c7365e2659..6b8e1978d87 100644
+--- a/gcc/testsuite/gcc.target/mips/compact-branches-1.c
++++ b/gcc/testsuite/gcc.target/mips/compact-branches-1.c
+@@ -1,4 +1,4 @@
+-/* { dg-options "-mcompact-branches=always -mno-micromips" } */
++/* { dg-options "-mcompact-branches=always -mno-micromips isa_rev>=6" } */
+ int glob;
+ 
+ void
+diff --git a/gcc/testsuite/gcc.target/mips/compact-branches-8.c b/gcc/testsuite/gcc.target/mips/compact-branches-8.c
+new file mode 100644
+index 00000000000..1290cedf4b5
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/mips/compact-branches-8.c
+@@ -0,0 +1,10 @@
++/* { dg-options "-mno-abicalls -mcompact-branches=always isa_rev<=5" } */
++void bar (int);
++
++void
++foo ()
++{
++  bar (1);
++}
++
++/* { dg-final { scan-assembler "\t(j|jal)\t" } } */
+diff --git a/gcc/testsuite/gcc.target/mips/compact-branches-9.c b/gcc/testsuite/gcc.target/mips/compact-branches-9.c
+new file mode 100644
+index 00000000000..4b23bf456d1
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/mips/compact-branches-9.c
+@@ -0,0 +1,10 @@
++/* { dg-options "-mno-abicalls -fno-PIC -mcompact-branches=always isa_rev>=6" } */
++void bar (int);
++
++void
++foo ()
++{
++  bar (1);
++}
++
++/* { dg-final { scan-assembler "\t(bc|balc)\t" } } */
+diff --git a/gcc/testsuite/gcc.target/mips/mips.exp b/gcc/testsuite/gcc.target/mips/mips.exp
+index 42a0dbb6202..c89626a50fa 100644
+--- a/gcc/testsuite/gcc.target/mips/mips.exp
++++ b/gcc/testsuite/gcc.target/mips/mips.exp
+@@ -1167,10 +1167,8 @@ proc mips-dg-options { args } {
+ 	# We need a revision 6 or better ISA for:
+ 	#
+ 	#   - When the LSA instruction is required
+-	#   - When only using compact branches
+ 	if { $isa_rev < 6
+-	     && ([mips_have_test_option_p options "HAS_LSA"]
+-		 || [mips_have_test_option_p options "-mcompact-branches=always"]) } {
++	     && ([mips_have_test_option_p options "HAS_LSA"]) } {
+ 	    if { $gp_size == 32 } {
+ 		mips_make_test_option options "-mips32r6"
+ 	    } else {
+-- 
+2.37.1
+

--- a/app-devel/gcc+cross-mips64r6el/autobuild/patches/0005-MIPS-add-builtime-option-for-mcompact-branches.patch.mips64r6el
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/patches/0005-MIPS-add-builtime-option-for-mcompact-branches.patch.mips64r6el
@@ -1,0 +1,103 @@
+From 593632051f48a20bdc685d00d168f064d808bd7b Mon Sep 17 00:00:00 2001
+From: YunQiang Su <yunqiang.su@cipunited.com>
+Date: Sat, 8 May 2021 05:45:54 -0400
+Subject: [PATCH] MIPS: add builtime option for -mcompact-branches
+
+For R6+ target, it allows to configure gcc to use compact branches only
+if avaiable.
+
+gcc/ChangeLog:
+	* config.gcc: add -with-compact-branches=policy build option.
+	* doc/install.texi: Likewise.
+	* config/mips/mips.h: Likewise.
+---
+ gcc/config.gcc         | 13 +++++++++++--
+ gcc/config/mips/mips.h |  3 ++-
+ gcc/doc/install.texi   | 19 +++++++++++++++++++
+ 3 files changed, 32 insertions(+), 3 deletions(-)
+
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index 160c52c5429..52f9e988bf6 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -4675,7 +4675,7 @@ case "${target}" in
+ 		;;
+ 
+ 	mips*-*-*)
+-		supported_defaults="abi arch arch_32 arch_64 float fpu nan fp_32 odd_spreg_32 tune tune_32 tune_64 divide llsc mips-plt synci lxc1-sxc1 madd4"
++		supported_defaults="abi arch arch_32 arch_64 float fpu nan fp_32 odd_spreg_32 tune tune_32 tune_64 divide llsc mips-plt synci lxc1-sxc1 madd4 compact-branches"
+ 
+ 		case ${with_float} in
+ 		"" | soft | hard)
+@@ -4828,6 +4828,15 @@ case "${target}" in
+ 			exit 1
+ 			;;
+ 		esac
++
++		case ${with_compact_branches} in
++		"" | never | always | optimal)
++			;;
++		*)
++			echo "Unknown compact-branches policy used in --with-compact-branches" 1>&2
++			exit 1
++			;;
++		esac
+ 		;;
+ 
+ 	loongarch*-*-*)
+@@ -5772,7 +5781,7 @@ case ${target} in
+ esac
+ 
+ t=
+-all_defaults="abi cpu cpu_32 cpu_64 arch arch_32 arch_64 tune tune_32 tune_64 schedule float mode fpu nan fp_32 odd_spreg_32 divide llsc mips-plt synci tls lxc1-sxc1 madd4 isa_spec"
++all_defaults="abi cpu cpu_32 cpu_64 arch arch_32 arch_64 tune tune_32 tune_64 schedule float mode fpu nan fp_32 odd_spreg_32 divide llsc mips-plt synci tls lxc1-sxc1 madd4 isa_spec compact-branches"
+ for option in $all_defaults
+ do
+ 	eval "val=\$with_"`echo $option | sed s/-/_/g`
+diff --git a/gcc/config/mips/mips.h b/gcc/config/mips/mips.h
+index ed058b5db5f..69de74eb416 100644
+--- a/gcc/config/mips/mips.h
++++ b/gcc/config/mips/mips.h
+@@ -915,7 +915,8 @@ struct mips_cpu_info {
+   {"mips-plt", "%{!mplt:%{!mno-plt:-m%(VALUE)}}" }, \
+   {"synci", "%{!msynci:%{!mno-synci:-m%(VALUE)}}" },			\
+   {"lxc1-sxc1", "%{!mlxc1-sxc1:%{!mno-lxc1-sxc1:-m%(VALUE)}}" }, \
+-  {"madd4", "%{!mmadd4:%{!mno-madd4:-m%(VALUE)}}" } \
++  {"madd4", "%{!mmadd4:%{!mno-madd4:-m%(VALUE)}}" }, \
++  {"compact-branches", "%{!mcompact-branches=*:-mcompact-branches=%(VALUE)}" } \
+ 
+ /* A spec that infers the:
+    -mnan=2008 setting from a -mips argument,
+diff --git a/gcc/doc/install.texi b/gcc/doc/install.texi
+index 4931e0b4fc5..c1876f24a84 100644
+--- a/gcc/doc/install.texi
++++ b/gcc/doc/install.texi
+@@ -1543,6 +1543,25 @@ systems that support conditional traps).
+ Division by zero checks use the break instruction.
+ @end table
+ 
++@item --with-compact-branches=@var{policy}
++Specify how the compiler should generate branch instructions.
++This option is only supported on the MIPS target.
++The possibilities for @var{type} are:
++@table @code
++@item optimal
++Cause a delay slot branch to be used if one is available in the
++current ISA and the delay slot is successfully filled. If the delay slot
++is not filled, a compact branch will be chosen if one is available.
++@item never
++Ensures that compact branch instructions will never be generated.
++@item always
++Ensures that a compact branch instruction will be generated if available.
++If a compact branch instruction is not available,
++a delay slot form of the branch will be used instead.
++This option is supported from MIPS Release 6 onwards.
++For pre-R6/microMIPS/MIPS16, this option is just same as never/optimal.
++@end table
++
+ @c If you make --with-llsc the default for additional targets,
+ @c update the --with-llsc description in the MIPS section below.
+ 
+-- 
+2.37.1
+

--- a/app-devel/gcc+cross-mips64r6el/autobuild/prepare
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/prepare
@@ -1,5 +1,11 @@
-if [ ! -d /var/ab/cross-root/mips64r6el ]; then
-        abinfo "Extracting mips64r6el sysroot ..."
-	mkdir -pv /var/ab/cross-root/mips64r6el
-	tar xfpJ "$SRCDIR"/../sysroot.tar.xz -C /var/ab/cross-root/mips64r6el/ || true
+abinfo "Checking if ${__CROSS} minimal sysroot is already extracted to /var/ab/cross-root/${__CROSS}..."
+if [ ! -d /var/ab/cross-root/${__CROSS} ]; then
+        abinfo "Extracting ${__CROSS} minimal sysroot ..."
+	mkdir -pv /var/ab/cross-root/${__CROSS}
+	for package in aosc-aaa linux+api glibc ; do
+		abinfo "Extracting $package..."
+		dpkg-deb -vx $SRCDIR/../$package.deb /var/ab/cross-root/${__CROSS}/
+	done
+else
+	abinfo "${__CROSS} minimal sysroot does exist, skipping."
 fi

--- a/app-devel/gcc+cross-mips64r6el/autobuild/prepare
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/prepare
@@ -1,0 +1,5 @@
+if [ ! -d /var/ab/cross-root/mips64r6el ]; then
+        abinfo "Extracting mips64r6el sysroot ..."
+	mkdir -pv /var/ab/cross-root/mips64r6el
+	tar xfpJ "$SRCDIR"/../sysroot.tar.xz -C /var/ab/cross-root/mips64r6el/ || true
+fi

--- a/app-devel/gcc+cross-mips64r6el/spec
+++ b/app-devel/gcc+cross-mips64r6el/spec
@@ -1,0 +1,7 @@
+VER=12.2.0
+SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-$VER/gcc-$VER.tar.xz \
+      file::rename=sysroot.tar.xz::https://mirrors.bfsu.edu.cn/anthon/aosc-os/os-mips64r6el/buildkit/aosc-os_buildkit_20230308_mips64r6el.tar.xz"
+CHKSUMS="sha256::e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff \
+         sha256::ed845ca9799d2ccbd1ed471dfe16d5468415827a7d8fa1e7f55b644110f50e9d"
+CHKUPDATE="anitya::id=6502"
+SUBDIR="gcc-$VER"

--- a/app-devel/gcc+cross-mips64r6el/spec
+++ b/app-devel/gcc+cross-mips64r6el/spec
@@ -1,7 +1,24 @@
-VER=12.2.0
-SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-$VER/gcc-$VER.tar.xz \
-      file::rename=sysroot.tar.xz::https://mirrors.bfsu.edu.cn/anthon/aosc-os/os-mips64r6el/buildkit/aosc-os_buildkit_20230308_mips64r6el.tar.xz"
+# Building this package requires a minimal set of package to be installed:
+# Version of glibc
+# glibc for target architecture is required to build and for further usage.
+GLIBC_VER=2.36-4
+# Version of linux+api
+LINUXAPI_VER=6.1.13-0
+# Version of aosc-aaa
+AOSCAAA_VER=10.1.1-0
+# Version of gcc
+GCC_VER=12.2.0
+# Target architecture - this variable is used during build process
+__CROSS=mips64r6el
+
+VER=${GCC_VER}+glibc${GLIBC_VER}
+SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VER}/gcc-${GCC_VER}.tar.xz \
+      file::rename=glibc.deb::https://repo.aosc.io/debs/pool/stable/main/g/glibc_${GLIBC_VER}_${__CROSS}.deb \
+      file::rename=linux+api.deb::https://repo.aosc.io/debs/pool/stable/main/l/linux+api_${LINUXAPI_VER}_${__CROSS}.deb \
+      file::rename=aosc-aaa.deb::https://repo.aosc.io/debs/pool/stable/main/a/aosc-aaa_${AOSCAAA_VER}_${__CROSS}.deb"
 CHKSUMS="sha256::e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff \
-         sha256::ed845ca9799d2ccbd1ed471dfe16d5468415827a7d8fa1e7f55b644110f50e9d"
+         sha256::1f90ce6746ecfbaa9cbf21dd637d4421a0243dbe1d7ecd63340deca074e80c5e \
+         sha256::dfd4a00031a1a7f00f0d1f9c17f08549ca0cd57233d880516a125693a1beaa83 \
+         sha256::139dfef65207867ceb47ca05b74608f24d071f134ef7211be5307fd42f28130c"
 CHKUPDATE="anitya::id=6502"
-SUBDIR="gcc-$VER"
+SUBDIR="gcc-${GCC_VER}"


### PR DESCRIPTION
Topic Description
-----------------

This topic brings MIPS64 R6 cross build toolchain.

Package(s) Affected
-------------------

- `binutils+cross-mips64r6el`
- `gcc+cross-mips64r6el`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
