### PR TITLE
pushpkg: update to 0+git20240103

### DIFF
--- a/app-devel/pushpkg/spec
+++ b/app-devel/pushpkg/spec
@@ -1,12 +1,11 @@
-VER=0+git20231129
-REL=1
-__COMMIT="eebcd6b4bfa361151ee130406c1682913a719106"
+VER=0+git20240103
+__COMMIT="52608c24b3f616b91289acd6ce8c3dc0089cb0aa"
 SRCS="file::rename=pushpkg::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/pushpkg \
       file::rename=pushpkg.bash::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/completions/pushpkg.bash \
       file::rename=pushpkg.fish::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/completions/pushpkg.fish \
       file::rename=COPYING::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/COPYING \
       file::rename=README.md::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/README.md"
-CHKSUMS="sha256::3f1a31a97db327ceab74de6b6cc69f34e4fba9eeb1f5e594aa9b4d129c77ee41 \
+CHKSUMS="sha256::a02caa4023d0fa11625907736f471fdb2d470baf4b2ee554af62eb4c36d5f07e \
          sha256::d30be57c8a8b08a2a4d780cd02398e15f13155f18b986414b501becf17cf0961 \
          sha256::6c3e1759290a8aab997d40bd4937b6d8a5936c24faafc399a2b3eb9a4ea83366 \
          sha256::992c720940396663b52389eea4c6a7409dd26b55ab3bfcd3a17f5da8b6d2a3c9 \


### PR DESCRIPTION
Topic Description
-----------------

- pushpkg: update to 0+git20240103

Package(s) Affected
-------------------

- pushpkg: 1:0+git20240103

Security Update?
----------------

No

Build Order
-----------

```
#buildit pushpkg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
