### PR TITLE
babl: fix ftbfs for mips64r6el

### DIFF
--- a/runtime-imaging/babl/autobuild/defines
+++ b/runtime-imaging/babl/autobuild/defines
@@ -17,5 +17,8 @@ MESON_AFTER__AMD64=" \
              -Denable-avx2=false \
              -Denable-f16c=false"
 
+# FIXME: The mips64r6el-architecture has a problem with rsgv that doesn't work
+# properly,so turn off document generation to skip rsvg 
+MESON_AFTER__MIPS64R6EL="-Dwith-docs=false"
 PKGBREAK="gegl<=0.2.0-9 gegl-0.3<=1:0.3.28-1 \
           gegl-0.4<=0.4.0 gimp<=2.10.0 gnome-photos<=3.28.0"


### PR DESCRIPTION
Topic Description
-----------------

- babl: disable docs generation for mips64r6el
    Due to rsvg's constant segmentation faults.
    
Package(s) Affected
-------------------

- babl: 0.1.96

Security Update?
----------------

No

Build Order
-----------

```
#buildit babl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`   
- [x] AArch64 `arm64`
 
<!-- - [ ] 32-bit Optional Environment `optenv32` -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`