### PR TITLE
xdelta: update to 3.1.0

### DIFF
--- a/app-utils/xdelta/spec
+++ b/app-utils/xdelta/spec
@@ -1,5 +1,5 @@
-VER=3.0.11
+VER=3.1.0
 SRCS="tbl::https://github.com/jmacd/xdelta/archive/v$VER.tar.gz"
-CHKSUMS="sha256::28278a4d73127f3d2b00bbde179f8ee1f289ccd3f7f2ac7cd837f6580f90a7b7"
+CHKSUMS="sha256::7515cf5378fca287a57f4e2fee1094aabc79569cfe60d91e06021a8fd7bae29d"
 SUBDIR="xdelta-$VER/xdelta3"
 CHKUPDATE="anitya::id=5177"


### PR DESCRIPTION
Topic Description
-----------------

- xdelta: update to 3.1.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xdelta: 3.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdelta
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
