### PR TITLE
qt-5: fix FTBFS after libproxy and ninja update

### DIFF
--- a/runtime-desktop/qt-5/autobuild/patches/0001-Fedora-QtBase-Fix-build-with-libxkbcommon-1.6.0.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0001-Fedora-QtBase-Fix-build-with-libxkbcommon-1.6.0.patch
@@ -1,7 +1,7 @@
 From 570180894dd56fdb7ba12827608a67f486c8317e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 21:52:54 +0800
-Subject: [PATCH 01/18] [Fedora] QtBase: Fix build with libxkbcommon >= 1.6.0
+Subject: [PATCH 01/22] [Fedora] QtBase: Fix build with libxkbcommon >= 1.6.0
 
 ---
  .../platformsupport/input/xkbcommon/qxkbcommon.cpp  | 13 +++++++++----
@@ -32,5 +32,5 @@ index f1e478274c..6d93768b10 100644
          // Special keys from X.org - This include multimedia keys,
          // wireless/bluetooth/uwb keys, special launcher keys, etc.
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0002-LoongArchLinux-QtBase-Add-LoongArch-definition-for-d.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0002-LoongArchLinux-QtBase-Add-LoongArch-definition-for-d.patch
@@ -1,7 +1,7 @@
 From 286f0e0515eeee2b872713bbb17e98c87dd1c1e4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 22:02:10 +0800
-Subject: [PATCH 02/18] [LoongArchLinux] QtBase: Add LoongArch definition for
+Subject: [PATCH 02/22] [LoongArchLinux] QtBase: Add LoongArch definition for
  double-conversion
 
 ---
@@ -21,5 +21,5 @@ index 70e697ca00..fecd82efbf 100644
      defined(__AARCH64EL__) || defined(__aarch64__) || defined(__AARCH64EB__) || \
      defined(__riscv) || \
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0003-OpenMandriva-QtBase-Work-around-PySide2-brokenness.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0003-OpenMandriva-QtBase-Work-around-PySide2-brokenness.patch
@@ -1,7 +1,7 @@
 From 8ba54e21505f84603f3bf1287c1a40203d5efbfc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 21:49:26 +0800
-Subject: [PATCH 03/18] [OpenMandriva] QtBase: Work around PySide2 brokenness
+Subject: [PATCH 03/22] [OpenMandriva] QtBase: Work around PySide2 brokenness
 
 ---
  qtbase/src/gui/kernel/qevent.h                | 22 +++++++++----------
@@ -145,5 +145,5 @@ index 9d940be2c0..b7dc19b5af 100644
  
      QPointF pos() const;
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0004-Fedora-QtLocation-Fix-build-with-GCC-10.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0004-Fedora-QtLocation-Fix-build-with-GCC-10.patch
@@ -1,7 +1,7 @@
 From 6da21dfcd9e8c0d46b97e5672e9e3331587fbbe8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 21:49:56 +0800
-Subject: [PATCH 04/18] [Fedora] QtLocation: Fix build with GCC >= 10
+Subject: [PATCH 04/22] [Fedora] QtLocation: Fix build with GCC >= 10
 
 ---
  .../src/3rdparty/mapbox-gl-native/include/mbgl/util/string.hpp   | 1 +
@@ -45,5 +45,5 @@ index bc959c9a73..2fc62bba74 100644
  
  namespace mbgl {
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0005-ALT-Linux-QtLocation-Fix-build-with-GCC-13.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0005-ALT-Linux-QtLocation-Fix-build-with-GCC-13.patch
@@ -1,7 +1,7 @@
 From 1f95e596fc9eb3c107f0b0bf0dd879c91d961ac5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 22:00:34 +0800
-Subject: [PATCH 05/18] [ALT Linux] QtLocation: Fix build with GCC >= 13
+Subject: [PATCH 05/22] [ALT Linux] QtLocation: Fix build with GCC >= 13
 
 ---
  .../src/3rdparty/mapbox-gl-native/include/mbgl/util/geometry.hpp | 1 +
@@ -19,5 +19,5 @@ index a28c59a47d..92d928a377 100644
  #include <mapbox/geometry/point_arithmetic.hpp>
  #include <mapbox/geometry/for_each_point.hpp>
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0006-LoongArchLinux-QtScript-Add-LoongArch-support.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0006-LoongArchLinux-QtScript-Add-LoongArch-support.patch
@@ -1,7 +1,7 @@
 From c360f13ca98c44231d4b9749e6f612930c235f02 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 22:02:57 +0800
-Subject: [PATCH 06/18] [LoongArchLinux] QtScript: Add LoongArch support
+Subject: [PATCH 06/22] [LoongArchLinux] QtScript: Add LoongArch support
 
 ---
  .../javascriptcore/JavaScriptCore/runtime/JSValue.h      | 8 ++++++++
@@ -71,5 +71,5 @@ index a4695a261f..df5212605d 100644
  #endif
  
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0007-QtWebEngine-AArch64-Enable-condbranch-fix.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0007-QtWebEngine-AArch64-Enable-condbranch-fix.patch
@@ -1,7 +1,7 @@
 From 80cbddc84c0951b45033417df9f9e06950d25077 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 21:42:34 +0800
-Subject: [PATCH 07/18] QtWebEngine: (AArch64) Enable condbranch fix
+Subject: [PATCH 07/22] QtWebEngine: (AArch64) Enable condbranch fix
 
 ---
  .../chromium/third_party/ffmpeg/libavcodec/aarch64/videodsp.S | 4 +++-
@@ -22,5 +22,5 @@ index 24067cc2af..419784e1f3 100644
          ret
  endfunc
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0008-QtWebEngine-Add-missing-include-for-GCC-13.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0008-QtWebEngine-Add-missing-include-for-GCC-13.patch
@@ -1,7 +1,7 @@
 From 32e87beb0b8ccde5f71d59e0f396474a5cdfab64 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 21:47:45 +0800
-Subject: [PATCH 08/18] QtWebEngine: Add missing include for GCC >= 13
+Subject: [PATCH 08/22] QtWebEngine: Add missing include for GCC >= 13
 
 ---
  .../chromium/third_party/skia/src/utils/SkParseColor.cpp       | 3 +++
@@ -22,5 +22,5 @@ index 7260365b2c..0dc3497062 100644
      "aliceblue",
      "antiquewhite",
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0009-QtWebEngine-Enable-GL-acceleration-on-Lima.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0009-QtWebEngine-Enable-GL-acceleration-on-Lima.patch
@@ -1,7 +1,7 @@
 From f300746a8c57996a5dfcc21ccfa5c88a06a6256c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 21:41:49 +0800
-Subject: [PATCH 09/18] QtWebEngine: Enable GL acceleration on Lima
+Subject: [PATCH 09/22] QtWebEngine: Enable GL acceleration on Lima
 
 ---
  .../src/3rdparty/chromium/gpu/config/gpu_driver_bug_list.json  | 3 +--
@@ -22,5 +22,5 @@ index b8330f2d24..3b0e4f6237 100644
          "disable_gl_rgb_format"
        ]
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0010-Fedora-QtWebEngine-Fix-build-with-GCC-13.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0010-Fedora-QtWebEngine-Fix-build-with-GCC-13.patch
@@ -1,7 +1,7 @@
 From b5c5dfdb98b7e46811acb73c6df5b1233d7809a6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 21:51:23 +0800
-Subject: [PATCH 10/18] [Fedora] QtWebEngine: Fix build with GCC >= 13
+Subject: [PATCH 10/22] [Fedora] QtWebEngine: Fix build with GCC >= 13
 
 ---
  qtwebengine/src/3rdparty/chromium/base/debug/profiler.h     | 1 +
@@ -530,5 +530,5 @@ index a10409f397..b9f5e59d8a 100644
  
  class BrowsingDataRemoverDelegateQt : public content::BrowsingDataRemoverDelegate {
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0011-QtWebKit-Fix-build-with-Python-3.9.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0011-QtWebKit-Fix-build-with-Python-3.9.patch
@@ -1,7 +1,7 @@
 From b95e490c330737628f0e599d3cf2c28b6e32d25c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 21:43:01 +0800
-Subject: [PATCH 11/18] QtWebKit: Fix build with Python >= 3.9
+Subject: [PATCH 11/22] QtWebKit: Fix build with Python >= 3.9
 
 ---
  qtwebkit/Source/JavaScriptCore/generate-bytecode-files | 2 +-
@@ -21,5 +21,5 @@ index c5dab429c7..af3431275e 100644
          print("Unexpected error parsing {0}: {1}".format(bytecodeJSONFile, sys.exc_info()))
  
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0012-QtWebKit-Fix-build-with-Bison-3.7.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0012-QtWebKit-Fix-build-with-Bison-3.7.patch
@@ -1,7 +1,7 @@
 From 8c12a036fe4075dddee7ef5de2ab9c141cadd26c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 21:43:29 +0800
-Subject: [PATCH 12/18] QtWebKit: Fix build with Bison >= 3.7
+Subject: [PATCH 12/22] QtWebKit: Fix build with Bison >= 3.7
 
 ---
  qtwebkit/Source/WebCore/css/makegrammar.pl | 21 +--------------------
@@ -39,5 +39,5 @@ index 5d63b08102..9435701c70 100644
 -unlink("$fileBase.hpp");
 -
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0013-QtWebKit-Fix-build-with-GLib-2.70.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0013-QtWebKit-Fix-build-with-GLib-2.70.patch
@@ -1,7 +1,7 @@
 From 63f72c7e40797c181c543e792cb9fd69a6ff1489 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 21:46:50 +0800
-Subject: [PATCH 13/18] QtWebKit: Fix build with GLib >= 2.70
+Subject: [PATCH 13/22] QtWebKit: Fix build with GLib >= 2.70
 
 ---
  qtwebkit/Source/WTF/wtf/glib/GRefPtr.h | 1 -
@@ -20,5 +20,5 @@ index d05084b66a..abd5f77cce 100644
  namespace WTF {
  
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0014-LoongArchLinux-QtWebKit-Add-LoongArch-support.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0014-LoongArchLinux-QtWebKit-Add-LoongArch-support.patch
@@ -1,7 +1,7 @@
 From e7fa982a5bffae9ed54a804e17a7c457fa74ec30 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 22:03:37 +0800
-Subject: [PATCH 14/18] [LoongArchLinux] QtWebKit: Add LoongArch support
+Subject: [PATCH 14/22] [LoongArchLinux] QtWebKit: Add LoongArch support
 
 ---
  qtwebkit/CMakeLists.txt                       | 2 ++
@@ -82,5 +82,5 @@ index 889642cee7..a90287d990 100644
  #elif defined(_M_IX86) || defined(__i386__)
  #if defined(_WIN32)
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0015-Debian-QtWebKit-Fix-build-for-riscv64.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0015-Debian-QtWebKit-Fix-build-for-riscv64.patch
@@ -1,7 +1,7 @@
 From 4650cbb113477972d34f1743553a8e6225b95a50 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 22:05:04 +0800
-Subject: [PATCH 15/18] [Debian] QtWebKit: Fix build for riscv64
+Subject: [PATCH 15/22] [Debian] QtWebKit: Fix build for riscv64
 
 ---
  qtwebkit/CMakeLists.txt                       | 2 ++
@@ -75,5 +75,5 @@ index a90287d990..b13616295b 100644
  #elif defined(_M_IX86) || defined(__i386__)
  #if defined(_WIN32)
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0016-Fedora-QtWebKit-Fix-missing-cstdint-for-GCC-13.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0016-Fedora-QtWebKit-Fix-missing-cstdint-for-GCC-13.patch
@@ -1,7 +1,7 @@
 From a767a5a593fb79d69da060297ac0b2eabb7d10dc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 22:01:06 +0800
-Subject: [PATCH 16/18] [Fedora] QtWebKit: Fix missing <cstdint> for GCC >= 13
+Subject: [PATCH 16/22] [Fedora] QtWebKit: Fix missing <cstdint> for GCC >= 13
 
 ---
  qtwebkit/Source/ThirdParty/ANGLE/src/common/mathutil.h | 1 +
@@ -20,5 +20,5 @@ index 7959da8bdc..c86afd61e1 100644
  namespace gl
  {
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0017-FreeBSD-QtWebKit-Fix-build-with-Ruby-3.2.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0017-FreeBSD-QtWebKit-Fix-build-with-Ruby-3.2.patch
@@ -1,7 +1,7 @@
 From 67bcc47136178cf89de7a72a532de86bbf73273a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 28 Feb 2024 21:48:25 +0800
-Subject: [PATCH 17/18] [FreeBSD] QtWebKit: Fix build with Ruby >= 3.2
+Subject: [PATCH 17/22] [FreeBSD] QtWebKit: Fix build with Ruby >= 3.2
 
 ---
  qtwebkit/Source/JavaScriptCore/offlineasm/parser.rb | 6 +++---
@@ -32,5 +32,5 @@ index b445112452..cd1cffaec6 100644
                  # ignore
                  @idx += 1
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0018-forkfd-linux-add-support-for-LoongArch.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0018-forkfd-linux-add-support-for-LoongArch.patch
@@ -1,7 +1,7 @@
 From f91955f648b19736862619074b2c9720f1e83da5 Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <git@xen0n.name>
 Date: Tue, 25 Oct 2022 12:14:07 +0800
-Subject: [PATCH 18/18] forkfd/linux: add support for LoongArch
+Subject: [PATCH 18/22] forkfd/linux: add support for LoongArch
 
 This architecture is not CLONE_BACKWARDS in any way.
 
@@ -29,5 +29,5 @@ index ffe0e9a5e2..b1f5408d11 100644
       * but since both values are 0, there's no harm. */
      return syscall(__NR_clone, cloneflags, child_stack, ptid, ctid, newtls);
 -- 
-2.43.0
+2.44.0
 

--- a/runtime-desktop/qt-5/autobuild/patches/0019-QPageSize-make-PageSizeId-ctor-non-explicit.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0019-QPageSize-make-PageSizeId-ctor-non-explicit.patch
@@ -1,0 +1,36 @@
+From 1c1363586d0e60bba1e18fbff58eb4baf9c1d61b Mon Sep 17 00:00:00 2001
+From: Marc Mutz <marc.mutz@kdab.com>
+Date: Mon, 19 Apr 2021 09:42:41 +0200
+Subject: [PATCH 19/22] QPageSize: make PageSizeId ctor non-explicit
+
+A QPageSize::PageSizeId is a faithful representation of a QPageSize,
+so the corresponding QPageSize ctor shouldn't be explicit.
+
+[ChangeLog][QtGui][QPageSize] Conversion from a QPageSize::PageSizeId
+is now implicit.
+
+Change-Id: I2d32da370c032949686757400cb7c28583d9d8ac
+Reviewed-by: Edward Welbourne <edward.welbourne@qt.io>
+Reviewed-by: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
+(cherry picked from commit c8f380bd13f077cd797edbdb55723a2524f55c78)
+Reviewed-by: Qt CI Bot <qt_ci_bot@qt-project.org>
+---
+ qtbase/src/gui/painting/qpagesize.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/qtbase/src/gui/painting/qpagesize.h b/qtbase/src/gui/painting/qpagesize.h
+index 133274760f..5b53eae458 100644
+--- a/qtbase/src/gui/painting/qpagesize.h
++++ b/qtbase/src/gui/painting/qpagesize.h
+@@ -228,7 +228,7 @@ public:
+     };
+ 
+     QPageSize();
+-    explicit QPageSize(PageSizeId pageSizeId);
++    /*implicit*/ QPageSize(PageSizeId pageSizeId);
+     explicit QPageSize(const QSize &pointSize,
+                        const QString &name = QString(),
+                        SizeMatchPolicy matchPolicy = FuzzyMatch);
+-- 
+2.44.0
+

--- a/runtime-desktop/qt-5/autobuild/patches/0020-Deepin-auto-select-opengl-or-opengles.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0020-Deepin-auto-select-opengl-or-opengles.patch
@@ -1,3 +1,26 @@
+From 5d196bf2ae999ff9a6187b6598d9dd10d591bc12 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Thu, 25 Apr 2024 05:31:42 -0700
+Subject: [PATCH 20/22] [Deepin] auto select opengl or opengles
+
+Adapt a patch from Linux Deepin to auto select GLES.
+
+The patch is modified to allow it to work on 5.15. Setting
+QT_XCB_GL_INTEGRATION=xcb_egl is necessary for it to work now.
+
+Tested on Lichee Pi 4A with PowerVR closed GLES driver (and llvmpipe as
+GLX driver).
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ .../xcb/gl_integrations/qxcbglintegration.cpp | 208 ++++++++++++++++++
+ .../xcb/gl_integrations/qxcbglintegration.h   |  20 ++
+ .../xcb_egl/qxcbeglintegration.cpp            |   5 +
+ .../gl_integrations/xcb_egl/qxcbeglwindow.cpp |   8 +-
+ .../xcb_glx/qglxintegration.cpp               |   4 +
+ .../src/plugins/platforms/xcb/xcb_qpa_lib.pro |   2 +-
+ 6 files changed, 245 insertions(+), 2 deletions(-)
+
 diff --git a/qtbase/src/plugins/platforms/xcb/gl_integrations/qxcbglintegration.cpp b/qtbase/src/plugins/platforms/xcb/gl_integrations/qxcbglintegration.cpp
 index 59401d2ce7..6cfa9a5ac3 100644
 --- a/qtbase/src/plugins/platforms/xcb/gl_integrations/qxcbglintegration.cpp
@@ -310,3 +333,6 @@ index a5d05faa9c..1b0405493b 100644
  DEFINES += QT_NO_FOREACH
  
  QT += \
+-- 
+2.44.0
+

--- a/runtime-desktop/qt-5/autobuild/patches/0021-Use-pkgconfig-in-order-to-find-libproxy-configuratio.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0021-Use-pkgconfig-in-order-to-find-libproxy-configuratio.patch
@@ -1,0 +1,32 @@
+From 32ce7749f94131e91773a549305e000cc1fe8e34 Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Wed, 24 May 2023 20:21:33 +0200
+Subject: [PATCH 21/22] Use pkgconfig in order to find libproxy configuration
+
+>=libproxy-0.5 moved proxy.h into a non-default include search path.
+
+See also:
+https://github.com/libproxy/libproxy/issues/226#issuecomment-1557064225
+https://bugs.gentoo.org/906879
+
+Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>
+---
+ qtbase/src/network/configure.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/qtbase/src/network/configure.json b/qtbase/src/network/configure.json
+index 271ff164ac..ffba2d1eea 100644
+--- a/qtbase/src/network/configure.json
++++ b/qtbase/src/network/configure.json
+@@ -53,7 +53,7 @@
+             },
+             "headers": "proxy.h",
+             "sources": [
+-                "-lproxy"
++                { "type": "pkgConfig", "args": "libproxy-1.0" }
+             ]
+         },
+         "openssl_headers": {
+-- 
+2.44.0
+

--- a/runtime-desktop/qt-5/autobuild/patches/0022-Gentoo-Fix-ninja-race-condition-in-webengine.patch
+++ b/runtime-desktop/qt-5/autobuild/patches/0022-Gentoo-Fix-ninja-race-condition-in-webengine.patch
@@ -1,0 +1,37 @@
+From 0e9ad3cbe3ecb6b835bf0733be279b667d14c795 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Thu, 25 Apr 2024 06:40:25 -0700
+Subject: [PATCH 22/22] [Gentoo] Fix ninja race condition in webengine
+
+---
+ qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn       | 1 +
+ .../src/3rdparty/chromium/qtwebengine/browser/pdf/BUILD.gn       | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn b/qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn
+index 1466f33d46..fe812cad61 100644
+--- a/qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn
++++ b/qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn
+@@ -166,6 +166,7 @@ jumbo_static_library("browser") {
+     "//components/services/storage/dom_storage:local_storage_proto",
+     "//components/services/storage/public/cpp",
+     "//components/services/storage/public/mojom",
++    "//components/spellcheck:buildflags",
+     "//components/system_media_controls",
+     "//components/tracing:startup_tracing",
+     "//components/ui_devtools",
+diff --git a/qtwebengine/src/3rdparty/chromium/qtwebengine/browser/pdf/BUILD.gn b/qtwebengine/src/3rdparty/chromium/qtwebengine/browser/pdf/BUILD.gn
+index 253ab8c863..4c9b94dada 100644
+--- a/qtwebengine/src/3rdparty/chromium/qtwebengine/browser/pdf/BUILD.gn
++++ b/qtwebengine/src/3rdparty/chromium/qtwebengine/browser/pdf/BUILD.gn
+@@ -6,6 +6,7 @@ source_set("pdf") {
+   ]
+ 
+   deps = [
++    "//chrome/app:generated_resources",
+     "//content/public/browser",
+   ]
+ }
+-- 
+2.44.0
+

--- a/runtime-desktop/qt-5/spec
+++ b/runtime-desktop/qt-5/spec
@@ -1,5 +1,5 @@
 VER=5.15.5+webengine5.15.10+webkit5.212.0+kde20220705
-REL=8
+REL=9
 SRCS="https://repo.aosc.io/aosc-repacks/qt-5-$VER.tar.xz"
 CHKSUMS="sha256::724101b5dbb845579b636bca4f89e12bacee736af57dbc78e30fe83a62092165"
 SUBDIR="qt-${VER:0:1}"


### PR DESCRIPTION
Topic Description
-----------------

- qt-5: fix FTBFS after libproxy and ninja update

Package(s) Affected
-------------------

- qt-5: 1:5.15.5+webengine5.15.10+webkit5.212.0+kde20220705-9

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
