### PR TITLE
gtkspell3: update to 3.0.10

### DIFF
--- a/desktop-gnome/gtkspell3/autobuild/defines
+++ b/desktop-gnome/gtkspell3/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=gtkspell3
 PKGSEC=gnome
-PKGDEP="gtk-3 enchant iso-codes"
+PKGDEP="gtk-3 enchant-2 iso-codes"
 BUILDDEP="gobject-introspection gtk-doc intltool vala"
 PKGDES="On-the-fly spell checking for GtkTextView widgets"
 
-AUTOTOOLS_AFTER="--enable-gtk-doc --enable-vala"
-ABSHADOW=no
+AUTOTOOLS_AFTER="--enable-gtk-doc \
+                 --enable-vala"
+ABSHADOW=0

--- a/desktop-gnome/gtkspell3/spec
+++ b/desktop-gnome/gtkspell3/spec
@@ -1,4 +1,4 @@
-VER=3.0.9
+VER=3.0.10
 SRCS="tbl::https://sourceforge.net/projects/gtkspell/files/$VER/gtkspell3-$VER.tar.xz"
-CHKSUMS="sha256::a4f4a4a2789f7499563e26d96b22d8085222ebe278da47d026b2de782b8b4d26"
+CHKSUMS="sha256::b040f63836b347eb344f5542443dc254621805072f7141d49c067ecb5a375732"
 CHKUPDATE="anitya::id=13111"


### PR DESCRIPTION
Topic Description
-----------------

- gtkspell3: update to 3.0.10
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gtkspell3: 3.0.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtkspell3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
