### PR TITLE
Pipewire survey 20230501

### DIFF
--- a/app-doc/sphinx/autobuild/defines
+++ b/app-doc/sphinx/autobuild/defines
@@ -1,14 +1,14 @@
 PKGNAME=sphinx
 PKGSEC=python
 PKGDEP="alabaster babel docutils jinja2 pygments six snowballstemmer \
-        sphinx-rtd-theme imagesize requests pytz packaging \
+        sphinx-rtd-theme imagesize requests packaging \
         sphinxcontrib-applehelp sphinxcontrib-devhelp \
         sphinxcontrib-htmlhelp sphinxcontrib-jsmath sphinxcontrib-qthelp \
         sphinxcontrib-serializinghtml sphinxcontrib-websupport"
 PKGSUG="texlive"
-BUILDDEP="setuptools"
+BUILDDEP="python-build python-installer wheel"
 PKGDES="Python documentation generator"
 
 ABHOST=noarch
-ABTYPE=python
+ABTYPE=pep517
 NOPYTHON2=1

--- a/app-doc/sphinx/spec
+++ b/app-doc/sphinx/spec
@@ -1,4 +1,4 @@
-VER=4.2.0
+VER=6.2.1
 SRCS="tbl::https://pypi.io/packages/source/S/Sphinx/Sphinx-$VER.tar.gz"
-CHKSUMS="sha256::94078db9184491e15bce0a56d9186e0aec95f16ac20b12d00e06d4e36f1058a6"
+CHKSUMS="sha256::6d56a34697bb749ffa0152feafc4b19836c755d90a7c59b72bc7dfd371b9cc6b"
 CHKUPDATE="anitya::id=4031"

--- a/app-multimedia/pipewire/autobuild/defines
+++ b/app-multimedia/pipewire/autobuild/defines
@@ -17,19 +17,22 @@ BUILDDEP="avahi doxygen docutils graphviz meson ninja pulseaudio sdl2 sphinx"
 # Must specify ABTYPE here because PipeWire owns Makefiles in the source root
 # to make building fairly straightforward as they say
 ABTYPE=meson
-MESON_AFTER="-Ddocs=enabled \
-             -Dman=enabled \
-             -Dgstreamer=enabled \
-             -Dsystemd=enabled \
-             -Dgstreamer-device-provider=disabled \
-             -Djack-devel=false \
-             -Dsdl2=disabled \
-             -Daudiotestsrc=disabled \
-             -Dvideotestsrc=disabled \
-             -Dvolume=disabled \
-             -Dbluez5-codec-aptx=enabled \
-             -Droc=disabled \
-             -Dsession-managers=[] \
-             -Dvulkan=enabled \
-             -Dffmpeg=enabled \
-             -Dudevrulesdir=$LIBDIR/udev/rules.d"
+MESON_AFTER=(
+    -Ddocs=enabled
+    -Dman=enabled
+    -Dgstreamer=enabled
+    -Dsystemd=enabled
+    -Dgstreamer-device-provider=disabled
+    -Djack-devel=false
+    -Dsdl2=disabled
+    -Daudiotestsrc=disabled
+    -Dvideotestsrc=disabled
+    -Dvolume=disabled
+    -Dbluez5-codec-aptx=enabled
+    -Droc=disabled
+    '-Dsession-managers=[]'
+    -Dvulkan=enabled
+    -Dffmpeg=enabled
+    -Dudevrulesdir="$LIBDIR"/udev/rules.d
+    -Drlimits-install=false
+)

--- a/app-multimedia/pipewire/autobuild/defines
+++ b/app-multimedia/pipewire/autobuild/defines
@@ -11,7 +11,7 @@ PKGDEP__AMD64="${PKGDEP__NONPPC64EL}"
 PKGDEP__ARM64="${PKGDEP__NONPPC64EL}"
 PKGDEP__LOONGSON3="${PKGDEP__NONPPC64EL}"
 
-BUILDDEP="avahi doxygen docutils graphviz meson ninja pulseaudio sdl2"
+BUILDDEP="avahi doxygen docutils graphviz meson ninja pulseaudio sdl2 sphinx"
 
 # Must specify ABTYPE here because PipeWire owns Makefiles in the source root
 # to make building fairly straightforward as they say

--- a/app-multimedia/pipewire/autobuild/defines
+++ b/app-multimedia/pipewire/autobuild/defines
@@ -4,13 +4,7 @@ PKGDES="Server and user space API to deal with multimedia pipelines"
 PKGDEP="alsa-lib bluez dbus ffmpeg gstreamer-1-0 gst-plugins-base-1-0 \
         libcanberra libfdk-aac libldac libfreeaptx libsndfile libusb libva \
         lilv ncurses readline rtkit sbc systemd v4l-utils vulkan \
-        webrtc-audio-processing wireplumber"
-PKGDEP__PPC64EL="${PKGDEP}"
-
-PKGDEP__NONPPC64EL="${PKGDEP} libcamera"
-PKGDEP__AMD64="${PKGDEP__NONPPC64EL}"
-PKGDEP__ARM64="${PKGDEP__NONPPC64EL}"
-PKGDEP__LOONGSON3="${PKGDEP__NONPPC64EL}"
+        webrtc-audio-processing libcamera wireplumber"
 
 BUILDDEP="avahi doxygen docutils graphviz meson ninja pulseaudio sdl2 sphinx"
 

--- a/app-multimedia/pipewire/autobuild/defines.stage2
+++ b/app-multimedia/pipewire/autobuild/defines.stage2
@@ -4,7 +4,7 @@ PKGDES="Server and user space API to deal with multimedia pipelines"
 PKGDEP="alsa-lib bluez dbus ffmpeg gstreamer-1-0 gst-plugins-base-1-0 \
         libcanberra libfdk-aac libldac libfreeaptx libsndfile libusb libva \
         lilv ncurses readline rtkit sbc systemd v4l-utils vulkan \
-        webrtc-audio-processing wireplumber"
+        webrtc-audio-processing"
 PKGDEP__PPC64EL="${PKGDEP}"
 
 PKGDEP__NONPPC64EL="${PKGDEP} libcamera"

--- a/app-multimedia/pipewire/autobuild/defines.stage2
+++ b/app-multimedia/pipewire/autobuild/defines.stage2
@@ -17,19 +17,22 @@ BUILDDEP="avahi doxygen docutils graphviz meson ninja pulseaudio sdl2 sphinx"
 # Must specify ABTYPE here because PipeWire owns Makefiles in the source root
 # to make building fairly straightforward as they say
 ABTYPE=meson
-MESON_AFTER="-Ddocs=enabled \
-             -Dman=enabled \
-             -Dgstreamer=enabled \
-             -Dsystemd=enabled \
-             -Dgstreamer-device-provider=disabled \
-             -Djack-devel=false \
-             -Dsdl2=disabled \
-             -Daudiotestsrc=disabled \
-             -Dvideotestsrc=disabled \
-             -Dvolume=disabled \
-             -Dbluez5-codec-aptx=enabled \
-             -Droc=disabled \
-             -Dsession-managers=[] \
-             -Dvulkan=enabled \
-             -Dffmpeg=enabled \
-             -Dudevrulesdir=$LIBDIR/udev/rules.d"
+MESON_AFTER=(
+    -Ddocs=enabled
+    -Dman=enabled
+    -Dgstreamer=enabled
+    -Dsystemd=enabled
+    -Dgstreamer-device-provider=disabled
+    -Djack-devel=false
+    -Dsdl2=disabled
+    -Daudiotestsrc=disabled
+    -Dvideotestsrc=disabled
+    -Dvolume=disabled
+    -Dbluez5-codec-aptx=enabled
+    -Droc=disabled
+    '-Dsession-managers=[]'
+    -Dvulkan=enabled
+    -Dffmpeg=enabled
+    -Dudevrulesdir="$LIBDIR"/udev/rules.d
+    -Drlimits-install=false
+)

--- a/app-multimedia/pipewire/autobuild/defines.stage2
+++ b/app-multimedia/pipewire/autobuild/defines.stage2
@@ -4,13 +4,7 @@ PKGDES="Server and user space API to deal with multimedia pipelines"
 PKGDEP="alsa-lib bluez dbus ffmpeg gstreamer-1-0 gst-plugins-base-1-0 \
         libcanberra libfdk-aac libldac libfreeaptx libsndfile libusb libva \
         lilv ncurses readline rtkit sbc systemd v4l-utils vulkan \
-        webrtc-audio-processing"
-PKGDEP__PPC64EL="${PKGDEP}"
-
-PKGDEP__NONPPC64EL="${PKGDEP} libcamera"
-PKGDEP__AMD64="${PKGDEP__NONPPC64EL}"
-PKGDEP__ARM64="${PKGDEP__NONPPC64EL}"
-PKGDEP__LOONGSON3="${PKGDEP__NONPPC64EL}"
+        webrtc-audio-processing libcamera"
 
 BUILDDEP="avahi doxygen docutils graphviz meson ninja pulseaudio sdl2 sphinx"
 

--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,4 +1,4 @@
-VER=0.3.51
+VER=0.3.70
 SRCS="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/$VER/pipewire-$VER.tar.gz"
-CHKSUMS="sha256::f18e7a2cd2fcd75482c3df4e736e01435bd20779ddf63da63b0a086d3a9735ac"
+CHKSUMS="sha256::e9a86d592dea6ee28c67b82c17bd6ba10afd1c880decfcf4b3e7c5421f146d38"
 CHKUPDATE="anitya::id=57357"

--- a/app-multimedia/wireplumber/autobuild/defines
+++ b/app-multimedia/wireplumber/autobuild/defines
@@ -2,11 +2,12 @@ PKGNAME=wireplumber
 PKGSEC=sound
 PKGDES="A modular session/policy manager for PipeWire"
 PKGDEP="glib pipewire lua-5.3 systemd"
-BUILDDEP="meson lua-5.3 gobject-introspection lxml doxygen"
+BUILDDEP="meson gobject-introspection lxml doxygen sphinx \
+          sphinx-rtd-theme breathe"
 
 ABTYPE=meson
 MESON_AFTER="-Dsystem-lua=true \
-             -Ddoc=disabled \
+             -Ddoc=enabled \
              -Dsystemd=enabled \
              -Dsystemd-user-service=true \
              -Dintrospection=enabled \

--- a/app-multimedia/wireplumber/spec
+++ b/app-multimedia/wireplumber/spec
@@ -1,4 +1,4 @@
-VER=0.4.10
+VER=0.4.14
 SRCS="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${VER}/wireplumber-${VER}.tar.bz2"
-CHKSUMS="sha256::f96315f1b6b2fa8e837803d7e90932dcae640d239cd867624a78f9cc5511b488"
+CHKSUMS="sha256::558aca3b6a8f6fc6219567caafecd295913a5ad30b480fa112d9feaba85efdef"
 CHKUPDATE="anitya::id=235056"

--- a/runtime-devices/libcamera/autobuild/beyond
+++ b/runtime-devices/libcamera/autobuild/beyond
@@ -1,4 +1,4 @@
-// No IPA modules are installed on architecures other than amd64 and arm64 by default
+# No IPA modules are installed on architecures other than amd64 and arm64 by default
 if [[ -e "$PKGDIR"/usr/lib/libcamera ]]; then
     abinfo 'Fixing permissions problem for signed IPA modules ...'
     find "$PKGDIR"/usr/lib/libcamera -type f -exec chmod -v 755 {} +

--- a/runtime-devices/libcamera/autobuild/beyond
+++ b/runtime-devices/libcamera/autobuild/beyond
@@ -1,3 +1,4 @@
+// No IPA modules are installed on architecures other than amd64 and arm64 by default
 if [[ -e "$PKGDIR"/usr/lib/libcamera ]]; then
     abinfo 'Fixing permissions problem for signed IPA modules ...'
     find "$PKGDIR"/usr/lib/libcamera -type f -exec chmod -v 755 {} +

--- a/runtime-devices/libcamera/autobuild/beyond
+++ b/runtime-devices/libcamera/autobuild/beyond
@@ -1,4 +1,4 @@
-# No IPA modules are installed on architecures other than amd64 and arm64 by default
+# No IPA modules are installed on architectures other than amd64 and arm64 by default
 if [[ -e "$PKGDIR"/usr/lib/libcamera ]]; then
     abinfo 'Fixing permissions problem for signed IPA modules ...'
     find "$PKGDIR"/usr/lib/libcamera -type f -exec chmod -v 755 {} +

--- a/runtime-devices/libcamera/autobuild/beyond
+++ b/runtime-devices/libcamera/autobuild/beyond
@@ -1,2 +1,4 @@
-abinfo 'Fixing permissions problem for signed IPA modules ...'
-find "$PKGDIR"/usr/lib/libcamera -type f -exec chmod -v 755 {} +
+if [[ -e "$PKGDIR"/usr/lib/libcamera ]]; then
+    abinfo 'Fixing permissions problem for signed IPA modules ...'
+    find "$PKGDIR"/usr/lib/libcamera -type f -exec chmod -v 755 {} +
+fi

--- a/runtime-devices/libcamera/autobuild/defines
+++ b/runtime-devices/libcamera/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=libs
 PKGDES="A cross-platform camera support library"
 BUILDDEP="boost doxygen gnutls gstreamer-1-0 gtest jinja2 ply libevent libtiff \
           libdwarf lttng-ust meson ninja openssl pyyaml qt-5 sphinx systemd \
-          texlive"
+          texlive yaml"
 
 # qcam and cam will crash with LTO,
 # see https://bugs.libcamera.org/show_bug.cgi?id=83

--- a/runtime-devices/libcamera/autobuild/defines
+++ b/runtime-devices/libcamera/autobuild/defines
@@ -9,6 +9,3 @@ BUILDDEP="boost doxygen gnutls gstreamer-1-0 gtest jinja2 ply libevent libtiff \
 # see https://bugs.libcamera.org/show_bug.cgi?id=83
 NOLTO=1
 MESON_AFTER="-Dv4l2=true"
-
-# Fail to build on ppc64el due to problems with double ABI
-FAIL_ARCH="!(amd64|arm64|loongson3)"

--- a/runtime-devices/libcamera/autobuild/defines
+++ b/runtime-devices/libcamera/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=libs
 PKGDES="A cross-platform camera support library"
 BUILDDEP="boost doxygen gnutls gstreamer-1-0 gtest jinja2 ply libevent libtiff \
           libdwarf lttng-ust meson ninja openssl pyyaml qt-5 sphinx systemd \
-          texlive yaml"
+          texlive yaml graphviz"
 
 # qcam and cam will crash with LTO,
 # see https://bugs.libcamera.org/show_bug.cgi?id=83

--- a/runtime-devices/libcamera/spec
+++ b/runtime-devices/libcamera/spec
@@ -1,5 +1,4 @@
-VER=0+git20220510
-SRCS="git::commit=226563607ea888c0af49bf3cdc7b3654d6a50089::https://git.libcamera.org/libcamera/libcamera.git"
+VER=0.0.5
+SRCS="git::commit=tags/v${VER}::https://git.libcamera.org/libcamera/libcamera.git"
 CHKSUMS="SKIP"
-CHKUPDATE="git::url=https://git.libcamera.org/libcamera/libcamera.git"
-REL=1
+CHKUPDATE="anitya::id=301902"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Update pipewire-related packages

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`pipewire` 0.3.70
`wireplumber` 0.4.14
`sphinx` 6.2.1
`libcamera` 0.0.5

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

```
sphinx libcamera
(stage2) pipewire
wireplumber pipewire
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
