### PR TITLE
fftw: update to 3.3.10

### DIFF
--- a/runtime-scientific/fftw/spec
+++ b/runtime-scientific/fftw/spec
@@ -1,6 +1,5 @@
-VER=3.3.8
-REL=4
+VER=3.3.10
 SRCS="tbl::http://www.fftw.org/fftw-${VER/+/-}.tar.gz"
-CHKSUMS="sha256::6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303"
+CHKSUMS="sha256::56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467"
 CHKUPDATE="anitya::id=803"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fftw: update to 3.3.10
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- fftw: 3.3.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit fftw
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
