### PR TITLE
aoscdk-rs: update to 0.10.0

### DIFF
--- a/app-admin/aoscdk-rs/autobuild/patches/0001-fix-ppc64el-build.patch
+++ b/app-admin/aoscdk-rs/autobuild/patches/0001-fix-ppc64el-build.patch
@@ -1,0 +1,21 @@
+From 622261b820e17e6ef376c3a12c31b63cc8562339 Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Thu, 30 Nov 2023 11:26:18 +0800
+Subject: [PATCH] fix: remove useless line to fix `ppc64el` arch build
+
+---
+ src/network.rs | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/network.rs b/src/network.rs
+index 89bf93a..e8ca04b 100644
+--- a/src/network.rs
++++ b/src/network.rs
+@@ -131,7 +131,6 @@ pub fn get_variants() -> Result<Vec<VariantEntry>> {
+ #[cfg(target_arch = "powerpc64")]
+ #[inline]
+ pub(crate) fn get_arch_name() -> Option<&'static str> {
+-    use nix::libc;
+     let mut endian: libc::c_int = -1;
+     let result;
+     unsafe {

--- a/app-admin/aoscdk-rs/spec
+++ b/app-admin/aoscdk-rs/spec
@@ -1,5 +1,4 @@
-VER=0.9.6
+VER=0.10.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscdk-rs/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226678"
-REL=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

aoscdk-rs: update to 0.10.0

Package(s) Affected
-------------------
aoscdk-rs: update to 0.10.0

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->



Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
