### PR TITLE
ouch: update to 0.5.1

### DIFF
--- a/app-utils/ouch/autobuild/defines
+++ b/app-utils/ouch/autobuild/defines
@@ -1,10 +1,12 @@
 PKGNAME="ouch"
 PKGDES="A command line (de)compression utility with support for multiple archive formats"
 PKGDEP="glibc zlib bzip2 xz gcc-runtime"
-BUILDDEP="rustc llvm"
+BUILDDEP="rustc"
 PKGSEC="util"
 
-USECLANG=1
+# FIXME: ld.lld: error: undefined symbol: std::bad_alloc::bad_alloc()
+NOLTO=1
+
 ABSPLITDBG=0
 
 CARGO_AFTER__I486="${CARGO_AFTER} --target=i486-unknown-linux-gnu"

--- a/app-utils/ouch/spec
+++ b/app-utils/ouch/spec
@@ -1,4 +1,4 @@
-VER=0.4.1
+VER=0.5.1
 SRCS="git::commit=tags/$VER::https://github.com/ouch-org/ouch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368665"


### PR DESCRIPTION
Topic Description
-----------------

- ouch: update to 0.5.1
    Co-authored-by: eatradish <unknown@unknown.com>

Package(s) Affected
-------------------

- ouch: 0.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ouch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
