### PR TITLE
LATX (Loongson Architecture Translator for x86): update to update to 1.4.4+emukit20231027

### DIFF
--- a/app-emulation/latx/autobuild/build
+++ b/app-emulation/latx/autobuild/build
@@ -7,9 +7,9 @@ mkdir -pv "$PKGDIR"/usr/gnemul
 # FIXME: unsquashfs would return an error regarding /dev/console since we are
 # building this package in nspawn.
 unsquashfs \
-    -d "$PKGDIR"/usr/gnemul/latx-x86_64 \
+    -d "$PKGDIR"/usr/gnemul/lat-x86_64 \
     "$SRCDIR"/amd64.squashfs || true
 
 abinfo "Creating a symlink for i386 sysroot ..."
-ln -sv latx-x86_64 \
-    "$PKGDIR"/usr/gnemul/latx-i386
+ln -sv lat-x86_64 \
+    "$PKGDIR"/usr/gnemul/lat-i386

--- a/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system-preset/50-latx.preset
+++ b/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system-preset/50-latx.preset
@@ -1,8 +1,8 @@
-enable usr-gnemul-latx\x2dx86_64-dev.mount
-enable usr-gnemul-latx\x2dx86_64-etc.mount
-enable usr-gnemul-latx\x2dx86_64-proc.mount
-enable usr-gnemul-latx\x2dx86_64-run.mount
-enable usr-gnemul-latx\x2dx86_64-sys.mount
-enable usr-gnemul-latx\x2dx86_64-usr-share-fontconfig.mount
-enable usr-gnemul-latx\x2dx86_64-usr-share-fonts.mount
-enable usr-gnemul-latx\x2dx86_64-usr-share-icons.mount
+enable usr-gnemul-lat\x2dx86_64-dev.mount
+enable usr-gnemul-lat\x2dx86_64-etc.mount
+enable usr-gnemul-lat\x2dx86_64-proc.mount
+enable usr-gnemul-lat\x2dx86_64-run.mount
+enable usr-gnemul-lat\x2dx86_64-sys.mount
+enable usr-gnemul-lat\x2dx86_64-usr-share-fontconfig.mount
+enable usr-gnemul-lat\x2dx86_64-usr-share-fonts.mount
+enable usr-gnemul-lat\x2dx86_64-usr-share-icons.mount

--- a/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-dev.mount
+++ b/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-dev.mount
@@ -3,7 +3,7 @@ Description=Mount /dev for the LATX runtime
 
 [Mount]
 What=/dev
-Where=/usr/gnemul/latx-x86_64/dev
+Where=/usr/gnemul/lat-x86_64/dev
 Type=none
 Options=bind
 LazyUnmount=true

--- a/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-etc.mount
+++ b/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-etc.mount
@@ -3,7 +3,7 @@ Description=Mount /etc for the LATX runtime
 
 [Mount]
 What=/etc
-Where=/usr/gnemul/latx-x86_64/etc
+Where=/usr/gnemul/lat-x86_64/etc
 Type=none
 Options=bind,ro
 LazyUnmount=true

--- a/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-proc.mount
+++ b/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-proc.mount
@@ -1,9 +1,9 @@
 [Unit]
-Description=Mount /sys for the LATX runtime
+Description=Mount /proc for the LATX runtime
 
 [Mount]
-What=/sys
-Where=/usr/gnemul/latx-x86_64/sys
+What=/proc
+Where=/usr/gnemul/lat-x86_64/proc
 Type=none
 Options=bind
 LazyUnmount=true

--- a/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-run.mount
+++ b/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-run.mount
@@ -3,7 +3,7 @@ Description=Mount /run for the LATX runtime
 
 [Mount]
 What=/run
-Where=/usr/gnemul/latx-x86_64/run
+Where=/usr/gnemul/lat-x86_64/run
 Type=none
 Options=bind
 LazyUnmount=true

--- a/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-sys.mount
+++ b/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-sys.mount
@@ -1,9 +1,9 @@
 [Unit]
-Description=Mount /proc for the LATX runtime
+Description=Mount /sys for the LATX runtime
 
 [Mount]
-What=/proc
-Where=/usr/gnemul/latx-x86_64/proc
+What=/sys
+Where=/usr/gnemul/lat-x86_64/sys
 Type=none
 Options=bind
 LazyUnmount=true

--- a/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-usr-share-fontconfig.mount
+++ b/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-usr-share-fontconfig.mount
@@ -3,7 +3,7 @@ Description=Mount /usr/share/fontconfig for the LATX runtime
 
 [Mount]
 What=/usr/share/fontconfig
-Where=/usr/gnemul/latx-x86_64/usr/share/fontconfig
+Where=/usr/gnemul/lat-x86_64/usr/share/fontconfig
 Type=none
 Options=bind,ro
 LazyUnmount=true

--- a/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-usr-share-fonts.mount
+++ b/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-usr-share-fonts.mount
@@ -3,7 +3,7 @@ Description=Mount /usr/share/fonts for the LATX runtime
 
 [Mount]
 What=/usr/share/fonts
-Where=/usr/gnemul/latx-x86_64/usr/share/fonts
+Where=/usr/gnemul/lat-x86_64/usr/share/fonts
 Type=none
 Options=bind,ro
 LazyUnmount=true

--- a/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-usr-share-icons.mount
+++ b/app-emulation/latx/autobuild/overrides/usr/lib/systemd/system/usr-gnemul-lat\x2dx86_64-usr-share-icons.mount
@@ -3,7 +3,7 @@ Description=Mount /usr/share/icons for the LATX runtime
 
 [Mount]
 What=/usr/share/icons
-Where=/usr/gnemul/latx-x86_64/usr/share/icons
+Where=/usr/gnemul/lat-x86_64/usr/share/icons
 Type=none
 Options=bind,ro
 LazyUnmount=true

--- a/app-emulation/latx/autobuild/postinst
+++ b/app-emulation/latx/autobuild/postinst
@@ -1,24 +1,27 @@
 echo "Loading sysctl profile for LAT (x86) ..."
-sysctl -p /usr/lib/sysctl.d/99-latx.conf
+sysctl -p /usr/lib/sysctl.d/99-lat.conf
 
 echo "Enabling mount targets ..."
-systemctl preset 'usr-gnemul-latx\x2dx86_64-dev.mount'
-systemctl preset 'usr-gnemul-latx\x2dx86_64-etc.mount'
-systemctl preset 'usr-gnemul-latx\x2dx86_64-proc.mount'
-systemctl preset 'usr-gnemul-latx\x2dx86_64-run.mount'
-systemctl preset 'usr-gnemul-latx\x2dx86_64-sys.mount'
-systemctl preset 'usr-gnemul-latx\x2dx86_64-usr-share-fontconfig.mount'
-systemctl preset 'usr-gnemul-latx\x2dx86_64-usr-share-fonts.mount'
-systemctl preset 'usr-gnemul-latx\x2dx86_64-usr-share-icons.mount'
+systemctl preset 'usr-gnemul-lat\x2dx86_64-dev.mount'
+systemctl preset 'usr-gnemul-lat\x2dx86_64-etc.mount'
+systemctl preset 'usr-gnemul-lat\x2dx86_64-proc.mount'
+systemctl preset 'usr-gnemul-lat\x2dx86_64-run.mount'
+systemctl preset 'usr-gnemul-lat\x2dx86_64-sys.mount'
+systemctl preset 'usr-gnemul-lat\x2dx86_64-usr-share-fontconfig.mount'
+systemctl preset 'usr-gnemul-lat\x2dx86_64-usr-share-fonts.mount'
+systemctl preset 'usr-gnemul-lat\x2dx86_64-usr-share-icons.mount'
 
 if ! systemd-detect-virt --container; then
+    echo "Reloading systemd daemon ..."
+    systemctl daemon-reload
+
     echo "Applying mount targets ..."
-    systemctl start 'usr-gnemul-latx\x2dx86_64-dev.mount'
-    systemctl start 'usr-gnemul-latx\x2dx86_64-etc.mount'
-    systemctl start 'usr-gnemul-latx\x2dx86_64-proc.mount'
-    systemctl start 'usr-gnemul-latx\x2dx86_64-run.mount'
-    systemctl start 'usr-gnemul-latx\x2dx86_64-sys.mount'
-    systemctl start 'usr-gnemul-latx\x2dx86_64-usr-share-fontconfig.mount'
-    systemctl start 'usr-gnemul-latx\x2dx86_64-usr-share-fonts.mount'
-    systemctl start 'usr-gnemul-latx\x2dx86_64-usr-share-icons.mount'
+    systemctl start 'usr-gnemul-lat\x2dx86_64-dev.mount'
+    systemctl start 'usr-gnemul-lat\x2dx86_64-etc.mount'
+    systemctl start 'usr-gnemul-lat\x2dx86_64-proc.mount'
+    systemctl start 'usr-gnemul-lat\x2dx86_64-run.mount'
+    systemctl start 'usr-gnemul-lat\x2dx86_64-sys.mount'
+    systemctl start 'usr-gnemul-lat\x2dx86_64-usr-share-fontconfig.mount'
+    systemctl start 'usr-gnemul-lat\x2dx86_64-usr-share-fonts.mount'
+    systemctl start 'usr-gnemul-lat\x2dx86_64-usr-share-icons.mount'
 fi

--- a/app-emulation/latx/autobuild/postrm
+++ b/app-emulation/latx/autobuild/postrm
@@ -1,3 +1,0 @@
-echo "Removing sysroots ..."
-rm -r /usr/gnemul/latx-x86_64
-rm /usr/gnemul/latx-i386

--- a/app-emulation/latx/autobuild/prerm
+++ b/app-emulation/latx/autobuild/prerm
@@ -1,11 +1,12 @@
-if ! systemd-detect-virt --container; then
-    echo "Stopping mount targets ..."
-    systemctl stop 'usr-gnemul-latx\x2dx86_64-dev.mount'
-    systemctl stop 'usr-gnemul-latx\x2dx86_64-etc.mount'
-    systemctl stop 'usr-gnemul-latx\x2dx86_64-proc.mount'
-    systemctl stop 'usr-gnemul-latx\x2dx86_64-run.mount'
-    systemctl stop 'usr-gnemul-latx\x2dx86_64-sys.mount'
-    systemctl stop 'usr-gnemul-latx\x2dx86_64-usr-share-fontconfig.mount'
-    systemctl stop 'usr-gnemul-latx\x2dx86_64-usr-share-fonts.mount'
-    systemctl stop 'usr-gnemul-latx\x2dx86_64-usr-share-icons.mount'
-fi
+for i in dev etc proc run sys usr/share/fontconfig usr/share/fonts usr/share/icons; do
+    echo "Unmounting /$i in the LATX runtime ..."
+    if [ -d /usr/gnemul/latx-x86_64 ]; then
+        umount -lf /usr/gnemul/latx-x86_64/$i
+    elif [ -d /usr/gnemul/lat-x86_64 ]; then
+        umount -lf /usr/gnemul/lat-x86_64/$i
+    fi
+done
+
+echo "Removing sysroots ..."
+rm -rf /usr/gnemul/lat{,x}-x86_64
+rm -f /usr/gnemul/lat{,x}-i386

--- a/app-emulation/latx/spec
+++ b/app-emulation/latx/spec
@@ -1,7 +1,7 @@
-VER=1.4.3+emukit20231027
+VER=1.4.4+emukit20231027
 SRCS="tbl::https://mirrors.wsyu.edu.cn/loongarch/archlinux/laur/os/loong64/lat-${VER%%+*}-1-loong64.pkg.tar.zst \
       file::rename=amd64.squashfs::https://releases.aosc.io/os-amd64/emukit/aosc-os_emukit_${VER##*+emukit}_amd64.squashfs"
-CHKSUMS="sha256::82b2e932a9e5dd8fea3cf04ec5d921f794e9884070ce3132e2e3468a31812e58 \
+CHKSUMS="sha256::6cf36c201b9304924ef51dab834090b08304b77464faec3b7c7f336d51a3b55c \
          sha256::ca4dfd6186d23b62f2e92dac27d2cbb341566b1ac238347b9b261028fc09a117"
 # FIXME: No valid way to check for version updates.
 # CHKUPDATE=""


### PR DESCRIPTION
Topic Description
-----------------

- latx: update to 1.4.4+emukit20231027
    - Use umount in prerm, as systemd mount units does not umount when stopped.
    - rename latx-* => lat-*.

Package(s) Affected
-------------------

- latx: 1.4.4+emukit20231027

Security Update?
----------------

No

Build Order
-----------

```
#buildit latx
```

Test Build(s) Done
------------------

**Experimental Architectures**

- [x] LoongArch 64-bit `loongarch64`
