### PR TITLE
libexttextcat: update to 3.4.6

### DIFF
--- a/runtime-i18n/libexttextcat/spec
+++ b/runtime-i18n/libexttextcat/spec
@@ -1,4 +1,4 @@
-VER=3.4.5
+VER=3.4.6
 SRCS="tbl::https://dev-www.libreoffice.org/src/libexttextcat/libexttextcat-$VER.tar.xz"
-CHKSUMS="sha256::13fdbc9d4c489a4d0519e51933a1aa21fe3fb9eb7da191b87f7a63e82797dac8"
+CHKSUMS="sha256::6d77eace20e9ea106c1330e268ede70c9a4a89744ddc25715682754eca3368df"
 CHKUPDATE="anitya::id=1609"


### PR DESCRIPTION
Topic Description
-----------------

- libexttextcat: update to 3.4.6
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libexttextcat: 3.4.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libexttextcat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
