### PR TITLE
signing-party: new

### DIFF
--- a/app-cryptography/signing-party/autobuild/build
+++ b/app-cryptography/signing-party/autobuild/build
@@ -1,0 +1,42 @@
+cd "$SRCDIR"
+
+abinfo "Running make to generate files..."
+make
+
+abinfo "Installing files..."
+mkdir -pv "$PKGDIR"/usr/bin
+mkdir -pv "$PKGDIR"/usr/share/man/man1
+
+# To make the following for loop work.
+install -Dvm755 gpgwrap/bin/gpgwrap gpgwrap/gpgwrap
+
+for binname in \
+	caff gpg-key2latex gpg-key2ps gpg-mailkeys gpgdir gpglist \
+	gpgparticipants gpgsigs gpgwrap keyanalyze keyart keylookup \
+	sig2dot springgraph ; do
+	install -Dvm755 "$SRCDIR"/$binname/$binname "$PKGDIR"/usr/bin/$binname
+	find $binname -type f -iname '*.1' -exec cp -v {} "$PKGDIR"/usr/share/man/man1/ \;
+done
+
+abinfo "Installing extra files..."
+for binpath in \
+	caff/pgp-clean caff/pgp-fixkey gpgparticipants/gpgparticipants-filter gpgparticipants/gpgparticipants-prefill \
+	keyanalyze/pgpring/pgpring keyanalyze/process_keys ; do
+	install -Dvm755 $binpath /usr/bin/${binpath/#*\//}
+done
+
+# List obtained from Arch Linux:
+# https://gitlab.archlinux.org/archlinux/packaging/packages/signing-party/-/blob/main/PKGBUILD?ref_type=heads
+abinfo "Installing examples..."
+mkdir -pv "$PKGDIR"/usr/share/doc/$PKGNAME/{caff,gpgsigs,keyanalyze,keyart}
+for example in \
+	caff/caffrc.sample gpgsigs/gpgsigs-lt2k5.txt gpgsigs/gpgsigs-lt2k5-annotated.txt keyanalyze/analyze.sh \
+	keyanalyze/allkeys.sh keyanalyze/scripts keyanalyze/willy keyart/doc ; do
+	cp -rv $example "$PKGDIR"/usr/share/doc/$PKGNAME/$example
+done
+# Remove keyart.1 in examples
+rm -v "$PKGDIR"/usr/share/doc/$PKGNAME/keyart/doc/keyart.1
+
+# Install README and LICENSE files
+abinfo "Installing README and LICENSE files..."
+find -type f -name README -and -name LICENSE -exec install -Dvm644 {} "$PKGDIR"/usr/share/doc/$PKGNAME/{} \;

--- a/app-cryptography/signing-party/autobuild/defines
+++ b/app-cryptography/signing-party/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=signing-party
+PKGSEC=misc
+PKGDES="Various OpenPGP related tools made for key signing party"
+PKGDEP="gnupg perl-class-methodmaker perl-mailtools perl-mime-tools perl-net-idn-encode perl-term-readkey perl-text-template \
+	perl-gnupg-interface imagemagick python-3 perl-gd qrencode qprint"
+BUILDDEP="perl gnupg"
+# TeXLive: for LaTeX support in gpg-key2latex.
+# Postfix: for mailing the encrypted messages containing signatures
+PKGSUG="texlive postfix"
+
+ABSPLITDBG=0

--- a/app-cryptography/signing-party/autobuild/postinst
+++ b/app-cryptography/signing-party/autobuild/postinst
@@ -1,0 +1,10 @@
+cat << EOF
+Notice for signing-party
+========================
+
+It is recommended to set up postfix or other MTAs to actually mail the
+signatures to the corresponding email addresses. Otherwise, the encrypted
+mail(s) will be saved to the currently working directory after you created
+signatures with caff(1).
+
+EOF

--- a/app-cryptography/signing-party/spec
+++ b/app-cryptography/signing-party/spec
@@ -1,0 +1,4 @@
+VER=2.11
+SRCS="git::commit=0196577f44de9bb04a9661eff1e575f770d09163::https://salsa.debian.org/signing-party-team/signing-party.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=8572"

--- a/app-utils/qprint/autobuild/defines
+++ b/app-utils/qprint/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=qprint
+PKGSEC=util
+PKGDES="Encoder and decoder for quoted-printable (RFC1521) encoding"
+PKGDEP="glibc"
+
+RECONF=0
+ABSHADOW=0

--- a/app-utils/qprint/autobuild/prepare
+++ b/app-utils/qprint/autobuild/prepare
@@ -1,0 +1,3 @@
+# Arch Linux: directories are not created during `make install`.
+mkdir -p "$PKGDIR"/usr/bin
+mkdir -p "$PKGDIR"/usr/share/man/man1

--- a/app-utils/qprint/spec
+++ b/app-utils/qprint/spec
@@ -1,0 +1,4 @@
+VER=1.1
+SRCS="tbl::https://www.fourmilab.ch/webtools/qprint/qprint-${VER}.tar.gz"
+CHKSUMS="sha256::ffa9ca1d51c871fb3b56a4bf0165418348cf080f01ff7e59cd04511b9665019c"
+CHKUPDATE="anitya::id=136538"

--- a/lang-perl/perl-class-tiny/autobuild/defines
+++ b/lang-perl/perl-class-tiny/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=perl-class-tiny
+PKGSEC=perl
+PKGDES="Minimalist class construction"
+PKGDEP="perl"
+ABHOST=noarch

--- a/lang-perl/perl-class-tiny/spec
+++ b/lang-perl/perl-class-tiny/spec
@@ -1,0 +1,4 @@
+VER=1.008
+SRCS="tbl::https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/Class-Tiny-${VER}.tar.gz"
+CHKSUMS="sha256::ee058a63912fa1fcb9a72498f56ca421a2056dc7f9f4b67837446d6421815615"
+CHKUPDATE="anitya::id=2704"

--- a/lang-perl/perl-data-perl/autobuild/defines
+++ b/lang-perl/perl-data-perl/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=perl-data-perl
+PKGSEC=perl
+PKGDES="Base classes wrapping fundamental Perl data types"
+PKGDEP="perl perl-class-method-modifiers perl-list-moreutils perl-module-runtime perl-role-tiny perl-strictures"
+ABHOST=noarch

--- a/lang-perl/perl-data-perl/spec
+++ b/lang-perl/perl-data-perl/spec
@@ -1,0 +1,4 @@
+VER=0.002011
+SRCS="tbl::https://cpan.metacpan.org/authors/id/T/TO/TOBYINK/Data-Perl-${VER}.tar.gz"
+CHKSUMS="sha256::8d34dbe314cfa2d99bd9aae546bbde94c38bb05b74b07c89bde1673a6f6c55f4"
+CHKUPDATE="anitya::id=12438"

--- a/lang-perl/perl-exporter-tiny/spec
+++ b/lang-perl/perl-exporter-tiny/spec
@@ -1,5 +1,4 @@
-VER=1.001+001
+VER=1.006002
 SRCS="tbl::https://search.cpan.org/CPAN/authors/id/T/TO/TOBYINK/Exporter-Tiny-${VER/+/_}.tar.gz"
-CHKSUMS="sha256::4028af291bf39cadffd5aa4e03bb93c1c753b0beb545bba89c5920c6d20ca7fd"
-REL=2
+CHKSUMS="sha256::6f295e2cbffb1dbc15bdb9dadc341671c1e0cd2bdf2d312b17526273c322638d"
 CHKUPDATE="anitya::id=11846"

--- a/lang-perl/perl-gnupg-interface/autobuild/defines
+++ b/lang-perl/perl-gnupg-interface/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=perl-gnupg-interface
+PKGDES="Perl interface to GnuPG"
+PKGSEC=perl
+PKGDEP="gnupg perl perl-moo perl-moox-late perl-moox-handlesvia"
+
+ABHOST=noarch

--- a/lang-perl/perl-gnupg-interface/spec
+++ b/lang-perl/perl-gnupg-interface/spec
@@ -1,0 +1,4 @@
+VER=1.03
+SRCS="tbl::https://cpan.metacpan.org/authors/id/B/BP/BPS/GnuPG-Interface-${VER}.tar.gz"
+CHKSUMS="sha256::5af56630f0fac290d7242183f6449aa0e02829f4611dc62bc6e9e9b3808f187a"
+CHKUPDATE="anitya::id=12665"

--- a/lang-perl/perl-moox-handlesvia/autobuild/defines
+++ b/lang-perl/perl-moox-handlesvia/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=perl-moox-handlesvia
+PKGSEC=perl
+PKGDES="NativeTrait-like behavior for Moo"
+PKGDEP="perl perl-class-method-modifiers perl-data-perl perl-module-runtime perl-moo perl-role-tiny"
+ABHOST=noarch

--- a/lang-perl/perl-moox-handlesvia/spec
+++ b/lang-perl/perl-moox-handlesvia/spec
@@ -1,0 +1,4 @@
+VER=0.001009
+SRCS="tbl::https://cpan.metacpan.org/authors/id/T/TO/TOBYINK/MooX-HandlesVia-${VER}.tar.gz"
+CHKSUMS="sha256::716353e38894ecb7e8e4c17bc95483db5f59002b03541b54a72c27f2a8f36c12"
+CHKUPDATE="anitya::id=14212"

--- a/lang-perl/perl-moox-late/autobuild/defines
+++ b/lang-perl/perl-moox-late/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=perl-moox-late
+PKGSEC=perl
+PKGDES="Easily translate Moose code to Moo"
+PKGDEP="perl perl-moox-handlesvia perl-sub-handlesvia perl-type-tiny"
+ABHOST=noarch

--- a/lang-perl/perl-moox-late/spec
+++ b/lang-perl/perl-moox-late/spec
@@ -1,0 +1,4 @@
+VER=0.100
+SRCS="tbl::https://cpan.metacpan.org/authors/id/T/TO/TOBYINK/MooX-late-${VER}.tar.gz"
+CHKSUMS="sha256::2ae5b1e3da5abc0e4006278ecbcfa8fa7c224ea5529a6a688acbb229c09e6a5f"
+CHKUPDATE="anitya::id=14214"

--- a/lang-perl/perl-mouse/autobuild/defines
+++ b/lang-perl/perl-mouse/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=perl-mouse
+PKGSEC=perl
+PKGDES="Moose minus the antlers"
+PKGDEP="perl"
+ABSPLITDBG=0

--- a/lang-perl/perl-mouse/spec
+++ b/lang-perl/perl-mouse/spec
@@ -1,0 +1,4 @@
+VER=2.5.10
+SRCS="tbl::https://cpan.metacpan.org/authors/id/S/SK/SKAJI/Mouse-v${VER}.tar.gz"
+CHKSUMS="sha256::ce8dc23946153a467ff09765167ee2590f5c502120f48a2d9441733f39aa32ee"
+CHKUPDATE="anitya::id=12781"

--- a/lang-perl/perl-net-idn-encode/autobuild/defines
+++ b/lang-perl/perl-net-idn-encode/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=perl-net-idn-encode
+PKGSEC=perl
+PKGDES="Easy-to-use Perl interface for encoding and decoding Internationalized Domain Names (IDNs)"
+PKGDEP="perl"
+
+ABHOST=noarch

--- a/lang-perl/perl-net-idn-encode/spec
+++ b/lang-perl/perl-net-idn-encode/spec
@@ -1,0 +1,4 @@
+VER=2.500
+SRCS="tbl::https://cpan.metacpan.org/authors/id/C/CF/CFAERBER/Net-IDN-Encode-${VER}.tar.gz"
+CHKSUMS="sha256::55453633e3ff24ce325b34bc2c8157b9859962a31ab5cf28bf7ccc1c9b3a3eaa"
+CHKUPDATE="anitya::id=8113"

--- a/lang-perl/perl-scalar-list-utils/autobuild/defines
+++ b/lang-perl/perl-scalar-list-utils/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=perl-scalar-list-utils
+PKGSEC=perl
+PKGDES="A selection of general-utility list subroutines"
+PKGDEP="perl"

--- a/lang-perl/perl-scalar-list-utils/spec
+++ b/lang-perl/perl-scalar-list-utils/spec
@@ -1,0 +1,4 @@
+VER=1.63
+SRCS="tbl::https://cpan.metacpan.org/authors/id/P/PE/PEVANS/Scalar-List-Utils-${VER}.tar.gz"
+CHKSUMS="sha256::cafbdf212f6827dc9a0dd3b57b6ee50e860586d7198228a33262d55c559eb2a9"
+CHKUPDATE="anitya::id=6483"

--- a/lang-perl/perl-strictures/autobuild/defines
+++ b/lang-perl/perl-strictures/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=perl-strictures
+PKGSEC=perl
+PKGDES="Perl module to make most warnings fatal"
+PKGDEP="perl"
+ABHOST=noarch

--- a/lang-perl/perl-strictures/spec
+++ b/lang-perl/perl-strictures/spec
@@ -1,0 +1,4 @@
+VER=2.000006
+SRCS="tbl::https://cpan.metacpan.org/authors/id/H/HA/HAARG/strictures-${VER}.tar.gz"
+CHKSUMS="sha256::09d57974a6d1b2380c802870fed471108f51170da81458e2751859f2714f8d57"
+CHKUPDATE="anitya::id=10544"

--- a/lang-perl/perl-sub-handlesvia/autobuild/defines
+++ b/lang-perl/perl-sub-handlesvia/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=perl-sub-handlesvia
+PKGSEC=perl
+PKGDES="Perl extension for easily overriding subroutines"
+PKGDEP="perl perl-moo perl-class-tiny perl-exporter-tiny perl-mouse perl-type-tiny"
+ABHOST=noarch

--- a/lang-perl/perl-sub-handlesvia/spec
+++ b/lang-perl/perl-sub-handlesvia/spec
@@ -1,0 +1,4 @@
+VER=0.050000
+SRCS="tbl::https://cpan.metacpan.org/authors/id/T/TO/TOBYINK/Sub-HandlesVia-${VER}.tar.gz"
+CHKSUMS="sha256::2df93493e2f9e95be579b950b6e19ff524f94c80613aadc03a88611dff75794f"
+CHKUPDATE="anitya::id=256877"

--- a/lang-perl/perl-type-tiny/autobuild/defines
+++ b/lang-perl/perl-type-tiny/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=perl-type-tiny
+PKGSEC=perl
+PKGDES="Moo(se)-compatible type constraint for Perl"
+PKGDEP="perl perl-exporter-tiny"
+ABHOST=noarch

--- a/lang-perl/perl-type-tiny/spec
+++ b/lang-perl/perl-type-tiny/spec
@@ -1,0 +1,4 @@
+VER=2.004000
+SRCS="tbl::https://cpan.metacpan.org/authors/id/T/TO/TOBYINK/Type-Tiny-${VER}.tar.gz"
+CHKSUMS="sha256::697e7f775edfc85f4cf07792d04fd19b09c25285f98f5938e8efc4f74507a128"
+CHKUPDATE="anitya::id=14406"


### PR DESCRIPTION
Topic Description
-----------------

This PR adds a set of scripts to make it easier for signing parties to sign and mail their signed PGP keys.

Package(s) Affected
-------------------

### New
- perl-strictures
- perl-scalar-list-utils
- perl-data-perl
- perl-class-tiny
- perl-mouse
- perl-type-tiny
- perl-sub-handlesvia
- perl-moox-handlesvia
- perl-moox-late
- perl-gnupg-interface
- perl-net-idn-encode
- qprint
- signing-party

### Existing
- perl-exporter-tiny

Security Update?
----------------

No

Build Order
-----------

```
perl-strictures perl-scalar-list-utils perl-data-perl perl-class-tiny perl-mouse perl-exporter-tiny perl-type-tiny perl-sub-handlesvia perl-moox-handlesvia perl-moox-late perl-gnupg-interface signing-party
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
- [ ] Architecture-independent `noarch`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
