### PR TITLE
bwm-ng: update to 0.6.3

### DIFF
--- a/app-network/bwm-ng/spec
+++ b/app-network/bwm-ng/spec
@@ -1,4 +1,4 @@
-VER=0.6.2
+VER=0.6.3
 SRCS="tbl::https://github.com/vgropp/bwm-ng/archive/v$VER.tar.gz"
-CHKSUMS="sha256::906a2d561f2ec9e0dd68b7f51b302908e99515ea1216d0ecaf14d873ef54ae70"
+CHKSUMS="sha256::c1a552b6ff48ea3e4e10110a7c188861abc4750befc67c6caaba8eb3ecf67f46"
 CHKUPDATE="anitya::id=9590"


### PR DESCRIPTION
Topic Description
-----------------

- bwm-ng: update to 0.6.3
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- bwm-ng: 0.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit bwm-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
