### PR TITLE
meson: update to 1.4.0

### DIFF
--- a/app-devel/meson/spec
+++ b/app-devel/meson/spec
@@ -1,4 +1,4 @@
-VER=1.2.3
-SRCS="tbl::https://github.com/mesonbuild/meson/releases/download/$VER/meson-$VER.tar.gz"
-CHKSUMS="sha256::4533a43c34548edd1f63a276a42690fce15bde9409bcf20c4b8fa3d7e4d7cac1"
+VER=1.4.0
+SRCS="git::commit=tags/${VER}::https://github.com/mesonbuild/meson.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6472"


### PR DESCRIPTION
Topic Description
-----------------

- meson: update to 1.4.0

Package(s) Affected
-------------------

- meson: 1.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit meson
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
