### PR TITLE
etckeeper: new, 1.18.20

### DIFF
--- a/app-admin/etckeeper/autobuild/build
+++ b/app-admin/etckeeper/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Installing etckeeper  ..."
+make install DESTDIR="$PKGDIR" systemddir=/usr/lib/systemd/system

--- a/app-admin/etckeeper/autobuild/defines
+++ b/app-admin/etckeeper/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=etckeeper
+PKGSEC=utils
+PKGDEP="git python-3"
+PKGDES="Store /etc in git"
+
+ABHOST=noarch

--- a/app-admin/etckeeper/autobuild/postinst
+++ b/app-admin/etckeeper/autobuild/postinst
@@ -1,0 +1,25 @@
+#!/bin/sh
+# learned from upstream debian/postinst
+set -e
+
+case "$1" in
+configure)
+	if [ "$2" = "" ] && [ -e "/etc/etckeeper/etckeeper.conf" ]; then
+		# Fresh install.
+		. /etc/etckeeper/etckeeper.conf || true
+		if [ -n "$VCS" ] && [ -x "`which $VCS 2>/dev/null`" ]; then
+			if etckeeper init; then
+				if ! etckeeper commit "Initial commit"; then
+					echo "etckeeper commit failed; run it by hand" >&2
+				fi
+			else
+				echo "etckeeper init failed; run it by hand" >&2
+			fi
+		else
+			echo "etckeeper init not ran as $VCS is not installed" >&2
+		fi
+	fi
+
+	# prints error and exits nonzero if the ignore file cannot be updated
+	etckeeper update-ignore || true
+esac

--- a/app-admin/etckeeper/spec
+++ b/app-admin/etckeeper/spec
@@ -1,0 +1,4 @@
+VER=1.18.20
+SRCS="tbl::https://git.joeyh.name/index.cgi/etckeeper.git/snapshot/etckeeper-$VER.tar.gz"
+CHKSUMS="sha256::0bb856e96f59cf582a92361294f0fc32e0a8bbc02fac3aacae0a735d11b3addd"
+CHKUPDATE="anitya::id=761"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->

Introduce [etckeeper](https://etckeeper.branchable.com/).

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

`etckeeper` 1.18.20.

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
