### PR TITLE
vte: update to 0.76.0

### DIFF
--- a/runtime-desktop/vte/autobuild/defines
+++ b/runtime-desktop/vte/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=vte
 PKGSEC=gnome
 PKGDEP="fribidi gtk-3 icu pcre2"
-BUILDDEP="glade gobject-introspection gtk-doc intltool vala gperf"
+BUILDDEP="glade gobject-introspection gi-docgen intltool vala gperf"
 # FIXME: js-102 -x-> gjs -x-> glade.
 BUILDDEP__MIPS64R6EL="${BUILDDEP/glade/}"
 PKGDES="VTE widget for use with GTK"
@@ -9,7 +9,7 @@ PKGDES="VTE widget for use with GTK"
 # FIXME: GTK 4 is not yet supported.
 MESON_AFTER="-D_b_symbolic_functions=true \
              -Da11y=true \
-             -Ddebugg=false \
+             -Ddebug=false \
              -Ddocs=true \
              -Dgir=true \
              -Dfribidi=true \

--- a/runtime-desktop/vte/spec
+++ b/runtime-desktop/vte/spec
@@ -1,5 +1,4 @@
-VER=0.68.0
-REL=1
+VER=0.76.0
 SRCS="https://download.gnome.org/sources/vte/${VER%.*}/vte-$VER.tar.xz"
-CHKSUMS="sha256::13e7d4789ca216a33780030d246c9b13ddbfd04094c6316eea7ff92284dd1749"
+CHKSUMS="sha256::bbce30b8f504370b12d6439c07a82993e97d7e9afe2dd367817cd58ff029ffda"
 CHKUPDATE="anitya::id=10895"


### PR DESCRIPTION
Topic Description
-----------------

- vte: update to 0.76.0

Package(s) Affected
-------------------

- vte: 0.76.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vte
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
