### PR TITLE
c-blosc: update to 1.21.5

### DIFF
--- a/runtime-common/c-blosc/spec
+++ b/runtime-common/c-blosc/spec
@@ -1,4 +1,4 @@
-VER=1.21.3
+VER=1.21.5
 SRCS="git::commit=tags/v${VER}::https://github.com/Blosc/c-blosc.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205"


### PR DESCRIPTION
Topic Description
-----------------

- c-blosc: update to 1.21.5
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- c-blosc: 1.21.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit c-blosc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
