### PR TITLE
libgit2: update to 1.7.2

### DIFF
--- a/app-devel/geany-plugins/autobuild/defines
+++ b/app-devel/geany-plugins/autobuild/defines
@@ -8,7 +8,5 @@ PKGDES="Plugins for Geany"
 # FIXME: Geanypy incompatible with GTK+ 3.
 AUTOTOOLS_AFTER="--libexecdir=/usr/lib \
                  --disable-markdown \
-                 --disable-devhelp \
-                 --disable-geanypy \
                  --disable-webhelper"
 ABSHADOW=0

--- a/app-devel/geany-plugins/spec
+++ b/app-devel/geany-plugins/spec
@@ -1,5 +1,4 @@
-VER=1.37
-REL=1
+VER=2.0
 SRCS="tbl::https://plugins.geany.org/geany-plugins/geany-plugins-$VER.tar.bz2"
-CHKSUMS="sha256::c98f9b1303f4ab9bed7587e749cd0b5594d9136a1bf8ba110900d46a17fa9cd8"
+CHKSUMS="sha256::9fc2ec5c99a74678fb9e8cdfbd245d3e2061a448d70fd110a6aefb62dd514705"
 CHKUPDATE="anitya::id=5517"

--- a/app-devel/geany/autobuild/prepare
+++ b/app-devel/geany/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Setting python intepreter to python3 ..."
+export PYTHON=/usr/bin/python3

--- a/app-devel/geany/spec
+++ b/app-devel/geany/spec
@@ -1,4 +1,4 @@
-VER=1.37.1
-SRCS="tbl::https://download.geany.org/geany-$VER.tar.gz"
-CHKSUMS="sha256::3978148c57570df8ed817afe050bc038f1b4dd39dc8efeb0acb19cd4f0690a58"
+VER=2.0
+SRCS="tbl::https://download.geany.org/geany-$VER.tar.bz2"
+CHKSUMS="sha256::565b4cd2f0311c1e3a167ec71c4a32dba642e0fe554ae5bb6b8177b7a74ccc92"
 CHKUPDATE="anitya::id=5514"

--- a/app-games/darkradiant/spec
+++ b/app-games/darkradiant/spec
@@ -1,5 +1,5 @@
 VER=3.8.0
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/codereader/DarkRadiant"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227643"

--- a/desktop-gnome/gnome-builder/spec
+++ b/desktop-gnome/gnome-builder/spec
@@ -1,5 +1,5 @@
 VER=42.1
-REL=4
+REL=5
 SRCS="https://download.gnome.org/sources/gnome-builder/${VER%.*}/gnome-builder-$VER.tar.xz"
 CHKSUMS="sha256::5d4d51b702865b48017201f0c607e24a27d72031a8f5c88d4fce875b5545670a"
 CHKUPDATE="anitya::id=5574"

--- a/desktop-kde/sink/spec
+++ b/desktop-kde/sink/spec
@@ -1,5 +1,5 @@
 VER=0.9.0
-REL=2
+REL=3
 SRCS="tbl::https://invent.kde.org/pim/sink/-/archive/v$VER/sink-v$VER.tar.gz"
 CHKSUMS="sha256::b16cf8f7a5f942bf02cdacb4942ef6cb959894ebc4d370ec21be26e948c67349"
 CHKUPDATE="gitlab::repo=pim/sink;instance=https://invent.kde.org"

--- a/lang-python/pygit2/spec
+++ b/lang-python/pygit2/spec
@@ -1,4 +1,4 @@
-VER=1.7.0
-SRCS="tbl::https://github.com/libgit2/pygit2/archive/v$VER.tar.gz"
-CHKSUMS="sha256::8fbd1b91bd594f5f9cdd515e3a691ec148fd431838455487663d73387183d844"
+VER=1.14.1
+SRCS="git::commit=tags/v$VER::https://github.com/libgit2/pygit2"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3985"

--- a/runtime-vcs/libgit2-glib/spec
+++ b/runtime-vcs/libgit2-glib/spec
@@ -1,4 +1,4 @@
-VER=1.1.0
+VER=1.2.0
 SRCS="tbl::https://download.gnome.org/sources/libgit2-glib/${VER%.*}/libgit2-glib-$VER.tar.xz"
-CHKSUMS="sha256::c38dd7575daf8141e1e422333a575faf65f3c9210c08e83e981b88dd41bf1ef3"
+CHKSUMS="sha256::1331dada838f4e1f591b26459d44126a325de762dc3cd26153a31afbdfe18190"
 CHKUPDATE="anitya::id=7263"

--- a/runtime-vcs/libgit2/autobuild/defines
+++ b/runtime-vcs/libgit2/autobuild/defines
@@ -2,10 +2,10 @@ PKGNAME=libgit2
 PKGSEC=libs
 PKGDEP="zlib openssl libssh2 http-parser pcre2"
 PKGDES="A linkable library for Git"
-PKGBREAK="cargo-audit<=0.15.0-1 calligra<=3.2.0 ciel<=3.0.12 exa<=0.10.1-3 \
-          fritzing<=0.9.6 geany-plugins<=1.37 gnome-builder<=3.40.2-1 \
-          ktexteditor<=5.86.0 libgit2-glib<=0.28.0.1-1 pygit2<=1.0.3-1"
+PKGBREAK="libgit2-glib<=1.1.0 darkradiant<=3.8.0-1 geany-plugins<=1.37-1 \
+          gnome-builder<=42.1-4 pygit2<=1.7.0 sink<=0.9.0-2"
 
 CMAKE_AFTER="-DTHREADSAFE=ON \
              -DUSE_HTTP_PARSER=system \
+             -DUSE_SSH=ON \
              -DUSE_NTLMCLIENT=OFF"

--- a/runtime-vcs/libgit2/autobuild/prepare
+++ b/runtime-vcs/libgit2/autobuild/prepare
@@ -1,5 +1,0 @@
-abinfo 'Fedora: Patching to disable `online` tests...'
-sed -e '/-sonline/s/^/#/' -i "$SRCDIR"/tests/CMakeLists.txt
-
-abinfo 'Removing bundled libararies...'
-rm -rv "$SRCDIR"/deps

--- a/runtime-vcs/libgit2/spec
+++ b/runtime-vcs/libgit2/spec
@@ -1,5 +1,4 @@
-VER=1.3.0
-SRCS="tbl::https://github.com/libgit2/libgit2/archive/v$VER.tar.gz"
-CHKSUMS="sha256::192eeff84596ff09efb6b01835a066f2df7cd7985e0991c79595688e6b36444e"
+VER=1.7.2
+SRCS="git::commit=tags/v$VER::https://github.com/libgit2/libgit2"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1627"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- sink: bump REL due to libgit2 update to 1.7.2
- pygit2: bump REL due to libgit2 update to 1.7.2
- gnome-builder: bump REL due to libgit2 update to 1.7.2
- darkradiant: bump REL due to libgit2 update to 1.7.2
- geany-plugins: update to 2.0
- geany: update to 2.0
- libgit2-glib: update to 1.2.0
- libgit2: update to 1.7.2

Package(s) Affected
-------------------

- darkradiant: 3.8.0-2
- geany-plugins: 2.0
- geany: 2.0
- gnome-builder: 42.1-5
- libgit2-glib: 1.2.0
- libgit2: 1.7.2
- pygit2: 1.7.0-1
- sink: 0.9.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgit2 libgit2-glib geany geany-plugins darkradiant gnome-builder pygit2 sink
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
