### PR TITLE
wget: update to 1.24.5

### DIFF
--- a/app-web/wget/spec
+++ b/app-web/wget/spec
@@ -1,5 +1,4 @@
-VER=1.21.2
+VER=1.24.5
 SRCS="tbl::https://ftp.gnu.org/gnu/wget/wget-$VER.tar.lz"
-CHKSUMS="sha256::1727a330a86acacb3e57615ce268f5f29978bf7adec4abe6a30d370207bc91b3"
+CHKSUMS="sha256::57a107151e4ef94fdf94affecfac598963f372f13293ed9c74032105390b36ee"
 CHKUPDATE="anitya::id=5124"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- wget: update to 1.24.5

Package(s) Affected
-------------------

- wget: 1.24.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit wget
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
