### PR TITLE
perl-exporter-tiny: update to 1.006002

### DIFF
--- a/lang-perl/perl-exporter-tiny/spec
+++ b/lang-perl/perl-exporter-tiny/spec
@@ -1,5 +1,4 @@
-VER=1.001+001
+VER=1.006002
 SRCS="tbl::https://search.cpan.org/CPAN/authors/id/T/TO/TOBYINK/Exporter-Tiny-${VER/+/_}.tar.gz"
-CHKSUMS="sha256::4028af291bf39cadffd5aa4e03bb93c1c753b0beb545bba89c5920c6d20ca7fd"
-REL=2
+CHKSUMS="sha256::6f295e2cbffb1dbc15bdb9dadc341671c1e0cd2bdf2d312b17526273c322638d"
 CHKUPDATE="anitya::id=11846"


### PR DESCRIPTION
Topic Description
-----------------

- perl-exporter-tiny: update to 1.006002
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-exporter-tiny: 1.006002

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-exporter-tiny
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
