### PR TITLE
kramdown: update to 2.4.0

### DIFF
--- a/lang-ruby/kramdown/spec
+++ b/lang-ruby/kramdown/spec
@@ -1,6 +1,5 @@
-VER=2.3.1
+VER=2.4.0
 SRCS="tbl::https://rubygems.org/downloads/kramdown-$VER.gem"
-CHKSUMS="sha256::59e938cfa42a3d6169b295727fe09c4c91d742336c8fbd1042529f4db664ab49"
+CHKSUMS="sha256::b62e5bcbd6ea20c7a6730ebbb2a107237856e14f29cebf5b10c876cc1a2481c5"
 CHKUPDATE="anitya::id=4451"
 SUBDIR="."
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- kramdown: update to 2.4.0
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- kramdown: 2.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit kramdown
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
