### PR TITLE
transmission disbale qt frontend

### DIFF
--- a/app-web/transmission/autobuild/defines
+++ b/app-web/transmission/autobuild/defines
@@ -1,6 +1,10 @@
 PKGNAME=transmission
 PKGSEC=net
+<<<<<<< HEAD
 PKGDEP="curl desktop-file-utils gtk-4 libdeflate gtkmm-4 hicolor-icon-theme libappindicator libevent systemd miniupnpc qt-5"
+=======
+PKGDEP="curl desktop-file-utils gtk-3 hicolor-icon-theme libappindicator libevent systemd miniupnpc"
+>>>>>>> d087f7f0ec (transmission: disbale qt frontend)
 PKGDES="A lightweight BitTorrent client"
 
 PKGCONFL="transmission-remote-gtk<=1.3.1-1"


### PR DESCRIPTION
Topic Description
-----------------

- transmission: disbale qt frontend

Package(s) Affected
-------------------

- transmission: 4.0.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit transmission
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
