### PR TITLE
perl-time-duration: update to 1.21

### DIFF
--- a/lang-perl/perl-time-duration/spec
+++ b/lang-perl/perl-time-duration/spec
@@ -1,5 +1,4 @@
-VER=1.20
+VER=1.21
 SRCS="tbl::https://search.cpan.org/CPAN/authors/id/N/NE/NEILB/Time-Duration-$VER.tar.gz"
-CHKSUMS="sha256::458205b528818e741757b2854afac5f9af257f983000aae0c0b1d04b5a9cbbb8"
-REL=2
+CHKSUMS="sha256::fe340eba8765f9263694674e5dff14833443e19865e5ff427bbd79b7b5f8a9b8"
 CHKUPDATE="anitya::id=3465"


### PR DESCRIPTION
Topic Description
-----------------

- perl-time-duration: update to 1.21
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-time-duration: 1.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-time-duration
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
