### PR TITLE
cython: rework spec to bump REL

### DIFF
--- a/lang-python/cython/spec
+++ b/lang-python/cython/spec
@@ -1,4 +1,5 @@
 VER=3.0.2
+REL=1
 SRCS="tbl::https://pypi.io/packages/source/C/Cython/Cython-$VER.tar.gz"
 CHKSUMS="sha256::9594818dca8bb22ae6580c5222da2bc5cc32334350bd2d294a00d8669bcc61b5"
 CHKUPDATE="anitya::id=36699"


### PR DESCRIPTION
Topic Description
-----------------

- cython: bump REL

Package(s) Affected
-------------------

- cython: 3.0.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cython
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Second Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
