### PR TITLE
systemd: enable hibernation support, disable in sleep.conf by default

### DIFF
--- a/app-admin/systemd/autobuild/defines
+++ b/app-admin/systemd/autobuild/defines
@@ -65,7 +65,7 @@ MESON_AFTER="-Dmode=release \
              -Dvalgrind=false \
              -Dlog-trace=false \
              -Dutmp=true \
-             -Dhibernate=false \
+             -Dhibernate=true \
              -Dldconfig=true \
              -Dresolve=true \
              -Defi=false \

--- a/app-admin/systemd/autobuild/patches/0003-sleep-conf-disable-hibernation-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0003-sleep-conf-disable-hibernation-by-default.patch
@@ -1,0 +1,26 @@
+From b74ccdc68ad585ad03a98b037ad0795276647cc7 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 11 Apr 2023 18:04:25 -0700
+Subject: [PATCH] sleep.conf: AllowHibernation=no by default
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ src/sleep/sleep.conf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/sleep/sleep.conf b/src/sleep/sleep.conf
+index a3d31140d8..bd15ebf50b 100644
+--- a/src/sleep/sleep.conf
++++ b/src/sleep/sleep.conf
+@@ -14,7 +14,7 @@
+ 
+ [Sleep]
+ #AllowSuspend=yes
+-#AllowHibernation=yes
++AllowHibernation=no
+ #AllowSuspendThenHibernate=yes
+ #AllowHybridSleep=yes
+ #SuspendMode=
+-- 
+2.39.1
+

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,5 +1,5 @@
 VER=252.3
-REL=1
+REL=2
 SRCS="tbl::https://github.com/systemd/systemd-stable/archive/v$VER.tar.gz"
 CHKSUMS="sha256::7996edd41f26fc077164a2c778e0d187601dd98bac702b873a28a8948ad92331"
 CHKUPDATE="anitya::id=205088"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Enable hibernation, set `AllowHibernation=no` by default in `/etc/systemd/sleep.conf`

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`systemd`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
