### PR TITLE
Go 1.21 Rework

### DIFF
--- a/lang-golang/go/autobuild/build
+++ b/lang-golang/go/autobuild/build
@@ -139,7 +139,7 @@ abinfo "Building extra Go tools ..."
 
 # List adapted from Arch Linux ..."
 abinfo "Installing extra Go tools ..."
-for i in authtest benchcmp bisect bundle callgraph \
+for i in authtest benchcmp bisect callgraph \
 	 compilebench cookieauth digraph eg file2fuzz \
 	 fiximports fuzz-driver fuzz-runner getgo gitauth \
 	 go-contrib-init godex godoc goimports gomvpkg \
@@ -151,7 +151,7 @@ for i in authtest benchcmp bisect bundle callgraph \
 done
 
 abinfo "Installing extra Go tools with possible name collision with existing packages..."
-for i in stress ; do
+for i in bundle stress ; do
 	install -Dvm755 "$SRCDIR"/bin/$i "$PKGDIR"/usr/bin/go-${i}
 done
 

--- a/lang-golang/go/autobuild/build.stage2
+++ b/lang-golang/go/autobuild/build.stage2
@@ -146,15 +146,20 @@ abinfo "Building extra Go tools ..."
 
 # List adapted from Arch Linux ..."
 abinfo "Installing extra Go tools ..."
-for i in authtest benchcmp bisect bundle callgraph \
+for i in authtest benchcmp bisect callgraph \
 	 compilebench cookieauth digraph eg file2fuzz \
 	 fiximports fuzz-driver fuzz-runner getgo gitauth \
 	 go-contrib-init godex godoc goimports gomvpkg \
 	 gonew gorename gotype goyacc guru \
 	 html2article netrcauth present present2md server \
-	 splitdwarf ssadump stress stringer toolstash ; do
+	 splitdwarf ssadump stringer toolstash ; do
     install -Dvm755 "$SRCDIR"/bin/$i \
         "$PKGDIR"/usr/bin/$i
+done
+
+abinfo "Installing extra Go tools with possible name collision with existing packages..."
+for i in bundle stress ; do
+	install -Dvm755 "$SRCDIR"/bin/$i "$PKGDIR"/usr/bin/go-${i}
 done
 
 cd "$SRCDIR"

--- a/lang-golang/go/spec
+++ b/lang-golang/go/spec
@@ -4,6 +4,7 @@ NET_VER=0.14.0
 GOLANG_VER=1.21.0
 
 VER="${GOLANG_VER}+tools${TOOLS_VER}+net${NET_VER}"
+REL=1
 SRCS="tbl::https://go.dev/dl/go${GOLANG_VER}.src.tar.gz \
       git::commit=tags/v${TOOLS_VER};rename=tools::https://go.googlesource.com/tools \
       git::commit=tags/v${NET_VER};rename=net::https://github.com/golang/net"


### PR DESCRIPTION
Topic Description
-----------------

This PR addresses the binary name collision with go and ruby (`/usr/bin/bundle`). The binary fron go is renamed to `go-bundle`.

Package(s) Affected
-------------------

- `go` 1.21.0-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
