### PR TITLE
Vulkan Survey (May, 2024)

### DIFF
--- a/app-utils/vulkan-tools/autobuild/defines
+++ b/app-utils/vulkan-tools/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=vulkan-tools
 PKGSEC=utils
-PKGDEP="libxkbcommon wayland x11-lib vulkan-loader"
-BUILDDEP="lxml glslang vulkan-headers"
+PKGDEP="libxkbcommon vulkan-loader wayland x11-lib"
+BUILDDEP="lxml glslang volk-meta-loader vulkan-headers"
 PKGDES="Vulkan Tools and Utilities"
 
 CMAKE_AFTER="-DBUILD_CUBE=ON \

--- a/app-utils/vulkan-tools/spec
+++ b/app-utils/vulkan-tools/spec
@@ -1,4 +1,4 @@
-VER=1.3.227
-SRCS="tbl::https://github.com/KhronosGroup/Vulkan-Tools/archive/v$VER.tar.gz"
-CHKSUMS="sha256::dbba74f6a4b3a4288276543ab692dd3a8298d9e37ed6c5f594e4ea1717052920"
+VER=1.3.280.0
+SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Tools"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15953"

--- a/runtime-display/spirv-headers/spec
+++ b/runtime-display/spirv-headers/spec
@@ -1,4 +1,4 @@
-VER=1.3.275.0
+VER=1.3.280.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/SPIRV-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230542"

--- a/runtime-display/volk-meta-loader/autobuild/defines
+++ b/runtime-display/volk-meta-loader/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=volk-meta-loader
+PKGSEC=libs
+PKGDEP="vulkan-headers"
+PKGDES="Meta loader for Vulkan API"
+
+CMAKE_AFTER="-DVOLK_PULL_IN_VULKAN=ON \
+             -DVOLK_INSTALL=ON \
+             -DVOLK_HEADERS_ONLY=OFF"
+# Note: Static-only library.
+NOSTATIC=0
+ABSPLITDBG=0

--- a/runtime-display/volk-meta-loader/spec
+++ b/runtime-display/volk-meta-loader/spec
@@ -1,0 +1,4 @@
+VER=1.3.280.0
+SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/zeux/volk"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=370476"

--- a/runtime-display/vulkan-extensionlayer/autobuild/defines
+++ b/runtime-display/vulkan-extensionlayer/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=vulkan-extensionlayer
+PKGSEC=libs
+PKGDEP="vulkan-headers vulkan-loader vulkan-utility-libraries wayland x11-lib"
+BUILDDEP="volk-meta-loader"
+PKGDES="Layer providing Vulkan features when native support is unavailable"
+
+CMAKE_AFTER="-DBUILD_WSI_XCB_SUPPORT=ON \
+             -DBUILD_WSI_XLIB_SUPPORT=ON \
+             -DBUILD_WSI_WAYLAND_SUPPORT=ON"

--- a/runtime-display/vulkan-extensionlayer/autobuild/prepare
+++ b/runtime-display/vulkan-extensionlayer/autobuild/prepare
@@ -1,0 +1,5 @@
+if [[ "${CROSS:-$ARCH}" = "loongson3" ]]; then
+    abinfo "Appending -Umips to fix build ..."
+    export CFLAGS="${CFLAGS} -Umips"
+    export CXXFLAGS="${CXXFLAGS} -Umips"
+fi

--- a/runtime-display/vulkan-extensionlayer/spec
+++ b/runtime-display/vulkan-extensionlayer/spec
@@ -1,0 +1,4 @@
+VER=1.3.280.0
+SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-ExtensionLayer"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=230558"

--- a/runtime-display/vulkan-headers/spec
+++ b/runtime-display/vulkan-headers/spec
@@ -1,4 +1,4 @@
-VER=1.3.275.0
+VER=1.3.280.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88835"

--- a/runtime-display/vulkan-loader/spec
+++ b/runtime-display/vulkan-loader/spec
@@ -1,5 +1,4 @@
-VER=1.3.275.0
-REL=1
+VER=1.3.280.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Loader"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230557"

--- a/runtime-display/vulkan-utility-libraries/spec
+++ b/runtime-display/vulkan-utility-libraries/spec
@@ -1,5 +1,4 @@
-VER=1.3.275.0
-REL=1
+VER=1.3.280.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Utility-Libraries"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370173"

--- a/runtime-display/vulkan-validationlayers/spec
+++ b/runtime-display/vulkan-validationlayers/spec
@@ -1,5 +1,4 @@
-VER=1.3.275.0
-REL=1
+VER=1.3.280.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-ValidationLayers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230558"

--- a/runtime-display/vulkan/autobuild/defines
+++ b/runtime-display/vulkan/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=vulkan
 PKGSEC=libs
-PKGDEP="vulkan-headers vulkan-loader vulkan-tools vulkan-validationlayers \
-        vulkan-utility-libraries"
+PKGDEP="vulkan-extensionlayer vulkan-headers vulkan-loader vulkan-tools \
+        vulkan-validationlayers vulkan-utility-libraries"
 PKGDES="A low-overhead, cross-platform 3D graphics and compute API (metapackage)"
 
 PKGEPOCH=1


### PR DESCRIPTION
Topic Description
-----------------

- vulkan: add vulkan-extensionlayer
- vulkan-extensionlayer: new, 1.3.280.0
- volk-meta-loader: new, 1.3.280.0
- spirv-headers: update to 1.3.280.0
- vulkan-tools: update to 1.3.280.0
- vulkan-validationlayers: update to 1.3.280.0
- vulkan-utility-libraries: update to 1.3.280.0
- vulkan-loader: update to 1.3.280.0
- vulkan-headers: update to 1.3.280.0

Package(s) Affected
-------------------

- spirv-headers: 1:1.3.280.0
- volk-meta-loader: 1.3.280.0
- vulkan-extensionlayer: 1.3.280.0
- vulkan-headers: 1.3.280.0
- vulkan-loader: 1.3.280.0
- vulkan-tools: 1.3.280.0
- vulkan-utility-libraries: 1.3.280.0
- vulkan-validationlayers: 1.3.280.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit volk-meta-loader spirv-headers vulkan-headers vulkan-loader vulkan-utility-libraries vulkan-validationlayers vulkan-tools vulkan-extensionlayer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
