### PR TITLE
libxmlb update to 0.3.15

### DIFF
--- a/runtime-common/libxmlb/spec
+++ b/runtime-common/libxmlb/spec
@@ -1,4 +1,4 @@
-VER=0.3.6
+VER=0.3.15
 SRCS="tbl::https://github.com/hughsie/libxmlb/archive/$VER.tar.gz"
-CHKSUMS="sha256::cb529d055c63d705bafd17b5fab8e36153292533668a0aba853514ed0e42862c"
+CHKSUMS="sha256::68ee69002cc2b792fca250d7a7df2a8e3f8e43ccd6ab7b14c8481407b95e7087"
 CHKUPDATE="anitya::id=179028"


### PR DESCRIPTION
Topic Description
-----------------

- libxmlb: update to 0.3.15

Package(s) Affected
-------------------

- libxmlb: 0.3.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxmlb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
