### PR TITLE
lua-socket: update to 3.1.0

### DIFF
--- a/lang-lua/lua-socket/spec
+++ b/lang-lua/lua-socket/spec
@@ -1,5 +1,4 @@
-VER=3.0+rc1
-REL=2
+VER=3.1.0
 SRCS="tbl::https://github.com/diegonehab/luasocket/archive/v${VER/+/-}.tar.gz"
-CHKSUMS="sha256::8b67d9b5b545e1b694753dab7bd6cdbc24c290f2b21ba1e14c77b32817ea1249"
+CHKSUMS="sha256::bf033aeb9e62bcaa8d007df68c119c966418e8c9ef7e4f2d7e96bddeca9cca6e"
 CHKUPDATE="anitya::id=6302"


### PR DESCRIPTION
Topic Description
-----------------

- lua-socket: update to 3.1.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lua-socket: 3.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lua-socket
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
