### PR TITLE
osinfo-db: update to 20240510

### DIFF
--- a/app-admin/osinfo-db/spec
+++ b/app-admin/osinfo-db/spec
@@ -1,5 +1,5 @@
-VER=20230719
+VER=20240510
 SRCS="file::https://releases.pagure.org/libosinfo/osinfo-db-${VER}.tar.xz"
-CHKSUMS="sha256::13d1c97fc7d67137935dcc97778c08bb079a4f0fe312d479786cea1411e4845a"
+CHKSUMS="sha256::08a2d521c485687f6be39940d5b3f61bc0f583bb7e3655a131c658385eb7e5ca"
 CHKUPDATE="anitya::id=226784"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- osinfo-db: update to 20240510
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- osinfo-db: 20240510

Security Update?
----------------

No

Build Order
-----------

```
#buildit osinfo-db
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
