### PR TITLE
WineHQ Survey (April, 2024)

### DIFF
--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,16 +1,16 @@
 __GECKO_VER=2.47.4
-__MONO_VER=9.0.0
-WINE_VER=9.3
+__MONO_VER=9.1.0
+WINE_VER=9.7
 VER=${WINE_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${WINE_VER:0:1}.x/wine-${WINE_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${WINE_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
-CHKSUMS="sha256::148b2e34147d1fa148415637c723c99f4376e92c84e90cc1d0e00ad4ed3b1793 \
+CHKSUMS="sha256::d9f3c333656e88bd4cef5331f34b1c8b69c964a52759eef745d8ddae51a15353 \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \
-         sha256::d73d440c08ebd67c93fbd6534f4f1b4e98aa07342f9c7d98c8aaeb74755eb9cf"
+         sha256::601169d0203b291fbfd946b356a9538855e01de22abd470ded73baf312c88767"
 CHKUPDATE="anitya::id=15657"
 SUBDIR="wine-${WINE_VER}"

--- a/app-emulation/winetricks-zh/autobuild/patches/0001-disable-version-check.patch
+++ b/app-emulation/winetricks-zh/autobuild/patches/0001-disable-version-check.patch
@@ -1,4 +1,4 @@
-From 54d690eab7390302e207affa60c5532238ceba65 Mon Sep 17 00:00:00 2001
+From 0012f861e70e2b6117fc6b3608922e493a6aae3f Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 1 Apr 2019 15:52:56 +0800
 Subject: [PATCH] disable version check
@@ -8,12 +8,12 @@ Subject: [PATCH] disable version check
  1 file changed, 3 insertions(+)
 
 diff --git a/winetricks-zh b/winetricks-zh
-index 056cecb..81d09d3 100755
+index 9c53c37..54e76bf 100755
 --- a/winetricks-zh
 +++ b/winetricks-zh
 @@ -8,6 +8,9 @@
  # (This doesn't change often, use the sha256sum of the file when reporting problems)
- WINETRICKS_VERSION=20220411-next
+ WINETRICKS_VERSION=20240105-next
  
 +# Disable version check
 +WINETRICKS_LATEST_VERSION_CHECK='disabled'
@@ -22,5 +22,5 @@ index 056cecb..81d09d3 100755
  # You should see an o with two dots over it here [ö]
  # You should see a micro (u with a tail) here [µ]
 -- 
-2.43.0
+2.44.0
 

--- a/app-emulation/winetricks-zh/spec
+++ b/app-emulation/winetricks-zh/spec
@@ -1,5 +1,4 @@
-VER=20220411.100
-REL=1
-SRCS="git::commit=tags/$VER::https://github.com/hillwoodroc/winetricks-zh/"
+VER=20240105.1
+SRCS="git::commit=tags/$VER::https://github.com/hillwoodroc/winetricks-zh"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227369"


### PR DESCRIPTION
Topic Description
-----------------

- winetricks-zh: update to 20240105.1
- wine: update to 9.7+gecko2.47.4+mono9.1.0

Package(s) Affected
-------------------

- wine: 3:9.7+gecko2.47.4+mono9.1.0
- winetricks-zh: 20240105.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine winetricks-zh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
