### PR TITLE
aoscdk-rs: update to 0.11.1

### DIFF
--- a/app-admin/aoscdk-rs/spec
+++ b/app-admin/aoscdk-rs/spec
@@ -1,4 +1,4 @@
-VER=0.11.0
+VER=0.11.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscdk-rs/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226678"


### PR DESCRIPTION
Topic Description
-----------------

- aoscdk-rs: update to 0.11.1



Package(s) Affected
-------------------

aoscdk-rs

Security Update?
----------------

No


Build Order
-----------


```
#buildit aoscdk-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
 
<!-- - [ ] 32-bit Optional Environment `optenv32` -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`