### PR TITLE
sudo: update to 1.9.15p5

### DIFF
--- a/app-admin/sudo/autobuild/build
+++ b/app-admin/sudo/autobuild/build
@@ -3,7 +3,7 @@ cd "${SRCDIR}/abbuild"
 
 abinfo "Running configure..."
 "${SRCDIR}/configure" \
-	${AUTOTOOLS_DEF} \
+	${AUTOTOOLS_DEF[@]} \
 	${AUTOTOOLS_AFTER} \
 	--with-passprompt="[sudo] password for %p: "
 

--- a/app-admin/sudo/autobuild/conffiles
+++ b/app-admin/sudo/autobuild/conffiles
@@ -2,3 +2,4 @@
 /etc/sudo.conf
 /etc/sudo_logsrvd.conf
 /etc/sudoers
+/etc/sudoers.dist

--- a/app-admin/sudo/spec
+++ b/app-admin/sudo/spec
@@ -1,4 +1,4 @@
-VER=1.9.12p1
+VER=1.9.15p5
 SRCS="tbl::https://www.sudo.ws/dist/sudo-$VER.tar.gz"
-CHKSUMS="sha256::475a18a8eb3da8b2917ceab063a6baf51ea09128c3c47e3e0e33ab7497bab7d8"
+CHKSUMS="sha256::558d10b9a1991fb3b9fa7fa7b07ec4405b7aefb5b3cb0b0871dbc81e3a88e558"
 CHKUPDATE="anitya::id=4906"


### PR DESCRIPTION
Topic Description
-----------------

- sudo: update to 1.9.15p5

Package(s) Affected
-------------------

- sudo: 1.9.15p5

Security Update?
----------------

No

Build Order
-----------

```
#buildit sudo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
