### PR TITLE
android-platform-tools (Android Platform Tools): update to 35.0.1

### DIFF
--- a/app-devices/android-platform-tools/spec
+++ b/app-devices/android-platform-tools/spec
@@ -1,5 +1,4 @@
-VER=34.0.5
-REL=1
+VER=35.0.1
 SRCS="https://github.com/nmeum/android-tools/releases/download/$VER/android-tools-$VER.tar.xz"
-CHKSUMS="sha256::fb09cff12cfb82acf42a8ebebbc0342671bfcd02117716368bdc73fdda60304a"
+CHKSUMS="sha256::654030c7f96d25d7224cd6861fac14a043cf1d3980f40288cdfbe219f94ffaf9"
 CHKUPDATE="anitya::id=226905"


### PR DESCRIPTION
Topic Description
-----------------

- android-platform-tools: update to 35.0.1

Package(s) Affected
-------------------

- android-platform-tools: 35.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit android-platform-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
