### PR TITLE
xdotool: update to 3.20211022.1

### DIFF
--- a/app-utils/xdotool/spec
+++ b/app-utils/xdotool/spec
@@ -1,4 +1,4 @@
-VER=3.20160805.1
-SRCS="tbl::https://github.com/jordansissel/xdotool/releases/download/v$VER/xdotool-$VER.tar.gz"
-CHKSUMS="sha256::35be5ff6edf0c620a0e16f09ea5e101d5173280161772fca18657d83f20fcca8"
+VER=3.20211022.1
+SRCS="git::commit=tags/v$VER::https://github.com/jordansissel/xdotool"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8648"


### PR DESCRIPTION
Topic Description
-----------------

- xdotool: update to 3.20211022.1

Package(s) Affected
-------------------

- xdotool: 3.20211022.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdotool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
