### PR TITLE
dpkg: update to 1.21.22

### DIFF
--- a/app-admin/dpkg/01-update-alternatives/patches/0001-Hack-loongarch64-recognition.patch.loongarch64
+++ b/app-admin/dpkg/01-update-alternatives/patches/0001-Hack-loongarch64-recognition.patch.loongarch64
@@ -1,11 +1,12 @@
-diff -Naur dpkg-1.20.9/data/cputable dpkg-1.20.9.loongarch64/data/cputable
---- dpkg-1.20.9/data/cputable	2021-07-24 16:27:34.120009451 +0800
-+++ dpkg-1.20.9.loongarch64/data/cputable	2021-07-24 16:28:50.683849503 +0800
-@@ -25,6 +25,7 @@
+diff -Naur dpkg/data/cputable dpkg.loongarch64/data/cputable
+--- dpkg/data/cputable	2023-04-10 20:38:03.368810867 +0000
++++ dpkg.loongarch64/data/cputable	2023-04-10 20:39:47.549231940 +0000
+@@ -26,7 +26,7 @@
  arm64		aarch64		aarch64			64	little
  avr32		avr32		avr32			32	big
  hppa		hppa		hppa.*			32	big
+-loong64		loongarch64	loongarch64		64	little
 +loongarch64	loongarch64	loongarch64		64	little
+ i386		i686		(i[34567]86|pentium)	32	little
+ ia64		ia64		ia64			64	little
  m32r		m32r		m32r			32	big
- m68k		m68k		m68k			32	big
- mips		mips		mips(eb)?		32	big

--- a/app-admin/dpkg/spec
+++ b/app-admin/dpkg/spec
@@ -1,4 +1,4 @@
-VER=1.21.18
+VER=1.21.22
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/dpkg-team/dpkg"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8127"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates `dpkg` to 1.21.22, with a `loongarch64`-specific change:

*Add a patch to rename loong64 => loongarch64.*

*We will adopt naming from Loongson. Loong64 does not associate with the product naming nor the name of the instruction set architecture. GNU and other basic tools also refer to this architecture as loongarch(64).*

This topic is part of the effort to merge #4701.

Package(s) Affected
-------------------

`dpkg` v1.21.22

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`