### PR TITLE
gtk-3: migrate to Meson

### DIFF
--- a/desktop-gnome/gtk-3/autobuild/defines
+++ b/desktop-gnome/gtk-3/autobuild/defines
@@ -26,33 +26,23 @@ BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="GIMP toolkit version 3"
 
-AUTOTOOLS_AFTER="--disable-schemas-compile \
-                 --enable-x11-backend \
-                 --enable-broadway-backend \
-                 --enable-wayland-backend \
-                 --enable-introspection=yes \
-                 --enable-gtk-doc \
-                 --enable-cups \
-                 --enable-colord \
-                 --disable-profiler"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-broadway-backend \
-                 --disable-wayland-backend \
-                 --disable-introspection \
-                 --disable-gtk-doc \
-                 --disable-gtk-doc-html \
-                 --disable-gtk-doc-pdf \
-                 --disable-cups \
-                 --disable-colord"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
-
-ABSHADOW=0
-RECONF=0
+MESON_AFTER="-Dx11_backend=true \
+             -Dwayland_backend=true \
+             -Dbroadway_backend=true \
+             -Dintrospection=true \
+             -Dgtk_doc=true \
+             -Dman=true \
+             -Dcolord=yes \
+             -Dprint_backends=auto \
+             -Dprofiler=false \
+             -Dbuiltin_immodules=all"
+MESON_AFTER__RETRO="-Dx11_backend=true \
+                    -Dwayland_backend=false \
+                    -Dbroadway_backend=false \
+                    -Dintrospection=false \
+                    -Dgtk_doc=false \
+                    -Dman=false \
+                    -Dcolord=no \
+                    -Dprint_backends=auto \
+                    -Dprofiler=false \
+                    -Dbuiltin_immodules=backend"

--- a/desktop-gnome/gtk-3/spec
+++ b/desktop-gnome/gtk-3/spec
@@ -1,4 +1,5 @@
 VER=3.24.38
+REL=1
 SRCS="https://download.gnome.org/sources/gtk+/${VER:0:4}/gtk+-$VER.tar.xz"
 CHKSUMS="sha256::ce11decf018b25bdd8505544a4f87242854ec88be054d9ade5f3a20444dd8ee7"
 CHKUPDATE="anitya::id=10018"


### PR DESCRIPTION
Topic Description
-----------------

This topic migrates `gtk-3` to the Meson build system and enable features explicitly. Addresses missing features in `gtk-3` v3.24.28

Package(s) Affected
-------------------

`gtk-3` v3.24.28-1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`