### PR TITLE
lxappearance: update to 0.6.3

### DIFF
--- a/desktop-lxde/lxappearance/spec
+++ b/desktop-lxde/lxappearance/spec
@@ -1,5 +1,4 @@
-VER=0.6.2
-REL=2
+VER=0.6.3
 SRCS="tbl::https://downloads.sourceforge.net/lxde/lxappearance-$VER.tar.xz"
-CHKSUMS="sha256::4462136e01f991d4c546f23a8cf59a4092f88ecdff587597959f8062e2ea201f"
+CHKSUMS="sha256::7222d858b8fef4b7967c42142d61e82ded6dd42dc5ef1d59caad775795928b38"
 CHKUPDATE="anitya::id=6226"


### PR DESCRIPTION
Topic Description
-----------------

- lxappearance: update to 0.6.3
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- lxappearance: 0.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxappearance
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
