### PR TITLE
stm32flash: update to 0.7

### DIFF
--- a/app-devel/stm32flash/autobuild/defines
+++ b/app-devel/stm32flash/autobuild/defines
@@ -1,3 +1,4 @@
 PKGNAME=stm32flash
-PKGDES="STM32 flasher via UART or I2C"
 PKGSEC=devel
+PKGDEP="glibc"
+PKGDES="UART/I2C flash program for the STM32 ARM microcontrollers"

--- a/app-devel/stm32flash/spec
+++ b/app-devel/stm32flash/spec
@@ -1,4 +1,4 @@
-VER=0.6
-SRCS="tbl::https://sourceforge.net/projects/stm32flash/files/stm32flash-0.5.tar.gz"
-CHKSUMS="sha256::97aa9422ef02e82f7da9039329e21a437decf972cb3919ad817f70ac9a49e306"
+VER=0.7
+SRCS="tbl::https://sourceforge.net/projects/stm32flash/files/stm32flash-$VER.tar.gz"
+CHKSUMS="sha256::c4c9cd8bec79da63b111d15713ef5cc2cd947deca411d35d6e3065e227dc414a"
 CHKUPDATE="anitya::id=227276"


### PR DESCRIPTION
Topic Description
-----------------

- stm32flash: update to 0.7
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- stm32flash: 0.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit stm32flash
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
