### PR TITLE
Remmina 1.4.31

### DIFF
--- a/app-network/freerdp/spec
+++ b/app-network/freerdp/spec
@@ -1,4 +1,4 @@
-VER=2.8.1
+VER=2.10.0
 SRCS="tbl::https://pub.freerdp.com/releases/freerdp-${VER/rc/-rc}.tar.gz"
-CHKSUMS="sha256::ea8903b29914134202a972c06052432678c89cb5eebcc8f5a41553030c97376b"
+CHKSUMS="sha256::a673d3fc21911dd9f196834f2f3a23c3ebc7e5e4deab2f7686fcec879279e2c1"
 CHKUPDATE="anitya::id=10442"

--- a/app-network/remmina/autobuild/defines
+++ b/app-network/remmina/autobuild/defines
@@ -1,14 +1,49 @@
 PKGNAME=remmina
 PKGSEC=net
-PKGDEP="gtk-3 zlib libjpeg-turbo libssh libunique avahi vte-gtk3 libgcrypt \
+PKGDEP="gtk-3 zlib libjpeg-turbo libssh libunique avahi libgcrypt \
 	freerdp telepathy-glib libvncserver libappindicator webkit2gtk \
-	libsodium libspice-gtk "
-BUILDDEP="gnome-keyring kwallet"
+	libsodium libspice-gtk cups vte libsecret"
+BUILDDEP="gnome-keyring kwallet spice-protocol"
 PKGSUG="gnome-keyring kwallet"
 PKGDES="A remote desktop client written in GTK+"
 
-CMAKE_AFTER="
-	-DWITH_NEWS=OFF
-	-DWITH_APPINDICATOR=ON
-	-DWITH_KF5WALLET=ON
-"
+# Note: -DWITH_ICON_CACHE, Generate the icon cache during install target.
+# Note: -DWITH_UPDATE_DESKTOP_DB, Generate desktop files cache database.
+#
+# FIXME: -DWITH_NX=OFF, plugin broken and orphaned
+# (Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1660515).
+# FIXME: -DWITH_{ST,XDMCP}=OFF, plugin orphaned.
+# FIXME: -DWITH_X2GO=OFF, introduce X2Go stack at a later date (tester needed).
+CMAKE_AFTER="-DHAVE_LIBAPPINDICATOR=ON \
+             -DSNAP_BUILD_ONLY=OFF \
+             -DWITH_AVAHI=ON \
+             -DWITH_CUPS=ON \
+             -DWITH_FREERDP_MASTER=OFF \
+             -DWITH_GCRYPT=ON \
+             -DWITH_GETTEXT=ON \
+             -DWITH_GVNC=ON \
+             -DWITH_ICON_CACHE=OFF \
+             -DWITH_KF5WALLET=ON \
+             -DWITH_KIOSK_SESSION=OFF \
+             -DWITH_LIBSECRET=ON \
+             -DWITH_LIBSSH=ON \
+             -DWITH_LIBVNCSERVER=ON \
+             -DWITH_MANPAGES=ON \
+             -DWITH_NX=OFF \
+             -DWITH_PYTHONLIBS=ON \
+             -DWITH_SPICE=ON \
+             -DWITH_ST=OFF \
+             -DWITH_TRANSLATIONS=ON \
+             -DWITH_UPDATE_DESKTOP_DB=OFF \
+             -DWITH_VTE=ON \
+             -DWITH_WEBKIT2GTK=ON \
+             -DWITH_WWW=ON \
+             -DWITH_X2GO=ON \
+             -DWITH_XDMCP=OFF \
+             -Dsodium_USE_STATIC_LIBS=OFF
+             -DWITH_IPP=OFF \
+             -DWITH_SSE2=OFF"
+CMAKE_AFTER__AMD64=" \
+             ${CMAKE_AFTER} \
+             -DWITH_IPP=ON \
+             -DWITH_SSE2=ON"

--- a/app-network/remmina/autobuild/patches/0001-desktop-entry-drop-kiosk-mode-action.patch
+++ b/app-network/remmina/autobuild/patches/0001-desktop-entry-drop-kiosk-mode-action.patch
@@ -1,0 +1,29 @@
+diff -Naur Remmina-v1.4.31-7407cc3a27eb25ba4ddddeab565f67fd688324ed/data/desktop/org.remmina.Remmina.desktop.in Remmina-v1.4.31-7407cc3a27eb25ba4ddddeab565f67fd688324ed.nokiosk/data/desktop/org.remmina.Remmina.desktop.in
+--- Remmina-v1.4.31-7407cc3a27eb25ba4ddddeab565f67fd688324ed/data/desktop/org.remmina.Remmina.desktop.in	2023-06-07 21:13:28.000000000 +0800
++++ Remmina-v1.4.31-7407cc3a27eb25ba4ddddeab565f67fd688324ed.nokiosk/data/desktop/org.remmina.Remmina.desktop.in	2023-08-21 12:22:11.927448436 +0800
+@@ -79,7 +79,7 @@
+ Keywords=remote desktop;rdp;vnc;ssh;spice;
+ StartupWMClass=@REMMINA_APP_ID@
+ MimeType=x-scheme-handler/rdp;x-scheme-handler/spice;x-scheme-handler/vnc;x-scheme-handler/ssh;x-scheme-handler/remmina;application/x-remmina;
+-Actions=Kiosk;Profile;Tray;Quit;
++Actions=Profile;Tray;Quit;
+ 
+ [Desktop Action Profile]
+ Name=Create a New Connection Profile
+@@ -106,16 +106,6 @@
+ Name[zh_CN]=新建连接配置
+ Exec=@REMMINA_BINARY_PATH@ --new
+ 
+-[Desktop Action Kiosk]
+-# Start Remmina with a minimal interface for kiosk/thin client mode
+-Name=Start Remmina in Kiosk mode
+-Name[da]=Start Remmina i kiosk-tilstand
+-Name[fr]=Démarrer Remmina en mode Kiosque
+-Name[hr]=Pokreni Remminu u Kisok načinu
+-Name[it]=Avvia Remmina in modo Chiosco
+-Name[uk]=Запустити Remmina у режимі кіоску
+-Exec=@REMMINA_BINARY_PATH@ --kiosk
+-
+ [Desktop Action Tray]
+ Name=Start Remmina Minimized
+ Name[ca]=Inicia el Remmina minimitzat

--- a/app-network/remmina/spec
+++ b/app-network/remmina/spec
@@ -1,5 +1,4 @@
-VER=1.4.11
+VER=1.4.31
 SRCS="tbl::https://gitlab.com/Remmina/Remmina/-/archive/v${VER}/Remmina-v{VER}.tar.gz"
-CHKSUMS="sha256::3991bb41ccc73e4183f8b786048fcbfcaf8b825d82f6fd168886a0151a781b76"
+CHKSUMS="sha256::5f28c219b411a4c185bdaf49f7dc80c3d30db915139975823fe249492f826d55"
 CHKUPDATE="anitya::id=4188"
-REL=4


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Remmina to 1.4.31, which fixes an issue with clipboard-induced hangs (since 1.4.24, see [upstream report](https://gitlab.com/Remmina/Remmina/-/issues/1951). It also updates FreeRDP to 2.10.0 to fix random crashes caused by double-free.

Package(s) Affected
-------------------

- `freerdp` v2.10.0
- `remmina` v1.4.31

Security Update?
----------------

No

Build Order
-----------

```
freerdp remmina
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`