### PR TITLE
i3wm: suggest packages used in default config

### DIFF
--- a/desktop-wm/i3/autobuild/defines
+++ b/desktop-wm/i3/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=i3
 PKGSEC=x11
-PKGDEP="dex dmenu libev libxkbcommon pango perl-anyevent-i3 perl-json-xs \
+PKGDEP="libev libxkbcommon pango perl-anyevent-i3 perl-json-xs \
         startup-notification xcb-util-cursor xcb-util-keysyms \
-        xcb-util-wm yajl xcb-util-xrm xss-lock"
-PKGSUG="i3lock i3status"
+        xcb-util-wm yajl xcb-util-xrm"
+PKGRECOM="i3lock i3status dex nm-applet dmenu xss-lock"
 BUILDDEP="graphviz doxygen xmlto"
 PKGDES="Improved tiling WM (window manager)"
 PKGBREAK="i3-gaps<=4.21.1"

--- a/desktop-wm/i3/spec
+++ b/desktop-wm/i3/spec
@@ -1,4 +1,5 @@
 VER=4.23
+REL=1
 SRCS="tbl::https://i3wm.org/downloads/i3-$VER.tar.xz"
 CHKSUMS="sha256::61026a7196c9139d0f3aadd27197e8b320c576e3a450e01d74c1aca484044c46"
 CHKUPDATE="anitya::id=1348"


### PR DESCRIPTION
Topic Description
-----------------

- i3: suggest packages used in default config
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- i3: 4.23-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit i3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
