### PR TITLE
libiscsi: Fix FTBFS for mips64r6el

### DIFF
--- a/runtime-network/libiscsi/autobuild/prepare
+++ b/runtime-network/libiscsi/autobuild/prepare
@@ -1,0 +1,6 @@
+# On mips64r6el, ld choses the wrong emulation while creating a static library.
+# For this instance, the creation of the static library is invoked by libtool.
+if ab_match_arch mips64r6el ; then
+	abinfo "(mips64r6el) Setting the default ld emulation ..."
+	export LDEMULATION="elf64ltsmip"
+fi


### PR DESCRIPTION
Topic Description
-----------------

- libiscsi: fix FTBFS for mips64r6el
    - By setting the default ld emulation to elf64ltsmip.

Package(s) Affected
-------------------

- libiscsi: 1.18.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libiscsi
```

Test Build(s) Done
------------------

**Second Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
