### PR TITLE
ruby: update to 3.3.0

### DIFF
--- a/lang-ruby/ruby/spec
+++ b/lang-ruby/ruby/spec
@@ -1,4 +1,4 @@
-VER=3.2.2
+VER=3.3.0
 SRCS="tbl::https://cache.ruby-lang.org/pub/ruby/${VER:0:3}/ruby-$VER.tar.xz"
-CHKSUMS="sha256::4b352d0f7ec384e332e3e44cdbfdcd5ff2d594af3c8296b5636c710975149e23"
+CHKSUMS="sha256::676b65a36e637e90f982b57b059189b3276b9045034dcd186a7e9078847b975b"
 CHKUPDATE="anitya::id=4223"


### PR DESCRIPTION
Topic Description
-----------------

- ruby: update to 3.3.0

Package(s) Affected
-------------------

- ruby: 3.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ruby
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
