### PR TITLE
mpvpaper: new, 1.4

### DIFF
--- a/app-multimedia/mpv/autobuild/defines
+++ b/app-multimedia/mpv/autobuild/defines
@@ -4,6 +4,9 @@ PKGDEP="ffmpeg lcms2 mesa enca wayland desktop-file-utils hicolor-icon-theme \
         xdg-utils lua libdvdnav jack openjpeg-legacy libvdpau libcdio-paranoia \
         libguess samba libva libcaca uchardet rubberband youtube-dl libcdio \
         libdvbpsi openal-soft sdl2 vulkan libarchive pipewire shaderc libplacebo"
+# NVIDIA driver is only available on amd64 and arm64
+PKGDEP__AMD64="${PKGDEP} ffnvcodec"
+PKGDEP__ARM64="${PKGDEP} ffnvcodec"
 PKGDEP__LOONGSON3="${PKGDEP//shaderc/}"
 PKGDEP__RETRO="ffmpeg lcms2 mesa enca desktop-file-utils hicolor-icon-theme \
         xdg-utils lua libdvdnav openjpeg-legacy libvdpau libcdio-paranoia \
@@ -17,7 +20,6 @@ PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 BUILDDEP="docutils ladspa-sdk"
-BUILDDEP__AMD64="${BUILDDEP} ffnvcodec"
 BUILDDEP__RETRO=""
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"

--- a/app-multimedia/mpv/spec
+++ b/app-multimedia/mpv/spec
@@ -1,4 +1,5 @@
 VER=0.37.0
+REL=1
 SRCS="tbl::https://github.com/mpv-player/mpv/archive/v$VER.tar.gz"
 CHKSUMS="sha256::1d2d4adbaf048a2fa6ee134575032c4b2dad9a7efafd5b3e69b88db935afaddf"
 CHKUPDATE="anitya::id=5348"

--- a/app-utils/mpvpaper/autobuild/beyond
+++ b/app-utils/mpvpaper/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Installing manpage for mpvpaper ..."
+install -Dvm644 "$SRCDIR"/mpvpaper.man "$PKGDIR"/usr/share/man/man1/mpvpaper.1

--- a/app-utils/mpvpaper/autobuild/defines
+++ b/app-utils/mpvpaper/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=mpvpaper
+PKGSEC=x11
+PKGDEP="mpv wlroots wayland egl-wayland glibc"
+BUILDDEP="meson ninja wayland-protocols"
+PKGDES="A video wallpaper program for wlroots based wayland compositors"

--- a/app-utils/mpvpaper/autobuild/defines
+++ b/app-utils/mpvpaper/autobuild/defines
@@ -2,4 +2,4 @@ PKGNAME=mpvpaper
 PKGSEC=x11
 PKGDEP="mpv wlroots wayland egl-wayland glibc"
 BUILDDEP="meson ninja wayland-protocols"
-PKGDES="A video wallpaper program for wlroots based wayland compositors"
+PKGDES="A video wallpaper program for wlroots-based wayland compositors"

--- a/app-utils/mpvpaper/spec
+++ b/app-utils/mpvpaper/spec
@@ -1,0 +1,4 @@
+VER=1.4
+SRCS="git::commit=tags/${VER}::https://github.com/GhostNaN/mpvpaper"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=235058"


### PR DESCRIPTION
Topic Description
-----------------

- mpvpaper: new, 1.4
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- mpv: (amd64,arm64) move ffnvcodec to BUILDDEP
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- mpv: 0.37.0-1
- mpvpaper: 1.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpv mpvpaper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
