### PR TITLE
clamav: update to 1.3.0

### DIFF
--- a/app-admin/clamav/autobuild/defines
+++ b/app-admin/clamav/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=clamav
 PKGSEC=admin
 PKGDEP="bzip2 curl json-c libtool libmspack libxml2 pcre2 systemd unrar"
-BUILDDEP="check doxygen"
+BUILDDEP="check doxygen rustc"
 BUILDDEP__RETRO=""
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"

--- a/app-admin/clamav/spec
+++ b/app-admin/clamav/spec
@@ -1,5 +1,4 @@
-VER=0.104.1
-REL=2
+VER=1.3.0
 SRCS="tbl::https://www.clamav.net/downloads/production/clamav-$VER.tar.gz"
-CHKSUMS="sha256::b7e6b709ab6c8a8eddb8c32b04c3e5df38adcae459b4ecd9bc1febaca9be57c0"
+CHKSUMS="sha256::0a86a6496320d91576037b33101119af6fd8d5b91060cd316a3a9c229e9604aa"
 CHKUPDATE="anitya::id=291"

--- a/desktop-trinity/klamav-trinity/spec
+++ b/desktop-trinity/klamav-trinity/spec
@@ -1,4 +1,5 @@
 VER=14.1.0
+REL=1
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/applications/system/klamav-trinity-$VER.tar.xz"
 CHKSUMS="sha256::c28bd4d1026b0dea81150476ba6b76a37fad0e73fd6394252adc4682d955b838"
 CHKUPDATE="anitya::id=16065"


### PR DESCRIPTION
Topic Description
-----------------

- klamav-trinity: bump REL due to clamav SONAME update
- clamav: update to 1.3.0

Package(s) Affected
-------------------

- clamav: 1.3.0
- klamav-trinity: 14.1.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit clamav klamav-trinity
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
