### PR TITLE
FTBFS fix for loongarch batch #17

### DIFF
--- a/app-doc/dblatex/autobuild/defines
+++ b/app-doc/dblatex/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=dblatex
 PKGSEC=doc
-PKGDEP="docbook-xml docbook-xsl python-2 texlive"
+PKGDEP="docbook-xml docbook-xsl python-3 texlive"
 PKGDES="DocBook (XML and SGML) to DVI, PDF, PostScript converter using LaTeX"
 
-NOPYTHON3=1
+NOPYTHON2=1
+ABHOST=noarch

--- a/app-doc/dblatex/spec
+++ b/app-doc/dblatex/spec
@@ -1,5 +1,4 @@
-VER=0.3.11
-SRCS="tbl::https://downloads.sourceforge.net/project/dblatex/dblatex/dblatex-$VER/dblatex-$VER.tar.bz2"
-CHKSUMS="sha256::7b7e97e275075fa275670b4ed368ef5d352c9aebffc480997e51c747055be166"
-REL=1
+VER=0.3.12
+SRCS="tbl::https://downloads.sourceforge.net/project/dblatex/dblatex/dblatex-$VER/dblatex3-$VER.tar.bz2"
+CHKSUMS="sha256::16e82786272ed1806a079d37914d7ba7a594db792dc4cc34c1c3737dbd4da079"
 CHKUPDATE="anitya::id=401"

--- a/app-multimedia/dcaenc/spec
+++ b/app-multimedia/dcaenc/spec
@@ -1,5 +1,5 @@
-VER=2
-REL=2
-SRCS="tbl::https://aepatrakov.narod.ru/olderfiles/1/dcaenc-$VER.tar.gz"
-CHKSUMS="sha256::1054e6113cd1304f35ca830f027a53e9efd989530fe6523f732a0a9cd4110199"
+VER=3
+REL=1
+SRCS="git::commit=tags/v$VER::https://gitlab.com/patrakov/dcaenc"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230654"

--- a/app-utils/daemonize/autobuild/beyond
+++ b/app-utils/daemonize/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Fixing binary path ..."
+mv -v "$PKGDIR"/usr/sbin "$PKGDIR"/usr/bin

--- a/app-utils/daemonize/spec
+++ b/app-utils/daemonize/spec
@@ -1,4 +1,5 @@
 VER=1.7.8
+REL=1
 SRCS="git::commit=tags/release-$VER::https://github.com/bmc/daemonize.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18168"

--- a/desktop-wm/cwm/autobuild/build
+++ b/desktop-wm/cwm/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building cwm ..."
+make PREFIX=/usr
+
+abinfo "Building cwm ..."
+make install PREFIX=/usr DESTDIR="$PKGDIR"

--- a/desktop-wm/cwm/spec
+++ b/desktop-wm/cwm/spec
@@ -1,4 +1,4 @@
-VER=7.1
+VER=7.4
 SRCS="git::commit=tags/v$VER::https://github.com/leahneukirchen/cwm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=123783"

--- a/lang-python/cysignals/autobuild/defines
+++ b/lang-python/cysignals/autobuild/defines
@@ -4,3 +4,5 @@ PKGDEP="cython pari"
 PKGDES="Interrupt and signal handling for Cython"
 
 ABTYPE=python
+# no longer support python2: invalid syntax
+NOPYTHON2=1

--- a/lang-python/cysignals/spec
+++ b/lang-python/cysignals/spec
@@ -1,5 +1,4 @@
-VER=1.9.0
-REL=3
-SRCS="tbl::https://github.com/sagemath/cysignals/archive/$VER.tar.gz"
-CHKSUMS="sha256::fbbccf8c85f594272023a01e833987861b4b364a24e285d5bf5a72142ecacf39"
+VER=1.11.4
+SRCS="git::commit=tags/$VER::https://github.com/sagemath/cysignals"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=177201"


### PR DESCRIPTION
Topic Description
-----------------

- dcaenc: update to v3, add REL to avoid apt bug
- dblatex: update to 0.3.12
- daemonize: fix binary path
- cysignals: update to 1.11.4
- cwm: update to 7.4 and migrate to ab4

Package(s) Affected
-------------------

- daemonize: 1.7.8-1
- dblatex: 0.3.12
- dcaenc: 3-1
- cwm: 7.4
- cysignals: 1.11.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit cwm cysignals daemonize dblatex dcaenc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
