### PR TITLE
octave: add dep

### DIFF
--- a/app-scientific/octave/autobuild/build
+++ b/app-scientific/octave/autobuild/build
@@ -1,4 +1,4 @@
-./configure ${AUTOTOOLS_DEF} \
+./configure ${AUTOTOOLS_DEF[@]} \
             --with-umfpack="-lumfpack -lsuitesparseconfig" \
             ${AUTOTOOLS_AFTER}
 make OCTAVE_RELEASE="${DISTVER}"

--- a/app-scientific/octave/autobuild/defines
+++ b/app-scientific/octave/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=octave
 PKGSEC=math
 PKGDEP="arpack-ng curl fftw fltk ghostscript glpk glu gnuplot graphicsmagick hdf5 \
-        libsndfile qhull qscintilla suitesparse texinfo openjdk qt-5 openblas"
+        libsndfile qhull qscintilla suitesparse texinfo openjdk qt-5 openblas gl2ps"
 PKGDES="A high-level language intended for numerical computations"
 
 AUTOTOOLS_AFTER="--libexecdir=/usr/lib \

--- a/app-scientific/octave/spec
+++ b/app-scientific/octave/spec
@@ -2,4 +2,4 @@ VER=6.4.0
 SRCS="tbl::https://ftp.gnu.org/gnu/octave/octave-$VER.tar.lz"
 CHKSUMS="sha256::40eaa1492ec1baf5084a1694288febdcba568838f4983450f8dac5819934059a"
 CHKUPDATE="anitya::id=2528"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- octave: bump REL due to add dep gl2ps
- octave: add gl2ps in PKGDEP
    Fix cannot found libgl2ps.so.1 when running octave

Package(s) Affected
-------------------

- octave: 6.4.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit octave
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
