### PR TITLE
gitui: update to 0.26.2

### DIFF
--- a/app-utils/gitui/spec
+++ b/app-utils/gitui/spec
@@ -1,4 +1,4 @@
-VER=0.25.0
+VER=0.26.2
 SRCS="git::commit=tags/v$VER::https://github.com/extrawurst/gitui"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=187553"


### PR DESCRIPTION
Topic Description
-----------------

- gitui: update to 0.26.2
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- gitui: 0.26.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gitui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
