### PR TITLE
oma: update to 1.3.8

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.3.6
+VER=1.3.8
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.3.8

Package(s) Affected
-------------------

- oma: 1.3.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 
- [x] AArch64 
- [x] LoongArch 64-bit 

**Secondary Architectures**

- [x] Loongson 3 
- [x] PowerPC 64-bit (Little Endian) 
- [x] RISC-V 64-bit 

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) 

