### PR TITLE
mesa (Mesa 3D Library): enable xe kernel module support for all architectures

### DIFF
--- a/runtime-display/mesa/autobuild/defines
+++ b/runtime-display/mesa/autobuild/defines
@@ -59,7 +59,8 @@ MESON_AFTER="-Ddri-drivers-path=/usr/lib/xorg/modules/dri \
              -Dosmesa=true \
              -Dshared-glapi=enabled \
              -Dvalgrind=enabled \
-             -Dvideo-codecs=vc1dec,h264dec,h264enc,h265dec,h265enc"
+             -Dvideo-codecs=vc1dec,h264dec,h264enc,h265dec,h265enc \
+             -Dintel-xe-kmd=enabled"
 
 MESON_AFTER__X86=" \
              ${MESON_AFTER} \
@@ -69,13 +70,11 @@ MESON_AFTER__X86=" \
 MESON_AFTER__ARM=" \
              ${MESON_AFTER} \
              -Dgallium-drivers=r300,r600,radeonsi,nouveau,iris,virgl,swrast,kmsro,lima,panfrost,freedreno,tegra,vc4,v3d,etnaviv,d3d12,zink,asahi \
-             -Dvulkan-drivers=amd,intel,broadcom,freedreno,panfrost,swrast,virtio \
-             -Dintel-xe-kmd=enabled"
+             -Dvulkan-drivers=amd,intel,broadcom,freedreno,panfrost,swrast,virtio"
 MESON_AFTER__OTHER=" \
              ${MESON_AFTER} \
              -Dgallium-drivers=r300,r600,radeonsi,nouveau,iris,virgl,swrast,zink \
-             -Dvulkan-drivers=amd,intel,swrast,virtio \
-             -Dintel-xe-kmd=enabled"
+             -Dvulkan-drivers=amd,intel,swrast,virtio"
 
 MESON_AFTER__AMD64=" \
              ${MESON_AFTER__X86} \

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,7 +1,7 @@
 MESA_VER=24.0.4
 DXHEADERS_VER=1.611.0
 VER=${MESA_VER}+dxheaders${DXHEADERS_VER}
-REL=1
+REL=2
 SRCS="tbl::https://archive.mesa3d.org/mesa-${MESA_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
 CHKSUMS="sha256::90febd30a098cbcd97ff62ecc3dcf5c93d76f7fa314de944cfce81951ba745f0 \


### PR DESCRIPTION
Topic Description
-----------------

- mesa: enable xe kernel module support for all architectures

Package(s) Affected
-------------------

- mesa: 1:24.0.4+dxheaders1.611.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
