### PR TITLE
libdc1394: update to 2.2.7

### DIFF
--- a/app-multimedia/vlc/spec
+++ b/app-multimedia/vlc/spec
@@ -1,5 +1,5 @@
 VER=3.0.20
-REL=6
+REL=7
 SRCS="tbl::https://get.videolan.org/vlc/$VER/vlc-$VER.tar.xz"
 CHKSUMS="sha256::adc7285b4d2721cddf40eb5270cada2aaa10a334cb546fd55a06353447ba29b5"
 CHKUPDATE="anitya::id=6504"

--- a/runtime-devices/libdc1394/autobuild/defines
+++ b/runtime-devices/libdc1394/autobuild/defines
@@ -5,4 +5,4 @@ PKGDEP="libraw1394 libusb"
 
 RECONF=0
 
-PKGBREAK="vlc<=3.0.12 opencv<=4.3.0"
+PKGBREAK="gstreamer<=1.24.3 opencv<=4.9.0 vlc<=3.0.20-6"

--- a/runtime-devices/libdc1394/spec
+++ b/runtime-devices/libdc1394/spec
@@ -1,4 +1,4 @@
-VER=2.2.6
+VER=2.2.7
 SRCS="tbl::https://sourceforge.net/projects/libdc1394/files/libdc1394-2/$VER/libdc1394-$VER.tar.gz"
-CHKSUMS="sha256::2b905fc9aa4eec6bdcf6a2ae5f5ba021232739f5be047dec8fe8dd6049c10fed"
+CHKSUMS="sha256::537ceb78dd3cef271a183f4a176191d1cecf85f025520e6bd3758b0e19e6609f"
 CHKUPDATE="anitya::id=1591"

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,4 +1,5 @@
 VER=1.24.3
+REL=1
 SRCS="tbl::https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/$VER/gstreamer-$VER.tar.gz"
 CHKSUMS="sha256::ed10e1ce7144ed1791712d32afa485423015b5264f05280653b37724fe382089"
 CHKUPDATE="anitya::id=1263"

--- a/runtime-scientific/opencv/spec
+++ b/runtime-scientific/opencv/spec
@@ -1,4 +1,5 @@
 VER=4.9.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/opencv/opencv \
       git::commit=tags/$VER;rename=opencv_contrib::https://github.com/opencv/opencv_contrib"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- vlc: bump REL due to libdc1394 update to 2.2.7
- opencv: bump REL due to libdc1394 update to 2.2.7
- gstreamer: bump REL due to libdc1394 update to 2.2.7
- libdc1394: update to 2.2.7
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gstreamer: 1.24.3-1
- libdc1394: 2.2.7
- opencv: 4.7.0-6
- vlc: 3.0.20-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdc1394:-pkgbreak opencv gstreamer vlc libdc1394
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
