### PR TITLE
MIPS64 R6 Rework 20230412

### DIFF
--- a/app-admin/thin-provisioning-tools/autobuild/defines
+++ b/app-admin/thin-provisioning-tools/autobuild/defines
@@ -2,10 +2,14 @@ PKGNAME=thin-provisioning-tools
 PKGSEC=admin
 PKGDEP="gcc-runtime zlib glibc"
 BUILDDEP="rustc llvm"
-# DRAFT: mips64r6el: no rust toolchain
-BUILDDEP__MIPS64R6EL="llvm"
 PKGDES="Suite of tools for manipulating thin provisioning targets"
 
 ABTYPE="rust"
 USECLANG=1
 CARGO_AFTER="--features=devtools"
+
+# FIXME: MIPS R6 fails to link Rust programs with lld, thus no LTO.
+# FIXME: Generating debuginfo crashes LLVM.
+USECLANG__MIPS64R6EL=0
+NOLTO__MIPS64R6EL=1
+ABSPLITDBG__MIPS64R6EL=0

--- a/app-network/avahi/autobuild/defines
+++ b/app-network/avahi/autobuild/defines
@@ -2,7 +2,6 @@ PKGNAME=avahi
 PKGSEC=net
 PKGDES="Service Discovery for Linux using mDNS/DNS-SD"
 PKGDEP="dbus-python expat libcap libdaemon nss-mdns twisted"
-PKGDEP__MIPS64R6EL="${PKGDEP/twisted/}"
 PKGDEP__RETRO="expat libcap libdaemon nss-mdns"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/app-network/samba/autobuild/defines
+++ b/app-network/samba/autobuild/defines
@@ -3,8 +3,6 @@ PKGSEC=net
 PKGDEP="glibc libbsd popt tdb ldb tevent libgcrypt python-3 talloc readline \
         gnutls openldap cups gamin libcap iniparser libaio lttng-ust gpgme \
         libnsl2 perl-parse-yapp markdown dnspython liburing jansson perl-json"
-# FIXME: No Rust for R6 - no setuptools-rust => !cryptography => !dnspython.
-PKGDEP__MIPS64R6EL="${PKGDEP/dnspython/}"
 PKGDEP__RETRO=" \
         glibc libbsd popt tdb ldb tevent libgcrypt python-3 talloc readline \
         gnutls openldap cups gamin libcap iniparser libaio gpgme libnsl2 \

--- a/lang-python/cryptography/autobuild/defines
+++ b/lang-python/cryptography/autobuild/defines
@@ -7,3 +7,5 @@ BUILDDEP="setuptools setuptools-rust appdirs wheel rustc llvm typing-extensions"
 NOPYTHON2=1
 ABTYPE=python
 NOLTO__RISCV64=1
+# FIXME: No lld support, thus no LTO.
+NOLTO__MIPS64R6EL=1


### PR DESCRIPTION
Topic Description
-----------------

This topic enables Rust features previously disabled on the `mips64r6el` port.

Package(s) Affected
-------------------

See "files changed." No version change made for port-specific changes.

Security Update?
----------------

No

Build Order
-----------

```
thin-provisioning-tools cryptography avahi samba
```

Test Build(s) Done
------------------

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`