### PR TITLE
gucharmap: update to 15.1.3

### DIFF
--- a/desktop-gnome/gucharmap/spec
+++ b/desktop-gnome/gucharmap/spec
@@ -1,4 +1,4 @@
-VER=14.0.3
-SRCS="tbl::https://gitlab.gnome.org/GNOME/gucharmap/-/archive/$VER/gucharmap-$VER.tar.bz2"
-CHKSUMS="sha256::6d229e3835150fa4d62c8b53fc764ba0da6c9d994a853194bf2bbcd4c11b48ee"
+VER=15.1.3
+SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/gucharmap"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1276"

--- a/runtime-data/unicode-ucd/spec
+++ b/runtime-data/unicode-ucd/spec
@@ -1,15 +1,14 @@
-VER=14.0.0
-REL=2
+VER=15.1.0
 SRCS="file::rename=UCD.zip::http://www.unicode.org/Public/zipped/$VER/UCD.zip \
       file::rename=Unihan.zip::http://www.unicode.org/Public/zipped/$VER/Unihan.zip \
       file::rename=ReadMe.txt::http://www.unicode.org/Public/emoji/${VER%.*}/ReadMe.txt \
       file::rename=emoji-sequences.txt::http://www.unicode.org/Public/emoji/${VER%.*}/emoji-sequences.txt \
       file::rename=emoji-tests.txt::http://www.unicode.org/Public/emoji/${VER%.*}/emoji-test.txt \
       file::rename=emoji-zwj-sequences.txt::http://www.unicode.org/Public/emoji/${VER%.*}/emoji-zwj-sequences.txt"
-CHKSUMS="sha256::033a5276b5d7af8844589f8e3482f3977a8385e71d107d375055465178c23600 \
-         sha256::2ae4519b2b82cd4d15379c17e57bfb12c33c0f54da4977de03b2b04bcf11852d \
-         sha256::09d78b47628c47af5383c2d4422a536c9b6acd8005804beacd00ce080c288a06 \
-         sha256::5432b76b57de3f6458ce0ffb91256c7427b3985ab3bc2398a5ae8c2a8bbc9d26 \
-         sha256::ec474be073670aa7ce6dc1de9025b9fbb9b875fc63df815c254a5d1686fc6109 \
-         sha256::bd2a7bd4ad4d50104054923ed406c5904fe587177295a84c67ec665d80921a68"
+CHKSUMS="sha256::cb1c663d053926500cd501229736045752713a066bd75802098598b7a7056177 \
+         sha256::a0226610e324bcf784ac380e11f4cbf533ee1e6b3d028b0991bf8c0dc3f85853 \
+         sha256::deae8f60470d2f4e3204b22979526a57ad1a9780fcaf3cb1344b505cd8a5013a \
+         sha256::eb72c9115e3504fbbe1c8621b619f879471a46ccc56e2f445417b7c1cad050d1 \
+         sha256::d876ee249aa28eaa76cfa6dfaa702847a8d13b062aa488d465d0395ee8137ed9 \
+         sha256::9a76a03dcacfcd8f9bfe08c49c8d90b55182b977cbcc87a694e8a8193efb0e57"
 CHKUPDATE="anitya::id=5045"


### PR DESCRIPTION
Topic Description
-----------------

- gucharmap: update to 15.1.3
- unicode-ucd: update to 15.1.0
    The new version is required for new version of gucharmap

Package(s) Affected
-------------------

- gucharmap: 15.1.3
- unicode-ucd: 15.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit unicode-ucd gucharmap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
