### PR TITLE
automake: update to 1.16.5

### DIFF
--- a/app-devel/automake/spec
+++ b/app-devel/automake/spec
@@ -1,4 +1,4 @@
-VER=1.16i
+VER=1.16.5
 SRCS="git::commit=tags/v$VER::https://git.savannah.gnu.org/git/automake.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=144"


### PR DESCRIPTION
Topic Description
-----------------

- automake: update to 1.16.5
    Co-authored-by: jiegec <c@jia.je>

Package(s) Affected
-------------------

- automake: 2:1.16.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit automake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
