### PR TITLE
aoscdk-rs: update to 1.0.4

### DIFF
--- a/app-admin/aoscdk-rs/spec
+++ b/app-admin/aoscdk-rs/spec
@@ -1,4 +1,4 @@
-VER=1.0.3
+VER=1.0.4
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/aoscdk-rs/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226678"


### PR DESCRIPTION
Topic Description
-----------------

- aoscdk-rs: update to 1.0.4

Package(s) Affected
-------------------

- aoscdk-rs: 1.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit aoscdk-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
