### PR TITLE
perl-ffi-checklib: update to 0.31

### DIFF
--- a/lang-perl/perl-ffi-checklib/spec
+++ b/lang-perl/perl-ffi-checklib/spec
@@ -1,5 +1,4 @@
-VER=0.25
+VER=0.31
 SRCS="tbl::https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/FFI-CheckLib-$VER.tar.gz"
-CHKSUMS="sha256::eb36b9a7cff1764a65b1b77e01e92c26207c558a3f986d0d17d2b110fa366ba4"
-REL=2
+CHKSUMS="sha256::04d885fc377d44896e5ea1c4ec310f979bb04f2f18658a7e7a4d509f7e80bb80"
 CHKUPDATE="anitya::id=13614"


### PR DESCRIPTION
Topic Description
-----------------

- perl-ffi-checklib: update to 0.31
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-ffi-checklib: 0.31

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-ffi-checklib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
