### PR TITLE
Testing Buildit DO NOT MERGE

### DIFF
--- a/core-misc/aosc-aaa/spec
+++ b/core-misc/aosc-aaa/spec
@@ -1,5 +1,13 @@
 VER=11.2.1
+REL=1
 __CODENAME="Koshki"
 __BUILD_ID="20240210"
 DUMMYSRC=1
 CHKSUMS="SKIP"
+ENVREQ="disk=10"
+ENVREQ__AMD64="core=16"
+ENVREQ__ARM64="core=16 total_mem=200"
+ENVREQ__LOONGARCH64="total_mem_per_core=1"
+ENVREQ__LOONGSON3="total_mem=10"
+ENVREQ__PPC64EL="core=128"
+ENVREQ__RISCV64="core=16 total_mem=32 total_mem_per_core=1.5"


### PR DESCRIPTION
Topic Description
-----------------

- aosc-aaa: bump REL and add ENVREQ
- foo: bar

Package(s) Affected
-------------------

- aosc-aaa: 11.2.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-aaa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
