### PR TITLE
libgusb: update to 0.4.8 and switch to Git source

### DIFF
--- a/runtime-devices/libgusb/autobuild/defines
+++ b/runtime-devices/libgusb/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libgusb
 PKGDES="A GObject wrapper for libusb1"
 PKGSEC=libs
-PKGDEP="systemd libusb glib"
+PKGDEP="systemd libusb glib json-glib gi-docgen"
 BUILDDEP="gobject-introspection vala gtk-doc intltool meson ninja"
 
 ABTYPE=meson

--- a/runtime-devices/libgusb/spec
+++ b/runtime-devices/libgusb/spec
@@ -1,5 +1,4 @@
-VER=0.3.5
-REL=1
-SRCS="tbl::https://people.freedesktop.org/~hughsient/releases/libgusb-$VER.tar.xz"
-CHKSUMS="sha256::5b2a00c6997cc4b0133c5a5748a2e616e9e7504626922105b62aadced78e65df"
+VER=0.4.8
+SRCS="git::commit=tags/$VER::https://github.com/hughsie/libgusb"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5505"


### PR DESCRIPTION
Topic Description
-----------------

- libgusb: update to 0.4.8; switch to Git source
    Tarball URL we used previously are no longer available, and upstream
    probably moved the development to GitHub.

Package(s) Affected
-------------------

- libgusb: 0.4.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgusb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
