### PR TITLE
zstd-static: update to 1.5.6

### DIFF
--- a/app-utils/zstd-static/spec
+++ b/app-utils/zstd-static/spec
@@ -1,5 +1,4 @@
-VER=1.4.5
-REL=2
-SRCS="tbl::https://github.com/facebook/zstd/archive/v$VER.tar.gz"
-CHKSUMS="sha256::734d1f565c42f691f8420c8d06783ad818060fc390dee43ae0a89f86d0a4f8c2"
+VER=1.5.6
+SRCS="git::commit=tags/v$VER::https://github.com/facebook/zstd"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12083"


### PR DESCRIPTION
Topic Description
-----------------

- zstd-static: update to 1.5.6
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- zstd-static: 1.5.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit zstd-static
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
