### PR TITLE
httpie: update to 3.2.2

### DIFF
--- a/app-web/httpie/spec
+++ b/app-web/httpie/spec
@@ -1,4 +1,4 @@
-VER=3.2.1
-SRCS="tbl::https://github.com/jakubroztocil/httpie/archive/$VER.tar.gz"
-CHKSUMS="sha256::803e1624e005c2f7002802a77ebc687b05375aca76af42639f844405328633eb"
+VER=3.2.2
+SRCS="git::commit=tags/$VER::https://github.com/jakubroztocil/httpie"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1337"


### PR DESCRIPTION
Topic Description
-----------------

- httpie: update to 3.2.2

Package(s) Affected
-------------------

- httpie: 3.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit httpie
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
