### PR TITLE
binutils+w64: update to 2.42

### DIFF
--- a/runtime-optenvw64/binutils+w64/autobuild/build
+++ b/runtime-optenvw64/binutils+w64/autobuild/build
@@ -3,8 +3,9 @@
 _targets="i686-w64-mingw32 x86_64-w64-mingw32"
 
 for _target in $_targets; do
-    mkdir $SRCDIR/binutils-${_target} && cd $SRCDIR/binutils-${_target}
-    $SRCDIR/configure --prefix=/opt/w64 \
+    abinfo "Configuring binutils for ${_target} ..."
+    mkdir "$SRCDIR"/binutils-${_target} && cd "$SRCDIR"/binutils-${_target}
+    "$SRCDIR"/configure --prefix=/opt/w64 \
         --target=${_target} \
         --infodir=/usr/share/info/${_target} \
         --enable-lto --enable-plugins \
@@ -12,6 +13,10 @@ for _target in $_targets; do
         --disable-werror --enable-gold \
         --enable-deterministic-archives --disable-gdb \
         --enable-64-bit-bfd
+
+    abinfo "Building binutils for ${_target} ..."
     make
-    make install DESTDIR=$PKGDIR
+
+    abinfo "Installing binutils for ${_target} ..."
+    make install DESTDIR="$PKGDIR"
 done

--- a/runtime-optenvw64/binutils+w64/autobuild/defines
+++ b/runtime-optenvw64/binutils+w64/autobuild/defines
@@ -2,3 +2,8 @@ PKGNAME=binutils+w64
 PKGSEC=devel
 PKGDEP="zlib"
 PKGDES="Binutils for the MinGW w64 environment"
+
+# FIXME: objcopy: x86_64-w64-mingw32-objdump[.debug_abbrev]: invalid operation
+ABSPLITDBG=0
+# FIXME: strip: i686-w64-mingw32-ld.bfd: file format not recognized
+ABSTRIP=0

--- a/runtime-optenvw64/binutils+w64/spec
+++ b/runtime-optenvw64/binutils+w64/spec
@@ -1,4 +1,4 @@
-VER=2.34
-SRCS="git::commit=f7930a553ccec9a9155237add6fcac8da8d0d096::https://sourceware.org/git/binutils-gdb.git"
+VER=2.42
+SRCS="git::commit=binutils-${VER/./_}::https://sourceware.org/git/binutils-gdb.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION
Topic Description
-----------------

- binutils+w64: update to 2.42

Package(s) Affected
-------------------

- binutils+w64: 2.42

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils+w64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
