### PR TITLE
archlinux-keyring: update to 20240520

### DIFF
--- a/app-admin/archlinux-keyring/spec
+++ b/app-admin/archlinux-keyring/spec
@@ -1,4 +1,4 @@
-VER=20231222
+VER=20240520
 SRCS="git::commit=tags/$VER::https://gitlab.archlinux.org/archlinux/archlinux-keyring"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=103"

--- a/app-cryptography/sequoia-sq/autobuild/defines
+++ b/app-cryptography/sequoia-sq/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME="sequoia-sq"
 PKGDES="Command-line frontends for Sequoia, Sequoia is a cool new OpenPGP implementation"
-PKGDEP="glibc"
+PKGDEP="glibc capnproto"
 BUILDDEP="rustc llvm"
 PKGSEC="admin"
 
-CARGO_AFTER="--features crypto-nettle,compression-bzip2,autocrypt,sequoia-autocrypt"
+CARGO_AFTER="--features crypto-nettle"
 USECLANG=1
 
 # FIXME: Segfaults during linkage.

--- a/app-cryptography/sequoia-sq/spec
+++ b/app-cryptography/sequoia-sq/spec
@@ -1,4 +1,4 @@
-VER=0.31.0
+VER=0.36.0
 SRCS="git::commit=tags/v$VER::https://gitlab.com/sequoia-pgp/sequoia-sq"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=191617"


### PR DESCRIPTION
Topic Description
-----------------

- archlinux-keyring: update to 20240520
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- archlinux-keyring: 20240520

Security Update?
----------------

No

Build Order
-----------

```
#buildit sequoia-sq archlinux-keyring
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
