### PR TITLE
vifm: update to 0.13

### DIFF
--- a/app-utils/vifm/spec
+++ b/app-utils/vifm/spec
@@ -1,5 +1,4 @@
-VER=0.9.1
-SRCS="tbl::https://prdownloads.sourceforge.net/vifm/vifm-$VER.tar.bz2"
-CHKSUMS="sha256::28b9a4b670d9ddc9af8c9804dc22fa93f4fd0adabce94d43ebedc157a5dce7b3"
-REL=1
+VER=0.13
+SRCS="tbl::https://sourceforge.net/projects/vifm/files/vifm/vifm-$VER.tar.bz2"
+CHKSUMS="sha256::0d9293749a794076ade967ecdc47d141d85e450370594765391bdf1a9bd45075"
 CHKUPDATE="anitya::id=5090"


### PR DESCRIPTION
Topic Description
-----------------

- vifm: update to 0.13

Package(s) Affected
-------------------

- vifm: 0.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit vifm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
