### PR TITLE
grc: update to 1.13

### DIFF
--- a/app-utils/grc/spec
+++ b/app-utils/grc/spec
@@ -1,5 +1,4 @@
-VER=1.11.3
-REL=2
-SRCS="tbl::https://github.com/garabik/grc/archive/v$VER.tar.gz"
-CHKSUMS="sha256::b167babd8f073a68f5a3091f833e4036fb8d86504e746694747a3ee5048fa7a9"
+VER=1.13
+SRCS="git::commit=tags/v$VER::https://github.com/garabik/grc"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14562"


### PR DESCRIPTION
Topic Description
-----------------

- grc: update to 1.13

Package(s) Affected
-------------------

- grc: 1.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit grc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
