### PR TITLE
sshpass: fix wrong package section

### DIFF
--- a/app-network/sshpass/autobuild/defines
+++ b/app-network/sshpass/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=sshpass
 PKGDES="Fool ssh into accepting an interactive password non-interactively"
 PKGDEP="openssh"
-PKGSEC=network
+PKGSEC=admin

--- a/app-network/sshpass/spec
+++ b/app-network/sshpass/spec
@@ -1,4 +1,5 @@
 VER=1.06
+REL=1
 SRCS="tbl::https://downloads.sourceforge.net/sshpass/sshpass-$VER.tar.gz"
 CHKSUMS="sha256::c6324fcee608b99a58f9870157dfa754837f8c48be3df0f5e2f3accf145dee60"
 CHKUPDATE="anitya::id=12961"


### PR DESCRIPTION
Topic Description
-----------------

- sshpass: fix wrong package section

Package(s) Affected
-------------------

- sshpass: 1.06-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sshpass
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
