### PR TITLE
serd: update to 0.32.0

### DIFF
--- a/runtime-common/serd/spec
+++ b/runtime-common/serd/spec
@@ -1,4 +1,4 @@
-VER=0.30.4
-SRCS="tbl::https://download.drobilla.net/serd-$VER.tar.bz2"
-CHKSUMS="sha256::0c95616a6587bee5e728e026190f4acd5ab6e2400e8890d5c2a93031eab01999"
+VER=0.32.0
+SRCS="tbl::https://download.drobilla.net/serd-$VER.tar.xz"
+CHKSUMS="sha256::d1e8699468e01d2a76abe402b4d5c60c5095335c92b259088f062bdd3b929ca1"
 CHKUPDATE="anitya::id=230531"


### PR DESCRIPTION
Topic Description
-----------------

- serd: update to 0.32.0

Package(s) Affected
-------------------

- serd: 0.32.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit serd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
 
<!-- - [ ] 32-bit Optional Environment `optenv32` -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`