### PR TITLE
libdeflate new 1.19

### DIFF
--- a/runtime-common/libdeflate/autobuild/defines
+++ b/runtime-common/libdeflate/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=libdeflate
+PKGDES="headers for whole-buffer compression and decompression library"
+PKGSEC=libs
+PKGDEP=glibc

--- a/runtime-common/libdeflate/spec
+++ b/runtime-common/libdeflate/spec
@@ -1,0 +1,4 @@
+VER=1.19
+SRCS="tbl::https://github.com/ebiggers/libdeflate/releases/download/v$VER/libdeflate-$VER.tar.gz"
+CHKSUMS="sha256::d9bb9bdd8cc5a8c1f7f6226fa0053dd72861e15f366e7ff7d0d191eac16d66f3"
+CHKUPDATE="anitya::id=242778"

--- a/runtime-gis/gdal/autobuild/defines
+++ b/runtime-gis/gdal/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="cfitsio curl geos giflib hdf5 libgeotiff libjpeg-turbo libpng \
         libspatialite libtiff mariadb netcdf numpy openjpeg perl poppler \
         postgresql sqlite mongodb xz libcl podofo geos xerces-c crypto++ \
         qhull jasper unixodbc python-3 proj libheif lz4 zlib zstd libxml2 \
-        freexl expat libwebp json-c libarchive"
+        freexl expat libwebp json-c libarchive libdeflate"
 PKGDEP__LOONGARCH64="${PKGDEP/mongodb/}"
 PKGDEP__LOONGSON3="${PKGDEP/mongodb/}"
 PKGDEP__MIPS64R6EL="${PKGDEP/mongodb/}"
@@ -13,7 +13,8 @@ BUILDDEP="doxygen graphviz opencl-registry-api swig"
 PKGDES="Geospatial Data Abstraction Library"
 
 CMAKE_AFTER=(
-	-DBUILD_TESTING=OFF # not until autobuild3 test framework is ready
+	-Deflate_LIBRARY=/usr/include/libdeflate.h
+	-DBUILD_TESTING=OFF # not until autobuild3 test framework is ready 
 )
 
 PKGBREAK="vtk<=9.1.0-5 opencv<=4.6.0-2"

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -2,4 +2,4 @@ VER=3.7.0
 SRCS="tbl::https://download.osgeo.org/gdal/$VER/gdal-$VER.tar.xz"
 CHKSUMS="sha256::af4b26a6b6b3509ae9ccf1fcc5104f7fe015ef2110f5ba13220816398365adce"
 CHKUPDATE="anitya::id=881"
-REL=2
+REL=3


### PR DESCRIPTION
Topic Description
-----------------

- libdeflate: new, 1.19
- gdal: bump REL
Enable libdeflate support

Package(s) Affected
-------------------

- libdeflate: 1.19

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdeflate gdal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
