### PR TITLE
zimg: update to 3.0.5

### DIFF
--- a/runtime-imaging/zimg/spec
+++ b/runtime-imaging/zimg/spec
@@ -1,4 +1,4 @@
-VER=3.0.2
+VER=3.0.5
 SRCS="tbl::https://github.com/sekrit-twc/zimg/archive/release-$VER.tar.gz"
-CHKSUMS="sha256::b9eadf1df12ae8395ba781f2468965d411b21abbebbebeae3651d492227d4633"
+CHKSUMS="sha256::a9a0226bf85e0d83c41a8ebe4e3e690e1348682f6a2a7838f1b8cbff1b799bcf"
 CHKUPDATE="anitya::id=13685"


### PR DESCRIPTION
Topic Description
-----------------

- zimg: update to 3.0.5
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- zimg: 3.0.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit zimg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
