### PR TITLE
emacs: update to 29.2

### DIFF
--- a/app-editors/emacs/spec
+++ b/app-editors/emacs/spec
@@ -1,5 +1,4 @@
-VER=28.2
-REL=1
+VER=29.2
 SRCS="tbl::https://ftp.gnu.org/gnu/emacs/emacs-$VER.tar.gz"
-CHKSUMS="sha256::a6912b14ef4abb1edab7f88191bfd61c3edd7085e084de960a4f86485cb7cad8"
+CHKSUMS="sha256::ac8773eb17d8b3c0c4a3bccbb478f7c359266b458563f9a5e2c23c53c05e4e59"
 CHKUPDATE="anitya::id=675"


### PR DESCRIPTION
Topic Description
-----------------

- emacs: update to 29.2

Package(s) Affected
-------------------

- emacs: 29.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit emacs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
