### PR TITLE
gdb: update to 14.2

### DIFF
--- a/app-devel/gdb/spec
+++ b/app-devel/gdb/spec
@@ -1,4 +1,4 @@
-VER=14.1
+VER=14.2
 SRCS="tbl::https://ftp.gnu.org/gnu/gdb/gdb-$VER.tar.xz"
-CHKSUMS="sha256::d66df51276143451fcbff464cc8723d68f1e9df45a6a2d5635a54e71643edb80"
+CHKSUMS="sha256::2d4dd8061d8ded12b6c63f55e45344881e8226105f4d2a9b234040efa5ce7772"
 CHKUPDATE="anitya::id=11798"


### PR DESCRIPTION
Topic Description
-----------------

- gdb: update to 14.2
    Co-authored-by: jiegec <c@jia.je>

Package(s) Affected
-------------------

- gdb: 14.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
