### PR TITLE
Cmark survey 20231220

### DIFF
--- a/app-multimedia/mkvtoolnix/spec
+++ b/app-multimedia/mkvtoolnix/spec
@@ -1,5 +1,5 @@
 VER=79.0
-REL=1
+REL=2
 SRCS="tbl::https://www.bunkus.org/videotools/mkvtoolnix/sources/mkvtoolnix-$VER.tar.xz"
 CHKSUMS="sha256::f039c27b0dfe4a4d1aa870ad32e20a28a5f254de6121cb12a42328130be3afbc"
 CHKUPDATE="anitya::id=1991"

--- a/desktop-gnome/evolution/spec
+++ b/desktop-gnome/evolution/spec
@@ -1,5 +1,5 @@
 VER=3.44.4
-REL=1
+REL=2
 SRCS="https://download.gnome.org/sources/evolution/${VER:0:4}/evolution-$VER.tar.xz"
 CHKSUMS="sha256::f0b16e7abad3c7945a29c322f17dab4a08d61e99bd7cc91b8df35053c5c12e8c"
 CHKUPDATE="anitya::id=10934"

--- a/desktop-gnome/gnome-builder/spec
+++ b/desktop-gnome/gnome-builder/spec
@@ -1,5 +1,5 @@
 VER=42.1
-REL=3
+REL=4
 SRCS="https://download.gnome.org/sources/gnome-builder/${VER%.*}/gnome-builder-$VER.tar.xz"
 CHKSUMS="sha256::5d4d51b702865b48017201f0c607e24a27d72031a8f5c88d4fce875b5545670a"
 CHKUPDATE="anitya::id=5574"

--- a/desktop-gnome/libcryptui/autobuild/patches/0001-libcryptui-3.12.2-gnupg-2.3.patch
+++ b/desktop-gnome/libcryptui/autobuild/patches/0001-libcryptui-3.12.2-gnupg-2.3.patch
@@ -9,7 +9,7 @@ diff -up libcryptui-3.12.2/configure.ac.gpg2 libcryptui-3.12.2/configure.ac
  
  if test	"$DO_CHECK" = "yes"; then
 -	accepted_versions="1.2 1.4 2.0"
-+	accepted_versions="1.2 1.4 2.0 2.1 2.2"
++	accepted_versions="1.2 1.4 2.0 2.1 2.2 2.3"
  	AC_PATH_PROGS(GNUPG, [gpg gpg2], no)
  	AC_DEFINE_UNQUOTED(GNUPG, "$GNUPG", [Path to gpg executable.])
  	ok="no"
@@ -21,7 +21,7 @@ diff -up libcryptui-3.12.2/configure.gpg2 libcryptui-3.12.2/configure
  
  if test	"$DO_CHECK" = "yes"; then
 -	accepted_versions="1.2 1.4 2.0"
-+	accepted_versions="1.2 1.4 2.0 2.1 2.2"
++	accepted_versions="1.2 1.4 2.0 2.1 2.2 2.3"
  	for ac_prog in gpg gpg2
  do
    # Extract the first word of "$ac_prog", so it can be a program name with args.

--- a/desktop-gnome/libcryptui/spec
+++ b/desktop-gnome/libcryptui/spec
@@ -1,5 +1,5 @@
 VER=3.12.2
-REL=5
+REL=6
 SRCS="tbl::https://download.gnome.org/sources/libcryptui/${VER:0:4}/libcryptui-$VER.tar.xz"
 CHKSUMS="sha256::71ead1a7b496f07f6c5102ae79945dd2515b7b9342c6edefe58b47318be20866"
 CHKUPDATE="anitya::id=229560"

--- a/runtime-doc/cmark/autobuild/defines
+++ b/runtime-doc/cmark/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=cmark
 PKGSEC=libs
 PKGDEP="glibc"
 PKGDES="CommonMark parsing and rendering library and program in C"
+
+PKGBREAK="evolution<=3.44.4-1 mkvtoolnix<=79.0-1 gnome-builder<=42.1-3"

--- a/runtime-doc/cmark/spec
+++ b/runtime-doc/cmark/spec
@@ -1,4 +1,4 @@
-VER=0.29.0
+VER=0.30.3
 SRCS="tbl::https://github.com/commonmark/cmark/archive/$VER.tar.gz"
-CHKSUMS="sha256::2558ace3cbeff85610de3bda32858f722b359acdadf0c4691851865bb84924a6"
+CHKSUMS="sha256::85e9fb515531cc2c9ae176d693f9871774830cf1f323a6758fb187a5148d7b16"
 CHKUPDATE="anitya::id=9159"


### PR DESCRIPTION
Topic Description
-----------------
This PR updates cmark to 0.30.3. Reverse dependencies are rebuilt.

Package(s) Affected
-------------------
- cmark
- evolution
- mkvtoolnix
- gnome-builder

Security Update?
----------------
No

Build Order
-----------
```
#buildit cmark libcryptui evolution mkvtoolnix gnome-builder
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
