### PR TITLE
shadowsocks-rust: update to 1.18.4

### DIFF
--- a/app-network/shadowsocks-rust/autobuild/patches/0001-fix-lto-inject.patch
+++ b/app-network/shadowsocks-rust/autobuild/patches/0001-fix-lto-inject.patch
@@ -1,7 +1,19 @@
---- a/Cargo.toml	2022-01-30 11:09:02.672672610 +0000
-+++ b/Cargo.toml	2022-01-30 11:09:51.659647964 +0000
-@@ -46,7 +46,7 @@
- ]
+From d79698d2566c63237fc1cc735002da7dd6af5fb9 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Sun, 19 May 2024 20:04:25 -0700
+Subject: [PATCH] fix lto inject
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index 0cfec4c3..1486ced3 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -48,7 +48,7 @@ required-features = ["winservice"]
+ members = ["crates/shadowsocks", "crates/shadowsocks-service"]
  
  [profile.release]
 -lto = "fat"
@@ -9,3 +21,6 @@
  codegen-units = 1
  incremental = false
  panic = "abort"
+-- 
+2.45.1
+

--- a/app-network/shadowsocks-rust/spec
+++ b/app-network/shadowsocks-rust/spec
@@ -1,5 +1,4 @@
-VER=1.15.3
+VER=1.18.4
 SRCS="git::commit=tags/v$VER::https://github.com/shadowsocks/shadowsocks-rust.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230992"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- shadowsocks-rust: update to 1.18.4
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- shadowsocks-rust: 1.18.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit shadowsocks-rust
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
