### PR TITLE
ninja: update to 1.12.1

### DIFF
--- a/app-devel/ninja/spec
+++ b/app-devel/ninja/spec
@@ -1,4 +1,4 @@
-VER=1.12.0
+VER=1.12.1
 SRCS="git::commit=tags/v$VER::https://github.com/ninja-build/ninja"
 CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=132832"
+CHKUPDATE="anitya::id=2089"


### PR DESCRIPTION
Topic Description
-----------------

- ninja: update to 1.11.1.1
    Co-authored-by: jiegec <c@jia.je>

Package(s) Affected
-------------------

- ninja: 1.11.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ninja
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
