### PR TITLE
feeluown: update to 4.1.1

### DIFF
--- a/app-multimedia/feeluown-netease/spec
+++ b/app-multimedia/feeluown-netease/spec
@@ -1,4 +1,4 @@
-VER=1.0
+VER=1.0.1
 SRCS="git::commit=v${VER}::https://github.com/feeluown/feeluown-netease"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=33792"

--- a/app-multimedia/feeluown-qqmusic/autobuild/defines
+++ b/app-multimedia/feeluown-qqmusic/autobuild/defines
@@ -2,6 +2,8 @@ PKGNAME=feeluown-qqmusic
 PKGSEC=sound
 PKGDES="FeelUOwn plugin for QQMusic"
 PKGDEP="feeluown python-3 marshmallow requests"
+PKGRECOM="pyqtwebengine"
+
 PKGBREAK="fuocore<=2.3-2"
 PKGREP="fuocore<=2.3-2"
 

--- a/app-multimedia/feeluown-qqmusic/spec
+++ b/app-multimedia/feeluown-qqmusic/spec
@@ -1,4 +1,4 @@
-VER=1.0.1
+VER=1.0.2
 SRCS="git::commit=tags/v$VER::https://github.com/feeluown/feeluown-qqmusic"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=33797"

--- a/app-multimedia/feeluown/autobuild/defines
+++ b/app-multimedia/feeluown/autobuild/defines
@@ -4,7 +4,8 @@ PKGDES="A universal player for various music streaming services"
 PKGRECOM="feeluown-bilibili feeluown-kuwo feeluown-netease feeluown-qqmusic feeluown-ytmusic"
 
 PKGDEP="python-3 requests tomlkit typing-extensions qasync \
-	janus pyqt5 pyopengl pydantic mpv mutagen yt-dlp"
+	janus pyqt5 pyopengl pydantic mpv mutagen yt-dlp \
+	secretstorage"
 
 
 PKGBREAK="fuocore feeluown-local feeluown-xiami"

--- a/app-multimedia/feeluown/spec
+++ b/app-multimedia/feeluown/spec
@@ -1,4 +1,4 @@
-VER=4.1
+VER=4.1.1
 SRCS="git::commit=tags/v$VER::https://github.com/feeluown/FeelUOwn"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=33791"


### PR DESCRIPTION
Topic Description
-----------------

- feeluown: add dependency `secretstorage`
- feeluown-qqmusic: update to 1.0.2
- feeluown-netease: update to 1.0.1
- feeluown: update to 4.1.1

Package(s) Affected
-------------------

- feeluown-netease: 1.0.1
- feeluown: 1:4.1.1
- feeluown-qqmusic: 1.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit feeluown feeluown-netease feeluown-qqmusic
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
