### PR TITLE
p7zip: update to 17.05

### DIFF
--- a/app-utils/p7zip/spec
+++ b/app-utils/p7zip/spec
@@ -1,4 +1,4 @@
-VER=17.04
-SRCS="tbl::https://github.com/p7zip-project/p7zip/archive/refs/tags/v17.04.zip"
-CHKSUMS="sha256::2314fac5f90c7910d177f6471df06910ef137d3bff983b1b0fc5f944e6f9687b"
+VER=17.05
+SRCS="git::commit=tags/v$VER::https://github.com/p7zip-project/p7zip"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2583"


### PR DESCRIPTION
Topic Description
-----------------

- p7zip: update to 17.05
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- p7zip: 17.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit p7zip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
