### PR TITLE
musescore: update to 4.2.1

### DIFF
--- a/app-creativity/musescore/autobuild/beyond
+++ b/app-creativity/musescore/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing bundled files ..."
+rm -rv "$PKGDIR"/usr/{bin/crashpad_handler,include,lib}

--- a/app-creativity/musescore/autobuild/build
+++ b/app-creativity/musescore/autobuild/build
@@ -1,2 +1,0 @@
-make release PREFIX=/usr BUILD_WEBENGINE=off
-make install DESTDIR="$PKGDIR" -C build.release

--- a/app-creativity/musescore/autobuild/defines
+++ b/app-creativity/musescore/autobuild/defines
@@ -4,4 +4,23 @@ PKGDEP="lame portaudio pulseaudio qt-5 shared-mime-info portmidi"
 BUILDDEP="doxygen gtk-2"
 PKGDES="Create, play and print beautiful sheet music"
 
-NOLTO__LOONGSON3=1
+CMAKE_AFTER="-DMSCORE_INSTALL_SUFFIX= \
+        -DMUSESCORE_LABEL=Alpha \
+        -DMUSESCORE_BUILD_CONFIG=release \
+        -DMUSESCORE_REVISION= \
+        -DTELEMETRY_TRACK_ID= \
+        -DCRASH_REPORT_URL= \
+        -DBUILD_JACK=ON \
+        -DBUILD_WEBENGINE=OFF \
+        -DDOWNLOAD_SOUNDFONT=ON \
+        -DUSE_SYSTEM_FREETYPE=ON \
+        -DBUILD_UNIT_TESTS=OFF \
+        -DCMAKE_SKIP_RPATH=OFF"
+
+# FIXME: No data signature found in rcc
+# See https://bugreports.qt.io/browse/QTBUG-73834
+# & https://bugs.gentoo.org/908808
+NOLTO=1
+
+# FIXME: crashpad only support these architectures
+FAIL_ARCH="!(amd64|arm64|loongson3)"

--- a/app-creativity/musescore/spec
+++ b/app-creativity/musescore/spec
@@ -1,5 +1,4 @@
-VER=3.6.2
-REL=3
-SRCS="tbl::https://github.com/musescore/MuseScore/archive/v$VER.tar.gz"
-CHKSUMS="sha256::c37acc6d7a316f04925265d2d22a35d715888580e16eff846e9b621954133c45"
+VER=4.2.1
+SRCS="git::commit=tags/v$VER::https://github.com/musescore/MuseScore"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6093"


### PR DESCRIPTION
Topic Description
-----------------

- musescore: update to 4.2.1

Package(s) Affected
-------------------

- musescore: 4.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit musescore
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
