### PR TITLE
LiveKit Survey (February 2024)

### DIFF
--- a/app-utils/select-language-gui/autobuild/defines
+++ b/app-utils/select-language-gui/autobuild/defines
@@ -1,0 +1,17 @@
+PKGNAME=select-language-gui
+PKGSEC=utils
+PKGDEP="gcc-runtime webkit2gtk"
+BUILDDEP="llvm rustc"
+PKGDES="A system language setting utility (graphical UI)"
+
+USECLANG=1
+
+# FIXME: ld.lld is not yet available.
+USECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1
+USECLANG__LOONGARCH64=0
+NOLTO__LOONGARCH64=1
+USECLANG__MIPS64R6EL=0
+NOLTO__MIPS64R6EL=1
+
+CARGO_AFTER="--features custom-protocol"

--- a/app-utils/select-language-gui/autobuild/prepare
+++ b/app-utils/select-language-gui/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Installing pre-built Web assets ..."
+cp -rv "$SRCDIR"/../../dist \
+    "$SRCDIR"/../dist

--- a/app-utils/select-language-gui/spec
+++ b/app-utils/select-language-gui/spec
@@ -1,0 +1,7 @@
+VER=0.2.0+1
+SRCS="git::commit=tags/v${VER/+/-}::https://github.com/AOSC-Dev/select-language-gui \
+      tbl::https://github.com/AOSC-Dev/select-language-gui/releases/download/v${VER/+/-}/dist.tar.xz"
+CHKSUMS="SKIP \
+         sha256::ed9b3fafceb0622dca4bfa2c426f82dbe0fd20999ce29fa6ee752427ac3c392d"
+CHKUPDATE="anitya::id=371442"
+SUBDIR="select-language-gui/src-tauri"

--- a/app-utils/select-language-tui/autobuild/defines
+++ b/app-utils/select-language-tui/autobuild/defines
@@ -1,0 +1,15 @@
+PKGNAME=select-language-tui
+PKGSEC=utils
+PKGDEP="gcc-runtime ncurses"
+BUILDDEP="llvm rustc"
+PKGDES="A system language setting utility (terminal UI)"
+
+USECLANG=1
+
+# FIXME: ld.lld is not yet available.
+USECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1
+USECLANG__LOONGARCH64=0
+NOLTO__LOONGARCH64=1
+USECLANG__MIPS64R6EL=0
+NOLTO__MIPS64R6EL=1

--- a/app-utils/select-language-tui/spec
+++ b/app-utils/select-language-tui/spec
@@ -1,0 +1,4 @@
+VER=0.3.0
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/select-language-tui"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371441"


### PR DESCRIPTION
Topic Description
-----------------

- select-language-tui: new, 0.3.0
- select-language-gui: new, 0.2.0+1

Package(s) Affected
-------------------

- select-language-gui: 0.2.0+1
- select-language-tui: 0.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit select-language-gui select-language-tui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
