### PR TITLE
units: update to 2.23

### DIFF
--- a/app-utils/units/autobuild/defines
+++ b/app-utils/units/autobuild/defines
@@ -4,3 +4,6 @@ PKGDEP="glibc"
 PKGDES="Converts between different systems of units"
 
 ABSHADOW=0
+
+#FIXME: unexpected path in package
+AUTOTOOLS_AFTER="--sharedstatedir=/usr/share/com"

--- a/app-utils/units/spec
+++ b/app-utils/units/spec
@@ -1,4 +1,4 @@
-VER=2.19
+VER=2.23
 SRCS="tbl::https://ftp.gnu.org/gnu/units/units-$VER.tar.gz"
-CHKSUMS="sha256::4262136bdfc152b63ff5a9b93a7d80ce18b5e8bebdcffddc932dda769e306556"
+CHKSUMS="sha256::d957b451245925c9e614c4513397449630eaf92bd62b8495ba09bbe351a17370"
 CHKUPDATE="anitya::id=5048"


### PR DESCRIPTION
Topic Description
-----------------

- units: move /usr/com => /usr/share/com
- units: update to 2.23

Package(s) Affected
-------------------

- units: 2.23

Security Update?
----------------

No

Build Order
-----------

```
#buildit units
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
