### PR TITLE
lact (Linux AMDGPU Controller): add postinst and systemd preset file

### DIFF
--- a/app-admin/lact/autobuild/beyond
+++ b/app-admin/lact/autobuild/beyond
@@ -1,7 +1,11 @@
 abinfo "Installing .desktop and service file ..."
-install -Dm644 "$SRCDIR"/res/lactd.service "$PKGDIR"/usr/lib/systemd/system/lactd.service
-install -Dm644 "$SRCDIR"/res/io.github.lact-linux.desktop "$PKGDIR"/usr/share/applications/io.github.lact-linux.desktop
+install -Dvm644 "$SRCDIR"/res/lactd.service \
+    "$PKGDIR"/usr/lib/systemd/system/lactd.service
+install -Dvm644 "$SRCDIR"/res/io.github.lact-linux.desktop \
+    "$PKGDIR"/usr/share/applications/io.github.lact-linux.desktop
 
 abinfo "Installing assests ..."
-install -Dm644 "$SRCDIR"/res/io.github.lact-linux.png "$PKGDIR"/usr/share/pixmaps/io.github.lact-linux.png
-install -Dm644 "$SRCDIR"/res/io.github.lact-linux.svg "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/io.github.lact-linux.svg
+install -Dvm644 "$SRCDIR"/res/io.github.lact-linux.png \
+    "$PKGDIR"/usr/share/pixmaps/io.github.lact-linux.png
+install -Dvm644 "$SRCDIR"/res/io.github.lact-linux.svg \
+    "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/io.github.lact-linux.svg

--- a/app-admin/lact/autobuild/defines
+++ b/app-admin/lact/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=lact
 PKGSEC=admin
 PKGDES="Linux AMDGPU Control Application"
 PKGDEP="libdrm hwdata gtk-4"
-BUILDDEP="rustc gtk-4 llvm blueprint-compiler"
+BUILDDEP="rustc llvm blueprint-compiler"
 
 USECLANG=1
 

--- a/app-admin/lact/autobuild/overrides/usr/lib/systemd/system-preset/70-lact.preset
+++ b/app-admin/lact/autobuild/overrides/usr/lib/systemd/system-preset/70-lact.preset
@@ -1,0 +1,1 @@
+enable lactd.service

--- a/app-admin/lact/autobuild/postinst
+++ b/app-admin/lact/autobuild/postinst
@@ -1,0 +1,20 @@
+case "$1" in
+    configure)
+        # Discern installation and upgrade/reinstall/residual-config.
+        if [ -z "$2" ]; then
+            systemctl preset lactd.service
+            # Apparently `systemctl preset' implies daemon-reload.
+            # This should be documented somewhere...
+            if ! systemd-detect-virt -cq; then
+                systemctl start lactd.service
+            fi
+        else
+            if ! systemd-detect-virt -cq; then
+                systemctl daemon-reload
+                if systemctl is-enabled lactd.sevice > /dev/null; then
+                    systemctl try-restart lactd.service
+                fi
+            fi
+        fi
+    ;;
+esac

--- a/app-admin/lact/spec
+++ b/app-admin/lact/spec
@@ -1,4 +1,5 @@
 VER=0.5.4
-SRCS="git::commit=tags/v$VER::https://github.com/ilya-zlobintsev/LACT"
+REL=1
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/ilya-zlobintsev/LACT"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372202"


### PR DESCRIPTION
Topic Description
-----------------

- lact: Added postinst and systemd preset file

Package(s) Affected
-------------------

- lact: 0.5.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lact
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
