### PR TITLE
pulseaudio: update to 17.0

### DIFF
--- a/app-multimedia/pulseaudio/autobuild/beyond
+++ b/app-multimedia/pulseaudio/autobuild/beyond
@@ -7,27 +7,10 @@ sed -e '/autospawn/iautospawn=no' \
 sed -e 's|/usr/bin/pactl load-module module-x11-cork-request|#&|' \
     -i "$PKGDIR"/usr/bin/start-pulseaudio-x11
 
-rm "$PKGDIR"/etc/dbus-1/system.d/pulseaudio-system.conf
-
-mkdir "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants
-ln -s ../pulseaudio.socket \
+mkdir -v "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants
+ln -vs ../pulseaudio.socket \
       "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants/pulseaudio.socket
 
 # FIXME: GDM does not release A2DP socket.
 # Note: gdm daemon owner GID/UID are both 771.
 setfacl -m u:771:r "$PKGDIR"/usr/bin/pulseaudio
-
-abinfo "Going to building advanced bluetooth module (pulseaudio-modules-bt)..."
-cd "$SRCDIR"/../pulseaudio-modules-bt
-
-abinfo "Setting correct PulseAudio version for pulseaudio-modules-bt..."
-# Since this module uses a submodule to get headers of PulseAudio, the submodule must have same
-# version as this package
-git -C "$SRCDIR"/../pulseaudio-modules-bt/pa checkout v"$PKGVER"
-
-abinfo "Building pulseaudio-modules-bt..."
-mkdir "$SRCDIR"/../pulseaudio-modules-bt/build && cd "$SRCDIR"/../pulseaudio-modules-bt/build
-cmake "$CMAKE_DEF" "$CMAKE_AFTER" ..
-make
-abinfo "Installing pulseaudio-modules-bt..."
-make DESTDIR="$PKGDIR" install

--- a/app-multimedia/pulseaudio/autobuild/defines
+++ b/app-multimedia/pulseaudio/autobuild/defines
@@ -5,15 +5,11 @@ PKGDEP="attr avahi bluez dbus fftw json-c libtool soxr orc \
         libsndfile openssl systemd libsamplerate gconf lirc
         libfdk-aac ffmpeg libldac"
 PKGSUG="alsa-plugins"
-BUILDDEP="check intltool pulseaudio"
+BUILDDEP="check intltool doxygen pulseaudio"
 PKGDES="A full featured, general-purpose sound server"
 
-AUTOTOOLS_AFTER="--with-udev-rules-dir=/usr/lib/udev/rules.d \
-                 --with-database=tdb \
-                 --disable-tcpwrap \
-                 --disable-default-build-tests \
-                 --enable-jack \
-                 --enable-samplerate"
+MESON_AFTER="-D udevrulesdir=/usr/lib/udev/rules.d \
+             -D tcpwrap=disabled"
 PKGREP="pulseaudio-modules-bt"
 PKGBREAK="pulseaudio-modules-bt"
 NOLTO=1

--- a/app-multimedia/pulseaudio/autobuild/defines.stage2
+++ b/app-multimedia/pulseaudio/autobuild/defines.stage2
@@ -9,12 +9,8 @@ PKGSUG="alsa-plugins"
 BUILDDEP="check intltool doxygen"
 PKGDES="A full featured, general-purpose sound server"
 
-AUTOTOOLS_AFTER="--with-udev-rules-dir=/usr/lib/udev/rules.d \
-                 --with-database=tdb \
-                 --disable-tcpwrap \
-                 --disable-default-build-tests \
-                 --enable-jack \
-                 --enable-samplerate"
+MESON_AFTER="-D udevrulesdir=/usr/lib/udev/rules.d \
+             -D tcpwrap=disabled"
 PKGREP="pulseaudio-modules-bt"
 PKGBREAK="pulseaudio-modules-bt"
 NOLTO=1

--- a/app-multimedia/pulseaudio/autobuild/overrides/usr/lib/sysusers.d/pulseaudio.conf
+++ b/app-multimedia/pulseaudio/autobuild/overrides/usr/lib/sysusers.d/pulseaudio.conf
@@ -1,0 +1,2 @@
+g    pulse  58
+u    pulse  58:58 "PulseAudio Daemon Owner" /var/run/pulse  /bin/false

--- a/app-multimedia/pulseaudio/autobuild/postinst
+++ b/app-multimedia/pulseaudio/autobuild/postinst
@@ -1,1 +1,5 @@
+echo "Setting up pulseaudio user and group ..."
+systemd-sysusers pulseaudio.conf
+
+echo "Creating temporary directory for pulseaudio ..."
 systemd-tmpfiles --create pulseaudio.conf

--- a/app-multimedia/pulseaudio/autobuild/prepare
+++ b/app-multimedia/pulseaudio/autobuild/prepare
@@ -1,2 +1,0 @@
-# Makefile doesn't seem to be generated properly. Try again next time.
-NOCONFIGURE=1 ./bootstrap.sh

--- a/app-multimedia/pulseaudio/autobuild/usergroup
+++ b/app-multimedia/pulseaudio/autobuild/usergroup
@@ -1,2 +1,0 @@
-group pulse 58
-user pulse 58 pulse /var/run/pulse "PulseAudio Daemon Owner" /bin/false

--- a/app-multimedia/pulseaudio/spec
+++ b/app-multimedia/pulseaudio/spec
@@ -1,7 +1,4 @@
-VER=13.0
-REL=10
-SRCS="tbl::https://freedesktop.org/software/pulseaudio/releases/pulseaudio-$VER.tar.xz \
-      git::commit=b02f9b621cfeaf72c8a0195073355420888d7238;rename=pulseaudio-modules-bt::https://github.com/EHfive/pulseaudio-modules-bt"
-SUBDIR="pulseaudio-$VER"
-CHKSUMS="sha256::961b23ca1acfd28f2bc87414c27bb40e12436efcf2158d29721b1e89f3f28057 SKIP"
+VER=17.0
+SRCS="tbl::https://freedesktop.org/software/pulseaudio/releases/pulseaudio-$VER.tar.xz"
+CHKSUMS="sha256::053794d6671a3e397d849e478a80b82a63cb9d8ca296bd35b73317bb5ceb87b5"
 CHKUPDATE="anitya::id=3729"


### PR DESCRIPTION
Topic Description
-----------------

- pulseaudio: update 17.0 and use sysusers
    pulseaudio-modules-bt has been upstreamed.

Package(s) Affected
-------------------

- pulseaudio: 17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pulseaudio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
