### PR TITLE
fwupd: update to 1.8.14

### DIFF
--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -26,7 +26,8 @@ MESON_AFTER__AMD64=" \
 MESON_AFTER__ARM64=" \
              ${MESON_AFTER} \
              -Dplugin_dell=false \
-             -Dplugin_msr=false"
+             -Dplugin_msr=false \
+             -Dplugin_flashrom=false"
 MESON_AFTER__LOONGSON3=" \
              ${MESON_AFTER} \
              -Dplugin_dell=false \

--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -3,11 +3,11 @@ PKGSEC=admin
 PKGDEP="appstream-glib colord dbus efivar elfutils gcab glib gnutls \
         gpgme json-glib libarchive libgpg-error libgudev libgusb libsoup \
         libxmlb modemmanager pango pillow polkit pycairo pygobject-3 python-3 \
-        shared-mime-info sqlite systemd tpm2-tss libjcat protobuf-c"
+        shared-mime-info sqlite systemd tpm2-tss libjcat protobuf-c libftdi"
 PKGDEP__AMD64="${PKGDEP} libsmbios thunderbolt-software-user-space"
 BUILDDEP="docbook-sgml gobject-introspection gtk-doc intltool meson \
           ninja pkg-config vala valgrind cairo dejavu-fonts fontconfig \
-          freetype gnu-efi markdown jinja2 toml typogrify"
+          freetype gnu-efi markdown jinja2 toml typogrify pefile"
 BUILDDEP__LOONGSON3="${BUILDDEP/gnu-efi/}"
 BUILDDEP__PPC64EL="${BUILDDEP/gnu-efi/}"
 PKGDES="Firmware update daemon and utilities"

--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,5 +1,4 @@
-VER=1.7.3
-REL=1
+VER=1.8.14
 SRCS="https://github.com/hughsie/fwupd/archive/$VER.tar.gz"
-CHKSUMS="sha256::e927003cf2673625abdb8ab1b7440a20fdfdb989b45e8f337668794f721a8994"
+CHKSUMS="sha256::02d31bbfb70219d2b86d5fba216f6dbaba89fac4cfc79508cece6cb79ec1d0dc"
 CHKUPDATE="anitya::id=5833"

--- a/lang-python/pefile/autobuild/defines
+++ b/lang-python/pefile/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=pefile
+PKGSEC=python
+PKGDEP="futures python-3"
+BUILDDEP="python-build python-installer wheel"
+PKGDES="A Python module to read and work with PE (Portable Executable) files"
+
+ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/pefile/spec
+++ b/lang-python/pefile/spec
@@ -1,0 +1,4 @@
+VER=2023.2.7
+SRCS="https://pypi.io/packages/source/p/pefile/pefile-$VER.tar.gz"
+CHKSUMS="sha256::82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc"
+CHKUPDATE="anitya::id=11315"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Fwupd to 1.8.14.

Package(s) Affected
-------------------

- `fwupd` v1.8.14
- `pefile` v2023.2.7

Security Update?
----------------

No

Build Order
-----------

```
pefile fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------


**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`