### PR TITLE
Fix Dependency Survey 20240319 Part 4

### DIFF
--- a/app-admin/systemd/autobuild/defines
+++ b/app-admin/systemd/autobuild/defines
@@ -2,10 +2,10 @@ PKGNAME=systemd
 PKGSEC=admin
 PKGDEP="glib lz4 xz acl bash cryptsetup curl elfutils gnutls kbd kmod \
         libcap libidn2 libmicrohttpd linux-pam util-linux libgcrypt hwdata \
-        libgpg-error iptables libxkbcommon qrencode aosc-aaa trousers \
-        libseccomp pcre2 zstd libfido2 tpm2-tss p11-kit dbus libpcap libnl"
+        libgpg-error iptables libxkbcommon qrencode aosc-aaa \
+        libseccomp pcre2 zstd libfido2 tpm2-tss p11-kit dbus openssl zlib bzip2"
 PKGDEP__RETRO="glib acl bash kbd libcap linux-pam util-linux hwdata \
-               aosc-aaa kmod polkit dbus libpcap libnl"
+               aosc-aaa kmod polkit dbus openssl zlib bzip2"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
 PKGDEP__ARMV7HF="${PKGDEP__RETRO}"

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,5 +1,5 @@
 VER=255.3
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd-stable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205088"

--- a/app-utils/bzip2/autobuild/defines
+++ b/app-utils/bzip2/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=bzip2
 PKGSEC=utils
 PKGDES="A freely available, patent free, high-quality data compressor"
-PKGDEP="glibc zlib"
+PKGDEP="glibc"
 
 NOSTATIC=0
 NOSTATIC__RETRO=1

--- a/app-utils/bzip2/spec
+++ b/app-utils/bzip2/spec
@@ -1,5 +1,5 @@
 VER=1.0.8
-REL=5
+REL=6
 SRCS="tbl::https://sourceware.org/pub/bzip2/bzip2-$VER.tar.gz"
 CHKSUMS="sha256::ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
 CHKUPDATE="anitya::id=237"

--- a/app-utils/keyutils/autobuild/build
+++ b/app-utils/keyutils/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building keyutils ..."
+make
+
+abinfo "Installing keyutils ..."
+make install DESTDIR="$PKGDIR" ${MAKE_AFTER}

--- a/app-utils/keyutils/autobuild/defines
+++ b/app-utils/keyutils/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=keyutils
 PKGSEC=utils
-PKGDEP="krb5"
+PKGDEP="glibc"
 PKGDES="Key managements utilities for Linux"
 
 MAKE_AFTER="SBINDIR=/usr/bin BINDIR=/usr/bin LIBDIR=/usr/lib USRLIBDIR=/usr/lib"

--- a/app-utils/keyutils/spec
+++ b/app-utils/keyutils/spec
@@ -1,5 +1,5 @@
 VER=1.6.3
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17740"

--- a/desktop-gnome/gtk-3/autobuild/defines
+++ b/desktop-gnome/gtk-3/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=gtk-3
 PKGSEC=x11
 PKGDEP="adwaita-icon-theme at-spi2-atk cairo colord x11-lib pango libepoxy \
-        shared-mime-info wayland libxkbcommon rest gdk-pixbuf \
-        wayland-protocols libffi cups"
+        shared-mime-info wayland libxkbcommon gdk-pixbuf \
+        cups glib harfbuzz fribidi fontconfig atk"
 PKGDEP__RETRO=" \
         adwaita-icon-theme at-spi2-atk cairo x11-lib pango libepoxy \
         shared-mime-info libxkbcommon gdk-pixbuf"
@@ -14,7 +14,7 @@ PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
-BUILDDEP="gobject-introspection gtk-doc vim"
+BUILDDEP="gobject-introspection gtk-doc vim wayland-protocols"
 BUILDDEP__RETRO=""
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"

--- a/desktop-gnome/gtk-3/spec
+++ b/desktop-gnome/gtk-3/spec
@@ -1,5 +1,5 @@
 VER=3.24.38
-REL=1
+REL=2
 SRCS="https://download.gnome.org/sources/gtk+/${VER:0:4}/gtk+-$VER.tar.xz"
 CHKSUMS="sha256::ce11decf018b25bdd8505544a4f87242854ec88be054d9ade5f3a20444dd8ee7"
 CHKUPDATE="anitya::id=10018"

--- a/desktop-gnome/gtk-4/autobuild/defines
+++ b/desktop-gnome/gtk-4/autobuild/defines
@@ -1,13 +1,12 @@
 PKGNAME=gtk-4
 PKGSEC=x11
 PKGDEP="adwaita-icon-theme cairo colord cups dconf desktop-file-utils ffmpeg \
-        fontconfig fribidi gdk-pixbuf glib graphene gstreamer \
-        harfbuzz iso-codes json-glib libcloudproviders libepoxy librsvg mesa \
-        pango rest shared-mime-info tracker vulkan wayland \
-        wayland-protocols"
+        fontconfig fribidi gdk-pixbuf glib graphene gstreamer libpng libxkbcommon \
+        harfbuzz iso-codes libcloudproviders libepoxy librsvg libtiff libjpeg-turbo \
+        pango shared-mime-info tracker vulkan-loader wayland x11-lib"
 BUILDDEP="docutils gi-docgen gobject-introspection gtk-doc sassc shaderc \
-          wayland-protocols"
-PKGDES="GIMP toolkit version 3"
+          wayland-protocols vulkan"
+PKGDES="GIMP toolkit version 4"
 
 MESON_AFTER="-Dx11-backend=true \
              -Dwayland-backend=true \

--- a/desktop-gnome/gtk-4/spec
+++ b/desktop-gnome/gtk-4/spec
@@ -1,5 +1,5 @@
 VER=4.6.7
-REL=3
+REL=4
 SRCS="https://download.gnome.org/sources/gtk/${VER%.*}/gtk-$VER.tar.xz"
 CHKSUMS="sha256::effd2e7c4b5e2a5c7fad43e0f24adea68baa4092abb0b752caff278e6bb010e8"
 CHKUPDATE="anitya::id=13942"


### PR DESCRIPTION
Topic Description
-----------------

- gtk-4: update PKGDEP according to sodep
- gtk-3: update PKGDEP according to sodep
- systemd: update PKGDEP according to sodep
- bzip2: update PKGDEP according to sodep
- keyutils: update PKGDEP according to sodep

Package(s) Affected
-------------------

- keyutils: 1.6.3-2
- bzip2: 1.0.8-6
- gtk-3: 3.24.38-2
- gtk-4: 4.6.7-4
- systemd: 1:255.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit keyutils bzip2 systemd gtk-3 gtk-4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
