### PR TITLE
expat: update to 2.6.2

### DIFF
--- a/runtime-common/expat/autobuild/defines
+++ b/runtime-common/expat/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=expat
 PKGDEP="glibc"
 PKGSEC=libs
 PKGDES="A stream-oriented C library for parsing XML"
+
+ABTYPE=cmakeninja

--- a/runtime-common/expat/spec
+++ b/runtime-common/expat/spec
@@ -1,4 +1,4 @@
-VER=2.5.0
+VER=2.6.2
 SRCS="tbl::https://sourceforge.net/projects/expat/files/expat/$VER/expat-$VER.tar.bz2"
-CHKSUMS="sha256::6f0e6e01f7b30025fa05c85fdad1e5d0ec7fd35d9f61b22f34998de11969ff67"
+CHKSUMS="sha256::9c7c1b5dcbc3c237c500a8fb1493e14d9582146dd9b42aa8d3ffb856a3b927e0"
 CHKUPDATE="anitya::id=770"


### PR DESCRIPTION
Topic Description
-----------------

- expat: update to 2.6.2
    Switch from autotools to cmake

Package(s) Affected
-------------------

- expat: 2.6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit expat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
