### PR TITLE
nss (Network Security Services): update to 3.98

### DIFF
--- a/runtime-cryptography/nss/autobuild/patches/0001-Distrust-CNNIC-patch.patch
+++ b/runtime-cryptography/nss/autobuild/patches/0001-Distrust-CNNIC-patch.patch
@@ -1,19 +1,19 @@
-From 71d72019332ace0db06214b1d564af27b7431023 Mon Sep 17 00:00:00 2001
+From 33c9bf7741b63b18870cb38f40fac922942b093a Mon Sep 17 00:00:00 2001
 From: Pale Moon <git-repo@palemoon.org>
 Date: Fri, 3 Apr 2015 13:17:15 +0200
 Subject: [PATCH] Distrust CNNIC root certificate.
 
 ---
- security/nss/lib/ckfw/builtins/certdata.txt | 6 +++---
+ nss/lib/ckfw/builtins/certdata.txt | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/nss/lib/ckfw/builtins/certdata.txt b/nss/lib/ckfw/builtins/certdata.txt
-index eaf40f1..4d66d85 100644
+index ed5e6cb17..106639180 100644
 --- a/nss/lib/ckfw/builtins/certdata.txt
 +++ b/nss/lib/ckfw/builtins/certdata.txt
-@@ -14885,9 +14885,9 @@ END
+@@ -6885,9 +6885,9 @@ END
  CKA_SERIAL_NUMBER MULTILINE_OCTAL
- \002\004\111\063\000\001
+ \002\003\011\203\364
  END
 -CKA_TRUST_SERVER_AUTH CK_TRUST CKT_NSS_TRUSTED_DELEGATOR
 -CKA_TRUST_EMAIL_PROTECTION CK_TRUST CKT_NSS_MUST_VERIFY_TRUST
@@ -25,5 +25,5 @@ index eaf40f1..4d66d85 100644
  
  #
 -- 
-1.8.3.msysgit.0
+2.43.0
 

--- a/runtime-cryptography/nss/spec
+++ b/runtime-cryptography/nss/spec
@@ -1,4 +1,4 @@
-VER=3.94
+VER=3.98
 SRCS="https://download-origin.cdn.mozilla.net/pub/security/nss/releases/NSS_${VER//./_}_RTM/src/nss-$VER.tar.gz"
-CHKSUMS="sha256::463ae180ee9e5ee9e3ad4f629326657e236780cc865572a930a16520abad9dd8"
+CHKSUMS="sha256::f549cc33d35c0601674bfacf7c6ad683c187595eb4125b423238d3e9aa4209ce"
 CHKUPDATE="anitya::id=2503"


### PR DESCRIPTION
Topic Description
-----------------

- nss: update to 3.98

Package(s) Affected
-------------------

- nss: 3.98

Security Update?
----------------

No

Build Order
-----------

```
#buildit nss
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
