### PR TITLE
yarl: update to 1.9.4

### DIFF
--- a/lang-python/expandvars/autobuild/defines
+++ b/lang-python/expandvars/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=expandvars
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build hatchling python-installer"
+PKGDES="Variable expansion library in Python"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/lang-python/expandvars/spec
+++ b/lang-python/expandvars/spec
@@ -1,0 +1,4 @@
+VER=0.12.0
+SRCS="tbl::https://pypi.io/packages/source/e/expandvars/expandvars-$VER.tar.gz"
+CHKSUMS="sha256::7d1adfa55728cf4b5d812ece3d087703faea953e0c0a1a78415de9df5024d844"
+CHKUPDATE="anitya::id=95228"

--- a/lang-python/yarl/autobuild/defines
+++ b/lang-python/yarl/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME=yarl
 PKGSEC=python
 PKGDEP="glibc multidict idna"
-BUILDDEP="setuptools pathlib cython"
+BUILDDEP="python-build tomli pathlib cython expandvars wheel python-installer"
 PKGDES="Yet another URL library for Python"
 
-ABTYPE=python
 NOPYTHON2=1

--- a/lang-python/yarl/autobuild/prepare
+++ b/lang-python/yarl/autobuild/prepare
@@ -1,4 +1,0 @@
-abinfo "Converting .pyx file into C file..."
-cd "$SRCDIR"
-sed 's| .install-cython ||g' -i "$SRCDIR"/Makefile
-make cythonize

--- a/lang-python/yarl/spec
+++ b/lang-python/yarl/spec
@@ -1,5 +1,4 @@
-VER=1.6.3
+VER=1.9.4
 SRCS="tbl::https://github.com/aio-libs/yarl/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::0dd52e81a7079982c33a22098148f2f6973209823418e820f8d9e596d7bacca4"
+CHKSUMS="sha256::d0df8ec8d4d41326406c4c2c27b795a12ace92e5cfcabcf934fa622b36a982f5"
 CHKUPDATE="anitya::id=25206"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- yarl: update to 1.9.4
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- yarl: 1.9.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit expandvars yarl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
