### PR TITLE
FTBFS Rework 20230416

### DIFF
--- a/app-devel/bam/autobuild/build
+++ b/app-devel/bam/autobuild/build
@@ -1,3 +1,7 @@
-./make_unix.sh
-mkdir -p "$PKGDIR"/usr/bin
-cp bam "$PKGDIR"/usr/bin
+abinfo "Building Bam ..."
+CC="gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}" \
+    "$SRCDIR"/make_unix.sh
+
+abinfo "Installing Bam ..."
+install -Dvm755 "$SRCDIR"/bam \
+    "$PKGDIR"/usr/bin/bam

--- a/app-devel/bam/spec
+++ b/app-devel/bam/spec
@@ -1,5 +1,5 @@
 VER=0.5.1
-REL=1
+REL=2
 SRCS="tbl::https://github.com/matricks/bam/archive/v$VER.tar.gz"
 CHKSUMS="sha256::cc8596af3325ecb18ebd6ec2baee550e82cb7b2da19588f3f843b02e943a15a9"
 CHKUPDATE="anitya::id=159"

--- a/app-doc/sphinx-press-theme/autobuild/defines
+++ b/app-doc/sphinx-press-theme/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=sphinx-press-theme
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="A Sphinx-doc theme based on Vuepress"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/app-doc/sphinx-press-theme/spec
+++ b/app-doc/sphinx-press-theme/spec
@@ -1,0 +1,4 @@
+VER=0.8.0
+SRCS="https://pypi.io/packages/source/s/sphinx_press_theme/sphinx_press_theme-$VER.tar.gz"
+CHKSUMS="sha256::2884caab1dc01ecb11d158d4dd6d3179e2dd97cd48516c769cc27360272e62b3"
+CHKUPDATE="anitya::id=199291"

--- a/app-doc/sphinx-tabs/autobuild/defines
+++ b/app-doc/sphinx-tabs/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=sphinx-tabs
+PKGSEC=python
+PKGDEP="docutils pygments python-3 sphinx"
+BUILDDEP="python-build python-installer setuptools wheel"
+PKGDES="A Sphinx-doc theme based on Vuepress"
+
+ABHOST=noarch
+NOPYTHON2=1
+
+ABTYPE=pep517

--- a/app-doc/sphinx-tabs/spec
+++ b/app-doc/sphinx-tabs/spec
@@ -1,0 +1,4 @@
+VER=3.4.1
+SRCS="https://pypi.io/packages/source/s/sphinx-tabs/sphinx-tabs-$VER.tar.gz"
+CHKSUMS="sha256::d2a09f9e8316e400d57503f6df1c78005fdde220e5af589cc79d493159e1b832"
+CHKUPDATE="anitya::id=126079"

--- a/app-games/ddnet/autobuild/defines
+++ b/app-games/ddnet/autobuild/defines
@@ -26,3 +26,7 @@ CMAKE_AFTER="-DANTIBOT=ON \
              -DWEBSOCKETS=ON"
 
 USECLANG=1
+
+# FIXME: ld.lld: error: lto.tmp: cannot link object files with different
+# floating-point ABI
+NOLTO__RISCV64=1

--- a/app-games/ddnet/autobuild/defines
+++ b/app-games/ddnet/autobuild/defines
@@ -30,3 +30,7 @@ USECLANG=1
 # FIXME: ld.lld: error: lto.tmp: cannot link object files with different
 # floating-point ABI
 NOLTO__RISCV64=1
+
+# FIXME: ld.lld failure.
+USECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1

--- a/app-multimedia/simplescreenrecorder/autobuild/patches/0001-Update-elfhack.h-to-support-RISC-V-architecture.patch
+++ b/app-multimedia/simplescreenrecorder/autobuild/patches/0001-Update-elfhack.h-to-support-RISC-V-architecture.patch
@@ -1,0 +1,28 @@
+From a1962846e8d170e3bcd5f5fb61c432bbdbaa3855 Mon Sep 17 00:00:00 2001
+From: rvalue <i@rvalue.moe>
+Date: Sat, 29 Jan 2022 20:33:04 +0800
+Subject: [PATCH] Update `elfhack.h` to support RISC-V architecture
+
+---
+ glinject/elfhacks.h | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/glinject/elfhacks.h b/glinject/elfhacks.h
+index 3c351e2..a23f5d7 100644
+--- a/glinject/elfhacks.h
++++ b/glinject/elfhacks.h
+@@ -44,6 +44,11 @@ extern "C" {
+ #ifdef __i386__
+ # define __elf32
+ #endif
++#if __riscv_xlen == 64
++# define __elf64
++#elif __riscv_xlen == 32
++# define __elf32
++#endif
+ 
+ #if defined(__elf64)
+ # define ELFW_R_SYM ELF64_R_SYM
+-- 
+2.39.1
+

--- a/app-multimedia/simplescreenrecorder/spec
+++ b/app-multimedia/simplescreenrecorder/spec
@@ -1,5 +1,5 @@
 VER=0.4.3
-REL=2
+REL=3
 SRCS="tbl::https://github.com/MaartenBaert/ssr/archive/$VER.tar.gz"
 CHKSUMS="sha256::03b5f6cd613b504f8b2351c2728a6fd070aa0cc98e709bcafdcf93b672bd2b71"
 CHKUPDATE="anitya::id=7253"

--- a/app-network/miniupnpc/autobuild/beyond
+++ b/app-network/miniupnpc/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Setting executable bits for /usr/lib/*.so* ..."
+chmod -v +x "$PKGDIR"/usr/lib/*.so*

--- a/app-network/miniupnpc/spec
+++ b/app-network/miniupnpc/spec
@@ -1,5 +1,5 @@
 VER=2.1
-REL=3
+REL=4
 SRCS="tbl::http://miniupnp.free.fr/files/miniupnpc-$VER.tar.gz"
 CHKSUMS="sha256::e19fb5e01ea5a707e2a8cb96f537fbd9f3a913d53d804a3265e3aeab3d2064c6"
 CHKUPDATE="anitya::id=1986"

--- a/app-productivity/libreoffice/autobuild/build
+++ b/app-productivity/libreoffice/autobuild/build
@@ -1,23 +1,21 @@
 if [[ "${CROSS:-$ARCH}" = "powerpc" || \
       "${CROSS:-$ARCH}" = "ppc64" || \
-      "${CROSS:-$ARCH}" = "loongson3" || \
-      "${CROSS:-$ARCH}" = "ppc64el" ]]; then
-    export FIREBIRD="--disable-firebird-sdbc"
-    export USE_LTO="--disable-lto"
-else
-    export FIREBIRD="--enable-firebird-sdbc"
-    export USE_LTO="--enable-lto"
-fi
-
-if [[ "${CROSS:-$ARCH}" = "powerpc" || \
-      "${CROSS:-$ARCH}" = "ppc64" || \
       "${CROSS:-$ARCH}" = "loongson3" ]]; then
     export FIREBIRD="--disable-firebird-sdbc"
 else
     export FIREBIRD="--enable-firebird-sdbc"
 fi
 
+if [[ "${USECLANG}" = 0 ]]; then
+  # HACK: when not using clang, we also need to avoid LibO
+  # force clang usage on Skia
+  export LO_CLANG_CC=gcc
+  export LO_CLANG_CXX=g++
+fi
+
 abinfo "Autogen-ing ..."
+# FIXME: Use bundled GpgME as our version is too new for 7.3.
+# Check again with 7.5.
 ./autogen.sh \
              --with-vendor="Anthon Open Source Community" \
              --with-parallelism="${ABTHREADS}" \
@@ -76,7 +74,6 @@ abinfo "Autogen-ing ..."
              --with-system-libwps \
              --with-system-redland\
              --with-system-libzmf \
-             --with-system-gpgmepp \
              --with-system-libstaroffice \
              --with-system-serf \
              --with-system-icu \
@@ -89,6 +86,7 @@ abinfo "Autogen-ing ..."
              --without-system-firebird ${FIREBIRD} \
              --without-system-hsqldb \
              --without-system-mariadb \
+             --without-system-gpgmepp \
              --without-myspell-dicts \
              --without-system-poppler \
              --without-junit \
@@ -96,7 +94,7 @@ abinfo "Autogen-ing ..."
              --with-gdrive-client-id="1006183841565.apps.googleusercontent.com" \
              --with-gdrive-client-secret="XN6oYWBv7O7w_heXB8TVuldr" \
              --disable-dependency-tracking \
-             --enable-pch=full "${USE_LTO}"
+             --enable-pch=full
 
 abinfo "Building LibreOffice"
 make build-nocheck

--- a/app-productivity/libreoffice/autobuild/defines
+++ b/app-productivity/libreoffice/autobuild/defines
@@ -23,3 +23,7 @@ PKGBREAK="libreoffice-help<=6.4.1.2 libreoffice-i18n<=5.0.4"
 
 USECLANG=1
 USECLANG__PPC64EL=0
+
+# FIXME: configure: error: Your gcc is not -fvisibility=hidden safe. This is
+# no longer supported.
+NOLTO__AMD64=1

--- a/app-productivity/libreoffice/autobuild/defines
+++ b/app-productivity/libreoffice/autobuild/defines
@@ -22,6 +22,4 @@ PKGREP="libreoffice-help<=6.4.1.2 libreoffice-i18n<=5.0.4"
 PKGBREAK="libreoffice-help<=6.4.1.2 libreoffice-i18n<=5.0.4"
 
 USECLANG=1
-
-# FIXME: Try building for Loongson3 again with Core 9.
-FAIL_ARCH="!(amd64|arm64|ppc64el)"
+USECLANG__PPC64EL=0

--- a/app-productivity/libreoffice/autobuild/prepare
+++ b/app-productivity/libreoffice/autobuild/prepare
@@ -1,8 +1,3 @@
-abinfo "Stripping LTO flags, let LibreOffice decide ..."
-export CFLAGS="${CFLAGS/\-flto=auto/}"
-export CXXFLAGS="${CXXFLAGS/\-flto=auto/}"
-export LDFLAGS="${LDFLAGS/\-flto/}"
-
 abinfo "Applying -fPIC to fix build ..."
 export CFLAGS="${CFLAGS} -fPIC"
 export CXXFLAGS="${CXXFLAGS} -fPIC"

--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,5 +1,5 @@
 VER=7.3.1.3
-REL=2
+REL=3
 SRCS="tbl::https://download.documentfoundation.org/libreoffice/src/${VER:0:5}/libreoffice-$VER.tar.xz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz \

--- a/app-utils/open-rs/autobuild/defines
+++ b/app-utils/open-rs/autobuild/defines
@@ -5,3 +5,8 @@ BUILDDEP="rustc llvm"
 PKGSEC="utils"
 
 USECLANG=1
+
+# FIXME: LLVM crashes with debuginfo enabled.
+USECLANG__MIPS64R6EL=0
+NOLTO__MIPS64R6EL=1
+ABSPLITDBG__MIPS64R6EL=0

--- a/app-web/thunderbird/autobuild/defines
+++ b/app-web/thunderbird/autobuild/defines
@@ -16,3 +16,7 @@ ABSPLITDBG=0
 
 # FIXME: Confuses lld on amd64 and will produce broken binary
 AB_FLAGS_PIE=0
+
+# FIXME: LLVM crashes.
+USECLANG__PPC64EL=0
+NOLTO__PPC64EL=1

--- a/app-web/thunderbird/autobuild/mozconfig
+++ b/app-web/thunderbird/autobuild/mozconfig
@@ -34,7 +34,6 @@ ac_add_options --enable-release
 ac_add_options --disable-strip
 ac_add_options --enable-linker=lld
 ac_add_options --disable-lto
-ac_add_options --disable-elf-hack
 
 # Dependencies.
 ac_add_options --enable-system-ffi

--- a/app-web/thunderbird/autobuild/patches/0016-Fix-missing-generic-sources-in-webrtc-module.patch
+++ b/app-web/thunderbird/autobuild/patches/0016-Fix-missing-generic-sources-in-webrtc-module.patch
@@ -1,0 +1,12 @@
+--- a/third_party/libwebrtc/moz.build   2023-04-17 16:31:46.251131174 -0700
++++ b/third_party/libwebrtc/moz.build   2023-04-17 16:33:03.683124514 -0700
+@@ -519,6 +519,9 @@
+     DIRS += [
+         "/third_party/libwebrtc/api/audio_codecs/isac/audio_decoder_isac_float_gn",
+         "/third_party/libwebrtc/api/audio_codecs/isac/audio_encoder_isac_float_gn",
++        "/third_party/libwebrtc/modules/desktop_capture/desktop_capture_generic_gn",
++        "/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn",
++        "/third_party/libwebrtc/modules/desktop_capture/primitives_gn",
+         "/third_party/libwebrtc/modules/audio_coding/isac_c_gn",
+         "/third_party/libwebrtc/modules/audio_coding/isac_gn"
+     ]

--- a/app-web/thunderbird/autobuild/prepare
+++ b/app-web/thunderbird/autobuild/prepare
@@ -18,6 +18,17 @@ if ab_match_arch loongson3; then
     echo "ac_add_options --disable-jit" >> "$SRCDIR"/mozconfig
 fi
 
+# FIXME: --disable-elf-hack is not available for ppc64el.
+if ! ab_match_arch ppc64el; then
+    abinfo "Setting --disable-elf-hack ..."
+    echo "ac_add_options --disable-elf-hack" \
+        >> "$SRCDIR"/autobuild/mozconfig
+
+    abinfo "Use the gold linker ..."
+    echo "ac_add_options --enable-linker=gold" \
+        >> "$SRCDIR"/autobuild/mozconfig
+fi
+
 abinfo "Declaring $SHELL as /bin/bash ..."
 export SHELL=/bin/bash
 

--- a/app-web/thunderbird/spec
+++ b/app-web/thunderbird/spec
@@ -1,4 +1,5 @@
 VER=102.9.1
+REL=1
 CHKUPDATE="anitya::id=4967"
 SRCS="https://archive.mozilla.org/pub/thunderbird/releases/$VER/source/thunderbird-$VER.source.tar.xz \
       file::rename=af.xpi::http://ftp.mozilla.org/pub/thunderbird/releases/$VER/linux-x86_64/xpi/af.xpi \

--- a/desktop-kde/discover/autobuild/defines
+++ b/desktop-kde/discover/autobuild/defines
@@ -7,6 +7,10 @@ PKGDEP="appstream-qt discount fwupd attica5 karchive kauth kbookmarks \
         kwidgetsaddons kxmlgui ostree packagekit-qt purpose solid"
 PKGRECOM="flatpak snapd-glib"
 BUILDDEP="extra-cmake-modules flatpak snapd-glib"
+# FIXME: Snapd fails to build due to missing CGO features.
+# osutil/sys/syscall.go:46:22: undefined: _SYS_GETUID
+# osutil/sys/syscall.go:50:22: undefined: _SYS_GETEUI
+BUILDDEP__LOONGSON3="${BUILDDEP/snapd-glib/}"
 PKGDES="An all-in-one software and addons manager for the Plasma desktop"
 
 # FIXME: -DCMAKE_SKIP_RPATH=OFF, Discover installs runtime libraries to a

--- a/desktop-kde/kdepim-runtime/autobuild/defines
+++ b/desktop-kde/kdepim-runtime/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="akonadi-calendar akonadi-contacts akonadi-notes cyrus-sasl fontconfig fr
 PKGDEP__NOWEBENGINE="${PKGDEP/libkgapi/}"
 PKGDEP__LOONGSON3="${PKGDEP__NOWEBENGINE}"
 PKGDEP__PPC64EL="${PKGDEP__NOWEBENGINE}"
-PKGDEP__RISCV64="${PKGDEP__NOWEBENGINE}"
+PKGDEP__RISCV64="${PKGDEP__NOWEBENGINE/libetebase/}"
 BUILDDEP="extra-cmake-modules kaccounts-integration kdoctools"
 PKGDES="Basic runtime libraries and data files for KDE PIM"
 

--- a/lang-python/breathe/autobuild/defines
+++ b/lang-python/breathe/autobuild/defines
@@ -5,3 +5,5 @@ PKGDES="An extension to reStructuredText and Sphinx to be able to read and rende
 
 ABTYPE=python
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/breathe/spec
+++ b/lang-python/breathe/spec
@@ -1,5 +1,4 @@
-VER=4.11.1
-REL=4
+VER=4.35.0
 SRCS="tbl::https://github.com/michaeljones/breathe/archive/v$VER.tar.gz"
-CHKSUMS="sha256::84723eefc7cc05da6895e2dd6e7c72926c5fd88a67de57edce42d99c058c7e06"
+CHKSUMS="sha256::55b54723752fc04b892a0f868782b1df65e69db6ca94fb32cf04be495bfd7841"
 CHKUPDATE="anitya::id=48918"

--- a/lang-python/commonmark/spec
+++ b/lang-python/commonmark/spec
@@ -1,5 +1,4 @@
-VER=0.8.1
-REL=3
+VER=0.9.1
 SRCS="tbl::https://pypi.io/packages/source/c/commonmark/commonmark-$VER.tar.gz"
-CHKSUMS="sha256::abcbc854e0eae5deaf52ae5e328501b78b4a0758bf98ac8bb792fce993006084"
+CHKSUMS="sha256::452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"
 CHKUPDATE="anitya::id=23870"

--- a/lang-python/testresources/autobuild/defines
+++ b/lang-python/testresources/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=testresources
+PKGSEC=python
+PKGDEP="pbr python-2 python-3"
+BUILDDEP="setuptools"
+PKGDES="A pyunit extension for managing expensive test resources"
+
+ABHOST=noarch

--- a/lang-python/testresources/spec
+++ b/lang-python/testresources/spec
@@ -1,0 +1,4 @@
+VER=2.0.1
+SRCS="https://pypi.io/packages/source/t/testresources/testresources-$VER.tar.gz"
+CHKSUMS="sha256::ee9d1982154a1e212d4e4bac6b610800bfb558e4fb853572a827bc14a96e4417"
+CHKUPDATE="anitya::id=9608"

--- a/runtime-cryptography/libetebase/autobuild/defines
+++ b/runtime-cryptography/libetebase/autobuild/defines
@@ -6,3 +6,7 @@ PKGDES="A C library for Etebase"
 
 USECLANG=1
 ABTYPE=plainmake
+
+# FIXME: ld.lld failure.
+UECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1

--- a/runtime-imaging/opencolorio/autobuild/defines.stage2
+++ b/runtime-imaging/opencolorio/autobuild/defines.stage2
@@ -1,6 +1,6 @@
 PKGNAME=opencolorio
 PKGSEC=libs
-PKGDEP="freeglut glew glu openimageio python-3 yaml-cpp tinyxml lcms1"
+PKGDEP="freeglut glew glu python-3 yaml-cpp tinyxml lcms1"
 BUILDDEP="breathe doxygen graphviz recommonmark sphinx sphinx-press-theme \
           sphinx-tabs testresources"
 PKGDES="A color management framework for visual effects and animation"

--- a/runtime-imaging/opencolorio/spec
+++ b/runtime-imaging/opencolorio/spec
@@ -1,5 +1,5 @@
 VER=2.1.2
-REL=2
+REL=3
 SRCS="tbl::https://github.com/imageworks/OpenColorIO/archive/v$VER.tar.gz"
 CHKSUMS="sha256::6c6d153470a7dbe56136073e7abea42fa34d06edc519ffc0a159daf9f9962b0b"
 CHKUPDATE="anitya::id=9631"

--- a/runtime-multimedia/vid.stab/autobuild/patches/0001-Drop-msse2-flag-declaration.patch
+++ b/runtime-multimedia/vid.stab/autobuild/patches/0001-Drop-msse2-flag-declaration.patch
@@ -1,0 +1,15 @@
+--- vid.stab-release-0.98b/CMakeLists.txt	2014-03-12 12:42:49.000000000 -0700
++++ vid.stab-release-0.98b.nosse2/CMakeLists.txt	2023-04-12 01:19:47.983378057 -0700
+@@ -26,12 +26,6 @@
+ add_definitions( -DDISABLE_ORC )
+ endif()
+ 
+-# here we should check for SSE2
+-# our  -DUSE_SSE2_ASM code does not work with fpic
+-if(SSE2_FOUND)
+-add_definitions( -DUSE_SSE2 -msse2 -ffast-math )
+-endif()
+-
+ set(SOURCES src/frameinfo.c src/transformtype.c src/libvidstab.c
+   src/transform.c src/transformfixedpoint.c src/motiondetect.c
+   src/motiondetect_opt.c src/serialize.c src/localmotion2transform.c

--- a/runtime-multimedia/vid.stab/spec
+++ b/runtime-multimedia/vid.stab/spec
@@ -1,5 +1,5 @@
 VER=0.98b
-REL=1
+REL=2
 SRCS="tbl::https://github.com/georgmartius/vid.stab/archive/release-$VER.tar.gz"
 CHKSUMS="sha256::530f0bf7479ec89d9326af3a286a15d7d6a90fcafbb641e3b8bdb8d05637d025"
 SUBDIR="vid.stab-release-$VER"


### PR DESCRIPTION
Topic Description
-----------------

This topic reworks packages with build failures while building updates for secondary ports.

Package(s) Affected
-------------------

See "files changed."

Security Update?
----------------

No

Build Order
-----------

```
bam simplescreenrecorder miniupnpc breathe commonmark sphinx-press-theme sphinx-tabs testresources opencolorio vid.stab libreoffice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------


**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`