### PR TITLE
Steam: update to 1.0.0.78

### DIFF
--- a/app-games/steam/autobuild/overrides/usr/share/applications/steam.desktop
+++ b/app-games/steam/autobuild/overrides/usr/share/applications/steam.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=Steam
+Comment=Application for accessing service of Steam store
+Exec=env LD_LIBRARY_PATH=/opt/32/lib:/usr/lib /usr/bin/steam %U
+Icon=steam
+Terminal=false
+Type=Application
+Categories=Network;Game;
+MimeType=x-scheme-handler/steam;x-scheme-handler/steamlink;
+
+# Use the most powerful GPU available by default (i.e. a dedicated Nvidia or AMD card instead of the integrated Intel card)
+PrefersNonDefaultGPU=true
+X-KDE-RunOnDiscreteGpu=true

--- a/app-games/steam/spec
+++ b/app-games/steam/spec
@@ -1,4 +1,4 @@
-VER=1.0.0.71
+VER=1.0.0.78
 SRCS="tbl::https://repo.steampowered.com/steam/pool/steam/s/steam/steam_$VER.tar.gz"
-CHKSUMS="sha256::39c33d1999f8cc6d4af696479e1d73eee2e93a217bc45887032e18b33535ca21"
+CHKSUMS="sha256::104259755d7211b5f101db247ff70ebfed6ae6ca3e14da61195d1fbf91c7200d"
 CHKUPDATE="anitya::id=12318"


### PR DESCRIPTION
Topic Description
-----------------

- steam: upadte to 1.0.0.78
    - Overrides steam.desktop by our own one that sets the environment
    variable needed for 32subsystem.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- steam: 1.0.0.78

Security Update?
----------------

No

Build Order
-----------

```
#buildit steam
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
