### PR TITLE
libdispatch: (AUR patch) disable -Werror

### DIFF
--- a/runtime-common/libdispatch/autobuild/patches/0001-AUR-remove-werror.patch
+++ b/runtime-common/libdispatch/autobuild/patches/0001-AUR-remove-werror.patch
@@ -1,0 +1,10 @@
+--- a/cmake/modules/DispatchCompilerWarnings.cmake.orig	2020-05-12 13:13:59.619689872 +0300
++++ b/cmake/modules/DispatchCompilerWarnings.cmake	2020-05-12 13:13:35.216171428 +0300
+@@ -2,7 +2,6 @@
+ if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+   # TODO: someone needs to provide the msvc equivalent warning flags
+ else()
+-  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Werror>)
+   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wall>)
+   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wextra>)
+ 

--- a/runtime-common/libdispatch/spec
+++ b/runtime-common/libdispatch/spec
@@ -1,4 +1,5 @@
 VER=5.6.1
+REL=1
 SRCS="tbl::https://github.com/apple/swift-corelibs-libdispatch/archive/refs/tags/swift-${VER}-RELEASE.tar.gz"
 CHKSUMS="sha256::856c9ffcf2ab2bbb28a6e0fa344277fc41aa0771419b283c7c4db69dad2b4cf9"
 CHKUPDATE="anitya::id=148807"


### PR DESCRIPTION
Topic Description
-----------------

This topic fixes `libdispatch` build by dropping the `-Werror` flag.

Package(s) Affected
-------------------

`libdispatch` v5.6.1-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`