### PR TITLE
telegram-desktop: enable Qt 6

### DIFF
--- a/app-web/telegram-desktop/autobuild/defines
+++ b/app-web/telegram-desktop/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=telegram-desktop
 PKGSEC=web
 PKGDEP="ffmpeg hicolor-icon-theme libnotify minizip abseil-cpp \
-        openal-soft openssl lz4 qt-5 xxhash hunspell libdispatch \
+        openal-soft openssl lz4 qt-6 xxhash hunspell libdispatch \
         libjpeg-turbo opus pulseaudio rnnoise pipewire kcoreaddons \
         glibmm-2.68 fmt ada"
 BUILDDEP="cmake range-v3 python-3 tl-expected microsoft-gsl yasm \
@@ -21,7 +21,7 @@ CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX='/usr' \
              -DDESKTOP_APP_DISABLE_X11_INTEGRATION=OFF \
              -DDESKTOP_APP_USE_PACKAGED=OFF \
              -DDESKTOP_APP_USE_PACKAGED_FONTS=OFF \
-             -DQT_VERSION_MAJOR=5"
+             -DQT_VERSION_MAJOR=6"
 
 ABTYPE=cmakeninja
 

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,4 +1,5 @@
 VER=5.5.3
+REL=1
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=dc17143230b5519f3c1a8da0079e00566bd4c5a8
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \

--- a/desktop-kde/plasma-wayland-protocols/autobuild/defines
+++ b/desktop-kde/plasma-wayland-protocols/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=plasma-wayland-protocols
 PKGSEC=kde
 PKGDEP="wayland-protocols"
-BUILDDEP="extra-cmake-modules qt-5"
+BUILDDEP="extra-cmake-modules qt-6"
 PKGDES="Plasma Specific Protocols for Wayland"
 
-CMAKE_AFTER="-DBUILD_WITH_QT6=OFF \
+CMAKE_AFTER="-DBUILD_WITH_QT6=ON \
              -DKDE_INSTALL_PREFIX_SCRIPT=OFF"
 
 ABSPLITDBG=0

--- a/desktop-kde/plasma-wayland-protocols/spec
+++ b/desktop-kde/plasma-wayland-protocols/spec
@@ -1,4 +1,5 @@
 VER=1.10.0
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma-wayland-protocols/plasma-wayland-protocols-$VER.tar.xz"
 CHKSUMS="sha256::31948867c9a04613e6de0d23adfcbc5acecddef0b39f986b345ec6c1972736fe"
 CHKUPDATE="anitya::id=229050"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: enable Qt 6
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- plasma-wayland-protocols: 1.10.0-1
- telegram-desktop: 4.15.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit plasma-wayland-protocols telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`