### PR TITLE
xfe: update to 1.46.1

### DIFF
--- a/app-utils/xfe/spec
+++ b/app-utils/xfe/spec
@@ -1,5 +1,4 @@
-VER=1.43.2
-REL=2
-SRCS="tbl::https://downloads.sourceforge.net/sourceforge/xfe/xfe-$VER.tar.gz"
-CHKSUMS="sha256::fa5f38fcac64b91eb5d615620a9607b7e6f8675c4f19f30473798b2acb0c85ba"
+VER=1.46.1
+SRCS="tbl::https://sourceforge.net/projects/xfe/files/xfe/1.46.1/xfe-$VER.tar.xz"
+CHKSUMS="sha256::353a68c190a5e0e4d6acadadc61edfeedf56c4645d7ccd0cdca2321eade72548"
 CHKUPDATE="anitya::id=8278"


### PR DESCRIPTION
Topic Description
-----------------

- xfe: update to 1.46.1

Package(s) Affected
-------------------

- xfe: 1.46.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xfe
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
