### PR TITLE
util-linux: update to 2.40.1

### DIFF
--- a/app-utils/util-linux/spec
+++ b/app-utils/util-linux/spec
@@ -1,5 +1,4 @@
-VER=2.40
-REL=1
+VER=2.40.1
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/util-linux/v${VER:0:4}/util-linux-$VER.tar.xz"
-CHKSUMS="sha256::d57a626081f9ead02fa44c63a6af162ec19c58f53e993f206ab7c3a6641c2cd7"
+CHKSUMS="sha256::59e676aa53ccb44b6c39f0ffe01a8fa274891c91bef1474752fad92461def24f"
 CHKUPDATE="anitya::id=8179"


### PR DESCRIPTION
Topic Description
-----------------

- util-linux: update to 2.40.1
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- util-linux: 2.40.1
- util-linux-runtime: 2.40.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit util-linux
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
