### PR TITLE
brltty: update to 6.6

### DIFF
--- a/app-a11y/brltty/autobuild/beyond
+++ b/app-a11y/brltty/autobuild/beyond
@@ -4,6 +4,3 @@ install -Dvm644 "$SRCDIR"/Documents/brltty.conf \
 
 abinfo "Setting executable bits for all binary executables ..."
 chmod -v +x "$PKGDIR"/usr/bin/*
-
-abinfo "Moving /var/run => /run ..."
-mv -v "$PKGDIR"/{var/,}run

--- a/app-a11y/brltty/spec
+++ b/app-a11y/brltty/spec
@@ -1,5 +1,4 @@
-VER=6.0
-REL=8
+VER=6.6
 SRCS="tbl::http://mielke.cc/brltty/archive/brltty-$VER.tar.gz"
-CHKSUMS="sha256::af4bcd1e030416c2b669cc6904f73c30e73bb4ed8f743c2ada9edc87964ab752"
+CHKSUMS="sha256::13e8f699bf144ee1b1e8f9003add3785092f7f55ef107c4912e3c14f6ccca4fc"
 CHKUPDATE="anitya::id=220"


### PR DESCRIPTION
Topic Description
-----------------

- brltty: update to 6.6

Package(s) Affected
-------------------

- brltty: 6.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit brltty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
