### PR TITLE
libnvme: new, 1.6

### DIFF
--- a/app-admin/nvme-cli/autobuild/defines
+++ b/app-admin/nvme-cli/autobuild/defines
@@ -1,9 +1,10 @@
 PKGNAME=nvme-cli
 PKGSEC=admin
-PKGDEP="systemd"
+PKGDEP="systemd libnvme json-c"
 PKGDES="NVMe management command line interface"
 
 # No point in re-generating documentations if the source tree provides it.
-MESON_AFTER="-Dhtmldir=/usr/share/doc/$PKGNAME/html \
+MESON_AFTER="-Dsysconfdir=/etc -Djson-c=enabled \
+             -Dhtmldir=/usr/share/doc/$PKGNAME/html \
              -Ddocs=all \
              -Ddocs-build=false"

--- a/app-admin/nvme-cli/spec
+++ b/app-admin/nvme-cli/spec
@@ -1,5 +1,4 @@
-VER=2.2.1
-REL=1
-SRCS="https://github.com/linux-nvme/nvme-cli/archive/v$VER.tar.gz"
-CHKSUMS="sha256::68720bc25c68adb93dafe1186de4fabbe40f8390ff1416256b52fe74f78259ae"
+VER=2.6
+SRCS="git::commit=tags/v${VER}::https://github.com/linux-nvme/nvme-cli.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9074"

--- a/runtime-devices/libnvme/autobuild/defines
+++ b/runtime-devices/libnvme/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=libnvme
+PKGDES="Library for NVMe protocol definition"
+PKGSEC=libs
+PKGDEP="dbus json-c"
+BUILDDEP="swig"
+
+PKGBREAK="nvme-cli<=2.2.1-0"
+PKGREP="nvme-cli<=2.2.1-0"

--- a/runtime-devices/libnvme/spec
+++ b/runtime-devices/libnvme/spec
@@ -1,0 +1,4 @@
+VER=1.6
+SRCS="git::commit=tags/v${VER}::https://github.com/linux-nvme/libnvme.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=242763"


### PR DESCRIPTION
Topic Description
-----------------

Add libnvme package (and make nvme-cli use it).

Package(s) Affected
-------------------

- `libnvme`: new
- `nvme-cli`: version updated, dependencies added

Security Update?
----------------

No

Build Order
-----------

`libnvme nvme-cli`

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`