### PR TITLE
powerpc-utils: drop unused snap utility

### DIFF
--- a/app-admin/powerpc-utils/autobuild/beyond
+++ b/app-admin/powerpc-utils/autobuild/beyond
@@ -3,3 +3,8 @@ if [[ "${CROSS:-$ARCH}" = "powerpc" || \
     abinfo "Dropping nvsetenv ..."
     rm -v "$PKGDIR"/usr/bin/nvsetenv
 fi
+
+abinfo "Debian: Drop RHEL/SLES-specific snap utility ..."
+rm -v \
+    "$PKGDIR"/usr/bin/snap \
+    "$PKGDIR"/usr/share/man/man8/snap.8

--- a/app-admin/powerpc-utils/spec
+++ b/app-admin/powerpc-utils/spec
@@ -1,5 +1,5 @@
 VER=1.3.10
-REL=1
+REL=2
 SRCS="tbl::https://github.com/nfont/powerpc-utils/archive/v$VER.tar.gz"
 CHKSUMS="sha256::d64d9016a3e63a1e44c6e0833742cf964ae6bb1c6a9c7f0c7c5748aa335dc3db"
 CHKUPDATE="anitya::id=10715"


### PR DESCRIPTION
Topic Description
-----------------

This topic drops the `snap` utility from `powerpc-utils`, which, according to Debian,  is RHEL/SLES-specific, it also conflicts with `snapd`.

Package(s) Affected
-------------------

`powerpc-utils` v1.3.10-2

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] PowerPC 64-bit (Little Endian) `ppc64el`