### PR TITLE
astyle: update to 3.4.14

### DIFF
--- a/app-devel/astyle/autobuild/build
+++ b/app-devel/astyle/autobuild/build
@@ -1,12 +1,11 @@
-cd build/gcc
-make release shared
-install -Dm0755 bin/astyle "$PKGDIR/usr/bin/astyle"
-mkdir -p "$PKGDIR"/usr/lib
-cp -av bin/libastyle.so* "$PKGDIR"/usr/lib/
+abinfo "Building the executable ..."
+export CMAKE_AFTER=""
+build_cmakeninja_configure
+build_cmakeninja_build
+build_cmakeninja_install
 
-install -d "$PKGDIR/usr/share/doc/astyle/"
-for f in ../../doc/*.html; do
-    install -m0644 "$f" "$PKGDIR/usr/share/doc/astyle/"
-done
-
-cd "$SRCDIR"
+abinfo "Building the shared library ..."
+export CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON"
+build_cmakeninja_configure
+build_cmakeninja_build
+build_cmakeninja_install

--- a/app-devel/astyle/spec
+++ b/app-devel/astyle/spec
@@ -1,5 +1,5 @@
-VER=3.1
-REL=2
-SRCS="tbl::https://downloads.sourceforge.net/sourceforge/astyle/astyle_${VER}_linux.tar.gz"
-CHKSUMS="sha256::cbcc4cf996294534bb56f025d6f199ebfde81aa4c271ccbd5ee1c1a3192745d7"
+VER=3.4.14
+SRCS="git::commit=tags/$VER::https://gitlab.com/saalen/astyle"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=123"
+SUBDIR="./astyle/AStyle"


### PR DESCRIPTION
Topic Description
-----------------

- astyle: update to 3.4.14
- Change source from SourceForge to GitLab
- Use CMake

Package(s) Affected
-------------------

- astyle: 3.4.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit astyle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
