### PR TITLE
caddy: new, 2.7.6

### DIFF
--- a/app-web/caddy/autobuild/build
+++ b/app-web/caddy/autobuild/build
@@ -1,0 +1,29 @@
+abinfo "Building Caddy executables ..."
+xcaddy build v$PKGVER
+
+abinfo "Installing Caddy executables ..."
+install -Dvm755 "$SRCDIR"/caddy \
+    -t "$PKGDIR"/usr/bin/
+
+abinfo "Installing manpages ..."
+"$SRCDIR"/caddy manpage -o "$PKGDIR"/usr/share/man/man8
+
+abinfo "Installing bash completions ..."
+install -d "$PKGDIR"/etc/bash-completion.d/
+"$SRCDIR"/caddy completion bash > "$PKGDIR"/etc/bash-completion.d/caddy
+
+install -d "$PKGDIR"/var/lib/caddy/
+
+abinfo "Installing default config ..."
+
+install -Dvm644 "$SRCDIR"/config/Caddyfile \
+    -t "$PKGDIR"/etc/caddy/
+
+install -Dvm644 "$SRCDIR"/welcome/index.html \
+    -t "$PKGDIR"/usr/share/caddy/
+
+install -Dvm644 "$SRCDIR"/init/caddy.service \
+    -t "$PKGDIR"/usr/lib/systemd/system/
+
+install -Dvm644 "$SRCDIR"/init/caddy-api.service \
+    -t "$PKGDIR"/usr/lib/systemd/system/

--- a/app-web/caddy/autobuild/conffiles
+++ b/app-web/caddy/autobuild/conffiles
@@ -1,0 +1,1 @@
+/etc/caddy/Caddyfile

--- a/app-web/caddy/autobuild/defines
+++ b/app-web/caddy/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=caddy
+PKGSEC=web
+PKGDES="Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS"
+PKGDEP="glibc"
+BUILDDEP="go xcaddy"
+
+ABSPLITDBG=0

--- a/app-web/caddy/autobuild/overrides/usr/lib/sysusers.d/caddy.conf
+++ b/app-web/caddy/autobuild/overrides/usr/lib/sysusers.d/caddy.conf
@@ -1,0 +1,1 @@
+u caddy - "Caddy web server" /var/lib/caddy

--- a/app-web/caddy/autobuild/postinst
+++ b/app-web/caddy/autobuild/postinst
@@ -1,0 +1,7 @@
+echo "Creating user for caddy ..."
+systemd-sysusers caddy.conf
+
+echo "Creating log folder for caddy ..."
+mkdir -p /var/log/caddy
+chmod 750 /var/log/caddy
+chown caddy:log /var/log/caddy

--- a/app-web/caddy/spec
+++ b/app-web/caddy/spec
@@ -1,0 +1,4 @@
+VER=2.7.6
+SRCS="git::commit=tags/v$VER::https://github.com/caddyserver/dist"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=15601"

--- a/app-web/xcaddy/autobuild/build
+++ b/app-web/xcaddy/autobuild/build
@@ -1,0 +1,11 @@
+# FIXME: PIE not support on loongarch64 and loongson3.
+if ! ab_match_arch loongarch64 && \
+   ! ab_match_arch loongson3; then
+    go build -buildmode=pie -o xcaddy cmd/xcaddy/main.go
+else 
+    go build -o xcaddy cmd/xcaddy/main.go
+fi
+
+abinfo "Installing executables ..."
+install -Dvm755 "$SRCDIR"/xcaddy \
+    -t "$PKGDIR"/usr/bin/

--- a/app-web/xcaddy/autobuild/defines
+++ b/app-web/xcaddy/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=xcaddy
+PKGSEC=web
+PKGDES="Build Caddy with plugins"
+PKGDEP="glibc"
+BUILDDEP="go"
+
+ABSPLITDBG=0

--- a/app-web/xcaddy/spec
+++ b/app-web/xcaddy/spec
@@ -1,0 +1,4 @@
+VER=0.4.1
+SRCS="git::commit=tags/v$VER::https://github.com/caddyserver/xcaddy"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=caddyserver/xcaddy"


### PR DESCRIPTION
Topic Description
-----------------

- caddy: new, 2.7.6
- xcaddy: new, 0.4.1

Package(s) Affected
-------------------

- xcaddy: 0.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xcaddy  caddy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
