### PR TITLE
ripgrep: update to 14.1.0

### DIFF
--- a/app-utils/ripgrep/spec
+++ b/app-utils/ripgrep/spec
@@ -1,4 +1,4 @@
-VER=14.0.3
+VER=14.1.0
 SRCS="git::commit=tags/$VER::https://github.com/BurntSushi/ripgrep"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15461"


### PR DESCRIPTION
Topic Description
-----------------

- ripgrep: update to 14.1.0

Package(s) Affected
-------------------

- ripgrep: 14.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ripgrep
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
