### PR TITLE
you-get: update to 0.4.1650

### DIFF
--- a/app-multimedia/you-get/spec
+++ b/app-multimedia/you-get/spec
@@ -1,4 +1,4 @@
-VER=0.4.1555
-SRCS="tbl::https://github.com/soimort/you-get/archive/v$VER.tar.gz"
-CHKSUMS="sha256::5590b4c2c8c45985182f211ac7419faa9142f4a09cd5fcd10f13fa43c16de67e"
+VER=0.4.1650
+SRCS="git::commit=tags/v$VER::https://github.com/soimort/you-get"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13697"


### PR DESCRIPTION
Topic Description
-----------------

- you-get: update to 0.4.1650

Package(s) Affected
-------------------

- you-get: 0.4.1650

Security Update?
----------------

No

Build Order
-----------

```
#buildit you-get
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
