### PR TITLE
wine (WineHQ): update to 9.8

### DIFF
--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,13 +1,13 @@
 __GECKO_VER=2.47.4
 __MONO_VER=9.1.0
-WINE_VER=9.7
+WINE_VER=9.8
 VER=${WINE_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${WINE_VER:0:1}.x/wine-${WINE_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${WINE_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
-CHKSUMS="sha256::d9f3c333656e88bd4cef5331f34b1c8b69c964a52759eef745d8ddae51a15353 \
+CHKSUMS="sha256::86943c838eda8fad9a7940d4099703394bf1d1be9a1014342fed879c7dc3b993 \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 9.8

Package(s) Affected
-------------------

- wine: 3:9.8+gecko2.47.4+mono9.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
