### PR TITLE
FTBFS fix for loongarch batch #4

### DIFF
--- a/app-devices/android-simg2img/autobuild/build
+++ b/app-devices/android-simg2img/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building android-simg2img ..."
+make ${MAKE_AFTER}
+
+abinfo "Installing android-simg2img ..."
+make install ${MAKE_AFTER}

--- a/app-devices/android-simg2img/spec
+++ b/app-devices/android-simg2img/spec
@@ -1,5 +1,5 @@
 VER=1.1.4
-REL=1
+REL=2
 SRCS="tbl::https://github.com/anestisb/android-simg2img/archive/$VER.tar.gz"
 CHKSUMS="sha256::cbd32490c1e29d9025601b81089b5aec1707cb62020dfcecd8747af4fde6fecd"
 CHKUPDATE="anitya::id=226907"

--- a/app-emulation/bochs/autobuild/build
+++ b/app-emulation/bochs/autobuild/build
@@ -1,6 +1,6 @@
 abinfo "Configuring Bochs ..."
 "$SRCDIR"/configure \
-    ${AUTOTOOLS_DEF} \
+    ${AUTOTOOLS_DEF[@]} \
     ${AUTOTOOLS_AFTER}
 
 echo "Tweaking config.h (disable BX_NETMOD_FBSD) to fix build ..."

--- a/app-emulation/bochs/spec
+++ b/app-emulation/bochs/spec
@@ -1,5 +1,5 @@
 VER=2.6.11
-REL=1
+REL=2
 SRCS="tbl::https://sourceforge.net/projects/bochs/files/bochs/$VER/bochs-$VER.tar.gz"
 CHKSUMS="sha256::63897b41fbbbdfb1c492d3c4dee1edb4224282a07bbdf442a4a68c19bcc18862"
 CHKUPDATE="anitya::id=10537"

--- a/app-utils/antiword/spec
+++ b/app-utils/antiword/spec
@@ -1,5 +1,5 @@
 VER=0.37
-REL=2
-SRCS="tbl::http://www.winfield.demon.nl/linux/antiword-$VER.tar.gz"
+REL=3
+SRCS="tbl::https://web.archive.org/web/20221207132720/http://www.winfield.demon.nl/linux/antiword-$VER.tar.gz"
 CHKSUMS="sha256::8e2c000fcbc6d641b0e6ff95e13c846da3ff31097801e86702124a206888f5ac"
 CHKUPDATE="anitya::id=10263"

--- a/app-utils/bashrun/autobuild/defines
+++ b/app-utils/bashrun/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=bashrun
 PKGSEC=x11
 PKGDEP="bash xdotool"
 PKGDES="An X11 application launcher based on bash"
+
+ABHOST=noarch

--- a/lang-tcl/tix/autobuild/prepare
+++ b/lang-tcl/tix/autobuild/prepare
@@ -1,2 +1,4 @@
-[ $ARCH == "amd64" ] && export CFLAGS+=" -DERR_IN_PROGRESS=2"
-[ $ARCH == "amd64" ] && export AUTOTOOLS_AFTER+=" --enable-64bit"
+if ab_match_arch amd64; then
+    export CFLAGS+=" -DERR_IN_PROGRESS=2"
+    export AUTOTOOLS_AFTER+=" --enable-64bit"
+fi

--- a/lang-tcl/tix/spec
+++ b/lang-tcl/tix/spec
@@ -1,5 +1,5 @@
 VER=8.4.3
-REL=2
+REL=3
 SRCS="tbl::https://downloads.sourceforge.net/tix/Tix$VER-src.tar.gz"
 CHKSUMS="sha256::562f040ff7657e10b5cffc2c41935f1a53c6402eb3d5f3189113d734fd6c03cb"
 CHKUPDATE="anitya::id=13722"


### PR DESCRIPTION
Topic Description
-----------------

- bochs: migrate to ab4
- bashrun: mark noarch to fix FTBFS
- tix: fix prepare script
- antiword: fix missing upstream
- android-simg2img: migrate to autobuild4

Package(s) Affected
-------------------

- bashrun: 0.16.1-2
- antiword: 0.37-3
- android-simg2img: 1.1.4-2
- tix: 8.4.3-3
- bochs: 2.6.11-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit android-simg2img antiword tix bashrun bochs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
