### PR TITLE
clash-verge-rev: update to 1.5.11

### DIFF
--- a/app-network/clash-verge-rev/autobuild/patches/0001-fix-package.json-allow-building-on-platforms-without.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0001-fix-package.json-allow-building-on-platforms-without.patch
@@ -1,7 +1,7 @@
-From fb4c46386c0aa33a7e62c0fddcac65c17a8d4c0d Mon Sep 17 00:00:00 2001
+From a22339ef6beaea6cd4909f6804b8a9d7a28895aa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 15:42:32 +0800
-Subject: [PATCH 1/9] fix(package.json): allow building on platforms without
+Subject: [PATCH 01/10] fix(package.json): allow building on platforms without
  native rollup binaries
 
 Ref: https://github.com/clash-verge-rev/clash-verge-rev/issues/453#issuecomment-2002506344
@@ -10,7 +10,7 @@ Ref: https://github.com/clash-verge-rev/clash-verge-rev/issues/453#issuecomment-
  1 file changed, 5 insertions(+)
 
 diff --git a/package.json b/package.json
-index e4ed81a..9f8e4cb 100644
+index b460039..927e9cf 100644
 --- a/package.json
 +++ b/package.json
 @@ -76,5 +76,10 @@

--- a/app-network/clash-verge-rev/autobuild/patches/0002-chore-src-tauri-update-Cargo-dependencies.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0002-chore-src-tauri-update-Cargo-dependencies.patch
@@ -1,7 +1,7 @@
-From 425afdd682566d5c518a7f007676f9a4b7e98bad Mon Sep 17 00:00:00 2001
+From b278a54bb8fc9b9625cd00f1e7dd55932760c750 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 15:43:11 +0800
-Subject: [PATCH 2/9] chore(src-tauri): update Cargo dependencies
+Subject: [PATCH 02/10] chore(src-tauri): update Cargo dependencies
 
 - This allows building clash-verge-rev on loongarch64.
 - Procedure: cd src-tauri && cargo update.
@@ -10,7 +10,7 @@ Subject: [PATCH 2/9] chore(src-tauri): update Cargo dependencies
  1 file changed, 438 insertions(+), 414 deletions(-)
 
 diff --git a/src-tauri/Cargo.lock b/src-tauri/Cargo.lock
-index d715578..81252ea 100644
+index ad5d0f0..8bcf486 100644
 --- a/src-tauri/Cargo.lock
 +++ b/src-tauri/Cargo.lock
 @@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"

--- a/app-network/clash-verge-rev/autobuild/patches/0003-feat-src-assets-add-XDG-.desktop-entry.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0003-feat-src-assets-add-XDG-.desktop-entry.patch
@@ -1,7 +1,7 @@
-From 38819bf3390f6d46a91253335d3834f3801949bb Mon Sep 17 00:00:00 2001
+From 09ffd810290daed1afb8d599e477af90c9d25962 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 16:28:51 +0800
-Subject: [PATCH 3/9] feat(src/assets): add XDG .desktop entry
+Subject: [PATCH 03/10] feat(src/assets): add XDG .desktop entry
 
 ---
  src/assets/xdg/io.github.clash-verge-rev.desktop | 14 ++++++++++++++

--- a/app-network/clash-verge-rev/autobuild/patches/0004-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0004-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,7 +1,7 @@
-From 3b9f3a6fc289970117bdae00b8e93da00fca9237 Mon Sep 17 00:00:00 2001
+From 0ba7191cc55e643bcc6521317442b5402011817a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 16:32:18 +0800
-Subject: [PATCH 4/9] fix(tauri.conf.json): disable bundle distribution
+Subject: [PATCH 04/10] fix(tauri.conf.json): disable bundle distribution
 
 We only need the binary in /src-tauri/target.
 ---
@@ -9,7 +9,7 @@ We only need the binary in /src-tauri/target.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 73cab21..8fa2757 100644
+index 2314f5a..463daca 100644
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -11,7 +11,7 @@

--- a/app-network/clash-verge-rev/autobuild/patches/0005-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0005-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
@@ -1,7 +1,7 @@
-From 3411cb57a5598b17fbbdc3a14ec1f2a29bc15914 Mon Sep 17 00:00:00 2001
+From fa11134b21455277e1259b175f820566518983ef Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 17:26:12 +0800
-Subject: [PATCH 5/9] fix(scripts): use ABI2 (New-World) Mihomo binary for
+Subject: [PATCH 05/10] fix(scripts): use ABI2 (New-World) Mihomo binary for
  loongarch64
 
 Currently, only the alpha Mihomo binary distinguishes between abi1 (old-world)

--- a/app-network/clash-verge-rev/autobuild/patches/0006-feat-drop-clash-meta-alpha-support.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0006-feat-drop-clash-meta-alpha-support.patch
@@ -1,7 +1,7 @@
-From 48a2d4682e730dbb2a127d29a81c320fb9c36041 Mon Sep 17 00:00:00 2001
+From 90ffb92425df9716d603e6f9a56729f818992fec Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
-Subject: [PATCH 6/9] feat: drop clash-meta-alpha support
+Subject: [PATCH 06/10] feat: drop clash-meta-alpha support
 
 ---
  src/components/setting/mods/clash-core-viewer.tsx | 5 +----

--- a/app-network/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
@@ -1,7 +1,8 @@
-From 08d0263b5ffd02f107358bda9d02823711d7990f Mon Sep 17 00:00:00 2001
+From 5ad9f210aae2dc3b6ac6e887b072f25856b87fc9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 11:45:21 +0800
-Subject: [PATCH 7/9] fix(check.mjs): do not fetch Mihomo (Clash Meta) binaries
+Subject: [PATCH 07/10] fix(check.mjs): do not fetch Mihomo (Clash Meta)
+ binaries
 
 We use a system copy for this purpose.
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0008-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0008-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
@@ -1,7 +1,7 @@
-From 64f8aee146e79b49d9ea3771d813f213ef616d87 Mon Sep 17 00:00:00 2001
+From 1a37b53f727bf6337f0101a7b3805cce4193b420 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 12:04:58 +0800
-Subject: [PATCH 8/9] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
+Subject: [PATCH 08/10] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
  Meta) bundling
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 8/9] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
  1 file changed, 1 deletion(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 8fa2757..2a6f4a3 100644
+index 463daca..23eed11 100644
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -21,7 +21,6 @@

--- a/app-network/clash-verge-rev/autobuild/patches/0009-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0009-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
@@ -1,8 +1,8 @@
-From 598e36ca170da96a9fb7c7bfdf77cdea6646d969 Mon Sep 17 00:00:00 2001
+From fe3aec98957426c6c6ef266afd5fdffdab7ed4aa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 13:07:37 +0800
-Subject: [PATCH 9/9] fix(check.mjs): do not check Mihomo (Clash Meta) platform
- support
+Subject: [PATCH 09/10] fix(check.mjs): do not check Mihomo (Clash Meta)
+ platform support
 
 This is pointless, as we supply our own.
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0010-Drop-check-update-feature.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0010-Drop-check-update-feature.patch
@@ -1,0 +1,258 @@
+From 475478a8a548130756351d1557cace5aa1d586df Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Fri, 29 Mar 2024 11:31:50 +0800
+Subject: [PATCH 10/10] Drop check update feature
+
+---
+ src/components/layout/update-button.tsx       |  47 --------
+ src/components/setting/mods/update-viewer.tsx | 104 ------------------
+ src/components/setting/setting-verge.tsx      |  26 -----
+ src/pages/_layout.tsx                         |   2 -
+ 4 files changed, 179 deletions(-)
+ delete mode 100644 src/components/layout/update-button.tsx
+ delete mode 100644 src/components/setting/mods/update-viewer.tsx
+
+diff --git a/src/components/layout/update-button.tsx b/src/components/layout/update-button.tsx
+deleted file mode 100644
+index 601a890..0000000
+--- a/src/components/layout/update-button.tsx
++++ /dev/null
+@@ -1,47 +0,0 @@
+-import useSWR from "swr";
+-import { useRef } from "react";
+-import { Button } from "@mui/material";
+-import { checkUpdate } from "@tauri-apps/api/updater";
+-import { UpdateViewer } from "../setting/mods/update-viewer";
+-import { DialogRef } from "../base";
+-import { useVerge } from "@/hooks/use-verge";
+-
+-interface Props {
+-  className?: string;
+-}
+-
+-export const UpdateButton = (props: Props) => {
+-  const { className } = props;
+-  const { verge } = useVerge();
+-  const { auto_check_update } = verge || {};
+-
+-  const viewerRef = useRef<DialogRef>(null);
+-
+-  const { data: updateInfo } = useSWR(
+-    auto_check_update || auto_check_update === null ? "checkUpdate" : null,
+-    checkUpdate,
+-    {
+-      errorRetryCount: 2,
+-      revalidateIfStale: false,
+-      focusThrottleInterval: 36e5, // 1 hour
+-    }
+-  );
+-
+-  if (!updateInfo?.shouldUpdate) return null;
+-
+-  return (
+-    <>
+-      <UpdateViewer ref={viewerRef} />
+-
+-      <Button
+-        color="error"
+-        variant="contained"
+-        size="small"
+-        className={className}
+-        onClick={() => viewerRef.current?.open()}
+-      >
+-        New
+-      </Button>
+-    </>
+-  );
+-};
+diff --git a/src/components/setting/mods/update-viewer.tsx b/src/components/setting/mods/update-viewer.tsx
+deleted file mode 100644
+index 9331696..0000000
+--- a/src/components/setting/mods/update-viewer.tsx
++++ /dev/null
+@@ -1,104 +0,0 @@
+-import useSWR from "swr";
+-import snarkdown from "snarkdown";
+-import { forwardRef, useImperativeHandle, useState, useMemo } from "react";
+-import { useLockFn } from "ahooks";
+-import { Box, LinearProgress, styled } from "@mui/material";
+-import { useRecoilState } from "recoil";
+-import { useTranslation } from "react-i18next";
+-import { relaunch } from "@tauri-apps/api/process";
+-import { checkUpdate, installUpdate } from "@tauri-apps/api/updater";
+-import { BaseDialog, DialogRef, Notice } from "@/components/base";
+-import { atomUpdateState } from "@/services/states";
+-import { listen, Event, UnlistenFn } from "@tauri-apps/api/event";
+-import { portableFlag } from "@/pages/_layout";
+-
+-const UpdateLog = styled(Box)(() => ({
+-  "h1,h2,h3,ul,ol,p": { margin: "0.5em 0", color: "inherit" },
+-}));
+-let eventListener: UnlistenFn | null = null;
+-
+-export const UpdateViewer = forwardRef<DialogRef>((props, ref) => {
+-  const { t } = useTranslation();
+-
+-  const [open, setOpen] = useState(false);
+-  const [updateState, setUpdateState] = useRecoilState(atomUpdateState);
+-
+-  const { data: updateInfo } = useSWR("checkUpdate", checkUpdate, {
+-    errorRetryCount: 2,
+-    revalidateIfStale: false,
+-    focusThrottleInterval: 36e5, // 1 hour
+-  });
+-
+-  const [downloaded, setDownloaded] = useState(0);
+-  const [buffer, setBuffer] = useState(0);
+-  const [total, setTotal] = useState(0);
+-
+-  useImperativeHandle(ref, () => ({
+-    open: () => setOpen(true),
+-    close: () => setOpen(false),
+-  }));
+-
+-  // markdown parser
+-  const parseContent = useMemo(() => {
+-    if (!updateInfo?.manifest?.body) {
+-      return "New Version is available";
+-    }
+-    return snarkdown(updateInfo?.manifest?.body);
+-  }, [updateInfo]);
+-
+-  const onUpdate = useLockFn(async () => {
+-    if (portableFlag) {
+-      Notice.error(t("Portable Updater Error"));
+-      return;
+-    }
+-    if (updateState) return;
+-    setUpdateState(true);
+-    if (eventListener !== null) {
+-      eventListener();
+-    }
+-    eventListener = await listen(
+-      "tauri://update-download-progress",
+-      (e: Event<any>) => {
+-        setTotal(e.payload.contentLength);
+-        setBuffer(e.payload.chunkLength);
+-        setDownloaded((a) => {
+-          return a + e.payload.chunkLength;
+-        });
+-      }
+-    );
+-    try {
+-      await installUpdate();
+-      await relaunch();
+-    } catch (err: any) {
+-      Notice.error(err?.message || err.toString());
+-    } finally {
+-      setUpdateState(false);
+-    }
+-  });
+-
+-  return (
+-    <BaseDialog
+-      open={open}
+-      title={`New Version v${updateInfo?.manifest?.version}`}
+-      contentSx={{ minWidth: 360, maxWidth: 400, height: "50vh" }}
+-      okBtn={t("Update")}
+-      cancelBtn={t("Cancel")}
+-      onClose={() => setOpen(false)}
+-      onCancel={() => setOpen(false)}
+-      onOk={onUpdate}
+-    >
+-      <UpdateLog
+-        dangerouslySetInnerHTML={{ __html: parseContent }}
+-        sx={{ height: "calc(100% - 10px)", overflow: "auto" }}
+-      />
+-      {updateState && (
+-        <LinearProgress
+-          variant="buffer"
+-          value={(downloaded / total) * 100}
+-          valueBuffer={buffer}
+-          sx={{ marginTop: "5px" }}
+-        />
+-      )}
+-    </BaseDialog>
+-  );
+-});
+diff --git a/src/components/setting/setting-verge.tsx b/src/components/setting/setting-verge.tsx
+index fa32c28..7d4d016 100644
+--- a/src/components/setting/setting-verge.tsx
++++ b/src/components/setting/setting-verge.tsx
+@@ -30,7 +30,6 @@ import { MiscViewer } from "./mods/misc-viewer";
+ import { ThemeViewer } from "./mods/theme-viewer";
+ import { GuardState } from "./mods/guard-state";
+ import { LayoutViewer } from "./mods/layout-viewer";
+-import { UpdateViewer } from "./mods/update-viewer";
+ import getSystem from "@/utils/get-system";
+ import { routers } from "@/pages/_routers";
+ 
+@@ -63,19 +62,6 @@ const SettingVerge = ({ onError }: Props) => {
+     mutateVerge({ ...verge, ...patch }, false);
+   };
+ 
+-  const onCheckUpdate = useLockFn(async () => {
+-    try {
+-      const info = await checkUpdate();
+-      if (!info?.shouldUpdate) {
+-        Notice.success("No Updates Available");
+-      } else {
+-        updateRef.current?.open();
+-      }
+-    } catch (err: any) {
+-      Notice.error(err.message || err.toString());
+-    }
+-  });
+-
+   return (
+     <SettingList title={t("Verge Setting")}>
+       <ThemeViewer ref={themeRef} />
+@@ -83,7 +69,6 @@ const SettingVerge = ({ onError }: Props) => {
+       <HotkeyViewer ref={hotkeyRef} />
+       <MiscViewer ref={miscRef} />
+       <LayoutViewer ref={layoutRef} />
+-      <UpdateViewer ref={updateRef} />
+ 
+       <SettingItem label={t("Language")}>
+         <GuardState
+@@ -301,17 +286,6 @@ const SettingVerge = ({ onError }: Props) => {
+         </IconButton>
+       </SettingItem>
+ 
+-      <SettingItem label={t("Check for Updates")}>
+-        <IconButton
+-          color="inherit"
+-          size="small"
+-          sx={{ my: "2px" }}
+-          onClick={onCheckUpdate}
+-        >
+-          <ArrowForward />
+-        </IconButton>
+-      </SettingItem>
+-
+       <SettingItem label={t("Open Dev Tools")}>
+         <IconButton
+           color="inherit"
+diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
+index be11146..fa21946 100644
+--- a/src/pages/_layout.tsx
++++ b/src/pages/_layout.tsx
+@@ -19,7 +19,6 @@ import { Notice } from "@/components/base";
+ import { LayoutItem } from "@/components/layout/layout-item";
+ import { LayoutControl } from "@/components/layout/layout-control";
+ import { LayoutTraffic } from "@/components/layout/layout-traffic";
+-import { UpdateButton } from "@/components/layout/update-button";
+ import { useCustomTheme } from "@/components/layout/use-custom-theme";
+ import getSystem from "@/utils/get-system";
+ import "dayjs/locale/ru";
+@@ -138,7 +137,6 @@ const Layout = () => {
+           <div className="layout__left">
+             <div className="the-logo" data-tauri-drag-region="true">
+               {!isDark ? <LogoSvg /> : <LogoSvg_dark />}
+-              {<UpdateButton className="the-newbtn" />}
+             </div>
+ 
+             <List className="the-menu">
+-- 
+2.44.0
+

--- a/app-network/clash-verge-rev/spec
+++ b/app-network/clash-verge-rev/spec
@@ -1,4 +1,4 @@
-VER=1.5.10
+VER=1.5.11
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"

--- a/app-network/mihomo/spec
+++ b/app-network/mihomo/spec
@@ -1,4 +1,4 @@
-VER=1.18.1
+VER=1.18.2
 SRCS="git::commit=tags/v$VER::https://github.com/MetaCubeX/mihomo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371845"


### PR DESCRIPTION
Topic Description
-----------------

- mihomo: update to 1.18.2
- clash-verge-rev: update to 1.5.11
    - Disable check update

Package(s) Affected
-------------------

- clash-verge-rev: 1.5.11
- mihomo: 1.18.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mihomo clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
