### PR TITLE
fail2ban: update to 1.1.0

### DIFF
--- a/app-admin/fail2ban/autobuild/prepare
+++ b/app-admin/fail2ban/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo "Running fail2ban-2to3 ..."
-"$SRCDIR/fail2ban-2to3"

--- a/app-admin/fail2ban/spec
+++ b/app-admin/fail2ban/spec
@@ -1,4 +1,4 @@
-VER=1.0.2
+VER=1.1.0
 SRCS="https://github.com/fail2ban/fail2ban/archive/refs/tags/${VER}.tar.gz"
-CHKSUMS="sha256::ae8b0b41f27a7be12d40488789d6c258029b23a01168e3c0d347ee80b325ac23"
+CHKSUMS="sha256::474fcc25afdaf929c74329d1e4d24420caabeea1ef2e041a267ce19269570bae"
 CHKUPDATE="anitya::id=6602"


### PR DESCRIPTION
Topic Description
-----------------

- fail2ban: update to 1.1.0
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- fail2ban: 1.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit fail2ban
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
