### PR TITLE
apt: update to 2.7.14

### DIFF
--- a/app-admin/apt/spec
+++ b/app-admin/apt/spec
@@ -1,5 +1,4 @@
-VER=2.6.1
-REL=2
+VER=2.7.14
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/apt-team/apt.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7208"


### PR DESCRIPTION
Topic Description
-----------------

- apt: update to 2.7.14
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- apt: 2:2.7.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit apt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
