### PR TITLE
htop: update to 3.2.2 and backport a fix for offline CPU display

### DIFF
--- a/app-admin/htop/autobuild/patches/0001-BACKPORT-Remove-LXC-special-handling-for-the-CPU-count.patch
+++ b/app-admin/htop/autobuild/patches/0001-BACKPORT-Remove-LXC-special-handling-for-the-CPU-count.patch
@@ -1,0 +1,72 @@
+From 11318b5ef6de6b2f80186a888cd5477e0ff167bb Mon Sep 17 00:00:00 2001
+From: Daniel Lange <DLange@git.local>
+Date: Sat, 25 Feb 2023 14:12:45 +0100
+Subject: [PATCH] Remove LXC special handling for the CPU count
+
+LXC shows the real host CPU ids but can be limited in configuration
+as to which cores are used. Still the sysfs files are visible and the
+CPUs (stay) marked online. We will need to parse
+/sys/devices/system/cpu/online to follow LXC's logic.
+Revert for now until we can come up with a better handling of the LXC hacks.
+
+Cf. issue #1195
+Essentially reverting 33973f7e and 0d53245c (#993, #995)
+---
+ linux/LinuxProcessList.c | 30 +-----------------------------
+ 1 file changed, 1 insertion(+), 29 deletions(-)
+
+diff --git a/linux/LinuxProcessList.c b/linux/LinuxProcessList.c
+index 24b7ea98f..f8d56b701 100644
+--- a/linux/LinuxProcessList.c
++++ b/linux/LinuxProcessList.c
+@@ -210,28 +210,6 @@ static void LinuxProcessList_initNetlinkSocket(LinuxProcessList* this) {
+ 
+ #endif
+ 
+-static unsigned int scanAvailableCPUsFromCPUinfo(LinuxProcessList* this) {
+-   FILE* file = fopen(PROCCPUINFOFILE, "r");
+-   if (file == NULL)
+-      return this->super.existingCPUs;
+-
+-   unsigned int availableCPUs = 0;
+-
+-   while (!feof(file)) {
+-      char buffer[PROC_LINE_LENGTH];
+-
+-      if (fgets(buffer, PROC_LINE_LENGTH, file) == NULL)
+-         break;
+-
+-      if (String_startsWith(buffer, "processor"))
+-         availableCPUs++;
+-   }
+-
+-   fclose(file);
+-
+-   return availableCPUs ? availableCPUs : 1;
+-}
+-
+ static void LinuxProcessList_updateCPUcount(ProcessList* super) {
+    /* Similar to get_nprocs_conf(3) / _SC_NPROCESSORS_CONF
+     * https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/getsysstats.c;hb=HEAD
+@@ -306,12 +284,6 @@ static void LinuxProcessList_updateCPUcount(ProcessList* super) {
+    if (existing < 1)
+       return;
+ 
+-   if (Running_containerized) {
+-      /* LXC munges /proc/cpuinfo but not the /sys/devices/system/cpu/ files,
+-       * so limit the visible CPUs to what the guest has been configured to see: */
+-      currExisting = active = scanAvailableCPUsFromCPUinfo(this);
+-   }
+-
+ #ifdef HAVE_SENSORS_SENSORS_H
+    /* When started with offline CPUs, libsensors does not monitor those,
+     * even when they become online. */
+@@ -320,7 +292,7 @@ static void LinuxProcessList_updateCPUcount(ProcessList* super) {
+ #endif
+ 
+    super->activeCPUs = active;
+-   assert(Running_containerized || (existing == currExisting));
++   assert(existing == currExisting);
+    super->existingCPUs = currExisting;
+ }
+ 

--- a/app-admin/htop/spec
+++ b/app-admin/htop/spec
@@ -1,5 +1,4 @@
-VER=3.2.1
-REL=1
-SRCS="tbl::https://github.com/htop-dev/htop/archive/$VER.tar.gz"
-CHKSUMS="sha256::b5ffac1949a8daaabcffa659c0964360b5008782aae4dfa7702d2323cfb4f438"
+VER=3.2.2
+SRCS="git::commit=tags/$VER::https://github.com/htop-dev/htop.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1332"


### PR DESCRIPTION
Topic Description
-----------------

Updating `htop` and backport a fix for the problem that offline CPUs will lead to CPU count decrease in htop (but the corresponding CPU is still displayed as offline, thus missing the information of the last CPU in case it's online).

The fix is tested on AOSC OS Buildbot GreenGoo, on which the CPU 15 failed, but there are totally 64 cores.

Package(s) Affected
-------------------

`htop`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
