### PR TITLE
rng-tools: update to 6.16

### DIFF
--- a/app-utils/rng-tools/autobuild/defines
+++ b/app-utils/rng-tools/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=rng-tools
 PKGSEC=utils
 PKGDEP="libgcrypt libp11 opensc"
 PKGDES="Random number generator related utilities"
+
+AUTOTOOLS_AFTER="--without-rtlsdr"

--- a/app-utils/rng-tools/spec
+++ b/app-utils/rng-tools/spec
@@ -1,5 +1,4 @@
-VER=6.7
-REL=3
+VER=6.16
 SRCS="tbl::https://github.com/nhorman/rng-tools/archive/v$VER.tar.gz"
-CHKSUMS="sha256::b85e3530dbf943b6da03ebecaf64d0a4febfcc4f562fc7f8d886483906b15f08"
+CHKSUMS="sha256::17666c4745fb635d91df293be188daf94b9e465d51d8503c0195fa3beb390894"
 CHKUPDATE="anitya::id=4202"


### PR DESCRIPTION
Topic Description
-----------------

- rng-tools: update to 6.16
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- rng-tools: 6.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit rng-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
