### PR TITLE
libcap: update to 2.69

### DIFF
--- a/runtime-common/libcap/spec
+++ b/runtime-common/libcap/spec
@@ -1,5 +1,4 @@
-VER=2.43
-REL=3
+VER=2.69
 SRCS="tbl::https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-$VER.tar.xz"
-CHKSUMS="sha256::512a0e5fc4c1e06d472a20da26aa96a9b9bf2a26b23f094f77f1b8da56cc427f"
+CHKSUMS="sha256::f311f8f3dad84699d0566d1d6f7ec943a9298b28f714cae3c931dfd57492d7eb"
 CHKUPDATE="anitya::id=1569"


### PR DESCRIPTION
Topic Description
-----------------

- libcap: update to 2.69

Package(s) Affected
-------------------

- libcap: 2.69

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
