### PR TITLE
Fix Dependency Survey 20240319 Part 3

### DIFF
--- a/app-admin/linux-pam/autobuild/defines
+++ b/app-admin/linux-pam/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=linux-pam
 PKGDES="Pluggable Authentication Modules"
 PKGSEC=admin
 
-PKGDEP="glibc libtirpc libnsl2"
+PKGDEP="glibc libtirpc libnsl2 db systemd libeconf"
 
 BUILDDEP="docbook-xsl"
 BUILDDEP__RETRO=""

--- a/app-admin/linux-pam/spec
+++ b/app-admin/linux-pam/spec
@@ -1,4 +1,5 @@
 VER=1.6.0
+REL=1
 SRCS="tbl::https://github.com/linux-pam/linux-pam/releases/download/v$VER/Linux-PAM-$VER.tar.xz"
 CHKSUMS="sha256::fff4a34e5bbee77e2e8f1992f27631e2329bcbf8a0563ddeb5c3389b4e3169ad"
 CHKUPDATE="anitya::id=12244"

--- a/app-admin/shadow/autobuild/defines
+++ b/app-admin/shadow/autobuild/defines
@@ -4,7 +4,8 @@ PKGSEC=admin
 
 RECONF=0
 
-PKGDEP="acl bash libpwquality linux-pam"
+# bash is required for postinst, libpwquality is added as pam module
+PKGDEP="acl bash libpwquality linux-pam cracklib attr"
 PKGDEP__RETRO="acl bash linux-pam"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/app-admin/shadow/spec
+++ b/app-admin/shadow/spec
@@ -1,4 +1,5 @@
 VER=4.13
+REL=1
 SRCS="tbl::https://github.com/shadow-maint/shadow/releases/download/$VER/shadow-$VER.tar.xz"
 CHKSUMS="sha256::9afe245d79a2e7caac5f1ed62519b17416b057ec89df316df1c3935502f9dd2c"
 CHKUPDATE="anitya::id=4802"

--- a/app-cryptography/gnupg/autobuild/defines
+++ b/app-cryptography/gnupg/autobuild/defines
@@ -2,8 +2,8 @@ PKGNAME=gnupg
 PKGSEC=libs
 PKGDES="Complete and free implementation of the OpenGPG standard"
 
-PKGDEP="curl openldap libusb-compat bzip2 libksba libgcrypt \
-        pth libassuan readline npth pinentry"
+PKGDEP="openldap libusb bzip2 libksba libgcrypt \
+        libassuan readline npth zlib libgpg-error gnutls sqlite"
 PKGDEP__RETRO="bzip2 libgpg-error libgcrypt libassuan libksba \
          npth readline"
 PKGDEP__ARMV4="$PKGDEP__RETRO"
@@ -14,6 +14,8 @@ PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="$PKGDEP__RETRO"
 PKGDEP__PPC64="$PKGDEP__RETRO"
+# gnupg has no library dependency on pinentry, but relies on it to enter passphrase
+PKGSUG="pinentry"
 BUILDDEP="transfig"
 
 AUTOTOOLS_AFTER="--enable-gpgsm \

--- a/app-cryptography/gnupg/spec
+++ b/app-cryptography/gnupg/spec
@@ -1,4 +1,5 @@
 VER=2.4.4
+REL=1
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-$VER.tar.bz2"
 CHKSUMS="sha256::67ebe016ca90fa7688ce67a387ebd82c6261e95897db7b23df24ff335be85bc6"
 CHKUPDATE="anitya::id=1215"

--- a/app-network/krb5/autobuild/defines
+++ b/app-network/krb5/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=krb5
 PKGDES="The Kerberos network authentication system"
 PKGSEC=libs
-PKGDEP="e2fsprogs openldap"
+PKGDEP="e2fsprogs openldap openssl keyutils lmdb"
 PKGDEP__RETRO="e2fsprogs"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/app-network/krb5/spec
+++ b/app-network/krb5/spec
@@ -1,5 +1,5 @@
 VER=1.17.1
-REL=5
+REL=6
 SRCS="tbl::https://web.mit.edu/kerberos/dist/krb5/${VER%.*}/krb5-$VER.tar.gz"
 CHKSUMS="sha256::3706d7ec2eaa773e0e32d3a87bf742ebaecae7d064e190443a3acddfd8afb181"
 CHKUPDATE="anitya::id=13287"

--- a/app-utils/grep/autobuild/defines
+++ b/app-utils/grep/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=grep
 PKGSEC=utils
 PKGDES="A pattern-based string searcher"
-PKGDEP="glibc libsigsegv pcre"
+PKGDEP="glibc libsigsegv pcre2"
 BUILDDEP="texinfo gperf"
 
 AUTOTOOLS_AFTER="--enable-largefile \

--- a/app-utils/grep/spec
+++ b/app-utils/grep/spec
@@ -1,4 +1,5 @@
 VER=3.8
+REL=1
 SRCS="https://ftp.gnu.org/gnu/grep/grep-$VER.tar.xz"
 CHKSUMS="sha256::498d7cc1b4fb081904d87343febb73475cf771e424fb7e6141aff66013abc382"
 CHKUPDATE="anitya::id=1251"


### PR DESCRIPTION
Topic Description
-----------------

- shadow: update PKGDEP according to sodep
- grep: update PKGDEP according to sodep
- gnupg: update PKGDEP according to sodep
- linux-pam: update PKGDEP according to sodep
- krb5: update PKGDEP according to sodep

Package(s) Affected
-------------------

- grep: 3.8-1
- gnupg: 1:2.4.4-1
- shadow: 4.13-1
- linux-pam: 1.6.0-1
- krb5: 1.17.1-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit krb5 linux-pam gnupg grep shadow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
