### PR TITLE
mihomo: update to 1.18.4

### DIFF
--- a/app-network/mihomo/spec
+++ b/app-network/mihomo/spec
@@ -1,5 +1,4 @@
-VER=1.18.2
-REL=2
+VER=1.18.4
 SRCS="git::commit=tags/v$VER::https://github.com/MetaCubeX/mihomo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371845"


### PR DESCRIPTION
Topic Description
-----------------

- mihomo: update to 1.18.4
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- mihomo: 1.18.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit mihomo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
