### PR TITLE
Feishin: update to 0.6.1

### DIFF
--- a/app-multimedia/feishin/spec
+++ b/app-multimedia/feishin/spec
@@ -1,4 +1,4 @@
-VER=0.6.0
+VER=0.6.1
 SRCS="git::commit=tags/v${VER}::https://github.com/jeffvli/feishin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368971"


### PR DESCRIPTION
Topic Description
-----------------

- feishin: update to 0.6.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- feishin: 0.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit feishin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
