### PR TITLE
glib (GLib): rebuild for libmount update

### DIFF
--- a/runtime-common/glib/spec
+++ b/runtime-common/glib/spec
@@ -1,5 +1,5 @@
 VER=2.80.0
-REL=2
+REL=3
 SRCS="https://download.gnome.org/sources/glib/${VER:0:4}/glib-$VER.tar.xz"
 CHKSUMS="sha256::8228a92f92a412160b139ae68b6345bd28f24434a7b5af150ebe21ff587a561d"
 CHKUPDATE="anitya::id=10024"


### PR DESCRIPTION
Topic Description
-----------------

- glib: rebuild for libmount (util-linux) update
    When attempting to launch baidunetdisk:
    /opt/baidunetdisk/baidunetdisk: /usr/lib/libmount.so.1: version `MOUNT_2_40'
    not found (required by /usr/lib/libgio-2.0.so.0)'

Package(s) Affected
-------------------

- glib: 2.80.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit glib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
