### PR TITLE
oma: update to 1.2.6

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,5 +1,4 @@
-VER=1.2.5
+VER=1.2.6
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

oma

Package(s) Affected
-------------------

oma

Security Update?
----------------

No


Build Order
-----------


```
oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
 
<!-- - [ ] 32-bit Optional Environment `optenv32` -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`