### PR TITLE
netavark: update to 1.10.3

### DIFF
--- a/runtime-containers/netavark/autobuild/defines
+++ b/runtime-containers/netavark/autobuild/defines
@@ -12,7 +12,7 @@ ABTYPE=rust
 
 USECLANG=1
 
-# FIXME: FTBFS on loongson3
-# build-script-build received SIGSEGV, "invalid memory reference"
-USECLANG__LOONGSON3=0
+# FIXME: ld.lld is not yet available.
 NOLTO__LOONGSON3=1
+NOLTO__LOONGARCH64=1
+NOLTO__MIPS64R6EL=1

--- a/runtime-containers/netavark/spec
+++ b/runtime-containers/netavark/spec
@@ -1,4 +1,4 @@
-VER=1.9.0
+VER=1.10.3
 SRCS="https://github.com/containers/netavark/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::9ec50b715ded0a0699134c001656fdd1411e3fb5325d347695c6cb8cc5fcf572"
+CHKSUMS="sha256::fdc3010cb221f0fcef0302f57ef6f4d9168a61f9606238a3e1ed4d2e348257b7"
 CHKUPDATE="anitya::id=242639"


### PR DESCRIPTION
Topic Description
-----------------

- netavark: update to 1.10.3
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- netavark: 1.10.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit netavark
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
