### PR TITLE
PipeWire Survey 20240514

### DIFF
--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,4 +1,4 @@
-VER=1.0.4
+VER=1.0.6
 SRCS="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/$VER/pipewire-$VER.tar.gz"
-CHKSUMS="sha256::ce00e0cee3eefaf8e92eecf5d28985f6dab43ccfe7e704d41b0cfda8376a187c"
+CHKSUMS="sha256::aaaaa9825f313f0acc64bd046776da8a2f31e270f20351ecf97438d15aebce79"
 CHKUPDATE="anitya::id=57357"

--- a/app-multimedia/wireplumber/spec
+++ b/app-multimedia/wireplumber/spec
@@ -1,4 +1,4 @@
-VER=0.5.0
+VER=0.5.2
 SRCS="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${VER}/wireplumber-${VER}.tar.bz2"
-CHKSUMS="sha256::75a885c32f2f31cea41d41049378077918667b1ff410942149053d78c31d01a4"
+CHKSUMS="sha256::f6c21592fc36de710cba869b91a407aaa0e4c74d04fccd9a91643e527c4306bb"
 CHKUPDATE="anitya::id=235056"


### PR DESCRIPTION
Topic Description
-----------------

- wireplumber: update to 0.5.2
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- pipewire: update to 1.0.6
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- pipewire: 1.0.6
- wireplumber: 0.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pipewire wireplumber pipewire
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
