### PR TITLE
seatd: update to 0.8.0

### DIFF
--- a/app-admin/seatd/autobuild/beyond
+++ b/app-admin/seatd/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing systemd unit ..."
+install -Dvm644 "$SRCDIR"/contrib/systemd/seatd.service \
+	"$PKGDIR"/usr/lib/systemd/system/seatd.service

--- a/app-admin/seatd/autobuild/defines
+++ b/app-admin/seatd/autobuild/defines
@@ -5,3 +5,4 @@ BUILDDEP="meson ninja scdoc"
 PKGDES="A minimal seat management daemon, and a universal seat management library"
 
 ABTYPE=meson
+MESON_AFTER="-Dlibseat-logind=systemd"

--- a/app-admin/seatd/autobuild/overrides/usr/lib/sysusers.d/seatd.conf
+++ b/app-admin/seatd/autobuild/overrides/usr/lib/sysusers.d/seatd.conf
@@ -1,0 +1,2 @@
+#Type Name   ID    GECOS           Home directory  Shell
+g     seat   -

--- a/app-admin/seatd/autobuild/postinst
+++ b/app-admin/seatd/autobuild/postinst
@@ -1,0 +1,1 @@
+systemd-sysusers seatd.conf

--- a/app-admin/seatd/spec
+++ b/app-admin/seatd/spec
@@ -1,4 +1,4 @@
-VER=0.6.3
+VER=0.8.0
 SRCS="git::commit=tags/$VER::https://git.sr.ht/~kennylevinsen/seatd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=234932"


### PR DESCRIPTION
Topic Description
-----------------

- seatd: update to 0.8.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- seatd: 0.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit seatd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
