### PR TITLE
libblkio: (upstream patch) update Cargo dependencies

### DIFF
--- a/runtime-common/libblkio/autobuild/patches/0001-Update-Cargo.lock.patch
+++ b/runtime-common/libblkio/autobuild/patches/0001-Update-Cargo.lock.patch
@@ -1,0 +1,152 @@
+From 792b6b97901bfe590bfc31bd6f472094639d3723 Mon Sep 17 00:00:00 2001
+From: Alberto Faria <afaria@redhat.com>
+Date: Sat, 5 Aug 2023 12:07:19 +0100
+Subject: [PATCH] Update Cargo.lock
+
+Update to pci-driver 0.1.4 to fix misaligned memory accesses in the
+virtio-blk-vfio-pci driver.
+
+Also update the other dependencies for good measure.
+
+Signed-off-by: Alberto Faria <afaria@redhat.com>
+---
+ Cargo.lock | 51 +++++++++++++++++++++++++++------------------------
+ 1 file changed, 27 insertions(+), 24 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 3000431..b1d3a74 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -30,15 +30,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.79"
++version = "1.0.81"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
++checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
++dependencies = [
++ "libc",
++]
+ 
+ [[package]]
+ name = "errno"
+-version = "0.3.1"
++version = "0.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
++checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+ dependencies = [
+  "errno-dragonfly",
+  "libc",
+@@ -57,15 +60,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "hermit-abi"
+-version = "0.3.1"
++version = "0.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
++checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+ 
+ [[package]]
+ name = "io-lifetimes"
+-version = "1.0.10"
++version = "1.0.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
++checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+ dependencies = [
+  "hermit-abi",
+  "libc",
+@@ -99,15 +102,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.142"
++version = "0.2.147"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
++checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+ 
+ [[package]]
+ name = "linux-raw-sys"
+-version = "0.3.4"
++version = "0.3.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
++checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+ 
+ [[package]]
+ name = "memmap2"
+@@ -120,24 +123,24 @@ dependencies = [
+ 
+ [[package]]
+ name = "num-traits"
+-version = "0.2.15"
++version = "0.2.16"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
++checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+ dependencies = [
+  "autocfg",
+ ]
+ 
+ [[package]]
+ name = "paste"
+-version = "1.0.12"
++version = "1.0.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
++checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+ 
+ [[package]]
+ name = "pci-driver"
+-version = "0.1.3"
++version = "0.1.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ee69f11b9613f88aaec808f614e0c8d63c9111a2cf3178a3134c5d900531dba2"
++checksum = "da882b89e91da979a91f6cc32f54e5bdbb18c6b46280a032a2225e30a03390fd"
+ dependencies = [
+  "libc",
+  "num-traits",
+@@ -145,9 +148,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustix"
+-version = "0.37.15"
++version = "0.37.23"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a0661814f891c57c930a610266415528da53c4933e6dea5fb350cbfe048a9ece"
++checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+ dependencies = [
+  "bitflags",
+  "errno",
+@@ -159,9 +162,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "virtio-bindings"
+-version = "0.2.0"
++version = "0.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0b9084faf91b9aa9676ae2cac8f1432df2839d9566e6f19f29dbc13a8b831dff"
++checksum = "c18d7b74098a946470ea265b5bacbbf877abc3373021388454de0d47735a5b98"
+ 
+ [[package]]
+ name = "virtio-driver"
+@@ -186,9 +189,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "windows-targets"
+-version = "0.48.0"
++version = "0.48.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
++checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+ dependencies = [
+  "windows_aarch64_gnullvm",
+  "windows_aarch64_msvc",
+-- 
+2.39.1
+

--- a/runtime-common/libblkio/spec
+++ b/runtime-common/libblkio/spec
@@ -1,4 +1,5 @@
 VER=1.3.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://gitlab.com/libblkio/libblkio"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368864"


### PR DESCRIPTION
Topic Description
-----------------

- libblkio: (upstream patch) update Cargo dependencies
    - This fixes build on loongarch64.
    
Package(s) Affected
-------------------

- libblkio: 1.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libblkio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
