### PR TITLE
systemd: fix getty@.service alternative

### DIFF
--- a/app-admin/systemd/autobuild/alternatives
+++ b/app-admin/systemd/autobuild/alternatives
@@ -7,3 +7,4 @@ alternative /usr/bin/telinit /usr/bin/systemctl 50
 alternative /usr/bin/service /usr/bin/systemctl 50
 alternative /usr/bin/init /usr/lib/systemd/systemd 50
 alternative /usr/lib/systemd/system/autovt@.service /usr/lib/systemd/system-alternatives/autovt-systemd.service 50
+alternative /usr/lib/systemd/system/getty@.service /usr/lib/systemd/system-alternatives/autovt-systemd.service 50

--- a/app-admin/systemd/autobuild/beyond
+++ b/app-admin/systemd/autobuild/beyond
@@ -19,7 +19,7 @@ echo 'disable *' \
 abinfo "Preparing autovt@.service for alternatives ..."
 mkdir -pv "$PKGDIR"/usr/lib/systemd/system-alternatives
 rm -v "$PKGDIR"/usr/lib/systemd/system/autovt@.service
-ln -sv ../system/getty@.service \
+mv -v "$PKGDIR"/usr/lib/systemd/system/getty@.service \
     "$PKGDIR"/usr/lib/systemd/system-alternatives/autovt-systemd.service
 
 if ab_match_archgroup retro; then

--- a/app-admin/systemd/autobuild/postinst
+++ b/app-admin/systemd/autobuild/postinst
@@ -15,12 +15,6 @@ systemd-sysusers
 systemd-hwdb update
 journalctl --update-catalog
 
-if ! systemctl is-enabled -q remote-fs.target; then
-	systemctl enable -q remote-fs.target
-fi
-
-systemctl enable getty@tty1.service remote-fs.target
-
 [ ! -d /var/log/journal/remote ] && mkdir -m2755 /var/log/journal/remote
 chgrp systemd-journal-remote /var/log/journal/remote
 

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,5 +1,5 @@
 VER=254.6
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd-stable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205088"


### PR DESCRIPTION
Topic Description
-----------------

- systemd: fix alternative for getty@.service
    - Make autovt-systemd.service an alternative provider for both autovt@.service
    and getty@.service.
    - This fixes a `systemctl preset-all` error:
    "autovt-systemd.service: symlink target name type "getty@.service" does not
    match source, rejecting."

Package(s) Affected
-------------------

- systemd: 1:254.6-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
