### PR TITLE
obs-studio: update to 30.1.2

### DIFF
--- a/app-multimedia/obs-studio/autobuild/defines
+++ b/app-multimedia/obs-studio/autobuild/defines
@@ -1,15 +1,30 @@
 PKGNAME=obs-studio
 PKGSEC=video
-PKGDEP="ffmpeg jansson libfdk-aac x11-lib libxkbcommon qt-5 curl imagemagick mbedtls sndio"
-BUILDDEP="cmake x264 swig vlc pipewire jack patchelf"
+PKGDEP="ffmpeg jansson libfdk-aac x11-lib libxkbcommon qt-6 curl imagemagick \
+        mbedtls sndio rnnoise pciutils libdatachannel"
+PKGDEP__AMD64="${PKGDEP} libvpl"
+BUILDDEP="cmake x264 swig vlc pipewire jack patchelf python-3 nlohmann-json"
+BUILDDEP__AMD64="${BUILDDEP} luajit"
+BUILDDEP__ARM64="${BUILDDEP__AMD64}"
+BUILDDEP__LOONGSON3="${BUILDDEP__AMD64}"
+BUILDDEP__MIPS64R6EL="${BUILDDEP__AMD64}"
 PKGDES="Free, open source software for live streaming and recording"
 
 CMAKE_AFTER="-DUSE_SSL=ON \
              -DBUILD_BROWSER=OFF \
-             -DOBS_VERSION_OVERRIDE=${PKGVER}"
-CMAKE_AFTER__WEB_PLUGIN="$CMAKE_AFTER -DBUILD_BROWSER=ON"
-CMAKE_AFTER__AMD64="${CMAKE_AFTER__WEB_PLUGIN}"
-CMAKE_AFTER__ARM64="${CMAKE_AFTER__WEB_PLUGIN}"
+             -DOBS_VERSION_OVERRIDE=${PKGVER} \
+             -DENABLE_WEBSOCKET=OFF \
+             -DENABLE_AJA=OFF \
+             -DENABLE_NEW_MPEGTS_OUTPUT=OFF \
+             -DENABLE_SCRIPTING_LUA=OFF \
+             -DENABLE_QSV11=OFF"
+CMAKE_AFTER__WEB_PLUGIN="${CMAKE_AFTER} -DBUILD_BROWSER=ON"
+CMAKE_AFTER__AMD64="${CMAKE_AFTER__WEB_PLUGIN} \
+             -DENABLE_QSV11=ON \
+             -DENABLE_SCRIPTING_LUA=ON"
+CMAKE_AFTER__ARM64="${CMAKE_AFTER__WEB_PLUGIN} -DENABLE_SCRIPTING_LUA=ON"
+CMAKE_AFTER__LOONGSON3="${CMAKE_AFTER} -DENABLE_SCRIPTING_LUA=ON"
+CMAKE_AFTER__MIPS64R6EL="${CMAKE_AFTER__LOONGSON3}"
 
 ABTYPE=cmakeninja
 AB_FLAGS_O3=1

--- a/app-multimedia/obs-studio/autobuild/patches/0001-keep-CEF-binary-file-permissions.patch
+++ b/app-multimedia/obs-studio/autobuild/patches/0001-keep-CEF-binary-file-permissions.patch
@@ -1,0 +1,33 @@
+From f4e7d2a6f7120b63e4be959910699ac841c60df6 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Fri, 24 May 2024 18:06:22 -0700
+Subject: [PATCH] keep CEF binary file permissions
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ cmake/Modules/ObsHelpers.cmake | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/cmake/Modules/ObsHelpers.cmake b/cmake/Modules/ObsHelpers.cmake
+index b4620ab56..1db7e9aa2 100644
+--- a/cmake/Modules/ObsHelpers.cmake
++++ b/cmake/Modules/ObsHelpers.cmake
+@@ -207,6 +207,7 @@ function(setup_target_browser target)
+   install(
+     DIRECTORY ${CEF_ROOT_DIR}/Release/
+     DESTINATION ${OBS_PLUGIN_DESTINATION}
++    USE_SOURCE_PERMISSIONS
+     COMPONENT ${target}_Runtime)
+ 
+   install(
+@@ -218,6 +219,7 @@ function(setup_target_browser target)
+   install(
+     DIRECTORY ${CEF_ROOT_DIR}/Release/
+     DESTINATION ${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_PLUGIN_DESTINATION}
++    USE_SOURCE_PERMISSIONS
+     COMPONENT obs_rundir
+     EXCLUDE_FROM_ALL)
+ endfunction()
+-- 
+2.45.1
+

--- a/app-multimedia/obs-studio/spec
+++ b/app-multimedia/obs-studio/spec
@@ -1,14 +1,13 @@
-VER=27.0.0
-REL=5
+VER=30.1.2
 # __OBS_CEF_VER: Find the build version on https://cef-builds.spotifycdn.com/index.html#linux64
-__OBS_CEF_VER="89.0.18+gb36241d+chromium-89.0.4389.114"
+__OBS_CEF_VER="103.0.12+g8eb56c7+chromium-103.0.5060.134"
 SRCS="git::commit=tags/$VER;rename=obs-studio::https://github.com/obsproject/obs-studio"
 SRCS__AMD64="${SRCS} \
             tbl::rename=cef.tar.bz2::https://cef-builds.spotifycdn.com/cef_binary_${__OBS_CEF_VER}_linux64_minimal.tar.bz2"
 SRCS__ARM64="${SRCS} \
             tbl::rename=cef.tar.bz2::https://cef-builds.spotifycdn.com/cef_binary_${__OBS_CEF_VER}_linuxarm64_minimal.tar.bz2"
 CHKSUMS="SKIP"
-CHKSUMS__AMD64="$CHKSUMS sha1::8a26b6de70187114f99ea294f9ad799751428ac1"
-CHKSUMS__ARM64="$CHKSUMS sha1::7c7b89a7d72df4815bdc7a717eac9f09e090c925"
+CHKSUMS__AMD64="$CHKSUMS sha1::2f6500b81ea780feaabae41570192aef71d60963"
+CHKSUMS__ARM64="$CHKSUMS sha1::12a1f35195f7d368019385defd980d6cf6fd2ff9"
 SUBDIR="obs-studio"
 CHKUPDATE="anitya::id=7239"

--- a/runtime-common/plog/autobuild/defines
+++ b/runtime-common/plog/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=plog
+PKGSEC=libs
+BUILDDEP="cmake"
+PKGDES="A C++ logging library"
+
+ABHOST=noarch
+ABSPLITDBG=0
+
+ABTYPE=cmake
+CMAKE_AFTER="-DPLOG_BUILD_SAMPLES=FALSE"

--- a/runtime-common/plog/spec
+++ b/runtime-common/plog/spec
@@ -1,0 +1,4 @@
+VER=1.1.10
+SRCS="git::commit=tags/$VER::https://github.com/SergiusTheBest/plog"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=369136"

--- a/runtime-multimedia/libdatachannel/autobuild/defines
+++ b/runtime-multimedia/libdatachannel/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=libdatachannel
+PKGSEC=libs
+PKGDEP="openssl libnice srtp usrsctp glib"
+BUILDDEP="cmake nlohmann-json plog"
+PKGDES="A C/C++ WebRTC network library"
+
+ABTYPE=cmake
+CMAKE_AFTER="-DUSE_GNUTLS=ON \
+            -DUSE_NICE=ON \
+            -DPREFER_SYSTEM_LIB=ON"

--- a/runtime-multimedia/libdatachannel/spec
+++ b/runtime-multimedia/libdatachannel/spec
@@ -1,0 +1,4 @@
+VER=0.21.1
+SRCS="git::commit=tags/v$VER::https://github.com/paullouisageneau/libdatachannel"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=369160"

--- a/runtime-multimedia/libvpl/autobuild/beyond
+++ b/runtime-multimedia/libvpl/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Moving vars.sh to /usr/share/vpl ..."
+mv -v "$PKGDIR"/usr/etc/vpl/vars.sh "$PKGDIR"/usr/share/vpl/
+rm -r "$PKGDIR"/usr/etc

--- a/runtime-multimedia/libvpl/autobuild/defines
+++ b/runtime-multimedia/libvpl/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=libvpl
+PKGSEC=libs
+BUILDDEP="cmake"
+PKGDES="Intel Video Processing Library"
+
+ABTYPE=cmake
+
+# libvpl only supports amd64
+FAIL_ARCH="!(amd64)"

--- a/runtime-multimedia/libvpl/spec
+++ b/runtime-multimedia/libvpl/spec
@@ -1,0 +1,4 @@
+VER=2.11.0
+SRCS="git::commit=tags/v$VER::https://github.com/intel/libvpl"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=242664"

--- a/runtime-network/usrsctp/autobuild/defines
+++ b/runtime-network/usrsctp/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=usrsctp
+PKGSEC=libs
+BUILDDEP="cmake"
+PKGDES="Portable SCTP userland stack"
+
+ABTYPE=cmake
+CMAKE_AFTER="-Dsctp_werror=OFF \
+            -Dsctp_build_shared_lib=ON"

--- a/runtime-network/usrsctp/spec
+++ b/runtime-network/usrsctp/spec
@@ -1,0 +1,4 @@
+VER=0.9.5.0
+SRCS="git::commit=tags/$VER::https://github.com/sctplab/usrsctp"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=141674"


### PR DESCRIPTION
Topic Description
-----------------

- obs-studio: update to 30.1.2
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- libvpl: new, 2.11.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- libdatachannel: new, 0.21.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- usrsctp: new, 0.9.5.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- plog: new, 1.1.10
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- libdatachannel: 0.21.1
- libvpl: 2.11.0
- obs-studio: 30.1.2
- plog: 1.1.10
- usrsctp: 0.9.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit plog usrsctp libdatachannel libvpl obs-studio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
