### PR TITLE
zfs: update to 2.2.4

### DIFF
--- a/app-admin/zfs/autobuild/defines
+++ b/app-admin/zfs/autobuild/defines
@@ -8,3 +8,6 @@ ABTYPE=self
 
 PKGBREAK="spl<=0.7.13"
 PKGREP="spl<=0.7.13"
+
+# FIXME: missing linux+kernel+lts
+FAIL_ARCH="(loongson3|mips64r6el)"

--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,4 +1,4 @@
-VER=2.2.3
+VER=2.2.4
 SRCS="tbl::https://github.com/zfsonlinux/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
-CHKSUMS="sha256::30a512f34ec5c841b8b2b32cc9c1a03fd49391b26c9164d3fb30573fb5d81ac3"
+CHKSUMS="sha256::9790905f7683d41759418e1ef3432828c31116654ff040e91356ff1c21c31ec0"
 CHKUPDATE="anitya::id=11706"


### PR DESCRIPTION
Topic Description
-----------------

- zfs: update to 2.2.4
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- zfs: 2.2.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit zfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch64 `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
