### PR TITLE
alacritty: update to 0.13.2

### DIFF
--- a/app-utils/alacritty/autobuild/defines
+++ b/app-utils/alacritty/autobuild/defines
@@ -14,3 +14,6 @@ ABSPLITDBG=0
 
 # FIXME: Disable LTO on loongarch64 before LLVM 18 update
 NOLTO__LOONGARCH64=1
+
+# FIXME: FTBFS with LTO on mips64r6el
+NOLTO__MIPS64R6EL=1

--- a/app-utils/alacritty/spec
+++ b/app-utils/alacritty/spec
@@ -1,4 +1,4 @@
-VER=0.13.1
-SRCS="https://github.com/alacritty/alacritty/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::38a42e23e1e6faaa9e300347df3f7b58b6182908a701517aac6e296fbdf37451"
+VER=0.13.2
+SRCS="git::commit=tags/v$VER::https://github.com/alacritty/alacritty"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141678"


### PR DESCRIPTION
Topic Description
-----------------

- alacritty: update to 0.13.2
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- alacritty: 0.13.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit alacritty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
