### PR TITLE
polkit: update to 124

### DIFF
--- a/app-admin/polkit/autobuild/overrides/usr/lib/sysusers.d/polkit.conf
+++ b/app-admin/polkit/autobuild/overrides/usr/lib/sysusers.d/polkit.conf
@@ -1,0 +1,2 @@
+g    polkitd  27
+u    polkitd  27:27 "PolicyKit Daemon Owner" /etc/polkit-1  /bin/false

--- a/app-admin/polkit/autobuild/postinst
+++ b/app-admin/polkit/autobuild/postinst
@@ -1,1 +1,5 @@
+echo "Setting up polkit group and user ..."
+systemd-sysusers polkit.conf
+
+echo "Changing permission of /etc/polkit-1/rules.d ..."
 chown 27:root /etc/polkit-1/rules.d

--- a/app-admin/polkit/autobuild/usergroup
+++ b/app-admin/polkit/autobuild/usergroup
@@ -1,2 +1,0 @@
-group polkitd 27
-user polkitd 27 polkitd /etc/polkit-1 "PolicyKit Daemon Owner" /bin/false

--- a/app-admin/polkit/spec
+++ b/app-admin/polkit/spec
@@ -1,4 +1,4 @@
-VER=122
-SRCS="tbl::https://gitlab.freedesktop.org/polkit/polkit/-/archive/${VER}/polkit-${VER}tar.gz"
-CHKSUMS="sha256::6b65706f47d60d9cb1f8283106373fa6fc2e560ce20072f96e6654cf4444bf64"
+VER=124
+SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/polkit/polkit"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3682"


### PR DESCRIPTION
Topic Description
-----------------

- polkit: update to 124 and use sysusers

Package(s) Affected
-------------------

- polkit: 1:124

Security Update?
----------------

No

Build Order
-----------

```
#buildit polkit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
