### PR TITLE
dua: update to 2.23.0

### DIFF
--- a/app-utils/dua/autobuild/defines
+++ b/app-utils/dua/autobuild/defines
@@ -6,3 +6,7 @@ PKGSEC="utils"
 PKGPROV="dua-cli"
 
 USECLANG=1
+
+# FIXME: loongson3 has no lld linker support
+NOLTO__LOONGSON3=1
+USECLANG__LOONGSON3=0

--- a/app-utils/dua/spec
+++ b/app-utils/dua/spec
@@ -1,4 +1,4 @@
-VER="2.20.1"
+VER="2.23.0"
 SRCS="git::commit=tags/v$VER::https://github.com/Byron/dua-cli"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=79030"


### PR DESCRIPTION
Topic Description
-----------------

- dua: update to 2.23.0

Package(s) Affected
-------------------

- dua: 2.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dua
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
 
<!-- - [ ] 32-bit Optional Environment `optenv32` -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`