### PR TITLE
difftastic: update to 0.6.1

### DIFF
--- a/app-utils/difftastic/spec
+++ b/app-utils/difftastic/spec
@@ -1,4 +1,4 @@
-VER=0.56.1
+VER=0.6.1
 # URL not found for submodule in .gitmodules.
 SRCS="git::commit=tags/$VER;submodule=false::https://github.com/Wilfred/difftastic"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- difftastic: update to 0.6.1
    Co-authored-by: eatradish <unknown@unknown.com>

Package(s) Affected
-------------------

- difftastic: 0.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit difftastic
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
