### PR TITLE
ripgrep: enable pcre2 feature

### DIFF
--- a/app-utils/ripgrep/autobuild/defines
+++ b/app-utils/ripgrep/autobuild/defines
@@ -15,5 +15,3 @@ NOLTO__LOONGSON3=1
 ABSPLITDBG__LOONGSON3=0
 NOLTO__MIPS64R6EL=1
 USECLANG__MIPS64R6EL=0
-# FIXME: ld.lld: error: lto.tmp: cannot link object files with different floating-point ABI
-NOLTO__RISCV64=1

--- a/app-utils/ripgrep/autobuild/defines
+++ b/app-utils/ripgrep/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=ripgrep
 PKGSEC=utils
-PKGDEP="glibc"
+PKGDEP="glibc pcre2"
 BUILDDEP="asciidoctor llvm rustc"
 PKGDES="Line-oriented search tool that recursively searches your current directory for a regex pattern"
+
+CARGO_AFTER="--features pcre2"
 
 USECLANG=1
 ABSPLITDBG=0

--- a/app-utils/ripgrep/spec
+++ b/app-utils/ripgrep/spec
@@ -1,5 +1,5 @@
 VER=13.0.0
-REL=9
+REL=10
 SRCS="tbl::https://github.com/BurntSushi/ripgrep/archive/$VER.tar.gz"
 CHKSUMS="sha256::0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2"
 CHKUPDATE="anitya::id=15461"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

ripgrep: enable pcre2 feature

Package(s) Affected
-------------------

ripgrep: enable pcre2 feature

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No
<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->


-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
