### PR TITLE
discord: update to 0.0.31

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.30
+VER=0.0.31
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::7827c5ef30bd24cff2d78a2f489c4c22f2d8f881afd09bf39fb31582e7a5b4db"
+CHKSUMS="sha256::b685b088cb0416c19a39868f673892999b69cf119df66fb632dc53ac9c2a15bc"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Discord to 0.0.31.

Package(s) Affected
-------------------

`discord` v0.0.31

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
