### PR TITLE
mesa (Mesa 3D Graphics Library): enable xe kernel-mode driver support on non-x86 systems

### DIFF
--- a/runtime-display/mesa/autobuild/defines
+++ b/runtime-display/mesa/autobuild/defines
@@ -69,11 +69,13 @@ MESON_AFTER__X86=" \
 MESON_AFTER__ARM=" \
              ${MESON_AFTER} \
              -Dgallium-drivers=r300,r600,radeonsi,nouveau,iris,virgl,swrast,kmsro,lima,panfrost,freedreno,tegra,vc4,v3d,etnaviv,d3d12,zink,asahi \
-             -Dvulkan-drivers=amd,intel,broadcom,freedreno,panfrost,swrast,virtio"
+             -Dvulkan-drivers=amd,intel,broadcom,freedreno,panfrost,swrast,virtio \
+             -Dintel-xe-kmd=enabled"
 MESON_AFTER__OTHER=" \
              ${MESON_AFTER} \
              -Dgallium-drivers=r300,r600,radeonsi,nouveau,iris,virgl,swrast,zink \
-             -Dvulkan-drivers=amd,intel,swrast,virtio"
+             -Dvulkan-drivers=amd,intel,swrast,virtio \
+             -Dintel-xe-kmd=enabled"
 
 MESON_AFTER__AMD64=" \
              ${MESON_AFTER__X86} \

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,7 +1,7 @@
 MESA_VER=24.0.2
 DXHEADERS_VER=1.611.0
 VER=${MESA_VER}+dxheaders${DXHEADERS_VER}
-REL=1
+REL=2
 SRCS="git::commit=tags/mesa-${MESA_VER/\~/-};rename=mesa-${MESA_VER}::https://gitlab.freedesktop.org/mesa/mesa \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- mesa: enable xe kernel-mode driver support
    This allows Intel cards to be used on non-x86 systems.

Package(s) Affected
-------------------

- mesa: 1:24.0.2+dxheaders1.611.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
