### PR TITLE
lapack: update to 3.12.0

### DIFF
--- a/app-scientific/lapack/autobuild/beyond
+++ b/app-scientific/lapack/autobuild/beyond
@@ -1,3 +1,7 @@
-doxygen DOCS/Doxyfile_man
-mkdir -p "$PKGDIR"/usr/share
-cp -r DOCS/man "$PKGDIR"/usr/share
+abinfo "Building manpages ..."
+doxygen "$SRCDIR"/DOCS/Doxyfile
+
+abinfo "Install manpages ..."
+mkdir -vp "$PKGDIR"/usr/share
+cp -vr "$SRCDIR"/DOCS/man "$PKGDIR"/usr/share
+rm -v "$PKGDIR"/usr/share/man/man3l/*_acbs_*

--- a/app-scientific/lapack/autobuild/patches/0001-migrate-manpage-secton-to-section-3l.patch
+++ b/app-scientific/lapack/autobuild/patches/0001-migrate-manpage-secton-to-section-3l.patch
@@ -1,8 +1,26 @@
-diff --git a/DOCS/Doxyfile_man b/DOCS/Doxyfile_man
+diff --git a/DOCS/Doxyfile b/DOCS/Doxyfile
 index 1767cf5..a7bf53d 100644
---- a/DOCS/Doxyfile_man
-+++ b/DOCS/Doxyfile_man
-@@ -1850,7 +1850,7 @@ MAN_OUTPUT             = man
+--- a/DOCS/Doxyfile
++++ b/DOCS/Doxyfile
+@@ -1138,7 +1138,7 @@
+ # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
+ # The default value is: YES.
+ 
+-GENERATE_HTML          = YES
++GENERATE_HTML          = NO
+ 
+ # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
+ # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
+@@ -1975,7 +1975,7 @@
+ # classes and files.
+ # The default value is: NO.
+ 
+-GENERATE_MAN           = NO
++GENERATE_MAN           = YES
+ 
+ # The MAN_OUTPUT tag is used to specify where the man pages will be put. If a
+ # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
+@@ -1993,7 +1993,7 @@
  # The default value is: .3.
  # This tag requires that the tag GENERATE_MAN is set to YES.
  

--- a/app-scientific/lapack/spec
+++ b/app-scientific/lapack/spec
@@ -1,5 +1,4 @@
-VER=3.9.0
-REL=2
-SRCS="tbl::https://github.com/Reference-LAPACK/lapack/archive/v$VER.tar.gz"
-CHKSUMS="sha256::106087f1bb5f46afdfba7f569d0cbe23dacb9a07cd24733765a0e89dbe1ad573"
+VER=3.12.0
+SRCS="git::commit=tags/v$VER::https://github.com/Reference-LAPACK/lapack"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1534"


### PR DESCRIPTION
Topic Description
-----------------

- lapack: update to 3.12.0

Package(s) Affected
-------------------

- lapack: 3.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lapack
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
