### PR TITLE
vboot-utils: new, 110.15728.B

### DIFF
--- a/app-admin/flashrom/autobuild/defines
+++ b/app-admin/flashrom/autobuild/defines
@@ -1,18 +1,14 @@
 PKGNAME=flashrom
 PKGDES="A utility for identifying, reading, writing, verifying and erasing flash chips"
 PKGDEP="libusb libftdi pciutils libusb-compat"
+BUILDDEP="cmocka"
 PKGSEC=admin
 
-MESON_AFTER__ARM64=" \
-             ${MESON_AFTER} \
-             -Dpciutils=false"
-MESON_AFTER__LOONGSON3=" \
-             ${MESON_AFTER} \
-             -Dpciutils=false"
-MESON_AFTER__PPC64EL=" \
-             ${MESON_AFTER} \
-             -Dpciutils=false"
+ABTYPE=meson
 
 # Note: To handle misbundling of flashrom files in fwupd.
 PKGBREAK="fwupd<=1.8.14"
 PKGREP="fwupd<=1.8.14"
+
+# FIXME: currently a hack for LTO crashing on arm64, needs fixing GCC
+NOLTO__ARM64=1

--- a/app-admin/flashrom/autobuild/prepare
+++ b/app-admin/flashrom/autobuild/prepare
@@ -1,6 +1,0 @@
-abinfo "Adding -Wno-error=deprecated-declarations to fix build ..."
-export CFLAGS="${CFLAGS} -Wno-error=deprecated-declarations"
-
-abinfo "Tweaking Makefile to install binary executables to /usr/bin ..."
-sed -e 's|sbin|bin|g' \
-    -i "$SRCDIR"/Makefile

--- a/app-admin/flashrom/spec
+++ b/app-admin/flashrom/spec
@@ -1,5 +1,4 @@
-VER=1.2
-REL=2
+VER=1.3.0
 SRCS="tbl::https://download.flashrom.org/releases/flashrom-v$VER.tar.bz2"
-CHKSUMS="sha256::e1f8d95881f5a4365dfe58776ce821dfcee0f138f75d0f44f8a3cd032d9ea42b"
+CHKSUMS="sha256::a053234453ccd012e79f3443bdcc61625cf97b7fd7cb4cdd8bfbffbe8b149623"
 CHKUPDATE="anitya::id=10202"

--- a/app-admin/vboot-utils/autobuild/build
+++ b/app-admin/vboot-utils/autobuild/build
@@ -1,0 +1,8 @@
+abinfo "Building ..."
+make ${ABMK}
+
+abinfo "Installing ..."
+make ${ABMK} DESTDIR="$PKGDIR" install
+
+abinfo "Installing extra test keys to developer-signing things ..."
+cp -rv "$SRCDIR"/tests/devkey* "$PKGDIR"/usr/share/vboot/

--- a/app-admin/vboot-utils/autobuild/defines
+++ b/app-admin/vboot-utils/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=vboot-utils
+PKGDES="Utilities to handle ChromeOS Verified Boot"
+PKGDEP="flashrom libzip libarchive openssl"
+PKGSEC=admin
+
+ABTYPE=self
+
+# FIXME: LTO crashes on arm64, the same happens on flashrom, investigation needed
+NOLTO__ARM64=1

--- a/app-admin/vboot-utils/spec
+++ b/app-admin/vboot-utils/spec
@@ -1,0 +1,3 @@
+VER=110.15728.B
+SRCS="git::commit=c4102fe4eef8c0539c03d60c7256fd4bc599bf4a::https://chromium.googlesource.com/chromiumos/platform/vboot_reference"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

Package `vboot-utils`, which are utilities useful for handling signed boot images for DepthCharge bootloader (the ChromeOS bootloader). In addition, as its dependency, flashrom is updated to 1.3.0 (no libflashrom soname change).

Package(s) Affected
-------------------

- `flashrom` (upgraded)
- `vboot-utils` (new)

Security Update?
----------------

No

Build Order
-----------

`flashrom vboot-utils`

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
