### PR TITLE
clpeak: 1.1.2, new

### DIFF
--- a/app-benchmarks/clpeak/autobuild/defines
+++ b/app-benchmarks/clpeak/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=clpeak
+PKGDES="Benchmark tool to measure theortical peak performance of OpenCL devices"
+PKGDEP="libcl"
+PKGSEC="utils"
+
+ABTYPE=cmakeninja

--- a/app-benchmarks/clpeak/spec
+++ b/app-benchmarks/clpeak/spec
@@ -1,0 +1,4 @@
+VER=1.1.2
+SRCS="git::commit=tags/${VER}::https://github.com/krrishnarraj/clpeak.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=15180"


### PR DESCRIPTION
Topic Description
-----------------

- clpeak: new package, 1.1.2
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- clpeak: 1.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit clpeak
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
