### PR TITLE
kwin: backport a patch to fix Wayland touch screen issue

### DIFF
--- a/desktop-kde/kwin/autobuild/patches/0001-BACKPORT-input-Make-sure-input-backends-are-initialised-when-the-workspace-is-set-up.patch
+++ b/desktop-kde/kwin/autobuild/patches/0001-BACKPORT-input-Make-sure-input-backends-are-initialised-when-the-workspace-is-set-up.patch
@@ -1,0 +1,31 @@
+From 4bc8cd6c5427665af89f232dce43f0375db3bb0b Mon Sep 17 00:00:00 2001
+From: Aleix Pol <aleixpol@kde.org>
+Date: Tue, 7 Mar 2023 03:12:48 +0100
+Subject: [PATCH] input: Make sure input backends are initialised when the
+ workspace is set up
+
+The outputs already present upon workspace setup wouldn't signal. This
+was easily triggered running a standalone kwin session on a tty, it
+would manifest with the touchscreen not working complaining that it
+didn't have an output assigned yet.
+
+BUG: 466721
+---
+ src/input.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/input.cpp b/src/input.cpp
+index 163565570aa..e14e9328551 100644
+--- a/src/input.cpp
++++ b/src/input.cpp
+@@ -2636,6 +2636,7 @@ void InputRedirection::setupWorkspace()
+ 
+         setupTouchpadShortcuts();
+         setupInputFilters();
++        updateScreens();
+     }
+ }
+ 
+-- 
+GitLab
+

--- a/desktop-kde/kwin/spec
+++ b/desktop-kde/kwin/spec
@@ -1,4 +1,5 @@
 VER=5.27.2
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwin-$VER.tar.xz"
 CHKSUMS="sha256::d0b2ec260cdc2299015357755a5096715358ccbdad683b6b39f63fd07dea56f5"
 CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
Topic Description
-----------------

Backport a patch to `kwin` to fix touch screen on Plasma Mobile on some Redmi 2's.

Package(s) Affected
-------------------

- `kwin`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
