### PR TITLE
virtualenv update to 20.25.0

### DIFF
--- a/lang-python/calver/autobuild/defines
+++ b/lang-python/calver/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=calver
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer wheel"
+PKGDES="Setuptools extension for CalVer package versions"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/calver/spec
+++ b/lang-python/calver/spec
@@ -1,0 +1,4 @@
+VER=2022.06.26
+SRCS="git::commit=$VER::https://github.com/di/calver.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=100823"

--- a/lang-python/hatchling/autobuild/build
+++ b/lang-python/hatchling/autobuild/build
@@ -1,3 +1,0 @@
-cd "${SRCDIR}"
-python3 -m build --wheel --no-isolation backend
-python3 -m installer --destdir="$PKGDIR" backend/dist/*.whl

--- a/lang-python/hatchling/autobuild/defines
+++ b/lang-python/hatchling/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=hatchling
 PKGSEC=python
-PKGDEP="python-3 packaging pathspec pluggy tomli editables"
+PKGDEP="python-3 packaging pathspec pluggy tomli editables trove-classifiers"
 BUILDDEP="python-build setuptools-python3 python-installer wheel"
 PKGDES="Modern, extensible Python build backend"
 
 ABHOST=noarch
 NOPYTHON2=1
+ABTYPE=pep517

--- a/lang-python/hatchling/spec
+++ b/lang-python/hatchling/spec
@@ -1,4 +1,5 @@
-VER=1.13.0
+VER=1.21.1
 SRCS="tbl::https://github.com/pypa/hatch/archive/refs/tags/hatchling-v${VER}.tar.gz"
-CHKSUMS="sha256::41e17b56a28fd4e8f69e4cecbea4527491c761998aba8bd2fc71d0d9eadf66b8"
+CHKSUMS="sha256::c931dd012812e8afc29c9d6f9943252960bfc4c81273aa5b2458bdea74ae2b39"
 CHKUPDATE="anitya::id=16137"
+SUBDIR="hatch-hatchling-v${VER}/backend"

--- a/lang-python/trove-classifiers/autobuild/defines
+++ b/lang-python/trove-classifiers/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=trove-classifiers
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer wheel calver"
+PKGDES="Canonical source for classifiers on PyPI"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/trove-classifiers/spec
+++ b/lang-python/trove-classifiers/spec
@@ -1,0 +1,4 @@
+VER=2024.1.31
+SRCS="git::commit=$VER::https://github.com/pypa/trove-classifiers.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=88298"

--- a/lang-python/virtualenv/autobuild/defines
+++ b/lang-python/virtualenv/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=virtualenv
 PKGSEC=python
-PKGDEP="python-3 py-filelock distlib"
-BUILDDEP="setuptools-scm"
+PKGDEP="python-3 py-filelock distlib platformdirs"
+BUILDDEP="python-build python-installer wheel tomli hatch-vcs"
 PKGDES="A tool to create isolated Python environments"
 
 ABHOST=noarch
 
 NOPYTHON2=1
-ABTYPE=python
+ABTYPE=pep517

--- a/lang-python/virtualenv/spec
+++ b/lang-python/virtualenv/spec
@@ -1,4 +1,4 @@
-VER=20.17.1
+VER=20.25.0
 SRCS="https://pypi.io/packages/source/v/virtualenv/virtualenv-${VER}.tar.gz"
-CHKSUMS="sha256::f8b927684efc6f1cc206c9db297a570ab9ad0e51c16fa9e45487d36d1905c058"
+CHKSUMS="sha256::bf51c0d9c7dd63ea8e44086fa1e4fb1093a31e963b86959257378aef020e1f1b"
 CHKUPDATE="anitya::id=6904"


### PR DESCRIPTION
Topic Description
-----------------

- virtualenv: update to 20.25.0
    Also fixed the issue of missing necessary dependencies during installation
- hatchling: update to 1.21.1
    Because virtualenv need new version
- trove-classifiers: new,2024.1.31
    Because hatching requires
- calver: new,2022.06.26
    Because thrust classifiers require
- virtualenv: add pkgdep and builddep.
    Fix the bug where platformdirs will not be automatically installed when
    installing this package

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit calver trove-classifiers hatchling virtualenv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
