### PR TITLE
bcachefs-tools: new, 1.4.0

### DIFF
--- a/app-admin/bcachefs-tools/autobuild/beyond
+++ b/app-admin/bcachefs-tools/autobuild/beyond
@@ -1,0 +1,3 @@
+# FIXME: upstream does not provide dracut hooks, removing unused initramfs-tools hooks
+abinfo "Removing initramfs-tools hooks ..."
+rm -rv "$PKGDIR"/usr/share/initramfs-tools

--- a/app-admin/bcachefs-tools/autobuild/defines
+++ b/app-admin/bcachefs-tools/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=bcachefs-tools
+PKGSEC=admin
+BUILDDEP="libaio util-linux llvm keyutils lz4 libsodium \
+        liburcu zstd pkg-config zlib rustc"
+PKGDES="Userspace tools and docs for bcachefs"
+
+MAKE_AFTER="ROOT_SBINDIR=/usr/bin"
+NOLTO=1

--- a/app-admin/bcachefs-tools/spec
+++ b/app-admin/bcachefs-tools/spec
@@ -1,0 +1,4 @@
+VER=1.4.0
+SRCS="git::commit=tags/v${VER}::https://evilpiepirate.org/git/bcachefs-tools.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=370291"


### PR DESCRIPTION
Topic Description
-----------------

- bcachefs-tools: new, 1.4.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
    

Package(s) Affected
-------------------

- bcachefs-tools: 1.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bcachefs-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
