### PR TITLE
Rework for kde-base adjustments

### DIFF
--- a/meta-bases/plasma-distro-base/autobuild/defines
+++ b/meta-bases/plasma-distro-base/autobuild/defines
@@ -3,7 +3,8 @@ PKGSEC=Bases
 PKGDEP="kde-base plasma-default-settings"
 PKGRECOM="ddnet digikam gparted haruna kblocks kbreakout kdenlive kdiamond \
           kgoldrunner kmahjongg knights kolourpaint kpat krita kshisen \
-          ksudoku kubrick minetest pidgin strawberry teeworlds gimp"
+          ksudoku kubrick minetest pidgin strawberry teeworlds gimp \
+          flatpak snapd"
 BUILDDEP="${PKGRECOM}"
 PKGDES="Meta package for AOSC OS Plasma distribution extras"
 

--- a/meta-bases/plasma-distro-base/spec
+++ b/meta-bases/plasma-distro-base/spec
@@ -1,2 +1,2 @@
-VER=4
+VER=5
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- plasma-distro-base: add flatpak, snapd to recommends
    This helps preserve features whilst Discover was removed from kde-base.

Package(s) Affected
-------------------

- plasma-distro-base: 5

Security Update?
----------------

No

Build Order
-----------

```
#buildit plasma-distro-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
