### PR TITLE
noto-fonts: remove COLRv1 emoji fonts

### DIFF
--- a/desktop-fonts/noto-fonts/01-noto/build
+++ b/desktop-fonts/noto-fonts/01-noto/build
@@ -9,7 +9,7 @@ install -Dvm644 "$SRCDIR"/notofonts.github.io-noto-monthly-release-${PKGVER%%+*}
     "$PKGDIR"/usr/share/doc/noto-fonts/LICENSE
 
 abinfo "Installing Noto Emoji ..."
-install -Dvm644 "$SRCDIR"/noto-emoji-*/fonts/!(*Windows*) \
+install -Dvm644 "$SRCDIR"/noto-emoji-*/fonts/!(*COLR*|*Windows*) \
     -t "$PKGDIR"/usr/share/fonts/TTF/
 
 abinfo "Installing license (Noto, Emoji) ..."

--- a/desktop-fonts/noto-fonts/spec
+++ b/desktop-fonts/noto-fonts/spec
@@ -2,6 +2,7 @@
 # https://github.com/notofonts/notofonts.github.io/.
 EMOJIVER=2.042
 VER=24.1.1+emoji${EMOJIVER}+cjksans2.004+cjkserif2.002
+REL=1
 # Note: We don't use the tags any more, since it's easier to install from a
 # Git repository.
 # CJKSANSVER=${VER:24:5}


### PR DESCRIPTION
Topic Description
-----------------

- noto-fonts: skip all COLR variants of Noto Color Emoji
    Before native apps start to adopt this format for emoji.

Package(s) Affected
-------------------

- noto-fonts: 24.1.1+emoji2.042+cjksans2.004+cjkserif2.002-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit noto-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
