### PR TITLE
inkscape (Inkscape): update to 1.3.2

### DIFF
--- a/app-creativity/inkscape/spec
+++ b/app-creativity/inkscape/spec
@@ -1,5 +1,4 @@
-VER=1.2.1
-REL=1
+VER=1.3.2
 SRCS="tbl::https://media.inkscape.org/dl/resources/file/inkscape-${VER}.tar.xz"
-CHKSUMS="sha256::46ce7da0eba7ca4badc1db70e9cbb67e0adf9bb342687dc6e08b5ca21b8d4c1b"
+CHKSUMS="sha256::dbd1844dc443fe5e10d3e9a887144e5fb7223852fff191cfb5ef7adeab0e086b"
 CHKUPDATE="anitya::id=1381"


### PR DESCRIPTION
Topic Description
-----------------

- inkscape: update to 1.3.2

Package(s) Affected
-------------------

- inkscape: 1.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit inkscape
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
