### PR TITLE
linux-kernel: fix process hang on loongarch64

### DIFF
--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-lib-cpumask-Make-CPUMASK_OFFSTACK-usable-without-deb.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-lib-cpumask-Make-CPUMASK_OFFSTACK-usable-without-deb.patch
@@ -1,7 +1,7 @@
 From 192f6d584b8357d6e2bd63e098c6f76336b468a7 Mon Sep 17 00:00:00 2001
 From: Josh Boyer <jwboyer@fedoraproject.org>
 Date: Mon, 11 Nov 2013 08:39:16 -0500
-Subject: [PATCH 01/60] lib/cpumask: Make CPUMASK_OFFSTACK usable without debug
+Subject: [PATCH 01/61] lib/cpumask: Make CPUMASK_OFFSTACK usable without debug
  dependency
 
 When CPUMASK_OFFSTACK was added in 2008, it was dependent upon

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-input-kill-stupid-messages.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-input-kill-stupid-messages.patch
@@ -1,7 +1,7 @@
 From 47e75374166e4e77b56bd322b5af5a12d0dff139 Mon Sep 17 00:00:00 2001
 From: "kernel-team@fedoraproject.org" <kernel-team@fedoraproject.org>
 Date: Thu, 29 Jul 2010 16:46:31 -0700
-Subject: [PATCH 02/60] input: kill stupid messages
+Subject: [PATCH 02/61] input: kill stupid messages
 
 Bugzilla: N/A
 Upstream-status: Fedora mustard

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-lis3-improve-handling-of-null-rate.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-lis3-improve-handling-of-null-rate.patch
@@ -1,7 +1,7 @@
 From 9b024e980a77d17bbcc09991df1453aab9c4a1f8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=89ric=20Piel?= <eric.piel@tremplin-utc.net>
 Date: Thu, 3 Nov 2011 16:22:40 +0100
-Subject: [PATCH 03/60] lis3: improve handling of null rate
+Subject: [PATCH 03/61] lis3: improve handling of null rate
 
 When obtaining a rate of 0, we would disable the device supposely
 because it seems to behave incorectly. It actually only comes from the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-ath9k-rx-dma-stop-check.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-ath9k-rx-dma-stop-check.patch
@@ -1,7 +1,7 @@
 From af87f18cc33f778f993ee840b382eaa496f55849 Mon Sep 17 00:00:00 2001
 From: "kernel-team@fedoraproject.org" <kernel-team@fedoraproject.org>
 Date: Wed, 6 Feb 2013 09:57:47 -0500
-Subject: [PATCH 04/60] ath9k: rx dma stop check
+Subject: [PATCH 04/61] ath9k: rx dma stop check
 
 ---
  drivers/net/wireless/ath/ath9k/mac.c | 12 +++++++++++-

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-Input-synaptics-pin-3-touches-when-the-firmware-repo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-Input-synaptics-pin-3-touches-when-the-firmware-repo.patch
@@ -1,7 +1,7 @@
 From fd6dbd7146582e2bc518a157890797b09b48f31d Mon Sep 17 00:00:00 2001
 From: Benjamin Tissoires <benjamin.tissoires@redhat.com>
 Date: Thu, 16 Apr 2015 13:01:46 -0400
-Subject: [PATCH 05/60] Input - synaptics: pin 3 touches when the firmware
+Subject: [PATCH 05/61] Input - synaptics: pin 3 touches when the firmware
  reports 3 fingers
 
 Synaptics PS/2 touchpad can send only 2 touches in a report. They can

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-driver-sisfb-add-resolution-1368-768-for-loongson-ly.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-driver-sisfb-add-resolution-1368-768-for-loongson-ly.patch
@@ -1,7 +1,7 @@
 From 924e5cb6520baf26a7ddc916199e1af058d32ca3 Mon Sep 17 00:00:00 2001
 From: flygoat <flygoatfree@gmail.com>
 Date: Sun, 5 Mar 2017 20:33:17 +0800
-Subject: [PATCH 06/60] driver sisfb add resolution 1368*768 for loongson
+Subject: [PATCH 06/61] driver sisfb add resolution 1368*768 for loongson
  lynloong
 
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-Revert-video-output-Drop-display-output-class-suppor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-Revert-video-output-Drop-display-output-class-suppor.patch
@@ -1,7 +1,7 @@
 From 14f64ee35a07c5d0272f7284ccec1de978c61d11 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 7 Nov 2017 09:01:33 +0800
-Subject: [PATCH 07/60] Revert "video / output: Drop display output class
+Subject: [PATCH 07/61] Revert "video / output: Drop display output class
  support" This reverts commit f167a64e9d67ebd03d304e369c12011cf2bffaf5
  Required by some Loongson platform devices drivers
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
@@ -1,7 +1,7 @@
 From 1897f278408823cd8499f64ba78d99d14a23f155 Mon Sep 17 00:00:00 2001
 From: Mark Weiman <mark.weiman@markzz.com>
 Date: Wed, 27 Jan 2021 13:28:09 -0500
-Subject: [PATCH 08/60] pci: Enable overrides for missing ACS capabilities
+Subject: [PATCH 08/61] pci: Enable overrides for missing ACS capabilities
  (5.10.11+)
 
 This an updated version of Alex Williamson's patch from:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
 From b712c43f79bd5639e4233c6a0673a6bc54f01e5f Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux@gmail.com>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 09/60] usb: phy: tegra: Add 38.4MHz clock table entry
+Subject: [PATCH 09/61] usb: phy: tegra: Add 38.4MHz clock table entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to
 use the ehci phy on the Jetson TX1.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-more-uarches-for-kernel-5.17.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-more-uarches-for-kernel-5.17.patch
@@ -1,7 +1,7 @@
 From 3d93e7e435a82d90224af128cc7ce787fb614124 Mon Sep 17 00:00:00 2001
 From: graysky <graysky@archlinux.us>
 Date: Tue, 15 Mar 2022 05:58:43 -0400
-Subject: [PATCH 10/60] more uarches for kernel 5.17+
+Subject: [PATCH 10/61] more uarches for kernel 5.17+
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-MIPS-Loongson64-Disable-writecombine-for-Loongson-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-MIPS-Loongson64-Disable-writecombine-for-Loongson-3A.patch
@@ -1,7 +1,7 @@
 From 00b62cdc89ad5508f237f6af739af2feb11b6d95 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Mon, 12 Oct 2020 13:32:23 +0800
-Subject: [PATCH 11/60] MIPS: Loongson64: Disable writecombine for Loongson-3A
+Subject: [PATCH 11/61] MIPS: Loongson64: Disable writecombine for Loongson-3A
  R1
 
 It breaks radeon.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-platform-surface-hid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-platform-surface-hid.patch
@@ -1,7 +1,7 @@
 From 79f317cbaa5ef624bebcfa148b111f89af612cc0 Mon Sep 17 00:00:00 2001
 From: qzed <qzed@users.noreply.github.com>
 Date: Tue, 17 Sep 2019 17:16:23 +0200
-Subject: [PATCH 12/60] platform: surface hid
+Subject: [PATCH 12/61] platform: surface hid
 
 ---
  drivers/hid/hid-ids.h | 12 ++++++++++++

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-loongson64-init-suppress-memcpy-out-of-bound-checkin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-loongson64-init-suppress-memcpy-out-of-bound-checkin.patch
@@ -1,7 +1,7 @@
 From e76e6a86286ac5ddbda0abe9fdcfeedca20cc736 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Wed, 24 Aug 2022 03:54:11 +0000
-Subject: [PATCH 13/60] loongson64/init: suppress memcpy out-of-bound checking
+Subject: [PATCH 13/61] loongson64/init: suppress memcpy out-of-bound checking
 
 ---
  arch/mips/loongson64/init.c | 3 +++

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
@@ -1,7 +1,7 @@
 From 5fe6d032e904a9fe97db9bc192e7777d92a18047 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 14/60] arm64: dts: rockchip: change GMAC rx_delay for
+Subject: [PATCH 14/61] arm64: dts: rockchip: change GMAC rx_delay for
  RockPro64
 
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-arm64-dts-rockchip-add-out-of-band-IRQ-for-RK3399-Wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-arm64-dts-rockchip-add-out-of-band-IRQ-for-RK3399-Wi.patch
@@ -1,7 +1,7 @@
 From 7efdbe02b7a063301b69554a74e705db6e197f93 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 30 Nov 2020 22:49:55 +0800
-Subject: [PATCH 15/60] arm64: dts: rockchip: add out-of-band IRQ for RK3399
+Subject: [PATCH 15/61] arm64: dts: rockchip: add out-of-band IRQ for RK3399
  Wi-Fi
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-arm64-rockchip-dts-rk3399-fix-PD-on-Pinebook-Pro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-arm64-rockchip-dts-rk3399-fix-PD-on-Pinebook-Pro.patch
@@ -1,7 +1,7 @@
 From 6263611f7744a88e542213eb90b25d03a08bc1c0 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Tue, 1 Dec 2020 16:19:04 +0800
-Subject: [PATCH 16/60] arm64: rockchip: dts: rk3399: fix PD on Pinebook Pro
+Subject: [PATCH 16/61] arm64: rockchip: dts: rk3399: fix PD on Pinebook Pro
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-HACK-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-HACK-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
 From abee6b1addf7befffcbf6c822ac76690eb262c3b Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Thu, 21 Apr 2022 11:36:35 +0800
-Subject: [PATCH 17/60] HACK: arm64: dts: rockchip: disable usb3 on quartz64
+Subject: [PATCH 17/61] HACK: arm64: dts: rockchip: disable usb3 on quartz64
 
 USB3 on Quartz64 is of bad quality because of sharing lines with SATA.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-arm64-add-Kconfig-option-for-Phytium-SoCs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-arm64-add-Kconfig-option-for-Phytium-SoCs.patch
@@ -1,7 +1,7 @@
 From 453321ad331853a7e81601ecd0f78fd79b9af1ae Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 25 Sep 2022 23:02:39 +0800
-Subject: [PATCH 18/60] arm64: add Kconfig option for Phytium SoCs
+Subject: [PATCH 18/61] arm64: add Kconfig option for Phytium SoCs
 
 This option works as a gate for Phytium-specific drivers.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-net-stmmac-add-a-glue-driver-for-GMACs-in-Phytium-So.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-net-stmmac-add-a-glue-driver-for-GMACs-in-Phytium-So.patch
@@ -1,7 +1,7 @@
 From 4c5690e70141e4ad618289a64c949e9e36478999 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 25 Sep 2022 23:03:51 +0800
-Subject: [PATCH 19/60] net: stmmac: add a glue driver for GMACs in Phytium
+Subject: [PATCH 19/61] net: stmmac: add a glue driver for GMACs in Phytium
  SoCs
 
 Multiple Phytium ARM64 SoCs feature DesignWare GMACs that is mostly

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-HID-logitech-dj-add-support-for-the-new-lightspeed-r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-HID-logitech-dj-add-support-for-the-new-lightspeed-r.patch
@@ -1,7 +1,7 @@
 From a63dbca7576216f7e8249acd6b2b2c4de502d4ab Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Filipe=20La=C3=ADns?= <lains@riseup.net>
 Date: Sat, 23 Jan 2021 18:03:33 +0000
-Subject: [PATCH 20/60] HID: logitech-dj: add support for the new lightspeed
+Subject: [PATCH 20/61] HID: logitech-dj: add support for the new lightspeed
  receiver iteration
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-iommu-make-IPMMU_VMSA-dependencies-more-strict.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-iommu-make-IPMMU_VMSA-dependencies-more-strict.patch
@@ -1,7 +1,7 @@
 From 8d35bf9f1a51f06dab896b80f242bf10a3257256 Mon Sep 17 00:00:00 2001
 From: Randy Dunlap <rdunlap@infradead.org>
 Date: Thu, 30 Mar 2023 09:58:17 -0700
-Subject: [PATCH 21/60] iommu: make IPMMU_VMSA dependencies more strict
+Subject: [PATCH 21/61] iommu: make IPMMU_VMSA dependencies more strict
 
 On riscv64, linux-next-20233030 (and for several days earlier),
 there is a kconfig warning:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-HACK-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-HACK-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
 From 18ae427b50950ef6f8db23597a330e9d63d6a947 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 27 Jul 2023 11:13:25 -0400
-Subject: [PATCH 22/60] HACK arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 22/61] HACK arm64: drop hisi_ddrc_pmu driver
 
 ---
  drivers/perf/hisilicon/Makefile | 2 +-

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-hid-lenovo-detect-false-positives.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-hid-lenovo-detect-false-positives.patch
@@ -1,7 +1,7 @@
 From 59c407cf717ab5e4c639b6c466ca426a0434ad07 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Thu, 4 Jan 2024 00:05:49 -0500
-Subject: [PATCH 23/60] hid-lenovo: detect false-positives
+Subject: [PATCH 23/61] hid-lenovo: detect false-positives
 
 This patch allows the workaround to work again when wheel signals
 are detected after identifying the keyboard as bug-free. False

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-kdump-Remove-redundant-DEFAULT_CRASH_KERNEL_LOW_SIZE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-kdump-Remove-redundant-DEFAULT_CRASH_KERNEL_LOW_SIZE.patch
@@ -1,7 +1,7 @@
 From ac0a22fb172b93f83714e35a0285e99ebfe960a5 Mon Sep 17 00:00:00 2001
 From: Youling Tang <tangyouling@kylinos.cn>
 Date: Wed, 27 Dec 2023 07:46:25 +0800
-Subject: [PATCH 24/60] kdump: Remove redundant DEFAULT_CRASH_KERNEL_LOW_SIZE
+Subject: [PATCH 24/61] kdump: Remove redundant DEFAULT_CRASH_KERNEL_LOW_SIZE
 
 Remove duplicate definitions, no functional changes.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-modpost-Ignore-relaxation-and-alignment-marker-reloc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-modpost-Ignore-relaxation-and-alignment-marker-reloc.patch
@@ -1,7 +1,7 @@
 From 466d3a82d54d82b422c7d505de05ef8388626efe Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <git@xen0n.name>
 Date: Wed, 27 Dec 2023 15:03:14 +0800
-Subject: [PATCH 25/60] modpost: Ignore relaxation and alignment marker relocs
+Subject: [PATCH 25/61] modpost: Ignore relaxation and alignment marker relocs
  on LoongArch
 
 With recent trunk versions of binutils and gcc, alignment directives are

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-scripts-min-tool-version.sh-Raise-minimum-clang-vers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-scripts-min-tool-version.sh-Raise-minimum-clang-vers.patch
@@ -1,7 +1,7 @@
 From e9eaa67b35f516711985ce5cef44b85cafc4b011 Mon Sep 17 00:00:00 2001
 From: WANG Rui <wangrui@loongson.cn>
 Date: Mon, 8 Jan 2024 11:31:38 +0800
-Subject: [PATCH 26/60] scripts/min-tool-version.sh: Raise minimum clang
+Subject: [PATCH 26/61] scripts/min-tool-version.sh: Raise minimum clang
  version to 18.0.0 for loongarch
 
 The existing mainline clang development version encounters diffculties

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-LoongArch-Enable-initial-Rust-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-LoongArch-Enable-initial-Rust-support.patch
@@ -1,7 +1,7 @@
 From 68df1d6cf1ee4f718c205d42678f3759e9b01f3d Mon Sep 17 00:00:00 2001
 From: WANG Rui <wangrui@loongson.cn>
 Date: Mon, 8 Jan 2024 11:21:17 +0800
-Subject: [PATCH 27/60] LoongArch: Enable initial Rust support
+Subject: [PATCH 27/61] LoongArch: Enable initial Rust support
 
 Enable initial Rust support for LoongArch.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-dt-bindings-loongarch-Add-CPU-bindings-for-LoongArch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-dt-bindings-loongarch-Add-CPU-bindings-for-LoongArch.patch
@@ -1,7 +1,7 @@
 From ea296c9bd76af1be849c292c1dfa9009bfc370e5 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 22 Dec 2023 16:00:44 +0800
-Subject: [PATCH 28/60] dt-bindings: loongarch: Add CPU bindings for LoongArch
+Subject: [PATCH 28/61] dt-bindings: loongarch: Add CPU bindings for LoongArch
 
 Add the available CPUs in LoongArch binding with DT schema format using
 json-schema.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-dt-bindings-loongarch-Add-Loongson-SoC-boards-compat.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-dt-bindings-loongarch-Add-Loongson-SoC-boards-compat.patch
@@ -1,7 +1,7 @@
 From 8ed52de0234322254c92a3775f6343a49995cba4 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 22 Dec 2023 16:00:45 +0800
-Subject: [PATCH 29/60] dt-bindings: loongarch: Add Loongson SoC boards
+Subject: [PATCH 29/61] dt-bindings: loongarch: Add Loongson SoC boards
  compatibles
 
 Add Loongson SoC boards binding with DT schema format using json-schema.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-dt-bindings-interrupt-controller-loongson-liointc-Fi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-dt-bindings-interrupt-controller-loongson-liointc-Fi.patch
@@ -1,7 +1,7 @@
 From 4395cfa314c71cc17fae25fcbc2241cddcb6cdbe Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 7 Dec 2023 15:29:38 +0800
-Subject: [PATCH 30/60] dt-bindings: interrupt-controller: loongson,liointc:
+Subject: [PATCH 30/61] dt-bindings: interrupt-controller: loongson,liointc:
  Fix dtbs_check warning for reg-names
 
 As we know, the Loongson-2K0500 is a single-core CPU, and the core1-

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-dt-bindings-interrupt-controller-loongson-liointc-Fi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-dt-bindings-interrupt-controller-loongson-liointc-Fi.patch
@@ -1,7 +1,7 @@
 From 0deecf0c19eaf018170b8433caaf4b54f31b36d6 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 7 Dec 2023 15:29:39 +0800
-Subject: [PATCH 31/60] dt-bindings: interrupt-controller: loongson,liointc:
+Subject: [PATCH 31/61] dt-bindings: interrupt-controller: loongson,liointc:
  Fix dtbs_check warning for interrupt-names
 
 The Loongson-2K0500/2K1000 CPUs have 64 interrupt sources as inputs, and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-LoongArch-Allow-device-trees-be-built-into-the-kerne.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-LoongArch-Allow-device-trees-be-built-into-the-kerne.patch
@@ -1,7 +1,7 @@
 From 774f12fd522c722eb5981937514f5a34804844dd Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 22 Dec 2023 16:00:46 +0800
-Subject: [PATCH 32/60] LoongArch: Allow device trees be built into the kernel
+Subject: [PATCH 32/61] LoongArch: Allow device trees be built into the kernel
 
 During the upstream progress of those DT-based drivers, DT properties
 are changed a lot so very different from those in existing bootloaders.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-LoongArch-dts-DeviceTree-for-Loongson-2K0500.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-LoongArch-dts-DeviceTree-for-Loongson-2K0500.patch
@@ -1,7 +1,7 @@
 From cabc6cb25028ed8b6117f5e57e09b436129db126 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 22 Dec 2023 16:01:10 +0800
-Subject: [PATCH 33/60] LoongArch: dts: DeviceTree for Loongson-2K0500
+Subject: [PATCH 33/61] LoongArch: dts: DeviceTree for Loongson-2K0500
 
 Add DeviceTree file for Loongson-2K0500 processor, which integrates one
 64-bit 2-issue superscalar LA264 processor core.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-LoongArch-dts-DeviceTree-for-Loongson-2K1000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-LoongArch-dts-DeviceTree-for-Loongson-2K1000.patch
@@ -1,7 +1,7 @@
 From d231deebeae7599b098d2836bd31b9987b3f0a98 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 22 Dec 2023 16:01:11 +0800
-Subject: [PATCH 34/60] LoongArch: dts: DeviceTree for Loongson-2K1000
+Subject: [PATCH 34/61] LoongArch: dts: DeviceTree for Loongson-2K1000
 
 Add DeviceTree file for Loongson-2K1000 processor, which integrates two
 64-bit 2-issue superscalar LA264 processor cores.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-LoongArch-dts-DeviceTree-for-Loongson-2K2000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-LoongArch-dts-DeviceTree-for-Loongson-2K2000.patch
@@ -1,7 +1,7 @@
 From 05425e963d1e14729333ce4013e15bea4f55ad76 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 22 Dec 2023 16:01:12 +0800
-Subject: [PATCH 35/60] LoongArch: dts: DeviceTree for Loongson-2K2000
+Subject: [PATCH 35/61] LoongArch: dts: DeviceTree for Loongson-2K2000
 
 Add DeviceTree file for Loongson-2K2000 processor, which integrates two
 64-bit 3-issue superscalar LA364 processor cores.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-LoongArch-Parsing-CPU-related-information-from-DTS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-LoongArch-Parsing-CPU-related-information-from-DTS.patch
@@ -1,7 +1,7 @@
 From 5a7dd9002ede00f24a72aafc62181c94e22be0b6 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 22 Dec 2023 16:01:13 +0800
-Subject: [PATCH 36/60] LoongArch: Parsing CPU-related information from DTS
+Subject: [PATCH 36/61] LoongArch: Parsing CPU-related information from DTS
 
 Generally, we can get cpu-related information, such as model name, from
 /proc/cpuinfo. For FDT-based systems, we need to parse the relevant

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-LoongArch-Change-SHMLBA-from-SZ_64K-to-PAGE_SIZE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-LoongArch-Change-SHMLBA-from-SZ_64K-to-PAGE_SIZE.patch
@@ -1,7 +1,7 @@
 From 1344b2181ab37e685fc3973ca82f92a3f93e1be5 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 8 Dec 2023 23:14:33 +0800
-Subject: [PATCH 37/60] LoongArch: Change SHMLBA from SZ_64K to PAGE_SIZE
+Subject: [PATCH 37/61] LoongArch: Change SHMLBA from SZ_64K to PAGE_SIZE
 
 LoongArch has hardware page coloring for L1 Cache, so we don't have
 cache aliases. But SFB (Store Fill Buffer) still has aliases. So we

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-LoongArch-Let-cores_io_master-cover-the-largest-NR_C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-LoongArch-Let-cores_io_master-cover-the-largest-NR_C.patch
@@ -1,7 +1,7 @@
 From d3eb83eb876adca34c54d52515c145720a71e00a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 25 Dec 2023 14:45:45 +0800
-Subject: [PATCH 38/60] LoongArch: Let cores_io_master cover the largest
+Subject: [PATCH 38/61] LoongArch: Let cores_io_master cover the largest
  NR_CPUS
 
 Now loongson_system_configuration::cores_io_master only covers 64 cpus,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-LoongArch-Use-generic-interface-to-support-crashkern.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-LoongArch-Use-generic-interface-to-support-crashkern.patch
@@ -1,7 +1,7 @@
 From 5aac20753759f8c21b058d89fd938a72cc518f63 Mon Sep 17 00:00:00 2001
 From: Youling Tang <tangyouling@kylinos.cn>
 Date: Wed, 27 Dec 2023 20:24:52 +0800
-Subject: [PATCH 39/60] LoongArch: Use generic interface to support
+Subject: [PATCH 39/61] LoongArch: Use generic interface to support
  crashkernel=X,[high,low]
 
 LoongArch already supports two crashkernel regions in kexec-tools, so we

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-LoongArch-BPF-Support-64-bit-pointers-to-kfuncs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-LoongArch-BPF-Support-64-bit-pointers-to-kfuncs.patch
@@ -1,7 +1,7 @@
 From 92c8086b25199a67c7af3136fb188bcc681bdc69 Mon Sep 17 00:00:00 2001
 From: Hengqi Chen <hengqi.chen@gmail.com>
 Date: Fri, 15 Dec 2023 14:21:38 +0000
-Subject: [PATCH 40/60] LoongArch: BPF: Support 64-bit pointers to kfuncs
+Subject: [PATCH 40/61] LoongArch: BPF: Support 64-bit pointers to kfuncs
 
 Like commit 1cf3bfc60f9836f ("bpf: Support 64-bit pointers to kfuncs")
 for s390x, add support for 64-bit pointers to kfuncs for LoongArch.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-LoongArch-Update-Loongson-3-default-config-file.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-LoongArch-Update-Loongson-3-default-config-file.patch
@@ -1,7 +1,7 @@
 From 6ef0980c7c06af7e9d60876c77bd6c65e737d0b5 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 13 Sep 2023 12:31:21 +0800
-Subject: [PATCH 41/60] LoongArch: Update Loongson-3 default config file
+Subject: [PATCH 41/61] LoongArch: Update Loongson-3 default config file
 
 1, Increase NR_CPUS to 256.
 2, Enable some cgroup options.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-MAINTAINERS-Add-BPF-JIT-for-LOONGARCH-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-MAINTAINERS-Add-BPF-JIT-for-LOONGARCH-entry.patch
@@ -1,7 +1,7 @@
 From 37b85637c0d247c06136b90962cd2ec5f02f3278 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Mon, 25 Dec 2023 17:07:30 +0800
-Subject: [PATCH 42/60] MAINTAINERS: Add BPF JIT for LOONGARCH entry
+Subject: [PATCH 42/61] MAINTAINERS: Add BPF JIT for LOONGARCH entry
 
 After commit 5dc615520c4d ("LoongArch: Add BPF JIT support"),
 there is no BPF JIT for LOONGARCH entry, in order to maintain

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,7 +1,7 @@
 From 9d28d63cf23a4a52520f36f73116aa6b513a7a42 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
-Subject: [PATCH 43/60] LoongArch: Add CPU HWMon platform driver
+Subject: [PATCH 43/61] LoongArch: Add CPU HWMon platform driver
 
 This add CPU HWMon (temperature sensor) platform driver for Loongson-3.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-SH-cpuinfo-Fix-a-warning-for-CONFIG_CPUMASK_OFFSTACK.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-SH-cpuinfo-Fix-a-warning-for-CONFIG_CPUMASK_OFFSTACK.patch
@@ -1,7 +1,7 @@
 From edce280e5c53f14114857d14d4d5d5ac101c7aed Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 12 Jul 2022 12:47:48 +0800
-Subject: [PATCH 44/60] SH: cpuinfo: Fix a warning for CONFIG_CPUMASK_OFFSTACK
+Subject: [PATCH 44/61] SH: cpuinfo: Fix a warning for CONFIG_CPUMASK_OFFSTACK
 
 When CONFIG_CPUMASK_OFFSTACK and CONFIG_DEBUG_PER_CPU_MAPS is selected,
 cpu_max_bits_warn() generates a runtime warning similar as below while

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-drm-Makefile-Move-tiny-drivers-before-native-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-drm-Makefile-Move-tiny-drivers-before-native-drivers.patch
@@ -1,7 +1,7 @@
 From 71e5826401f3e81a637fb5b10f498709783fe911 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 7 Nov 2023 20:25:53 +0800
-Subject: [PATCH 45/60] drm/Makefile: Move tiny drivers before native drivers
+Subject: [PATCH 45/61] drm/Makefile: Move tiny drivers before native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from
 device_initcall to subsys_initcall_sync") some Lenovo laptops get a blank

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-drm-radeon-Workaround-radeon-driver-bug-for-Loongson.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-drm-radeon-Workaround-radeon-driver-bug-for-Loongson.patch
@@ -1,7 +1,7 @@
 From 9f507870b7b590374e31f665e975e5572fd49130 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 46/60] drm/radeon: Workaround radeon driver bug for Loongson
+Subject: [PATCH 46/61] drm/radeon: Workaround radeon driver bug for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so
 irq handler must update an old ih.rptr value in IH_RB_RPTR register to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-stmmac-Expose-module-parameters.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-stmmac-Expose-module-parameters.patch
@@ -1,7 +1,7 @@
 From 23336c1c147da77c7902752ffe7e36294e9dc620 Mon Sep 17 00:00:00 2001
 From: Feiyang Chen <chenfeiyang@loongson.cn>
 Date: Wed, 17 Aug 2022 15:29:18 +0800
-Subject: [PATCH 47/60] stmmac: Expose module parameters
+Subject: [PATCH 47/61] stmmac: Expose module parameters
 
 Expose module parameters so that we can use them in specific device
 configurations. Add the 'stmmac_' prefix for them to avoid conflicts.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-stmmac-pci-Add-LS7A-support-for-dwmac-loongson.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-stmmac-pci-Add-LS7A-support-for-dwmac-loongson.patch
@@ -1,7 +1,7 @@
 From 7e62e81cf578872c2c75abb44f3d6a77a2c132e2 Mon Sep 17 00:00:00 2001
 From: Feiyang Chen <chenfeiyang@loongson.cn>
 Date: Wed, 17 Aug 2022 15:29:19 +0800
-Subject: [PATCH 48/60] stmmac: pci: Add LS7A support for dwmac-loongson
+Subject: [PATCH 48/61] stmmac: pci: Add LS7A support for dwmac-loongson
 
 Current dwmac-loongson only support LS2K in the "probed with PCI and
 configured with DT" manner. We add LS7A support on which the devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-LoongArch-KVM-Optimization-for-memslot-hugepage-chec.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-LoongArch-KVM-Optimization-for-memslot-hugepage-chec.patch
@@ -1,7 +1,7 @@
 From 6c90037625213ada24690485c08e9ea62a138430 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 19 Dec 2023 10:48:27 +0800
-Subject: [PATCH 49/60] LoongArch: KVM: Optimization for memslot hugepage
+Subject: [PATCH 49/61] LoongArch: KVM: Optimization for memslot hugepage
  checking
 
 During shadow mmu page fault, there is checking for huge page for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-LoongArch-KVM-Remove-SW-timer-switch-when-vcpu-is-ha.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-LoongArch-KVM-Remove-SW-timer-switch-when-vcpu-is-ha.patch
@@ -1,7 +1,7 @@
 From 21828aed9a0500a54ac1ced2916b0c4b578127fe Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 19 Dec 2023 10:48:27 +0800
-Subject: [PATCH 50/60] LoongArch: KVM: Remove SW timer switch when vcpu is
+Subject: [PATCH 50/61] LoongArch: KVM: Remove SW timer switch when vcpu is
  halt polling
 
 With halt-polling supported, there is checking for pending events or

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-LoongArch-KVM-Allow-to-access-HW-timer-CSR-registers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-LoongArch-KVM-Allow-to-access-HW-timer-CSR-registers.patch
@@ -1,7 +1,7 @@
 From 2c09b9a1e09694844866f5f4505bc1fb4410720b Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 19 Dec 2023 10:48:27 +0800
-Subject: [PATCH 51/60] LoongArch: KVM: Allow to access HW timer CSR registers
+Subject: [PATCH 51/61] LoongArch: KVM: Allow to access HW timer CSR registers
  always
 
 Currently HW timer CSR registers are allowed to access before entering

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-LoongArch-KVM-Remove-kvm_acquire_timer-before-enteri.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-LoongArch-KVM-Remove-kvm_acquire_timer-before-enteri.patch
@@ -1,7 +1,7 @@
 From 7c88cbb27463bae58a38bb7ad990707d3651b8ec Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 19 Dec 2023 10:48:28 +0800
-Subject: [PATCH 52/60] LoongArch: KVM: Remove kvm_acquire_timer() before
+Subject: [PATCH 52/61] LoongArch: KVM: Remove kvm_acquire_timer() before
  entering guest
 
 Timer emulation method in VM is switch to SW timer, there are two

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-LoongArch-KVM-Fix-timer-emulation-with-oneshot-mode.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-LoongArch-KVM-Fix-timer-emulation-with-oneshot-mode.patch
@@ -1,7 +1,7 @@
 From 13ed73ed06edba807cd2205c7c1e67b24de151b8 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 19 Dec 2023 10:48:28 +0800
-Subject: [PATCH 53/60] LoongArch: KVM: Fix timer emulation with oneshot mode
+Subject: [PATCH 53/61] LoongArch: KVM: Fix timer emulation with oneshot mode
 
 When timer is fired in oneshot mode, CSR TVAL will be -1 rather than 0.
 There needs special handing for this situation. There are two scenarios

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-LoongArch-KVM-Add-LSX-128bit-SIMD-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-LoongArch-KVM-Add-LSX-128bit-SIMD-support.patch
@@ -1,7 +1,7 @@
 From c3fc5276d98984fd9deb6e0c41651aba1a336f13 Mon Sep 17 00:00:00 2001
 From: Tianrui Zhao <zhaotianrui@loongson.cn>
 Date: Tue, 19 Dec 2023 10:48:28 +0800
-Subject: [PATCH 54/60] LoongArch: KVM: Add LSX (128bit SIMD) support
+Subject: [PATCH 54/61] LoongArch: KVM: Add LSX (128bit SIMD) support
 
 This patch adds LSX (128bit SIMD) support for LoongArch KVM.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-LoongArch-KVM-Add-LASX-256bit-SIMD-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-LoongArch-KVM-Add-LASX-256bit-SIMD-support.patch
@@ -1,7 +1,7 @@
 From f52444676281eef558fa4f68fa309fe2e3a36cc3 Mon Sep 17 00:00:00 2001
 From: Tianrui Zhao <zhaotianrui@loongson.cn>
 Date: Tue, 19 Dec 2023 10:48:28 +0800
-Subject: [PATCH 55/60] LoongArch: KVM: Add LASX (256bit SIMD) support
+Subject: [PATCH 55/61] LoongArch: KVM: Add LASX (256bit SIMD) support
 
 This patch adds LASX (256bit SIMD) support for LoongArch KVM.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-LoongArch-add-la_ow_syscall-as-in-tree-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-LoongArch-add-la_ow_syscall-as-in-tree-module.patch
@@ -1,7 +1,7 @@
 From 6fe4a6d02358eef857e4f34a46d675f245b5bf89 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Wed, 21 Feb 2024 16:58:32 -0500
-Subject: [PATCH 56/60] LoongArch: add la_ow_syscall as in-tree module
+Subject: [PATCH 56/61] LoongArch: add la_ow_syscall as in-tree module
 
 Co-authored-By: Miao Wang <shankerwangmiao@gmail.com>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
 From ced1ed4ebc1a649ea8dc1ff704a44e739e58b7b6 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 57/60] la_ow_syscall: add kconfig for module
+Subject: [PATCH 57/61] la_ow_syscall: add kconfig for module
 
 ---
  arch/loongarch/Kconfig            |  2 ++

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-drm-loongson-Error-out-if-no-VRAM-detected.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-drm-loongson-Error-out-if-no-VRAM-detected.patch
@@ -1,7 +1,7 @@
 From d289d784fa3aebd97be49f1cd6a14c5c6e1e50a2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 19 Jan 2024 18:40:49 +0800
-Subject: [PATCH 58/60] drm/loongson: Error out if no VRAM detected
+Subject: [PATCH 58/61] drm/loongson: Error out if no VRAM detected
 
 If there is no VRAM (it is true if there is a discreted card), we get
 such an error and Xorg fails to start:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-HACK-use-amdgpu-by-default-for-si-cik-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-HACK-use-amdgpu-by-default-for-si-cik-devices.patch
@@ -1,7 +1,7 @@
 From 7948bfe1b5e7c4a73666052f161532e0f7725c51 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 29 Feb 2024 20:54:51 +0800
-Subject: [PATCH 59/60] HACK: use amdgpu by default for si/cik devices
+Subject: [PATCH 59/61] HACK: use amdgpu by default for si/cik devices
 
 On LoongArch, radeon causes a memory read violation that crashes
 radeonsi_dri.so (and all processes that loaded this module). When using

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-ethernet-bundle-module-for-Motorcomm-YT6801.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-ethernet-bundle-module-for-Motorcomm-YT6801.patch
@@ -1,7 +1,7 @@
 From 3ad44930fddc2ab6d68b2eb85c6f690d77a4a360 Mon Sep 17 00:00:00 2001
 From: wanghuai <748928840@qq.com>
 Date: Fri, 2 Feb 2024 19:05:26 +0000
-Subject: [PATCH 60/60] ethernet: bundle module for Motorcomm YT6801
+Subject: [PATCH 60/61] ethernet: bundle module for Motorcomm YT6801
 
 - The Asus XC-LS3A6M motherboard (Loongson 3A6000) comes with two Ethernet
   ports, which uses a yt6801 controller.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0061-LoongArch-Change-__my_cpu_offset-definition-to-avoid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0061-LoongArch-Change-__my_cpu_offset-definition-to-avoid.patch
@@ -1,0 +1,53 @@
+From 2a386fe141eb5b65e15660bb50a32d97a52a9b1c Mon Sep 17 00:00:00 2001
+From: Huacai Chen <chenhuacai@loongson.cn>
+Date: Fri, 15 Mar 2024 10:45:26 +0800
+Subject: [PATCH 61/61] LoongArch: Change __my_cpu_offset definition to avoid
+ mis-optimization
+
+From GCC commit 3f13154553f8546a ("df-scan: remove ad-hoc handling of
+global regs in asms"), global registers will no longer be forced to add
+to the def-use chain. Then current_thread_info(), current_stack_pointer
+and __my_cpu_offset may be lifted out of the loop because they are no
+longer treated as "volatile variables".
+
+This optimization is still correct for the current_thread_info() and
+current_stack_pointer usages because they are associated to a thread.
+However it is wrong for __my_cpu_offset because it is associated to a
+CPU rather than a thread: if the thread migrates to a different CPU in
+the loop, __my_cpu_offset should be changed.
+
+Change __my_cpu_offset definition to treat it as a "volatile variable",
+in order to avoid such a mis-optimization.
+
+Cc: stable@vger.kernel.org
+Reported-by: Xiaotian Wu <wuxiaotian@loongson.cn>
+Reported-by: Miao Wang <shankerwangmiao@gmail.com>
+Signed-off-by: Xing Li <lixing@loongson.cn>
+Signed-off-by: Hongchen Zhang <zhanghongchen@loongson.cn>
+Signed-off-by: Rui Wang <wangrui@loongson.cn>
+Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
+---
+ arch/loongarch/include/asm/percpu.h | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/arch/loongarch/include/asm/percpu.h b/arch/loongarch/include/asm/percpu.h
+index 9b36ac003f89..8f290e5546cf 100644
+--- a/arch/loongarch/include/asm/percpu.h
++++ b/arch/loongarch/include/asm/percpu.h
+@@ -29,7 +29,12 @@ static inline void set_my_cpu_offset(unsigned long off)
+ 	__my_cpu_offset = off;
+ 	csr_write64(off, PERCPU_BASE_KS);
+ }
+-#define __my_cpu_offset __my_cpu_offset
++
++#define __my_cpu_offset					\
++({							\
++	__asm__ __volatile__("":"+r"(__my_cpu_offset));	\
++	__my_cpu_offset;				\
++})
+ 
+ #define PERCPU_OP(op, asm_op, c_op)					\
+ static __always_inline unsigned long __percpu_##op(void *ptr,		\
+-- 
+2.44.0
+

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -1,5 +1,5 @@
 VER=6.7.5
-REL=1
+REL=2
 # RC=
 # Use this for RC releases.
 #SRCS="tbl::https://git.kernel.org/torvalds/t/linux-${VER%%.0}-rc${RC}.tar.gz"


### PR DESCRIPTION
Topic Description
-----------------

- linux-kernel: import patch to fix process hang on loongarch64

Package(s) Affected
-------------------

- linux-kernel: 1:6.7.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
