### PR TITLE
intel-compute-runtime: update to 24.17.29377.6

### DIFF
--- a/runtime-devices/intel-gmmlib/spec
+++ b/runtime-devices/intel-gmmlib/spec
@@ -1,4 +1,4 @@
-VER=22.3.18
+VER=22.3.19
 SRCS="git::commit=tags/intel-gmmlib-$VER;copy-repo=true::https://github.com/intel/gmmlib"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20342"

--- a/runtime-scientific/intel-compute-runtime/spec
+++ b/runtime-scientific/intel-compute-runtime/spec
@@ -1,4 +1,4 @@
-VER=24.13.29138.7
+VER=24.17.29377.6
 SRCS="git::commit=tags/$VER::https://github.com/intel/compute-runtime.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229527"


### PR DESCRIPTION
Topic Description
-----------------

- intel-compute-runtime: update to 24.17.29377.6

Package(s) Affected
-------------------

- intel-compute-runtime: 24.17.29377.6
- intel-gmmlib: 22.3.19

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-gmmlib intel-compute-runtime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
