### PR TITLE
ddcutil: new, 2.0.0

### DIFF
--- a/app-utils/ddcutil/autobuild/defines
+++ b/app-utils/ddcutil/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=ddcutil
+PKGSEC=utils
+PKGDES="Utility for controlling monitor settings using DDC/CI and USB"
+PKGDEP="i2c-tools glib libgudev libusb systemd libdrm x11-lib hwdata"
+
+# FIXME: fatal error: src/ddc/ddc_displays.h: No such file or directory
+ABSHADOW=0

--- a/app-utils/ddcutil/spec
+++ b/app-utils/ddcutil/spec
@@ -1,0 +1,4 @@
+VER=2.0.0
+SRCS="git::commit=tags/v$VER::https://github.com/rockowitz/ddcutil"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=242390"

--- a/desktop-kde/powerdevil/autobuild/defines
+++ b/desktop-kde/powerdevil/autobuild/defines
@@ -1,24 +1,19 @@
 PKGNAME=powerdevil
 PKGSEC=kde
-# FIXME: "DDCUtil library support is disabled by default as recommended by
-# authors, add -DHAVE_DDCUTIL=On to enable"
 PKGDEP="bluez-qt fontconfig freetype kactivities kauth kcmutils kcodecs \
         kcompletion kconfig kconfigwidgets kcoreaddons kcrash kdbusaddons \
         kglobalaccel ki18n kidletime kio kirigami2 kitemviews kjobwidgets \
         knotifications knotifyconfig kservice kwayland kwidgetsaddons kxmlgui \
-        libcap libkscreen networkmanager-qt plasma-workspace solid systemd"
+        libcap libkscreen networkmanager-qt plasma-workspace solid systemd \
+        ddcutil"
 BUILDDEP="extra-cmake-modules kdoctools"
 PKGDES="Manages the power management settings of Plasma Workspace"
 
-# FIXME: -DHAVE_DDCUTIL=OFF
-#
-# "DDCUtil library support is disabled by default as recommended by
-# authors, add -DHAVE_DDCUTIL=On to enable"
 CMAKE_AFTER="-DBUILD_COVERAGE=OFF \
              -DBUILD_TESTING=OFF \
              -DBUILD_WITH_QT6=OFF \
              -DENABLE_BSYMBOLICFUNCTIONS=OFF \
-             -DHAVE_DDCUTIL=OFF \
+             -DHAVE_DDCUTIL=ON \
              -DKDE_INSTALL_PREFIX_SCRIPT=OFF \
              -DKDE_INSTALL_USE_QT_SYS_PATHS=ON \
              -DKDE_L10N_AUTO_TRANSLATIONS=OFF \

--- a/desktop-kde/powerdevil/spec
+++ b/desktop-kde/powerdevil/spec
@@ -1,4 +1,5 @@
 VER=5.27.2
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/powerdevil-$VER.tar.xz"
 CHKSUMS="sha256::3d74c855bc318b716e34efcaf851e194d15ad6dc44eb5615dfb5d110277799ab"
 CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
Topic Description
-----------------

- powerdevil: enable ddcutil support
    - The upstream has re-enabled ddcutil support by default.
    - Bump REL.
    
    Ref: https://invent.kde.org/plasma/powerdevil/-/commit/e4a5e5d3e017ef45979933e14e47408bb3a59dda
    
- ddcutil: new, 2.0.0
    - FIXME: ABSHADOW=0.
      "fatal error: src/ddc/ddc_displays.h: No such file or directory"
    
Package(s) Affected
-------------------

- ddcutil: 2.0.0
- powerdevil: 5.27.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ddcutil powerdevil
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
