### PR TITLE
archlinux-keyring: update to 20231222

### DIFF
--- a/app-admin/archlinux-keyring/autobuild/build
+++ b/app-admin/archlinux-keyring/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building ..."
+make SYSTEMD_SYSTEM_UNIT_DIR=/usr/lib/systemd/system PREFIX=/usr
+
+abinfo "Installing ..."
+make DESTDIR="${PKGDIR}" SYSTEMD_SYSTEM_UNIT_DIR=/usr/lib/systemd/system PREFIX=/usr install

--- a/app-admin/archlinux-keyring/autobuild/defines
+++ b/app-admin/archlinux-keyring/autobuild/defines
@@ -5,5 +5,4 @@ BUILDDEP="sequoia-sq"
 PKGDES="Arch Linux PGP keyring"
 
 ABHOST=noarch
-ABTYPE="plainmake"
-ABMK="build"
+ABTYPE=self

--- a/app-admin/archlinux-keyring/spec
+++ b/app-admin/archlinux-keyring/spec
@@ -1,4 +1,4 @@
-VER=20220727
+VER=20231222
 SRCS="git::commit=tags/$VER::https://gitlab.archlinux.org/archlinux/archlinux-keyring"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=103"


### PR DESCRIPTION
Topic Description
-----------------

- archlinux-keyring: update to 20231222
    Converted to build script because plainmake is going to be deprecated.
    
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
    

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Second Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
