### PR TITLE
glib: skip document generation for mips64r6el

### DIFF
--- a/runtime-common/glib/autobuild/defines
+++ b/runtime-common/glib/autobuild/defines
@@ -43,7 +43,8 @@ MESON_AFTER="-Dselinux=disabled \
 #     ERROR: Unknown variable "libgdbus_example_objectmanager_dep"
 MESON_AFTER__MIPS64R6EL=" \
              ${MESON_AFTER} \
-             -Dtests=false"
+             -Dtests=false \
+	     -Ddocumentation=false"
 MESON_AFTER__RETRO=" \
              ${MESON_AFTER} \
              -Dlibmount=disabled \

--- a/runtime-common/glib/spec
+++ b/runtime-common/glib/spec
@@ -1,5 +1,5 @@
 VER=2.80.0
-REL=1
+REL=2
 SRCS="https://download.gnome.org/sources/glib/${VER:0:4}/glib-$VER.tar.xz"
 CHKSUMS="sha256::8228a92f92a412160b139ae68b6345bd28f24434a7b5af150ebe21ff587a561d"
 CHKUPDATE="anitya::id=10024"


### PR DESCRIPTION
Topic Description
-----------------

- glib:Skip document generation for mips64r6el

Package(s) Affected
-------------------

- glib: 2.80.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit glib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
