### PR TITLE
oma: update to 1.3.0

### DIFF
--- a/app-admin/oma/autobuild/beyond
+++ b/app-admin/oma/autobuild/beyond
@@ -37,3 +37,7 @@ cp -v "$SRCDIR"/data/command-not-found/command-not-found.sh \
 abinfo "Installing config file ..."
 cp -v "$SRCDIR"/data/config/oma.toml \
 	"$PKGDIR"/etc/oma.toml
+
+abinfo "Installing D-Bus config file ..."
+install -Dvm644 "$SRCDIR"/data/dbus/oma-dbus.conf \
+	-t "$PKGDIR"/usr/share/dbus-1/

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.2.23
+VER=1.3.0
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: upadate to 1.3.0

Package(s) Affected
-------------------

- oma: 1.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
