### PR TITLE
libpfm: update to 4.13.0

### DIFF
--- a/runtime-admin/libpfm/autobuild/build
+++ b/runtime-admin/libpfm/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building libpfm ..."
+make PREFIX=/usr ${MAKE_AFTER}
+
+abinfo "Installing libpfm ..."
+make install PREFIX=/usr DESTDIR="$PKGDIR" ${MAKE_AFTER}

--- a/runtime-admin/libpfm/spec
+++ b/runtime-admin/libpfm/spec
@@ -1,4 +1,4 @@
-VER=4.12.0
+VER=4.13.0
 SRCS="tbl::https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-$VER.tar.gz"
-CHKSUMS="sha256::4b0c1f53f39a61525b69bebf532c68040c1b984d7544a8ae0844b13cd91e1ee4"
+CHKSUMS="sha256::d18b97764c755528c1051d376e33545d0eb60c6ebf85680436813fa5b04cc3d1"
 CHKUPDATE="anitya::id=21491"


### PR DESCRIPTION
Topic Description
-----------------

- libpfm: update to 4.13.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libpfm: 4.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpfm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
