### PR TITLE
bread-dog: update to 0.1.1

### DIFF
--- a/app-utils/bread-dog/autobuild/defines
+++ b/app-utils/bread-dog/autobuild/defines
@@ -8,4 +8,6 @@ BUILDDEP="rustc llvm"
 USECLANG=1
 
 # FIXME: ld.lld is not yet available.
+NOLTO__LOONGSON3=1
 NOLTO__LOONGARCH64=1
+NOLTO__MIPS64R6EL=1

--- a/app-utils/bread-dog/spec
+++ b/app-utils/bread-dog/spec
@@ -1,5 +1,4 @@
-VER="0.1.0"
+VER=0.1.1
 SRCS="git::commit=tags/v$VER::https://github.com/eatradish/bread-dog"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=302756"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- bread-dog: update to 0.1.1
    Co-authored-by: MingcongBai <unknown@unknown.com>

Package(s) Affected
-------------------

- bread-dog: 0.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bread-dog
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
