### PR TITLE
netease-cloud-music-gtk: update to 2.3.0 and fix shortcut

### DIFF
--- a/app-multimedia/netease-cloud-music-gtk/autobuild/beyond
+++ b/app-multimedia/netease-cloud-music-gtk/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Fix netease-cloud-music-gtk4 .desktop entry..."
+sed -e 's/网易云音乐/网易云音乐 (GTK)/g' \
+    -e 's/網易雲音樂/網易雲音樂 (GTK)/g' \
+    -i "${PKGDIR}"/usr/share/applications/com.gitee.gmg137.NeteaseCloudMusicGtk4.desktop 

--- a/app-multimedia/netease-cloud-music-gtk/autobuild/defines
+++ b/app-multimedia/netease-cloud-music-gtk/autobuild/defines
@@ -1,17 +1,13 @@
 PKGNAME=netease-cloud-music-gtk
 PKGDES="An unofficial client for Netease Cloud Music"
-PKGDEP="openssl curl gstreamer-1-0 atk gdk-pixbuf \
-	gst-plugins-bad-1-0 gst-plugins-good-1-0 gst-plugins-ugly-1-0 \
-	gst-libav-1-0 osdlyrics gtk-4 libadwaita"
+PKGDEP="openssl curl gstreamer atk gdk-pixbuf \
+        osdlyrics gtk-4 libadwaita"
 BUILDDEP="cargo llvm"
 PKGSEC="sound"
+
 USECLANG=1
+ABTYPE=meson
 
-ABSTRIP=0
-USECLANG__LOONGSON3=0
+# FIXME: ld.lld is not yet available
 NOLTO__LOONGSON3=1
-ABSPLITDBG=0
-
-# FIXME: ld.lld is not yet available.
-USECLANG__LOONGARCH64=0
-NOLTO__LOONGARCH=1
+NOLTO__LOONGARCH64=1

--- a/app-multimedia/netease-cloud-music-gtk/autobuild/prepare
+++ b/app-multimedia/netease-cloud-music-gtk/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo "Updating dependency to fix build ..."
-cargo update

--- a/app-multimedia/netease-cloud-music-gtk/spec
+++ b/app-multimedia/netease-cloud-music-gtk/spec
@@ -1,5 +1,4 @@
-VER=2.2.0
-SRCS="tbl::https://github.com/gmg137/netease-cloud-music-gtk/archive/$VER.tar.gz"
-CHKSUMS="sha256::76e0c2bb3447df2aee0c7e6d978c8f8fe866a31bf7caf0c7c72ea8de2e6a1d8f"
-CHKUPDATE="anitya::id=230942"
-REL=1
+VER=2.3.0
+SRCS="git::commit=tags/$VER::https://github.com/gmg137/netease-cloud-music-gtk"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=240228"


### PR DESCRIPTION
Topic Description
-----------------

- netease-cloud-music: lint scripts
- netease-cloud-music: lint scripts
- fix: add  $SRCDIR and $PKGDIR for build script
- fix: add description for the $SRCDIR and $PKGDIR
- fix: wrong commands "ninjia" in build script
- netease-cloud-music-gtk: update to 2.3.0; patch shortcut
- netease-cloud-music-gtk: update to 2.3.0; patch shortcut

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit netease-cloud-music-gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
