### PR TITLE
dejagnu: update to 1.6.3 and mark as noarch

### DIFF
--- a/app-devel/dejagnu/autobuild/defines
+++ b/app-devel/dejagnu/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=dejagnu
 PKGSEC=devel
 PKGDEP="expect bash tcl"
 PKGDES="Framework for testing other programs"
+
+ABHOST=noarch

--- a/app-devel/dejagnu/spec
+++ b/app-devel/dejagnu/spec
@@ -1,5 +1,4 @@
-VER=1.6.2
-REL=1
+VER=1.6.3
 SRCS="tbl::https://ftp.gnu.org/gnu/dejagnu/dejagnu-$VER.tar.gz"
-CHKSUMS="sha256::0d0671e1b45189c5fc8ade4b3b01635fb9eeab45cf54f57db23e4c4c1a17d261"
+CHKSUMS="sha256::87daefacd7958b4a69f88c6856dbd1634261963c414079d0c371f589cd66a2e3"
 CHKUPDATE="anitya::id=417"


### PR DESCRIPTION
Topic Description
-----------------

- dejagnu: update to 1.6.3 and mark as noarch

Package(s) Affected
-------------------

- dejagnu: 1.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit dejagnu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
