### PR TITLE
srtp: update to 2.6.0

### DIFF
--- a/runtime-multimedia/srtp/spec
+++ b/runtime-multimedia/srtp/spec
@@ -1,4 +1,4 @@
-VER=2.4.0
+VER=2.6.0
 SRCS="tbl::https://github.com/cisco/libsrtp/archive/v$VER.tar.gz"
-CHKSUMS="sha256::713c5c1dc740707422307f39834c0b0fbb76769168d87e92c438a3cca8233d3d"
+CHKSUMS="sha256::bf641aa654861be10570bfc137d1441283822418e9757dc71ebb69a6cf84ea6b"
 CHKUPDATE="anitya::id=18547"


### PR DESCRIPTION
Topic Description
-----------------

- srtp: update to 2.6.0
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- srtp: 1:2.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit srtp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
