### PR TITLE
sysctl.conf rework 20240309

### DIFF
--- a/app-admin/systemd/autobuild/beyond
+++ b/app-admin/systemd/autobuild/beyond
@@ -42,3 +42,9 @@ if ab_match_archgroup retro; then
         done
     )
 fi
+
+# systemd-sysctl only reads /etc/sysctl.d, but not /etc/sysctl.conf
+# However, procps reads both and the latter takes precedence
+# In order to reduce confusion, create symlink to align the behavior
+abinfo "Creating symlink for systemd-sysctl to read /etc/sysctl.conf ..."
+ln -svf ../sysctl.conf "$PKGDIR"/etc/sysctl.d/99-sysctl.conf

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,4 +1,5 @@
 VER=255.3
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd-stable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205088"

--- a/app-utils/procps/autobuild/patches/0001-src-watch_c-fix-ncurses_h-include.patch
+++ b/app-utils/procps/autobuild/patches/0001-src-watch_c-fix-ncurses_h-include.patch
@@ -1,6 +1,8 @@
---- procps-v4.0.2/src/watch.c   2022-12-05 02:04:05.000000000 -0800
-+++ procps-v4.0.2.ncurses/src/watch.c   2022-12-15 18:02:42.417425213 -0800
-@@ -52,7 +52,7 @@
+diff --git a/src/watch.c b/src/watch.c
+index 5c159a95..8bebc867 100644
+--- a/src/watch.c
++++ b/src/watch.c
+@@ -53,7 +53,7 @@
  # define _XOPEN_SOURCE_EXTENDED 1
  # include <wchar.h>
  # include <wctype.h>
@@ -8,5 +10,4 @@
 +# include <ncurses.h>
  #else
  # include <ncurses.h>
- #endif /* WITH_WATCH8BIT */
-
+ #endif	/* WITH_WATCH8BIT */

--- a/app-utils/procps/autobuild/patches/0002-comment-out-pid-limit.patch
+++ b/app-utils/procps/autobuild/patches/0002-comment-out-pid-limit.patch
@@ -1,0 +1,13 @@
+diff --git a/sysctl.conf b/sysctl.conf
+index e846a57d..5fed3529 100644
+--- a/sysctl.conf
++++ b/sysctl.conf
+@@ -56,7 +56,7 @@ net/ipv4/icmp_echo_ignore_broadcasts =1
+ 
+ # This limits PID values to 4 digits, which allows tools like ps
+ # to save screen space.
+-kernel/pid_max=10000
++#kernel/pid_max=10000
+ 
+ # Protects against creating or following links under certain conditions
+ # See https://www.kernel.org/doc/Documentation/sysctl/fs.txt

--- a/app-utils/procps/spec
+++ b/app-utils/procps/spec
@@ -1,4 +1,4 @@
-VER=4.0.2
+VER=4.0.4
 SRCS="https://gitlab.com/procps-ng/procps/-/archive/v$VER/procps-v$VER.tar.gz"
-CHKSUMS="sha256::b03e4b55eaa5661e726acb714e689356d80bc056b09965c2284d039ba8dc21e8"
+CHKSUMS="sha256::3214fab0f817d169f2c117842ba635bafb1cd6090273e311a8b5c6fc393ddb9d"
 CHKUPDATE="anitya::id=3708"


### PR DESCRIPTION
Topic Description
-----------------

- systemd: create 99-sysctl.conf symlink for compatibility with procps
- procps: update to 4.0.4 and remove pid_max config by default

Package(s) Affected
-------------------

- systemd: 1:255.3-1
- procps: 4.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit procps systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
