### PR TITLE
dunst: update to 1.10.0

### DIFF
--- a/app-utils/dunst/autobuild/build
+++ b/app-utils/dunst/autobuild/build
@@ -1,9 +1,5 @@
 abinfo "Building dunst ..."
-make "$MAKE_AFTER"
-
-abinfo "Building dunstify ..."
-make "$MAKE_AFTER" dunstify
+make DESTDIR="$PKGDIR" PREFIX=/usr SYSCONFDIR=/etc
 
 abinfo "Installing binaries ..."
 make DESTDIR="$PKGDIR" PREFIX=/usr SYSCONFDIR=/etc install
-install -Dvm755 "$SRCDIR"/dunstify "$PKGDIR"/usr/bin/dunstify

--- a/app-utils/dunst/autobuild/defines
+++ b/app-utils/dunst/autobuild/defines
@@ -1,6 +1,4 @@
 PKGNAME=dunst
 PKGSEC=utils
-PKGDEP="dbus x11-lib libnotify gdk-pixbuf libxdg-basedir pango"
+PKGDEP="dbus x11-lib libnotify gdk-pixbuf pango xdg-utils wayland"
 PKGDES="Customizable and lightweight notification-daemon"
-
-MAKE_AFTER="X11INC=/usr/include/X11 X11LIB=/usr/lib/X11"

--- a/app-utils/dunst/spec
+++ b/app-utils/dunst/spec
@@ -1,4 +1,4 @@
-VER=1.9.2
+VER=1.10.0
 SRCS="git::commit=tags/v${VER}::https://github.com/dunst-project/dunst"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12188"


### PR DESCRIPTION
Topic Description
-----------------

- dunst: update to 1.10.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- dunst: 1.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dunst
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
