### PR TITLE
openssl: security update to 3.2.1

### DIFF
--- a/runtime-cryptography/openssl/spec
+++ b/runtime-cryptography/openssl/spec
@@ -1,4 +1,4 @@
-VER=3.2.0
+VER=3.2.1
 SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::14c826f07c7e433706fb5c69fa9e25dab95684844b4c962a2cf1bf183eb4690e"
+CHKSUMS="sha256::83c7329fe52c850677d75e5d0b0ca245309b97e8ecbcfdc1dfdc4ab9fac35b39"
 CHKUPDATE="anitya::id=2566"


### PR DESCRIPTION
Topic Description
-----------------

- openssl: security update to 3.2.1

Package(s) Affected
-------------------

- openssl: 3.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
