### PR TITLE
scandir: update to 1.10.0

### DIFF
--- a/lang-python/scandir/spec
+++ b/lang-python/scandir/spec
@@ -1,5 +1,4 @@
-VER=1.9.0
-REL=1
+VER=1.10.0
 SRCS="tbl::https://pypi.io/packages/source/s/scandir/scandir-$VER.tar.gz"
-CHKSUMS="sha256::44975e209c4827fc18a3486f257154d34ec6eaec0f90fef0cca1caa482db7064"
+CHKSUMS="sha256::4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae"
 CHKUPDATE="anitya::id=231391"


### PR DESCRIPTION
Topic Description
-----------------

- scandir: update to 1.10.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- scandir: 1.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit scandir
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
