### PR TITLE
telegram-desktop (Telegram Desktop): update to 4.15.2

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -7,3 +7,4 @@ CHKSUMS="sha256::5340a06b613bdbceccd716b36d864f25da2b7a5b0966c91de36e88743887816
          SKIP"
 SUBDIR="tdesktop-$VER-full"
 CHKUPDATE="anitya::id=16951"
+ENVREQ__ARM64="total_mem_per_core=4"

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,10 +1,9 @@
-VER=4.12.2
-REL=1
+VER=4.15.2
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
-OWTVER=76a3513d7f25d6623d92463fbe6470d9001b66a8
+OWTVER=afd9d5d31798d3eacf9ed6c30601e91d0f1e4d60
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::7e9e51ae9c40d5b8c964bcfe0e252e35980c6668327934d2270144405c519914 \
+CHKSUMS="sha256::5340a06b613bdbceccd716b36d864f25da2b7a5b0966c91de36e88743887816d \
          SKIP"
 SUBDIR="tdesktop-$VER-full"
 CHKUPDATE="anitya::id=16951"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 4.15.2

Package(s) Affected
-------------------

- telegram-desktop: 4.15.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
