### PR TITLE
libstatgrab: update to 0.92.1

### DIFF
--- a/runtime-admin/libstatgrab/spec
+++ b/runtime-admin/libstatgrab/spec
@@ -1,5 +1,4 @@
-VER=0.91
-REL=3
+VER=0.92.1
 SRCS="tbl::https://www.mirrorservice.org/sites/ftp.i-scream.org/pub/i-scream/libstatgrab/libstatgrab-$VER.tar.gz"
-CHKSUMS="sha256::03e9328e4857c2c9dcc1b0347724ae4cd741a72ee11acc991784e8ef45b7f1ab"
+CHKSUMS="sha256::5688aa4a685547d7174a8a373ea9d8ee927e766e3cc302bdee34523c2c5d6c11"
 CHKUPDATE="anitya::id=1731"


### PR DESCRIPTION
Topic Description
-----------------

- libstatgrab: update to 0.92.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libstatgrab: 0.92.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libstatgrab
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
