### PR TITLE
debootstrap: update to 1.0.134

### DIFF
--- a/app-utils/debootstrap/autobuild/build
+++ b/app-utils/debootstrap/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building debootstrap ..."
+make PREFIX=/usr
+
+abinfo "Install debootstrap ..."
+make install DESTDIR="$PKGDIR" PREFIX=/usr

--- a/app-utils/debootstrap/spec
+++ b/app-utils/debootstrap/spec
@@ -1,4 +1,4 @@
-VER=1.0.128
+VER=1.0.134
 CHKSUMS="SKIP"
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/installer-team/debootstrap"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- debootstrap: update to 1.0.134

Package(s) Affected
-------------------

- debootstrap: 1.0.134

Security Update?
----------------

No

Build Order
-----------

```
#buildit debootstrap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
