### PR TITLE
spirv-llvm-translator: update to 18.1.0

### DIFF
--- a/app-devel/spirv-llvm-translator/spec
+++ b/app-devel/spirv-llvm-translator/spec
@@ -1,4 +1,4 @@
-VER=17.0.0
+VER=18.1.0
 SRCS="tbl::https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::eba381e1dd99b4ff6c672a28f52755d1adf2d810a97b51e6074ad4fa67937fb2"
+CHKSUMS="sha256::78a770eff24d5ffe2798479845adec4b909cbf058ddc55830ea00fa7d2c1698a"
 CHKUPDATE="anitya::id=227273"


### PR DESCRIPTION
Topic Description
-----------------

- spirv-llvm-translator: update to 18.1.0
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- spirv-llvm-translator: 18.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit spirv-llvm-translator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
