### PR TITLE
ed: update to 1.20.2

### DIFF
--- a/app-editors/ed/spec
+++ b/app-editors/ed/spec
@@ -1,4 +1,4 @@
-VER=1.19
+VER=1.20.2
 SRCS="tbl::https://ftp.gnu.org/gnu/ed/ed-$VER.tar.lz"
-CHKSUMS="sha256::ce2f2e5c424790aa96d09dacb93d9bbfdc0b7eb6249c9cb7538452e8ec77cd48"
+CHKSUMS="sha256::65fec7318f48c2ca17f334ac0f4703defe62037bb13cc23920de077b5fa24523"
 CHKUPDATE="anitya::id=659"


### PR DESCRIPTION
Topic Description
-----------------

- ed: update to 1.20.2

Package(s) Affected
-------------------

- ed: 1.20.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
