### PR TITLE
aarty: new, 0.4.9

### DIFF
--- a/app-utils/aarty/autobuild/defines
+++ b/app-utils/aarty/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=aarty
+PKGDES="A Command-line tool to convert images to ASCII art"
+PKGSEC="utils"
+PKGDEP="gcc-runtime glibc"
+BUILDDEP="rustc llvm"
+
+USECLANG=1
+
+# FIXME: ld.lld is not yet available.
+BUILDDEP__LOONGSON3="${BUILDDEP/llvm/}"
+USECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1

--- a/app-utils/aarty/autobuild/prepare
+++ b/app-utils/aarty/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Creating lock ..."
+cargo update

--- a/app-utils/aarty/spec
+++ b/app-utils/aarty/spec
@@ -1,0 +1,4 @@
+VER=0.4.9
+SRCS="git::commit=tags/$VER::https://github.com/0x61nas/aarty"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=370242"


### PR DESCRIPTION
Topic Description
-----------------

This topic introduces `aarty`, a command-line image to ASCII art converter.

Package(s) Affected
-------------------

aarty

Security Update?
----------------

No


Build Order
-----------


```
#buildit aarty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
 
<!-- - [ ] 32-bit Optional Environment `optenv32` -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`