### PR TITLE
gdmd: new, 0.1.0+git20230214

### DIFF
--- a/lang-dlang/gdmd/autobuild/build
+++ b/lang-dlang/gdmd/autobuild/build
@@ -1,0 +1,3 @@
+abinfo "Installing gdmd ..."
+mkdir -vp "$PKGDIR"/usr/{bin,share/man/man1}
+make prefix=/usr DESTDIR="$PKGDIR" install

--- a/lang-dlang/gdmd/autobuild/defines
+++ b/lang-dlang/gdmd/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=gdmd
+PKGSEC=devel
+PKGDEP="gcc"
+PKGDES="DMD-like wrapper for GDC"
+
+ABHOST=noarch

--- a/lang-dlang/gdmd/spec
+++ b/lang-dlang/gdmd/spec
@@ -1,0 +1,4 @@
+VER=0.1.0+git20230214
+SRCS="git::commit=563e438265252429455489d845002362d3b8991e::https://github.com/D-Programming-GDC/gdmd/"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372437"


### PR DESCRIPTION
Topic Description
-----------------

- gdmd: new, 0.1.0+git20230214

Package(s) Affected
-------------------

- gdmd: 0.1.0+git20230214

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdmd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
