### PR TITLE
discord: update to 0.0.47

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.46
+VER=0.0.47
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::b861c3660e2fbbbad425c7ba49255bb8b4413c41d780de28a1c01063e0ea75ac"
+CHKSUMS="sha256::e1c10bb3b2bb0c07f36c0d3f0700242ab6930fbcf9f23cce7f52773aeaf70b03"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- discord: update to 0.0.47

Package(s) Affected
-------------------

- discord: 0.0.47

Security Update?
----------------

No

Build Order
-----------

```
#buildit discord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
