### PR TITLE
yt-dlp: update to 2023.12.30

### DIFF
--- a/app-multimedia/yt-dlp/spec
+++ b/app-multimedia/yt-dlp/spec
@@ -1,4 +1,4 @@
-VER=2023.11.16
+VER=2023.12.30
 SRCS="git::commit=tags/$VER::https://github.com/yt-dlp/yt-dlp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=143399"


### PR DESCRIPTION
Topic Description
-----------------

- yt-dlp: update to 2023.12.30

Package(s) Affected
-------------------

- yt-dlp: 2023.12.30

Security Update?
----------------

No

Build Order
-----------

```
#buildit yt-dlp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
