### PR TITLE
hwinfo: update to 23.2

### DIFF
--- a/app-utils/hwinfo/autobuild/build
+++ b/app-utils/hwinfo/autobuild/build
@@ -7,3 +7,7 @@ make install \
     GIT2LOG=/usr/bin/true \
     DESTDIR="$PKGDIR" \
     LIBDIR=/usr/lib
+
+abinfo "Moving sbin to bin ..."
+rm -rf "$PKGDIR/sbin"
+mv "$PKGDIR/usr/sbin" "$PKGDIR/usr/bin"

--- a/app-utils/hwinfo/autobuild/build
+++ b/app-utils/hwinfo/autobuild/build
@@ -9,5 +9,5 @@ make install \
     LIBDIR=/usr/lib
 
 abinfo "Moving sbin to bin ..."
-rm -rf "$PKGDIR/sbin"
-mv "$PKGDIR/usr/sbin" "$PKGDIR/usr/bin"
+rm -rvf "$PKGDIR/sbin"
+mv -v "$PKGDIR/usr/sbin" "$PKGDIR/usr/bin"

--- a/app-utils/hwinfo/spec
+++ b/app-utils/hwinfo/spec
@@ -1,4 +1,4 @@
-VER=21.70
+VER=23.2
 SRCS="git::commit=tags/$VER::https://github.com/openSUSE/hwinfo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13400"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

hwinfo: update to 23.2
This version supports LoongArch.

Package(s) Affected
-------------------

hwinfo 23.2

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
