### PR TITLE
liteide: new, 38.3

### DIFF
--- a/app-editors/liteide/autobuild/build
+++ b/app-editors/liteide/autobuild/build
@@ -1,0 +1,29 @@
+# From https://gitlab.archlinux.org/archlinux/packaging/packages/liteide/
+
+abinfo "Building liteide..."
+pushd build
+./update_pkg.sh
+./build_linux.sh
+popd
+
+abinfo "Installing liteide..."
+install -dv \
+    "$PKGDIR"/usr/lib/liteide \
+    "$PKGDIR"/usr/share/liteide \
+    "$PKGDIR"/usr/share/doc/liteide
+for binary in gotools gocode liteide
+do
+    install -Dvm755 "$SRCDIR"/build/liteide/bin/$binary "$PKGDIR"/usr/bin/"$binary"
+done
+cp -rv "$SRCDIR"/liteidex/deploy/* os_deploy/* "$PKGDIR"/usr/share/liteide
+cp -rv "$SRCDIR"/liteidex/liteide/lib/liteide/* "$PKGDIR"/usr/lib/liteide
+chmod -x "$PKGDIR"/usr/lib/liteide/plugins/*
+install -Dvm644 "$SRCDIR"/liteidex/LICENSE.LGPL \
+    "$PKGDIR"/usr/share/doc/liteide/LICENSE
+install -Dvm644 "$SRCDIR"/liteidex/LGPL_EXCEPTION.TXT \
+    "$PKGDIR"/usr/share/doc/liteide/LGPL_EXCEPTION
+install -Dvm644 "$SRCDIR"/liteidex/liteide.desktop \
+    "$PKGDIR"/usr/share/applications/liteide.desktop
+install -dv "$PKGDIR"/usr/share/pixmaps
+ln -sv /usr/share/liteide/welcome/images/liteide400.png \
+    "$PKGDIR"/usr/share/pixmaps/liteide.png

--- a/app-editors/liteide/autobuild/defines
+++ b/app-editors/liteide/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=liteide
+PKGSEC=devel
+PKGDEP="go qt-5"
+PKGDES="A simple, open source, cross-platform Go IDE"
+
+ABSPLITDBG=0

--- a/app-editors/liteide/autobuild/patches/0001-update-gotools.patch
+++ b/app-editors/liteide/autobuild/patches/0001-update-gotools.patch
@@ -1,0 +1,29 @@
+From 45ced7cd7ea302bc9c4a61e1d328b6b0a8d52915 Mon Sep 17 00:00:00 2001
+From: SignKirigami <prcups@krgm.moe>
+Date: Fri, 19 Jan 2024 12:24:37 +0800
+Subject: [PATCH] update gotools
+
+A dependency of gotools requires high version to support loongarch. Pull
+Request has been merged but gotools should be manually updated before next main
+version.
+
+---
+ build/update_pkg.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/update_pkg.sh b/build/update_pkg.sh
+index b6d9de9b..53bd0fdd 100755
+--- a/build/update_pkg.sh
++++ b/build/update_pkg.sh
+@@ -25,7 +25,7 @@ export GOBIN=$PWD/bin
+ echo install gocode ...
+ go install -v github.com/visualfc/gocode@latest
+ echo install gotools ...
+-go install -v github.com/visualfc/gotools@latest
++go install -v github.com/visualfc/gotools@45f301a
+ echo install gomodifytags ...
+ go install -v github.com/fatih/gomodifytags@latest
+ 
+-- 
+2.39.1
+

--- a/app-editors/liteide/spec
+++ b/app-editors/liteide/spec
@@ -1,0 +1,4 @@
+VER=38.3
+SRCS="git::commit=tags/x$VER::https://github.com/visualfc/liteide.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=227233"


### PR DESCRIPTION
Topic Description
-----------------

liteide: new, 38.3

Package(s) Affected
-------------------

liteide: v38.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit liteide
```


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
- [x] LoongArch 64-bit `loongarch64`