### PR TITLE
fcitx5-pinyin-moegirl: update to 20240309

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20231114
+VER=20240309
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::c7e5e401388d30d6dc4a237cecc91146f2a236ecefa66903aed1a4c1d9c8b183 \
-         sha256::c840b5135d67f529323e15bf255a56b92e71a62f1c2eb05c42375e066cc95c9d \
+CHKSUMS="sha256::8abf56400d9ccfc54b2f8ebf19a2d31409cbfc7e6f296ab7b1bcb01d370029bf \
+         sha256::5d4257d2672a5ccd0eedcfbb70640ac30b35c000aa7213fc82c8496ee8406009 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Upgrade `fcitx5-pinyin-moegirl` to 20240309.

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Test Build(s) Done
------------------

- [x] Architecture-independent `noarch`