### PR TITLE
crazydiskinfo: update to 1.1.0

### DIFF
--- a/app-utils/crazydiskinfo/autobuild/defines
+++ b/app-utils/crazydiskinfo/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME=crazydiskinfo
 PKGSEC=utils
 PKGDEP="libatasmart ncurses"
-BUILDDEP="cmake"
-PKGDES="An interactive TUI S.M.A.R.T viewer for Unix systems"
+PKGDES="An interactive TUI S.M.A.R.T. viewer"
+
+# FIXME: FTBFS invalid conversion from ‘void (*)(int)’ to ‘int’
+FAIL_ARCH="(loongson3|mips64r6el)"

--- a/app-utils/crazydiskinfo/autobuild/patches/0001-fix-CMakeLists.txt-install-exeuctable-to-usr-bin.patch
+++ b/app-utils/crazydiskinfo/autobuild/patches/0001-fix-CMakeLists.txt-install-exeuctable-to-usr-bin.patch
@@ -1,0 +1,23 @@
+From c79452fac18ee5958f62b84a767bfb7cc74dffc6 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 19 Jun 2024 23:39:52 +0800
+Subject: [PATCH 1/2] fix(CMakeLists.txt): install exeuctable to /usr/bin
+
+AOSC OS does not distinguish between bin and sbin.
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cebc142..91a0259 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -7,4 +7,4 @@ SET_TARGET_PROPERTIES(CrazyDiskInfo PROPERTIES OUTPUT_NAME crazy)
+ target_link_libraries(CrazyDiskInfo atasmart)
+ target_link_libraries(CrazyDiskInfo tinfow)
+ target_link_libraries(CrazyDiskInfo ncursesw)
+-INSTALL(TARGETS CrazyDiskInfo RUNTIME DESTINATION /usr/sbin)
++INSTALL(TARGETS CrazyDiskInfo RUNTIME DESTINATION /usr/bin)
+-- 
+2.45.2
+

--- a/app-utils/crazydiskinfo/autobuild/patches/0002-fix-CMakeLists.txt-link-against-ltinfo.patch
+++ b/app-utils/crazydiskinfo/autobuild/patches/0002-fix-CMakeLists.txt-link-against-ltinfo.patch
@@ -1,0 +1,25 @@
+From e9c527fee30e17aa4a44bbcf8da44c436b61399d Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 19 Jun 2024 23:40:19 +0800
+Subject: [PATCH 2/2] fix(CMakeLists.txt): link against -ltinfo
+
+AOSC OS uses libtinfo as an equivalence to libtinfow.
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 91a0259..bb1f631 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,6 +5,6 @@ add_executable(CrazyDiskInfo main.cpp)
+ set(CMAKE_CXX_FLAGS "-Wall -std=c++11")
+ SET_TARGET_PROPERTIES(CrazyDiskInfo PROPERTIES OUTPUT_NAME crazy)
+ target_link_libraries(CrazyDiskInfo atasmart)
+-target_link_libraries(CrazyDiskInfo tinfow)
++target_link_libraries(CrazyDiskInfo tinfo)
+ target_link_libraries(CrazyDiskInfo ncursesw)
+ INSTALL(TARGETS CrazyDiskInfo RUNTIME DESTINATION /usr/bin)
+-- 
+2.45.2
+

--- a/app-utils/crazydiskinfo/autobuild/prepare
+++ b/app-utils/crazydiskinfo/autobuild/prepare
@@ -1,3 +1,0 @@
-abinfo "Tweaking CMakeLists.txt, /usr/sbin => /usr/bin ..."
-sed -e 's|sbin|bin|g' \
-    -i "$SRCDIR"/CMakeLists.txt

--- a/app-utils/crazydiskinfo/spec
+++ b/app-utils/crazydiskinfo/spec
@@ -1,5 +1,4 @@
-VER=1.0.2
-REL=3
+VER=1.1.0
 SRCS="tbl::https://github.com/otakuto/crazydiskinfo/archive/$VER.tar.gz"
-CHKSUMS="sha256::828165463a566b1736c5d94cfe8e0036085b99cefee65191fcba770156d9a2bd"
+CHKSUMS="sha256::fca9a4487bb088d4e12d11b0c3040843a109818e9f757912490a0ca15ad95bb4"
 CHKUPDATE="anitya::id=231573"


### PR DESCRIPTION
Topic Description
-----------------

- crazydiskinfo: update to 1.1.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- crazydiskinfo: 1.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit crazydiskinfo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
