### PR TITLE
exim: update to 4.97.1

### DIFF
--- a/app-web/exim/spec
+++ b/app-web/exim/spec
@@ -1,4 +1,4 @@
-VER=4.97
+VER=4.97.1
 SRCS="git::commit=exim-$VER;copy-repo=true::https://github.com/Exim/exim"
 CHKSUMS="SKIP"
 SUBDIR="exim/src"


### PR DESCRIPTION
Topic Description
-----------------

- exim: update to 4.97.1

Package(s) Affected
-------------------

- exim: 4.97.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit exim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
