### PR TITLE
showmethekey: update to 1.12.0

### DIFF
--- a/app-utils/showmethekey/autobuild/defines
+++ b/app-utils/showmethekey/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=showmethekey
 PKGSEC=utils
 PKGDES="Show keys you typed on screen"
-PKGDEP="systemd libevdev libinput gtk-4 glib json-glib cairo pango \
+PKGDEP="systemd libadwaita libevdev libinput gtk-4 glib json-glib cairo pango \
         libxkbcommon polkit"

--- a/app-utils/showmethekey/spec
+++ b/app-utils/showmethekey/spec
@@ -1,4 +1,4 @@
-VER=1.7.3
-SRCS="tbl::https://github.com/AlynxZhou/showmethekey/archive/v$VER.tar.gz"
-CHKSUMS="sha256::97a230b22eea63615bfe9865c0423e822c73b1d5252a0bdefe53c3b034836af6"
+VER=1.12.0
+SRCS="git::commit=tags/v$VER::https://github.com/AlynxZhou/showmethekey"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236314"


### PR DESCRIPTION
Topic Description
-----------------

- showmethekey: add libadwaita pkg dep
- showmethekey: update to 1.12.0

Package(s) Affected
-------------------

- showmethekey: 1.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit showmethekey
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
