### PR TITLE
shadow: update to 4.15.1

### DIFF
--- a/app-admin/shadow/autobuild/defines
+++ b/app-admin/shadow/autobuild/defines
@@ -21,7 +21,6 @@ AUTOTOOLS_AFTER="--enable-largefile \
                  --enable-shadowgrp \
                  --disable-man \
                  --enable-account-tools-setuid \
-                 --disable-utmpx \
                  --enable-subordinate-ids \
                  --enable-nls \
                  --disable-rpath \
@@ -33,7 +32,6 @@ AUTOTOOLS_AFTER="--enable-largefile \
                  --with-attr \
                  --without-skey \
                  --without-tcb \
-                 --with-libcrack \
                  --with-sha-crypt \
                  --without-bcrypt \
                  --without-yescrypt \

--- a/app-admin/shadow/spec
+++ b/app-admin/shadow/spec
@@ -1,5 +1,4 @@
-VER=4.13
-REL=1
+VER=4.15.1
 SRCS="tbl::https://github.com/shadow-maint/shadow/releases/download/$VER/shadow-$VER.tar.xz"
-CHKSUMS="sha256::9afe245d79a2e7caac5f1ed62519b17416b057ec89df316df1c3935502f9dd2c"
+CHKSUMS="sha256::bb5f70639a0581f9d626f227ce45b31ac137daa7c451c0f672ce14f2731a96ee"
 CHKUPDATE="anitya::id=4802"

--- a/runtime-common/libbsd/spec
+++ b/runtime-common/libbsd/spec
@@ -1,5 +1,4 @@
-VER=0.10.0
-REL=2
+VER=0.12.2
 SRCS="tbl::https://libbsd.freedesktop.org/releases/libbsd-$VER.tar.xz"
-CHKSUMS="sha256::34b8adc726883d0e85b3118fa13605e179a62b31ba51f676136ecb2d0bc1a887"
+CHKSUMS="sha256::b88cc9163d0c652aaf39a99991d974ddba1c3a9711db8f1b5838af2a14731014"
 CHKUPDATE="anitya::id=1567"


### PR DESCRIPTION
Topic Description
-----------------

- shadow: update to 4.15.1
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- shadow: 4.15.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libbsd shadow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
