### PR TITLE
flatpak: update to 1.14.6

### DIFF
--- a/app-admin/flatpak/autobuild/defines
+++ b/app-admin/flatpak/autobuild/defines
@@ -39,6 +39,6 @@ AUTOTOOLS_AFTER="--enable-nls \
                  --with-gpgme-prefix=/usr \
                  --with-priv-mode=setuid"
 
-PKGBREAK="xdg-app<=0.5.2 discover<=5.21.4 gnome-builder<=41.2 gnome-software<=40.4 \
-          malcontent<=0.10.1-1 xdg-desktop-portal<=1.8.0"
+PKGBREAK="xdg-app<=0.5.2 discover<=5.27.10 gnome-builder<=42.1-4 gnome-software<=42.4 \
+          malcontent<=0.10.5 xdg-desktop-portal<=1.16.0 flatpak-builder<=1.0.14"
 PKGREP="xdg-app<=0.5.2"

--- a/app-admin/flatpak/spec
+++ b/app-admin/flatpak/spec
@@ -1,7 +1,6 @@
-VER=1.14.3
-SRCS="tbl::https://github.com/flatpak/flatpak/releases/download/$VER/flatpak-$VER.tar.xz \
+VER=1.14.6
+SRCS="git::commit=tags/$VER::https://github.com/flatpak/flatpak \
       file::rename=flathub.flatpakrepo::https://flathub.org/repo/flathub.flatpakrepo"
-CHKSUMS="sha256::59f0470ccb894d852e4c6fbc1043d8bcc95e38033c5c36f2aa90dd295257eebe \
+CHKSUMS="SKIP \
          sha256::3371dd250e61d9e1633630073fefda153cd4426f72f4afa0c3373ae2e8fea03a"
 CHKUPDATE="anitya::id=6377"
-SUBDIR="flatpak-$VER"

--- a/app-admin/xdg-desktop-portal/spec
+++ b/app-admin/xdg-desktop-portal/spec
@@ -1,4 +1,5 @@
 VER=1.16.0
+REL=1
 SRCS="tbl::https://github.com/flatpak/xdg-desktop-portal/releases/download/$VER/xdg-desktop-portal-$VER.tar.xz"
 CHKSUMS="sha256::5b41a5915c11851493d8c33b9783f147a0a6f419db80ad760e84cd3420fd8c19"
 CHKUPDATE="anitya::id=11089"

--- a/app-devel/flatpak-builder/autobuild/defines
+++ b/app-devel/flatpak-builder/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=flatpak-builder
 PKGSEC=devel
-PKGDEP="flatpak"
+PKGDEP="flatpak libsoup"
 BUILDDEP="docbook-xsl"
 PKGDES="A tool for building flatpaks from sources"

--- a/app-devel/flatpak-builder/spec
+++ b/app-devel/flatpak-builder/spec
@@ -1,4 +1,5 @@
 VER=1.0.14
+REL=1
 SRCS="tbl::https://github.com/flatpak/flatpak-builder/releases/download/$VER/flatpak-builder-$VER.tar.xz"
 CHKSUMS="sha256::69b65af4f63804127518c545184f9dfc9a9358cdedaabef2b1e50623ae2b8d8b"
 CHKUPDATE="anitya::id=16046"

--- a/desktop-gnome/gnome-builder/spec
+++ b/desktop-gnome/gnome-builder/spec
@@ -1,5 +1,5 @@
 VER=42.1
-REL=4
+REL=5
 SRCS="https://download.gnome.org/sources/gnome-builder/${VER%.*}/gnome-builder-$VER.tar.xz"
 CHKSUMS="sha256::5d4d51b702865b48017201f0c607e24a27d72031a8f5c88d4fce875b5545670a"
 CHKUPDATE="anitya::id=5574"

--- a/desktop-gnome/gnome-software/autobuild/defines
+++ b/desktop-gnome/gnome-software/autobuild/defines
@@ -34,6 +34,9 @@ MESON_AFTER="-Dgsettings_desktop_schemas=enabled \
              -Dmogwai=false \
              -Dsysprof=enabled \
              -Dsoup2=true"
+MESON_AFTER__LOONGARCH64=" \
+             ${MESON_AFTER} \
+             -Dvalgrind=false"
 MESON_AFTER__LOONGSON3=" \
              ${MESON_AFTER} \
              -Dfwupd=false"

--- a/desktop-gnome/gnome-software/spec
+++ b/desktop-gnome/gnome-software/spec
@@ -1,4 +1,5 @@
 VER=42.4
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-software/${VER%.*}/gnome-software-$VER.tar.xz"
 CHKSUMS="sha256::711829ee67f9f2a1b64bfa17413773b98f0dc5d219eb8f6ca217cd6572bb4a74"
 CHKUPDATE="anitya::id=10902"

--- a/desktop-kde/discover/spec
+++ b/desktop-kde/discover/spec
@@ -1,4 +1,5 @@
 VER=5.27.10
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/discover-$VER.tar.xz"
 CHKSUMS="sha256::1f9189e2a759ac035a5ba83a2842a40b7034a7e5885b0836e3921b9671109fa8"
 CHKUPDATE="anitya::id=8761"

--- a/groups/flatpak-rebuilds
+++ b/groups/flatpak-rebuilds
@@ -3,3 +3,4 @@ desktop-gnome/gnome-builder
 desktop-gnome/gnome-software
 runtime-desktop/malcontent
 app-admin/xdg-desktop-portal
+app-devel/flatpak-builder

--- a/runtime-desktop/malcontent/spec
+++ b/runtime-desktop/malcontent/spec
@@ -1,4 +1,5 @@
 VER=0.10.5
+REL=1
 SRCS="https://gitlab.freedesktop.org/pwithnall/malcontent/-/archive/$VER/malcontent-$VER.tar.gz"
 CHKSUMS="sha256::f4c120c223c1a6ef6ea14e8f66d471cd20bb1a8033dcaf81720b3294b6dab830"
 CHKUPDATE="anitya::id=230451"


### PR DESCRIPTION
Topic Description
-----------------

- flatpak-builder: bump REL due to flatpak update to 1.14.6
- xdg-desktop-portal: bump REL due to flatpak update to 1.14.6
- malcontent: bump REL due to flatpak update to 1.14.6
- gnome-software: bump REL due to flatpak update to 1.14.6
- gnome-builder: bump REL due to flatpak update to 1.14.6
- discover: bump REL due to flatpak update to 1.14.6
- flatpak: security update to 1.14.6
    Fixes CVE-2024-32462

Package(s) Affected
-------------------

- discover: 5.27.10-1
- flatpak-builder: 1.0.14-1
- flatpak: 1.14.6
- gnome-builder: 42.1-5
- gnome-software: 42.4-1
- malcontent: 0.10.5-1
- xdg-desktop-portal: 1.16.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit flatpak:-pkgbreak discover gnome-builder gnome-software malcontent xdg-desktop-portal flatpak-builder flatpak
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
