### PR TITLE
xterm: update to 390

### DIFF
--- a/app-utils/xterm/spec
+++ b/app-utils/xterm/spec
@@ -1,4 +1,4 @@
-VER=375
+VER=390
 SRCS="tbl::https://invisible-mirror.net/archives/xterm/xterm-$VER.tgz"
-CHKSUMS="sha256::302c59a2bf81e79c6a701525d778161a218d1239f21568d89e2bdd31c015217f"
+CHKSUMS="sha256::75117c3cc5174a09c425ef106e69404d72f5ef05e03a5da00aaf15792d6f9c0f"
 CHKUPDATE="anitya::id=5272"


### PR DESCRIPTION
Topic Description
-----------------

- xterm: update to 390

Package(s) Affected
-------------------

- xterm: 390

Security Update?
----------------

No

Build Order
-----------

```
#buildit xterm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
