### PR TITLE
GPAC Survey (February 2024)

### DIFF
--- a/app-multimedia/gpac/autobuild/build
+++ b/app-multimedia/gpac/autobuild/build
@@ -3,7 +3,7 @@ abinfo "Configuring $PKGNAME ..."
     --prefix=/usr \
     --mandir=/usr/share/man \
     --X11-path=/usr \
-    --use-js=no \
+    --disable-qjs \
     --use-openjpeg=system \
     --extra-cflags="${CPPFLAGS} ${CFLAGS}" \
     --extra-ldflags="${LDFLAGS}"

--- a/app-multimedia/gpac/autobuild/defines
+++ b/app-multimedia/gpac/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="ffmpeg libjpeg-turbo libpng glu jack faad2 sdl pulseaudio openssl \
         xmlrpc-c openjpeg"
 PKGDES="A multimedia framework based on the MPEG-4 systems standard"
 
-PKGBREAK="ogmrip<=1.0.1-4"
+PKGBREAK="ogmrip<=1.0.1-7"
 
 # FIXME: /usr/bin/ld: ... relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol
 # `gf_sg_handle_dom_event' which may bind externally can not be used when

--- a/app-multimedia/gpac/spec
+++ b/app-multimedia/gpac/spec
@@ -1,5 +1,4 @@
-VER=1.0.1
-SRCS="tbl::https://github.com/gpac/gpac/archive/v$VER.tar.gz"
-CHKSUMS="sha256::3b0ffba73c68ea8847027c23f45cd81d705110ec47cf3c36f60e669de867e0af"
+VER=2.2.1
+SRCS="git::commit=tags/v$VER::https://github.com/gpac/gpac"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230919"
-REL=1

--- a/app-multimedia/ogmrip/spec
+++ b/app-multimedia/ogmrip/spec
@@ -1,5 +1,5 @@
 VER=1.0.1
-REL=7
+REL=8
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/ogmrip/ogmrip-$VER.tar.gz"
 CHKSUMS="sha256::4e2e9778ac4da9fe1ab159e3dc6d4367b7a9dbd8f3501df99733ecedb25b02ff"
 CHKUPDATE="anitya::id=230944"


### PR DESCRIPTION
Topic Description
-----------------

- ogmrip: bump REL due to gpac update
- gpac: modify configuration format by upstream
- gpac: update to 2.2.1

Package(s) Affected
-------------------

- ogmrip: 1.0.1-8
- gpac: 2.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gpac ogmrip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
