### PR TITLE
plzip: update to 1.11

### DIFF
--- a/app-utils/plzip/autobuild/build
+++ b/app-utils/plzip/autobuild/build
@@ -1,5 +1,14 @@
-./configure ${AUTOTOOLS_DEF} \
-            CPPFLAGS="${CPPFLAGS}" CXXFLAGS="${CXXFLAGS}" \
-            LDFLAGS="${LDFLAGS}"
+# Note: plzip uses a non-standard Autotools-like build system.
+abinfo "Configuring plzip ..."
+"$SRCDIR"/configure \
+    --prefix=/usr \
+    CPPFLAGS="${CPPFLAGS}" \
+    CXXFLAGS="${CXXFLAGS}" \
+    LDFLAGS="${LDFLAGS}"
+
+abinfo "Building plzip ..."
 make
-make install DESTDIR="$PKGDIR"
+
+abinfo "Installing plzip ..."
+make install \
+    DESTDIR="$PKGDIR"

--- a/app-utils/plzip/autobuild/defines
+++ b/app-utils/plzip/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=plzip
 PKGSEC=utils
 PKGDEP="lzlib gcc-runtime"
-PKGDES="A massively parallel (multi-threaded) lossless data compressor based on the lzlib compression library"
+PKGDES="A parallel (multi-threaded), lzlib-based lossless compressor"

--- a/app-utils/plzip/spec
+++ b/app-utils/plzip/spec
@@ -1,5 +1,4 @@
-VER=1.7
+VER=1.11
 SRCS="tbl::https://download.savannah.gnu.org/releases/lzip/plzip/plzip-$VER.tar.lz"
-CHKSUMS="sha256::70697c1b1f76e8e85ecbd7d1cb96eb545e52972dfbf76fb34b9a3f4c87e559dd"
-REL=1
+CHKSUMS="sha256::51f48d33df659bb3e1e7e418275e922ad752615a5bc984139da08f1e6d7d10fd"
 CHKUPDATE="anitya::id=231632"


### PR DESCRIPTION
Topic Description
-----------------

- plzip: migrate to autobuild4
- plzip: update to 1.11

Package(s) Affected
-------------------

- plzip: 1.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit plzip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
