### PR TITLE
i3lock: update to 2.15

### DIFF
--- a/desktop-wm/i3lock/spec
+++ b/desktop-wm/i3lock/spec
@@ -1,4 +1,4 @@
-VER=2.14.1
+VER=2.15
 SRCS="tbl::https://i3wm.org/i3lock/i3lock-$VER.tar.xz"
-CHKSUMS="sha256::062ef27eba0bc5a0c7ae91f7b7cbbf03b316d6a49fe80a58fc9f20c18a4e6843"
+CHKSUMS="sha256::5711ae5255e82b1dc8d8b4c035c520230921aba7ceee23d66f79765b21a84baa"
 CHKUPDATE="anitya::id=1349"


### PR DESCRIPTION
Topic Description
-----------------

- i3lock: update to 2.15
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- i3lock: 2.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit i3lock
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
