### PR TITLE
earlyoom: new, 1.8.2

### DIFF
--- a/app-admin/earlyoom/autobuild/build
+++ b/app-admin/earlyoom/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Building earlyoom ..."
+make PREFIX=/usr
+
+abinfo "Installing earlyoom ..."
+make install \
+    PREFIX=/usr \
+    DESTDIR="$PKGDIR"

--- a/app-admin/earlyoom/autobuild/defines
+++ b/app-admin/earlyoom/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=earlyoom
+PKGSEC=admin
+PKGDEP="glibc"
+PKGDES="Early OOM Daemon for Linux"

--- a/app-admin/earlyoom/spec
+++ b/app-admin/earlyoom/spec
@@ -1,0 +1,4 @@
+VER=1.8.2
+SRCS="git::commit=tags/v${VER}::https://github.com/rfjakob/earlyoom"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=17392"


### PR DESCRIPTION
Topic Description
-----------------

- earlyoom: new, 1.8.2

Package(s) Affected
-------------------

- earlyoom: 1.8.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit earlyoom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
