### PR TITLE
atop: update to 2.10.0

### DIFF
--- a/app-utils/atop/autobuild/build
+++ b/app-utils/atop/autobuild/build
@@ -3,6 +3,6 @@ mkdir -pv "$PKGDIR"/etc/default
 
 abinfo "Building atop ..."
 make
-make systemdinstall \
+make install \
     DESTDIR="$PKGDIR" \
     SBINPATH=/usr/bin

--- a/app-utils/atop/autobuild/patches/0001-fix-known-bad-path.patch
+++ b/app-utils/atop/autobuild/patches/0001-fix-known-bad-path.patch
@@ -1,0 +1,11 @@
+--- a/Makefile	2024-01-04 18:06:28.000000000 +0800
++++ b/Makefile	2024-01-16 13:58:48.852154395 +0800
+@@ -13,7 +13,7 @@
+ MAN8PATH = /usr/share/man/man8
+ INIPATH  = /etc/init.d
+ DEFPATH  = /etc/default
+-SYSDPATH = /lib/systemd/system
++SYSDPATH = /usr/lib/systemd/system
+ CRNPATH  = /etc/cron.d
+ ROTPATH  = /etc/logrotate.d
+ PMPATH1  = /usr/lib/pm-utils/sleep.d

--- a/app-utils/atop/spec
+++ b/app-utils/atop/spec
@@ -1,5 +1,4 @@
-VER=2.5.0
-REL=1
+VER=2.10.0
 SRCS="tbl::https://atoptool.nl/download/atop-$VER.tar.gz"
-CHKSUMS="sha256::4b911057ce50463b6e8b3016c5963d48535c0cddeebc6eda817e292b22f93f33"
+CHKSUMS="sha256::e7a673cf2c82578e7dd82ecb0dec83fd9ecb30828b2561c28a9fa5aaf75d5f93"
 CHKUPDATE="anitya::id=135"


### PR DESCRIPTION
Topic Description
-----------------

- atop: change install target from systemdinstall to install
    Upstream no longer provides systemdinstall. Instead,
    the default install target now installs systemd related files.
- atop: fix known bad path in Makefile

- atop: update to 2.10.0

Package(s) Affected
-------------------

- atop: 2.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit atop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
