### PR TITLE
caligula: new, 0.4.5

### DIFF
--- a/app-utils/caligula/autobuild/defines
+++ b/app-utils/caligula/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=caligula
+PKGDES="A TUI program for imaging disks"
+PKGDEP="glibc gcc-runtime"
+BUILDDEP="rustc"
+PKGSEC="utils"
+
+# FIXME: lzma-sys need gcc to build
+NOLTO=1

--- a/app-utils/caligula/autobuild/prepare
+++ b/app-utils/caligula/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "set RUSTFLAGS --cfg tracing_unstable to fix build ..."
+# https://github.com/tokio-rs/tracing/discussions/1906
+export RUSTFLAGS="${RUSTFLAGS} --cfg tracing_unstable"

--- a/app-utils/caligula/spec
+++ b/app-utils/caligula/spec
@@ -1,0 +1,4 @@
+VER=0.4.5
+SRCS="git::commit=tags/v$VER::https://github.com/ifd3f/caligula"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372353"


### PR DESCRIPTION
Topic Description
-----------------

- caligula: new, 0.4.5

Package(s) Affected
-------------------

- caligula: 0.4.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit caligula
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
