### PR TITLE
Telegram Desktop: Rebuild against Qt 5 5.15.13

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,4 +1,5 @@
 VER=5.0.1
+REL=1
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=afd9d5d31798d3eacf9ed6c30601e91d0f1e4d60
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \

--- a/groups/qt5-rebuilds
+++ b/groups/qt5-rebuilds
@@ -1,3 +1,4 @@
 app-i18n/fcitx-qt5
 app-i18n/fcitx5-qt
 app-creativity/lmms
+app-web/telegram-desktop


### PR DESCRIPTION
Topic Description
-----------------

- groups/qt5-rebuilds: add telegram-desktop
- telegram-desktop: rebuild against Qt 5 5.15.13

Package(s) Affected
-------------------

- telegram-desktop: 5.0.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
