### PR TITLE
Mesa LoongArch LLVMPipe fix

### DIFF
--- a/runtime-display/mesa/autobuild/patches/0003-llvmpipe-add-LoongArch-support-in-ORCJIT.patch
+++ b/runtime-display/mesa/autobuild/patches/0003-llvmpipe-add-LoongArch-support-in-ORCJIT.patch
@@ -1,18 +1,18 @@
-From 6db646fdb9d01d7f838a68a5e5fbe73c102302e4 Mon Sep 17 00:00:00 2001
+From 63af0383e59b872aeb905a4dffb5e1b7d283ea69 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Fri, 3 Nov 2023 12:57:09 +0800
-Subject: [PATCH 3/3] llvmpipe: add LoongArch support in ORCJIT
+Subject: [PATCH] llvmpipe: add LoongArch support in ORCJIT
 
 Currently set CPU features based on softdev convention.
 
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
 ---
- .../auxiliary/gallivm/lp_bld_init_orc.cpp     | 24 ++++++++++++++++++-
- src/util/detect_arch.h                        | 12 ++++++++++
- 2 files changed, 35 insertions(+), 1 deletion(-)
+ .../auxiliary/gallivm/lp_bld_init_orc.cpp     | 26 ++++++++++++++++++-
+ src/util/detect_arch.h                        | 12 +++++++++
+ 2 files changed, 37 insertions(+), 1 deletion(-)
 
 diff --git a/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp b/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
-index 758a8bb61c5..fbb2d85ddfb 100644
+index 758a8bb61c5..dc14f9ee02c 100644
 --- a/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
 +++ b/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
 @@ -48,7 +48,7 @@
@@ -39,7 +39,7 @@ index 758a8bb61c5..fbb2d85ddfb 100644
  #endif
  
     JTMB.setOptions(options);
-@@ -668,6 +676,20 @@ llvm::orc::JITTargetMachineBuilder LPJit::create_jtdb() {
+@@ -668,6 +676,22 @@ llvm::orc::JITTargetMachineBuilder LPJit::create_jtdb() {
     MAttrs = {"+m","+c","+a","+d","+f"};
  #endif
  
@@ -53,8 +53,10 @@ index 758a8bb61c5..fbb2d85ddfb 100644
 +    * The Software development convention defaults to have "128-bit
 +    * vector", so LSX is enabled here, see
 +    * https://github.com/loongson/la-softdev-convention/releases/download/v0.1/la-softdev-convention.pdf
++    *
++    * FIXME: lsx is disabled here now because it's broken on LLVM17.
 +    */
-+   MAttrs = {"+f","+d","+lsx"};
++   MAttrs = {"+f","+d","-lsx"};
 +#endif
 +
     JTMB.addFeatures(MAttrs);

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,6 +1,7 @@
 MESA_VER=24.0.1
 DXHEADERS_VER=1.611.0
 VER=${MESA_VER}+dxheaders${DXHEADERS_VER}
+REL=1
 SRCS="git::commit=tags/mesa-${MESA_VER/\~/-};rename=mesa-${MESA_VER}::https://gitlab.freedesktop.org/mesa/mesa \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- mesa: hotfix loongarch orcjit patch to disable LSX
    LSX JIT is broken on LLVM17.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- mesa: 1:24.0.1+dxheaders1.611.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
