### PR TITLE
bpftrace: update to 0.20.3

### DIFF
--- a/app-admin/bpftrace/spec
+++ b/app-admin/bpftrace/spec
@@ -1,5 +1,4 @@
-VER=0.19.1
-REL=1
+VER=0.20.3
 SRCS="tbl::https://github.com/iovisor/bpftrace/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::b520340f28ce4d6f2fb2355f1675b6801ff8498ed9e8bff14abbbf6baff5a08e"
+CHKSUMS="sha256::29057213d253f893590b3e0a358c9382ec8ddaa6efd1af500aaaf297d23beafc"
 CHKUPDATE="anitya::id=141354"


### PR DESCRIPTION
Topic Description
-----------------

- bpftrace: update to 0.20.3
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- bpftrace: 0.20.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit bpftrace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
