### PR TITLE
fim: update to 0.7-trunk

### DIFF
--- a/app-utils/fim/autobuild/defines
+++ b/app-utils/fim/autobuild/defines
@@ -1,13 +1,15 @@
 PKGNAME=fim
 PKGSEC=utils
-PKGDEP="djvulibre giflib libjpeg-turbo libspectre poppler sdl libexif"
+PKGDEP="djvulibre giflib gtk-3 libexif libjpeg-turbo libspectre poppler sdl"
 PKGDES="Fbi IMproved - a framebuffer image viewer"
 
+# FIXME: Fim cannot find rule to make target 'FbiStuffAVIF.o'
 AUTOTOOLS_AFTER="--enable-hardcoded-font \
                  --disable-xcftopnm \
                  --disable-inkscape \
                  --disable-xfig \
                  --disable-dia \
+                 --disable-avif \
                  --disable-imlib2 \
                  LIBS=-lSDL"
 

--- a/app-utils/fim/autobuild/patches/0001-configure.ac-link-libwebp-with-lwebp.patch
+++ b/app-utils/fim/autobuild/patches/0001-configure.ac-link-libwebp-with-lwebp.patch
@@ -1,0 +1,25 @@
+From 22e4c8970e62c14649a38bd62c9c9db2f6e7ee20 Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Tue, 12 Mar 2024 17:08:33 +0800
+Subject: [PATCH] configure.ac: link libwebp with -lwebp
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index b5684ea..e181a9b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -997,7 +997,7 @@ AC_ARG_ENABLE(webp, AS_HELP_STRING([--disable-webp],[Disable WebP file support.]
+         fi
+ ])
+ if test x$fim_handle_webp = xyes; then
+-	LIBS="$LIBS `pkg-config libwebpdemux --libs`";
++	LIBS="$LIBS `pkg-config libwebpdemux --libs` -lwebp";
+ 	CXXFLAGS="$CXXFLAGS `pkg-config libwebpdemux --cflags`";
+ 	AC_MSG_NOTICE([Enabling WebP file format support.])
+ 	AC_DEFINE(FIM_WITH_LIBWEBP, 1, [WebP file support.])
+-- 
+2.34.1
+

--- a/app-utils/fim/autobuild/prepare
+++ b/app-utils/fim/autobuild/prepare
@@ -1,0 +1,1 @@
+export PKG_CONFIG=/usr/bin/pkg-config

--- a/app-utils/fim/spec
+++ b/app-utils/fim/spec
@@ -1,4 +1,4 @@
-VER=0.7~trunk
-SRCS="tbl::http://download.savannah.nongnu.org/releases/fbi-improved/fim-${VER/\~/-}.tar.gz"
-CHKSUMS="sha256::f5b2442c67d0111bfefc06ee8a00c923fe9b992efd62b9c070e191f7d83c07ea"
+VER=0.7+git20240310
+SRCS="git::commit=72cf82eb88e9b62d135100826b6556c6779ab5ae::https://github.com/AOSC-Tracking/fim.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231580"

--- a/app-utils/fim/spec
+++ b/app-utils/fim/spec
@@ -1,4 +1,4 @@
-VER=0.6~trunk
-SRCS="tbl::https://repo.aosc.io/aosc-repacks/fim-${VER/\~/-}.tar.bz2"
-CHKSUMS="sha256::c49d2ab3bb9c5978b8573e6415be366f66cc1102815fa73d151c4a854f1f4066"
+VER=0.7~trunk
+SRCS="tbl::http://download.savannah.nongnu.org/releases/fbi-improved/fim-${VER/\~/-}.tar.gz"
+CHKSUMS="sha256::f5b2442c67d0111bfefc06ee8a00c923fe9b992efd62b9c070e191f7d83c07ea"
 CHKUPDATE="anitya::id=231580"


### PR DESCRIPTION
Topic Description
-----------------

- fim: export parameters
    - specify the correct $PKG_CONFIG
    - add missing LDFLAG '-lwebp'
- fim: fix no rule to make target file
- fim: update to 0.7-trunk

Package(s) Affected
-------------------

- fim: 1:0.7~trunk

Security Update?
----------------

No

Build Order
-----------

```
#buildit fim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
