### PR TITLE
fontconfig: fix no bitmaps

### DIFF
--- a/runtime-desktop/fontconfig/autobuild/overrides/etc/fonts/conf.d/70-no-bitmaps.conf
+++ b/runtime-desktop/fontconfig/autobuild/overrides/etc/fonts/conf.d/70-no-bitmaps.conf
@@ -1,1 +1,0 @@
-../conf.avail/70-no-bitmaps.conf

--- a/runtime-desktop/fontconfig/autobuild/patches/0002-Create-a-symlink-with-relative-patch.patch
+++ b/runtime-desktop/fontconfig/autobuild/patches/0002-Create-a-symlink-with-relative-patch.patch
@@ -1,0 +1,47 @@
+From 5d954398d1ebe04778a945d5c1546d9dbfb8e031 Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Thu, 10 Aug 2023 20:18:37 +0900
+Subject: [PATCH] Create a symlink with relative path
+
+Fixes https://gitlab.freedesktop.org/fontconfig/fontconfig/-/issues/378
+---
+ conf.d/Makefile.am   | 9 +--------
+ conf.d/link_confs.py | 2 +-
+ 2 files changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/conf.d/Makefile.am b/conf.d/Makefile.am
+index a844f292..fd858348 100644
+--- a/conf.d/Makefile.am
++++ b/conf.d/Makefile.am
+@@ -109,14 +109,7 @@ README: $(srcdir)/README.in
+ 	cd ../fc-lang && $(MAKE) $(AM_MAKEFLAGS) $(top_builddir)/conf.d/35-lang-normalize.conf
+ 
+ install-data-hook:
+-	mkdir -p $(DESTDIR)$(configdir)
+-	@(echo cd $(DESTDIR)$(configdir);			\
+-	  cd $(DESTDIR)$(configdir);				\
+-	  for i in $(CONF_LINKS); do				\
+-	    echo $(RM) $$i";" ln -s $(templatedir)/$$i .;	\
+-	    $(RM) $$i;						\
+-	    ln -s $(templatedir)/$$i .;				\
+-	  done)
++	$(PYTHON) $(srcdir)/link_confs.py $(templatedir) $(configdir) $(CONF_LINKS)
+ uninstall-local:
+ 	@(echo cd $(DESTDIR)$(configdir);			\
+ 	  cd $(DESTDIR)$(configdir);				\
+diff --git a/conf.d/link_confs.py b/conf.d/link_confs.py
+index 11e759aa..f92e1c3b 100644
+--- a/conf.d/link_confs.py
++++ b/conf.d/link_confs.py
+@@ -34,7 +34,7 @@ if __name__=='__main__':
+         except FileNotFoundError:
+             pass
+         try:
+-            os.symlink(src, dst)
++            os.symlink(os.path.relpath(src, start=args.confpath), dst)
+         except NotImplementedError:
+             # Not supported on this version of Windows
+             break
+-- 
+GitLab
+

--- a/runtime-desktop/fontconfig/autobuild/patches/0003-let-us-deny-bitmaps.patch
+++ b/runtime-desktop/fontconfig/autobuild/patches/0003-let-us-deny-bitmaps.patch
@@ -1,10 +1,10 @@
---- a/conf.d/Makefile.am	2023-11-07 17:13:50.532146594 +0800
-+++ b/conf.d/Makefile.am	2023-11-07 17:13:28.316998231 +0800
-@@ -49,6 +49,7 @@
- 	65-fonts-persian.conf \
- 	65-nonlatin.conf \
- 	69-unifont.conf \
-+	70-no-bitmaps.conf \
- 	80-delicious.conf \
- 	90-synthetic.conf
- 
+--- a/conf.d/meson.build	2022-01-16 18:30:59.000000000 -0800
++++ b/conf.d/meson.build	2023-11-07 02:26:44.280023241 -0800
+@@ -58,6 +58,7 @@
+   '65-fonts-persian.conf',
+   '65-nonlatin.conf',
+   '69-unifont.conf',
++  '70-no-bitmaps.conf',
+   '80-delicious.conf',
+   '90-synthetic.conf',
+ ]

--- a/runtime-desktop/fontconfig/autobuild/patches/0003-let-us-deny-bitmaps.patch
+++ b/runtime-desktop/fontconfig/autobuild/patches/0003-let-us-deny-bitmaps.patch
@@ -1,0 +1,10 @@
+--- a/conf.d/Makefile.am	2023-11-07 17:13:50.532146594 +0800
++++ b/conf.d/Makefile.am	2023-11-07 17:13:28.316998231 +0800
+@@ -49,6 +49,7 @@
+ 	65-fonts-persian.conf \
+ 	65-nonlatin.conf \
+ 	69-unifont.conf \
++	70-no-bitmaps.conf \
+ 	80-delicious.conf \
+ 	90-synthetic.conf
+ 

--- a/runtime-desktop/fontconfig/spec
+++ b/runtime-desktop/fontconfig/spec
@@ -1,4 +1,5 @@
 VER=2.14.0
+REL=1
 SRCS="tbl::https://www.freedesktop.org/software/fontconfig/release/fontconfig-$VER.tar.xz"
 CHKSUMS="sha256::dcbeb84c9c74bbfdb133d535fe1c7bedc9f2221a8daf3914b984c44c520e9bac"
 CHKUPDATE="anitya::id=827"


### PR DESCRIPTION


Topic Description
-----------------

Fix broken 70-no-bitmaps.conf linking in `fontconfig`

Package(s) Affected
-------------------

* fontconfig

Security Update?
----------------

No 

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
