### PR TITLE
fcitx5-pinyin-moegirl: update to 20231114

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20231014
+VER=20231114
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::34907c627a17dbc38da25ac55ea5319fc8c4211a39570114c852556da84ca866 \
-         sha256::8ded66335b3b8f8a1435233a0e33b3488226369f3a976adc517bf4b87855f22e \
+CHKSUMS="sha256::c7e5e401388d30d6dc4a237cecc91146f2a236ecefa66903aed1a4c1d9c8b183 \
+         sha256::c840b5135d67f529323e15bf255a56b92e71a62f1c2eb05c42375e066cc95c9d \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Upgrade `fcitx5-pinyin-moegirl` to 20231114.

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`