### PR TITLE
llvm (Low-Level Virtual Machine): enable lld for MIPS ports (loongson3, mips64r6el)

### DIFF
--- a/app-devel/llvm/01-runtime/defines
+++ b/app-devel/llvm/01-runtime/defines
@@ -51,10 +51,6 @@ _LLVM_MIN_SET="clang" # for Afterglow and other new ports
 _LLVM_BASE_SET="${_LLVM_MIN_SET};lld;lldb;clang-tools-extra;polly" # for main-T2 arch (e.g. loongson3, riscv64 ...)
 _LLVM_FULL_SET="${_LLVM_BASE_SET};mlir;bolt;flang;libclc" # for main-T1 arch (e.g. amd64, arm64 ...)
 _LLVM_BASE_SET__LOONGARCH64="clang;lldb;clang-tools-extra;compiler-rt;polly;"
-# FIXME: lld is broken on MIPS (as of 16.0.6), fails to link Mozilla
-# applications and causes a build-time segfault when building LibreOffice.
-_LLVM_BASE_SET__LOONGSON3="${_LLVM_BASE_SET/lld;}"
-_LLVM_BASE_SET__MIPS64R6EL="clang;lldb;clang-tools-extra;compiler-rt;polly;"
 
 _LLVM_MIN_RUNTIME_SET="libunwind" # for Afterglow and other new ports
 _LLVM_BASE_RUNTIME_SET="${_LLVM_MIN_RUNTIME_SET};libcxx;libcxxabi;compiler-rt"
@@ -95,13 +91,13 @@ CMAKE_AFTER__LOONGARCH64=" \
              -DLLVM_PARALLEL_LINK_JOBS=2"
 CMAKE_AFTER__LOONGSON3=" \
              ${CMAKE_AFTER} \
-             -DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET__LOONGSON3} \
+             -DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET} \
              -DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET__LOONGSON3} \
              -DLLVM_PARALLEL_LINK_JOBS=2 \
              -DLLVM_USE_LINKER="
 CMAKE_AFTER__MIPS64R6EL=" \
              ${CMAKE_AFTER} \
-             -DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET__MIPS64R6EL} \
+             -DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET} \
              -DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET__MIPS64R6EL} \
              -DLLVM_USE_LINKER=bfd"
 CMAKE_AFTER__RISCV64="${CMAKE_AFTER__BASE} -DLLVM_PARALLEL_LINK_JOBS=2"

--- a/app-devel/llvm/01-runtime/defines.stage2
+++ b/app-devel/llvm/01-runtime/defines.stage2
@@ -41,10 +41,6 @@ _LLVM_MIN_SET="clang" # for Afterglow and other new ports
 _LLVM_BASE_SET="${_LLVM_MIN_SET};lld;lldb;clang-tools-extra;polly" # for main-T2 arch (e.g. loongson3, riscv64 ...)
 _LLVM_FULL_SET="${_LLVM_BASE_SET}" # for main-T1 arch (e.g. amd64, arm64 ...)
 _LLVM_BASE_SET__LOONGARCH64="clang;lldb;clang-tools-extra;compiler-rt;polly;"
-# FIXME: lld is broken on MIPS (as of 16.0.6), fails to link Mozilla
-# applications and causes a build-time segfault when building LibreOffice.
-_LLVM_BASE_SET__LOONGSON3="${_LLVM_BASE_SET/lld;}"
-_LLVM_BASE_SET__MIPS64R6EL="clang;lldb;clang-tools-extra;compiler-rt;polly;"
 
 _LLVM_BASE_RUNTIME_SET="libcxx;libcxxabi;compiler-rt"
 _LLVM_FULL_RUNTIME_SET="${_LLVM_BASE_RUNTIME_SET}"

--- a/app-devel/llvm/spec
+++ b/app-devel/llvm/spec
@@ -1,5 +1,5 @@
 VER=17.0.6
-REL=1
+REL=2
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::58a8818c60e6627064f312dbf46c02d9949956558340938b71cf731ad8bc0813"

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,4 +1,5 @@
 VER=1.74.0
+REL=1
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz \
       tbl::rename=rustc-bootstrap-$VER-loongson3.tar.xz::https://repo.aosc.io/aosc-repacks/rust-bootstrap/rustc-bootstrap-$VER-loongson3.tar.xz"
 CHKSUMS="sha256::23705e38c1a37acfd7fbb921c5dd8772619476e80d0b3b39ac8eb45bc0c33187 \


### PR DESCRIPTION
Topic Description
-----------------

- llvm: (loongson3,mips64r6el) enable lld
- rustc: rebuild to reset linker preference

Package(s) Affected
-------------------

- llvm: 17.0.6-2
- rustc: 1.74.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
