### PR TITLE
srain: update to 1.7.0

### DIFF
--- a/app-web/srain/autobuild/defines
+++ b/app-web/srain/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=srain
 PKGSEC=web
-PKGDEP="gtk-3 libconfig libsoup libsecret"
+PKGDEP="gtk-3 libconfig libsoup-3 libsecret"
 BUILDDEP="sphinx"
-PKGDES="A modern IRC client written in GTK"
+PKGDES="An graphical IRC (Internet Relay Chat) client"
 
-MESON_AFTER="-Dbuildtype=release"
+MESON_AFTER="-Dbuildtype=release \
+             -Dapp_indicator=false"

--- a/app-web/srain/spec
+++ b/app-web/srain/spec
@@ -1,4 +1,4 @@
-VER=1.5.1
+VER=1.7.0
 SRCS="git::commit=tags/$VER::https://github.com/SrainApp/srain"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=27553"


### PR DESCRIPTION
Topic Description
-----------------

- srain: update to 1.7.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- srain: 1.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit srain
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
