### PR TITLE
superslicer: update to 2.5.59.4

### DIFF
--- a/app-creativity/superslicer/spec
+++ b/app-creativity/superslicer/spec
@@ -1,5 +1,4 @@
-VER=2.5.59.3
-REL=1
+VER=2.5.59.4
 SRCS="git::commit=tags/${VER}::https://github.com/supermerill/SuperSlicer.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=supermerill/SuperSlicer"


### PR DESCRIPTION
Topic Description
-----------------

- superslicer: update to 2.5.59.4
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
    
Package(s) Affected
-------------------

- superslicer: 2.5.59.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit superslicer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
