### PR TITLE
kicad (KiCAD): fix checksums

### DIFF
--- a/app-electronics/kicad/spec
+++ b/app-electronics/kicad/spec
@@ -1,14 +1,14 @@
 VER=7.0.0
-REL=2
-SRCS="tbl::rename=kicad-$VER.tar.bz2::https://gitlab.com/kicad/code/kicad/-/archive/$VER/kicad-$VER.tar.bz2 \
-      tbl::rename=kicad-footprints-$VER.tar.bz2::https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/$VER/kicad-footprints-$VER.tar.bz2 \
-      tbl::rename=kicad-symbols-$VER.tar.bz2::https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/$VER/kicad-symbols-$VER.tar.bz2 \
-      tbl::rename=kicad-packages3D-$VER.tar.bz2::https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/$VER/kicad-packages3D-$VER.tar.bz2 \
+REL=3
+SRCS="git::commit=tags/$VER;rename=kicad-$VER::https://gitlab.com/kicad/code/kicad \
+      git::commit=tags/$VER;rename=kicad-footprints-$VER::https://gitlab.com/kicad/libraries/kicad-footprints \
+      git::commit=tags/$VER;rename=kicad-symbols-$VER::https://gitlab.com/kicad/libraries/kicad-symbols \
+      git::commit=tags/$VER;rename=kicad-packages3D-$VER::https://gitlab.com/kicad/libraries/kicad-packages3D \
       tbl::rename=kicad-doc-$VER.tar.gz::https://kicad-downloads.s3.cern.ch/docs/kicad-doc-$VER.tar.gz"
-CHKSUMS="sha256::f0e188c67a1044c6cc884b66b25717326d93ec896194c0963c2fb79b35943d72 \
-         sha256::c344f1bf92d4161845117757197de83b1722391f2830d7d698a5879f6677e884 \
-         sha256::3042b1d9f64f1d96e276361cc99bd695d8c9a88d0cc34a0815d9cc68e7243dfe \
-         sha256::28e53e23b18b434702bcf0c0462f44e7c866f9dd0fed3ab60291057f8bfd7ff9 \
-         sha256::04cad356fd19b46e70eaa6e3365d94c326e4237d80c09394208fd4662e756465 "
+CHKSUMS="SKIP \
+         SKIP \
+         SKIP \
+         SKIP \
+         sha256::04cad356fd19b46e70eaa6e3365d94c326e4237d80c09394208fd4662e756465"
 SUBDIR="kicad-$VER"
 CHKUPDATE="anitya::id=8432"


### PR DESCRIPTION
Topic Description
-----------------

- kicad: fix checksums
    - Use Git tags where applicable, as GitLab seems to have replaced tarballs, causing checksum mismatches.

Package(s) Affected
-------------------

- kicad: 7.0.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit kicad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
