### PR TITLE
cython: update to 3.0.10

### DIFF
--- a/lang-python/cython/spec
+++ b/lang-python/cython/spec
@@ -1,5 +1,4 @@
-VER=3.0.2
-REL=2
+VER=3.0.10
 SRCS="tbl::https://pypi.io/packages/source/C/Cython/Cython-$VER.tar.gz"
-CHKSUMS="sha256::9594818dca8bb22ae6580c5222da2bc5cc32334350bd2d294a00d8669bcc61b5"
+CHKSUMS="sha256::dcc96739331fb854dcf503f94607576cfe8488066c61ca50dfd55836f132de99"
 CHKUPDATE="anitya::id=36699"


### PR DESCRIPTION
Topic Description
-----------------

- cython: update to 3.0.10
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cython: 3.0.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit cython
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
