### PR TITLE
axel: update to 2.17.14

### DIFF
--- a/app-web/axel/spec
+++ b/app-web/axel/spec
@@ -1,5 +1,4 @@
-VER=2.17.11
+VER=2.17.14
 SRCS="tbl::https://github.com/axel-download-accelerator/axel/releases/download/v$VER/axel-$VER.tar.xz"
-CHKSUMS="sha256::580b2c18692482fd7f1e2b2819159484311ffc50f6d18924dceb80fd41d4ccf9"
+CHKSUMS="sha256::938ee7c8c478bf6fcc82359bbf9576f298033e8b13908e53e3ea9c45c1443693"
 CHKUPDATE="anitya::id=9344"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- axel: update to 2.17.14
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- axel: 2.17.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit axel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
