### PR TITLE
thefuck: update to 3.32

### DIFF
--- a/app-utils/thefuck/spec
+++ b/app-utils/thefuck/spec
@@ -1,5 +1,4 @@
-VER=3.29
-SRCS="tbl::https://github.com/nvbn/thefuck/archive/$VER.tar.gz"
-CHKSUMS="sha256::34a9ec020ff991a96a895dfbe2313b69464bbcc6975b1ad8158b32a2de5803a9"
-REL=3
+VER=3.32
+SRCS="git::commit=tags/$VER::https://github.com/nvbn/thefuck"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=87015"


### PR DESCRIPTION
Topic Description
-----------------

- thefuck: update to 3.32

Package(s) Affected
-------------------

- thefuck: 3.32

Security Update?
----------------

No

Build Order
-----------

```
#buildit thefuck
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
