### PR TITLE
libproxy: update to 0.5.6

### DIFF
--- a/runtime-network/libproxy/spec
+++ b/runtime-network/libproxy/spec
@@ -1,4 +1,4 @@
-VER=0.5.5
+VER=0.5.6
 SRCS="git::commit=tags/$VER::https://github.com/libproxy/libproxy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12742"


### PR DESCRIPTION
Topic Description
-----------------

- libproxy: update to 0.5.6
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libproxy: 0.5.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libproxy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
