### PR TITLE
proxychains-ng: update to 4.17

### DIFF
--- a/app-network/proxychains-ng/spec
+++ b/app-network/proxychains-ng/spec
@@ -1,4 +1,4 @@
-VER=4.16
-SRCS="tbl::https://github.com/rofl0r/proxychains-ng/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::5f66908044cc0c504f4a7e618ae390c9a78d108d3f713d7839e440693f43b5e7"
+VER=4.17
+SRCS="git::commit=tags/v$VER::https://github.com/rofl0r/proxychains-ng"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6499"


### PR DESCRIPTION
Topic Description
-----------------

- proxychains-ng: update to 4.17

Package(s) Affected
-------------------

- proxychains-ng: 1:4.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit proxychains-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
