### PR TITLE
fribidi: update to 1.0.14

### DIFF
--- a/app-scientific/fribidi/spec
+++ b/app-scientific/fribidi/spec
@@ -1,4 +1,4 @@
-VER=1.0.10
+VER=1.0.14
 SRCS="tbl::https://github.com/fribidi/fribidi/releases/download/v$VER/fribidi-$VER.tar.xz"
-CHKSUMS="sha256::7f1c687c7831499bcacae5e8675945a39bacbad16ecaa945e9454a32df653c01"
+CHKSUMS="sha256::76ae204a7027652ac3981b9fa5817c083ba23114340284c58e756b259cd2259a"
 CHKUPDATE="anitya::id=857"


### PR DESCRIPTION
Topic Description
-----------------

- fribidi: update to 1.0.14
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- fribidi: 1.0.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit fribidi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
