### PR TITLE
autoconf-archive: update to 2023.02.20

### DIFF
--- a/app-devel/autoconf-archive/spec
+++ b/app-devel/autoconf-archive/spec
@@ -1,4 +1,4 @@
-VER=2021.02.19
+VER=2023.02.20
 SRCS="tbl::https://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-$VER.tar.xz"
-CHKSUMS="sha256::e8a6eb9d28ddcba8ffef3fa211653239e9bf239aba6a01a6b7cfc7ceaec69cbd"
+CHKSUMS="sha256::71d4048479ae28f1f5794619c3d72df9c01df49b1c628ef85fde37596dc31a33"
 CHKUPDATE="anitya::id=142"


### PR DESCRIPTION
Topic Description
-----------------

- autoconf-archive: update to 2023.02.20
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- autoconf-archive: 2023.02.20

Security Update?
----------------

No

Build Order
-----------

```
#buildit autoconf-archive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
