### PR TITLE
polybar: update to 3.7.1

### DIFF
--- a/app-utils/polybar/spec
+++ b/app-utils/polybar/spec
@@ -1,4 +1,4 @@
-VER=3.7.0
+VER=3.7.1
 SRCS="https://github.com/polybar/polybar/releases/download/$VER/polybar-$VER.tar.gz"
-CHKSUMS="sha256::b8e07aca94a013341b7d47ee548afe84f519113f202300565d4852885a11e91d"
+CHKSUMS="sha256::5de6ad385ba09dc453a4e5ec7054749a4882b5b21a62c17ae40bf7c90613ff0f"
 CHKUPDATE="anitya::id=231634"


### PR DESCRIPTION
Topic Description
-----------------

- polybar: update to 3.7.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- polybar: 3.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit polybar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
