### PR TITLE
xwayland: update to 23.2.5

### DIFF
--- a/runtime-display/xwayland/spec
+++ b/runtime-display/xwayland/spec
@@ -1,4 +1,4 @@
-VER=23.2.4
+VER=23.2.5
 SRCS="tbl::https://xorg.freedesktop.org/archive/individual/xserver/xwayland-$VER.tar.xz"
-CHKSUMS="sha256::a99e159b6d0d33098b3b6ab22a88bfcece23c8b9d0ca72c535c55dcb0681b46b"
+CHKSUMS="sha256::33ec7ff2687a59faaa52b9b09aa8caf118e7ecb6aed8953f526a625ff9f4bd90"
 CHKUPDATE="anitya::id=180949"


### PR DESCRIPTION
Topic Description
-----------------

- xwayland: update to 23.2.5

Package(s) Affected
-------------------

- xwayland: 23.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit xwayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
