### PR TITLE
libgnomekbd: update to 3.28.1

### DIFF
--- a/desktop-gnome/libgnomekbd/spec
+++ b/desktop-gnome/libgnomekbd/spec
@@ -1,4 +1,4 @@
-VER=3.28.0
+VER=3.28.1
 SRCS="tbl::https://ftp.acc.umu.se/pub/gnome/sources/libgnomekbd/${VER:0:4}/libgnomekbd-$VER.tar.xz"
-CHKSUMS="sha256::b3057a443e4c26f91fe352dcd1154a56cdd51f1cfd7cb6ace300c3cc128659c9"
+CHKSUMS="sha256::22dc59566d73c0065350f5a97340e62ecc7b08c4df19183804bb8be24c8fe870"
 CHKUPDATE="anitya::id=228580"


### PR DESCRIPTION
Topic Description
-----------------

- libgnomekbd: update to 3.28.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libgnomekbd: 3.28.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgnomekbd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
