### PR TITLE
serf: (Gentoo patches) fix compatibility with OpenSSL 3

### DIFF
--- a/runtime-web/serf/autobuild/patches/0001-Gentoo-serf-1.3.9-openssl-3-errgetfunc.patch
+++ b/runtime-web/serf/autobuild/patches/0001-Gentoo-serf-1.3.9-openssl-3-errgetfunc.patch
@@ -1,0 +1,15 @@
+https://src.fedoraproject.org/rpms/libserf/raw/rawhide/f/libserf-1.3.9-errgetfunc.patch
+https://bugs.gentoo.org/805161
+--- a/buckets/ssl_buckets.c
++++ b/buckets/ssl_buckets.c
+@@ -1204,6 +1204,10 @@
+     }
+ }
+ 
++#ifndef ERR_GET_FUNC
++#define ERR_GET_FUNC(ec) (0)
++#endif
++
+ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
+ {
+     serf_ssl_context_t *ctx = SSL_get_app_data(ssl);

--- a/runtime-web/serf/autobuild/patches/0002-Gentoo-serf-1.3.9-openssl-3-bio-ctrl.patch
+++ b/runtime-web/serf/autobuild/patches/0002-Gentoo-serf-1.3.9-openssl-3-bio-ctrl.patch
@@ -1,0 +1,21 @@
+https://src.fedoraproject.org/rpms/libserf/raw/rawhide/f/libserf-1.3.9-bio-ctrl.patch
+https://bugs.gentoo.org/805161
+--- a/buckets/ssl_buckets.c
++++ b/buckets/ssl_buckets.c
+@@ -407,7 +407,7 @@ static int bio_bucket_destroy(BIO *bio)
+ 
+ static long bio_bucket_ctrl(BIO *bio, int cmd, long num, void *ptr)
+ {
+-    long ret = 1;
++    long ret = 0;
+ 
+     switch (cmd) {
+     default:
+@@ -415,6 +415,7 @@ static long bio_bucket_ctrl(BIO *bio, int cmd, long num, void *ptr)
+         break;
+     case BIO_CTRL_FLUSH:
+         /* At this point we can't force a flush. */
++        ret = 1;
+         break;
+     case BIO_CTRL_PUSH:
+     case BIO_CTRL_POP:

--- a/runtime-web/serf/spec
+++ b/runtime-web/serf/spec
@@ -1,5 +1,5 @@
 VER=1.3.9
-REL=8
-SRCS="tbl::https://archive.apache.org/dist/serf/serf-$VER.zip"
-CHKSUMS="sha256::bed5a38ec9aa77eb184bb97cb6745736cb711e0e797f33cb9e832302576a0c73"
+REL=9
+SRCS="tbl::https://archive.apache.org/dist/serf/serf-$VER.tar.bz2"
+CHKSUMS="sha256::549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc"
 CHKUPDATE="anitya::id=1720"


### PR DESCRIPTION
Topic Description
-----------------

`svn` returns undefined reference to `ERR_GET_FUNC'. This was caused by symbol incompatibility with OpenSSL 3.

Ref: https://bugs.gentoo.org/805161

Package(s) Affected
-------------------

`serf` v1.3.9-9

Security Update?
----------------

No

Build Order
-----------

```
serf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`