### PR TITLE
GFileInfo Fix Survey 20231017

### DIFF
--- a/app-admin/appstream/01-appstream/patches/0001-Add-missing-standard-is-hidden-attribute-to-file-sea.patch
+++ b/app-admin/appstream/01-appstream/patches/0001-Add-missing-standard-is-hidden-attribute-to-file-sea.patch
@@ -1,0 +1,32 @@
+From bfa8fa6ac4ef645368a93384a6c16ac551a40922 Mon Sep 17 00:00:00 2001
+From: Matthias Klumpp <matthias@tenstral.net>
+Date: Sun, 12 Mar 2023 17:36:11 +0100
+Subject: [PATCH] Add missing standard::is-hidden attribute to file search
+ enumerator
+
+Resolves: #470
+---
+ src/as-utils.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/as-utils.c b/src/as-utils.c
+index 260f3cbf..b983e7ec 100644
+--- a/src/as-utils.c
++++ b/src/as-utils.c
+@@ -511,7 +511,12 @@ as_utils_find_files_matching (const gchar* dir, const gchar* pattern, gboolean r
+ 
+ 	list = g_ptr_array_new_with_free_func (g_free);
+ 	fdir =  g_file_new_for_path (dir);
+-	enumerator = g_file_enumerate_children (fdir, G_FILE_ATTRIBUTE_STANDARD_NAME, 0, NULL, &tmp_error);
++	enumerator = g_file_enumerate_children (fdir,
++						G_FILE_ATTRIBUTE_STANDARD_NAME ","
++						G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN,
++						0,
++						NULL,
++						&tmp_error);
+ 	if (tmp_error != NULL)
+ 		goto out;
+ 
+-- 
+2.39.1
+

--- a/app-admin/appstream/spec
+++ b/app-admin/appstream/spec
@@ -1,4 +1,5 @@
 VER=0.16.0
+REL=1
 SRCS="tbl::https://www.freedesktop.org/software/appstream/releases/AppStream-$VER.tar.xz"
 CHKSUMS="sha256::6430cce80ddfcda5a35270edf80f71e78f437ca5104183f765af9f3ed048e170"
 CHKUPDATE="anitya::id=10385"

--- a/app-admin/ostree/autobuild/patches/0001-core-Ensure-glib-standard-size-attribute-is-always-s.patch
+++ b/app-admin/ostree/autobuild/patches/0001-core-Ensure-glib-standard-size-attribute-is-always-s.patch
@@ -1,0 +1,33 @@
+From 376c9d7effa01fa020711a3f12829fe9b18b8bca Mon Sep 17 00:00:00 2001
+From: Evan Anderson <evan@eaanderson.com>
+Date: Wed, 15 Mar 2023 21:33:21 -0500
+Subject: [PATCH] core: Ensure glib standard::size attribute is always set
+
+* A recent change in glib [1] requires that the appropriate attribute
+be available when calling getters. ostree core only sets this attribute
+on regular files, and frequently triggers the critical warning. Solve
+this by setting standard::size to zero for non-regular files.
+
+Fixes https://github.com/ostreedev/ostree/issues/2827
+
+[1]: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3261
+---
+ src/libostree/ostree-core.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/libostree/ostree-core.c b/src/libostree/ostree-core.c
+index 56b381d9..0d1b0d5d 100644
+--- a/src/libostree/ostree-core.c
++++ b/src/libostree/ostree-core.c
+@@ -1739,6 +1739,8 @@ _ostree_stbuf_to_gfileinfo (const struct stat *stbuf)
+ 
+   if (S_ISREG (mode))
+     g_file_info_set_attribute_uint64 (ret, "standard::size", stbuf->st_size);
++  else
++    g_file_info_set_attribute_uint64 (ret, "standard::size", 0);
+ 
+   return ret;
+ }
+-- 
+2.39.1
+

--- a/app-admin/ostree/spec
+++ b/app-admin/ostree/spec
@@ -1,5 +1,5 @@
 VER=2023.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/ostreedev/ostree"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10899"

--- a/desktop-gnome/gtk-3/spec
+++ b/desktop-gnome/gtk-3/spec
@@ -1,5 +1,4 @@
-VER=3.24.34
-REL=2
+VER=3.24.38
 SRCS="https://download.gnome.org/sources/gtk+/${VER:0:4}/gtk+-$VER.tar.xz"
-CHKSUMS="sha256::dbc69f90ddc821b8d1441f00374dc1da4323a2eafa9078e61edbe5eeefa852ec"
+CHKSUMS="sha256::ce11decf018b25bdd8505544a4f87242854ec88be054d9ade5f3a20444dd8ee7"
 CHKUPDATE="anitya::id=10018"


### PR DESCRIPTION
Topic Description
-----------------

This topic addresses various `GFile` warnings after our recent GLib update.

Refs:

- https://github.com/flatpak/flatpak/issues/5340
- https://github.com/ostreedev/ostree/issues/2827

Package(s) Affected
-------------------

- `appstream` v0.16.0-1
- `gtk-3` v3.24.28
- `ostree` v2023.1-2

Security Update?
----------------

No

Build Order
-----------

```
appstream gtk-3 ostree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`