### PR TITLE
jack-capture: fix build

### DIFF
--- a/app-multimedia/jack-capture/autobuild/beyond
+++ b/app-multimedia/jack-capture/autobuild/beyond
@@ -1,2 +1,0 @@
-install -Dm755 jack_capture_gui ${PKGDIR}/usr/bin/jack_capture_gui
-install -Dm644 README ${PKGDIR}/usr/share/doc/jack-capture/README

--- a/app-multimedia/jack-capture/autobuild/build
+++ b/app-multimedia/jack-capture/autobuild/build
@@ -1,0 +1,16 @@
+MAKE_DEF=(
+        PREFIX='/usr'
+)
+MAKE_AFTER=(
+        CFLAGS="$CFLAGS"
+        LDFLAGS="$LDFLAGS"
+)
+
+export LDFLAGS="${LDFLAGS} -latomic"
+abinfo "Building jack-capture ..."
+make "${MAKE_DEF[@]}" "${MAKE_AFTER[@]}" -j$(nproc) SKIP_STRIPPING=true
+
+abinfo "Installing jack-capture ..."
+make DESTDIR="$PKGDIR" "${MAKE_DEF[@]}" "${MAKE_AFTER[@]}" install
+install -Dm755 jack_capture_gui ${PKGDIR}/usr/bin/jack_capture_gui
+install -Dm644 README ${PKGDIR}/usr/share/doc/jack-capture/README

--- a/app-multimedia/jack-capture/autobuild/patches/0001-fix_hardening.patch
+++ b/app-multimedia/jack-capture/autobuild/patches/0001-fix_hardening.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 08b8cfc..cc03acd 100644
+--- a/Makefile
++++ b/Makefile
+@@ -12,7 +12,7 @@ CFLAGS += -I/opt/local/include
+ OPTIMIZE=-O3
+ #OPTIMIZE=-O0 -g
+ 
+-COMPILEFLAGS=$(CFLAGS) $(OPTIMIZE) -DVERSION=\"$(VERSION)\" -Wall -Wextra -Wno-unused
++COMPILEFLAGS=$(CPPLAGS) $(CFLAGS) $(OPTIMIZE) -DVERSION=\"$(VERSION)\" -Wall -Wextra -Wno-unused
+ LINKFLAGS=$(LDFLAGS) -ljack -lsndfile -lm -lpthread
+ 
+ OS := $(shell uname)

--- a/app-multimedia/jack-capture/autobuild/patches/0002-spelling.patch
+++ b/app-multimedia/jack-capture/autobuild/patches/0002-spelling.patch
@@ -1,0 +1,26 @@
+diff --git a/README b/README
+index b813b59..8cb7024 100644
+--- a/README
++++ b/README
+@@ -160,7 +160,7 @@ Additional arguments:
+  All hook options take a full-path to an executable as argument.
+  The commands are executed in a fire-and-forget style upon internal events.
+  All output of the hooks is discarded.
+- Paramaters passed to the hook-scripts:
++ Parameters passed to the hook-scripts:
+   open:   CMD <filename>
+   close:  CMD <filename> <xrun-count> <io-error-count>
+   rotate: CMD <filename> <xrun-count> <io-error-count> <new-filename> <seq-number>
+diff --git a/jack_capture.c b/jack_capture.c
+index b2d15a1..6a1971f 100644
+--- a/jack_capture.c
++++ b/jack_capture.c
+@@ -2276,7 +2276,7 @@ static const char *advanced_help =
+   " All hook options take a full-path to an executable as argument.\n"
+   " The commands are executed in a fire-and-forget style upon internal events.\n"
+   " All output of the hooks is discarded.\n"
+-  " Paramaters passed to the hook-scripts:\n"
++  " Parameters passed to the hook-scripts:\n"
+   "  open:   CMD <filename>\n"
+   "  close:  CMD <filename> <xrun-count> <io-error-count>\n"
+   "  rotate: CMD <filename> <xrun-count> <io-error-count> <new-filename> <seq-number>\n"

--- a/app-multimedia/jack-capture/autobuild/patches/0003-fix_asprintf.patch
+++ b/app-multimedia/jack-capture/autobuild/patches/0003-fix_asprintf.patch
@@ -1,0 +1,68 @@
+diff --git a/jack_capture.c b/jack_capture.c
+index b2d15a1..ccbfa5c 100644
+--- a/jack_capture.c
++++ b/jack_capture.c
+@@ -20,6 +20,8 @@
+ 
+ #include "das_config.h"
+ 
++#define _GNU_SOURCE 1
++
+ #include <signal.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+@@ -900,54 +902,6 @@ static void stop_helper_thread(void){
+ /////////////////////////////////////////////////////////////////////
+ 
+ 
+-#ifndef __USE_GNU
+-/* This code has been derived from an example in the glibc2 documentation.
+- * "asprintf() implementation for braindamaged operating systems"
+- * Copyright (C) 1991, 1994-1999, 2000, 2001 Free Software Foundation, Inc.
+- */
+-#ifdef _WIN32
+-#define vsnprintf _vsnprintf
+-#endif
+-#ifndef __APPLE__
+-int asprintf(char **buffer, char *fmt, ...) {
+-    /* Guess we need no more than 200 chars of space. */
+-    int size = 200;
+-    int nchars;
+-    va_list ap;
+-
+-    *buffer = (char*)malloc(size);
+-    if (*buffer == NULL) return -1;
+-
+-    /* Try to print in the allocated space. */
+-    va_start(ap, fmt);
+-    nchars = vsnprintf(*buffer, size, fmt, ap);
+-    va_end(ap);
+-
+-    if (nchars >= size)
+-    {
+-        char *tmpbuff;
+-        /* Reallocate buffer now that we know how much space is needed. */
+-        size = nchars+1;
+-        tmpbuff = (char*)realloc(*buffer, size);
+-
+-        if (tmpbuff == NULL) { /* we need to free it*/
+-            free(*buffer);
+-            return -1;
+-        }
+-
+-        *buffer=tmpbuff;
+-        /* Try again. */
+-        va_start(ap, fmt);
+-        nchars = vsnprintf(*buffer, size, fmt, ap);
+-        va_end(ap);
+-    }
+-
+-    if (nchars < 0) return nchars;
+-    return size;
+-}
+-#endif
+-#endif
+-
+ #define ARGS_ADD_ARGV(FMT,ARG) \
+   argv=(char**) realloc((void*)argv, (argc+2)*sizeof(char*)); \
+   asprintf(&argv[argc++], FMT, ARG); argv[argc] = 0;

--- a/app-multimedia/jack-capture/autobuild/prepare
+++ b/app-multimedia/jack-capture/autobuild/prepare
@@ -1,1 +1,0 @@
-export LDFLAGS="${LDFLAGS} -latomic"

--- a/app-multimedia/jack-capture/spec
+++ b/app-multimedia/jack-capture/spec
@@ -1,5 +1,5 @@
 VER=0.9.73
+REL=3
 SRCS="tbl::https://archive.notam02.no/arkiv/src/jack_capture-$VER.tar.gz"
 CHKSUMS="sha256::21afb0257ed7437708cc9e5bec2f6299599461b7eec8bf66967d8ecadb0751de"
-REL=2
 CHKUPDATE="anitya::id=9925"


### PR DESCRIPTION
Topic Description
-----------------

- jack-capture: fix build
    autobuild4 requires a build script to be provided for the makefile type.
    suspected compatibility issue caused by gcc upgrade, fixed through patch.

Package(s) Affected
-------------------

- jack-capture: 0.9.73-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit jack-capture
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
