### PR TITLE
FTBFS fix for loongarch batch #21

### DIFF
--- a/app-admin/fwupdate/autobuild/defines
+++ b/app-admin/fwupdate/autobuild/defines
@@ -4,3 +4,5 @@ PKGDEP="fwupd"
 PKGDES="Tools for using the ESRT and UpdateCapsule() to apply firmware updates (transitional package for fwupd)"
 
 PKGEPOCH=1
+ABTYPE=dummy
+ABHOST=noarch

--- a/app-admin/fwupdate/spec
+++ b/app-admin/fwupdate/spec
@@ -1,2 +1,3 @@
 VER=0
+REL=1
 DUMMYSRC=1

--- a/app-doc/hevea/autobuild/build
+++ b/app-doc/hevea/autobuild/build
@@ -1,0 +1,11 @@
+if ab_match_archgroup ocaml_native; then
+    TARGET=opt
+else
+    TARGET=byte
+fi
+
+abinfo "Building hevea ..."
+make PREFIX=/usr TARGET=$TARGET
+
+abinfo "Installing hevea ..."
+make install PREFIX=/usr TARGET=$TARGET DESTDIR="$PKGDIR"

--- a/app-doc/hevea/autobuild/defines
+++ b/app-doc/hevea/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=hevea
+PKGSEC=doc
+PKGDEP="texlive ocaml"
+# Note: Hevea depends on ocamlrun if ocamlopt is missing.
+PKGDEP__OCAML_NATIVE="texlive"
+BUILDDEP="ocamlbuild"
+PKGDES="LATEX to HTML translator"
+
+ABSPLITDBG=0

--- a/app-doc/hevea/spec
+++ b/app-doc/hevea/spec
@@ -1,0 +1,4 @@
+VER=2.36
+SRCS="tbl::http://pauillac.inria.fr/~maranget/hevea/distri/hevea-$VER.tar.gz"
+CHKSUMS="sha256::5d6759d7702a295c76a12c1b2a1a16754ab0ec1ffed73fc9d0b138b41e720648"
+CHKUPDATE="anitya::id=7850"

--- a/app-network/fping/spec
+++ b/app-network/fping/spec
@@ -1,4 +1,4 @@
-VER=4.2
+VER=5.1
 SRCS="tbl::https://fping.org/dist/fping-$VER.tar.gz"
-CHKSUMS="sha256::7d339674b6a95aae1d8ad487ff5056fd95b474c3650938268f6a905c3771b64a"
+CHKSUMS="sha256::1ee5268c063d76646af2b4426052e7d81a42b657e6a77d8e7d3d2e60fd7409fe"
 CHKUPDATE="anitya::id=834"

--- a/app-scientific/gf2x/spec
+++ b/app-scientific/gf2x/spec
@@ -1,5 +1,4 @@
-VER=1.2
-SRCS="tbl::https://gforge.inria.fr/frs/download.php/file/36934/gf2x-1.2.tar.gz"
-CHKSUMS="sha256::61427ffa03b5006aa154def6dce8bcff0fdefb3bd72f43fb1a7b4fdd6b80db34"
-REL=1
+VER=1.3.0
+SRCS="git::commit=tags/gf2x-$VER::https://gitlab.inria.fr/gf2x/gf2x"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6340"

--- a/app-scientific/giac/autobuild/defines
+++ b/app-scientific/giac/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=giac
 PKGSEC=math
 PKGDEP="fltk gsl lapack libpng mpfi ntl pari mesa glu"
+BUILDDEP="hevea"
 PKGDES="A free computer algebra system"
 
 AB_FLAGS_O3=1

--- a/app-scientific/giac/autobuild/prepare
+++ b/app-scientific/giac/autobuild/prepare
@@ -1,1 +1,0 @@
-sed -e '/curlbuild/d' -i src/misc.cc

--- a/app-scientific/giac/spec
+++ b/app-scientific/giac/spec
@@ -1,5 +1,4 @@
-VER=1.5.0+43
+VER=1.9.0+93
 SRCS="tbl::https://www-fourier.ujf-grenoble.fr/~parisse/debian/dists/stable/main/source/giac_${VER/+/-}.tar.gz"
-CHKSUMS="sha256::b791eadaf4dee78d6d129aca8e26c7476ddd83f43d12d81cd7fdb716ef66a8c8"
-REL=2
+CHKSUMS="sha256::153fddf4a27de32300cc3e9e9497875bc52b3ad212f5ff464e711323da5b4c85"
 CHKUPDATE="anitya::id=15278"

--- a/app-scientific/singular/spec
+++ b/app-scientific/singular/spec
@@ -1,5 +1,5 @@
 VER=4.1.1
-REL=3
+REL=4
 MAJOR=${VER%%p*}
 SRCS="https://repo.aosc.io/aosc-repacks/singular-$VER.tar.gz"
 CHKSUMS="sha256::3792c5707b60c1748298bf47e2277de20303d60563b797372cc0e1eff4bbc583"

--- a/runtime-imaging/freeimage/autobuild/defines
+++ b/runtime-imaging/freeimage/autobuild/defines
@@ -4,3 +4,6 @@ PKGDES="Library for popular graphics image formats"
 PKGDEP="glibc"
 
 AB_FLAGS_O3=1
+
+# FTBFS: call to `CacheFile::~CacheFile()' lacks nop, can't restore toc; (plt call stub) 
+FAIL_ARCH="ppc64el"

--- a/runtime-imaging/freeimage/autobuild/patches/0002-do-not-strip.patch
+++ b/runtime-imaging/freeimage/autobuild/patches/0002-do-not-strip.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.gnu	2024-03-22 00:31:45.707149522 +0800
++++ b/Makefile.gnu	2024-03-22 00:31:49.878128591 +0800
+@@ -67,7 +67,7 @@
+ 	$(AR) r $@ $(MODULES)
+ 
+ $(SHAREDLIB): $(MODULES)
+-	$(CC) -s -shared -Wl,-soname,$(VERLIBNAME) $(LDFLAGS) -o $@ $(MODULES) $(LIBRARIES)
++	$(CC) -shared -Wl,-soname,$(VERLIBNAME) $(LDFLAGS) -o $@ $(MODULES) $(LIBRARIES)
+ 
+ install:
+ 	install -d $(INCDIR) $(INSTALLDIR)

--- a/runtime-imaging/freeimage/autobuild/prepare
+++ b/runtime-imaging/freeimage/autobuild/prepare
@@ -1,4 +1,4 @@
-if [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
+if ab_match_arch arm64; then
     abinfo "Appending -fPIC to fix build ..."
     export CFLAGS="${CFLAGS} -fPIC"
     export CXXFLAGS="${CXXFLAGS} -fPIC"
@@ -7,3 +7,7 @@ fi
 
 abinfo "Appending -Wno-narrowing to CXXFLAGS to fix build ..."
 export CXXFLAGS="${CXXFLAGS} -Wno-narrowing"
+
+# FIXME: error: ISO C++17 does not allow dynamic exception specifications
+abinfo "Appending --std=c++14 to CXXFLAGS to fix build ..."
+export CXXFLAGS="${CXXFLAGS} --std=c++14"

--- a/runtime-imaging/freeimage/spec
+++ b/runtime-imaging/freeimage/spec
@@ -1,5 +1,5 @@
 VER=3.18.0
-REL=2
+REL=3
 SRCS="tbl::https://downloads.sourceforge.net/freeimage/FreeImage${VER//./}.zip"
 CHKSUMS="sha256::f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd"
 CHKUPDATE="anitya::id=10655"

--- a/runtime-scientific/flint/spec
+++ b/runtime-scientific/flint/spec
@@ -1,5 +1,5 @@
 VER=2.5.2
-REL=8
+REL=9
 SRCS="http://flintlib.org/flint-$VER.tar.gz"
 CHKSUMS="sha256::cbf1fe0034533c53c5c41761017065f85207a1b770483e98b2392315f6575e87"
 CHKUPDATE="anitya::id=7621"

--- a/runtime-scientific/ntl/autobuild/build
+++ b/runtime-scientific/ntl/autobuild/build
@@ -1,7 +1,15 @@
-./configure \
-    SHARED=on NTL_GF2X_LIB=on NATIVE=off TUNE=generic \
-    LDFLAGS="${LDFLAGS} -fPIC" CXXFLAGS="${CXXFLAGS} ${CPPFLAGS} -fPIC"
-make
-make install PREFIX="$PKGDIR"/usr
+abinfo "Configuring ntl ..."
+build_autotools_update_base
+"$SRCDIR"/configure \
+    SHARED=on \
+    NTL_GF2X_LIB=on \
+    NATIVE=off \
+    TUNE=generic \
+    LDFLAGS="${LDFLAGS} -fPIC" \
+    CXXFLAGS="${CXXFLAGS} ${CPPFLAGS} -fPIC"
 
-chmod +x "$PKGDIR"/usr/lib/libntl.so.*
+abinfo "Building ntl ..."
+make
+
+abinfo "Installing ntl ..."
+make install PREFIX="$PKGDIR"/usr

--- a/runtime-scientific/ntl/spec
+++ b/runtime-scientific/ntl/spec
@@ -1,5 +1,5 @@
-VER=11.4.3
+VER=11.5.1
 SRCS="tbl::https://www.shoup.net/ntl/ntl-$VER.tar.gz"
-CHKSUMS="sha256::b7c1ccdc64840e6a24351eb4a1e68887d29974f03073a1941c906562c0b83ad2"
+CHKSUMS="sha256::210d06c31306cbc6eaf6814453c56c776d9d8e8df36d74eb306f6a523d1c6a8a"
 SUBDIR="ntl-$VER/src"
 CHKUPDATE="anitya::id=6334"


### PR DESCRIPTION
Topic Description
-----------------

- singular: bump REL due to ntl SONAME change
- giac: update to 1.9.0+93 due to ntl SONAME change
- hevea: new, 2.36 introduced as dependency of giac
- flint: bump REL due to ntl SONAME change
- fwupdate: fix dummy package
- freeimage: fix FTBFS and do not strip
- fping: update to 5.1
- ntl: update to 11.5.1
- gf2x: update to 1.3.0

Package(s) Affected
-------------------

- hevea: 2.36
- freeimage: 3.18.0-3
- ntl: 11.5.1
- flint: 2.5.2-9
- gf2x: 1:1.3.0
- singular: 4.1.1-4
- giac: 1.9.0+93
- fwupdate: 1:0-1
- fping: 5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gf2x ntl fping freeimage fwupdate flint hevea giac singular
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
