### PR TITLE
streamlink: update to 6.5.1

### DIFF
--- a/app-multimedia/streamlink/spec
+++ b/app-multimedia/streamlink/spec
@@ -1,5 +1,4 @@
-VER=1.7.0
-SRCS="https://pypi.org/packages/source/s/streamlink/streamlink-${VER}.tar.gz"
-CHKSUMS="sha256::f87a62a47212d94769929bd040d9c186b461643bdbda06f839b99ec9efefb87a"
+VER=6.5.1
+SRCS="git::commit=tags/$VER::https://github.com/streamlink/streamlink"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=47101"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- streamlink: update to 6.5.1

Package(s) Affected
-------------------

- streamlink: 6.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit streamlink
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
