### PR TITLE
chore: demote MIPS64 R6 to experimental

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -57,12 +57,17 @@ Test Build(s) Done
 
 <!-- Please remove any architecture to which this topic does not apply. -->
 
-Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.
+Architectural progress for secondary ports does not impede on merging of this topic.
 
 - [ ] Loongson 3 `loongson3`
-- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
 - [ ] PowerPC 64-bit (Little Endian) `ppc64el`
 - [ ] RISC-V 64-bit `riscv64`
+
+**Experimental Architectures**
+
+Architectural progress for experimental ports does not impede on merging of this topic.
+
+- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
 
 <!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->
 


### PR DESCRIPTION
Per the title. 