### PR TITLE
cereal: update to 1.3.2

### DIFF
--- a/runtime-common/cereal/spec
+++ b/runtime-common/cereal/spec
@@ -1,4 +1,4 @@
-VER=1.3.0
+VER=1.3.2
 SRCS="tbl::https://github.com/USCiLab/cereal/archive/refs/tags/v$VER.tar.gz"
 CHKUPDATE="anitya::id=11606"
-CHKSUMS="sha256::329ea3e3130b026c03a4acc50e168e7daff4e6e661bc6a7dfec0d77b570851d5"
+CHKSUMS="sha256::16a7ad9b31ba5880dac55d62b5d6f243c3ebc8d46a3514149e56b5e7ea81f85f"


### PR DESCRIPTION
Topic Description
-----------------

- cereal: update to 1.3.2
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cereal: 1.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cereal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
