### PR TITLE
7-zip: update to 24.03

### DIFF
--- a/app-utils/7-zip/spec
+++ b/app-utils/7-zip/spec
@@ -1,5 +1,4 @@
-VER=23.01
-REL=1
+VER=24.03
 SRCS="git::commit=tags/$VER::https://github.com/ip7z/7zip.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17875"


### PR DESCRIPTION
Topic Description
-----------------

- 7-zip: update to 24.03
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- 7-zip: 24.03

Security Update?
----------------

No

Build Order
-----------

```
#buildit 7-zip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
