### PR TITLE
liblastfm: update to 1.1.0

### DIFF
--- a/runtime-multimedia/liblastfm/spec
+++ b/runtime-multimedia/liblastfm/spec
@@ -1,5 +1,4 @@
-VER=1.0.9
-REL=7
+VER=1.1.0
 SRCS="tbl::https://github.com/lastfm/liblastfm/archive/$VER.tar.gz"
-CHKSUMS="sha256::5276b5fe00932479ce6fe370ba3213f3ab842d70a7d55e4bead6e26738425f7b"
+CHKSUMS="sha256::f61f0daa384e081a8f2bd2f7a2148babff22696e5b72ecdac86940a10100b1c8"
 CHKUPDATE="anitya::id=1651"


### PR DESCRIPTION
Topic Description
-----------------

- liblastfm: update to 1.1.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- liblastfm: 1.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit liblastfm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
