### PR TITLE
dar: update to 2.7.13

### DIFF
--- a/app-utils/dar/autobuild/defines
+++ b/app-utils/dar/autobuild/defines
@@ -5,4 +5,8 @@ PKGDES="Full, incremental, compressed and encrypted backups or archives"
 
 ABSHADOW=0
 RECONF=0
-AUTOTOOLS_AFTER="--enable-birthtime"
+
+# Note: Only the statx() implementation is usable under Linux.
+# Ref: https://github.com/Edrusb/DAR/issues/57#issuecomment-1870490023
+AUTOTOOLS_AFTER="--disable-birthtime \
+                 --disable-dar-static"

--- a/app-utils/dar/spec
+++ b/app-utils/dar/spec
@@ -1,5 +1,4 @@
-VER=2.6.6
-REL=1
+VER=2.7.13
 SRCS="tbl::https://sourceforge.net/projects/dar/files/dar/$VER/dar-$VER.tar.gz"
-CHKSUMS="sha256::fac66df4df145b3b6d6faa934d1f3035439b367ba45b7d3f478ecad9d2620ddf"
+CHKSUMS="sha256::2d563b5d1d928a3eecab719cc22d43320786c52053f4e3a557cdf1c84b120f4c"
 CHKUPDATE="anitya::id=389"


### PR DESCRIPTION
Topic Description
-----------------

- dar: update to 2.7.13

Package(s) Affected
-------------------

- dar: 2.7.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit dar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
