### PR TITLE
libnl: update to 3.9.0

### DIFF
--- a/runtime-network/libnl/spec
+++ b/runtime-network/libnl/spec
@@ -1,4 +1,4 @@
-VER=3.5.0
+VER=3.9.0
 SRCS="tbl::https://github.com/thom311/libnl/releases/download/libnl${VER//./_}/libnl-$VER.tar.gz"
-CHKSUMS="sha256::352133ec9545da76f77e70ccb48c9d7e5324d67f6474744647a7ed382b5e05fa"
+CHKSUMS="sha256::aed507004d728a5cf11eab48ca4bf9e6e1874444e33939b9d3dfed25018ee9bb"
 CHKUPDATE="anitya::id=1684"


### PR DESCRIPTION
Topic Description
-----------------

- libnl: update to 3.9.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libnl: 3.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libnl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
