### PR TITLE
git: update to 2.45.1

### DIFF
--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,4 +1,4 @@
-VER=2.45.0
+VER=2.45.1
 SRCS="https://www.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
-CHKSUMS="sha256::a0fc1410878716add0a3c0cf3d35728f3a7c960f751c657656cca0212bf89e65"
+CHKSUMS="sha256::10acb581993061e616be9c5674469335922025a666318e0748cb8306079fef24"
 CHKUPDATE="anitya::id=5350"


### PR DESCRIPTION
Topic Description
-----------------

- git: update to 2.45.1
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- git: 2.45.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
