### PR TITLE
smpeg+32: fix SRCS & BUILDDEP

### DIFF
--- a/runtime-optenv32/smpeg+32/autobuild/defines
+++ b/runtime-optenv32/smpeg+32/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=smpeg+32
 PKGSEC=x11
 PKGDEP="sdl+32"
+BUILDDEP="32subsystem"
 PKGDES="SDL MPEG Player Library (optenv32)"
 
 MAKE_AFTER='LIBS=-lX11'

--- a/runtime-optenv32/smpeg+32/spec
+++ b/runtime-optenv32/smpeg+32/spec
@@ -1,5 +1,5 @@
 VER=0.4.5
-SRCS="tbl::https://repo.anthonos.org/aosc-repacks/smpeg-$VER.tar.xz"
+SRCS="tbl::https://repo.aosc.io/aosc-repacks/smpeg-$VER.tar.xz"
 CHKSUMS="sha256::4238df675ebcbfb78cf1d5f2e7350896b34ace20ff6ac0f30ed5d1fbc7f064c0"
 REL=2
 CHKUPDATE="anitya::id=17787"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

smpeg+32: fix SRCS & BUILDDEP

Package(s) Affected
-------------------

smpeg+32

Security Update?
----------------

No
<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Test Build(s) Done
------------------

- [x] Architecture-independent `noarch`
