### PR TITLE
inochi2d-bundles: Inochi2D applications

### DIFF
--- a/app-creativity/inochi2d-creator/autobuild/build
+++ b/app-creativity/inochi2d-creator/autobuild/build
@@ -1,0 +1,41 @@
+if [[ "${CROSS:-$ARCH}" = loongson3 ]]; then
+    EXTRA_FLAGS="-mabi=n64 -mcpu=mips64r2 --linker=gold"
+elif [[ "${CROSS:-$ARCH}" = riscv64 ]]; then
+    EXTRA_FLAGS="-Xcc=-latomic --linker=lld -mattr=+d -mabi=lp64d"
+elif [[ "${CROSS:-$ARCH}" = loongarch64 ]]; then
+    EXTRA_FLAGS="-g -gdwarf=5 --linker=mold"
+else
+    EXTRA_FLAGS="-g -gdwarf=5 --linker=lld"
+fi
+
+if [[ "$NOLTO" != 1 ]]; then
+    LTO_FLAGS="-flto=full --gcc=clang"
+fi
+
+export DFLAGS="${EXTRA_FLAGS} ${LTO_FLAGS} -L-O3 -L-Wl,-build-id=sha1"
+
+abinfo "Registering D dependencies ..."
+dub add-local /usr/src/i2d-imgui 0.8.0
+dub add-local /usr/src/inochi2d 0.8.3
+
+abinfo "Generating version file ..."
+cat > "$SRCDIR"/source/creator/ver.d << EOF
+module creator.ver;
+enum INC_VERSION = "v$PKGVER";
+EOF
+
+abinfo "Building inochi2d-creator ..."
+dub fetch gitver
+dub build -c linux-barebones --compiler=ldmd -y -n -b release --override-config=i2d-imgui/static_dynamicCRT
+
+abinfo "Building translations ..."
+install -dv "$PKGDIR"/usr/share/inochi-creator
+for f in "$SRCDIR"/tl/*.po; do
+    msgfmt -o "$PKGDIR"/usr/share/inochi-creator/"$(basename -- "$f" .po).mo" -- "$f"
+done
+
+abinfo "Installing inochi2d-creator ..."
+install -Dvm755 "$SRCDIR"/out/inochi-creator -t "$PKGDIR"/usr/bin/
+install -Dvm644 "$SRCDIR"/build-aux/linux/inochi-creator.desktop -t "$PKGDIR"/usr/share/applications/
+install -Dvm644 "$SRCDIR"/build-aux/linux/inochi-creator.appdata.xml -t "$PKGDIR"/usr/share/metainfo/
+install -Dvm644 "$SRCDIR"/res/logo_256.png "$PKGDIR"/usr/share/icons/hicolor/256x256/apps/inochi-creator.png

--- a/app-creativity/inochi2d-creator/autobuild/defines
+++ b/app-creativity/inochi2d-creator/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=inochi2d-creator
+PKGSEC=graphics
+PKGDES="Inochi2D Rigging Application"
+PKGDEP="sdl2 mesa lua freetype gcc-runtime dbus desktop-file-utils liblphobos"
+BUILDDEP="dub ldc llvm i2d-imgui cmake ninja inochi2d"
+BUILDDEP__LOONGARCH64="$BUILDDEP mold"
+
+USECLANG=1
+
+# FIXME: ld.lld: error: lto.tmp: cannot link object files with different
+# floating-point ABI from
+# /usr/bin/../lib64/gcc/riscv64-aosc-linux-gnu/13.2.0/../../../../lib64/Scrt1.o
+NOLTO__RISCV64=1
+
+# FIXME: missing ldc, ICE on loongarch64
+FAIL_ARCH="!(amd64|arm64|riscv64)"

--- a/app-creativity/inochi2d-creator/autobuild/patches/0001-fix-desktop-file-icon-name.patch
+++ b/app-creativity/inochi2d-creator/autobuild/patches/0001-fix-desktop-file-icon-name.patch
@@ -1,0 +1,14 @@
+diff --git a/build-aux/linux/inochi-creator.desktop b/build-aux/linux/inochi-creator.desktop
+index 80a920e..0c71532 100644
+--- a/build-aux/linux/inochi-creator.desktop
++++ b/build-aux/linux/inochi-creator.desktop
+@@ -1,6 +1,6 @@
+ [Desktop Entry]
+ Name=inochi-creator
+ Exec=inochi-creator
+-Icon=logo_256
++Icon=inochi-creator
+ Type=Application
+-Categories=Utility
+\ No newline at end of file
++Categories=Utility

--- a/app-creativity/inochi2d-creator/autobuild/patches/0002-fix-gettext-mo-lookup.patch
+++ b/app-creativity/inochi2d-creator/autobuild/patches/0002-fix-gettext-mo-lookup.patch
@@ -1,0 +1,18 @@
+diff --git a/source/creator/core/path.d b/source/creator/core/path.d
+index 850ba23..c660e0a 100644
+--- a/source/creator/core/path.d
++++ b/source/creator/core/path.d
+@@ -152,12 +152,8 @@ string incGetAppLocalePath() {
+ */
+ string incGetAppLocalePathExtra() {
+     
+-    // AppImage locale dir is the root of the appimage
+     version(linux) {
+-        auto here = environment.get("HERE");
+-        if (here) {
+-            return here;
+-        }    
++        return "/usr/share/inochi-creator";
+     }
+ 
+     return null;

--- a/app-creativity/inochi2d-creator/spec
+++ b/app-creativity/inochi2d-creator/spec
@@ -1,0 +1,3 @@
+VER=0.8.3
+SRCS="git::commit=tags/v$VER::https://github.com/Inochi2D/inochi-creator"
+CHKSUMS="SKIP"

--- a/app-creativity/inochi2d-session/autobuild/build
+++ b/app-creativity/inochi2d-session/autobuild/build
@@ -1,0 +1,36 @@
+if [[ "${CROSS:-$ARCH}" = loongson3 ]]; then
+    EXTRA_FLAGS="-mabi=n64 -mcpu=mips64r2 --linker=gold"
+elif [[ "${CROSS:-$ARCH}" = riscv64 ]]; then
+    EXTRA_FLAGS="-Xcc=-latomic --linker=lld -mattr=+d -mabi=lp64d"
+elif [[ "${CROSS:-$ARCH}" = loongarch64 ]]; then
+    EXTRA_FLAGS="-g -gdwarf=5 --linker=mold"
+else
+    EXTRA_FLAGS="-g -gdwarf=5 --linker=lld"
+fi
+
+if [[ "$NOLTO" != 1 ]]; then
+    LTO_FLAGS="-flto=full --gcc=clang"
+fi
+
+export DFLAGS="${EXTRA_FLAGS} ${LTO_FLAGS} -L-O3 -L-Wl,-build-id=sha1"
+
+abinfo "Registering D dependencies ..."
+dub add-local /usr/src/i2d-imgui 0.8.0
+dub add-local /usr/src/lumars 1.6.1
+dub add-local /usr/src/inochi2d 0.8.3
+
+abinfo "Generating version file ..."
+cat > "$SRCDIR"/source/session/ver.d << EOF
+module session.ver;
+enum INS_VERSION = "v$PKGVER";
+EOF
+
+abinfo "Building inochi2d-session ..."
+dub fetch gitver
+dub build -c linux-barebones --compiler=ldmd -y -n -b release --override-config=i2d-imgui/static_dynamicCRT
+
+abinfo "Installing inochi2d-session ..."
+install -Dvm755 "$SRCDIR"/out/inochi-session -t "$PKGDIR"/usr/bin/
+install -Dvm644 "$SRCDIR"/build-aux/linux/inochi-session.desktop -t "$PKGDIR"/usr/share/applications/
+install -Dvm644 "$SRCDIR"/build-aux/linux/inochi-session.appdata.xml -t "$PKGDIR"/usr/share/metainfo/
+install -Dvm644 "$SRCDIR"/build-aux/linux/icon.png "$PKGDIR"/usr/share/icons/hicolor/256x256/apps/inochi-session.png

--- a/app-creativity/inochi2d-session/autobuild/defines
+++ b/app-creativity/inochi2d-session/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=inochi2d-session
+PKGSEC=graphics
+PKGDES="Application that allows streaming with Inochi2D puppets"
+PKGDEP="sdl2 mesa lua freetype gcc-runtime dbus desktop-file-utils liblphobos"
+BUILDDEP="dub ldc llvm i2d-imgui lumars cmake ninja inochi2d"
+BUILDDEP__LOONGARCH64="$BUILDDEP mold"
+
+USECLANG=1
+
+# FIXME: ld.lld: error: lto.tmp: cannot link object files with different
+# floating-point ABI from
+# /usr/bin/../lib64/gcc/riscv64-aosc-linux-gnu/13.2.0/../../../../lib64/Scrt1.o
+NOLTO__RISCV64=1
+
+# FIXME: missing ldc, ICE on loongarch64
+FAIL_ARCH="!(amd64|arm64|riscv64)"

--- a/app-creativity/inochi2d-session/autobuild/patches/0001-fix-desktop-file-icon-name.patch
+++ b/app-creativity/inochi2d-session/autobuild/patches/0001-fix-desktop-file-icon-name.patch
@@ -1,0 +1,26 @@
+From 96e5ce91ea2e7306f1b04c690f1a4cf57f751371 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Thu, 23 May 2024 00:55:39 +0800
+Subject: [PATCH 1/2] fix desktop file icon name
+
+---
+ build-aux/linux/inochi-session.desktop | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/build-aux/linux/inochi-session.desktop b/build-aux/linux/inochi-session.desktop
+index afa972e..037967e 100644
+--- a/build-aux/linux/inochi-session.desktop
++++ b/build-aux/linux/inochi-session.desktop
+@@ -1,6 +1,6 @@
+ [Desktop Entry]
+ Name=inochi-session
+ Exec=inochi-session
+-Icon=icon_x256
++Icon=inochi-session
+ Type=Application
+-Categories=Utility
+\ No newline at end of file
++Categories=Utility
+-- 
+2.45.1
+

--- a/app-creativity/inochi2d-session/autobuild/patches/0002-force-inochi2d-version-to-0.8.3.patch
+++ b/app-creativity/inochi2d-session/autobuild/patches/0002-force-inochi2d-version-to-0.8.3.patch
@@ -1,0 +1,32 @@
+From 90bb0c6ebbb263ebe4ea7325f9aab12c35f91a82 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Thu, 23 May 2024 00:55:52 +0800
+Subject: [PATCH 2/2] force inochi2d version to 0.8.3
+
+---
+ dub.sdl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/dub.sdl b/dub.sdl
+index a4e366b..d253f9b 100644
+--- a/dub.sdl
++++ b/dub.sdl
+@@ -10,7 +10,7 @@ dependency "inui" version="~>1.2.1"
+ dependency "lumars" version="~>1.6.1"
+ dependency "bindbc-sdl" version="~>1.1.2"
+ dependency "i18n-d" version="~>1.0.2"
+-dependency "inochi2d" version="~>0.8.2"
++dependency "inochi2d" version="~>0.8.3"
+ targetPath "out/"
+ workingDirectory "out/"
+ copyFiles "res/licenses/*"
+@@ -110,4 +110,4 @@ configuration "win32-nightly" {
+ 
+ 	lflags "/SUBSYSTEM:windows" "/ENTRY:mainCRTStartup" platform="window-dmd"
+ 	sourceFiles "build-aux\\windows\\inochi-session.res"
+-}
+\ No newline at end of file
++}
+-- 
+2.45.1
+

--- a/app-creativity/inochi2d-session/spec
+++ b/app-creativity/inochi2d-session/spec
@@ -1,0 +1,3 @@
+VER=0.8.3
+SRCS="git::commit=tags/v$VER::https://github.com/Inochi2D/inochi-session"
+CHKSUMS="SKIP"

--- a/app-creativity/inochi2d/autobuild/build
+++ b/app-creativity/inochi2d/autobuild/build
@@ -1,0 +1,3 @@
+abinfo 'Installing source files ...'
+install -vd "$PKGDIR"/usr/src
+rsync --exclude="autobuild" --exclude="*.log" --exclude="abdist" --exclude='.patch' -av "$SRCDIR" "$PKGDIR"/usr/src/

--- a/app-creativity/inochi2d/autobuild/defines
+++ b/app-creativity/inochi2d/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=inochi2d
+PKGSEC=lib
+PKGDES="Inochi2D"
+BUILDDEP="rsync"
+
+ABHOST=noarch

--- a/app-creativity/inochi2d/autobuild/patches/0001-Avoid-nogc-incompat-with-inmath-1.0.8.patch
+++ b/app-creativity/inochi2d/autobuild/patches/0001-Avoid-nogc-incompat-with-inmath-1.0.8.patch
@@ -1,0 +1,35 @@
+From 3f804918a32393cb42cfe13e36305a20b4c54209 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Thu, 23 May 2024 00:15:10 +0800
+Subject: [PATCH 1/2] Avoid @nogc incompat with inmath 1.0.8
+
+Building with inmath 1.0.8 fails with:
+
+../.dub/packages/inmath/1.0.8/inmath/inmath/interpolate.d(20,12): Error:
+`@nogc` function `inmath.interpolate.lerp!(Deformation).lerp` cannot
+call non-@nogc function
+`inochi2d.core.nodes.defstack.Deformation.opBinary!("*",
+float).opBinary` source/inochi2d/core/nodes/defstack.d(36,17):
+which calls
+`core.internal.array.capacity._d_arraysetlengthTImpl!(Vector!(float,
+2)[], Vector!(float, 2))._d_arraysetlengthT`
+---
+ dub.sdl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dub.sdl b/dub.sdl
+index dff91ca..c9f178b 100644
+--- a/dub.sdl
++++ b/dub.sdl
+@@ -4,7 +4,7 @@ authors "Luna Nielsen"
+ copyright "Copyright © 2020, Inochi2D Project"
+ license "BSD 2-clause"
+ dependency "imagefmt" version="~>2.1.0"
+-dependency "inmath" version="~>1.0.5"
++dependency "inmath" version=">=1.0.5 <1.0.8"
+ dependency "i2d-opengl" version="~>1.0.0"
+ dependency "fghj" version="~>1.0.2"
+ versions "GL_32" "GL_ARB_gl_spirv" "GL_KHR_blend_equation_advanced" "GL_ARB_texture_filter_anisotropic"
+-- 
+2.45.1
+

--- a/app-creativity/inochi2d/autobuild/patches/0002-Expose-this-for-serialization.patch
+++ b/app-creativity/inochi2d/autobuild/patches/0002-Expose-this-for-serialization.patch
@@ -1,0 +1,68 @@
+From 3ef0cd608434be58fed91b41f7a8ae68e00a41bb Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Thu, 23 May 2024 00:18:20 +0800
+Subject: [PATCH 2/2] Expose this() for serialization
+
+Fixes the following errors:
+
+Error: constructor `inochi2d.core.nodes.drivers.Driver.this` is not
+accessible from module `simplephysics`
+Error: constructor `inochi2d.core.nodes.Node.this` is not accessible
+from module `drivers`
+---
+ source/inochi2d/core/nodes/drivers/package.d | 6 +++++-
+ source/inochi2d/core/nodes/package.d         | 7 ++++---
+ 2 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/source/inochi2d/core/nodes/drivers/package.d b/source/inochi2d/core/nodes/drivers/package.d
+index 9a46846..264e57a 100644
+--- a/source/inochi2d/core/nodes/drivers/package.d
++++ b/source/inochi2d/core/nodes/drivers/package.d
+@@ -17,7 +17,11 @@ public import inochi2d.core.nodes.drivers.simplephysics;
+ */
+ @TypeId("Driver")
+ abstract class Driver : Node {
+-private:
++public:
++
++    /**
++        Needed for deserialization
++    */
+     this() { }
+ 
+ protected:
+diff --git a/source/inochi2d/core/nodes/package.d b/source/inochi2d/core/nodes/package.d
+index 6090355..f7e2abd 100644
+--- a/source/inochi2d/core/nodes/package.d
++++ b/source/inochi2d/core/nodes/package.d
+@@ -74,8 +74,6 @@ void inClearUUIDs() {
+ @TypeId("Node")
+ class Node : ISerializable {
+ private:
+-    this() { }
+-
+     @Ignore
+     Puppet puppet_;
+ 
+@@ -216,8 +214,11 @@ package(inochi2d):
+         this.puppet_ = puppet;
+     }
+ 
++
+ public:
+ 
++    this() { }
++
+     /**
+         Whether the node is enabled
+     */
+@@ -1051,4 +1052,4 @@ mixin template InNode(T) {
+     static this() {
+         inRegisterNodeType!(T);
+     }
+-}
+\ No newline at end of file
++}
+-- 
+2.45.1
+

--- a/app-creativity/inochi2d/spec
+++ b/app-creativity/inochi2d/spec
@@ -1,0 +1,3 @@
+VER=0.8.3
+SRCS="git::commit=tags/v$VER::https://github.com/Inochi2D/inochi2d"
+CHKSUMS="SKIP"

--- a/lang-dlang/dub/autobuild/defines
+++ b/lang-dlang/dub/autobuild/defines
@@ -7,5 +7,10 @@ USECLANG=1
 ABSPLITDBG__LOONGSON3=0
 ABSPLITDBG__RISCV64=0
 
+# FIXME: ld.lld: error: lto.tmp: cannot link object files with different
+# floating-point ABI from
+# /usr/bin/../lib64/gcc/riscv64-aosc-linux-gnu/13.2.0/../../../../lib64/Scrt1.o
+NOLTO__RISCV64=1
+
 # FIXME: missing ldc
-FAIL_ARCH="!(amd64|arm64|loongson3|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"

--- a/lang-dlang/dub/spec
+++ b/lang-dlang/dub/spec
@@ -1,4 +1,5 @@
 VER=1.37.0
+REL=1
 SRCS="https://github.com/dlang/dub/archive/v$VER.tar.gz"
 CHKSUMS="sha256::8e8c5c841a43cb75af9828c3155a7e1ef90319177a66cebf9c94b33792cf8491"
 CHKUPDATE="anitya::id=141409"

--- a/lang-dlang/lumars/autobuild/build
+++ b/lang-dlang/lumars/autobuild/build
@@ -1,0 +1,6 @@
+abinfo 'Removing unneeded source files ...'
+rm -rfv "$SRCDIR"/deps
+
+abinfo 'Installing source files ...'
+install -vd "$PKGDIR"/usr/src
+rsync --exclude="autobuild" --exclude="*.log" --exclude="abdist" --exclude='.patch' -av "$SRCDIR" "$PKGDIR"/usr/src/

--- a/lang-dlang/lumars/autobuild/defines
+++ b/lang-dlang/lumars/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=lumars
+PKGSEC=lib
+PKGDES="D language binding for Lua"
+BUILDDEP="rsync"
+
+ABHOST=noarch

--- a/lang-dlang/lumars/autobuild/patches/0001-remove-architecture-restrictions.patch
+++ b/lang-dlang/lumars/autobuild/patches/0001-remove-architecture-restrictions.patch
@@ -1,0 +1,27 @@
+diff --git a/dub.sdl b/dub.sdl
+index 5bac5f9..80c79c1 100644
+--- a/dub.sdl
++++ b/dub.sdl
+@@ -8,12 +8,10 @@ dependency "taggedalgebraic" version="~>0.11.22"
+ 
+ configuration "lua51" {
+ 	targetType "library"
+-	dflags "-L$PACKAGE_DIR/deps/linux64/lua51.a" platform="linux-x86_64"
+-	dflags "-L$PACKAGE_DIR/deps/win64/lua51.lib" platform="windows-x86_64"
+-	dflags "-L$PACKAGE_DIR/deps/macamd/lua51.a" platform="osx-aarch64"
+-	dflags "-L$PACKAGE_DIR/deps/macx64/lua51.a" platform="osx-x86_64"
++	dflags "-L-llua5.1" platform="linux"
+ 	versions "BindLua_Static" "LUA_51"
+     subConfiguration "bindbc-lua" "static"
++        libs "lua5.1" platform="linux"
+ }
+ 
+ configuration "lua51-dynamic" {
+@@ -26,5 +24,7 @@ configuration "lua51-dynamic" {
+ 
+ configuration "lua52-dynamic" {
+ 	targetType "library"
++        dflags "-L-llua5.2" platform="linux"
+ 	versions "LUA_52"
++        libs "lua5.2" platform="linux"
+ }

--- a/lang-dlang/lumars/spec
+++ b/lang-dlang/lumars/spec
@@ -1,0 +1,3 @@
+VER=1.6.1
+SRCS="git::commit=876cb77a94c6e2eb1bf8faa28668660c66fec450::https://github.com/Inochi2D/lumars"
+CHKSUMS="SKIP"

--- a/runtime-multimedia/i2d-imgui/autobuild/build
+++ b/runtime-multimedia/i2d-imgui/autobuild/build
@@ -1,0 +1,6 @@
+abinfo 'Removing unneeded source files ...'
+rm -rfv "$SRCDIR"/deps/{SDL,freetype,glfw}
+
+abinfo 'Installing source files ...'
+install -vd "$PKGDIR"/usr/src
+rsync --exclude="autobuild" --exclude="*.log" --exclude="abdist" --exclude='.patch' -av "$SRCDIR" "$PKGDIR"/usr/src/

--- a/runtime-multimedia/i2d-imgui/autobuild/defines
+++ b/runtime-multimedia/i2d-imgui/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=i2d-imgui
+PKGSEC=lib
+PKGDES="D language binding for imgui"
+BUILDDEP="rsync"
+
+ABHOST=noarch

--- a/runtime-multimedia/i2d-imgui/autobuild/patches/0001-remove-architecture-restrictions.patch
+++ b/runtime-multimedia/i2d-imgui/autobuild/patches/0001-remove-architecture-restrictions.patch
@@ -1,0 +1,66 @@
+diff --git a/deps/CMakeLists.txt b/deps/CMakeLists.txt
+index a8bf132..f1c4f85 100644
+--- a/deps/CMakeLists.txt
++++ b/deps/CMakeLists.txt
+@@ -1,11 +1,7 @@
+ cmake_minimum_required(VERSION 3.16)
+-
++set(OpenGL_GL_PREFERENCE "GLVND")
+ project(bindbc_imgui)
+ 
+-include(cmake/PullSubmodules.cmake)
+-
+-PullSubmodules(${CMAKE_CURRENT_LIST_DIR}/.. submodulePrefixPath)
+-
+ message(STATUS "submodulePrefixPath: ${submodulePrefixPath}")
+ 
+ ####################
+@@ -44,7 +40,7 @@ else ()
+     set(PlatformFolder "Unknown")
+ endif()
+ 
+-set(OutputDirectory ${CMAKE_CURRENT_LIST_DIR}/../libs/${PlatformArchitecture}/${PlatformFolder})
++set(OutputDirectory ${CMAKE_CURRENT_LIST_DIR}/../libs/${PlatformFolder})
+ 
+ if (DEFINED STATIC_CIMGUI)
+     set(OutputDirectory ${OutputDirectory}/Static)
+@@ -99,7 +95,7 @@ endif()
+ option(BUILD_SHARED_LIBS "Build shared instead of static libraries." OFF)
+ set(IMGUI_SDL "yes" CACHE STRING "Build with SDL")
+ set(IMGUI_OPENGL3 "yes" CACHE STRING "Build with OpenGL3")
+-add_subdirectory(${cimgui_SUBMOD_DIR})
++add_subdirectory(cimgui)
+ 
+ set_target_properties(cimgui PROPERTIES DEBUG_POSTFIX "")
+ set_target_properties(cimgui PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${OutputDirectory})
+diff --git a/dub.sdl b/dub.sdl
+index de7d5e8..4345706 100644
+--- a/dub.sdl
++++ b/dub.sdl
+@@ -45,21 +45,13 @@ configuration "static_dynamicCRT" {
+     copyFiles "libs/x86/win32/Static/DynamicCRT/SDL2.dll" platform="windows-x86"
+     copyFiles "libs/x86/win32/Static/DynamicCRT/freetype.dll" platform="windows-x86"
+     
+-    // Linux x86_64
++    // Linux
+     preBuildCommands \
+-        "cmake -DSTATIC_CIMGUI= -S deps -B deps/build_linux_x64_cimguiStatic" \
+-        "cmake --build deps/build_linux_x64_cimguiStatic --config Release" platform="linux-x86_64"
++        "cmake -GNinja -DSTATIC_CIMGUI= -S deps -B deps/build_linux_cimguiStatic" \
++        "cmake --build deps/build_linux_cimguiStatic --config Release" platform="linux"
+ 
+-    sourceFiles "$PACKAGE_DIR/libs/x86_64/linux/Static/cimgui.a" platform="linux-x86_64"
+-    libs "sdl2" "freetype" ":libstdc++.so" platform="linux-x86_64"
+-
+-    // Linux aarch64
+-    preBuildCommands \
+-        "cmake -DSTATIC_CIMGUI= -S deps -B deps/build_linux_aarch64_cimguiStatic" \
+-        "cmake --build deps/build_linux_aarch64_cimguiStatic --config Release" platform="linux-aarch64"
+-
+-    sourceFiles "$PACKAGE_DIR/libs/aarch64/linux/Static/cimgui.a" platform="linux-aarch64"
+-    libs "sdl2" "freetype" ":libstdc++.so" platform="linux-aarch64"
++    sourceFiles "$PACKAGE_DIR/libs/linux/Static/cimgui.a" platform="linux"
++    libs "sdl2" "freetype" ":libstdc++.so" platform="linux"
+ }
+ 
+ configuration "static_staticCRT" {

--- a/runtime-multimedia/i2d-imgui/spec
+++ b/runtime-multimedia/i2d-imgui/spec
@@ -1,0 +1,3 @@
+VER=0.8.0
+SRCS="git::commit=tags/v$VER::https://github.com/Inochi2D/i2d-imgui"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- inochi2d-creator: new, 0.8.3
- inochi2d-session: new, 0.8.3
- dub: update FAIL_ARCH to include loongarch64 and exclude loongson3
- inochi2d: new, 0.8.3
- lumars: new, 1.6.1
- i2d-imgui: new, 0.8.0

Package(s) Affected
-------------------

- dub: 1.37.0-1
- i2d-imgui: 0.8.0
- inochi2d: 0.8.3
- inochi2d-creator: 0.8.3
- inochi2d-session: 0.8.3
- lumars: 1.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit i2d-imgui lumars inochi2d dub inochi2d-session inochi2d-creator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
