### PR TITLE
libcl: update to 2.3.2

### DIFF
--- a/runtime-devices/libcl/spec
+++ b/runtime-devices/libcl/spec
@@ -1,4 +1,4 @@
-VER=2.3.1
+VER=2.3.2
 SRCS="git::commit=tags/v$VER::https://github.com/OCL-dev/ocl-icd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2525"


### PR DESCRIPTION
Topic Description
-----------------

- libcl: update to 2.3.2
    Co-authored-by: (@ouankou) <anjia@ouankou.com>

Package(s) Affected
-------------------

- libcl: 2.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
