### PR TITLE
vscodium: update to 1.89.1

### DIFF
--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.89.0.24127
+VER=1.89.1.24130
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium"
 CHKSUMS="SKIP"
-CHKUPDATE="github::repo=microsoft/vscode;pattern=^\d\.\d+\.\d+$"
+CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.89.1.24130
    - Switch to anitya to check update

Package(s) Affected
-------------------

- vscodium: 1.89.1.24130

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
