### PR TITLE
hmcl: update to 3.5.7

### DIFF
--- a/app-games/hmcl/autobuild/build
+++ b/app-games/hmcl/autobuild/build
@@ -11,5 +11,5 @@ ls "$SRCDIR"/HMCL/build/libs/ | grep ".jar$"
 cp -Lv "$SRCDIR"/HMCL/build/libs/HMCL*.jar "$PKGDIR"/usr/share/java/hmcl/hmcl.jar
 
 abinfo "Extracting desktop icon..."
-install -Dvm644 "$SRCDIR"/HCML/image/hmcl.png \
+install -Dvm644 "$SRCDIR"/HMCL/image/hmcl.png \
     "$PKGDIR"/usr/share/pixmaps/hmcl.png

--- a/app-games/hmcl/autobuild/build
+++ b/app-games/hmcl/autobuild/build
@@ -3,13 +3,13 @@ export VERSION_TYPE=stable
 export BUILD_NUMBER=$(echo $PKGVER | cut -d '.' -f 3)
 export MICROSOFT_AUTH_ID=81a207c0-a53c-46a3-be07-57d2b28c1643
 export CURSEFORGE_API_KEY="$2a$10$gWtfk4i6mQvxSLhtMdvBfuM1E46vEbmYV4w4sHSJBX6c3hO6WCDWG"
-./gradlew build
+"$SRCDIR"/gradlew build
 
 abinfo "Installing hmcl.jar..."
-mkdir -pv "${PKGDIR}/usr/share/java/hmcl"
-ls "${SRCDIR}"/HMCL/build/libs/ | grep ".jar$"
-cp -Lv "${SRCDIR}"/HMCL/build/libs/HMCL*.jar "${PKGDIR}/usr/share/java/hmcl/hmcl.jar"
+mkdir -pv "$PKGDIR/usr/share/java/hmcl"
+ls "$SRCDIR"/HMCL/build/libs/ | grep ".jar$"
+cp -Lv "$SRCDIR"/HMCL/build/libs/HMCL*.jar "$PKGDIR"/usr/share/java/hmcl/hmcl.jar
 
 abinfo "Extracting desktop icon..."
-mkdir -pv "${PKGDIR}"/usr/share/pixmaps
-cp "${SRCDIR}"/HMCL/image/hmcl.png "${PKGDIR}"/usr/share/pixmaps/hmcl.png
+install -Dvm644 "$SRCDIR"/HCML/image/hmcl.png \
+    "$PKGDIR"/usr/share/pixmaps/hmcl.png

--- a/app-games/hmcl/autobuild/build
+++ b/app-games/hmcl/autobuild/build
@@ -1,9 +1,15 @@
+abinfo "Building hmcl.jar..."
+export VERSION_TYPE=stable
+export BUILD_NUMBER=$(echo $PKGVER | cut -d '.' -f 3)
+export MICROSOFT_AUTH_ID=81a207c0-a53c-46a3-be07-57d2b28c1643
+export CURSEFORGE_API_KEY="$2a$10$gWtfk4i6mQvxSLhtMdvBfuM1E46vEbmYV4w4sHSJBX6c3hO6WCDWG"
+./gradlew build
+
 abinfo "Installing hmcl.jar..."
 mkdir -pv "${PKGDIR}/usr/share/java/hmcl"
-cp -Lv "${SRCDIR}"/*.jar "${PKGDIR}/usr/share/java/hmcl/hmcl.jar"
+ls "${SRCDIR}"/HMCL/build/libs/ | grep ".jar$"
+cp -Lv "${SRCDIR}"/HMCL/build/libs/HMCL*.jar "${PKGDIR}/usr/share/java/hmcl/hmcl.jar"
 
-abinfo "Extracting desktop icon from jar..."
+abinfo "Extracting desktop icon..."
 mkdir -pv "${PKGDIR}"/usr/share/pixmaps
-unzip -p "${PKGDIR}/usr/share/java/hmcl/hmcl.jar" \
-      assets/img/icon\@8x.png \
-      > "${PKGDIR}"/usr/share/pixmaps/hmcl.png
+cp "${SRCDIR}"/HMCL/image/hmcl.png "${PKGDIR}"/usr/share/pixmaps/hmcl.png

--- a/app-games/hmcl/autobuild/defines
+++ b/app-games/hmcl/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=hmcl
 PKGSEC=games
-PKGDEP="openjdk openjfx"
-PKGSUG="openjdk-11 openjdk-8"
+PKGDEP="openjdk openjfx noto-cjk-fonts"
+BUILDDEP="openjdk openjfx"
 PKGDES="A free, open source launcher for Minecraft"
 
 ABHOST=noarch

--- a/app-games/hmcl/autobuild/overrides/usr/bin/hmcl
+++ b/app-games/hmcl/autobuild/overrides/usr/bin/hmcl
@@ -1,5 +1,8 @@
 #!/bin/sh
-java --add-modules javafx.controls,javafx.graphics,javafx.swing,javafx.fxml,javafx.media,javafx.web \
+cd $HOME
+java \
     --module-path=/usr/share/openjfx/lib \
+    --add-modules javafx.controls,javafx.graphics,javafx.swing,javafx.fxml,javafx.media,javafx.web \
+    -Dhmcl.font.override="Noto Sans CJK SC" \
     "$@" \
     -jar /usr/share/java/hmcl/hmcl.jar

--- a/app-games/hmcl/spec
+++ b/app-games/hmcl/spec
@@ -1,5 +1,4 @@
-VER=3.5.5.236
-REL=1
-SRCS="file::https://github.com/HMCL-dev/HMCL/releases/download/v$VER/HMCL-$VER.jar"
-CHKSUMS="sha1::d7828f3c331a76b61a9b2b38e6899911ae50b40d"
+VER=3.5.7
+SRCS="git::commit=tags/release-$VER::https://github.com/HMCL-dev/HMCL"
+CHKSUMS=SKIP
 CHKUPDATE="github::repo=HMCL-dev/HMCL"


### PR DESCRIPTION
Topic Description
-----------------

- hmcl: update to 3.5.7
    Other changes:
    - Use release version instead of develop version
    - Add `Noto Sans CJK SC` as default font
    - Run at $HOME instead of current directory

Package(s) Affected
-------------------

- hmcl: 3.5.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit hmcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
