### PR TITLE
lazarus: update to 3.2

### DIFF
--- a/lang-pascal/fpc/autobuild/patches/0002-debian-ppc64el-toc-fixes.patch
+++ b/lang-pascal/fpc/autobuild/patches/0002-debian-ppc64el-toc-fixes.patch
@@ -1,0 +1,262 @@
+Description: Fix missing TOC loads on ppc64el
+ A backport of upstream commits:
+ - https://gitlab.com/freepascal.org/fpc/source/-/commit/12f48c230bccd49f368be1e5a2855cb6c3a60c0f
+ - https://gitlab.com/freepascal.org/fpc/source/-/commit/9314bbbf080418827eef94a8bc392ce0497bf72b
+ - https://gitlab.com/freepascal.org/fpc/source/-/commit/2de72c854115908271912cd9b260a607c826eadb
+ - https://gitlab.com/freepascal.org/fpc/source/-/commit/83c18df69a79fe1035a0cf0bc0897c60d1af0293
+ - https://gitlab.com/freepascal.org/fpc/source/-/commit/68b5ca633ca71a83c29b78cd3669bf15477cd94f
+ Some modifications were made to make the changes apply cleanly to v3.2.2. 
+Bug: https://gitlab.com/freepascal.org/fpc/source/-/issues/39542
+Origin: vendor, https://src.fedoraproject.org/rpms/fpc/c/01634e7f70132cc0bc1cab278edc8449e73ac1f9
+Author: Artur Frenszek-Iwicki <fedora@svgames.pl>
+Last-Update: 2022-02-07
+
+--- a/fpcsrc/compiler/ncgvmt.pas
++++ b/fpcsrc/compiler/ncgvmt.pas
+@@ -1222,14 +1222,25 @@
+         tmps : string;
+         pd   : TProcdef;
+         ImplIntf : TImplementedInterface;
+-{$ifdef cpuhighleveltarget}
+         wrapperpd: tprocdef;
+         wrapperinfo: pskpara_interface_wrapper;
+-{$else}
+-       tmplist: tasmlist;
+-       oldfileposinfo: tfileposinfo;
+-{$endif cpuhighleveltarget}
++        tmplist: tasmlist;
++        oldfileposinfo: tfileposinfo;
++        usehighlevelwrapper: Boolean;
+       begin
++{$if defined(cpuhighleveltarget)}
++        usehighlevelwrapper:=true;
++{$else defined(cpuhighleveltarget)}
++        { on PPC systems that use a TOC the linker needs to be able to insert
++          an instruction to restore the TOC register after every branch
++          between code fragments that use a different TOC (which has to be
++          executed when that "branch" returns). So we can't use tail call
++          branches to routines potentially using a different TOC there }
++        if target_info.system in systems_ppc_toc then
++          usehighlevelwrapper:=true
++        else
++          usehighlevelwrapper:=false;
++{$endif defined(cpuhighleveltarget)}
+         for i:=0 to _class.ImplementedInterfaces.count-1 do
+           begin
+             ImplIntf:=TImplementedInterface(_class.ImplementedInterfaces[i]);
+@@ -1246,43 +1257,47 @@
+                        not is_objectpascal_helper(tprocdef(pd).struct) then
+                       tobjectdef(tprocdef(pd).struct).register_vmt_call(tprocdef(pd).extnumber);
+                     tmps:=CreateWrapperName(_Class,ImplIntf,j,pd);
+-{$ifdef cpuhighleveltarget}
+-                    new(wrapperinfo);
+-                    wrapperinfo^.pd:=pd;
+-                    wrapperinfo^.offset:=ImplIntf.ioffset;
+-                    { insert the wrapper procdef in the current unit's local
+-                      symbol table, but set the owning "struct" to the current
+-                      class (so self will have the correct type) }
+-                    wrapperpd:=create_procdef_alias(pd,tmps,tmps,
+-                      current_module.localsymtable,_class,
+-                      tsk_interface_wrapper,wrapperinfo);
+-                    include(wrapperpd.procoptions,po_noreturn);
+-{$else cpuhighleveltarget}
+-                    oldfileposinfo:=current_filepos;
+-                    if pd.owner.iscurrentunit then
+-                      current_filepos:=pd.fileinfo
+-                    else
+-                      begin
+-                        current_filepos.moduleindex:=current_module.unit_index;
+-                        current_filepos.fileindex:=1;
+-                        current_filepos.line:=1;
+-                        current_filepos.column:=1;
+-                      end;
+-                    { create wrapper code }
+-                    tmplist:=tasmlist.create;
+-                    new_section(tmplist,sec_code,tmps,target_info.alignment.procalign);
+-                    tmplist.Concat(tai_function_name.create(tmps));
+-                    hlcg.init_register_allocators;
+-                    hlcg.g_intf_wrapper(tmplist,pd,tmps,ImplIntf.ioffset);
+-                    hlcg.done_register_allocators;
+-                    if ((cs_debuginfo in current_settings.moduleswitches) or
+-                       (cs_use_lineinfo in current_settings.globalswitches)) and
+-                       (target_dbg.id<>dbg_stabx) then
+-                         current_debuginfo.insertlineinfo(tmplist);
+-                    list.concatlist(tmplist);
+-                    tmplist.Free;
+-                    current_filepos:=oldfileposinfo;
+-{$endif cpuhighleveltarget}
++
++                  if usehighlevelwrapper then
++                    begin
++                      new(wrapperinfo);
++                      wrapperinfo^.pd:=pd;
++                      wrapperinfo^.offset:=ImplIntf.ioffset;
++                      { insert the wrapper procdef in the current unit's local
++                        symbol table, but set the owning "struct" to the current
++                        class (so self will have the correct type) }
++                      wrapperpd:=create_procdef_alias(pd,tmps,tmps,
++                        current_module.localsymtable,_class,
++                        tsk_interface_wrapper,wrapperinfo);
++                      include(wrapperpd.implprocoptions,pio_thunk);
++                    end
++                  else
++                    begin
++                      oldfileposinfo:=current_filepos;
++                      if pd.owner.iscurrentunit then
++                        current_filepos:=pd.fileinfo
++                      else
++                        begin
++                          current_filepos.moduleindex:=current_module.unit_index;
++                          current_filepos.fileindex:=1;
++                          current_filepos.line:=1;
++                          current_filepos.column:=1;
++                        end;
++                      { create wrapper code }
++                      tmplist:=tasmlist.create;
++                      new_section(tmplist,sec_code,tmps,target_info.alignment.procalign);
++                      tmplist.Concat(tai_function_name.create(tmps));
++                      hlcg.init_register_allocators;
++                      hlcg.g_intf_wrapper(tmplist,pd,tmps,ImplIntf.ioffset);
++                      hlcg.done_register_allocators;
++                      if ((cs_debuginfo in current_settings.moduleswitches) or
++                         (cs_use_lineinfo in current_settings.globalswitches)) and
++                         (target_dbg.id<>dbg_stabx) then
++                           current_debuginfo.insertlineinfo(tmplist);
++                      list.concatlist(tmplist);
++                      tmplist.Free;
++                      current_filepos:=oldfileposinfo;
++                    end;
+                   end;
+               end;
+           end;
+--- a/fpcsrc/compiler/powerpc64/cgcpu.pas
++++ b/fpcsrc/compiler/powerpc64/cgcpu.pas
+@@ -337,10 +337,6 @@
+     reference_reset_base(tmpref, reg, 0, ctempposinvalid, sizeof(pint), []);
+     a_load_ref_reg(list, OS_ADDR, OS_ADDR, tmpref, tempreg);
+ 
+-    { save TOC pointer in stackframe }
+-    reference_reset_base(tmpref, NR_STACK_POINTER_REG, get_rtoc_offset, ctempposinvalid, 8, []);
+-    a_load_reg_ref(list, OS_ADDR, OS_ADDR, NR_RTOC, tmpref);
+-
+     { move actual function pointer to CTR register }
+     list.concat(taicpu.op_reg(A_MTCTR, tempreg));
+ 
+@@ -1269,6 +1265,13 @@
+     end;
+   end;
+ 
++  { save current RTOC for restoration after calls if necessary }
++  if pi_do_call in current_procinfo.flags then
++    begin
++      reference_reset_base(href,NR_STACK_POINTER_REG,get_rtoc_offset,ctempposinvalid,target_info.stackalign,[]);
++      a_load_reg_ref(list,OS_ADDR,OS_ADDR,NR_RTOC,href);
++    end;
++
+   { CR register not used by FPC atm }
+ 
+   { keep R1 allocated??? }
+--- a/fpcsrc/compiler/ppcgen/cgppc.pas
++++ b/fpcsrc/compiler/ppcgen/cgppc.pas
+@@ -1055,6 +1055,7 @@
+            (assigned(ref.symbol) and
+             not assigned(ref.relsymbol)) then
+           begin
++            include(current_procinfo.flags,pi_needs_got);
+             tmpreg := load_got_symbol(list, ref.symbol.name, asmsym2indsymflags(ref.symbol));
+             if (ref.base = NR_NO) then
+               ref.base := tmpreg
+--- a/fpcsrc/compiler/ppcgen/hlcgppc.pas
++++ b/fpcsrc/compiler/ppcgen/hlcgppc.pas
+@@ -183,11 +183,16 @@
+           system_powerpc_darwin,
+           system_powerpc64_darwin:
+             list.concat(taicpu.op_sym(A_B,tcgppcgen(cg).get_darwin_call_stub(procdef.mangledname,false)));
+-          else if use_dotted_functions then
+-            {$note ts:todo add GOT change?? - think not needed :) }
+-            list.concat(taicpu.op_sym(A_B,current_asmdata.RefAsmSymbol('.' + procdef.mangledname,AT_FUNCTION)))
+           else
+-            list.concat(taicpu.op_sym(A_B,current_asmdata.RefAsmSymbol(procdef.mangledname,AT_FUNCTION)))
++            begin
++              if use_dotted_functions then
++                {$note ts:todo add GOT change?? - think not needed :) }
++                list.concat(taicpu.op_sym(A_B,current_asmdata.RefAsmSymbol('.' + procdef.mangledname,AT_FUNCTION)))
++              else
++                list.concat(taicpu.op_sym(A_B,current_asmdata.RefAsmSymbol(procdef.mangledname,AT_FUNCTION)));
++              if (target_info.system in ([system_powerpc64_linux]+systems_aix)) then
++                list.concat(taicpu.op_none(A_NOP));
++            end;
+         end;
+       List.concat(Tai_symbol_end.Createname(labelname));
+     end;
+--- a/fpcsrc/compiler/psub.pas
++++ b/fpcsrc/compiler/psub.pas
+@@ -2306,8 +2306,10 @@
+                  }
+                  if (not pd.forwarddef) and
+                     (pd.hasforward) and
+-                    (proc_get_importname(pd)<>'') then
+-                   call_through_new_name(pd,proc_get_importname(pd))
++                    (proc_get_importname(pd)<>'') then begin
++                     call_through_new_name(pd,proc_get_importname(pd))
++                     include(pd.implprocoptions,pio_thunk);
++                   end
+                  else
+ {$endif cpuhighleveltarget}
+                    begin
+--- a/fpcsrc/compiler/symconst.pas
++++ b/fpcsrc/compiler/symconst.pas
+@@ -425,7 +425,17 @@
+     { the routine contains no code }
+     pio_empty,
+     { the inline body of this routine is available }
+-    pio_has_inlininginfo
++    pio_has_inlininginfo,
++    { inline is not possible (has assembler block, etc) }
++    pio_inline_not_possible,
++    { a nested routine accesses a local variable from this routine }
++    pio_nested_access,
++    { a stub/thunk }
++    pio_thunk,
++    { compiled with fastmath enabled } 
++    pio_fastmath, 
++    { inline is forbidden (calls get_frame) }
++    pio_inline_forbidden
+   );
+   timplprocoptions = set of timplprocoption;
+ 
+--- a/fpcsrc/compiler/systems.pas
++++ b/fpcsrc/compiler/systems.pas
+@@ -393,6 +393,16 @@
+          on the caller side rather than on the callee side }
+        systems_caller_copy_addr_value_para = [system_aarch64_ios,system_aarch64_darwin,system_aarch64_linux];
+ 
++       { all PPC systems that use a TOC register to address globals }
++       { TODO: not used by Darwin, but don't know about others (JM) }
++       systems_ppc_toc = [
++         system_powerpc_linux,
++         system_powerpc64_linux,
++         system_powerpc_aix,
++         system_powerpc64_aix,
++         system_powerpc_macosclassic
++       ];
++
+        { pointer checking (requires special code in FPC_CHECKPOINTER,
+          and can never work for libc-based targets or any other program
+          linking to an external library)
+--- a/fpcsrc/compiler/utils/ppuutils/ppudump.pp
++++ b/fpcsrc/compiler/utils/ppuutils/ppudump.pp
+@@ -3087,7 +3087,12 @@
+ const
+   piopt : array[low(timplprocoption)..high(timplprocoption)] of tpiopt=(
+     (mask:pio_empty; str:'IsEmpty'),
+-    (mask:pio_has_inlininginfo; str:'HasInliningInfo')
++    (mask:pio_has_inlininginfo; str:'HasInliningInfo'),
++    (mask:pio_inline_not_possible; str:'InlineNotPossible'),
++    (mask:pio_nested_access; str:'NestedAccess'),
++    (mask:pio_thunk; str:'Thunk'),
++    (mask:pio_fastmath; str:'FastMath'),
++    (mask:pio_inline_forbidden; str:'InlineForbidden')
+   );
+ var
+   i: timplprocoption;

--- a/lang-pascal/fpc/spec
+++ b/lang-pascal/fpc/spec
@@ -1,5 +1,5 @@
 VER=3.2.2
-REL=3
+REL=4
 SRCS="https://sourceforge.net/projects/freepascal/files/Source/$VER/fpcbuild-$VER.tar.gz/download"
 CHKSUMS="sha256::85ef993043bb83f999e2212f1bca766eb71f6f973d362e2290475dbaaf50161f"
 SUBDIR="fpcbuild-$VER"

--- a/lang-pascal/lazarus/01-lazarus/defines
+++ b/lang-pascal/lazarus/01-lazarus/defines
@@ -1,9 +1,10 @@
 PKGNAME=lazarus
 PKGSEC=devel
-PKGDEP="desktop-file-utils fpc gtk-2 gtk-3 qt-5"
+PKGDEP="desktop-file-utils fpc gtk-2 gtk-3 qt-5 qt-6"
 PKGDES="Delphi-like IDE for Free Pascal development"
 
 NOPARALLEL=1
 ABSPLITDBG=0
 
-FAIL_ARCH="!(amd64|i486)"
+# fpc supported architectures
+FAIL_ARCH="!(amd64|arm64|ppc64el)"

--- a/lang-pascal/lazarus/02-qt5pas/build
+++ b/lang-pascal/lazarus/02-qt5pas/build
@@ -1,5 +1,14 @@
 abinfo "Switching into qt5pas directory ..."
 cd "$SRCDIR"/lcl/interfaces/qt5/cbindings
 
-abinfo "Building qt5pas using qtproj ABTYPE template ..."
+abinfo "Configuring qt5pas ..."
+QT_SELECT=5
+MAKE_AFTER=""
+QTPROJ_AFTER=""
+build_qtproj_configure
+
+abinfo "Building qt5pas ..."
 build_qtproj_build
+
+abinfo "Installing qt5pas ..."
+build_qtproj_install

--- a/lang-pascal/lazarus/02-qt5pas/defines
+++ b/lang-pascal/lazarus/02-qt5pas/defines
@@ -4,4 +4,5 @@ PKGDES="A FreePascal Qt5 binding library"
 PKGDEP="qt-5"
 BUILDDEP="fpc"
 
-FAIL_ARCH="!(amd64|i486)"
+# fpc supported architectures
+FAIL_ARCH="!(amd64|arm64|ppc64el)"

--- a/lang-pascal/lazarus/spec
+++ b/lang-pascal/lazarus/spec
@@ -1,5 +1,4 @@
-VER=2.0.12
-REL=2
-SRCS="https://sourceforge.net/projects/lazarus/files/Lazarus%20Zip%20_%20GZip/Lazarus%20${VER}/lazarus-${VER}.tar.gz"
-CHKSUMS="sha256::ba6cef7f823a2d28166229982efc926039d42313c40e22fe0c6776c13d0015b2"
+VER=3.2
+SRCS="tbl::https://sourceforge.net/projects/lazarus/files/Lazarus%20Zip%20_%20GZip/Lazarus%20${VER}/lazarus-${VER}-0.tar.gz"
+CHKSUMS="sha256::69f43f0a10b9e09deea5f35094c73b84464b82d3f40d8a2fcfcb5a5ab03c6edf"
 CHKUPDATE="anitya::id=1538"


### PR DESCRIPTION
Topic Description
-----------------

- lazarus: update to 3.2
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fpc: fix ppc64el toc error

Package(s) Affected
-------------------

- fpc: 3.2.2-4
- lazarus: 3.2
- qt5pas: 3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit fpc lazarus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
