### PR TITLE
Cmark survey 20231220

### DIFF
--- a/runtime-doc/cmark/spec
+++ b/runtime-doc/cmark/spec
@@ -1,4 +1,4 @@
-VER=0.29.0
+VER=0.30.3
 SRCS="tbl::https://github.com/commonmark/cmark/archive/$VER.tar.gz"
-CHKSUMS="sha256::2558ace3cbeff85610de3bda32858f722b359acdadf0c4691851865bb84924a6"
+CHKSUMS="sha256::85e9fb515531cc2c9ae176d693f9871774830cf1f323a6758fb187a5148d7b16"
 CHKUPDATE="anitya::id=9159"


### PR DESCRIPTION
Topic Description
-----------------
This PR updates cmark to version 0.30.3
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- cmark
- evolution
- pandoc
- mkvtoolnix
- gnome-builder

Security Update?
----------------
No

Build Order
-----------
```
cmark evolution  pandoc  mkvtoolnix  gnome-builder
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
