### PR TITLE
libpaper: update to 2.1.2

### DIFF
--- a/app-admin/cups/spec
+++ b/app-admin/cups/spec
@@ -1,4 +1,5 @@
 VER=2.4.2
+REL=1
 SRCS="tbl::https://github.com/OpenPrinting/cups/releases/download/v$VER/cups-${VER}-source.tar.gz"
 CHKSUMS="sha256::f03ccb40b087d1e30940a40e0141dcbba263f39974c20eb9f2521066c9c6c908"
 CHKUPDATE="anitya::id=380"

--- a/app-doc/ghostscript/spec
+++ b/app-doc/ghostscript/spec
@@ -1,4 +1,5 @@
 VER=9.54.0
+REL=1
 SRCS="tbl::https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${VER//./}/ghostscript-$VER.tar.gz"
 CHKSUMS="sha256::0646bb97f6f4d10a763f4919c54fa28b4fbdd3dff8e7de3410431c81762cade0"
 CHKUPDATE="anitya::id=1157"

--- a/app-doc/html2ps/spec
+++ b/app-doc/html2ps/spec
@@ -1,5 +1,5 @@
 VER=1.0b7
-REL=1
+REL=2
 SRCS="tbl::http://deb.debian.org/debian/pool/main/h/html2ps/html2ps_$VER.orig.tar.gz"
 CHKSUMS="sha256::d553980468a14bae738982c384c17f426ecf77dafd9a4e2499d520953f156f14"
 CHKUPDATE="html::url=http://deb.debian.org/debian/pool/main/h/html2ps;pattern=html2ps_(.+?).orig.tar.gz"

--- a/app-doc/texlive/autobuild/build
+++ b/app-doc/texlive/autobuild/build
@@ -44,8 +44,14 @@ make
 
 abinfo "Installing TeX Live binaries..."
 make install DESTDIR="$PKGDIR"
+
 abinfo "Creating symlinks to actual binaries.."
-make texlinks DESTDIR="$PKGDIR"
+# FIXME: Symlink installation requires kpsewhich, which depends on
+# libkpathsea.so.6, which is not yet available in LD_LIBRARY_PATH.
+#
+# Ref: https://gitlab.archlinux.org/archlinux/packaging/packages/texlive-bin/-/blob/f83b722db0c99cef02c18db41947b95299f0c735/PKGBUILD#L115
+LD_PRELOAD="$PKGDIR/usr/lib/libkpathsea.so.6" \
+    make texlinks DESTDIR="$PKGDIR"
 
 cd ..
 

--- a/app-doc/texlive/autobuild/overrides/etc/texmf/web2c/texmf.cnf
+++ b/app-doc/texlive/autobuild/overrides/etc/texmf/web2c/texmf.cnf
@@ -734,7 +734,7 @@ buf_size = 200000
 % for all known free hyphenation patterns to be loaded simultaneously
 % (as TeX Live does).
 %
-trie_size = 1000000
+trie_size = 4194303
 
 hyph_size = 8191        % prime number of hyphenation exceptions, >610, <32767.
                         % http://primes.utm.edu/curios/page.php/8191.html

--- a/app-doc/texlive/spec
+++ b/app-doc/texlive/spec
@@ -1,5 +1,5 @@
 VER=20220321
-REL=1
+REL=2
 SRCS="tbl::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-source.tar.xz \
       file::rename=texlive-$VER-texmf.tar.xz::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-texmf.tar.xz"
 CHKSUMS="sha256::5ffa3485e51eb2c4490496450fc69b9d7bd7cb9e53357d92db4bcd4fd6179b56 \

--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,5 +1,5 @@
 VER=7.5.4.2
-REL=1
+REL=2
 SRCS="tbl::https://download.documentfoundation.org/libreoffice/src/${VER:0:5}/libreoffice-$VER.tar.xz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz \

--- a/runtime-productivity/libpaper/autobuild/beyond
+++ b/runtime-productivity/libpaper/autobuild/beyond
@@ -1,8 +1,2 @@
-install -dm 755 abdist/etc/libpaper.d
-
-pushd debian/po
-for i in `ls *.po`; do
-	install -dm 755 ../../abdist/usr/share/locale/${i%.po}/LC_MESSAGES/;
-	msgfmt $i -o ../../abdist/usr/share/locale/${i%.po}/LC_MESSAGES/libpaper.mo;
-done
-popd
+abinfo "Creating /etc/libpaper.d ..."
+mkdir -pv "$PKGDIR"/etc/libpaper.d

--- a/runtime-productivity/libpaper/autobuild/defines
+++ b/runtime-productivity/libpaper/autobuild/defines
@@ -2,3 +2,6 @@ PKGNAME=libpaper
 PKGSEC=libs
 PKGDES="Library for handling paper characteristics"
 PKGDEP="bash"
+
+PKGBREAK="cups<=2.4.2 html2ps<=1.0b7-1 texlive<=20220321-1 \
+          libreoffice<=7.5.4.2-1 ghostscript<=9.54.0"

--- a/runtime-productivity/libpaper/spec
+++ b/runtime-productivity/libpaper/spec
@@ -1,4 +1,4 @@
-VER=1.1.24+nmu5
-SRCS="tbl::https://repo.aosc.io/aosc-repacks/libpaper_$VER.tar.gz"
-CHKSUMS="sha256::e29deda4cd7350189c71af0925cbf4a4473f9841d1419a922e1e8ff1954db1f2"
+VER=2.1.2
+SRCS="tbl::https://github.com/rrthomas/libpaper/releases/download/v$VER/libpaper-$VER.tar.gz"
+CHKSUMS="sha256::1fda0cf64efa46b9684a4ccc17df4386c4cc83254805419222c064bf62ea001f"
 CHKUPDATE="anitya::id=15136"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates `libpaper` to 2.1.2 and rebuilds all reverse dependencies due to a sover change.

This topic is part of the effort to merge https://github.com/AOSC-Dev/aosc-os-abbs/pull/4701.

Package(s) Affected
-------------------

See "Files changed."

Security Update?
----------------

No

Build Order
-----------

```
libpaper cups html2ps texlive ghostscript libreoffice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`