### PR TITLE
hmcl: add OpenJFX library path to the launch script

### DIFF
--- a/app-games/hmcl/autobuild/overrides/usr/bin/hmcl
+++ b/app-games/hmcl/autobuild/overrides/usr/bin/hmcl
@@ -1,4 +1,5 @@
 #!/bin/sh
 java --add-modules javafx.controls,javafx.graphics,javafx.swing,javafx.fxml,javafx.media,javafx.web \
+    --module-path=/usr/share/openjfx/lib \
     "$@" \
     -jar /usr/share/java/hmcl/hmcl.jar

--- a/app-games/hmcl/spec
+++ b/app-games/hmcl/spec
@@ -1,4 +1,5 @@
 VER=3.5.5.236
+REL=1
 SRCS="file::https://github.com/HMCL-dev/HMCL/releases/download/v$VER/HMCL-$VER.jar"
 CHKSUMS="sha1::d7828f3c331a76b61a9b2b38e6899911ae50b40d"
 CHKUPDATE="github::repo=HMCL-dev/HMCL"


### PR DESCRIPTION
Topic Description
-----------------

- hmcl: add OpenJFX library path to the launch script

Package(s) Affected
-------------------

- hmcl: 3.5.5.236-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit hmcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
