### PR TITLE
linux-firmware (Linux Firmware): update to 20240506+debian20230210-5~bpo11+1

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,8 +1,8 @@
 DEBIANVER=20230210-5~bpo11+1
-VER=20240405+debian${DEBIANVER/-/+}
+VER=20240506+debian${DEBIANVER/-/+}
 # When using a stable tag.
 # SRCS="git::commit=tags/${VER%%+debian*}::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
-SRCS="git::commit=2180c887de244e846662fa2d0057783a6fa489b4::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
+SRCS="git::commit=b93493c01691104b9a9b612f9e161702418d10a3::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/292e1e5b5bc5756e9314ea6d494d561422d23264/rkwifi/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20240506+debian20230210-5~bpo11+1
    - This snapshot incorporates the following features compared to the previous    snapshot from 20240405:
      - AMD GPU firmware updates.
      - Cirrus Logic sound card firmware updates for various laptops:
        - ASUS Zenbook models (2023) with Cirrus CS35L56.
        - HP laptops with Cirrus CS35L56 smart amplifier.
        - Lenovo Slim 7 (16ARHA7).
        - Lenovo Thinkbook 13x (2024).
        - Lenovo ThinkPad "ICE-1".
        - Lenovo Y770S (with Ciruss CS35L41).
      - Intel Wireless (iwlwifi) firmware updates (core87-44).
      - Intel Xe2LPD DMC firmware update to v2.20.
      - MediaTek MT7922 firmware update to v1.1.
      - Mont-TSSE crypto algorithm accelerator firmware update.
      - NVIDIA Tegra XUSB firmware update to v50.29.
      - Realtek RTL8822C Bluetooth UART firmware update to 0x0FD6_407B.
      - Realtek RTL8822C Bluetooth USB firmware update to 0x0ED6_407B.

Package(s) Affected
-------------------

- firmware-free: 20240506+debian20230210+5~bpo11+1
- firmware-nonfree: 20240506+debian20230210+5~bpo11+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
