### PR TITLE
FTBFS fix for loongarch batch #16

### DIFF
--- a/app-admin/gsmartcontrol/autobuild/beyond
+++ b/app-admin/gsmartcontrol/autobuild/beyond
@@ -1,2 +1,4 @@
+abinfo "Configuring PolicyKit wrapper for GSmartControl ..."
+mv "$PKGDIR"/usr/bin/gsmartcontrol{,-bin}
 sed -e 's|/usr/bin/gsmartcontrol-polkit|/usr/bin/gsmartcontrol|g' \
     -i "$PKGDIR"/usr/share/applications/gsmartcontrol.desktop

--- a/app-admin/gsmartcontrol/autobuild/build
+++ b/app-admin/gsmartcontrol/autobuild/build
@@ -1,5 +1,0 @@
-./configure ${AUTOTOOLS_DEF} ${AUTOTOOLS_AFTER}
-make
-make install DESTDIR="$PKGDIR"
-
-mv "$PKGDIR"/usr/bin/gsmartcontrol{,-bin}

--- a/app-admin/gsmartcontrol/spec
+++ b/app-admin/gsmartcontrol/spec
@@ -1,5 +1,5 @@
 VER=1.1.3
-REL=3
+REL=4
 SRCS="tbl::https://sourceforge.net/projects/gsmartcontrol/files/$VER/gsmartcontrol-$VER.tar.bz2"
 CHKSUMS="sha256::b64f62cffa4430a90b6d06cd52ebadd5bcf39d548df581e67dfb275a673b12a9"
 CHKUPDATE="anitya::id=11623"

--- a/app-multimedia/alsa-utils/autobuild/build
+++ b/app-multimedia/alsa-utils/autobuild/build
@@ -1,10 +1,10 @@
 abinfo "Configuring..."
 if [[ "${CROSS:-$ARCH}" != "i486" && "${CROSS:-$ARCH}" = "powerpc" ]]; then
-    ./configure ${AUTOTOOLS_DEF} --disable-alsaconf \
+    "$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} --disable-alsaconf \
                 --with-udev-rules-dir=/usr/lib/udev/rules.d \
                 --with-systemdsystemunitdir=/usr/lib/systemd/system
 else
-    ./configure ${AUTOTOOLS_DEF} --disable-alsaconf \
+    "$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} --disable-alsaconf \
                 --with-udev-rules-dir=/usr/lib/udev/rules.d \
                 --with-systemdsystemunitdir=/usr/lib/systemd/system \
                 --disable-bat

--- a/app-multimedia/alsa-utils/spec
+++ b/app-multimedia/alsa-utils/spec
@@ -1,4 +1,5 @@
 VER=1.2.8
+REL=1
 SRCS="tbl::https://www.alsa-project.org/files/pub/utils/alsa-utils-${VER}.tar.bz2"
 CHKSUMS="sha256::e140fa604c351f36bd72167c8860c69d81b964ae6ab53992d6434dde38e9333c"
 CHKUPDATE="anitya::id=37"

--- a/app-multimedia/ncmpcpp/autobuild/build
+++ b/app-multimedia/ncmpcpp/autobuild/build
@@ -1,4 +1,5 @@
-./configure ${AUTOTOOLS_DEF} \
+abinfo "Configuring ncmpcpp ..."
+"$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} \
     --enable-clock \
     --enable-outputs \
     --enable-unicode \
@@ -6,11 +7,14 @@
     --with-curl \
     --with-fftw \
     --with-taglib
+
+abinfo "Building ncmpcpp ..."
 make
 make -C extras CXXFLAGS="${CXXFLAGS}" \
                CPPFLAGS="${CPPFLAGS} `taglib-config --cflags`" \
                LDFLAGS="${LDFLAGS} `taglib-config --libs`"
 
+abinfo "Installing ncmpcpp ..."
 make install DESTDIR="$PKGDIR"
 install -Dm755 extras/artist_to_albumartist \
                "$PKGDIR"/usr/bin/artist_to_albumartist

--- a/app-multimedia/ncmpcpp/spec
+++ b/app-multimedia/ncmpcpp/spec
@@ -1,6 +1,5 @@
 VER=0.9.2
-REL=1
-SRCS="tbl::https://github.com/arybczak/ncmpcpp/archive/$VER.tar.gz"
-CHKSUMS="sha256::9321275e26ad4308448e661bb879b96d446b203cf57b3591db17b186387a7847"
-SUBDIR="ncmpcpp-$VER"
+REL=2
+SRCS="git::commit=tags/$VER::https://github.com/arybczak/ncmpcpp"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5521"

--- a/app-network/rp-pppoe/autobuild/build
+++ b/app-network/rp-pppoe/autobuild/build
@@ -1,5 +1,0 @@
-cd "$SRCDIR"/src
-./configure ${AUTOTOOLS_AFTER} ${AUTOTOOLS_DEF}
-make
-make install DESTDIR="$PKGDIR"
-cd "$SRCDIR"

--- a/app-network/rp-pppoe/autobuild/defines
+++ b/app-network/rp-pppoe/autobuild/defines
@@ -6,3 +6,5 @@ PKGDES="Roaring Penguin's Point-to-Point Protocol over Ethernet client"
 MAKE_AFTER="PLUGIN_DIR=/usr/lib/rp-pppoe"
 AUTOTOOLS_AFTER="--enable-plugin"
 ABSHADOW=no
+# autoheader failed
+RECONF=0

--- a/app-network/rp-pppoe/spec
+++ b/app-network/rp-pppoe/spec
@@ -1,5 +1,5 @@
-VER=3.12
-REL=2
-SRCS="tbl::https://dianne.skoll.ca/projects/rp-pppoe/download/rp-pppoe-$VER.tar.gz"
-CHKSUMS="sha256::00794e04031546b0e9b8cf286f2a6d1ccfc4a621b2a3abb2d7ef2a7ab7cc86c2"
+VER=3.15
+SRCS="http://deb.debian.org/debian/pool/main/r/rp-pppoe/rp-pppoe_$VER.orig.tar.gz"
+CHKSUMS="sha256::b1f318bc7e4e5b0fd8a8e23e8803f5e6e43165245a5a10a7162a92a6cf17829a"
+SUBDIR="rp-pppoe-$VER/src"
 CHKUPDATE="anitya::id=4209"

--- a/app-web/pidgin/01-libpurple/build
+++ b/app-web/pidgin/01-libpurple/build
@@ -5,7 +5,7 @@ for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do
 done
 
 abinfo "Configuring Pidgin ..."
-"$SRCDIR"/configure ${AUTOTOOLS_DEF} ${AUTOTOOLS_AFTER}
+"$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER}
 
 abinfo "Building Pidgin ..."
 make

--- a/app-web/pidgin/spec
+++ b/app-web/pidgin/spec
@@ -1,5 +1,5 @@
 VER=2.14.12
-REL=1
+REL=2
 SRCS="https://downloads.sourceforge.net/project/pidgin/Pidgin/$VER/pidgin-$VER.tar.bz2"
 CHKSUMS="sha256::2b05246be208605edbb93ae9edc079583d449e2a9710db6d348d17f59020a4b7"
 CHKUPDATE="anitya::id=3636"

--- a/desktop-gnome/yelp/autobuild/build
+++ b/desktop-gnome/yelp/autobuild/build
@@ -1,7 +1,7 @@
 abinfo "Running configure ..."
 "$SRCDIR"/configure \
     ${AUTOTOOLS_TARGET} \
-    ${AUTOTOOLS_DEF} \
+    ${AUTOTOOLS_DEF[@]} \
     ${AUTOTOOLS_AFTER} \
     --enable-option-checking=fatal
 

--- a/desktop-gnome/yelp/spec
+++ b/desktop-gnome/yelp/spec
@@ -1,5 +1,5 @@
 VER=42.1
-REL=1
+REL=2
 SRCS="https://download.gnome.org/sources/yelp/${VER%.*}/yelp-$VER.tar.xz"
 CHKSUMS="sha256::25b1146ab8549888a5a8da067f63b470b0f0f800b6ae889cacd114d01d713b41"
 CHKUPDATE="anitya::id=14867"


### PR DESCRIPTION
Topic Description
-----------------

- alsa-utils: migrate to ab4
- ncmpcpp: migrate to ab4
- yelp: migrate to ab4
- gsmartcontrol: migrate to ab4
- pidgin: migrate to ab4
- rp-pppoe: update to 3.15

Package(s) Affected
-------------------

- pidgin: 2.14.12-2
- ncmpcpp: 0.9.2-2
- alsa-utils: 1.2.8-1
- yelp: 42.1-2
- gsmartcontrol: 1.1.3-4
- rp-pppoe: 3.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit rp-pppoe pidgin gsmartcontrol yelp ncmpcpp alsa-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
