### PR TITLE
FTBFS Rework 20230719

### DIFF
--- a/app-admin/mdadm/autobuild/build
+++ b/app-admin/mdadm/autobuild/build
@@ -1,0 +1,17 @@
+abinfo "Unsetting problematic environment variables..."
+unset STRIP
+
+abinfo "Running Makefile..."
+cd ${SRCDIR}
+
+# Export CXXFLAGS and other configuration
+make \
+	${MAKE_DEF} \
+	${MAKE_AFTER} \
+	CXXFLAGS="${CFLAGS}" \
+	SYSCONFDIR=/etc \
+	mdadm mdmon
+
+abinfo "Installing to DESTDIR..."
+make DESTDIR=${PKGDIR} ${MAKE_INSTALL_DEF} ${MAKE_AFTER} install
+

--- a/app-admin/mdadm/autobuild/defines
+++ b/app-admin/mdadm/autobuild/defines
@@ -3,6 +3,5 @@ PKGSEC=admin
 PKGDEP="glibc"
 PKGDES="A tool for managing/monitoring Linux md (software RAID) device arrays"
 
-ABTYPE=plainmake
-ABMK="CXFLAGS=${CFLAGS} SYSCONFDIR=/etc mdadm mdmon"
-MAKE_AFTER="SYSTEMD_DIR=/usr/lib/systemd/system"
+MAKE_AFTER="SYSTEMD_DIR=/usr/lib/systemd/system \
+            UDEVDIR=/usr/lib/udev"

--- a/app-admin/mdadm/autobuild/defines.stage2
+++ b/app-admin/mdadm/autobuild/defines.stage2
@@ -3,7 +3,5 @@ PKGSEC=admin
 PKGDEP="glibc"
 PKGDES="A tool for managing/monitoring Linux md (software RAID) device arrays"
 
-ABTYPE=plainmake
-ABMK="CXFLAGS=${CFLAGS} SYSCONFDIR=/etc mdadm mdmon"
 MAKE_AFTER="SYSTEMD_DIR=/usr/lib/systemd/system \
             UDEVDIR=/usr/lib/udev"

--- a/app-admin/mdadm/spec
+++ b/app-admin/mdadm/spec
@@ -1,4 +1,5 @@
 VER=4.2
+REL=1
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/raid/mdadm/mdadm-$VER.tar.xz"
 CHKSUMS="sha256::461c215670864bb74a4d1a3620684aa2b2f8296dffa06743f26dda5557acf01d"
 CHKUPDATE="anitya::id=1958"

--- a/app-network/iptables/autobuild/defines
+++ b/app-network/iptables/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=iptables
 PKGDES="Packet control tool for Linux kernel"
-PKGDEP="glibc libmnl libnftnl"
+PKGDEP="glibc libmnl libnftnl libpcap"
 PKGDEP__RETRO="glibc libmnl"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/app-network/iptables/spec
+++ b/app-network/iptables/spec
@@ -1,4 +1,5 @@
 VER=1.8.8
+REL=1
 SRCS="https://netfilter.org/projects/iptables/files/iptables-$VER.tar.bz2"
 CHKSUMS="sha256::71c75889dc710676631553eb1511da0177bbaaf1b551265b912d236c3f51859f"
 CHKUPDATE="anitya::id=1394"

--- a/runtime-desktop/t1lib/autobuild/defines
+++ b/runtime-desktop/t1lib/autobuild/defines
@@ -6,3 +6,6 @@ PKGDES="Library for generating character and string-glyphs from Adobe Type 1 fon
 ABMK="without_doc $ABMK"
 ABSHADOW=no
 RECONF=0
+
+# FIXME: Fails mysteriously with parallelism.
+NOPARALLEL=1

--- a/runtime-desktop/t1lib/spec
+++ b/runtime-desktop/t1lib/spec
@@ -1,4 +1,4 @@
 VER=5.1.2
-REL=3
+REL=4
 SRCS="tbl::https://src.fedoraproject.org/repo/pkgs/t1lib/t1lib-5.1.2.tar.gz/a5629b56b93134377718009df1435f3c/t1lib-5.1.2.tar.gz"
 CHKSUMS="sha256::821328b5054f7890a0d0cd2f52825270705df3641dbd476d58d17e56ed957b59"

--- a/runtime-productivity/libpaper/spec
+++ b/runtime-productivity/libpaper/spec
@@ -1,4 +1,4 @@
 VER=1.1.24+nmu5
-SRCS="tbl::http://ftp.debian.org/debian/pool/main/libp/libpaper/libpaper_$VER.tar.gz"
+SRCS="tbl::https://repo.aosc.io/aosc-repacks/libpaper_$VER.tar.gz"
 CHKSUMS="sha256::e29deda4cd7350189c71af0925cbf4a4473f9841d1419a922e1e8ff1954db1f2"
 CHKUPDATE="anitya::id=15136"


### PR DESCRIPTION
Topic Description
-----------------

This topic fixes various build failures during mips32r6el port bootstrap.

Package(s) Affected
-------------------

See "Files changed."

Security Update?
----------------

No

Build Order
-----------

```
mdadm iptables t1lib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`