### PR TITLE
ldc: fix build on loongson3 and ppc64el

### DIFF
--- a/lang-dlang/ldc/01-liblphobos/beyond
+++ b/lang-dlang/ldc/01-liblphobos/beyond
@@ -1,2 +1,6 @@
+abinfo "Copying PKGDIR to fakeroot ..."
+mkdir -vp "$SRCDIR"/fakeroot
+cp -rvP "$PKGDIR"/* "$SRCDIR"/fakeroot
+
 abinfo "Dropping files in ldc ..."
 rm -rv "$PKGDIR"/{etc,usr/bin,usr/share/bash-completion}

--- a/lang-dlang/ldc/01-liblphobos/defines
+++ b/lang-dlang/ldc/01-liblphobos/defines
@@ -23,4 +23,4 @@ PKGBREAK="dub<=1.18.0 gtkd<=3.10.0-2 ldc<=1.18.0 tilix<=1:1.9.5-1"
 PKGREP="ldc<=1.1.0b5"
 
 # FIXME: Does not build on these architectures.
-FAIL_ARCH="(loongson3|mips64r6el|ppc64el)"
+FAIL_ARCH="(mips64r6el)"

--- a/lang-dlang/ldc/01-liblphobos/defines.stage2
+++ b/lang-dlang/ldc/01-liblphobos/defines.stage2
@@ -27,4 +27,4 @@ PKGBREAK="dub<=1.18.0 gtkd<=3.9.0-2 ldc<=1.18.0 tilix<=20190901-2"
 PKGREP="ldc<=1.1.0b5"
 
 # FIXME: Does not build on these architectures.
-FAIL_ARCH="(loongson3|mips64r6el|ppc64el)"
+FAIL_ARCH="(mips64r6el)"

--- a/lang-dlang/ldc/01-liblphobos/prepare.stage2
+++ b/lang-dlang/ldc/01-liblphobos/prepare.stage2
@@ -1,2 +1,5 @@
 abinfo "Removing previous versions of ldc ..."
 apt-get purge -y liblphobos ldc
+
+abinfo "Bootstrapping ldc using gdmd ..."
+export D_COMPILER=gdmd

--- a/lang-dlang/ldc/02-ldc/build
+++ b/lang-dlang/ldc/02-ldc/build
@@ -1,5 +1,6 @@
 abinfo "Installing LDC compiler components ..."
-DESTDIR="$PKGDIR" ninja -C "$BLDDIR" install
+mkdir -vp "$PKGDIR"
+cp -rPv "$SRCDIR"/fakeroot/* "$PKGDIR"
 
 abinfo "Removing files in liblphobos ..."
 rm -rv \

--- a/lang-dlang/ldc/02-ldc/defines
+++ b/lang-dlang/ldc/02-ldc/defines
@@ -8,4 +8,4 @@ AB_FLAGS_SPECS=0
 NOSTATIC=0
 
 # FIXME: Does not build on these architectures.
-FAIL_ARCH="(loongson3|mips64r6el|ppc64el)"
+FAIL_ARCH="(mips64r6el)"

--- a/lang-dlang/ldc/spec
+++ b/lang-dlang/ldc/spec
@@ -1,4 +1,5 @@
 VER=1.38.0
+REL=1
 SRCS="tbl::https://github.com/ldc-developers/ldc/releases/download/v$VER/ldc-$VER-src.tar.gz"
 CHKSUMS="sha256::ca6238efe022e34cd3076741f8a070c6a377196351c61949a48a48c99379f38e"
 CHKUPDATE="anitya::id=12072"


### PR DESCRIPTION
Topic Description
-----------------

- ldc: [WIP] fix build on loongson3 and ppc64el

Package(s) Affected
-------------------

- ldc: 1.38.0-1
- liblphobos: 1.38.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ldc:+stage2 ldc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
