### PR TITLE
libclc: update to 18.1.5

### DIFF
--- a/runtime-devices/libclc/spec
+++ b/runtime-devices/libclc/spec
@@ -1,6 +1,6 @@
-VER=17.0.3
+VER=18.1.5
 SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/libclc-${VER}.src.tar.xz"
-CHKSUMS="sha256::61160e3ac3841a2c27d4cd3c093961dbe58624599278a8c5a252e002f4c49686"
+CHKSUMS="sha256::3e54662d1897b1af5ec6d9cd04831393cab428d1a93814ad3812255ae2aa0d45"
 CHKUPDATE="anitya::id=1830"
 
 SUBDIR="libclc-${VER}.src"


### PR DESCRIPTION
Topic Description
-----------------

- libclc: update to 18.1.5
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- libclc: 1:18.1.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libclc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
