### PR TITLE
libseccomp: update to 2.5.5

### DIFF
--- a/runtime-common/libseccomp/spec
+++ b/runtime-common/libseccomp/spec
@@ -1,5 +1,4 @@
-VER=2.5.1
-REL=2
-SRCS="https://github.com/seccomp/libseccomp/releases/download/v$VER/libseccomp-$VER.tar.gz"
-CHKSUMS="sha256::ee307e383c77aa7995abc5ada544d51c9723ae399768a97667d4cdb3c3a30d55"
+VER=2.5.5
+SRCS="git::commit=tags/v$VER::https://github.com/seccomp/libseccomp"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13823"


### PR DESCRIPTION
Topic Description
-----------------

- libseccomp: update to 2.5.5
    This update enables loongarch64 host support.
    
Package(s) Affected
-------------------

- libseccomp: 2.5.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libseccomp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
