### PR TITLE
cryptography: update to 40.0.0

### DIFF
--- a/lang-python/cryptography/autobuild/defines
+++ b/lang-python/cryptography/autobuild/defines
@@ -6,12 +6,10 @@ BUILDDEP="setuptools setuptools-rust appdirs wheel rustc llvm typing-extensions"
 
 NOPYTHON2=1
 ABTYPE=python
-NOLTO__RISCV64=1
-# FIXME: No lld support, thus no LTO.
-NOLTO__LOONGARCH64=1
-NOLTO__MIPS64R6EL=1
+# Rust extension broken with LTO
+# See also: https://bugs.gentoo.org/903908 & https://github.com/pyca/cryptography/issues/9023
+NOLTO=1
 
 # FIXME: Signal 11 on linkage.
 USECLANG__LOONGSON3=0
-NOLTO__LOONGSON3=1
 ABSPLITDBG__LOONGSON3=0

--- a/lang-python/cryptography/spec
+++ b/lang-python/cryptography/spec
@@ -1,5 +1,4 @@
-VER=39.0.2
+VER=40.0.0
 SRCS="https://pypi.io/packages/source/c/cryptography/cryptography-$VER.tar.gz"
-CHKSUMS="sha256::bc5b871e977c8ee5a1bbc42fa8d19bcc08baf0c51cbf1586b0e87a2694dde42f"
+CHKSUMS="sha256::f421f6777592eb199ca8abac7c20b9ecef27c50ad63546e6c614b29771b46d0d"
 CHKUPDATE="anitya::id=5532"
-REL=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

cryptography: update to 40.0.0

- Disable LTO for all because mixing GCC LTO and LLVM LTO is known to have issues even on x86_64.

Package(s) Affected
-------------------

cryptography 40.0.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
