### PR TITLE
libkscreen: backport a patch to fix KScreenLocker crash on Wayland

### DIFF
--- a/desktop-kde/libkscreen/autobuild/patches/0001-BACKPORT-libdpms-wayland-Do-not-create-dpms-interfaces-for-placeholder-QScreens.patch
+++ b/desktop-kde/libkscreen/autobuild/patches/0001-BACKPORT-libdpms-wayland-Do-not-create-dpms-interfaces-for-placeholder-QScreens.patch
@@ -1,0 +1,32 @@
+From e1f3cb774435d11e8f68192eee17decdc6e2b661 Mon Sep 17 00:00:00 2001
+From: Aleix Pol <aleixpol@kde.org>
+Date: Mon, 6 Mar 2023 01:23:13 +0100
+Subject: [PATCH] libdpms/wayland: Do not create dpms interfaces for
+ placeholder QScreens
+
+BUG: 466674
+---
+ src/libdpms/waylanddpmshelper.cpp | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/libdpms/waylanddpmshelper.cpp b/src/libdpms/waylanddpmshelper.cpp
+index 021dbf5c..454d5272 100644
+--- a/src/libdpms/waylanddpmshelper.cpp
++++ b/src/libdpms/waylanddpmshelper.cpp
+@@ -112,6 +112,13 @@ public:
+ private:
+     void addScreen(QScreen *screen)
+     {
++        // We can't rely on checking the wl_output being null yet
++        // https://codereview.qt-project.org/c/qt/qtwayland/+/464669
++        const bool fake = screen->geometry().isEmpty() || screen->name().isEmpty();
++        if (fake) {
++            return;
++        }
++
+         QPlatformNativeInterface *native = qGuiApp->platformNativeInterface();
+         wl_output *output = reinterpret_cast<wl_output *>(native->nativeResourceForScreen(QByteArrayLiteral("output"), screen));
+         if (output) {
+-- 
+GitLab
+

--- a/desktop-kde/libkscreen/spec
+++ b/desktop-kde/libkscreen/spec
@@ -1,4 +1,5 @@
 VER=5.27.2
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/libkscreen-$VER.tar.xz"
 CHKSUMS="sha256::6b7281763a21a40321897164c61384382396784e6853de2e69430da5fbb429cf"
 CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
Topic Description
-----------------

Fixes kscreenlocker_greet crashing on Plasma Wayland, tested on Plasma Mobile, by backporting a patch to libkscreen.

Package(s) Affected
-------------------

- `libkscreen`

Security Update?
----------------
No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
