### PR TITLE
msgpack-c rework 20240227

### DIFF
--- a/app-utils/tmate/autobuild/patches/0001-Fix-msgpack-c-detection.patch
+++ b/app-utils/tmate/autobuild/patches/0001-Fix-msgpack-c-detection.patch
@@ -1,0 +1,78 @@
+From a5c6e80d3c54cd7faed52de5283b4f96bea86c13 Mon Sep 17 00:00:00 2001
+From: Carlo Cabrera <30379873+carlocab@users.noreply.github.com>
+Date: Sun, 5 Mar 2023 20:58:13 +0800
+Subject: [PATCH 1/2] Fix finding msgpack 6+
+
+`msgpack.pc` was renamed to `msgpack-c.pc` upstream in msgpack/msgpack-c#1053.
+---
+ configure.ac | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 028d55596..45c6085c5 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -209,6 +209,17 @@ PKG_CHECK_MODULES(
+   ],
+   found_msgpack=no
+ )
++# msgpack.pc was renamed to msgpack-c.pc in 6.0.0.
++PKG_CHECK_MODULES(
++  MSGPACKC,
++  msgpack-c >= 1.1.0,
++  [
++    CPPFLAGS="$MSGPACKC_CFLAGS $CPPFLAGS"
++    LIBS="$MSGPACKC_LIBS $LIBS"
++    found_msgpack=yes
++  ],
++  found_msgpack=no
++)
+ if test "x$found_msgpack" = xno; then
+   AC_MSG_ERROR("msgpack >= 1.1.0 not found")
+ fi
+
+From 2d79ff67f736c6c7473b22cb8553a06f3602ae71 Mon Sep 17 00:00:00 2001
+From: Carlo Cabrera <30379873+carlocab@users.noreply.github.com>
+Date: Mon, 3 Apr 2023 15:13:45 +0800
+Subject: [PATCH 2/2] Avoid clobbering older msgpack versions
+
+Co-authored-by: Sam James <sam@gentoo.org>
+---
+ configure.ac | 23 ++++++++++++-----------
+ 1 file changed, 12 insertions(+), 11 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 45c6085c5..3badf9e28 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -207,18 +207,19 @@ PKG_CHECK_MODULES(
+     LIBS="$MSGPACK_LIBS $LIBS"
+     found_msgpack=yes
+   ],
+-  found_msgpack=no
+-)
+-# msgpack.pc was renamed to msgpack-c.pc in 6.0.0.
+-PKG_CHECK_MODULES(
+-  MSGPACKC,
+-  msgpack-c >= 1.1.0,
+   [
+-    CPPFLAGS="$MSGPACKC_CFLAGS $CPPFLAGS"
+-    LIBS="$MSGPACKC_LIBS $LIBS"
+-    found_msgpack=yes
+-  ],
+-  found_msgpack=no
++    # msgpack.pc was renamed to msgpack-c.pc in 6.0.0.
++    PKG_CHECK_MODULES(
++      MSGPACKC,
++      msgpack-c >= 1.1.0,
++      [
++        CPPFLAGS="$MSGPACKC_CFLAGS $CPPFLAGS"
++        LIBS="$MSGPACKC_LIBS $LIBS"
++        found_msgpack=yes
++      ],
++      found_msgpack=no
++    )
++  ]
+ )
+ if test "x$found_msgpack" = xno; then
+   AC_MSG_ERROR("msgpack >= 1.1.0 not found")

--- a/app-utils/tmate/spec
+++ b/app-utils/tmate/spec
@@ -1,4 +1,5 @@
 VER=2.4.0
+REL=1
 SRCS="tbl::https://github.com/tmate-io/tmate/archive/$VER.tar.gz"
 CHKSUMS="sha256::62b61eb12ab394012c861f6b48ba0bc04ac8765abca13bdde5a4d9105cb16138"
 CHKUPDATE="anitya::id=10245"

--- a/runtime-common/msgpack-c/autobuild/defines
+++ b/runtime-common/msgpack-c/autobuild/defines
@@ -3,7 +3,6 @@ PKGSEC=libs
 PKGDEP="glibc libuv"
 PKGDES="An efficient object serialization library"
 
-ABHOST=noarch
 ABSHADOW=0
 NOSTATIC=0
 

--- a/runtime-common/msgpack-c/spec
+++ b/runtime-common/msgpack-c/spec
@@ -1,5 +1,5 @@
 VER=6.0.0
-REL=2
+REL=3
 SRCS="git::commit=tags/c-$VER::https://github.com/msgpack/msgpack-c"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235285"


### PR DESCRIPTION
Topic Description
-----------------

- tmate: bump REL due to msgpack-c SONAME changed
    Fix msg-pack-c 6.0.0 compatibility
- msgpack-c: remove ABHOST=noarch

Package(s) Affected
-------------------

- msgpack-c: 6.0.0-3
- tmate: 2.4.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit msgpack-c tmate
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
