### PR TITLE
darktable: update to 4.6.1

### DIFF
--- a/app-creativity/darktable/autobuild/defines
+++ b/app-creativity/darktable/autobuild/defines
@@ -4,29 +4,52 @@ PKGDEP="colord-gtk dbus-glib exiv2 flickcurl graphicsmagick gtk-3 \
         json-glib lcms2 lensfun libglade libgphoto2 libjpeg-turbo \
         librsvg libsecret libsoup libtiff libwebp iso-codes\
         libxslt openexr openjpeg pugixml sdl sqlite libosmgpsmap \
-        libcl jasper gmic lua-5.4 libheif libavif portmidi"
-BUILDDEP="cmake gnome-doc-utils intltool po4a llvm"
+        libcl jasper gmic lua-5.4 libheif libavif portmidi \
+        libcamera"
+BUILDDEP="cmake gnome-doc-utils intltool po4a llvm sphinx doxygen"
 PKGDES="Utility to organize and develop raw images"
 
-CMAKE_AFTER="-DBINARY_PACKAGE_BUILD=1 \
-             -DBUILD_USERMANUAL=ON \
-             -DUSE_LIBSECRET=ON \
-             -DUSE_GNOME_KEYRING=OFF \
-             -DUSE_LUA=ON \
-             -DUSE_COLORD=ON \
-             -DRAWSPEED_ENABLE_LTO=ON \
-             -DCMAKE_SKIP_RPATH=OFF \
-             -DDONT_USE_INTERNAL_LUA=OFF"
-CMAKE_AFTER__NONX86=" \
-             ${CMAKE_AFTER} \
-             -DBUILD_SSE2_CODEPATHS=OFF \
-             -DUSE_OPENCL=OFF"
-CMAKE_AFTER__ARM64=" \
-             ${CMAKE_AFTER__NONX86}"
-CMAKE_AFTER__LOONGSON3=" \
-             ${CMAKE_AFTER__NONX86}"
-CMAKE_AFTER__PPC64EL=" \
-             ${CMAKE_AFTER__NONX86}"
+CMAKE_AFTER=(
+	-DBINARY_PACKAGE_BUILD=ON
+	-DBUILD_BATTERY_INDICATOR=ON
+	-DBUILD_CURVE_TOOLS=ON
+	-DBUILD_DOCS=ON
+	-DBUILD_NOISE_TOOLS=ON
+	-DBUILD_PRINT=ON
+	-DBUILD_RS_IDENTIFY=ON
+	-DBUILD_SHARED_LIBS=ON
+	-DBUILD_SSE2_CODEPATHS=OFF
+	-DBUILD_TOOLS=ON
+	-DCMAKE_SKIP_RPATH=OFF
+	-DDONT_USE_INTERNAL_LUA=ON
+	-DUSE_AVIF=ON
+	-DUSE_CAMERA_SUPPORT=ON
+	-DUSE_COLORD=ON
+	-DUSE_GAME=OFF
+	-DUSE_GNOME_KEYRING=OFF
+	-DUSE_HEIF=ON
+	-DUSE_LIBSECRET=ON
+	-DUSE_LUA=ON
+	-DUSE_OPENCL=OFF
+	-DRAWSPEED_ENABLE_LTO=ON
+)
+CMAKE_AFTER__SSE=(
+	-DBUILD_SSE2_CODEPATHS=ON
+)
+CMAKE_AFTER__CL=(
+	-DUSE_OPENCL=ON
+)
+
+
+CMAKE_AFTER__AMD64=(
+	"${CMAKE_AFTER[@]}"
+	"${CMAKE_AFTER__SSE[@]}"
+	"${CMAKE_AFTER__CL[@]}"
+)
+CMAKE_AFTER__ARM64=(
+	"${CMAKE_AFTER[@]}"
+	"${CMAKE_AFTER__CL[@]}"
+)
 
 PKGEPOCH=1
 NOLTO__PPC64EL=1

--- a/app-creativity/darktable/autobuild/patches/0001-common-guided_filter-remove-broken-ifdefs-on-ppc.patch
+++ b/app-creativity/darktable/autobuild/patches/0001-common-guided_filter-remove-broken-ifdefs-on-ppc.patch
@@ -1,12 +1,11 @@
-From 457673302fc75fc6dba78c8a4a18b87e25e6f462 Mon Sep 17 00:00:00 2001
+From 00afe5689ec638db5d46336240db9946e44c14af Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Tue, 20 Dec 2022 01:01:11 -0500
-Subject: [PATCH] common/guided_filter: remove broken ifdefs on ppc
+Subject: [PATCH 1/2] common/guided_filter: remove broken ifdefs on ppc
 
 ---
- src/common/sse.h      | 4 +++-
- src/tests/integration | 2 +-
- 2 files changed, 4 insertions(+), 2 deletions(-)
+ src/common/sse.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/src/common/sse.h b/src/common/sse.h
 index f7609add9a..45d9c8e461 100644
@@ -24,5 +23,5 @@ index f7609add9a..45d9c8e461 100644
  
  
 -- 
-2.39.1
+2.44.0
 

--- a/app-creativity/darktable/autobuild/patches/0002-fix-building-for-mips64-and-loongarch64.patch
+++ b/app-creativity/darktable/autobuild/patches/0002-fix-building-for-mips64-and-loongarch64.patch
@@ -1,20 +1,26 @@
-From 913ccb6e186a412c75dc27cf3d1a3365479fd1b2 Mon Sep 17 00:00:00 2001
+From fe2144cd2647757ce96a326872b47cea41f8e9e6 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Tue, 20 Dec 2022 01:04:49 -0500
-Subject: [PATCH] fix building for mips64
+Subject: [PATCH 2/2] fix building for mips64 and loongarch64
 
 ---
- src/is_supported_platform.h | 11 +++++++++--
- 1 file changed, 9 insertions(+), 2 deletions(-)
+ src/is_supported_platform.h | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
 
 diff --git a/src/is_supported_platform.h b/src/is_supported_platform.h
-index 03a77f704d..9d418d3c5f 100644
+index 03a77f704d..275c12a28d 100644
 --- a/src/is_supported_platform.h
 +++ b/src/is_supported_platform.h
-@@ -36,6 +36,12 @@
+@@ -36,6 +36,18 @@
  #define DT_SUPPORTED_ARMv8A 0
  #endif
  
++#if defined(__loongarch__) && __loongarch_grlen == 64
++#define DT_SUPPORTED_LOONGARCH64 1
++#else
++#define DT_SUPPORTED_LOONGARCH64 0
++#endif
++
 +#if defined(__mips__) && defined(__mips64)
 +#define DT_SUPPORTED_MIPS64 1
 +#else
@@ -24,17 +30,17 @@ index 03a77f704d..9d418d3c5f 100644
  #if defined(__PPC64__)
  #define DT_SUPPORTED_PPC64 1
  #else
-@@ -48,16 +54,17 @@
+@@ -48,16 +60,17 @@
  #define DT_SUPPORTED_RISCV64 0
  #endif
  
 -#if (DT_SUPPORTED_X86 + DT_SUPPORTED_ARMv8A + DT_SUPPORTED_PPC64 + DT_SUPPORTED_RISCV64) > 1
-+#if (DT_SUPPORTED_X86 + DT_SUPPORTED_ARMv8A + DT_SUPPORTED_MIPS64 + DT_SUPPORTED_PPC64 + DT_SUPPORTED_RISCV64) > 1
++#if (DT_SUPPORTED_X86 + DT_SUPPORTED_ARMv8A + DT_SUPPORTED_LOONGARCH64 + DT_SUPPORTED_MIPS64 + DT_SUPPORTED_PPC64 + DT_SUPPORTED_RISCV64) > 1
  #error "Looks like hardware platform detection macros are broken?"
  #endif
  
 -#if !DT_SUPPORTED_X86 && !DT_SUPPORTED_ARMv8A && !DT_SUPPORTED_PPC64 && !DT_SUPPORTED_RISCV64
-+#if !DT_SUPPORTED_X86 && !DT_SUPPORTED_ARMv8A && !DT_SUPPORTED_MIPS64 && !DT_SUPPORTED_PPC64 && !DT_SUPPORTED_RISCV64
++#if !DT_SUPPORTED_X86 && !DT_SUPPORTED_ARMv8A && !DT_SUPPORTED_LOONGARCH64 && !DT_SUPPORTED_MIPS64 && !DT_SUPPORTED_PPC64 && !DT_SUPPORTED_RISCV64
  #error "Unfortunately we only work on amd64, ARMv8-A, PPC64 (64-bit little-endian only) and riscv64"
  #endif
  
@@ -45,5 +51,5 @@ index 03a77f704d..9d418d3c5f 100644
  #undef DT_SUPPORTED_X86
  
 -- 
-2.39.1
+2.44.0
 

--- a/app-creativity/darktable/spec
+++ b/app-creativity/darktable/spec
@@ -1,4 +1,4 @@
-VER=4.4.1
-SRCS="tbl::https://github.com/darktable-org/darktable/releases/download/release-$VER/darktable-$VER.tar.xz"
-CHKSUMS="sha256::e043d38d2e8adb67af7690b12b535a40e8ec7bea05cfa8684db8b21a626e0f0d"
+VER=4.6.1
+SRCS="git::commit=tags/release-$VER::https://github.com/darktable-org/darktable"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=392"

--- a/runtime-devices/lensfun/spec
+++ b/runtime-devices/lensfun/spec
@@ -1,4 +1,4 @@
-VER=0.3.3
-SRCS="tbl::https://github.com/lensfun/lensfun/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::57ba5a0377f24948972339e18be946af12eda22b7c707eb0ddd26586370f6765"
+VER=0.3.4
+SRCS="git::commit=tags/v$VER::https://github.com/lensfun/lensfun"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1548"


### PR DESCRIPTION
Topic Description
-----------------

- darktable: update to 4.6.1
- lensfun: update to 0.3.4

Package(s) Affected
-------------------

- lensfun: 1:0.3.4
- darktable: 1:4.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lensfun darktable
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
