### PR TITLE
intel-ucode: update to 20240514

### DIFF
--- a/runtime-data/intel-ucode/autobuild/build
+++ b/runtime-data/intel-ucode/autobuild/build
@@ -1,18 +1,16 @@
-abinfo "Arch Linux build procedures - building ucode image..."
-wget --content-disposition \
-    'https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/5ada2f32ed7d216e38823f1320358e4679941990/intel-ucode/06-55-04?raw=true' \
-    -O "$SRCDIR"/intel-ucode/06-55-04
-
+abinfo "Arch Linux build procedures - building ucode image ..."
 rm -fv "$SRCDIR"/intel-ucode{,-with-caveats}/list
 mkdir -pv "$SRCDIR"/kernel/x86/microcode
 iucode_tool --write-earlyfw=intel-ucode.img \
     intel-ucode{,-with-caveats}/
 
-abinfo "Installing ucode image..."
-install -Dvm0644 "$SRCDIR"/intel-ucode.img \
+abinfo "Installing ucode image and microcode ..."
+install -Dvm644 "$SRCDIR"/intel-ucode.img \
     "$PKGDIR"/boot/intel-ucode.img
+install -Dvm644 "$SRCDIR"/"$PKGNAME"/* -t \
+    "$PKGDIR"/usr/lib/firmware/"$PKGNAME"
 
-abinfo "Deploying license..."
+abinfo "Deploying license ..."
 mkdir -pv "$PKGDIR"/usr/share/doc/"$PKGNAME"
 cp -v "$SRCDIR"/license \
     "$PKGDIR"/usr/share/doc/"$PKGNAME"/LICENSE

--- a/runtime-data/intel-ucode/spec
+++ b/runtime-data/intel-ucode/spec
@@ -1,4 +1,4 @@
-VER=20221108
+VER=20240514
 SRCS="tbl::https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/microcode-$VER.tar.gz"
-CHKSUMS="sha256::8d14a914815f56c27b1f41be0fd699d1afcfdbc05432056427e455100798975e"
+CHKSUMS="sha256::b5e3cbcb2e34d4c32dcdbfee36603dd68e8a4162cf7e44084f6989d440e69a08"
 CHKUPDATE="anitya::id=20614"


### PR DESCRIPTION
Topic Description
-----------------

- intel-ucode: update to 20240514
    Co-authored-by: Anjia Wang (@ouankou) <anjia@ouankou.com>

Package(s) Affected
-------------------

- intel-ucode: 20240514

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-ucode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
