### PR TITLE
autobuild3: update to 1.9.0

### DIFF
--- a/app-devel/autobuild3/spec
+++ b/app-devel/autobuild3/spec
@@ -1,4 +1,4 @@
-VER=1.8.7
+VER=1.9.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild3: update to 1.9.0

Package(s) Affected
-------------------

- autobuild3: 2:1.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
