### PR TITLE
asciidoc: update to 10.2.0

### DIFF
--- a/app-doc/asciidoc/autobuild/beyond
+++ b/app-doc/asciidoc/autobuild/beyond
@@ -1,3 +1,0 @@
-install -Dm644 asciidocapi.py \
-    "$PKGDIR"/usr/lib/python2.7/site-packages/asciidoc/asciidocapi.py
-

--- a/app-doc/asciidoc/spec
+++ b/app-doc/asciidoc/spec
@@ -1,5 +1,4 @@
-VER=8.6.10
-REL=1
+VER=10.2.0
 SRCS="tbl::https://github.com/asciidoc/asciidoc/archive/$VER.tar.gz"
-CHKSUMS="sha256::22d6793d4f48cefb4a6963853212a214591a591ece1bcbc56af3c67c642003ea"
+CHKSUMS="sha256::684ea53c1f5b71d6d1ac6086bbc96906b1f709ecc7ab536615b0f0c9e1baa3cc"
 CHKUPDATE="anitya::id=13262"


### PR DESCRIPTION
Topic Description
-----------------

- asciidoc: update to 10.2.0
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- asciidoc: 10.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit asciidoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
