### PR TITLE
discord: update to 0.0.26

### DIFF
--- a/app-web/discord/autobuild/build
+++ b/app-web/discord/autobuild/build
@@ -33,10 +33,6 @@ ln -sfv /usr/lib/libEGL.so \
     "$PKGDIR"/usr/lib/discord/libEGL.so
 ln -sfv /usr/lib/libGLESv2.so \
     "$PKGDIR"/usr/lib/discord/libGLESv2.so
-ln -sfv /usr/lib/libEGL.so \
-    "$PKGDIR"/usr/lib/discord/swiftshader/libEGL.so
-ln -sfv /usr/lib/libGLESv2.so \
-    "$PKGDIR"/usr/lib/discord/swiftshader/libGLESv2.so
 
 abinfo "Setting executable bits on shared objects ..."
 chmod -v +x "$PKGDIR"/usr/lib/discord/*.so*

--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.25
+VER=0.0.26
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::581726cbd7f018fab756cd7eee520e47b3a25bf7749193482a9e10e4d458042c"
+CHKSUMS="sha256::30f74dc59241988378346128616bcbd9c98d9b7eff613dbbe66d9b5561d76f06"
 SUBDIR=.


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update `discord` to 0.0.26
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

discord
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

<!-- TODO: CI to auto-fill architectural progress. -->
