### PR TITLE
font-manager: update to 0.8.8

### DIFF
--- a/app-utils/font-manager/spec
+++ b/app-utils/font-manager/spec
@@ -1,4 +1,4 @@
-VER=0.7.4.3
-SRCS="tbl::https://github.com/FontManager/master/releases/download/$VER/font-manager-$VER.tar.bz2"
-CHKSUMS="sha256::39bb00942b89eeabb96946cc0c0db5e7ecfe8d62805d87f0115de49ee02487b6"
+VER=0.8.8
+SRCS="tbl::https://github.com/FontManager/font-manager/releases/download/$VER/font-manager-$VER.tar.xz"
+CHKSUMS="sha256::b6b6e7c62ce7a407f4151beb890b4dabfb1b2e446ff51f087f1b4fab986f8e79"
 CHKUPDATE="anitya::id=15389"


### PR DESCRIPTION
Topic Description
-----------------

- font-manager: update to 0.8.8

Package(s) Affected
-------------------

- font-manager: 0.8.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit font-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
