### PR TITLE
cuda: update to 12.5.0+555.42.02

### DIFF
--- a/app-devel/cuda/spec
+++ b/app-devel/cuda/spec
@@ -1,10 +1,10 @@
-CUDA_VER=12.4.0
-MIN_DRIVER_VER=550.54.14
+CUDA_VER=12.5.0
+MIN_DRIVER_VER=555.42.02
 VER=${CUDA_VER}+${MIN_DRIVER_VER}
 CHKUPDATE="anitya::id=13462"
 
 SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS__AMD64="sha256::e6a842f4eca9490575cdb68b6b1bb78d47b95a897de48dee292c431892e57d17"
+CHKSUMS__AMD64="sha256::90fcc7df48226434065ff12a4372136b40b9a4cbf0c8602bb763b745f22b7a99"
 
 SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
-CHKSUMS__ARM64="sha256::b12bfe6c36d32ecf009a6efb0024325c5fc389fca1143f5f377ae2555936e803"
+CHKSUMS__ARM64="sha256::e7b864c9ae27cef77cafc78614ec33cbb0a27606af9375deffa09c4269a07f04"


### PR DESCRIPTION
Topic Description
-----------------

- cuda: update to 12.5.0+555.42.02

Package(s) Affected
-------------------

- cuda: 12.5.0+555.42.02

Security Update?
----------------

No

Build Order
-----------

```
#buildit cuda
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
