### PR TITLE
micro: new, 2.0.13

### DIFF
--- a/app-editors/micro/autobuild/build
+++ b/app-editors/micro/autobuild/build
@@ -1,0 +1,9 @@
+abinfo "Building micro..."
+make
+
+abinfo "Installing micro..."
+install -v -Dm755 "$SRCDIR"/micro "$PKGDIR"/usr/bin/micro
+install -v -Dm644 "$SRCDIR"/assets/packaging/micro.1 -t "$PKGDIR"/usr/share/man/man1
+install -v -Dm644 "$SRCDIR"/assets/packaging/micro.desktop -t "$PKGDIR"/usr/share/applications
+install -v -Dm644 "$SRCDIR"/assets/micro-logo-mark.svg "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/micro.svg
+install -v -Dm644 -t "$PKGDIR"/usr/share/doc/micro "$SRCDIR"/LICENSE "$SRCDIR"/LICENSE-THIRD-PARTY

--- a/app-editors/micro/autobuild/defines
+++ b/app-editors/micro/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=micro
+PKGSEC=editors
+PKGDES="A terminal-based text editor"
+
+BUILDDEP="go"
+ABSPLITDBG=0

--- a/app-editors/micro/autobuild/patches/0001-remove-nodisplay-in-desktop-file.patch
+++ b/app-editors/micro/autobuild/patches/0001-remove-nodisplay-in-desktop-file.patch
@@ -1,0 +1,10 @@
+diff --git a/assets/packaging/micro.desktop b/assets/packaging/micro.desktop
+index 35772518..3066f82e 100644
+--- a/assets/packaging/micro.desktop
++++ b/assets/packaging/micro.desktop
+@@ -12,5 +12,4 @@ Keywords=text;editor;syntax;terminal;
+ Exec=micro %F
+ StartupNotify=false
+ Terminal=true
+-NoDisplay=true
+ MimeType=text/plain;text/x-chdr;text/x-csrc;text/x-c++hdr;text/x-c++src;text/x-java;text/x-dsrc;text/x-pascal;text/x-perl;text/x-python;application/x-php;application/x-httpd-php3;application/x-httpd-php4;application/x-httpd-php5;application/xml;text/html;text/css;text/x-sql;text/x-diff;

--- a/app-editors/micro/spec
+++ b/app-editors/micro/spec
@@ -1,0 +1,4 @@
+VER=2.0.13
+SRCS="git::commit=tags/v$VER::https://github.com/zyedidia/micro"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=19017"


### PR DESCRIPTION
Topic Description
-----------------

- micro: new, 2.0.13

Package(s) Affected
-------------------

- micro: 2.0.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit micro
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
