### PR TITLE
gstreamer: fix mips64r6el build

### DIFF
--- a/runtime-multimedia/gstreamer/autobuild/defines
+++ b/runtime-multimedia/gstreamer/autobuild/defines
@@ -30,6 +30,8 @@ BUILDDEP__RISCV64="${BUILDDEP/mono/}"
 BUILDDEP__MIPS64R6EL="${BUILDDEP/mono/}"
 # FIXME: Cargo-c fails to build.
 BUILDDEP__MIPS64R6EL="${BUILDDEP__MIPS64R6EL/cargo-c/}"
+# FIXME: rustc fails to build.
+BUILDDEP__MIPS64R6EL="${BUILDDEP__MIPS64R6EL/rustc/}"
 PKGDES="A modular and extensible multimedia framework"
 
 PKGBREAK="gst-editing-services<=1.18.4-1 gst-libav-1-0<=1.18.4 \
@@ -99,4 +101,5 @@ MESON_AFTER__RISCV64=" \
              -Dsharp=disabled \
              -Drs=disabled"
 
+ABTYPE=meson
 NOLTO=1

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,5 @@
 VER=1.22.0
-REL=3
+REL=4
 SRCS="tbl::https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/$VER/gstreamer-$VER.tar.gz"
 CHKSUMS="sha256::5de8dcf5cc1ae26b3177b7dddbea7943e376cd5ca35d4cb7b43616e6d30b1854"
 CHKUPDATE="anitya::id=1263"


### PR DESCRIPTION
Topic Description
-----------------

- gstreamer: fix mips64r6el build
Turn off Rustc support under mips64r6el architecture.

Package(s) Affected
-------------------

- gstreamer: 1.22.0-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit gstreamer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
