### PR TITLE
openldap: update to 2.6.7

### DIFF
--- a/app-admin/audit/spec
+++ b/app-admin/audit/spec
@@ -1,4 +1,5 @@
 VER=3.1
+REL=1
 SRCS="https://people.redhat.com/sgrubb/audit/audit-$VER.tar.gz"
 CHKSUMS="sha256::b5cf3cdabb2786c08b1de3599a3b1a547e55f7a9f9c1eb2078f5b44cf44e8378"
 CHKUPDATE="anitya::id=15225"

--- a/app-admin/autofs/spec
+++ b/app-admin/autofs/spec
@@ -1,5 +1,5 @@
 VER=5.1.8
-REL=2
+REL=3
 SRCS="tbl::https://www.kernel.org/pub/linux/daemons/autofs/v${VER:0:1}/autofs-$VER.tar.xz"
 CHKSUMS="sha256::b33d1059855664b20eeda26f3e28ff518fb0c3d58f565570af2ae569dc73c0fd"
 CHKUPDATE="anitya::id=140"

--- a/app-admin/cups-browsed/spec
+++ b/app-admin/cups-browsed/spec
@@ -1,4 +1,5 @@
 VER=2.0.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/OpenPrinting/cups-browsed"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328190"

--- a/app-admin/gconf/spec
+++ b/app-admin/gconf/spec
@@ -1,5 +1,5 @@
 VER=3.2.6
-REL=5
+REL=6
 SRCS="tbl::https://download.gnome.org/sources/GConf/${VER:0:3}/GConf-$VER.tar.xz"
 CHKSUMS="sha256::1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c"
 CHKUPDATE="anitya::id=8423"

--- a/app-admin/openldap/autobuild/defines
+++ b/app-admin/openldap/autobuild/defines
@@ -21,8 +21,6 @@ AUTOTOOLS_AFTER="--libexecdir=/usr/lib \
                  --enable-ipv6 \
                  --enable-syslog \
                  --enable-local \
-                 --disable-bdb \
-                 --disable-hdb \
                  --enable-crypt \
                  --enable-dynamic \
                  --with-threads \
@@ -37,3 +35,12 @@ AUTOTOOLS_AFTER="--libexecdir=/usr/lib \
                  --enable-slapi"
 
 RECONF=0
+# SONAME change
+PKGBREAK="apr-util<=1.6.1-7 audit<=3.1 autofs<=5.1.8-2 balsa<=2.6.3-1 \
+    cups-browsed<=2.0.0 cups-filters<=2.0.0 cyrus-sasl<=2.1.27-8 \
+    dovecot<=2.3.10.1-3 evolution-data-server<=3.44.4 evolution<=3.44.4 \
+    exim<=4.97.1 gconf<=3.2.6-5 gnupg<=1:2.4.4-2 httpd<=2.4.58 kldap<=22.08.3 \
+    krb5<=1.17.1-7 ldb<=2:2.5.1-1 libreoffice<=7.5.4.2-3 lighttpd<=1.4.55-2 \
+    nfs-utils<=2.6.2-1 opencryptoki<=3.20.0-1 php<=1:8.3.3 postfix<=3.7.3-3 \
+    quota-tools<=4.09 realmd<=0.17.1 samba<=4.17.2-2 seahorse<=42.0 squid<=5.7-2 \
+    sssd<=2.9.4 tdebase<=14.1.0-1 yubico-pam<=2.25-1"

--- a/app-admin/openldap/autobuild/prepare
+++ b/app-admin/openldap/autobuild/prepare
@@ -1,7 +1,3 @@
-abinfo "Making sure that libraries are installed with executable bits ..."
-sed -e 's|-m 644 $(LIBRARY)|-m 755 $(LIBRARY)|' \
-    -i "$SRCDIR"/libraries/{liblber,libldap,libldap_r}/Makefile.in
-
 abinfo "Tweaking ldap_defaults.h ..."
 sed -e 's|#define LDAPI_SOCK LDAP_RUNDIR LDAP_DIRSEP "run" LDAP_DIRSEP "ldapi"|#define LDAPI_SOCK LDAP_DIRSEP "run" LDAP_DIRSEP "openldap" LDAP_DIRSEP "ldapi"|' \
     -i "$SRCDIR"/include/ldap_defaults.h

--- a/app-admin/openldap/spec
+++ b/app-admin/openldap/spec
@@ -1,5 +1,4 @@
-VER=2.4.59
-REL=1
+VER=2.6.7
 SRCS="tbl::https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-$VER.tgz"
-CHKSUMS="sha256::99f37d6747d88206c470067eda624d5e48c1011e943ec0ab217bae8712e22f34"
+CHKSUMS="sha256::cd775f625c944ed78a3da18a03b03b08eea73c8aabc97b41bb336e9a10954930"
 CHKUPDATE="anitya::id=2551"

--- a/app-admin/quota-tools/spec
+++ b/app-admin/quota-tools/spec
@@ -1,4 +1,5 @@
 VER=4.09
+REL=1
 SRCS="tbl::https://sourceforge.net/projects/linuxquota/files/quota-tools/$VER/quota-$VER.tar.gz"
 CHKSUMS="sha256::9cdaca154bc92afc3117f0e5f5b3208dd5f84583af1cf061c39baa0a2bb142f9"
 CHKUPDATE="anitya::id=4145"

--- a/app-admin/sssd/spec
+++ b/app-admin/sssd/spec
@@ -1,4 +1,5 @@
 VER=2.9.4
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/SSSD/sssd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12810"

--- a/app-cryptography/gnupg/spec
+++ b/app-cryptography/gnupg/spec
@@ -1,5 +1,5 @@
 VER=2.4.4
-REL=2
+REL=3
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-$VER.tar.bz2"
 CHKSUMS="sha256::67ebe016ca90fa7688ce67a387ebd82c6261e95897db7b23df24ff335be85bc6"
 CHKUPDATE="anitya::id=1215"

--- a/app-database/ldb/spec
+++ b/app-database/ldb/spec
@@ -1,5 +1,5 @@
 VER=2.6.1
-REL=1
+REL=2
 SRCS="tbl::https://www.samba.org/ftp/pub/ldb/ldb-$VER.tar.gz"
 CHKSUMS="sha256::467403f77df86782c3965bb175440baa2ed751a9feb9560194bd8c06bf1736c9"
 CHKUPDATE="anitya::id=1652"

--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,4 +1,5 @@
 VER=8.3.3
+REL=1
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
 CHKSUMS="sha256::b0a996276fe21fe9ca8f993314c8bc02750f464c7b0343f056fb0894a8dfa9d1"
 CHKUPDATE="anitya::id=3627"

--- a/app-devices/yubico-pam/spec
+++ b/app-devices/yubico-pam/spec
@@ -1,5 +1,5 @@
 VER=2.26
-REL=1
+REL=2
 SRCS="tbl::https://github.com/Yubico/yubico-pam/archive/$VER.tar.gz"
 CHKSUMS="sha256::5178fc083d12c9b26412adc80dab5d7ef463a689ef2e0143cb6f117732705dc7"
 SUBDIR="yubico-pam-$VER"

--- a/app-network/cyrus-sasl/spec
+++ b/app-network/cyrus-sasl/spec
@@ -1,5 +1,5 @@
 VER=2.1.27
-REL=8
+REL=9
 SRCS="git::commit=tags/cyrus-sasl-$VER::https://github.com/cyrusimap/cyrus-sasl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13280"

--- a/app-network/krb5/spec
+++ b/app-network/krb5/spec
@@ -1,5 +1,5 @@
 VER=1.17.1
-REL=7
+REL=8
 SRCS="tbl::https://web.mit.edu/kerberos/dist/krb5/${VER%.*}/krb5-$VER.tar.gz"
 CHKSUMS="sha256::3706d7ec2eaa773e0e32d3a87bf742ebaecae7d064e190443a3acddfd8afb181"
 CHKUPDATE="anitya::id=13287"

--- a/app-network/lighttpd/spec
+++ b/app-network/lighttpd/spec
@@ -1,5 +1,5 @@
 VER=1.4.55
-REL=2
+REL=3
 SRCS="tbl::https://download.lighttpd.net/lighttpd/releases-${VER%.*}.x/lighttpd-$VER.tar.xz"
 CHKSUMS="sha256::6a0b50e9c9d5cc3d9e48592315c25a2d645858f863e1ccd120507a30ce21e927"
 CHKUPDATE="anitya::id=1817"

--- a/app-network/realmd/spec
+++ b/app-network/realmd/spec
@@ -1,4 +1,5 @@
 VER="0.17.1"
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/realmd/realmd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4175"

--- a/app-network/samba/spec
+++ b/app-network/samba/spec
@@ -1,5 +1,5 @@
 VER=4.17.2
-REL=2
+REL=3
 SRCS="tbl::https://download.samba.org/pub/samba/stable/samba-$VER.tar.gz"
 CHKSUMS="sha256::e55ddf4d5178f8c84316abf53c5edd7b35399e3b7d86bcb81b75261c827bb3b8"
 CHKUPDATE="anitya::id=4758"

--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,5 +1,5 @@
 VER=7.5.4.2
-REL=3
+REL=4
 SRCS="tbl::https://download.documentfoundation.org/libreoffice/src/${VER:0:5}/libreoffice-$VER.tar.xz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz \

--- a/app-utils/nfs-utils/spec
+++ b/app-utils/nfs-utils/spec
@@ -1,5 +1,5 @@
 VER=2.6.2
-REL=1
+REL=2
 SRCS="tbl::https://sourceforge.net/projects/nfs/files/nfs-utils/$VER/nfs-utils-$VER.tar.gz"
 CHKSUMS="sha256::2d8820583dd6a806cd8034d32d890c049a552c58c671a9021cb5d0271bb59eee"
 CHKUPDATE="anitya::id=2081"

--- a/app-web/dovecot/spec
+++ b/app-web/dovecot/spec
@@ -1,5 +1,5 @@
 VER=2.3.10.1
-REL=3
+REL=4
 SRCS="tbl::https://dovecot.org/releases/${VER:0:3}/dovecot-$VER.tar.gz"
 CHKSUMS="sha256::6642e62f23b1b23cfac235007ca6e21cb67460cca834689fad450724456eb10c"
 CHKUPDATE="anitya::id=456"

--- a/app-web/exim/spec
+++ b/app-web/exim/spec
@@ -1,4 +1,5 @@
 VER=4.97.1
+REL=1
 SRCS="git::commit=exim-$VER;copy-repo=true::https://github.com/Exim/exim"
 CHKSUMS="SKIP"
 SUBDIR="exim/src"

--- a/app-web/httpd/spec
+++ b/app-web/httpd/spec
@@ -1,4 +1,5 @@
 VER=2.4.58
+REL=1
 SRCS="tbl::http://archive.apache.org/dist/httpd/httpd-$VER.tar.bz2"
 CHKSUMS="sha256::fa16d72a078210a54c47dd5bef2f8b9b8a01d94909a51453956b3ec6442ea4c5"
 CHKUPDATE="anitya::id=1335"

--- a/app-web/postfix/spec
+++ b/app-web/postfix/spec
@@ -1,5 +1,5 @@
 VER=3.7.3
-REL=3
+REL=4
 SRCS="tbl::https://de.postfix.org/ftpmirror/official/postfix-$VER.tar.gz"
 CHKSUMS="sha256::d22f3d37ef75613d5d573b56fc51ef097f2c0d0b0e407923711f71c1fb72911b"
 CHKUPDATE="anitya::id=3693"

--- a/app-web/squid/spec
+++ b/app-web/squid/spec
@@ -1,7 +1,5 @@
 VER=5.7
-REL=2
-REL=2
+REL=3
 SRCS="tbl::http://www.squid-cache.org/Versions/v5/squid-${VER}.tar.xz"
 CHKSUMS="sha256::6b0753aaba4c9c4efd333e67124caecf7ad6cc2d38581f19d2f0321f5b7ecd81"
 CHKUPDATE="anitya::id=4880"
-REL=2

--- a/desktop-gnome/balsa/spec
+++ b/desktop-gnome/balsa/spec
@@ -2,4 +2,4 @@ VER=2.6.3
 SRCS="tbl::https://pawsa.fedorapeople.org/balsa/balsa-$VER.tar.xz"
 CHKSUMS="sha256::d4d04576c9a5026064f7d480b34531faf59543f2e4d57c48a6fa5c76661e1dd4"
 CHKUPDATE="anitya::id=8920"
-REL=1
+REL=2

--- a/desktop-gnome/evolution-data-server/spec
+++ b/desktop-gnome/evolution-data-server/spec
@@ -1,4 +1,5 @@
 VER=3.44.4
+REL=1
 SRCS="https://download.gnome.org/sources/evolution-data-server/${VER:0:4}/evolution-data-server-$VER.tar.xz"
 CHKSUMS="sha256::c0c6658838d58ba46042a4b9e50a3bb1129691e4cdb84b5eba0bf330b2ccb2eb"
 CHKUPDATE="anitya::id=10935"

--- a/desktop-gnome/evolution/spec
+++ b/desktop-gnome/evolution/spec
@@ -1,5 +1,5 @@
 VER=3.44.4
-REL=3
+REL=4
 SRCS="https://download.gnome.org/sources/evolution/${VER:0:4}/evolution-$VER.tar.xz"
 CHKSUMS="sha256::f0b16e7abad3c7945a29c322f17dab4a08d61e99bd7cc91b8df35053c5c12e8c"
 CHKUPDATE="anitya::id=10934"

--- a/desktop-gnome/seahorse/spec
+++ b/desktop-gnome/seahorse/spec
@@ -1,4 +1,5 @@
 VER=42.0
+REL=1
 SRCS="https://download.gnome.org/sources/seahorse/${VER:0:2}/seahorse-${VER/\~/.}.tar.xz"
 CHKSUMS="sha256::c50cacebf8de7a7e2e5f1dae0b98232114741296abe8d543e3923d62a153d630"
 CHKUPDATE="anitya::id=9548"

--- a/desktop-kde/kldap/spec
+++ b/desktop-kde/kldap/spec
@@ -1,4 +1,5 @@
 VER=22.08.3
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kldap-$VER.tar.xz"
 CHKSUMS="sha256::74d0b24f4c1d93ab8c7c149242c54ea5322468ba29f2bdb8845d2fd96bba4d9a"
 CHKUPDATE="anitya::id=8763"

--- a/desktop-trinity/tdebase/autobuild/defines
+++ b/desktop-trinity/tdebase/autobuild/defines
@@ -52,3 +52,6 @@ PKGCONFL="plasma-desktop drkonqi kate kcmutils kde-baseapps \
 NOLTO__LOONGSON3=1
 
 NOLIBTOOL=0
+
+# FIXME: #error "Unknown CPU architecture" in nsplugins/sdk/prcpucfg.h
+FAIL_ARCH="loongarch64"

--- a/desktop-trinity/tdebase/spec
+++ b/desktop-trinity/tdebase/spec
@@ -1,5 +1,5 @@
 VER=14.1.0
-REL=1
+REL=2
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/core/tdebase-trinity-$VER.tar.xz"
 CHKSUMS="sha256::ddbfd0de7eac798c08332d74071439c2de027490dbb79aed245a26d9d9634938"
 CHKUPDATE="anitya::id=16065"

--- a/runtime-common/apr-util/spec
+++ b/runtime-common/apr-util/spec
@@ -1,5 +1,5 @@
 VER=1.6.1
-REL=7
+REL=8
 SRCS="tbl::https://archive.apache.org/dist/apr/apr-util-$VER.tar.gz"
 CHKSUMS="sha256::b65e40713da57d004123b6319828be7f1273fbc6490e145874ee1177e112c459"
 CHKUPDATE="anitya::id=96"

--- a/runtime-cryptography/opencryptoki/spec
+++ b/runtime-cryptography/opencryptoki/spec
@@ -1,5 +1,5 @@
 VER=3.21.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/opencryptoki/opencryptoki"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=112179"

--- a/runtime-doc/cups-filters/spec
+++ b/runtime-doc/cups-filters/spec
@@ -1,4 +1,5 @@
 VER=2.0.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/OpenPrinting/cups-filters"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5541"


### PR DESCRIPTION
Topic Description
-----------------

- gconf: bump REL due to openldap SONAME change
- samba: bump REL due to openldap SONAME change
- ldb: bump REL due to openldap SONAME change
- libreoffice: bump REL due to openldap SONAME change
- cyrus-sasl: bump REL due to openldap SONAME change
- krb5: bump REL due to openldap SONAME change
- yubico-pam: bump REL due to openldap SONAME change
- tdebase: bump REL due to openldap SONAME change
- sssd: bump REL due to openldap SONAME change
- squid: bump REL due to openldap SONAME change

... and 22 more commits

Package(s) Affected
-------------------

- apr-util: 1.6.1-8
- audit: 3.1-1
- autofs: 5.1.8-3
- balsa: 2.6.3-2
- cups-browsed: 2.0.0-1
- cups-filters: 2.0.0-1
- cyrus-sasl: 2.1.27-9
- dovecot: 2.3.10.1-4
- evolution-data-server: 3.44.4-1
- evolution: 3.44.4-4
- exim: 4.97.1-1
- gconf: 3.2.6-6
- gnupg: 1:2.4.4-3
- httpd: 2.4.58-1
- kldap: 22.08.3-1
- krb5: 1.17.1-8
- ldb : 2:2.6.1-2
- libreoffice: 7.5.4.2-4
- lighttpd: 1.4.55-3
- nfs-utils: 2.6.2-2
- opencryptoki: 3.21.0-2
- openldap: 2.6.7
- php: 1:8.3.3-1
- postfix: 3.7.3-4
- quota-tools: 4.09-1
- realmd: 0.17.1-1
- samba: 4.17.2-3
- seahorse: 42.0-1
- squid: 5.7-3
- sssd: 2.9.4-1
- tdebase: 14.1.0-2
- yubico-pam: 2.26-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit openldap:-pkgbreak apr-util krb5 evolution-data-server nfs-utils audit autofs balsa cups-browsed cups-filters dovecot evolution exim gnupg httpd cyrus-sasl kldap lighttpd opencryptoki postfix php quota-tools ldb samba realmd seahorse squid sssd tdebase yubico-pam libreoffice gconf openldap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
