### PR TITLE
mercurial: update to 6.7.3

### DIFF
--- a/app-vcs/mercurial/spec
+++ b/app-vcs/mercurial/spec
@@ -1,5 +1,4 @@
-VER=5.2.1
-REL=3
+VER=6.7.3
 SRCS="tbl::https://www.mercurial-scm.org/release/mercurial-$VER.tar.gz"
-CHKSUMS="sha256::18b1550abf9872a6905eb67527bc73e13f2a448830cca9be883528b0ce68b3df"
+CHKSUMS="sha256::00196944ea92738809317dc7a8ed7cb21287ca0a00a85246e66170955dcd9031"
 CHKUPDATE="anitya::id=1969"


### PR DESCRIPTION
Topic Description
-----------------

- mercurial: update to 6.7.3
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- mercurial: 6.7.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit mercurial
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
