### PR TITLE
aarty: update to 0.6.1

### DIFF
--- a/app-utils/aarty/spec
+++ b/app-utils/aarty/spec
@@ -1,4 +1,4 @@
-VER=0.4.9
+VER=0.6.1
 SRCS="git::commit=tags/$VER::https://github.com/0x61nas/aarty"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370242"


### PR DESCRIPTION
Topic Description
-----------------

- aarty: update to 0.6.1

Package(s) Affected
-------------------

- aarty: 0.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit aarty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
