### PR TITLE
mpv: restore .desktop, add dependencies

### DIFF
--- a/app-multimedia/mpv/autobuild/build
+++ b/app-multimedia/mpv/autobuild/build
@@ -1,3 +1,32 @@
+# Common options
+__WAF_COMMON=(
+	--prefix=/usr
+	--confdir=/etc/mpv
+	--enable-libmpv-shared
+	--enable-cdda
+	--disable-vapoursynth
+	--disable-build-date
+	--enable-libarchive
+)
+# Reduced functionality for retro and such
+__WAF_REDUCED=(
+	--disable-dvbin
+	--disable-openal
+	--disable-sdl2
+	--disable-pipewire
+)
+# Standard feature set for all others
+__WAF_STANDARD=(
+	--enable-dvbin
+	--enable-openal
+	--enable-sdl2
+	--enable-pipewire
+)
+__WAF_LOONGSON3=(
+	--disable-shaderc
+)
+
+
 abinfo "Configuring..."
 if [[ "${CROSS:-$ARCH}" != "armv4" && \
       "${CROSS:-$ARCH}" != "armv6hf" && \
@@ -6,29 +35,13 @@ if [[ "${CROSS:-$ARCH}" != "armv4" && \
       "${CROSS:-$ARCH}" != "loongson2f" && \
       "${CROSS:-$ARCH}" != "powerpc" && \
       "${CROSS:-$ARCH}" != "ppc64" ]]; then
-    "$SRCDIR"/waf \
-        configure --prefix=/usr \
-            --confdir=/etc/mpv \
-            --enable-libmpv-shared \
-            --enable-cdda \
-            --disable-vapoursynth \
-            --enable-dvbin \
-            --enable-openal \
-            --enable-sdl2 \
-            --enable-libarchive \
-            --disable-build-date
+    if [[ "${CROSS:-$ARCH}" == "loongson3" ]]; then
+        "$SRCDIR"/waf configure "${__WAF_COMMON[@]}" "${__WAF_STANDARD[@]}" "${__WAF_LOONGSON3[@]}"
+    else
+        "$SRCDIR"/waf configure "${__WAF_COMMON[@]}" "${__WAF_STANDARD[@]}"
+    fi
 else
-    "$SRCDIR"/waf \
-        configure --prefix=/usr \
-            --confdir=/etc/mpv \
-            --enable-libmpv-shared \
-            --enable-cdda \
-            --disable-vapoursynth \
-            --disable-dvbin \
-            --disable-openal \
-            --disable-sdl2 \
-            --enable-libarchive \
-            --disable-build-date
+    "$SRCDIR"/waf configure "${__WAF_COMMON[@]}" "${__WAF_REDUCED[@]}"
 fi
 
 abinfo "Building..."
@@ -45,5 +58,7 @@ install -vm644 "$SRCDIR"/etc/mpv.conf "$PKGDIR"/etc/mpv/mpv.conf
 install -vm644 "$SRCDIR"/DOCS/{encoding.rst,tech-overview.txt} \
               "$PKGDIR"/usr/share/doc/mpv
 
-abinfo "Removing .desktop entry(s) to avoid confusion ..."
-rm -rv "$PKGDIR"/usr/share/applications
+abinfo "Hiding .desktop entry from application menu..."
+for i in "$PKGDIR"/usr/share/applications/*; do
+	echo "NoDisplay=true" >> $i
+done

--- a/app-multimedia/mpv/autobuild/defines
+++ b/app-multimedia/mpv/autobuild/defines
@@ -3,9 +3,8 @@ PKGSEC=video
 PKGDEP="ffmpeg lcms2 mesa enca wayland desktop-file-utils hicolor-icon-theme \
         xdg-utils lua libdvdnav jack openjpeg-legacy libvdpau libcdio-paranoia \
         libguess samba libva libcaca uchardet rubberband youtube-dl libcdio \
-        libdvbpsi openal-soft sdl2 vulkan libarchive"
-PKGSUG="libva-vdpau-driver"
-PKGSUG__AMD64="${PKGSUG} libva-intel-driver"
+        libdvbpsi openal-soft sdl2 vulkan libarchive pipewire shaderc"
+PKGDEP__LOONGSON3="${PKGDEP//shaderc/}"
 PKGDEP__RETRO="ffmpeg lcms2 mesa enca desktop-file-utils hicolor-icon-theme \
         xdg-utils lua libdvdnav openjpeg-legacy libvdpau libcdio-paranoia \
         libguess samba libva libcaca uchardet youtube-dl libcdio libarchive"
@@ -28,6 +27,8 @@ BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
 BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
+PKGSUG="libva-vdpau-driver"
+PKGSUG__AMD64="${PKGSUG} libva-intel-driver"
 PKGDES="Video player based on MPlayer/mplayer2"
 
 PKGBREAK="celluloid<=0.18-1 haruna<=0.9.1 minitube<=3.9.3-1"

--- a/app-multimedia/mpv/spec
+++ b/app-multimedia/mpv/spec
@@ -1,4 +1,5 @@
 VER=0.35.1
+REL=1
 SRCS="tbl::https://github.com/mpv-player/mpv/archive/v$VER.tar.gz"
 CHKSUMS="sha256::41df981b7b84e33a2ef4478aaf81d6f4f5c8b9cd2c0d337ac142fc20b387d1a9"
 CHKUPDATE="anitya::id=5348"


### PR DESCRIPTION
Topic Description
-----------------

This PR brings back .desktop entries for mpv so that direct playback with mpv from GUI file managers are again possible.

Package(s) Affected
-------------------

mpv

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
