### PR TITLE
extra-cmake-modules update to 5.247.0

### DIFF
--- a/app-devel/extra-cmake-modules/spec
+++ b/app-devel/extra-cmake-modules/spec
@@ -1,4 +1,4 @@
-VER=5.103.0
-SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/extra-cmake-modules-$VER.tar.xz"
-CHKSUMS="sha256::92ca2e55cb38956fbdeaf254231f074647173ccfd12dc9664989c6fa9e9c4346"
+VER=5.247.0
+SRCS="tbl::https://invent.kde.org/frameworks/extra-cmake-modules/-/archive/v$VER/extra-cmake-modules-v$VER.tar.gz"
+CHKSUMS="sha256::01ac4360eaae42b39c38086989b0031d90ef8b4c4dec353ba7922791a745a917"
 CHKUPDATE="anitya::id=8762"


### PR DESCRIPTION
Topic Description
-----------------

- extra-cmake-modules: update to 5.247.0

Package(s) Affected
-------------------

- extra-cmake-modules: 5.247.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit extra-cmake-modules
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
