### PR TITLE
nano: update to 7.2

### DIFF
--- a/app-editors/nano/spec
+++ b/app-editors/nano/spec
@@ -1,7 +1,8 @@
-VER=7.0+nanorc20221128
+NANORC_VER=20230126
+VER=7.2+nanorc${NANORC_VER}
 SRCS="tbl::https://www.nano-editor.org/dist/v${VER:0:1}/nano-${VER%%+nanorc*}.tar.xz \
-      git::rename=nanorc;commit=dc2a35ac3c3bfae5ba27caad52d303fee16fd4d2::https://github.com/Quentium-Forks/nanorc"
-CHKSUMS="sha256::8dd6eac38b2b8786d82681f0e1afd84f6b75210d17391b6443c437e451552149 \
+      git::rename=nanorc;commit=3883874e48b725b09ec4f19b7d566785ed87e0b4::https://github.com/Quentium-Forks/nanorc"
+CHKSUMS="sha256::86f3442768bd2873cec693f83cdf80b4b444ad3cc14760b74361474fc87a4526 \
          SKIP"
 CHKUPDATE="anitya::id=2046"
 SUBDIR="nano-${VER%%+nanorc*}"


### PR DESCRIPTION
Topic Description
-----------------
This PR updates nano to version 7.2.

Package(s) Affected
-------------------
```
nano
```

Security Update?
----------------
No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
