### PR TITLE
linux-pam: update to 1.6.1

### DIFF
--- a/app-admin/linux-pam/spec
+++ b/app-admin/linux-pam/spec
@@ -1,5 +1,4 @@
-VER=1.6.0
-REL=1
+VER=1.6.1
 SRCS="tbl::https://github.com/linux-pam/linux-pam/releases/download/v$VER/Linux-PAM-$VER.tar.xz"
-CHKSUMS="sha256::fff4a34e5bbee77e2e8f1992f27631e2329bcbf8a0563ddeb5c3389b4e3169ad"
+CHKSUMS="sha256::f8923c740159052d719dbfc2a2f81942d68dd34fcaf61c706a02c9b80feeef8e"
 CHKUPDATE="anitya::id=12244"


### PR DESCRIPTION
Topic Description
-----------------

- linux-pam: update to 1.6.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- linux-pam: 1.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-pam
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
