### PR TITLE
perl (Perl): update to 5.36.3

### DIFF
--- a/lang-perl/perl/autobuild/build
+++ b/lang-perl/perl/autobuild/build
@@ -1,33 +1,37 @@
 abinfo "Configuring Perl..."
-./Configure -des -Dusethreads -Duseshrplib \
-            -Dprefix=/usr -Dvendorprefix=/usr \
-            -Dman1dir=/usr/share/man/man1 \
-            -Dman3dir=/usr/share/man/man3 \
-            -Dprefix=/usr -Dvendorprefix=/usr \
-            -Dprivlib=/usr/share/perl5/core_perl \
-            -Darchlib=/usr/lib/perl5/core_perl \
-            -Dsitelib=/usr/share/perl5/site_perl \
-            -Dsitearch=/usr/lib/perl5/site_perl \
-            -Dvendorlib=/usr/share/perl5/vendor_perl \
-            -Dvendorarch=/usr/lib/perl5/vendor_perl \
-            -Dscriptdir=/usr/bin/core_perl \
-            -Dsitescript=/usr/bin/site_perl \
-            -Dvendorscript=/usr/bin/vendor_perl \
-            -Dinc_version_list=none \
-            -Dcccdlflags="${CFLAGS}" \
-            -Dlddlflags="-shared ${LDFLAGS}" \
-            -Dldflags="${LDFLAGS}" \
-            -Doptimize="${CFLAGS}"
+"$SRCDIR"/Configure \
+    -des -Dusethreads -Duseshrplib \
+    -Dprefix=/usr -Dvendorprefix=/usr \
+    -Dman1dir=/usr/share/man/man1 \
+    -Dman3dir=/usr/share/man/man3 \
+    -Dprefix=/usr -Dvendorprefix=/usr \
+    -Dprivlib=/usr/share/perl5/core_perl \
+    -Darchlib=/usr/lib/perl5/core_perl \
+    -Dsitelib=/usr/share/perl5/site_perl \
+    -Dsitearch=/usr/lib/perl5/site_perl \
+    -Dvendorlib=/usr/share/perl5/vendor_perl \
+    -Dvendorarch=/usr/lib/perl5/vendor_perl \
+    -Dscriptdir=/usr/bin/core_perl \
+    -Dsitescript=/usr/bin/site_perl \
+    -Dvendorscript=/usr/bin/vendor_perl \
+    -Dinc_version_list=none \
+    -Dcccdlflags="${CFLAGS}" \
+    -Dlddlflags="-shared ${LDFLAGS}" \
+    -Dldflags="${LDFLAGS}" \
+    -Doptimize="${CFLAGS}"
 
-abinfo "Building and installing Perl..."
+if ab_match_arch mips64r6el; then
+    abinfo "HACK: Runnning generation scripts manually to ensure Makefile is generated ..."
+    bash "$SRCDIR"/makedepend.SH
+    bash "$SRCDIR"/makedepend_file.SH
+    bash "$SRCDIR"/Makefile.SH
+fi
+
+abinfo "Building Perl ..."
 make
-make install DESTDIR="$PKGDIR"
 
-abinfo "Installing makepkg templates..."
-for template in "$SRCDIR"/*.template; do
-    install -Dvm644 "$template" \
-        "$PKGDIR"/usr/share/makepkg-template/"${template##*/}"
-done
+abinfo "Installing Perl ..."
+make install DESTDIR="$PKGDIR"
 
 # From Arch Linux:
 
@@ -49,3 +53,7 @@ abinfo "Creating symlinks for core executables..."
 abinfo "Purging metadata files..."
 find "$PKGDIR" -name perllocal.pod -delete
 find "$PKGDIR" -name .packlist -delete
+
+abinfo "Moving /usr/bin/core_perl/* => /usr/bin ..."
+mv -v "$PKGDIR"/usr/bin/core_perl/* \
+    "$PKGDIR"/usr/bin/

--- a/lang-perl/perl/autobuild/overrides/etc/bashrc.d/perl.sh
+++ b/lang-perl/perl/autobuild/overrides/etc/bashrc.d/perl.sh
@@ -1,7 +1,5 @@
 [ -d /usr/bin/site_perl ] && PATH="$PATH:/usr/bin/site_perl"
 [ -d /usr/lib/perl5/site_perl/bin ] && PATH="$PATH:/usr/lib/perl5/site_perl/bin"
-
 [ -d /usr/bin/vendor_perl ] && PATH="$PATH:/usr/bin/vendor_perl"
 [ -d /usr/lib/perl5/vendor_perl/bin ] && PATH="$PATH:/usr/lib/perl5/vendor_perl/bin"
-
 [ -d /usr/bin/core_perl ] && PATH="$PATH:/usr/bin/core_perl"

--- a/lang-perl/perl/autobuild/prepare
+++ b/lang-perl/perl/autobuild/prepare
@@ -1,11 +1,12 @@
 # FIXME: to adapt for the new -fPIC/-fPIE GCC specs,
 # which does not specify -fPIC by default once disabled
 # with AB_FLAGS_SPECS=0.
+abinfo "Appending -fPIC to fix build ..."
 export CFLAGS="${CFLAGS} -fPIC"
 export CXXFLAGS="${CXXFLAGS} -fPIC"
 
-# Use system dependencies.
-sed -i -e "s|BUILD_ZLIB\s*= True|BUILD_ZLIB = False|"           \
-       -e "s|INCLUDE\s*= ./zlib-src|INCLUDE    = /usr/include|" \
-       -e "s|LIB\s*= ./zlib-src|LIB        = /usr/lib|"         \
-       cpan/Compress-Raw-Zlib/config.in
+abinfo "Tweaking cpan/Compress-Raw-Zlib/config.in to use system Zlib ..."
+sed -e "s|BUILD_ZLIB\s*= True|BUILD_ZLIB = False|"           \
+    -e "s|INCLUDE\s*= ./zlib-src|INCLUDE    = /usr/include|" \
+    -e "s|LIB\s*= ./zlib-src|LIB        = /usr/lib|"         \
+    -i "$SRCDIR"/cpan/Compress-Raw-Zlib/config.in

--- a/lang-perl/perl/spec
+++ b/lang-perl/perl/spec
@@ -1,4 +1,4 @@
-VER=5.36.1
+VER=5.36.3
 SRCS="tbl::https://www.cpan.org/src/5.0/perl-${VER}.tar.xz"
-CHKSUMS="sha256::bd91217ea8a8c8b81f21ebbb6cefdf0d13ae532013f944cdece2cd51aef4b6a7"
+CHKSUMS="sha256::45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd"
 CHKUPDATE="anitya::id=13599"


### PR DESCRIPTION
Topic Description
-----------------

- perl: update to 5.36.3
    - Move core scripts to /usr/bin to ease usage.
    - Rename profile.d => bashrc.d to make sure PATH settings work for non-login
    sessions.
    - Drop a (historic!) Arch Linux copy-pasta.
- util-linux: drop unneeded /usr/bin/mips
    - FIXME: /usr/bin/mips launches a shell for some reason, breaking the Configure script in Perl.

Package(s) Affected
-------------------

- perl: 4:5.36.3
- util-linux: 2.39.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit util-linux perl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
