### PR TITLE
mesa (Mesa 3D Library): update to 24.0.6

### DIFF
--- a/runtime-display/mesa/autobuild/defines
+++ b/runtime-display/mesa/autobuild/defines
@@ -59,8 +59,7 @@ MESON_AFTER="-Ddri-drivers-path=/usr/lib/xorg/modules/dri \
              -Dosmesa=true \
              -Dshared-glapi=enabled \
              -Dvalgrind=enabled \
-             -Dvideo-codecs=vc1dec,h264dec,h264enc,h265dec,h265enc \
-             -Dintel-xe-kmd=enabled"
+             -Dvideo-codecs=vc1dec,h264dec,h264enc,h265dec,h265enc"
 
 MESON_AFTER__X86=" \
              ${MESON_AFTER} \

--- a/runtime-display/mesa/autobuild/patches/0001-llvmpipe-make-unnamed-global-have-internal-linkage.patch
+++ b/runtime-display/mesa/autobuild/patches/0001-llvmpipe-make-unnamed-global-have-internal-linkage.patch
@@ -1,7 +1,7 @@
-From 9ef49a1428425b3214463e952554ac69949b4ef6 Mon Sep 17 00:00:00 2001
+From f87c4ef20c5fafdbf3e861e0f5c943698d6431f3 Mon Sep 17 00:00:00 2001
 From: Yukari Chiba <i@0x7f.cc>
 Date: Fri, 3 Nov 2023 23:19:27 +0800
-Subject: [PATCH 1/5] llvmpipe: make unnamed global have internal linkage
+Subject: [PATCH 1/6] llvmpipe: make unnamed global have internal linkage
 
 ---
  src/gallium/drivers/llvmpipe/lp_state_fs.c | 1 +

--- a/runtime-display/mesa/autobuild/patches/0002-llvmpipe-add-an-implementation-with-llvm-orcjit.patch
+++ b/runtime-display/mesa/autobuild/patches/0002-llvmpipe-add-an-implementation-with-llvm-orcjit.patch
@@ -1,11 +1,12 @@
-From 9077c9e23938e3e3c05ef9fb0cc02a2d900a184a Mon Sep 17 00:00:00 2001
+From 905c95c5e895386cdb92f1b10cad63e5ba76eccf Mon Sep 17 00:00:00 2001
 From: Yukari Chiba <i@0x7f.cc>
 Date: Fri, 3 Nov 2023 23:18:47 +0800
-Subject: [PATCH 2/5] llvmpipe: add an implementation with llvm orcjit
+Subject: [PATCH 2/6] llvmpipe: add an implementation with llvm orcjit
 
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
 ---
  meson.build                                   |   7 +-
- meson_options.txt                             |   7 +
+ meson_options.txt                             |   9 +-
  src/gallium/auxiliary/draw/draw_context.c     |   4 +
  src/gallium/auxiliary/draw/draw_llvm.c        |  93 +-
  src/gallium/auxiliary/draw/draw_llvm.h        |  17 +-
@@ -34,23 +35,23 @@ Subject: [PATCH 2/5] llvmpipe: add an implementation with llvm orcjit
  .../drivers/llvmpipe/lp_texture_handle.c      |  24 +
  src/gallium/drivers/llvmpipe/meson.build      |   2 +-
  src/util/detect_arch.h                        |  23 +
- 30 files changed, 1619 insertions(+), 21 deletions(-)
+ 30 files changed, 1620 insertions(+), 22 deletions(-)
  create mode 100644 src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
  create mode 100644 src/gallium/drivers/llvmpipe/lp_test_lookup_multiple.c
 
 diff --git a/meson.build b/meson.build
-index 5c91048a3f1..506a540eb37 100644
+index 8963b314256..b192a616da1 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1725,6 +1725,7 @@ if with_clc
-   llvm_optional_modules += ['all-targets', 'windowsdriver', 'frontendhlsl']
+@@ -1720,6 +1720,7 @@ if with_clc
+   llvm_optional_modules += ['all-targets', 'windowsdriver', 'frontendhlsl', 'frontenddriver']
  endif
  draw_with_llvm = get_option('draw-use-llvm')
 +llvm_with_orcjit = get_option('llvm-orcjit')
  if draw_with_llvm
    llvm_modules += 'native'
    # lto is needded with LLVM>=15, but we don't know what LLVM verrsion we are using yet
-@@ -1733,7 +1734,7 @@ endif
+@@ -1728,7 +1729,7 @@ endif
  
  if with_amd_vk or with_gallium_radeonsi
    _llvm_version = '>= 15.0.0'
@@ -59,7 +60,7 @@ index 5c91048a3f1..506a540eb37 100644
    _llvm_version = '>= 13.0.0'
  elif with_gallium_opencl
    _llvm_version = '>= 11.0.0'
-@@ -1771,6 +1772,10 @@ if with_llvm
+@@ -1766,6 +1767,10 @@ if with_llvm
    pre_args += '-DMESA_LLVM_VERSION_STRING="@0@"'.format(dep_llvm.version())
    pre_args += '-DLLVM_IS_SHARED=@0@'.format(_shared_llvm.to_int())
  
@@ -71,13 +72,16 @@ index 5c91048a3f1..506a540eb37 100644
      error('Lavapipe requires LLVM draw support.')
    endif
 diff --git a/meson_options.txt b/meson_options.txt
-index 92ffd1d6c40..512835d75c7 100644
+index 500a2eb695f..e2f4aea73eb 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -690,3 +690,10 @@ option (
-   value : 'disabled',
-   description: 'Enable Intel Xe KMD support.'
- )
+@@ -682,4 +682,11 @@ option(
+   description : 'Build custom xmlconfig (driconf) support. If disabled, ' +
+                 'the default driconf file is hardcoded into Mesa. ' +
+                 'Requires expat.'
+-)
+\ No newline at end of file
++)
 +
 +option (
 +  'llvm-orcjit',
@@ -472,7 +476,7 @@ index 2fbaecc3152..5421d0926ca 100644
 +
  #endif
 diff --git a/src/gallium/auxiliary/gallivm/lp_bld_init.c b/src/gallium/auxiliary/gallivm/lp_bld_init.c
-index cd2108f3a08..41a62578375 100644
+index 1345d85b224..68f75d49d91 100644
 --- a/src/gallium/auxiliary/gallivm/lp_bld_init.c
 +++ b/src/gallium/auxiliary/gallivm/lp_bld_init.c
 @@ -515,6 +515,11 @@ gallivm_destroy(struct gallivm_state *gallivm)
@@ -487,7 +491,7 @@ index cd2108f3a08..41a62578375 100644
  
  /**
   * Validate a function.
-@@ -670,7 +675,7 @@ gallivm_compile_module(struct gallivm_state *gallivm)
+@@ -674,7 +679,7 @@ gallivm_compile_module(struct gallivm_state *gallivm)
     ++gallivm->compiled;
  
     lp_init_printf_hook(gallivm);
@@ -1645,10 +1649,10 @@ index 7dd6a3f8596..d30aa89db33 100644
     int max_global_buffers;
     struct pipe_resource **global_buffers;
 diff --git a/src/gallium/drivers/llvmpipe/lp_screen.c b/src/gallium/drivers/llvmpipe/lp_screen.c
-index ad3d66424e1..514217dc954 100644
+index ae341bfda13..c08802730d6 100644
 --- a/src/gallium/drivers/llvmpipe/lp_screen.c
 +++ b/src/gallium/drivers/llvmpipe/lp_screen.c
-@@ -950,7 +950,11 @@ static void
+@@ -955,7 +955,11 @@ static void
  lp_disk_cache_create(struct llvmpipe_screen *screen)
  {
     struct mesa_sha1 ctx;

--- a/runtime-display/mesa/autobuild/patches/0003-llvmpipe-add-LoongArch-support-in-ORCJIT.patch
+++ b/runtime-display/mesa/autobuild/patches/0003-llvmpipe-add-LoongArch-support-in-ORCJIT.patch
@@ -1,7 +1,7 @@
-From ad5a6be92eaaa306b464f224e791cc0013ef5a0c Mon Sep 17 00:00:00 2001
+From 739ac91a4a15e067dc3df11e2f3fb2ceae536216 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Fri, 3 Nov 2023 12:57:09 +0800
-Subject: [PATCH 3/5] llvmpipe: add LoongArch support in ORCJIT
+Subject: [PATCH 3/6] llvmpipe: add LoongArch support in ORCJIT
 
 Currently set CPU features based on softdev convention.
 

--- a/runtime-display/mesa/autobuild/patches/0004-llvmpipe-append-partial-mask-to-partial-fs_variant-f.patch
+++ b/runtime-display/mesa/autobuild/patches/0004-llvmpipe-append-partial-mask-to-partial-fs_variant-f.patch
@@ -1,7 +1,7 @@
-From d081baa7207e5f2af856c46b98db105d6a1b2074 Mon Sep 17 00:00:00 2001
+From 66b09256530673793f413a6d6a71fe864ab75b04 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Fri, 1 Mar 2024 11:21:48 +0800
-Subject: [PATCH 4/5] llvmpipe: append partial mask to partial fs_variant func
+Subject: [PATCH 4/6] llvmpipe: append partial mask to partial fs_variant func
  name
 
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

--- a/runtime-display/mesa/autobuild/patches/0005-llvmpipe-add-shader-cache-support-for-ORCJIT-impleme.patch
+++ b/runtime-display/mesa/autobuild/patches/0005-llvmpipe-add-shader-cache-support-for-ORCJIT-impleme.patch
@@ -1,7 +1,8 @@
-From 9ab327b3b40997bfd13d3fae17aecfdb729b9228 Mon Sep 17 00:00:00 2001
+From 31dee80a40daab2a0eaf871c201370ade450b802 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 2 Apr 2024 21:36:21 +0800
-Subject: [PATCH] llvmpipe: add shader cache support for ORCJIT implementation
+Subject: [PATCH 5/6] llvmpipe: add shader cache support for ORCJIT
+ implementation
 
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
 ---

--- a/runtime-display/mesa/autobuild/patches/0006-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-for-LoongAr.patch.loongarch64
+++ b/runtime-display/mesa/autobuild/patches/0006-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-for-LoongAr.patch.loongarch64
@@ -1,7 +1,7 @@
-From 48c89a59f0002d51f374c18553435cb980c7a8e3 Mon Sep 17 00:00:00 2001
+From 343ab6ff8ddb90a058822fd9b98f6da2f39d19a7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
-Subject: [PATCH 5/5] fix(iris_bufmgr.c): set PAGE_SIZE as 16384 for LoongArch
+Subject: [PATCH 6/6] fix(iris_bufmgr.c): set PAGE_SIZE as 16384 for LoongArch
 
 Obviously not ideal, but this is simply meant as a preview/PoC.
 ---

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,10 +1,9 @@
-MESA_VER=24.0.4
+MESA_VER=24.0.6
 DXHEADERS_VER=1.611.0
 VER=${MESA_VER}+dxheaders${DXHEADERS_VER}
-REL=2
 SRCS="tbl::https://archive.mesa3d.org/mesa-${MESA_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
-CHKSUMS="sha256::90febd30a098cbcd97ff62ecc3dcf5c93d76f7fa314de944cfce81951ba745f0 \
+CHKSUMS="sha256::8b7a92dbe6468c18f2383700135b5fe9de836cdf0cc8fd7dbae3c7110237d604 \
          SKIP"
 SUBDIR="mesa-${MESA_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 24.0.6
    Track patches at AOSC-Tracking/mesa @ aosc/mesa-24.0.6.

Package(s) Affected
-------------------

- mesa: 1:24.0.6+dxheaders1.611.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
