### PR TITLE
racket: update to 8.13

### DIFF
--- a/lang-lisp/racket/spec
+++ b/lang-lisp/racket/spec
@@ -1,5 +1,5 @@
-VER=8.12
+VER=8.13
 SRCS="tbl::https://mirror.racket-lang.org/installers/$VER/racket-$VER-src.tgz"
 SUBDIR="racket-$VER/src"
-CHKSUMS="sha256::a2bdba9e2ae6e5d1a18364bcb68f7d04538e492d8e92c9fb61bd32d8be5bebd7"
+CHKSUMS="sha256::001e04920440b6589cf62d5677d18cc2ff6ae8fbaf77e63b8a8cf20890685fbc"
 CHKUPDATE="anitya::id=13609"


### PR DESCRIPTION
Topic Description
-----------------

- racket: update to 8.13
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- racket: 8.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit racket
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
