### PR TITLE
vrms: update to 1.34

### DIFF
--- a/app-utils/vrms/autobuild/build
+++ b/app-utils/vrms/autobuild/build
@@ -1,12 +1,14 @@
 abinfo "Installing vrms ..."
-install -Dvm0755 "$SRCDIR"/vrms \
-    "$PKGDIR"/usr/bin/vrms
+install -Dvm0755 "$SRCDIR"/check-dfsg-status \
+    "$PKGDIR"/usr/bin/check-dfsg-status
+ln -sv check-dfsg-status "$PKGDIR"/usr/bin/vrms
 
 abinfo "Installing reasons (ha-ha-ha!!) ..."
-install -dv "$PKGDIR"/usr/share/vrms
+install -dv "$PKGDIR"/usr/share/check-dfsg-status
 cp -av "$SRCDIR"/reasons \
-    "$PKGDIR"/usr/share/vrms/
+    "$PKGDIR"/usr/share/check-dfsg-status/
 
 abinfo "Installing man page ..."
-install -Dvm0644 "$SRCDIR"/vrms.1 \
-    "$PKGDIR"/usr/share/man/man1/vrms.1
+install -Dvm0644 "$SRCDIR"/check-dfsg-status.1 \
+    "$PKGDIR"/usr/share/man/man1/check-dfsg-status.1
+ln -sv check-dfsg-status.1 "$PKGDIR"/usr/share/man/man1/vrms.1

--- a/app-utils/vrms/spec
+++ b/app-utils/vrms/spec
@@ -1,4 +1,4 @@
-VER=1.27
+VER=1.34
 SRCS="tbl::https://salsa.debian.org/debian/vrms/-/archive/$VER/vrms-$VER.tar.gz"
-CHKSUMS="sha256::c4a9d256c22df5dbd244748f2e3a58e9f06fd1f8947da90d0ef101d39d174166"
+CHKSUMS="sha256::9f67d5eacee217fabf44ff6d632d2dba80e52edd5893c4dfefbf22044782094f"
 CHKUPDATE="anitya::id=231673"


### PR DESCRIPTION
Topic Description
-----------------

- vrms: update to 1.34
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- vrms: 1.34

Security Update?
----------------

No

Build Order
-----------

```
#buildit vrms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
