### PR TITLE
libfm add stage2

### DIFF
--- a/desktop-lxde/libfm/autobuild/defines
+++ b/desktop-lxde/libfm/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libfm
 PKGSEC=x11
-PKGDEP="desktop-file-utils libexif dbus-glib gtk-3"
-BUILDDEP="menu-cache intltool"
+PKGDEP="desktop-file-utils libexif dbus-glib gtk-3 menu-cache"
+BUILDDEP="intltool gtk-doc"
 PKGDES="Library for file management (LXDE)"
 
 AUTOTOOLS_AFTER="--with-gnu-ld --with-gtk=3"

--- a/desktop-lxde/libfm/autobuild/defines.stage2
+++ b/desktop-lxde/libfm/autobuild/defines.stage2
@@ -1,0 +1,9 @@
+PKGNAME=libfm
+PKGSEC=x11
+PKGDEP="desktop-file-utils libexif dbus-glib gtk-3"
+BUILDDEP="intltool"
+PKGDES="Library for file management (LXDE)"
+
+AUTOTOOLS_AFTER="--with-gnu-ld --with-gtk=3 --with-extra-only --enable-gtk-doc-html=no"
+ABSHADOW=no
+RECONF=0

--- a/desktop-lxde/libfm/spec
+++ b/desktop-lxde/libfm/spec
@@ -1,4 +1,5 @@
 VER=1.3.0.2
+REL=1
 SRCS="tbl::https://downloads.sourceforge.net/pcmanfm/libfm-$VER.tar.xz"
 CHKSUMS="sha256::18d06f7996ce1cf8947df6e106bc0338c6ae0c4138c316f2501f6f6f435c7c72"
 CHKUPDATE="anitya::id=8794"


### PR DESCRIPTION
Topic Description
-----------------

- libfm: add stage2

Package(s) Affected
-------------------

- libfm: 1.3.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libfm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
