### PR TITLE
mcfly: update to 0.8.4

### DIFF
--- a/app-utils/mcfly/spec
+++ b/app-utils/mcfly/spec
@@ -1,5 +1,4 @@
-VER=0.8.0
-REL=1
+VER=0.8.4
 SRCS="git::commit=tags/v$VER::https://github.com/cantino/mcfly/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=179619"


### PR DESCRIPTION
Topic Description
-----------------

- mcly: update to 0.8.4

Package(s) Affected
-------------------

- mcfly: 0.8.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit mcfly
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
