### PR TITLE
bash-startup: set bash-git-status as dep

### DIFF
--- a/runtime-data/bash-startup/autobuild/defines.stage2
+++ b/runtime-data/bash-startup/autobuild/defines.stage2
@@ -1,6 +1,6 @@
 PKGNAME=bash-startup
 PKGSEC=misc
-PKGDEP="bash sed bash-git-status"
+PKGDEP="bash sed"
 PKGDES="Generic Bash Startup Files for AOSC OS"
 
 PKGEPOCH=2

--- a/runtime-data/bash-startup/spec
+++ b/runtime-data/bash-startup/spec
@@ -1,4 +1,5 @@
 VER=0.5.0
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226642"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

bash-startup: set bash-git-status as dep

- Add defines.stage2 to build bash-startup without rust

Package(s) Affected
-------------------

bash-startup v0.5.0-1

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No
<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch` 

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->
 - [ ] Architecture-independent `noarch` 