### PR TITLE
gn: update to 0+git20240313

### DIFF
--- a/app-devel/gn/autobuild/prepare
+++ b/app-devel/gn/autobuild/prepare
@@ -1,1 +1,0 @@
-acbs_copy_git

--- a/app-devel/gn/spec
+++ b/app-devel/gn/spec
@@ -1,4 +1,3 @@
-VER=0+git20220310
-SRCS="git::commit=f27bae882b2178ccc3c24f314c88db9a34118992::https://gn.googlesource.com/gn"
+VER=0+git20240313
+SRCS="git::commit=22581fb46c0c0c9530caa67149ee4dd8811063cf;copy-repo=true::https://gn.googlesource.com/gn"
 CHKSUMS="SKIP"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- gn: update to 0+git20240313

Package(s) Affected
-------------------

- gn: 1:0+git20240313

Security Update?
----------------

No

Build Order
-----------

```
#buildit gn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
