### PR TITLE
Telegram Desktop: enable Wayland support

### DIFF
--- a/app-web/telegram-desktop/autobuild/defines
+++ b/app-web/telegram-desktop/autobuild/defines
@@ -5,7 +5,7 @@ PKGDEP="ffmpeg hicolor-icon-theme libnotify minizip abseil-cpp \
         libjpeg-turbo opus pulseaudio rnnoise pipewire kcoreaddons \
         glibmm-2.68 fmt"
 BUILDDEP="cmake range-v3 python-3 tl-expected microsoft-gsl yasm \
-          extra-cmake-modules"
+          extra-cmake-modules wayland-protocols plasma-wayland-protocols"
 PKGSUG="webkit2gtk"
 PKGRECOM="kimageformats"
 PKGDES="The official Telegram desktop application"
@@ -17,6 +17,8 @@ CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX='/usr' \
              -DDESKTOP_APP_SPECIAL_TARGET= \
              -DTDESKTOP_LAUNCHER_BASENAME=telegramdesktop \
              -DDESKTOP_APP_DISABLE_WEBRTC_INTEGRATION=OFF \
+             -DDESKTOP_APP_DISABLE_WAYLAND_INTEGRATION=OFF \
+             -DDESKTOP_APP_DISABLE_X11_INTEGRATION=OFF \
              -DDESKTOP_APP_USE_PACKAGED=OFF \
              -DDESKTOP_APP_USE_PACKAGED_FONTS=OFF \
              -DQT_VERSION_MAJOR=5"

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,4 +1,5 @@
 VER=4.15.2
+REL=1
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=afd9d5d31798d3eacf9ed6c30601e91d0f1e4d60
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -8,4 +8,4 @@ CHKSUMS="sha256::5340a06b613bdbceccd716b36d864f25da2b7a5b0966c91de36e88743887816
          SKIP"
 SUBDIR="tdesktop-$VER-full"
 CHKUPDATE="anitya::id=16951"
-ENVREQ__ARM64="total_mem_per_core=4"
+ENVREQ__ARM64="total_mem_per_core=3"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: add wayland support
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
