### PR TITLE
discord: update to 0.0.35

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.34
+VER=0.0.35
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::b672abec351ee016c914e5418318b0c1ac959d50068e683c8028800338b55e65"
+CHKSUMS="sha256::55c49157d2c38945ddb91b76d2455e027c229e5e85980090827fff5ba785cb2b"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This topic updates Discord to 0.0.35.

Package(s) Affected
-------------------

`discord` v0.0.35

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
