### PR TITLE
python-3 rework for mips64r6el

### DIFF
--- a/lang-python/python-3/autobuild/defines
+++ b/lang-python/python-3/autobuild/defines
@@ -27,6 +27,9 @@ BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
+# FIXME: GCC prints the wrong multiarch, we used a hack in prepare to address this problem.
+RECONF__MIPS64R6EL=0
+
 AUTOTOOLS_AFTER="--with-computed-gotos \
                  --with-lto \
                  --enable-optimizations \


### PR DESCRIPTION
Topic Description
-----------------

- python-3: fix gcc print wrong multiarch on mips64r6el

Package(s) Affected
-------------------

- python-3: 3.10.13-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit python-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
