### PR TITLE
Firewalld Survey (December 2023)

### DIFF
--- a/app-network/firewalld/autobuild/beyond
+++ b/app-network/firewalld/autobuild/beyond
@@ -11,6 +11,3 @@ rm -v \
 mv -v \
     "$PKGDIR"/usr/share/polkit-1/actions/org.fedoraproject.FirewallD1.desktop.policy.choice \
     "$PKGDIR"/usr/share/polkit-1/actions/org.fedoraproject.FirewallD1.policy
-
-abinfo "Dropping a file provided by Kodi ..."
-rm -v "$PKGDIR"/usr/lib/firewalld/services/kodi-eventserver.xml

--- a/app-network/firewalld/spec
+++ b/app-network/firewalld/spec
@@ -1,5 +1,4 @@
-VER=1.2.0
-REL=1
+VER=2.0.0
 SRCS="tbl::https://github.com/firewalld/firewalld/archive/v$VER.tar.gz"
-CHKSUMS="sha256::3c3c7ea19d7e2475636b39100649c01551a99af5a1e9b2c46212da71a5ffab62"
+CHKSUMS="sha256::75f1fe7cb3ba82d55ab420459610e45a35dc2513019c99d0d2cc6fbbd5198c49"
 CHKUPDATE="anitya::id=9989"

--- a/app-network/nftables/autobuild/beyond
+++ b/app-network/nftables/autobuild/beyond
@@ -1,0 +1,6 @@
+abinfo "Building python module"
+(
+        cd "$SRCDIR/py"
+        python3 -m build --wheel --no-isolation
+        python3 -m installer --destdir="${PKGDIR}" dist/*.whl
+)

--- a/app-network/nftables/autobuild/defines
+++ b/app-network/nftables/autobuild/defines
@@ -1,10 +1,11 @@
 PKGNAME=nftables
 PKGSEC=net
 PKGDEP="gmp libnftnl ncurses readline python-3 jsonschema jansson"
+BUILDDEP="python-build python-installer wheel"
 PKGDES="Netfilter tables userspace tools"
 
-AUTOTOOLS_AFTER="
-                 PYTHON_BIN=/usr/bin/python3
-                 --sysconfdir=/usr/share
-                 --with-json
-"
+AUTOTOOLS_AFTER=(
+	PYTHON_BIN=/usr/bin/python3
+	--sysconfdir=/usr/share
+	--with-json
+)

--- a/app-network/nftables/spec
+++ b/app-network/nftables/spec
@@ -1,5 +1,4 @@
-VER=0.9.7
-SRCS="tbl::https://netfilter.org/projects/nftables/files/nftables-$VER.tar.bz2"
-CHKSUMS="sha256::fe6b8a8c326a2c09c02ca162b840d7d4aadb043ce7a367c166d6455b0e112cb0"
+VER=1.0.9
+SRCS="tbl::https://netfilter.org/projects/nftables/files/nftables-$VER.tar.xz"
+CHKSUMS="sha256::a3c304cd9ba061239ee0474f9afb938a9bb99d89b960246f66f0c3a0a85e14cd"
 CHKUPDATE="anitya::id=2082"
-REL=1

--- a/runtime-common/jansson/spec
+++ b/runtime-common/jansson/spec
@@ -1,4 +1,4 @@
-VER=2.12
-SRCS="tbl::http://www.digip.org/jansson/releases/jansson-$VER.tar.gz"
-CHKSUMS="sha256::5f8dec765048efac5d919aded51b26a32a05397ea207aa769ff6b53c7027d2c9"
+VER=2.14
+SRCS="tbl::https://github.com/akheron/jansson/releases/download/v${VER}/jansson-${VER}.tar.gz"
+CHKSUMS="sha256::5798d010e41cf8d76b66236cfb2f2543c8d082181d16bc3085ab49538d4b9929"
 CHKUPDATE="anitya::id=1417"

--- a/runtime-network/libmnl/spec
+++ b/runtime-network/libmnl/spec
@@ -1,5 +1,4 @@
-VER=1.0.4
-REL=1
+VER=1.0.5
 SRCS="tbl::https://www.netfilter.org/projects/libmnl/files/libmnl-$VER.tar.bz2"
-CHKSUMS="sha256::171f89699f286a5854b72b91d06e8f8e3683064c5901fb09d954a9ab6f551f81"
+CHKSUMS="sha256::274b9b919ef3152bfb3da3a13c950dd60d6e2bcd54230ffeca298d03b40d0525"
 CHKUPDATE="anitya::id=1663"

--- a/runtime-network/libnftnl/spec
+++ b/runtime-network/libnftnl/spec
@@ -1,5 +1,4 @@
-VER=1.1.8
-REL=1
-SRCS="https://netfilter.org/projects/libnftnl/files/libnftnl-$VER.tar.bz2"
-CHKSUMS="sha256::04a3fa5b08b736268f7e65836b9f05d9d5f438181467bee3c76c3c4a4f3ab711"
+VER=1.2.6
+SRCS="https://netfilter.org/projects/libnftnl/files/libnftnl-$VER.tar.xz"
+CHKSUMS="sha256::ceeaea2cd92147da19f13a35a7f1a4bc2767ff897e838e4b479cf54b59c777f4"
 CHKUPDATE="anitya::id=1681"


### PR DESCRIPTION
Topic Description
-----------------

- jansson: upgrade to 2.14
- libmnl: upgrade to 1.0.5
- libnftnl: upgrade to 1.2.6
- nftables: upgrade to 1.0.9
- firewalld: upgrade to 2.0.0

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit jansson libmnl libnftnl nftables firewalld
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`