### PR TITLE
difftastic: update to 0.58.0

### DIFF
--- a/app-utils/difftastic/spec
+++ b/app-utils/difftastic/spec
@@ -1,5 +1,5 @@
-VER=0.56.1
+VER=0.58.0
 # URL not found for submodule in .gitmodules.
 SRCS="git::commit=tags/$VER;submodule=false::https://github.com/Wilfred/difftastic"
 CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=370242"
+CHKUPDATE="anitya::id=320430"


### PR DESCRIPTION
Topic Description
-----------------

- difftastic: update to 0.58.0
    - fix wrong anitya number

Package(s) Affected
-------------------

- difftastic: 0.58.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit difftastic
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
