### PR TITLE
linux-firmware (Linux Firmware): update to 20240115+debian20230210-5~bpo11+1

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,8 +1,8 @@
 DEBIANVER=20230210-5~bpo11+1
-VER=20240115+debian${DEBIANVER/-/+}
+VER=20240405+debian${DEBIANVER/-/+}
 # When using a stable tag.
 # SRCS="git::commit=tags/${VER%%+debian*}::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
-SRCS="git::commit=tags/${VER%%+debian*}::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
+SRCS="git::commit=2180c887de244e846662fa2d0057783a6fa489b4::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/292e1e5b5bc5756e9314ea6d494d561422d23264/rkwifi/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20240115+debian20230210-5~bpo11+1

Package(s) Affected
-------------------

- firmware-free: 20240405+debian20230210+5~bpo11+1
- firmware-nonfree: 20240405+debian20230210+5~bpo11+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
