### PR TITLE
graphviz: update to 10.0.1

### DIFF
--- a/app-doc/graphviz/autobuild/defines
+++ b/app-doc/graphviz/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=graphics
 PKGDES="Graph visualization software"
 
 PKGDEP="libgd libtool librsvg x11-lib ghostscript pango gts libnsl2"
-BUILDDEP="gtk-2 guile lua perl python-2 ruby tcl xterm swig tk mono php qt-4 r"
+BUILDDEP="gtk-2 guile lua perl python-3 ruby tcl xterm swig tk mono php qt-5 r gtkglext"
 BUILDDEP__NOMONO="${BUILDDEP/mono/}"
 BUILDDEP__LOONGARCH64="${BUILDDEP__NOMONO}"
 BUILDDEP__LOONGSON3="${BUILDDEP__NOMONO}"

--- a/app-doc/graphviz/autobuild/prepare
+++ b/app-doc/graphviz/autobuild/prepare
@@ -1,9 +1,2 @@
-export PATH="/usr/lib/qt4/bin:$PATH"
-
-export CFLAGS="${CFLAGS} -fPIC"
-export CXXFLAGS="${CXXFLAGS} -fPIC"
-export LDFLAGS="${LDFLAGS} -fPIC"
-
 export LIBPOSTFIX=/
-export PYTHON=python2
 export LUA=lua5.1

--- a/app-doc/graphviz/spec
+++ b/app-doc/graphviz/spec
@@ -1,5 +1,4 @@
-VER=2.50.0
-SRCS="tbl::https://gitlab.com/graphviz/graphviz/-/archive/${VER}/graphviz-${VER}.tar.gz"
-CHKSUMS="sha256::afa48581f764a35e148909cc96a0308ec2356b5225b64af12492f3392f20ef1c"
+VER=10.0.1
+SRCS="git::commit=tags/$VER::https://gitlab.com/graphviz/graphviz"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1249"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- graphviz: update to 10.0.1

Package(s) Affected
-------------------

- graphviz: 10.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit graphviz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
