### PR TITLE
apr-util: update to 1.6.3

### DIFF
--- a/runtime-common/apr-util/spec
+++ b/runtime-common/apr-util/spec
@@ -1,5 +1,4 @@
-VER=1.6.1
-REL=8
+VER=1.6.3
 SRCS="tbl::https://archive.apache.org/dist/apr/apr-util-$VER.tar.gz"
-CHKSUMS="sha256::b65e40713da57d004123b6319828be7f1273fbc6490e145874ee1177e112c459"
+CHKSUMS="sha256::2b74d8932703826862ca305b094eef2983c27b39d5c9414442e9976a9acf1983"
 CHKUPDATE="anitya::id=96"


### PR DESCRIPTION
Topic Description
-----------------

- apr-util: update to 1.6.3
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- apr-util: 1.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit apr-util
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
