### PR TITLE
wps-office (WPS Office for Linux): add loongarch64 support

### DIFF
--- a/app-productivity/wps-office/autobuild/defines
+++ b/app-productivity/wps-office/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=wps-office
 PKGSEC=doc
 PKGDEP="bzip2 cups fontconfig glib glibc gcc-runtime glu mesa x11-lib libxcb aosc-nanny"
+PKGDEP__LOONGARCH64="${PKGDEP} liblol"
 PKGDES="An office productivity suite from Kingsoft"
 
 FAIL_ARCH="!(amd64|arm64|loongarch64|loongson3)"


### PR DESCRIPTION
Topic Description
-----------------

- wps-office: (loongarch64) add liblol dep
    This is an old-world ABI application, adding libLoL to fix compatibility.

Package(s) Affected
-------------------

- wps-office: 11.1.0.11711

Security Update?
----------------

No

Build Order
-----------

```
#buildit wps-office
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
