### PR TITLE
texlive: allow TeX to run extractbb by default (to fix many document building issues)

### DIFF
--- a/app-doc/texlive/autobuild/overrides/etc/texmf/web2c/texmf.cnf
+++ b/app-doc/texlive/autobuild/overrides/etc/texmf/web2c/texmf.cnf
@@ -564,6 +564,7 @@ kpsewhich,\
 makeindex,\
 mpost,\
 repstopdf,\
+extractbb,\
 
 % we'd like to allow:
 % dvips - but external commands can be executed, need at least -R1.

--- a/app-doc/texlive/spec
+++ b/app-doc/texlive/spec
@@ -1,5 +1,5 @@
 VER=20220321
-REL=5
+REL=6
 SRCS="tbl::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-source.tar.xz \
       file::rename=texlive-$VER-texmf.tar.xz::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-texmf.tar.xz"
 CHKSUMS="sha256::5ffa3485e51eb2c4490496450fc69b9d7bd7cb9e53357d92db4bcd4fd6179b56 \


### PR DESCRIPTION
Topic Description
-----------------

- texlive: allow TeX to run extractbb by default
    Multiple document classes in LaTeX requires extractbb to be run when
    built.
    Add it to the default shell escape command list.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- texlive: 20220321-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit texlive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
