### PR TITLE
v2raya: update to 2.2.5.1

### DIFF
--- a/app-network/v2raya/autobuild/defines
+++ b/app-network/v2raya/autobuild/defines
@@ -5,5 +5,3 @@ PKGDEP="v2ray"
 BUILDDEP="go yarn"
 
 ABSPLITDBG=0
-
-FAIL_ARCH="loongarch64"

--- a/app-network/v2raya/spec
+++ b/app-network/v2raya/spec
@@ -1,4 +1,4 @@
-VER=2.2.4
+VER=2.2.5.1
 SRCS="git::commit=tags/v$VER::https://github.com/v2rayA/v2rayA"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326097"


### PR DESCRIPTION
Topic Description
-----------------

- v2raya: update to 2.2.5.1

Package(s) Affected
-------------------

- v2raya: 2.2.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit v2raya
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
