### PR TITLE
mkvtoolnix: bump REL for rebuild

### DIFF
--- a/app-multimedia/mkvtoolnix/spec
+++ b/app-multimedia/mkvtoolnix/spec
@@ -1,4 +1,5 @@
 VER=79.0
+REL=1
 SRCS="tbl::https://www.bunkus.org/videotools/mkvtoolnix/sources/mkvtoolnix-$VER.tar.xz"
 CHKSUMS="sha256::f039c27b0dfe4a4d1aa870ad32e20a28a5f254de6121cb12a42328130be3afbc"
 CHKUPDATE="anitya::id=1991"


### PR DESCRIPTION
Topic Description
-----------------
We observed a dirty build on mips64el, which somehow depends on libfmt. Triggering a rebuild fixed the issue.

Package(s) Affected
-------------------
mkvtoolnix

Security Update?
----------------
No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
