### PR TITLE
perl-email-messageid: update to 1.408

### DIFF
--- a/lang-perl/perl-email-messageid/spec
+++ b/lang-perl/perl-email-messageid/spec
@@ -1,5 +1,4 @@
-VER=1.406
-REL=3
+VER=1.408
 SRCS="tbl::https://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Email-MessageID-$VER.tar.gz"
-CHKSUMS="sha256::ec425ddbf395e0e1ac7c6f95b4933c55c57ac9f1e7514003c7c904ec6cd342b8"
+CHKSUMS="sha256::1f3d5b4ff0b1c7b39e9ac7c318fb37adcd0bac9556036546494d14f06dc5643c"
 CHKUPDATE="anitya::id=5902"


### PR DESCRIPTION
Topic Description
-----------------

- perl-email-messageid: update to 1.408
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-email-messageid: 1.408

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-email-messageid
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
