### PR TITLE
luajit: update to 2.1.0b3+git20240222

### DIFF
--- a/lang-lua/luajit/autobuild/build
+++ b/lang-lua/luajit/autobuild/build
@@ -1,5 +1,3 @@
 make amalg PREFIX=/usr \
      CFLAGS="${CPPFLAGS} ${CFLAGS}" LDFLAGS="${LDFLAGS}" BUILDMODE=dynamic TARGET_STRIP=" @:"
 make install DESTDIR="$PKGDIR" PREFIX=/usr
-
-ln -sv luajit-${PKGVER/b/-beta} "$PKGDIR"/usr/bin/luajit

--- a/lang-lua/luajit/spec
+++ b/lang-lua/luajit/spec
@@ -1,5 +1,4 @@
-VER=2.1.0b3
-SRCS="tbl::https://luajit.org/download/LuaJIT-${VER/b/-beta}.tar.gz"
-CHKSUMS="sha256::1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
-REL=2
+VER=2.1.0b3+git20240222
+SRCS="git::commit=0d313b243194a0b8d2399d8b549ca5a0ff234db5::https://luajit.org/git/luajit.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6444"


### PR DESCRIPTION
Topic Description
-----------------

- luajit: update to 2.1.0b3+git20240222

Package(s) Affected
-------------------

- luajit: 2.1.0b3+git20240222

Security Update?
----------------

No

Build Order
-----------

```
#buildit luajit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
