### PR TITLE
mkvtoolnix: update to 84.0

### DIFF
--- a/app-multimedia/mkvtoolnix/autobuild/build
+++ b/app-multimedia/mkvtoolnix/autobuild/build
@@ -1,5 +1,15 @@
-./configure --prefix=/usr \
-            --with-boost-libdir=/usr/lib \
-            --enable-qt --without-curl
-rake ${MAKEFLAGS} V=1
-rake install DESTDIR="$PKGDIR"
+abinfo "Configuring MKVToolNix ..."
+"$SRCDIR"/configure \
+    --prefix=/usr \
+    --with-boost-libdir=/usr/lib \
+    --enable-qt \
+    --without-curl
+
+abinfo "Building MKVToolNix ..."
+rake \
+    ${MAKEFLAGS} \
+    V=1
+
+abinfo "Installing MKVToolNix ..."
+rake install \
+    DESTDIR="$PKGDIR"

--- a/app-multimedia/mkvtoolnix/autobuild/defines
+++ b/app-multimedia/mkvtoolnix/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=mkvtoolnix
 PKGSEC=video
-PKGDEP="cmark libebml libmatroska expat flac libvorbis file boost lzo qt-5 pugixml"
+PKGDEP="cmark libebml libmatroska expat flac libvorbis file boost lzo qt-6 \
+        pugixml"
 BUILDDEP="ruby po4a docbook-xsl"
 PKGDES="Set of tools to create, edit and inspect Matroska files"
 

--- a/app-multimedia/mkvtoolnix/spec
+++ b/app-multimedia/mkvtoolnix/spec
@@ -1,5 +1,4 @@
-VER=79.0
-REL=2
+VER=84.0
 SRCS="tbl::https://www.bunkus.org/videotools/mkvtoolnix/sources/mkvtoolnix-$VER.tar.xz"
-CHKSUMS="sha256::f039c27b0dfe4a4d1aa870ad32e20a28a5f254de6121cb12a42328130be3afbc"
+CHKSUMS="sha256::e9176dea435c3b06b4716fb131d53c8f2621977576ccc4aee8ff9050c0d9ea7a"
 CHKUPDATE="anitya::id=1991"


### PR DESCRIPTION
Topic Description
-----------------

- mkvtoolnix: update to 84.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mkvtoolnix: 84.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mkvtoolnix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
