### PR TITLE
pcre2: update to 10.43

### DIFF
--- a/runtime-common/pcre2/spec
+++ b/runtime-common/pcre2/spec
@@ -1,5 +1,4 @@
-VER=10.34
-REL=3
-SRCS="tbl::https://sourceforge.net/projects/pcre/files/pcre2/10.34/pcre2-10.34.tar.gz"
-CHKSUMS="sha256::da6aba7ba2509e918e41f4f744a59fa41a2425c59a298a232e7fe85691e00379"
+VER=10.43
+SRCS="git::commit=tags/pcre2-$VER::https://github.com/PCRE2Project/pcre2"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5832"


### PR DESCRIPTION
Topic Description
-----------------

- pcre2: update to 10.43

Package(s) Affected
-------------------

- pcre2: 10.43

Security Update?
----------------

No

Build Order
-----------

```
#buildit pcre2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
