### PR TITLE
bamf: update to 0.5.6

### DIFF
--- a/runtime-desktop/bamf/spec
+++ b/runtime-desktop/bamf/spec
@@ -1,5 +1,4 @@
-VER=0.5.5
-REL=1
-SRCS="tbl::https://launchpad.net/bamf/${VER:0:3}/$VER/+download/bamf-$VER.tar.xz"
-CHKSUMS="sha256::10e642adf5169d46e32b113346bebdad437cddd1ddbd45d16c640cf60cabf5da"
+VER=0.5.6
+SRCS="tbl::https://launchpad.net/bamf/${VER:0:3}/$VER/+download/bamf-$VER.tar.gz"
+CHKSUMS="sha256::4fcd00f23c542f3b79f35e10e322b67eacb399cac83f48db261cd8e8ea709478"
 CHKUPDATE="anitya::id=160"


### PR DESCRIPTION
Topic Description
-----------------

- bamf: update to 0.5.6
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- bamf: 1:0.5.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit bamf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
