### PR TITLE
apt-fast: update to 1.11.0

### DIFF
--- a/app-admin/apt-fast/spec
+++ b/app-admin/apt-fast/spec
@@ -1,4 +1,4 @@
-VER=1.9.11
+VER=1.11.0
 SRCS="tbl::https://github.com/ilikenwf/apt-fast/archive/$VER.tar.gz"
-CHKSUMS="sha256::1085c0bec32338a1f67b19cf350f6340253ff47d94ad66c382bf5e3c3d0407ca"
+CHKSUMS="sha256::ede19ac3b14a24fb7b640f26da696acda0e22ff03a3b0d6d9065cd2fc5978cbb"
 CHKUPDATE="anitya::id=226908"


### PR DESCRIPTION
Topic Description
-----------------

- apt-fast: update to 1.11.0
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- apt-fast: 1.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit apt-fast
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
