### PR TITLE
imv: new, 4.5.0

### DIFF
--- a/app-imaging/imv/autobuild/defines
+++ b/app-imaging/imv/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=imv
+PKGSEC=x11
+PKGDEP="wayland xorg-server glu libxcb libxkbcommon pango inih \
+    cairo egl-wayland eglexternalplatform librsvg libheif libtiff \
+    libjxl libpng libjpeg-turbo libnsgif glibc"
+BUILDDEP="meson ninja"
+PKGDES="A command-line image viewer"

--- a/app-imaging/imv/spec
+++ b/app-imaging/imv/spec
@@ -1,0 +1,4 @@
+VER=4.5.0
+SRCS="git::commit=tags/v${VER}::https://git.sr.ht/~exec64/imv"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=93177"

--- a/runtime-web/libnsgif/autobuild/build
+++ b/runtime-web/libnsgif/autobuild/build
@@ -1,0 +1,13 @@
+abinfo "Building libnsgif ..."
+make PREFIX=/usr \
+    LIBDIR=lib \
+    INCLUDEDIR=include \
+    COMPONENT_TYPE=lib-shared
+
+abinfo "Installing libnsgif ..."
+make PREFIX=/usr \
+    LIBDIR=lib \
+    INCLUDEDIR=include \
+    DESTDIR="$PKGDIR" \
+    COMPONENT_TYPE=lib-shared \
+    install

--- a/runtime-web/libnsgif/autobuild/defines
+++ b/runtime-web/libnsgif/autobuild/defines
@@ -3,7 +3,3 @@ PKGSEC=libs
 PKGDEP="glibc"
 BUILDDEP="netsurf-buildsystem"
 PKGDES="A C library for GIF image file format"
-
-MAKE_AFTER="PREFIX=/usr \
-            LIBDIR=lib \
-            COMPONENT_TYPE=lib-shared"

--- a/runtime-web/libnsgif/spec
+++ b/runtime-web/libnsgif/spec
@@ -1,5 +1,5 @@
 VER=0.2.1
-REL=3
+REL=4
 SRCS="tbl::https://download.netsurf-browser.org/libs/releases/libnsgif-$VER-src.tar.gz"
 CHKSUMS="sha256::9eaea534cd70b53c5aaf45317ae957701685a6b4a88dbe34ed26f4faae879a4b"
 CHKUPDATE="anitya::id=7303"


### PR DESCRIPTION
Topic Description
-----------------

- imv: new, 4.5.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- imv: 4.5.0
- libnsgif: 0.2.1-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit libnsgif imv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
