### PR TITLE
openldap 2.6.7 rework

### DIFF
--- a/desktop-gnome/evolution-data-server/autobuild/defines
+++ b/desktop-gnome/evolution-data-server/autobuild/defines
@@ -41,7 +41,8 @@ CMAKE_AFTER="-DENABLE_CODE_COVERAGE=OFF \
              -DENABLE_LARGEFILE=ON \
              -DENABLE_VALA_BINDINGS=ON \
              -DLIB_INSTALL_DIR=/usr/lib \
-             -DCMAKE_SKIP_RPATH=OFF"
+             -DCMAKE_SKIP_RPATH=OFF \
+             -DCMAKE_SKIP_INSTALL_RPATH=OFF"
 
 ABSHADOW=0
 PKGREP="evolution<=3.28.5-1"

--- a/desktop-gnome/evolution/autobuild/defines
+++ b/desktop-gnome/evolution/autobuild/defines
@@ -35,4 +35,5 @@ CMAKE_AFTER="-DLIB_INSTALL_DIR=/usr/lib \
              -DWITH_SPAMASSASSIN=ON \
              -DWITH_STATIC_LDAP=OFF \
              -DWITH_SUNLDAP=OFF \
-             -DCMAKE_SKIP_RPATH=OFF"
+             -DCMAKE_SKIP_RPATH=OFF \
+             -DCMAKE_SKIP_INSTALL_RPATH=OFF"


### PR DESCRIPTION
Topic Description
-----------------

- evolution: recover install rpath due to ab4 change
- evolution-data-server: recover install rpath due to ab4 change

Package(s) Affected
-------------------

- apr-util: 1.6.1-8
- audit: 3.1-1
- autofs: 5.1.8-3
- balsa: 2.6.3-2
- cups-browsed: 2.0.0-1
- cups-filters: 2.0.0-1
- cyrus-sasl: 2.1.27-9
- dovecot: 2.3.10.1-4
- evolution-data-server: 3.44.4-1
- evolution: 3.44.4-4
- exim: 4.97.1-1
- gconf: 3.2.6-6
- gnupg: 1:2.4.4-3
- httpd: 2.4.58-1
- kldap: 22.08.3-1
- krb5: 1.17.1-8
- ldb : 2:2.6.1-2
- libreoffice: 7.5.4.2-4
- lighttpd: 1.4.55-3
- nfs-utils: 2.6.2-2
- opencryptoki: 3.21.0-2
- openldap: 2.6.7
- php: 1:8.3.3-1
- postfix: 3.7.3-4
- quota-tools: 4.09-1
- realmd: 0.17.1-1
- samba: 4.17.2-3
- seahorse: 42.0-1
- squid: 5.7-3
- sssd: 2.9.4-1
- tdebase: 14.1.0-2
- yubico-pam: 2.26-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit openldap:-pkgbreak apr-util krb5 evolution-data-server nfs-utils audit autofs balsa cups-browsed cups-filters dovecot evolution exim gnupg httpd cyrus-sasl kldap lighttpd opencryptoki postfix php quota-tools ldb samba realmd seahorse squid sssd tdebase yubico-pam libreoffice gconf openldap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
