### PR TITLE
openocd: enable capstone and debundle libjaylink

### DIFF
--- a/app-devel/openocd/autobuild/defines
+++ b/app-devel/openocd/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=openocd
 PKGSEC=devel
-PKGDEP="libusb libusb-compat libftdi hidapi"
+PKGDEP="capstone hidapi libftdi libgpiod libjaylink libusb"
 PKGDES="An open-source JTAG On-Chip Debugging tool"
 
 ABSHADOW=0

--- a/app-devel/openocd/spec
+++ b/app-devel/openocd/spec
@@ -1,4 +1,5 @@
 VER=0.12.0
+REL=1
 SRCS="git::commit=v${VER}::http://repo.or.cz/openocd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2557"

--- a/runtime-devices/libjaylink/autobuild/beyond
+++ b/runtime-devices/libjaylink/autobuild/beyond
@@ -1,0 +1,6 @@
+abinfo "generating documentation ..."
+doxygen "${BLDDIR}/Doxyfile"
+
+abinfo "installing documentation ..."
+mkdir -pv "${PKGDIR}/usr/share/doc/libjaylink/"
+cp -rv doxy/html "${PKGDIR}/usr/share/doc/libjaylink/"

--- a/runtime-devices/libjaylink/autobuild/defines
+++ b/runtime-devices/libjaylink/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=libjaylink
+PKGSEC=libs
+PKGDEP="libusb"
+BUILDDEP="doxygen"
+PKGDES="A library to talk to SEGGER J-Link and compatible devices"
+ABTYPE=autotools

--- a/runtime-devices/libjaylink/spec
+++ b/runtime-devices/libjaylink/spec
@@ -1,0 +1,4 @@
+VER=0.3.1
+SRCS="git::commit=tags/${VER}::https://gitlab.zapb.de/libjaylink/libjaylink.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372323"


### PR DESCRIPTION
Topic Description
-----------------

- openocd: enable capstone and debundle libjaylink
- libjaylink: new, 0.3.1

Package(s) Affected
-------------------

- libjaylink: 0.3.1
- openocd: 0.12.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjaylink openocd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
