### PR TITLE
starship: update to 1.17.1

### DIFF
--- a/app-utils/starship/autobuild/defines
+++ b/app-utils/starship/autobuild/defines
@@ -8,6 +8,7 @@ ABTYPE=rust
 USECLANG=1
 ABSPLITDBG=0
 
+# FIXME: libz-ng does not support loongson3 and mips64r6el
 CARGO_AFTER__LOONGSON3="--no-default-features --features gix-faster"
 CARGO_AFTER__MIPS64R6EL="--no-default-features --features gix-faster"
 

--- a/app-utils/starship/autobuild/defines
+++ b/app-utils/starship/autobuild/defines
@@ -13,4 +13,5 @@ CARGO_AFTER__LOONGSON3="--no-default-features --features gix-faster"
 # FIXME: ld.lld is not yet available.
 NOLTO__LOONGSON3=1
 NOLTO__LOONGARCH64=1
+NOLTO__MIPS64R6EL=1
 USECLANG__LOONGSON3=0

--- a/app-utils/starship/autobuild/defines
+++ b/app-utils/starship/autobuild/defines
@@ -9,6 +9,7 @@ USECLANG=1
 ABSPLITDBG=0
 
 CARGO_AFTER__LOONGSON3="--no-default-features --features gix-faster"
+CARGO_AFTER__MIPS64R6EL="--no-default-features --features gix-faster"
 
 # FIXME: ld.lld is not yet available.
 NOLTO__LOONGSON3=1

--- a/app-utils/starship/spec
+++ b/app-utils/starship/spec
@@ -1,4 +1,4 @@
-VER=1.17.0
+VER=1.17.1
 SRCS="git::commit=tags/v$VER::https://github.com/starship/starship"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=55456"

--- a/app-utils/starship/spec
+++ b/app-utils/starship/spec
@@ -1,4 +1,4 @@
-VER=1.16.0
+VER=1.17.0
 SRCS="git::commit=tags/v$VER::https://github.com/starship/starship"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=55456"


### PR DESCRIPTION
Topic Description
-----------------

- starship: update to 1.17.0

Package(s) Affected
-------------------

- starship: 1.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit starship
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
