### PR TITLE
fwupd: (amd64, arm64) drop more invalid options

### DIFF
--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -21,15 +21,11 @@ MESON_AFTER="-Dman=true \
              -Dtests=false"
 MESON_AFTER__AMD64=" \
              ${MESON_AFTER} \
-             -Denable-thunderbolt=true \
              -Dplugin_dell=true \
-             -Dplugin_synaptics=true \
              -Dplugin_msr=true"
 MESON_AFTER__ARM64=" \
              ${MESON_AFTER} \
-             -Denable-thunderbolt=true \
              -Dplugin_dell=false \
-             -Dplugin_synaptics=true \
              -Dplugin_msr=false"
 MESON_AFTER__LOONGSON3=" \
              ${MESON_AFTER} \


### PR DESCRIPTION
Topic Description
-----------------

This topic fixes build issues with `fwupd` on amd64, arm64.

Package(s) Affected
-------------------

No version change.

Security Update?
----------------

No