### PR TITLE
lxgwcleargothic-font: update to 0.300.4

### DIFF
--- a/desktop-fonts/lxgwcleargothic-font/autobuild/build
+++ b/desktop-fonts/lxgwcleargothic-font/autobuild/build
@@ -1,5 +1,5 @@
 abinfo "Installing font file..."
-install -Dvm644 "$SRCDIR"/TTF/*.ttf -t "$PKGDIR"/usr/share/fonts/TTF
+install -Dvm644 "$SRCDIR"/*.ttf -t "$PKGDIR"/usr/share/fonts/TTF
 
 abinfo "Installing LICENSE..."
-install -Dvm644 "$SRCDIR"/LICENSE.txt -t "$PKGDIR"/usr/share/doc/lxgwcleargothic-font
+install -Dvm644 "$SRCDIR"/LICENSE.md -t "$PKGDIR"/usr/share/doc/lxgwcleargothic-font

--- a/desktop-fonts/lxgwcleargothic-font/spec
+++ b/desktop-fonts/lxgwcleargothic-font/spec
@@ -1,4 +1,8 @@
-VER=0.206
-SRCS="tbl::https://github.com/lxgw/LxgwClearGothic/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::6989865b8da2993cd124c408115a9d4603d8bf30c686e18ec4ff2d41136fbdac"
+VER=0.300.4
+SRCS="file::rename=LXGWXiHeiCL.ttf::https://github.com/lxgw/LxgwXiHei/releases/download/v$VER/LXGWXiHeiCL.ttf \
+      file::rename=LXGWXiHeiMN.ttf::https://github.com/lxgw/LxgwXiHei/releases/download/v$VER/LXGWXiHeiMN.ttf
+      file::rename=LICENSE.md::https://raw.githubusercontent.com/lxgw/LxgwXiHei/v$VER/LICENSE.md"
+CHKSUMS="sha256::7bc05c32f5741c830676ea2346d80af050b452d9407f36051da13e54378930a6 \
+         sha256::e7102c3cae0934a6d0d08796ab079d97dbcc017491daca1b44ab501cc85a6660 \
+         sha256::a186b1f3ad4b8d56a43dc96637ce55f5aa4f4446025d6247641d4ef13c4bb29b"
 CHKUPDATE="anitya::id=234782"


### PR DESCRIPTION
Topic Description
-----------------

- lxgwcleargothic-font: update to 0.300.4
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- lxgwcleargothic-font: 0.300.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxgwcleargothic-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
