### PR TITLE
serd: update to 0.32.2

### DIFF
--- a/runtime-common/serd/spec
+++ b/runtime-common/serd/spec
@@ -1,4 +1,4 @@
-VER=0.32.0
+VER=0.32.2
 SRCS="tbl::https://download.drobilla.net/serd-$VER.tar.xz"
-CHKSUMS="sha256::d1e8699468e01d2a76abe402b4d5c60c5095335c92b259088f062bdd3b929ca1"
+CHKSUMS="sha256::df7dc2c96f2ba1decfd756e458e061ded7d8158d255554e7693483ac0963c56b"
 CHKUPDATE="anitya::id=230531"


### PR DESCRIPTION
Topic Description
-----------------

- serd: update to 0.32.2
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- serd: 0.32.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit serd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
