### PR TITLE
bolt: update to 0.9.7

### DIFF
--- a/app-admin/bolt/spec
+++ b/app-admin/bolt/spec
@@ -1,4 +1,4 @@
-VER=0.9.1
+VER=0.9.7
 SRCS="tbl::https://gitlab.freedesktop.org/bolt/bolt/-/archive/${VER}/bolt-${VER}.tar.gz"
-CHKSUMS="sha256::f938db68df79d0ada135a055fd01204f6f3436e17e962dfb8dc6699de77e1895"
+CHKSUMS="sha256::593c7e7d0ecebd7b9e2c3efabe33f8fec5501ff02ffd6d8563cfc14a91c31c1c"
 CHKUPDATE="anitya::id=17645"


### PR DESCRIPTION
Topic Description
-----------------

- bolt: update to 0.9.7
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- bolt: 0.9.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit bolt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
