### PR TITLE
openjpeg: update to 2.5.2

### DIFF
--- a/runtime-imaging/openjpeg/spec
+++ b/runtime-imaging/openjpeg/spec
@@ -1,4 +1,4 @@
-VER=2.5.0
+VER=2.5.2
 SRCS="tbl::https://github.com/uclouvain/openjpeg/archive/v$VER.tar.gz"
-CHKSUMS="sha256::0333806d6adecc6f7a91243b2b839ff4d2053823634d4f6ed7a59bc87409122a"
+CHKSUMS="sha256::90e3896fed910c376aaf79cdd98bdfdaf98c6472efd8e1debf0a854938cbda6a"
 CHKUPDATE="anitya::id=2550"


### PR DESCRIPTION
Topic Description
-----------------

- openjpeg: update to 2.5.2
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- openjpeg: 2.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit openjpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
