### PR TITLE
bluez (BlueZ): update to 5.75

### DIFF
--- a/app-devices/bluez/autobuild/beyond
+++ b/app-devices/bluez/autobuild/beyond
@@ -6,10 +6,6 @@ abinfo "Installing API documentation"
 install -dvm755 "$PKGDIR"/usr/share/doc/bluez/dbus-apis
 cp -av "$SRCDIR"/doc/*.txt "$PKGDIR"/usr/share/doc/bluez/dbus-apis/
 
-abinfo "Installing object exchange protocol service"
-ln -sv obex.service \
-    "$PKGDIR"/usr/lib/systemd/user/dbus-org.bluez.obex.service
-
 for files in `find tools/ -type f -perm -755`; do
     filename=$(basename $files)
     abinfo "Installing $filename"

--- a/app-devices/bluez/spec
+++ b/app-devices/bluez/spec
@@ -1,4 +1,4 @@
-VER=5.71
+VER=5.75
 SRCS="tbl::https://www.kernel.org/pub/linux/bluetooth/bluez-$VER.tar.xz"
-CHKSUMS="sha256::b828d418c93ced1f55b616fb5482cf01537440bfb34fbda1a564f3ece94735d8"
+CHKSUMS="sha256::988cb3c4551f6e3a667708a578f5ca9f93fc896508f98f08709be4f8ab033c2f"
 CHKUPDATE="anitya::id=10029"


### PR DESCRIPTION
Topic Description
-----------------

- bluez: update to 5.75
    Drop upstreamed symlink for obex.service.

Package(s) Affected
-------------------

- bluez: 5.75

Security Update?
----------------

No

Build Order
-----------

```
#buildit bluez
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
