### PR TITLE
pigz: update to 2.8

### DIFF
--- a/app-utils/pigz/spec
+++ b/app-utils/pigz/spec
@@ -1,4 +1,4 @@
-VER=2.6
-SRCS="tbl::https://github.com/madler/pigz/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::577673676cd5c7219f94b236075451220bae3e1ca451cf849947a2998fbf5820"
+VER=2.8
+SRCS="git::commit=tags/v$VER::https://github.com/madler/pigz"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3642"


### PR DESCRIPTION
Topic Description
-----------------

- pigz: update to 2.8

Package(s) Affected
-------------------

- pigz: 2.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit pigz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
