### PR TITLE
rhash: update to 1.4.4

### DIFF
--- a/app-devel/cmake/spec
+++ b/app-devel/cmake/spec
@@ -1,4 +1,5 @@
 VER=3.27.8
+REL=1
 SRCS="tbl::https://cmake.org/files/v${VER:0:4}/cmake-$VER.tar.gz"
 CHKSUMS="sha256::fece24563f697870fbb982ea8bf17482c9d5f855d8c9bf0b82463d76c9e8d0cc"
 CHKUPDATE="anitya::id=306"

--- a/app-utils/rhash/spec
+++ b/app-utils/rhash/spec
@@ -1,5 +1,4 @@
-VER=1.3.9
-REL=4
-SRCS="tbl::https://github.com/rhash/RHash/archive/v$VER.tar.gz"
-CHKSUMS="sha256::42b1006f998adb189b1f316bf1a60e3171da047a85c4aaded2d0d26c1476c9f6"
+VER=1.4.4
+SRCS="git::commit=tags/v$VER::https://github.com/rhash/RHash"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13843"


### PR DESCRIPTION
Topic Description
-----------------

- cmake: bump REL due to rhash update
- rhash: update to 1.4.4

Package(s) Affected
-------------------

- rhash: 1.4.4
- cmake: 3.27.8-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rhash cmake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
