### PR TITLE
Maliit Survey 20230911

### DIFF
--- a/app-utils/maliit-framework/autobuild/defines
+++ b/app-utils/maliit-framework/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=maliit-framework
+PKGDES="Core framework of Maliit virtual keyboard"
+PKGSEC=x11
+PKGDEP="systemd gtk-3 qt-5 libxcb libxkbcommon wayland glib"
+BUILDDEP="graphviz doxygen wayland-protocols"
+
+CMAKE_AFTER="-Denable-wayland-gtk=ON -Denable-tests=OFF"

--- a/app-utils/maliit-framework/spec
+++ b/app-utils/maliit-framework/spec
@@ -1,0 +1,4 @@
+VER=2.3.0
+SRCS="git::commit=tags/$VER::https://github.com/maliit/framework"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=369153"

--- a/app-utils/maliit-keyboard/autobuild/defines
+++ b/app-utils/maliit-keyboard/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=maliit-keyboard
+PKGDES="Keyboard implementation of Maliit virtual keyboard"
+PKGSEC=x11
+PKGDEP="maliit-framework anthy libpinyin hunspell qt-5 dconf"
+
+CMAKE_AFTER="-Denable-tests=OFF -Denable-presage=OFF"

--- a/app-utils/maliit-keyboard/autobuild/prepare
+++ b/app-utils/maliit-keyboard/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Hacking for broken qt-5 QtFeedback ..."
+rm -v /usr/lib64/cmake/Qt5Feedback/Qt5Feedback_.cmake

--- a/app-utils/maliit-keyboard/spec
+++ b/app-utils/maliit-keyboard/spec
@@ -1,0 +1,4 @@
+VER=2.3.1
+SRCS="git::commit=tags/$VER::https://github.com/maliit/keyboard"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=369155"

--- a/desktop-kde/plasma-mobile/autobuild/defines
+++ b/desktop-kde/plasma-mobile/autobuild/defines
@@ -6,6 +6,7 @@ PKGDEP="plasma-framework ofono libqofono kpeople telepathy-qt \
         powerdevil plasma-workspace signon urfkill plasma-nano \
         modemmanager-qt plasma-pa plasma-nm kirigami-addons \
         kpipewire"
+PKGRECOM="maliit-keyboard"
 BUILDDEP="extra-cmake-modules"
 
 PKGBREAK="plasma-phone-components"

--- a/desktop-kde/plasma-mobile/spec
+++ b/desktop-kde/plasma-mobile/spec
@@ -1,5 +1,5 @@
 VER=5.27.5
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-mobile-$VER.tar.xz"
 CHKSUMS="sha256::cc1b2fbb64291fd63a498b7f9c8139e6a8a6a6a0a30c505f6eaa503e2dc2c140"
 CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
Topic Description
-----------------

This topic tries to import Maliit virtual keyboard, which integrates with Plasma Wayland well, and being the chosen one for Plasma Mobile.

Package(s) Affected
-------------------

- `maliit-framework`
- `maliit-keyboard`
- `plasma-mobile` (adding maliit-keyboard to RECOM because it's specified in plamo startup script)

Security Update?
----------------

No

Build Order
-----------

`maliit-framework maliit-keyboard plasma-mobile`

-->

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
