### PR TITLE
mm-common update to1.0.6

### DIFF
--- a/app-devel/mm-common/autobuild/defines
+++ b/app-devel/mm-common/autobuild/defines
@@ -13,3 +13,4 @@ BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="Common build files of GLib/GTK+ C++ bindings"
 
 ABHOST=noarch
+ABTYPE=meson

--- a/app-devel/mm-common/spec
+++ b/app-devel/mm-common/spec
@@ -1,4 +1,4 @@
-VER=1.0.4
+VER=1.0.6
 SRCS="tbl::https://download.gnome.org/sources/mm-common/${VER:0:3}/mm-common-$VER.tar.xz"
-CHKSUMS="sha256::e954c09b4309a7ef93e13b69260acdc5738c907477eb381b78bb1e414ee6dbd8"
+CHKSUMS="sha256::b55c46037dbcdabc5cee3b389ea11cc3910adb68ebe883e9477847aa660862e7"
 CHKUPDATE="anitya::id=13152"


### PR DESCRIPTION
Topic Description
-----------------

- mm-common: update to 1.0.6
Add ABTYPE to be built using meson

Package(s) Affected
-------------------

- mm-common: 1.0.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit mm-common
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
