### PR TITLE
v2ray: update to 5.16.1

### DIFF
--- a/app-network/v2ray/spec
+++ b/app-network/v2ray/spec
@@ -1,5 +1,4 @@
-VER=5.13.0
-REL=2
+VER=5.16.1
 SRCS="git::commit=tags/v$VER::https://github.com/v2fly/v2ray-core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=134851"


### PR DESCRIPTION
Topic Description
-----------------

- v2ray: update to 5.16.1
    Co-authored-by: stdmnpkg <unknown@unknown.com>

Package(s) Affected
-------------------

- v2ray: 5.16.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit v2ray
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
