### PR TITLE
nodejs: security update to 20.12.2

### DIFF
--- a/lang-js/nodejs/spec
+++ b/lang-js/nodejs/spec
@@ -1,4 +1,4 @@
-VER=20.12.1
+VER=20.12.2
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.gz"
-CHKSUMS="sha256::b9bef0314e12773ef004368ee56a2db509a948d4170b9efb07441bac1f1407a0"
+CHKSUMS="sha256::bc57ee721a12cc8be55bb90b4a9a2f598aed5581d5199ec3bd171a4781bfecda"
 CHKUPDATE="anitya::id=12594"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs: security update to 20.12.2
    Fixes CVE-2024-27980

Package(s) Affected
-------------------

- nodejs: 2:20.12.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
