### PR TITLE
tar: update to 1.35

### DIFF
--- a/app-utils/tar/spec
+++ b/app-utils/tar/spec
@@ -1,4 +1,4 @@
-VER=1.34
+VER=1.35
 SRCS="tbl::https://ftp.gnu.org/gnu/tar/tar-$VER.tar.xz"
-CHKSUMS="sha256::63bebd26879c5e1eea4352f0d03c991f966aeb3ddeb3c7445c902568d5411d28"
+CHKSUMS="sha256::4d62ff37342ec7aed748535323930c7cf94acf71c3591882b26a7ea50f3edc16"
 CHKUPDATE="anitya::id=4939"


### PR DESCRIPTION
Topic Description
-----------------

- tar: update to 1.35

Package(s) Affected
-------------------

- tar: 1.35

Security Update?
----------------

No

Build Order
-----------

```
#buildit tar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
