### PR TITLE
clash: (no-build) use aosc-repacks; upstream tarball gone

### DIFF
--- a/app-network/clash/spec
+++ b/app-network/clash/spec
@@ -1,4 +1,4 @@
 VER=1.18.0
-SRCS="https://github.com/Dreamacro/clash/archive/v$VER.tar.gz"
+SRCS="https://repo.aosc.io/aosc-repacks/clash-1.18.0.tar.gz"
 CHKSUMS="sha256::139794f50d3d94f438bab31a993cf25d7cbdf8ca8e034f3071e0dd0014069692"
 CHKUPDATE="anitya::id=211719"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

clash: update SRC URL
(To help bringing riscv64 up-to-date)

Package(s) Affected
-------------------

clash

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No
