### PR TITLE
ccache: update to 4.9.1

### DIFF
--- a/app-devel/ccache/spec
+++ b/app-devel/ccache/spec
@@ -1,4 +1,4 @@
-VER=4.2
+VER=4.9.1
 SRCS="tbl::https://github.com/ccache/ccache/releases/download/v$VER/ccache-$VER.tar.xz"
-CHKSUMS="sha256::2f14b11888c39778c93814fc6843fc25ad60ff6ba4eeee3dff29a1bad67ba94f"
+CHKSUMS="sha256::4c03bc840699127d16c3f0e6112e3f40ce6a230d5873daa78c60a59c7ef59d25"
 CHKUPDATE="anitya::id=257"


### PR DESCRIPTION
Topic Description
-----------------

- ccache: update to 4.9.1

Package(s) Affected
-------------------

- ccache: 4.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ccache
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
