### PR TITLE
perl-dbd-mysql: update to 5.005

### DIFF
--- a/lang-perl/perl-dbd-mysql/spec
+++ b/lang-perl/perl-dbd-mysql/spec
@@ -1,5 +1,4 @@
-VER=4.050
+VER=5.005
 SRCS="tbl::https://github.com/perl5-dbi/DBD-mysql/archive/${VER/./_}.tar.gz"
-CHKSUMS="sha256::55f31f02e9c0e11f7fd4cdb4ac942e2c6aea25499a1141db80536e6df653e2fa"
-REL=2
+CHKSUMS="sha256::fc4b32f088e8a7f45fe4cc92ebc261425f5bfb7b1ef34885b4279b621f99d531"
 CHKUPDATE="anitya::id=2807"


### PR DESCRIPTION
Topic Description
-----------------

- perl-dbd-mysql: update to 5.005
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-dbd-mysql: 5.005

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-dbd-mysql
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
