### PR TITLE
mesa (Mesa 3D Library): update to 24.0.5

### DIFF
--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,10 +1,9 @@
-MESA_VER=24.0.4
+MESA_VER=24.0.5
 DXHEADERS_VER=1.611.0
 VER=${MESA_VER}+dxheaders${DXHEADERS_VER}
-REL=2
 SRCS="tbl::https://archive.mesa3d.org/mesa-${MESA_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
-CHKSUMS="sha256::90febd30a098cbcd97ff62ecc3dcf5c93d76f7fa314de944cfce81951ba745f0 \
+CHKSUMS="sha256::38cc245ca8faa3c69da6d2687f8906377001f63365348a62cc6f7fafb1e8c018 \
          SKIP"
 SUBDIR="mesa-${MESA_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 24.0.5

Package(s) Affected
-------------------

- mesa: 1:24.0.5+dxheaders1.611.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
