### PR TITLE
libplist update and fix ftbfs

### DIFF
--- a/runtime-common/libplist/autobuild/defines
+++ b/runtime-common/libplist/autobuild/defines
@@ -13,6 +13,9 @@ BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
+# FIXME: Default to /usr/bin/cython3 path
+AUTOTOOLS_AFTER=" \
+		--with-cython=/usr/bin/cython"
 AUTOTOOLS_AFTER__RETRO=" \
                  --without-cython"
 AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"

--- a/runtime-common/libplist/spec
+++ b/runtime-common/libplist/spec
@@ -1,5 +1,4 @@
-VER=2.2.0
-REL=2
-SRCS="tbl::https://github.com/libimobiledevice/libplist/archive/$VER.tar.gz"
-CHKSUMS="sha256::7e654bdd5d8b96f03240227ed09057377f06ebad08e1c37d0cfa2abe6ba0cee2"
+VER=2.3.0
+SRCS="tbl::https://github.com/libimobiledevice/libplist/releases/download/$VER/libplist-$VER.tar.bz2"
+CHKSUMS="sha256::4e8580d3f39d3dfa13cefab1a13f39ea85c4b0202e9305c5c8f63818182cac61"
 CHKUPDATE="anitya::id=11675"


### PR DESCRIPTION
Topic Description
-----------------

- liplist: update to 2.3.0
    x The job requires this package to be updated and ftbfs a bit whether it is
    updated or not. The source download path was changed because the old source
    download path didn't seem to be labeled for the package, resulting in an
    error at build time "configure: error : PACKAGE_VERSION is not defined.
    Make sure to cnfigure a source tree out from git or that .tarball-version
    is present"
    
- libnvme: remove PKGBREAK
    To allow dpkg to replace nvme-cli during packaging, instead of removing
    it beforehand.
    
- sdl-ttf+32: build fixes

- mkvtoolnix: bump REL for rebuild
    We observed a dirty build on mips64el, which somehow depends on libfmt.
    Triggering a rebuild fixed the issue.
    
- chore: remove trailing whitespaces found in .github

- miniserve: fix for loongson3

- aoscdk-rs: update to 0.11.1

- shadowsocks-libev: add cap_net_admin to ss-redir in postinst
    This allows ss-redir to set the IP_TRANSPARENT option for a socket
    without root permission. TPROXY needs this option.
    
- serd: update to 0.32.0

- smpeg+32: fix SRCS & BUILDDEP


... and 95007 more commits
Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit liplist
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Second Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
