### PR TITLE
mutagen: update to 1.47.0

### DIFF
--- a/app-multimedia/mutagen/spec
+++ b/app-multimedia/mutagen/spec
@@ -1,5 +1,4 @@
-VER=1.46.0
-REL=1
+VER=1.47.0
 SRCS="tbl::https://pypi.io/packages/source/m/mutagen/mutagen-$VER.tar.gz"
-CHKSUMS="sha256::6e5f8ba84836b99fe60be5fb27f84be4ad919bbb6b49caa6ae81e70584b55e58"
+CHKSUMS="sha256::719fadef0a978c31b4cf3c956261b3c58b6948b32023078a2117b1de09f0fc99"
 CHKUPDATE="anitya::id=3931"


### PR DESCRIPTION
Topic Description
-----------------

- mutagen: update to 1.47.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mutagen: 1.47.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mutagen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
