### PR TITLE
perl-sys-virt: update to 10.2.0

### DIFF
--- a/lang-perl/perl-sys-virt/spec
+++ b/lang-perl/perl-sys-virt/spec
@@ -1,5 +1,4 @@
-VER=5.8.0
+VER=10.2.0
 SRCS="tbl::https://cpan.metacpan.org/authors/id/D/DA/DANBERR/Sys-Virt-v${VER}.tar.gz"
-CHKSUMS="sha256::71def28e571ddd6b7881f6e3ba0edf0375d8fdad75cd8681e402277c5fa71157"
-REL=2
+CHKSUMS="sha256::ec079c65eb0991db3cba6726cede04ba21a35a8b86840fab2a0c10243f374745"
 CHKUPDATE="anitya::id=3355"


### PR DESCRIPTION
Topic Description
-----------------

- perl-sys-virt: update to 10.2.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-sys-virt: 10.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-sys-virt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
