### PR TITLE
minikube: 1.33.1, new

### DIFF
--- a/app-containers/minikube/autobuild/build
+++ b/app-containers/minikube/autobuild/build
@@ -1,0 +1,11 @@
+abinfo "Building minikube ..."
+make
+
+abinfo "Installing minikube ..."
+install -Dvm755 "$SRCDIR"/out/minikube -t "$PKGDIR"/usr/bin
+
+abinfo "Installing minikube bash and zsh completions ..."
+"$PKGDIR"/usr/bin/minikube completion bash |  \
+	install -Dvm644 /dev/stdin "$PKGDIR"/usr/share/bash-completion/completions/minikube
+"$PKGDIR"/usr/bin/minikube completion zsh | \
+	install -Dvm644 /dev/stdin "$PKGDIR"/usr/share/zsh/site-functions/_minikube

--- a/app-containers/minikube/autobuild/defines
+++ b/app-containers/minikube/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=minikube
+PKGSEC=admin
+PKGDEP="glibc"
+BUILDDEP="go git"
+PKGDES="Tool to run Kubernetes locally"
+
+ABSPLITDBG=0

--- a/app-containers/minikube/spec
+++ b/app-containers/minikube/spec
@@ -1,0 +1,4 @@
+VER=1.33.1
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/kubernetes/minikube"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=320530"


### PR DESCRIPTION
Topic Description
-----------------

- minikube: new, 1.33.1

Package(s) Affected
-------------------

- minikube: 1.33.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit minikube
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
