### PR TITLE
discord: update to 0.0.45

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.44
+VER=0.0.45
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::9b3a62af926cde90edb8e2b96caa1c77be29d0f7039cca4da71f0fa5c844e851"
+CHKSUMS="sha256::7520dce44c9693f687e49146e9661f26a9dbd18dbf6f8e9871d341d99f70467d"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- discord: update to 0.0.45

Package(s) Affected
-------------------

- discord: 0.0.45

Security Update?
----------------

No

Build Order
-----------

```
#buildit discord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
