### PR TITLE
gitoxide: update to 0.34.0

### DIFF
--- a/app-vcs/gitoxide/autobuild/patches/0001-bump-libz-ng-sys-for-loongarch.patch
+++ b/app-vcs/gitoxide/autobuild/patches/0001-bump-libz-ng-sys-for-loongarch.patch
@@ -1,0 +1,16 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index deac531b0..87e132f6e 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -3299,9 +3299,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "libz-ng-sys"
+-version = "1.1.13"
++version = "1.1.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "601c27491de2c76b43c9f52d639b2240bfb9b02112009d3b754bfa90d891492d"
++checksum = "c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5"
+ dependencies = [
+  "cmake",
+  "libc",

--- a/app-vcs/gitoxide/spec
+++ b/app-vcs/gitoxide/spec
@@ -1,4 +1,4 @@
-VER="0.33.0"
+VER=0.34.0
 SRCS="git::commit=tags/v$VER::https://github.com/Byron/gitoxide"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236380"


### PR DESCRIPTION
Topic Description
-----------------

- gitoxide: update to 0.34.0

Package(s) Affected
-------------------

- gitoxide: 0.34.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gitoxide
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
