### PR TITLE
telegram-desktop: update to 4.11.8

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,9 +1,9 @@
-VER=4.11.6
+VER=4.11.8
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
-OWTVER=71cce98c5fb1d9328892d55f70db711afd5b1aef
-SRCS="git::rename=tdesktop;commit=tags/v$VER::https://github.com/telegramdesktop/tdesktop \
+OWTVER=76a3513d7f25d6623d92463fbe6470d9001b66a8
+SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt"
-CHKSUMS="SKIP \
+CHKSUMS="sha256::55920d2b6e55acef6e0d77d529e2ebf972acb07343b5a4ca95924caf2b70d805 \
          SKIP"
-SUBDIR="tdesktop"
+SUBDIR="tdesktop-$VER-full"
 CHKUPDATE="anitya::id=16951"


### PR DESCRIPTION
Topic Description
-----------------

telegram-desktop: update to 4.11.8

Package(s) Affected
-------------------

`telegram-desktop`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [X] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
