### PR TITLE
antlr4-cpp-runtime: 4.13.1, new

### DIFF
--- a/runtime-common/antlr4-cpp-runtime/autobuild/beyond
+++ b/runtime-common/antlr4-cpp-runtime/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Moving /usr/share/doc/libantlr4 => /usr/share/doc/${PKGNAME} ..."
+mv -v "${PKGDIR}/usr/share/doc/libantlr4" "${PKGDIR}/usr/share/doc/${PKGNAME}"

--- a/runtime-common/antlr4-cpp-runtime/autobuild/defines
+++ b/runtime-common/antlr4-cpp-runtime/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=antlr4-cpp-runtime
+PKGSEC=libs
+PKGDEP="gcc-runtime glibc"
+PKGDES="C++ runtime for ANTLR 4"
+ABTYPES=cmake
+
+CMAKE_AFTER=(
+    -DINSTALL_GTEST=OFF
+)

--- a/runtime-common/antlr4-cpp-runtime/spec
+++ b/runtime-common/antlr4-cpp-runtime/spec
@@ -1,0 +1,5 @@
+VER=4.13.1
+SRCS="tbl::https://www.antlr.org/download/antlr4-cpp-runtime-${VER}-source.zip"
+CHKSUMS="sha256::d350e09917a633b738c68e1d6dc7d7710e91f4d6543e154a78bb964cfd8eb4de"
+CHKUPDATE="anitya::id=14373"
+SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- antlr4-cpp-runtime: 4.13.1, new

Package(s) Affected
-------------------

- antlr4-cpp-runtime: 4.13.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit antlr4-cpp-runtime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
