### PR TITLE
uriparser: security update to 0.9.8

### DIFF
--- a/runtime-web/uriparser/spec
+++ b/runtime-web/uriparser/spec
@@ -1,4 +1,4 @@
-VER=0.9.7
+VER=0.9.8
 SRCS="git::commit=tags/uriparser-$VER::https://github.com/uriparser/uriparser"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10160"


### PR DESCRIPTION
Topic Description
-----------------

- uriparser: security update to 0.9.8
    Addresses #5830 (CVE-2024-34402, CVE-2024-34403).

Package(s) Affected
-------------------

- uriparser: 0.9.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit uriparser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
