### PR TITLE
lact (Linux AMDGPU Controllor): Added postinst and systemd preset file

### DIFF
--- a/app-admin/lact/autobuild/overrides/usr/lib/systemd/system-preset/70-lactd.preset
+++ b/app-admin/lact/autobuild/overrides/usr/lib/systemd/system-preset/70-lactd.preset
@@ -1,0 +1,1 @@
+enable lactd.service

--- a/app-admin/lact/autobuild/postinst
+++ b/app-admin/lact/autobuild/postinst
@@ -1,0 +1,5 @@
+systemctl daemon-reload
+
+systemctl restart lactd.service
+
+systemctl preset lactd.service

--- a/app-admin/lact/spec
+++ b/app-admin/lact/spec
@@ -1,4 +1,5 @@
 VER=0.5.4
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/ilya-zlobintsev/LACT"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372202"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
lact: Added autobuild/postinst and autobuild/overrides/usr/lib/systemd/system-preset/70-lactd.preset
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
lact
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------
-->

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

<!--
```
pkg1 pkg2 pkg3 ...
```

-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

Architectural progress for experimental ports does not impede on merging of this topic.

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
