### PR TITLE
love11: update to 11.5

### DIFF
--- a/app-games/love11/autobuild/defines
+++ b/app-games/love11/autobuild/defines
@@ -6,3 +6,6 @@ PKGDEP="libvorbis sdl2 physfs openal-soft mpg123 luajit lua mesa \
 
 AUTOTOOLS_AFTER="--program-suffix=11"
 USECLANG=0
+
+# FIXME: LuaJIT is only available for the following architectures.
+FAIL_ARCH="!(amd64|armv4|armv6hf|armv7hf|arm64|i486|loongson2f|loongson3|mips64r6el)"

--- a/app-games/love11/spec
+++ b/app-games/love11/spec
@@ -1,5 +1,4 @@
-VER=11.3
+VER=11.5
 SRCS="tbl::https://github.com/love2d/love/releases/download/$VER/love-$VER-linux-src.tar.gz"
-CHKSUMS="sha256::649f0db7750ca121e4de7b60208703661052356df35f4cfad490b1ba14dd1455"
+CHKSUMS="sha256::066e0843f71aa9fd28b8eaf27d41abb74bfaef7556153ac2e3cf08eafc874c39"
 CHKUPDATE="anitya::id=12269"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- love11: update to 11.5
    Sync FAIL_ARCH with lang-lua/luajit.
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- love11: 11.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit love11
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
