### PR TITLE
squashfs-tools-ng: update to 1.3.1

### DIFF
--- a/app-admin/squashfs-tools-ng/spec
+++ b/app-admin/squashfs-tools-ng/spec
@@ -1,4 +1,4 @@
-VER=1.2.0
+VER=1.3.1
 SRCS="git::commit=tags/v$VER::https://github.com/AgentD/squashfs-tools-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368669"


### PR DESCRIPTION
Topic Description
-----------------

- squashfs-tools-ng: update to 1.3.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- squashfs-tools-ng: 1.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit squashfs-tools-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
