### PR TITLE
bread-dog: update to 0.2.1

### DIFF
--- a/app-utils/bread-dog/autobuild/defines
+++ b/app-utils/bread-dog/autobuild/defines
@@ -9,3 +9,7 @@ USECLANG=1
 
 # FIXME: ld.lld is not yet available.
 NOLTO__LOONGARCH64=1
+
+# FIXME: serde_json FTBFS with clang on riscv64
+USECLANG__RISCV64=0
+NOLTO__RISCV64=1

--- a/app-utils/bread-dog/spec
+++ b/app-utils/bread-dog/spec
@@ -1,4 +1,4 @@
-VER=0.2.0
+VER=0.2.1
 SRCS="git::commit=tags/v$VER::https://github.com/eatradish/bread-dog"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=302756"


### PR DESCRIPTION
Topic Description
-----------------

- bread-dog: update to 0.2.1
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- bread-dog: 0.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bread-dog
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
