### PR TITLE
rbw: update to 1.9.0

### DIFF
--- a/app-utils/rbw/autobuild/defines
+++ b/app-utils/rbw/autobuild/defines
@@ -6,5 +6,9 @@ BUILDDEP="rustc llvm"
 
 USECLANG=1
 
-# Break for rustls
-FAIL_ARCH="!(amd64|arm64)"
+# ld.lld does not support
+USECLANG__LOONGSON3=0
+USECLANG__MIPS64R6EL=0
+
+NOLTO__LOONGSON3=1
+NOLTO__MIPS64R6EL=1

--- a/app-utils/rbw/spec
+++ b/app-utils/rbw/spec
@@ -1,5 +1,4 @@
-VER=1.8.3
+VER=1.9.0
 SRCS="git::commit=tags/$VER::https://github.com/doy/rbw"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241513"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- rbw: update to 1.9.0

Package(s) Affected
-------------------

- rbw: 1.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rbw
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
