### PR TITLE
hicolor-icon-theme: update to 0.18

### DIFF
--- a/runtime-data/hicolor-icon-theme/spec
+++ b/runtime-data/hicolor-icon-theme/spec
@@ -1,5 +1,4 @@
-VER=0.17
-REL=2
+VER=0.18
 SRCS="tbl::https://icon-theme.freedesktop.org/releases/hicolor-icon-theme-$VER.tar.xz"
-CHKSUMS="sha256::317484352271d18cbbcfac3868eab798d67fff1b8402e740baa6ff41d588a9d8"
+CHKSUMS="sha256::db0e50a80aa3bf64bb45cbca5cf9f75efd9348cf2ac690b907435238c3cf81d7"
 CHKUPDATE="anitya::id=1316"


### PR DESCRIPTION
Topic Description
-----------------

- hicolor-icon-theme: update to 0.18
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- hicolor-icon-theme: 0.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit hicolor-icon-theme
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
