### PR TITLE
ninja: update to 1.12.0

### DIFF
--- a/app-devel/ninja/autobuild/beyond
+++ b/app-devel/ninja/autobuild/beyond
@@ -1,5 +1,0 @@
-abinfo "Installing Shell completions ..."
-install -Dvm644 "$SRCDIR"/misc/bash-completion \
-    "$PKGDIR/usr/share/bash-completion/completions/ninja"
-install -Dvm644 "$SRCDIR"/misc/zsh-completion \
-    "$PKGDIR/usr/share/zsh/site-functions/_ninja"

--- a/app-devel/ninja/autobuild/build
+++ b/app-devel/ninja/autobuild/build
@@ -1,6 +1,13 @@
-python configure.py --bootstrap
+abinfo "Configuring ninja ..."
+python3 "$SRCDIR"/configure.py \
+    --bootstrap
 
-install -m755 -D ninja "$PKGDIR/usr/bin/ninja"
+abinfo "Installing ninja ..."
+install -Dvm755 "$SRCDIR"/ninja \
+    "$PKGDIR/usr/bin/ninja"
 
-install -m644 -D misc/bash-completion "$PKGDIR/usr/share/bash-completion/completions/ninja"
-install -m644 -D misc/zsh-completion "$PKGDIR/usr/share/zsh/site-functions/_ninja"
+abinfo "Installing shell completions ..."
+install -Dvm644 "$SRCDIR"/misc/bash-completion \
+    "$PKGDIR/usr/share/bash-completion/completions/ninja"
+install -Dvm644 "$SRCDIR"/misc/zsh-completion \
+    "$PKGDIR/usr/share/zsh/site-functions/_ninja"

--- a/app-devel/ninja/autobuild/defines
+++ b/app-devel/ninja/autobuild/defines
@@ -2,5 +2,3 @@ PKGNAME=ninja
 PKGSEC=devel
 PKGDEP="re2c"
 PKGDES="Small build system with a focus on speed"
-
-

--- a/app-devel/ninja/autobuild/defines.stage2
+++ b/app-devel/ninja/autobuild/defines.stage2
@@ -1,4 +1,0 @@
-PKGNAME=ninja
-PKGSEC=devel
-PKGDEP="re2c"
-PKGDES="Small build system with a focus on speed"

--- a/app-devel/ninja/spec
+++ b/app-devel/ninja/spec
@@ -1,4 +1,4 @@
-VER=1.11.1
+VER=1.12.0
 SRCS="git::commit=tags/v$VER::https://github.com/ninja-build/ninja"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=132832"


### PR DESCRIPTION
Topic Description
-----------------

- ninja: update to 1.12.0
    Drop unused stage2 defines.

Package(s) Affected
-------------------

- ninja: 1.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ninja
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
