### PR TITLE
Autotools config.* Replacement Survey 20231219

### DIFF
--- a/app-devel/php/autobuild/prepare
+++ b/app-devel/php/autobuild/prepare
@@ -6,3 +6,12 @@ sed -e '/APACHE_THREADED_MPM=/d' \
 abinfo "Setting $PKGVER in postinst ..."
 sed -e "s/TEMPVER/$PKGVER/g" \
     -i "$SRCDIR"/autobuild/postinst
+
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
+    abinfo "Copying replacement $i ..."
+    # FIXME: hard-coded automake version.
+    # Adapted from redhat-rpm-config.
+    # https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/rawhide/f/macros#_192
+        cp -v "/usr/share/automake-1.16/$(basename "$i")" "$i" \
+            || abdie "Failed to copy replacement $i: $?."; \
+done

--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,4 +1,5 @@
 VER=8.2.8
+REL=1
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
 CHKSUMS="sha256::cfe1055fbcd486de7d3312da6146949aae577365808790af6018205567609801"
 CHKUPDATE="anitya::id=3627"

--- a/app-doc/ghostscript/autobuild/prepare
+++ b/app-doc/ghostscript/autobuild/prepare
@@ -1,2 +1,24 @@
-rm -rf jpeg libpng zlib jasper expat tiff lcms lcms2 freetype cups/libs
-autoreconf -fi
+abinfo "Dropping bundled dependencies ..."
+rm -rfv \
+    "$SRCDIR"/jpeg \
+    "$SRCDIR"/libpng \
+    "$SRCDIR"/zlib \
+    "$SRCDIR"/jasper \
+    "$SRCDIR"/expat \
+    "$SRCDIR"/tiff \
+    "$SRCDIR"/lcms \
+    "$SRCDIR"/lcms2 \
+    "$SRCDIR"/freetype \
+    "$SRCDIR"/cups/libs
+
+abinfo "Re-configuring Autotools scripts ..."
+autoreconf -fvi
+
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
+    abinfo "Copying replacement $i ..."
+    # FIXME: hard-coded automake version.
+    # Adapted from redhat-rpm-config.
+    # https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/rawhide/f/macros#_192
+    cp -v "/usr/share/automake-1.16/$(basename "$i")" "$i" \
+        || abdie "Failed to copy replacement $i: $?."; \
+done

--- a/app-doc/ghostscript/spec
+++ b/app-doc/ghostscript/spec
@@ -1,5 +1,5 @@
 VER=9.54.0
-REL=1
+REL=2
 SRCS="tbl::https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${VER//./}/ghostscript-$VER.tar.gz"
 CHKSUMS="sha256::0646bb97f6f4d10a763f4919c54fa28b4fbdd3dff8e7de3410431c81762cade0"
 CHKUPDATE="anitya::id=1157"

--- a/app-electronics/ngspice/autobuild/prepare
+++ b/app-electronics/ngspice/autobuild/prepare
@@ -1,0 +1,8 @@
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
+    abinfo "Copying replacement $i ..."
+    # Adapted from redhat-rpm-config.
+    # https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/rawhide/f/macros#_192
+    # Note: config.guess and config.sub provided by the 'config' package.
+    cp -v "/usr/bin/$(basename "$i")" "$i" \
+        || abdie "Failed to copy replacement $i: $?."; \
+done

--- a/app-electronics/ngspice/spec
+++ b/app-electronics/ngspice/spec
@@ -1,4 +1,5 @@
 VER=35
+REL=1
 SRCS="tbl::https://repo.aosc.io/aosc-repacks/ngspice-$VER.tar.gz"
 CHKSUMS="sha256::c1b7f5c276db579acb3f0a7afb64afdeb4362289a6cab502d4ca302d6e5279ec"
 CHKUPDATE="anitya::id=20590"

--- a/app-scientific/r/autobuild/prepare
+++ b/app-scientific/r/autobuild/prepare
@@ -1,3 +1,9 @@
 export CFLAGS="${CFLAGS} -fPIC"
 export CXXFLAGS="${CXXFLAGS} -fPIC"
 export LDFLAGS="${LDFLAGS} -fPIC"
+
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do
+    abinfo "Copying replacement $i ..."
+    cp -v "/usr/bin/$(basename "$i")" "$i" \
+        || abdie "Failed to copy replacement $i: $?.";
+done

--- a/app-scientific/r/spec
+++ b/app-scientific/r/spec
@@ -1,4 +1,5 @@
 VER=4.3.1
+REL=1
 SRCS="tbl::http://cran.mirrors.hoobly.com/src/base/R-${VER:0:1}/R-$VER.tar.gz"
 CHKSUMS="sha256::8dd0bf24f1023c6f618c3b317383d291b4a494f40d73b983ac22ffea99e4ba99"
 CHKUPDATE="anitya::id=4150"

--- a/app-web/pidgin/01-libpurple/build
+++ b/app-web/pidgin/01-libpurple/build
@@ -1,3 +1,9 @@
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do
+    abinfo "Copying replacement $i ..."
+    cp -v "/usr/bin/$(basename "$i")" "$i" \
+        || abdie "Failed to copy replacement $i: $?.";
+done
+
 abinfo "Configuring Pidgin ..."
 "$SRCDIR"/configure ${AUTOTOOLS_DEF} ${AUTOTOOLS_AFTER}
 

--- a/app-web/pidgin/spec
+++ b/app-web/pidgin/spec
@@ -1,4 +1,5 @@
 VER=2.14.12
+REL=1
 SRCS="https://downloads.sourceforge.net/project/pidgin/Pidgin/$VER/pidgin-$VER.tar.bz2"
 CHKSUMS="sha256::2b05246be208605edbb93ae9edc079583d449e2a9710db6d348d17f59020a4b7"
 CHKUPDATE="anitya::id=3636"

--- a/desktop-gnome/libgweather/autobuild/defines
+++ b/desktop-gnome/libgweather/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libgweather
 PKGSEC=gnome
 PKGDEP="libsoup gtk-3 geocode-glib"
-BUILDDEP="gi-docgen glade gobject-introspection gtk-doc intltool itstool \
+BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool itstool \
           pygobject-3 pylint vala"
 PKGDES="Provides access to weather information in GNOME applications"
 

--- a/desktop-gnome/libgweather/spec
+++ b/desktop-gnome/libgweather/spec
@@ -1,4 +1,5 @@
 VER=4.1.0
+REL=1
 SRCS="tbl::https://download.gnome.org/sources/libgweather/${VER%.*}/libgweather-$VER.tar.xz"
 CHKSUMS="sha256::00bb8998e3b9a905f3a8d3295fcc15652d6b09cda5efa224e6744ded7abda65a"
 CHKUPDATE="anitya::id=13147"

--- a/desktop-gnome/yelp/autobuild/prepare
+++ b/desktop-gnome/yelp/autobuild/prepare
@@ -1,0 +1,5 @@
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do
+    abinfo "Copying replacement $i ..."
+    cp -v "/usr/bin/$(basename "$i")" "$i" \
+        || abdie "Failed to copy replacement $i: $?.";
+done

--- a/desktop-gnome/yelp/spec
+++ b/desktop-gnome/yelp/spec
@@ -1,4 +1,5 @@
 VER=42.1
+REL=1
 SRCS="https://download.gnome.org/sources/yelp/${VER%.*}/yelp-$VER.tar.xz"
 CHKSUMS="sha256::25b1146ab8549888a5a8da067f63b470b0f0f800b6ae889cacd114d01d713b41"
 CHKUPDATE="anitya::id=14867"

--- a/lang-ocaml/ocaml/autobuild/prepare
+++ b/lang-ocaml/ocaml/autobuild/prepare
@@ -1,0 +1,5 @@
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
+    abinfo "Copying replacement $i ..."
+    cp -v "/usr/bin/$(basename "$i")" "$i" \
+        || abdie "Failed to copy replacement $i: $?."; \
+done

--- a/lang-ocaml/ocaml/spec
+++ b/lang-ocaml/ocaml/spec
@@ -1,5 +1,5 @@
 VER=4.14.0
-REL=1
+REL=2
 SRCS="tbl::https://github.com/ocaml/ocaml/archive/$VER.tar.gz"
 CHKSUMS="sha256::39f44260382f28d1054c5f9d8bf4753cb7ad64027da792f7938344544da155e8"
 CHKUPDATE="anitya::id=2518"

--- a/runtime-display/glew/autobuild/build
+++ b/runtime-display/glew/autobuild/build
@@ -4,17 +4,13 @@ echo "CFLAGS.EXTRA += $CFLAGS" >> config/Makefile.linux
 abinfo "Building GLEW ..."
 make \
     STRIP= \
-    LIBDIR=/usr/lib \
-    CFLAGS.EXTRA="${CPPFLAGS} ${CFLAGS}" \
-    LDFLAGS.EXTRA="${LDFLAGS}"
+    LIBDIR=/usr/lib
 
 abinfo "Installing GLEW ..."
 make install.all \
     STRIP= \
     DESTDIR="$PKGDIR" \
-    LIBDIR=/usr/lib \
-    CFLAGS.EXTRA="${CPPFLAGS} ${CFLAGS}" \
-    LDFLAGS.EXTRA="${LDFLAGS}"
+    LIBDIR=/usr/lib
 
 abinfo "Setting executable bits for /usr/lib/*.so.* ..."
 chmod -v +x "$PKGDIR"/usr/lib/*.so.*

--- a/runtime-display/glew/autobuild/prepare
+++ b/runtime-display/glew/autobuild/prepare
@@ -1,3 +1,9 @@
 abinfo "Fixing PKGDIR name conflicts ..."
 sed -e 's|PKGDIR|PKGCONFIGDIR|g' \
     -i "$SRCDIR"/Makefile
+
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
+    abinfo "Copying replacement $i ..."
+    cp -v "/usr/bin/$(basename "$i")" "$i" \
+        || abdie "Failed to copy replacement $i: $?."; \
+done

--- a/runtime-display/glew/spec
+++ b/runtime-display/glew/spec
@@ -1,5 +1,5 @@
 VER=2.2.0
-REL=3
+REL=4
 SRCS="tbl::https://sourceforge.net/projects/glew/files/glew/$VER/glew-$VER.tgz"
 CHKSUMS="sha256::d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1"
 CHKUPDATE="anitya::id=7878"

--- a/runtime-imaging/cfitsio/autobuild/prepare
+++ b/runtime-imaging/cfitsio/autobuild/prepare
@@ -1,0 +1,5 @@
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do
+    abinfo "Copying replacement $i ..."
+    cp -v "/usr/bin/$(basename "$i")" "$i" \
+        || abdie "Failed to copy replacement $i: $?.";
+done

--- a/runtime-imaging/cfitsio/spec
+++ b/runtime-imaging/cfitsio/spec
@@ -1,5 +1,5 @@
 VER=3.450
-REL=2
+REL=3
 SRCS="tbl::https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio${VER//./}.tar.gz"
 CHKSUMS="sha256::bf6012dbe668ecb22c399c4b7b2814557ee282c74a7d5dc704eb17c30d9fb92e"
 CHKUPDATE="anitya::id=270"

--- a/runtime-scientific/fftw/autobuild/prepare
+++ b/runtime-scientific/fftw/autobuild/prepare
@@ -1,4 +1,13 @@
-chmod a-s "$SRCDIR"
 for i in fftw-${PKGVER/+/-}-{single,double,long-double,std}; do
-    cp -a fftw-${PKGVER/+/-} $i
+    abinfo "Preparing source tree for $i ..."
+    cp -av "$SRCDIR"/fftw-${PKGVER/+/-} "$SRCDIR"/$i
+done
+
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
+    abinfo "Copying replacement $i ..."
+    # FIXME: hard-coded automake version.
+    # Adapted from redhat-rpm-config.
+    # https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/rawhide/f/macros#_192
+        cp -v "/usr/share/automake-1.16/$(basename "$i")" "$i" \
+            || abdie "Failed to copy replacement $i: $?."; \
 done

--- a/runtime-scientific/fftw/spec
+++ b/runtime-scientific/fftw/spec
@@ -1,5 +1,5 @@
 VER=3.3.8
-REL=3
+REL=4
 SRCS="tbl::http://www.fftw.org/fftw-${VER/+/-}.tar.gz"
 CHKSUMS="sha256::6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303"
 CHKUPDATE="anitya::id=803"


### PR DESCRIPTION
Topic Description
-----------------

This topic introduce a few changes to packages where `config.*` replacement had to be manually invoked. These changes were introduced to fix build on the new `loongarch64` port.

This topic is part of the effort to merge #4701.

Package(s) Affected
-------------------

- `ngspice`: v35-1
- `yelp`: v42.1-1
- `pidgin`: v2.14.12-1
- `cfitsio`: v3.450-3
- `r`: v4.3.1-1
- `ocaml`: v4.14.0-2
- `fftw`: v3.3.8-4
- `glew`: v2.2.0-4
- `ghostscript`: v9.54.0-2
- `php`: v8.2.8-1
- `libgweather`: v4.1.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgweather php ghostscript glew fftw ocaml r cfitsio pidgin yelp ngspice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`