### PR TITLE
z3: update to 4.13.0

### DIFF
--- a/app-devel/z3/spec
+++ b/app-devel/z3/spec
@@ -1,5 +1,4 @@
-VER=4.8.10
-SRCS="tbl::https://github.com/Z3Prover/z3/archive/z3-${VER}.tar.gz"
-CHKSUMS="sha256::12cce6392b613d3133909ce7f93985d2470f0d00138837de06cf7eb2992886b4"
+VER=4.13.0
+SRCS="git::commit=tags/z3-$VER::https://github.com/Z3Prover/z3"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7812"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- z3: update to 4.13.0

Package(s) Affected
-------------------

- z3: 4.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit z3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
