### PR TITLE
zola: update to 0.18.0

### DIFF
--- a/app-web/zola/spec
+++ b/app-web/zola/spec
@@ -1,5 +1,4 @@
-VER=0.17.1
-SRCS="tbl::https://github.com/getzola/zola/archive/v$VER.tar.gz"
-CHKSUMS="sha256::ac58dd9d43b134d416bb29c19980bbcbbb9dd552c1ade69c72239df2128565d3"
+VER=0.18.0
+SRCS="git::commit=tags/v$VER::https://github.com/getzola/zola"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20639"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- zola: update to 0.18.0

Package(s) Affected
-------------------

- zola: 0.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit zola
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
