### PR TITLE
xa: update to 2.4.0

### DIFF
--- a/app-devel/xa/autobuild/defines
+++ b/app-devel/xa/autobuild/defines
@@ -4,3 +4,8 @@ PKGDEP="glibc"
 PKGDES="Cross-assembler for 6502 microprocessor"
 
 MAKE_AFTER="BINDIR=$PKGDIR/usr/bin MANDIR=$PKGDIR/usr/share/man"
+# FIXME: Causes errors during installation:
+# 
+# install: cannot stat 'xa': No such file or directory
+# make: *** [Makefile:65: install] Error 1
+NOPARALLEL=1

--- a/app-devel/xa/spec
+++ b/app-devel/xa/spec
@@ -1,5 +1,4 @@
-VER=2.3.11
-REL=1
+VER=2.4.0
 SRCS="tbl::http://www.floodgap.com/retrotech/xa/dists/xa-$VER.tar.gz"
-CHKSUMS="sha256::32f2164c99e305218e992970856dd8e2309b5cb6ac4758d7b2afe3bfebc9012d"
+CHKSUMS="sha256::9e587a0ca8ff791009880bfa331f6ed36935e08ef9c123822ca175285f8c030c"
 CHKUPDATE="anitya::id=14146"


### PR DESCRIPTION
Topic Description
-----------------

- xa: disable parallel building

- xa: update to 2.4.0

Package(s) Affected
-------------------

- xa: 2.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
