### PR TITLE
cups-filters: update to 2.0.0

### DIFF
--- a/app-admin/cups-browsed/autobuild/defines
+++ b/app-admin/cups-browsed/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=cups-browsed
+PKGDES="A daemon for browsing remote CUPS printers"
+PKGSEC=admin
+PKGDEP="cups libcupsfilters libppd avahi glib openldap"
+
+ABSHADOW=0

--- a/app-admin/cups-browsed/spec
+++ b/app-admin/cups-browsed/spec
@@ -1,0 +1,4 @@
+VER=2.0.0
+SRCS="git::commit=tags/$VER::https://github.com/OpenPrinting/cups-browsed"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=328190"

--- a/app-doc/qpdf/autobuild/defines
+++ b/app-doc/qpdf/autobuild/defines
@@ -1,7 +1,6 @@
 PKGNAME=qpdf
 PKGDES="Command-line programs and library for handling PDF files"
 PKGSEC=libs
-PKGDEP="pcre perl"
+PKGDEP="zlib libjpeg-turbo gnutls openssl"
 
-ABSHADOW=no
-PKGBREAK="cups-filters<=1.20.1"
+PKGBREAK="cups-filters<=1.28.9-1"

--- a/app-doc/qpdf/spec
+++ b/app-doc/qpdf/spec
@@ -1,5 +1,4 @@
-VER=10.2.0
-SRCS="https://github.com/qpdf/qpdf/releases/download/release-qpdf-$VER/qpdf-$VER.tar.gz"
-CHKSUMS="sha256::43ef260f4e70672660e1882856d59b9319301c6f170673ab465430a71cffe44c"
+VER=11.9.0
+SRCS="git::commit=tags/v$VER::https://github.com/qpdf/qpdf"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5542"
-REL=2

--- a/runtime-doc/cups-filters/autobuild/defines
+++ b/runtime-doc/cups-filters/autobuild/defines
@@ -1,13 +1,11 @@
 PKGNAME=cups-filters
 PKGDES="OpenPrinting CUPS Filters"
 PKGSEC=libs
-PKGDEP="cups qpdf lcms2 liblouis poppler brltty ijs"
+PKGDEP="cups libcupsfilters libppd"
+PKGRECOM="cups-browsed"
 PKGSUG="foomatic ghostscript php noto-fonts"
 BUILDDEP="ghostscript noto-fonts mupdf"
 
 ABSHADOW=0
-AUTOTOOLS_AFTER="--without-rcdir \
-                 --enable-avahi \
-                 --disable-static \
-                 --with-browseremoteprotocols=DNSSD,CUPS \
-                 --with-test-font-path=/usr/share/fonts/OTF/NotoSans-Regular.otf"
+AUTOTOOLS_AFTER="--enable-avahi \
+                 --disable-static"

--- a/runtime-doc/cups-filters/spec
+++ b/runtime-doc/cups-filters/spec
@@ -1,5 +1,4 @@
-VER=1.28.9
-SRCS="tbl::https://www.openprinting.org/download/cups-filters/cups-filters-$VER.tar.xz"
-CHKSUMS="sha256::2f69372a4fa76dc91e54b4c98ab4c65368e3dfbde92456205c98a39573e860ae"
+VER=2.0.0
+SRCS="git::commit=tags/$VER::https://github.com/OpenPrinting/cups-filters"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5541"
-REL=1

--- a/runtime-doc/libcupsfilters/autobuild/defines
+++ b/runtime-doc/libcupsfilters/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=libcupsfilters
+PKGDES="Runtime library for OpenPrinting CUPS filters"
+PKGSEC=libs
+PKGDEP="cups qpdf lcms2 poppler libexif fontconfig freetype libpng libtiff \
+        libjpeg-turbo dbus"
+PKGSUG="foomatic ghostscript php noto-fonts"
+BUILDDEP="ghostscript noto-fonts mupdf"
+
+AUTOTOOLS_AFTER="--disable-static"

--- a/runtime-doc/libcupsfilters/spec
+++ b/runtime-doc/libcupsfilters/spec
@@ -1,0 +1,4 @@
+VER=2.0.0
+SRCS="git::commit=tags/$VER::https://github.com/OpenPrinting/libcupsfilters"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=327181"

--- a/runtime-doc/libppd/autobuild/defines
+++ b/runtime-doc/libppd/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=libppd
+PKGDES="Support library for PPD files"
+PKGSEC=libs
+PKGDEP="cups libcupsfilters"
+BUILDDEP="ghostscript"
+
+AUTOTOOLS_AFTER="--disable-mutool"

--- a/runtime-doc/libppd/spec
+++ b/runtime-doc/libppd/spec
@@ -1,0 +1,4 @@
+VER=2.0.0
+SRCS="git::commit=tags/$VER::https://github.com/OpenPrinting/libppd"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=328127"


### PR DESCRIPTION
Topic Description
-----------------

- cups-filters: update to 2.0.0
- cups-browsed: new, 2.0.0
- libppd: new, 2.0.0
- libcupsfilters: new, 2.0.0
- qpdf: update to 11.9.0 with SONAME change

Package(s) Affected
-------------------

- cups-browsed: 2.0.0
- cups-filters: 2.0.0
- libcupsfilters: 2.0.0
- libppd: 2.0.0
- qpdf: 11.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit qpdf libcupsfilters libppd cups-browsed cups-filters
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
