### PR TITLE
gstreamer (GStreamer): update to 1.24.3

### DIFF
--- a/runtime-multimedia/gstreamer/autobuild/defines
+++ b/runtime-multimedia/gstreamer/autobuild/defines
@@ -56,7 +56,6 @@ MESON_AFTER="-Dpython=enabled \
              -Ddevtools=enabled \
              -Dges=enabled \
              -Drtsp_server=enabled \
-             -Domx=disabled \
              -Dvaapi=enabled \
              -Dsharp=enabled \
              -Drs=enabled \

--- a/runtime-multimedia/gstreamer/autobuild/defines.stage2
+++ b/runtime-multimedia/gstreamer/autobuild/defines.stage2
@@ -53,7 +53,6 @@ MESON_AFTER="-Dpython=enabled \
              -Ddevtools=enabled \
              -Dges=enabled \
              -Drtsp_server=enabled \
-             -Domx=disabled \
              -Dvaapi=enabled \
              -Dsharp=enabled \
              -Drs=enabled \

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,4 @@
-VER=1.22.0
-REL=7
+VER=1.24.3
 SRCS="tbl::https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/$VER/gstreamer-$VER.tar.gz"
-CHKSUMS="sha256::5de8dcf5cc1ae26b3177b7dddbea7943e376cd5ca35d4cb7b43616e6d30b1854"
+CHKSUMS="sha256::ed10e1ce7144ed1791712d32afa485423015b5264f05280653b37724fe382089"
 CHKUPDATE="anitya::id=1263"


### PR DESCRIPTION
Topic Description
-----------------

- gstreamer: update to 1.24.3
    - Drop removed -Domx= switch.

Package(s) Affected
-------------------

- gstreamer: 1.24.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit gstreamer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
