### PR TITLE
MIPS64 R6 Survey 20231214

### DIFF
--- a/app-multimedia/aubio/autobuild/build
+++ b/app-multimedia/aubio/autobuild/build
@@ -1,12 +1,19 @@
 # FIXME: Currently due to Loongson chips' bug with LL/SC, all
 # binaries including unit tests will stuck on exit.
 if [[ "${ARCH}" == "mips64el" ]]; then
+    abinfo "Disabling tests for mips64el ..."
     export MIPS_NOTESTS="--notests"
 fi
 
-python2 waf configure --prefix=/usr --enable-fftw3f $MIPS_NOTESTS
-python2 waf build $MAKEFLAGS $MIPS_NOTESTS
-python2 waf --destdir="$PKGDIR" install $MIPS_NOTESTS
+abinfo "Configuring aubio ..."
+python3 "$SRCDIR"/waf configure --prefix=/usr --libdir=/usr/lib --enable-fftw3f $MIPS_NOTESTS
 
-python2 setup.py build
-python2 setup.py install --root="$PKGDIR" --optimize=1
+abinfo "Building aubio ..."
+python3 "$SRCDIR"/waf build $MAKEFLAGS $MIPS_NOTESTS
+
+abinfo "Installing aubio ..."
+python3 "$SRCDIR"/waf --destdir="$PKGDIR" install $MIPS_NOTESTS
+
+abinfo "Building Python bindings ..."
+python3 "$SRCDIR"/setup.py build
+python3 "$SRCDIR"/setup.py install --root="$PKGDIR" --optimize=1

--- a/app-multimedia/aubio/spec
+++ b/app-multimedia/aubio/spec
@@ -1,5 +1,5 @@
 VER=0.4.9
+REL=3
 SRCS="tbl::https://aubio.org/pub/aubio-$VER.tar.bz2"
 CHKSUMS="sha256::d48282ae4dab83b3dc94c16cf011bcb63835c1c02b515490e1883049c3d1f3da"
-REL=2
 CHKUPDATE="anitya::id=10301"

--- a/app-multimedia/xjadeo/spec
+++ b/app-multimedia/xjadeo/spec
@@ -1,5 +1,4 @@
-VER=0.8.9
+VER=0.8.13
 SRCS="tbl::https://downloads.sourceforge.net/xjadeo/xjadeo-$VER.tar.gz"
-CHKSUMS="sha256::47b7aeb9d0a82178a72944bac31b3934afee620fb05eefb625f6f3f085d266f1"
-REL=1
+CHKSUMS="sha256::ac4b28831a0e4a0934ee61341027b18bf8a5fbbb040ae749b9487a003803195b"
 CHKUPDATE="anitya::id=14469"

--- a/runtime-multimedia/liblo/autobuild/prepare
+++ b/runtime-multimedia/liblo/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Disable warning as error to prevent build errors ..."
+export CFLAGS="${CFLAGS} -Wno-error=use-after-free"

--- a/runtime-multimedia/liblo/spec
+++ b/runtime-multimedia/liblo/spec
@@ -1,4 +1,5 @@
 VER=0.29
+REL=1
 SRCS="tbl::https://downloads.sourceforge.net/liblo/liblo-$VER.tar.gz"
 CHKSUMS="sha256::ace1b4e234091425c150261d1ca7070cece48ee3c228a5612d048116d864c06a"
 CHKUPDATE="anitya::id=21483"


### PR DESCRIPTION
Topic Description
-----------------

This PR provides mips64r6el with an additional package called 'ardour' and addresses build failures encountered on the dependency chain.

Package(s) Affected
-------------------

liblo aubio xjadeo

Security Update?
----------------
No

Build Order
-----------

liblo aubio xjadeo 

Test Build(s) Done
------------------

**Primary Architectures**
- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**
<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
