### PR TITLE
distcc: update to 3.4

### DIFF
--- a/app-devel/distcc/spec
+++ b/app-devel/distcc/spec
@@ -1,5 +1,4 @@
-VER=3.3.5
+VER=3.4
 SRCS="tbl::https://github.com/distcc/distcc/releases/download/v$VER/distcc-$VER.tar.gz"
-CHKSUMS="sha256::7a8e45a3a2601b7d5805c7d5b24918e3ad84b6b5cc9153133f432fdcc6dce518"
+CHKSUMS="sha256::2b99edda9dad9dbf283933a02eace6de7423fe5650daa4a728c950e5cd37bd7d"
 CHKUPDATE="anitya::id=14550"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- distcc: update to 3.4
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- distcc: 3.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit distcc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
