### PR TITLE
lftp: update to 4.9.2

### DIFF
--- a/app-network/lftp/autobuild/patches/0001-Fedora-lftp-4.9.2-cdefs.patch
+++ b/app-network/lftp/autobuild/patches/0001-Fedora-lftp-4.9.2-cdefs.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/libc-config.h.old b/lib/libc-config.h
+index 1300c3a..7537bab 100644
+--- a/lib/libc-config.h.old
++++ b/lib/libc-config.h
+@@ -156,7 +156,7 @@
+ #undef __warndecl
+ 
+ /* Include our copy of glibc <sys/cdefs.h>.  */
+-#include <cdefs.h>
++#include <sys/cdefs.h>
+ 
+ /* <cdefs.h> __inline is too pessimistic for non-GCC.  */
+ #undef __inline

--- a/app-network/lftp/autobuild/prepare
+++ b/app-network/lftp/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Fixing mkdir detection ..."
+export MKDIR_P="/usr/bin/mkdir -p"

--- a/app-network/lftp/spec
+++ b/app-network/lftp/spec
@@ -1,5 +1,4 @@
-VER=4.8.4
+VER=4.9.2
 SRCS="tbl::https://lftp.yar.ru/ftp/lftp-${VER}.tar.xz"
-CHKSUMS="sha256::4ebc271e9e5cea84a683375a0f7e91086e5dac90c5d51bb3f169f75386107a62"
-REL=1
+CHKSUMS="sha256::c517c4f4f9c39bd415d7313088a2b1e313b2d386867fe40b7692b83a20f0670d"
 CHKUPDATE="anitya::id=1555"


### PR DESCRIPTION
Topic Description
-----------------

- lftp: update to 4.9.2
    Import patch to fix compilation on ppc64le

Package(s) Affected
-------------------

- lftp: 4.9.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit lftp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
