### PR TITLE
treevsrepo: new, 0.3.3

### DIFF
--- a/app-devel/treevsrepo/autobuild/defines
+++ b/app-devel/treevsrepo/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=treevsrepo
+PKGSEC=devel
+PKGDEP="gcc-runtime openssl zlib"
+BUILDDEP="llvm rustc"
+PKGDES="A tool to expose package version discrepancies between the ABBS tree and the repository"
+
+USECLANG=1
+# FIXME: Signal 11 on linkage.
+USECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1

--- a/app-devel/treevsrepo/spec
+++ b/app-devel/treevsrepo/spec
@@ -1,0 +1,4 @@
+VER=0.3.3
+SRCS="git::commit=tags/v0.3.3::https://github.com/AOSC-Dev/treevsrepo"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=341996"


### PR DESCRIPTION
Topic Description
-----------------

This topic introduces treevsrepo, which checks for tree-repo version discrepancies.

Package(s) Affected
-------------------

`treevsrepo` v0.3.3

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`