### PR TITLE
gc: update to 8.2.6

### DIFF
--- a/runtime-common/gc/spec
+++ b/runtime-common/gc/spec
@@ -1,4 +1,4 @@
-VER=8.2.4
+VER=8.2.6
 SRCS="git::commit=tags/v$VER::https://github.com/ivmai/bdwgc.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=876"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Update gc from 8.2.4 to 8.2.6

Package(s) Affected
-------------------

gc: v8.2.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit gc 
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64le`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

Architectural progress for experimental ports does not impede on merging of this topic.

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
