### PR TITLE
linglong (Linglong Package Framework): new, 1.5.2

### DIFF
--- a/app-admin/linglong/autobuild/beyond
+++ b/app-admin/linglong/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Dropping unneeded linglong-repair-tool ..."
+rm -v \
+    "$PKGDIR"/usr/bin/linglong-repair-tool \
+    "$PKGDIR"/usr/share/applications/linglong-repair-tool.desktop

--- a/app-admin/linglong/autobuild/defines
+++ b/app-admin/linglong/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=linglong
+PKGSEC=admin
+PKGDEP="glib libseccomp ostree qt-5 systemd yaml-cpp"
+BUILDDEP="nlohmann-json"
+PKGDES="Containerized application distribution and packaging toolkit"
+
+CMAKE_AFTER="-DCPM_LOCAL_PACKAGES_ONLY=ON \
+             -DLINGLONG_DEFAULT_OCI_RUNTIME=ll-box"

--- a/app-admin/linglong/autobuild/postinst
+++ b/app-admin/linglong/autobuild/postinst
@@ -1,0 +1,8 @@
+echo "Creating user account for the Linglong daemon owner ..."
+systemd-sysusers linglong.conf
+
+echo "Reloading D-Bus configurations ..."
+dbus-send \
+	--system \
+	--type=method_call \
+	--dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig

--- a/app-admin/linglong/spec
+++ b/app-admin/linglong/spec
@@ -1,0 +1,4 @@
+VER=1.5.6
+SRCS="git::commit=tags/$VER::https://github.com/linuxdeepin/linglong"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372461"


### PR DESCRIPTION
Topic Description
-----------------

- linglong: new, 1.5.2

Package(s) Affected
-------------------

- linglong: 1.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linglong
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
