### PR TITLE
plasma-mobile: disable qtfeedback

### DIFF
--- a/desktop-kde/plasma-mobile/autobuild/patches/0001-BACKPORT-Disable-QtFeedback.patch
+++ b/desktop-kde/plasma-mobile/autobuild/patches/0001-BACKPORT-Disable-QtFeedback.patch
@@ -1,0 +1,36 @@
+From dc5a0dd419aaedbe836b501f289625e3f0e408d0 Mon Sep 17 00:00:00 2001
+From: Devin Lin <espidev@gmail.com>
+Date: Sun, 5 Mar 2023 12:53:09 -0800
+Subject: [PATCH] Disable QtFeedback
+
+---
+ .../mobileshell/qml/components/HapticsEffectLoader.qml   | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/components/mobileshell/qml/components/HapticsEffectLoader.qml b/components/mobileshell/qml/components/HapticsEffectLoader.qml
+index ebb42e88b..a25f5ba25 100644
+--- a/components/mobileshell/qml/components/HapticsEffectLoader.qml
++++ b/components/mobileshell/qml/components/HapticsEffectLoader.qml
+@@ -6,14 +6,15 @@ import QtQuick 2.15
+ import org.kde.plasma.private.mobileshell 1.0 as MobileShell
+ 
+ Loader {
+-    source: "qrc:/org/kde/plasma/private/mobileshell/qml/components/HapticsEffectWrapper.qml"
++    // source: "qrc:/org/kde/plasma/private/mobileshell/qml/components/HapticsEffectWrapper.qml"
+     property bool valid: item !== null
+     
+     function buttonVibrate() {
+         if (valid && MobileShell.MobileShellSettings.vibrationsEnabled) {
+-            item.intensity = MobileShell.MobileShellSettings.vibrationIntensity;
+-            item.duration = MobileShell.MobileShellSettings.vibrationDuration;
+-            item.start();
++            // TODO we need a haptics stack for Qt 6
++            // item.intensity = MobileShell.MobileShellSettings.vibrationIntensity;
++            // item.duration = MobileShell.MobileShellSettings.vibrationDuration;
++            // item.start();
+         }
+     }
+ }
+-- 
+2.39.1
+

--- a/desktop-kde/plasma-mobile/spec
+++ b/desktop-kde/plasma-mobile/spec
@@ -1,4 +1,5 @@
 VER=5.27.5
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-mobile-$VER.tar.xz"
 CHKSUMS="sha256::cc1b2fbb64291fd63a498b7f9c8139e6a8a6a6a0a30c505f6eaa503e2dc2c140"
 CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
Topic Description
-----------------

Disabling QtFeedback usage, which leads to some instability of plasmashell and kscreenlocker_greet, and disabling already in upstream (although the upstream disabling reason seems to be transitioning to Qt6).

This fixes random kscreenlocker_greet crashes on wt88047, however the first boot still have the screen locker crashes, further investigation is needed.

Package(s) Affected
-------------------

- `plasma-mobile`

Security Update?
----------------

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
