### PR TITLE
gc: Update to 8.2.4

### DIFF
--- a/runtime-common/gc/spec
+++ b/runtime-common/gc/spec
@@ -1,4 +1,4 @@
-VER=8.2.2
+VER=8.2.4
 SRCS="tbl::https://github.com/ivmai/bdwgc/releases/download/v$VER/gc-$VER.tar.gz"
-CHKSUMS="sha256::f30107bcb062e0920a790ffffa56d9512348546859364c23a14be264b38836a0"
+CHKSUMS="sha256::3d0d3cdbe077403d3106bb40f0cbb563413d6efdbb2a7e1cd6886595dec48fc2"
 CHKUPDATE="anitya::id=876"

--- a/runtime-common/gc/spec
+++ b/runtime-common/gc/spec
@@ -1,4 +1,4 @@
 VER=8.2.4
-SRCS="tbl::https://github.com/ivmai/bdwgc/releases/download/v$VER/gc-$VER.tar.gz"
-CHKSUMS="sha256::3d0d3cdbe077403d3106bb40f0cbb563413d6efdbb2a7e1cd6886595dec48fc2"
+SRCS="git::commit=tags/v$VER::https://github.com/ivmai/bdwgc.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=876"


### PR DESCRIPTION
Topic Description
-----------------

Update libgc from 8.2.2 to 8.2.4

Package(s) Affected
-------------------

libgc

Security Update?
----------------

No


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

