### PR TITLE
rp-pppoe: update to 4.0

### DIFF
--- a/app-network/rp-pppoe/spec
+++ b/app-network/rp-pppoe/spec
@@ -1,5 +1,5 @@
-VER=3.15
+VER=4.0
 SRCS="http://deb.debian.org/debian/pool/main/r/rp-pppoe/rp-pppoe_$VER.orig.tar.gz"
-CHKSUMS="sha256::b1f318bc7e4e5b0fd8a8e23e8803f5e6e43165245a5a10a7162a92a6cf17829a"
+CHKSUMS="sha256::41ac34e5db4482f7a558780d3b897bdbb21fae3fef4645d2852c3c0c19d81cea"
 SUBDIR="rp-pppoe-$VER/src"
 CHKUPDATE="anitya::id=4209"


### PR DESCRIPTION
Topic Description
-----------------

- rp-pppoe: update to 4.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- rp-pppoe: 4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rp-pppoe
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
