### PR TITLE
libjpeg-turbo: add extra Spiral provides

### DIFF
--- a/runtime-imaging/libjpeg-turbo/autobuild/defines
+++ b/runtime-imaging/libjpeg-turbo/autobuild/defines
@@ -22,3 +22,9 @@ PKGBREAK="mozjpeg<=3.1-1"
 PKGEPOCH=2
 
 AB_FLAGS_O3=1
+
+# Note: Extra Provides for Spiral.
+# Note: Do not provide libjpeg-turbo-progs_spiral, this should be provided by
+# jpegexiforient (to be packaged).
+PKGPROV="libjpeg62-turbo_spiral libjpeg62-turbo-dev_spiral \
+         libturbojpeg0-dev_spiral"

--- a/runtime-imaging/libjpeg-turbo/spec
+++ b/runtime-imaging/libjpeg-turbo/spec
@@ -1,4 +1,5 @@
 VER=3.0.2
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/libjpeg-turbo/libjpeg-turbo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1648"


### PR DESCRIPTION
Topic Description
-----------------

- libjpeg-turbo: add extra Spiral provides
    Note: Do not provide libjpeg-turbo-progs_spiral, this should be provided by
    jpegexiforient (to be packaged).

Package(s) Affected
-------------------

- libjpeg-turbo: 2:3.0.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjpeg-turbo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
