### PR TITLE
texlive: rebuild for Zlib-Lua API incompatibility

### DIFF
--- a/app-doc/texlive/autobuild/build
+++ b/app-doc/texlive/autobuild/build
@@ -19,7 +19,7 @@ fi
 
 mkdir "$SRCDIR"/build && cd "$SRCDIR"/build
 ../configure			   \
-    ${AUTOTOOLS_DEF}               \
+    ${AUTOTOOLS_DEF[@]}            \
     --enable-shared                \
     --disable-native-texlive-build \
     --disable-dvisvgm              \

--- a/app-doc/texlive/spec
+++ b/app-doc/texlive/spec
@@ -1,5 +1,5 @@
 VER=20220321
-REL=3
+REL=4
 SRCS="tbl::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-source.tar.xz \
       file::rename=texlive-$VER-texmf.tar.xz::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-texmf.tar.xz"
 CHKSUMS="sha256::5ffa3485e51eb2c4490496450fc69b9d7bd7cb9e53357d92db4bcd4fd6179b56 \


### PR DESCRIPTION
Topic Description
-----------------

- texlive: rebuild for Zlib-Lua API incompatibility

Package(s) Affected
-------------------

- texlive: 20220321-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit texlive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
