### PR TITLE
openssh (OpenSSH): update to 9.7p1

### DIFF
--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -1,5 +1,4 @@
-VER=9.6p1
-REL=1
+VER=9.7p1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
-CHKSUMS="sha256::910211c07255a8c5ad654391b40ee59800710dd8119dd5362de09385aa7a777c"
+CHKSUMS="sha256::490426f766d82a2763fcacd8d83ea3d70798750c7bd2aff2e57dc5660f773ffd"
 CHKUPDATE="anitya::id=2565"


### PR DESCRIPTION
Topic Description
-----------------

- openssh: update to 9.7p1
    This will also serve as a rebuild against OpenSSL 3.3 to prevent version
    mismatch error in sshgenkeys.service.

Package(s) Affected
-------------------

- openssh: 9.7p1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
