### PR TITLE
bpftrace: update to 0.20.4

### DIFF
--- a/app-admin/bpftrace/spec
+++ b/app-admin/bpftrace/spec
@@ -1,4 +1,4 @@
-VER=0.20.3
+VER=0.20.4
 SRCS="tbl::https://github.com/iovisor/bpftrace/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::29057213d253f893590b3e0a358c9382ec8ddaa6efd1af500aaaf297d23beafc"
+CHKSUMS="sha256::7182c59db82dd4eac69fc74d6eb43656e2b45795df0a89840ae0456966d985da"
 CHKUPDATE="anitya::id=141354"


### PR DESCRIPTION
Topic Description
-----------------

- bpftrace: update to 0.20.4
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- bpftrace: 0.20.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit bpftrace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
