### PR TITLE
musl: update to 1.12.5

### DIFF
--- a/app-devel/musl/autobuild/defines
+++ b/app-devel/musl/autobuild/defines
@@ -8,3 +8,5 @@ NOSTATIC=0
 # <artificial>:(.text+0x12): undefined reference to `_dlstart_c'
 # collect2: error: ld returned 1 exit status
 NOLTO=1
+# /opt/musl/lib/crtn.o: file not recognized: file format not recognized
+ABSTRIP=0

--- a/app-devel/musl/autobuild/prepare
+++ b/app-devel/musl/autobuild/prepare
@@ -1,2 +1,8 @@
+# handle ppc64el long double width
+if ab_match_arch ppc64el; then
+    abinfo "Setting -mlong-double-64 on ppc64el ..."
+    export CFLAGS="$CFLAGS -mlong-double-64"
+fi
+
 # musl configure doesn't take CPPLAGS and LDFLAGS
 export CFLAGS="$CPPFLAGS $CFLAGS $LDFLAGS" 

--- a/app-devel/musl/spec
+++ b/app-devel/musl/spec
@@ -1,5 +1,4 @@
-VER=1.2.3
+VER=1.2.5
 SRCS="tbl::https://www.musl-libc.org/releases/musl-$VER.tar.gz"
-CHKSUMS="sha256::7d5b0b6062521e4627e099e4c9dc8248d32a30285e959b7eecaa780cf8cfd4a4"
-
+CHKSUMS="sha256::a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4"
 CHKUPDATE="anitya::id=11688"


### PR DESCRIPTION
Topic Description
-----------------

- musl: update to 1.12.5

Package(s) Affected
-------------------

- musl: 1.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit musl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
