### PR TITLE
uncrustify: update to 0.78.1

### DIFF
--- a/app-devel/uncrustify/spec
+++ b/app-devel/uncrustify/spec
@@ -1,5 +1,4 @@
-VER=0.72.0
+VER=0.78.1
 SRCS="tbl::https://downloads.sourceforge.net/uncrustify/uncrustify-$VER.tar.gz"
-CHKSUMS="sha256::eef89f47858600d13d318c0d3d6d855075edba4e4f1baa6f0733ee6f950d63d3"
+CHKSUMS="sha256::5f92c90734e16b603c950ba7306bf8a2959afa41d4ecc6a52b4966183a1ea3cd"
 CHKUPDATE="anitya::id=5043"
-SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- uncrustify: update to 0.78.1

Package(s) Affected
-------------------

- uncrustify: 0.78.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit uncrustify
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
