### PR TITLE
mpv: update to 0.38.0

### DIFF
--- a/app-multimedia/mpv/spec
+++ b/app-multimedia/mpv/spec
@@ -1,5 +1,4 @@
-VER=0.37.0
-REL=1
+VER=0.38.0
 SRCS="tbl::https://github.com/mpv-player/mpv/archive/v$VER.tar.gz"
-CHKSUMS="sha256::1d2d4adbaf048a2fa6ee134575032c4b2dad9a7efafd5b3e69b88db935afaddf"
+CHKSUMS="sha256::86d9ef40b6058732f67b46d0bbda24a074fae860b3eaae05bab3145041303066"
 CHKUPDATE="anitya::id=5348"


### PR DESCRIPTION
Topic Description
-----------------

- mpv: update to 0.38.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- mpv: 0.38.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
