### PR TITLE
qbittorrent: update to 4.6.3

### DIFF
--- a/app-web/qbittorrent/01-gui/defines
+++ b/app-web/qbittorrent/01-gui/defines
@@ -4,4 +4,10 @@ PKGDEP="desktop-file-utils libtorrent-rasterbar qt-5 xdg-utils"
 BUILDDEP="boost"
 PKGDES="Free and reliable P2P Bittorrent client"
 
-ABTYPE=qtproj
+CMAKE_AFTER="-DDBUS=ON \
+             -DGUI=ON \
+             -DSTACKTRACE=ON \
+             -DSYSTEMD=ON \
+             -DWEBUI=ON"
+
+ABTYPE=cmakeninja

--- a/app-web/qbittorrent/01-gui/defines
+++ b/app-web/qbittorrent/01-gui/defines
@@ -7,7 +7,6 @@ PKGDES="Free and reliable P2P Bittorrent client"
 CMAKE_AFTER="-DDBUS=ON \
              -DGUI=ON \
              -DSTACKTRACE=ON \
-             -DSYSTEMD=ON \
              -DWEBUI=ON"
 
 ABTYPE=cmakeninja

--- a/app-web/qbittorrent/01-gui/defines
+++ b/app-web/qbittorrent/01-gui/defines
@@ -2,7 +2,7 @@ PKGNAME=qbittorrent
 PKGSEC=web
 PKGDEP="desktop-file-utils libtorrent-rasterbar qt-5 xdg-utils"
 BUILDDEP="boost"
-PKGDES="Free and reliable P2P Bittorrent client"
+PKGDES="A P2P (peer-to-peer) Bittorrent client"
 
 CMAKE_AFTER="-DDBUS=ON \
              -DGUI=ON \

--- a/app-web/qbittorrent/01-gui/prepare
+++ b/app-web/qbittorrent/01-gui/prepare
@@ -1,2 +1,0 @@
-abinfo "Running configure script to generate conf.pri ..."
-"$SRCDIR"/configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --enable-stacktrace --enable-gui --enable-systemd --enable-webui --enable-qt-dbus

--- a/app-web/qbittorrent/02-nox/defines
+++ b/app-web/qbittorrent/02-nox/defines
@@ -2,7 +2,7 @@ PKGNAME=qbittorrent-nox
 PKGSEC=web
 PKGDEP="libtorrent-rasterbar qt-5"
 BUILDDEP="boost"
-PKGDES="Free and reliable command line P2P Bittorrent client (headless version)"
+PKGDES="A P2P (peer-to-peer) Bittorrent client (Web interface)"
 
 CMAKE_AFTER="-DDBUS=ON \
              -DGUI=OFF \

--- a/app-web/qbittorrent/02-nox/defines
+++ b/app-web/qbittorrent/02-nox/defines
@@ -2,6 +2,12 @@ PKGNAME=qbittorrent-nox
 PKGSEC=web
 PKGDEP="libtorrent-rasterbar qt-5"
 BUILDDEP="boost"
-PKGDES="Free and reliable command line P2P Bittorrent client"
+PKGDES="Free and reliable command line P2P Bittorrent client (headless version)"
 
-ABTYPE=qtproj
+CMAKE_AFTER="-DDBUS=ON \
+             -DGUI=OFF \
+             -DSTACKTRACE=ON \
+             -DSYSTEMD=ON \
+             -DWEBUI=ON"
+
+ABTYPE=cmakeninja

--- a/app-web/qbittorrent/02-nox/prepare
+++ b/app-web/qbittorrent/02-nox/prepare
@@ -1,4 +1,0 @@
-abinfo "Cleaning ..."
-make distclean
-abinfo "Running configure script to generate conf.pri ..."
-"$SRCDIR"/configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --enable-stacktrace --disable-gui --enable-systemd --enable-webui

--- a/app-web/qbittorrent/spec
+++ b/app-web/qbittorrent/spec
@@ -1,4 +1,4 @@
-VER=4.5.4
+VER=4.6.3
 SRCS="tbl::https://sourceforge.net/projects/qbittorrent/files/qbittorrent/qbittorrent-$VER/qbittorrent-$VER.tar.xz"
-CHKSUMS="sha256::f92bcd3ed25600796c59257c507e56a252a65af60bd042b71f1e7ff3fe5264da"
+CHKSUMS="sha256::5f9f3e0b89861e8bae1894656f8b8f76feddb3c92e228065c8173632af6e544e"
 CHKUPDATE="anitya::id=6111"


### PR DESCRIPTION
Topic Description
-----------------

- qbittorrent: disable systemd for qbittorrent gui
    - The `--enable-systemd` options did nothing in previous qbittorrent gui
    - Enableing systemd for qbittorrent gui will generate qbittorrent-nox@.service
- qbittorrent: switch to cmake
    - As upstream advised that after 4.2.5 CMake should be considered as
    the preferred way to build qBittorrent.
    - Also change the description of the headless version.
- qbittorrent: update to 4.6.3

Package(s) Affected
-------------------

- qbittorrent: 4.6.3
- qbittorrent-nox: 4.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit qbittorrent
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
