### PR TITLE
less: disable --with-secure

### DIFF
--- a/app-utils/less/autobuild/defines
+++ b/app-utils/less/autobuild/defines
@@ -4,7 +4,6 @@ PKGDEP="glibc ncurses pcre2"
 PKGSEC=utils
 
 AUTOTOOLS_AFTER="--enable-largefile \
-                 --without-secure \
                  --with-regex=pcre2 \
                  --with-editor=editor"
 

--- a/app-utils/less/autobuild/defines
+++ b/app-utils/less/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="glibc ncurses pcre2"
 PKGSEC=utils
 
 AUTOTOOLS_AFTER="--enable-largefile \
-                 --with-secure \
+                 --without-secure \
                  --with-regex=pcre2 \
                  --with-editor=editor"
 

--- a/app-utils/less/spec
+++ b/app-utils/less/spec
@@ -1,4 +1,5 @@
 VER=643
+REL=1
 SRCS="http://www.greenwoodsoftware.com/less/less-$VER.tar.gz"
 CHKSUMS="sha256::2911b5432c836fa084c8a2e68f6cd6312372c026a58faaa98862731c8b6052e8"
 CHKUPDATE="anitya::id=1550"


### PR DESCRIPTION
Topic Description
-----------------

- less: disable --with-secure
    Breaks zless and xzless.
    Ref: https://github.com/orgs/AOSC-Dev/projects/17?pane=issue&itemId=56105790

Package(s) Affected
-------------------

- less: 1:643-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit less
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
