### PR TITLE
util-macros: update to 1.20.1

### DIFF
--- a/runtime-display/util-macros/spec
+++ b/runtime-display/util-macros/spec
@@ -1,4 +1,4 @@
-VER=1.20.0
+VER=1.20.1
 SRCS="tbl::https://xorg.freedesktop.org/archive/individual/util/util-macros-$VER.tar.xz"
-CHKSUMS="sha256::0b86b262dbe971edb4ff233bc370dfad9f241d09f078a3f6d5b7f4b8ea4430db"
+CHKSUMS="sha256::0b308f62dce78ac0f4d9de6888234bf170f276b64ac7c96e99779bb4319bcef5"
 CHKUPDATE="anitya::id=5252"


### PR DESCRIPTION
Topic Description
-----------------

- util-macros: update to 1.20.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- util-macros: 1.20.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit util-macros
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
