### PR TITLE
gparted: update to 1.5.0

### DIFF
--- a/app-admin/gparted/autobuild/patch
+++ b/app-admin/gparted/autobuild/patch
@@ -1,1 +1,0 @@
-sed -i "s:@gksuprog@ @installdir@/gparted %f:@installdir@/gparted_polkit %f:g" gparted.desktop.in.in

--- a/app-admin/gparted/spec
+++ b/app-admin/gparted/spec
@@ -1,4 +1,4 @@
-VER=1.4.0
+VER=1.5.0
 SRCS="tbl::https://sourceforge.net/projects/gparted/files/gparted/gparted-$VER/gparted-$VER.tar.gz"
-CHKSUMS="sha256::e5293a792e53fdbeba29c4a834113cd9603d0d639330da931a468bf3687887be"
+CHKSUMS="sha256::3c95ea26a944083ff1d9b17639b1e2ad9758df225dc751ff407b2a6aa092a8de"
 CHKUPDATE="anitya::id=1235"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates GParted to 1.5.0.

Package(s) Affected
-------------------

`gparted` v1.5.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`