### PR TITLE
discord: update to 0.0.53

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,4 +1,4 @@
-VER=0.0.52
+VER=0.0.53
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::e5c27379d12ec5d1a2ce051e9c1f838c57fe330624f2e4c7e2d8e25b3babfaaf"
+CHKSUMS="sha256::1c3f1b0c5515dd81a4feddd16e6dba9d7583bd48e321fe3291d3ba6060edbd35"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- discord: update to 0.0.53

Package(s) Affected
-------------------

- discord: 0.0.53

Security Update?
----------------

No

Build Order
-----------

```
#buildit discord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
