### PR TITLE
librsync: update to 2.3.4

### DIFF
--- a/runtime-network/librsync/spec
+++ b/runtime-network/librsync/spec
@@ -1,4 +1,4 @@
-VER=2.3.2
+VER=2.3.4
 SRCS="tbl::https://github.com/librsync/librsync/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::ef8ce23df38d5076d25510baa2cabedffbe0af460d887d86c2413a1c2b0c676f"
+CHKSUMS="sha256::a0dedf9fff66d8e29e7c25d23c1f42beda2089fb4eac1b36e6acd8a29edfbd1f"
 CHKUPDATE="anitya::id=6309"


### PR DESCRIPTION
Topic Description
-----------------

- librsync: update to 2.3.4
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- librsync: 2.3.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit librsync
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
