### PR TITLE
libcue: update to 2.3.0

### DIFF
--- a/runtime-multimedia/libcue/spec
+++ b/runtime-multimedia/libcue/spec
@@ -1,5 +1,4 @@
-VER=2.2.1
-REL=1
-SRCS="tbl::https://github.com/lipnitsk/libcue/archive/v$VER.tar.gz"
-CHKSUMS="sha256::f27bc3ebb2e892cd9d32a7bee6d84576a60f955f29f748b9b487b173712f1200"
+VER=2.3.0
+SRCS="git::commit=tags/v$VER::https://github.com/lipnitsk/libcue"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1585"


### PR DESCRIPTION
Topic Description
-----------------

- libcue: update to 2.3.0

Package(s) Affected
-------------------

- libcue: 2.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcue
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
