### PR TITLE
scrcpy: update to 2.4

### DIFF
--- a/app-devices/scrcpy/autobuild/defines
+++ b/app-devices/scrcpy/autobuild/defines
@@ -12,3 +12,6 @@ MESON_AFTER="-Dcompile_app=true \
              -Dserver_debugger=false \
              -Dv4l2=true \
              -Dusb=true"
+
+# FIXME: android-platform-tools is only available for these architectures.
+FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64)"

--- a/app-devices/scrcpy/spec
+++ b/app-devices/scrcpy/spec
@@ -1,7 +1,7 @@
-VER=2.3.1
+VER=2.4
 SRCS="git::commit=tags/v$VER::https://github.com/Genymobile/scrcpy \
       file::rename=scrcpy-server::https://github.com/Genymobile/scrcpy/releases/download/v$VER/scrcpy-server-v$VER"
 CHKSUMS="SKIP \
-         sha256::f6814822fc308a7a532f253485c9038183c6296a6c5df470a9e383b4f8e7605b"
+         sha256::93c272b7438605c055e127f7444064ed78fa9ca49f81156777fd201e79ce7ba3"
 SUBDIR="scrcpy"
 CHKUPDATE="anitya::id=226924"


### PR DESCRIPTION
Topic Description
-----------------

- scrcpy: update to 2.4
    Sync FAIL_ARCH with android-platform-tools.

Package(s) Affected
-------------------

- scrcpy: 2.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit scrcpy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
