### PR TITLE
xosview2: update to 2.3.3

### DIFF
--- a/app-utils/xosview2/spec
+++ b/app-utils/xosview2/spec
@@ -1,4 +1,4 @@
-VER=2.3.1
-SRCS="tbl::https://downloads.sourceforge.net/project/xosview/xosview2-$VER.tar.gz"
-CHKSUMS="sha512::c90fc4f79d1f776eba90620376d318302135fc18e79a49e1aa57607276b57d46c66eb647ad92b3ac314b74d64247887e81e1541f81dd276e1e5ef2206e241060"
+VER=2.3.3
+SRCS="tbl::https://sourceforge.net/projects/xosview/files/xosview2-$VER.tar.gz"
+CHKSUMS="sha256::904a7a9fd2a667eeac4c5c89af557c4acabd699ba1ebd7385356088aabf1231c"
 CHKUPDATE="anitya::id=231685"


### PR DESCRIPTION
Topic Description
-----------------

- xosview2: update to 2.3.3

Package(s) Affected
-------------------

- xosview2: 2.3.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit xosview2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
