### PR TITLE
dos2unix: update to 7.5.2

### DIFF
--- a/app-utils/dos2unix/spec
+++ b/app-utils/dos2unix/spec
@@ -1,4 +1,4 @@
-VER=7.4.3
+VER=7.5.2
 SRCS="tbl::https://sourceforge.net/projects/dos2unix/files/dos2unix/$VER/dos2unix-$VER.tar.gz"
-CHKSUMS="sha256::b68db41956daf933828423aa30510e00c12d29ef5916e715e8d4e694fe66ca72"
+CHKSUMS="sha256::264742446608442eb48f96c20af6da303cb3a92b364e72cb7e24f88239c4bf3a"
 CHKUPDATE="anitya::id=453"


### PR DESCRIPTION
Topic Description
-----------------

- dos2unix: update to 7.5.2

Package(s) Affected
-------------------

- dos2unix: 7.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit dos2unix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
