### PR TITLE
ACBS (Autobuild CI Build System): update to 20231230

### DIFF
--- a/app-devel/acbs/spec
+++ b/app-devel/acbs/spec
@@ -1,4 +1,4 @@
-VER=20231225
+VER=20231230
 SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/acbs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226984"


### PR DESCRIPTION
Topic Description
-----------------

- acbs: update to 20231230

Package(s) Affected
-------------------

- acbs: 2:20231230

Security Update?
----------------

No

Build Order
-----------

```
#buildit acbs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
