### PR TITLE
rdfind: update to 1.6.0

### DIFF
--- a/app-utils/rdfind/spec
+++ b/app-utils/rdfind/spec
@@ -1,5 +1,4 @@
-VER=1.4.1
-REL=1
+VER=1.6.0
 SRCS="tbl::https://rdfind.pauldreik.se/rdfind-$VER.tar.gz"
-CHKSUMS="sha256::30c613ec26eba48b188d2520cfbe64244f3b1a541e60909ce9ed2efb381f5e8c"
+CHKSUMS="sha256::7a406e8ef1886a5869655604618dd98f672f12c6a6be4926d053be65070f3279"
 CHKUPDATE="anitya::id=231641"


### PR DESCRIPTION
Topic Description
-----------------

- rdfind: update to 1.6.0

Package(s) Affected
-------------------

- rdfind: 1.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rdfind
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
