### PR TITLE
shadowsocks-libev: add cap_net_admin to ss-redir in postinst

### DIFF
--- a/app-network/shadowsocks-libev/autobuild/postinst
+++ b/app-network/shadowsocks-libev/autobuild/postinst
@@ -1,4 +1,4 @@
 setcap cap_net_bind_service+ep usr/bin/ss-local  2>/dev/null
 setcap cap_net_bind_service+ep usr/bin/ss-server 2>/dev/null
 setcap cap_net_bind_service+ep usr/bin/ss-tunnel 2>/dev/null
-setcap cap_net_bind_service+ep usr/bin/ss-redir  2>/dev/null
+setcap cap_net_bind_service,cap_net_admin+ep usr/bin/ss-redir  2>/dev/null

--- a/app-network/shadowsocks-libev/spec
+++ b/app-network/shadowsocks-libev/spec
@@ -1,5 +1,5 @@
 VER=3.3.5
-REL=1
+REL=2
 SRCS="tbl::https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$VER/shadowsocks-libev-$VER.tar.gz"
 CHKSUMS="sha256::cfc8eded35360f4b67e18dc447b0c00cddb29cc57a3cec48b135e5fb87433488"
 CHKUPDATE="anitya::id=21654"


### PR DESCRIPTION
Topic Description
-----------------

Add cap_net_admin capability to ss-redir in the postinst script of shadowsocks-libev. This allows ss-redir running as a non-root user to change the IP_TRANSPARENT option of a socket.
![image](https://github.com/AOSC-Dev/aosc-os-abbs/assets/18094117/3b922d6e-99c7-4d59-9f4b-e943ce5866ab)

Package(s) Affected
-------------------

`shadowsocks-libev` v3.3.5

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

