### PR TITLE
srtp: switch to meson

### DIFF
--- a/runtime-multimedia/srtp/autobuild/defines
+++ b/runtime-multimedia/srtp/autobuild/defines
@@ -3,6 +3,5 @@ PKGSEC=net
 PKGDEP="glibc"
 PKGDES="Open-source implementation of the Secure Real-time Transport Protocol (SRTP)"
 
-ABTYPE="cmakeninja"
-CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON"
+ABTYPE="meson"
 PKGEPOCH=1

--- a/runtime-multimedia/srtp/spec
+++ b/runtime-multimedia/srtp/spec
@@ -1,4 +1,5 @@
 VER=2.6.0
+REL=1
 SRCS="tbl::https://github.com/cisco/libsrtp/archive/v$VER.tar.gz"
 CHKSUMS="sha256::bf641aa654861be10570bfc137d1441283822418e9757dc71ebb69a6cf84ea6b"
 CHKUPDATE="anitya::id=18547"


### PR DESCRIPTION
Topic Description
-----------------

- srtp: switch to meson
    It is required for gstreamer to find libsrtp2.

Package(s) Affected
-------------------

- srtp: 1:2.6.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit srtp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
