### PR TITLE
linux+kernel+lts: drop FAIL_ARCH

### DIFF
--- a/runtime-kernel/linux+kernel+lts/autobuild/defines
+++ b/runtime-kernel/linux+kernel+lts/autobuild/defines
@@ -11,5 +11,3 @@ ABELFDEP=no
 ABHOST=noarch
 
 PKGEPOCH=2
-
-FAIL_ARCH="!(amd64|arm64|loongarch64|mips64r6el|ppc64el|riscv64)"


### PR DESCRIPTION
Topic Description
-----------------

- linux+kernel+lts: drop FAIL_ARCH

Package(s) Affected
-------------------

- linux+kernel+lts: 2:6.6.31

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux+kernel+lts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
