### PR TITLE
fcitx5-pinyin-moegirl: update to 20230814

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20230714
+VER=20230814
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::13c2b6e6e448c1910df225fca3b4b2f653419bc59fa896184ace7445e7a23059 \
-         sha256::4ba143c84ff10ad062d8909ccdcba1e7a9130b3904c9ed2e0457bfde3d49dce5 \
+CHKSUMS="sha256::31468b923446105ec761130167e7dff7783c2420dc7fe48983eeb17c5e1ece54 \
+         sha256::5a5edafcb5cfdb31862a359c9b52238a58d2f84c8e0c33905f60fdc2ec187244 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

fcitx5-pinyin-moegirl: update to 20230814

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`