### PR TITLE
luajit: fix build on arm64

### DIFF
--- a/lang-lua/luajit/autobuild/build
+++ b/lang-lua/luajit/autobuild/build
@@ -1,5 +1,5 @@
 make amalg PREFIX=/usr \
-     CFLAGS="${CPPFLAGS} ${CFLAGS}" LDFLAGS="${LDFLAGS}"
+     CFLAGS="${CPPFLAGS} ${CFLAGS}" LDFLAGS="${LDFLAGS}" BUILDMODE=dynamic TARGET_STRIP=" @:"
 make install DESTDIR="$PKGDIR" PREFIX=/usr
 
 ln -sv luajit-${PKGVER/b/-beta} "$PKGDIR"/usr/bin/luajit

--- a/lang-lua/luajit/autobuild/defines
+++ b/lang-lua/luajit/autobuild/defines
@@ -4,4 +4,4 @@ PKGDEP="glibc"
 PKGDES="Just-in-time compiler and drop-in replacement for Lua 5.1"
 
 AB_FLAGS_O3=1
-FAIL_ARCH="!(amd64|armv4|armv6hf|armv7hf|arm64|i486|loongson2f|loongson3)"
+FAIL_ARCH="!(amd64|armv4|armv6hf|armv7hf|arm64|i486|loongson2f|loongson3|mips64r6el)"

--- a/lang-lua/luajit/spec
+++ b/lang-lua/luajit/spec
@@ -1,5 +1,5 @@
 VER=2.1.0b3
 SRCS="tbl::https://luajit.org/download/LuaJIT-${VER/b/-beta}.tar.gz"
 CHKSUMS="sha256::1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
-REL=1
+REL=2
 CHKUPDATE="anitya::id=6444"


### PR DESCRIPTION
Topic Description
-----------------

- luajit: fix build on arm64

Package(s) Affected
-------------------

- luajit: 2.1.0b3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit luajit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
