### PR TITLE
openvpn: update to 2.5.4

### DIFF
--- a/app-network/openvpn/spec
+++ b/app-network/openvpn/spec
@@ -1,4 +1,4 @@
-VER=2.5.3
+VER=2.5.4
 SRCS="tbl::https://swupdate.openvpn.net/community/releases/openvpn-$VER.tar.gz"
-CHKSUMS="sha256::75f0044df449430555ca7b995a2b77ab24f2946fdc3668301b8edc23986a5f7e"
+CHKSUMS="sha256::f80f3c3df1b94a8892ae547df84f152583250684a24bd022ccc98ef56fa93d97"
 CHKUPDATE="anitya::id=2567"


### PR DESCRIPTION
Topic Description
-----------------

- openvpn: update to 2.5.4

Package(s) Affected
-------------------

- openvpn: 2.5.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit openvpn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
