### PR TITLE
debconf: update to 1.5.86

### DIFF
--- a/app-admin/debconf/spec
+++ b/app-admin/debconf/spec
@@ -1,4 +1,4 @@
-VER=1.5.83
+VER=1.5.86
 SRCS="git::commit=tags/debian/$VER::https://salsa.debian.org/pkg-debconf/debconf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8130"


### PR DESCRIPTION
Topic Description
-----------------

- debconf: update to 1.5.86
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- debconf: 1.5.86

Security Update?
----------------

No

Build Order
-----------

```
#buildit debconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
