### PR TITLE
ktoblzcheck: update to 1.57

### DIFF
--- a/runtime-productivity/ktoblzcheck/autobuild/defines
+++ b/runtime-productivity/ktoblzcheck/autobuild/defines
@@ -1,5 +1,9 @@
 PKGNAME=ktoblzcheck
 PKGSEC=libs
-PKGDEP="gcc-runtime glibc python-3"
+PKGDEP="gcc-runtime glibc python-3 openpyxl"
 BUILDDEP="doxygen"
 PKGDES="A library to check account numbers and bank codes of German and other banks"
+
+# FIXME: Build fails mysteriously with parallelism.
+ABTYPE=cmake
+NOPARALLEL=1

--- a/runtime-productivity/ktoblzcheck/spec
+++ b/runtime-productivity/ktoblzcheck/spec
@@ -1,5 +1,4 @@
-VER=1.53
+VER=1.57
 SRCS="tbl::https://sourceforge.net/projects/ktoblzcheck/files/ktoblzcheck-$VER.tar.gz"
-CHKSUMS="sha256::18b9118556fe83240f468f770641d2578f4ff613cdcf0a209fb73079ccb70c55"
+CHKSUMS="sha256::4c3b782e5d8e31e219c3e2ece0c6e84a93929ae0b2f36080d4c183a644d05672"
 CHKUPDATE="anitya::id=14983"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- ktoblzcheck: update to 1.57
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ktoblzcheck: 1.57

Security Update?
----------------

No

Build Order
-----------

```
#buildit ktoblzcheck
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
