### PR TITLE
suitesparse (SuiteSparse): fix dependency

### DIFF
--- a/runtime-scientific/suitesparse/autobuild/defines
+++ b/runtime-scientific/suitesparse/autobuild/defines
@@ -1,9 +1,12 @@
 PKGNAME=suitesparse
 PKGSEC=math
 PKGDEP="lapack tbb"
-PKGDEP__CUDA="${PKGDEP} cuda"
-PKGDEP__AMD64="${PKGDEP__CUDA}"
-PKGDEP__ARM64="${PKGDEP__CUDA}"
+BUILDDEP__CUDA="${BUILDDEP} cuda"
+BUILDDEP__AMD64="${BUILDDEP__CUDA}"
+BUILDDEP__ARM64="${BUILDDEP__CUDA}"
+PKGSUG__CUDA="${PKGSUG} cuda"
+PKGSUG__AMD64="${PKGSUG__CUDA}"
+PKGSUG__ARM64="${PKGSUG__CUDA}"
 PKGDES="A collection of sparse matrix libraries"
 
 ABTYPE=cmakeninja

--- a/runtime-scientific/suitesparse/spec
+++ b/runtime-scientific/suitesparse/spec
@@ -1,4 +1,5 @@
 VER=7.6.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/DrTimothyAldenDavis/SuiteSparse"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4908"


### PR DESCRIPTION
Topic Description
-----------------

- suitesparse: move cuda to PKGSUG
    Also mark it as a build-time dependency for supported architectures.

Package(s) Affected
-------------------

- suitesparse: 7.6.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit suitesparse
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
