### PR TITLE
ocaml-integers: update to 0.7.0

### DIFF
--- a/lang-ocaml/ocaml-integers/autobuild/defines
+++ b/lang-ocaml/ocaml-integers/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=ocaml-integers
 PKGSEC=ocaml
 PKGDEP="ocaml"
-BUILDDEP="findlib dune ocamlbuild opam"
+BUILDDEP="findlib dune ocamlbuild opam ocaml-stdlib-shims"
 PKGDES="Various signed and unsigned integer types for OCaml"
 
 NOSTATIC=0

--- a/lang-ocaml/ocaml-integers/spec
+++ b/lang-ocaml/ocaml-integers/spec
@@ -1,5 +1,4 @@
-VER=0.4.0
-REL=1
+VER=0.7.0
 SRCS="tbl::https://github.com/ocamllabs/ocaml-integers/archive/$VER.tar.gz"
-CHKSUMS="sha256::ba6e087606c622533ecca9dc4c0917a3cc183e73e3e7d8511b68e21183ef913f"
+CHKSUMS="sha256::8bb517fa9a1818246eb8c4ce34ee1489fbebb4b92defa3a25d13cab8d23ec685"
 CHKUPDATE="anitya::id=16707"


### PR DESCRIPTION
Topic Description
-----------------

- ocaml-integers: update to 0.7.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ocaml-integers: 0.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ocaml-integers
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
