### PR TITLE
FreeCAD: rebuild because of fmt soname change

### DIFF
--- a/app-creativity/freecad/autobuild/defines
+++ b/app-creativity/freecad/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=freecad
-PKGDEP="med hdf5 opencascade vtk glew boost coin xerces-c pyside2 libspnav matplotlib pcl pivy ply"
+PKGDEP="med hdf5 opencascade vtk glew boost coin xerces-c pyside2 libspnav matplotlib pcl pivy ply fmt"
 PKGSUG="openscad"
 BUILDDEP="swig pybind11 eigen-3"
 PKGSEC="graphics"
@@ -7,7 +7,7 @@ PKGDES="Parametric 3D CAD modeler"
 
 ABTYPE=cmakeninja
 
-CMAKE_AFTER="-DCMAKE_SKIP_RPATH=OFF \
+CMAKE_AFTER="-DCMAKE_SKIP_INSTALL_RPATH=OFF \
              -DCMAKE_INSTALL_PREFIX=/usr/lib/freecad \
              -DCMAKE_INSTALL_BINDIR=/usr/lib/freecad/bin \
              -DCMAKE_INSTALL_DATADIR=/usr/share/freecad \

--- a/app-creativity/freecad/spec
+++ b/app-creativity/freecad/spec
@@ -1,5 +1,5 @@
 VER=0.21.2
-REL=1
+REL=2
 SRCS="git::commit=tags/${VER};copy-repo=true::https://github.com/FreeCAD/FreeCAD"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=836"


### PR DESCRIPTION
Topic Description
-----------------

- freecad: rebuild for fmt soname change
    - Also add fmt to the dependency list, to prevent it from being ignored
    the next time.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- freecad: 0.21.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit freecad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
