### PR TITLE
attrs: update to 23.2.0

### DIFF
--- a/lang-python/attrs/autobuild/defines
+++ b/lang-python/attrs/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=attrs
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools"
-PKGDES="Python Attributes Without Boilerplate"
+PKGDEP="python-3"
+BUILDDEP="hatch-fancy-pypi-readme hatch-vcs hatchling python-build \
+          python-installer wheel"
+PKGDES="Python module that implements class attributes"
 
 ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/attrs/spec
+++ b/lang-python/attrs/spec
@@ -1,5 +1,4 @@
-VER=20.3.0
+VER=23.2.0
 SRCS="https://pypi.io/packages/source/a/attrs/attrs-$VER.tar.gz"
-CHKSUMS="sha256::832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
+CHKSUMS="sha256::935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"
 CHKUPDATE="anitya::id=126632"
-REL=1

--- a/lang-python/hatch-fancy-pypi-readme/spec
+++ b/lang-python/hatch-fancy-pypi-readme/spec
@@ -1,4 +1,4 @@
-VER=22.8.0
+VER=24.1.0
 SRCS="tbl::https://pypi.io/packages/source/h/hatch-fancy-pypi-readme/hatch_fancy_pypi_readme-$VER.tar.gz"
-CHKSUMS="sha256::da91282ca09601c18aded8e378daf8b578c70214866f0971156ee9bb9ce6c26a"
+CHKSUMS="sha256::44dd239f1a779b9dcf8ebc9401a611fd7f7e3e14578dcf22c265dfaf7c1514b8"
 CHKUPDATE="anitya::id=274452"


### PR DESCRIPTION
Topic Description
-----------------

- attrs: update to 23.2.0
    - Use pep517 build type.
    - Disable Python 2 binding as it is no longer supported.
    - Improve PKGDES.
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>
- hatch-fancy-pypi-readme: update to 24.1.0

Package(s) Affected
-------------------

- attrs: 23.2.0
- hatch-fancy-pypi-readme: 24.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit hatch-fancy-pypi-readme attrs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
