### PR TITLE
bread-dog: update to 0.2.0

### DIFF
--- a/app-utils/bread-dog/spec
+++ b/app-utils/bread-dog/spec
@@ -1,5 +1,4 @@
-VER="0.1.0"
+VER=0.2.0
 SRCS="git::commit=tags/v$VER::https://github.com/eatradish/bread-dog"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=302756"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- bread-dog: update to 0.2.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- bread-dog: 0.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bread-dog
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
