### PR TITLE
fcitx5-pinyin-moegirl: upgrade to 20230617

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20230514
+VER=20230617
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::3b3afd1013e86928f5ed14c30b67cf31f32ed29d8cbbf0fd5a4c6d75dc373329 \
-         sha256::0d80737472711ddcf4fc3000bee09f807bba37a488a664a50864b5b5ac004811 \
+CHKSUMS="sha256::7949ffd986077916f583639bcb072498dc7ef00075237e276214d83e964c45fa \
+         sha256::859e503d9f49c7f5377ba125c45df158cfa2804c6a537bf1e16888915027d90d \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Update fcitx5-pinyin-moegirl to 20230617.

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**
- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`