### PR TITLE
Autobuild4 4.0.2

### DIFF
--- a/app-devel/autobuild3/autobuild/alternatives
+++ b/app-devel/autobuild3/autobuild/alternatives
@@ -1,0 +1,1 @@
+alternative /usr/bin/autobuild /usr/lib/autobuild3/ab3.sh 50

--- a/app-devel/autobuild3/autobuild/build
+++ b/app-devel/autobuild3/autobuild/build
@@ -22,8 +22,6 @@ abinfo "Installing executable symlinks ..."
 mkdir -pv "$PKGDIR"/usr/bin
 (
     cd "$PKGDIR"/usr/bin
-    ln -sv ../lib/autobuild3/ab3.sh \
-        "$PKGDIR"/usr/bin/autobuild
     ln -sv ../lib/autobuild3/contrib/* \
         "$PKGDIR"/usr/bin/
 )

--- a/app-devel/autobuild3/spec
+++ b/app-devel/autobuild3/spec
@@ -1,4 +1,5 @@
 VER=1.8.6
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"

--- a/app-devel/autobuild4/autobuild/alternatives
+++ b/app-devel/autobuild4/autobuild/alternatives
@@ -1,1 +1,1 @@
-alternative /usr/bin/autobuild /usr/lib/autobuild4/autobuild 50
+alternative /usr/bin/autobuild /usr/lib/autobuild4/autobuild 80

--- a/app-devel/autobuild4/autobuild/alternatives
+++ b/app-devel/autobuild4/autobuild/alternatives
@@ -1,0 +1,1 @@
+alternative /usr/bin/autobuild /usr/lib/autobuild4/autobuild 50

--- a/app-devel/autobuild4/autobuild/beyond
+++ b/app-devel/autobuild4/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Moving autobuild script to /usr/lib for alternatives processing ..."
+mv -v "$PKGDIR"/usr/bin/autobuild "$PKGDIR"/usr/lib/autobuild4/autobuild

--- a/app-devel/autobuild4/autobuild/beyond.stage2
+++ b/app-devel/autobuild4/autobuild/beyond.stage2
@@ -1,2 +1,0 @@
-abinfo "Drop /etc/autobuild/ab3cfg.sh for stage2 ..."
-rm -v "$PKGDIR"/etc/autobuild/ab3cfg.sh

--- a/app-devel/autobuild4/autobuild/beyond.stage2
+++ b/app-devel/autobuild4/autobuild/beyond.stage2
@@ -1,0 +1,2 @@
+abinfo "Drop /etc/autobuild/ab3cfg.sh for stage2 ..."
+rm -v "$PKGDIR"/etc/autobuild/ab3cfg.sh

--- a/app-devel/autobuild4/autobuild/defines
+++ b/app-devel/autobuild4/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=autobuild4
+PKGSEC=devel
+PKGDES="Multi-backend and extensible packaging toolkit"
+PKGDEP="autoconf autoconf-archive automake apt dpkg bash config coreutils \
+        spdx-licenses"
+BUILDDEP="nlohmann-json"
+PKGRECOM="cargo-audit"
+
+VER_NONE=1

--- a/app-devel/autobuild4/autobuild/defines
+++ b/app-devel/autobuild4/autobuild/defines
@@ -5,5 +5,6 @@ PKGDEP="autoconf autoconf-archive automake apt dpkg bash config coreutils \
         spdx-licenses"
 BUILDDEP="nlohmann-json"
 PKGRECOM="cargo-audit"
+PKGPROV="autobuild3 autobuild"
 
 VER_NONE=1

--- a/app-devel/autobuild4/autobuild/defines
+++ b/app-devel/autobuild4/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=autobuild4
 PKGSEC=devel
 PKGDES="Multi-backend and extensible packaging toolkit"
 PKGDEP="autoconf autoconf-archive automake apt dpkg bash config coreutils \
-        spdx-licenses"
+        spdx-licenses gcc-runtime glibc"
 BUILDDEP="nlohmann-json"
 PKGRECOM="cargo-audit"
 PKGPROV="autobuild3 autobuild"

--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.0.0
+VER=4.0.2
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"

--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,0 +1,4 @@
+VER=4.0.0
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=226987"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: new, 4.0.0

Package(s) Affected
-------------------

- autobuild4: 4.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild3 autobuild4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
