### PR TITLE
pcmanfm: update to 1.3.2

### DIFF
--- a/desktop-lxde/pcmanfm/spec
+++ b/desktop-lxde/pcmanfm/spec
@@ -1,5 +1,4 @@
-VER=1.3.1
-SRCS="tbl::https://downloads.sourceforge.net/pcmanfm/pcmanfm-$VER.tar.xz"
-CHKSUMS="sha256::6804043b3ee3a703edde41c724946174b505fe958703eadbd7e0876ece836855"
-REL=1
+VER=1.3.2
+SRCS="git::commit=tags/$VER::https://github.com/lxde/pcmanfm"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2607"


### PR DESCRIPTION
Topic Description
-----------------

- pcmanfm: update to 1.3.2
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- pcmanfm: 1.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pcmanfm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
