### PR TITLE
fontforge: fix FTBFS

### DIFF
--- a/app-creativity/fontforge/autobuild/patches/0001-ArchLinux-fix-po-files.patch
+++ b/app-creativity/fontforge/autobuild/patches/0001-ArchLinux-fix-po-files.patch
@@ -1,0 +1,8803 @@
+From 642d8a3db6d4bc0e70b429622fdf01ecb09c4c10 Mon Sep 17 00:00:00 2001
+From: skef <6175836+skef@users.noreply.github.com>
+Date: Sun, 31 Dec 2023 02:17:59 -0800
+Subject: [PATCH] Update po files from Croudin sources after fixing problems
+
+---
+ po/ca.po    |   17 +-
+ po/de.po    |   25 +-
+ po/el.po    |    4 +-
+ po/en_GB.po |    8 +-
+ po/es.po    |   76 +++-
+ po/fr.po    |   93 ++--
+ po/hr.po    |  156 ++++++-
+ po/it.po    |   12 +-
+ po/ja.po    |  217 +++++++--
+ po/ka_GE.po | 1231 +++++++++++++++++++++++++++++++++++++++++++--------
+ po/ko.po    |   43 +-
+ po/ml.po    |    4 +-
+ po/pl.po    |   67 ++-
+ po/pt.po    |    4 +-
+ po/ru.po    |    4 +-
+ po/tr_TR.po |    4 +-
+ po/uk.po    |   41 +-
+ po/vi.po    |  428 +-----------------
+ po/zh_CN.po | 1021 +++++++++++++++++++++++++++++++++++-------
+ po/zh_TW.po |   24 +-
+ 20 files changed, 2485 insertions(+), 994 deletions(-)
+
+diff --git a/po/ca.po b/po/ca.po
+index e2349b6ef5..d25f08928f 100644
+--- a/po/ca.po
++++ b/po/ca.po
+@@ -15,8 +15,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Catalan\n"
+ "Language: ca_ES\n"
+@@ -11573,8 +11573,8 @@ msgid "SnapToInt"
+ msgstr "Edita amb enters"
+ 
+ msgid ""
+-"So if you type \"A\" here the first selected glyph would be named \"A.suffix"
+-"\".\n"
++"So if you type \"A\" here the first selected glyph would be named \"A."
++"suffix\".\n"
+ "The second \"B.suffix\", and so on."
+ msgstr ""
+ "Si aquí poseu «A», el primer glif seleccionat s'anomenarà «A.sufix».\n"
+@@ -12345,7 +12345,6 @@ msgstr "Thaana"
+ msgid "Thai"
+ msgstr "Tai"
+ 
+-#, c-format
+ msgid ""
+ "The %1$s in the search dialog contains a reference to %2$.20hs which does "
+ "not exist in the new font.\n"
+@@ -16406,16 +16405,16 @@ msgstr ""
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d ∆x_adv="
+-"%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
++"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d "
++"∆x_adv=%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ msgstr ""
+ "«%s» a %s no conté una consulta de posicionament per parelles ∆x=%d ∆y=%d "
+ "∆x_adv=%d ∆y_adv=%d a %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv="
+-"%d\n"
++"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d "
++"∆y_adv=%d\n"
+ msgstr ""
+ "«%s» a %s no conté una consulta de posicionament ∆x=%d ∆y=%d ∆x_adv=%d "
+ "∆y_adv=%d\n"
+diff --git a/po/de.po b/po/de.po
+index 41430ffaed..8b1a248f88 100644
+--- a/po/de.po
++++ b/po/de.po
+@@ -18,8 +18,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: German\n"
+ "Language: de_DE\n"
+@@ -228,8 +228,8 @@ msgid ""
+ "!!!!! Bad Base Coord format (%d) for '%c%c%c%c' in '%c%c%c%c' script in "
+ "'BASE' table\n"
+ msgstr ""
+-"!!!!! Ungültiges Format der Koordinaten des Grundzeichens (%d) für '%c%c%c"
+-"%c' im Schriftsystem '%c%c%c%c' in der 'BASE' Tabelle\n"
++"!!!!! Ungültiges Format der Koordinaten des Grundzeichens (%d) für "
++"'%c%c%c%c' im Schriftsystem '%c%c%c%c' in der 'BASE' Tabelle\n"
+ 
+ #, c-format
+ msgid ""
+@@ -14770,8 +14770,8 @@ msgid "SnapToInt"
+ msgstr "Auf ganze Zahlen einrasten"
+ 
+ msgid ""
+-"So if you type \"A\" here the first selected glyph would be named \"A.suffix"
+-"\".\n"
++"So if you type \"A\" here the first selected glyph would be named \"A."
++"suffix\".\n"
+ "The second \"B.suffix\", and so on."
+ msgstr ""
+ "Wenn du hier „A“ eingibst, dann bekommt die erste ausgewählte Glyphe den "
+@@ -15763,7 +15763,6 @@ msgstr ""
+ "nicht denen in %4$.30s (unterschiedliche Anzahl oder unterschiedliche "
+ "Kriterien für Überlappungen)"
+ 
+-#, c-format
+ msgid ""
+ "The %1$s in the search dialog contains a reference to %2$.20hs which does "
+ "not exist in the new font.\n"
+@@ -16909,8 +16908,8 @@ msgstr ""
+ #, c-format
+ msgid ""
+ "The width, height, depth or italic correction of %s is too big. Tfm files "
+-"may not contain values bigger than 16 times the em-size of the font. Width="
+-"%g, height=%g, depth=%g, italic correction=%g"
++"may not contain values bigger than 16 times the em-size of the font. "
++"Width=%g, height=%g, depth=%g, italic correction=%g"
+ msgstr ""
+ "Die Dickte, Höhe, Tiefe oder Kursiv-Korrektur %s sind zu groß. Tfm-Dateien "
+ "können nicht Werte größer als 16 mal die Geviertgröße enthalten. Dickte=%g, "
+@@ -21512,16 +21511,16 @@ msgstr ""
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d ∆x_adv="
+-"%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
++"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d "
++"∆x_adv=%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ msgstr ""
+ "„%s” in %s enthielt keine Nachschlagetabelle der paarweisen Positionierung "
+ "∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv="
+-"%d\n"
++"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d "
++"∆y_adv=%d\n"
+ msgstr ""
+ "„%s” in %s enthielt keine Nachschlagetabelle der Positionierung ∆x=%d ∆y=%d "
+ "∆x_adv=%d ∆y_adv=%d\n"
+diff --git a/po/el.po b/po/el.po
+index d942c68c6d..226afbe82c 100644
+--- a/po/el.po
++++ b/po/el.po
+@@ -12,8 +12,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Greek\n"
+ "Language: el_GR\n"
+diff --git a/po/en_GB.po b/po/en_GB.po
+index 9bd2d62bb6..40ec187cc7 100644
+--- a/po/en_GB.po
++++ b/po/en_GB.po
+@@ -12,8 +12,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: English, United Kingdom\n"
+ "Language: en_GB\n"
+@@ -133,6 +133,9 @@ msgstr ""
+ " Use of GDEF rather than lcar/prop\n"
+ "If both this and Apple are set, both formats are generated"
+ 
++msgid "Arabic"
++msgstr "Arabic"
++
+ msgid "Are you sure you don't want to use the cidmap I found?"
+ msgstr "Are you sure you do not want to use the cidmap I found?"
+ 
+@@ -726,7 +729,6 @@ msgstr "Spiros did not converge"
+ msgid "Template Color"
+ msgstr "Template Colour"
+ 
+-#, c-format
+ msgid ""
+ "The %1$s in the search dialog contains a reference to %2$.20hs which does "
+ "not exist in the new font.\n"
+diff --git a/po/es.po b/po/es.po
+index 424b0177b6..31603cd120 100644
+--- a/po/es.po
++++ b/po/es.po
+@@ -15,8 +15,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Spanish\n"
+ "Language: es_ES\n"
+@@ -453,6 +453,9 @@ msgstr "Argumento"
+ msgid "Arabic"
+ msgstr "Árabe"
+ 
++msgid "Arabic Supplement"
++msgstr "Árabe, suplemento"
++
+ msgid "Arakanese"
+ msgstr "Arakanés"
+ 
+@@ -1223,6 +1226,9 @@ msgstr ""
+ "Verificar si una substitución, una clase de interletraje, etc. utiliza un "
+ "nombre de glifo que no existe en la fuente"
+ 
++msgid "Cherokee"
++msgstr "Cheroqui"
++
+ msgid "Chinese (Hong Kong)"
+ msgstr "Chino (Hong Kong) zh_CN"
+ 
+@@ -1283,6 +1289,9 @@ msgstr "Co_piar margen izquierdo"
+ msgid "Com_binations"
+ msgstr "Com_binaciones"
+ 
++msgid "Combining Diacritical Marks"
++msgstr "Marcas diacríticas combinables"
++
+ msgid "Comment"
+ msgstr "Comentario"
+ 
+@@ -1459,6 +1468,9 @@ msgstr "Cor_tar"
+ msgid "Cubic"
+ msgstr "Cúbico"
+ 
++msgid "Cuneiform"
++msgstr "Cuneiforme"
++
+ msgid "Current"
+ msgstr "Actual"
+ 
+@@ -2538,6 +2550,9 @@ msgstr "Gallego"
+ msgid "Gaudeamus Ligature!"
+ msgstr "¡Alabemos la ligadura!"
+ 
++msgid "General Punctuation"
++msgstr "Puntuación general"
++
+ msgid "Generate Mac _Family..."
+ msgstr "Generar _familia para Mac..."
+ 
+@@ -3517,6 +3532,9 @@ msgstr "Diseños maestros"
+ msgid "Mathematical Greek"
+ msgstr "Griego para matemáticas"
+ 
++msgid "Mayan Numerals"
++msgstr "Cifras mayas"
++
+ msgid "Measure distance, angle between points"
+ msgstr "Medir distancia, ángulo entre puntos"
+ 
+@@ -4099,6 +4117,9 @@ msgstr "Abrir referencia"
+ msgid "Open failed"
+ msgstr "Error al abrir"
+ 
++msgid "Optical Character Recognition"
++msgstr "Reconocimiento óptico de caracteres"
++
+ msgid "Options"
+ msgstr "Opciones"
+ 
+@@ -4668,6 +4689,9 @@ msgstr "Ajustar a la horizo_ntal/vertical"
+ msgid "Sa_me Glyph As"
+ msgstr "Igual carácter que(_M)"
+ 
++msgid "Samaritan"
++msgstr "Samaritano"
++
+ msgid "Same as PostScript Names"
+ msgstr "Igual que los nombres de PostScript"
+ 
+@@ -5117,6 +5141,9 @@ msgstr "Espacia_r regiones..."
+ msgid "Space:"
+ msgstr "Espaciado:"
+ 
++msgid "Spacing Modifier Letters"
++msgstr "Letras modificadoras con espaciado"
++
+ msgid "Spanish"
+ msgstr "Español"
+ 
+@@ -5239,6 +5266,33 @@ msgstr "Trazado..."
+ msgid "Style Set 1"
+ msgstr "Estilo 1"
+ 
++msgid "Style Set 10"
++msgstr "Conjunto estilístico 10"
++
++msgid "Style Set 11"
++msgstr "Conjunto estilístico 11"
++
++msgid "Style Set 12"
++msgstr "Conjunto estilístico 12"
++
++msgid "Style Set 13"
++msgstr "Conjunto estilístico 13"
++
++msgid "Style Set 14"
++msgstr "Conjunto estilístico 14"
++
++msgid "Style Set 15"
++msgstr "Conjunto estilístico 15"
++
++msgid "Style Set 16"
++msgstr "Conjunto estilístico 16"
++
++msgid "Style Set 17"
++msgstr "Conjunto estilístico 17"
++
++msgid "Style Set 18"
++msgstr "Conjunto estilístico 18"
++
+ msgid "Style Set 2"
+ msgstr "Estilo 2"
+ 
+@@ -5251,6 +5305,18 @@ msgstr "Estilo 4"
+ msgid "Style Set 5"
+ msgstr "Estilo 5"
+ 
++msgid "Style Set 6"
++msgstr "Conjunto estilístico 6"
++
++msgid "Style Set 7"
++msgstr "Conjunto estilístico 7"
++
++msgid "Style Set 8"
++msgstr "Conjunto estilístico 8"
++
++msgid "Style Set 9"
++msgstr "Conjunto estilístico 9"
++
+ msgid "Style _ID:"
+ msgstr "Estilo _ID:"
+ 
+@@ -5269,6 +5335,9 @@ msgstr "Sundanese (romano)"
+ msgid "Superscript"
+ msgstr "Supraíndice"
+ 
++msgid "Superscripts and Subscripts"
++msgstr "Superíndices y subíndices"
++
+ msgid "Swadaya Aramaic"
+ msgstr "Arameo swadaya"
+ 
+@@ -5309,6 +5378,9 @@ msgstr "La etiqueta debe constar de 4 caracteres"
+ msgid "Tag too long"
+ msgstr "Etiqueta demasiado larga"
+ 
++msgid "Tags"
++msgstr "Etiquetas"
++
+ msgid "Tahitian"
+ msgstr "Tahitiano"
+ 
+diff --git a/po/fr.po b/po/fr.po
+index 26e446b380..d4b2b7eb05 100644
+--- a/po/fr.po
++++ b/po/fr.po
+@@ -14,8 +14,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: French\n"
+ "Language: fr_FR\n"
+@@ -291,7 +291,7 @@ msgstr "chaîne %1$.30s pour %2$.30s"
+ #. GT: $4 is the changed flag ('*' for the changed items)
+ #, c-format
+ msgid "%1$.80s at %2$d from %3$.90s%4$s"
+-msgstr "%1$.80s à %2$d de %3$.90hs%4$s"
++msgstr "%1$.80s à %2$d de %3$.90s%4$s"
+ 
+ #. GT: This is the title for a window showing a bitmap character
+ #. GT: It will look something like:
+@@ -302,7 +302,7 @@ msgstr "%1$.80s à %2$d de %3$.90hs%4$s"
+ #. GT: $4 is the font name
+ #, c-format
+ msgid "%1$.80s at %2$d size %3$d from %4$.80s"
+-msgstr "%1$.80s (%2$d) taille %3$d de %4$.80hs"
++msgstr "%1$.80s (%2$d) taille %3$d de %4$.80s"
+ 
+ #, c-format
+ msgid "%1$s from lookup subtable %2$.50s"
+@@ -3131,16 +3131,16 @@ msgstr "Glyphe de ligature incorrect. GID %d ne peut être moins que %d\n"
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "Format de table de lookup incorrect: format=2 (%d/%d), premier=%d dernier=%d "
+ "total de glyphes dans la fonte=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "Format de table de lookup incorrect: format=4 (%d/%d), premier=%d dernier=%d "
+ "total de glyphes dans la fonte=%d\n"
+@@ -7433,7 +7433,7 @@ msgid ""
+ "Reverting the file will lose those changes.\n"
+ "Is that what you want?"
+ msgstr ""
+-"La fonte %1$.40s dans le fichier %2$.40hs a été modifiée.\n"
++"La fonte %1$.40s dans le fichier %2$.40s a été modifiée.\n"
+ "Revenir vous fera perdre toutes les modifications.\n"
+ "Voulez vous vraiment revenir ?"
+ 
+@@ -17879,8 +17879,8 @@ msgid "SnapToInt"
+ msgstr "Magnétisme aux entiers"
+ 
+ msgid ""
+-"So if you type \"A\" here the first selected glyph would be named \"A.suffix"
+-"\".\n"
++"So if you type \"A\" here the first selected glyph would be named \"A."
++"suffix\".\n"
+ "The second \"B.suffix\", and so on."
+ msgstr ""
+ "Donc, si vous tapiez \"A\" ici, le premier glyphe sélectionné serait nommé "
+@@ -19075,7 +19075,6 @@ msgstr ""
+ "pas à ceux de %4$.30s (nombre différent ou critères de recouvrement "
+ "différents)"
+ 
+-#, c-format
+ msgid ""
+ "The %1$s in the search dialog contains a reference to %2$.20hs which does "
+ "not exist in the new font.\n"
+@@ -19925,7 +19924,7 @@ msgid ""
+ "The fonts %1$.30s and %2$.30s have a different number of glyphs or different "
+ "encodings"
+ msgstr ""
+-"Les fontes %1$.30s et %2$.30hs n'ont pas le même nombre de glyphes ou des "
++"Les fontes %1$.30s et %2$.30s n'ont pas le même nombre de glyphes ou des "
+ "codages différents"
+ 
+ #, c-format
+@@ -19933,7 +19932,7 @@ msgid ""
+ "The fonts %1$.30s and %2$.30s use different types of splines (one quadratic, "
+ "one cubic)"
+ msgstr ""
+-"Les fontes %1$.30s et %2$.30hs utilisent des courbes de Bézier d'ordres "
++"Les fontes %1$.30s et %2$.30s utilisent des courbes de Bézier d'ordres "
+ "différents (quadratique et cubique)"
+ 
+ msgid "The generated font won't work with ATM"
+@@ -19968,8 +19967,8 @@ msgid ""
+ "The glyph %1$.30s in font %2$.30s has a different hint mask on its contours "
+ "than in %3$.30s"
+ msgstr ""
+-"Le glyphe %1$.30s dans la police %2$.30hs a un masque de hints différent que "
+-"dans %3$.30hs"
++"Le glyphe %1$.30s dans la police %2$.30s a un masque de hints différent que "
++"dans %3$.30s"
+ 
+ #, c-format
+ msgid ""
+@@ -19984,8 +19983,8 @@ msgid ""
+ "The glyph %1$.30s in font %2$.30s has a different number of references than "
+ "in %3$.30s"
+ msgstr ""
+-"Le glyphe %1$.30s de la fonte %2$.30hs a un nombre de références différent "
+-"dans %3$.30hs"
++"Le glyphe %1$.30s de la fonte %2$.30s a un nombre de références différent "
++"dans %3$.30s"
+ 
+ #, c-format
+ msgid ""
+@@ -20295,8 +20294,8 @@ msgid ""
+ "Enlarge this to make the autohinter more tolerable to small deviations from "
+ "straight lines when detecting stem edges."
+ msgstr ""
+-"La différence de pente maximale qui permet encore de considérer deux points"
+-"\"parallèle\".\n"
++"La différence de pente maximale qui permet encore de considérer deux "
++"points\"parallèle\".\n"
+ "Augmenter pour rendre la auto-hinter plus tolérant aux petits écarts entre\n"
+ "des lignes droites lors de la détection des bords du fut ou de la traverse."
+ 
+@@ -20457,7 +20456,7 @@ msgstr ""
+ #, c-format
+ msgid "The outlines of glyph %2$.30s were not found in the font %1$.60s"
+ msgstr ""
+-"Le contours du glyphe %2$.30s n'ont pas été trouvés dans la police %1$.60hs"
++"Le contours du glyphe %2$.30s n'ont pas été trouvés dans la police %1$.60s"
+ 
+ msgid "The paths that make up this glyph intersect one another"
+ msgstr "Les chemins qui composent ce glyphe se coupent les uns les autres"
+@@ -20805,12 +20804,12 @@ msgstr "La largeur de la ligne utilisée pour dessiner les points sélectionnés
+ #, c-format
+ msgid ""
+ "The width, height, depth or italic correction of %s is too big. Tfm files "
+-"may not contain values bigger than 16 times the em-size of the font. Width="
+-"%g, height=%g, depth=%g, italic correction=%g"
++"may not contain values bigger than 16 times the em-size of the font. "
++"Width=%g, height=%g, depth=%g, italic correction=%g"
+ msgstr ""
+ "La largeur, hauteur, profondeur ou correction italique de %s est trop "
+-"grande. En TFM, on ne peut pas dépasser 16 fois le EM de la fonte.Largeur="
+-"%g, hauteur=%g, profondeur=%g, correction italique=%g"
++"grande. En TFM, on ne peut pas dépasser 16 fois le EM de la fonte."
++"Largeur=%g, hauteur=%g, profondeur=%g, correction italique=%g"
+ 
+ msgid "The x coord of the selected point is near the specified value"
+ msgstr "La'abscisse du point sélectionné est proche de la valeur de consigne"
+@@ -21042,7 +21041,7 @@ msgstr "Il y a déjà une sous-table avec ce nom, changez de nom SVP"
+ 
+ #, c-format
+ msgid "There is already an anchor point named %1$.40s in %2$.40s."
+-msgstr "Il y a déjà une ancre appelée %1$.40s dans %2$.40hs."
++msgstr "Il y a déjà une ancre appelée %1$.40s dans %2$.40s."
+ 
+ msgid "There is another glyph in the font with this name"
+ msgstr "Il y a un autre glyphe dans la fonte avec ce nom"
+@@ -21076,8 +21075,8 @@ msgstr "Il n'y a pas de glyphe %s dans cette fonte,"
+ 
+ msgid "There may be at most one reference with the use-my-metrics bit set"
+ msgstr ""
+-"Il ne doit pas y avoir plus d'une référence avec le \"use-my metrics bit set"
+-"\""
++"Il ne doit pas y avoir plus d'une référence avec le \"use-my metrics bit "
++"set\""
+ 
+ #, c-format
+ msgid ""
+@@ -21441,8 +21440,8 @@ msgid ""
+ "been able to find is %1$.20s-%2$.20s-%4$d.\n"
+ "Shall I use that or let you search?"
+ msgstr ""
+-"Cette fonte est basée sur le jeu de caractères %1$.20s-%2$.20hs-%3$d, mais "
+-"ce que j'ai trouvé de mieux c'est %1$.20hs-%2$.20hs-%4$d.\n"
++"Cette fonte est basée sur le jeu de caractères %1$.20s-%2$.20s-%3$d, mais ce "
++"que j'ai trouvé de mieux c'est %1$.20s-%2$.20s-%4$d.\n"
+ "Devrais-je utiliser cette valeur ou préférez vous chercher ?"
+ 
+ msgid ""
+@@ -21671,8 +21670,8 @@ msgid ""
+ "FontForge\n"
+ "does not support. FontForge only supports 'IK' format fonts.\n"
+ msgstr ""
+-"Ceci est probablement une fonte URW valide, mais elle est dans un format (% c"
+-"% c) que FontForge\n"
++"Ceci est probablement une fonte URW valide, mais elle est dans un format "
++"(% c% c) que FontForge\n"
+ "ne supporte pas. FontForge ne prend en charge que les fontes de format "
+ "'IK'.\n"
+ 
+@@ -21770,7 +21769,7 @@ msgid ""
+ "with a 0 offset for this combination. Would you like to alter this kerning "
+ "class entry (or create a kerning pair for just these two glyphs)?"
+ msgstr ""
+-"Cette paire de crénage (%.20s et %.20hs) est dans une classe de crénage\n"
++"Cette paire de crénage (%.20s et %.20s) est dans une classe de crénage\n"
+ "avec un déplacement de 0 pour cette combinaison. Voulez-vous modifier cette "
+ "partie\n"
+ "de la classe de crénage (ou créer une nouvelle paire rien que pour ces 2 "
+@@ -21864,8 +21863,8 @@ msgstr ""
+ #, c-format
+ msgid "This name was previously used to identify mark class/set #%d."
+ msgstr ""
+-"Ce nom a précédemment été utilisé pour identifier la classe/jeu de signes #"
+-"%d."
++"Ce nom a précédemment été utilisé pour identifier la classe/jeu de signes "
++"#%d."
+ 
+ #, c-format
+ msgid "This namelist contains at least one non-ASCII glyph name, namely: %s"
+@@ -23657,8 +23656,8 @@ msgid ""
+ "and %s@0x%02x)\n"
+ " Only one will be used here.\n"
+ msgstr ""
+-"Attention: Le codage %d (0x%x) correspond à au moins deux emplacements (%s@0x"
+-"%02x et %s@0x%02x)\n"
++"Attention: Le codage %d (0x%x) correspond à au moins deux emplacements "
++"(%s@0x%02x et %s@0x%02x)\n"
+ " Un seul sera utilisé ici.\n"
+ 
+ msgid "Warning: Font Bucket version 4 treated as 0.\n"
+@@ -24161,8 +24160,8 @@ msgstr ""
+ 
+ msgid "When serifs are removed (as first two in \"m\"), replace with:"
+ msgstr ""
+-"Lors de la suppression des empattements (comme les deux premières dans \"m"
+-"\"), remplacer avec:"
++"Lors de la suppression des empattements (comme les deux premières dans "
++"\"m\"), remplacer avec:"
+ 
+ msgid ""
+ "When the hint's position is changed\n"
+@@ -24551,8 +24550,8 @@ msgid ""
+ "referred to.\n"
+ "It will not be copied."
+ msgstr ""
+-"Vous essayer de coller une référence vers %1$s dans %2$hs.\n"
+-"Mais %1$hs n'existe pas dans cette fonte, et FontForge ne trouve pas le "
++"Vous essayer de coller une référence vers %1$s dans %2$s.\n"
++"Mais %1$s n'existe pas dans cette fonte, et FontForge ne trouve pas le "
+ "glyphe auquel il se référait.\n"
+ "Le glyphe ne sera pas copié."
+ 
+@@ -24562,8 +24561,8 @@ msgid ""
+ "But %1$s does not exist in this font.\n"
+ "Would you like to copy the original splines (or delete the reference)?"
+ msgstr ""
+-"Vous essayer de coller une référence vers %1$s dans %2$hs.\n"
+-"Mais %1$hs n'existe pas dans cette fonte.\n"
++"Vous essayer de coller une référence vers %1$s dans %2$s.\n"
++"Mais %1$s n'existe pas dans cette fonte.\n"
+ "Voulez vous copier le contour d'origine (ou supprimer la référence)?"
+ 
+ msgid ""
+@@ -26385,16 +26384,16 @@ msgstr ""
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d ∆x_adv="
+-"%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
++"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d "
++"∆x_adv=%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ msgstr ""
+ "\"%s\" dans %s ne contenait pas de lookup de positionnement par paire ∆x=%d "
+ "∆y=%d ∆x_adv=%d ∆y_adv=%d à %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv="
+-"%d\n"
++"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d "
++"∆y_adv=%d\n"
+ msgstr ""
+ "\"%s\" dans %s ne contenait pas de lookup de positionnement ∆x=%d ∆y=%d "
+ "∆x_adv=%d ∆y_adv=%d\n"
+diff --git a/po/hr.po b/po/hr.po
+index d261d4ca76..c10a697102 100644
+--- a/po/hr.po
++++ b/po/hr.po
+@@ -11,16 +11,16 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Croatian\n"
+ "Language: hr_HR\n"
+ "MIME-Version: 1.0\n"
+ "Content-Type: text/plain; charset=UTF-8\n"
+ "Content-Transfer-Encoding: 8bit\n"
+-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
++"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
++"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+ "X-Crowdin-Project: fontforge\n"
+ "X-Crowdin-Project-ID: 368599\n"
+ "X-Crowdin-Language: hr\n"
+@@ -237,8 +237,8 @@ msgid ""
+ "!!!!! Bad Base Coord format (%d) for '%c%c%c%c' in '%c%c%c%c' script in "
+ "'BASE' table\n"
+ msgstr ""
+-"!!!!! Neispravni format koordinata osnove (%d) za '%c%c%c%c' u pismu '%c%c%c"
+-"%c' u 'BASE' tablici\n"
++"!!!!! Neispravni format koordinata osnove (%d) za '%c%c%c%c' u pismu "
++"'%c%c%c%c' u 'BASE' tablici\n"
+ 
+ #, c-format
+ msgid ""
+@@ -695,6 +695,15 @@ msgstr "300 Svijetli"
+ msgid "32x8 cell window"
+ msgstr "Prozor: 32 × 8 polja"
+ 
++msgid "3D Buttons"
++msgstr "3D gumbovi"
++
++msgid "3D Dark Edge Color"
++msgstr "3D tamna boja ruba"
++
++msgid "3D Light Edge Color"
++msgstr "3D svijetla boja ruba"
++
+ msgid "4"
+ msgstr "4"
+ 
+@@ -1484,6 +1493,9 @@ msgstr ""
+ msgid "Adding points at Extrema..."
+ msgstr "Dodavanje točaka ektrema …"
+ 
++msgid "Adding points of inflection..."
++msgstr "Dodavanje točkaka infleksije …"
++
+ msgid "Additional arguments for autotrace program:"
+ msgstr "Dodatni argumenti za program za automatsko precrtavanje:"
+ 
+@@ -2065,6 +2077,9 @@ msgstr ""
+ "NAPOMENA: 'WinDescent' je POZITIVNI broj, a odnosi se na sve\n"
+ "što se nalazi ispod osnovne pismovne linije."
+ 
++msgid "Appea_rance Editor..."
++msgstr "U_ređivač prikaza …"
++
+ msgid "Append a FONTLOG entry"
+ msgstr "Dodaj FONTLOG zapis"
+ 
+@@ -2244,6 +2259,9 @@ msgstr "Arapsko, prošireno A"
+ msgid "Arabic Extended-B"
+ msgstr "Arapsko, prošireno B"
+ 
++msgid "Arabic Extended-C"
++msgstr "Arapsko prošireno-C"
++
+ msgid "Arabic Mathematical Alphabetic Symbols"
+ msgstr "Arapski matematički alfanumerički simboli"
+ 
+@@ -2373,6 +2391,9 @@ msgstr ""
+ "Uzlazni i silazni potezi moraju imati pozitivne vrijednosti, a njihov zbroj "
+ "manji od 16384"
+ 
++msgid "Ascent/Descent Color"
++msgstr "Boja uzlaznog/silaznog poteza"
++
+ msgid "Ask"
+ msgstr "Pitaj"
+ 
+@@ -3291,16 +3312,16 @@ msgstr "Neispravni grafem ligature. ID-oznaka grafema %d ne manja od %d\n"
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "Neispravna tablica definicija: format=2 (%d/%d), prvi=%d zadnji=%d ukupno "
+ "grafema u fontu=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "Neispravna tablica definicija: format=4 (%d/%d), prvi=%d zadnji=%d ukupno "
+ "grafema u fontu=%d\n"
+@@ -3797,6 +3818,9 @@ msgstr "Debeli"
+ msgid "Bold Italic"
+ msgstr "Debeli Kurziv"
+ 
++msgid "Bold font used in the Tile Path dialog"
++msgstr "Podebljani font za dijalog staza pločica"
++
+ msgid "Bone"
+ msgstr "Kosturni"
+ 
+@@ -4111,6 +4135,9 @@ msgstr "KJK sjedinjeni ideogrami, proširenje F"
+ msgid "CJK Unified Ideographs Extension G"
+ msgstr "KJK sjedinjeni ideogrami, proširenje G"
+ 
++msgid "CJK Unified Ideographs Extension H"
++msgstr "KJK sjedinjeni ideogrami, proširenje H"
++
+ msgid "CS Clarendon"
+ msgstr "4.1 – Clarendon"
+ 
+@@ -5166,12 +5193,24 @@ msgstr "Boja etiketa grafema kad etiketa nedostaje"
+ msgid "Color of the active entry in the main section of a matrix edit"
+ msgstr "Boja za aktivne zapise u glavnom odjeljku matrice"
+ 
++msgid "Color of the ascent and descent lines"
++msgstr "Boja za crte veličina uzlaznih i silaznih poteza"
++
+ msgid "Color of the font used to display glyph information in the fontview"
+ msgstr "Boja fonta za prikaz informacija o grafemu u prikazu fonta"
+ 
+ msgid "Color of the line between label and glyph"
+ msgstr "Boja linije između etikete i grafema"
+ 
++msgid "Color of the x=0 and y=0 lines"
++msgstr "Boja x=0 i y=0 linija"
++
++msgid "Color used for (some) glyph names in Show ATT dialog"
++msgstr "Boja za (neka) imena grafema u dijalogu Prikaži ATT"
++
++msgid "Color used for currently selected entry in Show ATT dialog"
++msgstr "Boja za trenutačno odabrani unos u dijalogu Prikaži ATT"
++
+ msgid "Color used to draw the advance width line of a glyph"
+ msgstr "Boja za crtanje linije, koja označuje širinu stošca"
+ 
+@@ -5208,6 +5247,18 @@ msgstr "Boja za onačavanje odabranih grafema"
+ msgid "Color:"
+ msgstr "Boja:"
+ 
++msgid "Colors of lines and fills in outline window"
++msgstr "Boje linija i ispuna u prozoru kontura"
++
++msgid "Colors related to CFF/PostScript hints"
++msgstr "Boje CFF/PostScript kontrola"
++
++msgid "Colors, etc of points in glyph outline window"
++msgstr "Boje itd. točaka u prozoru kontura grafema"
++
++msgid "Colors, etc. related to tool use in outline window"
++msgstr "Boje itd. koje se odnose na korištenje alata u prozoru kontura"
++
+ msgid "Color|Background"
+ msgstr "Stražnja boja"
+ 
+@@ -5984,6 +6035,9 @@ msgstr "Ćirilica prošireno-B"
+ msgid "Cyrillic Extended-C"
+ msgstr "Ćirilica prošireno-C"
+ 
++msgid "Cyrillic Extended-D"
++msgstr "Ćirilica prošireno-D"
++
+ msgid "Cyrillic Supplement"
+ msgstr "Ćirilica, dopuna"
+ 
+@@ -6121,6 +6175,9 @@ msgstr "Zadana debljina crte iznad i za nadcrte"
+ msgid "Default:"
+ msgstr "Zadano:"
+ 
++msgid "DefaultFont"
++msgstr "Standardni font"
++
+ msgid "Define \"Almost Horizontal\""
+ msgstr "Definiraj „Zamalo vodoravno”"
+ 
+@@ -6262,6 +6319,9 @@ msgstr "Devanagari"
+ msgid "Devanagari Extended"
+ msgstr "Devanagari prošireno"
+ 
++msgid "Devanagari Extended-A"
++msgstr "Devanagari prošireno-A"
++
+ msgid "Devanagari2"
+ msgstr "Devanagari2"
+ 
+@@ -8098,6 +8158,9 @@ msgstr "Font promijenjen"
+ msgid "Font file has bad glyph count field. maxp says: %d sizeof(loca)=>%d"
+ msgstr "Font sadrži neipravno polje brojanja. 'maxp' kaže: %d sizeof(loca)=>%d"
+ 
++msgid "Font for Mac Features in Preferences dialog"
++msgstr "Font za Mac funkcije u dijalogu potavki"
++
+ #, c-format
+ msgid "Font to compare with %.20s"
+ msgstr "Uspoređivanje fonta s %.20s"
+@@ -8106,6 +8169,9 @@ msgstr "Uspoređivanje fonta s %.20s"
+ msgid "Font to merge into %.20s"
+ msgstr "Font za sjedinjavanje u %.20s"
+ 
++msgid "Font used in the Glyph Info dialog"
++msgstr "Korišteni font u dijalogu informacija o grafemu"
++
+ msgid "Font used to draw titles of a matrix edit"
+ msgstr "Font za naslove matrice"
+ 
+@@ -8909,6 +8975,9 @@ msgstr "Granični okvir grafema uži od"
+ msgid "Glyph BB Right Of"
+ msgstr "Granični okvir grafema širi od"
+ 
++msgid "Glyph Color"
++msgstr "Boja grafema"
++
+ msgid "Glyph Composition/Decomposition"
+ msgstr "Sastavljanje/Rastavljanje grafema"
+ 
+@@ -10225,6 +10294,9 @@ msgstr "Zanemari spojne dijakritičke znakove"
+ msgid "Ignore Ligatures"
+ msgstr "Zanemari ligature"
+ 
++msgid "Ignore invalid substitutions"
++msgstr "Zanemari nevažeće zamjene"
++
+ msgid "Ignore this problem in the future"
+ msgstr "Ubuduće zanemari ovaj problem"
+ 
+@@ -10309,6 +10381,9 @@ msgstr "Uvezi tablicu definicija"
+ msgid "Import Parameters"
+ msgstr "Uvezi parametre"
+ 
++msgid "Import feature file"
++msgstr "Uvezi datoteku funkcija"
++
+ msgid "Imports a lookup (and all its subtables) from another font."
+ msgstr "Uvozi tablicu definicija (i sve pod-tablice) iz jednog drugog fonta."
+ 
+@@ -12737,6 +12812,9 @@ msgstr "Matematički operatori"
+ msgid "Mathematical centerline"
+ msgstr "Matematička srednja linija"
+ 
++msgid "Mathematical text layout"
++msgstr "Raspored matematičkog teksta"
++
+ msgid "Matrix Edit"
+ msgstr "Matrica za uređivanje"
+ 
+@@ -14332,6 +14410,9 @@ msgstr "Normalni bezserifni"
+ msgid "Normal Text Color:"
+ msgstr "Boja za obični tekst:"
+ 
++msgid "Normal font used in the Tile Path dialog"
++msgstr "Normalni font za dijalog staza pločica"
++
+ msgid "Normal/Boxed"
+ msgstr "Normalno/Kutijasto"
+ 
+@@ -15216,15 +15297,24 @@ msgstr "Konturni fontovi"
+ msgid "Outline Glyphs\n"
+ msgstr "Konturni grafemi\n"
+ 
++msgid "Outline Hints"
++msgstr "Kontrole kontura"
++
+ msgid "Outline Inner Border"
+ msgstr "Unutarnji obrub konture"
+ 
++msgid "Outline Lines/Fills"
++msgstr "Linije/Ispune konture"
++
+ msgid "Outline Outer Border"
+ msgstr "Vanjski obrub konture"
+ 
+ msgid "Outline Points"
+ msgstr "Točke konture"
+ 
++msgid "Outline Tools"
++msgstr "Alati za konture"
++
+ msgid "Outline View"
+ msgstr "Prikaz konture"
+ 
+@@ -15399,6 +15489,12 @@ msgstr "Pa_lete"
+ msgid "Palestinian Aramaic"
+ msgstr "Palestinski aramejski"
+ 
++msgid "Palette Background Color"
++msgstr "Paleta boje pozadine"
++
++msgid "Palette Foreground Color"
++msgstr "Paleta prednje boje"
++
+ msgid "Palettes"
+ msgstr "Palete"
+ 
+@@ -17247,6 +17343,9 @@ msgstr "Boja za razdvojne crte"
+ msgid "Ruler Big Tick Color"
+ msgstr "Boja za velike oznake ravnala"
+ 
++msgid "Ruler Font"
++msgstr "Font ravnala"
++
+ msgid "Ruler Options"
+ msgstr "Opcije ravnala"
+ 
+@@ -18235,6 +18334,9 @@ msgstr "'Fuzz' visina serifa"
+ msgid "Serif height:"
+ msgstr "Visina serifa:"
+ 
++msgid "SerifFont"
++msgstr "Serifni font"
++
+ msgid "SerifSlopeError"
+ msgstr "Greška nagiba serifa"
+ 
+@@ -18808,8 +18910,8 @@ msgid "SnapToInt"
+ msgstr "Privlači na cjelobrojne vrijednosti"
+ 
+ msgid ""
+-"So if you type \"A\" here the first selected glyph would be named \"A.suffix"
+-"\".\n"
++"So if you type \"A\" here the first selected glyph would be named \"A."
++"suffix\".\n"
+ "The second \"B.suffix\", and so on."
+ msgstr ""
+ "Prema tome, ako ovdje utipkaš 'A', onda će se prvi odabrani grafem\n"
+@@ -20085,6 +20187,9 @@ msgstr "Temne"
+ msgid "Template Color"
+ msgstr "Boja za predložak"
+ 
++msgid "Template Outline Color"
++msgstr "Boja konture predloška"
++
+ msgid "Terminal Forms"
+ msgstr "Završni oblici"
+ 
+@@ -20154,7 +20259,6 @@ msgstr ""
+ "'%1$s' kontrole u grafemu \"%2$.30s\" u fontu %3$.30s se ne poklapaju s "
+ "onima u %4$.30s (različiti broj ili različiti kriteriji preklapanja)"
+ 
+-#, c-format
+ msgid ""
+ "The %1$s in the search dialog contains a reference to %2$.20hs which does "
+ "not exist in the new font.\n"
+@@ -21344,9 +21448,9 @@ msgid ""
+ "\n"
+ "Would you like to add this script to one of those features?"
+ msgstr ""
+-"Tablica definicija %.30s je aktivan za grafem %.30s koji ima pismo '%c%c%c"
+-"%c', međutim tog pisma čini se nema u niti jednoj funkciji koja primijenjuje "
+-"tablicu definicija.\n"
++"Tablica definicija %.30s je aktivan za grafem %.30s koji ima pismo "
++"'%c%c%c%c', međutim tog pisma čini se nema u niti jednoj funkciji koja "
++"primijenjuje tablicu definicija.\n"
+ "\n"
+ "Želiš li dodati ovo pismo u jednu od tih funkcija?"
+ 
+@@ -21960,8 +22064,8 @@ msgstr "Širina linije koja se koristi za crtanje odabranih točaka"
+ #, c-format
+ msgid ""
+ "The width, height, depth or italic correction of %s is too big. Tfm files "
+-"may not contain values bigger than 16 times the em-size of the font. Width="
+-"%g, height=%g, depth=%g, italic correction=%g"
++"may not contain values bigger than 16 times the em-size of the font. "
++"Width=%g, height=%g, depth=%g, italic correction=%g"
+ msgstr ""
+ "Širina, visina, dubina ili ispravljanje kurziva od %s su preveliki. Tfm "
+ "datoteke ne smiju sadržati vrijednosti veće od 16 puta veličine četverca "
+@@ -24507,6 +24611,12 @@ msgstr "Koristi novo indijsko pismo"
+ msgid "UsePlugins"
+ msgstr "Koristi dodatke"
+ 
++msgid "Used for point numbers, hints, etc."
++msgstr "Koristi se za brojeve točaka, kontrole itd."
++
++msgid "Used for ruler numbers and other ruler notations."
++msgstr "Koristi se za brojeve i druge oznake ravnala."
++
+ msgid "User controls the emboldening with the next two fields"
+ msgstr "Korisnik kontrolira podebljavanje pomoću sljedeća dva polja"
+ 
+@@ -24874,7 +24984,6 @@ msgstr ""
+ "Upozorenje: 'cvar' sadrži međupodatke n-torke.\n"
+ " FontForge to ne podržava.\n"
+ 
+-#, c-format
+ msgid "Warning: Accuracy target %lf less than minimum %lf, using %lf instead\n"
+ msgstr ""
+ "Upozorenje: Ciljana točnost %lf manja je od minimalne %lf, umjesto toga se "
+@@ -24893,7 +25002,6 @@ msgstr "Upozorenje: Kraj konture se nije zatvorio\n"
+ msgid "Warning: Contour start did not close\n"
+ msgstr "Upozorenje: Početak konture se nije zatvorio\n"
+ 
+-#, c-format
+ msgid "Warning: Coordinate diff %lf greater than margin %lf\n"
+ msgstr "Upozorenje: Razlika koordinate %lf veća je od margine %lf\n"
+ 
+@@ -27962,16 +28070,16 @@ msgstr ""
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d ∆x_adv="
+-"%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
++"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d "
++"∆x_adv=%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ msgstr ""
+ "„%s” u %s ne sadrži tablicu definicija pozicioniranja parova ∆x=%d ∆y=%d "
+ "∆x_adv=%d ∆y_adv=%d s %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv="
+-"%d\n"
++"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d "
++"∆y_adv=%d\n"
+ msgstr ""
+ "„%s” u %s ne sadrži tablicu definicija pozicioniranja ∆x=%d ∆y=%d ∆x_adv=%d "
+ "∆y_adv=%d\n"
+diff --git a/po/it.po b/po/it.po
+index e13711485c..a3136f7bdf 100644
+--- a/po/it.po
++++ b/po/it.po
+@@ -13,8 +13,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-31 08:24\n"
+ "Last-Translator: \n"
+ "Language-Team: Italian\n"
+ "Language: it_IT\n"
+@@ -2303,7 +2303,7 @@ msgid ""
+ "Reverting the file will lose those changes.\n"
+ "Is that what you want?"
+ msgstr ""
+-"Il font %1$.40s nel file %2$.40hs è stato modificato.\n"
++"Il font %1$.40s nel file %2$.40s è stato modificato.\n"
+ "Ripristinando il file perderai tutte le modifiche.\n"
+ "È quello che vuoi fare?"
+ 
+@@ -5835,7 +5835,7 @@ msgid ""
+ "The glyph %1$.30s has a different number of contours in font %2$.30s than in "
+ "%3$.30s"
+ msgstr ""
+-"Il glifo %1$.30s ha un diverso numero di contorni nel font %2$.30hs rispetto "
++"Il glifo %1$.30s ha un diverso numero di contorni nel font %2$.30s rispetto "
+ "a %3$.30s"
+ 
+ #, c-format
+@@ -6235,8 +6235,8 @@ msgid ""
+ "been able to find is %1$.20s-%2$.20s-%4$d.\n"
+ "Shall I use that or let you search?"
+ msgstr ""
+-"Questo font è basato sulla codifica di caratteri %1$.20s-%2$.20hs-%3$d, ma "
+-"il migliore che io abbia trovato è %1$.20hs-%2$.20hs-%4$d.\n"
++"Questo font è basato sulla codifica di caratteri %1$.20s-%2$.20s-%3$d, ma il "
++"migliore che io abbia trovato è %1$.20s-%2$.20s-%4$d.\n"
+ "Devo usare questo valore o preferisci cercare tu stesso?"
+ 
+ msgid ""
+diff --git a/po/ja.po b/po/ja.po
+index ed9f5a645b..11825c73d4 100644
+--- a/po/ja.po
++++ b/po/ja.po
+@@ -15,8 +15,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Japanese\n"
+ "Language: ja_JP\n"
+@@ -388,6 +388,36 @@ msgstr "< 前(_P)"
+ msgid "<Nothing>"
+ msgstr "<何もしない>"
+ 
++msgid "<Unassigned Plane 10>"
++msgstr "〈保留未使用面10〉"
++
++msgid "<Unassigned Plane 11>"
++msgstr "〈保留未使用面11〉"
++
++msgid "<Unassigned Plane 12>"
++msgstr "〈保留未使用面12〉"
++
++msgid "<Unassigned Plane 13>"
++msgstr "〈保留未使用面13〉"
++
++msgid "<Unassigned Plane 4>"
++msgstr "〈保留未使用面4〉"
++
++msgid "<Unassigned Plane 5>"
++msgstr "〈保留未使用面5〉"
++
++msgid "<Unassigned Plane 6>"
++msgstr "〈保留未使用面6〉"
++
++msgid "<Unassigned Plane 7>"
++msgstr "〈保留未使用面7〉"
++
++msgid "<Unassigned Plane 8>"
++msgstr "〈保留未使用面8〉"
++
++msgid "<Unassigned Plane 9>"
++msgstr "〈保留未使用面9〉"
++
+ msgid "<Unknown direction>"
+ msgstr "<方向不明>"
+ 
+@@ -961,7 +991,7 @@ msgstr ""
+ "わずかに拡大/縮小します."
+ 
+ msgid "An outline font editor"
+-msgstr "アウトラインフォントエディタ"
++msgstr "アウトラインフォントエディター"
+ 
+ msgid "Anchor Control"
+ msgstr "アンカーの制御"
+@@ -1023,6 +1053,15 @@ msgstr ""
+ "追加されます. ほとんどの場合,このフィールドを0にして\n"
+ "\"[*]オフセットを指定\"にチェックを入れるべきでしょう."
+ 
++msgid "Appea_rance Editor..."
++msgstr "外観エディター(_R)..."
++
++msgid "Appearance Editor"
++msgstr "外観エディター"
++
++msgid "Apple"
++msgstr "アップル社"
++
+ msgid "Apple Advanced Typography"
+ msgstr "Apple 高度組版機能"
+ 
+@@ -1769,16 +1808,16 @@ msgstr "合字グリフが不正です. GID %d が %d 未満ではありませ
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "フォーマット 2 (%d/%d) の照合テーブルが壊れています.最初=%d 最後=%d フォント"
+ "内の全グリフ数=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "フォーマット 4 (%d/%d) の照合テーブルが壊れています.最初=%d 最後=%d フォント"
+ "内の全グリフ数=%d\n"
+@@ -1786,8 +1825,8 @@ msgstr ""
+ #, c-format
+ msgid "Bad lookup table: format=6, first=%d total glyphs in font=%d\n"
+ msgstr ""
+-"フォーマット 6 の照合テーブルが壊れています.最初=%d フォント内の全グリフ数="
+-"%d\n"
++"フォーマット 6 の照合テーブルが壊れています.最初=%d フォント内の全グリフ数"
++"=%d\n"
+ 
+ #, c-format
+ msgid "Bad lookup table: format=8, first=%d cnt=%d total glyphs in font=%d\n"
+@@ -2260,6 +2299,9 @@ msgstr "(裸の) CFF CID"
+ msgid "CFF version mismatch\n"
+ msgstr "CFF のバージョンが合っていません\n"
+ 
++msgid "CID"
++msgstr "CID"
++
+ msgid "CID findfont Name"
+ msgstr "CID findfont名"
+ 
+@@ -2554,7 +2596,10 @@ msgid "Change _Weight..."
+ msgstr "ウェイトを変更(_W)..."
+ 
+ msgid "Change _X-Height..."
+-msgstr "_Xハイトを変更..."
++msgstr "Xハイトを変更(_X)..."
++
++msgid "Change whether spiro is active or not"
++msgstr "螺旋描画モード切り替え"
+ 
+ msgid ""
+ "Changing the left side bearing\n"
+@@ -2970,6 +3015,9 @@ msgstr "AFMで合成グリフを使用"
+ msgid "Condensed"
+ msgstr "コンデンス"
+ 
++msgid "Config_ure Plugins..."
++msgstr "プラグインの設定(_U)..."
++
+ msgid "Contextual Alternates"
+ msgstr "文脈依存の異体字"
+ 
+@@ -3023,7 +3071,7 @@ msgstr ""
+ "役に立たない場合,無意味なものとされます"
+ 
+ msgid "Convert By C_Map"
+-msgstr "C_Mapを指定して変換"
++msgstr "CMapを指定して変換(_M)"
+ 
+ msgid "Convert Design Vector Function:"
+ msgstr "デザインベクトル関数を変換:"
+@@ -3790,16 +3838,16 @@ msgid "Edges near horizontal/vertical/italic"
+ msgstr "水平/垂直/イタリック角に近い辺"
+ 
+ msgid "Edit 'cvt '..."
+-msgstr "'cvt 'テーブルを編集..."
++msgstr "'cvt' テーブルを編集..."
+ 
+ msgid "Edit 'fpgm'..."
+-msgstr "'fpgm'テーブルを編集..."
++msgstr "'fpgm' テーブルを編集..."
+ 
+ msgid "Edit 'maxp'..."
+-msgstr "'maxp'テーブルを編集..."
++msgstr "'maxp' テーブルを編集..."
+ 
+ msgid "Edit 'prep'..."
+-msgstr "'prep'テーブルを編集..."
++msgstr "'prep' テーブルを編集..."
+ 
+ msgid "Edit Chaining Position"
+ msgstr "文脈連鎖依存の位置指定を編集"
+@@ -4359,7 +4407,7 @@ msgid "Fixing up References"
+ msgstr "リソースの修復中"
+ 
+ msgid "Fl_attenByCMap"
+-msgstr "指定したCM_apで単一化"
++msgstr "指定したCMapで単一化(_A)"
+ 
+ msgid "Flared"
+ msgstr "フレア"
+@@ -4379,6 +4427,9 @@ msgstr "フラマン語(ベルギーのオランダ語)"
+ msgid "Flex Hints"
+ msgstr "Flexヒント"
+ 
++msgid "Flip"
++msgstr "反転"
++
+ msgid "Flip Horizontally"
+ msgstr "水平方向に反転"
+ 
+@@ -4494,10 +4545,19 @@ msgid ""
+ "OpenType, cid-keyed, multi-master, cff, SVG and BitMap (bdf, FON, NFNT) "
+ "fonts."
+ msgstr ""
+-"FontForge はアウトラインおよびビットマップフォントのフォントエディタです。"
+-"フォントの作成、編集、変換を行うことができます。 PostScript, TrueType, "
+-"OpenType, Cid-keyed, multi-master, cff, SVG, BitMap (bdf, FON, NFNT) フォント"
+-"を扱えます。"
++"FontForge は、アウトラインフォントおよびビットマップフォントの作成、編集、変"
++"換を行うことができるフォントエディターです。扱える形式は PostScript、"
++"TrueType、OpenType、CID-Keyed、Multiple Master、CFF、SVG、ビットマップ (BDF、"
++"FON、NFNT) などです。"
++
++msgid ""
++"FontForge is free Open Source Software written to run on various computer "
++"operating systems. You can use FontForge Graphically or as a command-line "
++"tool."
++msgstr ""
++"FontForge は、さまざまなコンピュータのオペレーティングシステム上で動作するよ"
++"うに書かれた無料のオープンソースソフトウェアです。FontForge は GUI を用いて、"
++"またはコマンドラインツールとして使用できます。"
+ 
+ msgid ""
+ "FontForge loads large images into the background of each glyph\n"
+@@ -5380,6 +5440,9 @@ msgstr "ISO 10646-1 (Unicode, 基本多言語面)"
+ msgid "ISO 10646-1 (Unicode, Full)"
+ msgstr "ISO 10646-1 (Unicode, 完全)"
+ 
++msgid "ISO 10646:1993"
++msgstr "ISO 10646:1993"
++
+ msgid "ISO 8859-1  (Latin1)"
+ msgstr "ISO 8859-1  (ラテン1/西欧)"
+ 
+@@ -6842,6 +6905,9 @@ msgstr "マジャン語"
+ msgid "Make Background"
+ msgstr "背景として使用"
+ 
++msgid "Make Foreground"
++msgstr "前面として使用"
++
+ msgid "Make Namelist"
+ msgstr "名前リストを作成"
+ 
+@@ -7141,6 +7207,9 @@ msgstr "MFの背景をクリア"
+ msgid "MfShowErr"
+ msgstr "MFエラーを表示"
+ 
++msgid "MicroSoft"
++msgstr "マイクロソフト社"
++
+ msgid "Min"
+ msgstr "最小"
+ 
+@@ -7898,8 +7967,8 @@ msgstr ""
+ #, c-format
+ msgid "Nonsensical class assigned to a glyph-- class=%d is too big. Glyph=%d\n"
+ msgstr ""
+-"無意味なクラスがグリフに割り当てられています―クラス=%dは大きすぎます. グリフ="
+-"%d\n"
++"無意味なクラスがグリフに割り当てられています―クラス=%dは大きすぎます. グリフ"
++"=%d\n"
+ 
+ msgid "Normal"
+ msgstr "通常"
+@@ -8095,6 +8164,9 @@ msgstr "O/3次元的"
+ msgid "OEM Charset"
+ msgstr "OEM 文字セット"
+ 
++msgid "OK"
++msgstr "OK"
++
+ msgid "OS2Version|Automatic"
+ msgstr "自動"
+ 
+@@ -8128,6 +8200,12 @@ msgstr "OSS/ベネチアン"
+ msgid "OT _Glyph Class:"
+ msgstr "OTFグリフクラス(_G):"
+ 
++msgid "O_ff"
++msgstr "オフ(_F)"
++
++msgid "O_n"
++msgstr "オン(_N)"
++
+ msgid "O_pen Paths"
+ msgstr "開いたパス(_P)"
+ 
+@@ -8370,6 +8448,9 @@ msgstr "フォントを開く"
+ msgid "Open Reference"
+ msgstr "参照情報を開く"
+ 
++msgid "Open _Web Page"
++msgstr "Webページへ(_W)"
++
+ msgid "OpenType"
+ msgstr "OpenTypeの仕様"
+ 
+@@ -8940,6 +9021,9 @@ msgstr "\"軸の種類\"フィールドを設定してください"
+ msgid "Please specify a new supplement for %.20s-%.20s"
+ msgstr "%.20s-%.20sの補遺番号を指定し直してください."
+ 
++msgid "Plugin Configuration"
++msgstr "プラグインの設定"
++
+ msgid "Poin_ts too close"
+ msgstr "近すぎる点(_T)"
+ 
+@@ -9260,6 +9344,9 @@ msgstr "無変換"
+ msgid "Re_move"
+ msgstr "削除(_M)"
+ 
++msgid "Re_vert List"
++msgstr "リストを反転(_V)"
++
+ msgid "Reached end of file when reading composite glyph\n"
+ msgstr "合成グリフの読み込み中にファイルの終端に到達しました\n"
+ 
+@@ -9633,6 +9720,9 @@ msgstr "ルーマニア語(モルドバ)"
+ msgid "Romany"
+ msgstr "ロマーニー語"
+ 
++msgid "Rotate"
++msgstr "回転"
++
+ msgid "Rotate 180°"
+ msgstr "180°回転"
+ 
+@@ -10232,6 +10322,9 @@ msgstr "常に2番目を選択(_T)"
+ msgid "Second glyph of %s"
+ msgstr "%sの2つめのグリフ"
+ 
++msgid "SeekCharacter"
++msgstr "検索文字"
++
+ msgid "Segment Separator"
+ msgstr "セグメント区切り"
+ 
+@@ -10575,7 +10668,7 @@ msgid "Size of comb delimiters in non-display styles"
+ msgstr "非ディスプレイ数式の comb の区切り文字"
+ 
+ msgid "Skew"
+-msgstr "傾き"
++msgstr "傾斜"
+ 
+ msgid "Skew Angle"
+ msgstr "傾き角"
+@@ -11456,7 +11549,6 @@ msgstr ""
+ "フォント%3$.30sのグリフ\"%2$.30s\"に含まれるヒント%1$sは,%4$.30sに含まれるも"
+ "のと一致しません(個数または重なり合い方の特徴が異なります)"
+ 
+-#, c-format
+ msgid ""
+ "The %1$s in the search dialog contains a reference to %2$.20hs which does "
+ "not exist in the new font.\n"
+@@ -12403,8 +12495,8 @@ msgid ""
+ "This font contains a \"UniqueId\" variable, but the correct name for it is\n"
+ "\t\"UniqueID\" (postscript is case concious)\n"
+ msgstr ""
+-"このフォントには \"UniqueId\" という名の変数がありますが, 正しくは\t"
+-"\"UniqueID\" です (PostScriptでは大文字と小文字は区別されます)\n"
++"このフォントには \"UniqueId\" という名の変数がありますが, 正しくは"
++"\t\"UniqueID\" です (PostScriptでは大文字と小文字は区別されます)\n"
+ 
+ msgid ""
+ "This font contains at least one translucent layer, but type3 does not "
+@@ -13308,6 +13400,15 @@ msgstr "辞書 %d に不正な値が含まれています\n"
+ msgid "Unicase"
+ msgstr "大小文字混在形"
+ 
++msgid "Unicode"
++msgstr "Unicode"
++
++msgid "Unicode 1.0"
++msgstr "Unicode 1.0"
++
++msgid "Unicode 1.1"
++msgstr "Unicode 1.1"
++
+ msgid "Unicode 2.0+, BMP only"
+ msgstr "Unicode 2.0 以降, BMP のみ"
+ 
+@@ -14129,7 +14230,7 @@ msgid "X11 bitmap only sfnt (otb)"
+ msgstr "X11 ビットマップのみの sfnt (otb)"
+ 
+ msgid "XHeight:"
+-msgstr "xハイト:"
++msgstr "Xハイト:"
+ 
+ msgid "XUID-Base"
+ msgstr "XUIDの基底"
+@@ -14395,32 +14496,38 @@ msgstr "拡大(_I)"
+ msgid "Zulu"
+ msgstr "ズールー語"
+ 
++msgid "_128 pixel outline"
++msgstr "マスの大きさ: 128ピクセル(_1)"
++
+ msgid "_16x4 cell window"
+-msgstr "_16×4マス表示"
++msgstr "16×4マス表示(_1)"
+ 
+ msgid "_24 pixel outline"
+-msgstr "_24 ピクセル アウトライン"
++msgstr "マスの大きさ: 24ピクセル(_2)"
+ 
+ msgid "_36 pixel outline"
+-msgstr "_36 ピクセル アウトライン"
++msgstr "マスの大きさ: 36ピクセル(_3)"
++
++msgid "_3D Rotate"
++msgstr "3D 回転"
+ 
+ msgid "_48 pixel outline"
+-msgstr "_48 ピクセル アウトライン"
++msgstr "マスの大きさ: 48ピクセル(_4)"
+ 
+ msgid "_72 pixel outline"
+-msgstr "_72 ピクセル アウトライン"
++msgstr "マスの大きさ: 72ピクセル(_7)"
+ 
+ msgid "_8x2  cell window"
+-msgstr " _8×2マス表示"
++msgstr "8×2マス表示(_8)"
+ 
+ msgid "_96 pixel outline"
+-msgstr "_96 ピクセル アウトライン"
++msgstr "マスの大きさ: 96ピクセル(_9)"
+ 
+ msgid "_AA"
+ msgstr "階調表示(_A)"
+ 
+ msgid "_About..."
+-msgstr "…について(_A)..."
++msgstr "このソフトウェアについて(_A)..."
+ 
+ msgid "_Accept inexact"
+ msgstr "不正確な一致を許容(_A)"
+@@ -14479,6 +14586,9 @@ msgstr "周辺も(_A)"
+ msgid "_Ascent:"
+ msgstr "高さ(_A):"
+ 
++msgid "_Ask"
++msgstr "尋ねる(_A)"
++
+ msgid "_Aspect"
+ msgstr "様相(_A)"
+ 
+@@ -14521,7 +14631,7 @@ msgid "_Both"
+ msgstr "両方(_B)"
+ 
+ msgid "_Bottom"
+-msgstr "最後(_B)"
++msgstr "末尾へ(_B)"
+ 
+ msgid "_Bottom:"
+ msgstr "下限(_B):"
+@@ -14535,6 +14645,9 @@ msgstr "アクセントつきグリフを構築(_B)"
+ msgid "_Build Syllables"
+ msgstr "音節を構築する(_B)"
+ 
++msgid "_CID"
++msgstr "CID(_C)"
++
+ msgid "_Cancel"
+ msgstr "キャンセル(_C)"
+ 
+@@ -14568,6 +14681,9 @@ msgstr "定義済みのグリフのみ表示(_C)"
+ msgid "_Condense/Extend..."
+ msgstr "幅(_C)..."
+ 
++msgid "_Configure"
++msgstr "設定(_C)"
++
+ msgid "_Contrast"
+ msgstr "コントラスト(_C)"
+ 
+@@ -14578,7 +14694,7 @@ msgid "_Control Points near horizontal/vertical"
+ msgstr "水平/垂直に近い制御点(_C)"
+ 
+ msgid "_Convert to CID"
+-msgstr "_CIDに変換"
++msgstr "CIDに変換(_C)"
+ 
+ msgid "_Copies:"
+ msgstr "部数(_C):"
+@@ -14614,6 +14730,9 @@ msgstr "グリフの切り離し(_D)"
+ msgid "_Diagonal Hints"
+ msgstr "斜めのヒント(_D)"
+ 
++msgid "_Disable"
++msgstr "無効化(_D)"
++
+ msgid "_Display Compositions..."
+ msgstr "組合せを表示(_D)..."
+ 
+@@ -14659,6 +14778,9 @@ msgstr "EMの大きさ(_E):"
+ msgid "_Embeddable"
+ msgstr "埋め込み可能(_E)"
+ 
++msgid "_Enable"
++msgstr "有効化(_E)"
++
+ msgid "_Enabled"
+ msgstr "有効(_E)"
+ 
+@@ -14683,6 +14805,9 @@ msgstr "極大点を表示(_E)"
+ msgid "_FDEF"
+ msgstr "_FDEF:"
+ 
++msgid "_FF"
++msgstr "FF(_F)"
++
+ msgid "_Family Name:"
+ msgstr "ファミリー名(_F):"
+ 
+@@ -14870,6 +14995,9 @@ msgstr "合字(_L)"
+ msgid "_Lining"
+ msgstr "線描き(_L)"
+ 
++msgid "_Load"
++msgstr "読み込み(_L)"
++
+ msgid "_Load Encoding..."
+ msgstr "エンコーディングを読み込み(_L)..."
+ 
+@@ -14907,6 +15035,9 @@ msgstr "組合せを修正(_M)..."
+ msgid "_Mono"
+ msgstr "白黒(_M)"
+ 
++msgid "_More Info"
++msgstr "詳細情報(_M)"
++
+ msgid "_More hints than:"
+ msgstr "ヒントの個数の上限(_M):"
+ 
+@@ -14958,6 +15089,9 @@ msgstr "なし(_N)"
+ msgid "_Normal"
+ msgstr "通常(_N)"
+ 
++msgid "_OK"
++msgstr "OK(_O)"
++
+ msgid "_OS/2 Version"
+ msgstr "_OS/2バージョン"
+ 
+@@ -15030,6 +15164,9 @@ msgstr "プリンタ(_P):"
+ msgid "_Proportion"
+ msgstr "幅の比率(_P)"
+ 
++msgid "_Python"
++msgstr "Python(_P)"
++
+ msgid "_Quit"
+ msgstr "終了(_Q)"
+ 
+@@ -15184,7 +15321,7 @@ msgid "_Tools"
+ msgstr "ツール(_T)"
+ 
+ msgid "_Top"
+-msgstr "最初(_T)"
++msgstr "先頭へ(_T)"
+ 
+ msgid "_Top:"
+ msgstr "上限(_T):"
+@@ -15202,7 +15339,7 @@ msgid "_Transformations"
+ msgstr "変形(_T)"
+ 
+ msgid "_TrueType Instructions"
+-msgstr "_TrueType命令"
++msgstr "TrueType命令(_T)"
+ 
+ msgid "_Twilight Pnt Cnt:"
+ msgstr "トワイライトポイントの個数(_T):"
+@@ -15289,7 +15426,7 @@ msgid "_X-Ascent"
+ msgstr "_xの高さ"
+ 
+ msgid "_X-Height"
+-msgstr "_Xハイト"
++msgstr "Xハイト(_X)"
+ 
+ msgid "_Yes"
+ msgstr "はい(_Y)"
+diff --git a/po/ka_GE.po b/po/ka_GE.po
+index c55108f08c..ee1e9749d6 100644
+--- a/po/ka_GE.po
++++ b/po/ka_GE.po
+@@ -8,8 +8,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 11:56\n"
+ "Last-Translator: \n"
+ "Language-Team: Georgian\n"
+ "Language: ka_GE\n"
+@@ -23,6 +23,13 @@ msgstr ""
+ "X-Crowdin-File: FontForge.pot\n"
+ "X-Crowdin-File-ID: 2\n"
+ 
++msgid ""
++"\n"
++"Layers:"
++msgstr ""
++"\n"
++"შრეები:"
++
+ #, c-format
+ msgid "  Ignoring '%c%c%c%c'\n"
+ msgstr "  უგულებელყოფილია „%c%c%c%c“\n"
+@@ -39,14 +46,28 @@ msgstr " ზომის დამატებით შეიქმნება
+ 
+ #. GT: This continues a multi-line error message, hence the leading space
+ msgid " Bad kerning class table, ignored\n"
+-msgstr " წანაცვლების კლასის გაუმართავი ცხრილი, უგულებელყოფილია\n"
++msgstr " შემოკვეცის კლასის უმართებულო ცხრილი, უგულებელყოფილია\n"
+ 
+ msgid " Bad ligature table, ignored\n"
+ msgstr " გადაბმების გაუმართავი ცხრილი, უგულებელყოფილია\n"
+ 
+ #. GT: This continues a multi-line error message, hence the leading space
+ msgid " Bad pairwise kerning table, ignored\n"
+-msgstr " წანაცვლებული წყვილების გაუმართავი ცხრილი, უგულებელყოფილია\n"
++msgstr " შემოკვეცილი წყვილების უმართებულო ცხრილი, უგულებელყოფილია\n"
++
++#, c-format
++msgid " Curvature: %g"
++msgstr " სიმრუდე: %g"
++
++#, c-format
++msgid " Curvature: %g  Radius: %g"
++msgstr " სიმრუდე: %g  რადიუსი: %g"
++
++msgid " Next CP"
++msgstr " შემდ. მოსაჭიდი"
++
++msgid " Prev CP"
++msgstr " წინა მოსაჭიდი"
+ 
+ msgid " Removing a size will delete it."
+ msgstr " ზომის მოცილების შედეგად წაიშლება."
+@@ -60,8 +81,8 @@ msgid ""
+ "%.100s is not in a known format (or uses features of that format fontforge "
+ "does not support, or is so badly corrupted as to be unreadable)"
+ msgstr ""
+-"%.100s უცნობი სახისაა (ან იმ სახის თვისებებს შეიცავს, რომელთაც FontForge ვერ "
+-"აღიქვამს, ანდაც ისეა დაზიანებული, რომ ვერ იკითხება)"
++"%.100s უცნობი სახისაა (ან იმ სახის თვისებებს იყენებს, რომელთაც FontForge ვერ "
++"აღიქვამს, ანდა ისეა დაზიანებული, რომ ვერ იკითხება)"
+ 
+ #. GT: This is the title for a window showing an outline character
+ #. GT: It will look something like:
+@@ -72,7 +93,18 @@ msgstr ""
+ #. GT: $4 is the changed flag ('*' for the changed items)
+ #, c-format
+ msgid "%1$.80s at %2$d from %3$.90s%4$s"
+-msgstr "%1$.80s უჯრაში %2$d, შრიფტიდან %3$.90s%4$s"
++msgstr "%1$.80s უჯრაში %2$d შრიფტიდან %3$.90s%4$s"
++
++#. GT: This is the title for a window showing a bitmap character
++#. GT: It will look something like:
++#. GT:  exclam at 33 size 12 from Arial
++#. GT: $1 is the name of the glyph
++#. GT: $2 is the glyph's encoding
++#. GT: $3 is the pixel size of the bitmap font
++#. GT: $4 is the font name
++#, c-format
++msgid "%1$.80s at %2$d size %3$d from %4$.80s"
++msgstr "%1$.80s უჯრაში %2$d ზომით%3$d შრიფტიდან %4$.80s"
+ 
+ #. GT: The user is trying to open a font file which contains multiple fonts and
+ #. GT: has asked for a font which is not in that file.
+@@ -88,6 +120,16 @@ msgstr ""
+ "%s\n"
+ "განაგრძობთ მაინც?"
+ 
++#. GT: There are various broad classes of lookups here and the first string
++#. GT: describes those: "Contextual Positioning", Contextual Substitution", etc.
++#. GT: Each of those may be formatted in 3 different ways: by (or perhaps using
++#. GT: would be a better word) glyphs, classes or coverage tables.
++#. GT: So this might look like:
++#. GT:  Contextual Positioning by classes
++#, c-format
++msgid "%s by %s"
++msgstr "%s %sს მიხედვით"
++
+ #. GT: This string is used to generate a name for each OpenType lookup.
+ #. GT: The %s will be filled with the user friendly name of the feature used to invoke the lookup
+ #. GT: The second %s (if present) is the script
+@@ -103,7 +145,7 @@ msgstr "%s ფაილს არ შეიცავს %.100s"
+ 
+ #, c-format
+ msgid "%s kerning class %d"
+-msgstr "%s წანაცვლების კლასი %d"
++msgstr "%s შემოკვეცის კლასი %d"
+ 
+ #. GT: This string is used to generate a name for an OpenType lookup subtable.
+ #. GT:  %s is the lookup name
+@@ -120,7 +162,7 @@ msgid "'%s' is not the name of a currently known plugin"
+ msgstr "„%s“ არ ემთხვევა ამჟამად ცნობილი მოდულების სახელებს"
+ 
+ msgid "'kern' Horizontal Kerning Table"
+-msgstr "'kern' თარაზული წანაცვლების ცხრილი"
++msgstr "'kern' ცხრილი თარაზული შემოკვეცისთვის"
+ 
+ msgid "(Adobe now considers XUID/UniqueID unnecessary)"
+ msgstr "(Adobe მიიჩნევს, რომ XUID/UniqueID აღარაა აუცილებელი)"
+@@ -225,6 +267,12 @@ msgstr "ჭდე უნდა იყოს 4 ASCII სიმბოლოთი"
+ msgid "AMS Names"
+ msgstr "AMS სახელები"
+ 
++msgid "A_dd Extrema"
++msgstr "წვერ_ოს დამატება"
++
++msgid "Active Hints"
++msgstr "მოქმედი მიმთ."
++
+ msgid "Active Layer Color"
+ msgstr "მოქმედი შრის ფერი"
+ 
+@@ -241,12 +289,18 @@ msgstr "მოქმედი ხელსაწყოს ფერი"
+ msgid "Add"
+ msgstr "დამატება"
+ 
++msgid "Add All Extrema"
++msgstr "ყველა წვეროს დამატება"
++
+ msgid "Add Encoding Name..."
+ msgstr "დაშიფვრის სახელის დამატება..."
+ 
+ msgid "Add Encoding Slots..."
+ msgstr "დასაშიფრი ადგილების დამატება..."
+ 
++msgid "Add Good Extrema"
++msgstr "მართებული წვეროს დამატება"
++
+ msgid "Add Language to Script..."
+ msgstr "ენის დამატება დამწერლობისთვის..."
+ 
+@@ -266,10 +320,10 @@ msgid "Add a curve point"
+ msgstr "მრუდის წერტილის დამატება"
+ 
+ msgid "Add a curve point always either horizontal or vertical"
+-msgstr "მრუდის წერტილის დამატება მხოლოდ თარაზულად, ან შვეულად"
++msgstr "მრუდის წერტილი მხოლოდ თარაზულად ან შვეულად"
+ 
+ msgid "Add a left \"tangent\" point"
+-msgstr "მარცხენა „მხების“ წერტილის დამატება"
++msgstr "მარცხნივ მიმართული „მხების“ წერტილის დამატება"
+ 
+ msgid "Add a new layer"
+ msgstr "ახალი შრის დამატება"
+@@ -278,7 +332,7 @@ msgid "Add a point, then drag out its control points"
+ msgstr "წერტილის დამატება, გადაადგილება და მართვა"
+ 
+ msgid "Add a right \"tangent\" point"
+-msgstr "მარჯვენა „მხების“ წერტილის დამატება"
++msgstr "მარჯვნივ მიმართული „მხების“ წერტილის დამატება"
+ 
+ msgid "Add a subtable to which lookup?"
+ msgstr "რომეცლ ცნობარს დაემატოს ქვეცხრილი?"
+@@ -287,7 +341,10 @@ msgid "Add a tangent point"
+ msgstr "მხების წერტილის დამატება"
+ 
+ msgid "Adding points at Extrema..."
+-msgstr "ემატება კიდურა წერტილები..."
++msgstr "კიდურა წერტილების დამატება..."
++
++msgid "Additional arguments for autotrace program:"
++msgstr "დამატებითი არგუმენტები თვითგამომხაზველი პროგრამისთვის:"
+ 
+ #. GT: "Adjust" here means Device Table based pixel adjustments, an OpenType
+ #. GT: concept which allows small corrections for small pixel sizes where
+@@ -343,8 +400,8 @@ msgid ""
+ "After rotating or skewing a glyph you should probably apply Element->Add "
+ "Extrema"
+ msgstr ""
+-"ასონიშნის მობრუნების ან გადახრის შემდგომ, სასურველია გამოიყენოთ „შემადგენელი "
+-"→ კიდურა წერტილის დამატება“"
++"ასონიშნის მობრუნების ან გადახრის შემდგომ სასურველია გამოიყენოთ „შემადგენელი "
++"→ წვეროს წერტილის დამატება“"
+ 
+ msgid "Ahead Classes"
+ msgstr "მომდევნო კლასები"
+@@ -352,6 +409,9 @@ msgstr "მომდევნო კლასები"
+ msgid "Ahom"
+ msgstr "აჰომი"
+ 
++msgid "Align Points"
++msgstr "წერტილების სწორება"
++
+ msgid "All Files"
+ msgstr "ყველანაირი ფაილი"
+ 
+@@ -364,8 +424,11 @@ msgstr "ყველა ასონიშანი"
+ msgid "Allow _curve smoothing"
+ msgstr "_მრუდის დაგლუვების საშუალება"
+ 
++msgid "Allow _removal of extrema"
++msgstr "წვეროს მო_ცილების ნებართვა"
++
+ msgid "Allows you to select optional behavior when generating the font"
+-msgstr "დამატებითი მოქმედების მითითების საშუალება, შრიფტის შედგენისას"
++msgstr "დამატებითი მოქმედების მითითების საშუალება შრიფტის დამზადებისას"
+ 
+ msgid "Almost Horizontal/Vertical Curves"
+ msgstr "თითქმის თარ./შვეულ. მრუდები"
+@@ -596,6 +659,15 @@ msgstr "ისრები"
+ msgid "Arrows & Sup Arrows A/B & Misc Arrows"
+ msgstr "ისრები, დანართი A/B და სხვადასხვა ნიშნები"
+ 
++msgid "As CFF fonts"
++msgstr "როგორც CFF-შრიფტები"
++
++msgid "Ascent/Descent Color"
++msgstr "ზედატანის/ქვედატანის ფერი"
++
++msgid "Ask the user for autotrace arguments each time autotrace is invoked"
++msgstr "არგუმენტების მითითების მოთხოვნა გამოხაზვის ყოველი წამოწყებისას"
++
+ msgid "At most 31 glyphs may be specified in an insert list"
+ msgstr "არაუმეტეს 31 ასონიშანი შეიძლება მიეთითოს ჩასამატებელ სიაში"
+ 
+@@ -607,13 +679,13 @@ msgid "Auto Width"
+ msgstr "სიგანის თვითგანსაზღვრა"
+ 
+ msgid "AutoHint"
+-msgstr "თვითმინიშნება"
++msgstr "თვითმიმთითებელი"
+ 
+ msgid "AutoHint changed glyphs before generating a font"
+-msgstr "თვითმინიშნებით შესწორებულია ასონიშნები შრიფტის შედგენამდე"
++msgstr "თვითმიმთითებლით შესწორებულია ასონიშნები შრიფტის დამზადებამდე"
+ 
+ msgid "AutoKernDialog"
+-msgstr "თვითწანაცვლების სარკმელი"
++msgstr "თვითშემოკვეცის სარკმელი"
+ 
+ msgid "AutoLBearingSync"
+ msgstr "მარცხენა საბჯენის თვითშეწყობა"
+@@ -629,7 +701,16 @@ msgid "Auto_Instr"
+ msgstr "თვითმი_თითება"
+ 
+ msgid "Autokern new entries"
+-msgstr "ახლადშეყვანილის თვითწანაცვლება"
++msgstr "ახლად შეტანილის თვითშემოკვეცა"
++
++msgid "AutotraceArgs"
++msgstr "გამომხაზველის არგუმენტები"
++
++msgid "AutotraceAsk"
++msgstr "მოთხოვნა გამოხაზვისას"
++
++msgid "Autotracing..."
++msgstr "თვითგამოხაზვა..."
+ 
+ msgid "Axerbaijani (Arabic)"
+ msgstr "აზერბაიჯანული (არაბული)"
+@@ -647,6 +728,9 @@ msgstr "აზერი (ლათინური)"
+ msgid "BBearing:"
+ msgstr "ქვედა საბჯენი:"
+ 
++msgid "BMP"
++msgstr "BMP"
++
+ #. GT: Background, make it short
+ msgid "Back"
+ msgstr "უკანა"
+@@ -655,7 +739,7 @@ msgid "Back Classes"
+ msgstr "წინა კლასები"
+ 
+ msgid "Bad Apple Kern Class\n"
+-msgstr "Apple-ის გაუმართავი წანაცვლების კლასი\n"
++msgstr "Apple-ის უმართებულო კლასი შემოკვეცისთვის\n"
+ 
+ msgid "Bad Class"
+ msgstr "გაუმართავი კლასი"
+@@ -705,6 +789,9 @@ msgstr "გაუმართავი არეები"
+ msgid "Bad Version"
+ msgstr "არამართებული ვერსია"
+ 
++msgid "Bad WOFF header, a field which must be 0 is not."
++msgstr "უმართებულო WOFF-თავსართი, ველის მნიშვნელობა უნდა ყოფილიყო 0."
++
+ msgid "Bad Weight"
+ msgstr "არამართებული სისქე"
+ 
+@@ -712,7 +799,7 @@ msgid "Bad class name"
+ msgstr "კლასის გაუმართავი სახელი"
+ 
+ msgid "Bad default baseline"
+-msgstr "გაუმართავი საყრდენი ხაზი"
++msgstr "გაუმართავი ძირითადი ხაზი"
+ 
+ msgid "Bad encoding file format"
+ msgstr "გაუმართავი შიფრის მქონე ფაილი"
+@@ -733,7 +820,7 @@ msgstr "გაუმართავი გამოსახულება: %.1
+ 
+ #, c-format
+ msgid "Bad kern pair: glyphs %d & %d should have been < %d\n"
+-msgstr "გაუმართავი წანაცვლების წყვილი: ასონიშნები %d და %d უნდა იყოს < %d\n"
++msgstr "შემოკვეცის უმართებულო წყვილი: ასონიშნები %d და %d უნდა იყოს < %d\n"
+ 
+ msgid "Bad language tag"
+ msgstr "არამართებული ენის ჭდე"
+@@ -757,6 +844,9 @@ msgstr "არასწორი რიცხვი, Infinity ან NaN: %s\n"
+ msgid "Bad rule"
+ msgstr "გაუმართავი წესი"
+ 
++msgid "Bad signature in WOFF header."
++msgstr "უმართებულო ხელმოწერა WOFF-თავსართში."
++
+ #. GT: The words "true" and "false" should be left untranslated. We are restricted
+ #. GT: here by what PostScript understands, and it only understands the English
+ #. GT: words. You may, of course, change it to something like ("true" (vrai) ou "false" (faux))
+@@ -785,10 +875,10 @@ msgid "Base Ligatures"
+ msgstr "ძირითადი გადაბმები"
+ 
+ msgid "Baseline"
+-msgstr "საყრდენი ხაზი"
++msgstr "ძირითადი ხაზი"
+ 
+ msgid "Baseline used for Latin, Greek, Cyrillic text."
+-msgstr "საყრდენი ხაზი ლათინურის, ბერძნულისა და კირილიცისთვის."
++msgstr "ძირითადი ხაზი ლათინურის, ბერძნულისა და კირილიცისთვის."
+ 
+ msgid "Basic Latin"
+ msgstr "ძირითადი ლათინური"
+@@ -820,6 +910,9 @@ msgstr "რასტრული გადიდება..."
+ msgid "Bitmap _Magnification..."
+ msgstr "რასტრული გა_დიდება..."
+ 
++msgid "Bits/Pixel:"
++msgstr "ბიტი/პიქსელზე:"
++
+ msgid "Bold font used in the Find/Replace window"
+ msgstr "მუქი შრიფტი გამოიყენება პოვნა/ძიების ფანჯარაში"
+ 
+@@ -925,17 +1018,48 @@ msgstr ""
+ msgid "Can't Find Glyph"
+ msgstr "ვერ მოინახა ასონიშანი"
+ 
++msgid "Can't create temporary directory"
++msgstr "ვერ შეიქმნა დროებითი საქაღალდე"
++
++msgid "Can't find autotrace"
++msgstr "ვერ მოიძებნა გამომხაზველი"
++
++msgid ""
++"Can't find autotrace program (set AUTOTRACE environment variable) or "
++"download from:\n"
++"  http://sf.net/projects/autotrace/"
++msgstr ""
++"ვერ მოიძებნა თვითგამომხაზველი (გამართეთ გარემოს ცვლადი AUTOTRACE) ან "
++"ჩამოტვირთეთ აქედან:\n"
++"  http://sf.net/projects/autotrace/"
++
++msgid "Can't find mf"
++msgstr "ვერ მოიძებნა mf (metafont)"
++
++msgid ""
++"Can't find mf program -- metafont (set MF environment variable) or download "
++"from:\n"
++"  http://www.tug.org/\n"
++"  http://www.ctan.org/\n"
++"It's part of the TeX distribution"
++msgstr ""
++"ვერ მოინახა mf-პროგრამა -- metafont (გამართეთ გარემოს ცვლადი MF) ან "
++"ჩამოტვირთეთ აქედან:\n"
++"  http://www.tug.org/\n"
++"  http://www.ctan.org/\n"
++"TeX-ის შემადგენელი ნაწილია"
++
+ msgid "Can't find the file"
+ msgstr "ვერ მოიძებნა ფაილი"
+ 
+ msgid "Can't insert 'cvt'"
+-msgstr "ვერ ჩაისმება 'cvt'"
++msgstr "ვერ ჩაისმება „cvt“"
+ 
+ msgid "Can't insert 'fpgm'"
+-msgstr "ვერ ჩაისმება 'fpgm'"
++msgstr "ვერ ჩაისმება „fpgm“"
+ 
+ msgid "Can't insert 'prep'"
+-msgstr "ვერ ჩაისმება 'prep'"
++msgstr "ვერ ჩაისმება „prep“"
+ 
+ #, c-format
+ msgid "Can't open %s"
+@@ -951,6 +1075,9 @@ msgstr "ვერ იხსნება დროებითი ფაილი
+ msgid "Can't open temporary file for truetype output.\n"
+ msgstr "ვერ იხსნება დროებითი ფაილი Truetype-გამოტანისთვის.\n"
+ 
++msgid "Can't run mf"
++msgstr "ვერ გაეშვა mf (metafont)"
++
+ msgid "Cancel"
+ msgstr "გაუქმება"
+ 
+@@ -1341,9 +1468,15 @@ msgstr "ყველაფრის გასუფთავება"
+ msgid "Clear Device Table"
+ msgstr "მოწყობილობის ცხრილის გასუფთავება"
+ 
++msgid "Clear Instructions"
++msgstr "მითითებების გასუფთავება"
++
+ msgid "Clear Special Data"
+ msgstr "საგანგებო მონაცემების წაშლა"
+ 
++msgid "Clear _Background"
++msgstr "_ფონის გასუფთავება"
++
+ msgid ""
+ "Click on a range to select characters in that range.\n"
+ "Double click on a range to see characters that should be\n"
+@@ -1356,11 +1489,14 @@ msgstr ""
+ msgid "Co_py LBearing"
+ msgstr "მარცხენა საბჯენის ას_ლი"
+ 
++msgid "Color of the ascent and descent lines"
++msgstr "ზედატანისა და ქვედატანის ხაზების ფერი"
++
+ msgid "Color used to draw the advance width line of a glyph"
+ msgstr "ასონიშნის გაფართოებული სიგანის აღმნიშვნელი ფერი"
+ 
+ msgid "Color used to draw the kerning line"
+-msgstr "წანაცვლების ხაზის აღმნიშვნელი ფერი"
++msgstr "შემოკვეცის ზოლის აღმნიშვნელი ფერი"
+ 
+ msgid "Color used to draw the left side bearing"
+ msgstr "მარცხენა საბჯენის ფერი"
+@@ -1389,6 +1525,9 @@ msgstr "დასართავი განმასხვავებელ
+ msgid "Combining Diacritical Marks for Symbols"
+ msgstr "დასართავი განმასხვავებელი ნიშნები პირობითი ნიშნებისთვის"
+ 
++msgid "Comment"
++msgstr "შენიშვნა"
++
+ msgid "Common Indic Number Forms"
+ msgstr "გავრცელებული ინდური რიცხვითი ჩანაწერები"
+ 
+@@ -1401,12 +1540,31 @@ msgstr "შემჭირდოებული გახსნისას"
+ msgid "Compacted"
+ msgstr "შემჭიდროებული"
+ 
++msgid "Compare Layers"
++msgstr "შრეების შედარება"
++
++msgid "Compare Layers..."
++msgstr "შრეების შედარება..."
++
+ msgid "Compare _Outlines"
+ msgstr "_მოხაზულობის შედარება"
+ 
++msgid "Compare two layers"
++msgstr "ორი შრის შედარება"
++
+ msgid "Complex"
+ msgstr "რთული"
+ 
++msgid "Component"
++msgstr "შემადგენელი"
++
++#, c-format
++msgid "Component %d %.30s (%d,%d)"
++msgstr "შემადგენელი %d %.30s (%d,%d)"
++
++msgid "Components"
++msgstr "შემადგენლები"
++
+ msgid "Config_ure Plugins..."
+ msgstr "მოდულების გამარ_თვა..."
+ 
+@@ -1434,6 +1592,9 @@ msgstr "შრეების ასლი"
+ msgid "Copy RBearin_g"
+ msgstr "მარჯვენა სა_ბჯენის ასლი"
+ 
++msgid "Copy _Fg To Bg"
++msgstr "ასლი ფ_ონზე"
++
+ msgid "Copy _VWidth"
+ msgstr "_შვეული სიგანის ასლი"
+ 
+@@ -1447,7 +1608,7 @@ msgid "Copy_right:"
+ msgstr "საავ_ტორო უფლება:"
+ 
+ msgid "Copyright"
+-msgstr "საავტორო უფლება"
++msgstr "საკუთრების უფლება"
+ 
+ msgid ""
+ "Copyright text (in the Names pane) must be entirely ASCII. So, use (c) "
+@@ -1457,7 +1618,11 @@ msgstr ""
+ "გამოიყენეთ (c) და არა – ©."
+ 
+ msgid "Corner"
+-msgstr "კუთხე"
++msgstr "კუთხოვანი"
++
++#, c-format
++msgid "Could not create plugin directory '%s'\n"
++msgstr "ვერ შეიქმნა მოდულის საქაღალდე: „%s“\n"
+ 
+ msgid "Could not figure out a lookup type"
+ msgstr "ვერ დადგინდა ცნობარის სახეობა"
+@@ -1478,7 +1643,7 @@ msgid "Could not open temporary file."
+ msgstr "ვერ გაიხსნა დროებითი ფაილი."
+ 
+ msgid "Could not read (or perhaps find) mf output file"
+-msgstr "ვერ იკითხება (ან უფრო იძებნება) mf-გამოტანის ფაილი"
++msgstr "ვერ იკითხება (ანდა ვერ იძებნება) mf-გამოტანის ფაილი"
+ 
+ msgid "Couldn't Load"
+ msgstr "ვერ ჩაიტვირთა"
+@@ -1518,6 +1683,9 @@ msgstr "ვერ გაიხსნა ფაილი %.200s"
+ msgid "Couldn't open font"
+ msgstr "ვერ გაიხსნა შრიფტი"
+ 
++msgid "Cr_eate"
++msgstr "შე_ქმნა"
++
+ msgid "Cre_ate Named Glyphs..."
+ msgstr "სახელიანი ასონიშნების შ_ექმნა..."
+ 
+@@ -1527,6 +1695,12 @@ msgstr "მცირე მთავრულის შექმნა"
+ msgid "Create Subscript/Superscript"
+ msgstr "ხაზზედა/ხაზქვედა ნიშნის შექმნა"
+ 
++msgid "Create directory"
++msgstr "საქაღალდის შექმნა"
++
++msgid "Create directory..."
++msgstr "საქაღალდის შექმნა..."
++
+ msgid "Create small caps variants for symbols as well as letters"
+ msgstr "მცირე მთავრულის შექმნა სიმბოლოებისა და ასოებისთვის"
+ 
+@@ -1547,6 +1721,19 @@ msgstr ""
+ "ჯერჯერობით, FontForge-ში მხარდაჭერილია მხოლოდ ბიტური (და არა ბაიტური) სახის "
+ "type3-გამოტანა"
+ 
++#, c-format
++msgid "Curvature: %g"
++msgstr "სიმრუდე: %g"
++
++msgid "Curvature: -0.00000000"
++msgstr "სიმრუდე: -0.00000000"
++
++msgid "Curvature: ?"
++msgstr "სიმრუდე: ?"
++
++msgid "Curve"
++msgstr "მრუდი"
++
+ msgid "Curve Type"
+ msgstr "მრუდის სახეობა"
+ 
+@@ -1589,8 +1776,11 @@ msgstr "თარიღები"
+ msgid "De_activate Spiro"
+ msgstr "ხვეულის გა_უქმება"
+ 
++msgid "Decompressed length did not match expected length for table"
++msgstr "შეუკუმშავი სიგრძე შეუსაბამოა ცხრილისთვის მოსალოდნელ სიგრძესთან"
++
+ msgid "Default Baseline"
+-msgstr "საყრდენი ხაზი ნაგულისხმევად"
++msgstr "ნაგულისხმევი ძირითადი ხაზი"
+ 
+ msgid "Define Groups"
+ msgstr "ჯგუფების განსაზღვრა"
+@@ -1649,11 +1839,14 @@ msgstr "საქაღალდეები თავში"
+ msgid "Directories Separate"
+ msgstr "საქაღალდეები გამოყოფილად"
+ 
++msgid "Directory name?"
++msgstr "საქაღალდის სახელი?"
++
+ msgid "Directory|_New"
+ msgstr "_ახალი"
+ 
+ msgid "Discarding a duplicate kerning pair."
+-msgstr "ცილდება ერთნაირი წანაცვლებული წყვილები."
++msgstr "ცილდება ერთნაირი შემოკვეცილი წყვილები."
+ 
+ msgid "Display"
+ msgstr "ჩვენება"
+@@ -1696,6 +1889,12 @@ msgid ""
+ msgstr ""
+ "გამოაჩენს ყველა მონიშნულ სიმბოლოს, თითოეულს ცალკე გვერდზე, მეტად დიდი ზომით"
+ 
++msgid "Dist"
++msgstr "სიშორე"
++
++msgid "Distance"
++msgstr "დაშორება"
++
+ msgid "Dives Akuru"
+ msgstr "დივეჰი აკურუ"
+ 
+@@ -1711,7 +1910,7 @@ msgstr ""
+ "(თუ კი, რომლები)"
+ 
+ msgid "Doesn't look like a valid pdf file, couldn't find xref section"
+-msgstr "არ ჰგავს მართებულ PDF-ფაილს, ვერ მოინახა xref-განყოფილება"
++msgstr "არ ჰგავს მართებულ PDF-ფაილს, ვერ მოინახა xref-არე"
+ 
+ msgid "Dogra"
+ msgstr "დოგრი"
+@@ -1731,6 +1930,9 @@ msgstr "სახელი მეორდება"
+ msgid "Duployan"
+ msgstr "დუპლოი"
+ 
++msgid "EPS"
++msgstr "EPS"
++
+ msgid "E_lement"
+ msgstr "შ_ემადგენელი"
+ 
+@@ -1788,7 +1990,7 @@ msgid "Egyptian Hieroglyphs"
+ msgstr "ეგვიპტური იეროგლიფები"
+ 
+ msgid "Ellipse"
+-msgstr "ოვალი"
++msgstr "კვერცხისებრი"
+ 
+ msgid "Enclosed Alphanumeric Supplement"
+ msgstr "შემოსაზღვრული ასოციფრული დანართი"
+@@ -1854,12 +2056,33 @@ msgstr "აკლია „{“ განსაზღვრისას %d ხ
+ msgid "Expor_t..."
+ msgstr "გა_ტანა..."
+ 
++msgid "Export"
++msgstr "გამოტანა"
++
++msgid "Export Options"
++msgstr "გამოტანის პარამეტრები"
++
++msgid "ExportClipboard"
++msgstr "გამოტანის ასლის აღება"
++
+ msgid "Extended"
+ msgstr "გაფართოებული"
+ 
+ msgid "Extended Collection"
+ msgstr "გაფართოებული კრებული"
+ 
++#. GT: Extra Space, see below for a full comment
++#. GT: Extra Space
++msgid "Extra Sp:"
++msgstr "დამატ. სივრცე:"
++
++msgid ""
++"Extra arguments for configuring the autotrace program\n"
++"(either autotrace or potrace)"
++msgstr ""
++"დამატებითი არგუმენტები გამომხაზველი პროგრამის გასამართად\n"
++"(გამოდგება ორივესთვის, Autotrace და Potrace)"
++
+ msgid ""
+ "Extra white space to be added after each\n"
+ "sub/superscript."
+@@ -1871,12 +2094,16 @@ msgstr "ამოკრეფა PDF-ფაილიდან"
+ msgid "F_ind / Replace..."
+ msgstr "_პოვნა / ჩანაცვლება..."
+ 
++#. GT: Foreground, make it short
++msgid "F_ore"
++msgstr "_წინა"
++
+ msgid "Failed to generate postscript font"
+-msgstr "ვერ შეიქმნა PostScript-შრიფტი"
++msgstr "ვერ დამზადდა PostScript-შრიფტი"
+ 
+ #, c-format
+ msgid "Failed to generate postscript in file %s"
+-msgstr "ვერ შეიქმნა PostScript-შრიფტი ფაილში %s"
++msgstr "ვერ დამზადდა PostScript-შრიფტი ფაილში %s"
+ 
+ #, c-format
+ msgid "Failed to open %s for output"
+@@ -1913,12 +2140,17 @@ msgstr "თვისების ჭდეები მოცილდება"
+ msgid "File Exists"
+ msgstr "ფაილი არსებობს"
+ 
++msgid ""
++"File length as specified in the WOFF header does not match the actual file "
++"length."
++msgstr "ფაილის სიგრძე მითითებული WOFF-თავსართში არ ემთხვევა არსებულ სიგრძეს."
++
+ #, c-format
+ msgid "File, %s, exists. Replace it?"
+ msgstr "ფაილი %s უკვე არსებობს. ჩანაცვლდეს?"
+ 
+ msgid "Filled Ellipse"
+-msgstr "სავსე ოვალი"
++msgstr "სავსე კვერცხისებრი"
+ 
+ msgid "Filter"
+ msgstr "გამორჩევა"
+@@ -1964,22 +2196,22 @@ msgid "Flip"
+ msgstr "გადაკეცვა"
+ 
+ msgid "Flip Horizontally"
+-msgstr "თარაზულად შებრუნება"
++msgstr "თარაზულად გადაკეცვა"
+ 
+ msgid "Flip Vertically"
+-msgstr "შვეულად შებრუნება"
++msgstr "შვეულად გადაკეცვა"
+ 
+ msgid "Flip _Horizontally"
+-msgstr "თარა_ზულად შებრუნება"
++msgstr "თარა_ზულად გადაკეცვა"
+ 
+ msgid "Flip _Vertically"
+-msgstr "შ_ვეულად შებრუნება"
++msgstr "შ_ვეულად გადაკეცვა"
+ 
+ msgid "Flip the selection"
+-msgstr "მონიშნულის სარკისებრი შებრუნება"
++msgstr "მონიშნულის გადაკეცვა"
+ 
+ msgid "Flip..."
+-msgstr "შებრუნება..."
++msgstr "გადაკეცვა..."
+ 
+ msgid "Fo_ntname:"
+ msgstr "შრი_ფტის სახელი:"
+@@ -1990,7 +2222,7 @@ msgid ""
+ "Do you want to save it?"
+ msgstr ""
+ "შრიფტი %1$.40s შეცვლილია ფაილში %2$.40s.\n"
+-"გსურთ შეინახოს?"
++"გსურთ შენახვა?"
+ 
+ #, c-format
+ msgid ""
+@@ -2041,6 +2273,21 @@ msgstr ""
+ "სისტემებზე გასაშვებად. FontForge შეგიძლიათ გამოიყენოთ როგორც გამოსახულებითი "
+ "სახით, აგრეთვე ბრძანებათა ველის მეშვეობით."
+ 
++#, c-format
++msgid "FontForge supports at most %d layers"
++msgstr "FontForge-ში მხარდაჭერილია არაუმეტეს %d შრე"
++
++msgid ""
++"FontForge supports two different helper applications to do autotracing\n"
++" autotrace and potrace\n"
++"If your system only has one it will use that one, if you have both\n"
++"use this option to tell FontForge which to pick."
++msgstr ""
++"FontForge-თან თავსებადია თვითგამოხაზვის ორი სხვადასხვა დამხმარე პროგრამა\n"
++" Autotrace და Potrace.\n"
++"თუ სისტემაში მხოლოდ ერთია, მას გამოიყენებს, თუ ორივეა,\n"
++"ამ პარამეტრის მეშვეობით მიუთითეთ FontForge-ს, რომელი არჩიოს."
++
+ msgid ""
+ "FontForge was unable to load libspiro, spiros are not available for use."
+ msgstr ""
+@@ -2060,7 +2307,7 @@ msgstr ""
+ "უდიდესი მნიშვნელობები, თითოეული ნიშნის საბჯენებისთვის."
+ 
+ msgid "FontForge will guess kerning classes for selected glyphs"
+-msgstr "FontForge ივარაუდებს წანაცვლების კლასს შერჩეული ასონიშნებისთვის"
++msgstr "FontForge ივარაუდებს შემოკვეცის კლასს შერჩეული ასონიშნებისთვის"
+ 
+ msgid ""
+ "FontForge will look at the glyphs selected in the font view\n"
+@@ -2069,7 +2316,7 @@ msgid ""
+ msgstr ""
+ "FontForge გადახედავს ასონიშნებს შრიფტის ხედით\n"
+ "და შეეცდება იპოვოს მსგავსი ასონიშნები, რომელთა\n"
+-"მონაცემებითაც მიხედვითაც შექმნის წანაცვლების კლასებს."
++"მონაცემების მიხედვითაც შექმნის შემოკვეცის კლასებს."
+ 
+ msgid "FontLog Save Failed"
+ msgstr "FontLog ვერ შეინახა"
+@@ -2087,10 +2334,19 @@ msgstr "ასონიშნების იძულებით გადა
+ msgid "Fore"
+ msgstr "წინა"
+ 
++msgid "Forget _to All"
++msgstr "ყველას და_ვიწყება"
++
++msgid "Format:"
++msgstr "სახეობა:"
++
+ #. GT: This does not mean the program, but freehand drawing
+ msgid "Freehand"
+ msgstr "თავისუფალი"
+ 
++msgid "Friendly Name"
++msgstr "იოლი სახელი"
++
+ msgid "From the _other class"
+ msgstr "ს_ხვა კლასიდან"
+ 
+@@ -2109,6 +2365,9 @@ msgstr "75"
+ msgid "Gasp|_Version"
+ msgstr "ვე_რსია"
+ 
++msgid "General"
++msgstr "ძირითადი"
++
+ msgid "General Punctuation"
+ msgstr "ძირითადი სასვენი ნიშნები"
+ 
+@@ -2116,28 +2375,28 @@ msgid "General/Supplemental Punctuation"
+ msgstr "ძირითადი/დამატებითი სასვენი ნიშნები"
+ 
+ msgid "Generate"
+-msgstr "შედგენა"
++msgstr "დამზადება"
+ 
+ msgid "Generate Fonts"
+-msgstr "შრიფტების შედგენა"
++msgstr "შრიფტების დამზადება"
+ 
+ msgid "Generate Mac Family"
+-msgstr "შედგენა Mac-კრებულის"
++msgstr "Mac-კრებულის დამზადება"
+ 
+ msgid "Generate Mac _Family..."
+-msgstr "შედგენა Mac-კ_რებულის..."
++msgstr "Mac-კ_რებულის დამზადება..."
+ 
+ msgid "Generate TTC"
+-msgstr "შეიქმნას TTC"
++msgstr "დამზადდეს TTC"
+ 
+ msgid "Generate TTC..."
+-msgstr "შეიქმნას TTC..."
++msgstr "დამზადდეს TTC..."
+ 
+ msgid "Generating PostScript Font"
+-msgstr "იქმნება PostScript-შრიფტი"
++msgstr "მზადდება PostScript-შრიფტი"
+ 
+ msgid "Generating bitmap font"
+-msgstr "იქმნება ბიტური შრიფტი"
++msgstr "მზადდება ბიტური შრიფტი"
+ 
+ msgid "Generic"
+ msgstr "მთავარი"
+@@ -2169,6 +2428,19 @@ msgstr "გლაგოლიცური"
+ msgid "Glagolitic Supplement"
+ msgstr "გლაგოლიცური დანართი"
+ 
++msgid "Glif"
++msgstr "Glif"
++
++msgid "Glyph Info"
++msgstr "ასონიშნის შესახებ"
++
++#, c-format
++msgid "Glyph Info for %.40s"
++msgstr "%.40s ასონიშნის შესახებ"
++
++msgid "Glyph Info..."
++msgstr "ასონიშნის შესახებ..."
++
+ msgid "Glyph Insertion"
+ msgstr "ასონიშნის ჩამატება"
+ 
+@@ -2182,7 +2454,7 @@ msgid "Glyph Set by Selection"
+ msgstr "ასონიშნების კრებული მონიშვნით"
+ 
+ msgid "Glyph _Info..."
+-msgstr "ასო_ნიშნის შესახებ..."
++msgstr "ასო_ნიშნის მონაცემები..."
+ 
+ msgid "Glyph in two classes"
+ msgstr "ასონიშანი ორ კლასშია"
+@@ -2208,6 +2480,11 @@ msgstr ""
+ "ასონიშნის სახელში არსებული სიმბოლოები მხოლოდ ASCII-არეს უნდა ეკუთვნოდეს,\n"
+ "თუმცა სახელთა ამ სიაში, ზოგიერთი შეიცავს სიმბოლოებს, რომლებიც სცდება ამ არეს."
+ 
++#, c-format
++msgid "Glyph, %s, has no hints. FontForge will not produce many instructions."
++msgstr ""
++"ასონიშანი %s მიმთითებლების გარეშეა. FontForge ვერ დაამუშავებს ბევრ მითითებას."
++
+ msgid "GlyphName|New"
+ msgstr "ახალი"
+ 
+@@ -2272,6 +2549,9 @@ msgstr "ჯგუფის სახელი:"
+ msgid "Groups"
+ msgstr "ჯგუფები"
+ 
++msgid "Guess"
++msgstr "სავარაუდო"
++
+ #. GT: Guide layer, make it short
+ msgid "Guide"
+ msgstr "მიმმართველი"
+@@ -2301,7 +2581,7 @@ msgid "HVCurve"
+ msgstr "თარ./შვეულ. მრუდი"
+ 
+ msgid "H_ints"
+-msgstr "_მიმნიშნებლები"
++msgstr "_მიმთითებლები"
+ 
+ msgid "Hangul Jamo"
+ msgstr "ჰანგილ-ჯამო"
+@@ -2315,9 +2595,15 @@ msgstr "ჰანგილ-ჯამო გაფართოებული-B"
+ msgid "Hanunoo"
+ msgstr "ჰანუნო"
+ 
++msgid "Harmoni_ze"
++msgstr "შე_ხამება"
++
+ msgid "Harmonizing..."
+ msgstr "შეეხამება..."
+ 
++msgid "Has _Vertical Metrics"
++msgstr "_შვეული აზომვებით"
++
+ msgid "Hebrew"
+ msgstr "ებრაული"
+ 
+@@ -2325,7 +2611,7 @@ msgid "Height"
+ msgstr "სიმაღლე"
+ 
+ msgid "Height/Kern Data"
+-msgstr "სიმაღლის/წანაცვლების მონაცემები"
++msgstr "სიმაღლის/შემოკვეცის მონაცემები"
+ 
+ msgid "Hidden"
+ msgstr "დამალული"
+@@ -2333,6 +2619,9 @@ msgstr "დამალული"
+ msgid "Hide when _Moving"
+ msgstr "დამალვა მ_ოძრაობისას"
+ 
++msgid "Hint Mask"
++msgstr "მიმთ. ნიღაბი"
++
+ msgid "Hiragana"
+ msgstr "ჰირაგანა"
+ 
+@@ -2362,16 +2651,16 @@ msgid "Horizontal"
+ msgstr "თარაზული"
+ 
+ msgid "Horizontal Baselines"
+-msgstr "თარაზული საყრდენები"
++msgstr "ძირითადი თარაზული ხაზები"
+ 
+ msgid "Horizontal Kerning"
+-msgstr "თარაზული წანაცვლება"
++msgstr "თარაზული შემოკვეცა"
+ 
+ #, c-format
+ msgid "Horizontal: %d baseline"
+ msgid_plural "Horizontal: %d baselines"
+-msgstr[0] "თარაზული: %d საყრდენი"
+-msgstr[1] "თარაზული: %d საყრდენი"
++msgstr[0] "თარაზული: %d ძირითადი ხაზი"
++msgstr[1] "თარაზული: %d ძირითადი ხაზი"
+ 
+ msgid "How many unencoded glyph slots do you wish to add?"
+ msgstr "რამდენი დაუშიფრავი ასონიშნის ადგილის დამატება გსურთ?"
+@@ -2381,8 +2670,8 @@ msgid ""
+ "I miscalculated the size of subtable %s, this means the kerning output is "
+ "wrong."
+ msgstr ""
+-"შეცდომა, %s ქვეცხრილის ზომის გამოთვლისას, რაც ნიშნავს, რომ წანაცვლების "
+-"გამოტანა არამართებულია."
++"შეცდომა %s ქვეცხრილის ზომის გამოთვლისას, რაც ნიშნავს, რომ შემოკვეცის "
++"გამოტანა უმართებულოა."
+ 
+ msgid ""
+ "I'm sorry this file is too complex for me to understand (or is erroneous, or "
+@@ -2454,10 +2743,10 @@ msgid ""
+ "in the font, and specify how to position glyphs in this\n"
+ "script relative to all active baselines"
+ msgstr ""
+-"თუ ზემოთ მოცემული საყრდენებიდან რომელიმე მაინც მოქმედია,\n"
++"თუ ზემოთ მოცემული ძირითადი ხაზებიდან რომელიმე მაინც მოქმედია,\n"
+ "უნდა მიუთითოთ ნაგულისხმევი თითოეული დამწერლობისთვის\n"
+ "ამ შრიფტში და ისიც, თუ როგორ განთავსდება ასონიშნები ყველა\n"
+-"მოქმედი საყრდენი ხაზების მიმართ"
++"მოქმედი ძირითადი ხაზის მიმართ"
+ 
+ msgid ""
+ "If the old-style 'kern' table contains unencoded glyphs\n"
+@@ -2466,9 +2755,9 @@ msgid ""
+ "problematic glyphs from the old-style 'kern' table."
+ msgstr ""
+ "თუ ძველი სახის „kern“ ცხრილი შეიცავს დაუშიფრავ ასონიშნებს\n"
+-"(ან ასოებს BMP-ადგილების მიღმა), ბევრი პროგრამა Windows-ში\n"
+-"საერთოდ არ გამოიყენებს წანაცვლებას. ამის მითითებით კი გამოირიცხება\n"
+-"ამგვარი ასონიშნებს ძველებური „kern“ ცხრილიდან."
++"(ან ასოებს BMP-სივრცის გარეთ), ბევრი პროგრამა Windows-ში\n"
++"საერთოდ არ გამოიყენებს შემოკვეცას. ამის მითითებით კი გამოირიცხება\n"
++"ამგვარი ასონიშნები ძველებური „kern“ ცხრილიდან."
+ 
+ msgid ""
+ "If the start point of a contour is not an extremum, find a new start point "
+@@ -2499,7 +2788,7 @@ msgid ""
+ "If you leave this field blank FontForge will use a default based on\n"
+ "either the version string above, or one in the 'name' table."
+ msgstr ""
+-"თუ ცარიელს დატოვებთ, FontForge თავად შეავსებს ან ვერსიი, ან „სახელის“ "
++"თუ ცარიელს დატოვებთ, FontForge თავად შეავსებს ან ვერსიის, ან „სახელის“ "
+ "ცხრილის მიხედვით."
+ 
+ msgid "Ignore Ligatures"
+@@ -2509,8 +2798,8 @@ msgid ""
+ "In the 'kern' table, a subtable's length does not match the number of "
+ "kerning pairs."
+ msgstr ""
+-"„kern“ ცხრილში, ქვეცხრილების სიგრძე არ ემთხვევა წანაცვლებული წყვილების "
+-"რაოდენობას."
++"შემოკვეცის „kern“ ცხრილში, ქვეცხრილების სიგრძე არ ემთხვევა შემოკვეცილი "
++"წყვილების რაოდენობას."
+ 
+ msgid ""
+ "In the saved font, force all glyph names to match those in the specified "
+@@ -2537,7 +2826,7 @@ msgid "Increment RBearing By:"
+ msgstr "მარჯვენა საბჯენს დაემატოს:"
+ 
+ msgid "Indic (& Tibetan) hanging baseline"
+-msgstr "ინდური (და ტიბეტური) კიდული საყრდენით"
++msgstr "ინდური (და ტიბეტური) ძირითადი კიდული ხაზით"
+ 
+ msgid "Insert Before Current Glyph"
+ msgstr "მიმდინარე ასონიშნის შემდგომ ჩამატება"
+@@ -2560,9 +2849,26 @@ msgstr "ტექსტის მოხაზულობის ჩამატ
+ msgid "Insert random text in the specified script"
+ msgstr "ცალკეული დამწერლობის შემთხვევითი ტექსტის ჩამატება"
+ 
++msgid "Instructions out of date"
++msgstr "მითითებები ვადაგასულია"
++
+ msgid "Interface"
+ msgstr "გარსი"
+ 
++msgid "InterpolateCPsOnMotion"
++msgstr "ჩამატება მოსაჭიდის მოძრაობისას"
++
++#. GT: See the long comment at "Property|New"
++#. GT: The msgstr should contain a translation of "None", ignore "Interpretation|"
++#. GT: In french this could be "Aucun" or "Aucune" depending on the gender
++#. GT:  of "Interpretation"
++msgid "Interpretation|None"
++msgstr "არა"
++
++#, c-format
++msgid "Invalid compressed table length for '%c%c%c%c'."
++msgstr "უმართებული სიგრძე შეკუმშული ცხრილისთვის „%c%c%c%c“."
++
+ msgid "Invalid guideline.\n"
+ msgstr "გაუმართავი მიმმართველი ხაზი.\n"
+ 
+@@ -2575,7 +2881,13 @@ msgid "Invalid or unsupported version (0x%x) for 'kern' table"
+ msgstr "არასწორი ან მხარდაუჭერელი ვერსია (0x%x) „kern“ ცხრილისთვის"
+ 
+ msgid "Is this horizontal or vertical kerning data?"
+-msgstr "ეს თარაზული წანაცვლების მონაცემია თუ შვეულის?"
++msgstr "ეს თარაზული შემოკვეცის მონაცემია თუ შვეულისა?"
++
++msgid "Italic Angle"
++msgstr "დახრის კუთხე"
++
++msgid "Italic Angle:"
++msgstr "დახრის კუთხე:"
+ 
+ msgid "KOI8-R (Cyrillic)"
+ msgstr "KOI8-R (კირილიცა)"
+@@ -2611,61 +2923,61 @@ msgid "Ker_n By Classes..."
+ msgstr "წანა_ცვლება კლასებით..."
+ 
+ msgid "Kern"
+-msgstr "წანაცვლება"
++msgstr "შემოკვეცა"
+ 
+ msgid "Kern Adjusts"
+-msgstr "წანაცვლების დაყენება"
++msgstr "შემოკვეცის მორგება"
+ 
+ msgid "Kern By Classes"
+-msgstr "წანაცვლება კლასებით"
++msgstr "შემოკვეცა კლასებით"
+ 
+ msgid "Kern Line Color"
+-msgstr "წანაცვლების ხაზის ფერი"
++msgstr "შემოკვეცის ზოლის ფერი"
+ 
+ msgid "Kern Pair Closeup"
+-msgstr "წანაცვლებული წყვილის გადახედვა"
++msgstr "შემოკვეცის წყვილის დათვალიერება"
+ 
+ msgid "Kern Pair Closeup..."
+-msgstr "წანაცვლებული წყვილის გადახედვა..."
++msgstr "შემოკვეცის წყვილის შეთვალიერება..."
+ 
+ msgid "Kern Pairs"
+ msgstr "Წანაცვლებული წყვილები"
+ 
+ msgid "Kern Values:"
+-msgstr "წანაცვლების მნიშვნელობები:"
++msgstr "შემოკვეცის მნიშვნ.:"
+ 
+ msgid "Kern:"
+-msgstr "წანაცვლება:"
++msgstr "შემოკვეცა:"
+ 
+ msgid "KernClass|_New Lookup..."
+ msgstr "_ახალი ცნობარი..."
+ 
+ msgid "Kerning & such"
+-msgstr "წანაცვლება და სხვა დანარჩენი"
++msgstr "შემოკვეცა და სხვა"
+ 
+ msgid "Kerning Class"
+-msgstr "წანაცვლების კლასი"
++msgstr "შემოკვეცის კლასი"
+ 
+ #, c-format
+ msgid "Kerning Metrics For %.50s"
+-msgstr "წანაცვლების აზომვები – %.50s"
++msgstr "შემოკვეცის აზომვები – %.50s"
+ 
+ #. GT: The %s is the name of the lookup subtable containing this kerning class
+ #, c-format
+ msgid "Kerning by Classes: %s"
+-msgstr "წანაცვლება კლასებით: %s"
++msgstr "შემოკვეცა კლასებით: %s"
+ 
+ msgid "Kerning direction"
+-msgstr "წანაცვლების მიმართულება"
++msgstr "შემოკვეცის მიმართულება"
+ 
+ msgid ""
+ "Kerning may be specified either by classes of glyphs\n"
+ "or by pairwise combinations of individual glyphs.\n"
+ "Which do you want for this subtable?"
+ msgstr ""
+-"წანაცვლები მითითება შეიძლება ან ასონიშნების კლასებით,\n"
+-"ან ცალკეული ასონიშნების შეწყვილებით.\n"
+-"რომელი გსურთ ამ ქვეცხრილისთვის?"
++"შემოკვეცის მითითება შეიძლება ან ასონიშნების კლასებით,\n"
++"ანდა ცალკეული ასონიშნების შეწყვილებით.\n"
++"რომელს აირჩევთ ამ ქვეცხრილისთვის?"
+ 
+ msgid "Khmer"
+ msgstr "ქმერული"
+@@ -2781,7 +3093,13 @@ msgid "Layer"
+ msgstr "შრე"
+ 
+ msgid "Layer Info..."
+-msgstr "შრის შესახებ..."
++msgstr "შრის მონაცემები..."
++
++msgid "Layer Name"
++msgstr "შრის სახელი"
++
++msgid "Layers"
++msgstr "შრეები"
+ 
+ msgid "Left Side Bearing"
+ msgstr "მარცხენა საბჯენი"
+@@ -2875,6 +3193,9 @@ msgstr "იტვირთება ფონტი წყაროდან %.1
+ msgid "Loading..."
+ msgstr "იტვირთება..."
+ 
++msgid "Location"
++msgstr "მდებარეობა"
++
+ msgid "Lookup Name:"
+ msgstr "ცნობარის სახელი:"
+ 
+@@ -2981,7 +3302,7 @@ msgid ""
+ "It may not be set in conjunction with the Apple checkbox.\n"
+ "This may confuse other applications though."
+ msgstr ""
+-"ბევრ პროგრამაში ჯერ კიდევ მხარდაუჭერელია „GPOS“ წანაცვლება.\n"
++"ბევრ პროგრამაში ჯერ კიდევ მხარდაუჭერელია „GPOS“ შემოკვეცა.\n"
+ "თუ გსურთ დაურთოთ ორივე, „GPOS“ და ძველი სახის „kern“\n"
+ "ცხრილები, მიუთითეთ ამ უჯრის მონიშვნით.\n"
+ "ჯობია, არ მოინიშნოს Apple-ის უჯრასთან ერთად.\n"
+@@ -3000,7 +3321,7 @@ msgid "Mass Glyph _Rename..."
+ msgstr "ასონიშნების ერთბაშად გადარ_ქმევა..."
+ 
+ msgid "Math Kern"
+-msgstr "მათემატიკური წანაცვლება"
++msgstr "მათემატიკური შემოკვეცა"
+ 
+ msgid "Mathematical Alphanumeric Symbols"
+ msgstr "მათემატიკური ასოციფრული ნიშნები"
+@@ -3018,7 +3339,7 @@ msgid "Max Bearing"
+ msgstr "საბჯენი არაუმეტეს"
+ 
+ msgid "Measure distance, angle between points"
+-msgstr "წერტილებს შორის დაშორების, კუთხის გაზომვა"
++msgstr "წერტილთა დაშორების, კუთხის გაზომვა"
+ 
+ msgid "Mende Kikakui"
+ msgstr "მენდე"
+@@ -3029,11 +3350,36 @@ msgstr "მენიუს ზოლი"
+ msgid "Menu Name"
+ msgstr "მენიუს სახელი"
+ 
++msgid "Merge"
++msgstr "გაერთიანება"
++
++msgid "Merge Fonts"
++msgstr "შრიფტების გაერთიანება"
++
++msgid "Merge Results"
++msgstr "შედეგების გაერთიანება"
++
++msgid "Merge into selection"
++msgstr "გაერთიანება მონიშნულში"
++
++msgid "Merge to Line"
++msgstr "გაერთიანება ხაზით"
++
++msgid ""
++"Merges two selected (and compatible) lookups into one,\n"
++"or merges two selected subtables of a lookup into one"
++msgstr ""
++"გააერთიანებს ორ შერჩეულ (და თავსებად) ცნობარს,\n"
++"ან გააერთიანებს ცნობარის ორ შერჩეულ ქვეცხრილს"
++
++msgid "MetaFont exited with an error"
++msgstr "MetaFont დაიხურა შეცდომით"
++
+ msgid "Metrics"
+ msgstr "აზომვები"
+ 
+ msgid "Metrics Baseline Color"
+-msgstr "აზომვების საყრდენი ხაზის ფერი"
++msgstr "აზომვების ძირითადი ხაზის ფერი"
+ 
+ #, c-format
+ msgid "Metrics For %.50s"
+@@ -3157,17 +3503,29 @@ msgstr "მიანმარული გაფართოებული-B"
+ msgid "NKo"
+ msgstr "ნკო"
+ 
++msgid "N_ever Interpolate"
++msgstr "ა_რასდროს ჩაემატოს"
++
+ msgid "N_umber Points"
+ msgstr "წერტილების გადა_ნომვრა"
+ 
+ msgid "Name"
+ msgstr "სახელი"
+ 
++msgid "Name Contour"
++msgstr "მოხაზულობის სახელი"
++
+ msgid "Name For Human_s:"
+ msgstr "ად_ვილად წასაკითხი:"
+ 
++msgid "Name Point"
++msgstr "წერტილის სახელი"
++
++msgid "Name Point..."
++msgstr "წერტილის სახელი..."
++
+ msgid "Name this guideline or cancel to create it without a name"
+-msgstr "დაარქვით რამე მიმმართველ ხაზს ან გააუქმეთ უსახელოდ შექმნისთვის"
++msgstr "დაარქვით რამე ან გააუქმეთ უსახელოდ დატოვებისთვის"
+ 
+ msgid ""
+ "Name used for Vendor ID field in\n"
+@@ -3175,7 +3533,7 @@ msgid ""
+ "Must be no more than 4 characters"
+ msgstr ""
+ "სახელი მწარმოებლის ID-ველისთვის\n"
+-"ttf-შრიფტის (OS/2-ცხრილი) შესადგენად.\n"
++"ttf-შრიფტის (OS/2-ცხრილი) დასამზადებლად.\n"
+ "არ უნდა აღემატებოდეს 4 სიმბოლოს"
+ 
+ msgid "Name:"
+@@ -3242,6 +3600,31 @@ msgstr "_აზომვების ახალი ფანჯარა"
+ msgid "NewCharset"
+ msgstr "ასოთა ახალი ნაკრები"
+ 
++msgid "Next CP Angle"
++msgstr "შემდ. მოსაჭიდის დახრილობა"
++
++msgid "Next CP Color"
++msgstr "შემდეგი მოსაჭიდის ფერი"
++
++msgid "Next CP Dist"
++msgstr "შემდ. მოსაჭიდის სიშორე"
++
++msgid "Next CP X"
++msgstr "შემდ. მოსაჭიდი X"
++
++msgid "Next CP Y"
++msgstr "შემდ. მოსაჭიდი Y"
++
++msgid "Next CP:"
++msgstr "შემდ. მოსაჭიდი:"
++
++#, c-format
++msgid "Next CP: (%f,%f)"
++msgstr "შემდ. მოსაჭიდი: (%f,%f)"
++
++msgid "Next On Contour"
++msgstr "ნახაზზე შემდეგ"
++
+ msgid "Next _Defined Glyph"
+ msgstr "მომდევნო _განსაზღვრული ასონიშანი"
+ 
+@@ -3255,6 +3638,9 @@ msgstr "არ მოიძებნა (გამოსადეგი) ცხ
+ msgid "No Bitmap Fonts"
+ msgstr "ცხრილური შრიფტები არაა"
+ 
++msgid "No Curvature"
++msgstr "სიმრუდის გარეშე"
++
+ msgid "No Glyph"
+ msgstr "ასონიშანი არაა"
+ 
+@@ -3264,8 +3650,14 @@ msgstr "გამეორებული ასონიშნები არ
+ msgid "No Groups"
+ msgstr "ჯგუფები არაა"
+ 
++msgid "No Instructions"
++msgstr "მითითებები არაა"
++
++msgid "No Intersections"
++msgstr "არა თანაკვეთები"
++
+ msgid "No Kern Pairs"
+-msgstr "არაა წანაცვლებული წყვილები"
++msgstr "არაა შემოკვეცილი წყვილები"
+ 
+ msgid "No Lookup Type Selected"
+ msgstr "არაა შერჩეული ცნობარის სახეობა"
+@@ -3294,9 +3686,15 @@ msgstr "შვეული აზომვების გარეშე"
+ msgid "No _to All"
+ msgstr "არა ყ_ველას"
+ 
++msgid "No components"
++msgstr "არაა შემადგენლები"
++
++msgid "No curvature info"
++msgstr "სიმრუდის შესახებ უცნობია"
++
+ #, c-format
+ msgid "No kerning pairs found in %.200s"
+-msgstr "წანაცვლებულ წყვილებს არ შეიცავს %.200s"
++msgstr "შემოკვეცილ წყვილებს არ შეიცავს %.200s"
+ 
+ msgid "No languages"
+ msgstr "ენები არაა"
+@@ -3336,6 +3734,13 @@ msgstr ""
+ msgid "Normal font used in the Find/Replace window"
+ msgstr "ჩვეულებრივი შრიფტი გამოიყენება პოვნა/ძიების ფანჯარაში"
+ 
++msgid ""
++"Normally simplify will not remove points at the extrema of curves\n"
++"(both PostScript and TrueType suggest you retain these points)"
++msgstr ""
++"როგორც წესი, გამარტივებით არ იშლება მრუდის კიდურა წერტილები\n"
++"(ორივე, PostScript და TrueType გთავაზობთ მათი შენარჩუნების საშუალებას)"
++
+ msgid "Not Guides"
+ msgstr "მიმმართველის გარეშე"
+ 
+@@ -3352,10 +3757,10 @@ msgid ""
+ "pairs (eg, they have a Unicode value of -1) To avoid this, go to Generate, "
+ "Options, and check the \"Windows-compatible 'kern'\" option."
+ msgstr ""
+-"შენიშვნა: Windows-ზე ბევრი პროგრამა შეიძლება წააწყდეს სიძნელეს შრიფტის "
+-"წანაცვლებული წყვილების გამოყენებისას, ვინაიდან მისი წანაცვლებული ასონიშნების "
+-"წყვილების %d ვერ აისახება BMP-უნიკოდის წანაცვლების წყვილებზე (მაგ. მათ "
+-"ექნებათ უნიკოდის მნიშვნელობად -1) ამის ასარიდებლად, აირჩიეთ „შედგენა“, "
++"შენიშვნა: Windows-ზე ბევრი პროგრამა შეიძლება წააწყდეს სიძნელეს ამ შრიფტის "
++"წყვილების შემოკვეცისას, ვინაიდან %d მისი ასონიშნების შემოკვეცილი წყვილებით "
++"ვერ აისახება BMP-უნიკოდის შემოკვეცილ წყვილებზე (ანუ მათ ექნებათ უნიკოდის "
++"მნიშვნელობად -1) ამის ასარიდებლად გადადით მენიუში, აირჩიეთ „დამზადება“, "
+ "„პარამეტრები“ და მონიშნეთ „Windows-სთან თავსებადი „kern“."
+ 
+ msgid "Nothing Loaded"
+@@ -3367,6 +3772,9 @@ msgstr "არაფერია შერჩეული"
+ msgid "Nothing on stack to print\n"
+ msgstr "არაფერია მითითებული ამოსაბეჭდად\n"
+ 
++msgid "Nothing to trace"
++msgstr "არაფერია გამოსახაზი"
++
+ msgid "Number Forms"
+ msgstr "რიცხვითი ჩანაწერები"
+ 
+@@ -3389,12 +3797,21 @@ msgstr "OS/2 → ასოთა ნაკრებები"
+ msgid "OS/2 and Windows specific metrics table"
+ msgstr "OS/2 და Windows-ის შესაბამისი აზომვების ცხრილი"
+ 
++msgid "OTF 'CFF '"
++msgstr "OTF 'CFF '"
++
+ msgid "O_ff"
+ msgstr "გამო_რთ."
+ 
+ msgid "O_n"
+ msgstr "ჩ_ართ."
+ 
++msgid "Offset"
++msgstr "წანაცვლება"
++
++msgid "Offset %"
++msgstr "წანაცვლება %"
++
+ msgid "Ofm Save Failed"
+ msgstr "Ofm ვერ შეინახა"
+ 
+@@ -3456,7 +3873,7 @@ msgid "Only upper case"
+ msgstr "მხოლოდ მთავრული"
+ 
+ msgid "Open AutoKern dialog for new kerning subtables"
+-msgstr "თვითწანაცვლების არის გახსნა ახალი ქვეცხრილებისთვის"
++msgstr "თვითშემოკვეცის სარკმლის გახსნა ახალი ქვეცხრილებისთვის"
+ 
+ msgid "Open Font"
+ msgstr "შრიფტის გახსნა"
+@@ -3470,6 +3887,9 @@ msgstr "_ვებგვერდის გახსნა"
+ msgid "OpenType"
+ msgstr "OpenType"
+ 
++msgid "OpenType (CFF)"
++msgstr "OpenType (CFF)"
++
+ msgid "OpenTypeFeature|New"
+ msgstr "ახალი"
+ 
+@@ -3539,6 +3959,9 @@ msgstr "გამოიტანოს TFM და ENC"
+ msgid "Output error"
+ msgstr "გამოტანის შეცდომა"
+ 
++msgid "Oval"
++msgstr "კვერცხისებრი"
++
+ msgid "PDF"
+ msgstr "PDF"
+ 
+@@ -3551,6 +3974,9 @@ msgstr "ასონიშნის PS-სახელი"
+ msgid "PS Names"
+ msgstr "PS-სახელი"
+ 
++msgid "PS Private"
++msgstr "PS-კერძო"
++
+ msgid "PSPrivateDictKey|New"
+ msgstr "ახალი"
+ 
+@@ -3570,10 +3996,10 @@ msgid "Pahawh Hmong"
+ msgstr "ფაჰაუ-მონი"
+ 
+ msgid "Pair Position (kerning)"
+-msgstr "წყვილთა ურთიერთგანლაგება (წანაცვლება)"
++msgstr "წყვილთა ურთიერთგანლაგება (შემოკვეცა)"
+ 
+ msgid "Pairwise Positioning (kerning)"
+-msgstr "წყვილთა ურთიერთგანლაგება (წანაცვლება)"
++msgstr "წყვილთა ურთიერთგანლაგება (შემოკვეცა)"
+ 
+ msgid "PanoseWeight|Any"
+ msgstr "ნებისმიერი"
+@@ -3626,6 +4052,12 @@ msgstr "გვერდის არჩევა"
+ msgid "Pixel Sizes:"
+ msgstr "პიქსელის ზომები:"
+ 
++msgid "Pixel size:"
++msgstr "პიქსელის ზომა:"
++
++msgid "Pixel size?"
++msgstr "პიქსელის ზომა?"
++
+ msgid "Please choose File/Generate Fonts to save to other formats."
+ msgstr "გთხოვთ, იხილოთ ფაილი/შრიფტების წარმოქმნა, სხვა სახით შენახვისთვის."
+ 
+@@ -3639,6 +4071,9 @@ msgstr "დაარქვით სახელი %d დაშიფვრა
+ msgid "Please name this encoding"
+ msgstr "დაარქვით დაშიფვრას სახელი"
+ 
++msgid "Please name this point"
++msgstr "დაარქვით რამე წერტილს"
++
+ msgid "Please specify a bitmap magnification factor."
+ msgstr "გთხოვთ, მიუთითოთ რასტრული გადიდების მამრავლი."
+ 
+@@ -3689,18 +4124,49 @@ msgstr "მრავალკუთხედი ან ვარსკვლა
+ msgid "Pr_eferences..."
+ msgstr "_პარამეტრები..."
+ 
++msgid "PreferPotrace"
++msgstr "უპირატესია Potrace"
++
+ msgid "Preferences"
+ msgstr "პარამეტრები"
+ 
+ msgid "Preferred Family"
+ msgstr "უპირატესი კრებული"
+ 
++msgid "Prefs_App|FontForge recognizes BROWSER, MF and AUTOTRACE."
++msgstr "Prefs_App|FontForge-ს შეუძლია ამოიცნოს BROWSER, MF და AUTOTRACE."
++
+ msgid "Preserve the names of the GPOS/GSUB lookups and subtables"
+ msgstr "GPOS/GSUB-ცნობარებისა და ქვეცხრილების სახელების შენარჩუნება"
+ 
++msgid "Prev CP Angle"
++msgstr "წინა მოსაჭიდის დახრილობა"
++
++msgid "Prev CP Color"
++msgstr "წინა მოსაჭიდის ფერი"
++
++msgid "Prev CP Dist"
++msgstr "წინა მოსაჭიდის სიშორე"
++
++msgid "Prev CP X"
++msgstr "წინა მოსაჭიდი X"
++
++msgid "Prev CP Y"
++msgstr "წინა მოსაჭიდი Y"
++
++msgid "Prev CP:"
++msgstr "წინა მოსაჭიდი:"
++
++#, c-format
++msgid "Prev CP: (%f,%f)"
++msgstr "წინა მოსაჭიდი: (%f,%f)"
++
+ msgid "Prev Defined Gl_yph"
+ msgstr "წინა განსაზღვრული ას_ონიშანი"
+ 
++msgid "Prev On Contour"
++msgstr "ნახაზზე წინ"
++
+ msgid "Previe_w"
+ msgstr "შეთვა_ლიერება"
+ 
+@@ -3722,9 +4188,18 @@ msgstr "ამოსაბეჭდი დოკუმენტი"
+ msgid "Printing Font"
+ msgstr "შრიფტი იბეჭდება"
+ 
++#. GT: "Private" is a keyword (sort of) in PostScript. Perhaps it
++#. GT: should remain untranslated?
++msgid "Private Dictionary"
++msgstr "კერძო ლექსიკონი"
++
+ msgid "Private Use Area"
+ msgstr "კერძო გამოყენების არე"
+ 
++#, c-format
++msgid "Problem decompressing '%c%c%c%c' table."
++msgstr "ხარვეზი შეკუმშული „%c%c%c%c“ ცხრილის გახსნისას."
++
+ #. GT: I am told that the use of "|" to provide contextual information in a
+ #. GT: gettext string is non-standard. However it is documented in section
+ #. GT: 10.2.6 of http://www.gnu.org/software/gettext/manual/html_mono/gettext.html
+@@ -3744,9 +4219,21 @@ msgstr "კერძო გამოყენების არე"
+ msgid "Property|New..."
+ msgstr "ახალი..."
+ 
++msgid ""
++"Put CFF fonts into the ttc rather than TTF.\n"
++" These seem to work on the mac and linux\n"
++" but are documented not to work on Windows."
++msgstr ""
++"განათავსებს CFF-შრიფტებს TTC-ფაილში ნაცვლად TTF-ფაილისა.\n"
++" სავარაუდოდ, იმუშავებს Mac-სა და Linux-სისტემებში,\n"
++" მაგრამ დადასტურებულია, რომ არ გამოდგება Windows-ისთვის."
++
+ msgid "RBearing:"
+ msgstr "მარჯვენა საბჯენი:"
+ 
++msgid "Re_move"
++msgstr "მო_ცილება"
++
+ msgid "Re_vert List"
+ msgstr "სიის ა_ღდგენა"
+ 
+@@ -3756,23 +4243,32 @@ msgstr "ბიტური გამოსახულების ახლი
+ msgid "Recen_t"
+ msgstr "_ბოლოდროინდელი"
+ 
++msgid "Recover old edit"
++msgstr "წინათ ჩასწორებულის აღდგენა"
++
+ msgid "Rectangle"
+ msgstr "მართკუთხედი"
+ 
+ msgid "Rectangle or Ellipse"
+-msgstr "მართკუთხედი ან ოვალი"
++msgstr "მართკუთხა ან კვერცხისებრი"
+ 
+ msgid "Refresh File List"
+ msgstr "ფაილების სიის განახლება"
+ 
+ msgid "Regenerate _Bitmap Glyphs..."
+-msgstr "ახლიდან შეიქმნას _ბიტური ასონიშნები..."
++msgstr "ახლიდან დამზადდეს _ბიტური ასონიშნები..."
++
++msgid "Remo_ve Undoes"
++msgstr "დასაბრუნებლების მო_ცილება"
++
++msgid "Remo_ve Undoes..."
++msgstr "დასაბრუნებლების მო_ცილება..."
+ 
+ msgid "Remove All Kern _Pairs"
+-msgstr "ყველა წანაცვლებული წ_ყვილის მოცილება"
++msgstr "შემოკვეცის ყველა წ_ყვილის მოცილება"
+ 
+ msgid "Remove All VKern Pairs"
+-msgstr "ყველა შვეულად წანაცვლებული წ_ყვილის მოცილება"
++msgstr "შვეულად შემოკვეცის ყველა წ_ყვილის მოცილება"
+ 
+ msgid "Remove Bitmap Glyphs..."
+ msgstr "ბიტური ასონიშნების მოცილება..."
+@@ -3784,7 +4280,7 @@ msgid "Remove Encoding"
+ msgstr "დაშიფვრის მოცილება"
+ 
+ msgid "Remove Kern _Pairs"
+-msgstr "წანაცვლებული წ_ყვილის მოცილება"
++msgstr "შემოკვეცის წ_ყვილის მოცილება"
+ 
+ msgid "Remove Language from Script..."
+ msgstr "ენის მოცილება დამწერლობიდან..."
+@@ -3802,11 +4298,14 @@ msgid "Remove This Glyph"
+ msgstr "ამ ასონიშნის მოცილება"
+ 
+ msgid "Remove VKern Pairs"
+-msgstr "შვეულად წანაცვლებული წყვილის მოცილება"
++msgstr "შვეული შემოკვეცის წყვილების მოცილება"
+ 
+ msgid "Remove _Unused Slots"
+ msgstr "გამოუ_ყენებელი ადგილების მოცილება"
+ 
++msgid "Removing instructions cannot be UNDONE!"
++msgstr "მითითებების მოცილება ᲨᲔᲣᲥᲪᲔᲕᲐᲓᲘᲐ!"
++
+ msgid "Removing overlaps..."
+ msgstr "ცილდება გადაფარვები..."
+ 
+@@ -3860,6 +4359,12 @@ msgstr "დაბრუნება საწყისზე"
+ msgid "Revert To _Backup"
+ msgstr "აღდგენა მა_რქაფიდან"
+ 
++msgid "Review Hints"
++msgstr "მიმთითებლების შეთვალიერება"
++
++msgid "RevisionsToRetain"
++msgstr "შესანახი ვერსიები"
++
+ msgid "Right Side Bearing"
+ msgstr "მარჯვენა საბჯენი"
+ 
+@@ -3876,24 +4381,24 @@ msgid "Rotate"
+ msgstr "მობრუნება"
+ 
+ msgid "Rotate 180°"
+-msgstr "შებრუნება 180°"
++msgstr "მობრუნება 180°"
+ 
+ msgid "Rotate 3D Around..."
+ msgstr "სივრცული მობრუნება..."
+ 
+ #. GT: "CW" means Counter-Clockwise
+ msgid "Rotate 90° CCW"
+-msgstr "შებრუნება 90° საათის საწ."
++msgstr "მობრუნება 90° საათ. საწ."
+ 
+ #. GT: "CW" means Clockwise
+ msgid "Rotate 90° CW"
+-msgstr "შებრუნება 90° საათის მიმართ."
++msgstr "მობრუნება 90° საათ. მიმართ."
+ 
+ msgid "Rotate _180°"
+-msgstr "შებრუნება _180°"
++msgstr "მობრუნება _180°"
+ 
+ msgid "Rotate _90° CCW"
+-msgstr "შებრუნება _90° საათის საწ."
++msgstr "მობრუნება _90° საათ. საწ."
+ 
+ msgid "Rotate by Ruler..."
+ msgstr "მოტრიალება სახაზავით..."
+@@ -3908,7 +4413,7 @@ msgid "Rotate..."
+ msgstr "მობრუნება..."
+ 
+ msgid "Rotate:"
+-msgstr "შებრუნება:"
++msgstr "მობრუნება:"
+ 
+ msgid "Round To _Int"
+ msgstr "დამრგვალება მთე_ლამდე"
+@@ -3925,6 +4430,9 @@ msgstr "სახაზავის პარამეტრები"
+ msgid "Runic"
+ msgstr "რუნული"
+ 
++msgid "SVG"
++msgstr "SVG"
++
+ msgid "S_ave Feature File..."
+ msgstr "თვისებების ფაილად შენა_ხვა..."
+ 
+@@ -4026,8 +4534,8 @@ msgid ""
+ "Script '%c%c%c%c' claims baseline '%c%c%c%c' as its default, but that "
+ "baseline is not currently active."
+ msgstr ""
+-"დამწერლობა „%c%c%c%c“ მიუთითებს, რომ ნაგულისხმევი საყრდენია „%c%c%c%c“, "
+-"თუმცა ეს ხაზი არაა ამჟამად მოქმედი."
++"დამწერლობა „%c%c%c%c“ მიუთითებს, რომ ნაგულისხმევი ძირითადი ხაზია „%c%c%c%c“, "
++"მაგრამ ეს ხაზი არაა ამჟამად მოქმედი."
+ 
+ msgid "Script File"
+ msgstr "სკრიპტის ფაილი"
+@@ -4149,6 +4657,9 @@ msgstr ""
+ msgid "Select the class containing the named glyph"
+ msgstr "დასახელებული ასონიშნის შემცველი კლასის მონიშვნა"
+ 
++msgid "Selected CP Color"
++msgstr "შერჩეული მოსაჭიდის ფერი"
++
+ msgid "Selected Glyphs"
+ msgstr "შერჩეული ასონიშნები"
+ 
+@@ -4176,6 +4687,15 @@ msgstr "ორივე საბჯენის მითითება..."
+ msgid "Set Both Side Bearings..."
+ msgstr "ორივე მხარეს საბჯენის მითითება..."
+ 
++msgid "Set From N_ame"
++msgstr "მითითება სა_ხელიდან"
++
++msgid "Set From Selection"
++msgstr "მითითება მონიშნულიდან"
++
++msgid "Set From Val_ue"
++msgstr "მითითება მ_ნიშვნელობიდან"
++
+ msgid "Set LBearing To:"
+ msgstr "მარცხენა საბჯენად მიეთითოს:"
+ 
+@@ -4212,15 +4732,6 @@ msgstr "სი_განის მითითება..."
+ msgid "Set as Default"
+ msgstr "ნაგულისხმევად მითითება"
+ 
+-msgid ""
+-"Set the minimum and maximum values by which\n"
+-"the glyphs in this script extend below and\n"
+-"above the baseline when modified by a feature."
+-msgstr ""
+-"იმ უკიდურესი მნიშვნელობების მითითება,\n"
+-"რომლითაც ამ დამწერლობის ასონიშანი ასცდება და\n"
+-"ჩამოსცდება საყრდენ ხაზს გარდაქმნისას."
+-
+ msgid ""
+ "Set the minimum and maximum values by which\n"
+ "the glyphs in this script extend below and\n"
+@@ -4228,7 +4739,7 @@ msgid ""
+ msgstr ""
+ "იმ უკიდურესი მნიშვნელობების მითითება,\n"
+ "რომლითაც ამ დამწერლობის ასონიშანი ასცდება და\n"
+-"ჩამოსცდება საყრდენ ხაზს. განსხვავდება ენების მიხედვით"
++"ჩამოსცდება ძირითადი ხაზს. განსხვავდება ენების მიხედვით"
+ 
+ #, c-format
+ msgid ""
+@@ -4254,7 +4765,7 @@ msgid "Show Hidden Files"
+ msgstr "დამალული ფაილების გამოჩენა"
+ 
+ msgid "Show Kerning"
+-msgstr "წანაცვლების გამოჩენა"
++msgstr "შემოკვეცის გამოჩენა"
+ 
+ msgid "Show V. Metrics"
+ msgstr "გამოჩნდეს შვეული აზომვები"
+@@ -4308,7 +4819,7 @@ msgid "Skew by Ruler..."
+ msgstr "გადახრა სახაზავით..."
+ 
+ msgid "Skew the selection"
+-msgstr "მონიშნულის გადახრა"
++msgstr "მონიშნულის დახრა"
+ 
+ msgid "Skew..."
+ msgstr "გადახრა..."
+@@ -4316,6 +4827,9 @@ msgstr "გადახრა..."
+ msgid "Skew:"
+ msgstr "გადახრა:"
+ 
++msgid "Skip"
++msgstr "გამოტოვება"
++
+ #, c-format
+ msgid "Skipping duplicate group %s.\n"
+ msgstr "გამეორებული ჯგუფი %s უგულებელყოფილია.\n"
+@@ -4488,6 +5002,13 @@ msgstr "ზედა საბჯენი:"
+ msgid "TT"
+ msgstr "TrueType"
+ 
++msgid "TTF Names"
++msgstr "TTF-სახელები"
++
++#, c-format
++msgid "Table length stretches beyond end of file for '%c%c%c%c'."
++msgstr "ცხრილის სიგრძე სცდება ზღვარს ფაილისთვის „%c%c%c%c“."
++
+ msgid "Tag must be 4 characters long"
+ msgstr "ჭდე უნდა იყოს 4 სიმბოლოიანი"
+ 
+@@ -4515,6 +5036,9 @@ msgstr "ტამილური"
+ msgid "Tamil Supplement"
+ msgstr "ტამილური დანართი"
+ 
++msgid "Tangent"
++msgstr "მხები"
++
+ msgid "Tangsa"
+ msgstr "ტასე-ნაგა"
+ 
+@@ -4545,7 +5069,8 @@ msgstr "ტაილანდური"
+ 
+ msgid "The 'kern' table supports at most 10920 kern pairs in a subtable"
+ msgstr ""
+-"„kern“ ცხრილში მხარდაჭერილია არაუმეტეს 10920 წანაცვლების წყვილი ქვეცხრილში"
++"„kern“ ცხრილში მხარდაჭერილია შემოკვეცის არაუმეტეს 10920 წყვილის შემცველი "
++"ქვეცხრილი"
+ 
+ msgid ""
+ "The Merge operation cannot be reverted.\n"
+@@ -4632,7 +5157,7 @@ msgid "The color of the outline"
+ msgstr "ფერი მოხაზულობისთვის"
+ 
+ msgid "The color of the preview for drawing lines, rectangles, and ellipses"
+-msgstr "ფერი შესათვალიერებელი ხაზების, მართკუთხედისა და ოვალებისა"
++msgstr "ფერი შესათვალიერებლად წრფივი, მართკუთხა და კვერცხისებრი მოხაზულობისა"
+ 
+ msgid "The color of the selected region"
+ msgstr "მონიშნული ნაწილის ფერი"
+@@ -4646,6 +5171,20 @@ msgstr "მსხვილი გარემოხაზულობის ფ
+ msgid "The color used to display a new guide line dragged from the ruler."
+ msgstr "სახაზავიდან გადაჩოჩებული ახალი მიმმართველი ხაზის ფერი."
+ 
++msgid ""
++"The color used to draw the active horizontal hint which the Review Hints "
++"dialog is examining"
++msgstr ""
++"მოქმედი თარაზული მიმთითებლის აღმნიშვნელი ფერი შეთვალიერების ფანჯრით "
++"სარგებლობისას"
++
++msgid ""
++"The color used to draw the active vertical hint which the Review Hints "
++"dialog is examining"
++msgstr ""
++"მოქმედი შვეული მიმთითებლის აღმნიშვნელი ფერი შეთვალიერების ფანჯრით "
++"სარგებლობისას"
++
+ #, c-format
+ msgid ""
+ "The feature '%c%c%c%c' is named twice in language %s\n"
+@@ -4672,6 +5211,13 @@ msgstr "თვისების ჭდე ხაზზე %d (%s) უნდა
+ msgid "The following error occurred on the selected glyphs: %.100s"
+ msgstr "მოცემული შეცდომა წარმოიშვა მონიშნულ ასონიშნებზე: %.100s"
+ 
++msgid ""
++"The following options influence how glyphs are exported.\n"
++"Most are specific to one or more formats."
++msgstr ""
++"მოცემული პარამეტრები გავლენას ახდენს ასონიშნების გამოტანაზე.\n"
++"უმეტესობა თავსებადია ერთ ან რამდენიმე ცალკეულ სახეობასთან."
++
+ msgid "The following table(s) in the font have been ignored by FontForge\n"
+ msgstr "მოცემულ ცხრილ(ებ)ს შრიფტში არ გაითვალისწინებს FontForge\n"
+ 
+@@ -4680,6 +5226,9 @@ msgid ""
+ "The font %s is one of the standard fonts. It isn't actually in the file."
+ msgstr "შრიფტი %s ერთ-ერთია სტანდარტული შრიფტებიდან. უშუალოდ ფაილში არაა."
+ 
++msgid "The font comment can contain whatever you feel it should"
++msgstr "შრიფტის შენიშვნაში შეგიძლიათ დაურთოთ რაც მოგესურვებათ"
++
+ #, c-format
+ msgid "The font does not contain a glyph named %s."
+ msgstr "შრიფტი არ შეიცავს ასონიშანს დასახელებით %s."
+@@ -4700,9 +5249,9 @@ msgid ""
+ "continue font generation (and omit this character)?"
+ msgstr ""
+ "ასონიშანს შიფრით %d დასახელებად აქვს „.notdef“, მაგრამ შეიცავს მოხაზულობას. "
+-"ვინაიდან ჰქვია „.notdef“, იგი ვერ მოხვდება შექმნილ შრიფტში. ახალი სახელის "
++"ვინაიდან ჰქვია „.notdef“, იგი ვერ მოხვდება დამზადებულ შრიფტში. ახალი სახელის "
+ "მისანიჭებლად იხილეთ „შემადგენელი → ასონიშნის შესახებ“. გსურთ, განაგრძოთ "
+-"შრიფტის წარმოქმნა (ამ ასოს გამოკლებით)?"
++"შრიფტის დამზადება (ამ ასოს გამოკლებით)?"
+ 
+ #, c-format
+ msgid "The glyph name \"%1$.30s\" occurs in groups %2$.30s and %3$.30s"
+@@ -4723,7 +5272,7 @@ msgid ""
+ "You must remove it from one of them."
+ msgstr ""
+ "ასონიშანი %s აგრეთვე ჩანს ამ კლასის %d რიგში, რომლის საწყისია %.20s...\n"
+-"უნდა მოაცილოთ ერთერთიდან."
++"უნდა მოაცილოთ ერთ-ერთიდან."
+ 
+ msgid ""
+ "The human-readable fontname text (in the Names pane) must be entirely ASCII."
+@@ -4736,6 +5285,19 @@ msgid ""
+ "The language, '%s', is not in the list of known languages and will be omitted"
+ msgstr "ენა „%s“ არაა ცნობილი ენების სიაში და გამოტოვებული იქნება"
+ 
++msgid "The layers do not match"
++msgstr "შრეები არ ემთხვევა"
++
++msgid ""
++"The maximum number of Undoes/Redoes stored in a glyph. Use -1 for infinite "
++"Undoes\n"
++"(but watch RAM consumption and use the Edit menu's Remove Undoes as needed)"
++msgstr ""
++"უდიდესი რიცხვი დასაბრუნებელი/გასამეორებელი მოქმედებების დასამახსოვრებლად "
++"ასონიშნიშთვის. გამოიყენეთ -1 უსასრულო რაოდენობისთვის.\n"
++"(ოღონდ გაითვალისწინეთ მეხიერების დატვირთვა და საჭიროების შემთხვევაში "
++"ჩასწორების მენიუდან მოაცილეთ დამახსოვრებული მოქმედებები)"
++
+ #, c-format
+ msgid ""
+ "The name of glyph %.40s has changed. This is what I use to find the glyph in "
+@@ -4746,6 +5308,9 @@ msgstr ""
+ "ასე რომ ეს ასონიშანი ვეღარ დაბრუნდება.\n"
+ "(ამ გაფრთხილებას აღარ იხილავთ მომდევნო ასონიშნებზე.)"
+ 
++msgid "The only valid values for bits/pixel are 1, 2, 4 or 8"
++msgstr "ბიტ/პიქსელის მართებული მნიშვნელობებია მხოლოდ 1, 2, 4 ან 8"
++
+ msgid "The pattern size (width & height) must be a positive number"
+ msgstr "ნიმუშის ზომა (სიგრძე და სიგანე) დადებითი რიცხვი უნდა იყოს"
+ 
+@@ -4765,12 +5330,31 @@ msgstr "მოსაძიებელი ნიმუში კვლავ ვ
+ msgid "The search pattern was not found in the font %.100s"
+ msgstr "მოსაძიებელი ნიმუში ვერ მოინახა შრიფტში %.100s"
+ 
++msgid ""
++"The selected glyphs have no hints. FontForge will not produce many "
++"instructions."
++msgstr ""
++"შერჩეულ ასონიშნებს არ გააჩნია მიმთითებლები. FontForge ვერ დაამუშავებს ბევრ "
++"მითითებას."
++
+ msgid "The version text (in the Names pane) must be entirely ASCII."
+ msgstr "ვერსიის დასახელება (სახელთა არეში) უნდა იყოს სრულად ლათინური ASCII."
+ 
+ msgid "The weight text (in the Names pane) must be entirely ASCII."
+ msgstr "სისქის დასახელება (სახელთა არეში) უნდა იყოს სრულად ლათინური ASCII."
+ 
++msgid ""
++"There already exists a 'cvt' table, perhaps legacy. FontForge can use it, "
++"but can't make any assumptions on values stored there, so generated "
++"instructions will be of lower quality. If legacy hinting is to be scrapped, "
++"it is suggested to clear the `cvt` and repeat autoinstructing. "
++msgstr ""
++"უკვე არსებობს „cvt“ ცხრილი, სავარაუდოდ, მოძველებული. FontForge შეძლებს მის "
++"გამოყენებას, მაგრამ პასუხს ვერ აგებს იქ შენახულ მნიშვნელობებზე, ასე რომ, "
++"მომზადებული მითითებები შეიძლება დაბალი ხარისხის აღმოჩნდეს. თუ მოძველებული "
++"მიმთითებლები უვარგისი იქნება, უმჯობესია გასუფთავდეს `cvt` და კვლავ "
++"განმეორდეს თვითმითითება. "
++
+ #, c-format
+ msgid "There are %d pages in this file, which do you want?"
+ msgstr "ფაილში %d გვერდია, რომელი გნებავთ?"
+@@ -4781,6 +5365,30 @@ msgstr "რამდენიმე ფაილია არქივში, 
+ msgid "There are multiple fonts in this file, pick one"
+ msgstr "რამდენიმე შრიფტია ფაილში, მიუთითეთ ერთი"
+ 
++msgid ""
++"There exists a 'fpgm' code that seems incompatible with FontForge's. "
++"Instructions generated will be of lower quality. If legacy hinting is to be "
++"scrapped, it is suggested to clear the `fpgm` and repeat autoinstructing. It "
++"will be then possible to append user's code to FontForge's 'fpgm', but due "
++"to possible future updates, it is extremely advised to use high numbers for "
++"user's functions."
++msgstr ""
++"უკვე არსებობს „fpgm“ კოდი და როგორც ჩანს, მასთან შეუთავსებელია FontForge. "
++"მომზადებული მითითებები შეიძლება დაბალი ხარისხის აღმოჩნდეს. თუ მოძველებული "
++"მიმთითებლები უვარგისი იქნება, უმჯობესია გასუფთავდეს `fpgm` და კვლავ "
++"განმეორდეს თვითმითითება. შემდეგ უკვე FontForge შეძლებს, მომხმარებლის კოდიც "
++"შემატოს „fpgm-ს“, მაგრამ მოსალოდნელი განახლებებიდან გამომდინარე მეტად "
++"სასურველია მაღალი რიცხვების გამოყენება მომხმარებლის ფუნქციებისთვის."
++
++msgid ""
++"There exists a 'prep' code incompatible with FontForge's. It can't be "
++"guaranteed it will work well. It is suggested to allow FontForge to insert "
++"its code and then append user's own."
++msgstr ""
++"უკვე არსებობს „prep“ კოდი, რომელთანაც შეუთავსებელია FontForge. გამართულად "
++"მუშაობის საწინდარი არ არსებობს. სასურველი იქნება, თუ FontForge თავის კოდს "
++"ჩასვამს და შემდეგ მიამატებს მომხმარებლისას."
++
+ #, c-format
+ msgid "There is no glyph named %s (used in %s)"
+ msgstr "ასონიშანი დასახელებით %s არაა (ფონტში %s)"
+@@ -4789,6 +5397,9 @@ msgstr "ასონიშანი დასახელებით %s არ
+ msgid "There is no glyph named %s in the font"
+ msgstr "ასონიშანი დასახელებით %s არ მოიპოვება ამ შრიფტში"
+ 
++msgid "Things could be better..."
++msgstr "სულ არაფერს სჯობია..."
++
+ msgid "This feature code is already used"
+ msgstr "ამ თვისების კოდი უკვე გამოყენებულია"
+ 
+@@ -4840,22 +5451,33 @@ msgstr ""
+ "შედეგად გაიხსნება 10-ზე მეტი ფანჯარა.\n"
+ "ნამდვილად გსურთ, ასე მოხდეს?"
+ 
++msgid ""
++"This italic conversion will be incomplete!\n"
++"You will probably want to do manual fixups on e, g, k, and v-z\n"
++"And on в, г, д, е, ж, л, м, ц, щ, ъ, ђ\n"
++"And on all Greek lower case letters. And maybe everything else."
++msgstr ""
++"დახრილად გარდაქმნა არასრულყოფილადაა შესრულებული!\n"
++"სასურველი იქნება, ხელით გაასწოროთ e, g, k და v-z\n"
++"აგრეთვე в, г, д, е, ж, л, м, ц, щ, ъ, ђ\n"
++"და ყველა ბერძნული პატარა ასონიშანი. შესაძლოა – სხვა დანარჩენიც."
++
+ #, c-format
+ msgid ""
+ "This kerning pair (%.20s and %.20s) is currently part of a kerning class "
+ "with a 0 offset for this combination. Would you like to alter this kerning "
+ "class entry (or create a kerning pair for just these two glyphs)?"
+ msgstr ""
+-"წანაცვლებული წყვილი (%.20s და %.20s), ამჟამად კლასის ნაწილია 0 "
+-"ურთიერთდაშორებით. გსურთ ამ კლასის ჩანაწერის გადაკეთება (თუ შეიქმნას "
+-"წანაცვლების წყვილი მხოლოდ ამ ორი ასონიშნისთვის)?"
++"შემოკვეცის წყვილი (%.20s და %.20s) ამჟამად 0 წანაცვლების მქონე შემოკვეცის "
++"კლასს ეკუთვნის. გსურთ ამ კლასის ჩანაწერის გადაკეთება (თუ ცალკე შეიქმნას "
++"შემოკვეცის წყვილი მხოლოდ ამ ორი ასონიშნისთვის)?"
+ 
+ msgid ""
+ "This must be ASCII, so you may not use the copyright symbol (use (c) "
+ "instead)."
+ msgstr ""
+ "უნდა იყოს ლათინური ASCII, ამიტომ ვერ გამოიყენებთ საავტორო უფლების ნიშანს "
+-"(სანაცვლოდ (c) შეიძლება)."
++"(სანაცვლოდ (c) გამოდგება)."
+ 
+ msgid "This operation cannot be undone, do it anyway?"
+ msgstr "ეს ქმედება შეუქცევადია, მაინც განაგრძობთ?"
+@@ -4915,7 +5537,7 @@ msgid "To _File"
+ msgstr "ფ_აილში"
+ 
+ msgid "Too Many Kerns"
+-msgstr "ზედმეტად ბევრი წანაცვლება"
++msgstr "ზედმეტად ბევრი შემოკვეცა"
+ 
+ #, c-format
+ msgid "Too many dashes (at most %d allowed)"
+@@ -4926,7 +5548,10 @@ msgid "Too many features %d\n"
+ msgstr "ზედმეტად ბევრი თვისება %d\n"
+ 
+ msgid "Too many kern pairs"
+-msgstr "ზედმეტად ბევრი წანაცვლებული წყვილი"
++msgstr "ზედმეტად ბევრი შემოკვეცილი წყვილი"
++
++msgid "Too many layers"
++msgstr "ზედმეტად ბევრი შრე"
+ 
+ #, c-format
+ msgid "Too many lookups %d\n"
+@@ -4941,6 +5566,9 @@ msgstr "ზედა საბჯენი არ იცვლება."
+ msgid "Toto"
+ msgstr "ტოტო"
+ 
++msgid "Trace Color"
++msgstr "ფერის გამოხაზვა"
++
+ msgid "Trademark"
+ msgstr "სავაჭრო ნიშანი"
+ 
+@@ -4960,7 +5588,7 @@ msgid "Transform _Width Too"
+ msgstr "გარდაქმნა სიგა_ნიანად"
+ 
+ msgid "Transform kerning _classes too"
+-msgstr "გარდაქმნა _წანაცვლების კლასებიანად"
++msgstr "გარდაქმნა _შემოკვეცის კლასებიანად"
+ 
+ msgid "Transform:"
+ msgstr "გარდაქმნა:"
+@@ -4987,6 +5615,9 @@ msgstr "უგარითული"
+ msgid "Unable to parse the pdf objects that make up %s"
+ msgstr "ვერ ხერხდება იმ PDF-ობიექტების გარჩევა, რომლებითაც შექმნილია %s"
+ 
++msgid "Underline _Position:"
++msgstr "ხაზგასმის _მდებარეობა:"
++
+ msgid "Undo Fontlevel"
+ msgstr "დაბრუნება შრიფტის დონეზე"
+ 
+@@ -5018,7 +5649,7 @@ msgid "Uniform scaling for horizontal counters and side bearings"
+ msgstr "ზომის ერთგვაროვანი ცვლა თარაზული არეებისა და გვერდითი საბჯენების"
+ 
+ msgid "UniqueID"
+-msgstr "ამოსაცნობი ID"
++msgstr "საცნობი ID"
+ 
+ msgid "Unknown Language"
+ msgstr "უცნობი ენა"
+@@ -5038,9 +5669,9 @@ msgid ""
+ "to the original name, and it will copy a modified version of\n"
+ "the original glyph into the new one."
+ msgstr ""
+-"უმეტესი ბრძანებებისგან განსხვავებით, ეს პირდაპირ არ ზემოქმედებს მითითებულ "
+-"ასონიშნებზე. სანაცვლოდ, FontForge შექმნის (ან კვლავ გამოიყენებს) ცალკე "
+-"ასონიშანს, თავდაპირველის სახელის გაფართოებით და გადაკეთებული ვარიანტის "
++"უმეტესი ბრძანებებისგან განსხვავებით ეს პირდაპირ არ ზემოქმედებს მითითებულ "
++"ასონიშნებზე. სანაცვლოდ FontForge შექმნის (ან კვლავ გამოიყენებს) ცალკე "
++"ასონიშანს თავდაპირველის სახელის გაფართოებით და გადაკეთებულ ვარიანტს "
+ "განათავსებს იქ."
+ 
+ msgid ""
+@@ -5049,7 +5680,7 @@ msgid ""
+ "FontForge will create (or reuse) a glyph named \"a.sc\", and\n"
+ "it will copy a modified version of the \"A\" glyph into \"a.sc\"."
+ msgstr ""
+-"უმეტესი ბრძანებებისგან განსხვავებით, ეს პირდაპირ არ ზემოქმედებს მითითებულ "
++"უმეტესი ბრძანებებისგან განსხვავებით ეს პირდაპირ არ ზემოქმედებს მითითებულ "
+ "ასონიშნებზე. სანაცვლოდ, როცა მოინიშნება „A“ (ან „a“), FontForge შექმნის (ან "
+ "კვლავ გამოიყენებს) ცალკე ასონიშანს დასახელებით „a.sc“ და გადაკეთებული „A“ "
+ "განთავსდება „a.sc“ ადგილას."
+@@ -5063,6 +5694,27 @@ msgstr "ყველას ჩახსნა"
+ msgid "Unspecified Language"
+ msgstr "განუსაზღვრელი ენა"
+ 
++#, c-format
++msgid "Unsupported decode filter parameters : %s"
++msgstr "მხარდაუჭერელი პარამეტრები გამშირავი ფილტრისთვის: %s"
++
++#, c-format
++msgid "Unsupported filter: %s"
++msgstr "მხარდაუჭერელი ფილტრი: %s"
++
++msgid "Unsupported image format"
++msgstr "მხარდაუჭერელი სახის გამოსახულება"
++
++msgid "Unsupported image format must be bmp"
++msgstr "მხარდაუჭერელი სურათის სახეობა უნდა იყოს bpm"
++
++msgid "Unsupported image format must be bmp or png"
++msgstr "მხარდაუჭერელი სურათის სახეობა უნდა იყოს bpm ან png"
++
++#, c-format
++msgid "Unsupported mime type in data URI: %s\n"
++msgstr "მხარდაუჭერელი MIME-სახეობა მონაცემთა URI-ში : %s\n"
++
+ msgid "UntitledGroup"
+ msgstr "უსათაურო ჯგუფი"
+ 
+@@ -5070,10 +5722,23 @@ msgid "Use FreeType"
+ msgstr "გამოიყენოს FreeType"
+ 
+ msgid "Use Kerning Class?"
+-msgstr "გამოიყენოს წანაცვლების კლასი?"
++msgstr "გამოიყენოს შემოკვეცის კლასი?"
++
++msgid "Use UniqueID"
++msgstr "გამოიყენოს UniqueID"
++
++msgid "Use XUID"
++msgstr "გამოიყენოს XUID"
++
++msgid ""
++"Use this as the default base for the filename\n"
++"when generating a font."
++msgstr ""
++"გამოიყენება ძირეულ დასახელებად\n"
++"შრიფტის ფაილის შექმნისას."
+ 
+ msgid "Used for point numbers, hints, etc."
+-msgstr "გამოიყენება წერტილთა გადასანომრად, მიმნიშნებლებისთვის და სხვ."
++msgstr "გამოიყენება წერტილთა გადასანომრად, მიმთითებლებისა და სხვ."
+ 
+ msgid "Uzbek (Cyrillic)"
+ msgstr "უზბეკური (კირილიცა)"
+@@ -5082,16 +5747,16 @@ msgid "Uzbek (Latin)"
+ msgstr "უზბეკური (ლათინური)"
+ 
+ msgid "VKern By Classes"
+-msgstr "შვეული წანაცვლება კლასებით"
++msgstr "შვეული შემოკვეცა კლასებით"
+ 
+ msgid "VKern By Classes..."
+-msgstr "შვეული წანაცვლება კლასებით..."
++msgstr "შვეული შემოკვეცა კლასებით..."
+ 
+ msgid "VKern From HKern"
+-msgstr "შვეული წანაცვლება თარაზულიდან"
++msgstr "შვეული შემოკვეცა თარაზულიდან"
+ 
+ msgid "VKern:"
+-msgstr "შვეული წანაცვლება:"
++msgstr "შვეული შემოკვეცა:"
+ 
+ msgid "Vai"
+ msgstr "ვაი"
+@@ -5115,17 +5780,21 @@ msgstr "მწარმოებლის ბმული"
+ msgid "Version"
+ msgstr "ვერსია"
+ 
++#. GT: "Vert." is an abbreviation for Vertical
++msgid "Vert. Variants"
++msgstr "შვეულ. სახესხვაობები"
++
+ msgid "Vertical"
+ msgstr "შვეული"
+ 
+ msgid "Vertical Baselines"
+-msgstr "შვეული საყრდენები"
++msgstr "ძირითადი შვეული ხაზები"
+ 
+ msgid "Vertical Kerning"
+-msgstr "შვეული წანაცვლება"
++msgstr "შვეული შემოკვეცა"
+ 
+ msgid "Vertical Kerning Class"
+-msgstr "შვეული წანაცვლების კლასი"
++msgstr "შვეული შემოკვეცის კლასი"
+ 
+ msgid "Vertical Only"
+ msgstr "შვეული მხოლოდ"
+@@ -5142,8 +5811,8 @@ msgstr "შვეული _აზომვის ხაზები"
+ #, c-format
+ msgid "Vertical: %d baseline"
+ msgid_plural "Vertical: %d baselines"
+-msgstr[0] "შვეული: %d საყრდენი"
+-msgstr[1] "შვეული: %d საყრდენი"
++msgstr[0] "შვეული: %d ძირითადი ხაზი"
++msgstr[1] "შვეული: %d ძირითადი ხაზი"
+ 
+ msgid "Very Extended"
+ msgstr "მეტად გაფართოებული"
+@@ -5151,6 +5820,15 @@ msgstr "მეტად გაფართოებული"
+ msgid "Vietnamese"
+ msgstr "ვიეტნამური"
+ 
++msgid "WOFF"
++msgstr "WOFF"
++
++msgid "WOFF compressed metadata section too large.\n"
++msgstr "WOFF-ს დართული შეკუმშული მონაცემები ზედმეტად დიდია.\n"
++
++msgid "WOFF uncompressed metadata section too large.\n"
++msgstr "WOFF-ს დართული შეუკუმშავი მონაცემები ზედმეტად დიდია.\n"
++
+ msgid "WWS Subfamily"
+ msgstr "WWS-ქვეჯგუფი"
+ 
+@@ -5166,16 +5844,48 @@ msgstr "გაფრთხილება"
+ msgid "Warning: Font contained no glyphs"
+ msgstr "გაფრთხილება: შრიფტი არ შეიცავს ასონიშნებს"
+ 
++#, c-format
++msgid ""
++"Warning: Mac and Windows entries in the 'name' table differ for the\n"
++" %s string in the language %s\n"
++" Mac String: %s\n"
++"Windows String: %s\n"
++msgstr ""
++"გაფრთხილება: Mac-ისა და Windows-ის ჩანაწერები „name“ ცხრილში განსხვავდება\n"
++" %s ველში ენისთვის %s\n"
++" Mac-ჩანაწერია: %s\n"
++"Windows-ჩანაწერია: %s\n"
++
+ #, c-format
+ msgid "Warning: Unlikely number of subtables (%d) for 'kern' table"
+ msgstr "გაფრთხილება: შეუსაბამო რაოდენობის ქვეცხრილები (%d) „kern“ ცხრილისთვის"
+ 
++msgid "Warning: Unrecognized or unsupported join type, defaulting to 'nib'.\n"
++msgstr ""
++"გაფრთხილება: დაუდგენელი ან მხარდაუჭერელი სახის შეერთება, ნაგულისხმევად "
++"დაბრუნდება 'nib'.\n"
++
+ msgid "Warnings"
+ msgstr "გაფრთხილებები"
+ 
+ msgid "Warnings.Font"
+ msgstr "გაფრთხილებების.შრიფტი"
+ 
++msgid "Web Open Font (WOFF)"
++msgstr "Web Open Font (WOFF)"
++
++msgid "Web Open Font (WOFF2)"
++msgstr "Web Open Font (WOFF2)"
++
++msgid ""
++"When Saving, keep this number of previous versions of the file. file.sfd-01 "
++"will be the last saved file, file.sfd-02 will be the file saved before that, "
++"and so on. If you set this to 0 then no revisions will be retained."
++msgstr ""
++"შენახვისას დაიტოვებს მითითებული რაოდენობის გადამუშავებულ ვერსიებს. file."
++"sfd-01 იქნება ბოლოს შენახული ფაილი, file.sfd-02 იქნება წინა და ა.შ. თუ "
++"მიუთითებთ 0-ს, მაშინ წინა ვერსიები არ შენარჩუნდება."
++
+ msgid "When a font is opened, should it be made compact?"
+ msgstr "შრიფტის გახსნისას, იყოს თუ არა შემჭიდროებული?"
+ 
+@@ -5232,24 +5942,67 @@ msgstr "Win"
+ msgid "Windows Latin (\"ANSI\")"
+ msgstr "Windows ლათინური (\"ANSI\")"
+ 
++msgid "Windows will reject fonts with an OS/2 version number of 0\n"
++msgstr "Windows უარყოფს შრიფტებს OS/2 ვერსიის ნომრით 0\n"
++
++msgid "Windows will reject otf (cff) fonts with an OS/2 version number of 1\n"
++msgstr "Windows უარყოფს otf (cff) შრიფტებს OS/2 ვერსიის ნომრით 1\n"
++
+ msgid "Windows-compatible 'kern'"
+ msgstr "Windows-სთან თავსებადი „kern“"
+ 
++msgid "Woff Major Version:"
++msgstr "Woff ძირითადი ვერსია:"
++
++msgid "Woff Minor Version:"
++msgstr "Woff დამატებითი ვერსია:"
++
+ #. GT: X is a coordinate
+ msgid "X"
+ msgstr "X"
+ 
++msgid "XFig"
++msgstr "XFig"
++
+ #. GT: Y is a coordinate
+ #. GT: Y is a coordinate, the leading spaces help to align it
+ msgid "Y"
+ msgstr "Y"
+ 
++msgid "Yes"
++msgstr "დიახ"
++
+ msgid "Yes to _All"
+ msgstr "დიახ _ყველას"
+ 
+ msgid "Yes, and don't _remind me again"
+ msgstr "დიახ, მომავალში _კითხვის გარეშე"
+ 
++#, c-format
++msgid ""
++"You appear to have an old editing session on %s.\n"
++"Would you like to recover it?"
++msgstr ""
++"ჩანს, დაუსრულებელი გაქვთ ადრინდელი ნამუშევარი %s.\n"
++"გსურთ მისი აღდგენა?"
++
++msgid ""
++"You are about to change the last quadratic\n"
++"layer to cubic. When this happens FontForge\n"
++"will remove all truetype instructions.\n"
++"\n"
++"This cannot be undone.\n"
++"\n"
++"Is this really your intent?"
++msgstr ""
++"აპირებთ გადაიყვანოთ ბოლო კვადრატული\n"
++"შრე კუბურში. შედეგად FontForge\n"
++"მოაცილებას ყველა truetype-მითითებას.\n"
++"\n"
++"ეს ქმედება შეუქცცევადია.\n"
++"\n"
++"ნამდვილად გსურთ, განაგრძოთ?"
++
+ msgid ""
+ "You are about to delete a layer.\n"
+ "This will lose all contours in that layer.\n"
+@@ -5366,18 +6119,38 @@ msgstr "_დასაშიფრი ადგილების დამატ
+ msgid "_Advance Width only"
+ msgstr "მხოლოდ გა_ფართოებული სიგანე"
+ 
++#. GT: Align these points to their average position
++msgid "_Align Points"
++msgstr "წერტილების ურთიერთს_წორება"
++
+ msgid "_Alphabetic"
+ msgstr "_ანბანური"
+ 
++msgid "_Always raise this dialog when exporting"
++msgstr "ამ ფანჯრის _ყოველ ჯერზე ამოგდება გამოტანისას"
++
+ msgid "_Around"
+ msgstr "_მიახლოებით"
+ 
++msgid "_Ascent:"
++msgstr "_ზედატანი:"
++
+ msgid "_Ask"
+ msgstr "კით_ხვა"
+ 
+ msgid "_Auto Width..."
+ msgstr "_სიგანის თვითგანსაზღვრა..."
+ 
++#. GT: Background, make it short
++msgid "_Back"
++msgstr "_უკანა"
++
++msgid "_Base Filename:"
++msgstr "_ძირეული სახელი:"
++
++msgid "_Base:"
++msgstr "_საყრდენი:"
++
+ msgid "_Bigger Pixel Size"
+ msgstr "მო_ზრდილი ზომა პიქსელის"
+ 
+@@ -5403,10 +6176,10 @@ msgid "_Changed Glyphs"
+ msgstr "შე_ცვლილი ასონიშნები"
+ 
+ msgid "_Circular (Elliptical)"
+-msgstr "_წრიული (ოვალური)"
++msgstr "_წრიული (კვერცხისებრი)"
+ 
+ msgid "_Clear Hints"
+-msgstr "მიმნიშნებლების გას_უფთავება"
++msgstr "მიმთითებლების გას_უფთავება"
+ 
+ msgid "_Close"
+ msgstr "_დახურვა"
+@@ -5435,6 +6208,9 @@ msgstr "_ნაგულისხმევი გამოცალკევე
+ msgid "_Delete"
+ msgstr "_წაშლა"
+ 
++msgid "_Descent:"
++msgstr "_ქვედატანი:"
++
+ msgid "_Deselect All"
+ msgstr "ყველა მონიშვნის მო_ხსნა"
+ 
+@@ -5447,8 +6223,11 @@ msgstr "_ჩახსნა ასონიშნების"
+ msgid "_Disable"
+ msgstr "გამ_ორთვა"
+ 
++msgid "_Docked Palettes"
++msgstr "ჩამაგ_რებული"
++
+ msgid "_Don't AutoHint"
+-msgstr "თვითმინიშნების _გარეშე"
++msgstr "თვითმიმთითებლის _გარეშე"
+ 
+ msgid "_Don't Save"
+ msgstr "შენახვის _გარეშე"
+@@ -5480,6 +6259,12 @@ msgstr "ში_ფრი თექვსმეტობითში"
+ msgid "_Exact"
+ msgstr "_ზუსტად"
+ 
++msgid "_Exclude"
++msgstr "გამორი_ცხვა"
++
++msgid "_Extrema"
++msgstr "_წვერო"
++
+ msgid "_Family Name:"
+ msgstr "_კრებულის სახელი:"
+ 
+@@ -5492,6 +6277,9 @@ msgstr "შევ_სება"
+ msgid "_Filter"
+ msgstr "გამორ_ჩევა"
+ 
++msgid "_Find Intersections"
++msgstr "თანაკვეთის _პოვნა"
++
+ msgid "_Fit"
+ msgstr "მ_ორგება"
+ 
+@@ -5499,11 +6287,14 @@ msgid "_Flatten bumps on lines"
+ msgstr "ბორცვების დაბრტ_ყელება ხაზებზე"
+ 
+ msgid "_Font Info..."
+-msgstr "შრიფ_ტის შესახებ..."
++msgstr "შრიფ_ტის მონაცემები..."
+ 
+ msgid "_Force Encoding"
+ msgstr "_იძულებით დაშიფვრა"
+ 
++msgid "_Forget about it"
++msgstr "ამის დავი_წყება"
++
+ msgid "_Freehand"
+ msgstr "თა_ვისუფალი"
+ 
+@@ -5511,16 +6302,16 @@ msgid "_Full Font Display"
+ msgstr "_სრული შრიფტის გამოჩენა"
+ 
+ msgid "_Generate"
+-msgstr "შედ_გენა"
++msgstr "დამ_ზადება"
+ 
+ msgid "_Generate Fonts..."
+-msgstr "შრიფტების _შედგენა..."
++msgstr "შრიფტების _დამზადება..."
+ 
+ msgid "_Glyph Image"
+ msgstr "ას_ონიშნის გამოსახულება"
+ 
+ msgid "_Glyph Info..."
+-msgstr "ას_ონიშნის შესახებ..."
++msgstr "ას_ონიშნის მონაცემები..."
+ 
+ msgid "_Glyph Tabs"
+ msgstr "ას_ონიშნის ჩანართები"
+@@ -5528,6 +6319,9 @@ msgstr "ას_ონიშნის ჩანართები"
+ msgid "_Goto"
+ msgstr "გადა_სვლა"
+ 
++msgid "_Guess"
++msgstr "სავარა_უდო"
++
+ #. GT: Guide layer, make it short
+ msgid "_Guide"
+ msgstr "_მიმმართველი"
+@@ -5551,10 +6345,10 @@ msgid "_Horizontal"
+ msgstr "თარა_ზული"
+ 
+ msgid "_Horizontal Baselines..."
+-msgstr "_თარაზული საყრდენები..."
++msgstr "ძირითადი _თარაზული ხაზები..."
+ 
+ msgid "_Horizontal Hints"
+-msgstr "_თარაზული მიმნიშნებლები"
++msgstr "_თარაზული მიმთითებლები"
+ 
+ msgid "_IBM Family:"
+ msgstr "_IBM-კრებული:"
+@@ -5571,14 +6365,20 @@ msgstr "ჩამა_ტება"
+ msgid "_Insert Random Text..."
+ msgstr "შემთხვევითი ტექსტის ჩამა_ტება..."
+ 
++msgid "_Interpolated"
++msgstr "_ჩამატებული"
++
++msgid "_Intersect"
++msgstr "თანა_კვეთა"
++
+ msgid "_Invert Selection"
+ msgstr "შებრ_უნებული მონიშვნა"
+ 
+ msgid "_Kern Pairs"
+-msgstr "_წანაცვლებული წყვილები"
++msgstr "_შემოკვეცილი წყვილები"
+ 
+ msgid "_Kerning only"
+-msgstr "მხოლოდ _წანაცვლება"
++msgstr "მხოლოდ _შემოკვეცა"
+ 
+ msgid "_Knife"
+ msgstr "_მოსაჭრელი"
+@@ -5610,14 +6410,20 @@ msgstr "მოა_ხლოება"
+ msgid "_Maximum distance between points in a region"
+ msgstr "უ_დიდესი დაშორება წერტილებს შორის არეში"
+ 
++msgid "_Merge"
++msgstr "გა_ერთიანება"
++
+ msgid "_Merge Feature Info..."
+ msgstr "_თვისებების მონაცემთა გაერთიანება..."
+ 
++msgid "_Merge Fonts..."
++msgstr "შრიფტების გა_ერთიანება..."
++
+ msgid "_Metrics"
+ msgstr "_აზომვები"
+ 
+ msgid "_Min Kern:"
+-msgstr "უ_მცირესი წანაცვლება:"
++msgstr "უ_მცირესი შემოკვეცა:"
+ 
+ msgid "_Min:"
+ msgstr "უ_მცირესი:"
+@@ -5625,6 +6431,9 @@ msgstr "უ_მცირესი:"
+ msgid "_More Info"
+ msgstr "ვრ_ცლად"
+ 
++msgid "_Move Points"
++msgstr "წერტილების გადა_ტანა"
++
+ msgid "_Multi Size Glyph"
+ msgstr "_რამდენიმე ზომით"
+ 
+@@ -5667,6 +6476,9 @@ msgstr "_კარგი"
+ msgid "_Open"
+ msgstr "_გახსნა"
+ 
++msgid "_Options"
++msgstr "პარამე_ტრები"
++
+ msgid "_Other"
+ msgstr "ს_ხვა"
+ 
+@@ -5682,6 +6494,9 @@ msgstr "_მოხაზულობა..."
+ msgid "_Overview"
+ msgstr "_გადახედვა"
+ 
++msgid "_Palettes"
++msgstr "ხელსაწ_ყოთა არეები"
++
+ msgid "_Partial"
+ msgstr "_ნაწილობრივ"
+ 
+@@ -5754,8 +6569,11 @@ msgstr "ყველას ა_ღდგენა"
+ msgid "_Revert File"
+ msgstr "ა_ღდგენა"
+ 
++msgid "_Review Hints..."
++msgstr "_მიმთითებლების შეთვალიერება..."
++
+ msgid "_Rotate 90° CW"
+-msgstr "_შებრუნება 90° საათის მიმართ."
++msgstr "_მობრუნება 90° საათ. მიმართ."
+ 
+ msgid "_Ruler"
+ msgstr "_სახაზავი"
+@@ -5775,6 +6593,9 @@ msgstr "შრიფტის სახელთა სიის შენა_
+ msgid "_Save in UTF8"
+ msgstr "შენახ_ვა UTF8-სახით"
+ 
++msgid "_Scale Outlines"
++msgstr "მოხაზულობის _ზომის ცვლილება"
++
+ msgid "_Scroll"
+ msgstr "_გადასაადგილებელი"
+ 
+@@ -5802,12 +6623,21 @@ msgstr "_ზომა:"
+ msgid "_Skew..."
+ msgstr "გა_დახრა..."
+ 
++msgid "_Skip"
++msgstr "გამ_ოტოვება"
++
++msgid "_Skip for now"
++msgstr "ამჟამად _არიდება"
++
+ msgid "_Smaller Pixel Size"
+ msgstr "მომ_ცრო ზომა პიქსელის"
+ 
+ msgid "_Tag:"
+ msgstr "_ჭდე:"
+ 
++msgid "_Tangent"
++msgstr "_მხები"
++
+ msgid "_Thirds in Width"
+ msgstr "სიგანის მ_ესამედში"
+ 
+@@ -5826,12 +6656,18 @@ msgstr "გა_რდაქმნა..."
+ msgid "_Transformations"
+ msgstr "_გარდაქმნები"
+ 
++msgid "_Type3 Multi Layered Font"
++msgstr "მრავალშრიანი შრიფტი _Type3"
++
+ msgid "_Undo"
+ msgstr "_დაბრუნება"
+ 
+ msgid "_Unicode"
+ msgstr "_უნიკოდი"
+ 
++msgid "_UniqueID:"
++msgstr "_UniqueID:"
++
+ msgid "_Unlink All"
+ msgstr "_ჩაიხსნას ყველა"
+ 
+@@ -5841,6 +6677,9 @@ msgstr "აწ_ევა"
+ msgid "_Use My Metrics"
+ msgstr "_საკუთარი აზომვების გამოყენება"
+ 
++msgid "_Use Transform (SVG)"
++msgstr "„გარდაქმნის“ გამ_ოყენება (SVG)"
++
+ msgid "_Validate..."
+ msgstr "შემო_წმება..."
+ 
+@@ -5857,10 +6696,10 @@ msgid "_Vertical"
+ msgstr "შ_ვეული"
+ 
+ msgid "_Vertical Baselines..."
+-msgstr "_შვეული საყრდენები..."
++msgstr "ძირითადი _შვეული ხაზები..."
+ 
+ msgid "_Vertical Hints"
+-msgstr "_შვეული მიმნიშნებლები"
++msgstr "_შვეული მიმთითებლები"
+ 
+ msgid "_View"
+ msgstr "_ხედი"
+@@ -5880,12 +6719,23 @@ msgstr "_ფანჯრის სახეობა"
+ msgid "_X:"
+ msgstr "_X:"
+ 
++msgid "_XUID:"
++msgstr "_XUID:"
++
+ msgid "_Y:"
+ msgstr "_Y:"
+ 
+ msgid "_Yes"
+ msgstr "_დიახ"
+ 
++#. GT: The dialog looks like:
++#. GT:   Interpolating between <fontname> and:
++#. GT: <list of possible fonts>
++#. GT:   by  <50>%
++#. GT: So "by" means how much to interpolate.
++msgid "by"
++msgstr "მნიშვნ."
++
+ msgid "color bitmap data table"
+ msgstr "ფერის ცხრილურ მონაცემთა ნუსხა"
+ 
+@@ -5922,6 +6772,9 @@ msgstr "კრებულის სახელი"
+ msgid "gaspTableEntry|New"
+ msgstr "ახალი"
+ 
++msgid "glyph location table"
++msgstr "ასონიშნის მდებარეობის ცხრილი"
++
+ msgid "glyph outline table"
+ msgstr "ასონიშნის მოხაზულობის ცხრილი"
+ 
+@@ -5929,10 +6782,10 @@ msgid "if smaller than"
+ msgstr "თუ მოკლეა, ვიდრე"
+ 
+ msgid "kern pair"
+-msgstr "წანაცვლებული წყვილი"
++msgstr "შემოკვეცილი წყვილი"
+ 
+ msgid "kerning table"
+-msgstr "წანაცვლების ცხრილი"
++msgstr "შემოკვეცის ცხრილი"
+ 
+ msgid "language tag table"
+ msgstr "ენის ჭდეების ცხრილი"
+@@ -5946,6 +6799,24 @@ msgstr "გრძელი, ვიდრე"
+ msgid "metrics variations table"
+ msgstr "აზომვის გადახრების ცხრილი"
+ 
++msgid "png"
++msgstr "png"
++
++msgid "points|Merge to Line"
++msgstr "points|გაერთიანება ხაზით"
++
++msgid "points|_Merge"
++msgstr "points|გა_ერთიანება"
++
++msgid "problfixup|Missing Extrema"
++msgstr "problfixup|აკლია წვერო"
++
++msgid "sfnt Revision:"
++msgstr "sfnt-გადამუშავება:"
++
++msgid "sfnt _Revision:"
++msgstr "sfnt-გადამ_უშავება:"
++
+ msgid "version"
+ msgstr "ვერსია"
+ 
+@@ -6009,3 +6880,7 @@ msgstr "ბიტური შრიფტები ΤεΧ"
+ 
+ msgid "ΤεΧ Names"
+ msgstr "ΤεΧ სახელები"
++
++#, c-format
++msgid "∆Curvature: %g"
++msgstr "∆სიმრუდე: %g"
+diff --git a/po/ko.po b/po/ko.po
+index 971b4db03b..c74d554846 100644
+--- a/po/ko.po
++++ b/po/ko.po
+@@ -19,8 +19,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Korean\n"
+ "Language: ko_KR\n"
+@@ -3308,16 +3308,16 @@ msgstr "합음자글리프가 부적절합니다. GID %d가 %d 미만이 아닙
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "포맷 2 (%d/%d) 의 참조테이블이 손상되어 있습니다.최초=%d 마지막=%d 폰트내의 "
+ "모든 글리프수=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "포맷 4 (%d/%d) 의 참조테이블이 손상되어 있습니다.최초=%d 마지막=%d 폰트내의 "
+ "모든 글리프수=%d\n"
+@@ -7563,8 +7563,8 @@ msgstr "%2$s의 %1$d행에서 예상되는 콤마 또는 세미콜론"
+ msgid ""
+ "Expected either \"HorizAxis\" or \"VertAxis\" in BASE table on line %d of %s"
+ msgstr ""
+-"%2$s의 %1$d행에 있는 베이스 테이블에서 예상되는 \"HorizAxis\" 또는 \"VertAxis"
+-"\""
++"%2$s의 %1$d행에 있는 베이스 테이블에서 예상되는 \"HorizAxis\" 또는 "
++"\"VertAxis\""
+ 
+ msgid "Expected glyph file with format==1 or 2"
+ msgstr "형식이==1 또는 2인 예상 글리프 파일"
+@@ -9134,8 +9134,8 @@ msgid ""
+ " with platform=%d, specific=%d (in 'cmap')\n"
+ msgstr ""
+ "글리프인덱스가 범위 외의 %d 값으로 되어 있습니다만, %d 미만이어야 합니다.\n"
+-"  인코딩 %x 이라는 글리프 (('cmap' 의)세그멘트 %d 의 중에 있음.  이 플랫폼ID="
+-"%d, 고유ID=%d) 를 맵핑할 때에   검색합니다.\n"
++"  인코딩 %x 이라는 글리프 (('cmap' 의)세그멘트 %d 의 중에 있음.  이 플랫폼"
++"ID=%d, 고유ID=%d) 를 맵핑할 때에   검색합니다.\n"
+ 
+ msgid ""
+ "Glyph names (or unicode code points) may occur at most once in this group "
+@@ -14704,8 +14704,8 @@ msgstr "없음/열림 루프"
+ #, c-format
+ msgid "Nonsensical class assigned to a glyph-- class=%d is too big. Glyph=%d\n"
+ msgstr ""
+-"무의미한 클래스가 글리프에 부여되어 있습니다―클래스=%d는 너무 큽니다. 글리프="
+-"%d\n"
++"무의미한 클래스가 글리프에 부여되어 있습니다―클래스=%d는 너무 큽니다. 글리프"
++"=%d\n"
+ 
+ msgid "Normal"
+ msgstr "보통"
+@@ -19572,8 +19572,8 @@ msgid "SnapToInt"
+ msgstr "정수로 스냅"
+ 
+ msgid ""
+-"So if you type \"A\" here the first selected glyph would be named \"A.suffix"
+-"\".\n"
++"So if you type \"A\" here the first selected glyph would be named \"A."
++"suffix\".\n"
+ "The second \"B.suffix\", and so on."
+ msgstr ""
+ "그래서 여기서 \"A\"를 입력하면 첫 번째로 선택된 글리프 이름이 \"A.suffix\"가 "
+@@ -20918,7 +20918,6 @@ msgstr ""
+ "폰트%3$.30s 글리프\"%2$.30s\"에 포함되는 힌트%1$s는, %4$.30s에 포함되는 것과 "
+ "일치하지 않습니다(개수 또는 겹치기 특징이 다릅니다)"
+ 
+-#, c-format
+ msgid ""
+ "The %1$s in the search dialog contains a reference to %2$.20hs which does "
+ "not exist in the new font.\n"
+@@ -22659,8 +22658,8 @@ msgstr "선택한 점을 그리는 데 사용되는 선의 폭"
+ #, c-format
+ msgid ""
+ "The width, height, depth or italic correction of %s is too big. Tfm files "
+-"may not contain values bigger than 16 times the em-size of the font. Width="
+-"%g, height=%g, depth=%g, italic correction=%g"
++"may not contain values bigger than 16 times the em-size of the font. "
++"Width=%g, height=%g, depth=%g, italic correction=%g"
+ msgstr ""
+ "%s 너비, 높이, 깊이 또는 기울임 꼴 보정이 너무 큽니다. Tfm 파일에 포함 된 em "
+ "크기는 글꼴 크기의 16 배를 초과 할 수 없습니다. 폭 = %g, 높이 = %g, 깊이 = "
+@@ -25551,7 +25550,6 @@ msgstr ""
+ "경고: 'cvar' 에 중간tuple데이터가 포함되어 있습니다.\n"
+ "  FontForge는 이것을 지원하지 않습니다\n"
+ 
+-#, c-format
+ msgid "Warning: Accuracy target %lf less than minimum %lf, using %lf instead\n"
+ msgstr "경고: 정확도 목표 %lf는 최소 %lf 미만입니다. 대신 %lf를 사용합니다\n"
+ 
+@@ -25570,7 +25568,6 @@ msgstr "경고 : 등고선 엔드가 닫히지 않았습니다\n"
+ msgid "Warning: Contour start did not close\n"
+ msgstr "경고 : 등고선 시작이 닫 없습니다\n"
+ 
+-#, c-format
+ msgid "Warning: Coordinate diff %lf greater than margin %lf\n"
+ msgstr "경고: 좌표 차이 %lf이 여백 %lf를 초과합니다\n"
+ 
+@@ -28641,8 +28638,8 @@ msgstr ""
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d ∆x_adv="
+-"%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
++"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d "
++"∆x_adv=%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ msgstr ""
+ "%2$s의 “%1$s”에서 짝단위 위치지정 ∆x=%3$d ∆y=%4$d ∆x_adv=%5$d ∆y_adv=%6$d(다"
+ "음의 글리프%7$s에서 ∆x=%8$d ∆y=%9$d ∆x_adv=%10$d ∆y_adv=%11$d)를 수행하는 참"
+@@ -28650,8 +28647,8 @@ msgstr ""
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv="
+-"%d\n"
++"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d "
++"∆y_adv=%d\n"
+ msgstr ""
+ "%2$s의 “%1$s”에서 위치지정 ∆x=%3$d ∆y=%4$d ∆x_adv=%5$d ∆y_adv=%6$d를 수행하"
+ "는 참조는 없습니다\n"
+diff --git a/po/ml.po b/po/ml.po
+index a611e01b03..095d50e346 100644
+--- a/po/ml.po
++++ b/po/ml.po
+@@ -11,8 +11,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Malayalam\n"
+ "Language: ml_IN\n"
+diff --git a/po/pl.po b/po/pl.po
+index 2bbbf00be6..f6697c2d9c 100644
+--- a/po/pl.po
++++ b/po/pl.po
+@@ -12,17 +12,17 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Polish\n"
+ "Language: pl_PL\n"
+ "MIME-Version: 1.0\n"
+ "Content-Type: text/plain; charset=UTF-8\n"
+ "Content-Transfer-Encoding: 8bit\n"
+-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
+-"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
+-"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
++"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && "
++"(n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && "
++"n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+ "X-Crowdin-Project: fontforge\n"
+ "X-Crowdin-Project-ID: 368599\n"
+ "X-Crowdin-Language: pl\n"
+@@ -221,8 +221,8 @@ msgid ""
+ "!!!!! Bad Base Coord format (%d) for '%c%c%c%c' in '%c%c%c%c' script in "
+ "'BASE' table\n"
+ msgstr ""
+-"!!!!! Nieznany format współrzędnej linii podstawowej pisma (%d) w funkcji „%c"
+-"%c%c%c” dla pisma „%c%c%c%c” w talicy „BASE”\n"
++"!!!!! Nieznany format współrzędnej linii podstawowej pisma (%d) w funkcji "
++"„%c%c%c%c” dla pisma „%c%c%c%c” w talicy „BASE”\n"
+ 
+ #, c-format
+ msgid ""
+@@ -3101,19 +3101,19 @@ msgstr "Błędny glif ligatury: numer znaku %d nie jest mniejszy od %d\n"
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+-"Błędna tablica funkcji zecerskich: format=2 (%d/%d), pierwszy=%d, ostatni="
+-"%d, liczba glifów w foncie=%d\n"
++"Błędna tablica funkcji zecerskich: format=2 (%d/%d), pierwszy=%d, "
++"ostatni=%d, liczba glifów w foncie=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+-"Błędna tablica funkcji zecerskich: format=4 (%d/%d), pierwszy=%d, ostatni="
+-"%d, liczba glifów w foncie=%d\n"
++"Błędna tablica funkcji zecerskich: format=4 (%d/%d), pierwszy=%d, "
++"ostatni=%d, liczba glifów w foncie=%d\n"
+ 
+ #, c-format
+ msgid "Bad lookup table: format=6, first=%d total glyphs in font=%d\n"
+@@ -10384,8 +10384,8 @@ msgstr "Formy JIS90"
+ #, c-format
+ msgid "JSTF extension max at priority %d #%d for %c%c%c%c in %c%c%c%c"
+ msgstr ""
+-"'jstf' graniczne rozbicie wiersza: waga %d #%d, język %c%c%c%c, pismo %c%c%c"
+-"%c"
++"'jstf' graniczne rozbicie wiersza: waga %d #%d, język %c%c%c%c, pismo "
++"%c%c%c%c"
+ 
+ #. GT: This string is used to generate a name for an OpenType lookup.
+ #. GT:  the %c%c... is the language followed by the script (OT tags)
+@@ -16972,8 +16972,8 @@ msgid ""
+ "Script '%c%c%c%c' claims baseline '%c%c%c%c' as its default, but that "
+ "baseline is not currently active."
+ msgstr ""
+-"Pismo „%c%c%c%c” ma mieć ustawioną domyślą linię podstawową systemu „%c%c%c"
+-"%c”. Jednakże ten system linii podstawowych nie został wybrany jako "
++"Pismo „%c%c%c%c” ma mieć ustawioną domyślą linię podstawową systemu "
++"„%c%c%c%c”. Jednakże ten system linii podstawowych nie został wybrany jako "
+ "obsługiwany w foncie."
+ 
+ #, c-format
+@@ -18281,8 +18281,8 @@ msgid "SnapToInt"
+ msgstr "Przyciągaj do całkowitych"
+ 
+ msgid ""
+-"So if you type \"A\" here the first selected glyph would be named \"A.suffix"
+-"\".\n"
++"So if you type \"A\" here the first selected glyph would be named \"A."
++"suffix\".\n"
+ "The second \"B.suffix\", and so on."
+ msgstr ""
+ "Jeśli wpisane zostanie tu „A”, to nazwa pierwszego zaznaczonego glifu "
+@@ -19550,7 +19550,6 @@ msgstr ""
+ "Hinty %1$s w glifie „%2$.30s” w foncie „%3$.30s” nie pasują do tych z "
+ "„%4$.30s” (inna liczba lub inne maski hintów)"
+ 
+-#, c-format
+ msgid ""
+ "The %1$s in the search dialog contains a reference to %2$.20hs which does "
+ "not exist in the new font.\n"
+@@ -20649,8 +20648,8 @@ msgid ""
+ "\n"
+ "Would you like to add this script to one of those features?"
+ msgstr ""
+-"Tablica funkcji zecerskich %.30s jest aktywna dla glifu %.30s z pisma „%c%c%c"
+-"%c”, ale to pismo nie występuje w żadnej funkcji korzystającej z tej "
++"Tablica funkcji zecerskich %.30s jest aktywna dla glifu %.30s z pisma "
++"„%c%c%c%c”, ale to pismo nie występuje w żadnej funkcji korzystającej z tej "
+ "tablicy.\n"
+ "Czy dodać to pismo do którejś z wymienionych funkcji?"
+ 
+@@ -21196,8 +21195,8 @@ msgstr "Grubość obwódki używanej do rysowania zaznaczonych punktów na krzyw
+ #, c-format
+ msgid ""
+ "The width, height, depth or italic correction of %s is too big. Tfm files "
+-"may not contain values bigger than 16 times the em-size of the font. Width="
+-"%g, height=%g, depth=%g, italic correction=%g"
++"may not contain values bigger than 16 times the em-size of the font. "
++"Width=%g, height=%g, depth=%g, italic correction=%g"
+ msgstr ""
+ "Szerokość, wysokość, głębokość lub kompensata pochylenia dla %s jest zbyt "
+ "duża. Pliki tfm nie mogą zawierać wartości większych niż 16 × wysokość pola "
+@@ -24978,8 +24977,8 @@ msgstr ""
+ #, c-format
+ msgid "You have just changed the point numbering of glyph %s.%s%s%s"
+ msgstr ""
+-"Właśnie uległy zmianie numery poszczególnych punktów tworzących glif %s.%s%s"
+-"%s"
++"Właśnie uległy zmianie numery poszczególnych punktów tworzących glif %s."
++"%s%s%s"
+ 
+ msgid "You may change the default instance of this font"
+ msgstr "Można zmienić domyślny wariant w tym foncie"
+@@ -26839,19 +26838,19 @@ msgstr ""
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d ∆x_adv="
+-"%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
++"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d "
++"∆x_adv=%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ msgstr ""
+ "Glif “%s” w %s nie zawiera pozycjonowania ∆x=%d ∆y=%d ∆szer=%d ∆wys=%dw "
+ "parze z %s ∆x=%d ∆y=%d ∆szer=%d ∆wys=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv="
+-"%d\n"
++"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d "
++"∆y_adv=%d\n"
+ msgstr ""
+-"Glif „%s” w %s nie zawiera pozycjonowania prostego ∆x=%d ∆y=%d ∆szer=%d ∆wys="
+-"%d.\n"
++"Glif „%s” w %s nie zawiera pozycjonowania prostego ∆x=%d ∆y=%d ∆szer=%d "
++"∆wys=%d.\n"
+ 
+ #, c-format
+ msgid "“%s” in %s did not contain a substitution lookup to %s\n"
+diff --git a/po/pt.po b/po/pt.po
+index 62ec090e75..76ac806be7 100644
+--- a/po/pt.po
++++ b/po/pt.po
+@@ -14,8 +14,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Portuguese\n"
+ "Language: pt_PT\n"
+diff --git a/po/ru.po b/po/ru.po
+index 77b8f11baf..a6dd423420 100644
+--- a/po/ru.po
++++ b/po/ru.po
+@@ -12,8 +12,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Russian\n"
+ "Language: ru_RU\n"
+diff --git a/po/tr_TR.po b/po/tr_TR.po
+index f251a13300..4aa28e9761 100644
+--- a/po/tr_TR.po
++++ b/po/tr_TR.po
+@@ -9,8 +9,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Turkish\n"
+ "Language: tr_TR\n"
+diff --git a/po/uk.po b/po/uk.po
+index e3768acc3c..8dd79a1c24 100644
+--- a/po/uk.po
++++ b/po/uk.po
+@@ -6,8 +6,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Ukrainian\n"
+ "Language: uk_UA\n"
+@@ -3150,16 +3150,16 @@ msgstr "Помилковий гліф лігатури. GID %d не менше 
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "Помилкова таблиця фільтрування: формат=2 (%d/%d), перший=%d останній=%d "
+ "загалом гліфів у шрифті=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "Помилкова таблиця фільтрування: формат=4 (%d/%d), перший=%d останній=%d "
+ "загалом гліфів у шрифті=%d\n"
+@@ -3167,8 +3167,8 @@ msgstr ""
+ #, c-format
+ msgid "Bad lookup table: format=6, first=%d total glyphs in font=%d\n"
+ msgstr ""
+-"Помилкова таблиця фільтрування: формат=6, перший=%d загалом гліфів у шрифті="
+-"%d\n"
++"Помилкова таблиця фільтрування: формат=6, перший=%d загалом гліфів у "
++"шрифті=%d\n"
+ 
+ #, c-format
+ msgid "Bad lookup table: format=8, first=%d cnt=%d total glyphs in font=%d\n"
+@@ -8621,8 +8621,8 @@ msgstr ""
+ #, c-format
+ msgid "Glyph “%s” has vertical advance width %d in %s but %d in %s at %d@%d\n"
+ msgstr ""
+-"Гліф «%s» має значення вертикальної додаткової ширини %d у %s і %d у %s, %d@"
+-"%d\n"
++"Гліф «%s» має значення вертикальної додаткової ширини %d у %s і %d у %s, "
++"%d@%d\n"
+ 
+ #, c-format
+ msgid "Glyph “%s” in %s has no truetype instructions\n"
+@@ -18580,8 +18580,8 @@ msgid "SnapToInt"
+ msgstr "Округляти до цілого"
+ 
+ msgid ""
+-"So if you type \"A\" here the first selected glyph would be named \"A.suffix"
+-"\".\n"
++"So if you type \"A\" here the first selected glyph would be named \"A."
++"suffix\".\n"
+ "The second \"B.suffix\", and so on."
+ msgstr ""
+ "Отже, якщо ви введете тут «A», перший позначений гліф буде названо «A."
+@@ -19858,7 +19858,6 @@ msgstr ""
+ "Гінти %1$s у гліфі «%2$.30s» у шрифті %3$.30s не відповідають гінтам у "
+ "%4$.30s (інша кількість або інші критерії перекриття)"
+ 
+-#, c-format
+ msgid ""
+ "The %1$s in the search dialog contains a reference to %2$.20hs which does "
+ "not exist in the new font.\n"
+@@ -21581,8 +21580,8 @@ msgstr "Ширина лінії, яку буде використано для 
+ #, c-format
+ msgid ""
+ "The width, height, depth or italic correction of %s is too big. Tfm files "
+-"may not contain values bigger than 16 times the em-size of the font. Width="
+-"%g, height=%g, depth=%g, italic correction=%g"
++"may not contain values bigger than 16 times the em-size of the font. "
++"Width=%g, height=%g, depth=%g, italic correction=%g"
+ msgstr ""
+ "Велична ширини, висоти, глибини або виправлення курсиву %s є надто великою. "
+ "У файлах tfm не можна використовувати значення, що перевищують em більше ніж "
+@@ -27293,19 +27292,19 @@ msgstr ""
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d ∆x_adv="
+-"%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
++"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d "
++"∆x_adv=%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ msgstr ""
+ "«%s» у %s не містив попарного фільтрування розташувань ∆x=%d ∆y=%d ∆x_дод=%d "
+ "∆y_дод=%d до %s ∆x=%d ∆y=%d ∆x_дод=%d ∆y_дод=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv="
+-"%d\n"
++"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d "
++"∆y_adv=%d\n"
+ msgstr ""
+-"«%s» у %s не містила фільтрування розташування ∆x=%d ∆y=%d ∆x_дод=%d ∆y_дод="
+-"%d\n"
++"«%s» у %s не містила фільтрування розташування ∆x=%d ∆y=%d ∆x_дод=%d "
++"∆y_дод=%d\n"
+ 
+ #, c-format
+ msgid "“%s” in %s did not contain a substitution lookup to %s\n"
+diff --git a/po/vi.po b/po/vi.po
+index 6aee8bb3fa..7034fc284b 100644
+--- a/po/vi.po
++++ b/po/vi.po
+@@ -1,18 +1,10 @@
+-# Vietnamese translation for FontForge.
+-# Copyright (C) 2000-2010 by George Williams
+-# Clytie Siddall <clytie@riverland.net.au>, 2007, 2008, 2009, 2010.
+-#
+-# Translators:
+-# Clytie Siddall <clytie@riverland.net.au>, 2007, 2008, 2009, 2010.
+-# Clytie Siddall <clytie@riverland.net.au>, 2010-03-15 20:46+0930
+-#
+-#
++
+ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 02:46\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Vietnamese\n"
+ "Language: vi_VN\n"
+@@ -610,14 +602,6 @@ msgstr "Một hộp được vẽ chung quanh ô điều khiển khác"
+ msgid "A canvas (sub-window) wrapped up in a gadget, for drawing"
+ msgstr "Một vùng vẽ (cửa sổ phụ) được bao bọc trong một ô điều khiển, để vẽ"
+ 
+-msgid ""
+-"A comma separated list of font family names used to display small example "
+-"images of glyphs over the user designed glyphs"
+-msgstr ""
+-"Danh sách định giới bằng dấu phẩy mà chứa các tên nhóm phông chữ dùng để "
+-"hiển thị ảnh thí dụ nhỏ của hình tượng ở trên hình tượng được người dùng "
+-"thiết kế"
+-
+ msgid ""
+ "A contour in this glyph contains a different number of points in different "
+ "instances"
+@@ -1170,9 +1154,6 @@ msgstr "Bề rộng tiến tới của hình tượng %.30s phải nhỏ hơn 12
+ msgid "Adyghe"
+ msgstr "TIếng A-di-ghe"
+ 
+-msgid "Aegean scripts"
+-msgstr "Chữ viết Ægean"
+-
+ msgid "Afar"
+ msgstr "TIếng A-pha"
+ 
+@@ -1367,21 +1348,9 @@ msgstr "Đường gần nằm ngang/dọc"
+ msgid "Almost stem_3 hint"
+ msgstr "Gần là lời gợi ý stem_3"
+ 
+-msgid "Alphabetic"
+-msgstr "Chữ cái"
+-
+-msgid "Alphabetic Extended"
+-msgstr "Chữ cái đã mở rộng"
+-
+ msgid "Alphabetic Presentation Forms"
+ msgstr "Hình đại diện chữ cái"
+ 
+-msgid "Alphabetic and syllabic LTR scripts"
+-msgstr "Chữ viết bên trái-qua-phải kiểu chữ cái và âm tiết"
+-
+-msgid "Alphabetic and syllabic RTL scripts"
+-msgstr "Chữ viết bên phải-qua-trái kiểu chữ cái và âm tiết"
+-
+ msgid "Alsatian"
+ msgstr "Tiếng An-xa-ti"
+ 
+@@ -1752,9 +1721,6 @@ msgstr "Bên Phải qua Trái ngôn ngữ A Rập"
+ msgid "Arabic Supplement"
+ msgstr "Phần bổ sung tiếng A Rập"
+ 
+-msgid "Arakanese"
+-msgstr "Tiếng A-ra-ka-ni"
+-
+ msgid "Archives"
+ msgstr "Kho"
+ 
+@@ -1816,9 +1782,6 @@ msgstr ""
+ msgid "Armenian"
+ msgstr "Tiếng Ác-mê-ni"
+ 
+-msgid "Armenian Ligatures"
+-msgstr "Chữ ghép tiếng Ác-mê-ni"
+-
+ msgid "ArrowAccelFactor"
+ msgstr "Tăng Tốc Mũi Tên"
+ 
+@@ -1902,9 +1865,6 @@ msgstr ""
+ "Bảng thiết bị cho phép bạn ghi rõ giá trị\n"
+ "điều chỉnh cho mỗi kích cỡ theo điểm ảnh."
+ 
+-msgid "Athapaskan"
+-msgstr "Tiếng A-ta-pa-x-ca"
+-
+ #, c-format
+ msgid ""
+ "Attempt to apply a lookup to a location out of the range of this contextual\n"
+@@ -2120,9 +2080,6 @@ msgstr "Tiếng Ay-ma-ra"
+ msgid "Azebaijani (roman)"
+ msgstr "Tiếng A-xơ-bai-gianh (La-tinh)"
+ 
+-msgid "Azeri"
+-msgstr "Tiếng A-de-ri"
+-
+ msgid "Azeri (Cyrillic)"
+ msgstr "Tiếng A-xê-ri (Ki-rin)"
+ 
+@@ -2498,9 +2455,6 @@ msgstr "Có hàm phụ flex sai trong %s\n"
+ msgid "Bad font"
+ msgstr "Phông sai"
+ 
+-msgid "Bad font specification"
+-msgstr "Đặc tả phông sai"
+-
+ msgid "Bad font, offset out of bounds.\n"
+ msgstr "Phông sai : giá trị bù ở ngoại phạm vi.\n"
+ 
+@@ -2598,8 +2552,8 @@ msgstr "Hình tượng chữ ghép sai : GID %d không phải nhỏ hơn %d\n"
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "Bảng tra tìm sai:\n"
+ " • định dạng=2 (%d/%d)\n"
+@@ -2609,8 +2563,8 @@ msgstr ""
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "Bảng tra tìm sai:\n"
+ " • định dạng=4 (%d/%d)\n"
+@@ -2815,9 +2769,6 @@ msgstr "Tiếng Ba-li"
+ msgid "Balkar"
+ msgstr "Tiếng Ban-khă"
+ 
+-msgid "Balochi"
+-msgstr "Tiếng Ba-lô-khi"
+-
+ msgid "Balti"
+ msgstr "Tiếng Ban-thi"
+ 
+@@ -2887,9 +2838,6 @@ msgstr "Mặt Phẳng Đa Ngôn Ngữ Cơ Bản"
+ msgid "Basque"
+ msgstr "Tiếng Bax-quợ"
+ 
+-msgid "Baule"
+-msgstr "Tiếng Bau-le"
+-
+ msgid "Be_vel"
+ msgstr "Cạnh _xiên"
+ 
+@@ -3215,21 +3163,12 @@ msgstr "Bạn có muốn làm phông xiên theo góc nào?"
+ msgid "Byelorussian"
+ msgstr "Tiếng Bie-lo-ru-xi"
+ 
+-msgid "Byte Order Mark"
+-msgstr "Dấu thứ tự byte"
+-
+ msgid "Byzantine Music"
+ msgstr "Âm nhạc La Mã phương Đông"
+ 
+ msgid "Byzantine Musical Symbols"
+ msgstr "Ký hiệu âm nhạc La Mã phương Đông"
+ 
+-msgid "C0 Control Character"
+-msgstr "Ký tự điều khiển C0"
+-
+-msgid "C1 Control Character"
+-msgstr "Ký tự điều khiển C1"
+-
+ msgid ""
+ "CALL function\n"
+ "Pops a value, calls the function represented by it"
+@@ -3282,15 +3221,9 @@ msgstr "Chữ viết ghi ý tương thích với tiếng Trung/Nhật/Hàn"
+ msgid "CJK Compatibility Ideographs Supplement"
+ msgstr "Phần bổ sung Chữ viết Ghi ý Tương thích tiếng Trung/Nhật/Hàn"
+ 
+-msgid "CJK Enclosed Letters and Months"
+-msgstr "Chữ và tháng đã bao bọc tiếng Trung/Nhật/Hàn"
+-
+ msgid "CJK Ideographic"
+ msgstr "Chữ viết ghi ý tiếng Trung/Nhật/Hàn"
+ 
+-msgid "CJK Phonetics and Symbols"
+-msgstr "Ngữ âm và ký hiệu tiếng Trung/Nhật/Hàn"
+-
+ msgid "CJK Strokes"
+ msgstr "Nét tiếng Trung/Nhật/Hàn"
+ 
+@@ -3803,18 +3736,6 @@ msgstr "Tiếng Hoa (Xin-ga-po)"
+ msgid "Chinese (Taiwan)"
+ msgstr "Tiếng Trung (Đài-loan)"
+ 
+-msgid "Chinese Hong Kong"
+-msgstr "Tiếng Trung (Hông Kồng))"
+-
+-msgid "Chinese Phonetic"
+-msgstr "Tiếng Trung ngữ âm"
+-
+-msgid "Chinese Simplified"
+-msgstr "Tiếng Trung phổ thông"
+-
+-msgid "Chinese Traditional"
+-msgstr "Tiếng Trung truyền thống"
+-
+ msgid "Chipewyan"
+ msgstr "Tiếng Chi-pe-ouianh"
+ 
+@@ -4273,9 +4194,6 @@ msgstr "Sửa:"
+ msgid "Corner"
+ msgstr "Đỉnh"
+ 
+-msgid "Corporate Use"
+-msgstr "Dùng bởi công ty"
+-
+ msgid "Correct Direction"
+ msgstr "Sửa hướng"
+ 
+@@ -4347,10 +4265,6 @@ msgstr "Không thể mở"
+ msgid "Could not open %.100s"
+ msgstr "Không thể mở %.100s"
+ 
+-#, c-format
+-msgid "Could not open %s"
+-msgstr "Không thể mở %s"
+-
+ msgid "Could not open file"
+ msgstr "Không thể mở tập tin"
+ 
+@@ -4394,16 +4308,6 @@ msgstr "Không thể ghi %s."
+ msgid "Couldn't create directory"
+ msgstr "Không thể tạo thư mục"
+ 
+-#, c-format
+-msgid ""
+-"Couldn't create directory: %1$s\n"
+-"%2$s\n"
+-"%3$s"
+-msgstr ""
+-"Không thể tạo thư mục: %1$s\n"
+-"%2$s\n"
+-"%3$s"
+-
+ #, c-format
+ msgid "Couldn't create directory: %s"
+ msgstr "Không thể tạo thư mục: %s"
+@@ -4542,9 +4446,6 @@ msgstr "Lập phương"
+ msgid "Cuneiform"
+ msgstr "Chữ hình nêm"
+ 
+-msgid "Cuneiform Numbers"
+-msgstr "Chữ số hình nêm"
+-
+ msgid "Currency Symbols"
+ msgstr "Ký hiệu tiền tệ"
+ 
+@@ -4867,9 +4768,6 @@ msgstr "Khoảng thời gian (theo mili-giây) trước khi cửa sổ tự mở
+ msgid "Delete"
+ msgstr "Xoá"
+ 
+-msgid "Delete Character"
+-msgstr "Xoá ký tự"
+-
+ msgid ""
+ "Deletes any selected lookups and their subtables, or deletes any selected "
+ "subtables.\n"
+@@ -4988,12 +4886,6 @@ msgstr "Tiếng Đe-va-na-ga-ri 2"
+ msgid "Device Table Adjustments"
+ msgstr "Điều chỉnh bảng thiết bị"
+ 
+-msgid "Dhivehi"
+-msgstr "Tiếng Đi-ve-hi"
+-
+-msgid "Dhivehi (Obsolete)"
+-msgstr "Đi-vê-hi (Cũ)"
+-
+ msgid "Diagonal Fractions"
+ msgstr "Phân số chéo"
+ 
+@@ -5159,9 +5051,6 @@ msgstr "Khoảng cách tới mặt phẳng hiện hình:"
+ msgid "Divehi"
+ msgstr "Tiếng Đi-ve-hi"
+ 
+-msgid "Djerma"
+-msgstr "Tiếng Chơ-ma"
+-
+ msgid "Do Nothing"
+ msgstr "Đừng làm gì"
+ 
+@@ -5225,9 +5114,6 @@ msgstr "Không kế thừa từ gì"
+ msgid "Doesn't look like a valid pdf file, couldn't find xref section"
+ msgstr "Không hình như một tập tin PDF hợp lệ vì không tìm thấy phần xref"
+ 
+-msgid "Dogri"
+-msgstr "Tiếng Đo-gợ-ri"
+-
+ msgid "Domino Tiles"
+ msgstr "Ngói đôminô"
+ 
+@@ -6522,9 +6408,6 @@ msgstr ""
+ msgid "Font Compare"
+ msgstr "So sánh phông"
+ 
+-msgid "Font Family"
+-msgstr "Nhóm phông"
+-
+ msgid "Font Info"
+ msgstr "Thông tin phông"
+ 
+@@ -6532,9 +6415,6 @@ msgstr "Thông tin phông"
+ msgid "Font Information for %.90s"
+ msgstr "Thông tin phông về %.90s"
+ 
+-msgid "Font Size"
+-msgstr "Cỡ phông chữ"
+-
+ msgid "Font Type:"
+ msgstr "Kiểu phông:"
+ 
+@@ -6656,27 +6536,6 @@ msgstr ""
+ msgid "FontForge time stamp table"
+ msgstr "bảng nhãn thời gian FontForge"
+ 
+-#, c-format
+-msgid ""
+-"FontForge was unable to find a cidmap file for this font. It is not "
+-"essential to have one, but some things will work better if you do. If you "
+-"have not done so you might want to download the cidmaps from:\n"
+-"   http://FontForge.sourceforge.net/cidmaps.tgz\n"
+-"and then gunzip and untar them and move them to:\n"
+-"  %.80s\n"
+-"\n"
+-"Would you like to search your local disk for an appropriate file?"
+-msgstr ""
+-"Trình FontForge không tìm thấy tập tin sơ đồ CID thích hợp với phông này.\n"
+-"Không ép buộc phải dùng tập tin kiểu này, nhưng một số thứ sẽ hoạt động\n"
+-"tốt hơn với nó. Nếu bạn chưa tài về các tập tin sơ đồ CID, vẫn có thể tải "
+-"xuống:\n"
+-"   http://FontForge.sourceforge.net/cidmaps.tgz\n"
+-"rồi giải nén và di chuyển vào\n"
+-"  %.80s\n"
+-"\n"
+-"Bạn có muốn tìm kiếm một tập tin thích hợp trên đĩa cục bộ không?"
+-
+ msgid ""
+ "FontForge was unable to load libspiro, spiros are not available for use."
+ msgstr ""
+@@ -6748,9 +6607,6 @@ msgstr "Buộc tên hình tượng thành:"
+ msgid "Fore"
+ msgstr "Gần"
+ 
+-msgid "Forest Nenets"
+-msgstr "Tiếng Ne-net-x rừng"
+-
+ msgid "Forget _to All"
+ msgstr "Quên _tất cả"
+ 
+@@ -6900,9 +6756,6 @@ msgstr "Từ :"
+ msgid "Frozen Color"
+ msgstr "Màu đông cứng"
+ 
+-msgid "Fulani"
+-msgstr "Tiếng Phu-la-ni"
+-
+ msgid "Fulfulde"
+ msgstr "Tiếng Phun-phun-đe"
+ 
+@@ -7367,8 +7220,8 @@ msgstr "Hình tượng « %s » có chiều rộng sớm %d trong %s còn là %d
+ #, c-format
+ msgid "Glyph “%s” has advance width %d in %s but %d in %s at %d@%d\n"
+ msgstr ""
+-"Hình tượng « %s » có chiều rộng sớm %d trong %s còn là %d trong %s tại %d@"
+-"%d\n"
++"Hình tượng « %s » có chiều rộng sớm %d trong %s còn là %d trong %s tại "
++"%d@%d\n"
+ 
+ #, c-format
+ msgid "Glyph “%s” has different truetype instructions\n"
+@@ -7518,9 +7371,6 @@ msgstr ""
+ "Lớn hơn hay bằng (GTEQ)\n"
+ "Bỏ hai giá trị, đẩy (0/1) nếu cái dưới ≥ cái trên"
+ 
+-msgid "Greek"
+-msgstr "Tiếng Hy Lạp"
+-
+ msgid "Greek (polytonic)"
+ msgstr "Tiếng Hy Lạp (đa giọng)"
+ 
+@@ -7660,9 +7510,6 @@ msgstr "Nửa hình"
+ msgid "Half Widths"
+ msgstr "Nửa rộng"
+ 
+-msgid "Half and Full Width Forms"
+-msgstr "Hình nửa và toàn rộng"
+-
+ msgid "Halfwidth and Fullwidth Forms"
+ msgstr "Hình nửa/toàn rộng"
+ 
+@@ -7672,9 +7519,6 @@ msgstr "Tiếng Ha-mơ-Ba-na"
+ msgid "Hangul Compatibility Jamo"
+ msgstr "Hangul tương thích với Jamo"
+ 
+-msgid "Hangul Jamo Half Width Forms"
+-msgstr "Hình nửa rộng Hangul Jamo"
+-
+ msgid "Hangul Syllables"
+ msgstr "Âm tiết Hangul"
+ 
+@@ -7699,9 +7543,6 @@ msgstr "Nặng"
+ msgid "Hebrew"
+ msgstr "Tiếng Do Thái"
+ 
+-msgid "Hebrew Ligatures/Pointed Letters"
+-msgstr "Chữ ghép/chữ nhọn tiếng Do Thái"
+-
+ msgid "Height"
+ msgstr "Cao"
+ 
+@@ -7737,9 +7578,6 @@ msgstr "Ẩn khi di chu_yển"
+ msgid "High Mari"
+ msgstr "Tiếng Ma-ri cao"
+ 
+-msgid "High Surrogate"
+-msgstr "Thay thế cao"
+-
+ msgid "High-Density Font"
+ msgstr "Phông mật độ cao"
+ 
+@@ -8259,9 +8097,6 @@ msgstr "Đang bỏ qua mục nhập /CharStrings (chuỗi ký tự) trùng\n"
+ msgid "Ignoring duplicate /Subrs entry\n"
+ msgstr "Đang bỏ qua mục nhập /Subrs trùng\n"
+ 
+-msgid "Ijo"
+-msgstr "Tiếng I-chô"
+-
+ msgid "Ilokano"
+ msgstr "Tiếng I-lô-ca-nô"
+ 
+@@ -8294,10 +8129,6 @@ msgstr "Ảnh dùng cho dấu liệt kê đã bật (ghi đè lên hộp)"
+ msgid "Image used instead of the Check Box Off Mark"
+ msgstr "Ảnh dùng thay cho Dấu Hộp Chọn bị Tắt"
+ 
+-msgid ""
+-"Image used instead of the Check Box Off Mark (when the radio is disabled)"
+-msgstr "Ảnh dùng thay cho Dấu Hộp Chọn bị Tắt (khi nút chọn một bị tắt)"
+-
+ msgid "Image used instead of the Radio Off Mark"
+ msgstr "Ảnh dùng thay cho Dấu Hộp Chọn Một bị Tắt"
+ 
+@@ -8632,29 +8463,6 @@ msgstr ""
+ msgid "Instruction Gloss (TrueType)"
+ msgstr "Chú giải chỉ dẫn (TrueType)"
+ 
+-msgid ""
+-"Instructions in a TrueType font refer to\n"
+-"points by number, so if you edit a glyph\n"
+-"in such a way that some points have different\n"
+-"numbers (add points, remove them, etc.) then\n"
+-"the instructions will be applied to the wrong\n"
+-"points with disasterous results.\n"
+-"  Normally FontForge will remove the instructions\n"
+-"if it detects that the points have been renumbered\n"
+-"in order to avoid the above problem. You may turn\n"
+-"this behavior off -- but be careful!"
+-msgstr ""
+-"Chỉ dẫn trong phông TrueType tham chiếu\n"
+-"đến mỗi điểm theo con số. Vậy nếu bạn chỉnh\n"
+-"sửa hình tượng bằng cách mà các điểm có số bị đổi\n"
+-"(thêm/bỏ điểm v.v.) thì các chỉ dẫn sẽ được\n"
+-"áp dụng cho điểm không đúng, làm kết quả rất xấu.\n"
+-"\n"
+-"Bình thường, trình FontForge sẽ gỡ bỏ các chỉ dẫn\n"
+-"nếu nó phát hiện rằng các điểm đã được đánh số lại,\n"
+-"để tránh vấn đề trên. Bạn vẫn có khả năng tắt\n"
+-"ưng xử này, nhưng hãy rất cẩn thận."
+-
+ msgid "Instructions out of date"
+ msgstr "Chỉ dẫn quá cũ"
+ 
+@@ -8954,9 +8762,6 @@ msgstr ""
+ "JuMP Relative\n"
+ "Bỏ hiệu (theo byte) để di chuyển con trỏ chỉ lệnh"
+ 
+-msgid "Judezmo"
+-msgstr "Tiếng Giu-đex-mô"
+-
+ msgid "Jula"
+ msgstr "Tiếng Giu-la"
+ 
+@@ -9459,12 +9264,6 @@ msgstr "La-tinh đã mở rộng C"
+ msgid "Latin Extended-D"
+ msgstr "La-tinh đã mở rộng D"
+ 
+-msgid "Latin Full Width Forms"
+-msgstr "Hình toàn rộng La-tinh"
+-
+-msgid "Latin Ligatures"
+-msgstr "Chữ ghép La-tinh"
+-
+ msgid "Latin-1 Supplement"
+ msgstr "Phần bổ sung Latin-1"
+ 
+@@ -9937,12 +9736,6 @@ msgstr "Chữ thường sang chữ hoa rất nhỏ"
+ msgid "Lowercase to Small Capitals"
+ msgstr "Chữ thường sang chữ hoa nhỏ"
+ 
+-msgid "Luganda"
+-msgstr "Tiếng Lu-gan-đa"
+-
+-msgid "Luhya"
+-msgstr "Tiếng Lu-hia"
+-
+ msgid "Lule Sami"
+ msgstr "Tiếng Lu-le Xa-mi"
+ 
+@@ -10170,9 +9963,6 @@ msgstr ""
+ msgid "Make the counters narrower"
+ msgstr "Làm cho bộ đếm hẹp hơn"
+ 
+-msgid "Makua"
+-msgstr "Tiếng Ma-khua"
+-
+ msgid "Malagasy"
+ msgstr "Tiếng Ma-la-ga-xi"
+ 
+@@ -10544,9 +10334,6 @@ msgstr "Tên trình đơn"
+ msgid "Menu name with no associated script"
+ msgstr "Tên trình đơn không có văn lệnh tương ứng"
+ 
+-msgid "Merge Feature Info"
+-msgstr "Trộn thông tin tính năng"
+-
+ msgid "Merge Fonts"
+ msgstr "Trộn phông"
+ 
+@@ -10592,9 +10379,6 @@ msgstr "Đơn vị đo %.50s"
+ msgid "Metrics Label Color"
+ msgstr "Màu nhãn đơn vị đo"
+ 
+-msgid "MetricsView"
+-msgstr "ÔXemĐơnVịĐo"
+-
+ msgid "MfArgs"
+ msgstr "Đối Số MF"
+ 
+@@ -10745,21 +10529,12 @@ msgstr "Trục _phụ :"
+ msgid "Misc."
+ msgstr "Linh tinh"
+ 
+-msgid "Miscellaneous Math Symbols-A"
+-msgstr "Ký hiệu Toán học Linh tinh (A)"
+-
+-msgid "Miscellaneous Math Symbols-B"
+-msgstr "Ký hiệu Toán học Linh tinh (B)"
+-
+ msgid "Miscellaneous Symbols"
+ msgstr "Ký hiệu lặt vặt"
+ 
+ msgid "Miscellaneous Technical"
+ msgstr "Kỹ thuật linh tinh"
+ 
+-msgid "Miscellaneous Technical Symbols"
+-msgstr "Ký hiệu Kỹ thuật Linh tinh"
+-
+ msgid "Mismatch lookup types inside a parsed lookup"
+ msgstr "Sai khớp kiểu sự tra tìm bên trong sự tra tìm đã phân tích"
+ 
+@@ -11233,9 +11008,6 @@ msgstr "NFNT (MacBinary)"
+ msgid "NFNT (Resource)"
+ msgstr "NFNT (tài nguyên)"
+ 
+-msgid "NUL, Default Character"
+-msgstr "Ký tự mặc định NUL"
+-
+ msgid "N_ever Interpolate"
+ msgstr "Không _bao giờ nội suy"
+ 
+@@ -11518,9 +11290,6 @@ msgstr "Tiếng Ni-xi"
+ msgid "Niuean"
+ msgstr "Tiếng Ni-u-e"
+ 
+-msgid "Nkole"
+-msgstr "Tiếng N-cô-le"
+-
+ #, c-format
+ msgid "No (useable) bitmap strikes in this TTF font: %s"
+ msgstr "Không có gạch mảng ảnh có ích trong phông TTF này: %s"
+@@ -12009,9 +11778,6 @@ msgstr "Không phải là định dạng CID"
+ msgid "Not a CID-keyed font"
+ msgstr "Không phải là phông đã khoá CID"
+ 
+-msgid "Not a Unicode Character"
+-msgstr "Không phải ký tự Unicode"
+-
+ msgid "Not a bdf file"
+ msgstr "Không phải là tập tin bdf."
+ 
+@@ -12139,9 +11905,6 @@ msgstr "Dạng số"
+ msgid "Nyanja/Chewa"
+ msgstr "Tiếng Nai-an-gia"
+ 
+-msgid "Nynorsk"
+-msgstr "Tiếng Ny-noa-x-kh"
+-
+ msgid "O Black Letter"
+ msgstr "TH Chữ đen"
+ 
+@@ -12539,9 +12302,6 @@ msgstr "Gốc"
+ msgid "Origin:"
+ msgstr "Gốc:"
+ 
+-msgid "Original Color"
+-msgstr "Màu gốc"
+-
+ msgid "Original Y Position"
+ msgstr "Vị trí Y gốc"
+ 
+@@ -12605,12 +12365,6 @@ msgstr "Viền bên trong nét ngoài"
+ msgid "Outline Outer Border"
+ msgstr "Viền bên ngoài nét ngoài"
+ 
+-msgid "Outline View"
+-msgstr "Ô xem nét ngoài"
+-
+-msgid "Outline View 2"
+-msgstr "Ô xem nét ngoài 2"
+-
+ msgid "Outline Width"
+ msgstr "Bề rộng nét ngoài"
+ 
+@@ -13021,26 +12775,6 @@ msgstr "Phần mở rộng ngữ âm"
+ msgid "Phonetic Extensions Supplement"
+ msgstr "Phần bổ sung phần mở rộng ngữ âm"
+ 
+-msgid ""
+-"Physical screen width, measured in centimeters\n"
+-"For this to take effect you must save the resource data (press the [Save] "
+-"button)\n"
+-"and restart fontforge"
+-msgstr ""
+-"Chiều rộng vật lý của màn hình, đo theo xen-ti-mét\n"
+-"Để thiết lập này có tác động thì bạn cần phải lưu dữ liệu tài nguyên\n"
+-"(bấm nút [Lưu]), sau đó khởi chạy lại FontForge."
+-
+-msgid ""
+-"Physical screen width, measured in inches\n"
+-"For this to take effect you must save the resource data (press the [Save] "
+-"button)\n"
+-"and restart fontforge"
+-msgstr ""
+-"Chiều rộng vật lý của màn hình, đo theo insơ\n"
+-"Để thiết lập này có tác động thì bạn cần phải lưu dữ liệu tài nguyên\n"
+-"(bấm nút [Lưu]), sau đó khởi chạy lại FontForge."
+-
+ msgid "Pick a CMap subtable"
+ msgstr "Chọn một bảng phụ CMap"
+ 
+@@ -13056,9 +12790,6 @@ msgstr "Chọn một trang"
+ msgid "Pick a substitution to display in the window."
+ msgstr "Chọn một sự thay thế cần hiển thị trong cửa sổ."
+ 
+-msgid "Pilipino (Filipino)"
+-msgstr "Tiếng Phi-li-pi-nô"
+-
+ msgid "Pixel List"
+ msgstr "Danh sách điểm ảnh"
+ 
+@@ -13225,9 +12956,6 @@ msgstr "Hình đa g_iác"
+ msgid "Polish"
+ msgstr "Tiếng Ba Lan"
+ 
+-msgid "Pollard Phonetic"
+-msgstr "Ngữ âm Po-lat"
+-
+ msgid "Polygon"
+ msgstr "Đa giác"
+ 
+@@ -13438,9 +13166,6 @@ msgstr "Ưu tiên: %d"
+ msgid "Private Dictionary"
+ msgstr "Từ điển Riêng"
+ 
+-msgid "Private Use"
+-msgstr "Dùng riêng"
+-
+ msgid "Private Use Area"
+ msgstr "Vùng dùng riêng"
+ 
+@@ -13487,9 +13212,6 @@ msgstr "Chữ số tỷ lệ"
+ msgid "Proportional Width"
+ msgstr "Bề rộng tỷ lệ"
+ 
+-msgid "Provencal"
+-msgstr "Tiếng Pợ-ro-ven-xan"
+-
+ msgid "Provide a glyph name"
+ msgstr "Cung cấp tên hình tượng"
+ 
+@@ -14321,9 +14043,6 @@ msgstr "Đang làm tròn thành số nguyên..."
+ msgid "Row|New"
+ msgstr "Mới"
+ 
+-msgid "Ruanda"
+-msgstr "Tiếng Ru-oanh-đa"
+-
+ msgid "Ruby Notational Forms"
+ msgstr "Hình phụ chú Ruby"
+ 
+@@ -14763,12 +14482,6 @@ msgstr "Ký hiệu khoa học in thấp"
+ msgid "Scottish Gaelic"
+ msgstr "Tiếng Xen-tơ (Ê-cốt)"
+ 
+-msgid "Screen Width in Centimeters"
+-msgstr "Độ rộng màn hình (theo xen-ti-mét)"
+-
+-msgid "Screen Width in Inches"
+-msgstr "Độ rộng màn hình (theo insơ)"
+-
+ #, c-format
+ msgid "Script '%c%c%c%c' "
+ msgstr "Chữ viết '%c%c%c%c' "
+@@ -15769,9 +15482,6 @@ msgstr "Hệ số mở rộng vị trí phương hướng bên"
+ msgid "Side Bearings:"
+ msgstr "Vị trí phương hướng bên:"
+ 
+-msgid "Signature Mark"
+-msgstr "Dấu chữ ký"
+-
+ msgid "Silte Gurage"
+ msgstr "Tiếng Gu-ra-ge Xin-te"
+ 
+@@ -15955,8 +15665,8 @@ msgid "SnapToInt"
+ msgstr "Đính Số Nguyên"
+ 
+ msgid ""
+-"So if you type \"A\" here the first selected glyph would be named \"A.suffix"
+-"\".\n"
++"So if you type \"A\" here the first selected glyph would be named \"A."
++"suffix\".\n"
+ "The second \"B.suffix\", and so on."
+ msgstr ""
+ "Vì vậy, nếu bạn gõ vào đây chữ « A », hình tượng đã chọn đầu tiên\n"
+@@ -16059,13 +15769,6 @@ msgstr "Tiếng Nam Xla-vê"
+ msgid "Southern Sami"
+ msgstr "Tiếng Nam Xă-mi"
+ 
+-msgid ""
+-"Space (in points) left between images and text in labels, buttons, menu "
+-"items, etc. which have both"
+-msgstr ""
+-"Khoảng cách (theo điểm) nên còn lại giửa ảnh và chuỗi chữ trong nhãn, nút, "
+-"mục trình đơn v.v. chứa cả hai"
+-
+ msgid "Space Regions"
+ msgstr "Vùng khoảng cách"
+ 
+@@ -16758,9 +16461,6 @@ msgstr ""
+ "Super ROUND\n"
+ "Quá phức tạp. Hãy tra tìm"
+ 
+-msgid "Super and Sub scripts"
+-msgstr "Chữ in cao/thấp"
+-
+ msgid "Superscript"
+ msgstr "Chữ cao"
+ 
+@@ -16785,15 +16485,9 @@ msgstr "Mũi tên bổ sung A"
+ msgid "Supplemental Arrows-B"
+ msgstr "Mũi tên bổ sung B"
+ 
+-msgid "Supplemental Math Operators"
+-msgstr "Toán từ Toán học Bổ sung"
+-
+ msgid "Supplemental Punctuation"
+ msgstr "Dấu chấm câu bổ sung"
+ 
+-msgid "Supplemental Symbols and Arrows"
+-msgstr "Ký hiệu và Mũi tên Bổ sung"
+-
+ msgid "Supplementary Ideographic Plane"
+ msgstr "Mặt phẳng Chữ viết Ghi ý Bổ sung"
+ 
+@@ -16812,15 +16506,6 @@ msgstr "Mặt phẳng Mục đích Đặc biệt Bổ sung"
+ msgid "Suri"
+ msgstr "Tiếng Xu-ri"
+ 
+-msgid "Surrogate High"
+-msgstr "Thay thế cao"
+-
+-msgid "Surrogate High, Non Private Use"
+-msgstr "Thay thế cao, không dùng riêng"
+-
+-msgid "Surrogate High, Private Use"
+-msgstr "Thay thế cao, dùng riêng"
+-
+ msgid "Sutu"
+ msgstr "Tiếng Xu-tu"
+ 
+@@ -16839,9 +16524,6 @@ msgstr "Tiếng Xouă-hi-li (Ken-ya)"
+ msgid "Swash"
+ msgstr "Đuôi tu từ"
+ 
+-msgid "Swazi"
+-msgstr "Tiếng Xouă-xi"
+-
+ msgid "Swedish"
+ msgstr "Tiếng Thuỵ Điển"
+ 
+@@ -16875,9 +16557,6 @@ msgstr "Bộ ký tự ký hiệu"
+ msgid "Symbolic"
+ msgstr "Tượng Trưng"
+ 
+-msgid "Symbols"
+-msgstr "Ký hiệu"
+-
+ msgid "Symbols:"
+ msgstr "Ký hiệu:"
+ 
+@@ -17044,9 +16723,6 @@ msgstr "Tiếng Te-lu-gu"
+ msgid "Temne"
+ msgstr "Tiếng Tem-ne"
+ 
+-msgid "Template Color"
+-msgstr "Màu mẫu"
+-
+ msgid "Terminal Forms"
+ msgstr "Hình cuối"
+ 
+@@ -17107,7 +16783,6 @@ msgstr ""
+ "Những lời gợi ý %1$s trong hình tượng « %2$.30s » trong phông %3$.30s không "
+ "tương ứng với những lời trong %4$.30s (số khác hay tiêu chuẩn chồng lấp khác)"
+ 
+-#, c-format
+ msgid ""
+ "The %1$s in the search dialog contains a reference to %2$.20hs which does "
+ "not exist in the new font.\n"
+@@ -18515,8 +18190,8 @@ msgstr "Chiều rộng của đường được dùng để vẽ các điểm đ
+ #, c-format
+ msgid ""
+ "The width, height, depth or italic correction of %s is too big. Tfm files "
+-"may not contain values bigger than 16 times the em-size of the font. Width="
+-"%g, height=%g, depth=%g, italic correction=%g"
++"may not contain values bigger than 16 times the em-size of the font. "
++"Width=%g, height=%g, depth=%g, italic correction=%g"
+ msgstr ""
+ "%s có bề rộng, bề cao, bề sâu hay hệ số sửa in nghiêng mà quá lớn.\n"
+ "Tập tin TFM không thể chứa giá trị lớn hơn 16× kích cỡ em của phông.\n"
+@@ -19234,16 +18909,6 @@ msgstr ""
+ "Việc này mở hơn 10 cửa sổ.\n"
+ "Có hợp với ý muốn không?"
+ 
+-msgid ""
+-"This is an abstract class which defines common features of the\n"
+-"FontView, CharView, BitmapView and MetricsView"
+-msgstr ""
+-"Đây là một hạng trừu tượng mà xác định các tính năng chung của:\n"
+-" • FontView — khung xem phông chữ\n"
+-" • CharView — khung xem ký tự\n"
+-" • BitmapView — khung xem ảnh mảng\n"
+-" • MetricsView — khung xem đơn vị đo"
+-
+ msgid ""
+ "This is an identifying number shared by all members of\n"
+ "this font family with the same style (I.e. 10pt Bold and\n"
+@@ -19566,12 +19231,6 @@ msgstr ""
+ "Phiên bản Fontforge này đã không liên kết với thư viện spiro, do đó không "
+ "dùng được."
+ 
+-msgid "This window displays a single outline glyph"
+-msgstr " Cửa sổ này hiển thị một hình tượng nét ngoài riêng lẻ"
+-
+-msgid "This window displays a single outline glyph (more data)"
+-msgstr " Cửa sổ này hiển thị một hình tượng nét ngoài riêng lẻ (dữ liệu thêm)"
+-
+ msgid "This window displays metrics information about a font"
+ msgstr "Cửa sổ này hiển thị thông tin đơn vị đo về một phông chữ nào đó"
+ 
+@@ -20009,9 +19668,6 @@ msgstr "Tiếng T-xouă-na"
+ msgid "Tulu"
+ msgstr "Tiếng Tu-lu"
+ 
+-msgid "Tundra Nenets"
+-msgstr "Tiếng Ne-net-x lãnh nguyên"
+-
+ msgid "Turkish"
+ msgstr "Tiếng Thổ Nhĩ Kỳ"
+ 
+@@ -20332,9 +19988,6 @@ msgstr "Unicode 2.0+, chỉ BMP"
+ msgid "Unicode 2.0+, all planes"
+ msgstr "Unicode 2.0+, mọi mặt phẳng"
+ 
+-msgid "Unicode Basic Multilingual Plane"
+-msgstr "Mặt Phẳng Đa Ngôn Ngữ Cơ Bản Unicode"
+-
+ msgid "Unicode C_har:"
+ msgstr "_Ký tự Unicode:"
+ 
+@@ -20344,15 +19997,6 @@ msgstr "Phạm vi Unicode"
+ msgid "Unicode Ranges:"
+ msgstr "Phạm vi Unicode:"
+ 
+-msgid "Unicode Supplementary Ideographic Plane"
+-msgstr "Mặt phẳng Chữ viết Ghi ý Bổ sung Unicode"
+-
+-msgid "Unicode Supplementary Multilingual Plane"
+-msgstr "Mặt phẳng Đa ngôn ngữ Bổ sung Unicode"
+-
+-msgid "Unicode Supplementary Special-purpose Plane"
+-msgstr "Mặt phẳng Mục đích Đặc biệt Bổ sung Unicode"
+-
+ msgid "Unicode _Value:"
+ msgstr "_Giá trị Unicode:"
+ 
+@@ -20793,9 +20437,6 @@ msgstr "Dấu chọn biến đổi (hay 0)"
+ msgid "Variation Selectors"
+ msgstr "Dấu chọn biến đổi"
+ 
+-msgid "Variation Selectors B"
+-msgstr "Dấu chọn biến đổi B"
+-
+ #, c-format
+ msgid ""
+ "Variation selectors are normally between\n"
+@@ -21382,15 +21023,6 @@ msgstr ""
+ msgid "When serifs are removed (as first two in \"m\"), replace with:"
+ msgstr "Khi bỏ chân (như hai chân thứ nhất của « m ») thì thay thế bằng:"
+ 
+-msgid ""
+-"When the hint's position is changed\n"
+-"adjust the postion of any points\n"
+-"which lie on that hint"
+-msgstr ""
+-"Khi vị trí lời gợi ý đã thay đổi,\n"
+-"điều chỉnh vị trí của điểm nào\n"
+-"nằm trên lời gợi ý đó."
+-
+ msgid ""
+ "When the mouse pointer is within this many pixels\n"
+ "of one of the various interesting features (baseline,\n"
+@@ -21579,9 +21211,6 @@ msgstr "Dời X"
+ msgid "X Repeat Count"
+ msgstr "Số đếm X đã lặp lại"
+ 
+-msgid "X Resource Editor"
+-msgstr "Trình sửa tài nguyên X"
+-
+ msgid "X Scale Factor"
+ msgstr "Hệ số co giãn X"
+ 
+@@ -21622,18 +21251,12 @@ msgstr "Y gần¹ bề c_ao chuẩn"
+ msgid "Y-Cree"
+ msgstr "Tiếng Cợ-ri Y"
+ 
+-msgid "Yakut"
+-msgstr "Tiếng Ya-kut"
+-
+ msgid "Yes"
+ msgstr "Có"
+ 
+ msgid "Yes to _All"
+ msgstr "Đồng ý _với tất cả"
+ 
+-msgid "Yi"
+-msgstr "Tiếng Yi"
+-
+ msgid "Yi Classic"
+ msgstr "Tiếng Yi cổ điển"
+ 
+@@ -21892,10 +21515,6 @@ msgstr "Bạn cần phải ghi rõ một đá lát ở giữa"
+ msgid "You must specify a pattern"
+ msgstr "Phải ghi rõ một mẫu"
+ 
+-#, c-format
+-msgid "You must specify a replacement glyph for %s"
+-msgstr "Bạn phải xác định một hình tượng thay thế cho %s"
+-
+ msgid "You must specify a standard type1 extension (.pfb or .pfa)"
+ msgstr "Phải xác định một phần mở rộng kiểu 1 tiêu chuẩn (.pfb hay .pfa)."
+ 
+@@ -21968,9 +21587,6 @@ msgstr "Th_u nhỏ"
+ msgid "Zande"
+ msgstr "Tiếng Xan-đe"
+ 
+-msgid "Zapf Dingbats"
+-msgstr "Ký tự trang trí Zapf"
+-
+ msgid "Zone:"
+ msgstr "Vùng:"
+ 
+@@ -22171,9 +21787,6 @@ msgstr "Đón_g"
+ msgid "_Cluster"
+ msgstr "_Chùm"
+ 
+-msgid "_Compact"
+-msgstr "Nén _chặt"
+-
+ msgid "_Condense/Extend..."
+ msgstr "_Co lại/Dãn ra..."
+ 
+@@ -22984,9 +22597,6 @@ msgstr "_Lưới thép"
+ msgid "_Wireframe..."
+ msgstr "_Lưới thép..."
+ 
+-msgid "_X Resource Editor..."
+-msgstr "Trình sửa tài nguyên _X..."
+-
+ msgid "_X near¹"
+ msgstr "_X gần¹"
+ 
+@@ -23441,19 +23051,19 @@ msgstr "Phông mảng ảnh ΤεΧ"
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d ∆x_adv="
+-"%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
++"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d "
++"∆x_adv=%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ msgstr ""
+ "Trong %s, « %s » không chứa sự tra tìm định vị theo hướng cặp ∆x=%d ∆y=%d "
+ "∆x_adv=%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv="
+-"%d\n"
++"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d "
++"∆y_adv=%d\n"
+ msgstr ""
+-"Trong %s, « %s » không chứa sự tra tìm định vị ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv="
+-"%d\n"
++"Trong %s, « %s » không chứa sự tra tìm định vị ∆x=%d ∆y=%d ∆x_adv=%d "
++"∆y_adv=%d\n"
+ 
+ #, c-format
+ msgid "“%s” in %s did not contain a substitution lookup to %s\n"
+diff --git a/po/zh_CN.po b/po/zh_CN.po
+index 8f8e0e60e8..787be30337 100644
+--- a/po/zh_CN.po
++++ b/po/zh_CN.po
+@@ -22,8 +22,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 03:24\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-31 08:24\n"
+ "Last-Translator: \n"
+ "Language-Team: Chinese Simplified\n"
+ "Language: zh_CN\n"
+@@ -79,6 +79,10 @@ msgstr "  右边=%d"
+ msgid "  Stroke _Width:"
+ msgstr "  笔画宽度(_W):"
+ 
++#. GT: X is a coordinate, the leading spaces help to align it
++msgid "  X"
++msgstr "  X"
++
+ #, c-format
+ msgid " %s: line %d\n"
+ msgstr " %s: 行 %d\n"
+@@ -120,6 +124,9 @@ msgstr "后"
+ msgid " Next CP"
+ msgstr "下一控制点"
+ 
++msgid " Perhaps you meant to use the keyword 'sub' rather than 'subs'?"
++msgstr " 也许您打算使用关键字'sub'而不是'subs'？"
++
+ msgid " Prev"
+ msgstr "前"
+ 
+@@ -165,6 +172,12 @@ msgstr "符号"
+ msgid "%.*s is not a valid class name (or number)"
+ msgstr "%.*s 不是有效的类属名(或数值)"
+ 
++#, c-format
++msgid ""
++"%.50s contains a flipped reference. This cannot be corrected as is. Would "
++"you like me to unlink it and then correct it?"
++msgstr "%.50s 包含一个翻转的引用。此处无法更正。你想要取消链接，然后纠正吗？"
++
+ #, c-format
+ msgid "%1$.30s string for %2$.30s"
+ msgstr "%1$.30s 字符串向 %2$.30s"
+@@ -218,7 +231,7 @@ msgstr ""
+ 
+ #, c-format
+ msgid "%s No Slope"
+-msgstr "%s没有范围"
++msgstr "%s 无斜率"
+ 
+ #, c-format
+ msgid "%s anchor %d"
+@@ -391,6 +404,12 @@ msgstr "(未指定) SIL Graphite 规则表"
+ msgid ") while in %s it is ("
+ msgstr ") 但在 %s为 ("
+ 
++msgid "* Cap Widt_h"
++msgstr "* 端头宽度(_H)"
++
++msgid "* Nib _Span"
++msgstr "* 笔尖跨度(_S)"
++
+ msgid "100 Thin"
+ msgstr "100 超细体"
+ 
+@@ -568,12 +587,28 @@ msgstr "<无>"
+ msgid "<undefined>"
+ msgstr "<未定义>"
+ 
++msgid ""
++"A Convex nib will also be rotated by this amount\n"
++"although this is not displayed in the dialog."
++msgstr ""
++"尽量该量未显示于对话框内，\n"
++"凸形笔尖亦将按该量旋转。"
++
+ msgid "A Font Family name is required"
+ msgstr "需要字体集名称"
+ 
+ msgid "A PostScript name may not be a number"
+ msgstr "PostScript名称不可以用数字"
+ 
++msgid ""
++"A calligraphic pen or an elliptical pen has two widths\n"
++"(which may be the same, giving a circular or square pen,\n"
++"or different giving an elliptical or rectangular pen)."
++msgstr ""
++"书法笔或椭圆笔有两个宽度\n"
++"（可相同，得到圆形或正方形笔；\n"
++"或不同，得到椭圆形或矩形笔）。"
++
+ msgid "A coverage table:"
+ msgstr "范围表："
+ 
+@@ -655,6 +690,9 @@ msgstr "AGL 无 afii"
+ msgid "AMS Names"
+ msgstr "AMS名称"
+ 
++msgid "A_dd Extrema"
++msgstr "增添极值点(_D)"
++
+ msgid "A_lign"
+ msgstr "对齐(_L)"
+ 
+@@ -710,10 +748,10 @@ msgid "Add"
+ msgstr "添加"
+ 
+ msgid "Add 'D_FLT' script"
+-msgstr "添加 'D_FLT' 脚本"
++msgstr "添加 'D_FLT' 文字"
+ 
+ msgid "Add All Extrema"
+-msgstr "添加全部极点"
++msgstr "添加全部极值"
+ 
+ msgid "Add Anchor"
+ msgstr "增加锚点"
+@@ -728,7 +766,7 @@ msgid "Add E_ncoding Name..."
+ msgstr "增加编码名(_N)…"
+ 
+ msgid "Add E_xtrema"
+-msgstr "增加极点(_X)"
++msgstr "添加极值(_X)"
+ 
+ msgid "Add Encoding Name..."
+ msgstr "增加编码…"
+@@ -743,7 +781,7 @@ msgid "Add Exit Anchor..."
+ msgstr "增加已有锚点..."
+ 
+ msgid "Add Good Extrema"
+-msgstr "添加好极点"
++msgstr "增添良极值"
+ 
+ msgid "Add Language to Script..."
+ msgstr "添加语言到文字..."
+@@ -764,6 +802,9 @@ msgstr "增加标记锚点..."
+ msgid "Add OFL"
+ msgstr "添加 OFL"
+ 
++msgid "Add Points Of I_nflection"
++msgstr "添加拐点(_I)"
++
+ msgid "Add Sub_table"
+ msgstr "添加子表(_T)"
+ 
+@@ -780,7 +821,7 @@ msgid "Add _Missing Glyphs"
+ msgstr "添加缺失字形(_M)"
+ 
+ msgid "Add _Small Capitals..."
+-msgstr "添加小大写(_S)..."
++msgstr "添加小型大写(_S)..."
+ 
+ msgid "Add a corner point"
+ msgstr "增加拐点"
+@@ -824,6 +865,9 @@ msgstr "为选中字形中的各对字形添加字偶距信息"
+ msgid "Adding points at Extrema..."
+ msgstr "在极值处增加点..."
+ 
++msgid "Adding points of inflection..."
++msgstr "增添拐点..."
++
+ msgid "Additional arguments for autotrace program:"
+ msgstr "autotrace 附加参数:"
+ 
+@@ -846,12 +890,25 @@ msgstr ""
+ msgid "Adlam"
+ msgstr "阿德拉姆文"
+ 
++msgid "Adobe"
++msgstr "Adobe"
++
+ msgid "Adobe Glyph List"
+ msgstr "Adobe 字形列表"
+ 
+ msgid "Adobe Standard"
+ msgstr "Adobe标准"
+ 
++msgid ""
++"Adobe says that \"big\" splines should not have extrema.\n"
++"But they don't define what big means.\n"
++"If the distance between the spline's end-points is bigger than this value, "
++"then the spline is \"big\" to fontforge."
++msgstr ""
++"Adobe 认为大样条不应有极值。\n"
++"但其未定义上述“大”的意义。\n"
++"若样条端点间距大于此值，Fontforge 即认其为“大”样条。"
++
+ msgid ""
+ "Adobe's fontname spec (5088.FontNames.pdf) says that fontnames should not be "
+ "longer than 29 characters. Do you want to continue anyway?"
+@@ -897,7 +954,7 @@ msgstr "南非语"
+ msgid ""
+ "After rotating or skewing a glyph you should probably apply Element->Add "
+ "Extrema"
+-msgstr "旋转或倾斜字形后可能要执行“基础->增加极点”"
++msgstr "旋转或倾斜字形后可能要执行“基础->增加极值”"
+ 
+ msgid "Ahead Classes"
+ msgstr "向前类属"
+@@ -911,6 +968,9 @@ msgstr "阿尔巴尼亚语"
+ msgid "Alchemical Symbols"
+ msgstr "冶金符号"
+ 
++msgid "Align Points"
++msgstr "对齐点"
++
+ msgid "Align:"
+ msgstr "对齐:"
+ 
+@@ -929,6 +989,10 @@ msgstr "所有字形"
+ msgid "All characters in the value must be in ASCII"
+ msgstr "取值字符均应为ASCII码"
+ 
++#, c-format
++msgid "All entries in a lookup must have the same type on line %d of %s"
++msgstr "查找中的所有条目在 %2$s 的第 %1$d 行中必须具有相同的类型"
++
+ msgid "All glyphs"
+ msgstr "所有字形"
+ 
+@@ -948,7 +1012,7 @@ msgid "Allow _curve smoothing"
+ msgstr "允许曲线平滑(_C)"
+ 
+ msgid "Allow _removal of extrema"
+-msgstr "允许移除极点(_R)"
++msgstr "允许移除极值(_R)"
+ 
+ msgid "Allow _slopes to change"
+ msgstr "允许倾斜改变(_S)"
+@@ -960,7 +1024,7 @@ msgid "Allow:"
+ msgstr "允许:"
+ 
+ msgid "Almost H/V Color"
+-msgstr "差不多水平或垂直的颜色"
++msgstr "近水平/近垂直颜色"
+ 
+ msgid "Almost Horizontal/Vertical Curves"
+ msgstr "几乎水平或垂直的曲线"
+@@ -1092,8 +1156,11 @@ msgstr "角度："
+ msgid "Anti-Alias"
+ msgstr "抗锯齿"
+ 
++msgid "Appea_rance Editor..."
++msgstr "外观选项(_R)..."
++
+ msgid "Appearance Editor"
+-msgstr "外观选项"
++msgstr "外观编辑器(_R)..."
+ 
+ msgid "Append a FONTLOG entry"
+ msgstr "添加FONTLOG信息项"
+@@ -1243,14 +1310,27 @@ msgid "Arabic Right to Left"
+ msgstr "阿拉伯文从右到左"
+ 
+ msgid "Arabic Supplement"
+-msgstr "Arabic增补"
++msgstr "阿拉伯文补充"
+ 
+ msgid "Archives"
+ msgstr "包"
+ 
++msgid "Arcs"
++msgstr "圆弧"
++
++msgid "Arcs Clip:"
++msgstr "圆弧裁剪:"
++
+ msgid "Are you sure you don't want to use the cidmap I found?"
+ msgstr "确定不用我找到的cidmap文件？"
+ 
++msgid ""
++"Are you sure you want to replace Å?\n"
++"The ring will not join to the A."
++msgstr ""
++"您确定要替换 Å 吗？\n"
++"环不会加入 A。"
++
+ msgid ""
+ "Are you sure you wish to remove these glyphs? This operation cannot be "
+ "undone."
+@@ -1414,7 +1494,7 @@ msgid "Automatic"
+ msgstr "自动"
+ 
+ msgid "Autot_race"
+-msgstr "自动循迹(_R)"
++msgstr "自动描边(_R)"
+ 
+ msgid "AutotraceArgs"
+ msgstr "Autotrace参数"
+@@ -1456,7 +1536,7 @@ msgid "Axis Type:"
+ msgstr "轴类型:"
+ 
+ msgid "Axis height of the font"
+-msgstr "字体数轴高"
++msgstr "字体轴高"
+ 
+ msgid "Axis range not valid"
+ msgstr "轴域不可用"
+@@ -1486,6 +1566,9 @@ msgstr "BDF分辨率"
+ msgid "BDF bitmap properties table"
+ msgstr "BDF 位图属性表"
+ 
++msgid "B_evel"
++msgstr "截角(_E)"
++
+ msgid "B_uild"
+ msgstr "生成(_U)"
+ 
+@@ -1627,7 +1710,7 @@ msgid "Bad Lig. Caret Count"
+ msgstr "不良连写位计数"
+ 
+ msgid "Bad MM Weights"
+-msgstr "字体集粗细不良"
++msgstr "多母版字重不良"
+ 
+ msgid "Bad Mac Family"
+ msgstr "不良Mac字族"
+@@ -1636,7 +1719,7 @@ msgid "Bad Metrics"
+ msgstr "不良尺寸"
+ 
+ msgid "Bad Multiple Master Font"
+-msgstr "不良的多母版字体"
++msgstr "不良的多重母版字体"
+ 
+ msgid "Bad Name"
+ msgstr "不良名称"
+@@ -1909,11 +1992,14 @@ msgstr "不良类型"
+ msgid "Bad xfig file"
+ msgstr "不良 xfig 文件"
+ 
++msgid "Balancing..."
++msgstr "正在平衡..."
++
+ msgid "Balinese"
+ msgstr "巴厘文"
+ 
+ msgid "Ball (Round Cap)"
+-msgstr "圆球(圆头)"
++msgstr "圆球（圆头）"
+ 
+ msgid "Bamum"
+ msgstr "巴姆穆文"
+@@ -1982,7 +2068,7 @@ msgid "Batak"
+ msgstr "巴塔克文"
+ 
+ msgid "Be_vel"
+-msgstr "伞形(_V)"
++msgstr "截角(_V)"
+ 
+ msgid "Begin:"
+ msgstr "起点："
+@@ -2055,6 +2141,9 @@ msgstr "位图部件\n"
+ msgid "Bitmap Strikes Available"
+ msgstr "可用位图部件"
+ 
++msgid "Bitmap View"
++msgstr "位图视图"
++
+ msgid "Bitmap _Magnification..."
+ msgstr "位图缩放(_M)..."
+ 
+@@ -2097,6 +2186,9 @@ msgstr "粗体"
+ msgid "Bold Italic"
+ msgstr "粗斜体"
+ 
++msgid "Bold font used in the Find/Replace window"
++msgstr "查找/替换窗口中使用的粗体"
++
+ msgid "Bone"
+ msgstr "骨"
+ 
+@@ -2104,7 +2196,7 @@ msgid "Book"
+ msgstr "书体"
+ 
+ msgid "Bookmark Current Dir"
+-msgstr "标记当前方向"
++msgstr "将当前目录加入书签"
+ 
+ msgid "Bookmarks"
+ msgstr "标记"
+@@ -2136,6 +2228,9 @@ msgstr "边框"
+ msgid "Bosnian"
+ msgstr "爱沙尼亚语"
+ 
++msgid "Both"
++msgstr "两者"
++
+ msgid "Both points must be specified, or neither"
+ msgstr "两点须都指定或都不指定"
+ 
+@@ -2230,7 +2325,7 @@ msgid "Building duplicate encodings"
+ msgstr "生成重复编码"
+ 
+ msgid "Building small capitals"
+-msgstr "生成小大写"
++msgstr "生成小型大写"
+ 
+ msgid "Building sub/superscripts"
+ msgstr "生成上下标"
+@@ -2253,12 +2348,18 @@ msgstr "按钮"
+ msgid "By Classes"
+ msgstr "按类属"
+ 
++msgid "By Con_tour"
++msgstr "按轮廓线(_T)"
++
+ msgid "By Coverage"
+ msgstr "按范围"
+ 
+ msgid "By Glyphs"
+ msgstr "按字形"
+ 
++msgid "By La_yer"
++msgstr "按层(_Y)"
++
+ msgid "By _Scripts"
+ msgstr "按手写体(_S)"
+ 
+@@ -2294,8 +2395,8 @@ msgstr "CID字符标识名称"
+ 
+ msgid "CJK (& Ext A/B) & CJK Radicals Sup & Kangxi & IDC & Kanbun"
+ msgstr ""
+-"中日韩表意文字基本区 (& 扩展 A/B) & 中日韩部首补充 & 康熙部首 & 表意文字描述"
+-"符 & 汉文训读"
++"中日韩表意文字基本区（及扩展 A/B）、中日韩部首补充、康熙部首、表意文字描述"
++"符、汉文训读"
+ 
+ msgid "CJK Compatibility"
+ msgstr "中日韩兼容字符"
+@@ -2354,6 +2455,9 @@ msgstr "中日韩统一表意文字扩展 F"
+ msgid "CJK Unified Ideographs Extension G"
+ msgstr "中日韩统一表意文字扩展 G"
+ 
++msgid "CJK Unified Ideographs Extension H"
++msgstr "中日韩统一表意文字扩展 H"
++
+ msgid "CS Clarendon"
+ msgstr "CS粗长体"
+ 
+@@ -2396,6 +2500,9 @@ msgstr "清除(_L)"
+ msgid "C_lasses"
+ msgstr "类属(_L)"
+ 
++msgid "C_lear"
++msgstr "清除(_L)"
++
+ msgid "C_lose Tab"
+ msgstr "关闭(_C)页"
+ 
+@@ -2411,6 +2518,9 @@ msgstr "角(_O)"
+ msgid "C_ustom"
+ msgstr "自定义(_U)"
+ 
++msgid "Ca_lligraphic (Rectangular)"
++msgstr "书法（矩形）(_L)"
++
+ msgid "Call Script"
+ msgstr "调用脚本"
+ 
+@@ -2541,16 +2651,16 @@ msgid "Canonical Start _Point"
+ msgstr "标准起点(_P)"
+ 
+ msgid "Canonical _Contours"
+-msgstr "正则轮廓(_C)"
++msgstr "正则轮廓线(_C)"
+ 
+ msgid "Capital Spacing"
+ msgstr "大写间隔"
+ 
+ msgid "Capitals to Petite Capitals"
+-msgstr "大写到袖珍大写"
++msgstr "大写到微型大写"
+ 
+ msgid "Capitals to Small Capitals"
+-msgstr "大写到小大写"
++msgstr "大写到小型大写"
+ 
+ msgid "Carian"
+ msgstr "加里亚文"
+@@ -2616,7 +2726,7 @@ msgid "Change UniqueID?"
+ msgstr "更改UniqueID？"
+ 
+ msgid "Change Weight"
+-msgstr "更改粗细"
++msgstr "更改字重"
+ 
+ msgid "Change X-Height"
+ msgstr "更改X高"
+@@ -2628,10 +2738,10 @@ msgid "Change _Glyph..."
+ msgstr "改变字形(_G)..."
+ 
+ msgid "Change _Weight..."
+-msgstr "更改粗细(_W)..."
++msgstr "更改字重(_W)..."
+ 
+ msgid "Change _X-Height..."
+-msgstr "更改X高(_X)..."
++msgstr "更改_x高..."
+ 
+ msgid "Change whether spiro is active or not"
+ msgstr "切换spiro"
+@@ -2973,7 +3083,7 @@ msgid "Check _flipped references"
+ msgstr "检查翻转参照(_f)"
+ 
+ msgid "Check _missing extrema"
+-msgstr "检查缺失极点(_M)"
++msgstr "检查缺失极值(_M)"
+ 
+ msgid "Check _outermost paths clockwise"
+ msgstr "检查顺时针方向最外边的路径"
+@@ -3151,6 +3261,9 @@ msgstr "清除设备表"
+ msgid "Clear Instructions"
+ msgstr "清除指令"
+ 
++msgid "Clear Special Data"
++msgstr "清除特殊数据"
++
+ msgid "Clear _Background"
+ msgstr "清除背景(_B)"
+ 
+@@ -3192,10 +3305,10 @@ msgid "Cloc_kwise"
+ msgstr "顺时针(_K)"
+ 
+ msgid "Close Open Contours"
+-msgstr "关闭所有已打开的轮廓"
++msgstr "闭合开放的轮廓线"
+ 
+ msgid "Co_py LBearing"
+-msgstr "复制左边位(_p)"
++msgstr "复制左边位(_P)"
+ 
+ msgid "Collage"
+ msgstr "拼贴画"
+@@ -3305,7 +3418,7 @@ msgid "Compare Layers"
+ msgstr "比较层"
+ 
+ msgid "Compare Layers..."
+-msgstr "比较层…"
++msgstr "比较图层…"
+ 
+ msgid "Compare _Bitmaps"
+ msgstr "比较位图(_B)"
+@@ -3372,6 +3485,12 @@ msgstr "配置"
+ msgid "Conflict Hint Color"
+ msgstr "冲突渲调提示颜色"
+ 
++msgid "Conjunct Form After Ro"
++msgstr "Ro 后的连结形式"
++
++msgid "Conjunct Forms"
++msgstr "连结形式"
++
+ msgid "Connectors"
+ msgstr "连接"
+ 
+@@ -3420,6 +3539,9 @@ msgstr "关联替代"
+ msgid "Continue"
+ msgstr "继续"
+ 
++msgid "Contours (from closed):"
++msgstr "轮廓线（从闭合的）:"
++
+ msgid "Control Pictures"
+ msgstr "控制图片"
+ 
+@@ -3432,6 +3554,9 @@ msgstr "控制点临近水平/垂直/倾斜"
+ msgid "ControlPoint|Default"
+ msgstr "默认"
+ 
++msgid "Conve_x (Polygonal)"
++msgstr "凸形（多边形）(_X)"
++
+ msgid "Convert By C_Map"
+ msgstr "由CMap转换(_M)"
+ 
+@@ -3469,7 +3594,7 @@ msgid "Copy Loo_kup Data"
+ msgstr "复制查找数据(_K)"
+ 
+ msgid "Copy RBearin_g"
+-msgstr "复制右边位(_g)"
++msgstr "复制右边位(_G)"
+ 
+ msgid "Copy _Fg To Bg"
+ msgstr "复制前景到背景(_F)"
+@@ -3512,7 +3637,7 @@ msgid "Corporate Use"
+ msgstr "企业应用"
+ 
+ msgid "Correct Direction"
+-msgstr "正确方向"
++msgstr "修正方向"
+ 
+ msgid "Correct References"
+ msgstr "修正参考"
+@@ -3589,7 +3714,7 @@ msgstr "未能打开头文件(%s)于行 %d (%s中)"
+ 
+ #, c-format
+ msgid "Could not open output file: %s"
+-msgstr "未能打开输出文件: %s"
++msgstr "未能打开输出文件：%s"
+ 
+ msgid "Could not open temporary file."
+ msgstr "无法打开临时文件。"
+@@ -3603,7 +3728,7 @@ msgid "Could not read %s"
+ msgstr "不能读 %s"
+ 
+ msgid "Could not read (or perhaps find) mf output file"
+-msgstr "未能读（或未找到）mf输出文件"
++msgstr "无法读取（或找到）mf输出文件"
+ 
+ msgid "Could not write"
+ msgstr "未能写入"
+@@ -3703,7 +3828,7 @@ msgid "Cr_eate"
+ msgstr "新建(_E)"
+ 
+ msgid "Cr_eate VHint..."
+-msgstr "创建垂直渲调提示(_T)…"
++msgstr "创建垂直渲调提示(_E)…"
+ 
+ msgid "Cre_ate Named Glyphs..."
+ msgstr "创建命名字形(_A)…"
+@@ -3718,10 +3843,10 @@ msgid "Create Horizontal Stem Hint"
+ msgstr "创建水平字干渲调"
+ 
+ msgid "Create MM"
+-msgstr "创建字体集"
++msgstr "创建多母版"
+ 
+ msgid "Create Small Caps"
+-msgstr "创建小大写"
++msgstr "创建小型大写"
+ 
+ msgid "Create Subscript/Superscript"
+ msgstr "创建上下标"
+@@ -3872,6 +3997,9 @@ msgstr "西里尔文扩展 B"
+ msgid "Cyrillic Extended-C"
+ msgstr "西里尔文扩展 C"
+ 
++msgid "Cyrillic Extended-D"
++msgstr "西里尔文扩展 D"
++
+ msgid "Cyrillic Supplement"
+ msgstr "西里尔文补充"
+ 
+@@ -4063,13 +4191,13 @@ msgid "Designer URL"
+ msgstr "设计师网址"
+ 
+ msgid "Design|_New..."
+-msgstr "新建(_N)…"
++msgstr "设计|新建(_N)…"
+ 
+ msgid "Desired X-Height"
+ msgstr "预期X高度"
+ 
+ msgid "Desired x-height:"
+-msgstr "期望X高度:"
++msgstr "所需的 x 高度："
+ 
+ msgid "Detach & Remo_ve Glyphs..."
+ msgstr "分离及移除字形(_V)…"
+@@ -4092,6 +4220,9 @@ msgstr "天城文(梵文)"
+ msgid "Devanagari Extended"
+ msgstr "天城体扩展"
+ 
++msgid "Devanagari Extended-A"
++msgstr "梵文扩展 A"
++
+ msgid "Device Table Adjustments"
+ msgstr "设备表调整"
+ 
+@@ -4130,8 +4261,47 @@ msgstr "差异..."
+ msgid "Different Fonts"
+ msgstr "不同字体"
+ 
++#, c-format
++msgid "Different fill patterns in layer %d of %s\n"
++msgstr "%2$s 的 %1$d 层中的不同填充图案\n"
++
++#, c-format
++msgid "Different number of contours in glyph “%s”\n"
++msgstr "字形“%s”中有不同数量的轮廓线\n"
++
++#, c-format
++msgid "Different settings on whether to fill in layer %d of %s\n"
++msgstr "是否在 %2$s 的 %1$d 层中填充的不同设置\n"
++
++#, c-format
++msgid "Different settings on whether to inherit fill color in layer %d of %s\n"
++msgstr "是否在 %2$s 的 %1$d 层中继承填充颜色的不同设置\n"
++
++#, c-format
++msgid ""
++"Different settings on whether to inherit fill opacity in layer %d of %s\n"
++msgstr "是否在 %2$s 的 %1$d 层中继承填充不透明度的不同设置\n"
++
++#, c-format
++msgid ""
++"Different settings on whether to inherit stroke opacity in layer %d of %s\n"
++msgstr "是否在 %2$s 的 %1$d 层中继承笔划不透明度的不同设置\n"
++
++#, c-format
++msgid ""
++"Different settings on whether to inherit stroke width in layer %d of %s\n"
++msgstr "是否在 %2$s 的 %1$d 层中继承笔划宽度的不同设置\n"
++
++#, c-format
++msgid "Different settings on whether to stroke in layer %d of %s\n"
++msgstr "是否在 %2$s 的 %1$d 层中描边的不同设置\n"
++
++#, c-format
++msgid "Different stroke patterns in layer %d of %s\n"
++msgstr "%2$s 的 %1$d 层中的不同笔划图案\n"
++
+ msgid "Dingbats"
+-msgstr "Dingbats 英文字符"
++msgstr "装饰符号"
+ 
+ msgid "Diphthongs (Obsolete)"
+ msgstr "双元音（已停用）"
+@@ -4507,6 +4677,10 @@ msgstr "字形顺序"
+ msgid "End of file found in JSTF table.\n"
+ msgstr "JSTF表中找到文件结束符号。\n"
+ 
++#, c-format
++msgid "End of file found in string on line %d of %s"
++msgstr "在 %2$s 的第 %1$d 行的字符串中找到文件结尾"
++
+ #, c-format
+ msgid "End of file in %s table"
+ msgstr " %s 表中文件结束符号"
+@@ -4607,7 +4781,7 @@ msgid "Estonian"
+ msgstr "爱沙尼亚语"
+ 
+ msgid "Ethiopic"
+-msgstr "埃塞尔比亚文"
++msgstr "埃塞俄比亚文"
+ 
+ msgid "Ethiopic Extended"
+ msgstr "埃塞额比亚文扩展"
+@@ -4619,7 +4793,7 @@ msgid "Ethiopic Extended-B"
+ msgstr "吉兹文扩展 B"
+ 
+ msgid "Ethiopic Supplement"
+-msgstr "Ethiopic增补"
++msgstr "埃塞俄比亚文补充"
+ 
+ msgid "European Number"
+ msgstr "欧洲数字"
+@@ -4674,6 +4848,14 @@ msgstr "加宽"
+ msgid "Expanded (125%)"
+ msgstr "加宽至125%"
+ 
++#, c-format
++msgid "Expected %s in lookup definition on line %d of %s"
++msgstr "在 %3$s 的第 %2$d 行的查找定义中需要 %1$s"
++
++#, c-format
++msgid "Expected '%c%c%c%c' in lookup definition on line %d of %s"
++msgstr "在 %6$s 的第 %5$d 行的查找定义中需要“%1$c%2$c%3$c%4$c”"
++
+ #, c-format
+ msgid "Expected '%c' on line %d of %s"
+ msgstr "需要'%c' 于行 %d (%s中)"
+@@ -4684,15 +4866,15 @@ msgstr "需要'%s' 于行 %d (%s中)"
+ 
+ #, c-format
+ msgid "Expected ';' at statement end on line %d of %s"
+-msgstr "期望有';'在句末于行%d (%s)"
++msgstr "预期的 ';' 在 %2$s 的第 %1$d 行语句结束"
+ 
+ #, c-format
+ msgid "Expected ';' in lookupflags on line %d of %s"
+-msgstr "期望有';'  查找标记于行%d (%s)"
++msgstr "预期的 ';' 在 %2$s 的第 %1$d 行的 lookupflags 中"
+ 
+ #, c-format
+ msgid "Expected ';' on line %d of %s"
+-msgstr "期望';'于行%d (%s)"
++msgstr "预期的 ';' 在第 %d 行，共 %s"
+ 
+ #, c-format
+ msgid "Expected '=' in glyph class definition on line %d of %s"
+@@ -4700,11 +4882,11 @@ msgstr "在第 %d 行（ %s ）的字图类定义需要有'['"
+ 
+ #, c-format
+ msgid "Expected '>' in anchor on line %d of %s"
+-msgstr "期望有'>'  于行%d (%s)"
++msgstr "在 %2$s 的第 %1$d 行的锚点中需要“>”"
+ 
+ #, c-format
+ msgid "Expected '>' in caret on line %d of %s"
+-msgstr "期望有'>'  于行%d (%s)"
++msgstr "在 %2$s 的第 %1$d 行的插入符号中应为“>”"
+ 
+ #, c-format
+ msgid "Expected '>' in value record on line %d of %s"
+@@ -4732,7 +4914,11 @@ msgstr "%2$s 的第 %1$d 行的特征定义中应为“{”"
+ 
+ #, c-format
+ msgid "Expected '}' on line %d of %s"
+-msgstr "期望'}'于行%d (%s)"
++msgstr "%2$s 的第 %1$d 行应为“}”"
++
++#, c-format
++msgid "Expected Attach or LigatureCaret or GlyphClassDef on line %d of %s"
++msgstr "%2$s 的第 %1$d 行需要 Attach 或 LigatureCaret 或 GlyphClassDef"
+ 
+ #, c-format
+ msgid "Expected a single glyph name in reverse substitution on line %d of %s"
+@@ -4750,10 +4936,20 @@ msgstr "预期在 %2$s 的第 %1$d 行有一个锚点（在基础/标记之后
+ msgid "Expected an anchor (after ligature) on line %d of %s"
+ msgstr "预期在 %2$s 的第 %1$d 行有一个锚点（连字后）"
+ 
++#, c-format
++msgid ""
++"Expected an integer specifying baseline positions in BASE table on line %d "
++"of %s"
++msgstr "需要一个整数，用于指定 BASE 表中第 %d 行（共 %s）的基线位置"
++
+ #, c-format
+ msgid "Expected anchor in mark class definition on line %d of %s"
+ msgstr "%2$s 的第 %1$d 行上的标记类定义中的预期锚点"
+ 
++#, c-format
++msgid "Expected baseline tag in BASE table on line %d of %s"
++msgstr "%2$s 行 %1$d 上的 BASE 表中的预期基线标记"
++
+ msgid ""
+ "Expected boolean value.\n"
+ "(\"true\" or \"false\")"
+@@ -4763,15 +4959,32 @@ msgstr ""
+ 
+ #, c-format
+ msgid "Expected class name in mark class definition on line %d of %s"
+-msgstr "期望类属名称于标记类属定义的行%d (%s)"
++msgstr "%2$s 的第 %1$d 行标记类定义中的预期类名"
+ 
+ #, c-format
+ msgid "Expected class on line %d of %s"
+-msgstr "期望类属于行%d (%s)"
++msgstr "%2$s 行 %1$d 上应为类"
++
++#, c-format
++msgid "Expected closing curly brace on line %d of %s"
++msgstr "%2$s 的第 %1$d 行需要右大括号"
+ 
+ #, c-format
+ msgid "Expected comma in device table on line %d of %s"
+-msgstr "期望有设备表中有逗号， 于行%d (%s)"
++msgstr "%2$s 的第 %1$d 行设备表中应有逗号"
++
++#, c-format
++msgid "Expected comma or semicolon in BASE table on line %d of %s"
++msgstr "%2$s 的第 %1$d 行的 BASE 表中需要逗号或分号"
++
++#, c-format
++msgid "Expected comma or semicolon on line %d of %s"
++msgstr "%2$s 的第 %1$d 行需要逗号或分号"
++
++#, c-format
++msgid ""
++"Expected either \"HorizAxis\" or \"VertAxis\" in BASE table on line %d of %s"
++msgstr "在 %2$s 的第 %1$d 行的 BASE 表中应为“HorizAxis”或“VertAxis”"
+ 
+ #, c-format
+ msgid ""
+@@ -4792,7 +5005,7 @@ msgstr "在第 %d 行( %s)中的锚点需要有整数"
+ 
+ #, c-format
+ msgid "Expected integer in caret on line %d of %s"
+-msgstr "期望光标为整数于行%d (%s)"
++msgstr "%2$s 的第 %1$d 行插入符号中的预期整数"
+ 
+ #, c-format
+ msgid "Expected integer in device table on line %d of %s"
+@@ -4800,23 +5013,31 @@ msgstr "在第行%d (%s) 上的设备表中应该有整数"
+ 
+ #, c-format
+ msgid "Expected integer on line %d of %s"
+-msgstr "期望整数于行%d (%s)"
++msgstr "%2$s 行 %1$d 上的预期整数"
++
++#, c-format
++msgid "Expected integer or list of integers after %s on line %d of %s"
++msgstr "在 %s 的第 %d 行的 %s 之后需要整数或整数列表"
++
++#, c-format
++msgid "Expected matching tag in table on line %d of %s"
++msgstr "表中第 %d 行（共 %s）的预期匹配标记"
+ 
+ #, c-format
+ msgid "Expected name in anchor definition on line %d of %s"
+-msgstr "期望锚点定义名称， 于行%d (%s)"
++msgstr "%2$s 的第 %1$d 行锚点定义中的预期名称"
+ 
+ #, c-format
+ msgid "Expected name in lookup on line %d of %s"
+-msgstr "期望名称于行%d (%s)"
++msgstr "在 %2$s 的第 %1$d 行查找中需要名称"
+ 
+ #, c-format
+ msgid "Expected name in value record definition on line %d of %s"
+-msgstr "期望在记录中的第%d行第%s列定义了名称"
++msgstr "%2$s 的第 %1$d 行值记录定义中的预期名称"
+ 
+ #, c-format
+ msgid "Expected name or class on line %d of %s"
+-msgstr "期望名称或类属于行%d (%s)"
++msgstr "%2$s 的第 %1$d 行需要名称或类"
+ 
+ msgid "Expected number."
+ msgstr "需要数字。"
+@@ -4824,21 +5045,33 @@ msgstr "需要数字。"
+ msgid "Expected property list file"
+ msgstr "需要属性列表文件"
+ 
++#, c-format
++msgid "Expected semicolon in BASE table on line %d of %s"
++msgstr "%2$s 的第 %1$d 行的 BASE 表中需要分号"
++
+ #, c-format
+ msgid "Expected semicolon on line %d of %s"
+-msgstr "期望分号于行%d (%s)"
++msgstr "%2$s 的第 %1$d 行需要分号"
+ 
+ #, c-format
+ msgid "Expected string on line %d of %s"
+-msgstr "期望字符串于行%d (%s)"
++msgstr "%2$s 的第 %1$d 行需要字符串"
++
++#, c-format
++msgid "Expected tag in feature on line %d of %s"
++msgstr "%2$s 的第 %1$d 行功能中的预期标记"
+ 
+ #, c-format
+ msgid "Expected tag in languagesystem on line %d of %s"
+ msgstr "在第%d行（%s) 的语言系统应有标签"
+ 
++#, c-format
++msgid "Expected tag in table on line %d of %s"
++msgstr "表中第 %d 行（共 %s）的预期标记"
++
+ #, c-format
+ msgid "Expected tag on line %d of %s"
+-msgstr "期望标签于行%d (%s)"
++msgstr "%2$s 行 %1$d 上的预期标记"
+ 
+ #, c-format
+ msgid "Expected two anchors (after cursive) on line %d of %s"
+@@ -4863,6 +5096,9 @@ msgstr "导出"
+ msgid "Exten Shapes"
+ msgstr "扩展形状"
+ 
++msgid "Extend Cap:"
++msgstr "延伸端头:"
++
+ msgid "Extend Lookups Off"
+ msgstr "扩展查找关"
+ 
+@@ -4896,10 +5132,13 @@ msgstr "扩展"
+ msgid "Extent"
+ msgstr "扩展"
+ 
++msgid "External Only"
++msgstr "仅外部"
++
+ #. GT: Extra Space, see below for a full comment
+ #. GT: Extra Space
+ msgid "Extra Sp:"
+-msgstr "空位:"
++msgstr "额外空位:"
+ 
+ msgid "Extra-Condensed (62.5%)"
+ msgstr "压缩至62.5%"
+@@ -4929,7 +5168,7 @@ msgid "FS Modern"
+ msgstr "FS现代"
+ 
+ msgid "F_ind / Replace..."
+-msgstr "查找(_I) / 替换…"
++msgstr "查找/替换(_I)…"
+ 
+ #. GT: Foreground, make it short
+ msgid "F_ore"
+@@ -4954,7 +5193,7 @@ msgstr "从%s载入压缩数据失败"
+ 
+ #, c-format
+ msgid "Failed to open %s for output"
+-msgstr "未能打开 %s 作输出"
++msgstr "未能打开用于输出的%s"
+ 
+ #, c-format
+ msgid "Failed to open file %s for output"
+@@ -4991,7 +5230,7 @@ msgid "FamilyBl_ues"
+ msgstr "字族蓝值(_U)"
+ 
+ msgid "Faroese (Icelandic)"
+-msgstr "Faroese(冰岛语)"
++msgstr "法罗语（冰岛语）"
+ 
+ msgid "Feature"
+ msgstr "特性"
+@@ -5023,6 +5262,12 @@ msgstr "特性标签将被删除"
+ msgid "Features"
+ msgstr "特征"
+ 
++#, c-format
++msgid ""
++"Features inside of other features are only permitted for 'aalt' features on "
++"line %d of %s"
++msgstr "其他功能中的功能仅允许用于 %2$s 的第 %1$d 行的“aalt”功能"
++
+ msgid "Fi_ll"
+ msgstr "填充(_L)"
+ 
+@@ -5126,7 +5371,7 @@ msgid "First Glyph Name"
+ msgstr "首字形名称"
+ 
+ msgid "First P_oint, Next Contour"
+-msgstr "第一点，下一曲线(_O)"
++msgstr "第一点，下一轮廓线(_O)"
+ 
+ msgid "First Point Color"
+ msgstr "第一点颜色"
+@@ -5149,9 +5394,15 @@ msgstr "闪光的"
+ msgid "Flat"
+ msgstr "平整"
+ 
++msgid "Flat Nib"
++msgstr "扁平笔尖"
++
+ msgid "Flate decompression failed.\n"
+ msgstr "解压缩失败。\n"
+ 
++msgid "Flemish"
++msgstr "弗拉芒荷兰语"
++
+ msgid "Flemish (Belgian Dutch)"
+ msgstr "弗拉芒语（比利时荷兰）"
+ 
+@@ -5197,7 +5448,7 @@ msgid ""
+ "Do you want to save it?"
+ msgstr ""
+ "字体 %1$.40s (文件 %2$.40s) 已改变。\n"
+-"要保存么？"
++"要保存吗？"
+ 
+ #, c-format
+ msgid ""
+@@ -5248,6 +5499,14 @@ msgstr "字体:"
+ msgid "FontForge"
+ msgstr "FontForge"
+ 
++#, c-format
++msgid "FontForge does not support anonymous tables on line %d of %s"
++msgstr "FontForge 不支持第 %d 行的匿名表，共 %s"
++
++#, c-format
++msgid "FontForge does not support this bit depth %d (must be 1,2,4,8,16,32)\n"
++msgstr "FontForge不支持%d位深度(必须为1,2,4,8,16,32)\n"
++
+ msgid "FontForge font debugging table"
+ msgstr "FontForge 字体调试表"
+ 
+@@ -5334,7 +5593,7 @@ msgstr "格式："
+ 
+ #, c-format
+ msgid "Found %1$.4g, expected %2$.4g"
+-msgstr "发现 %1$.4g, 期望 %2$.4g"
++msgstr "已找到 %1$.4g，预期为 %2$.4g"
+ 
+ msgid "FoundryName"
+ msgstr "制作工具"
+@@ -5530,7 +5789,7 @@ msgid "Generate Mac Family"
+ msgstr "生成Mac字族"
+ 
+ msgid "Generate Mac _Family..."
+-msgstr "生成Mac族(_F)…"
++msgstr "生成Mac字体家族(_F)…"
+ 
+ msgid "Generate TTC..."
+ msgstr "生成TTC…"
+@@ -5757,6 +6016,23 @@ msgstr "字形 “%s” 不同\n"
+ msgid "Glyph “%s” differs at %d@%d\n"
+ msgstr "字形 “%s” 不同于 %d@%d\n"
+ 
++#, c-format
++msgid ""
++"Glyph “%s” does not have splines which match exactly, but they are close\n"
++msgstr "字形“%s”没有完全匹配的样条线，但已经接近了\n"
++
++#, c-format
++msgid "Glyph “%s” has a different fill in layer %d\n"
++msgstr "字形 “%s” 在%d图层中有不同的填充\n"
++
++#, c-format
++msgid "Glyph “%s” has a different number of layers\n"
++msgstr "字形 “%s” 有不同的图层数量。\n"
++
++#, c-format
++msgid "Glyph “%s” has a different stroke in layer %d\n"
++msgstr "字形 “%s”在%d图层中有不同的笔划\n"
++
+ #, c-format
+ msgid "Glyph “%s” missing from %s\n"
+ msgstr "字形“%s” 不在 %s 中\n"
+@@ -5811,6 +6087,15 @@ msgstr ""
+ "字形将由线组成而非可填充的轮廓。\n"
+ "所有字形的线宽为"
+ 
++msgid "Glyphs with both"
++msgstr "两者皆含的字形"
++
++msgid "Glyphs with only S_plines"
++msgstr "仅含样条的字形(_P)"
++
++msgid "Glyphs with only _References"
++msgstr "仅含参照的字形(_R)"
++
+ msgid "Glyphs:"
+ msgstr "字形："
+ 
+@@ -5869,7 +6154,7 @@ msgid "Greek and Coptic"
+ msgstr "希腊文及科普特文"
+ 
+ msgid "Greek small caps"
+-msgstr "希腊小大写"
++msgstr "希腊小型大写"
+ 
+ msgid "Green:"
+ msgstr "绿："
+@@ -5880,6 +6165,9 @@ msgstr "格陵兰语"
+ msgid "Grid"
+ msgstr "网格"
+ 
++msgid "Grid Color"
++msgstr "网格颜色"
++
+ msgid "Grid Fi_t"
+ msgstr "网格填充(_T)"
+ 
+@@ -5972,6 +6260,9 @@ msgstr "HV分组框"
+ msgid "H_ints"
+ msgstr "渲染调整(_I)"
+ 
++msgid "Halant Forms"
++msgstr "Halant 形"
++
+ msgid "Half Forms"
+ msgstr "半形"
+ 
+@@ -6017,9 +6308,18 @@ msgstr "谚文音节"
+ msgid "Hanifi Rohingya"
+ msgstr "哈尼菲罗兴亚文"
+ 
++msgid "Hanja to Hangul (Deprecated)"
++msgstr "由朝鲜汉字到朝鲜谚文（已弃用）"
++
+ msgid "Hanunoo"
+ msgstr "哈努努奥文"
+ 
++msgid "Harmoni_ze"
++msgstr "协调(_Z)"
++
++msgid "Harmonizing..."
++msgstr "正在协调..."
++
+ msgid "Has _Vertical Metrics"
+ msgstr "有垂直尺寸(_V)"
+ 
+@@ -6142,8 +6442,11 @@ msgstr "点击观察点"
+ msgid "Hojo (JIS X 0212-1990) Kanji Forms"
+ msgstr "JIS X 0212-1990 补助汉字表字形"
+ 
++msgid "Hold [Control] key to restrict"
++msgstr "按住 [Control] (Ctrl) 键来限制选择"
++
+ msgid "Hold [Shift] key to merge"
+-msgstr "按住 [Shift] 键合并"
++msgstr "按住 [Shift] 键合并选择"
+ 
+ msgid "Home Folder"
+ msgstr "主文件夹"
+@@ -6218,12 +6521,25 @@ msgstr "你想增加多少CID位？"
+ msgid "How many unencoded glyph slots do you wish to add?"
+ msgstr "你想增加多少未编码的字形位？"
+ 
++msgid "How to align these points?"
++msgstr "如何对齐这些点？"
++
+ msgid "Hue:"
+ msgstr "色调："
+ 
+ msgid "Hungarian"
+ msgstr "匈牙利语"
+ 
++#, c-format
++msgid ""
++"I can't even imagine how to attempt to interpolate gradients in layer %d of "
++"%s\n"
++msgstr "我甚至无法想象如何尝试在 %2$s 的 %1$d 层中插入渐变\n"
++
++#, c-format
++msgid "I can't figure out how to compare the subtable, %s, in %s to %s in %s\n"
++msgstr "无法将在%2$s中的替代表%1$s与%4$s中的替代表%3$s进行比较\n"
++
+ msgid ""
+ "I'm sorry this file is too complex for me to understand (or is erroneous)"
+ msgstr "抱歉，此文件太复杂，我不能理解。 (它可能有点问题)"
+@@ -6242,7 +6558,7 @@ msgid "I.C."
+ msgstr "倾斜修正"
+ 
+ msgid "IPA Extensions"
+-msgstr "国际音标扩展"
++msgstr "IPA 国际音标扩展"
+ 
+ msgid "IPA usage"
+ msgstr "IPA 用法"
+@@ -6271,6 +6587,11 @@ msgstr "表意文字描述字符"
+ msgid "Ideographic Symbols and Punctuation"
+ msgstr "表意符号及标点"
+ 
++msgid ""
++"If the start point of a contour is not an extremum, find a new start point "
++"(on the contour) which is."
++msgstr "如果轮廓线的起点不是极值，（在轮廓线上）寻找极值为新的起点。"
++
+ msgid "Ignore"
+ msgstr "忽略"
+ 
+@@ -6329,6 +6650,24 @@ msgstr "导入查找"
+ msgid "In TTF/OTF"
+ msgstr "TTF/OTF"
+ 
++#, c-format
++msgid "In character %s, could not find reference to %s\n"
++msgstr "在字符 %s 中，找不到对 %s 的引用\n"
++
++#, c-format
++msgid "In character %s, there are too few points on a path in the base\n"
++msgstr "字符 %s 中，基础路径上的点数太少\n"
++
++#, c-format
++msgid "In character %s, there are too many points on a path in the base\n"
++msgstr "字符 %s 中，基础路径上的点数太多\n"
++
++#, c-format
++msgid ""
++"In lookup subtable %.30s you replace a glyph with itself. Was this "
++"intentional?"
++msgstr "在查找子表 %.30s 中，有个字形自身替换。特地要如此吗？"
++
+ #. GT: Spoof on the bible
+ msgid "In the beginning was the letter..."
+ msgstr "开头是字母..."
+@@ -6488,6 +6827,9 @@ msgstr "指令已改变"
+ msgid "Intermediate Points:"
+ msgstr "中间点:"
+ 
++msgid "Internal Only"
++msgstr "仅内部"
++
+ msgid "Internal error in creating FNT. File offset wrong\n"
+ msgstr "创建FNT时发生内部错误。 文件偏移错误\n"
+ 
+@@ -6592,7 +6934,7 @@ msgid "Irish"
+ msgstr "爱尔兰语"
+ 
+ msgid "Irish Gaelic"
+-msgstr "盖尔语(爱尔兰)"
++msgstr "爱尔兰盖尔语"
+ 
+ msgid "Irish Gaelic (with dot)"
+ msgstr "爱尔兰盖尔语 (有修饰点)"
+@@ -6704,6 +7046,9 @@ msgstr "Javanese (罗马字母)"
+ msgid "Johab (Korean)"
+ msgstr "组合式（韩文Johab）"
+ 
++msgid "Join Limit:"
++msgstr "连接范围限制:"
++
+ msgid "JoinSnap"
+ msgstr "联合捕捉"
+ 
+@@ -6719,6 +7064,9 @@ msgstr "对齐的文字"
+ msgid "Kaithi"
+ msgstr "卡罗须提文"
+ 
++msgid "Kaktovik Numerals"
++msgstr "卡克托维克数字"
++
+ msgid "Kana Extended-A"
+ msgstr "假名扩展 A"
+ 
+@@ -6744,11 +7092,14 @@ msgid "Katakana"
+ msgstr "日文片假名"
+ 
+ msgid "Katakana (& Phonetic Extensions)"
+-msgstr "片假名（& 语音扩展)"
++msgstr "片假名（和音标扩展）"
+ 
+ msgid "Katakana Phonetic Extensions"
+ msgstr "片假名音标扩展"
+ 
++msgid "Kawi"
++msgstr "卡维"
++
+ msgid "Kayah Li"
+ msgstr "克耶利文"
+ 
+@@ -6809,6 +7160,10 @@ msgstr "字偶距类"
+ msgid "Kerning State Machine"
+ msgstr "压缩状态机"
+ 
++#, c-format
++msgid "Kerning between “%s” and %s is %d in %s and %d in %s\n"
++msgstr "“%1$s”和“%2$s”的字偶距在%4$s为%3$d，在%6$s为%5$d\n"
++
+ #. GT: The %s is the name of the lookup subtable containing this kerning class
+ #, c-format
+ msgid "Kerning by Classes: %s"
+@@ -6872,7 +7227,7 @@ msgid "LSB Compression Percent"
+ msgstr "左边位压缩比例"
+ 
+ msgid "L_ater"
+-msgstr "后来(_A)"
++msgstr "推后(_A)"
+ 
+ msgid "L_oad Namelist..."
+ msgstr "载入列表(_O)…"
+@@ -6909,7 +7264,7 @@ msgstr "新建语言"
+ #. GT: See the long comment at "Property|New"
+ #. GT: The msgstr should contain a translation of "Amharic", ignore "Lang|"
+ msgid "Lang|Amharic"
+-msgstr "Amharic"
++msgstr "语言|阿姆哈拉语"
+ 
+ msgid "Lang|Arabic"
+ msgstr "阿拉伯语"
+@@ -6943,7 +7298,7 @@ msgstr "波斯语"
+ #. GT: See the long comment at "Property|New"
+ #. GT: The msgstr should contain a translation of "Farsi/Persian", ignore "Lang|"
+ msgid "Lang|Farsi/Persian"
+-msgstr "波斯文"
++msgstr "语言|波斯语"
+ 
+ msgid "Lang|Ge'ez"
+ msgstr "Ge'ez"
+@@ -7061,7 +7416,7 @@ msgid "Latin Ligatures"
+ msgstr "拉丁组合字"
+ 
+ msgid "Latin-1 Supplement"
+-msgstr "拉丁一补充"
++msgstr "拉丁-1增补"
+ 
+ msgid "Latin: Decorative"
+ msgstr "拉丁文：修饰"
+@@ -7090,6 +7445,9 @@ msgstr "背景"
+ msgid "Layer|Foreground"
+ msgstr "前景"
+ 
++msgid "Leading Jamo Forms"
++msgstr "朝鲜谚文前导形式"
++
+ msgid ""
+ "Learning to use FontForge is easy, and there are various tutorials available "
+ "beginning with the basics up to more advanced features such as making and "
+@@ -7202,11 +7560,17 @@ msgid "Line"
+ msgstr "线"
+ 
+ msgid "Line Cap"
+-msgstr "线宽"
++msgstr "线端头"
++
++msgid "Line Cap:"
++msgstr "线端头:"
+ 
+ msgid "Line Join"
+ msgstr "线连接"
+ 
++msgid "Line Join:"
++msgstr "线连接:"
++
+ msgid "Line length max"
+ msgstr "最大线长"
+ 
+@@ -7424,10 +7788,10 @@ msgid "Lower Case"
+ msgstr "小写"
+ 
+ msgid "Lowercase to Petite Capitals"
+-msgstr "小写到袖珍大写"
++msgstr "小写到微型大写"
+ 
+ msgid "Lowercase to Small Capitals"
+-msgstr "小写到小大写"
++msgstr "小写到小型大写"
+ 
+ msgid "Luxembourgish"
+ msgstr "法语(卢森堡公国)"
+@@ -7443,23 +7807,23 @@ msgstr "数学表"
+ 
+ #. GT: Here (and following) MM means "MultiMaster"
+ msgid "MM"
+-msgstr "字体集"
++msgstr "多母版"
+ 
+ msgid "MM Change Def Weights"
+-msgstr "字体集更改默认粗细"
++msgstr "多母版更改默认字重"
+ 
+ msgid "MM Change Default _Weights..."
+-msgstr "字体集默认粗细(_W)…"
++msgstr "多母版更改默认字重(_W)..."
+ 
+ msgid "MM _Info"
+-msgstr "字体集信息(_I)"
++msgstr "多母版信息(_I)"
+ 
+ msgid "MM _Info..."
+ msgstr "字体集信息(_I)…"
+ 
+ #. GT: Here (and following) MM means "MultiMaster"
+ msgid "MM _Reblend"
+-msgstr "字体集再混合(_R)"
++msgstr "多母版再混合(_R)"
+ 
+ msgid "MM _Validity Check"
+ msgstr "字体集校核(_V)"
+@@ -7574,6 +7938,9 @@ msgstr "麻将牌面"
+ msgid "Maithili"
+ msgstr "米德勒语"
+ 
++msgid "Major Axis (_Width):"
++msgstr "主轴（宽度）(_W)："
++
+ msgid "Makasar"
+ msgstr "望加锡文"
+ 
+@@ -7966,7 +8333,10 @@ msgid "Min Kern"
+ msgstr "最小压缩(_M)"
+ 
+ msgid "Minor A_xis:"
+-msgstr "次轴线(_X):"
++msgstr "次轴(_X):"
++
++msgid "Minor Axis (_Height):"
++msgstr "次轴（高度）(_H):"
+ 
+ msgid "Minor:"
+ msgstr "次:"
+@@ -8025,7 +8395,7 @@ msgid "Missing POST resource %u\n"
+ msgstr "缺少 POST 资源 %u\n"
+ 
+ msgid "Missing Points at Extrema"
+-msgstr "在极值处缺少点"
++msgstr "在极值处缺点"
+ 
+ msgid "Missing Script"
+ msgstr "缺位图"
+@@ -8098,6 +8468,9 @@ msgstr "缺规则"
+ msgid "Missing suffix"
+ msgstr "遗失后缀"
+ 
++msgid "Miter Cli_p"
++msgstr "尖角裁剪(_P)"
++
+ msgid "Mixed contours and references"
+ msgstr "混合的轮廓及参照"
+ 
+@@ -8206,10 +8579,10 @@ msgid ""
+ msgstr "多个字形映射了同一个码位 U+%04X，只有一个字形会显示\n"
+ 
+ msgid "Multiple master font with more than 16 instances\n"
+-msgstr "多主字体超过16实例\n"
++msgstr "超16实例多重母版字体\n"
+ 
+ msgid "Multiple master font with more than 4 axes\n"
+-msgstr "多主字体超过4轴\n"
++msgstr "超4轴多重母版字体\n"
+ 
+ msgid "Multiple names for language"
+ msgstr "语言的多个名称"
+@@ -8256,12 +8629,18 @@ msgstr "NUL，默认字符"
+ msgid "N_ever Interpolate"
+ msgstr "从不插值(_E)"
+ 
++msgid "N_one (Debug)"
++msgstr "无（调试）(_O)"
++
+ msgid "N_umber Points"
+ msgstr "数值点"
+ 
+ msgid "Nabataean"
+ msgstr "那巴泰文"
+ 
++msgid "Nag Mundari"
++msgstr "纳格·蒙达里"
++
+ msgid "Name"
+ msgstr "名称"
+ 
+@@ -8275,7 +8654,7 @@ msgid "Name in use"
+ msgstr "正使用"
+ 
+ msgid "Name this contour"
+-msgstr "命名此轮廓"
++msgstr "命名此轮廓线"
+ 
+ msgid "Name this guideline or cancel to create it without a name"
+ msgstr "你可以给这条引导线附加一个文本标签"
+@@ -8491,7 +8870,7 @@ msgid "Next Hint."
+ msgstr "下一个渲染调整。"
+ 
+ msgid "Next On Contour"
+-msgstr "轮廓上下一个"
++msgstr "轮廓线上下一个"
+ 
+ msgid "Next State:"
+ msgstr "下一状态:"
+@@ -8499,6 +8878,15 @@ msgstr "下一状态:"
+ msgid "Next _Defined Glyph"
+ msgstr "下一定义的字形(_D)"
+ 
++msgid "Ni_b"
++msgstr "笔尖(_B)"
++
++msgid "Ni_b Angle:"
++msgstr "笔尖角度(_B):"
++
++msgid "Nib Type:"
++msgstr "笔尖类型:"
++
+ msgid "Niuean"
+ msgstr "纽埃语"
+ 
+@@ -8603,10 +8991,10 @@ msgid "No References"
+ msgstr "无参照"
+ 
+ msgid "No Rename"
+-msgstr "无重命名"
++msgstr "不改名"
+ 
+ msgid "No Script"
+-msgstr "无脚本"
++msgstr "无文字"
+ 
+ msgid "No Script Tag"
+ msgstr "无文字标签"
+@@ -8615,7 +9003,7 @@ msgid "No Sequence/Lookups"
+ msgstr "无排序/查找 "
+ 
+ msgid "No Slope"
+-msgstr "没有范围"
++msgstr "无斜率"
+ 
+ msgid "No Start Glyph"
+ msgstr "无起始字形"
+@@ -8691,6 +9079,10 @@ msgstr "字体里未包含 Unicode 编码为 U+%05x 的字形\n"
+ msgid "No glyphs matched"
+ msgstr "无匹配字形"
+ 
++#, c-format
++msgid "No kerning between “%s” and %s in %s whilst it is %d in %s\n"
++msgstr "在%3$s中没有“%1$s”和“%2$s”之间的字偶距，但在%5$s中却存在%4$d。\n"
++
+ #, c-format
+ msgid "No kerning pairs found in %.200s"
+ msgstr "%.200s中未发现字偶距对"
+@@ -8722,6 +9114,10 @@ msgstr "无标记于 counttomark\n"
+ msgid "No marked glyphs allowed in replacement on line %d of %s"
+ msgstr "%2$s 的第 %1$d 行不允许替换标记的字形"
+ 
++#, c-format
++msgid "No matching AnchorClass for %s"
++msgstr "%s 没有匹配的 AnchorClass"
++
+ #, c-format
+ msgid "No name for CharStrings dictionary \"%s"
+ msgstr "字符字串字典无名称 \"%s"
+@@ -8827,6 +9223,9 @@ msgstr "正常无衬线体"
+ msgid "Normal Text Color:"
+ msgstr "普通文本颜色："
+ 
++msgid "Normal font used in the Find/Replace window"
++msgstr "查找/替换窗口中使用的普通字体"
++
+ msgid "Normal/Boxed"
+ msgstr "外框"
+ 
+@@ -8854,6 +9253,17 @@ msgstr "规格化设计矢量函数:"
+ msgid "Normalized Settings:"
+ msgstr "规范化设定："
+ 
++msgid ""
++"Normally simplify will not change the slope of the contour at the points."
++msgstr "简化通常不会改变轮廓线在点处的斜率。"
++
++msgid ""
++"Normally simplify will not remove points at the extrema of curves\n"
++"(both PostScript and TrueType suggest you retain these points)"
++msgstr ""
++"简化通常不会删除曲线极值处的点\n"
++"(PostScript 和 TrueType 皆建议您保留这些点)"
++
+ msgid "Northern Sami"
+ msgstr "北萨莫斯语"
+ 
+@@ -8934,7 +9344,7 @@ msgid "Not quadratic"
+ msgstr "非二次曲线"
+ 
+ msgid "Not sure if this is an error..."
+-msgstr "不确定这是一个错误..."
++msgstr "不确定这是否为一个错误..."
+ 
+ msgid "Notdef name"
+ msgstr "未定义名称"
+@@ -9039,7 +9449,7 @@ msgid "OEM Charset"
+ msgstr "OEM 字符集"
+ 
+ msgid "OK"
+-msgstr "确认"
++msgstr "确定"
+ 
+ msgid "OS/2 -> Charsets"
+ msgstr "OS/2 -> 字符集"
+@@ -9204,7 +9614,7 @@ msgid ""
+ "One of the multiple master instances contains quadratic splines. It must be "
+ "converted to cubic splines before it can be used in a multiple master"
+ msgstr ""
+-"多母版的实例里面有一个包含了二次曲线。它必须转化成三次曲线才能用于多母版"
++"多重母版的实例里面有一个包含了二次曲线。它必须转化成三次曲线才能用于多重母版"
+ 
+ msgid "Only Embed Bitmaps"
+ msgstr "仅嵌入位图"
+@@ -9241,7 +9651,7 @@ msgid "Open"
+ msgstr "打开"
+ 
+ msgid "Open Contour"
+-msgstr "轮廓开放"
++msgstr "开放轮廓线"
+ 
+ msgid "Open Font"
+ msgstr "打开字体"
+@@ -9255,6 +9665,10 @@ msgstr "打开参照"
+ msgid "Open failed"
+ msgstr "打开失败"
+ 
++#, c-format
++msgid "Open/Closed contour mismatch in glyph “%s”\n"
++msgstr "字形“%s”中开放/关闭的轮廓线不匹配\n"
++
+ msgid "OpenCharsInNewWindow"
+ msgstr "于新窗口显示字符"
+ 
+@@ -9354,6 +9768,9 @@ msgstr "外部阴影"
+ msgid "Outline"
+ msgstr "轮廓"
+ 
++msgid "Outline Color"
++msgstr "轮廓颜色"
++
+ msgid "Outline Default Button"
+ msgstr "轮廓默认按钮"
+ 
+@@ -9387,17 +9804,20 @@ msgstr "空心字形"
+ msgid "Output AFM"
+ msgstr "生成AFM"
+ 
++msgid "Output FONTLOG.txt"
++msgstr "输出FONTLOG.txt"
++
+ msgid "Output Glyph Map"
+-msgstr "生成字形映射"
++msgstr "输出字形映射"
+ 
+ msgid "Output OFM & CFG"
+-msgstr "生成 OFM 及 CFG"
++msgstr "输出 OFM 及 CFG"
+ 
+ msgid "Output PFM"
+ msgstr "生成PFM"
+ 
+ msgid "Output TFM & ENC"
+-msgstr "生成 TFM 及 ENC"
++msgstr "输出 TFM 及 ENC"
+ 
+ msgid "Output error"
+ msgstr "输出错误"
+@@ -9424,10 +9844,10 @@ msgid "PS Hints"
+ msgstr "PS渲调提示"
+ 
+ msgid "PS Multiple Master(A)"
+-msgstr "PS 多母版(A)"
++msgstr "PS 多重母版(A)"
+ 
+ msgid "PS Multiple Master(B)"
+-msgstr "PS 多母版(B)"
++msgstr "PS 多重母版(B)"
+ 
+ msgid "PS Names"
+ msgstr "PS字体名称"
+@@ -9839,7 +10259,7 @@ msgid "Perspecti_ve"
+ msgstr "透视(_V)"
+ 
+ msgid "Petite Caps"
+-msgstr "小大写"
++msgstr "微型大写"
+ 
+ msgid "PfaEdit Table"
+ msgstr "PfaEdit表"
+@@ -9923,7 +10343,7 @@ msgid "Please name encoding %d in this file"
+ msgstr "请给此文件中的编码 %d命名"
+ 
+ msgid "Please name this contour"
+-msgstr "请为此轮廓命名"
++msgstr "请为此轮廓线命名"
+ 
+ msgid "Please name this encoding"
+ msgstr "请为此编码命名"
+@@ -10003,10 +10423,10 @@ msgid "Points (TrueType)"
+ msgstr "点(TrueType)"
+ 
+ msgid "Points of _Inflection"
+-msgstr "标记映像点(_I)"
++msgstr "拐点(_I)"
+ 
+ msgid "Points on Selected _Contours"
+-msgstr "曲线上的全部点(_C)"
++msgstr "所选轮廓线上的点(_C)"
+ 
+ msgid "Points:"
+ msgstr "点:"
+@@ -10112,7 +10532,7 @@ msgid "Preferred Styles"
+ msgstr "首选样式"
+ 
+ msgid "Prefs_App| "
+-msgstr " "
++msgstr "Prefs_App| "
+ 
+ msgid "Preserve cross-font kerning"
+ msgstr "保留交叉字体压缩"
+@@ -10149,7 +10569,7 @@ msgid "Prev Defined Gl_yph"
+ msgstr "上一定义的字形(_Y)"
+ 
+ msgid "Prev On Contour"
+-msgstr "轮廓上上一个"
++msgstr "轮廓线上上一个"
+ 
+ msgid "Previous Hint."
+ msgstr "上一个渲染调整。"
+@@ -10369,6 +10789,9 @@ msgstr "光栅化尺寸:"
+ msgid "Rasterizing..."
+ msgstr "正在光栅化..."
+ 
++msgid "Ratio"
++msgstr "比率"
++
+ msgid "Raw"
+ msgstr "原始"
+ 
+@@ -10394,7 +10817,7 @@ msgid "Recalculate Bitmaps"
+ msgstr "再算位图"
+ 
+ msgid "Recen_t"
+-msgstr "最近的(_T)"
++msgstr "最近(_T)"
+ 
+ msgid "RecognizePUANames"
+ msgstr "识别PUA名称"
+@@ -10510,6 +10933,9 @@ msgstr "雷姜文"
+ msgid "Remo_ve Undoes"
+ msgstr "清除修改历史"
+ 
++msgid "Remo_ve Undoes..."
++msgstr "清除修改历史(_V)..."
++
+ msgid "Remove"
+ msgstr "移除"
+ 
+@@ -10558,6 +10984,9 @@ msgstr "移除查找"
+ msgid "Remove Overlap"
+ msgstr "移除重叠"
+ 
++msgid "Remove Overlap:"
++msgstr "合并重叠:"
++
+ msgid "Remove This Glyph"
+ msgstr "移除字形(_Y)"
+ 
+@@ -10991,6 +11420,9 @@ msgstr "SIL Graphite 规则表"
+ msgid "SJIS (Kanji)"
+ msgstr "SJIS (汉字)"
+ 
++msgid "SVG 2"
++msgstr "SVG 2"
++
+ msgid "SVG Template"
+ msgstr "SVG模板"
+ 
+@@ -11015,6 +11447,9 @@ msgstr "显示依赖(_H)"
+ msgid "S_how H. Metrics..."
+ msgstr "显示水平尺寸(_h)…"
+ 
++msgid "S_implify"
++msgstr "简化(_I)"
++
+ msgid "S_nap to horizontal/vertical"
+ msgstr "定位到水平线/垂直线"
+ 
+@@ -11042,6 +11477,9 @@ msgstr "同匹配类属"
+ msgid "Same as PostScript Names"
+ msgstr "与 PostScript 名称相同"
+ 
++msgid "Sami (Lappish)"
++msgstr "萨米语（拉普兰语）"
++
+ msgid "Samoan"
+ msgstr "萨摩亚语"
+ 
+@@ -11112,7 +11550,7 @@ msgid "Save as _Directory"
+ msgstr "保存为文件夹(_D)"
+ 
+ msgid "Save as..."
+-msgstr "保存为…"
++msgstr "另存为…"
+ 
+ msgid "Save glyph colors in the PfEd table"
+ msgstr "保存字形颜色到PfaEdit表"
+@@ -11288,7 +11726,7 @@ msgstr "文字标签为4个字符"
+ #. GT: See the long comment at "Property|New"
+ #. GT: The msgstr should contain a translation of "Arabic", ignore "Script|"
+ msgid "Script|Arabic"
+-msgstr "阿拉伯文"
++msgstr "文字|阿拉伯文"
+ 
+ msgid "Script|Aramaic"
+ msgstr "亚拉姆文字"
+@@ -11561,10 +11999,10 @@ msgid "Segment Separator"
+ msgstr "段分隔符"
+ 
+ msgid "Selec_t By Lookup Subtable..."
+-msgstr "按查找表选择(_T)…"
++msgstr "按查找子表选择(_T)…"
+ 
+ msgid "Select All _Points & Refs"
+-msgstr "选择全部描点及参照(_P)"
++msgstr "选择全部点及参照(_P)"
+ 
+ msgid "Select Anc_hors"
+ msgstr "选择锚点(_H)"
+@@ -11589,7 +12027,7 @@ msgid "Select In Font"
+ msgstr "于字体中选择"
+ 
+ msgid "Select Open Contours"
+-msgstr "选择已打开的轮廓"
++msgstr "选择开放的轮廓线"
+ 
+ msgid "Select Point(s) at..."
+ msgstr "选择点…"
+@@ -11955,7 +12393,7 @@ msgid "Simplify"
+ msgstr "简化"
+ 
+ msgid "Simplify More..."
+-msgstr "简化更多…"
++msgstr "高级简化…"
+ 
+ msgid "Simplifying..."
+ msgstr "简化…"
+@@ -12067,10 +12505,10 @@ msgid "Slovenian"
+ msgstr "斯洛文尼亚语"
+ 
+ msgid "Small Capitals"
+-msgstr "小大写"
++msgstr "小型大写"
+ 
+ msgid "Small Caps"
+-msgstr "小大写"
++msgstr "小型大写"
+ 
+ msgid "Small Form Variants"
+ msgstr "小型形式变体"
+@@ -12249,6 +12687,10 @@ msgstr "样条线长度=%.1f"
+ msgid "Spline Length=%g"
+ msgstr "样条线长度=%g"
+ 
++#, c-format
++msgid "Spline mismatch in glyph “%s”\n"
++msgstr "字形“%s”的样条线不匹配\n"
++
+ msgid "Square"
+ msgstr "方形"
+ 
+@@ -12287,7 +12729,7 @@ msgid "Star"
+ msgstr "星形"
+ 
+ msgid "Start contours at e_xtrema"
+-msgstr "在极值处开始轮廓"
++msgstr "在极值处开始轮廓线(_X)"
+ 
+ #. GT: "Len" is an abbreviation for "Length"
+ msgid "StartLen"
+@@ -12392,6 +12834,9 @@ msgstr "笔画变化(_V)"
+ msgid "Stroke _Width:"
+ msgstr "笔画宽度(_W):"
+ 
++msgid "Stroke width cannot be zero"
++msgstr "笔划宽度不能为零"
++
+ msgid "Stroking..."
+ msgstr "笔画..."
+ 
+@@ -12971,8 +13416,11 @@ msgstr "激活层的轮廓线颜色"
+ msgid "The color of the clip path"
+ msgstr "剪切路径的颜色"
+ 
++msgid "The color of the outline"
++msgstr "轮廓的颜色"
++
+ msgid "The color of the point which is the start of a contour"
+-msgstr "曲线起点的颜色"
++msgstr "轮廓线起点的颜色"
+ 
+ msgid "The color used to draw a hint which conflicts with another"
+ msgstr "此颜色用于绘制与其他渲调提示冲突的渲调提示"
+@@ -12991,11 +13439,14 @@ msgid ""
+ "horizontal or vertical at their end-points"
+ msgstr "当样条线的端点几乎但又不完全水平或垂直时，用此颜色绘制其标记"
+ 
++msgid "The color used to draw points at extrema (if that mode is active)"
++msgstr "用于绘制极值处点的颜色（若模式激活时）"
++
+ msgid "The color used to draw points of inflection (if that mode is active)"
+-msgstr "绘制映像点的颜色（若激活模式时）"
++msgstr "用于绘制拐弯点的颜色（若模式激活时）"
+ 
+ msgid "The color used to draw the \"next\" control point of an on-curve point"
+-msgstr "此颜色用于绘制曲线上的点的下一个控制点"
++msgstr "用于绘制曲线上的点的下一个控制点的颜色"
+ 
+ msgid ""
+ "The color used to draw the \"previous\" control point of an on-curve point"
+@@ -13047,6 +13498,19 @@ msgstr ""
+ "字体有错误。\n"
+ "%s是否查看错误或继续保存?"
+ 
++#, c-format
++msgid ""
++"The font database already contains a bitmap\n"
++"font with this pixelsize (%d)\n"
++"Do you want to overwrite it?"
++msgstr ""
++"字体数据库已经包含了具有此像素尺寸(%d)\n"
++"的位图字体。\n"
++"您要覆盖它吗？"
++
++msgid "The generated font won't work with ATM"
++msgstr "生成的字体与ATM不兼容"
++
+ #, c-format
+ msgid ""
+ "The glyph at CID %d is mapped to more than %d encodings. Only the first %d "
+@@ -13088,6 +13552,24 @@ msgstr "当前位图尺寸列表"
+ msgid "The maximum number of Undoes/Redoes stored in a glyph"
+ msgstr "保存在字形中的取消/重来的最多数量"
+ 
++msgid ""
++"The maximum number of Undoes/Redoes stored in a glyph. Use -1 for infinite "
++"Undoes\n"
++"(but watch RAM consumption and use the Edit menu's Remove Undoes as needed)"
++msgstr ""
++"撤消/重做的最大值储存于字形内。用 -1 表示无限次撤消\n"
++"（但请注意内存消耗，并在必要时用“编辑”菜单内的“清除修改历史”项）"
++
++#, c-format
++msgid ""
++"The name of glyph %.40s has changed. This is what I use to find the glyph in "
++"the file, so I cannot revert this glyph.\n"
++"(You will not be warned for subsequent glyphs.)"
++msgstr ""
++"字形 %.40s 的名称已更改。 这是我用来在文件中查找字形的方法，因此我无法还原此"
++"字形。\n"
++" （您不会收到后续字形的警告。）"
++
+ msgid "The number of em-units by which an arrow key will move a selected point"
+ msgstr "方向键按此尺寸移动选定点"
+ 
+@@ -13115,6 +13597,10 @@ msgstr "已选字形沒有任何渲调。FontForge 将无法生成许多指令
+ msgid "The selected point does not have integral control points"
+ msgstr "选择的点没有整数控制点"
+ 
++msgid ""
++"The selected spline attains its extrema somewhere other than its endpoints"
++msgstr "所选的样条在其端点外的某处达到其极值"
++
+ msgid "The size (in points) for which this face was designed"
+ msgstr "此面以点为尺寸"
+ 
+@@ -13122,12 +13608,32 @@ msgstr "此面以点为尺寸"
+ msgid "The spline does not reach %g"
+ msgstr "样条线不到 %g"
+ 
++msgid ""
++"The stroke algorithm will attempt to be (at least)\n"
++"this accurate, but there may be exceptions."
++msgstr ""
++"笔划算法尝试（至少）达到\n"
++"该精度，但仍可能有例外情况。"
++
++#, c-format
++msgid ""
++"The width of %s is too big to fit in a tfm fix_word, it shall be truncated "
++"to the largest size allowed."
++msgstr "%s 的宽度过大，不匹配 tfm fix_word，该宽度将会被截断到所允许的最大值。"
++
+ msgid "The width of one em"
+ msgstr "M全字宽度"
+ 
+ msgid "The width of the line used to draw selected points"
+ msgstr "选中点的线宽"
+ 
++#, c-format
++msgid "There are %d pages in this file, which do you want?"
++msgstr "文件中有%d页，您想要哪些页面？"
++
++msgid "There are multiple fonts in this file, pick one"
++msgstr "此文件中有多个字体，请选择一个"
++
+ #, c-format
+ msgid "There are two entries for the same glyph (%.80s)"
+ msgstr "同一字形 (%.80s)有两个入口"
+@@ -13187,6 +13693,10 @@ msgstr "已有同名子表，请选择另一个。"
+ msgid "There is already an anchor point named %1$.40s in %2$.40s."
+ msgstr "已存在名为 %1$.40s 的 %2$.40s 的锚点。"
+ 
++#, c-format
++msgid "There is no glyph named \"%s\" in the font."
++msgstr "字体中无字形 %s."
++
+ #, c-format
+ msgid "There is no glyph named %s (used in %s)"
+ msgstr "字体中无字形 %s(用于%s)"
+@@ -13198,6 +13708,11 @@ msgstr "字体中无字形 %s"
+ msgid "There must be at least 2 gradient stops"
+ msgstr "至少要二项斜度"
+ 
++msgid ""
++"These results are those of the freetype autohinter. They do not reflect the "
++"truetype instructions."
++msgstr "这些结果是 freetype autohinter 的结果。 它们不反映 truetype 指令。"
++
+ msgid "These two lines share a common endpoint, I can't make them parallel"
+ msgstr "两线共点，不能平行"
+ 
+@@ -13222,6 +13737,15 @@ msgstr "三分之一宽"
+ msgid "Third argument of imagemask must be a boolean.\n"
+ msgstr "蒙板的第三个参数必须为布尔类型.\n"
+ 
++#, c-format
++msgid ""
++"This character (gid=%d) has a following part (%d). I'm not sure what that "
++"means, please send me (gww@silcom.com) a copy of this font so I can test "
++"with it.\n"
++msgstr ""
++"此字符（gid=%d）包含以下部分（%d）。我尚未清楚此为何意，但您是否能将此字体的"
++"副本发给我（gww@silcom.com）用以测试研究呢？\n"
++
+ msgid ""
+ "This does not seem to be a plate file\n"
+ "Expected left paren"
+@@ -13251,7 +13775,7 @@ msgstr ""
+ "第一行有误"
+ 
+ msgid "This doesn't look like an ofm file, I don't know how to read it."
+-msgstr "这个看来不像ofm文件，不知道怎么打开。"
++msgstr "这个看来不像ofm文件，不知如何读取。"
+ 
+ msgid "This feature code is already used"
+ msgstr "此特征代码已使用"
+@@ -13324,11 +13848,20 @@ msgid "This glyph is wider than desired"
+ msgstr "字形比预期的宽"
+ 
+ msgid "This hint does not control any points"
+-msgstr "此渲调提示不控制任何描点"
++msgstr "此渲染调整不控制任何点"
+ 
+ msgid "This index is much larger than the closest neighbor"
+ msgstr "此索引相比邻近值过大"
+ 
++#, c-format
++msgid ""
++"This is probably a valid URW font, but it is in a format (%c%c) which "
++"FontForge\n"
++"does not support. FontForge only supports 'IK' format fonts.\n"
++msgstr ""
++"也许此URW字体有效，但FontForge不支持此格式（%c%c）罢了。FontForge仅支持‘IK’格"
++"式的字体。\n"
++
+ msgid ""
+ "This is the difference of the curvature between\n"
+ "the next and previous splines. Contours often\n"
+@@ -13340,9 +13873,21 @@ msgstr ""
+ msgid "This ligature index is already in use"
+ msgstr "此连字索引正被使用"
+ 
++msgid ""
++"This looks like an ikarus format which I have seen examples of, but for "
++"which\n"
++"I have no documentation. FontForge does not support it yet.\n"
++msgstr ""
++"我似乎曾经见到过像这样的一些样例，这看上去是 ikarus 格式……但我手头上没有关于"
++"它的文档。而FontForge也还不支持。\n"
++
+ msgid "This lookup contains no data"
+ msgstr "此查找不含数据"
+ 
++#, c-format
++msgid "This lookup has no effect, I can't figure out its type on line %d of %s"
++msgstr "此查找无效，我无法在 %2$s 的第 %1$d 行找出它的类型"
++
+ msgid "This may take a while. Please be patient..."
+ msgstr "这需要一点时间。请稍候..."
+ 
+@@ -13352,6 +13897,11 @@ msgstr "这必须是truetype层."
+ msgid "This operation cannot be undone, do it anyway?"
+ msgstr "此操作不能取消，是否继续？"
+ 
++msgid ""
++"This option prepends a timestamp in the format YYMMDDHHMM to the filename "
++"and font-family name metadata."
++msgstr "此选项向文件名和字体名称元数据以YYMMDDHHM格式预设一个时间戳。"
++
+ msgid "This outline glyph is missing a bitmap version"
+ msgstr "此轮廓字形缺少相应位图字形"
+ 
+@@ -13364,6 +13914,9 @@ msgstr "此pdf文件不含页面"
+ msgid "This setting is already used"
+ msgstr "设置已被采用"
+ 
++msgid "This version of FontForge expects freetype 2.3.7 or more."
++msgstr "此版本的 FontForge 需要 freetype 2.3.7 或更高版本。"
++
+ msgid ""
+ "This version of fontforge was not linked with the spiro library, so you may "
+ "not use them."
+@@ -13466,7 +14019,7 @@ msgid "To _Hundredths"
+ msgstr "到百分点(_H)"
+ 
+ msgid "To _Int"
+-msgstr "到整点(_I)"
++msgstr "到整数(_I)"
+ 
+ msgid ""
+ "To generate a Mac family file, the current font must have plain (Normal, "
+@@ -13611,6 +14164,16 @@ msgstr "传统形式"
+ msgid "Traditional Name Forms"
+ msgstr "传统名称形式"
+ 
++msgid ""
++"Traditionally the x-height of an italic face is slightly less\n"
++"than the x-height of the companion roman"
++msgstr ""
++"传统上，斜体的x高度稍小于\n"
++"相应罗马体的x高度"
++
++msgid "Trailing Jamo Forms"
++msgstr "朝鲜谚文后缀形式"
++
+ msgid "Transform"
+ msgstr "变换"
+ 
+@@ -13823,6 +14386,10 @@ msgstr "未料到的密度数值"
+ msgid "Unexpected encoding format in cff: %d\n"
+ msgstr "未预期的编码格式于cff: %d\n"
+ 
++#, c-format
++msgid "Unexpected end of file in feature definition on line %d of %s"
++msgstr "%2$s 的第 %1$d 行的功能定义中出现意外的文件结尾"
++
+ #, c-format
+ msgid "Unexpected end of file in lookup definition on line %d of %s"
+ msgstr "%2$s 的第 %1$d 行的查找定义中的文件意外结束"
+@@ -13833,6 +14400,19 @@ msgstr "意外错误"
+ msgid "Unexpected number"
+ msgstr "不良数字"
+ 
++#, c-format
++msgid ""
++"Unexpected size for font info section of URW font (expected 12, got %d)\n"
++msgstr "错误的 URW 字体名称大小（应为 12，实际为 %d）\n"
++
++#, c-format
++msgid "Unexpected size for name section of URW font (expected 55, got %d)\n"
++msgstr "错误的 URW 字体名称大小（应为 55，实际为 %d）\n"
++
++#, c-format
++msgid "Unexpected token in GDEF on line %d of %s"
++msgstr "GDEF 中第 %d 行（共 %s）的意外标记"
++
+ #, c-format
+ msgid "Unexpected token in glyph class range on line %d of %s"
+ msgstr "在 第%d行（%s）上的字形类范围内有不该存在的字符"
+@@ -13845,6 +14425,14 @@ msgstr "第%d行(%s) 上的查找标记有未预期的字符"
+ msgid "Unexpected token in value record on line %d of %s"
+ msgstr "%2$s 的第 %1$d 行的值记录中出现意外标记"
+ 
++#, c-format
++msgid "Unexpected token, %s, in BASE table on line %d of %s"
++msgstr "BASE 表中的意外标记 %1$s，位于 %3$s 的第 %2$d 行"
++
++#, c-format
++msgid "Unexpected token, %s, in feature definition on line %d of %s"
++msgstr "%s 行 %d 上的功能定义中的意外标记 %s"
++
+ #, c-format
+ msgid "Unexpected token, %s, in lookup definition on line %d of %s"
+ msgstr "在 %3$s 的第 %2$d 行的查找定义中出现意外标记 %1$s"
+@@ -14022,6 +14610,12 @@ msgstr "无法解析的字形序列在 %2$s 的第 %1$d 行替换"
+ msgid "Unparseable include on line %d of %s"
+ msgstr "有不能解析的头文件处于行 %d (%s中)"
+ 
++#, c-format
++msgid ""
++"Unparsed characters found after end of groups file (last line parsed was "
++"%d).\n"
++msgstr "组文件末尾存在未解析的字符（被解析的最后一列为 %d）。\n"
++
+ msgid "Unreasonable DPI"
+ msgstr "不合理的DPI"
+ 
+@@ -14109,6 +14703,9 @@ msgstr ""
+ msgid "UseNewIndicScripts"
+ msgstr "使用新印地语文字"
+ 
++msgid "UsePlugins"
++msgstr "使用插件"
++
+ msgid "Using the OFL for your open fonts"
+ msgstr "在你的开源字体中使用 OFL"
+ 
+@@ -14373,6 +14970,9 @@ msgstr "警告未连接的参照"
+ msgid "Warning"
+ msgstr "警告"
+ 
++msgid "Warning: Contour start did not close\n"
++msgstr "警告：轮廓线开头未闭合\n"
++
+ #, c-format
+ msgid ""
+ "Warning: Encoding %d (0x%x) is mapped to at least two locations (%s@0x%02x "
+@@ -14416,7 +15016,7 @@ msgid "We don't understand this font\n"
+ msgstr "不识别此字体\n"
+ 
+ msgid "Weight, Width, Slope Only"
+-msgstr "仅粗细，宽度，斜度"
++msgstr "仅字重，宽度，斜率"
+ 
+ msgid "Welsh"
+ msgstr "威尔士语"
+@@ -14452,6 +15052,16 @@ msgstr ""
+ "若加载的 TrueType/OpenType 字体同时具有 Unicode 码表\n"
+ "和 CJK 码表，使用此标志来指明使用哪个码表来加载该字体。"
+ 
++msgid ""
++"When merging two CID keyed fonts, they must have the same Registry and "
++"Ordering, and the font being merged into (the mergee) must have a supplement "
++"which is at least as recent as the other's. Furthermore the mergee must have "
++"at least as many subfonts as the merger."
++msgstr ""
++"合并两个 CID 键控字体时，它们必须具有相同的注册表和排序，并且被合并到"
++"（mergee）中的字体必须有一个至少与另一个字体一样新的补充。 此外，合并后的子字"
++"体数量必须至少与合并后的子字体一样多。"
++
+ msgid ""
+ "When the mouse pointer is within this many pixels\n"
+ "of one of the various interesting features (baseline,\n"
+@@ -14555,6 +15165,9 @@ msgstr "回卷位置："
+ msgid "Write failed"
+ msgstr "不能写入"
+ 
++msgid "WritePNGInSFD"
++msgstr "SFD中写入PNG"
++
+ msgid "Wrong Direction"
+ msgstr "错误方向"
+ 
+@@ -14599,6 +15212,11 @@ msgstr "X高度:"
+ msgid "Xhosa"
+ msgstr "科萨语"
+ 
++#. GT: Y is a coordinate
++#. GT: Y is a coordinate, the leading spaces help to align it
++msgid "Y"
++msgstr "Y"
++
+ #. GT: an expression describing the transformation applied to the Y coordinate
+ msgid "Y Expr:"
+ msgstr "Y 表达式:"
+@@ -14619,11 +15237,14 @@ msgid "Yakut"
+ msgstr "雅库特语"
+ 
+ msgid "Yes"
+-msgstr "确定"
++msgstr "是"
+ 
+ msgid "Yes to _All"
+ msgstr "全是(_A)"
+ 
++msgid "Yes, and don't _remind me again"
++msgstr "是，并且不再提醒(_R)"
++
+ msgid "Yezidi"
+ msgstr "耶西迪文"
+ 
+@@ -14648,6 +15269,14 @@ msgstr "易经卦符"
+ msgid "Yoruba"
+ msgstr "约鲁巴语"
+ 
++#, c-format
++msgid ""
++"You are attempting to clear %.30s which is referred to by\n"
++"another character. Are you sure you want to clear it?"
++msgstr ""
++"您正尝试删除被其他字符引用的 %.30s 。\n"
++"确定要删除它吗？"
++
+ #, c-format
+ msgid ""
+ "You are attempting to paste a reference to %1$s into %2$s.\n"
+@@ -14774,6 +15403,11 @@ msgstr "需要指定模板"
+ msgid "You must specify a replacement glyph for %s"
+ msgstr "应为 %s 指定替换字形"
+ 
++msgid ""
++"You will get better instructions if you fill in the Private dictionary, "
++"Element->Font Info->Private, for the font"
++msgstr "如果您为字体填写私有字典，元素->字体信息->私有，您将获得更好的说明"
++
+ msgid ""
+ "Your font has exactly 65535 glyphs. Encoding 65535 is the limit and is often "
+ "used as a magic             value, so it may cause quirks.\n"
+@@ -14781,6 +15415,30 @@ msgstr ""
+ "您的字体塞满了 65535 个字形，达到了上限。这个值常会作为魔法数字，可能会引起程"
+ "序崩溃。\n"
+ 
++msgid ""
++"Your font is missing the dotlessi glyph,\n"
++"please add it and remake your accented glyphs"
++msgstr ""
++"您的字体缺少 无上句点i 字形，\n"
++"请添加它并重新制作你的重音字形"
++
++#. GT: Adobe decided that a dotless j glyph was needed, assigned a code
++#. GT: point to it in the private use area, and named it "dotlessj". Then
++#. GT: years later the Unicode people decided one was needed and assigned
++#. GT: it U+0237, so that's now the official code point and it is named
++#. GT: "uni0237". The name "dotlessj" is deprecated but still present in
++#. GT: many fonts. Neither "dotlessj" nor "uni0237" should be translated
++#. GT: because they are standard PostScript glyph names.
++#. GT: Again you may wish to explain that these refer to a "j" without a dot
++msgid ""
++"Your font is missing the uni0237 glyph,\n"
++"and the deprecated dotlessj glyph,\n"
++"please add the former and remake your accented glyphs"
++msgstr ""
++"您的字体缺少 uni0237 字形，\n"
++"和弃用的 无上句点j 字形，\n"
++"请添加前者并重新制作您的重音字形"
++
+ msgid "Z_oom out"
+ msgstr "缩小(_O)"
+ 
+@@ -14805,29 +15463,32 @@ msgstr "放大(_I)"
+ msgid "Zulu"
+ msgstr "祖鲁语"
+ 
++msgid "_128 pixel outline"
++msgstr "_128 像素轮廓"
++
+ msgid "_16x4 cell window"
+ msgstr "_16x4单元窗口"
+ 
+ msgid "_24 pixel outline"
+-msgstr "_24点轮廓"
++msgstr "_24 像素轮廓"
+ 
+ msgid "_36 pixel outline"
+-msgstr "_36点轮廓"
++msgstr "_36 像素轮廓"
+ 
+ msgid "_3D Rotate"
+ msgstr "3D旋转"
+ 
+ msgid "_48 pixel outline"
+-msgstr "_48点轮廓"
++msgstr "_48 像素轮廓"
+ 
+ msgid "_72 pixel outline"
+-msgstr "_72点轮廓"
++msgstr "_72 像素轮廓"
+ 
+ msgid "_8x2  cell window"
+ msgstr "_8x2单元窗口"
+ 
+ msgid "_96 pixel outline"
+-msgstr "_96点轮廓"
++msgstr "_96 像素轮廓"
+ 
+ msgid "_AA"
+ msgstr "抗锯齿(_A)"
+@@ -14865,6 +15526,10 @@ msgstr "添加选中项(_A)"
+ msgid "_Advance Width only"
+ msgstr "仅前导宽度(_A)"
+ 
++#. GT: Align these points to their average position
++msgid "_Align Points"
++msgstr "对齐点(_A)"
++
+ msgid "_All Fonts"
+ msgstr "所有字体(_A)"
+ 
+@@ -14929,6 +15594,9 @@ msgstr "BDF信息(_B)…"
+ msgid "_Back"
+ msgstr "背景(_B)"
+ 
++msgid "_Balance"
++msgstr "平衡(_B)"
++
+ msgid "_Base Filename:"
+ msgstr "文件名(_B):"
+ 
+@@ -14964,7 +15632,7 @@ msgid "_Browse"
+ msgstr "浏览(_B)"
+ 
+ msgid "_Build Accented Glyph"
+-msgstr "生成首饰字形(_B)"
++msgstr "生成带标字形(_B)"
+ 
+ msgid "_Build Syllables"
+ msgstr "生成音节(_B)"
+@@ -14993,6 +15661,9 @@ msgstr "改变附件(_C)…"
+ msgid "_Changed Glyphs"
+ msgstr "已改变字形(_C)"
+ 
++msgid "_Circular (Elliptical)"
++msgstr "圆（椭圆）(_C)"
++
+ msgid "_Class"
+ msgstr "类属(_C)"
+ 
+@@ -15006,7 +15677,7 @@ msgid "_Close"
+ msgstr "关闭(_C)"
+ 
+ msgid "_Cluster"
+-msgstr "簇(_C)"
++msgstr "簇集(_C)"
+ 
+ msgid "_Compact"
+ msgstr "压缩(_C)"
+@@ -15036,11 +15707,11 @@ msgid "_Copy"
+ msgstr "复制(_C)"
+ 
+ msgid "_Correct Direction"
+-msgstr "正确方向(_C)"
++msgstr "修正方向(_C)"
+ 
+ #. GT: Here (and following) MM means "MultiMaster"
+ msgid "_Create MM..."
+-msgstr "创建字体集(_C)…"
++msgstr "创建多母版(_C)…"
+ 
+ msgid "_Create Pair"
+ msgstr "创建配对(_C)"
+@@ -15103,7 +15774,7 @@ msgid "_Down"
+ msgstr "下(_D)"
+ 
+ msgid "_Earlier"
+-msgstr "早先(_E)"
++msgstr "提前(_E)"
+ 
+ msgid "_Edges near horizontal/vertical"
+ msgstr "边线临近水平线/垂直线(_E)"
+@@ -15142,7 +15813,10 @@ msgid "_Exclude"
+ msgstr "去除(_E)"
+ 
+ msgid "_Expand Stroke..."
+-msgstr "扩展重音符(_E)…"
++msgstr "扩展笔画(_E)…"
++
++msgid "_Extend Cap:"
++msgstr "延伸端头(_E):"
+ 
+ msgid "_Extrema"
+ msgstr "标记极值(_M)"
+@@ -15160,13 +15834,13 @@ msgid "_Fill"
+ msgstr "填充(_F)"
+ 
+ msgid "_Filter"
+-msgstr "过滤"
++msgstr "过滤(_F)"
+ 
+ msgid "_Find Intersections"
+ msgstr "寻找交叠(_F)"
+ 
+ msgid "_First"
+-msgstr "首先(_F)"
++msgstr "最前(_F)"
+ 
+ msgid "_First Point"
+ msgstr "第一点(_F)"
+@@ -15241,6 +15915,9 @@ msgstr "水平字干(_H)"
+ msgid "_HVCurve"
+ msgstr "水平垂直曲线(_H)"
+ 
++msgid "_Hangul"
++msgstr "谚文(_H)"
++
+ msgid "_Height:"
+ msgstr "高度(_H)："
+ 
+@@ -15257,7 +15934,7 @@ msgid "_Hinting Needed"
+ msgstr "所需的渲调(_H)"
+ 
+ msgid "_Hints controlling no points"
+-msgstr "渲调提示没有控制描点(_H)"
++msgstr "渲调调整未控制点(_H)"
+ 
+ msgid "_Histogram"
+ msgstr "直方图(_H)"
+@@ -15310,6 +15987,9 @@ msgstr "斜体(_I)..."
+ msgid "_Join"
+ msgstr "连接(_J)"
+ 
++msgid "_Join Limit:"
++msgstr "连接范围限制(_J):"
++
+ msgid "_Justification..."
+ msgstr "对齐(_J)..."
+ 
+@@ -15414,7 +16094,7 @@ msgid "_More points than:"
+ msgstr "点数超过(_M):"
+ 
+ msgid "_Move Points"
+-msgstr "移动描点(_M)"
++msgstr "移动点(_M)"
+ 
+ msgid "_Multi Size Glyph"
+ msgstr "多尺寸字形(_M)"
+@@ -15426,7 +16106,7 @@ msgid "_Name"
+ msgstr "名称(_N)"
+ 
+ msgid "_Name Contour"
+-msgstr "命名轮廓(_N)"
++msgstr "命名轮廓线(_N)"
+ 
+ msgid "_Name:"
+ msgstr "名称(_N):"
+@@ -15446,6 +16126,9 @@ msgstr "下一字形(_N)"
+ msgid "_Next Point"
+ msgstr "下一点(_N)"
+ 
++msgid "_Nib"
++msgstr "笔尖(_N)"
++
+ msgid "_No"
+ msgstr "否(_N)"
+ 
+@@ -15513,7 +16196,7 @@ msgid "_Paste"
+ msgstr "粘贴(_P)"
+ 
+ msgid "_Point"
+-msgstr "描点(_P)"
++msgstr "点(_P)"
+ 
+ msgid "_Point of View Projection..."
+ msgstr "投影视点(_P)…"
+@@ -15522,16 +16205,16 @@ msgid "_Pointer"
+ msgstr "指针(_P)"
+ 
+ msgid "_Points"
+-msgstr "描点(_P)"
++msgstr "点(_P)"
+ 
+ msgid "_Points near¹ hint edges"
+-msgstr "描点靠近¹渲调提示边缘(_P)"
++msgstr "靠近¹渲染调整边缘的点(_P)"
+ 
+ msgid "_Points too far"
+ msgstr "点太远"
+ 
+ msgid "_Pointsize Y:"
+-msgstr "网格大小(_P) Y轴："
++msgstr "点号 Y(_P)："
+ 
+ msgid "_Pointsize:"
+ msgstr "字号(_P)："
+@@ -15840,7 +16523,7 @@ msgid "_Weight"
+ msgstr "字重(_W)："
+ 
+ msgid "_Weight Class"
+-msgstr "粗细类属(_W)"
++msgstr "字重类别(_W)"
+ 
+ msgid "_Width"
+ msgstr "宽度(_W)"
+@@ -15860,6 +16543,9 @@ msgstr "线框(_W)"
+ msgid "_Wireframe..."
+ msgstr "线框(_W)..."
+ 
++msgid "_X"
++msgstr "_X"
++
+ msgid "_X Resource Editor..."
+ msgstr "_X 资源编辑器..."
+ 
+@@ -15873,7 +16559,10 @@ msgid "_X-Height"
+ msgstr "_X高度"
+ 
+ msgid "_X:"
+-msgstr "_X轴："
++msgstr "_X:"
++
++msgid "_Y"
++msgstr "_Y"
+ 
+ msgid "_Y near¹"
+ msgstr "_Y 临近¹"
+@@ -15893,6 +16582,12 @@ msgstr "上高属性表"
+ msgid "alternate subs"
+ msgstr "交换替代"
+ 
++msgid "as Len_gth"
++msgstr "作为长度(_G)"
++
++msgid "as _Length"
++msgstr "作为长度(_L)"
++
+ msgid "at position"
+ msgstr "在位置"
+ 
+@@ -16143,25 +16838,25 @@ msgid "positioning"
+ msgstr "定位"
+ 
+ msgid "problfixup|Bad Directions"
+-msgstr "不良方向"
++msgstr "problfixup|不良方向"
+ 
+ msgid "problfixup|Mark for Overlap fix before Save"
+-msgstr "保存前标记未连接的"
++msgstr "problfixup|标记重叠，保存前修复"
+ 
+ msgid "problfixup|Missing Extrema"
+-msgstr "缺少极点"
++msgstr "problfixup|缺少极点"
+ 
+ msgid "problfixup|Missing Extrema (cautiously)"
+-msgstr "缺极值"
++msgstr "problfixup|缺极值（谨慎）"
+ 
+ msgid "problfixup|Open Contours"
+-msgstr "轮廓开放"
++msgstr "problfixup|开放轮廓线"
+ 
+ msgid "problfixup|Self Intersections"
+-msgstr "自身相交"
++msgstr "problfixup|自相交"
+ 
+ msgid "problfixup|Too Many Points"
+-msgstr "过多点"
++msgstr "problfixup|点过多"
+ 
+ msgid "problselect|Bad Direction"
+ msgstr "方向错误"
+@@ -16170,10 +16865,10 @@ msgid "problselect|Errors"
+ msgstr "错误"
+ 
+ msgid "problselect|Missing Extrema"
+-msgstr "缺少极点"
++msgstr "problselect|缺极值"
+ 
+ msgid "problselect|Open Contours"
+-msgstr "轮廓开放"
++msgstr "problselect|开放轮廓线"
+ 
+ msgid "problselect|Self Intersections"
+ msgstr "自身相交"
+@@ -16235,7 +16930,7 @@ msgid "vertical origin table"
+ msgstr "垂直原点表"
+ 
+ msgid "weight"
+-msgstr "粗细"
++msgstr "字重"
+ 
+ #. GT: English uses "script" to mean a general writing system (latin, greek, kanji)
+ #. GT: and the cursive handwriting style. Here we mean the general writing system.
+@@ -16248,7 +16943,7 @@ msgstr "粗细"
+ #. GT: English uses "script" to me a general writing style (latin, greek, kanji)
+ #. GT: and the cursive handwriting style. Here we mean the general writing system.
+ msgid "writing system|Script"
+-msgstr "文字"
++msgstr "书写系统|文字"
+ 
+ #. GT: Short form of {Everything Else}, might use universal? U+2200
+ msgid "{All}"
+diff --git a/po/zh_TW.po b/po/zh_TW.po
+index 83139bb833..035bd61b79 100644
+--- a/po/zh_TW.po
++++ b/po/zh_TW.po
+@@ -13,8 +13,8 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: fontforge\n"
+ "Report-Msgid-Bugs-To: \n"
+-"POT-Creation-Date: 2022-12-31 02:48+0000\n"
+-"PO-Revision-Date: 2022-12-31 03:27\n"
++"POT-Creation-Date: 2023-12-30 03:08-0800\n"
++"PO-Revision-Date: 2023-12-30 08:15\n"
+ "Last-Translator: \n"
+ "Language-Team: Chinese Traditional\n"
+ "Language: zh_TW\n"
+@@ -2271,15 +2271,15 @@ msgstr "不當的連體字字圖。GID %d 未少於 %d\n"
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=2 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr ""
+ "不當的查找表格：格式=2 (%d/%d), 第一筆=%d 最末筆=%d 總計在字型=%d 中的字圖\n"
+ 
+ #, c-format
+ msgid ""
+-"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in font="
+-"%d\n"
++"Bad lookup table: format=4 (%d/%d), first=%d last=%d total glyphs in "
++"font=%d\n"
+ msgstr "不當的查找表：格式=4 (%d/%d)，首筆=%d 末筆=%d 字型中字圖總計=%d\n"
+ 
+ #, c-format
+@@ -19269,16 +19269,16 @@ msgstr "ΤεΧ 名稱"
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d ∆x_adv="
+-"%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
++"“%s” in %s did not contain a pairwise positioning lookup ∆x=%d ∆y=%d "
++"∆x_adv=%d ∆y_adv=%d to %s ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ msgstr ""
+-"“%s” 於 %s 中並未包含成對定位查找 ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d to %s ∆x="
+-"%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
++"“%s” 於 %s 中並未包含成對定位查找 ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d to %s "
++"∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ 
+ #, c-format
+ msgid ""
+-"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv="
+-"%d\n"
++"“%s” in %s did not contain a positioning lookup ∆x=%d ∆y=%d ∆x_adv=%d "
++"∆y_adv=%d\n"
+ msgstr "“%s” 於 %s 中並未包含定位查找 ∆x=%d ∆y=%d ∆x_adv=%d ∆y_adv=%d\n"
+ 
+ #, c-format

--- a/app-creativity/fontforge/spec
+++ b/app-creativity/fontforge/spec
@@ -1,4 +1,5 @@
 VER=20230101
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/fontforge/fontforge.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5807"


### PR DESCRIPTION
Topic Description
-----------------

- fontforge: fix FTBFS

Package(s) Affected
-------------------

- fontforge: 20230101-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fontforge
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
