### PR TITLE
Automake 1.16i (and GNU config update)

### DIFF
--- a/app-devel/automake/autobuild/beyond
+++ b/app-devel/automake/autobuild/beyond
@@ -1,3 +1,4 @@
+abinfo "Installing symlinks to Perl modules ..."
 mkdir -pv "$PKGDIR"/usr/lib/perl5/vendor_perl
 ln -sv ../../../share/automake-${PKGVER%.*}/Automake \
     "$PKGDIR"/usr/lib/perl5/vendor_perl/

--- a/app-devel/automake/autobuild/defines
+++ b/app-devel/automake/autobuild/defines
@@ -4,6 +4,10 @@ PKGDEP="autoconf"
 BUILDDEP="config"
 PKGSEC=devel
 
-PKGEPOCH=1
+PKGEPOCH=2
 ABHOST=noarch
 ABSHADOW=0
+
+# FIXME: Enabling this replaces key files supplied in this package,
+# specifically config.guess and config.sub.
+ABCONFIGHACK=0

--- a/app-devel/automake/autobuild/patches/0001-Hack-bump-automake-version-to-1.16.5.patch
+++ b/app-devel/automake/autobuild/patches/0001-Hack-bump-automake-version-to-1.16.5.patch
@@ -1,0 +1,33 @@
+diff -Naur automake/configure.ac automake.version/configure.ac
+--- automake/configure.ac	2023-04-11 23:31:33.179196632 +0000
++++ automake.version/configure.ac	2023-04-11 23:43:17.650175332 +0000
+@@ -16,7 +16,7 @@
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ 
+ AC_PREREQ([2.69])
+-AC_INIT([GNU Automake], [1.16i], [bug-automake@gnu.org])
++AC_INIT([GNU Automake], [1.16.5], [bug-automake@gnu.org])
+ 
+ AC_CONFIG_SRCDIR([bin/automake.in])
+ AC_CONFIG_AUX_DIR([lib])
+diff -Naur automake/m4/amversion.m4 automake.version/m4/amversion.m4
+--- automake/m4/amversion.m4	2023-04-11 23:31:35.423206525 +0000
++++ automake.version/m4/amversion.m4	2023-04-11 23:43:32.406235996 +0000
+@@ -15,7 +15,7 @@
+ [am__api_version='1.16'
+ dnl Some users find AM_AUTOMAKE_VERSION and mistake it for a way to
+ dnl require some minimum version.  Point them to the right macro.
+-m4_if([$1], [1.16i], [],
++m4_if([$1], [1.16.5], [],
+       [AC_FATAL([Do not call $0, use AM_INIT_AUTOMAKE([$1]).])])dnl
+ ])
+ 
+@@ -31,7 +31,7 @@
+ # Call AM_AUTOMAKE_VERSION and AM_AUTOMAKE_VERSION so they can be traced.
+ # This function is AC_REQUIREd by AM_INIT_AUTOMAKE.
+ AC_DEFUN([AM_SET_CURRENT_AUTOMAKE_VERSION],
+-[AM_AUTOMAKE_VERSION([1.16i])dnl
++[AM_AUTOMAKE_VERSION([1.16.5])dnl
+ m4_ifndef([AC_AUTOCONF_VERSION],
+   [m4_copy([m4_PACKAGE_VERSION], [AC_AUTOCONF_VERSION])])dnl
+ _AM_AUTOCONF_VERSION(m4_defn([AC_AUTOCONF_VERSION]))])

--- a/app-devel/automake/spec
+++ b/app-devel/automake/spec
@@ -1,4 +1,4 @@
-VER=1.16.5
-SRCS="tbl::https://ftp.gnu.org/gnu/automake/automake-$VER.tar.xz"
-CHKSUMS="sha256::f01d58cd6d9d77fbdca9eb4bbd5ead1988228fdb73d6f7a201f5f8d6b118b469"
+VER=1.16i
+SRCS="git::commit=tags/v$VER::https://git.savannah.gnu.org/git/automake.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=144"

--- a/app-devel/config/autobuild/defines
+++ b/app-devel/config/autobuild/defines
@@ -4,3 +4,4 @@ PKGSEC=devel
 PKGDEP="bash"
 
 ABHOST=noarch
+PKGEPOCH=1

--- a/app-devel/config/spec
+++ b/app-devel/config/spec
@@ -1,4 +1,3 @@
-VER=20180301
-REL=1
-SRCS=git::commit=6b2374c79506ee82a8b440f6d1ca293e2e2e2463::https://git.savannah.gnu.org/git/config.git
+VER=0+git20230121
+SRCS=git::commit=63acb96f92473ceb5e21d873d7c0aee266b3d6d3::https://git.savannah.gnu.org/git/config.git
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

config: update to 0+git20230121    This update adds loongarch64 host support.
automake: update to 1.16i    - This release adds loongarch64-* host support.
- Bump epoch due to non-linear version format changes.


Package(s) Affected
-------------------

- `automake` v2:1.16i
- `config` v0+git20230121

Security Update?
----------------

No


Build Order
-----------


```
#buildit automake config
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`