### PR TITLE
peewee: new, 3.17.1

### DIFF
--- a/lang-python/peewee/autobuild/defines
+++ b/lang-python/peewee/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=peewee
+PKGSEC=python
+PKGDEP="psycopg2 pymysql sqlite"
+BUILDDEP="python-build python-installer wheel"
+PKGDES="An object-relational mapper (ORM) for Python"
+
+ABTYPE=pep517

--- a/lang-python/peewee/spec
+++ b/lang-python/peewee/spec
@@ -1,0 +1,4 @@
+VER=3.17.1
+SRCS="tbl::https://pypi.io/packages/source/p/peewee/peewee-$VER.tar.gz"
+CHKSUMS="sha256::e009ac4227c4fdc0058a56e822ad5987684f0a1fbb20fed577200785102581c3"
+CHKUPDATE="anitya::id=52460"


### PR DESCRIPTION
Topic Description
-----------------

- peewee: new, 3.17.1

Package(s) Affected
-------------------

- peewee: 3.17.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit peewee
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
