### PR TITLE
dmidecode: update to 3.5

### DIFF
--- a/app-utils/dmidecode/autobuild/build
+++ b/app-utils/dmidecode/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building binaries"
+make
+
+abinfo "Build done, installing files"
+make DESTDIR="${PKGDIR}" prefix=/usr install

--- a/app-utils/dmidecode/autobuild/patch
+++ b/app-utils/dmidecode/autobuild/patch
@@ -1,3 +1,7 @@
+abinfo "Tweaking Makefile: /usr/sbin => /usr/bin ..."
+sed -e 's|sbin|bin|g' \
+    -i "$SRCDIR"/Makefile
+
 abinfo "Tweaking Makefile to use our own flags ..."
 cat >> "$SRCDIR"/Makefile << EOF
 CFLAGS = ${CPPFLAGS} ${CFLAGS}

--- a/app-utils/dmidecode/spec
+++ b/app-utils/dmidecode/spec
@@ -1,5 +1,4 @@
-VER=3.2
-REL=1
+VER=3.5
 SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/dmidecode/dmidecode-$VER.tar.xz"
-CHKSUMS="sha256::077006fa2da0d06d6383728112f2edef9684e9c8da56752e97cd45a11f838edd"
+CHKSUMS="sha256::79d76735ee8e25196e2a722964cf9683f5a09581503537884b256b01389cc073"
 CHKUPDATE="anitya::id=443"


### PR DESCRIPTION
Topic Description
-----------------

- dmidecode: rename prepare to patch
    As the only thing it does is to patch Makefile.
- dmidecode: migrate to Autobuild4
- dmidecode: update to 3.5

Package(s) Affected
-------------------

- dmidecode: 3.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit dmidecode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
