### PR TITLE
aosc-findupdate: update to 0.4.7

### DIFF
--- a/app-utils/aosc-findupdate/spec
+++ b/app-utils/aosc-findupdate/spec
@@ -1,4 +1,4 @@
-VER=0.4.6
+VER=0.4.7
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-findupdate"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242066"


### PR DESCRIPTION
Topic Description
-----------------

- aosc-findupdate: update to 0.4.7

Package(s) Affected
-------------------

- aosc-findupdate: 0.4.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-findupdate
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
