### PR TITLE
Desktop Recipe Survey (April, 2024)

### DIFF
--- a/app-scientific/vtk/autobuild/defines
+++ b/app-scientific/vtk/autobuild/defines
@@ -1,14 +1,11 @@
 PKGNAME=vtk
 PKGSEC=graphic
 PKGDES="The Visualization Toolkit, a software for manipulating and displaying scientific data"
-# TODO: Verify actual using of dependencies. They are: 
-# libharu ffmpeg utfcpp lapack
 PKGDEP="boost cgns double-conversion eigen-3 expat ffmpeg fmt freetype gdal \
-        gl2ps glew hdf5 jsoncpp lapack libarchive libglvnd libharu \
-        libjpeg-turbo libogg libpng libtheora libtiff libxml2 lz4 mesa netcdf \
-        openslide postgresql proj pugixml python-3 qt-5 sqlite utfcpp verdict \
-        x11-lib zlib xz mariadb"
-BUILDDEP="doxygen gnuplot graphviz motif nlohmann-json pyqt5 tcl tk"
+        gl2ps glew hdf5 jsoncpp lapack libarchive libglvnd libharu netcdf \
+        libjpeg-turbo libogg libpng libtheora libtiff libxml2 lz4 mesa \
+        openslide proj pugixml python-3 qt-5 sqlite verdict x11-lib zlib xz"
+BUILDDEP="doxygen gnuplot graphviz motif nlohmann-json pyqt5 tcl tk utfcpp"
 BUILDDEP__MIPS64R6EL="${BUILDDEP/doxygen gnuplot graphviz/}"
 
 CMAKE_AFTER="-DCMAKE_INSTALL_LICENSEDIR=share/doc/$PKGNAME \
@@ -40,7 +37,7 @@ CMAKE_AFTER="-DCMAKE_INSTALL_LICENSEDIR=share/doc/$PKGNAME \
              -DVTK_MODULE_ENABLE_VTK_ImagingOpenGL2=YES \
              -DVTK_MODULE_ENABLE_VTK_InfovisBoost=YES \
              -DVTK_MODULE_ENABLE_VTK_InfovisBoostGraphAlgorithms=YES \
-             -DVTK_MODULE_ENABLE_VTK_IOMySQL=YES"
+             -DVTK_MODULE_ENABLE_VTK_IOMySQL=NO"
 # FIXME: Takes way too long (literal days).
 CMAKE_AFTER__MIPS64R6EL=" \
              ${CMAKE_AFTER} \

--- a/app-scientific/vtk/autobuild/defines
+++ b/app-scientific/vtk/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=vtk
 PKGSEC=graphic
-PKGDES="The Visualization Toolkit, a software for manipulating and displaying scientific data"
+PKGDES="Software suite for manipulating and displaying scientific data"
 PKGDEP="boost cgns double-conversion eigen-3 expat ffmpeg fmt freetype gdal \
         gl2ps glew hdf5 jsoncpp lapack libarchive libglvnd libharu netcdf \
         libjpeg-turbo libogg libpng libtheora libtiff libxml2 lz4 mesa \

--- a/app-scientific/vtk/spec
+++ b/app-scientific/vtk/spec
@@ -1,4 +1,5 @@
 VER=9.3.0
+REL=1
 SRCS="tbl::https://www.vtk.org/files/release/${VER%.*}/VTK-$VER.tar.gz"
 CHKSUMS="sha256::fdc7b9295225b34e4fdddc49cd06e66e94260cb00efee456e0f66568c9681be9"
 CHKUPDATE="anitya::id=15084"

--- a/desktop-kde/digikam/autobuild/defines
+++ b/desktop-kde/digikam/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=kde
 PKGDEP="akonadi-contacts boost exiv2 expat ffmpeg glu imagemagick jasper \
         kcalcore kfilemetadata kiconthemes kio knotifications knotifyconfig \
         kio lcms2 lensfun libgphoto2 libheif libjpeg-turbo libksane liblqr \
-        libxml2 libxslt marble-runtime mariadb opencv qtav threadweaver x265"
+        libxml2 libxslt marble-runtime opencv qtav threadweaver x265"
 BUILDDEP="doxygen eigen-3 extra-cmake-modules graphviz kdoctools"
 PKGDES="Digital photo management application for KDE"
 
@@ -24,7 +24,7 @@ CMAKE_AFTER="-DBUILD_COVERAGE=OFF \
              -DENABLE_INTERNALMYSQL=ON \
              -DENABLE_KFILEMETADATASUPPORT=ON \
              -DENABLE_MEDIAPLAYER=ON \
-             -DENABLE_MYSQLSUPPORT=ON \
+             -DENABLE_MYSQLSUPPORT=OFF \
              -DENABLE_QWEBENGINE=ON \
              -DENABLE_SANITIZERS=OFF \
              -DKDE_INSTALL_PREFIX_SCRIPT=OFF \

--- a/desktop-kde/digikam/autobuild/patches/0001-feat-use-system-facesengine-data.patch
+++ b/desktop-kde/digikam/autobuild/patches/0001-feat-use-system-facesengine-data.patch
@@ -1,8 +1,17 @@
+From bd6ccff39ba5d774c635fc3f422884a90548d2d5 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 2 Apr 2024 18:22:22 +0800
+Subject: [PATCH 1/2] feat: use system facesengine data
+
+---
+ core/utilities/setup/downloader/filesdownloader.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
 diff --git a/core/utilities/setup/downloader/filesdownloader.cpp b/core/utilities/setup/downloader/filesdownloader.cpp
-index bfe2792236..98bcdb0a71 100644
+index 8083fa1c65..b786051d1e 100644
 --- a/core/utilities/setup/downloader/filesdownloader.cpp
 +++ b/core/utilities/setup/downloader/filesdownloader.cpp
-@@ -438,8 +438,7 @@ void FilesDownloader::slotDownloadProgress(qint64 bytesReceived, qint64 bytesTot
+@@ -449,8 +449,7 @@ void FilesDownloader::slotDownloadProgress(qint64 bytesReceived, qint64 bytesTot
  
  QString FilesDownloader::getFacesEnginePath() const
  {
@@ -12,3 +21,6 @@ index bfe2792236..98bcdb0a71 100644
      appUrl.setPath(appUrl.path() + QLatin1String("digikam/facesengine"));
  
      return appUrl.toLocalFile();
+-- 
+2.44.0
+

--- a/desktop-kde/digikam/autobuild/patches/0002-fix-compile-DNG-SDK-with-GCC13.patch
+++ b/desktop-kde/digikam/autobuild/patches/0002-fix-compile-DNG-SDK-with-GCC13.patch
@@ -1,18 +1,18 @@
-From 9c4fed4b5562c777fc6639ead9bcc95faacdb992 Mon Sep 17 00:00:00 2001
+From c159b6762de1015f8cddc7ba2c335f7e19a391c5 Mon Sep 17 00:00:00 2001
 From: Maik Qualmann <metzpinguin@gmail.com>
 Date: Sun, 26 Mar 2023 13:19:40 +0200
-Subject: [PATCH] fix compile DNG-SDK with GCC13
+Subject: [PATCH 2/2] fix compile DNG-SDK with GCC13
 
 ---
  core/libs/dngwriter/extra/dng_sdk/dng_string.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/core/libs/dngwriter/extra/dng_sdk/dng_string.cpp b/core/libs/dngwriter/extra/dng_sdk/dng_string.cpp
-index 4e76fc4c86..7814aff145 100644
+index fa58711216..dbd7e17bbc 100644
 --- a/core/libs/dngwriter/extra/dng_sdk/dng_string.cpp
 +++ b/core/libs/dngwriter/extra/dng_sdk/dng_string.cpp
-@@ -27,7 +27,7 @@
- #   endif
+@@ -23,7 +23,7 @@
+ #include <windows.h>
  #endif
  
 -#if qiPhone || qAndroid
@@ -21,5 +21,5 @@ index 4e76fc4c86..7814aff145 100644
  #endif
  
 -- 
-2.40.0
+2.44.0
 

--- a/desktop-kde/digikam/spec
+++ b/desktop-kde/digikam/spec
@@ -1,5 +1,5 @@
 VER=7.9.0
-REL=1
+REL=2
 SRCS="tbl::http://download.kde.org/stable/digikam/$VER/digiKam-$VER.tar.xz \
       file::rename=shapepredictor.dat::http://cdn.files.kde.org/digikam/facesengine/shape-predictor/shapepredictor.dat \
       file::rename=yolov3-face.cfg::http://cdn.files.kde.org/digikam/facesengine/dnnface/yolov3-face.cfg \

--- a/meta-bases/plasma-distro-base/autobuild/defines
+++ b/meta-bases/plasma-distro-base/autobuild/defines
@@ -1,11 +1,10 @@
 PKGNAME=plasma-distro-base
 PKGSEC=Bases
 PKGDEP="kde-base plasma-default-settings"
-PKGRECOM="ddnet digikam gparted haruna kblocks kbreakout kdenlive kdiamond \
+PKGRECOM="digikam gparted haruna kblocks kbreakout kdenlive kdiamond \
           kgoldrunner kmahjongg knights kolourpaint kpat krita kshisen \
-          ksudoku kubrick minetest pidgin strawberry teeworlds gimp \
-          flatpak snapd"
-BUILDDEP="${PKGRECOM}"
+          ksudoku kubrick pidgin strawberry teeworlds gimp flatpak snapd \
+          aosc-media-writer"
 PKGDES="Meta package for AOSC OS Plasma distribution extras"
 
 VER_NONE=1

--- a/meta-bases/plasma-distro-base/spec
+++ b/meta-bases/plasma-distro-base/spec
@@ -1,2 +1,2 @@
-VER=5
+VER=6
 DUMMYSRC=1

--- a/meta-bases/productivity-base/autobuild/defines
+++ b/meta-bases/productivity-base/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=productivity-base
 PKGSEC=Bases
-PKGDEP="libreoffice print-base scan-base proofread-base"
+PKGDEP="print-base scan-base proofread-base"
 PKGDES="Meta package for AOSC OS office productivity usage"
 
 VER_NONE=1

--- a/meta-bases/productivity-base/spec
+++ b/meta-bases/productivity-base/spec
@@ -1,2 +1,2 @@
-VER=1
+VER=2
 DUMMYSRC=1

--- a/runtime-common/utfcpp/autobuild/defines
+++ b/runtime-common/utfcpp/autobuild/defines
@@ -2,7 +2,6 @@ PKGNAME=utfcpp
 PKGSEC=libdevel
 PKGDES="A C/C++ library for handling UTF-8 encoded strings"
 PKGPROV="utf8cpp"
-PKGDEP="gcc"
 
 ABHOST=noarch
 CMAKE_AFTER="-DUTF8_TESTS=OFF"

--- a/runtime-common/utfcpp/spec
+++ b/runtime-common/utfcpp/spec
@@ -1,4 +1,5 @@
 VER=3.2.1
+REL=1
 SRCS="tbl::https://github.com/nemtrif/utfcpp/archive/refs/tags/v$VER.tar.gz"
 CHKSUMS="sha256::8d6aa7d77ad0abb35bb6139cb9a33597ac4c5b33da6a004ae42429b8598c9605"
 CHKUPDATE="anitya::id=20545"

--- a/runtime-gis/gdal/autobuild/defines
+++ b/runtime-gis/gdal/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=gdal
 PKGSEC=science
 PKGDEP="cfitsio curl geos giflib hdf5 libgeotiff libjpeg-turbo libpng \
-        libspatialite libtiff mariadb netcdf numpy openjpeg perl poppler \
-        postgresql sqlite xz libcl podofo geos xerces-c crypto++ qhull \
-        jasper unixodbc python-3 proj libheif lz4 zlib zstd libxml2 freexl \
-        expat libwebp json-c libarchive libdeflate"
+        libspatialite libtiff numpy openjpeg perl poppler sqlite xz libcl \
+        podofo geos xerces-c crypto++ qhull jasper unixodbc python-3 proj \
+        libheif lz4 zlib zstd libxml2 freexl expat libwebp json-c \
+        libarchive libdeflate"
 BUILDDEP="doxygen graphviz opencl-registry-api swig"
 PKGDES="Geospatial Data Abstraction Library"
 

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -1,5 +1,5 @@
 VER=3.7.0
-REL=4
+REL=5
 SRCS="tbl::https://download.osgeo.org/gdal/$VER/gdal-$VER.tar.xz"
 CHKSUMS="sha256::af4b26a6b6b3509ae9ccf1fcc5104f7fe015ef2110f5ba13220816398365adce"
 CHKUPDATE="anitya::id=881"

--- a/runtime-scientific/opencv/autobuild/defines
+++ b/runtime-scientific/opencv/autobuild/defines
@@ -2,13 +2,14 @@ PKGNAME=opencv
 PKGSEC=libs
 PKGDEP="clp coinutils freetype gdal gst-plugins-base-1-0 harfbuzz hdf5 \
         libdc1394 libjpeg-turbo libpng libtiff libva libwebp numpy openblas \
-        openexr openjdk openjpeg protobuf python-3 qt-5 tbb tesseract vtk zlib json-c"
-PKGDEP__RISCV64="${PKGDEP/openjdk/}"
-PKGDEP__MIPS64R6EL="${PKGDEP/openjdk/}"
+        openexr openjpeg protobuf python-3 qt-5 tbb tesseract vtk zlib json-c"
+PKGSUG="openjdk"
+# FIXME: Java is not yet available.
+PKGSUG__MIPS64R6EL="${PKGSUG/openjdk/}"
 BUILDDEP="apache-ant beautifulsoup4 eigen-3 gflags glog glu jasper lapack \
           libcl libglvnd libgphoto2 libraw1394 libtheora libtool libvorbis \
           swig v4l-utils vulkan-headers"
-BUILDDEP__RISCV64="${BUILDDEP/apache-ant/}"
+# FIXME: Java is not yet available.
 BUILDDEP__MIPS64R6EL="${BUILDDEP/apache-ant/}"
 PKGDES="Open Source Computer Vision Library"
 
@@ -40,10 +41,10 @@ CMAKE_AFTER="-DCV_TRACE=OFF \
              -DBUILD_opencv_dnn=ON \
              -DBUILD_opencv_dnn_modern=ON \
              -DBUILD_DOCS=ON \
-             -DBUILD_EXAMPLES=ON \
+             -DBUILD_EXAMPLES=OFF \
              -DBUILD_opencv_python2=OFF \
-             -DINSTALL_C_EXAMPLES=ON \
-             -DINSTALL_PYTHON_EXAMPLES=ON \
+             -DINSTALL_C_EXAMPLES=OFF \
+             -DINSTALL_PYTHON_EXAMPLES=OFF \
              -DBUILD_PROTOBUF=OFF \
              -DPROTOBUF_UPDATE_FILES=ON \
              -DOPENCV_SKIP_PYTHON_LOADER=ON \

--- a/runtime-scientific/opencv/autobuild/defines.stage2
+++ b/runtime-scientific/opencv/autobuild/defines.stage2
@@ -3,7 +3,7 @@ PKGSEC=libs
 PKGDEP="clp coinutils freetype gdal gst-plugins-base-1-0 harfbuzz hdf5 \
         libdc1394 libjpeg-turbo libpng libtiff libva libwebp numpy openblas \
         openexr openjpeg protobuf python-3 qt-5 tbb tesseract vtk zlib json-c"
-BUILDDEP="apache-ant beautifulsoup4 eigen-3 gflags glog glu jasper lapack \
+BUILDDEP="beautifulsoup4 eigen-3 gflags glog glu jasper lapack \
           libcl libglvnd libgphoto2 libraw1394 libtheora libtool libvorbis \
           swig v4l-utils vulkan-headers"
 BUILDDEP__RISCV64="${BUILDDEP/apache-ant/}"

--- a/runtime-scientific/opencv/spec
+++ b/runtime-scientific/opencv/spec
@@ -1,5 +1,5 @@
 VER=4.7.0
-REL=3
+REL=4
 SRCS="tbl::https://github.com/opencv/opencv/archive/$VER.tar.gz
       file::rename=contrib.tar.gz::https://github.com/opencv/opencv_contrib/archive/$VER.tar.gz"
 CHKSUMS="sha256::8df0079cdbe179748a18d44731af62a245a45ebf5085223dc03133954c662973 \


### PR DESCRIPTION
Topic Description
-----------------

- plasma-distro-base: keep only KDE games; add aosc-media-writer
- productivity-base: drop libreoffice dep
    I mean, come on.
- opencv: drop openjdk dep into PKGSUG; disable examples
- gdal: drop mariadb, postgresql deps
    Introduces excessive dependencies into Desktop.
- utfcpp: drop gcc dep
    This is a header library, having that dependency makes no sense.
- digikam: disable MySQL feature
    This is not often used and introduces mariadb dependency into Desktop.
- vtk: disable SQL module
    This is not yet used by any of our users and introduces mariadb/postgresql
    dependencies into our Desktop system.

Package(s) Affected
-------------------

- digikam: 7.9.0-2
- gdal: 3.7.0-5
- opencv: 4.7.0-4
- plasma-distro-base: 5
- productivity-base: 2
- utfcpp: 3.2.1-1
- vtk: 9.3.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit utfcpp gdal vtk opencv digikam productivity-base plasma-distro-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
