### PR TITLE
discord: update to 0.0.51

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.50
+VER=0.0.51
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::e955dd54b93b67c34640c89276005177c348b9e524b6421de815d828d0016fee"
+CHKSUMS="sha256::c3cccb79aa895dd6c8ebb5ff503c522d0c597a2e5eada6bf0643196be183a589"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- discord: update to 0.0.51

Package(s) Affected
-------------------

- discord: 0.0.51

Security Update?
----------------

No

Build Order
-----------

```
#buildit discord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
