### PR TITLE
memcached: update to 1.6.27

### DIFF
--- a/app-admin/memcached/autobuild/overrides/usr/lib/sysusers.d/memcached.conf
+++ b/app-admin/memcached/autobuild/overrides/usr/lib/sysusers.d/memcached.conf
@@ -1,0 +1,2 @@
+g    memcached  88
+u    memcached  88:88 "memcached daemon owner" /var/lib/memcached  /bin/bash

--- a/app-admin/memcached/autobuild/postinst
+++ b/app-admin/memcached/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Creating user and group for memcached ..."
+systemd-sysusers memcached.conf

--- a/app-admin/memcached/autobuild/usergroup
+++ b/app-admin/memcached/autobuild/usergroup
@@ -1,2 +1,0 @@
-group memcached 88
-user memcached 88 memcached /var/lib/memcached "memcached daemon owner" /bin/bash

--- a/app-admin/memcached/spec
+++ b/app-admin/memcached/spec
@@ -1,5 +1,4 @@
-VER=1.6.12
-SRCS="https://github.com/memcached/memcached/archive/$VER.tar.gz"
-CHKSUMS="sha256::7102f9f86c32047b5a4295a3c4622478b39e5c85bddf1aacb534fd0923135319"
+VER=1.6.27
+SRCS="git::commit=$VER;copy-repo=true::https://github.com/memcached/memcached"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1965"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- memcached: update to 1.6.27
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- memcached: 1.6.27

Security Update?
----------------

No

Build Order
-----------

```
#buildit memcached
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
