### PR TITLE
Fix Dependency Survey 20240319

### DIFF
--- a/app-admin/apt/autobuild/defines
+++ b/app-admin/apt/autobuild/defines
@@ -4,10 +4,11 @@ PKGDES="Advanced Packaging Tools"
 
 PKGEPOCH=2
 
-PKGDEP="dpkg glibc zlib bzip2 curl gtest lz4 mirrormgr libidn2 \
-        systemd gnutls zstd xxhash"
-PKGDEP__RETRO="dpkg glibc zlib bzip2 curl gnutls lz4 systemd zstd \
-               libunistring xxhash mirrormgr libgcrypt"
+# gnupg & dpkg are runtime dependencies for installing packages
+PKGDEP="gnupg dpkg glibc zlib bzip2 lz4 \
+        systemd gnutls zstd xxhash db libseccomp xz libgcrypt"
+PKGDEP__RETRO="dpkg glibc zlib bzip2 gnutls lz4 systemd zstd \
+               libunistring xxhash libgcrypt"
 PKGDEP__ARMV4="${PKGDEP__RETRO/mirrormgr/}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO/mirrormgr/}"
 PKGDEP__ARMV7HF="${PKGDEP__RETRO/mirrormgr/}"
@@ -17,9 +18,10 @@ PKGDEP__M68K="${PKGDEP__RETRO/mirrormgr/}"
 PKGDEP__POWERPC="${PKGDEP__RETRO/mirrormgr/}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGDEP__MIPS64R6EL="${PKGDEP/mirrormgr/}"
+PKGRECOM="mirrormgr"
 
 BUILDDEP="graphviz w3m docbook2x docbook-xml docbook-xsl docbook-sgml \
-          po4a cmake doxygen triehash perl-locale-gettext"
+          po4a cmake doxygen triehash perl-locale-gettext gtest"
 BUILDDEP__RETRO="po4a triehash"
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"

--- a/app-admin/apt/spec
+++ b/app-admin/apt/spec
@@ -1,5 +1,5 @@
 VER=2.6.1
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/apt-team/apt.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7208"

--- a/app-web/curl/autobuild/defines
+++ b/app-web/curl/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=curl
 PKGSEC=utils
-PKGDEP="ca-certs openssl krb5 libidn2 libssh2 nghttp2 gnutls zlib \
-        rtmpdump brotli libpsl e2fsprogs"
+PKGDEP="ca-certs openssl krb5 libidn2 libssh2 nghttp2 zlib \
+        rtmpdump brotli libpsl zstd"
 PKGDES="A URL retrieval utility and library"
+PKGRECOM="ca-certs"
 
 PKGDEP__RETRO="ca-certs openssl"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"

--- a/app-web/curl/spec
+++ b/app-web/curl/spec
@@ -1,4 +1,5 @@
 VER=8.6.0
+REL=1
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
 CHKSUMS="sha256::3ccd55d91af9516539df80625f818c734dc6f2ecf9bada33c76765e99121db15"
 CHKUPDATE="anitya::id=381"

--- a/lang-python/python-3/autobuild/defines
+++ b/lang-python/python-3/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=python-3
 PKGDES="Python 3 programming language libraries and interpreter"
 PKGSEC=python
 
-PKGDEP="bzip2 expat gdbm libffi mpdecimal openssl sqlite tk xz zlib libnsl2"
+PKGDEP="bzip2 expat gdbm libffi mpdecimal openssl sqlite tk xz zlib libnsl2 ncurses util-linux libtirpc readline"
 PKGDEP__RETRO="bzip2 expat gdbm libffi mpdecimal openssl sqlite xz zlib libnsl2"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/lang-python/python-3/spec
+++ b/lang-python/python-3/spec
@@ -1,5 +1,5 @@
 VER=3.10.13
-REL=1
+REL=2
 SRCS="tbl::https://www.python.org/ftp/python/$VER/Python-$VER.tar.xz"
 CHKSUMS="sha256::5c88848668640d3e152b35b4536ef1c23b2ca4bd2c957ef1ecbb053f571dd3f6"
 CHKUPDATE="anitya::id=13254"

--- a/lang-tcl/tk/autobuild/defines
+++ b/lang-tcl/tk/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=tk
 PKGDES="Tool Command Lanuage Toolkit"
-PKGDEP="glibc tcl x11-lib"
+PKGDEP="glibc tcl x11-lib fontconfig"
 PKGSEC=devel
 
 NOSTATIC=no

--- a/lang-tcl/tk/spec
+++ b/lang-tcl/tk/spec
@@ -1,5 +1,5 @@
 VER=8.6.10
-REL=3
+REL=4
 SRCS="tbl::https://downloads.sourceforge.net/tcl/tk$VER-src.tar.gz"
 CHKSUMS="sha256::63df418a859d0a463347f95ded5cd88a3dd3aaa1ceecaeee362194bc30f3e386"
 CHKUPDATE="anitya::id=11426"

--- a/runtime-imaging/cairo/autobuild/defines
+++ b/runtime-imaging/cairo/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=cairo
-PKGDEP="x11-lib libdrm libpng fontconfig glib pixman lzo mesa"
+PKGDEP="x11-lib libpng fontconfig glib pixman lzo zlib libglvnd libxcb freetype"
 BUILDDEP="gtk-doc librsvg libspectre poppler"
 BUILDDEP__RETRO=""
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"

--- a/runtime-imaging/cairo/spec
+++ b/runtime-imaging/cairo/spec
@@ -1,4 +1,5 @@
 VER=1.17.6
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/cairo/cairo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=247"


### PR DESCRIPTION
Topic Description
-----------------

- python-3: update PKGDEP according to sodep
- tk: update PKGDEP according to sodep
- curl: update PKGDEP according to sodep
- apt: update PKGDEP according to sodep
- cairo: update PKGDEP according to sodep

Package(s) Affected
-------------------

- curl: 8.6.0-1
- tk: 8.6.10-4
- cairo: 1.17.6-1
- python-3: 3.10.13-2
- apt: 2:2.6.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cairo apt curl tk python-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
