### PR TITLE
fuse-3: update to 3.16.2

### DIFF
--- a/app-admin/fuse-3/02-fuse-3/patches/do-not-mknod-dev-fuse-on-install.patch
+++ b/app-admin/fuse-3/02-fuse-3/patches/do-not-mknod-dev-fuse-on-install.patch
@@ -1,16 +1,13 @@
-diff -Naur fuse-3.10.1.orig/util/install_helper.sh fuse-3.10.1.mod/util/install_helper.sh
---- fuse-3.10.1.orig/util/install_helper.sh	2020-12-13 15:42:07.149454208 -0600
-+++ fuse-3.10.1.mod/util/install_helper.sh	2020-12-13 15:41:07.686333784 -0600
-@@ -30,10 +30,12 @@
+diff --git a/util/install_helper.sh b/util/install_helper.sh
+index 76f2b47..23dc77b 100755
+--- a/util/install_helper.sh
++++ b/util/install_helper.sh
+@@ -31,7 +31,7 @@ if $useroot; then
      chown root:root "${DESTDIR}${bindir}/fusermount3"
      chmod u+s "${DESTDIR}${bindir}/fusermount3"
  
+-    if test ! -e "${DESTDIR}/dev/fuse"; then
 +    if false; then
-     if test ! -e "${DESTDIR}/dev/fuse"; then
          mkdir -p "${DESTDIR}/dev"
          mknod "${DESTDIR}/dev/fuse" -m 0666 c 10 229
      fi
-+    fi
- fi
- 
- install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \

--- a/app-admin/fuse-3/spec
+++ b/app-admin/fuse-3/spec
@@ -1,5 +1,4 @@
-VER=3.10.1
-REL=3
-SRCS="tbl::https://github.com/libfuse/libfuse/releases/download/fuse-$VER/fuse-$VER.tar.xz"
-CHKSUMS="sha256::d82d74d4c03e099f806e4bb31483955637c69226576bf0ca9bd142f1d50ae451"
+VER=3.16.2
+SRCS="tbl::https://github.com/libfuse/libfuse/releases/download/fuse-$VER/fuse-$VER.tar.gz"
+CHKSUMS="sha256::f797055d9296b275e981f5f62d4e32e089614fc253d1ef2985851025b8a0ce87"
 CHKUPDATE="anitya::id=861"


### PR DESCRIPTION
Topic Description
-----------------

- fuse-3: update to 3.16.2

Package(s) Affected
-------------------

- fuse-3: 3.16.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit fuse-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
