### PR TITLE
docker: support loongarch

### DIFF
--- a/app-admin/criu/autobuild/build
+++ b/app-admin/criu/autobuild/build
@@ -1,7 +1,12 @@
-abinfo "Installing files ..."
+abinfo "Building criu ..."
+make PREFIX=/usr \
+    ${MAKE_AFTER}
+
+abinfo "Installing criu ..."
 make install-criu DESTDIR="$PKGDIR" PREFIX=/usr LIBDIR=/usr/lib
 make install-lib DESTDIR="$PKGDIR" PREFIX=/usr LIBDIR=/usr/lib PYTHON=python3
 
 abinfo "Moving sbin to bin ..."
+mkdir -pv "$PKGDIR"/usr/bin
 mv -v "$PKGDIR"/usr/sbin/criu "$PKGDIR"/usr/bin/
-rm -rf "$PKGDIR"/usr/sbin/
+rm -vrf "$PKGDIR"/usr/sbin/

--- a/app-admin/criu/autobuild/defines
+++ b/app-admin/criu/autobuild/defines
@@ -7,3 +7,6 @@ PKGDES="Checkpoint and restore in user space"
 MAKE_AFTER="RUNDIR=/run/criu \
             PYTHON=python3"
 NOLTO=1
+
+# See Makefile `Supported Architectures`
+FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64|loongson3|mips64r6el)"

--- a/app-admin/criu/autobuild/patches/0002-use-longlong-in-this-project.patch.loongson3
+++ b/app-admin/criu/autobuild/patches/0002-use-longlong-in-this-project.patch.loongson3
@@ -1,6 +1,8 @@
---- a/Makefile	2023-09-22 05:46:13.307308089 +0000
-+++ b/Makefile	2023-09-22 05:46:35.565139064 +0000
-@@ -77,7 +77,7 @@
+diff --git a/Makefile b/Makefile
+index 9f0928b01..1a3365b2e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -77,7 +77,7 @@ ifeq ($(ARCH),x86)
  endif
  
  ifeq ($(ARCH),mips)
@@ -8,4 +10,4 @@
 +        DEFINES		:= -DCONFIG_MIPS -D__SANE_USERSPACE_TYPES__
  endif
  
- #
+ ifeq ($(ARCH),loongarch64)

--- a/app-admin/criu/autobuild/prepare
+++ b/app-admin/criu/autobuild/prepare
@@ -8,3 +8,10 @@ if [[ "${CROSS:-$ARCH}" = "loongson3" ]]; then
     abinfo "Disabling stack protector to fix build ..."
     export CFLAGS="${CFLAGS} -fno-stack-protector"
 fi
+
+# On mips64r6el, ld choses the wrong emulation while creating a static library.
+# For this instance, the creation of the static library is invoked by libtool.
+if ab_match_arch mips64r6el ; then
+        abinfo "(mips64r6el) Setting the default ld emulation ..."
+        export LDEMULATION="elf64ltsmip"
+fi

--- a/app-admin/criu/spec
+++ b/app-admin/criu/spec
@@ -1,4 +1,4 @@
-VER=3.18
+VER=3.19
 SRCS="tbl::http://github.com/checkpoint-restore/criu/archive/v$VER/criu-$VER.tar.gz"
-CHKSUMS="sha256::6a9997981c9fe4730c848ce59346b3a22fad69b803607cb67a3f6ec0557fa474"
+CHKSUMS="sha256::990cdd147cb670a5d5d14216c2b5c2fc2b9a53ef19396569a6413807ba2a6aa2"
 CHKUPDATE="anitya::id=366"

--- a/app-admin/runc/autobuild/patches/0001-Add-loong64-support.patch
+++ b/app-admin/runc/autobuild/patches/0001-Add-loong64-support.patch
@@ -1,0 +1,13 @@
+diff --git a/libcontainer/system/syscall_linux_64.go b/libcontainer/system/syscall_linux_64.go
+index 1ed0dba1..262450ad 100644
+--- a/libcontainer/system/syscall_linux_64.go
++++ b/libcontainer/system/syscall_linux_64.go
+@@ -1,6 +1,6 @@
+-//go:build linux && (arm64 || amd64 || mips || mipsle || mips64 || mips64le || ppc || ppc64 || ppc64le || riscv64 || s390x)
++//go:build linux && (arm64 || amd64 || loong64 || mips || mipsle || mips64 || mips64le || ppc || ppc64 || ppc64le || riscv64 || s390x)
+ // +build linux
+-// +build arm64 amd64 mips mipsle mips64 mips64le ppc ppc64 ppc64le riscv64 s390x
++// +build arm64 amd64 loong64 mips mipsle mips64 mips64le ppc ppc64 ppc64le riscv64 s390x
+ 
+ package system
+ 

--- a/app-containers/containerd/autobuild/build
+++ b/app-containers/containerd/autobuild/build
@@ -2,7 +2,7 @@
 abinfo "Building containerd ..."
 make \
     VERSION=v$PKGVER \
-    GO_BUILD_FLAGS="${GOFLAGS}"
+    GO_BUILD_FLAGS="${GOFLAGS} -mod=vendor"
 
 abinfo "Installing containerd ..."
 make install \

--- a/app-containers/containerd/autobuild/patches/0001-Add-loong64-support.patch
+++ b/app-containers/containerd/autobuild/patches/0001-Add-loong64-support.patch
@@ -1,0 +1,12 @@
+diff --git a/vendor/github.com/cilium/ebpf/internal/endian_le.go b/vendor/github.com/cilium/ebpf/internal/endian_le.go
+index 41a68224c..273fad86f 100644
+--- a/vendor/github.com/cilium/ebpf/internal/endian_le.go
++++ b/vendor/github.com/cilium/ebpf/internal/endian_le.go
+@@ -1,5 +1,5 @@
+-//go:build 386 || amd64 || amd64p32 || arm || arm64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64
+-// +build 386 amd64 amd64p32 arm arm64 mipsle mips64le mips64p32le ppc64le riscv64
++//go:build 386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64
++// +build 386 amd64 amd64p32 arm arm64 loong64 mipsle mips64le mips64p32le ppc64le riscv64
+ 
+ package internal
+ 

--- a/app-containers/docker/autobuild/build
+++ b/app-containers/docker/autobuild/build
@@ -16,7 +16,7 @@ go build \
 
 # Fedora: Build tini (installed as docker-init).
 abinfo "tini: Building ..."
-cmake "$SRCDIR"/../tini ${CMAKE_DEF}
+cmake "$SRCDIR"/../tini ${CMAKE_DEF[@]}
 make tini-static 
 
 # Fedora: Build engine.

--- a/app-containers/docker/autobuild/defines
+++ b/app-containers/docker/autobuild/defines
@@ -6,4 +6,4 @@ PKGDES="A tool for deploying applications in containers"
 
 PKGPROV="moby"
 
-FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64)"
+FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64|loongarch64)"

--- a/app-containers/docker/autobuild/patches/0001-Add-loong64-support.patch
+++ b/app-containers/docker/autobuild/patches/0001-Add-loong64-support.patch
@@ -1,0 +1,12 @@
+diff --git a/vendor/github.com/cilium/ebpf/internal/endian_le.go b/vendor/github.com/cilium/ebpf/internal/endian_le.go
+index 41a68224c..273fad86f 100644
+--- a/vendor/github.com/cilium/ebpf/internal/endian_le.go
++++ b/vendor/github.com/cilium/ebpf/internal/endian_le.go
+@@ -1,5 +1,5 @@
+-//go:build 386 || amd64 || amd64p32 || arm || arm64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64
+-// +build 386 amd64 amd64p32 arm arm64 mipsle mips64le mips64p32le ppc64le riscv64
++//go:build 386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64
++// +build 386 amd64 amd64p32 arm arm64 loong64 mipsle mips64le mips64p32le ppc64le riscv64
+ 
+ package internal
+ 


### PR DESCRIPTION
Topic Description
-----------------

- docker: (loongarch64) fix missing syscall

- containerd: (loongarch64) fix missing syscall

- runc: (loongarch64) fix missing syscall

- criu: update to 3.19
    Add FAIL_ARCH

Package(s) Affected
-------------------

- runc: 1.1.10
- criu: 3.19
- containerd: 1.7.10
- docker: 24.0.7+tini0.19.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit criu runc containerd docker
```

Test Build(s) Done
------------------

**Experimental Architectures**

- [ ] LoongArch 64-bit `loongarch64`
