### PR TITLE
xserver: security update survey

### DIFF
--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,4 @@
-VER=21.1.9
+VER=21.1.11
 SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
-CHKSUMS="sha256::ff697be2011b4c4966b7806929e51b7a08e9d33800d505305d26d9ccde4b533a"
+CHKSUMS="sha256::1d3dadbd57fb86b16a018e9f5f957aeeadf744f56c0553f55737628d06d326ef"
 CHKUPDATE="anitya::id=5250"

--- a/runtime-display/xwayland/spec
+++ b/runtime-display/xwayland/spec
@@ -1,4 +1,4 @@
-VER=23.2.2
+VER=23.2.4
 SRCS="tbl::https://xorg.freedesktop.org/archive/individual/xserver/xwayland-$VER.tar.xz"
-CHKSUMS="sha256::9f7c0938d2a41e941ffa04f99c35e5db2bcd3eec034afe8d35d5c810a22eb0a8"
+CHKSUMS="sha256::a99e159b6d0d33098b3b6ab22a88bfcece23c8b9d0ca72c535c55dcb0681b46b"
 CHKUPDATE="anitya::id=180949"


### PR DESCRIPTION
Topic Description
-----------------

- xserver: security update
    - xorg-server: update to 21.1.11
    - xwayland: update to 23.2.4

Package(s) Affected
-------------------

- xorg-server: 21.1.11
- xwayland: 23.2.4

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit xorg-server xwayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
