### PR TITLE
MIPS64 R6 Survey 20231220

### DIFF
--- a/runtime-common/serd/spec
+++ b/runtime-common/serd/spec
@@ -1,4 +1,4 @@
-VER=0.30.4
-SRCS="tbl::https://download.drobilla.net/serd-$VER.tar.bz2"
-CHKSUMS="sha256::0c95616a6587bee5e728e026190f4acd5ab6e2400e8890d5c2a93031eab01999"
+VER=0.32.0
+SRCS="tbl::https://download.drobilla.net/serd-$VER.tar.xz"
+CHKSUMS="sha256::d1e8699468e01d2a76abe402b4d5c60c5095335c92b259088f062bdd3b929ca1"
 CHKUPDATE="anitya::id=230531"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

This PR has updated the packages required for mips64r6el

Package(s) Affected
-------------------

serd

Security Update?
----------------

No

Build Order
-----------

```
serd
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
