### PR TITLE
adaptivecpp: 24.02.0, new

### DIFF
--- a/app-devel/adaptivecpp/autobuild/defines
+++ b/app-devel/adaptivecpp/autobuild/defines
@@ -1,0 +1,17 @@
+PKGNAME=adaptivecpp
+PKGSEC=devel
+PKGDEP="boost gcc-runtime glibc llvm python-3"
+PKGDES="Compiler for C++-based heterogeneous programming models"
+
+BUILDDEP="boost llvm python-3"
+ABTYPE=cmakeninja
+CMAKE_AFTER=" \
+    -DACPP_CONFIG_FILE_GLOBAL_INSTALLATION=ON \
+    -DDEFAULT_TARGETS='omp.accelerated' \
+    -DWITH_ACCELERATED_CPU=ON \
+    -DWITH_CUDA_BACKEND=OFF \
+    -DWITH_LEVEL_ZERO_BACKEND=OFF \
+    -DWITH_OPENCL_BACKEND=OFF \
+    -DWITH_ROCM_BACKEND=OFF \
+    -DWITH_SSCP_COMPILER=OFF \
+"

--- a/app-devel/adaptivecpp/spec
+++ b/app-devel/adaptivecpp/spec
@@ -1,0 +1,4 @@
+VER=24.02.0
+SRCS="git::commit=tags/v${VER}::https://github.com/AdaptiveCpp/AdaptiveCpp.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=176075"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

adaptivecpp: 24.02.0, new

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

adaptivecpp: 24.02.0

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

```
#buildit adaptivecpp
```


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

Architectural progress for experimental ports does not impede on merging of this topic.

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
