### PR TITLE
Mozilla Scaling Rework

### DIFF
--- a/app-web/firefox/autobuild/overrides/usr/lib/firefox/browser/defaults/preferences/vendor.js
+++ b/app-web/firefox/autobuild/overrides/usr/lib/firefox/browser/defaults/preferences/vendor.js
@@ -17,6 +17,9 @@ pref("toolkit.legacyUserProfileCustomizations.stylesheets",	true);
 // Disable oft-broken client-side decoration.
 pref("browser.tabs.inTitlebar",			0);
 
+// Let the system handle DPI scaling.
+pref("layout.css.devPixelsPerPx",		-1.0);
+
 // ... from Fedora ...
 
 // Disable auto update.

--- a/app-web/firefox/spec
+++ b/app-web/firefox/spec
@@ -1,4 +1,5 @@
 VER=117.0.1
+REL=1
 CHKUPDATE="anitya::id=5506"
 SRCS="tbl::https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz \
       file::rename=ach.xpi::https://archive.mozilla.org/pub/firefox/releases/$VER/linux-x86_64/xpi/ach.xpi \

--- a/app-web/thunderbird/autobuild/overrides/usr/lib/thunderbird/defaults/preferences/vendor.js
+++ b/app-web/thunderbird/autobuild/overrides/usr/lib/thunderbird/defaults/preferences/vendor.js
@@ -1,7 +1,7 @@
-// Use LANG environment variable to choose locale
+// Use LANG environment variable to choose locale.
 pref("intl.locale.requested",				"");
 
-// Use system-provided dictionaries
+// Use system-provided dictionaries.
 pref("spellchecker.dictionary_path",			"/usr/share/hunspell");
 
 // Disable default mailer checking.
@@ -18,6 +18,9 @@ pref("widget.use-xdg-desktop-portal.file-picker",	1);
 // Disable oft-broken client-side decoration.
 pref("mail.tabs.drawInTitlebar",			false);
 
+// Let the system handle DPI scaling.
+pref("layout.css.devPixelsPerPx",                       -1.0);
+
 // ... From Fedora ...
 
 // Disable auto update.
@@ -31,9 +34,3 @@ pref("offline.autoDetect",				true);
 pref("datareporting.healthreport.uploadEnabled",	false);
 pref("datareporting.policy.dataSubmissionEnabled",	false);
 pref("toolkit.telemetry.archive.enabled",		false);
-
-// Default to our default font size (10px).
-pref("mail.uifontsize",					10);
-
-// Default to the "compact" (0) UI density, as it seems more appropriate for desktop devices.
-pref("mail.uidensity",					0);

--- a/app-web/thunderbird/spec
+++ b/app-web/thunderbird/spec
@@ -1,4 +1,5 @@
 VER=115.2.2
+REL=1
 CHKUPDATE="anitya::id=4967"
 SRCS="https://archive.mozilla.org/pub/thunderbird/releases/$VER/source/thunderbird-$VER.source.tar.xz \
       file::rename=af.xpi::http://ftp.mozilla.org/pub/thunderbird/releases/$VER/linux-x86_64/xpi/af.xpi \


### PR DESCRIPTION
Topic Description
-----------------

This topic reworks Mozilla applications to respect system scaling settings.

Package(s) Affected
-------------------

- `firefox` v117.0.1-1
- `thunderbird` v115.2.2-1

Security Update?
----------------

No

Build Order
-----------

```
firefox thunderbird
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`