### PR TITLE
iio-sensor-proxy: update to 3.4

### DIFF
--- a/app-utils/iio-sensor-proxy/autobuild/defines
+++ b/app-utils/iio-sensor-proxy/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=iio-sensor-proxy
 PKGSEC=utils
 PKGDEP="libgudev systemd"
-BUILDDEP="gnome-common gtk-doc gtk-3"
+BUILDDEP="gtk-doc gtk-3"
 PKGDES="IIO various sensor to input device proxy"
 
 MESON_AFTER="-Dgeoclue-user=root -Dgtk_doc=true"

--- a/app-utils/iio-sensor-proxy/spec
+++ b/app-utils/iio-sensor-proxy/spec
@@ -1,5 +1,4 @@
-VER=3.1
-REL=1
+VER=3.4
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/hadess/iio-sensor-proxy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6467"

--- a/runtime-admin/libgudev/spec
+++ b/runtime-admin/libgudev/spec
@@ -1,4 +1,4 @@
-VER=236
+VER=238
 SRCS="tbl::https://download.gnome.org/sources/libgudev/$VER/libgudev-$VER.tar.xz"
-CHKSUMS="sha256::e50369d06d594bae615eb7aeb787de304ebaad07a26d1043cef8e9c7ab7c9524"
+CHKSUMS="sha256::61266ab1afc9d73dbc60a8b2af73e99d2fdff47d99544d085760e4fa667b5dd1"
 CHKUPDATE="anitya::id=7735"


### PR DESCRIPTION
Topic Description
-----------------

Update `iio-sensor-proxy` to 3.4, and to meet its dependency, `libgudev` to 238.

Package(s) Affected
-------------------

- `libgudev`
- `iio-sensor-proxy`

Security Update?
----------------

No

Build Order
-----------

`libgudev iio-sensor-proxy`

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
