### PR TITLE
zsh-syntax-highlighting: update to 0.8.0

### DIFF
--- a/app-shells/zsh-syntax-highlighting/spec
+++ b/app-shells/zsh-syntax-highlighting/spec
@@ -1,5 +1,4 @@
-VER=0.7.1
-SRCS="tbl::https://github.com/zsh-users/zsh-syntax-highlighting/archive/$VER.tar.gz"
-CHKSUMS="sha256::f5044266ee198468b1bcec881a56e6399e209657d6ed9fa6d21175bc76afdefa"
-SUBDIR="zsh-syntax-highlighting-$VER"
+VER=0.8.0
+SRCS="git::commit=$VER::https://github.com/zsh-users/zsh-syntax-highlighting"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7552"


### PR DESCRIPTION
Topic Description
-----------------

- zsh-syntax-highlighting: update to 0.8.0

Package(s) Affected
-------------------

- zsh-syntax-highlighting: 0.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit zsh-syntax-highlighting
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
