### PR TITLE
open-iscsi: update to 2.1.9

### DIFF
--- a/app-admin/open-iscsi/spec
+++ b/app-admin/open-iscsi/spec
@@ -1,6 +1,5 @@
-VER=2.1.8
+VER=2.1.9
 SRCS="https://github.com/open-iscsi/open-iscsi/archive/$VER.tar.gz"
-CHKSUMS="sha256::9565bdf6b68b223e1e0d455d9a04d7536724a3f5b5a254e9398d06b2a0c6b6d2"
+CHKSUMS="sha256::60e2a1e3058a8af7f702e86a5a0511b05b8754d29d3d2df4e0e301399b5cf70a"
 CHKUPDATE="anitya::id=10861"
 SUBDIR="open-iscsi-$VER"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- open-iscsi: update to 2.1.9
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- open-iscsi: 2.1.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit open-iscsi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
