### PR TITLE
xournalpp: new, 1.1.3

### DIFF
--- a/runtime-productivity/xournalpp/autobuild/defines
+++ b/runtime-productivity/xournalpp/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=xournalpp
+PKGDES="Handwriting notetaking software"
+PKGDEP="gtk-3 gtksourceview-4 poppler libxml2 libzip portaudio libsndfile librsvg lua"
+PKGSEC=utils
+
+ABTYPE=cmakeninja

--- a/runtime-productivity/xournalpp/spec
+++ b/runtime-productivity/xournalpp/spec
@@ -1,0 +1,4 @@
+VER=1.1.3
+SRCS="git::commit=tags/v$VER::https://github.com/xournalpp/xournalpp.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=57279"


### PR DESCRIPTION
Topic Description
-----------------
Add `xournalpp`, a handwriting note-taking software.

Package(s) Affected
-------------------

- `xournalpp`: new

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
