### PR TITLE
libnvme: fix pkgbreak

### DIFF
--- a/runtime-devices/libnvme/autobuild/defines
+++ b/runtime-devices/libnvme/autobuild/defines
@@ -4,5 +4,8 @@ PKGSEC=libs
 PKGDEP="dbus json-c"
 BUILDDEP="swig"
 
-PKGBREAK="nvme-cli<=2.2.1-0"
-PKGREP="nvme-cli<=2.2.1-0"
+# FIXME: PKGBREAK can not coexist with PKGREP in such conditiion that a
+# needs to de-bundle a dependency, which will result in a file overwriting
+# error. Remove PKGBREAK to allow the affected package(s) to be replaced
+# without removing them beforehand.
+PKGREP="nvme-cli<=2.2.1-1"

--- a/runtime-devices/libnvme/spec
+++ b/runtime-devices/libnvme/spec
@@ -1,4 +1,5 @@
 VER=1.6
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/linux-nvme/libnvme.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242763"


### PR DESCRIPTION
Topic Description
-----------------

- libnvme: remove PKGBREAK
    To allow dpkg to replace nvme-cli during packaging, instead of removing
    it beforehand.
    
Package(s) Affected
-------------------

- libnvme: 1.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libnvme
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
 
<!-- - [ ] 32-bit Optional Environment `optenv32` -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`