### PR TITLE
mako-notification-daemon: update to 1.8.0

### DIFF
--- a/app-utils/mako-notification-daemon/autobuild/defines
+++ b/app-utils/mako-notification-daemon/autobuild/defines
@@ -1,5 +1,9 @@
 PKGNAME=mako-notification-daemon
 PKGSEC=utils
-PKGDEP="wayland pango cairo gdk-pixbuf dbus jq"
-BUILDDEP="scdoc"
+PKGDEP="wayland pango cairo gdk-pixbuf dbus jq systemd"
+BUILDDEP="scdoc meson ninja"
 PKGDES="A lightweight Wayland notification daemon"
+
+MESON_AFTER="-Dfish-completions=true \
+	-Dzsh-completions=true \
+	-Dbash-completions=true"

--- a/app-utils/mako-notification-daemon/spec
+++ b/app-utils/mako-notification-daemon/spec
@@ -1,4 +1,4 @@
-VER=1.6
+VER=1.8.0
 SRCS="git::commit=tags/v$VER::https://github.com/emersion/mako"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231610"


### PR DESCRIPTION
Topic Description
-----------------

- mako-notification-daemon: update to 1.8.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- mako-notification-daemon: 1.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mako-notification-daemon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
