### PR TITLE
subversion: update to 1.14.3

### DIFF
--- a/app-vcs/subversion/spec
+++ b/app-vcs/subversion/spec
@@ -1,5 +1,4 @@
-VER=1.14.2
-REL=3
+VER=1.14.3
 SRCS="tbl::https://archive.apache.org/dist/subversion/subversion-$VER.tar.gz"
-CHKSUMS="sha256::fd826afad03db7a580722839927dc664f3e93398fe88b66905732c8530971353"
+CHKSUMS="sha256::cf70775e5ed075ebc6a63fe8619dc6b530da254a3f61ba53a502dd83c8f14afc"
 CHKUPDATE="anitya::id=4905"


### PR DESCRIPTION
Topic Description
-----------------

- subversion: update to 1.14.3

Package(s) Affected
-------------------

- subversion: 1.14.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit subversion
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
