### PR TITLE
bash-git-status: update to 0.3.0

### DIFF
--- a/app-vcs/bash-git-status/spec
+++ b/app-vcs/bash-git-status/spec
@@ -1,4 +1,4 @@
-VER=0.2.2
+VER=0.3.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/bash-git-status"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369164"


### PR DESCRIPTION
Topic Description
-----------------

- bash-git-status: update to 0.3.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- bash-git-status: 0.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-git-status
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
