### PR TITLE
mokutil: new, 0.6.0

### DIFF
--- a/app-admin/mokutil/autobuild/defines
+++ b/app-admin/mokutil/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=mokutil
+PKGSEC=admin
+PKGDES="Shim.efi Machine Owner Key management tool"
+PKGDEP="openssl keyutil efivar"

--- a/app-admin/mokutil/spec
+++ b/app-admin/mokutil/spec
@@ -1,0 +1,4 @@
+VER=0.6.0
+SRCS="git::commit=tags/$VER::https://github.com/lcp/mokutil.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=246006"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
for manage shim installation when user needs, make secure boot manager a little more easier.
Note: currently archlinux and fedora have rolled the package to 0.7.x.

Package(s) Affected
-------------------
new: mokutil
depends: efivar, openssl
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

```
pkg1 pkg2 pkg3 ...
```

-->
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

other architecture were not tested.
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

Architectural progress for experimental ports does not impede on merging of this topic.

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
