### PR TITLE
LLVM Rework for RISCV

### DIFF
--- a/app-devel/llvm/01-runtime/build
+++ b/app-devel/llvm/01-runtime/build
@@ -32,6 +32,12 @@ if ab_match_arch loongarch64; then
   export CXXFLAGS="${CXXFLAGS} -mcmodel=medium"
 fi
 
+# Remove this when uleb128 relocation support is landed
+if ab_match_arch riscv64; then
+  abinfo "Stripping debug symbols from libc_nonshared.a for ULEB128 relocation ..."
+  strip --strip-debug /usr/lib/libc_nonshared.a
+fi
+
 abinfo "Running CMake for LLVM ..."
 cmake "$SRCDIR" \
     ${CMAKE_DEF[@]} ${CMAKE_AFTER} \

--- a/app-devel/llvm/01-runtime/patches/0001-Add-AOSC-exclusive-target-tuples.patch
+++ b/app-devel/llvm/01-runtime/patches/0001-Add-AOSC-exclusive-target-tuples.patch
@@ -1,7 +1,7 @@
 From 9604ebbd077082657864275dd1bbd3b91c0ee715 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:47:14 -0800
-Subject: [PATCH 01/15] Add AOSC exclusive target tuples
+Subject: [PATCH 01/18] Add AOSC exclusive target tuples
 
 ---
  clang/lib/Driver/ToolChains/Gnu.cpp | 14 +++++++++-----

--- a/app-devel/llvm/01-runtime/patches/0002-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
+++ b/app-devel/llvm/01-runtime/patches/0002-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
@@ -1,7 +1,7 @@
 From 23ee3781660ab3a921ba7dd8b5fd9f481bf53703 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:48:08 -0800
-Subject: [PATCH 02/15] Fix fuzzer objects building when LTO is enabled
+Subject: [PATCH 02/18] Fix fuzzer objects building when LTO is enabled
 
 ---
  compiler-rt/lib/fuzzer/CMakeLists.txt | 2 +-

--- a/app-devel/llvm/01-runtime/patches/0003-Fix-MSVC-detection.patch
+++ b/app-devel/llvm/01-runtime/patches/0003-Fix-MSVC-detection.patch
@@ -1,7 +1,7 @@
-From 15abfba831ffd39741ca809f6efc5084bd0ef192 Mon Sep 17 00:00:00 2001
+From be781c64fd59b75c20fce636552e86a3631364ad Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:49:47 -0800
-Subject: [PATCH 04/15] Fix MSVC detection
+Subject: [PATCH 03/18] Fix MSVC detection
 
 ---
  llvm/cmake/modules/CheckProblematicConfigurations.cmake | 2 +-

--- a/app-devel/llvm/01-runtime/patches/0004-mips-Add-stub-for-mips64-LLDB-impl.patch
+++ b/app-devel/llvm/01-runtime/patches/0004-mips-Add-stub-for-mips64-LLDB-impl.patch
@@ -1,7 +1,7 @@
-From c0c59f2dd5deac176a46825bb45e5d5ca046539c Mon Sep 17 00:00:00 2001
+From 24f4e4f49cf9ff43131595137949bc5e70e396e5 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:49:26 -0800
-Subject: [PATCH 03/15] Add stub for mips64 LLDB impl
+Subject: [PATCH 04/18] [mips] Add stub for mips64 LLDB impl
 
 ---
  .../Plugins/Process/Linux/NativeRegisterContextLinux.h     | 7 ++++++-

--- a/app-devel/llvm/01-runtime/patches/0005-mips-Fix-compiler-rt-tailcall-on-mips.patch
+++ b/app-devel/llvm/01-runtime/patches/0005-mips-Fix-compiler-rt-tailcall-on-mips.patch
@@ -1,7 +1,7 @@
-From 3af333ea35ebc5e8c43ade76f585b3b5e9555de6 Mon Sep 17 00:00:00 2001
+From 14946c1d15a004b51610ab18e255a548b647d9b4 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:51:33 -0800
-Subject: [PATCH 06/15] Fix compiler-rt tailcall on mips
+Subject: [PATCH 05/18] [mips] Fix compiler-rt tailcall on mips
 
 See https://reviews.llvm.org/D158491
 ---

--- a/app-devel/llvm/01-runtime/patches/0006-mips-Add-stub-for-lldb-arch-functions-on-loongson3.patch
+++ b/app-devel/llvm/01-runtime/patches/0006-mips-Add-stub-for-lldb-arch-functions-on-loongson3.patch
@@ -1,7 +1,7 @@
-From a39d4440001f4d3303600ff204c9f6cffbc1217f Mon Sep 17 00:00:00 2001
+From 7b067e563da6877ec1c6fbd8e5b6d0e807cbce1d Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:52:51 -0800
-Subject: [PATCH 12/15] Add stub for lldb arch functions on loongson3
+Subject: [PATCH 06/18] [mips] Add stub for lldb arch functions on loongson3
 
 ---
  .../Plugins/Process/Linux/NativeRegisterContextLinux.h    | 8 ++++++++

--- a/app-devel/llvm/01-runtime/patches/0007-mips-HACK-force-enable-cacheflush-function.patch
+++ b/app-devel/llvm/01-runtime/patches/0007-mips-HACK-force-enable-cacheflush-function.patch
@@ -1,7 +1,7 @@
-From 9f0b1f779af5f63c39ff015d46dccad06c3eb6f2 Mon Sep 17 00:00:00 2001
+From 2a7c0e9bb47697641c9e523e1dd5c1ee55b4d0c2 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:53:18 -0800
-Subject: [PATCH 13/15] HACK: force enable cacheflush function
+Subject: [PATCH 07/18] [mips] HACK: force enable cacheflush function
 
 ---
  compiler-rt/lib/builtins/clear_cache.c | 1 +

--- a/app-devel/llvm/01-runtime/patches/0008-mips-Fix-build-of-LinuxSignals-on-Mips.patch
+++ b/app-devel/llvm/01-runtime/patches/0008-mips-Fix-build-of-LinuxSignals-on-Mips.patch
@@ -1,7 +1,7 @@
-From 62a4125949b1ea78e2b869c7c6979c0359bc728a Mon Sep 17 00:00:00 2001
+From 1e60c34aedba6efd2ae2ff14eafd518e72f996ab Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Wed, 31 Jan 2024 14:37:12 +0800
-Subject: [PATCH 15/15] Fix build of LinuxSignals on Mips
+Subject: [PATCH 08/18] [mips] Fix build of LinuxSignals on Mips
 
 But only the build, not the functionality because lldb won't work
 anyway.

--- a/app-devel/llvm/01-runtime/patches/0009-mips-Use-pc-relative-relocations-in-.eh_frame.patch
+++ b/app-devel/llvm/01-runtime/patches/0009-mips-Use-pc-relative-relocations-in-.eh_frame.patch
@@ -1,7 +1,7 @@
-From 13ffcd764437c6c8ef6276c919a9dfc36616c1d4 Mon Sep 17 00:00:00 2001
+From 342ae049673a5e72a15899f349d55a02e38840b8 Mon Sep 17 00:00:00 2001
 From: Simon Atanasyan <simon@atanasyan.com>
 Date: Tue, 2 Jan 2024 22:29:22 -0700
-Subject: [PATCH 05/15] Use pc-relative relocations in .eh_frame
+Subject: [PATCH 09/18] [mips] Use pc-relative relocations in .eh_frame
 
 Co-Authored-By: liushuyu <liushuyu011@gmail.com>
 ---

--- a/app-devel/llvm/01-runtime/patches/0010-mips-Fix-Mips-N64-detection-and-set-znotext-as-defau.patch
+++ b/app-devel/llvm/01-runtime/patches/0010-mips-Fix-Mips-N64-detection-and-set-znotext-as-defau.patch
@@ -1,7 +1,8 @@
-From 75d2d959c3dd8a2df24bcb5b2c26346aeb96be4a Mon Sep 17 00:00:00 2001
+From 1c7ce87dfa925c8d355d85e9a522d957615540be Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Tue, 30 Jan 2024 18:52:54 +0800
-Subject: [PATCH 14/15] Fix Mips N64 detection and set -znotext as default
+Subject: [PATCH 10/18] [mips] Fix Mips N64 detection and set -znotext as
+ default
 
 ---
  lld/ELF/Driver.cpp                                |  2 +-

--- a/app-devel/llvm/01-runtime/patches/0011-rust-Add-accessors-for-MCSubtargetInfo-CPU-and-Featu.patch
+++ b/app-devel/llvm/01-runtime/patches/0011-rust-Add-accessors-for-MCSubtargetInfo-CPU-and-Featu.patch
@@ -1,25 +1,22 @@
-From f098f0461635e50d515d7181423c91ec93ad8ae3 Mon Sep 17 00:00:00 2001
+From 24f069f87bbc419d3b124668749c6c27443b986e Mon Sep 17 00:00:00 2001
 From: Cameron Hart <cameron.hart@gmail.com>
 Date: Sun, 10 Jul 2016 23:55:53 +1000
-Subject: [PATCH 07/15] [rust] Add accessors for MCSubtargetInfo CPU and
+Subject: [PATCH 11/18] [rust] Add accessors for MCSubtargetInfo CPU and
  Feature tables
 
 This is needed for `-C target-cpu=help` and `-C target-feature=help` in rustc
 ---
- llvm/include/llvm/MC/MCSubtargetInfo.h | 8 ++++++++
- 1 file changed, 8 insertions(+)
+ llvm/include/llvm/MC/MCSubtargetInfo.h | 5 +++++
+ 1 file changed, 5 insertions(+)
 
 diff --git a/llvm/include/llvm/MC/MCSubtargetInfo.h b/llvm/include/llvm/MC/MCSubtargetInfo.h
-index c1533ac8d005..be289de71119 100644
+index c1533ac8d005..2c5ba9a02140 100644
 --- a/llvm/include/llvm/MC/MCSubtargetInfo.h
 +++ b/llvm/include/llvm/MC/MCSubtargetInfo.h
-@@ -234,6 +234,14 @@ public:
+@@ -234,6 +234,11 @@ public:
      return ProcDesc;
    }
  
-+  ArrayRef<SubtargetSubTypeKV> getCPUTable() const {
-+    return ProcDesc;
-+  }
 +
 +  ArrayRef<SubtargetFeatureKV> getFeatureTable() const {
 +    return ProcFeatures;

--- a/app-devel/llvm/01-runtime/patches/0012-rust-Compile-with-MT-on-MSVC.patch
+++ b/app-devel/llvm/01-runtime/patches/0012-rust-Compile-with-MT-on-MSVC.patch
@@ -1,7 +1,7 @@
-From e22b02b01c1374967cb440cab5e748b9ab566133 Mon Sep 17 00:00:00 2001
+From 8412eefeaffd945df058524263a8060b7ed7d6e2 Mon Sep 17 00:00:00 2001
 From: Alex Crichton <alex@alexcrichton.com>
 Date: Sat, 10 Feb 2018 17:21:38 -0800
-Subject: [PATCH 08/15] [rust] Compile with /MT on MSVC
+Subject: [PATCH 12/18] [rust] Compile with /MT on MSVC
 
 Can't seem to figure out how to do this without this patch...
 ---

--- a/app-devel/llvm/01-runtime/patches/0013-rust-Comment-out-__builtin_available-use-21.patch
+++ b/app-devel/llvm/01-runtime/patches/0013-rust-Comment-out-__builtin_available-use-21.patch
@@ -1,7 +1,7 @@
-From e83e9d7eb26997ba181c61f63d7d42266e74a251 Mon Sep 17 00:00:00 2001
+From ac5b31ebf9741eaef9d9911e3b73f45c93341230 Mon Sep 17 00:00:00 2001
 From: Nikita Popov <nikita.ppv@googlemail.com>
 Date: Fri, 12 Jul 2019 16:06:11 +0200
-Subject: [PATCH 09/15] [rust] Comment out __builtin_available() use (#21)
+Subject: [PATCH 13/18] [rust] Comment out __builtin_available() use (#21)
 
 __builtin_available() pulls in __isOSVersionAtLeast() from
 compiler-rt. Comment it out so we don't have to figure out how

--- a/app-devel/llvm/01-runtime/patches/0014-rust-Changes-needed-for-x86_64-fortanix-unknown-sgx-.patch
+++ b/app-devel/llvm/01-runtime/patches/0014-rust-Changes-needed-for-x86_64-fortanix-unknown-sgx-.patch
@@ -1,7 +1,7 @@
-From 965ec6045ac94a302310f4277660d797097da5cf Mon Sep 17 00:00:00 2001
+From 53d2a8790a912e72ad708ec6a8d0bd4bdd9b2222 Mon Sep 17 00:00:00 2001
 From: Adrian Cruceru <cruceruadrian@gmail.com>
 Date: Mon, 25 May 2020 20:58:30 +0200
-Subject: [PATCH 10/15] [rust] Changes needed for 'x86_64-fortanix-unknown-sgx'
+Subject: [PATCH 14/18] [rust] Changes needed for 'x86_64-fortanix-unknown-sgx'
  nightly target.
 
 Code is guarded via defines to enable only if 'RUST_SGX' is present.

--- a/app-devel/llvm/01-runtime/patches/0015-rust-Fix-FreeBSD-12-build.patch
+++ b/app-devel/llvm/01-runtime/patches/0015-rust-Fix-FreeBSD-12-build.patch
@@ -1,7 +1,7 @@
-From 08d07f72e6ae17b82ab7a579907730e5e449fc46 Mon Sep 17 00:00:00 2001
+From bbaf7e57818719771029d3f28a812088687219af Mon Sep 17 00:00:00 2001
 From: Nikita Popov <npopov@redhat.com>
 Date: Tue, 7 Mar 2023 09:28:18 +0100
-Subject: [PATCH 11/15] [rust] Fix FreeBSD 12 build
+Subject: [PATCH 15/18] [rust] Fix FreeBSD 12 build
 
 Clang 6 appears to be unable to handle CTAD in this position:
 

--- a/app-devel/llvm/01-runtime/patches/0016-RISCV-Support-R_RISCV_SET_ULEB128-R_RISCV_SUB_ULEB12.patch
+++ b/app-devel/llvm/01-runtime/patches/0016-RISCV-Support-R_RISCV_SET_ULEB128-R_RISCV_SUB_ULEB12.patch
@@ -1,0 +1,409 @@
+From d7156342d5cd4624463c292112b0f4f761630fc1 Mon Sep 17 00:00:00 2001
+From: Fangrui Song <i@maskray.me>
+Date: Thu, 9 Nov 2023 09:27:32 -0800
+Subject: [PATCH 16/18] [RISCV] Support R_RISCV_SET_ULEB128/R_RISCV_SUB_ULEB128
+ for .uleb128 directives
+
+For a label difference like `.uleb128 A-B`, MC folds A-B even if A and B
+are separated by a RISC-V linker-relaxable instruction. This incorrect
+behavior is currently abused by DWARF v5 .debug_loclists/.debug_rnglists
+(DW_LLE_offset_pair/DW_RLE_offset_pair entry kinds) implemented in
+Clang/LLVM (see https://github.com/ClangBuiltLinux/linux/issues/1719 for
+an instance).
+
+https://github.com/riscv-non-isa/riscv-elf-psabi-doc/commit/96d6e190e9fc04a8517f9ff7fb9aed3e9876cbd6
+defined R_RISCV_SET_ULEB128/R_RISCV_SUB_ULEB128. This patch generates such
+a pair of relocations to represent A-B that should not be folded.
+GNU assembler computes the directive size by ignoring shrinkable section
+content, therefore after linking the value of A-B cannot use more bytes
+than the reserved number (`final size of uleb128 value at offset ... exceeds available space`).
+We make the same assumption.
+```
+w1:
+  call foo
+w2:
+  .space 120
+w3:
+.uleb128 w2-w1  # 1 byte, 0x08
+.uleb128 w3-w1  # 2 bytes, 0x80 0x01
+```
+
+We do not conservatively reserve 10 bytes (maximum size of an uleb128
+for uint64_t) as that would pessimize DWARF v5
+DW_LLE_offset_pair/DW_RLE_offset_pair, nullifying the benefits of
+introducing R_RISCV_SET_ULEB128/R_RISCV_SUB_ULEB128 relocations.
+
+The supported expressions are limited. For example,
+
+* non-subtraction `.uleb128 A` is not allowed
+* `.uleb128 A-B`: report an error unless A and B are both defined and in the same section
+
+The new cl::opt `-riscv-uleb128-reloc` can be used to suppress the
+relocations.
+
+Reviewed By: asb
+
+Differential Revision: https://reviews.llvm.org/D157657
+---
+ .../llvm/BinaryFormat/ELFRelocs/RISCV.def     |  2 +
+ llvm/include/llvm/MC/MCAsmBackend.h           |  8 ++
+ llvm/include/llvm/MC/MCFixup.h                |  1 +
+ llvm/include/llvm/MC/MCFragment.h             | 11 ++-
+ llvm/lib/MC/MCAsmBackend.cpp                  |  1 +
+ llvm/lib/MC/MCAssembler.cpp                   | 35 ++++++--
+ .../RISCV/MCTargetDesc/RISCVAsmBackend.cpp    | 26 ++++++
+ .../RISCV/MCTargetDesc/RISCVAsmBackend.h      |  2 +
+ llvm/test/MC/ELF/RISCV/gen-dwarf.s            |  3 +-
+ llvm/test/MC/RISCV/leb128.s                   | 81 +++++++++++++++++++
+ 10 files changed, 156 insertions(+), 14 deletions(-)
+ create mode 100644 llvm/test/MC/RISCV/leb128.s
+
+diff --git a/llvm/include/llvm/BinaryFormat/ELFRelocs/RISCV.def b/llvm/include/llvm/BinaryFormat/ELFRelocs/RISCV.def
+index 9a126df01531..c7fd6490041c 100644
+--- a/llvm/include/llvm/BinaryFormat/ELFRelocs/RISCV.def
++++ b/llvm/include/llvm/BinaryFormat/ELFRelocs/RISCV.def
+@@ -55,3 +55,5 @@ ELF_RELOC(R_RISCV_SET32,             56)
+ ELF_RELOC(R_RISCV_32_PCREL,          57)
+ ELF_RELOC(R_RISCV_IRELATIVE,         58)
+ ELF_RELOC(R_RISCV_PLT32,             59)
++ELF_RELOC(R_RISCV_SET_ULEB128,       60)
++ELF_RELOC(R_RISCV_SUB_ULEB128,       61)
+diff --git a/llvm/include/llvm/MC/MCAsmBackend.h b/llvm/include/llvm/MC/MCAsmBackend.h
+index 5e08fb41679b..1fd83f9a7c62 100644
+--- a/llvm/include/llvm/MC/MCAsmBackend.h
++++ b/llvm/include/llvm/MC/MCAsmBackend.h
+@@ -21,6 +21,7 @@ class MCAlignFragment;
+ class MCDwarfCallFrameFragment;
+ class MCDwarfLineAddrFragment;
+ class MCFragment;
++class MCLEBFragment;
+ class MCRelaxableFragment;
+ class MCSymbol;
+ class MCAsmLayout;
+@@ -194,6 +195,13 @@ public:
+     return false;
+   }
+ 
++  // Defined by linker relaxation targets to possibly emit LEB128 relocations
++  // and set Value at the relocated location.
++  virtual bool relaxLEB128(MCLEBFragment &LF, MCAsmLayout &Layout,
++                           int64_t &Value) const {
++    return false;
++  }
++
+   /// @}
+ 
+   /// Returns the minimum size of a nop in bytes on this target. The assembler
+diff --git a/llvm/include/llvm/MC/MCFixup.h b/llvm/include/llvm/MC/MCFixup.h
+index 069ca058310f..7f48a90cb1ec 100644
+--- a/llvm/include/llvm/MC/MCFixup.h
++++ b/llvm/include/llvm/MC/MCFixup.h
+@@ -25,6 +25,7 @@ enum MCFixupKind {
+   FK_Data_4,      ///< A four-byte fixup.
+   FK_Data_8,      ///< A eight-byte fixup.
+   FK_Data_6b,     ///< A six-bits fixup.
++  FK_Data_leb128, ///< A leb128 fixup.
+   FK_PCRel_1,     ///< A one-byte pc relative fixup.
+   FK_PCRel_2,     ///< A two-byte pc relative fixup.
+   FK_PCRel_4,     ///< A four-byte pc relative fixup.
+diff --git a/llvm/include/llvm/MC/MCFragment.h b/llvm/include/llvm/MC/MCFragment.h
+index 7be4792a4521..efe44b0b6917 100644
+--- a/llvm/include/llvm/MC/MCFragment.h
++++ b/llvm/include/llvm/MC/MCFragment.h
+@@ -428,7 +428,7 @@ public:
+   }
+ };
+ 
+-class MCLEBFragment : public MCFragment {
++class MCLEBFragment final : public MCEncodedFragmentWithFixups<10, 1> {
+   /// True if this is a sleb128, false if uleb128.
+   bool IsSigned;
+ 
+@@ -438,18 +438,17 @@ class MCLEBFragment : public MCFragment {
+   SmallString<8> Contents;
+ 
+ public:
+-  MCLEBFragment(const MCExpr &Value_, bool IsSigned_, MCSection *Sec = nullptr)
+-      : MCFragment(FT_LEB, false, Sec), IsSigned(IsSigned_), Value(&Value_) {
++  MCLEBFragment(const MCExpr &Value, bool IsSigned, MCSection *Sec = nullptr)
++      : MCEncodedFragmentWithFixups<10, 1>(FT_LEB, false, Sec),
++        IsSigned(IsSigned), Value(&Value) {
+     Contents.push_back(0);
+   }
+ 
+   const MCExpr &getValue() const { return *Value; }
++  void setValue(const MCExpr *Expr) { Value = Expr; }
+ 
+   bool isSigned() const { return IsSigned; }
+ 
+-  SmallString<8> &getContents() { return Contents; }
+-  const SmallString<8> &getContents() const { return Contents; }
+-
+   /// @}
+ 
+   static bool classof(const MCFragment *F) {
+diff --git a/llvm/lib/MC/MCAsmBackend.cpp b/llvm/lib/MC/MCAsmBackend.cpp
+index 64bbc63719c7..2eef7d363fe7 100644
+--- a/llvm/lib/MC/MCAsmBackend.cpp
++++ b/llvm/lib/MC/MCAsmBackend.cpp
+@@ -89,6 +89,7 @@ const MCFixupKindInfo &MCAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
+       {"FK_Data_4", 0, 32, 0},
+       {"FK_Data_8", 0, 64, 0},
+       {"FK_Data_6b", 0, 6, 0},
++      {"FK_Data_leb128", 0, 0, 0},
+       {"FK_PCRel_1", 0, 8, MCFixupKindInfo::FKF_IsPCRel},
+       {"FK_PCRel_2", 0, 16, MCFixupKindInfo::FKF_IsPCRel},
+       {"FK_PCRel_4", 0, 32, MCFixupKindInfo::FKF_IsPCRel},
+diff --git a/llvm/lib/MC/MCAssembler.cpp b/llvm/lib/MC/MCAssembler.cpp
+index 55ed1a285cd7..e25bfc044a15 100644
+--- a/llvm/lib/MC/MCAssembler.cpp
++++ b/llvm/lib/MC/MCAssembler.cpp
+@@ -918,6 +918,12 @@ void MCAssembler::layout(MCAsmLayout &Layout) {
+         Contents = DF.getContents();
+         break;
+       }
++      case MCFragment::FT_LEB: {
++        auto &LF = cast<MCLEBFragment>(Frag);
++        Fixups = LF.getFixups();
++        Contents = LF.getContents();
++        break;
++      }
+       case MCFragment::FT_PseudoProbe: {
+         MCPseudoProbeAddrFragment &PF = cast<MCPseudoProbeAddrFragment>(Frag);
+         Fixups = PF.getFixups();
+@@ -1006,12 +1012,27 @@ bool MCAssembler::relaxInstruction(MCAsmLayout &Layout,
+ }
+ 
+ bool MCAssembler::relaxLEB(MCAsmLayout &Layout, MCLEBFragment &LF) {
+-  uint64_t OldSize = LF.getContents().size();
++  const unsigned OldSize = static_cast<unsigned>(LF.getContents().size());
++  unsigned PadTo = OldSize;
+   int64_t Value;
+-  bool Abs = LF.getValue().evaluateKnownAbsolute(Value, Layout);
+-  if (!Abs)
+-    report_fatal_error("sleb128 and uleb128 expressions must be absolute");
+-  SmallString<8> &Data = LF.getContents();
++  SmallVectorImpl<char> &Data = LF.getContents();
++  LF.getFixups().clear();
++  // Use evaluateKnownAbsolute for Mach-O as a hack: .subsections_via_symbols
++  // requires that .uleb128 A-B is foldable where A and B reside in different
++  // fragments. This is used by __gcc_except_table.
++  bool Abs = getSubsectionsViaSymbols()
++                 ? LF.getValue().evaluateKnownAbsolute(Value, Layout)
++                 : LF.getValue().evaluateAsAbsolute(Value, Layout);
++  if (!Abs) {
++    if (!getBackend().relaxLEB128(LF, Layout, Value)) {
++      getContext().reportError(LF.getValue().getLoc(),
++                               Twine(LF.isSigned() ? ".s" : ".u") +
++                                   "leb128 expression is not absolute");
++      LF.setValue(MCConstantExpr::create(0, Context));
++    }
++    uint8_t Tmp[10]; // maximum size: ceil(64/7)
++    PadTo = std::max(PadTo, encodeULEB128(uint64_t(Value), Tmp));
++  }
+   Data.clear();
+   raw_svector_ostream OSE(Data);
+   // The compiler can generate EH table assembly that is impossible to assemble
+@@ -1019,9 +1040,9 @@ bool MCAssembler::relaxLEB(MCAsmLayout &Layout, MCLEBFragment &LF) {
+   // to a later alignment fragment. To accommodate such tables, relaxation can
+   // only increase an LEB fragment size here, not decrease it. See PR35809.
+   if (LF.isSigned())
+-    encodeSLEB128(Value, OSE, OldSize);
++    encodeSLEB128(Value, OSE, PadTo);
+   else
+-    encodeULEB128(Value, OSE, OldSize);
++    encodeULEB128(Value, OSE, PadTo);
+   return OldSize != LF.getContents().size();
+ }
+ 
+diff --git a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
+index 1b890fbe041a..e1e5d3340918 100644
+--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
++++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
+@@ -19,6 +19,7 @@
+ #include "llvm/MC/MCObjectWriter.h"
+ #include "llvm/MC/MCSymbol.h"
+ #include "llvm/MC/MCValue.h"
++#include "llvm/Support/CommandLine.h"
+ #include "llvm/Support/Endian.h"
+ #include "llvm/Support/EndianStream.h"
+ #include "llvm/Support/ErrorHandling.h"
+@@ -27,6 +28,13 @@
+ 
+ using namespace llvm;
+ 
++// Temporary workaround for old linkers that do not support ULEB128 relocations,
++// which are abused by DWARF v5 DW_LLE_offset_pair/DW_RLE_offset_pair
++// implemented in Clang/LLVM.
++static cl::opt<bool> ULEB128Reloc(
++    "riscv-uleb128-reloc", cl::init(true), cl::Hidden,
++    cl::desc("Emit R_RISCV_SET_ULEB128/E_RISCV_SUB_ULEB128 if appropriate"));
++
+ std::optional<MCFixupKind> RISCVAsmBackend::getFixupKind(StringRef Name) const {
+   if (STI.getTargetTriple().isOSBinFormatELF()) {
+     unsigned Type;
+@@ -126,6 +134,7 @@ bool RISCVAsmBackend::shouldForceRelocation(const MCAssembler &Asm,
+   case FK_Data_2:
+   case FK_Data_4:
+   case FK_Data_8:
++  case FK_Data_leb128:
+     if (Target.isAbsolute())
+       return false;
+     break;
+@@ -330,6 +339,18 @@ bool RISCVAsmBackend::relaxDwarfCFA(MCDwarfCallFrameFragment &DF,
+   return true;
+ }
+ 
++bool RISCVAsmBackend::relaxLEB128(MCLEBFragment &LF, MCAsmLayout &Layout,
++                                  int64_t &Value) const {
++  if (LF.isSigned())
++    return false;
++  const MCExpr &Expr = LF.getValue();
++  if (ULEB128Reloc) {
++    LF.getFixups().push_back(
++        MCFixup::create(0, &Expr, FK_Data_leb128, Expr.getLoc()));
++  }
++  return Expr.evaluateKnownAbsolute(Value, Layout);
++}
++
+ // Given a compressed control flow instruction this function returns
+ // the expanded instruction.
+ unsigned RISCVAsmBackend::getRelaxedOpcode(unsigned Op) const {
+@@ -416,6 +437,7 @@ static uint64_t adjustFixupValue(const MCFixup &Fixup, uint64_t Value,
+   case FK_Data_4:
+   case FK_Data_8:
+   case FK_Data_6b:
++  case FK_Data_leb128:
+     return Value;
+   case RISCV::fixup_riscv_set_6b:
+     return Value & 0x03;
+@@ -596,6 +618,10 @@ bool RISCVAsmBackend::handleAddSubRelocations(const MCAsmLayout &Layout,
+     TA = ELF::R_RISCV_ADD64;
+     TB = ELF::R_RISCV_SUB64;
+     break;
++  case llvm::FK_Data_leb128:
++    TA = ELF::R_RISCV_SET_ULEB128;
++    TB = ELF::R_RISCV_SUB_ULEB128;
++    break;
+   default:
+     llvm_unreachable("unsupported fixup size");
+   }
+diff --git a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.h b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.h
+index 0ea1f32e8296..baea6b922f01 100644
+--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.h
++++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.h
+@@ -99,6 +99,8 @@ public:
+                           bool &WasRelaxed) const override;
+   bool relaxDwarfCFA(MCDwarfCallFrameFragment &DF, MCAsmLayout &Layout,
+                      bool &WasRelaxed) const override;
++  bool relaxLEB128(MCLEBFragment &LF, MCAsmLayout &Layout,
++                   int64_t &Value) const override;
+ 
+   bool writeNopData(raw_ostream &OS, uint64_t Count,
+                     const MCSubtargetInfo *STI) const override;
+diff --git a/llvm/test/MC/ELF/RISCV/gen-dwarf.s b/llvm/test/MC/ELF/RISCV/gen-dwarf.s
+index 2235559d5f35..342ed1cc0e7e 100644
+--- a/llvm/test/MC/ELF/RISCV/gen-dwarf.s
++++ b/llvm/test/MC/ELF/RISCV/gen-dwarf.s
+@@ -48,9 +48,10 @@
+ # RELOC-NEXT:   0x34 R_RISCV_32_PCREL <null> 0x0
+ # RELOC-NEXT: }
+ 
+-## TODO A section needs two relocations.
+ # RELOC:      Section ([[#]]) .rela.debug_rnglists {
+ # RELOC-NEXT:   0xD R_RISCV_64 .text.foo 0x0
++# RELOC-NEXT:   0x15 R_RISCV_SET_ULEB128 <null> 0x0
++# RELOC-NEXT:   0x15 R_RISCV_SUB_ULEB128 .text.foo 0x0
+ # RELOC-NEXT:   0x17 R_RISCV_64 .text.bar 0x0
+ # RELOC-NEXT: }
+ 
+diff --git a/llvm/test/MC/RISCV/leb128.s b/llvm/test/MC/RISCV/leb128.s
+new file mode 100644
+index 000000000000..429eac697182
+--- /dev/null
++++ b/llvm/test/MC/RISCV/leb128.s
+@@ -0,0 +1,81 @@
++# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=-relax %s -o %t
++# RUN: llvm-readobj -r -x .alloc_w %t| FileCheck %s
++# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+relax %s -o %t.relax
++# RUN: llvm-readobj -r -x .alloc_w %t.relax | FileCheck %s --check-prefixes=CHECK,RELAX
++
++# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=-relax %s -o %t
++# RUN: llvm-readobj -r -x .alloc_w %t | FileCheck %s
++# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax %s -o %t.relax
++# RUN: llvm-readobj -r -x .alloc_w %t.relax | FileCheck %s --check-prefixes=CHECK,RELAX
++
++## Test temporary workaround for suppressting relocations for actually-non-foldable
++## DWARF v5 DW_LLE_offset_pair/DW_RLE_offset_pair.
++# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=-relax -riscv-uleb128-reloc=0 %s -o %t0
++# RUN: llvm-readobj -r -x .alloc_w %t0 | FileCheck %s --check-prefix=CHECK0
++# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax -riscv-uleb128-reloc=0 %s -o %t0.relax
++# RUN: llvm-readobj -r -x .alloc_w %t0.relax | FileCheck %s --check-prefixes=CHECK0,RELAX0
++
++# RUN: not llvm-mc -filetype=obj -triple=riscv64 -mattr=-relax --defsym ERR=1 %s -o /dev/null 2>&1 | \
++# RUN:   FileCheck %s --check-prefix=ERR
++# RUN: not llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax --defsym ERR=1 %s -o /dev/null 2>&1 | \
++# RUN:   FileCheck %s --check-prefix=ERR
++
++# CHECK0:      Relocations [
++# CHECK0-NEXT:   .rela.alloc_w {
++# CHECK0-NEXT:     0x2 R_RISCV_CALL_PLT foo 0x0
++# RELAX0-NEXT:     0x2 R_RISCV_RELAX - 0x0
++# CHECK0-NEXT:   }
++# CHECK0-NEXT: ]
++
++# CHECK:      Relocations [
++# CHECK-NEXT:   .rela.alloc_w {
++# CHECK-NEXT:     0x0 R_RISCV_SET_ULEB128 w1 0x0
++# CHECK-NEXT:     0x0 R_RISCV_SUB_ULEB128 w 0x0
++# RELAX-NEXT:     0x1 R_RISCV_SET_ULEB128 w2 0x0
++# RELAX-NEXT:     0x1 R_RISCV_SUB_ULEB128 w1 0x0
++# CHECK-NEXT:     0x2 R_RISCV_CALL_PLT foo 0x0
++# RELAX-NEXT:     0x2 R_RISCV_RELAX - 0x0
++# RELAX-NEXT:     0xA R_RISCV_SET_ULEB128 w2 0x0
++# RELAX-NEXT:     0xA R_RISCV_SUB_ULEB128 w1 0x0
++# RELAX-NEXT:     0xB R_RISCV_SET_ULEB128 w2 0x78
++# RELAX-NEXT:     0xB R_RISCV_SUB_ULEB128 w1 0x0
++# RELAX-NEXT:     0xD R_RISCV_SET_ULEB128 w1 0x0
++# RELAX-NEXT:     0xD R_RISCV_SUB_ULEB128 w2 0x0
++# CHECK-NEXT:   }
++# CHECK-NEXT: ]
++
++## R_RISCV_SET_ULEB128 relocated locations contain values not accounting for linker relaxation.
++# CHECK:      Hex dump of section '.alloc_w':
++# CHECK-NEXT: 0x00000000 02089700 0000e780 00000880 01f8ffff ................
++# CHECK-NEXT: 0x00000010 ffffffff ffff01                     .......
++
++.section .alloc_w,"ax",@progbits; w:
++.uleb128 w1-w       # w1 is later defined in the same section
++.uleb128 w2-w1      # w1 and w2 are separated by a linker relaxable instruction
++w1:
++  call foo
++w2:
++.uleb128 w2-w1      # 0x08
++.uleb128 w2-w1+120  # 0x0180
++.uleb128 -(w2-w1)   # 0x01fffffffffffffffff8
++
++.ifdef ERR
++# ERR: :[[#@LINE+1]]:16: error: .uleb128 expression is not absolute
++.uleb128 extern-w   # extern is undefined
++# ERR: :[[#@LINE+1]]:11: error: .uleb128 expression is not absolute
++.uleb128 w-extern
++# ERR: :[[#@LINE+1]]:11: error: .uleb128 expression is not absolute
++.uleb128 x-w        # x is later defined in another section
++
++.section .alloc_x,"aw",@progbits; x:
++# ERR: :[[#@LINE+1]]:11: error: .uleb128 expression is not absolute
++.uleb128 y-x
++.section .alloc_y,"aw",@progbits; y:
++# ERR: :[[#@LINE+1]]:11: error: .uleb128 expression is not absolute
++.uleb128 x-y
++
++# ERR: :[[#@LINE+1]]:10: error: .uleb128 expression is not absolute
++.uleb128 extern
++# ERR: :[[#@LINE+1]]:10: error: .uleb128 expression is not absolute
++.uleb128 y
++.endif
+-- 
+2.43.0
+

--- a/app-devel/llvm/01-runtime/patches/0017-ELF-Support-R_RISCV_SET_ULEB128-R_RISCV_SUB_ULEB128-.patch
+++ b/app-devel/llvm/01-runtime/patches/0017-ELF-Support-R_RISCV_SET_ULEB128-R_RISCV_SUB_ULEB128-.patch
@@ -1,0 +1,279 @@
+From afc7d7a63195d635e183ca3e373773b35565e918 Mon Sep 17 00:00:00 2001
+From: Fangrui Song <i@maskray.me>
+Date: Tue, 21 Nov 2023 07:43:29 -0800
+Subject: [PATCH 17/18] [ELF] Support R_RISCV_SET_ULEB128/R_RISCV_SUB_ULEB128
+ in non-SHF_ALLOC sections (#72610)
+
+For a label difference like `.uleb128 A-B`, MC generates a pair of
+R_RISCV_SET_ULEB128/R_RISCV_SUB_ULEB128 if A-B cannot be folded as a
+constant. GNU assembler generates a pair of relocations in more cases
+(when A or B is in a code section with linker relaxation).
+
+`.uleb128 A-B` is primarily used by DWARF v5
+.debug_loclists/.debug_rnglists (DW_LLE_offset_pair/DW_RLE_offset_pair
+entry kinds) implemented in Clang and GCC.
+
+`.uleb128 A-B` can be used in SHF_ALLOC sections as well (e.g.
+`.gcc_except_table`). This patch does not handle SHF_ALLOC.
+
+`-z dead-reloc-in-nonalloc=` can be used to change the relocated value,
+if the R_RISCV_SET_ULEB128 symbol is in a discarded section. We don't
+check the R_RISCV_SUB_ULEB128 symbol since for the expected cases A and
+B should be defined in the same input section.
+---
+ lld/ELF/Arch/RISCV.cpp            |   2 +
+ lld/ELF/InputSection.cpp          |  41 +++++++++-
+ lld/ELF/Relocations.h             |   1 +
+ lld/test/ELF/riscv-reloc-leb128.s | 129 ++++++++++++++++++++++++++++++
+ 4 files changed, 170 insertions(+), 3 deletions(-)
+ create mode 100644 lld/test/ELF/riscv-reloc-leb128.s
+
+diff --git a/lld/ELF/Arch/RISCV.cpp b/lld/ELF/Arch/RISCV.cpp
+index d0d75118e30d..930a2cdb7ccb 100644
+--- a/lld/ELF/Arch/RISCV.cpp
++++ b/lld/ELF/Arch/RISCV.cpp
+@@ -306,6 +306,8 @@ RelExpr RISCV::getRelExpr(const RelType type, const Symbol &s,
+   case R_RISCV_TPREL_ADD:
+   case R_RISCV_RELAX:
+     return config->relax ? R_RELAX_HINT : R_NONE;
++  case R_RISCV_SET_ULEB128:
++    return R_RISCV_LEB128;
+   default:
+     error(getErrorLocation(loc) + "unknown relocation (" + Twine(type) +
+           ") against symbol " + toString(s));
+diff --git a/lld/ELF/InputSection.cpp b/lld/ELF/InputSection.cpp
+index 2edaa2b40493..8eded2122f8c 100644
+--- a/lld/ELF/InputSection.cpp
++++ b/lld/ELF/InputSection.cpp
+@@ -839,6 +839,16 @@ uint64_t InputSectionBase::getRelocTargetVA(const InputFile *file, RelType type,
+   }
+ }
+ 
++// Overwrite a ULEB128 value and keep the original length.
++static uint64_t overwriteULEB128(uint8_t *bufLoc, uint64_t val) {
++  while (*bufLoc & 0x80) {
++    *bufLoc++ = 0x80 | (val & 0x7f);
++    val >>= 7;
++  }
++  *bufLoc = val;
++  return val;
++}
++
+ // This function applies relocations to sections without SHF_ALLOC bit.
+ // Such sections are never mapped to memory at runtime. Debug sections are
+ // an example. Relocations in non-alloc sections are much easier to
+@@ -850,6 +860,7 @@ template <class ELFT, class RelTy>
+ void InputSection::relocateNonAlloc(uint8_t *buf, ArrayRef<RelTy> rels) {
+   const unsigned bits = sizeof(typename ELFT::uint) * 8;
+   const TargetInfo &target = *elf::target;
++  const auto emachine = config->emachine;
+   const bool isDebug = isDebugSection(*this);
+   const bool isDebugLocOrRanges =
+       isDebug && (name == ".debug_loc" || name == ".debug_ranges");
+@@ -861,14 +872,15 @@ void InputSection::relocateNonAlloc(uint8_t *buf, ArrayRef<RelTy> rels) {
+       break;
+     }
+ 
+-  for (const RelTy &rel : rels) {
++  for (size_t i = 0, relsSize = rels.size(); i != relsSize; ++i) {
++    const RelTy &rel = rels[i];
+     RelType type = rel.getType(config->isMips64EL);
+ 
+     // GCC 8.0 or earlier have a bug that they emit R_386_GOTPC relocations
+     // against _GLOBAL_OFFSET_TABLE_ for .debug_info. The bug has been fixed
+     // in 2017 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82630), but we
+     // need to keep this bug-compatible code for a while.
+-    if (config->emachine == EM_386 && type == R_386_GOTPC)
++    if (emachine == EM_386 && type == R_386_GOTPC)
+       continue;
+ 
+     uint64_t offset = rel.r_offset;
+@@ -881,6 +893,30 @@ void InputSection::relocateNonAlloc(uint8_t *buf, ArrayRef<RelTy> rels) {
+     RelExpr expr = target.getRelExpr(type, sym, bufLoc);
+     if (expr == R_NONE)
+       continue;
++    auto *ds = dyn_cast<Defined>(&sym);
++
++    if (emachine == EM_RISCV && type == R_RISCV_SET_ULEB128) {
++      if (++i < relsSize &&
++          rels[i].getType(/*isMips64EL=*/false) == R_RISCV_SUB_ULEB128 &&
++          rels[i].r_offset == offset) {
++        uint64_t val;
++        if (!ds && tombstone) {
++          val = *tombstone;
++        } else {
++          val = sym.getVA(addend) -
++                (getFile<ELFT>()->getRelocTargetSym(rels[i]).getVA(0) +
++                 getAddend<ELFT>(rels[i]));
++        }
++        if (overwriteULEB128(bufLoc, val) >= 0x80)
++          errorOrWarn(getLocation(offset) + ": ULEB128 value " + Twine(val) +
++                      " exceeds available space; references '" +
++                      lld::toString(sym) + "'");
++        continue;
++      }
++      errorOrWarn(getLocation(offset) +
++                  ": R_RISCV_SET_ULEB128 not paired with R_RISCV_SUB_SET128");
++      return;
++    }
+ 
+     if (tombstone ||
+         (isDebug && (type == target.symbolicRel || expr == R_DTPREL))) {
+@@ -912,7 +948,6 @@ void InputSection::relocateNonAlloc(uint8_t *buf, ArrayRef<RelTy> rels) {
+       //
+       // TODO To reduce disruption, we use 0 instead of -1 as the tombstone
+       // value. Enable -1 in a future release.
+-      auto *ds = dyn_cast<Defined>(&sym);
+       if (!sym.getOutputSection() || (ds && ds->folded && !isDebugLine)) {
+         // If -z dead-reloc-in-nonalloc= is specified, respect it.
+         const uint64_t value = tombstone ? SignExtend64<bits>(*tombstone)
+diff --git a/lld/ELF/Relocations.h b/lld/ELF/Relocations.h
+index e36215bd0d93..a397692a591d 100644
+--- a/lld/ELF/Relocations.h
++++ b/lld/ELF/Relocations.h
+@@ -101,6 +101,7 @@ enum RelExpr {
+   R_PPC64_TOCBASE,
+   R_PPC64_RELAX_GOT_PC,
+   R_RISCV_ADD,
++  R_RISCV_LEB128,
+   R_RISCV_PC_INDIRECT,
+   // Same as R_PC but with page-aligned semantics.
+   R_LOONGARCH_PAGE_PC,
+diff --git a/lld/test/ELF/riscv-reloc-leb128.s b/lld/test/ELF/riscv-reloc-leb128.s
+new file mode 100644
+index 000000000000..8198819686c3
+--- /dev/null
++++ b/lld/test/ELF/riscv-reloc-leb128.s
+@@ -0,0 +1,129 @@
++# REQUIRES: riscv
++# RUN: rm -rf %t && split-file %s %t && cd %t
++# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax a.s -o a.o
++# RUN: llvm-readobj -r -x .debug_rnglists -x .debug_loclists a.o | FileCheck %s --check-prefix=REL
++# RUN: ld.lld -shared --gc-sections a.o -o a.so
++# RUN: llvm-readelf -x .debug_rnglists -x .debug_loclists a.so | FileCheck %s
++
++# REL:      .rela.debug_rnglists {
++# REL-NEXT:   0x0 R_RISCV_SET_ULEB128 w1 0x83
++# REL-NEXT:   0x0 R_RISCV_SUB_ULEB128 w2 0x0
++# REL-NEXT:   0x1 R_RISCV_SET_ULEB128 w2 0x78
++# REL-NEXT:   0x1 R_RISCV_SUB_ULEB128 w1 0x0
++# REL-NEXT:   0x3 R_RISCV_SET_ULEB128 w1 0x89
++# REL-NEXT:   0x3 R_RISCV_SUB_ULEB128 w2 0x0
++# REL-NEXT:   0x5 R_RISCV_SET_ULEB128 w2 0x3FF8
++# REL-NEXT:   0x5 R_RISCV_SUB_ULEB128 w1 0x0
++# REL-NEXT:   0x8 R_RISCV_SET_ULEB128 w1 0x4009
++# REL-NEXT:   0x8 R_RISCV_SUB_ULEB128 w2 0x0
++# REL-NEXT:   0xB R_RISCV_SET_ULEB128 w2 0x1FFFF8
++# REL-NEXT:   0xB R_RISCV_SUB_ULEB128 w1 0x0
++# REL-NEXT:   0xF R_RISCV_SET_ULEB128 w1 0x200009
++# REL-NEXT:   0xF R_RISCV_SUB_ULEB128 w2 0x0
++# REL-NEXT: }
++# REL:      .rela.debug_loclists {
++# REL-NEXT:   0x0 R_RISCV_SET_ULEB128 w2 0x3
++# REL-NEXT:   0x0 R_RISCV_SUB_ULEB128 w1 0x4
++# REL-NEXT:   0x1 R_RISCV_SET_ULEB128 x2 0x0
++# REL-NEXT:   0x1 R_RISCV_SUB_ULEB128 x1 0x0
++# REL-NEXT: }
++
++# REL:        Hex dump of section '.debug_rnglists':
++# REL-NEXT:   0x00000000 7b800181 01808001 81800180 80800181 {
++# REL-NEXT:   0x00000010 808001                              .
++# REL:        Hex dump of section '.debug_loclists':
++# REL-NEXT:   0x00000000 0008                                  .
++
++# CHECK:      Hex dump of section '.debug_rnglists':
++# CHECK-NEXT: 0x00000000 7ffc0085 01fcff00 858001fc ffff0085 .
++# CHECK-NEXT: 0x00000010 808001                              .
++# CHECK:      Hex dump of section '.debug_loclists':
++# CHECK-NEXT: 0x00000000 0300                                .
++
++# RUN: ld.lld -shared --gc-sections -z dead-reloc-in-nonalloc=.debug_loclists=0x7f a.o -o a127.so
++# RUN: llvm-readelf -x .debug_loclists a127.so | FileCheck %s --check-prefix=CHECK127
++# CHECK127:      Hex dump of section '.debug_loclists':
++# CHECK127-NEXT: 0x00000000 037f                                .
++
++# RUN: not ld.lld -shared --gc-sections -z dead-reloc-in-nonalloc=.debug_loclists=0x80 a.o 2>&1 | FileCheck %s --check-prefix=CHECK128
++# CHECK128: error: a.o:(.debug_loclists+0x1): ULEB128 value 128 exceeds available space; references 'x2'
++
++# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax sub.s -o sub.o
++# RUN: not ld.lld -shared sub.o 2>&1 | FileCheck %s --check-prefix=SUB
++# SUB: error: sub.o:(.debug_rnglists+0x8): unknown relocation (61) against symbol w2
++
++# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax unpaired1.s -o unpaired1.o
++# RUN: not ld.lld -shared unpaired1.o 2>&1 | FileCheck %s --check-prefix=UNPAIRED
++# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax unpaired2.s -o unpaired2.o
++# RUN: not ld.lld -shared unpaired2.o 2>&1 | FileCheck %s --check-prefix=UNPAIRED
++# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax unpaired3.s -o unpaired3.o
++# RUN: not ld.lld -shared unpaired3.o 2>&1 | FileCheck %s --check-prefix=UNPAIRED
++# UNPAIRED: error: {{.*}}.o:(.debug_rnglists+0x8): R_RISCV_SET_ULEB128 not paired with R_RISCV_SUB_SET128
++
++# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax overflow.s -o overflow.o
++# RUN: not ld.lld -shared overflow.o 2>&1 | FileCheck %s --check-prefix=OVERFLOW
++# OVERFLOW: error: overflow.o:(.debug_rnglists+0x8): ULEB128 value 128 exceeds available space; references 'w2'
++
++#--- a.s
++.section .text.w,"axR"
++w1:
++  call foo    # 4 bytes after relaxation
++w2:
++
++.section .text.x,"ax"
++x1:
++  call foo    # 4 bytes after relaxation
++x2:
++
++.section .debug_rnglists
++.uleb128 w1-w2+131                   # initial value: 0x7b
++.uleb128 w2-w1+120                   # initial value: 0x0180
++.uleb128 w1-w2+137                   # initial value: 0x0181
++.uleb128 w2-w1+16376                 # initial value: 0x018080
++.uleb128 w1-w2+16393                 # initial value: 0x018081
++.uleb128 w2-w1+2097144               # initial value: 0x01808080
++.uleb128 w1-w2+2097161               # initial value: 0x01808081
++
++.section .debug_loclists
++.reloc ., R_RISCV_SET_ULEB128, w2+3
++.reloc ., R_RISCV_SUB_ULEB128, w1+4  # SUB with a non-zero addend
++.byte 0
++.uleb128 x2-x1                       # references discarded symbols
++
++#--- sub.s
++w1: call foo; w2:
++.section .debug_rnglists
++.quad 0;
++.reloc ., R_RISCV_SUB_ULEB128, w2+120
++.byte 0x7f
++
++#--- unpaired1.s
++w1: call foo; w2:
++.section .debug_rnglists
++.quad 0;
++.reloc ., R_RISCV_SET_ULEB128, w2+120
++.byte 0x7f
++
++#--- unpaired2.s
++w1: call foo; w2:
++.section .debug_rnglists
++.quad 0
++.reloc ., R_RISCV_SET_ULEB128, w2+120
++.reloc .+1, R_RISCV_SUB_ULEB128, w1
++.byte 0x7f
++
++#--- unpaired3.s
++w1: call foo; w2:
++.section .debug_rnglists
++.quad 0
++.reloc ., R_RISCV_SET_ULEB128, w2+120
++.reloc ., R_RISCV_SUB64, w1
++.byte 0x7f
++
++#--- overflow.s
++w1: call foo; w2:
++.section .debug_rnglists
++.quad 0
++.reloc ., R_RISCV_SET_ULEB128, w2+124
++.reloc ., R_RISCV_SUB_ULEB128, w1
++.byte 0x7f
+-- 
+2.43.0
+

--- a/app-devel/llvm/01-runtime/patches/0018-ELF-Support-R_RISCV_SET_ULEB128-R_RISCV_SUB_ULEB128-.patch
+++ b/app-devel/llvm/01-runtime/patches/0018-ELF-Support-R_RISCV_SET_ULEB128-R_RISCV_SUB_ULEB128-.patch
@@ -1,0 +1,313 @@
+From c1cbdc8e1efbe6dd0e67419bba26afa04031743b Mon Sep 17 00:00:00 2001
+From: Fangrui Song <i@maskray.me>
+Date: Mon, 8 Jan 2024 20:24:00 -0800
+Subject: [PATCH 18/18] [ELF] Support R_RISCV_SET_ULEB128/R_RISCV_SUB_ULEB128
+ in SHF_ALLOC sections (#77261)
+
+Complement #72610 (non-SHF_ALLOC sections). GCC-generated
+.gcc_exception_table has the SHF_ALLOC flag and may contain
+R_RISCV_SET_ULEB128/R_RISCV_SUB_ULEB128 relocations.
+---
+ lld/ELF/Arch/RISCV.cpp            | 42 ++++++++++++++++
+ lld/ELF/InputSection.cpp          | 11 +----
+ lld/ELF/Relocations.cpp           |  4 +-
+ lld/ELF/Target.h                  | 10 ++++
+ lld/test/ELF/riscv-reloc-leb128.s | 80 ++++++++++++++++++++++++++-----
+ 5 files changed, 124 insertions(+), 23 deletions(-)
+
+diff --git a/lld/ELF/Arch/RISCV.cpp b/lld/ELF/Arch/RISCV.cpp
+index 930a2cdb7ccb..78b8d44a2a39 100644
+--- a/lld/ELF/Arch/RISCV.cpp
++++ b/lld/ELF/Arch/RISCV.cpp
+@@ -43,6 +43,7 @@ public:
+                      const uint8_t *loc) const override;
+   void relocate(uint8_t *loc, const Relocation &rel,
+                 uint64_t val) const override;
++  void relocateAlloc(InputSectionBase &sec, uint8_t *buf) const override;
+   bool relaxOnce(int pass) const override;
+ };
+ 
+@@ -307,6 +308,7 @@ RelExpr RISCV::getRelExpr(const RelType type, const Symbol &s,
+   case R_RISCV_RELAX:
+     return config->relax ? R_RELAX_HINT : R_NONE;
+   case R_RISCV_SET_ULEB128:
++  case R_RISCV_SUB_ULEB128:
+     return R_RISCV_LEB128;
+   default:
+     error(getErrorLocation(loc) + "unknown relocation (" + Twine(type) +
+@@ -515,6 +517,46 @@ void RISCV::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
+   }
+ }
+ 
++void RISCV::relocateAlloc(InputSectionBase &sec, uint8_t *buf) const {
++  uint64_t secAddr = sec.getOutputSection()->addr;
++  if (auto *s = dyn_cast<InputSection>(&sec))
++    secAddr += s->outSecOff;
++  else if (auto *ehIn = dyn_cast<EhInputSection>(&sec))
++    secAddr += ehIn->getParent()->outSecOff;
++  for (size_t i = 0, size = sec.relocs().size(); i != size; ++i) {
++    const Relocation &rel = sec.relocs()[i];
++    uint8_t *loc = buf + rel.offset;
++    const uint64_t val =
++        sec.getRelocTargetVA(sec.file, rel.type, rel.addend,
++                             secAddr + rel.offset, *rel.sym, rel.expr);
++
++    switch (rel.expr) {
++    case R_RELAX_HINT:
++      break;
++    case R_RISCV_LEB128:
++      if (i + 1 < size) {
++        const Relocation &rel1 = sec.relocs()[i + 1];
++        if (rel.type == R_RISCV_SET_ULEB128 &&
++            rel1.type == R_RISCV_SUB_ULEB128 && rel.offset == rel1.offset) {
++          auto val = rel.sym->getVA(rel.addend) - rel1.sym->getVA(rel1.addend);
++          if (overwriteULEB128(loc, val) >= 0x80)
++            errorOrWarn(sec.getLocation(rel.offset) + ": ULEB128 value " +
++                        Twine(val) + " exceeds available space; references '" +
++                        lld::toString(*rel.sym) + "'");
++          ++i;
++          continue;
++        }
++      }
++      errorOrWarn(sec.getLocation(rel.offset) +
++                  ": R_RISCV_SET_ULEB128 not paired with R_RISCV_SUB_SET128");
++      return;
++    default:
++      relocate(loc, rel, val);
++      break;
++    }
++  }
++}
++
+ namespace {
+ struct SymbolAnchor {
+   uint64_t offset;
+diff --git a/lld/ELF/InputSection.cpp b/lld/ELF/InputSection.cpp
+index 8eded2122f8c..cbf2c8da36dc 100644
+--- a/lld/ELF/InputSection.cpp
++++ b/lld/ELF/InputSection.cpp
+@@ -635,6 +635,7 @@ uint64_t InputSectionBase::getRelocTargetVA(const InputFile *file, RelType type,
+   case R_RELAX_TLS_LD_TO_LE_ABS:
+   case R_RELAX_GOT_PC_NOPIC:
+   case R_RISCV_ADD:
++  case R_RISCV_LEB128:
+     return sym.getVA(a);
+   case R_ADDEND:
+     return a;
+@@ -839,16 +840,6 @@ uint64_t InputSectionBase::getRelocTargetVA(const InputFile *file, RelType type,
+   }
+ }
+ 
+-// Overwrite a ULEB128 value and keep the original length.
+-static uint64_t overwriteULEB128(uint8_t *bufLoc, uint64_t val) {
+-  while (*bufLoc & 0x80) {
+-    *bufLoc++ = 0x80 | (val & 0x7f);
+-    val >>= 7;
+-  }
+-  *bufLoc = val;
+-  return val;
+-}
+-
+ // This function applies relocations to sections without SHF_ALLOC bit.
+ // Such sections are never mapped to memory at runtime. Debug sections are
+ // an example. Relocations in non-alloc sections are much easier to
+diff --git a/lld/ELF/Relocations.cpp b/lld/ELF/Relocations.cpp
+index af15f5a92546..e46b3f2e8e62 100644
+--- a/lld/ELF/Relocations.cpp
++++ b/lld/ELF/Relocations.cpp
+@@ -971,8 +971,8 @@ bool RelocationScanner::isStaticLinkTimeConstant(RelExpr e, RelType type,
+   if (!config->isPic)
+     return true;
+ 
+-  // The size of a non preemptible symbol is a constant.
+-  if (e == R_SIZE)
++  // Constant when referencing a non-preemptible symbol.
++  if (e == R_SIZE || e == R_RISCV_LEB128)
+     return true;
+ 
+   // For the target and the relocation, we want to know if they are
+diff --git a/lld/ELF/Target.h b/lld/ELF/Target.h
+index 47dbe6b4d1c6..1aa5e6b8db58 100644
+--- a/lld/ELF/Target.h
++++ b/lld/ELF/Target.h
+@@ -299,6 +299,16 @@ inline void write32(void *p, uint32_t v) {
+ inline void write64(void *p, uint64_t v) {
+   llvm::support::endian::write64(p, v, config->endianness);
+ }
++
++// Overwrite a ULEB128 value and keep the original length.
++inline uint64_t overwriteULEB128(uint8_t *bufLoc, uint64_t val) {
++  while (*bufLoc & 0x80) {
++    *bufLoc++ = 0x80 | (val & 0x7f);
++    val >>= 7;
++  }
++  *bufLoc = val;
++  return val;
++}
+ } // namespace elf
+ } // namespace lld
+ 
+diff --git a/lld/test/ELF/riscv-reloc-leb128.s b/lld/test/ELF/riscv-reloc-leb128.s
+index 8198819686c3..0bdc1eb18269 100644
+--- a/lld/test/ELF/riscv-reloc-leb128.s
++++ b/lld/test/ELF/riscv-reloc-leb128.s
+@@ -1,13 +1,13 @@
+ # REQUIRES: riscv
+ # RUN: rm -rf %t && split-file %s %t && cd %t
+ # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax a.s -o a.o
+-# RUN: llvm-readobj -r -x .debug_rnglists -x .debug_loclists a.o | FileCheck %s --check-prefix=REL
+-# RUN: ld.lld -shared --gc-sections a.o -o a.so
+-# RUN: llvm-readelf -x .debug_rnglists -x .debug_loclists a.so | FileCheck %s
++# RUN: llvm-readobj -r -x .gcc_except_table -x .debug_rnglists -x .debug_loclists a.o | FileCheck %s --check-prefix=REL
++# RUN: ld.lld -shared --gc-sections --noinhibit-exec a.o -o a.so
++# RUN: llvm-readelf -x .gcc_except_table -x .debug_rnglists -x .debug_loclists a.so | FileCheck %s
+ 
+ # REL:      .rela.debug_rnglists {
+-# REL-NEXT:   0x0 R_RISCV_SET_ULEB128 w1 0x83
+-# REL-NEXT:   0x0 R_RISCV_SUB_ULEB128 w2 0x0
++# REL-NEXT:   0x0 R_RISCV_SET_ULEB128 w1 0x82
++# REL-NEXT:   0x0 R_RISCV_SUB_ULEB128 w2 0xFFFFFFFFFFFFFFFF
+ # REL-NEXT:   0x1 R_RISCV_SET_ULEB128 w2 0x78
+ # REL-NEXT:   0x1 R_RISCV_SUB_ULEB128 w1 0x0
+ # REL-NEXT:   0x3 R_RISCV_SET_ULEB128 w1 0x89
+@@ -28,12 +28,18 @@
+ # REL-NEXT:   0x1 R_RISCV_SUB_ULEB128 x1 0x0
+ # REL-NEXT: }
+ 
++# REL:        Hex dump of section '.gcc_except_table':
++# REL-NEXT:   0x00000000 7b800181 01808001 81800180 80800181 {
++# REL-NEXT:   0x00000010 808001                              .
+ # REL:        Hex dump of section '.debug_rnglists':
+ # REL-NEXT:   0x00000000 7b800181 01808001 81800180 80800181 {
+ # REL-NEXT:   0x00000010 808001                              .
+ # REL:        Hex dump of section '.debug_loclists':
+ # REL-NEXT:   0x00000000 0008                                  .
+ 
++# CHECK:      Hex dump of section '.gcc_except_table':
++# CHECK-NEXT: 0x[[#%x,]] 7ffc0085 01fcff00 858001fc ffff0085 .
++# CHECK-NEXT: 0x[[#%x,]] 808001                              .
+ # CHECK:      Hex dump of section '.debug_rnglists':
+ # CHECK-NEXT: 0x00000000 7ffc0085 01fcff00 858001fc ffff0085 .
+ # CHECK-NEXT: 0x00000010 808001                              .
+@@ -50,21 +56,32 @@
+ 
+ # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax sub.s -o sub.o
+ # RUN: not ld.lld -shared sub.o 2>&1 | FileCheck %s --check-prefix=SUB
+-# SUB: error: sub.o:(.debug_rnglists+0x8): unknown relocation (61) against symbol w2
++# SUB: error: sub.o:(.debug_rnglists+0x8): has non-ABS relocation R_RISCV_SUB_ULEB128 against symbol 'w2'
+ 
+ # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax unpaired1.s -o unpaired1.o
+-# RUN: not ld.lld -shared unpaired1.o 2>&1 | FileCheck %s --check-prefix=UNPAIRED
++# RUN: not ld.lld -shared --threads=1 unpaired1.o 2>&1 | FileCheck %s --check-prefix=UNPAIRED
+ # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax unpaired2.s -o unpaired2.o
+-# RUN: not ld.lld -shared unpaired2.o 2>&1 | FileCheck %s --check-prefix=UNPAIRED
++# RUN: not ld.lld -shared --threads=1 unpaired2.o 2>&1 | FileCheck %s --check-prefix=UNPAIRED
+ # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax unpaired3.s -o unpaired3.o
+-# RUN: not ld.lld -shared unpaired3.o 2>&1 | FileCheck %s --check-prefix=UNPAIRED
++# RUN: not ld.lld -shared --threads=1 unpaired3.o 2>&1 | FileCheck %s --check-prefix=UNPAIRED
++# UNPAIRED: error: {{.*}}.o:(.alloc+0x8): R_RISCV_SET_ULEB128 not paired with R_RISCV_SUB_SET128
+ # UNPAIRED: error: {{.*}}.o:(.debug_rnglists+0x8): R_RISCV_SET_ULEB128 not paired with R_RISCV_SUB_SET128
+ 
+ # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax overflow.s -o overflow.o
+-# RUN: not ld.lld -shared overflow.o 2>&1 | FileCheck %s --check-prefix=OVERFLOW
++# RUN: not ld.lld -shared --threads=1 overflow.o 2>&1 | FileCheck %s --check-prefix=OVERFLOW
++# OVERFLOW: error: overflow.o:(.alloc+0x8): ULEB128 value 128 exceeds available space; references 'w2'
+ # OVERFLOW: error: overflow.o:(.debug_rnglists+0x8): ULEB128 value 128 exceeds available space; references 'w2'
+ 
++# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax preemptable.s -o preemptable.o
++# RUN: not ld.lld -shared --threads=1 preemptable.o 2>&1 | FileCheck %s --check-prefix=PREEMPTABLE --implicit-check-not=error:
++# PREEMPTABLE: error: relocation R_RISCV_SET_ULEB128 cannot be used against symbol 'w2'; recompile with -fPIC
++# PREEMPTABLE: error: relocation R_RISCV_SUB_ULEB128 cannot be used against symbol 'w1'; recompile with -fPIC
++
+ #--- a.s
++.cfi_startproc
++.cfi_lsda 0x1b,.LLSDA0
++.cfi_endproc
++
+ .section .text.w,"axR"
+ w1:
+   call foo    # 4 bytes after relaxation
+@@ -75,8 +92,22 @@ x1:
+   call foo    # 4 bytes after relaxation
+ x2:
+ 
++.section .gcc_except_table,"a"
++.LLSDA0:
++.reloc ., R_RISCV_SET_ULEB128, w1+130
++.reloc ., R_RISCV_SUB_ULEB128, w2-1  # non-zero addend for SUB
++.byte 0x7b
++.uleb128 w2-w1+120                   # initial value: 0x0180
++.uleb128 w1-w2+137                   # initial value: 0x0181
++.uleb128 w2-w1+16376                 # initial value: 0x018080
++.uleb128 w1-w2+16393                 # initial value: 0x018081
++.uleb128 w2-w1+2097144               # initial value: 0x01808080
++.uleb128 w1-w2+2097161               # initial value: 0x01808081
++
+ .section .debug_rnglists
+-.uleb128 w1-w2+131                   # initial value: 0x7b
++.reloc ., R_RISCV_SET_ULEB128, w1+130
++.reloc ., R_RISCV_SUB_ULEB128, w2-1  # non-zero addend for SUB
++.byte 0x7b
+ .uleb128 w2-w1+120                   # initial value: 0x0180
+ .uleb128 w1-w2+137                   # initial value: 0x0181
+ .uleb128 w2-w1+16376                 # initial value: 0x018080
+@@ -99,6 +130,10 @@ w1: call foo; w2:
+ 
+ #--- unpaired1.s
+ w1: call foo; w2:
++.section .alloc,"a"
++.quad 0
++.reloc ., R_RISCV_SET_ULEB128, w2+120
++.byte 0x7f
+ .section .debug_rnglists
+ .quad 0;
+ .reloc ., R_RISCV_SET_ULEB128, w2+120
+@@ -106,6 +141,11 @@ w1: call foo; w2:
+ 
+ #--- unpaired2.s
+ w1: call foo; w2:
++.section .alloc,"a"
++.quad 0
++.reloc ., R_RISCV_SET_ULEB128, w2+120
++.reloc .+1, R_RISCV_SUB_ULEB128, w1
++.byte 0x7f
+ .section .debug_rnglists
+ .quad 0
+ .reloc ., R_RISCV_SET_ULEB128, w2+120
+@@ -114,6 +154,11 @@ w1: call foo; w2:
+ 
+ #--- unpaired3.s
+ w1: call foo; w2:
++.section .alloc,"a"
++.quad 0
++.reloc ., R_RISCV_SET_ULEB128, w2+120
++.reloc ., R_RISCV_SUB64, w1
++.byte 0x7f
+ .section .debug_rnglists
+ .quad 0
+ .reloc ., R_RISCV_SET_ULEB128, w2+120
+@@ -122,8 +167,21 @@ w1: call foo; w2:
+ 
+ #--- overflow.s
+ w1: call foo; w2:
++.section .alloc,"a"
++.quad 0
++.reloc ., R_RISCV_SET_ULEB128, w2+124
++.reloc ., R_RISCV_SUB_ULEB128, w1
++.byte 0x7f
+ .section .debug_rnglists
+ .quad 0
+ .reloc ., R_RISCV_SET_ULEB128, w2+124
+ .reloc ., R_RISCV_SUB_ULEB128, w1
+ .byte 0x7f
++
++#--- preemptable.s
++.globl w1, w2
++w1: call foo; w2:
++.section .alloc,"a"
++.uleb128 w2-w1
++.section .debug_rnglists
++.uleb128 w2-w1
+-- 
+2.43.0
+

--- a/app-devel/llvm/spec
+++ b/app-devel/llvm/spec
@@ -1,5 +1,5 @@
 VER=17.0.6
-REL=3
+REL=4
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::58a8818c60e6627064f312dbf46c02d9949956558340938b71cf731ad8bc0813"


### PR DESCRIPTION
Topic Description
-----------------

- llvm: fix riscv uleb128 relocation
    - Patches are tracked at https://github.com/AOSC-Tracking/llvm-project/commits/aosc/17.0.6-rework
    - Import riscv patches for uleb128 relocation
    - Strip uleb128 symbols from libc temporarily

Package(s) Affected
-------------------

- llvm: 17.0.6-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
