### PR TITLE
glib (GLib): update to 2.78.3

### DIFF
--- a/runtime-common/glib/spec
+++ b/runtime-common/glib/spec
@@ -1,4 +1,4 @@
-VER=2.78.0
+VER=2.78.3
 SRCS="https://download.gnome.org/sources/glib/${VER:0:4}/glib-$VER.tar.xz"
-CHKSUMS="sha256::44eaab8b720877ce303c5540b657b126f12dc94972d9880b52959f43fb537b30"
+CHKSUMS="sha256::609801dd373796e515972bf95fc0b2daa44545481ee2f465c4f204d224b2bc21"
 CHKUPDATE="anitya::id=10024"


### PR DESCRIPTION
Topic Description
-----------------

- glib: update to 2.78.3
    This should address the weird crash whilst starting up LiveKit's MATE session.
    

Package(s) Affected
-------------------

- glib: 2.78.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit glib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
