### PR TITLE
gdb: update to 13.2

### DIFF
--- a/app-devel/gdb/autobuild/beyond
+++ b/app-devel/gdb/autobuild/beyond
@@ -3,8 +3,8 @@ install -dvm755 "$PKGDIR"/etc/gdb
 touch "$PKGDIR"/etc/gdb/gdbinit
 
 abinfo "Removing files found in Binutils..."
-rm -v "$PKGDIR"/usr/include/{ansidecl,bfd,bfdlink,ctf,ctf-api,dis-asm,plugin-api,symcat}.h
-rm -v "$PKGDIR"/usr/share/info/{bfd,ctf-spec}.info
+rm -v "$PKGDIR"/usr/include/{ansidecl,bfd,bfdlink,ctf,ctf-api,dis-asm,plugin-api,sframe,sframe-api,symcat}.h
+rm -v "$PKGDIR"/usr/share/info/{bfd,ctf-spec,sframe-spec}.info
 rm -v "$PKGDIR"/usr/lib/{libbfd,libopcodes}.a
 rm -v "$PKGDIR"/usr/share/locale/*/*/{bfd,opcodes}.mo
 rm -fv "$PKGDIR"/usr/bin/run*

--- a/app-devel/gdb/autobuild/beyond
+++ b/app-devel/gdb/autobuild/beyond
@@ -5,4 +5,3 @@ touch "$PKGDIR"/etc/gdb/gdbinit
 abinfo "Removing files found in Binutils..."
 rm -v "$PKGDIR"/usr/share/info/{bfd,ctf-spec,sframe-spec}.info
 rm -v "$PKGDIR"/usr/share/locale/*/*/{bfd,opcodes}.mo
-rm -fv "$PKGDIR"/usr/bin/run*

--- a/app-devel/gdb/autobuild/beyond
+++ b/app-devel/gdb/autobuild/beyond
@@ -3,8 +3,6 @@ install -dvm755 "$PKGDIR"/etc/gdb
 touch "$PKGDIR"/etc/gdb/gdbinit
 
 abinfo "Removing files found in Binutils..."
-rm -v "$PKGDIR"/usr/include/{ansidecl,bfd,bfdlink,ctf,ctf-api,dis-asm,plugin-api,sframe,sframe-api,symcat}.h
 rm -v "$PKGDIR"/usr/share/info/{bfd,ctf-spec,sframe-spec}.info
-rm -v "$PKGDIR"/usr/lib/{libbfd,libopcodes}.a
 rm -v "$PKGDIR"/usr/share/locale/*/*/{bfd,opcodes}.mo
 rm -fv "$PKGDIR"/usr/bin/run*

--- a/app-devel/gdb/autobuild/defines
+++ b/app-devel/gdb/autobuild/defines
@@ -19,7 +19,7 @@ AUTOTOOLS_AFTER="--with-system-readline --with-xxhash \
                  --with-system-gdbinit=/etc/gdb/gdbinit \
                  --enable-guile --enable-tui --enable-sim \
                  --enable-source-highlight --enable-threading \
-                 --enable-64-bit-bfd \
+                 --enable-64-bit-bfd --disable-install-libbfd \
                  --enable-targets=all --enable-languages=all"
 # TODO: Re-check this when updating this package in Retro
 AUTOTOOLS_AFTER__RETRO=" \

--- a/app-devel/gdb/spec
+++ b/app-devel/gdb/spec
@@ -1,5 +1,4 @@
-VER=12.1
-REL=2
+VER=13.2
 SRCS="tbl::https://ftp.gnu.org/gnu/gdb/gdb-$VER.tar.xz"
-CHKSUMS="sha256::0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed"
+CHKSUMS="sha256::fd5bebb7be1833abdb6e023c2f498a354498281df9d05523d8915babeb893f0a"
 CHKUPDATE="anitya::id=11798"

--- a/core-devel/binutils/autobuild/beyond
+++ b/core-devel/binutils/autobuild/beyond
@@ -1,6 +1,5 @@
 abinfo "Remove files to avoid conflicts with GDB, etc..."
 rm -v "$PKGDIR"/usr/share/man/man1/{dlltool,nlmconv,windres,windmc}*
-rm -v "$PKGDIR"/usr/include/diagnostics.h
 
 abinfo "Remove libbfd.so symlink to force 3rdparty applications to statically link libbfd..."
 rm -v "$PKGDIR"/usr/lib/libbfd.so

--- a/core-devel/binutils/autobuild/defines
+++ b/core-devel/binutils/autobuild/defines
@@ -2,6 +2,9 @@ PKGNAME=binutils
 PKGSEC=devel
 PKGDEP="glibc zlib"
 PKGDES="A set of programs to assemble and manipulate binary and object files"
+# diagnostics.h moved from gdb to binutils
+PKGBREAK="gdb<=12.1-2"
+PKGREP="gdb<=12.1-2"
 
 NOSTATIC=0
 NOLTO=1

--- a/core-devel/binutils/spec
+++ b/core-devel/binutils/spec
@@ -1,4 +1,5 @@
 VER=2.40
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/binutils/binutils-$VER.tar.xz"
 CHKSUMS="sha256::0f8a4c272d7f17f369ded10a4aca28b8e304828e95526da482b0ccc4dfc9d8e1"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->

- bump gdb to 13.2
- do not install libbfd in gdb
- do not remove run* in gdb
- do not remove diagnostics.h in binutils
- add PKGBREAK and PKGREP to avoid conflict:

```shell
dpkg: regarding .../b/binutils_2.40-1_amd64.deb containing binutils:
 binutils breaks gdb (<= 12.1-2)
  gdb (version 12.1-2) is present and installed.

dpkg: error processing archive /home/jiegec/ciel-amd64/OUTPUT-gdb-13.2/debs/b/binutils_2.40-1_amd64.deb (--install):
 installing binutils would break gdb, and
 deconfiguration is not permitted (--auto-deconfigure might help)
Errors were encountered while processing:
 /home/jiegec/ciel-amd64/OUTPUT-gdb-13.2/debs/b/binutils_2.40-1_amd64.deb
```

Upgrade cleanly:

```shell
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Calculating upgrade... Done
The following packages will be upgraded:
  binutils gdb
2 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 58.8 MB of archives.
After this operation, 3,908 kB of additional disk space will be used.
Do you want to continue? [Y/n]
Get:1 http://127.0.0.1:8000/debs gdb-13.2/main amd64 gdb amd64 13.2 [51.0 MB]
Get:2 http://127.0.0.1:8000/debs gdb-13.2/main amd64 binutils amd64 2.40-1 [7,788 kB]
Fetched 58.8 MB in 0s (131 MB/s)
(Reading database ... 638958 files and directories currently installed.)
Preparing to unpack .../archives/gdb_13.2_amd64.deb ...
Unpacking gdb (13.2) over (12.1-2) ...
Preparing to unpack .../binutils_2.40-1_amd64.deb ...
Unpacking binutils (2.40-1) over (2.40) ...
Setting up binutils (2.40-1) ...
Setting up gdb (13.2) ...
Processing triggers for texinfo (7.0.1) ...
Updating and installing Texinfo pages...

```

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

- gdb
- binutils

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

```
binutils gdb
```


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
