### PR TITLE
mingw+w64: update to 8.0.2

### DIFF
--- a/runtime-optenvw64/mingw+w64/autobuild/build
+++ b/runtime-optenvw64/mingw+w64/autobuild/build
@@ -3,17 +3,23 @@ _targets="i686-w64-mingw32 x86_64-w64-mingw32"
 # Phase 1. headers
 
 for _target in ${_targets}; do
+    abinfo "Configuring ${_target} ..."
     mkdir $SRCDIR/header-build-${_target} && cd $SRCDIR/header-build-${_target}
     $SRCDIR/mingw-w64-headers/configure \
         --prefix=/opt/w64/${_target} --enable-sdk=all --enable-secure-api \
         --host=${_target} CC=${_target}-gcc CXX=${_target}-g++
+
+    abinfo "Building ${_target} ..."
     make
+
+    abinfo "Installing ${_target} ..."
     make install DESTDIR=$PKGDIR
 done
 
 # Phase 2. C Runtime
 
 for _target in ${_targets}; do
+    abinfo "Configuring ${_target} runtime ..."
     if [ ${_target} == "i686-w64-mingw32" ]; then
         _crt_configure_args="--disable-lib64 --enable-lib32"
     elif [ ${_target} == "x86_64-w64-mingw32" ]; then
@@ -23,19 +29,28 @@ for _target in ${_targets}; do
     $SRCDIR/mingw-w64-crt/configure --prefix=/opt/w64/${_target} \
         --host=${_target} --enable-wildcard \
         ${_crt_configure_args} CC=${_target}-gcc CXX=${_target}-g++
+
+    abinfo "Building ${_target} runtime ..."
     make
+
+    abinfo "Installing ${_target} runtime ..."
     make install DESTDIR=$PKGDIR
 done
 
 # Phase 3. Win Pthread
 
 for _target in ${_targets}; do
+    abinfo "Configuring ${_target} win pthread ..."
     mkdir $SRCDIR/pth-build-${_target} && cd $SRCDIR/pth-build-${_target}
     $SRCDIR/mingw-w64-libraries/winpthreads/configure \
         --prefix=/opt/w64/${_target} \
         --host=${_target} --enable-static \
         --enable-shared CC=${_target}-gcc CXX=${_target}-g++
+
+    abinfo "Building ${_target} win pthread ..."
     make
+
+    abinfo "Installing ${_target} win pthread ..."
     make install DESTDIR=$PKGDIR
     ${_target}-strip --strip-unneeded $PKGDIR/opt/w64/${_target}/bin/*.dll
 done

--- a/runtime-optenvw64/mingw+w64/autobuild/defines
+++ b/runtime-optenvw64/mingw+w64/autobuild/defines
@@ -6,5 +6,6 @@ PKGDES="MinGW-w64 headers for Windows"
 
 ABSTRIP=no
 NOSTATIC=no
-ABHOST=noarch
 PKGPROV="mingw mingw-w64"
+
+FAIL_ARCH="!(amd64)"

--- a/runtime-optenvw64/mingw+w64/autobuild/prepare
+++ b/runtime-optenvw64/mingw+w64/autobuild/prepare
@@ -1,6 +1,12 @@
+abinfo "Clearing CFLAGS/CPPFLAGS/CXXFLAGS/LDFLAGS ..."
 unset CFLAGS CPPFLAGS CXXFLAGS LDFLAGS
 
+abinfo "Setting up CFLAGS ..."
 export CFLAGS+=" -I/opt/w64/include/"
 
+abinfo "Overriding ld ..."
 ln -sv /usr/bin/ld.bfd "$SRCDIR"/ld
 export PATH="$SRCDIR:$PATH"
+
+abinfo "Setting up w64 subsystem environment ..."
+source /etc/profile.d/w64subsystem.sh

--- a/runtime-optenvw64/mingw+w64/spec
+++ b/runtime-optenvw64/mingw+w64/spec
@@ -1,4 +1,4 @@
-VER=8.0.0
+VER=8.0.2
 SRCS="https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v$VER.tar.bz2"
-CHKSUMS="sha256::44c740ea6ab3924bc3aa169bad11ad3c5766c5c8459e3126d44eabb8735a5762"
+CHKSUMS="sha256::f00cf50951867a356d3dc0dcc7a9a9b422972302e23d54a33fc05ee7f73eee4d"
 CHKUPDATE="anitya::id=231062"


### PR DESCRIPTION
Topic Description
-----------------

- mingw+w64: update to 8.0.2
    - Fix packaging.
    - Set architecture from noarch to amd64.

Package(s) Affected
-------------------

- mingw+w64: 8.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mingw+w64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
