### PR TITLE
sqlcipher: update to 4.5.6

### DIFF
--- a/app-database/sqlcipher/spec
+++ b/app-database/sqlcipher/spec
@@ -1,5 +1,4 @@
-VER=4.4.2
-SRCS="tbl::https://github.com/sqlcipher/sqlcipher/archive/v$VER.tar.gz"
-CHKSUMS="sha256::87458e0e16594b3ba6c7a1f046bc1ba783d002d35e0e7b61bb6b7bb862f362a7"
+VER=4.5.6
+SRCS="git::commit=tags/v$VER::https://github.com/sqlcipher/sqlcipher"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11213"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- sqlcipher: update to 4.5.6

Package(s) Affected
-------------------

- sqlcipher: 4.5.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit sqlcipher
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
