### PR TITLE
transcode: fix FTBFS

### DIFF
--- a/app-multimedia/transcode/spec
+++ b/app-multimedia/transcode/spec
@@ -1,5 +1,5 @@
 VER=1.1.7
-REL=14
-SRCS="tbl::https://mirrorservice.org/sites/distfiles.gentoo.org/distfiles/transcode-$VER.tar.bz2"
+REL=15
+SRCS="tbl::https://sources.archlinux.org/other/packages/transcode/transcode-$VER.tar.bz2"
 CHKSUMS="sha256::1e4e72d8e0dd62a80b8dd90699f5ca64c9b0cb37a5c9325c184166a9654f0a92"
 CHKUPDATE="anitya::id=14876"


### PR DESCRIPTION
Topic Description
-----------------

- transcode: fix FTBFS
    The old upstream was gone

Package(s) Affected
-------------------

- transcode: 1.1.7-15

Security Update?
----------------

No

Build Order
-----------

```
#buildit transcode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
