### PR TITLE
libxml2: Security Update to 2.10.4

### DIFF
--- a/runtime-common/libxml2/spec
+++ b/runtime-common/libxml2/spec
@@ -1,5 +1,4 @@
-VER=2.10.3
-REL=1
+VER=2.10.4
 SRCS="tbl::https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${VER}/libxml2-v${VER}.tar.gz"
-CHKSUMS="sha256::497f12e34790d407ec9e2a190d576c0881a1cd78ff3c8991d1f9e40281a5ff57"
+CHKSUMS="sha256::1aa47bd54f9e0245686d494fbbbfa4e3e77b6fc4f988708383de8a1033292e66"
 CHKUPDATE="anitya::id=1783"

--- a/runtime-optenv32/libxml2+32/spec
+++ b/runtime-optenv32/libxml2+32/spec
@@ -1,4 +1,4 @@
-VER=2.10.3
+VER=2.10.4
 SRCS="tbl::https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${VER}/libxml2-v${VER}.tar.gz"
-CHKSUMS="sha256::497f12e34790d407ec9e2a190d576c0881a1cd78ff3c8991d1f9e40281a5ff57"
+CHKSUMS="sha256::1aa47bd54f9e0245686d494fbbbfa4e3e77b6fc4f988708383de8a1033292e66"
 CHKUPDATE="anitya::id=1783"


### PR DESCRIPTION
Topic Description
-----------------

This security update updates libxml2 to 2.10.4. See #4510 for more details.

Closes #4510 

Package(s) Affected
-------------------

`libxml2`

Security Update?
----------------

Yes. #4510 
<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

- `libxml2`
- amd64: `libxml2{,+32}`


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

