### PR TITLE
dua: update to 2.29.0

### DIFF
--- a/app-utils/dua/spec
+++ b/app-utils/dua/spec
@@ -1,4 +1,4 @@
-VER=2.28.0
+VER=2.29.0
 SRCS="git::commit=tags/v$VER::https://github.com/Byron/dua-cli"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=79030"


### PR DESCRIPTION
Topic Description
-----------------

- dua: update to 2.29.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- dua: 2.29.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dua
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
