### PR TITLE
wimlib: update to 1.14.4

### DIFF
--- a/app-utils/wimlib/autobuild/defines
+++ b/app-utils/wimlib/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=wimlib
 PKGSEC=utils
-PKGDEP="openssl fuse libxml2 ntfs-3g"
+PKGDEP="openssl fuse-3 libxml2 ntfs-3g"
 PKGSUG="cdrkit mtools syslinux cabextract"
-PKGDES="An open source, cross-platform library for creating, extracting, and modifying Windows Imaging (WIM) archives."
+PKGDES="Tools and libraries for creating, extracting, and modifying Windows Imaging (WIM) archives"
 
-AUTOTOOLS_AFTER="--with-libcrypto --with-fuse --with-ntfs-3g"
+AUTOTOOLS_AFTER="--with-fuse \
+                 --with-ntfs-3g"
 RECONF=0

--- a/app-utils/wimlib/spec
+++ b/app-utils/wimlib/spec
@@ -1,5 +1,4 @@
-VER=1.13.6
+VER=1.14.4
 SRCS="tbl::https://wimlib.net/downloads/wimlib-$VER.tar.gz"
-CHKSUMS="sha256::0a0f9c1c0d3a2a76645535aeb0f62e03fc55914ca65f3a4d5599bb8b0260dbd9"
+CHKSUMS="sha256::3633db2b6c8b255eb86d3bf3df3059796bd1f08e50b8c9728c7eb66662e51300"
 CHKUPDATE="anitya::id=16320"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- wimlib: update to 1.14.4
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wimlib: 1.14.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit wimlib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
