### PR TITLE
vasm: update to 1.9f

### DIFF
--- a/app-devel/vasm/spec
+++ b/app-devel/vasm/spec
@@ -1,4 +1,4 @@
-VER=1.8l
+VER=1.9f
 SRCS="tbl::http://sun.hasenbraten.de/vasm/release/vasm.tar.gz"
-CHKSUMS="sha256::ea0c340b350d8fe8ac36017668b4593cc5fed945cc024944c7f7eed2cb58fdf8"
+CHKSUMS="sha256::a09d4ff3b5ec50bb7538fb97b9539141376580b590586463569783c36438ebe8"
 CHKUPDATE="anitya::id=234716"


### PR DESCRIPTION
Topic Description
-----------------

- vasm: update to 1.9f

Package(s) Affected
-------------------

- vasm: 1.9f

Security Update?
----------------

No

Build Order
-----------

```
#buildit vasm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
