### PR TITLE
Firefox: add two patches to fix download cancellation issue on rv/la

### DIFF
--- a/app-web/firefox/autobuild/patches/0006-riscv64-Keep-unsigned-32-bit-parameter-sign-extended.patch
+++ b/app-web/firefox/autobuild/patches/0006-riscv64-Keep-unsigned-32-bit-parameter-sign-extended.patch
@@ -1,0 +1,32 @@
+From b517970af8b789a0a84548b6f78aac768f037f14 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Fri, 8 Mar 2024 17:24:55 +0800
+Subject: [PATCH 1/2] [riscv64] Keep unsigned 32-bit parameter sign-extended in
+ register.
+
+On riscv64, 32-bit value in 64-bit register should be sign-extended, even
+when it's type is unsigned.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ xpcom/reflect/xptcall/md/unix/xptcinvoke_riscv64.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/xpcom/reflect/xptcall/md/unix/xptcinvoke_riscv64.cpp b/xpcom/reflect/xptcall/md/unix/xptcinvoke_riscv64.cpp
+index ddd66921563c..ee2f7ff76777 100644
+--- a/xpcom/reflect/xptcall/md/unix/xptcinvoke_riscv64.cpp
++++ b/xpcom/reflect/xptcall/md/unix/xptcinvoke_riscv64.cpp
+@@ -48,7 +48,9 @@ extern "C" void invoke_copy_to_stack(uint64_t* gpregs, double* fpregs,
+           value = s->val.u16;
+           break;
+         case nsXPTType::T_U32:
+-          value = s->val.u32;
++          // 32-bit values need to be sign-extended in 64-bit registers,
++          // so use the signed value here.
++          value = s->val.i32;
+           break;
+         case nsXPTType::T_U64:
+           value = s->val.u64;
+-- 
+2.43.0
+

--- a/app-web/firefox/autobuild/patches/0007-loongarch64-Keep-unsigned-32-bit-parameter-sign-exte.patch
+++ b/app-web/firefox/autobuild/patches/0007-loongarch64-Keep-unsigned-32-bit-parameter-sign-exte.patch
@@ -1,0 +1,20 @@
+Origin: https://phabricator.services.mozilla.com/D204011
+diff --git a/xpcom/reflect/xptcall/md/unix/xptcinvoke_loongarch64.cpp b/xpcom/reflect/xptcall/md/unix/xptcinvoke_loongarch64.cpp
+--- a/xpcom/reflect/xptcall/md/unix/xptcinvoke_loongarch64.cpp
++++ b/xpcom/reflect/xptcall/md/unix/xptcinvoke_loongarch64.cpp
+@@ -42,11 +42,13 @@
+           break;
+         case nsXPTType::T_U16:
+           value = s->val.u16;
+           break;
+         case nsXPTType::T_U32:
+-          value = s->val.u32;
++          // 32-bit values need to be sign-extended in 64-bit registers,
++          // so use the signed value here.
++          value = s->val.i32;
+           break;
+         case nsXPTType::T_U64:
+           value = s->val.u64;
+           break;
+         case nsXPTType::T_BOOL:
+

--- a/app-web/firefox/spec
+++ b/app-web/firefox/spec
@@ -1,4 +1,5 @@
 VER=123.0
+REL=1
 CHKUPDATE="anitya::id=5506"
 SRCS="tbl::https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz \
       file::rename=ach.xpi::https://archive.mozilla.org/pub/firefox/releases/$VER/linux-x86_64/xpi/ach.xpi \


### PR DESCRIPTION
Topic Description
-----------------

- firefox: add two patches to fix download cancellation issue on rv/la
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- firefox: 123.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit firefox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
