### PR TITLE
python-ly: update to 0.9.7

### DIFF
--- a/lang-python/python-ly/spec
+++ b/lang-python/python-ly/spec
@@ -1,5 +1,4 @@
-VER=0.9.6
+VER=0.9.7
 SRCS="tbl::https://github.com/frescobaldi/python-ly/archive/v$VER.tar.gz"
-CHKSUMS="sha256::f1e7a2386c50460c2bf6e0876216f5101f3ee4aa956c6eb2348d901e005d1a07"
-REL=2
+CHKSUMS="sha256::8bfcbfb737b66eca90a419764ab1bfbf403ecb226093e7f3097a9a9b7e29f8a7"
 CHKUPDATE="anitya::id=5836"


### PR DESCRIPTION
Topic Description
-----------------

- python-ly: update to 0.9.7
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- python-ly: 0.9.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit python-ly
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
