### PR TITLE
dotnet-6.0: update to 6.0.30

### DIFF
--- a/app-devel/aspnetcore-runtime-6.0/spec
+++ b/app-devel/aspnetcore-runtime-6.0/spec
@@ -1,11 +1,11 @@
-VER=6.0.0
+VER=6.0.30
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$VER/aspnetcore-runtime-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::6a1ae878efdc9f654e1914b0753b710c3780b646ac160fb5a68850b2fd1101675dc71e015dbbea6b4fcf1edac0822d3f7d470e9ed533dd81d0cfbcbbb1745c6c"
+CHKSUMS__AMD64="sha512::757d017db28b8e34c4b242c082aa51eb85bce8fca16af37a0beabedb271c9bd13e1631868faa131745d7784db48974567f82275da09041ba434dcb7abe821a2d"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$VER/aspnetcore-runtime-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::e61eade344b686180b8a709229d6b3180ea6f085523e5e4e4b0d23dd00cf9edce3e51a920c986b1bab7d04d8cab5aae219c3b533b6feb84b32a02810936859b0"
+CHKSUMS__ARM64="sha512::de0921903ba55e21195107b126e271457550543fd6a9698ab3c2b1e2b95f7fe2d6fb2f067e08ed10c9e56940c247733dd9a2f9775e7993e033a945899461e130"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$VER/aspnetcore-runtime-$VER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha512::36be738bb40a0cadacd4531c3597a25fd45deb7c48090ffb61c79a5db7742a5b8e13051b06556e15e7e162e4a044795c0ca5e6da4db26b63b05c37b39e74e301"
+CHKSUMS__ARMV7HF="sha512::2ba7f132f198558ffd30864829d2ed71ade1cdec87092df3c6467f737475bea4acb82c2c366cd1e84fd6eccedc302294b408397c482580ce93cc9f534fea08de"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(6\..+?)\""

--- a/app-devel/aspnetcore-targeting-pack-6.0/spec
+++ b/app-devel/aspnetcore-targeting-pack-6.0/spec
@@ -1,12 +1,12 @@
-VER=6.0.0
-SDKVER=6.0.100
+VER=6.0.30
+SDKVER=6.0.422
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::cb0d174a79d6294c302261b645dba6a479da8f7cf6c1fe15ae6998bc09c5e0baec810822f9e0104e84b0efd51fdc0333306cb2a0a6fcdbaf515a8ad8cf1af25b"
+CHKSUMS__AMD64="sha512::e0e6ea234a5aef29c2571784c22396115db292fae8f859f4642f80f873807140bb7bbc009be568e8e34288b46b2e3e7732115b5f02bbc8ca0aa723e183bc084a"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::e5983c1c599d6dc7c3c7496b9698e47c68247f04a5d0d1e3162969d071471297bce1c2fd3a1f9fb88645006c327ae79f880dcbdd8eefc9166fd717331f2716e7"
+CHKSUMS__ARM64="sha512::c03c3708061f266a3d7fb5bf2240f5bdd00be4d877dc3dc62b95a857f2ad62c80dd4c54f5257737ef7bad3cb458685d7f2bcfe71c3562075ac3aed660df8ae41"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha512::c1e555893c48c4f4256d3e6b1d36b31d8a4d7763a6e958fb63dd31436c660648d481612b5e25d79a613e84a1954f5eac2c9c2b740bf410958172780f7bbeaeb3"
+CHKSUMS__ARMV7HF="sha512::b81fd26a92e16b8e9545f2172bc35651c1787178a0a50ef9edc1b98a9e6176b2289e0e0cc29aa57b3c188d3017a4120f9be47068e36dddc4540fea17424cf4a1"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(6\..+?)\""

--- a/app-devel/dotnet-sdk-6.0/spec
+++ b/app-devel/dotnet-sdk-6.0/spec
@@ -1,11 +1,11 @@
-VER=6.0.100
+VER=6.0.422
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Sdk/$VER/dotnet-sdk-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::cb0d174a79d6294c302261b645dba6a479da8f7cf6c1fe15ae6998bc09c5e0baec810822f9e0104e84b0efd51fdc0333306cb2a0a6fcdbaf515a8ad8cf1af25b"
+CHKSUMS__AMD64="sha512::e0e6ea234a5aef29c2571784c22396115db292fae8f859f4642f80f873807140bb7bbc009be568e8e34288b46b2e3e7732115b5f02bbc8ca0aa723e183bc084a"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Sdk/$VER/dotnet-sdk-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::e5983c1c599d6dc7c3c7496b9698e47c68247f04a5d0d1e3162969d071471297bce1c2fd3a1f9fb88645006c327ae79f880dcbdd8eefc9166fd717331f2716e7"
+CHKSUMS__ARM64="sha512::c03c3708061f266a3d7fb5bf2240f5bdd00be4d877dc3dc62b95a857f2ad62c80dd4c54f5257737ef7bad3cb458685d7f2bcfe71c3562075ac3aed660df8ae41"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Sdk/$VER/dotnet-sdk-$VER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha512::c1e555893c48c4f4256d3e6b1d36b31d8a4d7763a6e958fb63dd31436c660648d481612b5e25d79a613e84a1954f5eac2c9c2b740bf410958172780f7bbeaeb3"
+CHKSUMS__ARMV7HF="sha512::b81fd26a92e16b8e9545f2172bc35651c1787178a0a50ef9edc1b98a9e6176b2289e0e0cc29aa57b3c188d3017a4120f9be47068e36dddc4540fea17424cf4a1"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-sdk\": \"(6\..+?)\""

--- a/app-devel/dotnet-templates-6.0/spec
+++ b/app-devel/dotnet-templates-6.0/spec
@@ -1,11 +1,11 @@
-VER=6.0.100
+VER=6.0.422
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Sdk/$VER/dotnet-sdk-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::cb0d174a79d6294c302261b645dba6a479da8f7cf6c1fe15ae6998bc09c5e0baec810822f9e0104e84b0efd51fdc0333306cb2a0a6fcdbaf515a8ad8cf1af25b"
+CHKSUMS__AMD64="sha512::e0e6ea234a5aef29c2571784c22396115db292fae8f859f4642f80f873807140bb7bbc009be568e8e34288b46b2e3e7732115b5f02bbc8ca0aa723e183bc084a"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Sdk/$VER/dotnet-sdk-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::e5983c1c599d6dc7c3c7496b9698e47c68247f04a5d0d1e3162969d071471297bce1c2fd3a1f9fb88645006c327ae79f880dcbdd8eefc9166fd717331f2716e7"
+CHKSUMS__ARM64="sha512::c03c3708061f266a3d7fb5bf2240f5bdd00be4d877dc3dc62b95a857f2ad62c80dd4c54f5257737ef7bad3cb458685d7f2bcfe71c3562075ac3aed660df8ae41"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Sdk/$VER/dotnet-sdk-$VER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha512::c1e555893c48c4f4256d3e6b1d36b31d8a4d7763a6e958fb63dd31436c660648d481612b5e25d79a613e84a1954f5eac2c9c2b740bf410958172780f7bbeaeb3"
+CHKSUMS__ARMV7HF="sha512::b81fd26a92e16b8e9545f2172bc35651c1787178a0a50ef9edc1b98a9e6176b2289e0e0cc29aa57b3c188d3017a4120f9be47068e36dddc4540fea17424cf4a1"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-sdk\": \"(6\..+?)\""

--- a/lang-dotnet/dotnet-apphost-pack-6.0/spec
+++ b/lang-dotnet/dotnet-apphost-pack-6.0/spec
@@ -1,12 +1,12 @@
-VER=6.0.0
-SDKVER=6.0.100
+VER=6.0.30
+SDKVER=6.0.422
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::cb0d174a79d6294c302261b645dba6a479da8f7cf6c1fe15ae6998bc09c5e0baec810822f9e0104e84b0efd51fdc0333306cb2a0a6fcdbaf515a8ad8cf1af25b"
+CHKSUMS__AMD64="sha512::e0e6ea234a5aef29c2571784c22396115db292fae8f859f4642f80f873807140bb7bbc009be568e8e34288b46b2e3e7732115b5f02bbc8ca0aa723e183bc084a"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::e5983c1c599d6dc7c3c7496b9698e47c68247f04a5d0d1e3162969d071471297bce1c2fd3a1f9fb88645006c327ae79f880dcbdd8eefc9166fd717331f2716e7"
+CHKSUMS__ARM64="sha512::c03c3708061f266a3d7fb5bf2240f5bdd00be4d877dc3dc62b95a857f2ad62c80dd4c54f5257737ef7bad3cb458685d7f2bcfe71c3562075ac3aed660df8ae41"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha512::c1e555893c48c4f4256d3e6b1d36b31d8a4d7763a6e958fb63dd31436c660648d481612b5e25d79a613e84a1954f5eac2c9c2b740bf410958172780f7bbeaeb3"
+CHKSUMS__ARMV7HF="sha512::b81fd26a92e16b8e9545f2172bc35651c1787178a0a50ef9edc1b98a9e6176b2289e0e0cc29aa57b3c188d3017a4120f9be47068e36dddc4540fea17424cf4a1"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(6\..+?)\""

--- a/lang-dotnet/dotnet-hostfxr-6.0/spec
+++ b/lang-dotnet/dotnet-hostfxr-6.0/spec
@@ -1,11 +1,11 @@
-VER=6.0.0
+VER=6.0.30
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::7cc8d93f9495b516e1b33bf82af3af605f1300bcfeabdd065d448cc126bd97ab4da5ec5e95b7775ee70ab4baf899ff43671f5c6f647523fb41cda3d96f334ae5"
+CHKSUMS__AMD64="sha512::b43200ec3a8c74475f396becd21d22c6a78a6713585837707c2a84bbb869c7e551a05c4c1c1cdba8083baebdd09bc356de5d5a833b8bc84b83421d3ecfac71ca"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::b0f0f2b4dc0a31b06cc3af541a3c44260317ca3a4414a5d50e6cf859d93821b3d2c2246baec9f96004aeb1eb0e353631283b11cf3acc134d4694f0ed71c9503d"
+CHKSUMS__ARM64="sha512::75fa6de07e5d8e5485af910de522c1d0afed0532008ded1e80ec3f576c9a78c6e5759dd4d1331159263c02121a4d8f1e532f0533c11524c2d782cf861be13c09"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha512::575037f2e164deaf3bcdd82f7b3f2b5a5784547c5bad4070375c00373722265401b88a81695b919f92ca176f21c1bdf1716f8fce16ab3d301ae666daa8cae750"
+CHKSUMS__ARMV7HF="sha512::2a8e470886009a8626a7cace3b6f7ad5cc36c5e440be5d1eab792ccc51653bdcf4ba82d94dfd86bcfbdd9f41eef15161955fa2a6fd68b7a9c6ea46f3c043fe39"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(6\..+?)\""

--- a/lang-dotnet/dotnet-runtime-6.0/spec
+++ b/lang-dotnet/dotnet-runtime-6.0/spec
@@ -1,11 +1,11 @@
-VER=6.0.0
+VER=6.0.30
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::7cc8d93f9495b516e1b33bf82af3af605f1300bcfeabdd065d448cc126bd97ab4da5ec5e95b7775ee70ab4baf899ff43671f5c6f647523fb41cda3d96f334ae5"
+CHKSUMS__AMD64="sha512::b43200ec3a8c74475f396becd21d22c6a78a6713585837707c2a84bbb869c7e551a05c4c1c1cdba8083baebdd09bc356de5d5a833b8bc84b83421d3ecfac71ca"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::b0f0f2b4dc0a31b06cc3af541a3c44260317ca3a4414a5d50e6cf859d93821b3d2c2246baec9f96004aeb1eb0e353631283b11cf3acc134d4694f0ed71c9503d"
+CHKSUMS__ARM64="sha512::75fa6de07e5d8e5485af910de522c1d0afed0532008ded1e80ec3f576c9a78c6e5759dd4d1331159263c02121a4d8f1e532f0533c11524c2d782cf861be13c09"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha512::575037f2e164deaf3bcdd82f7b3f2b5a5784547c5bad4070375c00373722265401b88a81695b919f92ca176f21c1bdf1716f8fce16ab3d301ae666daa8cae750"
+CHKSUMS__ARMV7HF="sha512::2a8e470886009a8626a7cace3b6f7ad5cc36c5e440be5d1eab792ccc51653bdcf4ba82d94dfd86bcfbdd9f41eef15161955fa2a6fd68b7a9c6ea46f3c043fe39"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(6\..+?)\""

--- a/lang-dotnet/dotnet-targeting-pack-6.0/spec
+++ b/lang-dotnet/dotnet-targeting-pack-6.0/spec
@@ -1,12 +1,12 @@
-VER=6.0.0
-SDKVER=6.0.100
+VER=6.0.30
+SDKVER=6.0.422
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::cb0d174a79d6294c302261b645dba6a479da8f7cf6c1fe15ae6998bc09c5e0baec810822f9e0104e84b0efd51fdc0333306cb2a0a6fcdbaf515a8ad8cf1af25b"
+CHKSUMS__AMD64="sha512::e0e6ea234a5aef29c2571784c22396115db292fae8f859f4642f80f873807140bb7bbc009be568e8e34288b46b2e3e7732115b5f02bbc8ca0aa723e183bc084a"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::e5983c1c599d6dc7c3c7496b9698e47c68247f04a5d0d1e3162969d071471297bce1c2fd3a1f9fb88645006c327ae79f880dcbdd8eefc9166fd717331f2716e7"
+CHKSUMS__ARM64="sha512::c03c3708061f266a3d7fb5bf2240f5bdd00be4d877dc3dc62b95a857f2ad62c80dd4c54f5257737ef7bad3cb458685d7f2bcfe71c3562075ac3aed660df8ae41"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha512::c1e555893c48c4f4256d3e6b1d36b31d8a4d7763a6e958fb63dd31436c660648d481612b5e25d79a613e84a1954f5eac2c9c2b740bf410958172780f7bbeaeb3"
+CHKSUMS__ARMV7HF="sha512::b81fd26a92e16b8e9545f2172bc35651c1787178a0a50ef9edc1b98a9e6176b2289e0e0cc29aa57b3c188d3017a4120f9be47068e36dddc4540fea17424cf4a1"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(6\..+?)\""


### PR DESCRIPTION
Topic Description
-----------------

- aspnetcore-targeting-pack-6.0: update to 6.0.30
- dotnet-sdk-6.0: update to 6.0.422
- dotnet-apphost-pack-6.0: update to 6.0.30
- dotnet-targeting-pack-6.0: update to 6.0.30
- dotnet-template-6.0: update to 6.0.422
- aspnetcore-runtime-6.0: update to 6.0.30
- dotnet-runtime-6.0: update to 6.0.30
- dotnet-hostfxr-6.0: update to 6.0.30

Package(s) Affected
-------------------

- aspnetcore-runtime-6.0: 6.0.30
- aspnetcore-targeting-pack-6.0: 6.0.30
- dotnet-apphost-pack-6.0: 6.0.30
- dotnet-hostfxr-6.0: 6.0.30
- dotnet-runtime-6.0: 6.0.30
- dotnet-sdk-6.0: 6.0.422
- dotnet-targeting-pack-6.0: 6.0.30
- dotnet-templates-6.0: 6.0.422

Security Update?
----------------

No

Build Order
-----------

```
#buildit aspnetcore-runtime-6.0 aspnetcore-targeting-pack-6.0 dotnet-apphost-pack-6.0 dotnet-hostfxr-6.0 dotnet-runtime-6.0 dotnet-sdk-6.0 dotnet-targeting-pack-6.0 dotnet-templates-6.0
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
