### PR TITLE
superslicer: update to 2.5.59.3

### DIFF
--- a/app-creativity/superslicer/spec
+++ b/app-creativity/superslicer/spec
@@ -1,4 +1,4 @@
-VER=2.5.59.2
+VER=2.5.59.3
 SRCS="git::commit=tags/${VER}::https://github.com/supermerill/SuperSlicer.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=supermerill/SuperSlicer"


### PR DESCRIPTION
Topic Description
-----------------

Update SuperSlicer to 2.5.59.3. Upstream added some bugfix and changed some UI.

Package(s) Affected
-------------------

- `superslicer`

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
