### PR TITLE
perl-file-sharedir: update to 1.118

### DIFF
--- a/lang-perl/perl-file-sharedir/spec
+++ b/lang-perl/perl-file-sharedir/spec
@@ -1,5 +1,4 @@
-VER=1.116
+VER=1.118
 SRCS="tbl::https://cpan.metacpan.org/authors/id/R/RE/REHSACK/File-ShareDir-$VER.tar.gz"
-CHKSUMS='sha256::59d90bfdf98c4656ff4173e62954ea8cf0de66565e35d108ecd7050596cb8328'
-REL=1
+CHKSUMS="sha256::3bb2a20ba35df958dc0a4f2306fc05d903d8b8c4de3c8beefce17739d281c958"
 CHKUPDATE="anitya::id=2901"


### PR DESCRIPTION
Topic Description
-----------------

- perl-file-sharedir: update to 1.118
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-file-sharedir: 1.118

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-file-sharedir
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
