### PR TITLE
zstandard: update to 0.22.0

### DIFF
--- a/lang-python/zstandard/spec
+++ b/lang-python/zstandard/spec
@@ -1,5 +1,4 @@
-VER=0.15.2
+VER=0.22.0
 SRCS="https://pypi.io/packages/source/z/zstandard/zstandard-$VER.tar.gz"
-CHKSUMS="sha256::52de08355fd5cfb3ef4533891092bb96229d43c2069703d4aff04fdbedf9c92f"
+CHKSUMS="sha256::8226a33c542bcb54cd6bd0a366067b610b41713b64c9abec1bc4533d69f51e70"
 CHKUPDATE="anitya::id=159551"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- zstandard: update to 0.22.0
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- zstandard: 0.22.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit zstandard
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
