### PR TITLE
debian-archive-keyring: update to 2023.4

### DIFF
--- a/app-admin/debian-archive-keyring/autobuild/build
+++ b/app-admin/debian-archive-keyring/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Install debian-archive-keyring ..."
+make install DESTDIR="$PKGDIR"

--- a/app-admin/debian-archive-keyring/spec
+++ b/app-admin/debian-archive-keyring/spec
@@ -1,4 +1,4 @@
-VER=2021.1.1
+VER=2023.4
 SRCS="tbl::https://mirrors.kernel.org/debian/pool/main/d/debian-archive-keyring/debian-archive-keyring_${VER}.tar.xz"
-CHKSUMS="sha256::5fe6011f7caf516b19b8f2c545bd215f4b6f8022b161d1ce5262ac2c51c4dbcf"
+CHKSUMS="sha256::7f9b64d7c5e748b0cb99fd0674d872111c219e119f296912c59fc61ab49bb78a"
 CHKUPDATE="html::url=https://mirrors.kernel.org/debian/pool/main/d/debian-archive-keyring;pattern=debian-archive-keyring_(.+?).tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- debian-archive-keyring: update to 2023.4
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- debian-archive-keyring: 2023.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit debian-archive-keyring
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
