### PR TITLE
Fcitx5 Survey (April, 2024)

### DIFF
--- a/app-i18n/fcitx5-anthy/spec
+++ b/app-i18n/fcitx5-anthy/spec
@@ -1,4 +1,4 @@
-VER=5.1.2
-SRCS="tbl::https://github.com/fcitx/fcitx5-anthy/archive/$VER.tar.gz"
-CHKSUMS="sha256::e975fb86dd490f8a7a8b1dbe7243f11dce0ab0b8d938a8a5c0f313ae6e938c39"
+VER=5.1.3
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-anthy"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174357"

--- a/app-i18n/fcitx5-chinese-addons/spec
+++ b/app-i18n/fcitx5-chinese-addons/spec
@@ -1,7 +1,7 @@
-VER=5.1.2
-SRCS="tbl::https://github.com/fcitx/fcitx5-chinese-addons/archive/$VER.tar.gz \
+VER=5.1.4
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-chinese-addons \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5-chinese-addons/fcitx5-chinese-addons-${VER}_dict.tar.xz"
-CHKSUMS="sha256::9001007ed53770f38f1cf0e6bd80f1585479e86c89a8686afa98639ee92f1674 \
-         sha256::6c87ae3f4c06644ccd4f03a817ce57d5dcdb4db23220d5eb1b046ef03746ca8e"
+CHKSUMS="SKIP \
+         sha256::4546b50e41ba35d6b4044c8d615e15530eb8400b8dc9133efe11cfd70eea6dcd"
 CHKUPDATE="anitya::id=138238"
 SUBDIR="fcitx5-chinese-addons-$VER"

--- a/app-i18n/fcitx5-configtool/spec
+++ b/app-i18n/fcitx5-configtool/spec
@@ -1,4 +1,4 @@
-VER=5.1.2
-SRCS="tbl::https://github.com/fcitx/fcitx5-configtool/archive/$VER.tar.gz"
-CHKSUMS="sha256::73a43bece71173217479946fcc0ec5159023f137874b6151c4d2865a77cc742f"
+VER=5.1.4
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-configtool"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138233"

--- a/app-i18n/fcitx5-gtk/spec
+++ b/app-i18n/fcitx5-gtk/spec
@@ -1,4 +1,4 @@
-VER=5.1.0
-SRCS="tbl::https://github.com/fcitx/fcitx5-gtk/archive/$VER.tar.gz"
-CHKSUMS="sha256::b064d4be9d603583f1b5da8f809c28b0fa64d9c6a696fa318b64c47903f4fc4c"
+VER=5.1.2
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-gtk"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138235"

--- a/app-i18n/fcitx5-hangul/spec
+++ b/app-i18n/fcitx5-hangul/spec
@@ -1,4 +1,4 @@
-VER=5.1.1
-SRCS="tbl::https://github.com/fcitx/fcitx5-hangul/archive/$VER.tar.gz"
-CHKSUMS="sha256::55bcb2ccb993949e0227df2fbe7f40e5899b70a7e55c4394d525bb3e8a3d711f"
+VER=5.1.2
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-hangul"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174360"

--- a/app-i18n/fcitx5-kkc/spec
+++ b/app-i18n/fcitx5-kkc/spec
@@ -1,4 +1,4 @@
-VER=5.1.0
-SRCS="tbl::https://github.com/fcitx/fcitx5-kkc/archive/$VER.tar.gz"
-CHKSUMS="sha256::fc58d31901c54a24925743e986789f7ed41f0fa5033fb10ea76015af150abc65"
+VER=5.1.2
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-kkc"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138241"

--- a/app-i18n/fcitx5-libthai/spec
+++ b/app-i18n/fcitx5-libthai/spec
@@ -1,4 +1,4 @@
-VER=5.1.1
-SRCS="tbl::https://github.com/fcitx/fcitx5-libthai/archive/$VER.tar.gz"
-CHKSUMS="sha256::37aecaf6fa94375cf4a5195b0022afa192d77e6e441909b4561ba8d444b19920"
+VER=5.1.2
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-libthai"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174358"

--- a/app-i18n/fcitx5-lua/spec
+++ b/app-i18n/fcitx5-lua/spec
@@ -1,4 +1,4 @@
-VER=5.0.11
-SRCS="tbl::https://github.com/fcitx/fcitx5-lua/archive/$VER.tar.gz"
-CHKSUMS="sha256::9304a5d31693024b9bbfe4c3b2f0d1462cb5e02a8e6bdb00c7d6b5583dd85288"
+VER=5.0.12
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-lua"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138242"

--- a/app-i18n/fcitx5-pinyin-zhwiki/spec
+++ b/app-i18n/fcitx5-pinyin-zhwiki/spec
@@ -6,8 +6,8 @@ VER="${SCRIPT_VER}"+dict"${DICT_VER}"
 SRCS="file::rename=zhwiki.dict::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/${SCRIPT_VER}/zhwiki-${DICT_VER}.dict \
       file::rename=zhwiki.dict.yaml::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/${SCRIPT_VER}/zhwiki-${DICT_VER}.dict.yaml \
       file::rename=LICENSE::https://www.gnu.org/licenses/fdl-1.3.txt"
-CHKSUMS="sha256::b355b16a5c8c90edc0e859ccf2bd1509dd604180fe6631b852756f65a13ddacf \
-         sha256::e9ff15c746477cb8157a9825e22c5fa44c70c2676bb1bf5f1710a47149c0da7c \
-         sha256::6adc7b4f7c74882dbe7564f7b8285ff194d760727ab30036dfe9704039fe32d7"
+CHKSUMS="sha256::bcd1d2e67dd3a92c29531db01b6eb0eeb2ba8d2aabbcb00d786da7d2f0388989 \
+         sha256::d98e0ce11ac107134a1b25b1f98fa798512c28fba47cdb1a82023256b58cdb4e \
+         sha256::110535522396708cea37c72a802c5e7e81391139f5f7985631c93ef242b206a4"
 CHKUPDATE="anitya::id=228872"
 SUBDIR="."

--- a/app-i18n/fcitx5-pinyin-zhwiki/spec
+++ b/app-i18n/fcitx5-pinyin-zhwiki/spec
@@ -1,5 +1,5 @@
-DICT_VER=20210823
-SCRIPT_VER=0.2.3
+DICT_VER=20240210
+SCRIPT_VER=0.2.4
 VER="${SCRIPT_VER}"+dict"${DICT_VER}"
 
 # Arch Linux (felixonmars, also fcitx5-pinyin-zhwiki author): use FDL 1.3 LICENSE

--- a/app-i18n/fcitx5-rime/spec
+++ b/app-i18n/fcitx5-rime/spec
@@ -1,4 +1,4 @@
-VER=5.1.3
-SRCS="tbl::https://github.com/fcitx/fcitx5-rime/archive/$VER.tar.gz"
-CHKSUMS="sha256::8db7f28aaad34baab417d4ddde1bf8dcee8106d6f98271808a21c2cd4ca23627"
+VER=5.1.5
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-rime"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138239"

--- a/app-i18n/fcitx5-skk/spec
+++ b/app-i18n/fcitx5-skk/spec
@@ -1,4 +1,4 @@
-VER=5.1.0
-SRCS="tbl::https://github.com/fcitx/fcitx5-skk/archive/$VER.tar.gz"
-CHKSUMS="sha256::9ada51c87b2c4331f939ab9e9c77f7555e33b63b183461787395e7ee7f195e73"
+VER=5.1.2
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-skk"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138240"

--- a/app-i18n/fcitx5-unikey/spec
+++ b/app-i18n/fcitx5-unikey/spec
@@ -1,4 +1,4 @@
-VER=5.1.1
-SRCS="tbl::https://github.com/fcitx/fcitx5-unikey/archive/$VER.tar.gz"
-CHKSUMS="sha256::00bac82422a8feca4242a92eb5d52fcab38f615f38f3fd915e3cd836f04a7528"
+VER=5.1.3
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-unikey"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=180082"

--- a/app-i18n/fcitx5/spec
+++ b/app-i18n/fcitx5/spec
@@ -1,8 +1,7 @@
-VER=5.1.5
-REL=1
-SRCS="tbl::https://github.com/fcitx/fcitx5/archive/$VER.tar.gz \
+VER=5.1.8
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5 \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5/fcitx5-${VER}_dict.tar.xz"
-CHKSUMS="sha256::b9f5c969b1c8f717cb9eeda301776536a09568abf7c01588b4d4ea241a7f0c88 \
-         sha256::99781e5401a753437803818c56d11e1827986db5595cfc0add01401e4c410a81"
+CHKSUMS="SKIP \
+         sha256::4d1480bae7c0af488410b228d5bfdb6ee024b072519e64991b41d3366a690580"
 CHKUPDATE="anitya::id=138232"
 SUBDIR="fcitx5-$VER"

--- a/meta-bases/fcitx5-base/autobuild/defines
+++ b/meta-bases/fcitx5-base/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME="fcitx5-base"
 PKGDES="Meta package for AOSC OS Fcitx5 input method support"
-PKGRECOM="xcb-imdkit fcitx5 fcitx5-qt fcitx5-gtk libime \
+PKGDEP="fcitx5"
+PKGRECOM="xcb-imdkit fcitx5-qt fcitx5-gtk libime \
 	fcitx5-chinese-addons fcitx5-rime fcitx5-anthy fcitx5-kkc \
 	fcitx5-configtool fcitx5-lua fcitx5-skk fcitx5-sayura \
 	fcitx5-libthai fcitx5-unikey fcitx5-hangul fcitx5-m17n \

--- a/meta-bases/fcitx5-base/spec
+++ b/meta-bases/fcitx5-base/spec
@@ -1,2 +1,2 @@
-VER=3
+VER=4
 DUMMYSRC=1

--- a/runtime-i18n/libime/spec
+++ b/runtime-i18n/libime/spec
@@ -1,7 +1,7 @@
-VER=1.1.3
+VER=1.1.6
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/libime/ \
       tbl::https://download.fcitx-im.org/fcitx5/libime/libime-${VER}_dict.tar.xz"
 CHKSUMS="SKIP \
-         sha256::0e2e6f3a9856a7ea66eef4e9a1240255ea8cfbf0d4817ea02448851317b13f30"
+         sha256::54d9a088ef992bb2c8e791aa20246e76d550a81e7e616bce9e78859057cbd77e"
 CHKUPDATE="anitya::id=138236"
 SUBDIR="libime-$VER"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-zhwiki: update checksums
- libime: update to 1.1.6
- fcitx5-base: move fcitx5 to PKGDEP
    Such that by installing fcitx (4), fcitx5 would be removed correctly.
- fcitx5-unikey: update to 5.1.3
- fcitx5-skk: update to 5.1.2
- fcitx5-rime: update to 5.1.5
- fcitx5-pinyin-zhwiki: update to 0.2.4+dict20240210
- fcitx5-lua: update to 5.0.12
- fcitx5-libthai: update to 5.1.2
- fcitx5-kkc: update to 5.1.2

... and 6 more commits

Package(s) Affected
-------------------

- fcitx5-anthy: 1:5.1.3
- fcitx5-base: 4
- fcitx5-chinese-addons: 1:5.1.4
- fcitx5-configtool: 1:5.1.4
- fcitx5-gtk: 1:5.1.2
- fcitx5-hangul: 5.1.2
- fcitx5-kkc: 1:5.1.2
- fcitx5-libthai: 5.1.2
- fcitx5-lua: 1:5.0.12
- fcitx5-migrator: 1:5.1.4
- fcitx5-pinyin-zhwiki: 0.2.4+dict20240210
- fcitx5-qt: 1:5.1.6
- fcitx5-rime: 1:5.1.5
- fcitx5-skk: 5.1.2
- fcitx5-unikey: 5.1.3
- fcitx5: 1:5.1.8
- rime-pinyin-zhwiki: 0.2.4+dict20240210

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5 fcitx5-anthy fcitx5-chinese-addons fcitx5-configtool fcitx5-gtk fcitx5-hangul fcitx5-kkc fcitx5-libthai fcitx5-lua fcitx5-pinyin-zhwiki fcitx5-qt fcitx5-rime fcitx5-skk fcitx5-unikey fcitx5-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
