### PR TITLE
bcachefs-tools: update to 1.6.4

### DIFF
--- a/app-admin/bcachefs-tools/autobuild/defines
+++ b/app-admin/bcachefs-tools/autobuild/defines
@@ -6,6 +6,7 @@ PKGDES="Userspace tools for bcachefs"
 
 USECLANG=1
 
-# FIXME: FTBFS with LTO on riscv64 and loongson3
+# FIXME: FTBFS with LTO on riscv64, loongarch64 and loongson3
 NOLTO__RISCV64=1
 NOLTO__LOONGSON3=1
+NOLTO__LOONGARCH64=1

--- a/app-admin/bcachefs-tools/spec
+++ b/app-admin/bcachefs-tools/spec
@@ -1,4 +1,4 @@
-VER=1.4.1
+VER=1.6.4
 SRCS="git::rename=bcachefs-tools;commit=tags/v${VER}::https://evilpiepirate.org/git/bcachefs-tools.git \
     git::rename=dracut-bcachefs;commit=1f584d9::https://github.com/breavyn/dracut-bcachefs"
 CHKSUMS="SKIP SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- bcachefs-tools: update to 1.6.4
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- bcachefs-tools: 1.6.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit bcachefs-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
