### PR TITLE
gitoxide: update to 0.33.0

### DIFF
--- a/app-vcs/gitoxide/autobuild/defines
+++ b/app-vcs/gitoxide/autobuild/defines
@@ -7,5 +7,7 @@ BUILDDEP="rustc llvm"
 
 USECLANG=1
 
+# FIXME: ld.lld is not yet available.
 USCLANG__LOONGSON3=0
 NOLTO__LOONGSON3=1
+NOLTO__MIPS64R6EL=1

--- a/app-vcs/gitoxide/spec
+++ b/app-vcs/gitoxide/spec
@@ -1,4 +1,4 @@
-VER="0.32.0"
+VER="0.33.0"
 SRCS="git::commit=tags/v$VER::https://github.com/Byron/gitoxide"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236380"


### PR DESCRIPTION
Topic Description
-----------------

- gitoxide: update to 0.33.0

Package(s) Affected
-------------------

- gitoxide: 0.33.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gitoxide
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
