### PR TITLE
power-profiles-daemon: new, 0.21

### DIFF
--- a/app-admin/power-profiles-daemon/autobuild/defines
+++ b/app-admin/power-profiles-daemon/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=power-profiles-daemon
+PKGSEC=admin
+PKGDEP="libgudev systemd polkit glib upower pygobject-3"
+BUILDDEP="meson ninja argparse-manpage gtk-doc libxslt"
+PKGDES="A tool for handling power profiles over D-Bus"
+
+ABTYPE=meson
+
+MESON_AFTER="-Dgtk_doc=true \
+        -Dpylint=disabled \
+        -Dbashcomp=disabled \
+        -Dtests=false"

--- a/app-admin/power-profiles-daemon/spec
+++ b/app-admin/power-profiles-daemon/spec
@@ -1,0 +1,4 @@
+VER=0.21
+SRCS="tbl::https://gitlab.freedesktop.org/upower/power-profiles-daemon/-/archive/$VER/power-profiles-daemon-$VER.tar.gz"
+CHKSUMS="sha256::c15a368a59f2cae1474bdfccdd9357f06b0abc9eb7638a87f68c091aaf570349"
+CHKUPDATE="anitya::id=236320"


### PR DESCRIPTION
Topic Description
-----------------

- power-profiles-daemon: new, 0.21
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- power-profiles-daemon: 0.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit power-profiles-daemon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
