### PR TITLE
zziplib: update to 0.13.72

### DIFF
--- a/app-devel/xa/autobuild/build
+++ b/app-devel/xa/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Building xa ..."
+make ${MAKE_AFTER}
+
+abinfo "Installing xa ..."
+make install \
+    DESTDIR="$PKGDIR" \
+    ${MAKE_AFTER}

--- a/app-devel/xa/spec
+++ b/app-devel/xa/spec
@@ -1,4 +1,5 @@
 VER=2.4.0
+REL=1
 SRCS="tbl::http://www.floodgap.com/retrotech/xa/dists/xa-$VER.tar.gz"
 CHKSUMS="sha256::9e587a0ca8ff791009880bfa331f6ed36935e08ef9c123822ca175285f8c030c"
 CHKUPDATE="anitya::id=14146"

--- a/app-multimedia/milkytracker/spec
+++ b/app-multimedia/milkytracker/spec
@@ -1,5 +1,5 @@
 VER=1.02.00
-REL=2
+REL=3
 SRCS="tbl::https://github.com/milkytracker/MilkyTracker/archive/v$VER.tar.gz"
 CHKSUMS="sha256::6bcb6e74ee333e831137435a25c0f2f3da6e1462864deec9e693ef7d23a16023"
 CHKUPDATE="anitya::id=9135"

--- a/app-multimedia/mpd/autobuild/overrides/usr/lib/sysusers.d/mpd.conf
+++ b/app-multimedia/mpd/autobuild/overrides/usr/lib/sysusers.d/mpd.conf
@@ -1,0 +1,3 @@
+g    mpd  45
+u    mpd  45:45 "MusicPlayerDaemon owner" /var/lib/mpd  /bin/false
+m    mpd  audio

--- a/app-multimedia/mpd/autobuild/postinst
+++ b/app-multimedia/mpd/autobuild/postinst
@@ -1,1 +1,5 @@
+echo "Setting up mpd user and group ..."
+systemd-sysusers mpd.conf
+
+echo "Creating temporary directory for mpd ..."
 /usr/bin/systemd-tmpfiles --create mpd.conf 

--- a/app-multimedia/mpd/autobuild/prepare
+++ b/app-multimedia/mpd/autobuild/prepare
@@ -1,2 +1,0 @@
-export CFLAGS="${CFLAGS} -fuse-ld=gold"
-export CXXFLAGS="${CXXFLAGS} -fuse-ld=gold"

--- a/app-multimedia/mpd/autobuild/usergroup
+++ b/app-multimedia/mpd/autobuild/usergroup
@@ -1,2 +1,0 @@
-group mpd 45
-user mpd 45 mpd /var/lib/mpd "MusicPlayerDaemon owner" /bin/false audio

--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,5 +1,5 @@
 VER=0.23.12
-REL=2
+REL=3
 SRCS="tbl::http://www.musicpd.org/download/mpd/${VER%.*}/mpd-${VER}.tar.xz"
 CHKSUMS="sha256::b7fca62284ecc25a681ea6a07abc49200af5353be42cb5a31e3173be9d8702e7"
 CHKUPDATE="anitya::id=14864"

--- a/runtime-common/zziplib/spec
+++ b/runtime-common/zziplib/spec
@@ -1,4 +1,4 @@
-VER=0.13.71
+VER=0.13.72
 SRCS="tbl::https://github.com/gdraheim/zziplib/archive/v$VER.tar.gz"
-CHKSUMS="sha256::2ee1e0fbbb78ec7cc46bde5b62857bc51f8d665dd265577cf93584344b8b9de2"
+CHKSUMS="sha256::93ef44bf1f1ea24fc66080426a469df82fa631d13ca3b2e4abaeab89538518dc"
 CHKUPDATE="anitya::id=13802"


### PR DESCRIPTION
Topic Description
-----------------

- milkytracker: bump REL
- mpd: use sysusers
- mpd: bump REL
- zziplib: update to 0.13.72

Package(s) Affected
-------------------

- zziplib: 0.13.72
- mpd: 0.23.12-3
- milkytracker: 1.02.00-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit zziplib mpd milkytracker
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
