### PR TITLE
freecad: update to 0.21.2

### DIFF
--- a/app-creativity/freecad/spec
+++ b/app-creativity/freecad/spec
@@ -1,5 +1,4 @@
-VER=0.21.1
-REL=2
+VER=0.21.2
 SRCS="git::commit=tags/${VER};copy-repo=true::https://github.com/FreeCAD/FreeCAD"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=836"


### PR DESCRIPTION
Topic Description
-----------------

- freecad: update to 21.2
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- freecad: 0.21.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit freecad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
