### PR TITLE
hydrapaper: update to 3.3.2

### DIFF
--- a/app-utils/hydrapaper/autobuild/defines
+++ b/app-utils/hydrapaper/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=hydrapaper
 PKGSEC=utils
-PKGDEP="gtk-3 libhandy libwnck-3 pillow"
-BUILDDEP="appstream gobject-introspection"
+PKGDEP="gtk-4 python-3 libhandy libwnck-3 pillow xdg-user-dirs libadwaita"
+BUILDDEP="appstream gobject-introspection blueprint-compiler pandoc"
 PKGDES="Wallpaper manager with multimonitor support"
 
 ABHOST=noarch

--- a/app-utils/hydrapaper/spec
+++ b/app-utils/hydrapaper/spec
@@ -1,5 +1,4 @@
-VER=1.12
-REL=3
-SRCS="tbl::https://gitlab.com/gabmus/HydraPaper/-/archive/$VER/HydraPaper-$VER.tar.gz"
-CHKSUMS="sha256::6e11486d796a3c829e6ff059a07036a5bfd16fc6ac44ab51b80e28fc5bc2ac07"
+VER=3.3.2
+SRCS="git::commit=tags/$VER::https://gitlab.com/gabmus/HydraPaper"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=27563"


### PR DESCRIPTION
Topic Description
-----------------

- hydrapaper: update to 3.3.2

Package(s) Affected
-------------------

- hydrapaper: 3.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit hydrapaper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
