### PR TITLE
iperf3: update to 3.16

### DIFF
--- a/app-network/iperf3/spec
+++ b/app-network/iperf3/spec
@@ -1,5 +1,4 @@
-VER=3.7
-SRCS="tbl::https://github.com/esnet/iperf/archive/$VER.tar.gz"
-CHKSUMS="sha256::c349924a777e8f0a70612b765e26b8b94cc4a97cc21a80ed260f65e9823c8fc5"
+VER=3.16
+SRCS="git::commit=tags/$VER::https://github.com/esnet/iperf"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1389"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- iperf3: update to 3.16

Package(s) Affected
-------------------

- iperf3: 3.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit iperf3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
