### PR TITLE
go-md2man: update to 2.0.4

### DIFF
--- a/app-doc/go-md2man/spec
+++ b/app-doc/go-md2man/spec
@@ -1,5 +1,4 @@
-VER=2.0.3
-REL=2
+VER=2.0.4
 SRCS="git::commit=tags/v${VER}::https://github.com/cpuguy83/go-md2man"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14461"


### PR DESCRIPTION
Topic Description
-----------------

- go-md2man: update to 2.0.4
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- go-md2man: 2.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit go-md2man
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
