### PR TITLE
pyrsistent: update to 0.20.0

### DIFF
--- a/lang-python/exceptiongroup/autobuild/defines
+++ b/lang-python/exceptiongroup/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=exceptiongroup
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="wheel python-build python-installer flit-scm"
+PKGDES="Backport of PEP 654 (exception groups)"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/exceptiongroup/spec
+++ b/lang-python/exceptiongroup/spec
@@ -1,0 +1,4 @@
+VER=1.2.0
+SRCS="tbl::https://files.pythonhosted.org/packages/source/e/exceptiongroup/exceptiongroup-$VER.tar.gz"
+CHKSUMS="sha256::91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+CHKUPDATE="anitya::id=245950"

--- a/lang-python/flit-scm/autobuild/defines
+++ b/lang-python/flit-scm/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=flit-scm
+PKGSEC=python
+PKGDEP="setuptools-scm python-3"
+BUILDDEP="wheel python-build python-installer"
+PKGDES="PEP 518 build backend to generate a version file using setuptools_scm"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/flit-scm/spec
+++ b/lang-python/flit-scm/spec
@@ -1,0 +1,4 @@
+VER=1.7.0
+SRCS="tbl::https://files.pythonhosted.org/packages/source/f/flit_scm/flit_scm-$VER.tar.gz"
+CHKSUMS="sha256::961bd6fb24f31bba75333c234145fff88e6de0a90fc0f7e5e7c79deca69f6bb2"
+CHKUPDATE="anitya::id=250223"

--- a/lang-python/hypothesis-python/autobuild/defines
+++ b/lang-python/hypothesis-python/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=hypothesis-python
+PKGSEC=python
+PKGDEP="python-3 attrs exceptiongroup click sortedcontainers"
+BUILDDEP="python-build python-installer wheel"
+PKGDES="A library for property-based testing"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/hypothesis-python/spec
+++ b/lang-python/hypothesis-python/spec
@@ -1,0 +1,4 @@
+VER=6.97.4
+SRCS="tbl::https://files.pythonhosted.org/packages/source/h/hypothesis/hypothesis-$VER.tar.gz"
+CHKSUMS="sha256::28ff724fa81ccc55f64f0f1eb06e4a75db6a195fe0857e9b3184cf4ff613a103"
+CHKUPDATE="anitya::id=27540"

--- a/lang-python/pyrsistent/autobuild/defines
+++ b/lang-python/pyrsistent/autobuild/defines
@@ -1,5 +1,8 @@
 PKGNAME=pyrsistent
 PKGSEC=python
-PKGDEP="six"
-BUILDDEP="setuptools"
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer wheel hypothesis-python"
 PKGDES="Persistent/Functional/Immutable data structures for Python"
+
+NOPYTHON2=1
+ABTYPE=pep517

--- a/lang-python/pyrsistent/spec
+++ b/lang-python/pyrsistent/spec
@@ -1,5 +1,4 @@
-VER=0.16.0
+VER=0.20.0
 SRCS="tbl::https://pypi.io/packages/source/p/pyrsistent/pyrsistent-$VER.tar.gz"
-CHKSUMS="sha256::28669905fe725965daa16184933676547c5bb40a5153055a8dee2a4bd7933ad3"
+CHKSUMS="sha256::4c48f78f62ab596c679086084d0dd13254ae4f3d6c72a83ffdf5ebdef8f265a4"
 CHKUPDATE="anitya::id=19676"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- hypothesis: new,6.97.3
    - New version pyrsistent needs to be tested during the testing period
- pyrsistent: update to 0.20.0

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit flit-scm exceptiongroup hypothesis-python pyrsistent
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
