### PR TITLE
miniserve: update to 0.26.0

### DIFF
--- a/app-web/miniserve/spec
+++ b/app-web/miniserve/spec
@@ -1,4 +1,4 @@
-VER=0.25.0
+VER=0.26.0
 SRCS="git::commit=tags/v$VER::https://github.com/svenstaro/miniserve/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231970"


### PR DESCRIPTION
Topic Description
-----------------

- miniserve: update to 0.26.0

Package(s) Affected
-------------------

- miniserve: 0.26.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit miniserve
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
