### PR TITLE
MIPS64 R6 Rework 20231012

### DIFF
--- a/app-devel/autobuild3/spec
+++ b/app-devel/autobuild3/spec
@@ -1,4 +1,4 @@
-VER=1.6.108
+VER=1.6.109
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"

--- a/desktop-gnome/gtk-4/autobuild/defines
+++ b/desktop-gnome/gtk-4/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=gtk-4
 PKGSEC=x11
 PKGDEP="adwaita-icon-theme cairo colord cups dconf desktop-file-utils ffmpeg \
-        fontconfig fribidi gdk-pixbuf glib graphene gst-plugins-bad-1-0 \
+        fontconfig fribidi gdk-pixbuf glib graphene gstreamer \
         harfbuzz iso-codes json-glib libcloudproviders libepoxy librsvg mesa \
         pango rest shared-mime-info tracker vulkan wayland \
         wayland-protocols"

--- a/desktop-gnome/gtk-4/spec
+++ b/desktop-gnome/gtk-4/spec
@@ -1,5 +1,5 @@
 VER=4.6.7
-REL=2
+REL=3
 SRCS="https://download.gnome.org/sources/gtk/${VER%.*}/gtk-$VER.tar.xz"
 CHKSUMS="sha256::effd2e7c4b5e2a5c7fad43e0f24adea68baa4092abb0b752caff278e6bb010e8"
 CHKUPDATE="anitya::id=13942"

--- a/desktop-gnome/tracker/autobuild/defines
+++ b/desktop-gnome/tracker/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=tracker
 PKGSEC=gnome
-PKGDEP="desktop-file-utils enca exempi flac giflib gst-plugins-base-1-0 \
+PKGDEP="desktop-file-utils enca exempi flac giflib gstreamer \
         gtk-3 hicolor-icon-theme icu json-glib libcue libexif libffi libgee \
         libiptcdata libgrss libgsf libgxps libmediaart libosinfo libsecret \
         libsoup libunistring libvorbis networkmanager pcre poppler python-3 \

--- a/desktop-gnome/tracker/spec
+++ b/desktop-gnome/tracker/spec
@@ -1,5 +1,5 @@
 VER=3.3.3
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/tracker.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5578"

--- a/runtime-desktop/qt-5/autobuild/defines
+++ b/runtime-desktop/qt-5/autobuild/defines
@@ -3,7 +3,7 @@ PKGEPOCH=1
 PKGSEC=x11
 PKGDES="Qt version 5"
 PKGDEP="alsa-lib bluez cups dbus desktop-file-utils double-conversion ffmpeg \
-        fontconfig glib gst-plugins-base-1-0 harfbuzz hicolor-icon-theme \
+        fontconfig glib gstreamer harfbuzz hicolor-icon-theme \
         hyphen icu lcms2 libdrm libinput libglvnd libjpeg-turbo libmng libpng \
         libproxy libvpx libwebp libxkbcommon libxml2 libxslt mesa minizip \
         opus pciutils pcre2 perl protobuf pipewire-0.2 pulseaudio re2 snappy \
@@ -20,7 +20,7 @@ BUILDDEP__PPC64EL="${BUILDDEP__NOWEBENGINE}"
 BUILDDEP__RISCV64="${BUILDDEP__NOWEBENGINE}"
 
 PKGDEP_NOWEBENGINE="alsa-lib bluez cups dbus desktop-file-utils \
-        double-conversion fontconfig gst-plugins-base-1-0 glib harfbuzz \
+        double-conversion fontconfig glib gstreamer harfbuzz \
         hicolor-icon-theme hyphen icu libdrm libinput libglvnd libjpeg-turbo \
         libmng libpng libproxy libxkbcommon libxslt mesa pcre2 perl protobuf \
         pulseaudio re2 sqlite srtp systemd tslib vulkan x11-lib xcb-util \

--- a/runtime-multimedia/gstreamer/autobuild/defines.stage2
+++ b/runtime-multimedia/gstreamer/autobuild/defines.stage2
@@ -11,8 +11,7 @@ PKGDEP="a52dec aalib bluez bzip2 cairo cdparanoia chromaprint elfutils faac \
         mpg123 neon nettle openal-soft opencore-amr openh264 opus orc \
         pulseaudio pygobject-3 qrencode rtmpdump sbc sdl2 soundtouch \
         spandsp srtp taglib twolame v4l-utils wavpack wayland \
-        webrtc-audio-processing wildmidi x264 zbar zlib zvbi zxing-cpp dssim-c \
-        rav1e"
+        webrtc-audio-processing wildmidi x264 zbar zlib zvbi zxing-cpp dssim-c"
 PKGDEP__AMD64="${PKGDEP} openmpt svt-hevc"
 PKGDEP__ARM64="${PKGDEP} openmpt"
 PKGDEP__LOONGSON3="${PKGDEP}"


### PR DESCRIPTION
Topic Description
-----------------

This topic reworks a few FTBFS that was discovered during version sync for `mips64r6el`.

Package(s) Affected
-------------------

See "Files changed."

Security Update?
----------------

No

Build Order
-----------

```
autobuild3 tracker gtk-4 qt-5 gstreamer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`