### PR TITLE
libicns: new, 0.8.1

### DIFF
--- a/runtime-imaging/libicns/autobuild/defines
+++ b/runtime-imaging/libicns/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=libicns
+PKGSEC=libs
+PKGDEP="jasper libpng"
+PKGDES="Library and tools for manipulating Macintosh .icns files"
+
+# This package is often used for its tools, provide icnsutils and icns-utils to
+# help avoid confusion.
+PKGPROV="icnsutils icns-utils"

--- a/runtime-imaging/libicns/spec
+++ b/runtime-imaging/libicns/spec
@@ -1,0 +1,4 @@
+VER=0.8.1
+SRCS="tbl::https://sourceforge.net/projects/icns/files/libicns-$VER.tar.gz"
+CHKSUMS="sha256::335f10782fc79855cf02beac4926c4bf9f800a742445afbbf7729dab384555c2"
+CHKUPDATE="anitya::id=21940"


### PR DESCRIPTION
Topic Description
-----------------

This topic introduces `libicns`, library and tools for manipulating Macintosh .icns files.

Package(s) Affected
-------------------

`libicns` v0.8.1

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
