### PR TITLE
patchelf: update to 0.18.0

### DIFF
--- a/app-devel/patchelf/spec
+++ b/app-devel/patchelf/spec
@@ -1,5 +1,4 @@
-VER=0.12
-REL=1
-SRCS="tbl::https://github.com/NixOS/patchelf/releases/download/$VER/patchelf-$VER.tar.bz2"
-CHKSUMS="sha256::699a31cf52211cf5ad6e35a8801eb637bc7f3c43117140426400d67b7babd792"
+VER=0.18.0
+SRCS="git::commit=tags/$VER::https://github.com/NixOS/patchelf"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2598"


### PR DESCRIPTION
Topic Description
-----------------

- patchelf: update to 0.18.0

Package(s) Affected
-------------------

- patchelf: 0.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit patchelf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
