### PR TITLE
irssi: update to 1.4.5

### DIFF
--- a/app-web/irssi/autobuild/defines
+++ b/app-web/irssi/autobuild/defines
@@ -3,10 +3,9 @@ PKGSEC=web
 PKGDEP="glib libwww-perl openssl libutf8proc libotr"
 PKGDES="Modular text mode IRC client with Perl scripting"
 
-AUTOTOOLS_AFTER="--with-proxy \
-                 --with-perl-lib=vendor \
-                 --with-bot \
-                 --enable-true-color \
-                 --with-otr"
-ABSHADOW=0
-RECONF=0
+ABTYPE=meson
+MESON_AFTER="-Dwith-perl-lib=vendor \
+	     -Dwith-proxy=yes \
+	     -Dwith-otr=yes \
+	     -Dwith-perl=yes \
+	     -Denable-true-color=yes"

--- a/app-web/irssi/spec
+++ b/app-web/irssi/spec
@@ -1,5 +1,4 @@
-VER=1.2.3
+VER=1.4.5
 SRCS="tbl::https://github.com/irssi/irssi/releases/download/$VER/irssi-$VER.tar.xz"
-CHKSUMS="sha256::a647bfefed14d2221fa77b6edac594934dc672c4a560417b1abcbbc6b88d769f"
+CHKSUMS="sha256::72a951cb0ad622785a8962801f005a3a412736c7e7e3ce152f176287c52fe062"
 CHKUPDATE="anitya::id=1404"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- irssi: update to 1.4.5
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- irssi: 1.4.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit irssi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
