### PR TITLE
oma: update to 1.1

### DIFF
--- a/app-admin/apt-gen-list/spec
+++ b/app-admin/apt-gen-list/spec
@@ -1,5 +1,4 @@
-VER=0.6.8
-REL=3
-SRCS="tbl::https://github.com/AOSC-Dev/apt-gen-list-rs/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::ba4da1d708bbab53095ef5da84a7dc8e34f4ea273f5121d9fa256c923ebe6125"
+VER=0.7.0
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/apt-gen-list-rs"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226680"

--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -8,6 +8,8 @@ PKGRECOM="apt-gen-list"
 BUILDDEP="rustc llvm"
 PKGSEC="admin"
 
+# loongson3 llvm break nettle-sys build
+# so use openssl as oma-refresh sequoia-openpgp backend
 CARGO_AFTER__LOONGSON3="--no-default-features \
                         --features=aosc,sequoia-openssl-backend"
 

--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -8,8 +8,8 @@ PKGRECOM="apt-gen-list"
 BUILDDEP="rustc llvm"
 PKGSEC="admin"
 
-# loongson3 llvm break nettle-sys build
-# so use openssl as oma-refresh sequoia-openpgp backend
+# FIXME: nettle-sys does not build on loongson3 due to LLVM brokenness.
+# Use openssl backend for sequoia-openpgp, which is used by oma-refresh.
 CARGO_AFTER__LOONGSON3="--no-default-features \
                         --features=aosc,sequoia-openssl-backend"
 

--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -7,6 +7,9 @@ PKGDEP="apt bzip2 gcc-runtime gmp gnutls \
 BUILDDEP="rustc llvm"
 PKGSEC="admin"
 
+CARGO_AFTER__LOONGSON3="--no-default-features \
+                        --features=aosc,sequoia-openssl-backend"
+
 USECLANG=1
 
 NOLTO__LOONGSON3=1

--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -3,7 +3,8 @@ PKGDES="Default package management interface"
 PKGDEP="apt bzip2 gcc-runtime gmp gnutls \
         libcap libgcrypt libgpg-error lz4 \
         nettle openssl systemd xxhash xz \
-        zlib zstd"
+        zlib zstd ripgrep"
+PKGRECOM="apt-gen-list"
 BUILDDEP="rustc llvm"
 PKGSEC="admin"
 

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.1.0~beta6
+VER=1.1.0
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.1.1
+VER=1.1.2
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.1.0
+VER=1.1.1
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.1.2
+VER=1.1.3
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.1.4
+VER=1.1.5
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.0.9999
-SRCS="git::commit=96fd58d5336a2093f1cb8b262653857278cb5a12::https://github.com/AOSC-Dev/oma"
+VER=1.1.0~beta6
+SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.1.3
+VER=1.1.4
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
-SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/oma"
+VER=1.0.9999
+SRCS="git::commit=96fd58d5336a2093f1cb8b262653857278cb5a12::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Omakase to 1.1, with major refactoring and many new features.

Package(s) Affected
-------------------

`oma` v1.1.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and, if the build script(s) affected complies with the
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/), please
     add `lgtm` label to this issue. -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->

Update(s) Uploaded to Stable
----------------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- TODO: CI to auto-fill architectural progress. -->
