### PR TITLE
systemd 254

### DIFF
--- a/app-admin/dracut/autobuild/patches/0002-fix-shellcheck-0.8.0.patch
+++ b/app-admin/dracut/autobuild/patches/0002-fix-shellcheck-0.8.0.patch
@@ -1,0 +1,702 @@
+From 08b63a25296d689186c6343f96e764bf893367cb Mon Sep 17 00:00:00 2001
+From: Laszlo Gombos <laszlo.gombos@gmail.com>
+Date: Mon, 21 Nov 2022 04:01:59 +0000
+Subject: [PATCH] fix: shellcheck 0.8.0
+
+---
+ dracut-functions.sh                              |  2 +-
+ dracut-init.sh                                   |  8 ++++----
+ dracut.sh                                        |  5 +++--
+ modules.d/03modsign/module-setup.sh              |  2 +-
+ modules.d/10i18n/console_init.sh                 |  4 ++--
+ modules.d/35network-legacy/dhclient-script.sh    |  4 ++--
+ modules.d/35network-legacy/parse-bond.sh         |  2 +-
+ modules.d/35network-legacy/parse-bridge.sh       |  2 +-
+ modules.d/35network-legacy/parse-ip-opts.sh      |  2 +-
+ modules.d/35network-legacy/parse-team.sh         |  2 +-
+ modules.d/35network-legacy/parse-vlan.sh         |  2 +-
+ modules.d/40network/net-lib.sh                   | 16 ++++++++--------
+ modules.d/45url-lib/module-setup.sh              |  4 ++--
+ modules.d/45url-lib/url-lib.sh                   |  2 +-
+ modules.d/50plymouth/plymouth-populate-initrd.sh |  4 ++--
+ modules.d/90crypt/crypt-lib.sh                   |  2 +-
+ modules.d/90crypt/parse-crypt.sh                 |  6 +++---
+ modules.d/90dm/dm-shutdown.sh                    |  4 ++--
+ modules.d/90dmraid/dmraid.sh                     |  2 +-
+ modules.d/90mdraid/md-shutdown.sh                |  2 +-
+ modules.d/95lunmask/parse-lunmask.sh             |  8 ++++----
+ modules.d/98dracut-systemd/rootfs-generator.sh   |  4 ++--
+ modules.d/98syslog/rsyslogd-start.sh             |  6 +++---
+ modules.d/98usrmount/mount-usr.sh                |  6 +++---
+ modules.d/99base/dracut-lib.sh                   | 16 +++++++++-------
+ modules.d/99squash/module-setup.sh               |  2 +-
+ test/TEST-20-NFS/server-init.sh                  |  2 +-
+ test/TEST-30-ISCSI/server-init.sh                |  2 +-
+ test/TEST-35-ISCSI-MULTI/server-init.sh          |  2 +-
+ test/TEST-40-NBD/server-init.sh                  |  2 +-
+ test/TEST-50-MULTINIC/server-init.sh             |  2 +-
+ test/TEST-60-BONDBRIDGEVLANIFCFG/client-init.sh  |  2 +-
+ test/TEST-60-BONDBRIDGEVLANIFCFG/server-init.sh  |  2 +-
+ 33 files changed, 68 insertions(+), 65 deletions(-)
+
+diff --git a/dracut-functions.sh b/dracut-functions.sh
+index 280e4e78..6e3807b2 100755
+--- a/dracut-functions.sh
++++ b/dracut-functions.sh
+@@ -712,7 +712,7 @@ fs_get_option() {
+     while [ $# -gt 0 ]; do
+         case $1 in
+             $_option=*)
+-                echo "${1#${_option}=}"
++                echo "${1#"${_option}"=}"
+                 break
+                 ;;
+         esac
+diff --git a/dracut-init.sh b/dracut-init.sh
+index 40b66f54..9c9340cf 100755
+--- a/dracut-init.sh
++++ b/dracut-init.sh
+@@ -573,7 +573,7 @@ inst_rules_wildcard() {
+ # make sure that library links are correct and up to date
+ build_ld_cache() {
+     for f in "$dracutsysrootdir"/etc/ld.so.conf "$dracutsysrootdir"/etc/ld.so.conf.d/*; do
+-        [[ -f $f ]] && inst_simple "${f#$dracutsysrootdir}"
++        [[ -f $f ]] && inst_simple "${f#"$dracutsysrootdir"}"
+     done
+     if ! $DRACUT_LDCONFIG -r "$initdir" -f /etc/ld.so.conf; then
+         if [[ $EUID == 0 ]]; then
+@@ -696,8 +696,8 @@ inst_libdir_file() {
+         for _dir in $libdirs; do
+             for _i in "$@"; do
+                 for _f in "$dracutsysrootdir$_dir"/$_i; do
+-                    [[ ${_f#$dracutsysrootdir} =~ $_pattern ]] || continue
+-                    [[ -e $_f ]] && _files+=("${_f#$dracutsysrootdir}")
++                    [[ ${_f#"$dracutsysrootdir"} =~ $_pattern ]] || continue
++                    [[ -e $_f ]] && _files+=("${_f#"$dracutsysrootdir"}")
+                 done
+             done
+         done
+@@ -705,7 +705,7 @@ inst_libdir_file() {
+         for _dir in $libdirs; do
+             for _i in "$@"; do
+                 for _f in "$dracutsysrootdir$_dir"/$_i; do
+-                    [[ -e $_f ]] && _files+=("${_f#$dracutsysrootdir}")
++                    [[ -e $_f ]] && _files+=("${_f#"$dracutsysrootdir"}")
+                 done
+             done
+         done
+diff --git a/dracut.sh b/dracut.sh
+index bbb34697..901ed09e 100755
+--- a/dracut.sh
++++ b/dracut.sh
+@@ -958,6 +958,7 @@ if [[ $regenerate_all == "yes" ]]; then
+     for ((i = 0; i < len; i++)); do
+         case ${dracut_args[$i]} in
+             --regenerate-all | --parallel)
++                # shellcheck disable=SC2184
+                 unset dracut_args["$i"]
+                 ;;
+         esac
+@@ -999,7 +1000,7 @@ for i in $DRACUT_PATH; do
+     if [ -L "$dracutsysrootdir$i" ]; then
+         rl=$(readlink -f "$dracutsysrootdir$i")
+     fi
+-    rl="${rl#$dracutsysrootdir}"
++    rl="${rl#"$dracutsysrootdir"}"
+     if [[ $NPATH != *:$rl* ]]; then
+         NPATH+=":$rl"
+     fi
+@@ -2212,7 +2213,7 @@ for ((i = 0; i < ${#include_src[@]}; i++)); do
+                 [[ -e $objectname || -L $objectname ]] || continue
+                 if [[ -d $objectname ]] && [[ ! -L $objectname ]]; then
+                     # objectname is a directory, let's compute the final directory name
+-                    object_destdir=${destdir}/${objectname#$src/}
++                    object_destdir=${destdir}/${objectname#"$src"/}
+                     if ! [[ -e $object_destdir ]]; then
+                         # shellcheck disable=SC2174
+                         mkdir -m 0755 -p "$object_destdir"
+diff --git a/modules.d/03modsign/module-setup.sh b/modules.d/03modsign/module-setup.sh
+index 08fd3418..56e2bdb8 100755
+--- a/modules.d/03modsign/module-setup.sh
++++ b/modules.d/03modsign/module-setup.sh
+@@ -33,6 +33,6 @@ install() {
+ 
+     for x in "$dracutsysrootdir"/lib/modules/keys/*; do
+         [[ ${x} == "$dracutsysrootdir/lib/modules/keys/*" ]] && break
+-        inst_simple "${x#$dracutsysrootdir}"
++        inst_simple "${x#"$dracutsysrootdir"}"
+     done
+ }
+diff --git a/modules.d/10i18n/console_init.sh b/modules.d/10i18n/console_init.sh
+index 3fe3b673..3ca0ac1d 100755
+--- a/modules.d/10i18n/console_init.sh
++++ b/modules.d/10i18n/console_init.sh
+@@ -19,7 +19,7 @@ set_keyboard() {
+ }
+ 
+ set_terminal() {
+-    local dev=$1
++    local dev="$1"
+ 
+     if [ "${UNICODE}" = 1 ]; then
+         printf '\033%%G' >&7
+@@ -58,7 +58,7 @@ dev_close() {
+ }
+ 
+ dev_open() {
+-    local dev=$1
++    local dev="$1"
+ 
+     exec 6< "${dev}" \
+         && exec 7>> "${dev}"
+diff --git a/modules.d/35network-legacy/dhclient-script.sh b/modules.d/35network-legacy/dhclient-script.sh
+index 82fc7e2c..240c0fad 100755
+--- a/modules.d/35network-legacy/dhclient-script.sh
++++ b/modules.d/35network-legacy/dhclient-script.sh
+@@ -72,7 +72,7 @@ setup_interface() {
+     fi
+     # Note: hostname can be fqdn OR short hostname, so chop off any
+     # trailing domain name and explicity add any domain if set.
+-    [ -n "$hostname" ] && echo "echo ${hostname%.$domain}${domain:+.$domain} > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
++    [ -n "$hostname" ] && echo "echo ${hostname%."$domain"}${domain:+.$domain} > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
+ }
+ 
+ setup_interface6() {
+@@ -105,7 +105,7 @@ setup_interface6() {
+ 
+     # Note: hostname can be fqdn OR short hostname, so chop off any
+     # trailing domain name and explicity add any domain if set.
+-    [ -n "$hostname" ] && echo "echo ${hostname%.$domain}${domain:+.$domain} > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
++    [ -n "$hostname" ] && echo "echo ${hostname%."$domain"}${domain:+.$domain} > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
+ }
+ 
+ parse_option_121() {
+diff --git a/modules.d/35network-legacy/parse-bond.sh b/modules.d/35network-legacy/parse-bond.sh
+index 86cd89ce..ba30a3bc 100755
+--- a/modules.d/35network-legacy/parse-bond.sh
++++ b/modules.d/35network-legacy/parse-bond.sh
+@@ -15,7 +15,7 @@
+ # We translate list of slaves to space-separated here to make it easier to loop over them in ifup
+ # Ditto for bonding options
+ parsebond() {
+-    local v=${1}:
++    local v="${1}":
+     set --
+     while [ -n "$v" ]; do
+         set -- "$@" "${v%%:*}"
+diff --git a/modules.d/35network-legacy/parse-bridge.sh b/modules.d/35network-legacy/parse-bridge.sh
+index f15ce470..caea1dad 100755
+--- a/modules.d/35network-legacy/parse-bridge.sh
++++ b/modules.d/35network-legacy/parse-bridge.sh
+@@ -8,7 +8,7 @@
+ #
+ 
+ parsebridge() {
+-    local v=${1}:
++    local v="${1}":
+     set --
+     while [ -n "$v" ]; do
+         set -- "$@" "${v%%:*}"
+diff --git a/modules.d/35network-legacy/parse-ip-opts.sh b/modules.d/35network-legacy/parse-ip-opts.sh
+index 19af8789..6a90f2a1 100755
+--- a/modules.d/35network-legacy/parse-ip-opts.sh
++++ b/modules.d/35network-legacy/parse-ip-opts.sh
+@@ -139,7 +139,7 @@ fi
+ 
+ # This ensures that BOOTDEV is always first in IFACES
+ if [ -n "$BOOTDEV" ] && [ -n "$IFACES" ]; then
+-    IFACES="${IFACES%$BOOTDEV*} ${IFACES#*$BOOTDEV}"
++    IFACES="${IFACES%"$BOOTDEV"*} ${IFACES#*"$BOOTDEV"}"
+     IFACES="$BOOTDEV $IFACES"
+ fi
+ 
+diff --git a/modules.d/35network-legacy/parse-team.sh b/modules.d/35network-legacy/parse-team.sh
+index 7b1801ba..83badc99 100755
+--- a/modules.d/35network-legacy/parse-team.sh
++++ b/modules.d/35network-legacy/parse-team.sh
+@@ -10,7 +10,7 @@
+ #
+ 
+ parseteam() {
+-    local v=${1}:
++    local v="${1}":
+     set --
+     while [ -n "$v" ]; do
+         set -- "$@" "${v%%:*}"
+diff --git a/modules.d/35network-legacy/parse-vlan.sh b/modules.d/35network-legacy/parse-vlan.sh
+index 1570cd81..c23f8331 100755
+--- a/modules.d/35network-legacy/parse-vlan.sh
++++ b/modules.d/35network-legacy/parse-vlan.sh
+@@ -5,7 +5,7 @@
+ #
+ 
+ parsevlan() {
+-    local v=${1}:
++    local v="${1}":
+     set --
+     while [ -n "$v" ]; do
+         set -- "$@" "${v%%:*}"
+diff --git a/modules.d/40network/net-lib.sh b/modules.d/40network/net-lib.sh
+index bc1ffcde..43467e46 100755
+--- a/modules.d/40network/net-lib.sh
++++ b/modules.d/40network/net-lib.sh
+@@ -243,7 +243,7 @@ set_ifname() {
+ 
+ # pxelinux provides macaddr '-' separated, but we need ':'
+ fix_bootif() {
+-    local macaddr=${1}
++    local macaddr="${1}"
+     local IFS='-'
+     # shellcheck disable=SC2086
+     macaddr=$(printf '%s:' ${macaddr})
+@@ -395,11 +395,11 @@ parse_iscsi_root() {
+             iscsi_target_ip=${v#[[]}
+             iscsi_target_ip=${iscsi_target_ip%%[]]*}
+             # shellcheck disable=SC1087
+-            v=${v#[[]$iscsi_target_ip[]]:}
++            v=${v#[[]"$iscsi_target_ip"[]]:}
+             ;;
+         *)
+             iscsi_target_ip=${v%%[:]*}
+-            v=${v#$iscsi_target_ip:}
++            v=${v#"$iscsi_target_ip":}
+             ;;
+     esac
+ 
+@@ -467,7 +467,7 @@ parse_iscsi_root() {
+ }
+ 
+ ip_to_var() {
+-    local v=${1}:
++    local v="${1}":
+     local i
+     set --
+     while [ -n "$v" ]; do
+@@ -476,7 +476,7 @@ ip_to_var() {
+             i="${v%%\]:*}"
+             i="${i##\[}"
+             set -- "$@" "$i"
+-            v=${v#\[$i\]:}
++            v=${v#\["$i"\]:}
+         else
+             set -- "$@" "${v%%:*}"
+             v=${v#*:}
+@@ -565,7 +565,7 @@ ip_to_var() {
+ }
+ 
+ route_to_var() {
+-    local v=${1}:
++    local v="${1}":
+     local i
+     set --
+     while [ -n "$v" ]; do
+@@ -574,7 +574,7 @@ route_to_var() {
+             i="${v%%\]:*}"
+             i="${i##\[}"
+             set -- "$@" "$i"
+-            v=${v#\[$i\]:}
++            v=${v#\["$i"\]:}
+         else
+             set -- "$@" "${v%%:*}"
+             v=${v#*:}
+@@ -691,7 +691,7 @@ wait_for_route_ok() {
+ 
+     while [ $cnt -lt $timeout ]; do
+         li=$(ip route show)
+-        [ -n "$li" ] && [ -z "${li##*$1*}" ] && return 0
++        [ -n "$li" ] && [ -z "${li##*"$1"*}" ] && return 0
+         sleep 0.1
+         cnt=$((cnt + 1))
+     done
+diff --git a/modules.d/45url-lib/module-setup.sh b/modules.d/45url-lib/module-setup.sh
+index afbedb34..65da87ee 100755
+--- a/modules.d/45url-lib/module-setup.sh
++++ b/modules.d/45url-lib/module-setup.sh
+@@ -45,7 +45,7 @@ install() {
+     done
+     if [[ $_found ]] && [[ -n $_crts ]]; then
+         for _crt in $_crts; do
+-            if ! inst "${_crt#$dracutsysrootdir}"; then
++            if ! inst "${_crt#"$dracutsysrootdir"}"; then
+                 dwarn "Couldn't install '$_crt' SSL CA cert bundle; HTTPS might not work."
+                 continue
+             fi
+@@ -78,7 +78,7 @@ install() {
+                         # install everything in it
+                         mkdir -p -- "${initdir}/${_p11root}"
+                         if ! $DRACUT_CP -L -t "${initdir}/${_p11root}" "${dracutsysrootdir}${_p11root}"/*; then
+-                            dwarn "Couldn't install from p11-kit trust dir '${_p11root#$dracutsysrootdir}'; HTTPS might not work."
++                            dwarn "Couldn't install from p11-kit trust dir '${_p11root#"$dracutsysrootdir"}'; HTTPS might not work."
+                         fi
+                     done
+                 done
+diff --git a/modules.d/45url-lib/url-lib.sh b/modules.d/45url-lib/url-lib.sh
+index b009fd09..2fd69519 100755
+--- a/modules.d/45url-lib/url-lib.sh
++++ b/modules.d/45url-lib/url-lib.sh
+@@ -141,7 +141,7 @@ nfs_already_mounted() {
+             if [ "$path" = "$p" ]; then
+                 echo "$mnt"
+             elif str_starts "$path" "$p"; then
+-                echo "$mnt"/"${path#$p/}"
++                echo "$mnt"/"${path#"$p"/}"
+             fi
+         fi
+     done < /proc/mounts
+diff --git a/modules.d/50plymouth/plymouth-populate-initrd.sh b/modules.d/50plymouth/plymouth-populate-initrd.sh
+index 52baa210..e36ed521 100755
+--- a/modules.d/50plymouth/plymouth-populate-initrd.sh
++++ b/modules.d/50plymouth/plymouth-populate-initrd.sh
+@@ -34,10 +34,10 @@ if [[ $hostonly ]]; then
+ else
+     for x in "$dracutsysrootdir"/usr/share/plymouth/themes/{text,details}/*; do
+         [[ -f $x ]] || continue
+-        THEME_DIR=$(dirname "${x#$dracutsysrootdir}")
++        THEME_DIR=$(dirname "${x#"$dracutsysrootdir"}")
+         # shellcheck disable=SC2174
+         mkdir -m 0755 -p "${initdir}/$THEME_DIR"
+-        inst_multiple "${x#$dracutsysrootdir}"
++        inst_multiple "${x#"$dracutsysrootdir"}"
+     done
+     (
+         cd "${initdir}"/usr/share/plymouth/themes || exit
+diff --git a/modules.d/90crypt/crypt-lib.sh b/modules.d/90crypt/crypt-lib.sh
+index 7a88643c..f3ba20dc 100755
+--- a/modules.d/90crypt/crypt-lib.sh
++++ b/modules.d/90crypt/crypt-lib.sh
+@@ -141,7 +141,7 @@ ask_for_password() {
+ # example:
+ # test_dev -f LABEL="nice label" /some/file1
+ test_dev() {
+-    local test_op=$1
++    local test_op="$1"
+     local dev="$2"
+     local f="$3"
+     local ret=1
+diff --git a/modules.d/90crypt/parse-crypt.sh b/modules.d/90crypt/parse-crypt.sh
+index 70e96444..e46e347a 100755
+--- a/modules.d/90crypt/parse-crypt.sh
++++ b/modules.d/90crypt/parse-crypt.sh
+@@ -53,7 +53,7 @@ else
+ 
+             uuid=${uuid##luks-}
+             if luksname=$(_cryptgetargsname "$uuid="); then
+-                luksname="${luksname#$uuid=}"
++                luksname="${luksname#"$uuid"=}"
+             else
+                 luksname="luks-$uuid"
+             fi
+@@ -93,7 +93,7 @@ else
+ 
+             serialid=${serialid##luks-}
+             if luksname=$(_cryptgetargsname "$serialid="); then
+-                luksname="${luksname#$serialid=}"
++                luksname="${luksname#"$serialid"=}"
+             else
+                 luksname="luks-$serialid"
+             fi
+@@ -133,7 +133,7 @@ else
+ 
+             luksid=${luksid##luks-}
+             if luksname=$(_cryptgetargsname "$luksid="); then
+-                luksname="${luksname#$luksid=}"
++                luksname="${luksname#"$luksid"=}"
+             else
+                 luksname="luks-$luksid"
+             fi
+diff --git a/modules.d/90dm/dm-shutdown.sh b/modules.d/90dm/dm-shutdown.sh
+index 6dbd6175..bd7134a9 100755
+--- a/modules.d/90dm/dm-shutdown.sh
++++ b/modules.d/90dm/dm-shutdown.sh
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+ 
+ _remove_dm() {
+-    local dev=$1
++    local dev="$1"
+     local s
+     local devname
+ 
+@@ -26,7 +26,7 @@ _remove_dm() {
+ 
+ _do_dm_shutdown() {
+     local ret=0
+-    local final=$1
++    local final="$1"
+     local dev
+ 
+     info "Disassembling device-mapper devices"
+diff --git a/modules.d/90dmraid/dmraid.sh b/modules.d/90dmraid/dmraid.sh
+index d10f42aa..b517320a 100755
+--- a/modules.d/90dmraid/dmraid.sh
++++ b/modules.d/90dmraid/dmraid.sh
+@@ -26,7 +26,7 @@ if [ -n "$DM_RAIDS" ] || getargbool 0 rd.auto; then
+         # only activate specified DM RAIDS
+         for r in $DM_RAIDS; do
+             for s in $SETS; do
+-                if [ "${s##$r}" != "$s" ]; then
++                if [ "${s##"$r"}" != "$s" ]; then
+                     info "Activating $s"
+                     dmraid -ay -i -p --rm_partitions "$s" 2>&1 | vinfo
+                 fi
+diff --git a/modules.d/90mdraid/md-shutdown.sh b/modules.d/90mdraid/md-shutdown.sh
+index 5562ddb4..ca768a9c 100755
+--- a/modules.d/90mdraid/md-shutdown.sh
++++ b/modules.d/90mdraid/md-shutdown.sh
+@@ -2,7 +2,7 @@
+ 
+ _do_md_shutdown() {
+     local ret
+-    local final=$1
++    local final="$1"
+     info "Waiting for mdraid devices to be clean."
+     mdadm -vv --wait-clean --scan | vinfo
+     ret=$?
+diff --git a/modules.d/95lunmask/parse-lunmask.sh b/modules.d/95lunmask/parse-lunmask.sh
+index 504c76d8..5e05e5bc 100755
+--- a/modules.d/95lunmask/parse-lunmask.sh
++++ b/modules.d/95lunmask/parse-lunmask.sh
+@@ -3,10 +3,10 @@
+ # ex: ts=8 sw=4 sts=4 et filetype=sh
+ 
+ create_udev_rule() {
+-    local transport=$1
+-    local tgtid=$2
+-    local lun=$3
+-    local _rule=/etc/udev/rules.d/51-${transport}-lunmask-${tgtid}.rules
++    local transport="$1"
++    local tgtid="$2"
++    local lun="$3"
++    local _rule=/etc/udev/rules.d/51-"${transport}"-lunmask-"${tgtid}".rules
+ 
+     [ -e "${_rule}" ] && return 0
+ 
+diff --git a/modules.d/98dracut-systemd/rootfs-generator.sh b/modules.d/98dracut-systemd/rootfs-generator.sh
+index e1d365df..148c1cce 100755
+--- a/modules.d/98dracut-systemd/rootfs-generator.sh
++++ b/modules.d/98dracut-systemd/rootfs-generator.sh
+@@ -44,8 +44,8 @@ EOF
+ }
+ 
+ generator_mount_rootfs() {
+-    local _type=$2
+-    local _flags=$3
++    local _type="$2"
++    local _flags="$3"
+     local _name
+ 
+     [ -z "$1" ] && return 0
+diff --git a/modules.d/98syslog/rsyslogd-start.sh b/modules.d/98syslog/rsyslogd-start.sh
+index 1066893e..d404e51b 100755
+--- a/modules.d/98syslog/rsyslogd-start.sh
++++ b/modules.d/98syslog/rsyslogd-start.sh
+@@ -11,11 +11,11 @@ if [ -f /var/run/syslogd.pid ]; then
+ fi
+ 
+ rsyslog_config() {
+-    local server=$1
++    local server="$1"
+     shift
+-    local syslog_template=$1
++    local syslog_template="$1"
+     shift
+-    local filters=$*
++    local filters="$*"
+     local filter=
+ 
+     cat "$syslog_template"
+diff --git a/modules.d/98usrmount/mount-usr.sh b/modules.d/98usrmount/mount-usr.sh
+index 43ea0205..0a3eb324 100755
+--- a/modules.d/98usrmount/mount-usr.sh
++++ b/modules.d/98usrmount/mount-usr.sh
+@@ -20,9 +20,9 @@ filtersubvol() {
+ }
+ 
+ fsck_usr() {
+-    local _dev=$1
+-    local _fs=$2
+-    local _fsopts=$3
++    local _dev="$1"
++    local _fs="$2"
++    local _fsopts="$3"
+     local _fsckoptions
+ 
+     if [ -f "$NEWROOT"/fsckoptions ]; then
+diff --git a/modules.d/99base/dracut-lib.sh b/modules.d/99base/dracut-lib.sh
+index 6963a19b..218cb13b 100755
+--- a/modules.d/99base/dracut-lib.sh
++++ b/modules.d/99base/dracut-lib.sh
+@@ -36,6 +36,7 @@ strstr() {
+ # An empty $1 will not be considered matched, even if $2 is * which technically
+ # matches; as it would match anything, it's not an interesting case.
+ strglob() {
++    # shellcheck disable=SC2295
+     [ -n "$1" -a -z "${1##$2}" ]
+ }
+ 
+@@ -43,6 +44,7 @@ strglob() {
+ # An empty $1 will not be considered matched, even if $2 is * which technically
+ # matches; as it would match anything, it's not an interesting case.
+ strglobin() {
++    # shellcheck disable=SC2295
+     [ -n "$1" -a -z "${1##*$2*}" ]
+ }
+ 
+@@ -323,7 +325,7 @@ getoptcomma() {
+ 
+     case "${line}" in
+         *,${opt}=*,*)
+-            tmp="${line#*,${opt}=}"
++            tmp="${line#*,"${opt}"=}"
+             echo "${tmp%%,*}"
+             return 0
+             ;;
+@@ -353,10 +355,10 @@ splitsep() {
+     local tmp
+ 
+     while [ -n "$str" -a "$#" -gt 1 ]; do
+-        tmp="${str%%$sep*}"
++        tmp="${str%%"$sep"*}"
+         eval "$1='${tmp}'"
+         str="${str#"$tmp"}"
+-        str="${str#$sep}"
++        str="${str#"$sep"}"
+         shift
+     done
+     [ -n "$str" -a -n "$1" ] && eval "$1='$str'"
+@@ -471,8 +473,8 @@ check_occurances() {
+     local expected="$3"
+     local count=0
+ 
+-    while [ "${str#*$ch}" != "${str}" ]; do
+-        str="${str#*$ch}"
++    while [ "${str#*"$ch"}" != "${str}" ]; do
++        str="${str#*"$ch"}"
+         count=$((count + 1))
+     done
+ 
+@@ -827,7 +829,7 @@ killproc() {
+     debug_off
+     local _exe
+     _exe="$(command -v "$1")"
+-    local _sig=$2
++    local _sig="$2"
+     local _i
+     [ -x "$_exe" ] || return 1
+     for _i in /proc/[0-9]*; do
+@@ -891,7 +893,7 @@ if ! command -v pidof > /dev/null 2> /dev/null; then
+                 [ "$i" -ef "$_exe" ] || continue
+             else
+                 _rl=$(readlink -f "$i")
+-                [ "${_rl%/$_cmd}" != "$_rl" ] || continue
++                [ "${_rl%/"$_cmd"}" != "$_rl" ] || continue
+             fi
+             i=${i%/exe}
+             echo "${i##/proc/}"
+diff --git a/modules.d/99squash/module-setup.sh b/modules.d/99squash/module-setup.sh
+index 81311d3a..dc2e0a20 100755
+--- a/modules.d/99squash/module-setup.sh
++++ b/modules.d/99squash/module-setup.sh
+@@ -30,7 +30,7 @@ installpost() {
+     # so dracut rebuild and lsinitrd can work
+     for file in "$squash_dir"/usr/lib/dracut/*; do
+         [[ -f $file ]] || continue
+-        DRACUT_RESOLVE_DEPS=1 dracutsysrootdir="$squash_dir" inst "${file#$squash_dir}"
++        DRACUT_RESOLVE_DEPS=1 dracutsysrootdir="$squash_dir" inst "${file#"$squash_dir"}"
+     done
+ 
+     # Install required modules and binaries for the squash image init script.
+diff --git a/test/TEST-20-NFS/server-init.sh b/test/TEST-20-NFS/server-init.sh
+index 743f1d3e..6abe8266 100755
+--- a/test/TEST-20-NFS/server-init.sh
++++ b/test/TEST-20-NFS/server-init.sh
+@@ -37,7 +37,7 @@ wait_for_route_ok() {
+     local cnt=0
+     while [ $cnt -lt 200 ]; do
+         li=$(ip route show)
+-        [ -n "$li" ] && [ -z "${li##*$1*}" ] && return 0
++        [ -n "$li" ] && [ -z "${li##*"$1"*}" ] && return 0
+         sleep 0.1
+         cnt=$((cnt + 1))
+     done
+diff --git a/test/TEST-30-ISCSI/server-init.sh b/test/TEST-30-ISCSI/server-init.sh
+index fd5538d8..a1c3b7ee 100755
+--- a/test/TEST-30-ISCSI/server-init.sh
++++ b/test/TEST-30-ISCSI/server-init.sh
+@@ -36,7 +36,7 @@ wait_for_route_ok() {
+     local cnt=0
+     while [ $cnt -lt 200 ]; do
+         li=$(ip route show)
+-        [ -n "$li" ] && [ -z "${li##*$1*}" ] && return 0
++        [ -n "$li" ] && [ -z "${li##*"$1"*}" ] && return 0
+         sleep 0.1
+         cnt=$((cnt + 1))
+     done
+diff --git a/test/TEST-35-ISCSI-MULTI/server-init.sh b/test/TEST-35-ISCSI-MULTI/server-init.sh
+index fd5538d8..a1c3b7ee 100755
+--- a/test/TEST-35-ISCSI-MULTI/server-init.sh
++++ b/test/TEST-35-ISCSI-MULTI/server-init.sh
+@@ -36,7 +36,7 @@ wait_for_route_ok() {
+     local cnt=0
+     while [ $cnt -lt 200 ]; do
+         li=$(ip route show)
+-        [ -n "$li" ] && [ -z "${li##*$1*}" ] && return 0
++        [ -n "$li" ] && [ -z "${li##*"$1"*}" ] && return 0
+         sleep 0.1
+         cnt=$((cnt + 1))
+     done
+diff --git a/test/TEST-40-NBD/server-init.sh b/test/TEST-40-NBD/server-init.sh
+index 729d6a80..bc52b2e6 100755
+--- a/test/TEST-40-NBD/server-init.sh
++++ b/test/TEST-40-NBD/server-init.sh
+@@ -36,7 +36,7 @@ wait_for_route_ok() {
+     local cnt=0
+     while [ $cnt -lt 200 ]; do
+         li=$(ip route show)
+-        [ -n "$li" ] && [ -z "${li##*$1*}" ] && return 0
++        [ -n "$li" ] && [ -z "${li##*"$1"*}" ] && return 0
+         sleep 0.1
+         cnt=$((cnt + 1))
+     done
+diff --git a/test/TEST-50-MULTINIC/server-init.sh b/test/TEST-50-MULTINIC/server-init.sh
+index 7dcb2566..91db7ae7 100755
+--- a/test/TEST-50-MULTINIC/server-init.sh
++++ b/test/TEST-50-MULTINIC/server-init.sh
+@@ -37,7 +37,7 @@ wait_for_route_ok() {
+     local cnt=0
+     while [ $cnt -lt 200 ]; do
+         li=$(ip route show)
+-        [ -n "$li" ] && [ -z "${li##*$1*}" ] && return 0
++        [ -n "$li" ] && [ -z "${li##*"$1"*}" ] && return 0
+         sleep 0.1
+         cnt=$((cnt + 1))
+     done
+diff --git a/test/TEST-60-BONDBRIDGEVLANIFCFG/client-init.sh b/test/TEST-60-BONDBRIDGEVLANIFCFG/client-init.sh
+index 644308d1..b0851116 100755
+--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/client-init.sh
++++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/client-init.sh
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+ exec > /dev/console 2>&1
+ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+-strstr() { [ "${1#*$2*}" != "$1" ]; }
++strstr() { [ "${1#*"$2"*}" != "$1" ]; }
+ CMDLINE=$(while read -r line; do echo "$line"; done < /proc/cmdline)
+ export TERM=linux
+ export PS1='initramfs-test:\w\$ '
+diff --git a/test/TEST-60-BONDBRIDGEVLANIFCFG/server-init.sh b/test/TEST-60-BONDBRIDGEVLANIFCFG/server-init.sh
+index ea06b787..c125d0f4 100755
+--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/server-init.sh
++++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/server-init.sh
+@@ -39,7 +39,7 @@ wait_for_route_ok() {
+     local cnt=0
+     while [ $cnt -lt 200 ]; do
+         li=$(ip route show)
+-        [ -n "$li" ] && [ -z "${li##*$1*}" ] && return 0
++        [ -n "$li" ] && [ -z "${li##*"$1"*}" ] && return 0
+         sleep 0.1
+         cnt=$((cnt + 1))
+     done
+-- 
+2.39.1
+

--- a/app-admin/dracut/autobuild/patches/0003-fix-dracut-systemd-remove-unused-argument.patch
+++ b/app-admin/dracut/autobuild/patches/0003-fix-dracut-systemd-remove-unused-argument.patch
@@ -1,0 +1,27 @@
+From eb75861c2a1c05eb142616da1891a7fa5a2a34e1 Mon Sep 17 00:00:00 2001
+From: Antonio Alvarez Feijoo <antonio.feijoo@suse.com>
+Date: Mon, 9 Jan 2023 11:47:06 +0100
+Subject: [PATCH] fix(dracut-systemd): remove unused argument
+
+The `generator_wait_for_dev` function of the dracut rootfs systemd generator
+only uses the first argument. Moreover, RDRETRY is unset at this point.
+---
+ modules.d/98dracut-systemd/rootfs-generator.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules.d/98dracut-systemd/rootfs-generator.sh b/modules.d/98dracut-systemd/rootfs-generator.sh
+index 148c1cce..b98e4e57 100755
+--- a/modules.d/98dracut-systemd/rootfs-generator.sh
++++ b/modules.d/98dracut-systemd/rootfs-generator.sh
+@@ -104,7 +104,7 @@ esac
+ GENERATOR_DIR="$1"
+ 
+ if [ "$rootok" = "1" ]; then
+-    generator_wait_for_dev "${root#block:}" "$RDRETRY"
++    generator_wait_for_dev "${root#block:}"
+     generator_fsck_after_pre_mount "${root#block:}"
+     strstr "$(cat /proc/cmdline)" 'root=' || generator_mount_rootfs "${root#block:}" "$(getarg rootfstype=)" "$(getarg rootflags=)"
+ fi
+-- 
+2.39.1
+

--- a/app-admin/dracut/autobuild/patches/0004-fix-dracut-systemd-do-not-hardcode-the-systemd-gener.patch
+++ b/app-admin/dracut/autobuild/patches/0004-fix-dracut-systemd-do-not-hardcode-the-systemd-gener.patch
@@ -1,0 +1,44 @@
+From a7c04716a5e528d86135bf87745054f7cbd54469 Mon Sep 17 00:00:00 2001
+From: Antonio Alvarez Feijoo <antonio.feijoo@suse.com>
+Date: Wed, 1 Mar 2023 11:21:16 +0100
+Subject: [PATCH] fix(dracut-systemd): do not hardcode the systemd generator
+ directory
+
+The normal directory is the first argument passed to the systemd generator,
+so use it instead of hardcoding /run/systemd/generator.
+---
+ modules.d/98dracut-systemd/rootfs-generator.sh | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/modules.d/98dracut-systemd/rootfs-generator.sh b/modules.d/98dracut-systemd/rootfs-generator.sh
+index b98e4e57..32179fb4 100755
+--- a/modules.d/98dracut-systemd/rootfs-generator.sh
++++ b/modules.d/98dracut-systemd/rootfs-generator.sh
+@@ -17,7 +17,7 @@ generator_wait_for_dev() {
+         # after remote-fs-pre.target since the initqueue is ordered before it so
+         # it will never actually show up (think Tang-pinned rootfs).
+         cat > "$hookdir/initqueue/finished/devexists-${_name}.sh" << EOF
+-if ! grep -q After=remote-fs-pre.target /run/systemd/generator/systemd-cryptsetup@*.service 2>/dev/null; then
++if ! grep -q After=remote-fs-pre.target "$GENERATOR_DIR"/systemd-cryptsetup@*.service 2>/dev/null; then
+     [ -e "$1" ]
+ fi
+ EOF
+@@ -77,12 +77,12 @@ generator_fsck_after_pre_mount() {
+     [ -z "$1" ] && return 0
+ 
+     _name=$(dev_unit_name "$1")
+-    [ -d /run/systemd/generator/systemd-fsck@"${_name}".service.d ] || mkdir -p /run/systemd/generator/systemd-fsck@"${_name}".service.d
+-    if ! [ -f /run/systemd/generator/systemd-fsck@"${_name}".service.d/after-pre-mount.conf ]; then
++    [ -d "$GENERATOR_DIR"/systemd-fsck@"${_name}".service.d ] || mkdir -p "$GENERATOR_DIR"/systemd-fsck@"${_name}".service.d
++    if ! [ -f "$GENERATOR_DIR"/systemd-fsck@"${_name}".service.d/after-pre-mount.conf ]; then
+         {
+             echo "[Unit]"
+             echo "After=dracut-pre-mount.service"
+-        } > /run/systemd/generator/systemd-fsck@"${_name}".service.d/after-pre-mount.conf
++        } > "$GENERATOR_DIR"/systemd-fsck@"${_name}".service.d/after-pre-mount.conf
+     fi
+ 
+ }
+-- 
+2.39.1
+

--- a/app-admin/dracut/autobuild/patches/0005-fix-dracut-systemd-check-and-create-generator-dir-ou.patch
+++ b/app-admin/dracut/autobuild/patches/0005-fix-dracut-systemd-check-and-create-generator-dir-ou.patch
@@ -1,0 +1,39 @@
+From acfa793b5cc035ebd36b0c5ce97ba2fd89e5745c Mon Sep 17 00:00:00 2001
+From: Antonio Alvarez Feijoo <antonio.feijoo@suse.com>
+Date: Wed, 1 Mar 2023 12:07:29 +0100
+Subject: [PATCH] fix(dracut-systemd): check and create generator dir outside
+ of inner function
+
+---
+ modules.d/98dracut-systemd/rootfs-generator.sh | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/modules.d/98dracut-systemd/rootfs-generator.sh b/modules.d/98dracut-systemd/rootfs-generator.sh
+index 32179fb4..0ba1709b 100755
+--- a/modules.d/98dracut-systemd/rootfs-generator.sh
++++ b/modules.d/98dracut-systemd/rootfs-generator.sh
+@@ -51,7 +51,6 @@ generator_mount_rootfs() {
+     [ -z "$1" ] && return 0
+ 
+     _name=$(dev_unit_name "$1")
+-    [ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
+     if ! [ -f "$GENERATOR_DIR"/sysroot.mount ]; then
+         {
+             echo "[Unit]"
+@@ -101,9 +100,11 @@ case "${root#block:}" in
+         ;;
+ esac
+ 
+-GENERATOR_DIR="$1"
+-
+ if [ "$rootok" = "1" ]; then
++    GENERATOR_DIR="$1"
++    [ -z "$GENERATOR_DIR" ] && exit 1
++    [ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
++
+     generator_wait_for_dev "${root#block:}"
+     generator_fsck_after_pre_mount "${root#block:}"
+     strstr "$(cat /proc/cmdline)" 'root=' || generator_mount_rootfs "${root#block:}" "$(getarg rootfstype=)" "$(getarg rootflags=)"
+-- 
+2.39.1
+

--- a/app-admin/dracut/autobuild/patches/0006-fix-dracut-systemd-rootfs-generator-cannot-write-out.patch
+++ b/app-admin/dracut/autobuild/patches/0006-fix-dracut-systemd-rootfs-generator-cannot-write-out.patch
@@ -1,0 +1,118 @@
+From 86c8a5a7c2573645e67537fb9975efab808d42c9 Mon Sep 17 00:00:00 2001
+From: Antonio Alvarez Feijoo <antonio.feijoo@suse.com>
+Date: Wed, 8 Mar 2023 08:25:38 +0100
+Subject: [PATCH] fix(dracut-systemd): rootfs-generator cannot write outside of
+ generator dir
+
+Although it was already documented in systemd.generator(7) that generators must
+not write to locations other than those passed as arguments, since
+https://github.com/systemd/systemd/commit/ca6ce62d systemd executes generators
+in a mount namespace "sandbox", so now the hooks created by the rootfs-generator
+are lost.
+
+These hooks are created using the root= cmdline argument, so this patch moves
+the creation of these hooks to a cmdline hook.
+
+Fixes issue #2211
+Fixes issue #2225
+---
+ modules.d/98dracut-systemd/module-setup.sh    |  2 +
+ modules.d/98dracut-systemd/parse-root.sh      | 38 +++++++++++++++++++
+ .../98dracut-systemd/rootfs-generator.sh      | 20 +---------
+ 3 files changed, 41 insertions(+), 19 deletions(-)
+ create mode 100755 modules.d/98dracut-systemd/parse-root.sh
+
+diff --git a/modules.d/98dracut-systemd/module-setup.sh b/modules.d/98dracut-systemd/module-setup.sh
+index b7da86db..31953773 100755
+--- a/modules.d/98dracut-systemd/module-setup.sh
++++ b/modules.d/98dracut-systemd/module-setup.sh
+@@ -37,6 +37,8 @@ install() {
+ 
+     inst_script "$moddir/rootfs-generator.sh" "$systemdutildir"/system-generators/dracut-rootfs-generator
+ 
++    inst_hook cmdline 00 "$moddir/parse-root.sh"
++
+     for i in \
+         dracut-cmdline.service \
+         dracut-cmdline-ask.service \
+diff --git a/modules.d/98dracut-systemd/parse-root.sh b/modules.d/98dracut-systemd/parse-root.sh
+new file mode 100755
+index 00000000..90f145af
+--- /dev/null
++++ b/modules.d/98dracut-systemd/parse-root.sh
+@@ -0,0 +1,38 @@
++#!/bin/sh
++
++type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
++
++root=$(getarg root=)
++case "${root#block:}" in
++    LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
++        root="block:$(label_uuid_to_dev "$root")"
++        rootok=1
++        ;;
++    /dev/nfs | /dev/root) # ignore legacy
++        ;;
++    /dev/*)
++        root="block:${root}"
++        rootok=1
++        ;;
++esac
++
++if [ "$rootok" = "1" ]; then
++    root_dev="${root#block:}"
++    root_name="$(str_replace "$root_dev" '/' '\x2f')"
++    if ! [ -e "$hookdir/initqueue/finished/devexists-${root_name}.sh" ]; then
++
++        # If a LUKS device needs unlocking via systemd in the initrd, assume
++        # it's for the root device. In that case, don't block on it if it's
++        # after remote-fs-pre.target since the initqueue is ordered before it so
++        # it will never actually show up (think Tang-pinned rootfs).
++        cat > "$hookdir/initqueue/finished/devexists-${root_name}.sh" << EOF
++if ! grep -q After=remote-fs-pre.target /run/systemd/generator/systemd-cryptsetup@*.service 2>/dev/null; then
++    [ -e "$root_dev" ]
++fi
++EOF
++        {
++            printf '[ -e "%s" ] || ' "$root_dev"
++            printf 'warn "\"%s\" does not exist"\n' "$root_dev"
++        } >> "$hookdir/emergency/80-${root_name}.sh"
++    fi
++fi
+diff --git a/modules.d/98dracut-systemd/rootfs-generator.sh b/modules.d/98dracut-systemd/rootfs-generator.sh
+index 0ba1709b..cef3f490 100755
+--- a/modules.d/98dracut-systemd/rootfs-generator.sh
++++ b/modules.d/98dracut-systemd/rootfs-generator.sh
+@@ -6,28 +6,10 @@ generator_wait_for_dev() {
+     local _name
+     local _timeout
+ 
+-    _name="$(str_replace "$1" '/' '\x2f')"
++    _name=$(dev_unit_name "$1")
+     _timeout=$(getarg rd.timeout)
+     _timeout=${_timeout:-0}
+ 
+-    if ! [ -e "$hookdir/initqueue/finished/devexists-${_name}.sh" ]; then
+-
+-        # If a LUKS device needs unlocking via systemd in the initrd, assume
+-        # it's for the root device. In that case, don't block on it if it's
+-        # after remote-fs-pre.target since the initqueue is ordered before it so
+-        # it will never actually show up (think Tang-pinned rootfs).
+-        cat > "$hookdir/initqueue/finished/devexists-${_name}.sh" << EOF
+-if ! grep -q After=remote-fs-pre.target "$GENERATOR_DIR"/systemd-cryptsetup@*.service 2>/dev/null; then
+-    [ -e "$1" ]
+-fi
+-EOF
+-        {
+-            printf '[ -e "%s" ] || ' "$1"
+-            printf 'warn "\"%s\" does not exist"\n' "$1"
+-        } >> "$hookdir/emergency/80-${_name}.sh"
+-    fi
+-
+-    _name=$(dev_unit_name "$1")
+     if ! [ -L "$GENERATOR_DIR"/initrd.target.wants/"${_name}".device ]; then
+         [ -d "$GENERATOR_DIR"/initrd.target.wants ] || mkdir -p "$GENERATOR_DIR"/initrd.target.wants
+         ln -s ../"${_name}".device "$GENERATOR_DIR"/initrd.target.wants/"${_name}".device
+-- 
+2.39.1
+

--- a/app-admin/dracut/spec
+++ b/app-admin/dracut/spec
@@ -1,5 +1,5 @@
 VER=059
-REL=3
+REL=4
 SRCS="git::commit=tags/$VER::https://github.com/dracutdevs/dracut"
 CHKSUMS="sha256::eabf0bb685420c1e1d5475b6855ef787104508f0135ff570312845256e0fcecf"
 CHKUPDATE="anitya::id=10627"

--- a/app-admin/systemd/autobuild/alternatives
+++ b/app-admin/systemd/autobuild/alternatives
@@ -6,3 +6,4 @@ alternative /usr/bin/halt /usr/bin/systemctl 50
 alternative /usr/bin/telinit /usr/bin/systemctl 50
 alternative /usr/bin/service /usr/bin/systemctl 50
 alternative /usr/bin/init /usr/lib/systemd/systemd 50
+alternative /usr/lib/systemd/system/autovt@.service /usr/lib/systemd/system-alternatives/autovt-systemd.service 50

--- a/app-admin/systemd/autobuild/beyond
+++ b/app-admin/systemd/autobuild/beyond
@@ -16,6 +16,12 @@ abinfo "Creating default preset ..."
 echo 'disable *' \
     > "$PKGDIR"/usr/lib/systemd/system-preset/99-default.preset
 
+abinfo "Preparing autovt@.service for alternatives ..."
+mkdir -pv "$PKGDIR"/usr/lib/systemd/system-alternatives
+rm -v "$PKGDIR"/usr/lib/systemd/system/autovt@.service
+ln -sv ../system/getty@.service \
+    "$PKGDIR"/usr/lib/systemd/system-alternatives/autovt-systemd.service
+
 if ab_match_archgroup retro; then
     abinfo "Dropping unnecessary unit autostarts..."
     (

--- a/app-admin/systemd/autobuild/defines
+++ b/app-admin/systemd/autobuild/defines
@@ -14,9 +14,7 @@ PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
-BUILDDEP="gobject-introspection gperf gtk-doc intltool jinja2 llvm lxml"
-BUILDDEP__AMD64="${BUILDDEP} gnu-efi"
-BUILDDEP__ARM64="${BUILDDEP} gnu-efi"
+BUILDDEP="gobject-introspection gperf gtk-doc intltool jinja2 llvm lxml pyelftools"
 BUILDDEP__RETRO="docbook-xsl gperf intltool jinja2 libxslt"
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
@@ -62,13 +60,12 @@ MESON_AFTER="-Dmode=release \
              -Dmemory-accounting-default=true \
              -Dbump-proc-sys-fs-file-max=true \
              -Dbump-proc-sys-fs-nr-open=true \
-             -Dvalgrind=false \
              -Dlog-trace=false \
              -Dutmp=true \
              -Dhibernate=true \
              -Dldconfig=true \
              -Dresolve=true \
-             -Defi=false \
+             -Defi=true \
              -Dtpm=true \
              -Denvironment-d=true \
              -Dbinfmt=true \
@@ -174,9 +171,6 @@ MESON_AFTER="-Dmode=release \
              -Dpcre2=true \
              -Dglib=true \
              -Ddbus=true \
-             -Dgnu-efi=false \
-             -Defi-ld=bfd \
-             -Defi-tpm-pcr-compat=false \
              -Dsbat-distro=aosc \
              -Dsbat-distro-generation=1 \
              -Dsbat-distro-summary=AOSC \
@@ -198,14 +192,6 @@ MESON_AFTER="-Dmode=release \
              -Danalyze=true \
              -Dbpf-framework=false \
              -Dskip-deps=false"
-MESON_AFTER__AMD64=" \
-             ${MESON_AFTER} \
-             -Defi=true \
-             -Dgnu-efi=true"
-MESON_AFTER__ARM64=" \
-             ${MESON_AFTER} \
-             -Defi=true \
-             -Dgnu-efi=true"
 MESON_AFTER__RETRO=" \
              ${MESON_AFTER} \
              -Dxkbcommon=false \

--- a/app-admin/systemd/autobuild/defines.stage2
+++ b/app-admin/systemd/autobuild/defines.stage2
@@ -8,7 +8,7 @@ PKGSEC=admin
 # Also note that you don't need to change anything related to systemd.
 PKGDEP="glib acl bash kbd libcap linux-pam util-linux hwdata \
                aosc-aaa kmod dbus"
-BUILDDEP="gperf intltool jinja2"
+BUILDDEP="gperf intltool jinja2 pyelftools"
 PKGDES="System and service manager"
 
 ABTYPE=meson
@@ -38,7 +38,7 @@ MESON_AFTER=" \
              -Dlibidn2=false \
              -Dlibiptc=false \
              -Dlibcurl=false \
-             -Defi=false \
+             -Defi=true \
              -Dtpm=false \
              -Dhwdb=false \
              -Dsysusers=true \
@@ -90,12 +90,6 @@ MESON_AFTER__I486="${MESON_AFTER__RETRO}"
 MESON_AFTER__LOONGSON2F="${MESON_AFTER__RETRO}"
 MESON_AFTER__POWERPC="${MESON_AFTER__RETRO}"
 MESON_AFTER__PPC64="${MESON_AFTER__RETRO}"
-
-BUILDDEP__AMD64="${BUILDDEP} gnu-efi"
-MESON_AFTER__AMD64="${MESON_AFTER} -Defi=true"
-
-BUILDDEP__ARM64="${BUILDDEP} gnu-efi"
-MESON_AFTER__ARM64="${MESON_AFTER} -Defi=true"
 
 PKGBREAK="systemd-sysv<=1"
 PKGREP="systemd-sysv<=1"

--- a/app-admin/systemd/autobuild/overrides/usr/lib/sysusers.d/tss.conf
+++ b/app-admin/systemd/autobuild/overrides/usr/lib/sysusers.d/tss.conf
@@ -1,0 +1,2 @@
+g tss 159
+u tss 159:159 "Account for TPM access" - /usr/bin/nologin

--- a/app-admin/systemd/autobuild/postinst
+++ b/app-admin/systemd/autobuild/postinst
@@ -8,14 +8,15 @@ fi
 
 systemd-machine-id-setup
 
-setfacl -Rnm g:wheel:rx,d:g:wheel:rx,g:adm:rx,d:g:adm:rx var/log/journal/ 2>/dev/null
+setfacl -Rnm g:wheel:rx,d:g:wheel:rx,g:adm:rx,d:g:adm:rx \
+	/var/log/journal/ 2>/dev/null
 
 systemd-sysusers
-udevadm hwdb --update
+systemd-hwdb update
 journalctl --update-catalog
 
 if ! systemctl is-enabled -q remote-fs.target; then
-    systemctl enable -q remote-fs.target
+	systemctl enable -q remote-fs.target
 fi
 
 systemctl enable getty@tty1.service remote-fs.target
@@ -23,11 +24,10 @@ systemctl enable getty@tty1.service remote-fs.target
 [ ! -d /var/log/journal/remote ] && mkdir -m2755 /var/log/journal/remote
 chgrp systemd-journal-remote /var/log/journal/remote
 
-if grep -q "$(sha1sum /etc/machine-id | cut -d ' ' -f 1)" /usr/share/doc/systemd/aosc-revoked-machine-ids; then
-	echo "Your machine-id seems to be a common one from AOSC tarball."
-	echo "This broke the rule that machine-ids must be unique."
-	echo "A new one will be generated."
-	echo "If you met any problem, please reboot your system first."
+if grep -q "$(sha1sum /etc/machine-id | cut -d ' ' -f 1)" \
+	/usr/share/doc/systemd/aosc-revoked-machine-ids; then
+	echo "Your machine-id seems to be non-unique, a new one will be generated."
+	echo "Please reboot your system after this update."
 	rm /etc/machine-id
 	ln -sfv /etc/machine-id /var/lib/dbus/machine-id
 	systemd-machine-id-setup
@@ -35,5 +35,11 @@ fi
 
 # Systemd's forced seduction.
 getent group nobody > /dev/null && groupdel nobody
-groupadd -g 65534 systemd-nogroup
-useradd -u 65534 -g systemd-nogroup -d /dev/null -s /bin/false -c 'Unprivileged User (systemd)' systemd-nobody
+getent group systemd-nogroup > /dev/null || \
+	groupadd -g 65534 systemd-nogroup > /dev/null
+getent passwd systemd-nobody > /dev/null || \
+	useradd -u 65534 -g systemd-nogroup -d /dev/null -s /bin/false \
+		-c 'Unprivileged User (systemd)' systemd-nobody > /dev/null
+
+echo "Reloading binfmt ..."
+systemctl restart systemd-binfmt.service

--- a/app-admin/systemd/autobuild/triggers
+++ b/app-admin/systemd/autobuild/triggers
@@ -1,0 +1,3 @@
+interest-noawait /etc/binfmt.d
+interest-noawait /usr/lib/binfmt.d
+interest-noawait systemd-binfmt

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,5 +1,4 @@
-VER=252.3
-REL=4
-SRCS="tbl::https://github.com/systemd/systemd-stable/archive/v$VER.tar.gz"
-CHKSUMS="sha256::7996edd41f26fc077164a2c778e0d187601dd98bac702b873a28a8948ad92331"
+VER=254.6
+SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd-stable"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205088"

--- a/app-admin/trousers/autobuild/overrides/usr/lib/sysusers.d/tcsd.conf
+++ b/app-admin/trousers/autobuild/overrides/usr/lib/sysusers.d/tcsd.conf
@@ -1,3 +1,0 @@
-# See sysusers.d(5) for details.
-g	tss	159
-u	tss	159:159	"Account used by the trousers package to sandbox the tcsd daemon"	-	/bin/nologin

--- a/app-admin/trousers/autobuild/postinst
+++ b/app-admin/trousers/autobuild/postinst
@@ -1,3 +1,1 @@
-# Create required user and group
-systemd-sysusers tcsd.conf
 systemd-tmpfiles --create tcsd.conf

--- a/app-admin/trousers/spec
+++ b/app-admin/trousers/spec
@@ -2,4 +2,4 @@ VER=0.3.15
 SRCS="tbl::https://downloads.sourceforge.net/trousers/trousers-$VER.tar.gz"
 CHKSUMS="sha256::1e5be93e518372acf1d92d2f567d01a46fdb0b730487e544e6fb896c59cac77f"
 CHKUPDATE="anitya::id=5400"
-REL=1
+REL=2

--- a/app-devel/autobuild3/spec
+++ b/app-devel/autobuild3/spec
@@ -1,4 +1,4 @@
-VER=1.7.2
+VER=1.7.5
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"

--- a/app-utils/kmscon-enablement/autobuild/build
+++ b/app-utils/kmscon-enablement/autobuild/build
@@ -1,4 +1,0 @@
-abinfo "Creating a symlink to enable KMSCON on all virtual terminals ..."
-mkdir -pv "$PKGDIR"/etc/systemd/system
-ln -sv ../../../usr/lib/systemd/system/kmsconvt\@.service \
-    "$PKGDIR"/etc/systemd/system/autovt\@.service

--- a/app-utils/kmscon-enablement/autobuild/defines
+++ b/app-utils/kmscon-enablement/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=kmscon-enablement
-PKGSEC=utils
-PKGDEP="kmscon"
-PKGDES="Enables KMSCON on all virtual terminals"
-
-VER_NONE=1
-ABHOST=noarch

--- a/app-utils/kmscon-enablement/spec
+++ b/app-utils/kmscon-enablement/spec
@@ -1,2 +1,0 @@
-VER=0
-DUMMYSRC=1

--- a/app-utils/kmscon/autobuild/alternatives
+++ b/app-utils/kmscon/autobuild/alternatives
@@ -1,0 +1,1 @@
+alternative /usr/lib/systemd/system/autovt@.service /usr/lib/systemd/system-alternatives/autovt-kmscon.service 80

--- a/app-utils/kmscon/autobuild/beyond
+++ b/app-utils/kmscon/autobuild/beyond
@@ -1,3 +1,6 @@
 abinfo "Installing systemd services..."
-mkdir -pv "$PKGDIR"/usr/lib/systemd/system/
-cp -v docs/kmscon{,vt@}.service "$PKGDIR"/usr/lib/systemd/system/
+mkdir -pv "$PKGDIR"/usr/lib/systemd/system-alternatives/
+install -Dvm644 "$SRCDIR"/docs/kmscon{,vt@}.service \
+    -t "$PKGDIR"/usr/lib/systemd/system/
+install -Dvm644 "$SRCDIR"/docs/kmsconvt@.service \
+    "$PKGDIR"/usr/lib/systemd/system-alternatives/autovt-kmscon.service

--- a/app-utils/kmscon/autobuild/defines
+++ b/app-utils/kmscon/autobuild/defines
@@ -23,3 +23,6 @@ BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="Terminal emulator based on Kernel Mode Setting (KMS)"
 
 ABSHADOW=0
+
+PKGREP="kmscon-enablement"
+PKGBREAK="kmscon-enablement"

--- a/app-utils/kmscon/spec
+++ b/app-utils/kmscon/spec
@@ -1,5 +1,5 @@
 VER=8+git20221110
-REL=1
+REL=2
 SRCS="git::commit=daf51dfd5a70b671ee742ee13c185d6b37b9f199::https://github.com/AOSC-Dev/kmscon"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231600"

--- a/meta-bases/kmscon-base/autobuild/defines
+++ b/meta-bases/kmscon-base/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=kmscon-base
 PKGSEC=Bases
-PKGDEP="kmscon kmscon-enablement"
+PKGDEP="kmscon"
 PKGDES="Meta package for AOSC OS KMSCON experience"
 
 VER_NONE=1

--- a/meta-bases/kmscon-base/spec
+++ b/meta-bases/kmscon-base/spec
@@ -1,2 +1,2 @@
-VER=0
+VER=1
 DUMMYSRC=1

--- a/runtime-desktop/fontconfig/autobuild/overrides/usr/lib/systemd/system/fc-cache.service
+++ b/runtime-desktop/fontconfig/autobuild/overrides/usr/lib/systemd/system/fc-cache.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Refreshing font cache
-Before=display-manager.service
+Before=graphical.target
 
 [Service]
 Type=oneshot
@@ -9,4 +9,4 @@ ExecStart=/usr/bin/fc-cache -v
 TimeoutSec=0
 
 [Install]
-RequiredBy=graphical.target display-manager.service
+RequiredBy=graphical.target

--- a/runtime-desktop/fontconfig/spec
+++ b/runtime-desktop/fontconfig/spec
@@ -1,5 +1,5 @@
 VER=2.14.0
-REL=1
+REL=2
 SRCS="tbl::https://www.freedesktop.org/software/fontconfig/release/fontconfig-$VER.tar.xz"
 CHKSUMS="sha256::dcbeb84c9c74bbfdb133d535fe1c7bedc9f2221a8daf3914b984c44c520e9bac"
 CHKUPDATE="anitya::id=827"

--- a/runtime-devices/tpm2-tss/autobuild/overrides/usr/lib/sysusers.d/tpm2-tss.conf
+++ b/runtime-devices/tpm2-tss/autobuild/overrides/usr/lib/sysusers.d/tpm2-tss.conf
@@ -1,1 +1,0 @@
-u tss - "TPM2-TSS owner"

--- a/runtime-devices/tpm2-tss/autobuild/postinst
+++ b/runtime-devices/tpm2-tss/autobuild/postinst
@@ -1,1 +1,0 @@
-systemd-sysusers tpm2-tss.conf

--- a/runtime-devices/tpm2-tss/spec
+++ b/runtime-devices/tpm2-tss/spec
@@ -2,4 +2,4 @@ VER=2.3.3
 SRCS="tbl::https://github.com/tpm2-software/tpm2-tss/archive/$VER.tar.gz"
 CHKSUMS="sha256::8d0dd4e782a61163befcf974aa903476a8b9419ed6683299e702dc8b779fa737"
 CHKUPDATE="anitya::id=12683"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

This topic updates systemd to 254.5 and backports an upstream patch to fix compatibility with Dracut's multipath/device-mapper support with this update.

This topic is part of the effort to merge #4701.

Package(s) Affected
-------------------

- `autobuild3` v1.7.5
- `systemd` v254.6
- `dracut` v059-4
- `trousers` v0.3.15-2
- `tpm2-tss` v2.3.3-2
- `fontconfig` v2.14.0-2
- `kmscon` v8+git20221110-2
- `kmscon-base` v1

Security Update?
----------------

No

Build Order
-----------

```
autobuild3 systemd dracut trousers tpm2-tss fontconfig kmscon kmscon-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`