### PR TITLE
level-zero: update to 1.17.0

### DIFF
--- a/runtime-common/level-zero/autobuild/defines
+++ b/runtime-common/level-zero/autobuild/defines
@@ -3,3 +3,4 @@ PKGSEC=libs
 PKGDEP="gcc-runtime"
 BUILDDEP="opencl-registry-api"
 PKGDES="oneAPI Level Zero Specification Headers and Loader"
+ABTYPE=cmakeninja

--- a/runtime-common/level-zero/autobuild/prepare
+++ b/runtime-common/level-zero/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo "Copying Git directory ..."
-acbs_copy_git

--- a/runtime-common/level-zero/spec
+++ b/runtime-common/level-zero/spec
@@ -1,4 +1,4 @@
-VER=1.16.14
-SRCS="git::commit=tags/v$VER::https://github.com/oneapi-src/level-zero"
+VER=1.17.0
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/oneapi-src/level-zero"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229539"


### PR DESCRIPTION
Topic Description
-----------------

- level-zero: update to 1.17.0

Package(s) Affected
-------------------

- level-zero: 1.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit level-zero
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
