### PR TITLE
ffms2: update to 2.40

### DIFF
--- a/app-multimedia/ffms2/autobuild/beyond
+++ b/app-multimedia/ffms2/autobuild/beyond
@@ -1,2 +1,4 @@
-install -dm 755 "$PKGDIR"/usr/lib/vapoursynth
-ln -s ../libffms2.so "$PKGDIR"/usr/lib/vapoursynth/
+abinfo "Installing a symlink for VapourSynth ..."
+install -dvm755 "$PKGDIR"/usr/lib/vapoursynth
+ln -sv ../libffms2.so \
+    "$PKGDIR"/usr/lib/vapoursynth/

--- a/app-multimedia/ffms2/autobuild/defines
+++ b/app-multimedia/ffms2/autobuild/defines
@@ -4,4 +4,7 @@ PKGDEP="ffmpeg"
 PKGDES="A FFmpeg based library for easy frame accurate access"
 
 PKGBREAK="aegisub<=3.2.2-1"
-RECONF=0
+
+# FIXME: configure: error: source directory already configured; run "make
+# distclean" there first
+ABSHADOW=0

--- a/app-multimedia/ffms2/spec
+++ b/app-multimedia/ffms2/spec
@@ -1,5 +1,4 @@
-VER=2.23
-REL=4
-SRCS="tbl::https://github.com/FFMS/ffms2/archive/$VER.tar.gz"
-CHKSUMS="sha256::b09b2aa2b1c6f87f94a0a0dd8284b3c791cbe77f0f3df57af99ddebcd15273ed"
+VER=2.40
+SRCS="git::commit=tags/$VER::https://github.com/FFMS/ffms2"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10144"


### PR DESCRIPTION
Topic Description
-----------------

- ffms2: update to 2.40
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ffms2: 2.40

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffms2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
