### PR TITLE
autobuild3: update to 1.6.104

### DIFF
--- a/app-devel/autobuild3/spec
+++ b/app-devel/autobuild3/spec
@@ -1,4 +1,4 @@
-VER=1.6.99
+VER=1.6.104
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Autobuild3 to 1.6.104.

Package(s) Affected
-------------------

`autobuild3` v1.6.104

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`