### PR TITLE
libdatrie: update to 0.2.13

### DIFF
--- a/runtime-i18n/libdatrie/spec
+++ b/runtime-i18n/libdatrie/spec
@@ -1,5 +1,4 @@
-VER=0.2.12
-REL=2
+VER=0.2.13
 SRCS="tbl::https://linux.thai.net/pub/thailinux/software/libthai/libdatrie-$VER.tar.xz"
-CHKSUMS="sha256::452dcc4d3a96c01f80f7c291b42be11863cd1554ff78b93e110becce6e00b149"
+CHKSUMS="sha256::12231bb2be2581a7f0fb9904092d24b0ed2a271a16835071ed97bed65267f4be"
 CHKUPDATE="anitya::id=7342"


### PR DESCRIPTION
Topic Description
-----------------

- libdatrie: update to 0.2.13
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libdatrie: 0.2.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdatrie
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
