### PR TITLE
libcacard: update to 2.8.1

### DIFF
--- a/runtime-emulation/libcacard/spec
+++ b/runtime-emulation/libcacard/spec
@@ -1,4 +1,4 @@
-VER=2.7.0
+VER=2.8.1
 SRCS="tbl::https://www.spice-space.org/download/libcacard/libcacard-$VER.tar.xz"
-CHKSUMS="sha256::16b1a0847d5f9d2290e0785eca40f2e49d1ed80814bfc758c05c76b3c89cdb6f"
+CHKSUMS="sha256::fbbf4de8cb7db5bdff5ecb672ff0dbe6939fb9f344b900d51ba6295329a332e7"
 CHKUPDATE="anitya::id=18776"


### PR DESCRIPTION
Topic Description
-----------------

- libcacard: update to 2.8.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libcacard: 2.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcacard
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
