### PR TITLE
libgcrypt: update to 1.10.3

### DIFF
--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,4 +1,5 @@
 VER=8.2.2
+REL=1
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz \
       file::use-url-name=true::https://github.com/loongson/Firmware/raw/main/LoongArchVirtMachine/edk2-loongarch64-code.fd \
       file::use-url-name=true::https://github.com/loongson/Firmware/raw/main/LoongArchVirtMachine/edk2-loongarch64-vars.fd"

--- a/runtime-cryptography/libgcrypt-static/spec
+++ b/runtime-cryptography/libgcrypt-static/spec
@@ -1,5 +1,4 @@
-VER=1.9.1
-REL=1
+VER=1.10.3
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-$VER.tar.bz2"
-CHKSUMS="sha256::c5a67a8b9b2bd370fb415ed1ee31c7172e5683076493cf4a3678a0fbdf0265d9"
+CHKSUMS="sha256::8b0870897ac5ac67ded568dcfadf45969cfa8a6beb0fd60af2a9eadc2a3272aa"
 CHKUPDATE="anitya::id=1623"

--- a/runtime-cryptography/libgcrypt/spec
+++ b/runtime-cryptography/libgcrypt/spec
@@ -1,4 +1,4 @@
-VER=1.9.4
+VER=1.10.3
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-$VER.tar.bz2"
-CHKSUMS="sha256::ea849c83a72454e3ed4267697e8ca03390aee972ab421e7df69dfe42b65caaf7"
+CHKSUMS="sha256::8b0870897ac5ac67ded568dcfadf45969cfa8a6beb0fd60af2a9eadc2a3272aa"
 CHKUPDATE="anitya::id=1623"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: rebuild for libgcrypt-static
- libgcrypt-static: update to 1.10.3
- libgcrypt: update to 1.10.3

Package(s) Affected
-------------------

- libgcrypt-static: 1.10.3
- libgcrypt: 1.10.3
- qemu-aarch64-static: 8.2.2-1
- qemu-alpha-static: 8.2.2-1
- qemu-arm-static: 8.2.2-1
- qemu-armeb-static: 8.2.2-1
- qemu-cris-static: 8.2.2-1
- qemu-i386-static: 8.2.2-1
- qemu-loongarch64-static: 8.2.2-1
- qemu-m68k-static: 8.2.2-1
- qemu-microblaze-static: 8.2.2-1
- qemu-microblazeel-static: 8.2.2-1
- qemu-mips-static: 8.2.2-1
- qemu-mips64-static: 8.2.2-1
- qemu-mips64el-static: 8.2.2-1
- qemu-mipsel-static: 8.2.2-1
- qemu-mipsn32-static: 8.2.2-1
- qemu-mipsn32el-static: 8.2.2-1
- qemu-nios2-static: 8.2.2-1
- qemu-or32-static: 8.2.2-1
- qemu-ppc-static: 8.2.2-1
- qemu-ppc64-static: 8.2.2-1
- qemu-ppc64le-static: 8.2.2-1
- qemu-riscv32-static: 8.2.2-1
- qemu-riscv64-static: 8.2.2-1
- qemu-s390x-static: 8.2.2-1
- qemu-sh4-static: 8.2.2-1
- qemu-sh4eb-static: 8.2.2-1
- qemu-sparc-static: 8.2.2-1
- qemu-sparc32plus-static: 8.2.2-1
- qemu-sparc64-static: 8.2.2-1
- qemu-user-static: 8.2.2-1
- qemu-x86-64-static: 8.2.2-1
- qemu: 8.2.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgcrypt libgcrypt-static qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
