### PR TITLE
zig: update to 0.12.0

### DIFF
--- a/lang-ziglang/zig/spec
+++ b/lang-ziglang/zig/spec
@@ -1,4 +1,4 @@
-VER=0.11.0+git20240222
-SRCS="git::commit=dd1fc1cb8c2258256566fd0035deb6fbf700fc69::https://github.com/ziglang/zig"
+VER=0.12.0
+SRCS="git::commit=tags/$VER::https://github.com/ziglang/zig"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13871"


### PR DESCRIPTION
Topic Description
-----------------

- zig: update to 0.12.0

Package(s) Affected
-------------------

- zig: 0.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit zig
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
