### PR TITLE
discord: update to 0.0.43

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.42
+VER=0.0.43
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::edc6a7d7926105ce8e240599324f2e11db7f0f5a2b08a1b530dd5605d4d9ac8d"
+CHKSUMS="sha256::0cef1b4b996e48a84a5bab09661cf8c557883dec50568683e3162e80708ddee9"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- discord: update to 0.0.43

Package(s) Affected
-------------------

- discord: 0.0.43

Security Update?
----------------

No

Build Order
-----------

```
#buildit discord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
