### PR TITLE
picom: update to 11.2

### DIFF
--- a/desktop-wm/picom/autobuild/defines
+++ b/desktop-wm/picom/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=picom
 PKGSEC=x11
 PKGDEP="x11-lib hicolor-icon-theme libconfig dbus libev libglvnd \
-        pcre pixman xcb-util-image xcb-util-renderutil"
+        pcre pixman xcb-util-image xcb-util-renderutil libepoxy mesa"
 BUILDDEP="uthash x11-app asciidoc"
 PKGDES="A lightweight compositor for X11"
 

--- a/desktop-wm/picom/spec
+++ b/desktop-wm/picom/spec
@@ -1,4 +1,4 @@
-VER=11.1
-SRCS="https://github.com/yshui/picom/archive/v${VER/\~/-}.tar.gz"
-CHKSUMS="sha256::96f2a33a93064a74b557942d0300a2ac77ac853f50efbbf6466849fcc7542ec8"
+VER=11.2
+SRCS="git::commit=tags/v${VER}::https://github.com/yshui/picom"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=48078"


### PR DESCRIPTION
Topic Description
-----------------

- picom: update to 11.2
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- picom: 11.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit picom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
