### PR TITLE
nvidia: fix checksum for arm64

### DIFF
--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -15,8 +15,8 @@ SRCS__ARM64="
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__ARM64="
-	sha256::494c56fd9f2c249edb73fca1a334e1f1677680a2ec9e22702a65e1d6d270526f
-	sha256::34e7810b5db0996ee28a116122faaae810c18c41fc965f4bfd44962df47a09cf
+	sha256::6364433ae0ed888725af4ea098bacf0df1395459856a65f188820ab4a01ec2ba
+	sha256::4414ab928cd7efafd03e95d90d4b38bd279586d8811c533cad5968e9e47b7fa7
 "
 
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Fixing checksums for arm64 binaries

Package(s) Affected
-------------------

nvidia

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`