### PR TITLE
linux-kernel (Linux Kernel): update to 6.9.1

### DIFF
--- a/app-admin/kernel-tools/spec
+++ b/app-admin/kernel-tools/spec
@@ -1,8 +1,8 @@
-VER=6.9.0
+VER=6.9.1
 #RC=
 # Use this for RC releases.
 #SRCS="tbl::https://git.kernel.org/torvalds/t/linux-${VER%%.0}-rc${RC}.tar.gz"
 # Use this for stable releases.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
-CHKSUMS="sha256::24fa01fb989c7a3e28453f117799168713766e119c5381dac30115f18f268149"
+CHKSUMS="sha256::01b414ba98fd189ecd544435caf3860ae2a790e3ec48f5aa70fdf42dc4c5c04a"
 CHKUPDATE="anitya::id=6501"

--- a/runtime-kernel/linux+kernel/autobuild/defines
+++ b/runtime-kernel/linux+kernel/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=linux+kernel
 PKGSEC=kernel
-PKGDEP="linux-kernel-6.9.0"
+PKGDEP="linux-kernel-6.9.1"
 PKGDES="Generic Linux Kernel for AOSC OS (Mainline)"
 
 PKGREP="linux+image+new linux+header+new linux+image linux+header linux+image+old linux+header+old"

--- a/runtime-kernel/linux+kernel/spec
+++ b/runtime-kernel/linux+kernel/spec
@@ -1,3 +1,3 @@
-VER=6.9.0
+VER=6.9.1
 DUMMYSRC=1
 CHKUPDATE="anitya::id=6501"

--- a/runtime-kernel/linux-kernel/autobuild/defines
+++ b/runtime-kernel/linux-kernel/autobuild/defines
@@ -1,11 +1,11 @@
-PKGNAME=linux-kernel-6.9.0
+PKGNAME=linux-kernel-6.9.1
 PKGSEC=kernel
 PKGDEP=""
 BUILDDEP="bc git pahole parallel kernel-build-common"
 BUILDDEP__AMD64="$BUILDDEP llvm"
 BUILDDEP__ARM64="$BUILDDEP llvm"
 BUILDDEP__MIPS64R6EL="${BUILDDEP} uboot-tools"
-PKGDES="Generic Linux Kernel v6.9.0 for AOSC OS (Mainline)"
+PKGDES="Generic Linux Kernel v6.9.1 for AOSC OS (Mainline)"
 
 ABSTRIP=0
 ABELFDEP=0

--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-ath9k-rx-dma-stop-check.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-ath9k-rx-dma-stop-check.patch
@@ -1,4 +1,4 @@
-From acacbbe6653ad92204ec11e10d2614ed4155893e Mon Sep 17 00:00:00 2001
+From f8a88e47fd3f9d5d38072cf9411fc8828738e5a0 Mon Sep 17 00:00:00 2001
 From: "kernel-team@fedoraproject.org" <kernel-team@fedoraproject.org>
 Date: Wed, 6 Feb 2013 09:57:47 -0500
 Subject: [PATCH 01/60] ath9k: rx dma stop check
@@ -38,5 +38,5 @@ index b070403e083f..938d99c6fa80 100644
  			"DMA failed to stop in %d ms AR_CR=0x%08x AR_DIAG_SW=0x%08x DMADBG_7=0x%08x\n",
  			AH_RX_STOP_DMA_TIMEOUT / 1000,
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
@@ -1,4 +1,4 @@
-From 7ba57d9382c2ff460f53c5403dd6613cc94d4175 Mon Sep 17 00:00:00 2001
+From ba869360e80773df4318e0a65717c9a7efb8363f Mon Sep 17 00:00:00 2001
 From: Mark Weiman <mark.weiman@markzz.com>
 Date: Wed, 27 Jan 2021 13:28:09 -0500
 Subject: [PATCH 02/60] pci: Enable overrides for missing ACS capabilities
@@ -153,5 +153,5 @@ index eff7f5df08e2..12dd1a87c71a 100644
  };
  
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-cpuinfo-fix-a-warning-for-CONFIG_CPUMASK_OFFSTACK.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-cpuinfo-fix-a-warning-for-CONFIG_CPUMASK_OFFSTACK.patch
@@ -1,4 +1,4 @@
-From 6c555872e731a26914d0b8855f5e4625f39167ff Mon Sep 17 00:00:00 2001
+From 715ad51e77c9e3e7e17589f6e7ee8dd7c6adf68f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 12 Jul 2022 12:47:48 +0800
 Subject: [PATCH 03/60] cpuinfo: fix a warning for CONFIG_CPUMASK_OFFSTACK
@@ -57,5 +57,5 @@ index a306bcd6b341..5f6d0e827bae 100644
  static void *c_next(struct seq_file *m, void *v, loff_t *pos)
  {
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-HACK-drm-amdgpu-use-amdgpu-by-default-for-si-cik-dev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-HACK-drm-amdgpu-use-amdgpu-by-default-for-si-cik-dev.patch
@@ -1,4 +1,4 @@
-From c73c5d49d180670305bcbc91dea27eeb3ed4465b Mon Sep 17 00:00:00 2001
+From ffd7b13a8dce9a6482e181cf0d713815e2c6bd7a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 29 Feb 2024 20:54:51 +0800
 Subject: [PATCH 04/60] HACK(drm/amdgpu): use amdgpu by default for si/cik
@@ -68,5 +68,5 @@ index 7bf08164140e..e42956b683bb 100644
  
  static struct pci_device_id pciidlist[] = {
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-input-synaptics-pin-3-touches-when-the-firmware-repo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-input-synaptics-pin-3-touches-when-the-firmware-repo.patch
@@ -1,4 +1,4 @@
-From 4daff653604f5aa79e7a6169d76e7506f0747453 Mon Sep 17 00:00:00 2001
+From 4e8dcc5783a079885127367d46289fb2ec7db2cf Mon Sep 17 00:00:00 2001
 From: Benjamin Tissoires <benjamin.tissoires@redhat.com>
 Date: Thu, 16 Apr 2015 13:01:46 -0400
 Subject: [PATCH 05/60] input: synaptics: pin 3 touches when the firmware
@@ -47,5 +47,5 @@ index 7a303a9d6bf7..9eab057a0bee 100644
  
  	/* Don't use active slot count to generate BTN_TOOL events. */
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-hid-logitech-dj-add-support-for-the-new-lightspeed-r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-hid-logitech-dj-add-support-for-the-new-lightspeed-r.patch
@@ -1,4 +1,4 @@
-From a09eafe8c47f336358c6be4aefa14f0145d3f4ac Mon Sep 17 00:00:00 2001
+From 16ffb98927618da8d66ee6461434d433b8b77d64 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Filipe=20La=C3=ADns?= <lains@riseup.net>
 Date: Sat, 23 Jan 2021 18:03:33 +0000
 Subject: [PATCH 06/60] hid: logitech-dj: add support for the new lightspeed
@@ -127,5 +127,5 @@ index 3c3c497b6b91..50fc920f0dc6 100644
  	  HID_USB_DEVICE(USB_VENDOR_ID_LOGITECH, USB_DEVICE_ID_MX3000_RECEIVER),
  	 .driver_data = recvr_type_27mhz},
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-hid-add-PixArt-touchpad-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-hid-add-PixArt-touchpad-driver.patch
@@ -1,4 +1,4 @@
-From 5661babf1c81b9f89fe7a08c656e212b5fb212dd Mon Sep 17 00:00:00 2001
+From b2764a456d1956fc7376b2f3815507ba75032516 Mon Sep 17 00:00:00 2001
 From: zhangtianyang <zhangtianyang@loongson.cn>
 Date: Tue, 31 Aug 2021 20:31:01 +0800
 Subject: [PATCH 07/60] hid: add PixArt touchpad driver
@@ -498,5 +498,5 @@ index 4d8acfe0d82a..00a558d3a345 100644
  };
  
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-hid-register-Surface-hid-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-hid-register-Surface-hid-devices.patch
@@ -1,4 +1,4 @@
-From 8786c6e25615c9404537047fb447e23c72a422eb Mon Sep 17 00:00:00 2001
+From 3dad9eca69a81b8a47d237c5f61433f0b496d32d Mon Sep 17 00:00:00 2001
 From: qzed <qzed@users.noreply.github.com>
 Date: Tue, 17 Sep 2019 17:16:23 +0200
 Subject: [PATCH 08/60] hid: register Surface hid devices
@@ -31,5 +31,5 @@ index 9a0f8f6b39cd..6e85b3b41169 100644
   * For a description of the Xbox controller models, refer to:
   * https://en.wikipedia.org/wiki/Xbox_Wireless_Controller#Summary
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-lis3-improve-handling-of-null-rate.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-lis3-improve-handling-of-null-rate.patch
@@ -1,4 +1,4 @@
-From 47d688496755bd3cce1d54b2bb2f96df405ad6c2 Mon Sep 17 00:00:00 2001
+From 97d4816d9204bd7f23bbf7afeaba77e50b13b705 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=89ric=20Piel?= <eric.piel@tremplin-utc.net>
 Date: Thu, 3 Nov 2011 16:22:40 +0100
 Subject: [PATCH 09/60] lis3: improve handling of null rate
@@ -45,5 +45,5 @@ index 49868a45c0ad..eaedefe0ca5c 100644
  
  	/* LIS3 power on delay is quite long */
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-ethernet-bundle-module-for-Motorcomm-YT6801.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-ethernet-bundle-module-for-Motorcomm-YT6801.patch
@@ -1,4 +1,4 @@
-From c350f364840d318eb2539a5529a9fcadfeb64cf2 Mon Sep 17 00:00:00 2001
+From 163cbc42b912bf328fb660e413e5dc436e553956 Mon Sep 17 00:00:00 2001
 From: wanghuai <748928840@qq.com>
 Date: Fri, 2 Feb 2024 19:05:26 +0000
 Subject: [PATCH 10/60] ethernet: bundle module for Motorcomm YT6801
@@ -19345,5 +19345,5 @@ index 000000000000..26518fae6ae6
 +#endif //__FUXI_OS_H__
 +
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-net-stmmac-Move-the-atds-flag-to-the-stmmac_dma_cfg-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-net-stmmac-Move-the-atds-flag-to-the-stmmac_dma_cfg-.patch
@@ -1,4 +1,4 @@
-From 515a6a34e3c2ddfa03e620c9194ac38be3bc62b0 Mon Sep 17 00:00:00 2001
+From d9b71272e270dfc57fe1088c7bb9bce0d5a5adff Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:01:54 +0800
 Subject: [PATCH 11/60] net: stmmac: Move the atds flag to the stmmac_dma_cfg
@@ -153,5 +153,5 @@ index dfa1828cd756..1b54b84a6785 100644
  
  #define AXI_BLEN	7
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-net-stmmac-Add-multi-channel-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-net-stmmac-Add-multi-channel-support.patch
@@ -1,4 +1,4 @@
-From bd435a5eaf28b488378390283abff1e64b7995cc Mon Sep 17 00:00:00 2001
+From 0d1f60a8ebca18d236e3bc5c239a4f26ddbae1ae Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:01:55 +0800
 Subject: [PATCH 12/60] net: stmmac: Add multi-channel support
@@ -322,5 +322,5 @@ index 3e48d1a41c38..c4c81242adec 100644
  	entry = STMMAC_GET_ENTRY(entry, priv->dma_conf.dma_tx_size);
  	tx_q->cur_tx = entry;
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-net-stmmac-Export-dwmac1000_dma_ops.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-net-stmmac-Export-dwmac1000_dma_ops.patch
@@ -1,4 +1,4 @@
-From a82020571a26639648855386b204fdeba1f43011 Mon Sep 17 00:00:00 2001
+From 7f4d7ca19eb8c0621dab91bc30730092d90168cb Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:01:56 +0800
 Subject: [PATCH 13/60] net: stmmac: Export dwmac1000_dma_ops
@@ -22,5 +22,5 @@ index f161ec9ac490..66c0c22908b1 100644
  };
 +EXPORT_SYMBOL_GPL(dwmac1000_dma_ops);
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-net-stmmac-dwmac-loongson-Drop-useless-platform-data.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-net-stmmac-dwmac-loongson-Drop-useless-platform-data.patch
@@ -1,4 +1,4 @@
-From 16eeffd5bd53fafc21039a3b166893eec64a46ad Mon Sep 17 00:00:00 2001
+From 46788883818f4607c36c4bc2436c1b75d2c9ccab Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:04:35 +0800
 Subject: [PATCH 14/60] net: stmmac: dwmac-loongson: Drop useless platform data
@@ -28,5 +28,5 @@ index 9e40c28d453a..19906ea67636 100644
  	plat->unicast_filter_entries = 1;
  
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-net-stmmac-dwmac-loongson-Use-PCI_DEVICE_DATA-macro-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-net-stmmac-dwmac-loongson-Use-PCI_DEVICE_DATA-macro-.patch
@@ -1,4 +1,4 @@
-From fea780552e09fd7b41c12223ac7d0b2300bf779b Mon Sep 17 00:00:00 2001
+From 6f9a3fcd3b4a891ff4bf9ca12c2f04a12ac46f30 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:04:36 +0800
 Subject: [PATCH 15/60] net: stmmac: dwmac-loongson: Use PCI_DEVICE_DATA()
@@ -37,5 +37,5 @@ index 19906ea67636..4e0838db4259 100644
  };
  MODULE_DEVICE_TABLE(pci, loongson_dwmac_id_table);
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-net-stmmac-dwmac-loongson-Split-up-the-platform-data.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-net-stmmac-dwmac-loongson-Split-up-the-platform-data.patch
@@ -1,4 +1,4 @@
-From f2de0210f88fa5b650969974656faad52f9ad692 Mon Sep 17 00:00:00 2001
+From 2af49e159d75824f2cc4354196850a79889e4480 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:04:37 +0800
 Subject: [PATCH 16/60] net: stmmac: dwmac-loongson: Split up the platform data
@@ -98,5 +98,5 @@ index 4e0838db4259..904e288d0be0 100644
  	if (ret)
  		goto err_disable_msi;
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-net-stmmac-dwmac-loongson-Add-ref-and-ptp-clocks-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-net-stmmac-dwmac-loongson-Add-ref-and-ptp-clocks-for.patch
@@ -1,4 +1,4 @@
-From d373f8465970a18073666fc174146ef88727eb6b Mon Sep 17 00:00:00 2001
+From c94543f31e584193473f58893e0b2a5561c6cba0 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:06:10 +0800
 Subject: [PATCH 17/60] net: stmmac: dwmac-loongson: Add ref and ptp clocks for
@@ -28,5 +28,5 @@ index 904e288d0be0..9f208f84c1e7 100644
  	plat->phy_addr = -1;
  
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-net-stmmac-dwmac-loongson-Add-phy-mask-for-Loongson-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-net-stmmac-dwmac-loongson-Add-phy-mask-for-Loongson-.patch
@@ -1,4 +1,4 @@
-From cc61b6de994a8edc0d5862acb3edccbf171a5912 Mon Sep 17 00:00:00 2001
+From 810141e49637cce02be373c9627921a0b85d382f Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:06:11 +0800
 Subject: [PATCH 18/60] net: stmmac: dwmac-loongson: Add phy mask for Loongson
@@ -27,5 +27,5 @@ index 9f208f84c1e7..f7618edf4a3a 100644
  }
  
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-net-stmmac-dwmac-loongson-Add-phy_interface-for-Loon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-net-stmmac-dwmac-loongson-Add-phy_interface-for-Loon.patch
@@ -1,4 +1,4 @@
-From d321c6131c2d419abf8bab0a9f7c040e0e058099 Mon Sep 17 00:00:00 2001
+From 9e19c7242dd331b2d3186496845b97b287a17da7 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:06:12 +0800
 Subject: [PATCH 19/60] net: stmmac: dwmac-loongson: Add phy_interface for
@@ -26,5 +26,5 @@ index f7618edf4a3a..e989cb835340 100644
  	return 0;
  }
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-net-stmmac-dwmac-loongson-Add-full-PCI-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-net-stmmac-dwmac-loongson-Add-full-PCI-support.patch
@@ -1,4 +1,4 @@
-From 6ce821d513e0153e69f4d3d3947cf8d09964e670 Mon Sep 17 00:00:00 2001
+From fbaac92971742fa1d76ef50d1c541f4b5d7fbbfb Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:10:35 +0800
 Subject: [PATCH 20/60] net: stmmac: dwmac-loongson: Add full PCI support
@@ -195,5 +195,5 @@ index e989cb835340..1022bceaa680 100644
  };
  MODULE_DEVICE_TABLE(pci, loongson_dwmac_id_table);
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-net-stmmac-dwmac-loongson-Add-loongson_dwmac_config_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-net-stmmac-dwmac-loongson-Add-loongson_dwmac_config_.patch
@@ -1,4 +1,4 @@
-From 5cc685d7c3d6664d257ea482c5aa986ac4442edd Mon Sep 17 00:00:00 2001
+From 55ac576c4775d405f8af1c8cc48de8e577356f70 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:10:36 +0800
 Subject: [PATCH 21/60] net: stmmac: dwmac-loongson: Add
@@ -96,5 +96,5 @@ index 1022bceaa680..df5899bec91a 100644
  	if (ret)
  		goto err_disable_msi;
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-net-stmmac-dwmac-loongson-Fixed-failure-to-set-netwo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-net-stmmac-dwmac-loongson-Fixed-failure-to-set-netwo.patch
@@ -1,4 +1,4 @@
-From ca211a322d795bc496e25dd27e73b68565a9c346 Mon Sep 17 00:00:00 2001
+From ea29f7439d15d2fdafac0dbb9d4d8160b7925957 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:10:37 +0800
 Subject: [PATCH 22/60] net: stmmac: dwmac-loongson: Fixed failure to set
@@ -72,5 +72,5 @@ index 1b54b84a6785..c5d3d0ddb6f8 100644
  struct plat_stmmacenet_data {
  	int bus_id;
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-net-stmmac-dwmac-loongson-Add-Loongson-GNET-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-net-stmmac-dwmac-loongson-Add-Loongson-GNET-support.patch
@@ -1,4 +1,4 @@
-From 9ffdab1e72dfc3cbfd81f7e35e488ac7f2a62cae Mon Sep 17 00:00:00 2001
+From 9be486483a71aa34515ac2770a66956b82df55ca Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:11:36 +0800
 Subject: [PATCH 23/60] net: stmmac: dwmac-loongson: Add Loongson GNET support
@@ -541,5 +541,5 @@ index a16bba389417..68de90c44feb 100644
  };
  MODULE_DEVICE_TABLE(pci, loongson_dwmac_id_table);
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-net-stmmac-dwmac-loongson-Move-disable_force-flag-to.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-net-stmmac-dwmac-loongson-Move-disable_force-flag-to.patch
@@ -1,4 +1,4 @@
-From b4544e764511eb772cac767d9e2afcd16b04a1ce Mon Sep 17 00:00:00 2001
+From 9e6cfa36c31ad7b93ea1d20fe3c296861d50d8b7 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:11:37 +0800
 Subject: [PATCH 24/60] net: stmmac: dwmac-loongson: Move disable_force flag to
@@ -47,5 +47,5 @@ index 68de90c44feb..dea02de030e6 100644
  	if (ret)
  		goto err_disable_device;
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-net-stmmac-dwmac-loongson-Add-loongson-module-author.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-net-stmmac-dwmac-loongson-Add-loongson-module-author.patch
@@ -1,4 +1,4 @@
-From d96db4229c833a04824089964d46915cba9e69d9 Mon Sep 17 00:00:00 2001
+From 09127b390947352ed0563dd2cab43b20628124fe Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:11:38 +0800
 Subject: [PATCH 25/60] net: stmmac: dwmac-loongson: Add loongson module author
@@ -23,5 +23,5 @@ index dea02de030e6..f0eebed751f3 100644
 +MODULE_AUTHOR("Yanteng Si <siyanteng@loongson.cn>");
  MODULE_LICENSE("GPL v2");
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-net-stmmac-add-a-glue-driver-for-GMACs-in-Phytium-So.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-net-stmmac-add-a-glue-driver-for-GMACs-in-Phytium-So.patch
@@ -1,4 +1,4 @@
-From e6e3aa112f2d2edefe4906c7c9be2c097a9013ec Mon Sep 17 00:00:00 2001
+From 6dddac6ca13db95be80d7cfd3a687dfd1cf1bdae Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 25 Sep 2022 23:03:51 +0800
 Subject: [PATCH 26/60] net: stmmac: add a glue driver for GMACs in Phytium
@@ -279,5 +279,5 @@ index 000000000000..cda672e23b2c
 +MODULE_DESCRIPTION("Glue driver for Phytium DWMAC");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-x86-add-more-uarches-for-kernel-6.8-rc4.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-x86-add-more-uarches-for-kernel-6.8-rc4.patch
@@ -1,4 +1,4 @@
-From 5bc044edf6e723c681b1b1f2f0b1e6ac53d02a77 Mon Sep 17 00:00:00 2001
+From 8805cf2aab45dc54febbc23ed426033589452f08 Mon Sep 17 00:00:00 2001
 From: graysky <therealgraysky@proton.me>
 Date: Wed, 21 Feb 2024 08:38:13 -0500
 Subject: [PATCH 27/60] x86: add more uarches for kernel 6.8-rc4+
@@ -787,5 +787,5 @@ index 75884d2cdec3..02c1386eb653 100644
  #define MODULE_PROC_FAMILY "ELAN "
  #elif defined CONFIG_MCRUSOE
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-arm-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-arm-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,4 +1,4 @@
-From 1848ebbb4014874ea169b30ce45ba4d997454902 Mon Sep 17 00:00:00 2001
+From 34a8be48253f4c36189a7f42ae99228069688e46 Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux@gmail.com>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
 Subject: [PATCH 28/60] arm: usb: phy: tegra: Add 38.4MHz clock table entry
@@ -43,5 +43,5 @@ index 4ea47e6f835b..12f6a2bb4057 100644
  
  static inline struct tegra_usb_phy *to_tegra_usb_phy(struct usb_phy *u_phy)
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
@@ -1,4 +1,4 @@
-From eec6a629027792b738c4de088de18349fc6f8950 Mon Sep 17 00:00:00 2001
+From 6295ed7be07071165bb93d6f70c10f7b4c9586a3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
 Subject: [PATCH 29/60] arm64: dts: rockchip: change GMAC rx_delay for
@@ -22,5 +22,5 @@ index f30b82a10ca3..1692689f674e 100644
  };
  
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-arm64-dts-rockchip-add-out-of-band-IRQ-for-RK3399-Wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-arm64-dts-rockchip-add-out-of-band-IRQ-for-RK3399-Wi.patch
@@ -1,4 +1,4 @@
-From 16f7e70dc467424585cb87bd312fd5d0cd7a6472 Mon Sep 17 00:00:00 2001
+From a0d27d7397e218f8f18346d27a84c82b07cb854d Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 30 Nov 2020 22:49:55 +0800
 Subject: [PATCH 30/60] arm64: dts: rockchip: add out-of-band IRQ for RK3399
@@ -44,5 +44,5 @@ index 294eb2de263d..bcaf61fb2918 100644
  
  &sdhci {
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-arm64-rockchip-dts-rk3399-fix-PD-on-Pinebook-Pro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-arm64-rockchip-dts-rk3399-fix-PD-on-Pinebook-Pro.patch
@@ -1,4 +1,4 @@
-From 61866c995cc5ecc6900e028b625633071eea9036 Mon Sep 17 00:00:00 2001
+From 41821d94fde9581774edc38245ce8623fb98e9d3 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Tue, 1 Dec 2020 16:19:04 +0800
 Subject: [PATCH 31/60] arm64: rockchip: dts: rk3399: fix PD on Pinebook Pro
@@ -27,5 +27,5 @@ index bcaf61fb2918..206726656c41 100644
  			ports {
  				#address-cells = <1>;
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-arm64-add-Kconfig-option-for-Phytium-SoCs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-arm64-add-Kconfig-option-for-Phytium-SoCs.patch
@@ -1,4 +1,4 @@
-From a272b21c52914558ec8986054a69d6e98d76308c Mon Sep 17 00:00:00 2001
+From cc7a86b2be4459a5768486a9749a332a4a76abca Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 25 Sep 2022 23:02:39 +0800
 Subject: [PATCH 32/60] arm64: add Kconfig option for Phytium SoCs
@@ -27,5 +27,5 @@ index 24335565bad5..908a501ad32e 100644
  	bool "Qualcomm Platforms"
  	select GPIOLIB
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,4 +1,4 @@
-From 24868ee761f8d2f1c93af90832e70a65481366a6 Mon Sep 17 00:00:00 2001
+From 84f171cf106b9db8cce08f9637dc059dcf8ba412 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Thu, 21 Apr 2022 11:36:35 +0800
 Subject: [PATCH 33/60] arm64: dts: rockchip: disable usb3 on quartz64
@@ -36,5 +36,5 @@ index 59843a7a199c..9fd188776cf2 100644
  };
  
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,4 +1,4 @@
-From df59268dcd9cdf73c34c963f9b01908100aece3f Mon Sep 17 00:00:00 2001
+From 8089d363d43a67b7a4e2404ebd3d4b071112985a Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 27 Jul 2023 11:13:25 -0400
 Subject: [PATCH 34/60] arm64: drop hisi_ddrc_pmu driver
@@ -22,5 +22,5 @@ index 48dcc8381ea7..a62ab2f0766f 100644
  
  obj-$(CONFIG_HISI_PCIE_PMU) += hisi_pcie_pmu.o
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-MIPS-loongson64-disable-writecombine-for-Loongson-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-MIPS-loongson64-disable-writecombine-for-Loongson-3A.patch
@@ -1,4 +1,4 @@
-From 87b6bb4b0bf53c6002a911b36b060825738ca84d Mon Sep 17 00:00:00 2001
+From a4cc44e8964a71d1ce4aa65953f14e29c15faf46 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Mon, 12 Oct 2020 13:32:23 +0800
 Subject: [PATCH 35/60] MIPS: loongson64: disable writecombine for Loongson-3A
@@ -48,5 +48,5 @@ index bda7f193baab..8956d833c4c7 100644
  	case PRID_IMP_LOONGSON_32:  /* Loongson-1 */
  		decode_configs(c);
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-MIPS-loongson64-init-suppress-memcpy-out-of-bound-ch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-MIPS-loongson64-init-suppress-memcpy-out-of-bound-ch.patch
@@ -1,4 +1,4 @@
-From 255a5130a7004240b0c72fa7ae7164823094e39f Mon Sep 17 00:00:00 2001
+From 10152ad44e5c81c9ca4c8ab22e2d6279b13815a9 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Wed, 24 Aug 2022 03:54:11 +0000
 Subject: [PATCH 36/60] MIPS: loongson64/init: suppress memcpy out-of-bound
@@ -24,5 +24,5 @@ index a35dd7311795..159a3f82bda1 100644
  }
  
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-MIPS-loongson64-video-output-re-introduce-display-ou.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-MIPS-loongson64-video-output-re-introduce-display-ou.patch
@@ -1,4 +1,4 @@
-From 4d0f6d25217e4519b4db93df5155761554f030fa Mon Sep 17 00:00:00 2001
+From 89ff4ba34d9aa57fa0f0421f14d8cd2f9a0e7dfb Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 7 Nov 2017 09:01:33 +0800
 Subject: [PATCH 37/60] MIPS: loongson64: video: output: re-introduce display
@@ -250,5 +250,5 @@ index 000000000000..ed5cdeb3604d
 +#endif
 +#endif
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-MIPS-video-fbdev-sis-add-1368x768-resolution.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-MIPS-video-fbdev-sis-add-1368x768-resolution.patch
@@ -1,4 +1,4 @@
-From 736c12c462239bac33081f009f8b27ae939f58e0 Mon Sep 17 00:00:00 2001
+From ea0c85fe3bbef842855b3980afd298cd439b1904 Mon Sep 17 00:00:00 2001
 From: flygoat <flygoatfree@gmail.com>
 Date: Sun, 5 Mar 2017 20:33:17 +0800
 Subject: [PATCH 38/60] MIPS: video: fbdev: sis: add 1368x768 resolution
@@ -223,5 +223,5 @@ index 009bf1d92644..01aab3b045d7 100644
 -
 -
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-LoongArch-Select-ARCH_SUPPORTS_INT128-if-CC_HAS_INT1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-LoongArch-Select-ARCH_SUPPORTS_INT128-if-CC_HAS_INT1.patch
@@ -1,4 +1,4 @@
-From 11843e814fb64949d085d1c60280642a69f15c27 Mon Sep 17 00:00:00 2001
+From ea9017ed8e5829f2b6e26175591dc4d3d4897efd Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 28 Mar 2024 01:17:37 +0800
 Subject: [PATCH 39/60] LoongArch: Select ARCH_SUPPORTS_INT128 if CC_HAS_INT128
@@ -25,5 +25,5 @@ index 54ad04dacdee..38feb58d0bde 100644
  	select ARCH_SUPPORTS_LTO_CLANG_THIN
  	select ARCH_SUPPORTS_NUMA_BALANCING
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-LoongArch-Define-__ARCH_WANT_NEW_STAT-in-unistd.h.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-LoongArch-Define-__ARCH_WANT_NEW_STAT-in-unistd.h.patch
@@ -1,4 +1,4 @@
-From 70d9699d9623d19ddafb5db5993d00d9d98b77f8 Mon Sep 17 00:00:00 2001
+From a7c7bfc8438d5b03db59c5bc4ea4275156d825ec Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 28 Feb 2024 21:14:10 +0800
 Subject: [PATCH 40/60] LoongArch: Define __ARCH_WANT_NEW_STAT in unistd.h
@@ -56,5 +56,5 @@ index fcb668984f03..b344b1f91715 100644
  #define __ARCH_WANT_SYS_CLONE3
  
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-LoongArch-rust-Switch-to-use-built-in-rustc-target.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-LoongArch-rust-Switch-to-use-built-in-rustc-target.patch
@@ -1,4 +1,4 @@
-From 7c4db2cd3187ddcce6fb1a38f1957ae62faa1b33 Mon Sep 17 00:00:00 2001
+From c8d8f16fca4f37e8b829624ed31134cb71528930 Mon Sep 17 00:00:00 2001
 From: WANG Rui <wangrui@loongson.cn>
 Date: Mon, 4 Mar 2024 22:14:26 +0800
 Subject: [PATCH 41/60] LoongArch: rust: Switch to use built-in rustc target
@@ -75,5 +75,5 @@ index 54919cf48621..acd3b1acef83 100644
          panic!("Unsupported architecture");
      }
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,4 +1,4 @@
-From 3947eb382c2f7d7b3515c89cfb0542628128c361 Mon Sep 17 00:00:00 2001
+From 322500c76f475f7a454e8a5bdfd3e2258fde0049 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
 Subject: [PATCH 42/60] LoongArch: Add CPU HWMon platform driver
@@ -241,5 +241,5 @@ index 000000000000..93a05993745a
 +MODULE_DESCRIPTION("Loongson CPU Hwmon driver");
 +MODULE_LICENSE("GPL");
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-LoongArch-Update-Loongson-3-default-config-file.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-LoongArch-Update-Loongson-3-default-config-file.patch
@@ -1,4 +1,4 @@
-From 07d87a47509d39070163702b2950e343159a997e Mon Sep 17 00:00:00 2001
+From 0f5906366d02734f6157d133becf2441ca3c4f9e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sat, 23 Mar 2024 20:46:13 +0800
 Subject: [PATCH 43/60] LoongArch: Update Loongson-3 default config file
@@ -57,5 +57,5 @@ index f18c2ba871ef..ff02bdcec4b2 100644
  CONFIG_PPP_BSDCOMP=m
  CONFIG_PPP_DEFLATE=m
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-LoongArch-Select-THP_SWAP-if-HAVE_ARCH_TRANSPARENT_H.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-LoongArch-Select-THP_SWAP-if-HAVE_ARCH_TRANSPARENT_H.patch
@@ -1,4 +1,4 @@
-From cf352fdd576e14ee1593e1de0d15505a19acd7a1 Mon Sep 17 00:00:00 2001
+From 325ceb1d096829639545ede8cdc6de135db4671c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 10 Apr 2024 21:12:56 +0800
 Subject: [PATCH 44/60] LoongArch: Select THP_SWAP if
@@ -37,5 +37,5 @@ index 38feb58d0bde..8c1a70f724df 100644
  	select COMMON_CLK
  	select CPU_PM
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,4 +1,4 @@
-From 45b302efc5592538a763fd734f0ce65808783f4a Mon Sep 17 00:00:00 2001
+From 29a554f6a791d4df9707190ce38f91f41c8dcac7 Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
 Subject: [PATCH 45/60] LoongArch: Update the flush cache policy
@@ -55,5 +55,5 @@ index 6be04d36ca07..89eeb9a97dd5 100644
  	}
  
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-dt-bindings-pwm-Add-Loongson-PWM-controller.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-dt-bindings-pwm-Add-Loongson-PWM-controller.patch
@@ -1,4 +1,4 @@
-From 35909f542ea7db9e453d05f1368b7d5340b12c8b Mon Sep 17 00:00:00 2001
+From 5068ca216920496e40d192cc9052a77f7b4f5fa7 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Tue, 16 Apr 2024 09:55:14 +0800
 Subject: [PATCH 46/60] dt-bindings: pwm: Add Loongson PWM controller
@@ -104,5 +104,5 @@ index 28e20975c26f..3dde296c3d55 100644
  M:	Yinbo Zhu <zhuyinbo@loongson.cn>
  L:	linux-clk@vger.kernel.org
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-pwm-Add-Loongson-PWM-controller-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-pwm-Add-Loongson-PWM-controller-support.patch
@@ -1,4 +1,4 @@
-From 2281cd52649f27d3ad2f818f73ff7107f87ead36 Mon Sep 17 00:00:00 2001
+From 035a28a8563759498c1cd9c459cb81693ec5a7fb Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Tue, 16 Apr 2024 09:55:15 +0800
 Subject: [PATCH 47/60] pwm: Add Loongson PWM controller support
@@ -367,5 +367,5 @@ index 000000000000..5ac79a69acd3
 +MODULE_AUTHOR("Loongson Technology Corporation Limited.");
 +MODULE_LICENSE("GPL");
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-thermal-loongson2-Trivial-code-style-adjustment.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-thermal-loongson2-Trivial-code-style-adjustment.patch
@@ -1,4 +1,4 @@
-From 91959a333e0f54e468bea63e751e648c1fe4d753 Mon Sep 17 00:00:00 2001
+From 63beb4723c606be150da2f71bbda48f23d614e86 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 15 Apr 2024 10:31:30 +0800
 Subject: [PATCH 48/60] thermal: loongson2: Trivial code style adjustment
@@ -143,5 +143,5 @@ index 0f475fe46bc9..d77d829c8b55 100644
  
  static const struct loongson2_thermal_chip_data loongson2_thermal_ls2k1000_data = {
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-dt-bindings-thermal-loongson-ls2k-thermal-Add-Loongs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-dt-bindings-thermal-loongson-ls2k-thermal-Add-Loongs.patch
@@ -1,4 +1,4 @@
-From 363c46b0c7245b1a173479ae52271cb1de25ac6d Mon Sep 17 00:00:00 2001
+From c7d5d015685e1bf341ef99684949ac36321702d2 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 15 Apr 2024 10:31:31 +0800
 Subject: [PATCH 49/60] dt-bindings: thermal: loongson,ls2k-thermal: Add
@@ -27,5 +27,5 @@ index b634f57cd011..9748a479dcd4 100644
            - const: loongson,ls2k1000-thermal
  
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-dt-bindings-thermal-loongson-ls2k-thermal-Fix-incorr.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-dt-bindings-thermal-loongson-ls2k-thermal-Fix-incorr.patch
@@ -1,4 +1,4 @@
-From ecbcb7f2e37869d92e14311a7a9d849c25bea8c9 Mon Sep 17 00:00:00 2001
+From b62b06e737a7f6bb3c2c10bd9c26464eb51f16a5 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 15 Apr 2024 10:31:32 +0800
 Subject: [PATCH 50/60] dt-bindings: thermal: loongson,ls2k-thermal: Fix
@@ -70,5 +70,5 @@ index 9748a479dcd4..fac6f64d6c67 100644
    - |
      #include <dt-bindings/interrupt-controller/irq.h>
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-thermal-loongson2-Add-Loongson-2K2000-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-thermal-loongson2-Add-Loongson-2K2000-support.patch
@@ -1,4 +1,4 @@
-From 72a9e985cb389c39b27cf6fb9d83adb8a556f1bb Mon Sep 17 00:00:00 2001
+From 246cf75e11a7966d36149480a592abca37fe2170 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 15 Apr 2024 10:31:57 +0800
 Subject: [PATCH 51/60] thermal: loongson2: Add Loongson-2K2000 support
@@ -131,5 +131,5 @@ index d77d829c8b55..d803b6bc35b7 100644
  };
  MODULE_DEVICE_TABLE(of, of_loongson2_thermal_match);
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-KVM-loongarch-Add-vcpu-id-check-before-create-vcpu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-KVM-loongarch-Add-vcpu-id-check-before-create-vcpu.patch
@@ -1,4 +1,4 @@
-From 57dc1ddfcb438f1d8e5dad2181f1d4c1d14202a9 Mon Sep 17 00:00:00 2001
+From 01b85c9b68b8a354b890c092a1c257545557d80b Mon Sep 17 00:00:00 2001
 From: Wujie Duan <wjduan@linx-info.com>
 Date: Fri, 12 Apr 2024 16:47:03 +0800
 Subject: [PATCH 52/60] KVM: loongarch: Add vcpu id check before create vcpu
@@ -26,5 +26,5 @@ index 3a8779065f73..d41cacf39583 100644
  }
  
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-LOONGARCH64-arch-loongarch-add-la_ow_syscall-as-in-t.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-LOONGARCH64-arch-loongarch-add-la_ow_syscall-as-in-t.patch.loongarch64
@@ -1,4 +1,4 @@
-From d0078f7593ec6bcb21ef2b2befd1305e20f36061 Mon Sep 17 00:00:00 2001
+From 2dcd4d1c46ffb27fae08395bf58b4e6627554423 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Wed, 21 Feb 2024 16:58:32 -0500
 Subject: [PATCH 53/60] [LOONGARCH64] arch/loongarch: add la_ow_syscall as
@@ -1269,5 +1269,5 @@ index 000000000000..a640b39e982d
 +#undef P__SYSCALL_DEFINEx
 +#endif
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-LOONGARCH64-la_ow_syscall-add-kconfig-for-module.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-LOONGARCH64-la_ow_syscall-add-kconfig-for-module.patch.loongarch64
@@ -1,4 +1,4 @@
-From 50e9347da5437477b1768ec730ef1b907d7b03de Mon Sep 17 00:00:00 2001
+From 4548f2df5cc8ed80bc4ad0df20d0269df24ef72f Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
 Subject: [PATCH 54/60] [LOONGARCH64] la_ow_syscall: add kconfig for module
@@ -41,5 +41,5 @@ index 000000000000..c28a37145b6f
 +	  If unsure, say N.
 +
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
@@ -1,4 +1,4 @@
-From 1e11c37d2f23eb4df17be2ffd3fdbd643e5806b4 Mon Sep 17 00:00:00 2001
+From d439a5ec70a03386c8366982ee14be8325e3bee7 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
 Subject: [PATCH 55/60] [LOONGARCH64] drivers/firmware: Move sysfb_init() from
@@ -50,5 +50,5 @@ index 880ffcb50088..a9364fa18d6f 100644
 -device_initcall(sysfb_init);
 +fs_initcall(sysfb_init);
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-LOONGARCH64-drm-Makefile-Move-tiny-drivers-before-na.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-LOONGARCH64-drm-Makefile-Move-tiny-drivers-before-na.patch.loongarch64
@@ -1,4 +1,4 @@
-From acc4a0551db750eb8853dc61d0dabdeaeea107ce Mon Sep 17 00:00:00 2001
+From e9599605482b16ad4f58aaefae0dc26d421e4d6b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 7 Nov 2023 20:25:53 +0800
 Subject: [PATCH 56/60] [LOONGARCH64] drm/Makefile: Move tiny drivers before
@@ -55,5 +55,5 @@ index 104b42df2e95..9b8a02c13184 100644
  obj-$(CONFIG_DRM_TVE200) += tve200/
  obj-$(CONFIG_DRM_XEN) += xen/
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
@@ -1,4 +1,4 @@
-From 2653cd54e6045436806280f84c961f4d6867b5e4 Mon Sep 17 00:00:00 2001
+From bc11e2ca0d3383367074d858775df8c891af7591 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Mon, 11 Mar 2024 00:14:58 +0800
 Subject: [PATCH 57/60] [LOONGARCH64] drm/xe: fix build on non-4K kernels
@@ -370,5 +370,5 @@ index 32cd0c978aa2..e6db939db7c6 100644
  			 * FIXME: Killing VM rather than proper error handling
  			 */
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
@@ -1,4 +1,4 @@
-From e64efee068f9f18cdb421ba8b7de9b203fc92a5d Mon Sep 17 00:00:00 2001
+From e535a25d9d5caf6ddcf0892666f64a5964349dc6 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
 Subject: [PATCH 58/60] [LOONGARCH64] drm/radeon: Workaround radeon driver bug
@@ -66,5 +66,5 @@ index 15759c8ca5b7..3bc479da07cd 100644
  
  	/* make sure wptr hasn't changed while processing */
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
@@ -1,4 +1,4 @@
-From 5c9c92545d9079f51848340c53b722501a23711b Mon Sep 17 00:00:00 2001
+From fbfa964dff24c00e44c3d9ab7bd5a75d8083b150 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 14:28:02 +0800
 Subject: [PATCH 59/60] [LOONGARCH64] drm/radeon: Call mmiowb() at the end of
@@ -60,5 +60,5 @@ index 38048593bb4a..d461dc85d820 100644
  
  /**
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-LOONGARCH64-HACK-drm-amdgpu-disable-DPM-in-auto-mode.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-LOONGARCH64-HACK-drm-amdgpu-disable-DPM-in-auto-mode.patch.loongarch64
@@ -1,4 +1,4 @@
-From 840ab4ef85da10a207d981419bba383d446850ea Mon Sep 17 00:00:00 2001
+From 144a88b69ff6e4002fbef0ec0b451c5ad612a4f9 Mon Sep 17 00:00:00 2001
 From: Cyan <cyanoxygen@aosc.io>
 Date: Wed, 10 Apr 2024 16:44:01 +0800
 Subject: [PATCH 60/60] [LOONGARCH64] HACK(drm/amdgpu): disable DPM in auto
@@ -37,5 +37,5 @@ index 74d35c7f4897..57938b22655f 100644
  	if (IS_ERR(adev))
  		return PTR_ERR(adev);
 -- 
-2.45.0
+2.45.1
 

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -1,8 +1,8 @@
-VER=6.9.0
+VER=6.9.1
 #RC=
 # Use this for RC releases.
 #SRCS="tbl::https://git.kernel.org/torvalds/t/linux-${VER%%.0}-rc${RC}.tar.gz"
 # Use this for stable releases.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
-CHKSUMS="sha256::24fa01fb989c7a3e28453f117799168713766e119c5381dac30115f18f268149"
+CHKSUMS="sha256::01b414ba98fd189ecd544435caf3860ae2a790e3ec48f5aa70fdf42dc4c5c04a"
 CHKUPDATE="anitya::id=6501"


### PR DESCRIPTION
Topic Description
-----------------

- kernel-tools: update to 6.9.1
- linux+kernel: update to 6.9.1
- linux-kernel: update to 6.9.1
    Rebase patch against v6.9.1 (AOSC-Tracking/linux @ aosc/v6.9.1).

Package(s) Affected
-------------------

- kernel-tools: 6.9.1
- linux+kernel: 3:6.9.1
- linux-kernel-6.9.1: 1:6.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel linux+kernel kernel-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
