### PR TITLE
pushpkg: update to 0+git20240120

### DIFF
--- a/app-devel/pushpkg/spec
+++ b/app-devel/pushpkg/spec
@@ -1,13 +1,13 @@
-VER=0+git20240108
-__COMMIT="ba739f2709b8912d0da1559f4b9f0684e02f2119"
+VER=0+git20240120
+__COMMIT="377db001d7ed6a97cd97454cb2fcd08899a696f5"
 SRCS="file::rename=pushpkg::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/pushpkg \
       file::rename=pushpkg.bash::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/completions/pushpkg.bash \
       file::rename=pushpkg.fish::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/completions/pushpkg.fish \
       file::rename=COPYING::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/COPYING \
       file::rename=README.md::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/README.md"
-CHKSUMS="sha256::87c91d216117b3ce9af9cd79fc09c8a5a378198b9cf5fb7a4f06865b9aa0f128 \
-         sha256::d30be57c8a8b08a2a4d780cd02398e15f13155f18b986414b501becf17cf0961 \
-         sha256::6c3e1759290a8aab997d40bd4937b6d8a5936c24faafc399a2b3eb9a4ea83366 \
+CHKSUMS="sha256::f31bc60e905fbf62a19d86b9a19e8961bb2559797cc15042247d5ac86452b0e2 \
+         sha256::48101ed7b8c871f8d315e889816e31502682290b3ca03f8075409247b7a4724e \
+         sha256::9a7d8167284bbe2e36b6fe3f7e5bbe4e125a89685a9213db9caa83512ec48026 \
          sha256::992c720940396663b52389eea4c6a7409dd26b55ab3bfcd3a17f5da8b6d2a3c9 \
-         sha256::a23bd38a8e4ace9c7bf285df38d9d757543d7d2c664228300a0bd5f3f8b2b3aa"
+         sha256::c62c3891a4629143a7dd9ec135e0c12a5f4287fe705f01832ad1bd478195e014"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- pushpkg: update to 0+git20240120

Package(s) Affected
-------------------

- pushpkg: 1:0+git20240120

Security Update?
----------------

No

Build Order
-----------

```
#buildit pushpkg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
