### PR TITLE
Libjxl survey 20240513

### DIFF
--- a/app-creativity/gimp/autobuild/defines
+++ b/app-creativity/gimp/autobuild/defines
@@ -4,9 +4,11 @@ PKGSEC=graphics
 PKGDEP="babl dbus-glib desktop-file-utils gegl-0.4 hicolor-icon-theme \
         jasper lcms1 libexif libmng librsvg libwmf openexr pygtk \
         alsa-lib curl ghostscript gutenprint poppler libheif \
-        gvfs gexiv2 libmypaint mypaint-brushes+1 libwebp aalib libgudev"
+        gvfs gexiv2 libmypaint mypaint-brushes+1 libwebp aalib libgudev \
+        gnome-themes-standard"
 BUILDDEP="gtk-4 gtk-doc intltool iso-codes"
 
+ABTYPE=autotools
 AUTOTOOLS_AFTER="--enable-mp \
                  --enable-gimp-console \
                  --enable-python \

--- a/app-creativity/gimp/spec
+++ b/app-creativity/gimp/spec
@@ -1,5 +1,5 @@
 VER=2.10.36
-REL=1
+REL=2
 SRCS="tbl::https://download.gimp.org/pub/gimp/v${VER:0:4}/gimp-$VER.tar.bz2"
 CHKSUMS="sha256::3d3bc3c69a4bdb3aea9ba2d5385ed98ea03953f3857aafd1d6976011ed7cdbb2"
 CHKUPDATE="anitya::id=1161"

--- a/app-creativity/krita/autobuild/defines
+++ b/app-creativity/krita/autobuild/defines
@@ -9,6 +9,7 @@ BUILDDEP="eigen-3 extra-cmake-modules kdoctools sip xsimd"
 BUILDDEP__AMD64="${BUILDDEP} vc"
 PKGDES="A digital painting and graphics design program"
 
+ABTYPE=cmakeninja
 # Note: -DENABLE_UPDATERS=OFF, Enable updaters/update notifications.
 CMAKE_AFTER="-DBUILD_COVERAGE=OFF \
              -DBUILD_KRITA_QT_DESIGNER_PLUGINS=ON \

--- a/app-creativity/krita/autobuild/patches/0001-sip-6.8.patch
+++ b/app-creativity/krita/autobuild/patches/0001-sip-6.8.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/modules/pyproject.toml.in b/cmake/modules/pyproject.toml.in
+index 090b2d4b0c..085ddf4179 100644
+--- a/cmake/modules/pyproject.toml.in
++++ b/cmake/modules/pyproject.toml.in
+@@ -9,7 +9,7 @@ name = "@module_name_toml@"
+ sip-module = "@sip_name@"
+ sip-include-dirs = @sip_include_dirs@
+ sip-files-dir = "@module_srcs@"
+-abi-version = "12"
++abi-version = "12.8"
+ 
+ [tool.sip.bindings.@module_name_toml@]
+ tags = @module_tags@

--- a/app-creativity/krita/autobuild/patches/0002-xsimd-12.patch
+++ b/app-creativity/krita/autobuild/patches/0002-xsimd-12.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 94786e9279..a08bcb3027 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1070,7 +1070,7 @@ endif()
+ ##
+ ## Test for xsimd
+ ##
+-foreach(xsimd_version 8.1.0 9 10 11)
++foreach(xsimd_version 8.1.0 9 10 11 12)
+     if(NOT xsimd_FOUND)
+         find_package(xsimd ${xsimd_version})
+     endif()

--- a/app-creativity/krita/autobuild/patches/0003-fix-build-with-libjxl-0.9.0.patch
+++ b/app-creativity/krita/autobuild/patches/0003-fix-build-with-libjxl-0.9.0.patch
@@ -1,0 +1,93 @@
+From ace7edcca6ad322581ab39620f21ccf3ffbd3b5a Mon Sep 17 00:00:00 2001
+From: Timo Gurr <timo.gurr@gmail.com>
+Date: Fri, 5 Jan 2024 14:04:50 +0000
+Subject: [PATCH] Fix build with libjxl 0.9.0
+
+Fix build with libjxl 0.9.0
+
+BUG:478987
+
+Test Plan
+---------
+
+* Upgrade to libjxl 0.9.0
+* Apply patch from MR and build krita (5.2.2)
+* Open/Display a sample image e.g. https://jpegxl.info/test-page/red-room.jxl
+
+Formalities Checklist
+---------------------
+
+- [x] I confirmed this builds.
+- [x] I confirmed Krita ran and the relevant functions work (Could successfully open/display a sample image https://jpegxl.info/test-page/red-room.jxl).
+- [ ] I tested the relevant unit tests and can confirm they are not broken. (If not possible, don't hesitate to ask for help!)
+- [x] I made sure my commits build individually and have good descriptions as per [KDE guidelines](https://community.kde.org/Policies/Commit_Policy).
+- [x] I made sure my code conforms to the standards set in the HACKING file.
+- [x] I can confirm the code is licensed and attributed appropriately, and that unattributed code is mine, as per [KDE Licensing Policy](https://community.kde.org/Policies/Licensing_Policy).
+
+_**Reminder: the reviewer is responsible for merging the patch, this is to ensure at the least two people can build the patch. In case a patch breaks the build, both the author and the reviewer should be contacted to fix the build.**_
+_**If this is not possible, the commits shall be reverted, and a notification with the reasoning and any relevant logs shall be sent to the mailing list, kimageshop@kde.org.**_
+---
+ plugins/impex/jxl/JPEGXLImport.cpp | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/plugins/impex/jxl/JPEGXLImport.cpp b/plugins/impex/jxl/JPEGXLImport.cpp
+index 573bae41247..f5b989b3b70 100644
+--- a/plugins/impex/jxl/JPEGXLImport.cpp
++++ b/plugins/impex/jxl/JPEGXLImport.cpp
+@@ -511,7 +511,9 @@ JPEGXLImport::convert(KisDocument *document, QIODevice *io, KisPropertiesConfigu
+             JxlColorEncoding colorEncoding{};
+             if (JXL_DEC_SUCCESS
+                 == JxlDecoderGetColorAsEncodedProfile(dec.get(),
++#if JPEGXL_NUMERIC_VERSION < JPEGXL_COMPUTE_NUMERIC_VERSION(0, 9, 0)
+                                                       nullptr,
++#endif
+                                                       JXL_COLOR_PROFILE_TARGET_DATA,
+                                                       &colorEncoding)) {
+                 const TransferCharacteristics transferFunction = [&]() {
+@@ -635,7 +637,12 @@ JPEGXLImport::convert(KisDocument *document, QIODevice *io, KisPropertiesConfigu
+                 size_t iccSize = 0;
+                 QByteArray iccProfile;
+                 if (JXL_DEC_SUCCESS
+-                    != JxlDecoderGetICCProfileSize(dec.get(), nullptr, JXL_COLOR_PROFILE_TARGET_DATA, &iccSize)) {
++                    != JxlDecoderGetICCProfileSize(dec.get(),
++#if JPEGXL_NUMERIC_VERSION < JPEGXL_COMPUTE_NUMERIC_VERSION(0,9,0)
++                                                   nullptr,
++#endif
++                                                   JXL_COLOR_PROFILE_TARGET_DATA,
++                                                   &iccSize)) {
+                     errFile << "ICC profile size retrieval failed";
+                     document->setErrorMessage(i18nc("JPEG-XL errors", "Unable to read the image profile."));
+                     return ImportExportCodes::ErrorWhileReading;
+@@ -643,7 +650,9 @@ JPEGXLImport::convert(KisDocument *document, QIODevice *io, KisPropertiesConfigu
+                 iccProfile.resize(static_cast<int>(iccSize));
+                 if (JXL_DEC_SUCCESS
+                     != JxlDecoderGetColorAsICCProfile(dec.get(),
++#if JPEGXL_NUMERIC_VERSION < JPEGXL_COMPUTE_NUMERIC_VERSION(0,9,0)
+                                                       nullptr,
++#endif
+                                                       JXL_COLOR_PROFILE_TARGET_DATA,
+                                                       reinterpret_cast<uint8_t *>(iccProfile.data()),
+                                                       static_cast<size_t>(iccProfile.size()))) {
+@@ -657,7 +666,9 @@ JPEGXLImport::convert(KisDocument *document, QIODevice *io, KisPropertiesConfigu
+                 if (!d.m_info.uses_original_profile) {
+                     if (JXL_DEC_SUCCESS
+                         != JxlDecoderGetICCProfileSize(dec.get(),
++#if JPEGXL_NUMERIC_VERSION < JPEGXL_COMPUTE_NUMERIC_VERSION(0,9,0)
+                                                        nullptr,
++#endif
+                                                        JXL_COLOR_PROFILE_TARGET_ORIGINAL,
+                                                        &iccTargetSize)) {
+                         errFile << "ICC profile size retrieval failed";
+@@ -667,7 +678,9 @@ JPEGXLImport::convert(KisDocument *document, QIODevice *io, KisPropertiesConfigu
+                     iccTargetProfile.resize(static_cast<int>(iccTargetSize));
+                     if (JXL_DEC_SUCCESS
+                         != JxlDecoderGetColorAsICCProfile(dec.get(),
++#if JPEGXL_NUMERIC_VERSION < JPEGXL_COMPUTE_NUMERIC_VERSION(0,9,0)
+                                                           nullptr,
++#endif
+                                                           JXL_COLOR_PROFILE_TARGET_ORIGINAL,
+                                                           reinterpret_cast<uint8_t *>(iccTargetProfile.data()),
+                                                           static_cast<size_t>(iccTargetProfile.size()))) {
+-- 
+GitLab
+

--- a/app-creativity/krita/autobuild/patches/0004-fix-global-menu-on-Plasma-6.patch
+++ b/app-creativity/krita/autobuild/patches/0004-fix-global-menu-on-Plasma-6.patch
@@ -1,0 +1,47 @@
+From 5dfe4918fa178a5870b2320e4c04bef346d87c08 Mon Sep 17 00:00:00 2001
+From: Halla Rempt <halla@valdyas.org>
+Date: Thu, 14 Mar 2024 11:57:12 +0100
+Subject: [PATCH] Re-enable the workaround for plasma global menu
+
+BUG:483170
+---
+ libs/ui/opengl/KisOpenGLModeProber.cpp | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/libs/ui/opengl/KisOpenGLModeProber.cpp b/libs/ui/opengl/KisOpenGLModeProber.cpp
+index f76ded8b114..fba1b8c0e19 100644
+--- a/libs/ui/opengl/KisOpenGLModeProber.cpp
++++ b/libs/ui/opengl/KisOpenGLModeProber.cpp
+@@ -160,7 +160,6 @@ KisOpenGLModeProber::probeFormat(const KisOpenGL::RendererConfig &rendererConfig
+     char *argv = probeAppName.data();
+ 
+ 
+-
+     if (adjustGlobalState) {
+         sharedContextSetter.reset(new AppAttributeSetter(Qt::AA_ShareOpenGLContexts, false));
+ 
+@@ -175,9 +174,19 @@ KisOpenGLModeProber::probeFormat(const KisOpenGL::RendererConfig &rendererConfig
+ 
+         // Disable this workaround for plasma (BUG:408015), because it causes 
+         // a crash on Windows with Qt 5.15.7
+-        //QGuiApplication::setDesktopSettingsAware(false);
++        const bool runningInKDE =  qEnvironmentVariableIsSet("KDE_FULL_SESSION");
++        const bool isInAppimage = qEnvironmentVariableIsSet("APPIMAGE");
++
++        if (runningInKDE && !isInAppimage) {
++            QGuiApplication::setDesktopSettingsAware(false);
++        }
++
+         application.reset(new QGuiApplication(argc, &argv));
+-        //QGuiApplication::setDesktopSettingsAware(true);
++
++        if (runningInKDE && !isInAppimage) {
++            QGuiApplication::setDesktopSettingsAware(true);
++        }
++
+     }
+ 
+     QWindow surface;
+-- 
+GitLab
+

--- a/app-creativity/krita/spec
+++ b/app-creativity/krita/spec
@@ -1,4 +1,5 @@
 VER=5.2.2
+REL=1
 SRCS="tbl::https://download.kde.org/stable/krita/${VER:0:5}/krita-$VER.tar.xz"
 CHKSUMS="sha256::41515784d65b5bf12919df909f7406dc90f37076587b8c459ef2abd569a71adb"
 CHKUPDATE="anitya::id=10918"

--- a/app-imaging/imv/autobuild/defines
+++ b/app-imaging/imv/autobuild/defines
@@ -6,4 +6,5 @@ PKGDEP="wayland xorg-server glu libxcb libxkbcommon pango inih \
 BUILDDEP="meson ninja asciidoc"
 PKGDES="A command-line image viewer"
 
+ABTYPE=meson
 MESON_AFTER="-Dman=enabled"

--- a/app-imaging/imv/spec
+++ b/app-imaging/imv/spec
@@ -1,5 +1,5 @@
 VER=4.5.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v${VER}::https://git.sr.ht/~exec64/imv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=93177"

--- a/desktop-kde/kimageformats/autobuild/defines
+++ b/desktop-kde/kimageformats/autobuild/defines
@@ -4,6 +4,7 @@ PKGDEP="karchive libavif libheif libjxl libraw"
 BUILDDEP="extra-cmake-modules"
 PKGDES="An image format plugin for Qt 5"
 
+ABTYPE=cmakeninja
 CMAKE_AFTER="-DBUILD_COVERAGE=OFF \
              -DBUILD_TESTING=OFF \
              -DBUILD_WITH_QT6=OFF \

--- a/desktop-kde/kimageformats/spec
+++ b/desktop-kde/kimageformats/spec
@@ -1,4 +1,5 @@
 VER=5.115.0
+REL=1
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/kimageformats-$VER.tar.xz"
 CHKSUMS="sha256::9f61020d66f86b8b10bce14e42a39c5e8fd8e40ec9e6ca8b9e9b5ce3e1aa7283"
 CHKUPDATE="anitya::id=8762"

--- a/runtime-common/highway/autobuild/defines
+++ b/runtime-common/highway/autobuild/defines
@@ -3,6 +3,7 @@ PKGSEC=libs
 PKGDEP="gcc-runtime"
 PKGDES="A C++ library that provides portable SIMD/vector intrinsics"
 
+ABTYPE=cmakeninja
 CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON \
              -DBUILD_TESTING=OFF \
              -DHWY_ENABLE_CONTRIB=ON \
@@ -14,3 +15,8 @@ CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON \
 CMAKE_AFTER__ARMV7HF=" \
              ${CMAKE_AFTER} \
              -DHWY_CMAKE_ARM7=ON"
+
+#FIXME: lto1: fatal error: target specific builtin not available
+NOLTO__RISCV64=1
+
+PKGBREAK="libjxl<=0.7.0"

--- a/runtime-common/highway/spec
+++ b/runtime-common/highway/spec
@@ -1,4 +1,4 @@
-VER=1.0.2
-SRCS="tbl::https://github.com/google/highway/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::e8ef71236ac0d97f12d553ec1ffc5b6375d57b5f0b860c7447dd69b6ed1072db"
+VER=1.1.0
+SRCS="git::commit=tags/$VER::https://github.com/google/highway"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205809"

--- a/runtime-imaging/libjxl/autobuild/defines
+++ b/runtime-imaging/libjxl/autobuild/defines
@@ -10,6 +10,7 @@ PKGDEP__LOONGARCH64="${PKGDEP/gperftools/}"
 BUILDDEP="asciidoc doxygen gdk-pixbuf gimp openjdk xdg-utils"
 PKGDES="Reference encoder and decoder implementation for the JPEG XL image format"
 
+BUILDDEP__ARM64="$BUILDDEP llvm"
 # FIXME: doxygen SIGILLs during asset rendering on mips64r6el.
 # FIXME: Openjdk is not yet available on mips64r6el.
 BUILDDEP__MIPS64R6EL="${BUILDDEP/gimp openjdk/}"

--- a/runtime-imaging/libjxl/autobuild/defines.stage2
+++ b/runtime-imaging/libjxl/autobuild/defines.stage2
@@ -7,12 +7,12 @@ PKGDEP="brotli giflib gperftools highway lcms2 libjpeg-turbo libpng openexr \
 PKGDEP__LOONGARCH64="${PKGDEP/gperftools/}"
 # Note: Leave gdk-pixbuf and gimp in build dep, since dependees for these
 # packages would have introduced them as dependencies anyway.
-BUILDDEP="asciidoc doxygen gdk-pixbuf gimp openjdk xdg-utils"
+BUILDDEP="asciidoc doxygen gdk-pixbuf openjdk xdg-utils"
 PKGDES="Reference encoder and decoder implementation for the JPEG XL image format"
 
 # FIXME: doxygen SIGILLs during asset rendering on mips64r6el.
 # FIXME: Openjdk is not yet available on mips64r6el.
-BUILDDEP__MIPS64R6EL="${BUILDDEP/gimp openjdk/}"
+BUILDDEP__MIPS64R6EL="${BUILDDEP/openjdk/}"
 
 ABTYPE=cmakeninja
 #FIXME: gcc reports ICE on arm64.
@@ -61,5 +61,3 @@ CMAKE_AFTER__ARMV7HF=" \
 CMAKE_AFTER__LOONGARCH64=" \
              ${CMAKE_AFTER} \
              -DJPEGXL_ENABLE_TCMALLOC=OFF"
-
-PKGBREAK="gimp<=2.10.36-1 imv<=4.5.0-2 kimageformats<=5.115.0 krita<=5.2.2 webkit2gtk<=2.42.5-1"

--- a/runtime-imaging/libjxl/autobuild/defines.stage2
+++ b/runtime-imaging/libjxl/autobuild/defines.stage2
@@ -10,6 +10,7 @@ PKGDEP__LOONGARCH64="${PKGDEP/gperftools/}"
 BUILDDEP="asciidoc doxygen gdk-pixbuf openjdk xdg-utils"
 PKGDES="Reference encoder and decoder implementation for the JPEG XL image format"
 
+BUILDDEP__ARM64="$BUILDDEP llvm"
 # FIXME: doxygen SIGILLs during asset rendering on mips64r6el.
 # FIXME: Openjdk is not yet available on mips64r6el.
 BUILDDEP__MIPS64R6EL="${BUILDDEP/openjdk/}"

--- a/runtime-imaging/libjxl/spec
+++ b/runtime-imaging/libjxl/spec
@@ -1,4 +1,4 @@
-VER=0.7.0
+VER=0.10.2
 SRCS="git::commit=tags/v$VER::https://github.com/libjxl/libjxl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=232764"

--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -3,4 +3,5 @@ SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
 CHKSUMS="sha256::523f42c8ff24832add17631f6eaafe8f9303afe316ef1a7e1844b952a7f7521b"
 CHKUPDATE="anitya::id=324014"
 ENVREQ__ARM64="total_mem_per_core=3"
-ENVREQ__LOONGARCH64="total_mem_per_core=3"
+ENVREQ__LOONGARCH64="total_mem=100"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- krita: add patches from Arch Linux
    Fix cannot convert ‘std::nullptr_t’ to ‘JxlColorProfileTarget’
- krita: bump REL due to libjxl update
    Specify cmakeninja ABTYPE
- gimp: bump REL due to libjxl update and add PKGDEP
    - Specify autotools ABTYPE
    - Add gnome-themes-standard PKGDEP to
    fix unable to locate theme engine in module_path: "adwaita".
- kimageformats: bump REL due to libjxl update
    Specify cmakeninja ABTYPE
- imv: bump REL due to libjxl update
    Specify meson ABTYPE
- webkit2gtk: bump REL due to libjxl update
    (loongarch64) Require total memory instead of memory per core.
- libjxl: add llvm BUILDDEP for USECLANG__ARM64
- libjxl: update to 0.10.2 and add stage2 as gimp
    - Add PKGBREAK for rdepends
    - Specify cmakeninja ABTYPE
    - Fix gcc report ICE on ARM64
- highway: update to 1.1.0 due to libjxl require
    - Add libjxl PKGBREAK
    - Specify cmakeninja ABTYPE
    - Disable LTO on riscv64

Package(s) Affected
-------------------

- gimp: 2.10.36-2
- highway: 1.1.0
- imv: 4.5.0-3
- kimageformats: 5.115.0-1
- krita: 5.2.2-1
- libjxl: 0.10.2
- webkit2gtk: 1:2.44.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit highway libjxl:+stage2 gimp libjxl imv kimageformats webkit2gtk krita
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
