### PR TITLE
cmake: update to 3.29.3

### DIFF
--- a/app-devel/cmake/spec
+++ b/app-devel/cmake/spec
@@ -1,4 +1,4 @@
-VER=3.29.2
+VER=3.29.3
 SRCS="tbl::https://cmake.org/files/v${VER:0:4}/cmake-$VER.tar.gz"
-CHKSUMS="sha256::36db4b6926aab741ba6e4b2ea2d99c9193222132308b4dc824d4123cb730352e"
+CHKSUMS="sha256::252aee1448d49caa04954fd5e27d189dd51570557313e7b281636716a238bccb"
 CHKUPDATE="anitya::id=306"


### PR DESCRIPTION
Topic Description
-----------------

- cmake: update to 3.29.3
    Co-authored-by: jiegec <c@jia.je>

Package(s) Affected
-------------------

- cmake: 3.29.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit cmake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
