### PR TITLE
chore: promote loongarch64 as primary architecture

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -47,6 +47,7 @@ Test Build(s) Done
 
 - [ ] AMD64 `amd64`
 - [ ] AArch64 `arm64`
+- [ ] LoongArch 64-bit `loongarch64`
 <!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
 <!-- - [ ] 32-bit Optional Environment `optenv32` -->
 


### PR DESCRIPTION
Per the title.