### PR TITLE
openssh (OpenSSH): use internal mkdtemp

### DIFF
--- a/app-network/openssh/autobuild/defines
+++ b/app-network/openssh/autobuild/defines
@@ -54,11 +54,13 @@ AUTOTOOLS_AFTER="--sysconfdir=/etc/ssh \
                  --without-ipaddr-display \
                  --with-4in6 \
                  --without-bsd-auth \
-                 --with-pid-dir=/run"
+                 --with-pid-dir=/run \
+                 ac_cv_func_mkdtemp=no"
 # FIXME: seccomp sandbox not supported on mips64r6el.
 AUTOTOOLS_AFTER__MIPS64R6EL=" \
                  ${AUTOTOOLS_AFTER} \
-                 --with-sandbox=no"
+                 --with-sandbox=no \
+                 ac_cv_func_mkdtemp=no"
 AUTOTOOLS_AFTER__RETRO=" \
                  ${AUTOTOOLS_AFTER} \
                  --without-ldns \

--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -1,4 +1,5 @@
 VER=9.6p1
+REL=1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
 CHKSUMS="sha256::910211c07255a8c5ad654391b40ee59800710dd8119dd5362de09385aa7a777c"
 CHKUPDATE="anitya::id=2565"


### PR DESCRIPTION
Topic Description
-----------------

- openssh: use internal mkdtemp
    This seems to bring better randomness into template string.
    Ref: https://bugs.debian.org/1001186

Package(s) Affected
-------------------

- openssh: 9.6p1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
