### PR TITLE
libvterm: update to 0.3.3

### DIFF
--- a/runtime-common/libvterm/spec
+++ b/runtime-common/libvterm/spec
@@ -1,4 +1,4 @@
-VER=20190910
-SRCS="git::commit=4a5fa43e0dbc0db4fe67d40d788d60852864df9e::https://github.com/neovim/libvterm"
+VER=0.3.3
+SRCS="git::commit=tags/v$VER::https://github.com/neovim/libvterm"
 CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=230206"
+CHKUPDATE="anitya::id=267537"


### PR DESCRIPTION
Topic Description
-----------------

- libvterm: update to 0.3.3

Package(s) Affected
-------------------

- libvterm: 0.3.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvterm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
