### PR TITLE
parted: fix an issue where partition maps could not be edited

### DIFF
--- a/app-admin/parted/autobuild/defines
+++ b/app-admin/parted/autobuild/defines
@@ -7,7 +7,7 @@ AUTOTOOLS_AFTER="--disable-mtrace \
                  --enable-device-mapper \
                  --disable-discover-only \
                  --enable-debug \
-                 --enable-read-only \
+                 --disable-read-only \
                  --enable-pc98 \
                  --enable-hfs-extract-fs \
                  --enable-largefile \

--- a/app-admin/parted/autobuild/patches/0001-Fedora-0001-maint-post-release-administrivia.patch
+++ b/app-admin/parted/autobuild/patches/0001-Fedora-0001-maint-post-release-administrivia.patch
@@ -1,7 +1,7 @@
 From cec533a00a2cd0b64a7a0f5debc26554f6025831 Mon Sep 17 00:00:00 2001
 From: "Brian C. Lane" <bcl@redhat.com>
 Date: Mon, 18 Apr 2022 15:10:06 -0400
-Subject: [PATCH 1/5] maint: post-release administrivia
+Subject: [PATCH 01/13] maint: post-release administrivia
 
 * NEWS: Add header line for next release.
 * .prev-version: Record previous version.
@@ -46,5 +46,5 @@ index d5fdd80..11fa51b 100644
  include $(srcdir)/dist-check.mk
  
 -- 
-2.35.3
+2.37.3
 

--- a/app-admin/parted/autobuild/patches/0002-Fedora-0002-parted-add-type-command.patch
+++ b/app-admin/parted/autobuild/patches/0002-Fedora-0002-parted-add-type-command.patch
@@ -1,7 +1,7 @@
 From 61b3a9733c0e0a79ccc43096642d378c8706add6 Mon Sep 17 00:00:00 2001
 From: Arvin Schnell <aschnell@suse.com>
 Date: Wed, 11 May 2022 14:02:21 +0000
-Subject: [PATCH 2/5] parted: add type command
+Subject: [PATCH 02/13] parted: add type command
 
 Include the partition type-id and type-uuid in the JSON
 output. Also add the the command 'type' to set them. Remove
@@ -1632,5 +1632,5 @@ index f2001c5..b35d443 100644
  
    for mode in on_only on_and_off ; do
 -- 
-2.35.3
+2.37.3
 

--- a/app-admin/parted/autobuild/patches/0003-Fedora-0003-libparted-add-swap-flag-for-DASD-label.patch
+++ b/app-admin/parted/autobuild/patches/0003-Fedora-0003-libparted-add-swap-flag-for-DASD-label.patch
@@ -1,7 +1,7 @@
 From 29ffc6a1f285f48ac0b9efa7299373e486c486e8 Mon Sep 17 00:00:00 2001
 From: Arvin Schnell <aschnell@suse.com>
 Date: Fri, 8 Oct 2021 10:06:24 +0000
-Subject: [PATCH 3/5] libparted: add swap flag for DASD label
+Subject: [PATCH 03/13] libparted: add swap flag for DASD label
 
 Support the swap flag and fix reading flags from disk. Also
 cleanup code by dropping the 2 flags "raid" and "lvm" from
@@ -224,5 +224,5 @@ index 0c00c4f..27baad0 100644
  		dasd_data->system = PARTITION_LINUX;
          PDEBUG;
 -- 
-2.35.3
+2.37.3
 

--- a/app-admin/parted/autobuild/patches/0004-Fedora-0004-parted-Reset-the-filesystem-type-when-changing-the-i.patch
+++ b/app-admin/parted/autobuild/patches/0004-Fedora-0004-parted-Reset-the-filesystem-type-when-changing-the-i.patch
@@ -1,7 +1,7 @@
 From 9b0a83a747b28bd1b778bdd32616e6f7ea88c84d Mon Sep 17 00:00:00 2001
 From: "Brian C. Lane" <bcl@redhat.com>
 Date: Fri, 13 May 2022 10:02:06 -0700
-Subject: [PATCH 4/5] parted: Reset the filesystem type when changing the
+Subject: [PATCH 04/13] parted: Reset the filesystem type when changing the
  id/uuid
 
 Without this the print command keeps showing the type selected with
@@ -26,5 +26,5 @@ index b8a4acf..96da30d 100644
                  goto error;
          return 1;
 -- 
-2.35.3
+2.37.3
 

--- a/app-admin/parted/autobuild/patches/0005-Fedora-0005-tests-t3200-type-change-now-passes.patch
+++ b/app-admin/parted/autobuild/patches/0005-Fedora-0005-tests-t3200-type-change-now-passes.patch
@@ -1,7 +1,7 @@
 From ac2a35c2214ef42352d0ddb4f7f4cb77d116e92e Mon Sep 17 00:00:00 2001
 From: "Brian C. Lane" <bcl@redhat.com>
 Date: Fri, 13 May 2022 10:15:41 -0700
-Subject: [PATCH 5/5] tests: t3200-type-change now passes
+Subject: [PATCH 05/13] tests: t3200-type-change now passes
 
 ---
  tests/Makefile.am | 3 ---
@@ -19,5 +19,5 @@ index 2da653b..1d109d7 100644
  SH_LOG_COMPILER = $(SHELL)
  
 -- 
-2.35.3
+2.37.3
 

--- a/app-admin/parted/autobuild/patches/0006-Fedora-0006-libparted-Fix-check-for-availability-of-_type_id-fun.patch
+++ b/app-admin/parted/autobuild/patches/0006-Fedora-0006-libparted-Fix-check-for-availability-of-_type_id-fun.patch
@@ -1,0 +1,40 @@
+From bafa84b25a265ef9eed3872790d52bf56ac42998 Mon Sep 17 00:00:00 2001
+From: Arvin Schnell <aschnell@suse.com>
+Date: Wed, 27 Jul 2022 09:36:54 +0000
+Subject: [PATCH 06/13] libparted: Fix check for availability of _type_id
+ functions
+
+Fix a copy/paste error. In practice this didn't cause any problems
+because the *_set_type_id and *_get_type_id are either both NULL or both
+set to the function.
+
+Signed-off-by: Brian C. Lane <bcl@redhat.com>
+---
+ libparted/disk.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libparted/disk.c b/libparted/disk.c
+index 22dff36..a961d65 100644
+--- a/libparted/disk.c
++++ b/libparted/disk.c
+@@ -1572,7 +1572,7 @@ ped_partition_get_type_id (const PedPartition *part)
+         if (!_assert_partition_type_id_feature (part->disk->type))
+                 return 0;
+ 
+-        PED_ASSERT (part->disk->type->ops->partition_set_type_id != NULL);
++        PED_ASSERT (part->disk->type->ops->partition_get_type_id != NULL);
+         return part->disk->type->ops->partition_get_type_id (part);
+ }
+ 
+@@ -1608,7 +1608,7 @@ ped_partition_get_type_uuid (const PedPartition *part)
+         if (!_assert_partition_type_uuid_feature (part->disk->type))
+                 return NULL;
+ 
+-        PED_ASSERT (part->disk->type->ops->partition_set_type_uuid != NULL);
++        PED_ASSERT (part->disk->type->ops->partition_get_type_uuid != NULL);
+         return part->disk->type->ops->partition_get_type_uuid (part);
+ }
+ 
+-- 
+2.37.3
+

--- a/app-admin/parted/autobuild/patches/0007-Fedora-0007-parted-Simplify-code-for-json-output.patch
+++ b/app-admin/parted/autobuild/patches/0007-Fedora-0007-parted-Simplify-code-for-json-output.patch
@@ -1,0 +1,34 @@
+From b16be5ffc8e700df2b6b2545c4b6794cea71b8e7 Mon Sep 17 00:00:00 2001
+From: Arvin Schnell <aschnell@suse.com>
+Date: Wed, 27 Jul 2022 13:36:08 +0000
+Subject: [PATCH 07/13] parted: Simplify code for json output
+
+_PedDiskOps::get_max_primary_partition_count is always available, the
+macro PT_op_function_initializers ensures it. So use
+ped_disk_get_max_primary_partition_count instead of
+_PedDiskOps::get_max_primary_partition_count directly.
+
+Signed-off-by: Brian C. Lane <bcl@redhat.com>
+---
+ parted/parted.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/parted/parted.c b/parted/parted.c
+index 96da30d..36c39c7 100644
+--- a/parted/parted.c
++++ b/parted/parted.c
+@@ -1215,9 +1215,8 @@ _print_disk_info (const PedDevice *dev, const PedDisk *diskp)
+             ul_jsonwrt_value_u64 (&json, "physical-sector-size", dev->phys_sector_size);
+             ul_jsonwrt_value_s (&json, "label", pt_name);
+             if (diskp) {
+-                if (diskp->type->ops->get_max_primary_partition_count)
+-                    ul_jsonwrt_value_u64 (&json, "max-partitions",
+-                                          diskp->type->ops->get_max_primary_partition_count(diskp));
++                ul_jsonwrt_value_u64 (&json, "max-partitions",
++                                      ped_disk_get_max_primary_partition_count(diskp));
+                 disk_print_flags_json (diskp);
+             }
+         } else {
+-- 
+2.37.3
+

--- a/app-admin/parted/autobuild/patches/0008-Fedora-0008-disk.in.h-Remove-use-of-enums-with-define.patch
+++ b/app-admin/parted/autobuild/patches/0008-Fedora-0008-disk.in.h-Remove-use-of-enums-with-define.patch
@@ -1,7 +1,7 @@
 From aa690ee275db86d1edb2468bcf31c3d7cf81228e Mon Sep 17 00:00:00 2001
 From: "Brian C. Lane" <bcl@redhat.com>
 Date: Thu, 4 Aug 2022 11:39:09 -0700
-Subject: [PATCH] disk.in.h: Remove use of enums with #define
+Subject: [PATCH 08/13] disk.in.h: Remove use of enums with #define
 
 The preprocessor doesn't evaluate the enum, so it ends up being 0, which
 causes problems for library users like pyparted which try to use the _LAST
@@ -55,5 +55,5 @@ index 672c4ee..715637d 100644
  struct _PedDisk;
  struct _PedPartition;
 -- 
-2.37.1
+2.37.3
 

--- a/app-admin/parted/autobuild/patches/0009-Fedora-0009-libparted-Fix-handling-of-gpt-partition-types.patch
+++ b/app-admin/parted/autobuild/patches/0009-Fedora-0009-libparted-Fix-handling-of-gpt-partition-types.patch
@@ -1,7 +1,7 @@
-From 717d39a0a16b6fddfac65cf355a895d04995cdff Mon Sep 17 00:00:00 2001
+From 8957382b98fd79bc06dad132ef28a0be8b46ea16 Mon Sep 17 00:00:00 2001
 From: "Brian C. Lane" <bcl@redhat.com>
 Date: Mon, 8 Aug 2022 12:04:32 -0700
-Subject: [PATCH 07/10] libparted: Fix handling of gpt partition types
+Subject: [PATCH 09/13] libparted: Fix handling of gpt partition types
 
 This restores the previous behavior by testing the GUID against the list
 of known types and skipping the filesystem GUID reset. Now the sequence
@@ -97,5 +97,5 @@ index 0e9e060..8e6a37d 100644
    }
  
 -- 
-2.37.1
+2.37.3
 

--- a/app-admin/parted/autobuild/patches/0010-Fedora-0010-tests-Add-a-libparted-test-for-ped_partition_set_sys.patch
+++ b/app-admin/parted/autobuild/patches/0010-Fedora-0010-tests-Add-a-libparted-test-for-ped_partition_set_sys.patch
@@ -1,7 +1,7 @@
-From 14cf5be3d322d7e3e81c21a3542ae046a5fe1fda Mon Sep 17 00:00:00 2001
+From d50b7bf2b66b7b67ee332c1af63bc1f5fdfba7ad Mon Sep 17 00:00:00 2001
 From: "Brian C. Lane" <bcl@redhat.com>
 Date: Mon, 8 Aug 2022 13:49:09 -0700
-Subject: [PATCH 08/10] tests: Add a libparted test for
+Subject: [PATCH 10/13] tests: Add a libparted test for
  ped_partition_set_system on gpt
 
 Test the libparted API to make sure the flag is not cleared by calling
@@ -156,5 +156,5 @@ index 0000000..60a6248
 +
 +Exit $fail
 -- 
-2.37.1
+2.37.3
 

--- a/app-admin/parted/autobuild/patches/0011-Fedora-0011-libparted-Fix-handling-of-msdos-partition-types.patch
+++ b/app-admin/parted/autobuild/patches/0011-Fedora-0011-libparted-Fix-handling-of-msdos-partition-types.patch
@@ -1,7 +1,7 @@
-From 9be9067bc5a3641fc890b0d4ba994000941109bf Mon Sep 17 00:00:00 2001
+From 4a0e468ed63fff85a1f9b923189f20945b32f4f1 Mon Sep 17 00:00:00 2001
 From: "Brian C. Lane" <bcl@redhat.com>
 Date: Mon, 8 Aug 2022 15:02:30 -0700
-Subject: [PATCH 09/10] libparted: Fix handling of msdos partition types
+Subject: [PATCH 11/13] libparted: Fix handling of msdos partition types
 
 This restores the previous behavior by testing the partition type
 against the list of known types and skipping the filesystem type reset.
@@ -105,5 +105,5 @@ index bd7465d..4359276 100644
  
  	switch (flag) {
 -- 
-2.37.1
+2.37.3
 

--- a/app-admin/parted/autobuild/patches/0012-Fedora-0012-tests-Add-a-libparted-test-for-ped_partition_set_sys.patch
+++ b/app-admin/parted/autobuild/patches/0012-Fedora-0012-tests-Add-a-libparted-test-for-ped_partition_set_sys.patch
@@ -1,7 +1,7 @@
-From 7830678dbe832ea6815d9a31be8cbe3a67f3ed7e Mon Sep 17 00:00:00 2001
+From 8f37b28825933af9bbbac7f00cc7e23f916c7018 Mon Sep 17 00:00:00 2001
 From: "Brian C. Lane" <bcl@redhat.com>
 Date: Mon, 8 Aug 2022 15:06:03 -0700
-Subject: [PATCH 10/10] tests: Add a libparted test for
+Subject: [PATCH 12/13] tests: Add a libparted test for
  ped_partition_set_system on msdos
 
 Test the libparted API to make sure the flag is not cleared by calling
@@ -71,5 +71,5 @@ index c83a361..c4b290b 100644
          srunner_run_all (srunner, CK_VERBOSE);
  
 -- 
-2.37.1
+2.37.3
 

--- a/app-admin/parted/autobuild/patches/0013-Fedora-0013-show-GPT-UUIDs-in-JSON-output.patch
+++ b/app-admin/parted/autobuild/patches/0013-Fedora-0013-show-GPT-UUIDs-in-JSON-output.patch
@@ -1,0 +1,351 @@
+From 2194035fc0fe678472d279676a13511769f7ef20 Mon Sep 17 00:00:00 2001
+From: Arvin Schnell <aschnell@suse.com>
+Date: Thu, 28 Jul 2022 09:20:09 +0000
+Subject: [PATCH 13/13] show GPT UUIDs in JSON output
+
+Include GPT UUIDs in JSON output.
+---
+ include/parted/disk.in.h | 13 ++++++--
+ libparted/disk.c         | 64 ++++++++++++++++++++++++++++++++++++++++
+ libparted/labels/gpt.c   | 40 ++++++++++++++++++++++++-
+ parted/parted.c          | 18 +++++++++++
+ tests/t0800-json-gpt.sh  |  7 +++--
+ tests/t0900-type-gpt.sh  |  8 +++--
+ 6 files changed, 142 insertions(+), 8 deletions(-)
+
+diff --git a/include/parted/disk.in.h b/include/parted/disk.in.h
+index 715637d..f649bcc 100644
+--- a/include/parted/disk.in.h
++++ b/include/parted/disk.in.h
+@@ -98,10 +98,12 @@ enum _PedDiskTypeFeature {
+         PED_DISK_TYPE_PARTITION_NAME=2,       /**< supports partition names */
+         PED_DISK_TYPE_PARTITION_TYPE_ID=4,    /**< supports partition type-ids */
+         PED_DISK_TYPE_PARTITION_TYPE_UUID=8,  /**< supports partition type-uuids */
++        PED_DISK_TYPE_DISK_UUID=16,           /**< supports disk uuids */
++        PED_DISK_TYPE_PARTITION_UUID=32,      /**< supports partition uuids */
+ };
+ // NOTE: DO NOT define using enums
+-#define PED_DISK_TYPE_FIRST_FEATURE    1 // PED_DISK_TYPE_EXTENDED
+-#define PED_DISK_TYPE_LAST_FEATURE     8 // PED_DISK_TYPE_PARTITION_TYPE_UUID
++#define PED_DISK_TYPE_FIRST_FEATURE    1  // PED_DISK_TYPE_EXTENDED
++#define PED_DISK_TYPE_LAST_FEATURE     32 // PED_DISK_TYPE_PARTITION_UUID
+ 
+ struct _PedDisk;
+ struct _PedPartition;
+@@ -228,6 +230,7 @@ struct _PedDiskOps {
+         int (*disk_is_flag_available) (
+                 const PedDisk *disk,
+                 PedDiskFlag flag);
++        uint8_t* (*disk_get_uuid) (const PedDisk* disk);
+         /** \todo add label guessing op here */
+ 
+         /* partition operations */
+@@ -260,6 +263,8 @@ struct _PedDiskOps {
+         int (*partition_set_type_uuid) (PedPartition* part, const uint8_t* uuid);
+         uint8_t* (*partition_get_type_uuid) (const PedPartition* part);
+ 
++        uint8_t* (*partition_get_uuid) (const PedPartition* part);
++
+         int (*partition_align) (PedPartition* part,
+                                 const PedConstraint* constraint);
+         int (*partition_enumerate) (PedPartition* part);
+@@ -331,6 +336,8 @@ extern int ped_disk_set_flag(PedDisk *disk, PedDiskFlag flag, int state);
+ extern int ped_disk_get_flag(const PedDisk *disk, PedDiskFlag flag);
+ extern int ped_disk_is_flag_available(const PedDisk *disk, PedDiskFlag flag);
+ 
++extern uint8_t* ped_disk_get_uuid (const PedDisk* disk);
++
+ extern const char *ped_disk_flag_get_name(PedDiskFlag flag);
+ extern PedDiskFlag ped_disk_flag_get_by_name(const char *name);
+ extern PedDiskFlag ped_disk_flag_next(PedDiskFlag flag) _GL_ATTRIBUTE_CONST;
+@@ -367,6 +374,8 @@ extern uint8_t ped_partition_get_type_id (const PedPartition* part);
+ extern int ped_partition_set_type_uuid (PedPartition* part, const uint8_t* uuid);
+ extern uint8_t* ped_partition_get_type_uuid (const PedPartition* part);
+ 
++extern uint8_t* ped_partition_get_uuid (const PedPartition* part);
++
+ extern int ped_partition_is_busy (const PedPartition* part);
+ extern char* ped_partition_get_path (const PedPartition* part);
+ 
+diff --git a/libparted/disk.c b/libparted/disk.c
+index a961d65..0ed3d91 100644
+--- a/libparted/disk.c
++++ b/libparted/disk.c
+@@ -886,6 +886,37 @@ ped_disk_flag_next(PedDiskFlag flag)
+         return (flag + 1) % (PED_DISK_LAST_FLAG + 1);
+ }
+ 
++static int
++_assert_disk_uuid_feature (const PedDiskType* disk_type)
++{
++        if (!ped_disk_type_check_feature (
++                        disk_type, PED_DISK_TYPE_DISK_UUID)) {
++                ped_exception_throw (
++                        PED_EXCEPTION_ERROR,
++                        PED_EXCEPTION_CANCEL,
++                        "%s disk labels do not support disk uuids.",
++                        disk_type->name);
++                return 0;
++        }
++        return 1;
++}
++
++/**
++ * Get the uuid of the disk \p disk. This will only work if the disk label
++ * supports it.
++ */
++uint8_t*
++ped_disk_get_uuid (const PedDisk *disk)
++{
++        PED_ASSERT (disk != NULL);
++
++        if (!_assert_disk_uuid_feature (disk->type))
++                return NULL;
++
++        PED_ASSERT (disk->type->ops->disk_get_uuid != NULL);
++        return disk->type->ops->disk_get_uuid (disk);
++}
++
+ /**
+  * \internal We turned a really nasty bureaucracy problem into an elegant maths
+  * problem :-)  Basically, there are some constraints to a partition's
+@@ -1488,6 +1519,21 @@ _assert_partition_type_uuid_feature (const PedDiskType* disk_type)
+         return 1;
+ }
+ 
++static int
++_assert_partition_uuid_feature (const PedDiskType* disk_type)
++{
++        if (!ped_disk_type_check_feature (
++                        disk_type, PED_DISK_TYPE_PARTITION_UUID)) {
++                ped_exception_throw (
++                        PED_EXCEPTION_ERROR,
++                        PED_EXCEPTION_CANCEL,
++                        "%s disk labels do not support partition uuids.",
++                        disk_type->name);
++                return 0;
++        }
++        return 1;
++}
++
+ /**
+  * Sets the name of a partition.
+  *
+@@ -1612,6 +1658,24 @@ ped_partition_get_type_uuid (const PedPartition *part)
+         return part->disk->type->ops->partition_get_type_uuid (part);
+ }
+ 
++/**
++ * Get the uuid of the partition \p part. This will only work if the disk label
++ * supports it.
++ */
++uint8_t*
++ped_partition_get_uuid (const PedPartition *part)
++{
++        PED_ASSERT (part != NULL);
++        PED_ASSERT (part->disk != NULL);
++        PED_ASSERT (ped_partition_is_active (part));
++
++        if (!_assert_partition_uuid_feature (part->disk->type))
++                return NULL;
++
++        PED_ASSERT (part->disk->type->ops->partition_get_uuid != NULL);
++        return part->disk->type->ops->partition_get_uuid (part);
++}
++
+ /** @} */
+ 
+ /**
+diff --git a/libparted/labels/gpt.c b/libparted/labels/gpt.c
+index 8e6a37d..1993863 100644
+--- a/libparted/labels/gpt.c
++++ b/libparted/labels/gpt.c
+@@ -1576,6 +1576,24 @@ gpt_disk_is_flag_available(const PedDisk *disk, PedDiskFlag flag)
+     }
+ }
+ 
++static uint8_t*
++gpt_disk_get_uuid (const PedDisk *disk)
++{
++  GPTDiskData *gpt_disk_data = disk->disk_specific;
++
++  efi_guid_t uuid = gpt_disk_data->uuid;
++
++  /* uuid is always LE, while uint8_t is always kind of BE */
++
++  uuid.time_low = PED_SWAP32(uuid.time_low);
++  uuid.time_mid = PED_SWAP16(uuid.time_mid);
++  uuid.time_hi_and_version = PED_SWAP16(uuid.time_hi_and_version);
++
++  uint8_t *buf = ped_malloc(sizeof (uuid_t));
++  memcpy(buf, &uuid, sizeof (uuid_t));
++  return buf;
++}
++
+ static int
+ gpt_disk_get_flag (const PedDisk *disk, PedDiskFlag flag)
+ {
+@@ -1764,6 +1782,23 @@ gpt_partition_get_type_uuid (const PedPartition *part)
+   return buf;
+ }
+ 
++static uint8_t*
++gpt_partition_get_uuid (const PedPartition *part)
++{
++  const GPTPartitionData *gpt_part_data = part->disk_specific;
++
++  efi_guid_t uuid = gpt_part_data->uuid;
++
++  /* uuid is always LE, while uint8_t is always kind of BE */
++
++  uuid.time_low = PED_SWAP32(uuid.time_low);
++  uuid.time_mid = PED_SWAP16(uuid.time_mid);
++  uuid.time_hi_and_version = PED_SWAP16(uuid.time_hi_and_version);
++
++  uint8_t *buf = ped_malloc(sizeof (uuid_t));
++  memcpy(buf, &uuid, sizeof (uuid_t));
++  return buf;
++}
+ 
+ static int
+ gpt_get_max_primary_partition_count (const PedDisk *disk)
+@@ -1864,9 +1899,11 @@ static PedDiskOps gpt_disk_ops =
+   partition_get_type_id:	NULL,
+   partition_set_type_uuid:	gpt_partition_set_type_uuid,
+   partition_get_type_uuid:	gpt_partition_get_type_uuid,
++  partition_get_uuid:		gpt_partition_get_uuid,
+   disk_set_flag:		gpt_disk_set_flag,
+   disk_get_flag:		gpt_disk_get_flag,
+   disk_is_flag_available:	gpt_disk_is_flag_available,
++  disk_get_uuid:		gpt_disk_get_uuid,
+ 
+   PT_op_function_initializers (gpt)
+ };
+@@ -1876,7 +1913,8 @@ static PedDiskType gpt_disk_type =
+   next:		NULL,
+   name:		"gpt",
+   ops:		&gpt_disk_ops,
+-  features:	PED_DISK_TYPE_PARTITION_NAME | PED_DISK_TYPE_PARTITION_TYPE_UUID
++  features:	PED_DISK_TYPE_PARTITION_NAME | PED_DISK_TYPE_PARTITION_TYPE_UUID |
++		PED_DISK_TYPE_DISK_UUID | PED_DISK_TYPE_PARTITION_UUID
+ };
+ 
+ void
+diff --git a/parted/parted.c b/parted/parted.c
+index 36c39c7..84187b7 100644
+--- a/parted/parted.c
++++ b/parted/parted.c
+@@ -1215,6 +1215,14 @@ _print_disk_info (const PedDevice *dev, const PedDisk *diskp)
+             ul_jsonwrt_value_u64 (&json, "physical-sector-size", dev->phys_sector_size);
+             ul_jsonwrt_value_s (&json, "label", pt_name);
+             if (diskp) {
++                bool has_disk_uuid = ped_disk_type_check_feature (diskp->type, PED_DISK_TYPE_DISK_UUID);
++                if (has_disk_uuid) {
++                    uint8_t* uuid = ped_disk_get_uuid (diskp);
++                    static char buf[UUID_STR_LEN];
++                    uuid_unparse_lower (uuid, buf);
++                    ul_jsonwrt_value_s (&json, "uuid", buf);
++                    free (uuid);
++                }
+                 ul_jsonwrt_value_u64 (&json, "max-partitions",
+                                       ped_disk_get_max_primary_partition_count(diskp));
+                 disk_print_flags_json (diskp);
+@@ -1360,6 +1368,8 @@ do_print (PedDevice** dev, PedDisk** diskp)
+ 							PED_DISK_TYPE_PARTITION_TYPE_ID);
+         bool has_type_uuid = ped_disk_type_check_feature ((*diskp)->type,
+ 							  PED_DISK_TYPE_PARTITION_TYPE_UUID);
++        bool has_part_uuid = ped_disk_type_check_feature ((*diskp)->type,
++							  PED_DISK_TYPE_PARTITION_UUID);
+ 
+         PedPartition* part;
+         if (opt_output_mode == HUMAN) {
+@@ -1512,6 +1522,14 @@ do_print (PedDevice** dev, PedDisk** diskp)
+                         free (type_uuid);
+                     }
+ 
++                    if (has_part_uuid) {
++                        uint8_t* uuid = ped_partition_get_uuid (part);
++                        static char buf[UUID_STR_LEN];
++                        uuid_unparse_lower (uuid, buf);
++                        ul_jsonwrt_value_s (&json, "uuid", buf);
++                        free (uuid);
++                    }
++
+                     if (has_name) {
+                         name = ped_partition_get_name (part);
+                         if (strcmp (name, "") != 0)
+diff --git a/tests/t0800-json-gpt.sh b/tests/t0800-json-gpt.sh
+index 354c0bd..f6a3fb9 100755
+--- a/tests/t0800-json-gpt.sh
++++ b/tests/t0800-json-gpt.sh
+@@ -32,8 +32,8 @@ parted --script "$dev" mkpart "test1" ext4 10% 20% > out 2>&1 || fail=1
+ parted --script "$dev" mkpart "test2" xfs 20% 60% > out 2>&1 || fail=1
+ parted --script "$dev" set 2 raid on > out 2>&1 || fail=1
+ 
+-# print with json format
+-parted --script --json "$dev" unit s print free > out 2>&1 || fail=1
++# print with json format, replace non-deterministic uuids
++parted --script --json "$dev" unit s print free | sed -E 's/"uuid": "[0-9a-f-]{36}"/"uuid": "<uuid>"/' > out 2>&1 || fail=1
+ 
+ cat <<EOF > exp || fail=1
+ {
+@@ -45,6 +45,7 @@ cat <<EOF > exp || fail=1
+       "logical-sector-size": 512,
+       "physical-sector-size": 512,
+       "label": "gpt",
++      "uuid": "<uuid>",
+       "max-partitions": 128,
+       "flags": [
+           "pmbr_boot"
+@@ -63,6 +64,7 @@ cat <<EOF > exp || fail=1
+             "size": "10240s",
+             "type": "primary",
+             "type-uuid": "0fc63daf-8483-4772-8e79-3d69d8477de4",
++            "uuid": "<uuid>",
+             "name": "test1"
+          },{
+             "number": 2,
+@@ -71,6 +73,7 @@ cat <<EOF > exp || fail=1
+             "size": "40960s",
+             "type": "primary",
+             "type-uuid": "a19d880f-05fc-4d3b-a006-743f0f84911e",
++            "uuid": "<uuid>",
+             "name": "test2",
+             "flags": [
+                 "raid"
+diff --git a/tests/t0900-type-gpt.sh b/tests/t0900-type-gpt.sh
+index 2014820..03febba 100755
+--- a/tests/t0900-type-gpt.sh
++++ b/tests/t0900-type-gpt.sh
+@@ -32,8 +32,8 @@ parted --script "$dev" mkpart "''" "linux-swap" 10% 20% > out 2>&1 || fail=1
+ # set type-uuid
+ parted --script "$dev" type 1 "deadfd6d-a4ab-43c4-84e5-0933c84b4f4f" || fail=1
+ 
+-# print with json format
+-parted --script --json "$dev" unit s print > out 2>&1 || fail=1
++# print with json format, replace non-deterministic uuids
++parted --script --json "$dev" unit s print | sed -E 's/"uuid": "[0-9a-f-]{36}"/"uuid": "<uuid>"/' > out 2>&1 || fail=1
+ 
+ cat <<EOF > exp || fail=1
+ {
+@@ -45,6 +45,7 @@ cat <<EOF > exp || fail=1
+       "logical-sector-size": 512,
+       "physical-sector-size": 512,
+       "label": "gpt",
++      "uuid": "<uuid>",
+       "max-partitions": 128,
+       "partitions": [
+          {
+@@ -53,7 +54,8 @@ cat <<EOF > exp || fail=1
+             "end": "20479s",
+             "size": "10240s",
+             "type": "primary",
+-            "type-uuid": "deadfd6d-a4ab-43c4-84e5-0933c84b4f4f"
++            "type-uuid": "deadfd6d-a4ab-43c4-84e5-0933c84b4f4f",
++            "uuid": "<uuid>"
+          }
+       ]
+    }
+-- 
+2.37.3
+

--- a/app-admin/parted/autobuild/patches/0014-Fedora-0014-gpt-Add-no_automount-partition-flag.patch
+++ b/app-admin/parted/autobuild/patches/0014-Fedora-0014-gpt-Add-no_automount-partition-flag.patch
@@ -1,0 +1,145 @@
+From 55e4775c989af42d629401b9aa22c60ba2993e7d Mon Sep 17 00:00:00 2001
+From: Mike Fleetwood <mike.fleetwood@googlemail.com>
+Date: Tue, 13 Dec 2022 12:53:07 +0000
+Subject: [PATCH] gpt: Add no_automount partition flag
+
+Add user requested support for GPT partition type attribute bit 63 [1]
+so the no-auto flag in the systemd originated Discoverable Partitions
+Specification [2] can be manipulated.  The UEFI specification [3] says
+partition attribute bits 48 to 63 are partition type specific, however
+the DPS [2] and Microsoft [4] use the bit 63 to mean no automounting /
+assign no drive letter and apply it to multiple partition types so don't
+restrict its application.
+
+[1] Request for GPT partition attribute bit 63 "no automount" editing
+    support
+    https://gitlab.gnome.org/GNOME/gparted/-/issues/214
+[2] The Discoverable Partitions Specification (DPS),
+    Partition Attribute Flags
+    https://uapi-group.org/specifications/specs/discoverable_partitions_specification/
+[3] UEFI Specification, version 2.8,
+    Table 24. Defined GPT Partition Entry - Attributes
+    https://uefi.org/sites/default/files/resources/UEFI_Spec_2_8_final.pdf
+[4] CREATE_PARTITION_PARAMETERS structure (vds.h)
+    https://learn.microsoft.com/en-gb/windows/win32/api/vds/ns-vds-create_partition_parameters
+
+Signed-off-by: Mike Fleetwood <mike.fleetwood@googlemail.com>
+Signed-off-by: Brian C. Lane <bcl@redhat.com>
+---
+ NEWS                     |  2 ++
+ doc/C/parted.8           |  2 +-
+ include/parted/disk.in.h |  3 ++-
+ libparted/disk.c         |  2 ++
+ libparted/labels/gpt.c   | 12 ++++++++++--
+ 5 files changed, 17 insertions(+), 4 deletions(-)
+
+diff --git a/NEWS b/NEWS
+index 099f8bd..ac759fe 100644
+--- a/NEWS
++++ b/NEWS
+@@ -4,6 +4,8 @@ GNU parted NEWS                                    -*- outline -*-
+ 
+ ** New Features
+ 
++  Support GPT partition attribute bit 63 as no_automount flag.
++
+   Add type commands to set type-id on MS-DOS and type-uuid on GPT.
+ 
+ * Noteworthy changes in release 3.5 (2022-04-18) [stable]
+diff --git a/doc/C/parted.8 b/doc/C/parted.8
+index ab34be7..3069c33 100644
+--- a/doc/C/parted.8
++++ b/doc/C/parted.8
+@@ -120,7 +120,7 @@ or an LVM logical volume if necessary.
+ Change the state of the \fIflag\fP on \fIpartition\fP to \fIstate\fP.
+ Supported flags are: "boot", "root", "swap", "hidden", "raid", "lvm", "lba",
+ "legacy_boot", "irst", "msftres", "esp", "chromeos_kernel", "bls_boot", "linux-home",
+-"bios_grub", and "palo".
++"no_automount", "bios_grub", and "palo".
+ \fIstate\fP should be either "on" or "off".
+ .TP
+ .B unit \fIunit\fP
+diff --git a/include/parted/disk.in.h b/include/parted/disk.in.h
+index f649bcc..402d78a 100644
+--- a/include/parted/disk.in.h
++++ b/include/parted/disk.in.h
+@@ -88,10 +88,11 @@ enum _PedPartitionFlag {
+         PED_PARTITION_CHROMEOS_KERNEL=19,
+         PED_PARTITION_BLS_BOOT=20,
+         PED_PARTITION_LINUX_HOME=21,
++        PED_PARTITION_NO_AUTOMOUNT=22,
+ };
+ // NOTE: DO NOT define using enums
+ #define PED_PARTITION_FIRST_FLAG        1  // PED_PARTITION_BOOT
+-#define PED_PARTITION_LAST_FLAG         21 // PED_PARTITION_LINUX_HOME
++#define PED_PARTITION_LAST_FLAG         22 // PED_PARTITION_NO_AUTOMOUNT
+ 
+ enum _PedDiskTypeFeature {
+         PED_DISK_TYPE_EXTENDED=1,             /**< supports extended partitions */
+diff --git a/libparted/disk.c b/libparted/disk.c
+index 0ed3d91..45f35fd 100644
+--- a/libparted/disk.c
++++ b/libparted/disk.c
+@@ -2579,6 +2579,8 @@ ped_partition_flag_get_name (PedPartitionFlag flag)
+ 		return N_("bls_boot");
+         case PED_PARTITION_LINUX_HOME:
+                 return N_("linux-home");
++        case PED_PARTITION_NO_AUTOMOUNT:
++                return N_("no_automount");
+ 
+ 	default:
+ 		ped_exception_throw (
+diff --git a/libparted/labels/gpt.c b/libparted/labels/gpt.c
+index 1993863..780fb70 100644
+--- a/libparted/labels/gpt.c
++++ b/libparted/labels/gpt.c
+@@ -252,7 +252,8 @@ struct __attribute__ ((packed)) _GuidPartitionEntryAttributes_t
+   uint64_t NoBlockIOProtocol:1;
+   uint64_t LegacyBIOSBootable:1;
+   uint64_t Reserved:45;
+-  uint64_t GuidSpecific:16;
++  uint64_t GuidSpecific:15;
++  uint64_t NoAutomount:1;
+ #else
+ #       warning "Using crippled partition entry type"
+   uint32_t RequiredToFunction:1;
+@@ -260,7 +261,8 @@ struct __attribute__ ((packed)) _GuidPartitionEntryAttributes_t
+   uint32_t LegacyBIOSBootable:1;
+   uint32_t Reserved:30;
+   uint32_t LOST:5;
+-  uint32_t GuidSpecific:16;
++  uint32_t GuidSpecific:15;
++  uint32_t NoAutomount:1;
+ #endif
+ };
+ 
+@@ -1637,6 +1639,9 @@ gpt_partition_set_flag (PedPartition *part, PedPartitionFlag flag, int state)
+     case PED_PARTITION_LEGACY_BOOT:
+       gpt_part_data->attributes.LegacyBIOSBootable = state;
+       return 1;
++    case PED_PARTITION_NO_AUTOMOUNT:
++      gpt_part_data->attributes.NoAutomount = state;
++      return 1;
+     case PED_PARTITION_ROOT:
+     case PED_PARTITION_LBA:
+     default:
+@@ -1662,6 +1667,8 @@ gpt_partition_get_flag (const PedPartition *part, PedPartitionFlag flag)
+       return gpt_part_data->attributes.RequiredToFunction;
+     case PED_PARTITION_LEGACY_BOOT:
+       return gpt_part_data->attributes.LegacyBIOSBootable;
++    case PED_PARTITION_NO_AUTOMOUNT:
++      return gpt_part_data->attributes.NoAutomount;
+     case PED_PARTITION_LBA:
+     case PED_PARTITION_ROOT:
+     default:
+@@ -1681,6 +1688,7 @@ gpt_partition_is_flag_available (const PedPartition *part,
+     {
+     case PED_PARTITION_HIDDEN:
+     case PED_PARTITION_LEGACY_BOOT:
++    case PED_PARTITION_NO_AUTOMOUNT:
+       return 1;
+     case PED_PARTITION_ROOT:
+     case PED_PARTITION_LBA:
+-- 
+2.38.1
+

--- a/app-admin/parted/autobuild/patches/0015-Fedora-0015-tests-XFS-requires-a-minimum-size-of-300M.patch
+++ b/app-admin/parted/autobuild/patches/0015-Fedora-0015-tests-XFS-requires-a-minimum-size-of-300M.patch
@@ -1,0 +1,54 @@
+From caa588269709659d5cf51bf64c559e193f371de4 Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Tue, 13 Dec 2022 14:38:24 -0800
+Subject: [PATCH] tests: XFS requires a minimum size of 300M
+
+---
+ tests/t1700-probe-fs.sh               | 3 ++-
+ tests/t4100-dvh-partition-limits.sh   | 2 +-
+ tests/t4100-msdos-partition-limits.sh | 2 +-
+ 3 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/tests/t1700-probe-fs.sh b/tests/t1700-probe-fs.sh
+index d33606e..f8af74e 100755
+--- a/tests/t1700-probe-fs.sh
++++ b/tests/t1700-probe-fs.sh
+@@ -42,7 +42,8 @@ for type in ext2 ext3 ext4 btrfs xfs nilfs2 ntfs vfat hfsplus udf f2fs; do
+   # create an $type file system, creation failures are not parted bugs,
+   # skip the filesystem instead of failing the test.
+   if [ "$type" = "xfs" ]; then
+-      mkfs.xfs -ssize=$ss -dfile,name=$dev,size=${n_sectors}s || { warn_ "$ME: mkfs.$type failed, skipping"; continue; }
++      # XFS requires at least 300M which is > 1024 sectors with 8192b sector size
++      mkfs.xfs -ssize=$ss -dfile,name=$dev,size=300m || { warn_ "$ME: mkfs.$type failed, skipping"; continue; }
+   else
+       dd if=/dev/null of=$dev bs=$ss seek=$n_sectors >/dev/null || { warn_ "$ME: dd failed, skipping $type"; continue; }
+       mkfs.$type $force $dev || { warn_ "$ME: mkfs.$type failed skipping"; continue; }
+diff --git a/tests/t4100-dvh-partition-limits.sh b/tests/t4100-dvh-partition-limits.sh
+index d3798d2..a5b3516 100755
+--- a/tests/t4100-dvh-partition-limits.sh
++++ b/tests/t4100-dvh-partition-limits.sh
+@@ -37,7 +37,7 @@ mp=`pwd`/mount-point
+ n=4096
+ 
+ # create an XFS file system
+-mkfs.xfs -dfile,name=$fs,size=100m || fail=1
++mkfs.xfs -dfile,name=$fs,size=300m || fail=1
+ mkdir "$mp" || fail=1
+ 
+ # Unmount upon interrupt, failure, etc., as well as upon normal completion.
+diff --git a/tests/t4100-msdos-partition-limits.sh b/tests/t4100-msdos-partition-limits.sh
+index b591123..09267b5 100755
+--- a/tests/t4100-msdos-partition-limits.sh
++++ b/tests/t4100-msdos-partition-limits.sh
+@@ -37,7 +37,7 @@ mp=`pwd`/mount-point
+ n=4096
+ 
+ # create an XFS file system
+-mkfs.xfs -dfile,name=$fs,size=100m || fail=1
++mkfs.xfs -dfile,name=$fs,size=300m || fail=1
+ mkdir "$mp" || fail=1
+ 
+ # Unmount upon interrupt, failure, etc., as well as upon normal completion.
+-- 
+2.38.1
+

--- a/app-admin/parted/autobuild/patches/0016-Fedora-0016-libparted-Fix-problem-with-creating-1s-partitions.patch
+++ b/app-admin/parted/autobuild/patches/0016-Fedora-0016-libparted-Fix-problem-with-creating-1s-partitions.patch
@@ -1,0 +1,133 @@
+From 9b009985da2e5eee5b5c179acfafab3aa1624f8b Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Tue, 10 May 2022 15:04:12 -0700
+Subject: [PATCH 16/17] libparted: Fix problem with creating 1s partitions
+
+There was a 1-off error in _partition_get_overlap_constraint that
+prevented partitions from being created in 1s free space. You could
+create 1s partitions as long they were done in order, but not after
+leaving 'holes'.
+
+This fixes this and adds tests for it on msdos and gpt disklabels.
+---
+ libparted/disk.c                  |  2 +-
+ tests/Makefile.am                 |  2 ++
+ tests/t9024-msdos-1s-partition.sh | 36 +++++++++++++++++++++++++++++++
+ tests/t9025-gpt-1s-partition.sh   | 36 +++++++++++++++++++++++++++++++
+ 4 files changed, 75 insertions(+), 1 deletion(-)
+ create mode 100644 tests/t9024-msdos-1s-partition.sh
+ create mode 100644 tests/t9025-gpt-1s-partition.sh
+
+diff --git a/libparted/disk.c b/libparted/disk.c
+index 45f35fd..e1a3489 100644
+--- a/libparted/disk.c
++++ b/libparted/disk.c
+@@ -1960,7 +1960,7 @@ _partition_get_overlap_constraint (PedPartition* part, PedGeometry* geom)
+ 	if (walk)
+ 		max_end = walk->geom.start - 1;
+ 
+-	if (min_start >= max_end)
++	if (min_start > max_end)
+ 		return NULL;
+ 
+ 	ped_geometry_init (&free_space, part->disk->dev,
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 1d109d7..fa27b44 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -91,6 +91,8 @@ TESTS = \
+   t9021-maxima.sh \
+   t9022-one-unit-snap.sh \
+   t9023-value-lt-one.sh \
++  t9024-msdos-1s-partition.sh \
++  t9025-gpt-1s-partition.sh \
+   t9030-align-check.sh \
+   t9040-many-partitions.sh \
+   t9041-undetected-in-use-16th-partition.sh \
+diff --git a/tests/t9024-msdos-1s-partition.sh b/tests/t9024-msdos-1s-partition.sh
+new file mode 100644
+index 0000000..7115156
+--- /dev/null
++++ b/tests/t9024-msdos-1s-partition.sh
+@@ -0,0 +1,36 @@
++#!/bin/sh
++# Test creating 1s partitions in 1s free space
++
++# Copyright (C) 2022 Free Software Foundation, Inc.
++
++# This program is free software; you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation; either version 3 of the License, or
++# (at your option) any later version.
++
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++
++# You should have received a copy of the GNU General Public License
++# along with this program.  If not, see <http://www.gnu.org/licenses/>.
++
++. "${srcdir=.}/init.sh"; path_prepend_ ../parted
++
++dev=loop-file
++
++# create device
++truncate --size 10MiB "$dev" || fail=1
++
++# create msdos label and some partitions with 1s free space between
++parted --script "$dev" mklabel msdos > out 2>&1 || fail=1
++parted --script "$dev" mkpart primary ext4 64s 128s > out 2>&1 || fail=1
++parted --script "$dev" mkpart primary ext4 130s 200s > out 2>&1 || fail=1
++parted --script "$dev" u s p free
++
++# Free space is at 129s
++parted --script "$dev" mkpart primary ext4 129s 129s > out 2>&1 || fail=1
++parted --script "$dev" u s p free
++
++Exit $fail
+diff --git a/tests/t9025-gpt-1s-partition.sh b/tests/t9025-gpt-1s-partition.sh
+new file mode 100644
+index 0000000..c97ab8b
+--- /dev/null
++++ b/tests/t9025-gpt-1s-partition.sh
+@@ -0,0 +1,36 @@
++#!/bin/sh
++# Test creating 1s partitions in 1s free space
++
++# Copyright (C) 2022 Free Software Foundation, Inc.
++
++# This program is free software; you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation; either version 3 of the License, or
++# (at your option) any later version.
++
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++
++# You should have received a copy of the GNU General Public License
++# along with this program.  If not, see <http://www.gnu.org/licenses/>.
++
++. "${srcdir=.}/init.sh"; path_prepend_ ../parted
++
++dev=loop-file
++
++# create device
++truncate --size 10MiB "$dev" || fail=1
++
++# create msdos label and some partitions with 1s free space between
++parted --script "$dev" mklabel gpt > out 2>&1 || fail=1
++parted --script "$dev" mkpart p1 ext4 64s 128s > out 2>&1 || fail=1
++parted --script "$dev" mkpart p2 ext4 130s 200s > out 2>&1 || fail=1
++parted --script "$dev" u s p free
++
++# Free space is at 129s
++parted --script "$dev" mkpart p3 ext4 129s 129s > out 2>&1 || fail=1
++parted --script "$dev" u s p free
++
++Exit $fail
+-- 
+2.39.1
+

--- a/app-admin/parted/autobuild/patches/0017-Fedora-0017-tests-Fixing-libparted-test-framework-usage.patch
+++ b/app-admin/parted/autobuild/patches/0017-Fedora-0017-tests-Fixing-libparted-test-framework-usage.patch
@@ -1,0 +1,262 @@
+From 7b555132be63172a2d621afcdedfa7797185d3b5 Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Tue, 7 Feb 2023 09:31:42 -0800
+Subject: [PATCH 17/17] tests: Fixing libparted test framework usage
+
+The fail and fail_if functions from libcheck are deprecated, replace
+them with ck_abort_msg and ck_assert_msg. Note that the logic of assert
+is the opposite of fail_if.
+---
+ libparted/tests/common.c  |  8 ++++----
+ libparted/tests/disk.c    |  6 +++---
+ libparted/tests/flags.c   |  6 +++---
+ libparted/tests/label.c   | 14 ++++++--------
+ libparted/tests/symlink.c | 31 +++++++++++++++++++++----------
+ libparted/tests/volser.c  |  2 +-
+ libparted/tests/zerolen.c |  2 +-
+ 7 files changed, 39 insertions(+), 30 deletions(-)
+
+diff --git a/libparted/tests/common.c b/libparted/tests/common.c
+index 2be0e3a..8c42ece 100644
+--- a/libparted/tests/common.c
++++ b/libparted/tests/common.c
+@@ -27,7 +27,7 @@ size_t get_sector_size (void)
+ PedExceptionOption
+ _test_exception_handler (PedException* e)
+ {
+-        fail ("Exception of type %s has been raised: %s",
++        ck_abort_msg("Exception of type %s has been raised: %s",
+               ped_exception_get_type_string (e->type),
+               e->message);
+ 
+@@ -69,10 +69,10 @@ _create_disk_label (PedDevice *dev, PedDiskType *type)
+ 
+         /* Create the label */
+         disk = ped_disk_new_fresh (dev, type);
+-        fail_if (!disk, "Failed to create a label of type: %s",
++        ck_assert_msg(disk != NULL, "Failed to create a label of type: %s",
+                  type->name);
+-        fail_if (!ped_disk_commit(disk),
+-		 "Failed to commit label to device");
++        ck_assert_msg(ped_disk_commit(disk) != 0,
++                 "Failed to commit label to device");
+ 
+         return disk;
+ }
+diff --git a/libparted/tests/disk.c b/libparted/tests/disk.c
+index 62d20c1..f7b16a5 100644
+--- a/libparted/tests/disk.c
++++ b/libparted/tests/disk.c
+@@ -14,7 +14,7 @@ static void
+ create_disk (void)
+ {
+         temporary_disk = _create_disk (get_sector_size () * 4 * 10 * 1024);
+-        fail_if (temporary_disk == NULL, "Failed to create temporary disk");
++        ck_assert_msg(temporary_disk != NULL, "Failed to create temporary disk");
+ }
+ 
+ static void
+@@ -72,8 +72,8 @@ START_TEST (test_duplicate)
+                 part = ped_disk_get_partition (disk, *i);
+                 part_dup = ped_disk_get_partition (disk_dup, *i);
+ 
+-                fail_if (part->geom.start != part_dup->geom.start ||
+-                         part->geom.end != part_dup->geom.end,
++                ck_assert_msg(part->geom.start == part_dup->geom.start &&
++                         part->geom.end == part_dup->geom.end,
+                          "Duplicated partition %d doesn't match. "
+                          "Details are start: %d/%d end: %d/%d\n",
+                          *i, part->geom.start, part_dup->geom.start,
+diff --git a/libparted/tests/flags.c b/libparted/tests/flags.c
+index c4b290b..ff4ae71 100644
+--- a/libparted/tests/flags.c
++++ b/libparted/tests/flags.c
+@@ -16,7 +16,7 @@ static void
+ create_disk (void)
+ {
+         temporary_disk = _create_disk (80 * 1024 * 1024);
+-        fail_if (temporary_disk == NULL, "Failed to create temporary disk");
++        ck_assert_msg(temporary_disk != NULL, "Failed to create temporary disk");
+ }
+ 
+ static void
+@@ -47,7 +47,7 @@ START_TEST (test_gpt_flag)
+ 
+         // Check flag to confirm it is still set
+         part = ped_disk_get_partition (disk, 1);
+-        fail_if (ped_partition_get_flag(part, PED_PARTITION_BIOS_GRUB) != 1, "BIOS_GRUB flag not set");
++        ck_assert_msg(ped_partition_get_flag(part, PED_PARTITION_BIOS_GRUB) == 1, "BIOS_GRUB flag not set");
+ 
+         ped_disk_destroy (disk);
+         ped_device_destroy (dev);
+@@ -75,7 +75,7 @@ START_TEST (test_msdos_flag)
+ 
+         // Check flag to confirm it is still set
+         part = ped_disk_get_partition (disk, 1);
+-        fail_if (ped_partition_get_flag(part, PED_PARTITION_BLS_BOOT) != 1, "BLS_BOOT flag not set");
++        ck_assert_msg(ped_partition_get_flag(part, PED_PARTITION_BLS_BOOT) == 1, "BLS_BOOT flag not set");
+ 
+         ped_disk_destroy (disk);
+         ped_device_destroy (dev);
+diff --git a/libparted/tests/label.c b/libparted/tests/label.c
+index e0d63c7..67b1b07 100644
+--- a/libparted/tests/label.c
++++ b/libparted/tests/label.c
+@@ -16,7 +16,7 @@ static void
+ create_disk (void)
+ {
+         temporary_disk = _create_disk (80 * 1024 * 1024);
+-        fail_if (temporary_disk == NULL, "Failed to create temporary disk");
++        ck_assert_msg(temporary_disk != NULL, "Failed to create temporary disk");
+ }
+ 
+ static void
+@@ -72,12 +72,11 @@ START_TEST (test_probe_label)
+ 
+                 /* Try to probe the disk label. */
+                 probed = ped_disk_probe (dev);
+-                fail_if (!probed,
++                ck_assert_msg(probed,
+                          "Failed to probe the just created label of type: %s",
+                          type->name);
+                 if (probed && !STREQ (probed->name, type->name))
+-                        fail_if (1,
+-                                 "Probe returned label of type: %s as type: %s",
++                        ck_abort_msg("Probe returned label of type: %s as type: %s",
+                                  type->name, probed->name);
+         }
+         ped_device_destroy (dev);
+@@ -105,12 +104,11 @@ START_TEST (test_read_label)
+ 
+                 /* Try to read the disk label. */
+                 disk = ped_disk_new (dev);
+-                fail_if (!disk,
++                ck_assert_msg(disk,
+                          "Failed to read the just created label of type: %s",
+                          type->name);
+                 if (disk && !STREQ (disk->type->name, type->name))
+-                        fail_if (1,
+-                                 "Read returned label of type: %s as type: %s",
++                        ck_abort_msg("Read returned label of type: %s as type: %s",
+                                  type->name, disk->type->name);
+ 
+                 ped_disk_destroy (disk);
+@@ -138,7 +136,7 @@ START_TEST (test_clone_label)
+ 
+                 /* Try to clone the disk label. */
+                 PedDisk* clone = ped_disk_duplicate (disk);
+-                fail_if (!clone,
++                ck_assert_msg(clone,
+                          "Failed to clone the just created label of type: %s",
+                          type->name);
+ 
+diff --git a/libparted/tests/symlink.c b/libparted/tests/symlink.c
+index 52e99ca..da6bef8 100644
+--- a/libparted/tests/symlink.c
++++ b/libparted/tests/symlink.c
+@@ -30,7 +30,7 @@ static void
+ create_disk (void)
+ {
+         temporary_disk = _create_disk (4096 * 1024);
+-        fail_if (temporary_disk == NULL, "Failed to create temporary disk");
++        ck_assert_msg(temporary_disk != NULL, "Failed to create temporary disk");
+ }
+ 
+ static void
+@@ -45,7 +45,7 @@ START_TEST (test_symlink)
+         char cwd[256], ln[256] = "/dev/mapper/parted-test-XXXXXX";
+ 
+         if (!getcwd (cwd, sizeof cwd)) {
+-                fail ("Could not get cwd");
++                ck_abort_msg("Could not get cwd");
+                 return;
+         }
+ 
+@@ -53,7 +53,7 @@ START_TEST (test_symlink)
+            temporary disk */
+         int tmp_fd = mkstemp (ln);
+         if (tmp_fd == -1) {
+-                fail ("Could not create tempfile");
++                ck_abort_msg("Could not create tempfile");
+                 return;
+         }
+ 
+@@ -62,11 +62,17 @@ START_TEST (test_symlink)
+         close (tmp_fd);
+         unlink (ln);
+         char temp_disk_path[256];
+-        snprintf (temp_disk_path, sizeof temp_disk_path, "%s/%s", cwd,
+-                  temporary_disk);
++        int r = snprintf(temp_disk_path, sizeof temp_disk_path, "%s/%s",
++                          cwd,
++                          temporary_disk);
++        if (r < 0 || r >= sizeof temp_disk_path) {
++                ck_abort_msg("symlink truncated");
++                return;
++        }
++
+         int res = symlink (temp_disk_path, ln);
+         if (res) {
+-                fail ("could not create symlink");
++                ck_abort_msg("could not create symlink");
+                 return;
+         }
+ 
+@@ -77,7 +83,7 @@ START_TEST (test_symlink)
+         /* Create a second temporary_disk */
+         char *temporary_disk2 = _create_disk (4096 * 1024);
+         if (temporary_disk2 == NULL) {
+-                fail ("Failed to create 2nd temporary disk");
++                ck_abort_msg("Failed to create 2nd temporary disk");
+                 goto exit_destroy_dev;
+         }
+ 
+@@ -89,11 +95,16 @@ START_TEST (test_symlink)
+ 
+         /* Update symlink to point to our new / second temporary disk */
+         unlink (ln);
+-        snprintf (temp_disk_path, sizeof temp_disk_path, "%s/%s", cwd,
+-                  temporary_disk);
++        r = snprintf (temp_disk_path, sizeof temp_disk_path, "%s/%s",
++                          cwd, temporary_disk);
++        if (r < 0 || r >= sizeof temp_disk_path) {
++                ck_abort_msg("2nd symlink truncated");
++                goto exit_destroy_dev;
++        }
++
+         res = symlink (temp_disk_path, ln);
+         if (res) {
+-                fail ("could not create 2nd symlink");
++                ck_abort_msg("could not create 2nd symlink");
+                 goto exit_destroy_dev;
+         }
+ 
+diff --git a/libparted/tests/volser.c b/libparted/tests/volser.c
+index c6efa5f..4b6e2d1 100644
+--- a/libparted/tests/volser.c
++++ b/libparted/tests/volser.c
+@@ -34,7 +34,7 @@ static void set_test (void)
+         type = ped_disk_type_get ("dasd");
+ 
+         tmp_disk = _create_disk (20*1024*1024);
+-        fail_if (tmp_disk == NULL, "Failed to create temporary disk");
++        ck_assert_msg(tmp_disk != NULL, "Failed to create temporary disk");
+         dev = ped_device_get (tmp_disk);
+         if (dev == NULL)
+                 return;
+diff --git a/libparted/tests/zerolen.c b/libparted/tests/zerolen.c
+index cf2bd1c..2d9b424 100644
+--- a/libparted/tests/zerolen.c
++++ b/libparted/tests/zerolen.c
+@@ -28,7 +28,7 @@ main (int argc, char **argv)
+         TCase* tcase_probe = tcase_create ("Probe");
+ 
+         if (argc < 2) {
+-                fail ("Insufficient arguments");
++                ck_abort_msg("Insufficient arguments");
+                 return EXIT_FAILURE;
+         }
+         temporary_disk = argv[1];
+-- 
+2.39.1
+

--- a/app-admin/parted/autobuild/patches/0018-Fedora-0018-filesys-Check-for-null-from-close_fn.patch
+++ b/app-admin/parted/autobuild/patches/0018-Fedora-0018-filesys-Check-for-null-from-close_fn.patch
@@ -1,0 +1,28 @@
+From c409dbf423d870ab26684cd6a6953c76c4a08d7f Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Wed, 15 Feb 2023 10:04:36 -0800
+Subject: [PATCH 18/24] filesys: Check for null from close_fn
+
+If the filesystem type name isn't known it can return a NULL.
+---
+ libparted/fs/r/filesys.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/libparted/fs/r/filesys.c b/libparted/fs/r/filesys.c
+index 9dafd71..6e795bc 100644
+--- a/libparted/fs/r/filesys.c
++++ b/libparted/fs/r/filesys.c
+@@ -198,8 +198,9 @@ ped_file_system_close (PedFileSystem* fs)
+ {
+        PED_ASSERT (fs != NULL);
+        PedDevice *dev = fs->geom->dev;
++       close_fn_t fn = close_fn (fs->type->name);
+ 
+-       if (!(close_fn (fs->type->name) (fs)))
++       if (!fn || !(fn (fs)))
+                goto error_close_dev;
+        ped_device_close (dev);
+        return 1;
+-- 
+2.39.2
+

--- a/app-admin/parted/autobuild/patches/0019-Fedora-0019-libparted-Fix-potential-NULL-dereference-in-ped_disk.patch
+++ b/app-admin/parted/autobuild/patches/0019-Fedora-0019-libparted-Fix-potential-NULL-dereference-in-ped_disk.patch
@@ -1,0 +1,30 @@
+From 31db44c74a96f8e2b495205d18525449e9b29543 Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Wed, 15 Feb 2023 10:13:58 -0800
+Subject: [PATCH 19/24] libparted: Fix potential NULL dereference in
+ ped_disk_next_partition
+
+---
+ libparted/disk.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/libparted/disk.c b/libparted/disk.c
+index e1a3489..6c82877 100644
+--- a/libparted/disk.c
++++ b/libparted/disk.c
+@@ -1718,8 +1718,11 @@ ped_disk_next_partition (const PedDisk* disk, const PedPartition* part)
+ 		return part->part_list ? part->part_list : part->next;
+ 	if (part->next)
+ 		return part->next;
+-	if (part->type & PED_PARTITION_LOGICAL)
++	if (part->type & PED_PARTITION_LOGICAL) {
++		if (!ped_disk_extended_partition (disk))
++			return NULL;
+ 		return ped_disk_extended_partition (disk)->next;
++	}
+ 	return NULL;
+ }
+ 
+-- 
+2.39.2
+

--- a/app-admin/parted/autobuild/patches/0020-Fedora-0020-strlist-Handle-realloc-error-in-wchar_to_str.patch
+++ b/app-admin/parted/autobuild/patches/0020-Fedora-0020-strlist-Handle-realloc-error-in-wchar_to_str.patch
@@ -1,0 +1,28 @@
+From 9cb38a7444d02023d112ae8e9e38436104f75f64 Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Wed, 15 Feb 2023 10:32:59 -0800
+Subject: [PATCH 20/24] strlist: Handle realloc error in wchar_to_str
+
+It could return a NULL if the realloc fails. This handles the failure in
+the same way as other failures in wchar_to_str, it exits immediately
+with an error message.
+---
+ parted/strlist.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/parted/strlist.c b/parted/strlist.c
+index 71cba59..7901789 100644
+--- a/parted/strlist.c
++++ b/parted/strlist.c
+@@ -166,6 +166,8 @@ wchar_to_str (const wchar_t* str, size_t count)
+ 		goto error;
+ 
+ 	result = realloc (result, strlen (result) + 1);
++	if (!result)
++		goto error;
+ 	return result;
+ 
+ error:
+-- 
+2.39.2
+

--- a/app-admin/parted/autobuild/patches/0021-Fedora-0021-ui-Add-checks-for-prompt-being-NULL.patch
+++ b/app-admin/parted/autobuild/patches/0021-Fedora-0021-ui-Add-checks-for-prompt-being-NULL.patch
@@ -1,0 +1,50 @@
+From 09c95d2feab0c087339886134dfe2dc04094348a Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Wed, 15 Feb 2023 11:15:28 -0800
+Subject: [PATCH 21/24] ui: Add checks for prompt being NULL
+
+Also removes a cast from const char* to char* when passing to readline
+that doesn't appear to be necessary any longer.
+
+Added asserts to make sure prompt isn't NULL after strdup and realloc
+calls.
+---
+ parted/ui.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/parted/ui.c b/parted/ui.c
+index df14e55..9e5ced2 100644
+--- a/parted/ui.c
++++ b/parted/ui.c
+@@ -564,8 +564,7 @@ _readline (const char* prompt, const StrList* possibilities)
+         wipe_line ();
+ #ifdef HAVE_LIBREADLINE
+         if (!opt_script_mode) {
+-                /* XXX: why isn't prompt const? */
+-                line = readline ((char*) prompt);
++                line = readline (prompt);
+                 if (line)
+                         _add_history_unique (line);
+         } else
+@@ -781,6 +780,8 @@ realloc_and_cat (char* str, const char* append)
+         int      length = strlen (str) + strlen (append) + 1;
+         char*    new_str = realloc (str, length);
+ 
++        PED_ASSERT(new_str != NULL);
++
+         strcat (new_str, append);
+         return new_str;
+ }
+@@ -789,7 +790,9 @@ static char*
+ _construct_prompt (const char* head, const char* def,
+                    const StrList* possibilities)
+ {
++        PED_ASSERT(head != NULL);
+         char*    prompt = strdup (head);
++        PED_ASSERT(prompt != NULL);
+ 
+         if (def && possibilities)
+                 PED_ASSERT (str_list_match_any (possibilities, def));
+-- 
+2.39.2
+

--- a/app-admin/parted/autobuild/patches/0022-Fedora-0022-tests-Fix-formatting-and-snprintf-warnings-in-tests.patch
+++ b/app-admin/parted/autobuild/patches/0022-Fedora-0022-tests-Fix-formatting-and-snprintf-warnings-in-tests.patch
@@ -1,0 +1,46 @@
+From d272bb5b5343fd288a204314654a7fbaea84528d Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Wed, 15 Feb 2023 11:52:42 -0800
+Subject: [PATCH 22/24] tests: Fix formatting and snprintf warnings in tests.
+
+The assert message includes sector values, which are long long int, so
+use the proper formatting of %lld.
+
+The snprintf warning complained about trying to write 258 bytes so I
+bumped the buffer size up to 259. The return value is already being
+checked for truncation so this is just to keep the compiler happy
+without having to suppress the warning.
+---
+ libparted/tests/disk.c    | 2 +-
+ libparted/tests/symlink.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libparted/tests/disk.c b/libparted/tests/disk.c
+index f7b16a5..a2e304c 100644
+--- a/libparted/tests/disk.c
++++ b/libparted/tests/disk.c
+@@ -75,7 +75,7 @@ START_TEST (test_duplicate)
+                 ck_assert_msg(part->geom.start == part_dup->geom.start &&
+                          part->geom.end == part_dup->geom.end,
+                          "Duplicated partition %d doesn't match. "
+-                         "Details are start: %d/%d end: %d/%d\n",
++                         "Details are start: %lld/%lld end: %lld/%lld\n",
+                          *i, part->geom.start, part_dup->geom.start,
+                          part->geom.end, part_dup->geom.end);
+         }
+diff --git a/libparted/tests/symlink.c b/libparted/tests/symlink.c
+index da6bef8..7be02cd 100644
+--- a/libparted/tests/symlink.c
++++ b/libparted/tests/symlink.c
+@@ -61,7 +61,7 @@ START_TEST (test_symlink)
+            here, but as /dev/mapper is root owned this is a non issue */
+         close (tmp_fd);
+         unlink (ln);
+-        char temp_disk_path[256];
++        char temp_disk_path[259];
+         int r = snprintf(temp_disk_path, sizeof temp_disk_path, "%s/%s",
+                           cwd,
+                           temporary_disk);
+-- 
+2.39.2
+

--- a/app-admin/parted/autobuild/patches/0023-Fedora-0023-parted-Fix-ending-sector-location-when-using-kibi-IE.patch
+++ b/app-admin/parted/autobuild/patches/0023-Fedora-0023-parted-Fix-ending-sector-location-when-using-kibi-IE.patch
@@ -1,0 +1,146 @@
+From 3f6b723a7d610d98afb0c9d0cfefe4700712e4db Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Fri, 3 Mar 2023 14:35:22 -0800
+Subject: [PATCH] parted: Fix ending sector location when using kibi IEC suffix
+
+This fixes a bug when using KiB to specify the ending location of a
+partition. It was not subtracting 1s like it does with the other units
+because it was looking for a 'k' not a 'K'.
+
+This also fixes a quirk of the suffix checking code, it would check for
+matching case, but converting to the actual IEC value was case
+insensitive. This now uses common functions for the matching so that
+case doesn't matter.
+
+It also adds tests to check for the fix.
+
+The only change in behavior is that using KiB to specify the ending
+location of a partition will now correctly create the end 1s lower than
+the specified location like it does for MiB, GiB, etc.
+---
+ parted/parted.c                    | 29 ++++++++++++++++++----------
+ tests/t0207-IEC-binary-notation.sh | 31 ++++++++++++++++++++++++++++++
+ tests/t0208-mkpart-end-in-IEC.sh   |  2 +-
+ 3 files changed, 51 insertions(+), 11 deletions(-)
+
+diff --git a/parted/parted.c b/parted/parted.c
+index 84187b7..84465d5 100644
+--- a/parted/parted.c
++++ b/parted/parted.c
+@@ -583,16 +583,27 @@ void _strip_trailing_spaces(char *str)
+                 str[i]='\0';
+ }
+ 
+-/* Return true, if str ends with [kMGTPEZY]iB, i.e. IEC units.  */
++/* Return true if the unit is one of the supported IEC unit values */
++static bool
++_is_unit_IEC(const PedUnit unit) {
++    return (unit == PED_UNIT_KIBIBYTE) || (unit == PED_UNIT_MEBIBYTE) ||
++           (unit == PED_UNIT_GIBIBYTE) || (unit == PED_UNIT_TEBIBYTE);
++}
++
++/* Return true, if str ends with IEC units.  */
+ static bool
+ _string_ends_with_iec_unit(const char *str)
+ {
+-        /* 3 characters for the IEC unit and at least 1 digit */
+-        if (!str || strlen(str) < 4)
+-                return false;
++    /* 3 characters for the IEC unit and at least 1 digit */
++    if (!str || strlen(str) < 4)
++        return false;
+ 
+-        char const *p = str + strlen(str) - 3;
+-        return strchr ("kMGTPEZY", *p) && c_strcasecmp (p+1, "iB") == 0;
++    char const *p = str + strlen(str) - 3;
++    PedUnit unit = ped_unit_get_by_name(p);
++    if (unit == -1) {
++        return false;
++    }
++    return _is_unit_IEC(unit);
+ }
+ 
+ /* Return true if str ends with explicit unit identifier.
+@@ -612,7 +623,7 @@ _string_has_unit_suffix(const char *str)
+         return false;
+ }
+ 
+-/* If the selected unit is one of kiB, MiB, GiB or TiB and the partition is not
++/* If the selected unit is one of KiB, MiB, GiB or TiB and the partition is not
+  * only 1 sector long, then adjust the end so that it is one sector before the
+  * given position. Also adjust range_end accordingly. Thus next partition can
+  * start immediately after this one.
+@@ -636,9 +647,7 @@ _adjust_end_if_iec (PedSector* start, PedSector* end,
+         _strip_trailing_spaces(end_input);
+         PedUnit unit = ped_unit_get_default();
+         if (_string_ends_with_iec_unit(end_input) ||
+-            (!_string_has_unit_suffix(end_input) &&
+-             ((unit == PED_UNIT_KIBIBYTE) || (unit == PED_UNIT_MEBIBYTE) ||
+-              (unit == PED_UNIT_GIBIBYTE) || (unit == PED_UNIT_TEBIBYTE)))) {
++            (!_string_has_unit_suffix(end_input) && _is_unit_IEC(unit))) {
+                 *end -= 1;
+                 range_end->start -= 1;
+                 range_end->end -= 1;
+diff --git a/tests/t0207-IEC-binary-notation.sh b/tests/t0207-IEC-binary-notation.sh
+index d9bbad6..b8a789e 100644
+--- a/tests/t0207-IEC-binary-notation.sh
++++ b/tests/t0207-IEC-binary-notation.sh
+@@ -28,6 +28,7 @@ parted --align=none -s $dev mklabel gpt mkpart p1 $((64*1024))B $((1024*1024-$ss
+ compare /dev/null err || fail=1
+ parted -m -s $dev u s p > exp || fail=1
+ 
++# Test using MiB
+ rm $dev
+ dd if=/dev/null of=$dev bs=$ss seek=$n_sectors || fail=1
+ parted --align=none -s $dev mklabel gpt mkpart p1 64KiB 1MiB \
+@@ -37,4 +38,34 @@ parted -m -s $dev u s p > out || fail=1
+ 
+ compare exp out || fail=1
+ 
++# Test using lower case kib and mib
++rm $dev
++dd if=/dev/null of=$dev bs=$ss seek=$n_sectors || fail=1
++parted --align=none -s $dev mklabel gpt mkpart p1 64kib 1mib \
++    > err 2>&1 || fail=1
++compare /dev/null err || fail=1
++parted -m -s $dev u s p > out || fail=1
++
++compare exp out || fail=1
++
++# Test using KiB
++rm $dev
++dd if=/dev/null of=$dev bs=$ss seek=$n_sectors || fail=1
++parted --align=none -s $dev mklabel gpt mkpart p1 64KiB 1024KiB \
++    > err 2>&1 || fail=1
++compare /dev/null err || fail=1
++parted -m -s $dev u s p > out || fail=1
++
++compare exp out || fail=1
++
++# Test using kiB
++rm $dev
++dd if=/dev/null of=$dev bs=$ss seek=$n_sectors || fail=1
++parted --align=none -s $dev mklabel gpt mkpart p1 64kiB 1024kiB \
++    > err 2>&1 || fail=1
++compare /dev/null err || fail=1
++parted -m -s $dev u s p > out || fail=1
++
++compare exp out || fail=1
++
+ Exit $fail
+diff --git a/tests/t0208-mkpart-end-in-IEC.sh b/tests/t0208-mkpart-end-in-IEC.sh
+index 118ec72..a3db2c3 100644
+--- a/tests/t0208-mkpart-end-in-IEC.sh
++++ b/tests/t0208-mkpart-end-in-IEC.sh
+@@ -25,7 +25,7 @@ dev=dev-file
+ 
+ dd if=/dev/null of=$dev bs=1M seek=$n_mbs || fail=1
+ # create 1st partition
+-parted --align=none -s $dev mklabel gpt mkpart p1 1MiB 2MiB > err 2>&1 || fail=1
++parted --align=none -s $dev mklabel gpt mkpart p1 1MiB 2048KiB > err 2>&1 || fail=1
+ compare /dev/null err || fail=1  # expect no output
+ #parted -m -s $dev u s p > exp || fail=1
+ 
+-- 
+2.39.2
+

--- a/app-admin/parted/spec
+++ b/app-admin/parted/spec
@@ -1,4 +1,5 @@
 VER=3.5
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/parted/parted-$VER.tar.xz"
 CHKSUMS="sha256::4938dd5c1c125f6c78b1f4b3e297526f18ee74aa43d45c248578b1d2470c05a2"
 CHKUPDATE="anitya::id=2596"


### PR DESCRIPTION
Topic Description
-----------------

This topic fixes an issue where Parted is unable to save any changes to the partition maps. It additionally syncs the patch set from Fedora (`f38`) to incorporate various tested upstream patches.

Package(s) Affected
-------------------

`parted` v3.5-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`