### PR TITLE
discord: update to 0.0.28

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.27
+VER=0.0.28
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::e9f1da88f05cbfb4d0561f936ad20461767f2f03e69c2994fd059728581447b5"
+CHKSUMS="sha256::270c55566fd02012e857243615ffcc5f4e9436067e740b03f7ad06b0283533e5"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Discord to 0.0.28.

Package(s) Affected
-------------------

`discord` v0.0.28

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   