### PR TITLE
pandoc: update to 3.1.13

### DIFF
--- a/app-doc/pandoc/autobuild/defines
+++ b/app-doc/pandoc/autobuild/defines
@@ -3,3 +3,6 @@ PKGSEC=doc
 PKGDES="Universal markup converter"
 PKGDEP="cmark texlive"
 BUILDDEP="cabal-install ghc zlib-static numactl libffi"
+
+# FIXME: ghc is only available on these archs
+FAIL_ARCH="!(amd64|arm64)"

--- a/app-doc/pandoc/spec
+++ b/app-doc/pandoc/spec
@@ -1,4 +1,4 @@
-VER=3.1.12.3
+VER=3.1.13
 SRCS="git::commit=tags/$VER::https://github.com/jgm/pandoc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2589"


### PR DESCRIPTION
Topic Description
-----------------

- pandoc: update to 3.1.13
    Co-authored-by: jiegec (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- pandoc: 3.1.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit pandoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
