### PR TITLE
mesa (Mesa 3D Library): update to 24.0.7+dxheaders1.613.1

### DIFF
--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,9 +1,9 @@
-MESA_VER=24.0.6
-DXHEADERS_VER=1.611.0
+MESA_VER=24.0.7
+DXHEADERS_VER=1.613.1
 VER=${MESA_VER}+dxheaders${DXHEADERS_VER}
 SRCS="tbl::https://archive.mesa3d.org/mesa-${MESA_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
-CHKSUMS="sha256::8b7a92dbe6468c18f2383700135b5fe9de836cdf0cc8fd7dbae3c7110237d604 \
+CHKSUMS="sha256::7454425f1ed4a6f1b5b107e1672b30c88b22ea0efea000ae2c7d96db93f6c26a \
          SKIP"
 SUBDIR="mesa-${MESA_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 24.0.7+dxheaders1.613.1

Package(s) Affected
-------------------

- mesa: 1:24.0.7+dxheaders1.613.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
