### PR TITLE
perl-datetime-timezone: update to 2.62

### DIFF
--- a/lang-perl/perl-datetime-timezone/spec
+++ b/lang-perl/perl-datetime-timezone/spec
@@ -1,5 +1,4 @@
-VER=2.39
+VER=2.62
 SRCS="tbl::https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/DateTime-TimeZone-$VER.tar.gz"
-CHKSUMS='sha256::65a49083bf465b42c6a65df575efaceb87b5ba5a997d4e91e6ddba57190c8fca'
-REL=1
+CHKSUMS="sha256::6214f9c9c8dfa2000bae912ef2b8ebc5b163a83a0b5b2a82705162dad63466fa"
 CHKUPDATE="anitya::id=2801"


### PR DESCRIPTION
Topic Description
-----------------

- perl-datetime-timezone: update to 2.62
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-datetime-timezone: 2.62

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-datetime-timezone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
