### PR TITLE
oma: update to v1.3.8

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.3.6
+VER=v1.3.8
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to v1.3.8

Package(s) Affected
-------------------

- oma: v1.3.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 
- [ ] AArch64 
- [ ] LoongArch 64-bit 

**Secondary Architectures**

- [ ] Loongson 3 
- [ ] PowerPC 64-bit (Little Endian) 
- [ ] RISC-V 64-bit 

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) 

