### PR TITLE
apache-maven: update to 3.9.6

### DIFF
--- a/lang-java/apache-maven/spec
+++ b/lang-java/apache-maven/spec
@@ -1,5 +1,5 @@
-VER=3.9.4
+VER=3.9.6
 SRCS="tbl::https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/$VER/apache-maven-${VER}-src.tar.gz"
-CHKSUMS="sha256::d34f6a488c741c31a717301cd7b42d37aaa939cf981e950b707f4203e0bab956"
+CHKSUMS="sha256::817d8fbfc1f4d91712bfb1ff839a603f9873c4125e89151ae52b56f72ee8043e"
 CHKUPDATE="anitya::id=1894"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- apache-maven: update to 3.9.6
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- apache-maven: 3.9.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit apache-maven
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
