### PR TITLE
sysstat: update to 12.7.5

### DIFF
--- a/app-utils/sysstat/autobuild/defines
+++ b/app-utils/sysstat/autobuild/defines
@@ -6,5 +6,7 @@ PKGDES="Performance monitoring tools for Linux"
 
 AUTOTOOLS_AFTER="--mandir=/usr/share/man \
                  --enable-install-cron \
-                 --enable-copy-only"
+                 --enable-copy-only \
+                 --disable-stripping \
+                 sa_lib_dir=/usr/lib/sadc"
 ABSHADOW=0

--- a/app-utils/sysstat/spec
+++ b/app-utils/sysstat/spec
@@ -1,4 +1,4 @@
-VER=12.5.3
-SRCS="tbl::https://github.com/sysstat/sysstat/archive/v$VER.tar.gz"
-CHKSUMS="sha256::49fa6e4ce4994186d34f20cad43032be411d3f98244cbd8c3d3c480c3a4535bc"
+VER=12.7.5
+SRCS="git::commit=tags/v${VER}::https://github.com/sysstat/sysstat.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4931"


### PR DESCRIPTION
Topic Description
-----------------

- sysstat: update to 12.7.5
    - Fixed internal executables wrongly placed at /usr/lib64.
    - Added an option to preserve debug symbols to allow them to be stripped
    out by ab.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- sysstat: 12.7.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit sysstat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
