### PR TITLE
freepats2: update to 20221026

### DIFF
--- a/app-multimedia/freepats2/spec
+++ b/app-multimedia/freepats2/spec
@@ -1,4 +1,4 @@
-VER=20200523
-SRCS="tbl::https://freepats.zenvoid.org/SoundSets/FreePats-GeneralMIDI/FreePatsGM-SF2-$VER.tar.xz"
-CHKSUMS="sha256::d9ea94c3f95533b5e3b21174fc3172721053b7827e43149f16e9412ed7be0a5c"
+VER=20221026
+SRCS="tbl::https://freepats.zenvoid.org/SoundSets/FreePats-GeneralMIDI/FreePatsGM-SF2-$VER.7z"
+CHKSUMS="sha256::c2f5c777851e3ad86cba119bf91aa6b915022512e81c37ea010ee6a3f8b5415d"
 SUBDIR=FreePatsGM-SF2-$VER


### PR DESCRIPTION
Topic Description
-----------------

- freepats2: update to 20221026

Package(s) Affected
-------------------

- freepats2: 20221026

Security Update?
----------------

No

Build Order
-----------

```
#buildit freepats2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
