### PR TITLE
feh: update to 3.10.2

### DIFF
--- a/app-imaging/feh/autobuild/build
+++ b/app-imaging/feh/autobuild/build
@@ -1,2 +1,2 @@
-make PREFIX=/usr exif=0 help=0 stat64=1
+make PREFIX=/usr exif=1 stat64=1 magic=1 inotify=1
 make PREFIX=/usr DESTDIR="$PKGDIR" install

--- a/app-imaging/feh/autobuild/defines
+++ b/app-imaging/feh/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=feh
 PKGSEC=graphics
-PKGDEP="imlib2"
-PKGDES="Fast and light imlib2 based image viewer"
+PKGDEP="imlib2 curl libpng x11-lib libexif file"
+PKGDES="A light-weight, configurable and versatile image viewer"

--- a/app-imaging/feh/spec
+++ b/app-imaging/feh/spec
@@ -1,4 +1,4 @@
-VER=3.8
+VER=3.10.2
 SRCS="tbl::https://feh.finalrewind.org/feh-$VER.tar.bz2"
-CHKSUMS="sha256::7f3c34552b39336d7ebee2d7c4bf5697aaaa2c6c102c357f6e82ea240bd62ba9"
+CHKSUMS="sha256::5f94a77de25c5398876f0cf431612d782b842f4db154d2139b778c8f196e8969"
 CHKUPDATE="anitya::id=790"


### PR DESCRIPTION
Topic Description
-----------------

- feh: update to 3.10.2
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- feh: 3.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit feh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
