### PR TITLE
Wine Vulkan Gaming Survey (December 2023)

### DIFF
--- a/app-emulation/wine/autobuild/amd64/build
+++ b/app-emulation/wine/autobuild/amd64/build
@@ -1,6 +1,6 @@
 abinfo "Applying Wine Staging patches ..."
 ln -sv "$SRCDIR" "$SRCDIR"/../wine-staging/patches/wine
-"$SRCDIR"/../wine-staging/patches/patchinstall.sh DESTDIR="$SRCDIR" --all
+"$SRCDIR"/../wine-staging/staging/patchinstall.py DESTDIR="$SRCDIR" --all
 
 export CC="gcc-multilib-wrapper" CXX="g++-multilib-wrapper"
 

--- a/app-emulation/wine/autobuild/beyond
+++ b/app-emulation/wine/autobuild/beyond
@@ -1,4 +1,4 @@
-abinfo "Deleting rpath from Wine executables ..."
 for i in wmc wrc wine64 wineserver; do
+    abinfo "Deleting rpath from '$i'..."
     test -e "$PKGDIR"/usr/bin/$i && chrpath --delete "$PKGDIR"/usr/bin/$i
 done

--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,8 +1,7 @@
-VER=7.22
-REL=1
+VER=8.21
 SRCS="tbl::https://dl.winehq.org/wine/source/${VER:0:1}.x/wine-$VER.tar.xz \
       git::rename=wine-staging;commit=tags/v$VER::https://github.com/wine-staging/wine-staging"
-CHKSUMS="sha256::1f2ac3b2cdf66c49bf145b43e7a3f30e6d8176d0ae498056c903fef8a6ccfc3a \
+CHKSUMS="sha256::02d6493f348168268669b62d4795df5b335be9ae06229c68f388a093d0d6b61d \
          SKIP"
 CHKUPDATE="anitya::id=15657"
 SUBDIR="wine-$VER"

--- a/app-emulation/winetricks-zh/spec
+++ b/app-emulation/winetricks-zh/spec
@@ -1,4 +1,4 @@
-VER=20210206.1
+VER=20220411.100
 SRCS="git::commit=tags/$VER::https://github.com/hillwoodroc/winetricks-zh/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227369"

--- a/app-emulation/winetricks/spec
+++ b/app-emulation/winetricks/spec
@@ -1,4 +1,4 @@
-VER=20220411
+VER=20230212
 SRCS="tbl::https://github.com/Winetricks/winetricks/archive/$VER.tar.gz"
-CHKSUMS="sha256::c16e09ee4e5fda48a49ae9515a9c6d175713792be1b85ea92624d93e37effbd0"
+CHKSUMS="sha256::2b1b5e540a9941e602dde2ed27d0eb2c80dcba45d8021fed95b39b32438b4ea3"
 CHKUPDATE="anitya::id=7258"

--- a/runtime-display/vkd3d/autobuild/defines
+++ b/runtime-display/vkd3d/autobuild/defines
@@ -3,3 +3,7 @@ PKGDES="Direct3D 12 to Vulkan translation library By WineHQ"
 PKGDEP="glibc"
 PKGSEC="libs"
 BUILDDEP="vulkan xcb-util-keysyms spirv-tools"
+
+AUTOTOOLS_AFTER=(
+	--with-spirv-tools
+)

--- a/runtime-display/vkd3d/spec
+++ b/runtime-display/vkd3d/spec
@@ -1,4 +1,5 @@
 VER=1.9
+REL=1
 SRCS="tbl::https://dl.winehq.org/vkd3d/source/vkd3d-${VER}.tar.xz"
 CHKSUMS="sha256::9d1ebc6f36cccf40cffda3176851f73a0501b90c4d04e782abe79ca703057a4b"
 CHKUPDATE="anitya::id=230555"

--- a/runtime-display/vulkan-headers/spec
+++ b/runtime-display/vulkan-headers/spec
@@ -1,4 +1,4 @@
-VER=1.3.269
+VER=1.3.272
 SRCS="git::commit=tags/v$VER::https://github.com/KhronosGroup/Vulkan-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88835"

--- a/runtime-display/vulkan-loader/spec
+++ b/runtime-display/vulkan-loader/spec
@@ -1,4 +1,4 @@
-VER=1.3.269
+VER=1.3.272
 SRCS="git::commit=tags/v$VER::https://github.com/KhronosGroup/Vulkan-Loader"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230557"

--- a/runtime-optenv32/vkd3d+32/autobuild/build
+++ b/runtime-optenv32/vkd3d+32/autobuild/build
@@ -10,7 +10,8 @@ mkdir abbuild
 	export LDFLAGS="$LDFLAGS -L/opt/32/lib"
 	../configure \
 		--prefix=/opt/32 \
-		--exec-prefix=/opt/32
+		--exec-prefix=/opt/32 \
+		--with-ncurses
 )
 make -C abbuild $MAKE_DEF
 DESTDIR="$PKGDIR" make -C abbuild install

--- a/runtime-optenv32/vkd3d+32/spec
+++ b/runtime-optenv32/vkd3d+32/spec
@@ -1,5 +1,4 @@
-VER=1.5
-REL=1
+VER=1.9
 SRCS="tbl::https://dl.winehq.org/vkd3d/source/vkd3d-${VER}.tar.xz"
-CHKSUMS="sha256::e3b3c355f46f7cbfc19e710a478bcb2bee267a5f360e7e6406238cea52ce2cfc"
+CHKSUMS="sha256::9d1ebc6f36cccf40cffda3176851f73a0501b90c4d04e782abe79ca703057a4b"
 CHKUPDATE="anitya::id=230555"

--- a/runtime-optenv32/vulkan-headers+32/autobuild/defines
+++ b/runtime-optenv32/vulkan-headers+32/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=vulkan-headers+32
 PKGSEC=libs
 PKGDEP=""
 PKGDES="Vulkan header files and API registry (optenv32)"
+BUILDDEP="gcc+32"
 
 ABHOST=noarch
 

--- a/runtime-optenv32/vulkan-headers+32/spec
+++ b/runtime-optenv32/vulkan-headers+32/spec
@@ -1,4 +1,4 @@
-VER=1.3.227
-SRCS="tbl::https://github.com/KhronosGroup/Vulkan-Headers/archive/v$VER.tar.gz"
-CHKSUMS="sha256::5b345a9f0dafc96e4d0cd2d95547702c4451691dc731f6b486ba36fd9bab7bfe"
+VER=1.3.272
+SRCS="git::commit=tags/v$VER::https://github.com/KhronosGroup/Vulkan-Headers"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88835"

--- a/runtime-optenv32/vulkan-loader+32/autobuild/defines
+++ b/runtime-optenv32/vulkan-loader+32/autobuild/defines
@@ -6,7 +6,7 @@ PKGDES="Vulkan Installable Client Driver (ICD) Loader (optenv32)"
 
 CMAKE_AFTER="-DBUILD_LOADER=ON \
              -DBUILD_WSI_XCB_SUPPORT=ON \
-             -DBUILD_WSI_XLIB_SUPPORT=OFF \
+             -DBUILD_WSI_XLIB_SUPPORT=ON \
              -DBUILD_WSI_WAYLAND_SUPPORT=ON \
              -DBUILD_WSI_DIRECTFB_SUPPORT=OFF \
              -DVulkanRegistry_DIR=/usr/share"

--- a/runtime-optenv32/vulkan-loader+32/spec
+++ b/runtime-optenv32/vulkan-loader+32/spec
@@ -1,4 +1,4 @@
-VER=1.3.236
-SRCS="tbl::https://github.com/KhronosGroup/Vulkan-Loader/archive/v$VER.tar.gz"
-CHKSUMS="sha256::c18434976d6e67c3c1d5cfdfa630046e698402d1f666ff5094de1fcd3a012b0d"
+VER=1.3.272
+SRCS="git::commit=tags/v$VER::https://github.com/KhronosGroup/Vulkan-Loader"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230557"


### PR DESCRIPTION
Topic Description
-----------------

This PR updates a few packages needed to run 32bit wine applications with dxvk.

Package(s) Affected
-------------------

- vulkan-headers [noarch]
- vulkan-headers+32 [noarch]
- vulkan-loader
- vulkan-loader+32 [noarch, build on amd64 only]
- vkd3d
- vkd3d+32 [noarch, build on amd64 only]
- wine [amd64 arm64 only]
- winetricks [noarch]
- winetricks-zh [noarch]

Build Order
-----------

#buildit vulkan-headers vulkan-headers+32 vulkan-loader vulkan-loader+32 vkd3d vkd3d+32 wine winetricks winetricks-zh

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
