### PR TITLE
LTTng-UST (UserSpace Tracer): update to 2.13.5

### DIFF
--- a/runtime-common/lttng-ust/spec
+++ b/runtime-common/lttng-ust/spec
@@ -1,5 +1,4 @@
-VER=2.11.0
-REL=1
+VER=2.13.5
 SRCS="tbl::https://lttng.org/files/lttng-ust/lttng-ust-$VER.tar.bz2"
-CHKSUMS="sha256::683280cfe5e12021e64c32cef9eeb0128f1f23dec32ba28adb5a2074be37c4d8"
+CHKSUMS="sha256::f1d7bb4984a3dc5dacd3b7bcb4c10c04b041b0eecd7cba1fef3d8f86aff02bd6"
 CHKUPDATE="anitya::id=7135"


### PR DESCRIPTION
Topic Description
-----------------

- lttng-ust: update to 2.13.5
    This update enables loongarch64 host support.

Requires #5006.
    
Package(s) Affected
-------------------

- lttng-ust: 2.13.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit lttng-ust
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Second Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
