### PR TITLE
yazi: update to 0.2.5

### DIFF
--- a/app-utils/yazi/autobuild/beyond
+++ b/app-utils/yazi/autobuild/beyond
@@ -1,14 +1,14 @@
 abinfo "Installing completions ..."
 mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions
-cp -v "$SRCDIR"/yazi-config/completions/yazi.bash \
+cp -v "$SRCDIR"/yazi-boot/completions/yazi.bash \
         "$PKGDIR"/usr/share/bash-completion/completions/yazi.bash
 
 mkdir -pv "$PKGDIR"/usr/share/fish/completions
-cp -v "$SRCDIR"/yazi-config/completions/yazi.fish \
+cp -v "$SRCDIR"/yazi-boot/completions/yazi.fish \
         "$PKGDIR"/usr/share/fish/completions/yazi.fish
 
 mkdir -pv "$PKGDIR"/usr/share/zsh/site-functions
-cp -v "$SRCDIR"/yazi-config/completions/_yazi \
+cp -v "$SRCDIR"/yazi-boot/completions/_yazi \
 	"$PKGDIR"/usr/share/zsh/site-functions/_yazi
 
 abinfo "Installing .desktop file and icons ..."

--- a/app-utils/yazi/spec
+++ b/app-utils/yazi/spec
@@ -1,4 +1,4 @@
-VER=0.2.3
+VER=0.2.5
 SRCS="git::commit=tags/v$VER::https://github.com/sxyazi/yazi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370571"


### PR DESCRIPTION
Topic Description
-----------------

- yazi: update to 0.2.5

Package(s) Affected
-------------------

- yazi: 0.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit yazi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
