### PR TITLE
wine (WineHQ): update to 9.9

### DIFF
--- a/app-emulation/wine/autobuild/defines
+++ b/app-emulation/wine/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="desktop-file-utils fontconfig freetype gettext glu x11-lib libpcap alsa-
         alsa-plugins gnutls giflib cups lcms2 pulseaudio openldap libjpeg-turbo libxml2 libxslt \
         mpg123 ncurses openal-soft v4l-utils samba libcl gtk-3\
         gst-plugins-base-1-0 libgphoto2 sane-backends vulkan vkd3d"
-PKGDEP__AMD64="${PKGDEP} 32subsystem vulkan+32 vkd3d+32"
+PKGDEP__AMD64="${PKGDEP} 32subsystem vulkan+32 vkd3d+32 llvm-runtime"
 PKGDEP__ARM64="${PKGDEP} llvm-runtime"
 PKGDEP__RETRO="desktop-file-utils fontconfig freetype gettext glu x11-lib libpcap alsa-lib \
         gnutls giflib cups lcms2 openldap libjpeg-turbo libxml2 libxslt mpg123 ncurses \
@@ -13,8 +13,7 @@ PKGDEP__I486="${PKGDEP__RETRO}"
 PKGSUG="noto-fonts noto-cjk-fonts"
 PKGSUG__RETRO=""
 PKGSUG__I486="${PKGSUG__RETRO}"
-BUILDDEP="chrpath wayland-protocols opencl-registry-api dos2unix"
-BUILDDEP__ARM64="${BUILDDEP} llvm"
+BUILDDEP="chrpath wayland-protocols opencl-registry-api dos2unix llvm"
 BUILDDEP__RETRO="chrpath dos2unix"
 BUILDDEP__I486="${BUILDDEP__RETRO}"
 PKGDES="Runtime/Compatibility Layer for running programs designed for Microsoft Windows"

--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,13 +1,13 @@
 __GECKO_VER=2.47.4
 __MONO_VER=9.1.0
-WINE_VER=9.8
+WINE_VER=9.9
 VER=${WINE_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${WINE_VER:0:1}.x/wine-${WINE_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${WINE_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
-CHKSUMS="sha256::86943c838eda8fad9a7940d4099703394bf1d1be9a1014342fed879c7dc3b993 \
+CHKSUMS="sha256::4d67a7812c4abd4a3de923238e60f5a86b16ac7fb20f6294e0dc6ef9e8beca36 \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 9.9+gecko2.47.4+mono9.1.0

Package(s) Affected
-------------------

- wine: 3:9.9+gecko2.47.4+mono9.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
