### PR TITLE
hmcl: update to 3.5.8

### DIFF
--- a/app-games/hmcl/spec
+++ b/app-games/hmcl/spec
@@ -1,4 +1,4 @@
-VER=3.5.7
+VER=3.5.8
 SRCS="git::commit=tags/release-$VER::https://github.com/HMCL-dev/HMCL"
 CHKSUMS=SKIP
 CHKUPDATE="github::repo=HMCL-dev/HMCL"


### PR DESCRIPTION
Topic Description
-----------------

- hmcl: update to 3.5.8

Package(s) Affected
-------------------

- hmcl: 3.5.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit hmcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
