### PR TITLE
bash-startup: update to 0.4.7.7

### DIFF
--- a/runtime-data/bash-startup/spec
+++ b/runtime-data/bash-startup/spec
@@ -1,4 +1,4 @@
-VER=0.4.7.5
+VER=0.4.7.7
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226642"


### PR DESCRIPTION
Topic Description
-----------------

Update `bash-startup` to v0.4.7.7, fixing an issue where variable names enters completion for `cd`.

Package(s) Affected
-------------------

`bash-startup` v0.4.7.7

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
