### PR TITLE
mesa (Mesa 3D Graphics Library): update to 24.0.2

### DIFF
--- a/runtime-display/mesa/autobuild/defines
+++ b/runtime-display/mesa/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=libs
 PKGDES="MesaLib - a OpenGL implementation"
 PKGDEP="x11-lib libdrm expat systemd elfutils libvdpau nettle \
         libva wayland s2tc lm-sensors libglvnd llvm-runtime \
-        libcl libclc"
+        libcl libclc spirv-llvm-translator"
 PKGDEP__RETRO="x11-lib elfutils libdrm libglvnd libva libvdpau llvm-runtime \
                expat systemd"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
@@ -16,9 +16,7 @@ PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 
 BUILDDEP="x11-proto mako systemd valgrind llvm libunwind glslang \
-          spirv-llvm-translator spirv-tools"
-# For building Intel GRL shaders
-BUILDDEP__AMD64="${BUILDDEP} ply"
+          spirv-tools ply"
 # FIXME: Valgrind is not yet available.
 BUILDDEP__LOONGARCH64="${BUILDDEP/valgrind/}"
 BUILDDEP__RISCV64="${BUILDDEP/valgrind/}"
@@ -70,12 +68,12 @@ MESON_AFTER__X86=" \
              -Dvulkan-drivers=amd,intel,intel_hasvk,swrast,virtio"
 MESON_AFTER__ARM=" \
              ${MESON_AFTER} \
-             -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,swrast,kmsro,lima,panfrost,freedreno,tegra,vc4,v3d,etnaviv,d3d12,zink,asahi \
-             -Dvulkan-drivers=amd,broadcom,freedreno,panfrost,swrast,virtio"
+             -Dgallium-drivers=r300,r600,radeonsi,nouveau,iris,virgl,swrast,kmsro,lima,panfrost,freedreno,tegra,vc4,v3d,etnaviv,d3d12,zink,asahi \
+             -Dvulkan-drivers=amd,intel,broadcom,freedreno,panfrost,swrast,virtio"
 MESON_AFTER__OTHER=" \
              ${MESON_AFTER} \
-             -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,swrast,zink \
-             -Dvulkan-drivers=amd,swrast,virtio"
+             -Dgallium-drivers=r300,r600,radeonsi,nouveau,iris,virgl,swrast,zink \
+             -Dvulkan-drivers=amd,intel,swrast,virtio"
 
 MESON_AFTER__AMD64=" \
              ${MESON_AFTER__X86} \

--- a/runtime-display/mesa/autobuild/patches/0001-llvmpipe-make-unnamed-global-have-internal-linkage.patch
+++ b/runtime-display/mesa/autobuild/patches/0001-llvmpipe-make-unnamed-global-have-internal-linkage.patch
@@ -1,7 +1,7 @@
-From 690f8a2157c3f2d14daf775381bf0fa1e7bfd8a0 Mon Sep 17 00:00:00 2001
+From 201af0c5d790a6cdf1ac25a5665c88acd3692c67 Mon Sep 17 00:00:00 2001
 From: Yukari Chiba <i@0x7f.cc>
 Date: Fri, 3 Nov 2023 23:19:27 +0800
-Subject: [PATCH 1/3] llvmpipe: make unnamed global have internal linkage
+Subject: [PATCH 1/4] llvmpipe: make unnamed global have internal linkage
 
 ---
  src/gallium/drivers/llvmpipe/lp_state_fs.c | 1 +

--- a/runtime-display/mesa/autobuild/patches/0002-llvmpipe-add-an-implementation-with-llvm-orcjit.patch
+++ b/runtime-display/mesa/autobuild/patches/0002-llvmpipe-add-an-implementation-with-llvm-orcjit.patch
@@ -1,7 +1,7 @@
-From 47ed77a95cd51b9cf5b8ab4988e233265b5d7e4d Mon Sep 17 00:00:00 2001
+From 04fbe25bc2887cc084ca2f513717033b8d5713d9 Mon Sep 17 00:00:00 2001
 From: Yukari Chiba <i@0x7f.cc>
 Date: Fri, 3 Nov 2023 23:18:47 +0800
-Subject: [PATCH 2/3] llvmpipe: add an implementation with llvm orcjit
+Subject: [PATCH 2/4] llvmpipe: add an implementation with llvm orcjit
 
 ---
  meson.build                                   |   7 +-
@@ -39,10 +39,10 @@ Subject: [PATCH 2/3] llvmpipe: add an implementation with llvm orcjit
  create mode 100644 src/gallium/drivers/llvmpipe/lp_test_lookup_multiple.c
 
 diff --git a/meson.build b/meson.build
-index 1c8667a8fce..52008ff78f9 100644
+index 133fd9a8ca3..d9f968b5cc9 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1726,6 +1726,7 @@ if with_clc
+@@ -1725,6 +1725,7 @@ if with_clc
    llvm_optional_modules += ['all-targets', 'windowsdriver', 'frontendhlsl']
  endif
  draw_with_llvm = get_option('draw-use-llvm')
@@ -50,7 +50,7 @@ index 1c8667a8fce..52008ff78f9 100644
  if draw_with_llvm
    llvm_modules += 'native'
    # lto is needded with LLVM>=15, but we don't know what LLVM verrsion we are using yet
-@@ -1734,7 +1735,7 @@ endif
+@@ -1733,7 +1734,7 @@ endif
  
  if with_amd_vk or with_gallium_radeonsi
    _llvm_version = '>= 15.0.0'
@@ -59,7 +59,7 @@ index 1c8667a8fce..52008ff78f9 100644
    _llvm_version = '>= 13.0.0'
  elif with_gallium_opencl
    _llvm_version = '>= 11.0.0'
-@@ -1772,6 +1773,10 @@ if with_llvm
+@@ -1771,6 +1772,10 @@ if with_llvm
    pre_args += '-DMESA_LLVM_VERSION_STRING="@0@"'.format(dep_llvm.version())
    pre_args += '-DLLVM_IS_SHARED=@0@'.format(_shared_llvm.to_int())
  
@@ -1661,7 +1661,7 @@ index ad3d66424e1..514217dc954 100644
     char cache_id[20 * 2 + 1];
     _mesa_sha1_init(&ctx);
 diff --git a/src/gallium/drivers/llvmpipe/lp_state_cs.c b/src/gallium/drivers/llvmpipe/lp_state_cs.c
-index c4661ced025..cbe6dd6f784 100644
+index 46cc5ffb06f..7bbcc61ee16 100644
 --- a/src/gallium/drivers/llvmpipe/lp_state_cs.c
 +++ b/src/gallium/drivers/llvmpipe/lp_state_cs.c
 @@ -397,6 +397,10 @@ generate_compute(struct llvmpipe_context *lp,
@@ -1675,7 +1675,7 @@ index c4661ced025..cbe6dd6f784 100644
  
     for (i = 0; i < CS_ARG_MAX - !is_mesh; ++i) {
        if (LLVMGetTypeKind(arg_types[i]) == LLVMPointerTypeKind) {
-@@ -1047,6 +1051,10 @@ llvmpipe_remove_cs_shader_variant(struct llvmpipe_context *lp,
+@@ -1006,6 +1010,10 @@ llvmpipe_remove_cs_shader_variant(struct llvmpipe_context *lp,
     lp->nr_cs_variants--;
     lp->nr_cs_instrs -= variant->nr_instrs;
  
@@ -1686,7 +1686,7 @@ index c4661ced025..cbe6dd6f784 100644
     FREE(variant);
  }
  
-@@ -1305,12 +1313,22 @@ generate_variant(struct llvmpipe_context *lp,
+@@ -1264,12 +1272,22 @@ generate_variant(struct llvmpipe_context *lp,
  
     generate_compute(lp, shader, variant);
  

--- a/runtime-display/mesa/autobuild/patches/0003-llvmpipe-add-LoongArch-support-in-ORCJIT.patch
+++ b/runtime-display/mesa/autobuild/patches/0003-llvmpipe-add-LoongArch-support-in-ORCJIT.patch
@@ -1,7 +1,7 @@
-From 63af0383e59b872aeb905a4dffb5e1b7d283ea69 Mon Sep 17 00:00:00 2001
+From f70c9ac6be9f2b09bdf03673c316994d751f2d1d Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Fri, 3 Nov 2023 12:57:09 +0800
-Subject: [PATCH] llvmpipe: add LoongArch support in ORCJIT
+Subject: [PATCH 3/4] llvmpipe: add LoongArch support in ORCJIT
 
 Currently set CPU features based on softdev convention.
 

--- a/runtime-display/mesa/autobuild/patches/0004-llvmpipe-append-partial-mask-to-partial-fs_variant-f.patch
+++ b/runtime-display/mesa/autobuild/patches/0004-llvmpipe-append-partial-mask-to-partial-fs_variant-f.patch
@@ -1,0 +1,32 @@
+From 8c2f644aa70e76921784f64baa80cb5d71d75e6e Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Fri, 1 Mar 2024 11:21:48 +0800
+Subject: [PATCH 4/4] llvmpipe: append partial mask to partial fs_variant func
+ name
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/llvmpipe/lp_state_fs.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/gallium/drivers/llvmpipe/lp_state_fs.c b/src/gallium/drivers/llvmpipe/lp_state_fs.c
+index 2f5f577805c..3bafc988e24 100644
+--- a/src/gallium/drivers/llvmpipe/lp_state_fs.c
++++ b/src/gallium/drivers/llvmpipe/lp_state_fs.c
+@@ -3180,8 +3180,11 @@ generate_fragment(struct llvmpipe_context *lp,
+    blend_vec_type = lp_build_vec_type(gallivm, blend_type);
+ 
+    char func_name[64];
+-   snprintf(func_name, sizeof(func_name), "fs_variant_%s",
+-            partial_mask ? "partial" : "whole");
++   if (partial_mask)
++      snprintf(func_name, sizeof(func_name), "fs_variant_partial%u",
++               partial_mask);
++   else
++      strcpy(func_name, "fs_variant_whole");
+ 
+    arg_types[0] = variant->jit_context_ptr_type;       /* context */
+    arg_types[1] = variant->jit_resources_ptr_type;       /* context */
+-- 
+2.43.0
+

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,7 +1,6 @@
-MESA_VER=24.0.1
+MESA_VER=24.0.2
 DXHEADERS_VER=1.611.0
 VER=${MESA_VER}+dxheaders${DXHEADERS_VER}
-REL=1
 SRCS="git::commit=tags/mesa-${MESA_VER/\~/-};rename=mesa-${MESA_VER}::https://gitlab.freedesktop.org/mesa/mesa \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 24.0.2
    - Refreshed patches from AOSC-Tracking to include the newest symbol
    conflict fix.
    - Enabled iris gallium driver and intel vulkan driver for all platforms,
    because Xe KMD is already in mainline kernel 6.8.
    - Promote spirv-llvm-translator from BUILDDEP to PKGDEP because the
    built libMesaOpenCL.so.1 (Clover) dynamically linked to it.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- mesa: 1:24.0.2+dxheaders1.611.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
