### PR TITLE
Tilix Rework

### DIFF
--- a/app-utils/tilix/autobuild/defines
+++ b/app-utils/tilix/autobuild/defines
@@ -8,6 +8,7 @@ PKGDES="A tiling terminal emulator"
 PKGBREAK="terminix<=1.5.0"
 PKGREP="terminix<=1.5.0"
 
+USECLANG=1
 ABTYPE=meson
 
 PKGEPOCH=1

--- a/app-utils/tilix/autobuild/defines
+++ b/app-utils/tilix/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=tilix
 PKGSEC=utils
 PKGDEP="gtkd vte-gtk3 dconf gsettings-desktop-schemas gettext liblphobos librsvg"
-BUILDDEP="ldc po4a"
+BUILDDEP="ldc po4a undead"
 PKGSUG="nautilus-python"
 PKGDES="A tiling terminal emulator"
 

--- a/app-utils/tilix/autobuild/patches/0001-Arch-Linux-undeaD-xml.patch
+++ b/app-utils/tilix/autobuild/patches/0001-Arch-Linux-undeaD-xml.patch
@@ -1,0 +1,34 @@
+diff --git a/meson.build b/meson.build
+index 79981a96..c7e9cc34 100644
+--- a/meson.build
++++ b/meson.build
+@@ -7,7 +7,7 @@ project(
+ 
+ compiler = meson.get_compiler('d')
+ if compiler.get_id() == 'llvm'
+-  d_extra_args = ['-vcolumns']
++  d_extra_args = ['-vcolumns', '-I=../undeaD-1.1.8/src']
+   d_link_args = []
+ else
+   d_extra_args = []
+@@ -29,6 +29,7 @@ iconsdir = datadir / 'icons' / 'hicolor'
+ appdir = datadir / 'applications'
+ 
+ tilix_sources = [
++    'undeaD-1.1.8/src/undead/xml.d',
+     'source/gx/gtk/actions.d',
+     'source/gx/gtk/cairo.d',
+     'source/gx/gtk/clipboard.d',
+diff --git a/source/gx/tilix/prefeditor/prefdialog.d b/source/gx/tilix/prefeditor/prefdialog.d
+index a5c3ce37..9b94042f 100644
+--- a/source/gx/tilix/prefeditor/prefdialog.d
++++ b/source/gx/tilix/prefeditor/prefdialog.d
+@@ -957,7 +957,7 @@ private:
+             return;
+         }
+ 
+-        import std.xml: DocumentParser, ElementParser, Element, XMLException;
++        import undead.xml: DocumentParser, ElementParser, Element, XMLException;
+ 
+         try {
+             DocumentParser parser = new DocumentParser(ui);

--- a/app-utils/tilix/autobuild/patches/0001-Arch-Linux-undeaD-xml.patch
+++ b/app-utils/tilix/autobuild/patches/0001-Arch-Linux-undeaD-xml.patch
@@ -2,20 +2,11 @@ diff --git a/meson.build b/meson.build
 index 79981a96..c7e9cc34 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -7,7 +7,7 @@ project(
- 
- compiler = meson.get_compiler('d')
- if compiler.get_id() == 'llvm'
--  d_extra_args = ['-vcolumns']
-+  d_extra_args = ['-vcolumns', '-I=../undeaD-1.1.8/src']
-   d_link_args = []
- else
-   d_extra_args = []
 @@ -29,6 +29,7 @@ iconsdir = datadir / 'icons' / 'hicolor'
  appdir = datadir / 'applications'
  
  tilix_sources = [
-+    'undeaD-1.1.8/src/undead/xml.d',
++    '/usr/include/d/undead/xml.d',
      'source/gx/gtk/actions.d',
      'source/gx/gtk/cairo.d',
      'source/gx/gtk/clipboard.d',

--- a/app-utils/tilix/autobuild/prepare
+++ b/app-utils/tilix/autobuild/prepare
@@ -1,7 +1,11 @@
 abinfo "Unsetting flags for D compiler ..."
 # FIXME: Any way to pass Autobuild3 flags correctly?
-unset CFLAGS LDFLAGS
+unset LDFLAGS
 
-abinfo "Bundling undeaD to fix build with newer LDC ..."
-ln -sv "$SRCDIR"/../undeaD-${__UNDEADVER} \
-    "$SRCDIR"/undeaD-${__UNDEADVER}
+DFLAGS="-g --dwarf-version=5 --relocation-model=pic -L-Wl,-build-id=sha1"
+LDFLAGS="-L-Wl,-build-id=sha1 -fPIC"
+if ! bool "$NOLTO"; then
+    DFLAGS="$DFLAGS -flto=full --gcc=clang"
+fi
+
+export DFLAGS

--- a/app-utils/tilix/autobuild/prepare
+++ b/app-utils/tilix/autobuild/prepare
@@ -1,3 +1,7 @@
 abinfo "Unsetting flags for D compiler ..."
 # FIXME: Any way to pass Autobuild3 flags correctly?
 unset CFLAGS LDFLAGS
+
+abinfo "Bundling undeaD to fix build with newer LDC ..."
+ln -sv "$SRCDIR"/../undeaD-${__UNDEADVER} \
+    "$SRCDIR"/undeaD-${__UNDEADVER}

--- a/app-utils/tilix/spec
+++ b/app-utils/tilix/spec
@@ -1,4 +1,9 @@
 VER=1.9.5
-SRCS="git::commit=tags/$VER::https://github.com/gnunn1/tilix"
-CHKSUMS="SKIP"
+__UNDEADVER=1.1.8
+REL=1
+SRCS="git::commit=tags/$VER;rename=tilix::https://github.com/gnunn1/tilix \
+      git::commit=tags/v${__UNDEADVER};rename=undeaD-${__UNDEADVER}::https://github.com/dlang/undeaD"
+CHKSUMS="SKIP \
+         SKIP"
 CHKUPDATE="anitya::id=10148"
+SUBDIR="tilix"

--- a/app-utils/tilix/spec
+++ b/app-utils/tilix/spec
@@ -1,9 +1,6 @@
 VER=1.9.5
-__UNDEADVER=1.1.8
 REL=1
-SRCS="git::commit=tags/$VER;rename=tilix::https://github.com/gnunn1/tilix \
-      git::commit=tags/v${__UNDEADVER};rename=undeaD-${__UNDEADVER}::https://github.com/dlang/undeaD"
-CHKSUMS="SKIP \
-         SKIP"
+SRCS="git::commit=tags/$VER;rename=tilix::https://github.com/gnunn1/tilix"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10148"
 SUBDIR="tilix"

--- a/desktop-gnome/gtkd/spec
+++ b/desktop-gnome/gtkd/spec
@@ -1,5 +1,5 @@
 VER=3.10.0
-REL=1
+REL=2
 SRCS="https://github.com/gtkd-developers/GtkD/archive/v$VER.tar.gz"
 CHKSUMS="sha256::5c6edcdcfb6160ffc1524ab4996471e608c3632d81bd8ea689cf0e52ed13e953"
 CHKUPDATE="anitya::id=228569"

--- a/lang-dlang/undead/autobuild/build
+++ b/lang-dlang/undead/autobuild/build
@@ -1,0 +1,3 @@
+abinfo 'Installing header files ...'
+install -dv "$PKGDIR"/usr/include/d/
+cp -rv "$SRCDIR"/src/undead "$PKGDIR"/usr/include/d/

--- a/lang-dlang/undead/autobuild/defines
+++ b/lang-dlang/undead/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=undead
+PKGSEC=devel
+PKGDES="A collection of obsolete Phobos modules"
+
+ABHOST=noarch

--- a/lang-dlang/undead/spec
+++ b/lang-dlang/undead/spec
@@ -1,0 +1,3 @@
+VER=1.1.8
+SRCS="tbl::https://github.com/dlang/undeaD/archive/refs/tags/v$VER.tar.gz"
+CHKSUMS="sha256::36a59b4740b147f4345caa26908f40a97fc7cc67dac6983c226369c59f909e92"


### PR DESCRIPTION
Topic Description
-----------------

This topic rebuilds `gtkd` and `tilix`, which was not done in the previous LLVM topic (#4646).

Package(s) Affected
-------------------

- `gtkd`
- `tilix`

Security Update?
----------------

No

Build Order
-----------

```
gtkd tilix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`