### PR TITLE
racket: update to 8.11.1

### DIFF
--- a/lang-lisp/racket/autobuild/beyond
+++ b/lang-lisp/racket/autobuild/beyond
@@ -12,3 +12,9 @@ ln -sv ../../../../racket/pkgs/icons/plt-logo-red-diffuse.png \
 abinfo "Appending Icon= to desktop entry ..."
 echo "Icon=drracket" \
     >> "$PKGDIR"/usr/share/applications/drracket.desktop
+
+abinfo "Installing shell completions ..."
+install -Dvm644 "$SRCDIR"/../share/pkgs/shell-completion/racket-completion.bash \
+    "$PKGDIR"/usr/share/bash-completion/completions/racket.bash
+install -Dvm644 "$SRCDIR"/../share/pkgs/shell-completion/racket-completion.zsh \
+    "$PKGDIR"/usr/share/zsh/functions/Completion/Unix/_racket

--- a/lang-lisp/racket/autobuild/defines
+++ b/lang-lisp/racket/autobuild/defines
@@ -8,5 +8,9 @@ RECONF=0
 
 AUTOTOOLS_AFTER__PPC64EL="--enable-pb --enable-mach=tpb64l"
 AUTOTOOLS_AFTER__LOONGSON3="--enable-pb --enable-mach=pb64l"
-AUTOTOOLS_AFTER__MIPS64R6EL="--enable-pb --enable-mach=pb64l"
 AUTOTOOLS_AFTER__LOONGARCH64="--enable-pb --enable-mach=pb64l"
+
+# FIXME: FTBFS on mips64r6el, illegal instruction
+FAIL_ARCH="mips64r6el"
+# If fixed, uncomment the following building options
+# AUTOTOOLS_AFTER__MIPS64R6EL="--enable-pb --enable-mach=pb64l"

--- a/lang-lisp/racket/autobuild/defines
+++ b/lang-lisp/racket/autobuild/defines
@@ -8,4 +8,5 @@ RECONF=0
 
 AUTOTOOLS_AFTER__PPC64EL="--enable-pb --enable-mach=tpb64l"
 AUTOTOOLS_AFTER__LOONGSON3="--enable-pb --enable-mach=pb64l"
+AUTOTOOLS_AFTER__MIPS64R6EL="--enable-pb --enable-mach=pb64l"
 AUTOTOOLS_AFTER__LOONGARCH64="--enable-pb --enable-mach=pb64l"

--- a/lang-lisp/racket/spec
+++ b/lang-lisp/racket/spec
@@ -1,5 +1,5 @@
-VER=8.10
+VER=8.11.1
 SRCS="tbl::https://mirror.racket-lang.org/installers/$VER/racket-$VER-src.tgz"
 SUBDIR="racket-$VER/src"
-CHKSUMS="sha256::0e4963da2c17e7f6d57428bda1dcf64eda7437e2f26bb6cc48b47f417a3d93a3"
+CHKSUMS="sha256::e59ab030b92a78e3589ec405c5d25fa517688c20990233bd68cb34568d654c05"
 CHKUPDATE="anitya::id=13609"


### PR DESCRIPTION
Topic Description
-----------------

- racket: update to 8.11.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- racket: 8.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit racket
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
