### PR TITLE
rbw: update to 1.10.1

### DIFF
--- a/app-utils/rbw/autobuild/defines
+++ b/app-utils/rbw/autobuild/defines
@@ -6,9 +6,7 @@ BUILDDEP="rustc llvm"
 
 USECLANG=1
 
-# ld.lld does not support
-USECLANG__LOONGSON3=0
-USECLANG__MIPS64R6EL=0
-
+# FIXME: ld.lld is not yet available.
 NOLTO__LOONGSON3=1
 NOLTO__MIPS64R6EL=1
+NOLTO__LOONGARCH64=1

--- a/app-utils/rbw/spec
+++ b/app-utils/rbw/spec
@@ -1,4 +1,4 @@
-VER=1.9.0
+VER=1.10.1
 SRCS="git::commit=tags/$VER::https://github.com/doy/rbw"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241513"


### PR DESCRIPTION
Topic Description
-----------------

- rbw: update to 1.10.1

Package(s) Affected
-------------------

- rbw: 1.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rbw
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
