### PR TITLE
lunarsolarconverter: new, 1.1.0

### DIFF
--- a/lang-python/lunarsolarconverter/autobuild/defines
+++ b/lang-python/lunarsolarconverter/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=lunarsolarconverter
+PKGSEC=python
+PKGDEP="python-3"
+PKGDES="A Georgian to Lunar (Nongli) calendar converter module for Python"
+
+NOPYTHON2=1
+ABTYPE=python
+
+ABHOST=noarch

--- a/lang-python/lunarsolarconverter/spec
+++ b/lang-python/lunarsolarconverter/spec
@@ -1,0 +1,4 @@
+VER=1.1.0
+SRCS="tbl::https://pypi.io/packages/source/L/LunarSolarConverter/LunarSolarConverter-$VER.tar.gz"
+CHKSUMS="sha256::78dcde00f02944d9059042198e55c8fb90b5be05209a5fb9cf3ec57f102d68c4"
+CHKUPDATE="anitya::id=371532"


### PR DESCRIPTION
Topic Description
-----------------

- lunarsolarconverter: new, 1.1.0

Package(s) Affected
-------------------

- lunarsolarconverter: 1.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lunarsolarconverter
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
