### PR TITLE
ocamlbuild: bump REL

### DIFF
--- a/lang-ocaml/ocamlbuild/spec
+++ b/lang-ocaml/ocamlbuild/spec
@@ -1,4 +1,5 @@
 VER=0.14.1
-SRCS="tbl::https://github.com/ocaml/ocamlbuild/archive/$VER.tar.gz"
-CHKSUMS="sha256::4e1279ff0ef80c862eaa5207a77020d741e89ef94f0e4a92a37c4188dbf08256"
+REL=1
+SRCS="git::commit=tags/$VER::https://github.com/ocaml/ocamlbuild"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12387"


### PR DESCRIPTION
Topic Description
-----------------

- ocamlbuild: bump REL
    Fix ocaml version mismatch on riscv64:
    the file '/usr/bin/ocamlbuild' has not the right magic number: expected
    Caml1999X031, got Caml1999X026

Package(s) Affected
-------------------

- ocamlbuild: 0.14.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ocamlbuild
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
