### PR TITLE
gitui: update to 0.25.0

### DIFF
--- a/app-utils/gitui/autobuild/defines
+++ b/app-utils/gitui/autobuild/defines
@@ -12,3 +12,4 @@ NOLTO__RISCV64=1
 
 # FIXME: ld.lld is not yet available.
 NOLTO__LOONGSON3=1
+NOLTO__LOONGARCH64=1

--- a/app-utils/gitui/spec
+++ b/app-utils/gitui/spec
@@ -1,4 +1,4 @@
-VER=0.22.1
-SRCS="tbl::https://github.com/extrawurst/gitui/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::285e86c136ee7f410fdd52c5284ccf0d19011cc5f7709e5e10bb02f439a218ea"
+VER=0.25.0
+SRCS="git::commit=tags/v$VER::https://github.com/extrawurst/gitui"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=187553"


### PR DESCRIPTION
Topic Description
-----------------

- gitui: update to 0.25.0

Package(s) Affected
-------------------

- gitui: 0.25.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gitui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
