### PR TITLE
openh264: rebase mips64r6el-only patch

### DIFF
--- a/app-multimedia/openh264/autobuild/patches/0002-Do-not-enable-MIPS-assembly-for-r6.patch.mips64r6el
+++ b/app-multimedia/openh264/autobuild/patches/0002-Do-not-enable-MIPS-assembly-for-r6.patch.mips64r6el
@@ -1,18 +1,35 @@
---- openh264-2.0.0/build/arch.mk	2019-05-08 00:07:17.000000000 -0700
-+++ openh264-2.0.0.noasm/build/arch.mk	2022-11-06 17:38:44.879040825 -0800
-@@ -29,15 +29,3 @@
- CFLAGS += -DHAVE_NEON_AARCH64
+diff --git a/build/arch.mk b/build/arch.mk
+index 4e1538c4..21cb80bb 100644
+--- a/build/arch.mk
++++ b/build/arch.mk
+@@ -30,30 +30,6 @@ CFLAGS += -DHAVE_NEON_AARCH64
  endif
  endif
--
--#for loongson
+ 
+-#for mips
 -ifneq ($(filter mips mips64, $(ARCH)),)
 -ifeq ($(USE_ASM), Yes)
+-ENABLE_MMI=Yes
+-ENABLE_MSA=Yes
 -ASM_ARCH = mips
 -ASMFLAGS += -I$(SRC_PATH)codec/common/mips/
--LOONGSON3A = $(shell g++ -dM -E - < /dev/null | grep '_MIPS_TUNE ' | cut -f 3 -d " ")
--ifeq ($(LOONGSON3A), "loongson3a")
--CFLAGS += -DHAVE_MMI
+-#mmi
+-ifeq ($(ENABLE_MMI), Yes)
+-ENABLE_MMI = $(shell $(SRC_PATH)build/mips-simd-check.sh $(CC) mmi)
+-ifeq ($(ENABLE_MMI), Yes)
+-CFLAGS += -DHAVE_MMI -march=loongson3a
+-endif
+-endif
+-#msa
+-ifeq ($(ENABLE_MSA), Yes)
+-ENABLE_MSA = $(shell $(SRC_PATH)build/mips-simd-check.sh $(CC) msa)
+-ifeq ($(ENABLE_MSA), Yes)
+-CFLAGS += -DHAVE_MSA -mmsa
 -endif
 -endif
 -endif
+-endif
+-
+ #for loongarch
+ ifneq ($(filter loongarch64, $(ARCH)),)
+ ifeq ($(USE_ASM), Yes)


### PR DESCRIPTION
Topic Description
-----------------

- openh264: rebase mips64r6el-only patch

Package(s) Affected
-------------------

- openh264: 2.4.0+gmp114+2

Security Update?
----------------

No

Build Order
-----------

```
#buildit openh264
```

Test Build(s) Done
------------------

**Secondary Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
