### PR TITLE
libcava: update to 0.10.2

### DIFF
--- a/runtime-multimedia/libcava/spec
+++ b/runtime-multimedia/libcava/spec
@@ -1,4 +1,4 @@
-VER=0.10.1
+VER=0.10.2
 SRCS="git::commit=tags/$VER::https://github.com/LukashonakV/cava"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372377"


### PR DESCRIPTION
Topic Description
-----------------

- libcava: update to 0.10.2
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- libcava: 0.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcava
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
