### PR TITLE
bottom: update to 0.9.6

### DIFF
--- a/app-admin/bottom/autobuild/defines
+++ b/app-admin/bottom/autobuild/defines
@@ -4,7 +4,11 @@ PKGDES="A cross-platform graphical process/system monitor with a customizable in
 PKGDEP="gcc-runtime"
 BUILDDEP="rustc llvm"
 
+# ld.lld does not support loongson3 and mips64r6el
 USECLANG=1
+USECLANG__LOONGSON3=0
 NOLTO__LOONGSON3=1
+USECLANG__MIPS64R6EL=0
+NOLTO__MIPS64R6EL=1
 
 ABSPLITDBG=0

--- a/app-admin/bottom/spec
+++ b/app-admin/bottom/spec
@@ -1,4 +1,4 @@
-VER=0.8.0
-SRCS="https://github.com/ClementTsang/bottom/archive/$VER.tar.gz"
-CHKSUMS="sha256::0fe6a826d18570ab33b2af3b26ce28c61e3aa830abb2b622f2c3b81da802437a"
+VER=0.9.6
+SRCS="git::commit=tags/$VER::https://github.com/ClementTsang/bottom"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141487"


### PR DESCRIPTION
Topic Description
-----------------

- bottom: update to 0.9.6

Package(s) Affected
-------------------

- bottom: 0.9.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit bottom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
