### PR TITLE
x265: update to 3.6

### DIFF
--- a/app-creativity/avidemux/spec
+++ b/app-creativity/avidemux/spec
@@ -1,4 +1,5 @@
 VER=2.8.1
+REL=1
 SRCS="tbl::https://downloads.sourceforge.net/avidemux/avidemux_$VER.tar.gz \
       file::rename=binutils.patch::https://github.com/FFmpeg/FFmpeg/commit/effadce6.patch"
 CHKSUMS="sha256::77d9bdca8683ce57c192b69d207cfab7cf92a7759ce0f63fa37b5c8e42ad3da2 \

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=4.4.4
-REL=3
+REL=4
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::e80b380d595c809060f66f96a5d849511ef4a76a26b76eacf5778b94c3570309"
 CHKUPDATE="anitya::id=5405"

--- a/app-multimedia/vlc/spec
+++ b/app-multimedia/vlc/spec
@@ -1,5 +1,5 @@
 VER=3.0.20
-REL=3
+REL=4
 SRCS="tbl::https://get.videolan.org/vlc/$VER/vlc-$VER.tar.xz"
 CHKSUMS="sha256::adc7285b4d2721cddf40eb5270cada2aaa10a334cb546fd55a06353447ba29b5"
 CHKUPDATE="anitya::id=6504"

--- a/app-network/xpra/spec
+++ b/app-network/xpra/spec
@@ -1,4 +1,5 @@
 VER=5.0.8
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/Xpra-org/xpra"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5445"

--- a/runtime-imaging/libheif/spec
+++ b/runtime-imaging/libheif/spec
@@ -1,5 +1,5 @@
 VER=1.17.6
-REL=1
+REL=2
 SRCS="tbl::https://github.com/strukturag/libheif/releases/download/v${VER}/libheif-${VER}.tar.gz"
 CHKSUMS="sha256::8390baf4913eda0a183e132cec62b875fb2ef507ced5ddddc98dfd2f17780aee"
 CHKUPDATE="anitya::id=64439"

--- a/runtime-multimedia/gstreamer/autobuild/defines
+++ b/runtime-multimedia/gstreamer/autobuild/defines
@@ -11,7 +11,7 @@ PKGDEP="a52dec aalib bluez bzip2 cairo cdparanoia chromaprint elfutils faac \
         mpg123 neon nettle openal-soft opencore-amr openh264 opus orc \
         pulseaudio pygobject-3 qrencode rtmpdump sbc sdl2 soundtouch \
         spandsp srtp taglib twolame v4l-utils wavpack wayland \
-        webrtc-audio-processing wildmidi x264 zbar zlib zvbi zxing-cpp \
+        webrtc-audio-processing wildmidi x264 x265 zbar zlib zvbi zxing-cpp \
         dssim-c openjpeg"
 # Rust-only dependencies.
 PKGDEP__RUST="rav1e"

--- a/runtime-multimedia/gstreamer/autobuild/defines.stage2
+++ b/runtime-multimedia/gstreamer/autobuild/defines.stage2
@@ -11,7 +11,7 @@ PKGDEP="a52dec aalib bluez bzip2 cairo cdparanoia chromaprint elfutils faac \
         mpg123 neon nettle openal-soft opencore-amr openh264 opus orc \
         pulseaudio pygobject-3 qrencode rtmpdump sbc sdl2 soundtouch \
         spandsp srtp taglib twolame v4l-utils wavpack wayland \
-        webrtc-audio-processing wildmidi x264 zbar zlib zvbi zxing-cpp dssim-c"
+        webrtc-audio-processing wildmidi x264 x265 zbar zlib zvbi zxing-cpp dssim-c"
 PKGDEP__AMD64="${PKGDEP} openmpt svt-hevc"
 PKGDEP__ARM64="${PKGDEP} openmpt"
 PKGDEP__LOONGSON3="${PKGDEP}"

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,5 @@
 VER=1.22.0
-REL=5
+REL=6
 SRCS="tbl::https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/$VER/gstreamer-$VER.tar.gz"
 CHKSUMS="sha256::5de8dcf5cc1ae26b3177b7dddbea7943e376cd5ca35d4cb7b43616e6d30b1854"
 CHKUPDATE="anitya::id=1263"

--- a/runtime-multimedia/x265/autobuild/build
+++ b/runtime-multimedia/x265/autobuild/build
@@ -2,14 +2,17 @@ mkdir build{-10,-12}
 
 # High bit-depth support adapted from Arch Linux,
 # limited to x86_64 (amd64).
-if [[ "${CROSS:-$ARCH}" != "amd64" ]]; then
+if ! ab_match_arch amd64; then
 	cd build
-	cmake ../source ${CMAKE_DEF} ${CMAKE_AFTER}
+	cmake ../source ${CMAKE_DEF[@]} \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DENABLE_SHARED=TRUE \
+                ${CMAKE_AFTER}
 	make
 	make install DESTDIR="$PKGDIR"
 else
 	cd build-12
-	cmake ../source \
+	cmake ../source ${CMAKE_DEF[@]} \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DHIGH_BIT_DEPTH=TRUE \
 		-DMAIN12=TRUE \
@@ -18,23 +21,23 @@ else
 		-DENABLE_SHARED=FALSE ${CMAKE_AFTER}
 	make
 	cd ../build-10
-	cmake ../source \
-		-DCMAKE_INSTALL_PREFIX='/usr' \
-		-DHIGH_BIT_DEPTH='TRUE' \
-		-DEXPORT_C_API='FALSE' \
-		-DENABLE_CLI='FALSE' \
-		-DENABLE_SHARED='FALSE' ${CMAKE_AFTER}
+	cmake ../source ${CMAKE_DEF[@]} \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DHIGH_BIT_DEPTH=TRUE \
+		-DEXPORT_C_API=FALSE \
+		-DENABLE_CLI=FALSE \
+		-DENABLE_SHARED=FALSE ${CMAKE_AFTER}
 	make
 	cd ../build
 	ln -s ../build-10/libx265.a libx265_main10.a
 	ln -s ../build-12/libx265.a libx265_main12.a
-	cmake ../source \
-		-DCMAKE_INSTALL_PREFIX='/usr' \
-		-DENABLE_SHARED='TRUE' \
+	cmake ../source ${CMAKE_DEF[@]} \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DENABLE_SHARED=TRUE \
 		-DEXTRA_LIB='x265_main10.a;x265_main12.a' \
-		-DEXTRA_LINK_FLAGS='-L.' \
-		-DLINKED_10BIT='TRUE' \
-		-DLINKED_12BIT='TRUE' ${CMAKE_AFTER}
+		-DEXTRA_LINK_FLAGS=-L. \
+		-DLINKED_10BIT=TRUE \
+		-DLINKED_12BIT=TRUE ${CMAKE_AFTER}
 	make
 	make install DESTDIR="$PKGDIR"
 fi

--- a/runtime-multimedia/x265/autobuild/defines
+++ b/runtime-multimedia/x265/autobuild/defines
@@ -4,12 +4,13 @@ PKGDEP="glibc"
 BUILDDEP__AMD64="${BUILDDEP} nasm"
 PKGDES="Open source H265/HEVC video encoder"
 
+# some applications might want this e.g. sunshine
+CMAKE_AFTER="-DENABLE_HDR10_PLUS=ON"
 CMAKE_AFTER__PPC64=" \
              ${CMAKE_AFTER} \
              -DENABLE_ALTIVEC=OFF"
 
-PKGBREAK="avidemux<=2.7.4 ffmpeg<=4.2.1 gst-plugins-bad-1-0<=1.16.0 \
-          handbrake<=1.2.2-1 vlc<=3.0.8-2 xpra<=2.4.3-1 \
-          telegram-desktop<=1.8.8"
+PKGBREAK="avidemux<=2.8.1 digikam<=7.9.0-2 vlc<=3.0.20-3 xpra<=5.0.8 \
+          gstreamer<=1.22.0-5 ffmpeg<=4.4.4-3 libheif<=1.17.6-1"
 
 AB_FLAGS_O3=1

--- a/runtime-multimedia/x265/spec
+++ b/runtime-multimedia/x265/spec
@@ -1,5 +1,4 @@
-VER=3.1.1
-REL=2
-SRCS="tbl::http://ftp.videolan.org/pub/videolan/x265/x265_${VER}.tar.gz"
-CHKSUMS="sha256::827900c7cc0a0105b8a96460fab7cd22b97afa7b2835b5cb979c44bddaa3c8d0"
+VER=3.6
+SRCS="git::commit=tags/$VER::https://bitbucket.org/multicoreware/x265_git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7275"


### PR DESCRIPTION
Topic Description
-----------------

- libheif: bump REL due to x265 update to 3.6
- ffmpeg: bump REL due to x265 update to 3.6
- gstreamer: bump REL due to x265 update to 3.6
    Add missing PKGDEP: /usr/lib/gstreamer-1.0/libgstx265.so depends on x265
- xpra: bump REL due to x265 update to 3.6
- vlc: bump REL due to x265 update to 3.6
- digikam: bump REL due to x265 update to 3.6
- avidemux: bump REL due to x265 update to 3.6
- x265: update to 3.6

Package(s) Affected
-------------------

- avidemux: 2.8.1-1
- digikam: 7.9.0-3
- ffmpeg: 4.4.4-4
- gstreamer: 1.22.0-6
- libheif: 1.17.6-2
- vlc: 3.0.20-4
- x265: 3.6
- xpra: 5.0.8-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit x265:-pkgbreak libheif ffmpeg gstreamer xpra vlc digikam avidemux x265
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
