### PR TITLE
openssh (OpenSSH): fix LoongArch seccomp architecture

### DIFF
--- a/app-network/openssh/autobuild/patches/0002-Add-seccomp-audit-arch-for-loongarch64.patch
+++ b/app-network/openssh/autobuild/patches/0002-Add-seccomp-audit-arch-for-loongarch64.patch
@@ -1,0 +1,14 @@
+diff --git a/configure.ac b/configure.ac
+index 379cd746b..c0f7aeb69 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1013,6 +1013,9 @@ int main(void) { if (NSVersionOfRunTimeLibrary("System") >= (60 << 16))
+ 	riscv64-*)
+ 		seccomp_audit_arch=AUDIT_ARCH_RISCV64
+ 		;;
++	loongarch64-*)
++		seccomp_audit_arch=AUDIT_ARCH_LOONGARCH64
++		;;
+ 	esac
+ 	if test "x$seccomp_audit_arch" != "x" ; then
+ 		AC_MSG_RESULT(["$seccomp_audit_arch"])


### PR DESCRIPTION
Topic Description
-----------------

- openssh: (loongarch64) fix seccomp arch

Package(s) Affected
-------------------

- openssh: 9.6p1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Experimental Architectures**

- [ ] LoongArch 64-bit `loongarch64`
