### PR TITLE
sdcc: update to 4.3.6

### DIFF
--- a/app-devel/sdcc/autobuild/patches/0001-device-lib-fix-improper-usage-of-VERBOSE.patch
+++ b/app-devel/sdcc/autobuild/patches/0001-device-lib-fix-improper-usage-of-VERBOSE.patch
@@ -1,0 +1,43 @@
+From 4065a4387ccc621b6276e295910e7fb24aaf57a1 Mon Sep 17 00:00:00 2001
+From: Cyan <cyanoxygen@aosc.io>
+Date: Wed, 3 Jan 2024 15:26:47 +0800
+Subject: [PATCH 1/2] device/lib: fix improper usage of $(VERBOSE)
+
+ AOSC tries to pass VERBOSE=1 to the build system to enable verbose
+ mode. However there are two places which is using the same variable to
+ pass VERBOSE to the compiler. Since in those Makefiles the actual
+ variable is commented out, we just remove them from the CFLAGS.
+---
+ device/lib/ds390/Makefile.in | 2 +-
+ device/lib/ds400/Makefile.in | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/device/lib/ds390/Makefile.in b/device/lib/ds390/Makefile.in
+index 9f1796e02..ae4f45884 100644
+--- a/device/lib/ds390/Makefile.in
++++ b/device/lib/ds390/Makefile.in
+@@ -21,7 +21,7 @@ OBJECTS = tinibios.rel memcpyx.rel i2c390.rel rtc390.rel putchar.rel gptr_cmp.re
+ SOURCES = $(patsubst %.rel,%.c,$(OBJECTS))
+ 
+ CPPFLAGS = -I$(srcdir)/../../include
+-CFLAGS = -mds390 $(CPPFLAGS) $(VERBOSE) --std-c23
++CFLAGS = -mds390 $(CPPFLAGS) --std-c23
+ 
+ all: $(OBJECTS) $(PORTDIR)/libds390.lib
+ 
+diff --git a/device/lib/ds400/Makefile.in b/device/lib/ds400/Makefile.in
+index 3cad38f4b..fd901f99f 100644
+--- a/device/lib/ds400/Makefile.in
++++ b/device/lib/ds400/Makefile.in
+@@ -20,7 +20,7 @@ OBJECTS = tinibios.rel memcpyx.rel ds400rom.rel
+ SOURCES = $(patsubst %.rel,%.c,$(OBJECTS))
+ 
+ CPPFLAGS = -I$(srcdir)/../../include -I$(srcdir)/../../include/ds400
+-CFLAGS = -mds400 $(CPPFLAGS) $(VERBOSE) --std-c23
++CFLAGS = -mds400 $(CPPFLAGS) --std-c23
+ 
+ all: $(OBJECTS) $(PORTDIR)/libds400.lib
+ 
+-- 
+2.39.1
+

--- a/app-devel/sdcc/autobuild/patches/0002-device-lib-fix-usage-of-std-c23-flag-fix-CC.patch
+++ b/app-devel/sdcc/autobuild/patches/0002-device-lib-fix-usage-of-std-c23-flag-fix-CC.patch
@@ -1,0 +1,26 @@
+From a889fee21f1c7e7f6a727167ec1b9cad0bc094f6 Mon Sep 17 00:00:00 2001
+From: Cyan <cyanoxygen@aosc.io>
+Date: Wed, 3 Jan 2024 15:54:10 +0800
+Subject: [PATCH 2/2] device/lib: fix usage of --std=c23 flag; fix CC
+
+There should be two dashes instead of one.
+---
+ device/lib/Makefile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/device/lib/Makefile.in b/device/lib/Makefile.in
+index 8abcb7f2a..8a6d52e19 100644
+--- a/device/lib/Makefile.in
++++ b/device/lib/Makefile.in
+@@ -725,7 +725,7 @@ dep: Makefile.dep
+ Makefile.dep: $(SOURCES) $(INCDIR)/*.h $(PORTINCDIR)/*.h
+ 	rm -f Makefile.dep
+ 	for i in $(filter %.c,$^); do \
+-	  $(CPP) -std=c23 -M $(CPPFLAGS) $$i >$${i}.dep; \
++	  $(CC) --std=c23 -M $(CPPFLAGS) $$i >$${i}.dep; \
+ 	  cat $${i}.dep >>Makefile.dep; \
+ 	  rm $${i}.dep; \
+ 	done
+-- 
+2.39.1
+

--- a/app-devel/sdcc/spec
+++ b/app-devel/sdcc/spec
@@ -1,5 +1,12 @@
-VER=4.0.0
-REL=1
-SRCS="https://sourceforge.net/projects/sdcc/files/sdcc/$VER/sdcc-src-$VER.tar.bz2"
-CHKSUMS="sha256::489180806fc20a3911ba4cf5ccaf1875b68910d7aed3f401bbd0695b0bef4e10"
+VER=4.3.6
+# FIXME: upstream tags patch versions without publishing the corresponding
+# tarball. Using SVN source directly instead.
+# Here's the original SRCS.
+# SRCS="https://sourceforge.net/projects/sdcc/files/sdcc/$VER/sdcc-src-$VER.tar.bz2"
+# FIXME: Maintainer beware - checking out a tag MUST have its corresponding revision
+# specified using `commit=N', without the `r' prefix. Without the commit specified,
+# ACBS will refuse to checkout.
+SRCS="svn::commit=14418::svn://svn.code.sf.net/p/sdcc/code/tags/sdcc-4.3.6"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227271"
+SUBDIR="sdcc/sdcc"


### PR DESCRIPTION
Topic Description
-----------------

- sdcc: add patches to fix errors in the build system

- sdcc: update to 4.3.6; Use SVN source
    - Upstream tagged this version without publishing a tarball, which is
    kind of strange.

Package(s) Affected
-------------------

- sdcc: 4.3.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit sdcc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
