### PR TITLE
qemu: fix loongson3 detection for mips64

### DIFF
--- a/app-network/vde2/autobuild/defines
+++ b/app-network/vde2/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME=vde2
 PKGSEC=net
-PKGDEP="bash libpcap openssl"
+PKGDEP="bash libpcap wolfssl"
 PKGDES="Virtual Distributed Ethernet for emulators like QEMU"
 
 AUTOTOOLS_AFTER="--enable-experimental"
-NOPARALLEL=1
 PKGEPOCH=1

--- a/app-network/vde2/spec
+++ b/app-network/vde2/spec
@@ -1,5 +1,4 @@
-VER=2.3.2
-REL=3
-SRCS="tbl::https://downloads.sourceforge.net/vde/vde2-$VER.tar.bz2"
-CHKSUMS="sha256::cbea9b7e03097f87a6b5e98b07890d2275848f1fe4b9fcda77b8994148bc9542"
+VER=2.3.3
+SRCS="git::commit=tags/v${VER}::https://github.com/virtualsquare/vde-2.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13642"

--- a/app-virtualization/qemu/01-shared/patches/0001-linux-user-mips64-target_elf-detect-and-use-EF_MIPS_.patch
+++ b/app-virtualization/qemu/01-shared/patches/0001-linux-user-mips64-target_elf-detect-and-use-EF_MIPS_.patch
@@ -1,0 +1,34 @@
+From 77b167e36f2a1dc1377952fc958b39dc181425ab Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Tue, 21 May 2024 14:06:17 +0800
+Subject: [PATCH] linux-user/mips64/target_elf: detect and use
+ EF_MIPS_MACH_LS3A
+
+An ELF file with this flag should be expected to have some
+Loongson-3A-exclusive instructions, unsupported by QEMU's
+default 5KEf CPU.
+---
+ linux-user/mips64/target_elf.h | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/linux-user/mips64/target_elf.h b/linux-user/mips64/target_elf.h
+index 5f2f2df29f..35458ff907 100644
+--- a/linux-user/mips64/target_elf.h
++++ b/linux-user/mips64/target_elf.h
+@@ -15,6 +15,13 @@ static inline const char *cpu_get_model(uint32_t eflags)
+     if ((eflags & EF_MIPS_MACH) == EF_MIPS_MACH_5900) {
+         return "R5900";
+     }
++    if (eflags & EF_MIPS_MACH_LS3A) {
++        if (eflags & EF_MIPS_NAN2008) {
++            return "Loongson-3A4000";
++        } else {
++            return "Loongson-3A1000";
++        }
++    }
+     return "5KEf";
+ }
+ #endif
+-- 
+2.45.1
+

--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,4 +1,5 @@
 VER=9.0.0
+REL=1
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz \
       file::rename=edk2-loongarch64-code.fd::https://github.com/AOSC-Dev/LoongArchQemuVirtFirmware/releases/download/20240430-1/QEMU_EFI.fd \
       file::rename=edk2-loongarch64-vars.fd::https://github.com/AOSC-Dev/LoongArchQemuVirtFirmware/releases/download/20240430-1/QEMU_VARS.fd"

--- a/app-virtualization/virtualbox/spec
+++ b/app-virtualization/virtualbox/spec
@@ -1,6 +1,7 @@
 VER=7.0.16
 # Note: Sometimes Oracle seems to release fix-up tarballs.
 VBOX_REV=
+REL=1
 UBUNTU_VBOX_VER="162802~Ubuntu~jammy"
 SRCS="tbl::https://download.virtualbox.org/virtualbox/$VER/VirtualBox-${VER}${VBOX_REV}.tar.bz2 \
       file::rename=virtualbox.deb::https://download.virtualbox.org/virtualbox/$VER/virtualbox-${VER%.*}_${VER}-${UBUNTU_VBOX_VER}_amd64.deb \

--- a/groups/openssl-rebuilds
+++ b/groups/openssl-rebuilds
@@ -249,7 +249,6 @@ app-utils/uboot-tools
 app-web/uget
 app-utils/unshield
 app-admin/vboot-utils
-app-network/vde2
 app-virtualization/virtualbox
 app-network/vsftpd
 app-web/w3m

--- a/runtime-cryptography/wolfssl/autobuild/defines
+++ b/runtime-cryptography/wolfssl/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=wolfssl
+PKGSEC=libs
+PKGDEP="glibc"
+PKGDES="A TLS/SSL library for embedded and cloud environments"
+
+AUTOTOOLS_AFTER="--enable-all \
+                 --enable-dtls13 \
+                 --enable-dtls-mtu \
+                 --disable-examples \
+                 --disable-static"

--- a/runtime-cryptography/wolfssl/autobuild/patches/0001-sp_int-add-MIPS64R6-support.patch
+++ b/runtime-cryptography/wolfssl/autobuild/patches/0001-sp_int-add-MIPS64R6-support.patch
@@ -1,0 +1,234 @@
+From 31f5d2043ef433e9f6f730c9677ea93eea84a70f Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Tue, 4 Jun 2024 18:00:58 +0800
+Subject: [PATCH] sp_int: add MIPS64R6 support
+
+---
+ configure.ac           |   2 +-
+ wolfcrypt/src/sp_int.c | 190 +++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 191 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index dec2b1e..87024a3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -7960,7 +7960,7 @@ if test "$ENABLED_SP_MATH_ALL" = "yes" && test "$ENABLED_ASM" != "no"; then
+   *ppc* | *powerpc*)
+     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_PPC"
+     ;;
+-  *mips64*)
++  *mips*64*)
+     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_MIPS64"
+     ;;
+   *mips*)
+diff --git a/wolfcrypt/src/sp_int.c b/wolfcrypt/src/sp_int.c
+index 3a6884a..d59f6e4 100644
+--- a/wolfcrypt/src/sp_int.c
++++ b/wolfcrypt/src/sp_int.c
+@@ -3778,6 +3778,8 @@ static WC_INLINE sp_int_digit sp_div_word(sp_int_digit hi, sp_int_digit lo,
+     #endif /* WOLFSSL_SP_PPC && SP_WORD_SIZE == 64 */
+ 
+     #if defined(WOLFSSL_SP_MIPS64) && SP_WORD_SIZE == 64
++
++        #if !defined(__mips_isa_rev) || (__mips_isa_rev < 6)
+ /*
+  * CPU: MIPS 64-bit
+  */
+@@ -3973,6 +3975,194 @@ static WC_INLINE sp_int_digit sp_div_word(sp_int_digit hi, sp_int_digit lo,
+         : [a] "r" (va), [b] "r" (vb), [c] "r" (vc)       \
+         : "$12"                                          \
+     )
++        #else
++/*
++ * CPU: MIPSR6 64-bit
++ */
++
++/* Multiply va by vb and store double size result in: vh | vl */
++#define SP_ASM_MUL(vl, vh, va, vb)                       \
++    __asm__ __volatile__ (                               \
++        "dmulu	%[l], %[a], %[b]	\n\t"            \
++        "dmuhu	%[h], %[a], %[b]	\n\t"            \
++        : [h] "+r" (vh), [l] "+r" (vl)                   \
++        : [a] "r" (va), [b] "r" (vb)                     \
++        : "memory"                                       \
++    )
++/* Multiply va by vb and store double size result in: vo | vh | vl */
++#define SP_ASM_MUL_SET(vl, vh, vo, va, vb)               \
++    __asm__ __volatile__ (                               \
++        "dmulu	%[l], %[a], %[b]	\n\t"            \
++        "dmuhu	%[h], %[a], %[b]	\n\t"            \
++        "move	%[o], $0		\n\t"            \
++        : [l] "+r" (vl), [h] "+r" (vh), [o] "=r" (vo)    \
++        : [a] "r" (va), [b] "r" (vb)                     \
++    )
++/* Multiply va by vb and add double size result into: vo | vh | vl */
++#define SP_ASM_MUL_ADD(vl, vh, vo, va, vb)               \
++    __asm__ __volatile__ (                               \
++        "dmulu	$10, %[a], %[b]		\n\t"            \
++        "dmuhu	$11, %[a], %[b]		\n\t"            \
++        "daddu	%[l], %[l], $10		\n\t"            \
++        "sltu	$12, %[l], $10		\n\t"            \
++        "daddu	%[h], %[h], $12		\n\t"            \
++        "sltu	$12, %[h], $12		\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        "daddu	%[h], %[h], $11		\n\t"            \
++        "sltu	$12, %[h], $11		\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        : [l] "+r" (vl), [h] "+r" (vh), [o] "+r" (vo)    \
++        : [a] "r" (va), [b] "r" (vb)                     \
++        : "$10", "$11", "$12"                            \
++    )
++/* Multiply va by vb and add double size result into: vh | vl */
++#define SP_ASM_MUL_ADD_NO(vl, vh, va, vb)                \
++    __asm__ __volatile__ (                               \
++        "dmulu	$10, %[a], %[b]		\n\t"            \
++        "dmuhu	$11, %[a], %[b]		\n\t"            \
++        "daddu	%[l], %[l], $10		\n\t"            \
++        "sltu	$12, %[l], $10		\n\t"            \
++        "daddu	%[h], %[h], $11		\n\t"            \
++        "daddu	%[h], %[h], $12		\n\t"            \
++        : [l] "+r" (vl), [h] "+r" (vh)                   \
++        : [a] "r" (va), [b] "r" (vb)                     \
++        : "$10", "$11", "$12"                            \
++    )
++/* Multiply va by vb and add double size result twice into: vo | vh | vl */
++#define SP_ASM_MUL_ADD2(vl, vh, vo, va, vb)              \
++    __asm__ __volatile__ (                               \
++        "dmulu	$10, %[a], %[b]		\n\t"            \
++        "dmuhu	$11, %[a], %[b]		\n\t"            \
++        "daddu	%[l], %[l], $10		\n\t"            \
++        "sltu	$12, %[l], $10		\n\t"            \
++        "daddu	%[h], %[h], $12		\n\t"            \
++        "sltu	$12, %[h], $12		\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        "daddu	%[h], %[h], $11		\n\t"            \
++        "sltu	$12, %[h], $11		\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        "daddu	%[l], %[l], $10		\n\t"            \
++        "sltu	$12, %[l], $10		\n\t"            \
++        "daddu	%[h], %[h], $12		\n\t"            \
++        "sltu	$12, %[h], $12		\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        "daddu	%[h], %[h], $11		\n\t"            \
++        "sltu	$12, %[h], $11		\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        : [l] "+r" (vl), [h] "+r" (vh), [o] "+r" (vo)    \
++        : [a] "r" (va), [b] "r" (vb)                     \
++        : "$10", "$11", "$12"                            \
++    )
++/* Multiply va by vb and add double size result twice into: vo | vh | vl
++ * Assumes first add will not overflow vh | vl
++ */
++#define SP_ASM_MUL_ADD2_NO(vl, vh, vo, va, vb)           \
++    __asm__ __volatile__ (                               \
++        "dmulu	$10, %[a], %[b]		\n\t"            \
++        "dmuhu	$11, %[a], %[b]		\n\t"            \
++        "daddu	%[l], %[l], $10		\n\t"            \
++        "sltu	$12, %[l], $10		\n\t"            \
++        "daddu	%[h], %[h], $11		\n\t"            \
++        "daddu	%[h], %[h], $12		\n\t"            \
++        "daddu	%[l], %[l], $10		\n\t"            \
++        "sltu	$12, %[l], $10		\n\t"            \
++        "daddu	%[h], %[h], $12		\n\t"            \
++        "sltu	$12, %[h], $12		\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        "daddu	%[h], %[h], $11		\n\t"            \
++        "sltu	$12, %[h], $11		\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        : [l] "+r" (vl), [h] "+r" (vh), [o] "+r" (vo)    \
++        : [a] "r" (va), [b] "r" (vb)                     \
++        : "$10", "$11", "$12"                            \
++    )
++/* Square va and store double size result in: vh | vl */
++#define SP_ASM_SQR(vl, vh, va)                           \
++    __asm__ __volatile__ (                               \
++        "dmulu	%[l], %[a], %[a]	\n\t"            \
++        "dmuhu	%[h], %[a], %[a]	\n\t"            \
++        : [h] "+r" (vh), [l] "+r" (vl)                   \
++        : [a] "r" (va)                                   \
++        : "memory"                                       \
++    )
++/* Square va and add double size result into: vo | vh | vl */
++#define SP_ASM_SQR_ADD(vl, vh, vo, va)                   \
++    __asm__ __volatile__ (                               \
++        "dmulu	$10, %[a], %[a]		\n\t"            \
++        "dmuhu	$11, %[a], %[a]		\n\t"            \
++        "daddu	%[l], %[l], $10		\n\t"            \
++        "sltu	$12, %[l], $10		\n\t"            \
++        "daddu	%[h], %[h], $12		\n\t"            \
++        "sltu	$12, %[h], $12		\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        "daddu	%[h], %[h], $11		\n\t"            \
++        "sltu	$12, %[h], $11		\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        : [l] "+r" (vl), [h] "+r" (vh), [o] "+r" (vo)    \
++        : [a] "r" (va)                                   \
++        : "$10", "$11", "$12"                            \
++    )
++/* Square va and add double size result into: vh | vl */
++#define SP_ASM_SQR_ADD_NO(vl, vh, va)                    \
++    __asm__ __volatile__ (                               \
++        "dmulu	$10, %[a], %[a]		\n\t"            \
++        "dmuhu	$11, %[a], %[a]		\n\t"            \
++        "daddu	%[l], %[l], $10		\n\t"            \
++        "sltu	$12, %[l], $10		\n\t"            \
++        "daddu	%[h], %[h], $11		\n\t"            \
++        "daddu	%[h], %[h], $12		\n\t"            \
++        : [l] "+r" (vl), [h] "+r" (vh)                   \
++        : [a] "r" (va)                                   \
++        : "$10", "$11", "$12"                            \
++    )
++/* Add va into: vh | vl */
++#define SP_ASM_ADDC(vl, vh, va)                          \
++    __asm__ __volatile__ (                               \
++        "daddu	%[l], %[l], %[a]	\n\t"            \
++        "sltu	$12, %[l], %[a]		\n\t"            \
++        "daddu	%[h], %[h], $12		\n\t"            \
++        : [l] "+r" (vl), [h] "+r" (vh)                   \
++        : [a] "r" (va)                                   \
++        : "$12"                                          \
++    )
++/* Sub va from: vh | vl */
++#define SP_ASM_SUBB(vl, vh, va)                          \
++    __asm__ __volatile__ (                               \
++        "move	$12, %[l]		\n\t"            \
++        "dsubu	%[l], $12, %[a]		\n\t"            \
++        "sltu	$12, $12, %[l]		\n\t"            \
++        "dsubu	%[h], %[h], $12		\n\t"            \
++        : [l] "+r" (vl), [h] "+r" (vh)                   \
++        : [a] "r" (va)                                   \
++        : "$12"                                          \
++    )
++/* Add two times vc | vb | va into vo | vh | vl */
++#define SP_ASM_ADD_DBL_3(vl, vh, vo, va, vb, vc)         \
++    __asm__ __volatile__ (                               \
++        "daddu	%[l], %[l], %[a]	\n\t"            \
++        "sltu	$12, %[l], %[a]		\n\t"            \
++        "daddu	%[h], %[h], $12		\n\t"            \
++        "sltu	$12, %[h], $12		\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        "daddu	%[h], %[h], %[b]	\n\t"            \
++        "sltu	$12, %[h], %[b]		\n\t"            \
++        "daddu	%[o], %[o], %[c]	\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        "daddu	%[l], %[l], %[a]	\n\t"            \
++        "sltu	$12, %[l], %[a]		\n\t"            \
++        "daddu	%[h], %[h], $12		\n\t"            \
++        "sltu	$12, %[h], $12		\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        "daddu	%[h], %[h], %[b]	\n\t"            \
++        "sltu	$12, %[h], %[b]		\n\t"            \
++        "daddu	%[o], %[o], %[c]	\n\t"            \
++        "daddu	%[o], %[o], $12		\n\t"            \
++        : [l] "+r" (vl), [h] "+r" (vh), [o] "+r" (vo)    \
++        : [a] "r" (va), [b] "r" (vb), [c] "r" (vc)       \
++        : "$12"                                          \
++    )
++
++    #endif /* !defined(__mips_isa_rev) || (__mips_isa_rev < 6) */
+ 
+ #define SP_INT_ASM_AVAILABLE
+ 
+-- 
+2.45.1
+

--- a/runtime-cryptography/wolfssl/spec
+++ b/runtime-cryptography/wolfssl/spec
@@ -1,0 +1,4 @@
+VER=5.7.0
+SRCS="git::commit=tags/v${VER}-stable::https://github.com/wolfSSL/wolfssl"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=21631"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: fix loongson3 detection for mips64

Package(s) Affected
-------------------

- qemu: 9.0.0-1
- qemu-aarch64-static: 9.0.0-1
- qemu-alpha-static: 9.0.0-1
- qemu-arm-static: 9.0.0-1
- qemu-armeb-static: 9.0.0-1
- qemu-cris-static: 9.0.0-1
- qemu-i386-static: 9.0.0-1
- qemu-loongarch64-static: 9.0.0-1
- qemu-m68k-static: 9.0.0-1
- qemu-microblaze-static: 9.0.0-1
- qemu-microblazeel-static: 9.0.0-1
- qemu-mips-static: 9.0.0-1
- qemu-mips64-static: 9.0.0-1
- qemu-mips64el-static: 9.0.0-1
- qemu-mipsel-static: 9.0.0-1
- qemu-mipsn32-static: 9.0.0-1
- qemu-mipsn32el-static: 9.0.0-1
- qemu-nios2-static: 9.0.0-1
- qemu-or32-static: 9.0.0-1
- qemu-ppc-static: 9.0.0-1
- qemu-ppc64-static: 9.0.0-1
- qemu-ppc64le-static: 9.0.0-1
- qemu-riscv32-static: 9.0.0-1
- qemu-riscv64-static: 9.0.0-1
- qemu-s390x-static: 9.0.0-1
- qemu-sh4-static: 9.0.0-1
- qemu-sh4eb-static: 9.0.0-1
- qemu-sparc-static: 9.0.0-1
- qemu-sparc32plus-static: 9.0.0-1
- qemu-sparc64-static: 9.0.0-1
- qemu-user-static: 9.0.0-1
- qemu-x86-64-static: 9.0.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wolfssl vde2 qemu virtualbox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
