### PR TITLE
aosc-media-writer: update to 0.3.4

### DIFF
--- a/app-utils/aosc-media-writer/spec
+++ b/app-utils/aosc-media-writer/spec
@@ -1,4 +1,4 @@
-VER="0.3.1"
+VER="0.3.4"
 SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/MediaWriter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371926"


### PR DESCRIPTION
Topic Description
-----------------

- aosc-media-writer: update to 0.3.4

Package(s) Affected
-------------------

- aosc-media-writer: 0.3.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-media-writer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
