### PR TITLE
bash-startup: update to 0.5.2.4

### DIFF
--- a/runtime-data/bash-startup/spec
+++ b/runtime-data/bash-startup/spec
@@ -1,4 +1,4 @@
-VER=0.5.2.2
+VER=0.5.2.4
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226642"


### PR DESCRIPTION
Topic Description
-----------------

update bash-startup to v0.5.2.4

Package(s) Affected
-------------------

`bash-startup` v0.5.2.4

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] Architecture-independent `noarch`