### PR TITLE
openssh: update to 9.6p1

### DIFF
--- a/app-network/openssh/autobuild/patches/0001-configure.ac-fix-fzero-call-used-regs-used-for-mips6.patch
+++ b/app-network/openssh/autobuild/patches/0001-configure.ac-fix-fzero-call-used-regs-used-for-mips6.patch
@@ -1,0 +1,37 @@
+From bee2a942be50c7a879e74a1c0a76c927cae9048f Mon Sep 17 00:00:00 2001
+From: Cyan <cyan@cyano.uk>
+Date: Fri, 22 Dec 2023 21:17:03 +0800
+Subject: [PATCH] configure.ac: fix -fzero-call-used-regs=used for mips64
+ targets
+
+- This check somehow succeeded during configure check, but failed during
+  build.
+---
+ configure.ac | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 379cd74..e36cc60 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -236,7 +236,16 @@ if test "$GCC" = "yes" || test "$GCC" = "egcs"; then
+ 	case "$CLANG_VER" in
+ 	apple-15*) OSSH_CHECK_CFLAG_LINK([-fzero-call-used-regs=used]) ;;
+ 	17*)	;;
+-	*)	OSSH_CHECK_CFLAG_LINK([-fzero-call-used-regs=used]) ;;
++	*)
++		case "$host" in
++			# FIXME possible GCC oversight - 
++			# sorry, unimplemented: argument ‘used’ is not supported for ‘-fzero-call-used-regs’ on this target
++			# This check passed during configure, but failed later during build.
++			# It should fail during this check.
++			mips64el*) 	;;
++			*)		OSSH_CHECK_CFLAG_LINK([-fzero-call-used-regs=used]) ;;
++		esac
++		;;
+ 	esac
+ 	OSSH_CHECK_CFLAG_COMPILE([-ftrivial-auto-var-init=zero])
+     fi
+-- 
+2.39.1
+

--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -1,5 +1,4 @@
-VER=9.1p1
+VER=9.6p1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
-CHKSUMS="sha256::19f85009c7e3e23787f0236fbb1578392ab4d4bf9f8ec5fe6bc1cd7e8bfdd288"
+CHKSUMS="sha256::910211c07255a8c5ad654391b40ee59800710dd8119dd5362de09385aa7a777c"
 CHKUPDATE="anitya::id=2565"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

This PR updates OpenSSH to 9.6p1, which addresses several security vulnerabilities (See #4958).


Package(s) Affected
-------------------

- `openssh` 9.6p1

Security Update?
----------------

Yes - Issue Number: #4958 

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
