### PR TITLE
clash-verge-rev (Clash Verge): new, 1.15.0

### DIFF
--- a/app-network/clash-verge-rev/autobuild/build
+++ b/app-network/clash-verge-rev/autobuild/build
@@ -1,0 +1,19 @@
+abinfo "Fetching dependencies and assets ..."
+pnpm install
+pnpm run check
+
+abinfo "Building Clash Verge ..."
+cargo tauri build
+
+abinfo "Installing Clash Verge ..."
+install -Dvm755 "$SRCDIR"/src-tauri/target/release/clash-verge \
+    "$PKGDIR"/usr/bin/clash-verge
+
+abinfo "Installing icon ..."
+# Note: This seems to be the only appropriate icon.
+install -Dvm644 "$SRCDIR"/src/assets/image/logo.bak.svg \
+    "$PKGDIR"/usr/share/pixmaps/clash-verge.svg
+
+abinfo "Installing .desktop entry ..."
+install -Dvm644 "$SRCDIR"/src/assets/xdg/io.github.clash-verge-rev.desktop \
+    "$PKGDIR"/usr/share/applications/io.github.clash-verge-rev.desktop

--- a/app-network/clash-verge-rev/autobuild/defines
+++ b/app-network/clash-verge-rev/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=clash-verge-rev
+PKGSEC=net
+PKGDEP="gtk-3 libsoup mihomo webkit2gtk"
+BUILDDEP="pnpm rustc"
+PKGDES="A GUI configuration manager for the Clash rule-based proxy"
+
+PKGPROV="clash-verge"
+
+# FIXME: lld.ld and ring v0.17 issue
+NOLTO=1
+
+# FIXME: Node.js is not available on MIPS R6.
+# FIXME: Vite not supported on loongson3, riscv64.
+FAIL_ARCH="(loongson3|mips64r6el|riscv64)"

--- a/app-network/clash-verge-rev/autobuild/patches/0001-fix-package.json-allow-building-on-platforms-without.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0001-fix-package.json-allow-building-on-platforms-without.patch
@@ -1,0 +1,29 @@
+From fb4c46386c0aa33a7e62c0fddcac65c17a8d4c0d Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 22 Mar 2024 15:42:32 +0800
+Subject: [PATCH 1/9] fix(package.json): allow building on platforms without
+ native rollup binaries
+
+Ref: https://github.com/clash-verge-rev/clash-verge-rev/issues/453#issuecomment-2002506344
+---
+ package.json | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/package.json b/package.json
+index e4ed81a..9f8e4cb 100644
+--- a/package.json
++++ b/package.json
+@@ -76,5 +76,10 @@
+     "semi": true,
+     "singleQuote": false,
+     "endOfLine": "lf"
++  },
++  "pnpm": {
++    "overrides": {
++      "rollup": "npm:@rollup/wasm-node"
++    }
+   }
+ }
+-- 
+2.44.0
+

--- a/app-network/clash-verge-rev/autobuild/patches/0002-chore-src-tauri-update-Cargo-dependencies.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0002-chore-src-tauri-update-Cargo-dependencies.patch
@@ -1,0 +1,2586 @@
+From 425afdd682566d5c518a7f007676f9a4b7e98bad Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 22 Mar 2024 15:43:11 +0800
+Subject: [PATCH 2/9] chore(src-tauri): update Cargo dependencies
+
+- This allows building clash-verge-rev on loongarch64.
+- Procedure: cd src-tauri && cargo update.
+---
+ src-tauri/Cargo.lock | 852 ++++++++++++++++++++++---------------------
+ 1 file changed, 438 insertions(+), 414 deletions(-)
+
+diff --git a/src-tauri/Cargo.lock b/src-tauri/Cargo.lock
+index d715578..81252ea 100644
+--- a/src-tauri/Cargo.lock
++++ b/src-tauri/Cargo.lock
+@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+ 
+ [[package]]
+ name = "ahash"
+-version = "0.7.7"
++version = "0.7.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
++checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+ dependencies = [
+  "getrandom 0.2.12",
+  "once_cell",
+@@ -30,9 +30,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ahash"
+-version = "0.8.7"
++version = "0.8.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
++checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+ dependencies = [
+  "cfg-if",
+  "getrandom 0.2.12",
+@@ -52,9 +52,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aho-corasick"
+-version = "1.1.2"
++version = "1.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
++checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+ dependencies = [
+  "memchr",
+ ]
+@@ -97,35 +97,35 @@ dependencies = [
+ 
+ [[package]]
+ name = "anyhow"
+-version = "1.0.79"
++version = "1.0.81"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
++checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+ 
+ [[package]]
+ name = "arboard"
+-version = "3.3.0"
++version = "3.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "aafb29b107435aa276664c1db8954ac27a6e105cdad3c88287a199eb0e313c08"
++checksum = "a2041f1943049c7978768d84e6d0fd95de98b76d6c4727b09e78ec253d29fa58"
+ dependencies = [
+  "clipboard-win",
+- "core-graphics 0.22.3",
++ "core-graphics 0.23.1",
+  "image",
+- "log 0.4.20",
++ "log 0.4.21",
+  "objc",
+  "objc-foundation",
+  "objc_id",
+  "parking_lot",
+  "thiserror",
+- "winapi",
++ "windows-sys 0.48.0",
+  "wl-clipboard-rs",
+  "x11rb",
+ ]
+ 
+ [[package]]
+ name = "arc-swap"
+-version = "1.6.0"
++version = "1.7.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
++checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
+ 
+ [[package]]
+ name = "arrayvec"
+@@ -161,7 +161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+ dependencies = [
+  "concurrent-queue",
+- "event-listener 5.0.0",
++ "event-listener 5.2.0",
+  "event-listener-strategy 0.5.0",
+  "futures-core",
+  "pin-project-lite",
+@@ -177,7 +177,7 @@ dependencies = [
+  "async-task",
+  "concurrent-queue",
+  "fastrand 2.0.1",
+- "futures-lite 2.2.0",
++ "futures-lite 2.3.0",
+  "slab",
+ ]
+ 
+@@ -204,7 +204,7 @@ dependencies = [
+  "cfg-if",
+  "concurrent-queue",
+  "futures-lite 1.13.0",
+- "log 0.4.20",
++ "log 0.4.21",
+  "parking",
+  "polling 2.8.0",
+  "rustix 0.37.27",
+@@ -215,18 +215,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "async-io"
+-version = "2.3.1"
++version = "2.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
++checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
+ dependencies = [
+  "async-lock 3.3.0",
+  "cfg-if",
+  "concurrent-queue",
+  "futures-io",
+- "futures-lite 2.2.0",
++ "futures-lite 2.3.0",
+  "parking",
+- "polling 3.4.0",
+- "rustix 0.38.31",
++ "polling 3.5.0",
++ "rustix 0.38.32",
+  "slab",
+  "tracing",
+  "windows-sys 0.52.0",
+@@ -276,19 +276,19 @@ dependencies = [
+  "cfg-if",
+  "event-listener 3.1.0",
+  "futures-lite 1.13.0",
+- "rustix 0.38.31",
++ "rustix 0.38.32",
+  "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+ name = "async-recursion"
+-version = "1.0.5"
++version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
++checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -297,13 +297,13 @@ version = "0.2.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+ dependencies = [
+- "async-io 2.3.1",
++ "async-io 2.3.2",
+  "async-lock 2.8.0",
+  "atomic-waker",
+  "cfg-if",
+  "futures-core",
+  "futures-io",
+- "rustix 0.38.31",
++ "rustix 0.38.32",
+  "signal-hook-registry",
+  "slab",
+  "windows-sys 0.48.0",
+@@ -317,13 +317,13 @@ checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+ 
+ [[package]]
+ name = "async-trait"
+-version = "0.1.77"
++version = "0.1.78"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
++checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -347,7 +347,7 @@ dependencies = [
+  "glib-sys",
+  "gobject-sys",
+  "libc",
+- "system-deps 6.2.0",
++ "system-deps 6.2.2",
+ ]
+ 
+ [[package]]
+@@ -374,9 +374,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+ 
+ [[package]]
+ name = "backtrace"
+-version = "0.3.69"
++version = "0.3.70"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
++checksum = "95d8e92cac0961e91dbd517496b00f7e9b92363dbe6d42c3198268323798860c"
+ dependencies = [
+  "addr2line",
+  "cc",
+@@ -407,9 +407,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+ 
+ [[package]]
+ name = "bitflags"
+-version = "2.4.2"
++version = "2.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
++checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+ 
+ [[package]]
+ name = "block"
+@@ -446,7 +446,7 @@ dependencies = [
+  "async-task",
+  "fastrand 2.0.1",
+  "futures-io",
+- "futures-lite 2.2.0",
++ "futures-lite 2.3.0",
+  "piper",
+  "tracing",
+ ]
+@@ -457,7 +457,7 @@ version = "0.18.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "5b6fb81ca0f301f33aff7401e2ffab37dc9e0e4a1cf0ccf6b34f4d9e60aa0682"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "boa_interner",
+  "boa_macros",
+  "indexmap 2.2.5",
+@@ -472,7 +472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "600e4e4a65b26efcef08a7b1cf2899d3845a32e82e067ee3b75eaf7e413ff31c"
+ dependencies = [
+  "arrayvec",
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "boa_ast",
+  "boa_gc",
+  "boa_interner",
+@@ -546,7 +546,7 @@ checksum = "6be9c93793b60dac381af475b98634d4b451e28336e72218cad9a20176218dbc"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+  "synstructure",
+ ]
+ 
+@@ -556,7 +556,7 @@ version = "0.18.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9e8592556849f0619ed142ce2b3a19086769314a8d657f93a5765d06dbce4818"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "boa_ast",
+  "boa_interner",
+  "boa_macros",
+@@ -577,9 +577,9 @@ checksum = "e0d8372f2d5cbac600a260de87877141b42da1e18d2c7a08ccb493a49cbd55c0"
+ 
+ [[package]]
+ name = "brotli"
+-version = "3.4.0"
++version = "3.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
++checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+ dependencies = [
+  "alloc-no-stdlib",
+  "alloc-stdlib",
+@@ -598,9 +598,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "bstr"
+-version = "1.9.0"
++version = "1.9.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
++checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+ dependencies = [
+  "memchr",
+  "serde",
+@@ -608,15 +608,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "bumpalo"
+-version = "3.14.0"
++version = "3.15.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
++checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+ 
+ [[package]]
+ name = "bytemuck"
+-version = "1.14.3"
++version = "1.15.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
++checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+ dependencies = [
+  "bytemuck_derive",
+ ]
+@@ -629,7 +629,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -668,7 +668,7 @@ checksum = "3c55d429bef56ac9172d25fecb85dc8068307d17acd74b377866b7a1ef25d3c8"
+ dependencies = [
+  "glib-sys",
+  "libc",
+- "system-deps 6.2.0",
++ "system-deps 6.2.2",
+ ]
+ 
+ [[package]]
+@@ -683,12 +683,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.83"
++version = "1.0.90"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+-dependencies = [
+- "libc",
+-]
++checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+ 
+ [[package]]
+ name = "cesu8"
+@@ -732,11 +729,17 @@ version = "1.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+ 
++[[package]]
++name = "cfg_aliases"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
++
+ [[package]]
+ name = "chrono"
+-version = "0.4.33"
++version = "0.4.35"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
++checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+ dependencies = [
+  "android-tzdata",
+  "iana-time-zone",
+@@ -744,7 +747,7 @@ dependencies = [
+  "num-traits",
+  "serde",
+  "wasm-bindgen",
+- "windows-targets 0.52.0",
++ "windows-targets 0.52.4",
+ ]
+ 
+ [[package]]
+@@ -759,7 +762,7 @@ dependencies = [
+  "delay_timer",
+  "dirs 5.0.1",
+  "dunce",
+- "log 0.4.20",
++ "log 0.4.21",
+  "log4rs",
+  "nanoid",
+  "once_cell",
+@@ -784,13 +787,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "clipboard-win"
+-version = "4.5.0"
++version = "5.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
++checksum = "d517d4b86184dbb111d3556a10f1c8a04da7428d2987bf1081602bf11c3aa9ee"
+ dependencies = [
+  "error-code",
+- "str-buf",
+- "winapi",
+ ]
+ 
+ [[package]]
+@@ -862,7 +863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f76990911f2267d837d9d0ad060aa63aaad170af40904b29461734c339030d4d"
+ dependencies = [
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -944,9 +945,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crc32fast"
+-version = "1.3.2"
++version = "1.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
++checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+ dependencies = [
+  "cfg-if",
+ ]
+@@ -964,9 +965,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-channel"
+-version = "0.5.11"
++version = "0.5.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
++checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+ dependencies = [
+  "crossbeam-utils",
+ ]
+@@ -1030,24 +1031,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+ dependencies = [
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+ name = "ctor"
+-version = "0.2.6"
++version = "0.2.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e"
++checksum = "ad291aa74992b9b7a7e88c38acbbf6ad7e107f1d90ee8775b7bc1fc3394f485c"
+ dependencies = [
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+ name = "darling"
+-version = "0.20.5"
++version = "0.20.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
++checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+ dependencies = [
+  "darling_core",
+  "darling_macro",
+@@ -1055,27 +1056,27 @@ dependencies = [
+ 
+ [[package]]
+ name = "darling_core"
+-version = "0.20.5"
++version = "0.20.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
++checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+ dependencies = [
+  "fnv",
+  "ident_case",
+  "proc-macro2",
+  "quote",
+  "strsim",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+ name = "darling_macro"
+-version = "0.20.5"
++version = "0.20.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
++checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+ dependencies = [
+  "darling_core",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -1135,7 +1136,7 @@ dependencies = [
+  "dashmap 4.0.2",
+  "event-listener 2.5.3",
+  "futures",
+- "log 0.4.20",
++ "log 0.4.21",
+  "lru",
+  "once_cell",
+  "rs-snowflake",
+@@ -1169,13 +1170,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "derive-new"
+-version = "0.5.9"
++version = "0.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
++checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 1.0.109",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -1292,7 +1293,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -1301,7 +1302,7 @@ version = "0.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+ dependencies = [
+- "libloading",
++ "libloading 0.8.3",
+ ]
+ 
+ [[package]]
+@@ -1339,16 +1340,16 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+ 
+ [[package]]
+ name = "embed-resource"
+-version = "2.4.1"
++version = "2.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3bde55e389bea6a966bd467ad1ad7da0ae14546a5bc794d16d1e55e7fca44881"
++checksum = "c6985554d0688b687c5cb73898a34fbe3ad6c24c58c238a4d91d5e840670ee9d"
+ dependencies = [
+  "cc",
+  "memchr",
+  "rustc_version 0.4.0",
+- "toml 0.8.10",
++ "toml 0.8.12",
+  "vswhom",
+- "winreg 0.51.0",
++ "winreg 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -1368,9 +1369,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "enumflags2"
+-version = "0.7.8"
++version = "0.7.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5998b4f30320c9d93aed72f63af821bfdac50465b75428fce77b48ec482c3939"
++checksum = "3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d"
+ dependencies = [
+  "enumflags2_derive",
+  "serde",
+@@ -1378,13 +1379,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "enumflags2_derive"
+-version = "0.7.8"
++version = "0.7.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
++checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -1405,13 +1406,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "error-code"
+-version = "2.3.1"
++version = "3.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+-dependencies = [
+- "libc",
+- "str-buf",
+-]
++checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+ 
+ [[package]]
+ name = "event-listener"
+@@ -1443,9 +1440,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "event-listener"
+-version = "5.0.0"
++version = "5.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b72557800024fabbaa2449dd4bf24e37b93702d457a4d4f2b0dd1f0f039f20c1"
++checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+ dependencies = [
+  "concurrent-queue",
+  "parking",
+@@ -1468,7 +1465,7 @@ version = "0.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+ dependencies = [
+- "event-listener 5.0.0",
++ "event-listener 5.2.0",
+  "pin-project-lite",
+ ]
+ 
+@@ -1584,7 +1581,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -1683,9 +1680,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "futures-lite"
+-version = "2.2.0"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
++checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+ dependencies = [
+  "fastrand 2.0.1",
+  "futures-core",
+@@ -1702,7 +1699,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -1783,7 +1780,7 @@ dependencies = [
+  "glib-sys",
+  "gobject-sys",
+  "libc",
+- "system-deps 6.2.0",
++ "system-deps 6.2.2",
+ ]
+ 
+ [[package]]
+@@ -1800,7 +1797,7 @@ dependencies = [
+  "libc",
+  "pango-sys",
+  "pkg-config",
+- "system-deps 6.2.0",
++ "system-deps 6.2.2",
+ ]
+ 
+ [[package]]
+@@ -1814,7 +1811,7 @@ dependencies = [
+  "gobject-sys",
+  "libc",
+  "pkg-config",
+- "system-deps 6.2.0",
++ "system-deps 6.2.2",
+ ]
+ 
+ [[package]]
+@@ -1826,7 +1823,7 @@ dependencies = [
+  "gdk-sys",
+  "glib-sys",
+  "libc",
+- "system-deps 6.2.0",
++ "system-deps 6.2.2",
+  "x11",
+ ]
+ 
+@@ -1838,7 +1835,7 @@ checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+ dependencies = [
+  "cc",
+  "libc",
+- "log 0.4.20",
++ "log 0.4.21",
+  "rustversion",
+  "windows 0.48.0",
+ ]
+@@ -1855,12 +1852,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "gethostname"
+-version = "0.3.0"
++version = "0.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177"
++checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+ dependencies = [
+  "libc",
+- "winapi",
++ "windows-targets 0.48.5",
+ ]
+ 
+ [[package]]
+@@ -1917,7 +1914,7 @@ dependencies = [
+  "glib-sys",
+  "gobject-sys",
+  "libc",
+- "system-deps 6.2.0",
++ "system-deps 6.2.2",
+  "winapi",
+ ]
+ 
+@@ -1949,7 +1946,7 @@ checksum = "10c6ae9f6fa26f4fb2ac16b528d138d971ead56141de489f8111e259b9df3c4a"
+ dependencies = [
+  "anyhow",
+  "heck 0.4.1",
+- "proc-macro-crate",
++ "proc-macro-crate 1.3.1",
+  "proc-macro-error",
+  "proc-macro2",
+  "quote",
+@@ -1963,7 +1960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ef4b192f8e65e9cf76cbf4ea71fa8e3be4a0e18ffe3d68b8da6836974cc5bad4"
+ dependencies = [
+  "libc",
+- "system-deps 6.2.0",
++ "system-deps 6.2.2",
+ ]
+ 
+ [[package]]
+@@ -1978,10 +1975,10 @@ version = "0.4.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+ dependencies = [
+- "aho-corasick 1.1.2",
++ "aho-corasick 1.1.3",
+  "bstr",
+- "log 0.4.20",
+- "regex-automata 0.4.5",
++ "log 0.4.21",
++ "regex-automata 0.4.6",
+  "regex-syntax 0.8.2",
+ ]
+ 
+@@ -1993,7 +1990,7 @@ checksum = "0d57ce44246becd17153bd035ab4d32cfee096a657fc01f2231c9278378d1e0a"
+ dependencies = [
+  "glib-sys",
+  "libc",
+- "system-deps 6.2.0",
++ "system-deps 6.2.2",
+ ]
+ 
+ [[package]]
+@@ -2034,7 +2031,7 @@ dependencies = [
+  "gobject-sys",
+  "libc",
+  "pango-sys",
+- "system-deps 6.2.0",
++ "system-deps 6.2.2",
+ ]
+ 
+ [[package]]
+@@ -2044,7 +2041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "684c0456c086e8e7e9af73ec5b84e35938df394712054550e81558d21c44ab0d"
+ dependencies = [
+  "anyhow",
+- "proc-macro-crate",
++ "proc-macro-crate 1.3.1",
+  "proc-macro-error",
+  "proc-macro2",
+  "quote",
+@@ -2053,16 +2050,16 @@ dependencies = [
+ 
+ [[package]]
+ name = "h2"
+-version = "0.3.24"
++version = "0.3.25"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
++checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+ dependencies = [
+  "bytes",
+  "fnv",
+  "futures-core",
+  "futures-sink",
+  "futures-util",
+- "http 0.2.11",
++ "http 0.2.12",
+  "indexmap 2.2.5",
+  "slab",
+  "tokio",
+@@ -2110,7 +2107,7 @@ version = "0.12.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+ dependencies = [
+- "ahash 0.7.7",
++ "ahash 0.7.8",
+ ]
+ 
+ [[package]]
+@@ -2119,7 +2116,7 @@ version = "0.14.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+ dependencies = [
+- "ahash 0.8.7",
++ "ahash 0.8.11",
+  "allocator-api2",
+ ]
+ 
+@@ -2132,7 +2129,7 @@ dependencies = [
+  "base64 0.21.7",
+  "bytes",
+  "headers-core",
+- "http 0.2.11",
++ "http 0.2.12",
+  "httpdate",
+  "mime",
+  "sha1",
+@@ -2144,7 +2141,7 @@ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+ dependencies = [
+- "http 0.2.11",
++ "http 0.2.12",
+ ]
+ 
+ [[package]]
+@@ -2162,11 +2159,17 @@ version = "0.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+ 
++[[package]]
++name = "heck"
++version = "0.5.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
++
+ [[package]]
+ name = "hermit-abi"
+-version = "0.3.5"
++version = "0.3.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
++checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+ 
+ [[package]]
+ name = "hex"
+@@ -2189,7 +2192,7 @@ version = "0.26.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+ dependencies = [
+- "log 0.4.20",
++ "log 0.4.21",
+  "mac",
+  "markup5ever",
+  "proc-macro2",
+@@ -2199,9 +2202,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "http"
+-version = "0.2.11"
++version = "0.2.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
++checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+ dependencies = [
+  "bytes",
+  "fnv",
+@@ -2226,7 +2229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+ dependencies = [
+  "bytes",
+- "http 0.2.11",
++ "http 0.2.12",
+  "pin-project-lite",
+ ]
+ 
+@@ -2287,14 +2290,14 @@ dependencies = [
+  "futures-channel",
+  "futures-core",
+  "futures-util",
+- "h2 0.3.24",
+- "http 0.2.11",
++ "h2 0.3.25",
++ "http 0.2.12",
+  "http-body 0.4.6",
+  "httparse",
+  "httpdate",
+  "itoa 1.0.10",
+  "pin-project-lite",
+- "socket2 0.5.5",
++ "socket2 0.5.6",
+  "tokio",
+  "tower-service",
+  "tracing",
+@@ -2380,7 +2383,7 @@ dependencies = [
+  "http-body 1.0.0",
+  "hyper 1.2.0",
+  "pin-project-lite",
+- "socket2 0.5.5",
++ "socket2 0.5.6",
+  "tokio",
+  "tower",
+  "tower-service",
+@@ -2535,7 +2538,7 @@ checksum = "d2abdd3a62551e8337af119c5899e600ca0c88ec8f23a46c60ba216c803dcf1a"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -2562,9 +2565,9 @@ checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+ dependencies = [
+  "crossbeam-deque",
+  "globset",
+- "log 0.4.20",
++ "log 0.4.21",
+  "memchr",
+- "regex-automata 0.4.5",
++ "regex-automata 0.4.6",
+  "same-file",
+  "walkdir",
+  "winapi-util",
+@@ -2572,9 +2575,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "image"
+-version = "0.24.8"
++version = "0.24.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "034bbe799d1909622a74d1193aa50147769440040ff36cb2baa947609b0a4e23"
++checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+ dependencies = [
+  "bytemuck",
+  "byteorder",
+@@ -2681,7 +2684,7 @@ version = "0.2.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c416c05ba2a10240e022887617af3128fccdbf69713214da0fc81a5690d00df7"
+ dependencies = [
+- "ahash 0.8.7",
++ "ahash 0.8.11",
+  "once_cell",
+  "regex 1.10.3",
+ ]
+@@ -2758,7 +2761,7 @@ dependencies = [
+  "cesu8",
+  "combine",
+  "jni-sys",
+- "log 0.4.20",
++ "log 0.4.21",
+  "thiserror",
+  "walkdir",
+ ]
+@@ -2777,9 +2780,9 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+ 
+ [[package]]
+ name = "js-sys"
+-version = "0.3.68"
++version = "0.3.69"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
++checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+ dependencies = [
+  "wasm-bindgen",
+ ]
+@@ -2831,7 +2834,7 @@ dependencies = [
+  "gtk",
+  "gtk-sys",
+  "libappindicator-sys",
+- "log 0.4.20",
++ "log 0.4.21",
+ ]
+ 
+ [[package]]
+@@ -2841,7 +2844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f1b3b6681973cea8cc3bce7391e6d7d5502720b80a581c9a95c9cbaf592826aa"
+ dependencies = [
+  "gtk-sys",
+- "libloading",
++ "libloading 0.7.4",
+  "once_cell",
+ ]
+ 
+@@ -2861,13 +2864,23 @@ dependencies = [
+  "winapi",
+ ]
+ 
++[[package]]
++name = "libloading"
++version = "0.8.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
++dependencies = [
++ "cfg-if",
++ "windows-targets 0.52.4",
++]
++
+ [[package]]
+ name = "libredox"
+ version = "0.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "libc",
+  "redox_syscall",
+ ]
+@@ -2915,14 +2928,14 @@ version = "0.3.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+ dependencies = [
+- "log 0.4.20",
++ "log 0.4.21",
+ ]
+ 
+ [[package]]
+ name = "log"
+-version = "0.4.20"
++version = "0.4.21"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
++checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+ dependencies = [
+  "serde",
+ ]
+@@ -2946,7 +2959,7 @@ dependencies = [
+  "fnv",
+  "humantime",
+  "libc",
+- "log 0.4.20",
++ "log 0.4.21",
+  "log-mdc",
+  "once_cell",
+  "parking_lot",
+@@ -3019,7 +3032,7 @@ version = "0.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+ dependencies = [
+- "log 0.4.20",
++ "log 0.4.21",
+  "phf 0.10.1",
+  "phf_codegen 0.10.0",
+  "string_cache",
+@@ -3121,9 +3134,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "mio"
+-version = "0.8.10"
++version = "0.8.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
++checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+ dependencies = [
+  "libc",
+  "wasi 0.11.0+wasi-snapshot-preview1",
+@@ -3139,9 +3152,9 @@ dependencies = [
+  "bytes",
+  "encoding_rs",
+  "futures-util",
+- "http 0.2.11",
++ "http 0.2.12",
+  "httparse",
+- "log 0.4.20",
++ "log 0.4.21",
+  "memchr",
+  "mime",
+  "spin",
+@@ -3165,7 +3178,7 @@ checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+ dependencies = [
+  "lazy_static 1.4.0",
+  "libc",
+- "log 0.4.20",
++ "log 0.4.21",
+  "openssl",
+  "openssl-probe",
+  "openssl-sys",
+@@ -3205,9 +3218,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "new_debug_unreachable"
+-version = "1.0.4"
++version = "1.0.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
++checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+ 
+ [[package]]
+ name = "nix"
+@@ -3232,7 +3245,18 @@ dependencies = [
+  "cfg-if",
+  "libc",
+  "memoffset 0.7.1",
+- "pin-utils",
++]
++
++[[package]]
++name = "nix"
++version = "0.28.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
++dependencies = [
++ "bitflags 2.5.0",
++ "cfg-if",
++ "cfg_aliases",
++ "libc",
+ ]
+ 
+ [[package]]
+@@ -3267,7 +3291,7 @@ version = "4.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "827c5edfa80235ded4ab3fe8e9dc619b4f866ef16fe9b1c6b8a7f8692c0f2226"
+ dependencies = [
+- "log 0.4.20",
++ "log 0.4.21",
+  "mac-notification-sys",
+  "serde",
+  "tauri-winrt-notification",
+@@ -3374,7 +3398,7 @@ version = "0.5.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+ dependencies = [
+- "proc-macro-crate",
++ "proc-macro-crate 1.3.1",
+  "proc-macro2",
+  "quote",
+  "syn 1.0.109",
+@@ -3386,10 +3410,10 @@ version = "0.7.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+ dependencies = [
+- "proc-macro-crate",
++ "proc-macro-crate 3.1.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -3457,9 +3481,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+ 
+ [[package]]
+ name = "opaque-debug"
+-version = "0.3.0"
++version = "0.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
++checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+ 
+ [[package]]
+ name = "open"
+@@ -3484,11 +3508,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "openssl"
+-version = "0.10.63"
++version = "0.10.64"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
++checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "cfg-if",
+  "foreign-types 0.3.2",
+  "libc",
+@@ -3505,7 +3529,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -3516,9 +3540,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+ 
+ [[package]]
+ name = "openssl-sys"
+-version = "0.9.99"
++version = "0.9.101"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
++checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+ dependencies = [
+  "cc",
+  "libc",
+@@ -3589,7 +3613,7 @@ dependencies = [
+  "glib-sys",
+  "gobject-sys",
+  "libc",
+- "system-deps 6.2.0",
++ "system-deps 6.2.2",
+ ]
+ 
+ [[package]]
+@@ -3657,9 +3681,9 @@ checksum = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
+ 
+ [[package]]
+ name = "pest"
+-version = "2.7.7"
++version = "2.7.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
++checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
+ dependencies = [
+  "memchr",
+  "thiserror",
+@@ -3790,7 +3814,7 @@ dependencies = [
+  "phf_shared 0.11.2",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -3822,22 +3846,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "pin-project"
+-version = "1.1.4"
++version = "1.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
++checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+ dependencies = [
+  "pin-project-internal",
+ ]
+ 
+ [[package]]
+ name = "pin-project-internal"
+-version = "1.1.4"
++version = "1.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
++checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -3865,9 +3889,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "pkg-config"
+-version = "0.3.29"
++version = "0.3.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
++checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+ 
+ [[package]]
+ name = "plist"
+@@ -3885,9 +3909,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "png"
+-version = "0.17.11"
++version = "0.17.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1f6c3c3e617595665b8ea2ff95a86066be38fb121ff920a9c0eb282abcd1da5a"
++checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+ dependencies = [
+  "bitflags 1.3.2",
+  "crc32fast",
+@@ -3907,21 +3931,21 @@ dependencies = [
+  "cfg-if",
+  "concurrent-queue",
+  "libc",
+- "log 0.4.20",
++ "log 0.4.21",
+  "pin-project-lite",
+  "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+ name = "polling"
+-version = "3.4.0"
++version = "3.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "30054e72317ab98eddd8561db0f6524df3367636884b7b21b703e4b280a84a14"
++checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
+ dependencies = [
+  "cfg-if",
+  "concurrent-queue",
+  "pin-project-lite",
+- "rustix 0.38.31",
++ "rustix 0.38.32",
+  "tracing",
+  "windows-sys 0.52.0",
+ ]
+@@ -3972,6 +3996,15 @@ dependencies = [
+  "toml_edit 0.19.15",
+ ]
+ 
++[[package]]
++name = "proc-macro-crate"
++version = "3.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
++dependencies = [
++ "toml_edit 0.21.1",
++]
++
+ [[package]]
+ name = "proc-macro-error"
+ version = "1.0.4"
+@@ -4004,9 +4037,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+ 
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.78"
++version = "1.0.79"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
++checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+ dependencies = [
+  "unicode-ident",
+ ]
+@@ -4133,9 +4166,9 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+ 
+ [[package]]
+ name = "rayon"
+-version = "1.8.1"
++version = "1.9.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
++checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+ dependencies = [
+  "either",
+  "rayon-core",
+@@ -4190,9 +4223,9 @@ version = "1.10.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+ dependencies = [
+- "aho-corasick 1.1.2",
++ "aho-corasick 1.1.3",
+  "memchr",
+- "regex-automata 0.4.5",
++ "regex-automata 0.4.6",
+  "regex-syntax 0.8.2",
+ ]
+ 
+@@ -4207,11 +4240,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "regex-automata"
+-version = "0.4.5"
++version = "0.4.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
++checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+ dependencies = [
+- "aho-corasick 1.1.2",
++ "aho-corasick 1.1.3",
+  "memchr",
+  "regex-syntax 0.8.2",
+ ]
+@@ -4249,23 +4282,23 @@ dependencies = [
+ 
+ [[package]]
+ name = "reqwest"
+-version = "0.11.24"
++version = "0.11.27"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
++checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+ dependencies = [
+  "base64 0.21.7",
+  "bytes",
+  "encoding_rs",
+  "futures-core",
+  "futures-util",
+- "h2 0.3.24",
+- "http 0.2.11",
++ "h2 0.3.25",
++ "http 0.2.12",
+  "http-body 0.4.6",
+  "hyper 0.14.28",
+  "hyper-tls 0.5.0",
+  "ipnet",
+  "js-sys",
+- "log 0.4.20",
++ "log 0.4.21",
+  "mime",
+  "native-tls",
+  "once_cell",
+@@ -4310,7 +4343,7 @@ dependencies = [
+  "hyper-util",
+  "ipnet",
+  "js-sys",
+- "log 0.4.20",
++ "log 0.4.21",
+  "mime",
+  "native-tls",
+  "once_cell",
+@@ -4349,7 +4382,7 @@ dependencies = [
+  "gtk-sys",
+  "js-sys",
+  "lazy_static 1.4.0",
+- "log 0.4.20",
++ "log 0.4.21",
+  "objc",
+  "objc-foundation",
+  "objc_id",
+@@ -4362,16 +4395,17 @@ dependencies = [
+ 
+ [[package]]
+ name = "ring"
+-version = "0.17.7"
++version = "0.17.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
++checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+ dependencies = [
+  "cc",
++ "cfg-if",
+  "getrandom 0.2.12",
+  "libc",
+  "spin",
+  "untrusted",
+- "windows-sys 0.48.0",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -4419,7 +4453,7 @@ version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+ dependencies = [
+- "semver 1.0.21",
++ "semver 1.0.22",
+ ]
+ 
+ [[package]]
+@@ -4438,11 +4472,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustix"
+-version = "0.38.31"
++version = "0.38.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
++checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "errno",
+  "libc",
+  "linux-raw-sys 0.4.13",
+@@ -4455,7 +4489,7 @@ version = "0.22.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+ dependencies = [
+- "log 0.4.20",
++ "log 0.4.21",
+  "ring",
+  "rustls-pki-types",
+  "rustls-webpki",
+@@ -4497,9 +4531,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+ 
+ [[package]]
+ name = "ryu"
+-version = "1.0.16"
++version = "1.0.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
++checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+ 
+ [[package]]
+ name = "ryu-js"
+@@ -4576,7 +4610,7 @@ dependencies = [
+  "cssparser",
+  "derive_more",
+  "fxhash",
+- "log 0.4.20",
++ "log 0.4.21",
+  "matches",
+  "phf 0.8.0",
+  "phf_codegen 0.8.0",
+@@ -4606,9 +4640,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "semver"
+-version = "1.0.21"
++version = "1.0.22"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
++checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+ dependencies = [
+  "serde",
+ ]
+@@ -4625,7 +4659,7 @@ version = "0.10.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+ dependencies = [
+- "pest 2.7.7",
++ "pest 2.7.8",
+ ]
+ 
+ [[package]]
+@@ -4655,7 +4689,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -4678,7 +4712,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -4704,9 +4738,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "serde_with"
+-version = "3.6.1"
++version = "3.7.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
++checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
+ dependencies = [
+  "base64 0.21.7",
+  "chrono",
+@@ -4722,21 +4756,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "serde_with_macros"
+-version = "3.6.1"
++version = "3.7.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
++checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
+ dependencies = [
+  "darling",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+ name = "serde_yaml"
+-version = "0.9.31"
++version = "0.9.33"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
++checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
+ dependencies = [
+  "indexmap 2.2.5",
+  "itoa 1.0.10",
+@@ -4883,9 +4917,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "smallvec"
+-version = "1.13.1"
++version = "1.13.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
++checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+ 
+ [[package]]
+ name = "smol"
+@@ -4916,12 +4950,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "socket2"
+-version = "0.5.5"
++version = "0.5.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
++checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+ dependencies = [
+  "libc",
+- "windows-sys 0.48.0",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -4985,12 +5019,6 @@ version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+ 
+-[[package]]
+-name = "str-buf"
+-version = "1.0.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+-
+ [[package]]
+ name = "string_cache"
+ version = "0.8.7"
+@@ -5042,9 +5070,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "syn"
+-version = "2.0.52"
++version = "2.0.53"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
++checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -5065,14 +5093,14 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+ name = "sysinfo"
+-version = "0.30.5"
++version = "0.30.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1fb4f3438c8f6389c864e61221cbc97e9bca98b4daf39a5beb7bea660f528bb2"
++checksum = "0c385888ef380a852a16209afc8cfad22795dd8873d69c9a14d2e2088f118d18"
+ dependencies = [
+  "cfg-if",
+  "core-foundation-sys",
+@@ -5086,11 +5114,11 @@ dependencies = [
+ [[package]]
+ name = "sysproxy"
+ version = "0.3.0"
+-source = "git+https://github.com/zzzgydi/sysproxy-rs?branch=main#add5bbdf2edfa150f4469d3c3e4f8f2ec6d17fcb"
++source = "git+https://github.com/zzzgydi/sysproxy-rs?branch=main#31f96dd6923d163850295a05e32d665414b3dd88"
+ dependencies = [
+  "interfaces",
+  "iptools",
+- "log 0.4.20",
++ "log 0.4.21",
+  "thiserror",
+  "windows 0.52.0",
+  "winreg 0.52.0",
+@@ -5132,15 +5160,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "system-deps"
+-version = "6.2.0"
++version = "6.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331"
++checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+ dependencies = [
+  "cfg-expr 0.15.7",
+- "heck 0.4.1",
++ "heck 0.5.0",
+  "pkg-config",
+- "toml 0.8.10",
+- "version-compare 0.1.1",
++ "toml 0.8.12",
++ "version-compare 0.2.0",
+ ]
+ 
+ [[package]]
+@@ -5173,7 +5201,7 @@ dependencies = [
+  "lazy_static 1.4.0",
+  "libappindicator",
+  "libc",
+- "log 0.4.20",
++ "log 0.4.21",
+  "ndk",
+  "ndk-context",
+  "ndk-sys",
+@@ -5222,9 +5250,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "target-lexicon"
+-version = "0.12.13"
++version = "0.12.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
++checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+ 
+ [[package]]
+ name = "tauri"
+@@ -5246,7 +5274,7 @@ dependencies = [
+  "glob",
+  "gtk",
+  "heck 0.4.1",
+- "http 0.2.11",
++ "http 0.2.12",
+  "ignore",
+  "indexmap 1.9.3",
+  "infer 0.9.0",
+@@ -5262,9 +5290,9 @@ dependencies = [
+  "rand 0.8.5",
+  "raw-window-handle",
+  "regex 1.10.3",
+- "reqwest 0.11.24",
++ "reqwest 0.11.27",
+  "rfd",
+- "semver 1.0.21",
++ "semver 1.0.22",
+  "serde",
+  "serde_json",
+  "serde_repr",
+@@ -5299,7 +5327,7 @@ dependencies = [
+  "dirs-next",
+  "heck 0.4.1",
+  "json-patch",
+- "semver 1.0.21",
++ "semver 1.0.22",
+  "serde",
+  "serde_json",
+  "tauri-utils",
+@@ -5322,7 +5350,7 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+  "regex 1.10.3",
+- "semver 1.0.21",
++ "semver 1.0.22",
+  "serde",
+  "serde_json",
+  "sha2 0.10.8",
+@@ -5354,7 +5382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "cf2d0652aa2891ff3e9caa2401405257ea29ab8372cce01f186a5825f1bd0e76"
+ dependencies = [
+  "gtk",
+- "http 0.2.11",
++ "http 0.2.12",
+  "http-range",
+  "rand 0.8.5",
+  "raw-window-handle",
+@@ -5404,12 +5432,12 @@ dependencies = [
+  "infer 0.13.0",
+  "json-patch",
+  "kuchikiki",
+- "log 0.4.20",
++ "log 0.4.21",
+  "memchr",
+  "phf 0.11.2",
+  "proc-macro2",
+  "quote",
+- "semver 1.0.21",
++ "semver 1.0.22",
+  "serde",
+  "serde_json",
+  "serde_with",
+@@ -5441,13 +5469,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "tempfile"
+-version = "3.10.0"
++version = "3.10.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
++checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+ dependencies = [
+  "cfg-if",
+  "fastrand 2.0.1",
+- "rustix 0.38.31",
++ "rustix 0.38.32",
+  "windows-sys 0.52.0",
+ ]
+ 
+@@ -5498,7 +5526,7 @@ dependencies = [
+  "hex",
+  "lazy_static 1.4.0",
+  "libc",
+- "log 0.4.20",
++ "log 0.4.21",
+  "memmem",
+  "num-derive",
+  "num-traits",
+@@ -5545,7 +5573,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -5569,9 +5597,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "thread_local"
+-version = "1.1.7"
++version = "1.1.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
++checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+ dependencies = [
+  "cfg-if",
+  "once_cell",
+@@ -5661,7 +5689,7 @@ dependencies = [
+  "parking_lot",
+  "pin-project-lite",
+  "signal-hook-registry",
+- "socket2 0.5.5",
++ "socket2 0.5.6",
+  "tokio-macros",
+  "windows-sys 0.48.0",
+ ]
+@@ -5674,7 +5702,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -5700,9 +5728,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tokio-stream"
+-version = "0.1.14"
++version = "0.1.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
++checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+ dependencies = [
+  "futures-core",
+  "pin-project-lite",
+@@ -5716,7 +5744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+ dependencies = [
+  "futures-util",
+- "log 0.4.20",
++ "log 0.4.21",
+  "tokio",
+  "tungstenite",
+ ]
+@@ -5758,14 +5786,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "toml"
+-version = "0.8.10"
++version = "0.8.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
++checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+ dependencies = [
+  "serde",
+  "serde_spanned",
+  "toml_datetime",
+- "toml_edit 0.22.4",
++ "toml_edit 0.22.9",
+ ]
+ 
+ [[package]]
+@@ -5787,20 +5815,31 @@ dependencies = [
+  "serde",
+  "serde_spanned",
+  "toml_datetime",
+- "winnow",
++ "winnow 0.5.40",
++]
++
++[[package]]
++name = "toml_edit"
++version = "0.21.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
++dependencies = [
++ "indexmap 2.2.5",
++ "toml_datetime",
++ "winnow 0.5.40",
+ ]
+ 
+ [[package]]
+ name = "toml_edit"
+-version = "0.22.4"
++version = "0.22.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
++checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+ dependencies = [
+  "indexmap 2.2.5",
+  "serde",
+  "serde_spanned",
+  "toml_datetime",
+- "winnow",
++ "winnow 0.6.5",
+ ]
+ 
+ [[package]]
+@@ -5837,7 +5876,7 @@ version = "0.1.40"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+ dependencies = [
+- "log 0.4.20",
++ "log 0.4.21",
+  "pin-project-lite",
+  "tracing-attributes",
+  "tracing-core",
+@@ -5851,7 +5890,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -5870,7 +5909,7 @@ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+ dependencies = [
+- "log 0.4.20",
++ "log 0.4.21",
+  "once_cell",
+  "tracing-core",
+ ]
+@@ -5887,7 +5926,7 @@ dependencies = [
+  "regex 1.10.3",
+  "sharded-slab",
+  "smallvec",
+- "thread_local 1.1.7",
++ "thread_local 1.1.8",
+  "tracing",
+  "tracing-core",
+  "tracing-log",
+@@ -5931,9 +5970,9 @@ dependencies = [
+  "byteorder",
+  "bytes",
+  "data-encoding",
+- "http 0.2.11",
++ "http 0.2.12",
+  "httparse",
+- "log 0.4.20",
++ "log 0.4.21",
+  "rand 0.8.5",
+  "sha1",
+  "thiserror",
+@@ -6002,9 +6041,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+ 
+ [[package]]
+ name = "unicode-normalization"
+-version = "0.1.22"
++version = "0.1.23"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
++checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+ dependencies = [
+  "tinyvec",
+ ]
+@@ -6026,9 +6065,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "unsafe-libyaml"
+-version = "0.2.10"
++version = "0.2.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
++checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+ 
+ [[package]]
+ name = "untrusted"
+@@ -6080,9 +6119,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+ 
+ [[package]]
+ name = "uuid"
+-version = "1.7.0"
++version = "1.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
++checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+ dependencies = [
+  "getrandom 0.2.12",
+ ]
+@@ -6107,9 +6146,9 @@ checksum = "1c18c859eead79d8b95d09e4678566e8d70105c4e7b251f707a03df32442661b"
+ 
+ [[package]]
+ name = "version-compare"
+-version = "0.1.1"
++version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
++checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+ 
+ [[package]]
+ name = "version_check"
+@@ -6154,9 +6193,9 @@ checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+ 
+ [[package]]
+ name = "walkdir"
+-version = "2.4.0"
++version = "2.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
++checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+ dependencies = [
+  "same-file",
+  "winapi-util",
+@@ -6181,9 +6220,9 @@ dependencies = [
+  "futures-channel",
+  "futures-util",
+  "headers",
+- "http 0.2.11",
++ "http 0.2.12",
+  "hyper 0.14.28",
+- "log 0.4.20",
++ "log 0.4.21",
+  "mime",
+  "mime_guess",
+  "multer",
+@@ -6216,9 +6255,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+ 
+ [[package]]
+ name = "wasm-bindgen"
+-version = "0.2.91"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
++checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+ dependencies = [
+  "cfg-if",
+  "wasm-bindgen-macro",
+@@ -6226,24 +6265,24 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-backend"
+-version = "0.2.91"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
++checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+ dependencies = [
+  "bumpalo",
+- "log 0.4.20",
++ "log 0.4.21",
+  "once_cell",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+  "wasm-bindgen-shared",
+ ]
+ 
+ [[package]]
+ name = "wasm-bindgen-futures"
+-version = "0.4.41"
++version = "0.4.42"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
++checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+ dependencies = [
+  "cfg-if",
+  "js-sys",
+@@ -6253,9 +6292,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro"
+-version = "0.2.91"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
++checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+ dependencies = [
+  "quote",
+  "wasm-bindgen-macro-support",
+@@ -6263,22 +6302,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro-support"
+-version = "0.2.91"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
++checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+  "wasm-bindgen-backend",
+  "wasm-bindgen-shared",
+ ]
+ 
+ [[package]]
+ name = "wasm-bindgen-shared"
+-version = "0.2.91"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
++checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+ 
+ [[package]]
+ name = "wasm-streams"
+@@ -6301,7 +6340,7 @@ checksum = "9d50fa61ce90d76474c87f5fc002828d81b32677340112b4ef08079a9d459a40"
+ dependencies = [
+  "cc",
+  "downcast-rs",
+- "rustix 0.38.31",
++ "rustix 0.38.32",
+  "scoped-tls",
+  "smallvec",
+  "wayland-sys",
+@@ -6313,8 +6352,8 @@ version = "0.31.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f"
+ dependencies = [
+- "bitflags 2.4.2",
+- "rustix 0.38.31",
++ "bitflags 2.5.0",
++ "rustix 0.38.32",
+  "wayland-backend",
+  "wayland-scanner",
+ ]
+@@ -6325,7 +6364,7 @@ version = "0.31.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "wayland-backend",
+  "wayland-client",
+  "wayland-scanner",
+@@ -6337,7 +6376,7 @@ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "wayland-backend",
+  "wayland-client",
+  "wayland-protocols",
+@@ -6362,15 +6401,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
+ dependencies = [
+  "dlib",
+- "log 0.4.20",
++ "log 0.4.21",
+  "pkg-config",
+ ]
+ 
+ [[package]]
+ name = "web-sys"
+-version = "0.3.68"
++version = "0.3.69"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
++checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+ dependencies = [
+  "js-sys",
+  "wasm-bindgen",
+@@ -6420,7 +6459,7 @@ dependencies = [
+  "pango-sys",
+  "pkg-config",
+  "soup2-sys",
+- "system-deps 6.2.0",
++ "system-deps 6.2.2",
+ ]
+ 
+ [[package]]
+@@ -6485,7 +6524,7 @@ dependencies = [
+  "either",
+  "home",
+  "once_cell",
+- "rustix 0.38.31",
++ "rustix 0.38.32",
+ ]
+ 
+ [[package]]
+@@ -6513,15 +6552,6 @@ dependencies = [
+  "winapi",
+ ]
+ 
+-[[package]]
+-name = "winapi-wsapoll"
+-version = "0.1.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
+-dependencies = [
+- "winapi",
+-]
+-
+ [[package]]
+ name = "winapi-x86_64-pc-windows-gnu"
+ version = "0.4.0"
+@@ -6593,7 +6623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+ dependencies = [
+  "windows-core 0.52.0",
+- "windows-targets 0.52.0",
++ "windows-targets 0.52.4",
+ ]
+ 
+ [[package]]
+@@ -6621,7 +6651,7 @@ version = "0.52.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+ dependencies = [
+- "windows-targets 0.52.0",
++ "windows-targets 0.52.4",
+ ]
+ 
+ [[package]]
+@@ -6670,7 +6700,7 @@ version = "0.52.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+ dependencies = [
+- "windows-targets 0.52.0",
++ "windows-targets 0.52.4",
+ ]
+ 
+ [[package]]
+@@ -6690,17 +6720,17 @@ dependencies = [
+ 
+ [[package]]
+ name = "windows-targets"
+-version = "0.52.0"
++version = "0.52.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
++checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+ dependencies = [
+- "windows_aarch64_gnullvm 0.52.0",
+- "windows_aarch64_msvc 0.52.0",
+- "windows_i686_gnu 0.52.0",
+- "windows_i686_msvc 0.52.0",
+- "windows_x86_64_gnu 0.52.0",
+- "windows_x86_64_gnullvm 0.52.0",
+- "windows_x86_64_msvc 0.52.0",
++ "windows_aarch64_gnullvm 0.52.4",
++ "windows_aarch64_msvc 0.52.4",
++ "windows_i686_gnu 0.52.4",
++ "windows_i686_msvc 0.52.4",
++ "windows_x86_64_gnu 0.52.4",
++ "windows_x86_64_gnullvm 0.52.4",
++ "windows_x86_64_msvc 0.52.4",
+ ]
+ 
+ [[package]]
+@@ -6715,7 +6745,7 @@ version = "0.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "75aa004c988e080ad34aff5739c39d0312f4684699d6d71fc8a198d057b8b9b4"
+ dependencies = [
+- "windows-targets 0.52.0",
++ "windows-targets 0.52.4",
+ ]
+ 
+ [[package]]
+@@ -6732,9 +6762,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+ 
+ [[package]]
+ name = "windows_aarch64_gnullvm"
+-version = "0.52.0"
++version = "0.52.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
++checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+ 
+ [[package]]
+ name = "windows_aarch64_msvc"
+@@ -6762,9 +6792,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+ 
+ [[package]]
+ name = "windows_aarch64_msvc"
+-version = "0.52.0"
++version = "0.52.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
++checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+ 
+ [[package]]
+ name = "windows_i686_gnu"
+@@ -6792,9 +6822,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+ 
+ [[package]]
+ name = "windows_i686_gnu"
+-version = "0.52.0"
++version = "0.52.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
++checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+ 
+ [[package]]
+ name = "windows_i686_msvc"
+@@ -6822,9 +6852,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+ 
+ [[package]]
+ name = "windows_i686_msvc"
+-version = "0.52.0"
++version = "0.52.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
++checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+ 
+ [[package]]
+ name = "windows_x86_64_gnu"
+@@ -6852,9 +6882,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+ 
+ [[package]]
+ name = "windows_x86_64_gnu"
+-version = "0.52.0"
++version = "0.52.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
++checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+ 
+ [[package]]
+ name = "windows_x86_64_gnullvm"
+@@ -6870,9 +6900,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+ 
+ [[package]]
+ name = "windows_x86_64_gnullvm"
+-version = "0.52.0"
++version = "0.52.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
++checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+ 
+ [[package]]
+ name = "windows_x86_64_msvc"
+@@ -6900,43 +6930,42 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+ 
+ [[package]]
+ name = "windows_x86_64_msvc"
+-version = "0.52.0"
++version = "0.52.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
++checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+ 
+ [[package]]
+ name = "winnow"
+-version = "0.5.39"
++version = "0.5.40"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
++checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+ dependencies = [
+  "memchr",
+ ]
+ 
+ [[package]]
+-name = "winreg"
+-version = "0.10.1"
++name = "winnow"
++version = "0.6.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
++checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+ dependencies = [
+- "winapi",
++ "memchr",
+ ]
+ 
+ [[package]]
+ name = "winreg"
+-version = "0.50.0"
++version = "0.10.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
++checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+ dependencies = [
+- "cfg-if",
+- "windows-sys 0.48.0",
++ "winapi",
+ ]
+ 
+ [[package]]
+ name = "winreg"
+-version = "0.51.0"
++version = "0.50.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "937f3df7948156640f46aacef17a70db0de5917bda9c92b0f751f3a955b588fc"
++checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+ dependencies = [
+  "cfg-if",
+  "windows-sys 0.48.0",
+@@ -6954,14 +6983,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "wl-clipboard-rs"
+-version = "0.8.0"
++version = "0.8.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "57af79e973eadf08627115c73847392e6b766856ab8e3844a59245354b23d2fa"
++checksum = "12b41773911497b18ca8553c3daaf8ec9fe9819caf93d451d3055f69de028adb"
+ dependencies = [
+  "derive-new",
+  "libc",
+- "log 0.4.20",
+- "nix 0.26.4",
++ "log 0.4.21",
++ "nix 0.28.0",
+  "os_pipe",
+  "tempfile",
+  "thiserror",
+@@ -7001,10 +7030,10 @@ dependencies = [
+  "glib",
+  "gtk",
+  "html5ever",
+- "http 0.2.11",
++ "http 0.2.12",
+  "kuchikiki",
+  "libc",
+- "log 0.4.20",
++ "log 0.4.21",
+  "objc",
+  "objc_id",
+  "once_cell",
+@@ -7045,25 +7074,20 @@ dependencies = [
+ 
+ [[package]]
+ name = "x11rb"
+-version = "0.12.0"
++version = "0.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
++checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
+ dependencies = [
+  "gethostname",
+- "nix 0.26.4",
+- "winapi",
+- "winapi-wsapoll",
++ "rustix 0.38.32",
+  "x11rb-protocol",
+ ]
+ 
+ [[package]]
+ name = "x11rb-protocol"
+-version = "0.12.0"
++version = "0.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc"
+-dependencies = [
+- "nix 0.26.4",
+-]
++checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
+ 
+ [[package]]
+ name = "xattr"
+@@ -7073,7 +7097,7 @@ checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+ dependencies = [
+  "libc",
+  "linux-raw-sys 0.4.13",
+- "rustix 0.38.31",
++ "rustix 0.38.32",
+ ]
+ 
+ [[package]]
+@@ -7106,15 +7130,15 @@ checksum = "9e6936f0cce458098a201c245a11bef556c6a0181129c7034d10d76d1ec3a2b8"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+  "synstructure",
+ ]
+ 
+ [[package]]
+ name = "zbus"
+-version = "3.15.0"
++version = "3.15.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c45d06ae3b0f9ba1fb2671268b975557d8f5a84bb5ec6e43964f87e763d8bca8"
++checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
+ dependencies = [
+  "async-broadcast",
+  "async-executor",
+@@ -7153,11 +7177,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus_macros"
+-version = "3.15.0"
++version = "3.15.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b4a1ba45ed0ad344b85a2bb5a1fe9830aed23d67812ea39a586e7d0136439c7d"
++checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
+ dependencies = [
+- "proc-macro-crate",
++ "proc-macro-crate 1.3.1",
+  "proc-macro2",
+  "quote",
+  "regex 1.10.3",
+@@ -7167,9 +7191,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus_names"
+-version = "2.6.0"
++version = "2.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9"
++checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
+ dependencies = [
+  "serde",
+  "static_assertions",
+@@ -7193,7 +7217,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -7213,7 +7237,7 @@ checksum = "e6a647510471d372f2e6c2e6b7219e44d8c574d24fdc11c610a61455782f18c3"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+  "synstructure",
+ ]
+ 
+@@ -7242,7 +7266,7 @@ checksum = "7b4e5997cbf58990550ef1f0e5124a05e47e1ebd33a84af25739be6031a62c20"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.53",
+ ]
+ 
+ [[package]]
+@@ -7258,9 +7282,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zvariant"
+-version = "3.15.0"
++version = "3.15.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c"
++checksum = "4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db"
+ dependencies = [
+  "byteorder",
+  "enumflags2",
+@@ -7272,11 +7296,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "zvariant_derive"
+-version = "3.15.0"
++version = "3.15.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd"
++checksum = "37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9"
+ dependencies = [
+- "proc-macro-crate",
++ "proc-macro-crate 1.3.1",
+  "proc-macro2",
+  "quote",
+  "syn 1.0.109",
+-- 
+2.44.0
+

--- a/app-network/clash-verge-rev/autobuild/patches/0003-feat-src-assets-add-XDG-.desktop-entry.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0003-feat-src-assets-add-XDG-.desktop-entry.patch
@@ -1,0 +1,33 @@
+From 38819bf3390f6d46a91253335d3834f3801949bb Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 22 Mar 2024 16:28:51 +0800
+Subject: [PATCH 3/9] feat(src/assets): add XDG .desktop entry
+
+---
+ src/assets/xdg/io.github.clash-verge-rev.desktop | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+ create mode 100755 src/assets/xdg/io.github.clash-verge-rev.desktop
+
+diff --git a/src/assets/xdg/io.github.clash-verge-rev.desktop b/src/assets/xdg/io.github.clash-verge-rev.desktop
+new file mode 100755
+index 0000000..1dc4106
+--- /dev/null
++++ b/src/assets/xdg/io.github.clash-verge-rev.desktop
+@@ -0,0 +1,14 @@
++[Desktop Entry]
++Type=Application
++Exec=clash-verge
++Icon=clash-verge
++Categories=Network;
++StartupNotify=true
++StartupWMClass=clash-verge
++Keywords=clash;verge;proxy
++Keywords[zh_CN]=clash;verge;proxy;小猫咪;代理;xiaomaomi;daili
++Name=Clash Verge
++GenericName=Rule-based proxy manager
++GenericName[zh_CN]=代理服务规则管理器
++Comment=A graphical rule-based proxy manager
++Comment[zh_CN]=图形化代理服务规则管理器
+-- 
+2.44.0
+

--- a/app-network/clash-verge-rev/autobuild/patches/0004-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0004-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,0 +1,26 @@
+From 3b9f3a6fc289970117bdae00b8e93da00fca9237 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 22 Mar 2024 16:32:18 +0800
+Subject: [PATCH 4/9] fix(tauri.conf.json): disable bundle distribution
+
+We only need the binary in /src-tauri/target.
+---
+ src-tauri/tauri.conf.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
+index 73cab21..8fa2757 100644
+--- a/src-tauri/tauri.conf.json
++++ b/src-tauri/tauri.conf.json
+@@ -11,7 +11,7 @@
+   },
+   "tauri": {
+     "bundle": {
+-      "active": true,
++      "active": false,
+       "identifier": "io.github.clash-verge-rev.clash-verge-rev",
+       "icon": [
+         "icons/32x32.png",
+-- 
+2.44.0
+

--- a/app-network/clash-verge-rev/autobuild/patches/0005-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0005-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
@@ -1,0 +1,28 @@
+From 3411cb57a5598b17fbbdc3a14ec1f2a29bc15914 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 22 Mar 2024 17:26:12 +0800
+Subject: [PATCH 5/9] fix(scripts): use ABI2 (New-World) Mihomo binary for
+ loongarch64
+
+Currently, only the alpha Mihomo binary distinguishes between abi1 (old-world)
+and abi2 (new-world) binaries.
+---
+ scripts/check.mjs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/check.mjs b/scripts/check.mjs
+index 5c5a294..c507ec4 100644
+--- a/scripts/check.mjs
++++ b/scripts/check.mjs
+@@ -68,7 +68,7 @@ const META_ALPHA_MAP = {
+   "linux-arm64": "mihomo-linux-arm64",
+   "linux-arm": "mihomo-linux-armv7",
+   "linux-riscv64": "mihomo-linux-riscv64",
+-  "linux-loong64": "mihomo-linux-loong64",
++  "linux-loong64": "mihomo-linux-loong64-abi2",
+ };
+ 
+ // Fetch the latest alpha release version from the version.txt file
+-- 
+2.44.0
+

--- a/app-network/clash-verge-rev/autobuild/patches/0006-feat-drop-clash-meta-alpha-support.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0006-feat-drop-clash-meta-alpha-support.patch
@@ -1,0 +1,28 @@
+From 48a2d4682e730dbb2a127d29a81c320fb9c36041 Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Fri, 22 Mar 2024 22:45:34 +0800
+Subject: [PATCH 6/9] feat: drop clash-meta-alpha support
+
+---
+ src/components/setting/mods/clash-core-viewer.tsx | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
+index 3455508..c7ed0de 100644
+--- a/src/components/setting/mods/clash-core-viewer.tsx
++++ b/src/components/setting/mods/clash-core-viewer.tsx
+@@ -19,10 +19,7 @@ import { closeAllConnections, upgradeCore } from "@/services/api";
+ import { grantPermission } from "@/services/cmds";
+ import getSystem from "@/utils/get-system";
+ 
+-const VALID_CORE = [
+-  { name: "Clash Meta", core: "clash-meta" },
+-  { name: "Clash Meta Alpha", core: "clash-meta-alpha" },
+-];
++const VALID_CORE = [{ name: "Clash Meta", core: "clash-meta" }];
+ 
+ const OS = getSystem();
+ 
+-- 
+2.44.0
+

--- a/app-network/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
@@ -1,0 +1,36 @@
+From 08d0263b5ffd02f107358bda9d02823711d7990f Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 23 Mar 2024 11:45:21 +0800
+Subject: [PATCH 7/9] fix(check.mjs): do not fetch Mihomo (Clash Meta) binaries
+
+We use a system copy for this purpose.
+---
+ scripts/check.mjs | 12 ------------
+ 1 file changed, 12 deletions(-)
+
+diff --git a/scripts/check.mjs b/scripts/check.mjs
+index c507ec4..2bd52eb 100644
+--- a/scripts/check.mjs
++++ b/scripts/check.mjs
+@@ -407,18 +407,6 @@ const resolveEnableLoopback = () =>
+ 
+ const tasks = [
+   // { name: "clash", func: resolveClash, retry: 5 },
+-  {
+-    name: "clash-meta-alpha",
+-    func: () =>
+-      getLatestAlphaVersion().then(() => resolveSidecar(clashMetaAlpha())),
+-    retry: 5,
+-  },
+-  {
+-    name: "clash-meta",
+-    func: () =>
+-      getLatestReleaseVersion().then(() => resolveSidecar(clashMeta())),
+-    retry: 5,
+-  },
+   { name: "plugin", func: resolvePlugin, retry: 5, winOnly: true },
+   { name: "service", func: resolveService, retry: 5, winOnly: true },
+   { name: "install", func: resolveInstall, retry: 5, winOnly: true },
+-- 
+2.44.0
+

--- a/app-network/clash-verge-rev/autobuild/patches/0008-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0008-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
@@ -1,0 +1,25 @@
+From 64f8aee146e79b49d9ea3771d813f213ef616d87 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 23 Mar 2024 12:04:58 +0800
+Subject: [PATCH 8/9] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
+ Meta) bundling
+
+---
+ src-tauri/tauri.conf.json | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
+index 8fa2757..2a6f4a3 100644
+--- a/src-tauri/tauri.conf.json
++++ b/src-tauri/tauri.conf.json
+@@ -21,7 +21,6 @@
+         "icons/icon.ico"
+       ],
+       "resources": ["resources"],
+-      "externalBin": ["sidecar/clash-meta", "sidecar/clash-meta-alpha"],
+       "copyright": "© 2022 zzzgydi All Rights Reserved",
+       "category": "DeveloperTool",
+       "shortDescription": "A Clash Meta GUI based on tauri.",
+-- 
+2.44.0
+

--- a/app-network/clash-verge-rev/autobuild/patches/0009-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0009-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
@@ -1,0 +1,40 @@
+From 598e36ca170da96a9fb7c7bfdf77cdea6646d969 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 23 Mar 2024 13:07:37 +0800
+Subject: [PATCH 9/9] fix(check.mjs): do not check Mihomo (Clash Meta) platform
+ support
+
+This is pointless, as we supply our own.
+---
+ scripts/check.mjs | 15 ---------------
+ 1 file changed, 15 deletions(-)
+
+diff --git a/scripts/check.mjs b/scripts/check.mjs
+index 2bd52eb..9fd494c 100644
+--- a/scripts/check.mjs
++++ b/scripts/check.mjs
+@@ -145,21 +145,6 @@ async function getLatestReleaseVersion() {
+   }
+ }
+ 
+-/*
+- * check available
+- */
+-if (!META_MAP[`${platform}-${arch}`]) {
+-  throw new Error(
+-    `clash meta alpha unsupported platform "${platform}-${arch}"`
+-  );
+-}
+-
+-if (!META_ALPHA_MAP[`${platform}-${arch}`]) {
+-  throw new Error(
+-    `clash meta alpha unsupported platform "${platform}-${arch}"`
+-  );
+-}
+-
+ /**
+  * core info
+  */
+-- 
+2.44.0
+

--- a/app-network/clash-verge-rev/autobuild/prepare
+++ b/app-network/clash-verge-rev/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Installing tauri-cli ..."
+cargo install tauri-cli

--- a/app-network/clash-verge-rev/spec
+++ b/app-network/clash-verge-rev/spec
@@ -1,0 +1,4 @@
+VER=1.5.10
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371843"

--- a/app-network/mihomo/autobuild/build
+++ b/app-network/mihomo/autobuild/build
@@ -1,0 +1,19 @@
+# FIXME: Go PIE not supported on loongarch64 and loongson3.
+if ! ab_match_arch loongarch64 && \
+   ! ab_match_arch loongson3; then
+    abinfo "Enabling buildmode=pie ..."
+    export GOFLAGS="${GOFLAGS} -buildmode=pie"
+fi
+
+abinfo "Building clash..."
+go build \
+    -trimpath \
+    -ldflags \
+    "-X github.com/metacubex/mihomo/constant.Version=$PKGVER" \
+    -mod=readonly
+
+abinfo "Installing the binary..."
+install -Dvm755 "$SRCDIR"/mihomo \
+    "$PKGDIR"/usr/bin/mihomo
+ln -sv mihomo \
+    "$PKGDIR"/usr/bin/clash-meta

--- a/app-network/mihomo/autobuild/defines
+++ b/app-network/mihomo/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=mihomo
+PKGSEC=net
+PKGDEP="glibc"
+BUILDDEP="go"
+PKGDES="A rule-based tunnel for VMess, Shadowsocks, Trojan, Snell protocols (Clash Meta)"
+
+ABSPLITDBG=0
+
+PKGPROV="clash-meta"
+
+# FIXME: Golang is not available on MIPS R6.
+FAIL_ARCH="(mips64r6el)"

--- a/app-network/mihomo/autobuild/overrides/usr/lib/systemd/system/clash-meta@.service
+++ b/app-network/mihomo/autobuild/overrides/usr/lib/systemd/system/clash-meta@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Starting Mihomo (Clash Meta) for %i
+After=network.target
+
+[Service]
+Type=exec
+User=%i
+Restart=on-abort
+ExecStart=/usr/bin/mihomo
+
+[Install]
+WantedBy=multi-user.target

--- a/app-network/mihomo/autobuild/overrides/usr/lib/systemd/user/clash-meta.service
+++ b/app-network/mihomo/autobuild/overrides/usr/lib/systemd/user/clash-meta.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Starting Mihomo (Clash Meta)
+After=network.target
+
+[Service]
+Type=exec
+Restart=on-abort
+ExecStart=/usr/bin/mihomo
+
+[Install]
+WantedBy=default.target

--- a/app-network/mihomo/spec
+++ b/app-network/mihomo/spec
@@ -1,0 +1,4 @@
+VER=1.18.1
+SRCS="git::commit=tags/v$VER::https://github.com/MetaCubeX/mihomo"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371845"

--- a/lang-js/pnpm/autobuild/defines
+++ b/lang-js/pnpm/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=pnpm
+PKGSEC=devel
+PKGDEP="nodejs"
+PKGDES="A multi-function package manager for Node.js projects"
+
+ABTYPE=npm
+ABHOST=noarch
+
+# FIXME: No lock file in upstream source.
+NONPMAUDIT=1
+
+# FIXME: Node.js is not available on MIPS R6.
+FAIL_ARCH="(mips64r6el)"

--- a/lang-js/pnpm/spec
+++ b/lang-js/pnpm/spec
@@ -1,0 +1,4 @@
+VER=8.15.5
+SRCS="tbl::https://registry.npmjs.org/pnpm/-/pnpm-$VER.tgz"
+CHKSUMS="sha256::4b4efa12490e5055d59b9b9fc9438b7d581a6b7af3b5675eb5c5f447cee1a589"
+CHKUPDATE="anitya::id=371842"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: new, 1.15.10
    - Fix build on platforms without native rollup binaries (i.e., loongarch64).
    - Update Cargo dependencies to fix build on loongarch64.
    - Add a .desktop entry. [^1]
    - Disable unneeded bundle distribution routines.
    - Fix-up Mihomo (Clash Meta) target information (loong64-abi2, new-world).
    - Drop clash-meta-alpha support as we do not package it (moving tag snapshot).
    - Track patches at AOSC-Tracking/clash-verge-rev.
    - Disable LTO on all architectures due to Ring 0.17 issues.
    - Mark FAIL_ARCH.
    [^1]: https://github.com/clash-verge-rev/clash-verge-rev/pull/735
    [^2]: https://github.com/AOSC-Tracking/clash-verge-rev @ aosc/v1.15.10
    Co-authored-by: eatradish <sakiiily@aosc.io>
- mihomo: new, 1.18.1
- pnpm: new, 8.15.5

Package(s) Affected
-------------------

- pnpm: 8.15.5
- clash-verge-rev: 1.5.10
- mihomo: 1.18.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pnpm mihomo clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
