### PR TITLE
libwps: update to 0.4.14

### DIFF
--- a/runtime-productivity/libwps/spec
+++ b/runtime-productivity/libwps/spec
@@ -1,4 +1,4 @@
-VER=0.4.10
+VER=0.4.14
 SRCS="tbl::https://downloads.sourceforge.net/project/libwps/libwps/libwps-$VER/libwps-$VER.tar.xz"
-CHKSUMS="sha256::1421e034286a9f96d3168a1c54ea570ee7aa008ca07b89de005ad5ce49fb29ca"
+CHKSUMS="sha256::365b968e270e85a8469c6b160aa6af5619a4e6c995dbb04c1ecc1b4dd13e80de"
 CHKUPDATE="anitya::id=1763"


### PR DESCRIPTION
Topic Description
-----------------

- libwps: update to 0.4.14
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libwps: 0.4.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit libwps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
