### PR TITLE
gmpy2: update to 2.1.5

### DIFF
--- a/lang-python/gmpy2/spec
+++ b/lang-python/gmpy2/spec
@@ -1,4 +1,4 @@
-VER=2.1.0~rc1
-SRCS="tbl::https://github.com/aleaxit/gmpy/releases/download/gmpy2-${VER/\~/}/gmpy2-${VER/\~/}.tar.gz"
-CHKSUMS="sha256::86cb6d8e5837560c32c706d48d6ed25676be6b3c79e6aa5d245965b9e99231b9"
+VER=2.1.5
+SRCS="git::commit=tags/gmpy2-$VER::https://github.com/aleaxit/gmpy"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7789"


### PR DESCRIPTION
Topic Description
-----------------

- gmpy2: update to 2.1.5

Package(s) Affected
-------------------

- gmpy2: 2.1.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit gmpy2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
