### PR TITLE
xapps: update to 2.8.2

### DIFF
--- a/runtime-desktop/xapps/spec
+++ b/runtime-desktop/xapps/spec
@@ -1,4 +1,4 @@
-VER=2.6.1
+VER=2.8.2
 SRCS="tbl::https://github.com/linuxmint/xapps/archive/$VER.tar.gz"
-CHKSUMS="sha256::c16c633c5c7ea572d7db77be9f0fdaa57c7b9f335a62f5fcb6b87bf6473aff0f"
+CHKSUMS="sha256::07b00d02d2bdd93c043e370305071df80f21ded6404f7309b590a8f896e635b2"
 CHKUPDATE="anitya::id=12203"


### PR DESCRIPTION
Topic Description
-----------------

- xapps: update to 2.8.2
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xapps: 2.8.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit xapps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
