### PR TITLE
oma: fix 1.2.6 version bump

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,7 @@
 VER=1.2.6
-SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
+# FIXME: 1.2.6 has no bump version in Cargo.toml
+SRCS="git::commit=f79ea4b186315dc81a59074793c30c9fee3ca901::https://github.com/AOSC-Dev/oma"
+#SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

oma

Package(s) Affected
-------------------

oma

Security Update?
----------------

No


Build Order
-----------


```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
 
<!-- - [ ] 32-bit Optional Environment `optenv32` -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`