### PR TITLE
systemd: update to 255.6

### DIFF
--- a/app-admin/systemd/autobuild/patches/0001-hwdb-add-resolution-override-for-Pinebook-Pro-touchp.patch
+++ b/app-admin/systemd/autobuild/patches/0001-hwdb-add-resolution-override-for-Pinebook-Pro-touchp.patch
@@ -1,4 +1,4 @@
-From 1f1051260492855843b2032cb212b61626f3bcea Mon Sep 17 00:00:00 2001
+From a9261e758696d3c69ef7d7d89feaf9c24bc05fcc Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Tue, 13 Feb 2024 19:58:35 -0800
 Subject: [PATCH 1/2] hwdb: add resolution override for Pinebook Pro touchpad
@@ -16,12 +16,12 @@ Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
  1 file changed, 11 insertions(+)
 
 diff --git a/hwdb.d/60-evdev.hwdb b/hwdb.d/60-evdev.hwdb
-index 9a90420b5f..7a0c756b5e 100644
+index a4431e239e..b93c728304 100644
 --- a/hwdb.d/60-evdev.hwdb
 +++ b/hwdb.d/60-evdev.hwdb
-@@ -487,6 +487,17 @@ evdev:input:b0003v256Cp0064*
-  EVDEV_ABS_00=::200
-  EVDEV_ABS_01=::200
+@@ -504,6 +504,17 @@ evdev:input:b0003v256Cp006B*
+  EVDEV_ABS_35=::40
+  EVDEV_ABS_36=::42
  
 +###########################################################
 +# Pine64
@@ -38,5 +38,5 @@ index 9a90420b5f..7a0c756b5e 100644
  # Lenovo
  #########################################
 -- 
-2.43.0
+2.45.1
 

--- a/app-admin/systemd/autobuild/patches/0002-sleep.conf-AllowHibernation-no-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0002-sleep.conf-AllowHibernation-no-by-default.patch
@@ -1,4 +1,4 @@
-From d6d087130509fb829f98b116bf47fb3a7d8488a2 Mon Sep 17 00:00:00 2001
+From abc758fbac474598c10a393338c27362f94aedea Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Tue, 11 Apr 2023 18:04:25 -0700
 Subject: [PATCH 2/2] sleep.conf: AllowHibernation=no by default
@@ -22,5 +22,5 @@ index fad95b3897..a5c05dda26 100644
  #AllowHybridSleep=yes
  #SuspendState=mem standby freeze
 -- 
-2.43.0
+2.45.1
 

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,5 +1,4 @@
-VER=255.3
-REL=4
+VER=255.6
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd-stable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205088"


### PR DESCRIPTION
Topic Description
-----------------

- systemd: update to 255.6
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- systemd: 1:255.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
