### PR TITLE
js-102 (Mozilla SpiderMonkey): update to 102.15.1

### DIFF
--- a/lang-js/js-102/autobuild/patches/0001-Bug-1792981-loong64-Enable-JIT-compiler-of-loong64-p.patch
+++ b/lang-js/js-102/autobuild/patches/0001-Bug-1792981-loong64-Enable-JIT-compiler-of-loong64-p.patch
@@ -1,24 +1,22 @@
-
-# HG changeset patch
-# User Zhao Jiazhong <zhaojiazhong-hf@loongson.cn>
-# Date 1665408155 0
-# Node ID d9e0d2d8b3a89bdee2a55a0bdab9adcd108eb253
-# Parent  f0bbec2617db346c3032e870fc571970728ae220
-Bug 1792981 - [loong64] Enable JIT compiler of loong64 port by default. r=jandem
+From 134f532c67b5281f095e2fbc51eb26fb7f86c1db Mon Sep 17 00:00:00 2001
+From: Zhao Jiazhong <zhaojiazhong-hf@loongson.cn>
+Date: Mon, 10 Oct 2022 13:22:35 +0000
+Subject: [PATCH] Bug 1792981 - [loong64] Enable JIT compiler of loong64 port
+ by default. r=jandem
 
 Fix a build with JIT issue on native loongarch64 machine, and enable JIT by default.
 
 Differential Revision: https://phabricator.services.mozilla.com/D158397
+---
+ js/moz.configure                   |  2 ++
+ js/src/wasm/WasmSignalHandlers.cpp | 10 +++++-----
+ 2 files changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/js/moz.configure b/js/moz.configure
+index 7a241cac76..2bb7979e36 100644
 --- a/js/moz.configure
 +++ b/js/moz.configure
-@@ -265,16 +265,18 @@ def jit_codegen(jit_enabled, simulator, 
- 
-     if simulator:
-         return simulator
- 
-     if target.cpu == "aarch64":
+@@ -234,6 +234,8 @@ def jit_codegen(jit_enabled, simulator, target):
          return namespace(arm64=True)
      elif target.cpu == "x86_64":
          return namespace(x64=True)
@@ -27,15 +25,11 @@ diff --git a/js/moz.configure b/js/moz.configure
  
      return namespace(**{str(target.cpu): True})
  
- 
- set_config("JS_CODEGEN_NONE", jit_codegen.none)
- set_config("JS_CODEGEN_ARM", jit_codegen.arm)
- set_config("JS_CODEGEN_ARM64", jit_codegen.arm64)
- set_config("JS_CODEGEN_MIPS32", jit_codegen.mips32)
 diff --git a/js/src/wasm/WasmSignalHandlers.cpp b/js/src/wasm/WasmSignalHandlers.cpp
+index 4a45905431..074c373106 100644
 --- a/js/src/wasm/WasmSignalHandlers.cpp
 +++ b/js/src/wasm/WasmSignalHandlers.cpp
-@@ -158,10 +158,10 @@
+@@ -158,10 +158,10 @@ using mozilla::DebugOnly;
  #      define R32_sig(p) ((p)->uc_mcontext.gp_regs[32])
  #    endif
  #    if defined(__linux__) && defined(__loongarch__)
@@ -50,12 +44,7 @@ diff --git a/js/src/wasm/WasmSignalHandlers.cpp b/js/src/wasm/WasmSignalHandlers
  #    endif
  #  elif defined(__NetBSD__)
  #    define EIP_sig(p) ((p)->uc_mcontext.__gregs[_REG_EIP])
-@@ -403,17 +403,17 @@ struct macos_aarch64_context {
- #  elif defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) || \
-       defined(__PPC64LE__)
- #    define PC_sig(p) R32_sig(p)
- #    define SP_sig(p) R01_sig(p)
- #    define FP_sig(p) R01_sig(p)
+@@ -403,7 +403,7 @@ struct macos_aarch64_context {
  #  elif defined(__loongarch__)
  #    define PC_sig(p) EPC_sig(p)
  #    define FP_sig(p) RFP_sig(p)
@@ -64,9 +53,6 @@ diff --git a/js/src/wasm/WasmSignalHandlers.cpp b/js/src/wasm/WasmSignalHandlers
  #    define LR_sig(p) RRA_sig(p)
  #  endif
  
- static void SetContextPC(CONTEXT* context, uint8_t* pc) {
- #  ifdef PC_sig
-   *reinterpret_cast<uint8_t**>(&PC_sig(context)) = pc;
- #  else
-   MOZ_CRASH();
+-- 
+2.45.0
 

--- a/lang-js/js-102/spec
+++ b/lang-js/js-102/spec
@@ -1,5 +1,4 @@
-VER=102.13.0
-REL=1
+VER=102.15.1
 SRCS="https://ftp.mozilla.org/pub/firefox/releases/${VER}esr/source/firefox-${VER}esr.source.tar.xz"
-CHKSUMS="sha256::fc3fab3de4bf65d1ec7fc30ae776144097b70a35d37c36663e11ffa618c13a2c"
+CHKSUMS="sha256::09194fb765953bc6979a35aa8834118c453b9d6060bf1ec4e134551bad740113"
 CHKUPDATE="html::url=https://ftp.mozilla.org/pub/firefox/releases/;pattern=(102\.\d+\.\d+)esr"


### PR DESCRIPTION
Topic Description
-----------------

- js-102: update to 102.15.1
    Track patches at AOSC-Tracking/js-102 @ aosc/v102.15.1.

Package(s) Affected
-------------------

- js-102: 102.15.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit js-102
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
