### PR TITLE
imv: build manpage

### DIFF
--- a/app-imaging/imv/autobuild/defines
+++ b/app-imaging/imv/autobuild/defines
@@ -3,5 +3,7 @@ PKGSEC=x11
 PKGDEP="wayland xorg-server glu libxcb libxkbcommon pango inih \
     cairo egl-wayland eglexternalplatform librsvg libheif libtiff \
     libjxl libpng libjpeg-turbo libnsgif glibc"
-BUILDDEP="meson ninja"
+BUILDDEP="meson ninja asciidoc"
 PKGDES="A command-line image viewer"
+
+MESON_AFTER="-Dman=enabled"

--- a/app-imaging/imv/spec
+++ b/app-imaging/imv/spec
@@ -1,4 +1,5 @@
 VER=4.5.0
+REL=1
 SRCS="git::commit=tags/v${VER}::https://git.sr.ht/~exec64/imv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=93177"


### PR DESCRIPTION
Topic Description
-----------------

- imv: build manpage
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- imv: 4.5.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit imv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
