### PR TITLE
grub: fix bash completions

### DIFF
--- a/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,7 +1,7 @@
 From 2ec97c359ea87a2152e4076770c9ec8f7cbd225d Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:54 +0200
-Subject: [PATCH 01/16] Revert "templates: Properly disable the os-prober by
+Subject: [PATCH 01/21] Revert "templates: Properly disable the os-prober by
  default"
 
 This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.
@@ -71,5 +71,5 @@ index 656301eaf..30f27f15b 100644
  
  osx_entry() {
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,7 +1,7 @@
 From a3daa95d2769516586f7c38af93029663c9133a4 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:58 +0200
-Subject: [PATCH 02/16] Revert "templates: Disable the os-prober by default"
+Subject: [PATCH 02/21] Revert "templates: Disable the os-prober by default"
 
 This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
 ---
@@ -69,5 +69,5 @@ index 30f27f15b..f300e46fc 100644
  
  osx_entry() {
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
+++ b/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
@@ -1,7 +1,7 @@
 From 6bd3d7c7b9e643f6452e8dff6fcebc60d2c4d512 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 17:49:45 -0400
-Subject: [PATCH 03/16] Don't add '*' to highlighted row
+Subject: [PATCH 03/21] Don't add '*' to highlighted row
 
 It is already highlighted.
 ---
@@ -22,5 +22,5 @@ index b1321eb26..b147e0657 100644
    grub_print_ucs4_menu (unicode_title,
  			unicode_title + len,
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
+++ b/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
@@ -1,7 +1,7 @@
 From e5c241ea0ea922abbb2ecb8b3140518a6e2a03cd Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:08:23 -0400
-Subject: [PATCH 04/16] Fix border spacing now that we aren't displaying it
+Subject: [PATCH 04/21] Fix border spacing now that we aren't displaying it
 
 ---
  grub-core/normal/menu_text.c | 6 +++---
@@ -28,5 +28,5 @@ index b147e0657..e5960fd65 100644
    geo->timeout_lines = 2;
  
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
+++ b/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
@@ -1,7 +1,7 @@
 From 2b35e4db8d9f1f9cab8004e0761a28be960fbf7f Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:30:55 -0400
-Subject: [PATCH 05/16] Indent menu entries
+Subject: [PATCH 05/21] Indent menu entries
 
 ---
  grub-core/normal/menu_text.c | 3 ++-
@@ -22,5 +22,5 @@ index e5960fd65..fd1de05e3 100644
    grub_print_ucs4_menu (unicode_title,
  			unicode_title + len,
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
+++ b/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
@@ -1,7 +1,7 @@
 From d21e8096b9cc9eecfe6da4bb101c6d5d43cec3c5 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:59:36 -0400
-Subject: [PATCH 06/16] Fix margins
+Subject: [PATCH 06/21] Fix margins
 
 ---
  grub-core/normal/menu_text.c | 8 +++-----
@@ -33,5 +33,5 @@ index fd1de05e3..371524bf2 100644
      - geo->timeout_lines /* timeout */
      - 1 /* empty final line  */;
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
+++ b/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
@@ -1,7 +1,7 @@
 From 8ea6cc861054a03a1b437356a0b9b114a0d21adf Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Fri, 21 Jun 2013 14:44:08 -0400
-Subject: [PATCH 07/16] Use -2 instead of -1 for our right-hand margin, so
+Subject: [PATCH 07/21] Use -2 instead of -1 for our right-hand margin, so
  linewrapping works (#976643).
 
 Signed-off-by: Peter Jones <grub2-owner@fedoraproject.org>
@@ -23,5 +23,5 @@ index 371524bf2..f83f7ca54 100644
    geo->first_entry_y = 3; /* three empty lines*/
  
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
+++ b/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
@@ -1,7 +1,7 @@
 From 59c31c490870dd98bc6ca72862a97862bcef0c1b Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 14 Mar 2011 14:27:42 -0400
-Subject: [PATCH 08/16] Don't say "GNU/Linux" in generated menus.
+Subject: [PATCH 08/21] Don't say "GNU/Linux" in generated menus.
 
 ---
  util/grub.d/10_linux.in     | 4 ++--
@@ -41,5 +41,5 @@ index 94dd8be13..98ee5bc58 100644
  fi
  
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
@@ -1,7 +1,7 @@
 From 12e6fa95ada35a999b46adcbc35a34a73d178ebf Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 16:47:33 -0400
-Subject: [PATCH 09/16] Don't draw a border around the menu
+Subject: [PATCH 09/21] Don't draw a border around the menu
 
 It looks cleaner without it.
 ---
@@ -70,5 +70,5 @@ index f83f7ca54..982ef9100 100644
    grub_term_highlight_color = old_color_highlight;
    geo->timeout_y = geo->first_entry_y + geo->num_entries
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
+++ b/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
@@ -1,7 +1,7 @@
 From 8a14427edcdf93bc2c38822465d1082672bb9263 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 10:52:32 -0400
-Subject: [PATCH 10/16] Use the standard margin for the timeout string
+Subject: [PATCH 10/21] Use the standard margin for the timeout string
 
 So that it aligns with the other messages
 ---
@@ -39,5 +39,5 @@ index 982ef9100..986877454 100644
      }
  
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
+++ b/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
@@ -1,7 +1,7 @@
 From 5ff724e6a6e01cb6f03f5ce09d6cb01a44ad3d67 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:14 -0800
-Subject: [PATCH 11/16] grub-mkrescue: specify -iso-level 3
+Subject: [PATCH 11/21] grub-mkrescue: specify -iso-level 3
 
 This allows GRUB rescue ISOs to boot on LoongArch firmware.
 ---
@@ -22,5 +22,5 @@ index abcc1c2f5..27696e034 100644
    iso9660_dir = grub_util_make_temporary_dir ();
    grub_util_info ("temporary iso9660 dir is `%s'", iso9660_dir);
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
+++ b/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
@@ -1,7 +1,7 @@
 From b127120988f3d85ebc75c493eba08fc54c8b99dd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:42 -0800
-Subject: [PATCH 12/16] 10_linux: do not count intel-ucode image as a valid
+Subject: [PATCH 12/21] 10_linux: do not count intel-ucode image as a valid
  initrd
 
 ---
@@ -23,5 +23,5 @@ index c9bde9182..e896c0c1a 100644
      # no initrd or builtin initramfs, it can't work here.
      if [ "x${GRUB_DEVICE_PARTUUID}" = "x" ] \
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
+++ b/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
@@ -1,7 +1,7 @@
 From 42a8d6a924f700586328325eb3abe28c4055cc5e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:12:01 -0800
-Subject: [PATCH 13/16] util: add GRUB_COLOR_* variables
+Subject: [PATCH 13/21] util: add GRUB_COLOR_* variables
 
 ---
  util/grub-mkconfig.in    | 2 ++
@@ -41,5 +41,5 @@ index 6a316a5ba..6816e09d4 100644
  gfxterm=0;
  for x in ${GRUB_TERMINAL_INPUT} ${GRUB_TERMINAL_OUTPUT}; do
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
@@ -1,7 +1,7 @@
 From 5b839a619f7d871de5d6666bde4875c6a262edec Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:26:57 -0800
-Subject: [PATCH 14/16] grub-core: drop GRUB title from the menu
+Subject: [PATCH 14/21] grub-core: drop GRUB title from the menu
 
 We did not display it before, and it's really not very useful since we don't
 encourage reinstalling GRUB anyway.
@@ -23,5 +23,5 @@ index bd4431000..ca123caac 100644
      return;
  
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
+++ b/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
@@ -1,7 +1,7 @@
 From 4b607755f602b9844d637c7b7f48617600764238 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Jan 2024 13:58:02 +0800
-Subject: [PATCH 15/18] grub-install: add /efi to the candidate of the ESP
+Subject: [PATCH 15/21] grub-install: add /efi to the candidate of the ESP
  mountpoints
 
 ---
@@ -29,5 +29,5 @@ index 7dc5657bb..c5eef8ac6 100644
  	    The EFI System Partition may have been given directly using
  	    --root-directory.
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
+++ b/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
@@ -1,7 +1,7 @@
 From df48d64d21efa1e01ab1cf24f30e07e9efecf923 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 10 Nov 2023 10:57:02 +0800
-Subject: [PATCH 16/18] commands: add new command memsize
+Subject: [PATCH 16/21] commands: add new command memsize
 
 - This command traverses the entire GRUB memory map, adds the size of each
   region together. The result is the total amount of system memory
@@ -361,5 +361,5 @@ index 000000000..9c67971ac
 +  grub_unregister_extcmd (cmd);
 +}
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
+++ b/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
@@ -1,7 +1,7 @@
 From 0ded438a6ab7e8d11922582bf90a7dfa6b7fdcd4 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Mon, 10 Jul 2023 00:14:13 +0800
-Subject: [PATCH 17/18] commands: add new command 'pause'
+Subject: [PATCH 17/21] commands: add new command 'pause'
 
 - Simple enough, this command prints out a prompt, either pre-defined or
   user specified, and awaits a key stroke from the user.
@@ -88,5 +88,5 @@ index 000000000..39d193a17
 +  grub_unregister_extcmd (cmd);
 +}
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
+++ b/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
@@ -1,7 +1,7 @@
 From f608b5788b0e653ad9c2bbdcf078287f2a88d204 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 21:30:22 +0800
-Subject: [PATCH 18/18] normal: align countdown text with rest of the UI
+Subject: [PATCH 18/21] normal: align countdown text with rest of the UI
 
 And add an extra blank line above it.
 ---
@@ -23,5 +23,5 @@ index 986877454..584620a52 100644
    if (data->timeout_msg == TIMEOUT_TERSE
        || data->timeout_msg == TIMEOUT_TERSE_NO_MARGIN)
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
+++ b/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
@@ -1,7 +1,7 @@
 From 1e1ce61d967cc992b44c5206cc0cfe21cd44c7ff Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 22:21:55 +0800
-Subject: [PATCH] po: add patch to disable parallel execution
+Subject: [PATCH 19/21] po: add patch to disable parallel execution
 
 - `msgfilter' might fail while processing de.po to generate de_CH.po, if
   there are too many prarallel jobs.
@@ -76,5 +76,5 @@ index 000000000..0cef9fafe
 +2.39.1
 +
 -- 
-2.39.1
+2.44.0
 

--- a/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
+++ b/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
@@ -1,0 +1,860 @@
+From 919557515accb7a58bcd91fd07cdf20f78afaf52 Mon Sep 17 00:00:00 2001
+From: Gary Lin <glin@suse.com>
+Date: Tue, 30 Jan 2024 14:41:10 +0800
+Subject: [PATCH 20/21] util/bash-completion: Load scripts on demand
+
+There are two system directories for bash-completion scripts. One is
+/usr/share/bash-completion/completions/ and the other is
+/etc/bash_completion.d/. The "etc" scripts are loaded in advance and
+for backward compatibility while the "usr" scripts are loaded on demand.
+To load scripts on demand it requires a corresponding script for every
+command. So, the main bash-completion script is split into several
+subscripts for different "grub-*" commands. To share the code the real
+completion functions are still implemented in "grub" and each
+subscript sources "grub" and invokes the corresponding function.
+
+Signed-off-by: Gary Lin <glin@suse.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ util/bash-completion.d/Makefile.am            | 114 +++++++++++++++++-
+ .../bash-completion.d/grub-bios-setup.bash.in |  30 +++++
+ .../bash-completion.d/grub-completion.bash.in |  89 ++------------
+ util/bash-completion.d/grub-editenv.bash.in   |  30 +++++
+ util/bash-completion.d/grub-install.bash.in   |  30 +++++
+ util/bash-completion.d/grub-mkconfig.bash.in  |  30 +++++
+ util/bash-completion.d/grub-mkfont.bash.in    |  30 +++++
+ util/bash-completion.d/grub-mkimage.bash.in   |  30 +++++
+ .../grub-mkpasswd-pbkdf2.bash.in              |  30 +++++
+ util/bash-completion.d/grub-mkrescue.bash.in  |  30 +++++
+ util/bash-completion.d/grub-probe.bash.in     |  30 +++++
+ util/bash-completion.d/grub-reboot.bash.in    |  30 +++++
+ .../grub-script-check.bash.in                 |  30 +++++
+ .../grub-set-default.bash.in                  |  30 +++++
+ .../grub-sparc64-setup.bash.in                |  30 +++++
+ 15 files changed, 510 insertions(+), 83 deletions(-)
+ create mode 100644 util/bash-completion.d/grub-bios-setup.bash.in
+ create mode 100644 util/bash-completion.d/grub-editenv.bash.in
+ create mode 100644 util/bash-completion.d/grub-install.bash.in
+ create mode 100644 util/bash-completion.d/grub-mkconfig.bash.in
+ create mode 100644 util/bash-completion.d/grub-mkfont.bash.in
+ create mode 100644 util/bash-completion.d/grub-mkimage.bash.in
+ create mode 100644 util/bash-completion.d/grub-mkpasswd-pbkdf2.bash.in
+ create mode 100644 util/bash-completion.d/grub-mkrescue.bash.in
+ create mode 100644 util/bash-completion.d/grub-probe.bash.in
+ create mode 100644 util/bash-completion.d/grub-reboot.bash.in
+ create mode 100644 util/bash-completion.d/grub-script-check.bash.in
+ create mode 100644 util/bash-completion.d/grub-set-default.bash.in
+ create mode 100644 util/bash-completion.d/grub-sparc64-setup.bash.in
+
+diff --git a/util/bash-completion.d/Makefile.am b/util/bash-completion.d/Makefile.am
+index 136287cf1..33fff9546 100644
+--- a/util/bash-completion.d/Makefile.am
++++ b/util/bash-completion.d/Makefile.am
+@@ -1,13 +1,117 @@
+-
+ bash_completion_source = grub-completion.bash.in
+ bash_completion_script = grub
++grub_bios_setup_source = grub-bios-setup.bash.in
++grub_bios_setup_script = @grub_bios_setup@
++grub_editenv_source = grub-editenv.bash.in
++grub_editenv_script = @grub_editenv@
++grub_install_source = grub-install.bash.in
++grub_install_script = @grub_install@
++grub_mkconfig_source = grub-mkconfig.bash.in
++grub_mkconfig_script = @grub_mkconfig@
++grub_mkfont_source = grub-mkfont.bash.in
++grub_mkfont_script = @grub_mkfont@
++grub_mkimage_source = grub-mkimage.bash.in
++grub_mkimage_script = @grub_mkimage@
++grub_mkpasswd_pbkdf2_source = grub-mkpasswd-pbkdf2.bash.in
++grub_mkpasswd_pbkdf2_script = @grub_mkpasswd_pbkdf2@
++grub_mkrescue_source = grub-mkrescue.bash.in
++grub_mkrescue_script = @grub_mkrescue@
++grub_probe_source = grub-probe.bash.in
++grub_probe_script = @grub_probe@
++grub_reboot_source = grub-reboot.bash.in
++grub_reboot_script = @grub_reboot@
++grub_script_check_source = grub-script-check.bash.in
++grub_script_check_script = @grub_script_check@
++grub_set_default_source = grub-set-default.bash.in
++grub_set_default_script = @grub_set_default@
++grub_sparc64_setup_source = grub-sparc64-setup.bash.in
++grub_sparc64_setup_script = @grub_sparc64_setup@
+ 
+-EXTRA_DIST = $(bash_completion_source)
++EXTRA_DIST = $(bash_completion_source) \
++	$(grub_bios_setup_source) \
++	$(grub_editenv_source) \
++	$(grub_install_source) \
++	$(grub_mkconfig_source) \
++	$(grub_mkfont_source) \
++	$(grub_mkimage_source) \
++	$(grub_mkpasswd_pbkdf2_source) \
++	$(grub_mkrescue_source) \
++	$(grub_probe_source) \
++	$(grub_reboot_source) \
++	$(grub_script_check_source) \
++	$(grub_set_default_source) \
++	$(grub_sparc64_setup_source)
+ 
+-CLEANFILES = $(bash_completion_script) config.log
++CLEANFILES = $(bash_completion_script) \
++	$(grub_bios_setup_script) \
++	$(grub_editenv_script) \
++	$(grub_install_script) \
++	$(grub_mkconfig_script) \
++	$(grub_mkfont_script) \
++	$(grub_mkimage_script) \
++	$(grub_mkpasswd_pbkdf2_script) \
++	$(grub_mkrescure_script) \
++	$(grub_probe_script) \
++	$(grub_reboot_script) \
++	$(grub_script_check_script) \
++	$(grub_set_default_script) \
++	$(grub_sparc64_setup_script) \
++	config.log
+ 
+-bashcompletiondir = $(sysconfdir)/bash_completion.d
+-bashcompletion_DATA = $(bash_completion_script)
++bashcompletiondir = $(datarootdir)/bash-completion/completions
++bashcompletion_DATA = $(bash_completion_script) \
++	$(grub_bios_setup_script) \
++	$(grub_editenv_script) \
++	$(grub_install_script) \
++	$(grub_mkconfig_script) \
++	$(grub_mkfont_script) \
++	$(grub_mkimage_script) \
++	$(grub_mkpasswd_pbkdf2_script) \
++	$(grub_mkrescure_script) \
++	$(grub_probe_script) \
++	$(grub_reboot_script) \
++	$(grub_script_check_script) \
++	$(grub_set_default_script) \
++	$(grub_sparc64_setup_script)
+ 
+ $(bash_completion_script): $(bash_completion_source) $(top_builddir)/config.status
+ 	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_bios_setup_script): $(grub_bios_setup_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_editenv_script): $(grub_editenv_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_install_script): $(grub_install_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_mkconfig_script): $(grub_mkconfig_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_mkfont_script): $(grub_mkfont_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_mkimage_script): $(grub_mkimage_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_mkpasswd_pbkdf2_script): $(grub_mkpasswd_pbkdf2_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_mkrescue_script): $(grub_mkrescue_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_probe_script): $(grub_probe_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_reboot_script): $(grub_reboot_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_script_check_script): $(grub_script_check_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_set_default_script): $(grub_set_default_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
++
++$(grub_sparc64_setup_script): $(grub_sparc64_setup_source) $(top_builddir)/config.status
++	$(top_builddir)/config.status --file=$@:$<
+diff --git a/util/bash-completion.d/grub-bios-setup.bash.in b/util/bash-completion.d/grub-bios-setup.bash.in
+new file mode 100644
+index 000000000..2d362b5e2
+--- /dev/null
++++ b/util/bash-completion.d/grub-bios-setup.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-bios-setup@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_bios_setup () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_setup
++}
++complete -F _grub_bios_setup -o filenames @grub_bios_setup@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+diff --git a/util/bash-completion.d/grub-completion.bash.in b/util/bash-completion.d/grub-completion.bash.in
+index 213ce1e57..4c88ee901 100644
+--- a/util/bash-completion.d/grub-completion.bash.in
++++ b/util/bash-completion.d/grub-completion.bash.in
+@@ -150,7 +150,7 @@ __grub_list_modules () {
+ #
+ # grub-set-default & grub-reboot
+ #
+-_grub_set_entry () {
++__grub_set_entry () {
+     local cur prev split=false
+ 
+     COMPREPLY=()
+@@ -176,21 +176,10 @@ _grub_set_entry () {
+     fi
+ }
+ 
+-__grub_set_default_program="@grub_set_default@"
+-have ${__grub_set_default_program} && \
+-    complete -F _grub_set_entry -o filenames ${__grub_set_default_program}
+-unset __grub_set_default_program
+-
+-__grub_reboot_program="@grub_reboot@"
+-have ${__grub_reboot_program} && \
+- complete -F _grub_set_entry -o filenames ${__grub_reboot_program}
+-unset __grub_reboot_program
+-
+-
+ #
+ # grub-editenv
+ #
+-_grub_editenv () {
++__grub_editenv () {
+     local cur prev
+ 
+     COMPREPLY=()
+@@ -208,16 +197,10 @@ _grub_editenv () {
+                 create list set unset"
+ }
+ 
+-__grub_editenv_program="@grub_editenv@"
+-have ${__grub_editenv_program} && \
+- complete -F _grub_editenv -o filenames ${__grub_editenv_program}
+-unset __grub_editenv_program
+-
+-
+ #
+ # grub-mkconfig
+ #
+-_grub_mkconfig () {
++__grub_mkconfig () {
+     local cur prev
+ 
+     COMPREPLY=()
+@@ -229,16 +212,11 @@ _grub_mkconfig () {
+         _filedir
+     fi
+ }
+-__grub_mkconfig_program="@grub_mkconfig@"
+-have ${__grub_mkconfig_program} && \
+- complete -F _grub_mkconfig -o filenames ${__grub_mkconfig_program}
+-unset __grub_mkconfig_program
+-
+ 
+ #
+ # grub-setup
+ #
+-_grub_setup () {
++__grub_setup () {
+     local cur prev split=false
+ 
+     COMPREPLY=()
+@@ -264,21 +242,10 @@ _grub_setup () {
+     fi
+ }
+ 
+-__grub_bios_setup_program="@grub_bios_setup@"
+-have ${__grub_bios_setup_program} && \
+- complete -F _grub_setup -o filenames ${__grub_bios_setup_program}
+-unset __grub_bios_setup_program
+-
+-__grub_sparc64_setup_program="@grub_sparc64_setup@"
+-have ${__grub_sparc64_setup_program} && \
+- complete -F _grub_setup -o filenames ${__grub_sparc64_setup_program}
+-unset __grub_sparc64_setup_program
+-
+-
+ #
+ # grub-install
+ #
+-_grub_install () {
++__grub_install () {
+     local cur prev last split=false
+ 
+     COMPREPLY=()
+@@ -315,16 +282,11 @@ _grub_install () {
+         _filedir
+     fi
+ }
+-__grub_install_program="@grub_install@"
+-have ${__grub_install_program} && \
+- complete -F _grub_install -o filenames ${__grub_install_program}
+-unset __grub_install_program
+-
+ 
+ #
+ # grub-mkfont
+ #
+-_grub_mkfont () {
++__grub_mkfont () {
+     local cur
+ 
+     COMPREPLY=()
+@@ -337,16 +299,11 @@ _grub_mkfont () {
+         _filedir
+     fi
+ }
+-__grub_mkfont_program="@grub_mkfont@"
+-have ${__grub_mkfont_program} && \
+- complete -F _grub_mkfont -o filenames ${__grub_mkfont_program}
+-unset __grub_mkfont_program
+-
+ 
+ #
+ # grub-mkrescue
+ #
+-_grub_mkrescue () {
++__grub_mkrescue () {
+     local cur prev last
+ 
+     COMPREPLY=()
+@@ -368,16 +325,11 @@ _grub_mkrescue () {
+         _filedir
+     fi
+ }
+-__grub_mkrescue_program="@grub_mkrescue@"
+-have ${__grub_mkrescue_program} && \
+- complete -F _grub_mkrescue -o filenames ${__grub_mkrescue_program}
+-unset __grub_mkrescue_program
+-
+ 
+ #
+ # grub-mkimage
+ #
+-_grub_mkimage () {
++__grub_mkimage () {
+     local cur prev split=false
+ 
+     COMPREPLY=()
+@@ -410,16 +362,11 @@ _grub_mkimage () {
+         _filedir
+     fi
+ }
+-__grub_mkimage_program="@grub_mkimage@"
+-have ${__grub_mkimage_program} && \
+- complete -F _grub_mkimage -o filenames ${__grub_mkimage_program}
+-unset __grub_mkimage_program
+-
+ 
+ #
+ # grub-mkpasswd-pbkdf2
+ #
+-_grub_mkpasswd_pbkdf2 () {
++__grub_mkpasswd_pbkdf2 () {
+     local cur
+ 
+     COMPREPLY=()
+@@ -432,16 +379,11 @@ _grub_mkpasswd_pbkdf2 () {
+         _filedir
+     fi
+ }
+-__grub_mkpasswd_pbkdf2_program="@grub_mkpasswd_pbkdf2@"
+-have ${__grub_mkpasswd_pbkdf2_program} && \
+- complete -F _grub_mkpasswd_pbkdf2 -o filenames ${__grub_mkpasswd_pbkdf2_program}
+-unset __grub_mkpasswd_pbkdf2_program
+-
+ 
+ #
+ # grub-probe
+ #
+-_grub_probe () {
++__grub_probe () {
+     local cur prev split=false
+ 
+     COMPREPLY=()
+@@ -470,16 +412,11 @@ _grub_probe () {
+         _filedir
+     fi
+ }
+-__grub_probe_program="@grub_probe@"
+-have ${__grub_probe_program} && \
+- complete -F _grub_probe -o filenames ${__grub_probe_program}
+-unset __grub_probe_program
+-
+ 
+ #
+ # grub-script-check
+ #
+-_grub_script_check () {
++__grub_script_check () {
+     local cur
+ 
+     COMPREPLY=()
+@@ -492,10 +429,6 @@ _grub_script_check () {
+         _filedir
+     fi
+ }
+-__grub_script_check_program="@grub_script_check@"
+-have ${__grub_script_check_program} && \
+- complete -F _grub_script_check -o filenames ${__grub_script_check_program}
+-
+ 
+ # Local variables:
+ # mode: shell-script
+diff --git a/util/bash-completion.d/grub-editenv.bash.in b/util/bash-completion.d/grub-editenv.bash.in
+new file mode 100644
+index 000000000..29b1333ea
+--- /dev/null
++++ b/util/bash-completion.d/grub-editenv.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-editenv@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_editenv () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_editenv
++}
++complete -F _grub_editenv -o filenames @grub_editenv@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+diff --git a/util/bash-completion.d/grub-install.bash.in b/util/bash-completion.d/grub-install.bash.in
+new file mode 100644
+index 000000000..a89fc614a
+--- /dev/null
++++ b/util/bash-completion.d/grub-install.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-install@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_install () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_install
++}
++complete -F _grub_install -o filenames @grub_install@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+diff --git a/util/bash-completion.d/grub-mkconfig.bash.in b/util/bash-completion.d/grub-mkconfig.bash.in
+new file mode 100644
+index 000000000..862e0c58f
+--- /dev/null
++++ b/util/bash-completion.d/grub-mkconfig.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-mkconfig@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_mkconfig () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_mkconfig
++}
++complete -F _grub_mkconfig -o filenames @grub_mkconfig@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+diff --git a/util/bash-completion.d/grub-mkfont.bash.in b/util/bash-completion.d/grub-mkfont.bash.in
+new file mode 100644
+index 000000000..17baccdf5
+--- /dev/null
++++ b/util/bash-completion.d/grub-mkfont.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-mkfont@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_mkfont () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_mkfont
++}
++complete -F _grub_mkfont -o filenames @grub_mkfont@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+diff --git a/util/bash-completion.d/grub-mkimage.bash.in b/util/bash-completion.d/grub-mkimage.bash.in
+new file mode 100644
+index 000000000..a383ed3e9
+--- /dev/null
++++ b/util/bash-completion.d/grub-mkimage.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-mkimage@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_mkimage () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_mkimage
++}
++complete -F _grub_mkimage -o filenames @grub_mkimage@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+diff --git a/util/bash-completion.d/grub-mkpasswd-pbkdf2.bash.in b/util/bash-completion.d/grub-mkpasswd-pbkdf2.bash.in
+new file mode 100644
+index 000000000..32b8fd6eb
+--- /dev/null
++++ b/util/bash-completion.d/grub-mkpasswd-pbkdf2.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-mkpasswd-pbkdf2@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_mkpasswd_pbkdf2 () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_mkpasswd_pbkdf2
++}
++complete -F _grub_mkpasswd_pbkdf2 -o filenames @grub_mkpasswd_pbkdf2@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+diff --git a/util/bash-completion.d/grub-mkrescue.bash.in b/util/bash-completion.d/grub-mkrescue.bash.in
+new file mode 100644
+index 000000000..5968ba00e
+--- /dev/null
++++ b/util/bash-completion.d/grub-mkrescue.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-mkresue@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_mkrescue () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_mkrescue
++}
++complete -F _grub_mkrescue -o filenames @grub_mkrescue@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+diff --git a/util/bash-completion.d/grub-probe.bash.in b/util/bash-completion.d/grub-probe.bash.in
+new file mode 100644
+index 000000000..08400f2f1
+--- /dev/null
++++ b/util/bash-completion.d/grub-probe.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-probe@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_probe () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_probe
++}
++complete -F _grub_probe -o filenames @grub_probe@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+diff --git a/util/bash-completion.d/grub-reboot.bash.in b/util/bash-completion.d/grub-reboot.bash.in
+new file mode 100644
+index 000000000..154aecea9
+--- /dev/null
++++ b/util/bash-completion.d/grub-reboot.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-reboot@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_reboot () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_set_entry
++}
++complete -F _grub_reboot -o filenames @grub_reboot@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+diff --git a/util/bash-completion.d/grub-script-check.bash.in b/util/bash-completion.d/grub-script-check.bash.in
+new file mode 100644
+index 000000000..22d376832
+--- /dev/null
++++ b/util/bash-completion.d/grub-script-check.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-script-check@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_script_check () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_script_check
++}
++complete -F _grub_script_check -o filenames @grub_script_check@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+diff --git a/util/bash-completion.d/grub-set-default.bash.in b/util/bash-completion.d/grub-set-default.bash.in
+new file mode 100644
+index 000000000..14501b4fb
+--- /dev/null
++++ b/util/bash-completion.d/grub-set-default.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-set-default@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_set_default () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_set_entry
++}
++complete -F _grub_set_default -o filenames @grub_set_default@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+diff --git a/util/bash-completion.d/grub-sparc64-setup.bash.in b/util/bash-completion.d/grub-sparc64-setup.bash.in
+new file mode 100644
+index 000000000..6123d7b7c
+--- /dev/null
++++ b/util/bash-completion.d/grub-sparc64-setup.bash.in
+@@ -0,0 +1,30 @@
++#
++# Bash completion for @grub-sparc64-setup@
++#
++# Copyright (C) 2024  Free Software Foundation, Inc.
++#
++# GRUB is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# GRUB is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++
++_grub_sparc64_setup () {
++    . @datarootdir@/bash-completion/completions/grub && __grub_setup
++}
++complete -F _grub_sparc64_setup -o filenames @grub_sparc64_setup@
++
++# Local variables:
++# mode: shell-script
++# sh-basic-offset: 4
++# sh-indent-comment: t
++# indent-tabs-mode: nil
++# End:
++# ex: ts=4 sw=4 et filetype=sh
+-- 
+2.44.0
+

--- a/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
+++ b/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
@@ -1,0 +1,189 @@
+From 08b69851db8922397fc18f8e0f636d1661ce66f1 Mon Sep 17 00:00:00 2001
+From: Gary Lin <glin@suse.com>
+Date: Mon, 25 Mar 2024 10:11:34 +0800
+Subject: [PATCH 21/21] util/bash-completion: Fix for bash-completion 2.12
+
+_split_longopt() was the bash-completion private API and removed since
+bash-completion 2.12. This commit initializes the bash-completion
+general variables with _init_completion() to avoid the potential
+"command not found" error.
+
+Although bash-completion 2.12 introduces _comp_initialize() to deprecate
+_init_completion(), _init_completion() is still chosen for the better
+backward compatibility.
+
+Signed-off-by: Gary Lin <glin@suse.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ .../bash-completion.d/grub-completion.bash.in | 61 +++++++------------
+ 1 file changed, 22 insertions(+), 39 deletions(-)
+
+diff --git a/util/bash-completion.d/grub-completion.bash.in b/util/bash-completion.d/grub-completion.bash.in
+index 4c88ee901..749a5d3cf 100644
+--- a/util/bash-completion.d/grub-completion.bash.in
++++ b/util/bash-completion.d/grub-completion.bash.in
+@@ -151,13 +151,10 @@ __grub_list_modules () {
+ # grub-set-default & grub-reboot
+ #
+ __grub_set_entry () {
+-    local cur prev split=false
++    local cur prev words cword split
++    _init_completion -s || return
+ 
+     COMPREPLY=()
+-    cur=`_get_cword`
+-    prev=${COMP_WORDS[COMP_CWORD-1]}
+-
+-    _split_longopt && split=true
+ 
+     case "$prev" in
+         --boot-directory)
+@@ -180,11 +177,10 @@ __grub_set_entry () {
+ # grub-editenv
+ #
+ __grub_editenv () {
+-    local cur prev
++    local cur prev words cword
++    _init_completion || return
+ 
+     COMPREPLY=()
+-    cur=`_get_cword`
+-    prev=${COMP_WORDS[COMP_CWORD-1]}
+ 
+     case "$prev" in
+         create|list|set|unset)
+@@ -201,10 +197,10 @@ __grub_editenv () {
+ # grub-mkconfig
+ #
+ __grub_mkconfig () {
+-    local cur prev
++    local cur prev words cword
++    _init_completion || return
+ 
+     COMPREPLY=()
+-    cur=`_get_cword`
+ 
+     if [[ "$cur" == -* ]]; then
+         __grubcomp "$(__grub_get_options_from_help)"
+@@ -217,13 +213,10 @@ __grub_mkconfig () {
+ # grub-setup
+ #
+ __grub_setup () {
+-    local cur prev split=false
++    local cur prev words cword split
++    _init_completion -s || return
+ 
+     COMPREPLY=()
+-    cur=`_get_cword`
+-    prev=${COMP_WORDS[COMP_CWORD-1]}
+-
+-    _split_longopt && split=true
+ 
+     case "$prev" in
+         -d|--directory)
+@@ -246,15 +239,12 @@ __grub_setup () {
+ # grub-install
+ #
+ __grub_install () {
+-    local cur prev last split=false
++    local cur prev words cword split last
++    _init_completion -s || return
+ 
+     COMPREPLY=()
+-    cur=`_get_cword`
+-    prev=${COMP_WORDS[COMP_CWORD-1]}
+     last=$(__grub_get_last_option)
+ 
+-    _split_longopt && split=true
+-
+     case "$prev" in
+         --boot-directory)
+             _filedir -d
+@@ -287,10 +277,10 @@ __grub_install () {
+ # grub-mkfont
+ #
+ __grub_mkfont () {
+-    local cur
++    local cur prev words cword
++    _init_completion || return
+ 
+     COMPREPLY=()
+-    cur=`_get_cword`
+ 
+     if [[ "$cur" == -* ]]; then
+         __grubcomp "$(__grub_get_options_from_help)"
+@@ -304,11 +294,10 @@ __grub_mkfont () {
+ # grub-mkrescue
+ #
+ __grub_mkrescue () {
+-    local cur prev last
++    local cur prev words cword last
++    _init_completion || return
+ 
+     COMPREPLY=()
+-    cur=`_get_cword`
+-    prev=${COMP_WORDS[COMP_CWORD-1]}
+     last=$(__grub_get_last_option)
+ 
+     if [[ "$cur" == -* ]]; then
+@@ -330,13 +319,10 @@ __grub_mkrescue () {
+ # grub-mkimage
+ #
+ __grub_mkimage () {
+-    local cur prev split=false
++    local cur prev words cword split
++    _init_completion -s || return
+ 
+     COMPREPLY=()
+-    cur=`_get_cword`
+-    prev=${COMP_WORDS[COMP_CWORD-1]}
+-
+-    _split_longopt && split=true
+ 
+     case "$prev" in
+         -d|--directory|-p|--prefix)
+@@ -367,10 +353,10 @@ __grub_mkimage () {
+ # grub-mkpasswd-pbkdf2
+ #
+ __grub_mkpasswd_pbkdf2 () {
+-    local cur
++    local cur prev words cword
++    _init_completion || return
+ 
+     COMPREPLY=()
+-    cur=`_get_cword`
+ 
+     if [[ "$cur" == -* ]]; then
+         __grubcomp "$(__grub_get_options_from_help)"
+@@ -384,13 +370,10 @@ __grub_mkpasswd_pbkdf2 () {
+ # grub-probe
+ #
+ __grub_probe () {
+-    local cur prev split=false
++    local cur prev words cword split
++    _init_completion -s || return
+ 
+     COMPREPLY=()
+-    cur=`_get_cword`
+-    prev=${COMP_WORDS[COMP_CWORD-1]}
+-
+-    _split_longopt && split=true
+ 
+     case "$prev" in
+         -t|--target)
+@@ -417,10 +400,10 @@ __grub_probe () {
+ # grub-script-check
+ #
+ __grub_script_check () {
+-    local cur
++    local cur prev words cword
++    _init_completion || return
+ 
+     COMPREPLY=()
+-    cur=`_get_cword`
+ 
+     if [[ "$cur" == -* ]]; then
+         __grubcomp "$(__grub_get_options_from_help)"
+-- 
+2.44.0
+

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -5,6 +5,7 @@ __GRUBVER=2.12
 LINGUAS_VER=2.12-rc1
 
 VER=${__GRUBVER}+unifont${__UNIFONTVER}
+REL=1
 RETROFONTVER=20200402
 
 SRCS="git::commit=tags/grub-${__GRUBVER/\~/-};rename=grub-${__GRUBVER/\~/-}::https://git.savannah.gnu.org/git/grub.git \
@@ -52,12 +53,12 @@ CHKSUMS="SKIP \
          sha256::0cf00da56eaaf01359e1966c7826bc117f331493a3f7060243a9ed437631bcb0 \
          sha256::258d1ae35c299aaf1fff253226b214217ba4a02c3203f0dc293f13d92b44bd04 \
          sha256::9ea3261c5d721b321bc0ac32e44dbe83b417e3a952c731bdcb879ade744db42e \
-         sha256::7a481be97e8a17ec542a7c7ebc4e98452a3cc398d37dda41922f32aea458c53d \
+         sha256::de7236241340c9e8f61acd05e3a0798742c6a9244c1dae1b199b04381c02af66 \
          sha256::bd68f5ed1dd4db749eda78dad11e619f647978a747a202e4d6fdde7bf437e95c \
          sha256::297fa257b46e6b83bf85adb6a934e437b0e1fd987cdfe596cb63b65d8053c082 \
          sha256::444c7b230da7f0580bf2014f752d361ffd52e54da47674423d85c4c07903cbc8 \
          sha256::29616fbb8b18c591ff05355c7fa71b4668c1d3ce20f9de7bd2ae04245f117c94 \
-         sha256::71ea49145e995e863909b8448724d91326e9715aae9cf65970cf73e9108e712e \
+         sha256::b1f75dc2ffac9b538017d14af1e32cb4db6510ef389d806d4a2c7270d970e372 \
          sha256::6bbb1487539da6c8e2fa66fee412c6ed0c4d07d1f227f2155785bc8cfc1f193d \
          sha256::b0fc789b2cc8a4aecacb49faa276e0b7984e911bd52e8214798f168441798994 \
          sha256::2c47a944a28106cae79938f6f738a6a10cdeaaaff180c4c603f13414eb2776e1 \


### PR DESCRIPTION
Topic Description
-----------------

- grub: fix bash completions

Package(s) Affected
-------------------

- grub: 2:2.12+unifont15.1.04

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
