### PR TITLE
aoscdk-rs: update to 1.0.0

### DIFF
--- a/app-admin/aoscdk-rs/autobuild/defines
+++ b/app-admin/aoscdk-rs/autobuild/defines
@@ -11,6 +11,8 @@ USECLANG__LOONGSON3=0
 NOLTO__LOONGSON3=1
 USECLANG__LOONGARCH64=0
 NOLTO__LOONGARCH64=1
+USECLANG__MIPS64R6EL=0
+NOLTO__MIPS64R6EL=1
 
 # FIXME: ld.lld: error: lto.tmp: cannot link object files with different
 # floating-point ABI

--- a/app-admin/aoscdk-rs/spec
+++ b/app-admin/aoscdk-rs/spec
@@ -1,4 +1,4 @@
-VER=0.11.2
-SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscdk-rs/"
+VER=1.0.0
+SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/aoscdk-rs/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226678"


### PR DESCRIPTION
Topic Description
-----------------

- aoscdk-rs: update to 1.0.0

Package(s) Affected
-------------------

- aoscdk-rs: 1.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit aoscdk-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
