### PR TITLE
pavucontrol: update to 6.0

### DIFF
--- a/app-multimedia/pavucontrol/autobuild/defines
+++ b/app-multimedia/pavucontrol/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=pavucontrol
 PKGSEC=sound
-PKGDEP="gnome-icon-theme gtkmm-3 libcanberra libsigc++ pulseaudio"
-BUILDDEP="intltool lynx"
+PKGDEP="gtkmm-4 libcanberra libsigc++-3.0 pulseaudio json-glib"
+BUILDDEP="meson lynx"
 PKGDES="A GTK+ volume control for PulseAudio"
 
-AUTOTOOLS_AFTER="--enable-gtk3"
-ABSHADOW=no
+ABTYPE=meson
+MESON_AFTER="-Dlynx=true"

--- a/app-multimedia/pavucontrol/autobuild/prepare
+++ b/app-multimedia/pavucontrol/autobuild/prepare
@@ -1,1 +1,0 @@
-export CXXFLAGS="${CXXFLAGS} -std=c++11"

--- a/app-multimedia/pavucontrol/spec
+++ b/app-multimedia/pavucontrol/spec
@@ -1,5 +1,4 @@
-VER=3.0
-REL=3
-SRCS="git::commit=9b307dcfe2051caea7145c8ab48953bb4f57005c::git://anongit.freedesktop.org/pulseaudio/pavucontrol"
+VER=6.0
+SRCS="git::commit=tags/v$VER::https://gitlab.freedesktop.org/pulseaudio/pavucontrol"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8636"

--- a/desktop-gnome/gtkmm-4/autobuild/defines
+++ b/desktop-gnome/gtkmm-4/autobuild/defines
@@ -1,10 +1,13 @@
 PKGNAME=gtkmm-4
 PKGSEC=gnome
-PKGDEP="gtk-4 pangomm-2.48 atkmm"
+PKGDEP="gtk-4 pangomm-2.48 glibmm-2.68 gdk-pixbuf cairomm-1.16"
 BUILDDEP="doxygen graphviz libxslt mm-common"
 PKGDES="C++ bindings for GTK 4"
 
 ABTYPE=meson
+# Disabling demos, it does not install the binary anyway
 MESON_AFTER="-Dbuild-deprecated-api=true \
              -Dbuild-documentation=true \
-             -Dbuild-demos=true"
+             -Dbuild-demos=false \
+             -Dbuild-tests=false \
+             -Dmaintainer-mode=true"

--- a/desktop-gnome/gtkmm-4/spec
+++ b/desktop-gnome/gtkmm-4/spec
@@ -1,4 +1,4 @@
-VER=4.0.2
-SRCS="tbl::https://download.gnome.org/sources/gtkmm/${VER:0:3}/gtkmm-$VER.tar.xz"
-CHKSUMS="sha256::0c836e8daffd836ef469499b7a733afda3a5260ea0e4d81c552f688ae384bd97"
-CHKUPDATE="anitya::id=13942"
+VER=4.14.0
+SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/gtkmm"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=7963"


### PR DESCRIPTION
Topic Description
-----------------

- pavucontrol: update to 6.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- gtkmm-4: update to 4.14.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- gtkmm-4: 4.14.0
- pavucontrol: 6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtkmm-4 pavucontrol
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
