### PR TITLE
kmod: update to 31

### DIFF
--- a/app-admin/kmod/spec
+++ b/app-admin/kmod/spec
@@ -1,5 +1,4 @@
-VER=30
-REL=1
+VER=31
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-$VER.tar.xz"
-CHKSUMS="sha256::f897dd72698dc6ac1ef03255cd0a5734ad932318e4adbaebc7338ef2f5202f9f"
+CHKSUMS="sha256::f5a6949043cc72c001b728d8c218609c5a15f3c33d75614b78c79418fcf00d80"
 CHKUPDATE="anitya::id=1517"


### PR DESCRIPTION
Topic Description
-----------------

- kmod: update to 31
    - This update fixes segfault whilst building Linux Kernel 6.7 for loongarch64.
    
Package(s) Affected
-------------------

- kmod: 31

Security Update?
----------------

No

Build Order
-----------

```
#buildit kmod
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
