### PR TITLE
wxwidgets: fix FTBFS

### DIFF
--- a/runtime-desktop/wxwidgets/01-wxbase/prepare
+++ b/runtime-desktop/wxwidgets/01-wxbase/prepare
@@ -1,2 +1,6 @@
 abinfo "Updating locale files ..."
 make -C "$SRCDIR"/locale allmo
+
+# FIXME: configure expects this variable to be set,
+# otherwise it may fail to generate Makefile for wxrc
+export EGREP="grep -E"

--- a/runtime-desktop/wxwidgets/02-wxgtk3/prepare
+++ b/runtime-desktop/wxwidgets/02-wxgtk3/prepare
@@ -3,3 +3,7 @@ make distclean
 
 abinfo "Updating locale files ..."
 make -C "$SRCDIR"/locale allmo
+
+# FIXME: configure expects this variable to be set,
+# otherwise it may fail to generate Makefile for wxrc
+export EGREP="grep -E"

--- a/runtime-desktop/wxwidgets/spec
+++ b/runtime-desktop/wxwidgets/spec
@@ -1,4 +1,5 @@
 VER=3.2.4
+REL=1
 SRCS="tbl::https://github.com/wxWidgets/wxWidgets/releases/download/v$VER/wxWidgets-$VER.tar.bz2"
 CHKSUMS="sha256::0640e1ab716db5af2ecb7389dbef6138d7679261fbff730d23845ba838ca133e"
 CHKUPDATE="anitya::id=5150"


### PR DESCRIPTION
Topic Description
-----------------

- wxwidgets: fix FTBFS

Package(s) Affected
-------------------

- wxbase: 1:3.2.4-1
- wxgtk3: 1:3.2.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wxwidgets
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
