### PR TITLE
obs-studio (OBS Studio): fix build with autobuild4

### DIFF
--- a/app-multimedia/obs-studio/autobuild/beyond
+++ b/app-multimedia/obs-studio/autobuild/beyond
@@ -1,7 +1,18 @@
-[ -f "$PKGDIR"/usr/lib/obs-plugins/libcef.so ] || return
-
 abinfo "Correcting permissions for the browser plugin (if any) ..."
-chmod -v a+x "$PKGDIR"/usr/lib/obs-plugins/libcef.so
+if [ -f "$PKGDIR"/usr/lib/obs-plugins/libcef.so ]; then
+    chmod -v a+x "$PKGDIR"/usr/lib/obs-plugins/libcef.so
+fi
 
 abinfo "Adding plugin folder to linker search path ..."
-patchelf --debug --set-rpath /usr/lib/obs-plugins/ "$PKGDIR"/usr/lib/obs-plugins/obs-browser{-page,.so}
+if [ -f "$PKGDIR"/usr/lib/obs-plugins/obs-browser-page ]; then
+    patchelf \
+        --debug \
+        --set-rpath /usr/lib/obs-plugins/ \
+        "$PKGDIR"/usr/lib/obs-plugins/obs-browser-page
+fi
+if [ -f "$PKGDIR"/usr/lib/obs-plugins/obs-browser.so ]; then
+    patchelf \
+        --debug \
+        --set-rpath /usr/lib/obs-plugins/ \
+        "$PKGDIR"/usr/lib/obs-plugins/obs-browser.so
+fi

--- a/app-multimedia/obs-studio/spec
+++ b/app-multimedia/obs-studio/spec
@@ -1,4 +1,5 @@
 VER=27.0.0
+REL=4
 # __OBS_CEF_VER: Find the build version on https://cef-builds.spotifycdn.com/index.html#linux64
 __OBS_CEF_VER="89.0.18+gb36241d+chromium-89.0.4389.114"
 SRCS="git::commit=tags/$VER;rename=obs-studio::https://github.com/obsproject/obs-studio"
@@ -11,4 +12,3 @@ CHKSUMS__AMD64="$CHKSUMS sha1::8a26b6de70187114f99ea294f9ad799751428ac1"
 CHKSUMS__ARM64="$CHKSUMS sha1::7c7b89a7d72df4815bdc7a717eac9f09e090c925"
 SUBDIR="obs-studio"
 CHKUPDATE="anitya::id=7239"
-REL=3


### PR DESCRIPTION
Topic Description
-----------------

- obs-studio: fix beyond script

Package(s) Affected
-------------------

- obs-studio: 27.0.0-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit obs-studio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
