### PR TITLE
virtualbox (Oracle VM VirtualBox): update to 7.0.16

### DIFF
--- a/app-virtualization/virtualbox/01-host/patches/0001-Arch-Linux-fix-Frontends-VirtualBox-disable-update-c.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0001-Arch-Linux-fix-Frontends-VirtualBox-disable-update-c.patch
@@ -1,4 +1,4 @@
-From 0eb0c0e91f96e9b35bcbe4ce5c19b9018e5e5e77 Mon Sep 17 00:00:00 2001
+From baad29140e2809f5af2205a51ec3ea94be76af13 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 12:26:00 +0800
 Subject: [PATCH 1/8] [Arch Linux] fix(Frontends/VirtualBox): disable update

--- a/app-virtualization/virtualbox/01-host/patches/0002-Arch-Linux-fix-VBox-Additions-disable-unneeded-vboxv.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0002-Arch-Linux-fix-VBox-Additions-disable-unneeded-vboxv.patch
@@ -1,4 +1,4 @@
-From e770ed93fd57e5ee38663624ed2b8f7c8f886f63 Mon Sep 17 00:00:00 2001
+From 24f615f7023d6c5c8f8078d16264c03b1c42ea1d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 12:28:09 +0800
 Subject: [PATCH 2/8] [Arch Linux] fix(VBox/Additions): disable unneeded

--- a/app-virtualization/virtualbox/01-host/patches/0003-properly-handle-i3wm.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0003-properly-handle-i3wm.patch
@@ -1,4 +1,4 @@
-From 06e52e3bd1abaa6b0bfe037646689fdb58cdbcdc Mon Sep 17 00:00:00 2001
+From a9a651a5ff8947948154d3953f456422e445cd8d Mon Sep 17 00:00:00 2001
 From: Christian Hesse <mail@eworm.de>
 Date: Tue, 17 Jan 2023 22:04:08 +0100
 Subject: [PATCH 3/8] properly handle i3wm

--- a/app-virtualization/virtualbox/01-host/patches/0004-Arch-Linux-fix-VBox-Additions-disable-vbglR3GuestCtr.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0004-Arch-Linux-fix-VBox-Additions-disable-vbglR3GuestCtr.patch
@@ -1,4 +1,4 @@
-From baa898755cad91e157abc0b78b0432210485d78f Mon Sep 17 00:00:00 2001
+From e23be2007f4c2e2eb28b754e210031d7131e49a0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 12:32:48 +0800
 Subject: [PATCH 4/8] [Arch Linux] fix(VBox/Additions): disable

--- a/app-virtualization/virtualbox/01-host/patches/0005-support-building-from-dkms.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0005-support-building-from-dkms.patch
@@ -1,4 +1,4 @@
-From 88ea67bb5dab236af4b916b8d52ecb7f36afd9f7 Mon Sep 17 00:00:00 2001
+From aff29c6f8ea6dbb90d7994a8b5006efe883f88b2 Mon Sep 17 00:00:00 2001
 From: Christian Hesse <mail@eworm.de>
 Date: Mon, 17 Oct 2022 16:30:32 +0200
 Subject: [PATCH 5/8] support building from dkms

--- a/app-virtualization/virtualbox/01-host/patches/0006-upate-xclient-script.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0006-upate-xclient-script.patch
@@ -1,4 +1,4 @@
-From 25e056916adfb0f0b12ec1b3d6e34192270577ff Mon Sep 17 00:00:00 2001
+From b1ece064555060d4e46c0d23d693d0abd4a4c521 Mon Sep 17 00:00:00 2001
 From: Christian Hesse <mail@eworm.de>
 Date: Mon, 17 Oct 2022 16:40:29 +0200
 Subject: [PATCH 6/8] upate xclient script

--- a/app-virtualization/virtualbox/01-host/patches/0007-chore-use-the-wheel-group-for-hardware-access.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0007-chore-use-the-wheel-group-for-hardware-access.patch
@@ -1,4 +1,4 @@
-From 6d33c36554906e6564f880acb6d319ce08ea4aeb Mon Sep 17 00:00:00 2001
+From 25525b7f7232863e191d4806ed8c0b40a1919456 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 12:37:48 +0800
 Subject: [PATCH 7/8] chore: use the wheel group for hardware access
@@ -113,7 +113,7 @@ index 285072e2..5b8b1db6 100644
          member of this group.
        </para>
 diff --git a/doc/manual/en_US/user_Installation.xml b/doc/manual/en_US/user_Installation.xml
-index 12a83841..e8f8adcb 100644
+index 2661b259..091ea59a 100644
 --- a/doc/manual/en_US/user_Installation.xml
 +++ b/doc/manual/en_US/user_Installation.xml
 @@ -824,7 +824,7 @@
@@ -834,7 +834,7 @@ index 6893a6c0..b2e74daa 100755
    chown root:$group /dev/vboxusb 2>/dev/null
    mkdir "$devdir" -m 0750 2>/dev/null
 diff --git a/src/VBox/Installer/linux/debian/postinst b/src/VBox/Installer/linux/debian/postinst
-index 197ede68..bc789b5a 100755
+index 923608f6..13a29970 100755
 --- a/src/VBox/Installer/linux/debian/postinst
 +++ b/src/VBox/Installer/linux/debian/postinst
 @@ -59,9 +59,9 @@ if [ "$1" = "configure" ]; then
@@ -848,7 +848,7 @@ index 197ede68..bc789b5a 100755
 +    addgroup --system wheel || true
    fi
  
-   # The starters need to be Suid root. They drop the privileges before starting
+   # The starters need to be set-uid-to-root. They drop the privileges before
 diff --git a/src/VBox/Installer/linux/debian/templates b/src/VBox/Installer/linux/debian/templates
 index 341644b5..ec12350b 100644
 --- a/src/VBox/Installer/linux/debian/templates
@@ -867,7 +867,7 @@ index 341644b5..ec12350b 100644
   werden dieser Gruppe zugewiesen.
  
 diff --git a/src/VBox/Installer/linux/install.sh b/src/VBox/Installer/linux/install.sh
-index 9c11eb9b..de0099fc 100755
+index d32d9270..772604c8 100755
 --- a/src/VBox/Installer/linux/install.sh
 +++ b/src/VBox/Installer/linux/install.sh
 @@ -51,7 +51,7 @@ CONFIG_DIR="/etc/vbox"
@@ -880,10 +880,10 @@ index 9c11eb9b..de0099fc 100755
  LICENSE_ACCEPTED=""
  PREV_INSTALLATION=""
 diff --git a/src/VBox/Installer/linux/rpm/VirtualBox.tmpl.spec b/src/VBox/Installer/linux/rpm/VirtualBox.tmpl.spec
-index 829322aa..f1c3deba 100644
+index bab95a70..4994bf53 100644
 --- a/src/VBox/Installer/linux/rpm/VirtualBox.tmpl.spec
 +++ b/src/VBox/Installer/linux/rpm/VirtualBox.tmpl.spec
-@@ -299,9 +299,9 @@ rm -f /etc/vbox/module_not_compiled
+@@ -294,9 +294,9 @@ rm -f /etc/vbox/module_not_compiled
  # create users groups (disable with INSTALL_NO_GROUP=1 in /etc/default/virtualbox)
  if [ "$INSTALL_NO_GROUP" != "1" ]; then
    echo
@@ -896,10 +896,10 @@ index 829322aa..f1c3deba 100644
  
  %if %{?rpm_mdv:1}%{!?rpm_mdv:0}
 diff --git a/src/VBox/Installer/linux/vboxdrv.sh b/src/VBox/Installer/linux/vboxdrv.sh
-index 4077c169..07a2e2cb 100755
+index 5e6842cf..635bb3dc 100755
 --- a/src/VBox/Installer/linux/vboxdrv.sh
 +++ b/src/VBox/Installer/linux/vboxdrv.sh
-@@ -92,7 +92,7 @@ if test -u "${VIRTUALBOX}"; then
+@@ -94,7 +94,7 @@ if test -u "${INSTALL_DIR}/VirtualBoxVM" || test '!' -e "${INSTALL_DIR}/VirtualB
      GROUP=root
      DEVICE_MODE=0600
  else
@@ -908,7 +908,7 @@ index 4077c169..07a2e2cb 100755
      DEVICE_MODE=0660
  fi
  
-@@ -589,7 +589,7 @@ See the documentation for your Linux distribution." console
+@@ -591,7 +591,7 @@ See the documentation for your Linux distribution." console
      # of USB access.  The USB code checks for the existence of that path.
      if grep -q usb_device /proc/devices; then
          mkdir -p -m 0750 /dev/vboxusb 2>/dev/null

--- a/app-virtualization/virtualbox/01-host/patches/0008-fix-dxvk-native-1.9.2a-fix-build-with-GCC-13.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0008-fix-dxvk-native-1.9.2a-fix-build-with-GCC-13.patch
@@ -1,4 +1,4 @@
-From 83a5bfbbad0e729afeac5f89c0ecea10804ec35c Mon Sep 17 00:00:00 2001
+From a9458412f9c7e8fcee0074bd59142f4bca35a571 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 12:38:50 +0800
 Subject: [PATCH 8/8] fix(dxvk-native-1.9.2a): fix build with GCC >= 13

--- a/app-virtualization/virtualbox/spec
+++ b/app-virtualization/virtualbox/spec
@@ -1,11 +1,11 @@
-VER=7.0.14
+VER=7.0.16
 # Note: Sometimes Oracle seems to release fix-up tarballs.
-VBOX_REV=a
-UBUNTU_VBOX_VER="161095~Ubuntu~jammy"
+VBOX_REV=
+UBUNTU_VBOX_VER="162802~Ubuntu~jammy"
 SRCS="tbl::https://download.virtualbox.org/virtualbox/$VER/VirtualBox-${VER}${VBOX_REV}.tar.bz2 \
       file::rename=virtualbox.deb::https://download.virtualbox.org/virtualbox/$VER/virtualbox-${VER%.*}_${VER}-${UBUNTU_VBOX_VER}_amd64.deb \
       file::rename=VBoxGuestAdditions.iso::https://download.virtualbox.org/virtualbox/$VER/VBoxGuestAdditions_$VER.iso"
-CHKSUMS="sha256::79ac8bc97af9f6e7b57d67dd00cfb8c9e46efd64cca888ee174b0f06e6b0c419 \
-         sha256::43aa0932f73433e7a6b450a82708d275ee5f2c98375cfa708a46ecf75b3d4edc \
-         sha256::0efbcb9bf4722cb19292ae00eba29587432e918d3b1f70905deb70f7cf78e8ce"
+CHKSUMS="sha256::ca9062daf386a1810282503f83a7baa296ad46c4fc38aa988bca57f037e811fb \
+         sha256::32c88448e26a7a19d87beea5333b61edb6e6b5cc4f66f941f5c081085708e33e \
+         sha256::269dcd2217aedfea65daaa75317ffa32c0e3110e541f7dce74a8d16973eca0df"
 CHKUPDATE="anitya::id=14449"


### PR DESCRIPTION
Topic Description
-----------------

- virtualbox: update to 7.0.16
    Track patches at AOSC-Tracking/virtualbox @ aosc/v7.0.16.

Package(s) Affected
-------------------

- virtualbox-guest: 7.0.16
- virtualbox: 7.0.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit virtualbox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
