### PR TITLE
strawberry (Strawberry Media Player): update to 1.0.22

### DIFF
--- a/app-multimedia/strawberry/spec
+++ b/app-multimedia/strawberry/spec
@@ -1,4 +1,4 @@
-VER=1.0.14
-SRCS="https://github.com/strawberrymusicplayer/strawberry/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::f513f4c0ae322fa35a15b9cc9a41e0c56f56752651a7bd3a9812c670937cde95"
+VER=1.0.22
+SRCS="git::commit=tags/$VER::https://github.com/strawberrymusicplayer/strawberry"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19048"


### PR DESCRIPTION
Topic Description
-----------------

- strawberry: update to 1.0.22

Package(s) Affected
-------------------

- strawberry: 1.0.22

Security Update?
----------------

No

Build Order
-----------

```
#buildit strawberry
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
