### PR TITLE
Cross compile toolchain for arm64

### DIFF
--- a/app-devel/binutils+cross-arm64/autobuild/build
+++ b/app-devel/binutils+cross-arm64/autobuild/build
@@ -1,9 +1,23 @@
+abinfo "Clearing compiler flags in environment..."
 unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
 
-mkdir -p build
-cd build
-../configure --prefix=/opt/abcross/arm64 --target=aarch64-aosc-linux-gnu \
-             --with-sysroot=/var/ab/cross-root/arm64 --enable-shared --disable-multilib --with-arch=armv8-a --disable-werror
+abinfo "Configuring binutils..."
+mkdir -pv "$SRCDIR"/build
+cd "$SRCDIR"/build
+
+../configure \
+	--prefix=/opt/abcross/${__CROSS} \
+	--target=aarch64-aosc-linux-gnu \
+	--with-sysroot=/var/ab/cross-root/${__CROSS} \
+	--enable-shared \
+	--disable-multilib \
+	--with-arch=armv8-a \
+	--disable-werror \
+	--enable-gold
+
+abinfo "Building binutils..."
 make configure-host
-make 
+make
+
+abinfo "Installing binutils to target directory..."
 make DESTDIR=$PKGDIR install

--- a/app-devel/binutils+cross-arm64/spec
+++ b/app-devel/binutils+cross-arm64/spec
@@ -1,4 +1,6 @@
-VER=2.33.1
+VER=2.40
 SRCS="git::commit=b5624945ea67525c0ba4ffec7a9d3f9366bf9071::https://sourceware.org/git/binutils-gdb.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7981"
+
+__CROSS=arm64

--- a/app-devel/gcc+cross-arm64/autobuild/build
+++ b/app-devel/gcc+cross-arm64/autobuild/build
@@ -1,14 +1,37 @@
+abinfo "Clearing compiler flags in environment..."
 unset CFLAGS CXXFLAGS LDFLAGS CPPFLAGS
 
-mkdir -p build
-cd build
-export PATH="/opt/abcross/armel/bin:$PATH"
-AR=ar ../configure --prefix=/opt/abcross/arm64 --target=aarch64-aosc-linux-gnu \
-                   --with-sysroot=/var/ab/cross-root/arm64 --enable-shared --disable-multilib \
-                   --enable-c99 --enable-long-long --enable-threads=posix \
-                   --enable-languages=c,c++,fortran,lto,go,objc,obj-c++,d,ada --enable-__cxa_atexit --disable-altivec --disable-fixed-point --with-arch=armv8-a --enable-lto --enable-gnu-unique-object \
-                   --enable-linker-build-id --enable-libstdcxx-dual-abi --with-default-libstdcxx-abi=new
+abinfo "Configuring GCC..."
+mkdir -pv "$SRCDIR"/build
+cd "$SRCDIR"/build
 
-make AS_FOR_TARGET=/opt/abcross/arm64/bin/aarch64-aosc-linux-gnu-as \
-     LD_FOR_TARGET=/opt/abcross/arm64/bin/aarch64-aosc-linux-gnu-ld
-make DESTDIR=$PKGDIR install
+../configure \
+	    --prefix=/opt/abcross/${__CROSS} \
+	    --target=aarch64-aosc-linux-gnu \
+	    --with-sysroot=/var/ab/cross-root/${__CROSS} \
+	    --enable-shared \
+	    --disable-multilib \
+	    --enable-c99 \
+	    --enable-long-long \
+	    --enable-threads=posix \
+	    --enable-languages=c,c++,fortran,lto,go,objc,obj-c++,d,ada \
+	    --enable-__cxa_atexit \
+            --disable-altivec \
+	    --disable-fixed-point \
+	    --with-arch=armv8-a \
+	    --enable-lto \
+	    --enable-gnu-unique-object \
+	    --enable-linker-build-id \
+	    --enable-libstdcxx-dual-abi \
+	    --with-default-libstdcxx-abi=new
+
+abinfo "Building gcc..."
+make AS_FOR_TARGET=/opt/abcross/${__CROSS}/bin/aarch64-aosc-linux-gnu-as \
+     LD_FOR_TARGET=/opt/abcross/${__CROSS}/bin/aarch64-aosc-linux-gnu-ld
+
+abinfo "Installing gcc into PKGDIR..."
+make DESTDIR="$PKGDIR" install
+
+abinfo "Installing minimal sysroot into PKGDIR..."
+mkdir -pv "$PKGDIR"/var/ab/cross-root
+cp -avP /var/ab/cross-root/${__CROSS} ${PKGDIR}/var/ab/cross-root/

--- a/app-devel/gcc+cross-arm64/autobuild/prepare
+++ b/app-devel/gcc+cross-arm64/autobuild/prepare
@@ -1,5 +1,11 @@
-if [ ! -d /var/ab/cross-root/arm64 ]; then
-        abinfo "Extracting ARM64 sysroot ..."
-	mkdir -pv /var/ab/cross-root/arm64
-	tar xfpJ "$SRCDIR"/../sysroot.tar.xz -C /var/ab/cross-root/arm64/ || true
+abinfo "Checking if ${__CROSS} minimal sysroot is already extracted to /var/ab/cross-root/${__CROSS}..."
+if [ ! -d /var/ab/cross-root/${__CROSS} ]; then
+        abinfo "Extracting ${__CROSS} minimal sysroot ..."
+	mkdir -pv /var/ab/cross-root/${__CROSS}
+	for package in aosc-aaa linux+api glibc ; do
+		abinfo "Extracting $package..."
+		dpkg-deb -vx $SRCDIR/../$package.deb /var/ab/cross-root/${__CROSS}/
+	done
+else
+	abinfo "${__CROSS} minimal sysroot does exist, skipping."
 fi

--- a/app-devel/gcc+cross-arm64/spec
+++ b/app-devel/gcc+cross-arm64/spec
@@ -1,7 +1,24 @@
-VER=12.1.0
-SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-$VER/gcc-$VER.tar.xz \
-      file::rename=sysroot.tar.xz::https://releases.aosc.io/os-arm64/buildkit/aosc-os_buildkit_20220917_arm64.tar.xz"
-CHKSUMS="sha256::62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b \
-         sha256::204e177c5fddc1b3e00b1730e70c7df64e240dbc364925d58139f150834f69b4"
+# Building this package requires a minimal set of package to be installed:
+# Version of glibc
+# glibc for target architecture is required to build and for further usage.
+GLIBC_VER=2.36-4
+# Version of linux+api
+LINUXAPI_VER=6.1.13-0
+# Version of aosc-aaa
+AOSCAAA_VER=10.1.2-0
+# Version of gcc
+GCC_VER=12.2.0
+# Target architecture - this variable is used during build process
+__CROSS=arm64
+
+VER=${GCC_VER}+glibc${GLIBC_VER/-/+}
+SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VER}/gcc-${GCC_VER}.tar.xz \
+      file::rename=glibc.deb::https://repo.aosc.io/debs/pool/stable/main/g/glibc_${GLIBC_VER}_${__CROSS}.deb \
+      file::rename=linux+api.deb::https://repo.aosc.io/debs/pool/stable/main/l/linux+api_${LINUXAPI_VER}_${__CROSS}.deb \
+      file::rename=aosc-aaa.deb::https://repo.aosc.io/debs/pool/stable/main/a/aosc-aaa_${AOSCAAA_VER}_${__CROSS}.deb"
+CHKSUMS="sha256::e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff \
+         sha256::7cebf491c4625524f1f7d74fe7ec901a6fdbc706bfaa0505815fd41519041400 \
+         sha256::293f4491e54889a7d2d0348be6df5ed102b68f6dd26a02ba62ee30825f96dac0 \
+         sha256::866aba24bfa0edefe13cdb6b018d37605a32f7f87b9895f09f8a101de357f760"
 CHKUPDATE="anitya::id=6502"
-SUBDIR="gcc-$VER"
+SUBDIR="gcc-${GCC_VER}"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates cross compiling toolchain targetting arm64.

Package(s) Affected
-------------------
* binutils+cross-arm64
* gcc+cross-arm64

Build Order
-----------

binutils+cross-arm64 gcc+cross-arm64

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
