### PR TITLE
discord (Discord): update to 0.0.52

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.51
+VER=0.0.52
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::c3cccb79aa895dd6c8ebb5ff503c522d0c597a2e5eada6bf0643196be183a589"
+CHKSUMS="sha256::e5c27379d12ec5d1a2ce051e9c1f838c57fe330624f2e4c7e2d8e25b3babfaaf"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- discord: update to 0.0.52

Package(s) Affected
-------------------

- discord: 0.0.52

Security Update?
----------------

No

Build Order
-----------

```
#buildit discord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
