### PR TITLE
mpd: enable pipewire support

### DIFF
--- a/app-multimedia/mpd/autobuild/defines
+++ b/app-multimedia/mpd/autobuild/defines
@@ -5,7 +5,7 @@ PKGDEP="libao ffmpeg libmodplug audiofile libshout libmad curl \
         libmpdclient icu libupnp libnfs pulseaudio samba sndio \
         chromaprint libcdio-paranoia zziplib openal-soft libcdio \
         fluidsynth game-music-emu libmpcdec libmikmod mpg123 \
-        libsidplay libsidplayfp twolame wildmidi"
+        libsidplay libsidplayfp twolame wildmidi pipewire"
 BUILDDEP="boost doxygen"
 PKGDES="Flexible, powerful server-side application for playing music"
 

--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,4 +1,5 @@
 VER=0.23.12
+REL=1
 SRCS="tbl::http://www.musicpd.org/download/mpd/${VER%.*}/mpd-${VER}.tar.xz"
 CHKSUMS="sha256::b7fca62284ecc25a681ea6a07abc49200af5353be42cb5a31e3173be9d8702e7"
 CHKUPDATE="anitya::id=14864"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Enable pipewire support in mpd

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`mpd` 

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

Please describe in what order maintainers should build this pull request.
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
