### PR TITLE
postfix: fix FTBFS

### DIFF
--- a/app-web/postfix/autobuild/build
+++ b/app-web/postfix/autobuild/build
@@ -59,7 +59,7 @@ abinfo "Creating and tweaking default Postfix configuration ..."
     cd "$PKGDIR"
     LD_LIBRARY_PATH=usr/lib/postfix:$LD_LIBRARY_PATH \
     sh "$SRCDIR"/post-install \
-        command_directory=usr/bin \
+        command_directory=usr/lib/postfix/alternatives \
         config_directory=etc/postfix \
         meta_directory=etc/postfix \
         setgid_group=75 \

--- a/app-web/postfix/autobuild/build.stage2
+++ b/app-web/postfix/autobuild/build.stage2
@@ -53,7 +53,7 @@ abinfo "Creating and tweaking default Postfix configuration ..."
     cd "$PKGDIR"
     LD_LIBRARY_PATH=usr/lib/postfix:$LD_LIBRARY_PATH \
     sh "$SRCDIR"/post-install \
-        command_directory=usr/bin \
+        command_directory=usr/lib/postfix/alternatives \
         config_directory=etc/postfix \
         meta_directory=etc/postfix \
         setgid_group=75 \

--- a/app-web/postfix/spec
+++ b/app-web/postfix/spec
@@ -1,5 +1,5 @@
 VER=3.7.3
-REL=2
-SRCS="tbl::http://cdn.postfix.johnriley.me/mirrors/postfix-release/official/postfix-$VER.tar.gz"
+REL=3
+SRCS="tbl::https://de.postfix.org/ftpmirror/official/postfix-$VER.tar.gz"
 CHKSUMS="sha256::d22f3d37ef75613d5d573b56fc51ef097f2c0d0b0e407923711f71c1fb72911b"
 CHKUPDATE="anitya::id=3693"


### PR DESCRIPTION
Topic Description
-----------------

- postfix: fix FTBFS

Package(s) Affected
-------------------

- postfix: 3.7.3-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit postfix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
