### PR TITLE
pyyaml: update to 6.0.1

### DIFF
--- a/lang-python/pyyaml/autobuild/defines
+++ b/lang-python/pyyaml/autobuild/defines
@@ -1,6 +1,9 @@
 PKGNAME=pyyaml
 PKGSEC=python
-PKGDEP="python-2 python-3 yaml"
+PKGDEP="python-3 yaml pathlib"
+BUILDDEP="cython-0.29 python-build python-installer wheel"
 PKGDES="Python bindings for YAML"
+
+ABTYPE=pep517
 
 PKGEPOCH=1

--- a/lang-python/pyyaml/autobuild/prepare
+++ b/lang-python/pyyaml/autobuild/prepare
@@ -1,1 +1,0 @@
-chmod a-s "$SRCDIR"

--- a/lang-python/pyyaml/spec
+++ b/lang-python/pyyaml/spec
@@ -1,5 +1,4 @@
-VER=5.3.1
+VER=6.0.1
 SRCS="tbl::https://files.pythonhosted.org/packages/source/P/PyYAML/PyYAML-$VER.tar.gz"
-CHKSUMS="sha256::b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"
+CHKSUMS="sha256::bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"
 CHKUPDATE="anitya::id=48867"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- pyyaml: update to 6.0.1
    - Disable Python 2 binding as it is no longer supported.
    - Use Cython 0.29 as Cython 3 is not yet supported.
    - Use pep517 build type.

Package(s) Affected
-------------------

- pyyaml: 6.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyyaml
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
