### PR TITLE
XFCE Survey (December 2023)

### DIFF
--- a/desktop-xfce/catfish/spec
+++ b/desktop-xfce/catfish/spec
@@ -1,5 +1,4 @@
-VER=4.16.4
-REL=1
+VER=4.18.0
 SRCS="https://archive.xfce.org/src/apps/catfish/${VER%.*}/catfish-$VER.tar.bz2"
-CHKSUMS="sha256::6e5c01c534de7a8ce911965c4cd298c5b5d2079e0bc29c91b1e310c9884bb5fc"
+CHKSUMS="sha256::fdae9b73cc754a50716bb04b958aa31dbd7e94047068b7207f2ae313a7d58b99"
 CHKUPDATE="anitya::id=255"

--- a/desktop-xfce/garcon/spec
+++ b/desktop-xfce/garcon/spec
@@ -1,4 +1,4 @@
-VER=4.18.0
+VER=4.18.1
 SRCS="https://archive.xfce.org/src/xfce/garcon/${VER%.*}/garcon-$VER.tar.bz2"
-CHKSUMS="sha256::54633487566a8b8502b71c11a7f719efe27c069bd5773cc95f11ff4ea8f11a14"
+CHKSUMS="sha256::fe7a932a6dac95eb1438f3fbfd53096756ff2e1cb179d10d0fb796cefbb4c20b"
 CHKUPDATE="anitya::id=231996"

--- a/desktop-xfce/gigolo/spec
+++ b/desktop-xfce/gigolo/spec
@@ -1,5 +1,4 @@
-VER=0.5.2
-SRCS="https://archive.xfce.org/src/apps/gigolo/${VER:0:3}/gigolo-$VER.tar.bz2"
-CHKSUMS="sha256::e34a1aa0755f9f6c234c7d24b23a6cecd6ef50741d79da3bb6f698a2281dbbc3"
+VER=0.5.3
+SRCS="https://archive.xfce.org/src/apps/gigolo/${VER%.*}/gigolo-$VER.tar.bz2"
+CHKSUMS="sha256::d25984f65744665e2433335249f9547a38cead45440027af0c397ebf254d2fd0"
 CHKUPDATE="anitya::id=231999"
-REL=1

--- a/desktop-xfce/libxfce4ui/spec
+++ b/desktop-xfce/libxfce4ui/spec
@@ -1,4 +1,4 @@
-VER=4.18.1
+VER=4.18.4
 SRCS="https://archive.xfce.org/src/xfce/libxfce4ui/${VER%.*}/libxfce4ui-$VER.tar.bz2"
-CHKSUMS="sha256::6ebf7b30021b7bce75824b4c6dc2571ffb3dcd6a74468e823a74719313e5e52e"
+CHKSUMS="sha256::87eefe797c6d26de3f754de48872faf131f1b5fc93fb88e22f5c7886a842cb4c"
 CHKUPDATE="anitya::id=232000"

--- a/desktop-xfce/mousepad/spec
+++ b/desktop-xfce/mousepad/spec
@@ -1,4 +1,4 @@
-VER=0.5.10
+VER=0.6.1
 SRCS="https://archive.xfce.org/src/apps/mousepad/${VER%.*}/mousepad-$VER.tar.bz2"
-CHKSUMS="sha256::6ebaf38d52bee5560d9650c52a693f8a6ed0a67d88cc938d73f7d5ce13552bad"
+CHKSUMS="sha256::560c5436c7bc7de33fbf3e9f6cc545280772ad898dfb73257d86533880ffff36"
 CHKUPDATE="anitya::id=198617"

--- a/desktop-xfce/orage/autobuild/defines
+++ b/desktop-xfce/orage/autobuild/defines
@@ -3,6 +3,4 @@ PKGDES="A simple calendar application for Xfce"
 PKGDEP="xfce4-panel libical popt libnotify"
 BUILDDEP="intltool"
 PKGSEC=xfce
-
-AUTOTOOLS_AFTER="--enable-libical"
 RECONF=0

--- a/desktop-xfce/orage/spec
+++ b/desktop-xfce/orage/spec
@@ -1,4 +1,4 @@
-VER=4.16.0
+VER=4.18.0
 SRCS="https://archive.xfce.org/src/apps/orage/${VER%.*}/orage-$VER.tar.bz2"
-CHKSUMS="sha256::26111a3b6a2007c82f1e0a1e0591b774a0b132f3a7f1cde53d9be661b2f11700"
+CHKSUMS="sha256::6313b49b26cfa39fc5e99468f3fbcfe0fa1c0f3f74273f03674f1a7d6141a3ec"
 CHKUPDATE="anitya::id=231994"

--- a/desktop-xfce/parole/spec
+++ b/desktop-xfce/parole/spec
@@ -1,8 +1,4 @@
-# This package has various bug fixes in the master branch, but these changes
-#   are still not in a newer release. So the `parole` package should use a git
-#   snapshot instead of a release tarball.
-
-VER=4.16.0+git20221230
-SRCS="git::commit=389d6a72b08f90c15a5a193c7da8f9df25575ec6::https://gitlab.xfce.org/apps/parole"
-CHKSUMS="SKIP"
+VER=4.18.1
+SRCS="https://archive.xfce.org/src/apps/parole/${VER%.*}/parole-${VER}.tar.bz2"
+CHKSUMS="sha256::0c7364a484812f69cf2b20a2323864203334cc854fd8103d1d1131814ac55a66"
 CHKUPDATE="anitya::id=232002"

--- a/desktop-xfce/ristretto/spec
+++ b/desktop-xfce/ristretto/spec
@@ -1,4 +1,4 @@
-VER=0.12.4
+VER=0.13.1
 SRCS="https://archive.xfce.org/src/apps/ristretto/${VER%.*}/ristretto-$VER.tar.bz2"
-CHKSUMS="sha256::e4005c9743e5ecf329fb93d1171746c4250aecb2bd411dcf8d8e9cb904e87930"
+CHKSUMS="sha256::d71affbf15245067124725b153c908a53208c4ca1ba2d4df1ec5a1308d53791e"
 CHKUPDATE="anitya::id=8365"

--- a/desktop-xfce/thunar/spec
+++ b/desktop-xfce/thunar/spec
@@ -1,4 +1,4 @@
-VER=4.18.2
+VER=4.18.8
 SRCS="https://archive.xfce.org/src/xfce/thunar/${VER%.*}/thunar-$VER.tar.bz2"
-CHKSUMS="sha256::adfedd9d25428ddb750088f81d24c853ef4699230911994c8dfb90c5c5daa2be"
+CHKSUMS="sha256::3ac23b8a16545025cee860621d270f5f3848d05a3353902abdbc89e779269d2e"
 CHKUPDATE="anitya::id=14669"

--- a/desktop-xfce/tumbler/spec
+++ b/desktop-xfce/tumbler/spec
@@ -1,4 +1,4 @@
-VER=4.18.0
+VER=4.18.2
 SRCS="https://archive.xfce.org/src/xfce/tumbler/${VER%.*}/tumbler-$VER.tar.bz2"
-CHKSUMS="sha256::4087f3af4ef31271d3f315421a2f1fe67e4fda7ad60bbab1f073627914dfcf00"
+CHKSUMS="sha256::b530eec635eac7f898c0d8d3a3ff79d76a145d3bed3e786d54b1ec058132be7a"
 CHKUPDATE="anitya::id=5014"

--- a/desktop-xfce/xfburn/spec
+++ b/desktop-xfce/xfburn/spec
@@ -1,5 +1,4 @@
-VER=0.6.2
+VER=0.7.0
 SRCS="https://archive.xfce.org/src/apps/xfburn/${VER%.*}/xfburn-$VER.tar.bz2"
-CHKSUMS="sha256::83416e132e9bb31cd52fdc41460f96efa9ed57a290ec65f09714b83bb3d00327"
-REL=4
+CHKSUMS="sha256::ba960ea79a044b93e513f7c32bca1a599472d687ed0e0184bde8c84aeebb1f45"
 CHKUPDATE="anitya::id=10158"

--- a/desktop-xfce/xfce4-appfinder/spec
+++ b/desktop-xfce/xfce4-appfinder/spec
@@ -1,4 +1,4 @@
-VER=4.18.0
+VER=4.18.1
 SRCS="https://archive.xfce.org/src/xfce/xfce4-appfinder/${VER%.*}/xfce4-appfinder-$VER.tar.bz2"
-CHKSUMS="sha256::962a98d7b327d2073ed4cd0f78bce7945ed51b97d52fd60196e8b02ef819c18c"
+CHKSUMS="sha256::9854ea653981be544ad545850477716c4c92d0c43eb47b75f78534837c0893f9"
 CHKUPDATE="anitya::id=15895"

--- a/desktop-xfce/xfce4-battery-plugin/spec
+++ b/desktop-xfce/xfce4-battery-plugin/spec
@@ -1,5 +1,4 @@
-VER=1.1.4
+VER=1.1.5
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-battery-plugin/${VER%.*}/xfce4-battery-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::107df2a837156c010e1eab5430bab90c77f0a3dc699b5937678c8a9c5e64c222"
+CHKSUMS="sha256::752233bfb320ee1e26104a656cbb868299f562733063e2b9a18f0966585ce213"
 CHKUPDATE="anitya::id=15893"
-REL=1

--- a/desktop-xfce/xfce4-calculator-plugin/spec
+++ b/desktop-xfce/xfce4-calculator-plugin/spec
@@ -1,5 +1,4 @@
-VER=0.7.1
+VER=0.7.2
 SRCS="tbl::https://archive.xfce.org/src/panel-plugins/xfce4-calculator-plugin/${VER%.*}/xfce4-calculator-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::e4016a03c3ef4ebddd97e4135f5e304f80677033c98e19644b9989ec6f5ada81"
+CHKSUMS="sha256::d1f622bea41a90c1686bf9f13c488ab28e995e2762b84712dea9027e0c94028b"
 CHKUPDATE="anitya::id=16907"
-REL=1

--- a/desktop-xfce/xfce4-clipman-plugin/spec
+++ b/desktop-xfce/xfce4-clipman-plugin/spec
@@ -1,5 +1,4 @@
-VER=1.6.2
+VER=1.6.5
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-clipman-plugin/${VER%.*}/xfce4-clipman-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::ab8a5fe6f68fb1789190e498243a1d1385de3f64e984f470cbd3d1eb779399b8"
+CHKSUMS="sha256::73156d66c1f866d2af0c20526c5ce58aedbce511b89bb436ba9bc6413fac5190"
 CHKUPDATE="anitya::id=15892"
-REL=1

--- a/desktop-xfce/xfce4-cpugraph-plugin/spec
+++ b/desktop-xfce/xfce4-cpugraph-plugin/spec
@@ -1,4 +1,4 @@
-VER=1.2.7
+VER=1.2.10
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-cpugraph-plugin/${VER%.*}/xfce4-cpugraph-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::68a651e278ed7186964e455b69b15da77f8d56257e5c3d6adf783b3ee9337405"
+CHKSUMS="sha256::37792dd052691712195658169b95fb6583f924485ce7a467b33d01e08775d915"
 CHKUPDATE="anitya::id=15890"

--- a/desktop-xfce/xfce4-datetime-plugin/spec
+++ b/desktop-xfce/xfce4-datetime-plugin/spec
@@ -1,4 +1,4 @@
-VER=0.8.2
+VER=0.8.3
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-datetime-plugin/${VER%.*}/xfce4-datetime-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::6c388cc457015f629fecf546f1ee815d7c12e29576718f19bea5d496a8d7e037"
+CHKSUMS="sha256::6b2eeb79fb586868737426cbd2a4cd43c7f8c58507d8a2f578e0150187cc00b0"
 CHKUPDATE="anitya::id=15889"

--- a/desktop-xfce/xfce4-dev-tools/spec
+++ b/desktop-xfce/xfce4-dev-tools/spec
@@ -1,4 +1,4 @@
-VER=4.18.0
+VER=4.18.1
 SRCS="https://archive.xfce.org/src/xfce/xfce4-dev-tools/${VER%.*}/xfce4-dev-tools-$VER.tar.bz2"
-CHKSUMS="sha256::eedb4fc955f0e3459c46864ff98579295db2b900743e0ff69cad5970ba76be37"
+CHKSUMS="sha256::812cabe7048922ebc176564b73c3e427e467c9566365ee3e54c0487d305a7681"
 CHKUPDATE="anitya::id=15888"

--- a/desktop-xfce/xfce4-fsguard-plugin/spec
+++ b/desktop-xfce/xfce4-fsguard-plugin/spec
@@ -1,5 +1,4 @@
-VER=1.1.2
-REL=2
+VER=1.1.3
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-fsguard-plugin/${VER%.*}/xfce4-fsguard-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::67d8e6a219a7117c59693adbc59c39a6eba31e3f18a5499189ef4ef28b554105"
+CHKSUMS="sha256::84ef8bb4752292d64c0ef101badf7b14448790bfa0a85de644dbfa22986ec258"
 CHKUPDATE="anitya::id=15884"

--- a/desktop-xfce/xfce4-genmon-plugin/spec
+++ b/desktop-xfce/xfce4-genmon-plugin/spec
@@ -1,5 +1,4 @@
-VER=4.1.1
+VER=4.2.0
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-genmon-plugin/${VER%.*}/xfce4-genmon-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::b2119fd0ff19fa293b97ec97b0de8e241799e08b86218515167c568bd9b50135"
+CHKSUMS="sha256::948d08ee5f2140847f109b531bc1d4cc6268496913ea7600d3c5ad89025a0362"
 CHKUPDATE="anitya::id=15883"
-REL=1

--- a/desktop-xfce/xfce4-mailwatch-plugin/spec
+++ b/desktop-xfce/xfce4-mailwatch-plugin/spec
@@ -1,5 +1,4 @@
-VER=1.3.0
-REL=2
+VER=1.3.1
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-mailwatch-plugin/${VER%.*}/xfce4-mailwatch-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::20f91ebefd2880b27f421f773115b3740f67de2bf60feace3841bfd1a09cbe2e"
+CHKSUMS="sha256::054964e9fe4ca668486400991ce1ea01d07aac7ba235f4b14d4a8f7d9800046a"
 CHKUPDATE="anitya::id=15882"

--- a/desktop-xfce/xfce4-mpc-plugin/spec
+++ b/desktop-xfce/xfce4-mpc-plugin/spec
@@ -1,5 +1,4 @@
-VER=0.5.2
+VER=0.5.3
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-mpc-plugin/${VER%.*}/xfce4-mpc-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::eefe78b7b6b95312b3a52814b7f632dc92970c1b3e9535de616315749bf67760"
-REL=3
+CHKSUMS="sha256::0467fb4d1acd982d3c3e0b89cb41019946850524ff19ed0f658a8d56c7b7664d"
 CHKUPDATE="anitya::id=15835"

--- a/desktop-xfce/xfce4-netload-plugin/spec
+++ b/desktop-xfce/xfce4-netload-plugin/spec
@@ -1,5 +1,4 @@
-VER=1.3.2
+VER=1.4.1
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-netload-plugin/${VER%.*}/xfce4-netload-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::22e40425cfe1e07b01fe275b1afddc7c788af34d9c2c7e2842166963cb41215d"
-REL=3
+CHKSUMS="sha256::9fac3a3ad52e18584bfb127cd1721d56de1004b9fdd140915fded89704ccb44e"
 CHKUPDATE="anitya::id=15834"

--- a/desktop-xfce/xfce4-notes-plugin/spec
+++ b/desktop-xfce/xfce4-notes-plugin/spec
@@ -1,5 +1,4 @@
-VER=1.9.0
+VER=1.10.0
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-notes-plugin/${VER%.*}/xfce4-notes-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::13f909c948b639f96de64cf793eb74cb1779589201d3933eff214ee8f35ab088"
+CHKSUMS="sha256::2ee4406042edd352a91e166c83b60d13220ef04dce3fa6b9e0eb13636d636929"
 CHKUPDATE="anitya::id=15833"
-REL=1

--- a/desktop-xfce/xfce4-notifyd/autobuild/patches/0001-xfce4-notifyd-notification-panel-plugin-icon-workaround.patch
+++ b/desktop-xfce/xfce4-notifyd/autobuild/patches/0001-xfce4-notifyd-notification-panel-plugin-icon-workaround.patch
@@ -1,0 +1,12 @@
+diff --git a/panel-plugin/notification-plugin.desktop.in b/panel-plugin/notification-plugin.desktop.in
+index 2393376..f4672cc 100644
+--- a/panel-plugin/notification-plugin.desktop.in
++++ b/panel-plugin/notification-plugin.desktop.in
+@@ -5,6 +5,6 @@ Name=Notification Plugin
+ Comment=Notification plugin for the Xfce panel
+ Icon=org.xfce.notification
+ X-XFCE-Module=notification-plugin
+-X-XFCE-Internal=false
++X-XFCE-Internal=true
+ X-XFCE-Unique=false
+ X-XFCE-API=2.0

--- a/desktop-xfce/xfce4-notifyd/spec
+++ b/desktop-xfce/xfce4-notifyd/spec
@@ -1,4 +1,4 @@
-VER=0.6.5
+VER=0.9.3
 SRCS="https://archive.xfce.org/src/apps/xfce4-notifyd/${VER%.*}/xfce4-notifyd-$VER.tar.bz2"
-CHKSUMS="sha256::5b7130e49905e760231c918843a42f72f04911893b0d7c0e57ed040faebb4510"
+CHKSUMS="sha256::79ee4701e2f8715a700de2431aa33682933cab18d76938bb18e2820302bbe030"
 CHKUPDATE="anitya::id=15832"

--- a/desktop-xfce/xfce4-panel-profiles/spec
+++ b/desktop-xfce/xfce4-panel-profiles/spec
@@ -1,5 +1,4 @@
-VER=1.0.13
-SRCS="https://archive.xfce.org/src/apps/xfce4-panel-profiles/${VER:0:3}/xfce4-panel-profiles-$VER.tar.bz2"
-CHKSUMS="sha256::bc387c13f94109422dc72b0fcb919b0dc11619ba589d03e492252b0d2513b170"
+VER=1.0.14
+SRCS="https://archive.xfce.org/src/apps/xfce4-panel-profiles/${VER%.*}/xfce4-panel-profiles-${VER}.tar.bz2"
+CHKSUMS="sha256::6d08354e8c44d4b0370150809c1ed601d09c8b488b68986477260609a78be3f9"
 CHKUPDATE="anitya::id=232008"
-REL=1

--- a/desktop-xfce/xfce4-panel/spec
+++ b/desktop-xfce/xfce4-panel/spec
@@ -1,4 +1,4 @@
-VER=4.18.1
+VER=4.18.5
 SRCS="https://archive.xfce.org/src/xfce/xfce4-panel/${VER%.*}/xfce4-panel-$VER.tar.bz2"
-CHKSUMS="sha256::f1fd58097d231c1dbbe825c2eafd7a798564bbc39b7ba3e0000833f510e8ce72"
+CHKSUMS="sha256::b20e0d10cc5149a601d8eee07373efb446ea3e179dd032ed8ddb5782e3f9e7cb"
 CHKUPDATE="anitya::id=232007"

--- a/desktop-xfce/xfce4-power-manager/spec
+++ b/desktop-xfce/xfce4-power-manager/spec
@@ -1,4 +1,4 @@
-VER=4.18.0
+VER=4.18.3
 SRCS="https://archive.xfce.org/src/xfce/xfce4-power-manager/${VER%.*}/xfce4-power-manager-$VER.tar.bz2"
-CHKSUMS="sha256::2eee467886252f9fa704c978ec67dafad5274ede93e59b092a688faa7e72c39a"
+CHKSUMS="sha256::0d79dd0f68b90d07b384366be4d2291a6d7815410eb0c20d3d8e8590c62e84f0"
 CHKUPDATE="anitya::id=15831"

--- a/desktop-xfce/xfce4-pulseaudio-plugin/spec
+++ b/desktop-xfce/xfce4-pulseaudio-plugin/spec
@@ -1,4 +1,4 @@
-VER=0.4.5
+VER=0.4.8
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-pulseaudio-plugin/${VER%.*}/xfce4-pulseaudio-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::4425397dea6ba2599a91653dfb8ca91300faaf40be5bf5a73c3e6064bf13c115"
+CHKSUMS="sha256::bd742b207c39c221e91c57c9c9be2839eb802d1b1ee01a02b7427cd02d3f0348"
 CHKUPDATE="anitya::id=5752"

--- a/desktop-xfce/xfce4-screensaver/spec
+++ b/desktop-xfce/xfce4-screensaver/spec
@@ -1,4 +1,4 @@
-VER=4.16.0+git20221004
-SRCS="git::commit=785a456fd843c574def813fdb616162812631ebf::https://gitlab.xfce.org/apps/xfce4-screensaver"
-CHKSUMS="SKIP"
+VER=4.18.2
+SRCS="https://archive.xfce.org/src/apps/xfce4-screensaver/${VER%.*}/xfce4-screensaver-${VER}.tar.bz2"
+CHKSUMS="sha256::e4fcd2c414d3a4215e9e86a55edd87e2545b15c961917f5d72cace35b76e2b98"
 CHKUPDATE="anitya::id=232009"

--- a/desktop-xfce/xfce4-screenshooter/spec
+++ b/desktop-xfce/xfce4-screenshooter/spec
@@ -1,4 +1,4 @@
-VER=1.10.2
+VER=1.10.4
 SRCS="https://archive.xfce.org/src/apps/xfce4-screenshooter/${VER%.*}/xfce4-screenshooter-$VER.tar.bz2"
-CHKSUMS="sha256::9f416ef81f4a30c04a08f67bf37067cb3f5cac412b47a3d402ff4fc75cbc4d55"
+CHKSUMS="sha256::a2f199687e54e16a936d5636d660d42b6b9a5d548cdd0f04bd69213554806494"
 CHKUPDATE="anitya::id=15830"

--- a/desktop-xfce/xfce4-session/spec
+++ b/desktop-xfce/xfce4-session/spec
@@ -1,5 +1,4 @@
-VER=4.18.0
-REL=1
+VER=4.18.3
 SRCS="https://archive.xfce.org/src/xfce/xfce4-session/${VER%.*}/xfce4-session-$VER.tar.bz2"
-CHKSUMS="sha256::38badb500b272012f494543a60a9c0563c381647cc95bed73b68aec0b0b89a7f"
+CHKSUMS="sha256::382f93e096ec6493098719cab8cc31b93ad9bb469c0715c0c5117d75fe7394ec"
 CHKUPDATE="anitya::id=232010"

--- a/desktop-xfce/xfce4-settings/spec
+++ b/desktop-xfce/xfce4-settings/spec
@@ -1,4 +1,4 @@
-VER=4.18.1
+VER=4.18.4
 SRCS="https://archive.xfce.org/src/xfce/xfce4-settings/${VER%.*}/xfce4-settings-$VER.tar.bz2"
-CHKSUMS="sha256::d5750e68fad2dcb821fd37eb7919cacf78237df7d9f2c928efc3174037651d90"
+CHKSUMS="sha256::f10c55d0360308d9944f415645d9596d4352f952a20fc7c4a66f30fe511ca1dc"
 CHKUPDATE="anitya::id=232011"

--- a/desktop-xfce/xfce4-taskmanager/spec
+++ b/desktop-xfce/xfce4-taskmanager/spec
@@ -1,4 +1,4 @@
-VER=1.5.5
+VER=1.5.6
 SRCS="https://archive.xfce.org/src/apps/xfce4-taskmanager/${VER%.*}/xfce4-taskmanager-$VER.tar.bz2"
-CHKSUMS="sha256::f64f01ba241a0b8bbf2ed3274e5decc2313c9f8b0e4d160db3ba69b331558ae5"
+CHKSUMS="sha256::20979000761a41faed4f7f63f27bd18bb36fb27db4f7ecc8784a460701fb4abb"
 CHKUPDATE="anitya::id=15824"

--- a/desktop-xfce/xfce4-terminal/autobuild/defines
+++ b/desktop-xfce/xfce4-terminal/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=xfce4-terminal
 PKGDES="GTK+ terminal emulator for Xfce"
-PKGDEP="libxfce4ui vte-gtk3 hicolor-icon-theme"
+PKGDEP="libxfce4ui vte-gtk3 hicolor-icon-theme gtk-layer-shell"
 BUILDDEP="intltool"
 PKGSEC=xfce
 RECONF=0

--- a/desktop-xfce/xfce4-terminal/spec
+++ b/desktop-xfce/xfce4-terminal/spec
@@ -1,4 +1,4 @@
-VER=1.0.4
-SRCS="https://archive.xfce.org/src/apps/xfce4-terminal/${VER:0:3}/xfce4-terminal-$VER.tar.bz2"
-CHKSUMS="sha256::78e55957af7c6fc1f283e90be33988661593a4da98383da1b0b54fdf6554baf4"
+VER=1.1.1
+SRCS="https://archive.xfce.org/src/apps/xfce4-terminal/${VER%.*}/xfce4-terminal-${VER}.tar.bz2"
+CHKSUMS="sha256::5ab5c9b49c00be29f0be4eee5ccfa5073b16f2456185270265a9324549080aa6"
 CHKUPDATE="anitya::id=12981"

--- a/desktop-xfce/xfce4-timer-plugin/spec
+++ b/desktop-xfce/xfce4-timer-plugin/spec
@@ -1,5 +1,4 @@
-VER=1.7.1
+VER=1.7.2
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-timer-plugin/${VER%.*}/xfce4-timer-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::4b52d2911b1949e945971be6533155ee6ba99c77078eac7fd43b0f2aeca824e3"
-REL=3
+CHKSUMS="sha256::feb3b8c2d39505e816683540a3226bd7bda870ccbcb4c7d0f6abfeeff5c58b7d"
 CHKUPDATE="anitya::id=15822"

--- a/desktop-xfce/xfce4-weather-plugin/spec
+++ b/desktop-xfce/xfce4-weather-plugin/spec
@@ -1,5 +1,4 @@
-VER=0.11.0
-SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-weather-plugin/${VER:0:4}/xfce4-weather-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::e3242ea951d51bc0fded1d02a4f1f662bec16a1fb10c855f71bda6541a1153fc"
+VER=0.11.1
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-weather-plugin/${VER%.*}/xfce4-weather-plugin-${VER}.tar.bz2"
+CHKSUMS="sha256::a45146f9a0dcdc95d191c09c64ad279ae289cf8f811c4433e08e31a656845239"
 CHKUPDATE="anitya::id=15820"
-REL=1

--- a/desktop-xfce/xfce4-whiskermenu-plugin/autobuild/defines
+++ b/desktop-xfce/xfce4-whiskermenu-plugin/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=xfce4-whiskermenu-plugin
 PKGSEC=xfce
-PKGDEP="xfce4-panel mugshot"
+PKGDEP="xfce4-panel mugshot gtk-layer-shell"
 BUILDDEP="intltool"
 PKGDES="Alternative application menu plugin for the Xfce4 panel"
 RECONF=0

--- a/desktop-xfce/xfce4-whiskermenu-plugin/spec
+++ b/desktop-xfce/xfce4-whiskermenu-plugin/spec
@@ -1,5 +1,4 @@
-VER=2.7.1
-SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-whiskermenu-plugin/${VER:0:3}/xfce4-whiskermenu-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::04ae0c1764a0d5ec70f18a760d998a2109bb6724f048554d7d6999d9072ca63e"
+VER=2.8.2
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-whiskermenu-plugin/${VER%.*}/xfce4-whiskermenu-plugin-$VER.tar.bz2"
+CHKSUMS="sha256::cbff8325999a20194e0bbce6f4d3d568ce06704d2b79acd9547d6c90aa083e70"
 CHKUPDATE="anitya::id=7201"
-REL=1

--- a/desktop-xfce/xfconf/spec
+++ b/desktop-xfce/xfconf/spec
@@ -1,4 +1,4 @@
-VER=4.18.0
+VER=4.18.3
 SRCS="https://archive.xfce.org/src/xfce/xfconf/${VER%.*}/xfconf-$VER.tar.bz2"
-CHKSUMS="sha256::2e8c50160bf800a807aea094fc9dad81f9f361f42db56607508ed5b4855d2906"
+CHKSUMS="sha256::c56cc69056f6947b2c60b165ec1e4c2b0acf26a778da5f86c89ffce24d5ebd98"
 CHKUPDATE="anitya::id=14854"

--- a/desktop-xfce/xfdesktop/spec
+++ b/desktop-xfce/xfdesktop/spec
@@ -1,4 +1,4 @@
-VER=4.18.0
+VER=4.18.1
 SRCS="https://archive.xfce.org/src/xfce/xfdesktop/${VER%.*}/xfdesktop-$VER.tar.bz2"
-CHKSUMS="sha256::661783e7e6605459926d80bca46d25ce2197c221456457a863ea9d0252120d14"
+CHKSUMS="sha256::ef9268190c25877e22a9ff5aa31cc8ede120239cb0dfca080c174e7eed4ff756"
 CHKUPDATE="anitya::id=14855"

--- a/runtime-desktop/gtk-layer-shell/autobuild/defines
+++ b/runtime-desktop/gtk-layer-shell/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="gtk-layer-shell"
+PKGSEC=libs
+PKGDES="A library to write GTK applications that use Layer Shell"
+PKGDEP="gtk-3 wayland"
+BUILDDEP="gobject-introspection vala"
+ABTYPE=meson

--- a/runtime-desktop/gtk-layer-shell/spec
+++ b/runtime-desktop/gtk-layer-shell/spec
@@ -1,0 +1,4 @@
+VER=0.8.1
+SRCS="git::commit=v${VER}::https://github.com/wmww/gtk-layer-shell.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=198568"


### PR DESCRIPTION
Topic Description
-----------------

This topic surveys for available XFCE component and application updates as of December 2023.

Package(s) Affected
-------------------

### Modified
- xfce4-screensaver: 4.18.2
- xfce4-taskmanager: 1.5.6
- garcon: 4.18.1
- xfce4-appfinder: 4.18.1
- tumbler: 4.18.2
- libxfce4ui: 4.18.4
- xfce4-session: 1:4.18.3
- xfdesktop: 4.18.1
- orage: 4.18.0
- xfce4-notifyd: 0.9.3
- xfce4-pulseaudio-plugin: 0.4.8
- xfce4-calculator-plugin: 0.7.2
- xfce4-cpugraph-plugin: 1.2.10
- xfce4-netload-plugin: 1.4.1
- thunar: 4.18.8
- xfce4-weather-plugin: 0.11.1
- xfce4-mailwatch-plugin: 1.3.1
- xfce4-power-manager: 4.18.3
- mousepad: 0.6.1
- xfce4-notes-plugin: 1.10.0
- xfce4-panel: 1:4.18.5
- xfce4-datetime-plugin: 0.8.3
- xfce4-genmon-plugin: 4.2.0
- ristretto: 0.13.1
- xfce4-whiskermenu-plugin: 2.8.2
- xfce4-panel-profiles: 1.0.14
- xfce4-battery-plugin: 1.1.5
- xfce4-dev-tools: 4.18.1
- xfce4-fsguard-plugin: 1.1.3
- parole: 4.18.1
- xfconf: 4.18.3
- xfce4-terminal: 1.1.1
- gigolo: 0.5.3
- xfce4-screenshooter: 1.10.4
- xfce4-mpc-plugin: 0.5.3
- xfburn: 0.7.0
- catfish: 4.18.0
- xfce4-timer-plugin: 1.7.2
- xfce4-settings: 4.18.4
- xfce4-clipman-plugin: 1.6.5

### Introduced
- gtk-layer-shell: 0.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtk-layer-shell xfce4-dev-tools xfconf libxfce4ui garcon xfce4-panel xfce4-panel-profiles thunar xfdesktop xfce4-notifyd xfce4-power-manager xfce4-settings xfce4-session mousepad orage tumbler xfce4-appfinder parole ristretto xfburn gigolo catfish xfce4-screenshooter xfce4-taskmanager xfce4-terminal xfce4-calculator-plugin xfce4-pulseaudio-plugin xfce4-screensaver xfce4-battery-plugin xfce4-clipman-plugin xfce4-cpugraph-plugin xfce4-datetime-plugin xfce4-fsguard-plugin xfce4-genmon-plugin xfce4-mailwatch-plugin xfce4-mpc-plugin xfce4-netload-plugin xfce4-notes-plugin xfce4-timer-plugin xfce4-weather-plugin xfce4-whiskermenu-plugin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
