### PR TITLE
vala: update to 0.56.16

### DIFF
--- a/app-devel/vala/autobuild/defines
+++ b/app-devel/vala/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=vala
 PKGDES="Compiler for the Gobject type system"
 PKGDEP="gcc glib graphviz gtk-doc libgee pkg-config noto-fonts"
-BUILDDEP="help2man libxslt"
+BUILDDEP="help2man libxslt gobject-introspection"
 PKGSEC=devel
 
 AB_FLAGS_O3=1

--- a/app-devel/vala/autobuild/defines.stage2
+++ b/app-devel/vala/autobuild/defines.stage2
@@ -1,7 +1,7 @@
 PKGNAME=vala
 PKGDES="Compiler for the Gobject type system"
 PKGDEP="gcc glib libgee pkg-config"
-BUILDDEP="help2man libxslt"
+BUILDDEP="help2man libxslt gobject-introspection"
 PKGSEC=devel
 
 AB_FLAGS_O3=1

--- a/app-devel/vala/spec
+++ b/app-devel/vala/spec
@@ -1,4 +1,4 @@
-VER=0.56.2
+VER=0.56.16
 SRCS="https://download.gnome.org/sources/vala/${VER:0:4}/vala-$VER.tar.xz"
-CHKSUMS="sha256::66c9619bb17859fd1ac3aba0a57970613e38fd2a1ee30541174260c9fb90124c"
+CHKSUMS="sha256::05487b5600f5d2f09e66a753cccd8f39c1bff9f148aea1b7774d505b9c8bca9b"
 CHKUPDATE="anitya::id=5065"


### PR DESCRIPTION
Topic Description
-----------------

- vala: update to 0.56.16

Package(s) Affected
-------------------

- vala: 0.56.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit vala
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
