### PR TITLE
GIMP: fix crashing on exit without saving

### DIFF
--- a/app-creativity/gimp/autobuild/patches/0002-QuitDialog-disconnect-signal-handler-on-dialog-destroy.patch
+++ b/app-creativity/gimp/autobuild/patches/0002-QuitDialog-disconnect-signal-handler-on-dialog-destroy.patch
@@ -1,0 +1,28 @@
+From d7228727d7a4b11909001cf8fd8977d68bd29720 Mon Sep 17 00:00:00 2001
+From: Luca Bacci <luca.bacci982@gmail.com>
+Date: Tue, 2 Apr 2024 11:31:08 +0200
+Subject: [PATCH] QuitDialog: disconnect signal handler on dialog destroy
+
+...rather than finalize.
+
+Fixes #10785
+---
+ app/dialogs/quit-dialog.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/app/dialogs/quit-dialog.c b/app/dialogs/quit-dialog.c
+index ad9a4495f9c..3c18a09260a 100644
+--- a/app/dialogs/quit-dialog.c
++++ b/app/dialogs/quit-dialog.c
+@@ -300,7 +300,7 @@ quit_close_all_dialog_new (Gimp     *gimp,
+ 
+   closure = g_cclosure_new (G_CALLBACK (quit_close_all_dialog_container_changed),
+                             private, NULL);
+-  g_object_watch_closure (G_OBJECT (private->dialog), closure);
++  g_signal_connect_swapped (private->dialog, "destroy", G_CALLBACK (g_closure_invalidate), closure);
+   g_signal_connect_closure (private->images, "add", closure, FALSE);
+   g_signal_connect_closure (private->images, "remove", closure, FALSE);
+ 
+-- 
+GitLab
+

--- a/app-creativity/gimp/spec
+++ b/app-creativity/gimp/spec
@@ -1,4 +1,5 @@
 VER=2.10.36
+REL=1
 SRCS="tbl::https://download.gimp.org/pub/gimp/v${VER:0:4}/gimp-$VER.tar.bz2"
 CHKSUMS="sha256::3d3bc3c69a4bdb3aea9ba2d5385ed98ea03953f3857aafd1d6976011ed7cdbb2"
 CHKUPDATE="anitya::id=1161"


### PR DESCRIPTION
Topic Description
-----------------

- gimp: fix crashing on exit without saving
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- gimp: 2.10.36-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gimp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
