### PR TITLE
bluez-alsa: update to 4.1.1

### DIFF
--- a/app-multimedia/bluez-alsa/autobuild/defines
+++ b/app-multimedia/bluez-alsa/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=bluez-alsa
 PKGDES="ALSA PCM adapter for bluez"
 PKGSEC=sound
-PKGDEP="bluez sbc glib libfdk-aac libldac upower mpg123 lame dbus"
+PKGDEP="bluez sbc glib libfdk-aac libldac upower mpg123 lame dbus spandsp"
 BUILDDEP="ofono"
 
 AUTOTOOLS_AFTER="

--- a/app-multimedia/bluez-alsa/spec
+++ b/app-multimedia/bluez-alsa/spec
@@ -1,5 +1,4 @@
-VER=3.0.0
-REL=1
+VER=4.1.1
 SRCS="tbl::https://github.com/Arkq/bluez-alsa/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::8b9bc36be922c10c6628ddf84b13dfadfeb3ab0bcf72bad842c66f3120abc6b2"
+CHKSUMS="sha256::b69a3e6dd69315194403ee930ac1553aed3fb9a3988e502ae5c24a8bfef70f9f"
 CHKUPDATE="anitya::id=21324"

--- a/app-multimedia/sbc/spec
+++ b/app-multimedia/sbc/spec
@@ -1,4 +1,4 @@
-VER=1.4
+VER=2.0
 SRCS="tbl::https://www.kernel.org/pub/linux/bluetooth/sbc-$VER.tar.xz"
-CHKSUMS="sha256::518bf46e6bb3dc808a95e1eabad26fdebe8a099c1e781c27ed7fca6c2f4a54c9"
+CHKSUMS="sha256::8f12368e1dbbf55e14536520473cfb338c84b392939cc9b64298360fd4a07992"
 CHKUPDATE="anitya::id=16338"


### PR DESCRIPTION
Topic Description
-----------------

- sbc: update to 2.0
- bluez-alsa: update to 4.1.1
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- bluez-alsa: 4.1.1
- sbc: 2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sbc bluez-alsa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
