### PR TITLE
MATE Desktop Survey (December 2023)

### DIFF
--- a/desktop-gnome/libpeas/autobuild/defines
+++ b/desktop-gnome/libpeas/autobuild/defines
@@ -2,9 +2,11 @@ PKGNAME=libpeas
 PKGSEC=libs
 PKGDEP="gobject-introspection gtk-3 lgi luajit python-2 python-3"
 # FIXME: LuaJIT not available on these architectures.
-PKGDEP__LOONGARCH64="${PKGDEP/luajit/lua}"
-PKGDEP__PPC64EL="${PKGDEP/luajit/lua}"
-PKGDEP__RISCV64="${PKGDEP/luajit/lua}"
+PKGDEP__NOLUAJIT="${PKGDEP/luajit/lua}"
+PKGDEP__LOONGARCH64="${PKGDEP__NOLUAJIT}"
+PKGDEP__MIPS64R6EL="${PKGDEP__NOLUAJIT}"
+PKGDEP__PPC64EL="${PKGDEP__NOLUAJIT}"
+PKGDEP__RISCV64="${PKGDEP__NOLUAJIT}"
 BUILDDEP="glade gi-docgen gobject-introspection gtk-doc intltool \
           pygobject-3 vala"
 PKGDES="A GObject-based plugins engine"

--- a/desktop-gnome/libpeas/spec
+++ b/desktop-gnome/libpeas/spec
@@ -1,4 +1,5 @@
 VER=1.32.0
+REL=1
 SRCS="https://download.gnome.org/sources/libpeas/${VER:0:4}/libpeas-$VER.tar.xz"
 CHKSUMS="sha256::d625520fa02e8977029b246ae439bc218968965f1e82d612208b713f1dcc3d0e"
 CHKUPDATE="anitya::id=6871"

--- a/desktop-mate/atril/spec
+++ b/desktop-mate/atril/spec
@@ -1,5 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/atril-$VER.tar.xz"
-CHKSUMS="sha256::715e766eaede3fa5d8ca300fa3319fb2b63055dfdc6e971d8750c2aec624e45f"
+CHKSUMS="sha256::a53a613acb9701a18ad671bf590254d1ce836ba0ae1be2c0bd8948fdf6b491a4"
 CHKUPDATE="anitya::id=198706"
-REL=1

--- a/desktop-mate/caja-extensions/spec
+++ b/desktop-mate/caja-extensions/spec
@@ -1,5 +1,4 @@
-VER=1.26.0
-
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/caja-extensions-$VER.tar.xz"
-CHKSUMS="sha256::f01539530840f8bd32ad119fab346cac214149dec74a69ae65a39442fdd8fc0f"
+CHKSUMS="sha256::589c19e3fa10242d6239a5ccb9585598436a56ebe94d2eb2a50b5950cce1d520"
 CHKUPDATE="anitya::id=16411"

--- a/desktop-mate/caja/spec
+++ b/desktop-mate/caja/spec
@@ -1,5 +1,4 @@
-VER=1.26.0
-
+VER=1.26.3
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/caja-$VER.tar.xz"
-CHKSUMS="sha256::a200a6fad3a5fbc70d10f8626788e2f4f31bde363649bc50a6bb8a85b2880ad4"
+CHKSUMS="sha256::813edf08a36f995ec3c1504131ff8afbbd021f6e1586643fe5dced5e73e5790d"
 CHKUPDATE="anitya::id=16409"

--- a/desktop-mate/engrampa/spec
+++ b/desktop-mate/engrampa/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/engrampa-$VER.tar.xz"
-CHKSUMS="sha256::97cdb2c22c32315a38803d4147dfad9de7309e30ce8f37ac9f600709ad075ee3"
+CHKSUMS="sha256::f0224107a7a4e9ea6309c9e78aa5faac802c4cf72a49ac283aa9e7ae1e8a6c4a"
 CHKUPDATE="anitya::id=230601"

--- a/desktop-mate/eom/spec
+++ b/desktop-mate/eom/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/eom-$VER.tar.xz"
-CHKSUMS="sha256::27f169aa396ddbc75740bf802bef1c0251771ca0747b5a727ff985c03dc067db"
+CHKSUMS="sha256::b5251229494f7e6c62e09fb211e43308df4f074c551ba0a233dc2cd6864b9960"
 CHKUPDATE="anitya::id=198704"

--- a/desktop-mate/libmatekbd/spec
+++ b/desktop-mate/libmatekbd/spec
@@ -1,5 +1,4 @@
-VER=1.26.0
-REL=1
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/libmatekbd-$VER.tar.xz"
-CHKSUMS="sha256::220ee8cab0cbc5f42ca6b621bcd009b0b736507945a2aedbffe2235fa1d811ad"
+CHKSUMS="sha256::63938d91252945eeea88fd8374d1231bd83d02cd965c6bba17c185edb397bced"
 CHKUPDATE="anitya::id=230603"

--- a/desktop-mate/libmatemixer/spec
+++ b/desktop-mate/libmatemixer/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/libmatemixer-$VER.tar.xz"
-CHKSUMS="sha256::9a9bcc605b27e9c5c91a28eb7cb79831e6d6fbf6339f5e5c18d524f3ee259ff1"
+CHKSUMS="sha256::4960f59a6b9faf82a01d4a4b8cc260b4868dd991efd4a9b17b5d0a15a1d3a1ae"
 CHKUPDATE="anitya::id=230604"

--- a/desktop-mate/libmateweather/spec
+++ b/desktop-mate/libmateweather/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.3
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/libmateweather-$VER.tar.xz"
-CHKSUMS="sha256::a7fd9713099c88826fb67249771cd0cdb92ee9d4784068b1a165840b84607b15"
+CHKSUMS="sha256::5e6cd24418847cb45acf17da5b435a7131cb4ec2acff68e828f342a1bf13ef4a"
 CHKUPDATE="anitya::id=230605"

--- a/desktop-mate/marco/spec
+++ b/desktop-mate/marco/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.2
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/marco-$VER.tar.xz"
-CHKSUMS="sha256::f63c08cd8b07450ab3e33a04605c4f9e69522358884273b3cbcf30275eee5b05"
+CHKSUMS="sha256::12f1a254fe1072f0304884711e089a5682780a011593402ed38de6b9480e07a3"
 CHKUPDATE="anitya::id=230606"

--- a/desktop-mate/mate-applets/spec
+++ b/desktop-mate/mate-applets/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-applets-$VER.tar.xz"
-CHKSUMS="sha256::b7e0439b4e0c754233c2988644faa3f6ab6270970061b7a0c635d68d236fc977"
+CHKSUMS="sha256::3ab8f61db376dc333ce4c18722c63a07fab3e8e1272b7e0e097ad4597b17c2c2"
 CHKUPDATE="anitya::id=230607"

--- a/desktop-mate/mate-control-center/spec
+++ b/desktop-mate/mate-control-center/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-control-center-$VER.tar.xz"
-CHKSUMS="sha256::286714ea778f6540fe74ef00aaf504c47141518d26ab224994f4a1af36b0134a"
+CHKSUMS="sha256::e05f492a3b657aa56fc58f7cf71bc8c80df8e25351fde4db4f523ab8db5b5608"
 CHKUPDATE="anitya::id=230610"

--- a/desktop-mate/mate-media/spec
+++ b/desktop-mate/mate-media/spec
@@ -1,5 +1,4 @@
-VER=1.26.0
-REL=1
+VER=1.26.2
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-media-$VER.tar.xz"
-CHKSUMS="sha256::8b731b203fd8219ccc2f2ced40e4301823a17f7940acf3cec72b4494a3fe3c3a"
+CHKSUMS="sha256::af46639574cc388513089ca10bb141ffc3e6d1ac33e730e4208db5759642850f"
 CHKUPDATE="anitya::id=230614"

--- a/desktop-mate/mate-menus/spec
+++ b/desktop-mate/mate-menus/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-menus-$VER.tar.xz"
-CHKSUMS="sha256::0309964abd813053368ac4fc446898d27cdb019e894e78cea75751a68871ffe4"
+CHKSUMS="sha256::458d599ae5b650c7d21740f9fe954c4a838be45ed62ab40e20e306faf5dd1d8c"
 CHKUPDATE="anitya::id=230616"

--- a/desktop-mate/mate-notification-daemon/spec
+++ b/desktop-mate/mate-notification-daemon/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-notification-daemon-$VER.tar.xz"
-CHKSUMS="sha256::b23c6581f8f5916d6a16584edd91c2e4b6d0db7dd8e1eec5dd360acf2834b9ba"
+CHKSUMS="sha256::0eae9296c48a3c71fd56f1931961f92d29e45a045fe5f1a05f83c7400c319924"
 CHKUPDATE="anitya::id=230618"

--- a/desktop-mate/mate-panel/spec
+++ b/desktop-mate/mate-panel/spec
@@ -1,4 +1,4 @@
-VER=1.26.1
+VER=1.26.4
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-panel-$VER.tar.xz"
-CHKSUMS="sha256::683038c483456e5068f5bb20c3d565936700c9898005c7149ee7aa44e5cc110d"
+CHKSUMS="sha256::2070f9d515657e5ddcda0d87ef729713dba9cb7b2ad06223bd674a21cc6b3daf"
 CHKUPDATE="anitya::id=230619"

--- a/desktop-mate/mate-polkit/spec
+++ b/desktop-mate/mate-polkit/spec
@@ -1,5 +1,4 @@
-VER=1.26.0
-
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-polkit-$VER.tar.xz"
-CHKSUMS="sha256::ada57812add0dff4b03ed03adb467c3a9e59e179c1cf52451988065a04d8724e"
+CHKSUMS="sha256::f5b7b0b5dfc53302c40403245998eb9121af3f50e71666a09ab73bb254520357"
 CHKUPDATE="anitya::id=230620"

--- a/desktop-mate/mate-power-manager/spec
+++ b/desktop-mate/mate-power-manager/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-power-manager-$VER.tar.xz"
-CHKSUMS="sha256::26b603ccf077366414a41e91ca6aa4c4c227a8e9fb6925a8ec5ca147c4e67b79"
+CHKSUMS="sha256::20cd9d22ed04babf98bb50e71a0ec5d78a8a476287723278f87da76cabfb1042"
 CHKUPDATE="anitya::id=230621"

--- a/desktop-mate/mate-screensaver/spec
+++ b/desktop-mate/mate-screensaver/spec
@@ -1,4 +1,4 @@
-VER=1.26.1
+VER=1.26.2
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-screensaver-$VER.tar.xz"
-CHKSUMS="sha256::4fbdb21ea4a59ea8de33ea9bf776d869753e49295604664c30e220e09659b8bc"
+CHKSUMS="sha256::da9700ce24145bd55d24927eecfe6d31d0a52eae86e563b2c65054b356a5ff7e"
 CHKUPDATE="anitya::id=230622"

--- a/desktop-mate/mate-session-manager/spec
+++ b/desktop-mate/mate-session-manager/spec
@@ -1,5 +1,4 @@
-VER=1.26.0
-REL=1
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-session-manager-$VER.tar.xz"
-CHKSUMS="sha256::5915a2f6583c0e5e58afb3abae3f4adbbe6a003c174a5b6e3d204b4e398a1816"
+CHKSUMS="sha256::5b8c7d6441fd9c293c863882ab67a7493c53cdf64eab27c094575f423ebd4278"
 CHKUPDATE="anitya::id=230624"

--- a/desktop-mate/mate-settings-daemon/spec
+++ b/desktop-mate/mate-settings-daemon/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-settings-daemon-$VER.tar.xz"
-CHKSUMS="sha256::b77aa017ff811a6fcae40bd45f18d8606eec87be21e3e6fa6d35c0fe14e66d41"
+CHKSUMS="sha256::697ea65b542921c2b766145292d268d3009cc2da8316d2a7869869055e4b1859"
 CHKUPDATE="anitya::id=230625"

--- a/desktop-mate/mate-system-monitor/spec
+++ b/desktop-mate/mate-system-monitor/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.2
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-system-monitor-$VER.tar.xz"
-CHKSUMS="sha256::83472c3add79e52b2fb3c1bc55f33f968c71a2b90e2b62027ad688c1cecc338f"
+CHKSUMS="sha256::be6d97dec68f5f36bde12f8acaf1ac5642d239a5d24161a82fff5064f4502544"
 CHKUPDATE="anitya::id=230626"

--- a/desktop-mate/mate-terminal/spec
+++ b/desktop-mate/mate-terminal/spec
@@ -1,5 +1,4 @@
-VER=1.26.0
-REL=1
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-terminal-$VER.tar.xz"
-CHKSUMS="sha256::7727e714c191c3c55e535e30931974e229ca5128e052b62ce74dcc18f7eaaf22"
+CHKSUMS="sha256::7c130206f0b47887e8c9274e73f8c19fae511134572869a7c23111b789e1e1d0"
 CHKUPDATE="anitya::id=198702"

--- a/desktop-mate/mate-themes/spec
+++ b/desktop-mate/mate-themes/spec
@@ -1,5 +1,4 @@
-VER=3.22.23
-
+VER=3.22.24
 SRCS="tbl::https://github.com/mate-desktop/mate-themes/archive/v$VER.tar.gz"
-CHKSUMS="sha256::004ae5ed5bb55798d8da3cca936442f386476eb5710b92b15f7bddb93a7a23c8"
+CHKSUMS="sha256::888b5d55eac395a27d772bd178ed1495c1d3fa9c585b52a205e9a4bb537a706c"
 CHKUPDATE="anitya::id=10938"

--- a/desktop-mate/mate-user-guide/spec
+++ b/desktop-mate/mate-user-guide/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.2
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-user-guide-$VER.tar.xz"
-CHKSUMS="sha256::0581d45053e9a1c16925c3154341b5b21140905a22b1bd3caa84619f9f05c2c0"
+CHKSUMS="sha256::4d32b6e3564ac8f4eaab2b15482df7f9769750df8811abed837d0a2e7ee3808b"
 CHKUPDATE="anitya::id=230628"

--- a/desktop-mate/mate-utils/spec
+++ b/desktop-mate/mate-utils/spec
@@ -1,5 +1,4 @@
-VER=1.26.0
-
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-utils-$VER.tar.xz"
-CHKSUMS="sha256::7ca56ab242e8efaa64f93ffb84f6e4bf8d4d0df01e20b3b6ef8956ce3192782e"
+CHKSUMS="sha256::2f53475b1a0991dd5a93d9dda58fca4e416f259253586d94a5b1108f12370620"
 CHKUPDATE="anitya::id=230630"

--- a/desktop-mate/mozo/spec
+++ b/desktop-mate/mozo/spec
@@ -1,4 +1,4 @@
-VER=1.26.1
+VER=1.26.2
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mozo-$VER.tar.xz"
-CHKSUMS="sha256::0f24429a3b037bd0688ec4c391d9d8781e42b23ef345f5e50af1e72c5ef2fa39"
+CHKSUMS="sha256::472c482e0ef2fb1629e61e17daaa1a487f64392b029849dc9a4082afb38bc9ee"
 CHKUPDATE="anitya::id=230632"

--- a/desktop-mate/pluma/spec
+++ b/desktop-mate/pluma/spec
@@ -1,4 +1,4 @@
-VER=1.26.0
+VER=1.26.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/pluma-$VER.tar.xz"
-CHKSUMS="sha256::310644dae7393cf5d47928fd4fab5d120da4e683ecf4fc248fcf778145f08a53"
+CHKSUMS="sha256::5959ece3d7118e106659f64d202d0ed1763ad10bbbba5d2acd8cbfba2e3994f1"
 CHKUPDATE="anitya::id=198621"


### PR DESCRIPTION
Topic Description
-----------------

This topic surveys MATE Desktop component updates.

Package(s) Affected
-------------------

- atril: 1.26.1
- caja: 1:1.26.3
- caja-extensions: 1.26.1
- engrampa: 1:1.26.1
- eom: 1:1.26.1
- libmatekbd: 1:1.26.1
- libmatemixer: 1:1.26.1
- libmateweather: 1:1.26.3
- libpeas: 1.32.0-1
- marco: 1:1.26.2
- mate-applets: 1:1.26.1
- mate-control-center: 1.26.1
- mate-media: 1.26.2
- mate-menus: 1:1.26.1
- mate-notification-daemon: 1:1.26.1
- mate-panel: 1:1.26.4
- mate-polkit: 1.26.1
- mate-power-manager: 1:1.26.1
- mate-screensaver: 1:1.26.2
- mate-session-manager: 1.26.1
- mate-settings-daemon: 1.26.1
- mate-system-monitor: 1:1.26.2
- mate-terminal: 1:1.26.1
- mate-themes: 3.22.24
- mate-user-guide: 1.26.2
- mate-utils: 1:1.26.1
- mozo: 1.26.2
- pluma: 1.26.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpeas caja atril caja-extensions engrampa eom libmatekbd libmatemixer libmateweather marco mate-menus mate-polkit mate-settings-daemon mate-session-manager mate-panel mate-applets mate-control-center mate-media mate-notification-daemon mate-power-manager mate-screensaver mate-system-monitor mate-terminal mate-themes mate-user-guide mate-utils mozo pluma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
