### PR TITLE
celt-0.5: drop

### DIFF
--- a/runtime-multimedia/celt-0.5/autobuild/defines
+++ b/runtime-multimedia/celt-0.5/autobuild/defines
@@ -1,6 +1,0 @@
-PKGNAME=celt-0.5
-PKGSEC=sound
-PKGDEP="libogg"
-PKGDES="Low-latency audio communication codec - SPICE version"
-
-RECONF=0

--- a/runtime-multimedia/celt-0.5/autobuild/prepare
+++ b/runtime-multimedia/celt-0.5/autobuild/prepare
@@ -1,1 +1,0 @@
-chmod -R a-s "$SRCDIR"

--- a/runtime-multimedia/celt-0.5/spec
+++ b/runtime-multimedia/celt-0.5/spec
@@ -1,4 +1,0 @@
-VER=0.5.2
-SRCS="tbl::https://downloads.xiph.org/releases/celt/celt-$VER.tar.gz"
-CHKSUMS="sha256::58b06d7f79590a8cd0ca2412cfc7da04f8bee27a4635cb988fa9e8ee8908824c"
-CHKUPDATE="anitya::id=15311"

--- a/runtime-virtualization/spice/autobuild/defines
+++ b/runtime-virtualization/spice/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=spice
 PKGSEC=libs
-PKGDEP="alsa-lib celt-0.5 libjpeg-turbo cyrus-sasl pixman mesa lz4 opus gstreamer"
+PKGDEP="alsa-lib libjpeg-turbo cyrus-sasl pixman mesa lz4 opus gstreamer"
 BUILDDEP="libcacard pyparsing spice-protocol"
 PKGDES="SPICE client and server"
 

--- a/runtime-virtualization/spice/spec
+++ b/runtime-virtualization/spice/spec
@@ -1,5 +1,5 @@
 VER=0.15.2
+REL=2
 SRCS="tbl::https://spice-space.org/download/releases/spice-$VER.tar.bz2"
 CHKSUMS="sha256::6d9eb6117f03917471c4bc10004abecff48a79fb85eb85a1c45f023377015b81"
 CHKUPDATE="anitya::id=4871"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- celt-0.5: drop
    The use of celt-0.5 is deprecated in spice, hence removal.

Package(s) Affected
-------------------

- spice: 0.15.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit spice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
