### PR TITLE
Migrate to sysusers

### DIFF
--- a/app-admin/memcached/autobuild/overrides/usr/lib/sysusers.d/memcached.conf
+++ b/app-admin/memcached/autobuild/overrides/usr/lib/sysusers.d/memcached.conf
@@ -1,0 +1,2 @@
+g    memcached  88
+u    memcached  88:88 "memcached daemon owner" /var/lib/memcached  /bin/bash

--- a/app-admin/memcached/autobuild/postinst
+++ b/app-admin/memcached/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Setting up memcached user and group"
+systemd-sysusers memcached.conf

--- a/app-admin/memcached/autobuild/usergroup
+++ b/app-admin/memcached/autobuild/usergroup
@@ -1,2 +1,0 @@
-group memcached 88
-user memcached 88 memcached /var/lib/memcached "memcached daemon owner" /bin/bash

--- a/app-admin/memcached/spec
+++ b/app-admin/memcached/spec
@@ -1,5 +1,5 @@
 VER=1.6.12
+REL=2
 SRCS="https://github.com/memcached/memcached/archive/$VER.tar.gz"
 CHKSUMS="sha256::7102f9f86c32047b5a4295a3c4622478b39e5c85bddf1aacb534fd0923135319"
 CHKUPDATE="anitya::id=1965"
-REL=1

--- a/app-admin/partimage/autobuild/build
+++ b/app-admin/partimage/autobuild/build
@@ -1,5 +1,10 @@
-./configure ${AUTOTOOLS_DEF} ${AUTOTOOLS_AFTER}
+abinfo "Configuring partimage ..."
+"$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER}
+
+abinfo "Compiling partimage ..."
 make
 make pamfile
+
+abinfo "Installing partimage ..."
 make install DESTDIR="$PKGDIR"
 

--- a/app-admin/partimage/autobuild/overrides/usr/lib/sysusers.d/partimage.conf
+++ b/app-admin/partimage/autobuild/overrides/usr/lib/sysusers.d/partimage.conf
@@ -1,0 +1,2 @@
+g    partimag  311
+u    partimag  311:311 "Partimage daemon user" /dev/null  /bin/false

--- a/app-admin/partimage/autobuild/patches/0001-Description-fix-a-FTBFS-with-GLIBC-2.28.patch
+++ b/app-admin/partimage/autobuild/patches/0001-Description-fix-a-FTBFS-with-GLIBC-2.28.patch
@@ -1,14 +1,22 @@
-Description: fix a FTBFS with GLIBC 2.28.
- Patch from Gentoo Linux. Thanks.
+From ee076c9f00905cb9151cacc0f927757d1819a2ce Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Sun, 4 Feb 2024 21:07:46 +0800
+Subject: [PATCH 1/3] Description: fix a FTBFS with GLIBC 2.28.
+
+Patch from Gentoo Linux. Thanks.
 Author: Mike Frysinger <vapier@gentoo.org>
 Bug-Debian: https://bugs.debian.org/915987
 Origin: https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=f503f77079c568cd9628571cf69b418a51967e49
 Reviewed-By: Joao Eriberto Mota Filho <eriberto@debian.org>
 Last-Update: 2016-04-19
-Index: partimage-0.6.9/src/client/misc.h
-===================================================================
---- partimage-0.6.9.orig/src/client/misc.h
-+++ partimage-0.6.9/src/client/misc.h
+---
+ src/client/misc.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/client/misc.h b/src/client/misc.h
+index 2ec4b63..15567f0 100644
+--- a/src/client/misc.h
++++ b/src/client/misc.h
 @@ -36,7 +36,7 @@ struct COptions;
  #endif
  
@@ -18,3 +26,6 @@ Index: partimage-0.6.9/src/client/misc.h
  #endif
  
  // =======================================================
+-- 
+2.43.0
+

--- a/app-admin/partimage/autobuild/patches/0002-OpenSSL-1.1-compatibility.patch
+++ b/app-admin/partimage/autobuild/patches/0002-OpenSSL-1.1-compatibility.patch
@@ -1,3 +1,16 @@
+From b8e57972eb00f060064174a0557b3e872eb7aeb5 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Sun, 4 Feb 2024 21:08:06 +0800
+Subject: [PATCH 2/3] OpenSSL 1.1 compatibility
+
+---
+ configure.ac             | 2 +-
+ src/client/netclient.cpp | 6 +++++-
+ src/server/netserver.cpp | 6 +++++-
+ 3 files changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index bb2ff61..cd3cc9a 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -240,7 +240,7 @@ if test "$SSL" = "yes"; then
@@ -9,6 +22,8 @@
          AC_MSG_ERROR([ Required for SSL Crypto Library not found. ])
        )
         AC_CHECK_LIB(ssl, SSL_CTX_new,
+diff --git a/src/client/netclient.cpp b/src/client/netclient.cpp
+index 30b8d5c..29a59b8 100644
 --- a/src/client/netclient.cpp
 +++ b/src/client/netclient.cpp
 @@ -43,7 +43,11 @@ CNetClient::CNetClient(bool bMustLogin, bool bUseSSL):CNet()
@@ -24,6 +39,8 @@
        SSL_load_error_strings();
        ctx = SSL_CTX_new(meth);
        if (!ctx)
+diff --git a/src/server/netserver.cpp b/src/server/netserver.cpp
+index b3ba1c7..d66acde 100644
 --- a/src/server/netserver.cpp
 +++ b/src/server/netserver.cpp
 @@ -39,7 +39,11 @@ CNetServer::CNetServer(unsigned short int port):CNet()
@@ -39,3 +56,6 @@
        ctx = SSL_CTX_new(meth);
        if (!ctx)
          {
+-- 
+2.43.0
+

--- a/app-admin/partimage/autobuild/patches/0003-zlib-1.2.6-compatibility.patch
+++ b/app-admin/partimage/autobuild/patches/0003-zlib-1.2.6-compatibility.patch
@@ -1,3 +1,13 @@
+From 4c28585a7be3012000616873a48ab3da2fc4229e Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Sun, 4 Feb 2024 21:09:00 +0800
+Subject: [PATCH 3/3] zlib 1.2.6 compatibility
+
+---
+ src/client/imagefile.cpp | 4 ++--
+ src/client/imagefile.h   | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
 diff --git a/src/client/imagefile.cpp b/src/client/imagefile.cpp
 index dd83411..62d0f72 100644
 --- a/src/client/imagefile.cpp
@@ -9,8 +19,8 @@ index dd83411..62d0f72 100644
 -      m_gzImageFile = (gzFile *) gzdopen(m_nFdImage, "wb"); //"wb1h");
 +      m_gzImageFile = gzdopen(m_nFdImage, "wb"); //"wb1h");
        if (m_gzImageFile == NULL)
-    {
-      showDebug(1, "error:%d %s\n", errno, strerror(errno));
+ 	{
+ 	  showDebug(1, "error:%d %s\n", errno, strerror(errno));
 @@ -1098,7 +1098,7 @@ void CImage::openReading(CVolumeHeader *vh /* = NULL */)
      }
    else if (m_options.dwCompression == COMPRESS_GZIP) // Gzip compression
@@ -33,4 +43,6 @@ index 4ba8910..6adb098 100644
    BZFILE *m_bzImageFile;
  
    int m_nFdImage;
+-- 
+2.43.0
 

--- a/app-admin/partimage/autobuild/postinst
+++ b/app-admin/partimage/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Setting up partimag group and user ..."
+systemd-sysusers partimage.conf

--- a/app-admin/partimage/autobuild/usergroup
+++ b/app-admin/partimage/autobuild/usergroup
@@ -1,2 +1,0 @@
-group partimag 311
-user partimag 311 partimag /dev/null "Partimage daemon user" /bin/false

--- a/app-admin/partimage/spec
+++ b/app-admin/partimage/spec
@@ -1,5 +1,5 @@
 VER=0.6.9
-REL=5
+REL=6
 SRCS="tbl::https://sourceforge.net/projects/partimage/files/stable/$VER/partimage-$VER.tar.bz2"
 CHKSUMS="sha256::753a6c81f4be18033faed365320dc540fe5e58183eaadcd7a5b69b096fec6635"
 CHKUPDATE="anitya::id=226788"

--- a/app-admin/rtkit/autobuild/overrides/usr/lib/sysusers.d/rtkit.conf
+++ b/app-admin/rtkit/autobuild/overrides/usr/lib/sysusers.d/rtkit.conf
@@ -1,0 +1,2 @@
+g    rtkit  133
+u    rtkit  133:133 "RealtimeKit User" /proc  /sbin/nologin

--- a/app-admin/rtkit/autobuild/postinst
+++ b/app-admin/rtkit/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Setting up rtkit group and user ..."
+systemd-sysusers rtkit.conf

--- a/app-admin/rtkit/autobuild/usergroup
+++ b/app-admin/rtkit/autobuild/usergroup
@@ -1,2 +1,0 @@
-group rtkit 133
-user rtkit 133 rtkit /proc "RealtimeKit User" /sbin/nologin

--- a/app-admin/rtkit/spec
+++ b/app-admin/rtkit/spec
@@ -1,4 +1,5 @@
 VER=0.13
+REL=1
 SRCS="https://github.com/heftig/rtkit/releases/download/v$VER/rtkit-$VER.tar.xz"
 CHKSUMS="sha256::a157144cd95cf6d25200e74b74a8f01e4fe51fd421bb63c1f00d471394b640ab"
 CHKUPDATE="anitya::id=138132"

--- a/app-database/mariadb/autobuild/overrides/usr/lib/sysusers.d/mariadb.conf
+++ b/app-database/mariadb/autobuild/overrides/usr/lib/sysusers.d/mariadb.conf
@@ -1,0 +1,2 @@
+g    mysql  89
+u    mysql  89:89 "MariaDB Daemon User" /var/lib/mysql  /bin/false

--- a/app-database/mariadb/autobuild/postinst
+++ b/app-database/mariadb/autobuild/postinst
@@ -1,9 +1,15 @@
+echo "Setting up mysql user and group ..."
+systemd-sysusers mariadb.conf
+
 if [[ ! -e /var/lib/mysql ]]; then
+    echo "Creating database at /var/lib/mysql ..."
     install -dm700 /var/lib/mysql
     /usr/bin/mysql_install_db --user=mysql \
         --basedir=/usr --datadir=/var/lib/mysql
 fi
 
+echo "Configuring permission of /var/lib/mysql ..."
 chown -R mysql:mysql /var/lib/mysql &>/dev/null
 
+echo "Setting up mysql temporary directory ..."
 /usr/bin/systemd-tmpfiles --create mysql.conf

--- a/app-database/mariadb/autobuild/usergroup
+++ b/app-database/mariadb/autobuild/usergroup
@@ -1,2 +1,0 @@
-group mysql 89
-user mysql 89 mysql /var/lib/mysql "MariaDB Daemon User" /bin/false

--- a/app-database/mariadb/spec
+++ b/app-database/mariadb/spec
@@ -1,6 +1,5 @@
 VER=10.9.4
-REL=1
+REL=2
 SRCS="tbl::https://dlm.mariadb.com/2605261/MariaDB/mariadb-$VER/source/mariadb-$VER.tar.gz"
 CHKSUMS="sha256::1dff08a0f37ea5cf8f00cbd12d40e80759fae7d73184ccf56b5b51acfdcfc054"
 CHKUPDATE="anitya::id=1887"
-REL=1

--- a/app-database/postgresql/autobuild/overrides/usr/lib/sysusers.d/postgresql.conf
+++ b/app-database/postgresql/autobuild/overrides/usr/lib/sysusers.d/postgresql.conf
@@ -1,0 +1,2 @@
+g    postgres  90
+u    postgres  90:90 "Postgres Daemon Owner" /var/lib/postgres  /bin/bash

--- a/app-database/postgresql/autobuild/postinst
+++ b/app-database/postgresql/autobuild/postinst
@@ -1,8 +1,14 @@
+echo "Setting up postgres user and group ..."
+systemd-sysusers postgresql.conf
+
+echo "Migrating postgres home directory ..."
 usermod -d /var/lib/postgres postgres
 
+echo "Creating temporary directory for postgresql ..."
 systemd-tmpfiles --create postgresqld.conf
 
 if [ ! -d /var/lib/postgres/data ]; then
+    echo "Creating initial postgresql database ..."
     mkdir -p /var/lib/postgres/data
     chown 90:90 /var/lib/postgres/data
     su - postgres -c \

--- a/app-database/postgresql/autobuild/usergroup
+++ b/app-database/postgresql/autobuild/usergroup
@@ -1,2 +1,0 @@
-group postgres 90
-user postgres 90 postgres /srv/postgres "Postgres Daemon Owner" /bin/bash 

--- a/app-database/postgresql/spec
+++ b/app-database/postgresql/spec
@@ -1,4 +1,5 @@
 VER=13.13
+REL=1
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
 CHKSUMS="sha256::8af69c2599047a2ad246567d68ec4131aef116954d8c3e469e9789080b37a474"
 CHKUPDATE="anitya::id=5601"

--- a/app-network/dnsmasq/autobuild/overrides/usr/lib/sysusers.d/dnsmasq.conf
+++ b/app-network/dnsmasq/autobuild/overrides/usr/lib/sysusers.d/dnsmasq.conf
@@ -1,0 +1,1 @@
+u    dnsmasq  488:daemon "dnsmasq daemon owner" /  /bin/nologin

--- a/app-network/dnsmasq/autobuild/postinst
+++ b/app-network/dnsmasq/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Setting up dnsmasq user ..."
+systemd-sysusers dnsmasq.conf

--- a/app-network/dnsmasq/autobuild/usergroup
+++ b/app-network/dnsmasq/autobuild/usergroup
@@ -1,1 +1,0 @@
-user dnsmasq 488 daemon / "dnsmasq daemon owner" /bin/nologin

--- a/app-network/dnsmasq/spec
+++ b/app-network/dnsmasq/spec
@@ -1,4 +1,5 @@
 VER=2.89
+REL=1
 SRCS="tbl::http://www.thekelleys.org.uk/dnsmasq/dnsmasq-$VER.tar.xz"
 CHKSUMS="sha256::02bd230346cf0b9d5909f5e151df168b2707103785eb616b56685855adebb609"
 CHKUPDATE="anitya::id=444"

--- a/app-network/spamassassin/autobuild/overrides/usr/lib/sysusers.d/spamassassin.conf
+++ b/app-network/spamassassin/autobuild/overrides/usr/lib/sysusers.d/spamassassin.conf
@@ -1,0 +1,2 @@
+g    spamd  182
+u    spamd  182:182 "Mail Spam Daemon" /var/lib/spamassassin  /bin/false

--- a/app-network/spamassassin/autobuild/postinst
+++ b/app-network/spamassassin/autobuild/postinst
@@ -1,2 +1,8 @@
-sa-update --verbose
+echo "Setting up spamd user and grouop ..."
+systemd-sysusers spamassassin.conf
+
+echo "Updating spamassassin database ..."
+/usr/bin/vendor_perl/sa-update --verbose
+
+echo "Changing permission of /var/lib/spamassassin ..."
 chown 182:182 /var/lib/spamassassin

--- a/app-network/spamassassin/autobuild/usergroup
+++ b/app-network/spamassassin/autobuild/usergroup
@@ -1,2 +1,0 @@
-group spamd 182
-user spamd 182 spamd /var/lib/spamassassin "Mail Spam Daemon" /bin/false

--- a/app-network/spamassassin/spec
+++ b/app-network/spamassassin/spec
@@ -1,5 +1,5 @@
 VER=3.4.6
+REL=2
 SRCS="tbl::https://downloads.apache.org/spamassassin/source/Mail-SpamAssassin-$VER.tar.gz"
 CHKSUMS="sha256::500c7e2a7cdf3aa4dd822d97aaff2ab22235a60cf17a68ab817861d215a4e568"
 CHKUPDATE="anitya::id=4861"
-REL=1

--- a/app-network/tor/autobuild/overrides/usr/lib/sysusers.d/tor.conf
+++ b/app-network/tor/autobuild/overrides/usr/lib/sysusers.d/tor.conf
@@ -1,0 +1,2 @@
+g    tor  443
+u    tor  443:443 "Tor daemon owner" /var/lib/tor  /bin/false

--- a/app-network/tor/autobuild/postinst
+++ b/app-network/tor/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Setting up tor user and group"
+systemd-sysusers tor.conf

--- a/app-network/tor/autobuild/usergroup
+++ b/app-network/tor/autobuild/usergroup
@@ -1,2 +1,0 @@
-group tor 443
-user tor 443 tor /var/lib/tor "Tor daemon owner" /bin/false

--- a/app-network/tor/spec
+++ b/app-network/tor/spec
@@ -1,4 +1,5 @@
 VER=0.4.7.14
+REL=1
 SRCS="tbl::https://www.torproject.org/dist/tor-$VER.tar.gz"
 CHKSUMS="sha256::a5ac67f6466380fc05e8043d01c581e4e8a2b22fe09430013473e71065e65df8"
 CHKUPDATE="anitya::id=4991"

--- a/app-utils/pesign/autobuild/overrides/usr/lib/sysusers.d/pesign.conf
+++ b/app-utils/pesign/autobuild/overrides/usr/lib/sysusers.d/pesign.conf
@@ -1,0 +1,2 @@
+g    pesign  312
+u    pesign  312:312 "PESign signing daemon" /  /bin/bash

--- a/app-utils/pesign/autobuild/postinst
+++ b/app-utils/pesign/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Setting up pesign user and group"
+systemd-sysusers pesign.conf

--- a/app-utils/pesign/autobuild/usergroup
+++ b/app-utils/pesign/autobuild/usergroup
@@ -1,2 +1,0 @@
-group pesign 312
-user pesign 312 pesign / "PESign signing daemon" /bin/bash

--- a/app-utils/pesign/spec
+++ b/app-utils/pesign/spec
@@ -1,4 +1,5 @@
 VER=116
+REL=1
 SRCS="tbl::https://github.com/rhinstaller/pesign/releases/download/$VER/pesign-$VER.tar.bz2 \
       tbl::http://src.fedoraproject.org/lookaside/pkgs/pesign/rh-test-certs.tar.bz2/328db7cb27847cb610b7cf8f9c470455/rh-test-certs.tar.bz2"
 CHKSUMS="sha256::35331f75689863e5be595f2bb04a8bc934ce734b8d76fa5d6aeb4d85424e8996 \


### PR DESCRIPTION
Topic Description
-----------------

- xa: adapt to autobuild4
- wireshark: use sysusers
- tor: use sysusers
- spamassassin: use sysusers
- dnsmasq: use sysusers
- avahi: use sysusers
- pulseaudio: use sysusers
- mpd: use sysusers
- postgresql: use sysusers
- mariadb: use sysusers

... and 7 more commits

Package(s) Affected
-------------------

- xa: 2.4.0
- memcached: 1.6.12-2
- partimage: 0.6.9-6
- colord: 1.4.6-2
- dbus: 2:1.14.4-2
- rtkit: 0.13-1
- polkit: 1:122-1
- pesign: 116-1
- mariadb: 10.9.4-2
- postgresql: 13.13-1
- pulseaudio: 13.0-11
- mpd: 0.23.12-3
- wireshark: 4.0.0-1
- avahi: 0.8-6
- dnsmasq: 2.89-1
- spamassassin: 3.4.6-2
- tor: 0.4.7.14-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit polkit partimage dbus rtkit colord memcached pesign mariadb postgresql mpd pulseaudio avahi dnsmasq spamassassin tor wireshark xa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
