### PR TITLE
sqlite: update to 3.45.1

### DIFF
--- a/app-database/sqlite/spec
+++ b/app-database/sqlite/spec
@@ -1,6 +1,6 @@
-VER=3.39.4
-LOCAL_VER=3390400
-REL=1
-SRCS="tbl::https://sqlite.org/2022/sqlite-src-$LOCAL_VER.zip"
-CHKSUMS="sha256::02d96c6ccf811ab9b63919ef717f7e52a450c420e06bd129fb483cd70c3b3bba"
+VER=3.45.1
+LOCAL_VER=3450100
+YEAR=2024
+SRCS="tbl::https://sqlite.org/$YEAR/sqlite-src-$LOCAL_VER.zip"
+CHKSUMS="sha256::7f7b14a68edbcd4a57df3a8c4dbd56d2d3546a6e7cdd50de40ceb03af33d34ba"
 CHKUPDATE="anitya::id=4877"


### PR DESCRIPTION
Topic Description
-----------------

- sqlite: update to 3.45.1

Package(s) Affected
-------------------

- sqlite: 3.45.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sqlite
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
