### PR TITLE
sway-audio-idle-inhibit: new, 0.1.1

### DIFF
--- a/app-utils/sway-audio-idle-inhibit/autobuild/defines
+++ b/app-utils/sway-audio-idle-inhibit/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=sway-audio-idle-inhibit
+PKGSEC=utils
+PKGDEP="wayland pulseaudio"
+BUILDDEP="wayland-protocols"
+PKGDES="A utility for preventing swayidle from sleeping while audio is in use"
+PKGPROV="swayaudioidleinhibit"

--- a/app-utils/sway-audio-idle-inhibit/spec
+++ b/app-utils/sway-audio-idle-inhibit/spec
@@ -1,0 +1,4 @@
+VER=0.1.1
+SRCS="git::commit=tags/v$VER::https://github.com/ErikReider/SwayAudioIdleInhibit"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372107"


### PR DESCRIPTION
Topic Description
-----------------

- sway-audio-idle-inhibit: new, 0.1.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- sway-audio-idle-inhibit: 0.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sway-audio-idle-inhibit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
