### PR TITLE
bash-startup: update to 0.4.7.5

### DIFF
--- a/runtime-data/bash-startup/spec
+++ b/runtime-data/bash-startup/spec
@@ -1,4 +1,4 @@
-VER=0.4.7.4
+VER=0.4.7.5
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226642"


### PR DESCRIPTION


Topic Description
-----------------

This topic updates bash-startup to 0.4.7.5

See also: https://github.com/AOSC-Dev/bash-config/pull/23, which addressed this bugfix.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

bash-startup

Security Update?
----------------

No.

Test Build(s) Done
------------------

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

- [ ] Architecture-independent `noarch`
