### PR TITLE
nano: update to 8.0+nanorc2024.1.16

### DIFF
--- a/app-editors/nano/spec
+++ b/app-editors/nano/spec
@@ -1,8 +1,8 @@
-NANORC_VER=20230126
-VER=7.2+nanorc${NANORC_VER}
-SRCS="tbl::https://www.nano-editor.org/dist/v${VER:0:1}/nano-${VER%%+nanorc*}.tar.xz \
-      git::rename=nanorc;commit=3883874e48b725b09ec4f19b7d566785ed87e0b4::https://github.com/Quentium-Forks/nanorc"
-CHKSUMS="sha256::86f3442768bd2873cec693f83cdf80b4b444ad3cc14760b74361474fc87a4526 \
+NANORC_VER=2024.1.16
+VER=8.0+nanorc${NANORC_VER}
+SRCS="git::commit=tags/v${VER%%+nanorc*}::git://git.savannah.gnu.org/nano.git \
+      git::rename=nanorc;commit=tags/${NANORC_VER}::https://github.com/Quentium-Forks/nanorc"
+CHKSUMS="SKIP \
          SKIP"
 CHKUPDATE="anitya::id=2046"
-SUBDIR="nano-${VER%%+nanorc*}"
+SUBDIR="nano"


### PR DESCRIPTION
Topic Description
-----------------

- nano: update to 8.0+nanorc2024.1.16

Package(s) Affected
-------------------

- nano: 8.0+nanorc2024.1.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit nano
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
