### PR TITLE
oma: update to 1.3.5

### DIFF
--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -15,11 +15,11 @@ CARGO_AFTER__LOONGSON3="--no-default-features \
 
 USECLANG=1
 
+# FIXME: ld.lld is not yet available.
 NOLTO__LOONGSON3=1
-USECLANG__LOONGSON3=0
-
 NOLTO__LOONGARCH64=1
-USECLANG__LOONGARCH64=0
-
 NOLTO__MIPS64R6EL=1
-USECLANG__MIPS64R6EL=0
+
+# FIXME: `rustversion` raises error during build time, use GCC for now.
+NOLTO__RISCV64=1
+USECLANG__RISCV64=0

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.3.4
+VER=1.3.5
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.3.5

Package(s) Affected
-------------------

- oma: 1.3.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
