### PR TITLE
zellij: update to 0.40.1

### DIFF
--- a/app-utils/zellij/spec
+++ b/app-utils/zellij/spec
@@ -1,4 +1,4 @@
-VER=0.39.2
+VER=0.40.1
 SRCS="git::commit=tags/v${VER}::https://github.com/zellij-org/zellij"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=300087"


### PR DESCRIPTION
Topic Description
-----------------

- zellij: update to 0.40.1
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- zellij: 0.40.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zellij
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
