### PR TITLE
libaccounts-qt: update to 1.17

### DIFF
--- a/runtime-desktop/libaccounts-glib/spec
+++ b/runtime-desktop/libaccounts-glib/spec
@@ -1,5 +1,4 @@
-VER=1.24
-REL=3
-SRCS="tbl::https://gitlab.com/accounts-sso/libaccounts-glib/-/archive/$VER/libaccounts-glib-$VER.tar.gz"
-CHKSUMS="sha256::eebb1c6debfcf929efb388a0f28d8cc8ec9b32f273e4abe4224a33e5d299cd73"
+VER=1.27
+SRCS="git::commit=tags/VERSION_$VER::https://gitlab.com/accounts-sso/libaccounts-glib"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6532"

--- a/runtime-desktop/libaccounts-qt/spec
+++ b/runtime-desktop/libaccounts-qt/spec
@@ -1,5 +1,4 @@
-VER=1.16
-REL=2
+VER=1.17
 SRCS="git::commit=tags/VERSION_$VER::https://gitlab.com/accounts-sso/libaccounts-qt.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6531"


### PR DESCRIPTION
Topic Description
-----------------

- libaccounts-qt: update to 1.17
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libaccounts-qt: 1:1.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit libaccounts-glib libaccounts-qt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
