### PR TITLE
svt-av1: update to 2.0.0

### DIFF
--- a/runtime-multimedia/libavif/spec
+++ b/runtime-multimedia/libavif/spec
@@ -1,5 +1,5 @@
 VER=0.11.1
-REL=2
+REL=3
 SRCS="tbl::https://github.com/AOMediaCodec/libavif/archive/refs/tags/v${VER}.tar.gz"
 CHKSUMS="sha256::0eb49965562a0e5e5de58389650d434cff32af84c34185b6c9b7b2fccae06d4e"
 CHKUPDATE="anitya::id=178015"

--- a/runtime-multimedia/svt-av1/autobuild/defines
+++ b/runtime-multimedia/svt-av1/autobuild/defines
@@ -9,4 +9,4 @@ CMAKE_AFTER="
 	-DNATIVE=OFF
 "
 
-PKGBREAK="ffmpeg<=4.2.5-3 libavif<=0.9.3 libheif<=1.12.0"
+PKGBREAK="libavif<=0.11.1-2"

--- a/runtime-multimedia/svt-av1/spec
+++ b/runtime-multimedia/svt-av1/spec
@@ -1,5 +1,4 @@
-VER=1.4.1
-REL=2
+VER=2.0.0
 SRCS="git::commit=tags/v$VER::https://gitlab.com/AOMediaCodec/SVT-AV1"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=24271"


### PR DESCRIPTION
Topic Description
-----------------

- libavif: bump REL due to svt-av1 update to 2.0.0
- svt-av1: update to 2.0.0

Package(s) Affected
-------------------

- libavif: 0.11.1-3
- svt-av1: 2.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit svt-av1:-pkgbreak libavif svt-av1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
