### PR TITLE
bcachefs-tools: new, 1.4.1

### DIFF
--- a/app-admin/bcachefs-tools/autobuild/beyond
+++ b/app-admin/bcachefs-tools/autobuild/beyond
@@ -1,0 +1,17 @@
+# FIXME: upstream does not provide dracut hooks, removing unused initramfs-tools hooks
+abinfo "Removing initramfs-tools hooks ..."
+rm -rv "$PKGDIR"/usr/share/initramfs-tools
+
+abinfo "Installing Dracut hooks ..."
+install -dv "$PKGDIR"/usr/lib/dracut/modules.d/
+cp -rv "$SRCDIR"/../dracut-bcachefs/90bcachefs "$PKGDIR"/usr/lib/dracut/modules.d/
+chmod -v 755 "$PKGDIR"/usr/lib/dracut/modules.d
+chmod -v 755 "$PKGDIR"/usr/lib/dracut/modules.d/*
+
+abinfo "Installing shell completions ..."
+install -dv "$PKGDIR"/usr/share/bash-completion/completions/ \
+    "$PKGDIR"/usr/share/zsh/site-functions/ \
+    "$PKGDIR"/usr/share/fish/completions/
+"$PKGDIR"/usr/bin/bcachefs completions bash > "$PKGDIR"/usr/share/bash-completion/completions/bcachefs
+"$PKGDIR"/usr/bin/bcachefs completions zsh > "$PKGDIR"/usr/share/zsh/site-functions/_bcachefs
+"$PKGDIR"/usr/bin/bcachefs completions fish > "$PKGDIR"/usr/share/fish/completions/bcachefs.fish

--- a/app-admin/bcachefs-tools/autobuild/build
+++ b/app-admin/bcachefs-tools/autobuild/build
@@ -1,0 +1,11 @@
+abinfo "Building bcachefs-tools ..."
+make PREFIX=/usr \
+    ROOT_SBINDIR=/usr/bin \
+    LIBEXECDIR=/usr/lib
+
+abinfo "Installing bcachefs-tools ..."
+make install \
+    PREFIX=/usr \
+    DESTDIR="$PKGDIR" \
+    ROOT_SBINDIR=/usr/bin \
+    LIBEXECDIR=/usr/lib

--- a/app-admin/bcachefs-tools/autobuild/defines
+++ b/app-admin/bcachefs-tools/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=bcachefs-tools
+PKGSEC=admin
+BUILDDEP="libaio util-linux llvm keyutils lz4 libsodium \
+        liburcu zstd pkg-config zlib rustc"
+PKGDES="Userspace tools for bcachefs"
+
+USECLANG=1
+
+# FIXME: FTBFS with LTO on riscv64 and loongson3
+NOLTO__RISCV64=1
+NOLTO__LOONGSON3=1

--- a/app-admin/bcachefs-tools/spec
+++ b/app-admin/bcachefs-tools/spec
@@ -1,0 +1,6 @@
+VER=1.4.1
+SRCS="git::rename=bcachefs-tools;commit=tags/v${VER}::https://evilpiepirate.org/git/bcachefs-tools.git \
+    git::rename=dracut-bcachefs;commit=1f584d9::https://github.com/breavyn/dracut-bcachefs"
+CHKSUMS="SKIP SKIP"
+CHKUPDATE="anitya::id=370291"
+SUBDIR="bcachefs-tools"


### PR DESCRIPTION
Topic Description
-----------------

- bcachefs-tools: new, 1.4.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- bcachefs-tools: 1.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bcachefs-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
