### PR TITLE
repo: update to 2.45

### DIFF
--- a/app-devel/repo/spec
+++ b/app-devel/repo/spec
@@ -1,4 +1,4 @@
-VER=2.43
+VER=2.45
 SRCS="git::commit=tags/v$VER::https://android.googlesource.com/tools/repo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226921"


### PR DESCRIPTION
Topic Description
-----------------

- repo: update to 2.45
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- repo: 1:2.45

Security Update?
----------------

No

Build Order
-----------

```
#buildit repo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
