### PR TITLE
FTBFS fix for loongarch batch #12

### DIFF
--- a/app-a11y/brltty/autobuild/build
+++ b/app-a11y/brltty/autobuild/build
@@ -1,8 +1,12 @@
 for i in 2 3; do
     make distclean || true
-    abinfo "Building Brltty with Python${i} ..."
-    ./configure ${AUTOTOOLS_DEF} ${AUTOTOOLS_AFTER} \
+    abinfo "Configuring Brltty with Python${i} ..."
+    "$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER} \
                 PYTHON=/usr/bin/python$i
+
+    abinfo "Building Brltty with Python${i} ..."
     make
+
+    abinfo "Installing Brltty with Python${i} ..."
     make install DESTDIR="$PKGDIR" INSTALL_ROOT="$PKGDIR"
 done

--- a/app-a11y/brltty/spec
+++ b/app-a11y/brltty/spec
@@ -1,5 +1,5 @@
 VER=6.0
-REL=7
+REL=8
 SRCS="tbl::http://mielke.cc/brltty/archive/brltty-$VER.tar.gz"
 CHKSUMS="sha256::af4bcd1e030416c2b669cc6904f73c30e73bb4ed8f743c2ada9edc87964ab752"
 CHKUPDATE="anitya::id=220"

--- a/runtime-desktop/libappindicator/autobuild/build
+++ b/runtime-desktop/libappindicator/autobuild/build
@@ -5,7 +5,7 @@ cd "$SRCDIR"/build-gtk2
 
 abinfo "Configuring libappindicator for GTK+ 2 ..."
 "$SRCDIR"/configure \
-    ${AUTOTOOLS_DEF} \
+    ${AUTOTOOLS_DEF[@]} \
     --disable-mono-test \
     --with-gtk=2
 
@@ -19,7 +19,7 @@ cd "$SRCDIR"/build-gtk3
 
 abinfo "Configuring libappindicator for GTK+ 3 ..."
 "$SRCDIR"/configure \
-    ${AUTOTOOLS_DEF} \
+    ${AUTOTOOLS_DEF[@]} \
     --disable-mono-test \
     --with-gtk=3
 

--- a/runtime-desktop/libappindicator/spec
+++ b/runtime-desktop/libappindicator/spec
@@ -1,5 +1,5 @@
 VER=12.10.0
-REL=4
+REL=5
 SRCS="https://launchpad.net/libappindicator/${VER%.*}/$VER/+download/libappindicator-$VER.tar.gz"
 CHKSUMS="sha256::d5907c1f98084acf28fd19593cb70672caa0ca1cf82d747ba6f4830d4cc3b49f"
 CHKUPDATE="anitya::id=229549"

--- a/runtime-desktop/libdbusmenu/autobuild/build
+++ b/runtime-desktop/libdbusmenu/autobuild/build
@@ -1,13 +1,24 @@
-mkdir build-gtk{2,3}
+mkdir -vp build-gtk{2,3}
+
+abinfo "Configuring libdbusmenu for gtk-2 ..."
 cd build-gtk2
-../configure ${AUTOTOOLS_DEF} ${AUTOTOOLS_AFTER} \
+"$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER} \
             --with-gtk=2
+
+abinfo "Building libdbusmenu for gtk-2 ..."
 make
+
+abinfo "Installing libdbusmenu for gtk-2 ..."
 make install DESTDIR=$PKGDIR
 
+abinfo "Configuring libdbusmenu for gtk-3 ..."
 cd $SRCDIR/build-gtk3
-../configure ${AUTOTOOLS_DEF} ${AUTOTOOLS_AFTER} \
+"$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER} \
             --with-gtk=3
+
+abinfo "Building libdbusmenu for gtk-3 ..."
 make
+
+abinfo "Installing libdbusmenu for gtk-3 ..."
 make install DESTDIR=$PKGDIR
 cd $SRCDIR

--- a/runtime-desktop/libdbusmenu/spec
+++ b/runtime-desktop/libdbusmenu/spec
@@ -1,5 +1,5 @@
 VER=16.04.0
-REL=3
+REL=4
 SRCS="tbl::https://launchpad.net/dbusmenu/${VER%.?}/$VER/+download/libdbusmenu-$VER.tar.gz"
 CHKSUMS="sha256::b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a"
 CHKUPDATE="anitya::id=89383"

--- a/runtime-i18n/icu/autobuild/build
+++ b/runtime-i18n/icu/autobuild/build
@@ -9,7 +9,7 @@ for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
 done
 
 abinfo "Running configure ..."
-./configure ${AUTOTOOLS_DEF}
+"$SRCDIR"/source/configure ${AUTOTOOLS_DEF[@]}
 
 abinfo "Building binaries ..."
 make

--- a/runtime-i18n/icu/spec
+++ b/runtime-i18n/icu/spec
@@ -1,5 +1,5 @@
 VER=64.2
-REL=4
+REL=5
 SRCS="tbl::https://github.com/unicode-org/icu/releases/download/release-${VER//./-}/icu4c-${VER//./_}-src.tgz"
 CHKSUMS="sha256::627d5d8478e6d96fc8c90fed4851239079a561a6a8b9e48b0892f24e82d31d6c"
 CHKUPDATE="anitya::id=16134"

--- a/runtime-network/libdnet/autobuild/build
+++ b/runtime-network/libdnet/autobuild/build
@@ -1,11 +1,16 @@
+abinfo "Configuring libdnet ..."
 rm -f python/dnet.c
 autoreconf -I config --force --install
-./configure --prefix=/usr --sbindir=/usr/bin ${AUTOTOOLS_DEF}
+"$SRCDIR"/configure --prefix=/usr --sbindir=/usr/bin ${AUTOTOOLS_DEF[@]}
 pyrexc python/dnet.pyx
 
+abinfo "Building libdnet ..."
 make $ABMK $MAKE_AFTER
+
+abinfo "Installing libdnet ..."
 make install BUILDROOT=$PKGDIR DESTDIR=$PKGDIR $MAKE_AFTER
 
+abinfo "Installing libdnet python bindings ..."
 pushd python
 python2 setup.py install --root="$pkgdir"
 popd

--- a/runtime-network/libdnet/spec
+++ b/runtime-network/libdnet/spec
@@ -1,4 +1,5 @@
 VER=1.12
-SRCS="tbl::https://github.com/dugsong/libdnet/archive/libdnet-${VER}.tar.gz"
-CHKSUMS="sha256::b6360659c93fa2e3cde9e0a1fc9c07bc4111f3448c5de856e095eb98315dd424"
+REL=1
+SRCS="git::commit=tags/libdnet-$VER::https://github.com/dugsong/libdnet"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6308"


### PR DESCRIPTION
Topic Description
-----------------

- icu: migrate to ab4
- brltty: migrate to ab4
- libdnet: migrate to ab4
- libdbusmenu: migrate to ab4
- libappindicator: migrate to ab4

Package(s) Affected
-------------------

- libdnet: 1.12-1
- libdbusmenu: 1:16.04.0-4
- libappindicator: 1:12.10.0-5
- icu: 64.2-5
- brltty: 6.0-8

Security Update?
----------------

No

Build Order
-----------

```
#buildit libappindicator libdbusmenu libdnet brltty icu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
