### PR TITLE
scapy: update to 2.5.0

### DIFF
--- a/app-network/scapy/autobuild/defines
+++ b/app-network/scapy/autobuild/defines
@@ -2,6 +2,8 @@ PKGNAME=scapy
 PKGSEC=net
 PKGDEP="tcpdump python-2"
 PKGSUG="pycryptodome pyx python-gnuplot graphviz sox"
-PKGDES="A powerful interactive packet manipulation program written in Python"
+BUILDDEP="python-build python-installer wheel"
+PKGDES="An interactive packet manipulation program"
 
-NOPYTHON3=1
+ABTYPE=pep517
+ABHOST=noarch

--- a/app-network/scapy/spec
+++ b/app-network/scapy/spec
@@ -1,4 +1,4 @@
-VER=2.4.4
+VER=2.5.0
 SRCS="tbl::https://github.com/secdev/scapy/archive/v$VER.tar.gz"
-CHKSUMS="sha256::abe1b7fa606350df90209a60d23df727705097453b3dcb626bf36b3539d44021"
+CHKSUMS="sha256::5669fdf6a11b6ef7400716690016ffb9dcb6d984d560a63b87c7fad082ff6c3c"
 CHKUPDATE="anitya::id=115624"


### PR DESCRIPTION
Topic Description
-----------------

- scapy: update to 2.5.0
    - Switch to pep517 ABTYPE and disable Python 2 bindings.
    - Mark as noarch.
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- scapy: 2.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit scapy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
