### PR TITLE
mokutil: fix typo in PKGDEP

### DIFF
--- a/app-admin/mokutil/autobuild/defines
+++ b/app-admin/mokutil/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=mokutil
 PKGSEC=admin
 PKGDES="Shim.efi Machine Owner Key management tool"
-PKGDEP="openssl keyutil efivar"
+PKGDEP="openssl keyutils efivar"


### PR DESCRIPTION
Topic Description
-----------------

- mokutil: fix typo in PKGDEP
    Since the previous version could not be built, REL remains unchanged.

Package(s) Affected
-------------------

- mokutil: 0.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mokutil
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
