### PR TITLE
FFmpeg: enable CUDA for NVENC

### DIFF
--- a/app-multimedia/ffmpeg/autobuild/build
+++ b/app-multimedia/ffmpeg/autobuild/build
@@ -33,6 +33,7 @@ fi
 if ab_match_arch amd64; then
     MFX="--enable-libmfx"
     NVENC="--enable-nvenc"
+    CUDA="--enable-cuda-llvm"
 fi
 
 if ! ab_match_arch armv4 && \
@@ -84,7 +85,7 @@ if ! ab_match_arch armv4 && \
         --enable-lto \
         --enable-libaom \
         --enable-libsmbclient \
-        $MIPSCONF $PPCCONF $MFX $NVENC
+        $MIPSCONF $PPCCONF $MFX $NVENC $CUDA
 
     abinfo "Building FFmpeg ..."
     make

--- a/app-multimedia/ffmpeg/autobuild/defines
+++ b/app-multimedia/ffmpeg/autobuild/defines
@@ -5,7 +5,7 @@ PKGDEP="alsa-lib bzip2 fontconfig freetype fribidi gnutls gsm lame libass libblu
         x264 x265 opencore-amr opus schroedinger sdl speex v4l-utils xvidcore \
         zlib soxr libva sdl2 numactl ladspa-sdk xz aom samba dav1d avisynthplus"
 PKGDEP__AMD64="${PKGDEP} intel-media-sdk"
-BUILDDEP__AMD64="${BUILDDEP} yasm ffnvcodec"
+BUILDDEP__AMD64="${BUILDDEP} yasm ffnvcodec llvm"
 BUILDDEP_ARM64="${BUILDDEP} yasm"
 PKGDEP__RETRO="alsa-lib bzip2 fontconfig freetype fribidi gnutls lame libass \
               libmodplug libtheora libvdpau libvorbis libxcb x264 xvidcore \

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=4.4.4
-REL=5
+REL=6
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::e80b380d595c809060f66f96a5d849511ef4a76a26b76eacf5778b94c3570309"
 CHKUPDATE="anitya::id=5405"


### PR DESCRIPTION
Topic Description
-----------------

- ffmpeg: enable CUDA for NVENC
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- ffmpeg: 4.4.4-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
