### PR TITLE
colord: update to 1.4.7

### DIFF
--- a/app-admin/colord/autobuild/overrides/usr/lib/sysusers.d/colord.conf
+++ b/app-admin/colord/autobuild/overrides/usr/lib/sysusers.d/colord.conf
@@ -1,0 +1,2 @@
+g    colord  124
+u    colord  124:124 "Color Daemon Owner" /var/lib/colord  /bin/false

--- a/app-admin/colord/autobuild/postinst
+++ b/app-admin/colord/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Setting up colord group and user ..."
+systemd-sysusers colord.conf

--- a/app-admin/colord/autobuild/usergroup
+++ b/app-admin/colord/autobuild/usergroup
@@ -1,2 +1,0 @@
-group colord 124
-user colord 124 colord /var/lib/colord "Color Daemon Owner" /bin/false

--- a/app-admin/colord/spec
+++ b/app-admin/colord/spec
@@ -1,5 +1,4 @@
-VER=1.4.6
-REL=1
-SRCS="tbl::https://github.com/hughsie/colord/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::a1d1ccbd301a75aa79df59c8cda69521db0099db30dc5d297ccc587dd13a37e6"
+VER=1.4.7
+SRCS="git::commit=tags/$VER::https://github.com/hughsie/colord"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10190"


### PR DESCRIPTION
Topic Description
-----------------

- colord: update to 1.4.7 and use sysusers

Package(s) Affected
-------------------

- colord: 1.4.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit colord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
