### PR TITLE
iproute2: update to 6.8.0

### DIFF
--- a/app-network/iproute2/autobuild/conffiles
+++ b/app-network/iproute2/autobuild/conffiles
@@ -1,9 +1,0 @@
-/etc/iproute2/bpf_pinning
-/etc/iproute2/ematch_map
-/etc/iproute2/group
-/etc/iproute2/nl_protos
-/etc/iproute2/rt_dsfield
-/etc/iproute2/rt_protos
-/etc/iproute2/rt_realms
-/etc/iproute2/rt_scopes
-/etc/iproute2/rt_tables

--- a/app-network/iproute2/spec
+++ b/app-network/iproute2/spec
@@ -1,4 +1,4 @@
-VER=6.0.0
+VER=6.8.0
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-$VER.tar.xz"
-CHKSUMS="sha256::523139e9e72aec996374fa2de74be4c53d2dd05589488934d21ff97bae19580a"
+CHKSUMS="sha256::03a6cca3d71a908d1f15f7b495be2b8fe851f941458dc4664900d7f45fcf68ce"
 CHKUPDATE="anitya::id=1392"


### PR DESCRIPTION
Topic Description
-----------------

- iproute2: update to 6.8.0

Package(s) Affected
-------------------

- iproute2: 6.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iproute2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
