### PR TITLE
mesa (Mesa 3D Graphics Library): update to 23.3.2

### DIFF
--- a/runtime-display/mesa/autobuild/patches/0004-Revert-d3d12-Only-destroy-the-winsys-during-screen-d.patch
+++ b/runtime-display/mesa/autobuild/patches/0004-Revert-d3d12-Only-destroy-the-winsys-during-screen-d.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <jan.steffens@gmail.com>
+Date: Mon, 1 Jan 2024 17:19:30 +0100
+Subject: [PATCH] Revert "d3d12: Only destroy the winsys during screen
+ destruction, not reset"
+
+This reverts commit 684d11421c30c0f8230ccbcc8dcc94a457eb5f44.
+
+For: https://gitlab.archlinux.org/archlinux/packaging/packages/mesa/-/issues/5
+---
+ .pick_status.json                          | 2 +-
+ src/gallium/drivers/d3d12/d3d12_screen.cpp | 8 ++++----
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/.pick_status.json b/.pick_status.json
+index 0c787e915471..f6b0909e7d92 100644
+--- a/.pick_status.json
++++ b/.pick_status.json
+@@ -2014,7 +2014,7 @@
+         "description": "d3d12: Only destroy the winsys during screen destruction, not reset",
+         "nominated": true,
+         "nomination_type": 1,
+-        "resolution": 1,
++        "resolution": 0,
+         "main_sha": null,
+         "because_sha": "81c8e89ff8e846839fffc1d103b2080bef5c1b5c",
+         "notes": null
+diff --git a/src/gallium/drivers/d3d12/d3d12_screen.cpp b/src/gallium/drivers/d3d12/d3d12_screen.cpp
+index 9b0233fb9d92..ee74cf2b064f 100644
+--- a/src/gallium/drivers/d3d12/d3d12_screen.cpp
++++ b/src/gallium/drivers/d3d12/d3d12_screen.cpp
+@@ -735,15 +735,15 @@ d3d12_deinit_screen(struct d3d12_screen *screen)
+       screen->dev->Release();
+       screen->dev = nullptr;
+    }
++   if (screen->winsys) {
++      screen->winsys->destroy(screen->winsys);
++      screen->winsys = nullptr;
++   }
+ }
+ 
+ void
+ d3d12_destroy_screen(struct d3d12_screen *screen)
+ {
+-   if (screen->winsys) {
+-      screen->winsys->destroy(screen->winsys);
+-      screen->winsys = nullptr;
+-   }
+    slab_destroy_parent(&screen->transfer_pool);
+    mtx_destroy(&screen->submit_mutex);
+    mtx_destroy(&screen->descriptor_pool_mutex);

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,7 +1,7 @@
-VER=23.3.0
+VER=23.3.2
 SRCS="tbl::https://archive.mesa3d.org/mesa-$VER.tar.xz \
       git::commit=tags/v1.610.0;rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
-CHKSUMS="sha256::50f729dd60ed6335b989095baad81ef5edf7cfdd4b4b48b9b955917cb07d69c5 \
+CHKSUMS="sha256::3cfcb81fa16f89c56abe3855d2637d396ee4e03849b659000a6b8e5f57e69adc \
          SKIP"
 SUBDIR="mesa-$VER"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 23.3.2
    - Revert an upstream change that may cause Xorg crashes. [^1]

[^1]: Revert-d3d12-Only-destroy-the-winsys-during-screen-d.patch

Package(s) Affected
-------------------

- mesa: 1:23.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Second Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
