### PR TITLE
rsync: fix runtime AVX2 detection

### DIFF
--- a/app-network/rsync/autobuild/patches/0001-rsync-fix-runtime-avx2-detection.patch
+++ b/app-network/rsync/autobuild/patches/0001-rsync-fix-runtime-avx2-detection.patch
@@ -1,0 +1,63 @@
+diff --git a/simd-checksum-x86_64.cpp b/simd-checksum-x86_64.cpp
+index 33f26e92..438ce369 100644
+--- a/simd-checksum-x86_64.cpp
++++ b/simd-checksum-x86_64.cpp
+@@ -85,9 +85,7 @@ typedef long long __m256i_u __attribute__((__vector_size__(32), __may_alias__, _
+ #define SSE2_HADDS_EPI16(a, b) _mm_adds_epi16(SSE2_INTERLEAVE_EVEN_EPI16(a, b), SSE2_INTERLEAVE_ODD_EPI16(a, b))
+ #define SSE2_MADDUBS_EPI16(a, b) _mm_adds_epi16(SSE2_MULU_EVEN_EPI8(a, b), SSE2_MULU_ODD_EPI8(a, b))
+ 
+-#ifndef USE_ROLL_ASM
+-__attribute__ ((target("default"))) MVSTATIC int32 get_checksum1_avx2_64(schar* buf, int32 len, int32 i, uint32* ps1, uint32* ps2) { return i; }
+-#endif
++__attribute__ ((target("default"))) MVSTATIC int32 get_checksum1_avx2(schar* buf, int32 len, int32 i, uint32* ps1, uint32* ps2) { return i; }
+ __attribute__ ((target("default"))) MVSTATIC int32 get_checksum1_ssse3_32(schar* buf, int32 len, int32 i, uint32* ps1, uint32* ps2) { return i; }
+ __attribute__ ((target("default"))) MVSTATIC int32 get_checksum1_sse2_32(schar* buf, int32 len, int32 i, uint32* ps1, uint32* ps2) { return i; }
+ 
+@@ -316,6 +314,10 @@ __attribute__ ((target("sse2"))) MVSTATIC int32 get_checksum1_sse2_32(schar* buf
+ #ifdef USE_ROLL_ASM /* { */
+ 
+ extern "C" __attribute__ ((target("avx2"))) int32 get_checksum1_avx2_asm(schar* buf, int32 len, int32 i, uint32* ps1, uint32* ps2);
++__attribute__ ((target("avx2"))) MVSTATIC int32 get_checksum1_avx2(schar* buf, int32 len, int32 i, uint32* ps1, uint32* ps2)
++{
++	return get_checksum1_avx2_asm(buf, len, i, ps1, ps2);
++}
+ 
+ #else /* } { */
+ 
+@@ -432,6 +434,10 @@ __attribute__ ((target("avx2"))) MVSTATIC int32 get_checksum1_avx2_64(schar* buf
+     }
+     return i;
+ }
++__attribute__ ((target("avx2"))) MVSTATIC int32 get_checksum1_avx2(schar* buf, int32 len, int32 i, uint32* ps1, uint32* ps2)
++{
++	return get_checksum1_avx2_64(buf, len, i, ps1, ps2);
++}
+ 
+ #endif /* } !USE_ROLL_ASM */
+ 
+@@ -461,11 +467,7 @@ static inline uint32 get_checksum1_cpp(char *buf1, int32 len)
+     uint32 s2 = 0;
+ 
+     // multiples of 64 bytes using AVX2 (if available)
+-#ifdef USE_ROLL_ASM
+-    i = get_checksum1_avx2_asm((schar*)buf1, len, i, &s1, &s2);
+-#else
+-    i = get_checksum1_avx2_64((schar*)buf1, len, i, &s1, &s2);
+-#endif
++    i = get_checksum1_avx2((schar*)buf1, len, i, &s1, &s2);
+ 
+     // multiples of 32 bytes using SSSE3 (if available)
+     i = get_checksum1_ssse3_32((schar*)buf1, len, i, &s1, &s2);
+@@ -534,11 +536,7 @@ int main() {
+     benchmark("Raw-C", get_checksum1_default_1, (schar*)buf, BLOCK_LEN);
+     benchmark("SSE2", get_checksum1_sse2_32, (schar*)buf, BLOCK_LEN);
+     benchmark("SSSE3", get_checksum1_ssse3_32, (schar*)buf, BLOCK_LEN);
+-#ifdef USE_ROLL_ASM
+-    benchmark("AVX2-ASM", get_checksum1_avx2_asm, (schar*)buf, BLOCK_LEN);
+-#else
+-    benchmark("AVX2", get_checksum1_avx2_64, (schar*)buf, BLOCK_LEN);
+-#endif
++    benchmark("AVX2", get_checksum1_avx2, (schar*)buf, BLOCK_LEN);
+ 
+     free(buf);
+     return 0;

--- a/app-network/rsync/spec
+++ b/app-network/rsync/spec
@@ -2,4 +2,4 @@ VER=3.2.7
 SRCS="tbl::https://download.samba.org/pub/rsync/src/rsync-$VER.tar.gz"
 CHKSUMS="sha256::4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb"
 CHKUPDATE="anitya::id=4217"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

Fix SIGILL of `rsync` on x86-64 CPUs w/o AVX2.

Package(s) Affected
-------------------

- `rsync`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
