### PR TITLE
util-linux 20240401 rework

### DIFF
--- a/app-utils/util-linux/01-libraries/defines
+++ b/app-utils/util-linux/01-libraries/defines
@@ -160,7 +160,7 @@ AUTOTOOLS_AFTER="--localstatedir=/run \
                  --with-btrfs \
                  --with-systemd \
                  --without-smack \
-                 --with-econf \
+                 --without-econf \
                  --with-python=3 \
                  --with-cryptsetup"
 AUTOTOOLS_AFTER__RETRO=" \

--- a/app-utils/util-linux/spec
+++ b/app-utils/util-linux/spec
@@ -1,4 +1,5 @@
 VER=2.40
+REL=1
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/util-linux/v${VER:0:4}/util-linux-$VER.tar.xz"
 CHKSUMS="sha256::d57a626081f9ead02fa44c63a6af162ec19c58f53e993f206ab7c3a6641c2cd7"
 CHKUPDATE="anitya::id=8179"


### PR DESCRIPTION
Topic Description
-----------------

- util-linux: disable econf due to upstream bug
    See https://github.com/util-linux/util-linux/issues/2898

Package(s) Affected
-------------------

- util-linux-runtime: 2.40-1
- util-linux: 2.40-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit util-linux
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
