### PR TITLE
sdl-gfx: (loongarch64) fix build

### DIFF
--- a/runtime-multimedia/sdl-gfx/autobuild/defines
+++ b/runtime-multimedia/sdl-gfx/autobuild/defines
@@ -3,12 +3,7 @@ PKGSEC=libs
 PKGDEP="sdl"
 PKGDES="SDL Graphic Primitives"
 
-AUTOTOOLS_AFTER__ARM64=" \
+AUTOTOOLS_AFTER="--enable-mmx=no"
+AUTOTOOLS_AFTER__AMD64=" \
                  ${AUTOTOOLS_AFTER} \
-                 --enable-mmx=no"
-AUTOTOOLS_AFTER__LOONGSON3=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --enable-mmx=no"
-AUTOTOOLS_AFTER__PPC64EL=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --enable-mmx=no"
+                 --enable-mmx=yes"

--- a/runtime-multimedia/sdl-gfx/spec
+++ b/runtime-multimedia/sdl-gfx/spec
@@ -1,5 +1,5 @@
 VER=2.0.25
-REL=3
+REL=4
 SRCS="tbl::https://www.ferzkopp.net/Software/SDL_gfx-2.0/SDL_gfx-$VER.tar.gz"
 CHKSUMS="sha256::556eedc06b6cf29eb495b6d27f2dcc51bf909ad82389ba2fa7bdc4dec89059c0"
 CHKUPDATE="anitya::id=4778"


### PR DESCRIPTION
Topic Description
-----------------

- sdl-gfx: (loongarch64) fix build

Package(s) Affected
-------------------

- sdl-gfx: 2.0.25-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit sdl-gfx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
