### PR TITLE
telegram-desktop: update to 4.11.6

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/0004-core_settings-use-system-window-decoration-by-defaul.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-core_settings-use-system-window-decoration-by-defaul.patch
@@ -1,18 +1,8 @@
-From 80cf75a2d5e29d370ba801d2d9537e762a9dd723 Mon Sep 17 00:00:00 2001
-From: Kay Lin <kaymw@aosc.io>
-Date: Mon, 19 Sep 2022 05:58:06 -0700
-Subject: [PATCH 4/5] core_settings: use system window decoration by default
-
-Original filename: 0005-use-system-frame-by-default.patch
----
- Telegram/SourceFiles/core/core_settings.h | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 652269af..059c5366 100644
+index 31b0880b1..15966c0fe 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
-@@ -824,7 +824,7 @@ private:
+@@ -918,7 +918,7 @@ private:
  	rpl::variable<float64> _dialogsWidthRatio; // per-window
  	rpl::variable<int> _thirdColumnWidth = kDefaultThirdColumnWidth; // p-w
  	bool _notifyFromAll = true;
@@ -20,7 +10,4 @@ index 652269af..059c5366 100644
 +	rpl::variable<bool> _nativeWindowFrame = true;
  	rpl::variable<std::optional<bool>> _systemDarkMode = std::nullopt;
  	rpl::variable<bool> _systemDarkModeEnabled = false;
- 	WindowPosition _windowPosition; // per-window
--- 
-2.38.1
-
+ 	rpl::variable<WindowTitleContent> _windowTitleContent;

--- a/app-web/telegram-desktop/autobuild/patches/1000-tdesktop-fix-build-qt5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/1000-tdesktop-fix-build-qt5.patch
@@ -1,6 +1,48 @@
-diff -Naur tdesktop/Telegram/lib_webview/CMakeLists.txt tdesktop.qt5/Telegram/lib_webview/CMakeLists.txt
---- tdesktop/Telegram/lib_webview/CMakeLists.txt	2023-09-23 10:39:13.974421475 -0700
-+++ tdesktop.qt5/Telegram/lib_webview/CMakeLists.txt	2023-09-23 10:49:22.309717624 -0700
+Submodule Telegram/lib_base contains modified content
+diff --git a/Telegram/lib_base/base/qt/qt_compare.h b/Telegram/lib_base/base/qt/qt_compare.h
+index ca03fa2..3160943 100644
+--- a/Telegram/lib_base/base/qt/qt_compare.h
++++ b/Telegram/lib_base/base/qt/qt_compare.h
+@@ -7,6 +7,7 @@
+ #pragma once
+ 
+ #include <compare>
++#include <variant>
+ #include <gsl/pointers>
+ 
+ #include <QString>
+Submodule Telegram/lib_ui contains modified content
+diff --git a/Telegram/lib_ui/ui/text/text_entity.cpp b/Telegram/lib_ui/ui/text/text_entity.cpp
+index 383b3d0..f1fff9b 100644
+--- a/Telegram/lib_ui/ui/text/text_entity.cpp
++++ b/Telegram/lib_ui/ui/text/text_entity.cpp
+@@ -2349,6 +2349,8 @@ EntityInText::EntityInText(
+ , _data(data) {
+ }
+ 
++EntityInText::EntityInText() {}
++
+ int EntityInText::FirstMonospaceOffset(
+ 		const EntitiesInText &entities,
+ 		int textLength) {
+diff --git a/Telegram/lib_ui/ui/text/text_entity.h b/Telegram/lib_ui/ui/text/text_entity.h
+index 2aa8385..dacff68 100644
+--- a/Telegram/lib_ui/ui/text/text_entity.h
++++ b/Telegram/lib_ui/ui/text/text_entity.h
+@@ -70,6 +70,8 @@ public:
+ 		int length,
+ 		const QString &data = QString());
+ 
++	EntityInText();
++
+ 	[[nodiscard]] EntityType type() const {
+ 		return _type;
+ 	}
+Submodule Telegram/lib_webview contains modified content
+diff --git a/Telegram/lib_webview/CMakeLists.txt b/Telegram/lib_webview/CMakeLists.txt
+index 18ed682..e54ced0 100644
+--- a/Telegram/lib_webview/CMakeLists.txt
++++ b/Telegram/lib_webview/CMakeLists.txt
 @@ -7,6 +7,7 @@
  add_library(lib_webview STATIC)
  add_library(desktop-app::lib_webview ALIAS lib_webview)
@@ -9,10 +51,11 @@ diff -Naur tdesktop/Telegram/lib_webview/CMakeLists.txt tdesktop.qt5/Telegram/li
  
  get_filename_component(src_loc . REALPATH)
  
-diff -Naur tdesktop/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp tdesktop.qt5/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
---- tdesktop/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp	2023-09-23 10:39:13.975421509 -0700
-+++ tdesktop.qt5/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp	2023-09-23 10:50:13.671434361 -0700
-@@ -39,6 +39,7 @@
+diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
+index 60bed44..68635d2 100644
+--- a/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
++++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
+@@ -39,6 +39,7 @@ private:
  };
  
  class Output : public QWaylandQuickOutput {
@@ -20,42 +63,9 @@ diff -Naur tdesktop/Telegram/lib_webview/webview/platform/linux/webview_linux_co
  public:
  	Output(
  			QWaylandCompositor *compositor,
-@@ -231,3 +232,5 @@
+@@ -232,3 +233,5 @@ void Compositor::setWidget(QQuickWidget *widget) {
  }
  
  } // namespace Webview
 +
 +#include "webview_linux_compositor.moc"
-diff -Naur tdesktop/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp tdesktop.qt5/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
---- tdesktop/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp	2023-09-23 10:39:13.975421509 -0700
-+++ tdesktop.qt5/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp	2023-09-23 10:50:46.200521783 -0700
-@@ -110,6 +110,7 @@
- Instance::Instance(bool remoting)
- : _remoting(remoting) {
- 	if (_remoting) {
-+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
- 		if ((_wayland = ProvidesQWidget())) {
- 			[[maybe_unused]] static const auto Inited = [] {
- 				const auto backend = Ui::GL::ChooseBackendDefault(
-@@ -127,7 +128,7 @@
- 				return true;
- 			}();
- 		}
--
-+#endif
- 		startProcess();
- 	}
- }
---- a/Telegram/lib_base/base/platform/linux/base_linux_xdp_utilities.cpp	2023-09-23 12:37:24.217402847 -0700
-+++ b/Telegram/lib_base/base/platform/linux/base_linux_xdp_utilities.cpp	2023-09-23 12:37:35.245776842 -0700
-@@ -13,8 +13,10 @@
- #include <QtGui/QGuiApplication>
- #include <QtGui/QWindow>
- #include <qpa/qplatformintegration.h>
-+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
- #include <private/qguiapplication_p.h>
- #include <private/qgenericunixservices_p.h>
-+#endif
- 
- namespace base::Platform::XDP {
- 

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,7 +1,6 @@
-VER=4.10.1
-REL=1
+VER=4.11.6
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
-OWTVER=592b14d13bf9103226e90a83571e24c49f6bfdcd
+OWTVER=71cce98c5fb1d9328892d55f70db711afd5b1aef
 SRCS="git::rename=tdesktop;commit=tags/v$VER::https://github.com/telegramdesktop/tdesktop \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

update telegram-desktop to 4.11.6

Package(s) Affected
-------------------

`telegram-desktop` v4.11.6

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
