### PR TITLE
qt-5: runtime GLES selection

### DIFF
--- a/runtime-desktop/qt-5/autobuild/patches/0020-Deepin-auto-select-opengl-or-opengles.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0020-Deepin-auto-select-opengl-or-opengles.patch
@@ -1,0 +1,312 @@
+diff --git a/qtbase/src/plugins/platforms/xcb/gl_integrations/qxcbglintegration.cpp b/qtbase/src/plugins/platforms/xcb/gl_integrations/qxcbglintegration.cpp
+index 59401d2ce7..6cfa9a5ac3 100644
+--- a/qtbase/src/plugins/platforms/xcb/gl_integrations/qxcbglintegration.cpp
++++ b/qtbase/src/plugins/platforms/xcb/gl_integrations/qxcbglintegration.cpp
+@@ -43,6 +43,214 @@ QT_BEGIN_NAMESPACE
+ 
+ Q_LOGGING_CATEGORY(lcQpaGl, "qt.qpa.gl")
+ 
++#include <X11/Xlib.h>
++#include <GL/glx.h>
++#include <EGL/egl.h>
++
++int DetectOpenGLCapability::EGLtestGLESCapability()
++{
++     Display    *x_display;
++     Window      win;
++     EGLDisplay  egl_display;
++     EGLContext  egl_context;
++     EGLSurface  egl_surface;
++     EGLenum     current_api;
++
++     x_display = XOpenDisplay(nullptr);
++     if (x_display == nullptr) {
++         return 0;
++     }
++     Window root = DefaultRootWindow(x_display);
++     XSetWindowAttributes swa;
++     swa.event_mask = ExposureMask | PointerMotionMask | KeyPressMask;
++     win = XCreateWindow(x_display, root, 0, 0, 800, 480,   0,
++                                                  CopyFromParent, InputOutput,
++                                                  CopyFromParent, CWEventMask,
++                                                  &swa );
++     egl_display = eglGetDisplay((EGLNativeDisplayType)x_display);
++     if (egl_display == EGL_NO_DISPLAY ) {
++        XDestroyWindow(x_display, win);
++        XCloseDisplay(x_display);
++        return 0;
++     }
++     if (!eglInitialize(egl_display, nullptr, nullptr)) {
++        eglTerminate(egl_display);
++        XDestroyWindow(x_display, win);
++        XCloseDisplay(x_display);
++        return 0;
++     }
++     current_api = eglQueryAPI();
++     eglBindAPI(EGL_OPENGL_ES_API);
++     if (current_api == EGL_NONE) {
++        // do not support OpenGL ES at all
++        return 0;
++     }
++     EGLint attr[] = {       // some attributes to set up our egl-interface
++         EGL_BUFFER_SIZE, 16,
++         EGL_RENDERABLE_TYPE,
++         EGL_OPENGL_ES_BIT,
++         EGL_NONE
++     };
++     EGLConfig  ecfg;
++     EGLint     num_config;
++     if (!eglChooseConfig(egl_display, attr, &ecfg, 1, &num_config)) {
++        eglTerminate(egl_display);
++        XDestroyWindow(x_display, win);
++        XCloseDisplay(x_display);
++        return 0;
++     }
++     if (num_config != 1) {
++        eglTerminate(egl_display);
++        XDestroyWindow(x_display, win);
++        XCloseDisplay(x_display);
++        return 0;
++     }
++     egl_surface = eglCreateWindowSurface ( egl_display, ecfg, win, NULL );
++     if (egl_surface == EGL_NO_SURFACE) {
++        eglDestroySurface(egl_display, egl_surface);
++        eglTerminate(egl_display);
++        XDestroyWindow(x_display, win);
++        XCloseDisplay(x_display);
++        return 0;
++     }
++
++     EGLint ctxattr[] = {
++         EGL_CONTEXT_CLIENT_VERSION, 2,
++         EGL_NONE
++     };
++     egl_context = eglCreateContext (egl_display, ecfg, EGL_NO_CONTEXT, ctxattr);
++     if (egl_context == EGL_NO_CONTEXT) {
++        eglDestroySurface(egl_display, egl_surface);
++        eglTerminate(egl_display);
++        XDestroyWindow(x_display, win);
++        XCloseDisplay(x_display);
++        return 0;
++     }
++
++     eglMakeCurrent(egl_display, egl_surface, egl_surface, egl_context);
++     const QString strShadinglanguage = reinterpret_cast<const char *>(glGetString(GL_SHADING_LANGUAGE_VERSION));
++     const QString strVersion = reinterpret_cast<const char *>(glGetString(GL_VERSION));
++     const QString strRenderer = reinterpret_cast<const char *>(glGetString(GL_RENDERER));
++     eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
++
++     eglDestroyContext(egl_display, egl_context);
++     eglDestroySurface(egl_display, egl_surface);
++     eglBindAPI(current_api);
++     eglTerminate(egl_display);
++     XDestroyWindow(x_display, win);
++     XCloseDisplay(x_display);
++
++    if (strVersion.isNull() || strRenderer.isEmpty() || strShadinglanguage.isEmpty())
++        return 0;
++    if (strVersion.contains(QStringLiteral("Mesa")) || strRenderer.contains(QStringLiteral("llvm")))
++        return 1;
++    else
++        return 2;
++}
++int DetectOpenGLCapability::GLXtestOpenGLCapability()
++{
++    Display *dpy;
++    Window root;
++    XVisualInfo *vi;
++    Colormap cmap;
++    XSetWindowAttributes swa;
++    Window win;
++    GLXFBConfig *fc;
++    GLXContext glc;
++    int att[] = {GLX_RENDER_TYPE, GLX_RGBA_BIT,
++              GLX_DOUBLEBUFFER, True,
++              GLX_DEPTH_SIZE, 16,
++              None};
++    int nelements;
++
++    dpy = XOpenDisplay(nullptr);
++
++    if (dpy == nullptr) {
++        return 0;
++    }
++
++    fc = glXChooseFBConfig(dpy, 0, att, &nelements);
++
++    if (fc == nullptr) {
++        XDestroyWindow(dpy, win);
++        XCloseDisplay(dpy);
++        return 0;
++    }
++
++    vi = glXGetVisualFromFBConfig(dpy, *fc);
++
++    if (vi == nullptr) {
++        XFree(fc);
++        XDestroyWindow(dpy, win);
++        XCloseDisplay(dpy);
++        return 0;
++    }
++
++    root = DefaultRootWindow(dpy);
++    cmap = XCreateColormap(dpy, root, vi->visual, AllocNone);
++
++    swa.colormap = cmap;
++    swa.event_mask = ExposureMask | KeyPressMask;
++    win = XCreateWindow(dpy, root, 0, 0, 1, 1,
++                 0, vi->depth,
++                 InputOutput, vi->visual,
++                 CWColormap | CWEventMask, &swa);
++
++    XMapWindow(dpy, win);
++
++    glc = glXCreateNewContext(dpy, *fc, GLX_RGBA_TYPE, nullptr, GL_TRUE);
++    if (!glc){
++        XFree(fc);
++        XFree(vi);
++        XDestroyWindow(dpy, win);
++        XCloseDisplay(dpy);
++        return 0;
++    }
++
++    glXMakeContextCurrent(dpy, win, win, glc);
++    const QString strShadinglanguage = reinterpret_cast<const char *>(glGetString(GL_SHADING_LANGUAGE_VERSION));
++    const QString strVersion = reinterpret_cast<const char *>(glGetString(GL_VERSION));
++    const QString strRenderer = reinterpret_cast<const char *>(glGetString(GL_RENDERER));
++    glXMakeCurrent(dpy, None, nullptr);
++
++    XFree(fc);
++    XFree(vi);
++    glXDestroyContext(dpy, glc);
++    XDestroyWindow(dpy, win);
++    XCloseDisplay(dpy);
++
++    if (strVersion.isNull() || strRenderer.isEmpty() || strShadinglanguage.isEmpty())
++        return 0;
++    if (strRenderer.contains(QStringLiteral("softpipe")) || strRenderer.contains(QStringLiteral("llvmpipe")))
++        return 1;
++    else
++        return 2;
++}
++
++DetectOpenGLCapability::DetectOpenGLCapability()
++{
++    m_renderableType = QSurfaceFormat::DefaultRenderableType;
++    //test opengl
++    int openglCap = GLXtestOpenGLCapability();
++    //test gles
++    int glesCap = EGLtestGLESCapability();
++    if (openglCap == 2) {
++        m_renderableType =  QSurfaceFormat::OpenGL;
++    }
++    else if (glesCap == 2){
++        m_renderableType =  QSurfaceFormat::OpenGLES;
++    }
++    else if (openglCap == 1) {
++        m_renderableType =  QSurfaceFormat::OpenGL;
++    }
++    else if (glesCap == 1){
++        m_renderableType =  QSurfaceFormat::OpenGLES;
++    }
++    else {
++        qWarning() << "this platform don't support GL";
++    }
++}
++
+ QXcbGlIntegration::QXcbGlIntegration()
+ {
+ }
+diff --git a/qtbase/src/plugins/platforms/xcb/gl_integrations/qxcbglintegration.h b/qtbase/src/plugins/platforms/xcb/gl_integrations/qxcbglintegration.h
+index 07e983a499..1af54770ae 100644
+--- a/qtbase/src/plugins/platforms/xcb/gl_integrations/qxcbglintegration.h
++++ b/qtbase/src/plugins/platforms/xcb/gl_integrations/qxcbglintegration.h
+@@ -52,6 +52,26 @@ class QXcbNativeInterfaceHandler;
+ 
+ Q_XCB_EXPORT Q_DECLARE_LOGGING_CATEGORY(lcQpaGl)
+ 
++class Q_XCB_EXPORT DetectOpenGLCapability
++{
++public:
++    static DetectOpenGLCapability* instance()
++    {
++        static DetectOpenGLCapability openglCapability;
++        return &openglCapability;
++    }
++    QSurfaceFormat::RenderableType getOpenGLType()
++    {
++        return m_renderableType;
++    }
++private:
++    DetectOpenGLCapability();
++
++    int EGLtestGLESCapability();
++    int GLXtestOpenGLCapability();
++    QSurfaceFormat::RenderableType m_renderableType;
++};
++
+ class Q_XCB_EXPORT QXcbGlIntegration
+ {
+ public:
+diff --git a/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_egl/qxcbeglintegration.cpp b/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_egl/qxcbeglintegration.cpp
+index fe18bc24db..b298081c3f 100644
+--- a/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_egl/qxcbeglintegration.cpp
++++ b/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_egl/qxcbeglintegration.cpp
+@@ -98,6 +98,11 @@ QXcbWindow *QXcbEglIntegration::createWindow(QWindow *window) const
+ 
+ QPlatformOpenGLContext *QXcbEglIntegration::createPlatformOpenGLContext(QOpenGLContext *context) const
+ {
++    QSurfaceFormat fmt = context->format();
++    if (fmt.renderableType() == QSurfaceFormat::DefaultRenderableType) {
++        fmt.setRenderableType(DetectOpenGLCapability::instance()->getOpenGLType());
++        context->setFormat(fmt);
++    }
+     QXcbScreen *screen = static_cast<QXcbScreen *>(context->screen()->handle());
+     QXcbEglContext *platformContext = new QXcbEglContext(screen->surfaceFormatFor(context->format()),
+                                                          context->shareHandle(),
+diff --git a/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_egl/qxcbeglwindow.cpp b/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_egl/qxcbeglwindow.cpp
+index 30e3381993..f000fc5a55 100644
+--- a/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_egl/qxcbeglwindow.cpp
++++ b/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_egl/qxcbeglwindow.cpp
+@@ -59,8 +59,14 @@ QXcbEglWindow::~QXcbEglWindow()
+     eglDestroySurface(m_glIntegration->eglDisplay(), m_surface);
+ }
+ 
+-void QXcbEglWindow::resolveFormat(const QSurfaceFormat &format)
++void QXcbEglWindow::resolveFormat(const QSurfaceFormat &f)
+ {
++    QSurfaceFormat format = f;
++
++    if (format.renderableType() == QSurfaceFormat::DefaultRenderableType) {
++        format.setRenderableType(DetectOpenGLCapability::instance()->getOpenGLType());
++    }
++
+     m_config = q_configFromGLFormat(m_glIntegration->eglDisplay(), format);
+     m_format = q_glFormatFromConfig(m_glIntegration->eglDisplay(), m_config, format);
+ }
+diff --git a/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp b/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
+index 790837463e..3c111ba5b9 100644
+--- a/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
++++ b/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
+@@ -232,6 +232,10 @@ QGLXContext::QGLXContext(QXcbScreen *screen, const QSurfaceFormat &format, QPlat
+     , m_getGraphicsResetStatus(nullptr)
+     , m_lost(false)
+ {
++   if (m_format.renderableType() == QSurfaceFormat::DefaultRenderableType) {
++       m_format.setRenderableType(DetectOpenGLCapability::instance()->getOpenGLType());
++   }
++
+     if (nativeHandle.isNull())
+         init(screen, share);
+     else
+diff --git a/qtbase/src/plugins/platforms/xcb/xcb_qpa_lib.pro b/qtbase/src/plugins/platforms/xcb/xcb_qpa_lib.pro
+index a5d05faa9c..1b0405493b 100644
+--- a/qtbase/src/plugins/platforms/xcb/xcb_qpa_lib.pro
++++ b/qtbase/src/plugins/platforms/xcb/xcb_qpa_lib.pro
+@@ -1,5 +1,5 @@
+ TARGET     = QtXcbQpa
+-CONFIG += no_module_headers internal_module
++CONFIG += no_module_headers internal_module egl
+ DEFINES += QT_NO_FOREACH
+ 
+ QT += \

--- a/runtime-desktop/qt-5/spec
+++ b/runtime-desktop/qt-5/spec
@@ -1,5 +1,5 @@
 VER=5.15.5+webengine5.15.10+webkit5.212.0+kde20220705
-REL=7
+REL=8
 SRCS="https://repo.aosc.io/aosc-repacks/qt-5-$VER.tar.xz"
 CHKSUMS="sha256::724101b5dbb845579b636bca4f89e12bacee736af57dbc78e30fe83a62092165"
 SUBDIR="qt-${VER:0:1}"


### PR DESCRIPTION
Topic Description
-----------------

- qt-5: adapt a patch from Linux Deepin to auto select GLES
    The patch is modified to allow it to work on 5.15. Setting
    QT_XCB_GL_INTEGRATION=xcb_egl is necessary for it to work now.
    Tested on Lichee Pi 4A with PowerVR closed GLES driver (and llvmpipe as
    GLX driver).

Package(s) Affected
-------------------

- qt-5: 1:5.15.5+webengine5.15.10+webkit5.212.0+kde20220705-8

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
