### PR TITLE
pass: update to 1.7.4

### DIFF
--- a/app-utils/pass/spec
+++ b/app-utils/pass/spec
@@ -1,5 +1,4 @@
-VER=1.7.3
-REL=2
+VER=1.7.4
 SRCS="tbl::https://git.zx2c4.com/password-store/snapshot/password-store-$VER.tar.xz"
-CHKSUMS="sha256::2b6c65846ebace9a15a118503dcd31b6440949a30d3b5291dfb5b1615b99a3f4"
+CHKSUMS="sha256::cfa9faf659f2ed6b38e7a7c3fb43e177d00edbacc6265e6e32215ff40e3793c0"
 CHKUPDATE="anitya::id=10071"


### PR DESCRIPTION
Topic Description
-----------------

- pass: update to 1.7.4
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- pass: 1.7.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit pass
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
