### PR TITLE
arp-scan: update to 1.10.0

### DIFF
--- a/app-network/arp-scan/spec
+++ b/app-network/arp-scan/spec
@@ -1,4 +1,4 @@
-VER=1.9.8
+VER=1.10.0
 SRCS="tbl::https://github.com/royhills/arp-scan/archive/$VER.tar.gz"
-CHKSUMS="sha256::b9b75ceaef6348f5951b06c773ec7a243a9e780e160eafebc369f9c27f6a7d3f"
+CHKSUMS="sha256::204b13487158b8e46bf6dd207757a52621148fdd1d2467ebd104de17493bab25"
 CHKUPDATE="anitya::id=110"


### PR DESCRIPTION
Topic Description
-----------------

- arp-scan: update to 1.10.0
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- arp-scan: 1.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit arp-scan
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
