### PR TITLE
iotop-c: new, 1.26, replacing iotop

### DIFF
--- a/app-utils/iotop-c/autobuild/build
+++ b/app-utils/iotop-c/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building iotop-c ..."
+make DESTDIR="$PKGDIR"
+
+abinfo "Installing iotop-c ..."
+make install DESTDIR="$PKGDIR"

--- a/app-utils/iotop-c/autobuild/defines
+++ b/app-utils/iotop-c/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=iotop-c
+PKGSEC=utils
+PKGDEP="ncurses"
+PKGDES="A top-like utility for checking I/O load"
+PKGBREAK="iotop<=0.6"
+PKGREP="iotop<=0.6"

--- a/app-utils/iotop-c/autobuild/prepare
+++ b/app-utils/iotop-c/autobuild/prepare
@@ -1,0 +1,5 @@
+abinfo "Tweaking Makefile, install binary to bin instead of sbin ..."
+sed -i 's/sbin/bin/g' "$SRCDIR"/Makefile
+
+abinfo "Tweaking Makefile, do not strip during compilation ..."
+sed -i '/STRIP/d' "$SRCDIR"/Makefile

--- a/app-utils/iotop-c/spec
+++ b/app-utils/iotop-c/spec
@@ -1,0 +1,4 @@
+VER=1.26
+SRCS="git::commit=tags/v$VER::https://github.com/Tomas-M/iotop"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=370291"

--- a/app-utils/iotop/autobuild/defines
+++ b/app-utils/iotop/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=iotop
 PKGSEC=utils
-PKGDEP="python-3"
-PKGDES="A top-like utility for checking I/O load"
+PKGDEP="iotop-c"
+PKGDES="Transitional package for iotop-c"
 
-ABTYPE=python
-NOPYTHON2=1
+PKGEPOCH=1
+ABTYPE=dummy
 ABHOST=noarch

--- a/app-utils/iotop/spec
+++ b/app-utils/iotop/spec
@@ -1,5 +1,2 @@
-VER=0.6
-REL=7
-SRCS="tbl::http://guichaz.free.fr/iotop/files/iotop-$VER.tar.gz"
-CHKSUMS="sha256::1a7c02fd3758bb048d8af861c5f8735eb3ee9abadeaa787f27b8af2b1eaee8ce"
-CHKUPDATE="anitya::id=1387"
+VER=0
+DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- iotop-c: new, 1.26
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- iotop: make transitional package for iotop-c
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- iotop-c: 1.26
- iotop: 1:0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iotop-c
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
