### PR TITLE
bird: update to 2.15.1

### DIFF
--- a/app-network/bird/autobuild/beyond
+++ b/app-network/bird/autobuild/beyond
@@ -1,7 +1,3 @@
-abinfo "Installing example /etc/bird.conf ..."
-install -Dvm644 "$SRCDIR"/doc/bird.conf.example2 \
-    "$PKGDIR"/etc/bird.conf
-
 abinfo "Moving /var/run => /run ..."
 mv -v "$PKGDIR"/{var/,}run
 rm -rv "$PKGDIR"/var

--- a/app-network/bird/spec
+++ b/app-network/bird/spec
@@ -1,4 +1,4 @@
-VER=2.14
+VER=2.15.1
 SRCS="tbl::https://bird.network.cz/download/bird-$VER.tar.gz"
-CHKSUMS="sha256::b0b9f6f8566541b9be4af1f0cac675c5a3785601a55667a7ec3d7de29735a786"
+CHKSUMS="sha256::48e85c622de164756c132ea77ad1a8a95cc9fd0137ffd0d882746589ce75c75d"
 CHKUPDATE="anitya::id=192"


### PR DESCRIPTION
Topic Description
-----------------

- bird: update to 2.15.1
Use bird.conf installed by the default target, /doc/bird.conf.example2 used in
previous versions was broken.
    
Co-authored-by: MingcongBai (@MingcongBai) <jeffbai@aosc.io>


Package(s) Affected
-------------------

- bird: 2.15.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bird
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
