### PR TITLE
cutter: fix ftbfs

### DIFF
--- a/desktop-gnome/clutter/autobuild/defines
+++ b/desktop-gnome/clutter/autobuild/defines
@@ -18,3 +18,7 @@ AUTOTOOLS_AFTER="--enable-introspection \
                  --enable-gtk-doc"
 
 NOLTO=1
+# FIXME: reconf failed with automake 1.16i:
+# Use of uninitialized value $var in string eq at /usr/share/automake-1.16/Automake/Variable.pm line 754, <GEN2> line 45.
+# Disabling reconf to use the configure script shipped with source.
+RECONF=0


### PR DESCRIPTION
Topic Description
-----------------

- clutter: fix build
    This package will error out under the current latest 16i version of automake,
     so skip autoreconf for now and wait for an upstream fix.
    
Package(s) Affected
-------------------

- clutter: 1.26.4-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit clutter
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
**Second Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
