### PR TITLE
fcitx5-pinyin-moegirl: update to 20240509

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20240309
+VER=20240509
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::8abf56400d9ccfc54b2f8ebf19a2d31409cbfc7e6f296ab7b1bcb01d370029bf \
-         sha256::5d4257d2672a5ccd0eedcfbb70640ac30b35c000aa7213fc82c8496ee8406009 \
+CHKSUMS="sha256::2488487c7ed0cc5daff7d6aa5b5ef073f2be01c9ae8d47a3b9df2bebde303637 \
+         sha256::c2c956cb972b5a176aa18ea0df2346d353f5e5a38c8ed0343405de1278e60694 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

Upgrade fcitx5-pinyin-moegirl to 20240509.

Package(s) Affected
-------------------

* fcitx5-pinyin-moegirl

Security Update?
----------------

No

Build Order
----

```
#buildit fcitx5-pinyin-moegirl
```


Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`