### PR TITLE
bind Rework 20240404

### DIFF
--- a/app-network/bind/spec
+++ b/app-network/bind/spec
@@ -1,4 +1,5 @@
 VER=9.18.24
+REL=1
 SRCS="tbl::https://downloads.isc.org/isc/bind${VER:0:1}/${VER/.P/-P}/bind-${VER/.P/-P}.tar.xz"
 CHKSUMS="sha256::709d73023c9115ddad3bab65b6c8c79a590196d0d114f5d0ca2533dbd52ddf66"
 CHKUPDATE="anitya::id=77661"


### PR DESCRIPTION
Topic Description
-----------------

- bind: rebuild to fix libuv incompatibility
    Fixes the following error on ppc64el:
    /var/cache/acbs/build/acbs.0rlk9v8p/bind-9.18.24/lib/isc/netmgr/netmgr.c:223:isc__netmgr_create():
    fatal error: libuv version too new: running with libuv 1.48.0 when
    compiled with libuv 1.34.2 will lead to libuv failures

Package(s) Affected
-------------------

- bind: 1:9.18.24-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bind
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
