### PR TITLE
MIPS64 R6 Survey 20231214 Rework

### DIFF
--- a/runtime-multimedia/liblo/autobuild/patches/0000-configure-ac-fix-werror-detection.patch
+++ b/runtime-multimedia/liblo/autobuild/patches/0000-configure-ac-fix-werror-detection.patch
@@ -1,0 +1,20 @@
+diff --git a/configure.ac b/configure.ac
+index 0633284..fa7c1d0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -143,11 +143,11 @@ fi
+ 
+ # Filter out -Werror temporarily, otherwise library checks can fail
+ CFLAGS_nowerror="`echo $CFLAGS | sed 's/-Werror\([^=]\|$\)//'`"
+-if test "$CFLAGS" = "$CFLAGS_nowerror"; then
+-  CFLAGS_werror=
+-else
++if echo $CFLAGS | grep -q -- "Werror"; then
+   CFLAGS_werror=" -Werror"
+-  CFLAGS="$CFLAGS_nowerror"
++  CFLAGS="$CFLAGS_noweror"
++else
++  CFLAGS_werror=
+ fi
+ 
+ # Checks for libraries.

--- a/runtime-multimedia/liblo/autobuild/prepare
+++ b/runtime-multimedia/liblo/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo "Disable warning as error to prevent build errors ..."
-export CFLAGS="${CFLAGS} -Wno-error=use-after-free"


### PR DESCRIPTION
Topic Description
-----------------

This PR is a fix for r6-survey-hrh-20231214 PR.

Package(s) Affected
-------------------

```
liblo
```

Security Update?
----------------

No

Build Order
----------------

```
liblo
```

Test Build(s) Done
------------------

**Primary Architectures**


- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`


**Secondary Architectures**


Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`


