### PR TITLE
dvd+rw-tools update patches

### DIFF
--- a/app-multimedia/dvd+rw-tools/autobuild/patches/dvddl.patch
+++ b/app-multimedia/dvd+rw-tools/autobuild/patches/dvddl.patch
@@ -1,6 +1,8 @@
---- a/growisofs_mmc.cpp.joe	2006-04-27 20:45:00.788446635 +0200
-+++ b/growisofs_mmc.cpp	2006-04-27 20:46:01.666824300 +0200
-@@ -1412,9 +1412,7 @@
+diff --git a/growisofs_mmc.cpp b/growisofs_mmc.cpp
+index 4de8a14..cc25f0a 100644
+--- a/growisofs_mmc.cpp
++++ b/growisofs_mmc.cpp
+@@ -1640,9 +1640,7 @@ static void plus_r_dl_split (Scsi_Command &cmd,off64_t size)
      blocks += 15, blocks &= ~15;
  
      if (blocks <= split)
@@ -11,4 +13,3 @@
  
      blocks /= 16;
      blocks += 1;
-

--- a/app-multimedia/dvd+rw-tools/autobuild/patches/wctomb.patch
+++ b/app-multimedia/dvd+rw-tools/autobuild/patches/wctomb.patch
@@ -1,6 +1,8 @@
---- a/transport.hxx~	2008-03-25 21:24:47.000000000 -0400
-+++ b/transport.hxx	2008-03-25 21:25:36.000000000 -0400
-@@ -116,7 +116,7 @@
+diff --git a/transport.hxx b/transport.hxx
+index 35a57a7..1e7edc5 100644
+--- a/transport.hxx
++++ b/transport.hxx
+@@ -123,7 +123,7 @@ class autofree {
  extern "C" char *plusminus_locale()
  { static class __plusminus {
      private:
@@ -8,4 +10,4 @@
 +	char str[MB_LEN_MAX];
      public:
  	__plusminus()	{   setlocale(LC_CTYPE,ENV_LOCALE);
- 			    int l = wctomb(str,(wchar_t)(unsigned char)'ï¿½');
+ 			    int l = wctomb(str,(wchar_t)(unsigned char)'±');

--- a/app-multimedia/dvd+rw-tools/autobuild/patches/wexit.patch
+++ b/app-multimedia/dvd+rw-tools/autobuild/patches/wexit.patch
@@ -1,10 +1,13 @@
---- dvd+rw-tools-7.0/dvd+rw-format.cpp.wexit	2007-06-21 12:42:30.000000000 +0200
-+++ dvd+rw-tools-7.0/dvd+rw-format.cpp	2007-06-21 12:44:13.000000000 +0200
-@@ -245,7 +245,7 @@ int main (int argc, char *argv[])
+diff --git a/dvd+rw-format.cpp b/dvd+rw-format.cpp
+index 0969d11..abd8e07 100644
+--- a/dvd+rw-format.cpp
++++ b/dvd+rw-format.cpp
+@@ -247,7 +247,7 @@ int main (int argc, char *argv[])
  	alarm(1);
  	while ((waitpid(pid,&i,0) != pid) && !WIFEXITED(i)) ;
  	if (WEXITSTATUS(i) == 0) fprintf (stderr,"\n");
 -	exit (0);
-+	exit (WEXITSTATUS(i));
++    		exit (WEXITSTATUS(i));
      }
  #endif
+ 

--- a/app-multimedia/dvd+rw-tools/spec
+++ b/app-multimedia/dvd+rw-tools/spec
@@ -1,5 +1,5 @@
 VER=7.1
-REL=5
+REL=6
 SRCS="tbl::http://fy.chalmers.se/~appro/linux/DVD+RW/tools/dvd+rw-tools-$VER.tar.gz"
 CHKSUMS="sha256::f8d60f822e914128bcbc5f64fbe3ed131cbff9045dca7e12c5b77b26edde72ca"
 CHKUPDATE="anitya::id=230657"


### PR DESCRIPTION
Topic Description
-----------------

- dvd+rw-tools: update patches
    Regenerate patches to remove fuzz and update line numbers.

Package(s) Affected
-------------------

- dvd+rw-tools: 7.1-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit dvd+rw-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
