### PR TITLE
qt-6: update to 6.6.2

### DIFF
--- a/runtime-desktop/qt-6/autobuild/patches/0005-loongarch64.patch.loongarch64
+++ b/runtime-desktop/qt-6/autobuild/patches/0005-loongarch64.patch.loongarch64
@@ -1,27 +1,18 @@
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/cmake/Functions.cmake b/qtwebengine/cmake/Functions.cmake
---- a/qtwebengine/cmake/Functions.cmake	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/cmake/Functions.cmake	2024-01-18 23:11:22.535745082 +0800
-@@ -663,6 +663,8 @@ function(get_gn_arch result arch)
+--- a/qtwebengine/cmake/Functions.cmake	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/cmake/Functions.cmake	2024-02-23 13:35:52.073151187 +0800
+@@ -633,6 +633,8 @@ function(get_gn_arch result arch)
          set(${result} "mips64el" PARENT_SCOPE)
      elseif(arch STREQUAL "riscv64")
          set(${result} "riscv64" PARENT_SCOPE)
 +    elseif(arch STREQUAL "loongarch64")
 +        set(${result} "loong64" PARENT_SCOPE)
      else()
-         message(DEBUG "Unsupported architecture: ${arch}")
+         message(FATAL_ERROR "Unknown architecture: ${arch}")
      endif()
-@@ -684,6 +686,8 @@ function(get_v8_arch result targetArch h
-             set(${result} "mipsel" PARENT_SCOPE)
-         elseif(hostArch STREQUAL "riscv64")
-             set(${result} "riscv64" PARENT_SCOPE)
-+        elseif(hostArch STREQUAL "loongarch64")
-+            set(${result} "loong64" PARENT_SCOPE)
-         elseif(hostArch IN_LIST list32)
-             set(${result} "${hostArch}" PARENT_SCOPE)
-         else()
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.gni b/qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.gni
---- a/qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.gni	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.gni	2024-01-19 00:38:20.266846266 +0800
+--- a/qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.gni	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.gni	2024-02-23 13:35:52.074151194 +0800
 @@ -14,7 +14,7 @@ if (is_apple) {
  if (is_nacl) {
    # NaCl targets don't use 64-bit pointers.
@@ -32,8 +23,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  } else if (current_cpu == "x86" || current_cpu == "arm") {
    has_64_bit_pointers = false
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/features.gni b/qtwebengine/src/3rdparty/chromium/sandbox/features.gni
---- a/qtwebengine/src/3rdparty/chromium/sandbox/features.gni	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/features.gni	2024-01-18 23:11:22.535745082 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/features.gni	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/features.gni	2024-02-23 13:35:52.074151194 +0800
 @@ -9,7 +9,7 @@
  use_seccomp_bpf = (is_linux || is_chromeos || is_android) &&
                    (current_cpu == "x86" || current_cpu == "x64" ||
@@ -44,8 +35,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  # SSBD (Speculative Store Bypass Disable) is a mitigation of Spectre Variant 4.
  # As Spectre Variant 4 can be mitigated by site isolation, opt-out SSBD on site
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h	2024-01-18 23:11:22.536745095 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h	2024-02-23 13:35:52.074151194 +0800
 @@ -56,6 +56,13 @@
  #define MAX_PUBLIC_SYSCALL __NR_syscalls
  #define MAX_SYSCALL MAX_PUBLIC_SYSCALL
@@ -61,8 +52,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #error "Unsupported architecture"
  #endif
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h	2024-01-18 23:11:22.536745095 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h	2024-02-23 13:35:52.075151201 +0800
 @@ -343,6 +343,47 @@ struct regs_struct {
  #define SECCOMP_PT_PARM4(_regs) (_regs).regs[3]
  #define SECCOMP_PT_PARM5(_regs) (_regs).regs[4]
@@ -112,8 +103,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #error Unsupported target platform
  
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/syscall.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/syscall.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/syscall.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/syscall.cc	2024-01-18 23:11:22.537745109 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/syscall.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/syscall.cc	2024-02-23 13:35:52.076151207 +0800
 @@ -18,7 +18,7 @@ namespace sandbox {
  namespace {
  
@@ -170,10 +161,9 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #else
  #error "Unimplemented architecture"
  #endif
-Binary files a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/.baseline_policy.cc.swp and b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/.baseline_policy.cc.swp differ
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc	2024-01-19 01:10:04.101805346 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc	2024-02-23 13:35:52.076151207 +0800
 @@ -193,7 +193,7 @@ ResultExpr EvaluateSyscallImpl(int fs_de
      return RestrictFcntlCommands();
  #endif
@@ -227,8 +217,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
      return Allow();
    }
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc	2024-01-18 23:11:22.538745122 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc	2024-02-23 13:35:52.076151207 +0800
 @@ -354,6 +354,7 @@ intptr_t SIGSYSSchedHandler(const struct
  
  intptr_t SIGSYSFstatatHandler(const struct arch_seccomp_data& args,
@@ -246,8 +236,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    CrashSIGSYS_Handler(args, fs_denied_errno);
  
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc	2024-01-18 23:11:22.539745135 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc	2024-02-23 13:35:52.077151214 +0800
 @@ -37,7 +37,7 @@
  
  #if (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS_LACROS)) && \
@@ -280,8 +270,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #if defined(__arm__)
                   PTRACE_GETVFPREGS,
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc	2024-01-18 23:11:22.541745162 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc	2024-02-23 13:35:52.078151221 +0800
 @@ -103,7 +103,7 @@ bool SyscallSets::IsUmask(int sysno) {
  // Both EPERM and ENOENT are valid errno unless otherwise noted in comment.
  bool SyscallSets::IsFileSystem(int sysno) {
@@ -537,8 +527,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #endif
        return true;
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h	2024-01-18 23:11:22.541745162 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h	2024-02-23 13:35:52.078151221 +0800
 @@ -79,18 +79,18 @@ class SANDBOX_EXPORT SyscallSets {
    static bool IsAsyncIo(int sysno);
    static bool IsKeyManagement(int sysno);
@@ -562,8 +552,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #endif
  
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/credentials.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/credentials.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/credentials.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/credentials.cc	2024-01-18 23:11:22.542745175 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/credentials.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/credentials.cc	2024-02-23 13:35:52.079151228 +0800
 @@ -80,7 +80,7 @@ bool ChrootToSafeEmptyDir() {
    pid_t pid = -1;
    alignas(16) char stack_buf[PTHREAD_STACK_MIN];
@@ -574,8 +564,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    void* stack = stack_buf + sizeof(stack_buf);
  #else
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc	2024-01-18 23:11:22.542745175 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc	2024-02-23 13:35:52.079151228 +0800
 @@ -5,6 +5,7 @@
  #include "sandbox/linux/services/syscall_wrappers.h"
  
@@ -663,8 +653,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #else
    res = syscall(__NR_lstat, path, stat_buf);
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h	2024-01-18 23:11:22.542745175 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h	2024-02-23 13:35:52.080151234 +0800
 @@ -19,6 +19,7 @@ struct cap_hdr;
  struct cap_data;
  struct kernel_stat;
@@ -682,8 +672,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  // Takes care of unpoisoning |stat_buf| for MSAN. Check-fails if fstatat64() is
  // not a supported syscall on the current platform.
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_client.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_client.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_client.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_client.cc	2024-01-19 00:58:08.085546731 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_client.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_client.cc	2024-02-23 13:35:52.080151234 +0800
 @@ -193,6 +193,21 @@ int BrokerClient::Stat64(const char* pat
                             sizeof(*sb));
  }
@@ -707,8 +697,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    if (!path)
      return -EFAULT;
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_client.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_client.h
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_client.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_client.h	2024-01-18 23:11:22.543745189 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_client.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_client.h	2024-02-23 13:35:52.080151234 +0800
 @@ -67,6 +67,9 @@ class SANDBOX_EXPORT BrokerClient : publ
    int Stat64(const char* pathname,
               bool follow_links,
@@ -720,8 +710,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    int InotifyAddWatch(int fd,
                        const char* pathname,
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_command.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_command.h
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_command.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_command.h	2024-01-18 23:11:22.544745202 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_command.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_command.h	2024-02-23 13:35:52.081151241 +0800
 @@ -41,6 +41,7 @@ enum BrokerCommand {
    COMMAND_RMDIR,
    COMMAND_STAT,
@@ -731,8 +721,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    COMMAND_INOTIFY_ADD_WATCH,
  
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_host.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_host.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_host.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_host.cc	2024-01-18 23:11:22.544745202 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_host.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_host.cc	2024-02-23 13:35:52.081151241 +0800
 @@ -299,6 +299,21 @@ void BrokerHost::StatFileForIPC(BrokerCo
      RAW_CHECK(reply->AddIntToMessage(0));
      RAW_CHECK(
@@ -766,8 +756,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
        if (!message->ReadString(&requested_filename)) {
          return false;
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_process.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_process.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_process.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_process.cc	2024-01-18 23:11:22.545745215 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_process.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_process.cc	2024-02-23 13:35:52.082151248 +0800
 @@ -122,44 +122,46 @@ bool BrokerProcess::IsSyscallBrokerable(
    // and are default disabled in Android. So, we should refuse to broker them
    // to be consistent with the platform's restrictions.
@@ -842,8 +832,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
        return !fast_check || policy_->allowed_command_set.test(COMMAND_UNLINK);
  #endif
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.cc	2024-01-18 23:11:22.545745215 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.cc	2024-02-23 13:35:52.082151248 +0800
 @@ -169,6 +169,19 @@ int SyscallDispatcher::DispatchSyscall(c
        return Stat64(reinterpret_cast<const char*>(args.args[0]), true,
                      reinterpret_cast<struct kernel_stat64*>(args.args[1]));
@@ -865,8 +855,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
      case __NR_lstat:
        // See https://crbug.com/847096
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.h
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.h	2024-01-18 23:11:22.546745229 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.h	2024-02-23 13:35:52.083151255 +0800
 @@ -49,6 +49,9 @@ class SANDBOX_EXPORT SyscallDispatcher {
    virtual int Stat64(const char* pathname,
                       bool follow_links,
@@ -878,8 +868,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    // Emulates unlink()/unlinkat().
    virtual int Unlink(const char* unlink) const = 0;
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_seccomp.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_seccomp.h
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_seccomp.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_seccomp.h	2024-01-18 23:11:22.546745229 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_seccomp.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_seccomp.h	2024-02-23 13:35:52.083151255 +0800
 @@ -39,6 +39,10 @@
  #define EM_AARCH64 183
  #endif
@@ -903,8 +893,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #ifndef PR_SET_SECCOMP
  #define PR_SET_SECCOMP               22
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_signal.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_signal.h
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_signal.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_signal.h	2024-01-18 23:11:22.547745242 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_signal.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_signal.h	2024-02-23 13:35:52.083151255 +0800
 @@ -13,7 +13,7 @@
  // (not undefined, but defined different values and in different memory
  // layouts). So, fill the gap here.
@@ -915,8 +905,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #define LINUX_SIGHUP 1
  #define LINUX_SIGINT 2
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_stat.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_stat.h
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_stat.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_stat.h	2024-01-18 23:11:22.547745242 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_stat.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_stat.h	2024-02-23 13:35:52.084151261 +0800
 @@ -150,7 +150,7 @@ struct kernel_stat {
    int st_blocks;
    int st_pad4[14];
@@ -986,8 +976,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  
  #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LINUX_STAT_H_
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_syscalls.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_syscalls.h
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_syscalls.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_syscalls.h	2024-01-18 23:11:22.547745242 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_syscalls.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_syscalls.h	2024-02-23 13:35:52.084151261 +0800
 @@ -35,5 +35,9 @@
  #include "sandbox/linux/system_headers/arm64_linux_syscalls.h"
  #endif
@@ -1000,7 +990,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/loong64_linux_syscalls.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/loong64_linux_syscalls.h
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/loong64_linux_syscalls.h	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/loong64_linux_syscalls.h	2024-01-18 23:11:22.548745255 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/loong64_linux_syscalls.h	2024-02-23 13:35:52.085151268 +0800
 @@ -0,0 +1,1194 @@
 +// Copyright 2023 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
@@ -2197,8 +2187,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +
 +#endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LOONG64_LINUX_SYSCALLS_H_
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_audio_policy_linux.cc b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_audio_policy_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_audio_policy_linux.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_audio_policy_linux.cc	2024-01-18 23:12:32.573670550 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_audio_policy_linux.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_audio_policy_linux.cc	2024-02-23 13:35:52.086151275 +0800
 @@ -85,6 +85,7 @@ ResultExpr AudioProcessPolicy::EvaluateS
        return Switch(op & ~(FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME))
            .Cases({FUTEX_CMP_REQUEUE,
@@ -2208,8 +2198,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
                    FUTEX_WAIT,
                    FUTEX_WAIT_BITSET,
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_broker_policy_linux.cc b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_broker_policy_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_broker_policy_linux.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_broker_policy_linux.cc	2024-01-18 23:11:22.549745269 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_broker_policy_linux.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_broker_policy_linux.cc	2024-02-23 13:35:52.086151275 +0800
 @@ -87,6 +87,12 @@ ResultExpr BrokerProcessPolicy::Evaluate
          return Allow();
        break;
@@ -2224,8 +2214,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
      case __NR_lstat:
        if (allowed_command_set_.test(syscall_broker::COMMAND_STAT))
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc	2024-01-18 23:11:22.550745282 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc	2024-02-23 13:35:52.086151275 +0800
 @@ -38,7 +38,7 @@ ResultExpr CrosAmdGpuProcessPolicy::Eval
      case __NR_sched_setscheduler:
      case __NR_sysinfo:
@@ -2236,8 +2226,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
      case __NR_stat:
  #endif
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_gpu_policy_linux.cc b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_gpu_policy_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_gpu_policy_linux.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_gpu_policy_linux.cc	2024-01-18 23:11:22.550745282 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_gpu_policy_linux.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_gpu_policy_linux.cc	2024-02-23 13:35:52.087151281 +0800
 @@ -80,7 +80,7 @@ ResultExpr GpuProcessPolicy::EvaluateSys
      (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
      case __NR_ftruncate64:
@@ -2248,8 +2238,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #endif
      case __NR_getdents64:
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc	2024-01-18 23:12:55.395968768 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc	2024-02-23 13:35:52.087151281 +0800
 @@ -37,7 +37,7 @@ ResultExpr ScreenAIProcessPolicy::Evalua
        const Arg<int> op(1);
        return Switch(op & FUTEX_CMD_MASK)
@@ -2260,8 +2250,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
                Allow())
            // Sending ENOSYS tells the Futex backend to use another approach if
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc	2024-01-18 23:11:22.551745295 +0800
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc	2024-02-23 13:35:52.088151288 +0800
 @@ -555,6 +555,7 @@ bpf_dsl::ResultExpr SandboxLinux::Handle
    const bpf_dsl::ResultExpr handle_via_broker =
        bpf_dsl::Trap(syscall_broker::BrokerClient::SIGSYS_Handler,
@@ -2287,8 +2277,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
      return handle_via_broker;
    }
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn b/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn
---- a/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn	2024-01-18 23:11:22.552745309 +0800
+--- a/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn	2024-02-23 13:35:52.088151288 +0800
 @@ -765,6 +765,8 @@ skia_source_set("skia_opts") {
      # Conditional and empty body needed to avoid assert() below.
    } else if (current_cpu == "riscv64") {
@@ -2299,8 +2289,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
      assert(false, "Unknown cpu target")
    }
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/base.h b/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/base.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/base.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/base.h	2024-01-18 23:11:22.552745309 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/base.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/base.h	2024-02-23 13:35:52.089151295 +0800
 @@ -107,6 +107,8 @@ extern "C" {
  #define OPENSSL_RISCV64
  #elif defined(__riscv) && __SIZEOF_POINTER__ == 4
@@ -2311,8 +2301,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #define OPENSSL_32_BIT
  #define OPENSSL_PNACL
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/client/crashpad_client_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/client/crashpad_client_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/client/crashpad_client_linux.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/client/crashpad_client_linux.cc	2024-01-18 23:11:22.553745322 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/client/crashpad_client_linux.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/client/crashpad_client_linux.cc	2024-02-23 13:35:52.090151302 +0800
 @@ -716,6 +716,10 @@ void CrashpadClient::DumpWithoutCrash(Na
    memset(context->uc_mcontext.__reserved,
           0,
@@ -2325,8 +2315,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  
    siginfo_t siginfo;
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h	2024-01-18 23:11:22.554745335 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h	2024-02-23 13:35:52.090151302 +0800
 @@ -637,6 +637,56 @@ struct MinidumpContextMIPS64 {
    uint64_t fir;
  };
@@ -2385,8 +2375,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  
  #endif  // CRASHPAD_MINIDUMP_MINIDUMP_CONTEXT_H_
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc	2024-01-18 23:11:22.554745335 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc	2024-02-23 13:35:52.091151308 +0800
 @@ -102,6 +102,13 @@ MinidumpContextWriter::CreateFromSnapsho
        break;
      }
@@ -2447,8 +2437,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  
  }  // namespace crashpad
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h	2024-01-18 23:11:22.555745349 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h	2024-02-23 13:35:52.091151308 +0800
 @@ -369,6 +369,44 @@ class MinidumpContextMIPS64Writer final
    MinidumpContextMIPS64 context_;
  };
@@ -2495,8 +2485,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  
  #endif  // CRASHPAD_MINIDUMP_MINIDUMP_CONTEXT_WRITER_H_
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h	2024-01-18 23:11:22.555745349 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h	2024-02-23 13:35:52.092151315 +0800
 @@ -210,6 +210,9 @@ enum MinidumpCPUArchitecture : uint16_t
    //! \deprecated Use #kMinidumpCPUArchitectureARM64 instead.
    kMinidumpCPUArchitectureARM64Breakpad = 0x8003,
@@ -2508,8 +2498,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    kMinidumpCPUArchitectureUnknown = PROCESSOR_ARCHITECTURE_UNKNOWN,
  };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc	2024-01-18 23:11:22.556745362 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc	2024-02-23 13:35:52.092151315 +0800
 @@ -175,6 +175,8 @@ std::string MinidumpMiscInfoDebugBuildSt
    static constexpr char kCPU[] = "mips";
  #elif defined(ARCH_CPU_MIPS64EL)
@@ -2520,8 +2510,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #error define kCPU for this CPU
  #endif
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc	2024-01-18 23:11:22.556745362 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc	2024-02-23 13:35:52.093151322 +0800
 @@ -132,6 +132,9 @@ void MinidumpSystemInfoWriter::Initializ
      case kCPUArchitectureARM64:
        cpu_architecture = kMinidumpCPUArchitectureARM64;
@@ -2533,8 +2523,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
        NOTREACHED();
        cpu_architecture = kMinidumpCPUArchitectureUnknown;
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc	2024-01-18 23:11:22.557745375 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc	2024-02-23 13:35:52.093151322 +0800
 @@ -117,6 +117,11 @@ void CaptureMemory::PointedToByContext(c
    for (size_t i = 0; i < std::size(context.mipsel->regs); ++i) {
      MaybeCaptureMemoryAround(delegate, context.mipsel->regs[i]);
@@ -2548,8 +2538,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #error Port.
  #endif
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h	2024-01-18 23:11:22.557745375 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h	2024-02-23 13:35:52.093151322 +0800
 @@ -43,7 +43,10 @@ enum CPUArchitecture {
    kCPUArchitectureMIPSEL,
  
@@ -2563,8 +2553,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  
  }  // namespace crashpad
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc	2024-01-18 23:11:22.557745375 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc	2024-02-23 13:35:52.094151329 +0800
 @@ -170,6 +170,8 @@ uint64_t CPUContext::InstructionPointer(
        return arm->pc;
      case kCPUArchitectureARM64:
@@ -2592,8 +2582,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
      case kCPUArchitectureX86:
      case kCPUArchitectureARM:
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h	2024-01-18 23:11:22.558745389 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h	2024-02-23 13:35:52.094151329 +0800
 @@ -362,6 +362,22 @@ struct CPUContextMIPS64 {
    uint64_t fir;
  };
@@ -2626,8 +2616,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  };
  
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc	2024-01-18 23:11:22.558745389 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc	2024-02-23 13:35:52.095151335 +0800
 @@ -266,6 +266,40 @@ void InitializeCPUContextARM64_OnlyFPSIM
    context->fpcr = float_context.fpcr;
  }
@@ -2670,8 +2660,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  
  }  // namespace internal
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h	2024-01-18 23:11:22.559745402 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h	2024-02-23 13:35:52.095151335 +0800
 @@ -174,6 +174,45 @@ void InitializeCPUContextMIPS(
  
  #endif  // ARCH_CPU_MIPS_FAMILY || DOXYGEN
@@ -2719,8 +2709,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  }  // namespace crashpad
  
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc	2024-01-18 23:11:22.559745402 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc	2024-02-23 13:35:52.096151342 +0800
 @@ -15,6 +15,7 @@
  #include "snapshot/linux/exception_snapshot_linux.h"
  
@@ -2821,8 +2811,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  
    CaptureMemoryDelegateLinux capture_memory_delegate(
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h	2024-01-18 23:11:22.560745415 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h	2024-02-23 13:35:52.096151342 +0800
 @@ -89,6 +89,8 @@ class ExceptionSnapshotLinux final : pub
  #elif defined(ARCH_CPU_MIPS_FAMILY)
      CPUContextMIPS mipsel;
@@ -2833,8 +2823,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    } context_union_;
    CPUContext context_;
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc	2024-01-18 23:11:22.560745415 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc	2024-02-23 13:35:52.097151349 +0800
 @@ -127,6 +127,8 @@ void ProcessReaderLinux::Thread::Initial
  #elif defined(ARCH_CPU_MIPS_FAMILY)
    stack_pointer = reader->Is64Bit() ? thread_info.thread_context.t64.regs[29]
@@ -2845,8 +2835,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #error Port.
  #endif
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h	2024-01-18 23:11:22.561745429 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h	2024-02-23 13:35:52.097151349 +0800
 @@ -422,6 +422,46 @@ static_assert(offsetof(UContext<ContextT
                "context offset mismatch");
  #endif
@@ -2895,8 +2885,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #error Port.
  #endif  // ARCH_CPU_X86_FAMILY
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc	2024-01-18 23:11:22.561745429 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc	2024-02-23 13:35:52.098151355 +0800
 @@ -205,6 +205,8 @@ CPUArchitecture SystemSnapshotLinux::Get
  #elif defined(ARCH_CPU_MIPS_FAMILY)
    return process_reader_->Is64Bit() ? kCPUArchitectureMIPS64EL
@@ -2937,8 +2927,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #error Port.
  #endif  // ARCH_CPU_X86_FAMILY
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc	2024-01-18 23:11:22.562745442 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc	2024-02-23 13:35:52.098151355 +0800
 @@ -190,6 +190,13 @@ bool ThreadSnapshotLinux::Initialize(
          thread.thread_info.float_context.f32,
          context_.mipsel);
@@ -2954,8 +2944,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #error Port.
  #endif
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h	2024-01-18 23:11:22.562745442 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h	2024-02-23 13:35:52.099151362 +0800
 @@ -74,6 +74,8 @@ class ThreadSnapshotLinux final : public
  #elif defined(ARCH_CPU_MIPS_FAMILY)
      CPUContextMIPS mipsel;
@@ -2966,8 +2956,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #error Port.
  #endif  // ARCH_CPU_X86_FAMILY
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc	2024-01-18 23:11:22.563745455 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc	2024-02-23 13:35:52.099151362 +0800
 @@ -266,6 +266,30 @@ bool MinidumpContextConverter::Initializ
      context_.mips64->fir = src->fir;
  
@@ -3000,8 +2990,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
      // Architecture is listed as "unknown".
      DLOG(ERROR) << "Unknown architecture";
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc	2024-01-18 23:11:22.563745455 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc	2024-02-23 13:35:52.100151369 +0800
 @@ -68,6 +68,8 @@ CPUArchitecture SystemSnapshotMinidump::
      case kMinidumpCPUArchitectureMIPS:
        return kCPUArchitectureMIPSEL;
@@ -3012,8 +3002,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
      default:
        return CPUArchitecture::kCPUArchitectureUnknown;
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc	2024-01-18 23:11:22.564745469 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc	2024-02-23 13:35:52.100151369 +0800
 @@ -398,6 +398,37 @@ bool GetThreadArea64(pid_t tid,
    return true;
  }
@@ -3068,8 +3058,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  
  ssize_t Ptracer::ReadUpTo(pid_t pid,
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h	2024-01-18 23:11:22.564745469 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h	2024-02-23 13:35:52.101151376 +0800
 @@ -80,6 +80,8 @@ union ThreadContext {
      uint32_t cp0_status;
      uint32_t cp0_cause;
@@ -3131,8 +3121,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #error Port.
  #endif  // ARCH_CPU_X86
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S	2024-01-18 23:11:22.565745482 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S	2024-02-23 13:35:52.101151376 +0800
 @@ -336,6 +336,51 @@ CAPTURECONTEXT_SYMBOL2:
  
    // TODO(https://crashpad.chromium.org/bug/300): save floating-point registers.
@@ -3186,8 +3176,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #elif defined(__mips__)
    .set noat
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc	2024-01-18 23:11:22.565745482 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc	2024-02-23 13:35:52.102151382 +0800
 @@ -237,6 +237,8 @@ std::string UserAgent() {
  #elif defined(ARCH_CPU_BIG_ENDIAN)
      static constexpr char arch[] = "aarch64_be";
@@ -3198,8 +3188,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #error Port
  #endif
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js b/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js
---- a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js	2024-01-18 23:11:22.566745495 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js	2024-02-23 13:35:52.102151382 +0800
 @@ -52,11 +52,11 @@ export default commandLineArgs => ({
          },
        },
@@ -3219,7 +3209,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
        resolveId(source, importer) {
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h	2024-01-19 00:26:59.455993622 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h	2024-02-23 13:35:52.103151389 +0800
 @@ -0,0 +1,749 @@
 +/* Automatically generated by configure - do not modify! */
 +#ifndef FFMPEG_CONFIG_H
@@ -3972,7 +3962,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +#endif /* FFMPEG_CONFIG_H */
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h	2024-01-19 00:27:01.531017556 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h	2024-02-23 13:35:52.106151409 +0800
 @@ -0,0 +1,2146 @@
 +/* Automatically generated by configure - do not modify! */
 +#ifndef FFMPEG_CONFIG_COMPONENTS_H
@@ -6122,13 +6112,13 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +#endif /* FFMPEG_CONFIG_COMPONENTS_H */
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c	2024-01-19 00:27:13.731158277 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c	2024-02-23 13:35:52.106151409 +0800
 @@ -0,0 +1,2 @@
 +static const FFBitStreamFilter * const bitstream_filters[] = {
 +    NULL };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c	2024-01-19 00:27:13.730158265 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c	2024-02-23 13:35:52.107151416 +0800
 @@ -0,0 +1,20 @@
 +static const FFCodec * const codec_list[] = {
 +    &ff_h264_decoder,
@@ -6152,7 +6142,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +    NULL };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c	2024-01-19 00:27:13.730158265 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c	2024-02-23 13:35:52.107151416 +0800
 @@ -0,0 +1,11 @@
 +static const AVCodecParser * const parser_list[] = {
 +    &ff_aac_parser,
@@ -6167,7 +6157,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +    NULL };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c	2024-01-19 00:27:15.932183664 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c	2024-02-23 13:35:52.107151416 +0800
 @@ -0,0 +1,9 @@
 +static const AVInputFormat * const demuxer_list[] = {
 +    &ff_aac_demuxer,
@@ -6180,19 +6170,19 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +    NULL };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c	2024-01-19 00:27:15.932183664 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c	2024-02-23 13:35:52.107151416 +0800
 @@ -0,0 +1,2 @@
 +static const AVOutputFormat * const muxer_list[] = {
 +    NULL };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c	2024-01-19 00:27:15.932183664 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c	2024-02-23 13:35:52.108151423 +0800
 @@ -0,0 +1,2 @@
 +static const URLProtocol * const url_protocols[] = {
 +    NULL };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h	2024-01-19 00:27:19.080219975 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h	2024-02-23 13:35:52.108151423 +0800
 @@ -0,0 +1,6 @@
 +/* Generated by ffmpeg configure */
 +#ifndef AVUTIL_AVCONFIG_H
@@ -6202,7 +6192,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +#endif /* AVUTIL_AVCONFIG_H */
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h	2024-01-19 00:27:54.784631802 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h	2024-02-23 13:35:52.109151429 +0800
 @@ -0,0 +1,749 @@
 +/* Automatically generated by configure - do not modify! */
 +#ifndef FFMPEG_CONFIG_H
@@ -6955,7 +6945,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +#endif /* FFMPEG_CONFIG_H */
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h	2024-01-19 00:27:59.709688609 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h	2024-02-23 13:35:52.112151450 +0800
 @@ -0,0 +1,2146 @@
 +/* Automatically generated by configure - do not modify! */
 +#ifndef FFMPEG_CONFIG_COMPONENTS_H
@@ -9105,13 +9095,13 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +#endif /* FFMPEG_CONFIG_COMPONENTS_H */
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c	2024-01-19 00:28:12.924841037 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c	2024-02-23 13:35:52.112151450 +0800
 @@ -0,0 +1,2 @@
 +static const FFBitStreamFilter * const bitstream_filters[] = {
 +    NULL };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c	2024-01-19 00:28:12.923841026 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c	2024-02-23 13:35:52.112151450 +0800
 @@ -0,0 +1,18 @@
 +static const FFCodec * const codec_list[] = {
 +    &ff_theora_decoder,
@@ -9133,7 +9123,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +    NULL };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c	2024-01-19 00:28:12.924841037 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c	2024-02-23 13:35:52.112151450 +0800
 @@ -0,0 +1,9 @@
 +static const AVCodecParser * const parser_list[] = {
 +    &ff_flac_parser,
@@ -9146,7 +9136,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +    NULL };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c	2024-01-19 00:28:08.203786583 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c	2024-02-23 13:35:52.113151456 +0800
 @@ -0,0 +1,8 @@
 +static const AVInputFormat * const demuxer_list[] = {
 +    &ff_flac_demuxer,
@@ -9158,19 +9148,19 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +    NULL };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c	2024-01-19 00:28:08.204786594 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c	2024-02-23 13:35:52.113151456 +0800
 @@ -0,0 +1,2 @@
 +static const AVOutputFormat * const muxer_list[] = {
 +    NULL };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c	2024-01-19 00:28:08.204786594 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c	2024-02-23 13:35:52.113151456 +0800
 @@ -0,0 +1,2 @@
 +static const URLProtocol * const url_protocols[] = {
 +    NULL };
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h	1970-01-01 08:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h	2024-01-19 00:28:04.296741518 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h	2024-02-23 13:35:52.114151463 +0800
 @@ -0,0 +1,6 @@
 +/* Generated by ffmpeg configure */
 +#ifndef AVUTIL_AVCONFIG_H
@@ -9179,8 +9169,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +#define AV_HAVE_FAST_UNALIGNED 1
 +#endif /* AVUTIL_AVCONFIG_H */
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni	2024-01-18 23:14:48.812429404 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni	2024-02-23 13:35:52.114151463 +0800
 @@ -273,7 +273,7 @@ if ((is_apple && ffmpeg_branding == "Chr
    ]
  }
@@ -9211,8 +9201,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    ffmpeg_c_sources += [
      "libavcodec/arm/fft_init_arm.c",
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni b/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni
---- a/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni	2024-01-19 00:38:48.727174533 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni	2024-02-23 13:35:52.115151470 +0800
 @@ -9,5 +9,5 @@ declare_args() {
    use_libgav1_parser =
        (is_chromeos || is_linux || is_win) &&
@@ -9221,8 +9211,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 +       target_cpu == "arm64" || target_cpu == "ppc64" || target_cpu == "loong64")
  }
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn b/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn
---- a/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn	2024-01-18 23:11:22.579745669 +0800
+--- a/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn	2024-02-23 13:35:52.115151470 +0800
 @@ -156,6 +156,8 @@ swiftshader_llvm_source_set("swiftshader
      deps += [ ":swiftshader_llvm_ppc" ]
    } else if (current_cpu == "riscv64") {
@@ -9232,9 +9222,261 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    } else if (current_cpu == "x86" || current_cpu == "x64") {
      deps += [ ":swiftshader_llvm_x86" ]
    } else {
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/loong64/regexp-macro-assembler-loong64.cc b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/loong64/regexp-macro-assembler-loong64.cc
+--- a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/loong64/regexp-macro-assembler-loong64.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/loong64/regexp-macro-assembler-loong64.cc	2024-02-23 22:57:06.667731413 +0800
+@@ -717,6 +717,8 @@ Handle<HeapObject> RegExpMacroAssemblerL
+ 
+       ExternalReference stack_limit =
+           ExternalReference::address_of_jslimit(masm_->isolate());
++      Operand extra_space_for_variables(num_registers_ * kSystemPointerSize);
++
+       __ li(a0, Operand(stack_limit));
+       __ Ld_d(a0, MemOperand(a0, 0));
+       __ Sub_d(a0, sp, a0);
+@@ -724,14 +726,14 @@ Handle<HeapObject> RegExpMacroAssemblerL
+       __ Branch(&stack_limit_hit, le, a0, Operand(zero_reg));
+       // Check if there is room for the variable number of registers above
+       // the stack limit.
+-      __ Branch(&stack_ok, hs, a0, Operand(num_registers_ * kPointerSize));
++      __ Branch(&stack_ok, hs, a0, extra_space_for_variables);
+       // Exit with OutOfMemory exception. There is not enough space on the stack
+       // for our working registers.
+       __ li(a0, Operand(EXCEPTION));
+       __ jmp(&return_v0);
+ 
+       __ bind(&stack_limit_hit);
+-      CallCheckStackGuardState(a0);
++      CallCheckStackGuardState(a0, extra_space_for_variables);
+       // If returned value is non-zero, we exit with the returned value as
+       // result.
+       __ Branch(&return_v0, ne, a0, Operand(zero_reg));
+@@ -1131,7 +1133,8 @@ void RegExpMacroAssemblerLOONG64::ClearR
+ 
+ // Private methods:
+ 
+-void RegExpMacroAssemblerLOONG64::CallCheckStackGuardState(Register scratch) {
++void RegExpMacroAssemblerLOONG64::CallCheckStackGuardState(
++    Register scratch, Operand extra_space) {
+   DCHECK(!isolate()->IsGeneratingEmbeddedBuiltins());
+   DCHECK(!masm_->options().isolate_independent_code);
+ 
+@@ -1144,6 +1147,9 @@ void RegExpMacroAssemblerLOONG64::CallCh
+   __ And(sp, sp, Operand(-stack_alignment));
+   __ St_d(scratch, MemOperand(sp, 0));
+ 
++  // Extra space for variables.
++  __ li(a3, extra_space);
++  // RegExp code frame pointer.
+   __ mov(a2, frame_pointer());
+   // InstructionStream of self.
+   __ li(a1, Operand(masm_->CodeObject()), CONSTANT_SIZE);
+@@ -1152,16 +1158,6 @@ void RegExpMacroAssemblerLOONG64::CallCh
+   DCHECK(IsAligned(stack_alignment, kPointerSize));
+   __ Sub_d(sp, sp, Operand(stack_alignment));
+ 
+-  // The stack pointer now points to cell where the return address will be
+-  // written. Arguments are in registers, meaning we treat the return address as
+-  // argument 5. Since DirectCEntry will handle allocating space for the C
+-  // argument slots, we don't need to care about that here. This is how the
+-  // stack will look (sp meaning the value of sp at this moment):
+-  // [sp + 3] - empty slot if needed for alignment.
+-  // [sp + 2] - saved sp.
+-  // [sp + 1] - second word reserved for return value.
+-  // [sp + 0] - first word reserved for return value.
+-
+   // a0 will point to the return address, placed by DirectCEntry.
+   __ mov(a0, sp);
+ 
+@@ -1175,17 +1171,6 @@ void RegExpMacroAssemblerLOONG64::CallCh
+   __ li(kScratchReg, Operand(entry, RelocInfo::OFF_HEAP_TARGET));
+   __ Call(kScratchReg);
+ 
+-  // DirectCEntry allocated space for the C argument slots so we have to
+-  // drop them with the return address from the stack with loading saved sp.
+-  // At this point stack must look:
+-  // [sp + 7] - empty slot if needed for alignment.
+-  // [sp + 6] - saved sp.
+-  // [sp + 5] - second word reserved for return value.
+-  // [sp + 4] - first word reserved for return value.
+-  // [sp + 3] - C argument slot.
+-  // [sp + 2] - C argument slot.
+-  // [sp + 1] - C argument slot.
+-  // [sp + 0] - C argument slot.
+   __ Ld_d(sp, MemOperand(sp, stack_alignment));
+ 
+   __ li(code_pointer(), Operand(masm_->CodeObject()));
+@@ -1203,7 +1188,8 @@ static T* frame_entry_address(Address re
+ }
+ 
+ int64_t RegExpMacroAssemblerLOONG64::CheckStackGuardState(
+-    Address* return_address, Address raw_code, Address re_frame) {
++    Address* return_address, Address raw_code, Address re_frame,
++    uintptr_t extra_space) {
+   InstructionStream re_code = InstructionStream::cast(Object(raw_code));
+   return NativeRegExpMacroAssembler::CheckStackGuardState(
+       frame_entry<Isolate*>(re_frame, kIsolateOffset),
+@@ -1213,7 +1199,8 @@ int64_t RegExpMacroAssemblerLOONG64::Che
+       return_address, re_code,
+       frame_entry_address<Address>(re_frame, kInputStringOffset),
+       frame_entry_address<const byte*>(re_frame, kInputStartOffset),
+-      frame_entry_address<const byte*>(re_frame, kInputEndOffset));
++      frame_entry_address<const byte*>(re_frame, kInputEndOffset),
++      extra_space);
+ }
+ 
+ MemOperand RegExpMacroAssemblerLOONG64::register_location(int register_index) {
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/loong64/regexp-macro-assembler-loong64.h b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/loong64/regexp-macro-assembler-loong64.h
+--- a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/loong64/regexp-macro-assembler-loong64.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/loong64/regexp-macro-assembler-loong64.h	2024-02-23 22:57:19.115831489 +0800
+@@ -87,7 +87,7 @@ class V8_EXPORT_PRIVATE RegExpMacroAssem
+   // returning.
+   // {raw_code} is an Address because this is called via ExternalReference.
+   static int64_t CheckStackGuardState(Address* return_address, Address raw_code,
+-                                      Address re_frame);
++                                      Address re_frame, uintptr_t extra_space);
+ 
+   void print_regexp_frame_constants();
+ 
+@@ -162,7 +162,8 @@ class V8_EXPORT_PRIVATE RegExpMacroAssem
+   void CheckStackLimit();
+ 
+   // Generate a call to CheckStackGuardState.
+-  void CallCheckStackGuardState(Register scratch);
++  void CallCheckStackGuardState(Register scratch,
++                                Operand extra_space = Operand(0));
+   void CallIsCharacterInRangeArray(const ZoneList<CharacterRange>* ranges);
+ 
+   // The ebp-relative location of a regexp register.
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.cc b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.cc
+--- a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.cc	2024-02-23 22:58:35.937449052 +0800
+@@ -765,6 +765,8 @@ Handle<HeapObject> RegExpMacroAssemblerM
+ 
+       ExternalReference stack_limit =
+           ExternalReference::address_of_jslimit(masm_->isolate());
++      Operand extra_space_for_variables(num_registers_ * kPointerSize);
++
+       __ li(a0, Operand(stack_limit));
+       __ Ld(a0, MemOperand(a0));
+       __ Dsubu(a0, sp, a0);
+@@ -772,14 +774,14 @@ Handle<HeapObject> RegExpMacroAssemblerM
+       __ Branch(&stack_limit_hit, le, a0, Operand(zero_reg));
+       // Check if there is room for the variable number of registers above
+       // the stack limit.
+-      __ Branch(&stack_ok, hs, a0, Operand(num_registers_ * kPointerSize));
++      __ Branch(&stack_ok, hs, a0, extra_space_for_variables);
+       // Exit with OutOfMemory exception. There is not enough space on the stack
+       // for our working registers.
+       __ li(v0, Operand(EXCEPTION));
+       __ jmp(&return_v0);
+ 
+       __ bind(&stack_limit_hit);
+-      CallCheckStackGuardState(a0);
++      CallCheckStackGuardState(a0, extra_space_for_variables);
+       // If returned value is non-zero, we exit with the returned value as
+       // result.
+       __ Branch(&return_v0, ne, v0, Operand(zero_reg));
+@@ -1182,7 +1184,8 @@ bool RegExpMacroAssemblerMIPS::CanReadUn
+ 
+ // Private methods:
+ 
+-void RegExpMacroAssemblerMIPS::CallCheckStackGuardState(Register scratch) {
++void RegExpMacroAssemblerMIPS::CallCheckStackGuardState(Register scratch,
++                                                        Operand extra_space) {
+   DCHECK(!isolate()->IsGeneratingEmbeddedBuiltins());
+   DCHECK(!masm_->options().isolate_independent_code);
+ 
+@@ -1195,6 +1198,9 @@ void RegExpMacroAssemblerMIPS::CallCheck
+   __ And(sp, sp, Operand(-stack_alignment));
+   __ Sd(scratch, MemOperand(sp));
+ 
++  // Extra space for variables to consider in stack check.
++  __ li(a3, extra_space);
++  // RegExp code frame pointer.
+   __ mov(a2, frame_pointer());
+   // InstructionStream of self.
+   __ li(a1, Operand(masm_->CodeObject()), CONSTANT_SIZE);
+@@ -1203,16 +1209,6 @@ void RegExpMacroAssemblerMIPS::CallCheck
+   DCHECK(IsAligned(stack_alignment, kPointerSize));
+   __ Dsubu(sp, sp, Operand(stack_alignment));
+ 
+-  // The stack pointer now points to cell where the return address will be
+-  // written. Arguments are in registers, meaning we treat the return address as
+-  // argument 5. Since DirectCEntry will handle allocating space for the C
+-  // argument slots, we don't need to care about that here. This is how the
+-  // stack will look (sp meaning the value of sp at this moment):
+-  // [sp + 3] - empty slot if needed for alignment.
+-  // [sp + 2] - saved sp.
+-  // [sp + 1] - second word reserved for return value.
+-  // [sp + 0] - first word reserved for return value.
+-
+   // a0 will point to the return address, placed by DirectCEntry.
+   __ mov(a0, sp);
+ 
+@@ -1226,17 +1222,6 @@ void RegExpMacroAssemblerMIPS::CallCheck
+   __ li(kScratchReg, Operand(entry, RelocInfo::OFF_HEAP_TARGET));
+   __ Call(kScratchReg);
+ 
+-  // DirectCEntry allocated space for the C argument slots so we have to
+-  // drop them with the return address from the stack with loading saved sp.
+-  // At this point stack must look:
+-  // [sp + 7] - empty slot if needed for alignment.
+-  // [sp + 6] - saved sp.
+-  // [sp + 5] - second word reserved for return value.
+-  // [sp + 4] - first word reserved for return value.
+-  // [sp + 3] - C argument slot.
+-  // [sp + 2] - C argument slot.
+-  // [sp + 1] - C argument slot.
+-  // [sp + 0] - C argument slot.
+   __ Ld(sp, MemOperand(sp, stack_alignment + kCArgsSlotsSize));
+ 
+   __ li(code_pointer(), Operand(masm_->CodeObject()));
+@@ -1255,7 +1240,8 @@ static T* frame_entry_address(Address re
+ 
+ int64_t RegExpMacroAssemblerMIPS::CheckStackGuardState(Address* return_address,
+                                                        Address raw_code,
+-                                                       Address re_frame) {
++                                                       Address re_frame,
++						       uintptr_t extra_space) {
+   InstructionStream re_code = InstructionStream::cast(Object(raw_code));
+   return NativeRegExpMacroAssembler::CheckStackGuardState(
+       frame_entry<Isolate*>(re_frame, kIsolateOffset),
+@@ -1265,7 +1251,8 @@ int64_t RegExpMacroAssemblerMIPS::CheckS
+       return_address, re_code,
+       frame_entry_address<Address>(re_frame, kInputStringOffset),
+       frame_entry_address<const byte*>(re_frame, kInputStartOffset),
+-      frame_entry_address<const byte*>(re_frame, kInputEndOffset));
++      frame_entry_address<const byte*>(re_frame, kInputEndOffset),
++      extra_space);
+ }
+ 
+ MemOperand RegExpMacroAssemblerMIPS::register_location(int register_index) {
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.h b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.h
+--- a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.h	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.h	2024-02-23 22:54:29.327466274 +0800
+@@ -88,7 +88,7 @@ class V8_EXPORT_PRIVATE RegExpMacroAssem
+   // returning.
+   // {raw_code} is an Address because this is called via ExternalReference.
+   static int64_t CheckStackGuardState(Address* return_address, Address raw_code,
+-                                      Address re_frame);
++                                      Address re_frame, uintptr_t extra_space);
+ 
+   void print_regexp_frame_constants();
+ 
+@@ -163,7 +163,8 @@ class V8_EXPORT_PRIVATE RegExpMacroAssem
+ 
+ 
+   // Generate a call to CheckStackGuardState.
+-  void CallCheckStackGuardState(Register scratch);
++  void CallCheckStackGuardState(Register scratch,
++                                Operand extra_space = Operand(0));
+   void CallIsCharacterInRangeArray(const ZoneList<CharacterRange>* ranges);
+ 
+   // The ebp-relative location of a regexp register.
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/gn/src/util/sys_info.cc b/qtwebengine/src/3rdparty/gn/src/util/sys_info.cc
---- a/qtwebengine/src/3rdparty/gn/src/util/sys_info.cc	2023-11-21 00:08:07.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/gn/src/util/sys_info.cc	2024-01-18 23:11:22.580745682 +0800
+--- a/qtwebengine/src/3rdparty/gn/src/util/sys_info.cc	2024-02-10 08:23:21.000000000 +0800
++++ b/qtwebengine/src/3rdparty/gn/src/util/sys_info.cc	2024-02-23 13:35:52.116151477 +0800
 @@ -34,6 +34,8 @@ std::string OperatingSystemArchitecture(
      arch = "x86_64";
    } else if (arch == "amd64") {

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,4 +1,4 @@
-VER=6.6.1
+VER=6.6.2
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
-CHKSUMS="sha256::dd3668f65645fe270bc615d748bd4dc048bd17b9dc297025106e6ecc419ab95d"
-CHKUPDATE="anitya::id=230518"
+CHKSUMS="sha256::3c1e42b3073ade1f7adbf06863c01e2c59521b7cc2349df2f74ecd7ebfcb922d"
+CHKUPDATE="anitya::id=7927"


### PR DESCRIPTION
Topic Description
-----------------

- qt-6: update to 6.6.2

Package(s) Affected
-------------------

- qt-6: 6.6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
