### PR TITLE
arping: update to 2.24

### DIFF
--- a/app-network/arping/spec
+++ b/app-network/arping/spec
@@ -1,5 +1,4 @@
-VER=2.20
-REL=1
+VER=2.24
 SRCS="tbl::http://www.habets.pp.se/synscan/files/arping-$VER.tar.gz"
-CHKSUMS="sha256::34e108923cb601ebdc954062d3ff0bdd44d6eff087895af48994398f08025785"
+CHKSUMS="sha256::69060a3be150e54dc571f5c600b85dd9f37d76f7df1b23cd5c131b2c1412c218"
 CHKUPDATE="anitya::id=5495"


### PR DESCRIPTION
Topic Description
-----------------

- arping: update to 2.24
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- arping: 2.24

Security Update?
----------------

No

Build Order
-----------

```
#buildit arping
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
