### PR TITLE
ca-certs: update to 20231115

### DIFF
--- a/runtime-data/ca-certs/spec
+++ b/runtime-data/ca-certs/spec
@@ -1,4 +1,4 @@
-VER=20230112
-CERTHASH=733f1a8320b0a2312ab810b634a7379e670c4165
-SRCS="file::rename=certdata.txt::https://hg.mozilla.org/releases/mozilla-release/raw-file/942659c9c79f11313505137bdbf74324cf74d0a4/security/nss/lib/ckfw/builtins/certdata.txt"
-CHKSUMS="sha256::90c470e705b4b5f36f09684dc50e2b79c8b86989a848b62cd1a7bd6460ee65f6"
+VER=20231115
+CHANGESET=a3dd112b0ed075be924f114a490abaeb9d7c3cd6
+SRCS="file::rename=certdata.txt::https://hg.mozilla.org/mozilla-central/raw-file/$CHANGESET/security/nss/lib/ckfw/builtins/certdata.txt"
+CHKSUMS="sha256::1970dd65858925d68498d2356aea6d03f764422523c5887deca8ce3ba9e1f845"


### PR DESCRIPTION
Topic Description
-----------------

- ca-certs: update to 20231115

Package(s) Affected
-------------------

- ca-certs: 20230112

Security Update?
----------------

No

Build Order
-----------

```
#buildit ca-certs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
