### PR TITLE
httpd (Apache HTTPD): update to 2.4.58

### DIFF
--- a/app-web/httpd/autobuild/build
+++ b/app-web/httpd/autobuild/build
@@ -1,0 +1,10 @@
+abinfo "Configuring Apache HTTPD ..."
+"$SRCDIR"/configure \
+    "${AUTOTOOLS_AFTER[@]}"
+
+abinfo "Building Apache HTTPD ..."
+make
+
+abinfo "Installing Apache HTTPD ..."
+make install \
+    DESTDIR="$PKGDIR"

--- a/app-web/httpd/autobuild/defines
+++ b/app-web/httpd/autobuild/defines
@@ -46,3 +46,6 @@ AUTOTOOLS_AFTER=(
     --enable-pie
     --enable-option-checking=fatal
 )
+
+# FIXME: make install is not reliable with parallelism.
+NOPARALLEL=1

--- a/app-web/httpd/autobuild/overrides/usr/lib/sysusers.d/httpd.conf
+++ b/app-web/httpd/autobuild/overrides/usr/lib/sysusers.d/httpd.conf
@@ -1,0 +1,2 @@
+g apache 25
+u apache 25:25 "Apache Server Daemon" /srv/www /bin/false

--- a/app-web/httpd/autobuild/postinst
+++ b/app-web/httpd/autobuild/postinst
@@ -1,2 +1,7 @@
-chown -R 25:25 "$PKGDIR"/srv/www
-chown -R 25:25 "$PKGDIR"/srv/http
+echo "Setting up apache group and user ..."
+systemd-sysusers httpd.conf
+
+echo "Changing permission of /srv/www and /srv/http ..."
+chown -R apache:apache /srv/www
+chown -R apache:apache /srv/http
+

--- a/app-web/httpd/autobuild/prepare
+++ b/app-web/httpd/autobuild/prepare
@@ -27,7 +27,3 @@ chmod -v a-s "$SRCDIR"
 
 abinfo "Appending -lsystemd to LDFLAGS to fix build ..."
 export LDFLAGS="${LDFLAGS} -lsystemd"
-
-# FIXME: Conflicts with layout settings.
-abinfo "Unsetting AUTOTOOLS_DEF to prevent conflicts with layout settings ..."
-unset AUTOTOOLS_DEF

--- a/app-web/httpd/autobuild/usergroup
+++ b/app-web/httpd/autobuild/usergroup
@@ -1,2 +1,0 @@
-group apache 25
-user apache 25 apache /srv/www "Apache Server Daemon" /bin/false

--- a/app-web/httpd/spec
+++ b/app-web/httpd/spec
@@ -1,4 +1,4 @@
-VER=2.4.57
+VER=2.4.58
 SRCS="tbl::http://archive.apache.org/dist/httpd/httpd-$VER.tar.bz2"
-CHKSUMS="sha256::dbccb84aee95e095edfbb81e5eb926ccd24e6ada55dcd83caecb262e5cf94d2a"
+CHKSUMS="sha256::fa16d72a078210a54c47dd5bef2f8b9b8a01d94909a51453956b3ec6442ea4c5"
 CHKUPDATE="anitya::id=1335"


### PR DESCRIPTION
Topic Description
-----------------

- httpd: update to 2.4.58

Package(s) Affected
-------------------

- httpd: 2.4.58

Security Update?
----------------

No

Build Order
-----------

```
#buildit httpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
