### PR TITLE
signon-plugin-oauth2: update to 0.25

### DIFF
--- a/runtime-desktop/signon-plugin-oauth2/spec
+++ b/runtime-desktop/signon-plugin-oauth2/spec
@@ -1,5 +1,4 @@
-VER=0.24
-REL=4
-SRCS="git::commit=b74b5397992caddeb32a6158c9295126c55a3025::https://gitlab.com/accounts-sso/signon-plugin-oauth2.git"
+VER=0.25
+SRCS="git::commit=tags/VERSION_${VER}::https://gitlab.com/accounts-sso/signon-plugin-oauth2.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6089"


### PR DESCRIPTION
Topic Description
-----------------

- signon-plugin-oauth2: update to 0.25
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- signon-plugin-oauth2: 0.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit signon-plugin-oauth2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
