### PR TITLE
phonon: update to 4.12.0

### DIFF
--- a/desktop-kde/phonon/autobuild/build
+++ b/desktop-kde/phonon/autobuild/build
@@ -1,0 +1,22 @@
+abinfo "Configuring phonon for qt-5 ..."
+cmake -B "$SRCDIR/build5" -S "$SRCDIR" \
+    ${CMAKE_DEF[@]} \
+    -DPHONON_BUILD_QT6=OFF \
+    -DPHONON_BUILD_SETTINGS=OFF \
+
+abinfo "Building phonon for qt-5 ..."
+cmake --build "$SRCDIR/build5"
+
+abinfo "Installing phonon for qt-5 ..."
+DESTDIR="$PKGDIR" cmake --install "$SRCDIR/build5"
+
+abinfo "Configuring phonon for qt-6 ..."
+cmake -B "$SRCDIR/build6" -S "$SRCDIR" \
+    ${CMAKE_DEF[@]} \
+    -DPHONON_BUILD_QT5=OFF
+
+abinfo "Building phonon for qt-6 ..."
+cmake --build "$SRCDIR/build6"
+
+abinfo "Installing phonon for qt-6 ..."
+DESTDIR="$PKGDIR" cmake --install "$SRCDIR/build6"

--- a/desktop-kde/phonon/autobuild/defines
+++ b/desktop-kde/phonon/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=phonon
 PKGEPOCH=1
 PKGSEC=kde
-PKGDEP="qt-5 pulseaudio"
+PKGDEP="qt-6 qt-5 pulseaudio"
 BUILDDEP="automoc4 extra-cmake-modules"
 PKGDES="The KDE multimedia framework"

--- a/desktop-kde/phonon/spec
+++ b/desktop-kde/phonon/spec
@@ -1,5 +1,4 @@
-VER=4.11.1
-REL=5
+VER=4.12.0
 SRCS="tbl::https://download.kde.org/stable/phonon/$VER/phonon-$VER.tar.xz"
-CHKSUMS="sha256::b4431ea2600df8137a717741ad9ebc7f7ec1649fa3e138541d8f42597144de2d"
+CHKSUMS="sha256::3287ffe0fbcc2d4aa1363f9e15747302d0b080090fe76e5f211d809ecb43f39a"
 CHKUPDATE="anitya::id=229047"


### PR DESCRIPTION
Topic Description
-----------------

- phonon: update to 4.12.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- phonon: 1:4.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit phonon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
