### PR TITLE
Community Wallpapers Survey (April, 2024)

### DIFF
--- a/desktop-themes/aosc-community-wallpapers-extras-2023/autobuild/defines
+++ b/desktop-themes/aosc-community-wallpapers-extras-2023/autobuild/defines
@@ -7,3 +7,6 @@ PKGDES="Wallpapers from community contributors (extra submissions from 2023)"
 ABHOST=noarch
 
 PKGEPOCH=1
+
+PKGBREAK="aosc-community-wallpapers<=1:2023.10.3"
+PKGREP="aosc-community-wallpapers<=1:2023.10.3"

--- a/desktop-themes/aosc-community-wallpapers-extras-2023/spec
+++ b/desktop-themes/aosc-community-wallpapers-extras-2023/spec
@@ -1,4 +1,4 @@
-VER=2023.10.0
+VER=2023.10.1
 SRCS="git::commit=tags/extras-$VER::https://github.com/AOSC-Dev/community-wallpapers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=283163"

--- a/desktop-themes/aosc-community-wallpapers-extras-2024/autobuild/build
+++ b/desktop-themes/aosc-community-wallpapers-extras-2024/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Generating and installing wallpapers ..."
+WPMETA_LOG=info \
+wpmeta \
+    --src "$SRCDIR" \
+    --dst "$PKGDIR"

--- a/desktop-themes/aosc-community-wallpapers-extras-2024/autobuild/defines
+++ b/desktop-themes/aosc-community-wallpapers-extras-2024/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=aosc-community-wallpapers-extras-2024
+PKGSEC=misc
+PKGDEP=""
+BUILDDEP="wpmeta"
+PKGDES="Wallpapers from community contributors (extra submissions from 2024)"
+
+ABHOST=noarch
+
+PKGEPOCH=1

--- a/desktop-themes/aosc-community-wallpapers-extras-2024/spec
+++ b/desktop-themes/aosc-community-wallpapers-extras-2024/spec
@@ -1,0 +1,4 @@
+VER=2024.04.1
+SRCS="git::commit=tags/extras-$VER::https://github.com/AOSC-Dev/community-wallpapers"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=283163"

--- a/desktop-themes/aosc-community-wallpapers/spec
+++ b/desktop-themes/aosc-community-wallpapers/spec
@@ -1,4 +1,4 @@
-VER=2023.10.3
+VER=2024.04.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/community-wallpapers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=283163"

--- a/meta-bases/desktop-base/autobuild/build
+++ b/meta-bases/desktop-base/autobuild/build
@@ -1,7 +1,3 @@
-abinfo "Generating default wallpapers ..."
-"$SRCDIR"/generate.py \
-    -o "$PKGDIR"
-
 abinfo "Installing distribution logos ..."
 install -Dvm644 "$SRCDIR"/../logo/aosc-os-gdm.svg \
     "$PKGDIR"/usr/share/pixmaps/aosc-os-gdm.svg

--- a/meta-bases/desktop-base/spec
+++ b/meta-bases/desktop-base/spec
@@ -1,9 +1,3 @@
-_VER=11.0.0
-_DATE=20190706
-_LOGO_COMMIT=1cfb88ff35474dfdb8de7d1ba7ff3b1728778036
-VER=${_VER}+campanula${_DATE}
-SRCS="tbl::https://github.com/AOSC-Dev/aosc-os-artworks/archive/v${_DATE}.tar.gz \
-      git::rename=logo;commit=${_LOGO_COMMIT}::https://github.com/AOSC-Dev/logo"
-CHKSUMS="sha256::3daa54bbe12ba6046c70d11c361ec3c75d3f4a84bf762a3361649463f35e72fb \
-         SKIP"
-SUBDIR="aosc-os-artworks-${_DATE}"
+VER=11.3.1
+SRCS="git::rename=logo;commit=aa0462d91c4cee125961d5bb29eea8aa9c574359::https://github.com/AOSC-Dev/logo"
+CHKSUMS="SKIP"

--- a/runtime-data/plasma-default-settings/spec
+++ b/runtime-data/plasma-default-settings/spec
@@ -1,3 +1,3 @@
-VER=2023.10.1
+VER=2024.04.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-default-settings"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- desktop-base: remove Campanula wallpapers
    A thing of the past...
- plasma-default-settings: update to 2024.04.0
- aosc-community-wallpapers-extras-2024: new, 2024.04.1
- aosc-community-wallpapers-extras-2023: update to 2023.10.1
- aosc-community-wallpapers: update to 2024.04.0

Package(s) Affected
-------------------

- aosc-community-wallpapers-extras-2023: 1:2023.10.1
- aosc-community-wallpapers-extras-2024: 1:2024.04.1
- aosc-community-wallpapers: 1:2024.04.0
- desktop-base: 11.3.1
- plasma-default-settings: 1:2024.04.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-community-wallpapers aosc-community-wallpapers-extras-2023 aosc-community-wallpapers-extras-2024 plasma-default-settings desktop-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
