### PR TITLE
emacs: security update to 29.3

### DIFF
--- a/app-editors/emacs/spec
+++ b/app-editors/emacs/spec
@@ -1,4 +1,4 @@
-VER=29.2
+VER=29.3
 SRCS="tbl::https://ftp.gnu.org/gnu/emacs/emacs-$VER.tar.gz"
-CHKSUMS="sha256::ac8773eb17d8b3c0c4a3bccbb478f7c359266b458563f9a5e2c23c53c05e4e59"
+CHKSUMS="sha256::2de8df5cab8ac697c69a1c46690772b0cf58fe7529f1d1999582c67d927d22e4"
 CHKUPDATE="anitya::id=675"


### PR DESCRIPTION
Topic Description
-----------------

- emacs: security update to 29.3

Package(s) Affected
-------------------

- emacs: 29.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit emacs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
