### PR TITLE
perl-email-mime-encodings: update to 1.317

### DIFF
--- a/lang-perl/perl-email-mime-encodings/spec
+++ b/lang-perl/perl-email-mime-encodings/spec
@@ -1,5 +1,4 @@
-VER=1.315
-REL=4
+VER=1.317
 SRCS="tbl::https://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Email-MIME-Encodings-$VER.tar.gz"
-CHKSUMS="sha256::4c71045507b31ec853dd60152b40e33ba3741779c0f49bb143b50cf8d243ab5c"
+CHKSUMS="sha256::4a9a41671a9d1504c4da241be419a9503fa3486262526edb81eca9e2ebea0baf"
 CHKUPDATE="anitya::id=11940"


### PR DESCRIPTION
Topic Description
-----------------

- perl-email-mime-encodings: update to 1.317
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-email-mime-encodings: 1.317

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-email-mime-encodings
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
