### PR TITLE
wofi: update to 1.4.1

### DIFF
--- a/app-utils/wofi/spec
+++ b/app-utils/wofi/spec
@@ -1,4 +1,4 @@
-VER=1.2.2
-SRCS="hg::commit=b352d73b652aadd3b9da064267d6f3fa26007c25::https://hg.sr.ht/~scoopta/wofi"
+VER=1.4.1
+SRCS="hg::commit=v${VER}::https://hg.sr.ht/~scoopta/wofi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=70994"


### PR DESCRIPTION
Topic Description
-----------------

- wofi: update to 1.4.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- wofi: 1.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wofi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
