### PR TITLE
plocate: update to 1.1.22

### DIFF
--- a/app-utils/plocate/spec
+++ b/app-utils/plocate/spec
@@ -1,4 +1,4 @@
-VER=1.1.19
+VER=1.1.22
 SRCS="tbl::https://plocate.sesse.net/download/plocate-$VER.tar.gz"
-CHKSUMS="sha256::d95bc8ee8a9f79b9f69ce63df53fb85b202139f243bbb84c399555eda22e6165"
+CHKSUMS="sha256::3b7e4741b4aa2ec044e53eff06474a32a3fb1e928b9382351fe79d4c27fb0049"
 CHKUPDATE="anitya::id=188202"


### PR DESCRIPTION
Topic Description
-----------------

- plocate: update to 1.1.22

Package(s) Affected
-------------------

- plocate: 1.1.22

Security Update?
----------------

No

Build Order
-----------

```
#buildit plocate
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
