### PR TITLE
dnspython: update to 2.6.1

### DIFF
--- a/lang-python/dnspython/autobuild/defines
+++ b/lang-python/dnspython/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=dnspython
 PKGSEC=python
 PKGDEP="python-3 idna requests toolbelt cryptography httpx hyper-h2 sniffio"
-BUILDDEP="setuptools pep517 python-build wheel poetry python-installer"
+BUILDDEP="setuptools pep517 python-build wheel poetry python-installer \
+          hatchling"
 PKGDES="A DNS toolkit for Python"
 
 ABHOST=noarch

--- a/lang-python/dnspython/spec
+++ b/lang-python/dnspython/spec
@@ -1,4 +1,4 @@
-VER=2.3.0
+VER=2.6.1
 SRCS="tbl::https://pypi.io/packages/source/d/dnspython/dnspython-$VER.tar.gz"
-CHKSUMS="sha256::224e32b03eb46be70e12ef6d64e0be123a64e621ab4c0822ff6d450d52a540b9"
+CHKSUMS="sha256::e8f0f9c23a7b7cb99ded64e6c3a6f3e701d78f50c55e002b839dea7225cff7cc"
 CHKUPDATE="anitya::id=13190"


### PR DESCRIPTION
Topic Description
-----------------

- dnspython: update to 2.6.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dnspython: 2.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dnspython
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
