### PR TITLE
aoscdk-rs: update to 0.7.1

### DIFF
--- a/app-admin/aoscdk-rs/autobuild/defines
+++ b/app-admin/aoscdk-rs/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=aoscdk-rs
 PKGSEC=admin
-PKGDEP="gcc-runtime lvm2 ncurses openssl parted systemd xz"
+PKGDEP="gcc-runtime lvm2 ncurses openssl parted systemd xz squashfs-tools"
 BUILDDEP="llvm rustc"
 PKGDES="AOSC OS system installer"
 

--- a/app-admin/aoscdk-rs/spec
+++ b/app-admin/aoscdk-rs/spec
@@ -1,4 +1,4 @@
-VER=0.6.3
+VER=0.7.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscdk-rs/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226678"


### PR DESCRIPTION
Topic Description
-----------------

aoscdk-rs: update to 0.7.1

Package(s) Affected
-------------------

aoscdk-rs: update to 0.7.1

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No
<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->