### PR TITLE
yosys: update to 0.41

### DIFF
--- a/app-electronics/yosys/spec
+++ b/app-electronics/yosys/spec
@@ -1,4 +1,4 @@
-VER=0.39
+VER=0.41
 SRCS="git::commit=tags/yosys-$VER;copy-repo=true::https://github.com/YosysHQ/yosys"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12619"


### PR DESCRIPTION
Topic Description
-----------------

- yosys: update to 0.41
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- yosys: 0.41

Security Update?
----------------

No

Build Order
-----------

```
#buildit yosys
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
