### PR TITLE
php: update to 8.3.3

### DIFF
--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,5 +1,4 @@
-VER=8.2.8
-REL=2
+VER=8.3.3
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::cfe1055fbcd486de7d3312da6146949aae577365808790af6018205567609801"
+CHKSUMS="sha256::b0a996276fe21fe9ca8f993314c8bc02750f464c7b0343f056fb0894a8dfa9d1"
 CHKUPDATE="anitya::id=3627"


### PR DESCRIPTION
Topic Description
-----------------

- php: update to 8.3.3

Package(s) Affected
-------------------

- php: 1:8.3.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
