### PR TITLE
libjxl rework for mips64r6el

### DIFF
--- a/runtime-imaging/libjxl/autobuild/defines
+++ b/runtime-imaging/libjxl/autobuild/defines
@@ -10,6 +10,9 @@ PKGDEP__LOONGARCH64="${PKGDEP/gperftools/}"
 BUILDDEP="asciidoc doxygen gdk-pixbuf gimp openjdk xdg-utils"
 PKGDES="Reference encoder and decoder implementation for the JPEG XL image format"
 
+# FIXME: doxygen SIGILLs during asset rendering on mips64r6el.
+# FIXME: Openjdk is not yet available on mips64r6el.
+BUILDDEP__MIPS64R6EL="${BUILDDEP/gimp openjdk/}"
 # FIXME: Disabling skcms. Ain't dealing with this shit, New Year's Eve or
 # otherwise.
 CMAKE_AFTER="-DBROTLI_DISABLE_TESTS=ON \


### PR DESCRIPTION
Topic Description
-----------------

- libjxl: (mips64r6el) remove problematic deps
    Remove gimp and openjdk

Package(s) Affected
-------------------

- libjxl: 0.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjxl
```

Test Build(s) Done
------------------

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
