### PR TITLE
less: update to version 633

### DIFF
--- a/app-utils/less/autobuild/defines
+++ b/app-utils/less/autobuild/defines
@@ -5,7 +5,6 @@ PKGSEC=utils
 
 AUTOTOOLS_AFTER="--enable-largefile \
                  --with-secure \
-                 --with-no-float=no \
                  --with-regex=pcre2 \
                  --with-editor=editor"
 

--- a/app-utils/less/autobuild/prepare
+++ b/app-utils/less/autobuild/prepare
@@ -1,1 +1,1 @@
-chmod +x $SRCDIR/configure
+#chmod +x $SRCDIR/configure

--- a/app-utils/less/spec
+++ b/app-utils/less/spec
@@ -1,4 +1,4 @@
-VER=608
+VER=633
 SRCS="http://www.greenwoodsoftware.com/less/less-$VER.tar.gz"
-CHKSUMS="sha256::a69abe2e0a126777e021d3b73aa3222e1b261f10e64624d41ec079685a6ac209"
+CHKSUMS="sha256::2f201d64b828b88af36dfe6cfdba3e0819ece2e446ebe6224813209aaefed04f"
 CHKUPDATE="anitya::id=1550"


### PR DESCRIPTION
Topic Description
-----------------

The topic will upgrade less to version 633, which is the latest stable version of upstream as the PR's creation.

The topic involves a security fix to CVE-2022-46663. Besides, this topic is split from the upcoming security survey 2023H1. See also issue #4575 .

Package(s) Affected
-------------------

less

Security Update?
----------------

Yes. #4408 

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
