### PR TITLE
zfs: update to 2.2.3

### DIFF
--- a/app-admin/zfs/autobuild/build
+++ b/app-admin/zfs/autobuild/build
@@ -43,8 +43,3 @@ abinfo "Generating DKMS configuration"
     -n zfs
 rm -rfv "${PKGDIR}"/usr/src/zfs-${PKGVER}/{autobuild,abdist,acbs-build_*.log}
 chmod -v g-w,o-w -R "${PKGDIR}"/usr/src/zfs-${PKGVER}
-
-abinfo "Installing Bash completions ..."
-install -Dvm644 \
-    "$SRCDIR"/contrib/bash_completion.d/zfs \
-    "${PKGDIR}"/usr/share/bash-completion/completions/zfs

--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,5 +1,4 @@
-VER=2.1.12
+VER=2.2.3
 SRCS="tbl::https://github.com/zfsonlinux/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
-CHKSUMS="sha256::64daa26aed3e12c931f6f4413d7527c4ebdb8da35416b356152b5f9fdd4c6e6d"
+CHKSUMS="sha256::30a512f34ec5c841b8b2b32cc9c1a03fd49391b26c9164d3fb30573fb5d81ac3"
 CHKUPDATE="anitya::id=11706"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- zfs: update to 2.2.3
    Bash completion no longer required to install manually

Package(s) Affected
-------------------

- zfs: 2.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit zfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
