### PR TITLE
Darktable 4.4.1 survey

### DIFF
--- a/app-creativity/darktable/autobuild/patches/0001-common-guided_filter-remove-broken-ifdefs-on-ppc.patch
+++ b/app-creativity/darktable/autobuild/patches/0001-common-guided_filter-remove-broken-ifdefs-on-ppc.patch
@@ -1,29 +1,28 @@
-From 993e9ee531fb4edd2dd486ee3c4590bd477d84db Mon Sep 17 00:00:00 2001
+From 457673302fc75fc6dba78c8a4a18b87e25e6f462 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Tue, 20 Dec 2022 01:01:11 -0500
-Subject: [PATCH 1/2] common/guided_filter: remove broken ifdefs on ppc
+Subject: [PATCH] common/guided_filter: remove broken ifdefs on ppc
 
 ---
- src/common/guided_filter.h | 4 ----
- 1 file changed, 4 deletions(-)
+ src/common/sse.h      | 4 +++-
+ src/tests/integration | 2 +-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
 
-diff --git a/src/common/guided_filter.h b/src/common/guided_filter.h
-index 316a8f8bf7..23b99a3a58 100644
---- a/src/common/guided_filter.h
-+++ b/src/common/guided_filter.h
-@@ -23,12 +23,8 @@
- #ifdef NO_WARN_X86_INTRINSICS
+diff --git a/src/common/sse.h b/src/common/sse.h
+index f7609add9a..45d9c8e461 100644
+--- a/src/common/sse.h
++++ b/src/common/sse.h
+@@ -17,7 +17,9 @@
+ #include "common/darktable.h"
+ 
+ #ifdef __SSE__
+-
++#ifdef __PPC64__
++#define NO_WARN_X86_INTRINSICS 1
++#endif
  #include <xmmintrin.h>
- #else
--#define NO_WARN_X86_INTRINSICS 1
- #include <xmmintrin.h>
--#undef NO_WARN_X86_INTRINSICS
- #endif // NO_WARN_X86_INTRINSICS
--#else
--#include <xmmintrin.h>
- #endif // __PPC64__
- #endif
+ 
  
 -- 
-2.38.1
+2.39.1
 

--- a/app-creativity/darktable/autobuild/patches/0002-fix-building-for-mips64.patch
+++ b/app-creativity/darktable/autobuild/patches/0002-fix-building-for-mips64.patch
@@ -1,14 +1,14 @@
-From e415ac7c4280ed7046476548a3fe01f0cb645dca Mon Sep 17 00:00:00 2001
+From 913ccb6e186a412c75dc27cf3d1a3365479fd1b2 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Tue, 20 Dec 2022 01:04:49 -0500
-Subject: [PATCH 2/2] fix building for mips64
+Subject: [PATCH] fix building for mips64
 
 ---
  src/is_supported_platform.h | 11 +++++++++--
  1 file changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/src/is_supported_platform.h b/src/is_supported_platform.h
-index cf904e325f..96f193332c 100644
+index 03a77f704d..9d418d3c5f 100644
 --- a/src/is_supported_platform.h
 +++ b/src/is_supported_platform.h
 @@ -36,6 +36,12 @@
@@ -45,5 +45,5 @@ index cf904e325f..96f193332c 100644
  #undef DT_SUPPORTED_X86
  
 -- 
-2.38.1
+2.39.1
 

--- a/app-creativity/darktable/spec
+++ b/app-creativity/darktable/spec
@@ -1,4 +1,4 @@
-VER=4.2.1
+VER=4.4.1
 SRCS="tbl::https://github.com/darktable-org/darktable/releases/download/release-$VER/darktable-$VER.tar.xz"
-CHKSUMS="sha256::603a39c6074291a601f7feb16ebb453fd0c5b02a6f5d3c7ab6db612eadc97bac"
+CHKSUMS="sha256::e043d38d2e8adb67af7690b12b535a40e8ec7bea05cfa8684db8b21a626e0f0d"
 CHKUPDATE="anitya::id=392"

--- a/app-imaging/gphoto2/spec
+++ b/app-imaging/gphoto2/spec
@@ -1,4 +1,4 @@
-VER=2.5.27
-SRCS="tbl::https://sourceforge.net/projects/gphoto/files/gphoto/$VER/gphoto2-$VER.tar.xz"
-CHKSUMS="sha256::2fda6ffe0c7c2da4553801364a8cf6ef60685bd976cbfea24acc0fa142c77199"
+VER=2.5.28
+SRCS="tbl::https://github.com/gphoto/gphoto2/releases/download/v${VER}/gphoto2-${VER}.tar.xz"
+CHKSUMS="sha256::ff3e32c7bd2a129d817dcd9e75ce51834409b1966e1f20e74c427c32ae732afa"
 CHKUPDATE="anitya::id=10207"

--- a/runtime-devices/libgphoto2/spec
+++ b/runtime-devices/libgphoto2/spec
@@ -1,5 +1,4 @@
-VER=2.5.24
-REL=2
+VER=2.5.30
 SRCS="tbl::https://sourceforge.net/projects/gphoto/files/libgphoto/$VER/libgphoto2-$VER.tar.gz"
-CHKSUMS="sha256::bd1c35acde21faf2a5a282a5a832510da982d707e1cf348a5d9c4b60bbce66ce"
+CHKSUMS="sha256::3e7eb9500fbf73ffaf4aa5eb65efde1998fb7ac702e689c274aacf52646f7ea4"
 CHKUPDATE="anitya::id=12558"

--- a/runtime-imaging/gmic/spec
+++ b/runtime-imaging/gmic/spec
@@ -1,4 +1,4 @@
-VER=3.1.5
+VER=3.2.6
 SRCS="tbl::https://gmic.eu/files/source/gmic_${VER}.tar.gz"
-CHKSUMS="sha256::fa77e85b3a39638008515ac525f23f0ed7a45b63c463c0ba6292c87f5e88e30d"
+CHKSUMS="sha256::55993e55a30fe2da32f9533b9db2a3250affa2b32003b0c49c36eec2b2c6e007"
 CHKUPDATE="anitya::id=10217"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates darktable and some dependencies to their latest versions.

Package(s) Affected
-------------------

- libgphoto2
- gphoto2
- gmic
- darktable **Unsatisfiable dependency on rv64/ppc64el: portmidi requires bootstrapping**

Build Order
-----------

`libgphoto2 gphoto2 gmic darktable`

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
