### PR TITLE
tcsh: update to 6.24.12

### DIFF
--- a/app-shells/tcsh/spec
+++ b/app-shells/tcsh/spec
@@ -1,4 +1,4 @@
-VER=6.24.10
+VER=6.24.12
 SRCS="tbl::https://astron.com/pub/tcsh/tcsh-$VER.tar.gz"
-CHKSUMS="sha256::13475c0fbeb74139d33ed793bf00ffbbb2ac2dc9fb1d44467a410760aba36664"
+CHKSUMS="sha256::e3270ce9667fd5bd2a046687659fcf5fd6a6781326f806ebd724f1e1c9cd4185"
 CHKUPDATE="anitya::id=4945"


### PR DESCRIPTION
Topic Description
-----------------

- tcsh: update to 6.24.12

Package(s) Affected
-------------------

- tcsh: 6.24.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit tcsh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
