### PR TITLE
gparted (GParted): update to 1.6.0

### DIFF
--- a/app-admin/gparted/spec
+++ b/app-admin/gparted/spec
@@ -1,4 +1,4 @@
-VER=1.5.0
+VER=1.6.0
 SRCS="tbl::https://sourceforge.net/projects/gparted/files/gparted/gparted-$VER/gparted-$VER.tar.gz"
-CHKSUMS="sha256::3c95ea26a944083ff1d9b17639b1e2ad9758df225dc751ff407b2a6aa092a8de"
+CHKSUMS="sha256::9b9f51b3ce494ddcb59a55e1ae6679c09436604e331dbf5a536d60ded6c6ea5b"
 CHKUPDATE="anitya::id=1235"


### PR DESCRIPTION
Topic Description
-----------------

- gparted: update to 1.6.0

Package(s) Affected
-------------------

- gparted: 1.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gparted
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
