### PR TITLE
firehol: update to 3.1.7

### DIFF
--- a/app-network/firehol/spec
+++ b/app-network/firehol/spec
@@ -1,5 +1,4 @@
-VER=3.1.6
-REL=1
+VER=3.1.7
 SRCS="tbl::https://github.com/firehol/firehol/releases/download/v$VER/firehol-$VER.tar.xz"
-CHKSUMS="sha256::42a9d2622e160ff2f1e3b34fdb91c13ecf476957287e90fcbd8f3c679fcb1b7e"
+CHKSUMS="sha256::04ccb8e16a7220c11fe3c62884d007f46bc1d6d5d781300c6f7bc2f825f9ea9c"
 CHKUPDATE="anitya::id=814"


### PR DESCRIPTION
Topic Description
-----------------

- firehol: update to 3.1.7
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- firehol: 3.1.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit firehol
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
