### PR TITLE
ffmpeg: fix FTBFS

### DIFF
--- a/app-multimedia/ffmpeg/autobuild/patches/0001-avcodec-mips-Add-switch-for-MADD-instruction.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0001-avcodec-mips-Add-switch-for-MADD-instruction.patch
@@ -1,7 +1,7 @@
 From cac8b0b75e1259c37fbd78ab617622e94ed106ea Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Wed, 17 Feb 2021 22:27:11 +0800
-Subject: [PATCH 1/8] avcodec/mips: Add switch for MADD instruction
+Subject: [PATCH 01/11] avcodec/mips: Add switch for MADD instruction
 
 MADD.{d,s} is only available after MIPS IV and being dropped
 in MIPS R6 (Replaced by FMADD).
@@ -666,5 +666,5 @@ index 0943d6f343..8e8c00bda1 100644
  #endif /* HAVE_INLINE_ASM && HAVE_MIPSFPU */
  }
 -- 
-2.43.0
+2.45.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0002-avutil-mips-Use-MMI_-L-S-QC1-macro-in-SAVE-RECOVER-_.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0002-avutil-mips-Use-MMI_-L-S-QC1-macro-in-SAVE-RECOVER-_.patch
@@ -1,7 +1,8 @@
 From 5dfb9b79d42fe389a2880ba1f98f2dd256b42b66 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 18 Feb 2021 15:34:04 +0800
-Subject: [PATCH 2/8] avutil/mips: Use MMI_{L,S}QC1 macro in {SAVE,RECOVER}_REG
+Subject: [PATCH 02/11] avutil/mips: Use MMI_{L,S}QC1 macro in
+ {SAVE,RECOVER}_REG
 
 {SAVE,RECOVER}_REG will be avilable for Loongson2 again,
 also comment about the magic.
@@ -79,5 +80,5 @@ index 6a82caa908..41715c6490 100644
        : [temp]"r"(temp_backup_reg)                              \
        : "memory"                                                \
 -- 
-2.43.0
+2.45.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0003-avutil-mips-Extract-load-store-with-shift-C1-pair-ma.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0003-avutil-mips-Extract-load-store-with-shift-C1-pair-ma.patch
@@ -1,7 +1,8 @@
 From 0c900c14513a9143a82535bf8ae728f2324ecbe8 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 18 Feb 2021 15:58:25 +0800
-Subject: [PATCH 3/8] avutil/mips: Extract load store with shift C1 pair marco
+Subject: [PATCH 03/11] avutil/mips: Extract load store with shift C1 pair
+ marco
 
 We're doing some fancy hacks with load store with shift C1
 beside unaligned load store. Create a marco for l/r pair
@@ -137,5 +138,5 @@ index 41715c6490..f5b600e50c 100644
   * Backup saved registers
   * We're not using compiler's clobber list as it's not smart enough
 -- 
-2.43.0
+2.45.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0004-avcodec-mips-Use-MMI-marcos-to-replace-Loongson3-ins.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0004-avcodec-mips-Use-MMI-marcos-to-replace-Loongson3-ins.patch
@@ -1,7 +1,7 @@
 From a5c646959b719087c7541624bd0ca65cd83d4a57 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 18 Feb 2021 17:02:07 +0800
-Subject: [PATCH 4/8] avcodec/mips: Use MMI marcos to replace Loongson3
+Subject: [PATCH 04/11] avcodec/mips: Use MMI marcos to replace Loongson3
  instructions
 
 Loongson3's extention instructions (prefixed with gs) are widely used
@@ -1304,5 +1304,5 @@ index e7a83875b9..57825fb967 100644
            [tmp0]"=&r"(tmp[0]),    [tmp1]"=&r"(tmp[1]),
            [src]"+&r"(src),        [dst]"+&r"(dst),
 -- 
-2.43.0
+2.45.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0005-avutil-mips-Use-at-as-MMI-macro-temporary-register.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0005-avutil-mips-Use-at-as-MMI-macro-temporary-register.patch
@@ -1,7 +1,7 @@
 From f549bdb86ce7ac11961806bf6e4ecaab8ffd9193 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 18 Feb 2021 17:35:03 +0800
-Subject: [PATCH 5/8] avutil/mips: Use $at as MMI macro temporary register
+Subject: [PATCH 05/11] avutil/mips: Use $at as MMI macro temporary register
 
 Some function had exceed 30 inline assembly register oprands limiation
 when using LOONGSON2 version of MMI macros. We can avoid that by take
@@ -194,5 +194,5 @@ index f5b600e50c..c1a8046798 100644
  #else /* _MIPS_SIM != _ABIO32 */
  
 -- 
-2.43.0
+2.45.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0006-avcodec-x86-mathops-clip-constants-used-with-shift-i.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0006-avcodec-x86-mathops-clip-constants-used-with-shift-i.patch
@@ -1,7 +1,7 @@
 From f677ead4dd9032d93c4077b3db7e08c199101f8e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
 Date: Sun, 16 Jul 2023 18:18:02 +0300
-Subject: [PATCH 6/8] avcodec/x86/mathops: clip constants used with shift
+Subject: [PATCH 06/11] avcodec/x86/mathops: clip constants used with shift
  instructions within inline assembly
 
 Fixes assembling with binutil as >= 2.41
@@ -72,5 +72,5 @@ index 6298f5ed19..ca7e2dffc1 100644
  }
  
 -- 
-2.43.0
+2.45.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0007-Only-use-cpuinfo-to-read-cpu-ISAs.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0007-Only-use-cpuinfo-to-read-cpu-ISAs.patch
@@ -1,7 +1,7 @@
 From f24ba2a4b3ddcab28fba994b9422e373eb62dae9 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 7 Sep 2020 03:49:55 +0800
-Subject: [PATCH 7/8] Only use cpuinfo to read cpu ISAs
+Subject: [PATCH 07/11] Only use cpuinfo to read cpu ISAs
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
 ---
@@ -133,5 +133,5 @@ index 59619d54de..02579c8047 100644
      /* Assume no SIMD ASE supported */
      return 0;
 -- 
-2.43.0
+2.45.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0008-Add-mips64r6-generic-options.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0008-Add-mips64r6-generic-options.patch
@@ -1,7 +1,7 @@
 From 9c18b08622a6ef56cbc69ff59a9e78ba8eebfcd5 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Tue, 20 Feb 2024 06:57:42 -0800
-Subject: [PATCH 8/8] Add mips64r6 generic options
+Subject: [PATCH 08/11] Add mips64r6 generic options
 
 ---
  configure | 4 ++++
@@ -23,5 +23,5 @@ index 2602bf584a..8218bbfa23 100755
              loongson2e|loongson2f|loongson3*)
                  enable local_aligned
 -- 
-2.43.0
+2.45.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0009-doc-t2h.pm-fix-missing-CSS-with-texinfo-6.8-and-abov.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0009-doc-t2h.pm-fix-missing-CSS-with-texinfo-6.8-and-abov.patch
@@ -1,0 +1,82 @@
+From 7cc351b2bc1fe54b9de420e7b8f69ecee9368001 Mon Sep 17 00:00:00 2001
+From: Matthew White <mehw.is.me@inventati.org>
+Date: Sun, 14 Nov 2021 00:42:27 +0000
+Subject: [PATCH 09/11] doc/t2h.pm: fix missing CSS with texinfo 6.8 and above
+
+Since texinfo commit 6a5ceab6a48a4f052baad9f3474d741428409fd7, the
+formatting functions, in particular begin_file, program_string and
+end_file, are prefixed with format_, i.e. format_begin_file, etc.
+
+This patch fixes building the documentation when texinfo 6.8, or
+above, is used:
+
+Unknown formatting type begin_file
+ at /usr/bin/makeinfo line 415.
+Unknown formatting type program_string
+ at /usr/bin/makeinfo line 415.
+Unknown formatting type end_file
+ at /usr/bin/makeinfo line 415.
+
+(cherry picked from commit c980dd7a976635426f129417836251740e19b54b)
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ doc/t2h.pm | 22 +++++++++++++++++++---
+ 1 file changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/doc/t2h.pm b/doc/t2h.pm
+index e83d564a65..87412699aa 100644
+--- a/doc/t2h.pm
++++ b/doc/t2h.pm
+@@ -126,6 +126,10 @@ foreach my $command (keys(%Texinfo::Common::sectioning_commands), 'node') {
+     texinfo_register_command_formatting($command, \&ffmpeg_heading_command);
+ }
+ 
++# determine if texinfo is at least version 6.8
++my $program_version_num = version->declare(get_conf('PACKAGE_VERSION'))->numify;
++my $program_version_6_8 = $program_version_num >= 6.008000;
++
+ # print the TOC where @contents is used
+ set_from_init_file('INLINE_CONTENTS', 1);
+ 
+@@ -184,7 +188,11 @@ EOT
+ 
+     return $head1 . $head_title . $head2 . $head_title . $head3;
+ }
+-texinfo_register_formatting_function('begin_file', \&ffmpeg_begin_file);
++if ($program_version_6_8) {
++    texinfo_register_formatting_function('format_begin_file', \&ffmpeg_begin_file);
++} else {
++    texinfo_register_formatting_function('begin_file', \&ffmpeg_begin_file);
++}
+ 
+ sub ffmpeg_program_string($)
+ {
+@@ -201,7 +209,11 @@ sub ffmpeg_program_string($)
+       $self->gdt('This document was generated automatically.'));
+   }
+ }
+-texinfo_register_formatting_function('program_string', \&ffmpeg_program_string);
++if ($program_version_6_8) {
++    texinfo_register_formatting_function('format_program_string', \&ffmpeg_program_string);
++} else {
++    texinfo_register_formatting_function('program_string', \&ffmpeg_program_string);
++}
+ 
+ # Customized file ending
+ sub ffmpeg_end_file($)
+@@ -220,7 +232,11 @@ EOT
+ EOT
+     return $program_text . $footer;
+ }
+-texinfo_register_formatting_function('end_file', \&ffmpeg_end_file);
++if ($program_version_6_8) {
++    texinfo_register_formatting_function('format_end_file', \&ffmpeg_end_file);
++} else {
++    texinfo_register_formatting_function('end_file', \&ffmpeg_end_file);
++}
+ 
+ # Dummy title command
+ # Ignore title. Title is handled through ffmpeg_begin_file().
+-- 
+2.45.0
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0010-doc-t2h.pm-fix-missing-TOC-with-texinfo-6.8-and-abov.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0010-doc-t2h.pm-fix-missing-TOC-with-texinfo-6.8-and-abov.patch
@@ -1,0 +1,45 @@
+From 2015a9aeac5bc1bbf51d2cb2021759b01ac29532 Mon Sep 17 00:00:00 2001
+From: Matthew White <mehw.is.me@inventati.org>
+Date: Sun, 14 Nov 2021 01:10:58 +0000
+Subject: [PATCH 10/11] doc/t2h.pm: fix missing TOC with texinfo 6.8 and above
+
+Since texinfo 6.8, there's no longer an INLINE_CONTENTS variable.
+
+makeinfo: warning: set_from_init_file: unknown variable INLINE_CONTENTS
+
+texinfo commit 62a6adfb33b006e187483779974bbd45f0f782b1 replaced
+INLINE_CONTENTS with OUTPUT_CONTENTS_LOCATION.
+
+texinfo commit 41f8ed4eb42bf6daa7df7007afd946875597452d replaced
+OUTPUT_CONTENTS_LOCATION with CONTENTS_OUTPUT_LOCATION.
+
+With texinfo 6.8 and above, the same as INLINE_CONTENTS=1 could be
+achieved by CONTENTS_OUTPUT_LOCATION=inline.
+https://www.gnu.org/software/texinfo/manual/texinfo/html_node/HTML-Customization-Variables.html
+
+(cherry picked from commit bfbd5954e50e407693932b3900ca77c3daee26d7)
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ doc/t2h.pm | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/doc/t2h.pm b/doc/t2h.pm
+index 87412699aa..d07d974286 100644
+--- a/doc/t2h.pm
++++ b/doc/t2h.pm
+@@ -131,7 +131,11 @@ my $program_version_num = version->declare(get_conf('PACKAGE_VERSION'))->numify;
+ my $program_version_6_8 = $program_version_num >= 6.008000;
+ 
+ # print the TOC where @contents is used
+-set_from_init_file('INLINE_CONTENTS', 1);
++if ($program_version_6_8) {
++    set_from_init_file('CONTENTS_OUTPUT_LOCATION', 'inline');
++} else {
++    set_from_init_file('INLINE_CONTENTS', 1);
++}
+ 
+ # make chapters <h2>
+ set_from_init_file('CHAPTER_HEADER_LEVEL', 2);
+-- 
+2.45.0
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0011-doc-html-support-texinfo-7.0.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0011-doc-html-support-texinfo-7.0.patch
@@ -1,0 +1,220 @@
+From d2931b124860f2c6098f9d3b80fa6a6586fdeab4 Mon Sep 17 00:00:00 2001
+From: Frank Plowman <post@frankplowman.com>
+Date: Wed, 8 Nov 2023 07:55:18 +0000
+Subject: [PATCH 11/11] doc/html: support texinfo 7.0
+
+Resolves trac ticket #10636 (http://trac.ffmpeg.org/ticket/10636).
+
+Texinfo 7.0, released in November 2022, changed the names of various
+functions. Compiling docs with Texinfo 7.0 resulted in warnings and
+improperly formatted documentation. More old names appear to have
+been removed in Texinfo 7.1, released October 2023, which causes docs
+compilation to fail.
+
+This commit addresses the issue by adding logic to switch between the old
+and new function names depending on the Texinfo version. Texinfo 6.8
+produces identical documentation before and after the patch.
+
+CC
+https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1938238.html
+https://bugs.gentoo.org/916104
+
+Signed-off-by: Frank Plowman <post@frankplowman.com>
+(cherry picked from commit f01fdedb69e4accb1d1555106d8f682ff1f1ddc7)
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ doc/t2h.pm | 106 ++++++++++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 85 insertions(+), 21 deletions(-)
+
+diff --git a/doc/t2h.pm b/doc/t2h.pm
+index d07d974286..b7485e1f1e 100644
+--- a/doc/t2h.pm
++++ b/doc/t2h.pm
+@@ -20,8 +20,45 @@
+ # License along with FFmpeg; if not, write to the Free Software
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ 
++# Texinfo 7.0 changed the syntax of various functions.
++# Provide a shim for older versions.
++sub ff_set_from_init_file($$) {
++    my $key = shift;
++    my $value = shift;
++    if (exists &{'texinfo_set_from_init_file'}) {
++        texinfo_set_from_init_file($key, $value);
++    } else {
++        set_from_init_file($key, $value);
++    }
++}
++
++sub ff_get_conf($) {
++    my $key = shift;
++    if (exists &{'texinfo_get_conf'}) {
++        texinfo_get_conf($key);
++    } else {
++        get_conf($key);
++    }
++}
++
++sub get_formatting_function($$) {
++    my $obj = shift;
++    my $func = shift;
++
++    my $sub = $obj->can('formatting_function');
++    if ($sub) {
++        return $obj->formatting_function($func);
++    } else {
++        return $obj->{$func};
++    }
++}
++
++# determine texinfo version
++my $program_version_num = version->declare(ff_get_conf('PACKAGE_VERSION'))->numify;
++my $program_version_6_8 = $program_version_num >= 6.008000;
++
+ # no navigation elements
+-set_from_init_file('HEADERS', 0);
++ff_set_from_init_file('HEADERS', 0);
+ 
+ sub ffmpeg_heading_command($$$$$)
+ {
+@@ -55,7 +92,7 @@ sub ffmpeg_heading_command($$$$$)
+         $element = $command->{'parent'};
+     }
+     if ($element) {
+-        $result .= &{$self->{'format_element_header'}}($self, $cmdname,
++        $result .= &{get_formatting_function($self, 'format_element_header')}($self, $cmdname,
+                                                        $command, $element);
+     }
+ 
+@@ -112,7 +149,11 @@ sub ffmpeg_heading_command($$$$$)
+                 $cmdname
+                     = $Texinfo::Common::level_to_structuring_command{$cmdname}->[$heading_level];
+             }
+-            $result .= &{$self->{'format_heading_text'}}(
++            # format_heading_text expects an array of headings for texinfo >= 7.0
++            if ($program_version_num >= 7.000000) {
++                $heading = [$heading];
++            }
++            $result .= &{get_formatting_function($self,'format_heading_text')}(
+                         $self, $cmdname, $heading,
+                         $heading_level +
+                         $self->get_conf('CHAPTER_HEADER_LEVEL') - 1, $command);
+@@ -126,23 +167,19 @@ foreach my $command (keys(%Texinfo::Common::sectioning_commands), 'node') {
+     texinfo_register_command_formatting($command, \&ffmpeg_heading_command);
+ }
+ 
+-# determine if texinfo is at least version 6.8
+-my $program_version_num = version->declare(get_conf('PACKAGE_VERSION'))->numify;
+-my $program_version_6_8 = $program_version_num >= 6.008000;
+-
+ # print the TOC where @contents is used
+ if ($program_version_6_8) {
+-    set_from_init_file('CONTENTS_OUTPUT_LOCATION', 'inline');
++    ff_set_from_init_file('CONTENTS_OUTPUT_LOCATION', 'inline');
+ } else {
+-    set_from_init_file('INLINE_CONTENTS', 1);
++    ff_set_from_init_file('INLINE_CONTENTS', 1);
+ }
+ 
+ # make chapters <h2>
+-set_from_init_file('CHAPTER_HEADER_LEVEL', 2);
++ff_set_from_init_file('CHAPTER_HEADER_LEVEL', 2);
+ 
+ # Do not add <hr>
+-set_from_init_file('DEFAULT_RULE', '');
+-set_from_init_file('BIG_RULE', '');
++ff_set_from_init_file('DEFAULT_RULE', '');
++ff_set_from_init_file('BIG_RULE', '');
+ 
+ # Customized file beginning
+ sub ffmpeg_begin_file($$$)
+@@ -159,7 +196,18 @@ sub ffmpeg_begin_file($$$)
+     my ($title, $description, $encoding, $date, $css_lines,
+         $doctype, $bodytext, $copying_comment, $after_body_open,
+         $extra_head, $program_and_version, $program_homepage,
+-        $program, $generator) = $self->_file_header_informations($command);
++        $program, $generator);
++    if ($program_version_num >= 7.000000) {
++        ($title, $description, $encoding, $date, $css_lines,
++         $doctype, $bodytext, $copying_comment, $after_body_open,
++         $extra_head, $program_and_version, $program_homepage,
++         $program, $generator) = $self->_file_header_information($command);
++    } else {
++        ($title, $description, $encoding, $date, $css_lines,
++         $doctype, $bodytext, $copying_comment, $after_body_open,
++         $extra_head, $program_and_version, $program_homepage,
++         $program, $generator) = $self->_file_header_informations($command);
++    }
+ 
+     my $links = $self->_get_links ($filename, $element);
+ 
+@@ -223,7 +271,7 @@ if ($program_version_6_8) {
+ sub ffmpeg_end_file($)
+ {
+     my $self = shift;
+-    my $program_string = &{$self->{'format_program_string'}}($self);
++    my $program_string = &{get_formatting_function($self,'format_program_string')}($self);
+     my $program_text = <<EOT;
+       <p style="font-size: small;">
+         $program_string
+@@ -244,7 +292,7 @@ if ($program_version_6_8) {
+ 
+ # Dummy title command
+ # Ignore title. Title is handled through ffmpeg_begin_file().
+-set_from_init_file('USE_TITLEPAGE_FOR_TITLE', 1);
++ff_set_from_init_file('USE_TITLEPAGE_FOR_TITLE', 1);
+ sub ffmpeg_title($$$$)
+ {
+     return '';
+@@ -262,8 +310,14 @@ sub ffmpeg_float($$$$$)
+     my $args = shift;
+     my $content = shift;
+ 
+-    my ($caption, $prepended) = Texinfo::Common::float_name_caption($self,
+-                                                                $command);
++    my ($caption, $prepended);
++    if ($program_version_num >= 7.000000) {
++        ($caption, $prepended) = Texinfo::Convert::Converter::float_name_caption($self,
++                                                                                 $command);
++    } else {
++        ($caption, $prepended) = Texinfo::Common::float_name_caption($self,
++                                                                     $command);
++    }
+     my $caption_text = '';
+     my $prepended_text;
+     my $prepended_save = '';
+@@ -335,8 +389,13 @@ sub ffmpeg_float($$$$$)
+             $caption->{'args'}->[0], 'float caption');
+     }
+     if ($prepended_text.$caption_text ne '') {
+-        $prepended_text = $self->_attribute_class('div','float-caption'). '>'
+-                . $prepended_text;
++        if ($program_version_num >= 7.000000) {
++            $prepended_text = $self->html_attribute_class('div',['float-caption']). '>'
++                    . $prepended_text;
++        } else {
++            $prepended_text = $self->_attribute_class('div','float-caption'). '>'
++                    . $prepended_text;
++        }
+         $caption_text .= '</div>';
+     }
+     my $html_class = '';
+@@ -349,8 +408,13 @@ sub ffmpeg_float($$$$$)
+         $prepended_text = '';
+         $caption_text   = '';
+     }
+-    return $self->_attribute_class('div', $html_class). '>' . "\n" .
+-        $prepended_text . $caption_text . $content . '</div>';
++    if ($program_version_num >= 7.000000) {
++        return $self->html_attribute_class('div', [$html_class]). '>' . "\n" .
++            $prepended_text . $caption_text . $content . '</div>';
++    } else {
++        return $self->_attribute_class('div', $html_class). '>' . "\n" .
++            $prepended_text . $caption_text . $content . '</div>';
++    }
+ }
+ 
+ texinfo_register_command_formatting('float',
+-- 
+2.45.0
+

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=4.4.4
-REL=4
+REL=5
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::e80b380d595c809060f66f96a5d849511ef4a76a26b76eacf5778b94c3570309"
 CHKUPDATE="anitya::id=5405"


### PR DESCRIPTION
Topic Description
-----------------

- ffmpeg: fix FTBFS
    Cherry-pick three commits from releases/4.4 branch

Package(s) Affected
-------------------

- ffmpeg: 4.4.4-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
