### PR TITLE
edid-decode: new, 0.1+git20230804

### DIFF
--- a/app-utils/edid-decode/autobuild/build
+++ b/app-utils/edid-decode/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building edid-decode ..."
+make
+
+abinfo "Installing edid-decode ..."
+make install \
+    DESTDIR="$PKGDIR"

--- a/app-utils/edid-decode/autobuild/defines
+++ b/app-utils/edid-decode/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=edid-decode
+PKGSEC=utils
+PKGDEP="glibc"
+PKGDES="Decode EDID data in human-readable format"

--- a/app-utils/edid-decode/spec
+++ b/app-utils/edid-decode/spec
@@ -1,0 +1,4 @@
+VER=0+git20230804
+SRCS="git::commit=5f723267e04deb3aa9610483514a02bcee10d9c2::https://git.linuxtv.org/edid-decode.git"
+CHKSUMS="sha256::c10823c940641404cd6eb9c801d43b307e87e9252e8eded66eed8be750c4f884"
+# FIXME: no CHKUPDATE available


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->

edid-decode: new, 0.1+git20230804

https://git.linuxtv.org/edid-decode.git/about/

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

- edid-decode

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
