### PR TITLE
SwayWM survey 20240302

### DIFF
--- a/app-devel/wayland-protocols/spec
+++ b/app-devel/wayland-protocols/spec
@@ -1,4 +1,4 @@
-VER=1.32
+VER=1.33
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wayland/wayland-protocols"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13997"

--- a/app-utils/grim/autobuild/defines
+++ b/app-utils/grim/autobuild/defines
@@ -1,5 +1,8 @@
 PKGNAME=grim
 PKGSEC=utils
-PKGDEP="wayland cairo libjpeg-turbo"
+PKGDEP="wayland cairo pixman libpng libjpeg-turbo"
 BUILDDEP="wayland-protocols scdoc fish"
 PKGDES="A screenshot utility for Wayland"
+
+MESON_AFTER="-Dfish-completions=true \
+	-Dbash-completions=true"

--- a/app-utils/grim/spec
+++ b/app-utils/grim/spec
@@ -1,4 +1,4 @@
-VER=1.3.2
-SRCS="git::commit=tags/v$VER::https://github.com/emersion/grim"
+VER=1.4.1
+SRCS="git::commit=tags/v$VER::https://git.sr.ht/~emersion/grim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20169"

--- a/app-utils/slurp/autobuild/defines
+++ b/app-utils/slurp/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=slurp
 PKGSEC=utils
-PKGDEP="wayland wayland-protocols cairo libxkbcommon scdoc"
+PKGDEP="wayland wayland-protocols cairo libxkbcommon"
+BUILDDEP="scdoc"
 PKGDES="A tool to select a region in a Wayland compositor and print it to the standard output"

--- a/app-utils/slurp/spec
+++ b/app-utils/slurp/spec
@@ -1,4 +1,4 @@
-VER=1.3.2
+VER=1.5.0
 SRCS="git::commit=tags/v$VER::https://github.com/emersion/slurp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20171"

--- a/app-utils/swaybg/autobuild/defines
+++ b/app-utils/swaybg/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=swaybg
 PKGSEC=x11
-PKGDEP="wayland gdk-pixbuf"
-BUILDDEP="wayland-protocols scdoc fish"
+PKGDEP="wayland cairo gdk-pixbuf"
+BUILDDEP="meson ninja wayland-protocols scdoc"
 PKGDES="A utility for Wayland compositors to manage and set wallpaper"

--- a/app-utils/swaybg/spec
+++ b/app-utils/swaybg/spec
@@ -1,4 +1,4 @@
-VER=1.1
+VER=1.2.0
 SRCS="git::commit=tags/v$VER::https://github.com/swaywm/swaybg"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20562"

--- a/app-utils/swayidle/spec
+++ b/app-utils/swayidle/spec
@@ -1,4 +1,4 @@
-VER=1.7
+VER=1.8.0
 SRCS="git::commit=tags/$VER::https://github.com/swaywm/swayidle"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=137685"

--- a/app-utils/swaylock/autobuild/defines
+++ b/app-utils/swaylock/autobuild/defines
@@ -2,4 +2,4 @@ PKGNAME=swaylock
 PKGSEC=x11
 PKGDEP="wayland libxkbcommon gdk-pixbuf"
 BUILDDEP="wayland-protocols scdoc fish"
-PKGDES="An i3-compatible window manager for Wayland"
+PKGDES="A screen locking utility for Wayland compositors"

--- a/app-utils/swaylock/spec
+++ b/app-utils/swaylock/spec
@@ -1,4 +1,4 @@
-VER=1.5
-SRCS="git::commit=tags/$VER::https://github.com/swaywm/swaylock"
+VER=1.7.2
+SRCS="git::commit=tags/v$VER::https://github.com/swaywm/swaylock"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19218"

--- a/app-utils/wl-clipboard/spec
+++ b/app-utils/wl-clipboard/spec
@@ -1,4 +1,4 @@
-VER=2.0.0
+VER=2.2.1
 SRCS="git::commit=tags/v$VER::https://github.com/bugaevc/wl-clipboard"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=49082"

--- a/desktop-wm/sway/autobuild/defines
+++ b/desktop-wm/sway/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=sway
 PKGSEC=x11
-PKGDEP="gdk-pixbuf json-c cairo pcre2 xorg-server pango wlroots xwayland swaybg"
-BUILDDEP="asciidoc cmake scdoc"
+PKGDEP="wayland gdk-pixbuf json-c cairo pcre2 xorg-server pango wlroots xwayland swaybg"
+BUILDDEP="wayland-protocols meson ninja scdoc"
 PKGDES="An i3-compatible window manager for Wayland"

--- a/desktop-wm/sway/autobuild/defines
+++ b/desktop-wm/sway/autobuild/defines
@@ -2,4 +2,5 @@ PKGNAME=sway
 PKGSEC=x11
 PKGDEP="wayland gdk-pixbuf json-c cairo pcre2 xorg-server pango wlroots xwayland swaybg"
 BUILDDEP="wayland-protocols meson ninja scdoc"
+PKGSUG="swaylock swayidle"
 PKGDES="An i3-compatible window manager for Wayland"

--- a/desktop-wm/sway/autobuild/defines
+++ b/desktop-wm/sway/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=sway
 PKGSEC=x11
-PKGDEP="gdk-pixbuf json-c cairo pcre2 xorg-server pango wlroots xwayland"
+PKGDEP="gdk-pixbuf json-c cairo pcre2 xorg-server pango wlroots xwayland swaybg"
 BUILDDEP="asciidoc cmake scdoc"
 PKGDES="An i3-compatible window manager for Wayland"

--- a/desktop-wm/sway/spec
+++ b/desktop-wm/sway/spec
@@ -1,4 +1,4 @@
-VER=1.8.1
+VER=1.9
 SRCS="git::commit=tags/$VER::https://github.com/swaywm/sway"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11497"

--- a/runtime-display/libliftoff/autobuild/defines
+++ b/runtime-display/libliftoff/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=libliftoff
+PKGSEC=libs
+PKGDEP="libdrm"
+BUILDDEP="meson ninja"
+PKGDES="Lightweight KMS plane library"
+
+ABTYPE=meson

--- a/runtime-display/libliftoff/spec
+++ b/runtime-display/libliftoff/spec
@@ -1,0 +1,4 @@
+VER=0.4.1
+SRCS="git::commit=tags/v$VER::https://gitlab.freedesktop.org/emersion/libliftoff"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=236274"

--- a/runtime-display/wlroots/autobuild/defines
+++ b/runtime-display/wlroots/autobuild/defines
@@ -1,10 +1,13 @@
 PKGNAME=wlroots
 PKGSEC=libs
 PKGDEP="wayland libdrm libinput libxkbcommon pixman systemd \
-        libxcb freerdp seatd xcb-util-wm xcb-util"
+        libxcb freerdp seatd xcb-util-wm xcb-util libdisplay-info \
+	hwdata libliftoff seatd xcb-util-renderutil"
 BUILDDEP="wayland-protocols meson ninja xcb-proto ctags xwayland"
 PKGRECOM="xwayland"
-PKGDES="Pluggable, composable, unopinionated modules for building a Wayland compositor."
+PKGDES="Pluggable, composable, unopinionated modules for building a Wayland compositor"
 
 ABTYPE=meson
-MESON_AFTER="-Dxwayland=enabled"
+MESON_AFTER="-Dxwayland=enabled \
+	-Dbackends=drm,libinput,x11 \
+	-Dsession=enabled"

--- a/runtime-display/wlroots/autobuild/defines
+++ b/runtime-display/wlroots/autobuild/defines
@@ -2,12 +2,14 @@ PKGNAME=wlroots
 PKGSEC=libs
 PKGDEP="wayland libdrm libinput libxkbcommon pixman systemd \
         libxcb freerdp seatd xcb-util-wm xcb-util libdisplay-info \
-	hwdata libliftoff seatd xcb-util-renderutil"
+	hwdata libliftoff seatd xcb-util-renderutil vulkan-loader \
+	vulkan-headers glslang"
 BUILDDEP="wayland-protocols meson ninja xcb-proto ctags xwayland"
 PKGRECOM="xwayland"
 PKGDES="Pluggable, composable, unopinionated modules for building a Wayland compositor"
 
 ABTYPE=meson
 MESON_AFTER="-Dxwayland=enabled \
+	-Drenderers=gles2,vulkan \
 	-Dbackends=drm,libinput,x11 \
 	-Dsession=enabled"

--- a/runtime-display/wlroots/spec
+++ b/runtime-display/wlroots/spec
@@ -1,4 +1,4 @@
-VER=0.16.2
+VER=0.17.1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wlroots/wlroots"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18357"


### PR DESCRIPTION
Topic Description
-----------------

- sway: update to 1.9
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- wlroots: update to 0.17.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- grim: 1.4.1
- libliftoff: 0.4.1
- slurp: 1.5.0
- sway: 1.9
- swaybg: 1.2.0
- swayidle: 1.8.0
- swaylock: 1.7.2
- wayland-protocols: 1.33
- wlroots: 0.17.1
- wl-clipboard: 2.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wayland-protocols libliftoff wlroots swaybg sway grim slurp wl-clipboard swaylock swayidle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
