### PR TITLE
virtualbox: fix kernel modules on 6.4.10

### DIFF
--- a/app-virtualization/virtualbox/01-host/patches/0011-kernel-6-4-10-include-gso-h.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0011-kernel-6-4-10-include-gso-h.patch
@@ -1,0 +1,12 @@
+diff -Naur VirtualBox-7.0.10/src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c VirtualBox-7.0.10-kernel-6.4.10/src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c
+--- VirtualBox-7.0.10/src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c	2023-07-12 12:36:55.000000000 -0400
++++ VirtualBox-7.0.10-kernel-6.4.10/src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c	2023-08-12 15:35:55.789808111 -0400
+@@ -47,7 +47,7 @@
+ #if RTLNX_VER_MIN(2,6,24)
+ # include <linux/nsproxy.h>
+ #endif
+-#if RTLNX_VER_MIN(6,5,0)
++#if RTLNX_VER_MIN(6,4,10)
+ # include <net/gso.h>
+ #endif
+ #include <linux/netdevice.h>

--- a/app-virtualization/virtualbox/01-host/postinst.in
+++ b/app-virtualization/virtualbox/01-host/postinst.in
@@ -1,4 +1,4 @@
-VER=TEMPVER
+VER=%PKGVER%
 unset ARCH
 
 echo "Reloading UDev rules file..."

--- a/app-virtualization/virtualbox/01-host/prepare
+++ b/app-virtualization/virtualbox/01-host/prepare
@@ -3,10 +3,10 @@ export PATH="$PATH:/opt/32/bin"
 abinfo "Copying kmk config file to SRCDIR ..."
 cp -v "$SRCDIR"/autobuild/LocalConfig.kmk "$SRCDIR"/
 
-abinfo 'Fixing hard-coded version in postinst and prerm ...'
-sed -e "s/TEMPVER/$PKGVER/g" \
-    -i "$SRCDIR"/autobuild/postinst \
-    -i "$SRCDIR"/autobuild/prerm
+for i in postinst prerm; do
+	abinfo "Generating $i"
+	sed -e "s/%PKGVER%/$PKGVER/g" "${SRCDIR}/autobuild/${i}.in" > "${SRCDIR}/autobuild/${i}"
+done
 
 abinfo "Setting Java home ..."
 export JDK_HOME="/usr/lib/java-8"

--- a/app-virtualization/virtualbox/01-host/prerm
+++ b/app-virtualization/virtualbox/01-host/prerm
@@ -1,4 +1,0 @@
-VER=TEMPVER
-unset ARCH
-
-dkms remove vboxhost/$VER --all || true > /dev/null

--- a/app-virtualization/virtualbox/01-host/prerm.in
+++ b/app-virtualization/virtualbox/01-host/prerm.in
@@ -1,0 +1,4 @@
+VER=%PKGVER%
+unset ARCH
+
+dkms remove vboxhost/${VER}_OSE --all || true > /dev/null

--- a/app-virtualization/virtualbox/spec
+++ b/app-virtualization/virtualbox/spec
@@ -1,4 +1,5 @@
 VER=7.0.10
+REL=1
 UBUNTU_VBOX_VER="158379~Ubuntu~jammy"
 SRCS="tbl::https://download.virtualbox.org/virtualbox/$VER/VirtualBox-${VER}.tar.bz2 \
       file::rename=virtualbox.deb::https://download.virtualbox.org/virtualbox/$VER/virtualbox-${VER%.*}_${VER}-${UBUNTU_VBOX_VER}_amd64.deb \


### PR DESCRIPTION
Topic Description
-----------------

This PR makes modules include header "gso.h" for kernel version higher than or equal to 6.4.10 - gso related functions were moved into a separate header file in this version.

Package(s) Affected
-------------------

`virtualbox`

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   