### PR TITLE
devil: fix FTBFS on mips64r6el

### DIFF
--- a/runtime-imaging/devil/autobuild/prepare
+++ b/runtime-imaging/devil/autobuild/prepare
@@ -1,4 +1,4 @@
-if [[ "${CROSS:-$ARCH}" = "loongson3" ]]; then
+if ab_match_arch loongson3 || ab_match_arch mips64r6el; then
     abinfo "Undefining mips to prevent FTBFS ..."
     export CXXFLAGS="${CXXFLAGS} -Umips"
 fi

--- a/runtime-imaging/devil/spec
+++ b/runtime-imaging/devil/spec
@@ -1,5 +1,5 @@
 VER=1.8.0
-REL=1
+REL=2
 SRCS="tbl::https://downloads.sourceforge.net/openil/DevIL-$VER.tar.gz"
 CHKSUMS="sha256::0075973ee7dd89f0507873e2580ac78336452d29d34a07134b208f44e2feb709"
 CHKUPDATE="anitya::id=10197"


### PR DESCRIPTION
Topic Description
-----------------

- devil: fix FTBFS on mips64r6el

Package(s) Affected
-------------------

- devil: 1.8.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit devil
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
