### PR TITLE
fortunes-zh: update to 2.98

### DIFF
--- a/app-games/fortunes-zh/autobuild/build
+++ b/app-games/fortunes-zh/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building fortunes-zh ..."
+make PREFIX=/usr ${MAKE_AFTER}
+
+abinfo "Installing fortunes-zh ..."
+make install PREFIX=/usr DESTDIR="$PKGDIR" ${MAKE_AFTER}

--- a/app-games/fortunes-zh/spec
+++ b/app-games/fortunes-zh/spec
@@ -1,5 +1,4 @@
-VER=2.97
+VER=2.98
 SRCS="git::commit=tags/debian/$VER::https://salsa.debian.org/chinese-team/fortunes-zh"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227649"
-REL=3


### PR DESCRIPTION
Topic Description
-----------------

- fortunes-zh: update to 2.98
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- fortunes-zh: 2.98

Security Update?
----------------

No

Build Order
-----------

```
#buildit fortunes-zh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
