### PR TITLE
just: update to 1.25.2

### DIFF
--- a/app-devel/just/autobuild/defines
+++ b/app-devel/just/autobuild/defines
@@ -7,8 +7,10 @@ PKGSEC="utils"
 USECLANG=1
 ABSPLITDBG=0
 
-# ld.lld does not support loongson3 and mips64r6el
+# FIXME: ld.lld does not support loongson3, loongarch64 and mips64r6el
 USECLANG__LOONGSON3=0
 NOLTO__LOONGSON3=1
 USECLANG__MIPS64R6EL=0
 NOLTO__MIPS64R6EL=1
+USECLANG__LOONGARCH64=0
+NOLTO__LOONGARCH64=1

--- a/app-devel/just/autobuild/patches/0001-chore-switch-target-to-github-source-to-fix-loongarc.patch
+++ b/app-devel/just/autobuild/patches/0001-chore-switch-target-to-github-source-to-fix-loongarc.patch
@@ -1,0 +1,41 @@
+From f7df6d5d3edef6c61ba543892ce4cb2d73d7bbcc Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Mon, 13 May 2024 14:41:40 +0800
+Subject: [PATCH] chore: switch `target` to github source to fix loongarch64
+ build
+
+---
+ Cargo.lock | 3 +--
+ Cargo.toml | 2 +-
+ 2 files changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 3ae444b..f87ea14 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -928,8 +928,7 @@ dependencies = [
+ [[package]]
+ name = "target"
+ version = "2.0.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ba852e71502340e2eaf2fa51f9b3ec6aa25750da1aa65771491c69d67789b05c"
++source = "git+https://github.com/casey/target?rev=122c2528df780e977e216e0f8f2519fc3644c81f#122c2528df780e977e216e0f8f2519fc3644c81f"
+ 
+ [[package]]
+ name = "tempfile"
+diff --git a/Cargo.toml b/Cargo.toml
+index 64a1537..e568c58 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -42,7 +42,7 @@ sha2 = "0.10"
+ similar = { version = "2.1.0", features = ["unicode"] }
+ snafu = "0.8.0"
+ strum = { version = "0.26.0", features = ["derive"] }
+-target = "2.0.0"
++target = { git = "https://github.com/casey/target", rev = "122c2528df780e977e216e0f8f2519fc3644c81f" }
+ tempfile = "3.0.0"
+ typed-arena = "2.0.1"
+ unicode-width = "0.1.0"
+-- 
+2.45.0
+

--- a/app-devel/just/spec
+++ b/app-devel/just/spec
@@ -1,4 +1,4 @@
-VER="1.22.1"
+VER=1.25.2
 SRCS="git::commit=tags/$VER::https://github.com/casey/just"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141393"


### PR DESCRIPTION
Topic Description
-----------------

- just: update to 1.25.2
    Co-authored-by: eatradish <unknown@unknown.com>

Package(s) Affected
-------------------

- just: 1.25.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit just
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
