### PR TITLE
atuin: update to 18.2.0

### DIFF
--- a/app-utils/atuin/autobuild/defines
+++ b/app-utils/atuin/autobuild/defines
@@ -11,9 +11,12 @@ ABSPLITDBG=0
 CARGO_AFTER="--no-default-features \
              --features client,sync,server,clipboard"
 
-# ld.lld does not support loongarch64
+# ld.lld does not support loongarch64 and loongson3
 USECLANG__LOONGARCH64=0
 NOLTO__LOONGARCH64=1
+USECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1
+
 
 USECLANG__RISCV64=0
 NOLTO__RISCV64=1

--- a/app-utils/atuin/autobuild/patches/0001-fix-use-clipboard-to-fix-loongarch64-build.patch.loongarch64
+++ b/app-utils/atuin/autobuild/patches/0001-fix-use-clipboard-to-fix-loongarch64-build.patch.loongarch64
@@ -1,51 +1,39 @@
-From 2e7e3e7610afe7905f2b5790965c62ee8183767c Mon Sep 17 00:00:00 2001
+From f70b80d3874e7485e21776878f88c652c4d191fe Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
-Date: Sat, 10 Feb 2024 14:06:42 +0800
-Subject: [PATCH] Fix loongarch64 build
+Date: Wed, 15 May 2024 23:04:56 +0800
+Subject: [PATCH] fix: use `clipboard` to fix loongarch64 build
 
+- `cli-clipboard` use old version nix, It doesn't support loongarch64
 ---
- Cargo.lock                                    | 251 ++----------------
+ Cargo.lock                                    | 241 ++----------------
  atuin/Cargo.toml                              |   4 +-
- .../src/command/client/search/interactive.rs  |   8 +-
- 3 files changed, 26 insertions(+), 237 deletions(-)
+ .../src/command/client/search/interactive.rs  |   9 +-
+ 3 files changed, 24 insertions(+), 230 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index ad9bbeee..f735bece 100644
+index 18a49f7c..58c29f4b 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -174,7 +174,7 @@ version = "0.1.2"
+@@ -174,7 +174,7 @@ version = "0.1.3"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "edcdbedc2236483ab103a53415653d6b4442ea6141baf1ffa85df29635e88436"
+ checksum = "a8204db279bf648d64fe845bd8840f78b39c8132ed4d6a4194c3b10d4b4cfb0b"
  dependencies = [
-- "nix 0.27.1",
+- "nix 0.28.0",
 + "nix",
   "rand",
  ]
  
-@@ -190,7 +190,7 @@ dependencies = [
-  "base64 0.21.7",
+@@ -192,7 +192,7 @@ dependencies = [
   "clap",
   "clap_complete",
+  "clap_complete_nushell",
 - "cli-clipboard",
 + "clipboard",
   "colored",
   "crossterm",
   "directories",
-@@ -524,12 +524,6 @@ version = "3.14.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
- 
--[[package]]
--name = "bytecount"
--version = "0.6.7"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
--
- [[package]]
- name = "byteorder"
- version = "1.5.0"
-@@ -668,27 +662,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+@@ -702,27 +702,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
  
  [[package]]
 -name = "cli-clipboard"
@@ -77,7 +65,7 @@ index ad9bbeee..f735bece 100644
   "winapi",
  ]
  
-@@ -951,17 +942,6 @@ dependencies = [
+@@ -995,17 +992,6 @@ dependencies = [
   "serde",
  ]
  
@@ -95,20 +83,20 @@ index ad9bbeee..f735bece 100644
  [[package]]
  name = "diff"
  version = "0.1.13"
-@@ -1025,12 +1005,6 @@ version = "0.15.7"
+@@ -1069,12 +1055,6 @@ version = "0.15.7"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
  
 -[[package]]
 -name = "downcast-rs"
--version = "1.2.0"
+-version = "1.2.1"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 -
  [[package]]
  name = "ed25519"
  version = "2.2.3"
-@@ -1108,16 +1082,6 @@ dependencies = [
+@@ -1162,16 +1142,6 @@ dependencies = [
   "windows-sys 0.52.0",
  ]
  
@@ -125,7 +113,7 @@ index ad9bbeee..f735bece 100644
  [[package]]
  name = "etcetera"
  version = "0.8.0"
-@@ -1174,12 +1138,6 @@ version = "1.2.0"
+@@ -1228,12 +1198,6 @@ version = "1.2.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
  
@@ -138,7 +126,7 @@ index ad9bbeee..f735bece 100644
  [[package]]
  name = "flume"
  version = "0.11.0"
-@@ -1336,16 +1294,6 @@ dependencies = [
+@@ -1390,16 +1354,6 @@ dependencies = [
   "zeroize",
  ]
  
@@ -154,22 +142,10 @@ index ad9bbeee..f735bece 100644
 -
  [[package]]
  name = "getrandom"
- version = "0.2.12"
-@@ -1807,9 +1755,9 @@ dependencies = [
- 
- [[package]]
- name = "libc"
--version = "0.2.152"
-+version = "0.2.153"
+ version = "0.2.14"
+@@ -1998,15 +1952,6 @@ version = "2.7.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
-+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
- 
- [[package]]
- name = "libm"
-@@ -1951,15 +1899,6 @@ version = "2.7.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
  
 -[[package]]
 -name = "memoffset"
@@ -183,7 +159,7 @@ index ad9bbeee..f735bece 100644
  [[package]]
  name = "metrics"
  version = "0.21.1"
-@@ -2054,18 +1993,6 @@ dependencies = [
+@@ -2101,18 +2046,6 @@ dependencies = [
   "windows-sys 0.48.0",
  ]
  
@@ -201,8 +177,8 @@ index ad9bbeee..f735bece 100644
 -
  [[package]]
  name = "nix"
- version = "0.27.1"
-@@ -2288,16 +2215,6 @@ version = "0.2.0"
+ version = "0.28.0"
+@@ -2350,16 +2283,6 @@ version = "0.2.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
  
@@ -219,7 +195,7 @@ index ad9bbeee..f735bece 100644
  [[package]]
  name = "overload"
  version = "0.1.1"
-@@ -2385,16 +2302,6 @@ version = "2.3.1"
+@@ -2447,16 +2370,6 @@ version = "2.3.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
  
@@ -230,13 +206,13 @@ index ad9bbeee..f735bece 100644
 -checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 -dependencies = [
 - "fixedbitset",
-- "indexmap 2.1.0",
+- "indexmap 2.2.6",
 -]
 -
  [[package]]
  name = "pin-project"
- version = "1.1.4"
-@@ -3446,12 +3353,6 @@ dependencies = [
+ version = "1.1.5"
+@@ -3545,12 +3458,6 @@ dependencies = [
   "syn 1.0.109",
  ]
  
@@ -249,19 +225,19 @@ index ad9bbeee..f735bece 100644
  [[package]]
  name = "stringprep"
  version = "0.1.4"
-@@ -3854,20 +3755,6 @@ dependencies = [
+@@ -3972,20 +3879,6 @@ dependencies = [
   "tracing-subscriber",
  ]
  
 -[[package]]
 -name = "tree_magic_mini"
--version = "3.0.3"
+-version = "3.1.4"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "91adfd0607cacf6e4babdb870e9bec4037c1c4b151cfd279ccefc5e0c7feaa6d"
+-checksum = "77ee137597cdb361b55a4746983e4ac1b35ab6024396a419944ad473bb915265"
 -dependencies = [
-- "bytecount",
 - "fnv",
-- "lazy_static",
+- "home",
+- "memchr",
 - "nom",
 - "once_cell",
 - "petgraph",
@@ -270,9 +246,9 @@ index ad9bbeee..f735bece 100644
  [[package]]
  name = "try-lock"
  version = "0.2.5"
-@@ -4088,65 +3975,6 @@ version = "0.2.90"
+@@ -4218,65 +4111,6 @@ version = "0.2.92"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
  
 -[[package]]
 -name = "wayland-client"
@@ -335,16 +311,16 @@ index ad9bbeee..f735bece 100644
 -
  [[package]]
  name = "web-sys"
- version = "0.3.67"
-@@ -4198,15 +4026,6 @@ dependencies = [
-  "winapi",
- ]
+ version = "0.3.69"
+@@ -4320,15 +4154,6 @@ version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
  
 -[[package]]
 -name = "winapi-wsapoll"
--version = "0.1.1"
+-version = "0.1.2"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
+-checksum = "1eafc5f679c576995526e81635d0cf9695841736712b4e892f87abbe6fed3f28"
 -dependencies = [
 - "winapi",
 -]
@@ -352,7 +328,7 @@ index ad9bbeee..f735bece 100644
  [[package]]
  name = "winapi-x86_64-pc-windows-gnu"
  version = "0.4.0"
-@@ -4364,61 +4183,25 @@ dependencies = [
+@@ -4496,61 +4321,25 @@ dependencies = [
   "windows-sys 0.48.0",
  ]
  
@@ -415,15 +391,15 @@ index ad9bbeee..f735bece 100644
  
 -[[package]]
 -name = "xml-rs"
--version = "0.8.19"
+-version = "0.8.20"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+-checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 -
  [[package]]
  name = "yansi"
  version = "0.5.1"
 diff --git a/atuin/Cargo.toml b/atuin/Cargo.toml
-index 79d50703..56108f9c 100644
+index 9c112d73..0e8b1377 100644
 --- a/atuin/Cargo.toml
 +++ b/atuin/Cargo.toml
 @@ -37,7 +37,7 @@ default = ["client", "sync", "server", "clipboard", "check-update"]
@@ -435,34 +411,35 @@ index 79d50703..56108f9c 100644
  check-update = ["atuin-client/check-update"]
  
  [dependencies]
-@@ -75,7 +75,7 @@ fuzzy-matcher = "0.3.7"
- colored = "2.0.4"
- ratatui = "0.25"
- tracing = "0.1"
+@@ -83,7 +83,7 @@ serde_yaml = "0.9.32"
+ sysinfo = "0.30.7"
+ 
+ [target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))'.dependencies]
 -cli-clipboard = { version = "0.4.0", optional = true }
 +clipboard = { version = "0.5.0", optional = true }
- uuid = { workspace = true }
  
- 
+ [dependencies.tracing-subscriber]
+ version = "0.3"
 diff --git a/atuin/src/command/client/search/interactive.rs b/atuin/src/command/client/search/interactive.rs
-index 1a94e36d..e37cc890 100644
+index d2a314ef..a64d36b0 100644
 --- a/atuin/src/command/client/search/interactive.rs
 +++ b/atuin/src/command/client/search/interactive.rs
-@@ -1010,7 +1010,13 @@ pub async fn history(
- 
- #[cfg(feature = "clipboard")]
+@@ -1133,8 +1133,13 @@ pub async fn history(
+     any(target_os = "windows", target_os = "macos", target_os = "linux")
+ ))]
  fn set_clipboard(s: String) {
 -    cli_clipboard::set_contents(s).unwrap();
+-}
 +    use clipboard::{ClipboardContext, ClipboardProvider};
 +    let ctx = ClipboardContext::new();
 +
 +    if let Ok(mut ctx) = ctx {
 +        let _ = ctx.set_contents(s);
 +        let _ = ctx.get_contents();   
-+    }
- }
++    }}
  
- #[cfg(not(feature = "clipboard"))]
+ #[cfg(not(all(
+     feature = "clipboard",
 -- 
-2.43.0
+2.45.1
 

--- a/app-utils/atuin/spec
+++ b/app-utils/atuin/spec
@@ -1,4 +1,4 @@
-VER="18.0.1"
+VER=18.2.0
 SRCS="git::commit=tags/v$VER::https://github.com/atuinsh/atuin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243615"


### PR DESCRIPTION
Topic Description
-----------------

- atuin: update to 18.2.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- atuin: 18.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit atuin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
