### PR TITLE
bash-startup: update to 0.5.2.2

### DIFF
--- a/runtime-data/bash-startup/spec
+++ b/runtime-data/bash-startup/spec
@@ -1,4 +1,4 @@
-VER=0.5.1
+VER=0.5.2.2
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226642"


### PR DESCRIPTION
Topic Description
-----------------

This update fixes two usability issues:

- umask was not set correctly for non-login sessions, making umask 077 by default.
- PATH was not set in non-login sessions.

It also enhances the following:

- Setting /usr/{,s}bin to have more priority over /{,s}bin, as it may break prefix detection in CMake.
- Setting $HOME/.local/bin in default PATH to help with Cargo/PIP-installed user packages.

This topic is part of the effort to merge #4701.

Package(s) Affected
-------------------

`bash-startup` v0.5.2.2

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`