### PR TITLE
openocd: update to 0.12.0

### DIFF
--- a/app-devel/openocd/spec
+++ b/app-devel/openocd/spec
@@ -1,4 +1,4 @@
-VER=0.10.0+git20210213
-SRCS="git::commit=ba0f382137749b78b27ac58238735cc20a6fa847::http://repo.or.cz/openocd.git"
+VER=0.12.0
+SRCS="git::commit=v${VER}::http://repo.or.cz/openocd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2557"


### PR DESCRIPTION
Topic Description
-----------------

- openocd: update to 0.12.0

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit openocd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
