### PR TITLE
cython-enhancement

### DIFF
--- a/lang-python/cython/autobuild/beyond
+++ b/lang-python/cython/autobuild/beyond
@@ -1,0 +1,1 @@
+ln -sv cython /usr/bin/cython3


### PR DESCRIPTION
Topic Description
-----------------

- cython: enhancement
    Some packages upstream look for /usr/bin/cython3 as an indication that a
    dependency exists. Add this dynamic link to handle this situation
    
- aoscdk-rs: update to 0.11.1

- shadowsocks-libev: add cap_net_admin to ss-redir in postinst
    This allows ss-redir to set the IP_TRANSPARENT option for a socket
    without root permission. TPROXY needs this option.
    
- serd: update to 0.32.0

- smpeg+32: fix SRCS & BUILDDEP

- soundtouch+32: fix missing CHKSUMS

- gifski: fix for loongson3

- fd: update to 8.7.1

- discord: update to 0.0.39

- config: update to 0+git20230121
    This update adds loongarch64 host support.
    

... and 95002 more commits
Package(s) Affected
-------------------

- cython: 3.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cython
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Second Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
