### PR TITLE
dua: update to 2.28.0

### DIFF
--- a/app-utils/dua/autobuild/defines
+++ b/app-utils/dua/autobuild/defines
@@ -7,9 +7,10 @@ PKGPROV="dua-cli"
 ABSPLITDBG=0
 USECLANG=1
 
-# FIXME: loongson3 and mips64r6el has no lld linker support
+# FIXME: loongson3, mips64r6el and loongarch64 has no lld linker support
 NOLTO__LOONGSON3=1
 USECLANG__LOONGSON3=0
 NOLTO__MIPS64R6EL=1
 USECLANG__MIPS64R6EL=0
-
+NOLTO__LOONGARCH64=1
+USECLANG__LOONGARCH64=0

--- a/app-utils/dua/spec
+++ b/app-utils/dua/spec
@@ -1,4 +1,4 @@
-VER="2.27.2"
+VER=2.28.0
 SRCS="git::commit=tags/v$VER::https://github.com/Byron/dua-cli"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=79030"


### PR DESCRIPTION
Topic Description
-----------------

- dua: update to 2.28.0

Package(s) Affected
-------------------

- dua: 2.28.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dua
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
