### PR TITLE
Fix dependencies for cross toolchains

### DIFF
--- a/app-devel/binutils+cross-arm64/autobuild/defines
+++ b/app-devel/binutils+cross-arm64/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=binutils+cross-arm64
-PKGDEP="glibc"
+PKGDEP="glibc flex xz elfutils"
 PKGSEC=devel
 PKGDES="Binutils for arm64 cross build"

--- a/app-devel/binutils+cross-arm64/spec
+++ b/app-devel/binutils+cross-arm64/spec
@@ -1,6 +1,7 @@
 VER=2.40
-SRCS="git::commit=b5624945ea67525c0ba4ffec7a9d3f9366bf9071::https://sourceware.org/git/binutils-gdb.git"
-CHKSUMS="SKIP"
+REL=1
+SRCS="tbl::https://ftp.gnu.org/gnu/binutils/binutils-$VER.tar.xz"
+CHKSUMS="sha256::0f8a4c272d7f17f369ded10a4aca28b8e304828e95526da482b0ccc4dfc9d8e1"
 CHKUPDATE="anitya::id=7981"
 
 __CROSS=arm64

--- a/app-devel/binutils+cross-mips64r6el/autobuild/build
+++ b/app-devel/binutils+cross-mips64r6el/autobuild/build
@@ -9,6 +9,7 @@ cd "$SRCDIR"/build
 	    --prefix=/opt/abcross/${__CROSS} \
 	    --target=mipsisa64r6el-aosc-linux-gnuabi64 \
 	    --with-sysroot=/var/ab/cross-root/${__CROSS} \
+            --with-python=/usr/bin/python3 \
 	    --enable-shared \
 	    --disable-multilib \
 	    --with-arch=mips64r6 \

--- a/app-devel/binutils+cross-mips64r6el/autobuild/defines
+++ b/app-devel/binutils+cross-mips64r6el/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=binutils+cross-mips64r6el
-PKGDEP="glibc"
+PKGDEP="glibc flex xz elfutils"
 PKGSEC=devel
 PKGDES="Binutils for mips64r6el cross build"

--- a/app-devel/binutils+cross-mips64r6el/spec
+++ b/app-devel/binutils+cross-mips64r6el/spec
@@ -1,7 +1,7 @@
 VER=2.40
-REL=1
-SRCS="git::commit=b5624945ea67525c0ba4ffec7a9d3f9366bf9071::https://sourceware.org/git/binutils-gdb.git"
-CHKSUMS="SKIP"
+REL=3
+SRCS="tbl::https://ftp.gnu.org/gnu/binutils/binutils-$VER.tar.xz"
+CHKSUMS="sha256::0f8a4c272d7f17f369ded10a4aca28b8e304828e95526da482b0ccc4dfc9d8e1"
 CHKUPDATE="anitya::id=7981"
 
 __CROSS=mips64r6el

--- a/app-devel/gcc+cross-arm64/autobuild/defines
+++ b/app-devel/gcc+cross-arm64/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=gcc+cross-arm64
 PKGSEC=devel
-PKGDEP="binutils+cross-arm64"
+PKGDEP="binutils+cross-arm64 isl gmp mpfr zstd"
 PKGDES="GCC for arm64 build"
 NOSTATIC=no

--- a/app-devel/gcc+cross-arm64/spec
+++ b/app-devel/gcc+cross-arm64/spec
@@ -12,6 +12,7 @@ GCC_VER=12.2.0
 __CROSS=arm64
 
 VER=${GCC_VER}+glibc${GLIBC_VER/-/+}
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VER}/gcc-${GCC_VER}.tar.xz \
       file::rename=glibc.deb::https://repo.aosc.io/debs/pool/stable/main/g/glibc_${GLIBC_VER}_${__CROSS}.deb \
       file::rename=linux+api.deb::https://repo.aosc.io/debs/pool/stable/main/l/linux+api_${LINUXAPI_VER}_${__CROSS}.deb \

--- a/app-devel/gcc+cross-mips64r6el/autobuild/defines
+++ b/app-devel/gcc+cross-mips64r6el/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=gcc+cross-mips64r6el
 PKGSEC=devel
-PKGDEP="binutils+cross-mips64r6el"
+PKGDEP="binutils+cross-mips64r6el isl gmp mpfr zstd"
 PKGDES="GCC for mips64r6el build"
 NOSTATIC=no

--- a/app-devel/gdb+cross-arm64/autobuild/beyond
+++ b/app-devel/gdb+cross-arm64/autobuild/beyond
@@ -1,0 +1,23 @@
+abinfo "Getting rid of stuff also in binutils"
+for i in bfd ctf-spec opcodes; do
+	rm -vf "$PKGDIR"/opt/abcross/${__CROSS}/share/info/${i}.info
+	find "$PKGDIR"/opt/abcross/${__CROSS}/share/locale -name "$i.mo" -exec rm -v {} \;
+done
+rm -vf "$PKGDIR"/opt/abcross/${__CROSS}/bin/${__GNU_ABI}-run
+
+step_and_delete_empty_dir() {
+	# $1=starting point
+	# return 0 (true) if there are still more
+	find "$1" -type d -empty -delete
+	N=$(find "$1" -type d -empty | wc -l)
+	if [[ $N -gt 0 ]]; then
+		return 0;
+	else
+		return 1;
+	fi
+}
+
+abinfo "Getting rid of empty dirs"
+while step_and_delete_empty_dir "${PKGDIR}/opt/abcross/${__CROSS}/share"; do
+	echo "Iterating..."
+done

--- a/app-devel/gdb+cross-arm64/autobuild/defines
+++ b/app-devel/gdb+cross-arm64/autobuild/defines
@@ -1,0 +1,27 @@
+# FIXME: acbs cannot auto expand PKGNAME nor PKGDEP
+PKGNAME=gdb+cross-arm64
+PKGSEC=devel
+PKGDEP="babeltrace boost elfutils expat gc isl mpfr readline expat python-3
+	xxhash xz zlib guile source-highlight binutils+cross-arm64"
+PKGDES="GNU source-level debugger (cross toolchain for ${__CROSS})"
+
+AUTOTOOLS_STRICT=0
+AUTOTOOLS_DEF="--prefix=/opt/abcross/${__CROSS}"
+AUTOTOOLS_AFTER=(
+        --target=${__GNU_ABI}
+	--with-expat
+	--with-lzma
+	--with-babeltrace
+	--with-libbabeltrace-type=shared
+	--with-xxhash
+	--with-mpfr
+	--with-guile
+	--enable-source-highlight
+	--disable-install-libbfd  # Covered by binutils
+	--with-system-zlib
+	--with-system-readline
+	--with-python=/usr/bin/python3
+)
+RECONF=0
+
+PKGBREAK="binutils+cross-${__CROSS}<=2.40"

--- a/app-devel/gdb+cross-arm64/autobuild/prepare
+++ b/app-devel/gdb+cross-arm64/autobuild/prepare
@@ -1,0 +1,10 @@
+abinfo "Clearing compiler flags in environment..."
+unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
+export CFLAGS=" -Wno-error -ggdb "
+export CXXFLAGS=" -fpermissive "
+
+abinfo "Sanity check..."
+if [[ $PKGNAME != gdb+cross-${__CROSS} ]]; then
+	aberr "PKGNAME must be set to \"gdb+cross-${__CROSS}\""
+	abdie
+fi

--- a/app-devel/gdb+cross-arm64/spec
+++ b/app-devel/gdb+cross-arm64/spec
@@ -1,0 +1,7 @@
+VER=12.1
+SRCS="tbl::https://ftp.gnu.org/gnu/gdb/gdb-$VER.tar.xz"
+CHKSUMS="sha256::0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed"
+CHKUPDATE="anitya::id=11798"
+
+__CROSS=arm64
+__GNU_ABI=aarch64-aosc-linux-gnu

--- a/app-devel/gdb+cross-mips64r6el/autobuild/beyond
+++ b/app-devel/gdb+cross-mips64r6el/autobuild/beyond
@@ -1,0 +1,23 @@
+abinfo "Getting rid of stuff also in binutils"
+for i in bfd ctf-spec opcodes; do
+	rm -vf "$PKGDIR"/opt/abcross/${__CROSS}/share/info/${i}.info
+	find "$PKGDIR"/opt/abcross/${__CROSS}/share/locale -name "$i.mo" -exec rm -v {} \;
+done
+rm -vf "$PKGDIR"/opt/abcross/${__CROSS}/bin/${__GNU_ABI}-run
+
+step_and_delete_empty_dir() {
+	# $1=starting point
+	# return 0 (true) if there are still more
+	find "$1" -type d -empty -delete
+	N=$(find "$1" -type d -empty | wc -l)
+	if [[ $N -gt 0 ]]; then
+		return 0;
+	else
+		return 1;
+	fi
+}
+
+abinfo "Getting rid of empty dirs"
+while step_and_delete_empty_dir "${PKGDIR}/opt/abcross/${__CROSS}/share"; do
+	echo "Iterating..."
+done

--- a/app-devel/gdb+cross-mips64r6el/autobuild/defines
+++ b/app-devel/gdb+cross-mips64r6el/autobuild/defines
@@ -1,0 +1,27 @@
+# FIXME: acbs cannot auto expand PKGNAME nor PKGDEP
+PKGNAME=gdb+cross-mips64r6el
+PKGSEC=devel
+PKGDEP="babeltrace boost elfutils expat gc isl mpfr readline expat python-3
+	xxhash xz zlib guile source-highlight binutils+cross-mips64r6el"
+PKGDES="GNU source-level debugger (cross toolchain for ${__CROSS})"
+
+AUTOTOOLS_STRICT=0
+AUTOTOOLS_DEF="--prefix=/opt/abcross/${__CROSS}"
+AUTOTOOLS_AFTER=(
+        --target=${__GNU_ABI}
+	--with-expat
+	--with-lzma
+	--with-babeltrace
+	--with-libbabeltrace-type=shared
+	--with-xxhash
+	--with-mpfr
+	--with-guile
+	--enable-source-highlight
+	--disable-install-libbfd  # Covered by binutils
+	--with-system-zlib
+	--with-system-readline
+	--with-python=/usr/bin/python3
+)
+RECONF=0
+
+PKGBREAK="binutils+cross-${__CROSS}<=2.40-1"

--- a/app-devel/gdb+cross-mips64r6el/autobuild/prepare
+++ b/app-devel/gdb+cross-mips64r6el/autobuild/prepare
@@ -1,0 +1,10 @@
+abinfo "Clearing compiler flags in environment..."
+unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
+export CFLAGS=" -Wno-error -ggdb "
+export CXXFLAGS=" -fpermissive "
+
+abinfo "Sanity check..."
+if [[ $PKGNAME != gdb+cross-${__CROSS} ]]; then
+	aberr "PKGNAME must be set to \"gdb+cross-${__CROSS}\""
+	abdie
+fi

--- a/app-devel/gdb+cross-mips64r6el/spec
+++ b/app-devel/gdb+cross-mips64r6el/spec
@@ -1,0 +1,7 @@
+VER=12.1
+SRCS="tbl::https://ftp.gnu.org/gnu/gdb/gdb-$VER.tar.xz"
+CHKSUMS="sha256::0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed"
+CHKUPDATE="anitya::id=11798"
+
+__CROSS=mips64r6el
+__GNU_ABI=mipsisa64r6el-aosc-linux-gnuabi64


### PR DESCRIPTION
Topic Description
-----------------

- Use versioned tarballs
- Add dependencies in `{binutils,gdb,gcc}+cross-{arm64,mips64r6el}`
- Make templates from `${__CROSS}` and `${__GNU_API}`

Package(s) Affected
-------------------



Build Order
-----------

`{binutils,gdb,gcc}+cross-{arm64,mips64r6el}`

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
