### PR TITLE
mpvpaper: update to 1.6

### DIFF
--- a/app-utils/mpvpaper/spec
+++ b/app-utils/mpvpaper/spec
@@ -1,4 +1,4 @@
-VER=1.4
+VER=1.6
 SRCS="git::commit=tags/${VER}::https://github.com/GhostNaN/mpvpaper"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235058"


### PR DESCRIPTION
Topic Description
-----------------

- mpvpaper: update to 1.6
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- mpvpaper: 1.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpvpaper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
