### PR TITLE
network-manager-applet: update to 1.36.0

### DIFF
--- a/desktop-gnome/network-manager-applet/autobuild/patches/0001-Do-not-show-nm-connection-editor-in-KDE.patch
+++ b/desktop-gnome/network-manager-applet/autobuild/patches/0001-Do-not-show-nm-connection-editor-in-KDE.patch
@@ -1,8 +1,0 @@
-diff -Naur network-manager-applet-1.24.0/nm-connection-editor.desktop.in network-manager-applet-1.24.0.desktop/nm-connection-editor.desktop.in
---- network-manager-applet-1.24.0/nm-connection-editor.desktop.in	2021-08-17 08:10:34.000000000 +0000
-+++ network-manager-applet-1.24.0.desktop/nm-connection-editor.desktop.in	2022-09-14 05:44:19.885871247 +0000
-@@ -10,3 +10,4 @@
- X-GNOME-Bugzilla-Product=NetworkManager
- X-GNOME-Bugzilla-Component=nm-connection-editor
- Categories=GNOME;GTK;Settings;X-GNOME-NetworkSettings;X-GNOME-Utilities;
-+NotShowIn=KDE;

--- a/desktop-gnome/network-manager-applet/autobuild/patches/0001-do-not-show-nm-connection-editor-in-KDE.patch
+++ b/desktop-gnome/network-manager-applet/autobuild/patches/0001-do-not-show-nm-connection-editor-in-KDE.patch
@@ -1,0 +1,22 @@
+From ceea43dc0976ca0b716638bb1cee8ce24b10f319 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Wed, 15 May 2024 12:53:58 -0700
+Subject: [PATCH] do not show nm connection editor in KDE
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ nm-connection-editor.desktop.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/nm-connection-editor.desktop.in b/nm-connection-editor.desktop.in
+index bc13e9d9..24d576f1 100644
+--- a/nm-connection-editor.desktop.in
++++ b/nm-connection-editor.desktop.in
+@@ -7,3 +7,4 @@ Terminal=false
+ StartupNotify=true
+ Type=Application
+ Categories=GNOME;GTK;Settings;X-GNOME-NetworkSettings;X-GNOME-Utilities;
++NotShowIn=KDE;
+-- 
+2.45.1
+

--- a/desktop-gnome/network-manager-applet/spec
+++ b/desktop-gnome/network-manager-applet/spec
@@ -1,5 +1,4 @@
-VER=1.28.0
-REL=1
+VER=1.36.0
 SRCS="https://download.gnome.org/sources/network-manager-applet/${VER:0:4}/network-manager-applet-$VER.tar.xz"
-CHKSUMS="sha256::5c0348581de9e619185aa74b747f07f40312417e395afe0b293cc955df14e49c"
+CHKSUMS="sha256::a84704487ea3afe1485c47fb2ab598b8f779f540ae0dcbf0a1c5f85e64a7e253"
 CHKUPDATE="anitya::id=198502"

--- a/runtime-network/libnma/autobuild/beyond
+++ b/runtime-network/libnma/autobuild/beyond
@@ -1,0 +1,3 @@
+# FIXME: this schema is also provided by network-manager-applet, use that one instead
+abinfo "Removing nm-applet gschema ..."
+rm -v "$PKGDIR"/usr/share/glib-2.0/schemas/org.gnome.nm-applet.gschema.xml

--- a/runtime-network/libnma/autobuild/defines
+++ b/runtime-network/libnma/autobuild/defines
@@ -7,7 +7,6 @@ PKGDES="NetworkManager GUI client library"
 ABTYPE=meson
 MESON_AFTER="-Dlibnma_gtk4=true \
              -Dgcr=true \
-             -Dgcr_gtk4=false \
              -Diso_codes=true \
              -Dmobile_broadband_provider_info=true \
              -Dld_gc=true \

--- a/runtime-network/libnma/spec
+++ b/runtime-network/libnma/spec
@@ -1,4 +1,4 @@
-VER=1.10.2
+VER=1.10.6
 SRCS="tbl::https://download.gnome.org/sources/libnma/${VER%.*}/libnma-$VER.tar.xz"
-CHKSUMS="sha256::4fc3d9c404b7b13303d9394f96961c5298d71afa9f1fa7af5e4f0f6e842a0940"
+CHKSUMS="sha256::53a6fb2b190ad37c5986caed3e98bede7c3c602399ee4f93c8fc054303d76dab"
 CHKUPDATE="anitya::id=230112"


### PR DESCRIPTION
Topic Description
-----------------

- network-manager-applet: update to 1.36.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- network-manager-applet: 1.36.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libnma network-manager-applet
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
