### PR TITLE
gtkwave: update to 3.3.119

### DIFF
--- a/app-electronics/gtkwave/spec
+++ b/app-electronics/gtkwave/spec
@@ -1,4 +1,4 @@
-VER=3.3.109
-SRCS="tbl::http://gtkwave.sourceforge.net/gtkwave-$VER.tar.gz"
-CHKSUMS="sha256::ca487e5e9b728086ba4de6581058d6c096a7771915163ef600f63d0e88c3c05d"
+VER=3.3.119
+SRCS="tbl::https://gtkwave.sourceforge.net/gtkwave-$VER.tar.gz"
+CHKSUMS="sha256::3cb53a291a300b442927a3ca1900f325a962c730c8eb7f8b9b4dfdb2e5406207"
 CHKUPDATE="anitya::id=8813"


### PR DESCRIPTION
Topic Description
-----------------

- gtkwave: update to 3.3.119

Package(s) Affected
-------------------

- gtkwave: 3.3.119

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtkwave
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
