### PR TITLE
grub-customizer (GRUB Customizer): new, 5.2.4

### DIFF
--- a/app-admin/grub-customizer/autobuild/defines
+++ b/app-admin/grub-customizer/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=grub-customizer
+PKGSEC=admin
+PKGDEP="gtkmm-3 libarchive openssl"
+PKGDES="A graphical interface to configure the GRUB bootloader"
+
+ABTYPE=cmakeninja

--- a/app-admin/grub-customizer/autobuild/overrides/etc/grub-customizer/grub.cfg
+++ b/app-admin/grub-customizer/autobuild/overrides/etc/grub-customizer/grub.cfg
@@ -1,0 +1,39 @@
+#
+# Command to generate/print GRUB bootloader configuration.
+#
+MKCONFIG_CMD=grub-mkconfig
+
+#
+# Command to update GRUB bootloader configuration.
+#
+UPDATE_CMD=update-grub
+
+#
+# Command to install the GRUB bootloader.
+#
+INSTALL_CMD=grub-install
+
+#
+# Command to generate font data for the GRUB bootloader.
+#
+MKFONT_CMD=grub-mkfont
+
+#
+# Path to GRUB bootloader configuration generator scripts.
+#
+CFG_DIR=/etc/grub.d
+
+#
+# Path to generated GRUB bootloader configuration.
+#
+OUTPUT_DIR=/boot/grub
+
+#
+# File name for generated GRUB bootloader configuration.
+#
+OUTPUT_FILE=/boot/grub/grub.cfg
+
+#
+# Path to default GRUB bootloader configuration.
+#
+SETTINGS_FILE=/etc/default/grub

--- a/app-admin/grub-customizer/spec
+++ b/app-admin/grub-customizer/spec
@@ -1,0 +1,4 @@
+VER=5.2.4
+SRCS="tbl::https://launchpad.net/grub-customizer/${VER%.*}/$VER/+download/grub-customizer_$VER.tar.gz"
+CHKSUMS="sha256::81c881cae1cbd926fe309dbf8ff52c40e03b2937dd171ccb0f24cf9a4f99d5cc"
+CHKUPDATE="anitya::id=10153"


### PR DESCRIPTION
Topic Description
-----------------

- grub-customizer: new, 5.2.4

Package(s) Affected
-------------------

- grub-customizer: 5.2.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub-customizer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
