### PR TITLE
fcitx5-gtk: enable GTK 4 support

### DIFF
--- a/app-i18n/fcitx5-gtk/autobuild/defines
+++ b/app-i18n/fcitx5-gtk/autobuild/defines
@@ -3,8 +3,6 @@ PKGDES="gtk im module and glib based dbus client library"
 PKGSEC=utils
 PKGDEP="fcitx5"
 PKGCONFL="fcitx"
-BUILDDEP="gtk-2 gtk-3 extra-cmake-modules gobject-introspection git"
+BUILDDEP="gtk-2 gtk-3 gtk-4 extra-cmake-modules gobject-introspection git"
 
-# Currently AOSC OS does not have port gtk-4, so GTK4 support is temporarily disabled.
-CMAKE_AFTER="-DENABLE_GTK4_IM_MODULE=OFF"
 PKGEPOCH=1

--- a/app-i18n/fcitx5-gtk/spec
+++ b/app-i18n/fcitx5-gtk/spec
@@ -1,4 +1,5 @@
 VER=5.1.0
+REL=1
 SRCS="tbl::https://github.com/fcitx/fcitx5-gtk/archive/$VER.tar.gz"
 CHKSUMS="sha256::b064d4be9d603583f1b5da8f809c28b0fa64d9c6a696fa318b64c47903f4fc4c"
 CHKUPDATE="anitya::id=138235"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-gtk: enable gtk-4 support
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- fcitx5-gtk: 5.1.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
