### PR TITLE
fcitx5: add dependencies for classic ui plugin

### DIFF
--- a/app-i18n/fcitx5/autobuild/defines
+++ b/app-i18n/fcitx5/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=fcitx5
 PKGSEC=x11
 PKGDEP="enchant iso-codes cairo xkeyboard-config libxkbcommon pango \
         systemd wayland wayland-protocols xcb-imdkit xcb-util-wm \
-        cldr-emoji-annotation fmt imchooser"
+        cldr-emoji-annotation fmt imchooser gdk-pixbuf glib"
 BUILDDEP="extra-cmake-modules"
 PKGCONFL="fcitx"
 PKGDES="A generic input method framework"

--- a/app-i18n/fcitx5/spec
+++ b/app-i18n/fcitx5/spec
@@ -1,4 +1,5 @@
 VER=5.1.9
+REL=1
 SRCS="tbl::https://github.com/fcitx/fcitx5/archive/$VER.tar.gz \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5/fcitx5-${VER}_dict.tar.zst"
 CHKSUMS="sha256::00c714d94018182f9501fb60cbabd05d47824713f0d85572b06f6e6a2283b6dc \


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5: add dependencies for classic ui plugin
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- fcitx5: 1:5.1.9-1
- xcb-imdkit: 1:1.0.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit xcb-imdkit fcitx5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
