### PR TITLE
Qt5ct, Qt6ct Survey 20240310

### DIFF
--- a/app-utils/qt5ct/autobuild/beyond
+++ b/app-utils/qt5ct/autobuild/beyond
@@ -1,3 +1,3 @@
-install -d "$PKGDIR"/usr/share/qt5ct/translations
-install -D -pm 644 src/qt5ct/translations/*.qm \
+install -dv "$PKGDIR"/usr/share/qt5ct/translations
+install -Dvpm 644 src/qt5ct/translations/*.qm \
     "$PKGDIR"/usr/share/qt5ct/translations/

--- a/app-utils/qt5ct/autobuild/beyond
+++ b/app-utils/qt5ct/autobuild/beyond
@@ -1,3 +1,4 @@
+abinfo "Installing localization files ..."
 install -dv "$PKGDIR"/usr/share/qt5ct/translations
-install -Dvpm 644 src/qt5ct/translations/*.qm \
+install -Dvpm 644 "$SRCDIR"/src/qt5ct/translations/*.qm \
     "$PKGDIR"/usr/share/qt5ct/translations/

--- a/app-utils/qt5ct/spec
+++ b/app-utils/qt5ct/spec
@@ -1,5 +1,4 @@
-VER=1.1
+VER=1.8
 SRCS="tbl::https://downloads.sourceforge.net/project/qt5ct/qt5ct-$VER.tar.bz2"
-CHKSUMS="sha256::af77c4dbf7f9ba97fe0218648167395bca7bcb2b9c1886a9c98b1e343127ddd2"
-REL=3
+CHKSUMS="sha256::23b74054415ea4124328772ef9a6f95083a9b86569e128034a3ff75dfad808e9"
 CHKUPDATE="anitya::id=10638"

--- a/app-utils/qt6ct/spec
+++ b/app-utils/qt6ct/spec
@@ -1,4 +1,4 @@
-VER=0.5
-SRCS="tbl::https://github.com/trialuser02/qt6ct/releases/download/0.5/qt6ct-$VER.tar.xz"
-CHKSUMS="sha256::db3cbed576e90a41babf24827886451ff0c6d9baee337b2a1b058e90441f9bbd"
+VER=0.9
+SRCS="git::commit=tags/${VER}::https://github.com/trialuser02/qt6ct"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=288166"


### PR DESCRIPTION
Topic Description
-----------------

- qt6ct: update to 0.9
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- qt5ct: update to 1.8
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- qt5ct: 1.8
- qt6ct: 0.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt5ct qt6ct
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
