### PR TITLE
zig: new, 0.11.0+git20240222

### DIFF
--- a/lang-ziglang/zig/autobuild/defines
+++ b/lang-ziglang/zig/autobuild/defines
@@ -1,0 +1,23 @@
+PKGNAME=zig
+PKGSEC=devel
+PKGDEP="llvm zlib zstd"
+PKGDES="General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    -DZIG_SHARED_LLVM=ON
+    -DZIG_USE_LLVM_CONFIG=ON
+    -DZIG_PIE=ON
+    -DZIG_TARGET_MCPU=baseline
+    '-DZIG_RELEASE_ARG=-Doptimize=ReleaseFast -Dbuild-id=sha1'
+)
+USECLANG=0
+NOLTO=1
+
+# FIXME:
+# arm64: memory usage peaked at 7144988672 bytes, exceeding the declared upper bound of 7000000000
+# loongarch64: unsupported
+# ppc64el/loongson3: ‘asm’ specifier for variable ‘xx’ conflicts with ‘asm’ clobber list
+# mips64r6el: the register ‘lo’ cannot be clobbered in ‘asm’ for the current target
+# riscv64: infinite hang
+FAIL_ARCH="!(amd64)"

--- a/lang-ziglang/zig/autobuild/patches/0001-enable-build-id-tagging.patch
+++ b/lang-ziglang/zig/autobuild/patches/0001-enable-build-id-tagging.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt	2024-03-03 14:50:37.897551046 -0800
++++ b/CMakeLists.txt	2024-03-03 14:51:10.764685290 -0800
+@@ -925,6 +925,7 @@
+   --zig-lib-dir "${CMAKE_SOURCE_DIR}/lib"
+   "-Dconfig_h=${ZIG_CONFIG_H_OUT}"
+   "-Denable-llvm"
++  "-Dbuild-id=sha1"
+   ${ZIG_RELEASE_ARG}
+   ${ZIG_STATIC_ARG}
+   ${ZIG_NO_LIB_ARG}

--- a/lang-ziglang/zig/spec
+++ b/lang-ziglang/zig/spec
@@ -1,0 +1,4 @@
+VER=0.11.0+git20240222
+SRCS="git::commit=dd1fc1cb8c2258256566fd0035deb6fbf700fc69::https://github.com/ziglang/zig"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=13871"


### PR DESCRIPTION
Topic Description
-----------------

- zig: new, 0.11.0+git20240222
    * Enables PIE
    * Enables build-id tagging
    * Uses system LLVM

Package(s) Affected
-------------------

- zig: 0.11.0+git20240222

Security Update?
----------------

No

Build Order
-----------

```
#buildit zig
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
