### PR TITLE
perl-xml-libxml: update to 2.0210

### DIFF
--- a/lang-perl/perl-xml-libxml/spec
+++ b/lang-perl/perl-xml-libxml/spec
@@ -1,5 +1,4 @@
-VER=2.0201
+VER=2.0210
 SRCS="tbl::https://search.cpan.org/CPAN/authors/id/S/SH/SHLOMIF/XML-LibXML-$VER.tar.gz"
-CHKSUMS="sha256::e008700732502b3f1f0890696ec6e2dc70abf526cd710efd9ab7675cae199bc2"
-REL=2
+CHKSUMS="sha256::a29bf3f00ab9c9ee04218154e0afc8f799bf23674eb99c1a9ed4de1f4059a48d"
 CHKUPDATE="anitya::id=3527"


### PR DESCRIPTION
Topic Description
-----------------

- perl-xml-libxml: update to 2.0210
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-xml-libxml: 2.0210

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-xml-libxml
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
