### PR TITLE
python-xlib: update to 0.33

### DIFF
--- a/lang-python/python-xlib/autobuild/defines
+++ b/lang-python/python-xlib/autobuild/defines
@@ -5,3 +5,4 @@ BUILDDEP="setuptools setuptools-scm"
 PKGDES="A fully functional X client library for Python programs"
 
 ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/python-xlib/spec
+++ b/lang-python/python-xlib/spec
@@ -1,5 +1,4 @@
-VER=0.26
+VER=0.33
 SRCS="tbl::https://github.com/python-xlib/python-xlib/releases/download/$VER/python-xlib-$VER.tar.bz2"
-CHKSUMS="sha256::b819c7e5f55830305919d78ea42b0cbd5e13687f5d12aa53556c33674b9876df"
-REL=2
+CHKSUMS="sha256::b7a45aaf919915f4908e4b2d79fc2ff3abbbec3b801a45162b3d0f67ed581b37"
 CHKUPDATE="anitya::id=53213"


### PR DESCRIPTION
Topic Description
-----------------

- python-xlib: update to 0.33
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- python-xlib: 0.33

Security Update?
----------------

No

Build Order
-----------

```
#buildit python-xlib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
