### PR TITLE
roxterm: update to 3.14.3

### DIFF
--- a/app-utils/roxterm/autobuild/defines
+++ b/app-utils/roxterm/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=roxterm
 PKGSEC=x11
-PKGDEP="dbus-glib hicolor-icon-theme vte-gtk3"
+PKGDEP="dbus-glib hicolor-icon-theme vte"
 BUILDDEP="docbook-xsl imagemagick itstool librsvg po4a xmlto"
 PKGDES="A tabbed, VTE-based terminal emulator"

--- a/app-utils/roxterm/spec
+++ b/app-utils/roxterm/spec
@@ -1,4 +1,4 @@
-VER=3.7.3
-SRCS="tbl::https://github.com/realh/roxterm/archive/$VER.tar.gz"
-CHKSUMS="sha256::59b1ab781477a712b4509dac812931bff3c2bb7a9a82435f43430bede5cdca13"
+VER=3.14.3
+SRCS="git::commit=tags/$VER::https://github.com/realh/roxterm"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4207"


### PR DESCRIPTION
Topic Description
-----------------

- roxterm: update to 3.14.3

Package(s) Affected
-------------------

- roxterm: 3.14.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit roxterm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
