### PR TITLE
nss: update to 3.99

### DIFF
--- a/runtime-cryptography/nss/autobuild/build
+++ b/runtime-cryptography/nss/autobuild/build
@@ -9,11 +9,11 @@
     export NSPR_LIB_DIR="`nspr-config --libdir`"
 
     [[ "${CROSS:-$ARCH}" = *64* ]] && export USE_64=1
-    [[ "${CROSS:-$ARCH}" = "loongson2f" ]] && export USE_64=1
-    [[ "${CROSS:-$ARCH}" = "loongson3" ]] && export USE_64=1
-    [[ "${CROSS:-$ARCH}" = "arm64" ]] && export NS_USE_GCC=1
-    [[ "${CROSS:-$ARCH}" = "mips64r6el" ]] && export NSS_DISABLE_GTESTS=1
-    [[ "${CROSS:-$ARCH}" = "powerpc" ]] && \
+    ab_match_arch loongson2f && export USE_64=1
+    ab_match_arch loongson3 && export USE_64=1
+    ab_match_arch arm64 && export NS_USE_GCC=1
+    ab_match_arch mips64r6el && export NSS_DISABLE_GTESTS=1
+    ab_match_arch powerpc && \
         export NSS_DISABLE_ALTIVEC=1 \
                NSS_DISABLE_CRYPTO_VSX=1
 

--- a/runtime-cryptography/nss/spec
+++ b/runtime-cryptography/nss/spec
@@ -1,5 +1,4 @@
-VER=3.98
-REL=1
+VER=3.99
 SRCS="https://download-origin.cdn.mozilla.net/pub/security/nss/releases/NSS_${VER//./_}_RTM/src/nss-$VER.tar.gz"
-CHKSUMS="sha256::f549cc33d35c0601674bfacf7c6ad683c187595eb4125b423238d3e9aa4209ce"
+CHKSUMS="sha256::5cd5c2c8406a376686e6fa4b9c2de38aa280bea07bf927c0d521ba07c88b09bd"
 CHKUPDATE="anitya::id=2503"


### PR DESCRIPTION
Topic Description
-----------------

- nss: update to 3.99

Package(s) Affected
-------------------

- nss: 3.99

Security Update?
----------------

No

Build Order
-----------

```
#buildit nss
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
