### PR TITLE
chinadns-ng-20231028 Rework: fix Git tag name for ipt2socks

### DIFF
--- a/app-network/ipt2socks/spec
+++ b/app-network/ipt2socks/spec
@@ -1,5 +1,5 @@
 VER=1.1.3
-REL=2
-SRCS="git::commit=tags/${VER}::https://github.com/zfl9/ipt2socks"
+REL=3
+SRCS="git::commit=tags/v${VER}::https://github.com/zfl9/ipt2socks"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230974"


### PR DESCRIPTION
Topic Description
-----------------

- ipt2socks: fix source tag name
    By adding back the missing `v'.

Package(s) Affected
-------------------

- ipt2socks: 1.1.3-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit ipt2socks
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
