### PR TITLE
quickjs: update to 2024.01.13

### DIFF
--- a/lang-js/quickjs/autobuild/patches/0001-Disable-strip-for-debug-symbol-in-AOSC.patch
+++ b/lang-js/quickjs/autobuild/patches/0001-Disable-strip-for-debug-symbol-in-AOSC.patch
@@ -1,0 +1,25 @@
+From 0c7dfbc00c50b65ea81fb6b86ceb91851b694ffc Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Wed, 13 Mar 2024 06:25:29 -0700
+Subject: [PATCH] Disable strip for debug symbol in AOSC
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 57cdd7e..cc1fcb2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -319,7 +319,7 @@ clean:
+ 
+ install: all
+ 	mkdir -p "$(DESTDIR)$(PREFIX)/bin"
+-	$(STRIP) qjs qjsc
++	#$(STRIP) qjs qjsc
+ 	install -m755 qjs qjsc "$(DESTDIR)$(PREFIX)/bin"
+ 	ln -sf qjs "$(DESTDIR)$(PREFIX)/bin/qjscalc"
+ 	mkdir -p "$(DESTDIR)$(PREFIX)/lib/quickjs"
+-- 
+2.44.0
+

--- a/lang-js/quickjs/autobuild/prepare
+++ b/lang-js/quickjs/autobuild/prepare
@@ -1,2 +1,0 @@
-cd "${SRCDIR}"
-sed -i "s#prefix=/usr/local#prefix=/usr#g" "${SRCDIR}"/Makefile

--- a/lang-js/quickjs/spec
+++ b/lang-js/quickjs/spec
@@ -1,4 +1,4 @@
-VER=2020.09.06
+VER=2024.01.13
 SRCS="https://bellard.org/quickjs/quickjs-${VER//./-}.tar.xz"
-CHKSUMS="sha256::0021a3e8cdc6b61e225411d05e2841d2437e1ccf4b4cabb9a5f7685ebfb57717"
+CHKSUMS="sha256::3c4bf8f895bfa54beb486c8d1218112771ecfc5ac3be1036851ef41568212e03"
 CHKUPDATE="anitya::id=138263"


### PR DESCRIPTION
Topic Description
-----------------

- quickjs: update to 2024.01.13

Package(s) Affected
-------------------

- quickjs: 2024.01.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit quickjs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
