### PR TITLE
python-evdev: update to 1.7.1

### DIFF
--- a/lang-python/python-evdev/autobuild/defines
+++ b/lang-python/python-evdev/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME=python-evdev
 PKGSEC=python
-PKGDEP="libevdev python-2 python-3"
+PKGDEP="libevdev python-3"
 BUILDDEP="setuptools"
 PKGDES="Python interfaces for Linux event device handling"
+
+NOPYTHON2=1

--- a/lang-python/python-evdev/spec
+++ b/lang-python/python-evdev/spec
@@ -1,5 +1,4 @@
-VER=1.4.0
+VER=1.7.1
 SRCS="tbl::https://pypi.io/packages/source/e/evdev/evdev-$VER.tar.gz"
-CHKSUMS="sha256::8782740eb1a86b187334c07feb5127d3faa0b236e113206dfe3ae8f77fb1aaf1"
+CHKSUMS="sha256::0c72c370bda29d857e188d931019c32651a9c1ea977c08c8d939b1ced1637fde"
 CHKUPDATE="anitya::id=12300"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- python-evdev: update to 1.7.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- python-evdev: 1.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit python-evdev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
