### PR TITLE
treevsrepo: update to 0.4.3

### DIFF
--- a/app-devel/treevsrepo/autobuild/defines
+++ b/app-devel/treevsrepo/autobuild/defines
@@ -11,3 +11,4 @@ NOLTO__LOONGSON3=1
 
 # FIXME: ld.lld is not yet available.
 NOLTO__LOONGARCH64=1
+NOLTO__MIPS64R6EL=1

--- a/app-devel/treevsrepo/autobuild/defines
+++ b/app-devel/treevsrepo/autobuild/defines
@@ -4,6 +4,8 @@ PKGDEP="gcc-runtime openssl zlib"
 BUILDDEP="llvm rustc"
 PKGDES="A tool to expose package version discrepancies between the ABBS tree and the repository"
 
+ABSPLITDBG=0
+
 USECLANG=1
 # FIXME: Signal 11 on linkage.
 USECLANG__LOONGSON3=0

--- a/app-devel/treevsrepo/spec
+++ b/app-devel/treevsrepo/spec
@@ -1,4 +1,4 @@
-VER=0.4.0
+VER=0.4.3
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/treevsrepo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=341996"


### PR DESCRIPTION
Topic Description
-----------------

- treevsrepo: update to 0.4.3

Package(s) Affected
-------------------

- treevsrepo: 0.4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit treevsrepo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
