### PR TITLE
cava: update to 0.10.2

### DIFF
--- a/app-multimedia/cava/spec
+++ b/app-multimedia/cava/spec
@@ -1,5 +1,4 @@
-VER=0.10.1
-REL=2
+VER=0.10.2
 SRCS="git::commit=tags/$VER::https://github.com/karlstav/cava"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17019"


### PR DESCRIPTION
Topic Description
-----------------

- cava: update to 0.10.2
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- cava: 0.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cava
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
