### PR TITLE
zziplib: update to 0.13.74

### DIFF
--- a/runtime-common/zziplib/autobuild/defines
+++ b/runtime-common/zziplib/autobuild/defines
@@ -2,6 +2,6 @@ PKGNAME=zziplib
 PKGSEC=libs
 PKGDEP="zlib"
 BUILDDEP="doxygen xmlto"
-PKGDES="A lightweight library that offers the ability to easily extract data from files archived in a single zip file"
+PKGDES="Library to extract data from .zip archives"
 
 AUTOTOOLS_AFTER="PYTHON=/usr/bin/python3"

--- a/runtime-common/zziplib/autobuild/patches/0001-chore-fix-version-0.13.72-0.13.74.patch
+++ b/runtime-common/zziplib/autobuild/patches/0001-chore-fix-version-0.13.72-0.13.74.patch
@@ -1,0 +1,138 @@
+From e8abba0f12dbea06634c73978f6295ca571514e6 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 10 May 2024 16:40:50 +0800
+Subject: [PATCH] chore: fix version 0.13.72 => 0.13.74
+
+The project version was not bumped since v0.13.72.
+---
+ CMakeLists.txt          | 2 +-
+ SDL/CMakeLists.txt      | 2 +-
+ bins/CMakeLists.txt     | 2 +-
+ docs/CMakeLists.txt     | 2 +-
+ docs/tools/md2dbk.py    | 2 +-
+ test/CMakeLists.txt     | 2 +-
+ testbuilds.py           | 2 +-
+ zzip/CMakeLists.txt     | 2 +-
+ zziplib.spec            | 2 +-
+ zzipwrap/CMakeLists.txt | 2 +-
+ 10 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 19feea2..96cf296 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ cmake_minimum_required (VERSION 3.1)
+-project(zziplib VERSION "0.13.72" LANGUAGES C)
++project(zziplib VERSION "0.13.74" LANGUAGES C)
+ 
+ if(NOT CMAKE_BUILD_TYPE) 
+     set(CMAKE_BUILD_TYPE Release)
+diff --git a/SDL/CMakeLists.txt b/SDL/CMakeLists.txt
+index 8650d6a..2a7ca3d 100644
+--- a/SDL/CMakeLists.txt
++++ b/SDL/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ cmake_minimum_required (VERSION 3.1)
+-project(zzipsdl VERSION "0.13.72" LANGUAGES C)
++project(zzipsdl VERSION "0.13.74" LANGUAGES C)
+ 
+ if(NOT CMAKE_BUILD_TYPE) 
+     set(CMAKE_BUILD_TYPE Release)
+diff --git a/bins/CMakeLists.txt b/bins/CMakeLists.txt
+index 445b7b6..af44aba 100644
+--- a/bins/CMakeLists.txt
++++ b/bins/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ cmake_minimum_required (VERSION 3.1)
+-project(zzipbins VERSION "0.13.72" LANGUAGES C)
++project(zzipbins VERSION "0.13.74" LANGUAGES C)
+ 
+ if(NOT CMAKE_BUILD_TYPE) 
+     set(CMAKE_BUILD_TYPE Release)
+diff --git a/docs/CMakeLists.txt b/docs/CMakeLists.txt
+index 9f91fe9..8b1d46d 100644
+--- a/docs/CMakeLists.txt
++++ b/docs/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ cmake_minimum_required (VERSION 3.1)
+-project(zzipbins VERSION "0.13.72" LANGUAGES C)
++project(zzipbins VERSION "0.13.74" LANGUAGES C)
+ 
+ include ( GNUInstallDirs )
+ include ( FindPkgConfig )
+diff --git a/docs/tools/md2dbk.py b/docs/tools/md2dbk.py
+index 5fad450..1c38661 100755
+--- a/docs/tools/md2dbk.py
++++ b/docs/tools/md2dbk.py
+@@ -5,7 +5,7 @@ from __future__ import print_function, absolute_import, division
+ __copyright__ = "(C) 2021 Guido Draheim"
+ __contact__ = "https://github.com/gdraheim/zziplib"
+ __license__ = "CC0 Creative Commons Zero (Public Domain)"
+-__version__ = "0.13.72"
++__version__ = "0.13.74"
+ 
+ from typing import List, Generator, Optional
+ import re
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 753bca3..de829fe 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ cmake_minimum_required (VERSION 3.1)
+-project(zziptest VERSION "0.13.72" LANGUAGES C)
++project(zziptest VERSION "0.13.74" LANGUAGES C)
+ 
+ if(NOT CMAKE_BUILD_TYPE) 
+     set(CMAKE_BUILD_TYPE Release)
+diff --git a/testbuilds.py b/testbuilds.py
+index bf4c276..09fd74d 100755
+--- a/testbuilds.py
++++ b/testbuilds.py
+@@ -2,7 +2,7 @@
+ """ Testcases for zziplib build system """
+ 
+ __copyright__ = "(C) Guido Draheim, all rights reserved"""
+-__version__ = "0.13.72"
++__version__ = "0.13.74"
+ 
+ from typing import Union, Optional, Tuple, List, Iterator
+ import subprocess
+diff --git a/zzip/CMakeLists.txt b/zzip/CMakeLists.txt
+index 4b6fa1b..09da629 100644
+--- a/zzip/CMakeLists.txt
++++ b/zzip/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ cmake_minimum_required (VERSION 3.1)
+-project(zzip VERSION "0.13.72" LANGUAGES C)
++project(zzip VERSION "0.13.74" LANGUAGES C)
+ 
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMakeScripts")
+ 
+diff --git a/zziplib.spec b/zziplib.spec
+index 358646c..944306b 100644
+--- a/zziplib.spec
++++ b/zziplib.spec
+@@ -1,7 +1,7 @@
+ # norootforbuild
+ Summary:      ZZipLib - libZ-based ZIP-access Library with an Easy-to-Use API
+ Name:         zziplib
+-Version:      0.13.72
++Version:      0.13.74
+ Release:      1
+ License:      LGPLv2.1+
+ Group:        System/Libraries
+diff --git a/zzipwrap/CMakeLists.txt b/zzipwrap/CMakeLists.txt
+index 3d57b44..2c9a5e7 100644
+--- a/zzipwrap/CMakeLists.txt
++++ b/zzipwrap/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ cmake_minimum_required (VERSION 3.1)
+-project(zzipwrap VERSION "0.13.72" LANGUAGES C)
++project(zzipwrap VERSION "0.13.74" LANGUAGES C)
+ 
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMakeScripts")
+ 
+-- 
+2.45.0
+

--- a/runtime-common/zziplib/spec
+++ b/runtime-common/zziplib/spec
@@ -1,4 +1,4 @@
-VER=0.13.72
-SRCS="tbl::https://github.com/gdraheim/zziplib/archive/v$VER.tar.gz"
-CHKSUMS="sha256::93ef44bf1f1ea24fc66080426a469df82fa631d13ca3b2e4abaeab89538518dc"
+VER=0.13.74
+SRCS="git::commit=tags/v$VER::https://github.com/gdraheim/zziplib"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13802"


### PR DESCRIPTION
Topic Description
-----------------

- zziplib: update to 0.13.74
    Include a pre-upstream patch to fix version information.

Package(s) Affected
-------------------

- zziplib: 0.13.74

Security Update?
----------------

No

Build Order
-----------

```
#buildit zziplib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
