### PR TITLE
bash-completion: update to 2.13.0

### DIFF
--- a/app-shells/bash-completion/spec
+++ b/app-shells/bash-completion/spec
@@ -1,4 +1,4 @@
-VER=2.11
-SRCS="tbl::https://github.com/scop/bash-completion/releases/download/$VER/bash-completion-$VER.tar.xz"
+VER=2.13.0
+SRCS="git::commit=tags/$VER::https://github.com/scop/bash-completion"
 CHKSUMS="sha256::73a8894bad94dee83ab468fa09f628daffd567e8bef1a24277f1e9a0daf911ac"
 CHKUPDATE="anitya::id=5667"


### PR DESCRIPTION
Topic Description
-----------------

- bash-completion: update to 2.13.0

Package(s) Affected
-------------------

- bash-completion: 1:2.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-completion
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
