### PR TITLE
grub-customizer (GRUB Customizer): fix .desktop entry

### DIFF
--- a/app-admin/grub-customizer/autobuild/patches/0001-misc-use-pkexec-in-.desktop-entry.patch
+++ b/app-admin/grub-customizer/autobuild/patches/0001-misc-use-pkexec-in-.desktop-entry.patch
@@ -1,0 +1,32 @@
+From 78c8a914ab63b2b8bd680d4d9695311ab0208099 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 18 Feb 2024 20:03:05 +0800
+Subject: [PATCH] misc: use pkexec in .desktop entry
+
+The current implementation relies on KDE su, which is no longer supported.
+---
+ misc/grub-customizer.desktop | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/misc/grub-customizer.desktop b/misc/grub-customizer.desktop
+index 7e405e7..aac8041 100755
+--- a/misc/grub-customizer.desktop
++++ b/misc/grub-customizer.desktop
+@@ -1,7 +1,7 @@
+ [Desktop Entry]
+ Name=Grub Customizer
+ Comment=Customize the bootloader (GRUB2 or BURG)
+-Exec=grub-customizer
++Exec=pkexec grub-customizer
+ Terminal=false
+ X-MultipleArgs=false
+ Type=Application
+@@ -9,5 +9,4 @@ StartupNotify=false
+ Categories=System;Settings;
+ Icon=grub-customizer
+ X-Ubuntu-Gettext-Domain=grub-customizer
+-X-KDE-SubstituteUID=true
+ Keywords=GRUB;GRUB2;BURG;configuration;settings;menu;
+-- 
+2.43.0
+

--- a/app-admin/grub-customizer/spec
+++ b/app-admin/grub-customizer/spec
@@ -1,4 +1,5 @@
 VER=5.2.4
+REL=1
 SRCS="tbl::https://launchpad.net/grub-customizer/${VER%.*}/$VER/+download/grub-customizer_$VER.tar.gz"
 CHKSUMS="sha256::81c881cae1cbd926fe309dbf8ff52c40e03b2937dd171ccb0f24cf9a4f99d5cc"
 CHKUPDATE="anitya::id=10153"


### PR DESCRIPTION
Topic Description
-----------------

- grub-customizer: use pkexec in .desktop
    The upstream .desktop entry uses KDE su, which is no longer supported.

Package(s) Affected
-------------------

- grub-customizer: 5.2.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub-customizer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
