### PR TITLE
gnuplot: update to 6.0.0

### DIFF
--- a/app-utils/gnuplot/autobuild/prepare
+++ b/app-utils/gnuplot/autobuild/prepare
@@ -1,6 +1,0 @@
-sed -e 's|/usr/X11R6/lib/X11/fonts/truetype|/usr/share/fonts/TTF|' \
-    -i src/variable.c
-
-sed -e 's|/usr/X11R6/lib/X11/fonts/Type1|/usr/share/fonts/Type1|' \
-    -e 's|$(X11ROOT)/X11R6/lib/X11/fonts/Type1|$(X11ROOT)/usr/share/fonts/Type1|' \
-    -i src/variable.c

--- a/app-utils/gnuplot/spec
+++ b/app-utils/gnuplot/spec
@@ -1,5 +1,4 @@
-VER=5.2.8
-REL=4
+VER=6.0.0
 SRCS="tbl::https://sourceforge.net/projects/gnuplot/files/gnuplot/$VER/gnuplot-$VER.tar.gz"
-CHKSUMS="sha256::60a6764ccf404a1668c140f11cc1f699290ab70daa1151bb58fed6139a28ac37"
+CHKSUMS="sha256::635a28f0993f6ab0d1179e072ad39b8139d07f51237f841d93c6c2ff4b1758ec"
 CHKUPDATE="anitya::id=1216"


### PR DESCRIPTION
Topic Description
-----------------

- gnuplot: delete unnecessary prepare file
- gnuplot: update to 6.0.0

Package(s) Affected
-------------------

- gnuplot: 6.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnuplot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
