### PR TITLE
dracut: only hide Plymouth splash upon media check failure

### DIFF
--- a/app-admin/dracut/autobuild/patches/0001-dmsquash-live-Do-not-hide-splash-unless-media-check-fails.patch
+++ b/app-admin/dracut/autobuild/patches/0001-dmsquash-live-Do-not-hide-splash-unless-media-check-fails.patch
@@ -1,0 +1,23 @@
+diff -Naur dracut/modules.d/90dmsquash-live/dmsquash-live-root.sh dracut.splash/modules.d/90dmsquash-live/dmsquash-live-root.sh
+--- dracut/modules.d/90dmsquash-live/dmsquash-live-root.sh	2023-05-20 00:46:52.962579493 -0700
++++ dracut.splash/modules.d/90dmsquash-live/dmsquash-live-root.sh	2023-05-20 00:47:25.942142821 -0700
+@@ -67,7 +67,6 @@
+ fi
+ getarg rd.live.check -d check || check=""
+ if [ -n "$check" ]; then
+-    type plymouth > /dev/null 2>&1 && plymouth --hide-splash
+     if [ -n "$DRACUT_SYSTEMD" ]; then
+         p=$(dev_unit_name "$check_dev")
+         systemctl start checkisomd5@"${p}".service
+@@ -75,10 +74,10 @@
+         checkisomd5 --verbose "$check_dev"
+     fi
+     if [ $? -eq 1 ]; then
++        type plymouth > /dev/null 2>&1 && plymouth --hide-splash
+         die "CD check failed!"
+         exit 1
+     fi
+-    type plymouth > /dev/null 2>&1 && plymouth --show-splash
+ fi
+ 
+ ln -s "$livedev" /run/initramfs/livedev

--- a/app-admin/dracut/spec
+++ b/app-admin/dracut/spec
@@ -1,5 +1,5 @@
 VER=059
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/dracutdevs/dracut"
 CHKSUMS="sha256::eabf0bb685420c1e1d5475b6855ef787104508f0135ff570312845256e0fcecf"
 CHKUPDATE="anitya::id=10627"


### PR DESCRIPTION
Topic Description
-----------------

This topic makes dracut only hide Plymouth splash upon media check failure.

Package(s) Affected
-------------------

`dracut` v059-2

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
