### PR TITLE
curl{,+32}: security update to 8.5.0

### DIFF
--- a/app-web/curl/spec
+++ b/app-web/curl/spec
@@ -1,4 +1,4 @@
-VER=8.4.0
-SRCS="tbl::https://curl.se/download/curl-$VER.tar.bz2"
-CHKSUMS="sha256::e5250581a9c032b1b6ed3cf2f9c114c811fc41881069e9892d115cc73f9e88c6"
+VER=8.5.0
+SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
+CHKSUMS="sha256::42ab8db9e20d8290a3b633e7fbb3cec15db34df65fd1015ef8ac1e4723750eeb"
 CHKUPDATE="anitya::id=381"

--- a/runtime-optenv32/curl+32/spec
+++ b/runtime-optenv32/curl+32/spec
@@ -1,5 +1,4 @@
-VER=8.4.0
-SRCS="tbl::https://curl.se/download/curl-$VER.tar.bz2"
-CHKSUMS="sha256::e5250581a9c032b1b6ed3cf2f9c114c811fc41881069e9892d115cc73f9e88c6"
+VER=8.5.0
+SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
+CHKSUMS="sha256::42ab8db9e20d8290a3b633e7fbb3cec15db34df65fd1015ef8ac1e4723750eeb"
 CHKUPDATE="anitya::id=381"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- curl{,+32}: security update to 8.5.0

Package(s) Affected
-------------------

- curl: 8.5.0
- curl+32: 8.5.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit curl curl+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
