### PR TITLE
libcss: update to 0.9.2

### DIFF
--- a/app-web/netsurf/spec
+++ b/app-web/netsurf/spec
@@ -1,5 +1,5 @@
 VER=3.10
-REL=4
+REL=5
 SRCS="tbl::https://download.netsurf-browser.org/netsurf/releases/source/netsurf-$VER-src.tar.gz"
 CHKSUMS="sha256::36484429e193614685c2ff246f55bd0a6dddf31a018bee45e0d1f7c28851995e"
 CHKUPDATE="anitya::id=5386"

--- a/runtime-web/libcss/autobuild/build
+++ b/runtime-web/libcss/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building binaries"
+make
+
+abinfo "Build done, installing files"
+make DESTDIR="${PKGDIR}" prefix=/usr LIBDIR=lib COMPONENT_TYPE=lib-shared install

--- a/runtime-web/libcss/autobuild/defines
+++ b/runtime-web/libcss/autobuild/defines
@@ -3,7 +3,3 @@ PKGSEC=libs
 PKGDEP="libparserutils libwapcaplet"
 BUILDDEP="netsurf-buildsystem"
 PKGDES="CSS parser and selection engine"
-
-MAKE_AFTER="PREFIX=/usr \
-            LIBDIR=lib \
-            COMPONENT_TYPE=lib-shared"

--- a/runtime-web/libcss/autobuild/patch
+++ b/runtime-web/libcss/autobuild/patch
@@ -1,0 +1,3 @@
+abinfo "Tweaking Makefile: /opt/netsurf => /usr ..."
+sed -e 's|opt\/netsurf|usr|g' \
+    -i "$SRCDIR"/Makefile

--- a/runtime-web/libcss/spec
+++ b/runtime-web/libcss/spec
@@ -1,5 +1,4 @@
-VER=0.9.1
-REL=2
+VER=0.9.2
 SRCS="tbl::https://download.netsurf-browser.org/libs/releases/libcss-$VER-src.tar.gz"
-CHKSUMS="sha256::d2dce16e93392e8d6a7209420d47c2d56a3811701a0e81a724fc541c63d3c6dc"
+CHKSUMS="sha256::2df215bbec34d51d60c1a04b01b2df4d5d18f510f1f3a7af4b80cddb5671154e"
 CHKUPDATE="anitya::id=1582"


### PR DESCRIPTION
Topic Description
-----------------

- libcss: remove MAKE_AFTER as ab4
- libcss: migrate to Autobuild4
- libcss: modify $PREFIX to /usr in Makefile
- libcss: update to 0.9.2

Package(s) Affected
-------------------

- libcss: 0.9.2
- netsurf: 3.10-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcss netsurf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
