### PR TITLE
elfutils: disable thread-safety to workaround poor multi-threaded Pahole performance

### DIFF
--- a/app-utils/elfutils/autobuild/defines
+++ b/app-utils/elfutils/autobuild/defines
@@ -3,17 +3,24 @@ PKGSEC=utils
 PKGDEP="bzip2 curl libarchive libmicrohttpd xz zlib zstd"
 PKGDES="Libraries and utilities to handle ELF object files and DWARF debugging information"
 
-# Note: --with-biarch, enable biarch tests despite build problems.
+# Note:  --disable-thread-safety, this option causes poor and inconsistent
+#        performance when running Pahole across multiple cores. This feature
+#        is also marked as EXPERIMENTAL.
 #
-# Note: --disable-install-elfh, elf.h is provided by Glibc.
+#        Ref: https://sourceware.org/git/?p=elfutils.git;a=blob;f=configure.ac;h=af5b6bf77dd2bd17fb4bb0695e83e55c6ffbbef9;hb=HEAD#l80
+#
+# Note:  --with-biarch, enable biarch tests despite build problems.
+#
+# Note:  --disable-install-elfh, elf.h is provided by Glibc.
 #
 # FIXME: --disable-debugpred, enabling this option results in linkage failure
-# as follows...
+#        as follows...
+#
 #     relocation R_X86_64_32 against `predict_data' can not be used when making
 #     a PIE object
 AUTOTOOLS_AFTER="--program-prefix=eu- \
                  --enable-deterministic-archives \
-                 --enable-thread-safety \
+                 --disable-thread-safety \
                  --enable-largefile \
                  --disable-debugpred \
                  --disable-gprof \

--- a/app-utils/elfutils/spec
+++ b/app-utils/elfutils/spec
@@ -1,4 +1,5 @@
 VER=0.188
+REL=1
 SRCS="tbl::https://sourceware.org/elfutils/ftp/$VER/elfutils-$VER.tar.bz2"
 # checksum: https://sourceware.org/elfutils/ftp/$VER/sha512.sum
 CHKSUMS="sha256::fb8b0e8d0802005b9a309c60c1d8de32dd2951b56f0c3a3cb56d21ce01595dff"


### PR DESCRIPTION
Topic Description
-----------------

elfutils: disable thread-safety

Note: --disable-thread-safety, this option causes poor and inconsistent performance when running Pahole across multiple cores. This feature is also marked as EXPERIMENTAL.
    
Ref: https://sourceware.org/git/?p=elfutils.git;a=blob;f=configure.ac;=af5b6bf77dd2bd17fb4bb0695e83e55c6ffbbef9;hb=HEAD#l80

Package(s) Affected
-------------------

- elfutils: 0.188-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit elfutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
