### PR TITLE
sdcc: fix parallelism breaking build

### DIFF
--- a/app-devel/sdcc/autobuild/defines
+++ b/app-devel/sdcc/autobuild/defines
@@ -6,6 +6,8 @@ PKGDES="Small Device C Compiler, a C compiler suite that targets several microco
 ABSHADOW=0
 AB_FLAGS_FTF=0
 AUTOTOOLS_STRICT=0
+#FIXME: Parallelism breaks build.
+NOPARALLEL=1
 # Should we split the non-free part into another package?
 AUTOTOOLS_AFTER="--disable-shared \
                  --disable-non-free"


### PR DESCRIPTION
Topic Description
-----------------

- sdcc: fix parallelism breaking build.

Package(s) Affected
-------------------

- sdcc: 4.3.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit sdcc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
