### PR TITLE
django: update to 5.0.3

### DIFF
--- a/lang-python/asgiref/spec
+++ b/lang-python/asgiref/spec
@@ -1,5 +1,4 @@
-VER=3.3.4
+VER=3.8.1
 SRCS="https://pypi.io/packages/source/a/asgiref/asgiref-$VER.tar.gz"
-CHKSUMS="sha256::d1216dfbdfb63826470995d31caed36225dcaf34f182e0fa257a4dd9e86f1b78"
+CHKSUMS="sha256::c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590"
 CHKUPDATE="anitya::id=18462"
-REL=1

--- a/lang-python/django/spec
+++ b/lang-python/django/spec
@@ -1,5 +1,4 @@
-VER=3.2.6
-SRCS="tbl::https://github.com/django/django/archive/$VER.tar.gz"
-CHKSUMS="sha256::5a17c7295ddd434db2b2a0193c4fc9e8290bff976b4353c8dbb02c20809bfd68"
+VER=5.0.3
+SRCS="git::commit=tags/$VER::https://github.com/django/django"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3828"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- django: update to 5.0.3
- asgiref: update to 3.8.1

Package(s) Affected
-------------------

- asgiref: 3.8.1
- django: 5.0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit django asgiref
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
