### PR TITLE
oma: update to 1.2.13

### DIFF
--- a/app-admin/oma/autobuild/postinst
+++ b/app-admin/oma/autobuild/postinst
@@ -1,0 +1,7 @@
+if [ ! -d /var/lib/atm ]; then
+    mkdir /var/lib/atm
+fi
+
+if [ ! -e /var/lib/atm/state ]; then
+    touch /var/lib/atm/state
+fi

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.2.10
+VER=1.2.13
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.2.13
    Create /var/lib/atm/state if it does not exist.

Package(s) Affected
-------------------

- oma: 1.2.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
