### PR TITLE
discord: update to 0.0.34

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.33
+VER=0.0.34
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::51582e7cf3484bb7dadd50f38c25b080adf1c66a8d8afab8eb5a962e08ab0a57"
+CHKSUMS="sha256::b672abec351ee016c914e5418318b0c1ac959d50068e683c8028800338b55e65"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Discord to 0.0.34

Package(s) Affected
-------------------

`discord` v0.0.34

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
