### PR TITLE
libmbim: update to 1.30.0

### DIFF
--- a/runtime-devices/libmbim/spec
+++ b/runtime-devices/libmbim/spec
@@ -1,5 +1,4 @@
-VER=1.26.4
-REL=1
+VER=1.30.0
 SRCS="git::commit=tags/${VER}::https://gitlab.freedesktop.org/mobile-broadband/libmbim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7308"


### PR DESCRIPTION
Topic Description
-----------------

- libmbim: update to 1.30.0

Package(s) Affected
-------------------

- libmbim: 1.30.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmbim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
