### PR TITLE
strawberry: update to 1.0.23

### DIFF
--- a/app-multimedia/strawberry/spec
+++ b/app-multimedia/strawberry/spec
@@ -1,4 +1,4 @@
-VER=1.0.22
+VER=1.0.23
 SRCS="git::commit=tags/$VER::https://github.com/strawberrymusicplayer/strawberry"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19048"


### PR DESCRIPTION
Topic Description
-----------------

- strawberry: update to 1.0.23
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- strawberry: 1.0.23

Security Update?
----------------

No

Build Order
-----------

```
#buildit strawberry
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
