### PR TITLE
NVIDIA driver 550.54.14 + CUDA 12.4

### DIFF
--- a/app-devel/cuda/spec
+++ b/app-devel/cuda/spec
@@ -1,10 +1,10 @@
-CUDA_VER=12.3.2
-MIN_DRIVER_VER=545.23.08
+CUDA_VER=12.4.0
+MIN_DRIVER_VER=550.54.14
 VER=${CUDA_VER}+${MIN_DRIVER_VER}
 CHKUPDATE="anitya::id=13462"
 
 SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS__AMD64="sha256::24b2afc9f770d8cf43d6fa7adc2ebfd47c4084db01bdda1ce3ce0a4d493ba65b"
+CHKSUMS__AMD64="sha256::e6a842f4eca9490575cdb68b6b1bb78d47b95a897de48dee292c431892e57d17"
 
 SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
-CHKSUMS__ARM64="sha256::761b84e292b94c4d330f445d36326dfff90a418e909fb0baf3d6f03e24106d08"
+CHKSUMS__ARM64="sha256::b12bfe6c36d32ecf009a6efb0024325c5fc389fca1143f5f377ae2555936e803"

--- a/runtime-display/nvidia/autobuild/build
+++ b/runtime-display/nvidia/autobuild/build
@@ -1,5 +1,4 @@
 # vim: set expandtab sts=4 ts=4 sw=4:
-set +e
 
 create_links() {
     # FIXME: libglxserver_nvidia.so has no soname so this function won't create a symlink for it
@@ -23,6 +22,8 @@ install_for_all() {
     return $?
 }
 
+NEED_FIX=0
+
 install_if_amd64() {
     MOD="$1"
     SRC="$2"
@@ -33,7 +34,8 @@ install_if_amd64() {
     elif [[ -f "${SRC}" ]]; then
         # Make sure the file really doesn't exist
         aberr "File $SRC exists for non-amd64. Fix build scripts!"
-        abdie
+        # Set fail flag. Catch all errors in one go
+        NEED_FIX=1
     fi
     return 0
 }
@@ -70,13 +72,17 @@ case "$ABHOST" in
 esac
 
 
-cd NVIDIA-Linux-${NV_ARCH}-${PKGVER}
+cd "$SRCDIR"/NVIDIA-Linux-${NV_ARCH}-${PKGVER}
 
-abinfo "Patching kernel driver"
-for i in "${SRCDIR}/autobuild/patches/"*.patch; do
-	abinfo "Applying $(basename $i)"
-	(cd kernel; patch -Np1 -i "$i")
-done
+if [[ -d "${SRCDIR}/autobuild/patches" ]]; then
+    abinfo "Patching kernel driver"
+    for i in $(find "${SRCDIR}/autobuild/patches/" -type f -name "*.patch" | sort); do
+        abinfo "Applying $(basename $i)"
+        (cd kernel; patch -Np1 -i "$i")
+    done
+else
+    abinfo "No kernel patches needed"
+fi
 
 cd kernel
 
@@ -156,7 +162,7 @@ abinfo "Nvidia GPU control APIs"
 install_for_all 755 "libnvidia-api.so.1" "$PKGDIR"/usr/lib
 
 abinfo "Wayland support libraries and platform files..."
-install_for_all 755 "libnvidia-egl-gbm.so.1.1.0" "$PKGDIR"/usr/lib
+install_for_all 755 "libnvidia-egl-gbm.so.1.1.1" "$PKGDIR"/usr/lib
 install_if_amd64 755 "libnvidia-wayland-client.so.$PKGVER" "$PKGDIR"/usr/lib
 install -Dvm644 "15_nvidia_gbm.json" \
     "$PKGDIR"/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
@@ -259,25 +265,31 @@ install -Dvm644 nvidia-application-profiles-$PKGVER-key-documentation \
     "$PKGDIR"/usr/share/nvidia/nvidia-application-profiles-$PKGVER-key-documentation
 
 abinfo "NVIDIA Control Panel..."
-install -Dvm755 nvidia-settings "$PKGDIR"/usr/bin/nvidia-settings
-install -Dvm644 nvidia-settings.1.gz "$PKGDIR"/usr/share/man/man1/nvidia-settings.1.gz
-install -Dvm644 nvidia-settings.png "$PKGDIR"/usr/share/pixmaps/nvidia-settings.png
-install -Dvm755 libnvidia-gtk2.so.$PKGVER "$PKGDIR"/usr/lib/libnvidia-gtk2.so.$PKGVER
-install_if_amd64 755 "libnvidia-gtk3.so.$PKGVER" "$PKGDIR"/usr/lib
+install_for_all 755 nvidia-settings "$PKGDIR"/usr/bin
+install_for_all 644 nvidia-settings.1.gz "$PKGDIR"/usr/share/man/man1
+install_for_all 644 nvidia-settings.png "$PKGDIR"/usr/share/pixmaps
+install_for_all 755 libnvidia-gtk2.so.$PKGVER "$PKGDIR"/usr/lib
+install_for_all 755 libnvidia-gtk3.so.$PKGVER "$PKGDIR"/usr/lib
 
 abinfo "Power management services"
 for i in suspend hibernate resume; do
-	install_for_all 644 systemd/system/nvidia-${i}.service "$PKGDIR"/usr/lib/systemd/system/nvidia-${i}.service
+    install_for_all 644 systemd/system/nvidia-${i}.service \
+        "$PKGDIR"/usr/lib/systemd/system/nvidia-${i}.service
 done
 install_for_all 755 systemd/system-sleep/nvidia "$PKGDIR"/usr/lib/systemd/system-sleep/nvidia
 install_for_all 755 systemd/nvidia-sleep.sh "$PKGDIR"/usr/bin/nvidia-sleep.sh
-install_if_amd64 755 nvidia-powerd "${PKGDIR}/usr/bin"
-install_if_amd64 644 nvidia-dbus.conf "${PKGDIR}/usr/share/dbus-1/system.d"
-install_if_amd64 644 systemd/system/nvidia-powerd.service "$PKGDIR"/usr/lib/systemd/system
+install_for_all 755 nvidia-powerd "${PKGDIR}/usr/bin"
+install_for_all 644 nvidia-dbus.conf "${PKGDIR}/usr/share/dbus-1/system.d"
+install_for_all 644 systemd/system/nvidia-powerd.service "$PKGDIR"/usr/lib/systemd/system
 
 abinfo "Card Firmware"
 install_for_all 644 firmware/gsp_ga10x.bin "${PKGDIR}"/usr/lib/firmware/nvidia/${PKGVER}
 install_for_all 644 firmware/gsp_tu10x.bin "${PKGDIR}"/usr/lib/firmware/nvidia/${PKGVER}
+
+if ((NEED_FIX)); then
+    aberr "Additional files should be installed. See errors above."
+    abdir
+fi
 
 sanity_check "${PKGDIR}/usr/"
 
@@ -302,9 +314,8 @@ install -Dvm644 "$SRCDIR"/nvidia-settings-*/src/libXNVCtrl/*.h \
     -t "$PKGDIR"/usr/include/NVCtrl
 
 if [[ $NV_ARCH == "x86_64" ]]; then
-	abinfo "Installing optenv32 libraries"
-	pushd "${SRCDIR}"
-	source "${SRCDIR}/autobuild/build-optenv32"
-	popd
+    abinfo "Installing optenv32 libraries"
+    pushd "${SRCDIR}"
+    source "${SRCDIR}/autobuild/build-optenv32"
+    popd
 fi
-

--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,4 +1,4 @@
-VER=545.29.06
+VER=550.54.14
 _SETTINGS_VER=${VER}
 
 SRCS__AMD64="
@@ -6,8 +6,8 @@ SRCS__AMD64="
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__AMD64="
-	sha256::82bc55676add43416c146e70c624c8dc6af16cc04c7238680c56a30e0045b17b
-	sha256::1e1bcd2049413bab0e0c3bbd57b176e847bc492d3b45b884426f52c912ece149
+	sha256::8c497ff1cfc7c310fb875149bc30faa4fd26d2237b2cba6cd2e8b0780157cfe3
+	sha256::c1e163ea047d04c2bfdc5e48e3666d79af51cd0b36f3e731c5b2877920b678d6
 "
 
 SRCS__ARM64="
@@ -15,8 +15,8 @@ SRCS__ARM64="
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__ARM64="
-	sha256::a3a6528cce201dca2d15efa78454de3cf9579b4f9115feb8752203b7e46679e4
-	sha256::1e1bcd2049413bab0e0c3bbd57b176e847bc492d3b45b884426f52c912ece149
+	sha256::b0fae8061633885c24f6b0c047649b46249a3bb44cadffbf658af28f80642c1d
+	sha256::c1e163ea047d04c2bfdc5e48e3666d79af51cd0b36f3e731c5b2877920b678d6
 "
 
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

This PR updates nvidia drivers and cuda to support using nvcc with GCC 13.

Package(s) Affected
-------------------

Build Order
-----------

```
#buildit nvidia cuda
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`