### PR TITLE
aspell: update to 0.60.8.1+dict20161024

### DIFF
--- a/app-i18n/aspell/01-main/beyond
+++ b/app-i18n/aspell/01-main/beyond
@@ -1,4 +1,4 @@
 abinfo "Preparing to build dictionaries ..."
 mkdir -pv "$SRCDIR"/dicts/
-mv -v "$PKGDIR"/usr/lib/aspell-${PKGVER%.*}/*.{amf,c*,info,kbd} \
+mv -v "$PKGDIR"/usr/lib/aspell-${PKGVER:0:4}/*.{amf,info,kbd} \
     "$SRCDIR"/dicts/

--- a/app-i18n/aspell/01-main/defines
+++ b/app-i18n/aspell/01-main/defines
@@ -5,3 +5,6 @@ PKGDEP="ncurses perl"
 PKGSUG="aspell-dicts"
 
 ABSHADOW=0
+
+PKGBREAK="aspell-dicts<=0.60.8-4"
+PKGREP="aspell-dicts<=0.60.8-4"

--- a/app-i18n/aspell/02-dict/build
+++ b/app-i18n/aspell/02-dict/build
@@ -1,22 +1,23 @@
-(
-    cd "$SRCDIR"/../aspell-dicts-$DICTVER
-    for i in `cat build-list`; do
-        (
-            cd "$i"
+cd "$SRCDIR"/../aspell-dicts-$DICTVER
+for i in `cat build-list`; do
+    cd "$SRCDIR"/../aspell-dicts-$DICTVER/"$i"
 
-            abinfo "Configuring $i ..."
-            ./configure
+    abinfo "Configuring $i ..."
+    ./configure
 
-            abinfo "Building $i ..."
-            make
+    abinfo "Building $i ..."
+    make
 
-            abinfo "Installing $i ..."
-            make install \
-                DESTDIR="$PKGDIR"
-        )
-    done
-)
+    abinfo "Installing $i ..."
+    make install \
+        DESTDIR="$PKGDIR"
+done
 
 abinfo "Installing additional dictionaries shipped with main source ..."
 cp -v "$SRCDIR"/dicts/* \
-    "$PKGDIR"/usr/lib/aspell-${PKGVER%.*}/
+    "$PKGDIR"/usr/lib/aspell-${PKGVER:0:4}/
+
+abinfo "Dropping an extreanous file ..."
+rm -v \
+     "$PKGDIR"/usr/lib/aspell-${PKGVER:0:4}/iso-8859-15.cmap \
+     "$PKGDIR"/usr/lib/aspell-${PKGVER:0:4}/iso-8859-15.cset

--- a/app-i18n/aspell/spec
+++ b/app-i18n/aspell/spec
@@ -1,9 +1,9 @@
-VER=0.60.8
-DICTVER=20161024
-REL=4
-SRCS="tbl::https://ftp.gnu.org/gnu/aspell/aspell-$VER.tar.gz \
-      tbl::https://repo.aosc.io/aosc-repacks/aspell-dicts-$DICTVER.tar.xz"
-CHKSUMS="sha256::f9b77e515334a751b2e60daab5db23499e26c9209f5e7b7443b05235ad0226f2 \
+UPSTREAM_VER=0.60.8.1
+DICT_VER=20161024
+VER=${UPSTREAM_VER}+dict${DICT_VER}
+SRCS="tbl::https://ftp.gnu.org/gnu/aspell/aspell-${UPSTREAM_VER}.tar.gz \
+      tbl::https://repo.aosc.io/aosc-repacks/aspell-dicts-${DICT_VER}.tar.xz"
+CHKSUMS="sha256::d6da12b34d42d457fa604e435ad484a74b2effcd120ff40acd6bb3fb2887d21b \
          sha256::60e9e3ebbe818e04c9d2f51719cfac62c1c9e1280d31756ac237690e530510d8"
 CHKUPDATE="anitya::id=120"
-SUBDIR="aspell-$VER"
+SUBDIR="aspell-${UPSTREAM_VER}"


### PR DESCRIPTION
Topic Description
-----------------

- aspell: update to 0.60.8.1+dict20161024
    - Lint scripts in accordance with the Styling Manual.
    - Install .cset and .cmap files in the main package as it is shipped as basic
    configuration data.
    Co-authored-by: MingcongBai <jeffbai@aosc.io>

Package(s) Affected
-------------------

- aspell: 0.60.8.1+dict20161024
- aspell-dicts: 0.60.8.1+dict20161024

Security Update?
----------------

No

Build Order
-----------

```
#buildit aspell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
