### PR TITLE
discord: update to 0.0.29

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.28
+VER=0.0.29
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::270c55566fd02012e857243615ffcc5f4e9436067e740b03f7ad06b0283533e5"
+CHKSUMS="sha256::def8cebe4a8c0fba8a5f6cd151b2abc39807b44feff167c7e79eebb5a8162167"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Discord to 0.0.29.

Package(s) Affected
-------------------

`discord` v0.0.29

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   