### PR TITLE
atm (AOSC Topic Manager): update to 0.6.2

### DIFF
--- a/app-admin/atm/autobuild/defines
+++ b/app-admin/atm/autobuild/defines
@@ -13,3 +13,6 @@ ABSPLITDBG=0
 
 # FIXME: Segfaults during linkage.
 NOLTO__LOONGSON3=1
+
+# FIXME: ld.lld is not yet available.
+NOLTO__LOONGARCH64=1

--- a/app-admin/atm/spec
+++ b/app-admin/atm/spec
@@ -1,4 +1,4 @@
-VER=0.6.1
+VER=0.6.2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/atm.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226686"


### PR DESCRIPTION
Topic Description
-----------------

- atm: update to 0.6.2
    - This version fixes build with LoongArch64.
    - (loongarch64) disable LTO.
    
Package(s) Affected
-------------------

- atm: 0.6.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit atm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
