### PR TITLE
texlive: ship shared libraries

### DIFF
--- a/app-doc/texlive/autobuild/build
+++ b/app-doc/texlive/autobuild/build
@@ -19,6 +19,7 @@ fi
 mkdir "$SRCDIR"/build && cd "$SRCDIR"/build
 ../configure			   \
     ${AUTOTOOLS_DEF}               \
+    --enable-shared                \
     --disable-native-texlive-build \
     --disable-dvisvgm              \
     --with-system-cairo            \

--- a/app-doc/texlive/spec
+++ b/app-doc/texlive/spec
@@ -1,4 +1,5 @@
 VER=20220321
+REL=1
 SRCS="tbl::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-source.tar.xz \
       file::rename=texlive-$VER-texmf.tar.xz::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-texmf.tar.xz"
 CHKSUMS="sha256::5ffa3485e51eb2c4490496450fc69b9d7bd7cb9e53357d92db4bcd4fd6179b56 \


### PR DESCRIPTION
Topic Description
-----------------

This PR updates Texlive build with shared libraries enabled. Previously shared libraries are not enabled and caused problems for some program which depends on libkpathsea, libptexenc, etc.

Package(s) Affected
-------------------

texlive

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
