### PR TITLE
harfbuzz: update to 8.4.0

### DIFF
--- a/runtime-desktop/harfbuzz/spec
+++ b/runtime-desktop/harfbuzz/spec
@@ -1,5 +1,4 @@
-VER=7.3.0
-REL=1
-SRCS="tbl::https://github.com/harfbuzz/harfbuzz/releases/download/$VER/harfbuzz-$VER.tar.xz"
-CHKSUMS="sha256::20770789749ac9ba846df33983dbda22db836c70d9f5d050cb9aa5347094a8fb"
+VER=8.4.0
+SRCS="git::commit=tags/$VER::https://github.com/harfbuzz/harfbuzz"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1299"


### PR DESCRIPTION
Topic Description
-----------------

- harfbuzz: update to 8.4.0

Package(s) Affected
-------------------

- harfbuzz: 8.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit harfbuzz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
