### PR TITLE
fix dotnet-8.0 build

### DIFF
--- a/lang-dotnet/dotnet-host/spec
+++ b/lang-dotnet/dotnet-host/spec
@@ -4,7 +4,7 @@ REL=1
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-x64.tar.gz"
 CHKSUMS__AMD64="sha512::5c23889d3e6effa85d46c0e1969ce876c686723ae47bddf2cf9c0b1d99affde3f60c04063c2467027aa4163e9a981ef601250a7e8d14ddc6b365c89b24029c80"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::b0f0f2b4dc0a31b06cc3af541a3c44260317ca3a4414a5d50e6cf859d93821b3d2c2246baec9f96004aeb1eb0e353631283b11cf3acc134d4694f0ed71c9503d"
+CHKSUMS__ARM64="sha512::d11ce8867dc91d9e9b333753cc7b9677204898485d044dfbbfabe5c5eee43091580a11c3029fca4138cfa9576f84e23fc11bcffa44fcaf5c3d8e617a3cd18802"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm.tar.gz"
 CHKSUMS__ARMV7HF="sha512::4194840a6f1235808d1f1f4ff42046b6f11584c64fca65eb54b65c4dd924400679ae9e1f20efe582dda958f1838c5c125eb72da1d2fdcdd8628dcc20c35c6b88"
 


### PR DESCRIPTION
Topic Description
-----------------

- dotnet-8.0: fix dotnet-host arm64 build

Package(s) Affected
-------------------

- aspnetcore-runtime-8.0: 8.0.4
- aspnetcore-targeting-pack-8.0: 8.0.4
- dotnet-apphost-pack-8.0: 8.0.4
- dotnet-host: 8.0.4-1
- dotnet-hostfxr-8.0: 8.0.4
- dotnet-runtime-8.0: 8.0.4
- dotnet-sdk-8.0: 8.0.204
- dotnet-targeting-pack-8.0: 8.0.4
- dotnet-templates-8.0: 8.0.204

Security Update?
----------------

No

Build Order
-----------

```
#buildit aspnetcore-runtime-8.0 aspnetcore-targeting-pack-8.0 dotnet-apphost-pack-8.0 dotnet-host dotnet-hostfxr-8.0 dotnet-runtime-8.0 dotnet-sdk-8.0 dotnet-targeting-pack-8.0 dotnet-templates-8.0
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
