### PR TITLE
git-cliff: new, 2.2.2

### DIFF
--- a/app-vcs/git-cliff/autobuild/defines
+++ b/app-vcs/git-cliff/autobuild/defines
@@ -1,0 +1,15 @@
+PKGNAME=git-cliff
+PKGDES="Generate changelog files from the Git history"
+PKGDEP="glibc gcc-runtime zlib pcre http-parser libgit2 openssl"
+BUILDDEP="rustc llvm"
+PKGSEC="utils"
+
+USECLANG=1
+
+# FIXME: ld.lld not available:
+USECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1
+USECLANG__LOONGARCH64=0
+NOLTO__LOONGARCH64=1
+USECLANG__MIPS64R6EL=0
+NOLTO__MIPS64R6EL=1

--- a/app-vcs/git-cliff/spec
+++ b/app-vcs/git-cliff/spec
@@ -1,0 +1,4 @@
+VER=2.2.2
+SRCS="git::commit=tags/v$VER::https://github.com/orhun/git-cliff"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=368021"


### PR DESCRIPTION
Topic Description
-----------------

- git-cliff: new, 2.2.2

Package(s) Affected
-------------------

- git-cliff: 2.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-cliff
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
