### PR TITLE
Certbot 2.5.0, fixes #4516

### DIFF
--- a/app-web/certbot-apache/spec
+++ b/app-web/certbot-apache/spec
@@ -1,5 +1,4 @@
-VER=1.12.0
+VER=2.5.0
 SRCS="tbl::https://pypi.io/packages/source/c/certbot-apache/certbot-apache-$VER.tar.gz"
-CHKSUMS="sha256::e5679b40d99bd241f4fcd9fe44b73e6e25ccc969a617131ff6ebc90d562a49f2"
+CHKSUMS="sha256::96c9cd62ed57c2307282d7203d07d378d929ce644d6ea0bee6d6cff72a85ac70"
 CHKUPDATE="anitya::id=10837"
-REL=1

--- a/app-web/certbot-dns-cloudflare/spec
+++ b/app-web/certbot-dns-cloudflare/spec
@@ -1,5 +1,4 @@
-VER=1.12.0
+VER=2.5.0
 SRCS="tbl::https://pypi.io/packages/source/c/certbot-dns-cloudflare/certbot-dns-cloudflare-$VER.tar.gz"
-CHKSUMS="sha256::5fc6f3e55c3174e41f9bb79bb02fabe9a0c5679d2ac950ea454b3e979da4a823"
+CHKSUMS="sha256::b5efa224ea51d939756a3b94e2dcbda7801613165fdc016e9e5718acb48e6a41"
 CHKUPDATE="anitya::id=17035"
-REL=1

--- a/app-web/certbot-nginx/spec
+++ b/app-web/certbot-nginx/spec
@@ -1,5 +1,4 @@
-VER=1.12.0
+VER=2.5.0
 SRCS="tbl::https://pypi.io/packages/source/c/certbot-nginx/certbot-nginx-$VER.tar.gz"
-CHKSUMS="sha256::3fb6a55290d37ad466681a89a85ceca4c4026fdd8702f3010b87a74266a6fe7b"
+CHKSUMS="sha256::499fc15de782689a1dc2a224e8978e5de8369f6aef63262698ea2cc48e8028b5"
 CHKUPDATE="anitya::id=15248"
-REL=1

--- a/app-web/certbot/spec
+++ b/app-web/certbot/spec
@@ -1,4 +1,4 @@
-VER=1.31.0
+VER=2.5.0
 SRCS="tbl::https://pypi.io/packages/source/c/certbot/certbot-$VER.tar.gz"
-CHKSUMS="sha256::29af531d33aaa87c8104864cd31ac2af541f0ec973a7252d7f7f5b15e10479db"
+CHKSUMS="sha256::76e6e5305021d3ee54c42fc471f8f0ed5dba790e6fd7fef6713060b0e42b97d7"
 CHKUPDATE="anitya::id=10690"

--- a/lang-python/acme/spec
+++ b/lang-python/acme/spec
@@ -1,4 +1,4 @@
-VER=1.31.0
+VER=2.5.0
 SRCS="tbl::https://pypi.io/packages/source/a/acme/acme-$VER.tar.gz"
-CHKSUMS="sha256::f5e13262fa1101c38dd865378ac8b4639f819120eb66c5538fc6c09b7576fc53"
+CHKSUMS="sha256::9c760b115c54f55f692321abe5d09f5c70ce437e61f9f22340341621d9909a5a"
 CHKUPDATE="anitya::id=8231"

--- a/lang-python/pyopenssl/spec
+++ b/lang-python/pyopenssl/spec
@@ -1,4 +1,4 @@
-VER=22.1.0
+VER=23.1.1
 SRCS="https://pypi.io/packages/source/p/pyOpenSSL/pyOpenSSL-$VER.tar.gz"
-CHKSUMS="sha256::7a83b7b272dd595222d672f5ce29aa030f1fb837630ef229f62e72e395ce8968"
+CHKSUMS="sha256::841498b9bec61623b1b6c47ebbc02367c07d60e0e195f19790817f10cc8db0b7"
 CHKUPDATE="anitya::id=5535"


### PR DESCRIPTION
Topic Description
-----------------

This PR upgrades relavent package after cryptography 39+ breaks pyopenssl.

Package(s) Affected
-------------------

- pyopenssl
- acme
- certbot
- certbot-nginx
- certbot-apache
- certbot-dns-cloudflare

Build Order
-----------

pyopenssl acme certbot certbot-{nginx,apache,dns-cloudflare}

Test Build(s) Done
------------------

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

- [x] Architecture-independent `noarch`