### PR TITLE
snapper: update to 0.11.0

### DIFF
--- a/app-admin/snapper/autobuild/patches/0001-Arch-Linux-use-conf-d-instead-of-sysconfig.patch
+++ b/app-admin/snapper/autobuild/patches/0001-Arch-Linux-use-conf-d-instead-of-sysconfig.patch
@@ -1,36 +1,5 @@
-diff --git a/scripts/pam_snapper_userdel.sh b/scripts/pam_snapper_userdel.sh
-index 30be9be..1ffa63e 100755
---- a/scripts/pam_snapper_userdel.sh
-+++ b/scripts/pam_snapper_userdel.sh
-@@ -40,7 +40,7 @@ fi
- if [ ${DRYRUN} == 0 ] ; then
- 	# Delete the snapper configuration
- 	# This deletes $SNAPPERCFGDIR/home_${MYUSER}
--	# removes "home_${MYUSER}" from /etc/sysconfig/snapper
-+	# removes "home_${MYUSER}" from /etc/conf.d/snapper
- 	# and deletes all snapshots
- 	${CMD_SNAPPER} -c home_${MYUSER} delete-config
- 	# Delete the USER's home subvolume
-diff --git a/scripts/snapper-daily b/scripts/snapper-daily
-index 27e7a10..2ee7fff 100755
---- a/scripts/snapper-daily
-+++ b/scripts/snapper-daily
-@@ -9,10 +9,10 @@ export PATH
- 
- 
- #
--# get information from /etc/sysconfig/snapper
-+# get information from /etc/conf.d/snapper
- #
--if [ -f /etc/sysconfig/snapper ] ; then
--    . /etc/sysconfig/snapper
-+if [ -f /etc/conf.d/snapper ] ; then
-+    . /etc/conf.d/snapper
- fi
- 
- 
 diff --git a/scripts/snapper-hourly b/scripts/snapper-hourly
-index bc6cd4d..1ef49ff 100755
+index 36a41f5..f36d8ec 100755
 --- a/scripts/snapper-hourly
 +++ b/scripts/snapper-hourly
 @@ -9,10 +9,10 @@ export PATH
@@ -47,3 +16,4 @@ index bc6cd4d..1ef49ff 100755
  fi
  
  
+

--- a/app-admin/snapper/autobuild/patches/0002-Arch-Linux-fix-suse-cron-dir-name.patch
+++ b/app-admin/snapper/autobuild/patches/0002-Arch-Linux-fix-suse-cron-dir-name.patch
@@ -1,14 +1,13 @@
 diff --git a/scripts/Makefile.am b/scripts/Makefile.am
-index 506f74a..407382c 100644
+index 1f8176c..b5df671 100644
 --- a/scripts/Makefile.am
 +++ b/scripts/Makefile.am
-@@ -17,7 +17,7 @@ endif
- EXTRA_DIST = snapper-hourly snapper-daily bash-completion.bash $(pam_snapper_SCRIPTS)
+@@ -17,6 +17,6 @@ endif
+ EXTRA_DIST = snapper-hourly bash-completion.bash zsh-completion.zsh $(pam_snapper_SCRIPTS)
  
  install-data-local:
 -	install -D snapper-hourly $(DESTDIR)/etc/cron.hourly/suse.de-snapper
--	install -D snapper-daily $(DESTDIR)/etc/cron.daily/suse.de-snapper
 +	install -D snapper-hourly $(DESTDIR)/etc/cron.hourly/snapper
-+	install -D snapper-daily $(DESTDIR)/etc/cron.daily/snapper
  	install -D --mode a+r,u+w bash-completion.bash $(DESTDIR)/usr/share/bash-completion/completions/snapper
- 
+ 	install -D --mode a+r,u+w zsh-completion.zsh $(DESTDIR)/usr/share/zsh/site-functions/_snapper
+

--- a/app-admin/snapper/autobuild/patches/0004-Arch-Linux-use-usr-path.patch
+++ b/app-admin/snapper/autobuild/patches/0004-Arch-Linux-use-usr-path.patch
@@ -1,13 +1,12 @@
 diff --git a/data/org.opensuse.Snapper.service b/data/org.opensuse.Snapper.service
-index 39d7333..6c49474 100644
+index 6a08a25..2e0d2ef 100644
 --- a/data/org.opensuse.Snapper.service
 +++ b/data/org.opensuse.Snapper.service
-@@ -1,5 +1,5 @@
+@@ -1,6 +1,6 @@
  # DBus service activation config
  [D-BUS Service]
  Name=org.opensuse.Snapper
 -Exec=/usr/sbin/snapperd
 +Exec=/usr/bin/snapperd
  User=root
- 
-
+ SystemdService=snapperd.service

--- a/app-admin/snapper/spec
+++ b/app-admin/snapper/spec
@@ -1,4 +1,4 @@
-VER=0.10.7
+VER=0.11.0
 SRCS="git::commit=tags/v${VER}::https://github.com/openSUSE/snapper"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4843"


### PR DESCRIPTION
Topic Description
-----------------

- snapper: update to 0.11.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- snapper: 0.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit snapper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
