### PR TITLE
libass: update to 0.17.2

### DIFF
--- a/runtime-multimedia/libass/spec
+++ b/runtime-multimedia/libass/spec
@@ -1,4 +1,4 @@
-VER=0.15.1
+VER=0.17.2
 SRCS="tbl::https://github.com/libass/libass/releases/download/$VER/libass-$VER.tar.xz"
-CHKSUMS="sha256::1cdd39c9d007b06e737e7738004d7f38cf9b1e92843f37307b24e7ff63ab8e53"
+CHKSUMS="sha256::e8261b51d66ba933fe99248c6fdd8767ed96c5a7e5363c83992c735a2c2fbf74"
 CHKUPDATE="anitya::id=1560"


### PR DESCRIPTION
Topic Description
-----------------

- libass: update to 0.17.2
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libass: 0.17.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libass
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
