### PR TITLE
yazi: update to 0.2.3

### DIFF
--- a/app-utils/yazi/autobuild/beyond
+++ b/app-utils/yazi/autobuild/beyond
@@ -11,7 +11,6 @@ mkdir -pv "$PKGDIR"/usr/share/zsh/site-functions
 cp -v "$SRCDIR"/yazi-config/completions/_yazi \
 	"$PKGDIR"/usr/share/zsh/site-functions/_yazi
 
-
 abinfo "Installing .desktop file and icons ..."
 for RES in 16 24 32 48 64 128 256; do
 	 mkdir -pv "$PKGDIR"/usr/share/icons/hicolor/"$RES"x"$RES"/apps

--- a/app-utils/yazi/autobuild/beyond
+++ b/app-utils/yazi/autobuild/beyond
@@ -10,3 +10,14 @@ cp -v "$SRCDIR"/yazi-config/completions/yazi.fish \
 mkdir -pv "$PKGDIR"/usr/share/zsh/site-functions
 cp -v "$SRCDIR"/yazi-config/completions/_yazi \
 	"$PKGDIR"/usr/share/zsh/site-functions/_yazi
+
+
+abinfo "Installing .desktop file and icons ..."
+for RES in 16 24 32 48 64 128 256; do
+	 mkdir -pv "$PKGDIR"/usr/share/icons/hicolor/"$RES"x"$RES"/apps
+	 convert "$SRCDIR"/assets/logo.png -resize "$RES"x"$RES" \
+		"$PKGDIR"/usr/share/icons/hicolor/"$RES"x"$RES"/apps/yazi.png
+done
+
+install -Dvm644 "$SRCDIR"/assets/yazi.desktop \
+	-t "$PKGDIR"/usr/share/applications

--- a/app-utils/yazi/autobuild/defines
+++ b/app-utils/yazi/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME="yazi"
 PKGDES="A file manager for the terminal"
 PKGDEP="glibc gcc-runtime"
 PKGRECOM="jq ffmpegthumbnailer unar poppler fd ripgrep fzf zoxide"
-BUILDDEP="rustc"
+BUILDDEP="rustc imagemagick"
 PKGSEC=utils
 
 ABSPLITDBG=0

--- a/app-utils/yazi/spec
+++ b/app-utils/yazi/spec
@@ -1,4 +1,4 @@
-VER=0.2.0
+VER=0.2.3
 SRCS="git::commit=tags/v$VER::https://github.com/sxyazi/yazi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370571"


### PR DESCRIPTION
Topic Description
-----------------

- yazi: update to 0.2.3

Package(s) Affected
-------------------

- yazi: 0.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit yazi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
