### PR TITLE
go (Golang): security update to 1.22.3

### DIFF
--- a/app-admin/conmon/spec
+++ b/app-admin/conmon/spec
@@ -1,5 +1,5 @@
 VER=2.1.10
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/containers/conmon"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=96793"

--- a/app-admin/runc/spec
+++ b/app-admin/runc/spec
@@ -1,5 +1,5 @@
 VER=1.1.12
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/opencontainers/runc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7462"

--- a/app-admin/snapd/spec
+++ b/app-admin/snapd/spec
@@ -1,5 +1,5 @@
 VER=2.61.2
-REL=1
+REL=2
 SRCS="https://github.com/snapcore/snapd/releases/download/$VER/snapd_$VER.vendor.tar.xz"
 CHKSUMS="sha256::d000725250a4d9c8a931b74df9733479a2851d03fe1e663a81fcb61b21509702"
 CHKUPDATE="anitya::id=12370"

--- a/app-containers/containerd/spec
+++ b/app-containers/containerd/spec
@@ -1,5 +1,5 @@
 VER=1.7.13
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/containerd/containerd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16460"

--- a/app-containers/docker-compose/spec
+++ b/app-containers/docker-compose/spec
@@ -1,5 +1,5 @@
 VER=2.24.6
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/docker/compose"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6185"

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -1,5 +1,5 @@
 # Find tini version at:
-REL=1
+REL=2
 #
 # https://github.com/moby/moby/blob/v$PKGVER/hack/dockerfile/install/tini.installer
 TINI_VER=0.19.0

--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -4,7 +4,7 @@
 PODMAN_VER=4.9.3
 GVISOR_TAP_VSOCK_VER=0.7.2
 VER=${PODMAN_VER}+vsock${GVISOR_TAP_VSOCK_VER}
-REL=2
+REL=3
 SRCS="tbl::https://github.com/containers/podman/archive/v${PODMAN_VER}.tar.gz \
       git::commit=tags/v${GVISOR_TAP_VSOCK_VER};rename=gvisor-tap-vsock::https://github.com/containers/gvisor-tap-vsock"
 CHKSUMS="sha256::37afc5bba2738c68dc24400893b99226c658cc9a2b22309f4d7abe7225d8c437 \

--- a/app-devel/cf-tool/spec
+++ b/app-devel/cf-tool/spec
@@ -1,5 +1,5 @@
 VER=1.0.0
-REL=5
+REL=6
 SRCS="git::commit=tags/v$VER::https://github.com/xalanq/cf-tool"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235020"

--- a/app-devel/gh/spec
+++ b/app-devel/gh/spec
@@ -2,3 +2,4 @@ VER=2.49.0
 SRCS="git::commit=tags/v$VER::https://github.com/cli/cli"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235195"
+REL=1

--- a/app-devel/git-lfs/spec
+++ b/app-devel/git-lfs/spec
@@ -1,5 +1,5 @@
 VER=3.5.0
-REL=1
+REL=2
 SRCS=git::commit=tags/v${VER}::https://github.com/git-lfs/git-lfs.git
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11551"

--- a/app-devices/android-platform-tools/spec
+++ b/app-devices/android-platform-tools/spec
@@ -2,3 +2,4 @@ VER=35.0.1
 SRCS="https://github.com/nmeum/android-tools/releases/download/$VER/android-tools-$VER.tar.xz"
 CHKSUMS="sha256::654030c7f96d25d7224cd6861fac14a043cf1d3980f40288cdfbe219f94ffaf9"
 CHKUPDATE="anitya::id=226905"
+REL=1

--- a/app-doc/go-md2man/spec
+++ b/app-doc/go-md2man/spec
@@ -1,5 +1,5 @@
 VER=2.0.3
-REL=1
+REL=2
 SRCS="git::commit=tags/v${VER}::https://github.com/cpuguy83/go-md2man"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14461"

--- a/app-editors/liteide/spec
+++ b/app-editors/liteide/spec
@@ -1,5 +1,5 @@
 VER=38.3
-REL=2
+REL=3
 SRCS="git::commit=tags/x$VER::https://github.com/visualfc/liteide.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227233"

--- a/app-editors/micro/spec
+++ b/app-editors/micro/spec
@@ -1,5 +1,5 @@
 VER=2.0.13
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/zyedidia/micro"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19017"

--- a/app-network/chisel/spec
+++ b/app-network/chisel/spec
@@ -1,5 +1,5 @@
 VER=1.9.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/jpillora/chisel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=135401"

--- a/app-network/clash/spec
+++ b/app-network/clash/spec
@@ -1,5 +1,5 @@
 VER=1.18.0
-REL=2
+REL=3
 SRCS="https://repo.aosc.io/aosc-repacks/clash-1.18.0.tar.gz"
 CHKSUMS="sha256::139794f50d3d94f438bab31a993cf25d7cbdf8ca8e034f3071e0dd0014069692"
 CHKUPDATE="anitya::id=211719"

--- a/app-network/dnscrypt/spec
+++ b/app-network/dnscrypt/spec
@@ -1,5 +1,5 @@
 VER=2.1.5
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER::https://github.com/jedisct1/dnscrypt-proxy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15546"

--- a/app-network/frp/spec
+++ b/app-network/frp/spec
@@ -2,3 +2,4 @@ VER=0.57.0
 SRCS="git::commit=tags/v$VER::https://github.com/fatedier/frp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230969"
+REL=1

--- a/app-network/geoipupdate/spec
+++ b/app-network/geoipupdate/spec
@@ -2,3 +2,4 @@ VER=6.1.0
 SRCS="git::commit=tags/v$VER::https://github.com/maxmind/geoipupdate"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230971"
+REL=1

--- a/app-network/gost/spec
+++ b/app-network/gost/spec
@@ -1,5 +1,5 @@
 VER=2.11.5
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/ginuerzh/gost"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230972"

--- a/app-network/graftcp/spec
+++ b/app-network/graftcp/spec
@@ -1,5 +1,5 @@
 VER=0.7.2
-REL=1
+REL=2
 SRCS="git::commit=v$VER::https://github.com/hmgle/graftcp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230973"

--- a/app-network/kcptun/spec
+++ b/app-network/kcptun/spec
@@ -1,5 +1,5 @@
 VER=20240107
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/xtaci/kcptun"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14970"

--- a/app-network/kubo/spec
+++ b/app-network/kubo/spec
@@ -1,5 +1,5 @@
 VER=0.26.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/ipfs/kubo"
 CHKSUMS="sha256::e9430e071949b222ecd40571927eebb7fe108cb17144b9f385fcc309a446e243"
 CHKUPDATE="anitya::id=328587"

--- a/app-network/mihomo/spec
+++ b/app-network/mihomo/spec
@@ -1,5 +1,5 @@
 VER=1.18.2
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/MetaCubeX/mihomo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371845"

--- a/app-network/obfs4proxy/spec
+++ b/app-network/obfs4proxy/spec
@@ -1,5 +1,5 @@
 VER=0.0.14
-REL=1
+REL=2
 SRCS="git::commit=tags/obfs4proxy-$VER::https://gitlab.com/yawning/obfs4.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=195186"

--- a/app-network/popub/spec
+++ b/app-network/popub/spec
@@ -1,5 +1,5 @@
 VER=0+git20210814
-REL=3
+REL=4
 SRCS="git::commit=a96c877dbf168309d73525a7987dd0d26e5c03cc::https://github.com/m13253/popub"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243319"

--- a/app-network/syncthing/spec
+++ b/app-network/syncthing/spec
@@ -1,5 +1,5 @@
 VER=1.27.3
-REL=1
+REL=2
 SRCS="https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
 CHKSUMS="sha256::3fe25b863bb3a0f74bc95a7afa71bdaa2a79971542962236be5d85f469aa897d"
 CHKUPDATE="anitya::id=11814"

--- a/app-network/tailscale/spec
+++ b/app-network/tailscale/spec
@@ -2,3 +2,4 @@ VER=1.64.2
 SRCS="git::commit=tags/v${VER}::https://github.com/tailscale/tailscale"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141585"
+REL=1

--- a/app-network/v2ray-plugin/spec
+++ b/app-network/v2ray-plugin/spec
@@ -1,5 +1,5 @@
 VER=1.3.2
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/shadowsocks/v2ray-plugin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231002"

--- a/app-network/v2ray/spec
+++ b/app-network/v2ray/spec
@@ -1,5 +1,5 @@
 VER=5.13.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/v2fly/v2ray-core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=134851"

--- a/app-network/v2raya/spec
+++ b/app-network/v2raya/spec
@@ -1,5 +1,5 @@
 VER=2.2.5.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/v2rayA/v2rayA"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326097"

--- a/app-network/xray/spec
+++ b/app-network/xray/spec
@@ -1,5 +1,5 @@
 VER=1.8.4
-REL=1
+REL=2
 SRCS="tbl::https://github.com/XTLS/Xray-core/archive/v$VER.tar.gz"
 CHKSUMS="sha256::89f73107abba9bd438111edfe921603ddb3c2b631b2716fbdc6be78552f0d322"
 CHKUPDATE="anitya::id=231005"

--- a/app-utils/automatic-component-toolkit/spec
+++ b/app-utils/automatic-component-toolkit/spec
@@ -1,5 +1,5 @@
 VER="1.6.0"
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/Autodesk/AutomaticComponentToolkit"
 CHKSUMS="SKIP"
 CHKUPDATE="git::url=https://github.com/Autodesk/AutomaticComponentToolkit.git"

--- a/app-utils/direnv/spec
+++ b/app-utils/direnv/spec
@@ -1,5 +1,5 @@
 VER=2.34.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/direnv/direnv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11598"

--- a/app-utils/fzf/spec
+++ b/app-utils/fzf/spec
@@ -1,5 +1,5 @@
 VER=0.46.1
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/junegunn/fzf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15856"

--- a/app-utils/pcstat/spec
+++ b/app-utils/pcstat/spec
@@ -1,5 +1,5 @@
 VER=0.0.2
-REL=2
+REL=3
 SRCS="git::commit=tags/v${VER}::https://github.com/tobert/pcstat.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231629"

--- a/app-utils/restic/spec
+++ b/app-utils/restic/spec
@@ -1,5 +1,5 @@
 VER=0.16.4
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/restic/restic"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16643"

--- a/app-vcs/hub/spec
+++ b/app-vcs/hub/spec
@@ -1,5 +1,5 @@
 VER=2.14.2+git20230617
-REL=2
+REL=3
 SRCS="git::commit=bd8019b77e4a707ba5f5145b4b920e09de651c13::https://github.com/github/hub"
 CHKSUMS="SKIP"
 SUBDIR=.

--- a/app-web/hugo/spec
+++ b/app-web/hugo/spec
@@ -1,5 +1,5 @@
 VER=0.123.6
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/gohugoio/hugo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12959"

--- a/app-web/rclone/spec
+++ b/app-web/rclone/spec
@@ -1,5 +1,5 @@
 VER=1.65.2
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/rclone/rclone/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11750"

--- a/lang-golang/delve/spec
+++ b/lang-golang/delve/spec
@@ -1,5 +1,5 @@
 VER=1.22.1
-REL=1
+REL=2
 SRCS="https://github.com/go-delve/delve/archive/refs/tags/v$VER.tar.gz"
 CHKSUMS="sha256::fe6f0d97c233d4f0f1ed422c11508cc57c14e9e0915f9a258f1912c46824cbfb"
 CHKUPDATE="anitya::id=40149"

--- a/lang-golang/dep/spec
+++ b/lang-golang/dep/spec
@@ -1,5 +1,5 @@
 VER=0.5.4
-REL=18
+REL=19
 SRCS="https://github.com/golang/dep/archive/v$VER.tar.gz"
 CHKSUMS="sha256::929c8f759838f98323211ba408a831ea80d93b75beda8584b6d950f393a3298a"
 CHKUPDATE="anitya::id=18652"

--- a/lang-golang/glide/spec
+++ b/lang-golang/glide/spec
@@ -1,5 +1,5 @@
 VER=0.13.3
-REL=18
+REL=19
 SRCS="git::commit=tags/v$VER::https://github.com/Masterminds/glide"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11625"

--- a/lang-golang/go/spec
+++ b/lang-golang/go/spec
@@ -1,14 +1,14 @@
 # Versions of Golang, net library and Go tools
-TOOLS_VER=0.20.0
-NET_VER=0.24.0
-GOLANG_VER=1.22.2
+TOOLS_VER=0.21.0
+NET_VER=0.25.0
+GOLANG_VER=1.22.3
 
 VER="${GOLANG_VER}+tools${TOOLS_VER}+net${NET_VER}"
 REL=1
 SRCS="tbl::https://go.dev/dl/go${GOLANG_VER}.src.tar.gz \
       git::commit=tags/v${TOOLS_VER};rename=tools::https://go.googlesource.com/tools \
       git::commit=tags/v${NET_VER};rename=net::https://github.com/golang/net"
-CHKSUMS="sha256::374ea82b289ec738e968267cac59c7d5ff180f9492250254784b2044e90df5a9 \
+CHKSUMS="sha256::80648ef34f903193d72a59c0dff019f5f98ae0c9aa13ade0b0ecbff991a76f68 \
          SKIP \
          SKIP"
 CHKUPDATE="anitya::id=1227"

--- a/runtime-virtualization/libguestfs/spec
+++ b/runtime-virtualization/libguestfs/spec
@@ -1,5 +1,5 @@
 VER=1.52.0
-REL=2
+REL=3
 SRCS="tbl::https://download.libguestfs.org/${VER:0:4}-stable/libguestfs-$VER.tar.gz"
 CHKSUMS="sha256::2f8d9b8eb032b980ce9c4ae8ea87f41d5d9056c7bfa20c30aa0a2cd86adf70dc"
 CHKUPDATE="anitya::id=229572"


### PR DESCRIPTION
Topic Description
-----------------

Update Golang to 1.22.3 to address two security vulnerabilities noted in #5898 and rebuild all Golang packages.

Package(s) Affected
-------------------

- android-platform-tools: 35.0.1-1
- automatic-component-toolkit: 1.6.0-3
- cf-tool: 1.0.0-6
- chisel: 1.9.1-2
- clash: 1.18.0-3
- conmon: 2.1.10-2
- containerd: 1.7.13-2
- delve: 1.22.1-2
- dep: 0.5.4-19
- direnv: 2.34.0-2
- dnscrypt: 2.1.5-3
- docker-compose: 2.24.6-2
- docker: 25.0.3+tini0.19.0-2
- frp: 0.57.0-1
- fzf: 0.46.1-2
- geoipupdate: 6.1.0-1
- gh: 2.49.0-1
- git-lfs: 3.5.0-2
- glide: 0.13.3-19
- go-md2man: 2.0.3-2
- go: 1.22.3+tools0.21.0+net0.25.0-1
- gost: 2.11.5-2
- graftcp: 1:0.7.2-2
- hub: 2.14.2+git20230617-3
- hugo: 0.123.6-2
- kcptun: 20240107-2
- kubo: 0.26.0-2
- libguestfs: 1.52.0-3
- liteide: 38.3-3
- micro: 2.0.13-3
- mihomo: 1.18.2-2
- obfs4proxy: 0.0.14-2
- pcstat: 1:0.0.2-3
- podman: 4.9.3+vsock0.7.2-3
- popub: 1:0+git20210814-4
- rclone: 1.65.2-2
- restic: 0.16.4-2
- runc: 1.1.12-2
- snapd: 2.61.2-2
- syncthing: 1.27.3-2
- tailscale: 1.64.2-1
- v2ray-plugin: 1.3.2-3
- v2ray: 5.13.0-2
- v2raya: 2.2.5.1-2
- xray: 1.8.4-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit go groups/go-rebuilds
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
