### PR TITLE
LLVM: fix build for mips64r6el

### DIFF
--- a/app-devel/llvm/01-runtime/build.stage2
+++ b/app-devel/llvm/01-runtime/build.stage2
@@ -24,6 +24,14 @@ if [[ "$USECLANG" = '1' ]]; then
       export CFLAGS="${CFLAGS} -D__LONG_WIDTH__=64"
       export CXXFLAGS="${CXXFLAGS} -D__LONG_WIDTH__=64"
   fi
+else
+  # the clang freshly built by this script will be used to build
+  # compiler-rt, so we remove gcc-only flags here
+  for GCC_FLAG in '-fira-'{loop,hoist}'-pressure' '-fdeclone-ctor-dtor'; do
+    CFLAGS="${CFLAGS/${GCC_FLAG}/}"
+    CXXFLAGS="${CXXFLAGS/${GCC_FLAG}/}"
+  done
+  export CFLAGS CXXFLAGS
 fi
 
 abinfo "Running CMake for LLVM ..."

--- a/app-devel/llvm/01-runtime/defines.stage2
+++ b/app-devel/llvm/01-runtime/defines.stage2
@@ -32,26 +32,26 @@ ABSPLITDBG__ARMV6HF="${ABSPLITDBG__RETRO}"
 ABSPLITDBG__ARMV7HF="${ABSPLITDBG__RETRO}"
 ABSPLITDBG__I486="${ABSPLITDBG__RETRO}"
 ABSPLITDBG__LOONGSON2F="${ABSPLITDBG__RETRO}"
+ABSPLITDBG__M68K="${ABSPLITDBG__RETRO}"
 ABSPLITDBG__POWERPC="${ABSPLITDBG__RETRO}"
 ABSPLITDBG__PPC64="${ABSPLITDBG__RETRO}"
 
 # Figure out which feature/module to enable
-_LLVM_MIN_SET="clang;lld;lldb" # for AOSC OS/Retro
-_LLVM_BASE_SET="${_LLVM_MIN_SET};clang-tools-extra;compiler-rt;polly" # for main-T2 arch (e.g. loongson3, riscv64 ...)
-_LLVM_FULL_SET="${_LLVM_BASE_SET};mlir;bolt;pstl;flang;openmp" # for main-T1 arch (e.g. amd64, arm64 ...)
-_LLVM_BASE_SET__LOONGARCH64="clang;lldb;clang-tools-extra;compiler-rt;polly"
+_LLVM_MIN_SET="clang" # for Afterglow and other new ports
+_LLVM_BASE_SET="${_LLVM_MIN_SET};lld;lldb;clang-tools-extra;polly" # for main-T2 arch (e.g. loongson3, riscv64 ...)
+_LLVM_FULL_SET="${_LLVM_BASE_SET}" # for main-T1 arch (e.g. amd64, arm64 ...)
+_LLVM_BASE_SET__LOONGARCH64="clang;lldb;clang-tools-extra;compiler-rt;polly;"
 # FIXME: lld is broken on MIPS (as of 16.0.6), fails to link Mozilla
 # applications and causes a build-time segfault when building LibreOffice.
 _LLVM_BASE_SET__LOONGSON3="${_LLVM_BASE_SET/lld;}"
-_LLVM_BASE_SET__MIPS64R6EL="clang;lldb;clang-tools-extra;compiler-rt;polly"
+_LLVM_BASE_SET__MIPS64R6EL="clang;lldb;clang-tools-extra;compiler-rt;polly;"
 
-_LLVM_MIN_RUNTIME_SET="libunwind" # for AOSC OS/Retro
-_LLVM_BASE_RUNTIME_SET="${_LLVM_MIN_RUNTIME_SET};libcxx;libcxxabi"
-_LLVM_FULL_RUNTIME_SET="${_LLVM_BASE_RUNTIME_SET};libclc"
+_LLVM_BASE_RUNTIME_SET="libcxx;libcxxabi;compiler-rt"
+_LLVM_FULL_RUNTIME_SET="${_LLVM_BASE_RUNTIME_SET}"
 _LLVM_BASE_RUNTIME_SET__LOONGARCH64="libcxx;libcxxabi"
 # FIXME: Runtime libraries does not build without lld.
 _LLVM_BASE_RUNTIME_SET__LOONGSON3=""
-_LLVM_BASE_RUNTIME_SET__MIPS64R6EL="libcxx;libcxxabi"
+_LLVM_BASE_RUNTIME_SET__MIPS64R6EL=""
 
 CMAKE_AFTER="-DLLVM_BUILD_LLVM_DYLIB=ON \
              -DLLVM_DYLIB_EXPORT_ALL=ON \
@@ -64,7 +64,7 @@ CMAKE_AFTER="-DLLVM_BUILD_LLVM_DYLIB=ON \
              -DLLVM_BINUTILS_INCDIR=/usr/include \
              -DLLVM_INSTALL_UTILS=ON \
              -DLLVM_INCLUDE_TESTS=OFF \
-             -DLLVM_USE_LINKER=lld"
+             -DLLVM_USE_LINKER="
 # Mainline
 CMAKE_AFTER__BASE=" \
              ${CMAKE_AFTER} \
@@ -82,7 +82,12 @@ CMAKE_AFTER__LOONGARCH64=" \
              -DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET__LOONGARCH64} \
              -DLLVM_USE_LINKER=bfd \
              -DLLVM_PARALLEL_LINK_JOBS=2"
-CMAKE_AFTER__LOONGSON3="${CMAKE_AFTER__BASE} -DLLVM_USE_LINKER=gold -DLLVM_PARALLEL_LINK_JOBS=2"
+CMAKE_AFTER__LOONGSON3=" \
+             ${CMAKE_AFTER} \
+             -DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET__LOONGSON3} \
+             -DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET__LOONGSON3} \
+             -DLLVM_PARALLEL_LINK_JOBS=2 \
+             -DLLVM_USE_LINKER="
 CMAKE_AFTER__MIPS64R6EL=" \
              ${CMAKE_AFTER} \
              -DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET__MIPS64R6EL} \
@@ -100,25 +105,50 @@ CMAKE_AFTER__RETRO=" \
              -DLLVM_ENABLE_FFI=ON \
              -DLLVM_BUILD_DOCS=OFF \
              -DLLVM_ENABLE_PROJECTS=${_LLVM_MIN_SET} \
+             -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
              -DFFI_INCLUDE_DIR=$(pkg-config --variable=includedir libffi) \
              -DLLVM_BINUTILS_INCDIR=/usr/include \
              -DLLVM_INSTALL_UTILS=ON \
-             -DLLVM_USE_LINKER=bfd \
-             -DLLVM_INCLUDE_TESTS=OFF"
+             -DLLVM_INCLUDE_TESTS=OFF \
+             -DLLVM_USE_LINKER=bfd"
 CMAKE_AFTER__ARMV4="${CMAKE_AFTER__RETRO}"
 CMAKE_AFTER__ARMV6HF="${CMAKE_AFTER__RETRO}"
 CMAKE_AFTER__ARMV7HF="${CMAKE_AFTER__RETRO}"
 CMAKE_AFTER__I486="${CMAKE_AFTER__RETRO}"
 CMAKE_AFTER__LOONGSON2F="${CMAKE_AFTER__RETRO}"
+CMAKE_AFTER__M68K="${CMAKE_AFTER__RETRO}"
 CMAKE_AFTER__POWERPC="${CMAKE_AFTER__RETRO}"
 CMAKE_AFTER__PPC64="${CMAKE_AFTER__RETRO}"
 
-PKGBREAK="ccls<=0.20201219-2 codelite<=15.0 cquery<=20180718-5 \
-          edi<=0.8.0-5 gnome-builder<=3.40.0-1 \
-          intel-graphics-compiler<=1.0.7423 intellij-idea<=2020.3.2-1 \
-          ispc<=1.15.0-1 kdevelop<=5.6.2-1 ldc<=1.24.0-1 \
-          liblphobos<=1.24.0-1 libobjc2<=2.1-1 llvm<=11.1.0 \
-          mesa<=1:21.0.2 opencl-clang<=11.0.0-1 openstf<=3.3.0 \
-          pocl<=1:1.6-1 pyside2<=5.15.1 qt-5<=1:5.15.1+wk5.212.0-5 \
-          qtcreator<=4.14.1-1 rustc<=1:1.52.1 spirv-llvm-translator<=11.0.0-1"
+PKGBREAK="""
+bcc<=0.27.0
+bpftrace<=0.18.0
+castxml<=0.6.1
+ccls<=0.20220729-2
+clazy<=1.11-1
+codelite<=15.0
+cquery<=20180718-5
+edi<=0.8.0-5
+dub<=1.34.0
+gnome-builder<=42.1-2
+intel-graphics-compiler<=1.0.7423
+ispc<=1.20.0+git20230725
+kdevelop<=22.08.3-1
+ldc<=1.34.0
+liblphobos<=1.24.0-1
+libobjc2<=2.1-1
+llvm<=11.1.0
+mesa<=1:23.2.1-1
+opencl-clang<=16.0.0
+openstf<=3.3.0
+openvdb<=10.0.1-2
+pocl<=1:1.6-1
+postgresql<=13.11-1
+pyside2<=5.15.11
+qt-5<=1:5.15.1+wk5.212.0-5
+qtcreator<=4.14.1-1
+rustc<=1:1.71.1-1
+spirv-llvm-translator<=16.0.0
+"""
+
 PKGREP="llvm<=3.7.0-2"

--- a/app-devel/llvm/01-runtime/patches/0005-mips-mc-clang-Use-pc-relative-relocations-in-.eh_fra.patch
+++ b/app-devel/llvm/01-runtime/patches/0005-mips-mc-clang-Use-pc-relative-relocations-in-.eh_fra.patch
@@ -1,0 +1,463 @@
+From 83150d77568a547a7264a95bb49ed74598f0494f Mon Sep 17 00:00:00 2001
+From: Simon Atanasyan <simon@atanasyan.com>
+Date: Tue, 2 Jan 2024 22:29:22 -0700
+Subject: [PATCH] [mips][mc][clang] Use pc-relative relocations in .eh_frame
+
+Co-Authored-By: liushuyu <liushuyu011@gmail.com>
+---
+ clang/include/clang/Basic/CodeGenOptions.def  |  3 ++
+ clang/include/clang/Driver/Options.td         |  3 ++
+ clang/lib/CodeGen/BackendUtil.cpp             |  1 +
+ clang/lib/Driver/ToolChains/Clang.cpp         | 10 +++++
+ clang/test/Driver/mips-features.c             | 12 ++++++
+ clang/tools/driver/cc1as_main.cpp             |  3 ++
+ lld/test/ELF/mips-eh_frame-pic.s              | 16 ++++----
+ llvm/include/llvm/MC/MCContext.h              |  1 +
+ llvm/include/llvm/MC/MCTargetOptions.h        |  3 ++
+ .../llvm/MC/MCTargetOptionsCommandFlags.h     |  2 +
+ .../CodeGen/TargetLoweringObjectFileImpl.cpp  |  8 +---
+ llvm/lib/MC/MCContext.cpp                     |  6 +++
+ llvm/lib/MC/MCObjectFileInfo.cpp              | 13 +++---
+ llvm/lib/MC/MCTargetOptions.cpp               |  3 +-
+ llvm/lib/MC/MCTargetOptionsCommandFlags.cpp   |  9 +++++
+ llvm/test/CodeGen/Mips/ehframe-indirect.ll    | 40 ++++++++++++-------
+ llvm/test/DebugInfo/Mips/eh_frame.ll          |  4 +-
+ llvm/test/MC/Mips/eh-frame.s                  | 26 +++++++-----
+ 18 files changed, 114 insertions(+), 49 deletions(-)
+
+diff --git a/clang/include/clang/Basic/CodeGenOptions.def b/clang/include/clang/Basic/CodeGenOptions.def
+index d492b8681..72fe77a4a 100644
+--- a/clang/include/clang/Basic/CodeGenOptions.def
++++ b/clang/include/clang/Basic/CodeGenOptions.def
+@@ -118,6 +118,9 @@ CODEGENOPT(ForceDwarfFrameSection , 1, 0) ///< Set when -fforce-dwarf-frame is
+ ///< Set when -femit-compact-unwind-non-canonical is enabled.
+ CODEGENOPT(EmitCompactUnwindNonCanonical, 1, 0)
+ 
++///< Set when -mips-pc64-rel is enabled.
++CODEGENOPT(MipsPC64Relocation, 1, 0)
++
+ ///< Set when -femit-dwarf-unwind is passed.
+ ENUM_CODEGENOPT(EmitDwarfUnwind, llvm::EmitDwarfUnwindType, 2,
+                 llvm::EmitDwarfUnwindType::Default)
+diff --git a/clang/include/clang/Driver/Options.td b/clang/include/clang/Driver/Options.td
+index 37e8c56b2..632a61418 100644
+--- a/clang/include/clang/Driver/Options.td
++++ b/clang/include/clang/Driver/Options.td
+@@ -4351,6 +4351,9 @@ def mno_relax_pic_calls : Flag<["-"], "mno-relax-pic-calls">,
+   Group<m_mips_Features_Group>,
+   HelpText<"Do not produce relaxation hints for linkers to try optimizing PIC "
+            "call sequences into direct calls (MIPS only)">, Flags<[HelpHidden]>;
++defm mips_pc64_rel : BoolOption<"", "mips-pc64-rel",
++CodeGenOpts<"MipsPC64Relocation">, DefaultTrue,
++PosFlag<SetTrue, [CC1Option, CC1AsOption], "Use MIPS 64-bit PC-relative relocations">, NegFlag<SetFalse>>;
+ def mglibc : Flag<["-"], "mglibc">, Group<m_libc_Group>, Flags<[HelpHidden]>;
+ def muclibc : Flag<["-"], "muclibc">, Group<m_libc_Group>, Flags<[HelpHidden]>;
+ def module_file_info : Flag<["-"], "module-file-info">, Flags<[NoXarchOption,CC1Option]>, Group<Action_Group>,
+diff --git a/clang/lib/CodeGen/BackendUtil.cpp b/clang/lib/CodeGen/BackendUtil.cpp
+index 483f3e787..906756627 100644
+--- a/clang/lib/CodeGen/BackendUtil.cpp
++++ b/clang/lib/CodeGen/BackendUtil.cpp
+@@ -486,6 +486,7 @@ static bool initTargetOptions(DiagnosticsEngine &Diags,
+   Options.MCOptions.CommandLineArgs = CodeGenOpts.CommandLineArgs;
+   Options.MCOptions.AsSecureLogFile = CodeGenOpts.AsSecureLogFile;
+   Options.MisExpect = CodeGenOpts.MisExpect;
++  Options.MCOptions.MipsPC64Relocation = CodeGenOpts.MipsPC64Relocation;
+ 
+   return true;
+ }
+diff --git a/clang/lib/Driver/ToolChains/Clang.cpp b/clang/lib/Driver/ToolChains/Clang.cpp
+index 37a07b8f2..59fa245fb 100644
+--- a/clang/lib/Driver/ToolChains/Clang.cpp
++++ b/clang/lib/Driver/ToolChains/Clang.cpp
+@@ -2013,6 +2013,16 @@ void Clang::AddMIPSTargetArgs(const ArgList &Args,
+       CmdArgs.push_back("-mips-jalr-reloc=0");
+     }
+   }
++
++  if (Arg *A = Args.getLastArg(options::OPT_mips_pc64_rel,
++                               options::OPT_no_mips_pc64_rel)) {
++    CmdArgs.push_back("-mllvm");
++    if (A->getOption().matches(options::OPT_mips_pc64_rel))
++      CmdArgs.push_back("-mips-pc64-rel=true");
++    else
++      CmdArgs.push_back("-mips-pc64-rel=false");
++    A->claim();
++  }
+ }
+ 
+ void Clang::AddPPCTargetArgs(const ArgList &Args,
+diff --git a/clang/test/Driver/mips-features.c b/clang/test/Driver/mips-features.c
+index 5ae566774..58b5368d4 100644
+--- a/clang/test/Driver/mips-features.c
++++ b/clang/test/Driver/mips-features.c
+@@ -456,3 +456,15 @@
+ // RUN:     -mrelax-pic-calls -mno-relax-pic-calls 2>&1 \
+ // RUN:   | FileCheck --check-prefix=CHECK-NO-RELAX-PIC-CALLS %s
+ // CHECK-NO-RELAX-PIC-CALLS: "-mllvm" "-mips-jalr-reloc=0"
++//
++// -mips-pc64-rel
++// RUN: %clang -target mips-unknown-linux-gnu -### -c %s \
++// RUN:     -no-mips-pc64-rel -mips-pc64-rel 2>&1 \
++// RUN:   | FileCheck --check-prefix=CHECK-PC64-REL %s
++// CHECK-PC64-REL-NOT: "-mllvm" "-mips-pc64-rel=false"
++//
++// -no-mips-pc64-rel
++// RUN: %clang -target mips-unknown-linux-gnu -### -c %s \
++// RUN:     -mips-pc64-rel -no-mips-pc64-rel 2>&1 \
++// RUN:   | FileCheck --check-prefix=CHECK-NO-PC64-REL %s
++// CHECK-NO-PC64-REL: "-mllvm" "-mips-pc64-rel=false"
+diff --git a/clang/tools/driver/cc1as_main.cpp b/clang/tools/driver/cc1as_main.cpp
+index 3c5926073..1668f81a8 100644
+--- a/clang/tools/driver/cc1as_main.cpp
++++ b/clang/tools/driver/cc1as_main.cpp
+@@ -147,6 +147,8 @@ struct AssemblerInvocation {
+   // Note: maybe overriden by other constraints.
+   unsigned EmitCompactUnwindNonCanonical : 1;
+ 
++  unsigned MipsPC64Relocation : 1;
++
+   /// The name of the relocation model to use.
+   std::string RelocationModel;
+ 
+@@ -411,6 +413,7 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
+   MCTargetOptions MCOptions;
+   MCOptions.EmitDwarfUnwind = Opts.EmitDwarfUnwind;
+   MCOptions.EmitCompactUnwindNonCanonical = Opts.EmitCompactUnwindNonCanonical;
++  MCOptions.MipsPC64Relocation = Opts.MipsPC64Relocation;
+   MCOptions.AsSecureLogFile = Opts.AsSecureLogFile;
+ 
+   std::unique_ptr<MCAsmInfo> MAI(
+diff --git a/lld/test/ELF/mips-eh_frame-pic.s b/lld/test/ELF/mips-eh_frame-pic.s
+index a84c36b0e..8f005de95 100644
+--- a/lld/test/ELF/mips-eh_frame-pic.s
++++ b/lld/test/ELF/mips-eh_frame-pic.s
+@@ -12,11 +12,11 @@
+ ## relative addressing.
+ # NOPIC-ERR: ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol
+ 
+-## For -fPIC, .eh_frame should contain DW_EH_PE_pcrel | DW_EH_PE_sdata4 values:
++## For -fPIC, .eh_frame should contain DW_EH_PE_pcrel | DW_EH_PE_sdata8 values:
+ # RUN: llvm-mc -filetype=obj -triple=mips64-unknown-linux --position-independent %s -o %t-pic.o
+ # RUN: llvm-readobj -r %t-pic.o | FileCheck %s --check-prefixes=RELOCS,PIC64-RELOCS
+ # RUN: ld.lld -shared %t-pic.o -o %t-pic.so
+-# RUN: llvm-dwarfdump --eh-frame %t-pic.so | FileCheck %s --check-prefix=PIC-EH-FRAME
++# RUN: llvm-dwarfdump --eh-frame %t-pic.so | FileCheck %s --check-prefix=PIC64-EH-FRAME
+ 
+ ## Also check MIPS32:
+ # RUN: llvm-mc -filetype=obj -triple=mips-unknown-linux %s -o %t-nopic32.o
+@@ -31,12 +31,12 @@
+ # RUN: llvm-mc -filetype=obj -triple=mips-unknown-linux --position-independent %s -o %t-pic32.o
+ # RUN: llvm-readobj -r %t-pic32.o | FileCheck %s --check-prefixes=RELOCS,PIC32-RELOCS
+ # RUN: ld.lld -shared %t-pic32.o -o %t-pic32.so
+-# RUN: llvm-dwarfdump --eh-frame %t-pic32.so | FileCheck %s --check-prefix=PIC-EH-FRAME
++# RUN: llvm-dwarfdump --eh-frame %t-pic32.so | FileCheck %s --check-prefix=PIC32-EH-FRAME
+ 
+ # RELOCS:            .rel{{a?}}.eh_frame {
+ # ABS32-RELOCS-NEXT:   0x1C R_MIPS_32 .text
+ # ABS64-RELOCS-NEXT:   0x1C R_MIPS_64/R_MIPS_NONE/R_MIPS_NONE .text
+-# PIC64-RELOCS-NEXT:   0x1C R_MIPS_PC32/R_MIPS_NONE/R_MIPS_NONE <null>
++# PIC64-RELOCS-NEXT:   0x1C R_MIPS_PC32/R_MIPS_64/R_MIPS_NONE <null>
+ # PIC32-RELOCS-NEXT:   0x1C R_MIPS_PC32 <null>
+ # RELOCS-NEXT:       }
+ 
+@@ -44,10 +44,10 @@
+ ##                                   ^^ fde pointer encoding: DW_EH_PE_sdata8
+ # ABS32-EH-FRAME: Augmentation data: 0B
+ ##                                   ^^ fde pointer encoding: DW_EH_PE_sdata4
+-# PIC-EH-FRAME: Augmentation data: 1B
+-##                                 ^^ fde pointer encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata4
+-## Note: ld.bfd converts the R_MIPS_64 relocs to DW_EH_PE_pcrel | DW_EH_PE_sdata8
+-## for N64 ABI (and DW_EH_PE_pcrel | DW_EH_PE_sdata4 for MIPS32)
++# PIC32-EH-FRAME: Augmentation data: 1B
++##                                   ^^ fde pointer encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata4
++# PIC64-EH-FRAME: Augmentation data: 1C
++##                                   ^^ fde pointer encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata8
+ 
+ .ent func
+ .global func
+diff --git a/llvm/include/llvm/MC/MCContext.h b/llvm/include/llvm/MC/MCContext.h
+index 68d6f3e59..d6d6ec9ba 100644
+--- a/llvm/include/llvm/MC/MCContext.h
++++ b/llvm/include/llvm/MC/MCContext.h
+@@ -791,6 +791,7 @@ public:
+   unsigned getGenDwarfFileNumber() { return GenDwarfFileNumber; }
+   EmitDwarfUnwindType emitDwarfUnwindInfo() const;
+   bool emitCompactUnwindNonCanonical() const;
++  bool getMipsPC64Relocation() const;
+ 
+   void setGenDwarfFileNumber(unsigned FileNumber) {
+     GenDwarfFileNumber = FileNumber;
+diff --git a/llvm/include/llvm/MC/MCTargetOptions.h b/llvm/include/llvm/MC/MCTargetOptions.h
+index 9fc1e07d0..b14ba6222 100644
+--- a/llvm/include/llvm/MC/MCTargetOptions.h
++++ b/llvm/include/llvm/MC/MCTargetOptions.h
+@@ -89,6 +89,9 @@ public:
+   // functions on Darwins.
+   bool EmitCompactUnwindNonCanonical : 1;
+ 
++  // Whether to use MIPS 64-bit PC-relative relocations
++  bool MipsPC64Relocation : 1;
++
+   MCTargetOptions();
+ 
+   /// getABIName - If this returns a non-empty string this represents the
+diff --git a/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h b/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
+index 7f6ee6c8b..c961628ae 100644
+--- a/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
++++ b/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
+@@ -51,6 +51,8 @@ std::string getABIName();
+ 
+ std::string getAsSecureLogFile();
+ 
++bool getMipsPC64Relocation();
++
+ /// Create this object with static storage to register mc-related command
+ /// line options.
+ struct RegisterMCTargetOptionsFlags {
+diff --git a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+index 4ffffd85e..e8179de43 100644
+--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
++++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+@@ -212,13 +212,9 @@ void TargetLoweringObjectFileELF::Initialize(MCContext &Ctx,
+     //        identify N64 from just a triple.
+     TTypeEncoding = dwarf::DW_EH_PE_indirect | dwarf::DW_EH_PE_pcrel |
+                     dwarf::DW_EH_PE_sdata4;
+-    // We don't support PC-relative LSDA references in GAS so we use the default
+-    // DW_EH_PE_absptr for those.
+ 
+-    // FreeBSD must be explicit about the data size and using pcrel since it's
+-    // assembler/linker won't do the automatic conversion that the Linux tools
+-    // do.
+-    if (TgtM.getTargetTriple().isOSFreeBSD()) {
++    if (isPositionIndependent() &&
++        (TgtM.Options.MCOptions.MipsPC64Relocation || TgtM.getTargetTriple().isMIPS32())) {
+       PersonalityEncoding |= dwarf::DW_EH_PE_pcrel | dwarf::DW_EH_PE_sdata4;
+       LSDAEncoding = dwarf::DW_EH_PE_pcrel | dwarf::DW_EH_PE_sdata4;
+     }
+diff --git a/llvm/lib/MC/MCContext.cpp b/llvm/lib/MC/MCContext.cpp
+index c443f46e0..0f6d5f927 100644
+--- a/llvm/lib/MC/MCContext.cpp
++++ b/llvm/lib/MC/MCContext.cpp
+@@ -932,6 +932,12 @@ bool MCContext::emitCompactUnwindNonCanonical() const {
+   return false;
+ }
+ 
++bool MCContext::getMipsPC64Relocation() const {
++  if (TargetOptions)
++    return TargetOptions->MipsPC64Relocation;
++  return false;
++}
++
+ void MCContext::setGenDwarfRootFile(StringRef InputFileName, StringRef Buffer) {
+   // MCDwarf needs the root file as well as the compilation directory.
+   // If we find a '.file 0' directive that will supersede these values.
+diff --git a/llvm/lib/MC/MCObjectFileInfo.cpp b/llvm/lib/MC/MCObjectFileInfo.cpp
+index 0b5109e41..97e2e03bc 100644
+--- a/llvm/lib/MC/MCObjectFileInfo.cpp
++++ b/llvm/lib/MC/MCObjectFileInfo.cpp
+@@ -337,14 +337,11 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T, bool Large) {
+   case Triple::mipsel:
+   case Triple::mips64:
+   case Triple::mips64el:
+-    // We cannot use DW_EH_PE_sdata8 for the large PositionIndependent case
+-    // since there is no R_MIPS_PC64 relocation (only a 32-bit version).
+-    if (PositionIndependent && !Large)
+-      FDECFIEncoding = dwarf::DW_EH_PE_pcrel | dwarf::DW_EH_PE_sdata4;
+-    else
+-      FDECFIEncoding = Ctx->getAsmInfo()->getCodePointerSize() == 4
+-                           ? dwarf::DW_EH_PE_sdata4
+-                           : dwarf::DW_EH_PE_sdata8;
++    FDECFIEncoding = Ctx->getAsmInfo()->getCodePointerSize() == 4
++                         ? dwarf::DW_EH_PE_sdata4
++                         : dwarf::DW_EH_PE_sdata8;
++    if (PositionIndependent && (Ctx->getMipsPC64Relocation() || T.isMIPS32()))
++      FDECFIEncoding |= dwarf::DW_EH_PE_pcrel;
+     break;
+   case Triple::ppc64:
+   case Triple::ppc64le:
+diff --git a/llvm/lib/MC/MCTargetOptions.cpp b/llvm/lib/MC/MCTargetOptions.cpp
+index 8fea8c771..cb7f242e3 100644
+--- a/llvm/lib/MC/MCTargetOptions.cpp
++++ b/llvm/lib/MC/MCTargetOptions.cpp
+@@ -19,7 +19,8 @@ MCTargetOptions::MCTargetOptions()
+       PreserveAsmComments(true), Dwarf64(false),
+       EmitDwarfUnwind(EmitDwarfUnwindType::Default),
+       MCUseDwarfDirectory(DefaultDwarfDirectory),
+-      EmitCompactUnwindNonCanonical(false) {}
++      EmitCompactUnwindNonCanonical(false),
++      MipsPC64Relocation(true) {}
+ 
+ StringRef MCTargetOptions::getABIName() const {
+   return ABIName;
+diff --git a/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp b/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
+index 8a4923e47..76e719c51 100644
+--- a/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
++++ b/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
+@@ -47,6 +47,7 @@ MCOPT(bool, NoDeprecatedWarn)
+ MCOPT(bool, NoTypeCheck)
+ MCOPT(std::string, ABIName)
+ MCOPT(std::string, AsSecureLogFile)
++MCOPT(bool, MipsPC64Relocation)
+ 
+ llvm::mc::RegisterMCTargetOptionsFlags::RegisterMCTargetOptionsFlags() {
+ #define MCBINDOPT(NAME)                                                        \
+@@ -128,6 +129,13 @@ llvm::mc::RegisterMCTargetOptionsFlags::RegisterMCTargetOptionsFlags() {
+       "as-secure-log-file", cl::desc("As secure log file name"), cl::Hidden);
+   MCBINDOPT(AsSecureLogFile);
+ 
++  static cl::opt<bool> MipsPC64Relocation(
++      "mips-pc64-rel", cl::Hidden,
++      cl::desc(
++          "Whether to MIPS 64-bit PC-relative relocations"),
++      cl::init(true));
++  MCBINDOPT(MipsPC64Relocation);
++
+ #undef MCBINDOPT
+ }
+ 
+@@ -146,6 +154,7 @@ MCTargetOptions llvm::mc::InitMCTargetOptionsFromFlags() {
+   Options.EmitDwarfUnwind = getEmitDwarfUnwind();
+   Options.EmitCompactUnwindNonCanonical = getEmitCompactUnwindNonCanonical();
+   Options.AsSecureLogFile = getAsSecureLogFile();
++  Options.MipsPC64Relocation = getMipsPC64Relocation();
+ 
+   return Options;
+ }
+diff --git a/llvm/test/CodeGen/Mips/ehframe-indirect.ll b/llvm/test/CodeGen/Mips/ehframe-indirect.ll
+index b3f4b4832..cd3a33286 100644
+--- a/llvm/test/CodeGen/Mips/ehframe-indirect.ll
++++ b/llvm/test/CodeGen/Mips/ehframe-indirect.ll
+@@ -1,30 +1,40 @@
+ ; RUN: llc -mtriple=mipsel-linux-gnu < %s -asm-verbose -relocation-model=pic | \
+ ; RUN:     FileCheck -check-prefixes=ALL,LINUX,LINUX-O32,O32 %s
++; RUN: llc -mtriple=mipsel-linux-android < %s -asm-verbose -relocation-model=pic | \
++; RUN:     FileCheck -check-prefixes=ALL,LINUX,LINUX-O32,O32 %s
+ ; RUN: llc -mtriple=mips64el-linux-gnu -target-abi=n32 < %s -asm-verbose -relocation-model=pic | \
+-; RUN:     FileCheck -check-prefixes=ALL,LINUX,LINUX-NEW,N32 %s
++; RUN:     FileCheck -check-prefixes=ALL,N32,N32REL %s
+ ; RUN: llc -mtriple=mips64el-linux-gnu < %s -asm-verbose -relocation-model=pic | \
+-; RUN:     FileCheck -check-prefixes=ALL,LINUX,LINUX-NEW,N64 %s
++; RUN:     FileCheck -check-prefixes=ALL,LINUX,LINUX-NEW,N64,N64REL %s
++; RUN: llc -mtriple=mips64el-linux-android < %s -asm-verbose -relocation-model=pic | \
++; RUN:     FileCheck -check-prefixes=ALL,LINUX,LINUX-NEW,N64,N64REL %s
+ ; RUN: llc -mtriple=mips64el-linux-gnu < %s -asm-verbose -relocation-model=pic | \
+-; RUN:     FileCheck -check-prefixes=ALL,LINUX,LINUX-NEW,N64 %s
+-; RUN: llc -mtriple=mips-unknown-freebsd11.0 < %s -asm-verbose -relocation-model=pic | \
+-; RUN:     FileCheck -check-prefixes=ALL,FREEBSD,FREEBSD-O32,O32 %s
++; RUN:     FileCheck -check-prefixes=ALL,N64,N64REL %s
+ ; RUN: llc -mtriple=mips64-unknown-freebsd11.0 < %s -asm-verbose -relocation-model=pic | \
+-; RUN:     FileCheck -check-prefixes=ALL,FREEBSD,FREEBSD-NEW,N64 %s
++; RUN:     FileCheck -check-prefixes=ALL,N64,N64REL %s
++
++; RUN: llc -mtriple=mips64-linux-gnu -target-abi=n32 -mips-pc64-rel=false \
++; RUN:     -asm-verbose -relocation-model=pic < %s | \
++; RUN:     FileCheck -check-prefixes=ALL,N32,N32ABS %s
++; RUN: llc -mtriple=mips64-linux-gnu -mips-pc64-rel=false \
++; RUN:     -asm-verbose -relocation-model=pic < %s | \
++; RUN:     FileCheck -check-prefixes=ALL,N64,N64ABS %s
+ 
+ @_ZTISt9exception = external constant ptr
+ 
+ define i32 @main() personality ptr @__gxx_personality_v0 {
+ ; ALL: .cfi_startproc
+ 
+-; Linux must rely on the assembler/linker converting the encodings.
+-; LINUX: .cfi_personality 128, DW.ref.__gxx_personality_v0
+-; LINUX-O32: .cfi_lsda 0, $exception0
+-; LINUX-NEW: .cfi_lsda 0, .Lexception0
+-
+-; FreeBSD can (and must) be more direct about the encodings it wants.
+-; FREEBSD: .cfi_personality 155, DW.ref.__gxx_personality_v0
+-; FREEBSD-O32: .cfi_lsda 27, $exception0
+-; FREEBSD-NEW: .cfi_lsda 27, .Lexception0
++; O32: .cfi_personality 155, DW.ref.__gxx_personality_v0
++; O32: .cfi_lsda 27, $exception0
++; N32REL: .cfi_personality 155, DW.ref.__gxx_personality_v0
++; N32REL: .cfi_lsda 27, .Lexception0
++; N32ABS: .cfi_personality 128, DW.ref.__gxx_personality_v0
++; N32ABS: .cfi_lsda 0, .Lexception0
++; N64REL: .cfi_personality 155, DW.ref.__gxx_personality_v0
++; N64REL: .cfi_lsda 27, .Lexception0
++; N64ABS: .cfi_personality 128, DW.ref.__gxx_personality_v0
++; N64ABS: .cfi_lsda 0, .Lexception0
+ 
+ entry:
+   invoke void @foo() to label %cont unwind label %lpad
+diff --git a/llvm/test/DebugInfo/Mips/eh_frame.ll b/llvm/test/DebugInfo/Mips/eh_frame.ll
+index 506e5b878..77cde98e5 100644
+--- a/llvm/test/DebugInfo/Mips/eh_frame.ll
++++ b/llvm/test/DebugInfo/Mips/eh_frame.ll
+@@ -17,9 +17,9 @@
+ ; STATIC-DAG: R_MIPS_32 00000000 .gcc_except_table
+ 
+ ; PIC-LABEL: Relocation section '.rel.eh_frame'
+-; PIC-DAG: R_MIPS_32   00000000 DW.ref.__gxx_personality_v0
++; PIC-DAG: R_MIPS_PC32 00000000 DW.ref.__gxx_personality_v0
++; PIC-DAG: R_MIPS_PC32
+ ; PIC-DAG: R_MIPS_PC32
+-; PIC-DAG: R_MIPS_32   00000000 .gcc_except_table
+ 
+ ; CHECK-READELF: DW.ref.__gxx_personality_v0
+ ; CHECK-READELF-STATIC-NEXT: R_MIPS_32 00000000 .text
+diff --git a/llvm/test/MC/Mips/eh-frame.s b/llvm/test/MC/Mips/eh-frame.s
+index fd145317b..1b88f7740 100644
+--- a/llvm/test/MC/Mips/eh-frame.s
++++ b/llvm/test/MC/Mips/eh-frame.s
+@@ -33,14 +33,18 @@
+ // RUN: llvm-readobj -r %t.o | FileCheck --check-prefixes=RELOCS,PIC64 %s
+ // RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefixes=DWARF64,DWARF64_PIC %s
+ 
+-/// However using the large code model forces R_MIPS_64 since there is no R_MIPS_PC64 relocation:
+ // RUN: llvm-mc -filetype=obj %s -o %t.o -triple mips64-unknown-linux-gnu --position-independent --large-code-model
+-// RUN: llvm-readobj -r %t.o | FileCheck --check-prefixes=RELOCS,ABS64 %s
+-// RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefixes=DWARF64,DWARF64_ABS %s
++// RUN: llvm-readobj -r %t.o | FileCheck --check-prefixes=RELOCS,PIC64 %s
++// RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefixes=DWARF64,DWARF64_PIC %s
+ 
+ // RUN: llvm-mc -filetype=obj %s -o %t.o -triple mips64el-unknown-linux-gnu --position-independent  --large-code-model
+-// RUN: llvm-readobj -r %t.o | FileCheck --check-prefixes=RELOCS,ABS64 %s
+-// RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefixes=DWARF64,DWARF64_ABS %s
++// RUN: llvm-readobj -r %t.o | FileCheck --check-prefixes=RELOCS,PIC64 %s
++// RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefixes=DWARF64,DWARF64_PIC %s
++
++// RUN: llvm-mc -filetype=obj %s -o %t.o -triple mips64-unknown-linux-gnu \
++// RUN:         --position-independent --large-code-model -mips-pc64-rel=false
++// RUN: llvm-readobj -r %t.o | FileCheck --check-prefixes=RELOCS,OLD64 %s
++// RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefixes=DWARF64,DWARF64_OLD %s
+ 
+ func:
+ 	.cfi_startproc
+@@ -51,7 +55,8 @@ func:
+ // ABS32-NEXT:      R_MIPS_32
+ // ABS64-NEXT:      R_MIPS_64/R_MIPS_NONE/R_MIPS_NONE
+ // PIC32-NEXT:      R_MIPS_PC32
+-// PIC64-NEXT:      R_MIPS_PC32/R_MIPS_NONE/R_MIPS_NONE
++// PIC64-NEXT:      R_MIPS_PC32/R_MIPS_64/R_MIPS_NONE
++// OLD64-NEXT:      R_MIPS_64/R_MIPS_NONE/R_MIPS_NONE
+ // RELOCS-NEXT:   }
+ 
+ // DWARF32: 00000000 00000010 00000000 CIE
+@@ -87,14 +92,17 @@ func:
+ // DWARF64-NEXT:     Return address column: 31
+ // DWARF64_ABS-NEXT: Augmentation data: 0C
+ //                                      ^^ fde pointer encoding: DW_EH_PE_sdata8
+-// DWARF64_PIC:      Augmentation data: 1B
+-//                                      ^^ fde pointer encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata4
++// DWARF64_PIC:      Augmentation data: 1C
++//                                      ^^ fde pointer encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata8
++// DWARF64_OLD:      Augmentation data: 0C
++//                                      ^^ fde pointer encoding: DW_EH_PE_sdata8
+ // DWARF64-EMPTY:
+ // DWARF64-NEXT:     DW_CFA_def_cfa_register: SP_64
+ // DWARF64_PIC-NEXT: DW_CFA_nop:
+ //
+ // DWARF64_ABS:      00000014 00000018 00000018 FDE cie=00000000 pc=00000000...00000000
+-// DWARF64_PIC:      00000014 00000010 00000018 FDE cie=00000000 pc=00000000...00000000
++// DWARF64_PIC:      00000014 00000018 00000018 FDE cie=00000000 pc=0000001c...0000001c
++// DWARF64_OLD:      00000014 00000018 00000018 FDE cie=00000000 pc=00000000...00000000
+ // DWARF64-NEXT:     Format:       DWARF32
+ // DWARF64-NEXT:     DW_CFA_nop:
+ // DWARF64-NEXT:     DW_CFA_nop:
+-- 
+2.43.0
+

--- a/app-devel/llvm/01-runtime/patches/0006-debian-compiler-rt-mips-tail-call.patch
+++ b/app-devel/llvm/01-runtime/patches/0006-debian-compiler-rt-mips-tail-call.patch
@@ -1,0 +1,57 @@
+see https://reviews.llvm.org/D158491, still unreviewed upstream
+
+Index: llvm-toolchain-snapshot_18~++20231206102350+b304873134e8/compiler-rt/lib/interception/interception.h
+===================================================================
+--- llvm-toolchain-snapshot_18~++20231206102350+b304873134e8.orig/compiler-rt/lib/interception/interception.h
++++ llvm-toolchain-snapshot_18~++20231206102350+b304873134e8/compiler-rt/lib/interception/interception.h
+@@ -205,8 +205,9 @@ const interpose_substitution substitutio
+          ASM_TYPE_FUNCTION_STR "\n"                                            \
+        SANITIZER_STRINGIFY(TRAMPOLINE(func)) ":\n"                             \
+        SANITIZER_STRINGIFY(CFI_STARTPROC) "\n"                                 \
+-       SANITIZER_STRINGIFY(ASM_TAIL_CALL) " __interceptor_"                    \
+-         SANITIZER_STRINGIFY(ASM_PREEMPTIBLE_SYM(func)) "\n"                   \
++       C_ASM_TAIL_CALL(SANITIZER_STRINGIFY(TRAMPOLINE(func)),                  \
++                       "__interceptor_"                                        \
++                         SANITIZER_STRINGIFY(ASM_PREEMPTIBLE_SYM(func))) "\n"  \
+        SANITIZER_STRINGIFY(CFI_ENDPROC) "\n"                                   \
+        ".size  " SANITIZER_STRINGIFY(TRAMPOLINE(func)) ", "                    \
+             ".-" SANITIZER_STRINGIFY(TRAMPOLINE(func)) "\n"                    \
+Index: llvm-toolchain-snapshot_18~++20231206102350+b304873134e8/compiler-rt/lib/sanitizer_common/sanitizer_asm.h
+===================================================================
+--- llvm-toolchain-snapshot_18~++20231206102350+b304873134e8.orig/compiler-rt/lib/sanitizer_common/sanitizer_asm.h
++++ llvm-toolchain-snapshot_18~++20231206102350+b304873134e8/compiler-rt/lib/sanitizer_common/sanitizer_asm.h
+@@ -44,6 +44,8 @@
+ 
+ #if defined(__x86_64__) || defined(__i386__) || defined(__sparc__)
+ # define ASM_TAIL_CALL jmp
++#elif defined(__mips__) && __mips_isa_rev >= 6
++# define ASM_TAIL_CALL bc
+ #elif defined(__arm__) || defined(__aarch64__) || defined(__mips__) || \
+     defined(__powerpc__) || defined(__loongarch_lp64)
+ # define ASM_TAIL_CALL b
+@@ -53,6 +55,25 @@
+ # define ASM_TAIL_CALL tail
+ #endif
+ 
++#if defined(__mips64) && __mips_isa_rev < 6
++# define C_ASM_TAIL_CALL(tfunc, ifunc)                        \
++    "lui $t8, %hi(%neg(%gp_rel(" tfunc ")))\n"                \
++    "daddu $t8, $t8, $t9\n"                                   \
++    "daddu $t8, $t8, %lo(%neg(%gp_rel(" tfunc ")))\n"         \
++    "ld $t9, %got_disp(" ifunc ")($t8)\n"                     \
++    "jr $t9\n"
++#elif defined(__mips__) && __mips_isa_rev < 6
++# define C_ASM_TAIL_CALL(tfunc, ifunc)                        \
++    ".set    noreorder\n"                                     \
++    ".cpload $t9\n"                                           \
++    ".set    reorder\n"                                       \
++    "lw $t9, %got(" ifunc ")($gp)\n"                          \
++    "jr $t9\n"
++#elif defined(ASM_TAIL_CALL)
++#  define C_ASM_TAIL_CALL(tfunc, ifunc) \
++    SANITIZER_STRINGIFY(ASM_TAIL_CALL) " " ifunc
++#endif
++
+ #if defined(__ELF__) && defined(__x86_64__) || defined(__i386__) || \
+     defined(__riscv)
+ # define ASM_PREEMPTIBLE_SYM(sym) sym@plt

--- a/app-devel/llvm/02-compiler/build
+++ b/app-devel/llvm/02-compiler/build
@@ -71,7 +71,7 @@ abinfo "Moving conflicting LLVM replacements for GCC-compatible files ..."
 mkdir -pv "$PKGDIR"/usr/lib/llvm/
 if ! ab_match_arch loongarch64 && \
    ! ab_match_arch loongson3 && \
-   ! ab_match_march mips64r6el; then
+   ! ab_match_arch mips64r6el; then
     mv -v \
         "$PKGDIR"/usr/include/libunwind.* \
         "$PKGDIR"/usr/include/unwind* \

--- a/app-devel/llvm/spec
+++ b/app-devel/llvm/spec
@@ -1,4 +1,5 @@
 VER=17.0.6
+REL=1
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::58a8818c60e6627064f312dbf46c02d9949956558340938b71cf731ad8bc0813"


### PR DESCRIPTION
Topic Description
-----------------

- llvm: fix mips tail call in compiler-rt

- llvm: add a patch to support PCREL64 linkage in MIPS

Package(s) Affected
-------------------

- llvm: 17.0.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
