### PR TITLE
systemd: show unit description in systemd messages

### DIFF
--- a/app-admin/systemd/autobuild/defines
+++ b/app-admin/systemd/autobuild/defines
@@ -111,7 +111,7 @@ MESON_AFTER="-Dmode=release \
              -Dinstall-sysconfdir=true \
              -Dfallback-hostname=aosc \
              -Ddefault-hierarchy=unified \
-             -Dstatus-unit-format-default=name \
+             -Dstatus-unit-format-default=combined \
              -Dtime-epoch=0 \
              -Dclock-valid-range-usec-max=473364000000000 \
              -Ddefault-user-shell=/bin/bash \

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,5 +1,5 @@
 VER=255.3
-REL=3
+REL=4
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd-stable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205088"


### PR DESCRIPTION
Topic Description
-----------------

- systemd: show unit description in systemd messages
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- systemd: 1:255.3-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
