### PR TITLE
nodejs (Node.js): update to 20.10.0

### DIFF
--- a/lang-js/nodejs/spec
+++ b/lang-js/nodejs/spec
@@ -1,5 +1,4 @@
-VER=18.17.1
+VER=20.10.0
 SRCS="git::commit=tags/v${VER}::https://github.com/nodejs/node.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12594"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- nodejs: update to 20.10.0

Package(s) Affected
-------------------

- nodejs: 2:20.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
