### PR TITLE
libofx: update to 0.10.8

### DIFF
--- a/runtime-productivity/libofx/spec
+++ b/runtime-productivity/libofx/spec
@@ -1,4 +1,4 @@
-VER=0.9.15
+VER=0.10.8
 SRCS="tbl::https://github.com/libofx/libofx/archive/$VER.tar.gz"
-CHKSUMS="sha256::74a9370da560526424ab62d79f7301f86620a8566c3f38cfc4684e63a4aac155"
+CHKSUMS="sha256::33a842987838b0609dd64c81cf3a26966d8c020cb1661bf71597fffc55edf2aa"
 CHKUPDATE="anitya::id=7309"


### PR DESCRIPTION
Topic Description
-----------------

- libofx: update to 0.10.8
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libofx: 0.10.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit libofx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
