### PR TITLE
xreader: update to 3.8.5

### DIFF
--- a/app-doc/xreader/spec
+++ b/app-doc/xreader/spec
@@ -1,4 +1,4 @@
-VER=3.4.4
+VER=3.8.5
 SRCS="tbl::https://github.com/linuxmint/xreader/archive/$VER.tar.gz"
-CHKSUMS="sha256::2316c5d5e110a1af96121c4930d4d8f759aa538d1fb1e6a248b54732500c2e6e"
+CHKSUMS="sha256::7c949058a1da445053fa852fd0bc36d8ab1d994a06b9908da4cef556d2a21d33"
 CHKUPDATE="anitya::id=15149"


### PR DESCRIPTION
Topic Description
-----------------

- xreader: update to 3.8.5
    Signed-off-by: Camber Huang <camber@poi.science>

Package(s) Affected
-------------------

- xreader: 3.8.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit xreader
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
