### PR TITLE
shellingham: update to 1.5.4

### DIFF
--- a/lang-python/shellingham/spec
+++ b/lang-python/shellingham/spec
@@ -1,5 +1,4 @@
-VER=1.3.1
+VER=1.5.4
 SRCS="tbl::https://pypi.io/packages/source/s/shellingham/shellingham-$VER.tar.gz"
-CHKSUMS="sha256::985b23bbd1feae47ca6a6365eacd314d93d95a8a16f8f346945074c28fe6f3e0"
+CHKSUMS="sha256::8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"
 CHKUPDATE="anitya::id=72819"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- shellingham: update to 1.5.4
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- shellingham: 1.5.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit shellingham
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
