### PR TITLE
polyphone: new, 2.3.0

### DIFF
--- a/app-multimedia/polyphone/autobuild/build
+++ b/app-multimedia/polyphone/autobuild/build
@@ -1,0 +1,16 @@
+abinfo "Building polyphone..." 
+qmake-qt5 CONFIG+=release CONFIG+=force_debug_info "$SRCDIR"/sources/polyphone.pro
+make
+
+abinfo "Installing polyphone..."
+install -vDm 755 "$SRCDIR"/bin/polyphone -t "$PKGDIR"/usr/bin/
+install -vDm 644 "$SRCDIR"/sources/resources/logo.svg "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/polyphone.svg
+install -vDm 644 "$SRCDIR"/sources/resources/polyphone.png -t "$PKGDIR"/usr/share/icons/hicolor/512x512/apps
+install -vDm 644 "$SRCDIR"/sources/contrib/man/fr/man1/polyphone.*1 -t "$PKGDIR"/usr/share/man/fr/man1/
+install -vDm 644 "$SRCDIR"/sources/contrib/man/man1/polyphone.*1 -t "$PKGDIR"/usr/share/man/man1/
+install -vDm 644 "$SRCDIR"/sources/contrib/man/ru/man1/polyphone.*1 -t "$PKGDIR"/usr/share/man/ru/man1/
+install -vDm 644 "$SRCDIR"/sources/contrib/*.desktop -t "$PKGDIR"/usr/share/applications/
+install -vDm 644 "$SRCDIR"/sources/contrib/audio-x-soundfont.svg -t "$PKGDIR"/usr/share/icons/hicolor/scalable/mimetypes/
+install -vDm 644 "$SRCDIR"/sources/contrib/*.xml -t "$PKGDIR"/usr/share/metainfo/
+install -vDm 644 "$SRCDIR"/sources/contrib/polyphone.xml -t "$PKGDIR"/usr/share/mime/packages/
+install -vDm 644 "$SRCDIR"/{README.md,sources/changelog} -t "$PKGDIR"/usr/share/doc/polyphone/

--- a/app-multimedia/polyphone/autobuild/defines
+++ b/app-multimedia/polyphone/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=polyphone
+PKGSEC=sound
+PKGDEP="qt-5 zlib openssl"
+BUILDDEP="flac jack libogg libvorbis portaudio qcustomplot rtmidi stk"
+PKGDES="A soundfont editor for quickly designing musical instruments"

--- a/app-multimedia/polyphone/spec
+++ b/app-multimedia/polyphone/spec
@@ -1,0 +1,4 @@
+VER=2.3.0
+SRCS="git::commit=tags/$VER::https://github.com/davy7125/polyphone.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372486"

--- a/runtime-desktop/qcustomplot/autobuild/build
+++ b/runtime-desktop/qcustomplot/autobuild/build
@@ -1,0 +1,13 @@
+abinfo "Building qcustomplot..."
+tar xvf "$SRCDIR"/../sharedlib.tar.gz
+qmake-qt5 CONFIG+=release CONFIG+=force_debug_info "$SRCDIR"/qcustomplot-sharedlib/sharedlib-compilation/sharedlib-compilation.pro
+make
+
+abinfo "Installing qcustomplot..."
+install -vDm 644 "$SRCDIR"/qcustomplot.h -t "$PKGDIR"/usr/include/
+install -vdm 755 "$PKGDIR"/usr/lib/
+cp -av "$SRCDIR"/libqcustomplot.so* "$PKGDIR"/usr/lib/
+install -vDm 644 "$SRCDIR"/changelog.txt -t "$PKGDIR"/usr/share/doc/qcustomplot/
+install -vDm 644 "$SRCDIR"/documentation/*.qch -t "$PKGDIR"/usr/share/doc/qt/
+find "$SRCDIR"/examples -type f -exec install -vDm 644 {} "$PKGDIR"/usr/share/doc/qcustomplot/{} \; 
+find "$SRCDIR"/documentation/html -type f -exec install -vDm 644 {} "$PKGDIR"/usr/share/doc/qcustomplot/{} \;

--- a/runtime-desktop/qcustomplot/autobuild/defines
+++ b/runtime-desktop/qcustomplot/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=qcustomplot
+PKGSEC=libs
+PKGDEP="qt-5"
+PKGDES="Qt C++ widget for plotting and data visualization"

--- a/runtime-desktop/qcustomplot/spec
+++ b/runtime-desktop/qcustomplot/spec
@@ -1,0 +1,6 @@
+VER=2.1.1
+SRCS="tbl::https://www.qcustomplot.com/release/$VER/QCustomPlot.tar.gz \
+     file::rename=sharedlib.tar.gz::https://www.qcustomplot.com/release/$VER/QCustomPlot-sharedlib.tar.gz"
+CHKSUMS="sha256::9afc16e70e8bd8c8d5b13020387716f5e063e115b6599f0421a3846dc6ec312a \
+         sha256::35d6ea9c7e8740edf0b37e2cb6aa6794150d0dde2541563e493f3f817012b4c0"
+CHKUPDATE="anitya::id=28083"


### PR DESCRIPTION
Topic Description
-----------------

- qcustomplot: new, 2.1.1
- polyphone: new, 2.3.0

Package(s) Affected
-------------------

- polyphone: 2.3.0
- qcustomplot: 2.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qcustomplot polyphone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
