### PR TITLE
cargo-c: update to 0.9.24

### DIFF
--- a/lang-rust/cargo-c/autobuild/defines
+++ b/lang-rust/cargo-c/autobuild/defines
@@ -7,6 +7,9 @@ USECLANG=1
 ABSPLITDBG=0
 NOLTO__RISCV64=1
 
+# FIXME: ld.lld is not available on loongarch64.
+NOLTO__LOONGARCH64=1
+
 # FIXME: Signal 11 on linkage.
 USECLANG__LOONGSON3=0
 NOLTO__LOONGSON3=1

--- a/lang-rust/cargo-c/autobuild/prepare
+++ b/lang-rust/cargo-c/autobuild/prepare
@@ -1,2 +1,2 @@
-abinfo "Copy artifact Cargo.lock ..."
-cp -v "$SRCDIR"/../Cargo.lock "${SRCDIR}"/
+abinfo "Generating Cargo.lock ..."
+cargo generate-lockfile

--- a/lang-rust/cargo-c/spec
+++ b/lang-rust/cargo-c/spec
@@ -1,8 +1,4 @@
-VER=0.9.16
-SRCS="tbl::https://github.com/lu-zero/cargo-c/archive/refs/tags/v$VER.tar.gz \
-      file::rename=Cargo.lock::https://github.com/lu-zero/cargo-c/releases/download/v$VER/Cargo.lock"
+VER=0.9.24
+SRCS="git::commit=tags/v$VER::https://github.com/lu-zero/cargo-c"
 CHKUPDATE="anitya::id=58394"
-CHKSUMS="sha256::a84e31fa1718db05f0c7708aff0688858362113d35828e0bc478199b5761256f \
-         sha256::7c517a5f852dba7487f13ef5fcd244daec9f5b37176660a330eeea625e395470"
-SUBDIR="cargo-c-$VER"
-REL=1
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- cargo-c: update to 0.9.24
    - This update fixes build on loongarch64.
    - (loongarch64) Disable LTO. [^1]
    
    [^1]: FIXME: ld.lld is not available on loongarch64.
    
Package(s) Affected
-------------------

- cargo-c: 0.9.24

Security Update?
----------------

No

Build Order
-----------

```
#buildit cargo-c
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
