### PR TITLE
nghttp2: security update to 1.58.0

### DIFF
--- a/runtime-web/nghttp2/autobuild/defines
+++ b/runtime-web/nghttp2/autobuild/defines
@@ -34,7 +34,7 @@ AB_FLAGS_PIE=0
 
 # Note: --enable-debug turns on debug output.
 #       --disable-failmalloc disables a test program.
-#       --enable-http3 is experimental (as of 1.51.0).
+#       --enable-http3 is experimental (as of 1.58.0).
 #
 # FIXME: --disable-examples to skip broken examples (event.h incompatibility).
 AUTOTOOLS_AFTER="--disable-werror \

--- a/runtime-web/nghttp2/spec
+++ b/runtime-web/nghttp2/spec
@@ -1,5 +1,4 @@
-VER=1.56.0
-REL=1
+VER=1.58.0
 SRCS="tbl::https://github.com/nghttp2/nghttp2/releases/download/v$VER/nghttp2-$VER.tar.xz"
-CHKSUMS="sha256::65eee8021e9d3620589a4a4e91ce9983d802b5229f78f3313770e13f4d2720e9"
+CHKSUMS="sha256::4a68a3040da92fd9872c056d0f6b0cd60de8410de10b578f8ade9ecc14d297e0"
 CHKUPDATE="anitya::id=8651"


### PR DESCRIPTION
Topic Description
-----------------

- nghttp2: security update to 1.58.0
    - Closes #5170.

Package(s) Affected
-------------------

- nghttp2: 1.58.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit nghttp2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
