### PR TITLE
Streamlink survey 20240206

### DIFF
--- a/app-devel/versioningit/autobuild/defines
+++ b/app-devel/versioningit/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=versioningit
+PKGSEC=python
+PKGDEP="python-3 packaging tomli"
+BUILDDEP="python-build python-installer wheel hatchling"
+PKGDES="A package versioning tool for Python projects"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/app-devel/versioningit/spec
+++ b/app-devel/versioningit/spec
@@ -1,0 +1,4 @@
+VER=3.0.0
+SRCS="tbl::https://pypi.io/packages/source/v/versioningit/versioningit-$VER.tar.gz"
+CHKSUMS="sha256::4e3ce47a6424d850ae9e55e1b134a020e9fcbcb895338f107f2b5c51d34c9c1b"
+CHKUPDATE="anitya::id=218700"

--- a/app-multimedia/streamlink/autobuild/defines
+++ b/app-multimedia/streamlink/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=streamlink
 PKGSEC=video
 PKGDES="A tool for extracting video streams from various websites to a video player"
-PKGDEP="python-3 isodate websocket-client pycountry pycryptodome pysocks requests rtmpdump ffmpeg"
+PKGDEP="python-3 rtmpdump ffmpeg certifi isodate lxml pycountry pycryptodome pysocks requests typing-extensions urllib3 websocket-client trio trio-websocket"
+BUILDDEP="versioningit setuptools wheel"
 
 ABTYPE=python
 ABHOST=noarch

--- a/app-multimedia/streamlink/spec
+++ b/app-multimedia/streamlink/spec
@@ -1,5 +1,4 @@
-VER=1.7.0
-SRCS="https://pypi.org/packages/source/s/streamlink/streamlink-${VER}.tar.gz"
-CHKSUMS="sha256::f87a62a47212d94769929bd040d9c186b461643bdbda06f839b99ec9efefb87a"
+VER=6.5.1
+SRCS="tbl::https://pypi.io/packages/source/s/streamlink/streamlink-$VER.tar.gz"
+CHKSUMS="sha256::207fb4ce99c35bfeb1b8f7c76b96cfcb4076ad6881c61eaea553c2ec13d97c57"
 CHKUPDATE="anitya::id=47101"
-REL=1

--- a/lang-python/outcome/autobuild/defines
+++ b/lang-python/outcome/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=outcome
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer wheel"
+PKGDES="A helper library to capture the outcome of Python function calls"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/outcome/spec
+++ b/lang-python/outcome/spec
@@ -1,0 +1,4 @@
+VER=1.3.0.post0
+SRCS="tbl::https://pypi.io/packages/source/o/outcome/outcome-$VER.tar.gz"
+CHKSUMS="sha256::9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8"
+CHKUPDATE="anitya::id=17548"

--- a/lang-python/setuptools-python3/spec
+++ b/lang-python/setuptools-python3/spec
@@ -1,5 +1,4 @@
-VER=62.6.0
-REL=1
+VER=69.1.0
 SRCS="git::commit=tags/v$VER::https://github.com/pypa/setuptools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4021"

--- a/lang-python/sniffio/spec
+++ b/lang-python/sniffio/spec
@@ -1,5 +1,4 @@
-VER=1.2.0
-SRCS="tbl::https://github.com/python-trio/sniffio/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::0e9af48e3f55d286cac3884c4fd0f2c4365702a9ae447bf029d7fc9046c3d7a4"
+VER=1.3.0
+SRCS="git::commit=tags/v$VER::https://github.com/python-trio/sniffio"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18170"
-REL=1

--- a/lang-python/trio-websocket/autobuild/defines
+++ b/lang-python/trio-websocket/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=trio-websocket
+PKGSEC=python
+PKGDEP="python-3 wsproto"
+BUILDDEP="pytest attrs sphinx sphinx-rtd-theme"
+PKGDES="WebSocket client and server implementation for Python Trio"
+
+ABTYPE=python
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/trio-websocket/spec
+++ b/lang-python/trio-websocket/spec
@@ -1,0 +1,4 @@
+VER=0.11.1
+SRCS="tbl::https://pypi.io/packages/source/t/trio-websocket/trio-websocket-$VER.tar.gz"
+CHKSUMS="sha256::18c11793647703c158b1f6e62de638acada927344d534e3c7628eedcb746839f"
+CHKUPDATE="anitya::id=136283"

--- a/lang-python/trio/autobuild/defines
+++ b/lang-python/trio/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=trio
+PKGSEC=python
+PKGDEP="python-3 attrs sortedcontainers idna sniffio cffi exceptiongroup outcome"
+BUILDDEP="wheel python-build python-installer setuptools-python3"
+PKGDES="Python async concurrency and I/O library"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/trio/spec
+++ b/lang-python/trio/spec
@@ -1,0 +1,4 @@
+VER=0.24.0
+SRCS="tbl::https://pypi.io/packages/source/t/trio/trio-$VER.tar.gz"
+CHKSUMS="sha256::ffa09a74a6bf81b84f8613909fb0beaee84757450183a7a2e0b47b455c0cac5d"
+CHKUPDATE="anitya::id=17451"

--- a/lang-python/websocket-client/autobuild/defines
+++ b/lang-python/websocket-client/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=websocket-client
 PKGDES="WebSocket client library for Python"
 BUILDDEP="setuptools six"
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 PKGSEC="python"
 
 ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/websocket-client/spec
+++ b/lang-python/websocket-client/spec
@@ -1,5 +1,4 @@
-VER=0.55.0
-SRCS="tbl::https://pypi.io/packages/source/w/websocket-client/websocket_client-$VER.tar.gz"
-CHKSUMS="sha256::f6029deea21218f2c771848935aa26c15699c831770f4fa66958bdaabff80ca0"
-REL=2
+VER=1.7.0
+SRCS="tbl::https://pypi.io/packages/source/w/websocket-client/websocket-client-$VER.tar.gz"
+CHKSUMS="sha256::10e511ea3a8c744631d3bd77e61eb17ed09304c413ad42cf6ddfa4c7787e8fe6"
 CHKUPDATE="anitya::id=7288"


### PR DESCRIPTION
Topic Description
-----------------

- sniffio: update to 1.3.0 as trio required
    The current version is below the required minimum version.
- trio-websocket: new, 0.11.1, needed by streamlink
- trio: new, 0.24.0, needed by streamlink
- setuptools-python3: update to 69.1.0 as trio required
    The current version is below the required minimum version.
- outcome: new, 1.3.0.post0, needed by trio
- versioningit: new, 3.0.0, needed by streamlink
- websocket-client: disable python-2 dependency
- websocket-client: update to 1.7.0 as streamlink required
    The current version is below the required minimum version.
- streamlink: upstream updated dependencies
- streamlink: update to 6.5.1

Package(s) Affected
-------------------

- versioningit: 3.0.0
- streamlink: 6.5.1
- trio-websocket: 0.11.1
- sniffio: 1.3.0
- trio: 0.24.0
- outcome: 1.3.0.post0
- websocket-client: 1.7.0
- setuptools-python3: 69.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit setuptools-python3 websocket-client sniffio outcome trio trio-websocket versioningit streamlink
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
