### PR TITLE
webkit2gtk (WebKitGTK): include libsoup 3.x variant

### DIFF
--- a/runtime-web/webkit2gtk/autobuild/build
+++ b/runtime-web/webkit2gtk/autobuild/build
@@ -1,0 +1,17 @@
+for i in ON OFF; do
+    mkdir -pv "$SRCDIR"/build_${i}
+    cd "$SRCDIR"/build_${i}
+
+    abinfo "Running CMake for WebKitGTK (SOUP2=${i}) ..."
+    cmake "$SRCDIR" \
+        ${CMAKE_DEF[@]} ${CMAKE_AFTER[@]} \
+        -DUSE_SOUP2=${i} \
+        -GNinja
+
+    abinfo "Building WebKitGTK (SOUP2=${i}) ..."
+    cmake --build .
+
+    abinfo "Installing WebKitGTK (SOUP2=${i}) ..."
+    DESTDIR="$PKGDIR" \
+        cmake --install .
+done

--- a/runtime-web/webkit2gtk/autobuild/defines
+++ b/runtime-web/webkit2gtk/autobuild/defines
@@ -1,13 +1,12 @@
 PKGNAME=webkit2gtk
 PKGSEC=gnome
-PKGDEP="libxslt sqlite libsoup enchant-2 geoclue2 \
-        gst-plugins-bad-1-0 libsecret libwebp gtk-3 hyphen \
-        icu libnotify woff2 wpebackend-fdo openjpeg bubblewrap \
-        xdg-dbus-proxy libmanette libavif libjxl"
-BUILDDEP="cmake gtk-doc gperf gobject-introspection ruby unifdef vim gi-docgen"
-PKGDES="GTK+ Web content engine library, webkit2gtk"
+PKGDEP="bubblewrap enchant-2 geoclue2 gstreamer gtk-3 hyphen icu libavif \
+        libjxl libmanette libnotify libsecret libsoup libwebp libxslt \
+        openjpeg sqlite woff2 wpebackend-fdo xdg-dbus-proxy"
+BUILDDEP="gi-docgen gobject-introspection gperf gtk-doc ruby unifdef vim"
+PKGDES="A WebKit rendering engine port for GTK"
 
-ABTYPE=cmakeninja
+ABTYPE=self
 CMAKE_AFTER="-DLIB_INSTALL_DIR=/usr/lib \
              -DENABLE_BUBBLEWRAP_SANDBOX=ON \
              -DENABLE_DRAG_SUPPORT=ON \
@@ -40,14 +39,15 @@ CMAKE_AFTER="-DLIB_INSTALL_DIR=/usr/lib \
              -DUSE_LIBSECRET=ON \
              -DUSE_OPENGL_OR_ES=ON \
              -DUSE_OPENJPEG=ON \
-             -DUSE_SOUP2=ON \
              -DUSE_THIN_ARCHIVES=ON \
              -DUSE_WOFF2=ON \
              -DUSE_WPE_RENDERER=ON"
-CMAKE_AFTER__ARM64="${CMAKE_AFTER} -DUSE_64KB_PAGE_BLOCK=ON"
-CMAKE_AFTER__LOONGARCH64="${CMAKE_AFTER} -DUSE_64KB_PAGE_BLOCK=ON"
-
-AB_FLAGS_O3=1
+CMAKE_AFTER__ARM64=" \
+             ${CMAKE_AFTER} \
+             -DUSE_64KB_PAGE_BLOCK=ON"
+CMAKE_AFTER__LOONGARCH64=" \
+             ${CMAKE_AFTER} \
+             -DUSE_64KB_PAGE_BLOCK=ON"
 
 PKGEPOCH=1
 

--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -1,4 +1,5 @@
 VER=2.42.5
+REL=1
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
 CHKSUMS="sha256::b64278c1f20b8cfdbfb5ff573c37d871aba74a1db26d9b39f74e8953fe61e749"
 CHKUPDATE="anitya::id=324014"


### PR DESCRIPTION
Topic Description
-----------------

- webkit2gtk: include libsoup 3.x variant (webkit2gtk-4.1)

Package(s) Affected
-------------------

- webkit2gtk: 1:2.42.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit webkit2gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
