### PR TITLE
zathura: update to 0.5.6

### DIFF
--- a/app-doc/zathura-djvu/autobuild/defines
+++ b/app-doc/zathura-djvu/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=zathura-djvu
 PKGSEC=doc
-PKGDEP="djvulibre zathura"
+PKGDEP="djvulibre zathura girara"
 PKGDES="DjVu support for Zathura"
 
 ABTYPE=meson

--- a/app-doc/zathura-djvu/spec
+++ b/app-doc/zathura-djvu/spec
@@ -1,5 +1,5 @@
 VER=0.2.9
-REL=2
-SRCS="tbl::https://pwmt.org/projects/zathura-djvu/download/zathura-djvu-$VER.tar.xz"
-CHKSUMS="sha256::96e6f8a6ee53231073b2f7003264872f84501e63c3da7bf0598d046286b0c200"
+REL=3
+SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-djvu"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11036"

--- a/app-doc/zathura-pdf-poppler/autobuild/defines
+++ b/app-doc/zathura-pdf-poppler/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=zathura-pdf-poppler
 PKGSEC=doc
-PKGDEP="poppler zathura"
+PKGDEP="poppler zathura girara"
 PKGDES="Poppler PDF backend support for Zathura"
 
 ABTYPE=meson

--- a/app-doc/zathura-pdf-poppler/spec
+++ b/app-doc/zathura-pdf-poppler/spec
@@ -1,4 +1,4 @@
-VER=0.3.1
-SRCS="tbl::https://pwmt.org/projects/zathura-pdf-poppler/download/zathura-pdf-poppler-$VER.tar.xz"
-CHKSUMS="sha256::ee8127532cc6f92bf32d48a6a0d4c61e33cd4df49a3159e57592877ba19e108b"
+VER=0.3.2
+SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-pdf-poppler"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14847"

--- a/app-doc/zathura-ps/autobuild/defines
+++ b/app-doc/zathura-ps/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=zathura-ps
 PKGSEC=doc
-PKGDEP="libspectre zathura"
+PKGDEP="libspectre zathura girara"
 PKGDES="PostScript support for Zathura"

--- a/app-doc/zathura-ps/spec
+++ b/app-doc/zathura-ps/spec
@@ -1,4 +1,5 @@
 VER=0.2.7
-SRCS="https://pwmt.org/projects/zathura-ps/download/zathura-ps-$VER.tar.xz"
-CHKSUMS="sha256::5897f9204cf5f978b9413be7ce7febde843157af48e351938edf07dbf9308e46"
+REL=1
+SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-ps"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14848"

--- a/app-doc/zathura/autobuild/defines
+++ b/app-doc/zathura/autobuild/defines
@@ -1,7 +1,12 @@
 PKGNAME=zathura
 PKGSEC=doc
-PKGDEP="girara sqlite desktop-file-utils file"
+PKGDEP="girara sqlite desktop-file-utils file libseccomp texlive"
 BUILDDEP="docutils sphinx appstream-glib bash-completion fish"
 PKGDES="A minimalistic document viewer"
 
 ABTYPE=meson
+MESON_AFTER="-Dsynctex=enabled \
+             -Dseccomp=enabled \
+             -Dmanpages=enabled \
+             -Dtests=disabled \
+             -Dconvert-icon=enabled"

--- a/app-doc/zathura/spec
+++ b/app-doc/zathura/spec
@@ -1,4 +1,4 @@
-VER=0.5.2
-SRCS="tbl::https://pwmt.org/projects/zathura/download/zathura-$VER.tar.xz"
-CHKSUMS="sha256::c64ba7cb9facf2b1499b9dc929b6736c72c69f8062eed4f2940556c852256194"
+VER=0.5.6
+SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5298"

--- a/runtime-desktop/girara/autobuild/defines
+++ b/runtime-desktop/girara/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=girara
 PKGSEC=libs
-PKGDEP="gtk-3 libnotify json-glib"
+PKGDEP="gtk-3 json-glib glib pango glibc"
 BUILDDEP="doxygen"
 PKGDES="User interface library focused on simplicity and minimalism"
+PKGBREAK="zathura-djvu<=0.2.9-2 zathura<=0.5.2 zathura-pdf-poppler<=0.3.1 \
+          zathura-ps<=0.2.7"
 
 ABTYPE=meson

--- a/runtime-desktop/girara/spec
+++ b/runtime-desktop/girara/spec
@@ -1,4 +1,4 @@
-VER=0.4.0
-SRCS="tbl::https://pwmt.org/projects/girara/download/girara-$VER.tar.xz"
-CHKSUMS="sha256::ceafd0a6aed50ad832ba766ec629f1ea366681c15f8fa728a8f55418c39dc901"
+VER=0.4.4
+SRCS="git::commit=tags/$VER::https://github.com/pwmt/girara"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6750"


### PR DESCRIPTION
Topic Description
-----------------

- zathura: update to 0.5.6
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- girara: 0.4.4
- zathura: 0.5.6
- zathura-djvu: 0.2.9-3
- zathura-pdf-poppler: 0.3.2
- zathura-ps: 0.2.7-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit girara zathura zathura-djvu zathura-pdf-poppler zathura-ps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
