### PR TITLE
cwm: new, 7.1

### DIFF
--- a/desktop-wm/cwm/autobuild/defines
+++ b/desktop-wm/cwm/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=cwm
+PKGSEC=x11
+PKGDEP="x11-lib"
+PKGDES="An X11 window manager with minimal decoration"

--- a/desktop-wm/cwm/autobuild/overrides/usr/share/xsessions/cwm.desktop
+++ b/desktop-wm/cwm/autobuild/overrides/usr/share/xsessions/cwm.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=CWM
+Comment=An X11 window manager with minimal decoration
+Exec=cwm
+TryExec=cwm
+Type=XSession

--- a/desktop-wm/cwm/spec
+++ b/desktop-wm/cwm/spec
@@ -1,0 +1,4 @@
+VER=7.1
+SRCS="git::commit=tags/v$VER::https://github.com/leahneukirchen/cwm"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=123783"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
A lightweight and efficient window manager for X11

Package(s) Affected
-------------------

cwm

Security Update?
----------------

NO

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
