### PR TITLE
sunshine: update to 0.23.0

### DIFF
--- a/app-multimedia/sunshine/autobuild/defines
+++ b/app-multimedia/sunshine/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=sunshine
 PKGDES="A Gamestream host for Moonlight"
 PKGSEC=video
-PKGDEP="pulseaudio libdrm libevdev icu wayland openssl ffmpeg"
+PKGDEP="pulseaudio libdrm libevdev icu wayland openssl ffmpeg miniupnpc \
+        libnotify libappindicator"
 PKGRECOM="avahi"
 BUILDDEP="nodejs"
 
@@ -16,4 +17,4 @@ CMAKE_AFTER="-DSUNSHINE_ENABLE_CUDA=OFF \
              -DSUNSHINE_ASSETS_DIR=share/sunshine"
 
 # FIXME: Links against bundled FFmpeg binaries.
-FAIL_ARCH="!(amd64|arm64)"
+FAIL_ARCH="!(amd64|arm64|ppc64el)"

--- a/app-multimedia/sunshine/spec
+++ b/app-multimedia/sunshine/spec
@@ -1,5 +1,4 @@
-VER=0.20.0
-REL=1
-SRCS="git::commit=tags/v${VER}::https://github.com/LizardByte/Sunshine"
+VER=0.23.0
+SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/LizardByte/Sunshine"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236300"


### PR DESCRIPTION
Topic Description
-----------------

- sunshine: update to 0.23.0

Package(s) Affected
-------------------

- sunshine: 0.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sunshine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
