### PR TITLE
linux-kernel (Linux Kernel): update to 6.9.2

### DIFF
--- a/app-admin/kernel-tools/spec
+++ b/app-admin/kernel-tools/spec
@@ -1,8 +1,8 @@
-VER=6.9.1
+VER=6.9.2
 #RC=
 # Use this for RC releases.
 #SRCS="tbl::https://git.kernel.org/torvalds/t/linux-${VER%%.0}-rc${RC}.tar.gz"
 # Use this for stable releases.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
-CHKSUMS="sha256::01b414ba98fd189ecd544435caf3860ae2a790e3ec48f5aa70fdf42dc4c5c04a"
+CHKSUMS="sha256::d46c5bdf2c5961cc2a4dedefe0434d456865e95e4a7cd9f93fff054f9090e5f9"
 CHKUPDATE="anitya::id=6501"

--- a/runtime-kernel/linux+kernel/autobuild/defines
+++ b/runtime-kernel/linux+kernel/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=linux+kernel
 PKGSEC=kernel
-PKGDEP="linux-kernel-6.9.1"
+PKGDEP="linux-kernel-6.9.2"
 PKGDES="Generic Linux Kernel for AOSC OS (Mainline)"
 
 PKGREP="linux+image+new linux+header+new linux+image linux+header linux+image+old linux+header+old"

--- a/runtime-kernel/linux+kernel/spec
+++ b/runtime-kernel/linux+kernel/spec
@@ -1,3 +1,3 @@
-VER=6.9.1
+VER=6.9.2
 DUMMYSRC=1
 CHKUPDATE="anitya::id=6501"

--- a/runtime-kernel/linux-kernel/autobuild/defines
+++ b/runtime-kernel/linux-kernel/autobuild/defines
@@ -1,11 +1,11 @@
-PKGNAME=linux-kernel-6.9.1
+PKGNAME=linux-kernel-6.9.2
 PKGSEC=kernel
 PKGDEP=""
 BUILDDEP="bc git pahole parallel kernel-build-common"
 BUILDDEP__AMD64="$BUILDDEP llvm"
 BUILDDEP__ARM64="$BUILDDEP llvm"
 BUILDDEP__MIPS64R6EL="${BUILDDEP} uboot-tools"
-PKGDES="Generic Linux Kernel v6.9.1 for AOSC OS (Mainline)"
+PKGDES="Generic Linux Kernel v6.9.2 for AOSC OS (Mainline)"
 
 ABSTRIP=0
 ABELFDEP=0

--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-ath9k-rx-dma-stop-check.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-ath9k-rx-dma-stop-check.patch
@@ -1,4 +1,4 @@
-From f8a88e47fd3f9d5d38072cf9411fc8828738e5a0 Mon Sep 17 00:00:00 2001
+From 6ae3f449b1518205c121ff1a0e09d8a44df3bedb Mon Sep 17 00:00:00 2001
 From: "kernel-team@fedoraproject.org" <kernel-team@fedoraproject.org>
 Date: Wed, 6 Feb 2013 09:57:47 -0500
 Subject: [PATCH 01/60] ath9k: rx dma stop check

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
@@ -1,4 +1,4 @@
-From ba869360e80773df4318e0a65717c9a7efb8363f Mon Sep 17 00:00:00 2001
+From 6200a5714b8555ca9bb6dce9dadaef5f9b5f3545 Mon Sep 17 00:00:00 2001
 From: Mark Weiman <mark.weiman@markzz.com>
 Date: Wed, 27 Jan 2021 13:28:09 -0500
 Subject: [PATCH 02/60] pci: Enable overrides for missing ACS capabilities

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-cpuinfo-fix-a-warning-for-CONFIG_CPUMASK_OFFSTACK.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-cpuinfo-fix-a-warning-for-CONFIG_CPUMASK_OFFSTACK.patch
@@ -1,4 +1,4 @@
-From 715ad51e77c9e3e7e17589f6e7ee8dd7c6adf68f Mon Sep 17 00:00:00 2001
+From 33fec7ba09d05054f125061b0f581812440e3d2e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 12 Jul 2022 12:47:48 +0800
 Subject: [PATCH 03/60] cpuinfo: fix a warning for CONFIG_CPUMASK_OFFSTACK

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-HACK-drm-amdgpu-use-amdgpu-by-default-for-si-cik-dev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-HACK-drm-amdgpu-use-amdgpu-by-default-for-si-cik-dev.patch
@@ -1,4 +1,4 @@
-From ffd7b13a8dce9a6482e181cf0d713815e2c6bd7a Mon Sep 17 00:00:00 2001
+From 5ae095394fe757dd5a3406130e9ae8b80f7912f0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 29 Feb 2024 20:54:51 +0800
 Subject: [PATCH 04/60] HACK(drm/amdgpu): use amdgpu by default for si/cik

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-input-synaptics-pin-3-touches-when-the-firmware-repo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-input-synaptics-pin-3-touches-when-the-firmware-repo.patch
@@ -1,4 +1,4 @@
-From 4e8dcc5783a079885127367d46289fb2ec7db2cf Mon Sep 17 00:00:00 2001
+From 60be06173126d0c8d50a8f82d22070f23981fcd1 Mon Sep 17 00:00:00 2001
 From: Benjamin Tissoires <benjamin.tissoires@redhat.com>
 Date: Thu, 16 Apr 2015 13:01:46 -0400
 Subject: [PATCH 05/60] input: synaptics: pin 3 touches when the firmware

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-hid-logitech-dj-add-support-for-the-new-lightspeed-r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-hid-logitech-dj-add-support-for-the-new-lightspeed-r.patch
@@ -1,4 +1,4 @@
-From 16ffb98927618da8d66ee6461434d433b8b77d64 Mon Sep 17 00:00:00 2001
+From fdd47f4d1a6e1e6f1753a0c6ac2c1fcc72f7b412 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Filipe=20La=C3=ADns?= <lains@riseup.net>
 Date: Sat, 23 Jan 2021 18:03:33 +0000
 Subject: [PATCH 06/60] hid: logitech-dj: add support for the new lightspeed

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-hid-add-PixArt-touchpad-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-hid-add-PixArt-touchpad-driver.patch
@@ -1,4 +1,4 @@
-From b2764a456d1956fc7376b2f3815507ba75032516 Mon Sep 17 00:00:00 2001
+From cb095f8f77764259451f7592a4c2e3fdef9d72c6 Mon Sep 17 00:00:00 2001
 From: zhangtianyang <zhangtianyang@loongson.cn>
 Date: Tue, 31 Aug 2021 20:31:01 +0800
 Subject: [PATCH 07/60] hid: add PixArt touchpad driver

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-hid-register-Surface-hid-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-hid-register-Surface-hid-devices.patch
@@ -1,4 +1,4 @@
-From 3dad9eca69a81b8a47d237c5f61433f0b496d32d Mon Sep 17 00:00:00 2001
+From 09791ff0aa5d006d602f593d65c357da25faad84 Mon Sep 17 00:00:00 2001
 From: qzed <qzed@users.noreply.github.com>
 Date: Tue, 17 Sep 2019 17:16:23 +0200
 Subject: [PATCH 08/60] hid: register Surface hid devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-lis3-improve-handling-of-null-rate.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-lis3-improve-handling-of-null-rate.patch
@@ -1,4 +1,4 @@
-From 97d4816d9204bd7f23bbf7afeaba77e50b13b705 Mon Sep 17 00:00:00 2001
+From 76a482c362243d3c87937cc6f864caf850895436 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=89ric=20Piel?= <eric.piel@tremplin-utc.net>
 Date: Thu, 3 Nov 2011 16:22:40 +0100
 Subject: [PATCH 09/60] lis3: improve handling of null rate

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-ethernet-bundle-module-for-Motorcomm-YT6801.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-ethernet-bundle-module-for-Motorcomm-YT6801.patch
@@ -1,4 +1,4 @@
-From 163cbc42b912bf328fb660e413e5dc436e553956 Mon Sep 17 00:00:00 2001
+From f440f620aba2f3bca730c86e7003192e938ad70a Mon Sep 17 00:00:00 2001
 From: wanghuai <748928840@qq.com>
 Date: Fri, 2 Feb 2024 19:05:26 +0000
 Subject: [PATCH 10/60] ethernet: bundle module for Motorcomm YT6801

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-net-stmmac-Move-the-atds-flag-to-the-stmmac_dma_cfg-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-net-stmmac-Move-the-atds-flag-to-the-stmmac_dma_cfg-.patch
@@ -1,4 +1,4 @@
-From d9b71272e270dfc57fe1088c7bb9bce0d5a5adff Mon Sep 17 00:00:00 2001
+From 516fd611d51fb0b1e6ffc1a8fbae84693e1cbb78 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:01:54 +0800
 Subject: [PATCH 11/60] net: stmmac: Move the atds flag to the stmmac_dma_cfg

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-net-stmmac-Add-multi-channel-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-net-stmmac-Add-multi-channel-support.patch
@@ -1,4 +1,4 @@
-From 0d1f60a8ebca18d236e3bc5c239a4f26ddbae1ae Mon Sep 17 00:00:00 2001
+From a7d9f508a0d32659cf2f7eecff434f12ce49ad1c Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:01:55 +0800
 Subject: [PATCH 12/60] net: stmmac: Add multi-channel support

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-net-stmmac-Export-dwmac1000_dma_ops.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-net-stmmac-Export-dwmac1000_dma_ops.patch
@@ -1,4 +1,4 @@
-From 7f4d7ca19eb8c0621dab91bc30730092d90168cb Mon Sep 17 00:00:00 2001
+From 2bfdaaaaad8154ec43c078c6584d6115ccbe48d7 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:01:56 +0800
 Subject: [PATCH 13/60] net: stmmac: Export dwmac1000_dma_ops

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-net-stmmac-dwmac-loongson-Drop-useless-platform-data.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-net-stmmac-dwmac-loongson-Drop-useless-platform-data.patch
@@ -1,4 +1,4 @@
-From 46788883818f4607c36c4bc2436c1b75d2c9ccab Mon Sep 17 00:00:00 2001
+From 439e2e20f7808a716b966e312ebf9a800b07e630 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:04:35 +0800
 Subject: [PATCH 14/60] net: stmmac: dwmac-loongson: Drop useless platform data

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-net-stmmac-dwmac-loongson-Use-PCI_DEVICE_DATA-macro-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-net-stmmac-dwmac-loongson-Use-PCI_DEVICE_DATA-macro-.patch
@@ -1,4 +1,4 @@
-From 6f9a3fcd3b4a891ff4bf9ca12c2f04a12ac46f30 Mon Sep 17 00:00:00 2001
+From 84ec95704bc16c00a9104095d65e659115e2e325 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:04:36 +0800
 Subject: [PATCH 15/60] net: stmmac: dwmac-loongson: Use PCI_DEVICE_DATA()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-net-stmmac-dwmac-loongson-Split-up-the-platform-data.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-net-stmmac-dwmac-loongson-Split-up-the-platform-data.patch
@@ -1,4 +1,4 @@
-From 2af49e159d75824f2cc4354196850a79889e4480 Mon Sep 17 00:00:00 2001
+From ca9fa8165897305acacdd2ddcfd5684738ce55e5 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:04:37 +0800
 Subject: [PATCH 16/60] net: stmmac: dwmac-loongson: Split up the platform data

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-net-stmmac-dwmac-loongson-Add-ref-and-ptp-clocks-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-net-stmmac-dwmac-loongson-Add-ref-and-ptp-clocks-for.patch
@@ -1,4 +1,4 @@
-From c94543f31e584193473f58893e0b2a5561c6cba0 Mon Sep 17 00:00:00 2001
+From 89c4cee8eebe24ae78b1a12c04d2a2832718e8c7 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:06:10 +0800
 Subject: [PATCH 17/60] net: stmmac: dwmac-loongson: Add ref and ptp clocks for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-net-stmmac-dwmac-loongson-Add-phy-mask-for-Loongson-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-net-stmmac-dwmac-loongson-Add-phy-mask-for-Loongson-.patch
@@ -1,4 +1,4 @@
-From 810141e49637cce02be373c9627921a0b85d382f Mon Sep 17 00:00:00 2001
+From 0852745507c47bea48508dc6016c8ae672776b6a Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:06:11 +0800
 Subject: [PATCH 18/60] net: stmmac: dwmac-loongson: Add phy mask for Loongson

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-net-stmmac-dwmac-loongson-Add-phy_interface-for-Loon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-net-stmmac-dwmac-loongson-Add-phy_interface-for-Loon.patch
@@ -1,4 +1,4 @@
-From 9e19c7242dd331b2d3186496845b97b287a17da7 Mon Sep 17 00:00:00 2001
+From a05bd6f89b3a62f7bc5fa37b5ee4ee457152f276 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:06:12 +0800
 Subject: [PATCH 19/60] net: stmmac: dwmac-loongson: Add phy_interface for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-net-stmmac-dwmac-loongson-Add-full-PCI-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-net-stmmac-dwmac-loongson-Add-full-PCI-support.patch
@@ -1,4 +1,4 @@
-From fbaac92971742fa1d76ef50d1c541f4b5d7fbbfb Mon Sep 17 00:00:00 2001
+From 934659c12160b9393b1b74db879c96da73dd61f7 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:10:35 +0800
 Subject: [PATCH 20/60] net: stmmac: dwmac-loongson: Add full PCI support

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-net-stmmac-dwmac-loongson-Add-loongson_dwmac_config_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-net-stmmac-dwmac-loongson-Add-loongson_dwmac_config_.patch
@@ -1,4 +1,4 @@
-From 55ac576c4775d405f8af1c8cc48de8e577356f70 Mon Sep 17 00:00:00 2001
+From c2bb2010344ad10e7eefd3656bd6bff93e3d28ae Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:10:36 +0800
 Subject: [PATCH 21/60] net: stmmac: dwmac-loongson: Add

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-net-stmmac-dwmac-loongson-Fixed-failure-to-set-netwo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-net-stmmac-dwmac-loongson-Fixed-failure-to-set-netwo.patch
@@ -1,4 +1,4 @@
-From ea29f7439d15d2fdafac0dbb9d4d8160b7925957 Mon Sep 17 00:00:00 2001
+From 25c2399dcf11b78cfe521c9b9456ba5bfcd5db21 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:10:37 +0800
 Subject: [PATCH 22/60] net: stmmac: dwmac-loongson: Fixed failure to set

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-net-stmmac-dwmac-loongson-Add-Loongson-GNET-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-net-stmmac-dwmac-loongson-Add-Loongson-GNET-support.patch
@@ -1,4 +1,4 @@
-From 9be486483a71aa34515ac2770a66956b82df55ca Mon Sep 17 00:00:00 2001
+From 61225815962a1e452e0c10c764e7dcba45fccc8e Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:11:36 +0800
 Subject: [PATCH 23/60] net: stmmac: dwmac-loongson: Add Loongson GNET support

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-net-stmmac-dwmac-loongson-Move-disable_force-flag-to.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-net-stmmac-dwmac-loongson-Move-disable_force-flag-to.patch
@@ -1,4 +1,4 @@
-From 9e6cfa36c31ad7b93ea1d20fe3c296861d50d8b7 Mon Sep 17 00:00:00 2001
+From 8ec06a72dce89bf320e413411690386ca014d898 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:11:37 +0800
 Subject: [PATCH 24/60] net: stmmac: dwmac-loongson: Move disable_force flag to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-net-stmmac-dwmac-loongson-Add-loongson-module-author.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-net-stmmac-dwmac-loongson-Add-loongson-module-author.patch
@@ -1,4 +1,4 @@
-From 09127b390947352ed0563dd2cab43b20628124fe Mon Sep 17 00:00:00 2001
+From d1ae6c9fa7f4bd0fce59def96a650559e051ee36 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Thu, 25 Apr 2024 21:11:38 +0800
 Subject: [PATCH 25/60] net: stmmac: dwmac-loongson: Add loongson module author

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-net-stmmac-add-a-glue-driver-for-GMACs-in-Phytium-So.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-net-stmmac-add-a-glue-driver-for-GMACs-in-Phytium-So.patch
@@ -1,4 +1,4 @@
-From 6dddac6ca13db95be80d7cfd3a687dfd1cf1bdae Mon Sep 17 00:00:00 2001
+From 3adff010cbe6a53181facbc75e306b3270fb9f11 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 25 Sep 2022 23:03:51 +0800
 Subject: [PATCH 26/60] net: stmmac: add a glue driver for GMACs in Phytium

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-x86-add-more-uarches-for-kernel-6.8-rc4.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-x86-add-more-uarches-for-kernel-6.8-rc4.patch
@@ -1,4 +1,4 @@
-From 8805cf2aab45dc54febbc23ed426033589452f08 Mon Sep 17 00:00:00 2001
+From 7c8ccc699eb046d0a65479a450f2ab4b355cb8a2 Mon Sep 17 00:00:00 2001
 From: graysky <therealgraysky@proton.me>
 Date: Wed, 21 Feb 2024 08:38:13 -0500
 Subject: [PATCH 27/60] x86: add more uarches for kernel 6.8-rc4+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-arm-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-arm-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,4 +1,4 @@
-From 34a8be48253f4c36189a7f42ae99228069688e46 Mon Sep 17 00:00:00 2001
+From b764926568f67692e057b31e32d399589973fa9b Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux@gmail.com>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
 Subject: [PATCH 28/60] arm: usb: phy: tegra: Add 38.4MHz clock table entry

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
@@ -1,4 +1,4 @@
-From 6295ed7be07071165bb93d6f70c10f7b4c9586a3 Mon Sep 17 00:00:00 2001
+From f8a9c93e99871082491385444334858c9f01bf51 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
 Subject: [PATCH 29/60] arm64: dts: rockchip: change GMAC rx_delay for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-arm64-dts-rockchip-add-out-of-band-IRQ-for-RK3399-Wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-arm64-dts-rockchip-add-out-of-band-IRQ-for-RK3399-Wi.patch
@@ -1,4 +1,4 @@
-From a0d27d7397e218f8f18346d27a84c82b07cb854d Mon Sep 17 00:00:00 2001
+From 4a62f2fd4b31ec771c892c3c8deb48e199ff6906 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 30 Nov 2020 22:49:55 +0800
 Subject: [PATCH 30/60] arm64: dts: rockchip: add out-of-band IRQ for RK3399

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-arm64-rockchip-dts-rk3399-fix-PD-on-Pinebook-Pro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-arm64-rockchip-dts-rk3399-fix-PD-on-Pinebook-Pro.patch
@@ -1,4 +1,4 @@
-From 41821d94fde9581774edc38245ce8623fb98e9d3 Mon Sep 17 00:00:00 2001
+From 8e052975cc2d95b7b3be520b16a2a02b05273802 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Tue, 1 Dec 2020 16:19:04 +0800
 Subject: [PATCH 31/60] arm64: rockchip: dts: rk3399: fix PD on Pinebook Pro

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-arm64-add-Kconfig-option-for-Phytium-SoCs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-arm64-add-Kconfig-option-for-Phytium-SoCs.patch
@@ -1,4 +1,4 @@
-From cc7a86b2be4459a5768486a9749a332a4a76abca Mon Sep 17 00:00:00 2001
+From 684bfc426786dcf9e0073e83d1497c2ea622013a Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 25 Sep 2022 23:02:39 +0800
 Subject: [PATCH 32/60] arm64: add Kconfig option for Phytium SoCs

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,4 +1,4 @@
-From 84f171cf106b9db8cce08f9637dc059dcf8ba412 Mon Sep 17 00:00:00 2001
+From ed9187824677fd327a46b3c317cd53cfe23f2086 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Thu, 21 Apr 2022 11:36:35 +0800
 Subject: [PATCH 33/60] arm64: dts: rockchip: disable usb3 on quartz64

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,4 +1,4 @@
-From 8089d363d43a67b7a4e2404ebd3d4b071112985a Mon Sep 17 00:00:00 2001
+From 17bf455ed990d774a5c479877e482511fbfc5553 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 27 Jul 2023 11:13:25 -0400
 Subject: [PATCH 34/60] arm64: drop hisi_ddrc_pmu driver

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-MIPS-loongson64-disable-writecombine-for-Loongson-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-MIPS-loongson64-disable-writecombine-for-Loongson-3A.patch
@@ -1,4 +1,4 @@
-From a4cc44e8964a71d1ce4aa65953f14e29c15faf46 Mon Sep 17 00:00:00 2001
+From cb09c3c6310cbc74c76e038d47d369018dfe765e Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Mon, 12 Oct 2020 13:32:23 +0800
 Subject: [PATCH 35/60] MIPS: loongson64: disable writecombine for Loongson-3A

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-MIPS-loongson64-init-suppress-memcpy-out-of-bound-ch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-MIPS-loongson64-init-suppress-memcpy-out-of-bound-ch.patch
@@ -1,4 +1,4 @@
-From 10152ad44e5c81c9ca4c8ab22e2d6279b13815a9 Mon Sep 17 00:00:00 2001
+From 4f7cc3c721c30d57865ca2739e06201dd583ca4d Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Wed, 24 Aug 2022 03:54:11 +0000
 Subject: [PATCH 36/60] MIPS: loongson64/init: suppress memcpy out-of-bound

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-MIPS-loongson64-video-output-re-introduce-display-ou.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-MIPS-loongson64-video-output-re-introduce-display-ou.patch
@@ -1,4 +1,4 @@
-From 89ff4ba34d9aa57fa0f0421f14d8cd2f9a0e7dfb Mon Sep 17 00:00:00 2001
+From 145face60794291800ca5ddca1e75d660080cfdb Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 7 Nov 2017 09:01:33 +0800
 Subject: [PATCH 37/60] MIPS: loongson64: video: output: re-introduce display

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-MIPS-video-fbdev-sis-add-1368x768-resolution.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-MIPS-video-fbdev-sis-add-1368x768-resolution.patch
@@ -1,4 +1,4 @@
-From ea0c85fe3bbef842855b3980afd298cd439b1904 Mon Sep 17 00:00:00 2001
+From 788f716dfb3707c1244a97a5a1e271e62eb1c9f3 Mon Sep 17 00:00:00 2001
 From: flygoat <flygoatfree@gmail.com>
 Date: Sun, 5 Mar 2017 20:33:17 +0800
 Subject: [PATCH 38/60] MIPS: video: fbdev: sis: add 1368x768 resolution

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-LoongArch-Select-ARCH_SUPPORTS_INT128-if-CC_HAS_INT1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-LoongArch-Select-ARCH_SUPPORTS_INT128-if-CC_HAS_INT1.patch
@@ -1,4 +1,4 @@
-From ea9017ed8e5829f2b6e26175591dc4d3d4897efd Mon Sep 17 00:00:00 2001
+From a0e1680b8a66f403f86716eecba4e9e1f7ec8086 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 28 Mar 2024 01:17:37 +0800
 Subject: [PATCH 39/60] LoongArch: Select ARCH_SUPPORTS_INT128 if CC_HAS_INT128

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-LoongArch-Define-__ARCH_WANT_NEW_STAT-in-unistd.h.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-LoongArch-Define-__ARCH_WANT_NEW_STAT-in-unistd.h.patch
@@ -1,4 +1,4 @@
-From a7c7bfc8438d5b03db59c5bc4ea4275156d825ec Mon Sep 17 00:00:00 2001
+From 04e634046a44f4441ad3730e8657fecd1f5f49ca Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 28 Feb 2024 21:14:10 +0800
 Subject: [PATCH 40/60] LoongArch: Define __ARCH_WANT_NEW_STAT in unistd.h

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-LoongArch-rust-Switch-to-use-built-in-rustc-target.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-LoongArch-rust-Switch-to-use-built-in-rustc-target.patch
@@ -1,4 +1,4 @@
-From c8d8f16fca4f37e8b829624ed31134cb71528930 Mon Sep 17 00:00:00 2001
+From 201d3d2d4101fea97a789a722303381cb16d7ce7 Mon Sep 17 00:00:00 2001
 From: WANG Rui <wangrui@loongson.cn>
 Date: Mon, 4 Mar 2024 22:14:26 +0800
 Subject: [PATCH 41/60] LoongArch: rust: Switch to use built-in rustc target

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,4 +1,4 @@
-From 322500c76f475f7a454e8a5bdfd3e2258fde0049 Mon Sep 17 00:00:00 2001
+From 6f1b5fa45aeb6d06c3978e5b94107684766248b9 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
 Subject: [PATCH 42/60] LoongArch: Add CPU HWMon platform driver

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-LoongArch-Update-Loongson-3-default-config-file.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-LoongArch-Update-Loongson-3-default-config-file.patch
@@ -1,4 +1,4 @@
-From 0f5906366d02734f6157d133becf2441ca3c4f9e Mon Sep 17 00:00:00 2001
+From 4d0d825ebd4648579958b4161bdaee1fb5976d89 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sat, 23 Mar 2024 20:46:13 +0800
 Subject: [PATCH 43/60] LoongArch: Update Loongson-3 default config file

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-LoongArch-Select-THP_SWAP-if-HAVE_ARCH_TRANSPARENT_H.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-LoongArch-Select-THP_SWAP-if-HAVE_ARCH_TRANSPARENT_H.patch
@@ -1,4 +1,4 @@
-From 325ceb1d096829639545ede8cdc6de135db4671c Mon Sep 17 00:00:00 2001
+From 5912f73ad1f50a0432d43542fe29e4a3cf3bf973 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 10 Apr 2024 21:12:56 +0800
 Subject: [PATCH 44/60] LoongArch: Select THP_SWAP if

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,4 +1,4 @@
-From 29a554f6a791d4df9707190ce38f91f41c8dcac7 Mon Sep 17 00:00:00 2001
+From dd55c9609d6ffc6e5caa11e2cf834a6821551136 Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
 Subject: [PATCH 45/60] LoongArch: Update the flush cache policy

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-dt-bindings-pwm-Add-Loongson-PWM-controller.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-dt-bindings-pwm-Add-Loongson-PWM-controller.patch
@@ -1,4 +1,4 @@
-From 5068ca216920496e40d192cc9052a77f7b4f5fa7 Mon Sep 17 00:00:00 2001
+From 7471ca994623ee768fb41b2a58886e9095a399c3 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Tue, 16 Apr 2024 09:55:14 +0800
 Subject: [PATCH 46/60] dt-bindings: pwm: Add Loongson PWM controller

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-pwm-Add-Loongson-PWM-controller-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-pwm-Add-Loongson-PWM-controller-support.patch
@@ -1,4 +1,4 @@
-From 035a28a8563759498c1cd9c459cb81693ec5a7fb Mon Sep 17 00:00:00 2001
+From f167896003139160ddd47693aa408cd1f70bae85 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Tue, 16 Apr 2024 09:55:15 +0800
 Subject: [PATCH 47/60] pwm: Add Loongson PWM controller support

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-thermal-loongson2-Trivial-code-style-adjustment.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-thermal-loongson2-Trivial-code-style-adjustment.patch
@@ -1,4 +1,4 @@
-From 63beb4723c606be150da2f71bbda48f23d614e86 Mon Sep 17 00:00:00 2001
+From e7b7b44f7cfe5dbacca5a7a27c7bbacda456c873 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 15 Apr 2024 10:31:30 +0800
 Subject: [PATCH 48/60] thermal: loongson2: Trivial code style adjustment

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-dt-bindings-thermal-loongson-ls2k-thermal-Add-Loongs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-dt-bindings-thermal-loongson-ls2k-thermal-Add-Loongs.patch
@@ -1,4 +1,4 @@
-From c7d5d015685e1bf341ef99684949ac36321702d2 Mon Sep 17 00:00:00 2001
+From 78e41cdeaca0780f648cda1c414359ee0020ee39 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 15 Apr 2024 10:31:31 +0800
 Subject: [PATCH 49/60] dt-bindings: thermal: loongson,ls2k-thermal: Add

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-dt-bindings-thermal-loongson-ls2k-thermal-Fix-incorr.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-dt-bindings-thermal-loongson-ls2k-thermal-Fix-incorr.patch
@@ -1,4 +1,4 @@
-From b62b06e737a7f6bb3c2c10bd9c26464eb51f16a5 Mon Sep 17 00:00:00 2001
+From d17e3b44d9e5821f2a440d3158d423f5c07eb438 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 15 Apr 2024 10:31:32 +0800
 Subject: [PATCH 50/60] dt-bindings: thermal: loongson,ls2k-thermal: Fix

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-thermal-loongson2-Add-Loongson-2K2000-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-thermal-loongson2-Add-Loongson-2K2000-support.patch
@@ -1,4 +1,4 @@
-From 246cf75e11a7966d36149480a592abca37fe2170 Mon Sep 17 00:00:00 2001
+From 9e7f01b9c14ae80606ab66100d541778e8c27285 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 15 Apr 2024 10:31:57 +0800
 Subject: [PATCH 51/60] thermal: loongson2: Add Loongson-2K2000 support

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-KVM-loongarch-Add-vcpu-id-check-before-create-vcpu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-KVM-loongarch-Add-vcpu-id-check-before-create-vcpu.patch
@@ -1,4 +1,4 @@
-From 01b85c9b68b8a354b890c092a1c257545557d80b Mon Sep 17 00:00:00 2001
+From 05e299a28e1855ba7aab73f55fef2a7ba3d87663 Mon Sep 17 00:00:00 2001
 From: Wujie Duan <wjduan@linx-info.com>
 Date: Fri, 12 Apr 2024 16:47:03 +0800
 Subject: [PATCH 52/60] KVM: loongarch: Add vcpu id check before create vcpu

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-LOONGARCH64-arch-loongarch-add-la_ow_syscall-as-in-t.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-LOONGARCH64-arch-loongarch-add-la_ow_syscall-as-in-t.patch.loongarch64
@@ -1,4 +1,4 @@
-From 2dcd4d1c46ffb27fae08395bf58b4e6627554423 Mon Sep 17 00:00:00 2001
+From 0a47aa88c61fb6e3e9312daab8e400f63a24ed4c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Wed, 21 Feb 2024 16:58:32 -0500
 Subject: [PATCH 53/60] [LOONGARCH64] arch/loongarch: add la_ow_syscall as

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-LOONGARCH64-la_ow_syscall-add-kconfig-for-module.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-LOONGARCH64-la_ow_syscall-add-kconfig-for-module.patch.loongarch64
@@ -1,4 +1,4 @@
-From 4548f2df5cc8ed80bc4ad0df20d0269df24ef72f Mon Sep 17 00:00:00 2001
+From b6279084f9f6cffd0e03e6675e25a2e1b9a5091e Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
 Subject: [PATCH 54/60] [LOONGARCH64] la_ow_syscall: add kconfig for module

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
@@ -1,4 +1,4 @@
-From d439a5ec70a03386c8366982ee14be8325e3bee7 Mon Sep 17 00:00:00 2001
+From fd1e0866478dfe4d879a3ce2da5ce1325fc2614a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
 Subject: [PATCH 55/60] [LOONGARCH64] drivers/firmware: Move sysfb_init() from

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-LOONGARCH64-drm-Makefile-Move-tiny-drivers-before-na.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-LOONGARCH64-drm-Makefile-Move-tiny-drivers-before-na.patch.loongarch64
@@ -1,4 +1,4 @@
-From e9599605482b16ad4f58aaefae0dc26d421e4d6b Mon Sep 17 00:00:00 2001
+From 9df6392a1d114b4bdbef1b34ce118df1ada3ed84 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 7 Nov 2023 20:25:53 +0800
 Subject: [PATCH 56/60] [LOONGARCH64] drm/Makefile: Move tiny drivers before

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
@@ -1,4 +1,4 @@
-From bc11e2ca0d3383367074d858775df8c891af7591 Mon Sep 17 00:00:00 2001
+From 6fde094fb6b8a0f655894cfafbe3bbec09e8d8e0 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Mon, 11 Mar 2024 00:14:58 +0800
 Subject: [PATCH 57/60] [LOONGARCH64] drm/xe: fix build on non-4K kernels

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
@@ -1,4 +1,4 @@
-From e535a25d9d5caf6ddcf0892666f64a5964349dc6 Mon Sep 17 00:00:00 2001
+From a310b17894e43c9a95f8f99c2593dd2749c60d73 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
 Subject: [PATCH 58/60] [LOONGARCH64] drm/radeon: Workaround radeon driver bug

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
@@ -1,4 +1,4 @@
-From fbfa964dff24c00e44c3d9ab7bd5a75d8083b150 Mon Sep 17 00:00:00 2001
+From 9fb1eb4bef5a7f49be588799a28038612c37f406 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 14:28:02 +0800
 Subject: [PATCH 59/60] [LOONGARCH64] drm/radeon: Call mmiowb() at the end of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-LOONGARCH64-HACK-drm-amdgpu-disable-DPM-in-auto-mode.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-LOONGARCH64-HACK-drm-amdgpu-disable-DPM-in-auto-mode.patch.loongarch64
@@ -1,4 +1,4 @@
-From 144a88b69ff6e4002fbef0ec0b451c5ad612a4f9 Mon Sep 17 00:00:00 2001
+From c99d6446db69c8615c4c393c1e02cb91ac61aa2c Mon Sep 17 00:00:00 2001
 From: Cyan <cyanoxygen@aosc.io>
 Date: Wed, 10 Apr 2024 16:44:01 +0800
 Subject: [PATCH 60/60] [LOONGARCH64] HACK(drm/amdgpu): disable DPM in auto

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -1,8 +1,8 @@
-VER=6.9.1
+VER=6.9.2
 #RC=
 # Use this for RC releases.
 #SRCS="tbl::https://git.kernel.org/torvalds/t/linux-${VER%%.0}-rc${RC}.tar.gz"
 # Use this for stable releases.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
-CHKSUMS="sha256::01b414ba98fd189ecd544435caf3860ae2a790e3ec48f5aa70fdf42dc4c5c04a"
+CHKSUMS="sha256::d46c5bdf2c5961cc2a4dedefe0434d456865e95e4a7cd9f93fff054f9090e5f9"
 CHKUPDATE="anitya::id=6501"


### PR DESCRIPTION
Topic Description
-----------------

- kernel-tools: update to 6.9.2
- linux+kernel: update to 6.9.2
- linux-kernel: update to 6.9.2
    Track patches at AOSC-Tracking/linux @ aosc/v6.9.2.

Package(s) Affected
-------------------

- kernel-tools: 6.9.2
- linux+kernel: 3:6.9.2
- linux-kernel-6.9.2: 1:6.9.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel linux+kernel kernel-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
