### PR TITLE
libtorrent-rasterbar: update to 2.0.10

### DIFF
--- a/runtime-web/libtorrent-rasterbar/spec
+++ b/runtime-web/libtorrent-rasterbar/spec
@@ -1,5 +1,4 @@
-VER=2.0.8
+VER=2.0.10
 SRCS="tbl::https://github.com/arvidn/libtorrent/releases/download/v${VER}/libtorrent-rasterbar-$VER.tar.gz"
-CHKSUMS="sha256::09dd399b4477638cf140183f5f85d376abffb9c192bc2910002988e27d69e13e"
+CHKSUMS="sha256::fc935b8c1daca5c0a4d304bff59e64e532be16bb877c012aea4bda73d9ca885d"
 CHKUPDATE="anitya::id=4166"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- libtorrent-rasterbar: update to 2.0.10

Package(s) Affected
-------------------

- libtorrent-rasterbar: 2.0.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit libtorrent-rasterbar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
