### PR TITLE
flatpak-builder: update to 1.4.3

### DIFF
--- a/app-admin/appstream/01-appstream/defines
+++ b/app-admin/appstream/01-appstream/defines
@@ -1,6 +1,6 @@
 PKGNAME=appstream
 PKGSEC=admin
-PKGDEP="libxml2 polkit protobuf snowball xapian-core yaml libxmlb"
+PKGDEP="libxml2 polkit protobuf snowball xapian-core yaml libxmlb librsvg"
 BUILDDEP="docbook-xsl gobject-introspection gperf gtk-doc intltool qt-5 \
           xmlto vala"
 PKGDES="Provides a standard for creating app stores across distributions"

--- a/app-admin/appstream/spec
+++ b/app-admin/appstream/spec
@@ -1,5 +1,5 @@
 VER=0.16.0
-REL=1
+REL=2
 SRCS="tbl::https://www.freedesktop.org/software/appstream/releases/AppStream-$VER.tar.xz"
 CHKSUMS="sha256::6430cce80ddfcda5a35270edf80f71e78f437ca5104183f765af9f3ed048e170"
 CHKUPDATE="anitya::id=10385"

--- a/app-devel/flatpak-builder/spec
+++ b/app-devel/flatpak-builder/spec
@@ -1,5 +1,4 @@
-VER=1.0.14
-REL=1
+VER=1.4.3
 SRCS="tbl::https://github.com/flatpak/flatpak-builder/releases/download/$VER/flatpak-builder-$VER.tar.xz"
-CHKSUMS="sha256::69b65af4f63804127518c545184f9dfc9a9358cdedaabef2b1e50623ae2b8d8b"
+CHKSUMS="sha256::d8e264e939922cd25a80e0dc795e6ce9e249d1c33738a564f6fe5ca7816beade"
 CHKUPDATE="anitya::id=16046"


### PR DESCRIPTION
Topic Description
-----------------

- flatpak-builder: update to 1.4.3
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- flatpak-builder: 1.4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit appstream flatpak-builder
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
