### PR TITLE
ytmusicapi: update to 1.7.2

### DIFF
--- a/lang-python/ytmusicapi/spec
+++ b/lang-python/ytmusicapi/spec
@@ -1,4 +1,4 @@
-VER=1.5.1
+VER=1.7.2
 SRCS="tbl::https://pypi.io/packages/source/y/ytmusicapi/ytmusicapi-$VER.tar.gz"
-CHKSUMS="sha256::3c9bf092a1142d880299c7e8d50a7f2c277337001798823011876939cf53395b"
+CHKSUMS="sha256::0ba02ea66fa7379377d2dc3f067905b56b61150321b733d58ea4565085cb12f9"
 CHKUPDATE="anitya::id=80869"


### PR DESCRIPTION
Topic Description
-----------------

- ytmusicapi: update to 1.7.2
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ytmusicapi: 1.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ytmusicapi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
