### PR TITLE
gawk: update to 5.3.0

### DIFF
--- a/app-utils/gawk/spec
+++ b/app-utils/gawk/spec
@@ -1,4 +1,4 @@
-VER=5.2.1
+VER=5.3.0
 SRCS="tbl::https://ftp.gnu.org/gnu/gawk/gawk-$VER.tar.xz"
-CHKSUMS="sha256::673553b91f9e18cc5792ed51075df8d510c9040f550a6f74e09c9add243a7e4f"
+CHKSUMS="sha256::ca9c16d3d11d0ff8c69d79dc0b47267e1329a69b39b799895604ed447d3ca90b"
 CHKUPDATE="anitya::id=868"


### PR DESCRIPTION
Topic Description
-----------------

- gawk: update to 5.3.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gawk: 5.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gawk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
