### PR TITLE
owntone: update to 28.9

### DIFF
--- a/app-multimedia/owntone/spec
+++ b/app-multimedia/owntone/spec
@@ -1,5 +1,4 @@
-VER=28.6
-REL=1
+VER=28.9
 SRCTBL="https://github.com/owntone/owntone-server/releases/download/${VER}/owntone-${VER}.tar.xz"
-CHKSUM="sha256::5604d35d2a205cd7dee5b708969e2da96904600c2f5743beb207f61bb86bdc05"
+CHKSUM="sha256::76671ab46315566541018fd404cec315b7d0f9d4c9b9dbc51fcdae7fca7be832"
 CHKUPDATE="anitya::id=230673"


### PR DESCRIPTION
Topic Description
-----------------

- owntone: update to 28.9
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- owntone: 28.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit owntone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
