### PR TITLE
dmidecode: update to 3.6

### DIFF
--- a/app-utils/dmidecode/spec
+++ b/app-utils/dmidecode/spec
@@ -1,4 +1,4 @@
-VER=3.5
+VER=3.6
 SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/dmidecode/dmidecode-$VER.tar.xz"
-CHKSUMS="sha256::79d76735ee8e25196e2a722964cf9683f5a09581503537884b256b01389cc073"
+CHKSUMS="sha256::e40c65f3ec3dafe31ad8349a4ef1a97122d38f65004ed66575e1a8d575dd8bae"
 CHKUPDATE="anitya::id=443"


### PR DESCRIPTION
Topic Description
-----------------

- dmidecode: update to 3.6
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dmidecode: 3.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit dmidecode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
