### PR TITLE
chromium (Chromium browsers): update to 124.0.6367.91

### DIFF
--- a/app-web/chromium/spec
+++ b/app-web/chromium/spec
@@ -1,11 +1,11 @@
-VER=124.0.6367.60
+VER=124.0.6367.91
 LAUNCHERVER=8
 SRCS="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$VER.tar.xz \
       https://github.com/foutrelis/chromium-launcher/archive/v$LAUNCHERVER.tar.gz \
       file::rename=chromium-$VER.txt::https://chromium.googlesource.com/chromium/src/+/$VER?format=TEXT"
-CHKSUMS="sha256::ebd553527149cb8477a522df90acd6cea2388a6f431e2db589a0301df1d0cae2 \
+CHKSUMS="sha256::376cdcdb46b23eca7f3e6cdb933f27e73968ffb537258d70be503850bbbf1787 \
          sha256::213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a \
-         sha256::11d5dd6ff430911af7b01c608789b3866eceb552368e9d806908c27cd82eb026"
+         sha256::a0c1632fcecdca104bc26746d7f766cb592d18ea30ddf070011fb3fbc11c1bb5"
 SUBDIR="chromium-$VER"
 CHKUPDATE="anitya::id=13344"
 ENVREQ__ARM64="total_mem_per_core=3"

--- a/app-web/google-chrome/spec
+++ b/app-web/google-chrome/spec
@@ -1,4 +1,4 @@
-VER=124.0.6367.60
+VER=124.0.6367.91
 SRCS="file::rename=google-chrome-stable_current_amd64.deb::https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_$VER-1_amd64.deb"
-CHKSUMS="sha256::ad26e2806e7fc5b2f7d9dd67b4e9fa827672c52a60ae0d61ee56ff443e1844e2"
+CHKSUMS="sha256::0b209b650e5c7bc58b4edd89552a9b0e42c36e8138065a2267ca497dfddd9926"
 CHKUPDATE="anitya::id=5349"


### PR DESCRIPTION
Topic Description
-----------------

- google-chrome: update to 124.0.6367.91
- chromium: update to 124.0.6367.91

Package(s) Affected
-------------------

- chromium: 124.0.6367.91
- google-chrome: 124.0.6367.91

Security Update?
----------------

No

Build Order
-----------

```
#buildit chromium google-chrome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
