### PR TITLE
fwupd: update to 1.9.11

### DIFF
--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=fwupd
 PKGSEC=admin
-PKGDEP="appstream-glib colord dbus efivar elfutils gcab glib gnutls \
+PKGDEP="appstream-glib colord dbus elfutils gcab glib gnutls \
         gpgme json-glib libarchive libgpg-error libgudev libgusb libsoup \
         libxmlb modemmanager pango pillow polkit pycairo pygobject-3 python-3 \
         shared-mime-info sqlite systemd tpm2-tss libjcat protobuf-c libftdi"
-PKGDEP__AMD64="${PKGDEP} flashrom libsmbios thunderbolt-software-user-space"
+PKGDEP__AMD64="${PKGDEP} flashrom thunderbolt-software-user-space"
 BUILDDEP="docbook-sgml gobject-introspection gtk-doc intltool meson \
           ninja pkg-config vala valgrind cairo dejavu-fonts fontconfig \
           freetype gnu-efi markdown jinja2 toml typogrify pefile gi-docgen"
@@ -12,61 +12,68 @@ BUILDDEP="docbook-sgml gobject-introspection gtk-doc intltool meson \
 BUILDDEP__LOONGARCH64="${BUILDDEP/gnu-efi/}"
 BUILDDEP__LOONGSON3="${BUILDDEP/gnu-efi/}"
 BUILDDEP__PPC64EL="${BUILDDEP/gnu-efi/}"
+BUILDDEP__MIPS64R6EL="${BUILDDEP/gnu-efi/}"
 # FIXME: Valgrind is not yet available for RISC-V.
 BUILDDEP__RISCV64="${BUILDDEP/valgrind/}"
 PKGDES="Firmware update daemon and utilities"
 
 MESON_AFTER="-Dman=true \
-             -Dplugin_modem_manager=true \
-             -Dplugin_nvme=true \
-             -Dplugin_redfish=true \
-             -Dsystemd=true \
-             -Dconsolekit=true \
+             -Dplugin_modem_manager=enabled \
+             -Dplugin_nvme=enabled \
+             -Dplugin_redfish=enabled \
+             -Dsystemd=enabled \
+             -Dconsolekit=enabled \
              -Dtests=false"
 MESON_AFTER__AMD64=" \
              ${MESON_AFTER} \
-             -Dplugin_dell=true \
-             -Dplugin_msr=true"
+             -Dplugin_msr=enabled"
 MESON_AFTER__ARM64=" \
              ${MESON_AFTER} \
-             -Dplugin_dell=false \
-             -Dplugin_msr=false \
-             -Dplugin_flashrom=false"
+             -Dplugin_msr=disabled \
+             -Dplugin_flashrom=disabled"
 MESON_AFTER__LOONGARCH64=" \
              ${MESON_AFTER} \
-             -Dplugin_dell=false \
-             -Dplugin_msr=false \
-             -Dplugin_uefi_capsule=false \
-             -Dplugin_uefi_capsule_splash=false \
-             -Dplugin_uefi_pk=false \
+             -Dplugin_msr=disabled \
+             -Dplugin_uefi_capsule=enabled \
+             -Dplugin_uefi_capsule_splash=true \
+             -Dplugin_uefi_pk=enabled \
              -Defi_binary=false \
-             -Dplugin_flashrom=false"
+             -Dplugin_flashrom=disabled"
 MESON_AFTER__LOONGSON3=" \
              ${MESON_AFTER} \
-             -Dplugin_dell=false \
-             -Dplugin_msr=false \
-             -Dplugin_uefi_capsule=false \
-             -Dplugin_uefi_capsule_splash=false \
-             -Dplugin_uefi_pk=false \
+             -Dplugin_msr=disabled \
+             -Dplugin_uefi_capsule=enabled \
+             -Dplugin_uefi_capsule_splash=true \
+             -Dplugin_uefi_pk=enabled \
              -Defi_binary=false \
-             -Dplugin_flashrom=false"
+             -Dplugin_flashrom=disabled"
 MESON_AFTER__PPC64EL=" \
              ${MESON_AFTER} \
-             -Dplugin_dell=false \
-             -Dplugin_msr=false \
-             -Dplugin_uefi_capsule=false \
-             -Dplugin_uefi_capsule_splash=false \
-             -Dplugin_uefi_pk=false \
-             -Defi_binary=false"
+             -Dplugin_msr=disabled \
+             -Dplugin_uefi_capsule=enabled \
+             -Dplugin_uefi_capsule_splash=true \
+             -Dplugin_uefi_pk=enabled \
+             -Defi_binary=false \
+             -Dplugin_flashrom=disabled"
 MESON_AFTER__RISCV64=" \
              ${MESON_AFTER} \
-             -Dplugin_dell=false \
-             -Dplugin_msr=false \
-             -Dplugin_uefi_capsule=false \
-             -Dplugin_uefi_capsule_splash=false \
-             -Dplugin_uefi_pk=false \
+             -Dplugin_msr=disabled \
+             -Dplugin_uefi_capsule=enabled \
+             -Dplugin_uefi_capsule_splash=true \
+             -Dplugin_uefi_pk=enabled \
              -Defi_binary=false \
-             -Dplugin_flashrom=false"
+             -Dplugin_flashrom=disabled"
+
+# FIXME: disabling UEFI capsule support as python3 SIGILLS during:
+# /usr/bin/python3 ../plugins/uefi-capsule/make-images.py --podir /var/cache/acbs/build/acbs.hjpt357w/fwupd/po --label 'Installing firmware update…' --out plugins/uefi-capsule/uefi-capsule-ux.tar.xz
+MESON_AFTER__MIPS64R6EL=" \
+             ${MESON_AFTER} \
+             -Dplugin_msr=disabled \
+             -Dplugin_uefi_capsule=disabled \
+             -Dplugin_uefi_capsule_splash=false \
+             -Dplugin_uefi_pk=disabled \
+             -Defi_binary=false \
+             -Dplugin_flashrom=disabled"
 
 PKGBREAK="fwupdate<=12-2 gnome-software<=3.26.1"
 PKGREP="fwupdate<=12-2"

--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,5 +1,4 @@
-VER=1.8.14
-REL=1
-SRCS="https://github.com/hughsie/fwupd/archive/$VER.tar.gz"
-CHKSUMS="sha256::02d31bbfb70219d2b86d5fba216f6dbaba89fac4cfc79508cece6cb79ec1d0dc"
+VER=1.9.11
+SRCS="git::commit=tags/$VER::https://github.com/hughsie/fwupd"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5833"

--- a/runtime-devices/libgusb/autobuild/defines
+++ b/runtime-devices/libgusb/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=libgusb
 PKGDES="A GObject wrapper for libusb1"
 PKGSEC=libs
-PKGDEP="systemd libusb glib"
-BUILDDEP="gobject-introspection vala gtk-doc intltool meson ninja"
+PKGDEP="systemd libusb glib json-glib"
+BUILDDEP="gobject-introspection vala gtk-doc intltool meson ninja gi-docgen"
 
 ABTYPE=meson
 PKGBREAK="colord<=1.4.4 fwupd<=1.3.10 \

--- a/runtime-devices/libgusb/spec
+++ b/runtime-devices/libgusb/spec
@@ -1,5 +1,4 @@
-VER=0.3.5
-REL=1
-SRCS="tbl::https://people.freedesktop.org/~hughsient/releases/libgusb-$VER.tar.xz"
-CHKSUMS="sha256::5b2a00c6997cc4b0133c5a5748a2e616e9e7504626922105b62aadced78e65df"
+VER=0.4.8
+SRCS="git::commit=tags/$VER::https://github.com/hughsie/libgusb"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5505"


### PR DESCRIPTION
Topic Description
-----------------

- libgusb: fill PKGDEP and BUILDDEP
    - Add json-glib as runtime dependency.
    - Add gi-docgen as build dependency.
- libgusb: update to 0.4.8; switch to Git source
    - Updated as fwupd now requires libgusb >= 0.4.5.
    - Tarball URL we used previously are no longer available,
    and upstream probably moved the development to GitHub.
- fwupd: modify meson options
    - Drop all libefiboot and libsmbios references by upstream.
    - Some options value 'true' are replaced by 'enabled', some
    calue 'false' are replaced by 'disabled'.
    - Add missing option for ppc64el.
- fwupd: update to 1.9.11

Package(s) Affected
-------------------

- fwupd: 1.9.11
- libgusb: 0.4.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgusb fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
