### PR TITLE
discord: update to 0.0.46

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.45
+VER=0.0.46
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::7520dce44c9693f687e49146e9661f26a9dbd18dbf6f8e9871d341d99f70467d"
+CHKSUMS="sha256::b861c3660e2fbbbad425c7ba49255bb8b4413c41d780de28a1c01063e0ea75ac"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- discord: update to 0.0.46

Package(s) Affected
-------------------

- discord: 0.0.46

Security Update?
----------------

No

Build Order
-----------

```
#buildit discord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
