### PR TITLE
bat: update to 0.24.0

### DIFF
--- a/app-utils/bat/spec
+++ b/app-utils/bat/spec
@@ -1,5 +1,4 @@
-VER=0.22.1
-REL=1
-SRCS="tbl::https://github.com/sharkdp/bat/archive/v$VER.tar.gz"
-CHKSUMS="sha256::25e45debf7c86794281d63a51564feefa96fdfdf575381e3adc5c06653ecaeca"
+VER=0.24.0
+SRCS="git::commit=tags/v$VER::https://github.com/sharkdp/bat/"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17642"


### PR DESCRIPTION
Topic Description
-----------------

- bat: update to 0.24.0

Package(s) Affected
-------------------

- bat: 0.24.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
