### PR TITLE
btop (BTOP++): update to 1.3.2

### DIFF
--- a/app-utils/btop/autobuild/build
+++ b/app-utils/btop/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Building btop ..."
+make
+
+abinfo "Installing btop ..."
+make install \
+    DESTDIR="$PKGDIR" \
+    PREFIX=/usr

--- a/app-utils/btop/spec
+++ b/app-utils/btop/spec
@@ -1,4 +1,4 @@
-VER=1.2.7
-SRCS="tbl::https://github.com/aristocratos/btop/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::60075824ca4e14c1ca920b76ffb101fc2340c5342f3ba600b5c280389b69bbbf"
+VER=1.3.2
+SRCS="git::commit=tags/v$VER::https://github.com/aristocratos/btop"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=253331"


### PR DESCRIPTION
Topic Description
-----------------

- btop: update to 1.3.2

Package(s) Affected
-------------------

- btop: 1.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit btop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
