### PR TITLE
oma: update to 1.3.7

### DIFF
--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -13,6 +13,13 @@ PKGSEC="admin"
 CARGO_AFTER__LOONGSON3="--no-default-features \
                         --features=aosc,sequoia-openssl-backend"
 
+# FIXME: nettle-sys does not build on mips64r6el due to LLVM brokenness.
+# Use openssl backend for sequoia-openpgp, which is used by oma-refresh.
+# ring does not support misp64r6el, so use openssl
+CARGO_AFTER__MIPS64R6EL="--no-default-features \
+                        --features=aosc,sequoia-openssl-backend,openssl"
+
+
 USECLANG=1
 
 # FIXME: ld.lld is not yet available.

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.3.6
+VER=1.3.7
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.3.7

Package(s) Affected
-------------------

- oma: 1.3.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
