### PR TITLE
pivy: new, 0.6.8

### DIFF
--- a/app-creativity/freecad/autobuild/defines
+++ b/app-creativity/freecad/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=freecad
-PKGDEP="med hdf5 opencascade vtk glew boost coin xerces-c pyside2 libspnav matplotlib pcl"
+PKGDEP="med hdf5 opencascade vtk glew boost coin xerces-c pyside2 libspnav matplotlib pcl pivy ply"
 PKGSUG="openscad"
 BUILDDEP="swig pybind11 eigen-3"
 PKGSEC="graphics"

--- a/app-creativity/freecad/spec
+++ b/app-creativity/freecad/spec
@@ -1,4 +1,5 @@
 VER=0.21.1
+REL=1
 SRCS="git::commit=tags/${VER}::https://github.com/FreeCAD/FreeCAD"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=836"

--- a/lang-python/pivy/autobuild/defines
+++ b/lang-python/pivy/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=pivy
+PKGDES="Python binding to the Coin3D library"
+PKGDEP="python-3 coin"
+BUILDDEP="swig"
+PKGSEC=python
+
+ABTYPE=cmakeninja

--- a/lang-python/pivy/spec
+++ b/lang-python/pivy/spec
@@ -1,0 +1,4 @@
+VER=0.6.8
+SRCS="git::commit=tags/${VER}::https://github.com/coin3d/pivy.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=20111"


### PR DESCRIPTION
Topic Description
-----------------

Add `pivy` package, which is a binding for `coin` to Python, and let it and `ply` be (runtime) dependencies for `freecad`.

Package(s) Affected
-------------------

- `pivy`
- `freecad`

Security Update?
----------------

No

Build Order
-----------

`pivy freecad`

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
