### PR TITLE
x264: update to 1:0+git20240305

### DIFF
--- a/app-creativity/avidemux/spec
+++ b/app-creativity/avidemux/spec
@@ -1,5 +1,5 @@
 VER=2.8.1
-REL=1
+REL=2
 SRCS="tbl::https://downloads.sourceforge.net/avidemux/avidemux_$VER.tar.gz \
       file::rename=binutils.patch::https://github.com/FFmpeg/FFmpeg/commit/effadce6.patch"
 CHKSUMS="sha256::77d9bdca8683ce57c192b69d207cfab7cf92a7759ce0f63fa37b5c8e42ad3da2 \

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=4.4.4
-REL=6
+REL=7
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::e80b380d595c809060f66f96a5d849511ef4a76a26b76eacf5778b94c3570309"
 CHKUPDATE="anitya::id=5405"

--- a/app-multimedia/handbrake/spec
+++ b/app-multimedia/handbrake/spec
@@ -1,4 +1,5 @@
 VER=1.7.3
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/HandBrake/HandBrake"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9156"

--- a/app-multimedia/mplayer/autobuild/defines
+++ b/app-multimedia/mplayer/autobuild/defines
@@ -86,3 +86,8 @@ NOLTO=1
 AB_FLAGS_O3=1
 
 ABSPLITDBG=0
+
+# FIXME:
+# The architecture of your CPU (UNKNOWN) is not supported by this configure script
+# It seems nobody has ported MPlayer to your OS or CPU type yet.
+FAIL_ARCH="!(amd64|arm64|loongson3|ppc64el)"

--- a/app-multimedia/mplayer/spec
+++ b/app-multimedia/mplayer/spec
@@ -1,5 +1,5 @@
 VER=1.4
-REL=8
+REL=9
 SRCS="tbl::http://www.mplayerhq.hu/MPlayer/releases/MPlayer-$VER.tar.xz"
 CHKSUMS="sha256::82596ed558478d28248c7bc3828eb09e6948c099bbd76bb7ee745a0e3275b548"
 CHKUPDATE="anitya::id=9765"

--- a/app-multimedia/obs-studio/spec
+++ b/app-multimedia/obs-studio/spec
@@ -1,5 +1,5 @@
 VER=27.0.0
-REL=4
+REL=5
 # __OBS_CEF_VER: Find the build version on https://cef-builds.spotifycdn.com/index.html#linux64
 __OBS_CEF_VER="89.0.18+gb36241d+chromium-89.0.4389.114"
 SRCS="git::commit=tags/$VER;rename=obs-studio::https://github.com/obsproject/obs-studio"

--- a/app-multimedia/transcode/spec
+++ b/app-multimedia/transcode/spec
@@ -1,5 +1,5 @@
 VER=1.1.7
-REL=15
+REL=16
 SRCS="tbl::https://sources.archlinux.org/other/packages/transcode/transcode-$VER.tar.bz2"
 CHKSUMS="sha256::1e4e72d8e0dd62a80b8dd90699f5ca64c9b0cb37a5c9325c184166a9654f0a92"
 CHKUPDATE="anitya::id=14876"

--- a/app-multimedia/vlc/spec
+++ b/app-multimedia/vlc/spec
@@ -1,5 +1,5 @@
 VER=3.0.20
-REL=4
+REL=5
 SRCS="tbl::https://get.videolan.org/vlc/$VER/vlc-$VER.tar.xz"
 CHKSUMS="sha256::adc7285b4d2721cddf40eb5270cada2aaa10a334cb546fd55a06353447ba29b5"
 CHKUPDATE="anitya::id=6504"

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,5 @@
 VER=1.22.0
-REL=6
+REL=7
 SRCS="tbl::https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/$VER/gstreamer-$VER.tar.gz"
 CHKSUMS="sha256::5de8dcf5cc1ae26b3177b7dddbea7943e376cd5ca35d4cb7b43616e6d30b1854"
 CHKUPDATE="anitya::id=1263"

--- a/runtime-multimedia/x264/autobuild/defines
+++ b/runtime-multimedia/x264/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=x264
 PKGSEC=libs
 PKGDEP="glibc"
-BUILDDEP__AMD64="${BUILDDEP} yasm"
-BUILDDEP__I486="yasm"
+BUILDDEP__AMD64="${BUILDDEP} nasm"
+BUILDDEP__I486="nasm"
 PKGDES="H264 encoding library"
 
 AUTOTOOLS_AFTER="--enable-shared \
@@ -23,7 +23,9 @@ AB_FLAGS_O3=1
 
 RECONF=0
 ABSHADOW=0
+PKGEPOCH=1
 
-PKGBREAK="avidemux<=2.6.20 ffmpeg<=3.3.1 gst-plugins-ugly-0-10<=0.10.19-4 \
-          gst-plugins-ugly-1-0<=1.12.0 handbrake<=1.0.7-1 mplayer<=1:1.3.0-6 \
-          shotcut<=16.08 transcode<=1.1.7-5 vlc<=2.2.6 xpra<=2.0-1"
+PKGBREAK="avidemux<=2.8.1-1 ffmpeg<=4.4.4-6 \
+          gst-plugins-ugly-0-10<=0.10.19+git20121030 gstreamer<=1.22.0-6 \
+          handbrake<=1.7.3 mplayer<=1:1.4-8 obs-studio<=27.0.0-4 \
+          transcode<=1.1.7-15 vlc<=3.0.20-4"

--- a/runtime-multimedia/x264/spec
+++ b/runtime-multimedia/x264/spec
@@ -1,5 +1,4 @@
-VER=20170521
-REL=8
-SRCS="git::commit=aaa9aa83a111ed6f1db253d5afa91c5fc844583f::https://git.videolan.org/git/x264.git"
+VER=0+git20240305
+SRCS="git::commit=7ed753b10a61d0be95f683289dfb925b800b0676::https://git.videolan.org/git/x264.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15280"


### PR DESCRIPTION
Topic Description
-----------------

- vlc: bump REL due to x264 update to 1:0+git20240305
- transcode: bump REL due to x264 update to 1:0+git20240305
- obs-studio: bump REL due to x264 update to 1:0+git20240305
- mplayer: bump REL due to x264 update to 1:0+git20240305
- handbrake: bump REL due to x264 update to 1:0+git20240305
- gstreamer: bump REL due to x264 update to 1:0+git20240305
- ffmpeg: bump REL due to x264 update to 1:0+git20240305
- avidemux: bump REL due to x264 update to 1:0+git20240305
- x264: update to 1:0+git20240305

Package(s) Affected
-------------------

- avidemux: 2.8.1-2
- ffmpeg: 4.4.4-7
- gstreamer: 1.22.0-7
- handbrake: 1.7.3-1
- mplayer: 1:1.4-9
- obs-studio: 27.0.0-5
- transcode: 1.1.7-16
- vlc: 3.0.20-5
- x264: 1:0+git20240305

Security Update?
----------------

No

Build Order
-----------

```
#buildit x264:-pkgbreak avidemux ffmpeg gstreamer handbrake mplayer vlc obs-studio transcode x264
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
