### PR TITLE
cln: fix build on loongarch64

### DIFF
--- a/runtime-common/cln/autobuild/patches/0001-LoongArchLinux-cln-la64.patch.loongarch64
+++ b/runtime-common/cln/autobuild/patches/0001-LoongArchLinux-cln-la64.patch.loongarch64
@@ -1,0 +1,53 @@
+Index: cln-1.3.6/include/cln/object.h
+===================================================================
+--- cln-1.3.6.orig/include/cln/object.h
++++ cln-1.3.6/include/cln/object.h
+@@ -25,7 +25,7 @@ namespace cln {
+ #if defined(__i386__) || (defined(__mips__) && !defined(__LP64__)) || (defined(__sparc__) && !defined(__arch64__)) || defined(__hppa__) || defined(__arm__) || defined(__rs6000__) || defined(__m88k__) || defined(__convex__) || (defined(__s390__) && !defined(__s390x__)) || defined(__sh__) || (defined(__x86_64__) && defined(__ILP32__))
+   #define cl_word_alignment  4
+ #endif
+-#if defined(__alpha__) || defined(__ia64__) || defined(__mips64__) || defined(__powerpc64__) || (defined(__sparc__) && defined(__arch64__)) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(__s390x__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__e2k__)
++#if defined(__alpha__) || defined(__ia64__) || defined(__mips64__) || defined(__powerpc64__) || (defined(__sparc__) && defined(__arch64__)) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(__s390x__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__e2k__) || defined(__loongarch64)
+   #define cl_word_alignment  8
+ #endif
+ #if !defined(cl_word_alignment)
+Index: cln-1.3.6/include/cln/types.h
+===================================================================
+--- cln-1.3.6.orig/include/cln/types.h
++++ cln-1.3.6/include/cln/types.h
+@@ -51,7 +51,7 @@
+     #undef HAVE_LONGLONG
+    #endif
+   #endif
+-  #if defined(HAVE_LONGLONG) && (defined(__alpha__) || defined(__ia64__) || defined(__mips64__) || defined(__powerpc64__) || defined(__s390x__) || (defined(__sparc__) && defined(__arch64__)) || (defined(__x86_64__) || defined(_M_AMD64)) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64)) || defined(__e2k__)
++  #if defined(HAVE_LONGLONG) && (defined(__alpha__) || defined(__ia64__) || defined(__mips64__) || defined(__powerpc64__) || defined(__s390x__) || (defined(__sparc__) && defined(__arch64__)) || (defined(__x86_64__) || defined(_M_AMD64)) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64)) || defined(__e2k__) || defined(__loongarch64)
+     // 64 bit registers in hardware
+     #define HAVE_FAST_LONGLONG
+   #endif
+@@ -79,7 +79,7 @@
+ 
+ // Integer type used for counters.
+ // Constraint: sizeof(uintC) >= sizeof(uintL)
+-  #if (defined(HAVE_FAST_LONGLONG) && (defined(__alpha__) || defined(__ia64__) || defined(__powerpc64__) || defined(__s390x__) || (defined(__sparc__) && defined(__arch64__)) || defined(__x86_64__) || defined(__aarch64__) || defined(__mips64__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__e2k__)))
++  #if (defined(HAVE_FAST_LONGLONG) && (defined(__alpha__) || defined(__ia64__) || defined(__powerpc64__) || defined(__s390x__) || (defined(__sparc__) && defined(__arch64__)) || defined(__x86_64__) || defined(__aarch64__) || defined(__mips64__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__e2k__)) || defined(__loongarch64)) 
+     #define intCsize long_bitsize
+     typedef long           sintC;
+     typedef unsigned long  uintC;
+@@ -91,7 +91,7 @@
+ 
+ // Integer type used for lfloat exponents.
+ // Constraint: sizeof(uintE) >= sizeof(uintC)
+-  #if (defined(HAVE_LONGLONG) && (defined(__alpha__) || defined(__ia64__) || defined(__powerpc64__) || defined(__s390x__) || (defined(__sparc__) && defined(__arch64__)) || defined(__x86_64__) || defined(__i386__) || defined(__mips__) || defined(__rs6000__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__e2k__)))
++  #if (defined(HAVE_LONGLONG) && (defined(__alpha__) || defined(__ia64__) || defined(__powerpc64__) || defined(__s390x__) || (defined(__sparc__) && defined(__arch64__)) || defined(__x86_64__) || defined(__i386__) || defined(__mips__) || defined(__rs6000__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__e2k__) || defined(__loongarch64)))
+     #define intEsize 64
+     typedef sint64  sintE;
+     typedef uint64  uintE;
+@@ -132,7 +132,7 @@
+     typedef int sintD;
+     typedef unsigned int uintD;
+   #else  // we are not using GMP, so just guess something reasonable
+-    #if (defined(HAVE_FAST_LONGLONG) && (defined(__alpha__) || defined(__ia64__) || defined(__powerpc64__) || (defined(__sparc__) && defined(__arch64__)) || defined(__s390x__) || defined(__x86_64__) || defined(__aarch64__) || defined(__mips64__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__e2k__)))
++    #if (defined(HAVE_FAST_LONGLONG) && (defined(__alpha__) || defined(__ia64__) || defined(__powerpc64__) || (defined(__sparc__) && defined(__arch64__)) || defined(__s390x__) || defined(__x86_64__) || defined(__aarch64__) || defined(__mips64__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__e2k__) || defined(__loongarch64)))
+       #define intDsize 64
+       typedef sint64  sintD;
+       typedef uint64  uintD;


### PR DESCRIPTION
Topic Description
-----------------

- cln: (loongarch64) (LoongArchLinux patch) fix build

Package(s) Affected
-------------------

- cln: 1.3.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit cln
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Second Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
