### PR TITLE
debian-ports-archive-keyring: update to 2024.02.02

### DIFF
--- a/app-admin/debian-ports-archive-keyring/spec
+++ b/app-admin/debian-ports-archive-keyring/spec
@@ -1,5 +1,5 @@
-VER=2022.02.15~deb11u1
+VER=2024.02.02
 SRCS="tbl::rename=debian-ports-archive-keyring_${VER}_all.deb::https://mirrors.edge.kernel.org/debian/pool/main/d/debian-ports-archive-keyring/debian-ports-archive-keyring_${VER}_all.deb"
-CHKSUMS="sha256::2918bd81439d56ac193fc031ee225044c7da4983b50438373e80e0495c318f00"
+CHKSUMS="sha256::4401aefa875047cb66086e78500e16def33d5fcca9598bd1507ee1203fe72a62"
 CHKUPDATE="html::url=https://mirrors.kernel.org/debian/pool/main/d/debian-ports-archive-keyring;pattern=debian-ports-archive-keyring_(.+?).tar.xz"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- debian-ports-archive-keyring: update to 2024.02.02
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- debian-ports-archive-keyring: 2024.02.02

Security Update?
----------------

No

Build Order
-----------

```
#buildit debian-ports-archive-keyring
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
