### PR TITLE
webkit2gtk: update to 2.44.1

### DIFF
--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -1,5 +1,4 @@
-VER=2.42.5
-REL=1
+VER=2.44.1
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
-CHKSUMS="sha256::b64278c1f20b8cfdbfb5ff573c37d871aba74a1db26d9b39f74e8953fe61e749"
+CHKSUMS="sha256::425b1459b0f04d0600c78d1abb5e7edfa3c060a420f8b231e9a6a2d5d29c5561"
 CHKUPDATE="anitya::id=324014"


### PR DESCRIPTION
Topic Description
-----------------

- webkit2gtk: update to 2.44.1
    Co-authored-by: (@BC204)

Package(s) Affected
-------------------

- webkit2gtk: 1:2.44.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit webkit2gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
