### PR TITLE
util-linux: update to 2.39.3

### DIFF
--- a/app-utils/util-linux/autobuild/defines
+++ b/app-utils/util-linux/autobuild/defines
@@ -64,7 +64,6 @@ AUTOTOOLS_AFTER="--localstatedir=/run \
                  --enable-libuuid-force-uuidd \
                  --enable-libblkid \
                  --enable-libmount \
-                 --enable-libmount-support-mtab \
                  --enable-libsmartcols \
                  --enable-libfdisk \
                  --enable-fdisks \

--- a/app-utils/util-linux/spec
+++ b/app-utils/util-linux/spec
@@ -1,4 +1,4 @@
-VER=2.38.1
+VER=2.39.3
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/util-linux/v${VER:0:4}/util-linux-$VER.tar.xz"
-CHKSUMS="sha256::60492a19b44e6cf9a3ddff68325b333b8b52b6c59ce3ebd6a0ecaa4c5117e84f"
+CHKSUMS="sha256::7b6605e48d1a49f43cc4b4cfc59f313d0dd5402fa40b96810bd572e167dfed0f"
 CHKUPDATE="anitya::id=8179"


### PR DESCRIPTION
Topic Description
-----------------

- util-linux: update to 2.39.3

Package(s) Affected
-------------------

- util-linux: 2.39.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit util-linux
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
