### PR TITLE
GOverlay: new, 1.0

### DIFF
--- a/app-utils/goverlay/autobuild/build
+++ b/app-utils/goverlay/autobuild/build
@@ -1,0 +1,8 @@
+abinfo "Building GOverlay ..."
+make
+
+abinfo "Installing GOverlay ..."
+make install \
+    prefix=/usr \
+    DESTDIR="$PKGDIR" \
+    LIBEXECDIR=/usr/lib

--- a/app-utils/goverlay/autobuild/defines
+++ b/app-utils/goverlay/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=goverlay
+PKGSEC=utils
+PKGDEP="mangohud mesa-demos vulkan-tools vkbasalt \
+	replaysorcery qt5pas breeze"
+BUILDDEP="lazarus"
+PKGDES="A GUI application to manage Vulkan/OpenGL overlays"
+
+# FIXME: fpc only works on these architectures
+FAIL_ARCH="!(amd64|arm64|ppc64el)"
+ABSPLITDBG=0

--- a/app-utils/goverlay/spec
+++ b/app-utils/goverlay/spec
@@ -1,0 +1,4 @@
+VER=1.0
+SRCS="git::commit=tags/${VER}::https://github.com/benjamimgois/goverlay"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=344953"

--- a/app-utils/replaysorcery/autobuild/defines
+++ b/app-utils/replaysorcery/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=replaysorcery
+PKGSEC=utils
+PKGDEP="ffmpeg libxcb x11-lib pulseaudio libdrm"
+BUILDDEP="cmake"
+PKGDES="An open-source instant-replay solution"
+
+ABTYPE=cmake

--- a/app-utils/replaysorcery/autobuild/patches/0001-CMakeLists-fix-conf-file-path.patch
+++ b/app-utils/replaysorcery/autobuild/patches/0001-CMakeLists-fix-conf-file-path.patch
@@ -1,0 +1,34 @@
+From e93aef00283b701ed1ec64a5f9bf570744db1bab Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Thu, 7 Mar 2024 00:17:31 -0800
+Subject: [PATCH] CMakeLists: fix conf file path
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3ac6b60..88ac1d2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,6 +4,7 @@ include(CheckCCompilerFlag)
+ include(CheckIncludeFile)
+ include(CheckSymbolExists)
+ include(ExternalProject)
++include(GNUInstallDirs)
+ find_package(PkgConfig REQUIRED)
+ 
+ set(binary replay-sorcery)
+@@ -224,7 +225,7 @@ endif()
+ install(TARGETS ${binary} DESTINATION bin PERMISSIONS ${permissions})
+ 
+ # Install config
+-install(FILES sys/replay-sorcery.conf DESTINATION etc)
++install(FILES sys/replay-sorcery.conf DESTINATION /etc)
+ 
+ # Install services
+ set(RS_SYSTEMD_DIR /usr/lib/systemd CACHE STRING "Where to install the systemd services")
+-- 
+2.44.0
+

--- a/app-utils/replaysorcery/autobuild/prepare
+++ b/app-utils/replaysorcery/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Replacing config.guess and config.sub for submodule libbacktrace ..."
+build_autotools_update_base

--- a/app-utils/replaysorcery/spec
+++ b/app-utils/replaysorcery/spec
@@ -1,0 +1,4 @@
+VER=0.6.0
+SRCS="git::commit=tags/$VER::https://github.com/matanui159/ReplaySorcery"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371704"

--- a/app-utils/vkbasalt/autobuild/defines
+++ b/app-utils/vkbasalt/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=vkbasalt
+PKGSEC=utils
+BUILDDEP="xorg-server glslang vulkan-headers spirv-headers"
+PKGDES="A Vulkan post-processing layer"

--- a/app-utils/vkbasalt/spec
+++ b/app-utils/vkbasalt/spec
@@ -1,0 +1,4 @@
+VER=0.3.2.10
+SRCS="git::commit=tags/v$VER::https://github.com/DadSchoorse/vkBasalt"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=147374"

--- a/lang-pascal/lazarus/01-lazarus/build
+++ b/lang-pascal/lazarus/01-lazarus/build
@@ -15,6 +15,6 @@ desktop-file-install \
 
 abinfo "Setting Lazarus environment options..."
 mkdir -p "$PKGDIR"/etc/lazarus
-sed 's#__LAZARUSDIR__#/usr/lib/lazarus#;s#__FPCSRCDIR__#/usr/lib/fpc/src#' \
+sed 's#__LAZARUSDIR__#/usr/share/lazarus#;s#__FPCSRCDIR__#/usr/lib/fpc/src#' \
      tools/install/linux/environmentoptions.xml \
      > "$PKGDIR"/etc/lazarus/environmentoptions.xml

--- a/lang-pascal/lazarus/spec
+++ b/lang-pascal/lazarus/spec
@@ -1,4 +1,5 @@
 VER=3.2
+REL=1
 SRCS="tbl::https://sourceforge.net/projects/lazarus/files/Lazarus%20Zip%20_%20GZip/Lazarus%20${VER}/lazarus-${VER}-0.tar.gz"
 CHKSUMS="sha256::69f43f0a10b9e09deea5f35094c73b84464b82d3f40d8a2fcfcb5a5ab03c6edf"
 CHKUPDATE="anitya::id=1538"


### PR DESCRIPTION
Topic Description
-----------------

- goverlay: new, 1.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- lazarus: fix LAZARUSDIR
- replaysorcery: new, 0.6.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- vkbasalt: new, 0.3.2.10
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- goverlay: 1.0
- lazarus: 3.2-1
- qt5pas: 3.2-1
- replaysorcery: 0.6.0
- vkbasalt: 0.3.2.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit vkbasalt replaysorcery lazarus goverlay
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
