### PR TITLE
libmbim: update to 1.30.0

### DIFF
--- a/runtime-devices/libmbim/spec
+++ b/runtime-devices/libmbim/spec
@@ -1,5 +1,4 @@
-VER=1.26.4
-REL=1
+VER=1.30.0
 SRCS="git::commit=tags/${VER}::https://gitlab.freedesktop.org/mobile-broadband/libmbim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7308"


### PR DESCRIPTION
Topic Description
-----------------

- libmbim: update to 1.30.0

- libseccomp: update to 2.5.5
    This update enables loongarch64 host support.
    
- libiscsi: fix FTBFS for mips64r6el
    - By setting the default ld emulation to elf64ltsmip.
    
- latx: new, 1.4.3+emukit20231027
    - Add POCF flags for binfmt to improve compatibility with containers.
    - 32-bit x86 applications works via optenv32.
    - Bind mount /run to allow D-Bus to work.
    - Mark all mount units as lazy umount (LazyUnmount=true) to help with
      on-the-fly upgrades.
    - Stop all mount units during upgrade (in prerm).
    - Add a postrm script to remove sysroots (we plan to debundle the sysroot down
      the line).
    
- librsvg: update to 2.56.1
    - Fixes build on loongarch64 due to upgraded linux-raw-sys.
    - (loongarch64) disable LTO.
    
    FIXME: ld.lld not yet available for loongarch64.
    
- libusbmuxd: bump REL

- libimobiledevice: (Arch Linux) enable support for newer libplist versions

- solid: bump REL

- gvfs: bump REL

- owntone: bump REL


... and 95071 more commits

Package(s) Affected
-------------------

- libmbim: 1.30.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmbim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Second Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
