### PR TITLE
MPD: fix dependency

### DIFF
--- a/app-multimedia/mpd/autobuild/defines
+++ b/app-multimedia/mpd/autobuild/defines
@@ -1,12 +1,13 @@
 PKGNAME=mpd
 PKGSEC=sound
 PKGDEP="libao ffmpeg libmodplug audiofile libshout libmad curl \
-        faad2 sqlite jack libmms wavpack avahi libid3tag yajl \
-        libmpdclient icu libupnp libnfs pulseaudio samba sndio \
+        faad2 sqlite libmms wavpack avahi libid3tag yajl \
+        libmpdclient icu libupnp libnfs samba sndio \
         chromaprint libcdio-paranoia zziplib openal-soft libcdio \
         fluidsynth game-music-emu libmpcdec libmikmod mpg123 \
-        libsidplay libsidplayfp twolame wildmidi pipewire"
-BUILDDEP="boost doxygen"
+        libsidplay libsidplayfp twolame wildmidi"
+BUILDDEP="boost doxygen alsa-lib jack pipewire pulseaudio fmt"
+PKGSUG="jack pipewire pulseaudio"
 PKGDES="Flexible, powerful server-side application for playing music"
 
 ABTYPE=meson

--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,4 +1,5 @@
 VER=0.23.15
+REL=1
 SRCS="tbl::http://www.musicpd.org/download/mpd/${VER%.*}/mpd-${VER}.tar.xz"
 CHKSUMS="sha256::550132239ad1acf82ccf8905b56cc13dc2c81a4489b96fba7731b3049907661a"
 CHKUPDATE="anitya::id=14864"


### PR DESCRIPTION
Topic Description
-----------------

- mpd: fix dependency
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- mpd: 0.23.15-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
