### PR TITLE
fcitx5-pinyin-moegirl: upgrade to 20231014

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20230914
+VER=20231014
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::e48899c19b0611160cae73307fdce7600b584a259a30d171c8007a73bdbb358f \
-         sha256::7f81f4815e1f14dc18d6b014cfcd2ef3871a46ef766bf0f5ca2f579a959e832d \
+CHKSUMS="sha256::34907c627a17dbc38da25ac55ea5319fc8c4211a39570114c852556da84ca866 \
+         sha256::8ded66335b3b8f8a1435233a0e33b3488226369f3a976adc517bf4b87855f22e \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Upgrade `fcitx5-pinyin-moegirl` to 20231014.

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------
No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`