### PR TITLE
linux-pam: security update to 1.6.0

### DIFF
--- a/app-admin/linux-pam/spec
+++ b/app-admin/linux-pam/spec
@@ -1,4 +1,4 @@
-VER=1.5.2
+VER=1.6.0
 SRCS="tbl::https://github.com/linux-pam/linux-pam/releases/download/v$VER/Linux-PAM-$VER.tar.xz"
-CHKSUMS="sha256::e4ec7131a91da44512574268f493c6d8ca105c87091691b8e9b56ca685d4f94d"
+CHKSUMS="sha256::fff4a34e5bbee77e2e8f1992f27631e2329bcbf8a0563ddeb5c3389b4e3169ad"
 CHKUPDATE="anitya::id=12244"


### PR DESCRIPTION
Topic Description
-----------------

- linux-pam: update to 1.6.0
    - Closes #5143.

Package(s) Affected
-------------------

- linux-pam: 1.6.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit linux-pam
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
