### PR TITLE
owntone: new, 28.6

### DIFF
--- a/app-multimedia/owntone/autobuild/beyond
+++ b/app-multimedia/owntone/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Moving systemd service file /etc/systemd/system => /usr/lib/systemd/system ..."
+mv -v "$PKGDIR"/etc/systemd "$PKGDIR"/usr/lib

--- a/app-multimedia/owntone/autobuild/conffiles
+++ b/app-multimedia/owntone/autobuild/conffiles
@@ -1,0 +1,1 @@
+/etc/owntone.conf

--- a/app-multimedia/owntone/autobuild/defines
+++ b/app-multimedia/owntone/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=owntone
+PKGSEC=sound
+PKGDEP="avahi confuse mxml ffmpeg libwebsockets protobuf-c libplist"
+PKGDES="Linux DAAP (iTunes) and MPD media server with Airplay speakers support and more"
+PKGREP="forked-daapd"

--- a/app-multimedia/owntone/autobuild/overrides/usr/lib/sysusers.d/owntone.conf
+++ b/app-multimedia/owntone/autobuild/overrides/usr/lib/sysusers.d/owntone.conf
@@ -1,0 +1,2 @@
+u owntone - "Owntone server"
+g owntone - 

--- a/app-multimedia/owntone/autobuild/overrides/usr/lib/tmpfiles.d/owntone.conf
+++ b/app-multimedia/owntone/autobuild/overrides/usr/lib/tmpfiles.d/owntone.conf
@@ -1,0 +1,2 @@
+d /srv/music 0774 owntone owntone -
+d /var/cache/owntone 0744 owntone owntone -

--- a/app-multimedia/owntone/autobuild/postinst
+++ b/app-multimedia/owntone/autobuild/postinst
@@ -1,0 +1,2 @@
+systemd-sysusers owntone.conf
+systemd-tmpfiles --create owntone.conf

--- a/app-multimedia/owntone/spec
+++ b/app-multimedia/owntone/spec
@@ -1,0 +1,4 @@
+VER=28.6
+SRCTBL="https://github.com/owntone/owntone-server/releases/download/${VER}/owntone-${VER}.tar.xz"
+CHKSUM="sha256::5604d35d2a205cd7dee5b708969e2da96904600c2f5743beb207f61bb86bdc05"
+CHKUPDATE="anitya::id=230673"


### PR DESCRIPTION
Topic Description
-----------------

Add new package `owntone`, a DAAP server that replaces `forked-daapd` dropped a few months ago on https://github.com/AOSC-Dev/aosc-os-abbs/commit/44454f30bed613f9e9c64071bba6e801a278a730 .

Package(s) Affected
-------------------

`owntone`: new, 28.6

Security Update?
----------------
No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
