### PR TITLE
mimalloc: various improvements

### DIFF
--- a/runtime-common/mimalloc/autobuild/defines
+++ b/runtime-common/mimalloc/autobuild/defines
@@ -6,4 +6,9 @@ PKGDEP="glibc"
 # Default behavior (-DMI_INSTALL_TOPLEVEL=OFF) puts libraries inside a 
 # sub-directory in /usr/lib, which will cause unnecessary rebuilds on update.
 # Use -DMI_INSTALL_TOPLEVEL=ON to install libraries in /usr/lib.
-CMAKE_AFTER="-DMI_INSTALL_TOPLEVEL=ON"
+# Building static libraries will put the static libraries in the generated
+# cmake files, which will break when we strip them off. Use -DMI_BUILD_STATIC=OFF
+# to turn it off.
+# Building object file will put the object file in /usr/lib which
+# is unnecessary. Use -DMI_BUILD_OBJECT=OFF to turn it off.
+CMAKE_AFTER="-DMI_INSTALL_TOPLEVEL=ON -DMI_BUILD_STATIC=OFF -DMI_BUILD_OBJECT=OFF"

--- a/runtime-common/mimalloc/spec
+++ b/runtime-common/mimalloc/spec
@@ -2,3 +2,4 @@ VER=2.1.2
 SRCS="git::commit=tags/v$VER::https://github.com/microsoft/mimalloc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=233872"
+REL=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

mimalloc: various improvements

Disable building of static libraries and objects.

Package(s) Affected
-------------------

mimalloc

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
