### PR TITLE
vim (Vim): update to 9.1.0140

### DIFF
--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.1.0095
-SRCS="tbl::https://github.com/vim/vim/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::172c5a80f316f79d1aae07162c473b2343a8c9a189a7f3c48ef941f9ff1a5e2a"
+VER=9.1.0140
+SRCS="git::commit=tags/v$VER::https://github.com/vim/vim"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"


### PR DESCRIPTION
Topic Description
-----------------

- vim: update to 9.1.0140

Package(s) Affected
-------------------

- vim: 9.1.0140

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
