### PR TITLE
acbs (Autobuild CI Build System): update to 20240109

### DIFF
--- a/app-devel/acbs/autobuild/defines
+++ b/app-devel/acbs/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=acbs
 PKGSEC=devel
-PKGDEP="autobuild3 file libarchive pexpect git mercurial wget pyparsing \
+PKGDEP="autobuild4 file libarchive pexpect git mercurial wget pyparsing \
         pycryptodome ptyprocess"
 BUILDDEP="pybind11 setuptools-python3 pip"
 # Hack for pybind11 cannot set different build settings on retro/non-retro

--- a/app-devel/acbs/spec
+++ b/app-devel/acbs/spec
@@ -1,4 +1,4 @@
-VER=20240107.1
+VER=20240109.1
 SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/acbs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226984"

--- a/app-devel/autobuild4/autobuild/defines
+++ b/app-devel/autobuild4/autobuild/defines
@@ -5,6 +5,5 @@ PKGDEP="autoconf autoconf-archive automake apt dpkg bash config coreutils \
         spdx-licenses gcc-runtime glibc"
 BUILDDEP="nlohmann-json"
 PKGRECOM="cargo-audit"
-PKGPROV="autobuild3 autobuild"
 
 VER_NONE=1

--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.0.3
+VER=4.0.11
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"

--- a/app-devel/ciel/spec
+++ b/app-devel/ciel/spec
@@ -1,4 +1,4 @@
-VER=3.2.1
+VER=3.2.2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227000"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: update to 4.0.11
    - This version fixes Autobuild4 bootstrapping.
    - Drop unneeded PKGPROV.
- acbs: update to 20240109.1
    - Switch autobuild3 => autobuild4.
- ciel: update to 3.2.2

Package(s) Affected
-------------------

- acbs: 2:20240109.1
- autobuild4: 4.0.11
- ciel: 3.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 acbs autobuild4 ciel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
