### PR TITLE
avahi rework for mips64r6el

### DIFF
--- a/app-network/avahi/autobuild/defines
+++ b/app-network/avahi/autobuild/defines
@@ -47,9 +47,6 @@ AUTOTOOLS_AFTER="--disable-mono \
                  --with-autoipd-group=avahi \
                  --with-dbus-sys=/usr/share/dbus-1/system.d \
                  --with-systemdsystemunitdir=/usr/lib/systemd/system"
-AUTOTOOLS_AFTER__MIPS64R6EL=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-python"
 AUTOTOOLS_AFTER__RETRO=" \
                  ${AUTOTOOLS_AFTER} \
                  --disable-mono \

--- a/app-network/avahi/autobuild/overrides/usr/lib/sysusers.d/avahi.conf
+++ b/app-network/avahi/autobuild/overrides/usr/lib/sysusers.d/avahi.conf
@@ -1,0 +1,3 @@
+g avahi 84
+g netdev 86
+u avahi 84 "Avahi Daemon Owner" /run/avahi-daemon /bin/false

--- a/app-network/avahi/autobuild/usergroup
+++ b/app-network/avahi/autobuild/usergroup
@@ -1,3 +1,0 @@
-group avahi 84
-group netdev 86
-user avahi 84 avahi /run/avahi-daemon "Avahi Daemon Owner" /bin/false

--- a/app-network/avahi/spec
+++ b/app-network/avahi/spec
@@ -1,5 +1,5 @@
 VER=0.8
-REL=5
+REL=6
 SRCS="tbl::https://github.com/lathiat/avahi/releases/download/v$VER/avahi-$VER.tar.gz"
 CHKSUMS="sha256::060309d7a333d38d951bc27598c677af1796934dbd98e1024e7ad8de798fedda"
 CHKUPDATE="anitya::id=147"


### PR DESCRIPTION
Topic Description
-----------------

- avahi: (mips64r6el) enable python
    fix cannot find libavahi-common.so building avahi-tqt
- avahi: migrate to autobuild4

Package(s) Affected
-------------------

- avahi: 0.8-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit avahi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
