### PR TITLE
mosh: update to 1.4.0

### DIFF
--- a/app-network/mosh/autobuild/beyond
+++ b/app-network/mosh/autobuild/beyond
@@ -1,2 +1,3 @@
-install -Dm644 conf/bash-completion/completions/mosh \
+abinfo "Installing Bash completion ..."
+install -Dvm644 conf/bash-completion/completions/mosh \
     "$PKGDIR"/usr/share/bash-completion/completions/mosh

--- a/app-network/mosh/autobuild/defines
+++ b/app-network/mosh/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=mosh
 PKGSEC=net
-PKGDEP="protobuf ncurses openssh perl-io-tty libutempter"
+PKGDEP="protobuf ncurses openssl openssh perl libutempter zlib"
 PKGDES="Mobile shell, surviving disconnects with local echo and line editing"

--- a/app-network/mosh/spec
+++ b/app-network/mosh/spec
@@ -1,5 +1,4 @@
-VER=1.3.2
-REL=5
-SRCS="https://mosh.mit.edu/mosh-$VER.tar.gz"
-CHKSUMS="sha256::da600573dfa827d88ce114e0fed30210689381bbdcff543c931e4d6a2e851216"
+VER=1.4.0
+SRCS="https://mosh.org/mosh-${VER}.tar.gz"
+CHKSUMS="sha256::872e4b134e5df29c8933dff12350785054d2fd2839b5ae6b5587b14db1465ddd"
 CHKUPDATE="anitya::id=7269"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Update mosh and upstream url

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`mosh` v1.4.0

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
