### PR TITLE
hplip: update to 3.23.12

### DIFF
--- a/app-doc/hplip/spec
+++ b/app-doc/hplip/spec
@@ -1,5 +1,4 @@
-VER=3.22.4
-REL=3
+VER=3.23.12
 SRCS="tbl::https://prdownloads.sourceforge.net/hplip/hplip-$VER.tar.gz"
-CHKSUMS="sha256::7be9e547c5ac40917160ef34f59f82275d1daea577067f7eeeb2ae07c7bec110"
+CHKSUMS="sha256::a76c2ac8deb31ddb5f0da31398d25ac57440928a0692dcb060a48daa718e69ed"
 CHKUPDATE="anitya::id=1327"


### PR DESCRIPTION
Topic Description
-----------------

- hplip: update to 3.23.12
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- hplip: 2:3.23.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit hplip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
