### PR TITLE
sympy: new, 1.12

### DIFF
--- a/lang-python/sympy/autobuild/defines
+++ b/lang-python/sympy/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=sympy
+PKGSEC=python
+PKGDEP="ipython mpmath pyglet"
+BUILDDEP="python-build python-installer wheel"
+PKGDES="Symbolic manipulation package (Computer Algebra System)"
+
+ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/sympy/spec
+++ b/lang-python/sympy/spec
@@ -1,0 +1,4 @@
+VER=1.12
+SRCS="tbl::https://pypi.io/packages/source/s/sympy/sympy-$VER.tar.gz"
+CHKSUMS="sha256::ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8"
+CHKUPDATE="anitya::id=4923"


### PR DESCRIPTION
Topic Description
-----------------

- sympy: new, 1.12

Package(s) Affected
-------------------

- sympy: 1.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit sympy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
