### PR TITLE
zotero: update to 6.0.26

### DIFF
--- a/app-productivity/zotero/spec
+++ b/app-productivity/zotero/spec
@@ -1,10 +1,9 @@
-VER=6.0.3
-_STANDALONE_VER=6.0.1
-_BUILD_REPO_COMMIT=87e125bedcb3a01194013e207eff39d4e6deec92
+VER=6.0.26
+_BUILD_REPO_COMMIT=5cec38cd40361d939e32eb0b6e0fd18ac7b78a56
 SRCS="
 	git::commit=tags/${VER};rename=zotero-client::https://github.com/zotero/zotero.git
 	git::commit=${_BUILD_REPO_COMMIT};rename=zotero-build::https://github.com/zotero/zotero-build.git
-	git::commit=tags/${_STANDALONE_VER};rename=zotero-standalone-build::https://github.com/zotero/zotero-standalone-build.git
+	git::commit=${VER}-hotfix;rename=zotero-standalone-build::https://github.com/zotero/zotero-standalone-build.git
 "
 CHKSUMS="
 	SKIP


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Zotero: update to `6.0.26`
- some add-ons are not working on current version (`6.0.3`)

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->

No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->




Build Order
-----------

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->
<!-- 

```
pkg1 pkg2 pkg3 ...
```

-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
