### PR TITLE
nss: update to 3.100

### DIFF
--- a/runtime-cryptography/nss/spec
+++ b/runtime-cryptography/nss/spec
@@ -1,4 +1,4 @@
-VER=3.99
+VER=3.100
 SRCS="https://download-origin.cdn.mozilla.net/pub/security/nss/releases/NSS_${VER//./_}_RTM/src/nss-$VER.tar.gz"
-CHKSUMS="sha256::5cd5c2c8406a376686e6fa4b9c2de38aa280bea07bf927c0d521ba07c88b09bd"
+CHKSUMS="sha256::1e35373ce9cb5b776f678bb341b0625c437520d09ebd91d1abd622e072e38d88"
 CHKUPDATE="anitya::id=2503"


### PR DESCRIPTION
Topic Description
-----------------

- nss: update to 3.100
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- nss: 3.100

Security Update?
----------------

No

Build Order
-----------

```
#buildit nss
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
