### PR TITLE
ast-grep: update to 0.19.4

### DIFF
--- a/app-devel/ast-grep/spec
+++ b/app-devel/ast-grep/spec
@@ -1,4 +1,4 @@
-VER=0.19.2
+VER=0.19.4
 SRCS="git::commit=tags/$VER::https://github.com/ast-grep/ast-grep"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=361439"


### PR DESCRIPTION
Topic Description
-----------------

- ast-grep: update to 0.19.4

Package(s) Affected
-------------------

- ast-grep: 0.19.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit ast-grep
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
