### PR TITLE
frei0r-plugins: update to 2.3.2

### DIFF
--- a/runtime-multimedia/frei0r-plugins/spec
+++ b/runtime-multimedia/frei0r-plugins/spec
@@ -1,4 +1,4 @@
-VER=2.2.0
+VER=2.3.2
 SRCS="tbl::https://github.com/dyne/frei0r/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::51bbcbebb40be75c75dba7df211b0ef1bd0463b02b80b7d34e93efeaceb98d3b"
+CHKSUMS="sha256::304291e0ecb456a8b054fe04e14adc50ace54d0223b7b29165ff5343e820ef9d"
 CHKUPDATE="anitya::id=10670"


### PR DESCRIPTION
Topic Description
-----------------

- frei0r-plugins: update to 2.3.2
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- frei0r-plugins: 2.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit frei0r-plugins
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
