### PR TITLE
iotop: fix executable path

### DIFF
--- a/app-utils/iotop/autobuild/beyond
+++ b/app-utils/iotop/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Moving /usr/sbin => /usr/bin ..."
+mv -v "$PKGDIR"/usr/{s,}bin

--- a/app-utils/iotop/spec
+++ b/app-utils/iotop/spec
@@ -1,5 +1,5 @@
 VER=0.6
-REL=5
+REL=6
 SRCS="tbl::http://guichaz.free.fr/iotop/files/iotop-$VER.tar.gz"
 CHKSUMS="sha256::1a7c02fd3758bb048d8af861c5f8735eb3ee9abadeaa787f27b8af2b1eaee8ce"
 CHKUPDATE="anitya::id=1387"


### PR DESCRIPTION
Topic Description
-----------------

- iotop: move /usr/sbin => /usr/bin

Package(s) Affected
-------------------

- iotop: 0.6-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit iotop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
