### PR TITLE
throttled: update to 0.10.0

### DIFF
--- a/app-utils/throttled/spec
+++ b/app-utils/throttled/spec
@@ -1,4 +1,4 @@
-VER=0.9.2
+VER=0.10.0
 SRCS="tbl::https://github.com/erpalma/throttled/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::01beb3e17303b11d86aeadc74d85d0ee2d50375998137dcdb5e464de4fdc4e07"
+CHKSUMS="sha256::49e042fc26a809b0e4f129598c8f12377809a43f6be5792a50a0b765a6cb69b8"
 CHKUPDATE="anitya::id=231654"


### PR DESCRIPTION
Topic Description
-----------------

- throttled: update to 0.10.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- throttled: 0.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit throttled
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
