### PR TITLE
xpra: update to 5.0.8

### DIFF
--- a/app-network/xpra/autobuild/conffiles
+++ b/app-network/xpra/autobuild/conffiles
@@ -6,7 +6,7 @@
 /etc/xpra/conf.d/12_ssl.conf
 /etc/xpra/conf.d/15_file_transfers.conf
 /etc/xpra/conf.d/16_printing.conf
-/etc/xpra/conf.d/20_sound.conf
+/etc/xpra/conf.d/20_audio.conf
 /etc/xpra/conf.d/30_picture.conf
 /etc/xpra/conf.d/35_webcam.conf
 /etc/xpra/conf.d/40_client.conf

--- a/app-network/xpra/autobuild/patches/0001-disable-doc-generation-by-default.patch
+++ b/app-network/xpra/autobuild/patches/0001-disable-doc-generation-by-default.patch
@@ -1,12 +1,12 @@
 diff -Naur xpra-4.2.2/setup.py xpra-4.2.2.no-default-doc/setup.py
 --- xpra-4.2.2/setup.py	2021-08-09 11:39:02.000000000 -0500
 +++ xpra-4.2.2.no-default-doc/setup.py	2021-08-21 13:50:41.314329243 -0500
-@@ -202,7 +202,7 @@
- example_ENABLED         = DEFAULT
+@@ -297,7 +297,7 @@
+ win32_tools_ENABLED     = WIN32 and DEFAULT
  
  #Cython / gcc / packaging build options:
 -docs_ENABLED            = DEFAULT
 +docs_ENABLED            = False
+ pandoc_lua_ENABLED      = DEFAULT
  annotate_ENABLED        = DEFAULT
  warn_ENABLED            = True
- strict_ENABLED          = True

--- a/app-network/xpra/spec
+++ b/app-network/xpra/spec
@@ -1,4 +1,4 @@
-VER=4.3
-SRCS="tbl::https://github.com/Xpra-org/xpra/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::d9ec407a514e0dba650196b90103eb47ec9c6b09acefc1ab71bbd3e9d6663c10"
+VER=5.0.8
+SRCS="git::commit=tags/v$VER::https://github.com/Xpra-org/xpra"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5445"


### PR DESCRIPTION
Topic Description
-----------------

- xpra: update to 5.0.8

Package(s) Affected
-------------------

- xpra: 5.0.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit xpra
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
