### PR TITLE
argyllcms: update to 3.1.0

### DIFF
--- a/app-imaging/argyllcms/spec
+++ b/app-imaging/argyllcms/spec
@@ -1,5 +1,4 @@
-VER=2.2.0
+VER=3.1.0
 SRCS="tbl::https://www.argyllcms.com/Argyll_V${VER}_src.zip"
-CHKSUMS="sha256::c612a2e49fd51e089616cd27b6d4717d0f20fc8edbd906462f0d0dbbabbc711c"
+CHKSUMS="sha256::4fdd5a1d7bc6dde79a54e350ec9374f6ef00b53903ee0d184cdfa4a11f0ecdcb"
 CHKUPDATE="anitya::id=108"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- argyllcms: update to 3.1.0

Package(s) Affected
-------------------

- argyllcms: 3.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit argyllcms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
