### PR TITLE
MusicBrainz Picard 2.8.5

### DIFF
--- a/app-multimedia/mutagen/spec
+++ b/app-multimedia/mutagen/spec
@@ -1,5 +1,4 @@
-VER=1.45.1
+VER=1.46.0
 SRCS="tbl::https://pypi.io/packages/source/m/mutagen/mutagen-$VER.tar.gz"
-CHKSUMS="sha256::6397602efb3c2d7baebd2166ed85731ae1c1d475abca22090b7141ff5034b3e1"
+CHKSUMS="sha256::6e5f8ba84836b99fe60be5fb27f84be4ad919bbb6b49caa6ae81e70584b55e58"
 CHKUPDATE="anitya::id=3931"
-REL=1

--- a/app-multimedia/picard/spec
+++ b/app-multimedia/picard/spec
@@ -1,4 +1,4 @@
-VER=2.6.4
+VER=2.8.5
 SRCTBL="https://github.com/metabrainz/picard/archive/release-${VER}.tar.gz"
-CHKSUM="sha256::c71ec4605842e24bbe6d92639e1cafac943548afed3a05193488d4bcc3d95370"
+CHKSUM="sha256::b1c1f76d5fe92cb481f4362142c6a84f1cf45948e42cfd7c3d3beffd703c54ce"
 CHKUPDATE="anitya::id=3633"

--- a/lang-python/dateutil/spec
+++ b/lang-python/dateutil/spec
@@ -1,5 +1,4 @@
-VER=2.7.3
-REL=3
+VER=2.8.2
 SRCS="tbl::https://files.pythonhosted.org/packages/source/p/python-dateutil/python-dateutil-$VER.tar.gz"
-CHKSUMS="sha256::e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+CHKSUMS="sha256::0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
 CHKUPDATE="anitya::id=5621"

--- a/lang-python/fasteners/autobuild/defines
+++ b/lang-python/fasteners/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=fasteners
 PKGSEC=libs
 PKGDES="A python package that provides useful locks."
 PKGDEP="six monotonic"
+BUILDDEP="python-build python-installer wheel"
 
-ABTYPE=python
 ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/fasteners/spec
+++ b/lang-python/fasteners/spec
@@ -1,4 +1,4 @@
-VER=0.16.3
+VER=0.18
 SRCS="tbl::https://github.com/harlowja/fasteners/archive/${VER}.tar.gz"
-CHKSUMS="sha256::76db20e2709151a3b689a9e571f4d65f60880812972f89c24a13640937ca11c7"
+CHKSUMS="sha256::7e2675f3baf4e334e4dcd051c998ca127da538dddd435d2dc4ba014f5f586b4b"
 CHKUPDATE="anitya::id=209388"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates picard and its dependencies to latest versions...

Package(s) Affected
-------------------

- mutagen
- dateutil
- fasteners
- picard


Build Order
-----------

```
mutagen dateutil fasteners (noarch)
picard
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
