### PR TITLE
sddm: tmpfiles: disable auto cleanup for /var/lib/sddm

### DIFF
--- a/desktop-displaymanagers/sddm/autobuild/overrides/usr/lib/tmpfiles.d/sddm.conf
+++ b/desktop-displaymanagers/sddm/autobuild/overrides/usr/lib/tmpfiles.d/sddm.conf
@@ -1,2 +1,2 @@
 D /run/sddm 1733 root root -
-D /var/lib/sddm - sddm sddm - -
+d /var/lib/sddm - sddm sddm - -

--- a/desktop-displaymanagers/sddm/spec
+++ b/desktop-displaymanagers/sddm/spec
@@ -1,5 +1,5 @@
 VER=0.19.0
-REL=6
+REL=7
 SRCS="tbl::https://github.com/sddm/sddm/releases/download/v$VER/sddm-$VER.tar.xz"
 CHKSUMS="sha256::e254f14048c275c12a3084ec6330855bc6b20135659f88e63626af88b8f68d41"
 CHKUPDATE="anitya::id=4776"


### PR DESCRIPTION
Topic Description
-----------------

This makes SDDM being able to remember its settings, including last sessoion logged in.

Fixes #4478.

Package(s) Affected
-------------------

- sddm

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
