### PR TITLE
neofetch (Neofetch): update to 7.3.11

### DIFF
--- a/app-utils/neofetch/autobuild/patches/0001-neofetch-AOSC-OS-print-dpkg-architecture-where-possi.patch
+++ b/app-utils/neofetch/autobuild/patches/0001-neofetch-AOSC-OS-print-dpkg-architecture-where-possi.patch
@@ -1,17 +1,18 @@
-From c869026639d38eab8342e428788f2076a657ca48 Mon Sep 17 00:00:00 2001
+From 5b7bf6cf969429b5068dc151018882ecfb129a56 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Fri, 21 Oct 2022 18:06:45 -0700
-Subject: [PATCH] neofetch: (AOSC OS) print dpkg architecture where possible
+Subject: [PATCH 1/2] neofetch: (AOSC OS) print dpkg architecture where
+ possible
 
 ---
  neofetch | 6 +++++-
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/neofetch b/neofetch
-index 48b96d21..341aca51 100755
+index c2f56f04..a07a8e68 100755
 --- a/neofetch
 +++ b/neofetch
-@@ -4893,7 +4893,11 @@ cache_uname() {
+@@ -6195,7 +6195,11 @@ cache_uname() {
  
      kernel_name="${uname[0]}"
      kernel_version="${uname[1]}"
@@ -22,7 +23,8 @@ index 48b96d21..341aca51 100755
 +        kernel_machine="${uname[2]}"
 +    fi
  
-     if [[ "$kernel_name" == "Darwin" ]]; then
-         # macOS can report incorrect versions unless this is 0.
+     if [[ "$kernel_name" == "Darwin" ]] ||
+        [[ "$kernel_name" == "FreeBSD" && -f /System/Library/CoreServices/SystemVersion.plist ]]; then
 -- 
-2.37.1
+2.44.0
+

--- a/app-utils/neofetch/autobuild/patches/0002-neofetch-AOSC-OS-add-quotation-marks-around-architec.patch
+++ b/app-utils/neofetch/autobuild/patches/0002-neofetch-AOSC-OS-add-quotation-marks-around-architec.patch
@@ -1,18 +1,18 @@
-From 2c392729e23db9a89307c2fa032d4427d9471c27 Mon Sep 17 00:00:00 2001
+From 6916763b8e9be69cac3cd20eb4344d39460f45df Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Fri, 21 Oct 2022 18:16:03 -0700
-Subject: [PATCH] neofetch: (AOSC OS) add quotation marks around architecture
- name
+Subject: [PATCH 2/2] neofetch: (AOSC OS) add quotation marks around
+ architecture name
 
 ---
  neofetch | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/neofetch b/neofetch
-index 341aca51..abe510e3 100755
+index a07a8e68..0dc4bc97 100755
 --- a/neofetch
 +++ b/neofetch
-@@ -1226,7 +1226,7 @@ get_distro() {
+@@ -1496,7 +1496,7 @@ get_distro() {
      esac
  
      [[ $os_arch == on ]] && \
@@ -22,4 +22,5 @@ index 341aca51..abe510e3 100755
      [[ ${ascii_distro:-auto} == auto ]] && \
          ascii_distro=$(trim "$distro")
 -- 
-2.37.1
+2.44.0
+

--- a/app-utils/neofetch/spec
+++ b/app-utils/neofetch/spec
@@ -1,7 +1,4 @@
-VER=7.3.10+git20230913
-# Note: Temporarily using a snapshot to introduce our new logo.
-SRCS="git::commit=74d1bb5622c057cd75ff8efae7878d289e57a6a3::https://github.com/hykilpikonna/neofetch"
-# Note: Revert to this on next release.
-# SRCS="git::commit=tags/neofetch-$VER::https://github.com/hykilpikonna/neofetch"
+VER=7.3.11
+SRCS="git::commit=tags/neofetch-$VER::https://github.com/hykilpikonna/neofetch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16261"


### PR DESCRIPTION
Topic Description
-----------------

- neofetch: update to 7.3.11

Package(s) Affected
-------------------

- neofetch: 2:7.3.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit neofetch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
