### PR TITLE
bzip3: new, 1.4.0

### DIFF
--- a/app-utils/bzip3/autobuild/defines
+++ b/app-utils/bzip3/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=bzip3
+PKGSEC=utils
+PKGDES="A text-optimized compression program and library suite"
+PKGDEP="glibc"

--- a/app-utils/bzip3/spec
+++ b/app-utils/bzip3/spec
@@ -1,0 +1,4 @@
+VER=1.4.0
+SRCS="git::commit=tags/$VER::https://github.com/kspalaiologos/bzip3"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=301351"


### PR DESCRIPTION
Topic Description
-----------------

- bzip3: new, 1.4.0

Package(s) Affected
-------------------

- bzip3: 1.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bzip3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
