### PR TITLE
gdb: update to 14.1

### DIFF
--- a/app-devel/gdb/spec
+++ b/app-devel/gdb/spec
@@ -1,4 +1,4 @@
-VER=13.2
+VER=14.1
 SRCS="tbl::https://ftp.gnu.org/gnu/gdb/gdb-$VER.tar.xz"
-CHKSUMS="sha256::fd5bebb7be1833abdb6e023c2f498a354498281df9d05523d8915babeb893f0a"
+CHKSUMS="sha256::d66df51276143451fcbff464cc8723d68f1e9df45a6a2d5635a54e71643edb80"
 CHKUPDATE="anitya::id=11798"


### PR DESCRIPTION
Topic Description
-----------------

- gdb: update to 14.1

Package(s) Affected
-------------------

- gdb: 14.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
