### PR TITLE
chromium (Chromium browsers): update to 124.0.6367.118

### DIFF
--- a/app-web/chromium/autobuild/patches/2002-Debian-fixes-blink.patch
+++ b/app-web/chromium/autobuild/patches/2002-Debian-fixes-blink.patch
@@ -944,7 +944,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/th
 +      FontCache::Get().GetLastResortFallbackFont(font_description,
 +                                                 kDoNotRetain);
    if (!temporary_font) {
-     NOTREACHED();
+     DUMP_WILL_BE_NOTREACHED_NORETURN();
      return nullptr;
    }
 -  CSSCustomFontData* css_font_data = MakeGarbageCollected<CSSCustomFontData>(

--- a/app-web/chromium/autobuild/patches/copy-loongarch64.bash
+++ b/app-web/chromium/autobuild/patches/copy-loongarch64.bash
@@ -1,0 +1,16 @@
+#!/bin/bash -x
+
+# Source spec for $VER.
+source ../../spec
+PREFIX="$PWD"/chromium-loongarch64/chromium/chromium-$VER
+
+# Clone patches
+git clone https://github.com/AOSC-Dev/chromium-loongarch64
+
+# Copy and rename patches.
+cp $PREFIX.*.diff "$PWD"/
+rename -v chromium-$VER. "" "$PWD"/*.diff
+rename -v .diff .patch "$PWD"/*.diff
+
+# Cleaning up (-f for when running as normal user).
+rm -rf "$PWD"/chromium-loongarch64

--- a/app-web/chromium/autobuild/patches/copy.sh
+++ b/app-web/chromium/autobuild/patches/copy.sh
@@ -1,6 +1,0 @@
-set -x
-VER=124.0.6367.60
-PREFIX=/buildroots/jiegec/build-chromium/chromium-loongarch64/chromium/chromium-$VER
-cp $PREFIX.*.diff .
-rename -v chromium-$VER. "" *.diff
-rename -v .diff .patch *.diff

--- a/app-web/chromium/spec
+++ b/app-web/chromium/spec
@@ -1,11 +1,11 @@
-VER=124.0.6367.91
+VER=124.0.6367.118
 LAUNCHERVER=8
 SRCS="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$VER.tar.xz \
       https://github.com/foutrelis/chromium-launcher/archive/v$LAUNCHERVER.tar.gz \
       file::rename=chromium-$VER.txt::https://chromium.googlesource.com/chromium/src/+/$VER?format=TEXT"
-CHKSUMS="sha256::376cdcdb46b23eca7f3e6cdb933f27e73968ffb537258d70be503850bbbf1787 \
+CHKSUMS="sha256::8aa5a14aad1234b48b568da9ef23d6e0b1b72d7f4ca5c4039462e54e6ad45d96 \
          sha256::213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a \
-         sha256::a0c1632fcecdca104bc26746d7f766cb592d18ea30ddf070011fb3fbc11c1bb5"
+         sha256::bb5ef0e406c33c9995f84581364bb86666d5bb1873eae302303d906db4dcc05f"
 SUBDIR="chromium-$VER"
 CHKUPDATE="anitya::id=13344"
 ENVREQ__ARM64="total_mem_per_core=3"

--- a/app-web/google-chrome/spec
+++ b/app-web/google-chrome/spec
@@ -1,4 +1,4 @@
-VER=124.0.6367.91
+VER=124.0.6367.118
 SRCS="file::rename=google-chrome-stable_current_amd64.deb::https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_$VER-1_amd64.deb"
-CHKSUMS="sha256::0b209b650e5c7bc58b4edd89552a9b0e42c36e8138065a2267ca497dfddd9926"
+CHKSUMS="sha256::1f76efe96895065e23dfc44e67cd3e483f543bda24fb1c5c285c4377dca358d6"
 CHKUPDATE="anitya::id=5349"


### PR DESCRIPTION
Topic Description
-----------------

- google-chrome: update to 124.0.6367.118
- chromium: update to 124.0.6367.118

Package(s) Affected
-------------------

- chromium: 124.0.6367.118
- google-chrome: 124.0.6367.118

Security Update?
----------------

No

Build Order
-----------

```
#buildit chromium google-chrome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
