### PR TITLE
libmd: update to 1.1.0

### DIFF
--- a/runtime-cryptography/libmd/spec
+++ b/runtime-cryptography/libmd/spec
@@ -1,4 +1,4 @@
-VER=1.0.4
+VER=1.1.0
 SRCS="tbl::https://archive.hadrons.org/software/libmd/libmd-$VER.tar.xz"
-CHKSUMS="sha256::f51c921042e34beddeded4b75557656559cf5b1f2448033b4c1eec11c07e530f"
+CHKSUMS="sha256::1bd6aa42275313af3141c7cf2e5b964e8b1fd488025caf2f971f43b00776b332"
 CHKUPDATE="anitya::id=15525"


### PR DESCRIPTION
Topic Description
-----------------

- libmd: update to 1.1.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libmd: 1.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
