### PR TITLE
dnsmasq: Update to 2.89; Fix CVE-2023-28450

### DIFF
--- a/app-network/dnsmasq/autobuild/patches/0001-Upstream-Git-CVE-2023-28450.patch
+++ b/app-network/dnsmasq/autobuild/patches/0001-Upstream-Git-CVE-2023-28450.patch
@@ -1,0 +1,43 @@
+From eb92fb32b746f2104b0f370b5b295bb8dd4bd5e5 Mon Sep 17 00:00:00 2001
+From: Simon Kelley <simon@thekelleys.org.uk>
+Date: Tue, 7 Mar 2023 22:07:46 +0000
+Subject: [PATCH] Set the default maximum DNS UDP packet size to 1232.
+
+http://www.dnsflagday.net/2020/ refers.
+
+Thanks to Xiang Li for the prompt.
+---
+ man/dnsmasq.8 | 3 ++-
+ src/config.h  | 2 +-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/man/dnsmasq.8 b/man/dnsmasq.8
+index 41e2e04..5acb935 100644
+--- a/man/dnsmasq.8
++++ b/man/dnsmasq.8
+@@ -183,7 +183,8 @@ to zero completely disables DNS function, leaving only DHCP and/or TFTP.
+ .TP
+ .B \-P, --edns-packet-max=<size>
+ Specify the largest EDNS.0 UDP packet which is supported by the DNS
+-forwarder. Defaults to 4096, which is the RFC5625-recommended size.
++forwarder. Defaults to 1232, which is the recommended size following the
++DNS flag day in 2020. Only increase if you know what you are doing.
+ .TP
+ .B \-Q, --query-port=<query_port>
+ Send outbound DNS queries from, and listen for their replies on, the
+diff --git a/src/config.h b/src/config.h
+index 1e7b30f..37b374e 100644
+--- a/src/config.h
++++ b/src/config.h
+@@ -19,7 +19,7 @@
+ #define CHILD_LIFETIME 150 /* secs 'till terminated (RFC1035 suggests > 120s) */
+ #define TCP_MAX_QUERIES 100 /* Maximum number of queries per incoming TCP connection */
+ #define TCP_BACKLOG 32  /* kernel backlog limit for TCP connections */
+-#define EDNS_PKTSZ 4096 /* default max EDNS.0 UDP packet from RFC5625 */
++#define EDNS_PKTSZ 1232 /* default max EDNS.0 UDP packet from from  /dnsflagday.net/2020 */
+ #define SAFE_PKTSZ 1232 /* "go anywhere" UDP packet size, see https://dnsflagday.net/2020/ */
+ #define KEYBLOCK_LEN 40 /* choose to minimise fragmentation when storing DNSSEC keys */
+ #define DNSSEC_WORK 50 /* Max number of queries to validate one question */
+-- 
+2.20.1
+

--- a/app-network/dnsmasq/spec
+++ b/app-network/dnsmasq/spec
@@ -1,4 +1,4 @@
-VER=2.88
+VER=2.89
 SRCS="tbl::http://www.thekelleys.org.uk/dnsmasq/dnsmasq-$VER.tar.xz"
-CHKSUMS="sha256::23544deda10340c053bea6f15a93fed6ea7f5aaa85316bfc671ffa6d22fbc1b3"
+CHKSUMS="sha256::02bd230346cf0b9d5909f5e151df168b2707103785eb616b56685855adebb609"
 CHKUPDATE="anitya::id=444"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

This topic updates dnsmasq to latest, and plus adapt a minor security improvment/fix for CVE-2023-28450 from upstream patch.


Package(s) Affected
-------------------

`dnsmasq`

Security Update?
----------------

Yes. (Minor errata, no issue)


Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] ~~MIPS R6 64-bit (Little Endian) `mips64r6el`~~
- [ ] ~~PowerPC 64-bit (Little Endian) `ppc64el`~~
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] ~~MIPS R6 64-bit (Little Endian) `mips64r6el`~~
- [ ] ~~PowerPC 64-bit (Little Endian) `ppc64el`~~
- [ ] RISC-V 64-bit `riscv64`

