### PR TITLE
dub: update to 1.37.0

### DIFF
--- a/lang-dlang/dub/autobuild/defines
+++ b/lang-dlang/dub/autobuild/defines
@@ -6,3 +6,6 @@ PKGDES="Package and build management system for D"
 USECLANG=1
 ABSPLITDBG__LOONGSON3=0
 ABSPLITDBG__RISCV64=0
+
+# FIXME: missing ldc
+FAIL_ARCH="!(amd64|arm64|loongson3|riscv64)"

--- a/lang-dlang/dub/spec
+++ b/lang-dlang/dub/spec
@@ -1,5 +1,4 @@
-VER=1.34.0
+VER=1.37.0
 SRCS="https://github.com/dlang/dub/archive/v$VER.tar.gz"
-CHKSUMS="sha256::970a33561310eb62a5494170e2a542f0c675952a18d4ba38a399449be0a8caff"
+CHKSUMS="sha256::8e8c5c841a43cb75af9828c3155a7e1ef90319177a66cebf9c94b33792cf8491"
 CHKUPDATE="anitya::id=141409"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- dub: update to 1.37.0
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- dub: 1.37.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`
