### PR TITLE
kodi (KODI): update to 20.3

### DIFF
--- a/app-multimedia/kodi/autobuild/patches/0001-settings-force-Arial-based-fonts.patch
+++ b/app-multimedia/kodi/autobuild/patches/0001-settings-force-Arial-based-fonts.patch
@@ -1,8 +1,17 @@
+From af3f10926d1a843a76a8900a99212344638e6097 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 7 Feb 2024 19:31:29 +0800
+Subject: [PATCH 1/5] settings: force Arial-based fonts
+
+---
+ system/settings/settings.xml | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
 diff --git a/system/settings/settings.xml b/system/settings/settings.xml
-index 19cfe2d..4e32180 100755
+index 0898ee71be..98e9b5b993 100755
 --- a/system/settings/settings.xml
 +++ b/system/settings/settings.xml
-@@ -3196,13 +3196,10 @@
+@@ -3715,13 +3715,10 @@
          </setting>
          <setting id="lookandfeel.font" type="string" parent="lookandfeel.skin" label="13303" help="36107">
            <level>1</level>
@@ -17,3 +26,6 @@ index 19cfe2d..4e32180 100755
            <control type="list" format="string" />
          </setting>
          <setting id="lookandfeel.skinzoom" type="integer" parent="lookandfeel.skin" label="20109" help="36108">
+-- 
+2.43.0
+

--- a/app-multimedia/kodi/autobuild/patches/0002-Adjust-addons.patch
+++ b/app-multimedia/kodi/autobuild/patches/0002-Adjust-addons.patch
@@ -1,6 +1,18 @@
---- xbmc/cmake/installdata/common/addons.txt	2023-09-12 20:43:34.493889095 -0700
-+++ xbmc.addons/cmake/installdata/common/addons.txt	2023-09-12 20:51:36.261747578 -0700
-@@ -31,7 +31,6 @@
+From eee53964adbdd0c880822b89a767c5d81a0395c6 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 7 Feb 2024 19:31:48 +0800
+Subject: [PATCH 2/5] Adjust addons
+
+---
+ cmake/installdata/common/addons.txt | 79 ++++++++++++++++++++++++++++-
+ system/addon-manifest.xml           | 79 ++++++++++++++++++++++++++++-
+ 2 files changed, 156 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/installdata/common/addons.txt b/cmake/installdata/common/addons.txt
+index 263e57bb66..d0fc465f54 100644
+--- a/cmake/installdata/common/addons.txt
++++ b/cmake/installdata/common/addons.txt
+@@ -31,7 +31,6 @@ addons/screensaver.xbmc.builtin.black/*
  addons/screensaver.xbmc.builtin.dim/*
  addons/script.module.pil/*
  addons/script.module.pycryptodome/*
@@ -8,7 +20,7 @@
  addons/webinterface.default/*
  addons/xbmc.addon/metadata.xsd
  addons/xbmc.addon/repository.xsd
-@@ -43,3 +42,81 @@
+@@ -43,3 +42,81 @@ addons/xbmc.metadata/*
  addons/xbmc.pvr/*
  addons/xbmc.python/*
  addons/xbmc.webinterface/*
@@ -90,8 +102,10 @@
 +addons/resource.language.vi_vn/*
 +addons/resource.language.zh_cn/*
 +addons/resource.language.zh_tw/*
---- xbmc/system/addon-manifest.xml	2023-10-05 16:20:03.881585790 -0700
-+++ xbmc.addons/system/addon-manifest.xml	2023-10-05 16:19:25.172248750 -0700
+diff --git a/system/addon-manifest.xml b/system/addon-manifest.xml
+index 7df13a6d6f..5185d6a9f2 100644
+--- a/system/addon-manifest.xml
++++ b/system/addon-manifest.xml
 @@ -55,5 +55,82 @@
    <addon>xbmc.webinterface</addon>
    <addon optional="true">inputstream.adaptive</addon>
@@ -176,3 +190,6 @@
 +  <addon>resource.language.zh_cn</addon>
 +  <addon>resource.language.zh_tw</addon>
  </addons>
+-- 
+2.43.0
+

--- a/app-multimedia/kodi/autobuild/patches/0003-Fix-build-for-other-architectures.patch
+++ b/app-multimedia/kodi/autobuild/patches/0003-Fix-build-for-other-architectures.patch
@@ -1,19 +1,19 @@
-From 48d574ea01731eab9f3ff5435faae3902e41934c Mon Sep 17 00:00:00 2001
-From: eatradish <sakiiily@aosc.io>
-Date: Sat, 14 Nov 2020 23:35:32 -0600
-Subject: [PATCH] Fix other arch build
+From f9900876ac7b087987ed27a18105e6dc98d1bbc9 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 7 Feb 2024 19:32:03 +0800
+Subject: [PATCH 3/5] Fix build for other architectures
 
 ---
  cmake/scripts/linux/ArchSetup.cmake | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/cmake/scripts/linux/ArchSetup.cmake b/cmake/scripts/linux/ArchSetup.cmake
-index 624edf6..f8a2a00 100644
+index 4083483173..7ff62cab05 100644
 --- a/cmake/scripts/linux/ArchSetup.cmake
 +++ b/cmake/scripts/linux/ArchSetup.cmake
-@@ -33,7 +33,7 @@ else()
-     set(ARCH aarch64)
-     set(NEON True)
+@@ -47,7 +47,7 @@ else()
+     set(ARCH loongarch64)
+     set(NEON False)
    else()
 -    message(SEND_ERROR "Unknown CPU: ${CPU}")
 +    set(NEON False)
@@ -21,5 +21,5 @@ index 624edf6..f8a2a00 100644
  endif()
  
 -- 
-2.27.0
+2.43.0
 

--- a/app-multimedia/kodi/autobuild/patches/0004-allow-separate-windowing-binaries-being-launched-fro.patch
+++ b/app-multimedia/kodi/autobuild/patches/0004-allow-separate-windowing-binaries-being-launched-fro.patch
@@ -1,8 +1,8 @@
-From 5b75228b51c3422644468050debbc495f5195585 Mon Sep 17 00:00:00 2001
+From 338f834641787183160f97f4711f10e53dd2a1bd Mon Sep 17 00:00:00 2001
 From: BlackEagle <ike.devolder@gmail.com>
 Date: Thu, 25 Feb 2021 15:24:21 +0100
-Subject: [PATCH] allow separate windowing binaries being launched from kodi
- wrapper
+Subject: [PATCH 4/5] allow separate windowing binaries being launched from
+ kodi wrapper
 
 Signed-off-by: BlackEagle <ike.devolder@gmail.com>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: BlackEagle <ike.devolder@gmail.com>
  1 file changed, 28 insertions(+), 1 deletion(-)
 
 diff --git a/tools/Linux/kodi.sh.in b/tools/Linux/kodi.sh.in
-index 108c0b0..38a49e0 100644
+index 11cace29a5..404a8966b8 100644
 --- a/tools/Linux/kodi.sh.in
 +++ b/tools/Linux/kodi.sh.in
 @@ -28,6 +28,7 @@ LIBDIR="@libdir@"
@@ -63,5 +63,5 @@ index 108c0b0..38a49e0 100644
  if [ ! -x ${KODI_BINARY} ]; then
      echo "Error: ${KODI_BINARY} not found"
 -- 
-2.30.1
+2.43.0
 

--- a/app-multimedia/kodi/autobuild/patches/0005-ffmpeg-fix-build-with-binutils-update.patch
+++ b/app-multimedia/kodi/autobuild/patches/0005-ffmpeg-fix-build-with-binutils-update.patch
@@ -1,7 +1,7 @@
-From 6a83b674531d980a459057a8fd7c8b5050ba2f7c Mon Sep 17 00:00:00 2001
+From b9b28d631a51a123126ab6c808a7f21f85297eb7 Mon Sep 17 00:00:00 2001
 From: graysky <therealgraysky AT proton DOT me>
 Date: Wed, 2 Aug 2023 14:43:24 -0400
-Subject: [PATCH] ffmpeg: fix build with binutils update
+Subject: [PATCH 5/5] ffmpeg: fix build with binutils update
 
 ---
  cmake/modules/FindFFMPEG.cmake                |  5 +-
@@ -10,10 +10,10 @@ Subject: [PATCH] ffmpeg: fix build with binutils update
  create mode 100644 tools/depends/target/ffmpeg/0001-Fixes-assembling-w-binutil-as-2.41.patch
 
 diff --git a/cmake/modules/FindFFMPEG.cmake b/cmake/modules/FindFFMPEG.cmake
-index e53a121..eca8e27 100644
+index fedbf0adde..78b781f457 100644
 --- a/cmake/modules/FindFFMPEG.cmake
 +++ b/cmake/modules/FindFFMPEG.cmake
-@@ -85,7 +85,10 @@ macro(buildFFMPEG)
+@@ -96,7 +96,10 @@ macro(buildFFMPEG)
                   -DPKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig)
    set(PATCH_COMMAND ${CMAKE_COMMAND} -E copy
                      ${CMAKE_SOURCE_DIR}/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -27,7 +27,7 @@ index e53a121..eca8e27 100644
      set(FFMPEG_GENERATOR CMAKE_GENERATOR "Unix Makefiles")
 diff --git a/tools/depends/target/ffmpeg/0001-Fixes-assembling-w-binutil-as-2.41.patch b/tools/depends/target/ffmpeg/0001-Fixes-assembling-w-binutil-as-2.41.patch
 new file mode 100644
-index 0000000..33fd3d4
+index 0000000000..33fd3d484f
 --- /dev/null
 +++ b/tools/depends/target/ffmpeg/0001-Fixes-assembling-w-binutil-as-2.41.patch
 @@ -0,0 +1,76 @@
@@ -108,5 +108,5 @@ index 0000000..33fd3d4
 +2.30.2
 +
 -- 
-2.41.0
+2.43.0
 

--- a/app-multimedia/kodi/spec
+++ b/app-multimedia/kodi/spec
@@ -1,5 +1,4 @@
-VER=20.2
-REL=1
+VER=20.3
 PERIPHERAL_JOYSTICK_VER=20.1.0
 CODE=Nexus
 # Note: Take commit from branch with the corresponding codename.


### PR DESCRIPTION
Topic Description
-----------------

- kodi: update to 20.3
    - Tracking patches at AOSC-Tracking/kodi@aosc/20.3-Nexus.

Package(s) Affected
-------------------

- kodi: 1:20.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit kodi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
