### PR TITLE
qt-6: update to 6.7.0

### DIFF
--- a/app-i18n/fcitx-qt5/spec
+++ b/app-i18n/fcitx-qt5/spec
@@ -1,5 +1,5 @@
 VER=1.2.7
-REL=3
+REL=4
 SRCS="tbl::https://download.fcitx-im.org/fcitx-qt5/fcitx-qt5-$VER.tar.xz"
 CHKSUMS="sha256::951fcf8f1db23ed22ad91094eb4c6c906f92005a3643b52f666bd8a331163147"
 CHKUPDATE="anitya::id=6513"

--- a/app-i18n/fcitx5-qt/spec
+++ b/app-i18n/fcitx5-qt/spec
@@ -1,5 +1,4 @@
-VER=5.1.3
-REL=1
-SRCS="https://github.com/fcitx/fcitx5-qt/archive/$VER.tar.gz"
-CHKSUMS="sha256::fbf5060e94632cdb80cbe8352c217821ebf7bb961b057ab34153f5e53290109e"
+VER=5.1.6
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-qt"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138234"

--- a/app-utils/qt6ct/spec
+++ b/app-utils/qt6ct/spec
@@ -1,4 +1,5 @@
 VER=0.9
+REL=1
 SRCS="git::commit=tags/${VER}::https://github.com/trialuser02/qt6ct"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=288166"

--- a/runtime-desktop/qt-6/autobuild/defines
+++ b/runtime-desktop/qt-6/autobuild/defines
@@ -103,3 +103,6 @@ CMAKE_AFTER__RISCV64="${CMAKE_AFTER__NOWEBENGINE} \
 
 # Note: Needed for libQt6QmlDom.a
 NOSTATIC=0
+
+# Does not work if built with qt 6.6
+PKGBREAK="fcitx5-qt<=1:5.1.3-1 fcitx-qt5<=1.2.7-3"

--- a/runtime-desktop/qt-6/autobuild/patches/0003-Gentoo-x11-header.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0003-Gentoo-x11-header.patch
@@ -1,0 +1,14 @@
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/ui/gl/gl_display.cc b/qtwebengine/src/3rdparty/chromium/ui/gl/gl_display.cc
+--- a/qtwebengine/src/3rdparty/chromium/ui/gl/gl_display.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/ui/gl/gl_display.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -28,6 +28,10 @@
+ #include "ui/gl/gl_implementation.h"
+ #include "ui/gl/gl_surface.h"
+ 
++#if defined(USE_GLX)
++#include "ui/gfx/x/connection.h"
++#endif
++
+ #if BUILDFLAG(IS_OZONE)
+ #include "ui/ozone/buildflags.h"
+ #endif  // BUILDFLAG(IS_OZONE)

--- a/runtime-desktop/qt-6/autobuild/patches/0004-Gentoo-ninja-race-condition.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0004-Gentoo-ninja-race-condition.patch
@@ -1,0 +1,33 @@
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn b/qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn
+--- a/qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
+@@ -196,6 +196,7 @@ jumbo_source_set("browser") {
+     "//components/services/storage/dom_storage:local_storage_proto",
+     "//components/services/storage/public/cpp",
+     "//components/services/storage/public/mojom",
++    "//components/spellcheck:buildflags",
+     "//components/sqlite_proto",
+     "//components/system_media_controls",
+     "//components/tracing:startup_tracing",
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/extensions/browser/api/declarative_net_request/BUILD.gn b/qtwebengine/src/3rdparty/chromium/extensions/browser/api/declarative_net_request/BUILD.gn
+--- a/qtwebengine/src/3rdparty/chromium/extensions/browser/api/declarative_net_request/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/extensions/browser/api/declarative_net_request/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
+@@ -20,6 +20,7 @@ source_set("declarative_net_request") {
+   deps = [
+     "//base",
+     "//content/public/browser",
++    "//components/web_cache/public/mojom",
+     "//extensions/common",
+     "//extensions/common/api",
+     "//services/preferences/public/cpp",
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/core/configure/BUILD.root.gn.in b/qtwebengine/src/core/configure/BUILD.root.gn.in
+--- a/qtwebengine/src/core/configure/BUILD.root.gn.in	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/core/configure/BUILD.root.gn.in	2000-01-01 00:00:00.000000000 +0800
+@@ -233,6 +233,7 @@ source_set("qtwebengine_spellcheck_sourc
+ source_set("devtools_sources") {
+   configs += [ ":cpp20_config" ]
+   deps = [
++    "//chrome/app:generated_resources",
+     "//components/zoom",
+     "//third_party/blink/public/mojom:mojom_platform",
+     ]

--- a/runtime-desktop/qt-6/autobuild/patches/0005-Skip-unstable-terser-plugin.patch.loongarch64
+++ b/runtime-desktop/qt-6/autobuild/patches/0005-Skip-unstable-terser-plugin.patch.loongarch64
@@ -1,0 +1,20 @@
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js b/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js
+--- a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js	2000-01-01 00:00:00.000000000 +0800
+@@ -19,11 +19,11 @@ export default commandLineArgs => ({
+     sourcemap: Boolean(commandLineArgs.configSourcemaps),
+   }],
+   plugins: [
+-    terser({
+-      compress: {
+-        pure_funcs: commandLineArgs.configDCHECK ? ['Platform.DCHECK'] : [],
+-      },
+-    }),
++    // terser({
++    //   compress: {
++    //     pure_funcs: commandLineArgs.configDCHECK ? ['Platform.DCHECK'] : [],
++    //   },
++    // }),
+     {
+       name: 'devtools-plugin',
+       resolveId(source, importer) {

--- a/runtime-desktop/qt-6/autobuild/patches/0006-loongarch64-support.patch.loongarch64
+++ b/runtime-desktop/qt-6/autobuild/patches/0006-loongarch64-support.patch.loongarch64
@@ -1,27 +1,7061 @@
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/cmake/Functions.cmake b/qtwebengine/cmake/Functions.cmake
---- a/qtwebengine/cmake/Functions.cmake	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/cmake/Functions.cmake	2000-01-01 00:00:00.000000000 +0800
-@@ -635,6 +635,8 @@ function(get_gn_arch result arch)
-         set(${result} "mips64el" PARENT_SCOPE)
-     elseif(arch STREQUAL "riscv64")
-         set(${result} "riscv64" PARENT_SCOPE)
-+    elseif(arch STREQUAL "loongarch64")
-+        set(${result} "loong64" PARENT_SCOPE)
-     else()
-         message(FATAL_ERROR "Unknown architecture: ${arch}")
-     endif()
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.gni b/qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.gni
---- a/qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.gni	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.gni	2000-01-01 00:00:00.000000000 +0800
-@@ -14,7 +14,7 @@ if (is_apple) {
- if (is_nacl) {
-   # NaCl targets don't use 64-bit pointers.
-   has_64_bit_pointers = false
--} else if (current_cpu == "x64" || current_cpu == "arm64") {
-+} else if (current_cpu == "x64" || current_cpu == "arm64" || current_cpu == "loong64") {
-   has_64_bit_pointers = true
- } else if (current_cpu == "x86" || current_cpu == "arm") {
-   has_64_bit_pointers = false
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h	2000-01-01 00:00:00.000000000 +0800
+@@ -687,6 +687,56 @@ struct MinidumpContextRISCV64 {
+   uint32_t fcsr;
+ };
+ 
++//! \brief LOONG64-specifc flags for MinidumpContextLOONG64::context_flags.
++//! Based on minidump_cpu_loong64.h from breakpad
++enum MinidumpContextLOONG64Flags : uint32_t {
++  //! \brief Identifies the context structure as LOONG64.
++  kMinidumpContextLOONG64 = 0x00800000,
++
++  //! \brief Indicates the validity of integer registers.
++  //!
++  //! Registers `0`-`31`, `csr_era` are valid.
++  kMinidumpContextLOONG64Integer = kMinidumpContextLOONG64 | 0x00000002,
++
++  //! \brief Indicates the validity of floating point registers.
++  //!
++  //! Floating point registers `0`-`31`, `fcsr` and `fcc` are valid
++  kMinidumpContextLOONG64FloatingPoint = kMinidumpContextLOONG64 | 0x00000004,
++
++  //! \brief Indicates the validity of all registers.
++  kMinidumpContextLOONG64All = kMinidumpContextLOONG64Integer |
++                              kMinidumpContextLOONG64FloatingPoint,
++};
++
++//! \brief A LOONG64 CPU context (register state) carried in a minidump file.
++struct MinidumpContextLOONG64 {
++  uint64_t context_flags;
++
++  //! \brief General purpose registers.
++  uint64_t regs[32];
++
++  //! \brief csr_era registers.
++  uint64_t csr_era;
++
++  //! \brief FPU registers.
++  union {
++    struct {
++      float _fp_fregs;
++      uint32_t _fp_pad;
++    } fregs[32];
++    double dregs[32];
++  } fpregs;
++
++  //! \brief Floating-point status and control register.
++  uint64_t fcc;
++
++  //! \brief Floating-point control and status register.
++  uint32_t fcsr;
++
++  //! \brief padding
++  uint32_t _pad;
++};
++
+ }  // namespace crashpad
+ 
+ #endif  // CRASHPAD_MINIDUMP_MINIDUMP_CONTEXT_H_
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -109,6 +109,13 @@ MinidumpContextWriter::CreateFromSnapsho
+       break;
+     }
+ 
++    case kCPUArchitectureLOONG64: {
++      context = std::make_unique<MinidumpContextLOONG64Writer>();
++      reinterpret_cast<MinidumpContextLOONG64Writer*>(context.get())
++          ->InitializeFromSnapshot(context_snapshot->loong64);
++      break;
++    }
++
+     default: {
+       LOG(ERROR) << "unknown context architecture "
+                  << context_snapshot->architecture;
+@@ -600,5 +607,44 @@ size_t MinidumpContextRISCV64Writer::Con
+   DCHECK_GE(state(), kStateFrozen);
+   return sizeof(context_);
+ }
++
++MinidumpContextLOONG64Writer::MinidumpContextLOONG64Writer()
++    : MinidumpContextWriter(), context_() {
++  context_.context_flags = kMinidumpContextLOONG64;
++}
++
++MinidumpContextLOONG64Writer::~MinidumpContextLOONG64Writer() = default;
++
++void MinidumpContextLOONG64Writer::InitializeFromSnapshot(
++    const CPUContextLOONG64* context_snapshot) {
++  DCHECK_EQ(state(), kStateMutable);
++  DCHECK_EQ(context_.context_flags, kMinidumpContextLOONG64);
++
++  context_.context_flags = kMinidumpContextLOONG64All;
++
++  static_assert(sizeof(context_.regs) == sizeof(context_snapshot->regs),
++                "GPRs size mismatch");
++  memcpy(context_.regs, context_snapshot->regs, sizeof(context_.regs));
++  context_.csr_era = context_snapshot->csr_era;
++
++  static_assert(sizeof(context_.fpregs) == sizeof(context_snapshot->fpregs),
++                "FPRs size mismatch");
++  memcpy(context_.fpregs.dregs,
++         context_snapshot->fpregs.dregs,
++         sizeof(context_.fpregs.dregs));
++  context_.fcsr = context_snapshot->fcsr;
++  context_.fcc = context_snapshot->fcc;
++}
++
++bool MinidumpContextLOONG64Writer::WriteObject(
++    FileWriterInterface* file_writer) {
++  DCHECK_EQ(state(), kStateWritable);
++  return file_writer->Write(&context_, sizeof(context_));
++}
++
++size_t MinidumpContextLOONG64Writer::ContextSize() const {
++  DCHECK_GE(state(), kStateFrozen);
++  return sizeof(context_);
++}
+ 
+ }  // namespace crashpad
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h	2000-01-01 00:00:00.000000000 +0800
+@@ -413,6 +413,44 @@ class MinidumpContextRISCV64Writer final
+   MinidumpContextRISCV64 context_;
+ };
+ 
++//! \brief The writer for a MinidumpContextLOONG64 structure in a minidump file.
++class MinidumpContextLOONG64Writer final : public MinidumpContextWriter {
++ public:
++  MinidumpContextLOONG64Writer();
++  ~MinidumpContextLOONG64Writer() override;
++
++  //! \brief Initializes the MinidumpContextLOONG64 based on \a context_snapshot.
++  //!
++  //! \param[in] context_snapshot The context snapshot to use as source data.
++  //!
++  //! \note Valid in #kStateMutable. No mutation of context() may be done before
++  //!     calling this method, and it is not normally necessary to alter
++  //!     context() after calling this method.
++  void InitializeFromSnapshot(const CPUContextLOONG64* context_snapshot);
++
++  //! \brief Returns a pointer to the context structure that this object will
++  //!     write.
++  //!
++  //! \attention This returns a non-`const` pointer to this object’s private
++  //!     data so that a caller can populate the context structure directly.
++  //!     This is done because providing setter interfaces to each field in the
++  //!     context structure would be unwieldy and cumbersome. Care must be taken
++  //!     to populate the context structure correctly. The context structure
++  //!     must only be modified while this object is in the #kStateMutable
++  //!     state.
++  MinidumpContextLOONG64* context() { return &context_; }
++
++ protected:
++  // MinidumpWritable:
++  bool WriteObject(FileWriterInterface* file_writer) override;
++
++  // MinidumpContextWriter:
++  size_t ContextSize() const override;
++
++ private:
++  MinidumpContextLOONG64 context_;
++};
++
+ }  // namespace crashpad
+ 
+ #endif  // CRASHPAD_MINIDUMP_MINIDUMP_CONTEXT_WRITER_H_
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h	2000-01-01 00:00:00.000000000 +0800
+@@ -213,6 +213,9 @@ enum MinidumpCPUArchitecture : uint16_t
+   //! \brief Used by Breakpad for 64-bit RISC-V.
+   kMinidumpCPUArchitectureRISCV64Breakpad = 0x8006,
+ 
++  //! \brief Used by Breakpad for 64-bit LoongArch.
++  kMinidumpCPUArchitectureLOONG64Breakpad = 0x8007,
++
+   //! \brief Unknown CPU architecture.
+   kMinidumpCPUArchitectureUnknown = PROCESSOR_ARCHITECTURE_UNKNOWN,
+ };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -177,6 +177,8 @@ std::string MinidumpMiscInfoDebugBuildSt
+   static constexpr char kCPU[] = "mips64";
+ #elif defined(ARCH_CPU_RISCV64)
+   static constexpr char kCPU[] = "riscv64";
++#elif defined(ARCH_CPU_LOONGARCH64)
++  static constexpr char kCPU[] = "loong64";
+ #else
+ #error define kCPU for this CPU
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -135,6 +135,9 @@ void MinidumpSystemInfoWriter::Initializ
+     case kCPUArchitectureRISCV64:
+       cpu_architecture = kMinidumpCPUArchitectureRISCV64Breakpad;
+       break;
++    case kCPUArchitectureLOONG64:
++      cpu_architecture = kMinidumpCPUArchitectureLOONG64Breakpad;
++      break;
+     default:
+       NOTREACHED();
+       cpu_architecture = kMinidumpCPUArchitectureUnknown;
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -122,6 +122,11 @@ void CaptureMemory::PointedToByContext(c
+   for (size_t i = 0; i < std::size(context.riscv64->regs); ++i) {
+     MaybeCaptureMemoryAround(delegate, context.riscv64->regs[i]);
+   }
++#elif defined(ARCH_CPU_LOONGARCH64)
++  MaybeCaptureMemoryAround(delegate, context.loong64->csr_era);
++  for (size_t i = 0; i < std::size(context.loong64->regs); ++i) {
++    MaybeCaptureMemoryAround(delegate, context.loong64->regs[i]);
++  }
+ #else
+ #error Port.
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h	2000-01-01 00:00:00.000000000 +0800
+@@ -47,6 +47,9 @@ enum CPUArchitecture {
+ 
+   //! \brief 64-bit RISC-V.
+   kCPUArchitectureRISCV64,
++
++  //! \brief 64-bit LOONGARCH.
++  kCPUArchitectureLOONG64,
+ };
+ 
+ }  // namespace crashpad
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -173,6 +173,8 @@ uint64_t CPUContext::InstructionPointer(
+       return arm64->pc;
+     case kCPUArchitectureRISCV64:
+       return riscv64->pc;
++    case kCPUArchitectureLOONG64:
++      return loong64->csr_era;
+     default:
+       NOTREACHED();
+       return ~0ull;
+@@ -191,6 +193,8 @@ uint64_t CPUContext::StackPointer() cons
+       return arm64->sp;
+     case kCPUArchitectureRISCV64:
+       return riscv64->regs[1];
++    case kCPUArchitectureLOONG64:
++      return loong64->regs[3];
+     default:
+       NOTREACHED();
+       return ~0ull;
+@@ -232,6 +236,7 @@ bool CPUContext::Is64Bit() const {
+     case kCPUArchitectureARM64:
+     case kCPUArchitectureMIPS64EL:
+     case kCPUArchitectureRISCV64:
++    case kCPUArchitectureLOONG64:
+       return true;
+     case kCPUArchitectureX86:
+     case kCPUArchitectureARM:
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h	2000-01-01 00:00:00.000000000 +0800
+@@ -371,6 +371,22 @@ struct CPUContextRISCV64 {
+   uint32_t fcsr;
+ };
+ 
++//! \brief A context structure carrying LOONG64 CPU state.
++struct CPUContextLOONG64 {
++  uint64_t regs[32];
++  uint64_t csr_era;
++
++  union {
++    double dregs[32];
++    struct {
++      float _fp_fregs;
++      uint32_t _fp_pad;
++    } fregs[32];
++  } fpregs;
++  uint64_t fcc;
++  uint32_t fcsr;
++};
++
+ //! \brief A context structure capable of carrying the context of any supported
+ //!     CPU architecture.
+ struct CPUContext {
+@@ -412,6 +428,7 @@ struct CPUContext {
+     CPUContextMIPS* mipsel;
+     CPUContextMIPS64* mips64;
+     CPUContextRISCV64* riscv64;
++    CPUContextLOONG64* loong64;
+   };
+ };
+ 
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -281,6 +281,40 @@ void InitializeCPUContextRISCV64(const T
+   context->fcsr = float_context.fcsr;
+ }
+ 
++#elif defined(ARCH_CPU_LOONGARCH64)
++
++void InitializeCPUContextLOONG64_NoFloatingPoint(
++    const ThreadContext::t64_t& thread_context,
++    CPUContextLOONG64* context) {
++  static_assert(sizeof(context->regs) == sizeof(thread_context.regs),
++                "gpr context size mismtach");
++  memcpy(context->regs, thread_context.regs, sizeof(context->regs));
++  context->csr_era = thread_context.csr_era;
++
++  memset(&context->fpregs, 0, sizeof(context->fpregs));
++  context->fcc = 0;
++  context->fcsr = 0;
++}
++
++void InitializeCPUContextLOONG64_OnlyFPU(
++    const FloatContext::f64_t& float_context,
++    CPUContextLOONG64* context) {
++  static_assert(sizeof(context->fpregs) == sizeof(float_context.fpregs),
++                "fpu context size mismatch");
++  memcpy(&context->fpregs, &float_context.fpregs, sizeof(context->fpregs));
++  context->fcc = float_context.fcc;
++  context->fcsr = float_context.fcsr;
++}
++
++void InitializeCPUContextLOONG64(
++    const ThreadContext::t64_t& thread_context,
++    const FloatContext::f64_t& float_context,
++    CPUContextLOONG64* context) {
++  InitializeCPUContextLOONG64_NoFloatingPoint(thread_context, context);
++
++  InitializeCPUContextLOONG64_OnlyFPU(float_context, context);
++}
++
+ #endif  // ARCH_CPU_X86_FAMILY
+ 
+ }  // namespace internal
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h	2000-01-01 00:00:00.000000000 +0800
+@@ -188,6 +188,45 @@ void InitializeCPUContextRISCV64(const T
+ 
+ #endif  // ARCH_CPU_RISCV64 || DOXYGEN
+ 
++#if defined(ARCH_CPU_LOONGARCH64) || DOXYGEN
++
++//! \brief Initializes GPR state in a CPUContextLOONG64 from a native context
++//!     structure on Linux.
++//!
++//! Floating point state is initialized to zero.
++//!
++//! \param[in] thread_context The native thread context.
++//! \param[out] context The CPUContextLOONG64 structure to initialize.
++void InitializeCPUContextLOONG64_NoFloatingPoint(
++    const ThreadContext::t64_t& thread_context,
++    CPUContextLOONG64* context);
++//! \brief Initializes FPU state in a CPUContextLOONG64 from a native fpu
++//!     signal context structure on Linux.
++//!
++//! General purpose registers are not initialized.
++//!
++//! \param[in] float_context The native fpu context.
++//! \param[out] context The CPUContextLOONG64 structure to initialize.
++void InitializeCPUContextLOONG64_OnlyFPU(
++    const FloatContext::f64_t& float_context,
++    CPUContextLOONG64* context);
++//! \brief Initializes a CPUContextLOONG64 structure from native context
++//!     structures on Linux.
++//!
++//! This function has template specializations for LOONG64 architecture
++//! contexts, using ContextTraits32 or ContextTraits64 as template parameter,
++//! respectively.
++//!
++//! \param[in] thread_context The native thread context.
++//! \param[in] float_context The native float context.
++//! \param[out] context The CPUContextLOONG64 structure to initialize.
++void InitializeCPUContextLOONG64(
++    const ThreadContext::t64_t& thread_context,
++    const FloatContext::f64_t& float_context,
++    CPUContextLOONG64* context);
++
++#endif  // ARCH_CPU_LOONGARCH64 || DOXYGEN
++
+ }  // namespace internal
+ }  // namespace crashpad
+ 
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -15,6 +15,7 @@
+ #include "snapshot/linux/exception_snapshot_linux.h"
+ 
+ #include <signal.h>
++#include <cstring>
+ 
+ #include "base/logging.h"
+ #include "snapshot/linux/capture_memory_delegate_linux.h"
+@@ -367,6 +368,77 @@ bool ExceptionSnapshotLinux::ReadContext
+   return internal::ReadContext(reader, context_address, context_.riscv64);
+ }
+ 
++#elif defined(ARCH_CPU_LOONGARCH64)
++
++static bool ReadContext(ProcessReaderLinux* reader,
++                        LinuxVMAddress context_address,
++                        typename ContextTraits64::CPUContext* dest_context) {
++  const ProcessMemory* memory = reader->Memory();
++  LinuxVMAddress gregs_address = context_address +
++                                 offsetof(UContext<ContextTraits64>, mcontext);
++  ThreadContext::t64_t thread_context;
++  ContextTraits64::MContext mcontext;
++  if (!memory->Read(gregs_address, sizeof(mcontext), &mcontext)) {
++    LOG(ERROR) << "Couldn't read gregs";
++    return false;
++  }
++  static_assert(sizeof(thread_context.regs) == sizeof(mcontext.gregs),
++                "gpr context size mismtach");
++  memcpy(thread_context.regs, mcontext.gregs, sizeof(mcontext.gregs));
++  thread_context.csr_era = mcontext.pc;
++  thread_context.orig_a0 = 0;
++  thread_context.csr_badv = 0;
++  InitializeCPUContextLOONG64_NoFloatingPoint(thread_context, dest_context);
++  LinuxVMAddress reserved_address =
++        context_address + offsetof(UContext<ContextTraits64>, mcontext.extcontext);
++  if ((reserved_address & 15) != 0) {
++    LOG(ERROR) << "invalid alignment 0x" << std::hex << reserved_address;
++    return false;
++   }
++  constexpr VMSize kMaxContextSpace = 4096;
++  ProcessMemoryRange range;
++  if (!range.Initialize(memory, true, reserved_address, kMaxContextSpace)) {
++    return false;
++  }
++  do {
++    struct sctx_info head;
++    if (!range.Read(reserved_address, sizeof(head), &head)) {
++      LOG(ERROR) << "missing context terminator";
++      return false;
++    }
++    reserved_address += sizeof(head);
++    switch (head.magic) {
++      case FPU_CTX_MAGIC:
++        if (head.size != sizeof(struct fpu_context) + sizeof(head)) {
++          LOG(ERROR) << "unexpected fpu context size " << head.size;
++          return false;
++        }
++        FloatContext::f64_t fpucontext;
++        if (!range.Read(reserved_address, sizeof(fpucontext), &fpucontext)) {
++          LOG(ERROR) << "Couldn't read fpu " << head.size;
++          return false;
++        }
++        InitializeCPUContextLOONG64_OnlyFPU(fpucontext, dest_context);
++        return true;
++      case 0:
++        return true;
++      default:
++        LOG(ERROR) << "invalid magic number 0x" << std::hex << head.magic;
++        return false;
++    }
++  } while (true);
++}
++
++template <>
++bool ExceptionSnapshotLinux::ReadContext<ContextTraits64>(
++    ProcessReaderLinux* reader,
++    LinuxVMAddress context_address) {
++  context_.architecture = kCPUArchitectureLOONG64;
++  context_.loong64 = &context_union_.loong64;
++
++  return internal::ReadContext(reader, context_address, context_.loong64);
++}
++
+ #endif  // ARCH_CPU_X86_FAMILY
+ 
+ bool ExceptionSnapshotLinux::Initialize(
+@@ -397,7 +469,7 @@ bool ExceptionSnapshotLinux::Initialize(
+       return false;
+     }
+   } else {
+-#if !defined(ARCH_CPU_RISCV64)
++#if !defined(ARCH_CPU_RISCV64) && !defined(ARCH_CPU_LOONGARCH64)
+     if (!ReadContext<ContextTraits32>(process_reader, context_address) ||
+         !ReadSiginfo<Traits32>(process_reader, siginfo_address)) {
+       return false;
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h	2000-01-01 00:00:00.000000000 +0800
+@@ -91,6 +91,8 @@ class ExceptionSnapshotLinux final : pub
+     CPUContextMIPS64 mips64;
+ #elif defined(ARCH_CPU_RISCV64)
+     CPUContextRISCV64 riscv64;
++#elif defined(ARCH_CPU_LOONGARCH64)
++    CPUContextLOONG64 loong64;
+ #endif
+   } context_union_;
+   CPUContext context_;
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -129,6 +129,8 @@ void ProcessReaderLinux::Thread::Initial
+                                     : thread_info.thread_context.t32.regs[29];
+ #elif defined(ARCH_CPU_RISCV64)
+   stack_pointer = thread_info.thread_context.t64.regs[1];
++#elif defined(ARCH_CPU_LOONGARCH64)
++  stack_pointer = thread_info.thread_context.t64.regs[3];
+ #else
+ #error Port.
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h	2000-01-01 00:00:00.000000000 +0800
+@@ -456,6 +456,46 @@ static_assert(offsetof(UContext<ContextT
+                   offsetof(ucontext_t, uc_mcontext.__fpregs),
+               "context offset mismatch");
+ 
++#elif defined(ARCH_CPU_LOONGARCH64)
++
++// See asm/sigcontext.h
++struct MContext64 {
++  uint64_t pc;
++  uint64_t gregs[32];
++  uint32_t flags;
++  uint32_t padding;
++  uint64_t extcontext[0] __attribute__((__aligned__(16)));
++};
++
++struct ContextTraits64 : public Traits64 {
++  using MContext = MContext64;
++  using SignalThreadContext = ThreadContext::t64_t;
++  using SignalFloatContext = FloatContext::f64_t;
++  using CPUContext = CPUContextLOONG64;
++};
++
++// See asm/ucontext.h
++template <typename Traits>
++struct UContext {
++  typename Traits::ULong flags;
++  typename Traits::Address link;
++  SignalStack<Traits> stack;
++  Sigset<Traits> sigmask;
++  char alignment_padding_[8];
++  char padding[128 - sizeof(Sigset<Traits>)];
++  MContext64 mcontext;
++};
++
++static_assert(offsetof(UContext<ContextTraits64>, mcontext) ==
++                  offsetof(ucontext_t, uc_mcontext),
++              "context offset mismatch");
++static_assert(offsetof(UContext<ContextTraits64>, mcontext.gregs) ==
++                  offsetof(ucontext_t, uc_mcontext.__gregs),
++              "context offset mismatch");
++static_assert(offsetof(UContext<ContextTraits64>, mcontext.extcontext) ==
++                  offsetof(ucontext_t, uc_mcontext.__extcontext),
++              "context offset mismatch");
++
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -207,6 +207,8 @@ CPUArchitecture SystemSnapshotLinux::Get
+                                     : kCPUArchitectureMIPSEL;
+ #elif defined(ARCH_CPU_RISCV64)
+   return kCPUArchitectureRISCV64;
++#elif defined(ARCH_CPU_LOONGARCH64)
++  return kCPUArchitectureLOONG64;
+ #else
+ #error port to your architecture
+ #endif
+@@ -225,6 +227,9 @@ uint32_t SystemSnapshotLinux::CPURevisio
+ #elif defined(ARCH_CPU_RISCV64)
+   // Not implemented
+   return 0;
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++  // Not implemented
++  return 0;
+ #else
+ #error port to your architecture
+ #endif
+@@ -248,6 +253,9 @@ std::string SystemSnapshotLinux::CPUVend
+ #elif defined(ARCH_CPU_RISCV64)
+   // Not implemented
+   return std::string();
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++  // Not implemented
++  return std::string();
+ #else
+ #error port to your architecture
+ #endif
+@@ -384,6 +392,9 @@ bool SystemSnapshotLinux::NXEnabled() co
+ #elif defined(ARCH_CPU_RISCV64)
+   // Not implemented
+   return false;
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++  // Not implemented
++  return false;
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -196,6 +196,13 @@ bool ThreadSnapshotLinux::Initialize(
+   InitializeCPUContextRISCV64(thread.thread_info.thread_context.t64,
+                               thread.thread_info.float_context.f64,
+                               context_.riscv64);
++#elif defined(ARCH_CPU_LOONGARCH64)
++  context_.architecture = kCPUArchitectureLOONG64;
++  context_.loong64 = &context_union_.loong64;
++  InitializeCPUContextLOONG64<ContextTraits64>(
++      thread.thread_info.thread_context.t64,
++      thread.thread_info.float_context.f64,
++      context_.loong64);
+ #else
+ #error Port.
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h	2000-01-01 00:00:00.000000000 +0800
+@@ -76,6 +76,8 @@ class ThreadSnapshotLinux final : public
+     CPUContextMIPS64 mips64;
+ #elif defined(ARCH_CPU_RISCV64)
+     CPUContextRISCV64 riscv64;
++#elif defined(ARCH_CPU_LOONGARCH64)
++    CPUContextLOONG64 loong64;
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -293,6 +293,30 @@ bool MinidumpContextConverter::Initializ
+     memcpy(&context_.riscv64->fpregs, &src->fpregs, sizeof(src->fpregs));
+ 
+     context_.riscv64->fcsr = src->fcsr;
++  } else if (context_.architecture ==
++             CPUArchitecture::kCPUArchitectureLOONG64) {
++    context_memory_.resize(sizeof(CPUContextLOONG64));
++    context_.loong64 =
++        reinterpret_cast<CPUContextLOONG64*>(context_memory_.data());
++    const MinidumpContextLOONG64* src =
++        reinterpret_cast<const MinidumpContextLOONG64*>(minidump_context.data());
++    if (minidump_context.size() < sizeof(MinidumpContextLOONG64)) {
++      return false;
++    }
++
++    if (!(src->context_flags & kMinidumpContextLOONG64)) {
++      return false;
++    }
++
++    for (size_t i = 0; i < std::size(src->regs); i++) {
++      context_.loong64->regs[i] = src->regs[i];
++    }
++
++    context_.loong64->csr_era = src->csr_era;
++    context_.loong64->fcsr = src->fcsr;
++    context_.loong64->fcc = src->fcc;
++
++    memcpy(&context_.loong64->fpregs, &src->fpregs, sizeof(src->fpregs));
+   } else {
+     // Architecture is listed as "unknown".
+     DLOG(ERROR) << "Unknown architecture";
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -70,6 +70,8 @@ CPUArchitecture SystemSnapshotMinidump::
+     // No word on how MIPS64 is signalled
+     case kMinidumpCPUArchitectureRISCV64Breakpad:
+       return kCPUArchitectureRISCV64;
++    case kMinidumpCPUArchitectureLOONG64Breakpad:
++      return kCPUArchitectureLOONG64;
+ 
+     default:
+       return CPUArchitecture::kCPUArchitectureUnknown;
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -429,6 +429,37 @@ bool GetThreadArea64(pid_t tid,
+   return true;
+ }
+ 
++#elif defined(ARCH_CPU_LOONGARCH64)
++
++bool GetFloatingPointRegisters64(pid_t tid,
++                                 FloatContext* context,
++                                 bool can_log) {
++  iovec iov;
++  iov.iov_base = context;
++  iov.iov_len = sizeof(*context);
++  if (ptrace(
++          PTRACE_GETREGSET, tid, reinterpret_cast<void*>(NT_PRFPREG), &iov) !=
++      0) {
++    PLOG_IF(ERROR, can_log) << "ptrace";
++    return false;
++  }
++  if (iov.iov_len != sizeof(context->f64)) {
++    LOG_IF(ERROR, can_log) << "Unexpected registers size " << iov.iov_len
++                           << " != " << sizeof(context->f64);
++    return false;
++  }
++  return true;
++}
++
++bool GetThreadArea64(pid_t tid,
++                     const ThreadContext& context,
++                     LinuxVMAddress* address,
++                     bool can_log) {
++  // Thread pointer register
++  *address = context.t64.regs[2];
++  return true;
++}
++
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+@@ -533,7 +564,7 @@ bool Ptracer::GetThreadInfo(pid_t tid, T
+                            can_log_);
+   }
+ 
+-#if !defined(ARCH_CPU_RISCV64)
++#if !defined(ARCH_CPU_RISCV64) && !defined(ARCH_CPU_LOONGARCH64)
+   return GetGeneralPurposeRegisters32(tid, &info->thread_context, can_log_) &&
+          GetFloatingPointRegisters32(tid, &info->float_context, can_log_) &&
+          GetThreadArea32(tid,
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h	2000-01-01 00:00:00.000000000 +0800
+@@ -87,6 +87,8 @@ union ThreadContext {
+     uint32_t padding1_;
+ #elif defined(ARCH_CPU_RISCV64)
+     // 32 bit RISC-V not supported
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++    // 32 bit LoongArch not supported
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+@@ -144,13 +146,20 @@ union ThreadContext {
+     // Reflects user_regs_struct in asm/ptrace.h.
+     uint64_t pc;
+     uint64_t regs[31];
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++    // Reflects user_regs_struct in sys/user.h.
++    uint64_t regs[32];
++    uint64_t orig_a0;
++    uint64_t csr_era;
++    uint64_t csr_badv;
++    uint64_t reserved[10];
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+   } t64;
+ 
+ #if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM64) || \
+-    defined(ARCH_CPU_RISCV64)
++    defined(ARCH_CPU_RISCV64) || defined(ARCH_CPU_LOONGARCH64)
+   using NativeThreadContext = user_regs_struct;
+ #elif defined(ARCH_CPU_ARMEL)
+   using NativeThreadContext = user_regs;
+@@ -233,6 +242,8 @@ union FloatContext {
+     uint32_t fpu_id;
+ #elif defined(ARCH_CPU_RISCV64)
+     // 32 bit RISC-V not supported
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++    // 32 bit LoongArch not supported
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+@@ -271,6 +282,11 @@ union FloatContext {
+     // Reflects __riscv_d_ext_state in asm/ptrace.h
+     uint64_t fpregs[32];
+     uint64_t fcsr;
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++    // Reflects user_fp_struct in sys/user.h
++    uint64_t fpregs[32];
++    uint64_t fcc;
++    uint32_t fcsr;
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+@@ -302,6 +318,8 @@ union FloatContext {
+ // No appropriate floating point context native type for available MIPS.
+ #elif defined(ARCH_CPU_RISCV64)
+   static_assert(sizeof(f64) == sizeof(__riscv_d_ext_state), "Size mismatch");
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++  static_assert(sizeof(f64) == sizeof(user_fp_struct), "Size mismatch");
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S	2000-01-01 00:00:00.000000000 +0800
+@@ -338,6 +338,51 @@ CAPTURECONTEXT_SYMBOL2:
+ 
+   // TODO(https://crashpad.chromium.org/bug/300): save floating-point registers.
+ 
++#elif defined(__loongarch_lp64)
++
++#define MCONTEXT_GREG_SIZE 8
++#define MCONTEXT_PC_OFFSET 176
++#define MCONTEXT_GREGS_OFFSET 184
++
++#define STORE_GPR(X) st.d $r##X, $a0, MCONTEXT_GREGS_OFFSET + X * MCONTEXT_GREG_SIZE
++#define STORE_PC st.d $ra, $a0, MCONTEXT_PC_OFFSET
++
++  STORE_PC
++  STORE_GPR(0)
++  STORE_GPR(1)
++  STORE_GPR(2)
++  STORE_GPR(3)
++  STORE_GPR(4)
++  STORE_GPR(5)
++  STORE_GPR(6)
++  STORE_GPR(7)
++  STORE_GPR(8)
++  STORE_GPR(9)
++  STORE_GPR(10)
++  STORE_GPR(11)
++  STORE_GPR(12)
++  STORE_GPR(13)
++  STORE_GPR(14)
++  STORE_GPR(15)
++  STORE_GPR(16)
++  STORE_GPR(17)
++  STORE_GPR(18)
++  STORE_GPR(19)
++  STORE_GPR(20)
++  STORE_GPR(21)
++  STORE_GPR(22)
++  STORE_GPR(23)
++  STORE_GPR(24)
++  STORE_GPR(25)
++  STORE_GPR(26)
++  STORE_GPR(27)
++  STORE_GPR(28)
++  STORE_GPR(29)
++  STORE_GPR(30)
++  STORE_GPR(31)
++
++  jirl $zero, $ra, 0
++
+   ret
+ #elif defined(__mips__)
+   .set noat
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -239,6 +239,8 @@ std::string UserAgent() {
+ #endif
+ #elif defined (ARCH_CPU_RISCV64)
+     static constexpr char arch[] = "riscv64";
++#elif defined(ARCH_CPU_LOONGARCH64)
++    static constexpr char arch[] = "loong64";
+ #else
+ #error Port
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,764 @@
++/* Automatically generated by configure - do not modify! */
++#ifndef FFMPEG_CONFIG_H
++#define FFMPEG_CONFIG_H
++#define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-fft --enable-rdft --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\\\\\"-O2\\\\\"' --enable-decoder='theora,vp8' --enable-parser='vp3,vp8' --enable-lto --enable-pic --cc=clang --cxx=clang++ --ld=clang --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'"
++#define FFMPEG_LICENSE "LGPL version 2.1 or later"
++#define CONFIG_THIS_YEAR 2023
++#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
++#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
++#define CC_IDENT "clang version 17.0.6"
++#define OS_NAME linux
++#define av_restrict restrict
++#define EXTERN_PREFIX ""
++#define EXTERN_ASM 
++#define BUILDSUF ""
++#define SLIBSUF ".so"
++#define HAVE_MMX2 HAVE_MMXEXT
++#define SWS_MAX_FILTER_SIZE 256
++#define ARCH_AARCH64 0
++#define ARCH_ALPHA 0
++#define ARCH_ARM 0
++#define ARCH_AVR32 0
++#define ARCH_AVR32_AP 0
++#define ARCH_AVR32_UC 0
++#define ARCH_BFIN 0
++#define ARCH_IA64 0
++#define ARCH_LOONGARCH 1
++#define ARCH_LOONGARCH32 0
++#define ARCH_LOONGARCH64 1
++#define ARCH_M68K 0
++#define ARCH_MIPS 0
++#define ARCH_MIPS64 0
++#define ARCH_PARISC 0
++#define ARCH_PPC 0
++#define ARCH_PPC64 0
++#define ARCH_RISCV 0
++#define ARCH_S390 0
++#define ARCH_SH4 0
++#define ARCH_SPARC 0
++#define ARCH_SPARC64 0
++#define ARCH_TILEGX 0
++#define ARCH_TILEPRO 0
++#define ARCH_TOMI 0
++#define ARCH_X86 0
++#define ARCH_X86_32 0
++#define ARCH_X86_64 0
++#define HAVE_ARMV5TE 0
++#define HAVE_ARMV6 0
++#define HAVE_ARMV6T2 0
++#define HAVE_ARMV8 0
++#define HAVE_DOTPROD 0
++#define HAVE_I8MM 0
++#define HAVE_NEON 0
++#define HAVE_VFP 0
++#define HAVE_VFPV3 0
++#define HAVE_SETEND 0
++#define HAVE_ALTIVEC 0
++#define HAVE_DCBZL 0
++#define HAVE_LDBRX 0
++#define HAVE_POWER8 0
++#define HAVE_PPC4XX 0
++#define HAVE_VSX 0
++#define HAVE_RVV 0
++#define HAVE_AESNI 0
++#define HAVE_AMD3DNOW 0
++#define HAVE_AMD3DNOWEXT 0
++#define HAVE_AVX 0
++#define HAVE_AVX2 0
++#define HAVE_AVX512 0
++#define HAVE_AVX512ICL 0
++#define HAVE_FMA3 0
++#define HAVE_FMA4 0
++#define HAVE_MMX 0
++#define HAVE_MMXEXT 0
++#define HAVE_SSE 0
++#define HAVE_SSE2 0
++#define HAVE_SSE3 0
++#define HAVE_SSE4 0
++#define HAVE_SSE42 0
++#define HAVE_SSSE3 0
++#define HAVE_XOP 0
++#define HAVE_CPUNOP 0
++#define HAVE_I686 0
++#define HAVE_MIPSFPU 0
++#define HAVE_MIPS32R2 0
++#define HAVE_MIPS32R5 0
++#define HAVE_MIPS64R2 0
++#define HAVE_MIPS32R6 0
++#define HAVE_MIPS64R6 0
++#define HAVE_MIPSDSP 0
++#define HAVE_MIPSDSPR2 0
++#define HAVE_MSA 0
++#define HAVE_LOONGSON2 0
++#define HAVE_LOONGSON3 0
++#define HAVE_MMI 0
++#define HAVE_LSX 0
++#define HAVE_LASX 0
++#define HAVE_ARMV5TE_EXTERNAL 0
++#define HAVE_ARMV6_EXTERNAL 0
++#define HAVE_ARMV6T2_EXTERNAL 0
++#define HAVE_ARMV8_EXTERNAL 0
++#define HAVE_DOTPROD_EXTERNAL 0
++#define HAVE_I8MM_EXTERNAL 0
++#define HAVE_NEON_EXTERNAL 0
++#define HAVE_VFP_EXTERNAL 0
++#define HAVE_VFPV3_EXTERNAL 0
++#define HAVE_SETEND_EXTERNAL 0
++#define HAVE_ALTIVEC_EXTERNAL 0
++#define HAVE_DCBZL_EXTERNAL 0
++#define HAVE_LDBRX_EXTERNAL 0
++#define HAVE_POWER8_EXTERNAL 0
++#define HAVE_PPC4XX_EXTERNAL 0
++#define HAVE_VSX_EXTERNAL 0
++#define HAVE_RVV_EXTERNAL 0
++#define HAVE_AESNI_EXTERNAL 0
++#define HAVE_AMD3DNOW_EXTERNAL 0
++#define HAVE_AMD3DNOWEXT_EXTERNAL 0
++#define HAVE_AVX_EXTERNAL 0
++#define HAVE_AVX2_EXTERNAL 0
++#define HAVE_AVX512_EXTERNAL 0
++#define HAVE_AVX512ICL_EXTERNAL 0
++#define HAVE_FMA3_EXTERNAL 0
++#define HAVE_FMA4_EXTERNAL 0
++#define HAVE_MMX_EXTERNAL 0
++#define HAVE_MMXEXT_EXTERNAL 0
++#define HAVE_SSE_EXTERNAL 0
++#define HAVE_SSE2_EXTERNAL 0
++#define HAVE_SSE3_EXTERNAL 0
++#define HAVE_SSE4_EXTERNAL 0
++#define HAVE_SSE42_EXTERNAL 0
++#define HAVE_SSSE3_EXTERNAL 0
++#define HAVE_XOP_EXTERNAL 0
++#define HAVE_CPUNOP_EXTERNAL 0
++#define HAVE_I686_EXTERNAL 0
++#define HAVE_MIPSFPU_EXTERNAL 0
++#define HAVE_MIPS32R2_EXTERNAL 0
++#define HAVE_MIPS32R5_EXTERNAL 0
++#define HAVE_MIPS64R2_EXTERNAL 0
++#define HAVE_MIPS32R6_EXTERNAL 0
++#define HAVE_MIPS64R6_EXTERNAL 0
++#define HAVE_MIPSDSP_EXTERNAL 0
++#define HAVE_MIPSDSPR2_EXTERNAL 0
++#define HAVE_MSA_EXTERNAL 0
++#define HAVE_LOONGSON2_EXTERNAL 0
++#define HAVE_LOONGSON3_EXTERNAL 0
++#define HAVE_MMI_EXTERNAL 0
++#define HAVE_LSX_EXTERNAL 0
++#define HAVE_LASX_EXTERNAL 0
++#define HAVE_ARMV5TE_INLINE 0
++#define HAVE_ARMV6_INLINE 0
++#define HAVE_ARMV6T2_INLINE 0
++#define HAVE_ARMV8_INLINE 0
++#define HAVE_DOTPROD_INLINE 0
++#define HAVE_I8MM_INLINE 0
++#define HAVE_NEON_INLINE 0
++#define HAVE_VFP_INLINE 0
++#define HAVE_VFPV3_INLINE 0
++#define HAVE_SETEND_INLINE 0
++#define HAVE_ALTIVEC_INLINE 0
++#define HAVE_DCBZL_INLINE 0
++#define HAVE_LDBRX_INLINE 0
++#define HAVE_POWER8_INLINE 0
++#define HAVE_PPC4XX_INLINE 0
++#define HAVE_VSX_INLINE 0
++#define HAVE_RVV_INLINE 0
++#define HAVE_AESNI_INLINE 0
++#define HAVE_AMD3DNOW_INLINE 0
++#define HAVE_AMD3DNOWEXT_INLINE 0
++#define HAVE_AVX_INLINE 0
++#define HAVE_AVX2_INLINE 0
++#define HAVE_AVX512_INLINE 0
++#define HAVE_AVX512ICL_INLINE 0
++#define HAVE_FMA3_INLINE 0
++#define HAVE_FMA4_INLINE 0
++#define HAVE_MMX_INLINE 0
++#define HAVE_MMXEXT_INLINE 0
++#define HAVE_SSE_INLINE 0
++#define HAVE_SSE2_INLINE 0
++#define HAVE_SSE3_INLINE 0
++#define HAVE_SSE4_INLINE 0
++#define HAVE_SSE42_INLINE 0
++#define HAVE_SSSE3_INLINE 0
++#define HAVE_XOP_INLINE 0
++#define HAVE_CPUNOP_INLINE 0
++#define HAVE_I686_INLINE 0
++#define HAVE_MIPSFPU_INLINE 0
++#define HAVE_MIPS32R2_INLINE 0
++#define HAVE_MIPS32R5_INLINE 0
++#define HAVE_MIPS64R2_INLINE 0
++#define HAVE_MIPS32R6_INLINE 0
++#define HAVE_MIPS64R6_INLINE 0
++#define HAVE_MIPSDSP_INLINE 0
++#define HAVE_MIPSDSPR2_INLINE 0
++#define HAVE_MSA_INLINE 0
++#define HAVE_LOONGSON2_INLINE 0
++#define HAVE_LOONGSON3_INLINE 0
++#define HAVE_MMI_INLINE 0
++#define HAVE_LSX_INLINE 0
++#define HAVE_LASX_INLINE 0
++#define HAVE_ALIGNED_STACK 0
++#define HAVE_FAST_64BIT 1
++#define HAVE_FAST_CLZ 1
++#define HAVE_FAST_CMOV 0
++#define HAVE_FAST_FLOAT16 0
++#define HAVE_LOCAL_ALIGNED 1
++#define HAVE_SIMD_ALIGN_16 0
++#define HAVE_SIMD_ALIGN_32 1
++#define HAVE_SIMD_ALIGN_64 0
++#define HAVE_ATOMIC_CAS_PTR 0
++#define HAVE_MACHINE_RW_BARRIER 0
++#define HAVE_MEMORYBARRIER 0
++#define HAVE_MM_EMPTY 0
++#define HAVE_RDTSC 0
++#define HAVE_SEM_TIMEDWAIT 1
++#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
++#define HAVE_INLINE_ASM 1
++#define HAVE_SYMVER 0
++#define HAVE_X86ASM 0
++#define HAVE_BIGENDIAN 0
++#define HAVE_FAST_UNALIGNED 1
++#define HAVE_ARPA_INET_H 0
++#define HAVE_ASM_HWCAP_H 1
++#define HAVE_ASM_TYPES_H 1
++#define HAVE_CDIO_PARANOIA_H 0
++#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
++#define HAVE_CUDA_H 0
++#define HAVE_DISPATCH_DISPATCH_H 0
++#define HAVE_DEV_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_BKTR_IOCTL_METEOR_H 0
++#define HAVE_DEV_IC_BT8XX_H 0
++#define HAVE_DEV_VIDEO_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_VIDEO_METEOR_IOCTL_METEOR_H 0
++#define HAVE_DIRECT_H 0
++#define HAVE_DIRENT_H 1
++#define HAVE_DXGIDEBUG_H 0
++#define HAVE_DXVA_H 0
++#define HAVE_ES2_GL_H 0
++#define HAVE_GSM_H 0
++#define HAVE_IO_H 0
++#define HAVE_LINUX_DMA_BUF_H 0
++#define HAVE_LINUX_PERF_EVENT_H 1
++#define HAVE_MACHINE_IOCTL_BT848_H 0
++#define HAVE_MACHINE_IOCTL_METEOR_H 0
++#define HAVE_MALLOC_H 1
++#define HAVE_OPENCV2_CORE_CORE_C_H 0
++#define HAVE_OPENGL_GL3_H 0
++#define HAVE_POLL_H 1
++#define HAVE_SYS_PARAM_H 1
++#define HAVE_SYS_RESOURCE_H 1
++#define HAVE_SYS_SELECT_H 1
++#define HAVE_SYS_SOUNDCARD_H 1
++#define HAVE_SYS_TIME_H 1
++#define HAVE_SYS_UN_H 1
++#define HAVE_SYS_VIDEOIO_H 0
++#define HAVE_TERMIOS_H 1
++#define HAVE_UDPLITE_H 0
++#define HAVE_UNISTD_H 1
++#define HAVE_VALGRIND_VALGRIND_H 0
++#define HAVE_WINDOWS_H 0
++#define HAVE_WINSOCK2_H 0
++#define HAVE_INTRINSICS_NEON 0
++#define HAVE_ATANF 1
++#define HAVE_ATAN2F 1
++#define HAVE_CBRT 1
++#define HAVE_CBRTF 1
++#define HAVE_COPYSIGN 1
++#define HAVE_COSF 1
++#define HAVE_ERF 1
++#define HAVE_EXP2 1
++#define HAVE_EXP2F 1
++#define HAVE_EXPF 1
++#define HAVE_HYPOT 1
++#define HAVE_ISFINITE 1
++#define HAVE_ISINF 1
++#define HAVE_ISNAN 1
++#define HAVE_LDEXPF 1
++#define HAVE_LLRINT 1
++#define HAVE_LLRINTF 1
++#define HAVE_LOG2 1
++#define HAVE_LOG2F 1
++#define HAVE_LOG10F 1
++#define HAVE_LRINT 1
++#define HAVE_LRINTF 1
++#define HAVE_POWF 1
++#define HAVE_RINT 1
++#define HAVE_ROUND 1
++#define HAVE_ROUNDF 1
++#define HAVE_SINF 1
++#define HAVE_TRUNC 1
++#define HAVE_TRUNCF 1
++#define HAVE_DOS_PATHS 0
++#define HAVE_LIBC_MSVCRT 0
++#define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
++#define HAVE_SECTION_DATA_REL_RO 1
++#define HAVE_THREADS 1
++#define HAVE_UWP 0
++#define HAVE_WINRT 0
++#define HAVE_ACCESS 1
++#define HAVE_ALIGNED_MALLOC 0
++#define HAVE_ARC4RANDOM_BUF 0
++#define HAVE_CLOCK_GETTIME 1
++#define HAVE_CLOSESOCKET 0
++#define HAVE_COMMANDLINETOARGVW 0
++#define HAVE_FCNTL 1
++#define HAVE_GETADDRINFO 0
++#define HAVE_GETAUXVAL 1
++#define HAVE_GETENV 1
++#define HAVE_GETHRTIME 0
++#define HAVE_GETOPT 1
++#define HAVE_GETMODULEHANDLE 0
++#define HAVE_GETPROCESSAFFINITYMASK 0
++#define HAVE_GETPROCESSMEMORYINFO 0
++#define HAVE_GETPROCESSTIMES 0
++#define HAVE_GETRUSAGE 1
++#define HAVE_GETSTDHANDLE 0
++#define HAVE_GETSYSTEMTIMEASFILETIME 0
++#define HAVE_GETTIMEOFDAY 1
++#define HAVE_GLOB 1
++#define HAVE_GLXGETPROCADDRESS 0
++#define HAVE_GMTIME_R 1
++#define HAVE_INET_ATON 0
++#define HAVE_ISATTY 1
++#define HAVE_KBHIT 0
++#define HAVE_LOCALTIME_R 1
++#define HAVE_LSTAT 1
++#define HAVE_LZO1X_999_COMPRESS 0
++#define HAVE_MACH_ABSOLUTE_TIME 0
++#define HAVE_MAPVIEWOFFILE 0
++#define HAVE_MEMALIGN 1
++#define HAVE_MKSTEMP 1
++#define HAVE_MMAP 1
++#define HAVE_MPROTECT 1
++#define HAVE_NANOSLEEP 1
++#define HAVE_PEEKNAMEDPIPE 0
++#define HAVE_POSIX_MEMALIGN 1
++#define HAVE_PRCTL 1
++#define HAVE_PTHREAD_CANCEL 1
++#define HAVE_SCHED_GETAFFINITY 1
++#define HAVE_SECITEMIMPORT 0
++#define HAVE_SETCONSOLETEXTATTRIBUTE 0
++#define HAVE_SETCONSOLECTRLHANDLER 0
++#define HAVE_SETDLLDIRECTORY 0
++#define HAVE_SETMODE 0
++#define HAVE_SETRLIMIT 1
++#define HAVE_SLEEP 0
++#define HAVE_STRERROR_R 1
++#define HAVE_SYSCONF 1
++#define HAVE_SYSCTL 0
++#define HAVE_SYSCTLBYNAME 0
++#define HAVE_USLEEP 1
++#define HAVE_UTGETOSTYPEFROMSTRING 0
++#define HAVE_VIRTUALALLOC 0
++#define HAVE_WGLGETPROCADDRESS 0
++#define HAVE_BCRYPT 0
++#define HAVE_VAAPI_DRM 0
++#define HAVE_VAAPI_X11 0
++#define HAVE_VAAPI_WIN32 0
++#define HAVE_VDPAU_X11 0
++#define HAVE_PTHREADS 1
++#define HAVE_OS2THREADS 0
++#define HAVE_W32THREADS 0
++#define HAVE_AS_ARCH_DIRECTIVE 0
++#define HAVE_AS_ARCHEXT_DOTPROD_DIRECTIVE 0
++#define HAVE_AS_ARCHEXT_I8MM_DIRECTIVE 0
++#define HAVE_AS_DN_DIRECTIVE 0
++#define HAVE_AS_FPU_DIRECTIVE 0
++#define HAVE_AS_FUNC 0
++#define HAVE_AS_OBJECT_ARCH 0
++#define HAVE_ASM_MOD_Q 0
++#define HAVE_BLOCKS_EXTENSION 0
++#define HAVE_EBP_AVAILABLE 0
++#define HAVE_EBX_AVAILABLE 0
++#define HAVE_GNU_AS 0
++#define HAVE_GNU_WINDRES 0
++#define HAVE_IBM_ASM 0
++#define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
++#define HAVE_INLINE_ASM_LABELS 1
++#define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
++#define HAVE_PRAGMA_DEPRECATED 1
++#define HAVE_RSYNC_CONTIMEOUT 1
++#define HAVE_SYMVER_ASM_LABEL 1
++#define HAVE_SYMVER_GNU_ASM 1
++#define HAVE_VFP_ARGS 0
++#define HAVE_XFORM_ASM 0
++#define HAVE_XMM_CLOBBERS 0
++#define HAVE_DPI_AWARENESS_CONTEXT 0
++#define HAVE_IDXGIOUTPUT5 0
++#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
++#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
++#define HAVE_KCMVIDEOCODECTYPE_VP9 0
++#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
++#define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
++#define HAVE_SOCKLEN_T 0
++#define HAVE_STRUCT_ADDRINFO 0
++#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
++#define HAVE_STRUCT_IP_MREQ_SOURCE 0
++#define HAVE_STRUCT_IPV6_MREQ 0
++#define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
++#define HAVE_STRUCT_POLLFD 0
++#define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
++#define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
++#define HAVE_STRUCT_SOCKADDR_IN6 0
++#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
++#define HAVE_STRUCT_SOCKADDR_STORAGE 0
++#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
++#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 0
++#define HAVE_GZIP 1
++#define HAVE_LIBDRM_GETFB2 0
++#define HAVE_MAKEINFO 1
++#define HAVE_MAKEINFO_HTML 1
++#define HAVE_OPENCL_D3D11 0
++#define HAVE_OPENCL_DRM_ARM 0
++#define HAVE_OPENCL_DRM_BEIGNET 0
++#define HAVE_OPENCL_DXVA2 0
++#define HAVE_OPENCL_VAAPI_BEIGNET 0
++#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
++#define HAVE_PERL 1
++#define HAVE_POD2MAN 1
++#define HAVE_TEXI2HTML 0
++#define HAVE_XMLLINT 1
++#define HAVE_ZLIB_GZIP 0
++#define CONFIG_DOC 0
++#define CONFIG_HTMLPAGES 0
++#define CONFIG_MANPAGES 0
++#define CONFIG_PODPAGES 0
++#define CONFIG_TXTPAGES 0
++#define CONFIG_AVIO_HTTP_SERVE_FILES_EXAMPLE 1
++#define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
++#define CONFIG_AVIO_READ_CALLBACK_EXAMPLE 1
++#define CONFIG_DECODE_AUDIO_EXAMPLE 1
++#define CONFIG_DECODE_FILTER_AUDIO_EXAMPLE 0
++#define CONFIG_DECODE_FILTER_VIDEO_EXAMPLE 0
++#define CONFIG_DECODE_VIDEO_EXAMPLE 1
++#define CONFIG_DEMUX_DECODE_EXAMPLE 1
++#define CONFIG_ENCODE_AUDIO_EXAMPLE 1
++#define CONFIG_ENCODE_VIDEO_EXAMPLE 1
++#define CONFIG_EXTRACT_MVS_EXAMPLE 1
++#define CONFIG_FILTER_AUDIO_EXAMPLE 0
++#define CONFIG_HW_DECODE_EXAMPLE 1
++#define CONFIG_MUX_EXAMPLE 0
++#define CONFIG_QSV_DECODE_EXAMPLE 0
++#define CONFIG_REMUX_EXAMPLE 1
++#define CONFIG_RESAMPLE_AUDIO_EXAMPLE 0
++#define CONFIG_SCALE_VIDEO_EXAMPLE 0
++#define CONFIG_SHOW_METADATA_EXAMPLE 1
++#define CONFIG_TRANSCODE_AAC_EXAMPLE 0
++#define CONFIG_TRANSCODE_EXAMPLE 0
++#define CONFIG_VAAPI_ENCODE_EXAMPLE 0
++#define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
++#define CONFIG_QSV_TRANSCODE_EXAMPLE 0
++#define CONFIG_AVISYNTH 0
++#define CONFIG_FREI0R 0
++#define CONFIG_LIBCDIO 0
++#define CONFIG_LIBDAVS2 0
++#define CONFIG_LIBRUBBERBAND 0
++#define CONFIG_LIBVIDSTAB 0
++#define CONFIG_LIBX264 0
++#define CONFIG_LIBX265 0
++#define CONFIG_LIBXAVS 0
++#define CONFIG_LIBXAVS2 0
++#define CONFIG_LIBXVID 0
++#define CONFIG_DECKLINK 0
++#define CONFIG_LIBFDK_AAC 0
++#define CONFIG_LIBTLS 0
++#define CONFIG_GMP 0
++#define CONFIG_LIBARIBB24 0
++#define CONFIG_LIBLENSFUN 0
++#define CONFIG_LIBOPENCORE_AMRNB 0
++#define CONFIG_LIBOPENCORE_AMRWB 0
++#define CONFIG_LIBVO_AMRWBENC 0
++#define CONFIG_MBEDTLS 0
++#define CONFIG_RKMPP 0
++#define CONFIG_LIBSMBCLIENT 0
++#define CONFIG_CHROMAPRINT 0
++#define CONFIG_GCRYPT 0
++#define CONFIG_GNUTLS 0
++#define CONFIG_JNI 0
++#define CONFIG_LADSPA 0
++#define CONFIG_LCMS2 0
++#define CONFIG_LIBAOM 0
++#define CONFIG_LIBARIBCAPTION 0
++#define CONFIG_LIBASS 0
++#define CONFIG_LIBBLURAY 0
++#define CONFIG_LIBBS2B 0
++#define CONFIG_LIBCACA 0
++#define CONFIG_LIBCELT 0
++#define CONFIG_LIBCODEC2 0
++#define CONFIG_LIBDAV1D 0
++#define CONFIG_LIBDC1394 0
++#define CONFIG_LIBDRM 0
++#define CONFIG_LIBFLITE 0
++#define CONFIG_LIBFONTCONFIG 0
++#define CONFIG_LIBFREETYPE 0
++#define CONFIG_LIBFRIBIDI 0
++#define CONFIG_LIBHARFBUZZ 0
++#define CONFIG_LIBGLSLANG 0
++#define CONFIG_LIBGME 0
++#define CONFIG_LIBGSM 0
++#define CONFIG_LIBIEC61883 0
++#define CONFIG_LIBILBC 0
++#define CONFIG_LIBJACK 0
++#define CONFIG_LIBJXL 0
++#define CONFIG_LIBKLVANC 0
++#define CONFIG_LIBKVAZAAR 0
++#define CONFIG_LIBMODPLUG 0
++#define CONFIG_LIBMP3LAME 0
++#define CONFIG_LIBMYSOFA 0
++#define CONFIG_LIBOPENCV 0
++#define CONFIG_LIBOPENH264 0
++#define CONFIG_LIBOPENJPEG 0
++#define CONFIG_LIBOPENMPT 0
++#define CONFIG_LIBOPENVINO 0
++#define CONFIG_LIBOPUS 1
++#define CONFIG_LIBPLACEBO 0
++#define CONFIG_LIBPULSE 0
++#define CONFIG_LIBRABBITMQ 0
++#define CONFIG_LIBRAV1E 0
++#define CONFIG_LIBRIST 0
++#define CONFIG_LIBRSVG 0
++#define CONFIG_LIBRTMP 0
++#define CONFIG_LIBSHADERC 0
++#define CONFIG_LIBSHINE 0
++#define CONFIG_LIBSMBCLIENT 0
++#define CONFIG_LIBSNAPPY 0
++#define CONFIG_LIBSOXR 0
++#define CONFIG_LIBSPEEX 0
++#define CONFIG_LIBSRT 0
++#define CONFIG_LIBSSH 0
++#define CONFIG_LIBSVTAV1 0
++#define CONFIG_LIBTENSORFLOW 0
++#define CONFIG_LIBTESSERACT 0
++#define CONFIG_LIBTHEORA 0
++#define CONFIG_LIBTWOLAME 0
++#define CONFIG_LIBUAVS3D 0
++#define CONFIG_LIBV4L2 0
++#define CONFIG_LIBVMAF 0
++#define CONFIG_LIBVORBIS 0
++#define CONFIG_LIBVPX 0
++#define CONFIG_LIBWEBP 0
++#define CONFIG_LIBXML2 0
++#define CONFIG_LIBZIMG 0
++#define CONFIG_LIBZMQ 0
++#define CONFIG_LIBZVBI 0
++#define CONFIG_LV2 0
++#define CONFIG_MEDIACODEC 0
++#define CONFIG_OPENAL 0
++#define CONFIG_OPENGL 0
++#define CONFIG_OPENSSL 0
++#define CONFIG_POCKETSPHINX 0
++#define CONFIG_VAPOURSYNTH 0
++#define CONFIG_ALSA 0
++#define CONFIG_APPKIT 0
++#define CONFIG_AVFOUNDATION 0
++#define CONFIG_BZLIB 0
++#define CONFIG_COREIMAGE 0
++#define CONFIG_ICONV 0
++#define CONFIG_LIBXCB 0
++#define CONFIG_LIBXCB_SHM 0
++#define CONFIG_LIBXCB_SHAPE 0
++#define CONFIG_LIBXCB_XFIXES 0
++#define CONFIG_LZMA 0
++#define CONFIG_MEDIAFOUNDATION 0
++#define CONFIG_METAL 0
++#define CONFIG_SCHANNEL 0
++#define CONFIG_SDL2 0
++#define CONFIG_SECURETRANSPORT 0
++#define CONFIG_SNDIO 0
++#define CONFIG_XLIB 0
++#define CONFIG_ZLIB 0
++#define CONFIG_CUDA_NVCC 0
++#define CONFIG_CUDA_SDK 0
++#define CONFIG_LIBNPP 0
++#define CONFIG_LIBMFX 0
++#define CONFIG_LIBVPL 0
++#define CONFIG_MMAL 0
++#define CONFIG_OMX 0
++#define CONFIG_OPENCL 0
++#define CONFIG_AMF 0
++#define CONFIG_AUDIOTOOLBOX 0
++#define CONFIG_CRYSTALHD 0
++#define CONFIG_CUDA 0
++#define CONFIG_CUDA_LLVM 0
++#define CONFIG_CUVID 0
++#define CONFIG_D3D11VA 0
++#define CONFIG_DXVA2 0
++#define CONFIG_FFNVCODEC 0
++#define CONFIG_NVDEC 0
++#define CONFIG_NVENC 0
++#define CONFIG_VAAPI 0
++#define CONFIG_VDPAU 0
++#define CONFIG_VIDEOTOOLBOX 0
++#define CONFIG_VULKAN 0
++#define CONFIG_V4L2_M2M 0
++#define CONFIG_FTRAPV 0
++#define CONFIG_GRAY 0
++#define CONFIG_HARDCODED_TABLES 0
++#define CONFIG_OMX_RPI 0
++#define CONFIG_RUNTIME_CPUDETECT 1
++#define CONFIG_SAFE_BITSTREAM_READER 1
++#define CONFIG_SHARED 0
++#define CONFIG_SMALL 0
++#define CONFIG_STATIC 1
++#define CONFIG_SWSCALE_ALPHA 1
++#define CONFIG_GPL 0
++#define CONFIG_NONFREE 0
++#define CONFIG_VERSION3 0
++#define CONFIG_AVDEVICE 0
++#define CONFIG_AVFILTER 0
++#define CONFIG_SWSCALE 0
++#define CONFIG_POSTPROC 0
++#define CONFIG_AVFORMAT 1
++#define CONFIG_AVCODEC 1
++#define CONFIG_SWRESAMPLE 0
++#define CONFIG_AVUTIL 1
++#define CONFIG_FFPLAY 0
++#define CONFIG_FFPROBE 0
++#define CONFIG_FFMPEG 0
++#define CONFIG_DCT 1
++#define CONFIG_DWT 0
++#define CONFIG_ERROR_RESILIENCE 0
++#define CONFIG_FAAN 0
++#define CONFIG_FAST_UNALIGNED 1
++#define CONFIG_FFT 1
++#define CONFIG_LSP 0
++#define CONFIG_MDCT 0
++#define CONFIG_PIXELUTILS 0
++#define CONFIG_NETWORK 0
++#define CONFIG_RDFT 1
++#define CONFIG_AUTODETECT 0
++#define CONFIG_FONTCONFIG 0
++#define CONFIG_LARGE_TESTS 1
++#define CONFIG_LINUX_PERF 0
++#define CONFIG_MACOS_KPERF 0
++#define CONFIG_MEMORY_POISONING 0
++#define CONFIG_NEON_CLOBBER_TEST 0
++#define CONFIG_OSSFUZZ 0
++#define CONFIG_PIC 1
++#define CONFIG_PTX_COMPRESSION 0
++#define CONFIG_THUMB 0
++#define CONFIG_VALGRIND_BACKTRACE 0
++#define CONFIG_XMM_CLOBBER_TEST 0
++#define CONFIG_BSFS 0
++#define CONFIG_DECODERS 1
++#define CONFIG_ENCODERS 0
++#define CONFIG_HWACCELS 0
++#define CONFIG_PARSERS 1
++#define CONFIG_INDEVS 0
++#define CONFIG_OUTDEVS 0
++#define CONFIG_FILTERS 0
++#define CONFIG_DEMUXERS 1
++#define CONFIG_MUXERS 0
++#define CONFIG_PROTOCOLS 0
++#define CONFIG_AANDCTTABLES 0
++#define CONFIG_AC3DSP 0
++#define CONFIG_ADTS_HEADER 1
++#define CONFIG_ATSC_A53 1
++#define CONFIG_AUDIO_FRAME_QUEUE 0
++#define CONFIG_AUDIODSP 0
++#define CONFIG_BLOCKDSP 0
++#define CONFIG_BSWAPDSP 0
++#define CONFIG_CABAC 1
++#define CONFIG_CBS 0
++#define CONFIG_CBS_AV1 0
++#define CONFIG_CBS_H264 0
++#define CONFIG_CBS_H265 0
++#define CONFIG_CBS_H266 0
++#define CONFIG_CBS_JPEG 0
++#define CONFIG_CBS_MPEG2 0
++#define CONFIG_CBS_VP9 0
++#define CONFIG_DEFLATE_WRAPPER 0
++#define CONFIG_DIRAC_PARSE 1
++#define CONFIG_DNN 0
++#define CONFIG_DOVI_RPU 0
++#define CONFIG_DVPROFILE 0
++#define CONFIG_EVCPARSE 0
++#define CONFIG_EXIF 0
++#define CONFIG_FAANDCT 0
++#define CONFIG_FAANIDCT 0
++#define CONFIG_FDCTDSP 0
++#define CONFIG_FMTCONVERT 0
++#define CONFIG_FRAME_THREAD_ENCODER 0
++#define CONFIG_G722DSP 0
++#define CONFIG_GOLOMB 1
++#define CONFIG_GPLV3 0
++#define CONFIG_H263DSP 0
++#define CONFIG_H264CHROMA 1
++#define CONFIG_H264DSP 1
++#define CONFIG_H264PARSE 1
++#define CONFIG_H264PRED 1
++#define CONFIG_H264QPEL 1
++#define CONFIG_H264_SEI 1
++#define CONFIG_HEVCPARSE 0
++#define CONFIG_HEVC_SEI 0
++#define CONFIG_HPELDSP 1
++#define CONFIG_HUFFMAN 0
++#define CONFIG_HUFFYUVDSP 0
++#define CONFIG_HUFFYUVENCDSP 0
++#define CONFIG_IDCTDSP 0
++#define CONFIG_IIRFILTER 0
++#define CONFIG_INFLATE_WRAPPER 0
++#define CONFIG_INTRAX8 0
++#define CONFIG_ISO_MEDIA 1
++#define CONFIG_IVIDSP 0
++#define CONFIG_JPEGTABLES 0
++#define CONFIG_LGPLV3 0
++#define CONFIG_LIBX262 0
++#define CONFIG_LLAUDDSP 0
++#define CONFIG_LLVIDDSP 0
++#define CONFIG_LLVIDENCDSP 0
++#define CONFIG_LPC 0
++#define CONFIG_LZF 0
++#define CONFIG_ME_CMP 0
++#define CONFIG_MPEG_ER 0
++#define CONFIG_MPEGAUDIO 1
++#define CONFIG_MPEGAUDIODSP 1
++#define CONFIG_MPEGAUDIOHEADER 1
++#define CONFIG_MPEG4AUDIO 1
++#define CONFIG_MPEGVIDEO 0
++#define CONFIG_MPEGVIDEODEC 0
++#define CONFIG_MPEGVIDEOENC 0
++#define CONFIG_MSMPEG4DEC 0
++#define CONFIG_MSMPEG4ENC 0
++#define CONFIG_MSS34DSP 0
++#define CONFIG_PIXBLOCKDSP 0
++#define CONFIG_QPELDSP 0
++#define CONFIG_QSV 0
++#define CONFIG_QSVDEC 0
++#define CONFIG_QSVENC 0
++#define CONFIG_QSVVPP 0
++#define CONFIG_RANGECODER 0
++#define CONFIG_RIFFDEC 1
++#define CONFIG_RIFFENC 0
++#define CONFIG_RTPDEC 0
++#define CONFIG_RTPENC_CHAIN 0
++#define CONFIG_RV34DSP 0
++#define CONFIG_SCENE_SAD 0
++#define CONFIG_SINEWIN 1
++#define CONFIG_SNAPPY 0
++#define CONFIG_SRTP 0
++#define CONFIG_STARTCODE 1
++#define CONFIG_TEXTUREDSP 0
++#define CONFIG_TEXTUREDSPENC 0
++#define CONFIG_TPELDSP 0
++#define CONFIG_VAAPI_1 0
++#define CONFIG_VAAPI_ENCODE 0
++#define CONFIG_VC1DSP 0
++#define CONFIG_VIDEODSP 1
++#define CONFIG_VP3DSP 1
++#define CONFIG_VP56DSP 0
++#define CONFIG_VP8DSP 1
++#define CONFIG_WMA_FREQS 0
++#define CONFIG_WMV2DSP 0
++#endif /* FFMPEG_CONFIG_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2187 @@
++/* Automatically generated by configure - do not modify! */
++#ifndef FFMPEG_CONFIG_COMPONENTS_H
++#define FFMPEG_CONFIG_COMPONENTS_H
++#define CONFIG_AAC_ADTSTOASC_BSF 0
++#define CONFIG_AV1_FRAME_MERGE_BSF 0
++#define CONFIG_AV1_FRAME_SPLIT_BSF 0
++#define CONFIG_AV1_METADATA_BSF 0
++#define CONFIG_CHOMP_BSF 0
++#define CONFIG_DUMP_EXTRADATA_BSF 0
++#define CONFIG_DCA_CORE_BSF 0
++#define CONFIG_DTS2PTS_BSF 0
++#define CONFIG_DV_ERROR_MARKER_BSF 0
++#define CONFIG_EAC3_CORE_BSF 0
++#define CONFIG_EXTRACT_EXTRADATA_BSF 0
++#define CONFIG_FILTER_UNITS_BSF 0
++#define CONFIG_H264_METADATA_BSF 0
++#define CONFIG_H264_MP4TOANNEXB_BSF 0
++#define CONFIG_H264_REDUNDANT_PPS_BSF 0
++#define CONFIG_HAPQA_EXTRACT_BSF 0
++#define CONFIG_HEVC_METADATA_BSF 0
++#define CONFIG_HEVC_MP4TOANNEXB_BSF 0
++#define CONFIG_IMX_DUMP_HEADER_BSF 0
++#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
++#define CONFIG_MJPEG2JPEG_BSF 0
++#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
++#define CONFIG_MP3_HEADER_DECOMPRESS_BSF 0
++#define CONFIG_MPEG2_METADATA_BSF 0
++#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
++#define CONFIG_MOV2TEXTSUB_BSF 0
++#define CONFIG_NOISE_BSF 0
++#define CONFIG_NULL_BSF 0
++#define CONFIG_OPUS_METADATA_BSF 0
++#define CONFIG_PCM_RECHUNK_BSF 0
++#define CONFIG_PGS_FRAME_MERGE_BSF 0
++#define CONFIG_PRORES_METADATA_BSF 0
++#define CONFIG_REMOVE_EXTRADATA_BSF 0
++#define CONFIG_SETTS_BSF 0
++#define CONFIG_TEXT2MOVSUB_BSF 0
++#define CONFIG_TRACE_HEADERS_BSF 0
++#define CONFIG_TRUEHD_CORE_BSF 0
++#define CONFIG_VP9_METADATA_BSF 0
++#define CONFIG_VP9_RAW_REORDER_BSF 0
++#define CONFIG_VP9_SUPERFRAME_BSF 0
++#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
++#define CONFIG_VVC_METADATA_BSF 0
++#define CONFIG_VVC_MP4TOANNEXB_BSF 0
++#define CONFIG_EVC_FRAME_MERGE_BSF 0
++#define CONFIG_AASC_DECODER 0
++#define CONFIG_AIC_DECODER 0
++#define CONFIG_ALIAS_PIX_DECODER 0
++#define CONFIG_AGM_DECODER 0
++#define CONFIG_AMV_DECODER 0
++#define CONFIG_ANM_DECODER 0
++#define CONFIG_ANSI_DECODER 0
++#define CONFIG_APNG_DECODER 0
++#define CONFIG_ARBC_DECODER 0
++#define CONFIG_ARGO_DECODER 0
++#define CONFIG_ASV1_DECODER 0
++#define CONFIG_ASV2_DECODER 0
++#define CONFIG_AURA_DECODER 0
++#define CONFIG_AURA2_DECODER 0
++#define CONFIG_AVRP_DECODER 0
++#define CONFIG_AVRN_DECODER 0
++#define CONFIG_AVS_DECODER 0
++#define CONFIG_AVUI_DECODER 0
++#define CONFIG_AYUV_DECODER 0
++#define CONFIG_BETHSOFTVID_DECODER 0
++#define CONFIG_BFI_DECODER 0
++#define CONFIG_BINK_DECODER 0
++#define CONFIG_BITPACKED_DECODER 0
++#define CONFIG_BMP_DECODER 0
++#define CONFIG_BMV_VIDEO_DECODER 0
++#define CONFIG_BRENDER_PIX_DECODER 0
++#define CONFIG_C93_DECODER 0
++#define CONFIG_CAVS_DECODER 0
++#define CONFIG_CDGRAPHICS_DECODER 0
++#define CONFIG_CDTOONS_DECODER 0
++#define CONFIG_CDXL_DECODER 0
++#define CONFIG_CFHD_DECODER 0
++#define CONFIG_CINEPAK_DECODER 0
++#define CONFIG_CLEARVIDEO_DECODER 0
++#define CONFIG_CLJR_DECODER 0
++#define CONFIG_CLLC_DECODER 0
++#define CONFIG_COMFORTNOISE_DECODER 0
++#define CONFIG_CPIA_DECODER 0
++#define CONFIG_CRI_DECODER 0
++#define CONFIG_CSCD_DECODER 0
++#define CONFIG_CYUV_DECODER 0
++#define CONFIG_DDS_DECODER 0
++#define CONFIG_DFA_DECODER 0
++#define CONFIG_DIRAC_DECODER 0
++#define CONFIG_DNXHD_DECODER 0
++#define CONFIG_DPX_DECODER 0
++#define CONFIG_DSICINVIDEO_DECODER 0
++#define CONFIG_DVAUDIO_DECODER 0
++#define CONFIG_DVVIDEO_DECODER 0
++#define CONFIG_DXA_DECODER 0
++#define CONFIG_DXTORY_DECODER 0
++#define CONFIG_DXV_DECODER 0
++#define CONFIG_EACMV_DECODER 0
++#define CONFIG_EAMAD_DECODER 0
++#define CONFIG_EATGQ_DECODER 0
++#define CONFIG_EATGV_DECODER 0
++#define CONFIG_EATQI_DECODER 0
++#define CONFIG_EIGHTBPS_DECODER 0
++#define CONFIG_EIGHTSVX_EXP_DECODER 0
++#define CONFIG_EIGHTSVX_FIB_DECODER 0
++#define CONFIG_ESCAPE124_DECODER 0
++#define CONFIG_ESCAPE130_DECODER 0
++#define CONFIG_EXR_DECODER 0
++#define CONFIG_FFV1_DECODER 0
++#define CONFIG_FFVHUFF_DECODER 0
++#define CONFIG_FIC_DECODER 0
++#define CONFIG_FITS_DECODER 0
++#define CONFIG_FLASHSV_DECODER 0
++#define CONFIG_FLASHSV2_DECODER 0
++#define CONFIG_FLIC_DECODER 0
++#define CONFIG_FLV_DECODER 0
++#define CONFIG_FMVC_DECODER 0
++#define CONFIG_FOURXM_DECODER 0
++#define CONFIG_FRAPS_DECODER 0
++#define CONFIG_FRWU_DECODER 0
++#define CONFIG_G2M_DECODER 0
++#define CONFIG_GDV_DECODER 0
++#define CONFIG_GEM_DECODER 0
++#define CONFIG_GIF_DECODER 0
++#define CONFIG_H261_DECODER 0
++#define CONFIG_H263_DECODER 0
++#define CONFIG_H263I_DECODER 0
++#define CONFIG_H263P_DECODER 0
++#define CONFIG_H263_V4L2M2M_DECODER 0
++#define CONFIG_H264_DECODER 1
++#define CONFIG_H264_CRYSTALHD_DECODER 0
++#define CONFIG_H264_V4L2M2M_DECODER 0
++#define CONFIG_H264_MEDIACODEC_DECODER 0
++#define CONFIG_H264_MMAL_DECODER 0
++#define CONFIG_H264_QSV_DECODER 0
++#define CONFIG_H264_RKMPP_DECODER 0
++#define CONFIG_HAP_DECODER 0
++#define CONFIG_HEVC_DECODER 0
++#define CONFIG_HEVC_QSV_DECODER 0
++#define CONFIG_HEVC_RKMPP_DECODER 0
++#define CONFIG_HEVC_V4L2M2M_DECODER 0
++#define CONFIG_HNM4_VIDEO_DECODER 0
++#define CONFIG_HQ_HQA_DECODER 0
++#define CONFIG_HQX_DECODER 0
++#define CONFIG_HUFFYUV_DECODER 0
++#define CONFIG_HYMT_DECODER 0
++#define CONFIG_IDCIN_DECODER 0
++#define CONFIG_IFF_ILBM_DECODER 0
++#define CONFIG_IMM4_DECODER 0
++#define CONFIG_IMM5_DECODER 0
++#define CONFIG_INDEO2_DECODER 0
++#define CONFIG_INDEO3_DECODER 0
++#define CONFIG_INDEO4_DECODER 0
++#define CONFIG_INDEO5_DECODER 0
++#define CONFIG_INTERPLAY_VIDEO_DECODER 0
++#define CONFIG_IPU_DECODER 0
++#define CONFIG_JPEG2000_DECODER 0
++#define CONFIG_JPEGLS_DECODER 0
++#define CONFIG_JV_DECODER 0
++#define CONFIG_KGV1_DECODER 0
++#define CONFIG_KMVC_DECODER 0
++#define CONFIG_LAGARITH_DECODER 0
++#define CONFIG_LOCO_DECODER 0
++#define CONFIG_LSCR_DECODER 0
++#define CONFIG_M101_DECODER 0
++#define CONFIG_MAGICYUV_DECODER 0
++#define CONFIG_MDEC_DECODER 0
++#define CONFIG_MEDIA100_DECODER 0
++#define CONFIG_MIMIC_DECODER 0
++#define CONFIG_MJPEG_DECODER 0
++#define CONFIG_MJPEGB_DECODER 0
++#define CONFIG_MMVIDEO_DECODER 0
++#define CONFIG_MOBICLIP_DECODER 0
++#define CONFIG_MOTIONPIXELS_DECODER 0
++#define CONFIG_MPEG1VIDEO_DECODER 0
++#define CONFIG_MPEG2VIDEO_DECODER 0
++#define CONFIG_MPEG4_DECODER 0
++#define CONFIG_MPEG4_CRYSTALHD_DECODER 0
++#define CONFIG_MPEG4_V4L2M2M_DECODER 0
++#define CONFIG_MPEG4_MMAL_DECODER 0
++#define CONFIG_MPEGVIDEO_DECODER 0
++#define CONFIG_MPEG1_V4L2M2M_DECODER 0
++#define CONFIG_MPEG2_MMAL_DECODER 0
++#define CONFIG_MPEG2_CRYSTALHD_DECODER 0
++#define CONFIG_MPEG2_V4L2M2M_DECODER 0
++#define CONFIG_MPEG2_QSV_DECODER 0
++#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
++#define CONFIG_MSA1_DECODER 0
++#define CONFIG_MSCC_DECODER 0
++#define CONFIG_MSMPEG4V1_DECODER 0
++#define CONFIG_MSMPEG4V2_DECODER 0
++#define CONFIG_MSMPEG4V3_DECODER 0
++#define CONFIG_MSMPEG4_CRYSTALHD_DECODER 0
++#define CONFIG_MSP2_DECODER 0
++#define CONFIG_MSRLE_DECODER 0
++#define CONFIG_MSS1_DECODER 0
++#define CONFIG_MSS2_DECODER 0
++#define CONFIG_MSVIDEO1_DECODER 0
++#define CONFIG_MSZH_DECODER 0
++#define CONFIG_MTS2_DECODER 0
++#define CONFIG_MV30_DECODER 0
++#define CONFIG_MVC1_DECODER 0
++#define CONFIG_MVC2_DECODER 0
++#define CONFIG_MVDV_DECODER 0
++#define CONFIG_MVHA_DECODER 0
++#define CONFIG_MWSC_DECODER 0
++#define CONFIG_MXPEG_DECODER 0
++#define CONFIG_NOTCHLC_DECODER 0
++#define CONFIG_NUV_DECODER 0
++#define CONFIG_PAF_VIDEO_DECODER 0
++#define CONFIG_PAM_DECODER 0
++#define CONFIG_PBM_DECODER 0
++#define CONFIG_PCX_DECODER 0
++#define CONFIG_PDV_DECODER 0
++#define CONFIG_PFM_DECODER 0
++#define CONFIG_PGM_DECODER 0
++#define CONFIG_PGMYUV_DECODER 0
++#define CONFIG_PGX_DECODER 0
++#define CONFIG_PHM_DECODER 0
++#define CONFIG_PHOTOCD_DECODER 0
++#define CONFIG_PICTOR_DECODER 0
++#define CONFIG_PIXLET_DECODER 0
++#define CONFIG_PNG_DECODER 0
++#define CONFIG_PPM_DECODER 0
++#define CONFIG_PRORES_DECODER 0
++#define CONFIG_PROSUMER_DECODER 0
++#define CONFIG_PSD_DECODER 0
++#define CONFIG_PTX_DECODER 0
++#define CONFIG_QDRAW_DECODER 0
++#define CONFIG_QOI_DECODER 0
++#define CONFIG_QPEG_DECODER 0
++#define CONFIG_QTRLE_DECODER 0
++#define CONFIG_R10K_DECODER 0
++#define CONFIG_R210_DECODER 0
++#define CONFIG_RASC_DECODER 0
++#define CONFIG_RAWVIDEO_DECODER 0
++#define CONFIG_RKA_DECODER 0
++#define CONFIG_RL2_DECODER 0
++#define CONFIG_ROQ_DECODER 0
++#define CONFIG_RPZA_DECODER 0
++#define CONFIG_RSCC_DECODER 0
++#define CONFIG_RTV1_DECODER 0
++#define CONFIG_RV10_DECODER 0
++#define CONFIG_RV20_DECODER 0
++#define CONFIG_RV30_DECODER 0
++#define CONFIG_RV40_DECODER 0
++#define CONFIG_S302M_DECODER 0
++#define CONFIG_SANM_DECODER 0
++#define CONFIG_SCPR_DECODER 0
++#define CONFIG_SCREENPRESSO_DECODER 0
++#define CONFIG_SGA_DECODER 0
++#define CONFIG_SGI_DECODER 0
++#define CONFIG_SGIRLE_DECODER 0
++#define CONFIG_SHEERVIDEO_DECODER 0
++#define CONFIG_SIMBIOSIS_IMX_DECODER 0
++#define CONFIG_SMACKER_DECODER 0
++#define CONFIG_SMC_DECODER 0
++#define CONFIG_SMVJPEG_DECODER 0
++#define CONFIG_SNOW_DECODER 0
++#define CONFIG_SP5X_DECODER 0
++#define CONFIG_SPEEDHQ_DECODER 0
++#define CONFIG_SPEEX_DECODER 0
++#define CONFIG_SRGC_DECODER 0
++#define CONFIG_SUNRAST_DECODER 0
++#define CONFIG_SVQ1_DECODER 0
++#define CONFIG_SVQ3_DECODER 0
++#define CONFIG_TARGA_DECODER 0
++#define CONFIG_TARGA_Y216_DECODER 0
++#define CONFIG_TDSC_DECODER 0
++#define CONFIG_THEORA_DECODER 1
++#define CONFIG_THP_DECODER 0
++#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
++#define CONFIG_TIFF_DECODER 0
++#define CONFIG_TMV_DECODER 0
++#define CONFIG_TRUEMOTION1_DECODER 0
++#define CONFIG_TRUEMOTION2_DECODER 0
++#define CONFIG_TRUEMOTION2RT_DECODER 0
++#define CONFIG_TSCC_DECODER 0
++#define CONFIG_TSCC2_DECODER 0
++#define CONFIG_TXD_DECODER 0
++#define CONFIG_ULTI_DECODER 0
++#define CONFIG_UTVIDEO_DECODER 0
++#define CONFIG_V210_DECODER 0
++#define CONFIG_V210X_DECODER 0
++#define CONFIG_V308_DECODER 0
++#define CONFIG_V408_DECODER 0
++#define CONFIG_V410_DECODER 0
++#define CONFIG_VB_DECODER 0
++#define CONFIG_VBN_DECODER 0
++#define CONFIG_VBLE_DECODER 0
++#define CONFIG_VC1_DECODER 0
++#define CONFIG_VC1_CRYSTALHD_DECODER 0
++#define CONFIG_VC1IMAGE_DECODER 0
++#define CONFIG_VC1_MMAL_DECODER 0
++#define CONFIG_VC1_QSV_DECODER 0
++#define CONFIG_VC1_V4L2M2M_DECODER 0
++#define CONFIG_VCR1_DECODER 0
++#define CONFIG_VMDVIDEO_DECODER 0
++#define CONFIG_VMIX_DECODER 0
++#define CONFIG_VMNC_DECODER 0
++#define CONFIG_VP3_DECODER 1
++#define CONFIG_VP4_DECODER 0
++#define CONFIG_VP5_DECODER 0
++#define CONFIG_VP6_DECODER 0
++#define CONFIG_VP6A_DECODER 0
++#define CONFIG_VP6F_DECODER 0
++#define CONFIG_VP7_DECODER 0
++#define CONFIG_VP8_DECODER 1
++#define CONFIG_VP8_RKMPP_DECODER 0
++#define CONFIG_VP8_V4L2M2M_DECODER 0
++#define CONFIG_VP9_DECODER 0
++#define CONFIG_VP9_RKMPP_DECODER 0
++#define CONFIG_VP9_V4L2M2M_DECODER 0
++#define CONFIG_VQA_DECODER 0
++#define CONFIG_VQC_DECODER 0
++#define CONFIG_WBMP_DECODER 0
++#define CONFIG_WEBP_DECODER 0
++#define CONFIG_WCMV_DECODER 0
++#define CONFIG_WRAPPED_AVFRAME_DECODER 0
++#define CONFIG_WMV1_DECODER 0
++#define CONFIG_WMV2_DECODER 0
++#define CONFIG_WMV3_DECODER 0
++#define CONFIG_WMV3_CRYSTALHD_DECODER 0
++#define CONFIG_WMV3IMAGE_DECODER 0
++#define CONFIG_WNV1_DECODER 0
++#define CONFIG_XAN_WC3_DECODER 0
++#define CONFIG_XAN_WC4_DECODER 0
++#define CONFIG_XBM_DECODER 0
++#define CONFIG_XFACE_DECODER 0
++#define CONFIG_XL_DECODER 0
++#define CONFIG_XPM_DECODER 0
++#define CONFIG_XWD_DECODER 0
++#define CONFIG_Y41P_DECODER 0
++#define CONFIG_YLC_DECODER 0
++#define CONFIG_YOP_DECODER 0
++#define CONFIG_YUV4_DECODER 0
++#define CONFIG_ZERO12V_DECODER 0
++#define CONFIG_ZEROCODEC_DECODER 0
++#define CONFIG_ZLIB_DECODER 0
++#define CONFIG_ZMBV_DECODER 0
++#define CONFIG_AAC_DECODER 1
++#define CONFIG_AAC_FIXED_DECODER 0
++#define CONFIG_AAC_LATM_DECODER 0
++#define CONFIG_AC3_DECODER 0
++#define CONFIG_AC3_FIXED_DECODER 0
++#define CONFIG_ACELP_KELVIN_DECODER 0
++#define CONFIG_ALAC_DECODER 0
++#define CONFIG_ALS_DECODER 0
++#define CONFIG_AMRNB_DECODER 0
++#define CONFIG_AMRWB_DECODER 0
++#define CONFIG_APAC_DECODER 0
++#define CONFIG_APE_DECODER 0
++#define CONFIG_APTX_DECODER 0
++#define CONFIG_APTX_HD_DECODER 0
++#define CONFIG_ATRAC1_DECODER 0
++#define CONFIG_ATRAC3_DECODER 0
++#define CONFIG_ATRAC3AL_DECODER 0
++#define CONFIG_ATRAC3P_DECODER 0
++#define CONFIG_ATRAC3PAL_DECODER 0
++#define CONFIG_ATRAC9_DECODER 0
++#define CONFIG_BINKAUDIO_DCT_DECODER 0
++#define CONFIG_BINKAUDIO_RDFT_DECODER 0
++#define CONFIG_BMV_AUDIO_DECODER 0
++#define CONFIG_BONK_DECODER 0
++#define CONFIG_COOK_DECODER 0
++#define CONFIG_DCA_DECODER 0
++#define CONFIG_DFPWM_DECODER 0
++#define CONFIG_DOLBY_E_DECODER 0
++#define CONFIG_DSD_LSBF_DECODER 0
++#define CONFIG_DSD_MSBF_DECODER 0
++#define CONFIG_DSD_LSBF_PLANAR_DECODER 0
++#define CONFIG_DSD_MSBF_PLANAR_DECODER 0
++#define CONFIG_DSICINAUDIO_DECODER 0
++#define CONFIG_DSS_SP_DECODER 0
++#define CONFIG_DST_DECODER 0
++#define CONFIG_EAC3_DECODER 0
++#define CONFIG_EVRC_DECODER 0
++#define CONFIG_FASTAUDIO_DECODER 0
++#define CONFIG_FFWAVESYNTH_DECODER 0
++#define CONFIG_FLAC_DECODER 1
++#define CONFIG_FTR_DECODER 0
++#define CONFIG_G723_1_DECODER 0
++#define CONFIG_G729_DECODER 0
++#define CONFIG_GSM_DECODER 0
++#define CONFIG_GSM_MS_DECODER 0
++#define CONFIG_HCA_DECODER 0
++#define CONFIG_HCOM_DECODER 0
++#define CONFIG_HDR_DECODER 0
++#define CONFIG_IAC_DECODER 0
++#define CONFIG_ILBC_DECODER 0
++#define CONFIG_IMC_DECODER 0
++#define CONFIG_INTERPLAY_ACM_DECODER 0
++#define CONFIG_MACE3_DECODER 0
++#define CONFIG_MACE6_DECODER 0
++#define CONFIG_METASOUND_DECODER 0
++#define CONFIG_MISC4_DECODER 0
++#define CONFIG_MLP_DECODER 0
++#define CONFIG_MP1_DECODER 0
++#define CONFIG_MP1FLOAT_DECODER 0
++#define CONFIG_MP2_DECODER 0
++#define CONFIG_MP2FLOAT_DECODER 0
++#define CONFIG_MP3FLOAT_DECODER 0
++#define CONFIG_MP3_DECODER 1
++#define CONFIG_MP3ADUFLOAT_DECODER 0
++#define CONFIG_MP3ADU_DECODER 0
++#define CONFIG_MP3ON4FLOAT_DECODER 0
++#define CONFIG_MP3ON4_DECODER 0
++#define CONFIG_MPC7_DECODER 0
++#define CONFIG_MPC8_DECODER 0
++#define CONFIG_MSNSIREN_DECODER 0
++#define CONFIG_NELLYMOSER_DECODER 0
++#define CONFIG_ON2AVC_DECODER 0
++#define CONFIG_OPUS_DECODER 0
++#define CONFIG_PAF_AUDIO_DECODER 0
++#define CONFIG_QCELP_DECODER 0
++#define CONFIG_QDM2_DECODER 0
++#define CONFIG_QDMC_DECODER 0
++#define CONFIG_RA_144_DECODER 0
++#define CONFIG_RA_288_DECODER 0
++#define CONFIG_RALF_DECODER 0
++#define CONFIG_SBC_DECODER 0
++#define CONFIG_SHORTEN_DECODER 0
++#define CONFIG_SIPR_DECODER 0
++#define CONFIG_SIREN_DECODER 0
++#define CONFIG_SMACKAUD_DECODER 0
++#define CONFIG_SONIC_DECODER 0
++#define CONFIG_TAK_DECODER 0
++#define CONFIG_TRUEHD_DECODER 0
++#define CONFIG_TRUESPEECH_DECODER 0
++#define CONFIG_TTA_DECODER 0
++#define CONFIG_TWINVQ_DECODER 0
++#define CONFIG_VMDAUDIO_DECODER 0
++#define CONFIG_VORBIS_DECODER 1
++#define CONFIG_WAVARC_DECODER 0
++#define CONFIG_WAVPACK_DECODER 0
++#define CONFIG_WMALOSSLESS_DECODER 0
++#define CONFIG_WMAPRO_DECODER 0
++#define CONFIG_WMAV1_DECODER 0
++#define CONFIG_WMAV2_DECODER 0
++#define CONFIG_WMAVOICE_DECODER 0
++#define CONFIG_WS_SND1_DECODER 0
++#define CONFIG_XMA1_DECODER 0
++#define CONFIG_XMA2_DECODER 0
++#define CONFIG_PCM_ALAW_DECODER 1
++#define CONFIG_PCM_BLURAY_DECODER 0
++#define CONFIG_PCM_DVD_DECODER 0
++#define CONFIG_PCM_F16LE_DECODER 0
++#define CONFIG_PCM_F24LE_DECODER 0
++#define CONFIG_PCM_F32BE_DECODER 0
++#define CONFIG_PCM_F32LE_DECODER 1
++#define CONFIG_PCM_F64BE_DECODER 0
++#define CONFIG_PCM_F64LE_DECODER 0
++#define CONFIG_PCM_LXF_DECODER 0
++#define CONFIG_PCM_MULAW_DECODER 1
++#define CONFIG_PCM_S8_DECODER 0
++#define CONFIG_PCM_S8_PLANAR_DECODER 0
++#define CONFIG_PCM_S16BE_DECODER 1
++#define CONFIG_PCM_S16BE_PLANAR_DECODER 0
++#define CONFIG_PCM_S16LE_DECODER 1
++#define CONFIG_PCM_S16LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S24BE_DECODER 1
++#define CONFIG_PCM_S24DAUD_DECODER 0
++#define CONFIG_PCM_S24LE_DECODER 1
++#define CONFIG_PCM_S24LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S32BE_DECODER 0
++#define CONFIG_PCM_S32LE_DECODER 1
++#define CONFIG_PCM_S32LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S64BE_DECODER 0
++#define CONFIG_PCM_S64LE_DECODER 0
++#define CONFIG_PCM_SGA_DECODER 0
++#define CONFIG_PCM_U8_DECODER 1
++#define CONFIG_PCM_U16BE_DECODER 0
++#define CONFIG_PCM_U16LE_DECODER 0
++#define CONFIG_PCM_U24BE_DECODER 0
++#define CONFIG_PCM_U24LE_DECODER 0
++#define CONFIG_PCM_U32BE_DECODER 0
++#define CONFIG_PCM_U32LE_DECODER 0
++#define CONFIG_PCM_VIDC_DECODER 0
++#define CONFIG_CBD2_DPCM_DECODER 0
++#define CONFIG_DERF_DPCM_DECODER 0
++#define CONFIG_GREMLIN_DPCM_DECODER 0
++#define CONFIG_INTERPLAY_DPCM_DECODER 0
++#define CONFIG_ROQ_DPCM_DECODER 0
++#define CONFIG_SDX2_DPCM_DECODER 0
++#define CONFIG_SOL_DPCM_DECODER 0
++#define CONFIG_XAN_DPCM_DECODER 0
++#define CONFIG_WADY_DPCM_DECODER 0
++#define CONFIG_ADPCM_4XM_DECODER 0
++#define CONFIG_ADPCM_ADX_DECODER 0
++#define CONFIG_ADPCM_AFC_DECODER 0
++#define CONFIG_ADPCM_AGM_DECODER 0
++#define CONFIG_ADPCM_AICA_DECODER 0
++#define CONFIG_ADPCM_ARGO_DECODER 0
++#define CONFIG_ADPCM_CT_DECODER 0
++#define CONFIG_ADPCM_DTK_DECODER 0
++#define CONFIG_ADPCM_EA_DECODER 0
++#define CONFIG_ADPCM_EA_MAXIS_XA_DECODER 0
++#define CONFIG_ADPCM_EA_R1_DECODER 0
++#define CONFIG_ADPCM_EA_R2_DECODER 0
++#define CONFIG_ADPCM_EA_R3_DECODER 0
++#define CONFIG_ADPCM_EA_XAS_DECODER 0
++#define CONFIG_ADPCM_G722_DECODER 0
++#define CONFIG_ADPCM_G726_DECODER 0
++#define CONFIG_ADPCM_G726LE_DECODER 0
++#define CONFIG_ADPCM_IMA_ACORN_DECODER 0
++#define CONFIG_ADPCM_IMA_AMV_DECODER 0
++#define CONFIG_ADPCM_IMA_ALP_DECODER 0
++#define CONFIG_ADPCM_IMA_APC_DECODER 0
++#define CONFIG_ADPCM_IMA_APM_DECODER 0
++#define CONFIG_ADPCM_IMA_CUNNING_DECODER 0
++#define CONFIG_ADPCM_IMA_DAT4_DECODER 0
++#define CONFIG_ADPCM_IMA_DK3_DECODER 0
++#define CONFIG_ADPCM_IMA_DK4_DECODER 0
++#define CONFIG_ADPCM_IMA_EA_EACS_DECODER 0
++#define CONFIG_ADPCM_IMA_EA_SEAD_DECODER 0
++#define CONFIG_ADPCM_IMA_ISS_DECODER 0
++#define CONFIG_ADPCM_IMA_MOFLEX_DECODER 0
++#define CONFIG_ADPCM_IMA_MTF_DECODER 0
++#define CONFIG_ADPCM_IMA_OKI_DECODER 0
++#define CONFIG_ADPCM_IMA_QT_DECODER 0
++#define CONFIG_ADPCM_IMA_RAD_DECODER 0
++#define CONFIG_ADPCM_IMA_SSI_DECODER 0
++#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
++#define CONFIG_ADPCM_IMA_WAV_DECODER 0
++#define CONFIG_ADPCM_IMA_WS_DECODER 0
++#define CONFIG_ADPCM_MS_DECODER 0
++#define CONFIG_ADPCM_MTAF_DECODER 0
++#define CONFIG_ADPCM_PSX_DECODER 0
++#define CONFIG_ADPCM_SBPRO_2_DECODER 0
++#define CONFIG_ADPCM_SBPRO_3_DECODER 0
++#define CONFIG_ADPCM_SBPRO_4_DECODER 0
++#define CONFIG_ADPCM_SWF_DECODER 0
++#define CONFIG_ADPCM_THP_DECODER 0
++#define CONFIG_ADPCM_THP_LE_DECODER 0
++#define CONFIG_ADPCM_VIMA_DECODER 0
++#define CONFIG_ADPCM_XA_DECODER 0
++#define CONFIG_ADPCM_XMD_DECODER 0
++#define CONFIG_ADPCM_YAMAHA_DECODER 0
++#define CONFIG_ADPCM_ZORK_DECODER 0
++#define CONFIG_SSA_DECODER 0
++#define CONFIG_ASS_DECODER 0
++#define CONFIG_CCAPTION_DECODER 0
++#define CONFIG_DVBSUB_DECODER 0
++#define CONFIG_DVDSUB_DECODER 0
++#define CONFIG_JACOSUB_DECODER 0
++#define CONFIG_MICRODVD_DECODER 0
++#define CONFIG_MOVTEXT_DECODER 0
++#define CONFIG_MPL2_DECODER 0
++#define CONFIG_PGSSUB_DECODER 0
++#define CONFIG_PJS_DECODER 0
++#define CONFIG_REALTEXT_DECODER 0
++#define CONFIG_SAMI_DECODER 0
++#define CONFIG_SRT_DECODER 0
++#define CONFIG_STL_DECODER 0
++#define CONFIG_SUBRIP_DECODER 0
++#define CONFIG_SUBVIEWER_DECODER 0
++#define CONFIG_SUBVIEWER1_DECODER 0
++#define CONFIG_TEXT_DECODER 0
++#define CONFIG_VPLAYER_DECODER 0
++#define CONFIG_WEBVTT_DECODER 0
++#define CONFIG_XSUB_DECODER 0
++#define CONFIG_AAC_AT_DECODER 0
++#define CONFIG_AC3_AT_DECODER 0
++#define CONFIG_ADPCM_IMA_QT_AT_DECODER 0
++#define CONFIG_ALAC_AT_DECODER 0
++#define CONFIG_AMR_NB_AT_DECODER 0
++#define CONFIG_EAC3_AT_DECODER 0
++#define CONFIG_GSM_MS_AT_DECODER 0
++#define CONFIG_ILBC_AT_DECODER 0
++#define CONFIG_MP1_AT_DECODER 0
++#define CONFIG_MP2_AT_DECODER 0
++#define CONFIG_MP3_AT_DECODER 0
++#define CONFIG_PCM_ALAW_AT_DECODER 0
++#define CONFIG_PCM_MULAW_AT_DECODER 0
++#define CONFIG_QDMC_AT_DECODER 0
++#define CONFIG_QDM2_AT_DECODER 0
++#define CONFIG_LIBARIBCAPTION_DECODER 0
++#define CONFIG_LIBARIBB24_DECODER 0
++#define CONFIG_LIBCELT_DECODER 0
++#define CONFIG_LIBCODEC2_DECODER 0
++#define CONFIG_LIBDAV1D_DECODER 0
++#define CONFIG_LIBDAVS2_DECODER 0
++#define CONFIG_LIBFDK_AAC_DECODER 0
++#define CONFIG_LIBGSM_DECODER 0
++#define CONFIG_LIBGSM_MS_DECODER 0
++#define CONFIG_LIBILBC_DECODER 0
++#define CONFIG_LIBJXL_DECODER 0
++#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
++#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
++#define CONFIG_LIBOPUS_DECODER 1
++#define CONFIG_LIBRSVG_DECODER 0
++#define CONFIG_LIBSPEEX_DECODER 0
++#define CONFIG_LIBUAVS3D_DECODER 0
++#define CONFIG_LIBVORBIS_DECODER 0
++#define CONFIG_LIBVPX_VP8_DECODER 0
++#define CONFIG_LIBVPX_VP9_DECODER 0
++#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
++#define CONFIG_BINTEXT_DECODER 0
++#define CONFIG_XBIN_DECODER 0
++#define CONFIG_IDF_DECODER 0
++#define CONFIG_LIBAOM_AV1_DECODER 0
++#define CONFIG_AV1_DECODER 0
++#define CONFIG_AV1_CUVID_DECODER 0
++#define CONFIG_AV1_MEDIACODEC_DECODER 0
++#define CONFIG_AV1_QSV_DECODER 0
++#define CONFIG_LIBOPENH264_DECODER 0
++#define CONFIG_H264_CUVID_DECODER 0
++#define CONFIG_HEVC_CUVID_DECODER 0
++#define CONFIG_HEVC_MEDIACODEC_DECODER 0
++#define CONFIG_MJPEG_CUVID_DECODER 0
++#define CONFIG_MJPEG_QSV_DECODER 0
++#define CONFIG_MPEG1_CUVID_DECODER 0
++#define CONFIG_MPEG2_CUVID_DECODER 0
++#define CONFIG_MPEG4_CUVID_DECODER 0
++#define CONFIG_MPEG4_MEDIACODEC_DECODER 0
++#define CONFIG_VC1_CUVID_DECODER 0
++#define CONFIG_VP8_CUVID_DECODER 0
++#define CONFIG_VP8_MEDIACODEC_DECODER 0
++#define CONFIG_VP8_QSV_DECODER 0
++#define CONFIG_VP9_CUVID_DECODER 0
++#define CONFIG_VP9_MEDIACODEC_DECODER 0
++#define CONFIG_VP9_QSV_DECODER 0
++#define CONFIG_VNULL_DECODER 0
++#define CONFIG_ANULL_DECODER 0
++#define CONFIG_A64MULTI_ENCODER 0
++#define CONFIG_A64MULTI5_ENCODER 0
++#define CONFIG_ALIAS_PIX_ENCODER 0
++#define CONFIG_AMV_ENCODER 0
++#define CONFIG_APNG_ENCODER 0
++#define CONFIG_ASV1_ENCODER 0
++#define CONFIG_ASV2_ENCODER 0
++#define CONFIG_AVRP_ENCODER 0
++#define CONFIG_AVUI_ENCODER 0
++#define CONFIG_AYUV_ENCODER 0
++#define CONFIG_BITPACKED_ENCODER 0
++#define CONFIG_BMP_ENCODER 0
++#define CONFIG_CFHD_ENCODER 0
++#define CONFIG_CINEPAK_ENCODER 0
++#define CONFIG_CLJR_ENCODER 0
++#define CONFIG_COMFORTNOISE_ENCODER 0
++#define CONFIG_DNXHD_ENCODER 0
++#define CONFIG_DPX_ENCODER 0
++#define CONFIG_DVVIDEO_ENCODER 0
++#define CONFIG_EXR_ENCODER 0
++#define CONFIG_FFV1_ENCODER 0
++#define CONFIG_FFVHUFF_ENCODER 0
++#define CONFIG_FITS_ENCODER 0
++#define CONFIG_FLASHSV_ENCODER 0
++#define CONFIG_FLASHSV2_ENCODER 0
++#define CONFIG_FLV_ENCODER 0
++#define CONFIG_GIF_ENCODER 0
++#define CONFIG_H261_ENCODER 0
++#define CONFIG_H263_ENCODER 0
++#define CONFIG_H263P_ENCODER 0
++#define CONFIG_H264_MEDIACODEC_ENCODER 0
++#define CONFIG_HAP_ENCODER 0
++#define CONFIG_HUFFYUV_ENCODER 0
++#define CONFIG_JPEG2000_ENCODER 0
++#define CONFIG_JPEGLS_ENCODER 0
++#define CONFIG_LJPEG_ENCODER 0
++#define CONFIG_MAGICYUV_ENCODER 0
++#define CONFIG_MJPEG_ENCODER 0
++#define CONFIG_MPEG1VIDEO_ENCODER 0
++#define CONFIG_MPEG2VIDEO_ENCODER 0
++#define CONFIG_MPEG4_ENCODER 0
++#define CONFIG_MSMPEG4V2_ENCODER 0
++#define CONFIG_MSMPEG4V3_ENCODER 0
++#define CONFIG_MSRLE_ENCODER 0
++#define CONFIG_MSVIDEO1_ENCODER 0
++#define CONFIG_PAM_ENCODER 0
++#define CONFIG_PBM_ENCODER 0
++#define CONFIG_PCX_ENCODER 0
++#define CONFIG_PFM_ENCODER 0
++#define CONFIG_PGM_ENCODER 0
++#define CONFIG_PGMYUV_ENCODER 0
++#define CONFIG_PHM_ENCODER 0
++#define CONFIG_PNG_ENCODER 0
++#define CONFIG_PPM_ENCODER 0
++#define CONFIG_PRORES_ENCODER 0
++#define CONFIG_PRORES_AW_ENCODER 0
++#define CONFIG_PRORES_KS_ENCODER 0
++#define CONFIG_QOI_ENCODER 0
++#define CONFIG_QTRLE_ENCODER 0
++#define CONFIG_R10K_ENCODER 0
++#define CONFIG_R210_ENCODER 0
++#define CONFIG_RAWVIDEO_ENCODER 0
++#define CONFIG_ROQ_ENCODER 0
++#define CONFIG_RPZA_ENCODER 0
++#define CONFIG_RV10_ENCODER 0
++#define CONFIG_RV20_ENCODER 0
++#define CONFIG_S302M_ENCODER 0
++#define CONFIG_SGI_ENCODER 0
++#define CONFIG_SMC_ENCODER 0
++#define CONFIG_SNOW_ENCODER 0
++#define CONFIG_SPEEDHQ_ENCODER 0
++#define CONFIG_SUNRAST_ENCODER 0
++#define CONFIG_SVQ1_ENCODER 0
++#define CONFIG_TARGA_ENCODER 0
++#define CONFIG_TIFF_ENCODER 0
++#define CONFIG_UTVIDEO_ENCODER 0
++#define CONFIG_V210_ENCODER 0
++#define CONFIG_V308_ENCODER 0
++#define CONFIG_V408_ENCODER 0
++#define CONFIG_V410_ENCODER 0
++#define CONFIG_VBN_ENCODER 0
++#define CONFIG_VC2_ENCODER 0
++#define CONFIG_WBMP_ENCODER 0
++#define CONFIG_WRAPPED_AVFRAME_ENCODER 0
++#define CONFIG_WMV1_ENCODER 0
++#define CONFIG_WMV2_ENCODER 0
++#define CONFIG_XBM_ENCODER 0
++#define CONFIG_XFACE_ENCODER 0
++#define CONFIG_XWD_ENCODER 0
++#define CONFIG_Y41P_ENCODER 0
++#define CONFIG_YUV4_ENCODER 0
++#define CONFIG_ZLIB_ENCODER 0
++#define CONFIG_ZMBV_ENCODER 0
++#define CONFIG_AAC_ENCODER 0
++#define CONFIG_AC3_ENCODER 0
++#define CONFIG_AC3_FIXED_ENCODER 0
++#define CONFIG_ALAC_ENCODER 0
++#define CONFIG_APTX_ENCODER 0
++#define CONFIG_APTX_HD_ENCODER 0
++#define CONFIG_DCA_ENCODER 0
++#define CONFIG_DFPWM_ENCODER 0
++#define CONFIG_EAC3_ENCODER 0
++#define CONFIG_FLAC_ENCODER 0
++#define CONFIG_G723_1_ENCODER 0
++#define CONFIG_HDR_ENCODER 0
++#define CONFIG_MLP_ENCODER 0
++#define CONFIG_MP2_ENCODER 0
++#define CONFIG_MP2FIXED_ENCODER 0
++#define CONFIG_NELLYMOSER_ENCODER 0
++#define CONFIG_OPUS_ENCODER 0
++#define CONFIG_RA_144_ENCODER 0
++#define CONFIG_SBC_ENCODER 0
++#define CONFIG_SONIC_ENCODER 0
++#define CONFIG_SONIC_LS_ENCODER 0
++#define CONFIG_TRUEHD_ENCODER 0
++#define CONFIG_TTA_ENCODER 0
++#define CONFIG_VORBIS_ENCODER 0
++#define CONFIG_WAVPACK_ENCODER 0
++#define CONFIG_WMAV1_ENCODER 0
++#define CONFIG_WMAV2_ENCODER 0
++#define CONFIG_PCM_ALAW_ENCODER 0
++#define CONFIG_PCM_BLURAY_ENCODER 0
++#define CONFIG_PCM_DVD_ENCODER 0
++#define CONFIG_PCM_F32BE_ENCODER 0
++#define CONFIG_PCM_F32LE_ENCODER 0
++#define CONFIG_PCM_F64BE_ENCODER 0
++#define CONFIG_PCM_F64LE_ENCODER 0
++#define CONFIG_PCM_MULAW_ENCODER 0
++#define CONFIG_PCM_S8_ENCODER 0
++#define CONFIG_PCM_S8_PLANAR_ENCODER 0
++#define CONFIG_PCM_S16BE_ENCODER 0
++#define CONFIG_PCM_S16BE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S16LE_ENCODER 0
++#define CONFIG_PCM_S16LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S24BE_ENCODER 0
++#define CONFIG_PCM_S24DAUD_ENCODER 0
++#define CONFIG_PCM_S24LE_ENCODER 0
++#define CONFIG_PCM_S24LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S32BE_ENCODER 0
++#define CONFIG_PCM_S32LE_ENCODER 0
++#define CONFIG_PCM_S32LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S64BE_ENCODER 0
++#define CONFIG_PCM_S64LE_ENCODER 0
++#define CONFIG_PCM_U8_ENCODER 0
++#define CONFIG_PCM_U16BE_ENCODER 0
++#define CONFIG_PCM_U16LE_ENCODER 0
++#define CONFIG_PCM_U24BE_ENCODER 0
++#define CONFIG_PCM_U24LE_ENCODER 0
++#define CONFIG_PCM_U32BE_ENCODER 0
++#define CONFIG_PCM_U32LE_ENCODER 0
++#define CONFIG_PCM_VIDC_ENCODER 0
++#define CONFIG_ROQ_DPCM_ENCODER 0
++#define CONFIG_ADPCM_ADX_ENCODER 0
++#define CONFIG_ADPCM_ARGO_ENCODER 0
++#define CONFIG_ADPCM_G722_ENCODER 0
++#define CONFIG_ADPCM_G726_ENCODER 0
++#define CONFIG_ADPCM_G726LE_ENCODER 0
++#define CONFIG_ADPCM_IMA_AMV_ENCODER 0
++#define CONFIG_ADPCM_IMA_ALP_ENCODER 0
++#define CONFIG_ADPCM_IMA_APM_ENCODER 0
++#define CONFIG_ADPCM_IMA_QT_ENCODER 0
++#define CONFIG_ADPCM_IMA_SSI_ENCODER 0
++#define CONFIG_ADPCM_IMA_WAV_ENCODER 0
++#define CONFIG_ADPCM_IMA_WS_ENCODER 0
++#define CONFIG_ADPCM_MS_ENCODER 0
++#define CONFIG_ADPCM_SWF_ENCODER 0
++#define CONFIG_ADPCM_YAMAHA_ENCODER 0
++#define CONFIG_SSA_ENCODER 0
++#define CONFIG_ASS_ENCODER 0
++#define CONFIG_DVBSUB_ENCODER 0
++#define CONFIG_DVDSUB_ENCODER 0
++#define CONFIG_MOVTEXT_ENCODER 0
++#define CONFIG_SRT_ENCODER 0
++#define CONFIG_SUBRIP_ENCODER 0
++#define CONFIG_TEXT_ENCODER 0
++#define CONFIG_TTML_ENCODER 0
++#define CONFIG_WEBVTT_ENCODER 0
++#define CONFIG_XSUB_ENCODER 0
++#define CONFIG_AAC_AT_ENCODER 0
++#define CONFIG_ALAC_AT_ENCODER 0
++#define CONFIG_ILBC_AT_ENCODER 0
++#define CONFIG_PCM_ALAW_AT_ENCODER 0
++#define CONFIG_PCM_MULAW_AT_ENCODER 0
++#define CONFIG_LIBAOM_AV1_ENCODER 0
++#define CONFIG_LIBCODEC2_ENCODER 0
++#define CONFIG_LIBFDK_AAC_ENCODER 0
++#define CONFIG_LIBGSM_ENCODER 0
++#define CONFIG_LIBGSM_MS_ENCODER 0
++#define CONFIG_LIBILBC_ENCODER 0
++#define CONFIG_LIBJXL_ENCODER 0
++#define CONFIG_LIBMP3LAME_ENCODER 0
++#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
++#define CONFIG_LIBOPENJPEG_ENCODER 0
++#define CONFIG_LIBOPUS_ENCODER 0
++#define CONFIG_LIBRAV1E_ENCODER 0
++#define CONFIG_LIBSHINE_ENCODER 0
++#define CONFIG_LIBSPEEX_ENCODER 0
++#define CONFIG_LIBSVTAV1_ENCODER 0
++#define CONFIG_LIBTHEORA_ENCODER 0
++#define CONFIG_LIBTWOLAME_ENCODER 0
++#define CONFIG_LIBVO_AMRWBENC_ENCODER 0
++#define CONFIG_LIBVORBIS_ENCODER 0
++#define CONFIG_LIBVPX_VP8_ENCODER 0
++#define CONFIG_LIBVPX_VP9_ENCODER 0
++#define CONFIG_LIBWEBP_ANIM_ENCODER 0
++#define CONFIG_LIBWEBP_ENCODER 0
++#define CONFIG_LIBX262_ENCODER 0
++#define CONFIG_LIBX264_ENCODER 0
++#define CONFIG_LIBX264RGB_ENCODER 0
++#define CONFIG_LIBX265_ENCODER 0
++#define CONFIG_LIBXAVS_ENCODER 0
++#define CONFIG_LIBXAVS2_ENCODER 0
++#define CONFIG_LIBXVID_ENCODER 0
++#define CONFIG_AAC_MF_ENCODER 0
++#define CONFIG_AC3_MF_ENCODER 0
++#define CONFIG_H263_V4L2M2M_ENCODER 0
++#define CONFIG_AV1_MEDIACODEC_ENCODER 0
++#define CONFIG_AV1_NVENC_ENCODER 0
++#define CONFIG_AV1_QSV_ENCODER 0
++#define CONFIG_AV1_AMF_ENCODER 0
++#define CONFIG_LIBOPENH264_ENCODER 0
++#define CONFIG_H264_AMF_ENCODER 0
++#define CONFIG_H264_MF_ENCODER 0
++#define CONFIG_H264_NVENC_ENCODER 0
++#define CONFIG_H264_OMX_ENCODER 0
++#define CONFIG_H264_QSV_ENCODER 0
++#define CONFIG_H264_V4L2M2M_ENCODER 0
++#define CONFIG_H264_VAAPI_ENCODER 0
++#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_HEVC_AMF_ENCODER 0
++#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
++#define CONFIG_HEVC_MF_ENCODER 0
++#define CONFIG_HEVC_NVENC_ENCODER 0
++#define CONFIG_HEVC_QSV_ENCODER 0
++#define CONFIG_HEVC_V4L2M2M_ENCODER 0
++#define CONFIG_HEVC_VAAPI_ENCODER 0
++#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_LIBKVAZAAR_ENCODER 0
++#define CONFIG_MJPEG_QSV_ENCODER 0
++#define CONFIG_MJPEG_VAAPI_ENCODER 0
++#define CONFIG_MP3_MF_ENCODER 0
++#define CONFIG_MPEG2_QSV_ENCODER 0
++#define CONFIG_MPEG2_VAAPI_ENCODER 0
++#define CONFIG_MPEG4_MEDIACODEC_ENCODER 0
++#define CONFIG_MPEG4_OMX_ENCODER 0
++#define CONFIG_MPEG4_V4L2M2M_ENCODER 0
++#define CONFIG_PRORES_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_VP8_MEDIACODEC_ENCODER 0
++#define CONFIG_VP8_V4L2M2M_ENCODER 0
++#define CONFIG_VP8_VAAPI_ENCODER 0
++#define CONFIG_VP9_MEDIACODEC_ENCODER 0
++#define CONFIG_VP9_VAAPI_ENCODER 0
++#define CONFIG_VP9_QSV_ENCODER 0
++#define CONFIG_VNULL_ENCODER 0
++#define CONFIG_ANULL_ENCODER 0
++#define CONFIG_AV1_D3D11VA_HWACCEL 0
++#define CONFIG_AV1_D3D11VA2_HWACCEL 0
++#define CONFIG_AV1_DXVA2_HWACCEL 0
++#define CONFIG_AV1_NVDEC_HWACCEL 0
++#define CONFIG_AV1_VAAPI_HWACCEL 0
++#define CONFIG_AV1_VDPAU_HWACCEL 0
++#define CONFIG_AV1_VULKAN_HWACCEL 0
++#define CONFIG_H263_VAAPI_HWACCEL 0
++#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_H264_D3D11VA_HWACCEL 0
++#define CONFIG_H264_D3D11VA2_HWACCEL 0
++#define CONFIG_H264_DXVA2_HWACCEL 0
++#define CONFIG_H264_NVDEC_HWACCEL 0
++#define CONFIG_H264_VAAPI_HWACCEL 0
++#define CONFIG_H264_VDPAU_HWACCEL 0
++#define CONFIG_H264_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_H264_VULKAN_HWACCEL 0
++#define CONFIG_HEVC_D3D11VA_HWACCEL 0
++#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
++#define CONFIG_HEVC_DXVA2_HWACCEL 0
++#define CONFIG_HEVC_NVDEC_HWACCEL 0
++#define CONFIG_HEVC_VAAPI_HWACCEL 0
++#define CONFIG_HEVC_VDPAU_HWACCEL 0
++#define CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_HEVC_VULKAN_HWACCEL 0
++#define CONFIG_MJPEG_NVDEC_HWACCEL 0
++#define CONFIG_MJPEG_VAAPI_HWACCEL 0
++#define CONFIG_MPEG1_NVDEC_HWACCEL 0
++#define CONFIG_MPEG1_VDPAU_HWACCEL 0
++#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
++#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
++#define CONFIG_MPEG2_NVDEC_HWACCEL 0
++#define CONFIG_MPEG2_DXVA2_HWACCEL 0
++#define CONFIG_MPEG2_VAAPI_HWACCEL 0
++#define CONFIG_MPEG2_VDPAU_HWACCEL 0
++#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MPEG4_NVDEC_HWACCEL 0
++#define CONFIG_MPEG4_VAAPI_HWACCEL 0
++#define CONFIG_MPEG4_VDPAU_HWACCEL 0
++#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_VC1_D3D11VA_HWACCEL 0
++#define CONFIG_VC1_D3D11VA2_HWACCEL 0
++#define CONFIG_VC1_DXVA2_HWACCEL 0
++#define CONFIG_VC1_NVDEC_HWACCEL 0
++#define CONFIG_VC1_VAAPI_HWACCEL 0
++#define CONFIG_VC1_VDPAU_HWACCEL 0
++#define CONFIG_VP8_NVDEC_HWACCEL 0
++#define CONFIG_VP8_VAAPI_HWACCEL 0
++#define CONFIG_VP9_D3D11VA_HWACCEL 0
++#define CONFIG_VP9_D3D11VA2_HWACCEL 0
++#define CONFIG_VP9_DXVA2_HWACCEL 0
++#define CONFIG_VP9_NVDEC_HWACCEL 0
++#define CONFIG_VP9_VAAPI_HWACCEL 0
++#define CONFIG_VP9_VDPAU_HWACCEL 0
++#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_WMV3_D3D11VA_HWACCEL 0
++#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
++#define CONFIG_WMV3_DXVA2_HWACCEL 0
++#define CONFIG_WMV3_NVDEC_HWACCEL 0
++#define CONFIG_WMV3_VAAPI_HWACCEL 0
++#define CONFIG_WMV3_VDPAU_HWACCEL 0
++#define CONFIG_AAC_PARSER 1
++#define CONFIG_AAC_LATM_PARSER 0
++#define CONFIG_AC3_PARSER 0
++#define CONFIG_ADX_PARSER 0
++#define CONFIG_AMR_PARSER 0
++#define CONFIG_AV1_PARSER 0
++#define CONFIG_AVS2_PARSER 0
++#define CONFIG_AVS3_PARSER 0
++#define CONFIG_BMP_PARSER 0
++#define CONFIG_CAVSVIDEO_PARSER 0
++#define CONFIG_COOK_PARSER 0
++#define CONFIG_CRI_PARSER 0
++#define CONFIG_DCA_PARSER 0
++#define CONFIG_DIRAC_PARSER 0
++#define CONFIG_DNXHD_PARSER 0
++#define CONFIG_DOLBY_E_PARSER 0
++#define CONFIG_DPX_PARSER 0
++#define CONFIG_DVAUDIO_PARSER 0
++#define CONFIG_DVBSUB_PARSER 0
++#define CONFIG_DVDSUB_PARSER 0
++#define CONFIG_DVD_NAV_PARSER 0
++#define CONFIG_EVC_PARSER 0
++#define CONFIG_FLAC_PARSER 1
++#define CONFIG_FTR_PARSER 0
++#define CONFIG_G723_1_PARSER 0
++#define CONFIG_G729_PARSER 0
++#define CONFIG_GIF_PARSER 0
++#define CONFIG_GSM_PARSER 0
++#define CONFIG_H261_PARSER 0
++#define CONFIG_H263_PARSER 0
++#define CONFIG_H264_PARSER 1
++#define CONFIG_HEVC_PARSER 0
++#define CONFIG_HDR_PARSER 0
++#define CONFIG_IPU_PARSER 0
++#define CONFIG_JPEG2000_PARSER 0
++#define CONFIG_MISC4_PARSER 0
++#define CONFIG_MJPEG_PARSER 0
++#define CONFIG_MLP_PARSER 0
++#define CONFIG_MPEG4VIDEO_PARSER 0
++#define CONFIG_MPEGAUDIO_PARSER 1
++#define CONFIG_MPEGVIDEO_PARSER 0
++#define CONFIG_OPUS_PARSER 1
++#define CONFIG_PNG_PARSER 0
++#define CONFIG_PNM_PARSER 0
++#define CONFIG_QOI_PARSER 0
++#define CONFIG_RV30_PARSER 0
++#define CONFIG_RV40_PARSER 0
++#define CONFIG_SBC_PARSER 0
++#define CONFIG_SIPR_PARSER 0
++#define CONFIG_TAK_PARSER 0
++#define CONFIG_VC1_PARSER 0
++#define CONFIG_VORBIS_PARSER 1
++#define CONFIG_VP3_PARSER 1
++#define CONFIG_VP8_PARSER 1
++#define CONFIG_VP9_PARSER 1
++#define CONFIG_VVC_PARSER 0
++#define CONFIG_WEBP_PARSER 0
++#define CONFIG_XBM_PARSER 0
++#define CONFIG_XMA_PARSER 0
++#define CONFIG_XWD_PARSER 0
++#define CONFIG_ALSA_INDEV 0
++#define CONFIG_ANDROID_CAMERA_INDEV 0
++#define CONFIG_AVFOUNDATION_INDEV 0
++#define CONFIG_BKTR_INDEV 0
++#define CONFIG_DECKLINK_INDEV 0
++#define CONFIG_DSHOW_INDEV 0
++#define CONFIG_FBDEV_INDEV 0
++#define CONFIG_GDIGRAB_INDEV 0
++#define CONFIG_IEC61883_INDEV 0
++#define CONFIG_JACK_INDEV 0
++#define CONFIG_KMSGRAB_INDEV 0
++#define CONFIG_LAVFI_INDEV 0
++#define CONFIG_OPENAL_INDEV 0
++#define CONFIG_OSS_INDEV 0
++#define CONFIG_PULSE_INDEV 0
++#define CONFIG_SNDIO_INDEV 0
++#define CONFIG_V4L2_INDEV 0
++#define CONFIG_VFWCAP_INDEV 0
++#define CONFIG_XCBGRAB_INDEV 0
++#define CONFIG_LIBCDIO_INDEV 0
++#define CONFIG_LIBDC1394_INDEV 0
++#define CONFIG_ALSA_OUTDEV 0
++#define CONFIG_AUDIOTOOLBOX_OUTDEV 0
++#define CONFIG_CACA_OUTDEV 0
++#define CONFIG_DECKLINK_OUTDEV 0
++#define CONFIG_FBDEV_OUTDEV 0
++#define CONFIG_OPENGL_OUTDEV 0
++#define CONFIG_OSS_OUTDEV 0
++#define CONFIG_PULSE_OUTDEV 0
++#define CONFIG_SDL2_OUTDEV 0
++#define CONFIG_SNDIO_OUTDEV 0
++#define CONFIG_V4L2_OUTDEV 0
++#define CONFIG_XV_OUTDEV 0
++#define CONFIG_ABENCH_FILTER 0
++#define CONFIG_ACOMPRESSOR_FILTER 0
++#define CONFIG_ACONTRAST_FILTER 0
++#define CONFIG_ACOPY_FILTER 0
++#define CONFIG_ACUE_FILTER 0
++#define CONFIG_ACROSSFADE_FILTER 0
++#define CONFIG_ACROSSOVER_FILTER 0
++#define CONFIG_ACRUSHER_FILTER 0
++#define CONFIG_ADECLICK_FILTER 0
++#define CONFIG_ADECLIP_FILTER 0
++#define CONFIG_ADECORRELATE_FILTER 0
++#define CONFIG_ADELAY_FILTER 0
++#define CONFIG_ADENORM_FILTER 0
++#define CONFIG_ADERIVATIVE_FILTER 0
++#define CONFIG_ADRC_FILTER 0
++#define CONFIG_ADYNAMICEQUALIZER_FILTER 0
++#define CONFIG_ADYNAMICSMOOTH_FILTER 0
++#define CONFIG_AECHO_FILTER 0
++#define CONFIG_AEMPHASIS_FILTER 0
++#define CONFIG_AEVAL_FILTER 0
++#define CONFIG_AEXCITER_FILTER 0
++#define CONFIG_AFADE_FILTER 0
++#define CONFIG_AFFTDN_FILTER 0
++#define CONFIG_AFFTFILT_FILTER 0
++#define CONFIG_AFIR_FILTER 0
++#define CONFIG_AFORMAT_FILTER 0
++#define CONFIG_AFREQSHIFT_FILTER 0
++#define CONFIG_AFWTDN_FILTER 0
++#define CONFIG_AGATE_FILTER 0
++#define CONFIG_AIIR_FILTER 0
++#define CONFIG_AINTEGRAL_FILTER 0
++#define CONFIG_AINTERLEAVE_FILTER 0
++#define CONFIG_ALATENCY_FILTER 0
++#define CONFIG_ALIMITER_FILTER 0
++#define CONFIG_ALLPASS_FILTER 0
++#define CONFIG_ALOOP_FILTER 0
++#define CONFIG_AMERGE_FILTER 0
++#define CONFIG_AMETADATA_FILTER 0
++#define CONFIG_AMIX_FILTER 0
++#define CONFIG_AMULTIPLY_FILTER 0
++#define CONFIG_ANEQUALIZER_FILTER 0
++#define CONFIG_ANLMDN_FILTER 0
++#define CONFIG_ANLMF_FILTER 0
++#define CONFIG_ANLMS_FILTER 0
++#define CONFIG_ANULL_FILTER 0
++#define CONFIG_APAD_FILTER 0
++#define CONFIG_APERMS_FILTER 0
++#define CONFIG_APHASER_FILTER 0
++#define CONFIG_APHASESHIFT_FILTER 0
++#define CONFIG_APSYCLIP_FILTER 0
++#define CONFIG_APULSATOR_FILTER 0
++#define CONFIG_AREALTIME_FILTER 0
++#define CONFIG_ARESAMPLE_FILTER 0
++#define CONFIG_AREVERSE_FILTER 0
++#define CONFIG_ARLS_FILTER 0
++#define CONFIG_ARNNDN_FILTER 0
++#define CONFIG_ASDR_FILTER 0
++#define CONFIG_ASEGMENT_FILTER 0
++#define CONFIG_ASELECT_FILTER 0
++#define CONFIG_ASENDCMD_FILTER 0
++#define CONFIG_ASETNSAMPLES_FILTER 0
++#define CONFIG_ASETPTS_FILTER 0
++#define CONFIG_ASETRATE_FILTER 0
++#define CONFIG_ASETTB_FILTER 0
++#define CONFIG_ASHOWINFO_FILTER 0
++#define CONFIG_ASIDEDATA_FILTER 0
++#define CONFIG_ASOFTCLIP_FILTER 0
++#define CONFIG_ASPECTRALSTATS_FILTER 0
++#define CONFIG_ASPLIT_FILTER 0
++#define CONFIG_ASR_FILTER 0
++#define CONFIG_ASTATS_FILTER 0
++#define CONFIG_ASTREAMSELECT_FILTER 0
++#define CONFIG_ASUBBOOST_FILTER 0
++#define CONFIG_ASUBCUT_FILTER 0
++#define CONFIG_ASUPERCUT_FILTER 0
++#define CONFIG_ASUPERPASS_FILTER 0
++#define CONFIG_ASUPERSTOP_FILTER 0
++#define CONFIG_ATEMPO_FILTER 0
++#define CONFIG_ATILT_FILTER 0
++#define CONFIG_ATRIM_FILTER 0
++#define CONFIG_AXCORRELATE_FILTER 0
++#define CONFIG_AZMQ_FILTER 0
++#define CONFIG_BANDPASS_FILTER 0
++#define CONFIG_BANDREJECT_FILTER 0
++#define CONFIG_BASS_FILTER 0
++#define CONFIG_BIQUAD_FILTER 0
++#define CONFIG_BS2B_FILTER 0
++#define CONFIG_CHANNELMAP_FILTER 0
++#define CONFIG_CHANNELSPLIT_FILTER 0
++#define CONFIG_CHORUS_FILTER 0
++#define CONFIG_COMPAND_FILTER 0
++#define CONFIG_COMPENSATIONDELAY_FILTER 0
++#define CONFIG_CROSSFEED_FILTER 0
++#define CONFIG_CRYSTALIZER_FILTER 0
++#define CONFIG_DCSHIFT_FILTER 0
++#define CONFIG_DEESSER_FILTER 0
++#define CONFIG_DIALOGUENHANCE_FILTER 0
++#define CONFIG_DRMETER_FILTER 0
++#define CONFIG_DYNAUDNORM_FILTER 0
++#define CONFIG_EARWAX_FILTER 0
++#define CONFIG_EBUR128_FILTER 0
++#define CONFIG_EQUALIZER_FILTER 0
++#define CONFIG_EXTRASTEREO_FILTER 0
++#define CONFIG_FIREQUALIZER_FILTER 0
++#define CONFIG_FLANGER_FILTER 0
++#define CONFIG_HAAS_FILTER 0
++#define CONFIG_HDCD_FILTER 0
++#define CONFIG_HEADPHONE_FILTER 0
++#define CONFIG_HIGHPASS_FILTER 0
++#define CONFIG_HIGHSHELF_FILTER 0
++#define CONFIG_JOIN_FILTER 0
++#define CONFIG_LADSPA_FILTER 0
++#define CONFIG_LOUDNORM_FILTER 0
++#define CONFIG_LOWPASS_FILTER 0
++#define CONFIG_LOWSHELF_FILTER 0
++#define CONFIG_LV2_FILTER 0
++#define CONFIG_MCOMPAND_FILTER 0
++#define CONFIG_PAN_FILTER 0
++#define CONFIG_REPLAYGAIN_FILTER 0
++#define CONFIG_RUBBERBAND_FILTER 0
++#define CONFIG_SIDECHAINCOMPRESS_FILTER 0
++#define CONFIG_SIDECHAINGATE_FILTER 0
++#define CONFIG_SILENCEDETECT_FILTER 0
++#define CONFIG_SILENCEREMOVE_FILTER 0
++#define CONFIG_SOFALIZER_FILTER 0
++#define CONFIG_SPEECHNORM_FILTER 0
++#define CONFIG_STEREOTOOLS_FILTER 0
++#define CONFIG_STEREOWIDEN_FILTER 0
++#define CONFIG_SUPEREQUALIZER_FILTER 0
++#define CONFIG_SURROUND_FILTER 0
++#define CONFIG_TILTSHELF_FILTER 0
++#define CONFIG_TREBLE_FILTER 0
++#define CONFIG_TREMOLO_FILTER 0
++#define CONFIG_VIBRATO_FILTER 0
++#define CONFIG_VIRTUALBASS_FILTER 0
++#define CONFIG_VOLUME_FILTER 0
++#define CONFIG_VOLUMEDETECT_FILTER 0
++#define CONFIG_AEVALSRC_FILTER 0
++#define CONFIG_AFDELAYSRC_FILTER 0
++#define CONFIG_AFIREQSRC_FILTER 0
++#define CONFIG_AFIRSRC_FILTER 0
++#define CONFIG_ANOISESRC_FILTER 0
++#define CONFIG_ANULLSRC_FILTER 0
++#define CONFIG_FLITE_FILTER 0
++#define CONFIG_HILBERT_FILTER 0
++#define CONFIG_SINC_FILTER 0
++#define CONFIG_SINE_FILTER 0
++#define CONFIG_ANULLSINK_FILTER 0
++#define CONFIG_ADDROI_FILTER 0
++#define CONFIG_ALPHAEXTRACT_FILTER 0
++#define CONFIG_ALPHAMERGE_FILTER 0
++#define CONFIG_AMPLIFY_FILTER 0
++#define CONFIG_ASS_FILTER 0
++#define CONFIG_ATADENOISE_FILTER 0
++#define CONFIG_AVGBLUR_FILTER 0
++#define CONFIG_AVGBLUR_OPENCL_FILTER 0
++#define CONFIG_AVGBLUR_VULKAN_FILTER 0
++#define CONFIG_BACKGROUNDKEY_FILTER 0
++#define CONFIG_BBOX_FILTER 0
++#define CONFIG_BENCH_FILTER 0
++#define CONFIG_BILATERAL_FILTER 0
++#define CONFIG_BILATERAL_CUDA_FILTER 0
++#define CONFIG_BITPLANENOISE_FILTER 0
++#define CONFIG_BLACKDETECT_FILTER 0
++#define CONFIG_BLACKFRAME_FILTER 0
++#define CONFIG_BLEND_FILTER 0
++#define CONFIG_BLEND_VULKAN_FILTER 0
++#define CONFIG_BLOCKDETECT_FILTER 0
++#define CONFIG_BLURDETECT_FILTER 0
++#define CONFIG_BM3D_FILTER 0
++#define CONFIG_BOXBLUR_FILTER 0
++#define CONFIG_BOXBLUR_OPENCL_FILTER 0
++#define CONFIG_BWDIF_FILTER 0
++#define CONFIG_BWDIF_CUDA_FILTER 0
++#define CONFIG_BWDIF_VULKAN_FILTER 0
++#define CONFIG_CAS_FILTER 0
++#define CONFIG_CCREPACK_FILTER 0
++#define CONFIG_CHROMABER_VULKAN_FILTER 0
++#define CONFIG_CHROMAHOLD_FILTER 0
++#define CONFIG_CHROMAKEY_FILTER 0
++#define CONFIG_CHROMAKEY_CUDA_FILTER 0
++#define CONFIG_CHROMANR_FILTER 0
++#define CONFIG_CHROMASHIFT_FILTER 0
++#define CONFIG_CIESCOPE_FILTER 0
++#define CONFIG_CODECVIEW_FILTER 0
++#define CONFIG_COLORBALANCE_FILTER 0
++#define CONFIG_COLORCHANNELMIXER_FILTER 0
++#define CONFIG_COLORCONTRAST_FILTER 0
++#define CONFIG_COLORCORRECT_FILTER 0
++#define CONFIG_COLORIZE_FILTER 0
++#define CONFIG_COLORKEY_FILTER 0
++#define CONFIG_COLORKEY_OPENCL_FILTER 0
++#define CONFIG_COLORHOLD_FILTER 0
++#define CONFIG_COLORLEVELS_FILTER 0
++#define CONFIG_COLORMAP_FILTER 0
++#define CONFIG_COLORMATRIX_FILTER 0
++#define CONFIG_COLORSPACE_FILTER 0
++#define CONFIG_COLORSPACE_CUDA_FILTER 0
++#define CONFIG_COLORTEMPERATURE_FILTER 0
++#define CONFIG_CONVOLUTION_FILTER 0
++#define CONFIG_CONVOLUTION_OPENCL_FILTER 0
++#define CONFIG_CONVOLVE_FILTER 0
++#define CONFIG_COPY_FILTER 0
++#define CONFIG_COREIMAGE_FILTER 0
++#define CONFIG_CORR_FILTER 0
++#define CONFIG_COVER_RECT_FILTER 0
++#define CONFIG_CROP_FILTER 0
++#define CONFIG_CROPDETECT_FILTER 0
++#define CONFIG_CUE_FILTER 0
++#define CONFIG_CURVES_FILTER 0
++#define CONFIG_DATASCOPE_FILTER 0
++#define CONFIG_DBLUR_FILTER 0
++#define CONFIG_DCTDNOIZ_FILTER 0
++#define CONFIG_DEBAND_FILTER 0
++#define CONFIG_DEBLOCK_FILTER 0
++#define CONFIG_DECIMATE_FILTER 0
++#define CONFIG_DECONVOLVE_FILTER 0
++#define CONFIG_DEDOT_FILTER 0
++#define CONFIG_DEFLATE_FILTER 0
++#define CONFIG_DEFLICKER_FILTER 0
++#define CONFIG_DEINTERLACE_QSV_FILTER 0
++#define CONFIG_DEINTERLACE_VAAPI_FILTER 0
++#define CONFIG_DEJUDDER_FILTER 0
++#define CONFIG_DELOGO_FILTER 0
++#define CONFIG_DENOISE_VAAPI_FILTER 0
++#define CONFIG_DERAIN_FILTER 0
++#define CONFIG_DESHAKE_FILTER 0
++#define CONFIG_DESHAKE_OPENCL_FILTER 0
++#define CONFIG_DESPILL_FILTER 0
++#define CONFIG_DETELECINE_FILTER 0
++#define CONFIG_DILATION_FILTER 0
++#define CONFIG_DILATION_OPENCL_FILTER 0
++#define CONFIG_DISPLACE_FILTER 0
++#define CONFIG_DNN_CLASSIFY_FILTER 0
++#define CONFIG_DNN_DETECT_FILTER 0
++#define CONFIG_DNN_PROCESSING_FILTER 0
++#define CONFIG_DOUBLEWEAVE_FILTER 0
++#define CONFIG_DRAWBOX_FILTER 0
++#define CONFIG_DRAWGRAPH_FILTER 0
++#define CONFIG_DRAWGRID_FILTER 0
++#define CONFIG_DRAWTEXT_FILTER 0
++#define CONFIG_EDGEDETECT_FILTER 0
++#define CONFIG_ELBG_FILTER 0
++#define CONFIG_ENTROPY_FILTER 0
++#define CONFIG_EPX_FILTER 0
++#define CONFIG_EQ_FILTER 0
++#define CONFIG_EROSION_FILTER 0
++#define CONFIG_EROSION_OPENCL_FILTER 0
++#define CONFIG_ESTDIF_FILTER 0
++#define CONFIG_EXPOSURE_FILTER 0
++#define CONFIG_EXTRACTPLANES_FILTER 0
++#define CONFIG_FADE_FILTER 0
++#define CONFIG_FEEDBACK_FILTER 0
++#define CONFIG_FFTDNOIZ_FILTER 0
++#define CONFIG_FFTFILT_FILTER 0
++#define CONFIG_FIELD_FILTER 0
++#define CONFIG_FIELDHINT_FILTER 0
++#define CONFIG_FIELDMATCH_FILTER 0
++#define CONFIG_FIELDORDER_FILTER 0
++#define CONFIG_FILLBORDERS_FILTER 0
++#define CONFIG_FIND_RECT_FILTER 0
++#define CONFIG_FLIP_VULKAN_FILTER 0
++#define CONFIG_FLOODFILL_FILTER 0
++#define CONFIG_FORMAT_FILTER 0
++#define CONFIG_FPS_FILTER 0
++#define CONFIG_FRAMEPACK_FILTER 0
++#define CONFIG_FRAMERATE_FILTER 0
++#define CONFIG_FRAMESTEP_FILTER 0
++#define CONFIG_FREEZEDETECT_FILTER 0
++#define CONFIG_FREEZEFRAMES_FILTER 0
++#define CONFIG_FREI0R_FILTER 0
++#define CONFIG_FSPP_FILTER 0
++#define CONFIG_GBLUR_FILTER 0
++#define CONFIG_GBLUR_VULKAN_FILTER 0
++#define CONFIG_GEQ_FILTER 0
++#define CONFIG_GRADFUN_FILTER 0
++#define CONFIG_GRAPHMONITOR_FILTER 0
++#define CONFIG_GRAYWORLD_FILTER 0
++#define CONFIG_GREYEDGE_FILTER 0
++#define CONFIG_GUIDED_FILTER 0
++#define CONFIG_HALDCLUT_FILTER 0
++#define CONFIG_HFLIP_FILTER 0
++#define CONFIG_HFLIP_VULKAN_FILTER 0
++#define CONFIG_HISTEQ_FILTER 0
++#define CONFIG_HISTOGRAM_FILTER 0
++#define CONFIG_HQDN3D_FILTER 0
++#define CONFIG_HQX_FILTER 0
++#define CONFIG_HSTACK_FILTER 0
++#define CONFIG_HSVHOLD_FILTER 0
++#define CONFIG_HSVKEY_FILTER 0
++#define CONFIG_HUE_FILTER 0
++#define CONFIG_HUESATURATION_FILTER 0
++#define CONFIG_HWDOWNLOAD_FILTER 0
++#define CONFIG_HWMAP_FILTER 0
++#define CONFIG_HWUPLOAD_FILTER 0
++#define CONFIG_HWUPLOAD_CUDA_FILTER 0
++#define CONFIG_HYSTERESIS_FILTER 0
++#define CONFIG_ICCDETECT_FILTER 0
++#define CONFIG_ICCGEN_FILTER 0
++#define CONFIG_IDENTITY_FILTER 0
++#define CONFIG_IDET_FILTER 0
++#define CONFIG_IL_FILTER 0
++#define CONFIG_INFLATE_FILTER 0
++#define CONFIG_INTERLACE_FILTER 0
++#define CONFIG_INTERLEAVE_FILTER 0
++#define CONFIG_KERNDEINT_FILTER 0
++#define CONFIG_KIRSCH_FILTER 0
++#define CONFIG_LAGFUN_FILTER 0
++#define CONFIG_LATENCY_FILTER 0
++#define CONFIG_LENSCORRECTION_FILTER 0
++#define CONFIG_LENSFUN_FILTER 0
++#define CONFIG_LIBPLACEBO_FILTER 0
++#define CONFIG_LIBVMAF_FILTER 0
++#define CONFIG_LIMITDIFF_FILTER 0
++#define CONFIG_LIMITER_FILTER 0
++#define CONFIG_LOOP_FILTER 0
++#define CONFIG_LUMAKEY_FILTER 0
++#define CONFIG_LUT_FILTER 0
++#define CONFIG_LUT1D_FILTER 0
++#define CONFIG_LUT2_FILTER 0
++#define CONFIG_LUT3D_FILTER 0
++#define CONFIG_LUTRGB_FILTER 0
++#define CONFIG_LUTYUV_FILTER 0
++#define CONFIG_MASKEDCLAMP_FILTER 0
++#define CONFIG_MASKEDMAX_FILTER 0
++#define CONFIG_MASKEDMERGE_FILTER 0
++#define CONFIG_MASKEDMIN_FILTER 0
++#define CONFIG_MASKEDTHRESHOLD_FILTER 0
++#define CONFIG_MASKFUN_FILTER 0
++#define CONFIG_MCDEINT_FILTER 0
++#define CONFIG_MEDIAN_FILTER 0
++#define CONFIG_MERGEPLANES_FILTER 0
++#define CONFIG_MESTIMATE_FILTER 0
++#define CONFIG_METADATA_FILTER 0
++#define CONFIG_MIDEQUALIZER_FILTER 0
++#define CONFIG_MINTERPOLATE_FILTER 0
++#define CONFIG_MIX_FILTER 0
++#define CONFIG_MONOCHROME_FILTER 0
++#define CONFIG_MORPHO_FILTER 0
++#define CONFIG_MPDECIMATE_FILTER 0
++#define CONFIG_MSAD_FILTER 0
++#define CONFIG_MULTIPLY_FILTER 0
++#define CONFIG_NEGATE_FILTER 0
++#define CONFIG_NLMEANS_FILTER 0
++#define CONFIG_NLMEANS_OPENCL_FILTER 0
++#define CONFIG_NLMEANS_VULKAN_FILTER 0
++#define CONFIG_NNEDI_FILTER 0
++#define CONFIG_NOFORMAT_FILTER 0
++#define CONFIG_NOISE_FILTER 0
++#define CONFIG_NORMALIZE_FILTER 0
++#define CONFIG_NULL_FILTER 0
++#define CONFIG_OCR_FILTER 0
++#define CONFIG_OCV_FILTER 0
++#define CONFIG_OSCILLOSCOPE_FILTER 0
++#define CONFIG_OVERLAY_FILTER 0
++#define CONFIG_OVERLAY_OPENCL_FILTER 0
++#define CONFIG_OVERLAY_QSV_FILTER 0
++#define CONFIG_OVERLAY_VAAPI_FILTER 0
++#define CONFIG_OVERLAY_VULKAN_FILTER 0
++#define CONFIG_OVERLAY_CUDA_FILTER 0
++#define CONFIG_OWDENOISE_FILTER 0
++#define CONFIG_PAD_FILTER 0
++#define CONFIG_PAD_OPENCL_FILTER 0
++#define CONFIG_PALETTEGEN_FILTER 0
++#define CONFIG_PALETTEUSE_FILTER 0
++#define CONFIG_PERMS_FILTER 0
++#define CONFIG_PERSPECTIVE_FILTER 0
++#define CONFIG_PHASE_FILTER 0
++#define CONFIG_PHOTOSENSITIVITY_FILTER 0
++#define CONFIG_PIXDESCTEST_FILTER 0
++#define CONFIG_PIXELIZE_FILTER 0
++#define CONFIG_PIXSCOPE_FILTER 0
++#define CONFIG_PP_FILTER 0
++#define CONFIG_PP7_FILTER 0
++#define CONFIG_PREMULTIPLY_FILTER 0
++#define CONFIG_PREWITT_FILTER 0
++#define CONFIG_PREWITT_OPENCL_FILTER 0
++#define CONFIG_PROCAMP_VAAPI_FILTER 0
++#define CONFIG_PROGRAM_OPENCL_FILTER 0
++#define CONFIG_PSEUDOCOLOR_FILTER 0
++#define CONFIG_PSNR_FILTER 0
++#define CONFIG_PULLUP_FILTER 0
++#define CONFIG_QP_FILTER 0
++#define CONFIG_RANDOM_FILTER 0
++#define CONFIG_READEIA608_FILTER 0
++#define CONFIG_READVITC_FILTER 0
++#define CONFIG_REALTIME_FILTER 0
++#define CONFIG_REMAP_FILTER 0
++#define CONFIG_REMAP_OPENCL_FILTER 0
++#define CONFIG_REMOVEGRAIN_FILTER 0
++#define CONFIG_REMOVELOGO_FILTER 0
++#define CONFIG_REPEATFIELDS_FILTER 0
++#define CONFIG_REVERSE_FILTER 0
++#define CONFIG_RGBASHIFT_FILTER 0
++#define CONFIG_ROBERTS_FILTER 0
++#define CONFIG_ROBERTS_OPENCL_FILTER 0
++#define CONFIG_ROTATE_FILTER 0
++#define CONFIG_SAB_FILTER 0
++#define CONFIG_SCALE_FILTER 0
++#define CONFIG_SCALE_CUDA_FILTER 0
++#define CONFIG_SCALE_NPP_FILTER 0
++#define CONFIG_SCALE_QSV_FILTER 0
++#define CONFIG_SCALE_VAAPI_FILTER 0
++#define CONFIG_SCALE_VULKAN_FILTER 0
++#define CONFIG_SCALE2REF_FILTER 0
++#define CONFIG_SCALE2REF_NPP_FILTER 0
++#define CONFIG_SCDET_FILTER 0
++#define CONFIG_SCHARR_FILTER 0
++#define CONFIG_SCROLL_FILTER 0
++#define CONFIG_SEGMENT_FILTER 0
++#define CONFIG_SELECT_FILTER 0
++#define CONFIG_SELECTIVECOLOR_FILTER 0
++#define CONFIG_SENDCMD_FILTER 0
++#define CONFIG_SEPARATEFIELDS_FILTER 0
++#define CONFIG_SETDAR_FILTER 0
++#define CONFIG_SETFIELD_FILTER 0
++#define CONFIG_SETPARAMS_FILTER 0
++#define CONFIG_SETPTS_FILTER 0
++#define CONFIG_SETRANGE_FILTER 0
++#define CONFIG_SETSAR_FILTER 0
++#define CONFIG_SETTB_FILTER 0
++#define CONFIG_SHARPEN_NPP_FILTER 0
++#define CONFIG_SHARPNESS_VAAPI_FILTER 0
++#define CONFIG_SHEAR_FILTER 0
++#define CONFIG_SHOWINFO_FILTER 0
++#define CONFIG_SHOWPALETTE_FILTER 0
++#define CONFIG_SHUFFLEFRAMES_FILTER 0
++#define CONFIG_SHUFFLEPIXELS_FILTER 0
++#define CONFIG_SHUFFLEPLANES_FILTER 0
++#define CONFIG_SIDEDATA_FILTER 0
++#define CONFIG_SIGNALSTATS_FILTER 0
++#define CONFIG_SIGNATURE_FILTER 0
++#define CONFIG_SITI_FILTER 0
++#define CONFIG_SMARTBLUR_FILTER 0
++#define CONFIG_SOBEL_FILTER 0
++#define CONFIG_SOBEL_OPENCL_FILTER 0
++#define CONFIG_SPLIT_FILTER 0
++#define CONFIG_SPP_FILTER 0
++#define CONFIG_SR_FILTER 0
++#define CONFIG_SSIM_FILTER 0
++#define CONFIG_SSIM360_FILTER 0
++#define CONFIG_STEREO3D_FILTER 0
++#define CONFIG_STREAMSELECT_FILTER 0
++#define CONFIG_SUBTITLES_FILTER 0
++#define CONFIG_SUPER2XSAI_FILTER 0
++#define CONFIG_SWAPRECT_FILTER 0
++#define CONFIG_SWAPUV_FILTER 0
++#define CONFIG_TBLEND_FILTER 0
++#define CONFIG_TELECINE_FILTER 0
++#define CONFIG_THISTOGRAM_FILTER 0
++#define CONFIG_THRESHOLD_FILTER 0
++#define CONFIG_THUMBNAIL_FILTER 0
++#define CONFIG_THUMBNAIL_CUDA_FILTER 0
++#define CONFIG_TILE_FILTER 0
++#define CONFIG_TINTERLACE_FILTER 0
++#define CONFIG_TLUT2_FILTER 0
++#define CONFIG_TMEDIAN_FILTER 0
++#define CONFIG_TMIDEQUALIZER_FILTER 0
++#define CONFIG_TMIX_FILTER 0
++#define CONFIG_TONEMAP_FILTER 0
++#define CONFIG_TONEMAP_OPENCL_FILTER 0
++#define CONFIG_TONEMAP_VAAPI_FILTER 0
++#define CONFIG_TPAD_FILTER 0
++#define CONFIG_TRANSPOSE_FILTER 0
++#define CONFIG_TRANSPOSE_NPP_FILTER 0
++#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
++#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
++#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
++#define CONFIG_TRIM_FILTER 0
++#define CONFIG_UNPREMULTIPLY_FILTER 0
++#define CONFIG_UNSHARP_FILTER 0
++#define CONFIG_UNSHARP_OPENCL_FILTER 0
++#define CONFIG_UNTILE_FILTER 0
++#define CONFIG_USPP_FILTER 0
++#define CONFIG_V360_FILTER 0
++#define CONFIG_VAGUEDENOISER_FILTER 0
++#define CONFIG_VARBLUR_FILTER 0
++#define CONFIG_VECTORSCOPE_FILTER 0
++#define CONFIG_VFLIP_FILTER 0
++#define CONFIG_VFLIP_VULKAN_FILTER 0
++#define CONFIG_VFRDET_FILTER 0
++#define CONFIG_VIBRANCE_FILTER 0
++#define CONFIG_VIDSTABDETECT_FILTER 0
++#define CONFIG_VIDSTABTRANSFORM_FILTER 0
++#define CONFIG_VIF_FILTER 0
++#define CONFIG_VIGNETTE_FILTER 0
++#define CONFIG_VMAFMOTION_FILTER 0
++#define CONFIG_VPP_QSV_FILTER 0
++#define CONFIG_VSTACK_FILTER 0
++#define CONFIG_W3FDIF_FILTER 0
++#define CONFIG_WAVEFORM_FILTER 0
++#define CONFIG_WEAVE_FILTER 0
++#define CONFIG_XBR_FILTER 0
++#define CONFIG_XCORRELATE_FILTER 0
++#define CONFIG_XFADE_FILTER 0
++#define CONFIG_XFADE_OPENCL_FILTER 0
++#define CONFIG_XFADE_VULKAN_FILTER 0
++#define CONFIG_XMEDIAN_FILTER 0
++#define CONFIG_XSTACK_FILTER 0
++#define CONFIG_YADIF_FILTER 0
++#define CONFIG_YADIF_CUDA_FILTER 0
++#define CONFIG_YADIF_VIDEOTOOLBOX_FILTER 0
++#define CONFIG_YAEPBLUR_FILTER 0
++#define CONFIG_ZMQ_FILTER 0
++#define CONFIG_ZOOMPAN_FILTER 0
++#define CONFIG_ZSCALE_FILTER 0
++#define CONFIG_HSTACK_VAAPI_FILTER 0
++#define CONFIG_VSTACK_VAAPI_FILTER 0
++#define CONFIG_XSTACK_VAAPI_FILTER 0
++#define CONFIG_HSTACK_QSV_FILTER 0
++#define CONFIG_VSTACK_QSV_FILTER 0
++#define CONFIG_XSTACK_QSV_FILTER 0
++#define CONFIG_ALLRGB_FILTER 0
++#define CONFIG_ALLYUV_FILTER 0
++#define CONFIG_CELLAUTO_FILTER 0
++#define CONFIG_COLOR_FILTER 0
++#define CONFIG_COLOR_VULKAN_FILTER 0
++#define CONFIG_COLORCHART_FILTER 0
++#define CONFIG_COLORSPECTRUM_FILTER 0
++#define CONFIG_COREIMAGESRC_FILTER 0
++#define CONFIG_DDAGRAB_FILTER 0
++#define CONFIG_FREI0R_SRC_FILTER 0
++#define CONFIG_GRADIENTS_FILTER 0
++#define CONFIG_HALDCLUTSRC_FILTER 0
++#define CONFIG_LIFE_FILTER 0
++#define CONFIG_MANDELBROT_FILTER 0
++#define CONFIG_MPTESTSRC_FILTER 0
++#define CONFIG_NULLSRC_FILTER 0
++#define CONFIG_OPENCLSRC_FILTER 0
++#define CONFIG_PAL75BARS_FILTER 0
++#define CONFIG_PAL100BARS_FILTER 0
++#define CONFIG_RGBTESTSRC_FILTER 0
++#define CONFIG_SIERPINSKI_FILTER 0
++#define CONFIG_SMPTEBARS_FILTER 0
++#define CONFIG_SMPTEHDBARS_FILTER 0
++#define CONFIG_TESTSRC_FILTER 0
++#define CONFIG_TESTSRC2_FILTER 0
++#define CONFIG_YUVTESTSRC_FILTER 0
++#define CONFIG_ZONEPLATE_FILTER 0
++#define CONFIG_NULLSINK_FILTER 0
++#define CONFIG_A3DSCOPE_FILTER 0
++#define CONFIG_ABITSCOPE_FILTER 0
++#define CONFIG_ADRAWGRAPH_FILTER 0
++#define CONFIG_AGRAPHMONITOR_FILTER 0
++#define CONFIG_AHISTOGRAM_FILTER 0
++#define CONFIG_APHASEMETER_FILTER 0
++#define CONFIG_AVECTORSCOPE_FILTER 0
++#define CONFIG_CONCAT_FILTER 0
++#define CONFIG_SHOWCQT_FILTER 0
++#define CONFIG_SHOWCWT_FILTER 0
++#define CONFIG_SHOWFREQS_FILTER 0
++#define CONFIG_SHOWSPATIAL_FILTER 0
++#define CONFIG_SHOWSPECTRUM_FILTER 0
++#define CONFIG_SHOWSPECTRUMPIC_FILTER 0
++#define CONFIG_SHOWVOLUME_FILTER 0
++#define CONFIG_SHOWWAVES_FILTER 0
++#define CONFIG_SHOWWAVESPIC_FILTER 0
++#define CONFIG_SPECTRUMSYNTH_FILTER 0
++#define CONFIG_AVSYNCTEST_FILTER 0
++#define CONFIG_AMOVIE_FILTER 0
++#define CONFIG_MOVIE_FILTER 0
++#define CONFIG_AFIFO_FILTER 0
++#define CONFIG_FIFO_FILTER 0
++#define CONFIG_AA_DEMUXER 0
++#define CONFIG_AAC_DEMUXER 1
++#define CONFIG_AAX_DEMUXER 0
++#define CONFIG_AC3_DEMUXER 0
++#define CONFIG_AC4_DEMUXER 0
++#define CONFIG_ACE_DEMUXER 0
++#define CONFIG_ACM_DEMUXER 0
++#define CONFIG_ACT_DEMUXER 0
++#define CONFIG_ADF_DEMUXER 0
++#define CONFIG_ADP_DEMUXER 0
++#define CONFIG_ADS_DEMUXER 0
++#define CONFIG_ADX_DEMUXER 0
++#define CONFIG_AEA_DEMUXER 0
++#define CONFIG_AFC_DEMUXER 0
++#define CONFIG_AIFF_DEMUXER 0
++#define CONFIG_AIX_DEMUXER 0
++#define CONFIG_ALP_DEMUXER 0
++#define CONFIG_AMR_DEMUXER 0
++#define CONFIG_AMRNB_DEMUXER 0
++#define CONFIG_AMRWB_DEMUXER 0
++#define CONFIG_ANM_DEMUXER 0
++#define CONFIG_APAC_DEMUXER 0
++#define CONFIG_APC_DEMUXER 0
++#define CONFIG_APE_DEMUXER 0
++#define CONFIG_APM_DEMUXER 0
++#define CONFIG_APNG_DEMUXER 0
++#define CONFIG_APTX_DEMUXER 0
++#define CONFIG_APTX_HD_DEMUXER 0
++#define CONFIG_AQTITLE_DEMUXER 0
++#define CONFIG_ARGO_ASF_DEMUXER 0
++#define CONFIG_ARGO_BRP_DEMUXER 0
++#define CONFIG_ARGO_CVG_DEMUXER 0
++#define CONFIG_ASF_DEMUXER 0
++#define CONFIG_ASF_O_DEMUXER 0
++#define CONFIG_ASS_DEMUXER 0
++#define CONFIG_AST_DEMUXER 0
++#define CONFIG_AU_DEMUXER 0
++#define CONFIG_AV1_DEMUXER 0
++#define CONFIG_AVI_DEMUXER 0
++#define CONFIG_AVISYNTH_DEMUXER 0
++#define CONFIG_AVR_DEMUXER 0
++#define CONFIG_AVS_DEMUXER 0
++#define CONFIG_AVS2_DEMUXER 0
++#define CONFIG_AVS3_DEMUXER 0
++#define CONFIG_BETHSOFTVID_DEMUXER 0
++#define CONFIG_BFI_DEMUXER 0
++#define CONFIG_BINTEXT_DEMUXER 0
++#define CONFIG_BINK_DEMUXER 0
++#define CONFIG_BINKA_DEMUXER 0
++#define CONFIG_BIT_DEMUXER 0
++#define CONFIG_BITPACKED_DEMUXER 0
++#define CONFIG_BMV_DEMUXER 0
++#define CONFIG_BFSTM_DEMUXER 0
++#define CONFIG_BRSTM_DEMUXER 0
++#define CONFIG_BOA_DEMUXER 0
++#define CONFIG_BONK_DEMUXER 0
++#define CONFIG_C93_DEMUXER 0
++#define CONFIG_CAF_DEMUXER 0
++#define CONFIG_CAVSVIDEO_DEMUXER 0
++#define CONFIG_CDG_DEMUXER 0
++#define CONFIG_CDXL_DEMUXER 0
++#define CONFIG_CINE_DEMUXER 0
++#define CONFIG_CODEC2_DEMUXER 0
++#define CONFIG_CODEC2RAW_DEMUXER 0
++#define CONFIG_CONCAT_DEMUXER 0
++#define CONFIG_DASH_DEMUXER 0
++#define CONFIG_DATA_DEMUXER 0
++#define CONFIG_DAUD_DEMUXER 0
++#define CONFIG_DCSTR_DEMUXER 0
++#define CONFIG_DERF_DEMUXER 0
++#define CONFIG_DFA_DEMUXER 0
++#define CONFIG_DFPWM_DEMUXER 0
++#define CONFIG_DHAV_DEMUXER 0
++#define CONFIG_DIRAC_DEMUXER 0
++#define CONFIG_DNXHD_DEMUXER 0
++#define CONFIG_DSF_DEMUXER 0
++#define CONFIG_DSICIN_DEMUXER 0
++#define CONFIG_DSS_DEMUXER 0
++#define CONFIG_DTS_DEMUXER 0
++#define CONFIG_DTSHD_DEMUXER 0
++#define CONFIG_DV_DEMUXER 0
++#define CONFIG_DVBSUB_DEMUXER 0
++#define CONFIG_DVBTXT_DEMUXER 0
++#define CONFIG_DXA_DEMUXER 0
++#define CONFIG_EA_DEMUXER 0
++#define CONFIG_EA_CDATA_DEMUXER 0
++#define CONFIG_EAC3_DEMUXER 0
++#define CONFIG_EPAF_DEMUXER 0
++#define CONFIG_EVC_DEMUXER 0
++#define CONFIG_FFMETADATA_DEMUXER 0
++#define CONFIG_FILMSTRIP_DEMUXER 0
++#define CONFIG_FITS_DEMUXER 0
++#define CONFIG_FLAC_DEMUXER 1
++#define CONFIG_FLIC_DEMUXER 0
++#define CONFIG_FLV_DEMUXER 0
++#define CONFIG_LIVE_FLV_DEMUXER 0
++#define CONFIG_FOURXM_DEMUXER 0
++#define CONFIG_FRM_DEMUXER 0
++#define CONFIG_FSB_DEMUXER 0
++#define CONFIG_FWSE_DEMUXER 0
++#define CONFIG_G722_DEMUXER 0
++#define CONFIG_G723_1_DEMUXER 0
++#define CONFIG_G726_DEMUXER 0
++#define CONFIG_G726LE_DEMUXER 0
++#define CONFIG_G729_DEMUXER 0
++#define CONFIG_GDV_DEMUXER 0
++#define CONFIG_GENH_DEMUXER 0
++#define CONFIG_GIF_DEMUXER 0
++#define CONFIG_GSM_DEMUXER 0
++#define CONFIG_GXF_DEMUXER 0
++#define CONFIG_H261_DEMUXER 0
++#define CONFIG_H263_DEMUXER 0
++#define CONFIG_H264_DEMUXER 0
++#define CONFIG_HCA_DEMUXER 0
++#define CONFIG_HCOM_DEMUXER 0
++#define CONFIG_HEVC_DEMUXER 0
++#define CONFIG_HLS_DEMUXER 0
++#define CONFIG_HNM_DEMUXER 0
++#define CONFIG_ICO_DEMUXER 0
++#define CONFIG_IDCIN_DEMUXER 0
++#define CONFIG_IDF_DEMUXER 0
++#define CONFIG_IFF_DEMUXER 0
++#define CONFIG_IFV_DEMUXER 0
++#define CONFIG_ILBC_DEMUXER 0
++#define CONFIG_IMAGE2_DEMUXER 0
++#define CONFIG_IMAGE2PIPE_DEMUXER 0
++#define CONFIG_IMAGE2_ALIAS_PIX_DEMUXER 0
++#define CONFIG_IMAGE2_BRENDER_PIX_DEMUXER 0
++#define CONFIG_IMF_DEMUXER 0
++#define CONFIG_INGENIENT_DEMUXER 0
++#define CONFIG_IPMOVIE_DEMUXER 0
++#define CONFIG_IPU_DEMUXER 0
++#define CONFIG_IRCAM_DEMUXER 0
++#define CONFIG_ISS_DEMUXER 0
++#define CONFIG_IV8_DEMUXER 0
++#define CONFIG_IVF_DEMUXER 0
++#define CONFIG_IVR_DEMUXER 0
++#define CONFIG_JACOSUB_DEMUXER 0
++#define CONFIG_JV_DEMUXER 0
++#define CONFIG_JPEGXL_ANIM_DEMUXER 0
++#define CONFIG_KUX_DEMUXER 0
++#define CONFIG_KVAG_DEMUXER 0
++#define CONFIG_LAF_DEMUXER 0
++#define CONFIG_LMLM4_DEMUXER 0
++#define CONFIG_LOAS_DEMUXER 0
++#define CONFIG_LUODAT_DEMUXER 0
++#define CONFIG_LRC_DEMUXER 0
++#define CONFIG_LVF_DEMUXER 0
++#define CONFIG_LXF_DEMUXER 0
++#define CONFIG_M4V_DEMUXER 0
++#define CONFIG_MCA_DEMUXER 0
++#define CONFIG_MCC_DEMUXER 0
++#define CONFIG_MATROSKA_DEMUXER 1
++#define CONFIG_MGSTS_DEMUXER 0
++#define CONFIG_MICRODVD_DEMUXER 0
++#define CONFIG_MJPEG_DEMUXER 0
++#define CONFIG_MJPEG_2000_DEMUXER 0
++#define CONFIG_MLP_DEMUXER 0
++#define CONFIG_MLV_DEMUXER 0
++#define CONFIG_MM_DEMUXER 0
++#define CONFIG_MMF_DEMUXER 0
++#define CONFIG_MODS_DEMUXER 0
++#define CONFIG_MOFLEX_DEMUXER 0
++#define CONFIG_MOV_DEMUXER 1
++#define CONFIG_MP3_DEMUXER 1
++#define CONFIG_MPC_DEMUXER 0
++#define CONFIG_MPC8_DEMUXER 0
++#define CONFIG_MPEGPS_DEMUXER 0
++#define CONFIG_MPEGTS_DEMUXER 0
++#define CONFIG_MPEGTSRAW_DEMUXER 0
++#define CONFIG_MPEGVIDEO_DEMUXER 0
++#define CONFIG_MPJPEG_DEMUXER 0
++#define CONFIG_MPL2_DEMUXER 0
++#define CONFIG_MPSUB_DEMUXER 0
++#define CONFIG_MSF_DEMUXER 0
++#define CONFIG_MSNWC_TCP_DEMUXER 0
++#define CONFIG_MSP_DEMUXER 0
++#define CONFIG_MTAF_DEMUXER 0
++#define CONFIG_MTV_DEMUXER 0
++#define CONFIG_MUSX_DEMUXER 0
++#define CONFIG_MV_DEMUXER 0
++#define CONFIG_MVI_DEMUXER 0
++#define CONFIG_MXF_DEMUXER 0
++#define CONFIG_MXG_DEMUXER 0
++#define CONFIG_NC_DEMUXER 0
++#define CONFIG_NISTSPHERE_DEMUXER 0
++#define CONFIG_NSP_DEMUXER 0
++#define CONFIG_NSV_DEMUXER 0
++#define CONFIG_NUT_DEMUXER 0
++#define CONFIG_NUV_DEMUXER 0
++#define CONFIG_OBU_DEMUXER 0
++#define CONFIG_OGG_DEMUXER 1
++#define CONFIG_OMA_DEMUXER 0
++#define CONFIG_PAF_DEMUXER 0
++#define CONFIG_PCM_ALAW_DEMUXER 0
++#define CONFIG_PCM_MULAW_DEMUXER 0
++#define CONFIG_PCM_VIDC_DEMUXER 0
++#define CONFIG_PCM_F64BE_DEMUXER 0
++#define CONFIG_PCM_F64LE_DEMUXER 0
++#define CONFIG_PCM_F32BE_DEMUXER 0
++#define CONFIG_PCM_F32LE_DEMUXER 0
++#define CONFIG_PCM_S32BE_DEMUXER 0
++#define CONFIG_PCM_S32LE_DEMUXER 0
++#define CONFIG_PCM_S24BE_DEMUXER 0
++#define CONFIG_PCM_S24LE_DEMUXER 0
++#define CONFIG_PCM_S16BE_DEMUXER 0
++#define CONFIG_PCM_S16LE_DEMUXER 0
++#define CONFIG_PCM_S8_DEMUXER 0
++#define CONFIG_PCM_U32BE_DEMUXER 0
++#define CONFIG_PCM_U32LE_DEMUXER 0
++#define CONFIG_PCM_U24BE_DEMUXER 0
++#define CONFIG_PCM_U24LE_DEMUXER 0
++#define CONFIG_PCM_U16BE_DEMUXER 0
++#define CONFIG_PCM_U16LE_DEMUXER 0
++#define CONFIG_PCM_U8_DEMUXER 0
++#define CONFIG_PDV_DEMUXER 0
++#define CONFIG_PJS_DEMUXER 0
++#define CONFIG_PMP_DEMUXER 0
++#define CONFIG_PP_BNK_DEMUXER 0
++#define CONFIG_PVA_DEMUXER 0
++#define CONFIG_PVF_DEMUXER 0
++#define CONFIG_QCP_DEMUXER 0
++#define CONFIG_R3D_DEMUXER 0
++#define CONFIG_RAWVIDEO_DEMUXER 0
++#define CONFIG_REALTEXT_DEMUXER 0
++#define CONFIG_REDSPARK_DEMUXER 0
++#define CONFIG_RKA_DEMUXER 0
++#define CONFIG_RL2_DEMUXER 0
++#define CONFIG_RM_DEMUXER 0
++#define CONFIG_ROQ_DEMUXER 0
++#define CONFIG_RPL_DEMUXER 0
++#define CONFIG_RSD_DEMUXER 0
++#define CONFIG_RSO_DEMUXER 0
++#define CONFIG_RTP_DEMUXER 0
++#define CONFIG_RTSP_DEMUXER 0
++#define CONFIG_S337M_DEMUXER 0
++#define CONFIG_SAMI_DEMUXER 0
++#define CONFIG_SAP_DEMUXER 0
++#define CONFIG_SBC_DEMUXER 0
++#define CONFIG_SBG_DEMUXER 0
++#define CONFIG_SCC_DEMUXER 0
++#define CONFIG_SCD_DEMUXER 0
++#define CONFIG_SDNS_DEMUXER 0
++#define CONFIG_SDP_DEMUXER 0
++#define CONFIG_SDR2_DEMUXER 0
++#define CONFIG_SDS_DEMUXER 0
++#define CONFIG_SDX_DEMUXER 0
++#define CONFIG_SEGAFILM_DEMUXER 0
++#define CONFIG_SER_DEMUXER 0
++#define CONFIG_SGA_DEMUXER 0
++#define CONFIG_SHORTEN_DEMUXER 0
++#define CONFIG_SIFF_DEMUXER 0
++#define CONFIG_SIMBIOSIS_IMX_DEMUXER 0
++#define CONFIG_SLN_DEMUXER 0
++#define CONFIG_SMACKER_DEMUXER 0
++#define CONFIG_SMJPEG_DEMUXER 0
++#define CONFIG_SMUSH_DEMUXER 0
++#define CONFIG_SOL_DEMUXER 0
++#define CONFIG_SOX_DEMUXER 0
++#define CONFIG_SPDIF_DEMUXER 0
++#define CONFIG_SRT_DEMUXER 0
++#define CONFIG_STR_DEMUXER 0
++#define CONFIG_STL_DEMUXER 0
++#define CONFIG_SUBVIEWER1_DEMUXER 0
++#define CONFIG_SUBVIEWER_DEMUXER 0
++#define CONFIG_SUP_DEMUXER 0
++#define CONFIG_SVAG_DEMUXER 0
++#define CONFIG_SVS_DEMUXER 0
++#define CONFIG_SWF_DEMUXER 0
++#define CONFIG_TAK_DEMUXER 0
++#define CONFIG_TEDCAPTIONS_DEMUXER 0
++#define CONFIG_THP_DEMUXER 0
++#define CONFIG_THREEDOSTR_DEMUXER 0
++#define CONFIG_TIERTEXSEQ_DEMUXER 0
++#define CONFIG_TMV_DEMUXER 0
++#define CONFIG_TRUEHD_DEMUXER 0
++#define CONFIG_TTA_DEMUXER 0
++#define CONFIG_TXD_DEMUXER 0
++#define CONFIG_TTY_DEMUXER 0
++#define CONFIG_TY_DEMUXER 0
++#define CONFIG_V210_DEMUXER 0
++#define CONFIG_V210X_DEMUXER 0
++#define CONFIG_VAG_DEMUXER 0
++#define CONFIG_VC1_DEMUXER 0
++#define CONFIG_VC1T_DEMUXER 0
++#define CONFIG_VIVIDAS_DEMUXER 0
++#define CONFIG_VIVO_DEMUXER 0
++#define CONFIG_VMD_DEMUXER 0
++#define CONFIG_VOBSUB_DEMUXER 0
++#define CONFIG_VOC_DEMUXER 0
++#define CONFIG_VPK_DEMUXER 0
++#define CONFIG_VPLAYER_DEMUXER 0
++#define CONFIG_VQF_DEMUXER 0
++#define CONFIG_VVC_DEMUXER 0
++#define CONFIG_W64_DEMUXER 0
++#define CONFIG_WADY_DEMUXER 0
++#define CONFIG_WAVARC_DEMUXER 0
++#define CONFIG_WAV_DEMUXER 1
++#define CONFIG_WC3_DEMUXER 0
++#define CONFIG_WEBM_DASH_MANIFEST_DEMUXER 0
++#define CONFIG_WEBVTT_DEMUXER 0
++#define CONFIG_WSAUD_DEMUXER 0
++#define CONFIG_WSD_DEMUXER 0
++#define CONFIG_WSVQA_DEMUXER 0
++#define CONFIG_WTV_DEMUXER 0
++#define CONFIG_WVE_DEMUXER 0
++#define CONFIG_WV_DEMUXER 0
++#define CONFIG_XA_DEMUXER 0
++#define CONFIG_XBIN_DEMUXER 0
++#define CONFIG_XMD_DEMUXER 0
++#define CONFIG_XMV_DEMUXER 0
++#define CONFIG_XVAG_DEMUXER 0
++#define CONFIG_XWMA_DEMUXER 0
++#define CONFIG_YOP_DEMUXER 0
++#define CONFIG_YUV4MPEGPIPE_DEMUXER 0
++#define CONFIG_IMAGE_BMP_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_CRI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_DDS_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_DPX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_EXR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_GEM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_GIF_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_HDR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_J2K_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEGLS_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEGXL_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PAM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PBM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PCX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PFM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGMYUV_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PHM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PHOTOCD_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PICTOR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PNG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PPM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PSD_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_QDRAW_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_QOI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SGI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SVG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SUNRAST_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_TIFF_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_VBN_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_WEBP_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
++#define CONFIG_LIBGME_DEMUXER 0
++#define CONFIG_LIBMODPLUG_DEMUXER 0
++#define CONFIG_LIBOPENMPT_DEMUXER 0
++#define CONFIG_VAPOURSYNTH_DEMUXER 0
++#define CONFIG_A64_MUXER 0
++#define CONFIG_AC3_MUXER 0
++#define CONFIG_AC4_MUXER 0
++#define CONFIG_ADTS_MUXER 0
++#define CONFIG_ADX_MUXER 0
++#define CONFIG_AIFF_MUXER 0
++#define CONFIG_ALP_MUXER 0
++#define CONFIG_AMR_MUXER 0
++#define CONFIG_AMV_MUXER 0
++#define CONFIG_APM_MUXER 0
++#define CONFIG_APNG_MUXER 0
++#define CONFIG_APTX_MUXER 0
++#define CONFIG_APTX_HD_MUXER 0
++#define CONFIG_ARGO_ASF_MUXER 0
++#define CONFIG_ARGO_CVG_MUXER 0
++#define CONFIG_ASF_MUXER 0
++#define CONFIG_ASS_MUXER 0
++#define CONFIG_AST_MUXER 0
++#define CONFIG_ASF_STREAM_MUXER 0
++#define CONFIG_AU_MUXER 0
++#define CONFIG_AVI_MUXER 0
++#define CONFIG_AVIF_MUXER 0
++#define CONFIG_AVM2_MUXER 0
++#define CONFIG_AVS2_MUXER 0
++#define CONFIG_AVS3_MUXER 0
++#define CONFIG_BIT_MUXER 0
++#define CONFIG_CAF_MUXER 0
++#define CONFIG_CAVSVIDEO_MUXER 0
++#define CONFIG_CODEC2_MUXER 0
++#define CONFIG_CODEC2RAW_MUXER 0
++#define CONFIG_CRC_MUXER 0
++#define CONFIG_DASH_MUXER 0
++#define CONFIG_DATA_MUXER 0
++#define CONFIG_DAUD_MUXER 0
++#define CONFIG_DFPWM_MUXER 0
++#define CONFIG_DIRAC_MUXER 0
++#define CONFIG_DNXHD_MUXER 0
++#define CONFIG_DTS_MUXER 0
++#define CONFIG_DV_MUXER 0
++#define CONFIG_EAC3_MUXER 0
++#define CONFIG_EVC_MUXER 0
++#define CONFIG_F4V_MUXER 0
++#define CONFIG_FFMETADATA_MUXER 0
++#define CONFIG_FIFO_MUXER 0
++#define CONFIG_FIFO_TEST_MUXER 0
++#define CONFIG_FILMSTRIP_MUXER 0
++#define CONFIG_FITS_MUXER 0
++#define CONFIG_FLAC_MUXER 0
++#define CONFIG_FLV_MUXER 0
++#define CONFIG_FRAMECRC_MUXER 0
++#define CONFIG_FRAMEHASH_MUXER 0
++#define CONFIG_FRAMEMD5_MUXER 0
++#define CONFIG_G722_MUXER 0
++#define CONFIG_G723_1_MUXER 0
++#define CONFIG_G726_MUXER 0
++#define CONFIG_G726LE_MUXER 0
++#define CONFIG_GIF_MUXER 0
++#define CONFIG_GSM_MUXER 0
++#define CONFIG_GXF_MUXER 0
++#define CONFIG_H261_MUXER 0
++#define CONFIG_H263_MUXER 0
++#define CONFIG_H264_MUXER 0
++#define CONFIG_HASH_MUXER 0
++#define CONFIG_HDS_MUXER 0
++#define CONFIG_HEVC_MUXER 0
++#define CONFIG_HLS_MUXER 0
++#define CONFIG_ICO_MUXER 0
++#define CONFIG_ILBC_MUXER 0
++#define CONFIG_IMAGE2_MUXER 0
++#define CONFIG_IMAGE2PIPE_MUXER 0
++#define CONFIG_IPOD_MUXER 0
++#define CONFIG_IRCAM_MUXER 0
++#define CONFIG_ISMV_MUXER 0
++#define CONFIG_IVF_MUXER 0
++#define CONFIG_JACOSUB_MUXER 0
++#define CONFIG_KVAG_MUXER 0
++#define CONFIG_LATM_MUXER 0
++#define CONFIG_LRC_MUXER 0
++#define CONFIG_M4V_MUXER 0
++#define CONFIG_MD5_MUXER 0
++#define CONFIG_MATROSKA_MUXER 0
++#define CONFIG_MATROSKA_AUDIO_MUXER 0
++#define CONFIG_MICRODVD_MUXER 0
++#define CONFIG_MJPEG_MUXER 0
++#define CONFIG_MLP_MUXER 0
++#define CONFIG_MMF_MUXER 0
++#define CONFIG_MOV_MUXER 0
++#define CONFIG_MP2_MUXER 0
++#define CONFIG_MP3_MUXER 0
++#define CONFIG_MP4_MUXER 0
++#define CONFIG_MPEG1SYSTEM_MUXER 0
++#define CONFIG_MPEG1VCD_MUXER 0
++#define CONFIG_MPEG1VIDEO_MUXER 0
++#define CONFIG_MPEG2DVD_MUXER 0
++#define CONFIG_MPEG2SVCD_MUXER 0
++#define CONFIG_MPEG2VIDEO_MUXER 0
++#define CONFIG_MPEG2VOB_MUXER 0
++#define CONFIG_MPEGTS_MUXER 0
++#define CONFIG_MPJPEG_MUXER 0
++#define CONFIG_MXF_MUXER 0
++#define CONFIG_MXF_D10_MUXER 0
++#define CONFIG_MXF_OPATOM_MUXER 0
++#define CONFIG_NULL_MUXER 0
++#define CONFIG_NUT_MUXER 0
++#define CONFIG_OBU_MUXER 0
++#define CONFIG_OGA_MUXER 0
++#define CONFIG_OGG_MUXER 0
++#define CONFIG_OGV_MUXER 0
++#define CONFIG_OMA_MUXER 0
++#define CONFIG_OPUS_MUXER 0
++#define CONFIG_PCM_ALAW_MUXER 0
++#define CONFIG_PCM_MULAW_MUXER 0
++#define CONFIG_PCM_VIDC_MUXER 0
++#define CONFIG_PCM_F64BE_MUXER 0
++#define CONFIG_PCM_F64LE_MUXER 0
++#define CONFIG_PCM_F32BE_MUXER 0
++#define CONFIG_PCM_F32LE_MUXER 0
++#define CONFIG_PCM_S32BE_MUXER 0
++#define CONFIG_PCM_S32LE_MUXER 0
++#define CONFIG_PCM_S24BE_MUXER 0
++#define CONFIG_PCM_S24LE_MUXER 0
++#define CONFIG_PCM_S16BE_MUXER 0
++#define CONFIG_PCM_S16LE_MUXER 0
++#define CONFIG_PCM_S8_MUXER 0
++#define CONFIG_PCM_U32BE_MUXER 0
++#define CONFIG_PCM_U32LE_MUXER 0
++#define CONFIG_PCM_U24BE_MUXER 0
++#define CONFIG_PCM_U24LE_MUXER 0
++#define CONFIG_PCM_U16BE_MUXER 0
++#define CONFIG_PCM_U16LE_MUXER 0
++#define CONFIG_PCM_U8_MUXER 0
++#define CONFIG_PSP_MUXER 0
++#define CONFIG_RAWVIDEO_MUXER 0
++#define CONFIG_RM_MUXER 0
++#define CONFIG_ROQ_MUXER 0
++#define CONFIG_RSO_MUXER 0
++#define CONFIG_RTP_MUXER 0
++#define CONFIG_RTP_MPEGTS_MUXER 0
++#define CONFIG_RTSP_MUXER 0
++#define CONFIG_SAP_MUXER 0
++#define CONFIG_SBC_MUXER 0
++#define CONFIG_SCC_MUXER 0
++#define CONFIG_SEGAFILM_MUXER 0
++#define CONFIG_SEGMENT_MUXER 0
++#define CONFIG_STREAM_SEGMENT_MUXER 0
++#define CONFIG_SMJPEG_MUXER 0
++#define CONFIG_SMOOTHSTREAMING_MUXER 0
++#define CONFIG_SOX_MUXER 0
++#define CONFIG_SPX_MUXER 0
++#define CONFIG_SPDIF_MUXER 0
++#define CONFIG_SRT_MUXER 0
++#define CONFIG_STREAMHASH_MUXER 0
++#define CONFIG_SUP_MUXER 0
++#define CONFIG_SWF_MUXER 0
++#define CONFIG_TEE_MUXER 0
++#define CONFIG_TG2_MUXER 0
++#define CONFIG_TGP_MUXER 0
++#define CONFIG_MKVTIMESTAMP_V2_MUXER 0
++#define CONFIG_TRUEHD_MUXER 0
++#define CONFIG_TTA_MUXER 0
++#define CONFIG_TTML_MUXER 0
++#define CONFIG_UNCODEDFRAMECRC_MUXER 0
++#define CONFIG_VC1_MUXER 0
++#define CONFIG_VC1T_MUXER 0
++#define CONFIG_VOC_MUXER 0
++#define CONFIG_VVC_MUXER 0
++#define CONFIG_W64_MUXER 0
++#define CONFIG_WAV_MUXER 0
++#define CONFIG_WEBM_MUXER 0
++#define CONFIG_WEBM_DASH_MANIFEST_MUXER 0
++#define CONFIG_WEBM_CHUNK_MUXER 0
++#define CONFIG_WEBP_MUXER 0
++#define CONFIG_WEBVTT_MUXER 0
++#define CONFIG_WSAUD_MUXER 0
++#define CONFIG_WTV_MUXER 0
++#define CONFIG_WV_MUXER 0
++#define CONFIG_YUV4MPEGPIPE_MUXER 0
++#define CONFIG_CHROMAPRINT_MUXER 0
++#define CONFIG_ASYNC_PROTOCOL 0
++#define CONFIG_BLURAY_PROTOCOL 0
++#define CONFIG_CACHE_PROTOCOL 0
++#define CONFIG_CONCAT_PROTOCOL 0
++#define CONFIG_CONCATF_PROTOCOL 0
++#define CONFIG_CRYPTO_PROTOCOL 0
++#define CONFIG_DATA_PROTOCOL 0
++#define CONFIG_FD_PROTOCOL 0
++#define CONFIG_FFRTMPCRYPT_PROTOCOL 0
++#define CONFIG_FFRTMPHTTP_PROTOCOL 0
++#define CONFIG_FILE_PROTOCOL 0
++#define CONFIG_FTP_PROTOCOL 0
++#define CONFIG_GOPHER_PROTOCOL 0
++#define CONFIG_GOPHERS_PROTOCOL 0
++#define CONFIG_HLS_PROTOCOL 0
++#define CONFIG_HTTP_PROTOCOL 0
++#define CONFIG_HTTPPROXY_PROTOCOL 0
++#define CONFIG_HTTPS_PROTOCOL 0
++#define CONFIG_ICECAST_PROTOCOL 0
++#define CONFIG_MMSH_PROTOCOL 0
++#define CONFIG_MMST_PROTOCOL 0
++#define CONFIG_MD5_PROTOCOL 0
++#define CONFIG_PIPE_PROTOCOL 0
++#define CONFIG_PROMPEG_PROTOCOL 0
++#define CONFIG_RTMP_PROTOCOL 0
++#define CONFIG_RTMPE_PROTOCOL 0
++#define CONFIG_RTMPS_PROTOCOL 0
++#define CONFIG_RTMPT_PROTOCOL 0
++#define CONFIG_RTMPTE_PROTOCOL 0
++#define CONFIG_RTMPTS_PROTOCOL 0
++#define CONFIG_RTP_PROTOCOL 0
++#define CONFIG_SCTP_PROTOCOL 0
++#define CONFIG_SRTP_PROTOCOL 0
++#define CONFIG_SUBFILE_PROTOCOL 0
++#define CONFIG_TEE_PROTOCOL 0
++#define CONFIG_TCP_PROTOCOL 0
++#define CONFIG_TLS_PROTOCOL 0
++#define CONFIG_UDP_PROTOCOL 0
++#define CONFIG_UDPLITE_PROTOCOL 0
++#define CONFIG_UNIX_PROTOCOL 0
++#define CONFIG_LIBAMQP_PROTOCOL 0
++#define CONFIG_LIBRIST_PROTOCOL 0
++#define CONFIG_LIBRTMP_PROTOCOL 0
++#define CONFIG_LIBRTMPE_PROTOCOL 0
++#define CONFIG_LIBRTMPS_PROTOCOL 0
++#define CONFIG_LIBRTMPT_PROTOCOL 0
++#define CONFIG_LIBRTMPTE_PROTOCOL 0
++#define CONFIG_LIBSRT_PROTOCOL 0
++#define CONFIG_LIBSSH_PROTOCOL 0
++#define CONFIG_LIBSMBCLIENT_PROTOCOL 0
++#define CONFIG_LIBZMQ_PROTOCOL 0
++#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
++#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
++#endif /* FFMPEG_CONFIG_COMPONENTS_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2 @@
++static const FFBitStreamFilter * const bitstream_filters[] = {
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,20 @@
++static const FFCodec * const codec_list[] = {
++    &ff_h264_decoder,
++    &ff_theora_decoder,
++    &ff_vp3_decoder,
++    &ff_vp8_decoder,
++    &ff_aac_decoder,
++    &ff_flac_decoder,
++    &ff_mp3_decoder,
++    &ff_vorbis_decoder,
++    &ff_pcm_alaw_decoder,
++    &ff_pcm_f32le_decoder,
++    &ff_pcm_mulaw_decoder,
++    &ff_pcm_s16be_decoder,
++    &ff_pcm_s16le_decoder,
++    &ff_pcm_s24be_decoder,
++    &ff_pcm_s24le_decoder,
++    &ff_pcm_s32le_decoder,
++    &ff_pcm_u8_decoder,
++    &ff_libopus_decoder,
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,11 @@
++static const AVCodecParser * const parser_list[] = {
++    &ff_aac_parser,
++    &ff_flac_parser,
++    &ff_h264_parser,
++    &ff_mpegaudio_parser,
++    &ff_opus_parser,
++    &ff_vorbis_parser,
++    &ff_vp3_parser,
++    &ff_vp8_parser,
++    &ff_vp9_parser,
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,9 @@
++static const AVInputFormat * const demuxer_list[] = {
++    &ff_aac_demuxer,
++    &ff_flac_demuxer,
++    &ff_matroska_demuxer,
++    &ff_mov_demuxer,
++    &ff_mp3_demuxer,
++    &ff_ogg_demuxer,
++    &ff_wav_demuxer,
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2 @@
++static const FFOutputFormat * const muxer_list[] = {
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2 @@
++static const URLProtocol * const url_protocols[] = {
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,6 @@
++/* Generated by ffmpeg configure */
++#ifndef AVUTIL_AVCONFIG_H
++#define AVUTIL_AVCONFIG_H
++#define AV_HAVE_BIGENDIAN 0
++#define AV_HAVE_FAST_UNALIGNED 1
++#endif /* AVUTIL_AVCONFIG_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,764 @@
++/* Automatically generated by configure - do not modify! */
++#ifndef FFMPEG_CONFIG_H
++#define FFMPEG_CONFIG_H
++#define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-fft --enable-rdft --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\\\\\"-O2\\\\\"' --enable-decoder='theora,vp8' --enable-parser='vp3,vp8' --enable-lto --enable-pic --cc=clang --cxx=clang++ --ld=clang"
++#define FFMPEG_LICENSE "LGPL version 2.1 or later"
++#define CONFIG_THIS_YEAR 2023
++#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
++#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
++#define CC_IDENT "clang version 17.0.6"
++#define OS_NAME linux
++#define av_restrict restrict
++#define EXTERN_PREFIX ""
++#define EXTERN_ASM 
++#define BUILDSUF ""
++#define SLIBSUF ".so"
++#define HAVE_MMX2 HAVE_MMXEXT
++#define SWS_MAX_FILTER_SIZE 256
++#define ARCH_AARCH64 0
++#define ARCH_ALPHA 0
++#define ARCH_ARM 0
++#define ARCH_AVR32 0
++#define ARCH_AVR32_AP 0
++#define ARCH_AVR32_UC 0
++#define ARCH_BFIN 0
++#define ARCH_IA64 0
++#define ARCH_LOONGARCH 1
++#define ARCH_LOONGARCH32 0
++#define ARCH_LOONGARCH64 1
++#define ARCH_M68K 0
++#define ARCH_MIPS 0
++#define ARCH_MIPS64 0
++#define ARCH_PARISC 0
++#define ARCH_PPC 0
++#define ARCH_PPC64 0
++#define ARCH_RISCV 0
++#define ARCH_S390 0
++#define ARCH_SH4 0
++#define ARCH_SPARC 0
++#define ARCH_SPARC64 0
++#define ARCH_TILEGX 0
++#define ARCH_TILEPRO 0
++#define ARCH_TOMI 0
++#define ARCH_X86 0
++#define ARCH_X86_32 0
++#define ARCH_X86_64 0
++#define HAVE_ARMV5TE 0
++#define HAVE_ARMV6 0
++#define HAVE_ARMV6T2 0
++#define HAVE_ARMV8 0
++#define HAVE_DOTPROD 0
++#define HAVE_I8MM 0
++#define HAVE_NEON 0
++#define HAVE_VFP 0
++#define HAVE_VFPV3 0
++#define HAVE_SETEND 0
++#define HAVE_ALTIVEC 0
++#define HAVE_DCBZL 0
++#define HAVE_LDBRX 0
++#define HAVE_POWER8 0
++#define HAVE_PPC4XX 0
++#define HAVE_VSX 0
++#define HAVE_RVV 0
++#define HAVE_AESNI 0
++#define HAVE_AMD3DNOW 0
++#define HAVE_AMD3DNOWEXT 0
++#define HAVE_AVX 0
++#define HAVE_AVX2 0
++#define HAVE_AVX512 0
++#define HAVE_AVX512ICL 0
++#define HAVE_FMA3 0
++#define HAVE_FMA4 0
++#define HAVE_MMX 0
++#define HAVE_MMXEXT 0
++#define HAVE_SSE 0
++#define HAVE_SSE2 0
++#define HAVE_SSE3 0
++#define HAVE_SSE4 0
++#define HAVE_SSE42 0
++#define HAVE_SSSE3 0
++#define HAVE_XOP 0
++#define HAVE_CPUNOP 0
++#define HAVE_I686 0
++#define HAVE_MIPSFPU 0
++#define HAVE_MIPS32R2 0
++#define HAVE_MIPS32R5 0
++#define HAVE_MIPS64R2 0
++#define HAVE_MIPS32R6 0
++#define HAVE_MIPS64R6 0
++#define HAVE_MIPSDSP 0
++#define HAVE_MIPSDSPR2 0
++#define HAVE_MSA 0
++#define HAVE_LOONGSON2 0
++#define HAVE_LOONGSON3 0
++#define HAVE_MMI 0
++#define HAVE_LSX 0
++#define HAVE_LASX 0
++#define HAVE_ARMV5TE_EXTERNAL 0
++#define HAVE_ARMV6_EXTERNAL 0
++#define HAVE_ARMV6T2_EXTERNAL 0
++#define HAVE_ARMV8_EXTERNAL 0
++#define HAVE_DOTPROD_EXTERNAL 0
++#define HAVE_I8MM_EXTERNAL 0
++#define HAVE_NEON_EXTERNAL 0
++#define HAVE_VFP_EXTERNAL 0
++#define HAVE_VFPV3_EXTERNAL 0
++#define HAVE_SETEND_EXTERNAL 0
++#define HAVE_ALTIVEC_EXTERNAL 0
++#define HAVE_DCBZL_EXTERNAL 0
++#define HAVE_LDBRX_EXTERNAL 0
++#define HAVE_POWER8_EXTERNAL 0
++#define HAVE_PPC4XX_EXTERNAL 0
++#define HAVE_VSX_EXTERNAL 0
++#define HAVE_RVV_EXTERNAL 0
++#define HAVE_AESNI_EXTERNAL 0
++#define HAVE_AMD3DNOW_EXTERNAL 0
++#define HAVE_AMD3DNOWEXT_EXTERNAL 0
++#define HAVE_AVX_EXTERNAL 0
++#define HAVE_AVX2_EXTERNAL 0
++#define HAVE_AVX512_EXTERNAL 0
++#define HAVE_AVX512ICL_EXTERNAL 0
++#define HAVE_FMA3_EXTERNAL 0
++#define HAVE_FMA4_EXTERNAL 0
++#define HAVE_MMX_EXTERNAL 0
++#define HAVE_MMXEXT_EXTERNAL 0
++#define HAVE_SSE_EXTERNAL 0
++#define HAVE_SSE2_EXTERNAL 0
++#define HAVE_SSE3_EXTERNAL 0
++#define HAVE_SSE4_EXTERNAL 0
++#define HAVE_SSE42_EXTERNAL 0
++#define HAVE_SSSE3_EXTERNAL 0
++#define HAVE_XOP_EXTERNAL 0
++#define HAVE_CPUNOP_EXTERNAL 0
++#define HAVE_I686_EXTERNAL 0
++#define HAVE_MIPSFPU_EXTERNAL 0
++#define HAVE_MIPS32R2_EXTERNAL 0
++#define HAVE_MIPS32R5_EXTERNAL 0
++#define HAVE_MIPS64R2_EXTERNAL 0
++#define HAVE_MIPS32R6_EXTERNAL 0
++#define HAVE_MIPS64R6_EXTERNAL 0
++#define HAVE_MIPSDSP_EXTERNAL 0
++#define HAVE_MIPSDSPR2_EXTERNAL 0
++#define HAVE_MSA_EXTERNAL 0
++#define HAVE_LOONGSON2_EXTERNAL 0
++#define HAVE_LOONGSON3_EXTERNAL 0
++#define HAVE_MMI_EXTERNAL 0
++#define HAVE_LSX_EXTERNAL 0
++#define HAVE_LASX_EXTERNAL 0
++#define HAVE_ARMV5TE_INLINE 0
++#define HAVE_ARMV6_INLINE 0
++#define HAVE_ARMV6T2_INLINE 0
++#define HAVE_ARMV8_INLINE 0
++#define HAVE_DOTPROD_INLINE 0
++#define HAVE_I8MM_INLINE 0
++#define HAVE_NEON_INLINE 0
++#define HAVE_VFP_INLINE 0
++#define HAVE_VFPV3_INLINE 0
++#define HAVE_SETEND_INLINE 0
++#define HAVE_ALTIVEC_INLINE 0
++#define HAVE_DCBZL_INLINE 0
++#define HAVE_LDBRX_INLINE 0
++#define HAVE_POWER8_INLINE 0
++#define HAVE_PPC4XX_INLINE 0
++#define HAVE_VSX_INLINE 0
++#define HAVE_RVV_INLINE 0
++#define HAVE_AESNI_INLINE 0
++#define HAVE_AMD3DNOW_INLINE 0
++#define HAVE_AMD3DNOWEXT_INLINE 0
++#define HAVE_AVX_INLINE 0
++#define HAVE_AVX2_INLINE 0
++#define HAVE_AVX512_INLINE 0
++#define HAVE_AVX512ICL_INLINE 0
++#define HAVE_FMA3_INLINE 0
++#define HAVE_FMA4_INLINE 0
++#define HAVE_MMX_INLINE 0
++#define HAVE_MMXEXT_INLINE 0
++#define HAVE_SSE_INLINE 0
++#define HAVE_SSE2_INLINE 0
++#define HAVE_SSE3_INLINE 0
++#define HAVE_SSE4_INLINE 0
++#define HAVE_SSE42_INLINE 0
++#define HAVE_SSSE3_INLINE 0
++#define HAVE_XOP_INLINE 0
++#define HAVE_CPUNOP_INLINE 0
++#define HAVE_I686_INLINE 0
++#define HAVE_MIPSFPU_INLINE 0
++#define HAVE_MIPS32R2_INLINE 0
++#define HAVE_MIPS32R5_INLINE 0
++#define HAVE_MIPS64R2_INLINE 0
++#define HAVE_MIPS32R6_INLINE 0
++#define HAVE_MIPS64R6_INLINE 0
++#define HAVE_MIPSDSP_INLINE 0
++#define HAVE_MIPSDSPR2_INLINE 0
++#define HAVE_MSA_INLINE 0
++#define HAVE_LOONGSON2_INLINE 0
++#define HAVE_LOONGSON3_INLINE 0
++#define HAVE_MMI_INLINE 0
++#define HAVE_LSX_INLINE 0
++#define HAVE_LASX_INLINE 0
++#define HAVE_ALIGNED_STACK 0
++#define HAVE_FAST_64BIT 1
++#define HAVE_FAST_CLZ 1
++#define HAVE_FAST_CMOV 0
++#define HAVE_FAST_FLOAT16 0
++#define HAVE_LOCAL_ALIGNED 1
++#define HAVE_SIMD_ALIGN_16 0
++#define HAVE_SIMD_ALIGN_32 1
++#define HAVE_SIMD_ALIGN_64 0
++#define HAVE_ATOMIC_CAS_PTR 0
++#define HAVE_MACHINE_RW_BARRIER 0
++#define HAVE_MEMORYBARRIER 0
++#define HAVE_MM_EMPTY 0
++#define HAVE_RDTSC 0
++#define HAVE_SEM_TIMEDWAIT 1
++#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
++#define HAVE_INLINE_ASM 1
++#define HAVE_SYMVER 0
++#define HAVE_X86ASM 0
++#define HAVE_BIGENDIAN 0
++#define HAVE_FAST_UNALIGNED 1
++#define HAVE_ARPA_INET_H 0
++#define HAVE_ASM_HWCAP_H 1
++#define HAVE_ASM_TYPES_H 1
++#define HAVE_CDIO_PARANOIA_H 0
++#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
++#define HAVE_CUDA_H 0
++#define HAVE_DISPATCH_DISPATCH_H 0
++#define HAVE_DEV_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_BKTR_IOCTL_METEOR_H 0
++#define HAVE_DEV_IC_BT8XX_H 0
++#define HAVE_DEV_VIDEO_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_VIDEO_METEOR_IOCTL_METEOR_H 0
++#define HAVE_DIRECT_H 0
++#define HAVE_DIRENT_H 1
++#define HAVE_DXGIDEBUG_H 0
++#define HAVE_DXVA_H 0
++#define HAVE_ES2_GL_H 0
++#define HAVE_GSM_H 0
++#define HAVE_IO_H 0
++#define HAVE_LINUX_DMA_BUF_H 0
++#define HAVE_LINUX_PERF_EVENT_H 1
++#define HAVE_MACHINE_IOCTL_BT848_H 0
++#define HAVE_MACHINE_IOCTL_METEOR_H 0
++#define HAVE_MALLOC_H 1
++#define HAVE_OPENCV2_CORE_CORE_C_H 0
++#define HAVE_OPENGL_GL3_H 0
++#define HAVE_POLL_H 1
++#define HAVE_SYS_PARAM_H 1
++#define HAVE_SYS_RESOURCE_H 1
++#define HAVE_SYS_SELECT_H 1
++#define HAVE_SYS_SOUNDCARD_H 1
++#define HAVE_SYS_TIME_H 1
++#define HAVE_SYS_UN_H 1
++#define HAVE_SYS_VIDEOIO_H 0
++#define HAVE_TERMIOS_H 1
++#define HAVE_UDPLITE_H 0
++#define HAVE_UNISTD_H 1
++#define HAVE_VALGRIND_VALGRIND_H 0
++#define HAVE_WINDOWS_H 0
++#define HAVE_WINSOCK2_H 0
++#define HAVE_INTRINSICS_NEON 0
++#define HAVE_ATANF 1
++#define HAVE_ATAN2F 1
++#define HAVE_CBRT 1
++#define HAVE_CBRTF 1
++#define HAVE_COPYSIGN 1
++#define HAVE_COSF 1
++#define HAVE_ERF 1
++#define HAVE_EXP2 1
++#define HAVE_EXP2F 1
++#define HAVE_EXPF 1
++#define HAVE_HYPOT 1
++#define HAVE_ISFINITE 1
++#define HAVE_ISINF 1
++#define HAVE_ISNAN 1
++#define HAVE_LDEXPF 1
++#define HAVE_LLRINT 1
++#define HAVE_LLRINTF 1
++#define HAVE_LOG2 1
++#define HAVE_LOG2F 1
++#define HAVE_LOG10F 1
++#define HAVE_LRINT 1
++#define HAVE_LRINTF 1
++#define HAVE_POWF 1
++#define HAVE_RINT 1
++#define HAVE_ROUND 1
++#define HAVE_ROUNDF 1
++#define HAVE_SINF 1
++#define HAVE_TRUNC 1
++#define HAVE_TRUNCF 1
++#define HAVE_DOS_PATHS 0
++#define HAVE_LIBC_MSVCRT 0
++#define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
++#define HAVE_SECTION_DATA_REL_RO 1
++#define HAVE_THREADS 1
++#define HAVE_UWP 0
++#define HAVE_WINRT 0
++#define HAVE_ACCESS 1
++#define HAVE_ALIGNED_MALLOC 0
++#define HAVE_ARC4RANDOM_BUF 0
++#define HAVE_CLOCK_GETTIME 1
++#define HAVE_CLOSESOCKET 0
++#define HAVE_COMMANDLINETOARGVW 0
++#define HAVE_FCNTL 1
++#define HAVE_GETADDRINFO 0
++#define HAVE_GETAUXVAL 1
++#define HAVE_GETENV 1
++#define HAVE_GETHRTIME 0
++#define HAVE_GETOPT 1
++#define HAVE_GETMODULEHANDLE 0
++#define HAVE_GETPROCESSAFFINITYMASK 0
++#define HAVE_GETPROCESSMEMORYINFO 0
++#define HAVE_GETPROCESSTIMES 0
++#define HAVE_GETRUSAGE 1
++#define HAVE_GETSTDHANDLE 0
++#define HAVE_GETSYSTEMTIMEASFILETIME 0
++#define HAVE_GETTIMEOFDAY 1
++#define HAVE_GLOB 1
++#define HAVE_GLXGETPROCADDRESS 0
++#define HAVE_GMTIME_R 1
++#define HAVE_INET_ATON 0
++#define HAVE_ISATTY 1
++#define HAVE_KBHIT 0
++#define HAVE_LOCALTIME_R 1
++#define HAVE_LSTAT 1
++#define HAVE_LZO1X_999_COMPRESS 0
++#define HAVE_MACH_ABSOLUTE_TIME 0
++#define HAVE_MAPVIEWOFFILE 0
++#define HAVE_MEMALIGN 1
++#define HAVE_MKSTEMP 1
++#define HAVE_MMAP 1
++#define HAVE_MPROTECT 1
++#define HAVE_NANOSLEEP 1
++#define HAVE_PEEKNAMEDPIPE 0
++#define HAVE_POSIX_MEMALIGN 1
++#define HAVE_PRCTL 1
++#define HAVE_PTHREAD_CANCEL 1
++#define HAVE_SCHED_GETAFFINITY 1
++#define HAVE_SECITEMIMPORT 0
++#define HAVE_SETCONSOLETEXTATTRIBUTE 0
++#define HAVE_SETCONSOLECTRLHANDLER 0
++#define HAVE_SETDLLDIRECTORY 0
++#define HAVE_SETMODE 0
++#define HAVE_SETRLIMIT 1
++#define HAVE_SLEEP 0
++#define HAVE_STRERROR_R 1
++#define HAVE_SYSCONF 1
++#define HAVE_SYSCTL 0
++#define HAVE_SYSCTLBYNAME 0
++#define HAVE_USLEEP 1
++#define HAVE_UTGETOSTYPEFROMSTRING 0
++#define HAVE_VIRTUALALLOC 0
++#define HAVE_WGLGETPROCADDRESS 0
++#define HAVE_BCRYPT 0
++#define HAVE_VAAPI_DRM 0
++#define HAVE_VAAPI_X11 0
++#define HAVE_VAAPI_WIN32 0
++#define HAVE_VDPAU_X11 0
++#define HAVE_PTHREADS 1
++#define HAVE_OS2THREADS 0
++#define HAVE_W32THREADS 0
++#define HAVE_AS_ARCH_DIRECTIVE 0
++#define HAVE_AS_ARCHEXT_DOTPROD_DIRECTIVE 0
++#define HAVE_AS_ARCHEXT_I8MM_DIRECTIVE 0
++#define HAVE_AS_DN_DIRECTIVE 0
++#define HAVE_AS_FPU_DIRECTIVE 0
++#define HAVE_AS_FUNC 0
++#define HAVE_AS_OBJECT_ARCH 0
++#define HAVE_ASM_MOD_Q 0
++#define HAVE_BLOCKS_EXTENSION 0
++#define HAVE_EBP_AVAILABLE 0
++#define HAVE_EBX_AVAILABLE 0
++#define HAVE_GNU_AS 0
++#define HAVE_GNU_WINDRES 0
++#define HAVE_IBM_ASM 0
++#define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
++#define HAVE_INLINE_ASM_LABELS 1
++#define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
++#define HAVE_PRAGMA_DEPRECATED 1
++#define HAVE_RSYNC_CONTIMEOUT 1
++#define HAVE_SYMVER_ASM_LABEL 1
++#define HAVE_SYMVER_GNU_ASM 1
++#define HAVE_VFP_ARGS 0
++#define HAVE_XFORM_ASM 0
++#define HAVE_XMM_CLOBBERS 0
++#define HAVE_DPI_AWARENESS_CONTEXT 0
++#define HAVE_IDXGIOUTPUT5 0
++#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
++#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
++#define HAVE_KCMVIDEOCODECTYPE_VP9 0
++#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
++#define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
++#define HAVE_SOCKLEN_T 0
++#define HAVE_STRUCT_ADDRINFO 0
++#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
++#define HAVE_STRUCT_IP_MREQ_SOURCE 0
++#define HAVE_STRUCT_IPV6_MREQ 0
++#define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
++#define HAVE_STRUCT_POLLFD 0
++#define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
++#define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
++#define HAVE_STRUCT_SOCKADDR_IN6 0
++#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
++#define HAVE_STRUCT_SOCKADDR_STORAGE 0
++#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
++#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 0
++#define HAVE_GZIP 1
++#define HAVE_LIBDRM_GETFB2 0
++#define HAVE_MAKEINFO 1
++#define HAVE_MAKEINFO_HTML 1
++#define HAVE_OPENCL_D3D11 0
++#define HAVE_OPENCL_DRM_ARM 0
++#define HAVE_OPENCL_DRM_BEIGNET 0
++#define HAVE_OPENCL_DXVA2 0
++#define HAVE_OPENCL_VAAPI_BEIGNET 0
++#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
++#define HAVE_PERL 1
++#define HAVE_POD2MAN 1
++#define HAVE_TEXI2HTML 0
++#define HAVE_XMLLINT 1
++#define HAVE_ZLIB_GZIP 0
++#define CONFIG_DOC 0
++#define CONFIG_HTMLPAGES 0
++#define CONFIG_MANPAGES 0
++#define CONFIG_PODPAGES 0
++#define CONFIG_TXTPAGES 0
++#define CONFIG_AVIO_HTTP_SERVE_FILES_EXAMPLE 1
++#define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
++#define CONFIG_AVIO_READ_CALLBACK_EXAMPLE 1
++#define CONFIG_DECODE_AUDIO_EXAMPLE 1
++#define CONFIG_DECODE_FILTER_AUDIO_EXAMPLE 0
++#define CONFIG_DECODE_FILTER_VIDEO_EXAMPLE 0
++#define CONFIG_DECODE_VIDEO_EXAMPLE 1
++#define CONFIG_DEMUX_DECODE_EXAMPLE 1
++#define CONFIG_ENCODE_AUDIO_EXAMPLE 1
++#define CONFIG_ENCODE_VIDEO_EXAMPLE 1
++#define CONFIG_EXTRACT_MVS_EXAMPLE 1
++#define CONFIG_FILTER_AUDIO_EXAMPLE 0
++#define CONFIG_HW_DECODE_EXAMPLE 1
++#define CONFIG_MUX_EXAMPLE 0
++#define CONFIG_QSV_DECODE_EXAMPLE 0
++#define CONFIG_REMUX_EXAMPLE 1
++#define CONFIG_RESAMPLE_AUDIO_EXAMPLE 0
++#define CONFIG_SCALE_VIDEO_EXAMPLE 0
++#define CONFIG_SHOW_METADATA_EXAMPLE 1
++#define CONFIG_TRANSCODE_AAC_EXAMPLE 0
++#define CONFIG_TRANSCODE_EXAMPLE 0
++#define CONFIG_VAAPI_ENCODE_EXAMPLE 0
++#define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
++#define CONFIG_QSV_TRANSCODE_EXAMPLE 0
++#define CONFIG_AVISYNTH 0
++#define CONFIG_FREI0R 0
++#define CONFIG_LIBCDIO 0
++#define CONFIG_LIBDAVS2 0
++#define CONFIG_LIBRUBBERBAND 0
++#define CONFIG_LIBVIDSTAB 0
++#define CONFIG_LIBX264 0
++#define CONFIG_LIBX265 0
++#define CONFIG_LIBXAVS 0
++#define CONFIG_LIBXAVS2 0
++#define CONFIG_LIBXVID 0
++#define CONFIG_DECKLINK 0
++#define CONFIG_LIBFDK_AAC 0
++#define CONFIG_LIBTLS 0
++#define CONFIG_GMP 0
++#define CONFIG_LIBARIBB24 0
++#define CONFIG_LIBLENSFUN 0
++#define CONFIG_LIBOPENCORE_AMRNB 0
++#define CONFIG_LIBOPENCORE_AMRWB 0
++#define CONFIG_LIBVO_AMRWBENC 0
++#define CONFIG_MBEDTLS 0
++#define CONFIG_RKMPP 0
++#define CONFIG_LIBSMBCLIENT 0
++#define CONFIG_CHROMAPRINT 0
++#define CONFIG_GCRYPT 0
++#define CONFIG_GNUTLS 0
++#define CONFIG_JNI 0
++#define CONFIG_LADSPA 0
++#define CONFIG_LCMS2 0
++#define CONFIG_LIBAOM 0
++#define CONFIG_LIBARIBCAPTION 0
++#define CONFIG_LIBASS 0
++#define CONFIG_LIBBLURAY 0
++#define CONFIG_LIBBS2B 0
++#define CONFIG_LIBCACA 0
++#define CONFIG_LIBCELT 0
++#define CONFIG_LIBCODEC2 0
++#define CONFIG_LIBDAV1D 0
++#define CONFIG_LIBDC1394 0
++#define CONFIG_LIBDRM 0
++#define CONFIG_LIBFLITE 0
++#define CONFIG_LIBFONTCONFIG 0
++#define CONFIG_LIBFREETYPE 0
++#define CONFIG_LIBFRIBIDI 0
++#define CONFIG_LIBHARFBUZZ 0
++#define CONFIG_LIBGLSLANG 0
++#define CONFIG_LIBGME 0
++#define CONFIG_LIBGSM 0
++#define CONFIG_LIBIEC61883 0
++#define CONFIG_LIBILBC 0
++#define CONFIG_LIBJACK 0
++#define CONFIG_LIBJXL 0
++#define CONFIG_LIBKLVANC 0
++#define CONFIG_LIBKVAZAAR 0
++#define CONFIG_LIBMODPLUG 0
++#define CONFIG_LIBMP3LAME 0
++#define CONFIG_LIBMYSOFA 0
++#define CONFIG_LIBOPENCV 0
++#define CONFIG_LIBOPENH264 0
++#define CONFIG_LIBOPENJPEG 0
++#define CONFIG_LIBOPENMPT 0
++#define CONFIG_LIBOPENVINO 0
++#define CONFIG_LIBOPUS 1
++#define CONFIG_LIBPLACEBO 0
++#define CONFIG_LIBPULSE 0
++#define CONFIG_LIBRABBITMQ 0
++#define CONFIG_LIBRAV1E 0
++#define CONFIG_LIBRIST 0
++#define CONFIG_LIBRSVG 0
++#define CONFIG_LIBRTMP 0
++#define CONFIG_LIBSHADERC 0
++#define CONFIG_LIBSHINE 0
++#define CONFIG_LIBSMBCLIENT 0
++#define CONFIG_LIBSNAPPY 0
++#define CONFIG_LIBSOXR 0
++#define CONFIG_LIBSPEEX 0
++#define CONFIG_LIBSRT 0
++#define CONFIG_LIBSSH 0
++#define CONFIG_LIBSVTAV1 0
++#define CONFIG_LIBTENSORFLOW 0
++#define CONFIG_LIBTESSERACT 0
++#define CONFIG_LIBTHEORA 0
++#define CONFIG_LIBTWOLAME 0
++#define CONFIG_LIBUAVS3D 0
++#define CONFIG_LIBV4L2 0
++#define CONFIG_LIBVMAF 0
++#define CONFIG_LIBVORBIS 0
++#define CONFIG_LIBVPX 0
++#define CONFIG_LIBWEBP 0
++#define CONFIG_LIBXML2 0
++#define CONFIG_LIBZIMG 0
++#define CONFIG_LIBZMQ 0
++#define CONFIG_LIBZVBI 0
++#define CONFIG_LV2 0
++#define CONFIG_MEDIACODEC 0
++#define CONFIG_OPENAL 0
++#define CONFIG_OPENGL 0
++#define CONFIG_OPENSSL 0
++#define CONFIG_POCKETSPHINX 0
++#define CONFIG_VAPOURSYNTH 0
++#define CONFIG_ALSA 0
++#define CONFIG_APPKIT 0
++#define CONFIG_AVFOUNDATION 0
++#define CONFIG_BZLIB 0
++#define CONFIG_COREIMAGE 0
++#define CONFIG_ICONV 0
++#define CONFIG_LIBXCB 0
++#define CONFIG_LIBXCB_SHM 0
++#define CONFIG_LIBXCB_SHAPE 0
++#define CONFIG_LIBXCB_XFIXES 0
++#define CONFIG_LZMA 0
++#define CONFIG_MEDIAFOUNDATION 0
++#define CONFIG_METAL 0
++#define CONFIG_SCHANNEL 0
++#define CONFIG_SDL2 0
++#define CONFIG_SECURETRANSPORT 0
++#define CONFIG_SNDIO 0
++#define CONFIG_XLIB 0
++#define CONFIG_ZLIB 0
++#define CONFIG_CUDA_NVCC 0
++#define CONFIG_CUDA_SDK 0
++#define CONFIG_LIBNPP 0
++#define CONFIG_LIBMFX 0
++#define CONFIG_LIBVPL 0
++#define CONFIG_MMAL 0
++#define CONFIG_OMX 0
++#define CONFIG_OPENCL 0
++#define CONFIG_AMF 0
++#define CONFIG_AUDIOTOOLBOX 0
++#define CONFIG_CRYSTALHD 0
++#define CONFIG_CUDA 0
++#define CONFIG_CUDA_LLVM 0
++#define CONFIG_CUVID 0
++#define CONFIG_D3D11VA 0
++#define CONFIG_DXVA2 0
++#define CONFIG_FFNVCODEC 0
++#define CONFIG_NVDEC 0
++#define CONFIG_NVENC 0
++#define CONFIG_VAAPI 0
++#define CONFIG_VDPAU 0
++#define CONFIG_VIDEOTOOLBOX 0
++#define CONFIG_VULKAN 0
++#define CONFIG_V4L2_M2M 0
++#define CONFIG_FTRAPV 0
++#define CONFIG_GRAY 0
++#define CONFIG_HARDCODED_TABLES 0
++#define CONFIG_OMX_RPI 0
++#define CONFIG_RUNTIME_CPUDETECT 1
++#define CONFIG_SAFE_BITSTREAM_READER 1
++#define CONFIG_SHARED 0
++#define CONFIG_SMALL 0
++#define CONFIG_STATIC 1
++#define CONFIG_SWSCALE_ALPHA 1
++#define CONFIG_GPL 0
++#define CONFIG_NONFREE 0
++#define CONFIG_VERSION3 0
++#define CONFIG_AVDEVICE 0
++#define CONFIG_AVFILTER 0
++#define CONFIG_SWSCALE 0
++#define CONFIG_POSTPROC 0
++#define CONFIG_AVFORMAT 1
++#define CONFIG_AVCODEC 1
++#define CONFIG_SWRESAMPLE 0
++#define CONFIG_AVUTIL 1
++#define CONFIG_FFPLAY 0
++#define CONFIG_FFPROBE 0
++#define CONFIG_FFMPEG 0
++#define CONFIG_DCT 1
++#define CONFIG_DWT 0
++#define CONFIG_ERROR_RESILIENCE 0
++#define CONFIG_FAAN 0
++#define CONFIG_FAST_UNALIGNED 1
++#define CONFIG_FFT 1
++#define CONFIG_LSP 0
++#define CONFIG_MDCT 0
++#define CONFIG_PIXELUTILS 0
++#define CONFIG_NETWORK 0
++#define CONFIG_RDFT 1
++#define CONFIG_AUTODETECT 0
++#define CONFIG_FONTCONFIG 0
++#define CONFIG_LARGE_TESTS 1
++#define CONFIG_LINUX_PERF 0
++#define CONFIG_MACOS_KPERF 0
++#define CONFIG_MEMORY_POISONING 0
++#define CONFIG_NEON_CLOBBER_TEST 0
++#define CONFIG_OSSFUZZ 0
++#define CONFIG_PIC 1
++#define CONFIG_PTX_COMPRESSION 0
++#define CONFIG_THUMB 0
++#define CONFIG_VALGRIND_BACKTRACE 0
++#define CONFIG_XMM_CLOBBER_TEST 0
++#define CONFIG_BSFS 0
++#define CONFIG_DECODERS 1
++#define CONFIG_ENCODERS 0
++#define CONFIG_HWACCELS 0
++#define CONFIG_PARSERS 1
++#define CONFIG_INDEVS 0
++#define CONFIG_OUTDEVS 0
++#define CONFIG_FILTERS 0
++#define CONFIG_DEMUXERS 1
++#define CONFIG_MUXERS 0
++#define CONFIG_PROTOCOLS 0
++#define CONFIG_AANDCTTABLES 0
++#define CONFIG_AC3DSP 0
++#define CONFIG_ADTS_HEADER 0
++#define CONFIG_ATSC_A53 0
++#define CONFIG_AUDIO_FRAME_QUEUE 0
++#define CONFIG_AUDIODSP 0
++#define CONFIG_BLOCKDSP 0
++#define CONFIG_BSWAPDSP 0
++#define CONFIG_CABAC 0
++#define CONFIG_CBS 0
++#define CONFIG_CBS_AV1 0
++#define CONFIG_CBS_H264 0
++#define CONFIG_CBS_H265 0
++#define CONFIG_CBS_H266 0
++#define CONFIG_CBS_JPEG 0
++#define CONFIG_CBS_MPEG2 0
++#define CONFIG_CBS_VP9 0
++#define CONFIG_DEFLATE_WRAPPER 0
++#define CONFIG_DIRAC_PARSE 1
++#define CONFIG_DNN 0
++#define CONFIG_DOVI_RPU 0
++#define CONFIG_DVPROFILE 0
++#define CONFIG_EVCPARSE 0
++#define CONFIG_EXIF 0
++#define CONFIG_FAANDCT 0
++#define CONFIG_FAANIDCT 0
++#define CONFIG_FDCTDSP 0
++#define CONFIG_FMTCONVERT 0
++#define CONFIG_FRAME_THREAD_ENCODER 0
++#define CONFIG_G722DSP 0
++#define CONFIG_GOLOMB 1
++#define CONFIG_GPLV3 0
++#define CONFIG_H263DSP 0
++#define CONFIG_H264CHROMA 0
++#define CONFIG_H264DSP 0
++#define CONFIG_H264PARSE 0
++#define CONFIG_H264PRED 1
++#define CONFIG_H264QPEL 0
++#define CONFIG_H264_SEI 0
++#define CONFIG_HEVCPARSE 0
++#define CONFIG_HEVC_SEI 0
++#define CONFIG_HPELDSP 1
++#define CONFIG_HUFFMAN 0
++#define CONFIG_HUFFYUVDSP 0
++#define CONFIG_HUFFYUVENCDSP 0
++#define CONFIG_IDCTDSP 0
++#define CONFIG_IIRFILTER 0
++#define CONFIG_INFLATE_WRAPPER 0
++#define CONFIG_INTRAX8 0
++#define CONFIG_ISO_MEDIA 1
++#define CONFIG_IVIDSP 0
++#define CONFIG_JPEGTABLES 0
++#define CONFIG_LGPLV3 0
++#define CONFIG_LIBX262 0
++#define CONFIG_LLAUDDSP 0
++#define CONFIG_LLVIDDSP 0
++#define CONFIG_LLVIDENCDSP 0
++#define CONFIG_LPC 0
++#define CONFIG_LZF 0
++#define CONFIG_ME_CMP 0
++#define CONFIG_MPEG_ER 0
++#define CONFIG_MPEGAUDIO 1
++#define CONFIG_MPEGAUDIODSP 1
++#define CONFIG_MPEGAUDIOHEADER 1
++#define CONFIG_MPEG4AUDIO 1
++#define CONFIG_MPEGVIDEO 0
++#define CONFIG_MPEGVIDEODEC 0
++#define CONFIG_MPEGVIDEOENC 0
++#define CONFIG_MSMPEG4DEC 0
++#define CONFIG_MSMPEG4ENC 0
++#define CONFIG_MSS34DSP 0
++#define CONFIG_PIXBLOCKDSP 0
++#define CONFIG_QPELDSP 0
++#define CONFIG_QSV 0
++#define CONFIG_QSVDEC 0
++#define CONFIG_QSVENC 0
++#define CONFIG_QSVVPP 0
++#define CONFIG_RANGECODER 0
++#define CONFIG_RIFFDEC 1
++#define CONFIG_RIFFENC 0
++#define CONFIG_RTPDEC 0
++#define CONFIG_RTPENC_CHAIN 0
++#define CONFIG_RV34DSP 0
++#define CONFIG_SCENE_SAD 0
++#define CONFIG_SINEWIN 0
++#define CONFIG_SNAPPY 0
++#define CONFIG_SRTP 0
++#define CONFIG_STARTCODE 0
++#define CONFIG_TEXTUREDSP 0
++#define CONFIG_TEXTUREDSPENC 0
++#define CONFIG_TPELDSP 0
++#define CONFIG_VAAPI_1 0
++#define CONFIG_VAAPI_ENCODE 0
++#define CONFIG_VC1DSP 0
++#define CONFIG_VIDEODSP 1
++#define CONFIG_VP3DSP 1
++#define CONFIG_VP56DSP 0
++#define CONFIG_VP8DSP 1
++#define CONFIG_WMA_FREQS 0
++#define CONFIG_WMV2DSP 0
++#endif /* FFMPEG_CONFIG_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2187 @@
++/* Automatically generated by configure - do not modify! */
++#ifndef FFMPEG_CONFIG_COMPONENTS_H
++#define FFMPEG_CONFIG_COMPONENTS_H
++#define CONFIG_AAC_ADTSTOASC_BSF 0
++#define CONFIG_AV1_FRAME_MERGE_BSF 0
++#define CONFIG_AV1_FRAME_SPLIT_BSF 0
++#define CONFIG_AV1_METADATA_BSF 0
++#define CONFIG_CHOMP_BSF 0
++#define CONFIG_DUMP_EXTRADATA_BSF 0
++#define CONFIG_DCA_CORE_BSF 0
++#define CONFIG_DTS2PTS_BSF 0
++#define CONFIG_DV_ERROR_MARKER_BSF 0
++#define CONFIG_EAC3_CORE_BSF 0
++#define CONFIG_EXTRACT_EXTRADATA_BSF 0
++#define CONFIG_FILTER_UNITS_BSF 0
++#define CONFIG_H264_METADATA_BSF 0
++#define CONFIG_H264_MP4TOANNEXB_BSF 0
++#define CONFIG_H264_REDUNDANT_PPS_BSF 0
++#define CONFIG_HAPQA_EXTRACT_BSF 0
++#define CONFIG_HEVC_METADATA_BSF 0
++#define CONFIG_HEVC_MP4TOANNEXB_BSF 0
++#define CONFIG_IMX_DUMP_HEADER_BSF 0
++#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
++#define CONFIG_MJPEG2JPEG_BSF 0
++#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
++#define CONFIG_MP3_HEADER_DECOMPRESS_BSF 0
++#define CONFIG_MPEG2_METADATA_BSF 0
++#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
++#define CONFIG_MOV2TEXTSUB_BSF 0
++#define CONFIG_NOISE_BSF 0
++#define CONFIG_NULL_BSF 0
++#define CONFIG_OPUS_METADATA_BSF 0
++#define CONFIG_PCM_RECHUNK_BSF 0
++#define CONFIG_PGS_FRAME_MERGE_BSF 0
++#define CONFIG_PRORES_METADATA_BSF 0
++#define CONFIG_REMOVE_EXTRADATA_BSF 0
++#define CONFIG_SETTS_BSF 0
++#define CONFIG_TEXT2MOVSUB_BSF 0
++#define CONFIG_TRACE_HEADERS_BSF 0
++#define CONFIG_TRUEHD_CORE_BSF 0
++#define CONFIG_VP9_METADATA_BSF 0
++#define CONFIG_VP9_RAW_REORDER_BSF 0
++#define CONFIG_VP9_SUPERFRAME_BSF 0
++#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
++#define CONFIG_VVC_METADATA_BSF 0
++#define CONFIG_VVC_MP4TOANNEXB_BSF 0
++#define CONFIG_EVC_FRAME_MERGE_BSF 0
++#define CONFIG_AASC_DECODER 0
++#define CONFIG_AIC_DECODER 0
++#define CONFIG_ALIAS_PIX_DECODER 0
++#define CONFIG_AGM_DECODER 0
++#define CONFIG_AMV_DECODER 0
++#define CONFIG_ANM_DECODER 0
++#define CONFIG_ANSI_DECODER 0
++#define CONFIG_APNG_DECODER 0
++#define CONFIG_ARBC_DECODER 0
++#define CONFIG_ARGO_DECODER 0
++#define CONFIG_ASV1_DECODER 0
++#define CONFIG_ASV2_DECODER 0
++#define CONFIG_AURA_DECODER 0
++#define CONFIG_AURA2_DECODER 0
++#define CONFIG_AVRP_DECODER 0
++#define CONFIG_AVRN_DECODER 0
++#define CONFIG_AVS_DECODER 0
++#define CONFIG_AVUI_DECODER 0
++#define CONFIG_AYUV_DECODER 0
++#define CONFIG_BETHSOFTVID_DECODER 0
++#define CONFIG_BFI_DECODER 0
++#define CONFIG_BINK_DECODER 0
++#define CONFIG_BITPACKED_DECODER 0
++#define CONFIG_BMP_DECODER 0
++#define CONFIG_BMV_VIDEO_DECODER 0
++#define CONFIG_BRENDER_PIX_DECODER 0
++#define CONFIG_C93_DECODER 0
++#define CONFIG_CAVS_DECODER 0
++#define CONFIG_CDGRAPHICS_DECODER 0
++#define CONFIG_CDTOONS_DECODER 0
++#define CONFIG_CDXL_DECODER 0
++#define CONFIG_CFHD_DECODER 0
++#define CONFIG_CINEPAK_DECODER 0
++#define CONFIG_CLEARVIDEO_DECODER 0
++#define CONFIG_CLJR_DECODER 0
++#define CONFIG_CLLC_DECODER 0
++#define CONFIG_COMFORTNOISE_DECODER 0
++#define CONFIG_CPIA_DECODER 0
++#define CONFIG_CRI_DECODER 0
++#define CONFIG_CSCD_DECODER 0
++#define CONFIG_CYUV_DECODER 0
++#define CONFIG_DDS_DECODER 0
++#define CONFIG_DFA_DECODER 0
++#define CONFIG_DIRAC_DECODER 0
++#define CONFIG_DNXHD_DECODER 0
++#define CONFIG_DPX_DECODER 0
++#define CONFIG_DSICINVIDEO_DECODER 0
++#define CONFIG_DVAUDIO_DECODER 0
++#define CONFIG_DVVIDEO_DECODER 0
++#define CONFIG_DXA_DECODER 0
++#define CONFIG_DXTORY_DECODER 0
++#define CONFIG_DXV_DECODER 0
++#define CONFIG_EACMV_DECODER 0
++#define CONFIG_EAMAD_DECODER 0
++#define CONFIG_EATGQ_DECODER 0
++#define CONFIG_EATGV_DECODER 0
++#define CONFIG_EATQI_DECODER 0
++#define CONFIG_EIGHTBPS_DECODER 0
++#define CONFIG_EIGHTSVX_EXP_DECODER 0
++#define CONFIG_EIGHTSVX_FIB_DECODER 0
++#define CONFIG_ESCAPE124_DECODER 0
++#define CONFIG_ESCAPE130_DECODER 0
++#define CONFIG_EXR_DECODER 0
++#define CONFIG_FFV1_DECODER 0
++#define CONFIG_FFVHUFF_DECODER 0
++#define CONFIG_FIC_DECODER 0
++#define CONFIG_FITS_DECODER 0
++#define CONFIG_FLASHSV_DECODER 0
++#define CONFIG_FLASHSV2_DECODER 0
++#define CONFIG_FLIC_DECODER 0
++#define CONFIG_FLV_DECODER 0
++#define CONFIG_FMVC_DECODER 0
++#define CONFIG_FOURXM_DECODER 0
++#define CONFIG_FRAPS_DECODER 0
++#define CONFIG_FRWU_DECODER 0
++#define CONFIG_G2M_DECODER 0
++#define CONFIG_GDV_DECODER 0
++#define CONFIG_GEM_DECODER 0
++#define CONFIG_GIF_DECODER 0
++#define CONFIG_H261_DECODER 0
++#define CONFIG_H263_DECODER 0
++#define CONFIG_H263I_DECODER 0
++#define CONFIG_H263P_DECODER 0
++#define CONFIG_H263_V4L2M2M_DECODER 0
++#define CONFIG_H264_DECODER 0
++#define CONFIG_H264_CRYSTALHD_DECODER 0
++#define CONFIG_H264_V4L2M2M_DECODER 0
++#define CONFIG_H264_MEDIACODEC_DECODER 0
++#define CONFIG_H264_MMAL_DECODER 0
++#define CONFIG_H264_QSV_DECODER 0
++#define CONFIG_H264_RKMPP_DECODER 0
++#define CONFIG_HAP_DECODER 0
++#define CONFIG_HEVC_DECODER 0
++#define CONFIG_HEVC_QSV_DECODER 0
++#define CONFIG_HEVC_RKMPP_DECODER 0
++#define CONFIG_HEVC_V4L2M2M_DECODER 0
++#define CONFIG_HNM4_VIDEO_DECODER 0
++#define CONFIG_HQ_HQA_DECODER 0
++#define CONFIG_HQX_DECODER 0
++#define CONFIG_HUFFYUV_DECODER 0
++#define CONFIG_HYMT_DECODER 0
++#define CONFIG_IDCIN_DECODER 0
++#define CONFIG_IFF_ILBM_DECODER 0
++#define CONFIG_IMM4_DECODER 0
++#define CONFIG_IMM5_DECODER 0
++#define CONFIG_INDEO2_DECODER 0
++#define CONFIG_INDEO3_DECODER 0
++#define CONFIG_INDEO4_DECODER 0
++#define CONFIG_INDEO5_DECODER 0
++#define CONFIG_INTERPLAY_VIDEO_DECODER 0
++#define CONFIG_IPU_DECODER 0
++#define CONFIG_JPEG2000_DECODER 0
++#define CONFIG_JPEGLS_DECODER 0
++#define CONFIG_JV_DECODER 0
++#define CONFIG_KGV1_DECODER 0
++#define CONFIG_KMVC_DECODER 0
++#define CONFIG_LAGARITH_DECODER 0
++#define CONFIG_LOCO_DECODER 0
++#define CONFIG_LSCR_DECODER 0
++#define CONFIG_M101_DECODER 0
++#define CONFIG_MAGICYUV_DECODER 0
++#define CONFIG_MDEC_DECODER 0
++#define CONFIG_MEDIA100_DECODER 0
++#define CONFIG_MIMIC_DECODER 0
++#define CONFIG_MJPEG_DECODER 0
++#define CONFIG_MJPEGB_DECODER 0
++#define CONFIG_MMVIDEO_DECODER 0
++#define CONFIG_MOBICLIP_DECODER 0
++#define CONFIG_MOTIONPIXELS_DECODER 0
++#define CONFIG_MPEG1VIDEO_DECODER 0
++#define CONFIG_MPEG2VIDEO_DECODER 0
++#define CONFIG_MPEG4_DECODER 0
++#define CONFIG_MPEG4_CRYSTALHD_DECODER 0
++#define CONFIG_MPEG4_V4L2M2M_DECODER 0
++#define CONFIG_MPEG4_MMAL_DECODER 0
++#define CONFIG_MPEGVIDEO_DECODER 0
++#define CONFIG_MPEG1_V4L2M2M_DECODER 0
++#define CONFIG_MPEG2_MMAL_DECODER 0
++#define CONFIG_MPEG2_CRYSTALHD_DECODER 0
++#define CONFIG_MPEG2_V4L2M2M_DECODER 0
++#define CONFIG_MPEG2_QSV_DECODER 0
++#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
++#define CONFIG_MSA1_DECODER 0
++#define CONFIG_MSCC_DECODER 0
++#define CONFIG_MSMPEG4V1_DECODER 0
++#define CONFIG_MSMPEG4V2_DECODER 0
++#define CONFIG_MSMPEG4V3_DECODER 0
++#define CONFIG_MSMPEG4_CRYSTALHD_DECODER 0
++#define CONFIG_MSP2_DECODER 0
++#define CONFIG_MSRLE_DECODER 0
++#define CONFIG_MSS1_DECODER 0
++#define CONFIG_MSS2_DECODER 0
++#define CONFIG_MSVIDEO1_DECODER 0
++#define CONFIG_MSZH_DECODER 0
++#define CONFIG_MTS2_DECODER 0
++#define CONFIG_MV30_DECODER 0
++#define CONFIG_MVC1_DECODER 0
++#define CONFIG_MVC2_DECODER 0
++#define CONFIG_MVDV_DECODER 0
++#define CONFIG_MVHA_DECODER 0
++#define CONFIG_MWSC_DECODER 0
++#define CONFIG_MXPEG_DECODER 0
++#define CONFIG_NOTCHLC_DECODER 0
++#define CONFIG_NUV_DECODER 0
++#define CONFIG_PAF_VIDEO_DECODER 0
++#define CONFIG_PAM_DECODER 0
++#define CONFIG_PBM_DECODER 0
++#define CONFIG_PCX_DECODER 0
++#define CONFIG_PDV_DECODER 0
++#define CONFIG_PFM_DECODER 0
++#define CONFIG_PGM_DECODER 0
++#define CONFIG_PGMYUV_DECODER 0
++#define CONFIG_PGX_DECODER 0
++#define CONFIG_PHM_DECODER 0
++#define CONFIG_PHOTOCD_DECODER 0
++#define CONFIG_PICTOR_DECODER 0
++#define CONFIG_PIXLET_DECODER 0
++#define CONFIG_PNG_DECODER 0
++#define CONFIG_PPM_DECODER 0
++#define CONFIG_PRORES_DECODER 0
++#define CONFIG_PROSUMER_DECODER 0
++#define CONFIG_PSD_DECODER 0
++#define CONFIG_PTX_DECODER 0
++#define CONFIG_QDRAW_DECODER 0
++#define CONFIG_QOI_DECODER 0
++#define CONFIG_QPEG_DECODER 0
++#define CONFIG_QTRLE_DECODER 0
++#define CONFIG_R10K_DECODER 0
++#define CONFIG_R210_DECODER 0
++#define CONFIG_RASC_DECODER 0
++#define CONFIG_RAWVIDEO_DECODER 0
++#define CONFIG_RKA_DECODER 0
++#define CONFIG_RL2_DECODER 0
++#define CONFIG_ROQ_DECODER 0
++#define CONFIG_RPZA_DECODER 0
++#define CONFIG_RSCC_DECODER 0
++#define CONFIG_RTV1_DECODER 0
++#define CONFIG_RV10_DECODER 0
++#define CONFIG_RV20_DECODER 0
++#define CONFIG_RV30_DECODER 0
++#define CONFIG_RV40_DECODER 0
++#define CONFIG_S302M_DECODER 0
++#define CONFIG_SANM_DECODER 0
++#define CONFIG_SCPR_DECODER 0
++#define CONFIG_SCREENPRESSO_DECODER 0
++#define CONFIG_SGA_DECODER 0
++#define CONFIG_SGI_DECODER 0
++#define CONFIG_SGIRLE_DECODER 0
++#define CONFIG_SHEERVIDEO_DECODER 0
++#define CONFIG_SIMBIOSIS_IMX_DECODER 0
++#define CONFIG_SMACKER_DECODER 0
++#define CONFIG_SMC_DECODER 0
++#define CONFIG_SMVJPEG_DECODER 0
++#define CONFIG_SNOW_DECODER 0
++#define CONFIG_SP5X_DECODER 0
++#define CONFIG_SPEEDHQ_DECODER 0
++#define CONFIG_SPEEX_DECODER 0
++#define CONFIG_SRGC_DECODER 0
++#define CONFIG_SUNRAST_DECODER 0
++#define CONFIG_SVQ1_DECODER 0
++#define CONFIG_SVQ3_DECODER 0
++#define CONFIG_TARGA_DECODER 0
++#define CONFIG_TARGA_Y216_DECODER 0
++#define CONFIG_TDSC_DECODER 0
++#define CONFIG_THEORA_DECODER 1
++#define CONFIG_THP_DECODER 0
++#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
++#define CONFIG_TIFF_DECODER 0
++#define CONFIG_TMV_DECODER 0
++#define CONFIG_TRUEMOTION1_DECODER 0
++#define CONFIG_TRUEMOTION2_DECODER 0
++#define CONFIG_TRUEMOTION2RT_DECODER 0
++#define CONFIG_TSCC_DECODER 0
++#define CONFIG_TSCC2_DECODER 0
++#define CONFIG_TXD_DECODER 0
++#define CONFIG_ULTI_DECODER 0
++#define CONFIG_UTVIDEO_DECODER 0
++#define CONFIG_V210_DECODER 0
++#define CONFIG_V210X_DECODER 0
++#define CONFIG_V308_DECODER 0
++#define CONFIG_V408_DECODER 0
++#define CONFIG_V410_DECODER 0
++#define CONFIG_VB_DECODER 0
++#define CONFIG_VBN_DECODER 0
++#define CONFIG_VBLE_DECODER 0
++#define CONFIG_VC1_DECODER 0
++#define CONFIG_VC1_CRYSTALHD_DECODER 0
++#define CONFIG_VC1IMAGE_DECODER 0
++#define CONFIG_VC1_MMAL_DECODER 0
++#define CONFIG_VC1_QSV_DECODER 0
++#define CONFIG_VC1_V4L2M2M_DECODER 0
++#define CONFIG_VCR1_DECODER 0
++#define CONFIG_VMDVIDEO_DECODER 0
++#define CONFIG_VMIX_DECODER 0
++#define CONFIG_VMNC_DECODER 0
++#define CONFIG_VP3_DECODER 1
++#define CONFIG_VP4_DECODER 0
++#define CONFIG_VP5_DECODER 0
++#define CONFIG_VP6_DECODER 0
++#define CONFIG_VP6A_DECODER 0
++#define CONFIG_VP6F_DECODER 0
++#define CONFIG_VP7_DECODER 0
++#define CONFIG_VP8_DECODER 1
++#define CONFIG_VP8_RKMPP_DECODER 0
++#define CONFIG_VP8_V4L2M2M_DECODER 0
++#define CONFIG_VP9_DECODER 0
++#define CONFIG_VP9_RKMPP_DECODER 0
++#define CONFIG_VP9_V4L2M2M_DECODER 0
++#define CONFIG_VQA_DECODER 0
++#define CONFIG_VQC_DECODER 0
++#define CONFIG_WBMP_DECODER 0
++#define CONFIG_WEBP_DECODER 0
++#define CONFIG_WCMV_DECODER 0
++#define CONFIG_WRAPPED_AVFRAME_DECODER 0
++#define CONFIG_WMV1_DECODER 0
++#define CONFIG_WMV2_DECODER 0
++#define CONFIG_WMV3_DECODER 0
++#define CONFIG_WMV3_CRYSTALHD_DECODER 0
++#define CONFIG_WMV3IMAGE_DECODER 0
++#define CONFIG_WNV1_DECODER 0
++#define CONFIG_XAN_WC3_DECODER 0
++#define CONFIG_XAN_WC4_DECODER 0
++#define CONFIG_XBM_DECODER 0
++#define CONFIG_XFACE_DECODER 0
++#define CONFIG_XL_DECODER 0
++#define CONFIG_XPM_DECODER 0
++#define CONFIG_XWD_DECODER 0
++#define CONFIG_Y41P_DECODER 0
++#define CONFIG_YLC_DECODER 0
++#define CONFIG_YOP_DECODER 0
++#define CONFIG_YUV4_DECODER 0
++#define CONFIG_ZERO12V_DECODER 0
++#define CONFIG_ZEROCODEC_DECODER 0
++#define CONFIG_ZLIB_DECODER 0
++#define CONFIG_ZMBV_DECODER 0
++#define CONFIG_AAC_DECODER 0
++#define CONFIG_AAC_FIXED_DECODER 0
++#define CONFIG_AAC_LATM_DECODER 0
++#define CONFIG_AC3_DECODER 0
++#define CONFIG_AC3_FIXED_DECODER 0
++#define CONFIG_ACELP_KELVIN_DECODER 0
++#define CONFIG_ALAC_DECODER 0
++#define CONFIG_ALS_DECODER 0
++#define CONFIG_AMRNB_DECODER 0
++#define CONFIG_AMRWB_DECODER 0
++#define CONFIG_APAC_DECODER 0
++#define CONFIG_APE_DECODER 0
++#define CONFIG_APTX_DECODER 0
++#define CONFIG_APTX_HD_DECODER 0
++#define CONFIG_ATRAC1_DECODER 0
++#define CONFIG_ATRAC3_DECODER 0
++#define CONFIG_ATRAC3AL_DECODER 0
++#define CONFIG_ATRAC3P_DECODER 0
++#define CONFIG_ATRAC3PAL_DECODER 0
++#define CONFIG_ATRAC9_DECODER 0
++#define CONFIG_BINKAUDIO_DCT_DECODER 0
++#define CONFIG_BINKAUDIO_RDFT_DECODER 0
++#define CONFIG_BMV_AUDIO_DECODER 0
++#define CONFIG_BONK_DECODER 0
++#define CONFIG_COOK_DECODER 0
++#define CONFIG_DCA_DECODER 0
++#define CONFIG_DFPWM_DECODER 0
++#define CONFIG_DOLBY_E_DECODER 0
++#define CONFIG_DSD_LSBF_DECODER 0
++#define CONFIG_DSD_MSBF_DECODER 0
++#define CONFIG_DSD_LSBF_PLANAR_DECODER 0
++#define CONFIG_DSD_MSBF_PLANAR_DECODER 0
++#define CONFIG_DSICINAUDIO_DECODER 0
++#define CONFIG_DSS_SP_DECODER 0
++#define CONFIG_DST_DECODER 0
++#define CONFIG_EAC3_DECODER 0
++#define CONFIG_EVRC_DECODER 0
++#define CONFIG_FASTAUDIO_DECODER 0
++#define CONFIG_FFWAVESYNTH_DECODER 0
++#define CONFIG_FLAC_DECODER 1
++#define CONFIG_FTR_DECODER 0
++#define CONFIG_G723_1_DECODER 0
++#define CONFIG_G729_DECODER 0
++#define CONFIG_GSM_DECODER 0
++#define CONFIG_GSM_MS_DECODER 0
++#define CONFIG_HCA_DECODER 0
++#define CONFIG_HCOM_DECODER 0
++#define CONFIG_HDR_DECODER 0
++#define CONFIG_IAC_DECODER 0
++#define CONFIG_ILBC_DECODER 0
++#define CONFIG_IMC_DECODER 0
++#define CONFIG_INTERPLAY_ACM_DECODER 0
++#define CONFIG_MACE3_DECODER 0
++#define CONFIG_MACE6_DECODER 0
++#define CONFIG_METASOUND_DECODER 0
++#define CONFIG_MISC4_DECODER 0
++#define CONFIG_MLP_DECODER 0
++#define CONFIG_MP1_DECODER 0
++#define CONFIG_MP1FLOAT_DECODER 0
++#define CONFIG_MP2_DECODER 0
++#define CONFIG_MP2FLOAT_DECODER 0
++#define CONFIG_MP3FLOAT_DECODER 0
++#define CONFIG_MP3_DECODER 1
++#define CONFIG_MP3ADUFLOAT_DECODER 0
++#define CONFIG_MP3ADU_DECODER 0
++#define CONFIG_MP3ON4FLOAT_DECODER 0
++#define CONFIG_MP3ON4_DECODER 0
++#define CONFIG_MPC7_DECODER 0
++#define CONFIG_MPC8_DECODER 0
++#define CONFIG_MSNSIREN_DECODER 0
++#define CONFIG_NELLYMOSER_DECODER 0
++#define CONFIG_ON2AVC_DECODER 0
++#define CONFIG_OPUS_DECODER 0
++#define CONFIG_PAF_AUDIO_DECODER 0
++#define CONFIG_QCELP_DECODER 0
++#define CONFIG_QDM2_DECODER 0
++#define CONFIG_QDMC_DECODER 0
++#define CONFIG_RA_144_DECODER 0
++#define CONFIG_RA_288_DECODER 0
++#define CONFIG_RALF_DECODER 0
++#define CONFIG_SBC_DECODER 0
++#define CONFIG_SHORTEN_DECODER 0
++#define CONFIG_SIPR_DECODER 0
++#define CONFIG_SIREN_DECODER 0
++#define CONFIG_SMACKAUD_DECODER 0
++#define CONFIG_SONIC_DECODER 0
++#define CONFIG_TAK_DECODER 0
++#define CONFIG_TRUEHD_DECODER 0
++#define CONFIG_TRUESPEECH_DECODER 0
++#define CONFIG_TTA_DECODER 0
++#define CONFIG_TWINVQ_DECODER 0
++#define CONFIG_VMDAUDIO_DECODER 0
++#define CONFIG_VORBIS_DECODER 1
++#define CONFIG_WAVARC_DECODER 0
++#define CONFIG_WAVPACK_DECODER 0
++#define CONFIG_WMALOSSLESS_DECODER 0
++#define CONFIG_WMAPRO_DECODER 0
++#define CONFIG_WMAV1_DECODER 0
++#define CONFIG_WMAV2_DECODER 0
++#define CONFIG_WMAVOICE_DECODER 0
++#define CONFIG_WS_SND1_DECODER 0
++#define CONFIG_XMA1_DECODER 0
++#define CONFIG_XMA2_DECODER 0
++#define CONFIG_PCM_ALAW_DECODER 1
++#define CONFIG_PCM_BLURAY_DECODER 0
++#define CONFIG_PCM_DVD_DECODER 0
++#define CONFIG_PCM_F16LE_DECODER 0
++#define CONFIG_PCM_F24LE_DECODER 0
++#define CONFIG_PCM_F32BE_DECODER 0
++#define CONFIG_PCM_F32LE_DECODER 1
++#define CONFIG_PCM_F64BE_DECODER 0
++#define CONFIG_PCM_F64LE_DECODER 0
++#define CONFIG_PCM_LXF_DECODER 0
++#define CONFIG_PCM_MULAW_DECODER 1
++#define CONFIG_PCM_S8_DECODER 0
++#define CONFIG_PCM_S8_PLANAR_DECODER 0
++#define CONFIG_PCM_S16BE_DECODER 1
++#define CONFIG_PCM_S16BE_PLANAR_DECODER 0
++#define CONFIG_PCM_S16LE_DECODER 1
++#define CONFIG_PCM_S16LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S24BE_DECODER 1
++#define CONFIG_PCM_S24DAUD_DECODER 0
++#define CONFIG_PCM_S24LE_DECODER 1
++#define CONFIG_PCM_S24LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S32BE_DECODER 0
++#define CONFIG_PCM_S32LE_DECODER 1
++#define CONFIG_PCM_S32LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S64BE_DECODER 0
++#define CONFIG_PCM_S64LE_DECODER 0
++#define CONFIG_PCM_SGA_DECODER 0
++#define CONFIG_PCM_U8_DECODER 1
++#define CONFIG_PCM_U16BE_DECODER 0
++#define CONFIG_PCM_U16LE_DECODER 0
++#define CONFIG_PCM_U24BE_DECODER 0
++#define CONFIG_PCM_U24LE_DECODER 0
++#define CONFIG_PCM_U32BE_DECODER 0
++#define CONFIG_PCM_U32LE_DECODER 0
++#define CONFIG_PCM_VIDC_DECODER 0
++#define CONFIG_CBD2_DPCM_DECODER 0
++#define CONFIG_DERF_DPCM_DECODER 0
++#define CONFIG_GREMLIN_DPCM_DECODER 0
++#define CONFIG_INTERPLAY_DPCM_DECODER 0
++#define CONFIG_ROQ_DPCM_DECODER 0
++#define CONFIG_SDX2_DPCM_DECODER 0
++#define CONFIG_SOL_DPCM_DECODER 0
++#define CONFIG_XAN_DPCM_DECODER 0
++#define CONFIG_WADY_DPCM_DECODER 0
++#define CONFIG_ADPCM_4XM_DECODER 0
++#define CONFIG_ADPCM_ADX_DECODER 0
++#define CONFIG_ADPCM_AFC_DECODER 0
++#define CONFIG_ADPCM_AGM_DECODER 0
++#define CONFIG_ADPCM_AICA_DECODER 0
++#define CONFIG_ADPCM_ARGO_DECODER 0
++#define CONFIG_ADPCM_CT_DECODER 0
++#define CONFIG_ADPCM_DTK_DECODER 0
++#define CONFIG_ADPCM_EA_DECODER 0
++#define CONFIG_ADPCM_EA_MAXIS_XA_DECODER 0
++#define CONFIG_ADPCM_EA_R1_DECODER 0
++#define CONFIG_ADPCM_EA_R2_DECODER 0
++#define CONFIG_ADPCM_EA_R3_DECODER 0
++#define CONFIG_ADPCM_EA_XAS_DECODER 0
++#define CONFIG_ADPCM_G722_DECODER 0
++#define CONFIG_ADPCM_G726_DECODER 0
++#define CONFIG_ADPCM_G726LE_DECODER 0
++#define CONFIG_ADPCM_IMA_ACORN_DECODER 0
++#define CONFIG_ADPCM_IMA_AMV_DECODER 0
++#define CONFIG_ADPCM_IMA_ALP_DECODER 0
++#define CONFIG_ADPCM_IMA_APC_DECODER 0
++#define CONFIG_ADPCM_IMA_APM_DECODER 0
++#define CONFIG_ADPCM_IMA_CUNNING_DECODER 0
++#define CONFIG_ADPCM_IMA_DAT4_DECODER 0
++#define CONFIG_ADPCM_IMA_DK3_DECODER 0
++#define CONFIG_ADPCM_IMA_DK4_DECODER 0
++#define CONFIG_ADPCM_IMA_EA_EACS_DECODER 0
++#define CONFIG_ADPCM_IMA_EA_SEAD_DECODER 0
++#define CONFIG_ADPCM_IMA_ISS_DECODER 0
++#define CONFIG_ADPCM_IMA_MOFLEX_DECODER 0
++#define CONFIG_ADPCM_IMA_MTF_DECODER 0
++#define CONFIG_ADPCM_IMA_OKI_DECODER 0
++#define CONFIG_ADPCM_IMA_QT_DECODER 0
++#define CONFIG_ADPCM_IMA_RAD_DECODER 0
++#define CONFIG_ADPCM_IMA_SSI_DECODER 0
++#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
++#define CONFIG_ADPCM_IMA_WAV_DECODER 0
++#define CONFIG_ADPCM_IMA_WS_DECODER 0
++#define CONFIG_ADPCM_MS_DECODER 0
++#define CONFIG_ADPCM_MTAF_DECODER 0
++#define CONFIG_ADPCM_PSX_DECODER 0
++#define CONFIG_ADPCM_SBPRO_2_DECODER 0
++#define CONFIG_ADPCM_SBPRO_3_DECODER 0
++#define CONFIG_ADPCM_SBPRO_4_DECODER 0
++#define CONFIG_ADPCM_SWF_DECODER 0
++#define CONFIG_ADPCM_THP_DECODER 0
++#define CONFIG_ADPCM_THP_LE_DECODER 0
++#define CONFIG_ADPCM_VIMA_DECODER 0
++#define CONFIG_ADPCM_XA_DECODER 0
++#define CONFIG_ADPCM_XMD_DECODER 0
++#define CONFIG_ADPCM_YAMAHA_DECODER 0
++#define CONFIG_ADPCM_ZORK_DECODER 0
++#define CONFIG_SSA_DECODER 0
++#define CONFIG_ASS_DECODER 0
++#define CONFIG_CCAPTION_DECODER 0
++#define CONFIG_DVBSUB_DECODER 0
++#define CONFIG_DVDSUB_DECODER 0
++#define CONFIG_JACOSUB_DECODER 0
++#define CONFIG_MICRODVD_DECODER 0
++#define CONFIG_MOVTEXT_DECODER 0
++#define CONFIG_MPL2_DECODER 0
++#define CONFIG_PGSSUB_DECODER 0
++#define CONFIG_PJS_DECODER 0
++#define CONFIG_REALTEXT_DECODER 0
++#define CONFIG_SAMI_DECODER 0
++#define CONFIG_SRT_DECODER 0
++#define CONFIG_STL_DECODER 0
++#define CONFIG_SUBRIP_DECODER 0
++#define CONFIG_SUBVIEWER_DECODER 0
++#define CONFIG_SUBVIEWER1_DECODER 0
++#define CONFIG_TEXT_DECODER 0
++#define CONFIG_VPLAYER_DECODER 0
++#define CONFIG_WEBVTT_DECODER 0
++#define CONFIG_XSUB_DECODER 0
++#define CONFIG_AAC_AT_DECODER 0
++#define CONFIG_AC3_AT_DECODER 0
++#define CONFIG_ADPCM_IMA_QT_AT_DECODER 0
++#define CONFIG_ALAC_AT_DECODER 0
++#define CONFIG_AMR_NB_AT_DECODER 0
++#define CONFIG_EAC3_AT_DECODER 0
++#define CONFIG_GSM_MS_AT_DECODER 0
++#define CONFIG_ILBC_AT_DECODER 0
++#define CONFIG_MP1_AT_DECODER 0
++#define CONFIG_MP2_AT_DECODER 0
++#define CONFIG_MP3_AT_DECODER 0
++#define CONFIG_PCM_ALAW_AT_DECODER 0
++#define CONFIG_PCM_MULAW_AT_DECODER 0
++#define CONFIG_QDMC_AT_DECODER 0
++#define CONFIG_QDM2_AT_DECODER 0
++#define CONFIG_LIBARIBCAPTION_DECODER 0
++#define CONFIG_LIBARIBB24_DECODER 0
++#define CONFIG_LIBCELT_DECODER 0
++#define CONFIG_LIBCODEC2_DECODER 0
++#define CONFIG_LIBDAV1D_DECODER 0
++#define CONFIG_LIBDAVS2_DECODER 0
++#define CONFIG_LIBFDK_AAC_DECODER 0
++#define CONFIG_LIBGSM_DECODER 0
++#define CONFIG_LIBGSM_MS_DECODER 0
++#define CONFIG_LIBILBC_DECODER 0
++#define CONFIG_LIBJXL_DECODER 0
++#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
++#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
++#define CONFIG_LIBOPUS_DECODER 1
++#define CONFIG_LIBRSVG_DECODER 0
++#define CONFIG_LIBSPEEX_DECODER 0
++#define CONFIG_LIBUAVS3D_DECODER 0
++#define CONFIG_LIBVORBIS_DECODER 0
++#define CONFIG_LIBVPX_VP8_DECODER 0
++#define CONFIG_LIBVPX_VP9_DECODER 0
++#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
++#define CONFIG_BINTEXT_DECODER 0
++#define CONFIG_XBIN_DECODER 0
++#define CONFIG_IDF_DECODER 0
++#define CONFIG_LIBAOM_AV1_DECODER 0
++#define CONFIG_AV1_DECODER 0
++#define CONFIG_AV1_CUVID_DECODER 0
++#define CONFIG_AV1_MEDIACODEC_DECODER 0
++#define CONFIG_AV1_QSV_DECODER 0
++#define CONFIG_LIBOPENH264_DECODER 0
++#define CONFIG_H264_CUVID_DECODER 0
++#define CONFIG_HEVC_CUVID_DECODER 0
++#define CONFIG_HEVC_MEDIACODEC_DECODER 0
++#define CONFIG_MJPEG_CUVID_DECODER 0
++#define CONFIG_MJPEG_QSV_DECODER 0
++#define CONFIG_MPEG1_CUVID_DECODER 0
++#define CONFIG_MPEG2_CUVID_DECODER 0
++#define CONFIG_MPEG4_CUVID_DECODER 0
++#define CONFIG_MPEG4_MEDIACODEC_DECODER 0
++#define CONFIG_VC1_CUVID_DECODER 0
++#define CONFIG_VP8_CUVID_DECODER 0
++#define CONFIG_VP8_MEDIACODEC_DECODER 0
++#define CONFIG_VP8_QSV_DECODER 0
++#define CONFIG_VP9_CUVID_DECODER 0
++#define CONFIG_VP9_MEDIACODEC_DECODER 0
++#define CONFIG_VP9_QSV_DECODER 0
++#define CONFIG_VNULL_DECODER 0
++#define CONFIG_ANULL_DECODER 0
++#define CONFIG_A64MULTI_ENCODER 0
++#define CONFIG_A64MULTI5_ENCODER 0
++#define CONFIG_ALIAS_PIX_ENCODER 0
++#define CONFIG_AMV_ENCODER 0
++#define CONFIG_APNG_ENCODER 0
++#define CONFIG_ASV1_ENCODER 0
++#define CONFIG_ASV2_ENCODER 0
++#define CONFIG_AVRP_ENCODER 0
++#define CONFIG_AVUI_ENCODER 0
++#define CONFIG_AYUV_ENCODER 0
++#define CONFIG_BITPACKED_ENCODER 0
++#define CONFIG_BMP_ENCODER 0
++#define CONFIG_CFHD_ENCODER 0
++#define CONFIG_CINEPAK_ENCODER 0
++#define CONFIG_CLJR_ENCODER 0
++#define CONFIG_COMFORTNOISE_ENCODER 0
++#define CONFIG_DNXHD_ENCODER 0
++#define CONFIG_DPX_ENCODER 0
++#define CONFIG_DVVIDEO_ENCODER 0
++#define CONFIG_EXR_ENCODER 0
++#define CONFIG_FFV1_ENCODER 0
++#define CONFIG_FFVHUFF_ENCODER 0
++#define CONFIG_FITS_ENCODER 0
++#define CONFIG_FLASHSV_ENCODER 0
++#define CONFIG_FLASHSV2_ENCODER 0
++#define CONFIG_FLV_ENCODER 0
++#define CONFIG_GIF_ENCODER 0
++#define CONFIG_H261_ENCODER 0
++#define CONFIG_H263_ENCODER 0
++#define CONFIG_H263P_ENCODER 0
++#define CONFIG_H264_MEDIACODEC_ENCODER 0
++#define CONFIG_HAP_ENCODER 0
++#define CONFIG_HUFFYUV_ENCODER 0
++#define CONFIG_JPEG2000_ENCODER 0
++#define CONFIG_JPEGLS_ENCODER 0
++#define CONFIG_LJPEG_ENCODER 0
++#define CONFIG_MAGICYUV_ENCODER 0
++#define CONFIG_MJPEG_ENCODER 0
++#define CONFIG_MPEG1VIDEO_ENCODER 0
++#define CONFIG_MPEG2VIDEO_ENCODER 0
++#define CONFIG_MPEG4_ENCODER 0
++#define CONFIG_MSMPEG4V2_ENCODER 0
++#define CONFIG_MSMPEG4V3_ENCODER 0
++#define CONFIG_MSRLE_ENCODER 0
++#define CONFIG_MSVIDEO1_ENCODER 0
++#define CONFIG_PAM_ENCODER 0
++#define CONFIG_PBM_ENCODER 0
++#define CONFIG_PCX_ENCODER 0
++#define CONFIG_PFM_ENCODER 0
++#define CONFIG_PGM_ENCODER 0
++#define CONFIG_PGMYUV_ENCODER 0
++#define CONFIG_PHM_ENCODER 0
++#define CONFIG_PNG_ENCODER 0
++#define CONFIG_PPM_ENCODER 0
++#define CONFIG_PRORES_ENCODER 0
++#define CONFIG_PRORES_AW_ENCODER 0
++#define CONFIG_PRORES_KS_ENCODER 0
++#define CONFIG_QOI_ENCODER 0
++#define CONFIG_QTRLE_ENCODER 0
++#define CONFIG_R10K_ENCODER 0
++#define CONFIG_R210_ENCODER 0
++#define CONFIG_RAWVIDEO_ENCODER 0
++#define CONFIG_ROQ_ENCODER 0
++#define CONFIG_RPZA_ENCODER 0
++#define CONFIG_RV10_ENCODER 0
++#define CONFIG_RV20_ENCODER 0
++#define CONFIG_S302M_ENCODER 0
++#define CONFIG_SGI_ENCODER 0
++#define CONFIG_SMC_ENCODER 0
++#define CONFIG_SNOW_ENCODER 0
++#define CONFIG_SPEEDHQ_ENCODER 0
++#define CONFIG_SUNRAST_ENCODER 0
++#define CONFIG_SVQ1_ENCODER 0
++#define CONFIG_TARGA_ENCODER 0
++#define CONFIG_TIFF_ENCODER 0
++#define CONFIG_UTVIDEO_ENCODER 0
++#define CONFIG_V210_ENCODER 0
++#define CONFIG_V308_ENCODER 0
++#define CONFIG_V408_ENCODER 0
++#define CONFIG_V410_ENCODER 0
++#define CONFIG_VBN_ENCODER 0
++#define CONFIG_VC2_ENCODER 0
++#define CONFIG_WBMP_ENCODER 0
++#define CONFIG_WRAPPED_AVFRAME_ENCODER 0
++#define CONFIG_WMV1_ENCODER 0
++#define CONFIG_WMV2_ENCODER 0
++#define CONFIG_XBM_ENCODER 0
++#define CONFIG_XFACE_ENCODER 0
++#define CONFIG_XWD_ENCODER 0
++#define CONFIG_Y41P_ENCODER 0
++#define CONFIG_YUV4_ENCODER 0
++#define CONFIG_ZLIB_ENCODER 0
++#define CONFIG_ZMBV_ENCODER 0
++#define CONFIG_AAC_ENCODER 0
++#define CONFIG_AC3_ENCODER 0
++#define CONFIG_AC3_FIXED_ENCODER 0
++#define CONFIG_ALAC_ENCODER 0
++#define CONFIG_APTX_ENCODER 0
++#define CONFIG_APTX_HD_ENCODER 0
++#define CONFIG_DCA_ENCODER 0
++#define CONFIG_DFPWM_ENCODER 0
++#define CONFIG_EAC3_ENCODER 0
++#define CONFIG_FLAC_ENCODER 0
++#define CONFIG_G723_1_ENCODER 0
++#define CONFIG_HDR_ENCODER 0
++#define CONFIG_MLP_ENCODER 0
++#define CONFIG_MP2_ENCODER 0
++#define CONFIG_MP2FIXED_ENCODER 0
++#define CONFIG_NELLYMOSER_ENCODER 0
++#define CONFIG_OPUS_ENCODER 0
++#define CONFIG_RA_144_ENCODER 0
++#define CONFIG_SBC_ENCODER 0
++#define CONFIG_SONIC_ENCODER 0
++#define CONFIG_SONIC_LS_ENCODER 0
++#define CONFIG_TRUEHD_ENCODER 0
++#define CONFIG_TTA_ENCODER 0
++#define CONFIG_VORBIS_ENCODER 0
++#define CONFIG_WAVPACK_ENCODER 0
++#define CONFIG_WMAV1_ENCODER 0
++#define CONFIG_WMAV2_ENCODER 0
++#define CONFIG_PCM_ALAW_ENCODER 0
++#define CONFIG_PCM_BLURAY_ENCODER 0
++#define CONFIG_PCM_DVD_ENCODER 0
++#define CONFIG_PCM_F32BE_ENCODER 0
++#define CONFIG_PCM_F32LE_ENCODER 0
++#define CONFIG_PCM_F64BE_ENCODER 0
++#define CONFIG_PCM_F64LE_ENCODER 0
++#define CONFIG_PCM_MULAW_ENCODER 0
++#define CONFIG_PCM_S8_ENCODER 0
++#define CONFIG_PCM_S8_PLANAR_ENCODER 0
++#define CONFIG_PCM_S16BE_ENCODER 0
++#define CONFIG_PCM_S16BE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S16LE_ENCODER 0
++#define CONFIG_PCM_S16LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S24BE_ENCODER 0
++#define CONFIG_PCM_S24DAUD_ENCODER 0
++#define CONFIG_PCM_S24LE_ENCODER 0
++#define CONFIG_PCM_S24LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S32BE_ENCODER 0
++#define CONFIG_PCM_S32LE_ENCODER 0
++#define CONFIG_PCM_S32LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S64BE_ENCODER 0
++#define CONFIG_PCM_S64LE_ENCODER 0
++#define CONFIG_PCM_U8_ENCODER 0
++#define CONFIG_PCM_U16BE_ENCODER 0
++#define CONFIG_PCM_U16LE_ENCODER 0
++#define CONFIG_PCM_U24BE_ENCODER 0
++#define CONFIG_PCM_U24LE_ENCODER 0
++#define CONFIG_PCM_U32BE_ENCODER 0
++#define CONFIG_PCM_U32LE_ENCODER 0
++#define CONFIG_PCM_VIDC_ENCODER 0
++#define CONFIG_ROQ_DPCM_ENCODER 0
++#define CONFIG_ADPCM_ADX_ENCODER 0
++#define CONFIG_ADPCM_ARGO_ENCODER 0
++#define CONFIG_ADPCM_G722_ENCODER 0
++#define CONFIG_ADPCM_G726_ENCODER 0
++#define CONFIG_ADPCM_G726LE_ENCODER 0
++#define CONFIG_ADPCM_IMA_AMV_ENCODER 0
++#define CONFIG_ADPCM_IMA_ALP_ENCODER 0
++#define CONFIG_ADPCM_IMA_APM_ENCODER 0
++#define CONFIG_ADPCM_IMA_QT_ENCODER 0
++#define CONFIG_ADPCM_IMA_SSI_ENCODER 0
++#define CONFIG_ADPCM_IMA_WAV_ENCODER 0
++#define CONFIG_ADPCM_IMA_WS_ENCODER 0
++#define CONFIG_ADPCM_MS_ENCODER 0
++#define CONFIG_ADPCM_SWF_ENCODER 0
++#define CONFIG_ADPCM_YAMAHA_ENCODER 0
++#define CONFIG_SSA_ENCODER 0
++#define CONFIG_ASS_ENCODER 0
++#define CONFIG_DVBSUB_ENCODER 0
++#define CONFIG_DVDSUB_ENCODER 0
++#define CONFIG_MOVTEXT_ENCODER 0
++#define CONFIG_SRT_ENCODER 0
++#define CONFIG_SUBRIP_ENCODER 0
++#define CONFIG_TEXT_ENCODER 0
++#define CONFIG_TTML_ENCODER 0
++#define CONFIG_WEBVTT_ENCODER 0
++#define CONFIG_XSUB_ENCODER 0
++#define CONFIG_AAC_AT_ENCODER 0
++#define CONFIG_ALAC_AT_ENCODER 0
++#define CONFIG_ILBC_AT_ENCODER 0
++#define CONFIG_PCM_ALAW_AT_ENCODER 0
++#define CONFIG_PCM_MULAW_AT_ENCODER 0
++#define CONFIG_LIBAOM_AV1_ENCODER 0
++#define CONFIG_LIBCODEC2_ENCODER 0
++#define CONFIG_LIBFDK_AAC_ENCODER 0
++#define CONFIG_LIBGSM_ENCODER 0
++#define CONFIG_LIBGSM_MS_ENCODER 0
++#define CONFIG_LIBILBC_ENCODER 0
++#define CONFIG_LIBJXL_ENCODER 0
++#define CONFIG_LIBMP3LAME_ENCODER 0
++#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
++#define CONFIG_LIBOPENJPEG_ENCODER 0
++#define CONFIG_LIBOPUS_ENCODER 0
++#define CONFIG_LIBRAV1E_ENCODER 0
++#define CONFIG_LIBSHINE_ENCODER 0
++#define CONFIG_LIBSPEEX_ENCODER 0
++#define CONFIG_LIBSVTAV1_ENCODER 0
++#define CONFIG_LIBTHEORA_ENCODER 0
++#define CONFIG_LIBTWOLAME_ENCODER 0
++#define CONFIG_LIBVO_AMRWBENC_ENCODER 0
++#define CONFIG_LIBVORBIS_ENCODER 0
++#define CONFIG_LIBVPX_VP8_ENCODER 0
++#define CONFIG_LIBVPX_VP9_ENCODER 0
++#define CONFIG_LIBWEBP_ANIM_ENCODER 0
++#define CONFIG_LIBWEBP_ENCODER 0
++#define CONFIG_LIBX262_ENCODER 0
++#define CONFIG_LIBX264_ENCODER 0
++#define CONFIG_LIBX264RGB_ENCODER 0
++#define CONFIG_LIBX265_ENCODER 0
++#define CONFIG_LIBXAVS_ENCODER 0
++#define CONFIG_LIBXAVS2_ENCODER 0
++#define CONFIG_LIBXVID_ENCODER 0
++#define CONFIG_AAC_MF_ENCODER 0
++#define CONFIG_AC3_MF_ENCODER 0
++#define CONFIG_H263_V4L2M2M_ENCODER 0
++#define CONFIG_AV1_MEDIACODEC_ENCODER 0
++#define CONFIG_AV1_NVENC_ENCODER 0
++#define CONFIG_AV1_QSV_ENCODER 0
++#define CONFIG_AV1_AMF_ENCODER 0
++#define CONFIG_LIBOPENH264_ENCODER 0
++#define CONFIG_H264_AMF_ENCODER 0
++#define CONFIG_H264_MF_ENCODER 0
++#define CONFIG_H264_NVENC_ENCODER 0
++#define CONFIG_H264_OMX_ENCODER 0
++#define CONFIG_H264_QSV_ENCODER 0
++#define CONFIG_H264_V4L2M2M_ENCODER 0
++#define CONFIG_H264_VAAPI_ENCODER 0
++#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_HEVC_AMF_ENCODER 0
++#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
++#define CONFIG_HEVC_MF_ENCODER 0
++#define CONFIG_HEVC_NVENC_ENCODER 0
++#define CONFIG_HEVC_QSV_ENCODER 0
++#define CONFIG_HEVC_V4L2M2M_ENCODER 0
++#define CONFIG_HEVC_VAAPI_ENCODER 0
++#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_LIBKVAZAAR_ENCODER 0
++#define CONFIG_MJPEG_QSV_ENCODER 0
++#define CONFIG_MJPEG_VAAPI_ENCODER 0
++#define CONFIG_MP3_MF_ENCODER 0
++#define CONFIG_MPEG2_QSV_ENCODER 0
++#define CONFIG_MPEG2_VAAPI_ENCODER 0
++#define CONFIG_MPEG4_MEDIACODEC_ENCODER 0
++#define CONFIG_MPEG4_OMX_ENCODER 0
++#define CONFIG_MPEG4_V4L2M2M_ENCODER 0
++#define CONFIG_PRORES_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_VP8_MEDIACODEC_ENCODER 0
++#define CONFIG_VP8_V4L2M2M_ENCODER 0
++#define CONFIG_VP8_VAAPI_ENCODER 0
++#define CONFIG_VP9_MEDIACODEC_ENCODER 0
++#define CONFIG_VP9_VAAPI_ENCODER 0
++#define CONFIG_VP9_QSV_ENCODER 0
++#define CONFIG_VNULL_ENCODER 0
++#define CONFIG_ANULL_ENCODER 0
++#define CONFIG_AV1_D3D11VA_HWACCEL 0
++#define CONFIG_AV1_D3D11VA2_HWACCEL 0
++#define CONFIG_AV1_DXVA2_HWACCEL 0
++#define CONFIG_AV1_NVDEC_HWACCEL 0
++#define CONFIG_AV1_VAAPI_HWACCEL 0
++#define CONFIG_AV1_VDPAU_HWACCEL 0
++#define CONFIG_AV1_VULKAN_HWACCEL 0
++#define CONFIG_H263_VAAPI_HWACCEL 0
++#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_H264_D3D11VA_HWACCEL 0
++#define CONFIG_H264_D3D11VA2_HWACCEL 0
++#define CONFIG_H264_DXVA2_HWACCEL 0
++#define CONFIG_H264_NVDEC_HWACCEL 0
++#define CONFIG_H264_VAAPI_HWACCEL 0
++#define CONFIG_H264_VDPAU_HWACCEL 0
++#define CONFIG_H264_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_H264_VULKAN_HWACCEL 0
++#define CONFIG_HEVC_D3D11VA_HWACCEL 0
++#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
++#define CONFIG_HEVC_DXVA2_HWACCEL 0
++#define CONFIG_HEVC_NVDEC_HWACCEL 0
++#define CONFIG_HEVC_VAAPI_HWACCEL 0
++#define CONFIG_HEVC_VDPAU_HWACCEL 0
++#define CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_HEVC_VULKAN_HWACCEL 0
++#define CONFIG_MJPEG_NVDEC_HWACCEL 0
++#define CONFIG_MJPEG_VAAPI_HWACCEL 0
++#define CONFIG_MPEG1_NVDEC_HWACCEL 0
++#define CONFIG_MPEG1_VDPAU_HWACCEL 0
++#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
++#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
++#define CONFIG_MPEG2_NVDEC_HWACCEL 0
++#define CONFIG_MPEG2_DXVA2_HWACCEL 0
++#define CONFIG_MPEG2_VAAPI_HWACCEL 0
++#define CONFIG_MPEG2_VDPAU_HWACCEL 0
++#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MPEG4_NVDEC_HWACCEL 0
++#define CONFIG_MPEG4_VAAPI_HWACCEL 0
++#define CONFIG_MPEG4_VDPAU_HWACCEL 0
++#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_VC1_D3D11VA_HWACCEL 0
++#define CONFIG_VC1_D3D11VA2_HWACCEL 0
++#define CONFIG_VC1_DXVA2_HWACCEL 0
++#define CONFIG_VC1_NVDEC_HWACCEL 0
++#define CONFIG_VC1_VAAPI_HWACCEL 0
++#define CONFIG_VC1_VDPAU_HWACCEL 0
++#define CONFIG_VP8_NVDEC_HWACCEL 0
++#define CONFIG_VP8_VAAPI_HWACCEL 0
++#define CONFIG_VP9_D3D11VA_HWACCEL 0
++#define CONFIG_VP9_D3D11VA2_HWACCEL 0
++#define CONFIG_VP9_DXVA2_HWACCEL 0
++#define CONFIG_VP9_NVDEC_HWACCEL 0
++#define CONFIG_VP9_VAAPI_HWACCEL 0
++#define CONFIG_VP9_VDPAU_HWACCEL 0
++#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_WMV3_D3D11VA_HWACCEL 0
++#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
++#define CONFIG_WMV3_DXVA2_HWACCEL 0
++#define CONFIG_WMV3_NVDEC_HWACCEL 0
++#define CONFIG_WMV3_VAAPI_HWACCEL 0
++#define CONFIG_WMV3_VDPAU_HWACCEL 0
++#define CONFIG_AAC_PARSER 0
++#define CONFIG_AAC_LATM_PARSER 0
++#define CONFIG_AC3_PARSER 0
++#define CONFIG_ADX_PARSER 0
++#define CONFIG_AMR_PARSER 0
++#define CONFIG_AV1_PARSER 0
++#define CONFIG_AVS2_PARSER 0
++#define CONFIG_AVS3_PARSER 0
++#define CONFIG_BMP_PARSER 0
++#define CONFIG_CAVSVIDEO_PARSER 0
++#define CONFIG_COOK_PARSER 0
++#define CONFIG_CRI_PARSER 0
++#define CONFIG_DCA_PARSER 0
++#define CONFIG_DIRAC_PARSER 0
++#define CONFIG_DNXHD_PARSER 0
++#define CONFIG_DOLBY_E_PARSER 0
++#define CONFIG_DPX_PARSER 0
++#define CONFIG_DVAUDIO_PARSER 0
++#define CONFIG_DVBSUB_PARSER 0
++#define CONFIG_DVDSUB_PARSER 0
++#define CONFIG_DVD_NAV_PARSER 0
++#define CONFIG_EVC_PARSER 0
++#define CONFIG_FLAC_PARSER 1
++#define CONFIG_FTR_PARSER 0
++#define CONFIG_G723_1_PARSER 0
++#define CONFIG_G729_PARSER 0
++#define CONFIG_GIF_PARSER 0
++#define CONFIG_GSM_PARSER 0
++#define CONFIG_H261_PARSER 0
++#define CONFIG_H263_PARSER 0
++#define CONFIG_H264_PARSER 0
++#define CONFIG_HEVC_PARSER 0
++#define CONFIG_HDR_PARSER 0
++#define CONFIG_IPU_PARSER 0
++#define CONFIG_JPEG2000_PARSER 0
++#define CONFIG_MISC4_PARSER 0
++#define CONFIG_MJPEG_PARSER 0
++#define CONFIG_MLP_PARSER 0
++#define CONFIG_MPEG4VIDEO_PARSER 0
++#define CONFIG_MPEGAUDIO_PARSER 1
++#define CONFIG_MPEGVIDEO_PARSER 0
++#define CONFIG_OPUS_PARSER 1
++#define CONFIG_PNG_PARSER 0
++#define CONFIG_PNM_PARSER 0
++#define CONFIG_QOI_PARSER 0
++#define CONFIG_RV30_PARSER 0
++#define CONFIG_RV40_PARSER 0
++#define CONFIG_SBC_PARSER 0
++#define CONFIG_SIPR_PARSER 0
++#define CONFIG_TAK_PARSER 0
++#define CONFIG_VC1_PARSER 0
++#define CONFIG_VORBIS_PARSER 1
++#define CONFIG_VP3_PARSER 1
++#define CONFIG_VP8_PARSER 1
++#define CONFIG_VP9_PARSER 1
++#define CONFIG_VVC_PARSER 0
++#define CONFIG_WEBP_PARSER 0
++#define CONFIG_XBM_PARSER 0
++#define CONFIG_XMA_PARSER 0
++#define CONFIG_XWD_PARSER 0
++#define CONFIG_ALSA_INDEV 0
++#define CONFIG_ANDROID_CAMERA_INDEV 0
++#define CONFIG_AVFOUNDATION_INDEV 0
++#define CONFIG_BKTR_INDEV 0
++#define CONFIG_DECKLINK_INDEV 0
++#define CONFIG_DSHOW_INDEV 0
++#define CONFIG_FBDEV_INDEV 0
++#define CONFIG_GDIGRAB_INDEV 0
++#define CONFIG_IEC61883_INDEV 0
++#define CONFIG_JACK_INDEV 0
++#define CONFIG_KMSGRAB_INDEV 0
++#define CONFIG_LAVFI_INDEV 0
++#define CONFIG_OPENAL_INDEV 0
++#define CONFIG_OSS_INDEV 0
++#define CONFIG_PULSE_INDEV 0
++#define CONFIG_SNDIO_INDEV 0
++#define CONFIG_V4L2_INDEV 0
++#define CONFIG_VFWCAP_INDEV 0
++#define CONFIG_XCBGRAB_INDEV 0
++#define CONFIG_LIBCDIO_INDEV 0
++#define CONFIG_LIBDC1394_INDEV 0
++#define CONFIG_ALSA_OUTDEV 0
++#define CONFIG_AUDIOTOOLBOX_OUTDEV 0
++#define CONFIG_CACA_OUTDEV 0
++#define CONFIG_DECKLINK_OUTDEV 0
++#define CONFIG_FBDEV_OUTDEV 0
++#define CONFIG_OPENGL_OUTDEV 0
++#define CONFIG_OSS_OUTDEV 0
++#define CONFIG_PULSE_OUTDEV 0
++#define CONFIG_SDL2_OUTDEV 0
++#define CONFIG_SNDIO_OUTDEV 0
++#define CONFIG_V4L2_OUTDEV 0
++#define CONFIG_XV_OUTDEV 0
++#define CONFIG_ABENCH_FILTER 0
++#define CONFIG_ACOMPRESSOR_FILTER 0
++#define CONFIG_ACONTRAST_FILTER 0
++#define CONFIG_ACOPY_FILTER 0
++#define CONFIG_ACUE_FILTER 0
++#define CONFIG_ACROSSFADE_FILTER 0
++#define CONFIG_ACROSSOVER_FILTER 0
++#define CONFIG_ACRUSHER_FILTER 0
++#define CONFIG_ADECLICK_FILTER 0
++#define CONFIG_ADECLIP_FILTER 0
++#define CONFIG_ADECORRELATE_FILTER 0
++#define CONFIG_ADELAY_FILTER 0
++#define CONFIG_ADENORM_FILTER 0
++#define CONFIG_ADERIVATIVE_FILTER 0
++#define CONFIG_ADRC_FILTER 0
++#define CONFIG_ADYNAMICEQUALIZER_FILTER 0
++#define CONFIG_ADYNAMICSMOOTH_FILTER 0
++#define CONFIG_AECHO_FILTER 0
++#define CONFIG_AEMPHASIS_FILTER 0
++#define CONFIG_AEVAL_FILTER 0
++#define CONFIG_AEXCITER_FILTER 0
++#define CONFIG_AFADE_FILTER 0
++#define CONFIG_AFFTDN_FILTER 0
++#define CONFIG_AFFTFILT_FILTER 0
++#define CONFIG_AFIR_FILTER 0
++#define CONFIG_AFORMAT_FILTER 0
++#define CONFIG_AFREQSHIFT_FILTER 0
++#define CONFIG_AFWTDN_FILTER 0
++#define CONFIG_AGATE_FILTER 0
++#define CONFIG_AIIR_FILTER 0
++#define CONFIG_AINTEGRAL_FILTER 0
++#define CONFIG_AINTERLEAVE_FILTER 0
++#define CONFIG_ALATENCY_FILTER 0
++#define CONFIG_ALIMITER_FILTER 0
++#define CONFIG_ALLPASS_FILTER 0
++#define CONFIG_ALOOP_FILTER 0
++#define CONFIG_AMERGE_FILTER 0
++#define CONFIG_AMETADATA_FILTER 0
++#define CONFIG_AMIX_FILTER 0
++#define CONFIG_AMULTIPLY_FILTER 0
++#define CONFIG_ANEQUALIZER_FILTER 0
++#define CONFIG_ANLMDN_FILTER 0
++#define CONFIG_ANLMF_FILTER 0
++#define CONFIG_ANLMS_FILTER 0
++#define CONFIG_ANULL_FILTER 0
++#define CONFIG_APAD_FILTER 0
++#define CONFIG_APERMS_FILTER 0
++#define CONFIG_APHASER_FILTER 0
++#define CONFIG_APHASESHIFT_FILTER 0
++#define CONFIG_APSYCLIP_FILTER 0
++#define CONFIG_APULSATOR_FILTER 0
++#define CONFIG_AREALTIME_FILTER 0
++#define CONFIG_ARESAMPLE_FILTER 0
++#define CONFIG_AREVERSE_FILTER 0
++#define CONFIG_ARLS_FILTER 0
++#define CONFIG_ARNNDN_FILTER 0
++#define CONFIG_ASDR_FILTER 0
++#define CONFIG_ASEGMENT_FILTER 0
++#define CONFIG_ASELECT_FILTER 0
++#define CONFIG_ASENDCMD_FILTER 0
++#define CONFIG_ASETNSAMPLES_FILTER 0
++#define CONFIG_ASETPTS_FILTER 0
++#define CONFIG_ASETRATE_FILTER 0
++#define CONFIG_ASETTB_FILTER 0
++#define CONFIG_ASHOWINFO_FILTER 0
++#define CONFIG_ASIDEDATA_FILTER 0
++#define CONFIG_ASOFTCLIP_FILTER 0
++#define CONFIG_ASPECTRALSTATS_FILTER 0
++#define CONFIG_ASPLIT_FILTER 0
++#define CONFIG_ASR_FILTER 0
++#define CONFIG_ASTATS_FILTER 0
++#define CONFIG_ASTREAMSELECT_FILTER 0
++#define CONFIG_ASUBBOOST_FILTER 0
++#define CONFIG_ASUBCUT_FILTER 0
++#define CONFIG_ASUPERCUT_FILTER 0
++#define CONFIG_ASUPERPASS_FILTER 0
++#define CONFIG_ASUPERSTOP_FILTER 0
++#define CONFIG_ATEMPO_FILTER 0
++#define CONFIG_ATILT_FILTER 0
++#define CONFIG_ATRIM_FILTER 0
++#define CONFIG_AXCORRELATE_FILTER 0
++#define CONFIG_AZMQ_FILTER 0
++#define CONFIG_BANDPASS_FILTER 0
++#define CONFIG_BANDREJECT_FILTER 0
++#define CONFIG_BASS_FILTER 0
++#define CONFIG_BIQUAD_FILTER 0
++#define CONFIG_BS2B_FILTER 0
++#define CONFIG_CHANNELMAP_FILTER 0
++#define CONFIG_CHANNELSPLIT_FILTER 0
++#define CONFIG_CHORUS_FILTER 0
++#define CONFIG_COMPAND_FILTER 0
++#define CONFIG_COMPENSATIONDELAY_FILTER 0
++#define CONFIG_CROSSFEED_FILTER 0
++#define CONFIG_CRYSTALIZER_FILTER 0
++#define CONFIG_DCSHIFT_FILTER 0
++#define CONFIG_DEESSER_FILTER 0
++#define CONFIG_DIALOGUENHANCE_FILTER 0
++#define CONFIG_DRMETER_FILTER 0
++#define CONFIG_DYNAUDNORM_FILTER 0
++#define CONFIG_EARWAX_FILTER 0
++#define CONFIG_EBUR128_FILTER 0
++#define CONFIG_EQUALIZER_FILTER 0
++#define CONFIG_EXTRASTEREO_FILTER 0
++#define CONFIG_FIREQUALIZER_FILTER 0
++#define CONFIG_FLANGER_FILTER 0
++#define CONFIG_HAAS_FILTER 0
++#define CONFIG_HDCD_FILTER 0
++#define CONFIG_HEADPHONE_FILTER 0
++#define CONFIG_HIGHPASS_FILTER 0
++#define CONFIG_HIGHSHELF_FILTER 0
++#define CONFIG_JOIN_FILTER 0
++#define CONFIG_LADSPA_FILTER 0
++#define CONFIG_LOUDNORM_FILTER 0
++#define CONFIG_LOWPASS_FILTER 0
++#define CONFIG_LOWSHELF_FILTER 0
++#define CONFIG_LV2_FILTER 0
++#define CONFIG_MCOMPAND_FILTER 0
++#define CONFIG_PAN_FILTER 0
++#define CONFIG_REPLAYGAIN_FILTER 0
++#define CONFIG_RUBBERBAND_FILTER 0
++#define CONFIG_SIDECHAINCOMPRESS_FILTER 0
++#define CONFIG_SIDECHAINGATE_FILTER 0
++#define CONFIG_SILENCEDETECT_FILTER 0
++#define CONFIG_SILENCEREMOVE_FILTER 0
++#define CONFIG_SOFALIZER_FILTER 0
++#define CONFIG_SPEECHNORM_FILTER 0
++#define CONFIG_STEREOTOOLS_FILTER 0
++#define CONFIG_STEREOWIDEN_FILTER 0
++#define CONFIG_SUPEREQUALIZER_FILTER 0
++#define CONFIG_SURROUND_FILTER 0
++#define CONFIG_TILTSHELF_FILTER 0
++#define CONFIG_TREBLE_FILTER 0
++#define CONFIG_TREMOLO_FILTER 0
++#define CONFIG_VIBRATO_FILTER 0
++#define CONFIG_VIRTUALBASS_FILTER 0
++#define CONFIG_VOLUME_FILTER 0
++#define CONFIG_VOLUMEDETECT_FILTER 0
++#define CONFIG_AEVALSRC_FILTER 0
++#define CONFIG_AFDELAYSRC_FILTER 0
++#define CONFIG_AFIREQSRC_FILTER 0
++#define CONFIG_AFIRSRC_FILTER 0
++#define CONFIG_ANOISESRC_FILTER 0
++#define CONFIG_ANULLSRC_FILTER 0
++#define CONFIG_FLITE_FILTER 0
++#define CONFIG_HILBERT_FILTER 0
++#define CONFIG_SINC_FILTER 0
++#define CONFIG_SINE_FILTER 0
++#define CONFIG_ANULLSINK_FILTER 0
++#define CONFIG_ADDROI_FILTER 0
++#define CONFIG_ALPHAEXTRACT_FILTER 0
++#define CONFIG_ALPHAMERGE_FILTER 0
++#define CONFIG_AMPLIFY_FILTER 0
++#define CONFIG_ASS_FILTER 0
++#define CONFIG_ATADENOISE_FILTER 0
++#define CONFIG_AVGBLUR_FILTER 0
++#define CONFIG_AVGBLUR_OPENCL_FILTER 0
++#define CONFIG_AVGBLUR_VULKAN_FILTER 0
++#define CONFIG_BACKGROUNDKEY_FILTER 0
++#define CONFIG_BBOX_FILTER 0
++#define CONFIG_BENCH_FILTER 0
++#define CONFIG_BILATERAL_FILTER 0
++#define CONFIG_BILATERAL_CUDA_FILTER 0
++#define CONFIG_BITPLANENOISE_FILTER 0
++#define CONFIG_BLACKDETECT_FILTER 0
++#define CONFIG_BLACKFRAME_FILTER 0
++#define CONFIG_BLEND_FILTER 0
++#define CONFIG_BLEND_VULKAN_FILTER 0
++#define CONFIG_BLOCKDETECT_FILTER 0
++#define CONFIG_BLURDETECT_FILTER 0
++#define CONFIG_BM3D_FILTER 0
++#define CONFIG_BOXBLUR_FILTER 0
++#define CONFIG_BOXBLUR_OPENCL_FILTER 0
++#define CONFIG_BWDIF_FILTER 0
++#define CONFIG_BWDIF_CUDA_FILTER 0
++#define CONFIG_BWDIF_VULKAN_FILTER 0
++#define CONFIG_CAS_FILTER 0
++#define CONFIG_CCREPACK_FILTER 0
++#define CONFIG_CHROMABER_VULKAN_FILTER 0
++#define CONFIG_CHROMAHOLD_FILTER 0
++#define CONFIG_CHROMAKEY_FILTER 0
++#define CONFIG_CHROMAKEY_CUDA_FILTER 0
++#define CONFIG_CHROMANR_FILTER 0
++#define CONFIG_CHROMASHIFT_FILTER 0
++#define CONFIG_CIESCOPE_FILTER 0
++#define CONFIG_CODECVIEW_FILTER 0
++#define CONFIG_COLORBALANCE_FILTER 0
++#define CONFIG_COLORCHANNELMIXER_FILTER 0
++#define CONFIG_COLORCONTRAST_FILTER 0
++#define CONFIG_COLORCORRECT_FILTER 0
++#define CONFIG_COLORIZE_FILTER 0
++#define CONFIG_COLORKEY_FILTER 0
++#define CONFIG_COLORKEY_OPENCL_FILTER 0
++#define CONFIG_COLORHOLD_FILTER 0
++#define CONFIG_COLORLEVELS_FILTER 0
++#define CONFIG_COLORMAP_FILTER 0
++#define CONFIG_COLORMATRIX_FILTER 0
++#define CONFIG_COLORSPACE_FILTER 0
++#define CONFIG_COLORSPACE_CUDA_FILTER 0
++#define CONFIG_COLORTEMPERATURE_FILTER 0
++#define CONFIG_CONVOLUTION_FILTER 0
++#define CONFIG_CONVOLUTION_OPENCL_FILTER 0
++#define CONFIG_CONVOLVE_FILTER 0
++#define CONFIG_COPY_FILTER 0
++#define CONFIG_COREIMAGE_FILTER 0
++#define CONFIG_CORR_FILTER 0
++#define CONFIG_COVER_RECT_FILTER 0
++#define CONFIG_CROP_FILTER 0
++#define CONFIG_CROPDETECT_FILTER 0
++#define CONFIG_CUE_FILTER 0
++#define CONFIG_CURVES_FILTER 0
++#define CONFIG_DATASCOPE_FILTER 0
++#define CONFIG_DBLUR_FILTER 0
++#define CONFIG_DCTDNOIZ_FILTER 0
++#define CONFIG_DEBAND_FILTER 0
++#define CONFIG_DEBLOCK_FILTER 0
++#define CONFIG_DECIMATE_FILTER 0
++#define CONFIG_DECONVOLVE_FILTER 0
++#define CONFIG_DEDOT_FILTER 0
++#define CONFIG_DEFLATE_FILTER 0
++#define CONFIG_DEFLICKER_FILTER 0
++#define CONFIG_DEINTERLACE_QSV_FILTER 0
++#define CONFIG_DEINTERLACE_VAAPI_FILTER 0
++#define CONFIG_DEJUDDER_FILTER 0
++#define CONFIG_DELOGO_FILTER 0
++#define CONFIG_DENOISE_VAAPI_FILTER 0
++#define CONFIG_DERAIN_FILTER 0
++#define CONFIG_DESHAKE_FILTER 0
++#define CONFIG_DESHAKE_OPENCL_FILTER 0
++#define CONFIG_DESPILL_FILTER 0
++#define CONFIG_DETELECINE_FILTER 0
++#define CONFIG_DILATION_FILTER 0
++#define CONFIG_DILATION_OPENCL_FILTER 0
++#define CONFIG_DISPLACE_FILTER 0
++#define CONFIG_DNN_CLASSIFY_FILTER 0
++#define CONFIG_DNN_DETECT_FILTER 0
++#define CONFIG_DNN_PROCESSING_FILTER 0
++#define CONFIG_DOUBLEWEAVE_FILTER 0
++#define CONFIG_DRAWBOX_FILTER 0
++#define CONFIG_DRAWGRAPH_FILTER 0
++#define CONFIG_DRAWGRID_FILTER 0
++#define CONFIG_DRAWTEXT_FILTER 0
++#define CONFIG_EDGEDETECT_FILTER 0
++#define CONFIG_ELBG_FILTER 0
++#define CONFIG_ENTROPY_FILTER 0
++#define CONFIG_EPX_FILTER 0
++#define CONFIG_EQ_FILTER 0
++#define CONFIG_EROSION_FILTER 0
++#define CONFIG_EROSION_OPENCL_FILTER 0
++#define CONFIG_ESTDIF_FILTER 0
++#define CONFIG_EXPOSURE_FILTER 0
++#define CONFIG_EXTRACTPLANES_FILTER 0
++#define CONFIG_FADE_FILTER 0
++#define CONFIG_FEEDBACK_FILTER 0
++#define CONFIG_FFTDNOIZ_FILTER 0
++#define CONFIG_FFTFILT_FILTER 0
++#define CONFIG_FIELD_FILTER 0
++#define CONFIG_FIELDHINT_FILTER 0
++#define CONFIG_FIELDMATCH_FILTER 0
++#define CONFIG_FIELDORDER_FILTER 0
++#define CONFIG_FILLBORDERS_FILTER 0
++#define CONFIG_FIND_RECT_FILTER 0
++#define CONFIG_FLIP_VULKAN_FILTER 0
++#define CONFIG_FLOODFILL_FILTER 0
++#define CONFIG_FORMAT_FILTER 0
++#define CONFIG_FPS_FILTER 0
++#define CONFIG_FRAMEPACK_FILTER 0
++#define CONFIG_FRAMERATE_FILTER 0
++#define CONFIG_FRAMESTEP_FILTER 0
++#define CONFIG_FREEZEDETECT_FILTER 0
++#define CONFIG_FREEZEFRAMES_FILTER 0
++#define CONFIG_FREI0R_FILTER 0
++#define CONFIG_FSPP_FILTER 0
++#define CONFIG_GBLUR_FILTER 0
++#define CONFIG_GBLUR_VULKAN_FILTER 0
++#define CONFIG_GEQ_FILTER 0
++#define CONFIG_GRADFUN_FILTER 0
++#define CONFIG_GRAPHMONITOR_FILTER 0
++#define CONFIG_GRAYWORLD_FILTER 0
++#define CONFIG_GREYEDGE_FILTER 0
++#define CONFIG_GUIDED_FILTER 0
++#define CONFIG_HALDCLUT_FILTER 0
++#define CONFIG_HFLIP_FILTER 0
++#define CONFIG_HFLIP_VULKAN_FILTER 0
++#define CONFIG_HISTEQ_FILTER 0
++#define CONFIG_HISTOGRAM_FILTER 0
++#define CONFIG_HQDN3D_FILTER 0
++#define CONFIG_HQX_FILTER 0
++#define CONFIG_HSTACK_FILTER 0
++#define CONFIG_HSVHOLD_FILTER 0
++#define CONFIG_HSVKEY_FILTER 0
++#define CONFIG_HUE_FILTER 0
++#define CONFIG_HUESATURATION_FILTER 0
++#define CONFIG_HWDOWNLOAD_FILTER 0
++#define CONFIG_HWMAP_FILTER 0
++#define CONFIG_HWUPLOAD_FILTER 0
++#define CONFIG_HWUPLOAD_CUDA_FILTER 0
++#define CONFIG_HYSTERESIS_FILTER 0
++#define CONFIG_ICCDETECT_FILTER 0
++#define CONFIG_ICCGEN_FILTER 0
++#define CONFIG_IDENTITY_FILTER 0
++#define CONFIG_IDET_FILTER 0
++#define CONFIG_IL_FILTER 0
++#define CONFIG_INFLATE_FILTER 0
++#define CONFIG_INTERLACE_FILTER 0
++#define CONFIG_INTERLEAVE_FILTER 0
++#define CONFIG_KERNDEINT_FILTER 0
++#define CONFIG_KIRSCH_FILTER 0
++#define CONFIG_LAGFUN_FILTER 0
++#define CONFIG_LATENCY_FILTER 0
++#define CONFIG_LENSCORRECTION_FILTER 0
++#define CONFIG_LENSFUN_FILTER 0
++#define CONFIG_LIBPLACEBO_FILTER 0
++#define CONFIG_LIBVMAF_FILTER 0
++#define CONFIG_LIMITDIFF_FILTER 0
++#define CONFIG_LIMITER_FILTER 0
++#define CONFIG_LOOP_FILTER 0
++#define CONFIG_LUMAKEY_FILTER 0
++#define CONFIG_LUT_FILTER 0
++#define CONFIG_LUT1D_FILTER 0
++#define CONFIG_LUT2_FILTER 0
++#define CONFIG_LUT3D_FILTER 0
++#define CONFIG_LUTRGB_FILTER 0
++#define CONFIG_LUTYUV_FILTER 0
++#define CONFIG_MASKEDCLAMP_FILTER 0
++#define CONFIG_MASKEDMAX_FILTER 0
++#define CONFIG_MASKEDMERGE_FILTER 0
++#define CONFIG_MASKEDMIN_FILTER 0
++#define CONFIG_MASKEDTHRESHOLD_FILTER 0
++#define CONFIG_MASKFUN_FILTER 0
++#define CONFIG_MCDEINT_FILTER 0
++#define CONFIG_MEDIAN_FILTER 0
++#define CONFIG_MERGEPLANES_FILTER 0
++#define CONFIG_MESTIMATE_FILTER 0
++#define CONFIG_METADATA_FILTER 0
++#define CONFIG_MIDEQUALIZER_FILTER 0
++#define CONFIG_MINTERPOLATE_FILTER 0
++#define CONFIG_MIX_FILTER 0
++#define CONFIG_MONOCHROME_FILTER 0
++#define CONFIG_MORPHO_FILTER 0
++#define CONFIG_MPDECIMATE_FILTER 0
++#define CONFIG_MSAD_FILTER 0
++#define CONFIG_MULTIPLY_FILTER 0
++#define CONFIG_NEGATE_FILTER 0
++#define CONFIG_NLMEANS_FILTER 0
++#define CONFIG_NLMEANS_OPENCL_FILTER 0
++#define CONFIG_NLMEANS_VULKAN_FILTER 0
++#define CONFIG_NNEDI_FILTER 0
++#define CONFIG_NOFORMAT_FILTER 0
++#define CONFIG_NOISE_FILTER 0
++#define CONFIG_NORMALIZE_FILTER 0
++#define CONFIG_NULL_FILTER 0
++#define CONFIG_OCR_FILTER 0
++#define CONFIG_OCV_FILTER 0
++#define CONFIG_OSCILLOSCOPE_FILTER 0
++#define CONFIG_OVERLAY_FILTER 0
++#define CONFIG_OVERLAY_OPENCL_FILTER 0
++#define CONFIG_OVERLAY_QSV_FILTER 0
++#define CONFIG_OVERLAY_VAAPI_FILTER 0
++#define CONFIG_OVERLAY_VULKAN_FILTER 0
++#define CONFIG_OVERLAY_CUDA_FILTER 0
++#define CONFIG_OWDENOISE_FILTER 0
++#define CONFIG_PAD_FILTER 0
++#define CONFIG_PAD_OPENCL_FILTER 0
++#define CONFIG_PALETTEGEN_FILTER 0
++#define CONFIG_PALETTEUSE_FILTER 0
++#define CONFIG_PERMS_FILTER 0
++#define CONFIG_PERSPECTIVE_FILTER 0
++#define CONFIG_PHASE_FILTER 0
++#define CONFIG_PHOTOSENSITIVITY_FILTER 0
++#define CONFIG_PIXDESCTEST_FILTER 0
++#define CONFIG_PIXELIZE_FILTER 0
++#define CONFIG_PIXSCOPE_FILTER 0
++#define CONFIG_PP_FILTER 0
++#define CONFIG_PP7_FILTER 0
++#define CONFIG_PREMULTIPLY_FILTER 0
++#define CONFIG_PREWITT_FILTER 0
++#define CONFIG_PREWITT_OPENCL_FILTER 0
++#define CONFIG_PROCAMP_VAAPI_FILTER 0
++#define CONFIG_PROGRAM_OPENCL_FILTER 0
++#define CONFIG_PSEUDOCOLOR_FILTER 0
++#define CONFIG_PSNR_FILTER 0
++#define CONFIG_PULLUP_FILTER 0
++#define CONFIG_QP_FILTER 0
++#define CONFIG_RANDOM_FILTER 0
++#define CONFIG_READEIA608_FILTER 0
++#define CONFIG_READVITC_FILTER 0
++#define CONFIG_REALTIME_FILTER 0
++#define CONFIG_REMAP_FILTER 0
++#define CONFIG_REMAP_OPENCL_FILTER 0
++#define CONFIG_REMOVEGRAIN_FILTER 0
++#define CONFIG_REMOVELOGO_FILTER 0
++#define CONFIG_REPEATFIELDS_FILTER 0
++#define CONFIG_REVERSE_FILTER 0
++#define CONFIG_RGBASHIFT_FILTER 0
++#define CONFIG_ROBERTS_FILTER 0
++#define CONFIG_ROBERTS_OPENCL_FILTER 0
++#define CONFIG_ROTATE_FILTER 0
++#define CONFIG_SAB_FILTER 0
++#define CONFIG_SCALE_FILTER 0
++#define CONFIG_SCALE_CUDA_FILTER 0
++#define CONFIG_SCALE_NPP_FILTER 0
++#define CONFIG_SCALE_QSV_FILTER 0
++#define CONFIG_SCALE_VAAPI_FILTER 0
++#define CONFIG_SCALE_VULKAN_FILTER 0
++#define CONFIG_SCALE2REF_FILTER 0
++#define CONFIG_SCALE2REF_NPP_FILTER 0
++#define CONFIG_SCDET_FILTER 0
++#define CONFIG_SCHARR_FILTER 0
++#define CONFIG_SCROLL_FILTER 0
++#define CONFIG_SEGMENT_FILTER 0
++#define CONFIG_SELECT_FILTER 0
++#define CONFIG_SELECTIVECOLOR_FILTER 0
++#define CONFIG_SENDCMD_FILTER 0
++#define CONFIG_SEPARATEFIELDS_FILTER 0
++#define CONFIG_SETDAR_FILTER 0
++#define CONFIG_SETFIELD_FILTER 0
++#define CONFIG_SETPARAMS_FILTER 0
++#define CONFIG_SETPTS_FILTER 0
++#define CONFIG_SETRANGE_FILTER 0
++#define CONFIG_SETSAR_FILTER 0
++#define CONFIG_SETTB_FILTER 0
++#define CONFIG_SHARPEN_NPP_FILTER 0
++#define CONFIG_SHARPNESS_VAAPI_FILTER 0
++#define CONFIG_SHEAR_FILTER 0
++#define CONFIG_SHOWINFO_FILTER 0
++#define CONFIG_SHOWPALETTE_FILTER 0
++#define CONFIG_SHUFFLEFRAMES_FILTER 0
++#define CONFIG_SHUFFLEPIXELS_FILTER 0
++#define CONFIG_SHUFFLEPLANES_FILTER 0
++#define CONFIG_SIDEDATA_FILTER 0
++#define CONFIG_SIGNALSTATS_FILTER 0
++#define CONFIG_SIGNATURE_FILTER 0
++#define CONFIG_SITI_FILTER 0
++#define CONFIG_SMARTBLUR_FILTER 0
++#define CONFIG_SOBEL_FILTER 0
++#define CONFIG_SOBEL_OPENCL_FILTER 0
++#define CONFIG_SPLIT_FILTER 0
++#define CONFIG_SPP_FILTER 0
++#define CONFIG_SR_FILTER 0
++#define CONFIG_SSIM_FILTER 0
++#define CONFIG_SSIM360_FILTER 0
++#define CONFIG_STEREO3D_FILTER 0
++#define CONFIG_STREAMSELECT_FILTER 0
++#define CONFIG_SUBTITLES_FILTER 0
++#define CONFIG_SUPER2XSAI_FILTER 0
++#define CONFIG_SWAPRECT_FILTER 0
++#define CONFIG_SWAPUV_FILTER 0
++#define CONFIG_TBLEND_FILTER 0
++#define CONFIG_TELECINE_FILTER 0
++#define CONFIG_THISTOGRAM_FILTER 0
++#define CONFIG_THRESHOLD_FILTER 0
++#define CONFIG_THUMBNAIL_FILTER 0
++#define CONFIG_THUMBNAIL_CUDA_FILTER 0
++#define CONFIG_TILE_FILTER 0
++#define CONFIG_TINTERLACE_FILTER 0
++#define CONFIG_TLUT2_FILTER 0
++#define CONFIG_TMEDIAN_FILTER 0
++#define CONFIG_TMIDEQUALIZER_FILTER 0
++#define CONFIG_TMIX_FILTER 0
++#define CONFIG_TONEMAP_FILTER 0
++#define CONFIG_TONEMAP_OPENCL_FILTER 0
++#define CONFIG_TONEMAP_VAAPI_FILTER 0
++#define CONFIG_TPAD_FILTER 0
++#define CONFIG_TRANSPOSE_FILTER 0
++#define CONFIG_TRANSPOSE_NPP_FILTER 0
++#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
++#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
++#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
++#define CONFIG_TRIM_FILTER 0
++#define CONFIG_UNPREMULTIPLY_FILTER 0
++#define CONFIG_UNSHARP_FILTER 0
++#define CONFIG_UNSHARP_OPENCL_FILTER 0
++#define CONFIG_UNTILE_FILTER 0
++#define CONFIG_USPP_FILTER 0
++#define CONFIG_V360_FILTER 0
++#define CONFIG_VAGUEDENOISER_FILTER 0
++#define CONFIG_VARBLUR_FILTER 0
++#define CONFIG_VECTORSCOPE_FILTER 0
++#define CONFIG_VFLIP_FILTER 0
++#define CONFIG_VFLIP_VULKAN_FILTER 0
++#define CONFIG_VFRDET_FILTER 0
++#define CONFIG_VIBRANCE_FILTER 0
++#define CONFIG_VIDSTABDETECT_FILTER 0
++#define CONFIG_VIDSTABTRANSFORM_FILTER 0
++#define CONFIG_VIF_FILTER 0
++#define CONFIG_VIGNETTE_FILTER 0
++#define CONFIG_VMAFMOTION_FILTER 0
++#define CONFIG_VPP_QSV_FILTER 0
++#define CONFIG_VSTACK_FILTER 0
++#define CONFIG_W3FDIF_FILTER 0
++#define CONFIG_WAVEFORM_FILTER 0
++#define CONFIG_WEAVE_FILTER 0
++#define CONFIG_XBR_FILTER 0
++#define CONFIG_XCORRELATE_FILTER 0
++#define CONFIG_XFADE_FILTER 0
++#define CONFIG_XFADE_OPENCL_FILTER 0
++#define CONFIG_XFADE_VULKAN_FILTER 0
++#define CONFIG_XMEDIAN_FILTER 0
++#define CONFIG_XSTACK_FILTER 0
++#define CONFIG_YADIF_FILTER 0
++#define CONFIG_YADIF_CUDA_FILTER 0
++#define CONFIG_YADIF_VIDEOTOOLBOX_FILTER 0
++#define CONFIG_YAEPBLUR_FILTER 0
++#define CONFIG_ZMQ_FILTER 0
++#define CONFIG_ZOOMPAN_FILTER 0
++#define CONFIG_ZSCALE_FILTER 0
++#define CONFIG_HSTACK_VAAPI_FILTER 0
++#define CONFIG_VSTACK_VAAPI_FILTER 0
++#define CONFIG_XSTACK_VAAPI_FILTER 0
++#define CONFIG_HSTACK_QSV_FILTER 0
++#define CONFIG_VSTACK_QSV_FILTER 0
++#define CONFIG_XSTACK_QSV_FILTER 0
++#define CONFIG_ALLRGB_FILTER 0
++#define CONFIG_ALLYUV_FILTER 0
++#define CONFIG_CELLAUTO_FILTER 0
++#define CONFIG_COLOR_FILTER 0
++#define CONFIG_COLOR_VULKAN_FILTER 0
++#define CONFIG_COLORCHART_FILTER 0
++#define CONFIG_COLORSPECTRUM_FILTER 0
++#define CONFIG_COREIMAGESRC_FILTER 0
++#define CONFIG_DDAGRAB_FILTER 0
++#define CONFIG_FREI0R_SRC_FILTER 0
++#define CONFIG_GRADIENTS_FILTER 0
++#define CONFIG_HALDCLUTSRC_FILTER 0
++#define CONFIG_LIFE_FILTER 0
++#define CONFIG_MANDELBROT_FILTER 0
++#define CONFIG_MPTESTSRC_FILTER 0
++#define CONFIG_NULLSRC_FILTER 0
++#define CONFIG_OPENCLSRC_FILTER 0
++#define CONFIG_PAL75BARS_FILTER 0
++#define CONFIG_PAL100BARS_FILTER 0
++#define CONFIG_RGBTESTSRC_FILTER 0
++#define CONFIG_SIERPINSKI_FILTER 0
++#define CONFIG_SMPTEBARS_FILTER 0
++#define CONFIG_SMPTEHDBARS_FILTER 0
++#define CONFIG_TESTSRC_FILTER 0
++#define CONFIG_TESTSRC2_FILTER 0
++#define CONFIG_YUVTESTSRC_FILTER 0
++#define CONFIG_ZONEPLATE_FILTER 0
++#define CONFIG_NULLSINK_FILTER 0
++#define CONFIG_A3DSCOPE_FILTER 0
++#define CONFIG_ABITSCOPE_FILTER 0
++#define CONFIG_ADRAWGRAPH_FILTER 0
++#define CONFIG_AGRAPHMONITOR_FILTER 0
++#define CONFIG_AHISTOGRAM_FILTER 0
++#define CONFIG_APHASEMETER_FILTER 0
++#define CONFIG_AVECTORSCOPE_FILTER 0
++#define CONFIG_CONCAT_FILTER 0
++#define CONFIG_SHOWCQT_FILTER 0
++#define CONFIG_SHOWCWT_FILTER 0
++#define CONFIG_SHOWFREQS_FILTER 0
++#define CONFIG_SHOWSPATIAL_FILTER 0
++#define CONFIG_SHOWSPECTRUM_FILTER 0
++#define CONFIG_SHOWSPECTRUMPIC_FILTER 0
++#define CONFIG_SHOWVOLUME_FILTER 0
++#define CONFIG_SHOWWAVES_FILTER 0
++#define CONFIG_SHOWWAVESPIC_FILTER 0
++#define CONFIG_SPECTRUMSYNTH_FILTER 0
++#define CONFIG_AVSYNCTEST_FILTER 0
++#define CONFIG_AMOVIE_FILTER 0
++#define CONFIG_MOVIE_FILTER 0
++#define CONFIG_AFIFO_FILTER 0
++#define CONFIG_FIFO_FILTER 0
++#define CONFIG_AA_DEMUXER 0
++#define CONFIG_AAC_DEMUXER 0
++#define CONFIG_AAX_DEMUXER 0
++#define CONFIG_AC3_DEMUXER 0
++#define CONFIG_AC4_DEMUXER 0
++#define CONFIG_ACE_DEMUXER 0
++#define CONFIG_ACM_DEMUXER 0
++#define CONFIG_ACT_DEMUXER 0
++#define CONFIG_ADF_DEMUXER 0
++#define CONFIG_ADP_DEMUXER 0
++#define CONFIG_ADS_DEMUXER 0
++#define CONFIG_ADX_DEMUXER 0
++#define CONFIG_AEA_DEMUXER 0
++#define CONFIG_AFC_DEMUXER 0
++#define CONFIG_AIFF_DEMUXER 0
++#define CONFIG_AIX_DEMUXER 0
++#define CONFIG_ALP_DEMUXER 0
++#define CONFIG_AMR_DEMUXER 0
++#define CONFIG_AMRNB_DEMUXER 0
++#define CONFIG_AMRWB_DEMUXER 0
++#define CONFIG_ANM_DEMUXER 0
++#define CONFIG_APAC_DEMUXER 0
++#define CONFIG_APC_DEMUXER 0
++#define CONFIG_APE_DEMUXER 0
++#define CONFIG_APM_DEMUXER 0
++#define CONFIG_APNG_DEMUXER 0
++#define CONFIG_APTX_DEMUXER 0
++#define CONFIG_APTX_HD_DEMUXER 0
++#define CONFIG_AQTITLE_DEMUXER 0
++#define CONFIG_ARGO_ASF_DEMUXER 0
++#define CONFIG_ARGO_BRP_DEMUXER 0
++#define CONFIG_ARGO_CVG_DEMUXER 0
++#define CONFIG_ASF_DEMUXER 0
++#define CONFIG_ASF_O_DEMUXER 0
++#define CONFIG_ASS_DEMUXER 0
++#define CONFIG_AST_DEMUXER 0
++#define CONFIG_AU_DEMUXER 0
++#define CONFIG_AV1_DEMUXER 0
++#define CONFIG_AVI_DEMUXER 0
++#define CONFIG_AVISYNTH_DEMUXER 0
++#define CONFIG_AVR_DEMUXER 0
++#define CONFIG_AVS_DEMUXER 0
++#define CONFIG_AVS2_DEMUXER 0
++#define CONFIG_AVS3_DEMUXER 0
++#define CONFIG_BETHSOFTVID_DEMUXER 0
++#define CONFIG_BFI_DEMUXER 0
++#define CONFIG_BINTEXT_DEMUXER 0
++#define CONFIG_BINK_DEMUXER 0
++#define CONFIG_BINKA_DEMUXER 0
++#define CONFIG_BIT_DEMUXER 0
++#define CONFIG_BITPACKED_DEMUXER 0
++#define CONFIG_BMV_DEMUXER 0
++#define CONFIG_BFSTM_DEMUXER 0
++#define CONFIG_BRSTM_DEMUXER 0
++#define CONFIG_BOA_DEMUXER 0
++#define CONFIG_BONK_DEMUXER 0
++#define CONFIG_C93_DEMUXER 0
++#define CONFIG_CAF_DEMUXER 0
++#define CONFIG_CAVSVIDEO_DEMUXER 0
++#define CONFIG_CDG_DEMUXER 0
++#define CONFIG_CDXL_DEMUXER 0
++#define CONFIG_CINE_DEMUXER 0
++#define CONFIG_CODEC2_DEMUXER 0
++#define CONFIG_CODEC2RAW_DEMUXER 0
++#define CONFIG_CONCAT_DEMUXER 0
++#define CONFIG_DASH_DEMUXER 0
++#define CONFIG_DATA_DEMUXER 0
++#define CONFIG_DAUD_DEMUXER 0
++#define CONFIG_DCSTR_DEMUXER 0
++#define CONFIG_DERF_DEMUXER 0
++#define CONFIG_DFA_DEMUXER 0
++#define CONFIG_DFPWM_DEMUXER 0
++#define CONFIG_DHAV_DEMUXER 0
++#define CONFIG_DIRAC_DEMUXER 0
++#define CONFIG_DNXHD_DEMUXER 0
++#define CONFIG_DSF_DEMUXER 0
++#define CONFIG_DSICIN_DEMUXER 0
++#define CONFIG_DSS_DEMUXER 0
++#define CONFIG_DTS_DEMUXER 0
++#define CONFIG_DTSHD_DEMUXER 0
++#define CONFIG_DV_DEMUXER 0
++#define CONFIG_DVBSUB_DEMUXER 0
++#define CONFIG_DVBTXT_DEMUXER 0
++#define CONFIG_DXA_DEMUXER 0
++#define CONFIG_EA_DEMUXER 0
++#define CONFIG_EA_CDATA_DEMUXER 0
++#define CONFIG_EAC3_DEMUXER 0
++#define CONFIG_EPAF_DEMUXER 0
++#define CONFIG_EVC_DEMUXER 0
++#define CONFIG_FFMETADATA_DEMUXER 0
++#define CONFIG_FILMSTRIP_DEMUXER 0
++#define CONFIG_FITS_DEMUXER 0
++#define CONFIG_FLAC_DEMUXER 1
++#define CONFIG_FLIC_DEMUXER 0
++#define CONFIG_FLV_DEMUXER 0
++#define CONFIG_LIVE_FLV_DEMUXER 0
++#define CONFIG_FOURXM_DEMUXER 0
++#define CONFIG_FRM_DEMUXER 0
++#define CONFIG_FSB_DEMUXER 0
++#define CONFIG_FWSE_DEMUXER 0
++#define CONFIG_G722_DEMUXER 0
++#define CONFIG_G723_1_DEMUXER 0
++#define CONFIG_G726_DEMUXER 0
++#define CONFIG_G726LE_DEMUXER 0
++#define CONFIG_G729_DEMUXER 0
++#define CONFIG_GDV_DEMUXER 0
++#define CONFIG_GENH_DEMUXER 0
++#define CONFIG_GIF_DEMUXER 0
++#define CONFIG_GSM_DEMUXER 0
++#define CONFIG_GXF_DEMUXER 0
++#define CONFIG_H261_DEMUXER 0
++#define CONFIG_H263_DEMUXER 0
++#define CONFIG_H264_DEMUXER 0
++#define CONFIG_HCA_DEMUXER 0
++#define CONFIG_HCOM_DEMUXER 0
++#define CONFIG_HEVC_DEMUXER 0
++#define CONFIG_HLS_DEMUXER 0
++#define CONFIG_HNM_DEMUXER 0
++#define CONFIG_ICO_DEMUXER 0
++#define CONFIG_IDCIN_DEMUXER 0
++#define CONFIG_IDF_DEMUXER 0
++#define CONFIG_IFF_DEMUXER 0
++#define CONFIG_IFV_DEMUXER 0
++#define CONFIG_ILBC_DEMUXER 0
++#define CONFIG_IMAGE2_DEMUXER 0
++#define CONFIG_IMAGE2PIPE_DEMUXER 0
++#define CONFIG_IMAGE2_ALIAS_PIX_DEMUXER 0
++#define CONFIG_IMAGE2_BRENDER_PIX_DEMUXER 0
++#define CONFIG_IMF_DEMUXER 0
++#define CONFIG_INGENIENT_DEMUXER 0
++#define CONFIG_IPMOVIE_DEMUXER 0
++#define CONFIG_IPU_DEMUXER 0
++#define CONFIG_IRCAM_DEMUXER 0
++#define CONFIG_ISS_DEMUXER 0
++#define CONFIG_IV8_DEMUXER 0
++#define CONFIG_IVF_DEMUXER 0
++#define CONFIG_IVR_DEMUXER 0
++#define CONFIG_JACOSUB_DEMUXER 0
++#define CONFIG_JV_DEMUXER 0
++#define CONFIG_JPEGXL_ANIM_DEMUXER 0
++#define CONFIG_KUX_DEMUXER 0
++#define CONFIG_KVAG_DEMUXER 0
++#define CONFIG_LAF_DEMUXER 0
++#define CONFIG_LMLM4_DEMUXER 0
++#define CONFIG_LOAS_DEMUXER 0
++#define CONFIG_LUODAT_DEMUXER 0
++#define CONFIG_LRC_DEMUXER 0
++#define CONFIG_LVF_DEMUXER 0
++#define CONFIG_LXF_DEMUXER 0
++#define CONFIG_M4V_DEMUXER 0
++#define CONFIG_MCA_DEMUXER 0
++#define CONFIG_MCC_DEMUXER 0
++#define CONFIG_MATROSKA_DEMUXER 1
++#define CONFIG_MGSTS_DEMUXER 0
++#define CONFIG_MICRODVD_DEMUXER 0
++#define CONFIG_MJPEG_DEMUXER 0
++#define CONFIG_MJPEG_2000_DEMUXER 0
++#define CONFIG_MLP_DEMUXER 0
++#define CONFIG_MLV_DEMUXER 0
++#define CONFIG_MM_DEMUXER 0
++#define CONFIG_MMF_DEMUXER 0
++#define CONFIG_MODS_DEMUXER 0
++#define CONFIG_MOFLEX_DEMUXER 0
++#define CONFIG_MOV_DEMUXER 1
++#define CONFIG_MP3_DEMUXER 1
++#define CONFIG_MPC_DEMUXER 0
++#define CONFIG_MPC8_DEMUXER 0
++#define CONFIG_MPEGPS_DEMUXER 0
++#define CONFIG_MPEGTS_DEMUXER 0
++#define CONFIG_MPEGTSRAW_DEMUXER 0
++#define CONFIG_MPEGVIDEO_DEMUXER 0
++#define CONFIG_MPJPEG_DEMUXER 0
++#define CONFIG_MPL2_DEMUXER 0
++#define CONFIG_MPSUB_DEMUXER 0
++#define CONFIG_MSF_DEMUXER 0
++#define CONFIG_MSNWC_TCP_DEMUXER 0
++#define CONFIG_MSP_DEMUXER 0
++#define CONFIG_MTAF_DEMUXER 0
++#define CONFIG_MTV_DEMUXER 0
++#define CONFIG_MUSX_DEMUXER 0
++#define CONFIG_MV_DEMUXER 0
++#define CONFIG_MVI_DEMUXER 0
++#define CONFIG_MXF_DEMUXER 0
++#define CONFIG_MXG_DEMUXER 0
++#define CONFIG_NC_DEMUXER 0
++#define CONFIG_NISTSPHERE_DEMUXER 0
++#define CONFIG_NSP_DEMUXER 0
++#define CONFIG_NSV_DEMUXER 0
++#define CONFIG_NUT_DEMUXER 0
++#define CONFIG_NUV_DEMUXER 0
++#define CONFIG_OBU_DEMUXER 0
++#define CONFIG_OGG_DEMUXER 1
++#define CONFIG_OMA_DEMUXER 0
++#define CONFIG_PAF_DEMUXER 0
++#define CONFIG_PCM_ALAW_DEMUXER 0
++#define CONFIG_PCM_MULAW_DEMUXER 0
++#define CONFIG_PCM_VIDC_DEMUXER 0
++#define CONFIG_PCM_F64BE_DEMUXER 0
++#define CONFIG_PCM_F64LE_DEMUXER 0
++#define CONFIG_PCM_F32BE_DEMUXER 0
++#define CONFIG_PCM_F32LE_DEMUXER 0
++#define CONFIG_PCM_S32BE_DEMUXER 0
++#define CONFIG_PCM_S32LE_DEMUXER 0
++#define CONFIG_PCM_S24BE_DEMUXER 0
++#define CONFIG_PCM_S24LE_DEMUXER 0
++#define CONFIG_PCM_S16BE_DEMUXER 0
++#define CONFIG_PCM_S16LE_DEMUXER 0
++#define CONFIG_PCM_S8_DEMUXER 0
++#define CONFIG_PCM_U32BE_DEMUXER 0
++#define CONFIG_PCM_U32LE_DEMUXER 0
++#define CONFIG_PCM_U24BE_DEMUXER 0
++#define CONFIG_PCM_U24LE_DEMUXER 0
++#define CONFIG_PCM_U16BE_DEMUXER 0
++#define CONFIG_PCM_U16LE_DEMUXER 0
++#define CONFIG_PCM_U8_DEMUXER 0
++#define CONFIG_PDV_DEMUXER 0
++#define CONFIG_PJS_DEMUXER 0
++#define CONFIG_PMP_DEMUXER 0
++#define CONFIG_PP_BNK_DEMUXER 0
++#define CONFIG_PVA_DEMUXER 0
++#define CONFIG_PVF_DEMUXER 0
++#define CONFIG_QCP_DEMUXER 0
++#define CONFIG_R3D_DEMUXER 0
++#define CONFIG_RAWVIDEO_DEMUXER 0
++#define CONFIG_REALTEXT_DEMUXER 0
++#define CONFIG_REDSPARK_DEMUXER 0
++#define CONFIG_RKA_DEMUXER 0
++#define CONFIG_RL2_DEMUXER 0
++#define CONFIG_RM_DEMUXER 0
++#define CONFIG_ROQ_DEMUXER 0
++#define CONFIG_RPL_DEMUXER 0
++#define CONFIG_RSD_DEMUXER 0
++#define CONFIG_RSO_DEMUXER 0
++#define CONFIG_RTP_DEMUXER 0
++#define CONFIG_RTSP_DEMUXER 0
++#define CONFIG_S337M_DEMUXER 0
++#define CONFIG_SAMI_DEMUXER 0
++#define CONFIG_SAP_DEMUXER 0
++#define CONFIG_SBC_DEMUXER 0
++#define CONFIG_SBG_DEMUXER 0
++#define CONFIG_SCC_DEMUXER 0
++#define CONFIG_SCD_DEMUXER 0
++#define CONFIG_SDNS_DEMUXER 0
++#define CONFIG_SDP_DEMUXER 0
++#define CONFIG_SDR2_DEMUXER 0
++#define CONFIG_SDS_DEMUXER 0
++#define CONFIG_SDX_DEMUXER 0
++#define CONFIG_SEGAFILM_DEMUXER 0
++#define CONFIG_SER_DEMUXER 0
++#define CONFIG_SGA_DEMUXER 0
++#define CONFIG_SHORTEN_DEMUXER 0
++#define CONFIG_SIFF_DEMUXER 0
++#define CONFIG_SIMBIOSIS_IMX_DEMUXER 0
++#define CONFIG_SLN_DEMUXER 0
++#define CONFIG_SMACKER_DEMUXER 0
++#define CONFIG_SMJPEG_DEMUXER 0
++#define CONFIG_SMUSH_DEMUXER 0
++#define CONFIG_SOL_DEMUXER 0
++#define CONFIG_SOX_DEMUXER 0
++#define CONFIG_SPDIF_DEMUXER 0
++#define CONFIG_SRT_DEMUXER 0
++#define CONFIG_STR_DEMUXER 0
++#define CONFIG_STL_DEMUXER 0
++#define CONFIG_SUBVIEWER1_DEMUXER 0
++#define CONFIG_SUBVIEWER_DEMUXER 0
++#define CONFIG_SUP_DEMUXER 0
++#define CONFIG_SVAG_DEMUXER 0
++#define CONFIG_SVS_DEMUXER 0
++#define CONFIG_SWF_DEMUXER 0
++#define CONFIG_TAK_DEMUXER 0
++#define CONFIG_TEDCAPTIONS_DEMUXER 0
++#define CONFIG_THP_DEMUXER 0
++#define CONFIG_THREEDOSTR_DEMUXER 0
++#define CONFIG_TIERTEXSEQ_DEMUXER 0
++#define CONFIG_TMV_DEMUXER 0
++#define CONFIG_TRUEHD_DEMUXER 0
++#define CONFIG_TTA_DEMUXER 0
++#define CONFIG_TXD_DEMUXER 0
++#define CONFIG_TTY_DEMUXER 0
++#define CONFIG_TY_DEMUXER 0
++#define CONFIG_V210_DEMUXER 0
++#define CONFIG_V210X_DEMUXER 0
++#define CONFIG_VAG_DEMUXER 0
++#define CONFIG_VC1_DEMUXER 0
++#define CONFIG_VC1T_DEMUXER 0
++#define CONFIG_VIVIDAS_DEMUXER 0
++#define CONFIG_VIVO_DEMUXER 0
++#define CONFIG_VMD_DEMUXER 0
++#define CONFIG_VOBSUB_DEMUXER 0
++#define CONFIG_VOC_DEMUXER 0
++#define CONFIG_VPK_DEMUXER 0
++#define CONFIG_VPLAYER_DEMUXER 0
++#define CONFIG_VQF_DEMUXER 0
++#define CONFIG_VVC_DEMUXER 0
++#define CONFIG_W64_DEMUXER 0
++#define CONFIG_WADY_DEMUXER 0
++#define CONFIG_WAVARC_DEMUXER 0
++#define CONFIG_WAV_DEMUXER 1
++#define CONFIG_WC3_DEMUXER 0
++#define CONFIG_WEBM_DASH_MANIFEST_DEMUXER 0
++#define CONFIG_WEBVTT_DEMUXER 0
++#define CONFIG_WSAUD_DEMUXER 0
++#define CONFIG_WSD_DEMUXER 0
++#define CONFIG_WSVQA_DEMUXER 0
++#define CONFIG_WTV_DEMUXER 0
++#define CONFIG_WVE_DEMUXER 0
++#define CONFIG_WV_DEMUXER 0
++#define CONFIG_XA_DEMUXER 0
++#define CONFIG_XBIN_DEMUXER 0
++#define CONFIG_XMD_DEMUXER 0
++#define CONFIG_XMV_DEMUXER 0
++#define CONFIG_XVAG_DEMUXER 0
++#define CONFIG_XWMA_DEMUXER 0
++#define CONFIG_YOP_DEMUXER 0
++#define CONFIG_YUV4MPEGPIPE_DEMUXER 0
++#define CONFIG_IMAGE_BMP_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_CRI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_DDS_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_DPX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_EXR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_GEM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_GIF_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_HDR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_J2K_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEGLS_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEGXL_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PAM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PBM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PCX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PFM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGMYUV_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PHM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PHOTOCD_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PICTOR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PNG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PPM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PSD_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_QDRAW_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_QOI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SGI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SVG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SUNRAST_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_TIFF_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_VBN_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_WEBP_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
++#define CONFIG_LIBGME_DEMUXER 0
++#define CONFIG_LIBMODPLUG_DEMUXER 0
++#define CONFIG_LIBOPENMPT_DEMUXER 0
++#define CONFIG_VAPOURSYNTH_DEMUXER 0
++#define CONFIG_A64_MUXER 0
++#define CONFIG_AC3_MUXER 0
++#define CONFIG_AC4_MUXER 0
++#define CONFIG_ADTS_MUXER 0
++#define CONFIG_ADX_MUXER 0
++#define CONFIG_AIFF_MUXER 0
++#define CONFIG_ALP_MUXER 0
++#define CONFIG_AMR_MUXER 0
++#define CONFIG_AMV_MUXER 0
++#define CONFIG_APM_MUXER 0
++#define CONFIG_APNG_MUXER 0
++#define CONFIG_APTX_MUXER 0
++#define CONFIG_APTX_HD_MUXER 0
++#define CONFIG_ARGO_ASF_MUXER 0
++#define CONFIG_ARGO_CVG_MUXER 0
++#define CONFIG_ASF_MUXER 0
++#define CONFIG_ASS_MUXER 0
++#define CONFIG_AST_MUXER 0
++#define CONFIG_ASF_STREAM_MUXER 0
++#define CONFIG_AU_MUXER 0
++#define CONFIG_AVI_MUXER 0
++#define CONFIG_AVIF_MUXER 0
++#define CONFIG_AVM2_MUXER 0
++#define CONFIG_AVS2_MUXER 0
++#define CONFIG_AVS3_MUXER 0
++#define CONFIG_BIT_MUXER 0
++#define CONFIG_CAF_MUXER 0
++#define CONFIG_CAVSVIDEO_MUXER 0
++#define CONFIG_CODEC2_MUXER 0
++#define CONFIG_CODEC2RAW_MUXER 0
++#define CONFIG_CRC_MUXER 0
++#define CONFIG_DASH_MUXER 0
++#define CONFIG_DATA_MUXER 0
++#define CONFIG_DAUD_MUXER 0
++#define CONFIG_DFPWM_MUXER 0
++#define CONFIG_DIRAC_MUXER 0
++#define CONFIG_DNXHD_MUXER 0
++#define CONFIG_DTS_MUXER 0
++#define CONFIG_DV_MUXER 0
++#define CONFIG_EAC3_MUXER 0
++#define CONFIG_EVC_MUXER 0
++#define CONFIG_F4V_MUXER 0
++#define CONFIG_FFMETADATA_MUXER 0
++#define CONFIG_FIFO_MUXER 0
++#define CONFIG_FIFO_TEST_MUXER 0
++#define CONFIG_FILMSTRIP_MUXER 0
++#define CONFIG_FITS_MUXER 0
++#define CONFIG_FLAC_MUXER 0
++#define CONFIG_FLV_MUXER 0
++#define CONFIG_FRAMECRC_MUXER 0
++#define CONFIG_FRAMEHASH_MUXER 0
++#define CONFIG_FRAMEMD5_MUXER 0
++#define CONFIG_G722_MUXER 0
++#define CONFIG_G723_1_MUXER 0
++#define CONFIG_G726_MUXER 0
++#define CONFIG_G726LE_MUXER 0
++#define CONFIG_GIF_MUXER 0
++#define CONFIG_GSM_MUXER 0
++#define CONFIG_GXF_MUXER 0
++#define CONFIG_H261_MUXER 0
++#define CONFIG_H263_MUXER 0
++#define CONFIG_H264_MUXER 0
++#define CONFIG_HASH_MUXER 0
++#define CONFIG_HDS_MUXER 0
++#define CONFIG_HEVC_MUXER 0
++#define CONFIG_HLS_MUXER 0
++#define CONFIG_ICO_MUXER 0
++#define CONFIG_ILBC_MUXER 0
++#define CONFIG_IMAGE2_MUXER 0
++#define CONFIG_IMAGE2PIPE_MUXER 0
++#define CONFIG_IPOD_MUXER 0
++#define CONFIG_IRCAM_MUXER 0
++#define CONFIG_ISMV_MUXER 0
++#define CONFIG_IVF_MUXER 0
++#define CONFIG_JACOSUB_MUXER 0
++#define CONFIG_KVAG_MUXER 0
++#define CONFIG_LATM_MUXER 0
++#define CONFIG_LRC_MUXER 0
++#define CONFIG_M4V_MUXER 0
++#define CONFIG_MD5_MUXER 0
++#define CONFIG_MATROSKA_MUXER 0
++#define CONFIG_MATROSKA_AUDIO_MUXER 0
++#define CONFIG_MICRODVD_MUXER 0
++#define CONFIG_MJPEG_MUXER 0
++#define CONFIG_MLP_MUXER 0
++#define CONFIG_MMF_MUXER 0
++#define CONFIG_MOV_MUXER 0
++#define CONFIG_MP2_MUXER 0
++#define CONFIG_MP3_MUXER 0
++#define CONFIG_MP4_MUXER 0
++#define CONFIG_MPEG1SYSTEM_MUXER 0
++#define CONFIG_MPEG1VCD_MUXER 0
++#define CONFIG_MPEG1VIDEO_MUXER 0
++#define CONFIG_MPEG2DVD_MUXER 0
++#define CONFIG_MPEG2SVCD_MUXER 0
++#define CONFIG_MPEG2VIDEO_MUXER 0
++#define CONFIG_MPEG2VOB_MUXER 0
++#define CONFIG_MPEGTS_MUXER 0
++#define CONFIG_MPJPEG_MUXER 0
++#define CONFIG_MXF_MUXER 0
++#define CONFIG_MXF_D10_MUXER 0
++#define CONFIG_MXF_OPATOM_MUXER 0
++#define CONFIG_NULL_MUXER 0
++#define CONFIG_NUT_MUXER 0
++#define CONFIG_OBU_MUXER 0
++#define CONFIG_OGA_MUXER 0
++#define CONFIG_OGG_MUXER 0
++#define CONFIG_OGV_MUXER 0
++#define CONFIG_OMA_MUXER 0
++#define CONFIG_OPUS_MUXER 0
++#define CONFIG_PCM_ALAW_MUXER 0
++#define CONFIG_PCM_MULAW_MUXER 0
++#define CONFIG_PCM_VIDC_MUXER 0
++#define CONFIG_PCM_F64BE_MUXER 0
++#define CONFIG_PCM_F64LE_MUXER 0
++#define CONFIG_PCM_F32BE_MUXER 0
++#define CONFIG_PCM_F32LE_MUXER 0
++#define CONFIG_PCM_S32BE_MUXER 0
++#define CONFIG_PCM_S32LE_MUXER 0
++#define CONFIG_PCM_S24BE_MUXER 0
++#define CONFIG_PCM_S24LE_MUXER 0
++#define CONFIG_PCM_S16BE_MUXER 0
++#define CONFIG_PCM_S16LE_MUXER 0
++#define CONFIG_PCM_S8_MUXER 0
++#define CONFIG_PCM_U32BE_MUXER 0
++#define CONFIG_PCM_U32LE_MUXER 0
++#define CONFIG_PCM_U24BE_MUXER 0
++#define CONFIG_PCM_U24LE_MUXER 0
++#define CONFIG_PCM_U16BE_MUXER 0
++#define CONFIG_PCM_U16LE_MUXER 0
++#define CONFIG_PCM_U8_MUXER 0
++#define CONFIG_PSP_MUXER 0
++#define CONFIG_RAWVIDEO_MUXER 0
++#define CONFIG_RM_MUXER 0
++#define CONFIG_ROQ_MUXER 0
++#define CONFIG_RSO_MUXER 0
++#define CONFIG_RTP_MUXER 0
++#define CONFIG_RTP_MPEGTS_MUXER 0
++#define CONFIG_RTSP_MUXER 0
++#define CONFIG_SAP_MUXER 0
++#define CONFIG_SBC_MUXER 0
++#define CONFIG_SCC_MUXER 0
++#define CONFIG_SEGAFILM_MUXER 0
++#define CONFIG_SEGMENT_MUXER 0
++#define CONFIG_STREAM_SEGMENT_MUXER 0
++#define CONFIG_SMJPEG_MUXER 0
++#define CONFIG_SMOOTHSTREAMING_MUXER 0
++#define CONFIG_SOX_MUXER 0
++#define CONFIG_SPX_MUXER 0
++#define CONFIG_SPDIF_MUXER 0
++#define CONFIG_SRT_MUXER 0
++#define CONFIG_STREAMHASH_MUXER 0
++#define CONFIG_SUP_MUXER 0
++#define CONFIG_SWF_MUXER 0
++#define CONFIG_TEE_MUXER 0
++#define CONFIG_TG2_MUXER 0
++#define CONFIG_TGP_MUXER 0
++#define CONFIG_MKVTIMESTAMP_V2_MUXER 0
++#define CONFIG_TRUEHD_MUXER 0
++#define CONFIG_TTA_MUXER 0
++#define CONFIG_TTML_MUXER 0
++#define CONFIG_UNCODEDFRAMECRC_MUXER 0
++#define CONFIG_VC1_MUXER 0
++#define CONFIG_VC1T_MUXER 0
++#define CONFIG_VOC_MUXER 0
++#define CONFIG_VVC_MUXER 0
++#define CONFIG_W64_MUXER 0
++#define CONFIG_WAV_MUXER 0
++#define CONFIG_WEBM_MUXER 0
++#define CONFIG_WEBM_DASH_MANIFEST_MUXER 0
++#define CONFIG_WEBM_CHUNK_MUXER 0
++#define CONFIG_WEBP_MUXER 0
++#define CONFIG_WEBVTT_MUXER 0
++#define CONFIG_WSAUD_MUXER 0
++#define CONFIG_WTV_MUXER 0
++#define CONFIG_WV_MUXER 0
++#define CONFIG_YUV4MPEGPIPE_MUXER 0
++#define CONFIG_CHROMAPRINT_MUXER 0
++#define CONFIG_ASYNC_PROTOCOL 0
++#define CONFIG_BLURAY_PROTOCOL 0
++#define CONFIG_CACHE_PROTOCOL 0
++#define CONFIG_CONCAT_PROTOCOL 0
++#define CONFIG_CONCATF_PROTOCOL 0
++#define CONFIG_CRYPTO_PROTOCOL 0
++#define CONFIG_DATA_PROTOCOL 0
++#define CONFIG_FD_PROTOCOL 0
++#define CONFIG_FFRTMPCRYPT_PROTOCOL 0
++#define CONFIG_FFRTMPHTTP_PROTOCOL 0
++#define CONFIG_FILE_PROTOCOL 0
++#define CONFIG_FTP_PROTOCOL 0
++#define CONFIG_GOPHER_PROTOCOL 0
++#define CONFIG_GOPHERS_PROTOCOL 0
++#define CONFIG_HLS_PROTOCOL 0
++#define CONFIG_HTTP_PROTOCOL 0
++#define CONFIG_HTTPPROXY_PROTOCOL 0
++#define CONFIG_HTTPS_PROTOCOL 0
++#define CONFIG_ICECAST_PROTOCOL 0
++#define CONFIG_MMSH_PROTOCOL 0
++#define CONFIG_MMST_PROTOCOL 0
++#define CONFIG_MD5_PROTOCOL 0
++#define CONFIG_PIPE_PROTOCOL 0
++#define CONFIG_PROMPEG_PROTOCOL 0
++#define CONFIG_RTMP_PROTOCOL 0
++#define CONFIG_RTMPE_PROTOCOL 0
++#define CONFIG_RTMPS_PROTOCOL 0
++#define CONFIG_RTMPT_PROTOCOL 0
++#define CONFIG_RTMPTE_PROTOCOL 0
++#define CONFIG_RTMPTS_PROTOCOL 0
++#define CONFIG_RTP_PROTOCOL 0
++#define CONFIG_SCTP_PROTOCOL 0
++#define CONFIG_SRTP_PROTOCOL 0
++#define CONFIG_SUBFILE_PROTOCOL 0
++#define CONFIG_TEE_PROTOCOL 0
++#define CONFIG_TCP_PROTOCOL 0
++#define CONFIG_TLS_PROTOCOL 0
++#define CONFIG_UDP_PROTOCOL 0
++#define CONFIG_UDPLITE_PROTOCOL 0
++#define CONFIG_UNIX_PROTOCOL 0
++#define CONFIG_LIBAMQP_PROTOCOL 0
++#define CONFIG_LIBRIST_PROTOCOL 0
++#define CONFIG_LIBRTMP_PROTOCOL 0
++#define CONFIG_LIBRTMPE_PROTOCOL 0
++#define CONFIG_LIBRTMPS_PROTOCOL 0
++#define CONFIG_LIBRTMPT_PROTOCOL 0
++#define CONFIG_LIBRTMPTE_PROTOCOL 0
++#define CONFIG_LIBSRT_PROTOCOL 0
++#define CONFIG_LIBSSH_PROTOCOL 0
++#define CONFIG_LIBSMBCLIENT_PROTOCOL 0
++#define CONFIG_LIBZMQ_PROTOCOL 0
++#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
++#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
++#endif /* FFMPEG_CONFIG_COMPONENTS_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2 @@
++static const FFBitStreamFilter * const bitstream_filters[] = {
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,18 @@
++static const FFCodec * const codec_list[] = {
++    &ff_theora_decoder,
++    &ff_vp3_decoder,
++    &ff_vp8_decoder,
++    &ff_flac_decoder,
++    &ff_mp3_decoder,
++    &ff_vorbis_decoder,
++    &ff_pcm_alaw_decoder,
++    &ff_pcm_f32le_decoder,
++    &ff_pcm_mulaw_decoder,
++    &ff_pcm_s16be_decoder,
++    &ff_pcm_s16le_decoder,
++    &ff_pcm_s24be_decoder,
++    &ff_pcm_s24le_decoder,
++    &ff_pcm_s32le_decoder,
++    &ff_pcm_u8_decoder,
++    &ff_libopus_decoder,
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,9 @@
++static const AVCodecParser * const parser_list[] = {
++    &ff_flac_parser,
++    &ff_mpegaudio_parser,
++    &ff_opus_parser,
++    &ff_vorbis_parser,
++    &ff_vp3_parser,
++    &ff_vp8_parser,
++    &ff_vp9_parser,
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,8 @@
++static const AVInputFormat * const demuxer_list[] = {
++    &ff_flac_demuxer,
++    &ff_matroska_demuxer,
++    &ff_mov_demuxer,
++    &ff_mp3_demuxer,
++    &ff_ogg_demuxer,
++    &ff_wav_demuxer,
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2 @@
++static const FFOutputFormat * const muxer_list[] = {
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2 @@
++static const URLProtocol * const url_protocols[] = {
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,6 @@
++/* Generated by ffmpeg configure */
++#ifndef AVUTIL_AVCONFIG_H
++#define AVUTIL_AVCONFIG_H
++#define AV_HAVE_BIGENDIAN 0
++#define AV_HAVE_FAST_UNALIGNED 1
++#endif /* AVUTIL_AVCONFIG_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni
+--- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni	2000-01-01 00:00:00.000000000 +0800
+@@ -272,7 +272,7 @@ if ((is_apple && ffmpeg_branding == "Chr
+   ]
+ }
+ 
+-if ((current_cpu == "arm64" && ffmpeg_branding == "Chrome") || (current_cpu == "x64" && ffmpeg_branding == "Chrome") || (is_android && current_cpu == "arm" && arm_use_neon && ffmpeg_branding == "Chrome") || (is_android && current_cpu == "x86" && ffmpeg_branding == "Chrome") || (is_apple && ffmpeg_branding == "Chrome") || (is_win && ffmpeg_branding == "Chrome") || (use_linux_config && ffmpeg_branding == "Chrome") || (use_linux_config && ffmpeg_branding == "ChromeOS")) {
++if ((current_cpu == "arm64" && ffmpeg_branding == "Chrome") || (current_cpu == "x64" && ffmpeg_branding == "Chrome") || (current_cpu == "loong64" && ffmpeg_branding == "Chrome") || (is_android && current_cpu == "arm" && arm_use_neon && ffmpeg_branding == "Chrome") || (is_android && current_cpu == "x86" && ffmpeg_branding == "Chrome") || (is_apple && ffmpeg_branding == "Chrome") || (is_win && ffmpeg_branding == "Chrome") || (use_linux_config && ffmpeg_branding == "Chrome") || (use_linux_config && ffmpeg_branding == "ChromeOS")) {
+   ffmpeg_c_sources += [
+     "libavcodec/aac_ac3_parser.c",
+     "libavcodec/aac_parser.c",
+@@ -424,6 +424,19 @@ if ((is_android && current_cpu == "x64")
+   ]
+ }
+ 
++if ((use_linux_config && current_cpu == "loong64")) {
++  ffmpeg_c_sources += [
++    "libavutil/loongarch/cpu.c",
++    "libavcodec/loongarch/vp8dsp_init_loongarch.c",
++    "libavcodec/loongarch/h264chroma_init_loongarch.c",
++    "libavcodec/loongarch/h264dsp_init_loongarch.c",
++    "libavcodec/loongarch/h264qpel_init_loongarch.c",
++    "libavcodec/loongarch/videodsp_init.c",
++    "libavcodec/loongarch/h264_intrapred_init_loongarch.c",
++    "libavcodec/loongarch/hpeldsp_init_loongarch.c",
++  ]
++}
++
+ if ((is_android && current_cpu == "arm" && arm_use_neon) || (use_linux_config && current_cpu == "arm" && arm_use_neon) || (use_linux_config && current_cpu == "arm")) {
+   ffmpeg_c_sources += [
+     "libavcodec/arm/fft_init_arm.c",
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/libvpx/source/libvpx/vpx_dsp/loongarch/quantize_lsx.c b/qtwebengine/src/3rdparty/chromium/third_party/libvpx/source/libvpx/vpx_dsp/loongarch/quantize_lsx.c
+--- a/qtwebengine/src/3rdparty/chromium/third_party/libvpx/source/libvpx/vpx_dsp/loongarch/quantize_lsx.c	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/libvpx/source/libvpx/vpx_dsp/loongarch/quantize_lsx.c	2000-01-01 00:00:00.000000000 +0800
+@@ -11,6 +11,8 @@
+ #include "./vpx_config.h"
+ #include "./vpx_dsp_rtcd.h"
+ #include "vpx_util/loongson_intrinsics.h"
++#include "vp9/common/vp9_scan.h"
++#include "vp9/encoder/vp9_block.h"
+ 
+ static INLINE __m128i calculate_qcoeff(__m128i coeff, __m128i coeff_abs,
+                                        __m128i round, __m128i quant,
+@@ -89,14 +91,13 @@ static INLINE int16_t accumulate_eob(__m
+ 
+ #if !CONFIG_VP9_HIGHBITDEPTH
+ void vpx_quantize_b_lsx(const int16_t *coeff_ptr, intptr_t n_coeffs,
+-                        const int16_t *zbin_ptr, const int16_t *round_ptr,
+-                        const int16_t *quant_ptr,
+-                        const int16_t *quant_shift_ptr, int16_t *qcoeff_ptr,
+-                        int16_t *dqcoeff_ptr, const int16_t *dequant_ptr,
+-                        uint16_t *eob_ptr, const int16_t *scan,
+-                        const int16_t *iscan) {
++                        const struct macroblock_plane *const mb_plane,
++                        tran_low_t *qcoeff_ptr, tran_low_t *dqcoeff_ptr,
++                        const int16_t *dequant_ptr, uint16_t *eob_ptr,
++                        const struct ScanOrder *const scan_order) {
+   __m128i zero = __lsx_vldi(0);
+   int index = 16;
++  const int16_t *iscan = scan_order->iscan;
+ 
+   __m128i zbin, round, quant, dequant, quant_shift;
+   __m128i coeff0, coeff1;
+@@ -104,13 +105,11 @@ void vpx_quantize_b_lsx(const int16_t *c
+   __m128i cmp_mask0, cmp_mask1;
+   __m128i eob, eob0;
+ 
+-  (void)scan;
+-
+-  zbin = __lsx_vld(zbin_ptr, 0);
+-  round = __lsx_vld(round_ptr, 0);
+-  quant = __lsx_vld(quant_ptr, 0);
++  zbin = __lsx_vld(mb_plane->zbin, 0);
++  round = __lsx_vld(mb_plane->round, 0);
++  quant = __lsx_vld(mb_plane->quant, 0);
+   dequant = __lsx_vld(dequant_ptr, 0);
+-  quant_shift = __lsx_vld(quant_shift_ptr, 0);
++  quant_shift = __lsx_vld(mb_plane->quant_shift, 0);
+   // Handle one DC and first 15 AC.
+   DUP2_ARG2(__lsx_vld, coeff_ptr, 0, coeff_ptr, 16, coeff0, coeff1);
+   qcoeff0 = __lsx_vabsd_h(coeff0, zero);
+@@ -167,31 +166,27 @@ void vpx_quantize_b_lsx(const int16_t *c
+   *eob_ptr = accumulate_eob(eob);
+ }
+ 
+-void vpx_quantize_b_32x32_lsx(const int16_t *coeff_ptr, intptr_t n_coeffs,
+-                              const int16_t *zbin_ptr, const int16_t *round_ptr,
+-                              const int16_t *quant_ptr,
+-                              const int16_t *quant_shift_ptr,
+-                              int16_t *qcoeff_ptr, int16_t *dqcoeff_ptr,
++void vpx_quantize_b_32x32_lsx(const tran_low_t *coeff_ptr,
++                              const struct macroblock_plane *const mb_plane,
++                              tran_low_t *qcoeff_ptr, tran_low_t *dqcoeff_ptr,
+                               const int16_t *dequant_ptr, uint16_t *eob_ptr,
+-                              const int16_t *scan, const int16_t *iscan) {
++                              const struct ScanOrder *const scan_order) {
+   __m128i zero = __lsx_vldi(0);
+   int index;
++  const int16_t *iscan = scan_order->iscan;
+ 
+   __m128i zbin, round, quant, dequant, quant_shift;
+   __m128i coeff0, coeff1, qcoeff0, qcoeff1, cmp_mask0, cmp_mask1;
+   __m128i eob = zero, eob0;
+ 
+-  (void)scan;
+-  (void)n_coeffs;
+-
+-  zbin = __lsx_vld(zbin_ptr, 0);
++  zbin = __lsx_vld(mb_plane->zbin, 0);
+   zbin = __lsx_vsrari_h(zbin, 1);
+-  round = __lsx_vld(round_ptr, 0);
++  round = __lsx_vld(mb_plane->round, 0);
+   round = __lsx_vsrari_h(round, 1);
+ 
+-  quant = __lsx_vld(quant_ptr, 0);
++  quant = __lsx_vld(mb_plane->quant, 0);
+   dequant = __lsx_vld(dequant_ptr, 0);
+-  quant_shift = __lsx_vld(quant_shift_ptr, 0);
++  quant_shift = __lsx_vld(mb_plane->quant_shift, 0);
+   quant_shift = __lsx_vslli_h(quant_shift, 1);
+   // Handle one DC and first 15 AC.
+   DUP2_ARG2(__lsx_vld, coeff_ptr, 0, coeff_ptr, 16, coeff0, coeff1);
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/features.gni b/qtwebengine/src/3rdparty/chromium/sandbox/features.gni
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/features.gni	2000-01-01 00:00:00.000000000 +0800
 +++ b/qtwebengine/src/3rdparty/chromium/sandbox/features.gni	2000-01-01 00:00:00.000000000 +0800
@@ -188,7 +7222,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  // Also include asm/ptrace-abi.h since ptrace.h in older libc (for instance
  // the one in Ubuntu 16.04 LTS) is missing PTRACE_GET_THREAD_AREA.
  // asm/ptrace-abi.h doesn't exist on arm32 and PTRACE_GET_THREAD_AREA isn't
-@@ -329,7 +329,7 @@ ResultExpr RestrictFutex() {
+@@ -347,7 +347,7 @@ ResultExpr RestrictFutex() {
        .Cases({FUTEX_WAIT, FUTEX_WAKE, FUTEX_REQUEUE, FUTEX_CMP_REQUEUE,
  #if BUILDFLAG(ENABLE_MUTEX_PRIORITY_INHERITANCE)
                // Enable priority-inheritance operations.
@@ -197,7 +7231,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
                FUTEX_WAIT_REQUEUE_PI, FUTEX_CMP_REQUEUE_PI,
  #endif  // BUILDFLAG(ENABLE_MUTEX_PRIORITY_INHERITANCE)
                FUTEX_WAKE_OP, FUTEX_WAIT_BITSET, FUTEX_WAKE_BITSET},
-@@ -442,8 +442,11 @@ ResultExpr RestrictPtrace() {
+@@ -460,8 +460,11 @@ ResultExpr RestrictPtrace() {
    return Switch(request)
        .Cases({
  #if !defined(__aarch64__)
@@ -500,7 +7534,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  
  #if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM_FAMILY) || \
 -    defined(ARCH_CPU_MIPS_FAMILY)
-+    defined(ARCH_CPU_MIPS_FAMILY) || defined(ARCH_CPU_LOONG_FAMILY)
++    defined(ARCH_CPU_MIPS_FAMILY) || defined(ARCH_CPU_LOONGARCH_FAMILY)
  // Number that's not currently used by any Linux kernel ABIs.
  const int kInvalidSyscallNumber = 0x351d3;
  #else
@@ -559,7 +7593,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    alignas(16) char stack_buf[PTHREAD_STACK_MIN];
  #if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM_FAMILY) || \
 -    defined(ARCH_CPU_MIPS_FAMILY)
-+    defined(ARCH_CPU_MIPS_FAMILY) || defined(ARCH_CPU_LOONG_FAMILY)
++    defined(ARCH_CPU_MIPS_FAMILY) || defined(ARCH_CPU_LOONGARCH_FAMILY)
    // The stack grows downward.
    void* stack = stack_buf + sizeof(stack_buf);
  #else
@@ -579,7 +7613,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    // See kernel/fork.c in Linux. There is different ordering of sys_clone
    // parameters depending on CONFIG_CLONE_BACKWARDS* configuration options.
 -#if defined(ARCH_CPU_X86_64)
-+#if defined(ARCH_CPU_X86_64) || defined(ARCH_CPU_LOONG_FAMILY)
++#if defined(ARCH_CPU_X86_64) || defined(ARCH_CPU_LOONGARCH_FAMILY)
    return syscall(__NR_clone, flags, child_stack, ptid, ctid, tls);
  #elif defined(ARCH_CPU_X86) || defined(ARCH_CPU_ARM_FAMILY) || \
      defined(ARCH_CPU_MIPS_FAMILY)
@@ -712,7 +7746,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_command.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_command.h
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_command.h	2000-01-01 00:00:00.000000000 +0800
 +++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_command.h	2000-01-01 00:00:00.000000000 +0800
-@@ -41,6 +41,7 @@ enum BrokerCommand {
+@@ -42,6 +42,7 @@ enum BrokerCommand {
    COMMAND_RMDIR,
    COMMAND_STAT,
    COMMAND_STAT64,
@@ -2237,6 +9271,18 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
      case __NR_getdents:
  #endif
      case __NR_getdents64:
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_network_policy_linux.cc b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_network_policy_linux.cc
+--- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_network_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_network_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -255,7 +255,7 @@ ResultExpr NetworkProcessPolicy::Evaluat
+     case __NR_fdatasync:
+     case __NR_fsync:
+     case __NR_mremap:
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_getdents:
+ #endif
+     case __NR_getdents64:
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
 +++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
@@ -2252,7 +9298,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc	2000-01-01 00:00:00.000000000 +0800
 +++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -555,6 +555,7 @@ bpf_dsl::ResultExpr SandboxLinux::Handle
+@@ -552,6 +552,7 @@ bpf_dsl::ResultExpr SandboxLinux::Handle
    const bpf_dsl::ResultExpr handle_via_broker =
        bpf_dsl::Trap(syscall_broker::BrokerClient::SIGSYS_Handler,
                      broker_process_->GetBrokerClientSignalBased());
@@ -2260,7 +9306,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    if (sysno == __NR_fstatat_default) {
      // This may be an fstatat(fd, "", stat_buf, AT_EMPTY_PATH), which should be
      // rewritten as fstat(fd, stat_buf). This should be consistent with how the
-@@ -565,6 +566,15 @@ bpf_dsl::ResultExpr SandboxLinux::Handle
+@@ -562,6 +563,15 @@ bpf_dsl::ResultExpr SandboxLinux::Handle
      return bpf_dsl::If((flags & AT_EMPTY_PATH) == AT_EMPTY_PATH,
                         RewriteFstatatSIGSYS(BPFBasePolicy::GetFSDeniedErrno()))
          .Else(handle_via_broker);
@@ -2276,6952 +9322,6 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    } else {
      return handle_via_broker;
    }
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn b/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn
---- a/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
-@@ -765,6 +765,8 @@ skia_source_set("skia_opts") {
-     # Conditional and empty body needed to avoid assert() below.
-   } else if (current_cpu == "riscv64") {
-     # Conditional and empty body needed to avoid assert() below.
-+  } else if (current_cpu == "loong64") {
-+    # Conditional and empty body needed to avoid assert() below.
-   } else {
-     assert(false, "Unknown cpu target")
-   }
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/base.h b/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/base.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/base.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/base.h	2000-01-01 00:00:00.000000000 +0800
-@@ -107,6 +107,8 @@ extern "C" {
- #define OPENSSL_RISCV64
- #elif defined(__riscv) && __SIZEOF_POINTER__ == 4
- #define OPENSSL_32_BIT
-+#elif defined(__loongarch__) && __SIZEOF_POINTER__ == 8
-+#define OPENSSL_64_BIT
- #elif defined(__pnacl__)
- #define OPENSSL_32_BIT
- #define OPENSSL_PNACL
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/client/crashpad_client_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/client/crashpad_client_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/client/crashpad_client_linux.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/client/crashpad_client_linux.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -716,6 +716,10 @@ void CrashpadClient::DumpWithoutCrash(Na
-   memset(context->uc_mcontext.__reserved,
-          0,
-          sizeof(context->uc_mcontext.__reserved));
-+#elif defined(ARCH_CPU_LOONG_FAMILY)
-+  memset(context->uc_mcontext.__extcontext,
-+         0,
-+         sizeof(struct sctx_info));
- #endif
- 
-   siginfo_t siginfo;
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context.h	2000-01-01 00:00:00.000000000 +0800
-@@ -637,6 +637,56 @@ struct MinidumpContextMIPS64 {
-   uint64_t fir;
- };
- 
-+//! \brief LOONG64-specifc flags for MinidumpContextLOONG64::context_flags.
-+//! Based on minidump_cpu_loong64.h from breakpad
-+enum MinidumpContextLOONG64Flags : uint32_t {
-+  //! \brief Identifies the context structure as LOONG64.
-+  kMinidumpContextLOONG64 = 0x00800000,
-+
-+  //! \brief Indicates the validity of integer registers.
-+  //!
-+  //! Registers `0`-`31`, `csr_era` are valid.
-+  kMinidumpContextLOONG64Integer = kMinidumpContextLOONG64 | 0x00000002,
-+
-+  //! \brief Indicates the validity of floating point registers.
-+  //!
-+  //! Floating point registers `0`-`31`, `fcsr` and `fcc` are valid
-+  kMinidumpContextLOONG64FloatingPoint = kMinidumpContextLOONG64 | 0x00000004,
-+
-+  //! \brief Indicates the validity of all registers.
-+  kMinidumpContextLOONG64All = kMinidumpContextLOONG64Integer |
-+                              kMinidumpContextLOONG64FloatingPoint,
-+};
-+
-+//! \brief A LOONG64 CPU context (register state) carried in a minidump file.
-+struct MinidumpContextLOONG64 {
-+  uint64_t context_flags;
-+
-+  //! \brief General purpose registers.
-+  uint64_t regs[32];
-+
-+  //! \brief csr_era registers.
-+  uint64_t csr_era;
-+
-+  //! \brief FPU registers.
-+  union {
-+    struct {
-+      float _fp_fregs;
-+      uint32_t _fp_pad;
-+    } fregs[32];
-+    double dregs[32];
-+  } fpregs;
-+
-+  //! \brief Floating-point status and control register.
-+  uint64_t fcc;
-+
-+  //! \brief Floating-point control and status register.
-+  uint32_t fcsr;
-+
-+  //! \brief padding
-+  uint32_t _pad;
-+};
-+
- }  // namespace crashpad
- 
- #endif  // CRASHPAD_MINIDUMP_MINIDUMP_CONTEXT_H_
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -102,6 +102,13 @@ MinidumpContextWriter::CreateFromSnapsho
-       break;
-     }
- 
-+    case kCPUArchitectureLOONG64: {
-+      context = std::make_unique<MinidumpContextLOONG64Writer>();
-+      reinterpret_cast<MinidumpContextLOONG64Writer*>(context.get())
-+          ->InitializeFromSnapshot(context_snapshot->loong64);
-+      break;
-+    }
-+
-     default: {
-       LOG(ERROR) << "unknown context architecture "
-                  << context_snapshot->architecture;
-@@ -555,5 +562,44 @@ size_t MinidumpContextMIPS64Writer::Cont
-   DCHECK_GE(state(), kStateFrozen);
-   return sizeof(context_);
- }
-+
-+MinidumpContextLOONG64Writer::MinidumpContextLOONG64Writer()
-+    : MinidumpContextWriter(), context_() {
-+  context_.context_flags = kMinidumpContextLOONG64;
-+}
-+
-+MinidumpContextLOONG64Writer::~MinidumpContextLOONG64Writer() = default;
-+
-+void MinidumpContextLOONG64Writer::InitializeFromSnapshot(
-+    const CPUContextLOONG64* context_snapshot) {
-+  DCHECK_EQ(state(), kStateMutable);
-+  DCHECK_EQ(context_.context_flags, kMinidumpContextLOONG64);
-+
-+  context_.context_flags = kMinidumpContextLOONG64All;
-+
-+  static_assert(sizeof(context_.regs) == sizeof(context_snapshot->regs),
-+                "GPRs size mismatch");
-+  memcpy(context_.regs, context_snapshot->regs, sizeof(context_.regs));
-+  context_.csr_era = context_snapshot->csr_era;
-+
-+  static_assert(sizeof(context_.fpregs) == sizeof(context_snapshot->fpregs),
-+                "FPRs size mismatch");
-+  memcpy(context_.fpregs.dregs,
-+         context_snapshot->fpregs.dregs,
-+         sizeof(context_.fpregs.dregs));
-+  context_.fcsr = context_snapshot->fcsr;
-+  context_.fcc = context_snapshot->fcc;
-+}
-+
-+bool MinidumpContextLOONG64Writer::WriteObject(
-+    FileWriterInterface* file_writer) {
-+  DCHECK_EQ(state(), kStateWritable);
-+  return file_writer->Write(&context_, sizeof(context_));
-+}
-+
-+size_t MinidumpContextLOONG64Writer::ContextSize() const {
-+  DCHECK_GE(state(), kStateFrozen);
-+  return sizeof(context_);
-+}
- 
- }  // namespace crashpad
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_context_writer.h	2000-01-01 00:00:00.000000000 +0800
-@@ -369,6 +369,44 @@ class MinidumpContextMIPS64Writer final
-   MinidumpContextMIPS64 context_;
- };
- 
-+//! \brief The writer for a MinidumpContextLOONG64 structure in a minidump file.
-+class MinidumpContextLOONG64Writer final : public MinidumpContextWriter {
-+ public:
-+  MinidumpContextLOONG64Writer();
-+  ~MinidumpContextLOONG64Writer() override;
-+
-+  //! \brief Initializes the MinidumpContextLOONG64 based on \a context_snapshot.
-+  //!
-+  //! \param[in] context_snapshot The context snapshot to use as source data.
-+  //!
-+  //! \note Valid in #kStateMutable. No mutation of context() may be done before
-+  //!     calling this method, and it is not normally necessary to alter
-+  //!     context() after calling this method.
-+  void InitializeFromSnapshot(const CPUContextLOONG64* context_snapshot);
-+
-+  //! \brief Returns a pointer to the context structure that this object will
-+  //!     write.
-+  //!
-+  //! \attention This returns a non-`const` pointer to this object’s private
-+  //!     data so that a caller can populate the context structure directly.
-+  //!     This is done because providing setter interfaces to each field in the
-+  //!     context structure would be unwieldy and cumbersome. Care must be taken
-+  //!     to populate the context structure correctly. The context structure
-+  //!     must only be modified while this object is in the #kStateMutable
-+  //!     state.
-+  MinidumpContextLOONG64* context() { return &context_; }
-+
-+ protected:
-+  // MinidumpWritable:
-+  bool WriteObject(FileWriterInterface* file_writer) override;
-+
-+  // MinidumpContextWriter:
-+  size_t ContextSize() const override;
-+
-+ private:
-+  MinidumpContextLOONG64 context_;
-+};
-+
- }  // namespace crashpad
- 
- #endif  // CRASHPAD_MINIDUMP_MINIDUMP_CONTEXT_WRITER_H_
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_extensions.h	2000-01-01 00:00:00.000000000 +0800
-@@ -210,6 +210,9 @@ enum MinidumpCPUArchitecture : uint16_t
-   //! \deprecated Use #kMinidumpCPUArchitectureARM64 instead.
-   kMinidumpCPUArchitectureARM64Breakpad = 0x8003,
- 
-+  //! \brief Used by Breakpad for 64-bit LoongArch.
-+  kMinidumpCPUArchitectureLOONG64Breakpad = 0x8007,
-+
-   //! \brief Unknown CPU architecture.
-   kMinidumpCPUArchitectureUnknown = PROCESSOR_ARCHITECTURE_UNKNOWN,
- };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -175,6 +175,8 @@ std::string MinidumpMiscInfoDebugBuildSt
-   static constexpr char kCPU[] = "mips";
- #elif defined(ARCH_CPU_MIPS64EL)
-   static constexpr char kCPU[] = "mips64";
-+#elif defined(ARCH_CPU_LOONG64)
-+  static constexpr char kCPU[] = "loong64";
- #else
- #error define kCPU for this CPU
- #endif
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -132,6 +132,9 @@ void MinidumpSystemInfoWriter::Initializ
-     case kCPUArchitectureARM64:
-       cpu_architecture = kMinidumpCPUArchitectureARM64;
-       break;
-+    case kCPUArchitectureLOONG64:
-+      cpu_architecture = kMinidumpCPUArchitectureLOONG64Breakpad;
-+      break;
-     default:
-       NOTREACHED();
-       cpu_architecture = kMinidumpCPUArchitectureUnknown;
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/capture_memory.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -117,6 +117,11 @@ void CaptureMemory::PointedToByContext(c
-   for (size_t i = 0; i < std::size(context.mipsel->regs); ++i) {
-     MaybeCaptureMemoryAround(delegate, context.mipsel->regs[i]);
-   }
-+#elif defined(ARCH_CPU_LOONG64)
-+  MaybeCaptureMemoryAround(delegate, context.loong64->csr_era);
-+  for (size_t i = 0; i < std::size(context.loong64->regs); ++i) {
-+    MaybeCaptureMemoryAround(delegate, context.loong64->regs[i]);
-+  }
- #else
- #error Port.
- #endif
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_architecture.h	2000-01-01 00:00:00.000000000 +0800
-@@ -43,7 +43,10 @@ enum CPUArchitecture {
-   kCPUArchitectureMIPSEL,
- 
-   //! \brief 64-bit MIPSEL.
--  kCPUArchitectureMIPS64EL
-+  kCPUArchitectureMIPS64EL,
-+
-+  //! \brief 64-bit LOONGARCH.
-+  kCPUArchitectureLOONG64
- };
- 
- }  // namespace crashpad
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -170,6 +170,8 @@ uint64_t CPUContext::InstructionPointer(
-       return arm->pc;
-     case kCPUArchitectureARM64:
-       return arm64->pc;
-+    case kCPUArchitectureLOONG64:
-+      return loong64->csr_era;
-     default:
-       NOTREACHED();
-       return ~0ull;
-@@ -186,6 +188,8 @@ uint64_t CPUContext::StackPointer() cons
-       return arm->sp;
-     case kCPUArchitectureARM64:
-       return arm64->sp;
-+    case kCPUArchitectureLOONG64:
-+      return loong64->regs[3];
-     default:
-       NOTREACHED();
-       return ~0ull;
-@@ -226,6 +230,7 @@ bool CPUContext::Is64Bit() const {
-     case kCPUArchitectureX86_64:
-     case kCPUArchitectureARM64:
-     case kCPUArchitectureMIPS64EL:
-+    case kCPUArchitectureLOONG64:
-       return true;
-     case kCPUArchitectureX86:
-     case kCPUArchitectureARM:
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/cpu_context.h	2000-01-01 00:00:00.000000000 +0800
-@@ -362,6 +362,22 @@ struct CPUContextMIPS64 {
-   uint64_t fir;
- };
- 
-+//! \brief A context structure carrying LOONG64 CPU state.
-+struct CPUContextLOONG64 {
-+  uint64_t regs[32];
-+  uint64_t csr_era;
-+
-+  union {
-+    double dregs[32];
-+    struct {
-+      float _fp_fregs;
-+      uint32_t _fp_pad;
-+    } fregs[32];
-+  } fpregs;
-+  uint64_t fcc;
-+  uint32_t fcsr;
-+};
-+
- //! \brief A context structure capable of carrying the context of any supported
- //!     CPU architecture.
- struct CPUContext {
-@@ -402,6 +418,7 @@ struct CPUContext {
-     CPUContextARM64* arm64;
-     CPUContextMIPS* mipsel;
-     CPUContextMIPS64* mips64;
-+    CPUContextLOONG64* loong64;
-   };
- };
- 
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -266,6 +266,40 @@ void InitializeCPUContextARM64_OnlyFPSIM
-   context->fpcr = float_context.fpcr;
- }
- 
-+#elif defined(ARCH_CPU_LOONG64)
-+
-+void InitializeCPUContextLOONG64_NoFloatingPoint(
-+    const ThreadContext::t64_t& thread_context,
-+    CPUContextLOONG64* context) {
-+  static_assert(sizeof(context->regs) == sizeof(thread_context.regs),
-+                "gpr context size mismtach");
-+  memcpy(context->regs, thread_context.regs, sizeof(context->regs));
-+  context->csr_era = thread_context.csr_era;
-+
-+  memset(&context->fpregs, 0, sizeof(context->fpregs));
-+  context->fcc = 0;
-+  context->fcsr = 0;
-+}
-+
-+void InitializeCPUContextLOONG64_OnlyFPU(
-+    const FloatContext::f64_t& float_context,
-+    CPUContextLOONG64* context) {
-+  static_assert(sizeof(context->fpregs) == sizeof(float_context.fpregs),
-+                "fpu context size mismatch");
-+  memcpy(&context->fpregs, &float_context.fpregs, sizeof(context->fpregs));
-+  context->fcc = float_context.fcc;
-+  context->fcsr = float_context.fcsr;
-+}
-+
-+void InitializeCPUContextLOONG64(
-+    const ThreadContext::t64_t& thread_context,
-+    const FloatContext::f64_t& float_context,
-+    CPUContextLOONG64* context) {
-+  InitializeCPUContextLOONG64_NoFloatingPoint(thread_context, context);
-+
-+  InitializeCPUContextLOONG64_OnlyFPU(float_context, context);
-+}
-+
- #endif  // ARCH_CPU_X86_FAMILY
- 
- }  // namespace internal
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h	2000-01-01 00:00:00.000000000 +0800
-@@ -174,6 +174,45 @@ void InitializeCPUContextMIPS(
- 
- #endif  // ARCH_CPU_MIPS_FAMILY || DOXYGEN
- 
-+#if defined(ARCH_CPU_LOONG64) || DOXYGEN
-+
-+//! \brief Initializes GPR state in a CPUContextLOONG64 from a native context
-+//!     structure on Linux.
-+//!
-+//! Floating point state is initialized to zero.
-+//!
-+//! \param[in] thread_context The native thread context.
-+//! \param[out] context The CPUContextLOONG64 structure to initialize.
-+void InitializeCPUContextLOONG64_NoFloatingPoint(
-+    const ThreadContext::t64_t& thread_context,
-+    CPUContextLOONG64* context);
-+//! \brief Initializes FPU state in a CPUContextLOONG64 from a native fpu
-+//!     signal context structure on Linux.
-+//!
-+//! General purpose registers are not initialized.
-+//!
-+//! \param[in] float_context The native fpu context.
-+//! \param[out] context The CPUContextLOONG64 structure to initialize.
-+void InitializeCPUContextLOONG64_OnlyFPU(
-+    const FloatContext::f64_t& float_context,
-+    CPUContextLOONG64* context);
-+//! \brief Initializes a CPUContextLOONG64 structure from native context
-+//!     structures on Linux.
-+//!
-+//! This function has template specializations for LOONG64 architecture
-+//! contexts, using ContextTraits32 or ContextTraits64 as template parameter,
-+//! respectively.
-+//!
-+//! \param[in] thread_context The native thread context.
-+//! \param[in] float_context The native float context.
-+//! \param[out] context The CPUContextLOONG64 structure to initialize.
-+void InitializeCPUContextLOONG64(
-+    const ThreadContext::t64_t& thread_context,
-+    const FloatContext::f64_t& float_context,
-+    CPUContextLOONG64* context);
-+
-+#endif  // ARCH_CPU_LOONG64 || DOXYGEN
-+
- }  // namespace internal
- }  // namespace crashpad
- 
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -15,6 +15,7 @@
- #include "snapshot/linux/exception_snapshot_linux.h"
- 
- #include <signal.h>
-+#include <cstring>
- 
- #include "base/logging.h"
- #include "snapshot/linux/capture_memory_delegate_linux.h"
-@@ -325,6 +326,77 @@ bool ExceptionSnapshotLinux::ReadContext
-       reader, context_address, context_.mips64);
- }
- 
-+#elif defined(ARCH_CPU_LOONG64)
-+
-+static bool ReadContext(ProcessReaderLinux* reader,
-+                        LinuxVMAddress context_address,
-+                        typename ContextTraits64::CPUContext* dest_context) {
-+  const ProcessMemory* memory = reader->Memory();
-+  LinuxVMAddress gregs_address = context_address +
-+                                 offsetof(UContext<ContextTraits64>, mcontext);
-+  ThreadContext::t64_t thread_context;
-+  ContextTraits64::MContext mcontext;
-+  if (!memory->Read(gregs_address, sizeof(mcontext), &mcontext)) {
-+    LOG(ERROR) << "Couldn't read gregs";
-+    return false;
-+  }
-+  static_assert(sizeof(thread_context.regs) == sizeof(mcontext.gregs),
-+                "gpr context size mismtach");
-+  memcpy(thread_context.regs, mcontext.gregs, sizeof(mcontext.gregs));
-+  thread_context.csr_era = mcontext.pc;
-+  thread_context.orig_a0 = 0;
-+  thread_context.csr_badv = 0;
-+  InitializeCPUContextLOONG64_NoFloatingPoint(thread_context, dest_context);
-+  LinuxVMAddress reserved_address =
-+        context_address + offsetof(UContext<ContextTraits64>, mcontext.extcontext);
-+  if ((reserved_address & 15) != 0) {
-+    LOG(ERROR) << "invalid alignment 0x" << std::hex << reserved_address;
-+    return false;
-+   }
-+  constexpr VMSize kMaxContextSpace = 4096;
-+  ProcessMemoryRange range;
-+  if (!range.Initialize(memory, true, reserved_address, kMaxContextSpace)) {
-+    return false;
-+  }
-+  do {
-+    struct sctx_info head;
-+    if (!range.Read(reserved_address, sizeof(head), &head)) {
-+      LOG(ERROR) << "missing context terminator";
-+      return false;
-+    }
-+    reserved_address += sizeof(head);
-+    switch (head.magic) {
-+      case FPU_CTX_MAGIC:
-+        if (head.size != sizeof(struct fpu_context) + sizeof(head)) {
-+          LOG(ERROR) << "unexpected fpu context size " << head.size;
-+          return false;
-+        }
-+        FloatContext::f64_t fpucontext;
-+        if (!range.Read(reserved_address, sizeof(fpucontext), &fpucontext)) {
-+          LOG(ERROR) << "Couldn't read fpu " << head.size;
-+          return false;
-+        }
-+        InitializeCPUContextLOONG64_OnlyFPU(fpucontext, dest_context);
-+        return true;
-+      case 0:
-+        return true;
-+      default:
-+        LOG(ERROR) << "invalid magic number 0x" << std::hex << head.magic;
-+        return false;
-+    }
-+  } while (true);
-+}
-+
-+template <>
-+bool ExceptionSnapshotLinux::ReadContext<ContextTraits64>(
-+    ProcessReaderLinux* reader,
-+    LinuxVMAddress context_address) {
-+  context_.architecture = kCPUArchitectureLOONG64;
-+  context_.loong64 = &context_union_.loong64;
-+
-+  return internal::ReadContext(reader, context_address, context_.loong64);
-+}
-+
- #endif  // ARCH_CPU_X86_FAMILY
- 
- bool ExceptionSnapshotLinux::Initialize(
-@@ -355,10 +427,12 @@ bool ExceptionSnapshotLinux::Initialize(
-       return false;
-     }
-   } else {
-+#if !defined(ARCH_CPU_LOONG64)
-     if (!ReadContext<ContextTraits32>(process_reader, context_address) ||
-         !ReadSiginfo<Traits32>(process_reader, siginfo_address)) {
-       return false;
-     }
-+#endif
-   }
- 
-   CaptureMemoryDelegateLinux capture_memory_delegate(
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h	2000-01-01 00:00:00.000000000 +0800
-@@ -89,6 +89,8 @@ class ExceptionSnapshotLinux final : pub
- #elif defined(ARCH_CPU_MIPS_FAMILY)
-     CPUContextMIPS mipsel;
-     CPUContextMIPS64 mips64;
-+#elif defined(ARCH_CPU_LOONG64)
-+    CPUContextLOONG64 loong64;
- #endif
-   } context_union_;
-   CPUContext context_;
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -127,6 +127,8 @@ void ProcessReaderLinux::Thread::Initial
- #elif defined(ARCH_CPU_MIPS_FAMILY)
-   stack_pointer = reader->Is64Bit() ? thread_info.thread_context.t64.regs[29]
-                                     : thread_info.thread_context.t32.regs[29];
-+#elif defined(ARCH_CPU_LOONG64)
-+  stack_pointer = thread_info.thread_context.t64.regs[3];
- #else
- #error Port.
- #endif
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/signal_context.h	2000-01-01 00:00:00.000000000 +0800
-@@ -422,6 +422,46 @@ static_assert(offsetof(UContext<ContextT
-               "context offset mismatch");
- #endif
- 
-+#elif defined(ARCH_CPU_LOONG64)
-+
-+// See asm/sigcontext.h
-+struct MContext64 {
-+  uint64_t pc;
-+  uint64_t gregs[32];
-+  uint32_t flags;
-+  uint32_t padding;
-+  uint64_t extcontext[0] __attribute__((__aligned__(16)));
-+};
-+
-+struct ContextTraits64 : public Traits64 {
-+  using MContext = MContext64;
-+  using SignalThreadContext = ThreadContext::t64_t;
-+  using SignalFloatContext = FloatContext::f64_t;
-+  using CPUContext = CPUContextLOONG64;
-+};
-+
-+// See asm/ucontext.h
-+template <typename Traits>
-+struct UContext {
-+  typename Traits::ULong flags;
-+  typename Traits::Address link;
-+  SignalStack<Traits> stack;
-+  Sigset<Traits> sigmask;
-+  char alignment_padding_[8];
-+  char padding[128 - sizeof(Sigset<Traits>)];
-+  MContext64 mcontext;
-+};
-+
-+static_assert(offsetof(UContext<ContextTraits64>, mcontext) ==
-+                  offsetof(ucontext_t, uc_mcontext),
-+              "context offset mismatch");
-+static_assert(offsetof(UContext<ContextTraits64>, mcontext.gregs) ==
-+                  offsetof(ucontext_t, uc_mcontext.__gregs),
-+              "context offset mismatch");
-+static_assert(offsetof(UContext<ContextTraits64>, mcontext.extcontext) ==
-+                  offsetof(ucontext_t, uc_mcontext.__extcontext),
-+              "context offset mismatch");
-+
- #else
- #error Port.
- #endif  // ARCH_CPU_X86_FAMILY
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -205,6 +205,8 @@ CPUArchitecture SystemSnapshotLinux::Get
- #elif defined(ARCH_CPU_MIPS_FAMILY)
-   return process_reader_->Is64Bit() ? kCPUArchitectureMIPS64EL
-                                     : kCPUArchitectureMIPSEL;
-+#elif defined(ARCH_CPU_LOONG64)
-+  return kCPUArchitectureLOONG64;
- #else
- #error port to your architecture
- #endif
-@@ -220,6 +222,9 @@ uint32_t SystemSnapshotLinux::CPURevisio
- #elif defined(ARCH_CPU_MIPS_FAMILY)
-   // Not implementable on MIPS
-   return 0;
-+#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
-+  // Not implemented
-+  return 0;
- #else
- #error port to your architecture
- #endif
-@@ -240,6 +245,9 @@ std::string SystemSnapshotLinux::CPUVend
- #elif defined(ARCH_CPU_MIPS_FAMILY)
-   // Not implementable on MIPS
-   return std::string();
-+#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
-+  // Not implemented
-+  return std::string();
- #else
- #error port to your architecture
- #endif
-@@ -373,6 +381,9 @@ bool SystemSnapshotLinux::NXEnabled() co
- #elif defined(ARCH_CPU_MIPS_FAMILY)
-   // Not implementable on MIPS
-   return false;
-+#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
-+  // Not implemented
-+  return false;
- #else
- #error Port.
- #endif  // ARCH_CPU_X86_FAMILY
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -190,6 +190,13 @@ bool ThreadSnapshotLinux::Initialize(
-         thread.thread_info.float_context.f32,
-         context_.mipsel);
-   }
-+#elif defined(ARCH_CPU_LOONG64)
-+  context_.architecture = kCPUArchitectureLOONG64;
-+  context_.loong64 = &context_union_.loong64;
-+  InitializeCPUContextLOONG64<ContextTraits64>(
-+      thread.thread_info.thread_context.t64,
-+      thread.thread_info.float_context.f64,
-+      context_.loong64);
- #else
- #error Port.
- #endif
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h	2000-01-01 00:00:00.000000000 +0800
-@@ -74,6 +74,8 @@ class ThreadSnapshotLinux final : public
- #elif defined(ARCH_CPU_MIPS_FAMILY)
-     CPUContextMIPS mipsel;
-     CPUContextMIPS64 mips64;
-+#elif defined(ARCH_CPU_LOONG64)
-+    CPUContextLOONG64 loong64;
- #else
- #error Port.
- #endif  // ARCH_CPU_X86_FAMILY
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -266,6 +266,30 @@ bool MinidumpContextConverter::Initializ
-     context_.mips64->fir = src->fir;
- 
-     memcpy(&context_.mips64->fpregs, &src->fpregs, sizeof(src->fpregs));
-+  } else if (context_.architecture ==
-+             CPUArchitecture::kCPUArchitectureLOONG64) {
-+    context_memory_.resize(sizeof(CPUContextLOONG64));
-+    context_.loong64 =
-+        reinterpret_cast<CPUContextLOONG64*>(context_memory_.data());
-+    const MinidumpContextLOONG64* src =
-+        reinterpret_cast<const MinidumpContextLOONG64*>(minidump_context.data());
-+    if (minidump_context.size() < sizeof(MinidumpContextLOONG64)) {
-+      return false;
-+    }
-+
-+    if (!(src->context_flags & kMinidumpContextLOONG64)) {
-+      return false;
-+    }
-+
-+    for (size_t i = 0; i < std::size(src->regs); i++) {
-+      context_.loong64->regs[i] = src->regs[i];
-+    }
-+
-+    context_.loong64->csr_era = src->csr_era;
-+    context_.loong64->fcsr = src->fcsr;
-+    context_.loong64->fcc = src->fcc;
-+
-+    memcpy(&context_.loong64->fpregs, &src->fpregs, sizeof(src->fpregs));
-   } else {
-     // Architecture is listed as "unknown".
-     DLOG(ERROR) << "Unknown architecture";
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -68,6 +68,8 @@ CPUArchitecture SystemSnapshotMinidump::
-     case kMinidumpCPUArchitectureMIPS:
-       return kCPUArchitectureMIPSEL;
-     // No word on how MIPS64 is signalled
-+    case kMinidumpCPUArchitectureLOONG64Breakpad:
-+      return kCPUArchitectureLOONG64;
- 
-     default:
-       return CPUArchitecture::kCPUArchitectureUnknown;
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/ptracer.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -398,6 +398,37 @@ bool GetThreadArea64(pid_t tid,
-   return true;
- }
- 
-+#elif defined(ARCH_CPU_LOONG64)
-+
-+bool GetFloatingPointRegisters64(pid_t tid,
-+                                 FloatContext* context,
-+                                 bool can_log) {
-+  iovec iov;
-+  iov.iov_base = context;
-+  iov.iov_len = sizeof(*context);
-+  if (ptrace(
-+          PTRACE_GETREGSET, tid, reinterpret_cast<void*>(NT_PRFPREG), &iov) !=
-+      0) {
-+    PLOG_IF(ERROR, can_log) << "ptrace";
-+    return false;
-+  }
-+  if (iov.iov_len != sizeof(context->f64)) {
-+    LOG_IF(ERROR, can_log) << "Unexpected registers size " << iov.iov_len
-+                           << " != " << sizeof(context->f64);
-+    return false;
-+  }
-+  return true;
-+}
-+
-+bool GetThreadArea64(pid_t tid,
-+                     const ThreadContext& context,
-+                     LinuxVMAddress* address,
-+                     bool can_log) {
-+  // Thread pointer register
-+  *address = context.t64.regs[2];
-+  return true;
-+}
-+
- #else
- #error Port.
- #endif  // ARCH_CPU_X86_FAMILY
-@@ -500,12 +531,14 @@ bool Ptracer::GetThreadInfo(pid_t tid, T
-                            can_log_);
-   }
- 
-+#if !defined(ARCH_CPU_LOONG64)
-   return GetGeneralPurposeRegisters32(tid, &info->thread_context, can_log_) &&
-          GetFloatingPointRegisters32(tid, &info->float_context, can_log_) &&
-          GetThreadArea32(tid,
-                          info->thread_context,
-                          &info->thread_specific_data_address,
-                          can_log_);
-+#endif
- }
- 
- ssize_t Ptracer::ReadUpTo(pid_t pid,
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/linux/thread_info.h	2000-01-01 00:00:00.000000000 +0800
-@@ -80,6 +80,8 @@ union ThreadContext {
-     uint32_t cp0_status;
-     uint32_t cp0_cause;
-     uint32_t padding1_;
-+#elif defined(ARCH_CPU_LOONG_FAMILY)
-+    // 32 bit LoongArch not supported
- #else
- #error Port.
- #endif  // ARCH_CPU_X86_FAMILY
-@@ -133,12 +135,19 @@ union ThreadContext {
-     uint64_t cp0_badvaddr;
-     uint64_t cp0_status;
-     uint64_t cp0_cause;
-+#elif defined(ARCH_CPU_LOONG_FAMILY)
-+    // Reflects user_regs_struct in sys/user.h.
-+    uint64_t regs[32];
-+    uint64_t orig_a0;
-+    uint64_t csr_era;
-+    uint64_t csr_badv;
-+    uint64_t reserved[10];
- #else
- #error Port.
- #endif  // ARCH_CPU_X86_FAMILY
-   } t64;
- 
--#if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM64)
-+#if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM64) || defined(ARCH_CPU_LOONG_FAMILY)
-   using NativeThreadContext = user_regs_struct;
- #elif defined(ARCH_CPU_ARMEL)
-   using NativeThreadContext = user_regs;
-@@ -219,6 +228,8 @@ union FloatContext {
-     } fpregs[32];
-     uint32_t fpcsr;
-     uint32_t fpu_id;
-+#elif defined(ARCH_CPU_LOONG_FAMILY)
-+    // 32 bit LoongArch not supported
- #else
- #error Port.
- #endif  // ARCH_CPU_X86_FAMILY
-@@ -253,6 +264,11 @@ union FloatContext {
-     double fpregs[32];
-     uint32_t fpcsr;
-     uint32_t fpu_id;
-+#elif defined(ARCH_CPU_LOONG_FAMILY)
-+    // Reflects user_fp_struct in sys/user.h
-+    uint64_t fpregs[32];
-+    uint64_t fcc;
-+    uint32_t fcsr;
- #else
- #error Port.
- #endif  // ARCH_CPU_X86_FAMILY
-@@ -282,6 +298,8 @@ union FloatContext {
-   static_assert(sizeof(f64) == sizeof(user_fpsimd_struct), "Size mismatch");
- #elif defined(ARCH_CPU_MIPS_FAMILY)
- // No appropriate floating point context native type for available MIPS.
-+#elif defined(ARCH_CPU_LOONG_FAMILY)
-+  static_assert(sizeof(f64) == sizeof(user_fp_struct), "Size mismatch");
- #else
- #error Port.
- #endif  // ARCH_CPU_X86
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/misc/capture_context_linux.S	2000-01-01 00:00:00.000000000 +0800
-@@ -336,6 +336,51 @@ CAPTURECONTEXT_SYMBOL2:
- 
-   // TODO(https://crashpad.chromium.org/bug/300): save floating-point registers.
- 
-+#elif defined(__loongarch_lp64)
-+
-+#define MCONTEXT_GREG_SIZE 8
-+#define MCONTEXT_PC_OFFSET 176
-+#define MCONTEXT_GREGS_OFFSET 184
-+
-+#define STORE_GPR(X) st.d $r##X, $a0, MCONTEXT_GREGS_OFFSET + X * MCONTEXT_GREG_SIZE
-+#define STORE_PC st.d $ra, $a0, MCONTEXT_PC_OFFSET
-+
-+  STORE_PC
-+  STORE_GPR(0)
-+  STORE_GPR(1)
-+  STORE_GPR(2)
-+  STORE_GPR(3)
-+  STORE_GPR(4)
-+  STORE_GPR(5)
-+  STORE_GPR(6)
-+  STORE_GPR(7)
-+  STORE_GPR(8)
-+  STORE_GPR(9)
-+  STORE_GPR(10)
-+  STORE_GPR(11)
-+  STORE_GPR(12)
-+  STORE_GPR(13)
-+  STORE_GPR(14)
-+  STORE_GPR(15)
-+  STORE_GPR(16)
-+  STORE_GPR(17)
-+  STORE_GPR(18)
-+  STORE_GPR(19)
-+  STORE_GPR(20)
-+  STORE_GPR(21)
-+  STORE_GPR(22)
-+  STORE_GPR(23)
-+  STORE_GPR(24)
-+  STORE_GPR(25)
-+  STORE_GPR(26)
-+  STORE_GPR(27)
-+  STORE_GPR(28)
-+  STORE_GPR(29)
-+  STORE_GPR(30)
-+  STORE_GPR(31)
-+
-+  jirl $zero, $ra, 0
-+
-   ret
- #elif defined(__mips__)
-   .set noat
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc
---- a/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -237,6 +237,8 @@ std::string UserAgent() {
- #elif defined(ARCH_CPU_BIG_ENDIAN)
-     static constexpr char arch[] = "aarch64_be";
- #endif
-+#elif defined(ARCH_CPU_LOONG64)
-+    static constexpr char arch[] = "loong64";
- #else
- #error Port
- #endif
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js b/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js
---- a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js	2000-01-01 00:00:00.000000000 +0800
-@@ -52,11 +52,11 @@ export default commandLineArgs => ({
-         },
-       },
-     }),
--    terser({
--      compress: {
--        pure_funcs: commandLineArgs.configDCHECK ? ['Platform.DCHECK'] : [],
--      },
--    }),
-+    // terser({
-+    //   compress: {
-+    //     pure_funcs: commandLineArgs.configDCHECK ? ['Platform.DCHECK'] : [],
-+    //   },
-+    // }),
-     {
-       name: 'devtools-plugin',
-       resolveId(source, importer) {
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,749 @@
-+/* Automatically generated by configure - do not modify! */
-+#ifndef FFMPEG_CONFIG_H
-+#define FFMPEG_CONFIG_H
-+#define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-fft --enable-rdft --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\\\"-O2\\\"' --enable-decoder='theora,vp8' --enable-parser='vp3,vp8' --enable-lto --enable-pic --cc=clang --cxx=clang++ --ld=clang --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'"
-+#define FFMPEG_LICENSE "LGPL version 2.1 or later"
-+#define CONFIG_THIS_YEAR 2023
-+#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
-+#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
-+#define CC_IDENT "clang version 17.0.6"
-+#define OS_NAME linux
-+#define av_restrict restrict
-+#define EXTERN_PREFIX ""
-+#define EXTERN_ASM 
-+#define BUILDSUF ""
-+#define SLIBSUF ".so"
-+#define HAVE_MMX2 HAVE_MMXEXT
-+#define SWS_MAX_FILTER_SIZE 256
-+#define ARCH_AARCH64 0
-+#define ARCH_ALPHA 0
-+#define ARCH_ARM 0
-+#define ARCH_AVR32 0
-+#define ARCH_AVR32_AP 0
-+#define ARCH_AVR32_UC 0
-+#define ARCH_BFIN 0
-+#define ARCH_IA64 0
-+#define ARCH_LOONGARCH 1
-+#define ARCH_LOONGARCH32 0
-+#define ARCH_LOONGARCH64 1
-+#define ARCH_M68K 0
-+#define ARCH_MIPS 0
-+#define ARCH_MIPS64 0
-+#define ARCH_PARISC 0
-+#define ARCH_PPC 0
-+#define ARCH_PPC64 0
-+#define ARCH_RISCV 0
-+#define ARCH_S390 0
-+#define ARCH_SH4 0
-+#define ARCH_SPARC 0
-+#define ARCH_SPARC64 0
-+#define ARCH_TILEGX 0
-+#define ARCH_TILEPRO 0
-+#define ARCH_TOMI 0
-+#define ARCH_X86 0
-+#define ARCH_X86_32 0
-+#define ARCH_X86_64 0
-+#define HAVE_ARMV5TE 0
-+#define HAVE_ARMV6 0
-+#define HAVE_ARMV6T2 0
-+#define HAVE_ARMV8 0
-+#define HAVE_NEON 0
-+#define HAVE_VFP 0
-+#define HAVE_VFPV3 0
-+#define HAVE_SETEND 0
-+#define HAVE_ALTIVEC 0
-+#define HAVE_DCBZL 0
-+#define HAVE_LDBRX 0
-+#define HAVE_POWER8 0
-+#define HAVE_PPC4XX 0
-+#define HAVE_VSX 0
-+#define HAVE_RVV 0
-+#define HAVE_AESNI 0
-+#define HAVE_AMD3DNOW 0
-+#define HAVE_AMD3DNOWEXT 0
-+#define HAVE_AVX 0
-+#define HAVE_AVX2 0
-+#define HAVE_AVX512 0
-+#define HAVE_AVX512ICL 0
-+#define HAVE_FMA3 0
-+#define HAVE_FMA4 0
-+#define HAVE_MMX 0
-+#define HAVE_MMXEXT 0
-+#define HAVE_SSE 0
-+#define HAVE_SSE2 0
-+#define HAVE_SSE3 0
-+#define HAVE_SSE4 0
-+#define HAVE_SSE42 0
-+#define HAVE_SSSE3 0
-+#define HAVE_XOP 0
-+#define HAVE_CPUNOP 0
-+#define HAVE_I686 0
-+#define HAVE_MIPSFPU 0
-+#define HAVE_MIPS32R2 0
-+#define HAVE_MIPS32R5 0
-+#define HAVE_MIPS64R2 0
-+#define HAVE_MIPS32R6 0
-+#define HAVE_MIPS64R6 0
-+#define HAVE_MIPSDSP 0
-+#define HAVE_MIPSDSPR2 0
-+#define HAVE_MSA 0
-+#define HAVE_LOONGSON2 0
-+#define HAVE_LOONGSON3 0
-+#define HAVE_MMI 0
-+#define HAVE_LSX 0
-+#define HAVE_LASX 0
-+#define HAVE_ARMV5TE_EXTERNAL 0
-+#define HAVE_ARMV6_EXTERNAL 0
-+#define HAVE_ARMV6T2_EXTERNAL 0
-+#define HAVE_ARMV8_EXTERNAL 0
-+#define HAVE_NEON_EXTERNAL 0
-+#define HAVE_VFP_EXTERNAL 0
-+#define HAVE_VFPV3_EXTERNAL 0
-+#define HAVE_SETEND_EXTERNAL 0
-+#define HAVE_ALTIVEC_EXTERNAL 0
-+#define HAVE_DCBZL_EXTERNAL 0
-+#define HAVE_LDBRX_EXTERNAL 0
-+#define HAVE_POWER8_EXTERNAL 0
-+#define HAVE_PPC4XX_EXTERNAL 0
-+#define HAVE_VSX_EXTERNAL 0
-+#define HAVE_RVV_EXTERNAL 0
-+#define HAVE_AESNI_EXTERNAL 0
-+#define HAVE_AMD3DNOW_EXTERNAL 0
-+#define HAVE_AMD3DNOWEXT_EXTERNAL 0
-+#define HAVE_AVX_EXTERNAL 0
-+#define HAVE_AVX2_EXTERNAL 0
-+#define HAVE_AVX512_EXTERNAL 0
-+#define HAVE_AVX512ICL_EXTERNAL 0
-+#define HAVE_FMA3_EXTERNAL 0
-+#define HAVE_FMA4_EXTERNAL 0
-+#define HAVE_MMX_EXTERNAL 0
-+#define HAVE_MMXEXT_EXTERNAL 0
-+#define HAVE_SSE_EXTERNAL 0
-+#define HAVE_SSE2_EXTERNAL 0
-+#define HAVE_SSE3_EXTERNAL 0
-+#define HAVE_SSE4_EXTERNAL 0
-+#define HAVE_SSE42_EXTERNAL 0
-+#define HAVE_SSSE3_EXTERNAL 0
-+#define HAVE_XOP_EXTERNAL 0
-+#define HAVE_CPUNOP_EXTERNAL 0
-+#define HAVE_I686_EXTERNAL 0
-+#define HAVE_MIPSFPU_EXTERNAL 0
-+#define HAVE_MIPS32R2_EXTERNAL 0
-+#define HAVE_MIPS32R5_EXTERNAL 0
-+#define HAVE_MIPS64R2_EXTERNAL 0
-+#define HAVE_MIPS32R6_EXTERNAL 0
-+#define HAVE_MIPS64R6_EXTERNAL 0
-+#define HAVE_MIPSDSP_EXTERNAL 0
-+#define HAVE_MIPSDSPR2_EXTERNAL 0
-+#define HAVE_MSA_EXTERNAL 0
-+#define HAVE_LOONGSON2_EXTERNAL 0
-+#define HAVE_LOONGSON3_EXTERNAL 0
-+#define HAVE_MMI_EXTERNAL 0
-+#define HAVE_LSX_EXTERNAL 0
-+#define HAVE_LASX_EXTERNAL 0
-+#define HAVE_ARMV5TE_INLINE 0
-+#define HAVE_ARMV6_INLINE 0
-+#define HAVE_ARMV6T2_INLINE 0
-+#define HAVE_ARMV8_INLINE 0
-+#define HAVE_NEON_INLINE 0
-+#define HAVE_VFP_INLINE 0
-+#define HAVE_VFPV3_INLINE 0
-+#define HAVE_SETEND_INLINE 0
-+#define HAVE_ALTIVEC_INLINE 0
-+#define HAVE_DCBZL_INLINE 0
-+#define HAVE_LDBRX_INLINE 0
-+#define HAVE_POWER8_INLINE 0
-+#define HAVE_PPC4XX_INLINE 0
-+#define HAVE_VSX_INLINE 0
-+#define HAVE_RVV_INLINE 0
-+#define HAVE_AESNI_INLINE 0
-+#define HAVE_AMD3DNOW_INLINE 0
-+#define HAVE_AMD3DNOWEXT_INLINE 0
-+#define HAVE_AVX_INLINE 0
-+#define HAVE_AVX2_INLINE 0
-+#define HAVE_AVX512_INLINE 0
-+#define HAVE_AVX512ICL_INLINE 0
-+#define HAVE_FMA3_INLINE 0
-+#define HAVE_FMA4_INLINE 0
-+#define HAVE_MMX_INLINE 0
-+#define HAVE_MMXEXT_INLINE 0
-+#define HAVE_SSE_INLINE 0
-+#define HAVE_SSE2_INLINE 0
-+#define HAVE_SSE3_INLINE 0
-+#define HAVE_SSE4_INLINE 0
-+#define HAVE_SSE42_INLINE 0
-+#define HAVE_SSSE3_INLINE 0
-+#define HAVE_XOP_INLINE 0
-+#define HAVE_CPUNOP_INLINE 0
-+#define HAVE_I686_INLINE 0
-+#define HAVE_MIPSFPU_INLINE 0
-+#define HAVE_MIPS32R2_INLINE 0
-+#define HAVE_MIPS32R5_INLINE 0
-+#define HAVE_MIPS64R2_INLINE 0
-+#define HAVE_MIPS32R6_INLINE 0
-+#define HAVE_MIPS64R6_INLINE 0
-+#define HAVE_MIPSDSP_INLINE 0
-+#define HAVE_MIPSDSPR2_INLINE 0
-+#define HAVE_MSA_INLINE 0
-+#define HAVE_LOONGSON2_INLINE 0
-+#define HAVE_LOONGSON3_INLINE 0
-+#define HAVE_MMI_INLINE 0
-+#define HAVE_LSX_INLINE 0
-+#define HAVE_LASX_INLINE 0
-+#define HAVE_ALIGNED_STACK 0
-+#define HAVE_FAST_64BIT 1
-+#define HAVE_FAST_CLZ 1
-+#define HAVE_FAST_CMOV 0
-+#define HAVE_FAST_FLOAT16 0
-+#define HAVE_LOCAL_ALIGNED 1
-+#define HAVE_SIMD_ALIGN_16 0
-+#define HAVE_SIMD_ALIGN_32 1
-+#define HAVE_SIMD_ALIGN_64 0
-+#define HAVE_ATOMIC_CAS_PTR 0
-+#define HAVE_MACHINE_RW_BARRIER 0
-+#define HAVE_MEMORYBARRIER 0
-+#define HAVE_MM_EMPTY 0
-+#define HAVE_RDTSC 0
-+#define HAVE_SEM_TIMEDWAIT 1
-+#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
-+#define HAVE_INLINE_ASM 1
-+#define HAVE_SYMVER 0
-+#define HAVE_X86ASM 0
-+#define HAVE_BIGENDIAN 0
-+#define HAVE_FAST_UNALIGNED 1
-+#define HAVE_ARPA_INET_H 0
-+#define HAVE_ASM_TYPES_H 1
-+#define HAVE_CDIO_PARANOIA_H 0
-+#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
-+#define HAVE_CUDA_H 0
-+#define HAVE_DISPATCH_DISPATCH_H 0
-+#define HAVE_DEV_BKTR_IOCTL_BT848_H 0
-+#define HAVE_DEV_BKTR_IOCTL_METEOR_H 0
-+#define HAVE_DEV_IC_BT8XX_H 0
-+#define HAVE_DEV_VIDEO_BKTR_IOCTL_BT848_H 0
-+#define HAVE_DEV_VIDEO_METEOR_IOCTL_METEOR_H 0
-+#define HAVE_DIRECT_H 0
-+#define HAVE_DIRENT_H 1
-+#define HAVE_DXGIDEBUG_H 0
-+#define HAVE_DXVA_H 0
-+#define HAVE_ES2_GL_H 0
-+#define HAVE_GSM_H 0
-+#define HAVE_IO_H 0
-+#define HAVE_LINUX_DMA_BUF_H 0
-+#define HAVE_LINUX_PERF_EVENT_H 1
-+#define HAVE_MACHINE_IOCTL_BT848_H 0
-+#define HAVE_MACHINE_IOCTL_METEOR_H 0
-+#define HAVE_MALLOC_H 1
-+#define HAVE_OPENCV2_CORE_CORE_C_H 0
-+#define HAVE_OPENGL_GL3_H 0
-+#define HAVE_POLL_H 1
-+#define HAVE_SYS_PARAM_H 1
-+#define HAVE_SYS_RESOURCE_H 1
-+#define HAVE_SYS_SELECT_H 1
-+#define HAVE_SYS_SOUNDCARD_H 1
-+#define HAVE_SYS_TIME_H 1
-+#define HAVE_SYS_UN_H 1
-+#define HAVE_SYS_VIDEOIO_H 0
-+#define HAVE_TERMIOS_H 1
-+#define HAVE_UDPLITE_H 0
-+#define HAVE_UNISTD_H 1
-+#define HAVE_VALGRIND_VALGRIND_H 0
-+#define HAVE_WINDOWS_H 0
-+#define HAVE_WINSOCK2_H 0
-+#define HAVE_INTRINSICS_NEON 0
-+#define HAVE_ATANF 1
-+#define HAVE_ATAN2F 1
-+#define HAVE_CBRT 1
-+#define HAVE_CBRTF 1
-+#define HAVE_COPYSIGN 1
-+#define HAVE_COSF 1
-+#define HAVE_ERF 1
-+#define HAVE_EXP2 1
-+#define HAVE_EXP2F 1
-+#define HAVE_EXPF 1
-+#define HAVE_HYPOT 1
-+#define HAVE_ISFINITE 1
-+#define HAVE_ISINF 1
-+#define HAVE_ISNAN 1
-+#define HAVE_LDEXPF 1
-+#define HAVE_LLRINT 1
-+#define HAVE_LLRINTF 1
-+#define HAVE_LOG2 1
-+#define HAVE_LOG2F 1
-+#define HAVE_LOG10F 1
-+#define HAVE_LRINT 1
-+#define HAVE_LRINTF 1
-+#define HAVE_POWF 1
-+#define HAVE_RINT 1
-+#define HAVE_ROUND 1
-+#define HAVE_ROUNDF 1
-+#define HAVE_SINF 1
-+#define HAVE_TRUNC 1
-+#define HAVE_TRUNCF 1
-+#define HAVE_DOS_PATHS 0
-+#define HAVE_LIBC_MSVCRT 0
-+#define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
-+#define HAVE_SECTION_DATA_REL_RO 1
-+#define HAVE_THREADS 1
-+#define HAVE_UWP 0
-+#define HAVE_WINRT 0
-+#define HAVE_ACCESS 1
-+#define HAVE_ALIGNED_MALLOC 0
-+#define HAVE_ARC4RANDOM 0
-+#define HAVE_CLOCK_GETTIME 1
-+#define HAVE_CLOSESOCKET 0
-+#define HAVE_COMMANDLINETOARGVW 0
-+#define HAVE_FCNTL 1
-+#define HAVE_GETADDRINFO 0
-+#define HAVE_GETAUXVAL 1
-+#define HAVE_GETENV 1
-+#define HAVE_GETHRTIME 0
-+#define HAVE_GETOPT 1
-+#define HAVE_GETMODULEHANDLE 0
-+#define HAVE_GETPROCESSAFFINITYMASK 0
-+#define HAVE_GETPROCESSMEMORYINFO 0
-+#define HAVE_GETPROCESSTIMES 0
-+#define HAVE_GETRUSAGE 1
-+#define HAVE_GETSTDHANDLE 0
-+#define HAVE_GETSYSTEMTIMEASFILETIME 0
-+#define HAVE_GETTIMEOFDAY 1
-+#define HAVE_GLOB 1
-+#define HAVE_GLXGETPROCADDRESS 0
-+#define HAVE_GMTIME_R 1
-+#define HAVE_INET_ATON 0
-+#define HAVE_ISATTY 1
-+#define HAVE_KBHIT 0
-+#define HAVE_LOCALTIME_R 1
-+#define HAVE_LSTAT 1
-+#define HAVE_LZO1X_999_COMPRESS 0
-+#define HAVE_MACH_ABSOLUTE_TIME 0
-+#define HAVE_MAPVIEWOFFILE 0
-+#define HAVE_MEMALIGN 1
-+#define HAVE_MKSTEMP 1
-+#define HAVE_MMAP 1
-+#define HAVE_MPROTECT 1
-+#define HAVE_NANOSLEEP 1
-+#define HAVE_PEEKNAMEDPIPE 0
-+#define HAVE_POSIX_MEMALIGN 1
-+#define HAVE_PRCTL 1
-+#define HAVE_PTHREAD_CANCEL 1
-+#define HAVE_SCHED_GETAFFINITY 1
-+#define HAVE_SECITEMIMPORT 0
-+#define HAVE_SETCONSOLETEXTATTRIBUTE 0
-+#define HAVE_SETCONSOLECTRLHANDLER 0
-+#define HAVE_SETDLLDIRECTORY 0
-+#define HAVE_SETMODE 0
-+#define HAVE_SETRLIMIT 1
-+#define HAVE_SLEEP 0
-+#define HAVE_STRERROR_R 1
-+#define HAVE_SYSCONF 1
-+#define HAVE_SYSCTL 0
-+#define HAVE_USLEEP 1
-+#define HAVE_UTGETOSTYPEFROMSTRING 0
-+#define HAVE_VIRTUALALLOC 0
-+#define HAVE_WGLGETPROCADDRESS 0
-+#define HAVE_BCRYPT 0
-+#define HAVE_VAAPI_DRM 0
-+#define HAVE_VAAPI_X11 0
-+#define HAVE_VDPAU_X11 0
-+#define HAVE_PTHREADS 1
-+#define HAVE_OS2THREADS 0
-+#define HAVE_W32THREADS 0
-+#define HAVE_AS_ARCH_DIRECTIVE 0
-+#define HAVE_AS_DN_DIRECTIVE 0
-+#define HAVE_AS_FPU_DIRECTIVE 0
-+#define HAVE_AS_FUNC 0
-+#define HAVE_AS_OBJECT_ARCH 0
-+#define HAVE_ASM_MOD_Q 0
-+#define HAVE_BLOCKS_EXTENSION 0
-+#define HAVE_EBP_AVAILABLE 0
-+#define HAVE_EBX_AVAILABLE 0
-+#define HAVE_GNU_AS 0
-+#define HAVE_GNU_WINDRES 0
-+#define HAVE_IBM_ASM 0
-+#define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
-+#define HAVE_INLINE_ASM_LABELS 1
-+#define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
-+#define HAVE_PRAGMA_DEPRECATED 1
-+#define HAVE_RSYNC_CONTIMEOUT 1
-+#define HAVE_SYMVER_ASM_LABEL 1
-+#define HAVE_SYMVER_GNU_ASM 1
-+#define HAVE_VFP_ARGS 0
-+#define HAVE_XFORM_ASM 0
-+#define HAVE_XMM_CLOBBERS 0
-+#define HAVE_DPI_AWARENESS_CONTEXT 0
-+#define HAVE_IDXGIOUTPUT5 0
-+#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
-+#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
-+#define HAVE_KCMVIDEOCODECTYPE_VP9 0
-+#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
-+#define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
-+#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
-+#define HAVE_SOCKLEN_T 0
-+#define HAVE_STRUCT_ADDRINFO 0
-+#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
-+#define HAVE_STRUCT_IP_MREQ_SOURCE 0
-+#define HAVE_STRUCT_IPV6_MREQ 0
-+#define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
-+#define HAVE_STRUCT_POLLFD 0
-+#define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
-+#define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
-+#define HAVE_STRUCT_SOCKADDR_IN6 0
-+#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
-+#define HAVE_STRUCT_SOCKADDR_STORAGE 0
-+#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
-+#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 0
-+#define HAVE_GZIP 1
-+#define HAVE_LIBDRM_GETFB2 0
-+#define HAVE_MAKEINFO 1
-+#define HAVE_MAKEINFO_HTML 1
-+#define HAVE_OPENCL_D3D11 0
-+#define HAVE_OPENCL_DRM_ARM 0
-+#define HAVE_OPENCL_DRM_BEIGNET 0
-+#define HAVE_OPENCL_DXVA2 0
-+#define HAVE_OPENCL_VAAPI_BEIGNET 0
-+#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
-+#define HAVE_PERL 1
-+#define HAVE_POD2MAN 0
-+#define HAVE_TEXI2HTML 0
-+#define HAVE_XMLLINT 1
-+#define HAVE_ZLIB_GZIP 0
-+#define CONFIG_DOC 0
-+#define CONFIG_HTMLPAGES 0
-+#define CONFIG_MANPAGES 0
-+#define CONFIG_PODPAGES 0
-+#define CONFIG_TXTPAGES 0
-+#define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
-+#define CONFIG_AVIO_READING_EXAMPLE 1
-+#define CONFIG_DECODE_AUDIO_EXAMPLE 1
-+#define CONFIG_DECODE_VIDEO_EXAMPLE 1
-+#define CONFIG_DEMUXING_DECODING_EXAMPLE 1
-+#define CONFIG_ENCODE_AUDIO_EXAMPLE 1
-+#define CONFIG_ENCODE_VIDEO_EXAMPLE 1
-+#define CONFIG_EXTRACT_MVS_EXAMPLE 1
-+#define CONFIG_FILTER_AUDIO_EXAMPLE 0
-+#define CONFIG_FILTERING_AUDIO_EXAMPLE 0
-+#define CONFIG_FILTERING_VIDEO_EXAMPLE 0
-+#define CONFIG_HTTP_MULTICLIENT_EXAMPLE 1
-+#define CONFIG_HW_DECODE_EXAMPLE 1
-+#define CONFIG_METADATA_EXAMPLE 1
-+#define CONFIG_MUXING_EXAMPLE 0
-+#define CONFIG_QSVDEC_EXAMPLE 0
-+#define CONFIG_REMUXING_EXAMPLE 1
-+#define CONFIG_RESAMPLING_AUDIO_EXAMPLE 0
-+#define CONFIG_SCALING_VIDEO_EXAMPLE 0
-+#define CONFIG_TRANSCODE_AAC_EXAMPLE 0
-+#define CONFIG_TRANSCODING_EXAMPLE 0
-+#define CONFIG_VAAPI_ENCODE_EXAMPLE 0
-+#define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
-+#define CONFIG_QSV_TRANSCODE_EXAMPLE 0
-+#define CONFIG_AVISYNTH 0
-+#define CONFIG_FREI0R 0
-+#define CONFIG_LIBCDIO 0
-+#define CONFIG_LIBDAVS2 0
-+#define CONFIG_LIBRUBBERBAND 0
-+#define CONFIG_LIBVIDSTAB 0
-+#define CONFIG_LIBX264 0
-+#define CONFIG_LIBX265 0
-+#define CONFIG_LIBXAVS 0
-+#define CONFIG_LIBXAVS2 0
-+#define CONFIG_LIBXVID 0
-+#define CONFIG_DECKLINK 0
-+#define CONFIG_LIBFDK_AAC 0
-+#define CONFIG_LIBTLS 0
-+#define CONFIG_GMP 0
-+#define CONFIG_LIBARIBB24 0
-+#define CONFIG_LIBLENSFUN 0
-+#define CONFIG_LIBOPENCORE_AMRNB 0
-+#define CONFIG_LIBOPENCORE_AMRWB 0
-+#define CONFIG_LIBVO_AMRWBENC 0
-+#define CONFIG_MBEDTLS 0
-+#define CONFIG_RKMPP 0
-+#define CONFIG_LIBSMBCLIENT 0
-+#define CONFIG_CHROMAPRINT 0
-+#define CONFIG_GCRYPT 0
-+#define CONFIG_GNUTLS 0
-+#define CONFIG_JNI 0
-+#define CONFIG_LADSPA 0
-+#define CONFIG_LCMS2 0
-+#define CONFIG_LIBAOM 0
-+#define CONFIG_LIBASS 0
-+#define CONFIG_LIBBLURAY 0
-+#define CONFIG_LIBBS2B 0
-+#define CONFIG_LIBCACA 0
-+#define CONFIG_LIBCELT 0
-+#define CONFIG_LIBCODEC2 0
-+#define CONFIG_LIBDAV1D 0
-+#define CONFIG_LIBDC1394 0
-+#define CONFIG_LIBDRM 0
-+#define CONFIG_LIBFLITE 0
-+#define CONFIG_LIBFONTCONFIG 0
-+#define CONFIG_LIBFREETYPE 0
-+#define CONFIG_LIBFRIBIDI 0
-+#define CONFIG_LIBGLSLANG 0
-+#define CONFIG_LIBGME 0
-+#define CONFIG_LIBGSM 0
-+#define CONFIG_LIBIEC61883 0
-+#define CONFIG_LIBILBC 0
-+#define CONFIG_LIBJACK 0
-+#define CONFIG_LIBJXL 0
-+#define CONFIG_LIBKLVANC 0
-+#define CONFIG_LIBKVAZAAR 0
-+#define CONFIG_LIBMODPLUG 0
-+#define CONFIG_LIBMP3LAME 0
-+#define CONFIG_LIBMYSOFA 0
-+#define CONFIG_LIBOPENCV 0
-+#define CONFIG_LIBOPENH264 0
-+#define CONFIG_LIBOPENJPEG 0
-+#define CONFIG_LIBOPENMPT 0
-+#define CONFIG_LIBOPENVINO 0
-+#define CONFIG_LIBOPUS 1
-+#define CONFIG_LIBPLACEBO 0
-+#define CONFIG_LIBPULSE 0
-+#define CONFIG_LIBRABBITMQ 0
-+#define CONFIG_LIBRAV1E 0
-+#define CONFIG_LIBRIST 0
-+#define CONFIG_LIBRSVG 0
-+#define CONFIG_LIBRTMP 0
-+#define CONFIG_LIBSHADERC 0
-+#define CONFIG_LIBSHINE 0
-+#define CONFIG_LIBSMBCLIENT 0
-+#define CONFIG_LIBSNAPPY 0
-+#define CONFIG_LIBSOXR 0
-+#define CONFIG_LIBSPEEX 0
-+#define CONFIG_LIBSRT 0
-+#define CONFIG_LIBSSH 0
-+#define CONFIG_LIBSVTAV1 0
-+#define CONFIG_LIBTENSORFLOW 0
-+#define CONFIG_LIBTESSERACT 0
-+#define CONFIG_LIBTHEORA 0
-+#define CONFIG_LIBTWOLAME 0
-+#define CONFIG_LIBUAVS3D 0
-+#define CONFIG_LIBV4L2 0
-+#define CONFIG_LIBVMAF 0
-+#define CONFIG_LIBVORBIS 0
-+#define CONFIG_LIBVPX 0
-+#define CONFIG_LIBWEBP 0
-+#define CONFIG_LIBXML2 0
-+#define CONFIG_LIBZIMG 0
-+#define CONFIG_LIBZMQ 0
-+#define CONFIG_LIBZVBI 0
-+#define CONFIG_LV2 0
-+#define CONFIG_MEDIACODEC 0
-+#define CONFIG_OPENAL 0
-+#define CONFIG_OPENGL 0
-+#define CONFIG_OPENSSL 0
-+#define CONFIG_POCKETSPHINX 0
-+#define CONFIG_VAPOURSYNTH 0
-+#define CONFIG_ALSA 0
-+#define CONFIG_APPKIT 0
-+#define CONFIG_AVFOUNDATION 0
-+#define CONFIG_BZLIB 0
-+#define CONFIG_COREIMAGE 0
-+#define CONFIG_ICONV 0
-+#define CONFIG_LIBXCB 0
-+#define CONFIG_LIBXCB_SHM 0
-+#define CONFIG_LIBXCB_SHAPE 0
-+#define CONFIG_LIBXCB_XFIXES 0
-+#define CONFIG_LZMA 0
-+#define CONFIG_MEDIAFOUNDATION 0
-+#define CONFIG_METAL 0
-+#define CONFIG_SCHANNEL 0
-+#define CONFIG_SDL2 0
-+#define CONFIG_SECURETRANSPORT 0
-+#define CONFIG_SNDIO 0
-+#define CONFIG_XLIB 0
-+#define CONFIG_ZLIB 0
-+#define CONFIG_CUDA_NVCC 0
-+#define CONFIG_CUDA_SDK 0
-+#define CONFIG_LIBNPP 0
-+#define CONFIG_LIBMFX 0
-+#define CONFIG_LIBVPL 0
-+#define CONFIG_MMAL 0
-+#define CONFIG_OMX 0
-+#define CONFIG_OPENCL 0
-+#define CONFIG_AMF 0
-+#define CONFIG_AUDIOTOOLBOX 0
-+#define CONFIG_CRYSTALHD 0
-+#define CONFIG_CUDA 0
-+#define CONFIG_CUDA_LLVM 0
-+#define CONFIG_CUVID 0
-+#define CONFIG_D3D11VA 0
-+#define CONFIG_DXVA2 0
-+#define CONFIG_FFNVCODEC 0
-+#define CONFIG_NVDEC 0
-+#define CONFIG_NVENC 0
-+#define CONFIG_VAAPI 0
-+#define CONFIG_VDPAU 0
-+#define CONFIG_VIDEOTOOLBOX 0
-+#define CONFIG_VULKAN 0
-+#define CONFIG_V4L2_M2M 0
-+#define CONFIG_FTRAPV 0
-+#define CONFIG_GRAY 0
-+#define CONFIG_HARDCODED_TABLES 0
-+#define CONFIG_OMX_RPI 0
-+#define CONFIG_RUNTIME_CPUDETECT 1
-+#define CONFIG_SAFE_BITSTREAM_READER 1
-+#define CONFIG_SHARED 0
-+#define CONFIG_SMALL 0
-+#define CONFIG_STATIC 1
-+#define CONFIG_SWSCALE_ALPHA 1
-+#define CONFIG_GPL 0
-+#define CONFIG_NONFREE 0
-+#define CONFIG_VERSION3 0
-+#define CONFIG_AVDEVICE 0
-+#define CONFIG_AVFILTER 0
-+#define CONFIG_SWSCALE 0
-+#define CONFIG_POSTPROC 0
-+#define CONFIG_AVFORMAT 1
-+#define CONFIG_AVCODEC 1
-+#define CONFIG_SWRESAMPLE 0
-+#define CONFIG_AVUTIL 1
-+#define CONFIG_FFPLAY 0
-+#define CONFIG_FFPROBE 0
-+#define CONFIG_FFMPEG 0
-+#define CONFIG_DCT 1
-+#define CONFIG_DWT 0
-+#define CONFIG_ERROR_RESILIENCE 0
-+#define CONFIG_FAAN 0
-+#define CONFIG_FAST_UNALIGNED 1
-+#define CONFIG_FFT 1
-+#define CONFIG_LSP 0
-+#define CONFIG_MDCT 0
-+#define CONFIG_PIXELUTILS 0
-+#define CONFIG_NETWORK 0
-+#define CONFIG_RDFT 1
-+#define CONFIG_AUTODETECT 0
-+#define CONFIG_FONTCONFIG 0
-+#define CONFIG_LARGE_TESTS 1
-+#define CONFIG_LINUX_PERF 0
-+#define CONFIG_MACOS_KPERF 0
-+#define CONFIG_MEMORY_POISONING 0
-+#define CONFIG_NEON_CLOBBER_TEST 0
-+#define CONFIG_OSSFUZZ 0
-+#define CONFIG_PIC 1
-+#define CONFIG_PTX_COMPRESSION 0
-+#define CONFIG_THUMB 0
-+#define CONFIG_VALGRIND_BACKTRACE 0
-+#define CONFIG_XMM_CLOBBER_TEST 0
-+#define CONFIG_BSFS 0
-+#define CONFIG_DECODERS 1
-+#define CONFIG_ENCODERS 0
-+#define CONFIG_HWACCELS 0
-+#define CONFIG_PARSERS 1
-+#define CONFIG_INDEVS 0
-+#define CONFIG_OUTDEVS 0
-+#define CONFIG_FILTERS 0
-+#define CONFIG_DEMUXERS 1
-+#define CONFIG_MUXERS 0
-+#define CONFIG_PROTOCOLS 0
-+#define CONFIG_AANDCTTABLES 0
-+#define CONFIG_AC3DSP 0
-+#define CONFIG_ADTS_HEADER 1
-+#define CONFIG_ATSC_A53 1
-+#define CONFIG_AUDIO_FRAME_QUEUE 0
-+#define CONFIG_AUDIODSP 0
-+#define CONFIG_BLOCKDSP 0
-+#define CONFIG_BSWAPDSP 0
-+#define CONFIG_CABAC 1
-+#define CONFIG_CBS 0
-+#define CONFIG_CBS_AV1 0
-+#define CONFIG_CBS_H264 0
-+#define CONFIG_CBS_H265 0
-+#define CONFIG_CBS_JPEG 0
-+#define CONFIG_CBS_MPEG2 0
-+#define CONFIG_CBS_VP9 0
-+#define CONFIG_DEFLATE_WRAPPER 0
-+#define CONFIG_DIRAC_PARSE 1
-+#define CONFIG_DNN 0
-+#define CONFIG_DOVI_RPU 0
-+#define CONFIG_DVPROFILE 0
-+#define CONFIG_EXIF 0
-+#define CONFIG_FAANDCT 0
-+#define CONFIG_FAANIDCT 0
-+#define CONFIG_FDCTDSP 0
-+#define CONFIG_FMTCONVERT 0
-+#define CONFIG_FRAME_THREAD_ENCODER 0
-+#define CONFIG_G722DSP 0
-+#define CONFIG_GOLOMB 1
-+#define CONFIG_GPLV3 0
-+#define CONFIG_H263DSP 0
-+#define CONFIG_H264CHROMA 1
-+#define CONFIG_H264DSP 1
-+#define CONFIG_H264PARSE 1
-+#define CONFIG_H264PRED 1
-+#define CONFIG_H264QPEL 1
-+#define CONFIG_H264_SEI 1
-+#define CONFIG_HEVCPARSE 0
-+#define CONFIG_HEVC_SEI 0
-+#define CONFIG_HPELDSP 1
-+#define CONFIG_HUFFMAN 0
-+#define CONFIG_HUFFYUVDSP 0
-+#define CONFIG_HUFFYUVENCDSP 0
-+#define CONFIG_IDCTDSP 0
-+#define CONFIG_IIRFILTER 0
-+#define CONFIG_INFLATE_WRAPPER 0
-+#define CONFIG_INTRAX8 0
-+#define CONFIG_ISO_MEDIA 1
-+#define CONFIG_IVIDSP 0
-+#define CONFIG_JPEGTABLES 0
-+#define CONFIG_LGPLV3 0
-+#define CONFIG_LIBX262 0
-+#define CONFIG_LLAUDDSP 0
-+#define CONFIG_LLVIDDSP 0
-+#define CONFIG_LLVIDENCDSP 0
-+#define CONFIG_LPC 0
-+#define CONFIG_LZF 0
-+#define CONFIG_ME_CMP 0
-+#define CONFIG_MPEG_ER 0
-+#define CONFIG_MPEGAUDIO 1
-+#define CONFIG_MPEGAUDIODSP 1
-+#define CONFIG_MPEGAUDIOHEADER 1
-+#define CONFIG_MPEG4AUDIO 1
-+#define CONFIG_MPEGVIDEO 0
-+#define CONFIG_MPEGVIDEODEC 0
-+#define CONFIG_MPEGVIDEOENC 0
-+#define CONFIG_MSMPEG4DEC 0
-+#define CONFIG_MSMPEG4ENC 0
-+#define CONFIG_MSS34DSP 0
-+#define CONFIG_PIXBLOCKDSP 0
-+#define CONFIG_QPELDSP 0
-+#define CONFIG_QSV 0
-+#define CONFIG_QSVDEC 0
-+#define CONFIG_QSVENC 0
-+#define CONFIG_QSVVPP 0
-+#define CONFIG_RANGECODER 0
-+#define CONFIG_RIFFDEC 1
-+#define CONFIG_RIFFENC 0
-+#define CONFIG_RTPDEC 0
-+#define CONFIG_RTPENC_CHAIN 0
-+#define CONFIG_RV34DSP 0
-+#define CONFIG_SCENE_SAD 0
-+#define CONFIG_SINEWIN 1
-+#define CONFIG_SNAPPY 0
-+#define CONFIG_SRTP 0
-+#define CONFIG_STARTCODE 1
-+#define CONFIG_TEXTUREDSP 0
-+#define CONFIG_TEXTUREDSPENC 0
-+#define CONFIG_TPELDSP 0
-+#define CONFIG_VAAPI_1 0
-+#define CONFIG_VAAPI_ENCODE 0
-+#define CONFIG_VC1DSP 0
-+#define CONFIG_VIDEODSP 1
-+#define CONFIG_VP3DSP 1
-+#define CONFIG_VP56DSP 0
-+#define CONFIG_VP8DSP 1
-+#define CONFIG_WMA_FREQS 0
-+#define CONFIG_WMV2DSP 0
-+#endif /* FFMPEG_CONFIG_H */
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,2146 @@
-+/* Automatically generated by configure - do not modify! */
-+#ifndef FFMPEG_CONFIG_COMPONENTS_H
-+#define FFMPEG_CONFIG_COMPONENTS_H
-+#define CONFIG_AAC_ADTSTOASC_BSF 0
-+#define CONFIG_AV1_FRAME_MERGE_BSF 0
-+#define CONFIG_AV1_FRAME_SPLIT_BSF 0
-+#define CONFIG_AV1_METADATA_BSF 0
-+#define CONFIG_CHOMP_BSF 0
-+#define CONFIG_DUMP_EXTRADATA_BSF 0
-+#define CONFIG_DCA_CORE_BSF 0
-+#define CONFIG_DTS2PTS_BSF 0
-+#define CONFIG_DV_ERROR_MARKER_BSF 0
-+#define CONFIG_EAC3_CORE_BSF 0
-+#define CONFIG_EXTRACT_EXTRADATA_BSF 0
-+#define CONFIG_FILTER_UNITS_BSF 0
-+#define CONFIG_H264_METADATA_BSF 0
-+#define CONFIG_H264_MP4TOANNEXB_BSF 0
-+#define CONFIG_H264_REDUNDANT_PPS_BSF 0
-+#define CONFIG_HAPQA_EXTRACT_BSF 0
-+#define CONFIG_HEVC_METADATA_BSF 0
-+#define CONFIG_HEVC_MP4TOANNEXB_BSF 0
-+#define CONFIG_IMX_DUMP_HEADER_BSF 0
-+#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
-+#define CONFIG_MJPEG2JPEG_BSF 0
-+#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
-+#define CONFIG_MP3_HEADER_DECOMPRESS_BSF 0
-+#define CONFIG_MPEG2_METADATA_BSF 0
-+#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
-+#define CONFIG_MOV2TEXTSUB_BSF 0
-+#define CONFIG_NOISE_BSF 0
-+#define CONFIG_NULL_BSF 0
-+#define CONFIG_OPUS_METADATA_BSF 0
-+#define CONFIG_PCM_RECHUNK_BSF 0
-+#define CONFIG_PGS_FRAME_MERGE_BSF 0
-+#define CONFIG_PRORES_METADATA_BSF 0
-+#define CONFIG_REMOVE_EXTRADATA_BSF 0
-+#define CONFIG_SETTS_BSF 0
-+#define CONFIG_TEXT2MOVSUB_BSF 0
-+#define CONFIG_TRACE_HEADERS_BSF 0
-+#define CONFIG_TRUEHD_CORE_BSF 0
-+#define CONFIG_VP9_METADATA_BSF 0
-+#define CONFIG_VP9_RAW_REORDER_BSF 0
-+#define CONFIG_VP9_SUPERFRAME_BSF 0
-+#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
-+#define CONFIG_AASC_DECODER 0
-+#define CONFIG_AIC_DECODER 0
-+#define CONFIG_ALIAS_PIX_DECODER 0
-+#define CONFIG_AGM_DECODER 0
-+#define CONFIG_AMV_DECODER 0
-+#define CONFIG_ANM_DECODER 0
-+#define CONFIG_ANSI_DECODER 0
-+#define CONFIG_APNG_DECODER 0
-+#define CONFIG_ARBC_DECODER 0
-+#define CONFIG_ARGO_DECODER 0
-+#define CONFIG_ASV1_DECODER 0
-+#define CONFIG_ASV2_DECODER 0
-+#define CONFIG_AURA_DECODER 0
-+#define CONFIG_AURA2_DECODER 0
-+#define CONFIG_AVRP_DECODER 0
-+#define CONFIG_AVRN_DECODER 0
-+#define CONFIG_AVS_DECODER 0
-+#define CONFIG_AVUI_DECODER 0
-+#define CONFIG_AYUV_DECODER 0
-+#define CONFIG_BETHSOFTVID_DECODER 0
-+#define CONFIG_BFI_DECODER 0
-+#define CONFIG_BINK_DECODER 0
-+#define CONFIG_BITPACKED_DECODER 0
-+#define CONFIG_BMP_DECODER 0
-+#define CONFIG_BMV_VIDEO_DECODER 0
-+#define CONFIG_BRENDER_PIX_DECODER 0
-+#define CONFIG_C93_DECODER 0
-+#define CONFIG_CAVS_DECODER 0
-+#define CONFIG_CDGRAPHICS_DECODER 0
-+#define CONFIG_CDTOONS_DECODER 0
-+#define CONFIG_CDXL_DECODER 0
-+#define CONFIG_CFHD_DECODER 0
-+#define CONFIG_CINEPAK_DECODER 0
-+#define CONFIG_CLEARVIDEO_DECODER 0
-+#define CONFIG_CLJR_DECODER 0
-+#define CONFIG_CLLC_DECODER 0
-+#define CONFIG_COMFORTNOISE_DECODER 0
-+#define CONFIG_CPIA_DECODER 0
-+#define CONFIG_CRI_DECODER 0
-+#define CONFIG_CSCD_DECODER 0
-+#define CONFIG_CYUV_DECODER 0
-+#define CONFIG_DDS_DECODER 0
-+#define CONFIG_DFA_DECODER 0
-+#define CONFIG_DIRAC_DECODER 0
-+#define CONFIG_DNXHD_DECODER 0
-+#define CONFIG_DPX_DECODER 0
-+#define CONFIG_DSICINVIDEO_DECODER 0
-+#define CONFIG_DVAUDIO_DECODER 0
-+#define CONFIG_DVVIDEO_DECODER 0
-+#define CONFIG_DXA_DECODER 0
-+#define CONFIG_DXTORY_DECODER 0
-+#define CONFIG_DXV_DECODER 0
-+#define CONFIG_EACMV_DECODER 0
-+#define CONFIG_EAMAD_DECODER 0
-+#define CONFIG_EATGQ_DECODER 0
-+#define CONFIG_EATGV_DECODER 0
-+#define CONFIG_EATQI_DECODER 0
-+#define CONFIG_EIGHTBPS_DECODER 0
-+#define CONFIG_EIGHTSVX_EXP_DECODER 0
-+#define CONFIG_EIGHTSVX_FIB_DECODER 0
-+#define CONFIG_ESCAPE124_DECODER 0
-+#define CONFIG_ESCAPE130_DECODER 0
-+#define CONFIG_EXR_DECODER 0
-+#define CONFIG_FFV1_DECODER 0
-+#define CONFIG_FFVHUFF_DECODER 0
-+#define CONFIG_FIC_DECODER 0
-+#define CONFIG_FITS_DECODER 0
-+#define CONFIG_FLASHSV_DECODER 0
-+#define CONFIG_FLASHSV2_DECODER 0
-+#define CONFIG_FLIC_DECODER 0
-+#define CONFIG_FLV_DECODER 0
-+#define CONFIG_FMVC_DECODER 0
-+#define CONFIG_FOURXM_DECODER 0
-+#define CONFIG_FRAPS_DECODER 0
-+#define CONFIG_FRWU_DECODER 0
-+#define CONFIG_G2M_DECODER 0
-+#define CONFIG_GDV_DECODER 0
-+#define CONFIG_GEM_DECODER 0
-+#define CONFIG_GIF_DECODER 0
-+#define CONFIG_H261_DECODER 0
-+#define CONFIG_H263_DECODER 0
-+#define CONFIG_H263I_DECODER 0
-+#define CONFIG_H263P_DECODER 0
-+#define CONFIG_H263_V4L2M2M_DECODER 0
-+#define CONFIG_H264_DECODER 1
-+#define CONFIG_H264_CRYSTALHD_DECODER 0
-+#define CONFIG_H264_V4L2M2M_DECODER 0
-+#define CONFIG_H264_MEDIACODEC_DECODER 0
-+#define CONFIG_H264_MMAL_DECODER 0
-+#define CONFIG_H264_QSV_DECODER 0
-+#define CONFIG_H264_RKMPP_DECODER 0
-+#define CONFIG_HAP_DECODER 0
-+#define CONFIG_HEVC_DECODER 0
-+#define CONFIG_HEVC_QSV_DECODER 0
-+#define CONFIG_HEVC_RKMPP_DECODER 0
-+#define CONFIG_HEVC_V4L2M2M_DECODER 0
-+#define CONFIG_HNM4_VIDEO_DECODER 0
-+#define CONFIG_HQ_HQA_DECODER 0
-+#define CONFIG_HQX_DECODER 0
-+#define CONFIG_HUFFYUV_DECODER 0
-+#define CONFIG_HYMT_DECODER 0
-+#define CONFIG_IDCIN_DECODER 0
-+#define CONFIG_IFF_ILBM_DECODER 0
-+#define CONFIG_IMM4_DECODER 0
-+#define CONFIG_IMM5_DECODER 0
-+#define CONFIG_INDEO2_DECODER 0
-+#define CONFIG_INDEO3_DECODER 0
-+#define CONFIG_INDEO4_DECODER 0
-+#define CONFIG_INDEO5_DECODER 0
-+#define CONFIG_INTERPLAY_VIDEO_DECODER 0
-+#define CONFIG_IPU_DECODER 0
-+#define CONFIG_JPEG2000_DECODER 0
-+#define CONFIG_JPEGLS_DECODER 0
-+#define CONFIG_JV_DECODER 0
-+#define CONFIG_KGV1_DECODER 0
-+#define CONFIG_KMVC_DECODER 0
-+#define CONFIG_LAGARITH_DECODER 0
-+#define CONFIG_LOCO_DECODER 0
-+#define CONFIG_LSCR_DECODER 0
-+#define CONFIG_M101_DECODER 0
-+#define CONFIG_MAGICYUV_DECODER 0
-+#define CONFIG_MDEC_DECODER 0
-+#define CONFIG_MEDIA100_DECODER 0
-+#define CONFIG_MIMIC_DECODER 0
-+#define CONFIG_MJPEG_DECODER 0
-+#define CONFIG_MJPEGB_DECODER 0
-+#define CONFIG_MMVIDEO_DECODER 0
-+#define CONFIG_MOBICLIP_DECODER 0
-+#define CONFIG_MOTIONPIXELS_DECODER 0
-+#define CONFIG_MPEG1VIDEO_DECODER 0
-+#define CONFIG_MPEG2VIDEO_DECODER 0
-+#define CONFIG_MPEG4_DECODER 0
-+#define CONFIG_MPEG4_CRYSTALHD_DECODER 0
-+#define CONFIG_MPEG4_V4L2M2M_DECODER 0
-+#define CONFIG_MPEG4_MMAL_DECODER 0
-+#define CONFIG_MPEGVIDEO_DECODER 0
-+#define CONFIG_MPEG1_V4L2M2M_DECODER 0
-+#define CONFIG_MPEG2_MMAL_DECODER 0
-+#define CONFIG_MPEG2_CRYSTALHD_DECODER 0
-+#define CONFIG_MPEG2_V4L2M2M_DECODER 0
-+#define CONFIG_MPEG2_QSV_DECODER 0
-+#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
-+#define CONFIG_MSA1_DECODER 0
-+#define CONFIG_MSCC_DECODER 0
-+#define CONFIG_MSMPEG4V1_DECODER 0
-+#define CONFIG_MSMPEG4V2_DECODER 0
-+#define CONFIG_MSMPEG4V3_DECODER 0
-+#define CONFIG_MSMPEG4_CRYSTALHD_DECODER 0
-+#define CONFIG_MSP2_DECODER 0
-+#define CONFIG_MSRLE_DECODER 0
-+#define CONFIG_MSS1_DECODER 0
-+#define CONFIG_MSS2_DECODER 0
-+#define CONFIG_MSVIDEO1_DECODER 0
-+#define CONFIG_MSZH_DECODER 0
-+#define CONFIG_MTS2_DECODER 0
-+#define CONFIG_MV30_DECODER 0
-+#define CONFIG_MVC1_DECODER 0
-+#define CONFIG_MVC2_DECODER 0
-+#define CONFIG_MVDV_DECODER 0
-+#define CONFIG_MVHA_DECODER 0
-+#define CONFIG_MWSC_DECODER 0
-+#define CONFIG_MXPEG_DECODER 0
-+#define CONFIG_NOTCHLC_DECODER 0
-+#define CONFIG_NUV_DECODER 0
-+#define CONFIG_PAF_VIDEO_DECODER 0
-+#define CONFIG_PAM_DECODER 0
-+#define CONFIG_PBM_DECODER 0
-+#define CONFIG_PCX_DECODER 0
-+#define CONFIG_PFM_DECODER 0
-+#define CONFIG_PGM_DECODER 0
-+#define CONFIG_PGMYUV_DECODER 0
-+#define CONFIG_PGX_DECODER 0
-+#define CONFIG_PHM_DECODER 0
-+#define CONFIG_PHOTOCD_DECODER 0
-+#define CONFIG_PICTOR_DECODER 0
-+#define CONFIG_PIXLET_DECODER 0
-+#define CONFIG_PNG_DECODER 0
-+#define CONFIG_PPM_DECODER 0
-+#define CONFIG_PRORES_DECODER 0
-+#define CONFIG_PROSUMER_DECODER 0
-+#define CONFIG_PSD_DECODER 0
-+#define CONFIG_PTX_DECODER 0
-+#define CONFIG_QDRAW_DECODER 0
-+#define CONFIG_QOI_DECODER 0
-+#define CONFIG_QPEG_DECODER 0
-+#define CONFIG_QTRLE_DECODER 0
-+#define CONFIG_R10K_DECODER 0
-+#define CONFIG_R210_DECODER 0
-+#define CONFIG_RASC_DECODER 0
-+#define CONFIG_RAWVIDEO_DECODER 0
-+#define CONFIG_RL2_DECODER 0
-+#define CONFIG_ROQ_DECODER 0
-+#define CONFIG_RPZA_DECODER 0
-+#define CONFIG_RSCC_DECODER 0
-+#define CONFIG_RV10_DECODER 0
-+#define CONFIG_RV20_DECODER 0
-+#define CONFIG_RV30_DECODER 0
-+#define CONFIG_RV40_DECODER 0
-+#define CONFIG_S302M_DECODER 0
-+#define CONFIG_SANM_DECODER 0
-+#define CONFIG_SCPR_DECODER 0
-+#define CONFIG_SCREENPRESSO_DECODER 0
-+#define CONFIG_SGA_DECODER 0
-+#define CONFIG_SGI_DECODER 0
-+#define CONFIG_SGIRLE_DECODER 0
-+#define CONFIG_SHEERVIDEO_DECODER 0
-+#define CONFIG_SIMBIOSIS_IMX_DECODER 0
-+#define CONFIG_SMACKER_DECODER 0
-+#define CONFIG_SMC_DECODER 0
-+#define CONFIG_SMVJPEG_DECODER 0
-+#define CONFIG_SNOW_DECODER 0
-+#define CONFIG_SP5X_DECODER 0
-+#define CONFIG_SPEEDHQ_DECODER 0
-+#define CONFIG_SPEEX_DECODER 0
-+#define CONFIG_SRGC_DECODER 0
-+#define CONFIG_SUNRAST_DECODER 0
-+#define CONFIG_SVQ1_DECODER 0
-+#define CONFIG_SVQ3_DECODER 0
-+#define CONFIG_TARGA_DECODER 0
-+#define CONFIG_TARGA_Y216_DECODER 0
-+#define CONFIG_TDSC_DECODER 0
-+#define CONFIG_THEORA_DECODER 1
-+#define CONFIG_THP_DECODER 0
-+#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
-+#define CONFIG_TIFF_DECODER 0
-+#define CONFIG_TMV_DECODER 0
-+#define CONFIG_TRUEMOTION1_DECODER 0
-+#define CONFIG_TRUEMOTION2_DECODER 0
-+#define CONFIG_TRUEMOTION2RT_DECODER 0
-+#define CONFIG_TSCC_DECODER 0
-+#define CONFIG_TSCC2_DECODER 0
-+#define CONFIG_TXD_DECODER 0
-+#define CONFIG_ULTI_DECODER 0
-+#define CONFIG_UTVIDEO_DECODER 0
-+#define CONFIG_V210_DECODER 0
-+#define CONFIG_V210X_DECODER 0
-+#define CONFIG_V308_DECODER 0
-+#define CONFIG_V408_DECODER 0
-+#define CONFIG_V410_DECODER 0
-+#define CONFIG_VB_DECODER 0
-+#define CONFIG_VBN_DECODER 0
-+#define CONFIG_VBLE_DECODER 0
-+#define CONFIG_VC1_DECODER 0
-+#define CONFIG_VC1_CRYSTALHD_DECODER 0
-+#define CONFIG_VC1IMAGE_DECODER 0
-+#define CONFIG_VC1_MMAL_DECODER 0
-+#define CONFIG_VC1_QSV_DECODER 0
-+#define CONFIG_VC1_V4L2M2M_DECODER 0
-+#define CONFIG_VCR1_DECODER 0
-+#define CONFIG_VMDVIDEO_DECODER 0
-+#define CONFIG_VMNC_DECODER 0
-+#define CONFIG_VP3_DECODER 1
-+#define CONFIG_VP4_DECODER 0
-+#define CONFIG_VP5_DECODER 0
-+#define CONFIG_VP6_DECODER 0
-+#define CONFIG_VP6A_DECODER 0
-+#define CONFIG_VP6F_DECODER 0
-+#define CONFIG_VP7_DECODER 0
-+#define CONFIG_VP8_DECODER 1
-+#define CONFIG_VP8_RKMPP_DECODER 0
-+#define CONFIG_VP8_V4L2M2M_DECODER 0
-+#define CONFIG_VP9_DECODER 0
-+#define CONFIG_VP9_RKMPP_DECODER 0
-+#define CONFIG_VP9_V4L2M2M_DECODER 0
-+#define CONFIG_VQA_DECODER 0
-+#define CONFIG_VQC_DECODER 0
-+#define CONFIG_WBMP_DECODER 0
-+#define CONFIG_WEBP_DECODER 0
-+#define CONFIG_WCMV_DECODER 0
-+#define CONFIG_WRAPPED_AVFRAME_DECODER 0
-+#define CONFIG_WMV1_DECODER 0
-+#define CONFIG_WMV2_DECODER 0
-+#define CONFIG_WMV3_DECODER 0
-+#define CONFIG_WMV3_CRYSTALHD_DECODER 0
-+#define CONFIG_WMV3IMAGE_DECODER 0
-+#define CONFIG_WNV1_DECODER 0
-+#define CONFIG_XAN_WC3_DECODER 0
-+#define CONFIG_XAN_WC4_DECODER 0
-+#define CONFIG_XBM_DECODER 0
-+#define CONFIG_XFACE_DECODER 0
-+#define CONFIG_XL_DECODER 0
-+#define CONFIG_XPM_DECODER 0
-+#define CONFIG_XWD_DECODER 0
-+#define CONFIG_Y41P_DECODER 0
-+#define CONFIG_YLC_DECODER 0
-+#define CONFIG_YOP_DECODER 0
-+#define CONFIG_YUV4_DECODER 0
-+#define CONFIG_ZERO12V_DECODER 0
-+#define CONFIG_ZEROCODEC_DECODER 0
-+#define CONFIG_ZLIB_DECODER 0
-+#define CONFIG_ZMBV_DECODER 0
-+#define CONFIG_AAC_DECODER 1
-+#define CONFIG_AAC_FIXED_DECODER 0
-+#define CONFIG_AAC_LATM_DECODER 0
-+#define CONFIG_AC3_DECODER 0
-+#define CONFIG_AC3_FIXED_DECODER 0
-+#define CONFIG_ACELP_KELVIN_DECODER 0
-+#define CONFIG_ALAC_DECODER 0
-+#define CONFIG_ALS_DECODER 0
-+#define CONFIG_AMRNB_DECODER 0
-+#define CONFIG_AMRWB_DECODER 0
-+#define CONFIG_APAC_DECODER 0
-+#define CONFIG_APE_DECODER 0
-+#define CONFIG_APTX_DECODER 0
-+#define CONFIG_APTX_HD_DECODER 0
-+#define CONFIG_ATRAC1_DECODER 0
-+#define CONFIG_ATRAC3_DECODER 0
-+#define CONFIG_ATRAC3AL_DECODER 0
-+#define CONFIG_ATRAC3P_DECODER 0
-+#define CONFIG_ATRAC3PAL_DECODER 0
-+#define CONFIG_ATRAC9_DECODER 0
-+#define CONFIG_BINKAUDIO_DCT_DECODER 0
-+#define CONFIG_BINKAUDIO_RDFT_DECODER 0
-+#define CONFIG_BMV_AUDIO_DECODER 0
-+#define CONFIG_BONK_DECODER 0
-+#define CONFIG_COOK_DECODER 0
-+#define CONFIG_DCA_DECODER 0
-+#define CONFIG_DFPWM_DECODER 0
-+#define CONFIG_DOLBY_E_DECODER 0
-+#define CONFIG_DSD_LSBF_DECODER 0
-+#define CONFIG_DSD_MSBF_DECODER 0
-+#define CONFIG_DSD_LSBF_PLANAR_DECODER 0
-+#define CONFIG_DSD_MSBF_PLANAR_DECODER 0
-+#define CONFIG_DSICINAUDIO_DECODER 0
-+#define CONFIG_DSS_SP_DECODER 0
-+#define CONFIG_DST_DECODER 0
-+#define CONFIG_EAC3_DECODER 0
-+#define CONFIG_EVRC_DECODER 0
-+#define CONFIG_FASTAUDIO_DECODER 0
-+#define CONFIG_FFWAVESYNTH_DECODER 0
-+#define CONFIG_FLAC_DECODER 1
-+#define CONFIG_FTR_DECODER 0
-+#define CONFIG_G723_1_DECODER 0
-+#define CONFIG_G729_DECODER 0
-+#define CONFIG_GSM_DECODER 0
-+#define CONFIG_GSM_MS_DECODER 0
-+#define CONFIG_HCA_DECODER 0
-+#define CONFIG_HCOM_DECODER 0
-+#define CONFIG_HDR_DECODER 0
-+#define CONFIG_IAC_DECODER 0
-+#define CONFIG_ILBC_DECODER 0
-+#define CONFIG_IMC_DECODER 0
-+#define CONFIG_INTERPLAY_ACM_DECODER 0
-+#define CONFIG_MACE3_DECODER 0
-+#define CONFIG_MACE6_DECODER 0
-+#define CONFIG_METASOUND_DECODER 0
-+#define CONFIG_MISC4_DECODER 0
-+#define CONFIG_MLP_DECODER 0
-+#define CONFIG_MP1_DECODER 0
-+#define CONFIG_MP1FLOAT_DECODER 0
-+#define CONFIG_MP2_DECODER 0
-+#define CONFIG_MP2FLOAT_DECODER 0
-+#define CONFIG_MP3FLOAT_DECODER 0
-+#define CONFIG_MP3_DECODER 1
-+#define CONFIG_MP3ADUFLOAT_DECODER 0
-+#define CONFIG_MP3ADU_DECODER 0
-+#define CONFIG_MP3ON4FLOAT_DECODER 0
-+#define CONFIG_MP3ON4_DECODER 0
-+#define CONFIG_MPC7_DECODER 0
-+#define CONFIG_MPC8_DECODER 0
-+#define CONFIG_MSNSIREN_DECODER 0
-+#define CONFIG_NELLYMOSER_DECODER 0
-+#define CONFIG_ON2AVC_DECODER 0
-+#define CONFIG_OPUS_DECODER 0
-+#define CONFIG_PAF_AUDIO_DECODER 0
-+#define CONFIG_QCELP_DECODER 0
-+#define CONFIG_QDM2_DECODER 0
-+#define CONFIG_QDMC_DECODER 0
-+#define CONFIG_RA_144_DECODER 0
-+#define CONFIG_RA_288_DECODER 0
-+#define CONFIG_RALF_DECODER 0
-+#define CONFIG_SBC_DECODER 0
-+#define CONFIG_SHORTEN_DECODER 0
-+#define CONFIG_SIPR_DECODER 0
-+#define CONFIG_SIREN_DECODER 0
-+#define CONFIG_SMACKAUD_DECODER 0
-+#define CONFIG_SONIC_DECODER 0
-+#define CONFIG_TAK_DECODER 0
-+#define CONFIG_TRUEHD_DECODER 0
-+#define CONFIG_TRUESPEECH_DECODER 0
-+#define CONFIG_TTA_DECODER 0
-+#define CONFIG_TWINVQ_DECODER 0
-+#define CONFIG_VMDAUDIO_DECODER 0
-+#define CONFIG_VORBIS_DECODER 1
-+#define CONFIG_WAVPACK_DECODER 0
-+#define CONFIG_WMALOSSLESS_DECODER 0
-+#define CONFIG_WMAPRO_DECODER 0
-+#define CONFIG_WMAV1_DECODER 0
-+#define CONFIG_WMAV2_DECODER 0
-+#define CONFIG_WMAVOICE_DECODER 0
-+#define CONFIG_WS_SND1_DECODER 0
-+#define CONFIG_XMA1_DECODER 0
-+#define CONFIG_XMA2_DECODER 0
-+#define CONFIG_PCM_ALAW_DECODER 1
-+#define CONFIG_PCM_BLURAY_DECODER 0
-+#define CONFIG_PCM_DVD_DECODER 0
-+#define CONFIG_PCM_F16LE_DECODER 0
-+#define CONFIG_PCM_F24LE_DECODER 0
-+#define CONFIG_PCM_F32BE_DECODER 0
-+#define CONFIG_PCM_F32LE_DECODER 1
-+#define CONFIG_PCM_F64BE_DECODER 0
-+#define CONFIG_PCM_F64LE_DECODER 0
-+#define CONFIG_PCM_LXF_DECODER 0
-+#define CONFIG_PCM_MULAW_DECODER 1
-+#define CONFIG_PCM_S8_DECODER 0
-+#define CONFIG_PCM_S8_PLANAR_DECODER 0
-+#define CONFIG_PCM_S16BE_DECODER 1
-+#define CONFIG_PCM_S16BE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S16LE_DECODER 1
-+#define CONFIG_PCM_S16LE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S24BE_DECODER 1
-+#define CONFIG_PCM_S24DAUD_DECODER 0
-+#define CONFIG_PCM_S24LE_DECODER 1
-+#define CONFIG_PCM_S24LE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S32BE_DECODER 0
-+#define CONFIG_PCM_S32LE_DECODER 1
-+#define CONFIG_PCM_S32LE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S64BE_DECODER 0
-+#define CONFIG_PCM_S64LE_DECODER 0
-+#define CONFIG_PCM_SGA_DECODER 0
-+#define CONFIG_PCM_U8_DECODER 1
-+#define CONFIG_PCM_U16BE_DECODER 0
-+#define CONFIG_PCM_U16LE_DECODER 0
-+#define CONFIG_PCM_U24BE_DECODER 0
-+#define CONFIG_PCM_U24LE_DECODER 0
-+#define CONFIG_PCM_U32BE_DECODER 0
-+#define CONFIG_PCM_U32LE_DECODER 0
-+#define CONFIG_PCM_VIDC_DECODER 0
-+#define CONFIG_CBD2_DPCM_DECODER 0
-+#define CONFIG_DERF_DPCM_DECODER 0
-+#define CONFIG_GREMLIN_DPCM_DECODER 0
-+#define CONFIG_INTERPLAY_DPCM_DECODER 0
-+#define CONFIG_ROQ_DPCM_DECODER 0
-+#define CONFIG_SDX2_DPCM_DECODER 0
-+#define CONFIG_SOL_DPCM_DECODER 0
-+#define CONFIG_XAN_DPCM_DECODER 0
-+#define CONFIG_WADY_DPCM_DECODER 0
-+#define CONFIG_ADPCM_4XM_DECODER 0
-+#define CONFIG_ADPCM_ADX_DECODER 0
-+#define CONFIG_ADPCM_AFC_DECODER 0
-+#define CONFIG_ADPCM_AGM_DECODER 0
-+#define CONFIG_ADPCM_AICA_DECODER 0
-+#define CONFIG_ADPCM_ARGO_DECODER 0
-+#define CONFIG_ADPCM_CT_DECODER 0
-+#define CONFIG_ADPCM_DTK_DECODER 0
-+#define CONFIG_ADPCM_EA_DECODER 0
-+#define CONFIG_ADPCM_EA_MAXIS_XA_DECODER 0
-+#define CONFIG_ADPCM_EA_R1_DECODER 0
-+#define CONFIG_ADPCM_EA_R2_DECODER 0
-+#define CONFIG_ADPCM_EA_R3_DECODER 0
-+#define CONFIG_ADPCM_EA_XAS_DECODER 0
-+#define CONFIG_ADPCM_G722_DECODER 0
-+#define CONFIG_ADPCM_G726_DECODER 0
-+#define CONFIG_ADPCM_G726LE_DECODER 0
-+#define CONFIG_ADPCM_IMA_ACORN_DECODER 0
-+#define CONFIG_ADPCM_IMA_AMV_DECODER 0
-+#define CONFIG_ADPCM_IMA_ALP_DECODER 0
-+#define CONFIG_ADPCM_IMA_APC_DECODER 0
-+#define CONFIG_ADPCM_IMA_APM_DECODER 0
-+#define CONFIG_ADPCM_IMA_CUNNING_DECODER 0
-+#define CONFIG_ADPCM_IMA_DAT4_DECODER 0
-+#define CONFIG_ADPCM_IMA_DK3_DECODER 0
-+#define CONFIG_ADPCM_IMA_DK4_DECODER 0
-+#define CONFIG_ADPCM_IMA_EA_EACS_DECODER 0
-+#define CONFIG_ADPCM_IMA_EA_SEAD_DECODER 0
-+#define CONFIG_ADPCM_IMA_ISS_DECODER 0
-+#define CONFIG_ADPCM_IMA_MOFLEX_DECODER 0
-+#define CONFIG_ADPCM_IMA_MTF_DECODER 0
-+#define CONFIG_ADPCM_IMA_OKI_DECODER 0
-+#define CONFIG_ADPCM_IMA_QT_DECODER 0
-+#define CONFIG_ADPCM_IMA_RAD_DECODER 0
-+#define CONFIG_ADPCM_IMA_SSI_DECODER 0
-+#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
-+#define CONFIG_ADPCM_IMA_WAV_DECODER 0
-+#define CONFIG_ADPCM_IMA_WS_DECODER 0
-+#define CONFIG_ADPCM_MS_DECODER 0
-+#define CONFIG_ADPCM_MTAF_DECODER 0
-+#define CONFIG_ADPCM_PSX_DECODER 0
-+#define CONFIG_ADPCM_SBPRO_2_DECODER 0
-+#define CONFIG_ADPCM_SBPRO_3_DECODER 0
-+#define CONFIG_ADPCM_SBPRO_4_DECODER 0
-+#define CONFIG_ADPCM_SWF_DECODER 0
-+#define CONFIG_ADPCM_THP_DECODER 0
-+#define CONFIG_ADPCM_THP_LE_DECODER 0
-+#define CONFIG_ADPCM_VIMA_DECODER 0
-+#define CONFIG_ADPCM_XA_DECODER 0
-+#define CONFIG_ADPCM_XMD_DECODER 0
-+#define CONFIG_ADPCM_YAMAHA_DECODER 0
-+#define CONFIG_ADPCM_ZORK_DECODER 0
-+#define CONFIG_SSA_DECODER 0
-+#define CONFIG_ASS_DECODER 0
-+#define CONFIG_CCAPTION_DECODER 0
-+#define CONFIG_DVBSUB_DECODER 0
-+#define CONFIG_DVDSUB_DECODER 0
-+#define CONFIG_JACOSUB_DECODER 0
-+#define CONFIG_MICRODVD_DECODER 0
-+#define CONFIG_MOVTEXT_DECODER 0
-+#define CONFIG_MPL2_DECODER 0
-+#define CONFIG_PGSSUB_DECODER 0
-+#define CONFIG_PJS_DECODER 0
-+#define CONFIG_REALTEXT_DECODER 0
-+#define CONFIG_SAMI_DECODER 0
-+#define CONFIG_SRT_DECODER 0
-+#define CONFIG_STL_DECODER 0
-+#define CONFIG_SUBRIP_DECODER 0
-+#define CONFIG_SUBVIEWER_DECODER 0
-+#define CONFIG_SUBVIEWER1_DECODER 0
-+#define CONFIG_TEXT_DECODER 0
-+#define CONFIG_VPLAYER_DECODER 0
-+#define CONFIG_WEBVTT_DECODER 0
-+#define CONFIG_XSUB_DECODER 0
-+#define CONFIG_AAC_AT_DECODER 0
-+#define CONFIG_AC3_AT_DECODER 0
-+#define CONFIG_ADPCM_IMA_QT_AT_DECODER 0
-+#define CONFIG_ALAC_AT_DECODER 0
-+#define CONFIG_AMR_NB_AT_DECODER 0
-+#define CONFIG_EAC3_AT_DECODER 0
-+#define CONFIG_GSM_MS_AT_DECODER 0
-+#define CONFIG_ILBC_AT_DECODER 0
-+#define CONFIG_MP1_AT_DECODER 0
-+#define CONFIG_MP2_AT_DECODER 0
-+#define CONFIG_MP3_AT_DECODER 0
-+#define CONFIG_PCM_ALAW_AT_DECODER 0
-+#define CONFIG_PCM_MULAW_AT_DECODER 0
-+#define CONFIG_QDMC_AT_DECODER 0
-+#define CONFIG_QDM2_AT_DECODER 0
-+#define CONFIG_LIBARIBB24_DECODER 0
-+#define CONFIG_LIBCELT_DECODER 0
-+#define CONFIG_LIBCODEC2_DECODER 0
-+#define CONFIG_LIBDAV1D_DECODER 0
-+#define CONFIG_LIBDAVS2_DECODER 0
-+#define CONFIG_LIBFDK_AAC_DECODER 0
-+#define CONFIG_LIBGSM_DECODER 0
-+#define CONFIG_LIBGSM_MS_DECODER 0
-+#define CONFIG_LIBILBC_DECODER 0
-+#define CONFIG_LIBJXL_DECODER 0
-+#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
-+#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
-+#define CONFIG_LIBOPENJPEG_DECODER 0
-+#define CONFIG_LIBOPUS_DECODER 1
-+#define CONFIG_LIBRSVG_DECODER 0
-+#define CONFIG_LIBSPEEX_DECODER 0
-+#define CONFIG_LIBUAVS3D_DECODER 0
-+#define CONFIG_LIBVORBIS_DECODER 0
-+#define CONFIG_LIBVPX_VP8_DECODER 0
-+#define CONFIG_LIBVPX_VP9_DECODER 0
-+#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
-+#define CONFIG_BINTEXT_DECODER 0
-+#define CONFIG_XBIN_DECODER 0
-+#define CONFIG_IDF_DECODER 0
-+#define CONFIG_LIBAOM_AV1_DECODER 0
-+#define CONFIG_AV1_DECODER 0
-+#define CONFIG_AV1_CUVID_DECODER 0
-+#define CONFIG_AV1_MEDIACODEC_DECODER 0
-+#define CONFIG_AV1_QSV_DECODER 0
-+#define CONFIG_LIBOPENH264_DECODER 0
-+#define CONFIG_H264_CUVID_DECODER 0
-+#define CONFIG_HEVC_CUVID_DECODER 0
-+#define CONFIG_HEVC_MEDIACODEC_DECODER 0
-+#define CONFIG_MJPEG_CUVID_DECODER 0
-+#define CONFIG_MJPEG_QSV_DECODER 0
-+#define CONFIG_MPEG1_CUVID_DECODER 0
-+#define CONFIG_MPEG2_CUVID_DECODER 0
-+#define CONFIG_MPEG4_CUVID_DECODER 0
-+#define CONFIG_MPEG4_MEDIACODEC_DECODER 0
-+#define CONFIG_VC1_CUVID_DECODER 0
-+#define CONFIG_VP8_CUVID_DECODER 0
-+#define CONFIG_VP8_MEDIACODEC_DECODER 0
-+#define CONFIG_VP8_QSV_DECODER 0
-+#define CONFIG_VP9_CUVID_DECODER 0
-+#define CONFIG_VP9_MEDIACODEC_DECODER 0
-+#define CONFIG_VP9_QSV_DECODER 0
-+#define CONFIG_VNULL_DECODER 0
-+#define CONFIG_ANULL_DECODER 0
-+#define CONFIG_A64MULTI_ENCODER 0
-+#define CONFIG_A64MULTI5_ENCODER 0
-+#define CONFIG_ALIAS_PIX_ENCODER 0
-+#define CONFIG_AMV_ENCODER 0
-+#define CONFIG_APNG_ENCODER 0
-+#define CONFIG_ASV1_ENCODER 0
-+#define CONFIG_ASV2_ENCODER 0
-+#define CONFIG_AVRP_ENCODER 0
-+#define CONFIG_AVUI_ENCODER 0
-+#define CONFIG_AYUV_ENCODER 0
-+#define CONFIG_BITPACKED_ENCODER 0
-+#define CONFIG_BMP_ENCODER 0
-+#define CONFIG_CFHD_ENCODER 0
-+#define CONFIG_CINEPAK_ENCODER 0
-+#define CONFIG_CLJR_ENCODER 0
-+#define CONFIG_COMFORTNOISE_ENCODER 0
-+#define CONFIG_DNXHD_ENCODER 0
-+#define CONFIG_DPX_ENCODER 0
-+#define CONFIG_DVVIDEO_ENCODER 0
-+#define CONFIG_EXR_ENCODER 0
-+#define CONFIG_FFV1_ENCODER 0
-+#define CONFIG_FFVHUFF_ENCODER 0
-+#define CONFIG_FITS_ENCODER 0
-+#define CONFIG_FLASHSV_ENCODER 0
-+#define CONFIG_FLASHSV2_ENCODER 0
-+#define CONFIG_FLV_ENCODER 0
-+#define CONFIG_GIF_ENCODER 0
-+#define CONFIG_H261_ENCODER 0
-+#define CONFIG_H263_ENCODER 0
-+#define CONFIG_H263P_ENCODER 0
-+#define CONFIG_H264_MEDIACODEC_ENCODER 0
-+#define CONFIG_HAP_ENCODER 0
-+#define CONFIG_HUFFYUV_ENCODER 0
-+#define CONFIG_JPEG2000_ENCODER 0
-+#define CONFIG_JPEGLS_ENCODER 0
-+#define CONFIG_LJPEG_ENCODER 0
-+#define CONFIG_MAGICYUV_ENCODER 0
-+#define CONFIG_MJPEG_ENCODER 0
-+#define CONFIG_MPEG1VIDEO_ENCODER 0
-+#define CONFIG_MPEG2VIDEO_ENCODER 0
-+#define CONFIG_MPEG4_ENCODER 0
-+#define CONFIG_MSMPEG4V2_ENCODER 0
-+#define CONFIG_MSMPEG4V3_ENCODER 0
-+#define CONFIG_MSVIDEO1_ENCODER 0
-+#define CONFIG_PAM_ENCODER 0
-+#define CONFIG_PBM_ENCODER 0
-+#define CONFIG_PCX_ENCODER 0
-+#define CONFIG_PFM_ENCODER 0
-+#define CONFIG_PGM_ENCODER 0
-+#define CONFIG_PGMYUV_ENCODER 0
-+#define CONFIG_PHM_ENCODER 0
-+#define CONFIG_PNG_ENCODER 0
-+#define CONFIG_PPM_ENCODER 0
-+#define CONFIG_PRORES_ENCODER 0
-+#define CONFIG_PRORES_AW_ENCODER 0
-+#define CONFIG_PRORES_KS_ENCODER 0
-+#define CONFIG_QOI_ENCODER 0
-+#define CONFIG_QTRLE_ENCODER 0
-+#define CONFIG_R10K_ENCODER 0
-+#define CONFIG_R210_ENCODER 0
-+#define CONFIG_RAWVIDEO_ENCODER 0
-+#define CONFIG_ROQ_ENCODER 0
-+#define CONFIG_RPZA_ENCODER 0
-+#define CONFIG_RV10_ENCODER 0
-+#define CONFIG_RV20_ENCODER 0
-+#define CONFIG_S302M_ENCODER 0
-+#define CONFIG_SGI_ENCODER 0
-+#define CONFIG_SMC_ENCODER 0
-+#define CONFIG_SNOW_ENCODER 0
-+#define CONFIG_SPEEDHQ_ENCODER 0
-+#define CONFIG_SUNRAST_ENCODER 0
-+#define CONFIG_SVQ1_ENCODER 0
-+#define CONFIG_TARGA_ENCODER 0
-+#define CONFIG_TIFF_ENCODER 0
-+#define CONFIG_UTVIDEO_ENCODER 0
-+#define CONFIG_V210_ENCODER 0
-+#define CONFIG_V308_ENCODER 0
-+#define CONFIG_V408_ENCODER 0
-+#define CONFIG_V410_ENCODER 0
-+#define CONFIG_VBN_ENCODER 0
-+#define CONFIG_VC2_ENCODER 0
-+#define CONFIG_WBMP_ENCODER 0
-+#define CONFIG_WRAPPED_AVFRAME_ENCODER 0
-+#define CONFIG_WMV1_ENCODER 0
-+#define CONFIG_WMV2_ENCODER 0
-+#define CONFIG_XBM_ENCODER 0
-+#define CONFIG_XFACE_ENCODER 0
-+#define CONFIG_XWD_ENCODER 0
-+#define CONFIG_Y41P_ENCODER 0
-+#define CONFIG_YUV4_ENCODER 0
-+#define CONFIG_ZLIB_ENCODER 0
-+#define CONFIG_ZMBV_ENCODER 0
-+#define CONFIG_AAC_ENCODER 0
-+#define CONFIG_AC3_ENCODER 0
-+#define CONFIG_AC3_FIXED_ENCODER 0
-+#define CONFIG_ALAC_ENCODER 0
-+#define CONFIG_APTX_ENCODER 0
-+#define CONFIG_APTX_HD_ENCODER 0
-+#define CONFIG_DCA_ENCODER 0
-+#define CONFIG_DFPWM_ENCODER 0
-+#define CONFIG_EAC3_ENCODER 0
-+#define CONFIG_FLAC_ENCODER 0
-+#define CONFIG_G723_1_ENCODER 0
-+#define CONFIG_HDR_ENCODER 0
-+#define CONFIG_MLP_ENCODER 0
-+#define CONFIG_MP2_ENCODER 0
-+#define CONFIG_MP2FIXED_ENCODER 0
-+#define CONFIG_NELLYMOSER_ENCODER 0
-+#define CONFIG_OPUS_ENCODER 0
-+#define CONFIG_RA_144_ENCODER 0
-+#define CONFIG_SBC_ENCODER 0
-+#define CONFIG_SONIC_ENCODER 0
-+#define CONFIG_SONIC_LS_ENCODER 0
-+#define CONFIG_TRUEHD_ENCODER 0
-+#define CONFIG_TTA_ENCODER 0
-+#define CONFIG_VORBIS_ENCODER 0
-+#define CONFIG_WAVPACK_ENCODER 0
-+#define CONFIG_WMAV1_ENCODER 0
-+#define CONFIG_WMAV2_ENCODER 0
-+#define CONFIG_PCM_ALAW_ENCODER 0
-+#define CONFIG_PCM_BLURAY_ENCODER 0
-+#define CONFIG_PCM_DVD_ENCODER 0
-+#define CONFIG_PCM_F32BE_ENCODER 0
-+#define CONFIG_PCM_F32LE_ENCODER 0
-+#define CONFIG_PCM_F64BE_ENCODER 0
-+#define CONFIG_PCM_F64LE_ENCODER 0
-+#define CONFIG_PCM_MULAW_ENCODER 0
-+#define CONFIG_PCM_S8_ENCODER 0
-+#define CONFIG_PCM_S8_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S16BE_ENCODER 0
-+#define CONFIG_PCM_S16BE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S16LE_ENCODER 0
-+#define CONFIG_PCM_S16LE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S24BE_ENCODER 0
-+#define CONFIG_PCM_S24DAUD_ENCODER 0
-+#define CONFIG_PCM_S24LE_ENCODER 0
-+#define CONFIG_PCM_S24LE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S32BE_ENCODER 0
-+#define CONFIG_PCM_S32LE_ENCODER 0
-+#define CONFIG_PCM_S32LE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S64BE_ENCODER 0
-+#define CONFIG_PCM_S64LE_ENCODER 0
-+#define CONFIG_PCM_U8_ENCODER 0
-+#define CONFIG_PCM_U16BE_ENCODER 0
-+#define CONFIG_PCM_U16LE_ENCODER 0
-+#define CONFIG_PCM_U24BE_ENCODER 0
-+#define CONFIG_PCM_U24LE_ENCODER 0
-+#define CONFIG_PCM_U32BE_ENCODER 0
-+#define CONFIG_PCM_U32LE_ENCODER 0
-+#define CONFIG_PCM_VIDC_ENCODER 0
-+#define CONFIG_ROQ_DPCM_ENCODER 0
-+#define CONFIG_ADPCM_ADX_ENCODER 0
-+#define CONFIG_ADPCM_ARGO_ENCODER 0
-+#define CONFIG_ADPCM_G722_ENCODER 0
-+#define CONFIG_ADPCM_G726_ENCODER 0
-+#define CONFIG_ADPCM_G726LE_ENCODER 0
-+#define CONFIG_ADPCM_IMA_AMV_ENCODER 0
-+#define CONFIG_ADPCM_IMA_ALP_ENCODER 0
-+#define CONFIG_ADPCM_IMA_APM_ENCODER 0
-+#define CONFIG_ADPCM_IMA_QT_ENCODER 0
-+#define CONFIG_ADPCM_IMA_SSI_ENCODER 0
-+#define CONFIG_ADPCM_IMA_WAV_ENCODER 0
-+#define CONFIG_ADPCM_IMA_WS_ENCODER 0
-+#define CONFIG_ADPCM_MS_ENCODER 0
-+#define CONFIG_ADPCM_SWF_ENCODER 0
-+#define CONFIG_ADPCM_YAMAHA_ENCODER 0
-+#define CONFIG_SSA_ENCODER 0
-+#define CONFIG_ASS_ENCODER 0
-+#define CONFIG_DVBSUB_ENCODER 0
-+#define CONFIG_DVDSUB_ENCODER 0
-+#define CONFIG_MOVTEXT_ENCODER 0
-+#define CONFIG_SRT_ENCODER 0
-+#define CONFIG_SUBRIP_ENCODER 0
-+#define CONFIG_TEXT_ENCODER 0
-+#define CONFIG_TTML_ENCODER 0
-+#define CONFIG_WEBVTT_ENCODER 0
-+#define CONFIG_XSUB_ENCODER 0
-+#define CONFIG_AAC_AT_ENCODER 0
-+#define CONFIG_ALAC_AT_ENCODER 0
-+#define CONFIG_ILBC_AT_ENCODER 0
-+#define CONFIG_PCM_ALAW_AT_ENCODER 0
-+#define CONFIG_PCM_MULAW_AT_ENCODER 0
-+#define CONFIG_LIBAOM_AV1_ENCODER 0
-+#define CONFIG_LIBCODEC2_ENCODER 0
-+#define CONFIG_LIBFDK_AAC_ENCODER 0
-+#define CONFIG_LIBGSM_ENCODER 0
-+#define CONFIG_LIBGSM_MS_ENCODER 0
-+#define CONFIG_LIBILBC_ENCODER 0
-+#define CONFIG_LIBJXL_ENCODER 0
-+#define CONFIG_LIBMP3LAME_ENCODER 0
-+#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
-+#define CONFIG_LIBOPENJPEG_ENCODER 0
-+#define CONFIG_LIBOPUS_ENCODER 0
-+#define CONFIG_LIBRAV1E_ENCODER 0
-+#define CONFIG_LIBSHINE_ENCODER 0
-+#define CONFIG_LIBSPEEX_ENCODER 0
-+#define CONFIG_LIBSVTAV1_ENCODER 0
-+#define CONFIG_LIBTHEORA_ENCODER 0
-+#define CONFIG_LIBTWOLAME_ENCODER 0
-+#define CONFIG_LIBVO_AMRWBENC_ENCODER 0
-+#define CONFIG_LIBVORBIS_ENCODER 0
-+#define CONFIG_LIBVPX_VP8_ENCODER 0
-+#define CONFIG_LIBVPX_VP9_ENCODER 0
-+#define CONFIG_LIBWEBP_ANIM_ENCODER 0
-+#define CONFIG_LIBWEBP_ENCODER 0
-+#define CONFIG_LIBX262_ENCODER 0
-+#define CONFIG_LIBX264_ENCODER 0
-+#define CONFIG_LIBX264RGB_ENCODER 0
-+#define CONFIG_LIBX265_ENCODER 0
-+#define CONFIG_LIBXAVS_ENCODER 0
-+#define CONFIG_LIBXAVS2_ENCODER 0
-+#define CONFIG_LIBXVID_ENCODER 0
-+#define CONFIG_AAC_MF_ENCODER 0
-+#define CONFIG_AC3_MF_ENCODER 0
-+#define CONFIG_H263_V4L2M2M_ENCODER 0
-+#define CONFIG_AV1_NVENC_ENCODER 0
-+#define CONFIG_AV1_QSV_ENCODER 0
-+#define CONFIG_AV1_AMF_ENCODER 0
-+#define CONFIG_LIBOPENH264_ENCODER 0
-+#define CONFIG_H264_AMF_ENCODER 0
-+#define CONFIG_H264_MF_ENCODER 0
-+#define CONFIG_H264_NVENC_ENCODER 0
-+#define CONFIG_H264_OMX_ENCODER 0
-+#define CONFIG_H264_QSV_ENCODER 0
-+#define CONFIG_H264_V4L2M2M_ENCODER 0
-+#define CONFIG_H264_VAAPI_ENCODER 0
-+#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_HEVC_AMF_ENCODER 0
-+#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
-+#define CONFIG_HEVC_MF_ENCODER 0
-+#define CONFIG_HEVC_NVENC_ENCODER 0
-+#define CONFIG_HEVC_QSV_ENCODER 0
-+#define CONFIG_HEVC_V4L2M2M_ENCODER 0
-+#define CONFIG_HEVC_VAAPI_ENCODER 0
-+#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_LIBKVAZAAR_ENCODER 0
-+#define CONFIG_MJPEG_QSV_ENCODER 0
-+#define CONFIG_MJPEG_VAAPI_ENCODER 0
-+#define CONFIG_MP3_MF_ENCODER 0
-+#define CONFIG_MPEG2_QSV_ENCODER 0
-+#define CONFIG_MPEG2_VAAPI_ENCODER 0
-+#define CONFIG_MPEG4_OMX_ENCODER 0
-+#define CONFIG_MPEG4_V4L2M2M_ENCODER 0
-+#define CONFIG_PRORES_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_VP8_V4L2M2M_ENCODER 0
-+#define CONFIG_VP8_VAAPI_ENCODER 0
-+#define CONFIG_VP9_VAAPI_ENCODER 0
-+#define CONFIG_VP9_QSV_ENCODER 0
-+#define CONFIG_VNULL_ENCODER 0
-+#define CONFIG_ANULL_ENCODER 0
-+#define CONFIG_AV1_D3D11VA_HWACCEL 0
-+#define CONFIG_AV1_D3D11VA2_HWACCEL 0
-+#define CONFIG_AV1_DXVA2_HWACCEL 0
-+#define CONFIG_AV1_NVDEC_HWACCEL 0
-+#define CONFIG_AV1_VAAPI_HWACCEL 0
-+#define CONFIG_AV1_VDPAU_HWACCEL 0
-+#define CONFIG_H263_VAAPI_HWACCEL 0
-+#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_H264_D3D11VA_HWACCEL 0
-+#define CONFIG_H264_D3D11VA2_HWACCEL 0
-+#define CONFIG_H264_DXVA2_HWACCEL 0
-+#define CONFIG_H264_NVDEC_HWACCEL 0
-+#define CONFIG_H264_VAAPI_HWACCEL 0
-+#define CONFIG_H264_VDPAU_HWACCEL 0
-+#define CONFIG_H264_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_HEVC_D3D11VA_HWACCEL 0
-+#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
-+#define CONFIG_HEVC_DXVA2_HWACCEL 0
-+#define CONFIG_HEVC_NVDEC_HWACCEL 0
-+#define CONFIG_HEVC_VAAPI_HWACCEL 0
-+#define CONFIG_HEVC_VDPAU_HWACCEL 0
-+#define CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_MJPEG_NVDEC_HWACCEL 0
-+#define CONFIG_MJPEG_VAAPI_HWACCEL 0
-+#define CONFIG_MPEG1_NVDEC_HWACCEL 0
-+#define CONFIG_MPEG1_VDPAU_HWACCEL 0
-+#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
-+#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
-+#define CONFIG_MPEG2_NVDEC_HWACCEL 0
-+#define CONFIG_MPEG2_DXVA2_HWACCEL 0
-+#define CONFIG_MPEG2_VAAPI_HWACCEL 0
-+#define CONFIG_MPEG2_VDPAU_HWACCEL 0
-+#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_MPEG4_NVDEC_HWACCEL 0
-+#define CONFIG_MPEG4_VAAPI_HWACCEL 0
-+#define CONFIG_MPEG4_VDPAU_HWACCEL 0
-+#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_VC1_D3D11VA_HWACCEL 0
-+#define CONFIG_VC1_D3D11VA2_HWACCEL 0
-+#define CONFIG_VC1_DXVA2_HWACCEL 0
-+#define CONFIG_VC1_NVDEC_HWACCEL 0
-+#define CONFIG_VC1_VAAPI_HWACCEL 0
-+#define CONFIG_VC1_VDPAU_HWACCEL 0
-+#define CONFIG_VP8_NVDEC_HWACCEL 0
-+#define CONFIG_VP8_VAAPI_HWACCEL 0
-+#define CONFIG_VP9_D3D11VA_HWACCEL 0
-+#define CONFIG_VP9_D3D11VA2_HWACCEL 0
-+#define CONFIG_VP9_DXVA2_HWACCEL 0
-+#define CONFIG_VP9_NVDEC_HWACCEL 0
-+#define CONFIG_VP9_VAAPI_HWACCEL 0
-+#define CONFIG_VP9_VDPAU_HWACCEL 0
-+#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_WMV3_D3D11VA_HWACCEL 0
-+#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
-+#define CONFIG_WMV3_DXVA2_HWACCEL 0
-+#define CONFIG_WMV3_NVDEC_HWACCEL 0
-+#define CONFIG_WMV3_VAAPI_HWACCEL 0
-+#define CONFIG_WMV3_VDPAU_HWACCEL 0
-+#define CONFIG_AAC_PARSER 1
-+#define CONFIG_AAC_LATM_PARSER 0
-+#define CONFIG_AC3_PARSER 0
-+#define CONFIG_ADX_PARSER 0
-+#define CONFIG_AMR_PARSER 0
-+#define CONFIG_AV1_PARSER 0
-+#define CONFIG_AVS2_PARSER 0
-+#define CONFIG_AVS3_PARSER 0
-+#define CONFIG_BMP_PARSER 0
-+#define CONFIG_CAVSVIDEO_PARSER 0
-+#define CONFIG_COOK_PARSER 0
-+#define CONFIG_CRI_PARSER 0
-+#define CONFIG_DCA_PARSER 0
-+#define CONFIG_DIRAC_PARSER 0
-+#define CONFIG_DNXHD_PARSER 0
-+#define CONFIG_DOLBY_E_PARSER 0
-+#define CONFIG_DPX_PARSER 0
-+#define CONFIG_DVAUDIO_PARSER 0
-+#define CONFIG_DVBSUB_PARSER 0
-+#define CONFIG_DVDSUB_PARSER 0
-+#define CONFIG_DVD_NAV_PARSER 0
-+#define CONFIG_FLAC_PARSER 1
-+#define CONFIG_FTR_PARSER 0
-+#define CONFIG_G723_1_PARSER 0
-+#define CONFIG_G729_PARSER 0
-+#define CONFIG_GIF_PARSER 0
-+#define CONFIG_GSM_PARSER 0
-+#define CONFIG_H261_PARSER 0
-+#define CONFIG_H263_PARSER 0
-+#define CONFIG_H264_PARSER 1
-+#define CONFIG_HEVC_PARSER 0
-+#define CONFIG_HDR_PARSER 0
-+#define CONFIG_IPU_PARSER 0
-+#define CONFIG_JPEG2000_PARSER 0
-+#define CONFIG_MISC4_PARSER 0
-+#define CONFIG_MJPEG_PARSER 0
-+#define CONFIG_MLP_PARSER 0
-+#define CONFIG_MPEG4VIDEO_PARSER 0
-+#define CONFIG_MPEGAUDIO_PARSER 1
-+#define CONFIG_MPEGVIDEO_PARSER 0
-+#define CONFIG_OPUS_PARSER 1
-+#define CONFIG_PNG_PARSER 0
-+#define CONFIG_PNM_PARSER 0
-+#define CONFIG_QOI_PARSER 0
-+#define CONFIG_RV30_PARSER 0
-+#define CONFIG_RV40_PARSER 0
-+#define CONFIG_SBC_PARSER 0
-+#define CONFIG_SIPR_PARSER 0
-+#define CONFIG_TAK_PARSER 0
-+#define CONFIG_VC1_PARSER 0
-+#define CONFIG_VORBIS_PARSER 1
-+#define CONFIG_VP3_PARSER 1
-+#define CONFIG_VP8_PARSER 1
-+#define CONFIG_VP9_PARSER 1
-+#define CONFIG_WEBP_PARSER 0
-+#define CONFIG_XBM_PARSER 0
-+#define CONFIG_XMA_PARSER 0
-+#define CONFIG_XWD_PARSER 0
-+#define CONFIG_ALSA_INDEV 0
-+#define CONFIG_ANDROID_CAMERA_INDEV 0
-+#define CONFIG_AVFOUNDATION_INDEV 0
-+#define CONFIG_BKTR_INDEV 0
-+#define CONFIG_DECKLINK_INDEV 0
-+#define CONFIG_DSHOW_INDEV 0
-+#define CONFIG_FBDEV_INDEV 0
-+#define CONFIG_GDIGRAB_INDEV 0
-+#define CONFIG_IEC61883_INDEV 0
-+#define CONFIG_JACK_INDEV 0
-+#define CONFIG_KMSGRAB_INDEV 0
-+#define CONFIG_LAVFI_INDEV 0
-+#define CONFIG_OPENAL_INDEV 0
-+#define CONFIG_OSS_INDEV 0
-+#define CONFIG_PULSE_INDEV 0
-+#define CONFIG_SNDIO_INDEV 0
-+#define CONFIG_V4L2_INDEV 0
-+#define CONFIG_VFWCAP_INDEV 0
-+#define CONFIG_XCBGRAB_INDEV 0
-+#define CONFIG_LIBCDIO_INDEV 0
-+#define CONFIG_LIBDC1394_INDEV 0
-+#define CONFIG_ALSA_OUTDEV 0
-+#define CONFIG_AUDIOTOOLBOX_OUTDEV 0
-+#define CONFIG_CACA_OUTDEV 0
-+#define CONFIG_DECKLINK_OUTDEV 0
-+#define CONFIG_FBDEV_OUTDEV 0
-+#define CONFIG_OPENGL_OUTDEV 0
-+#define CONFIG_OSS_OUTDEV 0
-+#define CONFIG_PULSE_OUTDEV 0
-+#define CONFIG_SDL2_OUTDEV 0
-+#define CONFIG_SNDIO_OUTDEV 0
-+#define CONFIG_V4L2_OUTDEV 0
-+#define CONFIG_XV_OUTDEV 0
-+#define CONFIG_ABENCH_FILTER 0
-+#define CONFIG_ACOMPRESSOR_FILTER 0
-+#define CONFIG_ACONTRAST_FILTER 0
-+#define CONFIG_ACOPY_FILTER 0
-+#define CONFIG_ACUE_FILTER 0
-+#define CONFIG_ACROSSFADE_FILTER 0
-+#define CONFIG_ACROSSOVER_FILTER 0
-+#define CONFIG_ACRUSHER_FILTER 0
-+#define CONFIG_ADECLICK_FILTER 0
-+#define CONFIG_ADECLIP_FILTER 0
-+#define CONFIG_ADECORRELATE_FILTER 0
-+#define CONFIG_ADELAY_FILTER 0
-+#define CONFIG_ADENORM_FILTER 0
-+#define CONFIG_ADERIVATIVE_FILTER 0
-+#define CONFIG_ADRC_FILTER 0
-+#define CONFIG_ADYNAMICEQUALIZER_FILTER 0
-+#define CONFIG_ADYNAMICSMOOTH_FILTER 0
-+#define CONFIG_AECHO_FILTER 0
-+#define CONFIG_AEMPHASIS_FILTER 0
-+#define CONFIG_AEVAL_FILTER 0
-+#define CONFIG_AEXCITER_FILTER 0
-+#define CONFIG_AFADE_FILTER 0
-+#define CONFIG_AFFTDN_FILTER 0
-+#define CONFIG_AFFTFILT_FILTER 0
-+#define CONFIG_AFIR_FILTER 0
-+#define CONFIG_AFORMAT_FILTER 0
-+#define CONFIG_AFREQSHIFT_FILTER 0
-+#define CONFIG_AFWTDN_FILTER 0
-+#define CONFIG_AGATE_FILTER 0
-+#define CONFIG_AIIR_FILTER 0
-+#define CONFIG_AINTEGRAL_FILTER 0
-+#define CONFIG_AINTERLEAVE_FILTER 0
-+#define CONFIG_ALATENCY_FILTER 0
-+#define CONFIG_ALIMITER_FILTER 0
-+#define CONFIG_ALLPASS_FILTER 0
-+#define CONFIG_ALOOP_FILTER 0
-+#define CONFIG_AMERGE_FILTER 0
-+#define CONFIG_AMETADATA_FILTER 0
-+#define CONFIG_AMIX_FILTER 0
-+#define CONFIG_AMULTIPLY_FILTER 0
-+#define CONFIG_ANEQUALIZER_FILTER 0
-+#define CONFIG_ANLMDN_FILTER 0
-+#define CONFIG_ANLMF_FILTER 0
-+#define CONFIG_ANLMS_FILTER 0
-+#define CONFIG_ANULL_FILTER 0
-+#define CONFIG_APAD_FILTER 0
-+#define CONFIG_APERMS_FILTER 0
-+#define CONFIG_APHASER_FILTER 0
-+#define CONFIG_APHASESHIFT_FILTER 0
-+#define CONFIG_APSYCLIP_FILTER 0
-+#define CONFIG_APULSATOR_FILTER 0
-+#define CONFIG_AREALTIME_FILTER 0
-+#define CONFIG_ARESAMPLE_FILTER 0
-+#define CONFIG_AREVERSE_FILTER 0
-+#define CONFIG_ARNNDN_FILTER 0
-+#define CONFIG_ASDR_FILTER 0
-+#define CONFIG_ASEGMENT_FILTER 0
-+#define CONFIG_ASELECT_FILTER 0
-+#define CONFIG_ASENDCMD_FILTER 0
-+#define CONFIG_ASETNSAMPLES_FILTER 0
-+#define CONFIG_ASETPTS_FILTER 0
-+#define CONFIG_ASETRATE_FILTER 0
-+#define CONFIG_ASETTB_FILTER 0
-+#define CONFIG_ASHOWINFO_FILTER 0
-+#define CONFIG_ASIDEDATA_FILTER 0
-+#define CONFIG_ASOFTCLIP_FILTER 0
-+#define CONFIG_ASPECTRALSTATS_FILTER 0
-+#define CONFIG_ASPLIT_FILTER 0
-+#define CONFIG_ASR_FILTER 0
-+#define CONFIG_ASTATS_FILTER 0
-+#define CONFIG_ASTREAMSELECT_FILTER 0
-+#define CONFIG_ASUBBOOST_FILTER 0
-+#define CONFIG_ASUBCUT_FILTER 0
-+#define CONFIG_ASUPERCUT_FILTER 0
-+#define CONFIG_ASUPERPASS_FILTER 0
-+#define CONFIG_ASUPERSTOP_FILTER 0
-+#define CONFIG_ATEMPO_FILTER 0
-+#define CONFIG_ATILT_FILTER 0
-+#define CONFIG_ATRIM_FILTER 0
-+#define CONFIG_AXCORRELATE_FILTER 0
-+#define CONFIG_AZMQ_FILTER 0
-+#define CONFIG_BANDPASS_FILTER 0
-+#define CONFIG_BANDREJECT_FILTER 0
-+#define CONFIG_BASS_FILTER 0
-+#define CONFIG_BIQUAD_FILTER 0
-+#define CONFIG_BS2B_FILTER 0
-+#define CONFIG_CHANNELMAP_FILTER 0
-+#define CONFIG_CHANNELSPLIT_FILTER 0
-+#define CONFIG_CHORUS_FILTER 0
-+#define CONFIG_COMPAND_FILTER 0
-+#define CONFIG_COMPENSATIONDELAY_FILTER 0
-+#define CONFIG_CROSSFEED_FILTER 0
-+#define CONFIG_CRYSTALIZER_FILTER 0
-+#define CONFIG_DCSHIFT_FILTER 0
-+#define CONFIG_DEESSER_FILTER 0
-+#define CONFIG_DIALOGUENHANCE_FILTER 0
-+#define CONFIG_DRMETER_FILTER 0
-+#define CONFIG_DYNAUDNORM_FILTER 0
-+#define CONFIG_EARWAX_FILTER 0
-+#define CONFIG_EBUR128_FILTER 0
-+#define CONFIG_EQUALIZER_FILTER 0
-+#define CONFIG_EXTRASTEREO_FILTER 0
-+#define CONFIG_FIREQUALIZER_FILTER 0
-+#define CONFIG_FLANGER_FILTER 0
-+#define CONFIG_HAAS_FILTER 0
-+#define CONFIG_HDCD_FILTER 0
-+#define CONFIG_HEADPHONE_FILTER 0
-+#define CONFIG_HIGHPASS_FILTER 0
-+#define CONFIG_HIGHSHELF_FILTER 0
-+#define CONFIG_JOIN_FILTER 0
-+#define CONFIG_LADSPA_FILTER 0
-+#define CONFIG_LOUDNORM_FILTER 0
-+#define CONFIG_LOWPASS_FILTER 0
-+#define CONFIG_LOWSHELF_FILTER 0
-+#define CONFIG_LV2_FILTER 0
-+#define CONFIG_MCOMPAND_FILTER 0
-+#define CONFIG_PAN_FILTER 0
-+#define CONFIG_REPLAYGAIN_FILTER 0
-+#define CONFIG_RUBBERBAND_FILTER 0
-+#define CONFIG_SIDECHAINCOMPRESS_FILTER 0
-+#define CONFIG_SIDECHAINGATE_FILTER 0
-+#define CONFIG_SILENCEDETECT_FILTER 0
-+#define CONFIG_SILENCEREMOVE_FILTER 0
-+#define CONFIG_SOFALIZER_FILTER 0
-+#define CONFIG_SPEECHNORM_FILTER 0
-+#define CONFIG_STEREOTOOLS_FILTER 0
-+#define CONFIG_STEREOWIDEN_FILTER 0
-+#define CONFIG_SUPEREQUALIZER_FILTER 0
-+#define CONFIG_SURROUND_FILTER 0
-+#define CONFIG_TILTSHELF_FILTER 0
-+#define CONFIG_TREBLE_FILTER 0
-+#define CONFIG_TREMOLO_FILTER 0
-+#define CONFIG_VIBRATO_FILTER 0
-+#define CONFIG_VIRTUALBASS_FILTER 0
-+#define CONFIG_VOLUME_FILTER 0
-+#define CONFIG_VOLUMEDETECT_FILTER 0
-+#define CONFIG_AEVALSRC_FILTER 0
-+#define CONFIG_AFDELAYSRC_FILTER 0
-+#define CONFIG_AFIRSRC_FILTER 0
-+#define CONFIG_ANOISESRC_FILTER 0
-+#define CONFIG_ANULLSRC_FILTER 0
-+#define CONFIG_FLITE_FILTER 0
-+#define CONFIG_HILBERT_FILTER 0
-+#define CONFIG_SINC_FILTER 0
-+#define CONFIG_SINE_FILTER 0
-+#define CONFIG_ANULLSINK_FILTER 0
-+#define CONFIG_ADDROI_FILTER 0
-+#define CONFIG_ALPHAEXTRACT_FILTER 0
-+#define CONFIG_ALPHAMERGE_FILTER 0
-+#define CONFIG_AMPLIFY_FILTER 0
-+#define CONFIG_ASS_FILTER 0
-+#define CONFIG_ATADENOISE_FILTER 0
-+#define CONFIG_AVGBLUR_FILTER 0
-+#define CONFIG_AVGBLUR_OPENCL_FILTER 0
-+#define CONFIG_AVGBLUR_VULKAN_FILTER 0
-+#define CONFIG_BACKGROUNDKEY_FILTER 0
-+#define CONFIG_BBOX_FILTER 0
-+#define CONFIG_BENCH_FILTER 0
-+#define CONFIG_BILATERAL_FILTER 0
-+#define CONFIG_BILATERAL_CUDA_FILTER 0
-+#define CONFIG_BITPLANENOISE_FILTER 0
-+#define CONFIG_BLACKDETECT_FILTER 0
-+#define CONFIG_BLACKFRAME_FILTER 0
-+#define CONFIG_BLEND_FILTER 0
-+#define CONFIG_BLEND_VULKAN_FILTER 0
-+#define CONFIG_BLOCKDETECT_FILTER 0
-+#define CONFIG_BLURDETECT_FILTER 0
-+#define CONFIG_BM3D_FILTER 0
-+#define CONFIG_BOXBLUR_FILTER 0
-+#define CONFIG_BOXBLUR_OPENCL_FILTER 0
-+#define CONFIG_BWDIF_FILTER 0
-+#define CONFIG_CAS_FILTER 0
-+#define CONFIG_CHROMABER_VULKAN_FILTER 0
-+#define CONFIG_CHROMAHOLD_FILTER 0
-+#define CONFIG_CHROMAKEY_FILTER 0
-+#define CONFIG_CHROMAKEY_CUDA_FILTER 0
-+#define CONFIG_CHROMANR_FILTER 0
-+#define CONFIG_CHROMASHIFT_FILTER 0
-+#define CONFIG_CIESCOPE_FILTER 0
-+#define CONFIG_CODECVIEW_FILTER 0
-+#define CONFIG_COLORBALANCE_FILTER 0
-+#define CONFIG_COLORCHANNELMIXER_FILTER 0
-+#define CONFIG_COLORCONTRAST_FILTER 0
-+#define CONFIG_COLORCORRECT_FILTER 0
-+#define CONFIG_COLORIZE_FILTER 0
-+#define CONFIG_COLORKEY_FILTER 0
-+#define CONFIG_COLORKEY_OPENCL_FILTER 0
-+#define CONFIG_COLORHOLD_FILTER 0
-+#define CONFIG_COLORLEVELS_FILTER 0
-+#define CONFIG_COLORMAP_FILTER 0
-+#define CONFIG_COLORMATRIX_FILTER 0
-+#define CONFIG_COLORSPACE_FILTER 0
-+#define CONFIG_COLORSPACE_CUDA_FILTER 0
-+#define CONFIG_COLORTEMPERATURE_FILTER 0
-+#define CONFIG_CONVOLUTION_FILTER 0
-+#define CONFIG_CONVOLUTION_OPENCL_FILTER 0
-+#define CONFIG_CONVOLVE_FILTER 0
-+#define CONFIG_COPY_FILTER 0
-+#define CONFIG_COREIMAGE_FILTER 0
-+#define CONFIG_CORR_FILTER 0
-+#define CONFIG_COVER_RECT_FILTER 0
-+#define CONFIG_CROP_FILTER 0
-+#define CONFIG_CROPDETECT_FILTER 0
-+#define CONFIG_CUE_FILTER 0
-+#define CONFIG_CURVES_FILTER 0
-+#define CONFIG_DATASCOPE_FILTER 0
-+#define CONFIG_DBLUR_FILTER 0
-+#define CONFIG_DCTDNOIZ_FILTER 0
-+#define CONFIG_DEBAND_FILTER 0
-+#define CONFIG_DEBLOCK_FILTER 0
-+#define CONFIG_DECIMATE_FILTER 0
-+#define CONFIG_DECONVOLVE_FILTER 0
-+#define CONFIG_DEDOT_FILTER 0
-+#define CONFIG_DEFLATE_FILTER 0
-+#define CONFIG_DEFLICKER_FILTER 0
-+#define CONFIG_DEINTERLACE_QSV_FILTER 0
-+#define CONFIG_DEINTERLACE_VAAPI_FILTER 0
-+#define CONFIG_DEJUDDER_FILTER 0
-+#define CONFIG_DELOGO_FILTER 0
-+#define CONFIG_DENOISE_VAAPI_FILTER 0
-+#define CONFIG_DERAIN_FILTER 0
-+#define CONFIG_DESHAKE_FILTER 0
-+#define CONFIG_DESHAKE_OPENCL_FILTER 0
-+#define CONFIG_DESPILL_FILTER 0
-+#define CONFIG_DETELECINE_FILTER 0
-+#define CONFIG_DILATION_FILTER 0
-+#define CONFIG_DILATION_OPENCL_FILTER 0
-+#define CONFIG_DISPLACE_FILTER 0
-+#define CONFIG_DNN_CLASSIFY_FILTER 0
-+#define CONFIG_DNN_DETECT_FILTER 0
-+#define CONFIG_DNN_PROCESSING_FILTER 0
-+#define CONFIG_DOUBLEWEAVE_FILTER 0
-+#define CONFIG_DRAWBOX_FILTER 0
-+#define CONFIG_DRAWGRAPH_FILTER 0
-+#define CONFIG_DRAWGRID_FILTER 0
-+#define CONFIG_DRAWTEXT_FILTER 0
-+#define CONFIG_EDGEDETECT_FILTER 0
-+#define CONFIG_ELBG_FILTER 0
-+#define CONFIG_ENTROPY_FILTER 0
-+#define CONFIG_EPX_FILTER 0
-+#define CONFIG_EQ_FILTER 0
-+#define CONFIG_EROSION_FILTER 0
-+#define CONFIG_EROSION_OPENCL_FILTER 0
-+#define CONFIG_ESTDIF_FILTER 0
-+#define CONFIG_EXPOSURE_FILTER 0
-+#define CONFIG_EXTRACTPLANES_FILTER 0
-+#define CONFIG_FADE_FILTER 0
-+#define CONFIG_FEEDBACK_FILTER 0
-+#define CONFIG_FFTDNOIZ_FILTER 0
-+#define CONFIG_FFTFILT_FILTER 0
-+#define CONFIG_FIELD_FILTER 0
-+#define CONFIG_FIELDHINT_FILTER 0
-+#define CONFIG_FIELDMATCH_FILTER 0
-+#define CONFIG_FIELDORDER_FILTER 0
-+#define CONFIG_FILLBORDERS_FILTER 0
-+#define CONFIG_FIND_RECT_FILTER 0
-+#define CONFIG_FLIP_VULKAN_FILTER 0
-+#define CONFIG_FLOODFILL_FILTER 0
-+#define CONFIG_FORMAT_FILTER 0
-+#define CONFIG_FPS_FILTER 0
-+#define CONFIG_FRAMEPACK_FILTER 0
-+#define CONFIG_FRAMERATE_FILTER 0
-+#define CONFIG_FRAMESTEP_FILTER 0
-+#define CONFIG_FREEZEDETECT_FILTER 0
-+#define CONFIG_FREEZEFRAMES_FILTER 0
-+#define CONFIG_FREI0R_FILTER 0
-+#define CONFIG_FSPP_FILTER 0
-+#define CONFIG_GBLUR_FILTER 0
-+#define CONFIG_GBLUR_VULKAN_FILTER 0
-+#define CONFIG_GEQ_FILTER 0
-+#define CONFIG_GRADFUN_FILTER 0
-+#define CONFIG_GRAPHMONITOR_FILTER 0
-+#define CONFIG_GRAYWORLD_FILTER 0
-+#define CONFIG_GREYEDGE_FILTER 0
-+#define CONFIG_GUIDED_FILTER 0
-+#define CONFIG_HALDCLUT_FILTER 0
-+#define CONFIG_HFLIP_FILTER 0
-+#define CONFIG_HFLIP_VULKAN_FILTER 0
-+#define CONFIG_HISTEQ_FILTER 0
-+#define CONFIG_HISTOGRAM_FILTER 0
-+#define CONFIG_HQDN3D_FILTER 0
-+#define CONFIG_HQX_FILTER 0
-+#define CONFIG_HSTACK_FILTER 0
-+#define CONFIG_HSVHOLD_FILTER 0
-+#define CONFIG_HSVKEY_FILTER 0
-+#define CONFIG_HUE_FILTER 0
-+#define CONFIG_HUESATURATION_FILTER 0
-+#define CONFIG_HWDOWNLOAD_FILTER 0
-+#define CONFIG_HWMAP_FILTER 0
-+#define CONFIG_HWUPLOAD_FILTER 0
-+#define CONFIG_HWUPLOAD_CUDA_FILTER 0
-+#define CONFIG_HYSTERESIS_FILTER 0
-+#define CONFIG_ICCDETECT_FILTER 0
-+#define CONFIG_ICCGEN_FILTER 0
-+#define CONFIG_IDENTITY_FILTER 0
-+#define CONFIG_IDET_FILTER 0
-+#define CONFIG_IL_FILTER 0
-+#define CONFIG_INFLATE_FILTER 0
-+#define CONFIG_INTERLACE_FILTER 0
-+#define CONFIG_INTERLEAVE_FILTER 0
-+#define CONFIG_KERNDEINT_FILTER 0
-+#define CONFIG_KIRSCH_FILTER 0
-+#define CONFIG_LAGFUN_FILTER 0
-+#define CONFIG_LATENCY_FILTER 0
-+#define CONFIG_LENSCORRECTION_FILTER 0
-+#define CONFIG_LENSFUN_FILTER 0
-+#define CONFIG_LIBPLACEBO_FILTER 0
-+#define CONFIG_LIBVMAF_FILTER 0
-+#define CONFIG_LIMITDIFF_FILTER 0
-+#define CONFIG_LIMITER_FILTER 0
-+#define CONFIG_LOOP_FILTER 0
-+#define CONFIG_LUMAKEY_FILTER 0
-+#define CONFIG_LUT_FILTER 0
-+#define CONFIG_LUT1D_FILTER 0
-+#define CONFIG_LUT2_FILTER 0
-+#define CONFIG_LUT3D_FILTER 0
-+#define CONFIG_LUTRGB_FILTER 0
-+#define CONFIG_LUTYUV_FILTER 0
-+#define CONFIG_MASKEDCLAMP_FILTER 0
-+#define CONFIG_MASKEDMAX_FILTER 0
-+#define CONFIG_MASKEDMERGE_FILTER 0
-+#define CONFIG_MASKEDMIN_FILTER 0
-+#define CONFIG_MASKEDTHRESHOLD_FILTER 0
-+#define CONFIG_MASKFUN_FILTER 0
-+#define CONFIG_MCDEINT_FILTER 0
-+#define CONFIG_MEDIAN_FILTER 0
-+#define CONFIG_MERGEPLANES_FILTER 0
-+#define CONFIG_MESTIMATE_FILTER 0
-+#define CONFIG_METADATA_FILTER 0
-+#define CONFIG_MIDEQUALIZER_FILTER 0
-+#define CONFIG_MINTERPOLATE_FILTER 0
-+#define CONFIG_MIX_FILTER 0
-+#define CONFIG_MONOCHROME_FILTER 0
-+#define CONFIG_MORPHO_FILTER 0
-+#define CONFIG_MPDECIMATE_FILTER 0
-+#define CONFIG_MSAD_FILTER 0
-+#define CONFIG_MULTIPLY_FILTER 0
-+#define CONFIG_NEGATE_FILTER 0
-+#define CONFIG_NLMEANS_FILTER 0
-+#define CONFIG_NLMEANS_OPENCL_FILTER 0
-+#define CONFIG_NNEDI_FILTER 0
-+#define CONFIG_NOFORMAT_FILTER 0
-+#define CONFIG_NOISE_FILTER 0
-+#define CONFIG_NORMALIZE_FILTER 0
-+#define CONFIG_NULL_FILTER 0
-+#define CONFIG_OCR_FILTER 0
-+#define CONFIG_OCV_FILTER 0
-+#define CONFIG_OSCILLOSCOPE_FILTER 0
-+#define CONFIG_OVERLAY_FILTER 0
-+#define CONFIG_OVERLAY_OPENCL_FILTER 0
-+#define CONFIG_OVERLAY_QSV_FILTER 0
-+#define CONFIG_OVERLAY_VAAPI_FILTER 0
-+#define CONFIG_OVERLAY_VULKAN_FILTER 0
-+#define CONFIG_OVERLAY_CUDA_FILTER 0
-+#define CONFIG_OWDENOISE_FILTER 0
-+#define CONFIG_PAD_FILTER 0
-+#define CONFIG_PAD_OPENCL_FILTER 0
-+#define CONFIG_PALETTEGEN_FILTER 0
-+#define CONFIG_PALETTEUSE_FILTER 0
-+#define CONFIG_PERMS_FILTER 0
-+#define CONFIG_PERSPECTIVE_FILTER 0
-+#define CONFIG_PHASE_FILTER 0
-+#define CONFIG_PHOTOSENSITIVITY_FILTER 0
-+#define CONFIG_PIXDESCTEST_FILTER 0
-+#define CONFIG_PIXELIZE_FILTER 0
-+#define CONFIG_PIXSCOPE_FILTER 0
-+#define CONFIG_PP_FILTER 0
-+#define CONFIG_PP7_FILTER 0
-+#define CONFIG_PREMULTIPLY_FILTER 0
-+#define CONFIG_PREWITT_FILTER 0
-+#define CONFIG_PREWITT_OPENCL_FILTER 0
-+#define CONFIG_PROCAMP_VAAPI_FILTER 0
-+#define CONFIG_PROGRAM_OPENCL_FILTER 0
-+#define CONFIG_PSEUDOCOLOR_FILTER 0
-+#define CONFIG_PSNR_FILTER 0
-+#define CONFIG_PULLUP_FILTER 0
-+#define CONFIG_QP_FILTER 0
-+#define CONFIG_RANDOM_FILTER 0
-+#define CONFIG_READEIA608_FILTER 0
-+#define CONFIG_READVITC_FILTER 0
-+#define CONFIG_REALTIME_FILTER 0
-+#define CONFIG_REMAP_FILTER 0
-+#define CONFIG_REMAP_OPENCL_FILTER 0
-+#define CONFIG_REMOVEGRAIN_FILTER 0
-+#define CONFIG_REMOVELOGO_FILTER 0
-+#define CONFIG_REPEATFIELDS_FILTER 0
-+#define CONFIG_REVERSE_FILTER 0
-+#define CONFIG_RGBASHIFT_FILTER 0
-+#define CONFIG_ROBERTS_FILTER 0
-+#define CONFIG_ROBERTS_OPENCL_FILTER 0
-+#define CONFIG_ROTATE_FILTER 0
-+#define CONFIG_SAB_FILTER 0
-+#define CONFIG_SCALE_FILTER 0
-+#define CONFIG_SCALE_CUDA_FILTER 0
-+#define CONFIG_SCALE_NPP_FILTER 0
-+#define CONFIG_SCALE_QSV_FILTER 0
-+#define CONFIG_SCALE_VAAPI_FILTER 0
-+#define CONFIG_SCALE_VULKAN_FILTER 0
-+#define CONFIG_SCALE2REF_FILTER 0
-+#define CONFIG_SCALE2REF_NPP_FILTER 0
-+#define CONFIG_SCDET_FILTER 0
-+#define CONFIG_SCHARR_FILTER 0
-+#define CONFIG_SCROLL_FILTER 0
-+#define CONFIG_SEGMENT_FILTER 0
-+#define CONFIG_SELECT_FILTER 0
-+#define CONFIG_SELECTIVECOLOR_FILTER 0
-+#define CONFIG_SENDCMD_FILTER 0
-+#define CONFIG_SEPARATEFIELDS_FILTER 0
-+#define CONFIG_SETDAR_FILTER 0
-+#define CONFIG_SETFIELD_FILTER 0
-+#define CONFIG_SETPARAMS_FILTER 0
-+#define CONFIG_SETPTS_FILTER 0
-+#define CONFIG_SETRANGE_FILTER 0
-+#define CONFIG_SETSAR_FILTER 0
-+#define CONFIG_SETTB_FILTER 0
-+#define CONFIG_SHARPEN_NPP_FILTER 0
-+#define CONFIG_SHARPNESS_VAAPI_FILTER 0
-+#define CONFIG_SHEAR_FILTER 0
-+#define CONFIG_SHOWINFO_FILTER 0
-+#define CONFIG_SHOWPALETTE_FILTER 0
-+#define CONFIG_SHUFFLEFRAMES_FILTER 0
-+#define CONFIG_SHUFFLEPIXELS_FILTER 0
-+#define CONFIG_SHUFFLEPLANES_FILTER 0
-+#define CONFIG_SIDEDATA_FILTER 0
-+#define CONFIG_SIGNALSTATS_FILTER 0
-+#define CONFIG_SIGNATURE_FILTER 0
-+#define CONFIG_SITI_FILTER 0
-+#define CONFIG_SMARTBLUR_FILTER 0
-+#define CONFIG_SOBEL_FILTER 0
-+#define CONFIG_SOBEL_OPENCL_FILTER 0
-+#define CONFIG_SPLIT_FILTER 0
-+#define CONFIG_SPP_FILTER 0
-+#define CONFIG_SR_FILTER 0
-+#define CONFIG_SSIM_FILTER 0
-+#define CONFIG_SSIM360_FILTER 0
-+#define CONFIG_STEREO3D_FILTER 0
-+#define CONFIG_STREAMSELECT_FILTER 0
-+#define CONFIG_SUBTITLES_FILTER 0
-+#define CONFIG_SUPER2XSAI_FILTER 0
-+#define CONFIG_SWAPRECT_FILTER 0
-+#define CONFIG_SWAPUV_FILTER 0
-+#define CONFIG_TBLEND_FILTER 0
-+#define CONFIG_TELECINE_FILTER 0
-+#define CONFIG_THISTOGRAM_FILTER 0
-+#define CONFIG_THRESHOLD_FILTER 0
-+#define CONFIG_THUMBNAIL_FILTER 0
-+#define CONFIG_THUMBNAIL_CUDA_FILTER 0
-+#define CONFIG_TILE_FILTER 0
-+#define CONFIG_TINTERLACE_FILTER 0
-+#define CONFIG_TLUT2_FILTER 0
-+#define CONFIG_TMEDIAN_FILTER 0
-+#define CONFIG_TMIDEQUALIZER_FILTER 0
-+#define CONFIG_TMIX_FILTER 0
-+#define CONFIG_TONEMAP_FILTER 0
-+#define CONFIG_TONEMAP_OPENCL_FILTER 0
-+#define CONFIG_TONEMAP_VAAPI_FILTER 0
-+#define CONFIG_TPAD_FILTER 0
-+#define CONFIG_TRANSPOSE_FILTER 0
-+#define CONFIG_TRANSPOSE_NPP_FILTER 0
-+#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
-+#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
-+#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
-+#define CONFIG_TRIM_FILTER 0
-+#define CONFIG_UNPREMULTIPLY_FILTER 0
-+#define CONFIG_UNSHARP_FILTER 0
-+#define CONFIG_UNSHARP_OPENCL_FILTER 0
-+#define CONFIG_UNTILE_FILTER 0
-+#define CONFIG_USPP_FILTER 0
-+#define CONFIG_V360_FILTER 0
-+#define CONFIG_VAGUEDENOISER_FILTER 0
-+#define CONFIG_VARBLUR_FILTER 0
-+#define CONFIG_VECTORSCOPE_FILTER 0
-+#define CONFIG_VFLIP_FILTER 0
-+#define CONFIG_VFLIP_VULKAN_FILTER 0
-+#define CONFIG_VFRDET_FILTER 0
-+#define CONFIG_VIBRANCE_FILTER 0
-+#define CONFIG_VIDSTABDETECT_FILTER 0
-+#define CONFIG_VIDSTABTRANSFORM_FILTER 0
-+#define CONFIG_VIF_FILTER 0
-+#define CONFIG_VIGNETTE_FILTER 0
-+#define CONFIG_VMAFMOTION_FILTER 0
-+#define CONFIG_VPP_QSV_FILTER 0
-+#define CONFIG_VSTACK_FILTER 0
-+#define CONFIG_W3FDIF_FILTER 0
-+#define CONFIG_WAVEFORM_FILTER 0
-+#define CONFIG_WEAVE_FILTER 0
-+#define CONFIG_XBR_FILTER 0
-+#define CONFIG_XCORRELATE_FILTER 0
-+#define CONFIG_XFADE_FILTER 0
-+#define CONFIG_XFADE_OPENCL_FILTER 0
-+#define CONFIG_XMEDIAN_FILTER 0
-+#define CONFIG_XSTACK_FILTER 0
-+#define CONFIG_YADIF_FILTER 0
-+#define CONFIG_YADIF_CUDA_FILTER 0
-+#define CONFIG_YADIF_VIDEOTOOLBOX_FILTER 0
-+#define CONFIG_YAEPBLUR_FILTER 0
-+#define CONFIG_ZMQ_FILTER 0
-+#define CONFIG_ZOOMPAN_FILTER 0
-+#define CONFIG_ZSCALE_FILTER 0
-+#define CONFIG_HSTACK_VAAPI_FILTER 0
-+#define CONFIG_VSTACK_VAAPI_FILTER 0
-+#define CONFIG_XSTACK_VAAPI_FILTER 0
-+#define CONFIG_ALLRGB_FILTER 0
-+#define CONFIG_ALLYUV_FILTER 0
-+#define CONFIG_CELLAUTO_FILTER 0
-+#define CONFIG_COLOR_FILTER 0
-+#define CONFIG_COLORCHART_FILTER 0
-+#define CONFIG_COLORSPECTRUM_FILTER 0
-+#define CONFIG_COREIMAGESRC_FILTER 0
-+#define CONFIG_DDAGRAB_FILTER 0
-+#define CONFIG_FREI0R_SRC_FILTER 0
-+#define CONFIG_GRADIENTS_FILTER 0
-+#define CONFIG_HALDCLUTSRC_FILTER 0
-+#define CONFIG_LIFE_FILTER 0
-+#define CONFIG_MANDELBROT_FILTER 0
-+#define CONFIG_MPTESTSRC_FILTER 0
-+#define CONFIG_NULLSRC_FILTER 0
-+#define CONFIG_OPENCLSRC_FILTER 0
-+#define CONFIG_PAL75BARS_FILTER 0
-+#define CONFIG_PAL100BARS_FILTER 0
-+#define CONFIG_RGBTESTSRC_FILTER 0
-+#define CONFIG_SIERPINSKI_FILTER 0
-+#define CONFIG_SMPTEBARS_FILTER 0
-+#define CONFIG_SMPTEHDBARS_FILTER 0
-+#define CONFIG_TESTSRC_FILTER 0
-+#define CONFIG_TESTSRC2_FILTER 0
-+#define CONFIG_YUVTESTSRC_FILTER 0
-+#define CONFIG_NULLSINK_FILTER 0
-+#define CONFIG_A3DSCOPE_FILTER 0
-+#define CONFIG_ABITSCOPE_FILTER 0
-+#define CONFIG_ADRAWGRAPH_FILTER 0
-+#define CONFIG_AGRAPHMONITOR_FILTER 0
-+#define CONFIG_AHISTOGRAM_FILTER 0
-+#define CONFIG_APHASEMETER_FILTER 0
-+#define CONFIG_AVECTORSCOPE_FILTER 0
-+#define CONFIG_CONCAT_FILTER 0
-+#define CONFIG_SHOWCQT_FILTER 0
-+#define CONFIG_SHOWCWT_FILTER 0
-+#define CONFIG_SHOWFREQS_FILTER 0
-+#define CONFIG_SHOWSPATIAL_FILTER 0
-+#define CONFIG_SHOWSPECTRUM_FILTER 0
-+#define CONFIG_SHOWSPECTRUMPIC_FILTER 0
-+#define CONFIG_SHOWVOLUME_FILTER 0
-+#define CONFIG_SHOWWAVES_FILTER 0
-+#define CONFIG_SHOWWAVESPIC_FILTER 0
-+#define CONFIG_SPECTRUMSYNTH_FILTER 0
-+#define CONFIG_AVSYNCTEST_FILTER 0
-+#define CONFIG_AMOVIE_FILTER 0
-+#define CONFIG_MOVIE_FILTER 0
-+#define CONFIG_AFIFO_FILTER 0
-+#define CONFIG_FIFO_FILTER 0
-+#define CONFIG_AA_DEMUXER 0
-+#define CONFIG_AAC_DEMUXER 1
-+#define CONFIG_AAX_DEMUXER 0
-+#define CONFIG_AC3_DEMUXER 0
-+#define CONFIG_ACE_DEMUXER 0
-+#define CONFIG_ACM_DEMUXER 0
-+#define CONFIG_ACT_DEMUXER 0
-+#define CONFIG_ADF_DEMUXER 0
-+#define CONFIG_ADP_DEMUXER 0
-+#define CONFIG_ADS_DEMUXER 0
-+#define CONFIG_ADX_DEMUXER 0
-+#define CONFIG_AEA_DEMUXER 0
-+#define CONFIG_AFC_DEMUXER 0
-+#define CONFIG_AIFF_DEMUXER 0
-+#define CONFIG_AIX_DEMUXER 0
-+#define CONFIG_ALP_DEMUXER 0
-+#define CONFIG_AMR_DEMUXER 0
-+#define CONFIG_AMRNB_DEMUXER 0
-+#define CONFIG_AMRWB_DEMUXER 0
-+#define CONFIG_ANM_DEMUXER 0
-+#define CONFIG_APAC_DEMUXER 0
-+#define CONFIG_APC_DEMUXER 0
-+#define CONFIG_APE_DEMUXER 0
-+#define CONFIG_APM_DEMUXER 0
-+#define CONFIG_APNG_DEMUXER 0
-+#define CONFIG_APTX_DEMUXER 0
-+#define CONFIG_APTX_HD_DEMUXER 0
-+#define CONFIG_AQTITLE_DEMUXER 0
-+#define CONFIG_ARGO_ASF_DEMUXER 0
-+#define CONFIG_ARGO_BRP_DEMUXER 0
-+#define CONFIG_ARGO_CVG_DEMUXER 0
-+#define CONFIG_ASF_DEMUXER 0
-+#define CONFIG_ASF_O_DEMUXER 0
-+#define CONFIG_ASS_DEMUXER 0
-+#define CONFIG_AST_DEMUXER 0
-+#define CONFIG_AU_DEMUXER 0
-+#define CONFIG_AV1_DEMUXER 0
-+#define CONFIG_AVI_DEMUXER 0
-+#define CONFIG_AVISYNTH_DEMUXER 0
-+#define CONFIG_AVR_DEMUXER 0
-+#define CONFIG_AVS_DEMUXER 0
-+#define CONFIG_AVS2_DEMUXER 0
-+#define CONFIG_AVS3_DEMUXER 0
-+#define CONFIG_BETHSOFTVID_DEMUXER 0
-+#define CONFIG_BFI_DEMUXER 0
-+#define CONFIG_BINTEXT_DEMUXER 0
-+#define CONFIG_BINK_DEMUXER 0
-+#define CONFIG_BINKA_DEMUXER 0
-+#define CONFIG_BIT_DEMUXER 0
-+#define CONFIG_BITPACKED_DEMUXER 0
-+#define CONFIG_BMV_DEMUXER 0
-+#define CONFIG_BFSTM_DEMUXER 0
-+#define CONFIG_BRSTM_DEMUXER 0
-+#define CONFIG_BOA_DEMUXER 0
-+#define CONFIG_BONK_DEMUXER 0
-+#define CONFIG_C93_DEMUXER 0
-+#define CONFIG_CAF_DEMUXER 0
-+#define CONFIG_CAVSVIDEO_DEMUXER 0
-+#define CONFIG_CDG_DEMUXER 0
-+#define CONFIG_CDXL_DEMUXER 0
-+#define CONFIG_CINE_DEMUXER 0
-+#define CONFIG_CODEC2_DEMUXER 0
-+#define CONFIG_CODEC2RAW_DEMUXER 0
-+#define CONFIG_CONCAT_DEMUXER 0
-+#define CONFIG_DASH_DEMUXER 0
-+#define CONFIG_DATA_DEMUXER 0
-+#define CONFIG_DAUD_DEMUXER 0
-+#define CONFIG_DCSTR_DEMUXER 0
-+#define CONFIG_DERF_DEMUXER 0
-+#define CONFIG_DFA_DEMUXER 0
-+#define CONFIG_DFPWM_DEMUXER 0
-+#define CONFIG_DHAV_DEMUXER 0
-+#define CONFIG_DIRAC_DEMUXER 0
-+#define CONFIG_DNXHD_DEMUXER 0
-+#define CONFIG_DSF_DEMUXER 0
-+#define CONFIG_DSICIN_DEMUXER 0
-+#define CONFIG_DSS_DEMUXER 0
-+#define CONFIG_DTS_DEMUXER 0
-+#define CONFIG_DTSHD_DEMUXER 0
-+#define CONFIG_DV_DEMUXER 0
-+#define CONFIG_DVBSUB_DEMUXER 0
-+#define CONFIG_DVBTXT_DEMUXER 0
-+#define CONFIG_DXA_DEMUXER 0
-+#define CONFIG_EA_DEMUXER 0
-+#define CONFIG_EA_CDATA_DEMUXER 0
-+#define CONFIG_EAC3_DEMUXER 0
-+#define CONFIG_EPAF_DEMUXER 0
-+#define CONFIG_FFMETADATA_DEMUXER 0
-+#define CONFIG_FILMSTRIP_DEMUXER 0
-+#define CONFIG_FITS_DEMUXER 0
-+#define CONFIG_FLAC_DEMUXER 1
-+#define CONFIG_FLIC_DEMUXER 0
-+#define CONFIG_FLV_DEMUXER 0
-+#define CONFIG_LIVE_FLV_DEMUXER 0
-+#define CONFIG_FOURXM_DEMUXER 0
-+#define CONFIG_FRM_DEMUXER 0
-+#define CONFIG_FSB_DEMUXER 0
-+#define CONFIG_FWSE_DEMUXER 0
-+#define CONFIG_G722_DEMUXER 0
-+#define CONFIG_G723_1_DEMUXER 0
-+#define CONFIG_G726_DEMUXER 0
-+#define CONFIG_G726LE_DEMUXER 0
-+#define CONFIG_G729_DEMUXER 0
-+#define CONFIG_GDV_DEMUXER 0
-+#define CONFIG_GENH_DEMUXER 0
-+#define CONFIG_GIF_DEMUXER 0
-+#define CONFIG_GSM_DEMUXER 0
-+#define CONFIG_GXF_DEMUXER 0
-+#define CONFIG_H261_DEMUXER 0
-+#define CONFIG_H263_DEMUXER 0
-+#define CONFIG_H264_DEMUXER 0
-+#define CONFIG_HCA_DEMUXER 0
-+#define CONFIG_HCOM_DEMUXER 0
-+#define CONFIG_HEVC_DEMUXER 0
-+#define CONFIG_HLS_DEMUXER 0
-+#define CONFIG_HNM_DEMUXER 0
-+#define CONFIG_ICO_DEMUXER 0
-+#define CONFIG_IDCIN_DEMUXER 0
-+#define CONFIG_IDF_DEMUXER 0
-+#define CONFIG_IFF_DEMUXER 0
-+#define CONFIG_IFV_DEMUXER 0
-+#define CONFIG_ILBC_DEMUXER 0
-+#define CONFIG_IMAGE2_DEMUXER 0
-+#define CONFIG_IMAGE2PIPE_DEMUXER 0
-+#define CONFIG_IMAGE2_ALIAS_PIX_DEMUXER 0
-+#define CONFIG_IMAGE2_BRENDER_PIX_DEMUXER 0
-+#define CONFIG_IMF_DEMUXER 0
-+#define CONFIG_INGENIENT_DEMUXER 0
-+#define CONFIG_IPMOVIE_DEMUXER 0
-+#define CONFIG_IPU_DEMUXER 0
-+#define CONFIG_IRCAM_DEMUXER 0
-+#define CONFIG_ISS_DEMUXER 0
-+#define CONFIG_IV8_DEMUXER 0
-+#define CONFIG_IVF_DEMUXER 0
-+#define CONFIG_IVR_DEMUXER 0
-+#define CONFIG_JACOSUB_DEMUXER 0
-+#define CONFIG_JV_DEMUXER 0
-+#define CONFIG_KUX_DEMUXER 0
-+#define CONFIG_KVAG_DEMUXER 0
-+#define CONFIG_LAF_DEMUXER 0
-+#define CONFIG_LMLM4_DEMUXER 0
-+#define CONFIG_LOAS_DEMUXER 0
-+#define CONFIG_LUODAT_DEMUXER 0
-+#define CONFIG_LRC_DEMUXER 0
-+#define CONFIG_LVF_DEMUXER 0
-+#define CONFIG_LXF_DEMUXER 0
-+#define CONFIG_M4V_DEMUXER 0
-+#define CONFIG_MCA_DEMUXER 0
-+#define CONFIG_MCC_DEMUXER 0
-+#define CONFIG_MATROSKA_DEMUXER 1
-+#define CONFIG_MGSTS_DEMUXER 0
-+#define CONFIG_MICRODVD_DEMUXER 0
-+#define CONFIG_MJPEG_DEMUXER 0
-+#define CONFIG_MJPEG_2000_DEMUXER 0
-+#define CONFIG_MLP_DEMUXER 0
-+#define CONFIG_MLV_DEMUXER 0
-+#define CONFIG_MM_DEMUXER 0
-+#define CONFIG_MMF_DEMUXER 0
-+#define CONFIG_MODS_DEMUXER 0
-+#define CONFIG_MOFLEX_DEMUXER 0
-+#define CONFIG_MOV_DEMUXER 1
-+#define CONFIG_MP3_DEMUXER 1
-+#define CONFIG_MPC_DEMUXER 0
-+#define CONFIG_MPC8_DEMUXER 0
-+#define CONFIG_MPEGPS_DEMUXER 0
-+#define CONFIG_MPEGTS_DEMUXER 0
-+#define CONFIG_MPEGTSRAW_DEMUXER 0
-+#define CONFIG_MPEGVIDEO_DEMUXER 0
-+#define CONFIG_MPJPEG_DEMUXER 0
-+#define CONFIG_MPL2_DEMUXER 0
-+#define CONFIG_MPSUB_DEMUXER 0
-+#define CONFIG_MSF_DEMUXER 0
-+#define CONFIG_MSNWC_TCP_DEMUXER 0
-+#define CONFIG_MSP_DEMUXER 0
-+#define CONFIG_MTAF_DEMUXER 0
-+#define CONFIG_MTV_DEMUXER 0
-+#define CONFIG_MUSX_DEMUXER 0
-+#define CONFIG_MV_DEMUXER 0
-+#define CONFIG_MVI_DEMUXER 0
-+#define CONFIG_MXF_DEMUXER 0
-+#define CONFIG_MXG_DEMUXER 0
-+#define CONFIG_NC_DEMUXER 0
-+#define CONFIG_NISTSPHERE_DEMUXER 0
-+#define CONFIG_NSP_DEMUXER 0
-+#define CONFIG_NSV_DEMUXER 0
-+#define CONFIG_NUT_DEMUXER 0
-+#define CONFIG_NUV_DEMUXER 0
-+#define CONFIG_OBU_DEMUXER 0
-+#define CONFIG_OGG_DEMUXER 1
-+#define CONFIG_OMA_DEMUXER 0
-+#define CONFIG_PAF_DEMUXER 0
-+#define CONFIG_PCM_ALAW_DEMUXER 0
-+#define CONFIG_PCM_MULAW_DEMUXER 0
-+#define CONFIG_PCM_VIDC_DEMUXER 0
-+#define CONFIG_PCM_F64BE_DEMUXER 0
-+#define CONFIG_PCM_F64LE_DEMUXER 0
-+#define CONFIG_PCM_F32BE_DEMUXER 0
-+#define CONFIG_PCM_F32LE_DEMUXER 0
-+#define CONFIG_PCM_S32BE_DEMUXER 0
-+#define CONFIG_PCM_S32LE_DEMUXER 0
-+#define CONFIG_PCM_S24BE_DEMUXER 0
-+#define CONFIG_PCM_S24LE_DEMUXER 0
-+#define CONFIG_PCM_S16BE_DEMUXER 0
-+#define CONFIG_PCM_S16LE_DEMUXER 0
-+#define CONFIG_PCM_S8_DEMUXER 0
-+#define CONFIG_PCM_U32BE_DEMUXER 0
-+#define CONFIG_PCM_U32LE_DEMUXER 0
-+#define CONFIG_PCM_U24BE_DEMUXER 0
-+#define CONFIG_PCM_U24LE_DEMUXER 0
-+#define CONFIG_PCM_U16BE_DEMUXER 0
-+#define CONFIG_PCM_U16LE_DEMUXER 0
-+#define CONFIG_PCM_U8_DEMUXER 0
-+#define CONFIG_PJS_DEMUXER 0
-+#define CONFIG_PMP_DEMUXER 0
-+#define CONFIG_PP_BNK_DEMUXER 0
-+#define CONFIG_PVA_DEMUXER 0
-+#define CONFIG_PVF_DEMUXER 0
-+#define CONFIG_QCP_DEMUXER 0
-+#define CONFIG_R3D_DEMUXER 0
-+#define CONFIG_RAWVIDEO_DEMUXER 0
-+#define CONFIG_REALTEXT_DEMUXER 0
-+#define CONFIG_REDSPARK_DEMUXER 0
-+#define CONFIG_RL2_DEMUXER 0
-+#define CONFIG_RM_DEMUXER 0
-+#define CONFIG_ROQ_DEMUXER 0
-+#define CONFIG_RPL_DEMUXER 0
-+#define CONFIG_RSD_DEMUXER 0
-+#define CONFIG_RSO_DEMUXER 0
-+#define CONFIG_RTP_DEMUXER 0
-+#define CONFIG_RTSP_DEMUXER 0
-+#define CONFIG_S337M_DEMUXER 0
-+#define CONFIG_SAMI_DEMUXER 0
-+#define CONFIG_SAP_DEMUXER 0
-+#define CONFIG_SBC_DEMUXER 0
-+#define CONFIG_SBG_DEMUXER 0
-+#define CONFIG_SCC_DEMUXER 0
-+#define CONFIG_SCD_DEMUXER 0
-+#define CONFIG_SDP_DEMUXER 0
-+#define CONFIG_SDR2_DEMUXER 0
-+#define CONFIG_SDS_DEMUXER 0
-+#define CONFIG_SDX_DEMUXER 0
-+#define CONFIG_SEGAFILM_DEMUXER 0
-+#define CONFIG_SER_DEMUXER 0
-+#define CONFIG_SGA_DEMUXER 0
-+#define CONFIG_SHORTEN_DEMUXER 0
-+#define CONFIG_SIFF_DEMUXER 0
-+#define CONFIG_SIMBIOSIS_IMX_DEMUXER 0
-+#define CONFIG_SLN_DEMUXER 0
-+#define CONFIG_SMACKER_DEMUXER 0
-+#define CONFIG_SMJPEG_DEMUXER 0
-+#define CONFIG_SMUSH_DEMUXER 0
-+#define CONFIG_SOL_DEMUXER 0
-+#define CONFIG_SOX_DEMUXER 0
-+#define CONFIG_SPDIF_DEMUXER 0
-+#define CONFIG_SRT_DEMUXER 0
-+#define CONFIG_STR_DEMUXER 0
-+#define CONFIG_STL_DEMUXER 0
-+#define CONFIG_SUBVIEWER1_DEMUXER 0
-+#define CONFIG_SUBVIEWER_DEMUXER 0
-+#define CONFIG_SUP_DEMUXER 0
-+#define CONFIG_SVAG_DEMUXER 0
-+#define CONFIG_SVS_DEMUXER 0
-+#define CONFIG_SWF_DEMUXER 0
-+#define CONFIG_TAK_DEMUXER 0
-+#define CONFIG_TEDCAPTIONS_DEMUXER 0
-+#define CONFIG_THP_DEMUXER 0
-+#define CONFIG_THREEDOSTR_DEMUXER 0
-+#define CONFIG_TIERTEXSEQ_DEMUXER 0
-+#define CONFIG_TMV_DEMUXER 0
-+#define CONFIG_TRUEHD_DEMUXER 0
-+#define CONFIG_TTA_DEMUXER 0
-+#define CONFIG_TXD_DEMUXER 0
-+#define CONFIG_TTY_DEMUXER 0
-+#define CONFIG_TY_DEMUXER 0
-+#define CONFIG_V210_DEMUXER 0
-+#define CONFIG_V210X_DEMUXER 0
-+#define CONFIG_VAG_DEMUXER 0
-+#define CONFIG_VC1_DEMUXER 0
-+#define CONFIG_VC1T_DEMUXER 0
-+#define CONFIG_VIVIDAS_DEMUXER 0
-+#define CONFIG_VIVO_DEMUXER 0
-+#define CONFIG_VMD_DEMUXER 0
-+#define CONFIG_VOBSUB_DEMUXER 0
-+#define CONFIG_VOC_DEMUXER 0
-+#define CONFIG_VPK_DEMUXER 0
-+#define CONFIG_VPLAYER_DEMUXER 0
-+#define CONFIG_VQF_DEMUXER 0
-+#define CONFIG_W64_DEMUXER 0
-+#define CONFIG_WADY_DEMUXER 0
-+#define CONFIG_WAV_DEMUXER 1
-+#define CONFIG_WC3_DEMUXER 0
-+#define CONFIG_WEBM_DASH_MANIFEST_DEMUXER 0
-+#define CONFIG_WEBVTT_DEMUXER 0
-+#define CONFIG_WSAUD_DEMUXER 0
-+#define CONFIG_WSD_DEMUXER 0
-+#define CONFIG_WSVQA_DEMUXER 0
-+#define CONFIG_WTV_DEMUXER 0
-+#define CONFIG_WVE_DEMUXER 0
-+#define CONFIG_WV_DEMUXER 0
-+#define CONFIG_XA_DEMUXER 0
-+#define CONFIG_XBIN_DEMUXER 0
-+#define CONFIG_XMD_DEMUXER 0
-+#define CONFIG_XMV_DEMUXER 0
-+#define CONFIG_XVAG_DEMUXER 0
-+#define CONFIG_XWMA_DEMUXER 0
-+#define CONFIG_YOP_DEMUXER 0
-+#define CONFIG_YUV4MPEGPIPE_DEMUXER 0
-+#define CONFIG_IMAGE_BMP_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_CRI_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_DDS_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_DPX_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_EXR_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_GEM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_GIF_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_HDR_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_J2K_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_JPEG_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_JPEGLS_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_JPEGXL_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PAM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PBM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PCX_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PFM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PGMYUV_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PGM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PGX_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PHM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PHOTOCD_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PICTOR_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PNG_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PPM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PSD_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_QDRAW_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_QOI_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_SGI_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_SVG_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_SUNRAST_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_TIFF_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_VBN_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_WEBP_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
-+#define CONFIG_LIBGME_DEMUXER 0
-+#define CONFIG_LIBMODPLUG_DEMUXER 0
-+#define CONFIG_LIBOPENMPT_DEMUXER 0
-+#define CONFIG_VAPOURSYNTH_DEMUXER 0
-+#define CONFIG_A64_MUXER 0
-+#define CONFIG_AC3_MUXER 0
-+#define CONFIG_ADTS_MUXER 0
-+#define CONFIG_ADX_MUXER 0
-+#define CONFIG_AIFF_MUXER 0
-+#define CONFIG_ALP_MUXER 0
-+#define CONFIG_AMR_MUXER 0
-+#define CONFIG_AMV_MUXER 0
-+#define CONFIG_APM_MUXER 0
-+#define CONFIG_APNG_MUXER 0
-+#define CONFIG_APTX_MUXER 0
-+#define CONFIG_APTX_HD_MUXER 0
-+#define CONFIG_ARGO_ASF_MUXER 0
-+#define CONFIG_ARGO_CVG_MUXER 0
-+#define CONFIG_ASF_MUXER 0
-+#define CONFIG_ASS_MUXER 0
-+#define CONFIG_AST_MUXER 0
-+#define CONFIG_ASF_STREAM_MUXER 0
-+#define CONFIG_AU_MUXER 0
-+#define CONFIG_AVI_MUXER 0
-+#define CONFIG_AVIF_MUXER 0
-+#define CONFIG_AVM2_MUXER 0
-+#define CONFIG_AVS2_MUXER 0
-+#define CONFIG_AVS3_MUXER 0
-+#define CONFIG_BIT_MUXER 0
-+#define CONFIG_CAF_MUXER 0
-+#define CONFIG_CAVSVIDEO_MUXER 0
-+#define CONFIG_CODEC2_MUXER 0
-+#define CONFIG_CODEC2RAW_MUXER 0
-+#define CONFIG_CRC_MUXER 0
-+#define CONFIG_DASH_MUXER 0
-+#define CONFIG_DATA_MUXER 0
-+#define CONFIG_DAUD_MUXER 0
-+#define CONFIG_DFPWM_MUXER 0
-+#define CONFIG_DIRAC_MUXER 0
-+#define CONFIG_DNXHD_MUXER 0
-+#define CONFIG_DTS_MUXER 0
-+#define CONFIG_DV_MUXER 0
-+#define CONFIG_EAC3_MUXER 0
-+#define CONFIG_F4V_MUXER 0
-+#define CONFIG_FFMETADATA_MUXER 0
-+#define CONFIG_FIFO_MUXER 0
-+#define CONFIG_FIFO_TEST_MUXER 0
-+#define CONFIG_FILMSTRIP_MUXER 0
-+#define CONFIG_FITS_MUXER 0
-+#define CONFIG_FLAC_MUXER 0
-+#define CONFIG_FLV_MUXER 0
-+#define CONFIG_FRAMECRC_MUXER 0
-+#define CONFIG_FRAMEHASH_MUXER 0
-+#define CONFIG_FRAMEMD5_MUXER 0
-+#define CONFIG_G722_MUXER 0
-+#define CONFIG_G723_1_MUXER 0
-+#define CONFIG_G726_MUXER 0
-+#define CONFIG_G726LE_MUXER 0
-+#define CONFIG_GIF_MUXER 0
-+#define CONFIG_GSM_MUXER 0
-+#define CONFIG_GXF_MUXER 0
-+#define CONFIG_H261_MUXER 0
-+#define CONFIG_H263_MUXER 0
-+#define CONFIG_H264_MUXER 0
-+#define CONFIG_HASH_MUXER 0
-+#define CONFIG_HDS_MUXER 0
-+#define CONFIG_HEVC_MUXER 0
-+#define CONFIG_HLS_MUXER 0
-+#define CONFIG_ICO_MUXER 0
-+#define CONFIG_ILBC_MUXER 0
-+#define CONFIG_IMAGE2_MUXER 0
-+#define CONFIG_IMAGE2PIPE_MUXER 0
-+#define CONFIG_IPOD_MUXER 0
-+#define CONFIG_IRCAM_MUXER 0
-+#define CONFIG_ISMV_MUXER 0
-+#define CONFIG_IVF_MUXER 0
-+#define CONFIG_JACOSUB_MUXER 0
-+#define CONFIG_KVAG_MUXER 0
-+#define CONFIG_LATM_MUXER 0
-+#define CONFIG_LRC_MUXER 0
-+#define CONFIG_M4V_MUXER 0
-+#define CONFIG_MD5_MUXER 0
-+#define CONFIG_MATROSKA_MUXER 0
-+#define CONFIG_MATROSKA_AUDIO_MUXER 0
-+#define CONFIG_MICRODVD_MUXER 0
-+#define CONFIG_MJPEG_MUXER 0
-+#define CONFIG_MLP_MUXER 0
-+#define CONFIG_MMF_MUXER 0
-+#define CONFIG_MOV_MUXER 0
-+#define CONFIG_MP2_MUXER 0
-+#define CONFIG_MP3_MUXER 0
-+#define CONFIG_MP4_MUXER 0
-+#define CONFIG_MPEG1SYSTEM_MUXER 0
-+#define CONFIG_MPEG1VCD_MUXER 0
-+#define CONFIG_MPEG1VIDEO_MUXER 0
-+#define CONFIG_MPEG2DVD_MUXER 0
-+#define CONFIG_MPEG2SVCD_MUXER 0
-+#define CONFIG_MPEG2VIDEO_MUXER 0
-+#define CONFIG_MPEG2VOB_MUXER 0
-+#define CONFIG_MPEGTS_MUXER 0
-+#define CONFIG_MPJPEG_MUXER 0
-+#define CONFIG_MXF_MUXER 0
-+#define CONFIG_MXF_D10_MUXER 0
-+#define CONFIG_MXF_OPATOM_MUXER 0
-+#define CONFIG_NULL_MUXER 0
-+#define CONFIG_NUT_MUXER 0
-+#define CONFIG_OBU_MUXER 0
-+#define CONFIG_OGA_MUXER 0
-+#define CONFIG_OGG_MUXER 0
-+#define CONFIG_OGV_MUXER 0
-+#define CONFIG_OMA_MUXER 0
-+#define CONFIG_OPUS_MUXER 0
-+#define CONFIG_PCM_ALAW_MUXER 0
-+#define CONFIG_PCM_MULAW_MUXER 0
-+#define CONFIG_PCM_VIDC_MUXER 0
-+#define CONFIG_PCM_F64BE_MUXER 0
-+#define CONFIG_PCM_F64LE_MUXER 0
-+#define CONFIG_PCM_F32BE_MUXER 0
-+#define CONFIG_PCM_F32LE_MUXER 0
-+#define CONFIG_PCM_S32BE_MUXER 0
-+#define CONFIG_PCM_S32LE_MUXER 0
-+#define CONFIG_PCM_S24BE_MUXER 0
-+#define CONFIG_PCM_S24LE_MUXER 0
-+#define CONFIG_PCM_S16BE_MUXER 0
-+#define CONFIG_PCM_S16LE_MUXER 0
-+#define CONFIG_PCM_S8_MUXER 0
-+#define CONFIG_PCM_U32BE_MUXER 0
-+#define CONFIG_PCM_U32LE_MUXER 0
-+#define CONFIG_PCM_U24BE_MUXER 0
-+#define CONFIG_PCM_U24LE_MUXER 0
-+#define CONFIG_PCM_U16BE_MUXER 0
-+#define CONFIG_PCM_U16LE_MUXER 0
-+#define CONFIG_PCM_U8_MUXER 0
-+#define CONFIG_PSP_MUXER 0
-+#define CONFIG_RAWVIDEO_MUXER 0
-+#define CONFIG_RM_MUXER 0
-+#define CONFIG_ROQ_MUXER 0
-+#define CONFIG_RSO_MUXER 0
-+#define CONFIG_RTP_MUXER 0
-+#define CONFIG_RTP_MPEGTS_MUXER 0
-+#define CONFIG_RTSP_MUXER 0
-+#define CONFIG_SAP_MUXER 0
-+#define CONFIG_SBC_MUXER 0
-+#define CONFIG_SCC_MUXER 0
-+#define CONFIG_SEGAFILM_MUXER 0
-+#define CONFIG_SEGMENT_MUXER 0
-+#define CONFIG_STREAM_SEGMENT_MUXER 0
-+#define CONFIG_SMJPEG_MUXER 0
-+#define CONFIG_SMOOTHSTREAMING_MUXER 0
-+#define CONFIG_SOX_MUXER 0
-+#define CONFIG_SPX_MUXER 0
-+#define CONFIG_SPDIF_MUXER 0
-+#define CONFIG_SRT_MUXER 0
-+#define CONFIG_STREAMHASH_MUXER 0
-+#define CONFIG_SUP_MUXER 0
-+#define CONFIG_SWF_MUXER 0
-+#define CONFIG_TEE_MUXER 0
-+#define CONFIG_TG2_MUXER 0
-+#define CONFIG_TGP_MUXER 0
-+#define CONFIG_MKVTIMESTAMP_V2_MUXER 0
-+#define CONFIG_TRUEHD_MUXER 0
-+#define CONFIG_TTA_MUXER 0
-+#define CONFIG_TTML_MUXER 0
-+#define CONFIG_UNCODEDFRAMECRC_MUXER 0
-+#define CONFIG_VC1_MUXER 0
-+#define CONFIG_VC1T_MUXER 0
-+#define CONFIG_VOC_MUXER 0
-+#define CONFIG_W64_MUXER 0
-+#define CONFIG_WAV_MUXER 0
-+#define CONFIG_WEBM_MUXER 0
-+#define CONFIG_WEBM_DASH_MANIFEST_MUXER 0
-+#define CONFIG_WEBM_CHUNK_MUXER 0
-+#define CONFIG_WEBP_MUXER 0
-+#define CONFIG_WEBVTT_MUXER 0
-+#define CONFIG_WSAUD_MUXER 0
-+#define CONFIG_WTV_MUXER 0
-+#define CONFIG_WV_MUXER 0
-+#define CONFIG_YUV4MPEGPIPE_MUXER 0
-+#define CONFIG_CHROMAPRINT_MUXER 0
-+#define CONFIG_ASYNC_PROTOCOL 0
-+#define CONFIG_BLURAY_PROTOCOL 0
-+#define CONFIG_CACHE_PROTOCOL 0
-+#define CONFIG_CONCAT_PROTOCOL 0
-+#define CONFIG_CONCATF_PROTOCOL 0
-+#define CONFIG_CRYPTO_PROTOCOL 0
-+#define CONFIG_DATA_PROTOCOL 0
-+#define CONFIG_FD_PROTOCOL 0
-+#define CONFIG_FFRTMPCRYPT_PROTOCOL 0
-+#define CONFIG_FFRTMPHTTP_PROTOCOL 0
-+#define CONFIG_FILE_PROTOCOL 0
-+#define CONFIG_FTP_PROTOCOL 0
-+#define CONFIG_GOPHER_PROTOCOL 0
-+#define CONFIG_GOPHERS_PROTOCOL 0
-+#define CONFIG_HLS_PROTOCOL 0
-+#define CONFIG_HTTP_PROTOCOL 0
-+#define CONFIG_HTTPPROXY_PROTOCOL 0
-+#define CONFIG_HTTPS_PROTOCOL 0
-+#define CONFIG_ICECAST_PROTOCOL 0
-+#define CONFIG_MMSH_PROTOCOL 0
-+#define CONFIG_MMST_PROTOCOL 0
-+#define CONFIG_MD5_PROTOCOL 0
-+#define CONFIG_PIPE_PROTOCOL 0
-+#define CONFIG_PROMPEG_PROTOCOL 0
-+#define CONFIG_RTMP_PROTOCOL 0
-+#define CONFIG_RTMPE_PROTOCOL 0
-+#define CONFIG_RTMPS_PROTOCOL 0
-+#define CONFIG_RTMPT_PROTOCOL 0
-+#define CONFIG_RTMPTE_PROTOCOL 0
-+#define CONFIG_RTMPTS_PROTOCOL 0
-+#define CONFIG_RTP_PROTOCOL 0
-+#define CONFIG_SCTP_PROTOCOL 0
-+#define CONFIG_SRTP_PROTOCOL 0
-+#define CONFIG_SUBFILE_PROTOCOL 0
-+#define CONFIG_TEE_PROTOCOL 0
-+#define CONFIG_TCP_PROTOCOL 0
-+#define CONFIG_TLS_PROTOCOL 0
-+#define CONFIG_UDP_PROTOCOL 0
-+#define CONFIG_UDPLITE_PROTOCOL 0
-+#define CONFIG_UNIX_PROTOCOL 0
-+#define CONFIG_LIBAMQP_PROTOCOL 0
-+#define CONFIG_LIBRIST_PROTOCOL 0
-+#define CONFIG_LIBRTMP_PROTOCOL 0
-+#define CONFIG_LIBRTMPE_PROTOCOL 0
-+#define CONFIG_LIBRTMPS_PROTOCOL 0
-+#define CONFIG_LIBRTMPT_PROTOCOL 0
-+#define CONFIG_LIBRTMPTE_PROTOCOL 0
-+#define CONFIG_LIBSRT_PROTOCOL 0
-+#define CONFIG_LIBSSH_PROTOCOL 0
-+#define CONFIG_LIBSMBCLIENT_PROTOCOL 0
-+#define CONFIG_LIBZMQ_PROTOCOL 0
-+#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
-+#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
-+#endif /* FFMPEG_CONFIG_COMPONENTS_H */
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,2 @@
-+static const FFBitStreamFilter * const bitstream_filters[] = {
-+    NULL };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,20 @@
-+static const FFCodec * const codec_list[] = {
-+    &ff_h264_decoder,
-+    &ff_theora_decoder,
-+    &ff_vp3_decoder,
-+    &ff_vp8_decoder,
-+    &ff_aac_decoder,
-+    &ff_flac_decoder,
-+    &ff_mp3_decoder,
-+    &ff_vorbis_decoder,
-+    &ff_pcm_alaw_decoder,
-+    &ff_pcm_f32le_decoder,
-+    &ff_pcm_mulaw_decoder,
-+    &ff_pcm_s16be_decoder,
-+    &ff_pcm_s16le_decoder,
-+    &ff_pcm_s24be_decoder,
-+    &ff_pcm_s24le_decoder,
-+    &ff_pcm_s32le_decoder,
-+    &ff_pcm_u8_decoder,
-+    &ff_libopus_decoder,
-+    NULL };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,11 @@
-+static const AVCodecParser * const parser_list[] = {
-+    &ff_aac_parser,
-+    &ff_flac_parser,
-+    &ff_h264_parser,
-+    &ff_mpegaudio_parser,
-+    &ff_opus_parser,
-+    &ff_vorbis_parser,
-+    &ff_vp3_parser,
-+    &ff_vp8_parser,
-+    &ff_vp9_parser,
-+    NULL };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,9 @@
-+static const AVInputFormat * const demuxer_list[] = {
-+    &ff_aac_demuxer,
-+    &ff_flac_demuxer,
-+    &ff_matroska_demuxer,
-+    &ff_mov_demuxer,
-+    &ff_mp3_demuxer,
-+    &ff_ogg_demuxer,
-+    &ff_wav_demuxer,
-+    NULL };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,2 @@
-+static const AVOutputFormat * const muxer_list[] = {
-+    NULL };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,2 @@
-+static const URLProtocol * const url_protocols[] = {
-+    NULL };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,6 @@
-+/* Generated by ffmpeg configure */
-+#ifndef AVUTIL_AVCONFIG_H
-+#define AVUTIL_AVCONFIG_H
-+#define AV_HAVE_BIGENDIAN 0
-+#define AV_HAVE_FAST_UNALIGNED 1
-+#endif /* AVUTIL_AVCONFIG_H */
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,749 @@
-+/* Automatically generated by configure - do not modify! */
-+#ifndef FFMPEG_CONFIG_H
-+#define FFMPEG_CONFIG_H
-+#define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-fft --enable-rdft --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\\\"-O2\\\"' --enable-decoder='theora,vp8' --enable-parser='vp3,vp8' --enable-lto --enable-pic --cc=clang --cxx=clang++ --ld=clang"
-+#define FFMPEG_LICENSE "LGPL version 2.1 or later"
-+#define CONFIG_THIS_YEAR 2023
-+#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
-+#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
-+#define CC_IDENT "clang version 17.0.6"
-+#define OS_NAME linux
-+#define av_restrict restrict
-+#define EXTERN_PREFIX ""
-+#define EXTERN_ASM 
-+#define BUILDSUF ""
-+#define SLIBSUF ".so"
-+#define HAVE_MMX2 HAVE_MMXEXT
-+#define SWS_MAX_FILTER_SIZE 256
-+#define ARCH_AARCH64 0
-+#define ARCH_ALPHA 0
-+#define ARCH_ARM 0
-+#define ARCH_AVR32 0
-+#define ARCH_AVR32_AP 0
-+#define ARCH_AVR32_UC 0
-+#define ARCH_BFIN 0
-+#define ARCH_IA64 0
-+#define ARCH_LOONGARCH 1
-+#define ARCH_LOONGARCH32 0
-+#define ARCH_LOONGARCH64 1
-+#define ARCH_M68K 0
-+#define ARCH_MIPS 0
-+#define ARCH_MIPS64 0
-+#define ARCH_PARISC 0
-+#define ARCH_PPC 0
-+#define ARCH_PPC64 0
-+#define ARCH_RISCV 0
-+#define ARCH_S390 0
-+#define ARCH_SH4 0
-+#define ARCH_SPARC 0
-+#define ARCH_SPARC64 0
-+#define ARCH_TILEGX 0
-+#define ARCH_TILEPRO 0
-+#define ARCH_TOMI 0
-+#define ARCH_X86 0
-+#define ARCH_X86_32 0
-+#define ARCH_X86_64 0
-+#define HAVE_ARMV5TE 0
-+#define HAVE_ARMV6 0
-+#define HAVE_ARMV6T2 0
-+#define HAVE_ARMV8 0
-+#define HAVE_NEON 0
-+#define HAVE_VFP 0
-+#define HAVE_VFPV3 0
-+#define HAVE_SETEND 0
-+#define HAVE_ALTIVEC 0
-+#define HAVE_DCBZL 0
-+#define HAVE_LDBRX 0
-+#define HAVE_POWER8 0
-+#define HAVE_PPC4XX 0
-+#define HAVE_VSX 0
-+#define HAVE_RVV 0
-+#define HAVE_AESNI 0
-+#define HAVE_AMD3DNOW 0
-+#define HAVE_AMD3DNOWEXT 0
-+#define HAVE_AVX 0
-+#define HAVE_AVX2 0
-+#define HAVE_AVX512 0
-+#define HAVE_AVX512ICL 0
-+#define HAVE_FMA3 0
-+#define HAVE_FMA4 0
-+#define HAVE_MMX 0
-+#define HAVE_MMXEXT 0
-+#define HAVE_SSE 0
-+#define HAVE_SSE2 0
-+#define HAVE_SSE3 0
-+#define HAVE_SSE4 0
-+#define HAVE_SSE42 0
-+#define HAVE_SSSE3 0
-+#define HAVE_XOP 0
-+#define HAVE_CPUNOP 0
-+#define HAVE_I686 0
-+#define HAVE_MIPSFPU 0
-+#define HAVE_MIPS32R2 0
-+#define HAVE_MIPS32R5 0
-+#define HAVE_MIPS64R2 0
-+#define HAVE_MIPS32R6 0
-+#define HAVE_MIPS64R6 0
-+#define HAVE_MIPSDSP 0
-+#define HAVE_MIPSDSPR2 0
-+#define HAVE_MSA 0
-+#define HAVE_LOONGSON2 0
-+#define HAVE_LOONGSON3 0
-+#define HAVE_MMI 0
-+#define HAVE_LSX 0
-+#define HAVE_LASX 0
-+#define HAVE_ARMV5TE_EXTERNAL 0
-+#define HAVE_ARMV6_EXTERNAL 0
-+#define HAVE_ARMV6T2_EXTERNAL 0
-+#define HAVE_ARMV8_EXTERNAL 0
-+#define HAVE_NEON_EXTERNAL 0
-+#define HAVE_VFP_EXTERNAL 0
-+#define HAVE_VFPV3_EXTERNAL 0
-+#define HAVE_SETEND_EXTERNAL 0
-+#define HAVE_ALTIVEC_EXTERNAL 0
-+#define HAVE_DCBZL_EXTERNAL 0
-+#define HAVE_LDBRX_EXTERNAL 0
-+#define HAVE_POWER8_EXTERNAL 0
-+#define HAVE_PPC4XX_EXTERNAL 0
-+#define HAVE_VSX_EXTERNAL 0
-+#define HAVE_RVV_EXTERNAL 0
-+#define HAVE_AESNI_EXTERNAL 0
-+#define HAVE_AMD3DNOW_EXTERNAL 0
-+#define HAVE_AMD3DNOWEXT_EXTERNAL 0
-+#define HAVE_AVX_EXTERNAL 0
-+#define HAVE_AVX2_EXTERNAL 0
-+#define HAVE_AVX512_EXTERNAL 0
-+#define HAVE_AVX512ICL_EXTERNAL 0
-+#define HAVE_FMA3_EXTERNAL 0
-+#define HAVE_FMA4_EXTERNAL 0
-+#define HAVE_MMX_EXTERNAL 0
-+#define HAVE_MMXEXT_EXTERNAL 0
-+#define HAVE_SSE_EXTERNAL 0
-+#define HAVE_SSE2_EXTERNAL 0
-+#define HAVE_SSE3_EXTERNAL 0
-+#define HAVE_SSE4_EXTERNAL 0
-+#define HAVE_SSE42_EXTERNAL 0
-+#define HAVE_SSSE3_EXTERNAL 0
-+#define HAVE_XOP_EXTERNAL 0
-+#define HAVE_CPUNOP_EXTERNAL 0
-+#define HAVE_I686_EXTERNAL 0
-+#define HAVE_MIPSFPU_EXTERNAL 0
-+#define HAVE_MIPS32R2_EXTERNAL 0
-+#define HAVE_MIPS32R5_EXTERNAL 0
-+#define HAVE_MIPS64R2_EXTERNAL 0
-+#define HAVE_MIPS32R6_EXTERNAL 0
-+#define HAVE_MIPS64R6_EXTERNAL 0
-+#define HAVE_MIPSDSP_EXTERNAL 0
-+#define HAVE_MIPSDSPR2_EXTERNAL 0
-+#define HAVE_MSA_EXTERNAL 0
-+#define HAVE_LOONGSON2_EXTERNAL 0
-+#define HAVE_LOONGSON3_EXTERNAL 0
-+#define HAVE_MMI_EXTERNAL 0
-+#define HAVE_LSX_EXTERNAL 0
-+#define HAVE_LASX_EXTERNAL 0
-+#define HAVE_ARMV5TE_INLINE 0
-+#define HAVE_ARMV6_INLINE 0
-+#define HAVE_ARMV6T2_INLINE 0
-+#define HAVE_ARMV8_INLINE 0
-+#define HAVE_NEON_INLINE 0
-+#define HAVE_VFP_INLINE 0
-+#define HAVE_VFPV3_INLINE 0
-+#define HAVE_SETEND_INLINE 0
-+#define HAVE_ALTIVEC_INLINE 0
-+#define HAVE_DCBZL_INLINE 0
-+#define HAVE_LDBRX_INLINE 0
-+#define HAVE_POWER8_INLINE 0
-+#define HAVE_PPC4XX_INLINE 0
-+#define HAVE_VSX_INLINE 0
-+#define HAVE_RVV_INLINE 0
-+#define HAVE_AESNI_INLINE 0
-+#define HAVE_AMD3DNOW_INLINE 0
-+#define HAVE_AMD3DNOWEXT_INLINE 0
-+#define HAVE_AVX_INLINE 0
-+#define HAVE_AVX2_INLINE 0
-+#define HAVE_AVX512_INLINE 0
-+#define HAVE_AVX512ICL_INLINE 0
-+#define HAVE_FMA3_INLINE 0
-+#define HAVE_FMA4_INLINE 0
-+#define HAVE_MMX_INLINE 0
-+#define HAVE_MMXEXT_INLINE 0
-+#define HAVE_SSE_INLINE 0
-+#define HAVE_SSE2_INLINE 0
-+#define HAVE_SSE3_INLINE 0
-+#define HAVE_SSE4_INLINE 0
-+#define HAVE_SSE42_INLINE 0
-+#define HAVE_SSSE3_INLINE 0
-+#define HAVE_XOP_INLINE 0
-+#define HAVE_CPUNOP_INLINE 0
-+#define HAVE_I686_INLINE 0
-+#define HAVE_MIPSFPU_INLINE 0
-+#define HAVE_MIPS32R2_INLINE 0
-+#define HAVE_MIPS32R5_INLINE 0
-+#define HAVE_MIPS64R2_INLINE 0
-+#define HAVE_MIPS32R6_INLINE 0
-+#define HAVE_MIPS64R6_INLINE 0
-+#define HAVE_MIPSDSP_INLINE 0
-+#define HAVE_MIPSDSPR2_INLINE 0
-+#define HAVE_MSA_INLINE 0
-+#define HAVE_LOONGSON2_INLINE 0
-+#define HAVE_LOONGSON3_INLINE 0
-+#define HAVE_MMI_INLINE 0
-+#define HAVE_LSX_INLINE 0
-+#define HAVE_LASX_INLINE 0
-+#define HAVE_ALIGNED_STACK 0
-+#define HAVE_FAST_64BIT 1
-+#define HAVE_FAST_CLZ 1
-+#define HAVE_FAST_CMOV 0
-+#define HAVE_FAST_FLOAT16 0
-+#define HAVE_LOCAL_ALIGNED 1
-+#define HAVE_SIMD_ALIGN_16 0
-+#define HAVE_SIMD_ALIGN_32 1
-+#define HAVE_SIMD_ALIGN_64 0
-+#define HAVE_ATOMIC_CAS_PTR 0
-+#define HAVE_MACHINE_RW_BARRIER 0
-+#define HAVE_MEMORYBARRIER 0
-+#define HAVE_MM_EMPTY 0
-+#define HAVE_RDTSC 0
-+#define HAVE_SEM_TIMEDWAIT 1
-+#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
-+#define HAVE_INLINE_ASM 1
-+#define HAVE_SYMVER 0
-+#define HAVE_X86ASM 0
-+#define HAVE_BIGENDIAN 0
-+#define HAVE_FAST_UNALIGNED 1
-+#define HAVE_ARPA_INET_H 0
-+#define HAVE_ASM_TYPES_H 1
-+#define HAVE_CDIO_PARANOIA_H 0
-+#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
-+#define HAVE_CUDA_H 0
-+#define HAVE_DISPATCH_DISPATCH_H 0
-+#define HAVE_DEV_BKTR_IOCTL_BT848_H 0
-+#define HAVE_DEV_BKTR_IOCTL_METEOR_H 0
-+#define HAVE_DEV_IC_BT8XX_H 0
-+#define HAVE_DEV_VIDEO_BKTR_IOCTL_BT848_H 0
-+#define HAVE_DEV_VIDEO_METEOR_IOCTL_METEOR_H 0
-+#define HAVE_DIRECT_H 0
-+#define HAVE_DIRENT_H 1
-+#define HAVE_DXGIDEBUG_H 0
-+#define HAVE_DXVA_H 0
-+#define HAVE_ES2_GL_H 0
-+#define HAVE_GSM_H 0
-+#define HAVE_IO_H 0
-+#define HAVE_LINUX_DMA_BUF_H 0
-+#define HAVE_LINUX_PERF_EVENT_H 1
-+#define HAVE_MACHINE_IOCTL_BT848_H 0
-+#define HAVE_MACHINE_IOCTL_METEOR_H 0
-+#define HAVE_MALLOC_H 1
-+#define HAVE_OPENCV2_CORE_CORE_C_H 0
-+#define HAVE_OPENGL_GL3_H 0
-+#define HAVE_POLL_H 1
-+#define HAVE_SYS_PARAM_H 1
-+#define HAVE_SYS_RESOURCE_H 1
-+#define HAVE_SYS_SELECT_H 1
-+#define HAVE_SYS_SOUNDCARD_H 1
-+#define HAVE_SYS_TIME_H 1
-+#define HAVE_SYS_UN_H 1
-+#define HAVE_SYS_VIDEOIO_H 0
-+#define HAVE_TERMIOS_H 1
-+#define HAVE_UDPLITE_H 0
-+#define HAVE_UNISTD_H 1
-+#define HAVE_VALGRIND_VALGRIND_H 0
-+#define HAVE_WINDOWS_H 0
-+#define HAVE_WINSOCK2_H 0
-+#define HAVE_INTRINSICS_NEON 0
-+#define HAVE_ATANF 1
-+#define HAVE_ATAN2F 1
-+#define HAVE_CBRT 1
-+#define HAVE_CBRTF 1
-+#define HAVE_COPYSIGN 1
-+#define HAVE_COSF 1
-+#define HAVE_ERF 1
-+#define HAVE_EXP2 1
-+#define HAVE_EXP2F 1
-+#define HAVE_EXPF 1
-+#define HAVE_HYPOT 1
-+#define HAVE_ISFINITE 1
-+#define HAVE_ISINF 1
-+#define HAVE_ISNAN 1
-+#define HAVE_LDEXPF 1
-+#define HAVE_LLRINT 1
-+#define HAVE_LLRINTF 1
-+#define HAVE_LOG2 1
-+#define HAVE_LOG2F 1
-+#define HAVE_LOG10F 1
-+#define HAVE_LRINT 1
-+#define HAVE_LRINTF 1
-+#define HAVE_POWF 1
-+#define HAVE_RINT 1
-+#define HAVE_ROUND 1
-+#define HAVE_ROUNDF 1
-+#define HAVE_SINF 1
-+#define HAVE_TRUNC 1
-+#define HAVE_TRUNCF 1
-+#define HAVE_DOS_PATHS 0
-+#define HAVE_LIBC_MSVCRT 0
-+#define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
-+#define HAVE_SECTION_DATA_REL_RO 1
-+#define HAVE_THREADS 1
-+#define HAVE_UWP 0
-+#define HAVE_WINRT 0
-+#define HAVE_ACCESS 1
-+#define HAVE_ALIGNED_MALLOC 0
-+#define HAVE_ARC4RANDOM 0
-+#define HAVE_CLOCK_GETTIME 1
-+#define HAVE_CLOSESOCKET 0
-+#define HAVE_COMMANDLINETOARGVW 0
-+#define HAVE_FCNTL 1
-+#define HAVE_GETADDRINFO 0
-+#define HAVE_GETAUXVAL 1
-+#define HAVE_GETENV 1
-+#define HAVE_GETHRTIME 0
-+#define HAVE_GETOPT 1
-+#define HAVE_GETMODULEHANDLE 0
-+#define HAVE_GETPROCESSAFFINITYMASK 0
-+#define HAVE_GETPROCESSMEMORYINFO 0
-+#define HAVE_GETPROCESSTIMES 0
-+#define HAVE_GETRUSAGE 1
-+#define HAVE_GETSTDHANDLE 0
-+#define HAVE_GETSYSTEMTIMEASFILETIME 0
-+#define HAVE_GETTIMEOFDAY 1
-+#define HAVE_GLOB 1
-+#define HAVE_GLXGETPROCADDRESS 0
-+#define HAVE_GMTIME_R 1
-+#define HAVE_INET_ATON 0
-+#define HAVE_ISATTY 1
-+#define HAVE_KBHIT 0
-+#define HAVE_LOCALTIME_R 1
-+#define HAVE_LSTAT 1
-+#define HAVE_LZO1X_999_COMPRESS 0
-+#define HAVE_MACH_ABSOLUTE_TIME 0
-+#define HAVE_MAPVIEWOFFILE 0
-+#define HAVE_MEMALIGN 1
-+#define HAVE_MKSTEMP 1
-+#define HAVE_MMAP 1
-+#define HAVE_MPROTECT 1
-+#define HAVE_NANOSLEEP 1
-+#define HAVE_PEEKNAMEDPIPE 0
-+#define HAVE_POSIX_MEMALIGN 1
-+#define HAVE_PRCTL 1
-+#define HAVE_PTHREAD_CANCEL 1
-+#define HAVE_SCHED_GETAFFINITY 1
-+#define HAVE_SECITEMIMPORT 0
-+#define HAVE_SETCONSOLETEXTATTRIBUTE 0
-+#define HAVE_SETCONSOLECTRLHANDLER 0
-+#define HAVE_SETDLLDIRECTORY 0
-+#define HAVE_SETMODE 0
-+#define HAVE_SETRLIMIT 1
-+#define HAVE_SLEEP 0
-+#define HAVE_STRERROR_R 1
-+#define HAVE_SYSCONF 1
-+#define HAVE_SYSCTL 0
-+#define HAVE_USLEEP 1
-+#define HAVE_UTGETOSTYPEFROMSTRING 0
-+#define HAVE_VIRTUALALLOC 0
-+#define HAVE_WGLGETPROCADDRESS 0
-+#define HAVE_BCRYPT 0
-+#define HAVE_VAAPI_DRM 0
-+#define HAVE_VAAPI_X11 0
-+#define HAVE_VDPAU_X11 0
-+#define HAVE_PTHREADS 1
-+#define HAVE_OS2THREADS 0
-+#define HAVE_W32THREADS 0
-+#define HAVE_AS_ARCH_DIRECTIVE 0
-+#define HAVE_AS_DN_DIRECTIVE 0
-+#define HAVE_AS_FPU_DIRECTIVE 0
-+#define HAVE_AS_FUNC 0
-+#define HAVE_AS_OBJECT_ARCH 0
-+#define HAVE_ASM_MOD_Q 0
-+#define HAVE_BLOCKS_EXTENSION 0
-+#define HAVE_EBP_AVAILABLE 0
-+#define HAVE_EBX_AVAILABLE 0
-+#define HAVE_GNU_AS 0
-+#define HAVE_GNU_WINDRES 0
-+#define HAVE_IBM_ASM 0
-+#define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
-+#define HAVE_INLINE_ASM_LABELS 1
-+#define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
-+#define HAVE_PRAGMA_DEPRECATED 1
-+#define HAVE_RSYNC_CONTIMEOUT 1
-+#define HAVE_SYMVER_ASM_LABEL 1
-+#define HAVE_SYMVER_GNU_ASM 1
-+#define HAVE_VFP_ARGS 0
-+#define HAVE_XFORM_ASM 0
-+#define HAVE_XMM_CLOBBERS 0
-+#define HAVE_DPI_AWARENESS_CONTEXT 0
-+#define HAVE_IDXGIOUTPUT5 0
-+#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
-+#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
-+#define HAVE_KCMVIDEOCODECTYPE_VP9 0
-+#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
-+#define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
-+#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
-+#define HAVE_SOCKLEN_T 0
-+#define HAVE_STRUCT_ADDRINFO 0
-+#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
-+#define HAVE_STRUCT_IP_MREQ_SOURCE 0
-+#define HAVE_STRUCT_IPV6_MREQ 0
-+#define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
-+#define HAVE_STRUCT_POLLFD 0
-+#define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
-+#define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
-+#define HAVE_STRUCT_SOCKADDR_IN6 0
-+#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
-+#define HAVE_STRUCT_SOCKADDR_STORAGE 0
-+#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
-+#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 0
-+#define HAVE_GZIP 1
-+#define HAVE_LIBDRM_GETFB2 0
-+#define HAVE_MAKEINFO 1
-+#define HAVE_MAKEINFO_HTML 1
-+#define HAVE_OPENCL_D3D11 0
-+#define HAVE_OPENCL_DRM_ARM 0
-+#define HAVE_OPENCL_DRM_BEIGNET 0
-+#define HAVE_OPENCL_DXVA2 0
-+#define HAVE_OPENCL_VAAPI_BEIGNET 0
-+#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
-+#define HAVE_PERL 1
-+#define HAVE_POD2MAN 0
-+#define HAVE_TEXI2HTML 0
-+#define HAVE_XMLLINT 1
-+#define HAVE_ZLIB_GZIP 0
-+#define CONFIG_DOC 0
-+#define CONFIG_HTMLPAGES 0
-+#define CONFIG_MANPAGES 0
-+#define CONFIG_PODPAGES 0
-+#define CONFIG_TXTPAGES 0
-+#define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
-+#define CONFIG_AVIO_READING_EXAMPLE 1
-+#define CONFIG_DECODE_AUDIO_EXAMPLE 1
-+#define CONFIG_DECODE_VIDEO_EXAMPLE 1
-+#define CONFIG_DEMUXING_DECODING_EXAMPLE 1
-+#define CONFIG_ENCODE_AUDIO_EXAMPLE 1
-+#define CONFIG_ENCODE_VIDEO_EXAMPLE 1
-+#define CONFIG_EXTRACT_MVS_EXAMPLE 1
-+#define CONFIG_FILTER_AUDIO_EXAMPLE 0
-+#define CONFIG_FILTERING_AUDIO_EXAMPLE 0
-+#define CONFIG_FILTERING_VIDEO_EXAMPLE 0
-+#define CONFIG_HTTP_MULTICLIENT_EXAMPLE 1
-+#define CONFIG_HW_DECODE_EXAMPLE 1
-+#define CONFIG_METADATA_EXAMPLE 1
-+#define CONFIG_MUXING_EXAMPLE 0
-+#define CONFIG_QSVDEC_EXAMPLE 0
-+#define CONFIG_REMUXING_EXAMPLE 1
-+#define CONFIG_RESAMPLING_AUDIO_EXAMPLE 0
-+#define CONFIG_SCALING_VIDEO_EXAMPLE 0
-+#define CONFIG_TRANSCODE_AAC_EXAMPLE 0
-+#define CONFIG_TRANSCODING_EXAMPLE 0
-+#define CONFIG_VAAPI_ENCODE_EXAMPLE 0
-+#define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
-+#define CONFIG_QSV_TRANSCODE_EXAMPLE 0
-+#define CONFIG_AVISYNTH 0
-+#define CONFIG_FREI0R 0
-+#define CONFIG_LIBCDIO 0
-+#define CONFIG_LIBDAVS2 0
-+#define CONFIG_LIBRUBBERBAND 0
-+#define CONFIG_LIBVIDSTAB 0
-+#define CONFIG_LIBX264 0
-+#define CONFIG_LIBX265 0
-+#define CONFIG_LIBXAVS 0
-+#define CONFIG_LIBXAVS2 0
-+#define CONFIG_LIBXVID 0
-+#define CONFIG_DECKLINK 0
-+#define CONFIG_LIBFDK_AAC 0
-+#define CONFIG_LIBTLS 0
-+#define CONFIG_GMP 0
-+#define CONFIG_LIBARIBB24 0
-+#define CONFIG_LIBLENSFUN 0
-+#define CONFIG_LIBOPENCORE_AMRNB 0
-+#define CONFIG_LIBOPENCORE_AMRWB 0
-+#define CONFIG_LIBVO_AMRWBENC 0
-+#define CONFIG_MBEDTLS 0
-+#define CONFIG_RKMPP 0
-+#define CONFIG_LIBSMBCLIENT 0
-+#define CONFIG_CHROMAPRINT 0
-+#define CONFIG_GCRYPT 0
-+#define CONFIG_GNUTLS 0
-+#define CONFIG_JNI 0
-+#define CONFIG_LADSPA 0
-+#define CONFIG_LCMS2 0
-+#define CONFIG_LIBAOM 0
-+#define CONFIG_LIBASS 0
-+#define CONFIG_LIBBLURAY 0
-+#define CONFIG_LIBBS2B 0
-+#define CONFIG_LIBCACA 0
-+#define CONFIG_LIBCELT 0
-+#define CONFIG_LIBCODEC2 0
-+#define CONFIG_LIBDAV1D 0
-+#define CONFIG_LIBDC1394 0
-+#define CONFIG_LIBDRM 0
-+#define CONFIG_LIBFLITE 0
-+#define CONFIG_LIBFONTCONFIG 0
-+#define CONFIG_LIBFREETYPE 0
-+#define CONFIG_LIBFRIBIDI 0
-+#define CONFIG_LIBGLSLANG 0
-+#define CONFIG_LIBGME 0
-+#define CONFIG_LIBGSM 0
-+#define CONFIG_LIBIEC61883 0
-+#define CONFIG_LIBILBC 0
-+#define CONFIG_LIBJACK 0
-+#define CONFIG_LIBJXL 0
-+#define CONFIG_LIBKLVANC 0
-+#define CONFIG_LIBKVAZAAR 0
-+#define CONFIG_LIBMODPLUG 0
-+#define CONFIG_LIBMP3LAME 0
-+#define CONFIG_LIBMYSOFA 0
-+#define CONFIG_LIBOPENCV 0
-+#define CONFIG_LIBOPENH264 0
-+#define CONFIG_LIBOPENJPEG 0
-+#define CONFIG_LIBOPENMPT 0
-+#define CONFIG_LIBOPENVINO 0
-+#define CONFIG_LIBOPUS 1
-+#define CONFIG_LIBPLACEBO 0
-+#define CONFIG_LIBPULSE 0
-+#define CONFIG_LIBRABBITMQ 0
-+#define CONFIG_LIBRAV1E 0
-+#define CONFIG_LIBRIST 0
-+#define CONFIG_LIBRSVG 0
-+#define CONFIG_LIBRTMP 0
-+#define CONFIG_LIBSHADERC 0
-+#define CONFIG_LIBSHINE 0
-+#define CONFIG_LIBSMBCLIENT 0
-+#define CONFIG_LIBSNAPPY 0
-+#define CONFIG_LIBSOXR 0
-+#define CONFIG_LIBSPEEX 0
-+#define CONFIG_LIBSRT 0
-+#define CONFIG_LIBSSH 0
-+#define CONFIG_LIBSVTAV1 0
-+#define CONFIG_LIBTENSORFLOW 0
-+#define CONFIG_LIBTESSERACT 0
-+#define CONFIG_LIBTHEORA 0
-+#define CONFIG_LIBTWOLAME 0
-+#define CONFIG_LIBUAVS3D 0
-+#define CONFIG_LIBV4L2 0
-+#define CONFIG_LIBVMAF 0
-+#define CONFIG_LIBVORBIS 0
-+#define CONFIG_LIBVPX 0
-+#define CONFIG_LIBWEBP 0
-+#define CONFIG_LIBXML2 0
-+#define CONFIG_LIBZIMG 0
-+#define CONFIG_LIBZMQ 0
-+#define CONFIG_LIBZVBI 0
-+#define CONFIG_LV2 0
-+#define CONFIG_MEDIACODEC 0
-+#define CONFIG_OPENAL 0
-+#define CONFIG_OPENGL 0
-+#define CONFIG_OPENSSL 0
-+#define CONFIG_POCKETSPHINX 0
-+#define CONFIG_VAPOURSYNTH 0
-+#define CONFIG_ALSA 0
-+#define CONFIG_APPKIT 0
-+#define CONFIG_AVFOUNDATION 0
-+#define CONFIG_BZLIB 0
-+#define CONFIG_COREIMAGE 0
-+#define CONFIG_ICONV 0
-+#define CONFIG_LIBXCB 0
-+#define CONFIG_LIBXCB_SHM 0
-+#define CONFIG_LIBXCB_SHAPE 0
-+#define CONFIG_LIBXCB_XFIXES 0
-+#define CONFIG_LZMA 0
-+#define CONFIG_MEDIAFOUNDATION 0
-+#define CONFIG_METAL 0
-+#define CONFIG_SCHANNEL 0
-+#define CONFIG_SDL2 0
-+#define CONFIG_SECURETRANSPORT 0
-+#define CONFIG_SNDIO 0
-+#define CONFIG_XLIB 0
-+#define CONFIG_ZLIB 0
-+#define CONFIG_CUDA_NVCC 0
-+#define CONFIG_CUDA_SDK 0
-+#define CONFIG_LIBNPP 0
-+#define CONFIG_LIBMFX 0
-+#define CONFIG_LIBVPL 0
-+#define CONFIG_MMAL 0
-+#define CONFIG_OMX 0
-+#define CONFIG_OPENCL 0
-+#define CONFIG_AMF 0
-+#define CONFIG_AUDIOTOOLBOX 0
-+#define CONFIG_CRYSTALHD 0
-+#define CONFIG_CUDA 0
-+#define CONFIG_CUDA_LLVM 0
-+#define CONFIG_CUVID 0
-+#define CONFIG_D3D11VA 0
-+#define CONFIG_DXVA2 0
-+#define CONFIG_FFNVCODEC 0
-+#define CONFIG_NVDEC 0
-+#define CONFIG_NVENC 0
-+#define CONFIG_VAAPI 0
-+#define CONFIG_VDPAU 0
-+#define CONFIG_VIDEOTOOLBOX 0
-+#define CONFIG_VULKAN 0
-+#define CONFIG_V4L2_M2M 0
-+#define CONFIG_FTRAPV 0
-+#define CONFIG_GRAY 0
-+#define CONFIG_HARDCODED_TABLES 0
-+#define CONFIG_OMX_RPI 0
-+#define CONFIG_RUNTIME_CPUDETECT 1
-+#define CONFIG_SAFE_BITSTREAM_READER 1
-+#define CONFIG_SHARED 0
-+#define CONFIG_SMALL 0
-+#define CONFIG_STATIC 1
-+#define CONFIG_SWSCALE_ALPHA 1
-+#define CONFIG_GPL 0
-+#define CONFIG_NONFREE 0
-+#define CONFIG_VERSION3 0
-+#define CONFIG_AVDEVICE 0
-+#define CONFIG_AVFILTER 0
-+#define CONFIG_SWSCALE 0
-+#define CONFIG_POSTPROC 0
-+#define CONFIG_AVFORMAT 1
-+#define CONFIG_AVCODEC 1
-+#define CONFIG_SWRESAMPLE 0
-+#define CONFIG_AVUTIL 1
-+#define CONFIG_FFPLAY 0
-+#define CONFIG_FFPROBE 0
-+#define CONFIG_FFMPEG 0
-+#define CONFIG_DCT 1
-+#define CONFIG_DWT 0
-+#define CONFIG_ERROR_RESILIENCE 0
-+#define CONFIG_FAAN 0
-+#define CONFIG_FAST_UNALIGNED 1
-+#define CONFIG_FFT 1
-+#define CONFIG_LSP 0
-+#define CONFIG_MDCT 0
-+#define CONFIG_PIXELUTILS 0
-+#define CONFIG_NETWORK 0
-+#define CONFIG_RDFT 1
-+#define CONFIG_AUTODETECT 0
-+#define CONFIG_FONTCONFIG 0
-+#define CONFIG_LARGE_TESTS 1
-+#define CONFIG_LINUX_PERF 0
-+#define CONFIG_MACOS_KPERF 0
-+#define CONFIG_MEMORY_POISONING 0
-+#define CONFIG_NEON_CLOBBER_TEST 0
-+#define CONFIG_OSSFUZZ 0
-+#define CONFIG_PIC 1
-+#define CONFIG_PTX_COMPRESSION 0
-+#define CONFIG_THUMB 0
-+#define CONFIG_VALGRIND_BACKTRACE 0
-+#define CONFIG_XMM_CLOBBER_TEST 0
-+#define CONFIG_BSFS 0
-+#define CONFIG_DECODERS 1
-+#define CONFIG_ENCODERS 0
-+#define CONFIG_HWACCELS 0
-+#define CONFIG_PARSERS 1
-+#define CONFIG_INDEVS 0
-+#define CONFIG_OUTDEVS 0
-+#define CONFIG_FILTERS 0
-+#define CONFIG_DEMUXERS 1
-+#define CONFIG_MUXERS 0
-+#define CONFIG_PROTOCOLS 0
-+#define CONFIG_AANDCTTABLES 0
-+#define CONFIG_AC3DSP 0
-+#define CONFIG_ADTS_HEADER 0
-+#define CONFIG_ATSC_A53 0
-+#define CONFIG_AUDIO_FRAME_QUEUE 0
-+#define CONFIG_AUDIODSP 0
-+#define CONFIG_BLOCKDSP 0
-+#define CONFIG_BSWAPDSP 0
-+#define CONFIG_CABAC 0
-+#define CONFIG_CBS 0
-+#define CONFIG_CBS_AV1 0
-+#define CONFIG_CBS_H264 0
-+#define CONFIG_CBS_H265 0
-+#define CONFIG_CBS_JPEG 0
-+#define CONFIG_CBS_MPEG2 0
-+#define CONFIG_CBS_VP9 0
-+#define CONFIG_DEFLATE_WRAPPER 0
-+#define CONFIG_DIRAC_PARSE 1
-+#define CONFIG_DNN 0
-+#define CONFIG_DOVI_RPU 0
-+#define CONFIG_DVPROFILE 0
-+#define CONFIG_EXIF 0
-+#define CONFIG_FAANDCT 0
-+#define CONFIG_FAANIDCT 0
-+#define CONFIG_FDCTDSP 0
-+#define CONFIG_FMTCONVERT 0
-+#define CONFIG_FRAME_THREAD_ENCODER 0
-+#define CONFIG_G722DSP 0
-+#define CONFIG_GOLOMB 1
-+#define CONFIG_GPLV3 0
-+#define CONFIG_H263DSP 0
-+#define CONFIG_H264CHROMA 0
-+#define CONFIG_H264DSP 0
-+#define CONFIG_H264PARSE 0
-+#define CONFIG_H264PRED 1
-+#define CONFIG_H264QPEL 0
-+#define CONFIG_H264_SEI 0
-+#define CONFIG_HEVCPARSE 0
-+#define CONFIG_HEVC_SEI 0
-+#define CONFIG_HPELDSP 1
-+#define CONFIG_HUFFMAN 0
-+#define CONFIG_HUFFYUVDSP 0
-+#define CONFIG_HUFFYUVENCDSP 0
-+#define CONFIG_IDCTDSP 0
-+#define CONFIG_IIRFILTER 0
-+#define CONFIG_INFLATE_WRAPPER 0
-+#define CONFIG_INTRAX8 0
-+#define CONFIG_ISO_MEDIA 1
-+#define CONFIG_IVIDSP 0
-+#define CONFIG_JPEGTABLES 0
-+#define CONFIG_LGPLV3 0
-+#define CONFIG_LIBX262 0
-+#define CONFIG_LLAUDDSP 0
-+#define CONFIG_LLVIDDSP 0
-+#define CONFIG_LLVIDENCDSP 0
-+#define CONFIG_LPC 0
-+#define CONFIG_LZF 0
-+#define CONFIG_ME_CMP 0
-+#define CONFIG_MPEG_ER 0
-+#define CONFIG_MPEGAUDIO 1
-+#define CONFIG_MPEGAUDIODSP 1
-+#define CONFIG_MPEGAUDIOHEADER 1
-+#define CONFIG_MPEG4AUDIO 1
-+#define CONFIG_MPEGVIDEO 0
-+#define CONFIG_MPEGVIDEODEC 0
-+#define CONFIG_MPEGVIDEOENC 0
-+#define CONFIG_MSMPEG4DEC 0
-+#define CONFIG_MSMPEG4ENC 0
-+#define CONFIG_MSS34DSP 0
-+#define CONFIG_PIXBLOCKDSP 0
-+#define CONFIG_QPELDSP 0
-+#define CONFIG_QSV 0
-+#define CONFIG_QSVDEC 0
-+#define CONFIG_QSVENC 0
-+#define CONFIG_QSVVPP 0
-+#define CONFIG_RANGECODER 0
-+#define CONFIG_RIFFDEC 1
-+#define CONFIG_RIFFENC 0
-+#define CONFIG_RTPDEC 0
-+#define CONFIG_RTPENC_CHAIN 0
-+#define CONFIG_RV34DSP 0
-+#define CONFIG_SCENE_SAD 0
-+#define CONFIG_SINEWIN 0
-+#define CONFIG_SNAPPY 0
-+#define CONFIG_SRTP 0
-+#define CONFIG_STARTCODE 0
-+#define CONFIG_TEXTUREDSP 0
-+#define CONFIG_TEXTUREDSPENC 0
-+#define CONFIG_TPELDSP 0
-+#define CONFIG_VAAPI_1 0
-+#define CONFIG_VAAPI_ENCODE 0
-+#define CONFIG_VC1DSP 0
-+#define CONFIG_VIDEODSP 1
-+#define CONFIG_VP3DSP 1
-+#define CONFIG_VP56DSP 0
-+#define CONFIG_VP8DSP 1
-+#define CONFIG_WMA_FREQS 0
-+#define CONFIG_WMV2DSP 0
-+#endif /* FFMPEG_CONFIG_H */
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,2146 @@
-+/* Automatically generated by configure - do not modify! */
-+#ifndef FFMPEG_CONFIG_COMPONENTS_H
-+#define FFMPEG_CONFIG_COMPONENTS_H
-+#define CONFIG_AAC_ADTSTOASC_BSF 0
-+#define CONFIG_AV1_FRAME_MERGE_BSF 0
-+#define CONFIG_AV1_FRAME_SPLIT_BSF 0
-+#define CONFIG_AV1_METADATA_BSF 0
-+#define CONFIG_CHOMP_BSF 0
-+#define CONFIG_DUMP_EXTRADATA_BSF 0
-+#define CONFIG_DCA_CORE_BSF 0
-+#define CONFIG_DTS2PTS_BSF 0
-+#define CONFIG_DV_ERROR_MARKER_BSF 0
-+#define CONFIG_EAC3_CORE_BSF 0
-+#define CONFIG_EXTRACT_EXTRADATA_BSF 0
-+#define CONFIG_FILTER_UNITS_BSF 0
-+#define CONFIG_H264_METADATA_BSF 0
-+#define CONFIG_H264_MP4TOANNEXB_BSF 0
-+#define CONFIG_H264_REDUNDANT_PPS_BSF 0
-+#define CONFIG_HAPQA_EXTRACT_BSF 0
-+#define CONFIG_HEVC_METADATA_BSF 0
-+#define CONFIG_HEVC_MP4TOANNEXB_BSF 0
-+#define CONFIG_IMX_DUMP_HEADER_BSF 0
-+#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
-+#define CONFIG_MJPEG2JPEG_BSF 0
-+#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
-+#define CONFIG_MP3_HEADER_DECOMPRESS_BSF 0
-+#define CONFIG_MPEG2_METADATA_BSF 0
-+#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
-+#define CONFIG_MOV2TEXTSUB_BSF 0
-+#define CONFIG_NOISE_BSF 0
-+#define CONFIG_NULL_BSF 0
-+#define CONFIG_OPUS_METADATA_BSF 0
-+#define CONFIG_PCM_RECHUNK_BSF 0
-+#define CONFIG_PGS_FRAME_MERGE_BSF 0
-+#define CONFIG_PRORES_METADATA_BSF 0
-+#define CONFIG_REMOVE_EXTRADATA_BSF 0
-+#define CONFIG_SETTS_BSF 0
-+#define CONFIG_TEXT2MOVSUB_BSF 0
-+#define CONFIG_TRACE_HEADERS_BSF 0
-+#define CONFIG_TRUEHD_CORE_BSF 0
-+#define CONFIG_VP9_METADATA_BSF 0
-+#define CONFIG_VP9_RAW_REORDER_BSF 0
-+#define CONFIG_VP9_SUPERFRAME_BSF 0
-+#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
-+#define CONFIG_AASC_DECODER 0
-+#define CONFIG_AIC_DECODER 0
-+#define CONFIG_ALIAS_PIX_DECODER 0
-+#define CONFIG_AGM_DECODER 0
-+#define CONFIG_AMV_DECODER 0
-+#define CONFIG_ANM_DECODER 0
-+#define CONFIG_ANSI_DECODER 0
-+#define CONFIG_APNG_DECODER 0
-+#define CONFIG_ARBC_DECODER 0
-+#define CONFIG_ARGO_DECODER 0
-+#define CONFIG_ASV1_DECODER 0
-+#define CONFIG_ASV2_DECODER 0
-+#define CONFIG_AURA_DECODER 0
-+#define CONFIG_AURA2_DECODER 0
-+#define CONFIG_AVRP_DECODER 0
-+#define CONFIG_AVRN_DECODER 0
-+#define CONFIG_AVS_DECODER 0
-+#define CONFIG_AVUI_DECODER 0
-+#define CONFIG_AYUV_DECODER 0
-+#define CONFIG_BETHSOFTVID_DECODER 0
-+#define CONFIG_BFI_DECODER 0
-+#define CONFIG_BINK_DECODER 0
-+#define CONFIG_BITPACKED_DECODER 0
-+#define CONFIG_BMP_DECODER 0
-+#define CONFIG_BMV_VIDEO_DECODER 0
-+#define CONFIG_BRENDER_PIX_DECODER 0
-+#define CONFIG_C93_DECODER 0
-+#define CONFIG_CAVS_DECODER 0
-+#define CONFIG_CDGRAPHICS_DECODER 0
-+#define CONFIG_CDTOONS_DECODER 0
-+#define CONFIG_CDXL_DECODER 0
-+#define CONFIG_CFHD_DECODER 0
-+#define CONFIG_CINEPAK_DECODER 0
-+#define CONFIG_CLEARVIDEO_DECODER 0
-+#define CONFIG_CLJR_DECODER 0
-+#define CONFIG_CLLC_DECODER 0
-+#define CONFIG_COMFORTNOISE_DECODER 0
-+#define CONFIG_CPIA_DECODER 0
-+#define CONFIG_CRI_DECODER 0
-+#define CONFIG_CSCD_DECODER 0
-+#define CONFIG_CYUV_DECODER 0
-+#define CONFIG_DDS_DECODER 0
-+#define CONFIG_DFA_DECODER 0
-+#define CONFIG_DIRAC_DECODER 0
-+#define CONFIG_DNXHD_DECODER 0
-+#define CONFIG_DPX_DECODER 0
-+#define CONFIG_DSICINVIDEO_DECODER 0
-+#define CONFIG_DVAUDIO_DECODER 0
-+#define CONFIG_DVVIDEO_DECODER 0
-+#define CONFIG_DXA_DECODER 0
-+#define CONFIG_DXTORY_DECODER 0
-+#define CONFIG_DXV_DECODER 0
-+#define CONFIG_EACMV_DECODER 0
-+#define CONFIG_EAMAD_DECODER 0
-+#define CONFIG_EATGQ_DECODER 0
-+#define CONFIG_EATGV_DECODER 0
-+#define CONFIG_EATQI_DECODER 0
-+#define CONFIG_EIGHTBPS_DECODER 0
-+#define CONFIG_EIGHTSVX_EXP_DECODER 0
-+#define CONFIG_EIGHTSVX_FIB_DECODER 0
-+#define CONFIG_ESCAPE124_DECODER 0
-+#define CONFIG_ESCAPE130_DECODER 0
-+#define CONFIG_EXR_DECODER 0
-+#define CONFIG_FFV1_DECODER 0
-+#define CONFIG_FFVHUFF_DECODER 0
-+#define CONFIG_FIC_DECODER 0
-+#define CONFIG_FITS_DECODER 0
-+#define CONFIG_FLASHSV_DECODER 0
-+#define CONFIG_FLASHSV2_DECODER 0
-+#define CONFIG_FLIC_DECODER 0
-+#define CONFIG_FLV_DECODER 0
-+#define CONFIG_FMVC_DECODER 0
-+#define CONFIG_FOURXM_DECODER 0
-+#define CONFIG_FRAPS_DECODER 0
-+#define CONFIG_FRWU_DECODER 0
-+#define CONFIG_G2M_DECODER 0
-+#define CONFIG_GDV_DECODER 0
-+#define CONFIG_GEM_DECODER 0
-+#define CONFIG_GIF_DECODER 0
-+#define CONFIG_H261_DECODER 0
-+#define CONFIG_H263_DECODER 0
-+#define CONFIG_H263I_DECODER 0
-+#define CONFIG_H263P_DECODER 0
-+#define CONFIG_H263_V4L2M2M_DECODER 0
-+#define CONFIG_H264_DECODER 0
-+#define CONFIG_H264_CRYSTALHD_DECODER 0
-+#define CONFIG_H264_V4L2M2M_DECODER 0
-+#define CONFIG_H264_MEDIACODEC_DECODER 0
-+#define CONFIG_H264_MMAL_DECODER 0
-+#define CONFIG_H264_QSV_DECODER 0
-+#define CONFIG_H264_RKMPP_DECODER 0
-+#define CONFIG_HAP_DECODER 0
-+#define CONFIG_HEVC_DECODER 0
-+#define CONFIG_HEVC_QSV_DECODER 0
-+#define CONFIG_HEVC_RKMPP_DECODER 0
-+#define CONFIG_HEVC_V4L2M2M_DECODER 0
-+#define CONFIG_HNM4_VIDEO_DECODER 0
-+#define CONFIG_HQ_HQA_DECODER 0
-+#define CONFIG_HQX_DECODER 0
-+#define CONFIG_HUFFYUV_DECODER 0
-+#define CONFIG_HYMT_DECODER 0
-+#define CONFIG_IDCIN_DECODER 0
-+#define CONFIG_IFF_ILBM_DECODER 0
-+#define CONFIG_IMM4_DECODER 0
-+#define CONFIG_IMM5_DECODER 0
-+#define CONFIG_INDEO2_DECODER 0
-+#define CONFIG_INDEO3_DECODER 0
-+#define CONFIG_INDEO4_DECODER 0
-+#define CONFIG_INDEO5_DECODER 0
-+#define CONFIG_INTERPLAY_VIDEO_DECODER 0
-+#define CONFIG_IPU_DECODER 0
-+#define CONFIG_JPEG2000_DECODER 0
-+#define CONFIG_JPEGLS_DECODER 0
-+#define CONFIG_JV_DECODER 0
-+#define CONFIG_KGV1_DECODER 0
-+#define CONFIG_KMVC_DECODER 0
-+#define CONFIG_LAGARITH_DECODER 0
-+#define CONFIG_LOCO_DECODER 0
-+#define CONFIG_LSCR_DECODER 0
-+#define CONFIG_M101_DECODER 0
-+#define CONFIG_MAGICYUV_DECODER 0
-+#define CONFIG_MDEC_DECODER 0
-+#define CONFIG_MEDIA100_DECODER 0
-+#define CONFIG_MIMIC_DECODER 0
-+#define CONFIG_MJPEG_DECODER 0
-+#define CONFIG_MJPEGB_DECODER 0
-+#define CONFIG_MMVIDEO_DECODER 0
-+#define CONFIG_MOBICLIP_DECODER 0
-+#define CONFIG_MOTIONPIXELS_DECODER 0
-+#define CONFIG_MPEG1VIDEO_DECODER 0
-+#define CONFIG_MPEG2VIDEO_DECODER 0
-+#define CONFIG_MPEG4_DECODER 0
-+#define CONFIG_MPEG4_CRYSTALHD_DECODER 0
-+#define CONFIG_MPEG4_V4L2M2M_DECODER 0
-+#define CONFIG_MPEG4_MMAL_DECODER 0
-+#define CONFIG_MPEGVIDEO_DECODER 0
-+#define CONFIG_MPEG1_V4L2M2M_DECODER 0
-+#define CONFIG_MPEG2_MMAL_DECODER 0
-+#define CONFIG_MPEG2_CRYSTALHD_DECODER 0
-+#define CONFIG_MPEG2_V4L2M2M_DECODER 0
-+#define CONFIG_MPEG2_QSV_DECODER 0
-+#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
-+#define CONFIG_MSA1_DECODER 0
-+#define CONFIG_MSCC_DECODER 0
-+#define CONFIG_MSMPEG4V1_DECODER 0
-+#define CONFIG_MSMPEG4V2_DECODER 0
-+#define CONFIG_MSMPEG4V3_DECODER 0
-+#define CONFIG_MSMPEG4_CRYSTALHD_DECODER 0
-+#define CONFIG_MSP2_DECODER 0
-+#define CONFIG_MSRLE_DECODER 0
-+#define CONFIG_MSS1_DECODER 0
-+#define CONFIG_MSS2_DECODER 0
-+#define CONFIG_MSVIDEO1_DECODER 0
-+#define CONFIG_MSZH_DECODER 0
-+#define CONFIG_MTS2_DECODER 0
-+#define CONFIG_MV30_DECODER 0
-+#define CONFIG_MVC1_DECODER 0
-+#define CONFIG_MVC2_DECODER 0
-+#define CONFIG_MVDV_DECODER 0
-+#define CONFIG_MVHA_DECODER 0
-+#define CONFIG_MWSC_DECODER 0
-+#define CONFIG_MXPEG_DECODER 0
-+#define CONFIG_NOTCHLC_DECODER 0
-+#define CONFIG_NUV_DECODER 0
-+#define CONFIG_PAF_VIDEO_DECODER 0
-+#define CONFIG_PAM_DECODER 0
-+#define CONFIG_PBM_DECODER 0
-+#define CONFIG_PCX_DECODER 0
-+#define CONFIG_PFM_DECODER 0
-+#define CONFIG_PGM_DECODER 0
-+#define CONFIG_PGMYUV_DECODER 0
-+#define CONFIG_PGX_DECODER 0
-+#define CONFIG_PHM_DECODER 0
-+#define CONFIG_PHOTOCD_DECODER 0
-+#define CONFIG_PICTOR_DECODER 0
-+#define CONFIG_PIXLET_DECODER 0
-+#define CONFIG_PNG_DECODER 0
-+#define CONFIG_PPM_DECODER 0
-+#define CONFIG_PRORES_DECODER 0
-+#define CONFIG_PROSUMER_DECODER 0
-+#define CONFIG_PSD_DECODER 0
-+#define CONFIG_PTX_DECODER 0
-+#define CONFIG_QDRAW_DECODER 0
-+#define CONFIG_QOI_DECODER 0
-+#define CONFIG_QPEG_DECODER 0
-+#define CONFIG_QTRLE_DECODER 0
-+#define CONFIG_R10K_DECODER 0
-+#define CONFIG_R210_DECODER 0
-+#define CONFIG_RASC_DECODER 0
-+#define CONFIG_RAWVIDEO_DECODER 0
-+#define CONFIG_RL2_DECODER 0
-+#define CONFIG_ROQ_DECODER 0
-+#define CONFIG_RPZA_DECODER 0
-+#define CONFIG_RSCC_DECODER 0
-+#define CONFIG_RV10_DECODER 0
-+#define CONFIG_RV20_DECODER 0
-+#define CONFIG_RV30_DECODER 0
-+#define CONFIG_RV40_DECODER 0
-+#define CONFIG_S302M_DECODER 0
-+#define CONFIG_SANM_DECODER 0
-+#define CONFIG_SCPR_DECODER 0
-+#define CONFIG_SCREENPRESSO_DECODER 0
-+#define CONFIG_SGA_DECODER 0
-+#define CONFIG_SGI_DECODER 0
-+#define CONFIG_SGIRLE_DECODER 0
-+#define CONFIG_SHEERVIDEO_DECODER 0
-+#define CONFIG_SIMBIOSIS_IMX_DECODER 0
-+#define CONFIG_SMACKER_DECODER 0
-+#define CONFIG_SMC_DECODER 0
-+#define CONFIG_SMVJPEG_DECODER 0
-+#define CONFIG_SNOW_DECODER 0
-+#define CONFIG_SP5X_DECODER 0
-+#define CONFIG_SPEEDHQ_DECODER 0
-+#define CONFIG_SPEEX_DECODER 0
-+#define CONFIG_SRGC_DECODER 0
-+#define CONFIG_SUNRAST_DECODER 0
-+#define CONFIG_SVQ1_DECODER 0
-+#define CONFIG_SVQ3_DECODER 0
-+#define CONFIG_TARGA_DECODER 0
-+#define CONFIG_TARGA_Y216_DECODER 0
-+#define CONFIG_TDSC_DECODER 0
-+#define CONFIG_THEORA_DECODER 1
-+#define CONFIG_THP_DECODER 0
-+#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
-+#define CONFIG_TIFF_DECODER 0
-+#define CONFIG_TMV_DECODER 0
-+#define CONFIG_TRUEMOTION1_DECODER 0
-+#define CONFIG_TRUEMOTION2_DECODER 0
-+#define CONFIG_TRUEMOTION2RT_DECODER 0
-+#define CONFIG_TSCC_DECODER 0
-+#define CONFIG_TSCC2_DECODER 0
-+#define CONFIG_TXD_DECODER 0
-+#define CONFIG_ULTI_DECODER 0
-+#define CONFIG_UTVIDEO_DECODER 0
-+#define CONFIG_V210_DECODER 0
-+#define CONFIG_V210X_DECODER 0
-+#define CONFIG_V308_DECODER 0
-+#define CONFIG_V408_DECODER 0
-+#define CONFIG_V410_DECODER 0
-+#define CONFIG_VB_DECODER 0
-+#define CONFIG_VBN_DECODER 0
-+#define CONFIG_VBLE_DECODER 0
-+#define CONFIG_VC1_DECODER 0
-+#define CONFIG_VC1_CRYSTALHD_DECODER 0
-+#define CONFIG_VC1IMAGE_DECODER 0
-+#define CONFIG_VC1_MMAL_DECODER 0
-+#define CONFIG_VC1_QSV_DECODER 0
-+#define CONFIG_VC1_V4L2M2M_DECODER 0
-+#define CONFIG_VCR1_DECODER 0
-+#define CONFIG_VMDVIDEO_DECODER 0
-+#define CONFIG_VMNC_DECODER 0
-+#define CONFIG_VP3_DECODER 1
-+#define CONFIG_VP4_DECODER 0
-+#define CONFIG_VP5_DECODER 0
-+#define CONFIG_VP6_DECODER 0
-+#define CONFIG_VP6A_DECODER 0
-+#define CONFIG_VP6F_DECODER 0
-+#define CONFIG_VP7_DECODER 0
-+#define CONFIG_VP8_DECODER 1
-+#define CONFIG_VP8_RKMPP_DECODER 0
-+#define CONFIG_VP8_V4L2M2M_DECODER 0
-+#define CONFIG_VP9_DECODER 0
-+#define CONFIG_VP9_RKMPP_DECODER 0
-+#define CONFIG_VP9_V4L2M2M_DECODER 0
-+#define CONFIG_VQA_DECODER 0
-+#define CONFIG_VQC_DECODER 0
-+#define CONFIG_WBMP_DECODER 0
-+#define CONFIG_WEBP_DECODER 0
-+#define CONFIG_WCMV_DECODER 0
-+#define CONFIG_WRAPPED_AVFRAME_DECODER 0
-+#define CONFIG_WMV1_DECODER 0
-+#define CONFIG_WMV2_DECODER 0
-+#define CONFIG_WMV3_DECODER 0
-+#define CONFIG_WMV3_CRYSTALHD_DECODER 0
-+#define CONFIG_WMV3IMAGE_DECODER 0
-+#define CONFIG_WNV1_DECODER 0
-+#define CONFIG_XAN_WC3_DECODER 0
-+#define CONFIG_XAN_WC4_DECODER 0
-+#define CONFIG_XBM_DECODER 0
-+#define CONFIG_XFACE_DECODER 0
-+#define CONFIG_XL_DECODER 0
-+#define CONFIG_XPM_DECODER 0
-+#define CONFIG_XWD_DECODER 0
-+#define CONFIG_Y41P_DECODER 0
-+#define CONFIG_YLC_DECODER 0
-+#define CONFIG_YOP_DECODER 0
-+#define CONFIG_YUV4_DECODER 0
-+#define CONFIG_ZERO12V_DECODER 0
-+#define CONFIG_ZEROCODEC_DECODER 0
-+#define CONFIG_ZLIB_DECODER 0
-+#define CONFIG_ZMBV_DECODER 0
-+#define CONFIG_AAC_DECODER 0
-+#define CONFIG_AAC_FIXED_DECODER 0
-+#define CONFIG_AAC_LATM_DECODER 0
-+#define CONFIG_AC3_DECODER 0
-+#define CONFIG_AC3_FIXED_DECODER 0
-+#define CONFIG_ACELP_KELVIN_DECODER 0
-+#define CONFIG_ALAC_DECODER 0
-+#define CONFIG_ALS_DECODER 0
-+#define CONFIG_AMRNB_DECODER 0
-+#define CONFIG_AMRWB_DECODER 0
-+#define CONFIG_APAC_DECODER 0
-+#define CONFIG_APE_DECODER 0
-+#define CONFIG_APTX_DECODER 0
-+#define CONFIG_APTX_HD_DECODER 0
-+#define CONFIG_ATRAC1_DECODER 0
-+#define CONFIG_ATRAC3_DECODER 0
-+#define CONFIG_ATRAC3AL_DECODER 0
-+#define CONFIG_ATRAC3P_DECODER 0
-+#define CONFIG_ATRAC3PAL_DECODER 0
-+#define CONFIG_ATRAC9_DECODER 0
-+#define CONFIG_BINKAUDIO_DCT_DECODER 0
-+#define CONFIG_BINKAUDIO_RDFT_DECODER 0
-+#define CONFIG_BMV_AUDIO_DECODER 0
-+#define CONFIG_BONK_DECODER 0
-+#define CONFIG_COOK_DECODER 0
-+#define CONFIG_DCA_DECODER 0
-+#define CONFIG_DFPWM_DECODER 0
-+#define CONFIG_DOLBY_E_DECODER 0
-+#define CONFIG_DSD_LSBF_DECODER 0
-+#define CONFIG_DSD_MSBF_DECODER 0
-+#define CONFIG_DSD_LSBF_PLANAR_DECODER 0
-+#define CONFIG_DSD_MSBF_PLANAR_DECODER 0
-+#define CONFIG_DSICINAUDIO_DECODER 0
-+#define CONFIG_DSS_SP_DECODER 0
-+#define CONFIG_DST_DECODER 0
-+#define CONFIG_EAC3_DECODER 0
-+#define CONFIG_EVRC_DECODER 0
-+#define CONFIG_FASTAUDIO_DECODER 0
-+#define CONFIG_FFWAVESYNTH_DECODER 0
-+#define CONFIG_FLAC_DECODER 1
-+#define CONFIG_FTR_DECODER 0
-+#define CONFIG_G723_1_DECODER 0
-+#define CONFIG_G729_DECODER 0
-+#define CONFIG_GSM_DECODER 0
-+#define CONFIG_GSM_MS_DECODER 0
-+#define CONFIG_HCA_DECODER 0
-+#define CONFIG_HCOM_DECODER 0
-+#define CONFIG_HDR_DECODER 0
-+#define CONFIG_IAC_DECODER 0
-+#define CONFIG_ILBC_DECODER 0
-+#define CONFIG_IMC_DECODER 0
-+#define CONFIG_INTERPLAY_ACM_DECODER 0
-+#define CONFIG_MACE3_DECODER 0
-+#define CONFIG_MACE6_DECODER 0
-+#define CONFIG_METASOUND_DECODER 0
-+#define CONFIG_MISC4_DECODER 0
-+#define CONFIG_MLP_DECODER 0
-+#define CONFIG_MP1_DECODER 0
-+#define CONFIG_MP1FLOAT_DECODER 0
-+#define CONFIG_MP2_DECODER 0
-+#define CONFIG_MP2FLOAT_DECODER 0
-+#define CONFIG_MP3FLOAT_DECODER 0
-+#define CONFIG_MP3_DECODER 1
-+#define CONFIG_MP3ADUFLOAT_DECODER 0
-+#define CONFIG_MP3ADU_DECODER 0
-+#define CONFIG_MP3ON4FLOAT_DECODER 0
-+#define CONFIG_MP3ON4_DECODER 0
-+#define CONFIG_MPC7_DECODER 0
-+#define CONFIG_MPC8_DECODER 0
-+#define CONFIG_MSNSIREN_DECODER 0
-+#define CONFIG_NELLYMOSER_DECODER 0
-+#define CONFIG_ON2AVC_DECODER 0
-+#define CONFIG_OPUS_DECODER 0
-+#define CONFIG_PAF_AUDIO_DECODER 0
-+#define CONFIG_QCELP_DECODER 0
-+#define CONFIG_QDM2_DECODER 0
-+#define CONFIG_QDMC_DECODER 0
-+#define CONFIG_RA_144_DECODER 0
-+#define CONFIG_RA_288_DECODER 0
-+#define CONFIG_RALF_DECODER 0
-+#define CONFIG_SBC_DECODER 0
-+#define CONFIG_SHORTEN_DECODER 0
-+#define CONFIG_SIPR_DECODER 0
-+#define CONFIG_SIREN_DECODER 0
-+#define CONFIG_SMACKAUD_DECODER 0
-+#define CONFIG_SONIC_DECODER 0
-+#define CONFIG_TAK_DECODER 0
-+#define CONFIG_TRUEHD_DECODER 0
-+#define CONFIG_TRUESPEECH_DECODER 0
-+#define CONFIG_TTA_DECODER 0
-+#define CONFIG_TWINVQ_DECODER 0
-+#define CONFIG_VMDAUDIO_DECODER 0
-+#define CONFIG_VORBIS_DECODER 1
-+#define CONFIG_WAVPACK_DECODER 0
-+#define CONFIG_WMALOSSLESS_DECODER 0
-+#define CONFIG_WMAPRO_DECODER 0
-+#define CONFIG_WMAV1_DECODER 0
-+#define CONFIG_WMAV2_DECODER 0
-+#define CONFIG_WMAVOICE_DECODER 0
-+#define CONFIG_WS_SND1_DECODER 0
-+#define CONFIG_XMA1_DECODER 0
-+#define CONFIG_XMA2_DECODER 0
-+#define CONFIG_PCM_ALAW_DECODER 1
-+#define CONFIG_PCM_BLURAY_DECODER 0
-+#define CONFIG_PCM_DVD_DECODER 0
-+#define CONFIG_PCM_F16LE_DECODER 0
-+#define CONFIG_PCM_F24LE_DECODER 0
-+#define CONFIG_PCM_F32BE_DECODER 0
-+#define CONFIG_PCM_F32LE_DECODER 1
-+#define CONFIG_PCM_F64BE_DECODER 0
-+#define CONFIG_PCM_F64LE_DECODER 0
-+#define CONFIG_PCM_LXF_DECODER 0
-+#define CONFIG_PCM_MULAW_DECODER 1
-+#define CONFIG_PCM_S8_DECODER 0
-+#define CONFIG_PCM_S8_PLANAR_DECODER 0
-+#define CONFIG_PCM_S16BE_DECODER 1
-+#define CONFIG_PCM_S16BE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S16LE_DECODER 1
-+#define CONFIG_PCM_S16LE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S24BE_DECODER 1
-+#define CONFIG_PCM_S24DAUD_DECODER 0
-+#define CONFIG_PCM_S24LE_DECODER 1
-+#define CONFIG_PCM_S24LE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S32BE_DECODER 0
-+#define CONFIG_PCM_S32LE_DECODER 1
-+#define CONFIG_PCM_S32LE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S64BE_DECODER 0
-+#define CONFIG_PCM_S64LE_DECODER 0
-+#define CONFIG_PCM_SGA_DECODER 0
-+#define CONFIG_PCM_U8_DECODER 1
-+#define CONFIG_PCM_U16BE_DECODER 0
-+#define CONFIG_PCM_U16LE_DECODER 0
-+#define CONFIG_PCM_U24BE_DECODER 0
-+#define CONFIG_PCM_U24LE_DECODER 0
-+#define CONFIG_PCM_U32BE_DECODER 0
-+#define CONFIG_PCM_U32LE_DECODER 0
-+#define CONFIG_PCM_VIDC_DECODER 0
-+#define CONFIG_CBD2_DPCM_DECODER 0
-+#define CONFIG_DERF_DPCM_DECODER 0
-+#define CONFIG_GREMLIN_DPCM_DECODER 0
-+#define CONFIG_INTERPLAY_DPCM_DECODER 0
-+#define CONFIG_ROQ_DPCM_DECODER 0
-+#define CONFIG_SDX2_DPCM_DECODER 0
-+#define CONFIG_SOL_DPCM_DECODER 0
-+#define CONFIG_XAN_DPCM_DECODER 0
-+#define CONFIG_WADY_DPCM_DECODER 0
-+#define CONFIG_ADPCM_4XM_DECODER 0
-+#define CONFIG_ADPCM_ADX_DECODER 0
-+#define CONFIG_ADPCM_AFC_DECODER 0
-+#define CONFIG_ADPCM_AGM_DECODER 0
-+#define CONFIG_ADPCM_AICA_DECODER 0
-+#define CONFIG_ADPCM_ARGO_DECODER 0
-+#define CONFIG_ADPCM_CT_DECODER 0
-+#define CONFIG_ADPCM_DTK_DECODER 0
-+#define CONFIG_ADPCM_EA_DECODER 0
-+#define CONFIG_ADPCM_EA_MAXIS_XA_DECODER 0
-+#define CONFIG_ADPCM_EA_R1_DECODER 0
-+#define CONFIG_ADPCM_EA_R2_DECODER 0
-+#define CONFIG_ADPCM_EA_R3_DECODER 0
-+#define CONFIG_ADPCM_EA_XAS_DECODER 0
-+#define CONFIG_ADPCM_G722_DECODER 0
-+#define CONFIG_ADPCM_G726_DECODER 0
-+#define CONFIG_ADPCM_G726LE_DECODER 0
-+#define CONFIG_ADPCM_IMA_ACORN_DECODER 0
-+#define CONFIG_ADPCM_IMA_AMV_DECODER 0
-+#define CONFIG_ADPCM_IMA_ALP_DECODER 0
-+#define CONFIG_ADPCM_IMA_APC_DECODER 0
-+#define CONFIG_ADPCM_IMA_APM_DECODER 0
-+#define CONFIG_ADPCM_IMA_CUNNING_DECODER 0
-+#define CONFIG_ADPCM_IMA_DAT4_DECODER 0
-+#define CONFIG_ADPCM_IMA_DK3_DECODER 0
-+#define CONFIG_ADPCM_IMA_DK4_DECODER 0
-+#define CONFIG_ADPCM_IMA_EA_EACS_DECODER 0
-+#define CONFIG_ADPCM_IMA_EA_SEAD_DECODER 0
-+#define CONFIG_ADPCM_IMA_ISS_DECODER 0
-+#define CONFIG_ADPCM_IMA_MOFLEX_DECODER 0
-+#define CONFIG_ADPCM_IMA_MTF_DECODER 0
-+#define CONFIG_ADPCM_IMA_OKI_DECODER 0
-+#define CONFIG_ADPCM_IMA_QT_DECODER 0
-+#define CONFIG_ADPCM_IMA_RAD_DECODER 0
-+#define CONFIG_ADPCM_IMA_SSI_DECODER 0
-+#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
-+#define CONFIG_ADPCM_IMA_WAV_DECODER 0
-+#define CONFIG_ADPCM_IMA_WS_DECODER 0
-+#define CONFIG_ADPCM_MS_DECODER 0
-+#define CONFIG_ADPCM_MTAF_DECODER 0
-+#define CONFIG_ADPCM_PSX_DECODER 0
-+#define CONFIG_ADPCM_SBPRO_2_DECODER 0
-+#define CONFIG_ADPCM_SBPRO_3_DECODER 0
-+#define CONFIG_ADPCM_SBPRO_4_DECODER 0
-+#define CONFIG_ADPCM_SWF_DECODER 0
-+#define CONFIG_ADPCM_THP_DECODER 0
-+#define CONFIG_ADPCM_THP_LE_DECODER 0
-+#define CONFIG_ADPCM_VIMA_DECODER 0
-+#define CONFIG_ADPCM_XA_DECODER 0
-+#define CONFIG_ADPCM_XMD_DECODER 0
-+#define CONFIG_ADPCM_YAMAHA_DECODER 0
-+#define CONFIG_ADPCM_ZORK_DECODER 0
-+#define CONFIG_SSA_DECODER 0
-+#define CONFIG_ASS_DECODER 0
-+#define CONFIG_CCAPTION_DECODER 0
-+#define CONFIG_DVBSUB_DECODER 0
-+#define CONFIG_DVDSUB_DECODER 0
-+#define CONFIG_JACOSUB_DECODER 0
-+#define CONFIG_MICRODVD_DECODER 0
-+#define CONFIG_MOVTEXT_DECODER 0
-+#define CONFIG_MPL2_DECODER 0
-+#define CONFIG_PGSSUB_DECODER 0
-+#define CONFIG_PJS_DECODER 0
-+#define CONFIG_REALTEXT_DECODER 0
-+#define CONFIG_SAMI_DECODER 0
-+#define CONFIG_SRT_DECODER 0
-+#define CONFIG_STL_DECODER 0
-+#define CONFIG_SUBRIP_DECODER 0
-+#define CONFIG_SUBVIEWER_DECODER 0
-+#define CONFIG_SUBVIEWER1_DECODER 0
-+#define CONFIG_TEXT_DECODER 0
-+#define CONFIG_VPLAYER_DECODER 0
-+#define CONFIG_WEBVTT_DECODER 0
-+#define CONFIG_XSUB_DECODER 0
-+#define CONFIG_AAC_AT_DECODER 0
-+#define CONFIG_AC3_AT_DECODER 0
-+#define CONFIG_ADPCM_IMA_QT_AT_DECODER 0
-+#define CONFIG_ALAC_AT_DECODER 0
-+#define CONFIG_AMR_NB_AT_DECODER 0
-+#define CONFIG_EAC3_AT_DECODER 0
-+#define CONFIG_GSM_MS_AT_DECODER 0
-+#define CONFIG_ILBC_AT_DECODER 0
-+#define CONFIG_MP1_AT_DECODER 0
-+#define CONFIG_MP2_AT_DECODER 0
-+#define CONFIG_MP3_AT_DECODER 0
-+#define CONFIG_PCM_ALAW_AT_DECODER 0
-+#define CONFIG_PCM_MULAW_AT_DECODER 0
-+#define CONFIG_QDMC_AT_DECODER 0
-+#define CONFIG_QDM2_AT_DECODER 0
-+#define CONFIG_LIBARIBB24_DECODER 0
-+#define CONFIG_LIBCELT_DECODER 0
-+#define CONFIG_LIBCODEC2_DECODER 0
-+#define CONFIG_LIBDAV1D_DECODER 0
-+#define CONFIG_LIBDAVS2_DECODER 0
-+#define CONFIG_LIBFDK_AAC_DECODER 0
-+#define CONFIG_LIBGSM_DECODER 0
-+#define CONFIG_LIBGSM_MS_DECODER 0
-+#define CONFIG_LIBILBC_DECODER 0
-+#define CONFIG_LIBJXL_DECODER 0
-+#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
-+#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
-+#define CONFIG_LIBOPENJPEG_DECODER 0
-+#define CONFIG_LIBOPUS_DECODER 1
-+#define CONFIG_LIBRSVG_DECODER 0
-+#define CONFIG_LIBSPEEX_DECODER 0
-+#define CONFIG_LIBUAVS3D_DECODER 0
-+#define CONFIG_LIBVORBIS_DECODER 0
-+#define CONFIG_LIBVPX_VP8_DECODER 0
-+#define CONFIG_LIBVPX_VP9_DECODER 0
-+#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
-+#define CONFIG_BINTEXT_DECODER 0
-+#define CONFIG_XBIN_DECODER 0
-+#define CONFIG_IDF_DECODER 0
-+#define CONFIG_LIBAOM_AV1_DECODER 0
-+#define CONFIG_AV1_DECODER 0
-+#define CONFIG_AV1_CUVID_DECODER 0
-+#define CONFIG_AV1_MEDIACODEC_DECODER 0
-+#define CONFIG_AV1_QSV_DECODER 0
-+#define CONFIG_LIBOPENH264_DECODER 0
-+#define CONFIG_H264_CUVID_DECODER 0
-+#define CONFIG_HEVC_CUVID_DECODER 0
-+#define CONFIG_HEVC_MEDIACODEC_DECODER 0
-+#define CONFIG_MJPEG_CUVID_DECODER 0
-+#define CONFIG_MJPEG_QSV_DECODER 0
-+#define CONFIG_MPEG1_CUVID_DECODER 0
-+#define CONFIG_MPEG2_CUVID_DECODER 0
-+#define CONFIG_MPEG4_CUVID_DECODER 0
-+#define CONFIG_MPEG4_MEDIACODEC_DECODER 0
-+#define CONFIG_VC1_CUVID_DECODER 0
-+#define CONFIG_VP8_CUVID_DECODER 0
-+#define CONFIG_VP8_MEDIACODEC_DECODER 0
-+#define CONFIG_VP8_QSV_DECODER 0
-+#define CONFIG_VP9_CUVID_DECODER 0
-+#define CONFIG_VP9_MEDIACODEC_DECODER 0
-+#define CONFIG_VP9_QSV_DECODER 0
-+#define CONFIG_VNULL_DECODER 0
-+#define CONFIG_ANULL_DECODER 0
-+#define CONFIG_A64MULTI_ENCODER 0
-+#define CONFIG_A64MULTI5_ENCODER 0
-+#define CONFIG_ALIAS_PIX_ENCODER 0
-+#define CONFIG_AMV_ENCODER 0
-+#define CONFIG_APNG_ENCODER 0
-+#define CONFIG_ASV1_ENCODER 0
-+#define CONFIG_ASV2_ENCODER 0
-+#define CONFIG_AVRP_ENCODER 0
-+#define CONFIG_AVUI_ENCODER 0
-+#define CONFIG_AYUV_ENCODER 0
-+#define CONFIG_BITPACKED_ENCODER 0
-+#define CONFIG_BMP_ENCODER 0
-+#define CONFIG_CFHD_ENCODER 0
-+#define CONFIG_CINEPAK_ENCODER 0
-+#define CONFIG_CLJR_ENCODER 0
-+#define CONFIG_COMFORTNOISE_ENCODER 0
-+#define CONFIG_DNXHD_ENCODER 0
-+#define CONFIG_DPX_ENCODER 0
-+#define CONFIG_DVVIDEO_ENCODER 0
-+#define CONFIG_EXR_ENCODER 0
-+#define CONFIG_FFV1_ENCODER 0
-+#define CONFIG_FFVHUFF_ENCODER 0
-+#define CONFIG_FITS_ENCODER 0
-+#define CONFIG_FLASHSV_ENCODER 0
-+#define CONFIG_FLASHSV2_ENCODER 0
-+#define CONFIG_FLV_ENCODER 0
-+#define CONFIG_GIF_ENCODER 0
-+#define CONFIG_H261_ENCODER 0
-+#define CONFIG_H263_ENCODER 0
-+#define CONFIG_H263P_ENCODER 0
-+#define CONFIG_H264_MEDIACODEC_ENCODER 0
-+#define CONFIG_HAP_ENCODER 0
-+#define CONFIG_HUFFYUV_ENCODER 0
-+#define CONFIG_JPEG2000_ENCODER 0
-+#define CONFIG_JPEGLS_ENCODER 0
-+#define CONFIG_LJPEG_ENCODER 0
-+#define CONFIG_MAGICYUV_ENCODER 0
-+#define CONFIG_MJPEG_ENCODER 0
-+#define CONFIG_MPEG1VIDEO_ENCODER 0
-+#define CONFIG_MPEG2VIDEO_ENCODER 0
-+#define CONFIG_MPEG4_ENCODER 0
-+#define CONFIG_MSMPEG4V2_ENCODER 0
-+#define CONFIG_MSMPEG4V3_ENCODER 0
-+#define CONFIG_MSVIDEO1_ENCODER 0
-+#define CONFIG_PAM_ENCODER 0
-+#define CONFIG_PBM_ENCODER 0
-+#define CONFIG_PCX_ENCODER 0
-+#define CONFIG_PFM_ENCODER 0
-+#define CONFIG_PGM_ENCODER 0
-+#define CONFIG_PGMYUV_ENCODER 0
-+#define CONFIG_PHM_ENCODER 0
-+#define CONFIG_PNG_ENCODER 0
-+#define CONFIG_PPM_ENCODER 0
-+#define CONFIG_PRORES_ENCODER 0
-+#define CONFIG_PRORES_AW_ENCODER 0
-+#define CONFIG_PRORES_KS_ENCODER 0
-+#define CONFIG_QOI_ENCODER 0
-+#define CONFIG_QTRLE_ENCODER 0
-+#define CONFIG_R10K_ENCODER 0
-+#define CONFIG_R210_ENCODER 0
-+#define CONFIG_RAWVIDEO_ENCODER 0
-+#define CONFIG_ROQ_ENCODER 0
-+#define CONFIG_RPZA_ENCODER 0
-+#define CONFIG_RV10_ENCODER 0
-+#define CONFIG_RV20_ENCODER 0
-+#define CONFIG_S302M_ENCODER 0
-+#define CONFIG_SGI_ENCODER 0
-+#define CONFIG_SMC_ENCODER 0
-+#define CONFIG_SNOW_ENCODER 0
-+#define CONFIG_SPEEDHQ_ENCODER 0
-+#define CONFIG_SUNRAST_ENCODER 0
-+#define CONFIG_SVQ1_ENCODER 0
-+#define CONFIG_TARGA_ENCODER 0
-+#define CONFIG_TIFF_ENCODER 0
-+#define CONFIG_UTVIDEO_ENCODER 0
-+#define CONFIG_V210_ENCODER 0
-+#define CONFIG_V308_ENCODER 0
-+#define CONFIG_V408_ENCODER 0
-+#define CONFIG_V410_ENCODER 0
-+#define CONFIG_VBN_ENCODER 0
-+#define CONFIG_VC2_ENCODER 0
-+#define CONFIG_WBMP_ENCODER 0
-+#define CONFIG_WRAPPED_AVFRAME_ENCODER 0
-+#define CONFIG_WMV1_ENCODER 0
-+#define CONFIG_WMV2_ENCODER 0
-+#define CONFIG_XBM_ENCODER 0
-+#define CONFIG_XFACE_ENCODER 0
-+#define CONFIG_XWD_ENCODER 0
-+#define CONFIG_Y41P_ENCODER 0
-+#define CONFIG_YUV4_ENCODER 0
-+#define CONFIG_ZLIB_ENCODER 0
-+#define CONFIG_ZMBV_ENCODER 0
-+#define CONFIG_AAC_ENCODER 0
-+#define CONFIG_AC3_ENCODER 0
-+#define CONFIG_AC3_FIXED_ENCODER 0
-+#define CONFIG_ALAC_ENCODER 0
-+#define CONFIG_APTX_ENCODER 0
-+#define CONFIG_APTX_HD_ENCODER 0
-+#define CONFIG_DCA_ENCODER 0
-+#define CONFIG_DFPWM_ENCODER 0
-+#define CONFIG_EAC3_ENCODER 0
-+#define CONFIG_FLAC_ENCODER 0
-+#define CONFIG_G723_1_ENCODER 0
-+#define CONFIG_HDR_ENCODER 0
-+#define CONFIG_MLP_ENCODER 0
-+#define CONFIG_MP2_ENCODER 0
-+#define CONFIG_MP2FIXED_ENCODER 0
-+#define CONFIG_NELLYMOSER_ENCODER 0
-+#define CONFIG_OPUS_ENCODER 0
-+#define CONFIG_RA_144_ENCODER 0
-+#define CONFIG_SBC_ENCODER 0
-+#define CONFIG_SONIC_ENCODER 0
-+#define CONFIG_SONIC_LS_ENCODER 0
-+#define CONFIG_TRUEHD_ENCODER 0
-+#define CONFIG_TTA_ENCODER 0
-+#define CONFIG_VORBIS_ENCODER 0
-+#define CONFIG_WAVPACK_ENCODER 0
-+#define CONFIG_WMAV1_ENCODER 0
-+#define CONFIG_WMAV2_ENCODER 0
-+#define CONFIG_PCM_ALAW_ENCODER 0
-+#define CONFIG_PCM_BLURAY_ENCODER 0
-+#define CONFIG_PCM_DVD_ENCODER 0
-+#define CONFIG_PCM_F32BE_ENCODER 0
-+#define CONFIG_PCM_F32LE_ENCODER 0
-+#define CONFIG_PCM_F64BE_ENCODER 0
-+#define CONFIG_PCM_F64LE_ENCODER 0
-+#define CONFIG_PCM_MULAW_ENCODER 0
-+#define CONFIG_PCM_S8_ENCODER 0
-+#define CONFIG_PCM_S8_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S16BE_ENCODER 0
-+#define CONFIG_PCM_S16BE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S16LE_ENCODER 0
-+#define CONFIG_PCM_S16LE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S24BE_ENCODER 0
-+#define CONFIG_PCM_S24DAUD_ENCODER 0
-+#define CONFIG_PCM_S24LE_ENCODER 0
-+#define CONFIG_PCM_S24LE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S32BE_ENCODER 0
-+#define CONFIG_PCM_S32LE_ENCODER 0
-+#define CONFIG_PCM_S32LE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S64BE_ENCODER 0
-+#define CONFIG_PCM_S64LE_ENCODER 0
-+#define CONFIG_PCM_U8_ENCODER 0
-+#define CONFIG_PCM_U16BE_ENCODER 0
-+#define CONFIG_PCM_U16LE_ENCODER 0
-+#define CONFIG_PCM_U24BE_ENCODER 0
-+#define CONFIG_PCM_U24LE_ENCODER 0
-+#define CONFIG_PCM_U32BE_ENCODER 0
-+#define CONFIG_PCM_U32LE_ENCODER 0
-+#define CONFIG_PCM_VIDC_ENCODER 0
-+#define CONFIG_ROQ_DPCM_ENCODER 0
-+#define CONFIG_ADPCM_ADX_ENCODER 0
-+#define CONFIG_ADPCM_ARGO_ENCODER 0
-+#define CONFIG_ADPCM_G722_ENCODER 0
-+#define CONFIG_ADPCM_G726_ENCODER 0
-+#define CONFIG_ADPCM_G726LE_ENCODER 0
-+#define CONFIG_ADPCM_IMA_AMV_ENCODER 0
-+#define CONFIG_ADPCM_IMA_ALP_ENCODER 0
-+#define CONFIG_ADPCM_IMA_APM_ENCODER 0
-+#define CONFIG_ADPCM_IMA_QT_ENCODER 0
-+#define CONFIG_ADPCM_IMA_SSI_ENCODER 0
-+#define CONFIG_ADPCM_IMA_WAV_ENCODER 0
-+#define CONFIG_ADPCM_IMA_WS_ENCODER 0
-+#define CONFIG_ADPCM_MS_ENCODER 0
-+#define CONFIG_ADPCM_SWF_ENCODER 0
-+#define CONFIG_ADPCM_YAMAHA_ENCODER 0
-+#define CONFIG_SSA_ENCODER 0
-+#define CONFIG_ASS_ENCODER 0
-+#define CONFIG_DVBSUB_ENCODER 0
-+#define CONFIG_DVDSUB_ENCODER 0
-+#define CONFIG_MOVTEXT_ENCODER 0
-+#define CONFIG_SRT_ENCODER 0
-+#define CONFIG_SUBRIP_ENCODER 0
-+#define CONFIG_TEXT_ENCODER 0
-+#define CONFIG_TTML_ENCODER 0
-+#define CONFIG_WEBVTT_ENCODER 0
-+#define CONFIG_XSUB_ENCODER 0
-+#define CONFIG_AAC_AT_ENCODER 0
-+#define CONFIG_ALAC_AT_ENCODER 0
-+#define CONFIG_ILBC_AT_ENCODER 0
-+#define CONFIG_PCM_ALAW_AT_ENCODER 0
-+#define CONFIG_PCM_MULAW_AT_ENCODER 0
-+#define CONFIG_LIBAOM_AV1_ENCODER 0
-+#define CONFIG_LIBCODEC2_ENCODER 0
-+#define CONFIG_LIBFDK_AAC_ENCODER 0
-+#define CONFIG_LIBGSM_ENCODER 0
-+#define CONFIG_LIBGSM_MS_ENCODER 0
-+#define CONFIG_LIBILBC_ENCODER 0
-+#define CONFIG_LIBJXL_ENCODER 0
-+#define CONFIG_LIBMP3LAME_ENCODER 0
-+#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
-+#define CONFIG_LIBOPENJPEG_ENCODER 0
-+#define CONFIG_LIBOPUS_ENCODER 0
-+#define CONFIG_LIBRAV1E_ENCODER 0
-+#define CONFIG_LIBSHINE_ENCODER 0
-+#define CONFIG_LIBSPEEX_ENCODER 0
-+#define CONFIG_LIBSVTAV1_ENCODER 0
-+#define CONFIG_LIBTHEORA_ENCODER 0
-+#define CONFIG_LIBTWOLAME_ENCODER 0
-+#define CONFIG_LIBVO_AMRWBENC_ENCODER 0
-+#define CONFIG_LIBVORBIS_ENCODER 0
-+#define CONFIG_LIBVPX_VP8_ENCODER 0
-+#define CONFIG_LIBVPX_VP9_ENCODER 0
-+#define CONFIG_LIBWEBP_ANIM_ENCODER 0
-+#define CONFIG_LIBWEBP_ENCODER 0
-+#define CONFIG_LIBX262_ENCODER 0
-+#define CONFIG_LIBX264_ENCODER 0
-+#define CONFIG_LIBX264RGB_ENCODER 0
-+#define CONFIG_LIBX265_ENCODER 0
-+#define CONFIG_LIBXAVS_ENCODER 0
-+#define CONFIG_LIBXAVS2_ENCODER 0
-+#define CONFIG_LIBXVID_ENCODER 0
-+#define CONFIG_AAC_MF_ENCODER 0
-+#define CONFIG_AC3_MF_ENCODER 0
-+#define CONFIG_H263_V4L2M2M_ENCODER 0
-+#define CONFIG_AV1_NVENC_ENCODER 0
-+#define CONFIG_AV1_QSV_ENCODER 0
-+#define CONFIG_AV1_AMF_ENCODER 0
-+#define CONFIG_LIBOPENH264_ENCODER 0
-+#define CONFIG_H264_AMF_ENCODER 0
-+#define CONFIG_H264_MF_ENCODER 0
-+#define CONFIG_H264_NVENC_ENCODER 0
-+#define CONFIG_H264_OMX_ENCODER 0
-+#define CONFIG_H264_QSV_ENCODER 0
-+#define CONFIG_H264_V4L2M2M_ENCODER 0
-+#define CONFIG_H264_VAAPI_ENCODER 0
-+#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_HEVC_AMF_ENCODER 0
-+#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
-+#define CONFIG_HEVC_MF_ENCODER 0
-+#define CONFIG_HEVC_NVENC_ENCODER 0
-+#define CONFIG_HEVC_QSV_ENCODER 0
-+#define CONFIG_HEVC_V4L2M2M_ENCODER 0
-+#define CONFIG_HEVC_VAAPI_ENCODER 0
-+#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_LIBKVAZAAR_ENCODER 0
-+#define CONFIG_MJPEG_QSV_ENCODER 0
-+#define CONFIG_MJPEG_VAAPI_ENCODER 0
-+#define CONFIG_MP3_MF_ENCODER 0
-+#define CONFIG_MPEG2_QSV_ENCODER 0
-+#define CONFIG_MPEG2_VAAPI_ENCODER 0
-+#define CONFIG_MPEG4_OMX_ENCODER 0
-+#define CONFIG_MPEG4_V4L2M2M_ENCODER 0
-+#define CONFIG_PRORES_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_VP8_V4L2M2M_ENCODER 0
-+#define CONFIG_VP8_VAAPI_ENCODER 0
-+#define CONFIG_VP9_VAAPI_ENCODER 0
-+#define CONFIG_VP9_QSV_ENCODER 0
-+#define CONFIG_VNULL_ENCODER 0
-+#define CONFIG_ANULL_ENCODER 0
-+#define CONFIG_AV1_D3D11VA_HWACCEL 0
-+#define CONFIG_AV1_D3D11VA2_HWACCEL 0
-+#define CONFIG_AV1_DXVA2_HWACCEL 0
-+#define CONFIG_AV1_NVDEC_HWACCEL 0
-+#define CONFIG_AV1_VAAPI_HWACCEL 0
-+#define CONFIG_AV1_VDPAU_HWACCEL 0
-+#define CONFIG_H263_VAAPI_HWACCEL 0
-+#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_H264_D3D11VA_HWACCEL 0
-+#define CONFIG_H264_D3D11VA2_HWACCEL 0
-+#define CONFIG_H264_DXVA2_HWACCEL 0
-+#define CONFIG_H264_NVDEC_HWACCEL 0
-+#define CONFIG_H264_VAAPI_HWACCEL 0
-+#define CONFIG_H264_VDPAU_HWACCEL 0
-+#define CONFIG_H264_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_HEVC_D3D11VA_HWACCEL 0
-+#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
-+#define CONFIG_HEVC_DXVA2_HWACCEL 0
-+#define CONFIG_HEVC_NVDEC_HWACCEL 0
-+#define CONFIG_HEVC_VAAPI_HWACCEL 0
-+#define CONFIG_HEVC_VDPAU_HWACCEL 0
-+#define CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_MJPEG_NVDEC_HWACCEL 0
-+#define CONFIG_MJPEG_VAAPI_HWACCEL 0
-+#define CONFIG_MPEG1_NVDEC_HWACCEL 0
-+#define CONFIG_MPEG1_VDPAU_HWACCEL 0
-+#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
-+#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
-+#define CONFIG_MPEG2_NVDEC_HWACCEL 0
-+#define CONFIG_MPEG2_DXVA2_HWACCEL 0
-+#define CONFIG_MPEG2_VAAPI_HWACCEL 0
-+#define CONFIG_MPEG2_VDPAU_HWACCEL 0
-+#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_MPEG4_NVDEC_HWACCEL 0
-+#define CONFIG_MPEG4_VAAPI_HWACCEL 0
-+#define CONFIG_MPEG4_VDPAU_HWACCEL 0
-+#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_VC1_D3D11VA_HWACCEL 0
-+#define CONFIG_VC1_D3D11VA2_HWACCEL 0
-+#define CONFIG_VC1_DXVA2_HWACCEL 0
-+#define CONFIG_VC1_NVDEC_HWACCEL 0
-+#define CONFIG_VC1_VAAPI_HWACCEL 0
-+#define CONFIG_VC1_VDPAU_HWACCEL 0
-+#define CONFIG_VP8_NVDEC_HWACCEL 0
-+#define CONFIG_VP8_VAAPI_HWACCEL 0
-+#define CONFIG_VP9_D3D11VA_HWACCEL 0
-+#define CONFIG_VP9_D3D11VA2_HWACCEL 0
-+#define CONFIG_VP9_DXVA2_HWACCEL 0
-+#define CONFIG_VP9_NVDEC_HWACCEL 0
-+#define CONFIG_VP9_VAAPI_HWACCEL 0
-+#define CONFIG_VP9_VDPAU_HWACCEL 0
-+#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_WMV3_D3D11VA_HWACCEL 0
-+#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
-+#define CONFIG_WMV3_DXVA2_HWACCEL 0
-+#define CONFIG_WMV3_NVDEC_HWACCEL 0
-+#define CONFIG_WMV3_VAAPI_HWACCEL 0
-+#define CONFIG_WMV3_VDPAU_HWACCEL 0
-+#define CONFIG_AAC_PARSER 0
-+#define CONFIG_AAC_LATM_PARSER 0
-+#define CONFIG_AC3_PARSER 0
-+#define CONFIG_ADX_PARSER 0
-+#define CONFIG_AMR_PARSER 0
-+#define CONFIG_AV1_PARSER 0
-+#define CONFIG_AVS2_PARSER 0
-+#define CONFIG_AVS3_PARSER 0
-+#define CONFIG_BMP_PARSER 0
-+#define CONFIG_CAVSVIDEO_PARSER 0
-+#define CONFIG_COOK_PARSER 0
-+#define CONFIG_CRI_PARSER 0
-+#define CONFIG_DCA_PARSER 0
-+#define CONFIG_DIRAC_PARSER 0
-+#define CONFIG_DNXHD_PARSER 0
-+#define CONFIG_DOLBY_E_PARSER 0
-+#define CONFIG_DPX_PARSER 0
-+#define CONFIG_DVAUDIO_PARSER 0
-+#define CONFIG_DVBSUB_PARSER 0
-+#define CONFIG_DVDSUB_PARSER 0
-+#define CONFIG_DVD_NAV_PARSER 0
-+#define CONFIG_FLAC_PARSER 1
-+#define CONFIG_FTR_PARSER 0
-+#define CONFIG_G723_1_PARSER 0
-+#define CONFIG_G729_PARSER 0
-+#define CONFIG_GIF_PARSER 0
-+#define CONFIG_GSM_PARSER 0
-+#define CONFIG_H261_PARSER 0
-+#define CONFIG_H263_PARSER 0
-+#define CONFIG_H264_PARSER 0
-+#define CONFIG_HEVC_PARSER 0
-+#define CONFIG_HDR_PARSER 0
-+#define CONFIG_IPU_PARSER 0
-+#define CONFIG_JPEG2000_PARSER 0
-+#define CONFIG_MISC4_PARSER 0
-+#define CONFIG_MJPEG_PARSER 0
-+#define CONFIG_MLP_PARSER 0
-+#define CONFIG_MPEG4VIDEO_PARSER 0
-+#define CONFIG_MPEGAUDIO_PARSER 1
-+#define CONFIG_MPEGVIDEO_PARSER 0
-+#define CONFIG_OPUS_PARSER 1
-+#define CONFIG_PNG_PARSER 0
-+#define CONFIG_PNM_PARSER 0
-+#define CONFIG_QOI_PARSER 0
-+#define CONFIG_RV30_PARSER 0
-+#define CONFIG_RV40_PARSER 0
-+#define CONFIG_SBC_PARSER 0
-+#define CONFIG_SIPR_PARSER 0
-+#define CONFIG_TAK_PARSER 0
-+#define CONFIG_VC1_PARSER 0
-+#define CONFIG_VORBIS_PARSER 1
-+#define CONFIG_VP3_PARSER 1
-+#define CONFIG_VP8_PARSER 1
-+#define CONFIG_VP9_PARSER 1
-+#define CONFIG_WEBP_PARSER 0
-+#define CONFIG_XBM_PARSER 0
-+#define CONFIG_XMA_PARSER 0
-+#define CONFIG_XWD_PARSER 0
-+#define CONFIG_ALSA_INDEV 0
-+#define CONFIG_ANDROID_CAMERA_INDEV 0
-+#define CONFIG_AVFOUNDATION_INDEV 0
-+#define CONFIG_BKTR_INDEV 0
-+#define CONFIG_DECKLINK_INDEV 0
-+#define CONFIG_DSHOW_INDEV 0
-+#define CONFIG_FBDEV_INDEV 0
-+#define CONFIG_GDIGRAB_INDEV 0
-+#define CONFIG_IEC61883_INDEV 0
-+#define CONFIG_JACK_INDEV 0
-+#define CONFIG_KMSGRAB_INDEV 0
-+#define CONFIG_LAVFI_INDEV 0
-+#define CONFIG_OPENAL_INDEV 0
-+#define CONFIG_OSS_INDEV 0
-+#define CONFIG_PULSE_INDEV 0
-+#define CONFIG_SNDIO_INDEV 0
-+#define CONFIG_V4L2_INDEV 0
-+#define CONFIG_VFWCAP_INDEV 0
-+#define CONFIG_XCBGRAB_INDEV 0
-+#define CONFIG_LIBCDIO_INDEV 0
-+#define CONFIG_LIBDC1394_INDEV 0
-+#define CONFIG_ALSA_OUTDEV 0
-+#define CONFIG_AUDIOTOOLBOX_OUTDEV 0
-+#define CONFIG_CACA_OUTDEV 0
-+#define CONFIG_DECKLINK_OUTDEV 0
-+#define CONFIG_FBDEV_OUTDEV 0
-+#define CONFIG_OPENGL_OUTDEV 0
-+#define CONFIG_OSS_OUTDEV 0
-+#define CONFIG_PULSE_OUTDEV 0
-+#define CONFIG_SDL2_OUTDEV 0
-+#define CONFIG_SNDIO_OUTDEV 0
-+#define CONFIG_V4L2_OUTDEV 0
-+#define CONFIG_XV_OUTDEV 0
-+#define CONFIG_ABENCH_FILTER 0
-+#define CONFIG_ACOMPRESSOR_FILTER 0
-+#define CONFIG_ACONTRAST_FILTER 0
-+#define CONFIG_ACOPY_FILTER 0
-+#define CONFIG_ACUE_FILTER 0
-+#define CONFIG_ACROSSFADE_FILTER 0
-+#define CONFIG_ACROSSOVER_FILTER 0
-+#define CONFIG_ACRUSHER_FILTER 0
-+#define CONFIG_ADECLICK_FILTER 0
-+#define CONFIG_ADECLIP_FILTER 0
-+#define CONFIG_ADECORRELATE_FILTER 0
-+#define CONFIG_ADELAY_FILTER 0
-+#define CONFIG_ADENORM_FILTER 0
-+#define CONFIG_ADERIVATIVE_FILTER 0
-+#define CONFIG_ADRC_FILTER 0
-+#define CONFIG_ADYNAMICEQUALIZER_FILTER 0
-+#define CONFIG_ADYNAMICSMOOTH_FILTER 0
-+#define CONFIG_AECHO_FILTER 0
-+#define CONFIG_AEMPHASIS_FILTER 0
-+#define CONFIG_AEVAL_FILTER 0
-+#define CONFIG_AEXCITER_FILTER 0
-+#define CONFIG_AFADE_FILTER 0
-+#define CONFIG_AFFTDN_FILTER 0
-+#define CONFIG_AFFTFILT_FILTER 0
-+#define CONFIG_AFIR_FILTER 0
-+#define CONFIG_AFORMAT_FILTER 0
-+#define CONFIG_AFREQSHIFT_FILTER 0
-+#define CONFIG_AFWTDN_FILTER 0
-+#define CONFIG_AGATE_FILTER 0
-+#define CONFIG_AIIR_FILTER 0
-+#define CONFIG_AINTEGRAL_FILTER 0
-+#define CONFIG_AINTERLEAVE_FILTER 0
-+#define CONFIG_ALATENCY_FILTER 0
-+#define CONFIG_ALIMITER_FILTER 0
-+#define CONFIG_ALLPASS_FILTER 0
-+#define CONFIG_ALOOP_FILTER 0
-+#define CONFIG_AMERGE_FILTER 0
-+#define CONFIG_AMETADATA_FILTER 0
-+#define CONFIG_AMIX_FILTER 0
-+#define CONFIG_AMULTIPLY_FILTER 0
-+#define CONFIG_ANEQUALIZER_FILTER 0
-+#define CONFIG_ANLMDN_FILTER 0
-+#define CONFIG_ANLMF_FILTER 0
-+#define CONFIG_ANLMS_FILTER 0
-+#define CONFIG_ANULL_FILTER 0
-+#define CONFIG_APAD_FILTER 0
-+#define CONFIG_APERMS_FILTER 0
-+#define CONFIG_APHASER_FILTER 0
-+#define CONFIG_APHASESHIFT_FILTER 0
-+#define CONFIG_APSYCLIP_FILTER 0
-+#define CONFIG_APULSATOR_FILTER 0
-+#define CONFIG_AREALTIME_FILTER 0
-+#define CONFIG_ARESAMPLE_FILTER 0
-+#define CONFIG_AREVERSE_FILTER 0
-+#define CONFIG_ARNNDN_FILTER 0
-+#define CONFIG_ASDR_FILTER 0
-+#define CONFIG_ASEGMENT_FILTER 0
-+#define CONFIG_ASELECT_FILTER 0
-+#define CONFIG_ASENDCMD_FILTER 0
-+#define CONFIG_ASETNSAMPLES_FILTER 0
-+#define CONFIG_ASETPTS_FILTER 0
-+#define CONFIG_ASETRATE_FILTER 0
-+#define CONFIG_ASETTB_FILTER 0
-+#define CONFIG_ASHOWINFO_FILTER 0
-+#define CONFIG_ASIDEDATA_FILTER 0
-+#define CONFIG_ASOFTCLIP_FILTER 0
-+#define CONFIG_ASPECTRALSTATS_FILTER 0
-+#define CONFIG_ASPLIT_FILTER 0
-+#define CONFIG_ASR_FILTER 0
-+#define CONFIG_ASTATS_FILTER 0
-+#define CONFIG_ASTREAMSELECT_FILTER 0
-+#define CONFIG_ASUBBOOST_FILTER 0
-+#define CONFIG_ASUBCUT_FILTER 0
-+#define CONFIG_ASUPERCUT_FILTER 0
-+#define CONFIG_ASUPERPASS_FILTER 0
-+#define CONFIG_ASUPERSTOP_FILTER 0
-+#define CONFIG_ATEMPO_FILTER 0
-+#define CONFIG_ATILT_FILTER 0
-+#define CONFIG_ATRIM_FILTER 0
-+#define CONFIG_AXCORRELATE_FILTER 0
-+#define CONFIG_AZMQ_FILTER 0
-+#define CONFIG_BANDPASS_FILTER 0
-+#define CONFIG_BANDREJECT_FILTER 0
-+#define CONFIG_BASS_FILTER 0
-+#define CONFIG_BIQUAD_FILTER 0
-+#define CONFIG_BS2B_FILTER 0
-+#define CONFIG_CHANNELMAP_FILTER 0
-+#define CONFIG_CHANNELSPLIT_FILTER 0
-+#define CONFIG_CHORUS_FILTER 0
-+#define CONFIG_COMPAND_FILTER 0
-+#define CONFIG_COMPENSATIONDELAY_FILTER 0
-+#define CONFIG_CROSSFEED_FILTER 0
-+#define CONFIG_CRYSTALIZER_FILTER 0
-+#define CONFIG_DCSHIFT_FILTER 0
-+#define CONFIG_DEESSER_FILTER 0
-+#define CONFIG_DIALOGUENHANCE_FILTER 0
-+#define CONFIG_DRMETER_FILTER 0
-+#define CONFIG_DYNAUDNORM_FILTER 0
-+#define CONFIG_EARWAX_FILTER 0
-+#define CONFIG_EBUR128_FILTER 0
-+#define CONFIG_EQUALIZER_FILTER 0
-+#define CONFIG_EXTRASTEREO_FILTER 0
-+#define CONFIG_FIREQUALIZER_FILTER 0
-+#define CONFIG_FLANGER_FILTER 0
-+#define CONFIG_HAAS_FILTER 0
-+#define CONFIG_HDCD_FILTER 0
-+#define CONFIG_HEADPHONE_FILTER 0
-+#define CONFIG_HIGHPASS_FILTER 0
-+#define CONFIG_HIGHSHELF_FILTER 0
-+#define CONFIG_JOIN_FILTER 0
-+#define CONFIG_LADSPA_FILTER 0
-+#define CONFIG_LOUDNORM_FILTER 0
-+#define CONFIG_LOWPASS_FILTER 0
-+#define CONFIG_LOWSHELF_FILTER 0
-+#define CONFIG_LV2_FILTER 0
-+#define CONFIG_MCOMPAND_FILTER 0
-+#define CONFIG_PAN_FILTER 0
-+#define CONFIG_REPLAYGAIN_FILTER 0
-+#define CONFIG_RUBBERBAND_FILTER 0
-+#define CONFIG_SIDECHAINCOMPRESS_FILTER 0
-+#define CONFIG_SIDECHAINGATE_FILTER 0
-+#define CONFIG_SILENCEDETECT_FILTER 0
-+#define CONFIG_SILENCEREMOVE_FILTER 0
-+#define CONFIG_SOFALIZER_FILTER 0
-+#define CONFIG_SPEECHNORM_FILTER 0
-+#define CONFIG_STEREOTOOLS_FILTER 0
-+#define CONFIG_STEREOWIDEN_FILTER 0
-+#define CONFIG_SUPEREQUALIZER_FILTER 0
-+#define CONFIG_SURROUND_FILTER 0
-+#define CONFIG_TILTSHELF_FILTER 0
-+#define CONFIG_TREBLE_FILTER 0
-+#define CONFIG_TREMOLO_FILTER 0
-+#define CONFIG_VIBRATO_FILTER 0
-+#define CONFIG_VIRTUALBASS_FILTER 0
-+#define CONFIG_VOLUME_FILTER 0
-+#define CONFIG_VOLUMEDETECT_FILTER 0
-+#define CONFIG_AEVALSRC_FILTER 0
-+#define CONFIG_AFDELAYSRC_FILTER 0
-+#define CONFIG_AFIRSRC_FILTER 0
-+#define CONFIG_ANOISESRC_FILTER 0
-+#define CONFIG_ANULLSRC_FILTER 0
-+#define CONFIG_FLITE_FILTER 0
-+#define CONFIG_HILBERT_FILTER 0
-+#define CONFIG_SINC_FILTER 0
-+#define CONFIG_SINE_FILTER 0
-+#define CONFIG_ANULLSINK_FILTER 0
-+#define CONFIG_ADDROI_FILTER 0
-+#define CONFIG_ALPHAEXTRACT_FILTER 0
-+#define CONFIG_ALPHAMERGE_FILTER 0
-+#define CONFIG_AMPLIFY_FILTER 0
-+#define CONFIG_ASS_FILTER 0
-+#define CONFIG_ATADENOISE_FILTER 0
-+#define CONFIG_AVGBLUR_FILTER 0
-+#define CONFIG_AVGBLUR_OPENCL_FILTER 0
-+#define CONFIG_AVGBLUR_VULKAN_FILTER 0
-+#define CONFIG_BACKGROUNDKEY_FILTER 0
-+#define CONFIG_BBOX_FILTER 0
-+#define CONFIG_BENCH_FILTER 0
-+#define CONFIG_BILATERAL_FILTER 0
-+#define CONFIG_BILATERAL_CUDA_FILTER 0
-+#define CONFIG_BITPLANENOISE_FILTER 0
-+#define CONFIG_BLACKDETECT_FILTER 0
-+#define CONFIG_BLACKFRAME_FILTER 0
-+#define CONFIG_BLEND_FILTER 0
-+#define CONFIG_BLEND_VULKAN_FILTER 0
-+#define CONFIG_BLOCKDETECT_FILTER 0
-+#define CONFIG_BLURDETECT_FILTER 0
-+#define CONFIG_BM3D_FILTER 0
-+#define CONFIG_BOXBLUR_FILTER 0
-+#define CONFIG_BOXBLUR_OPENCL_FILTER 0
-+#define CONFIG_BWDIF_FILTER 0
-+#define CONFIG_CAS_FILTER 0
-+#define CONFIG_CHROMABER_VULKAN_FILTER 0
-+#define CONFIG_CHROMAHOLD_FILTER 0
-+#define CONFIG_CHROMAKEY_FILTER 0
-+#define CONFIG_CHROMAKEY_CUDA_FILTER 0
-+#define CONFIG_CHROMANR_FILTER 0
-+#define CONFIG_CHROMASHIFT_FILTER 0
-+#define CONFIG_CIESCOPE_FILTER 0
-+#define CONFIG_CODECVIEW_FILTER 0
-+#define CONFIG_COLORBALANCE_FILTER 0
-+#define CONFIG_COLORCHANNELMIXER_FILTER 0
-+#define CONFIG_COLORCONTRAST_FILTER 0
-+#define CONFIG_COLORCORRECT_FILTER 0
-+#define CONFIG_COLORIZE_FILTER 0
-+#define CONFIG_COLORKEY_FILTER 0
-+#define CONFIG_COLORKEY_OPENCL_FILTER 0
-+#define CONFIG_COLORHOLD_FILTER 0
-+#define CONFIG_COLORLEVELS_FILTER 0
-+#define CONFIG_COLORMAP_FILTER 0
-+#define CONFIG_COLORMATRIX_FILTER 0
-+#define CONFIG_COLORSPACE_FILTER 0
-+#define CONFIG_COLORSPACE_CUDA_FILTER 0
-+#define CONFIG_COLORTEMPERATURE_FILTER 0
-+#define CONFIG_CONVOLUTION_FILTER 0
-+#define CONFIG_CONVOLUTION_OPENCL_FILTER 0
-+#define CONFIG_CONVOLVE_FILTER 0
-+#define CONFIG_COPY_FILTER 0
-+#define CONFIG_COREIMAGE_FILTER 0
-+#define CONFIG_CORR_FILTER 0
-+#define CONFIG_COVER_RECT_FILTER 0
-+#define CONFIG_CROP_FILTER 0
-+#define CONFIG_CROPDETECT_FILTER 0
-+#define CONFIG_CUE_FILTER 0
-+#define CONFIG_CURVES_FILTER 0
-+#define CONFIG_DATASCOPE_FILTER 0
-+#define CONFIG_DBLUR_FILTER 0
-+#define CONFIG_DCTDNOIZ_FILTER 0
-+#define CONFIG_DEBAND_FILTER 0
-+#define CONFIG_DEBLOCK_FILTER 0
-+#define CONFIG_DECIMATE_FILTER 0
-+#define CONFIG_DECONVOLVE_FILTER 0
-+#define CONFIG_DEDOT_FILTER 0
-+#define CONFIG_DEFLATE_FILTER 0
-+#define CONFIG_DEFLICKER_FILTER 0
-+#define CONFIG_DEINTERLACE_QSV_FILTER 0
-+#define CONFIG_DEINTERLACE_VAAPI_FILTER 0
-+#define CONFIG_DEJUDDER_FILTER 0
-+#define CONFIG_DELOGO_FILTER 0
-+#define CONFIG_DENOISE_VAAPI_FILTER 0
-+#define CONFIG_DERAIN_FILTER 0
-+#define CONFIG_DESHAKE_FILTER 0
-+#define CONFIG_DESHAKE_OPENCL_FILTER 0
-+#define CONFIG_DESPILL_FILTER 0
-+#define CONFIG_DETELECINE_FILTER 0
-+#define CONFIG_DILATION_FILTER 0
-+#define CONFIG_DILATION_OPENCL_FILTER 0
-+#define CONFIG_DISPLACE_FILTER 0
-+#define CONFIG_DNN_CLASSIFY_FILTER 0
-+#define CONFIG_DNN_DETECT_FILTER 0
-+#define CONFIG_DNN_PROCESSING_FILTER 0
-+#define CONFIG_DOUBLEWEAVE_FILTER 0
-+#define CONFIG_DRAWBOX_FILTER 0
-+#define CONFIG_DRAWGRAPH_FILTER 0
-+#define CONFIG_DRAWGRID_FILTER 0
-+#define CONFIG_DRAWTEXT_FILTER 0
-+#define CONFIG_EDGEDETECT_FILTER 0
-+#define CONFIG_ELBG_FILTER 0
-+#define CONFIG_ENTROPY_FILTER 0
-+#define CONFIG_EPX_FILTER 0
-+#define CONFIG_EQ_FILTER 0
-+#define CONFIG_EROSION_FILTER 0
-+#define CONFIG_EROSION_OPENCL_FILTER 0
-+#define CONFIG_ESTDIF_FILTER 0
-+#define CONFIG_EXPOSURE_FILTER 0
-+#define CONFIG_EXTRACTPLANES_FILTER 0
-+#define CONFIG_FADE_FILTER 0
-+#define CONFIG_FEEDBACK_FILTER 0
-+#define CONFIG_FFTDNOIZ_FILTER 0
-+#define CONFIG_FFTFILT_FILTER 0
-+#define CONFIG_FIELD_FILTER 0
-+#define CONFIG_FIELDHINT_FILTER 0
-+#define CONFIG_FIELDMATCH_FILTER 0
-+#define CONFIG_FIELDORDER_FILTER 0
-+#define CONFIG_FILLBORDERS_FILTER 0
-+#define CONFIG_FIND_RECT_FILTER 0
-+#define CONFIG_FLIP_VULKAN_FILTER 0
-+#define CONFIG_FLOODFILL_FILTER 0
-+#define CONFIG_FORMAT_FILTER 0
-+#define CONFIG_FPS_FILTER 0
-+#define CONFIG_FRAMEPACK_FILTER 0
-+#define CONFIG_FRAMERATE_FILTER 0
-+#define CONFIG_FRAMESTEP_FILTER 0
-+#define CONFIG_FREEZEDETECT_FILTER 0
-+#define CONFIG_FREEZEFRAMES_FILTER 0
-+#define CONFIG_FREI0R_FILTER 0
-+#define CONFIG_FSPP_FILTER 0
-+#define CONFIG_GBLUR_FILTER 0
-+#define CONFIG_GBLUR_VULKAN_FILTER 0
-+#define CONFIG_GEQ_FILTER 0
-+#define CONFIG_GRADFUN_FILTER 0
-+#define CONFIG_GRAPHMONITOR_FILTER 0
-+#define CONFIG_GRAYWORLD_FILTER 0
-+#define CONFIG_GREYEDGE_FILTER 0
-+#define CONFIG_GUIDED_FILTER 0
-+#define CONFIG_HALDCLUT_FILTER 0
-+#define CONFIG_HFLIP_FILTER 0
-+#define CONFIG_HFLIP_VULKAN_FILTER 0
-+#define CONFIG_HISTEQ_FILTER 0
-+#define CONFIG_HISTOGRAM_FILTER 0
-+#define CONFIG_HQDN3D_FILTER 0
-+#define CONFIG_HQX_FILTER 0
-+#define CONFIG_HSTACK_FILTER 0
-+#define CONFIG_HSVHOLD_FILTER 0
-+#define CONFIG_HSVKEY_FILTER 0
-+#define CONFIG_HUE_FILTER 0
-+#define CONFIG_HUESATURATION_FILTER 0
-+#define CONFIG_HWDOWNLOAD_FILTER 0
-+#define CONFIG_HWMAP_FILTER 0
-+#define CONFIG_HWUPLOAD_FILTER 0
-+#define CONFIG_HWUPLOAD_CUDA_FILTER 0
-+#define CONFIG_HYSTERESIS_FILTER 0
-+#define CONFIG_ICCDETECT_FILTER 0
-+#define CONFIG_ICCGEN_FILTER 0
-+#define CONFIG_IDENTITY_FILTER 0
-+#define CONFIG_IDET_FILTER 0
-+#define CONFIG_IL_FILTER 0
-+#define CONFIG_INFLATE_FILTER 0
-+#define CONFIG_INTERLACE_FILTER 0
-+#define CONFIG_INTERLEAVE_FILTER 0
-+#define CONFIG_KERNDEINT_FILTER 0
-+#define CONFIG_KIRSCH_FILTER 0
-+#define CONFIG_LAGFUN_FILTER 0
-+#define CONFIG_LATENCY_FILTER 0
-+#define CONFIG_LENSCORRECTION_FILTER 0
-+#define CONFIG_LENSFUN_FILTER 0
-+#define CONFIG_LIBPLACEBO_FILTER 0
-+#define CONFIG_LIBVMAF_FILTER 0
-+#define CONFIG_LIMITDIFF_FILTER 0
-+#define CONFIG_LIMITER_FILTER 0
-+#define CONFIG_LOOP_FILTER 0
-+#define CONFIG_LUMAKEY_FILTER 0
-+#define CONFIG_LUT_FILTER 0
-+#define CONFIG_LUT1D_FILTER 0
-+#define CONFIG_LUT2_FILTER 0
-+#define CONFIG_LUT3D_FILTER 0
-+#define CONFIG_LUTRGB_FILTER 0
-+#define CONFIG_LUTYUV_FILTER 0
-+#define CONFIG_MASKEDCLAMP_FILTER 0
-+#define CONFIG_MASKEDMAX_FILTER 0
-+#define CONFIG_MASKEDMERGE_FILTER 0
-+#define CONFIG_MASKEDMIN_FILTER 0
-+#define CONFIG_MASKEDTHRESHOLD_FILTER 0
-+#define CONFIG_MASKFUN_FILTER 0
-+#define CONFIG_MCDEINT_FILTER 0
-+#define CONFIG_MEDIAN_FILTER 0
-+#define CONFIG_MERGEPLANES_FILTER 0
-+#define CONFIG_MESTIMATE_FILTER 0
-+#define CONFIG_METADATA_FILTER 0
-+#define CONFIG_MIDEQUALIZER_FILTER 0
-+#define CONFIG_MINTERPOLATE_FILTER 0
-+#define CONFIG_MIX_FILTER 0
-+#define CONFIG_MONOCHROME_FILTER 0
-+#define CONFIG_MORPHO_FILTER 0
-+#define CONFIG_MPDECIMATE_FILTER 0
-+#define CONFIG_MSAD_FILTER 0
-+#define CONFIG_MULTIPLY_FILTER 0
-+#define CONFIG_NEGATE_FILTER 0
-+#define CONFIG_NLMEANS_FILTER 0
-+#define CONFIG_NLMEANS_OPENCL_FILTER 0
-+#define CONFIG_NNEDI_FILTER 0
-+#define CONFIG_NOFORMAT_FILTER 0
-+#define CONFIG_NOISE_FILTER 0
-+#define CONFIG_NORMALIZE_FILTER 0
-+#define CONFIG_NULL_FILTER 0
-+#define CONFIG_OCR_FILTER 0
-+#define CONFIG_OCV_FILTER 0
-+#define CONFIG_OSCILLOSCOPE_FILTER 0
-+#define CONFIG_OVERLAY_FILTER 0
-+#define CONFIG_OVERLAY_OPENCL_FILTER 0
-+#define CONFIG_OVERLAY_QSV_FILTER 0
-+#define CONFIG_OVERLAY_VAAPI_FILTER 0
-+#define CONFIG_OVERLAY_VULKAN_FILTER 0
-+#define CONFIG_OVERLAY_CUDA_FILTER 0
-+#define CONFIG_OWDENOISE_FILTER 0
-+#define CONFIG_PAD_FILTER 0
-+#define CONFIG_PAD_OPENCL_FILTER 0
-+#define CONFIG_PALETTEGEN_FILTER 0
-+#define CONFIG_PALETTEUSE_FILTER 0
-+#define CONFIG_PERMS_FILTER 0
-+#define CONFIG_PERSPECTIVE_FILTER 0
-+#define CONFIG_PHASE_FILTER 0
-+#define CONFIG_PHOTOSENSITIVITY_FILTER 0
-+#define CONFIG_PIXDESCTEST_FILTER 0
-+#define CONFIG_PIXELIZE_FILTER 0
-+#define CONFIG_PIXSCOPE_FILTER 0
-+#define CONFIG_PP_FILTER 0
-+#define CONFIG_PP7_FILTER 0
-+#define CONFIG_PREMULTIPLY_FILTER 0
-+#define CONFIG_PREWITT_FILTER 0
-+#define CONFIG_PREWITT_OPENCL_FILTER 0
-+#define CONFIG_PROCAMP_VAAPI_FILTER 0
-+#define CONFIG_PROGRAM_OPENCL_FILTER 0
-+#define CONFIG_PSEUDOCOLOR_FILTER 0
-+#define CONFIG_PSNR_FILTER 0
-+#define CONFIG_PULLUP_FILTER 0
-+#define CONFIG_QP_FILTER 0
-+#define CONFIG_RANDOM_FILTER 0
-+#define CONFIG_READEIA608_FILTER 0
-+#define CONFIG_READVITC_FILTER 0
-+#define CONFIG_REALTIME_FILTER 0
-+#define CONFIG_REMAP_FILTER 0
-+#define CONFIG_REMAP_OPENCL_FILTER 0
-+#define CONFIG_REMOVEGRAIN_FILTER 0
-+#define CONFIG_REMOVELOGO_FILTER 0
-+#define CONFIG_REPEATFIELDS_FILTER 0
-+#define CONFIG_REVERSE_FILTER 0
-+#define CONFIG_RGBASHIFT_FILTER 0
-+#define CONFIG_ROBERTS_FILTER 0
-+#define CONFIG_ROBERTS_OPENCL_FILTER 0
-+#define CONFIG_ROTATE_FILTER 0
-+#define CONFIG_SAB_FILTER 0
-+#define CONFIG_SCALE_FILTER 0
-+#define CONFIG_SCALE_CUDA_FILTER 0
-+#define CONFIG_SCALE_NPP_FILTER 0
-+#define CONFIG_SCALE_QSV_FILTER 0
-+#define CONFIG_SCALE_VAAPI_FILTER 0
-+#define CONFIG_SCALE_VULKAN_FILTER 0
-+#define CONFIG_SCALE2REF_FILTER 0
-+#define CONFIG_SCALE2REF_NPP_FILTER 0
-+#define CONFIG_SCDET_FILTER 0
-+#define CONFIG_SCHARR_FILTER 0
-+#define CONFIG_SCROLL_FILTER 0
-+#define CONFIG_SEGMENT_FILTER 0
-+#define CONFIG_SELECT_FILTER 0
-+#define CONFIG_SELECTIVECOLOR_FILTER 0
-+#define CONFIG_SENDCMD_FILTER 0
-+#define CONFIG_SEPARATEFIELDS_FILTER 0
-+#define CONFIG_SETDAR_FILTER 0
-+#define CONFIG_SETFIELD_FILTER 0
-+#define CONFIG_SETPARAMS_FILTER 0
-+#define CONFIG_SETPTS_FILTER 0
-+#define CONFIG_SETRANGE_FILTER 0
-+#define CONFIG_SETSAR_FILTER 0
-+#define CONFIG_SETTB_FILTER 0
-+#define CONFIG_SHARPEN_NPP_FILTER 0
-+#define CONFIG_SHARPNESS_VAAPI_FILTER 0
-+#define CONFIG_SHEAR_FILTER 0
-+#define CONFIG_SHOWINFO_FILTER 0
-+#define CONFIG_SHOWPALETTE_FILTER 0
-+#define CONFIG_SHUFFLEFRAMES_FILTER 0
-+#define CONFIG_SHUFFLEPIXELS_FILTER 0
-+#define CONFIG_SHUFFLEPLANES_FILTER 0
-+#define CONFIG_SIDEDATA_FILTER 0
-+#define CONFIG_SIGNALSTATS_FILTER 0
-+#define CONFIG_SIGNATURE_FILTER 0
-+#define CONFIG_SITI_FILTER 0
-+#define CONFIG_SMARTBLUR_FILTER 0
-+#define CONFIG_SOBEL_FILTER 0
-+#define CONFIG_SOBEL_OPENCL_FILTER 0
-+#define CONFIG_SPLIT_FILTER 0
-+#define CONFIG_SPP_FILTER 0
-+#define CONFIG_SR_FILTER 0
-+#define CONFIG_SSIM_FILTER 0
-+#define CONFIG_SSIM360_FILTER 0
-+#define CONFIG_STEREO3D_FILTER 0
-+#define CONFIG_STREAMSELECT_FILTER 0
-+#define CONFIG_SUBTITLES_FILTER 0
-+#define CONFIG_SUPER2XSAI_FILTER 0
-+#define CONFIG_SWAPRECT_FILTER 0
-+#define CONFIG_SWAPUV_FILTER 0
-+#define CONFIG_TBLEND_FILTER 0
-+#define CONFIG_TELECINE_FILTER 0
-+#define CONFIG_THISTOGRAM_FILTER 0
-+#define CONFIG_THRESHOLD_FILTER 0
-+#define CONFIG_THUMBNAIL_FILTER 0
-+#define CONFIG_THUMBNAIL_CUDA_FILTER 0
-+#define CONFIG_TILE_FILTER 0
-+#define CONFIG_TINTERLACE_FILTER 0
-+#define CONFIG_TLUT2_FILTER 0
-+#define CONFIG_TMEDIAN_FILTER 0
-+#define CONFIG_TMIDEQUALIZER_FILTER 0
-+#define CONFIG_TMIX_FILTER 0
-+#define CONFIG_TONEMAP_FILTER 0
-+#define CONFIG_TONEMAP_OPENCL_FILTER 0
-+#define CONFIG_TONEMAP_VAAPI_FILTER 0
-+#define CONFIG_TPAD_FILTER 0
-+#define CONFIG_TRANSPOSE_FILTER 0
-+#define CONFIG_TRANSPOSE_NPP_FILTER 0
-+#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
-+#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
-+#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
-+#define CONFIG_TRIM_FILTER 0
-+#define CONFIG_UNPREMULTIPLY_FILTER 0
-+#define CONFIG_UNSHARP_FILTER 0
-+#define CONFIG_UNSHARP_OPENCL_FILTER 0
-+#define CONFIG_UNTILE_FILTER 0
-+#define CONFIG_USPP_FILTER 0
-+#define CONFIG_V360_FILTER 0
-+#define CONFIG_VAGUEDENOISER_FILTER 0
-+#define CONFIG_VARBLUR_FILTER 0
-+#define CONFIG_VECTORSCOPE_FILTER 0
-+#define CONFIG_VFLIP_FILTER 0
-+#define CONFIG_VFLIP_VULKAN_FILTER 0
-+#define CONFIG_VFRDET_FILTER 0
-+#define CONFIG_VIBRANCE_FILTER 0
-+#define CONFIG_VIDSTABDETECT_FILTER 0
-+#define CONFIG_VIDSTABTRANSFORM_FILTER 0
-+#define CONFIG_VIF_FILTER 0
-+#define CONFIG_VIGNETTE_FILTER 0
-+#define CONFIG_VMAFMOTION_FILTER 0
-+#define CONFIG_VPP_QSV_FILTER 0
-+#define CONFIG_VSTACK_FILTER 0
-+#define CONFIG_W3FDIF_FILTER 0
-+#define CONFIG_WAVEFORM_FILTER 0
-+#define CONFIG_WEAVE_FILTER 0
-+#define CONFIG_XBR_FILTER 0
-+#define CONFIG_XCORRELATE_FILTER 0
-+#define CONFIG_XFADE_FILTER 0
-+#define CONFIG_XFADE_OPENCL_FILTER 0
-+#define CONFIG_XMEDIAN_FILTER 0
-+#define CONFIG_XSTACK_FILTER 0
-+#define CONFIG_YADIF_FILTER 0
-+#define CONFIG_YADIF_CUDA_FILTER 0
-+#define CONFIG_YADIF_VIDEOTOOLBOX_FILTER 0
-+#define CONFIG_YAEPBLUR_FILTER 0
-+#define CONFIG_ZMQ_FILTER 0
-+#define CONFIG_ZOOMPAN_FILTER 0
-+#define CONFIG_ZSCALE_FILTER 0
-+#define CONFIG_HSTACK_VAAPI_FILTER 0
-+#define CONFIG_VSTACK_VAAPI_FILTER 0
-+#define CONFIG_XSTACK_VAAPI_FILTER 0
-+#define CONFIG_ALLRGB_FILTER 0
-+#define CONFIG_ALLYUV_FILTER 0
-+#define CONFIG_CELLAUTO_FILTER 0
-+#define CONFIG_COLOR_FILTER 0
-+#define CONFIG_COLORCHART_FILTER 0
-+#define CONFIG_COLORSPECTRUM_FILTER 0
-+#define CONFIG_COREIMAGESRC_FILTER 0
-+#define CONFIG_DDAGRAB_FILTER 0
-+#define CONFIG_FREI0R_SRC_FILTER 0
-+#define CONFIG_GRADIENTS_FILTER 0
-+#define CONFIG_HALDCLUTSRC_FILTER 0
-+#define CONFIG_LIFE_FILTER 0
-+#define CONFIG_MANDELBROT_FILTER 0
-+#define CONFIG_MPTESTSRC_FILTER 0
-+#define CONFIG_NULLSRC_FILTER 0
-+#define CONFIG_OPENCLSRC_FILTER 0
-+#define CONFIG_PAL75BARS_FILTER 0
-+#define CONFIG_PAL100BARS_FILTER 0
-+#define CONFIG_RGBTESTSRC_FILTER 0
-+#define CONFIG_SIERPINSKI_FILTER 0
-+#define CONFIG_SMPTEBARS_FILTER 0
-+#define CONFIG_SMPTEHDBARS_FILTER 0
-+#define CONFIG_TESTSRC_FILTER 0
-+#define CONFIG_TESTSRC2_FILTER 0
-+#define CONFIG_YUVTESTSRC_FILTER 0
-+#define CONFIG_NULLSINK_FILTER 0
-+#define CONFIG_A3DSCOPE_FILTER 0
-+#define CONFIG_ABITSCOPE_FILTER 0
-+#define CONFIG_ADRAWGRAPH_FILTER 0
-+#define CONFIG_AGRAPHMONITOR_FILTER 0
-+#define CONFIG_AHISTOGRAM_FILTER 0
-+#define CONFIG_APHASEMETER_FILTER 0
-+#define CONFIG_AVECTORSCOPE_FILTER 0
-+#define CONFIG_CONCAT_FILTER 0
-+#define CONFIG_SHOWCQT_FILTER 0
-+#define CONFIG_SHOWCWT_FILTER 0
-+#define CONFIG_SHOWFREQS_FILTER 0
-+#define CONFIG_SHOWSPATIAL_FILTER 0
-+#define CONFIG_SHOWSPECTRUM_FILTER 0
-+#define CONFIG_SHOWSPECTRUMPIC_FILTER 0
-+#define CONFIG_SHOWVOLUME_FILTER 0
-+#define CONFIG_SHOWWAVES_FILTER 0
-+#define CONFIG_SHOWWAVESPIC_FILTER 0
-+#define CONFIG_SPECTRUMSYNTH_FILTER 0
-+#define CONFIG_AVSYNCTEST_FILTER 0
-+#define CONFIG_AMOVIE_FILTER 0
-+#define CONFIG_MOVIE_FILTER 0
-+#define CONFIG_AFIFO_FILTER 0
-+#define CONFIG_FIFO_FILTER 0
-+#define CONFIG_AA_DEMUXER 0
-+#define CONFIG_AAC_DEMUXER 0
-+#define CONFIG_AAX_DEMUXER 0
-+#define CONFIG_AC3_DEMUXER 0
-+#define CONFIG_ACE_DEMUXER 0
-+#define CONFIG_ACM_DEMUXER 0
-+#define CONFIG_ACT_DEMUXER 0
-+#define CONFIG_ADF_DEMUXER 0
-+#define CONFIG_ADP_DEMUXER 0
-+#define CONFIG_ADS_DEMUXER 0
-+#define CONFIG_ADX_DEMUXER 0
-+#define CONFIG_AEA_DEMUXER 0
-+#define CONFIG_AFC_DEMUXER 0
-+#define CONFIG_AIFF_DEMUXER 0
-+#define CONFIG_AIX_DEMUXER 0
-+#define CONFIG_ALP_DEMUXER 0
-+#define CONFIG_AMR_DEMUXER 0
-+#define CONFIG_AMRNB_DEMUXER 0
-+#define CONFIG_AMRWB_DEMUXER 0
-+#define CONFIG_ANM_DEMUXER 0
-+#define CONFIG_APAC_DEMUXER 0
-+#define CONFIG_APC_DEMUXER 0
-+#define CONFIG_APE_DEMUXER 0
-+#define CONFIG_APM_DEMUXER 0
-+#define CONFIG_APNG_DEMUXER 0
-+#define CONFIG_APTX_DEMUXER 0
-+#define CONFIG_APTX_HD_DEMUXER 0
-+#define CONFIG_AQTITLE_DEMUXER 0
-+#define CONFIG_ARGO_ASF_DEMUXER 0
-+#define CONFIG_ARGO_BRP_DEMUXER 0
-+#define CONFIG_ARGO_CVG_DEMUXER 0
-+#define CONFIG_ASF_DEMUXER 0
-+#define CONFIG_ASF_O_DEMUXER 0
-+#define CONFIG_ASS_DEMUXER 0
-+#define CONFIG_AST_DEMUXER 0
-+#define CONFIG_AU_DEMUXER 0
-+#define CONFIG_AV1_DEMUXER 0
-+#define CONFIG_AVI_DEMUXER 0
-+#define CONFIG_AVISYNTH_DEMUXER 0
-+#define CONFIG_AVR_DEMUXER 0
-+#define CONFIG_AVS_DEMUXER 0
-+#define CONFIG_AVS2_DEMUXER 0
-+#define CONFIG_AVS3_DEMUXER 0
-+#define CONFIG_BETHSOFTVID_DEMUXER 0
-+#define CONFIG_BFI_DEMUXER 0
-+#define CONFIG_BINTEXT_DEMUXER 0
-+#define CONFIG_BINK_DEMUXER 0
-+#define CONFIG_BINKA_DEMUXER 0
-+#define CONFIG_BIT_DEMUXER 0
-+#define CONFIG_BITPACKED_DEMUXER 0
-+#define CONFIG_BMV_DEMUXER 0
-+#define CONFIG_BFSTM_DEMUXER 0
-+#define CONFIG_BRSTM_DEMUXER 0
-+#define CONFIG_BOA_DEMUXER 0
-+#define CONFIG_BONK_DEMUXER 0
-+#define CONFIG_C93_DEMUXER 0
-+#define CONFIG_CAF_DEMUXER 0
-+#define CONFIG_CAVSVIDEO_DEMUXER 0
-+#define CONFIG_CDG_DEMUXER 0
-+#define CONFIG_CDXL_DEMUXER 0
-+#define CONFIG_CINE_DEMUXER 0
-+#define CONFIG_CODEC2_DEMUXER 0
-+#define CONFIG_CODEC2RAW_DEMUXER 0
-+#define CONFIG_CONCAT_DEMUXER 0
-+#define CONFIG_DASH_DEMUXER 0
-+#define CONFIG_DATA_DEMUXER 0
-+#define CONFIG_DAUD_DEMUXER 0
-+#define CONFIG_DCSTR_DEMUXER 0
-+#define CONFIG_DERF_DEMUXER 0
-+#define CONFIG_DFA_DEMUXER 0
-+#define CONFIG_DFPWM_DEMUXER 0
-+#define CONFIG_DHAV_DEMUXER 0
-+#define CONFIG_DIRAC_DEMUXER 0
-+#define CONFIG_DNXHD_DEMUXER 0
-+#define CONFIG_DSF_DEMUXER 0
-+#define CONFIG_DSICIN_DEMUXER 0
-+#define CONFIG_DSS_DEMUXER 0
-+#define CONFIG_DTS_DEMUXER 0
-+#define CONFIG_DTSHD_DEMUXER 0
-+#define CONFIG_DV_DEMUXER 0
-+#define CONFIG_DVBSUB_DEMUXER 0
-+#define CONFIG_DVBTXT_DEMUXER 0
-+#define CONFIG_DXA_DEMUXER 0
-+#define CONFIG_EA_DEMUXER 0
-+#define CONFIG_EA_CDATA_DEMUXER 0
-+#define CONFIG_EAC3_DEMUXER 0
-+#define CONFIG_EPAF_DEMUXER 0
-+#define CONFIG_FFMETADATA_DEMUXER 0
-+#define CONFIG_FILMSTRIP_DEMUXER 0
-+#define CONFIG_FITS_DEMUXER 0
-+#define CONFIG_FLAC_DEMUXER 1
-+#define CONFIG_FLIC_DEMUXER 0
-+#define CONFIG_FLV_DEMUXER 0
-+#define CONFIG_LIVE_FLV_DEMUXER 0
-+#define CONFIG_FOURXM_DEMUXER 0
-+#define CONFIG_FRM_DEMUXER 0
-+#define CONFIG_FSB_DEMUXER 0
-+#define CONFIG_FWSE_DEMUXER 0
-+#define CONFIG_G722_DEMUXER 0
-+#define CONFIG_G723_1_DEMUXER 0
-+#define CONFIG_G726_DEMUXER 0
-+#define CONFIG_G726LE_DEMUXER 0
-+#define CONFIG_G729_DEMUXER 0
-+#define CONFIG_GDV_DEMUXER 0
-+#define CONFIG_GENH_DEMUXER 0
-+#define CONFIG_GIF_DEMUXER 0
-+#define CONFIG_GSM_DEMUXER 0
-+#define CONFIG_GXF_DEMUXER 0
-+#define CONFIG_H261_DEMUXER 0
-+#define CONFIG_H263_DEMUXER 0
-+#define CONFIG_H264_DEMUXER 0
-+#define CONFIG_HCA_DEMUXER 0
-+#define CONFIG_HCOM_DEMUXER 0
-+#define CONFIG_HEVC_DEMUXER 0
-+#define CONFIG_HLS_DEMUXER 0
-+#define CONFIG_HNM_DEMUXER 0
-+#define CONFIG_ICO_DEMUXER 0
-+#define CONFIG_IDCIN_DEMUXER 0
-+#define CONFIG_IDF_DEMUXER 0
-+#define CONFIG_IFF_DEMUXER 0
-+#define CONFIG_IFV_DEMUXER 0
-+#define CONFIG_ILBC_DEMUXER 0
-+#define CONFIG_IMAGE2_DEMUXER 0
-+#define CONFIG_IMAGE2PIPE_DEMUXER 0
-+#define CONFIG_IMAGE2_ALIAS_PIX_DEMUXER 0
-+#define CONFIG_IMAGE2_BRENDER_PIX_DEMUXER 0
-+#define CONFIG_IMF_DEMUXER 0
-+#define CONFIG_INGENIENT_DEMUXER 0
-+#define CONFIG_IPMOVIE_DEMUXER 0
-+#define CONFIG_IPU_DEMUXER 0
-+#define CONFIG_IRCAM_DEMUXER 0
-+#define CONFIG_ISS_DEMUXER 0
-+#define CONFIG_IV8_DEMUXER 0
-+#define CONFIG_IVF_DEMUXER 0
-+#define CONFIG_IVR_DEMUXER 0
-+#define CONFIG_JACOSUB_DEMUXER 0
-+#define CONFIG_JV_DEMUXER 0
-+#define CONFIG_KUX_DEMUXER 0
-+#define CONFIG_KVAG_DEMUXER 0
-+#define CONFIG_LAF_DEMUXER 0
-+#define CONFIG_LMLM4_DEMUXER 0
-+#define CONFIG_LOAS_DEMUXER 0
-+#define CONFIG_LUODAT_DEMUXER 0
-+#define CONFIG_LRC_DEMUXER 0
-+#define CONFIG_LVF_DEMUXER 0
-+#define CONFIG_LXF_DEMUXER 0
-+#define CONFIG_M4V_DEMUXER 0
-+#define CONFIG_MCA_DEMUXER 0
-+#define CONFIG_MCC_DEMUXER 0
-+#define CONFIG_MATROSKA_DEMUXER 1
-+#define CONFIG_MGSTS_DEMUXER 0
-+#define CONFIG_MICRODVD_DEMUXER 0
-+#define CONFIG_MJPEG_DEMUXER 0
-+#define CONFIG_MJPEG_2000_DEMUXER 0
-+#define CONFIG_MLP_DEMUXER 0
-+#define CONFIG_MLV_DEMUXER 0
-+#define CONFIG_MM_DEMUXER 0
-+#define CONFIG_MMF_DEMUXER 0
-+#define CONFIG_MODS_DEMUXER 0
-+#define CONFIG_MOFLEX_DEMUXER 0
-+#define CONFIG_MOV_DEMUXER 1
-+#define CONFIG_MP3_DEMUXER 1
-+#define CONFIG_MPC_DEMUXER 0
-+#define CONFIG_MPC8_DEMUXER 0
-+#define CONFIG_MPEGPS_DEMUXER 0
-+#define CONFIG_MPEGTS_DEMUXER 0
-+#define CONFIG_MPEGTSRAW_DEMUXER 0
-+#define CONFIG_MPEGVIDEO_DEMUXER 0
-+#define CONFIG_MPJPEG_DEMUXER 0
-+#define CONFIG_MPL2_DEMUXER 0
-+#define CONFIG_MPSUB_DEMUXER 0
-+#define CONFIG_MSF_DEMUXER 0
-+#define CONFIG_MSNWC_TCP_DEMUXER 0
-+#define CONFIG_MSP_DEMUXER 0
-+#define CONFIG_MTAF_DEMUXER 0
-+#define CONFIG_MTV_DEMUXER 0
-+#define CONFIG_MUSX_DEMUXER 0
-+#define CONFIG_MV_DEMUXER 0
-+#define CONFIG_MVI_DEMUXER 0
-+#define CONFIG_MXF_DEMUXER 0
-+#define CONFIG_MXG_DEMUXER 0
-+#define CONFIG_NC_DEMUXER 0
-+#define CONFIG_NISTSPHERE_DEMUXER 0
-+#define CONFIG_NSP_DEMUXER 0
-+#define CONFIG_NSV_DEMUXER 0
-+#define CONFIG_NUT_DEMUXER 0
-+#define CONFIG_NUV_DEMUXER 0
-+#define CONFIG_OBU_DEMUXER 0
-+#define CONFIG_OGG_DEMUXER 1
-+#define CONFIG_OMA_DEMUXER 0
-+#define CONFIG_PAF_DEMUXER 0
-+#define CONFIG_PCM_ALAW_DEMUXER 0
-+#define CONFIG_PCM_MULAW_DEMUXER 0
-+#define CONFIG_PCM_VIDC_DEMUXER 0
-+#define CONFIG_PCM_F64BE_DEMUXER 0
-+#define CONFIG_PCM_F64LE_DEMUXER 0
-+#define CONFIG_PCM_F32BE_DEMUXER 0
-+#define CONFIG_PCM_F32LE_DEMUXER 0
-+#define CONFIG_PCM_S32BE_DEMUXER 0
-+#define CONFIG_PCM_S32LE_DEMUXER 0
-+#define CONFIG_PCM_S24BE_DEMUXER 0
-+#define CONFIG_PCM_S24LE_DEMUXER 0
-+#define CONFIG_PCM_S16BE_DEMUXER 0
-+#define CONFIG_PCM_S16LE_DEMUXER 0
-+#define CONFIG_PCM_S8_DEMUXER 0
-+#define CONFIG_PCM_U32BE_DEMUXER 0
-+#define CONFIG_PCM_U32LE_DEMUXER 0
-+#define CONFIG_PCM_U24BE_DEMUXER 0
-+#define CONFIG_PCM_U24LE_DEMUXER 0
-+#define CONFIG_PCM_U16BE_DEMUXER 0
-+#define CONFIG_PCM_U16LE_DEMUXER 0
-+#define CONFIG_PCM_U8_DEMUXER 0
-+#define CONFIG_PJS_DEMUXER 0
-+#define CONFIG_PMP_DEMUXER 0
-+#define CONFIG_PP_BNK_DEMUXER 0
-+#define CONFIG_PVA_DEMUXER 0
-+#define CONFIG_PVF_DEMUXER 0
-+#define CONFIG_QCP_DEMUXER 0
-+#define CONFIG_R3D_DEMUXER 0
-+#define CONFIG_RAWVIDEO_DEMUXER 0
-+#define CONFIG_REALTEXT_DEMUXER 0
-+#define CONFIG_REDSPARK_DEMUXER 0
-+#define CONFIG_RL2_DEMUXER 0
-+#define CONFIG_RM_DEMUXER 0
-+#define CONFIG_ROQ_DEMUXER 0
-+#define CONFIG_RPL_DEMUXER 0
-+#define CONFIG_RSD_DEMUXER 0
-+#define CONFIG_RSO_DEMUXER 0
-+#define CONFIG_RTP_DEMUXER 0
-+#define CONFIG_RTSP_DEMUXER 0
-+#define CONFIG_S337M_DEMUXER 0
-+#define CONFIG_SAMI_DEMUXER 0
-+#define CONFIG_SAP_DEMUXER 0
-+#define CONFIG_SBC_DEMUXER 0
-+#define CONFIG_SBG_DEMUXER 0
-+#define CONFIG_SCC_DEMUXER 0
-+#define CONFIG_SCD_DEMUXER 0
-+#define CONFIG_SDP_DEMUXER 0
-+#define CONFIG_SDR2_DEMUXER 0
-+#define CONFIG_SDS_DEMUXER 0
-+#define CONFIG_SDX_DEMUXER 0
-+#define CONFIG_SEGAFILM_DEMUXER 0
-+#define CONFIG_SER_DEMUXER 0
-+#define CONFIG_SGA_DEMUXER 0
-+#define CONFIG_SHORTEN_DEMUXER 0
-+#define CONFIG_SIFF_DEMUXER 0
-+#define CONFIG_SIMBIOSIS_IMX_DEMUXER 0
-+#define CONFIG_SLN_DEMUXER 0
-+#define CONFIG_SMACKER_DEMUXER 0
-+#define CONFIG_SMJPEG_DEMUXER 0
-+#define CONFIG_SMUSH_DEMUXER 0
-+#define CONFIG_SOL_DEMUXER 0
-+#define CONFIG_SOX_DEMUXER 0
-+#define CONFIG_SPDIF_DEMUXER 0
-+#define CONFIG_SRT_DEMUXER 0
-+#define CONFIG_STR_DEMUXER 0
-+#define CONFIG_STL_DEMUXER 0
-+#define CONFIG_SUBVIEWER1_DEMUXER 0
-+#define CONFIG_SUBVIEWER_DEMUXER 0
-+#define CONFIG_SUP_DEMUXER 0
-+#define CONFIG_SVAG_DEMUXER 0
-+#define CONFIG_SVS_DEMUXER 0
-+#define CONFIG_SWF_DEMUXER 0
-+#define CONFIG_TAK_DEMUXER 0
-+#define CONFIG_TEDCAPTIONS_DEMUXER 0
-+#define CONFIG_THP_DEMUXER 0
-+#define CONFIG_THREEDOSTR_DEMUXER 0
-+#define CONFIG_TIERTEXSEQ_DEMUXER 0
-+#define CONFIG_TMV_DEMUXER 0
-+#define CONFIG_TRUEHD_DEMUXER 0
-+#define CONFIG_TTA_DEMUXER 0
-+#define CONFIG_TXD_DEMUXER 0
-+#define CONFIG_TTY_DEMUXER 0
-+#define CONFIG_TY_DEMUXER 0
-+#define CONFIG_V210_DEMUXER 0
-+#define CONFIG_V210X_DEMUXER 0
-+#define CONFIG_VAG_DEMUXER 0
-+#define CONFIG_VC1_DEMUXER 0
-+#define CONFIG_VC1T_DEMUXER 0
-+#define CONFIG_VIVIDAS_DEMUXER 0
-+#define CONFIG_VIVO_DEMUXER 0
-+#define CONFIG_VMD_DEMUXER 0
-+#define CONFIG_VOBSUB_DEMUXER 0
-+#define CONFIG_VOC_DEMUXER 0
-+#define CONFIG_VPK_DEMUXER 0
-+#define CONFIG_VPLAYER_DEMUXER 0
-+#define CONFIG_VQF_DEMUXER 0
-+#define CONFIG_W64_DEMUXER 0
-+#define CONFIG_WADY_DEMUXER 0
-+#define CONFIG_WAV_DEMUXER 1
-+#define CONFIG_WC3_DEMUXER 0
-+#define CONFIG_WEBM_DASH_MANIFEST_DEMUXER 0
-+#define CONFIG_WEBVTT_DEMUXER 0
-+#define CONFIG_WSAUD_DEMUXER 0
-+#define CONFIG_WSD_DEMUXER 0
-+#define CONFIG_WSVQA_DEMUXER 0
-+#define CONFIG_WTV_DEMUXER 0
-+#define CONFIG_WVE_DEMUXER 0
-+#define CONFIG_WV_DEMUXER 0
-+#define CONFIG_XA_DEMUXER 0
-+#define CONFIG_XBIN_DEMUXER 0
-+#define CONFIG_XMD_DEMUXER 0
-+#define CONFIG_XMV_DEMUXER 0
-+#define CONFIG_XVAG_DEMUXER 0
-+#define CONFIG_XWMA_DEMUXER 0
-+#define CONFIG_YOP_DEMUXER 0
-+#define CONFIG_YUV4MPEGPIPE_DEMUXER 0
-+#define CONFIG_IMAGE_BMP_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_CRI_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_DDS_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_DPX_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_EXR_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_GEM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_GIF_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_HDR_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_J2K_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_JPEG_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_JPEGLS_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_JPEGXL_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PAM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PBM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PCX_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PFM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PGMYUV_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PGM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PGX_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PHM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PHOTOCD_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PICTOR_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PNG_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PPM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PSD_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_QDRAW_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_QOI_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_SGI_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_SVG_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_SUNRAST_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_TIFF_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_VBN_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_WEBP_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
-+#define CONFIG_LIBGME_DEMUXER 0
-+#define CONFIG_LIBMODPLUG_DEMUXER 0
-+#define CONFIG_LIBOPENMPT_DEMUXER 0
-+#define CONFIG_VAPOURSYNTH_DEMUXER 0
-+#define CONFIG_A64_MUXER 0
-+#define CONFIG_AC3_MUXER 0
-+#define CONFIG_ADTS_MUXER 0
-+#define CONFIG_ADX_MUXER 0
-+#define CONFIG_AIFF_MUXER 0
-+#define CONFIG_ALP_MUXER 0
-+#define CONFIG_AMR_MUXER 0
-+#define CONFIG_AMV_MUXER 0
-+#define CONFIG_APM_MUXER 0
-+#define CONFIG_APNG_MUXER 0
-+#define CONFIG_APTX_MUXER 0
-+#define CONFIG_APTX_HD_MUXER 0
-+#define CONFIG_ARGO_ASF_MUXER 0
-+#define CONFIG_ARGO_CVG_MUXER 0
-+#define CONFIG_ASF_MUXER 0
-+#define CONFIG_ASS_MUXER 0
-+#define CONFIG_AST_MUXER 0
-+#define CONFIG_ASF_STREAM_MUXER 0
-+#define CONFIG_AU_MUXER 0
-+#define CONFIG_AVI_MUXER 0
-+#define CONFIG_AVIF_MUXER 0
-+#define CONFIG_AVM2_MUXER 0
-+#define CONFIG_AVS2_MUXER 0
-+#define CONFIG_AVS3_MUXER 0
-+#define CONFIG_BIT_MUXER 0
-+#define CONFIG_CAF_MUXER 0
-+#define CONFIG_CAVSVIDEO_MUXER 0
-+#define CONFIG_CODEC2_MUXER 0
-+#define CONFIG_CODEC2RAW_MUXER 0
-+#define CONFIG_CRC_MUXER 0
-+#define CONFIG_DASH_MUXER 0
-+#define CONFIG_DATA_MUXER 0
-+#define CONFIG_DAUD_MUXER 0
-+#define CONFIG_DFPWM_MUXER 0
-+#define CONFIG_DIRAC_MUXER 0
-+#define CONFIG_DNXHD_MUXER 0
-+#define CONFIG_DTS_MUXER 0
-+#define CONFIG_DV_MUXER 0
-+#define CONFIG_EAC3_MUXER 0
-+#define CONFIG_F4V_MUXER 0
-+#define CONFIG_FFMETADATA_MUXER 0
-+#define CONFIG_FIFO_MUXER 0
-+#define CONFIG_FIFO_TEST_MUXER 0
-+#define CONFIG_FILMSTRIP_MUXER 0
-+#define CONFIG_FITS_MUXER 0
-+#define CONFIG_FLAC_MUXER 0
-+#define CONFIG_FLV_MUXER 0
-+#define CONFIG_FRAMECRC_MUXER 0
-+#define CONFIG_FRAMEHASH_MUXER 0
-+#define CONFIG_FRAMEMD5_MUXER 0
-+#define CONFIG_G722_MUXER 0
-+#define CONFIG_G723_1_MUXER 0
-+#define CONFIG_G726_MUXER 0
-+#define CONFIG_G726LE_MUXER 0
-+#define CONFIG_GIF_MUXER 0
-+#define CONFIG_GSM_MUXER 0
-+#define CONFIG_GXF_MUXER 0
-+#define CONFIG_H261_MUXER 0
-+#define CONFIG_H263_MUXER 0
-+#define CONFIG_H264_MUXER 0
-+#define CONFIG_HASH_MUXER 0
-+#define CONFIG_HDS_MUXER 0
-+#define CONFIG_HEVC_MUXER 0
-+#define CONFIG_HLS_MUXER 0
-+#define CONFIG_ICO_MUXER 0
-+#define CONFIG_ILBC_MUXER 0
-+#define CONFIG_IMAGE2_MUXER 0
-+#define CONFIG_IMAGE2PIPE_MUXER 0
-+#define CONFIG_IPOD_MUXER 0
-+#define CONFIG_IRCAM_MUXER 0
-+#define CONFIG_ISMV_MUXER 0
-+#define CONFIG_IVF_MUXER 0
-+#define CONFIG_JACOSUB_MUXER 0
-+#define CONFIG_KVAG_MUXER 0
-+#define CONFIG_LATM_MUXER 0
-+#define CONFIG_LRC_MUXER 0
-+#define CONFIG_M4V_MUXER 0
-+#define CONFIG_MD5_MUXER 0
-+#define CONFIG_MATROSKA_MUXER 0
-+#define CONFIG_MATROSKA_AUDIO_MUXER 0
-+#define CONFIG_MICRODVD_MUXER 0
-+#define CONFIG_MJPEG_MUXER 0
-+#define CONFIG_MLP_MUXER 0
-+#define CONFIG_MMF_MUXER 0
-+#define CONFIG_MOV_MUXER 0
-+#define CONFIG_MP2_MUXER 0
-+#define CONFIG_MP3_MUXER 0
-+#define CONFIG_MP4_MUXER 0
-+#define CONFIG_MPEG1SYSTEM_MUXER 0
-+#define CONFIG_MPEG1VCD_MUXER 0
-+#define CONFIG_MPEG1VIDEO_MUXER 0
-+#define CONFIG_MPEG2DVD_MUXER 0
-+#define CONFIG_MPEG2SVCD_MUXER 0
-+#define CONFIG_MPEG2VIDEO_MUXER 0
-+#define CONFIG_MPEG2VOB_MUXER 0
-+#define CONFIG_MPEGTS_MUXER 0
-+#define CONFIG_MPJPEG_MUXER 0
-+#define CONFIG_MXF_MUXER 0
-+#define CONFIG_MXF_D10_MUXER 0
-+#define CONFIG_MXF_OPATOM_MUXER 0
-+#define CONFIG_NULL_MUXER 0
-+#define CONFIG_NUT_MUXER 0
-+#define CONFIG_OBU_MUXER 0
-+#define CONFIG_OGA_MUXER 0
-+#define CONFIG_OGG_MUXER 0
-+#define CONFIG_OGV_MUXER 0
-+#define CONFIG_OMA_MUXER 0
-+#define CONFIG_OPUS_MUXER 0
-+#define CONFIG_PCM_ALAW_MUXER 0
-+#define CONFIG_PCM_MULAW_MUXER 0
-+#define CONFIG_PCM_VIDC_MUXER 0
-+#define CONFIG_PCM_F64BE_MUXER 0
-+#define CONFIG_PCM_F64LE_MUXER 0
-+#define CONFIG_PCM_F32BE_MUXER 0
-+#define CONFIG_PCM_F32LE_MUXER 0
-+#define CONFIG_PCM_S32BE_MUXER 0
-+#define CONFIG_PCM_S32LE_MUXER 0
-+#define CONFIG_PCM_S24BE_MUXER 0
-+#define CONFIG_PCM_S24LE_MUXER 0
-+#define CONFIG_PCM_S16BE_MUXER 0
-+#define CONFIG_PCM_S16LE_MUXER 0
-+#define CONFIG_PCM_S8_MUXER 0
-+#define CONFIG_PCM_U32BE_MUXER 0
-+#define CONFIG_PCM_U32LE_MUXER 0
-+#define CONFIG_PCM_U24BE_MUXER 0
-+#define CONFIG_PCM_U24LE_MUXER 0
-+#define CONFIG_PCM_U16BE_MUXER 0
-+#define CONFIG_PCM_U16LE_MUXER 0
-+#define CONFIG_PCM_U8_MUXER 0
-+#define CONFIG_PSP_MUXER 0
-+#define CONFIG_RAWVIDEO_MUXER 0
-+#define CONFIG_RM_MUXER 0
-+#define CONFIG_ROQ_MUXER 0
-+#define CONFIG_RSO_MUXER 0
-+#define CONFIG_RTP_MUXER 0
-+#define CONFIG_RTP_MPEGTS_MUXER 0
-+#define CONFIG_RTSP_MUXER 0
-+#define CONFIG_SAP_MUXER 0
-+#define CONFIG_SBC_MUXER 0
-+#define CONFIG_SCC_MUXER 0
-+#define CONFIG_SEGAFILM_MUXER 0
-+#define CONFIG_SEGMENT_MUXER 0
-+#define CONFIG_STREAM_SEGMENT_MUXER 0
-+#define CONFIG_SMJPEG_MUXER 0
-+#define CONFIG_SMOOTHSTREAMING_MUXER 0
-+#define CONFIG_SOX_MUXER 0
-+#define CONFIG_SPX_MUXER 0
-+#define CONFIG_SPDIF_MUXER 0
-+#define CONFIG_SRT_MUXER 0
-+#define CONFIG_STREAMHASH_MUXER 0
-+#define CONFIG_SUP_MUXER 0
-+#define CONFIG_SWF_MUXER 0
-+#define CONFIG_TEE_MUXER 0
-+#define CONFIG_TG2_MUXER 0
-+#define CONFIG_TGP_MUXER 0
-+#define CONFIG_MKVTIMESTAMP_V2_MUXER 0
-+#define CONFIG_TRUEHD_MUXER 0
-+#define CONFIG_TTA_MUXER 0
-+#define CONFIG_TTML_MUXER 0
-+#define CONFIG_UNCODEDFRAMECRC_MUXER 0
-+#define CONFIG_VC1_MUXER 0
-+#define CONFIG_VC1T_MUXER 0
-+#define CONFIG_VOC_MUXER 0
-+#define CONFIG_W64_MUXER 0
-+#define CONFIG_WAV_MUXER 0
-+#define CONFIG_WEBM_MUXER 0
-+#define CONFIG_WEBM_DASH_MANIFEST_MUXER 0
-+#define CONFIG_WEBM_CHUNK_MUXER 0
-+#define CONFIG_WEBP_MUXER 0
-+#define CONFIG_WEBVTT_MUXER 0
-+#define CONFIG_WSAUD_MUXER 0
-+#define CONFIG_WTV_MUXER 0
-+#define CONFIG_WV_MUXER 0
-+#define CONFIG_YUV4MPEGPIPE_MUXER 0
-+#define CONFIG_CHROMAPRINT_MUXER 0
-+#define CONFIG_ASYNC_PROTOCOL 0
-+#define CONFIG_BLURAY_PROTOCOL 0
-+#define CONFIG_CACHE_PROTOCOL 0
-+#define CONFIG_CONCAT_PROTOCOL 0
-+#define CONFIG_CONCATF_PROTOCOL 0
-+#define CONFIG_CRYPTO_PROTOCOL 0
-+#define CONFIG_DATA_PROTOCOL 0
-+#define CONFIG_FD_PROTOCOL 0
-+#define CONFIG_FFRTMPCRYPT_PROTOCOL 0
-+#define CONFIG_FFRTMPHTTP_PROTOCOL 0
-+#define CONFIG_FILE_PROTOCOL 0
-+#define CONFIG_FTP_PROTOCOL 0
-+#define CONFIG_GOPHER_PROTOCOL 0
-+#define CONFIG_GOPHERS_PROTOCOL 0
-+#define CONFIG_HLS_PROTOCOL 0
-+#define CONFIG_HTTP_PROTOCOL 0
-+#define CONFIG_HTTPPROXY_PROTOCOL 0
-+#define CONFIG_HTTPS_PROTOCOL 0
-+#define CONFIG_ICECAST_PROTOCOL 0
-+#define CONFIG_MMSH_PROTOCOL 0
-+#define CONFIG_MMST_PROTOCOL 0
-+#define CONFIG_MD5_PROTOCOL 0
-+#define CONFIG_PIPE_PROTOCOL 0
-+#define CONFIG_PROMPEG_PROTOCOL 0
-+#define CONFIG_RTMP_PROTOCOL 0
-+#define CONFIG_RTMPE_PROTOCOL 0
-+#define CONFIG_RTMPS_PROTOCOL 0
-+#define CONFIG_RTMPT_PROTOCOL 0
-+#define CONFIG_RTMPTE_PROTOCOL 0
-+#define CONFIG_RTMPTS_PROTOCOL 0
-+#define CONFIG_RTP_PROTOCOL 0
-+#define CONFIG_SCTP_PROTOCOL 0
-+#define CONFIG_SRTP_PROTOCOL 0
-+#define CONFIG_SUBFILE_PROTOCOL 0
-+#define CONFIG_TEE_PROTOCOL 0
-+#define CONFIG_TCP_PROTOCOL 0
-+#define CONFIG_TLS_PROTOCOL 0
-+#define CONFIG_UDP_PROTOCOL 0
-+#define CONFIG_UDPLITE_PROTOCOL 0
-+#define CONFIG_UNIX_PROTOCOL 0
-+#define CONFIG_LIBAMQP_PROTOCOL 0
-+#define CONFIG_LIBRIST_PROTOCOL 0
-+#define CONFIG_LIBRTMP_PROTOCOL 0
-+#define CONFIG_LIBRTMPE_PROTOCOL 0
-+#define CONFIG_LIBRTMPS_PROTOCOL 0
-+#define CONFIG_LIBRTMPT_PROTOCOL 0
-+#define CONFIG_LIBRTMPTE_PROTOCOL 0
-+#define CONFIG_LIBSRT_PROTOCOL 0
-+#define CONFIG_LIBSSH_PROTOCOL 0
-+#define CONFIG_LIBSMBCLIENT_PROTOCOL 0
-+#define CONFIG_LIBZMQ_PROTOCOL 0
-+#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
-+#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
-+#endif /* FFMPEG_CONFIG_COMPONENTS_H */
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,2 @@
-+static const FFBitStreamFilter * const bitstream_filters[] = {
-+    NULL };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,18 @@
-+static const FFCodec * const codec_list[] = {
-+    &ff_theora_decoder,
-+    &ff_vp3_decoder,
-+    &ff_vp8_decoder,
-+    &ff_flac_decoder,
-+    &ff_mp3_decoder,
-+    &ff_vorbis_decoder,
-+    &ff_pcm_alaw_decoder,
-+    &ff_pcm_f32le_decoder,
-+    &ff_pcm_mulaw_decoder,
-+    &ff_pcm_s16be_decoder,
-+    &ff_pcm_s16le_decoder,
-+    &ff_pcm_s24be_decoder,
-+    &ff_pcm_s24le_decoder,
-+    &ff_pcm_s32le_decoder,
-+    &ff_pcm_u8_decoder,
-+    &ff_libopus_decoder,
-+    NULL };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,9 @@
-+static const AVCodecParser * const parser_list[] = {
-+    &ff_flac_parser,
-+    &ff_mpegaudio_parser,
-+    &ff_opus_parser,
-+    &ff_vorbis_parser,
-+    &ff_vp3_parser,
-+    &ff_vp8_parser,
-+    &ff_vp9_parser,
-+    NULL };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,8 @@
-+static const AVInputFormat * const demuxer_list[] = {
-+    &ff_flac_demuxer,
-+    &ff_matroska_demuxer,
-+    &ff_mov_demuxer,
-+    &ff_mp3_demuxer,
-+    &ff_ogg_demuxer,
-+    &ff_wav_demuxer,
-+    NULL };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,2 @@
-+static const AVOutputFormat * const muxer_list[] = {
-+    NULL };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,2 @@
-+static const URLProtocol * const url_protocols[] = {
-+    NULL };
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,6 @@
-+/* Generated by ffmpeg configure */
-+#ifndef AVUTIL_AVCONFIG_H
-+#define AVUTIL_AVCONFIG_H
-+#define AV_HAVE_BIGENDIAN 0
-+#define AV_HAVE_FAST_UNALIGNED 1
-+#endif /* AVUTIL_AVCONFIG_H */
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni
---- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni	2000-01-01 00:00:00.000000000 +0800
-@@ -273,7 +273,7 @@ if ((is_apple && ffmpeg_branding == "Chr
-   ]
- }
- 
--if ((current_cpu == "arm64" && ffmpeg_branding == "Chrome") || (current_cpu == "x64" && ffmpeg_branding == "Chrome") || (is_android && current_cpu == "arm" && arm_use_neon && ffmpeg_branding == "Chrome") || (is_android && current_cpu == "x86" && ffmpeg_branding == "Chrome") || (is_apple && ffmpeg_branding == "Chrome") || (is_win && ffmpeg_branding == "Chrome") || (use_linux_config && ffmpeg_branding == "Chrome") || (use_linux_config && ffmpeg_branding == "ChromeOS")) {
-+if ((current_cpu == "arm64" && ffmpeg_branding == "Chrome") || (current_cpu == "x64" && ffmpeg_branding == "Chrome") || (current_cpu == "loong64" && ffmpeg_branding == "Chrome") || (is_android && current_cpu == "arm" && arm_use_neon && ffmpeg_branding == "Chrome") || (is_android && current_cpu == "x86" && ffmpeg_branding == "Chrome") || (is_apple && ffmpeg_branding == "Chrome") || (is_win && ffmpeg_branding == "Chrome") || (use_linux_config && ffmpeg_branding == "Chrome") || (use_linux_config && ffmpeg_branding == "ChromeOS")) {
-   ffmpeg_c_sources += [
-     "libavcodec/aac_ac3_parser.c",
-     "libavcodec/aac_parser.c",
-@@ -425,6 +425,19 @@ if ((is_android && current_cpu == "x64")
-   ]
- }
- 
-+if ((use_linux_config && current_cpu == "loong64")) {
-+  ffmpeg_c_sources += [
-+    "libavutil/loongarch/cpu.c",
-+    "libavcodec/loongarch/vp8dsp_init_loongarch.c",
-+    "libavcodec/loongarch/h264chroma_init_loongarch.c",
-+    "libavcodec/loongarch/h264dsp_init_loongarch.c",
-+    "libavcodec/loongarch/h264qpel_init_loongarch.c",
-+    "libavcodec/loongarch/videodsp_init.c",
-+    "libavcodec/loongarch/h264_intrapred_init_loongarch.c",
-+    "libavcodec/loongarch/hpeldsp_init_loongarch.c",
-+  ]
-+}
-+
- if ((is_android && current_cpu == "arm" && arm_use_neon) || (use_linux_config && current_cpu == "arm" && arm_use_neon) || (use_linux_config && current_cpu == "arm")) {
-   ffmpeg_c_sources += [
-     "libavcodec/arm/fft_init_arm.c",
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni b/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni
---- a/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni	2000-01-01 00:00:00.000000000 +0800
-@@ -9,5 +9,5 @@ declare_args() {
-   use_libgav1_parser =
-       (is_chromeos || is_linux || is_win) &&
-       (target_cpu == "x86" || target_cpu == "x64" || target_cpu == "arm" ||
--       target_cpu == "arm64" || target_cpu == "ppc64")
-+       target_cpu == "arm64" || target_cpu == "ppc64" || target_cpu == "loong64")
- }
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn b/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn
---- a/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
-@@ -156,6 +156,8 @@ swiftshader_llvm_source_set("swiftshader
-     deps += [ ":swiftshader_llvm_ppc" ]
-   } else if (current_cpu == "riscv64") {
-     deps += [ ":swiftshader_llvm_riscv64" ]
-+  } else if (current_cpu == "loong64") {
-+    # swiftshader unused in qt6-webengine
-   } else if (current_cpu == "x86" || current_cpu == "x64") {
-     deps += [ ":swiftshader_llvm_x86" ]
-   } else {
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/loong64/regexp-macro-assembler-loong64.cc b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/loong64/regexp-macro-assembler-loong64.cc
 --- a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/loong64/regexp-macro-assembler-loong64.cc	2000-01-01 00:00:00.000000000 +0800
 +++ b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/loong64/regexp-macro-assembler-loong64.cc	2000-01-01 00:00:00.000000000 +0800
@@ -9234,11 +9334,12 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
        __ li(a0, Operand(stack_limit));
        __ Ld_d(a0, MemOperand(a0, 0));
        __ Sub_d(a0, sp, a0);
-@@ -724,14 +726,14 @@ Handle<HeapObject> RegExpMacroAssemblerL
+@@ -724,15 +726,14 @@ Handle<HeapObject> RegExpMacroAssemblerL
        __ Branch(&stack_limit_hit, le, a0, Operand(zero_reg));
        // Check if there is room for the variable number of registers above
        // the stack limit.
--      __ Branch(&stack_ok, hs, a0, Operand(num_registers_ * kPointerSize));
+-      __ Branch(&stack_ok, hs, a0,
+-                Operand(num_registers_ * kSystemPointerSize));
 +      __ Branch(&stack_ok, hs, a0, extra_space_for_variables);
        // Exit with OutOfMemory exception. There is not enough space on the stack
        // for our working registers.
@@ -9251,7 +9352,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
        // If returned value is non-zero, we exit with the returned value as
        // result.
        __ Branch(&return_v0, ne, a0, Operand(zero_reg));
-@@ -1131,7 +1133,8 @@ void RegExpMacroAssemblerLOONG64::ClearR
+@@ -1131,7 +1132,8 @@ void RegExpMacroAssemblerLOONG64::ClearR
  
  // Private methods:
  
@@ -9261,7 +9362,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    DCHECK(!isolate()->IsGeneratingEmbeddedBuiltins());
    DCHECK(!masm_->options().isolate_independent_code);
  
-@@ -1144,6 +1147,9 @@ void RegExpMacroAssemblerLOONG64::CallCh
+@@ -1144,6 +1146,9 @@ void RegExpMacroAssemblerLOONG64::CallCh
    __ And(sp, sp, Operand(-stack_alignment));
    __ St_d(scratch, MemOperand(sp, 0));
  
@@ -9271,8 +9372,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    __ mov(a2, frame_pointer());
    // InstructionStream of self.
    __ li(a1, Operand(masm_->CodeObject()), CONSTANT_SIZE);
-@@ -1152,16 +1158,6 @@ void RegExpMacroAssemblerLOONG64::CallCh
-   DCHECK(IsAligned(stack_alignment, kPointerSize));
+@@ -1152,16 +1157,6 @@ void RegExpMacroAssemblerLOONG64::CallCh
+   DCHECK(IsAligned(stack_alignment, kSystemPointerSize));
    __ Sub_d(sp, sp, Operand(stack_alignment));
  
 -  // The stack pointer now points to cell where the return address will be
@@ -9288,7 +9389,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    // a0 will point to the return address, placed by DirectCEntry.
    __ mov(a0, sp);
  
-@@ -1175,17 +1171,6 @@ void RegExpMacroAssemblerLOONG64::CallCh
+@@ -1175,17 +1170,6 @@ void RegExpMacroAssemblerLOONG64::CallCh
    __ li(kScratchReg, Operand(entry, RelocInfo::OFF_HEAP_TARGET));
    __ Call(kScratchReg);
  
@@ -9306,7 +9407,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    __ Ld_d(sp, MemOperand(sp, stack_alignment));
  
    __ li(code_pointer(), Operand(masm_->CodeObject()));
-@@ -1203,7 +1188,8 @@ static T* frame_entry_address(Address re
+@@ -1203,7 +1187,8 @@ static T* frame_entry_address(Address re
  }
  
  int64_t RegExpMacroAssemblerLOONG64::CheckStackGuardState(
@@ -9316,12 +9417,12 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    InstructionStream re_code = InstructionStream::cast(Object(raw_code));
    return NativeRegExpMacroAssembler::CheckStackGuardState(
        frame_entry<Isolate*>(re_frame, kIsolateOffset),
-@@ -1213,7 +1199,8 @@ int64_t RegExpMacroAssemblerLOONG64::Che
+@@ -1213,7 +1198,8 @@ int64_t RegExpMacroAssemblerLOONG64::Che
        return_address, re_code,
        frame_entry_address<Address>(re_frame, kInputStringOffset),
-       frame_entry_address<const byte*>(re_frame, kInputStartOffset),
--      frame_entry_address<const byte*>(re_frame, kInputEndOffset));
-+      frame_entry_address<const byte*>(re_frame, kInputEndOffset),
+       frame_entry_address<const uint8_t*>(re_frame, kInputStartOffset),
+-      frame_entry_address<const uint8_t*>(re_frame, kInputEndOffset));
++      frame_entry_address<const uint8_t*>(re_frame, kInputEndOffset),
 +      extra_space);
  }
  
@@ -9348,132 +9449,193 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
    void CallIsCharacterInRangeArray(const ZoneList<CharacterRange>* ranges);
  
    // The ebp-relative location of a regexp register.
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.cc b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.cc
---- a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -765,6 +765,8 @@ Handle<HeapObject> RegExpMacroAssemblerM
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/cmake/Functions.cmake b/qtwebengine/cmake/Functions.cmake
+--- a/qtwebengine/cmake/Functions.cmake	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/cmake/Functions.cmake	2000-01-01 00:00:00.000000000 +0800
+@@ -635,6 +635,8 @@ function(get_gn_arch result arch)
+         set(${result} "mips64el" PARENT_SCOPE)
+     elseif(arch STREQUAL "riscv64")
+         set(${result} "riscv64" PARENT_SCOPE)
++    elseif(arch STREQUAL "loongarch64")
++        set(${result} "loong64" PARENT_SCOPE)
+     else()
+         message(FATAL_ERROR "Unknown architecture: ${arch}")
+     endif()
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn b/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn
+--- a/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
+@@ -783,6 +783,8 @@ skia_source_set("skia_opts") {
+     # Conditional and empty body needed to avoid assert() below.
+   } else if (current_cpu == "riscv64") {
+     # Conditional and empty body needed to avoid assert() below.
++  } else if (current_cpu == "loong64") {
++    # Conditional and empty body needed to avoid assert() below.
+   } else {
+     assert(false, "Unknown cpu target")
+   }
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h b/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h	2000-01-01 00:00:00.000000000 +0800
+@@ -91,19 +91,19 @@ ALWAYS_INLINE void PackOneRowOfRGBA8Litt
+   v4f32 mask_falpha = __lsx_vffint_s_w(mask_lalpha);
+   v16u8 ra_index = {0,19, 4,23, 8,27, 12,31};
+   for (unsigned i = 0; i < pixels_per_row_trunc; i += 4) {
+-    v16u8 bgra = *((__m128i*)(source));
++    __m128i bgra = *((__m128i*)(source));
+     //if A !=0, A=0; else A=0xFF
+-    v4f32 alpha_factor = __lsx_vseq_b(bgra, mask_zero);
++    __m128i alpha_factor = __lsx_vseq_b(bgra, mask_zero);
+     //if A!=0, A=A; else A=0xFF
+     alpha_factor = __lsx_vor_v(bgra, alpha_factor);
+     alpha_factor = __lsx_vsrli_w(alpha_factor, 24);
+-    alpha_factor = __lsx_vffint_s_w(alpha_factor);
+-    alpha_factor = __lsx_vfdiv_s(mask_falpha, alpha_factor);
++    alpha_factor = (__m128i) __lsx_vffint_s_w(alpha_factor);
++    alpha_factor = (__m128i) __lsx_vfdiv_s((__m128) mask_falpha, (__m128) alpha_factor);
  
-       ExternalReference stack_limit =
-           ExternalReference::address_of_jslimit(masm_->isolate());
-+      Operand extra_space_for_variables(num_registers_ * kPointerSize);
-+
-       __ li(a0, Operand(stack_limit));
-       __ Ld(a0, MemOperand(a0));
-       __ Dsubu(a0, sp, a0);
-@@ -772,14 +774,14 @@ Handle<HeapObject> RegExpMacroAssemblerM
-       __ Branch(&stack_limit_hit, le, a0, Operand(zero_reg));
-       // Check if there is room for the variable number of registers above
-       // the stack limit.
--      __ Branch(&stack_ok, hs, a0, Operand(num_registers_ * kPointerSize));
-+      __ Branch(&stack_ok, hs, a0, extra_space_for_variables);
-       // Exit with OutOfMemory exception. There is not enough space on the stack
-       // for our working registers.
-       __ li(v0, Operand(EXCEPTION));
-       __ jmp(&return_v0);
+-    v16u8 component_r = __lsx_vand_v(bgra, mask_lalpha);
+-    component_r = __lsx_vffint_s_w(component_r);
+-    component_r = __lsx_vfmul_s(component_r, alpha_factor);
+-    component_r = __lsx_vftintrz_w_s(component_r);
++    __m128i component_r = __lsx_vand_v(bgra, mask_lalpha);
++    component_r = (__m128i) __lsx_vffint_s_w(component_r);
++    component_r = (__m128i) __lsx_vfmul_s((__m128) component_r, (__m128) alpha_factor);
++    component_r = __lsx_vftintrz_w_s((__m128) component_r);
  
-       __ bind(&stack_limit_hit);
--      CallCheckStackGuardState(a0);
-+      CallCheckStackGuardState(a0, extra_space_for_variables);
-       // If returned value is non-zero, we exit with the returned value as
-       // result.
-       __ Branch(&return_v0, ne, v0, Operand(zero_reg));
-@@ -1182,7 +1184,8 @@ bool RegExpMacroAssemblerMIPS::CanReadUn
+     v2u64 ra = __lsx_vshuf_b(bgra, component_r, ra_index);
+     __lsx_vstelm_d(ra, destination, 0, 0);
+@@ -138,19 +138,19 @@ ALWAYS_INLINE void PackOneRowOfRGBA8Litt
+   v4u32 mask_lalpha = __lsx_vreplgr2vr_w(0x0ff);
+   v4f32 mask_falpha = __lsx_vffint_s_w(mask_lalpha);
+   for (unsigned i = 0; i < pixels_per_row_trunc; i += 4) {
+-    v16u8 bgra = *((__m128i*)(source));
++    __m128i bgra = *((__m128i*)(source));
+     //if A !=0, A=0; else A=0xFF
+-    v4f32 alpha_factor = __lsx_vseq_b(bgra, mask_zero);
++    __m128i alpha_factor = __lsx_vseq_b(bgra, mask_zero);
+     //if A!=0, A=A; else A=0xFF
+     alpha_factor = __lsx_vor_v(bgra, alpha_factor);
+     alpha_factor = __lsx_vsrli_w(alpha_factor, 24);
+-    alpha_factor = __lsx_vffint_s_w(alpha_factor);
+-    alpha_factor = __lsx_vfdiv_s(mask_falpha, alpha_factor);
++    alpha_factor = (__m128i) __lsx_vffint_s_w(alpha_factor);
++    alpha_factor = (__m128i) __lsx_vfdiv_s((__m128) mask_falpha, (__m128) alpha_factor);
  
- // Private methods:
+-    v16u8 component_r = __lsx_vand_v(bgra, mask_lalpha);
+-    component_r = __lsx_vffint_s_w(component_r);
+-    component_r = __lsx_vfmul_s(component_r, alpha_factor);
+-    component_r = __lsx_vftintrz_w_s(component_r);
++    __m128i component_r = __lsx_vand_v(bgra, mask_lalpha);
++    component_r = (__m128i) __lsx_vffint_s_w(component_r);
++    component_r = (__m128i) __lsx_vfmul_s((__m128) component_r, (__m128) alpha_factor);
++    component_r = __lsx_vftintrz_w_s((__m128) component_r);
  
--void RegExpMacroAssemblerMIPS::CallCheckStackGuardState(Register scratch) {
-+void RegExpMacroAssemblerMIPS::CallCheckStackGuardState(Register scratch,
-+                                                        Operand extra_space) {
-   DCHECK(!isolate()->IsGeneratingEmbeddedBuiltins());
-   DCHECK(!masm_->options().isolate_independent_code);
+     component_r = __lsx_vpickev_b(component_r, component_r);
+     component_r = __lsx_vpickev_b(component_r, component_r);
+@@ -173,41 +173,41 @@ ALWAYS_INLINE void PackOneRowOfRGBA8Litt
+   v4f32 mask_falpha = __lsx_vffint_s_w(mask_lalpha);
+   v16u8 rgba_index = {0,1,2,19, 4,5,6,23, 8,9,10,27, 12,13,14,31};
+   for (unsigned i = 0; i < pixels_per_row_trunc; i += 4) {
+-    v16u8 bgra = *((__m128i*)(source));
++    __m128i bgra = *((__m128i*)(source));
+     //if A !=0, A=0; else A=0xFF
+-    v4f32 alpha_factor = __lsx_vseq_b(bgra, mask_zero);
++    __m128i alpha_factor = __lsx_vseq_b(bgra, mask_zero);
+     //if A!=0, A=A; else A=0xFF
+     alpha_factor = __lsx_vor_v(bgra, alpha_factor);
+     alpha_factor = __lsx_vsrli_w(alpha_factor, 24);
+-    alpha_factor = __lsx_vffint_s_w(alpha_factor);
+-    alpha_factor = __lsx_vfdiv_s(mask_falpha, alpha_factor);
++    alpha_factor = (__m128i) __lsx_vffint_s_w(alpha_factor);
++    alpha_factor = (__m128i) __lsx_vfdiv_s((__m128) mask_falpha, (__m128) alpha_factor);
  
-@@ -1195,6 +1198,9 @@ void RegExpMacroAssemblerMIPS::CallCheck
-   __ And(sp, sp, Operand(-stack_alignment));
-   __ Sd(scratch, MemOperand(sp));
- 
-+  // Extra space for variables to consider in stack check.
-+  __ li(a3, extra_space);
-+  // RegExp code frame pointer.
-   __ mov(a2, frame_pointer());
-   // InstructionStream of self.
-   __ li(a1, Operand(masm_->CodeObject()), CONSTANT_SIZE);
-@@ -1203,16 +1209,6 @@ void RegExpMacroAssemblerMIPS::CallCheck
-   DCHECK(IsAligned(stack_alignment, kPointerSize));
-   __ Dsubu(sp, sp, Operand(stack_alignment));
- 
--  // The stack pointer now points to cell where the return address will be
--  // written. Arguments are in registers, meaning we treat the return address as
--  // argument 5. Since DirectCEntry will handle allocating space for the C
--  // argument slots, we don't need to care about that here. This is how the
--  // stack will look (sp meaning the value of sp at this moment):
--  // [sp + 3] - empty slot if needed for alignment.
--  // [sp + 2] - saved sp.
--  // [sp + 1] - second word reserved for return value.
--  // [sp + 0] - first word reserved for return value.
+     v16u8 bgra_01 = __lsx_vilvl_b(mask_zero, bgra);
+     v16u8 bgra_23 = __lsx_vilvh_b(mask_zero, bgra);
+-    v16u8 bgra_0 = __lsx_vilvl_b(mask_zero, bgra_01);
+-    v16u8 bgra_1 = __lsx_vilvh_b(mask_zero, bgra_01);
+-    v16u8 bgra_2 = __lsx_vilvl_b(mask_zero, bgra_23);
+-    v16u8 bgra_3 = __lsx_vilvh_b(mask_zero, bgra_23);
 -
-   // a0 will point to the return address, placed by DirectCEntry.
-   __ mov(a0, sp);
+-    bgra_0 = __lsx_vffint_s_w(bgra_0);
+-    bgra_1 = __lsx_vffint_s_w(bgra_1);
+-    bgra_2 = __lsx_vffint_s_w(bgra_2);
+-    bgra_3 = __lsx_vffint_s_w(bgra_3);
+-
+-    v4f32 alpha_factor_0 = __lsx_vreplvei_w(alpha_factor, 0);
+-    v4f32 alpha_factor_1 = __lsx_vreplvei_w(alpha_factor, 1);
+-    v4f32 alpha_factor_2 = __lsx_vreplvei_w(alpha_factor, 2);
+-    v4f32 alpha_factor_3 = __lsx_vreplvei_w(alpha_factor, 3);
+-
+-    bgra_0 = __lsx_vfmul_s(alpha_factor_0, bgra_0);
+-    bgra_1 = __lsx_vfmul_s(alpha_factor_1, bgra_1);
+-    bgra_2 = __lsx_vfmul_s(alpha_factor_2, bgra_2);
+-    bgra_3 = __lsx_vfmul_s(alpha_factor_3, bgra_3);
+-
+-    bgra_0 = __lsx_vftintrz_w_s(bgra_0);
+-    bgra_1 = __lsx_vftintrz_w_s(bgra_1);
+-    bgra_2 = __lsx_vftintrz_w_s(bgra_2);
+-    bgra_3 = __lsx_vftintrz_w_s(bgra_3);
++    __m128i bgra_0 = __lsx_vilvl_b(mask_zero, bgra_01);
++    __m128i bgra_1 = __lsx_vilvh_b(mask_zero, bgra_01);
++    __m128i bgra_2 = __lsx_vilvl_b(mask_zero, bgra_23);
++    __m128i bgra_3 = __lsx_vilvh_b(mask_zero, bgra_23);
++
++    bgra_0 = (__m128i) __lsx_vffint_s_w(bgra_0);
++    bgra_1 = (__m128i) __lsx_vffint_s_w(bgra_1);
++    bgra_2 = (__m128i) __lsx_vffint_s_w(bgra_2);
++    bgra_3 = (__m128i) __lsx_vffint_s_w(bgra_3);
++
++    __m128i alpha_factor_0 = __lsx_vreplvei_w(alpha_factor, 0);
++    __m128i alpha_factor_1 = __lsx_vreplvei_w(alpha_factor, 1);
++    __m128i alpha_factor_2 = __lsx_vreplvei_w(alpha_factor, 2);
++    __m128i alpha_factor_3 = __lsx_vreplvei_w(alpha_factor, 3);
++
++    bgra_0 = (__m128i) __lsx_vfmul_s((__m128) alpha_factor_0, (__m128) bgra_0);
++    bgra_1 = (__m128i) __lsx_vfmul_s((__m128) alpha_factor_1, (__m128) bgra_1);
++    bgra_2 = (__m128i) __lsx_vfmul_s((__m128) alpha_factor_2, (__m128) bgra_2);
++    bgra_3 = (__m128i) __lsx_vfmul_s((__m128) alpha_factor_3, (__m128) bgra_3);
++
++    bgra_0 = __lsx_vftintrz_w_s((__m128) bgra_0);
++    bgra_1 = __lsx_vftintrz_w_s((__m128) bgra_1);
++    bgra_2 = __lsx_vftintrz_w_s((__m128) bgra_2);
++    bgra_3 = __lsx_vftintrz_w_s((__m128) bgra_3);
  
-@@ -1226,17 +1222,6 @@ void RegExpMacroAssemblerMIPS::CallCheck
-   __ li(kScratchReg, Operand(entry, RelocInfo::OFF_HEAP_TARGET));
-   __ Call(kScratchReg);
- 
--  // DirectCEntry allocated space for the C argument slots so we have to
--  // drop them with the return address from the stack with loading saved sp.
--  // At this point stack must look:
--  // [sp + 7] - empty slot if needed for alignment.
--  // [sp + 6] - saved sp.
--  // [sp + 5] - second word reserved for return value.
--  // [sp + 4] - first word reserved for return value.
--  // [sp + 3] - C argument slot.
--  // [sp + 2] - C argument slot.
--  // [sp + 1] - C argument slot.
--  // [sp + 0] - C argument slot.
-   __ Ld(sp, MemOperand(sp, stack_alignment + kCArgsSlotsSize));
- 
-   __ li(code_pointer(), Operand(masm_->CodeObject()));
-@@ -1255,7 +1240,8 @@ static T* frame_entry_address(Address re
- 
- int64_t RegExpMacroAssemblerMIPS::CheckStackGuardState(Address* return_address,
-                                                        Address raw_code,
--                                                       Address re_frame) {
-+                                                       Address re_frame,
-+						       uintptr_t extra_space) {
-   InstructionStream re_code = InstructionStream::cast(Object(raw_code));
-   return NativeRegExpMacroAssembler::CheckStackGuardState(
-       frame_entry<Isolate*>(re_frame, kIsolateOffset),
-@@ -1265,7 +1251,8 @@ int64_t RegExpMacroAssemblerMIPS::CheckS
-       return_address, re_code,
-       frame_entry_address<Address>(re_frame, kInputStringOffset),
-       frame_entry_address<const byte*>(re_frame, kInputStartOffset),
--      frame_entry_address<const byte*>(re_frame, kInputEndOffset));
-+      frame_entry_address<const byte*>(re_frame, kInputEndOffset),
-+      extra_space);
+     bgra_01 = __lsx_vpickev_b(bgra_1, bgra_0);
+     bgra_23 = __lsx_vpickev_b(bgra_3, bgra_2);
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/target.h b/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/target.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/target.h	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/boringssl/src/include/openssl/target.h	2000-01-01 00:00:00.000000000 +0800
+@@ -45,6 +45,8 @@
+ #define OPENSSL_RISCV64
+ #elif defined(__riscv) && __SIZEOF_POINTER__ == 4
+ #define OPENSSL_32_BIT
++#elif defined(__loongarch__) && __SIZEOF_POINTER__ == 8
++#define OPENSSL_64_BIT
+ #elif defined(__pnacl__)
+ #define OPENSSL_32_BIT
+ #define OPENSSL_PNACL
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni b/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni
+--- a/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/libgav1/options.gni	2000-01-01 00:00:00.000000000 +0800
+@@ -9,5 +9,5 @@ declare_args() {
+   use_libgav1_parser =
+       (is_chromeos || is_linux || is_win) &&
+       (target_cpu == "x86" || target_cpu == "x64" || target_cpu == "arm" ||
+-       target_cpu == "arm64" || target_cpu == "ppc64")
++       target_cpu == "arm64" || target_cpu == "ppc64" || target_cpu == "loong64")
  }
- 
- MemOperand RegExpMacroAssemblerMIPS::register_location(int register_index) {
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.h b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.h
---- a/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.h	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/v8/src/regexp/mips64/regexp-macro-assembler-mips64.h	2000-01-01 00:00:00.000000000 +0800
-@@ -88,7 +88,7 @@ class V8_EXPORT_PRIVATE RegExpMacroAssem
-   // returning.
-   // {raw_code} is an Address because this is called via ExternalReference.
-   static int64_t CheckStackGuardState(Address* return_address, Address raw_code,
--                                      Address re_frame);
-+                                      Address re_frame, uintptr_t extra_space);
- 
-   void print_regexp_frame_constants();
- 
-@@ -163,7 +163,8 @@ class V8_EXPORT_PRIVATE RegExpMacroAssem
- 
- 
-   // Generate a call to CheckStackGuardState.
--  void CallCheckStackGuardState(Register scratch);
-+  void CallCheckStackGuardState(Register scratch,
-+                                Operand extra_space = Operand(0));
-   void CallIsCharacterInRangeArray(const ZoneList<CharacterRange>* ranges);
- 
-   // The ebp-relative location of a regexp register.
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn b/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn
+--- a/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
+@@ -156,6 +156,8 @@ swiftshader_llvm_source_set("swiftshader
+     deps += [ ":swiftshader_llvm_ppc" ]
+   } else if (current_cpu == "riscv64") {
+     deps += [ ":swiftshader_llvm_riscv64" ]
++  } else if (current_cpu == "loong64") {
++    # swiftshader unused in qt6-webengine
+   } else if (current_cpu == "x86" || current_cpu == "x64") {
+     deps += [ ":swiftshader_llvm_x86" ]
+   } else {
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/gn/src/util/sys_info.cc b/qtwebengine/src/3rdparty/gn/src/util/sys_info.cc
 --- a/qtwebengine/src/3rdparty/gn/src/util/sys_info.cc	2000-01-01 00:00:00.000000000 +0800
 +++ b/qtwebengine/src/3rdparty/gn/src/util/sys_info.cc	2000-01-01 00:00:00.000000000 +0800

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,4 +1,4 @@
-VER=6.6.3
+VER=6.7.0
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
-CHKSUMS="sha256::69d0348fef415da98aa890a34651e9cfb232f1bffcee289b7b4e21386bf36104"
+CHKSUMS="sha256::bf5089912364f99cf9baf6c109de76a3172eec6267f148c69800575c47f90087"
 CHKUPDATE="anitya::id=7927"


### PR DESCRIPTION
Topic Description
-----------------

- qt6ct: bump REL due to qt-6 update
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx-qt5: bump REL due to qt-6 update
- fcitx5-qt: update to 5.1.6
- qt-6: update to 6.7.0

Package(s) Affected
-------------------

- fcitx-qt5: 1.2.7-4
- fcitx5-qt: 1:5.1.6
- qt-6: 6.7.0
- qt6ct: 0.9-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6 fcitx5-qt fcitx-qt5 qt6ct
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
