### PR TITLE
cups-pdf (PDF Driver for CUPS): fix build

### DIFF
--- a/runtime-doc/cups-pdf/autobuild/build
+++ b/runtime-doc/cups-pdf/autobuild/build
@@ -1,9 +1,18 @@
-cd src
-gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -lcups -Wall -o cups-pdf cups-pdf.c
-install -D -m700 cups-pdf "$PKGDIR"/usr/lib/cups/backend/cups-pdf
+abinfo "Building cups-pdf ..."
+gcc \
+    ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} \
+    -o "$SRCDIR"/cups-pdf \
+    "$SRCDIR"/src/cups-pdf.c \
+    -lcups -Wall
 
-cd ../extra
-install -D -m644 CUPS-PDF.ppd "$PKGDIR"/usr/share/cups/model/CUPS-PDF.ppd
-install -D -m644 cups-pdf.conf "$PKGDIR"/etc/cups/cups-pdf.conf
-chgrp -R lp "$PKGDIR"/etc/cups
-cd ..
+abinfo "Installing cups-pdf ..."
+install -Dvm700 "$SRCDIR"/cups-pdf \
+    "$PKGDIR"/usr/lib/cups/backend/cups-pdf
+
+abinfo "Installing PPD ..."
+install -Dvm644 "$SRCDIR"/extra/CUPS-PDF_{no,}opt.ppd \
+    -t "$PKGDIR"/usr/share/cups/model/
+
+abinfo "Installing configuration file ..."
+install -Dvm644 "$SRCDIR"/extra/cups-pdf.conf \
+    "$PKGDIR"/etc/cups/cups-pdf.conf

--- a/runtime-doc/cups-pdf/autobuild/defines
+++ b/runtime-doc/cups-pdf/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=cups-pdf
 PKGSEC=libs
 PKGDEP="cups ghostscript"
-PKGDES="PDF printer for CUPS"
+PKGDES="PDF printer driver for CUPS"
 
 PKGEPOCH=1

--- a/runtime-doc/cups-pdf/autobuild/patches/0001-Fedora-feat-cups-pdf.c-use-document-title-where-poss.patch
+++ b/runtime-doc/cups-pdf/autobuild/patches/0001-Fedora-feat-cups-pdf.c-use-document-title-where-poss.patch
@@ -1,0 +1,46 @@
+From b4396b8fc0a01b88496392df25d1852970877849 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 25 Apr 2024 01:10:22 -0700
+Subject: [PATCH 1/4] [Fedora] feat(cups-pdf.c): use document title where
+ possible
+
+---
+ src/cups-pdf.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/src/cups-pdf.c b/src/cups-pdf.c
+index 4c814d7..2068f9d 100644
+--- a/src/cups-pdf.c
++++ b/src/cups-pdf.c
+@@ -651,6 +651,13 @@ static int preparetitle(char *title) {
+       title[strlen(title)-1]='\0';
+       memmove(title, title+1, strlen(title));
+     }
++    cut=strchr(title, '\r');
++    if (!cut)
++      cut=strchr(title, '\n');
++    if (cut) {
++      *cut = 0;
++      log_event(CPDEBUG, "removing newlines from title", title);
++    }
+   }
+   cut=strrchr(title, '/');
+   if (cut != NULL) {
+@@ -740,11 +747,13 @@ static int preparespoolfile(FILE *fpsrc, char *spoolfile, char *title, char *cmd
+   (void) fputs(buffer, fpdest);
+   while (fgets2(buffer, BUFSIZE, fpsrc) != NULL) {
+     (void) fputs(buffer, fpdest);
+-    if (!is_title && !rec_depth)
++    if (!is_title && !rec_depth) {
++      memset(title, 0, BUFSIZE);
+       if (sscanf(buffer, "%%%%Title: %"TBUFSIZE"c", title)==1) {
+         log_event(CPDEBUG, "found title in ps code: %s", title);
+         is_title=1;
+       }
++    }
+     if (!strncmp(buffer, "%!", 2)) {
+       log_event(CPDEBUG, "found embedded (e)ps code: %s", buffer);
+       rec_depth++;
+-- 
+2.44.0
+

--- a/runtime-doc/cups-pdf/autobuild/patches/0002-feat-cups-pdf.c-implement-error-reporting.patch
+++ b/runtime-doc/cups-pdf/autobuild/patches/0002-feat-cups-pdf.c-implement-error-reporting.patch
@@ -1,0 +1,58 @@
+From c86bae104f1c2010ea54cf19a8a0ed65aab4a43b Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 25 Apr 2024 00:58:00 -0700
+Subject: [PATCH 2/4] feat(cups-pdf.c): implement error reporting
+
+---
+ src/cups-pdf.c | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/src/cups-pdf.c b/src/cups-pdf.c
+index 2068f9d..a0b8547 100644
+--- a/src/cups-pdf.c
++++ b/src/cups-pdf.c
+@@ -830,6 +830,7 @@ int main(int argc, char *argv[]) {
+   gid_t *groups;
+   int ngroups;
+   pid_t pid;
++  struct stat statout;
+ 
+   if (setuid(0)) {
+     (void) fputs("CUPS-PDF cannot be called without root privileges!\n", stderr);
+@@ -1059,7 +1060,11 @@ int main(int argc, char *argv[]) {
+      
+     (void) umask(0077);
+     size=system(gscall);
+-    log_event(CPDEBUG, "ghostscript has finished: %d", size);
++    if (size)
++      log_event(CPERROR, "ghostscript reported an error", size);
++    else
++      log_event(CPDEBUG, "ghostscript succeeded", NULL);
++
+     if (chmod(outfile, mode))
+       log_event(CPERROR, "failed to set file mode for PDF file: %s (non fatal)", outfile);
+     else
+@@ -1092,6 +1097,11 @@ int main(int argc, char *argv[]) {
+   else 
+     log_event(CPDEBUG, "spoolfile unlinked: %s", spoolfile);
+ 
++  if (stat(outfile, &statout) || statout.st_size==0)
++    log_event(CPSTATUS, "PDF creation failed", NULL);
++  else
++    log_event(CPSTATUS, "PDF creation successfully finished", outfile);
++
+   free(groups);
+   free(dirname);
+   free(spoolfile);
+@@ -1100,8 +1110,6 @@ int main(int argc, char *argv[]) {
+   
+   log_event(CPDEBUG, "all memory has been freed");
+ 
+-  log_event(CPSTATUS, "PDF creation successfully finished for %s", passwd->pw_name);
+-
+   if (logfp!=NULL)
+     (void) fclose(logfp);
+   return 0;
+-- 
+2.44.0
+

--- a/runtime-doc/cups-pdf/autobuild/patches/0003-fix-make-cups-pdf-compatible-with-Ghostscript-9.54.patch
+++ b/runtime-doc/cups-pdf/autobuild/patches/0003-fix-make-cups-pdf-compatible-with-Ghostscript-9.54.patch
@@ -1,0 +1,42 @@
+From ecba73184a96c2e9988d1e5279fe61e3966b47dd Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 25 Apr 2024 01:00:03 -0700
+Subject: [PATCH 3/4] fix: make cups-pdf compatible with Ghostscript >= 9.54
+
+---
+ extra/cups-pdf.conf | 4 ++--
+ src/cups-pdf.h      | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/extra/cups-pdf.conf b/extra/cups-pdf.conf
+index 7f90fec..eb568c7 100644
+--- a/extra/cups-pdf.conf
++++ b/extra/cups-pdf.conf
+@@ -250,9 +250,9 @@
+ ### Key: GSCall (config)
+ ## command line for calling GhostScript (!!! DO NOT USE NEWLINES !!!)
+ ## MacOSX: for using pstopdf set this to %s %s -o %s %s
+-### Default: %s -q -dCompatibilityLevel=%s -dNOPAUSE -dBATCH -dSAFER -sDEVICE=pdfwrite -sOutputFile="%s" -dAutoRotatePages=/PageByPage -dAutoFilterColorImages=false -dColorImageFilter=/FlateEncode -dPDFSETTINGS=/prepress -c .setpdfwrite -f %s
++### Default: %s -q -dCompatibilityLevel=%s -dNOPAUSE -dBATCH -dSAFER -sDEVICE=pdfwrite -sOutputFile="%s" -dAutoRotatePages=/PageByPage -dAutoFilterColorImages=false -dColorImageFilter=/FlateEncode -dPDFSETTINGS=/prepress -c -f %s
+ 
+-#GSCall %s -q -dCompatibilityLevel=%s -dNOPAUSE -dBATCH -dSAFER -sDEVICE=pdfwrite -sOutputFile="%s" -dAutoRotatePages=/PageByPage -dAutoFilterColorImages=false -dColorImageFilter=/FlateEncode -dPDFSETTINGS=/prepress -c .setpdfwrite -f %s
++#GSCall %s -q -dCompatibilityLevel=%s -dNOPAUSE -dBATCH -dSAFER -sDEVICE=pdfwrite -sOutputFile="%s" -dAutoRotatePages=/PageByPage -dAutoFilterColorImages=false -dColorImageFilter=/FlateEncode -dPDFSETTINGS=/prepress -c -f %s
+ 
+ ### Key: PDFVer (config, ppd, lptopions)
+ ##  PDF version to be created - can be "1.5", "1.4", "1.3" or "1.2" 
+diff --git a/src/cups-pdf.h b/src/cups-pdf.h
+index 2782b44..f6aca62 100644
+--- a/src/cups-pdf.h
++++ b/src/cups-pdf.h
+@@ -58,7 +58,7 @@ struct {
+   { "AnonDirName", SEC_CONF|SEC_PPD, { "/var/spool/cups-pdf/ANONYMOUS" } },
+   { "AnonUser", SEC_CONF|SEC_PPD, { "nobody" } },
+   { "GhostScript", SEC_CONF|SEC_PPD, { "/usr/bin/gs" } },
+-  { "GSCall", SEC_CONF|SEC_PPD, { "%s -q -dCompatibilityLevel=%s -dNOPAUSE -dBATCH -dSAFER -sDEVICE=pdfwrite -sOutputFile=\"%s\" -dAutoRotatePages=/PageByPage -dAutoFilterColorImages=false -dColorImageFilter=/FlateEncode -dPDFSETTINGS=/prepress -c .setpdfwrite -f %s" } },
++  { "GSCall", SEC_CONF|SEC_PPD, { "%s -q -dCompatibilityLevel=%s -dNOPAUSE -dBATCH -dSAFER -sDEVICE=pdfwrite -sOutputFile=\"%s\" -dAutoRotatePages=/PageByPage -dAutoFilterColorImages=false -dColorImageFilter=/FlateEncode -dPDFSETTINGS=/prepress -c -f %s" } },
+   { "Grp", SEC_CONF|SEC_PPD, { "lp" } },
+   { "GSTmp", SEC_CONF|SEC_PPD, { "TMPDIR=/var/tmp" } },
+   { "Log", SEC_CONF|SEC_PPD, { "/var/log/cups" } },
+-- 
+2.44.0
+

--- a/runtime-doc/cups-pdf/autobuild/patches/0004-fix-cups-pdf.conf-output-PDFs-to-a-more-convenient-l.patch
+++ b/runtime-doc/cups-pdf/autobuild/patches/0004-fix-cups-pdf.conf-output-PDFs-to-a-more-convenient-l.patch
@@ -1,0 +1,27 @@
+From 343fa95f20146aa07d8e8ca8fa1447bc3d42b482 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 25 Apr 2024 01:17:33 -0700
+Subject: [PATCH 4/4] fix(cups-pdf.conf): output PDFs to a more convenient
+ location
+
+Follow Debian and output all "printed" PDFs to $HOME/PDF.
+---
+ extra/cups-pdf.conf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/extra/cups-pdf.conf b/extra/cups-pdf.conf
+index eb568c7..c7dc3d2 100644
+--- a/extra/cups-pdf.conf
++++ b/extra/cups-pdf.conf
+@@ -48,7 +48,7 @@
+ ##  root_squash! 
+ ### Default: /var/spool/cups-pdf/${USER}
+ 
+-#Out /var/spool/cups-pdf/${USER}
++Out ${HOME}/PDF
+ 
+ ### Key: AnonDirName (config)
+ ##  ABSOLUTE path for anonymously created PDF files
+-- 
+2.44.0
+

--- a/runtime-doc/cups-pdf/spec
+++ b/runtime-doc/cups-pdf/spec
@@ -1,4 +1,5 @@
 VER=3.0.1
+REL=1
 SRCS="tbl::https://www.cups-pdf.de/src/cups-pdf_$VER.tar.gz"
 CHKSUMS="sha256::738669edff7f1469fe5e411202d87f93ba25b45f332a623fb607d49c59aa9531"
 CHKUPDATE="anitya::id=17498"


### PR DESCRIPTION
Topic Description
-----------------

- cups-pdf: fix build
    - Track patches at AOSC-Tracking/cups-pdf @ aosc/v3.0.1.
    - Print PDFs to $HOME/PDF.
    - (Gentoo) Fix compatibility with Ghostscript >= 9.54.
    - (Fedora) Improve error output.
    - (Fedora) Print using the file name or document title where possible.
    - Lint scripts in accordance with the Styling Manual.

Package(s) Affected
-------------------

- cups-pdf: 1:3.0.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cups-pdf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
