### PR TITLE
cups: update to 2.4.7

### DIFF
--- a/app-admin/cups/spec
+++ b/app-admin/cups/spec
@@ -1,5 +1,4 @@
-VER=2.4.2
-REL=2
-SRCS="tbl::https://github.com/OpenPrinting/cups/releases/download/v$VER/cups-${VER}-source.tar.gz"
-CHKSUMS="sha256::f03ccb40b087d1e30940a40e0141dcbba263f39974c20eb9f2521066c9c6c908"
+VER=2.4.7
+SRCS="git::commit=tags/v$VER::https://github.com/OpenPrinting/cups"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=380"


### PR DESCRIPTION
Topic Description
-----------------

- cups: update to 2.4.7

Package(s) Affected
-------------------

- cups: 2.4.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit cups
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
