### PR TITLE
xdg-desktop-portal-gtk: update to 1.15.1

### DIFF
--- a/app-admin/xdg-desktop-portal-gtk/autobuild/defines
+++ b/app-admin/xdg-desktop-portal-gtk/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=xdg-desktop-portal-gtk
 PKGSEC=admin
-PKGDEP="dbus gsettings-desktop-schemas gtk-3 xdg-desktop-portal"
+PKGDEP="dbus gsettings-desktop-schemas gtk-3 xdg-desktop-portal gnome-desktop"
 BUILDDEP="xmlto docbook-xsl"
 PKGDES="Portal frontend service to flatpak (GTK+ interface)"

--- a/app-admin/xdg-desktop-portal-gtk/spec
+++ b/app-admin/xdg-desktop-portal-gtk/spec
@@ -1,4 +1,4 @@
-VER=1.12.0
+VER=1.15.1
 SRCS="tbl::https://github.com/flatpak/xdg-desktop-portal-gtk/releases/download/$VER/xdg-desktop-portal-gtk-$VER.tar.xz"
-CHKSUMS="sha256::aa0220edf9ceeadbb915f72ed981e16adaaebf8789f79b513c328ee2083b68a1"
+CHKSUMS="sha256::425551ca5f36451d386d53599d95a3a05b94020f1a4927c5111a2c3ba3a0fe4c"
 CHKUPDATE="anitya::id=11108"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-desktop-portal-gtk: update to 1.15.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xdg-desktop-portal-gtk: 1.15.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-desktop-portal-gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
