### PR TITLE
nvm (Node.js Version Manager): update to 0.39.7

### DIFF
--- a/lang-js/nvm/autobuild/build
+++ b/lang-js/nvm/autobuild/build
@@ -1,9 +1,14 @@
-abinfo "Installing nvm.sh, bash completion and doc..."
-install -Dvm644 "$SRCDIR"/nvm.sh "$PKGDIR"/usr/share/nvm/nvm.sh
-install -Dvm644 "$SRCDIR"/bash_completion "$PKGDIR"/usr/share/bash-completion/completions/nvm
-install -Dvm644 "$SRCDIR"/*.md -t "$PKGDIR"/usr/share/doc/nvm/
+abinfo "Installing nvm.sh, bash completion, and documentation ..."
+install -Dvm644 "$SRCDIR"/nvm.sh \
+    "$PKGDIR"/usr/share/nvm/nvm.sh
+install -Dvm644 "$SRCDIR"/bash_completion \
+    "$PKGDIR"/usr/share/bash-completion/completions/nvm
+install -Dvm644 "$SRCDIR"/*.md \
+    -t "$PKGDIR"/usr/share/doc/nvm/
 
-abinfo "Creating symlink to nvm.sh in bashrc.d and zshrc.d"
+abinfo "Creating symlink to nvm.sh in bashrc.d and zshrc.d ..."
 mkdir -pv "$PKGDIR"/etc/{bashrc.d,zsh/zshrc.d}
-ln -vs ../../usr/share/nvm/nvm.sh "$PKGDIR"/etc/bashrc.d/30-nvm
-ln -vs ../../../usr/share/nvm/nvm.sh "$PKGDIR"/etc/zsh/zshrc.d/30-nvm
+ln -vs ../../usr/share/nvm/nvm.sh \
+    "$PKGDIR"/etc/bashrc.d/30-nvm
+ln -vs ../../../usr/share/nvm/nvm.sh \
+    "$PKGDIR"/etc/zsh/zshrc.d/30-nvm

--- a/lang-js/nvm/autobuild/defines
+++ b/lang-js/nvm/autobuild/defines
@@ -4,4 +4,3 @@ PKGDES="NodeJS Version Manager"
 PKGDEP="bash wget curl"
 
 ABHOST=noarch
-

--- a/lang-js/nvm/autobuild/patches/0001-nvm.sh-drop-hash-r.patch
+++ b/lang-js/nvm/autobuild/patches/0001-nvm.sh-drop-hash-r.patch
@@ -1,0 +1,32 @@
+From a7185ed2ae440717e29cde5d923b62d621be03f9 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.xyz>
+Date: Sat, 6 Jan 2024 22:53:21 -0800
+Subject: [PATCH] nvm.sh: drop hash -r
+
+---
+ nvm.sh | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/nvm.sh b/nvm.sh
+index 2e4378f..cb4dda5 100644
+--- a/nvm.sh
++++ b/nvm.sh
+@@ -3565,7 +3565,6 @@ nvm() {
+         fi
+       else
+         export PATH="${NEWPATH}"
+-        \hash -r
+         if [ "${NVM_SILENT:-0}" -ne 1 ]; then
+           nvm_echo "${NVM_DIR}/*/bin removed from \${PATH}"
+         fi
+@@ -3697,7 +3696,6 @@ nvm() {
+         export MANPATH
+       fi
+       export PATH
+-      \hash -r
+       export NVM_BIN="${NVM_VERSION_DIR}/bin"
+       export NVM_INC="${NVM_VERSION_DIR}/include/node"
+       if [ "${NVM_SYMLINK_CURRENT-}" = true ]; then
+-- 
+2.39.1
+

--- a/lang-js/nvm/spec
+++ b/lang-js/nvm/spec
@@ -1,5 +1,4 @@
-VER=0.37.0
-REL=2
-SRCS="tbl::https://github.com/creationix/nvm/archive/v$VER.tar.gz"
-CHKSUMS="sha256::c22fb788a64ed48f6f44ebd7ba6c796471a1413eee085adfb7493b553ae05a09"
+VER=0.39.7
+SRCS="git::commit=tags/v$VER::https://github.com/creationix/nvm"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229016"


### PR DESCRIPTION
Topic Description
-----------------

- nvm: update to 0.39.7
    - Drop `hash -r' in as AOSC OS prohibits command hashing by default.
    - Lint build script to make it more readable.

Package(s) Affected
-------------------

- nvm: 0.39.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
