### PR TITLE
hidapi: update to 0.14.0

### DIFF
--- a/runtime-devices/hidapi/spec
+++ b/runtime-devices/hidapi/spec
@@ -1,5 +1,4 @@
-VER=0.12.0
-REL=1
+VER=0.14.0
 SRCS="tbl::https://github.com/libusb/hidapi/archive/refs/tags/hidapi-${VER}.tar.gz"
-CHKSUMS="sha256::28ec1451f0527ad40c1a4c92547966ffef96813528c8b184a665f03ecbb508bc"
+CHKSUMS="sha256::a5714234abe6e1f53647dd8cba7d69f65f71c558b7896ed218864ffcf405bcbd"
 CHKUPDATE="anitya::id=5594"


### PR DESCRIPTION
Topic Description
-----------------

- hidapi: update to 0.14.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- hidapi: 0.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit hidapi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
