### PR TITLE
gnutls: security update to 3.8.4

### DIFF
--- a/runtime-cryptography/gnutls/spec
+++ b/runtime-cryptography/gnutls/spec
@@ -1,5 +1,4 @@
-VER=3.8.3
-REL=1
+VER=3.8.4
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnutls/v${VER:0:3}/gnutls-$VER.tar.xz"
-CHKSUMS="sha256::f74fc5954b27d4ec6dfbb11dea987888b5b124289a3703afcada0ee520f4173e"
+CHKSUMS="sha256::2bea4e154794f3f00180fa2a5c51fe8b005ac7a31cd58bd44cdfa7f36ebc3a9b"
 CHKUPDATE="anitya::id=1221"


### PR DESCRIPTION
Topic Description
-----------------

- gnutls: security update to 3.8.4

Package(s) Affected
-------------------

- gnutls: 3.8.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnutls
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
