### PR TITLE
Cython 0.29

### DIFF
--- a/lang-python/cython-0.29/autobuild/build
+++ b/lang-python/cython-0.29/autobuild/build
@@ -1,0 +1,9 @@
+python3 setup.py install --root="$PKGDIR"
+mv -v "$PKGDIR"/usr/bin/cygdb "$PKGDIR"/usr/bin/cygdb3-0.29
+mv "$PKGDIR"/usr/bin/cython "$PKGDIR"/usr/bin/cython3-0.29
+
+python2 setup.py install --root="$PKGDIR"
+mv -v "$PKGDIR"/usr/bin/cygdb "$PKGDIR"/usr/bin/cygdb-0.29
+mv -v "$PKGDIR"/usr/bin/cython "$PKGDIR"/usr/bin/cython-0.29
+
+mv -v "$PKGDIR"/usr/bin/cythonize "$PKGDIR"/usr/bin/cythonize-0.29

--- a/lang-python/cython-0.29/autobuild/build
+++ b/lang-python/cython-0.29/autobuild/build
@@ -1,9 +1,0 @@
-python3 setup.py install --root="$PKGDIR"
-mv -v "$PKGDIR"/usr/bin/cygdb "$PKGDIR"/usr/bin/cygdb3-0.29
-mv "$PKGDIR"/usr/bin/cython "$PKGDIR"/usr/bin/cython3-0.29
-
-python2 setup.py install --root="$PKGDIR"
-mv -v "$PKGDIR"/usr/bin/cygdb "$PKGDIR"/usr/bin/cygdb-0.29
-mv -v "$PKGDIR"/usr/bin/cython "$PKGDIR"/usr/bin/cython-0.29
-
-mv -v "$PKGDIR"/usr/bin/cythonize "$PKGDIR"/usr/bin/cythonize-0.29

--- a/lang-python/cython-0.29/autobuild/defines
+++ b/lang-python/cython-0.29/autobuild/defines
@@ -1,9 +1,6 @@
 PKGNAME=cython-0.29
 PKGSEC=python
-PKGDES="C extensions for Python (Version 0.29)"
+PKGDES="C extensions for Python (version 0.29)"
 PKGDEP="python-2 python-3 setuptools"
 
-PKGPROV=cython
-PKGCONFL="cython>=3.0.0"
-
-ABTYPE=self
+PKGCONFL="cython"

--- a/lang-python/cython-0.29/autobuild/defines
+++ b/lang-python/cython-0.29/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=cython-0.29
+PKGSEC=python
+PKGDES="C extensions for Python (Version 0.29)"
+PKGDEP="python-2 python-3 setuptools"
+
+PKGPROV=cython
+PKGBREAK="cython>=3.0.0"
+
+ABTYPE=self

--- a/lang-python/cython-0.29/autobuild/defines
+++ b/lang-python/cython-0.29/autobuild/defines
@@ -4,6 +4,6 @@ PKGDES="C extensions for Python (Version 0.29)"
 PKGDEP="python-2 python-3 setuptools"
 
 PKGPROV=cython
-PKGBREAK="cython>=3.0.0"
+PKGCONFL="cython>=3.0.0"
 
 ABTYPE=self

--- a/lang-python/cython-0.29/spec
+++ b/lang-python/cython-0.29/spec
@@ -1,0 +1,4 @@
+VER=0.29.36
+SRCS="tbl::https://pypi.io/packages/source/C/Cython/Cython-$VER.tar.gz"
+CHKSUMS="sha256::41c0cfd2d754e383c9eeb95effc9aa4ab847d0c9747077ddd7c0dcb68c3bc01f"
+CHKUPDATE="anitya::id=36699"

--- a/lang-python/cython/autobuild/build
+++ b/lang-python/cython/autobuild/build
@@ -1,5 +1,0 @@
-python3 setup.py install --root="$PKGDIR"
-mv "$PKGDIR"/usr/bin/cygdb "$PKGDIR"/usr/bin/cygdb3
-mv "$PKGDIR"/usr/bin/cython "$PKGDIR"/usr/bin/cython3
-
-python2 setup.py install --root="$PKGDIR"

--- a/lang-python/cython/autobuild/defines
+++ b/lang-python/cython/autobuild/defines
@@ -3,4 +3,6 @@ PKGSEC=python
 PKGDES="C extensions for Python"
 PKGDEP="python-2 python-3 setuptools"
 
+PKGBCONFL="cython-0.29"
+
 ABTYPE=self

--- a/lang-python/cython/autobuild/defines
+++ b/lang-python/cython/autobuild/defines
@@ -4,5 +4,3 @@ PKGDES="C extensions for Python"
 PKGDEP="python-2 python-3 setuptools"
 
 PKGCONFL="cython-0.29"
-
-ABTYPE=self

--- a/lang-python/cython/autobuild/defines
+++ b/lang-python/cython/autobuild/defines
@@ -3,6 +3,6 @@ PKGSEC=python
 PKGDES="C extensions for Python"
 PKGDEP="python-2 python-3 setuptools"
 
-PKGBCONFL="cython-0.29"
+PKGCONFL="cython-0.29"
 
 ABTYPE=self

--- a/lang-python/cython/spec
+++ b/lang-python/cython/spec
@@ -1,4 +1,4 @@
-VER=3.0.0
+VER=3.0.2
 SRCS="tbl::https://pypi.io/packages/source/C/Cython/Cython-$VER.tar.gz"
-CHKSUMS="sha256::350b18f9673e63101dbbfcf774ee2f57c20ac4636d255741d76ca79016b1bd82"
+CHKSUMS="sha256::9594818dca8bb22ae6580c5222da2bc5cc32334350bd2d294a00d8669bcc61b5"
 CHKUPDATE="anitya::id=36699"

--- a/lang-python/rapidfuzz/autobuild/patches/0001-Arch-remove-version-constraints.patch
+++ b/lang-python/rapidfuzz/autobuild/patches/0001-Arch-remove-version-constraints.patch
@@ -1,0 +1,14 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,8 +1,8 @@
+ [build-system]
+ requires = [
+-    "setuptools>=42",
+-    "scikit-build~=0.17.0",
+-    "Cython==3.0.0"
++    "setuptools",
++    "scikit-build",
++    "Cython"
+ ]
+ build-backend = "backend"
+ backend-path = ["_custom_build"]

--- a/lang-python/rapidfuzz/spec
+++ b/lang-python/rapidfuzz/spec
@@ -1,6 +1,7 @@
 TASKFLOW_VER="3.6.0"
 
 VER=3.2.0
+REL=1
 SRCS="tbl::https://github.com/maxbachmann/RapidFuzz/archive/refs/tags/v${VER}.tar.gz \
       git::commit=v${TASKFLOW_VER};rename=taskflow::https://github.com/taskflow/taskflow.git"
 CHKSUMS="sha256::dcd916fe55eb9c1892319d8a6bee2a7a7372a917a10336d7c9b84ce04b4bb225 \


### PR DESCRIPTION
Topic Description
-----------------

This PR introduces the legacy version of Cython (0.29.x branch, needed for older sources) and also updates Cython 3.0.x to its latest patch version.

Package(s) Affected
-------------------

### New

- `cython-0.29` 0.29.36

### Existing

- `cython` 3.0.2
- `rapidfuzz` 3.2.0-1


Security Update?
----------------

No

Build Order
-----------

```
cython cython-0.29 rapidfuzz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
