### PR TITLE
picom: update to 11.1

### DIFF
--- a/desktop-wm/picom/spec
+++ b/desktop-wm/picom/spec
@@ -1,4 +1,4 @@
-VER=10.2
+VER=11.1
 SRCS="https://github.com/yshui/picom/archive/v${VER/\~/-}.tar.gz"
-CHKSUMS="sha256::9741577df0136d8a2be48005ca2b93edc15913528e19bceb798535ca4683341c"
+CHKSUMS="sha256::96f2a33a93064a74b557942d0300a2ac77ac853f50efbbf6466849fcc7542ec8"
 CHKUPDATE="anitya::id=48078"


### PR DESCRIPTION
Topic Description
-----------------

- picom: update to 11.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- picom: 11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit picom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
