### PR TITLE
gifsicle: update to 1.95

### DIFF
--- a/app-utils/gifsicle/spec
+++ b/app-utils/gifsicle/spec
@@ -1,4 +1,4 @@
-VER=1.92
-SRCS="tbl::https://github.com/kohler/gifsicle/archive/v$VER.tar.gz"
-CHKSUMS="sha256::f8a944f47faa9323bcc72c6e2239e0608bf30693894aee61512aba107a4c6b55"
+VER=1.95
+SRCS="git::commit=tags/v$VER::https://github.com/kohler/gifsicle"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1159"


### PR DESCRIPTION
Topic Description
-----------------

- gifsicle: update to 1.95

Package(s) Affected
-------------------

- gifsicle: 1.95

Security Update?
----------------

No

Build Order
-----------

```
#buildit gifsicle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
