### PR TITLE
python-mpd2: update to 3.1.1

### DIFF
--- a/lang-python/python-mpd2/spec
+++ b/lang-python/python-mpd2/spec
@@ -1,4 +1,4 @@
-VER=3.0.5
+VER=3.1.1
 SRCS="tbl::https://github.com/Mic92/python-mpd2/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::f0ff8e421fa40a2ad92f6b7420385847cf27076b1d000fb1cbaec7f5f456821d"
+CHKSUMS="sha256::9c8485c8900af294b7287fd5fb061c0cc34827ef13e26d5728ae6a24afe56d4b"
 CHKUPDATE="anitya::id=19721"


### PR DESCRIPTION
Topic Description
-----------------

- python-mpd2: update to 3.1.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- python-mpd2: 3.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit python-mpd2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
