### PR TITLE
taskwarrior: update to 3.0.2

### DIFF
--- a/app-productivity/taskwarrior/autobuild/config
+++ b/app-productivity/taskwarrior/autobuild/config
@@ -1,0 +1,7 @@
+# Source debconf library.
+. /usr/share/debconf/confmodule
+
+# Let the user know the manual migration needed for this upgrade
+db_input high taskwarrior/migrate_from_2_preinst || true
+db_input high taskwarrior/migrate_from_2_postinst || true
+db_go

--- a/app-productivity/taskwarrior/autobuild/defines
+++ b/app-productivity/taskwarrior/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=taskwarrior
 PKGSEC=utils
-PKGDEP="gnutls util-linux"
+PKGDEP="gnutls util-linux debconf"
+BUILDDEP="rustc llvm"
 PKGDES="A command line task manager"
 
-ABTYPE="cmake"
+ABTYPE=cmake
+USECLANG=1

--- a/app-productivity/taskwarrior/autobuild/patches/0001-Update-taskchampion-deps-to-support-more-architectur.patch
+++ b/app-productivity/taskwarrior/autobuild/patches/0001-Update-taskchampion-deps-to-support-more-architectur.patch
@@ -1,0 +1,951 @@
+From fa88177031a1addcfd4957fe9032370b2960bef9 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Sun, 26 May 2024 18:35:07 -0700
+Subject: [PATCH] Update taskchampion deps to support more architectures
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ Cargo.lock | 437 ++++++++++++++++++++++++++++-------------------------
+ Cargo.toml |   4 +-
+ 2 files changed, 229 insertions(+), 212 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 8d742b235..d6a1532db 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -108,15 +108,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "base64"
+-version = "0.13.1"
++version = "0.21.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
++checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+ 
+ [[package]]
+ name = "base64"
+-version = "0.21.0"
++version = "0.22.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
++checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+ 
+ [[package]]
+ name = "base64ct"
+@@ -180,9 +180,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.73"
++version = "1.0.98"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
++checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+ 
+ [[package]]
+ name = "cfg-if"
+@@ -395,9 +395,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "futures-channel"
+-version = "0.3.25"
++version = "0.3.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
++checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+ dependencies = [
+  "futures-core",
+  "futures-sink",
+@@ -405,9 +405,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "futures-core"
+-version = "0.3.25"
++version = "0.3.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
++checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+ 
+ [[package]]
+ name = "futures-executor"
+@@ -422,32 +422,32 @@ dependencies = [
+ 
+ [[package]]
+ name = "futures-io"
+-version = "0.3.25"
++version = "0.3.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
++checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+ 
+ [[package]]
+ name = "futures-macro"
+-version = "0.3.25"
++version = "0.3.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
++checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 1.0.104",
++ "syn 2.0.18",
+ ]
+ 
+ [[package]]
+ name = "futures-sink"
+-version = "0.3.25"
++version = "0.3.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
++checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+ 
+ [[package]]
+ name = "futures-task"
+-version = "0.3.25"
++version = "0.3.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
++checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+ 
+ [[package]]
+ name = "futures-timer"
+@@ -457,9 +457,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+ 
+ [[package]]
+ name = "futures-util"
+-version = "0.3.25"
++version = "0.3.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
++checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+ dependencies = [
+  "futures-channel",
+  "futures-core",
+@@ -485,13 +485,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "getrandom"
+-version = "0.2.9"
++version = "0.2.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
++checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+ dependencies = [
+  "cfg-if",
++ "js-sys",
+  "libc",
+  "wasi",
++ "wasm-bindgen",
+ ]
+ 
+ [[package]]
+@@ -502,9 +504,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+ 
+ [[package]]
+ name = "google-cloud-auth"
+-version = "0.13.0"
++version = "0.15.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "af1087f1fbd2dd3f58c17c7574ddd99cd61cbbbc2c4dc81114b8687209b196cb"
++checksum = "e09ed5b2998bc8d0d3df09c859028210d4961b8fe779cfda8dc8ca4e83d5def2"
+ dependencies = [
+  "async-trait",
+  "base64 0.21.0",
+@@ -524,9 +526,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "google-cloud-metadata"
+-version = "0.4.0"
++version = "0.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cc279bfb50487d7bcd900e8688406475fc750fe474a835b2ab9ade9eb1fc90e2"
++checksum = "04f945a208886a13d07636f38fb978da371d0abc3e34bad338124b9f8c135a8f"
+ dependencies = [
+  "reqwest",
+  "thiserror",
+@@ -535,10 +537,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "google-cloud-storage"
+-version = "0.15.0"
++version = "0.18.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ac04b29849ebdeb9fb008988cc1c4d1f0c9d121b4c7f1ddeb8061df124580e93"
++checksum = "1b390b31edb05310fe83adfd3121de2e1e6c5a3ff4129287e0599c421c8b4e62"
+ dependencies = [
++ "anyhow",
+  "async-stream",
+  "async-trait",
+  "base64 0.21.0",
+@@ -553,7 +556,8 @@ dependencies = [
+  "pkcs8",
+  "regex",
+  "reqwest",
+- "ring 0.17.3",
++ "reqwest-middleware",
++ "ring",
+  "serde",
+  "serde_json",
+  "sha2",
+@@ -573,31 +577,6 @@ dependencies = [
+  "async-trait",
+ ]
+ 
+-[[package]]
+-name = "h2"
+-version = "0.3.17"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+-dependencies = [
+- "bytes",
+- "fnv",
+- "futures-core",
+- "futures-sink",
+- "futures-util",
+- "http",
+- "indexmap",
+- "slab",
+- "tokio",
+- "tokio-util",
+- "tracing",
+-]
+-
+-[[package]]
+-name = "hashbrown"
+-version = "0.11.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+-
+ [[package]]
+ name = "hashbrown"
+ version = "0.12.2"
+@@ -613,7 +592,7 @@ version = "0.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d452c155cb93fecdfb02a73dd57b5d8e442c2063bd7aac72f1bc5e4263a43086"
+ dependencies = [
+- "hashbrown 0.12.2",
++ "hashbrown",
+ ]
+ 
+ [[package]]
+@@ -654,9 +633,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "http"
+-version = "0.2.9"
++version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
++checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+ dependencies = [
+  "bytes",
+  "fnv",
+@@ -665,63 +644,87 @@ dependencies = [
+ 
+ [[package]]
+ name = "http-body"
+-version = "0.4.6"
++version = "1.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
++checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+ dependencies = [
+  "bytes",
+  "http",
+- "pin-project-lite",
+ ]
+ 
+ [[package]]
+-name = "httparse"
+-version = "1.7.1"
++name = "http-body-util"
++version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
++checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
++dependencies = [
++ "bytes",
++ "futures-core",
++ "http",
++ "http-body",
++ "pin-project-lite",
++]
+ 
+ [[package]]
+-name = "httpdate"
+-version = "1.0.2"
++name = "httparse"
++version = "1.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
++checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+ 
+ [[package]]
+ name = "hyper"
+-version = "0.14.20"
++version = "1.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
++checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+ dependencies = [
+  "bytes",
+  "futures-channel",
+- "futures-core",
+  "futures-util",
+- "h2",
+  "http",
+  "http-body",
+  "httparse",
+- "httpdate",
+  "itoa",
+  "pin-project-lite",
+- "socket2 0.4.9",
++ "smallvec",
+  "tokio",
+- "tower-service",
+- "tracing",
+  "want",
+ ]
+ 
+ [[package]]
+ name = "hyper-rustls"
+-version = "0.24.2"
++version = "0.26.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
++checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+ dependencies = [
+  "futures-util",
+  "http",
+  "hyper",
++ "hyper-util",
+  "rustls",
++ "rustls-pki-types",
+  "tokio",
+  "tokio-rustls",
++ "tower-service",
++]
++
++[[package]]
++name = "hyper-util"
++version = "0.1.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "3d8d52be92d09acc2e01dddb7fde3ad983fc6489c7db4837e605bc3fca4cb63e"
++dependencies = [
++ "bytes",
++ "futures-channel",
++ "futures-util",
++ "http",
++ "http-body",
++ "hyper",
++ "pin-project-lite",
++ "socket2",
++ "tokio",
++ "tower",
++ "tower-service",
++ "tracing",
+ ]
+ 
+ [[package]]
+@@ -748,16 +751,6 @@ dependencies = [
+  "unicode-normalization",
+ ]
+ 
+-[[package]]
+-name = "indexmap"
+-version = "1.8.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+-dependencies = [
+- "autocfg",
+- "hashbrown 0.11.2",
+-]
+-
+ [[package]]
+ name = "instant"
+ version = "0.1.12"
+@@ -814,22 +807,23 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+ 
+ [[package]]
+ name = "js-sys"
+-version = "0.3.59"
++version = "0.3.69"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
++checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+ dependencies = [
+  "wasm-bindgen",
+ ]
+ 
+ [[package]]
+ name = "jsonwebtoken"
+-version = "8.3.0"
++version = "9.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
++checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+ dependencies = [
+  "base64 0.21.0",
++ "js-sys",
+  "pem",
+- "ring 0.16.20",
++ "ring",
+  "serde",
+  "serde_json",
+  "simple_asn1",
+@@ -843,9 +837,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.151"
++version = "0.2.155"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
++checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+ 
+ [[package]]
+ name = "libm"
+@@ -1041,11 +1035,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "pem"
+-version = "1.1.1"
++version = "3.0.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
++checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+ dependencies = [
+- "base64 0.13.1",
++ "base64 0.22.1",
++ "serde",
+ ]
+ 
+ [[package]]
+@@ -1063,6 +1058,26 @@ version = "2.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+ 
++[[package]]
++name = "pin-project"
++version = "1.1.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
++dependencies = [
++ "pin-project-internal",
++]
++
++[[package]]
++name = "pin-project-internal"
++version = "1.1.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn 2.0.18",
++]
++
+ [[package]]
+ name = "pin-project-lite"
+ version = "0.2.13"
+@@ -1239,20 +1254,21 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+ 
+ [[package]]
+ name = "reqwest"
+-version = "0.11.18"
++version = "0.12.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
++checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+ dependencies = [
+- "base64 0.21.0",
++ "base64 0.22.1",
+  "bytes",
+  "encoding_rs",
+  "futures-core",
+  "futures-util",
+- "h2",
+  "http",
+  "http-body",
++ "http-body-util",
+  "hyper",
+  "hyper-rustls",
++ "hyper-util",
+  "ipnet",
+  "js-sys",
+  "log",
+@@ -1263,9 +1279,11 @@ dependencies = [
+  "pin-project-lite",
+  "rustls",
+  "rustls-pemfile",
++ "rustls-pki-types",
+  "serde",
+  "serde_json",
+  "serde_urlencoded",
++ "sync_wrapper",
+  "tokio",
+  "tokio-rustls",
+  "tokio-util",
+@@ -1275,37 +1293,38 @@ dependencies = [
+  "wasm-bindgen-futures",
+  "wasm-streams",
+  "web-sys",
+- "webpki-roots 0.22.6",
++ "webpki-roots",
+  "winreg",
+ ]
+ 
+ [[package]]
+-name = "ring"
+-version = "0.16.20"
++name = "reqwest-middleware"
++version = "0.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
++checksum = "a45d100244a467870f6cb763c4484d010a6bed6bd610b3676e3825d93fb4cfbd"
+ dependencies = [
+- "cc",
+- "libc",
+- "once_cell",
+- "spin 0.5.2",
+- "untrusted 0.7.1",
+- "web-sys",
+- "winapi",
++ "anyhow",
++ "async-trait",
++ "http",
++ "reqwest",
++ "serde",
++ "thiserror",
++ "tower-service",
+ ]
+ 
+ [[package]]
+ name = "ring"
+-version = "0.17.3"
++version = "0.17.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
++checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+ dependencies = [
+  "cc",
++ "cfg-if",
+  "getrandom",
+  "libc",
+- "spin 0.9.8",
+- "untrusted 0.9.0",
+- "windows-sys 0.48.0",
++ "spin",
++ "untrusted",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -1379,33 +1398,43 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustls"
+-version = "0.21.11"
++version = "0.22.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
++checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+ dependencies = [
+  "log",
+- "ring 0.17.3",
++ "ring",
++ "rustls-pki-types",
+  "rustls-webpki",
+- "sct",
++ "subtle",
++ "zeroize",
+ ]
+ 
+ [[package]]
+ name = "rustls-pemfile"
+-version = "1.0.4"
++version = "2.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
++checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+ dependencies = [
+- "base64 0.21.0",
++ "base64 0.22.1",
++ "rustls-pki-types",
+ ]
+ 
++[[package]]
++name = "rustls-pki-types"
++version = "1.7.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
++
+ [[package]]
+ name = "rustls-webpki"
+-version = "0.101.7"
++version = "0.102.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
++checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+ dependencies = [
+- "ring 0.17.3",
+- "untrusted 0.9.0",
++ "ring",
++ "rustls-pki-types",
++ "untrusted",
+ ]
+ 
+ [[package]]
+@@ -1438,16 +1467,6 @@ version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+ 
+-[[package]]
+-name = "sct"
+-version = "0.7.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+-dependencies = [
+- "ring 0.16.20",
+- "untrusted 0.7.1",
+-]
+-
+ [[package]]
+ name = "semver"
+ version = "1.0.9"
+@@ -1528,19 +1547,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+ 
+ [[package]]
+ name = "smallvec"
+-version = "1.8.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+-
+-[[package]]
+-name = "socket2"
+-version = "0.4.9"
++version = "1.13.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+-dependencies = [
+- "libc",
+- "winapi",
+-]
++checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+ 
+ [[package]]
+ name = "socket2"
+@@ -1552,12 +1561,6 @@ dependencies = [
+  "windows-sys 0.48.0",
+ ]
+ 
+-[[package]]
+-name = "spin"
+-version = "0.5.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+-
+ [[package]]
+ name = "spin"
+ version = "0.9.8"
+@@ -1593,6 +1596,12 @@ dependencies = [
+  "syn 2.0.18",
+ ]
+ 
++[[package]]
++name = "subtle"
++version = "2.5.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
++
+ [[package]]
+ name = "syn"
+ version = "1.0.104"
+@@ -1615,6 +1624,12 @@ dependencies = [
+  "unicode-ident",
+ ]
+ 
++[[package]]
++name = "sync_wrapper"
++version = "0.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
++
+ [[package]]
+ name = "taskchampion"
+ version = "0.4.1"
+@@ -1627,7 +1642,7 @@ dependencies = [
+  "log",
+  "pretty_assertions",
+  "proptest",
+- "ring 0.17.3",
++ "ring",
+  "rstest",
+  "rusqlite",
+  "serde",
+@@ -1752,7 +1767,7 @@ dependencies = [
+  "num_cpus",
+  "parking_lot",
+  "pin-project-lite",
+- "socket2 0.5.5",
++ "socket2",
+  "tokio-macros",
+  "windows-sys 0.48.0",
+ ]
+@@ -1770,11 +1785,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "tokio-rustls"
+-version = "0.24.1"
++version = "0.25.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
++checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+ dependencies = [
+  "rustls",
++ "rustls-pki-types",
+  "tokio",
+ ]
+ 
+@@ -1792,6 +1808,27 @@ dependencies = [
+  "tracing",
+ ]
+ 
++[[package]]
++name = "tower"
++version = "0.4.13"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
++dependencies = [
++ "futures-core",
++ "futures-util",
++ "pin-project",
++ "pin-project-lite",
++ "tokio",
++ "tower-layer",
++ "tower-service",
++]
++
++[[package]]
++name = "tower-layer"
++version = "0.3.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
++
+ [[package]]
+ name = "tower-service"
+ version = "0.3.2"
+@@ -1878,12 +1915,6 @@ dependencies = [
+  "tinyvec",
+ ]
+ 
+-[[package]]
+-name = "untrusted"
+-version = "0.7.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+-
+ [[package]]
+ name = "untrusted"
+ version = "0.9.0"
+@@ -1892,18 +1923,19 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+ 
+ [[package]]
+ name = "ureq"
+-version = "2.9.0"
++version = "2.9.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7830e33f6e25723d41a63f77e434159dad02919f18f55a512b5f16f3b1d77138"
++checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
+ dependencies = [
+- "base64 0.21.0",
++ "base64 0.22.1",
+  "flate2",
+  "log",
+  "once_cell",
+  "rustls",
++ "rustls-pki-types",
+  "rustls-webpki",
+  "url",
+- "webpki-roots 0.25.2",
++ "webpki-roots",
+ ]
+ 
+ [[package]]
+@@ -1971,9 +2003,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+ 
+ [[package]]
+ name = "wasm-bindgen"
+-version = "0.2.82"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
++checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+ dependencies = [
+  "cfg-if",
+  "wasm-bindgen-macro",
+@@ -1981,24 +2013,24 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-backend"
+-version = "0.2.82"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
++checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+ dependencies = [
+  "bumpalo",
+  "log",
+  "once_cell",
+  "proc-macro2",
+  "quote",
+- "syn 1.0.104",
++ "syn 2.0.18",
+  "wasm-bindgen-shared",
+ ]
+ 
+ [[package]]
+ name = "wasm-bindgen-futures"
+-version = "0.4.32"
++version = "0.4.42"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
++checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+ dependencies = [
+  "cfg-if",
+  "js-sys",
+@@ -2008,9 +2040,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro"
+-version = "0.2.82"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
++checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+ dependencies = [
+  "quote",
+  "wasm-bindgen-macro-support",
+@@ -2018,28 +2050,28 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro-support"
+-version = "0.2.82"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
++checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 1.0.104",
++ "syn 2.0.18",
+  "wasm-bindgen-backend",
+  "wasm-bindgen-shared",
+ ]
+ 
+ [[package]]
+ name = "wasm-bindgen-shared"
+-version = "0.2.82"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
++checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+ 
+ [[package]]
+ name = "wasm-streams"
+-version = "0.2.3"
++version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
++checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+ dependencies = [
+  "futures-util",
+  "js-sys",
+@@ -2050,39 +2082,23 @@ dependencies = [
+ 
+ [[package]]
+ name = "web-sys"
+-version = "0.3.57"
++version = "0.3.69"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
++checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+ dependencies = [
+  "js-sys",
+  "wasm-bindgen",
+ ]
+ 
+-[[package]]
+-name = "webpki"
+-version = "0.22.4"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+-dependencies = [
+- "ring 0.17.3",
+- "untrusted 0.9.0",
+-]
+-
+ [[package]]
+ name = "webpki-roots"
+-version = "0.22.6"
++version = "0.26.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
++checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+ dependencies = [
+- "webpki",
++ "rustls-pki-types",
+ ]
+ 
+-[[package]]
+-name = "webpki-roots"
+-version = "0.25.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+-
+ [[package]]
+ name = "winapi"
+ version = "0.3.9"
+@@ -2305,11 +2321,12 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+ 
+ [[package]]
+ name = "winreg"
+-version = "0.10.1"
++version = "0.52.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
++checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+ dependencies = [
+- "winapi",
++ "cfg-if",
++ "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+diff --git a/Cargo.toml b/Cargo.toml
+index efe0c179d..f6e7b0ace 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -21,7 +21,7 @@ cc = "1.0.73"
+ chrono = { version = "^0.4.22", features = ["serde"] }
+ ffizz-header = "0.5"
+ flate2 = "1"
+-google-cloud-storage = { version = "0.15.0", default-features = false, features = ["rustls-tls", "auth"] }
++google-cloud-storage = { version = "0.18.0", default-features = false, features = ["rustls-tls", "auth"] }
+ lazy_static = "1"
+ libc = "0.2.136"
+ log = "^0.4.17"
+@@ -37,6 +37,6 @@ strum_macros = "0.25"
+ tempfile = "3"
+ tokio = { version = "1", features = ["rt-multi-thread"] }
+ thiserror = "1.0"
+-ureq = { version = "^2.9.0", features = ["tls"] }
++ureq = { version = "^2.9.7", features = ["tls"] }
+ uuid = { version = "^1.8.0", features = ["serde", "v4"] }
+ url = { version = "2" }
+-- 
+2.45.1
+

--- a/app-productivity/taskwarrior/autobuild/postinst
+++ b/app-productivity/taskwarrior/autobuild/postinst
@@ -1,0 +1,4 @@
+# Source Debconf module.
+. /usr/share/debconf/confmodule
+
+db_get taskwarrior/migrate_from_2_postinst

--- a/app-productivity/taskwarrior/autobuild/preinst
+++ b/app-productivity/taskwarrior/autobuild/preinst
@@ -1,0 +1,4 @@
+# Source Debconf module.
+. /usr/share/debconf/confmodule
+
+db_get taskwarrior/migrate_from_2_preinst

--- a/app-productivity/taskwarrior/autobuild/templates
+++ b/app-productivity/taskwarrior/autobuild/templates
@@ -1,0 +1,47 @@
+Template: taskwarrior/migrate_from_2_preinst
+Type: note
+Description: Migration Notes for Taskwarrior 2 Users
+ Taskwarrior 3 introduced a new format for storing and synchronising tasks.
+ Before upgrading Taskwarrior, you must export all your previous data using the
+ following command:
+ .
+ $ task export > all-tasks.json
+ .
+ After you have finished exporting your data, return and press enter to proceed.
+ .
+ For more information about migrating to Taskwarrior 3 and the new
+ synchronisation method, please visit https://taskwarrior.org/docs/upgrade-3/ .
+Description-zh_CN.UTF-8: Taskwarrior 2 迁移注记
+ Taskwarrior 3 更改了储存和同步任务的格式。在更新之前，请使用下面的命令导出之前
+ 的所有任务：
+ .
+ $ task export > all-tasks.json
+ .
+ 导出完成后，请回到该注记并按下回车键以继续。
+ .
+ 有关迁移到 Taskwarrior 3 和新同步方式的更多信息请访问
+ https://taskwarrior.org/docs/upgrade-3/ 。
+
+Template: taskwarrior/migrate_from_2_postinst
+Type: note
+Description: Migration Notes for Taskwarrior 2 Users
+ After upgrading to Taskwarrior 3, re-import your tasks using the following
+ command:
+ .
+ $ task import rc.hooks=0 all-tasks.json
+ .
+ And then you may backup or remove the *.data files in your task directory
+ (default: ~/.task), they are no longer used.
+ .
+ For more information about migrating to Taskwarrior 3 and the new
+ synchronisation method, please visit https://taskwarrior.org/docs/upgrade-3/ .
+Description-zh_CN.UTF-8: Taskwarrior 2 迁移注记
+ 完成更新后，请使用下面的命令重新导入您的任务：
+ .
+ $ task import rc.hooks=0 all-tasks.json
+ .
+ 之后，您可以备份或删除任务文件夹（默认路径为 ~/.task）下的所有 *.data 文件，
+ Taskwarrior 将不再使用它们。
+ .
+ 有关迁移到 Taskwarrior 3 和新同步方式的更多信息请访问
+ https://taskwarrior.org/docs/upgrade-3/ 。

--- a/app-productivity/taskwarrior/spec
+++ b/app-productivity/taskwarrior/spec
@@ -1,4 +1,4 @@
-VER=2.6.2
+VER=3.0.2
 SRCS="git::commit=tags/v${VER}::https://github.com/GothenburgBitFactory/taskwarrior"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5841"


### PR DESCRIPTION
Topic Description
-----------------

- taskwarrior: update to 3.0.2
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- taskwarrior: 3.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit taskwarrior
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
