### PR TITLE
wtf: update to 20230906

### DIFF
--- a/app-utils/wtf/spec
+++ b/app-utils/wtf/spec
@@ -1,4 +1,4 @@
-VER=20190308
+VER=20230906
 SRCS="tbl::https://downloads.sourceforge.net/project/bsdwtf/wtf-$VER.tar.gz"
-CHKSUMS="sha256::f3e04136e63c8658ade0eb6acd825b0e548bb7c8c763caf1e3ac3fa42063b722"
+CHKSUMS="sha256::ed9c1fa927fcd878cce955fb0bdc586876ee1ae234666be75c3bbd6e5b2a094b"
 CHKUPDATE="anitya::id=231679"


### PR DESCRIPTION
Topic Description
-----------------

- wtf: update to 20230906

Package(s) Affected
-------------------

- wtf: 20230906

Security Update?
----------------

No

Build Order
-----------

```
#buildit wtf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
