### PR TITLE
aria2: update to 1.37.0

### DIFF
--- a/app-web/aria2/spec
+++ b/app-web/aria2/spec
@@ -1,4 +1,4 @@
-VER=1.36.0
+VER=1.37.0
 SRCS="tbl::https://github.com/aria2/aria2/releases/download/release-$VER/aria2-$VER.tar.xz"
-CHKSUMS="sha256::58d1e7608c12404f0229a3d9a4953d0d00c18040504498b483305bcb3de907a5"
+CHKSUMS="sha256::60a420ad7085eb616cb6e2bdf0a7206d68ff3d37fb5a956dc44242eb2f79b66b"
 CHKUPDATE="anitya::id=109"


### PR DESCRIPTION
Topic Description
-----------------

- aria2: update to 1.37.0

Package(s) Affected
-------------------

- aria2: 1.37.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit aria2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
