### PR TITLE
qemu (QEMU): update to 8.2.2

### DIFF
--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,9 +1,8 @@
-VER=8.2.0
-REL=1
+VER=8.2.2
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz \
       file::use-url-name=true::https://github.com/loongson/Firmware/raw/main/LoongArchVirtMachine/edk2-loongarch64-code.fd \
       file::use-url-name=true::https://github.com/loongson/Firmware/raw/main/LoongArchVirtMachine/edk2-loongarch64-vars.fd"
-CHKSUMS="sha256::bf00d2fa12010df8b0ade93371def58e632cb32a6bfdc5f5a0ff8e6a1fb1bf32 \
+CHKSUMS="sha256::847346c1b82c1a54b2c38f6edbd85549edeb17430b7d4d3da12620e2962bc4f3 \
          sha256::71d329de60a0fd0fd6672c7f9be9ea79394ea51c4e650e1df8895202c1367037 \
          sha256::adbfcb31d6470ef090220baeb53559e26323b6cfb5e7614f879e89608a3ed748"
 CHKUPDATE="anitya::id=13607"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: update to 8.2.2
    Migrate to systemd-sysusers.

Package(s) Affected
-------------------

- qemu-aarch64-static: 8.2.2
- qemu-alpha-static: 8.2.2
- qemu-arm-static: 8.2.2
- qemu-armeb-static: 8.2.2
- qemu-cris-static: 8.2.2
- qemu-i386-static: 8.2.2
- qemu-loongarch64-static: 8.2.2
- qemu-m68k-static: 8.2.2
- qemu-microblaze-static: 8.2.2
- qemu-microblazeel-static: 8.2.2
- qemu-mips-static: 8.2.2
- qemu-mips64-static: 8.2.2
- qemu-mips64el-static: 8.2.2
- qemu-mipsel-static: 8.2.2
- qemu-mipsn32-static: 8.2.2
- qemu-mipsn32el-static: 8.2.2
- qemu-nios2-static: 8.2.2
- qemu-or32-static: 8.2.2
- qemu-ppc-static: 8.2.2
- qemu-ppc64-static: 8.2.2
- qemu-ppc64le-static: 8.2.2
- qemu-riscv32-static: 8.2.2
- qemu-riscv64-static: 8.2.2
- qemu-s390x-static: 8.2.2
- qemu-sh4-static: 8.2.2
- qemu-sh4eb-static: 8.2.2
- qemu-sparc-static: 8.2.2
- qemu-sparc32plus-static: 8.2.2
- qemu-sparc64-static: 8.2.2
- qemu-user-static: 8.2.2
- qemu-x86-64-static: 8.2.2
- qemu: 8.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
