### PR TITLE
opam: update to 2.1.6

### DIFF
--- a/lang-ocaml/opam/spec
+++ b/lang-ocaml/opam/spec
@@ -1,5 +1,4 @@
-VER=2.1.3
+VER=2.1.6
 SRCS="tbl::https://github.com/ocaml/opam/releases/download/$VER/opam-full-$VER.tar.gz"
-CHKSUMS="sha256::cb2ab00661566178318939918085aa4b5c35c727df83751fd92d114fdd2fa001"
-REL=2
+CHKSUMS="sha256::d2af5edc85f552e0cf5ec0ddcc949d94f2dc550dc5df595174a06a4eaf8af628"
 CHKUPDATE="anitya::id=16645"


### PR DESCRIPTION
Topic Description
-----------------

- opam: update to 2.1.6
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- opam: 2.1.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit opam
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
