### PR TITLE
git (Git SCM): update to 2.43.0

### DIFF
--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,5 +1,4 @@
-VER=2.39.1
+VER=2.43.0
 SRCS="https://www.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
-CHKSUMS="sha256::ae8d3427e4ccd677abc931f16183c0ec953e3bfcd866493601351e04a2b97398"
+CHKSUMS="sha256::ed238f5c72a014f238cc49fe7df4c6883732a3881111b381c105e2c5be77302f"
 CHKUPDATE="anitya::id=5350"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- git: update to 2.43.0

Package(s) Affected
-------------------

- git: 2.43.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
