### PR TITLE
ninja: update to 1.11.1

### DIFF
--- a/app-devel/ninja/spec
+++ b/app-devel/ninja/spec
@@ -1,4 +1,4 @@
-VER=1.10.2
-SRCS="tbl::https://github.com/ninja-build/ninja/archive/v$VER.tar.gz"
-CHKSUMS="sha256::ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed"
+VER=1.11.1
+SRCS="git::commit=tags/v$VER::https://github.com/ninja-build/ninja"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=132832"


### PR DESCRIPTION
Topic Description
-----------------

- ninja: update to 1.11.1

Package(s) Affected
-------------------

- ninja: 1.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ninja
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
