### PR TITLE
Solaar survey 20230501

### DIFF
--- a/app-utils/solaar/autobuild/prepare
+++ b/app-utils/solaar/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Building localization files ..."
+"$SRCDIR"/tools/po-compile.sh

--- a/app-utils/solaar/spec
+++ b/app-utils/solaar/spec
@@ -1,4 +1,4 @@
-VER=1.1.3
-SRCS="https://github.com/pwr-Solaar/Solaar/archive/refs/tags/${VER}.tar.gz"
-CHKSUMS="sha256::780fc518a64cef94fc9b47bc537d36477168fd1e5d8d350814c4f31d6e741fd4"
+VER=1.1.9
+SRCS="git::commit=tags/$VER::https://github.com/pwr-Solaar/Solaar.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11338"

--- a/lang-python/pyudev/autobuild/defines
+++ b/lang-python/pyudev/autobuild/defines
@@ -5,3 +5,4 @@ PKGDES="A pure Python binding for libudev"
 
 ABHOST=noarch
 ABTYPE=python
+NOPYTHON2=1

--- a/lang-python/pyudev/spec
+++ b/lang-python/pyudev/spec
@@ -1,4 +1,4 @@
-VER=0.22
-SRCS="tbl::https://github.com/pyudev/pyudev/archive/v$VER.tar.gz"
-CHKSUMS="sha256::245b5717923bed83993cd50761c3f8f1a1a68e2cd09031adbd30beed4dc60077"
+VER=0.24.1
+SRCS="git::commit=tags/v$VER::https://github.com/pyudev/pyudev.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8485"

--- a/lang-python/six/spec
+++ b/lang-python/six/spec
@@ -1,5 +1,4 @@
-VER=1.12.0
-REL=3
+VER=1.16.0
 SRCS="tbl::https://pypi.io/packages/source/s/six/six-$VER.tar.gz"
-CHKSUMS="sha256::d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+CHKSUMS="sha256::1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
 CHKUPDATE="anitya::id=4027"


### PR DESCRIPTION
Topic Description
-----------------

Update `solaar`, its dependency `pyudev`, and its dependency's dependency `six`.

Package(s) Affected
-------------------

- `six`
- `pyudev`
- `solaar`

Security Update?
----------------

No

Build Order
-----------

Please describe in what order maintainers should build this pull request.

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

<!-- TODO: CI to auto-fill architectural progress. -->
