### PR TITLE
nano: disable implicit --modernbinding for e-prefixed-executables

### DIFF
--- a/app-editors/nano/autobuild/patches/0001-Revert-bindings-set-up-modern-bindings-also-when-bin.patch
+++ b/app-editors/nano/autobuild/patches/0001-Revert-bindings-set-up-modern-bindings-also-when-bin.patch
@@ -1,0 +1,27 @@
+From 4ee6b087b4526e652fdf49142e07505b867097e7 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 5 May 2024 14:01:26 -0700
+Subject: [PATCH] Revert "bindings: set up modern bindings also when binary's
+ name starts with "e""
+
+This reverts commit 580eaf29d60734133c11f4ddb4b6aa06cdf33fdc.
+---
+ src/nano.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/nano.c b/src/nano.c
+index 973054f0..dbdbf5db 100644
+--- a/src/nano.c
++++ b/src/nano.c
+@@ -1846,8 +1846,6 @@ int main(int argc, char **argv)
+ 	/* If the executable's name starts with 'r', activate restricted mode. */
+ 	if (*(tail(argv[0])) == 'r')
+ 		SET(RESTRICTED);
+-	else if (*(tail(argv[0])) == 'e')
+-		SET(MODERN_BINDINGS);
+ 
+ 	while ((optchr = getopt_long(argc, argv, "ABC:DEFGHIJ:KLMNOPQ:RS$T:UVWX:Y:Z"
+ 				"abcdef:ghijklmno:pqr:s:tuvwxy!%_0/", long_options, NULL)) != -1) {
+-- 
+2.44.0
+

--- a/app-editors/nano/spec
+++ b/app-editors/nano/spec
@@ -1,5 +1,6 @@
 NANORC_VER=2024.1.16
 VER=8.0+nanorc${NANORC_VER}
+REL=1
 SRCS="git::commit=tags/v${VER%%+nanorc*}::git://git.savannah.gnu.org/nano.git \
       git::rename=nanorc;commit=tags/${NANORC_VER}::https://github.com/Quentium-Forks/nanorc"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- nano: disable implicit --modernbinding with e-prefixed executables
    - Drop this behavior that causes great confusion in programs that invokes
    /usr/bin/editor (i.e., git).
    - This reverts upstream commit 580eaf29d60734133c11f4ddb4b6aa06cdf33fdc.
    - Track this patch at AOSC-Tracking/nano @ aosc/v8.0.

Package(s) Affected
-------------------

- nano: 8.0+nanorc2024.1.16-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nano
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
