### PR TITLE
dracut: add isomd5sum dep

### DIFF
--- a/app-admin/dracut/autobuild/defines
+++ b/app-admin/dracut/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=dracut
 PKGSEC=utils
-PKGDEP="arping coreutils cpio gawk kbd kmod nfs-utils util-linux systemd bash parallel"
-PKGDEP__RETRO="coreutils cpio gawk kbd kmod util-linux systemd bash parallel"
+PKGDEP="arping coreutils cpio gawk kbd kmod nfs-utils util-linux systemd bash \
+        parallel isomd5sum"
+PKGDEP__RETRO=" \
+        coreutils cpio gawk kbd kmod util-linux systemd bash parallel \
+        isomd5sum"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
 PKGDEP__ARMV7HF="${PKGDEP__RETRO}"

--- a/app-admin/dracut/spec
+++ b/app-admin/dracut/spec
@@ -1,4 +1,5 @@
 VER=059
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/dracutdevs/dracut"
 CHKSUMS="sha256::eabf0bb685420c1e1d5475b6855ef787104508f0135ff570312845256e0fcecf"
 CHKUPDATE="anitya::id=10627"

--- a/app-utils/isomd5sum/autobuild/defines
+++ b/app-utils/isomd5sum/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=isomd5sum
+PKGSEC=utils
+PKGDEP="glibc python-3"
+PKGDES="Utilities for working with md5sum implanted in ISO images"
+
+MAKE_AFTER="LIBDIR=lib \
+            PYTHON=/usr/bin/python3"
+NOPARALLEL=1

--- a/app-utils/isomd5sum/spec
+++ b/app-utils/isomd5sum/spec
@@ -1,0 +1,4 @@
+VER=1.2.3
+SRCS="git::commit=tags/$VER::https://github.com/rhinstaller/isomd5sum"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=10547"


### PR DESCRIPTION
Topic Description
-----------------

This topic adds `isomd5sum` dependency to `dracut`, which fixes `rd.image.check` (ISO media test) functionality.

Package(s) Affected
-------------------

- `dracut` v059-1
- `isomd5sum` v1.2.3 (new)

Security Update?
----------------

No

Build Order
-----------

```
isomd5sum dracut
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`