### PR TITLE
iproute2: enable automatic colors

### DIFF
--- a/app-network/iproute2/autobuild/prepare
+++ b/app-network/iproute2/autobuild/prepare
@@ -1,2 +1,2 @@
 abinfo "Running configure ..."
-"$SRCDIR"/configure
+"$SRCDIR"/configure --color auto

--- a/app-network/iproute2/spec
+++ b/app-network/iproute2/spec
@@ -1,4 +1,5 @@
 VER=6.8.0
+REL=1
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-$VER.tar.xz"
 CHKSUMS="sha256::03a6cca3d71a908d1f15f7b495be2b8fe851f941458dc4664900d7f45fcf68ce"
 CHKUPDATE="anitya::id=1392"


### PR DESCRIPTION
Topic Description
-----------------

- iproute2: enable automatic colors

Package(s) Affected
-------------------

- iproute2: 6.8.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit iproute2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
