### PR TITLE
solid: fix loongarch64 /proc/cpuinfo parsing

### DIFF
--- a/desktop-kde/solid/autobuild/patches/0001-cpuinfo-add-loongarch64-proc-cpuinfo-parsing.patch
+++ b/desktop-kde/solid/autobuild/patches/0001-cpuinfo-add-loongarch64-proc-cpuinfo-parsing.patch
@@ -1,0 +1,55 @@
+From 75ae2a23fa535f0410c77915e8dc44c5d1f9ee42 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 20 Feb 2024 22:52:37 +0800
+Subject: [PATCH] cpuinfo: add loongarch64 /proc/cpuinfo parsing
+
+---
+ src/solid/devices/backends/udev/cpuinfo.cpp | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/src/solid/devices/backends/udev/cpuinfo.cpp b/src/solid/devices/backends/udev/cpuinfo.cpp
+index 05ec78ae..d824abb2 100644
+--- a/src/solid/devices/backends/udev/cpuinfo.cpp
++++ b/src/solid/devices/backends/udev/cpuinfo.cpp
+@@ -38,6 +38,9 @@ QString extractCpuVendor(int processorNumber)
+     if (vendor.isEmpty()) {
+         vendor = info.extractInfoLine("Hardware\\s+:\\s+(\\S.+)");
+     }
++#elif defined(__loongarch64)
++    // Splitting from "-" and taking only the first segment.
++    vendor = info.extractInfoLine("CPU Family\\s+:\\s+(\\S.+)").section('-', 0, 0);
+ #else
+     // ARM ? "CPU implementer : 0x41"
+     vendor = info.extractCpuInfoLine(processorNumber, "CPU implementer\\s+:\\s+(\\S.+)");
+@@ -69,6 +72,11 @@ QString extractCpuModel(int processorNumber)
+     if (model.isEmpty()) {
+         model = info.extractInfoLine("cpu\\s+:\\s+(\\S.+)");
+     }
++
++    // for loongarch64, extract from "Model Name:" line.
++    if (model.isEmpty()) {
++        model = info.extractInfoLine("Model Name\\s+:\\s+(\\S.+)");
++    }
+ #else
+     // ARM? "CPU part        : 0xd03"
+     const QString vendor = info.extractCpuInfoLine(processorNumber, "CPU implementer\\s+:\\s+(\\S.+)");
+@@ -89,7 +97,15 @@ QString extractCpuModel(int processorNumber)
+ int extractCurrentCpuSpeed(int processorNumber)
+ {
+     CpuInfo info;
+-    int speed = info.extractCpuInfoLine(processorNumber, "cpu MHz\\s+:\\s+(\\d+).*").toInt();
++    int speed;
++
++#if defined(__loongarch64)
++    // for loongarch64, extract from the "CPU MHz:" line.
++    speed = info.extractCpuInfoLine(processorNumber, "CPU MHz\\s+:\\s+(\\d+).*").toInt();
++#else
++    speed = info.extractCpuInfoLine(processorNumber, "cpu MHz\\s+:\\s+(\\d+).*").toInt();
++#endif
++
+     return speed;
+ }
+ 
+-- 
+2.43.0
+

--- a/desktop-kde/solid/spec
+++ b/desktop-kde/solid/spec
@@ -1,5 +1,5 @@
 VER=5.103.0
-REL=2
+REL=3
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/solid-$VER.tar.xz"
 CHKSUMS="sha256::e067087bcfc9d18dd2bfdf7b33901ee20fcdf7ba907242adc53356fd44e3d344"
 CHKUPDATE="anitya::id=8762"


### PR DESCRIPTION
Topic Description
-----------------

- solid: (loongarch64) fix /proc/cpuinfo parsing

Package(s) Affected
-------------------

- solid: 5.103.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit solid
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
