### PR TITLE
topgrade: add new package

### DIFF
--- a/app-admin/topgrade/autobuild/defines
+++ b/app-admin/topgrade/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=topgrade
+PKGDES="A package manager invoker to upgrade multiple packages with one command" 
+BUILDDEP="rustc llvm"
+PKGSEC="utils"
+
+USECLANG=1
+ABSPLITDBG=0
+
+# FIXME: Signal 11 on linkage.
+USECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1
+ABSPLITDBG__LOONGSON3=0
+NOLTO__MIPS64R6EL=1
+USECLANG__MIPS64R6EL=0
+# FIXME: ld.lld: error: lto.tmp: cannot link object files with different floating-point ABI
+NOLTO__RISCV64=1

--- a/app-admin/topgrade/autobuild/patches/0001-disable-firmware-and-apt-updates.patch
+++ b/app-admin/topgrade/autobuild/patches/0001-disable-firmware-and-apt-updates.patch
@@ -1,0 +1,74 @@
+diff --git a/src/main.rs b/src/main.rs
+index 8ffd39c..1401d30 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -180,22 +180,24 @@ For more information about this issue see https://askubuntu.com/questions/110969
+     #[cfg(target_os = "linux")]
+     let distribution = linux::Distribution::detect();
+ 
+-    #[cfg(target_os = r#"linux"#)]
+-    {
+-        match &distribution {
+-            Ok(distribution) => {
+-                runner.execute(Step::System, "System update", || distribution.upgrade(&ctx))?;
+-            }
+-            Err(e) => {
+-                println!("Error detecting current distribution: {e}");
+-            }
+-        }
+-        runner.execute(Step::ConfigUpdate, "config-update", || linux::run_config_update(&ctx))?;
+-
+-        runner.execute(Step::BrewFormula, "Brew", || {
+-            unix::run_brew_formula(&ctx, unix::BrewVariant::Path)
+-        })?;
+-    }
++    // Lines below are for system upgrades
++    // Commented out because it may be a bit too aggressive
++    // #[cfg(target_os = r#"linux"#)]
++    // {
++    //     match &distribution {
++    //         Ok(distribution) => {
++    //             runner.execute(Step::System, "System update", || distribution.upgrade(&ctx))?;
++    //         }
++    //         Err(e) => {
++    //             println!("Error detecting current distribution: {e}");
++    //         }
++    //     }
++    //     runner.execute(Step::ConfigUpdate, "config-update", || linux::run_config_update(&ctx))?;
++
++    //     runner.execute(Step::BrewFormula, "Brew", || {
++    //         unix::run_brew_formula(&ctx, unix::BrewVariant::Path)
++    //     })?;
++    // }
+ 
+     #[cfg(windows)]
+     {
+@@ -439,16 +441,18 @@ For more information about this issue see https://askubuntu.com/questions/110969
+         }
+     }
+ 
+-    #[cfg(target_os = "linux")]
+-    {
+-        runner.execute(Step::System, "pihole", || {
+-            linux::run_pihole_update(ctx.sudo().as_ref(), run_type)
+-        })?;
+-        runner.execute(Step::Firmware, "Firmware upgrades", || linux::run_fwupdmgr(&ctx))?;
+-        runner.execute(Step::Restarts, "Restarts", || {
+-            linux::run_needrestart(ctx.sudo().as_ref(), run_type)
+-        })?;
+-    }
++    // Lines below are for firmware upgrades
++    // Commented out because it may be a bit too aggressive
++    // #[cfg(target_os = "linux")]
++    // {
++    //     runner.execute(Step::System, "pihole", || {
++    //         linux::run_pihole_update(ctx.sudo().as_ref(), run_type)
++    //     })?;
++    //     runner.execute(Step::Firmware, "Firmware upgrades", || linux::run_fwupdmgr(&ctx))?;
++    //     runner.execute(Step::Restarts, "Restarts", || {
++    //         linux::run_needrestart(ctx.sudo().as_ref(), run_type)
++    //     })?;
++    // }
+ 
+     #[cfg(target_os = "macos")]
+     {

--- a/app-admin/topgrade/spec
+++ b/app-admin/topgrade/spec
@@ -1,0 +1,4 @@
+VER=11.0.2
+SRCS="tbl::https://github.com/topgrade-rs/topgrade/archive/refs/tags/v$VER.tar.gz"
+CHKSUMS="sha256::29cd1d870dafbfa46d07c4056ba229a98755660a2e37804f12e1507fdde7d237"
+CHKUPDATE="anitya::id=344703"


### PR DESCRIPTION

<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
topgrade: add new package
- `apt` / `fwupt` support has been disabled
  - It may be a bit too aggressive
  - Users may accidentally cause damage to the system environment due to misoperations

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

```
pkg1 pkg2 pkg3 ...
```

-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
