### PR TITLE
balsa: update to 2.6.4

### DIFF
--- a/desktop-gnome/balsa/spec
+++ b/desktop-gnome/balsa/spec
@@ -1,5 +1,4 @@
-VER=2.6.3
+VER=2.6.4
 SRCS="tbl::https://pawsa.fedorapeople.org/balsa/balsa-$VER.tar.xz"
-CHKSUMS="sha256::d4d04576c9a5026064f7d480b34531faf59543f2e4d57c48a6fa5c76661e1dd4"
+CHKSUMS="sha256::befa5984511db33d41f2b1ecbfc99e22a15d45d08efe5d737b5174a1a6ac8fc1"
 CHKUPDATE="anitya::id=8920"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- balsa: update to 2.6.4
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- balsa: 2.6.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit balsa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
