### PR TITLE
editorconfig-core-c: update to 0.12.6

### DIFF
--- a/runtime-editors/editorconfig-core-c/spec
+++ b/runtime-editors/editorconfig-core-c/spec
@@ -1,4 +1,4 @@
-VER=0.12.4
-SRCS="tbl::https://github.com/editorconfig/editorconfig-core-c/archive/v$VER.tar.gz"
-CHKSUMS="sha256::c2671595f1793b498cdf50b9dc03d632cc724891de7909f2ea78588fbffba289"
+VER=0.12.6
+SRCS="git::commit=tags/v$VER::https://github.com/editorconfig/editorconfig-core-c"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14833"


### PR DESCRIPTION
Topic Description
-----------------

- editorconfig-core-c: update to 0.12.6

Package(s) Affected
-------------------

- editorconfig-core-c: 0.12.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit editorconfig-core-c
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
