### PR TITLE
swaybg: update to 1.2.1

### DIFF
--- a/app-utils/swaybg/spec
+++ b/app-utils/swaybg/spec
@@ -1,4 +1,4 @@
-VER=1.2.0
+VER=1.2.1
 SRCS="git::commit=tags/v$VER::https://github.com/swaywm/swaybg"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20562"


### PR DESCRIPTION
Topic Description
-----------------

- swaybg: update to 1.2.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- swaybg: 1.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit swaybg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
