### PR TITLE
kodi (KODI): update to 21.0

### DIFF
--- a/app-multimedia/kodi/autobuild/defines
+++ b/app-multimedia/kodi/autobuild/defines
@@ -7,7 +7,7 @@ PKGDEP="afpfs-ng bluez dcadec fribidi glew hicolor-icon-theme \
         mesa-demos pillow pulseaudio samba shairplay simplejson sdl2 \
         taglib tinyxml udisks unrar unzip upower yajl rtmpdump \
         pybluez cwiid flatbuffers fmt fstrcmp rapidjson mariadb libxslt \
-        sndio spdlog waylandpp libinput libudfread dav1d ffmpeg"
+        sndio spdlog waylandpp libinput libudfread dav1d ffmpeg tinyxml2"
 BUILDDEP="boost cmake curl doxygen gperf jasper openjdk swig zip"
 BUILDDEP__AMD64="${BUILDDEP} nasm yasm"
 BUILDDEP__MIPS64R6EL="${BUILDDEP/openjdk/}"

--- a/app-multimedia/kodi/spec
+++ b/app-multimedia/kodi/spec
@@ -1,9 +1,8 @@
-VER=20.3
-REL=3
-PERIPHERAL_JOYSTICK_VER=20.1.0
-CODE=Nexus
+VER=21.0
+PERIPHERAL_JOYSTICK_VER=21.1.8
+CODE=Omega
 # Note: Take commit from branch with the corresponding codename.
-RSRC_COMMIT=1be759417b34cec73dfafac3e386b34b767fd1ce
+RSRC_COMMIT=c451373742c0df37de392d66fa5274736bc0022e
 SRCS="git::rename=xbmc;commit=tags/${VER}-${CODE}::https://github.com/xbmc/xbmc.git \
       git::rename=kodi-res;commit=${RSRC_COMMIT}::https://github.com/xbmc/repo-resources.git \
       git::rename=peripheral.joystick;commit=tags/${PERIPHERAL_JOYSTICK_VER}-${CODE}::https://github.com/xbmc/peripheral.joystick.git"

--- a/app-multimedia/kodi/spec
+++ b/app-multimedia/kodi/spec
@@ -11,3 +11,4 @@ CHKSUMS="SKIP \
          SKIP"
 SUBDIR="xbmc"
 CHKUPDATE="anitya::id=5511"
+REL=1

--- a/runtime-common/tinyxml2/autobuild/defines
+++ b/runtime-common/tinyxml2/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=tinyxml2
+PKGSEC=libs
+PKGDEP="gcc-runtime"
+PKGDES="A C++ XML parser library"
+
+ABTYPE=meson
+MESON_AFTER=(
+    -Dtests=false
+)

--- a/runtime-common/tinyxml2/spec
+++ b/runtime-common/tinyxml2/spec
@@ -1,0 +1,4 @@
+VER=10.0.0
+SRCS="git::commit=tags/$VER::https://github.com/leethomason/tinyxml2"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=4976"

--- a/runtime-common/tinyxml2/spec
+++ b/runtime-common/tinyxml2/spec
@@ -2,3 +2,4 @@ VER=10.0.0
 SRCS="git::commit=tags/$VER::https://github.com/leethomason/tinyxml2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4976"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- kodi: bump REL for topic Revision Marking Guidelines
- tinyxml2: bump REL for topic Revision Marking Guidelines
- kodi: update to 21.0
    Add tinyxml2 dep.
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>
- tinyxml2: new, 10.0.0

Package(s) Affected
-------------------

- kodi: 1:21.0-1
- tinyxml2: 10.0.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tinyxml2 kodi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
