### PR TITLE
yaz: update to 5.34.0

### DIFF
--- a/runtime-web/yaz/spec
+++ b/runtime-web/yaz/spec
@@ -1,4 +1,4 @@
-VER=5.31.0
+VER=5.34.0
 SRCS="tbl::http://ftp.indexdata.dk/pub/yaz/yaz-$VER.tar.gz"
-CHKSUMS="sha256::864d4476d1578ac132782b3d4e2eb96391bd88f7ae3040ddcb1556aba6fe0d15"
+CHKSUMS="sha256::bcbea894599a13342910003401c17576f0fb910092aecb51cb54065d0cd2d613"
 CHKUPDATE="anitya::id=5287"


### PR DESCRIPTION
Topic Description
-----------------

- yaz: update to 5.34.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- yaz: 5.34.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit yaz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
