### PR TITLE
openssl-1.1: update to 1.1.1w

### DIFF
--- a/runtime-cryptography/openssl-1.1/spec
+++ b/runtime-cryptography/openssl-1.1/spec
@@ -1,5 +1,4 @@
-VER=1.1.1q
-REL=2
+VER=1.1.1w
 SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca"
+CHKSUMS="sha256::cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8"
 CHKUPDATE="anitya::id=2566"


### PR DESCRIPTION
Topic Description
-----------------

- openssl-1.1: update to 1.1.1w

Package(s) Affected
-------------------

- openssl-1.1: 1.1.1w

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl-1.1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
