### PR TITLE
fish: fix wildcard globbing

### DIFF
--- a/app-shells/fish/autobuild/patches/0001-Revert-wildcard-Remove-useless-access-call-for-trail.patch
+++ b/app-shells/fish/autobuild/patches/0001-Revert-wildcard-Remove-useless-access-call-for-trail.patch
@@ -1,0 +1,50 @@
+From c31e194120b36360864511c341e368408cd300c2 Mon Sep 17 00:00:00 2001
+From: Fabian Boehm <FHomborg@gmail.com>
+Date: Tue, 9 Jan 2024 18:56:36 +0100
+Subject: [PATCH] Revert "wildcard: Remove useless access() call for trailing
+ slash"
+
+This reverts commit 6823f5e3374f00f43e9d20a4db12d63e0bc5da84.
+
+Fixes #10205
+---
+ src/wildcard.cpp           | 7 +++++--
+ tests/checks/wildcard.fish | 4 ++++
+ 2 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/src/wildcard.cpp b/src/wildcard.cpp
+index 2683cfa1b..2c012637d 100644
+--- a/src/wildcard.cpp
++++ b/src/wildcard.cpp
+@@ -646,8 +646,11 @@ void wildcard_expander_t::expand_trailing_slash(const wcstring &base_dir, const
+     }
+ 
+     if (!(flags & expand_flag::for_completions)) {
+-        // Trailing slash and not accepting incomplete, e.g. `echo /xyz/`. Insert this file, we already know it exists!
+-        this->add_expansion_result(wcstring{base_dir});
++        // Trailing slash and not accepting incomplete, e.g. `echo /xyz/`. Insert this file if it
++        // exists.
++        if (waccess(base_dir, F_OK) == 0) {
++            this->add_expansion_result(wcstring{base_dir});
++        }
+     } else {
+         // Trailing slashes and accepting incomplete, e.g. `echo /xyz/<tab>`. Everything is added.
+         dir_iter_t dir = open_dir(base_dir);
+diff --git a/tests/checks/wildcard.fish b/tests/checks/wildcard.fish
+index 189d6dff7..03f28aa81 100644
+--- a/tests/checks/wildcard.fish
++++ b/tests/checks/wildcard.fish
+@@ -11,6 +11,10 @@ touch ./b/file.txt
+ 
+ set dirs ./a ./b
+ echo $dirs/*.txt # CHECK: ./b/file.txt
++echo */foo/
++# CHECKERR: checks/wildcard.fish (line {{\d+}}): No matches for wildcard '*/foo/'. See `help wildcards-globbing`.
++# CHECKERR: echo */foo/
++# CHECKERR:      ^~~~~^
+ 
+ cd $oldpwd
+ rm -Rf $dir
+-- 
+2.43.0
+

--- a/app-shells/fish/spec
+++ b/app-shells/fish/spec
@@ -1,4 +1,5 @@
 VER=3.7.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/fish-shell/fish-shell"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=815"


### PR DESCRIPTION
Topic Description
-----------------

- fish: fix wildcard globbing
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- fish: 3.7.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fish
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
