### PR TITLE
libvirt: fix sysusers conflict

### DIFF
--- a/app-virtualization/libvirt/autobuild/overrides/usr/lib/sysusers.d/libvirt-qemu.conf
+++ b/app-virtualization/libvirt/autobuild/overrides/usr/lib/sysusers.d/libvirt-qemu.conf
@@ -1,0 +1,5 @@
+# Avoid conflict with /usr/lib/sysusers.d/qemu.conf
+#g kvm 36
+g qemu 107
+u qemu 107:qemu "qemu user" - -
+m qemu kvm

--- a/app-virtualization/libvirt/autobuild/postinst
+++ b/app-virtualization/libvirt/autobuild/postinst
@@ -1,2 +1,6 @@
+echo "Creating temporary folders for libvirt ..."
 systemd-tmpfiles --create libvirt.conf
+
+echo "Setting up user and groups for libvirt ..."
+systemd-sysusers libvirt-qemu.conf
 groupadd -f libvirt

--- a/app-virtualization/libvirt/spec
+++ b/app-virtualization/libvirt/spec
@@ -1,4 +1,5 @@
 VER=10.2.0
+REL=1
 SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
 CHKSUMS="sha256::215772bc5dc4a672e67ffa9de3774f05ed4b7ed282dbe296ec5c9fec01dd7ae3"
 CHKUPDATE="anitya::id=13830"


### PR DESCRIPTION
Topic Description
-----------------

- libvirt: fix sysusers conflict

Package(s) Affected
-------------------

- libvirt: 10.2.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvirt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
