### PR TITLE
Mstflint: update to 4.25.0+1

### DIFF
--- a/app-admin/mstflint/autobuild/patches/0001-hardware-support-linux-on-loongarch64.patch
+++ b/app-admin/mstflint/autobuild/patches/0001-hardware-support-linux-on-loongarch64.patch
@@ -1,0 +1,71 @@
+From 1641246ad0c45528c5f3db22059e79ce7108ddf9 Mon Sep 17 00:00:00 2001
+From: Tianhao Chai <cth451@gmail.com>
+Date: Thu, 14 Sep 2023 02:00:39 +0000
+Subject: [PATCH] hardware support: linux on loongarch64
+
+---
+ common/compatibility.h         | 4 +++-
+ mtcr_ul/packets_common.h       | 2 ++
+ tools_layouts/adb_to_c_utils.h | 4 +++-
+ 3 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/common/compatibility.h b/common/compatibility.h
+index e5991c2..7d582d6 100644
+--- a/common/compatibility.h
++++ b/common/compatibility.h
+@@ -69,6 +69,8 @@
+ #define ARCH_arm6l
+ #elif defined(__riscv)
+ #define ARCH_riscv
++#elif defined(__loongarch64)
++#define ARCH_loongarch64
+ #else
+ #error Unknown CPU architecture using the linux OS
+ #endif
+@@ -116,7 +118,7 @@
+ #define U48H_FMT "0x%012llx"
+ #define U64D_FMT_GEN "llu"
+ #endif
+-#elif defined(ARCH_ia64) || defined(ARCH_x86_64) || defined(ARCH_ppc64) || defined(ARCH_arm64) || defined(ARCH_riscv)
++#elif defined(ARCH_ia64) || defined(ARCH_x86_64) || defined(ARCH_ppc64) || defined(ARCH_arm64) || defined(ARCH_riscv) || defined(ARCH_loongarch64)
+ #define U64D_FMT "%lu"
+ #define U64H_FMT "0x%016lx"
+ #define U48H_FMT "0x%012lx"
+diff --git a/mtcr_ul/packets_common.h b/mtcr_ul/packets_common.h
+index 2ab255f..b693d06 100644
+--- a/mtcr_ul/packets_common.h
++++ b/mtcr_ul/packets_common.h
+@@ -152,6 +152,8 @@
+ #define ARCH_arm6l
+ #elif defined(__riscv)
+ #define ARCH_riscv
++#elif defined(__loongarch64)
++#define ARCH_loongarch64
+ #else
+ #error Unknown CPU architecture using the linux OS
+ #endif
+diff --git a/tools_layouts/adb_to_c_utils.h b/tools_layouts/adb_to_c_utils.h
+index 5aa7f3c..364df31 100644
+--- a/tools_layouts/adb_to_c_utils.h
++++ b/tools_layouts/adb_to_c_utils.h
+@@ -146,6 +146,8 @@ extern "C"
+ #define ARCH_arm6l
+ #elif defined(__riscv)
+ #define ARCH_riscv
++#elif defined(__loongarch64)
++#define ARCH_loongarch64
+ #else
+ #error Unknown CPU architecture using the linux OS
+ #endif
+@@ -188,7 +190,7 @@ extern "C"
+ #define U64H_FMT "0x%016llx"
+ #define U48H_FMT "0x%012llx"
+ #endif
+-#elif defined(ARCH_ia64) || defined(ARCH_x86_64) || defined(ARCH_ppc64) || defined(ARCH_arm64) || defined(ARCH_riscv)
++#elif defined(ARCH_ia64) || defined(ARCH_x86_64) || defined(ARCH_ppc64) || defined(ARCH_arm64) || defined(ARCH_riscv) || defined(ARCH_loongarch64)
+ #define U64D_FMT "%lu"
+ #define U64H_FMT "0x%016lx"
+ #define U48H_FMT "0x%012lx"
+-- 
+2.39.1
+

--- a/app-admin/mstflint/spec
+++ b/app-admin/mstflint/spec
@@ -1,5 +1,5 @@
-VER=4.18.0+1
+VER=4.25.0+1
 SRCS="tbl::https://github.com/Mellanox/mstflint/releases/download/v${VER/+/-}/mstflint-${VER/+/-}.tar.gz"
-CHKSUMS="sha256::b5e98bb3c97a1d7cea2f4bd7a719b7d7af4765d576cf7e8198a8a88784a66641"
+CHKSUMS="sha256::9d81a259fafc6b7ab7f9b1946f5a2f2eb012f3f2e71097fee229c8125956f79b"
 CHKUPDATE="anitya::id=13357"
 REL=1

--- a/app-admin/rdma-core/autobuild/defines
+++ b/app-admin/rdma-core/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=rdma-core
 PKGSEC=admin
 PKGDEP="ethtool libnl"
-BUILDDEP="systemd python-3 docutils cython"
+# FIXME: Version 38.0 is not yet compatible with Cython 3.x.
+BUILDDEP="systemd python-3 docutils cython-0.29"
 PKGDES="RDMA userspace libraries and utilites"
 
 PKGPROV="rdma infiniband-diags"

--- a/app-admin/rdma-core/spec
+++ b/app-admin/rdma-core/spec
@@ -1,4 +1,5 @@
 VER=38.0
+REL=1
 SRCS="tbl::https://github.com/linux-rdma/rdma-core/releases/download/v${VER}/rdma-core-${VER}.tar.gz"
 CHKSUMS="sha256::9a8dcc9fae13c7d8a41fb2303927fc5b00aefffc12485bd7aae4cfd4f9f27b10"
 CHKUPDATE="anitya::id=12907"


### PR DESCRIPTION
Topic Description
-----------------

- rdma-core: use cython-0.29
- mstflint: update to 4.25.0+1
    - Introduce a patch to add loongarch64 support.
    
Package(s) Affected
-------------------

- rdma-core: 38.0
- mstflint: 4.25.0+1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rdma-core mstflint
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
