### PR TITLE
curl{,+32}: security update to 8.6.0

### DIFF
--- a/app-web/curl/spec
+++ b/app-web/curl/spec
@@ -1,4 +1,4 @@
-VER=8.5.0
+VER=8.6.0
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
-CHKSUMS="sha256::42ab8db9e20d8290a3b633e7fbb3cec15db34df65fd1015ef8ac1e4723750eeb"
+CHKSUMS="sha256::3ccd55d91af9516539df80625f818c734dc6f2ecf9bada33c76765e99121db15"
 CHKUPDATE="anitya::id=381"

--- a/runtime-optenv32/curl+32/autobuild/build
+++ b/runtime-optenv32/curl+32/autobuild/build
@@ -2,6 +2,8 @@ export PATH=/opt/32/bin:$PATH
 export CFLAGS+=" -I/opt/32/include"
 export LDFLAGS+=" -L/opt/32/lib"
 
+# FIXME: enable libpsl support
+# https://daniel.haxx.se/blog/2024/01/10/psl-in-curl/
 ./configure --prefix=/opt/32 --exec-prefix=/opt/32 \
             --libdir=/opt/32/lib --bindir=/opt/32/bin --sbindir=/opt/32/bin \
             --disable-static \
@@ -10,6 +12,7 @@ export LDFLAGS+=" -L/opt/32/lib"
             --enable-threaded-resolver --with-gssapi \
             --without-libidn --with-openssl --with-random=/dev/urandom \
             --with-ca-bundle=/etc/ssl/ca-bundle.crt \
+            --without-libpsl \
             CC=i686-pc-linux-gnu-gcc CXX=i686-pc-linux-gnu-g++ \
             PKG_CONFIG_PATH=/opt/32/lib/pkconfig
 make

--- a/runtime-optenv32/curl+32/spec
+++ b/runtime-optenv32/curl+32/spec
@@ -1,4 +1,4 @@
-VER=8.5.0
+VER=8.6.0
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
-CHKSUMS="sha256::42ab8db9e20d8290a3b633e7fbb3cec15db34df65fd1015ef8ac1e4723750eeb"
+CHKSUMS="sha256::3ccd55d91af9516539df80625f818c734dc6f2ecf9bada33c76765e99121db15"
 CHKUPDATE="anitya::id=381"


### PR DESCRIPTION
Topic Description
-----------------

- curl{,+32}: security update to 8.6.0

Package(s) Affected
-------------------

- curl: 8.6.0
- curl+32: 8.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit curl curl+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
