### PR TITLE
snapd-glib: update to 1.65

### DIFF
--- a/runtime-admin/snapd-glib/autobuild/defines
+++ b/runtime-admin/snapd-glib/autobuild/defines
@@ -8,6 +8,10 @@ PKGDES="GLib ibrary for communicating with Snapd"
 MESON_AFTER="-Dintrospection=true \
              -Ddocs=true \
              -Dvala-bindings=true \
-             -Dqt-bindings=true \
+             -Dqt5=true \
+             -Dqt6=false \
              -Dqml-bindings=true \
              -Dsoup2=false"
+
+# FIXME: snapd only support these architectures
+FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64)"

--- a/runtime-admin/snapd-glib/spec
+++ b/runtime-admin/snapd-glib/spec
@@ -1,4 +1,4 @@
-VER=1.63
+VER=1.65
 SRCS="tbl::https://github.com/snapcore/snapd-glib/releases/download/$VER/snapd-glib-$VER.tar.xz"
-CHKSUMS="sha256::28bc96c8bb76d09f709c3d35cab743ccae57699f4eef5d36db914f0c1a77ab47"
+CHKSUMS="sha256::f2e6d0f45ed10065f8d7d65cde27d57ef23c0541663d912acbf85322ae911e61"
 CHKUPDATE="anitya::id=13996"


### PR DESCRIPTION
Topic Description
-----------------

- snapd-glib: update to 1.65
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- snapd-glib: 1.65

Security Update?
----------------

No

Build Order
-----------

```
#buildit snapd-glib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
