### PR TITLE
libmpack: fix FTBFS

### DIFF
--- a/runtime-common/libmpack/autobuild/build
+++ b/runtime-common/libmpack/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Compiling libmpack ..."
+make PREFIX=/usr
+
+abinfo "Installing libmpack ..."
+make DESTDIR="$PKGDIR" PREFIX=/usr install

--- a/runtime-common/libmpack/spec
+++ b/runtime-common/libmpack/spec
@@ -1,4 +1,5 @@
 VER=1.0.5
-SRCS="tbl::https://github.com/libmpack/libmpack/archive/$VER.tar.gz"
-CHKSUMS="sha256::4ce91395d81ccea97d3ad4cb962f8540d166e59d3e2ddce8a22979b49f108956"
+REL=1
+SRCS="git::commit=tags/$VER::https://github.com/libmpack/libmpack"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12423"


### PR DESCRIPTION
Topic Description
-----------------

- libmpack: fix FTBFS on ab4

Package(s) Affected
-------------------

- libmpack: 1.0.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmpack
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
