### PR TITLE
tortoisehg: update to 6.6.3

### DIFF
--- a/app-vcs/tortoisehg/spec
+++ b/app-vcs/tortoisehg/spec
@@ -1,4 +1,4 @@
-VER=5.3.2
+VER=6.6.3
 SRCS="tbl::https://www.mercurial-scm.org/release/tortoisehg/targz/tortoisehg-$VER.tar.gz"
-CHKSUMS="sha256::ad67279fd774132212494a2debfa474b6bdd2fb320f7dbe090a4ad5520e3443d"
+CHKSUMS="sha256::f69835379ba3d596990809b837cb684707d51e67bb9c0b0d319917491805bdeb"
 CHKUPDATE="anitya::id=4994"


### PR DESCRIPTION
Topic Description
-----------------

- tortoisehg: update to 6.6.3
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- tortoisehg: 6.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit tortoisehg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
