### PR TITLE
aosc-media-writer: new, 0.3.1

### DIFF
--- a/app-utils/aosc-media-writer/autobuild/defines
+++ b/app-utils/aosc-media-writer/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME="aosc-media-writer"
+PKGDES="Write .iso/raw images to portable boot media"
+PKGDEP="qt-6 adwaita-qt udisks-2 xz"
+PKGSEC="utils"

--- a/app-utils/aosc-media-writer/spec
+++ b/app-utils/aosc-media-writer/spec
@@ -1,0 +1,4 @@
+VER="0.3.1"
+SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/MediaWriter"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371926"


### PR DESCRIPTION
Topic Description
-----------------

- aosc-media-writer: new, 0.3.1

Package(s) Affected
-------------------

- aosc-media-writer: 0.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-media-writer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
