### PR TITLE
telegram-desktop: add patch to revert hidpi handling behavior

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/1001-revert-hidpi-handling.patch
+++ b/app-web/telegram-desktop/autobuild/patches/1001-revert-hidpi-handling.patch
@@ -1,0 +1,15 @@
+diff --git a/Telegram/SourceFiles/core/launcher.cpp b/Telegram/SourceFiles/core/launcher.cpp
+index b171b070e..f5cf06206 100644
+--- a/Telegram/SourceFiles/core/launcher.cpp
++++ b/Telegram/SourceFiles/core/launcher.cpp
+@@ -338,7 +338,9 @@ void Launcher::initHighDpi() {
+ #endif // Qt < 6.2.0
+ 
+ #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+-	QApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
++	QApplication::setAttribute(Qt::AA_DisableHighDpiScaling, true);
++	QApplication::setHighDpiScaleFactorRoundingPolicy(
++		Qt::HighDpiScaleFactorRoundingPolicy::Floor);
+ #endif // Qt < 6.0.0
+ 
+ 	if (OptionFractionalScalingEnabled.value()) {

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,4 +1,5 @@
 VER=4.10.1
+REL=1
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=592b14d13bf9103226e90a83571e24c49f6bfdcd
 SRCS="git::rename=tdesktop;commit=tags/v$VER::https://github.com/telegramdesktop/tdesktop \


### PR DESCRIPTION
Topic Description
-----------------

This topic reverts `telegram-desktop`'s HiDPI handling because the new behavior breaks if we don't use their qt patches.

Package(s) Affected
-------------------

`telegram-desktop` v4.10.1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
