### PR TITLE
gdal: update to 3.8.4

### DIFF
--- a/app-scientific/vtk/spec
+++ b/app-scientific/vtk/spec
@@ -1,5 +1,5 @@
 VER=9.3.0
-REL=1
+REL=2
 SRCS="tbl::https://www.vtk.org/files/release/${VER%.*}/VTK-$VER.tar.gz"
 CHKSUMS="sha256::fdc7b9295225b34e4fdddc49cd06e66e94260cb00efee456e0f66568c9681be9"
 CHKUPDATE="anitya::id=15084"

--- a/runtime-games/openscenegraph/autobuild/defines
+++ b/runtime-games/openscenegraph/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=openscenegraph
 PKGSEC=libs
-PKGDEP="curl ffmpeg giflib jasper librsvg libvncserver openexr poppler pth qt-5 xine-lib libglvnd"
+PKGDEP="curl ffmpeg giflib jasper librsvg libvncserver openexr poppler pth qt-5 xine-lib libglvnd gdal"
 PKGDES="An Open Source, high performance real-time graphics toolkit"
 
 PKGEPOCH=3

--- a/runtime-games/openscenegraph/spec
+++ b/runtime-games/openscenegraph/spec
@@ -1,5 +1,5 @@
 VER=3.6.5
-REL=2
+REL=3
 SRCS="tbl::https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-$VER.tar.gz"
 CHKSUMS="sha256::aea196550f02974d6d09291c5d83b51ca6a03b3767e234a8c0e21322927d1e12"
 CHKUPDATE="anitya::id=6848"

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -1,5 +1,4 @@
-VER=3.7.0
-REL=5
+VER=3.8.4
 SRCS="tbl::https://download.osgeo.org/gdal/$VER/gdal-$VER.tar.xz"
-CHKSUMS="sha256::af4b26a6b6b3509ae9ccf1fcc5104f7fe015ef2110f5ba13220816398365adce"
+CHKSUMS="sha256::0c53ced95d29474236487202709b49015854f8e02e35e44ed0f4f4e12a7966ce"
 CHKUPDATE="anitya::id=881"

--- a/runtime-scientific/opencv/autobuild/prepare
+++ b/runtime-scientific/opencv/autobuild/prepare
@@ -3,7 +3,7 @@ export CXXFLAGS="${CXXFLAGS} -I/usr/include/openjpeg-2.3"
 export CFLAGS="${CFLAGS} -I/usr/include/openjpeg-2.3"
 
 # Contributed modules.
-tar xf ${SRCDIR}/../contrib.tar.gz
+mv "$SRCDIR"/../opencv_contrib "$SRCDIR"/opencv_contrib-$PKGVER
 rm -rv "$SRCDIR"/opencv_contrib-$PKGVER/modules/hdf
 
 # FIXME: On PowerPC 32/64-bit Big Endian

--- a/runtime-scientific/opencv/spec
+++ b/runtime-scientific/opencv/spec
@@ -1,7 +1,8 @@
 VER=4.7.0
-REL=4
-SRCS="tbl::https://github.com/opencv/opencv/archive/$VER.tar.gz
-      file::rename=contrib.tar.gz::https://github.com/opencv/opencv_contrib/archive/$VER.tar.gz"
-CHKSUMS="sha256::8df0079cdbe179748a18d44731af62a245a45ebf5085223dc03133954c662973 \
-         sha256::42df840cf9055e59d0e22c249cfb19f04743e1bdad113d31b1573d3934d62584"
+REL=5
+SRCS="git::commit=tags/$VER::https://github.com/opencv/opencv \
+      git::commit=tags/$VER;rename=opencv_contrib::https://github.com/opencv/opencv_contrib"
+CHKSUMS="SKIP \
+         SKIP"
+SUBDIR="opencv"
 CHKUPDATE="anitya::id=6615"


### PR DESCRIPTION
Topic Description
-----------------

- vtk: bump REL due to gdal update
- openscenegraph: bump REL due to gdal update
- opencv: bump REL due to gdal update
- gdal: update to 3.8.4

Package(s) Affected
-------------------

- gdal: 3.8.4
- opencv: 4.7.0-4
- openscenegraph: 3:3.6.5-3
- vtk: 9.3.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdal opencv openscenegraph vtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
