### PR TITLE
util-linux: update to 2.40

### DIFF
--- a/app-utils/util-linux/spec
+++ b/app-utils/util-linux/spec
@@ -1,5 +1,4 @@
-VER=2.39.3
-REL=3
+VER=2.40
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/util-linux/v${VER:0:4}/util-linux-$VER.tar.xz"
-CHKSUMS="sha256::7b6605e48d1a49f43cc4b4cfc59f313d0dd5402fa40b96810bd572e167dfed0f"
+CHKSUMS="sha256::d57a626081f9ead02fa44c63a6af162ec19c58f53e993f206ab7c3a6641c2cd7"
 CHKUPDATE="anitya::id=8179"


### PR DESCRIPTION
Topic Description
-----------------

- util-linux: update to 2.40
    Fix CVE-2024-28085.

Package(s) Affected
-------------------

- util-linux-runtime: 2.40
- util-linux: 2.40

Security Update?
----------------

No

Build Order
-----------

```
#buildit util-linux
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
