### PR TITLE
openssl{,+32}: update to 3.2.0

### DIFF
--- a/runtime-cryptography/openssl/spec
+++ b/runtime-cryptography/openssl/spec
@@ -1,4 +1,4 @@
-VER=3.1.4
+VER=3.2.0
 SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3"
+CHKSUMS="sha256::14c826f07c7e433706fb5c69fa9e25dab95684844b4c962a2cf1bf183eb4690e"
 CHKUPDATE="anitya::id=2566"

--- a/runtime-optenv32/openssl+32/spec
+++ b/runtime-optenv32/openssl+32/spec
@@ -1,4 +1,4 @@
-VER=3.1.4
+VER=3.2.0
 SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3"
+CHKSUMS="sha256::14c826f07c7e433706fb5c69fa9e25dab95684844b4c962a2cf1bf183eb4690e"
 CHKUPDATE="anitya::id=2566"


### PR DESCRIPTION
Topic Description
-----------------

- openssl{,+32}: update to 3.2.0

Package(s) Affected
-------------------

- openssl+32: 3.2.0
- openssl: 3.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl openssl+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
