### PR TITLE
ddcutil: update to 2.1.3

### DIFF
--- a/app-utils/ddcutil/autobuild/defines
+++ b/app-utils/ddcutil/autobuild/defines
@@ -2,6 +2,15 @@ PKGNAME=ddcutil
 PKGSEC=utils
 PKGDES="Utility for controlling monitor settings using DDC/CI and USB"
 PKGDEP="i2c-tools glib libgudev libusb systemd libdrm x11-lib hwdata"
+BUILDDEP="doxygen"
 
-# FIXME: fatal error: src/ddc/ddc_displays.h: No such file or directory
-ABSHADOW=0
+# FIXME: doxyfile: No such file or directory
+AUTOTOOLS_AFTER=(
+    --enable-lib
+    --enable-envcmds
+    --enable-udev
+    --enable-usb
+    --enable-drm
+    --enable-x11
+    --disable-doxygen
+)

--- a/app-utils/ddcutil/spec
+++ b/app-utils/ddcutil/spec
@@ -1,4 +1,4 @@
-VER=2.0.0
+VER=2.1.3
 SRCS="git::commit=tags/v$VER::https://github.com/rockowitz/ddcutil"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242390"


### PR DESCRIPTION
Topic Description
-----------------

- ddcutil: update to 2.1.3
    - Enable shadow build.
    - Specify options explicitly where applicable.

Package(s) Affected
-------------------

- ddcutil: 2.1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit ddcutil
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
