### PR TITLE
fish: update to 3.7.0

### DIFF
--- a/app-shells/fish/spec
+++ b/app-shells/fish/spec
@@ -1,4 +1,4 @@
-VER=3.6.4
-SRCS="tbl::https://github.com/fish-shell/fish-shell/archive/$VER.tar.gz"
-CHKSUMS="sha256::ae51eb8cbe17479fc2e5bdc2ede93f41d4ce0d137626eacbb5cc7446ddafa9e3"
+VER=3.7.0
+SRCS="git::commit=tags/$VER::https://github.com/fish-shell/fish-shell"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=815"


### PR DESCRIPTION
Topic Description
-----------------

- fish: update to 3.7.0

Package(s) Affected
-------------------

- fish: 3.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit fish
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
