### PR TITLE
gzip: update to 1.13

### DIFF
--- a/app-utils/gzip/spec
+++ b/app-utils/gzip/spec
@@ -1,4 +1,4 @@
-VER=1.12
+VER=1.13
 SRCS="tbl::https://ftp.gnu.org/gnu/gzip/gzip-$VER.tar.xz"
-CHKSUMS="sha256::ce5e03e519f637e1f814011ace35c4f87b33c0bbabeec35baf5fbd3479e91956"
+CHKSUMS="sha256::7454eb6935db17c6655576c2e1b0fabefd38b4d0936e0f87f48cd062ce91a057"
 CHKUPDATE="anitya::id=1290"


### PR DESCRIPTION
Topic Description
-----------------

- gzip: update to 1.13
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- gzip: 1:1.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit gzip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
