### PR TITLE
fsearch: update to 0.2.3

### DIFF
--- a/app-utils/fsearch/spec
+++ b/app-utils/fsearch/spec
@@ -1,5 +1,4 @@
-VER=0.1~beta4
-SRCS="tbl::https://github.com/cboxdoerfer/fsearch/archive/v${VER/\~/}.tar.gz"
-CHKSUMS="sha512::9f1d628d944c4665958f516d7b484a7a92f49b78ead08e6bcdf6b846f3828bbd9db67ba5e33138a20011e2d34c153f0c7240db81c665e346a7f51e75231ab6ee"
-REL=2
+VER=0.2.3
+SRCS="git::commit=tags/$VER::https://github.com/cboxdoerfer/fsearch"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231581"


### PR DESCRIPTION
Topic Description
-----------------

- fsearch: update to 0.2.3

Package(s) Affected
-------------------

- fsearch: 0.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit fsearch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
