### PR TITLE
lynx: update to 2.9.0

### DIFF
--- a/app-web/lynx/spec
+++ b/app-web/lynx/spec
@@ -1,5 +1,4 @@
-VER=2.8.9rel1
-REL=4
+VER=2.9.0
 SRCS="tbl::https://invisible-mirror.net/archives/lynx/tarballs/lynx${VER/rel/rel.}.tar.gz"
-CHKSUMS="sha256::a46e4167b8f02c066d2fe2eafcc5603367be0e3fe2e59e9fc4eb016f306afc8e"
+CHKSUMS="sha256::746c926e28d50571a42d2477f9c50784b27fc8cba4c7db7f3e6c9e00dde89070"
 CHKUPDATE="anitya::id=1863"


### PR DESCRIPTION
Topic Description
-----------------

- lynx: update to 2.9.0

Package(s) Affected
-------------------

- lynx: 1:2.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lynx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
