### PR TITLE
autobuild4: update to 4.0.16

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.0.15
+VER=4.0.16
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226987"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: update to 4.0.16
    - Fix issue with xz-ing manpages with multiple hard-links. [^1]
    - Introduce a workaround for PEP 517 sources using setuptools as their build backends.
    [^1]: https://www.mail-archive.com/xz-devel@tukaani.org/msg00393.html

Package(s) Affected
-------------------

- autobuild4: 4.0.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
