### PR TITLE
cava: enable all audio system support

### DIFF
--- a/app-multimedia/cava/autobuild/defines
+++ b/app-multimedia/cava/autobuild/defines
@@ -1,7 +1,15 @@
 PKGNAME=cava
 PKGSEC=sound
-PKGDEP="alsa-lib fftw iniparser ncurses pulseaudio"
+PKGDEP="fftw iniparser ncurses"
+BUILDDEP="alsa-lib pulseaudio pipewire portaudio sndio jack"
 PKGDES="Console-based Audio Visualizer for Alsa (MPD and Pulseaudio)"
 
 # FIXME: {standard input}:11: Error: file not found: example_files/config
 ABSHADOW=0
+
+AUTOTOOLS_AFTER="--enable-input-alsa \
+	--enable-input-pulse \
+	--enable-input-pipewire \
+	--enable-input-portaudio \
+	--enable-input-sndio \
+	--enable-input-jack"

--- a/app-multimedia/cava/spec
+++ b/app-multimedia/cava/spec
@@ -1,4 +1,5 @@
 VER=0.10.1
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/karlstav/cava"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17019"


### PR DESCRIPTION
Topic Description
-----------------

- cava: enable all audio system support
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- cava: 0.10.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cava
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
