### PR TITLE
isomd5sum: update to 1.2.4

### DIFF
--- a/app-utils/isomd5sum/autobuild/build
+++ b/app-utils/isomd5sum/autobuild/build
@@ -1,0 +1,8 @@
+abinfo "Building isomd5sum ..."
+make \
+    ${MAKE_AFTER[@]}
+
+abinfo "Installing isomd5sum ..."
+make install \
+    DESTDIR="$PKGDIR" \
+    ${MAKE_AFTER[@]}

--- a/app-utils/isomd5sum/autobuild/defines
+++ b/app-utils/isomd5sum/autobuild/defines
@@ -3,6 +3,9 @@ PKGSEC=utils
 PKGDEP="glibc python-3"
 PKGDES="Utilities for working with md5sum implanted in ISO images"
 
-MAKE_AFTER="LIBDIR=lib \
-            PYTHON=/usr/bin/python3"
+MAKE_AFTER=(
+    'LIBDIR=lib'
+    'PYTHON=/usr/bin/python3'
+)
+# FIXME: race condition
 NOPARALLEL=1

--- a/app-utils/isomd5sum/spec
+++ b/app-utils/isomd5sum/spec
@@ -1,4 +1,4 @@
-VER=1.2.3
+VER=1.2.4
 SRCS="git::commit=tags/$VER::https://github.com/rhinstaller/isomd5sum"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10547"


### PR DESCRIPTION
Topic Description
-----------------

- isomd5sum: update to 1.2.4
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- isomd5sum: 1.2.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit isomd5sum
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
