### PR TITLE
gimp (GNU Image Manipulator Program): update to 2.10.36

### DIFF
--- a/app-creativity/gimp/autobuild/patches/0001-feat-gimprc-enable-color-management.patch
+++ b/app-creativity/gimp/autobuild/patches/0001-feat-gimprc-enable-color-management.patch
@@ -1,6 +1,16 @@
-diff -up gimp-2.10.14/etc/gimprc.in.cm-system-monitor-profile-by-default gimp-2.10.14/etc/gimprc.in
---- gimp-2.10.14/etc/gimprc.in.cm-system-monitor-profile-by-default	2019-10-26 21:46:48.000000000 +0200
-+++ gimp-2.10.14/etc/gimprc.in	2019-11-04 13:17:23.322750636 +0100
+From 56d01b6f654a7138486d5b29053898dc06947910 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 6 Mar 2024 15:36:55 +0800
+Subject: [PATCH] feat(gimprc): enable color management
+
+---
+ etc/gimprc.in | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/etc/gimprc.in b/etc/gimprc.in
+index 426cb0575f..9cf71ab655 100644
+--- a/etc/gimprc.in
++++ b/etc/gimprc.in
 @@ -317,9 +317,9 @@
  
  # Defines the color management behavior.  This is a parameter list.
@@ -13,13 +23,15 @@ diff -up gimp-2.10.14/etc/gimprc.in.cm-system-monitor-profile-by-default gimp-2.
  #     (display-rendering-intent relative-colorimetric)
  #     (display-use-black-point-compensation yes)
  #     (display-optimize yes)
-@@ -328,7 +328,8 @@
- #     (simulation-optimize yes)
- #     (simulation-gamut-check no)
+@@ -330,7 +330,7 @@
  #     (out-of-gamut-color (color-rgb 1 0 1))
+ #     (show-rgb-u8 no)
+ #     (show-hsv no)
 -#     (display-module "CdisplayLcms"))
-+#     (display-module "CdisplayLcms")
-+)
++      (display-module "CdisplayLcms"))
  
  # Keep a permanent record of all opened and saved files in the Recent
  # Documents list.  Possible values are yes and no.
+-- 
+2.44.0
+

--- a/app-creativity/gimp/spec
+++ b/app-creativity/gimp/spec
@@ -1,5 +1,4 @@
-VER=2.10.32
+VER=2.10.36
 SRCS="tbl::https://download.gimp.org/pub/gimp/v${VER:0:4}/gimp-$VER.tar.bz2"
-CHKSUMS="sha256::3f15c70554af5dcc1b46e6dc68f3d8f0a6cc9fe56b6d78ac08c0fd859ab89a25"
+CHKSUMS="sha256::3d3bc3c69a4bdb3aea9ba2d5385ed98ea03953f3857aafd1d6976011ed7cdbb2"
 CHKUPDATE="anitya::id=1161"
-REL=1

--- a/runtime-imaging/babl/spec
+++ b/runtime-imaging/babl/spec
@@ -1,4 +1,4 @@
-VER=0.1.96
+VER=0.1.108
 SRCS="tbl::https://download.gimp.org/pub/babl/${VER%.*}/babl-$VER.tar.xz"
-CHKSUMS="sha256::33673fe459a983f411245a49f81fd7f1966af1ea8eca9b095a940c542b8545f6"
+CHKSUMS="sha256::26defe9deaab7ac4d0e076cab49c2a0d6ebd0df0c31fd209925a5f07edee1475"
 CHKUPDATE="anitya::id=7843"

--- a/runtime-imaging/gegl-0.4/spec
+++ b/runtime-imaging/gegl-0.4/spec
@@ -1,5 +1,4 @@
-VER=0.4.38
+VER=0.4.48
 SRCS="tbl::https://download.gimp.org/pub/gegl/${VER:0:3}/gegl-$VER.tar.xz"
-CHKSUMS="sha256::e4a33c8430a5042fba8439b595348e71870f0d95fbf885ff553f9020c1bed750"
+CHKSUMS="sha256::418c26d94be8805d7d98f6de0c6825ca26bd74fcacb6c188da47533d9ee28247"
 CHKUPDATE="anitya::id=229510"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- gimp: update to 2.10.36
- gegl-0.4: update to 0.4.48
- babl: update to 0.1.108

Package(s) Affected
-------------------

- babl: 0.1.108
- gegl-0.4: 0.4.48
- gimp: 2.10.36

Security Update?
----------------

No

Build Order
-----------

```
#buildit babl gegl-0.4 gimp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
