### PR TITLE
xfsprogs: update to 6.5.0

### DIFF
--- a/app-admin/xfsprogs/spec
+++ b/app-admin/xfsprogs/spec
@@ -1,5 +1,4 @@
-VER=6.0.0
-REL=1
+VER=6.5.0
 SRCS="https://www.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-$VER.tar.xz"
-CHKSUMS="sha256::b77cec2364aab0b8ae8d8c67daac7fdb3801e0979f1d8328d9c3469e57ca9ca0"
+CHKSUMS="sha256::8db81712b32756b97d89dd9a681ac5e325bbb75e585382cd4863fab7f9d021c6"
 CHKUPDATE="anitya::id=5188"


### PR DESCRIPTION
Topic Description
-----------------

- xfsprogs: update to 6.5.0

Package(s) Affected
-------------------

- xfsprogs: 6.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xfsprogs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
