### PR TITLE
Kmod revert to 30

### DIFF
--- a/app-admin/kmod/autobuild/defines
+++ b/app-admin/kmod/autobuild/defines
@@ -19,3 +19,9 @@ AUTOTOOLS_AFTER="--disable-experimental \
                  --with-xz \
                  --with-zlib \
                  --with-openssl"
+
+# Reverted 4774b31b8a58ce65895d586c489c248733b02965 due to a fatal regression
+# discovered which might render the system unbootable
+PKGEPOCH=1
+PKGBREAK="kmod==31"
+PKGREP="kmod==31"

--- a/app-admin/kmod/spec
+++ b/app-admin/kmod/spec
@@ -1,5 +1,4 @@
 VER=30
-REL=1
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-$VER.tar.xz"
 CHKSUMS="sha256::f897dd72698dc6ac1ef03255cd0a5734ad932318e4adbaebc7338ef2f5202f9f"
 CHKUPDATE="anitya::id=1517"

--- a/app-admin/kmod/spec
+++ b/app-admin/kmod/spec
@@ -1,4 +1,5 @@
-VER=31
+VER=30
+REL=1
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-$VER.tar.xz"
-CHKSUMS="sha256::f5a6949043cc72c001b728d8c218609c5a15f3c33d75614b78c79418fcf00d80"
+CHKSUMS="sha256::f897dd72698dc6ac1ef03255cd0a5734ad932318e4adbaebc7338ef2f5202f9f"
 CHKUPDATE="anitya::id=1517"


### PR DESCRIPTION
Topic Description
-----------------

This PR reverts `kmod` back to version 30, due to a fatal regression which might renders the system unbootable.

Package(s) Affected
-------------------

- `kmod` 1:30

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`