### PR TITLE
libxaw3d: update to 1.6.6

### DIFF
--- a/runtime-display/libxaw3d/spec
+++ b/runtime-display/libxaw3d/spec
@@ -1,6 +1,5 @@
-VER=1.6.3
+VER=1.6.6
 SRCS="tbl::https://www.x.org/archive/individual/lib/libXaw3d-$VER.tar.gz"
-CHKSUMS="sha256::9f42b409e5a4a0d7a2c94595b31d17fc078e5e307d14389dbc396754c3a01fcc"
+CHKSUMS="sha256::0cdb8f51c390b0f9f5bec74454e53b15b6b815bc280f6b7c969400c9ef595803"
 SUBDIR="libXaw3d-$VER"
-REL=1
 CHKUPDATE="anitya::id=231984"


### PR DESCRIPTION
Topic Description
-----------------

- libxaw3d: update to 1.6.6
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libxaw3d: 1.6.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxaw3d
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
