### PR TITLE
celt-0.5: update to 0.5.2

### DIFF
--- a/runtime-multimedia/celt-0.5/spec
+++ b/runtime-multimedia/celt-0.5/spec
@@ -1,5 +1,4 @@
-VER=0.5.1.3
-REL=3
-SRCS="tbl::https://downloads.xiph.org/releases/celt/celt-0.5.1.3.tar.gz"
-CHKSUMS="sha256::fc2e5b68382eb436a38c3104684a6c494df9bde133c139fbba3ddb5d7eaa6a2e"
+VER=0.5.2
+SRCS="tbl::https://downloads.xiph.org/releases/celt/celt-$VER.tar.gz"
+CHKSUMS="sha256::58b06d7f79590a8cd0ca2412cfc7da04f8bee27a4635cb988fa9e8ee8908824c"
 CHKUPDATE="anitya::id=15311"


### PR DESCRIPTION
Topic Description
-----------------

- celt-0.5: update to 0.5.2
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- celt-0.5: 0.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit celt-0.5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
