### PR TITLE
lmms: update to 1.2.2+git20240508

### DIFF
--- a/app-creativity/lmms/autobuild/defines
+++ b/app-creativity/lmms/autobuild/defines
@@ -5,10 +5,10 @@ PKGDEP="qt-5 sdl-sound jack libsamplerate fluidsynth portaudio x11-lib \
         shared-mime-info hicolor-icon-theme desktop-file-utils libgig alsa-lib \
         libpng pulseaudio glib libsoundio stk fltk sndio"
 BUILDDEP="git cmake ladspa-sdk raptor2 rasqal x11-lib freetype redland gcc-runtime \
-          chrpath zynaddsubfx ninja perl-list-moreutils"
-BUILDDEP__AMD64="${BUILDDEP} wine carla"
-PKGSUG="fftw zynaddsubfx"
-PKGSUG__AMD64="${PKGSUG} wine carla"
+          chrpath carla zynaddsubfx ninja perl-list-moreutils"
+BUILDDEP__AMD64="${BUILDDEP} wine"
+PKGSUG="fftw zynaddsubfx carla"
+PKGSUG__AMD64="${PKGSUG} wine"
 PKGEPOCH=2
 NOLTO=1
 
@@ -16,9 +16,11 @@ ABTYPE=cmakeninja
 CMAKE_AFTER="-DQT_QMAKE_EXECUTABLE=/usr/bin/qmake-qt5 \
              -DWANT_QT5=yes \
              -DCMAKE_SKIP_RPATH=OFF \
-             -DWANT_WEAKJACK=OFF"
+             -DWANT_WEAKJACK=OFF \
+             -DWANT_VST=OFF"
 CMAKE_AFTER__AMD64=" \
              ${CMAKE_AFTER} \
-             -DWINE_LIBRARY:FILEPATH=/usr/lib/wine"
+             -DWINE_LIBRARY:FILEPATH=/usr/lib/wine \
+             -DWANT_VST=ON"
 
 AB_FLAGS_SPECS=0

--- a/app-creativity/lmms/spec
+++ b/app-creativity/lmms/spec
@@ -1,4 +1,4 @@
-VER=1.2.2+git20240125
-SRCS="git::commit=ffcf8c261dcf8f4fb10d951d1d32571b28cafa01::https://github.com/LMMS/lmms"
+VER=1.2.2+git20240508
+SRCS="git::commit=acefd06f9baca67ef4cc68c6dc0d2072e96f15e6::https://github.com/LMMS/lmms"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1832"


### PR DESCRIPTION
Topic Description
-----------------

- lmms: update to 1.2.2+git20240508
    - fix carla support for architecture other than amd64

Package(s) Affected
-------------------

- lmms: 2:1.2.2+git20240508

Security Update?
----------------

No

Build Order
-----------

```
#buildit lmms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
