### PR TITLE
minetest: (riscv64) use lua (no luajit support)

### DIFF
--- a/app-games/minetest/autobuild/defines
+++ b/app-games/minetest/autobuild/defines
@@ -2,8 +2,10 @@ PKGNAME=minetest
 PKGDES="A sandbox game inspired by Minecraft"
 PKGSEC=games
 PKGDEP="openal-soft libvorbis libogg luajit zstd"
+# FIXME: LuaJIT not available on these architectures.
 PKGDEP__PPC64="${PKGDEP/luajit/lua}"
 PKGDEP__PPC64EL="${PKGDEP/luajit/lua}"
+PKGDEP__RISCV64="${PKGDEP/luajit/lua}"
 BUILDDEP="doxygen graphviz leveldb postgresql sqlite"
 
 CMAKE_AFTER="-DBUILD_BENCHMARKS=OFF \


### PR DESCRIPTION
Topic Description
-----------------

This topic enables Minetest to build on RISC-V, using Lua over LuaJIT, which is not yet ported to this architecture.

Package(s) Affected
-------------------

No version change.

Security Update?
----------------

No

Test Build(s) Done
------------------

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] RISC-V 64-bit `riscv64`
