### PR TITLE
libgusb: update to 0.4.9

### DIFF
--- a/runtime-devices/libgusb/spec
+++ b/runtime-devices/libgusb/spec
@@ -1,4 +1,4 @@
-VER=0.4.8
+VER=0.4.9
 SRCS="git::commit=tags/$VER::https://github.com/hughsie/libgusb"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5505"


### PR DESCRIPTION
Topic Description
-----------------

- libgusb: update to 0.4.9
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libgusb: 0.4.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgusb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
