### PR TITLE
racket: update to 8.10

### DIFF
--- a/lang-lisp/racket/autobuild/defines
+++ b/lang-lisp/racket/autobuild/defines
@@ -8,3 +8,4 @@ RECONF=0
 
 AUTOTOOLS_AFTER__PPC64EL="--enable-pb --enable-mach=tpb64l"
 AUTOTOOLS_AFTER__LOONGSON3="--enable-pb --enable-mach=pb64l"
+AUTOTOOLS_AFTER__LOONGARCH64="--enable-pb --enable-mach=pb64l"

--- a/lang-lisp/racket/spec
+++ b/lang-lisp/racket/spec
@@ -1,5 +1,5 @@
-VER=8.9
+VER=8.10
 SRCS="tbl::https://mirror.racket-lang.org/installers/$VER/racket-$VER-src.tgz"
 SUBDIR="racket-$VER/src"
-CHKSUMS="sha256::3ae225e84e119f4cd1a47f1b16133568fc7d35c290c505495566d9dccefc5224"
+CHKSUMS="sha256::0e4963da2c17e7f6d57428bda1dcf64eda7437e2f26bb6cc48b47f417a3d93a3"
 CHKUPDATE="anitya::id=13609"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Update racket

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`racket` 8.10

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
