### PR TITLE
FTBFS fix for loongarch batch #11

### DIFF
--- a/app-admin/cpulimit/autobuild/build
+++ b/app-admin/cpulimit/autobuild/build
@@ -1,3 +1,8 @@
+abinfo "Building cpulimit ..."
 make
-install -Dm755 cpulimit "$PKGDIR"/usr/bin/cpulimit
-install -Dm755 cpulimit.1 "$PKGDIR"/usr/share/man/man1/cpulimit.1
+
+abinfo "Installing cpulimit ..."
+install -Dvm755 "$SRCDIR"/cpulimit \
+    "$PKGDIR"/usr/bin/cpulimit
+install -Dvm755 "$SRCDIR"/cpulimit.1 \
+    "$PKGDIR"/usr/share/man/man1/cpulimit.1

--- a/app-admin/cpulimit/spec
+++ b/app-admin/cpulimit/spec
@@ -1,4 +1,4 @@
-VER=2.7
+VER=3.0
 SRCS="tbl::https://fossies.org/linux/misc/cpulimit-$VER.tar.gz"
-CHKSUMS="sha256::1de040a4f8a40dfe8c7a025fe98075673468fbc3fccccbc231bc7402f62ec4a0"
+CHKSUMS="sha256::ad2f415eb2bbda3e83a8a2d918ef5e90f52ebcc6fee61e94bf917b3e84ebb49c"
 CHKUPDATE="anitya::id=226697"

--- a/app-devel/cvechecker/autobuild/defines
+++ b/app-devel/cvechecker/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=cvechecker
-PKGSEC=security
+PKGSEC=utils
 PKGDEP="libconfig libxslt sqlite wget"
 PKGDES="Command-line utility to scan the system and report on potential vulnerabilities, based on public CVE data"
 

--- a/app-devel/cvechecker/spec
+++ b/app-devel/cvechecker/spec
@@ -1,4 +1,5 @@
 VER=3.9
-SRCS="tbl::https://github.com/sjvermeu/cvechecker/archive/v$VER.tar.gz"
-CHKSUMS="sha256::a8c05be9e81533bd1b9441fe1a38e54d2939123af7c5d933bac28cb51d41dc27"
+REL=1
+SRCS="git::commit=tags/v$VER::https://github.com/sjvermeu/cvechecker"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15634"

--- a/app-devel/radare2/autobuild/defines
+++ b/app-devel/radare2/autobuild/defines
@@ -3,8 +3,8 @@ PKGDES="A reverse-engineering statical analyze tool"
 PKGDEP="capstone libzip openssl"
 PKGSEC=devel
 
-AUTOTOOLS_AFTER="--prefix=/usr \
-                 --with-syscapstone \
-                 --with-syszip \
-                 --with-openssl"
-ABSHADOW=0
+ABTYPE=meson
+
+MESON_AFTER="-D use_sys_capstone=true \
+	-D use_sys_zip=true \
+	-D use_sys_openssl=true"

--- a/app-devel/radare2/autobuild/prepare
+++ b/app-devel/radare2/autobuild/prepare
@@ -1,1 +1,0 @@
-unset AUTOTOOLS_DEF

--- a/app-devel/radare2/spec
+++ b/app-devel/radare2/spec
@@ -1,5 +1,4 @@
-VER=5.1.1
-SRCS="tbl::https://github.com/radare/radare2/archive/$VER.tar.gz"
-CHKSUMS="sha256::34c22680ee55addd942392725c79d2457dfcadf32bbaf10d144d338368f86f2f"
+VER=5.8.8
+SRCS="git::commit=tags/$VER::https://github.com/radare/radare2"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11009"
-REL=1

--- a/app-utils/cpufrequtils/autobuild/build
+++ b/app-utils/cpufrequtils/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building cpufrequtils ..."
+make
+
+abinfo "Installing cpufrequtils ..."
+make install DESTDIR="$PKGDIR" mandir=/usr/share/man

--- a/app-utils/cpufrequtils/spec
+++ b/app-utils/cpufrequtils/spec
@@ -1,5 +1,5 @@
 VER=008
-REL=1
+REL=2
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/kernel/cpufreq/cpufrequtils-$VER.tar.xz"
 CHKSUMS="sha256::a2149db551f83112209b1a8e79bd50d386979bbf64edbc69126f4e0b4f0a4cab"
 CHKUPDATE="anitya::id=231572"

--- a/lang-lua/luafilesystem/autobuild/build
+++ b/lang-lua/luafilesystem/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building luafilesystem ..."
+# override variables defined by makefile
+make CFLAGS="$CFLAGS -fPIC" ${MAKE_AFTER}
+
+abinfo "Installing luafilesystem ..."
+make install DESTDIR="$PKGDIR" ${MAKE_AFTER}

--- a/lang-lua/luafilesystem/autobuild/defines
+++ b/lang-lua/luafilesystem/autobuild/defines
@@ -3,5 +3,4 @@ PKGSEC=devel
 PKGDEP="lua"
 PKGDES="File System Library for the Lua Programming Language"
 
-ABMK="LUA_INC=/usr/include/lua5.1"
-MAKE_AFTER="PREFIX=$PKGDIR/usr LUA_LIBDIR=$PKGDIR/usr/lib/lua/5.1"
+MAKE_AFTER="LUA_INC=/usr/include/lua5.1 PREFIX=$PKGDIR/usr LUA_LIBDIR=$PKGDIR/usr/lib/lua/5.1"

--- a/lang-lua/luafilesystem/spec
+++ b/lang-lua/luafilesystem/spec
@@ -1,4 +1,5 @@
 VER=1.7.0.2
-SRCS="tbl::https://github.com/keplerproject/luafilesystem/archive/v${VER//./_}.tar.gz"
-CHKSUMS="sha256::23b4883aeb4fb90b2d0f338659f33a631f9df7a7e67c54115775a77d4ac3cc59"
+REL=1
+SRCS="git::commit=tags/v${VER//./_}::https://github.com/keplerproject/luafilesystem"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230582"


### PR DESCRIPTION
Topic Description
-----------------

- radare2: update to 3.8.8
- cvecheker: fix PKGSEC
- cpulimit: update to 3.0 and migrate to ab4
- cpufrequtils: migrate to ab4
- luafilesystem: migrate to ab4

Package(s) Affected
-------------------

- cpufrequtils: 008-2
- luafilesystem: 1.7.0.2-1
- cpulimit: 3.0
- radare2: 5.8.8
- cvechecker: 3.9-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit luafilesystem cpufrequtils cpulimit cvechecker radare2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
