### PR TITLE
FTBFS fix for loongarch batch #14

### DIFF
--- a/app-utils/lunzip/autobuild/build
+++ b/app-utils/lunzip/autobuild/build
@@ -1,5 +1,10 @@
-./configure ${AUTOTOOLS_DEF} \
+abinfo "Configuring lunzip ..."
+"$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} \
             CPPFLAGS="${CPPFLAGS}" CFLAGS="${CFLAGS}" \
             LDFLAGS="${LDFLAGS}"
+
+abinfo "Building lunzip ..."
 make
+
+abinfo "Installing lunzip ..."
 make install DESTDIR="$PKGDIR"

--- a/app-utils/lunzip/spec
+++ b/app-utils/lunzip/spec
@@ -1,4 +1,5 @@
 VER=1.10
+REL=1
 SRCS="tbl::https://download.savannah.gnu.org/releases/lzip/lunzip/lunzip-$VER.tar.lz"
 CHKSUMS="sha256::74ca4744aa4adb62ccfd2ab363cb451fa5c049b80162c3cc932a4efea87e58fc"
 CHKUPDATE="anitya::id=231607"

--- a/app-utils/lzd/autobuild/build
+++ b/app-utils/lzd/autobuild/build
@@ -1,5 +1,10 @@
-./configure ${AUTOTOOLS_DEF} \
+abinfo "Configuring lzd ..."
+"$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} \
             CPPFLAGS="${CPPFLAGS}" CXXFLAGS="${CXXFLAGS}" \
             LDFLAGS="${LDFLAGS}"
+
+abinfo "Building lzd ..."
 make
+
+abinfo "Installing lzd ..."
 make install DESTDIR="$PKGDIR"

--- a/app-utils/lzd/spec
+++ b/app-utils/lzd/spec
@@ -1,5 +1,5 @@
 VER=1.0
-SRCS="tbl::http://savannah.spinellicreations.com/lzip/lzd/lzd-$VER.tar.lz"
+REL=2
+SRCS="tbl::http://download.savannah.gnu.org/releases/lzip/lzd/lzd-$VER.tar.lz"
 CHKSUMS="sha256::b165eeaaa2758f7dafb43272cb81b1f9dd989f0b02d26d766b7e7bc9c0e4b423"
-REL=1
 CHKUPDATE="anitya::id=231608"

--- a/app-utils/man-db/autobuild/build
+++ b/app-utils/man-db/autobuild/build
@@ -1,4 +1,5 @@
-./configure ${AUTOTOOLS_DEF} \
+abinfo "Configuring man-db ..."
+"$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} \
             --with-systemdtmpfilesdir=/usr/lib/tmpfiles.d \
             --with-systemdsystemunitdir=/usr/lib/systemd/system \
             --with-db=gdbm \
@@ -6,7 +7,11 @@
             --enable-cache-owner=root \
 	    --enable-mandirs=GNU \
 	    --with-sections="1 n l 8 3 0 2 5 4 9 6 7"
+
+abinfo "Building man-db ..."
 make
+
+abinfo "Installing man-db ..."
 make DESTDIR="$PKGDIR" install
 
 abinfo "Avoiding a DPKG warning ..."

--- a/app-utils/man-db/spec
+++ b/app-utils/man-db/spec
@@ -1,4 +1,5 @@
 VER=2.11.1
+REL=1
 SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/man-db/man-db-$VER.tar.xz"
 CHKSUMS="sha256::2eabaa5251349847de9c9e43c634d986cbcc6f87642d1d9cb8608ec18487b6cc"
 CHKUPDATE="anitya::id=1882"

--- a/app-utils/pdlzip/autobuild/build
+++ b/app-utils/pdlzip/autobuild/build
@@ -1,5 +1,10 @@
-./configure ${AUTOTOOLS_DEF} \
+abinfo "Configuring pdlzip ..."
+"$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} \
             CPPFLAGS="${CPPFLAGS}" CFLAGS="${CFLAGS}" \
             LDFLAGS="${LDFLAGS}"
+
+abinfo "Building pdlzip ..."
 make
+
+abinfo "Installing pdlzip ..."
 make install DESTDIR="$PKGDIR"

--- a/app-utils/pdlzip/spec
+++ b/app-utils/pdlzip/spec
@@ -1,4 +1,5 @@
 VER=1.9
+REL=1
 SRCS="tbl::https://download.savannah.gnu.org/releases/lzip/pdlzip/pdlzip-$VER.tar.lz"
 CHKSUMS="sha256::5a09982bf71b34a5c74cc3dba84a52b4149e8907d9417d04ab83dc3d4f394069"
 CHKUPDATE="anitya::id=231630"

--- a/runtime-multimedia/speex/autobuild/beyond
+++ b/runtime-multimedia/speex/autobuild/beyond
@@ -1,12 +1,18 @@
 # Build speexdsp, removed in newest releases.
-cd speexdsp-1.2rc3
+cd "$SRCDIR"/speexdsp-1.2rc3
 patch -Np1 -i "$SRCDIR"/autobuild/patches/speexdsp-fixbuilds-774c87d.patch
+
+abinfo "Configuring speexdsp ..."
 autoreconf -fi
-if [[ "${CROSS:-$ARCH}" != "arm64" ]]; then
-    ./configure ${AUTOTOOLS_DEF}
+if !ab_match_arch arm64; then
+    ./configure ${AUTOTOOLS_DEF[@]}
 else
-    ./configure ${AUTOTOOLS_DEF} --disable-neon
+    ./configure ${AUTOTOOLS_DEF[@]} --disable-neon
 fi
+
+abinfo "Building speexdsp ..."
 make
+
+abinfo "Installing speexdsp ..."
 make install DESTDIR="$PKGDIR"
 cd "$SRCDIR"

--- a/runtime-multimedia/speex/spec
+++ b/runtime-multimedia/speex/spec
@@ -1,5 +1,5 @@
 VER=1.2.0
-REL=1
+REL=2
 SRCS="tbl::https://downloads.us.xiph.org/releases/speex/speex-$VER.tar.gz"
 CHKSUMS="sha256::eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094"
 CHKUPDATE="anitya::id=14498"


### PR DESCRIPTION
Topic Description
-----------------

- man-db: migrate to ab4
- pdlzip: migrate to ab4
- lunzip: migrate to ab4
- speex: migrate to ab4
- lzd: migrate to ab4

Package(s) Affected
-------------------

- lzd: 1.0-2
- pdlzip: 1.9-1
- lunzip: 1.10-1
- man-db: 2.11.1-1
- speex: 2:1.2.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit lzd speex lunzip pdlzip man-db
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
