### PR TITLE
castxml: update to 0.6.6

### DIFF
--- a/app-devel/castxml/spec
+++ b/app-devel/castxml/spec
@@ -1,4 +1,4 @@
-VER=0.6.2
-SRCS="tbl::https://github.com/CastXML/CastXML/archive/v$VER.tar.gz"
-CHKSUMS="sha256::9bb108de1b3348a257be5b08a9f8418f89fdcd4af2e6ee271d68b0203ac75d5e"
+VER=0.6.6
+SRCS="git::commit=tags/v$VER::https://github.com/CastXML/CastXML"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9347"


### PR DESCRIPTION
Topic Description
-----------------

- castxml: update to 0.6.6
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- castxml: 0.6.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit castxml
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
