### PR TITLE
neon: update to 0.33.0

### DIFF
--- a/runtime-web/neon/autobuild/patches/0001-neon-fix-cannot-stat-files-under-doc.patch
+++ b/runtime-web/neon/autobuild/patches/0001-neon-fix-cannot-stat-files-under-doc.patch
@@ -1,0 +1,36 @@
+From 64fcc8abc9353d825e9c6237219c6bef11fda0d8 Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Wed, 24 Apr 2024 15:57:23 +0800
+Subject: [PATCH] neon: fix cannot stat files under 'doc/'
+
+---
+ Makefile.in | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 148b43a..48699f7 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -129,16 +129,16 @@ install-docs: install-man install-html
+ 
+ install-html:
+ 	$(INSTALL) -d $(DESTDIR)$(docdir)/html
+-	for d in doc/html/*.html; do \
++	for d in $(srcdir)/doc/html/*.html; do \
+ 		$(INSTALL_DATA) $$d $(DESTDIR)$(docdir)/html; \
+ 	done
+ 
+ install-man:
+ 	$(INSTALL) -d $(DESTDIR)$(man3dir)
+ 	$(INSTALL) -d $(DESTDIR)$(man1dir)
+-	for m in doc/man/*.3; do \
++	for m in $(srcdir)/doc/man/*.3; do \
+ 	 $(INSTALL_DATA) $$m $(DESTDIR)$(man3dir); done
+-	for m in doc/man/*.1; do \
++	for m in $(srcdir)/doc/man/*.1; do \
+ 	 $(INSTALL_DATA) $$m $(DESTDIR)$(man1dir); done
+ 
+ install: install-@ALLOW_INSTALL@
+-- 
+2.34.1
+

--- a/runtime-web/neon/spec
+++ b/runtime-web/neon/spec
@@ -1,5 +1,4 @@
-VER=0.31.2
+VER=0.33.0
 SRCS="https://notroj.github.io/neon/neon-$VER.tar.gz"
-CHKSUMS="sha256::cf1ee3ac27a215814a9c80803fcee4f0ede8466ebead40267a9bd115e16a8678"
+CHKSUMS="sha256::659a5cc9cea05e6e7864094f1e13a77abbbdbab452f04d751a8c16a9447cf4b8"
 CHKUPDATE="anitya::id=7604"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- neon: fix cannot stat files
- neon: update to 0.33.0

Package(s) Affected
-------------------

- neon: 0.33.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit neon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
