### PR TITLE
FTBFS fix for loongarch batch #8

### DIFF
--- a/app-games/cataclysm/autobuild/prepare
+++ b/app-games/cataclysm/autobuild/prepare
@@ -1,1 +1,3 @@
-acbs_copy_git
+# https://github.com/CleverRaven/Cataclysm-DDA/pull/65542
+abinfo "Fixing GCC13 incompatilities ..."
+export CXXFLAGS="$CXXFLAGS -Wno-dangling-reference -Wno-c++20-compat -Wno-maybe-uninitialized"

--- a/app-games/cataclysm/spec
+++ b/app-games/cataclysm/spec
@@ -1,4 +1,4 @@
-VER=0.F+3
-SRCS="git::commit=tags/${VER/+/-}::https://github.com/CleverRaven/Cataclysm-DDA"
+VER=0.G
+SRCS="git::commit=tags/${VER/+/-};copy-repo=true::https://github.com/CleverRaven/Cataclysm-DDA"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=192505"

--- a/app-web/carbons/autobuild/build
+++ b/app-web/carbons/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building carbons ..."
+make FLAGS="$CFLAGS"
+
+abinfo "Installing carbons ..."
+make install DESTDIR="$PKGDIR"

--- a/app-web/carbons/autobuild/defines
+++ b/app-web/carbons/autobuild/defines
@@ -2,6 +2,3 @@ PKGNAME=carbons
 PKGDES="Experimental XEP-0280: Message Carbons plugin for libpurple."
 PKGSEC=web
 PKGDEP="libpurple glib libxml2"
-
-ABTYPE=plainmake
-MAKE_AFTER="PURPLE_PLUGIN_DIR=$PKGDIR/usr/lib/purple-2"

--- a/app-web/carbons/spec
+++ b/app-web/carbons/spec
@@ -1,4 +1,5 @@
 VER=0.2.3
-SRCS="https://github.com/gkdr/carbons/archive/v${VER}.tar.gz"
-CHKSUMS="sha384::5f2e7f35f52eab6f6f10ce6f55386723a36e74eb5f55d118d3a48f7a56e4d41d837e68d0c1f0e5add52ba6a36b474c32"
+REL=1
+SRCS="git::commit=tags/v$VER::https://github.com/gkdr/carbons"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231942"

--- a/desktop-gnome/calls/autobuild/defines
+++ b/desktop-gnome/calls/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=calls
 PKGSEC=gnome
 PKGDEP="wayland gtk-3 gom libpeas gsound folks evolution-data-server \
         modemmanager libhandy callaudiod feedbackd sofia-sip"
-BUILDDEP="appstream-glib gtk-doc vala"
+BUILDDEP="appstream-glib gtk-doc vala docutils"
 PKGDES="Phone dialer and call handler for GNOME/Phosh"
 
 MESON_AFTER="-Dgtk_doc=true"

--- a/desktop-gnome/calls/spec
+++ b/desktop-gnome/calls/spec
@@ -1,4 +1,4 @@
-VER=42.0
-SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/calls"
+VER=46.0
+SRCS="git::commit=tags/v$VER::https://gitlab.gnome.org/GNOME/calls"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=111609"

--- a/desktop-gnome/feedbackd/autobuild/defines
+++ b/desktop-gnome/feedbackd/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=feedbackd
+PKGSEC=admin
+PKGDEP="systemd glib gsound json-glib libgudev"
+BUILDDEP="gobject-introspection gtk-doc vala jinja2 typogrify tomli docutils"
+PKGDES="Daemon to provide haptic, LED, and audio feedback triggered by application events"
+
+MESON_AFTER="-Dintrospection=enabled \
+             -Dvapi=true \
+             -Ddaemon=true \
+             -Dgtk_doc=true \
+             -Dman=true"
+
+PKGEPOCH=1

--- a/desktop-gnome/feedbackd/spec
+++ b/desktop-gnome/feedbackd/spec
@@ -1,0 +1,4 @@
+VER=0.2.1
+SRCS="git::commit=tags/v$VER::https://source.puri.sm/Librem5/feedbackd"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=89345"

--- a/desktop-wm/bspwm/autobuild/build
+++ b/desktop-wm/bspwm/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building bspwm ..."
+make
+
+abinfo "Installing bspwm ..."
+make install PREFIX=/usr DESTDIR="$PKGDIR"

--- a/desktop-wm/bspwm/spec
+++ b/desktop-wm/bspwm/spec
@@ -1,5 +1,4 @@
-VER=0.9.5
-SRCS="tbl::https://github.com/baskerville/bspwm/archive/$VER.tar.gz"
-CHKSUMS="sha256::273591baf6a15d317cfedf4a423c51c132c52dd05b0328d6994f7bdc3982f782"
-REL=1
+VER=0.9.10
+SRCS="git::commit=tags/$VER::https://github.com/baskerville/bspwm"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14715"


### PR DESCRIPTION
Topic Description
-----------------

- cataclysm: update to 0.G
- carbons: migrate to ab4
- calls: update to 46.0
- feedbackd: new, 0.2.1
    Revived as a dependency of desktop-gnome/calls.
- bspwm: update to 0.9.10 and migrate to ab4

Package(s) Affected
-------------------

- cataclysm: 0.G
- carbons: 0.2.3-1
- bspwm: 0.9.10
- feedbackd: 1:0.2.1
- calls: 46.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bspwm feedbackd calls carbons cataclysm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
