### PR TITLE
digikam: rebuild against x265 3.6 update

### DIFF
--- a/desktop-kde/digikam/spec
+++ b/desktop-kde/digikam/spec
@@ -1,5 +1,5 @@
 VER=7.9.0
-REL=3
+REL=4
 SRCS="tbl::http://download.kde.org/stable/digikam/$VER/digiKam-$VER.tar.xz \
       file::rename=shapepredictor.dat::http://cdn.files.kde.org/digikam/facesengine/shape-predictor/shapepredictor.dat \
       file::rename=yolov3-face.cfg::http://cdn.files.kde.org/digikam/facesengine/dnnface/yolov3-face.cfg \


### PR DESCRIPTION
Topic Description
-----------------

- digikam: rebuild against x265 3.6 update

Package(s) Affected
-------------------

- digikam: 7.9.0-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit digikam
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
