### PR TITLE
mc: update to 4.8.31

### DIFF
--- a/app-utils/mc/autobuild/conffiles
+++ b/app-utils/mc/autobuild/conffiles
@@ -1,8 +1,0 @@
-/etc/mc/edit.indent.rc
-/etc/mc/filehighlight.ini
-/etc/mc/mc.default.keymap
-/etc/mc/mc.emacs.keymap
-/etc/mc/mc.ext
-/etc/mc/mc.menu
-/etc/mc/mcedit.menu
-/etc/mc/sfs.ini

--- a/app-utils/mc/spec
+++ b/app-utils/mc/spec
@@ -1,4 +1,4 @@
-VER=4.8.25
+VER=4.8.31
 SRCS="tbl::http://ftp.midnight-commander.org/mc-$VER.tar.xz"
-CHKSUMS="sha256::ffc19617f20ebb23330acd3998b7fd559a042d172fa55746d53d246697b2548a"
+CHKSUMS="sha256::24191cf8667675b8e31fc4a9d18a0a65bdc0598c2c5c4ea092494cd13ab4ab1a"
 CHKUPDATE="anitya::id=1954"


### PR DESCRIPTION
Topic Description
-----------------

- mc: remove unnecessary autobuild/conffiles
- mc: update to 4.8.31

Package(s) Affected
-------------------

- mc: 4.8.31

Security Update?
----------------

No

Build Order
-----------

```
#buildit mc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
