### PR TITLE
ciel: rebuild for OpenSSL 3.1.1 (rework)

### DIFF
--- a/app-devel/ciel/spec
+++ b/app-devel/ciel/spec
@@ -1,6 +1,5 @@
 VER=3.2.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227000"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

This topic bumps `ciel`'s REL for OpenSSL 3.1.1 rebuild, which was missed in the main topic.

Package(s) Affected
-------------------

`ciel` v3.2.0-2

Security Update?
----------------

No