### PR TITLE
texlive (TeXLive): rebuild against latest zlib

### DIFF
--- a/app-doc/texlive/spec
+++ b/app-doc/texlive/spec
@@ -1,5 +1,5 @@
 VER=20220321
-REL=4
+REL=5
 SRCS="tbl::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-source.tar.xz \
       file::rename=texlive-$VER-texmf.tar.xz::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-texmf.tar.xz"
 CHKSUMS="sha256::5ffa3485e51eb2c4490496450fc69b9d7bd7cb9e53357d92db4bcd4fd6179b56 \


### PR DESCRIPTION
Topic Description
-----------------

- texlive: bump REL due to zlib update
    - fix unprotected error in call to Lua API after being installed

Package(s) Affected
-------------------

- texlive: 20220321-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit texlive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
