### PR TITLE
zotero: update to 6.0.37

### DIFF
--- a/app-productivity/zotero/spec
+++ b/app-productivity/zotero/spec
@@ -1,15 +1,13 @@
-VER=6.0.26
+VER=6.0.37
 _BUILD_REPO_COMMIT=5cec38cd40361d939e32eb0b6e0fd18ac7b78a56
 SRCS="
 	git::commit=tags/${VER};rename=zotero-client::https://github.com/zotero/zotero.git
 	git::commit=${_BUILD_REPO_COMMIT};rename=zotero-build::https://github.com/zotero/zotero-build.git
-	git::commit=${VER}-hotfix;rename=zotero-standalone-build::https://github.com/zotero/zotero-standalone-build.git
+	git::commit=${VER};rename=zotero-standalone-build::https://github.com/zotero/zotero-standalone-build.git
 "
-CHKSUMS="
-	SKIP
-	SKIP
-	SKIP
-"
+CHKSUMS="SKIP \
+         SKIP \
+         SKIP"
 SUBDIR="."
 
 CHKUPDATE="anitya::id=14815"


### PR DESCRIPTION
Topic Description
-----------------

- zotero: update to 6.0.37
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- zotero: 6.0.37

Security Update?
----------------

No

Build Order
-----------

```
#buildit zotero
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
