### PR TITLE
tdb: update to 1.4.10

### DIFF
--- a/app-database/tdb/spec
+++ b/app-database/tdb/spec
@@ -1,5 +1,4 @@
-VER=1.4.7
-REL=1
+VER=1.4.10
 SRCS="tbl::https://www.samba.org/ftp/tdb/tdb-$VER.tar.gz"
-CHKSUMS="sha256::a4fb168def533f31ff2c07f7d9844bb3131e6799f094ebe77d0380adc987c20e"
+CHKSUMS="sha256::02338e33c16c21c9e29571cef523e76b2b708636254f6f30c6cf195d48c62daf"
 CHKUPDATE="anitya::id=1735"


### PR DESCRIPTION
Topic Description
-----------------

- tdb: update to 1.4.10
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- tdb: 1.4.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit tdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
