### PR TITLE
scrot: update to 1.10

### DIFF
--- a/app-utils/scrot/spec
+++ b/app-utils/scrot/spec
@@ -1,5 +1,4 @@
-VER=0.8
-REL=1
+VER=1.10
 SRCS="tbl::http://archive.ubuntu.com/ubuntu/pool/universe/s/scrot/scrot_$VER.orig.tar.gz"
-CHKSUMS="sha256::613d1cf524c2b62ce3c65f1232ea4f05c7daf248d5e82ff2a6892c98093994f2"
+CHKSUMS="sha256::5f18f5234964513409141eb08b268c83e9e5d340062de37c3a04772be4bf4058"
 CHKUPDATE="anitya::id=9819"


### PR DESCRIPTION
Topic Description
-----------------

- scrot: update to 1.10
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- scrot: 1:1.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit scrot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
