### PR TITLE
7-zip: 23.01, new

### DIFF
--- a/app-utils/7-zip/autobuild/build
+++ b/app-utils/7-zip/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Building 7-zip ..."
+cd "${SRCDIR}/CPP/7zip/Bundles/Alone2"
+make -f ../../cmpl_clang.mak
+
+abinfo "Installing 7-zip ..."
+install -v -Dm755 "${SRCDIR}/CPP/7zip/Bundles/Alone2/b/c/7zz" "${PKGDIR}/usr/bin/7zz"
+install -v -Dm644 "${SRCDIR}/DOC/"* -t "${PKGDIR}/usr/share/doc/${PKGNAME}"

--- a/app-utils/7-zip/autobuild/defines
+++ b/app-utils/7-zip/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=7-zip
+PKGSEC=utils
+PKGDEP="gcc-runtime glibc"
+BUILDDEP="llvm"
+PKGDES="A file archive manager with support for multiple formats"

--- a/app-utils/7-zip/autobuild/patches/0001-fix-CPP-clang-llvm-build-errors.patch
+++ b/app-utils/7-zip/autobuild/patches/0001-fix-CPP-clang-llvm-build-errors.patch
@@ -1,0 +1,40 @@
+From 95c86b2e95cd7013a66033471bf7001429282196 Mon Sep 17 00:00:00 2001
+From: Anjia Wang <anjiawang@gmail.com>
+Date: Fri, 29 Mar 2024 14:09:05 -0700
+Subject: [PATCH] fix(CPP): clang/llvm build errors
+
+Use Clang instead because GCC with -g doesn't create a DEBUG build.
+Removed -Werror since it triggered multiple compilation errors with Clang.
+
+The upstream project is expected to address this issue in the next release.
+
+Ref: https://github.com/ip7z/7zip/issues/20
+---
+ CPP/7zip/7zip_gcc.mak | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CPP/7zip/7zip_gcc.mak b/CPP/7zip/7zip_gcc.mak
+index 8bf0594..7bb4d3a 100644
+--- a/CPP/7zip/7zip_gcc.mak
++++ b/CPP/7zip/7zip_gcc.mak
+@@ -24,7 +24,7 @@ PROGPATH_STATIC = $(O)/$(PROG)s
+ 
+ 
+ ifneq ($(CC), xlc)
+-CFLAGS_WARN_WALL = -Werror -Wall -Wextra
++CFLAGS_WARN_WALL = -Wall -Wextra
+ endif
+ 
+ # for object file
+@@ -34,7 +34,7 @@ CFLAGS_BASE_LIST = -c
+ # CFLAGS_BASE_LIST = -S
+ CFLAGS_BASE = -O2 $(CFLAGS_BASE_LIST) $(CFLAGS_WARN_WALL) $(CFLAGS_WARN) \
+  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE \
+- -fPIC
++ -fPIC -g
+ 
+ FLAGS_FLTO = -ffunction-sections
+ FLAGS_FLTO = -flto
+-- 
+2.44.0
+

--- a/app-utils/7-zip/spec
+++ b/app-utils/7-zip/spec
@@ -1,0 +1,4 @@
+VER=23.01
+SRCS="git::commit=tags/$VER::https://github.com/ip7z/7zip.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=17875"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

- 7-zip: 23.01, new

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- 7-zip: 23.01, new

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. 

```
#buildit 7zip
```
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

Architectural progress for experimental ports does not impede on merging of this topic.

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
