### PR TITLE
socat: update to 1.8.0.0

### DIFF
--- a/app-network/socat/spec
+++ b/app-network/socat/spec
@@ -1,5 +1,4 @@
-VER=1.7.3.4
+VER=1.8.0.0
 SRCS="tbl::http://www.dest-unreach.org/socat/download/socat-${VER/b/-b}.tar.gz"
-CHKSUMS="sha256::d9ed2075abed7b3ec9730ed729b4c8e287c502181c806d4487020418a6e2fc36"
+CHKSUMS="sha256::6010f4f311e5ebe0e63c77f78613d264253680006ac8979f52b0711a9a231e82"
 CHKUPDATE="anitya::id=4848"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- socat: update to 1.8.0.0

Package(s) Affected
-------------------

- socat: 1:1.8.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit socat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
