### PR TITLE
cURL: security update to 8.4.0

### DIFF
--- a/app-web/curl/autobuild/defines
+++ b/app-web/curl/autobuild/defines
@@ -29,8 +29,7 @@ AUTOTOOLS_AFTER="--mandir=/usr/share/man \
                  --with-libpsl \
                  --with-openssl \
                  --with-random=/dev/urandom \
-                 --with-ca-bundle=/etc/ssl/ca-bundle.crt \
-                 --enable-debug"
+                 --with-ca-bundle=/etc/ssl/ca-bundle.crt"
 AUTOTOOLS_AFTER__RETRO=" \
                  --mandir=/usr/share/man \
                  --disable-ldap \
@@ -47,8 +46,7 @@ AUTOTOOLS_AFTER__RETRO=" \
                  --without-libpsl \
                  --with-openssl \
                  --with-random=/dev/urandom \
-                 --with-ca-bundle=/etc/ssl/ca-bundle.crt \
-                 --enable-debug"
+                 --with-ca-bundle=/etc/ssl/ca-bundle.crt"
 AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"

--- a/app-web/curl/spec
+++ b/app-web/curl/spec
@@ -1,5 +1,4 @@
-VER=8.3.0
-SRCS="tbl::https://curl.haxx.se/download/curl-$VER.tar.xz"
-CHKSUMS="sha256::376d627767d6c4f05105ab6d497b0d9aba7111770dd9d995225478209c37ea63"
+VER=8.4.0
+SRCS="tbl::https://curl.se/download/curl-$VER.tar.bz2"
+CHKSUMS="sha256::e5250581a9c032b1b6ed3cf2f9c114c811fc41881069e9892d115cc73f9e88c6"
 CHKUPDATE="anitya::id=381"
-REL=1

--- a/runtime-optenv32/curl+32/spec
+++ b/runtime-optenv32/curl+32/spec
@@ -1,4 +1,4 @@
-VER=8.3.0
-SRCS="tbl::https://curl.haxx.se/download/curl-$VER.tar.xz"
-CHKSUMS="sha256::376d627767d6c4f05105ab6d497b0d9aba7111770dd9d995225478209c37ea63"
+VER=8.4.0
+SRCS="tbl::https://curl.se/download/curl-$VER.tar.bz2"
+CHKSUMS="sha256::e5250581a9c032b1b6ed3cf2f9c114c811fc41881069e9892d115cc73f9e88c6"
 CHKUPDATE="anitya::id=381"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates cURL to 8.4.0, addressing a severe security vulnerability.

Package(s) Affected
-------------------

- `curl` v8.4.0
- `curl+32` v8.4.0

Security Update?
----------------

Yes, #4764

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit Optional Environment `optenv32`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
- [ ] 32-bit Optional Environment `optenv32`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`