### PR TITLE
hwdata: update to 0.382

### DIFF
--- a/runtime-data/hwdata/spec
+++ b/runtime-data/hwdata/spec
@@ -1,5 +1,4 @@
-VER=0.377
-REL=1
+VER=0.382
 SRCS="git::commit=tags/v$VER::https://github.com/vcrhonek/hwdata"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13577"


### PR DESCRIPTION
Topic Description
-----------------

- hwdata: update to 0.382
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- hwdata: 0.382

Security Update?
----------------

No

Build Order
-----------

```
#buildit hwdata
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
