### PR TITLE
sway-audio-idle-inhibit: backport ignore source function

### DIFF
--- a/app-utils/sway-audio-idle-inhibit/autobuild/patches/0001-allow-ignoring-source-outputs.patch
+++ b/app-utils/sway-audio-idle-inhibit/autobuild/patches/0001-allow-ignoring-source-outputs.patch
@@ -1,0 +1,224 @@
+From fcf6ae19cdbd1fb345d0d588ab9a2bc812f9589f Mon Sep 17 00:00:00 2001
+From: rkrishn7 <rkrishn7@users.noreply.github.com>
+Date: Thu, 12 Oct 2023 20:34:51 -0700
+Subject: [PATCH] allow ignoring source outputs
+
+---
+ include/data.hpp  |  6 +++++-
+ include/pulse.hpp |  4 ++--
+ src/data.cpp      |  3 ++-
+ src/main.cpp      | 27 +++++++++++++++++++++------
+ src/pulse.cpp     | 27 ++++++++++++++++++++++-----
+ 5 files changed, 52 insertions(+), 15 deletions(-)
+
+diff --git a/include/data.hpp b/include/data.hpp
+index 30534ea..d6d99cd 100644
+--- a/include/data.hpp
++++ b/include/data.hpp
+@@ -9,6 +9,8 @@
+ 
+ using namespace std;
+ 
++#define MAX_IGNORED_SOURCE_OUTPUTS 100
++
+ enum SubscriptionType {
+   SUBSCRIPTION_TYPE_IDLE,
+   SUBSCRIPTION_TYPE_DRY_BOTH,
+@@ -36,13 +38,15 @@ struct Data {
+   SubscriptionType subscriptionType;
+   pa_subscription_mask_t pa_subscriptionType;
+ 
++  char **ignoredSourceOutputs;
++
+   Idle *idle = NULL;
+ 
+   bool failed = false;
+ 
+   Data(pa_threaded_mainloop *mainloop, pa_mainloop_api *mainloop_api,
+        SubscriptionType subscriptionType,
+-       pa_subscription_mask_t pa_subscriptionType, EventType eventType);
++       pa_subscription_mask_t pa_subscriptionType, EventType eventType, char **ignoredSourceOutputs);
+ 
+   void quit(int returnValue = 0);
+ 
+diff --git a/include/pulse.hpp b/include/pulse.hpp
+index 6b76ec8..0e92167 100644
+--- a/include/pulse.hpp
++++ b/include/pulse.hpp
+@@ -16,7 +16,7 @@
+ class Pulse {
+  public:
+   int init(SubscriptionType subscriptionType,
+-           pa_subscription_mask_t pa_subscriptionType, EventType eventType);
++           pa_subscription_mask_t pa_subscriptionType, EventType eventType, char **ignoredSourceOutputs);
+ 
+  private:
+   static void sink_input_info_callback(pa_context *,
+@@ -40,7 +40,7 @@ class Pulse {
+ 
+   void connect(pa_threaded_mainloop *mainloop, pa_mainloop_api *mainloop_api,
+                SubscriptionType subscriptionType,
+-               pa_subscription_mask_t pa_subscriptionType, EventType eventType);
++               pa_subscription_mask_t pa_subscriptionType, EventType eventType, char **ignoredSourceOutputs);
+ 
+   pa_threaded_mainloop *getMainLoop();
+ 
+diff --git a/src/data.cpp b/src/data.cpp
+index 8c9a814..60e8ea1 100644
+--- a/src/data.cpp
++++ b/src/data.cpp
+@@ -2,12 +2,13 @@
+ 
+ Data::Data(pa_threaded_mainloop *mainloop, pa_mainloop_api *mainloop_api,
+            SubscriptionType subscriptionType,
+-           pa_subscription_mask_t pa_subscriptionType, EventType eventType) {
++           pa_subscription_mask_t pa_subscriptionType, EventType eventType, char** ignoredSourceOutputs) {
+   this->mainloop = mainloop;
+   this->mainloop_api = mainloop_api;
+   this->subscriptionType = subscriptionType;
+   this->pa_subscriptionType = pa_subscriptionType;
+   this->eventCalled = eventType;
++  this->ignoredSourceOutputs = ignoredSourceOutputs;
+ 
+   if (subscriptionType == SUBSCRIPTION_TYPE_IDLE) idle = new Idle();
+ }
+diff --git a/src/main.cpp b/src/main.cpp
+index eb57c19..c573fc6 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -20,6 +20,9 @@ void showHelp(char **argv) {
+           "sink is running\n";
+   cout << "\t --dry-print-source \t\t Don't inhibit idle and print if any "
+           "source is running\n";
++  cout << "\t --ignore-source-outputs \t\t Don't inhibit idle for these "
++          "source outputs\n";
++  
+ }
+ 
+ int main(int argc, char *argv[]) {
+@@ -28,6 +31,9 @@ int main(int argc, char *argv[]) {
+   bool printSource = false;
+   bool printSink = false;
+ 
++  char* ignoredSourceOutputs[MAX_IGNORED_SOURCE_OUTPUTS];
++  int ignoredSourceOutputsCount = 0;
++
+   if (argc > 1) {
+     for (int i = 1; i < argc; i++) {
+       if (strcmp(argv[i], "--dry-print-source") == 0) {
+@@ -38,6 +44,15 @@ int main(int argc, char *argv[]) {
+         printBoth = true;
+       } else if (strcmp(argv[i], "--dry-print-both-waybar") == 0) {
+         printBothWayBar = true;
++      } else if (strcmp(argv[i], "--ignore-source-outputs") == 0 && i + 1 < argc) {
++        char *saveptr;
++        char *token = strtok_r(argv[++i], " ", &saveptr);
++        while (token != nullptr && ignoredSourceOutputsCount < MAX_IGNORED_SOURCE_OUTPUTS) {
++          ignoredSourceOutputs[ignoredSourceOutputsCount++] = token;
++          token = strtok_r(nullptr, " ", &saveptr);
++        }
++
++        ignoredSourceOutputs[ignoredSourceOutputsCount] = nullptr;
+       } else {
+         showHelp(argv);
+         return 0;
+@@ -49,19 +64,19 @@ int main(int argc, char *argv[]) {
+       (pa_subscription_mask_t)(PA_SUBSCRIPTION_MASK_SINK |
+                                PA_SUBSCRIPTION_MASK_SOURCE);
+   if (!printSink && !printSource && !printBoth && !printBothWayBar) {
+-    return Pulse().init(SUBSCRIPTION_TYPE_IDLE, all_mask, EVENT_TYPE_IDLE);
++    return Pulse().init(SUBSCRIPTION_TYPE_IDLE, all_mask, EVENT_TYPE_IDLE, ignoredSourceOutputs);
+   } else if (printBoth) {
+     return Pulse().init(SUBSCRIPTION_TYPE_DRY_BOTH, all_mask,
+-                        EVENT_TYPE_DRY_BOTH);
++                        EVENT_TYPE_DRY_BOTH, ignoredSourceOutputs);
+   } else if (printBothWayBar) {
+     return Pulse().init(SUBSCRIPTION_TYPE_DRY_BOTH_WAYBAR, all_mask,
+-                        EVENT_TYPE_DRY_BOTH);
++                        EVENT_TYPE_DRY_BOTH, ignoredSourceOutputs);
+   } else if (printSink) {
+-    return Pulse().init(SUBSCRIPTION_TYPE_DRY_SINK, PA_SUBSCRIPTION_MASK_SINK,
+-                        EVENT_TYPE_DRY_SINK);
++    return Pulse().init(SUBSCRIPTION_TYPE_DRY_SINK, PA_SUBSCRIPTION_MASK_SINK_INPUT,
++                        EVENT_TYPE_DRY_SINK, ignoredSourceOutputs);
+   } else if (printSource) {
+     return Pulse().init(SUBSCRIPTION_TYPE_DRY_SOURCE,
+-                        PA_SUBSCRIPTION_MASK_SOURCE, EVENT_TYPE_DRY_SOURCE);
++                        PA_SUBSCRIPTION_MASK_SOURCE, EVENT_TYPE_DRY_SOURCE, ignoredSourceOutputs);
+   }
+   return 0;
+ }
+diff --git a/src/pulse.cpp b/src/pulse.cpp
+index abe58ec..2fc3815 100644
+--- a/src/pulse.cpp
++++ b/src/pulse.cpp
+@@ -3,10 +3,12 @@
+ #include <pulse/context.h>
+ #include <pulse/def.h>
+ #include <pulse/mainloop-api.h>
++#include <pulse/proplist.h>
+ #include <pulse/pulseaudio.h>
+ #include <pulse/thread-mainloop.h>
+ #include <string.h>
+ 
++#include <cstring>
+ #include <cstdlib>
+ #include <iostream>
+ 
+@@ -14,7 +16,8 @@
+ 
+ int Pulse::init(SubscriptionType subscriptionType,
+                 pa_subscription_mask_t pa_subscriptionType,
+-                EventType eventType) {
++                EventType eventType,
++                char **ignoredSourceOutputs) {
+   pa_threaded_mainloop *mainloop = getMainLoop();
+   pa_mainloop_api *mainloop_api = getMainLoopApi(mainloop);
+   if (pa_threaded_mainloop_start(mainloop)) {
+@@ -22,7 +25,7 @@ int Pulse::init(SubscriptionType subscriptionType,
+     return 1;
+   }
+   connect(mainloop, mainloop_api, subscriptionType, pa_subscriptionType,
+-          eventType);
++          eventType, ignoredSourceOutputs);
+   return 0;
+ }
+ 
+@@ -37,7 +40,20 @@ void Pulse::source_output_info_callback(pa_context *,
+                                         const pa_source_output_info *i, int,
+                                         void *userdata) {
+   Data *data = (Data *)userdata;
+-  if (i && !i->corked) data->activeSource = true;
++  bool ignoreSourceOutput = false;
++  if (i && i->proplist) {
++    const char *appName = pa_proplist_gets(i->proplist, "application.name");
++    if (appName) {
++      int i = 0;
++      while (data->ignoredSourceOutputs[i] != nullptr) {
++        if (strcmp(appName, data->ignoredSourceOutputs[i]) == 0) {
++          ignoreSourceOutput = true;
++        }
++        i++;
++      }
++    }
++  }
++  if (i && !i->corked && !ignoreSourceOutput) data->activeSource = true;
+   pa_threaded_mainloop_signal(data->mainloop, 0);
+ }
+ 
+@@ -155,9 +171,10 @@ void Pulse::connect(pa_threaded_mainloop *mainloop,
+                     pa_mainloop_api *mainloop_api,
+                     SubscriptionType subscriptionType,
+                     pa_subscription_mask_t pa_subscriptionType,
+-                    EventType eventType) {
++                    EventType eventType,
++                    char **ignoredSourceOutputs) {
+   Data *data = new Data(mainloop, mainloop_api, subscriptionType,
+-                        pa_subscriptionType, eventType);
++                        pa_subscriptionType, eventType, ignoredSourceOutputs);
+ 
+   pa_context *context = getContext(mainloop, mainloop_api, data);
+ 
+-- 
+2.45.1
+

--- a/app-utils/sway-audio-idle-inhibit/spec
+++ b/app-utils/sway-audio-idle-inhibit/spec
@@ -1,4 +1,5 @@
 VER=0.1.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/ErikReider/SwayAudioIdleInhibit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372107"


### PR DESCRIPTION
Topic Description
-----------------

- sway-audio-idle-inhibit: backport ignore source function
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- sway-audio-idle-inhibit: 0.1.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sway-audio-idle-inhibit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
