### PR TITLE
mirrormgr: update to 0.10.0

### DIFF
--- a/app-admin/mirrormgr/autobuild/beyond
+++ b/app-admin/mirrormgr/autobuild/beyond
@@ -11,6 +11,8 @@ abinfo "Installing bash completions ..."
 install -dv "$PKGDIR"/usr/share/bash-completion/completions/
 install -Dvm644 "$SRCDIR"/completions/mirrormgr.bash "$PKGDIR"/usr/share/bash-completion/completions/
 
-abinfo "Symlink to oma mirror ..."
+abinfo "Symlink to oma mirror(s) ..."
 mkdir -pv "$PKGDIR"/usr/libexec
 ln -sv ../bin/mirrormgr "$PKGDIR"/usr/libexec/oma-mirror
+ln -sv ../bin/mirrormgr "$PKGDIR"/usr/libexec/oma-mirrors
+

--- a/app-admin/mirrormgr/spec
+++ b/app-admin/mirrormgr/spec
@@ -1,4 +1,4 @@
-VER="0.8.3"
+VER="0.10.0"
 SRCS="git::commit=tags/v${VER/\~beta/-beta}::https://github.com/AOSC-Dev/mirrormgr"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226680"


### PR DESCRIPTION
Topic Description
-----------------

- mirrormgr: update to 0.10.0
    - Add symlink to /usr/libexec/oma-mirrors

Package(s) Affected
-------------------

- mirrormgr: 0.8.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit mirrormgr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
