### PR TITLE
opencc: update to 1.1.7

### DIFF
--- a/app-i18n/opencc/spec
+++ b/app-i18n/opencc/spec
@@ -1,5 +1,4 @@
-VER=1.1.3
-REL=5
+VER=1.1.7
 SRCS="tbl::https://github.com/BYVoid/OpenCC/archive/ver.$VER.tar.gz"
-CHKSUMS="sha256::99a9af883b304f11f3b0f6df30d9fb4161f15b848803f9ff9c65a96d59ce877f"
+CHKSUMS="sha256::80a12675094a0cac90e70ee530e936dc76ca0953cb0443f7283c2b558635e4fe"
 CHKUPDATE="anitya::id=7230"


### PR DESCRIPTION
Topic Description
-----------------

- opencc: update to 1.1.7
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- opencc: 1:1.1.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit opencc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
