### PR TITLE
roxterm: update to 3.15.0

### DIFF
--- a/app-utils/roxterm/spec
+++ b/app-utils/roxterm/spec
@@ -1,4 +1,4 @@
-VER=3.14.3
+VER=3.15.0
 SRCS="git::commit=tags/$VER::https://github.com/realh/roxterm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4207"


### PR DESCRIPTION
Topic Description
-----------------

- roxterm: update to 3.15.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- roxterm: 3.15.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit roxterm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
