### PR TITLE
Go survey: 1.21.0

### DIFF
--- a/app-admin/conmon/autobuild/defines
+++ b/app-admin/conmon/autobuild/defines
@@ -2,5 +2,6 @@ PKGNAME=conmon
 PKGSEC=admin
 PKGDES="OCI container runtime monitor"
 PKGDEP="glib"
+BUILDDEP="go"
 
 ABTYPE=plainmake

--- a/app-admin/conmon/spec
+++ b/app-admin/conmon/spec
@@ -1,4 +1,4 @@
-VER=2.0.31
+VER=2.1.8
 SRCS="https://github.com/containers/conmon/archive/v$VER.tar.gz"
-CHKSUMS="sha256::76286480065d4cf9b24610c159c683710fe9c8b9f753518f804f22bbb59796a8"
+CHKSUMS="sha256::e72c090210a03ca3b43a0fad53f15bca90bbee65105c412468009cf3a5988325"
 CHKUPDATE="anitya::id=96793"

--- a/app-admin/criu/autobuild/patches/0001-plugins-amdgpu-Makefile-add-missing-defines.patch
+++ b/app-admin/criu/autobuild/patches/0001-plugins-amdgpu-Makefile-add-missing-defines.patch
@@ -1,0 +1,25 @@
+From fbe9855d513deaa65528fb7a962001aeba8cfce6 Mon Sep 17 00:00:00 2001
+From: Cyan <cyan@cyano.uk>
+Date: Wed, 20 Sep 2023 18:46:38 -0700
+Subject: [PATCH] plugins/amdgpu/Makefile: add missing defines
+
+---
+ plugins/amdgpu/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/amdgpu/Makefile b/plugins/amdgpu/Makefile
+index 64a923d..d5c2652 100644
+--- a/plugins/amdgpu/Makefile
++++ b/plugins/amdgpu/Makefile
+@@ -29,7 +29,7 @@ criu-amdgpu.pb-c.c: criu-amdgpu.proto
+ 		protoc-c --proto_path=. --c_out=. criu-amdgpu.proto
+ 
+ amdgpu_plugin.so: amdgpu_plugin.c amdgpu_plugin_topology.c criu-amdgpu.pb-c.c
+-	$(CC) $(PLUGIN_CFLAGS) $(shell $(COMPEL) includes) $^ -o $@ $(PLUGIN_INCLUDE) $(PLUGIN_LDFLAGS) $(LIBDRM_INC)
++	$(CC) $(DEFINES) $(PLUGIN_CFLAGS) $(shell $(COMPEL) includes) $^ -o $@ $(PLUGIN_INCLUDE) $(PLUGIN_LDFLAGS) $(LIBDRM_INC)
+ 
+ amdgpu_plugin_clean:
+ 	$(call msg-clean, $@)
+-- 
+2.39.1
+

--- a/app-admin/criu/autobuild/patches/0002-use-longlong-in-this-project.patch.loongson3
+++ b/app-admin/criu/autobuild/patches/0002-use-longlong-in-this-project.patch.loongson3
@@ -1,0 +1,11 @@
+--- a/Makefile	2023-09-22 05:46:13.307308089 +0000
++++ b/Makefile	2023-09-22 05:46:35.565139064 +0000
+@@ -77,7 +77,7 @@
+ endif
+ 
+ ifeq ($(ARCH),mips)
+-        DEFINES		:= -DCONFIG_MIPS
++        DEFINES		:= -DCONFIG_MIPS -D__SANE_USERSPACE_TYPES__
+ endif
+ 
+ #

--- a/app-admin/criu/spec
+++ b/app-admin/criu/spec
@@ -1,4 +1,4 @@
-VER=3.16.1
+VER=3.18
 SRCS="tbl::http://github.com/checkpoint-restore/criu/archive/v$VER/criu-$VER.tar.gz"
-CHKSUMS="sha256::13d6e2f99a34abf83ec2b9777af5bd069e739bf38582857c7f4c19a355a2b0b5"
+CHKSUMS="sha256::6a9997981c9fe4730c848ce59346b3a22fad69b803607cb67a3f6ec0557fa474"
 CHKUPDATE="anitya::id=366"

--- a/app-containers/docker-compose/autobuild/build
+++ b/app-containers/docker-compose/autobuild/build
@@ -1,0 +1,13 @@
+# Translated from Makefile
+abinfo "Gathering info..."
+GO_LDFLAGS="$GO_LDFLAGS -w -X github.com/docker/compose/v2/internal.Version=${PKGVER}"
+GO_BUILDTAGS=e2e
+
+abinfo "Building docker-compose..."
+cd "$SRCDIR"
+env GO111MODULE=on \
+	go build ${GOFLAGS} -trimpath -tags "${O_BUILDTAGS}" -ldflags "${GO_LDFLAGS}" -o "$SRCDIR"/bin/build/docker-compose ./cmd
+
+abinfo "Installing $PKGNAME ..."
+install -Dvm755 "$SRCDIR"/bin/build/docker-compose "$PKGDIR"/usr/lib/docker/cli-plugins/docker-compose
+install -Dvm644 "$SRCDIR"/packaging/LICENSE "$PKGDIR"/usr/share/doc/docker-compose/LICENSE

--- a/app-containers/docker-compose/autobuild/defines
+++ b/app-containers/docker-compose/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=docker-compose
+PKGDES="Define and run multi-container applications with Docker"
+PKGSEC=admin
+PKGDEP="docker"
+BUILDDEP="go"
+
+FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64)"
+ABSPLITDBG=0

--- a/app-containers/docker-compose/spec
+++ b/app-containers/docker-compose/spec
@@ -1,0 +1,4 @@
+VER=2.21.0
+SRCS="tbl::https://github.com/docker/compose/archive/refs/tags/v${VER}.tar.gz"
+CHKSUMS="sha256::0014b23382a50c90f91849e491500568366052882e22011822ca2d8a3b2976f2"
+CHKUPDATE="anitya::id=6185"

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -1,10 +1,13 @@
 # Find tini version at:
 #
 # https://github.com/moby/moby/blob/v$PKGVER/hack/dockerfile/install/tini.installer
-VER=23.0.1+tini0.19.0
-SRCS="git::commit=tags/v${VER%%+tini*};rename=cli::https://github.com/docker/cli \
-      git::commit=tags/v${VER%%+tini*};rename=moby::https://github.com/moby/moby \
-      git::commit=tags/v${VER##*+tini};rename=tini::https://github.com/krallin/tini"
+TINI_VER=0.19.0
+DOCKER_VER=24.0.6
+
+VER=${DOCKER_VER}+tini${TINI_VER}
+SRCS="git::commit=tags/v${DOCKER_VER};rename=cli::https://github.com/docker/cli \
+      git::commit=tags/v${DOCKER_VER};rename=moby::https://github.com/moby/moby \
+      git::commit=tags/v${TINI_VER};rename=tini::https://github.com/krallin/tini"
 CHKSUMS="SKIP \
          SKIP \
          SKIP"

--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,7 +1,7 @@
-VER=4.4.1
+VER=4.6.2
 SRCS="tbl::https://github.com/containers/podman/archive/v${VER}.tar.gz \
-      git::commit=tags/v0.5.0;rename=gvisor-tap-vsock::https://github.com/containers/gvisor-tap-vsock"
-CHKSUMS="sha256::0b84dbc3ca1d3cc75708635e3a322c481bb679103040866024b1fa2be6826455 \
+      git::commit=tags/v0.7.0;rename=gvisor-tap-vsock::https://github.com/containers/gvisor-tap-vsock"
+CHKSUMS="sha256::2d8e04f0c3819c3f0ed1ca5d01da87e6d911571b96ae690448f7f75df41f2ad1 \
          SKIP"
 CHKUPDATE="anitya::id=93284"
 SUBDIR="podman-$VER"

--- a/app-database/mongodb/autobuild/build
+++ b/app-database/mongodb/autobuild/build
@@ -10,6 +10,13 @@ S_CXXFLAGS="$(echo "$CXXFLAGS" | tr -s ' ')"
 CFLAGS=''
 CXXFLAGS=''
 
+# FIXME: ld.gold is not available in these targets:
+linker=gold
+if ab_match_arch riscv64 || ab_match_arch loongarch64 ; then
+	abinfo "Using bfd as linker instead of gold..."
+	linker=bfd
+fi
+
 abinfo "Invoking scons ..."
 scons install-core \
 	${MAKEFLAGS/ /} \
@@ -20,6 +27,7 @@ scons install-core \
         --use-system-zstd \
         --ssl \
         --lto=on \
+	--linker=$linker \
 	--disable-warnings-as-errors \
 	--wiredtiger=on \
 	--force-jobs \

--- a/app-database/mongodb/autobuild/defines
+++ b/app-database/mongodb/autobuild/defines
@@ -1,10 +1,8 @@
 PKGNAME=mongodb
 PKGSEC=database
 PKGDEP="pcre snappy openssl gperftools cyrus-sasl libpcap yaml-cpp"
-BUILDDEP="scons valgrind typing pyyaml cheetah3 go pymongo"
+BUILDDEP="scons valgrind typing pyyaml cheetah3 go pymongo mongo-tooling-metrics"
 PKGDES="A high performance, open source, schema-free and document oriented database"
-
-FAIL_ARCH="!(amd64|arm64|ppc64el)"
 
 PKGBREAK="mongodb-tools<=4.0.0"
 PKGREP="mongodb-tools<=4.0.0"

--- a/app-database/mongodb/autobuild/patches/0002-free_mon_options-fix-build-on-GCC-13.patch
+++ b/app-database/mongodb/autobuild/patches/0002-free_mon_options-fix-build-on-GCC-13.patch
@@ -1,0 +1,24 @@
+From 7ef0e7bef54f8fa14544454e556f99f71ae7ba23 Mon Sep 17 00:00:00 2001
+From: Cyan <cyan@cyano.uk>
+Date: Mon, 11 Sep 2023 05:29:33 -0700
+Subject: [PATCH] free_mon_options: fix build on GCC 13
+
+---
+ src/mongo/db/free_mon/free_mon_options.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/mongo/db/free_mon/free_mon_options.h b/src/mongo/db/free_mon/free_mon_options.h
+index 19f707e8b65..6bf8b3b5206 100644
+--- a/src/mongo/db/free_mon/free_mon_options.h
++++ b/src/mongo/db/free_mon/free_mon_options.h
+@@ -31,6 +31,7 @@
+ 
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ 
+ namespace mongo {
+ 
+-- 
+2.39.1
+

--- a/app-database/mongodb/spec
+++ b/app-database/mongodb/spec
@@ -1,8 +1,7 @@
-VER=6.1.1
-REL=1
+VER=7.0.1
 SRCS="tbl::https://fastdl.mongodb.org/src/mongodb-src-r$VER.tar.gz \
       tbl::https://github.com/mongodb/mongo-tools/archive/refs/tags/r4.2.23.tar.gz"
-CHKSUMS="sha256::e85df708aee3c5f0b97216665ecb409b9db45d9013bb97b003e73cee7b406961 \
+CHKSUMS="sha256::448c45a05a053b917bd08a1e2d04b9829838fb97582a371c1bb764893dc14241 \
          sha256::3e138607c8f26b2ea2a83d86114ab8aaebb0764c7a5b005f0e780cdc90a03f8e"
 CHKUPDATE="anitya::id=2008"
 SUBDIR=mongodb-src-r"$VER"

--- a/app-devel/cf-tool/spec
+++ b/app-devel/cf-tool/spec
@@ -1,5 +1,5 @@
 VER=1.0.0
-REL=2
+REL=3
 SRCS="tbl::https://github.com/xalanq/cf-tool/archive/refs/tags/v$VER.tar.gz"
 CHKSUMS="sha256::6671392df969e7decf9bf6b89a43a93c2bde978e005e99ddb7fd84b0c513df9f"
 CHKUPDATE="anitya::id=235020"

--- a/app-devel/git-lfs/autobuild/build
+++ b/app-devel/git-lfs/autobuild/build
@@ -1,18 +1,18 @@
+# Reference: https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/git-lfs
 set +e
 
 pushd "$SRCDIR"
 
-go build \
-	-mod=vendor \
-	-trimpath \
-	.
+go build -trimpath .
+
+abinfo "Building manuals..."
 make man
 
-install -Dm755 git-lfs "$PKGDIR"/usr/bin/git-lfs
+abinfo "Installing git-lfs manuals..."
+pushd "$SRCDIR"/man
+for man in man1 man5 ; do
+	find . -type f -exec install -Dvm644 {} "$PKGDIR"/usr/share/man/{} \;
+done
 install -Dm644 LICENSE.md "$PKGDIR"/usr/share/licenses/git-lfs/LICENSE
-install -Dm644 -t "$PKGDIR"/usr/share/man/man1 man/*.1
-install -Dm644 -t "$PKGDIR"/usr/share/man/man5 man/*.5
-
-# Reference: https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/git-lfs
-
+popd
 popd

--- a/app-devel/git-lfs/autobuild/build
+++ b/app-devel/git-lfs/autobuild/build
@@ -1,6 +1,7 @@
 # Reference: https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/git-lfs
 set +e
 
+abinfo "Building git-lfs..."
 pushd "$SRCDIR"
 
 go build -trimpath .
@@ -8,11 +9,14 @@ go build -trimpath .
 abinfo "Building manuals..."
 make man
 
+abinfo "Installing git-lfs..."
+install -Dm755 git-lfs "$PKGDIR"/usr/bin/git-lfs
+install -Dm644 LICENSE.md "$PKGDIR"/usr/share/doc/git-lfs/LICENSE
+
 abinfo "Installing git-lfs manuals..."
 pushd "$SRCDIR"/man
 for man in man1 man5 ; do
 	find . -type f -exec install -Dvm644 {} "$PKGDIR"/usr/share/man/{} \;
 done
-install -Dm644 LICENSE.md "$PKGDIR"/usr/share/licenses/git-lfs/LICENSE
 popd
 popd

--- a/app-devel/git-lfs/autobuild/defines
+++ b/app-devel/git-lfs/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=git-lfs
 PKGSEC=devel
 PKGDEP="git"
-BUILDDEP="go ronn"
+BUILDDEP="go ronn asciidoctor"
 PKGDES="Git extension for versioning large files"
 ABSPLITDBG=0

--- a/app-devel/git-lfs/spec
+++ b/app-devel/git-lfs/spec
@@ -1,5 +1,4 @@
-VER=3.1.4
+VER=3.4.0
 SRCS=git::commit=tags/v${VER}::https://github.com/git-lfs/git-lfs.git
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11551"
-REL=1

--- a/app-devel/mongo-tooling-metrics/autobuild/defines
+++ b/app-devel/mongo-tooling-metrics/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME="mongo-tooling-metrics"
+PKGDES="A library to collect type enforced metrics and store them in MongoDB databases"
+PKGSEC=python
+PKGDEP="python-3 platformdirs distro pydantic gitpython typing-extensions boto3"
+BUILDDEP="python-build python-installer poetry"
+
+NOPYTHON2=1
+ABSPLITDBG=0

--- a/app-devel/mongo-tooling-metrics/spec
+++ b/app-devel/mongo-tooling-metrics/spec
@@ -1,0 +1,3 @@
+VER=1.0.8
+SRCS="tbl::https://files.pythonhosted.org/packages/5a/9a/582069b66a4f8dece95a600bd7bbbc1befb45213def7c5d89a56f1432cc0/mongo_tooling_metrics-${VER}.tar.gz"
+CHKSUMS="sha256::1f10712b237a8c99551a4b63ce4e62db42aca05ef6d054af728b55081dd477d4"

--- a/app-devices/android-platform-tools/autobuild/patches/0001-HACK-Bring-basic-support-for-ppc64el-to-boringssl.patch.ppc64el
+++ b/app-devices/android-platform-tools/autobuild/patches/0001-HACK-Bring-basic-support-for-ppc64el-to-boringssl.patch.ppc64el
@@ -1,0 +1,27 @@
+From 2c9b59cb15d1ac4134e0f228d233d17256a1c30a Mon Sep 17 00:00:00 2001
+From: Cyan <cyan@cyano.uk>
+Date: Tue, 19 Sep 2023 19:38:07 -0700
+Subject: [PATCH 1/2] HACK: Bring basic support for ppc64el to boringssl
+
+---
+ vendor/boringssl/include/openssl/base.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/vendor/boringssl/include/openssl/base.h b/vendor/boringssl/include/openssl/base.h
+index fb1815f..364c302 100644
+--- a/vendor/boringssl/include/openssl/base.h
++++ b/vendor/boringssl/include/openssl/base.h
+@@ -107,6 +107,10 @@ extern "C" {
+ #define OPENSSL_RISCV64
+ #elif defined(__riscv) && __SIZEOF_POINTER__ == 4
+ #define OPENSSL_32_BIT
++#elif defined(__PPC__) && defined(__LP64__)
++#define OPENSSL_64_BIT
++#elif defined(__PPC__) && !defined(__LP64__)
++#define OPENSSL_32_BIT
+ #elif defined(__pnacl__)
+ #define OPENSSL_32_BIT
+ #define OPENSSL_PNACL
+-- 
+2.39.1
+

--- a/app-devices/android-platform-tools/autobuild/patches/0002-HACK-set-64-bit-types-as-long-instead-of-long-long.patch.ppc64el
+++ b/app-devices/android-platform-tools/autobuild/patches/0002-HACK-set-64-bit-types-as-long-instead-of-long-long.patch.ppc64el
@@ -1,0 +1,76 @@
+From 2cf8fd73ff2cac97a3d95f2e22e0cf19ec748b23 Mon Sep 17 00:00:00 2001
+From: Cyan <cyan@cyano.uk>
+Date: Tue, 19 Sep 2023 19:41:16 -0700
+Subject: [PATCH 2/2] HACK: set 64-bit types as long instead of long long
+
+---
+ vendor/e2fsprogs/lib/ext2fs/ext2_types.h    |  5 +++++
+ vendor/e2fsprogs/lib/ext2fs/ext2_types.h.in | 18 +++++++++++-------
+ 2 files changed, 16 insertions(+), 7 deletions(-)
+
+diff --git a/vendor/e2fsprogs/lib/ext2fs/ext2_types.h b/vendor/e2fsprogs/lib/ext2fs/ext2_types.h
+index 0e5ebe6..58d3b17 100644
+--- a/vendor/e2fsprogs/lib/ext2fs/ext2_types.h
++++ b/vendor/e2fsprogs/lib/ext2fs/ext2_types.h
+@@ -13,9 +13,14 @@ typedef unsigned short __u16;
+ typedef __signed__ short __s16;
+ typedef unsigned int __u32;
+ typedef __signed__ int __s32;
++#if __SIZEOF_LONG__ == 8
++typedef unsigned long __u64;
++typedef __signed__ long __s64;
++#else
+ typedef unsigned long long __u64;
+ typedef __signed__ long long __s64;
+ #endif
++#endif
+ 
+ #include <stdint.h> //uintptr_t
+ 
+diff --git a/vendor/e2fsprogs/lib/ext2fs/ext2_types.h.in b/vendor/e2fsprogs/lib/ext2fs/ext2_types.h.in
+index 98cc65b..95e6a92 100644
+--- a/vendor/e2fsprogs/lib/ext2fs/ext2_types.h.in
++++ b/vendor/e2fsprogs/lib/ext2fs/ext2_types.h.in
+@@ -115,12 +115,12 @@ typedef __U64_TYPEDEF __u64;
+ #if (@SIZEOF_INT@ == 8)
+ typedef unsigned int	__u64;
+ #else
+-#if (@SIZEOF_LONG_LONG@ == 8)
+-typedef unsigned long long	__u64;
+-#else
+ #if (@SIZEOF_LONG@ == 8)
+ typedef unsigned long	__u64;
+ #else
++#if (@SIZEOF_LONG_LONG@ == 8)
++typedef unsigned long long	__u64;
++#else
+ #undef HAVE___U64
+  ?== error: undefined 64 bit type
+ #endif /* SIZEOF_LONG_LONG == 8 */
+@@ -137,15 +137,19 @@ typedef __S64_TYPEDEF __s64;
+ #if (@SIZEOF_INT@ == 8)
+ typedef int		__s64;
+ #else
++#if (@SIZEOF_LONG@ == 8)
++#if defined(__GNUC__)
++typedef __signed__ long	__s64;
++#else
++typedef signed long	__s64;
++#endif /* __GNUC__ */
++#else
+ #if (@SIZEOF_LONG_LONG@ == 8)
+ #if defined(__GNUC__)
+ typedef __signed__ long long	__s64;
+ #else
+ typedef signed long long	__s64;
+-#endif /* __GNUC__ */
+-#else
+-#if (@SIZEOF_LONG@ == 8)
+-typedef long		__s64;
++#endif
+ #else
+ #undef HAVE___S64
+  ?== error: undefined 64 bit type
+-- 
+2.39.1
+

--- a/app-devices/android-platform-tools/spec
+++ b/app-devices/android-platform-tools/spec
@@ -1,4 +1,4 @@
-VER=33.0.3p2
+VER=34.0.4
 SRCS="https://github.com/nmeum/android-tools/releases/download/$VER/android-tools-$VER.tar.xz"
-CHKSUMS="sha256::6bf6b52d7389e79fc92b63cc206451ee42fc4f7da769d76922193e98d75f5604"
+CHKSUMS="sha256::7a22ff9cea81ff4f38f560687858e8f8fb733624412597e3cc1ab0262f8da3a1"
 CHKUPDATE="anitya::id=226905"

--- a/app-doc/go-md2man/spec
+++ b/app-doc/go-md2man/spec
@@ -2,4 +2,4 @@ VER=2.0.2
 SRCS="git::commit=tags/v${VER}::https://github.com/cpuguy83/go-md2man"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14461"
-REL=1
+REL=2

--- a/app-network/clash/spec
+++ b/app-network/clash/spec
@@ -1,4 +1,4 @@
-VER=1.12.0
+VER=1.18.0
 SRCS="https://github.com/Dreamacro/clash/archive/v$VER.tar.gz"
-CHKSUMS="sha256::9b8f28c2adf378e4da5b139dd72c3e13bf19394e2555080832dc47c64fbcdb9a"
+CHKSUMS="sha256::139794f50d3d94f438bab31a993cf25d7cbdf8ca8e034f3071e0dd0014069692"
 CHKUPDATE="anitya::id=211719"

--- a/app-network/dnscrypt/autobuild/patches/0001-make-example-configuration-FHS-compliant.diff
+++ b/app-network/dnscrypt/autobuild/patches/0001-make-example-configuration-FHS-compliant.diff
@@ -1,8 +1,8 @@
 diff --git a/dnscrypt-proxy/example-dnscrypt-proxy.toml b/dnscrypt-proxy/example-dnscrypt-proxy.toml
-index d3f6521..90a5553 100644
+index 0f973adb..a3222bf0 100644
 --- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
 +++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
-@@ -163,7 +163,7 @@ keepalive = 30
+@@ -170,7 +170,7 @@ keepalive = 30
  ## This file is different from other log files, and will not be
  ## automatically rotated by the application.
  
@@ -11,7 +11,7 @@ index d3f6521..90a5553 100644
  
  
  ## When using a log file, only keep logs from the most recent launch.
-@@ -173,7 +173,7 @@ keepalive = 30
+@@ -180,7 +180,7 @@ keepalive = 30
  
  ## Use the system logger (syslog on Unix, Event Log on Windows)
  
@@ -20,7 +20,7 @@ index d3f6521..90a5553 100644
  
  
  ## Delay, in minutes, after which certificates are reloaded
-@@ -341,7 +341,7 @@ reject_ttl = 10
+@@ -372,7 +372,7 @@ reject_ttl = 10
  
  ## See the `example-forwarding-rules.txt` file for an example
  
@@ -29,7 +29,7 @@ index d3f6521..90a5553 100644
  
  
  
-@@ -355,7 +355,7 @@ reject_ttl = 10
+@@ -388,7 +388,7 @@ reject_ttl = 10
  ##
  ## See the `example-cloaking-rules.txt` file for an example
  
@@ -38,7 +38,7 @@ index d3f6521..90a5553 100644
  
  ## TTL used when serving entries in cloaking-rules.txt
  
-@@ -408,7 +408,7 @@ cache_neg_max_ttl = 600
+@@ -442,7 +442,7 @@ cache_neg_max_ttl = 600
  ## check for connectivity and captive portals, along with hard-coded
  ## IP addresses to return.
  
@@ -47,8 +47,8 @@ index d3f6521..90a5553 100644
  
  
  
-@@ -438,8 +438,8 @@ cache_neg_max_ttl = 600
- ## Certificate file and key - Note that the certificate has to be trusted.
+@@ -474,8 +474,8 @@ cache_neg_max_ttl = 600
+ ## openssl req -x509 -nodes -newkey rsa:2048 -days 5000 -sha256 -keyout localhost.pem -out localhost.pem
  ## See the documentation (wiki) for more information.
  
 -# cert_file = 'localhost.pem'
@@ -58,119 +58,67 @@ index d3f6521..90a5553 100644
  
  
  
-@@ -454,7 +454,7 @@ cache_neg_max_ttl = 600
-   ## Path to the query log file (absolute, or relative to the same directory as the config file)
-   ## Can be set to /dev/stdout in order to log to the standard output.
+@@ -546,12 +546,12 @@ format = 'tsv'
  
--  # file = 'query.log'
-+  # file = '/var/log/dnscrypt-proxy/query.log'
+ ## Path to the file of blocking rules (absolute, or relative to the same directory as the config file)
  
- 
-   ## Query log format (currently supported: tsv and ltsv)
-@@ -480,7 +480,7 @@ cache_neg_max_ttl = 600
- 
-   ## Path to the query log file (absolute, or relative to the same directory as the config file)
- 
--  # file = 'nx.log'
-+  # file = '/var/log/dnscrypt-proxy/nx.log'
+-# blocked_names_file = 'blocked-names.txt'
++# blocked_names_file = '/etc/dnscrypt-proxy/blocked-names.txt'
  
  
-   ## Query log format (currently supported: tsv and ltsv)
-@@ -510,12 +510,12 @@ cache_neg_max_ttl = 600
+ ## Optional path to a file logging blocked queries
  
-   ## Path to the file of blocking rules (absolute, or relative to the same directory as the config file)
- 
--  # blocked_names_file = 'blocked-names.txt'
-+  # blocked_names_file = '/etc/dnscrypt-proxy/blocked_names.txt'
+-# log_file = 'blocked-names.log'
++# log_file = '/var/log/dnscrypt-proxy/blocked-names.log'
  
  
-   ## Optional path to a file logging blocked queries
+ ## Optional log format: tsv or ltsv (default: tsv)
+@@ -574,12 +574,12 @@ format = 'tsv'
  
--  # log_file = 'blocked-names.log'
-+  # log_file = '/var/log/dnscrypt-proxy/blocked-names.log'
+ ## Path to the file of blocking rules (absolute, or relative to the same directory as the config file)
  
- 
-   ## Optional log format: tsv or ltsv (default: tsv)
-@@ -538,12 +538,12 @@ cache_neg_max_ttl = 600
- 
-   ## Path to the file of blocking rules (absolute, or relative to the same directory as the config file)
- 
--  # blocked_ips_file = 'blocked-ips.txt'
-+  # blocked_ips_file = '/etc/dnscrypt-proxy/blocked-ips.txt'
+-# blocked_ips_file = 'blocked-ips.txt'
++# blocked_ips_file = '/etc/dnscrypt-proxy/blocked-ips.txt'
  
  
-   ## Optional path to a file logging blocked queries
+ ## Optional path to a file logging blocked queries
  
--  # log_file = 'blocked-ips.log'
-+  # log_file = '/var/log/dnscrypt-proxy/blocked-ips.log'
- 
- 
-   ## Optional log format: tsv or ltsv (default: tsv)
-@@ -566,12 +566,12 @@ cache_neg_max_ttl = 600
- 
-   ## Path to the file of allow list rules (absolute, or relative to the same directory as the config file)
- 
--  # allowed_names_file = 'allowed-names.txt'
-+  # allowed_names_file = '/etc/dnscrypt-proxy/allowed-names.txt'
+-# log_file = 'blocked-ips.log'
++# log_file = '/var/log/dnscrypt-proxy/blocked-ips.log'
  
  
-   ## Optional path to a file logging allowed queries
+ ## Optional log format: tsv or ltsv (default: tsv)
+@@ -602,12 +602,12 @@ format = 'tsv'
  
--  # log_file = 'allowed-names.log'
-+  # log_file = '/var/log/dnscrypt-proxy/allowed-names.log'
+ ## Path to the file of allow list rules (absolute, or relative to the same directory as the config file)
  
- 
-   ## Optional log format: tsv or ltsv (default: tsv)
-@@ -594,12 +594,12 @@ cache_neg_max_ttl = 600
- 
-   ## Path to the file of allowed ip rules (absolute, or relative to the same directory as the config file)
- 
--  # allowed_ips_file = 'allowed-ips.txt'
-+  # allowed_ips_file = '/etc/dnscrypt-proxy/allowed-ips.txt'
+-# allowed_names_file = 'allowed-names.txt'
++# allowed_names_file = '/etc/dnscrypt-proxy/allowed-names.txt'
  
  
-   ## Optional path to a file logging allowed queries
+ ## Optional path to a file logging allowed queries
  
--  # log_file = 'allowed-ips.log'
-+  # log_file = '/var/log/dnscrypt-proxy/allowed-ips.log'
+-# log_file = 'allowed-names.log'
++# log_file = '/var/log/dnscrypt-proxy/allowed-names.log'
  
-   ## Optional log format: tsv or ltsv (default: tsv)
  
-@@ -670,7 +670,7 @@ cache_neg_max_ttl = 600
+ ## Optional log format: tsv or ltsv (default: tsv)
+@@ -630,12 +630,12 @@ format = 'tsv'
  
-   [sources.'public-resolvers']
-     urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/public-resolvers.md', 'https://download.dnscrypt.info/resolvers-list/v3/public-resolvers.md', 'https://ipv6.download.dnscrypt.info/resolvers-list/v3/public-resolvers.md', 'https://download.dnscrypt.net/resolvers-list/v3/public-resolvers.md']
--    cache_file = 'public-resolvers.md'
-+    cache_file = '/var/cache/dnscrypt-proxy/public-resolvers.md'
-     minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
-     refresh_delay = 72
-     prefix = ''
-@@ -679,7 +679,7 @@ cache_neg_max_ttl = 600
+ ## Path to the file of allowed ip rules (absolute, or relative to the same directory as the config file)
  
-   [sources.'relays']
-     urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/relays.md', 'https://download.dnscrypt.info/resolvers-list/v3/relays.md', 'https://ipv6.download.dnscrypt.info/resolvers-list/v3/relays.md', 'https://download.dnscrypt.net/resolvers-list/v3/relays.md']
--    cache_file = 'relays.md'
-+    cache_file = '/var/cache/dnscrypt-proxy/relays.md'
-     minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
-     refresh_delay = 72
-     prefix = ''
-@@ -688,13 +688,13 @@ cache_neg_max_ttl = 600
+-# allowed_ips_file = 'allowed-ips.txt'
++# allowed_ips_file = '/etc/dnscrypt-proxy/allowed-ips.txt'
  
-   # [sources.'odoh-servers']
-   #   urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/odoh-servers.md', 'https://download.dnscrypt.info/resolvers-list/v3/odoh-servers.md', 'https://ipv6.download.dnscrypt.info/resolvers-list/v3/odoh-servers.md', 'https://download.dnscrypt.net/resolvers-list/v3/odoh-servers.md']
--  #   cache_file = 'odoh-servers.md'
-+  #   cache_file = '/var/cache/dnscrypt-proxy/odoh-servers.md'
-   #   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
-   #   refresh_delay = 24
-   #   prefix = ''
-   # [sources.'odoh-relays']
-   #   urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/odoh-relays.md', 'https://download.dnscrypt.info/resolvers-list/v3/odoh-relays.md', 'https://ipv6.download.dnscrypt.info/resolvers-list/v3/odoh-relays.md', 'https://download.dnscrypt.net/resolvers-list/v3/odoh-relays.md']
--  #   cache_file = 'odoh-relays.md'
-+  #   cache_file = '/var/cache/dnscrypt-proxy/odoh-relays.md'
-   #   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
-   #   refresh_delay = 24
-   #   prefix = ''
-@@ -704,7 +704,7 @@ cache_neg_max_ttl = 600
+ 
+ ## Optional path to a file logging allowed queries
+ 
+-# log_file = 'allowed-ips.log'
++# log_file = '/var/log/dnscrypt-proxy/allowed-ips.log'
+ 
+ ## Optional log format: tsv or ltsv (default: tsv)
+ 
+@@ -740,7 +740,7 @@ format = 'tsv'
    # [sources.quad9-resolvers]
    #   urls = ['https://www.quad9.net/quad9-resolvers.md']
    #   minisign_key = 'RWQBphd2+f6eiAqBsvDZEBXBGHQBJfeG6G+wJPPKxCZMoEQYpmoysKUN'
@@ -178,13 +126,4 @@ index d3f6521..90a5553 100644
 +  #   cache_file = '/var/cache/dnscrypt-proxy/quad9-resolvers.md'
    #   prefix = 'quad9-'
  
-   ## Another example source, with resolvers censoring some websites not appropriate for children
-@@ -712,7 +712,7 @@ cache_neg_max_ttl = 600
- 
-   #  [sources.'parental-control']
-   #    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/parental-control.md', 'https://download.dnscrypt.info/resolvers-list/v3/parental-control.md', 'https://ipv6.download.dnscrypt.info/resolvers-list/v3/parental-control.md', 'https://download.dnscrypt.net/resolvers-list/v3/parental-control.md']
--  #    cache_file = 'parental-control.md'
-+  #    cache_file = '/var/cache/dnscrypt-proxy/parental-control.md'
-   #    minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
- 
- 
+   ### Another example source, with resolvers censoring some websites not appropriate for children

--- a/app-network/dnscrypt/spec
+++ b/app-network/dnscrypt/spec
@@ -1,5 +1,4 @@
-VER=2.1.1
+VER=2.1.5
 SRCS="https://github.com/jedisct1/dnscrypt-proxy/archive/$VER.tar.gz"
-CHKSUMS="sha256::cc4a2f274ce48c3731ff981e940e6475d912fb356a80481e91725e81d67bde14"
+CHKSUMS="sha256::044c4db9a3c7bdcf886ff8f83c4b137d2fd37a65477a92bfe86bf69587ea7355"
 CHKUPDATE="anitya::id=15546"
-REL=1

--- a/app-network/frp/autobuild/patches/0001-Revert-remove-systemd-files.patch
+++ b/app-network/frp/autobuild/patches/0001-Revert-remove-systemd-files.patch
@@ -1,0 +1,102 @@
+From 1a0022af4a7ce2d7f77f398be2a309af5d0b9ed2 Mon Sep 17 00:00:00 2001
+From: Cyan <cyan@cyano.uk>
+Date: Sun, 3 Sep 2023 18:27:25 -0700
+Subject: [PATCH] Revert "remove systemd files"
+
+This reverts commit bd89eaba2fc465c0c3ba4509c7ce75b2ca49206d.
+---
+ conf/systemd/frpc.service  | 15 +++++++++++++++
+ conf/systemd/frpc@.service | 15 +++++++++++++++
+ conf/systemd/frps.service  | 14 ++++++++++++++
+ conf/systemd/frps@.service | 14 ++++++++++++++
+ 4 files changed, 58 insertions(+)
+ create mode 100644 conf/systemd/frpc.service
+ create mode 100644 conf/systemd/frpc@.service
+ create mode 100644 conf/systemd/frps.service
+ create mode 100644 conf/systemd/frps@.service
+
+diff --git a/conf/systemd/frpc.service b/conf/systemd/frpc.service
+new file mode 100644
+index 0000000..37a6a9b
+--- /dev/null
++++ b/conf/systemd/frpc.service
+@@ -0,0 +1,15 @@
++[Unit]
++Description=Frp Client Service
++After=network.target
++
++[Service]
++Type=simple
++User=nobody
++Restart=on-failure
++RestartSec=5s
++ExecStart=/usr/bin/frpc -c /etc/frp/frpc.ini
++ExecReload=/usr/bin/frpc reload -c /etc/frp/frpc.ini
++LimitNOFILE=1048576
++
++[Install]
++WantedBy=multi-user.target
+diff --git a/conf/systemd/frpc@.service b/conf/systemd/frpc@.service
+new file mode 100644
+index 0000000..5914ff6
+--- /dev/null
++++ b/conf/systemd/frpc@.service
+@@ -0,0 +1,15 @@
++[Unit]
++Description=Frp Client Service
++After=network.target
++
++[Service]
++Type=simple
++User=nobody
++Restart=on-failure
++RestartSec=5s
++ExecStart=/usr/bin/frpc -c /etc/frp/%i.ini
++ExecReload=/usr/bin/frpc reload -c /etc/frp/%i.ini
++LimitNOFILE=1048576
++
++[Install]
++WantedBy=multi-user.target
+diff --git a/conf/systemd/frps.service b/conf/systemd/frps.service
+new file mode 100644
+index 0000000..c00f2dc
+--- /dev/null
++++ b/conf/systemd/frps.service
+@@ -0,0 +1,14 @@
++[Unit]
++Description=Frp Server Service
++After=network.target
++
++[Service]
++Type=simple
++User=nobody
++Restart=on-failure
++RestartSec=5s
++ExecStart=/usr/bin/frps -c /etc/frp/frps.ini
++LimitNOFILE=1048576
++
++[Install]
++WantedBy=multi-user.target
+diff --git a/conf/systemd/frps@.service b/conf/systemd/frps@.service
+new file mode 100644
+index 0000000..2942e0b
+--- /dev/null
++++ b/conf/systemd/frps@.service
+@@ -0,0 +1,14 @@
++[Unit]
++Description=Frp Server Service
++After=network.target
++
++[Service]
++Type=simple
++User=nobody
++Restart=on-failure
++RestartSec=5s
++ExecStart=/usr/bin/frps -c /etc/frp/%i.ini
++LimitNOFILE=1048576
++
++[Install]
++WantedBy=multi-user.target
+-- 
+2.39.1
+

--- a/app-network/frp/spec
+++ b/app-network/frp/spec
@@ -1,5 +1,4 @@
-VER=0.42.0
+VER=0.51.3
 SRCS="tbl::https://github.com/fatedier/frp/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::4bb815e9c9a4588fce20c6ef33168f0ceb1f420937c4dcf03ce085666328043a"
+CHKSUMS="sha256::83032399773901348c660d41c967530e794ab58172ccd070db89d5e50d915fef"
 CHKUPDATE="anitya::id=230969"
-REL=1

--- a/app-network/geoipupdate/autobuild/patches/0002-replace-pandoc-with-ronn-ng.patch.source
+++ b/app-network/geoipupdate/autobuild/patches/0002-replace-pandoc-with-ronn-ng.patch.source
@@ -1,16 +1,25 @@
-As pandoc is unavailable to architectures other than amd64 in AOSC OS, 
-generation of manpages with upstream-shipped repository is not possible. This 
-patch replaces pandoc with architecture-independent ronn-ng, along with minor 
+From 432ee78984ca94560ce3145748ba2ef6069dc825 Mon Sep 17 00:00:00 2001
+From: Camber Huang <camber@aosc.io>
+Date: Sun, 17 Sep 2023 06:30:50 +0000
+Subject: [PATCH] Replace Pandoc with ronn-ng
+
+As pandoc is unavailable to architectures other than amd64 in AOSC OS,
+generation of manpages with upstream-shipped repository is not possible. This
+patch replaces pandoc with architecture-independent ronn-ng, along with minor
 tweaks to markdown source files.
 
-This patch will also replace previous patch which just simply disables the 
-generation of manpage. 
+This patch will also replace previous patch which just simply disables the
+generation of manpage.
 
-This patch should be dropped when haskell compiler is available on other 
+This patch should be dropped when haskell compiler is available on other
 architectures.
 
-Signed-off-by: Camber Huang<camber@aosc.io>
+Signed-off-by: Camber Huang <camber@aosc.io>
 ---
+ dev-bin/make-man-pages.pl | 13 ++++++-------
+ doc/GeoIP.conf.md         | 12 ++++++------
+ doc/geoipupdate.md        | 18 +++++++++---------
+ 3 files changed, 21 insertions(+), 22 deletions(-)
 
 diff --git a/dev-bin/make-man-pages.pl b/dev-bin/make-man-pages.pl
 index 82acb07..f191e5c 100755
@@ -37,7 +46,7 @@ index 82acb07..f191e5c 100755
      return;
  }
 diff --git a/doc/GeoIP.conf.md b/doc/GeoIP.conf.md
-index 7383571..e562ea0 100644
+index 6ba9ca5..46454ef 100644
 --- a/doc/GeoIP.conf.md
 +++ b/doc/GeoIP.conf.md
 @@ -2,18 +2,18 @@
@@ -48,7 +57,7 @@ index 7383571..e562ea0 100644
 +## SYNOPSIS
  
  This file allows you to configure your `geoipupdate` program to
- download GeoIP2, GeoLite2, and GeoIP Legacy databases.
+ download GeoIP2 and GeoLite2 databases.
  
 -# DESCRIPTION
 +## DESCRIPTION
@@ -62,25 +71,25 @@ index 7383571..e562ea0 100644
  
  `AccountID`
  
-@@ -30,7 +30,7 @@ sensitive.
-     download the GeoIP2 City database (`GeoIP2-City`) and the GeoIP Legacy
-     Country database (`106`). Note: this was formerly called `ProductIds`.
+@@ -35,7 +35,7 @@ sensitive.
+     at run time by the `GEOIPUPDATE_EDITION_IDS` environment variable. Note:
+     this was formerly called `ProductIds`.
  
 -## Optional settings:
 +### Optional settings:
  
  `DatabaseDirectory`
  
-@@ -72,7 +72,7 @@ sensitive.
-     followed by a unit suffix. Valid time units are `ns`, `us` (or `µs`), `ms`,
-     `s`, `m`, `h`. The default is `5m` (5 minutes).
+@@ -92,7 +92,7 @@ sensitive.
+     overridden at run time by the `GEOIPUPDATE_PARALLELISM` environment
+     variable or the `--parallelism` command line argument.
  
 -## Deprecated settings:
 +### Deprecated settings:
  
  The following are deprecated and will be ignored if present:
  
-@@ -82,6 +82,6 @@ The following are deprecated and will be ignored if present:
+@@ -102,6 +102,6 @@ The following are deprecated and will be ignored if present:
  
  `SkipHostnameVerification`
  
@@ -89,12 +98,12 @@ index 7383571..e562ea0 100644
  
  `geoipupdate`(1)
 diff --git a/doc/geoipupdate.md b/doc/geoipupdate.md
-index 0f9b311..914c333 100644
+index e39b88d..98d9e5e 100644
 --- a/doc/geoipupdate.md
 +++ b/doc/geoipupdate.md
 @@ -2,11 +2,11 @@
  
- geoipupdate - GeoIP2, GeoLite2, and GeoIP Legacy Update Program
+ geoipupdate - GeoIP2 and GeoLite2 Update Program
  
 -# SYNOPSIS
 +## SYNOPSIS
@@ -104,9 +113,9 @@ index 0f9b311..914c333 100644
 -# DESCRIPTION
 +## DESCRIPTION
  
- `geoipupdate` automatically updates GeoIP2, GeoLite2, and GeoIP Legacy
- databases. The program connects to the MaxMind GeoIP Update server to
-@@ -16,7 +16,7 @@ download and install it.
+ `geoipupdate` automatically updates GeoIP2 and GeoLite2 databases. The
+ program connects to the MaxMind GeoIP Update server to check for new
+@@ -16,7 +16,7 @@ install it.
  If you are using a firewall, you must have the DNS and HTTPS ports
  open.
  
@@ -115,9 +124,9 @@ index 0f9b311..914c333 100644
  
  `-d`, `--database-directory`
  
-@@ -45,11 +45,11 @@ open.
+@@ -56,11 +56,11 @@ open.
  
- :   Enable verbose mode. Prints out the steps that `geoipupdate` takes.
+ :   Output download/update results in JSON format.
  
 -# EXIT STATUS
 +## EXIT STATUS
@@ -129,9 +138,9 @@ index 0f9b311..914c333 100644
  
  Typically you should run `geoipupdate` weekly. On most Unix-like systems,
  this can be achieved by using cron. Below is a sample crontab file that
-@@ -68,11 +68,11 @@ To use with a proxy server, update your `GeoIP.conf` file as specified
- in the `GeoIP.conf` man page or set the `http_proxy` environment
- variable.
+@@ -79,11 +79,11 @@ To use with a proxy server, update your `GeoIP.conf` file as specified in
+ the `GeoIP.conf` man page. Alternatively, set the `GEOIPUPDATE_PROXY` or
+ `http_proxy` environment variable.
  
 -# BUGS
 +## BUGS
@@ -143,7 +152,7 @@ index 0f9b311..914c333 100644
  
  Written by William Storey.
  
-@@ -81,12 +81,12 @@ This software is Copyright (c) 2018-2022 by MaxMind, Inc.
+@@ -92,11 +92,11 @@ This software is Copyright (c) 2018-2023 by MaxMind, Inc.
  This is free software, licensed under the Apache License, Version 2.0 or
  the MIT License, at your option.
  
@@ -151,10 +160,12 @@ index 0f9b311..914c333 100644
 +## MORE INFORMATION
  
  Visit [our website](https://www.maxmind.com/en/geoip2-services-and-databases)
- to learn more about the GeoIP2 and GeoIP Legacy databases or to sign up
- for a subscription.
+ to learn more about the GeoIP2 databases or to sign up for a subscription.
  
 -# SEE ALSO
 +## SEE ALSO
  
  `GeoIP.conf`(5)
+-- 
+2.39.1
+

--- a/app-network/geoipupdate/spec
+++ b/app-network/geoipupdate/spec
@@ -1,5 +1,4 @@
-VER=4.9.0
+VER=6.0.0
 SRCS="https://github.com/maxmind/geoipupdate/archive/v$VER.tar.gz"
-CHKSUMS="sha256::43195d457a372dc07be593d815212d6ea21e499a37a6111058efa3296759cba9"
+CHKSUMS="sha256::50a403fb8f94029824766b32d4bf46e67c051699f761df8c4e2c916ecca4126e"
 CHKUPDATE="anitya::id=230971"
-REL=1

--- a/app-network/kcptun/spec
+++ b/app-network/kcptun/spec
@@ -1,5 +1,4 @@
-VER=20210922
+VER=20230811
 SRCS="https://github.com/xtaci/kcptun/archive/v$VER.tar.gz"
-CHKSUMS="sha256::f6a08f0fe75fa85d15f9c0c28182c69a5ad909229b4c230a8cbe38f91ba2d038"
+CHKSUMS="sha256::dd88c7ddb85cc74ff22940ba2dc22f65d3b6737153b225d611abb801a0694c4d"
 CHKUPDATE="anitya::id=14970"
-REL=1

--- a/app-network/syncthing/spec
+++ b/app-network/syncthing/spec
@@ -1,5 +1,5 @@
-VER=1.22.2
+VER=1.24.0
 SRCS="https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
-CHKSUMS="sha256::211704904788808ef2818994fb36e33c3e33ed1b52267f7adbf1411fa5ee2d2f"
+CHKSUMS="sha256::4a9459667f9b70a7d1e7d572c7c9d02431ef8f055679eef368300ce1a826608f"
 CHKUPDATE="anitya::id=11814"
 SUBDIR="."

--- a/app-network/v2ray-plugin/spec
+++ b/app-network/v2ray-plugin/spec
@@ -1,5 +1,4 @@
-VER=1.3.1
+VER=1.3.2
 SRCS="https://github.com/shadowsocks/v2ray-plugin/archive/v$VER.tar.gz"
-CHKSUMS="sha256::86d37a8ecef82457b4750a1af9e8d093b25ae0d32ea7dcc2ad5c0068fe2d3d74"
-REL=6
+CHKSUMS="sha256::0ffb0a938bae58ea40a024cb04418c7fecb74f7d807de27ae0589c42307802a4"
 CHKUPDATE="anitya::id=231002"

--- a/app-network/v2ray/spec
+++ b/app-network/v2ray/spec
@@ -1,4 +1,4 @@
-VER=5.3.0
-SRCS="https://github.com/v2fly/v2ray-core/archive/v$VER.tar.gz"
-CHKSUMS="sha256::8e97e2647cb1dee8aa7e71df276c56d74258b2d97bb490a362afa84bdf1b9e25"
+VER=5.7.0+git20230810
+SRCS="git::commit=347088b286e7a2e89ec361feb1b15e21664082ae::https://github.com/v2fly/v2ray-core"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=134851"

--- a/app-network/xray/spec
+++ b/app-network/xray/spec
@@ -1,4 +1,4 @@
-VER=1.6.6
+VER=1.8.4
 SRCS="tbl::https://github.com/XTLS/Xray-core/archive/v$VER.tar.gz"
-CHKSUMS="sha256::b92053f2bde18fb83efeb938b1d5fa7a9d62e8fe8c795e747b8c521e1cbd002a"
+CHKSUMS="sha256::89f73107abba9bd438111edfe921603ddb3c2b631b2716fbdc6be78552f0d322"
 CHKUPDATE="anitya::id=231005"

--- a/app-utils/direnv/spec
+++ b/app-utils/direnv/spec
@@ -1,5 +1,4 @@
-VER=2.31.0
+VER=2.32.3
 SRCS="https://github.com/direnv/direnv/archive/v$VER.tar.gz"
-CHKSUMS="sha256::f82694202f584d281a166bd5b7e877565f96a94807af96325c8f43643d76cb44"
+CHKSUMS="sha256::c66f6d1000f28f919c6106b5dcdd0a0e54fb553602c63c60bf59d9bbdf8bd33c"
 CHKUPDATE="anitya::id=11598"
-REL=1

--- a/app-utils/fzf/spec
+++ b/app-utils/fzf/spec
@@ -1,5 +1,4 @@
-VER=0.30.0
+VER=0.42.0
 SRCS="https://github.com/junegunn/fzf/archive/$VER.tar.gz"
-CHKSUMS="sha256::a3428f510b7136e39104a002f19b2e563090496cb5205fa2e4c5967d34a20124"
+CHKSUMS="sha256::743c1bfc7851b0796ab73c6da7db09d915c2b54c0dd3e8611308985af8ed3df2"
 CHKUPDATE="anitya::id=15856"
-REL=2

--- a/app-utils/pcstat/spec
+++ b/app-utils/pcstat/spec
@@ -1,5 +1,4 @@
-VER=0.0.1
+VER=0.0.2
 SRCS="git::commit=tags/v${VER}::https://github.com/tobert/pcstat.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231629"
-REL=1

--- a/app-utils/restic/spec
+++ b/app-utils/restic/spec
@@ -1,5 +1,4 @@
-VER=0.13.1
+VER=0.16.0
 SRCS="https://github.com/restic/restic/archive/v$VER.tar.gz"
-CHKSUMS="sha256::8430f80dc17b98fd78aca6f7d635bf12a486687677e15989a891ff4f6d8490a9"
+CHKSUMS="sha256::b91f5ef6203a5c50a72943c21aaef336e1344f19a3afd35406c00f065db8a8b9"
 CHKUPDATE="anitya::id=16643"
-REL=1

--- a/app-vcs/hub/spec
+++ b/app-vcs/hub/spec
@@ -1,6 +1,5 @@
-VER=2.14.2+git20220404
-SRCS="git::commit=363513a0f822a8bde5b620e5de183702280d4ace::https://github.com/github/hub"
+VER=2.14.2+git20230617
+SRCS="git::commit=bd8019b77e4a707ba5f5145b4b920e09de651c13::https://github.com/github/hub"
 CHKSUMS="SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=5368"
-REL=1

--- a/app-web/hugo/spec
+++ b/app-web/hugo/spec
@@ -1,5 +1,4 @@
-VER=0.99.0
-REL=2
+VER=0.118.2
 SRCS="https://github.com/gohugoio/hugo/archive/v$VER.tar.gz"
-CHKSUMS="sha256::7ad1d95c3fc9c0f880ba6fe3ff699b54bd38f7b2bda8e3706b087d368b7b77fb"
+CHKSUMS="sha256::915d7dcb44fba949c80858f9c2a55a11256162ba28a9067752f808cfe8faedaa"
 CHKUPDATE="anitya::id=12959"

--- a/app-web/rclone/spec
+++ b/app-web/rclone/spec
@@ -1,5 +1,4 @@
-VER=1.58.1
-REL=2
+VER=1.63.1
 SRCS="git::commit=tags/v$VER::https://github.com/rclone/rclone/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11750"

--- a/groups/go-rebuilds.amd64
+++ b/groups/go-rebuilds.amd64
@@ -1,3 +1,5 @@
+app-containers/docker-compose
+app-containers/docker
 app-containers/podman
 app-devices/android-platform-tools
 app-database/mongodb

--- a/groups/go-rebuilds.arm64
+++ b/groups/go-rebuilds.arm64
@@ -1,3 +1,5 @@
+app-containers/docker-compose
+app-containers/docker
 app-containers/podman
 app-devices/android-platform-tools
 app-database/mongodb

--- a/groups/go-rebuilds.ppc64el
+++ b/groups/go-rebuilds.ppc64el
@@ -1,3 +1,5 @@
+app-containers/docker-compose
+app-containers/docker
 app-containers/podman
 app-devices/android-platform-tools
 app-database/mongodb

--- a/lang-golang/delve/spec
+++ b/lang-golang/delve/spec
@@ -1,6 +1,5 @@
-VER=1.8.3
+VER=1.21.0
 SRCS="https://github.com/go-delve/delve/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::b18dc56de8768da055125663e7c368ecf24cdac4d72d9080ac90dc0ee99ea852"
+CHKSUMS="sha256::f00321e9333a61cb10c18141484c44ed55b1da1c4239a3f4faf2100b64613199"
 CHKUPDATE="anitya::id=40149"
 SUBDIR=.
-REL=1

--- a/lang-golang/dep/spec
+++ b/lang-golang/dep/spec
@@ -1,5 +1,5 @@
 VER=0.5.4
-REL=15
+REL=16
 SRCS="https://github.com/golang/dep/archive/v$VER.tar.gz"
 CHKSUMS="sha256::929c8f759838f98323211ba408a831ea80d93b75beda8584b6d950f393a3298a"
 CHKUPDATE="anitya::id=18652"

--- a/lang-golang/glide/spec
+++ b/lang-golang/glide/spec
@@ -1,5 +1,5 @@
 VER=0.13.3
-REL=15
+REL=16
 SRCS="git::commit=tags/v$VER::https://github.com/Masterminds/glide"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11625"

--- a/lang-golang/go/autobuild/alternatives
+++ b/lang-golang/go/autobuild/alternatives
@@ -1,2 +1,2 @@
-alternative /usr/bin/go /usr/bin/go-google 80
-alternative /usr/bin/gofmt /usr/bin/gofmt-google 80
+alternative /usr/bin/go /usr/lib/go/bin/go 80
+alternative /usr/bin/gofmt /usr/lib/go/bin/gofmt 80

--- a/lang-golang/go/autobuild/build
+++ b/lang-golang/go/autobuild/build
@@ -138,10 +138,13 @@ abinfo "Building extra Go tools ..."
 
 # List adapted from Arch Linux ..."
 abinfo "Installing extra Go tools ..."
-for i in benchcmp callgraph compilebench cover digraph eg fiximports \
-         go-contrib-init godex godoc goimports gomvpkg gorename gotype \
-         goyacc guru html2article present ssadump stringer \
-         toolstash; do
+for i in authtest benchcmp bisect bundle callgraph \
+	 compilebench cookieauth digraph eg file2fuzz \
+	 fiximports fuzz-driver fuzz-runner getgo gitauth \
+	 go-contrib-init godex godoc goimports gomvpkg \
+	 gonew gorename gotype goyacc guru \
+	 html2article netrcauth present present2md server \
+	 splitdwarf ssadump stress stringer toolstash ; do
     install -Dvm755 "$SRCDIR"/bin/$i \
         "$PKGDIR"/usr/bin/$i
 done

--- a/lang-golang/go/autobuild/build
+++ b/lang-golang/go/autobuild/build
@@ -145,9 +145,14 @@ for i in authtest benchcmp bisect bundle callgraph \
 	 go-contrib-init godex godoc goimports gomvpkg \
 	 gonew gorename gotype goyacc guru \
 	 html2article netrcauth present present2md server \
-	 splitdwarf ssadump stress stringer toolstash ; do
+	 splitdwarf ssadump stringer toolstash ; do
     install -Dvm755 "$SRCDIR"/bin/$i \
         "$PKGDIR"/usr/bin/$i
+done
+
+abinfo "Installing extra Go tools with possible name collision with existing packages..."
+for i in stress ; do
+	install -Dvm755 "$SRCDIR"/bin/$i "$PKGDIR"/usr/bin/go-${i}
 done
 
 cd "$SRCDIR"

--- a/lang-golang/go/autobuild/build
+++ b/lang-golang/go/autobuild/build
@@ -98,6 +98,10 @@ abinfo "Installing VERSION file ..."
 install -Dvm644 "$SRCDIR"/VERSION \
     "$PKGDIR/usr/lib/go/VERSION"
 
+abinfo "Installing go.env file ..."
+install -Dvm644 "$SRCDIR"/go.env \
+    "$PKGDIR/usr/lib/go/go.env"
+
 abinfo "Touching all installed files ..."
 find "$PKGDIR"/usr/lib/go/{pkg,bin} \
     -type f -exec touch '{}' +

--- a/lang-golang/go/autobuild/build
+++ b/lang-golang/go/autobuild/build
@@ -59,9 +59,9 @@ cp -rv "$SRCDIR"/{doc,misc} \
 ln -sv ../../share/go/doc \
     "$PKGDIR/usr/lib/go/doc"
 cp -av "$SRCDIR"/bin \
-    "$PKGDIR/usr"
+    "$PKGDIR/usr/lib/go/"
 cp -av "$SRCDIR"/pkg \
-    "$PKGDIR/usr/lib/go"
+    "$PKGDIR/usr/lib/go/"
 cp -av "$GOROOT/src" \
     "$PKGDIR/usr/lib/go/"
 cp -av "$GOROOT/src/cmd" \
@@ -83,10 +83,6 @@ abinfo "Setting executable bit for sql.go ..."
 find "$PKGDIR" \
     -type f -name sql.go -exec chmod -v -x {} \;
 
-abinfo "Creating a symlink for /usr/lib/go/bin to /usr/bin ..."
-ln -svf ../../bin \
-    "$PKGDIR/usr/lib/go/bin"
-
 abinfo "Installing build scripts ..."
 install -Dvm755 "$SRCDIR"/src/make.bash \
     "$PKGDIR/usr/lib/go/src/make.bash"
@@ -103,7 +99,7 @@ install -Dvm644 "$SRCDIR"/VERSION \
     "$PKGDIR/usr/lib/go/VERSION"
 
 abinfo "Touching all installed files ..."
-find "$PKGDIR"/usr/{lib/go/pkg,bin} \
+find "$PKGDIR"/usr/lib/go/{pkg,bin} \
     -type f -exec touch '{}' +
 
 abinfo "Installing basic Go tools ..."
@@ -111,9 +107,10 @@ install -dvm755 "$PKGDIR"/usr/lib/go/pkg/tool/"${GOOS}"_"$GOARCH"
 install -pvm755 "$SRCDIR"/pkg/tool/"${GOOS}"_"$GOARCH"/* \
    "$PKGDIR"/usr/lib/go/pkg/tool/"${GOOS}"_"$GOARCH"
 
-abinfo "Renaming go and gofmt for alternatives ..."
-mv -v "$PKGDIR"/usr/bin/go{,-google}
-mv -v "$PKGDIR"/usr/bin/gofmt{,-google}
+abinfo "Linking go and gofmt installed in GOROOT to /usr/bin ..."
+mkdir "$PKGDIR"/usr/bin
+ln -sfv ../lib/go/bin/go "$PKGDIR"/usr/bin/go-google
+ln -sfv ../lib/go/bin/gofmt "$PKGDIR"/usr/bin/gofmt-google
 
 abinfo "Preparing to build extra Go tools ..."
 mkdir -pv "$SRCDIR"/go-tools/src/golang.org/x/

--- a/lang-golang/go/autobuild/build.stage2
+++ b/lang-golang/go/autobuild/build.stage2
@@ -105,6 +105,10 @@ abinfo "Installing VERSION file ..."
 install -Dvm644 "$SRCDIR"/VERSION \
     "$PKGDIR/usr/lib/go/VERSION"
 
+abinfo "Installing go.env file ..."
+install -Dvm644 "$SRCDIR"/go.env \
+    "$PKGDIR/usr/lib/go/go.env"
+
 abinfo "Touching all installed files ..."
 find "$PKGDIR"/usr/lib/go/{pkg,bin} \
     -type f -exec touch '{}' +

--- a/lang-golang/go/autobuild/build.stage2
+++ b/lang-golang/go/autobuild/build.stage2
@@ -66,9 +66,9 @@ cp -rv "$SRCDIR"/{doc,misc} \
 ln -sv ../../share/go/doc \
     "$PKGDIR/usr/lib/go/doc"
 cp -av "$SRCDIR"/bin \
-    "$PKGDIR/usr"
+    "$PKGDIR/usr/lib/go/"
 cp -av "$SRCDIR"/pkg \
-    "$PKGDIR/usr/lib/go"
+    "$PKGDIR/usr/lib/go/"
 cp -av "$GOROOT/src" \
     "$PKGDIR/usr/lib/go/"
 cp -av "$GOROOT/src/cmd" \
@@ -90,10 +90,6 @@ abinfo "Setting executable bit for sql.go ..."
 find "$PKGDIR" \
     -type f -name sql.go -exec chmod -v -x {} \;
 
-abinfo "Creating a symlink for /usr/lib/go/bin to /usr/bin ..."
-ln -svf ../../bin \
-    "$PKGDIR/usr/lib/go/bin"
-
 abinfo "Installing build scripts ..."
 install -Dvm755 "$SRCDIR"/src/make.bash \
     "$PKGDIR/usr/lib/go/src/make.bash"
@@ -110,7 +106,7 @@ install -Dvm644 "$SRCDIR"/VERSION \
     "$PKGDIR/usr/lib/go/VERSION"
 
 abinfo "Touching all installed files ..."
-find "$PKGDIR"/usr/{lib/go/pkg,bin} \
+find "$PKGDIR"/usr/lib/go/{pkg,bin} \
     -type f -exec touch '{}' +
 
 abinfo "Installing basic Go tools ..."
@@ -118,9 +114,10 @@ install -dvm755 "$PKGDIR"/usr/lib/go/pkg/tool/"${GOOS}"_"$GOARCH"
 install -pvm755 "$SRCDIR"/pkg/tool/"${GOOS}"_"$GOARCH"/* \
    "$PKGDIR"/usr/lib/go/pkg/tool/"${GOOS}"_"$GOARCH"
 
-abinfo "Renaming go and gofmt for alternatives ..."
-mv -v "$PKGDIR"/usr/bin/go{,-google}
-mv -v "$PKGDIR"/usr/bin/gofmt{,-google}
+abinfo "Linking go and gofmt installed in GOROOT to /usr/bin ..."
+mkdir "$PKGDIR"/usr/bin
+ln -sfv ../lib/go/bin/go "$PKGDIR"/usr/bin/go-google
+ln -sfv ../lib/go/bin/gofmt "$PKGDIR"/usr/bin/gofmt-google
 
 abinfo "Preparing to build extra Go tools ..."
 mkdir -pv "$SRCDIR"/go-tools/src/golang.org/x/

--- a/lang-golang/go/autobuild/build.stage2
+++ b/lang-golang/go/autobuild/build.stage2
@@ -145,10 +145,13 @@ abinfo "Building extra Go tools ..."
 
 # List adapted from Arch Linux ..."
 abinfo "Installing extra Go tools ..."
-for i in benchcmp callgraph compilebench cover digraph eg fiximports \
-         go-contrib-init godex godoc goimports gomvpkg gorename gotype \
-         goyacc guru html2article present ssadump stringer \
-         toolstash; do
+for i in authtest benchcmp bisect bundle callgraph \
+	 compilebench cookieauth digraph eg file2fuzz \
+	 fiximports fuzz-driver fuzz-runner getgo gitauth \
+	 go-contrib-init godex godoc goimports gomvpkg \
+	 gonew gorename gotype goyacc guru \
+	 html2article netrcauth present present2md server \
+	 splitdwarf ssadump stress stringer toolstash ; do
     install -Dvm755 "$SRCDIR"/bin/$i \
         "$PKGDIR"/usr/bin/$i
 done

--- a/lang-golang/go/autobuild/defines
+++ b/lang-golang/go/autobuild/defines
@@ -6,8 +6,8 @@ BUILDDEP="inetutils git go llvm mercurial"
 BUILDDEP__LOONGSON3="${BUILDDEP/llvm/}"
 PKGDES="The Go language compiler and tools"
 
-NOSTATIC=no
-ABSTRIP=no
+NOSTATIC=0
+ABSTRIP=0
 FAIL_ARCH="!(amd64|armv4|armv6hf|armv7hf|arm64|loongson3|ppc64el|riscv64)"
 
 USECLANG=1

--- a/lang-golang/go/autobuild/preinst
+++ b/lang-golang/go/autobuild/preinst
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Regression - dpkg is not unlinking /usr/lib/go/bin.
+if [ -h /usr/lib/go/bin ] ; then
+	echo "Unlinking /usr/lib/go/bin ..."
+	unlink /usr/lib/go/bin
+fi

--- a/lang-golang/go/spec
+++ b/lang-golang/go/spec
@@ -1,8 +1,13 @@
-VER=1.19.4+tools0.4.0+net0.4.0
-SRCS="tbl::https://go.dev/dl/go${VER:0:6}.src.tar.gz \
-      git::commit=tags/v${VER:12:5};rename=tools::https://go.googlesource.com/tools \
-      git::commit=tags/v${VER##*+net};rename=net::https://github.com/golang/net"
-CHKSUMS="sha256::eda74db4ac494800a3e66ee784e495bfbb9b8e535df924a8b01b1a8028b7f368 \
+# Versions of Golang, net library and Go tools
+TOOLS_VER=0.12.0
+NET_VER=0.14.0
+GOLANG_VER=1.21.0
+
+VER="${GOLANG_VER}+tools${TOOLS_VER}+net${NET_VER}"
+SRCS="tbl::https://go.dev/dl/go${GOLANG_VER}.src.tar.gz \
+      git::commit=tags/v${TOOLS_VER};rename=tools::https://go.googlesource.com/tools \
+      git::commit=tags/v${NET_VER};rename=net::https://github.com/golang/net"
+CHKSUMS="sha256::818d46ede85682dd551ad378ef37a4d247006f12ec59b5b755601d2ce114369a \
          SKIP \
          SKIP"
 CHKUPDATE="anitya::id=1227"

--- a/lang-python/cleo/autobuild/defines
+++ b/lang-python/cleo/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=cleo
 PKGSEC=python
-PKGDEP="clikit"
+PKGDEP="clikit tomli rapidfuzz"
 BUILDDEP="setuptools"
 PKGDES="Cleo allows you to create beautiful and testable command-line interfaces"
 

--- a/lang-python/cleo/spec
+++ b/lang-python/cleo/spec
@@ -1,5 +1,4 @@
-VER=0.8.1
+VER=2.0.1
 SRCS="tbl::https://pypi.io/packages/source/c/cleo/cleo-$VER.tar.gz"
-CHKSUMS="sha256::3d0e22d30117851b45970b6c14aca4ab0b18b1b53c8af57bed13208147e4069f"
+CHKSUMS="sha256::eb4b2e1f3063c11085cebe489a6e9124163c226575a3c3be69b2e51af4a15ec5"
 CHKUPDATE="anitya::id=21160"
-REL=1

--- a/lang-python/cython/spec
+++ b/lang-python/cython/spec
@@ -1,4 +1,4 @@
-VER=0.29.24
+VER=3.0.0
 SRCS="tbl::https://pypi.io/packages/source/C/Cython/Cython-$VER.tar.gz"
-CHKSUMS="sha256::cdf04d07c3600860e8c2ebaad4e8f52ac3feb212453c1764a49ac08c827e8443"
+CHKSUMS="sha256::350b18f9673e63101dbbfcf774ee2f57c20ac4636d255741d76ca79016b1bd82"
 CHKUPDATE="anitya::id=36699"

--- a/lang-python/hatch-vcs/autobuild/defines
+++ b/lang-python/hatch-vcs/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=hatch-vcs
+PKGSEC=python
+PKGDEP="python-3 hatchling"
+BUILDDEP="python-build setuptools-python3 python-installer wheel setuptools-scm"
+PKGDES="Hatch plugin for versioning with your preferred VCS"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/hatch-vcs/spec
+++ b/lang-python/hatch-vcs/spec
@@ -1,0 +1,4 @@
+VER=0.3.0
+SRCS="tbl::https://github.com/ofek/hatch-vcs/archive/refs/tags/v${VER}.tar.gz"
+CHKSUMS="sha256::f9d04225bcab0344b11f8daa5f14cb6b4ca591428a3a9166f876a7311ed165e5"
+CHKUPDATE="anitya::id=301800"

--- a/lang-python/poetry-core/autobuild/build
+++ b/lang-python/poetry-core/autobuild/build
@@ -1,0 +1,3 @@
+abinfo "Building poetry-core..."
+python3 -m build -w "$SRCDIR"
+find "$SRCDIR"/dist -type f -iname '*.whl' -exec python3 -m installer --destdir "$PKGDIR" {} \;

--- a/lang-python/poetry-core/autobuild/defines
+++ b/lang-python/poetry-core/autobuild/defines
@@ -4,4 +4,3 @@ PKGDES="Poetry PEP 517 Build Backend"
 PKGDEP="python-3 python-2 typing pathlib2"
 
 ABHOST=noarch
-ABTYPE=python

--- a/lang-python/poetry-core/autobuild/defines
+++ b/lang-python/poetry-core/autobuild/defines
@@ -1,6 +1,10 @@
 PKGNAME=poetry-core
 PKGSEC=python
 PKGDES="Poetry PEP 517 Build Backend"
-PKGDEP="python-3 python-2 typing pathlib2"
+PKGDEP="python-3 typing pathlib2"
+BUILDDEP="python-build python-installer"
 
+ABTYPE=pep517
+# Since it is using PEP 517.
+NOPYTHON2=1
 ABHOST=noarch

--- a/lang-python/poetry-core/autobuild/prepare
+++ b/lang-python/poetry-core/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo "Remove the conflicting __init__.py file against poetry"
-rm -v "${SRCDIR}"/poetry/__init__.py

--- a/lang-python/poetry-core/spec
+++ b/lang-python/poetry-core/spec
@@ -1,5 +1,4 @@
-VER=1.0.3
-SRCS="https://pypi.io/packages/source/p/poetry-core/poetry-core-${VER}.tar.gz"
-CHKSUMS="sha256::2315c928249fc3207801a81868b64c66273077b26c8d8da465dccf8f488c90c5"
+VER=1.7.0
+SRCS="tbl::https://github.com/python-poetry/poetry-core/releases/download/${VER}/poetry_core-${VER}.tar.gz"
+CHKSUMS="sha256::8f679b83bd9c820082637beca1204124d5d2a786e4818da47ec8acefd0353b74"
 CHKUPDATE="anitya::id=71155"
-REL=1

--- a/lang-python/poetry/autobuild/defines
+++ b/lang-python/poetry/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=python
 PKGDEP="cachecontrol cachy cleo clikit html5lib-python jsonschema pexpect \
         pkginfo pyparsing pyrsistent toolbelt requests shellingham tomlkit \
 	crashtest pexpect packaging virtualenv keyring poetry-core lockfile \
-	platformdirs"
+	platformdirs dulwich tomli"
 BUILDDEP="setuptools"
 PKGDES="Python dependency management and packaging made easy"
 

--- a/lang-python/poetry/autobuild/defines
+++ b/lang-python/poetry/autobuild/defines
@@ -2,7 +2,8 @@ PKGNAME=poetry
 PKGSEC=python
 PKGDEP="cachecontrol cachy cleo clikit html5lib-python jsonschema pexpect \
         pkginfo pyparsing pyrsistent toolbelt requests shellingham tomlkit \
-	crashtest pexpect packaging virtualenv keyring poetry-core lockfile"
+	crashtest pexpect packaging virtualenv keyring poetry-core lockfile \
+	platformdirs"
 BUILDDEP="setuptools"
 PKGDES="Python dependency management and packaging made easy"
 

--- a/lang-python/poetry/autobuild/defines
+++ b/lang-python/poetry/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="cachecontrol cachy cleo clikit html5lib-python jsonschema pexpect \
         pkginfo pyparsing pyrsistent toolbelt requests shellingham tomlkit \
 	crashtest pexpect packaging virtualenv keyring poetry-core lockfile \
 	platformdirs dulwich tomli"
-BUILDDEP="setuptools"
+BUILDDEP="setuptools python-build python-installer"
 PKGDES="Python dependency management and packaging made easy"
 
 ABHOST=noarch

--- a/lang-python/poetry/spec
+++ b/lang-python/poetry/spec
@@ -1,5 +1,4 @@
-VER=1.1.4
+VER=1.6.1
 SRCS="https://pypi.io/packages/source/p/poetry/poetry-$VER.tar.gz"
-CHKSUMS="sha256::946a5a1173be607c7c5c593358a0fb0c0d6af4400c978929ecdb19c3a37b53a8"
+CHKSUMS="sha256::0ab9b1a592731cc8b252b8d6aaeea19c72cc0a109d7468b829ad57e6c48039d2"
 CHKUPDATE="anitya::id=32514"
-REL=1

--- a/lang-python/rapidfuzz/autobuild/defines
+++ b/lang-python/rapidfuzz/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=rapidfuzz
+PKGDES="Rapid fuzzy string matching in Python using various string metrics"
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer cython scikit-build rapidfuzz-cpp"
+
+NOPYTHON2=1
+ABTYPE=pep517
+# This package contains native builds.

--- a/lang-python/rapidfuzz/autobuild/prepare
+++ b/lang-python/rapidfuzz/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Installing TaskFlow into project dependency..."
+rmdir -v "$SRCDIR/extern/taskflow"
+cp -vr "$SRCDIR"/../taskflow "$SRCDIR"/extern/

--- a/lang-python/rapidfuzz/spec
+++ b/lang-python/rapidfuzz/spec
@@ -1,0 +1,10 @@
+TASKFLOW_VER="3.6.0"
+
+VER=3.2.0
+SRCS="tbl::https://github.com/maxbachmann/RapidFuzz/archive/refs/tags/v${VER}.tar.gz \
+      git::commit=v${TASKFLOW_VER};rename=taskflow::https://github.com/taskflow/taskflow.git"
+CHKSUMS="sha256::dcd916fe55eb9c1892319d8a6bee2a7a7372a917a10336d7c9b84ce04b4bb225 \
+	 SKIP"
+CHKUPDATE="anitya::id=88678"
+
+SUBDIR="RapidFuzz-$VER"

--- a/lang-python/scikit-build/autobuild/defines
+++ b/lang-python/scikit-build/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=scikit-build
+PKGDES="Improved build system generator for CPython C, C++, Cython and Fortran extensions"
+PKGSEC=python
+PKGDEP="distro packaging tomli typing-extensions wheel hatchling hatch-vcs hatch-fancy-pypi-readme"
+BUILDDEP="python-build packaging python-installer setuptools-scm"
+
+NOPYTHON2=1
+ABHOST=noarch
+ABSPLITDBG=0

--- a/lang-python/scikit-build/spec
+++ b/lang-python/scikit-build/spec
@@ -1,0 +1,3 @@
+VER=0.17.6
+SRCS="tbl::https://github.com/scikit-build/scikit-build/archive/refs/tags/${VER}.tar.gz"
+CHKSUMS="sha256::86533b64464c85dd9a7f79fbbafea0476779d8030cf127ef2d452db8ccb007c3"

--- a/lang-python/setuptools-scm/autobuild/defines
+++ b/lang-python/setuptools-scm/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=python
 PKGDEP="setuptools"
 PKGDES="Handles managing your python package versions in SCM metadata"
 
+NOPYTHON2=1
 ABHOST=noarch

--- a/lang-python/setuptools-scm/spec
+++ b/lang-python/setuptools-scm/spec
@@ -1,5 +1,4 @@
-VER=3.2.0
-REL=3
+VER=7.1.0
 SRCS="tbl::https://pypi.io/packages/source/s/setuptools_scm/setuptools_scm-$VER.tar.gz"
-CHKSUMS="sha256::52ab47715fa0fc7d8e6cd15168d1a69ba995feb1505131c3e814eb7087b57358"
+CHKSUMS="sha256::6c508345a771aad7d56ebff0e70628bf2b0ec7573762be9960214730de278f27"
 CHKUPDATE="anitya::id=65053"

--- a/runtime-common/rapidfuzz-cpp/autobuild/defines
+++ b/runtime-common/rapidfuzz-cpp/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=rapidfuzz-cpp
+PKGDES="Rapid fuzzy string matching in C++ using the Levenshtein Distance"
+PKGSEC=libs
+
+# This package only contains functions defined in header files, and related CMake files.
+ABHOST=noarch
+ABSPLITDBG=0

--- a/runtime-common/rapidfuzz-cpp/spec
+++ b/runtime-common/rapidfuzz-cpp/spec
@@ -1,0 +1,4 @@
+VER=2.0.0
+SRCS="https://github.com/maxbachmann/rapidfuzz-cpp/archive/refs/tags/v${VER}.tar.gz"
+CHKSUMS="sha256::0d6d399be1de151631bbc189b72089600884831a4dac91e22f17351cef18ae64"
+CHKUPDATE="anitya::id=369163"

--- a/runtime-vcs/dulwich/autobuild/defines
+++ b/runtime-vcs/dulwich/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=dulwich
+PKGDES="A Git implementation in Python"
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer wheel setuptools"
+
+ABTYPE=pep517
+NOPYTHON2=1
+# This package contains C extensions.

--- a/runtime-vcs/dulwich/spec
+++ b/runtime-vcs/dulwich/spec
@@ -1,0 +1,4 @@
+VER=0.21.6
+SRCS="tbl::https://github.com/jelmer/dulwich/archive/refs/tags/dulwich-${VER}.tar.gz"
+CHKSUMS="sha256::ec05c3723bac25e0851f47d8b14c24cb418ba3e3a7686cf67f7f83923d2fb0bd"
+CHKUPDATE="anitya::id=6077"

--- a/runtime-vcs/gitdb/autobuild/defines
+++ b/runtime-vcs/gitdb/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=gitdb
+PKGSEC=python
+PKGDES="A Git object database for Python"
+PKGDEP="python-3 git smmap"
+
+ABHOST=noarch
+NOPYTHON2=1
+ABSPLITDBG=0

--- a/runtime-vcs/gitdb/spec
+++ b/runtime-vcs/gitdb/spec
@@ -1,0 +1,4 @@
+VER=4.0.10
+SRCS="tbl::https://github.com/gitpython-developers/gitdb/archive/refs/tags/${VER}.tar.gz"
+CHKSUMS="sha256::38b010cfae4b75576a7f99c60c1deb8a4c97c0477a6f07171e8e25a3a53c41ad"
+CHKUPDATE="anitya::id=12730"

--- a/runtime-vcs/gitpython/autobuild/defines
+++ b/runtime-vcs/gitpython/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=gitpython
+PKGSEC=python
+PKGDES="Python library used to interact with Git repositories"
+PKGDEP="python-3 git gitdb"
+
+NOPYTHON2=1
+ABSPLITDBG=0

--- a/runtime-vcs/gitpython/spec
+++ b/runtime-vcs/gitpython/spec
@@ -1,0 +1,4 @@
+VER=3.1.35
+SRCS="tbl::https://github.com/gitpython-developers/GitPython/archive/refs/tags/${VER}.tar.gz"
+CHKSUMS="sha256::cf9da1215b6bceee451a4dda8ddbaa90aa5fac42955c850f0679ba54d9762c26"
+CHKUPDATE="anitya::id=6459"

--- a/runtime-vcs/smmap/autobuild/defines
+++ b/runtime-vcs/smmap/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=smmap
+PKGDES="A sliding memory map manager"
+PKGSEC=python
+PKGDEP="python-3"
+
+ABHOST=noarch
+ABSPLITDBG=0

--- a/runtime-vcs/smmap/autobuild/patches/0001-no-reading-README.patch
+++ b/runtime-vcs/smmap/autobuild/patches/0001-no-reading-README.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index b995328..cb20c25 100755
+--- a/setup.py
++++ b/setup.py
+@@ -10,10 +10,7 @@ except ImportError:
+ 
+ import smmap
+ 
+-if os.path.exists("README.md"):
+-    long_description = open('README.md', encoding="utf-8").read().replace('\r\n', '\n')
+-else:
+-    long_description = "See https://github.com/gitpython-developers/smmap"
++long_description = "See https://github.com/gitpython-developers/smmap"
+ 
+ setup(
+     name="smmap",

--- a/runtime-vcs/smmap/spec
+++ b/runtime-vcs/smmap/spec
@@ -1,0 +1,4 @@
+VER=5.0.0
+SRCS="tbl::https://github.com/gitpython-developers/smmap/archive/refs/tags/v${VER}.tar.gz"
+CHKSUMS="sha256::265a54c1cc32742ac37204396f62680bf45295fe03a4ece82f9e63a5a08c9686"
+CHKUPDATE="anitya::id=12729"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates the Go toolchain and Go packages we provide to their latest version.

Package(s) Affected
-------------------

### Existing packages

- `go` 1.21.0
- `podman` 4.6.2
- `android-platform-tools` 34.0.4
- `git-lfs` 3.4.0
- `delve` 1.21.0
- `libguestfs` 1.50.1
- `clash` 1.18.0
- `dnscrypt` 2.1.5
- `frp` 0.51.3
- `geoipupdate` 6.0.0
- `kcptun` 20230811
- `syncthing` 1.24.0
- `v2ray` 5.7.0+git20230810
- `v2ray-plugin` 1.3.2
- `xray` 1.8.4
- `direnv` 2.32.3
- `fzf` 0.42.0
- `pcstat` 0.0.2
- `restic` 0.16.0
- `hub` 2.14.2+git20230617
- `hugo` 0.118.2
- `rclone` 1.63.1
- `poetry-code` 1.7.0
- `poetry` 1.6.1
- `setuptools-scm` 7.1.0
- `cython` 3.0.0
- `cleo` 2.0.1
- `mongodb` 7.0.1
- `docker` 24.0.6
- `conmon` 2.1.8
- `criu` 3.18

### New

- `hatch-vcs` 0.3.0
- `scikit-build` 0.17.6
- `rapidfuzz-cpp` 2.0.0
- `rapidfuzz` 3.2.0
- `dulwich` 0.21.6
- `smmap` 5.0.0
- `gitdb` 4.0.10
- `gitpython` 3.1.35
- `mongo-tooling-metrics` 1.0.8
- `docker-compose` 2.1.0

Security Update?
----------------

No

Build Order
-----------

```
go conmon podman android-platform-tools git-lfs delve libguestfs clash dnscrypt frp geoipupdate kcptun syncthing v2ray v2ray-plugin xray direnv fzf pcstat restic hub hugo rclone git-lfs dnscrypt libguestfs poetry-core poetry setuptools-scm hatch-vcs scikit-build cython rapidfuzz-cpp rapidfuzz cleo dulwich smmap gitdb gitpython mongo-tooling-metrics mongodb criu docker docker-compose
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
- [ ] 32-bit Optional Environment `optenv32`
- [ ] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
