### PR TITLE
bash: update to 5.2.26

### DIFF
--- a/app-shells/bash/autobuild/patches/0022-bash52-022.patch
+++ b/app-shells/bash/autobuild/patches/0022-bash52-022.patch
@@ -1,0 +1,53 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-022
+
+Bug-Reported-by:	srobertson@peratonlabs.com
+Bug-Reference-ID:
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2022-09/msg00049.html
+
+Bug-Description:
+
+It's possible for readline to try to zero out a line that's not null-
+terminated, leading to a memory fault.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-5.2-patched/lib/readline/display.c	2022-04-05 10:47:31.000000000 -0400
+--- lib/readline/display.c	2022-12-13 13:11:22.000000000 -0500
+***************
+*** 2684,2692 ****
+  
+    if (visible_line)
+!     {
+!       temp = visible_line;
+!       while (*temp)
+! 	*temp++ = '\0';
+!     }
+    rl_on_new_line ();
+    forced_display++;
+--- 2735,2740 ----
+  
+    if (visible_line)
+!     memset (visible_line, 0, line_size);
+! 
+    rl_on_new_line ();
+    forced_display++;
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 21
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 22
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0023-bash52-023.patch
+++ b/app-shells/bash/autobuild/patches/0023-bash52-023.patch
@@ -1,0 +1,64 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-023
+
+Bug-Reported-by:	Emanuele Torre <torreemanuele6@gmail.com>
+Bug-Reference-ID:	<20230206140824.1710288-1-torreemanuele6@gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2023-02/msg00045.html
+
+Bug-Description:
+
+Running `local -' multiple times in a shell function would overwrite the
+original saved set of options.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-5.2-patched/builtins/declare.def	2023-01-04 20:40:28.000000000 -0500
+--- builtins/declare.def	2023-02-08 15:36:49.000000000 -0500
+***************
+*** 421,429 ****
+        if (local_var && variable_context && STREQ (name, "-"))
+  	{
+  	  var = make_local_variable ("-", 0);
+! 	  FREE (value_cell (var));		/* just in case */
+! 	  value = get_current_options ();
+! 	  var_setvalue (var, value);
+! 	  VSETATTR (var, att_invisible);
+  	  NEXT_VARIABLE ();
+  	}
+--- 421,437 ----
+        if (local_var && variable_context && STREQ (name, "-"))
+  	{
++ 	  int o;
++ 
++ 	  o = localvar_inherit;
++ 	  localvar_inherit = 0;
+  	  var = make_local_variable ("-", 0);
+! 	  localvar_inherit = o;
+! 
+! 	  if (value_cell (var) == NULL)		/* no duplicate instances */
+! 	    {
+! 	      value = get_current_options ();
+! 	      var_setvalue (var, value);
+! 	      VSETATTR (var, att_invisible);
+! 	    }
+  	  NEXT_VARIABLE ();
+  	}
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 22
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 23
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0024-bash52-024.patch
+++ b/app-shells/bash/autobuild/patches/0024-bash52-024.patch
@@ -1,0 +1,88 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-024
+
+Bug-Reported-by:	Marco <maroloccio@gmail.com>
+Bug-Reference-ID:	<eaf9af76-c4ed-8b61-c517-22ed980529d3@gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2023-02/msg00044.html
+
+Bug-Description:
+
+Fix bug where associative array compound assignment would not expand tildes
+in values.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-20230105/arrayfunc.c	Thu Jan  5 14:23:28 2023
+--- arrayfunc.c	Wed Feb  8 16:27:48 2023
+***************
+*** 651,655 ****
+  	}	      
+  
+!       aval = expand_subscript_string (v, 0);
+        if (aval == 0)
+  	{
+--- 651,655 ----
+  	}	      
+  
+!       aval = expand_assignment_string_to_string (v, 0);
+        if (aval == 0)
+  	{
+***************
+*** 843,847 ****
+        if (assoc_p (var))
+  	{
+! 	  val = expand_subscript_string (val, 0);
+  	  if (val == 0)
+  	    {
+--- 843,847 ----
+        if (assoc_p (var))
+  	{
+! 	  val = expand_assignment_string_to_string (val, 0);
+  	  if (val == 0)
+  	    {
+***************
+*** 1031,1035 ****
+    nword[i++] = w[ind++];
+  
+!   t = expand_subscript_string (w+ind, 0);
+    s = (t && strchr (t, CTLESC)) ? quote_escapes (t) : t;
+    value = sh_single_quote (s ? s : "");
+--- 1031,1035 ----
+    nword[i++] = w[ind++];
+  
+!   t = expand_assignment_string_to_string (w+ind, 0);
+    s = (t && strchr (t, CTLESC)) ? quote_escapes (t) : t;
+    value = sh_single_quote (s ? s : "");
+*** ../bash-20230201/subst.c	Mon Jan 30 16:19:46 2023
+--- subst.c	Mon Feb  6 16:25:22 2023
+***************
+*** 10803,10807 ****
+--- 10803,10811 ----
+    ret = (char *)NULL;
+  
++ #if 0
+    td.flags = W_NOPROCSUB|W_NOTILDE|W_NOSPLIT2;	/* XXX - W_NOCOMSUB? */
++ #else
++   td.flags = W_NOPROCSUB|W_NOSPLIT2;	/* XXX - W_NOCOMSUB? */
++ #endif
+    td.word = savestring (string);		/* in case it's freed on error */
+  
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 23
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 24
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0025-bash52-025.patch
+++ b/app-shells/bash/autobuild/patches/0025-bash52-025.patch
@@ -1,0 +1,46 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-025
+
+Bug-Reported-by:	Andrew Neff <andrew.neff@visionsystemsinc.com>
+Bug-Reference-ID:	<SA1P110MB1357F68AFD51BB225019EFF48D2B9@SA1P110MB1357.NAMP110.PROD.OUTLOOK.COM>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2022-10/msg00100.html
+
+Bug-Description:
+
+Make sure a subshell checks for and handles any terminating signals before
+exiting (which might have arrived after the command completed) so the parent
+and any EXIT trap will see the correct value for $?.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-5.2.9/execute_cmd.c	2022-11-02 10:36:54.000000000 -0400
+--- execute_cmd.c	2022-10-27 16:52:55.000000000 -0400
+***************
+*** 1726,1729 ****
+--- 1726,1732 ----
+  						     : EXECUTION_SUCCESS;
+  
++   /* Check for terminating signals before we return to our caller, which we
++      expect to exit immediately anyway. */
++   CHECK_TERMSIG;
+  
+    /* If we were explicitly placed in a subshell with (), we need
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 24
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 25
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0026-bash52-026.patch
+++ b/app-shells/bash/autobuild/patches/0026-bash52-026.patch
@@ -1,0 +1,48 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-026
+
+Bug-Reported-by:	Stefan Klinger <readline-gnu.org@stefan-klinger.de>
+Bug-Reference-ID:
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-readline/2023-08/msg00018.html
+
+Bug-Description:
+
+The custom color prefix that readline uses to color possible completions
+must have a leading `.'.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-5.2-patched/lib/readline/colors.c	2021-12-08 11:38:25.000000000 -0500
+--- lib/readline/colors.c	2023-08-28 16:40:04.000000000 -0400
+***************
+*** 74,78 ****
+  static void restore_default_color (void);
+  
+! #define RL_COLOR_PREFIX_EXTENSION	"readline-colored-completion-prefix"
+  
+  COLOR_EXT_TYPE *_rl_color_ext_list = 0;
+--- 74,78 ----
+  static void restore_default_color (void);
+  
+! #define RL_COLOR_PREFIX_EXTENSION	".readline-colored-completion-prefix"
+  
+  COLOR_EXT_TYPE *_rl_color_ext_list = 0;
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 25
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 26
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/spec
+++ b/app-shells/bash/spec
@@ -1,4 +1,4 @@
-VER=5.2.21
+VER=5.2.26
 SRCS="https://ftp.gnu.org/gnu/bash/bash-${VER%.*}.tar.gz"
 CHKSUMS="sha256::a139c166df7ff4471c5e0733051642ee5556c1cc8a4a78f145583c5c81ab32fb"
 CHKUPDATE="anitya::id=166"


### PR DESCRIPTION
Topic Description
-----------------

- bash: update to 5.2.26

Package(s) Affected
-------------------

- bash: 5.2.26

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
