### PR TITLE
xorg-server: update to 21.1.13

### DIFF
--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,4 @@
-VER=21.1.12
+VER=21.1.13
 SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
-CHKSUMS="sha256::1e016e2be1b5ccdd65eac3ea08e54bd13ce8f4f6c3fb32ad6fdac4e71729a90f"
+CHKSUMS="sha256::b45a02d5943f72236a360d3cc97e75134aa4f63039ff88c04686b508a3dc740c"
 CHKUPDATE="anitya::id=5250"


### PR DESCRIPTION
Topic Description
-----------------

- xorg-server: update to 21.1.13
    Co-authored-by: jiegec <c@jia.je>

Package(s) Affected
-------------------

- xorg-server: 21.1.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorg-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
