### PR TITLE
onefetch: update to 2.20.0

### DIFF
--- a/app-utils/onefetch/autobuild/defines
+++ b/app-utils/onefetch/autobuild/defines
@@ -5,7 +5,11 @@ BUILDDEP="rustc llvm"
 PKGDES="A command-line tool to show local Git repository summary"
 
 USECLANG=1
-ABSPLITDBG=0
 
-# FIXME: LTO breaks build on riscv64 when linking zstd.
-NOLTO__RISCV64=1
+# FIXME: ld.lld is not yet available
+NOLTO__LOONGSON3=1
+NOLTO__LOONGARCH64=1
+NOLTO__MIPS64R6EL=1
+
+# FIXME: zlib-ng FTBFS
+FAIL_ARCH="loongarch64"

--- a/app-utils/onefetch/spec
+++ b/app-utils/onefetch/spec
@@ -1,4 +1,4 @@
-VER=2.11.0
-SRCS="https://github.com/o2sh/onefetch/archive/v$VER.tar.gz"
-CHKSUMS="sha256::ffd3cc3bd24e299ede1fada2b2da8bf066d59219da167477e1997c860650c192"
+VER=2.20.0
+SRCS="git::commit=tags/$VER::https://github.com/o2sh/onefetch"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141703"


### PR DESCRIPTION
Topic Description
-----------------

- onefetch: update to 2.20.0

Package(s) Affected
-------------------

- onefetch: 2.20.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit onefetch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
