### PR TITLE
hexedit: update to 1.6

### DIFF
--- a/app-utils/hexedit/spec
+++ b/app-utils/hexedit/spec
@@ -1,5 +1,4 @@
-VER=1.4.2
-REL=1
-SRCS="tbl::https://github.com/pixel/hexedit/archive/$VER.tar.gz"
-CHKSUMS="sha256::c81ffb36af9243aefc0887e33dd8e41c4b22d091f1f27d413cbda443b0440d66"
+VER=1.6
+SRCS="git::commit=tags/$VER::https://github.com/pixel/hexedit"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13305"


### PR DESCRIPTION
Topic Description
-----------------

- hexedit: update to 1.6

Package(s) Affected
-------------------

- hexedit: 1.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit hexedit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
