### PR TITLE
ast-grep: update to 0.18.0

### DIFF
--- a/app-devel/ast-grep/autobuild/beyond
+++ b/app-devel/ast-grep/autobuild/beyond
@@ -1,6 +1,9 @@
 abinfo "Setting asg as ast-grep symlink ..."
 ln -sv ast-grep "$PKGDIR"/usr/bin/asg
 
+abinfo "Removing xtask binary ..."
+rm -fv "$PKGDIR"/usr/bin/xtask
+
 abinfo "Installing completions ..."
 mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions
 "$PKGDIR"/usr/bin/ast-grep completions > "$PKGDIR"/usr/share/bash-completion/completions/ast-grep

--- a/app-devel/ast-grep/spec
+++ b/app-devel/ast-grep/spec
@@ -1,4 +1,4 @@
-VER=0.16.1
+VER=0.18.0
 SRCS="git::commit=tags/$VER::https://github.com/ast-grep/ast-grep"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=361439"


### PR DESCRIPTION
Topic Description
-----------------

- ast-grep: update to 0.18.0

Package(s) Affected
-------------------

- ast-grep: 0.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ast-grep
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
