### PR TITLE
autobuild3: add config dep

### DIFF
--- a/app-devel/autobuild3/autobuild/defines
+++ b/app-devel/autobuild3/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=autobuild3
 PKGSEC=devel
-PKGDEP="dpkg bash apt coreutils autoconf automake \
-        spdx-licenses autoconf-archive"
+PKGDEP="autoconf autoconf-archive automake apt dpkg bash config coreutils \
+        spdx-licenses"
 PKGRECOM="cargo-audit"
 PKGDES="Multi-backend and extensible packaging toolkit"
 

--- a/app-devel/autobuild3/spec
+++ b/app-devel/autobuild3/spec
@@ -1,4 +1,5 @@
 VER=1.6.88
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"


### PR DESCRIPTION
Topic Description
-----------------

This topic reworks Autobuild3 v1.6.88 update to add missing `config` dep.

Package(s) Affected
-------------------

`autobuild3` v1.6.88-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`