### PR TITLE
fcitx5-pinyin-moegirl: update to 20230414

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20230214
+VER=20230414
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::2567b802f69eedc434bbe5a3fa59adc5b7ab0be843ff49f0c4f5e5ecb333362e \
-         sha256::bfead0bdfc9f2f5261475e8b72490c4d5b56ef7b2ce5782ac924306d9a21cf02 \
+CHKSUMS="sha256::35a41b4bf2653b525b7cba4cf7729a62ec18552c10930ac32fa5adb604ca4e83 \
+         sha256::d210e3175fc6b7e394ebf60463eb7579f2115a9a8faca22268c441434cc45898 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Update fcitx5-pinyin-moegirl to 20230414.

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**
- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`