### PR TITLE
pydantic: disable ABSPLITDBG for !amd64

### DIFF
--- a/lang-python/pydantic/autobuild/defines
+++ b/lang-python/pydantic/autobuild/defines
@@ -5,3 +5,7 @@ PKGDEP="python-3"
 
 ABTYPE=python
 NOPYTHON2=1
+
+# FIXME: No native components for !amd64.
+ABSPLITDBG=0
+ABSPLITDBG__AMD64=1


### PR DESCRIPTION
Topic Description
-----------------

This topic reworks `pydantic` for non-amd64 ports, as there is no native components for these architectures.

Package(s) Affected
-------------------

`pydantic` v1.10.2 (no version change)

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`