### PR TITLE
system-config-printer: fix .ui data installation path

### DIFF
--- a/app-admin/system-config-printer/01-runtime/beyond
+++ b/app-admin/system-config-printer/01-runtime/beyond
@@ -12,23 +12,15 @@ abinfo "Splitting out system-config-printer GUI ..."
 # installing the GUI by default, the system has two GUI applications for
 # printer management, which is not desirable.
 mkdir -pv "$SRCDIR"/guidir/etc/xdg/autostart
-mkdir -pv "$SRCDIR"/guidir/usr/{bin,share/{applications,man/man1,metainfo,system-config-printer/{__pycache__,xml,ui}}}
+mkdir -pv "$SRCDIR"/guidir/usr/{bin,share/{applications,man/man1,metainfo,system-config-printer/}}
 for i in \
     "$PKGDIR"/usr/bin/system-config-printer-applet \
-    "$PKGDIR"/usr/share/system-config-printer/__pycache__/applet* \
     "$PKGDIR"/usr/share/system-config-printer/applet.py* \
     "$PKGDIR"/etc/xdg/autostart/print-applet.desktop \
     "$PKGDIR"/usr/share/man/man1/system-config-printer-applet.1* \
     "$PKGDIR"/usr/bin/system-config-printer \
     "$PKGDIR"/usr/bin/install-printerdriver \
-    "$PKGDIR"/usr/share/system-config-printer/__pycache__/check-device-ids* \
-    "$PKGDIR"/usr/share/system-config-printer/__pycache__/HIG* \
-    "$PKGDIR"/usr/share/system-config-printer/__pycache__/SearchCriterion* \
-    "$PKGDIR"/usr/share/system-config-printer/__pycache__/serversettings* \
-    "$PKGDIR"/usr/share/system-config-printer/__pycache__/system-config-printer* \
-    "$PKGDIR"/usr/share/system-config-printer/__pycache__/ToolbarSearchEntry* \
-    "$PKGDIR"/usr/share/system-config-printer/__pycache__/userdefault* \
-    "$PKGDIR"/usr/share/system-config-printer/__pycache__/install-printerdriver* \
+    "$PKGDIR"/usr/share/system-config-printer/__pycache__ \
     "$PKGDIR"/usr/share/system-config-printer/check-device-ids.py* \
     "$PKGDIR"/usr/share/system-config-printer/HIG.py* \
     "$PKGDIR"/usr/share/system-config-printer/SearchCriterion.py* \
@@ -39,8 +31,7 @@ for i in \
     "$PKGDIR"/usr/share/system-config-printer/troubleshoot \
     "$PKGDIR"/usr/share/system-config-printer/icons \
     "$PKGDIR"/usr/share/system-config-printer/install-printerdriver.py* \
-    "$PKGDIR"/usr/share/system-config-printer/xml/__pycache__ \
-    "$PKGDIR"/usr/share/system-config-printer/xml/validate.py* \
+    "$PKGDIR"/usr/share/system-config-printer/xml \
     "$PKGDIR"/usr/share/system-config-printer/ui \
     "$PKGDIR"/usr/share/applications/system-config-printer.desktop \
     "$PKGDIR"/usr/share/metainfo/system-config-printer.appdata.xml \

--- a/app-admin/system-config-printer/01-runtime/prepare
+++ b/app-admin/system-config-printer/01-runtime/prepare
@@ -1,0 +1,4 @@
+# FIXME: (from Fedora) workaround https://github.com/pypa/setuptools/issues/3143
+abinfo "Fixing setup.py invocation ..."
+sed -e 's/setup.py install --prefix=$(DESTDIR)$(prefix)/setup.py install --root $(DESTDIR) --prefix=$(prefix)/' \
+    -i "$SRCDIR"/Makefile*

--- a/app-admin/system-config-printer/spec
+++ b/app-admin/system-config-printer/spec
@@ -1,4 +1,5 @@
 VER=1.5.17
+REL=1
 SRCS="https://github.com/OpenPrinting/system-config-printer/releases/download/v$VER/system-config-printer-$VER.tar.xz"
 CHKSUMS="sha256::dc9c8ad03f7983962ddf0ef05621c948370bd1763cd90c3dcff672280aa2d6e6"
 CHKUPDATE="anitya::id=8855"


### PR DESCRIPTION
Topic Description
-----------------

- system-config-printer: fix .ui data installation path
    Also fix setup.py invocation during make install.
    Ref: https://github.com/pypa/setuptools/issues/3143

Package(s) Affected
-------------------

- system-config-printer-runtime: 1.5.17-1
- system-config-printer: 1.5.17-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit system-config-printer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
