### PR TITLE
haruna (Haruna Media Player): update to 0.12.3

### DIFF
--- a/desktop-kde/haruna/spec
+++ b/desktop-kde/haruna/spec
@@ -1,5 +1,4 @@
-VER=0.10.2
+VER=0.12.3
 SRCS="tbl::https://download.kde.org/stable/haruna/haruna-$VER.tar.xz"
-CHKSUMS="sha256::b08edc5b7b430f4856dac32722d8ecbdcb8ea2fc5cc103b17cbc9996dfd427c0"
+CHKSUMS="sha256::d0202e0060ae86e10c461e7529f6de6b67f8281bf7b82c845479f46772b9fa6f"
 CHKUPDATE="anitya::id=267594"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- haruna: update to 0.12.3

Package(s) Affected
-------------------

- haruna: 0.12.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit haruna
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
