### PR TITLE
FTBFS fix for loongarch batch #9

### DIFF
--- a/app-multimedia/cdcover/autobuild/beyond
+++ b/app-multimedia/cdcover/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Moving /usr/doc/cdcover to /usr/share/doc/cdcover ..."
+mkdir -pv "$PKGDIR"/usr/share/doc
+mv -v "$PKGDIR"/usr/doc/cdcover "$PKGDIR"/usr/share/doc/cdcover
+rm -vr "$PKGDIR"/usr/doc

--- a/app-multimedia/cdcover/autobuild/defines
+++ b/app-multimedia/cdcover/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=cdcover
 PKGSEC=utils
 PKGDEP="python-2"
 PKGDES="Cdcover allows the creation of inlay-sheets of CD cases and DVDs"
+
+ABHOST=noarch

--- a/app-multimedia/cdcover/spec
+++ b/app-multimedia/cdcover/spec
@@ -1,5 +1,5 @@
 VER=0.7.4
-REL=2
+REL=3
 SRCS="tbl::https://sourceforge.net/projects/cdcover/files/cdcover/cdcover-$VER/cdcover-$VER.tar.gz"
 CHKSUMS="sha256::f93d8cd2b85f21872e18f61f22522ff56ab70d627ae45cf970d689166327a6c0"
 CHKUPDATE="anitya::id=14554"

--- a/app-utils/cd-discid/autobuild/build
+++ b/app-utils/cd-discid/autobuild/build
@@ -1,2 +1,5 @@
+abinfo "Building cd-discid ..."
 make CFLAGS="$CFLAGS -DVERSION=\"1.4\"" LDFLAGS="$LDFLAGS -DVERSION=\"1.4\""
-make install DESTDIR=$PKGDIR PREFIX=/usr 
+
+abinfo "Installing cd-discid ..."
+make install DESTDIR=$PKGDIR PREFIX=/usr STRIP="echo"

--- a/app-utils/lpaq/spec
+++ b/app-utils/lpaq/spec
@@ -1,4 +1,6 @@
 VER=8
+# Do not remvoe REL! apt is buggy
+REL=1
 SRCS="tbl::https://www.cs.fit.edu/~mmahoney/compression/lpaq$VER.zip"
 CHKSUMS="sha256::ea43474526f13338cbb50ce3fbd974a0d088d77a3b73d42010ad11fb89a498b2"
 SUBDIR=.

--- a/runtime-common/ucommon/autobuild/prepare
+++ b/runtime-common/ucommon/autobuild/prepare
@@ -1,0 +1,3 @@
+# FTBFS: ISO C++17 does not allow dynamic exception specifications 
+abinfo "Adding --std=c++14 to CFLAGS ..."
+export CXXFLAGS="$CXXFLAGS --std=c++14"

--- a/runtime-common/ucommon/spec
+++ b/runtime-common/ucommon/spec
@@ -1,5 +1,5 @@
 VER=7.0.0
-REL=3
+REL=4
 SRCS="tbl::https://ftp.gnu.org/pub/gnu/commoncpp/ucommon-$VER.tar.gz"
 CHKSUMS="sha256::6ac9f76c2af010f97e916e4bae1cece341dc64ca28e3881ff4ddc3bc334060d7"
 CHKUPDATE="anitya::id=5024"

--- a/runtime-multimedia/libmirage/spec
+++ b/runtime-multimedia/libmirage/spec
@@ -1,4 +1,4 @@
-VER=3.2.4
-SRCS="tbl::https://downloads.sourceforge.net/cdemu/libmirage-$VER.tar.bz2"
-CHKSUMS="sha256::fc5b3b8acd40d63c6194fba65c841b906a8074e89b14a10bf76f35d1c371a355"
+VER=3.2.7
+SRCS="tbl::https://downloads.sourceforge.net/cdemu/libmirage-$VER.tar.xz"
+CHKSUMS="sha256::fa892480d7954bcca8292ad00f2e08b7b3e23e54d288eb14a05c50d454bdb3d3"
 CHKUPDATE="anitya::id=1661"


### PR DESCRIPTION
Topic Description
-----------------

- libmirage: update to 3.2.7
- cdcover: migrate to ab4
- cd-discid: migrate to ab4
- lpaq: bump REL due to apt bug
- ucommon: fix GCC 13 compat

Package(s) Affected
-------------------

- cd-discid: 1.4-2
- lpaq: 8-1
- libmirage: 3.2.7
- cdcover: 0.7.4-3
- ucommon: 7.0.0-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit ucommon lpaq cd-discid cdcover libmirage
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
