### PR TITLE
rustc: update to 1.77.2

### DIFF
--- a/lang-rust/rustc/autobuild/defines
+++ b/lang-rust/rustc/autobuild/defines
@@ -3,6 +3,9 @@ PKGEPOCH=1
 PKGSEC=devel
 PKGDEP="gcc-runtime llvm-runtime http-parser"
 BUILDDEP="cmake curl libffi llvm ninja"
+# no rustup bootstrap binary
+BUILDDEP__LOONGSON3="${BUILDDEP} rustc"
+BUILDDEP__MIPS64R6EL="${BUILDDEP} rustc"
 PKGDES="General purpose, multi-paradigm programming language (compiler and runtime)"
 
 NOLTO=1

--- a/lang-rust/rustc/autobuild/prepare
+++ b/lang-rust/rustc/autobuild/prepare
@@ -1,20 +1,3 @@
-# FIXME: No Rustup bootstrap binaries for these architectures yet.
-if ab_match_arch loongson3 || \
-   ab_match_arch mips64r6el; then
-    SRC_PARENT="$(realpath $SRCDIR/..)"
-    abinfo "Extracting bootstrapped Stage 1 Rust toolchain..."
-    bsdtar xf "$SRC_PARENT"/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH}.tar.xz \
-        -C "$SRC_PARENT"
-
-    abinfo "Copying bootstrapped Stage 1 Rust toolchain ..."
-    cp -rv "$SRC_PARENT"/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH}/opt/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH} \
-        /opt
-
-    if [ ! -e /opt/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH}/bin/rustc ] ; then
-        abdie "Help! Stage 1 Rust toolchain does not exist in the desired directory."
-    fi
-fi
-
 abinfo "Appending -fPIC ..."
 export CFLAGS="${CFLAGS} -fPIC"
 export CXXFLAGS="${CXXFLAGS} -fPIC"
@@ -71,11 +54,11 @@ EOF
 
 if ab_match_arch loongson3 || \
    ab_match_arch mips64r6el; then
-    abinfo "Using local bootstrap binaries ..."
+    abinfo "Using system rustc for bootstrapping ..."
     cat >> "$SRCDIR"/config.toml << EOF
-cargo = "/opt/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH}/bin/cargo"
-rustc = "/opt/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH}/bin/rustc"
-rustfmt = "/opt/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH}/bin/rustfmt"
+cargo = "/usr/bin/cargo"
+rustc = "/usr/bin/rustc"
+rustfmt = "/usr/bin/rustfmt"
 EOF
 fi
 

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,9 +1,5 @@
-VER=1.77.1
-SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz \
-      tbl::rename=rustc-bootstrap-$VER-loongson3.tar.xz::https://repo.aosc.io/aosc-repacks/rust-bootstrap/rustc-bootstrap-$VER-loongson3.tar.xz \
-      tbl::rename=rustc-bootstrap-$VER-mips64r6el.tar.xz::https://repo.aosc.io/aosc-repacks/rust-bootstrap/rustc-bootstrap-$VER-mips64r6el.tar.xz"
-CHKSUMS="sha256::2ddc6f5e01df1bd6c7ff94d9931574181795a231b199ca6948d433fa5e795873 \
-         sha256::04838a63a1e46dd9750e4f3792574cde36ac78c131c34e5d95446386b204e0db \
-         sha256::0b5e9a9670df47da4f90b53e6b534e98ba88d59eae98152f3a7fbb6877694771"
+VER=1.77.2
+SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
+CHKSUMS="sha256::4d214c4189e4dd934d47e869fa5721b2c33dbbbdea21f2fc7fa6df3f38c1dea2"
 CHKUPDATE="anitya::id=7635"
 SUBDIR="rustc-${VER}-src"


### PR DESCRIPTION
Topic Description
-----------------

- rustc: securiy update to 1.77.2
    Fixes CVE-2024-24576

Package(s) Affected
-------------------

- rustc: 1:1.77.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
