### PR TITLE
perl-xml-writer: update to 0.900

### DIFF
--- a/lang-perl/perl-xml-writer/spec
+++ b/lang-perl/perl-xml-writer/spec
@@ -1,5 +1,4 @@
-VER=0.625
+VER=0.900
 SRCS="tbl::https://www.cpan.org/authors/id/J/JO/JOSEPHW/XML-Writer-$VER.tar.gz"
-CHKSUMS="sha256::e080522c6ce050397af482665f3965a93c5d16f5e81d93f6e2fe98084ed15fbe"
-REL=2
+CHKSUMS="sha256::73c8f5bd3ecf2b350f4adae6d6676d52e08ecc2d7df4a9f089fa68360d400d1f"
 CHKUPDATE="anitya::id=3543"


### PR DESCRIPTION
Topic Description
-----------------

- perl-xml-writer: update to 0.900
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-xml-writer: 0.900

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-xml-writer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
