### PR TITLE
logrotate: update to 3.21.0

### DIFF
--- a/app-admin/logrotate/spec
+++ b/app-admin/logrotate/spec
@@ -1,4 +1,4 @@
-VER=3.18.1
+VER=3.21.0
 SRCS="tbl::https://github.com/logrotate/logrotate/releases/download/$VER/logrotate-$VER.tar.xz"
-CHKSUMS="sha256::14a924e4804b3974e85019a9f9352c2a69726702e6656155c48bcdeace68a5dc"
+CHKSUMS="sha256::8fa12015e3b8415c121fc9c0ca53aa872f7b0702f543afda7e32b6c4900f6516"
 CHKUPDATE="anitya::id=10567"


### PR DESCRIPTION
Topic Description
-----------------

- logrotate: update to 3.21.0
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- logrotate: 3.21.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit logrotate
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
