### PR TITLE
libxkbcommon: update to 1.7.0

### DIFF
--- a/runtime-display/libxkbcommon/spec
+++ b/runtime-display/libxkbcommon/spec
@@ -1,5 +1,4 @@
-VER=1.6.0
-REL=1
+VER=1.7.0
 SRCS="tbl::https://xkbcommon.org/download/libxkbcommon-$VER.tar.xz"
-CHKSUMS="sha256::0edc14eccdd391514458bc5f5a4b99863ed2d651e4dd761a90abf4f46ef99c2b"
+CHKSUMS="sha256::65782f0a10a4b455af9c6baab7040e2f537520caa2ec2092805cdfd36863b247"
 CHKUPDATE="anitya::id=1780"


### PR DESCRIPTION
Topic Description
-----------------

- libxkbcommon: update to 1.7.0

Package(s) Affected
-------------------

- libxkbcommon: 1.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxkbcommon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
