### PR TITLE
gpac: update to 2.2.1

### DIFF
--- a/app-multimedia/gpac/autobuild/build
+++ b/app-multimedia/gpac/autobuild/build
@@ -3,7 +3,7 @@ abinfo "Configuring $PKGNAME ..."
     --prefix=/usr \
     --mandir=/usr/share/man \
     --X11-path=/usr \
-    --use-js=no \
+    --disable-qjs \
     --use-openjpeg=system \
     --extra-cflags="${CPPFLAGS} ${CFLAGS}" \
     --extra-ldflags="${LDFLAGS}"

--- a/app-multimedia/gpac/spec
+++ b/app-multimedia/gpac/spec
@@ -1,5 +1,4 @@
-VER=1.0.1
-SRCS="tbl::https://github.com/gpac/gpac/archive/v$VER.tar.gz"
-CHKSUMS="sha256::3b0ffba73c68ea8847027c23f45cd81d705110ec47cf3c36f60e669de867e0af"
+VER=2.2.1
+SRCS="git::commit=tags/v$VER::https://github.com/gpac/gpac"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230919"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- gpac: modify configuration format by upstream

- gpac: update to 2.2.1

Package(s) Affected
-------------------

- gpac: 2.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gpac
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
