### PR TITLE
xclock: update to 1.1.1

### DIFF
--- a/app-utils/xclock/spec
+++ b/app-utils/xclock/spec
@@ -1,5 +1,4 @@
-VER=1.0.9
-REL=1
-SRCS="tbl::https://ftp.x.org/pub/individual/app/xclock-$VER.tar.bz2"
-CHKSUMS="sha256::cf461fb2c6f2ac42c54d8429ee2010fdb9a1442a370adfbfe8a7bfaf33c123bb"
+VER=1.1.1
+SRCS="tbl::https://ftp.x.org/pub/individual/app/xclock-$VER.tar.xz"
+CHKSUMS="sha256::df7ceabf8f07044a2fde4924d794554996811640a45de40cb12c2cf1f90f742c"
 CHKUPDATE="anitya::id=15032"


### PR DESCRIPTION
Topic Description
-----------------

- xclock: update to 1.1.1

Package(s) Affected
-------------------

- xclock: 1.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xclock
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
