### PR TITLE
libpaper: update to 2.2.5

### DIFF
--- a/runtime-productivity/libpaper/spec
+++ b/runtime-productivity/libpaper/spec
@@ -1,4 +1,4 @@
-VER=2.1.2
+VER=2.2.5
 SRCS="tbl::https://github.com/rrthomas/libpaper/releases/download/v$VER/libpaper-$VER.tar.gz"
-CHKSUMS="sha256::1fda0cf64efa46b9684a4ccc17df4386c4cc83254805419222c064bf62ea001f"
+CHKSUMS="sha256::7be50974ce0df0c74e7587f10b04272cd53fd675cb6a1273ae1cc5c9cc9cab09"
 CHKUPDATE="anitya::id=15136"


### PR DESCRIPTION
Topic Description
-----------------

- libpaper: update to 2.2.5
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libpaper: 2.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpaper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
