### PR TITLE
telegram-desktop: update to 4.12.2

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,9 +1,9 @@
-VER=4.11.8
+VER=4.12.2
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=76a3513d7f25d6623d92463fbe6470d9001b66a8
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::55920d2b6e55acef6e0d77d529e2ebf972acb07343b5a4ca95924caf2b70d805 \
+CHKSUMS="sha256::7e9e51ae9c40d5b8c964bcfe0e252e35980c6668327934d2270144405c519914 \
          SKIP"
 SUBDIR="tdesktop-$VER-full"
 CHKUPDATE="anitya::id=16951"


### PR DESCRIPTION
Topic Description
-----------------

Update telegram-desktop to 4.12.2

Package(s) Affected
-------------------

`telegram-desktop` v4.12.2

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
