### PR TITLE
cava: update to 0.10.1

### DIFF
--- a/app-multimedia/cava/spec
+++ b/app-multimedia/cava/spec
@@ -1,4 +1,4 @@
-VER=0.8.3
-SRCS="tbl::https://github.com/karlstav/cava/archive/$VER.tar.gz"
-CHKSUMS="sha256::ce7378ababada5a20fa8250c6b3fe6412bc1a7dd31301a52b8b4a71d362875b9"
+VER=0.10.1
+SRCS="git::commit=tags/$VER::https://github.com/karlstav/cava"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17019"


### PR DESCRIPTION
Topic Description
-----------------

- cava: update to 0.10.1

Package(s) Affected
-------------------

- cava: 0.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cava
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
