### PR TITLE
eza: update to 0.10.1

### DIFF
--- a/app-utils/eza/spec
+++ b/app-utils/eza/spec
@@ -1,4 +1,4 @@
-VER=0.11.0
+VER=0.10.1
 SRCS="git::commit=tags/v$VER::https://github.com/eza-community/eza"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16575"


### PR DESCRIPTION
Topic Description
-----------------

- eza: update to 0.10.1
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- eza: 0.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit eza
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
