### PR TITLE
colord: apply usability fixes

### DIFF
--- a/app-admin/colord/autobuild/overrides/usr/lib/sysusers.d/colord.conf
+++ b/app-admin/colord/autobuild/overrides/usr/lib/sysusers.d/colord.conf
@@ -1,2 +1,3 @@
-g    colord  124
-u    colord  124:124 "Color Daemon Owner" /var/lib/colord  /bin/false
+g colord 124
+u colord 124:124 "Color Daemon Owner" /var/lib/colord  /bin/false
+m colord lp

--- a/app-admin/colord/autobuild/patches/0001-Fix-writing-to-the-database-with-ProtectSystem-stric.patch
+++ b/app-admin/colord/autobuild/patches/0001-Fix-writing-to-the-database-with-ProtectSystem-stric.patch
@@ -1,0 +1,28 @@
+From 1acc580fbc845057fb07fb5f71b0c452b07e558f Mon Sep 17 00:00:00 2001
+From: Richard Hughes <richard@hughsie.com>
+Date: Mon, 29 Jan 2024 10:37:11 +0000
+Subject: [PATCH 1/5] Fix writing to the database with ProtectSystem=strict
+
+Fixes https://github.com/hughsie/colord/issues/166
+---
+ data/colord.service.in | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/data/colord.service.in b/data/colord.service.in
+index 6825d94..c358dc4 100644
+--- a/data/colord.service.in
++++ b/data/colord.service.in
+@@ -17,6 +17,10 @@ ProtectControlGroups=true
+ RestrictRealtime=true
+ RestrictAddressFamilies=AF_UNIX
+ 
++ConfigurationDirectory=colord
++StateDirectory=colord
++CacheDirectory=colord
++
+ # drop all capabilities
+ CapabilityBoundingSet=~CAP_SETUID CAP_SETGID CAP_SETPCAP CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_IPC_OWNER CAP_NET_ADMIN CAP_SYS_RAWIO CAP_SYS_TIME CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE CAP_KILL CAP_MKNOD CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SYS_NICE CAP_SYS_RESOURCE CAP_MAC_ADMIN CAP_MAC_OVERRIDE CAP_SYS_BOOT CAP_LINUX_IMMUTABLE CAP_IPC_LOCK CAP_SYS_CHROOT CAP_BLOCK_SUSPEND CAP_LEASE CAP_SYS_PACCT CAP_SYS_TTY_CONFIG CAP_WAKE_ALARM
+ 
+-- 
+2.44.0
+

--- a/app-admin/colord/autobuild/patches/0002-Fix-USB-scanners-not-working-with-RestrictAddressFam.patch
+++ b/app-admin/colord/autobuild/patches/0002-Fix-USB-scanners-not-working-with-RestrictAddressFam.patch
@@ -1,0 +1,31 @@
+From e4a236ba3015531ca0a5b412362f1f789be6bcad Mon Sep 17 00:00:00 2001
+From: Ferdinand Bachmann <ferdinand.bachmann@yrlf.at>
+Date: Tue, 30 Jan 2024 12:44:18 +0100
+Subject: [PATCH 2/5] Fix USB scanners not working with RestrictAddressFamilies
+
+colord-sane scanner drivers using libusb can't initialize properly with
+RestrictAddressFamilies set to AF_UNIX. Remove that line to ensure those
+can work properly.
+
+This also avoids a crash in HPLIP due to unchecked calls to libusb_init().
+
+Fixes #165
+---
+ data/colord.service.in | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/data/colord.service.in b/data/colord.service.in
+index c358dc4..45ec581 100644
+--- a/data/colord.service.in
++++ b/data/colord.service.in
+@@ -15,7 +15,6 @@ ProtectKernelModules=true
+ ProtectKernelLogs=true
+ ProtectControlGroups=true
+ RestrictRealtime=true
+-RestrictAddressFamilies=AF_UNIX
+ 
+ ConfigurationDirectory=colord
+ StateDirectory=colord
+-- 
+2.44.0
+

--- a/app-admin/colord/autobuild/patches/0003-fix-NULL-passed-to-free-with-sqlite3-error_msg-point.patch
+++ b/app-admin/colord/autobuild/patches/0003-fix-NULL-passed-to-free-with-sqlite3-error_msg-point.patch
@@ -1,0 +1,66 @@
+From 8d33df371c8bb76b831cbb58364c5aeb23269b88 Mon Sep 17 00:00:00 2001
+From: psykose <alice@ayaya.dev>
+Date: Thu, 8 Feb 2024 12:10:45 +0000
+Subject: [PATCH 3/5] fix NULL passed to free with sqlite3 error_msg pointers
+
+when an error does not happen, and an error_msg pointer is passed,
+sqlite does not touch it. that means this pointer is uninitialised
+(=NULL) which violates the constraints of g_autofree ("the variable must
+be initialized").
+
+this is then passed to g_free and crashes in tests.
+
+use a regular pointer and free it manually on error, after sqlite writes
+to it after setting it with sqlite_malloc.
+
+fixes https://github.com/hughsie/colord/issues/163
+---
+ src/cd-mapping-db.c | 3 ++-
+ src/cd-profile-db.c | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/cd-mapping-db.c b/src/cd-mapping-db.c
+index 996f07e..5ffd74d 100644
+--- a/src/cd-mapping-db.c
++++ b/src/cd-mapping-db.c
+@@ -67,7 +67,7 @@ cd_mapping_db_open (CdMappingDb *mdb,
+ 		    GError  **error)
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+-	g_autofree gchar *error_msg = NULL;
++	gchar *error_msg = NULL;
+ 	gint rc;
+ 	g_autofree gchar *path = NULL;
+ 
+@@ -97,6 +97,7 @@ cd_mapping_db_open (CdMappingDb *mdb,
+ 	if (rc != SQLITE_OK) {
+ 		/* Database appears to be mangled, so wipe it and try again */
+ 		sqlite3_close (priv->db);
++		sqlite3_free(error_msg);
+ 		priv->db = NULL;
+ 
+ 		if (retry) {
+diff --git a/src/cd-profile-db.c b/src/cd-profile-db.c
+index 57ab864..e5b74e3 100644
+--- a/src/cd-profile-db.c
++++ b/src/cd-profile-db.c
+@@ -48,7 +48,7 @@ cd_profile_db_load (CdProfileDb *pdb,
+ {
+ 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
+ 	const gchar *statement;
+-	g_autofree gchar *error_msg = NULL;
++	gchar *error_msg = NULL;
+ 	gint rc;
+ 	g_autofree gchar *path = NULL;
+ 
+@@ -69,6 +69,7 @@ cd_profile_db_load (CdProfileDb *pdb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "Can't open database: %s\n",
+ 			     sqlite3_errmsg (priv->db));
++		sqlite3_free (error_msg);
+ 		sqlite3_close (priv->db);
+ 		return FALSE;
+ 	}
+-- 
+2.44.0
+

--- a/app-admin/colord/autobuild/patches/0004-use-char-instead-of-gchar-for-pointers-passed-to-sql.patch
+++ b/app-admin/colord/autobuild/patches/0004-use-char-instead-of-gchar-for-pointers-passed-to-sql.patch
@@ -1,0 +1,225 @@
+From 1413602a0ac225665888a02d8fab4143ef60993b Mon Sep 17 00:00:00 2001
+From: psykose <alice@ayaya.dev>
+Date: Thu, 8 Feb 2024 13:12:41 +0000
+Subject: [PATCH 4/5] use char * instead of gchar * for pointers passed to
+ sqlite3_exec
+
+---
+ src/cd-device-db.c  | 16 ++++++++--------
+ src/cd-mapping-db.c | 18 +++++++++---------
+ src/cd-profile-db.c | 10 +++++-----
+ 3 files changed, 22 insertions(+), 22 deletions(-)
+
+diff --git a/src/cd-device-db.c b/src/cd-device-db.c
+index 3ae44ef..ac87a52 100644
+--- a/src/cd-device-db.c
++++ b/src/cd-device-db.c
+@@ -48,7 +48,7 @@ cd_device_db_load (CdDeviceDb *ddb,
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+ 	const gchar *statement;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gint rc;
+ 	g_autofree gchar *path = NULL;
+ 
+@@ -109,7 +109,7 @@ cd_device_db_empty (CdDeviceDb *ddb,
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+ 	const gchar *statement;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gint rc;
+ 
+ 	g_return_val_if_fail (CD_IS_DEVICE_DB (ddb), FALSE);
+@@ -137,7 +137,7 @@ cd_device_db_add (CdDeviceDb *ddb,
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+ 	gboolean ret = TRUE;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 
+@@ -175,7 +175,7 @@ cd_device_db_set_property (CdDeviceDb *ddb,
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+ 	gboolean ret = TRUE;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 
+@@ -212,7 +212,7 @@ cd_device_db_remove (CdDeviceDb *ddb,
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+ 	gboolean ret = TRUE;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement1 = NULL;
+ 	gchar *statement2 = NULL;
+ 	gint rc;
+@@ -277,7 +277,7 @@ cd_device_db_get_property (CdDeviceDb *ddb,
+ 			   GError  **error)
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	gchar *value = NULL;
+@@ -331,7 +331,7 @@ cd_device_db_get_devices (CdDeviceDb *ddb,
+ 			  GError  **error)
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	GPtrArray *array = NULL;
+@@ -372,7 +372,7 @@ cd_device_db_get_properties (CdDeviceDb *ddb,
+ 			     GError  **error)
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	GPtrArray *array = NULL;
+diff --git a/src/cd-mapping-db.c b/src/cd-mapping-db.c
+index 5ffd74d..291274a 100644
+--- a/src/cd-mapping-db.c
++++ b/src/cd-mapping-db.c
+@@ -67,7 +67,7 @@ cd_mapping_db_open (CdMappingDb *mdb,
+ 		    GError  **error)
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gint rc;
+ 	g_autofree gchar *path = NULL;
+ 
+@@ -131,7 +131,7 @@ cd_mapping_db_load (CdMappingDb *mdb,
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+ 	const gchar *statement;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gint rc;
+ 	g_autofree gchar *path = NULL;
+ 
+@@ -230,7 +230,7 @@ cd_mapping_db_empty (CdMappingDb *mdb,
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+ 	const gchar *statement;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gint rc;
+ 
+ 	g_return_val_if_fail (CD_IS_MAPPING_DB (mdb), FALSE);
+@@ -259,7 +259,7 @@ cd_mapping_db_add (CdMappingDb *mdb,
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+ 	gboolean ret = TRUE;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	gint64 timestamp;
+@@ -307,7 +307,7 @@ cd_mapping_db_clear_timestamp (CdMappingDb *mdb,
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+ 	gboolean ret = TRUE;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 
+@@ -351,7 +351,7 @@ cd_mapping_db_remove (CdMappingDb *mdb,
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+ 	gboolean ret = TRUE;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 
+@@ -406,7 +406,7 @@ cd_mapping_db_get_profiles (CdMappingDb *mdb,
+ 			    GError  **error)
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	GPtrArray *array = NULL;
+@@ -456,7 +456,7 @@ cd_mapping_db_get_devices (CdMappingDb *mdb,
+ 			   GError  **error)
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	GPtrArray *array = NULL;
+@@ -522,7 +522,7 @@ cd_mapping_db_get_timestamp (CdMappingDb *mdb,
+ 			     GError  **error)
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	guint64 timestamp = G_MAXUINT64;
+diff --git a/src/cd-profile-db.c b/src/cd-profile-db.c
+index e5b74e3..124fa09 100644
+--- a/src/cd-profile-db.c
++++ b/src/cd-profile-db.c
+@@ -48,7 +48,7 @@ cd_profile_db_load (CdProfileDb *pdb,
+ {
+ 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
+ 	const gchar *statement;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gint rc;
+ 	g_autofree gchar *path = NULL;
+ 
+@@ -98,7 +98,7 @@ cd_profile_db_empty (CdProfileDb *pdb, GError **error)
+ {
+ 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
+ 	const gchar *statement;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gint rc;
+ 
+ 	g_return_val_if_fail (CD_IS_PROFILE_DB (pdb), FALSE);
+@@ -129,7 +129,7 @@ cd_profile_db_set_property (CdProfileDb *pdb,
+ {
+ 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
+ 	gboolean ret = TRUE;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 
+@@ -169,7 +169,7 @@ cd_profile_db_remove (CdProfileDb *pdb,
+ {
+ 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
+ 	gboolean ret = TRUE;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement = NULL;
+ 	gint rc;
+ 
+@@ -223,7 +223,7 @@ cd_profile_db_get_property (CdProfileDb *pdb,
+ {
+ 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
+ 	gboolean ret = TRUE;
+-	gchar *error_msg = NULL;
++	char *error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 
+-- 
+2.44.0
+

--- a/app-admin/colord/autobuild/patches/0005-use-g_autoptr-again-but-with-a-custom-CLEANUP_FUNC.patch
+++ b/app-admin/colord/autobuild/patches/0005-use-g_autoptr-again-but-with-a-custom-CLEANUP_FUNC.patch
@@ -1,0 +1,395 @@
+From 5665a440aabc7ba778588ee7e8806069338d7d44 Mon Sep 17 00:00:00 2001
+From: psykose <alice@ayaya.dev>
+Date: Mon, 12 Feb 2024 14:59:42 +0000
+Subject: [PATCH 5/5] use g_autoptr again but with a custom CLEANUP_FUNC
+
+my prior analysis was completely wrong, and the original crash was seen
+because sqlite3_malloc pointers passed to g_free cause a mismatched
+malloc/free, not because of lack of initialisation.
+
+use autoptr with an overriden CLEANUP_FUNC instead. for
+cd_mapping_db_load/cd_device_db_remove, keep using manual sqlite3_free
+since we reuse the same error_msg multiple times.
+---
+ src/cd-common.h     |  3 +++
+ src/cd-device-db.c  | 21 +++++++--------------
+ src/cd-mapping-db.c | 24 ++++++++----------------
+ src/cd-profile-db.c | 15 +++++----------
+ 4 files changed, 23 insertions(+), 40 deletions(-)
+
+diff --git a/src/cd-common.h b/src/cd-common.h
+index adf9343..c60061a 100644
+--- a/src/cd-common.h
++++ b/src/cd-common.h
+@@ -26,6 +26,7 @@
+ 
+ #include <gio/gio.h>
+ #include <colord-private.h>
++#include <sqlite3.h>
+ 
+ #define COLORD_DBUS_SERVICE		"org.freedesktop.ColorManager"
+ #define COLORD_DBUS_PATH		"/org/freedesktop/ColorManager"
+@@ -37,6 +38,8 @@
+ #define CD_DBUS_METADATA_KEY_LEN_MAX	256	/* chars */
+ #define CD_DBUS_METADATA_VALUE_LEN_MAX	4096	/* chars */
+ 
++typedef char sqlite_str;
++G_DEFINE_AUTOPTR_CLEANUP_FUNC (sqlite_str, sqlite3_free)
+ 
+ #define CD_CLIENT_ERROR			cd_client_error_quark()
+ 
+diff --git a/src/cd-device-db.c b/src/cd-device-db.c
+index ac87a52..e97c882 100644
+--- a/src/cd-device-db.c
++++ b/src/cd-device-db.c
+@@ -48,7 +48,7 @@ cd_device_db_load (CdDeviceDb *ddb,
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+ 	const gchar *statement;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gint rc;
+ 	g_autofree gchar *path = NULL;
+ 
+@@ -82,7 +82,6 @@ cd_device_db_load (CdDeviceDb *ddb,
+ 			   NULL, NULL, &error_msg);
+ 	if (rc != SQLITE_OK) {
+ 		g_debug ("CdDeviceDb: creating table to repair: %s", error_msg);
+-		sqlite3_free (error_msg);
+ 		statement = "CREATE TABLE devices ("
+ 			    "device_id TEXT PRIMARY KEY,"
+ 			    "device TEXT);";
+@@ -109,7 +108,7 @@ cd_device_db_empty (CdDeviceDb *ddb,
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+ 	const gchar *statement;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gint rc;
+ 
+ 	g_return_val_if_fail (CD_IS_DEVICE_DB (ddb), FALSE);
+@@ -124,7 +123,6 @@ cd_device_db_empty (CdDeviceDb *ddb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		return FALSE;
+ 	}
+ 	return TRUE;
+@@ -137,7 +135,7 @@ cd_device_db_add (CdDeviceDb *ddb,
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+ 	gboolean ret = TRUE;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 
+@@ -157,7 +155,6 @@ cd_device_db_add (CdDeviceDb *ddb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		ret = FALSE;
+ 		goto out;
+ 	}
+@@ -175,7 +172,7 @@ cd_device_db_set_property (CdDeviceDb *ddb,
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+ 	gboolean ret = TRUE;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 
+@@ -196,7 +193,6 @@ cd_device_db_set_property (CdDeviceDb *ddb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		ret = FALSE;
+ 		goto out;
+ 	}
+@@ -277,7 +273,7 @@ cd_device_db_get_property (CdDeviceDb *ddb,
+ 			   GError  **error)
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	gchar *value = NULL;
+@@ -305,7 +301,6 @@ cd_device_db_get_property (CdDeviceDb *ddb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		goto out;
+ 	}
+ 
+@@ -331,7 +326,7 @@ cd_device_db_get_devices (CdDeviceDb *ddb,
+ 			  GError  **error)
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	GPtrArray *array = NULL;
+@@ -355,7 +350,6 @@ cd_device_db_get_devices (CdDeviceDb *ddb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		goto out;
+ 	}
+ 
+@@ -372,7 +366,7 @@ cd_device_db_get_properties (CdDeviceDb *ddb,
+ 			     GError  **error)
+ {
+ 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	GPtrArray *array = NULL;
+@@ -398,7 +392,6 @@ cd_device_db_get_properties (CdDeviceDb *ddb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		goto out;
+ 	}
+ 
+diff --git a/src/cd-mapping-db.c b/src/cd-mapping-db.c
+index 291274a..edf944c 100644
+--- a/src/cd-mapping-db.c
++++ b/src/cd-mapping-db.c
+@@ -67,7 +67,7 @@ cd_mapping_db_open (CdMappingDb *mdb,
+ 		    GError  **error)
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gint rc;
+ 	g_autofree gchar *path = NULL;
+ 
+@@ -97,7 +97,6 @@ cd_mapping_db_open (CdMappingDb *mdb,
+ 	if (rc != SQLITE_OK) {
+ 		/* Database appears to be mangled, so wipe it and try again */
+ 		sqlite3_close (priv->db);
+-		sqlite3_free(error_msg);
+ 		priv->db = NULL;
+ 
+ 		if (retry) {
+@@ -230,7 +229,7 @@ cd_mapping_db_empty (CdMappingDb *mdb,
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+ 	const gchar *statement;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gint rc;
+ 
+ 	g_return_val_if_fail (CD_IS_MAPPING_DB (mdb), FALSE);
+@@ -245,7 +244,6 @@ cd_mapping_db_empty (CdMappingDb *mdb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		return FALSE;
+ 	}
+ 	return TRUE;
+@@ -259,7 +257,7 @@ cd_mapping_db_add (CdMappingDb *mdb,
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+ 	gboolean ret = TRUE;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	gint64 timestamp;
+@@ -282,7 +280,6 @@ cd_mapping_db_add (CdMappingDb *mdb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		ret = FALSE;
+ 		goto out;
+ 	}
+@@ -307,7 +304,7 @@ cd_mapping_db_clear_timestamp (CdMappingDb *mdb,
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+ 	gboolean ret = TRUE;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 
+@@ -328,7 +325,6 @@ cd_mapping_db_clear_timestamp (CdMappingDb *mdb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		ret = FALSE;
+ 		goto out;
+ 	}
+@@ -351,7 +347,7 @@ cd_mapping_db_remove (CdMappingDb *mdb,
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+ 	gboolean ret = TRUE;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 
+@@ -371,7 +367,6 @@ cd_mapping_db_remove (CdMappingDb *mdb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		ret = FALSE;
+ 		goto out;
+ 	}
+@@ -406,7 +401,7 @@ cd_mapping_db_get_profiles (CdMappingDb *mdb,
+ 			    GError  **error)
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	GPtrArray *array = NULL;
+@@ -433,7 +428,6 @@ cd_mapping_db_get_profiles (CdMappingDb *mdb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		goto out;
+ 	}
+ 
+@@ -456,7 +450,7 @@ cd_mapping_db_get_devices (CdMappingDb *mdb,
+ 			   GError  **error)
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	GPtrArray *array = NULL;
+@@ -483,7 +477,6 @@ cd_mapping_db_get_devices (CdMappingDb *mdb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		goto out;
+ 	}
+ 
+@@ -522,7 +515,7 @@ cd_mapping_db_get_timestamp (CdMappingDb *mdb,
+ 			     GError  **error)
+ {
+ 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 	guint64 timestamp = G_MAXUINT64;
+@@ -548,7 +541,6 @@ cd_mapping_db_get_timestamp (CdMappingDb *mdb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		goto out;
+ 	}
+ 
+diff --git a/src/cd-profile-db.c b/src/cd-profile-db.c
+index 124fa09..7d6b09a 100644
+--- a/src/cd-profile-db.c
++++ b/src/cd-profile-db.c
+@@ -48,7 +48,7 @@ cd_profile_db_load (CdProfileDb *pdb,
+ {
+ 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
+ 	const gchar *statement;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gint rc;
+ 	g_autofree gchar *path = NULL;
+ 
+@@ -69,7 +69,6 @@ cd_profile_db_load (CdProfileDb *pdb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "Can't open database: %s\n",
+ 			     sqlite3_errmsg (priv->db));
+-		sqlite3_free (error_msg);
+ 		sqlite3_close (priv->db);
+ 		return FALSE;
+ 	}
+@@ -98,7 +97,7 @@ cd_profile_db_empty (CdProfileDb *pdb, GError **error)
+ {
+ 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
+ 	const gchar *statement;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gint rc;
+ 
+ 	g_return_val_if_fail (CD_IS_PROFILE_DB (pdb), FALSE);
+@@ -113,7 +112,6 @@ cd_profile_db_empty (CdProfileDb *pdb, GError **error)
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		return FALSE;
+ 	}
+ 	return TRUE;
+@@ -129,7 +127,7 @@ cd_profile_db_set_property (CdProfileDb *pdb,
+ {
+ 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
+ 	gboolean ret = TRUE;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 
+@@ -151,7 +149,6 @@ cd_profile_db_set_property (CdProfileDb *pdb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		ret = FALSE;
+ 		goto out;
+ 	}
+@@ -169,7 +166,7 @@ cd_profile_db_remove (CdProfileDb *pdb,
+ {
+ 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
+ 	gboolean ret = TRUE;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement = NULL;
+ 	gint rc;
+ 
+@@ -190,7 +187,6 @@ cd_profile_db_remove (CdProfileDb *pdb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		ret = FALSE;
+ 		goto out;
+ 	}
+@@ -223,7 +219,7 @@ cd_profile_db_get_property (CdProfileDb *pdb,
+ {
+ 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
+ 	gboolean ret = TRUE;
+-	char *error_msg = NULL;
++	g_autoptr(sqlite_str) error_msg = NULL;
+ 	gchar *statement;
+ 	gint rc;
+ 
+@@ -250,7 +246,6 @@ cd_profile_db_get_property (CdProfileDb *pdb,
+ 			     CD_CLIENT_ERROR_INTERNAL,
+ 			     "SQL error: %s",
+ 			     error_msg);
+-		sqlite3_free (error_msg);
+ 		goto out;
+ 	}
+ out:
+-- 
+2.44.0
+

--- a/app-admin/colord/spec
+++ b/app-admin/colord/spec
@@ -1,4 +1,5 @@
 VER=1.4.7
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/hughsie/colord"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10190"


### PR DESCRIPTION
Topic Description
-----------------

- colord: apply usability fixes
    - Backport upstream patches to fix database access and SQLite crashes with
    newer versions of systemd and sqlite.
    - Add the colord daemon owner to lp group (for printer administration), this
    fixes errors in colord-sane such as the following:
    colord-sane[2688]: io/hpmud/musb.c 2099: Invalid usb_open: Permission denied

Package(s) Affected
-------------------

- colord: 1.4.7-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit colord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
