### PR TITLE
fdkaac: update to 1.0.6

### DIFF
--- a/app-multimedia/fdkaac/spec
+++ b/app-multimedia/fdkaac/spec
@@ -1,4 +1,4 @@
-VER=1.0.1
+VER=1.0.6
 SRCS="tbl::https://github.com/nu774/fdkaac/archive/v$VER.tar.gz"
-CHKSUMS="sha256::ce9459111cee48c84b2e5e7154fa5a182c8ec1132da880656de3c1bc3bf2cc79"
+CHKSUMS="sha256::ed34c8dcae3d49d385e1ceaa380c5871cda744402358c61bcb49950a25bfae58"
 CHKUPDATE="anitya::id=14706"


### PR DESCRIPTION
Topic Description
-----------------

- fdkaac: update to 1.0.6
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- fdkaac: 1.0.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit fdkaac
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
