### PR TITLE
lxgwnewcleargothic-font: update to 1.121

### DIFF
--- a/desktop-fonts/lxgwnewcleargothic-font/spec
+++ b/desktop-fonts/lxgwnewcleargothic-font/spec
@@ -1,9 +1,9 @@
-VER=1.108
+VER=1.121
 SRCS="file::rename=LXGWFasmartGothic.ttf::https://github.com/lxgw/LxgwNeoXiHei/releases/download/v$VER/LXGWFasmartGothic.ttf \
       file::rename=LxgwNeoXiHei-Book.ttf::https://github.com/lxgw/LxgwNeoXiHei/releases/download/v$VER/LxgwNeoXiHei.ttf \
       tbl::https://github.com/lxgw/LxgwNeoXiHei/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::ba19399dca057023a856e375e1d1881774e4a0625c8c3cd9243ed4b51a5fcbb5 \
-         sha256::5b1d9f9af2041e08a6bbb049e3dc562bb734f11b1fddfb2330b4ddc9e7602b72 \
-         sha256::92f6c1875fe3cd5309cf79dc68d86b7aa9f79106a93de82a67828ca1408f74fb"
+CHKSUMS="sha256::c38f0b48d6b2c594969932717d720e643ccd45f05a00c08ac42ef90e6897fe5e \
+         sha256::dfeb61e1a95657e8bd9114f8179b71f24383e23f1e99c37699e95cc8dfe630c4 \
+         sha256::6be0e697f1c43f5bc224dc1988bd7816661aada3a67ab7b78482f6b81a6fbcf9"
 CHKUPDATE="anitya::id=234778"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- lxgwnewcleargothic-font: update to 1.121
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- lxgwnewcleargothic-font: 1.121

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxgwnewcleargothic-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
