### PR TITLE
binutils+32: enable 64-bit bfd

### DIFF
--- a/runtime-optenv32/binutils+32/autobuild/build
+++ b/runtime-optenv32/binutils+32/autobuild/build
@@ -5,7 +5,7 @@ CC=i686-pc-linux-gnu-gcc
 
 linux32 ./configure --host=i686-pc-linux-gnu --build=i686-pc-linux-gnu \
             --target=i686-pc-linux-gnu --enable-shared --prefix=/opt/32 \
-            --disable-werror
+            --disable-werror --enable-64-bit-bfd
 make
 make DESTDIR="$PKGDIR" install
 cp -v include/libiberty.h "$PKGDIR"/opt/32/include

--- a/runtime-optenv32/binutils+32/spec
+++ b/runtime-optenv32/binutils+32/spec
@@ -1,5 +1,5 @@
 VER=2.38
-REL=1
+REL=2
 SRCS="tbl::https://ftp.gnu.org/gnu/binutils/binutils-$VER.tar.xz"
 CHKSUMS="sha256::e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION
Topic Description
-----------------

This topic enables 64-bit bfd for `binutils+32`, which is required for building Memtest86+'s 32-bit BIOS image.

Package(s) Affected
-------------------

`binutils+32` v2.38-2

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] 32-bit Optional Environment `optenv32`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] 32-bit Optional Environment `optenv32`