### PR TITLE
gpgme update to 1.23.2

### DIFF
--- a/runtime-cryptography/gpgme/spec
+++ b/runtime-cryptography/gpgme/spec
@@ -1,4 +1,4 @@
-VER=1.18.0
+VER=1.23.2
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-$VER.tar.bz2"
-CHKSUMS="sha256::361d4eae47ce925dba0ea569af40e7b52c645c4ae2e65e5621bf1b6cdd8b0e9e"
+CHKSUMS="sha256::9499e8b1f33cccb6815527a1bc16049d35a6198a6c5fae0185f2bd561bce5224"
 CHKUPDATE="anitya::id=1239"


### PR DESCRIPTION
Topic Description
-----------------

- gpgme: update to 1.23.2

Package(s) Affected
-------------------

- gpgme: 1.23.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gpgme
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
