### PR TITLE
cherrypy: update to 18.9.0

### DIFF
--- a/lang-python/cherrypy/autobuild/defines
+++ b/lang-python/cherrypy/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=cherrypy
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-scm"
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer setuptools-scm wheel"
 PKGDES="A pythonic, object-oriented web development framework"
 
 ABHOST=noarch
+
+ABTYPE=pep517

--- a/lang-python/cherrypy/spec
+++ b/lang-python/cherrypy/spec
@@ -1,5 +1,4 @@
-VER=18.1.0
-REL=3
+VER=18.9.0
 SRCS="tbl::https://pypi.io/packages/source/C/CherryPy/CherryPy-$VER.tar.gz"
-CHKSUMS="sha256::4dd2f59b5af93bd9ca85f1ed0bb8295cd0f5a8ee2b84d476374d4e070aa5c615"
+CHKSUMS="sha256::6b06c191ce71a86461f30572a1ab57ffc09f43143ba8e42c103c7b3347220eb1"
 CHKUPDATE="anitya::id=3799"


### PR DESCRIPTION
Topic Description
-----------------

- cherrypy: update to 18.9.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cherrypy: 18.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit cherrypy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
