### PR TITLE
FTBFS fix for loongarch batch #10

### DIFF
--- a/app-scientific/chemtool/autobuild/prepare
+++ b/app-scientific/chemtool/autobuild/prepare
@@ -1,0 +1,3 @@
+# FTBFS: multiple definition
+abinfo "Adding -fcommon to CFLAGS ..."
+export CFLAGS="$CFLAGS -fcommon"

--- a/app-scientific/chemtool/spec
+++ b/app-scientific/chemtool/spec
@@ -1,5 +1,5 @@
 VER=1.6.14
-REL=3
+REL=4
 SRCS="tbl::http://ruby.chemie.uni-freiburg.de/~martin/chemtool/chemtool-$VER.tar.gz"
 CHKSUMS="sha256::86161a0461386b334a5ffb17cdf094a491941884678272f45749813514ddafcb"
 CHKUPDATE="anitya::id=278"

--- a/app-utils/cmix/autobuild/build
+++ b/app-utils/cmix/autobuild/build
@@ -1,5 +1,7 @@
-make
-install -Dm755 cmix "$PKGDIR"/usr/bin/cmix
+abinfo "Building cmix ..."
+make CC=g++
 
-mkdir -p "$PKGDIR"/usr/share/cmix/
-cp -r dictionary "$PKGDIR"/usr/share/cmix/
+abinfo "Installing cmix ..."
+install -Dvm755 "$SRCDIR"/cmix "$PKGDIR"/usr/bin/cmix
+mkdir -vp "$PKGDIR"/usr/share/cmix/
+cp -vr "$SRCDIR"/dictionary "$PKGDIR"/usr/share/cmix/

--- a/app-utils/cmix/autobuild/defines
+++ b/app-utils/cmix/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=cmix
-PGKSEC=utils
+PKGSEC=utils
 PKGDEP="glibc"
 PKGDES="A lossless data compression program"
 

--- a/app-utils/cmix/autobuild/patches/0001-remove-opt-flags-override.patch
+++ b/app-utils/cmix/autobuild/patches/0001-remove-opt-flags-override.patch
@@ -1,0 +1,12 @@
+diff --git a/makefile b/makefile
+index 0b2196b..323f709 100644
+--- a/makefile
++++ b/makefile
+@@ -1,7 +1,6 @@
+ CC = clang++
+ LFLAGS = -std=c++11 -Wall
+ 
+-all: LFLAGS += -Ofast -march=native
+ all: cmix enwik9-preproc
+ 
+ debug: LFLAGS += -ggdb

--- a/app-utils/cmix/spec
+++ b/app-utils/cmix/spec
@@ -1,5 +1,4 @@
-VER=16
-SRCS="tbl::https://github.com/byronknoll/cmix/archive/v$VER.tar.gz"
-CHKSUMS="sha256::66924f82a63e1b3ac1167192da1618810700d467e7469c8def6c7b3127d597ae"
-REL=1
+VER=20
+SRCS="git::commit=tags/v$VER::https://github.com/byronknoll/cmix"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231569"

--- a/app-utils/compsize/autobuild/build
+++ b/app-utils/compsize/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building compsize ..."
+make
+
+abinfo "Installing compsize ..."
+mkdir -vp "$PKGDIR"/usr/share/man/man8
+make install DESTDIR="$PKGDIR"

--- a/app-utils/compsize/spec
+++ b/app-utils/compsize/spec
@@ -1,4 +1,4 @@
-VER=1.3
-SRCS="tbl::https://github.com/kilobyte/compsize/archive/v$VER.tar.gz"
-CHKSUMS="sha256::c10823c940641404cd6eb9c801d43b307e87e9252e8eded66eed8be750c4f884"
+VER=1.5
+SRCS="git::commit=tags/v$VER::https://github.com/kilobyte/compsize"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17663"

--- a/lang-lua/toluapp/autobuild/defines
+++ b/lang-lua/toluapp/autobuild/defines
@@ -1,5 +1,8 @@
 PKGNAME=toluapp
-PKGSEC=lua
+PKGSEC=devel
 PKGDEP="lua"
 BUILDDEP="cmake"
 PKGDES="A tool to integrate C/C++ code with Lua"
+
+# force linkage with lua 5.1
+CMAKE_AFTER="-DLUA_LIBRARIES=lua5.1"

--- a/lang-lua/toluapp/spec
+++ b/lang-lua/toluapp/spec
@@ -1,4 +1,5 @@
 VER=1.0.93
-SRCS="tbl::https://github.com/LuaDist/toluapp/archive/$VER.tar.gz"
-CHKSUMS="sha256::0a1ff87cb74e7531aec57e2a7cfdf282116647dea3b46223e3cc7c362b55b5bb"
+REL=1
+SRCS="git::commit=tags/$VER::https://github.com/LuaDist/toluapp"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230583"

--- a/runtime-common/concurrencykit/autobuild/build
+++ b/runtime-common/concurrencykit/autobuild/build
@@ -1,0 +1,10 @@
+# Package does not use autotools, and not recognize --enable-option-checking=fatal
+# Therefore disable autotools-related fetures
+abinfo "Configuring concurrencykit ..."
+"$SRCDIR"/configure --prefix=/usr
+
+abinfo "Building concurrencykit ..."
+make
+
+abinfo "Installing concurrencykit ..."
+make install DESTDIR="$PKGDIR"

--- a/runtime-common/concurrencykit/autobuild/defines
+++ b/runtime-common/concurrencykit/autobuild/defines
@@ -2,8 +2,3 @@ PKGNAME=concurrencykit
 PKGDES="C library to aid concurrent application development"
 PKGSEC=libs
 PKGDEP="glibc"
-
-# Package does not use autotools, and not recognize --enable-option-checking=fatal
-# Therefore disable autotools-related fetures
-RECONF=0
-AUTOTOOLS_STRICT=0

--- a/runtime-common/concurrencykit/spec
+++ b/runtime-common/concurrencykit/spec
@@ -1,4 +1,5 @@
 VER=0.7.1
+REL=1
 SRCS="tbl::https://github.com/concurrencykit/ck/archive/refs/tags/${VER}.tar.gz"
 CHKUPDATE="anitya::id=292814"
 CHKSUMS="sha256::97d2a21d5326ef79b4668be2e6eda6284ee77a64c0981b35fd9695c736c3d4ac"


### PR DESCRIPTION
Topic Description
-----------------

- toluapp: fix PKGSEC
- concurrencykit: migrate to ab4
- compsize: update to 1.5
- cmix: update to 20
- chemtool: fix FTBFS

Package(s) Affected
-------------------

- cmix: 20
- compsize: 1.5
- toluapp: 1.0.93-1
- chemtool: 1.6.14-4
- concurrencykit: 0.7.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit chemtool cmix compsize concurrencykit toluapp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
