### PR TITLE
acbs: update to 20231217.4

### DIFF
--- a/app-devel/acbs/spec
+++ b/app-devel/acbs/spec
@@ -1,5 +1,4 @@
-VER=20221105
-REL=1
-SRCS="git::commit=ebb28b6405a797ad812c4369abdefb17bfd7bb3d::https://github.com/AOSC-Dev/acbs"
+VER=20231217.4
+SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/acbs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226984"


### PR DESCRIPTION
Topic Description
-----------------

This topic updates ACBS to 20231217.4 with fixes and new features (including improved build summary output).

Package(s) Affected
-------------------

`acbs` v20231217.4

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`