### PR TITLE
libhandy: (mips64r6el) drop glade dep

### DIFF
--- a/desktop-gnome/libhandy/autobuild/defines
+++ b/desktop-gnome/libhandy/autobuild/defines
@@ -2,6 +2,8 @@ PKGNAME=libhandy
 PKGSEC=gnome
 PKGDEP="gtk-3 fribidi"
 BUILDDEP="gobject-introspection gi-docgen gtk-doc vala glade libxml2 vala"
+# FIXME: js-102 -x-> gjs -x-> glade.
+BUILDDEP__MIPS64R6EL="${BUILDDEP/glade/}"
 PKGDES="A library full of GTK+ widgets for mobile phones"
 
 MESON_AFTER="-Dprofiling=false \
@@ -10,3 +12,6 @@ MESON_AFTER="-Dprofiling=false \
              -Dgtk_doc=true \
              -Dexamples=true \
              -Dglade_catalog=enabled"
+# FIXME: js-102 -x-> gjs -x-> glade.
+MESON_AFTER__MIPS64R6EL=" \
+             -Dglade_catalog=disabled"


### PR DESCRIPTION
Topic Description
-----------------

- libhandy: (mips64r6el) drop glade dep
    FIXME: js-102 -x-> gjs -x-> libhandy.
    

Package(s) Affected
-------------------

- libhandy: 1.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libhandy
```

Test Build(s) Done
------------------

**Second Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
