### PR TITLE
semantic-version: update to 2.10.0

### DIFF
--- a/lang-python/semantic-version/spec
+++ b/lang-python/semantic-version/spec
@@ -1,5 +1,4 @@
-VER=2.8.5
-REL=2
+VER=2.10.0
 SRCS="https://pypi.io/packages/source/s/semantic_version/semantic_version-$VER.tar.gz"
-CHKSUMS="sha256::d2cb2de0558762934679b9a104e82eca7af448c9f4974d1f3eeccff651df8a54"
+CHKSUMS="sha256::bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c"
 CHKUPDATE="anitya::id=46758"


### PR DESCRIPTION
Topic Description
-----------------

- semantic-version: update to 2.10.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- semantic-version: 2.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit semantic-version
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
