### PR TITLE
c-ares: update to 1.28.1

### DIFF
--- a/runtime-network/c-ares/autobuild/prepare
+++ b/runtime-network/c-ares/autobuild/prepare
@@ -1,3 +1,0 @@
-abinfo "Changing flag for disabling debug info to adding debug info ..."
-sed -e 's/-g0/-ggdb/g' \
-    -i "$SRCDIR"/m4/cares-compilers.m4

--- a/runtime-network/c-ares/spec
+++ b/runtime-network/c-ares/spec
@@ -1,5 +1,4 @@
-VER=1.14.0
-REL=2
+VER=1.28.1
 SRCS="tbl::https://c-ares.haxx.se/download/c-ares-$VER.tar.gz"
-CHKSUMS="sha256::45d3c1fd29263ceec2afc8ff9cd06d5f8f889636eb4e80ce3cc7f0eaf7aadc6e"
+CHKSUMS="sha256::675a69fc54ddbf42e6830bc671eeb6cd89eeca43828eb413243fd2c0a760809d"
 CHKUPDATE="anitya::id=5840"


### PR DESCRIPTION
Topic Description
-----------------

- c-ares: update to 1.28.1

Package(s) Affected
-------------------

- c-ares: 1.28.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit c-ares
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
