### PR TITLE
rbw: update to 1.10.2

### DIFF
--- a/app-utils/rbw/spec
+++ b/app-utils/rbw/spec
@@ -1,4 +1,4 @@
-VER=1.10.1
+VER=1.10.2
 SRCS="git::commit=tags/$VER::https://github.com/doy/rbw"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241513"


### PR DESCRIPTION
Topic Description
-----------------

- rbw: update to 1.10.2
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- rbw: 1.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rbw
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
