### PR TITLE
redis: update to 7.2.4

### DIFF
--- a/app-database/redis/spec
+++ b/app-database/redis/spec
@@ -1,4 +1,4 @@
-VER=6.2.4
+VER=7.2.4
 SRCS="tbl::http://download.redis.io/releases/redis-$VER.tar.gz"
-CHKSUMS="sha256::ba32c406a10fc2c09426e2be2787d74ff204eb3a2e496d87cff76a476b6ae16e"
+CHKSUMS="sha256::8d104c26a154b29fd67d6568b4f375212212ad41e0c2caa3d66480e78dbd3b59"
 CHKUPDATE="anitya::id=4181"


### PR DESCRIPTION
Topic Description
-----------------

- redis: update to 7.2.4

Package(s) Affected
-------------------

- redis: 7.2.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit redis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
