### PR TITLE
fwupd: add flashrom dep; gi-docgen build dep

### DIFF
--- a/app-admin/flashrom/autobuild/defines
+++ b/app-admin/flashrom/autobuild/defines
@@ -12,3 +12,7 @@ MESON_AFTER__LOONGSON3=" \
 MESON_AFTER__PPC64EL=" \
              ${MESON_AFTER} \
              -Dpciutils=false"
+
+# Note: To handle misbundling of flashrom files in fwupd.
+PKGBREAK="fwupd<=1.8.14"
+PKGREP="fwupd<=1.8.14"

--- a/app-admin/flashrom/spec
+++ b/app-admin/flashrom/spec
@@ -1,5 +1,5 @@
 VER=1.2
-REL=1
+REL=2
 SRCS="tbl::https://download.flashrom.org/releases/flashrom-v$VER.tar.bz2"
 CHKSUMS="sha256::e1f8d95881f5a4365dfe58776ce821dfcee0f138f75d0f44f8a3cd032d9ea42b"
 CHKUPDATE="anitya::id=10202"

--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -4,10 +4,10 @@ PKGDEP="appstream-glib colord dbus efivar elfutils gcab glib gnutls \
         gpgme json-glib libarchive libgpg-error libgudev libgusb libsoup \
         libxmlb modemmanager pango pillow polkit pycairo pygobject-3 python-3 \
         shared-mime-info sqlite systemd tpm2-tss libjcat protobuf-c libftdi"
-PKGDEP__AMD64="${PKGDEP} libsmbios thunderbolt-software-user-space"
+PKGDEP__AMD64="${PKGDEP} flashrom libsmbios thunderbolt-software-user-space"
 BUILDDEP="docbook-sgml gobject-introspection gtk-doc intltool meson \
           ninja pkg-config vala valgrind cairo dejavu-fonts fontconfig \
-          freetype gnu-efi markdown jinja2 toml typogrify pefile"
+          freetype gnu-efi markdown jinja2 toml typogrify pefile gi-docgen"
 BUILDDEP__LOONGSON3="${BUILDDEP/gnu-efi/}"
 BUILDDEP__PPC64EL="${BUILDDEP/gnu-efi/}"
 # FIXME: Valgrind is not yet available for RISC-V.

--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,5 @@
 VER=1.8.14
+REL=1
 SRCS="https://github.com/hughsie/fwupd/archive/$VER.tar.gz"
 CHKSUMS="sha256::02d31bbfb70219d2b86d5fba216f6dbaba89fac4cfc79508cece6cb79ec1d0dc"
 CHKUPDATE="anitya::id=5833"


### PR DESCRIPTION
Topic Description
-----------------

This topic fixes an issue where files from `flashrom` and `gi-docgen` gets bundled in the `fwupd` package, resulting in file conflicts.

Package(s) Affected
-------------------

`fwupd` v1.8.14-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
