### PR TITLE
Xfce Survey (May, 2024)

### DIFF
--- a/desktop-xfce/garcon/spec
+++ b/desktop-xfce/garcon/spec
@@ -1,4 +1,4 @@
-VER=4.18.1
+VER=4.18.2
 SRCS="https://archive.xfce.org/src/xfce/garcon/${VER%.*}/garcon-$VER.tar.bz2"
-CHKSUMS="sha256::fe7a932a6dac95eb1438f3fbfd53096756ff2e1cb179d10d0fb796cefbb4c20b"
+CHKSUMS="sha256::1b8c9292e131968fbfc8987bbc62c5ba47186dd45ef4e47c5d8c5088bb2d434d"
 CHKUPDATE="anitya::id=231996"

--- a/desktop-xfce/libxfce4ui/spec
+++ b/desktop-xfce/libxfce4ui/spec
@@ -1,4 +1,4 @@
-VER=4.18.4
+VER=4.18.6
 SRCS="https://archive.xfce.org/src/xfce/libxfce4ui/${VER%.*}/libxfce4ui-$VER.tar.bz2"
-CHKSUMS="sha256::87eefe797c6d26de3f754de48872faf131f1b5fc93fb88e22f5c7886a842cb4c"
+CHKSUMS="sha256::77dd99206cc8c6c7f69c269c83c7ee6a037bca9d4a89b1a6d9765e5a09ce30cd"
 CHKUPDATE="anitya::id=232000"

--- a/desktop-xfce/libxfce4util/spec
+++ b/desktop-xfce/libxfce4util/spec
@@ -1,4 +1,4 @@
-VER=4.18.1
+VER=4.18.2
 SRCS="https://archive.xfce.org/src/xfce/libxfce4util/${VER%.*}/libxfce4util-${VER}.tar.bz2"
-CHKSUMS="sha256::8a52063a5adc66252238cad9ee6997909b59983ed21c77eb83c5e67829d1b01f"
+CHKSUMS="sha256::d9a329182b78f7e2520cd4aafcbb276bbbf162f6a89191676539ad2e3889c353"
 CHKUPDATE="anitya::id=232001"

--- a/desktop-xfce/mousepad/spec
+++ b/desktop-xfce/mousepad/spec
@@ -1,4 +1,4 @@
-VER=0.6.1
+VER=0.6.2
 SRCS="https://archive.xfce.org/src/apps/mousepad/${VER%.*}/mousepad-$VER.tar.bz2"
-CHKSUMS="sha256::560c5436c7bc7de33fbf3e9f6cc545280772ad898dfb73257d86533880ffff36"
+CHKSUMS="sha256::e7cacb3b8cb1cd689e6341484691069e73032810ca51fc747536fc36eb18d19d"
 CHKUPDATE="anitya::id=198617"

--- a/desktop-xfce/ristretto/spec
+++ b/desktop-xfce/ristretto/spec
@@ -1,4 +1,4 @@
-VER=0.13.1
+VER=0.13.2
 SRCS="https://archive.xfce.org/src/apps/ristretto/${VER%.*}/ristretto-$VER.tar.bz2"
-CHKSUMS="sha256::d71affbf15245067124725b153c908a53208c4ca1ba2d4df1ec5a1308d53791e"
+CHKSUMS="sha256::779f5ede3016019eec01d64a025583078d3936e35d4288ec2e8433494d757dd9"
 CHKUPDATE="anitya::id=8365"

--- a/desktop-xfce/thunar/spec
+++ b/desktop-xfce/thunar/spec
@@ -1,4 +1,4 @@
-VER=4.18.8
+VER=4.18.10
 SRCS="https://archive.xfce.org/src/xfce/thunar/${VER%.*}/thunar-$VER.tar.bz2"
-CHKSUMS="sha256::3ac23b8a16545025cee860621d270f5f3848d05a3353902abdbc89e779269d2e"
+CHKSUMS="sha256::e8308a1f139602d8c125f594bfcebb063b7dac1fbb6e14293bab4cdb3ecf1d08"
 CHKUPDATE="anitya::id=14669"

--- a/desktop-xfce/xfce4-clipman-plugin/spec
+++ b/desktop-xfce/xfce4-clipman-plugin/spec
@@ -1,4 +1,4 @@
-VER=1.6.5
+VER=1.6.6
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-clipman-plugin/${VER%.*}/xfce4-clipman-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::73156d66c1f866d2af0c20526c5ce58aedbce511b89bb436ba9bc6413fac5190"
+CHKSUMS="sha256::08ad475b006f878df5dd20d83c98edc33ed21e69b414d0e5ff6d4accd64d7120"
 CHKUPDATE="anitya::id=15892"

--- a/desktop-xfce/xfce4-notes-plugin/spec
+++ b/desktop-xfce/xfce4-notes-plugin/spec
@@ -1,4 +1,4 @@
-VER=1.10.0
+VER=1.11.0
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-notes-plugin/${VER%.*}/xfce4-notes-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::2ee4406042edd352a91e166c83b60d13220ef04dce3fa6b9e0eb13636d636929"
+CHKSUMS="sha256::eb38246deb0fc89535fa9ff9b953c762cece232b5585d8210fab9abbf282aae3"
 CHKUPDATE="anitya::id=15833"

--- a/desktop-xfce/xfce4-notifyd/spec
+++ b/desktop-xfce/xfce4-notifyd/spec
@@ -1,4 +1,4 @@
-VER=0.9.3
+VER=0.9.4
 SRCS="https://archive.xfce.org/src/apps/xfce4-notifyd/${VER%.*}/xfce4-notifyd-$VER.tar.bz2"
-CHKSUMS="sha256::79ee4701e2f8715a700de2431aa33682933cab18d76938bb18e2820302bbe030"
+CHKSUMS="sha256::ae6c128c055c44bd07202f73ae69ad833c5e4754f3530696965136e4d9ea7818"
 CHKUPDATE="anitya::id=15832"

--- a/desktop-xfce/xfce4-panel/spec
+++ b/desktop-xfce/xfce4-panel/spec
@@ -1,4 +1,4 @@
-VER=4.18.5
+VER=4.18.6
 SRCS="https://archive.xfce.org/src/xfce/xfce4-panel/${VER%.*}/xfce4-panel-$VER.tar.bz2"
-CHKSUMS="sha256::b20e0d10cc5149a601d8eee07373efb446ea3e179dd032ed8ddb5782e3f9e7cb"
+CHKSUMS="sha256::21337161f58bb9b6e42760cb6883bc79beea27882aa6272b61f0e09d750d7c62"
 CHKUPDATE="anitya::id=232007"

--- a/desktop-xfce/xfce4-screensaver/spec
+++ b/desktop-xfce/xfce4-screensaver/spec
@@ -1,4 +1,4 @@
-VER=4.18.2
+VER=4.18.3
 SRCS="https://archive.xfce.org/src/apps/xfce4-screensaver/${VER%.*}/xfce4-screensaver-${VER}.tar.bz2"
-CHKSUMS="sha256::e4fcd2c414d3a4215e9e86a55edd87e2545b15c961917f5d72cace35b76e2b98"
+CHKSUMS="sha256::d171316136a1189dfe69ef3da7f7a7f842014129ece184cc21ffb13bc0e13a39"
 CHKUPDATE="anitya::id=232009"

--- a/desktop-xfce/xfce4-screenshooter/spec
+++ b/desktop-xfce/xfce4-screenshooter/spec
@@ -1,4 +1,4 @@
-VER=1.10.4
+VER=1.10.5
 SRCS="https://archive.xfce.org/src/apps/xfce4-screenshooter/${VER%.*}/xfce4-screenshooter-$VER.tar.bz2"
-CHKSUMS="sha256::a2f199687e54e16a936d5636d660d42b6b9a5d548cdd0f04bd69213554806494"
+CHKSUMS="sha256::fa711f2a6a5517f575f2e129fe48c2678e836bd4ede5433075f3076d7670621c"
 CHKUPDATE="anitya::id=15830"

--- a/desktop-xfce/xfce4-taskmanager/spec
+++ b/desktop-xfce/xfce4-taskmanager/spec
@@ -1,4 +1,4 @@
-VER=1.5.6
+VER=1.5.7
 SRCS="https://archive.xfce.org/src/apps/xfce4-taskmanager/${VER%.*}/xfce4-taskmanager-$VER.tar.bz2"
-CHKSUMS="sha256::20979000761a41faed4f7f63f27bd18bb36fb27db4f7ecc8784a460701fb4abb"
+CHKSUMS="sha256::6736832f5a64533e536f4994280bd907da19666cda8d2f465c8a53bb581f68bb"
 CHKUPDATE="anitya::id=15824"

--- a/desktop-xfce/xfce4-terminal/spec
+++ b/desktop-xfce/xfce4-terminal/spec
@@ -1,4 +1,4 @@
-VER=1.1.1
+VER=1.1.3
 SRCS="https://archive.xfce.org/src/apps/xfce4-terminal/${VER%.*}/xfce4-terminal-${VER}.tar.bz2"
-CHKSUMS="sha256::5ab5c9b49c00be29f0be4eee5ccfa5073b16f2456185270265a9324549080aa6"
+CHKSUMS="sha256::214dd588d441b69f816009682a3bb4652cc19bed7ea64b612a12f097417b3d45"
 CHKUPDATE="anitya::id=12981"

--- a/desktop-xfce/xfce4-weather-plugin/spec
+++ b/desktop-xfce/xfce4-weather-plugin/spec
@@ -1,4 +1,4 @@
-VER=0.11.1
+VER=0.11.2
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-weather-plugin/${VER%.*}/xfce4-weather-plugin-${VER}.tar.bz2"
-CHKSUMS="sha256::a45146f9a0dcdc95d191c09c64ad279ae289cf8f811c4433e08e31a656845239"
+CHKSUMS="sha256::65d40aff7863550858a9f9d2b6054f27c69a3e7e712991785987f9a73bba876b"
 CHKUPDATE="anitya::id=15820"

--- a/desktop-xfce/xfce4-whiskermenu-plugin/spec
+++ b/desktop-xfce/xfce4-whiskermenu-plugin/spec
@@ -1,4 +1,4 @@
-VER=2.8.2
+VER=2.8.3
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-whiskermenu-plugin/${VER%.*}/xfce4-whiskermenu-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::cbff8325999a20194e0bbce6f4d3d568ce06704d2b79acd9547d6c90aa083e70"
+CHKSUMS="sha256::e776c287658f98d0739447279522fe78766088438242cf2365a49c8973fc9cd0"
 CHKUPDATE="anitya::id=7201"


### PR DESCRIPTION
Topic Description
-----------------

Survey Xfce component updates.

Package(s) Affected
-------------------

- garcon: 4.18.2
- libxfce4ui: 4.18.6
- libxfce4util: 4.18.2
- mousepad: 0.6.2
- ristretto: 0.13.2
- thunar: 4.18.10
- xfce4-clipman-plugin: 1.6.6
- xfce4-notes-plugin: 1.11.0
- xfce4-notifyd: 0.9.4
- xfce4-panel: 1:4.18.6
- xfce4-screensaver: 4.18.3
- xfce4-screenshooter: 1.10.5
- xfce4-taskmanager: 1.5.7
- xfce4-terminal: 1.1.3
- xfce4-weather-plugin: 0.11.2
- xfce4-whiskermenu-plugin: 2.8.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxfce4util libxfce4ui garcon xfce4-panel thunar xfce4-notifyd mousepad ristretto xfce4-screenshooter xfce4-taskmanager xfce4-terminal xfce4-screensaver xfce4-clipman-plugin xfce4-notes-plugin xfce4-weather-plugin xfce4-whiskermenu-plugin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
