### PR TITLE
cryptsetup: update to 2.7.0

### DIFF
--- a/app-admin/cryptsetup/spec
+++ b/app-admin/cryptsetup/spec
@@ -1,5 +1,4 @@
-VER=2.6.0
-REL=2
+VER=2.7.0
 SRCS="https://www.kernel.org/pub/linux/utils/cryptsetup/v${VER:0:3}/cryptsetup-$VER.tar.xz"
-CHKSUMS="sha256::44397ba76e75a9cde5b02177bc63cd7af428a785788e3a7067733e7761842735"
+CHKSUMS="sha256::94003a00cd5a81944f45e8dc529e0cfd2a6ff629bd2cd21cf5e574e465daf795"
 CHKUPDATE="anitya::id=13709"


### PR DESCRIPTION
Topic Description
-----------------

- cryptsetup: update to 2.7.0

Package(s) Affected
-------------------

- cryptsetup: 2.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit cryptsetup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
