### PR TITLE
CRIU Rework 20240226

### DIFF
--- a/app-admin/criu/autobuild/defines
+++ b/app-admin/criu/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=criu
 PKGSEC=admin
-PKGDEP="python-3 protobuf libnl libbsd nftables libnet gnutls"
-BUILDDEP="perl xmlto asciidoc libcap protobuf-c"
+PKGDEP="python-3 protobuf libnl libbsd nftables libnet gnutls protobuf-c"
+BUILDDEP="perl xmlto asciidoc libcap"
 PKGDES="Checkpoint and restore in user space"
 
 MAKE_AFTER="RUNDIR=/run/criu \

--- a/app-admin/criu/spec
+++ b/app-admin/criu/spec
@@ -1,4 +1,5 @@
 VER=3.19
+REL=1
 SRCS="tbl::http://github.com/checkpoint-restore/criu/archive/v$VER/criu-$VER.tar.gz"
 CHKSUMS="sha256::990cdd147cb670a5d5d14216c2b5c2fc2b9a53ef19396569a6413807ba2a6aa2"
 CHKUPDATE="anitya::id=366"


### PR DESCRIPTION
Topic Description
-----------------

- criu: add protobuf-c as PKGDEP
    libcriu.so depends on libprotobuf-c.so.1

Package(s) Affected
-------------------

- criu: 3.19-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit criu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
