### PR TITLE
lincity-ng: update to 2.9.0

### DIFF
--- a/app-games/lincity-ng/autobuild/build
+++ b/app-games/lincity-ng/autobuild/build
@@ -1,3 +1,16 @@
-./configure --prefix=/usr
+abinfo "Generating configure script ..."
+"$SRCDIR"/autogen.sh
+
+abinfo "Configuring lincity-ng ..."
+"$SRCDIR"/configure \
+    --prefix=/usr
+
+abinfo "Building lincity-ng ..."
 jam
+
+abinfo "Installing lincity-ng..."
 jam install -sprefix="$PKGDIR"/usr
+
+abinfo "Installing CJK fonts..."
+ln -sv ../../fonts/TTF/NotoSansCJK-Regular.ttc "$PKGDIR"/usr/share/lincity-ng/fonts/sans-zh.ttf
+ln -sv ../../fonts/TTF/NotoSansCJK-Regular.ttc "$PKGDIR"/usr/share/lincity-ng/fonts/sans-ja.ttf 

--- a/app-games/lincity-ng/autobuild/defines
+++ b/app-games/lincity-ng/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=lincity-ng
 PKGSEC=games
-PKGDEP="physfs sdl-gfx sdl-image sdl-mixer sdl-ttf"
+PKGDEP="physfs sdl2-gfx sdl2-image sdl2-mixer sdl2-ttf noto-cjk-fonts"
 BUILDDEP="ftjam glu"
 PKGDES="A city simulation game"

--- a/app-games/lincity-ng/autobuild/patches/0001-fix-build.patch
+++ b/app-games/lincity-ng/autobuild/patches/0001-fix-build.patch
@@ -1,0 +1,14 @@
+diff -urN a/Jamfile b/Jamfile
+--- a/Jamfile	2023-12-18 21:07:44.000000000 +0800
++++ b/Jamfile	2024-01-22 16:11:28.193486960 +0800
+@@ -16,8 +16,8 @@
+ }
+ 
+ # add some additional files to package
+-Package README README-Unlimited README-WaterWell RELNOTES TODO COPYING COPYING-data.txt COPYING-fonts.txt CREDITS ;
+-InstallDoc README README-Unlimited README-WaterWell RELNOTES TODO COPYING COPYING-data.txt COPYING-fonts.txt CREDITS ;
++Package README README-Unlimited README-WaterWell RELNOTES TODO COPYING COPYING-data.txt COPYING-fonts.txt ;
++InstallDoc README README-Unlimited README-WaterWell RELNOTES TODO COPYING COPYING-data.txt COPYING-fonts.txt ;
+ 
+ InstallDesktop lincity-ng.desktop ;
+ InstallPixmap data/lincity-ng.png ;

--- a/app-games/lincity-ng/autobuild/prepare
+++ b/app-games/lincity-ng/autobuild/prepare
@@ -1,3 +1,4 @@
-for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
-    cp -v /usr/share/automake-1.16/$(basename $i) $i ; \
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do
+    abinfo "Copying replacement $i ..."
+    cp -v /usr/bin/$(basename $i) $i
 done

--- a/app-games/lincity-ng/spec
+++ b/app-games/lincity-ng/spec
@@ -1,5 +1,4 @@
-VER=2.0
-REL=2
-SRCS="tbl::https://sourceforge.net/projects/lincity-ng.berlios/files/lincity-ng-$VER.tar.bz2"
-CHKSUMS="sha256::a6b206a5dfc7a817669f4fc7cbc012bd4a7073c42f918ceb2f1f484cc0b06606"
+VER=2.9.0
+SRCS="git::commit=tags/lincity-ng-$VER::https://github.com/lincity-ng/lincity-ng.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8576"

--- a/runtime-multimedia/sdl2-gfx/autobuild/defines
+++ b/runtime-multimedia/sdl2-gfx/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=sdl2-gfx
+PKGSEC=libs
+PKGDEP="sdl2"
+PKGDES="SDL Graphic Primitives (version 2)"
+
+AUTOTOOLS_AFTER="--enable-mmx=no"
+AUTOTOOLS_AFTER__AMD64=" \
+                 ${AUTOTOOLS_AFTER} \
+                 --enable-mmx=yes"

--- a/runtime-multimedia/sdl2-gfx/spec
+++ b/runtime-multimedia/sdl2-gfx/spec
@@ -1,0 +1,4 @@
+VER=1.0.4
+SRCS="tbl::https://www.ferzkopp.net/Software/SDL2_gfx/SDL2_gfx-$VER.tar.gz"
+CHKSUMS="sha256::63e0e01addedc9df2f85b93a248f06e8a04affa014a835c2ea34bfe34e576262"
+CHKUPDATE="anitya::id=4780"


### PR DESCRIPTION
Topic Description
-----------------

- lincity-ng: fix CJK issue

- lincity-ng: fix file loss on installing

- lincity-ng: lint scripts

- sdl2-gfx: new, 1.0.4

- lincity-ng: update to 2.9.0

Package(s) Affected
-------------------

- lincity-ng: 2.9.0
- sdl2-gfx: 1.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit sdl2-gfx lincity-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
