### PR TITLE
openssl: Security Update to 3.1.4

### DIFF
--- a/runtime-cryptography/openssl/spec
+++ b/runtime-cryptography/openssl/spec
@@ -1,5 +1,4 @@
-VER=3.1.1
-REL=2
+VER=3.1.4
 SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::b3aa61334233b852b63ddb048df181177c2c659eb9d4376008118f9c08d07674"
+CHKSUMS="sha256::840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3"
 CHKUPDATE="anitya::id=2566"

--- a/runtime-optenv32/curl+32/spec
+++ b/runtime-optenv32/curl+32/spec
@@ -2,3 +2,4 @@ VER=8.4.0
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.bz2"
 CHKSUMS="sha256::e5250581a9c032b1b6ed3cf2f9c114c811fc41881069e9892d115cc73f9e88c6"
 CHKUPDATE="anitya::id=381"
+REL=1

--- a/runtime-optenv32/libssh+32/spec
+++ b/runtime-optenv32/libssh+32/spec
@@ -1,5 +1,5 @@
 VER=0.8.9
-REL=1
+REL=2
 SRCS="tbl::https://git.libssh.org/projects/libssh.git/snapshot/libssh-$VER.tar.gz"
 CHKSUMS="sha256::46763c6fadd101cba11d5aaa505c1a20bc4afc9c28d3adcc4c42932eeeaab3f0"
 CHKUPDATE="anitya::id=1729"

--- a/runtime-optenv32/libssh2+32/spec
+++ b/runtime-optenv32/libssh2+32/spec
@@ -1,5 +1,5 @@
 VER=1.9.0
 SRCS="tbl::https://www.libssh2.org/download/libssh2-$VER.tar.gz"
 CHKSUMS="sha256::d5fb8bd563305fd1074dda90bd053fb2d29fc4bce048d182f96eaa466dfadafd"
-REL=1
+REL=2
 CHKUPDATE="anitya::id=1730"

--- a/runtime-optenv32/neon+32/spec
+++ b/runtime-optenv32/neon+32/spec
@@ -2,3 +2,4 @@ VER=0.31.2
 SRCS="https://notroj.github.io/neon/neon-$VER.tar.gz"
 CHKSUMS="sha256::cf1ee3ac27a215814a9c80803fcee4f0ede8466ebead40267a9bd115e16a8678"
 CHKUPDATE="anitya::id=7604"
+REL=1

--- a/runtime-optenv32/openldap+32/spec
+++ b/runtime-optenv32/openldap+32/spec
@@ -2,3 +2,4 @@ VER=2.4.59
 SRCS="tbl::https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-$VER.tgz"
 CHKSUMS="sha256::99f37d6747d88206c470067eda624d5e48c1011e943ec0ab217bae8712e22f34"
 CHKUPDATE="anitya::id=2551"
+REL=1

--- a/runtime-optenv32/openssl+32/autobuild/build
+++ b/runtime-optenv32/openssl+32/autobuild/build
@@ -1,16 +1,23 @@
-export PATH=/opt/32/bin:$PATH
-
+abinfo "Setting up the environment ..."
+export PATH="/opt/32/bin:$PATH"
 export CC=i686-pc-linux-gnu-gcc
 export CPPFLAGS="${CPPFLAGS} ${CFLAGS}"
 
+abinfo "Configuring openssl+32 ..."
 # Disable tests to speed-up building process for optenv32
 "$SRCDIR"/Configure --prefix=/opt/32 --openssldir=/opt/32/etc/ssl --libdir=lib \
             shared zlib enable-ssl2 no-tests\
-            -Wa,--noexecstack linux-elf 
+            -Wa,--noexecstack linux-elf
 
-make depend
+abinfo "Building openssl+32 ..."
 make
 
-make MANDIR=/opt/32/share/man MANSUFFIX=ssl DESTDIR="$PKGDIR" install
+abinfo "Installing openssl+32 ..."
+make install \
+    MANDIR=/opt/32/share/man \
+    MANSUFFIX=ssl \
+    DESTDIR="$PKGDIR"
 
-rm -rf "$PKGDIR"/opt/32/{etc,bin,share}
+abinfo "Dropping non-runtime files ..."
+rm -rv \
+    "$PKGDIR"/opt/32/{bin,etc,share} \

--- a/runtime-optenv32/openssl+32/autobuild/defines
+++ b/runtime-optenv32/openssl+32/autobuild/defines
@@ -8,5 +8,11 @@ NOPARALLEL=1
 NOLTO=1
 ABHOST=noarch
 
-PKGBREAK="curl+32<=7.65.3 libssh+32<=0.7.6 libssh2+32<=1.8.2 \
-          openldap+32<=2.4.46-1 rtmpdump+32<=20150114-1"
+PKGBREAK="""
+curl+32<=8.4.0
+libssh+32<=0.8.9-1
+libssh2+32<=1.9.0
+neon+32<=0.31.2
+openldap+32<=2.4.59
+rtmpdump+32<=20150114-2
+"""

--- a/runtime-optenv32/openssl+32/spec
+++ b/runtime-optenv32/openssl+32/spec
@@ -1,4 +1,4 @@
-VER=1.1.1q
+VER=3.1.4
 SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca"
+CHKSUMS="sha256::840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3"
 CHKUPDATE="anitya::id=2566"

--- a/runtime-optenv32/openssl-1.1+32/autobuild/build
+++ b/runtime-optenv32/openssl-1.1+32/autobuild/build
@@ -1,0 +1,24 @@
+abinfo "Setting up the environment ..."
+export PATH="/opt/32/bin:$PATH"
+export CC=i686-pc-linux-gnu-gcc
+export CPPFLAGS="${CPPFLAGS} ${CFLAGS}"
+
+abinfo "Configuring openssl-1.1+32 ..."
+# Disable tests to speed-up building process for optenv32
+"$SRCDIR"/Configure --prefix=/opt/32 --openssldir=/opt/32/etc/ssl --libdir=lib \
+            shared zlib enable-ssl2 no-tests\
+            -Wa,--noexecstack linux-elf 
+
+abinfo "Building openssl-1.1+32 ..."
+make
+
+abinfo "Installing openssl-1.1+32 ..."
+make install \
+    MANDIR=/opt/32/share/man \
+    MANSUFFIX=ssl \
+    DESTDIR="$PKGDIR"
+
+abinfo "Dropping non-runtime files ..."
+rm -rv \
+    "$PKGDIR"/opt/32/{bin,etc,include,share} \
+    "$PKGDIR"/opt/32/lib/{pkgconfig,lib{crypto,ssl}.so}

--- a/runtime-optenv32/openssl-1.1+32/autobuild/defines
+++ b/runtime-optenv32/openssl-1.1+32/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=openssl-1.1+32
+PKGDEP="glibc+32 zlib+32 ca-certs"
+PKGSEC=libs
+PKGDES="Open Source toolkit for Secure Sockets Layer and Transport Layer Security (1.1 compatibility runtime for optenv32)"
+BUILDDEP="linux+api+32 32subsystem"
+
+NOPARALLEL=1
+NOLTO=1
+ABHOST=noarch

--- a/runtime-optenv32/openssl-1.1+32/spec
+++ b/runtime-optenv32/openssl-1.1+32/spec
@@ -1,0 +1,4 @@
+VER=1.1.1q
+SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
+CHKSUMS="sha256::d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca"
+CHKUPDATE="anitya::id=2566"

--- a/runtime-optenv32/rtmpdump+32/autobuild/defines
+++ b/runtime-optenv32/rtmpdump+32/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=rtmpdump+32
 PKGDES="A tool to download RTMP streams (optenv32)"
 PKGSEC=libs
 PKGDEP="openssl+32"
+BUILDDEP="32subsystem"
 
 NOPARALLEL=1
 NOLTO=1

--- a/runtime-optenv32/rtmpdump+32/spec
+++ b/runtime-optenv32/rtmpdump+32/spec
@@ -1,5 +1,5 @@
 VER=20150114
-REL=4
+REL=5
 SRCS="git::commit=fa8646d::git://git.ffmpeg.org/rtmpdump"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141551"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates OpenSSL to 3.1.4 to address a recently announced security vulnerability. It also syncs the version of its counterpart in `optenv32` and introduces a 1.1 compatibility runtime for that environment.

Package(s) Affected
-------------------

See "Files changed."

Security Update?
----------------

Yes, #4793 

Build Order
-----------

```
openssl openssl+32 openssl-1.1+32 curl+32 libssh+32 libssh2+32 neon+32 openldap+32 rtmpdump+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
- [x] 32-bit Optional Environment `optenv32`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`