### PR TITLE
libxcb: update to 1.16.1

### DIFF
--- a/runtime-display/libxcb/spec
+++ b/runtime-display/libxcb/spec
@@ -1,5 +1,4 @@
-VER=1.16
-REL=1
+VER=1.16.1
 SRCS="tbl::https://xorg.freedesktop.org/releases/individual/lib/libxcb-$VER.tar.gz"
-CHKSUMS="sha256::bc0f75f84b28e6496a19a1d094d7e47def861a50cb7cce5b23b62eecdc2a4479"
+CHKSUMS="sha256::830c58758d814213e338fd1bb454be3787a7ef2aff9b9e4b721d9adef2662536"
 CHKUPDATE="anitya::id=1767"


### PR DESCRIPTION
Topic Description
-----------------

- libxcb: update to 1.16.1

Package(s) Affected
-------------------

- libxcb: 1.16.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxcb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
