### PR TITLE
mono: update to 6.12.0.206

### DIFF
--- a/lang-dotnet/mono/spec
+++ b/lang-dotnet/mono/spec
@@ -1,5 +1,5 @@
-VER=6.12.0.182
+VER=6.12.0.206
 REL=1
-SRCS="tbl::https://download.mono-project.com/sources/mono/mono-$VER.tar.xz"
-CHKSUMS="sha256::57366a6ab4f3b5ecf111d48548031615b3a100db87c679fc006e8c8a4efd9424"
+SRCS="git::commit=tags/mono-$VER::https://github.com/mono/mono.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6360"


### PR DESCRIPTION
Topic Description
-----------------

- mono: update to 6.12.0.206

Package(s) Affected
-------------------

- mono: 6.12.0.206-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mono
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
