### PR TITLE
frp: update to 0.56.0

### DIFF
--- a/app-network/frp/autobuild/patches/0002-feat-update-go.mod-to-support-loong64-with-latest-ve.patch
+++ b/app-network/frp/autobuild/patches/0002-feat-update-go.mod-to-support-loong64-with-latest-ve.patch
@@ -1,0 +1,40 @@
+From 85157567560d68ee7304f9aa9c3afe9ad718fee2 Mon Sep 17 00:00:00 2001
+From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
+Date: Wed, 3 Apr 2024 17:00:23 +0800
+Subject: [PATCH] feat: update go.mod to support loong64 with latest version of
+ github.com/templexxx/cpu
+
+---
+ go.mod | 2 +-
+ go.sum | 2 ++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/go.mod b/go.mod
+index d820b96..dbea080 100644
+--- a/go.mod
++++ b/go.mod
+@@ -61,7 +61,7 @@ require (
+ 	github.com/prometheus/common v0.42.0 // indirect
+ 	github.com/prometheus/procfs v0.10.1 // indirect
+ 	github.com/rogpeppe/go-internal v1.11.0 // indirect
+-	github.com/templexxx/cpu v0.1.0 // indirect
++	github.com/templexxx/cpu v0.1.1-0.20240303154708-598a14b050c5 // indirect
+ 	github.com/templexxx/xorsimd v0.4.2 // indirect
+ 	github.com/tidwall/match v1.1.1 // indirect
+ 	github.com/tidwall/pretty v1.2.0 // indirect
+diff --git a/go.sum b/go.sum
+index b00cb78..e7646da 100644
+--- a/go.sum
++++ b/go.sum
+@@ -138,6 +138,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
+ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+ github.com/templexxx/cpu v0.1.0 h1:wVM+WIJP2nYaxVxqgHPD4wGA2aJ9rvrQRV8CvFzNb40=
+ github.com/templexxx/cpu v0.1.0/go.mod h1:w7Tb+7qgcAlIyX4NhLuDKt78AHA5SzPmq0Wj6HiEnnk=
++github.com/templexxx/cpu v0.1.1-0.20240303154708-598a14b050c5 h1:Ke6p9WHBy8Ooz8Vg/+o9SHp5yE2VlzzyHVEfHTFmJoM=
++github.com/templexxx/cpu v0.1.1-0.20240303154708-598a14b050c5/go.mod h1:w7Tb+7qgcAlIyX4NhLuDKt78AHA5SzPmq0Wj6HiEnnk=
+ github.com/templexxx/xorsimd v0.4.2 h1:ocZZ+Nvu65LGHmCLZ7OoCtg8Fx8jnHKK37SjvngUoVI=
+ github.com/templexxx/xorsimd v0.4.2/go.mod h1:HgwaPoDREdi6OnULpSfxhzaiiSUY4Fi3JPn1wpt28NI=
+ github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
+-- 
+2.44.0
+

--- a/app-network/frp/spec
+++ b/app-network/frp/spec
@@ -1,4 +1,4 @@
-VER=0.54.0
+VER=0.56.0
 SRCS="git::commit=tags/v$VER::https://github.com/fatedier/frp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230969"


### PR DESCRIPTION
Topic Description
-----------------

- frp: add patch for loongarch64
    - Update go.mod to support loong64 with latest version of github.com/templexxx/cpu
- frp: update to 0.56.0

Package(s) Affected
-------------------

- frp: 0.56.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit frp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
