### PR TITLE
Crossbuild toolchain mips64r6el rework

### DIFF
--- a/app-devel/binutils+cross-mips64r6el/spec
+++ b/app-devel/binutils+cross-mips64r6el/spec
@@ -1,4 +1,7 @@
 VER=2.40
+REL=1
 SRCS="git::commit=b5624945ea67525c0ba4ffec7a9d3f9366bf9071::https://sourceware.org/git/binutils-gdb.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7981"
+
+__CROSS=mips64r6el

--- a/app-devel/gcc+cross-mips64r6el/spec
+++ b/app-devel/gcc+cross-mips64r6el/spec
@@ -12,6 +12,7 @@ GCC_VER=12.2.0
 __CROSS=mips64r6el
 
 VER=${GCC_VER}+glibc${GLIBC_VER}
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VER}/gcc-${GCC_VER}.tar.xz \
       file::rename=glibc.deb::https://repo.aosc.io/debs/pool/stable/main/g/glibc_${GLIBC_VER}_${__CROSS}.deb \
       file::rename=linux+api.deb::https://repo.aosc.io/debs/pool/stable/main/l/linux+api_${LINUXAPI_VER}_${__CROSS}.deb \
@@ -19,6 +20,6 @@ SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VER}/gcc-${GCC_VER}.tar.xz \
 CHKSUMS="sha256::e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff \
          sha256::1f90ce6746ecfbaa9cbf21dd637d4421a0243dbe1d7ecd63340deca074e80c5e \
          sha256::dfd4a00031a1a7f00f0d1f9c17f08549ca0cd57233d880516a125693a1beaa83 \
-         sha256::139dfef65207867ceb47ca05b74608f24d071f134ef7211be5307fd42f28130c"
+         sha256::04f2bda3561fb643dfc1614566f0fa4215b73342c6c8a02bab0d70cafc38d441"
 CHKUPDATE="anitya::id=6502"
 SUBDIR="gcc-${GCC_VER}"


### PR DESCRIPTION
Topic Description
-----------------

This topic is a rework of the previous mips64r6el cross toolchain.

Package(s) Affected
-------------------

- `binutils+cross-mips64r6el`
- `gcc+cross-mips64r6el`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`


**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
