### PR TITLE
jpegoptim: update to 1.5.5

### DIFF
--- a/app-utils/jpegoptim/spec
+++ b/app-utils/jpegoptim/spec
@@ -1,5 +1,4 @@
-VER=1.4.6
-REL=1
-SRCS="tbl::https://github.com/tjko/jpegoptim/archive/RELEASE.${VER}.tar.gz"
-CHKSUMS="sha256::c44dcfac0a113c3bec13d0fc60faf57a0f9a31f88473ccad33ecdf210b4c0c52"
+VER=1.5.5
+SRCS="git::commit=tags/v$VER::https://github.com/tjko/jpegoptim"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1472"


### PR DESCRIPTION
Topic Description
-----------------

- jpegoptim: update to 1.5.5

Package(s) Affected
-------------------

- jpegoptim: 1.5.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit jpegoptim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
