### PR TITLE
bluez (BlueZ Bluetooth Stack): security update to 5.71

### DIFF
--- a/app-devices/bluez/spec
+++ b/app-devices/bluez/spec
@@ -1,4 +1,4 @@
-VER=5.66
+VER=5.71
 SRCS="tbl::https://www.kernel.org/pub/linux/bluetooth/bluez-$VER.tar.xz"
-CHKSUMS="sha256::39fea64b590c9492984a0c27a89fc203e1cdc74866086efb8f4698677ab2b574"
+CHKSUMS="sha256::b828d418c93ced1f55b616fb5482cf01537440bfb34fbda1a564f3ece94735d8"
 CHKUPDATE="anitya::id=10029"


### PR DESCRIPTION
Topic Description
-----------------

- bluez: update to 5.71

Package(s) Affected
-------------------

- bluez: 5.71

Security Update?
----------------

No

Build Order
-----------

```
#buildit bluez
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
