### PR TITLE
perl-clone: update to 0.46

### DIFF
--- a/lang-perl/perl-clone/spec
+++ b/lang-perl/perl-clone/spec
@@ -1,5 +1,4 @@
-VER=0.41
+VER=0.46
 SRCS="tbl::https://search.cpan.org/CPAN/authors/id/G/GA/GARU/Clone-$VER.tar.gz"
-CHKSUMS="sha256::e8c056dcf4bc8889079a09412af70194a54a269689ba72edcd91291a46a51518"
-REL=3
+CHKSUMS="sha256::aadeed5e4c8bd6bbdf68c0dd0066cb513e16ab9e5b4382dc4a0aafd55890697b"
 CHKUPDATE="anitya::id=5875"


### PR DESCRIPTION
Topic Description
-----------------

- perl-clone: update to 0.46
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-clone: 0.46

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-clone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
