### PR TITLE
fwupd: update to 1.9.12

### DIFF
--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -17,10 +17,14 @@ BUILDDEP__MIPS64R6EL="${BUILDDEP/gnu-efi/}"
 BUILDDEP__RISCV64="${BUILDDEP/valgrind/}"
 PKGDES="Firmware update daemon and utilities"
 
+# FIXME: plugin_redfish breaks fwupd service.
+#
+# Failed to load daemon: failed to load engine: Failed to load config: Key
+# file does not have group “redfish”.
 MESON_AFTER="-Dman=true \
              -Dplugin_modem_manager=enabled \
              -Dplugin_nvme=enabled \
-             -Dplugin_redfish=enabled \
+             -Dplugin_redfish=disabled \
              -Dsystemd=enabled \
              -Dconsolekit=enabled \
              -Dtests=false"

--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,4 @@
-VER=1.9.11
+VER=1.9.12
 SRCS="git::commit=tags/$VER::https://github.com/hughsie/fwupd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5833"


### PR DESCRIPTION
Topic Description
-----------------

- fwupd: update to 1.9.12

Package(s) Affected
-------------------

- fwupd: 1.9.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
