### PR TITLE
pytest: update to 8.2.2

### DIFF
--- a/lang-python/pluggy/spec
+++ b/lang-python/pluggy/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.5.0
 SRCS="tbl::https://pypi.io/packages/source/p/pluggy/pluggy-$VER.tar.gz"
-CHKSUMS="sha256::4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"
+CHKSUMS="sha256::2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"
 CHKUPDATE="anitya::id=7500"

--- a/lang-python/pytest/autobuild/defines
+++ b/lang-python/pytest/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=pytest
 PKGSEC=python
-PKGDEP="py setuptools attrs iniconfig packaging pluggy tomli"
-BUILDDEP="pip setuptools setuptools-scm tomli"
+PKGDEP="py setuptools attrs iniconfig packaging pluggy tomli exceptiongroup"
+BUILDDEP="pip setuptools setuptools-scm tomli wheel python-build python-installer"
 PKGDES="A simple but powerful testing framework for Python"
 
 ABHOST=noarch

--- a/lang-python/pytest/spec
+++ b/lang-python/pytest/spec
@@ -1,5 +1,4 @@
-VER=7.1.1
-REL=2
+VER=8.2.2
 SRCS="tbl::https://pypi.io/packages/source/p/pytest/pytest-$VER.tar.gz"
-CHKSUMS="sha256::841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63"
+CHKSUMS="sha256::de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977"
 CHKUPDATE="anitya::id=3765"


### PR DESCRIPTION
Topic Description
-----------------

- pluggy: update to 1.5.0
- pytest: update to 8.2.2

Package(s) Affected
-------------------

- pluggy: 1.5.0
- pytest: 8.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pluggy pytest
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
