### PR TITLE
tree: update to 2.1.1

### DIFF
--- a/app-utils/tree/spec
+++ b/app-utils/tree/spec
@@ -1,4 +1,4 @@
-VER=2.0.4
-SRCS="tbl::http://mama.indstate.edu/users/ice/tree/src/tree-$VER.tgz"
-CHKSUMS="sha256::b0ea92197849579a3f09a50dbefc3d4708caf555d304a830e16e20b73b4ffa74"
+VER=2.1.1
+SRCS="git::commit=tags/$VER::https://gitlab.com/OldManProgrammer/unix-tree"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5006"


### PR DESCRIPTION
Topic Description
-----------------

- tree: update to 2.1.1

Package(s) Affected
-------------------

- tree: 2.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
