### PR TITLE
lxdm: fix dependencies

### DIFF
--- a/desktop-lxde/lxdm/autobuild/defines
+++ b/desktop-lxde/lxdm/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=lxdm
 PKGDES="Lightweight X11 Display Manager"
 PKGSEC=LXDE
 PKGDEP="iso-codes gtk-3 xorg-server"
-PKGDEP="iso-codes gtk-2 xorg-server"
+PKGDEP__RETRO="${PKGDEP/gtk-3/gtk-2}"
 BUILDDEP="intltool"
 
 AUTOTOOLS_AFTER="--with-pam \

--- a/desktop-lxde/lxdm/autobuild/overrides/usr/lib/systemd/system/lxdm.service
+++ b/desktop-lxde/lxdm/autobuild/overrides/usr/lib/systemd/system/lxdm.service
@@ -10,4 +10,3 @@ IgnoreSIGPIPE=no
 
 [Install]
 Alias=display-manager.service
-

--- a/desktop-lxde/lxdm/spec
+++ b/desktop-lxde/lxdm/spec
@@ -1,5 +1,5 @@
 VER=0.5.3
-REL=2retro1
+REL=3
 SRCS="tbl::https://downloads.sourceforge.net/lxdm/lxdm-$VER.tar.xz"
 CHKSUMS="sha256::4891efee81c72a400cc6703e40aa76f3f3853833d048b72ec805da0f93567f2f"
 CHKUPDATE="anitya::id=8662"


### PR DESCRIPTION
Topic Description
-----------------

This topic fixes dependency declarations for `lxdm`.

Package(s) Affected
-------------------

`lxdm` v0.5.3-3

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`