### PR TITLE
Debconf Survey (New, January 2024)

### DIFF
--- a/app-admin/debconf-kde/autobuild/defines
+++ b/app-admin/debconf-kde/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=debconf-kde
+PKGSEC=admin
+PKGDEP="debconf kcoreaddons ki18n kiconthemes ktextwidgets kwidgetsaddons"
+BUILDDEP="extra-cmake-modules"
+PKGDES="KDE GUI frontend for Debconf"

--- a/app-admin/debconf-kde/spec
+++ b/app-admin/debconf-kde/spec
@@ -1,0 +1,4 @@
+VER=1.1.0
+SRCS="git::commit=tags/upstream/$VER::https://salsa.debian.org/qt-kde-team/extras/debconf-kde"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371003"

--- a/app-admin/debconf/autobuild/build
+++ b/app-admin/debconf/autobuild/build
@@ -1,0 +1,58 @@
+# Adapted from Fedora's `debconf' package.
+
+abinfo "Building Debconf ..."
+make
+
+abinfo "Installing Debconf ..."
+make install-utils install-i18n install-rest \
+    prefix="$PKGDIR"
+
+abinfo "Installing Python 3 helper ..."
+install -Dvm644 "$SRCDIR"/debconf.py \
+    "$PKGDIR"/usr/lib/python${ABPY3VER}/site-packages/debconf.py
+
+abinfo "Generating empty status templates ..."
+mkdir -pv "$PKGDIR"/var/cache/debconf
+touch  \
+    "$PKGDIR"/var/cache/debconf/config.dat \
+    "$PKGDIR"/var/cache/debconf/passwords.dat \
+    "$PKGDIR"/var/cache/debconf/templates.dat
+
+abinfo "Installing extra directories ..."
+mkdir -pv \
+    "$PKGDIR"/usr/share/man/{,de,fr,ru,pt_BR}/man{1,3,5,7,8}
+
+abinfo "Marking confmodules as executable ..."
+chmod -v +x "$PKGDIR"/usr/share/debconf/confmodule*
+
+abinfo "Installing man pages ..."
+for man in \
+    "debconf-apt-progress" \
+    "debconf-communicate" \
+    "debconf-copydb" \
+    "debconf-escape" \
+    "debconf-set-selections" \
+    "debconf-show" \
+    "debconf" \
+    "dpkg-preconfigure" \
+    "dpkg-reconfigure" \
+    "Debconf::Client::ConfModule" \
+    "confmodule" \
+    "debconf.conf" \
+    "debconf-devel" \
+    "debconf" \
+    get-selections \
+    getlang \
+    loadtemplate \
+    mergetemplate; do
+    for level in 1 3 5 7 8; do
+        test -f "$SRCDIR"/doc/man/gen/$man.$level && \
+            install -vm644 "$SRCDIR"/doc/man/gen/$man.$level \
+                "$PKGDIR"/usr/share/man/man$level/$man.$level
+    done
+done
+
+abinfo "Moving /usr/sbin => /usr/bin ..."
+mv -v "$PKGDIR"/usr/sbin/* \
+    "$PKGDIR"/usr/bin/
+rm -rv "$PKGDIR"/usr/sbin

--- a/app-admin/debconf/autobuild/defines
+++ b/app-admin/debconf/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=debconf
+PKGSEC=admin
+PKGDEP="apt dialog libintl-perl newt perl-locale-gettext perl-text-charwidth \
+        perl-text-wrapi18n python-3"
+BUILDDEP="gettext po4a"
+PKGDES="Debian package configuration manager"
+
+ABHOST=noarch

--- a/app-admin/debconf/spec
+++ b/app-admin/debconf/spec
@@ -1,0 +1,4 @@
+VER=1.5.83
+SRCS="git::commit=tags/debian/$VER::https://salsa.debian.org/pkg-debconf/debconf"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=8130"

--- a/app-admin/po-debconf/autobuild/build
+++ b/app-admin/po-debconf/autobuild/build
@@ -1,0 +1,31 @@
+# Adapted from Fedora's `po-debconf' package.
+
+abinfo "Building po-debconf ..."
+make
+
+abinfo "Installing po-debconf ..."
+mkdir -pv "$PKGDIR"/usr/{bin,share/po-debconf}
+
+abinfo "Installing programs ..."
+install -Dvm755 \
+    "$SRCDIR"/{debconf-{gettextize,updatepo},po2debconf,podebconf-{display,report}-po} \
+    -t "$PKGDIR"/usr/bin
+
+abinfo "Installing extra data files ..."
+install -Dvm644 "$SRCDIR"/{encodings,pot-header} \
+    -t "$PKGDIR"/usr/share/po-debconf/
+cp -av "$SRCDIR"/podebconf-report-po_templates/ \
+    "$PKGDIR"/usr/share/po-debconf/templates
+
+abinfo "Installing man pages ..."
+for lang_man in `find "$SRCDIR"/doc/ -name "*.1" -exec dirname {} \; | sort -u`; do
+    lang_id=$(basename $lang_man | sed -e 's/en//g')
+    mkdir -pv \
+        "$PKGDIR"/usr/share/man/man1 \
+        "$PKGDIR"/usr/share/man/$lang_id/man1
+    for man in $lang_man/*.1; do
+        dest_name=$(basename $man | sed -e "s/\.$lang_id\././")
+        install -vm644 "$man" \
+            "$PKGDIR"/usr/share/man/$lang_id/man1/$dest_name
+    done
+done

--- a/app-admin/po-debconf/autobuild/defines
+++ b/app-admin/po-debconf/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=po-debconf
+PKGSEC=admin
+PKGDEP="gettext intltool perl"
+BUILDDEP="po4a"
+PKGDES="Tool for managing templates file translations with Gettext"
+
+ABHOST=noarch

--- a/app-admin/po-debconf/spec
+++ b/app-admin/po-debconf/spec
@@ -1,0 +1,4 @@
+VER=1.0.21
+SRCS="git::commit=tags/debian/$VER::https://salsa.debian.org/debian/po-debconf"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=8137"

--- a/app-i18n/po4a/autobuild/build
+++ b/app-i18n/po4a/autobuild/build
@@ -1,7 +1,11 @@
-abinfo "Set locale to unicode"
-export LC_ALL=en_US.UTF-8
-abinfo "Building po4a"
+abinfo "Building po4a ..."
 perl Build.PL create_packlist=0
 perl Build
-abinfo "Installing"
+
+abinfo "Installing ..."
 perl Build destdir="$PKGDIR" install
+
+abinfo "Moving executables /usr/bin/site_perl/* => /usr/bin ..."
+mv -v "$PKGDIR"/usr/bin/site_perl/* \
+    "$PKGDIR"/usr/bin/
+rm -rv "$PKGDIR"/usr/bin/site_perl

--- a/app-i18n/po4a/spec
+++ b/app-i18n/po4a/spec
@@ -1,4 +1,5 @@
 VER=0.63
+REL=1
 SRCS="tbl::https://github.com/mquinson/po4a/releases/download/v$VER/po4a-$VER.tar.gz"
 CHKSUMS="sha256::e21be3ee545444bae2fe6a44aeb9d320604708cc2e4c601bcb3cc440db75b4ce"
 CHKUPDATE="anitya::id=3675"


### PR DESCRIPTION
Topic Description
-----------------

- po-debconf: new, 1.0.21
- debconf-kde: new, 1.1.0
- debconf: new, 1.5.83
- po4a: move executables to /usr/bin

Package(s) Affected
-------------------

- debconf-kde: 1.1.0
- po-debconf: 1.0.21
- debconf: 1.5.83
- po4a: 0.63-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit po4a debconf debconf-kde po-debconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
