### PR TITLE
helm: update to 3.15.0

### DIFF
--- a/app-containers/helm/autobuild/build
+++ b/app-containers/helm/autobuild/build
@@ -1,0 +1,11 @@
+abinfo "Building helm ..."
+make
+
+abinfo "Installing helm ..."
+install -Dvm755 "$SRCDIR"/bin/helm -t "$PKGDIR"/usr/bin
+
+abinfo "Installing bash and zsh completions ..."
+"$PKGDIR"/usr/bin/helm completion bash | \
+	install -Dvm644 /dev/stdin "$PKGDIR"/usr/share/bash-completion/completions/helm
+"$PKGDIR"/usr/bin/helm completion zsh | \
+	install -Dvm644 /dev/stdin "$PKGDIR"/usr/share/zsh/site-functions/_helm

--- a/app-containers/helm/autobuild/defines
+++ b/app-containers/helm/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=helm
+PKGSEC=admin
+PKGDEP="glibc"
+BUILDDEP="go git"
+PKGDES="Kubernetes Package Manager"
+
+ABSPLITDBG=0

--- a/app-containers/helm/spec
+++ b/app-containers/helm/spec
@@ -1,0 +1,4 @@
+VER=3.15.0
+SRCS="git::commit=tags/v$VER::https://github.com/helm/helm"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=15046"


### PR DESCRIPTION
Topic Description
-----------------

- helm: new, 3.15.0

Package(s) Affected
-------------------

- helm: 3.15.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit helm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
