### PR TITLE
Libvirt Survey (December 2023)

### DIFF
--- a/app-admin/zfs/autobuild/build
+++ b/app-admin/zfs/autobuild/build
@@ -1,3 +1,6 @@
+abinfo "Enabling Bash extended globbing support ..."
+shopt -s extglob
+
 abinfo "Configuring ZFS userspace tools ..."
 mkdir -pv "$SRCDIR"/build
 cd "$SRCDIR"/build

--- a/app-network/wireshark/autobuild/defines
+++ b/app-network/wireshark/autobuild/defines
@@ -7,3 +7,6 @@ PKGDEP="brotli c-ares desktop-file-utils glib gnutls krb5 libcap libgcrypt libnl
 BUILDDEP="docbook-xsl doxygen lynx w3m asciidoctor"
 
 CMAKE_AFTER="-DDISABLE_WERROR=ON"
+
+# FIXME: /usr/bin/ld: not enough GOT space for local GOT entries
+NOLTO__MIPS64R6EL=1

--- a/app-network/wireshark/autobuild/prepare
+++ b/app-network/wireshark/autobuild/prepare
@@ -1,1 +1,9 @@
 export PATH="$PATH:/usr/lib/qt5/bin"
+
+# FIXME: /usr/bin/ld: not enough GOT space for local GOT entries
+# /usr/bin/ld: BFD (GNU Binutils) 2.41 internal error, aborting at
+# .../binutils-2.41/bfd/elfxx-mips.c:10714 in _bfd_mips_elf_relocate_section
+if ab_match_arch mips64r6el; then
+    abinfo "Appending -mxgot to fix linkage ..."
+    export LDFLAGS="${LDFLAGS} -mxgot"
+fi

--- a/app-virtualization/libvirt/autobuild/patches/0001-Add-loongarch-cpu-support.patch
+++ b/app-virtualization/libvirt/autobuild/patches/0001-Add-loongarch-cpu-support.patch
@@ -1,0 +1,990 @@
+From 5dcb70783a2738a2b3dd182c6fec094b4b1297bb Mon Sep 17 00:00:00 2001
+From: lixianglai <lixianglai@loongson.cn>
+Date: Fri, 28 Jul 2023 02:45:55 -0400
+Subject: [PATCH 1/6] Add loongarch cpu support
+
+Add loongarch cpu support, Define new cpu type 'loongarch64'
+and implement it's driver functions.
+
+Signed-off-by: lixianglai <lixianglai@loongson.cn>
+---
+ po/POTFILES                     |   1 +
+ src/conf/schemas/basictypes.rng |   1 +
+ src/cpu/cpu.c                   |   2 +
+ src/cpu/cpu.h                   |   2 +
+ src/cpu/cpu_loongarch.c         | 742 ++++++++++++++++++++++++++++++++
+ src/cpu/cpu_loongarch.h         |  25 ++
+ src/cpu/cpu_loongarch_data.h    |  37 ++
+ src/cpu/meson.build             |   1 +
+ src/qemu/qemu_capabilities.c    |   1 +
+ src/qemu/qemu_domain.c          |   4 +
+ src/util/virarch.c              |   2 +
+ src/util/virarch.h              |   4 +
+ 12 files changed, 822 insertions(+)
+ create mode 100644 src/cpu/cpu_loongarch.c
+ create mode 100644 src/cpu/cpu_loongarch.h
+ create mode 100644 src/cpu/cpu_loongarch_data.h
+
+diff --git a/po/POTFILES b/po/POTFILES
+index 3a51aea5cb..c0e66d563e 100644
+--- a/po/POTFILES
++++ b/po/POTFILES
+@@ -70,6 +70,7 @@ src/cpu/cpu.c
+ src/cpu/cpu_arm.c
+ src/cpu/cpu_map.c
+ src/cpu/cpu_ppc64.c
++src/cpu/cpu_loongarch.c
+ src/cpu/cpu_riscv64.c
+ src/cpu/cpu_s390.c
+ src/cpu/cpu_x86.c
+diff --git a/src/conf/schemas/basictypes.rng b/src/conf/schemas/basictypes.rng
+index 26eb538077..04f032b3ab 100644
+--- a/src/conf/schemas/basictypes.rng
++++ b/src/conf/schemas/basictypes.rng
+@@ -470,6 +470,7 @@
+       <value>x86_64</value>
+       <value>xtensa</value>
+       <value>xtensaeb</value>
++      <value>loongarch64</value>
+     </choice>
+   </define>
+ 
+diff --git a/src/cpu/cpu.c b/src/cpu/cpu.c
+index bc43aa4e93..1e7c879ca5 100644
+--- a/src/cpu/cpu.c
++++ b/src/cpu/cpu.c
+@@ -27,6 +27,7 @@
+ #include "cpu_ppc64.h"
+ #include "cpu_s390.h"
+ #include "cpu_arm.h"
++#include "cpu_loongarch.h"
+ #include "cpu_riscv64.h"
+ #include "capabilities.h"
+ 
+@@ -41,6 +42,7 @@ static struct cpuArchDriver *drivers[] = {
+     &cpuDriverS390,
+     &cpuDriverArm,
+     &cpuDriverRiscv64,
++    &cpuDriverLoongArch,
+ };
+ 
+ 
+diff --git a/src/cpu/cpu.h b/src/cpu/cpu.h
+index a4cdb37f03..9ec0a109b8 100644
+--- a/src/cpu/cpu.h
++++ b/src/cpu/cpu.h
+@@ -27,6 +27,7 @@
+ #include "cpu_x86_data.h"
+ #include "cpu_ppc64_data.h"
+ #include "cpu_arm_data.h"
++#include "cpu_loongarch_data.h"
+ 
+ 
+ typedef struct _virCPUData virCPUData;
+@@ -36,6 +37,7 @@ struct _virCPUData {
+         virCPUx86Data x86;
+         virCPUppc64Data ppc64;
+         virCPUarmData arm;
++        virCPULoongArchData loongarch;
+         /* generic driver needs no data */
+     } data;
+ };
+diff --git a/src/cpu/cpu_loongarch.c b/src/cpu/cpu_loongarch.c
+new file mode 100644
+index 0000000000..0f96535606
+--- /dev/null
++++ b/src/cpu/cpu_loongarch.c
+@@ -0,0 +1,742 @@
++/*
++ * cpu_loongarch.c: CPU driver for 64-bit LOONGARCH CPUs
++ *
++ * Copyright (C) 2023 Loongson Technology.
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library.  If not, see
++ * <http://www.gnu.org/licenses/>.
++ */
++
++#include <config.h>
++#include <fcntl.h>
++#include <unistd.h>
++#include <stdint.h>
++#include <stdio.h>
++#include <sys/time.h>
++#include <sys/types.h>
++#include <sys/stat.h>
++#include "virlog.h"
++#include "viralloc.h"
++#include "cpu.h"
++#include "virstring.h"
++#include "cpu_map.h"
++#include "virbuffer.h"
++
++#define VIR_FROM_THIS VIR_FROM_CPU
++
++VIR_LOG_INIT("cpu.cpu_loongarch");
++
++static const virArch archs[] = { VIR_ARCH_LOONGARCH64 };
++
++typedef struct _virCPULoongArchVendor virCPULoongArchVendor;
++struct _virCPULoongArchVendor {
++    char *name;
++};
++
++typedef struct _virCPULoongArchModel virCPULoongArchModel;
++struct _virCPULoongArchModel {
++    char *name;
++    const virCPULoongArchVendor *vendor;
++    virCPULoongArchData data;
++};
++
++typedef struct _virCPULoongArchMap virCPULoongArchMap;
++struct _virCPULoongArchMap {
++    size_t nvendors;
++    virCPULoongArchVendor **vendors;
++    size_t nmodels;
++    virCPULoongArchModel **models;
++};
++
++static void
++virCPULoongArchDataClear(virCPULoongArchData *data)
++{
++    if (!data)
++        return;
++
++    VIR_FREE(data->prid);
++}
++
++static int
++virCPULoongArchDataCopy(virCPULoongArchData *dst,
++                        const virCPULoongArchData *src)
++{
++    size_t i;
++
++    dst->prid = g_new0(virCPULoongArchPrid, src->len);
++    if (!dst->prid)
++        return -1;
++
++    dst->len = src->len;
++
++    for (i = 0; i < src->len; i++) {
++        dst->prid[i].value = src->prid[i].value;
++        dst->prid[i].mask = src->prid[i].mask;
++    }
++
++    return 0;
++}
++
++static void
++virCPULoongArchVendorFree(virCPULoongArchVendor *vendor)
++{
++    if (!vendor)
++        return;
++
++    VIR_FREE(vendor->name);
++    VIR_FREE(vendor);
++}
++
++static virCPULoongArchVendor *
++virCPULoongArchVendorFind(const virCPULoongArchMap *map,
++                    const char *name)
++{
++    size_t i;
++
++    for (i = 0; i < map->nvendors; i++) {
++        if (STREQ(map->vendors[i]->name, name))
++            return map->vendors[i];
++    }
++
++    return NULL;
++}
++
++static void
++virCPULoongArchModelFree(virCPULoongArchModel *model)
++{
++    if (!model)
++        return;
++
++    virCPULoongArchDataClear(&model->data);
++    VIR_FREE(model->name);
++    VIR_FREE(model);
++}
++
++static virCPULoongArchModel *
++virCPULoongArchModelCopy(const virCPULoongArchModel *model)
++{
++    virCPULoongArchModel *copy;
++
++    copy = g_new0(virCPULoongArchModel, 1);
++    if (!copy)
++        goto cleanup;
++
++    copy->name = g_strdup(model->name);
++
++    if (virCPULoongArchDataCopy(&copy->data, &model->data) < 0)
++        goto cleanup;
++
++    copy->vendor = model->vendor;
++
++    return copy;
++
++ cleanup:
++    virCPULoongArchModelFree(copy);
++    return NULL;
++}
++
++static virCPULoongArchModel *
++virCPULoongArchModelFind(const virCPULoongArchMap *map,
++                   const char *name)
++{
++    size_t i;
++
++    for (i = 0; i < map->nmodels; i++) {
++        if (STREQ(map->models[i]->name, name))
++            return map->models[i];
++    }
++
++    return NULL;
++}
++
++static virCPULoongArchModel *
++virCPULoongArchModelFindPrid(const virCPULoongArchMap *map,
++                       uint32_t prid)
++{
++    size_t i;
++    size_t j;
++
++    for (i = 0; i < map->nmodels; i++) {
++        virCPULoongArchModel *model = map->models[i];
++        for (j = 0; j < model->data.len; j++) {
++            if ((prid & model->data.prid[j].mask) == model->data.prid[j].value)
++                return model;
++        }
++    }
++
++    return NULL;
++}
++
++static virCPULoongArchModel *
++virCPULoongArchModelFromCPU(const virCPUDef *cpu,
++                      const virCPULoongArchMap *map)
++{
++    virCPULoongArchModel *model;
++
++    if (!cpu->model) {
++        virReportError(VIR_ERR_INVALID_ARG, "%s",
++                       _("no CPU model specified"));
++        return NULL;
++    }
++
++    if (!(model = virCPULoongArchModelFind(map, cpu->model))) {
++        virReportError(VIR_ERR_INTERNAL_ERROR,
++                       _("Unknown CPU model %1$s"), cpu->model);
++        return NULL;
++    }
++
++    return virCPULoongArchModelCopy(model);
++}
++
++static void
++virCPULoongArchMapFree(virCPULoongArchMap *map)
++{
++    size_t i;
++
++    if (!map)
++        return;
++
++    for (i = 0; i < map->nmodels; i++)
++        virCPULoongArchModelFree(map->models[i]);
++    VIR_FREE(map->models);
++
++    for (i = 0; i < map->nvendors; i++)
++        virCPULoongArchVendorFree(map->vendors[i]);
++    VIR_FREE(map->vendors);
++
++    VIR_FREE(map);
++}
++
++static int
++virCPULoongArchVendorParse(xmlXPathContextPtr ctxt ATTRIBUTE_UNUSED,
++                     const char *name,
++                     void *data)
++{
++    virCPULoongArchMap *map = data;
++    virCPULoongArchVendor *vendor;
++    int ret = -1;
++
++    vendor = g_new0(virCPULoongArchVendor, 1);
++    if (!vendor)
++        return ret;
++    vendor->name = g_strdup(name);
++
++    if (virCPULoongArchVendorFind(map, vendor->name)) {
++        virReportError(VIR_ERR_INTERNAL_ERROR,
++                       _("CPU vendor %1$s already defined"), vendor->name);
++        goto cleanup;
++    }
++
++    VIR_APPEND_ELEMENT(map->vendors, map->nvendors, vendor);
++
++    ret = 0;
++
++ cleanup:
++    virCPULoongArchVendorFree(vendor);
++    return ret;
++}
++
++static int
++virCPULoongArchModelParse(xmlXPathContextPtr ctxt,
++                    const char *name,
++                    void *data)
++{
++    virCPULoongArchMap *map = data;
++    virCPULoongArchModel *model;
++    xmlNodePtr *nodes = NULL;
++    char *vendor = NULL;
++    uint32_t prid;
++    size_t i;
++    int n;
++    int ret = -1;
++
++    model = g_new0(virCPULoongArchModel, 1);
++    if (!model)
++        goto cleanup;
++
++    model->name = g_strdup(name);
++
++    if (virCPULoongArchModelFind(map, model->name)) {
++        virReportError(VIR_ERR_INTERNAL_ERROR,
++                       _("CPU model %1$s already defined"), model->name);
++        goto cleanup;
++    }
++
++    if (virXPathBoolean("boolean(./vendor)", ctxt)) {
++        vendor = virXPathString("string(./vendor/@name)", ctxt);
++        if (!vendor) {
++            virReportError(VIR_ERR_INTERNAL_ERROR,
++                           _("Invalid vendor element in CPU model %1$s"),
++                           model->name);
++            goto cleanup;
++        }
++
++        if (!(model->vendor = virCPULoongArchVendorFind(map, vendor))) {
++            virReportError(VIR_ERR_INTERNAL_ERROR,
++                           _("Unknown vendor %1$s referenced by CPU model %2$s"),
++                           vendor, model->name);
++            goto cleanup;
++        }
++    }
++
++    if ((n = virXPathNodeSet("./prid", ctxt, &nodes)) <= 0) {
++        virReportError(VIR_ERR_INTERNAL_ERROR,
++                       _("Missing Prid information for CPU model %1$s"),
++                       model->name);
++        goto cleanup;
++    }
++
++    model->data.prid = g_new0(virCPULoongArchPrid, n);
++    if (!model->data.prid)
++        goto cleanup;
++
++    model->data.len = n;
++
++    for (i = 0; i < n; i++) {
++
++        if (virXMLPropUInt(nodes[i], "value", 16, VIR_XML_PROP_REQUIRED,
++                                &prid) < 0)
++        {
++            virReportError(VIR_ERR_INTERNAL_ERROR,
++                           _("Missing or invalid Prid value in CPU model %1$s"),
++                           model->name);
++            goto cleanup;
++        }
++        model->data.prid[i].value = prid;
++
++        if (virXMLPropUInt(nodes[i], "mask", 16, VIR_XML_PROP_REQUIRED,
++                                &prid) < 0)
++        {
++            virReportError(VIR_ERR_INTERNAL_ERROR,
++                           _("Missing or invalid PVR mask in CPU model %1$s"),
++                           model->name);
++            goto cleanup;
++        }
++        model->data.prid[i].mask = prid;
++    }
++
++    VIR_APPEND_ELEMENT(map->models, map->nmodels, model);
++
++    ret = 0;
++
++ cleanup:
++    virCPULoongArchModelFree(model);
++    VIR_FREE(vendor);
++    VIR_FREE(nodes);
++    return ret;
++}
++
++static virCPULoongArchMap *
++virCPULoongArchLoadMap(void)
++{
++    virCPULoongArchMap *map;
++
++    map = g_new0(virCPULoongArchMap, 1);
++    if (!map)
++        goto cleanup;
++
++    if (cpuMapLoad("loongarch64", virCPULoongArchVendorParse, NULL,
++                    virCPULoongArchModelParse, map) < 0)
++        goto cleanup;
++
++    return map;
++
++ cleanup:
++    virCPULoongArchMapFree(map);
++    return NULL;
++}
++
++static virCPUData *
++virCPULoongArchMakeCPUData(virArch arch,
++                     virCPULoongArchData *data)
++{
++    virCPUData * cpuData;
++
++    cpuData = g_new0(virCPUData, 1);
++    if (!cpuData)
++        return NULL;
++
++    cpuData->arch = arch;
++
++    if (virCPULoongArchDataCopy(&cpuData->data.loongarch, data) < 0)
++        VIR_FREE(cpuData);
++
++    return cpuData;
++}
++
++static virCPUCompareResult
++virCPULoongArchCompute(virCPUDef *host,
++                 const virCPUDef *other,
++                 virCPUData **guestData,
++                 char **message)
++{
++    virCPULoongArchMap *map = NULL;
++    virCPULoongArchModel *host_model = NULL;
++    virCPULoongArchModel *guest_model = NULL;
++    virCPUDef *cpu = NULL;
++    virCPUCompareResult ret = VIR_CPU_COMPARE_ERROR;
++    virArch arch;
++    size_t i;
++
++    /* Ensure existing configurations are handled correctly */
++    if (!(cpu = virCPUDefCopy(other)))
++        goto cleanup;
++
++    if (cpu->arch != VIR_ARCH_NONE) {
++        bool found = false;
++
++        for (i = 0; i < G_N_ELEMENTS(archs); i++) {
++            if (archs[i] == cpu->arch) {
++                found = true;
++                break;
++            }
++        }
++
++        if (!found) {
++            VIR_DEBUG("CPU arch %s does not match host arch",
++                      virArchToString(cpu->arch));
++            if (message) {
++                *message = g_strdup_printf(_("CPU arch %1$s does not match host arch"),
++                                             virArchToString(cpu->arch));
++            }
++            ret = VIR_CPU_COMPARE_INCOMPATIBLE;
++            goto cleanup;
++        }
++        arch = cpu->arch;
++    } else {
++        arch = host->arch;
++    }
++
++    if (cpu->vendor &&
++        (!host->vendor || STRNEQ(cpu->vendor, host->vendor))) {
++        VIR_DEBUG("host CPU vendor does not match required CPU vendor %s",
++                  cpu->vendor);
++        if (message) {
++            *message = g_strdup_printf(_("host CPU vendor does not match required CPU vendor %1$s"),
++                                       cpu->vendor);
++        }
++        ret = VIR_CPU_COMPARE_INCOMPATIBLE;
++        goto cleanup;
++    }
++
++    if (!(map = virCPULoongArchLoadMap()))
++        goto cleanup;
++
++    /* Host CPU information */
++    if (!(host_model = virCPULoongArchModelFromCPU(host, map)))
++        goto cleanup;
++
++    if (cpu->type == VIR_CPU_TYPE_GUEST) {
++        /* Guest CPU information */
++        switch (cpu->mode) {
++        case VIR_CPU_MODE_HOST_MODEL:
++        case VIR_CPU_MODE_HOST_PASSTHROUGH:
++            /* host-model and host-passthrough:
++             * the guest CPU is the same as the host */
++            guest_model = virCPULoongArchModelCopy(host_model);
++            break;
++
++        case VIR_CPU_MODE_CUSTOM:
++            /* custom:
++             * look up guest CPU information */
++            guest_model = virCPULoongArchModelFromCPU(cpu, map);
++            break;
++        }
++    } else {
++        /* Other host CPU information */
++        guest_model = virCPULoongArchModelFromCPU(cpu, map);
++    }
++
++    if (!guest_model)
++        goto cleanup;
++
++    if (STRNEQ(guest_model->name, host_model->name)) {
++        VIR_DEBUG("host CPU model does not match required CPU model %s",
++                  guest_model->name);
++        if (message) {
++            *message = g_strdup_printf(_("host CPU model does not match required CPU model %1$s"),
++                                       guest_model->name);
++        }
++        ret = VIR_CPU_COMPARE_INCOMPATIBLE;
++        goto cleanup;
++    }
++
++    if (guestData)
++        if (!(*guestData = virCPULoongArchMakeCPUData(arch, &guest_model->data)))
++            goto cleanup;
++
++    ret = VIR_CPU_COMPARE_IDENTICAL;
++
++ cleanup:
++    virCPUDefFree(cpu);
++    virCPULoongArchMapFree(map);
++    virCPULoongArchModelFree(host_model);
++    virCPULoongArchModelFree(guest_model);
++    return ret;
++}
++
++static virCPUCompareResult
++virCPULoongArchCompare(virCPUDef *host,
++                       virCPUDef *cpu,
++                       bool failIncompatible)
++{
++    virCPUCompareResult ret;
++    char *message = NULL;
++
++    if (!host || !host->model) {
++        if (failIncompatible) {
++            virReportError(VIR_ERR_CPU_INCOMPATIBLE, "%s",
++                           _("unknown host CPU"));
++        } else {
++            VIR_WARN("unknown host CPU");
++            ret = VIR_CPU_COMPARE_INCOMPATIBLE;
++        }
++        return -1;
++    }
++
++    ret = virCPULoongArchCompute(host, cpu, NULL, &message);
++
++    if (failIncompatible && ret == VIR_CPU_COMPARE_INCOMPATIBLE) {
++        ret = VIR_CPU_COMPARE_ERROR;
++        if (message) {
++            virReportError(VIR_ERR_CPU_INCOMPATIBLE, "%s", message);
++        } else {
++            virReportError(VIR_ERR_CPU_INCOMPATIBLE, NULL);
++        }
++    }
++    VIR_FREE(message);
++
++    return ret;
++}
++
++static int
++virCPULoongArchDriverDecode(virCPUDef *cpu,
++                      const virCPUData *data,
++                      virDomainCapsCPUModels *models)
++{
++    int ret = -1;
++    virCPULoongArchMap *map;
++    const virCPULoongArchModel *model;
++
++    if (!data || !(map = virCPULoongArchLoadMap()))
++        return -1;
++
++    if (!(model = virCPULoongArchModelFindPrid(map, data->data.loongarch.prid[0].value))) {
++        virReportError(VIR_ERR_OPERATION_FAILED,
++                       _("Cannot find CPU model with Prid 0x%1$08x"),
++                       data->data.loongarch.prid[0].value);
++        goto cleanup;
++    }
++
++    if (!virCPUModelIsAllowed(model->name, models)) {
++        virReportError(VIR_ERR_CONFIG_UNSUPPORTED,
++                       _("CPU model %1$s is not supported by hypervisor"),
++                       model->name);
++        goto cleanup;
++    }
++
++    cpu->model = g_strdup(model->name);
++    if (model->vendor) {
++        cpu->vendor = g_strdup(model->vendor->name);
++    }
++    ret = 0;
++
++ cleanup:
++    virCPULoongArchMapFree(map);
++
++    return ret;
++}
++
++static void
++virCPULoongArchDataFree(virCPUData *data)
++{
++    if (!data)
++        return;
++
++    virCPULoongArchDataClear(&data->data.loongarch);
++    VIR_FREE(data);
++}
++
++static int
++virCPULoongArchGetHostPRID(void)
++{
++    return 0x14c010;
++}
++
++static int
++virCPULoongArchGetHost(virCPUDef *cpu,
++                       virDomainCapsCPUModels *models)
++{
++    virCPUData *cpuData = NULL;
++    virCPULoongArchData *data;
++    int ret = -1;
++
++    if (!(cpuData = virCPUDataNew(archs[0])))
++        goto cleanup;
++
++    data = &cpuData->data.loongarch;
++    data->prid = g_new0(virCPULoongArchPrid, 1);
++    if (!data->prid)
++        goto cleanup;
++
++
++    data->len = 1;
++
++    data->prid[0].value = virCPULoongArchGetHostPRID();
++    data->prid[0].mask = 0xffff00ul;
++
++    ret = virCPULoongArchDriverDecode(cpu, cpuData, models);
++
++ cleanup:
++    virCPULoongArchDataFree(cpuData);
++    return ret;
++}
++
++
++static int
++virCPULoongArchUpdate(virCPUDef *guest,
++                      const virCPUDef *host ATTRIBUTE_UNUSED,
++                      bool relative G_GNUC_UNUSED)
++{
++    /*
++     * - host-passthrough doesn't even get here
++     * - host-model is used for host CPU running in a compatibility mode and
++     *   it needs to remain unchanged
++     * - custom doesn't support any optional features, there's nothing to
++     *   update
++     */
++
++    if (guest->mode == VIR_CPU_MODE_CUSTOM)
++        guest->match = VIR_CPU_MATCH_EXACT;
++
++    return 0;
++}
++
++static virCPUDef *
++virCPULoongArchDriverBaseline(virCPUDef **cpus,
++                        unsigned int ncpus,
++                        virDomainCapsCPUModels *models ATTRIBUTE_UNUSED,
++                        const char **features ATTRIBUTE_UNUSED,
++                        bool migratable ATTRIBUTE_UNUSED)
++{
++    virCPULoongArchMap *map;
++    const virCPULoongArchModel *model;
++    const virCPULoongArchVendor *vendor = NULL;
++    virCPUDef *cpu = NULL;
++    size_t i;
++
++    if (!(map = virCPULoongArchLoadMap()))
++        goto error;
++
++    if (!(model = virCPULoongArchModelFind(map, cpus[0]->model))) {
++        virReportError(VIR_ERR_INTERNAL_ERROR,
++                       _("Unknown CPU model %1$s"), cpus[0]->model);
++        goto error;
++    }
++
++    for (i = 0; i < ncpus; i++) {
++        const virCPULoongArchVendor *vnd;
++
++        if (STRNEQ(cpus[i]->model, model->name)) {
++            virReportError(VIR_ERR_OPERATION_FAILED, "%s",
++                           _("CPUs are incompatible"));
++            goto error;
++        }
++
++        if (!cpus[i]->vendor)
++            continue;
++
++        if (!(vnd = virCPULoongArchVendorFind(map, cpus[i]->vendor))) {
++            virReportError(VIR_ERR_OPERATION_FAILED,
++                           _("Unknown CPU vendor %1$s"), cpus[i]->vendor);
++            goto error;
++        }
++
++        if (model->vendor) {
++            if (model->vendor != vnd) {
++                virReportError(VIR_ERR_OPERATION_FAILED,
++                               _("CPU vendor %1$s of model %2$s differs from vendor %3$s"),
++                               model->vendor->name, model->name,
++                               vnd->name);
++                goto error;
++            }
++        } else if (vendor) {
++            if (vendor != vnd) {
++                virReportError(VIR_ERR_OPERATION_FAILED, "%s",
++                               _("CPU vendors do not match"));
++                goto error;
++            }
++        } else {
++            vendor = vnd;
++        }
++    }
++
++    cpu = virCPUDefNew();
++    cpu->model = g_strdup(model->name);
++    if (vendor) {
++        cpu->vendor = g_strdup(vendor->name);
++    }
++    cpu->type = VIR_CPU_TYPE_GUEST;
++    cpu->match = VIR_CPU_MATCH_EXACT;
++    cpu->fallback = VIR_CPU_FALLBACK_FORBID;
++
++ cleanup:
++    virCPULoongArchMapFree(map);
++    return cpu;
++
++ error:
++    virCPUDefFree(cpu);
++    cpu = NULL;
++    goto cleanup;
++}
++
++static int
++virCPULoongArchDriverGetModels(char ***models)
++{
++    virCPULoongArchMap *map;
++    size_t i;
++    int ret = -1;
++
++    if (!(map = virCPULoongArchLoadMap())) {
++        return -1;
++    }
++
++    if (models) {
++        *models = g_new0(char *, map->nmodels + 1);
++        if (!(*models))
++            return -1;
++
++        for (i = 0; i < map->nmodels; i++) {
++            (*models)[i] = g_strdup(map->models[i]->name);
++        }
++    }
++
++    ret = map->nmodels;
++
++    return ret;
++}
++
++struct cpuArchDriver cpuDriverLoongArch = {
++    .name       = "LoongArch",
++    .arch       = archs,
++    .narch      = G_N_ELEMENTS(archs),
++    .compare    = virCPULoongArchCompare,
++    .decode     = virCPULoongArchDriverDecode,
++    .encode     = NULL,
++    .dataFree   = virCPULoongArchDataFree,
++    .getHost    = virCPULoongArchGetHost,
++    .baseline   = virCPULoongArchDriverBaseline,
++    .update     = virCPULoongArchUpdate,
++    .getModels  = virCPULoongArchDriverGetModels,
++};
+diff --git a/src/cpu/cpu_loongarch.h b/src/cpu/cpu_loongarch.h
+new file mode 100644
+index 0000000000..bebc16a242
+--- /dev/null
++++ b/src/cpu/cpu_loongarch.h
+@@ -0,0 +1,25 @@
++/*
++ * cpu_loongarch.h: CPU driver for 64-bit LOONGARCH CPUs
++ *
++ * Copyright (C) 2023 Loongson Technology.
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library.  If not, see
++ * <http://www.gnu.org/licenses/>.
++ */
++
++#pragma once
++
++# include "cpu.h"
++
++extern struct cpuArchDriver cpuDriverLoongArch;
+diff --git a/src/cpu/cpu_loongarch_data.h b/src/cpu/cpu_loongarch_data.h
+new file mode 100644
+index 0000000000..43ae044838
+--- /dev/null
++++ b/src/cpu/cpu_loongarch_data.h
+@@ -0,0 +1,37 @@
++/*
++ * cpu_loongarch_data.h: 64-bit LOONGARCH CPU specific data
++ *
++ * Copyright (C) 2023 Loongson Technology.
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library;  If not, see
++ * <http://www.gnu.org/licenses/>.
++ */
++
++#pragma once
++
++# include <stdint.h>
++
++typedef struct _virCPULoongArchPrid virCPULoongArchPrid;
++struct _virCPULoongArchPrid {
++    uint32_t value;
++    uint32_t mask;
++};
++
++# define VIR_CPU_LOONGARCH_DATA_INIT { 0 }
++
++typedef struct _virCPULoongArchData virCPULoongArchData;
++struct _virCPULoongArchData {
++    size_t len;
++    virCPULoongArchPrid *prid;
++};
+diff --git a/src/cpu/meson.build b/src/cpu/meson.build
+index 55396903b9..254d6b4545 100644
+--- a/src/cpu/meson.build
++++ b/src/cpu/meson.build
+@@ -6,6 +6,7 @@ cpu_sources = [
+   'cpu_riscv64.c',
+   'cpu_s390.c',
+   'cpu_x86.c',
++  'cpu_loongarch.c'
+ ]
+ 
+ cpu_lib = static_library(
+diff --git a/src/qemu/qemu_capabilities.c b/src/qemu/qemu_capabilities.c
+index 83119e871a..118d3429c3 100644
+--- a/src/qemu/qemu_capabilities.c
++++ b/src/qemu/qemu_capabilities.c
+@@ -2697,6 +2697,7 @@ static const char *preferredMachines[] =
+ 
+     "sim", /* VIR_ARCH_XTENSA */
+     "sim", /* VIR_ARCH_XTENSAEB */
++    "virt", /* VIR_ARCH_LOONGARCH64 */
+ };
+ G_STATIC_ASSERT(G_N_ELEMENTS(preferredMachines) == VIR_ARCH_LAST);
+ 
+diff --git a/src/qemu/qemu_domain.c b/src/qemu/qemu_domain.c
+index 953808fcfe..00e38950b6 100644
+--- a/src/qemu/qemu_domain.c
++++ b/src/qemu/qemu_domain.c
+@@ -4222,6 +4222,10 @@ qemuDomainDefAddDefaultDevices(virQEMUDriver *driver,
+             addPCIRoot = true;
+         break;
+ 
++    case VIR_ARCH_LOONGARCH64:
++        addPCIeRoot = true;
++        break;
++
+     case VIR_ARCH_ARMV7B:
+     case VIR_ARCH_CRIS:
+     case VIR_ARCH_ITANIUM:
+diff --git a/src/util/virarch.c b/src/util/virarch.c
+index 01e520de73..289bd80d90 100644
+--- a/src/util/virarch.c
++++ b/src/util/virarch.c
+@@ -83,6 +83,8 @@ static const struct virArchData {
+ 
+     { "xtensa",       32, VIR_ARCH_LITTLE_ENDIAN },
+     { "xtensaeb",     32, VIR_ARCH_BIG_ENDIAN },
++
++    { "loongarch64",  64, VIR_ARCH_LITTLE_ENDIAN },
+ };
+ 
+ G_STATIC_ASSERT(G_N_ELEMENTS(virArchData) == VIR_ARCH_LAST);
+diff --git a/src/util/virarch.h b/src/util/virarch.h
+index 747f77c48e..638e519fe6 100644
+--- a/src/util/virarch.h
++++ b/src/util/virarch.h
+@@ -69,6 +69,8 @@ typedef enum {
+     VIR_ARCH_XTENSA,       /* XTensa      32 LE https://en.wikipedia.org/wiki/Xtensa#Processor_Cores */
+     VIR_ARCH_XTENSAEB,     /* XTensa      32 BE https://en.wikipedia.org/wiki/Xtensa#Processor_Cores */
+ 
++    VIR_ARCH_LOONGARCH64,  /* LoongArch   64 LE */
++
+     VIR_ARCH_LAST,
+ } virArch;
+ 
+@@ -106,6 +108,8 @@ typedef enum {
+ #define ARCH_IS_SH4(arch) ((arch) == VIR_ARCH_SH4 ||\
+                            (arch) == VIR_ARCH_SH4EB)
+ 
++#define ARCH_IS_LOONGARCH(arch)  ((arch) == VIR_ARCH_LOONGARCH64)
++
+ typedef enum {
+     VIR_ARCH_LITTLE_ENDIAN,
+     VIR_ARCH_BIG_ENDIAN,
+-- 
+2.39.1
+

--- a/app-virtualization/libvirt/autobuild/patches/0002-Add-loongarch-cpu-model-and-vendor-info.patch
+++ b/app-virtualization/libvirt/autobuild/patches/0002-Add-loongarch-cpu-model-and-vendor-info.patch
@@ -1,0 +1,69 @@
+From c2f4f567ce39bfc7e27b3d6a799caa83eda2ee84 Mon Sep 17 00:00:00 2001
+From: lixianglai <lixianglai@loongson.cn>
+Date: Fri, 28 Jul 2023 02:51:11 -0400
+Subject: [PATCH 2/6] Add loongarch cpu model and vendor info
+
+Define loongarch cpu model type and vendor id in
+cpu_map loongarch xml.
+
+Signed-off-by: lixianglai <lixianglai@loongson.cn>
+---
+ src/cpu_map/index.xml             | 5 +++++
+ src/cpu_map/loongarch_la464.xml   | 6 ++++++
+ src/cpu_map/loongarch_vendors.xml | 3 +++
+ src/cpu_map/meson.build           | 2 ++
+ 4 files changed, 16 insertions(+)
+ create mode 100644 src/cpu_map/loongarch_la464.xml
+ create mode 100644 src/cpu_map/loongarch_vendors.xml
+
+diff --git a/src/cpu_map/index.xml b/src/cpu_map/index.xml
+index d2c5af5797..9cfcd1a9c0 100644
+--- a/src/cpu_map/index.xml
++++ b/src/cpu_map/index.xml
+@@ -119,4 +119,9 @@
+     <include filename='arm_FT-2000plus.xml'/>
+     <include filename='arm_Tengyun-S2500.xml'/>
+   </arch>
++
++  <arch name='loongarch64'>
++    <include filename="loongarch_vendors.xml"/>
++    <include filename="loongarch_la464.xml"/>
++  </arch>
+ </cpus>
+diff --git a/src/cpu_map/loongarch_la464.xml b/src/cpu_map/loongarch_la464.xml
+new file mode 100644
+index 0000000000..1029e39681
+--- /dev/null
++++ b/src/cpu_map/loongarch_la464.xml
+@@ -0,0 +1,6 @@
++<cpus>
++  <model name='la464'>
++    <vendor name='Loongson'/>
++      <prid value='0x14c010' mask='0xfffff0'/>
++  </model>
++</cpus>
+diff --git a/src/cpu_map/loongarch_vendors.xml b/src/cpu_map/loongarch_vendors.xml
+new file mode 100644
+index 0000000000..c744654617
+--- /dev/null
++++ b/src/cpu_map/loongarch_vendors.xml
+@@ -0,0 +1,3 @@
++<cpus>
++  <vendor name='Loongson'/>
++</cpus>
+diff --git a/src/cpu_map/meson.build b/src/cpu_map/meson.build
+index ae5293e85f..4ea63188df 100644
+--- a/src/cpu_map/meson.build
++++ b/src/cpu_map/meson.build
+@@ -84,6 +84,8 @@ cpumap_data = [
+   'x86_vendors.xml',
+   'x86_Westmere-IBRS.xml',
+   'x86_Westmere.xml',
++  'loongarch_vendors.xml',
++  'loongarch_la464.xml',
+ ]
+ 
+ install_data(cpumap_data, install_dir: pkgdatadir / 'cpu_map')
+-- 
+2.39.1
+

--- a/app-virtualization/libvirt/autobuild/patches/0003-Config-some-capabilities-for-loongarch-virt-machine.patch
+++ b/app-virtualization/libvirt/autobuild/patches/0003-Config-some-capabilities-for-loongarch-virt-machine.patch
@@ -1,0 +1,187 @@
+From 34ab62f47759a04d7b318919574791d7e71f4e1f Mon Sep 17 00:00:00 2001
+From: lixianglai <lixianglai@loongson.cn>
+Date: Fri, 28 Jul 2023 03:18:44 -0400
+Subject: [PATCH 3/6] Config some capabilities for loongarch virt machine
+
+Config some capabilities for loongarch virt machine such as
+PCI multi bus.
+
+Signed-off-by: lixianglai <lixianglai@loongson.cn>
+---
+ src/qemu/qemu_capabilities.c   |  5 ++++
+ src/qemu/qemu_domain.c         | 28 +++++++++++++++++
+ src/qemu/qemu_domain.h         |  1 +
+ src/qemu/qemu_domain_address.c | 55 ++++++++++++++++++++++++++++++++++
+ src/qemu/qemu_validate.c       |  2 +-
+ 5 files changed, 90 insertions(+), 1 deletion(-)
+
+diff --git a/src/qemu/qemu_capabilities.c b/src/qemu/qemu_capabilities.c
+index 118d3429c3..eb84c9da7d 100644
+--- a/src/qemu/qemu_capabilities.c
++++ b/src/qemu/qemu_capabilities.c
+@@ -2080,6 +2080,11 @@ bool virQEMUCapsHasPCIMultiBus(const virDomainDef *def)
+         return true;
+     }
+ 
++    /* loongarch64 support PCI-multibus on all machine types
++     * since forever */
++    if (ARCH_IS_LOONGARCH(def->os.arch))
++        return true;
++
+     return false;
+ }
+ 
+diff --git a/src/qemu/qemu_domain.c b/src/qemu/qemu_domain.c
+index 00e38950b6..a8f04155a3 100644
+--- a/src/qemu/qemu_domain.c
++++ b/src/qemu/qemu_domain.c
+@@ -5635,6 +5635,11 @@ qemuDomainControllerDefPostParse(virDomainControllerDef *cont,
+                     cont->model = VIR_DOMAIN_CONTROLLER_MODEL_USB_QEMU_XHCI;
+                 else if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_NEC_USB_XHCI))
+                     cont->model = VIR_DOMAIN_CONTROLLER_MODEL_USB_NEC_XHCI;
++            } else if (ARCH_IS_LOONGARCH(def->os.arch)) {
++                if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_DEVICE_QEMU_XHCI))
++                    cont->model = VIR_DOMAIN_CONTROLLER_MODEL_USB_QEMU_XHCI;
++                else if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_NEC_USB_XHCI))
++                    cont->model = VIR_DOMAIN_CONTROLLER_MODEL_USB_NEC_XHCI;
+             }
+         }
+         /* forbid usb model 'qusb1' and 'qusb2' in this kind of hyperviosr */
+@@ -8924,6 +8929,22 @@ qemuDomainMachineIsPSeries(const char *machine,
+ }
+ 
+ 
++static bool
++qemuDomainMachineIsLoongson(const char *machine,
++                            const virArch arch)
++{
++    if (!ARCH_IS_LOONGARCH(arch))
++        return false;
++
++    if (STREQ(machine, "virt") ||
++        STRPREFIX(machine, "virt-")) {
++        return true;
++    }
++
++    return false;
++}
++
++
+ static bool
+ qemuDomainMachineIsMipsMalta(const char *machine,
+                              const virArch arch)
+@@ -9017,6 +9038,13 @@ qemuDomainIsMipsMalta(const virDomainDef *def)
+ }
+ 
+ 
++bool
++qemuDomainIsLoongson(const virDomainDef *def)
++{
++    return qemuDomainMachineIsLoongson(def->os.machine, def->os.arch);
++}
++
++
+ bool
+ qemuDomainHasPCIRoot(const virDomainDef *def)
+ {
+diff --git a/src/qemu/qemu_domain.h b/src/qemu/qemu_domain.h
+index 1e56e50672..1bdbb9c549 100644
+--- a/src/qemu/qemu_domain.h
++++ b/src/qemu/qemu_domain.h
+@@ -827,6 +827,7 @@ bool qemuDomainIsS390CCW(const virDomainDef *def);
+ bool qemuDomainIsARMVirt(const virDomainDef *def);
+ bool qemuDomainIsRISCVVirt(const virDomainDef *def);
+ bool qemuDomainIsPSeries(const virDomainDef *def);
++bool qemuDomainIsLoongson(const virDomainDef *def);
+ bool qemuDomainIsMipsMalta(const virDomainDef *def);
+ bool qemuDomainHasPCIRoot(const virDomainDef *def);
+ bool qemuDomainHasPCIeRoot(const virDomainDef *def);
+diff --git a/src/qemu/qemu_domain_address.c b/src/qemu/qemu_domain_address.c
+index 099778b2a8..2a37853d56 100644
+--- a/src/qemu/qemu_domain_address.c
++++ b/src/qemu/qemu_domain_address.c
+@@ -2079,6 +2079,56 @@ qemuDomainValidateDevicePCISlotsQ35(virDomainDef *def,
+ }
+ 
+ 
++static int
++qemuDomainValidateDevicePCISlotsLoongson(virDomainDef *def,
++                                         virDomainPCIAddressSet *addrs)
++{
++    virPCIDeviceAddress tmp_addr;
++    g_autofree char *addrStr = NULL;
++    virDomainPCIConnectFlags flags = VIR_PCI_CONNECT_TYPE_PCI_DEVICE;
++
++    if (addrs->nbuses) {
++        memset(&tmp_addr, 0, sizeof(tmp_addr));
++        tmp_addr.slot = 1;
++        /* pci-ohci at 00:01.0 */
++        if (virDomainPCIAddressReserveAddr(addrs, &tmp_addr, flags, 0) < 0)
++            return -1;
++    }
++
++    if (def->nvideos > 0 &&
++        def->videos[0]->type != VIR_DOMAIN_VIDEO_TYPE_NONE &&
++        def->videos[0]->type != VIR_DOMAIN_VIDEO_TYPE_RAMFB) {
++        /* reserve slot 2 for vga device */
++        virDomainVideoDef *primaryVideo = def->videos[0];
++
++        if (virDeviceInfoPCIAddressIsWanted(&primaryVideo->info)) {
++            memset(&tmp_addr, 0, sizeof(tmp_addr));
++            tmp_addr.slot = 2;
++
++            if (!(addrStr = virPCIDeviceAddressAsString(&tmp_addr)))
++                return -1;
++            if (!virDomainPCIAddressValidate(addrs, &tmp_addr,
++                                             addrStr, flags, true))
++                return -1;
++
++            if (virDomainPCIAddressSlotInUse(addrs, &tmp_addr)) {
++                if (qemuDomainPCIAddressReserveNextAddr(addrs,
++                                                        &primaryVideo->info) < 0) {
++                    return -1;
++                }
++            } else {
++                if (virDomainPCIAddressReserveAddr(addrs, &tmp_addr, flags, 0) < 0)
++                    return -1;
++                primaryVideo->info.addr.pci = tmp_addr;
++                primaryVideo->info.type = VIR_DOMAIN_DEVICE_ADDRESS_TYPE_PCI;
++            }
++        }
++    }
++
++    return 0;
++}
++
++
+ static int
+ qemuDomainValidateDevicePCISlotsChipsets(virDomainDef *def,
+                                          virDomainPCIAddressSet *addrs)
+@@ -2093,6 +2143,11 @@ qemuDomainValidateDevicePCISlotsChipsets(virDomainDef *def,
+         return -1;
+     }
+ 
++    if (qemuDomainIsLoongson(def) &&
++        qemuDomainValidateDevicePCISlotsLoongson(def, addrs) < 0) {
++        return -1;
++    }
++
+     return 0;
+ }
+ 
+diff --git a/src/qemu/qemu_validate.c b/src/qemu/qemu_validate.c
+index e475ad035e..498e76b1e7 100644
+--- a/src/qemu/qemu_validate.c
++++ b/src/qemu/qemu_validate.c
+@@ -100,7 +100,7 @@ qemuValidateDomainDefFeatures(const virDomainDef *def,
+         switch ((virDomainFeature) i) {
+         case VIR_DOMAIN_FEATURE_IOAPIC:
+             if (def->features[i] != VIR_DOMAIN_IOAPIC_NONE) {
+-                if (!ARCH_IS_X86(def->os.arch)) {
++                if (!ARCH_IS_X86(def->os.arch) && !ARCH_IS_LOONGARCH(def->os.arch)) {
+                     virReportError(VIR_ERR_CONFIG_UNSUPPORTED,
+                                    _("The '%1$s' feature is not supported for architecture '%2$s' or machine type '%3$s'"),
+                                    featureName,
+-- 
+2.39.1
+

--- a/app-virtualization/libvirt/autobuild/patches/0004-Implement-the-method-of-getting-host-info-for-loonga.patch
+++ b/app-virtualization/libvirt/autobuild/patches/0004-Implement-the-method-of-getting-host-info-for-loonga.patch
@@ -1,0 +1,75 @@
+From b2c1d2009475793fe97854a58fc1284dc160e617 Mon Sep 17 00:00:00 2001
+From: lixianglai <lixianglai@loongson.cn>
+Date: Fri, 28 Jul 2023 03:27:41 -0400
+Subject: [PATCH 4/6] Implement the method of getting host info for loongarch
+
+Implement method for loongarch to get host info, such as
+cpu frequency, system info, etc.
+
+Signed-off-by: lixianglai <lixianglai@loongson.cn>
+---
+ src/util/virarch.c    | 2 ++
+ src/util/virhostcpu.c | 4 ++--
+ src/util/virsysinfo.c | 5 +++--
+ 3 files changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/src/util/virarch.c b/src/util/virarch.c
+index 289bd80d90..8107279fb8 100644
+--- a/src/util/virarch.c
++++ b/src/util/virarch.c
+@@ -224,6 +224,8 @@ virArch virArchFromHost(void)
+         arch = VIR_ARCH_X86_64;
+     } else if (STREQ(ut.machine, "arm64")) {
+         arch = VIR_ARCH_AARCH64;
++    } else if (STREQ(ut.machine, "loongarch64")) {
++        arch = VIR_ARCH_LOONGARCH64;
+     } else {
+         /* Otherwise assume the canonical name */
+         if ((arch = virArchFromString(ut.machine)) == VIR_ARCH_NONE) {
+diff --git a/src/util/virhostcpu.c b/src/util/virhostcpu.c
+index 4027547e1e..15e97151d6 100644
+--- a/src/util/virhostcpu.c
++++ b/src/util/virhostcpu.c
+@@ -544,7 +544,7 @@ virHostCPUParseFrequency(FILE *cpuinfo,
+     char line[1024];
+ 
+     /* No sensible way to retrieve CPU frequency */
+-    if (ARCH_IS_ARM(arch))
++    if (ARCH_IS_ARM(arch) || ARCH_IS_LOONGARCH(arch))
+         return 0;
+ 
+     if (ARCH_IS_X86(arch))
+@@ -579,7 +579,7 @@ virHostCPUParsePhysAddrSize(FILE *cpuinfo, unsigned int *addrsz)
+         char *str;
+         char *endptr;
+ 
+-        if (!(str = STRSKIP(line, "address sizes")))
++        if (!(str = STRCASESKIP(line, "address sizes")))
+             continue;
+ 
+         /* Skip the colon. */
+diff --git a/src/util/virsysinfo.c b/src/util/virsysinfo.c
+index 36a861c53f..3a09497725 100644
+--- a/src/util/virsysinfo.c
++++ b/src/util/virsysinfo.c
+@@ -1241,14 +1241,15 @@ virSysinfoRead(void)
+ {
+ #if defined(__powerpc__)
+     return virSysinfoReadPPC();
+-#elif defined(__arm__) || defined(__aarch64__)
++#elif defined(__arm__) || defined(__aarch64__) || defined(__loongarch__)
+     return virSysinfoReadARM();
+ #elif defined(__s390__) || defined(__s390x__)
+     return virSysinfoReadS390();
+ #elif !defined(WIN32) && \
+     (defined(__x86_64__) || \
+      defined(__i386__) || \
+-     defined(__amd64__))
++     defined(__amd64__) || \
++    defined(__loongarch__))
+     return virSysinfoReadDMI();
+ #else /* WIN32 || not supported arch */
+     /*
+-- 
+2.39.1
+

--- a/app-virtualization/libvirt/autobuild/patches/0005-Add-bios-path-for-loongarch.patch
+++ b/app-virtualization/libvirt/autobuild/patches/0005-Add-bios-path-for-loongarch.patch
@@ -1,0 +1,57 @@
+From d567d504abaab2a6bd4221b9d3300752ec512ba0 Mon Sep 17 00:00:00 2001
+From: lixianglai <lixianglai@loongson.cn>
+Date: Thu, 17 Aug 2023 04:28:13 -0400
+Subject: [PATCH 5/6] Add bios path for loongarch
+
+Add a default BIOS file name for loongarch.
+
+Signed-off-by: lixianglai <lixianglai@loongson.cn>
+---
+ src/qemu/qemu.conf.in              | 3 ++-
+ src/qemu/qemu_conf.c               | 3 ++-
+ src/qemu/test_libvirtd_qemu.aug.in | 1 +
+ 3 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/qemu/qemu.conf.in b/src/qemu/qemu.conf.in
+index 6897e0f760..54c18e31b9 100644
+--- a/src/qemu/qemu.conf.in
++++ b/src/qemu/qemu.conf.in
+@@ -842,7 +842,8 @@
+ #   "/usr/share/OVMF/OVMF_CODE.fd:/usr/share/OVMF/OVMF_VARS.fd",
+ #   "/usr/share/OVMF/OVMF_CODE.secboot.fd:/usr/share/OVMF/OVMF_VARS.fd",
+ #   "/usr/share/AAVMF/AAVMF_CODE.fd:/usr/share/AAVMF/AAVMF_VARS.fd",
+-#   "/usr/share/AAVMF/AAVMF32_CODE.fd:/usr/share/AAVMF/AAVMF32_VARS.fd"
++#   "/usr/share/AAVMF/AAVMF32_CODE.fd:/usr/share/AAVMF/AAVMF32_VARS.fd",
++#   "/usr/share/qemu/edk2-loongarch64-code.fd:/usr/share/qemu/edk2-loongarch64-vars.fd"
+ #]
+ 
+ # The backend to use for handling stdout/stderr output from
+diff --git a/src/qemu/qemu_conf.c b/src/qemu/qemu_conf.c
+index 513b5ebb1e..5fe711ee1d 100644
+--- a/src/qemu/qemu_conf.c
++++ b/src/qemu/qemu_conf.c
+@@ -93,7 +93,8 @@ VIR_ONCE_GLOBAL_INIT(virQEMUConfig);
+     "/usr/share/OVMF/OVMF_CODE.fd:/usr/share/OVMF/OVMF_VARS.fd:" \
+     "/usr/share/OVMF/OVMF_CODE.secboot.fd:/usr/share/OVMF/OVMF_VARS.fd:" \
+     "/usr/share/AAVMF/AAVMF_CODE.fd:/usr/share/AAVMF/AAVMF_VARS.fd:" \
+-    "/usr/share/AAVMF/AAVMF32_CODE.fd:/usr/share/AAVMF/AAVMF32_VARS.fd"
++    "/usr/share/AAVMF/AAVMF32_CODE.fd:/usr/share/AAVMF/AAVMF32_VARS.fd:" \
++    "/usr/share/qemu/edk2-loongarch64-code.fd:/usr/share/qemu/edk2-loongarch64-vars.fd"
+ #endif
+ 
+ 
+diff --git a/src/qemu/test_libvirtd_qemu.aug.in b/src/qemu/test_libvirtd_qemu.aug.in
+index c730df40b0..92f886a968 100644
+--- a/src/qemu/test_libvirtd_qemu.aug.in
++++ b/src/qemu/test_libvirtd_qemu.aug.in
+@@ -99,6 +99,7 @@ module Test_libvirtd_qemu =
+     { "2" = "/usr/share/OVMF/OVMF_CODE.secboot.fd:/usr/share/OVMF/OVMF_VARS.fd" }
+     { "3" = "/usr/share/AAVMF/AAVMF_CODE.fd:/usr/share/AAVMF/AAVMF_VARS.fd" }
+     { "4" = "/usr/share/AAVMF/AAVMF32_CODE.fd:/usr/share/AAVMF/AAVMF32_VARS.fd" }
++    { "5" = "/usr/share/qemu/edk2-loongarch64-code.fd:/usr/share/qemu/edk2-loongarch64-vars.fd" }
+ }
+ { "stdio_handler" = "logd" }
+ { "gluster_debug_level" = "9" }
+-- 
+2.39.1
+

--- a/app-virtualization/libvirt/autobuild/patches/0006-fix-acpi-bug.patch
+++ b/app-virtualization/libvirt/autobuild/patches/0006-fix-acpi-bug.patch
@@ -1,0 +1,27 @@
+From 0b48d42a2686b4dfd486740a7e916e7702d4571d Mon Sep 17 00:00:00 2001
+From: xianglai li <lixianglai@loongson.cn>
+Date: Thu, 14 Dec 2023 07:21:48 -0500
+Subject: [PATCH 6/6] fix acpi bug.
+
+Signed-off-by: xianglai li <lixianglai@loongson.cn>
+---
+ src/qemu/qemu_capabilities.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/qemu/qemu_capabilities.c b/src/qemu/qemu_capabilities.c
+index eb84c9da7d..7d31c6f302 100644
+--- a/src/qemu/qemu_capabilities.c
++++ b/src/qemu/qemu_capabilities.c
+@@ -1138,7 +1138,8 @@ virQEMUCapsInitGuestFromBinary(virCaps *caps,
+                                       NULL, NULL, 0, NULL);
+     }
+ 
+-    if ((ARCH_IS_X86(guestarch) || guestarch == VIR_ARCH_AARCH64))
++    if ((ARCH_IS_X86(guestarch) || guestarch == VIR_ARCH_AARCH64 ||
++        ARCH_IS_LOONGARCH(guestarch)))
+         virCapabilitiesAddGuestFeatureWithToggle(guest, VIR_CAPS_GUEST_FEATURE_TYPE_ACPI,
+                                                  true, true);
+ 
+-- 
+2.39.1
+

--- a/app-virtualization/libvirt/spec
+++ b/app-virtualization/libvirt/spec
@@ -1,4 +1,5 @@
-VER=9.6.0
+VER=9.10.0
+REL=1
 SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
-CHKSUMS="sha256::10f2e52dbb5df90410594a8e36d0e0587d38f11efb64ff32cbec422b93b70c52"
+CHKSUMS="sha256::1060afc0e85a84c579bcdc91cfaf6d471918f97a780f04c5260a034ff7db7519"
 CHKUPDATE="anitya::id=13830"

--- a/app-virtualization/virt-manager/01-virt-install/patches/0002-Add-more-keywords-to-desktop-file.patch
+++ b/app-virtualization/virt-manager/01-virt-install/patches/0002-Add-more-keywords-to-desktop-file.patch
@@ -1,0 +1,130 @@
+diff -Naur virt-manager-4.1.0/data/virt-manager.desktop.in virt-manager-4.1.0.desktop/data/virt-manager.desktop.in
+--- virt-manager-4.1.0/data/virt-manager.desktop.in	2022-04-05 11:42:17.000000000 -0700
++++ virt-manager-4.1.0.desktop/data/virt-manager.desktop.in	2024-01-01 00:17:37.843060032 -0800
+@@ -5,5 +5,5 @@
+ Exec=virt-manager
+ Type=Application
+ Terminal=false
+-Keywords=vmm;
++Keywords=bhyve;kvm;libvirt;lxc;qemu;virt;virt-manager;virtuozzo;vm;vmm;xen;
+ Categories=System;
+diff -Naur virt-manager-4.1.0/po/cs.po virt-manager-4.1.0.desktop/po/cs.po
+--- virt-manager-4.1.0/po/cs.po	2022-08-04 12:08:02.000000000 -0700
++++ virt-manager-4.1.0.desktop/po/cs.po	2024-01-01 00:19:16.649422744 -0800
+@@ -72,7 +72,7 @@
+ 
+ #: data/virt-manager.desktop.in:9
+ msgid "vmm;"
+-msgstr "vmm;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff -Naur virt-manager-4.1.0/po/fi.po virt-manager-4.1.0.desktop/po/fi.po
+--- virt-manager-4.1.0/po/fi.po	2022-08-04 12:08:02.000000000 -0700
++++ virt-manager-4.1.0.desktop/po/fi.po	2024-01-01 00:19:19.636433523 -0800
+@@ -67,7 +67,7 @@
+ 
+ #: data/virt-manager.desktop.in:9
+ msgid "vmm;"
+-msgstr "vmm;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff -Naur virt-manager-4.1.0/po/hr.po virt-manager-4.1.0.desktop/po/hr.po
+--- virt-manager-4.1.0/po/hr.po	2022-08-04 12:08:02.000000000 -0700
++++ virt-manager-4.1.0.desktop/po/hr.po	2024-01-01 00:19:25.244453734 -0800
+@@ -64,7 +64,7 @@
+ 
+ #: data/virt-manager.desktop.in:9
+ msgid "vmm;"
+-msgstr "uvr;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff -Naur virt-manager-4.1.0/po/ka.po virt-manager-4.1.0.desktop/po/ka.po
+--- virt-manager-4.1.0/po/ka.po	2022-08-04 12:08:02.000000000 -0700
++++ virt-manager-4.1.0.desktop/po/ka.po	2024-01-01 00:19:49.298540024 -0800
+@@ -60,7 +60,7 @@
+ 
+ #: data/virt-manager.desktop.in:9
+ msgid "vmm;"
+-msgstr "vmm;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff -Naur virt-manager-4.1.0/po/ko.po virt-manager-4.1.0.desktop/po/ko.po
+--- virt-manager-4.1.0/po/ko.po	2022-08-04 12:08:02.000000000 -0700
++++ virt-manager-4.1.0.desktop/po/ko.po	2024-01-01 00:19:28.877466808 -0800
+@@ -69,7 +69,7 @@
+ 
+ #: data/virt-manager.desktop.in:9
+ msgid "vmm;"
+-msgstr "vmm;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff -Naur virt-manager-4.1.0/po/pl.po virt-manager-4.1.0.desktop/po/pl.po
+--- virt-manager-4.1.0/po/pl.po	2022-08-04 12:08:02.000000000 -0700
++++ virt-manager-4.1.0.desktop/po/pl.po	2024-01-01 00:19:32.544479989 -0800
+@@ -72,7 +72,7 @@
+ 
+ #: data/virt-manager.desktop.in:9
+ msgid "vmm;"
+-msgstr "vmm;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff -Naur virt-manager-4.1.0/po/pt_BR.po virt-manager-4.1.0.desktop/po/pt_BR.po
+--- virt-manager-4.1.0/po/pt_BR.po	2022-08-04 12:08:02.000000000 -0700
++++ virt-manager-4.1.0.desktop/po/pt_BR.po	2024-01-01 00:19:36.299493471 -0800
+@@ -79,7 +79,7 @@
+ 
+ #: data/virt-manager.desktop.in:9
+ msgid "vmm;"
+-msgstr "vmm;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff -Naur virt-manager-4.1.0/po/sv.po virt-manager-4.1.0.desktop/po/sv.po
+--- virt-manager-4.1.0/po/sv.po	2022-08-04 12:08:02.000000000 -0700
++++ virt-manager-4.1.0.desktop/po/sv.po	2024-01-01 00:19:40.075507013 -0800
+@@ -71,7 +71,7 @@
+ 
+ #: data/virt-manager.desktop.in:9
+ msgid "vmm;"
+-msgstr "vmm;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff -Naur virt-manager-4.1.0/po/tr.po virt-manager-4.1.0.desktop/po/tr.po
+--- virt-manager-4.1.0/po/tr.po	2022-08-04 12:08:02.000000000 -0700
++++ virt-manager-4.1.0.desktop/po/tr.po	2024-01-01 00:19:42.838516912 -0800
+@@ -72,7 +72,7 @@
+ 
+ #: data/virt-manager.desktop.in:9
+ msgid "vmm;"
+-msgstr "vmm;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff -Naur virt-manager-4.1.0/po/uk.po virt-manager-4.1.0.desktop/po/uk.po
+--- virt-manager-4.1.0/po/uk.po	2022-08-04 12:08:02.000000000 -0700
++++ virt-manager-4.1.0.desktop/po/uk.po	2024-01-01 00:19:46.035528355 -0800
+@@ -74,7 +74,7 @@
+ 
+ #: data/virt-manager.desktop.in:9
+ msgid "vmm;"
+-msgstr "vmm;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."

--- a/app-virtualization/virt-manager/01-virt-install/patches/1001-Add-loongarch-support.patch
+++ b/app-virtualization/virt-manager/01-virt-install/patches/1001-Add-loongarch-support.patch
@@ -1,0 +1,52 @@
+From 5f7e63432a0dc746637e976bf4043478f537724f Mon Sep 17 00:00:00 2001
+From: lixianglai <lixianglai@loongson.cn>
+Date: Wed, 13 Dec 2023 04:43:24 -0500
+Subject: [PATCH 1/3] Add loongarch support
+
+Signed-off-by: lixianglai <lixianglai@loongson.cn>
+---
+ virtManager/createvm.py | 7 ++++++-
+ virtinst/domain/os.py   | 2 ++
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/virtManager/createvm.py b/virtManager/createvm.py
+index 7e5ded68..b8110ad2 100644
+--- a/virtManager/createvm.py
++++ b/virtManager/createvm.py
+@@ -476,7 +476,8 @@ class vmmCreateVM(vmmGObjectUI):
+ 
+         installable_arch = bool(guest.os.is_x86() or
+                 guest.os.is_ppc64() or
+-                guest.os.is_s390x())
++                guest.os.is_s390x() or
++                guest.os.is_loongarch64())
+ 
+         default_efi = (
+             self.config.get_default_firmware_setting() == "uefi" and
+@@ -864,6 +865,10 @@ class vmmCreateVM(vmmGObjectUI):
+             defmachine = recommended_machine
+             prios = [defmachine]
+ 
++        if self._capsinfo.arch in ["loongarch64"]:
++                defmachine = "virt"
++ 
++
+         for p in prios[:]:
+             if p not in machines:
+                 prios.remove(p)  # pragma: no cover
+diff --git a/virtinst/domain/os.py b/virtinst/domain/os.py
+index e2cea755..e783c851 100644
+--- a/virtinst/domain/os.py
++++ b/virtinst/domain/os.py
+@@ -77,6 +77,8 @@ class DomainOs(XMLBuilder):
+         return self.arch == "riscv64" or self.arch == "riscv32"
+     def is_riscv_virt(self):
+         return self.is_riscv() and str(self.machine).startswith("virt")
++    def is_loongarch64(self):
++        return self.arch == "loongarch64"
+ 
+     ##################
+     # XML properties #
+-- 
+2.39.1
+

--- a/app-virtualization/virt-manager/01-virt-install/patches/1002-Add-virtio-scsi-controller-if-needed-for-LoongArch.patch
+++ b/app-virtualization/virt-manager/01-virt-install/patches/1002-Add-virtio-scsi-controller-if-needed-for-LoongArch.patch
@@ -1,0 +1,83 @@
+From 0cfe38bcd9a570144bc541602741d39f7dddac21 Mon Sep 17 00:00:00 2001
+From: lixianglai <lixianglai@loongson.cn>
+Date: Wed, 13 Dec 2023 04:43:51 -0500
+Subject: [PATCH 2/3] Add virtio-scsi controller if needed for LoongArch
+
+Signed-off-by: lixianglai <lixianglai@loongson.cn>
+---
+ virtinst/guest.py | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/virtinst/guest.py b/virtinst/guest.py
+index e6636022..7a032378 100644
+--- a/virtinst/guest.py
++++ b/virtinst/guest.py
+@@ -212,6 +212,7 @@ class Guest(XMLBuilder):
+         self.skip_default_rng = False
+         self.skip_default_tpm = False
+         self.x86_cpu_default = self.cpu.SPECIAL_MODE_APP_DEFAULT
++        self.loongarch_cpu_default = self.cpu.SPECIAL_MODE_APP_DEFAULT
+ 
+         # qemu 6.1, fairly new when we added this option, has an unfortunate
+         # bug with >= 15 root ports, so we choose 14 instead of our original 16
+@@ -352,7 +353,8 @@ class Guest(XMLBuilder):
+         if (self.os.is_arm_machvirt() or
+             self.os.is_riscv_virt() or
+             self.os.is_s390x() or
+-            self.os.is_pseries()):
++            self.os.is_pseries() or
++            self.os.is_loongarch64()):
+             return True
+ 
+         if not os_support:
+@@ -541,7 +543,7 @@ class Guest(XMLBuilder):
+             # and doesn't break QEMU internal snapshots
+             prefer_efi = self.osinfo.requires_firmware_efi(self.os.arch)
+         else:
+-            prefer_efi = self.os.is_arm_machvirt() or self.conn.is_bhyve()
++            prefer_efi = self.os.is_arm_machvirt() or self.conn.is_bhyve() or self.os.is_loongarch64()
+ 
+         log.debug("Prefer EFI => %s", prefer_efi)
+         return prefer_efi
+@@ -558,6 +560,8 @@ class Guest(XMLBuilder):
+         """
+         self.os.loader_ro = True
+         self.os.loader_type = "pflash"
++        if (self.os.is_loongarch64()):
++            self.os.loader_type = "rom"
+         self.os.loader = path
+ 
+         # If the firmware name contains "secboot" it is probably build
+@@ -902,7 +906,8 @@ class Guest(XMLBuilder):
+             usb_tablet = True
+         if (self.os.is_arm_machvirt() or
+             self.os.is_riscv_virt() or
+-            self.os.is_pseries()):
++            self.os.is_pseries() or
++            self.os.is_loongarch64()):
+             usb_tablet = True
+             usb_keyboard = True
+ 
+@@ -1016,7 +1021,7 @@ class Guest(XMLBuilder):
+         if self.os.is_container() and not self.conn.is_vz():
+             return
+         if (not self.os.is_x86() and
+-            not self.os.is_pseries()):
++            not self.os.is_pseries() and not self.os.is_loongarch64()):
+             return
+         self.add_device(DeviceGraphics(self.conn))
+ 
+@@ -1155,6 +1160,10 @@ class Guest(XMLBuilder):
+         self.add_device(dev)
+ 
+     def _add_spice_usbredir(self):
++        if (self.os.is_loongarch64()):
++            return
++        if not self.lookup_domcaps().supports_redirdev_usb():
++            return  # pragma: no cover
+         if self.skip_default_usbredir:
+             return
+         if self.devices.redirdev:
+-- 
+2.39.1
+

--- a/app-virtualization/virt-manager/01-virt-install/patches/1003-Improve-functions-for-loongarch.patch
+++ b/app-virtualization/virt-manager/01-virt-install/patches/1003-Improve-functions-for-loongarch.patch
@@ -1,0 +1,83 @@
+From 0b27fde3cd2ceaf4fb4920b2035e6817dc77b22f Mon Sep 17 00:00:00 2001
+From: lixianglai <lixianglai@loongson.cn>
+Date: Wed, 13 Dec 2023 04:44:23 -0500
+Subject: [PATCH 3/3] Improve functions for loongarch
+
+Signed-off-by: lixianglai <lixianglai@loongson.cn>
+---
+ virtinst/devices/disk.py    | 2 ++
+ virtinst/devices/video.py   | 2 ++
+ virtinst/domain/cpu.py      | 3 +++
+ virtinst/domain/features.py | 1 +
+ virtinst/domcapabilities.py | 4 ++++
+ 5 files changed, 12 insertions(+)
+
+diff --git a/virtinst/devices/disk.py b/virtinst/devices/disk.py
+index dc59fd13..cfb13872 100644
+--- a/virtinst/devices/disk.py
++++ b/virtinst/devices/disk.py
+@@ -974,6 +974,8 @@ class DeviceDisk(Device):
+             return "sd"
+         if guest.os.is_q35():
+             return "sata"
++        if self.is_cdrom() and guest.os.is_loongarch64():
++            return "scsi"
+         if self.conn.is_bhyve():
+             # IDE bus is not supported by bhyve
+             return "sata"
+diff --git a/virtinst/devices/video.py b/virtinst/devices/video.py
+index 70067a72..97adf7d3 100644
+--- a/virtinst/devices/video.py
++++ b/virtinst/devices/video.py
+@@ -31,6 +31,8 @@ class DeviceVideo(Device):
+             return None
+         if guest.os.is_pseries():
+             return "vga"
++        if guest.os.is_loongarch64():
++            return "virtio"
+         if guest.os.is_arm_machvirt():
+             # For all cases here the hv and guest are new enough for virtio
+             return "virtio"
+diff --git a/virtinst/domain/cpu.py b/virtinst/domain/cpu.py
+index 5de42b4e..c93a43bf 100644
+--- a/virtinst/domain/cpu.py
++++ b/virtinst/domain/cpu.py
+@@ -449,5 +449,8 @@ class DomainCpu(XMLBuilder):
+             # -M virt defaults to a 32bit CPU, even if using aarch64
+             self.set_model(guest, "cortex-a57")
+ 
++        elif guest.os.is_loongarch64():
++            self.set_model(guest, "la464")
++
+         elif guest.os.is_x86() and guest.type == "kvm":
+             self._set_cpu_x86_kvm_default(guest)
+diff --git a/virtinst/domain/features.py b/virtinst/domain/features.py
+index 87de4358..620526b6 100644
+--- a/virtinst/domain/features.py
++++ b/virtinst/domain/features.py
+@@ -64,6 +64,7 @@ class DomainFeatures(XMLBuilder):
+         capsinfo = guest.lookup_capsinfo()
+         if self._prop_is_unset("acpi"):
+             self.acpi = capsinfo.guest.supports_acpi()
++        self.acpi = True
+         if self._prop_is_unset("apic"):
+             self.apic = capsinfo.guest.supports_apic()
+         if self._prop_is_unset("pae"):
+diff --git a/virtinst/domcapabilities.py b/virtinst/domcapabilities.py
+index d22ce6a2..b9da063d 100644
+--- a/virtinst/domcapabilities.py
++++ b/virtinst/domcapabilities.py
+@@ -289,6 +289,10 @@ class DomainCapabilities(XMLBuilder):
+             r".*arm/QEMU_EFI.*",  # fedora, gerd's firmware repo
+             r".*edk2-arm-code\.fd"  # upstream qemu
+         ],
++        "loongarch64": [
++            ".*edk2-loongarch64-code.fd",  # loongarch
++            ".*edk2-loongarch64-vars.fd",  # gerd's firmware repo
++        ],
+     }
+ 
+     def find_uefi_path_for_arch(self):
+-- 
+2.39.1
+

--- a/app-virtualization/virt-manager/spec
+++ b/app-virtualization/virt-manager/spec
@@ -1,5 +1,5 @@
 VER=4.1.0
-REL=1
+REL=2
 SRCS="tbl::https://releases.pagure.org/virt-manager/virt-manager-$VER.tar.gz"
 CHKSUMS="sha256::950681d7b32dc61669278ad94ef31da33109bf6fcf0426ed82dfd7379aa590a2"
 CHKUPDATE="anitya::id=8183"

--- a/runtime-desktop/vte/autobuild/defines
+++ b/runtime-desktop/vte/autobuild/defines
@@ -2,6 +2,8 @@ PKGNAME=vte
 PKGSEC=gnome
 PKGDEP="fribidi gtk-3 icu pcre2"
 BUILDDEP="glade gobject-introspection gtk-doc intltool vala gperf"
+# FIXME: js-102 -x-> gjs -x-> glade.
+BUILDDEP__MIPS64R6EL="${BUILDDEP/glade/}"
 PKGDES="VTE widget for use with GTK"
 
 # FIXME: GTK 4 is not yet supported.
@@ -18,6 +20,10 @@ MESON_AFTER="-D_b_symbolic_functions=true \
              -Dicu=true \
              -D_systemd=true \
              -Dvapi=true"
+# FIXME: js-102 -x-> gjs -x-> glade.
+MESON_AFTER__MIPS64R6EL=" \
+             ${MESON_AFTER} \
+             -Dglade=false"
 
 PKGBREAK="vte-gtk3<=0.62.1"
 PKGREP="vte-gtk3<=0.62.1"


### PR DESCRIPTION
Topic Description
-----------------

- wireshark: (mips64r6el) disable LTO to work around a build failure
- vte: (mips64r6el) disable Glade catalog
- zfs: only perform DKMS operations outside of containers
- virt-manager: improve packaging
    - Add more keywords to .desktop, making it easier to find.
    - Introduce LoongArch patchset. [^1]
- libvirt: update to 9.10.0
    - Add LoongArch patches.
    - Ref: https://gitlab.com/lixianglai/libvirt/-/commits/loongarch-fix-acpi

[^1]: https://github.com/loongson/virt-manager/tree/loongarch by Mingcong Bai


Package(s) Affected
-------------------

- libvirt: 9.10.0-1
- virt-manager: 4.1.0-2
- zfs: 2.1.12-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit zfs libvirt virt-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Second Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
