### PR TITLE
blueman: update to 2.4.1

### DIFF
--- a/app-utils/blueman/spec
+++ b/app-utils/blueman/spec
@@ -1,4 +1,4 @@
-VER=2.2.2
+VER=2.4.1
 SRCS="tbl::https://github.com/blueman-project/blueman/releases/download/$VER/blueman-$VER.tar.xz"
-CHKSUMS="sha256::19ed59b1a134f584fc005f47295fef640a9709fd9b9b2307388e112a32ecd0f6"
+CHKSUMS="sha256::07d8de3e4a412c590ea0fa93950df6b2e487b0317a408ec29e1d6ac22bad60db"
 CHKUPDATE="anitya::id=6500"


### PR DESCRIPTION
Topic Description
-----------------

- blueman: update to 2.4.1
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- blueman: 2:2.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit blueman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
