### PR TITLE
glew: (loongarch64) disable LTO

### DIFF
--- a/runtime-display/glew/autobuild/defines
+++ b/runtime-display/glew/autobuild/defines
@@ -5,6 +5,7 @@ PKGDES="The OpenGL Extension Wrangler Library"
 
 # FIXME: LTO causes glewInit() crash on loongarch64.
 NOLTO__LOONGARCH64=1
+
 PKGBREAK="avogadro<=1.2.0-6 avogadrolibs<=1.92.1-1 blastem<=0.6.2 blender<=2.81a-1 \
           clementine<=1.3.1-6 darkradiant<=2.6.0-3 enblend-enfuse<=4.2-2 \
           flightgear<=2019.1.1 hugin<=2019.2.0 kicad<=5.1.5 kitty<=0.12.1 \
@@ -13,4 +14,3 @@ PKGBREAK="avogadro<=1.2.0-6 avogadrolibs<=1.92.1-1 blastem<=0.6.2 blender<=2.81a
           opensubdiv<=3.3.3-4 pcsx2<=1.4.0-5 ppsspp<=1.9.4 projectm<=2.1.0-4 \
           rlvm<=0.14.67-2 sfml<=2.5.0 slop<=7.4-3 supertux<=0.6.1 supertuxkart<=1.1 \
           vice<=3.3-1 warzone2100<=3.2.3-4 yabause<=0.9.15-1"
-

--- a/runtime-display/glew/autobuild/defines
+++ b/runtime-display/glew/autobuild/defines
@@ -3,6 +3,8 @@ PKGSEC=libs
 PKGDEP="glu"
 PKGDES="The OpenGL Extension Wrangler Library"
 
+# FIXME: LTO causes glewInit() crash on loongarch64.
+NOLTO__LOONGARCH64=1
 PKGBREAK="avogadro<=1.2.0-6 avogadrolibs<=1.92.1-1 blastem<=0.6.2 blender<=2.81a-1 \
           clementine<=1.3.1-6 darkradiant<=2.6.0-3 enblend-enfuse<=4.2-2 \
           flightgear<=2019.1.1 hugin<=2019.2.0 kicad<=5.1.5 kitty<=0.12.1 \

--- a/runtime-display/glew/autobuild/defines
+++ b/runtime-display/glew/autobuild/defines
@@ -13,3 +13,4 @@ PKGBREAK="avogadro<=1.2.0-6 avogadrolibs<=1.92.1-1 blastem<=0.6.2 blender<=2.81a
           opensubdiv<=3.3.3-4 pcsx2<=1.4.0-5 ppsspp<=1.9.4 projectm<=2.1.0-4 \
           rlvm<=0.14.67-2 sfml<=2.5.0 slop<=7.4-3 supertux<=0.6.1 supertuxkart<=1.1 \
           vice<=3.3-1 warzone2100<=3.2.3-4 yabause<=0.9.15-1"
+

--- a/runtime-display/glew/spec
+++ b/runtime-display/glew/spec
@@ -1,5 +1,5 @@
 VER=2.2.0
-REL=4
+REL=5
 SRCS="tbl::https://sourceforge.net/projects/glew/files/glew/$VER/glew-$VER.tgz"
 CHKSUMS="sha256::d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1"
 CHKUPDATE="anitya::id=7878"


### PR DESCRIPTION
Topic Description
-----------------

Disable LTO for loongarch64 which causes `glewInit()` to fail in a crash.

Package(s) Affected
-------------------

glew: v2.2.0

Build Order
-----------------

```
#buildit glew
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
