### PR TITLE
perl-text-bibtex: update to 0.89

### DIFF
--- a/lang-perl/perl-text-bibtex/spec
+++ b/lang-perl/perl-text-bibtex/spec
@@ -1,5 +1,4 @@
-VER=0.88
+VER=0.89
 SRCS="tbl::https://cpan.metacpan.org/authors/id/A/AM/AMBS/Text-BibTeX-$VER.tar.gz"
-CHKSUMS="sha256::b014586e68bdbcafb0a2cfa0401eb0a04ea5de8c4d5bc36dd0f7faeab6acf42c"
+CHKSUMS="sha256::88a78ebf088ec7502f401c5a2b138c862cf5458534b773223bbf3aaf41224196"
 CHKUPDATE="anitya::id=5429"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- perl-text-bibtex: update to 0.89
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-text-bibtex: 0.89

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-text-bibtex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
