### PR TITLE
sssd: update to 2.9.4

### DIFF
--- a/app-admin/sssd/autobuild/beyond
+++ b/app-admin/sssd/autobuild/beyond
@@ -1,4 +1,0 @@
-abinfo "Moving dbus system configuration to /usr"
-mkdir -vp "${PKGDIR}/usr/share/dbus-1/system.d/"
-mv -v "${PKGDIR}/etc/dbus-1/system.d/"*.conf "${PKGDIR}/usr/share/dbus-1/system.d"
-rm -rv "${PKGDIR}/etc/dbus-1"

--- a/app-admin/sssd/autobuild/defines
+++ b/app-admin/sssd/autobuild/defines
@@ -15,6 +15,9 @@ AUTOTOOLS_AFTER="--enable-pammoddir=/usr/lib/security \
                  --with-python3-bindings  \
                  --with-syslog=journald \
                  --with-autofs \
-                 --without-selinux  \
+                 --without-selinux \
+                 --with-oidc-child=no \
                  --without-semanage"
 ABSHADOW=0
+# FIXME: race condition upon make install
+NOPARALLEL=1

--- a/app-admin/sssd/autobuild/prepare
+++ b/app-admin/sssd/autobuild/prepare
@@ -2,7 +2,3 @@ abinfo "Arch Linux: Tweaking logrotate config (/var/run => /run) ..."
 sed -e 's#/var/run/#/run/#' \
     -i "$SRCDIR"/src/examples/logrotate
 
-abinfo "Arch Linux: Tweaking Makefile to install D-Bus policy files in /usr/share/dbus-1 ..."
-sed -e 's/^dbuspolicydir = $(sysconfdir)/dbuspolicydir = $(datadir)/' \
-    -i Makefile.in
-

--- a/app-admin/sssd/spec
+++ b/app-admin/sssd/spec
@@ -1,5 +1,4 @@
-VER=2.6.1
-SRCS="https://github.com/SSSD/sssd/releases/download/${VER}/sssd-$VER.tar.gz"
-CHKSUMS="sha256::81d41881d0d1f120717ea80e75daca357e40ccbd0d656eb9f99b5824d59e594d"
+VER=2.9.4
+SRCS="git::commit=tags/$VER::https://github.com/SSSD/sssd"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12810"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- sssd: update to 2.9.4

Package(s) Affected
-------------------

- sssd: 2.9.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit sssd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
