### PR TITLE
m4ri: update to  20200125

### DIFF
--- a/runtime-scientific/m4ri/spec
+++ b/runtime-scientific/m4ri/spec
@@ -1,5 +1,4 @@
-VER=20140914
-REL=1
-SRCS="tbl::https://src.fedoraproject.org/repo/pkgs/m4ri/m4ri-20140914.tar.gz/91d964b6c6754499da81277433605199/m4ri-20140914.tar.gz"
-CHKSUMS="sha256::4bc3f53a5116e1ff0720c08f34ce415c88e2fb503437abfd15e196792ec6d5aa"
+VER=20200125
+SRCS="https://bitbucket.org/malb/m4ri/downloads/m4ri-$VER.tar.gz"
+CHKSUMS="sha256::0dfb34aed351882a0f2281535ea6f81c690a5efeb14edab131d9ba0dffe44863"
 CHKUPDATE="anitya::id=7719"

--- a/runtime-scientific/m4rie/spec
+++ b/runtime-scientific/m4rie/spec
@@ -1,4 +1,4 @@
-VER=20150908
+VER=20200125
 SRCS="tbl::https://bitbucket.org/malb/m4rie/downloads/m4rie-$VER.tar.gz"
-CHKSUMS="sha256::a0c3f46c399ed2e4af5aaad9de9db0962d15d5ccb9bd0e313df6b2c16bf8e0b1"
+CHKSUMS="sha256::7f3107f7cd10f6c22d9663d9536e1af2f551e10183601852a60d760918caf58d"
 CHKUPDATE="anitya::id=7720"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

This PR updates `m4ri` and its extended variant to version 20200125

Package(s) Affected
-------------------

```
m4ri m4rie
```

Security Update?
----------------

No


Build Order
-----------


```
m4ri m4rie
```


Test Build(s) Done
------------------

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
