### PR TITLE
Kvantum: update to 1.0.10, enable Qt 6 support

### DIFF
--- a/desktop-kde/kvantum/autobuild/build
+++ b/desktop-kde/kvantum/autobuild/build
@@ -1,0 +1,14 @@
+abinfo "Building Qt 5 support and manager ..."
+cmake -B "$BLDDIR"/build5 -S "$SRCDIR" \
+    -DCMAKE_INSTALL_PREFIX=/usr
+make -C "$BLDDIR"/build5
+
+abinfo "Building Qt 6 support ..."
+cmake -B "$BLDDIR"/build6 -S "$SRCDIR" \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DENABLE_QT5=OFF
+make -C "$BLDDIR"/build6
+
+abinfo "Installing Kvantum ..."
+DESTDIR="$PKGDIR" cmake --install "$BLDDIR"/build5
+DESTDIR="$PKGDIR" cmake --install "$BLDDIR"/build6

--- a/desktop-kde/kvantum/autobuild/defines
+++ b/desktop-kde/kvantum/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=kvantum
 PKGSEC=kde
-PKGDEP="qt-5 kwindowsystem"
+PKGDEP="qt-5 qt-6 kwindowsystem xorg-server"
 PKGDES="An SVG-based theme engine for Qt/KDE/LxQt"
 
-ABTYPE=cmakeninja
+ABSHADOW=1

--- a/desktop-kde/kvantum/spec
+++ b/desktop-kde/kvantum/spec
@@ -1,5 +1,5 @@
-VER=1.0.3
+VER=1.0.10
 SRCS="tbl::https://github.com/tsujan/Kvantum/archive/V$VER.tar.gz"
-CHKSUMS="sha256::87222a5e7b452cfde367638dab89740cf559075579e10f11178db731957f7fb3"
+CHKSUMS="sha256::2ef368df6c54a3bde2097ed89341f188b6670d1b1f8d11bcb3a80138887aca12"
 CHKUPDATE="anitya::id=17749"
 SUBDIR="Kvantum-$VER/Kvantum"


### PR DESCRIPTION
Topic Description
-----------------

- kvantum: update to 1.0.10, enable Qt 6 support
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- kvantum: 1.0.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit kvantum
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
