### PR TITLE
rt-tests: update to 2.6

### DIFF
--- a/app-utils/rt-tests/spec
+++ b/app-utils/rt-tests/spec
@@ -1,5 +1,4 @@
-VER=1.8
+VER=2.6
 SRCS="tbl::https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git/snapshot/rt-tests-${VER}.tar.gz"
-CHKSUMS="sha512::f37df6c1873c53b7d9d7eb3970a89ae892b7c95f34765f1a8c4633dce091f5310ff92c3ef9bbe7288a97a42e01cdf9037f0765e7a82ad4185f0849f5a24cb170"
+CHKSUMS="sha256::6a9449c11a9ccb37e6c86082bf904337dda928fdcd69f6bd4a4c6567e071ae6d"
 CHKUPDATE="anitya::id=59450"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- rt-tests: update to 2.6

Package(s) Affected
-------------------

- rt-tests: 2.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit rt-tests
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
