### PR TITLE
texinfo: update to 7.1

### DIFF
--- a/app-utils/texinfo/spec
+++ b/app-utils/texinfo/spec
@@ -1,4 +1,4 @@
-VER=7.0.1
+VER=7.1
 SRCS="tbl::https://ftp.gnu.org/gnu/texinfo/texinfo-$VER.tar.xz"
-CHKSUMS="sha256::bcd221fdb2d807a8a09938a0f8d5e010ebd2b58fca16075483d6fcb78db2c6b2"
+CHKSUMS="sha256::deeec9f19f159e046fdf8ad22231981806dac332cc372f1c763504ad82b30953"
 CHKUPDATE="anitya::id=4958"


### PR DESCRIPTION
Topic Description
-----------------

- texinfo: update to 7.1

Package(s) Affected
-------------------

- texinfo: 7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit texinfo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
