### PR TITLE
plasma-mobile: revive, 5.27.5

### DIFF
--- a/desktop-kde/kirigami-addons/autobuild/defines
+++ b/desktop-kde/kirigami-addons/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=kirigami-addons
+PKGSEC=kde
+PKGDEP="qt-5 kirigami2 ki18n"
+BUILDDEP="extra-cmake-modules"
+PKGDES="A QtQuick-based component set"
+
+CMAKE_AFTER="-DKDE_INSTALL_USE_QT_SYS_PATHS=yes \
+             -DBUILD_TESTING=OFF \
+             -DBUILD_QCH=OFF"

--- a/desktop-kde/kirigami-addons/spec
+++ b/desktop-kde/kirigami-addons/spec
@@ -1,0 +1,4 @@
+VER=0.8.0
+SRCS="tbl::https://download.kde.org/stable/kirigami-addons/kirigami-addons-${VER}.tar.xz"
+CHKSUMS="sha256::3741a940fa688f53c7d9bdf607b1c6991f6d690e9ce826e8c76794336c594bcf"
+CHKUPDATE="anitya::id=242933"

--- a/desktop-kde/plasma-mobile/autobuild/defines
+++ b/desktop-kde/plasma-mobile/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=plasma-mobile
+PKGDES="Plasma UI components for mobile device interface"
+PKGSEC=kde
+PKGDEP="plasma-framework ofono libqofono kpeople telepathy-qt \
+        gst-plugins-base-1-0 libphonenumber polkit-kde-agent-1 \
+        powerdevil plasma-workspace signon urfkill plasma-nano \
+        modemmanager-qt plasma-pa plasma-nm kirigami-addons \
+        kpipewire"
+BUILDDEP="extra-cmake-modules"
+
+PKGBREAK="plasma-phone-components"
+PKGPROV="plasma-phone-components"
+PKGREP="plasma-phone-components"

--- a/desktop-kde/plasma-mobile/spec
+++ b/desktop-kde/plasma-mobile/spec
@@ -1,0 +1,4 @@
+VER=5.27.5
+SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-mobile-$VER.tar.xz"
+CHKSUMS="sha256::cc1b2fbb64291fd63a498b7f9c8139e6a8a6a6a0a30c505f6eaa503e2dc2c140"
+CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
Topic Description
-----------------

Revive plasma-mobile (previously dropped as plasma-phone-components), and add a new dependency of it, kirigami-addons.

Package(s) Affected
-------------------

`kirigami-addons plasma-mobile`, both are new to us (at least with the current name).

Security Update?
----------------

No

Build Order
-----------

`kirigami-addons plasma-mobile`

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
