### PR TITLE
ldoc: update to 1.5.0

### DIFF
--- a/app-doc/ldoc/autobuild/defines
+++ b/app-doc/ldoc/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=ldoc
 PKGSEC=doc
-PKGDEP="penlight"
+PKGDEP="lua penlight"
 PKGDES="LuaDoc-compatible documentation generation system"
+
+ABHOST=noarch

--- a/app-doc/ldoc/spec
+++ b/app-doc/ldoc/spec
@@ -1,5 +1,4 @@
-VER=1.4.6
-REL=1
-SRCS="tbl::https://github.com/stevedonovan/LDoc/archive/$VER.tar.gz"
-CHKSUMS="sha256::4b73e78a0325fb3c295d015ddb60b5cee5b647cecb5c50ce8f01319b53bd536f"
+VER=1.5.0
+SRCS="git::commit=tags/v$VER::https://github.com/stevedonovan/LDoc"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1850"

--- a/lang-lua/penlight/autobuild/defines
+++ b/lang-lua/penlight/autobuild/defines
@@ -1,4 +1,7 @@
 PKGNAME=penlight
 PKGSEC=devel
 PKGDEP="luafilesystem"
+BUILDDEP="lua"
 PKGDES="Lua libraries focusing on input data handling"
+
+ABHOST=noarch

--- a/lang-lua/penlight/spec
+++ b/lang-lua/penlight/spec
@@ -1,5 +1,4 @@
-VER=1.6.0
-SRCS="tbl::https://github.com/stevedonovan/Penlight/archive/$VER.tar.gz"
-CHKSUMS="sha256::a552d0a314f7aa94c9579746996a7aad4ed59f3187f33b4735d3e323e27354b0"
-SUBDIR="Penlight-$VER"
+VER=1.14.0
+SRCS="git::commit=tags/$VER::https://github.com/stevedonovan/Penlight"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1854"


### PR DESCRIPTION
Topic Description
-----------------

- ldoc: update to 1.5.0
    - Add lua as runtime dependency.
    - Mark as noarch as there are no compiled binaries in this package.
- penlight: update to 1.14.0
    - Also mark as noarch as there's no compiled binaries in this package.
    - Add lua as build depedency.

Package(s) Affected
-------------------

- ldoc: 1.5.0
- penlight: 1.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit penlight ldoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
