### PR TITLE
playerctl: update to 2.4.1

### DIFF
--- a/app-multimedia/playerctl/autobuild/defines
+++ b/app-multimedia/playerctl/autobuild/defines
@@ -1,8 +1,12 @@
 PKGNAME=playerctl
 PKGSEC=sound
-PKGDEP="pygobject-3"
-BUILDDEP="gtk-doc"
+PKGDEP="glib"
+BUILDDEP="gtk-doc gobject-introspection bash-completion"
 PKGDES="Media player controller for mpris2-based players"
 
-ABSHADOW=no
-NOPARALLEL=1
+ABTYPE=meson
+
+MESON_AFTER="-Dgtk-doc=true \
+        -Dintrospection=true \
+        -Dbash-completions=true \
+        -Dzsh-completions=true"

--- a/app-multimedia/playerctl/spec
+++ b/app-multimedia/playerctl/spec
@@ -1,5 +1,4 @@
-VER=2.0.1
+VER=2.4.1
 SRCS="tbl::https://github.com/acrisci/playerctl/archive/v$VER.tar.gz"
-CHKSUMS="sha256::f02f2fbeb2b51fd906af1e01404485ef316e24f616eac00eeee3cdfa54310b5a"
-REL=1
+CHKSUMS="sha256::75957ad5071956f563542c7557af16a57e40b4a7f66bc9b6373d022ec5eef548"
 CHKUPDATE="anitya::id=18550"


### PR DESCRIPTION
Topic Description
-----------------

- playerctl: update to 2.4.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- playerctl: 2.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit playerctl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
