### PR TITLE
jq: update to 1.7.1

### DIFF
--- a/app-devel/jq/spec
+++ b/app-devel/jq/spec
@@ -1,5 +1,4 @@
-VER=1.6
-REL=1
+VER=1.7.1
 SRCS="tbl::https://github.com/stedolan/jq/archive/jq-$VER.tar.gz"
-CHKSUMS="sha256::158182b85f3be9e23ab1dc50cfcc24e415aade2a0b8a5d9f709e0b587666d61b"
+CHKSUMS="sha256::fc75b1824aba7a954ef0886371d951c3bf4b6e0a921d1aefc553f309702d6ed1"
 CHKUPDATE="anitya::id=13252"


### PR DESCRIPTION
Topic Description
-----------------

- jq: update to 1.7.1
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- jq: 1.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit jq
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
