### PR TITLE
LoongArch64 Cross Toolchain

### DIFF
--- a/app-devel/binutils+cross-loongarch64/autobuild/beyond
+++ b/app-devel/binutils+cross-loongarch64/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Dropping texinfo dir ..."
+rm -v "$PKGDIR"/opt/abcross/${__CROSS}/share/info/dir

--- a/app-devel/binutils+cross-loongarch64/autobuild/build
+++ b/app-devel/binutils+cross-loongarch64/autobuild/build
@@ -1,0 +1,23 @@
+abinfo "Clearing compiler flags in environment..."
+unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
+
+abinfo "Configuring binutils..."
+mkdir -pv "$SRCDIR"/build
+cd "$SRCDIR"/build
+
+../configure \
+	--prefix=/opt/abcross/${__CROSS} \
+	--target=${__CROSS}-aosc-linux-gnu \
+	--with-sysroot=/var/ab/cross-root/${__CROSS} \
+	--enable-shared \
+	--disable-multilib \
+	--with-arch=la464 \
+	--disable-werror \
+	--disable-gold
+
+abinfo "Building binutils..."
+make configure-host
+make
+
+abinfo "Installing binutils to target directory..."
+make DESTDIR=$PKGDIR install

--- a/app-devel/binutils+cross-loongarch64/autobuild/defines
+++ b/app-devel/binutils+cross-loongarch64/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=binutils+cross-loongarch64
+PKGDEP="glibc"
+PKGSEC=devel
+PKGDES="Binutils for loongarch64 cross build"

--- a/app-devel/binutils+cross-loongarch64/autobuild/prepare
+++ b/app-devel/binutils+cross-loongarch64/autobuild/prepare
@@ -1,0 +1,5 @@
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
+    abinfo "Copying replacement $i ..."
+    cp -v "/usr/bin/$(basename "$i")" "$i" \
+        || abdie "Failed to copy replacement $i: $?."; \
+done

--- a/app-devel/binutils+cross-loongarch64/spec
+++ b/app-devel/binutils+cross-loongarch64/spec
@@ -1,0 +1,6 @@
+VER=2.40
+SRCS="tbl::https://ftp.gnu.org/gnu/binutils/binutils-$VER.tar.xz"
+CHKSUMS="sha256::0f8a4c272d7f17f369ded10a4aca28b8e304828e95526da482b0ccc4dfc9d8e1"
+CHKUPDATE="anitya::id=7981"
+
+__CROSS=loongarch64

--- a/app-devel/gcc+cross-loongarch64/autobuild/beyond
+++ b/app-devel/gcc+cross-loongarch64/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Dropping texinfo dir ..."
+rm -v "$PKGDIR"/opt/abcross/${__CROSS}/share/info/dir

--- a/app-devel/gcc+cross-loongarch64/autobuild/build
+++ b/app-devel/gcc+cross-loongarch64/autobuild/build
@@ -1,0 +1,42 @@
+abinfo "Clearing compiler flags in environment..."
+unset CFLAGS CXXFLAGS LDFLAGS CPPFLAGS
+
+abinfo "Configuring GCC..."
+mkdir -pv "$SRCDIR"/build
+cd "$SRCDIR"/build
+
+GCC_LANGS="c,c++,d,fortran,lto,objc,obj-c++"
+if ab_match_arch mips64r6el; then
+    GCC_LANGS="${GCC_LANGS/,d/}"
+fi
+
+../configure \
+	    --prefix=/opt/abcross/${__CROSS} \
+	    --target=loongarch64-aosc-linux-gnu \
+	    --with-sysroot=/var/ab/cross-root/${__CROSS} \
+	    --enable-shared \
+	    --disable-multilib \
+	    --enable-c99 \
+	    --enable-long-long \
+	    --enable-threads=posix \
+	    --enable-languages=${GCC_LANGS} \
+	    --enable-__cxa_atexit \
+            --disable-altivec \
+	    --disable-fixed-point \
+	    --with-arch=la464 \
+	    --enable-lto \
+	    --enable-gnu-unique-object \
+	    --enable-linker-build-id \
+	    --enable-libstdcxx-dual-abi \
+	    --with-default-libstdcxx-abi=new
+
+abinfo "Building gcc..."
+make AS_FOR_TARGET=/opt/abcross/${__CROSS}/bin/loongarch64-aosc-linux-gnu-as \
+     LD_FOR_TARGET=/opt/abcross/${__CROSS}/bin/loongarch64-aosc-linux-gnu-ld
+
+abinfo "Installing gcc into PKGDIR..."
+make DESTDIR="$PKGDIR" install
+
+abinfo "Installing minimal sysroot into PKGDIR..."
+mkdir -pv "$PKGDIR"/var/ab/cross-root
+cp -avP /var/ab/cross-root/${__CROSS} ${PKGDIR}/var/ab/cross-root/

--- a/app-devel/gcc+cross-loongarch64/autobuild/defines
+++ b/app-devel/gcc+cross-loongarch64/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=gcc+cross-loongarch64
+PKGSEC=devel
+PKGDEP="binutils+cross-loongarch64"
+PKGDES="GCC for loongarch64 build"
+NOSTATIC=no

--- a/app-devel/gcc+cross-loongarch64/autobuild/prepare
+++ b/app-devel/gcc+cross-loongarch64/autobuild/prepare
@@ -1,0 +1,11 @@
+abinfo "Checking if ${__CROSS} minimal sysroot is already extracted to /var/ab/cross-root/${__CROSS}..."
+if [ ! -d /var/ab/cross-root/${__CROSS} ]; then
+        abinfo "Extracting ${__CROSS} minimal sysroot ..."
+	mkdir -pv /var/ab/cross-root/${__CROSS}
+	for package in aosc-aaa linux+api glibc ; do
+		abinfo "Extracting $package..."
+		dpkg-deb -vx $SRCDIR/../$package.deb /var/ab/cross-root/${__CROSS}/
+	done
+else
+	abinfo "${__CROSS} minimal sysroot does exist, skipping."
+fi

--- a/app-devel/gcc+cross-loongarch64/spec
+++ b/app-devel/gcc+cross-loongarch64/spec
@@ -1,0 +1,25 @@
+# Building this package requires a minimal set of package to be installed:
+# Version of glibc
+# glibc for target architecture is required to build and for further usage.
+GLIBC_VER=2.37-1
+# Version of linux+api
+LINUXAPI_VER=6.4.7-0
+# Version of aosc-aaa
+AOSCAAA_VER=11.0.1-0
+# Version of gcc
+GCC_VER=13.2.0
+# Target architecture - this variable is used during build process
+__CROSS=loongarch64
+
+VER=${GCC_VER}+glibc${GLIBC_VER/-/+}
+SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VER}/gcc-${GCC_VER}.tar.xz \
+      file::rename=glibc.deb::https://repo.aosc.io/debs/pool/frontier/main/g/glibc_${GLIBC_VER}_${__CROSS}.deb \
+      file::rename=linux+api.deb::https://repo.aosc.io/debs/pool/frontier/main/l/linux+api_${LINUXAPI_VER}_${__CROSS}.deb \
+      file::rename=aosc-aaa.deb::https://repo.aosc.io/debs/pool/frontier/main/a/aosc-aaa_${AOSCAAA_VER}_${__CROSS}.deb"
+CHKSUMS="sha256::e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da \
+         sha256::1aad8cf9f8d322dcca9e19aac0fc241dafe1095e60c9f09e104e37d8f924df87 \
+         sha256::65f005eddd675e428ec4b8323164b53f426dad9319b4067861c8b6068f724bd9 \
+         sha256::218af00547c92a9bd40ce56c814601520b4b4be4785dd8bd417de8b82b64f312"
+CHKUPDATE="anitya::id=6502"
+# Note: Use this when using official releases.
+SUBDIR="gcc-${GCC_VER}"


### PR DESCRIPTION
Topic Description
-----------------

This topic introduces LoongArch64 cross toolchain, as part of the effort to merge #4701.

Package(s) Affected
-------------------

- `binutils+cross-loongarch64 ` v2.40
- `gcc+cross-loongarch64` v13.2.0+glibc2.37+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils+cross-loongarch64 gcc+cross-loongarch64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`