### PR TITLE
recode: update to 3.7.14

### DIFF
--- a/app-utils/recode/spec
+++ b/app-utils/recode/spec
@@ -1,4 +1,4 @@
-VER=3.7.7
+VER=3.7.14
 SRCS="tbl::https://github.com/rrthomas/recode/releases/download/v$VER/recode-$VER.tar.gz"
-CHKSUMS="sha256::0946f63b706719e6aa74ea5c0c2276c265ca1ced2cb44e05f2b5654c0e7f38fb"
+CHKSUMS="sha256::786aafd544851a2b13b0a377eac1500f820ce62615ccc2e630b501e7743b9f33"
 CHKUPDATE="anitya::id=4176"


### PR DESCRIPTION
Topic Description
-----------------

- recode: update to 3.7.14
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- recode: 3.7.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit recode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
