### PR TITLE
discord: update to 0.0.41

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.40
+VER=0.0.41
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::90a59b0f67ef46afbb567384ded110d4b7869de64e41f0ffefd6c6dae125612c"
+CHKSUMS="sha256::cb308e958203bdb84945b8aa7f9342da2053d9ece524ff353bfc2d916204a7e5"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- discord: update to 0.0.41

Package(s) Affected
-------------------

- discord: 0.0.41

Security Update?
----------------

No

Build Order
-----------

```
#buildit discord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
