### PR TITLE
rmlint: update to 2.10.2

### DIFF
--- a/app-utils/rmlint/spec
+++ b/app-utils/rmlint/spec
@@ -1,4 +1,4 @@
-VER=2.10.1
-SRCS="tbl::https://github.com/sahib/rmlint/archive/v$VER.tar.gz"
-CHKSUMS="sha256::10e72ba4dd9672d1b6519c0c94eae647c5069c7d11f1409a46e7011dd0c6b883"
+VER=2.10.2
+SRCS="git::commit=tags/v$VER::https://github.com/sahib/rmlint"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19045"


### PR DESCRIPTION
Topic Description
-----------------

- rmlint: update to 2.10.2

Package(s) Affected
-------------------

- rmlint: 2.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rmlint
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
