### PR TITLE
appres: update to 1.0.6

### DIFF
--- a/app-utils/appres/spec
+++ b/app-utils/appres/spec
@@ -1,4 +1,4 @@
-VER=1.0.5
+VER=1.0.6
 SRCS="tbl::https://ftp.x.org/pub/individual/app/appres-$VER.tar.gz"
-CHKSUMS="sha256::c9257a3688ce48aa8f3d51f9767ba59b6e3fffff58b801965d3c87bb95104481"
+CHKSUMS="sha256::848f383ff429612fb9df840d79e97dc193dc72dbbf53d3217a8d1e90a5aa1e26"
 CHKUPDATE="anitya::id=15053"


### PR DESCRIPTION
Topic Description
-----------------

- appres: update to 1.0.6
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- appres: 1.0.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit appres
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
