### PR TITLE
osu-lazer: update to 2024.412.1

### DIFF
--- a/app-games/osu-lazer/autobuild/defines
+++ b/app-games/osu-lazer/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=osu-lazer
 PKGSEC=games
 PKGDES="Rhythm is just a click away!"
-PKGDEP="alsa-lib desktop-file-utils libgdiplus dotnet-runtime-6.0"
-BUILDDEP="dotnet-sdk-6.0"
+PKGDEP="alsa-lib desktop-file-utils libgdiplus dotnet-runtime-8.0"
+BUILDDEP="dotnet-sdk-8.0"
 
 FAIL_ARCH="!(amd64)"
 NOSTATIC=0

--- a/app-games/osu-lazer/spec
+++ b/app-games/osu-lazer/spec
@@ -1,4 +1,4 @@
-VER=2022.1022.0
+VER=2024.412.1
 SRCS="tbl::https://github.com/ppy/osu/archive/$VER.tar.gz"
-CHKSUMS="sha256::490e6bbe561f22619822bca0a72e2235a8b6395adaa1e0840abf1e80b5f0e3c5"
+CHKSUMS="sha256::6797f21fb91fd96e49246bfa5c3421d51e0311392fcd0992b229cb51101eae25"
 CHKUPDATE="anitya::id=227666"


### PR DESCRIPTION
Topic Description
-----------------

- osu-lazer: update to 2024.412.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- osu-lazer: 2024.412.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit osu-lazer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
