### PR TITLE
dkms: update to 3.0.13

### DIFF
--- a/app-admin/dkms/autobuild/defines
+++ b/app-admin/dkms/autobuild/defines
@@ -4,9 +4,9 @@ PKGDEP="bash kmod gcc make patch gawk"
 PKGDES="Dynamic Kernel Modules System"
 
 ABTYPE=plainmake
-MAKE_AFTER="LIBDIR=$PKGDIR/usr/lib/dkms \
-            SYSTEMD=$PKGDIR/usr/lib/systemd/system \
-            DESTDIR=$PKGDIR install-redhat-systemd \
-            SBIN=$PKGDIR/usr/bin"
+MAKE_AFTER="LIBDIR=/usr/lib/dkms \
+            SYSTEMD=/usr/lib/systemd/system \
+            DESTDIR=$PKGDIR install-redhat \
+            SBIN=/usr/bin"
 ABHOST=noarch
 PKGEPOCH=1

--- a/app-admin/dkms/spec
+++ b/app-admin/dkms/spec
@@ -1,4 +1,4 @@
-VER=2.8.3
+VER=3.0.13
 SRCS="tbl::https://github.com/dell/dkms/archive/v$VER.tar.gz"
-CHKSUMS="sha256::0fcbb2691aa8231927b000edf3594d2798211c3944fd4a2a8b1864aa1c06eaaf"
+CHKSUMS="sha256::ceb5bbb89ece7310ee96952a56c926faa51c4486f7e5e43c8589585056e45bb5"
 CHKUPDATE="anitya::id=440"


### PR DESCRIPTION
Topic Description
-----------------

- dkms: update to 3.0.13
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- dkms: 1:3.0.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
