### PR TITLE
cython: create cython3 symlink

### DIFF
--- a/lang-python/cython/autobuild/beyond
+++ b/lang-python/cython/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Adding a symlink to cython3 to satisfy dependency checks for some packages ..."
+ln -sv cython /usr/bin/cython3


### PR DESCRIPTION
Topic Description
-----------------

- cython: create a /usr/bin/cython3 symlink
    Some packages look for /usr/bin/cython3 as an indication that a
    dependency exists. Add this symlink to handle this situation
    
Package(s) Affected
-------------------

- cython: 3.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cython
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Second Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
