### PR TITLE
Chromium: security update to 120.0.6099.224

### DIFF
--- a/app-web/chromium/spec
+++ b/app-web/chromium/spec
@@ -1,10 +1,10 @@
-VER=120.0.6099.216
+VER=120.0.6099.224
 LAUNCHERVER=8
 SRCS="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$VER.tar.xz \
       https://github.com/foutrelis/chromium-launcher/archive/v$LAUNCHERVER.tar.gz \
       file::rename=chromium-$VER.txt::https://chromium.googlesource.com/chromium/src/+/$VER?format=TEXT"
-CHKSUMS="sha256::7e7bea15bf56f3cc920bb015fed1a1b1368267299e132e795935c5cc604adfc0 \
+CHKSUMS="sha256::850a85c8d8a01041a07dfaaea8289fa5f8294b4e375e6b77997b61434e0a2f1a \
          sha256::213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a \
-         sha256::ab9789504702599598241cbf3b0db0fd9e1b74d8dd1e8d7de79b240cd84d24c8"
+         sha256::3e5b107050c1db3ceebdb586793ab39a0c3bef5f15b4357050f68fde0bd35646"
 SUBDIR="chromium-$VER"
 CHKUPDATE="anitya::id=13344"

--- a/app-web/google-chrome/spec
+++ b/app-web/google-chrome/spec
@@ -1,4 +1,4 @@
-VER=116.0.5845.179
+VER=120.0.6099.224
 SRCS="file::rename=google-chrome-stable_current_amd64.deb::https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
-CHKSUMS="sha256::75d091c547b4f336c88e45c61ba8b7a6fddb869034122b3ffe0ed60225c389b4"
+CHKSUMS="sha256::7459651074581f7c803e0dee69a0b3769899c522c4344c26b486ff820e77fd95"
 CHKUPDATE="anitya::id=5349"


### PR DESCRIPTION
Topic Description
-----------------

- chromium: security update to 120.0.6099.224
    - Closes #5150.
- google-chrome: security update to 120.0.6099.224

Package(s) Affected
-------------------

- chromium: 120.0.6099.224
- google-chrome: 116.0.5845.179

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit chromium google-chrome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
