### PR TITLE
less: update to version 643

### DIFF
--- a/app-utils/less/autobuild/defines
+++ b/app-utils/less/autobuild/defines
@@ -5,7 +5,6 @@ PKGSEC=utils
 
 AUTOTOOLS_AFTER="--enable-largefile \
                  --with-secure \
-                 --with-no-float=no \
                  --with-regex=pcre2 \
                  --with-editor=editor"
 

--- a/app-utils/less/autobuild/prepare
+++ b/app-utils/less/autobuild/prepare
@@ -1,1 +1,0 @@
-chmod +x $SRCDIR/configure

--- a/app-utils/less/spec
+++ b/app-utils/less/spec
@@ -1,4 +1,4 @@
-VER=608
+VER=643
 SRCS="http://www.greenwoodsoftware.com/less/less-$VER.tar.gz"
-CHKSUMS="sha256::a69abe2e0a126777e021d3b73aa3222e1b261f10e64624d41ec079685a6ac209"
+CHKSUMS="sha256::2911b5432c836fa084c8a2e68f6cd6312372c026a58faaa98862731c8b6052e8"
 CHKUPDATE="anitya::id=1550"


### PR DESCRIPTION
Topic Description
-----------------

* Fixes CVE-2022-46663
* Closes #4408
* Closes #4576 by superseding 

Package(s) Affected
-------------------

less

Security Update?
----------------

Yes #4408


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
