### PR TITLE
cyrus-sasl (libsasl2): fix sover compatibility and symbol versioning

### DIFF
--- a/app-network/cyrus-sasl/autobuild/beyond
+++ b/app-network/cyrus-sasl/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Creating a compatibility symlink for sover 2 ..."
+ln -sv libsasl2.so.3 \
+    "$PKGDIR"/usr/lib/libsasl2.so.2

--- a/app-network/cyrus-sasl/autobuild/patches/0003-Debian-Make-the-libsasl2-symbols-versioned.patch
+++ b/app-network/cyrus-sasl/autobuild/patches/0003-Debian-Make-the-libsasl2-symbols-versioned.patch
@@ -1,0 +1,38 @@
+From: Debian Cyrus SASL Team
+ <pkg-cyrus-sasl2-debian-devel@lists.alioth.debian.org>
+Date: Thu, 24 Mar 2016 11:35:02 +0100
+Subject: Make the libsasl2 symbols versioned
+
+---
+ Versions        | 7 +++++++
+ lib/Makefile.am | 3 ++-
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+ create mode 100644 Versions
+
+diff --git a/Versions b/Versions
+new file mode 100644
+index 0000000..f803d00
+--- /dev/null
++++ b/Versions
+@@ -0,0 +1,7 @@
++SASL2 {
++    global:
++        sasl_*; prop_*; auxprop_plugin_info; _sasl_MD5*;
++};
++
++HIDDEN { local: __*; _rest*; _save*; *; };
++
+diff --git a/lib/Makefile.am b/lib/Makefile.am
+index 72ada6d..c2dfbf7 100644
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -79,7 +79,8 @@ libobj_la_SOURCES =
+ libobj_la_LIBADD = $(LTLIBOBJS)
+ 
+ libsasl2_la_SOURCES = $(common_sources) $(common_headers)
+-libsasl2_la_LDFLAGS = -version-info $(sasl_version) -no-undefined
++libsasl2_la_LDFLAGS = -version-info $(sasl_version) -no-undefined -Wl,--version-script=$(top_srcdir)/Versions
++libsasl2_la_DEPENDENCIES = $(LTLIBOBJS) $(top_srcdir)/Versions
+ 
+ libsasl2_la_LIBADD = $(SASL_DL_LIB) $(SASL_STATIC_LIBS) $(LIB_SOCKET) $(LIB_DOOR) $(PLUGIN_COMMON_OBJS) -lcrypto
+ if BUILD_LIBOBJ

--- a/app-network/cyrus-sasl/spec
+++ b/app-network/cyrus-sasl/spec
@@ -1,5 +1,5 @@
 VER=2.1.27
-REL=6
+REL=7
 SRCS="tbl::https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-$VER/cyrus-sasl-$VER.tar.gz"
 CHKSUMS="sha256::26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5"
 CHKUPDATE="anitya::id=13280"


### PR DESCRIPTION
Topic Description
-----------------

- cyrus-sasl: (Debian patches) enable symbol versioning; add symlink for sover 2

Package(s) Affected
-------------------

- cyrus-sasl: 2.1.27-7

Security Update?
----------------

No

Build Order
-----------

```
#buildit cyrus-sasl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
