### PR TITLE
autoconf: update to 2.72

### DIFF
--- a/app-devel/autoconf/spec
+++ b/app-devel/autoconf/spec
@@ -1,4 +1,4 @@
-VER=2.71
+VER=2.72
 SRCS="tbl::https://ftp.gnu.org/gnu/autoconf/autoconf-$VER.tar.xz"
-CHKSUMS="sha256::f14c83cfebcc9427f2c3cea7258bd90df972d92eb26752da4ddad81c87a0faa4"
+CHKSUMS="sha256::ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a"
 CHKUPDATE="anitya::id=141"


### PR DESCRIPTION
Topic Description
-----------------

- autoconf: update to 2.72

Package(s) Affected
-------------------

- autoconf: 2.72

Security Update?
----------------

No

Build Order
-----------

```
#buildit autoconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
