### PR TITLE
pushpkg: update to 0+git20240108

### DIFF
--- a/app-devel/pushpkg/spec
+++ b/app-devel/pushpkg/spec
@@ -1,11 +1,11 @@
-VER=0+git20240103
-__COMMIT="52608c24b3f616b91289acd6ce8c3dc0089cb0aa"
+VER=0+git20240108
+__COMMIT="ba739f2709b8912d0da1559f4b9f0684e02f2119"
 SRCS="file::rename=pushpkg::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/pushpkg \
       file::rename=pushpkg.bash::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/completions/pushpkg.bash \
       file::rename=pushpkg.fish::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/completions/pushpkg.fish \
       file::rename=COPYING::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/COPYING \
       file::rename=README.md::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/README.md"
-CHKSUMS="sha256::a02caa4023d0fa11625907736f471fdb2d470baf4b2ee554af62eb4c36d5f07e \
+CHKSUMS="sha256::87c91d216117b3ce9af9cd79fc09c8a5a378198b9cf5fb7a4f06865b9aa0f128 \
          sha256::d30be57c8a8b08a2a4d780cd02398e15f13155f18b986414b501becf17cf0961 \
          sha256::6c3e1759290a8aab997d40bd4937b6d8a5936c24faafc399a2b3eb9a4ea83366 \
          sha256::992c720940396663b52389eea4c6a7409dd26b55ab3bfcd3a17f5da8b6d2a3c9 \


### PR DESCRIPTION
Topic Description
-----------------

- pushpkg: update to 0+git20240108

Package(s) Affected
-------------------

- pushpkg: 1:0+git20240108

Security Update?
----------------

No

Build Order
-----------

```
#buildit pushpkg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
