### PR TITLE
fio: new, 3.34

### DIFF
--- a/app-benchmarks/fio/autobuild/build
+++ b/app-benchmarks/fio/autobuild/build
@@ -1,0 +1,11 @@
+abinfo "Configuring $PKGNAME ..."
+"$SRCDIR"/configure \
+    --prefix=/usr 
+
+abinfo "Building $PKGNAME ..."
+make 
+
+abinfo "Installing $PKGNAME ..."
+make install \
+    DESTDIR="$PKGDIR" \
+    mandir=/usr/share/man 

--- a/app-benchmarks/fio/autobuild/defines
+++ b/app-benchmarks/fio/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=fio
+PKGSEC=utils
+PKGDEP="gcc-runtime"
+BUILDDEP="gcc"
+PKGDES="An I/O tester and benchmark tool that is used to simulate various I/O workloads"

--- a/app-benchmarks/fio/spec
+++ b/app-benchmarks/fio/spec
@@ -1,0 +1,4 @@
+VER=3.34
+SRCS="tbl::https://github.com/axboe/fio/archive/refs/tags/fio-$VER.tar.gz"
+CHKSUMS="sha256::42ea28c78d269c4cc111b7516213f4d4b32986797a710b0ff364232cc7a3a0b7"
+CHKUPDATE="anitya::id=806"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

newpkg: fio-3.34

fio is a flexible I/O tester 


Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

```
pkg1 pkg2 pkg3 ...
```

-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
