### PR TITLE
wireshark: update to 4.2.3

### DIFF
--- a/app-database/sqlite/autobuild/beyond
+++ b/app-database/sqlite/autobuild/beyond
@@ -13,6 +13,9 @@ if ab_match_archgroup mainline; then
     install -vm755 \
         "$SRCDIR"/{sqlite3_analyzer,showdb,showjournal,showstat4,showwal,sqldiff,dbhash,lemon} \
         -t "$PKGDIR"/usr/bin/
+    install -Dvm644 \
+        "$SRCDIR"/tool/lempar.c \
+        -t "$PKGDIR"/usr/share/lemon/
 fi
 
 abinfo "Installing man pages ..."

--- a/app-database/sqlite/spec
+++ b/app-database/sqlite/spec
@@ -1,5 +1,6 @@
 VER=3.39.4
 LOCAL_VER=3390400
+REL=1
 SRCS="tbl::https://sqlite.org/2022/sqlite-src-$LOCAL_VER.zip"
 CHKSUMS="sha256::02d96c6ccf811ab9b63919ef717f7e52a450c420e06bd129fb483cd70c3b3bba"
 CHKUPDATE="anitya::id=4877"

--- a/app-network/wireshark/autobuild/beyond
+++ b/app-network/wireshark/autobuild/beyond
@@ -3,3 +3,6 @@ chgrp -v 86 "$PKGDIR"/usr/bin/dumpcap
 chmod -v 754 "$PKGDIR"/usr/bin/dumpcap
 
 rm -vf "$PKGDIR"/usr/share/applications/wireshark-gtk.desktop
+
+abinfo "Installing development headers ..."
+DESTDIR="$PKGDIR" ninja -C "$SRCDIR"/abbuild install-headers

--- a/app-network/wireshark/autobuild/defines
+++ b/app-network/wireshark/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=wireshark
 PKGDES="A network protocol analyzer, also known as a sniffer"
 PKGSEC=net
 PKGDEP="brotli c-ares desktop-file-utils glib gnutls krb5 libcap libgcrypt libnl \
-        libpcap libssh lua minizip qt-5 sbc shared-mime-info xdg-utils portaudio geoip-api-c \
+        libpcap libssh lua minizip qt-6 sbc shared-mime-info xdg-utils portaudio geoip-api-c \
         speex snappy systemd libilbc bcg729"
 BUILDDEP="docbook-xsl doxygen lynx w3m asciidoctor"
 

--- a/app-network/wireshark/autobuild/overrides/usr/lib/sysusers.d/wireshark.conf
+++ b/app-network/wireshark/autobuild/overrides/usr/lib/sysusers.d/wireshark.conf
@@ -1,0 +1,1 @@
+g    netdev  86

--- a/app-network/wireshark/autobuild/postinst
+++ b/app-network/wireshark/autobuild/postinst
@@ -1,1 +1,5 @@
+echo "Setting up netdev group ..."
+systemd-sysusers wireshark.conf
+
+echo "Configuring capability of /usr/bin/dumpcap ..."
 setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' /usr/bin/dumpcap

--- a/app-network/wireshark/autobuild/usergroup
+++ b/app-network/wireshark/autobuild/usergroup
@@ -1,1 +1,0 @@
-group netdev 86

--- a/app-network/wireshark/spec
+++ b/app-network/wireshark/spec
@@ -1,4 +1,4 @@
-VER=4.0.0
+VER=4.2.3
 SRCS="tbl::https://www.wireshark.org/download/src/all-versions/wireshark-$VER.tar.xz"
-CHKSUMS="sha256::3dc125ef85e85c2a756a74cc739b3eb11ce38e30a08e085e77d378ee7fdcaded"
+CHKSUMS="sha256::958bd5996f543d91779b1a4e7e952dcd7b0245fe82194202c3333a8f78795811"
 CHKUPDATE="anitya::id=5137"

--- a/app-virtualization/libvirt/spec
+++ b/app-virtualization/libvirt/spec
@@ -1,5 +1,5 @@
 VER=9.10.0
-REL=1
+REL=2
 SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
 CHKSUMS="sha256::1060afc0e85a84c579bcdc91cfaf6d471918f97a780f04c5260a034ff7db7519"
 CHKUPDATE="anitya::id=13830"


### PR DESCRIPTION
Topic Description
-----------------

- libvirt: bump REL due to wireshark update
- wireshark: update to 4.2.3
    - Migrate to sysusers
    - The new version uses qt-6 by default
    - SONAME changed
- sqlite: install lempar.c for wireshark

Package(s) Affected
-------------------

- libvirt: 9.10.0-2
- sqlite: 3.39.4-1
- wireshark: 4.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit sqlite wireshark libvirt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
