### PR TITLE
darkhttpd: update to 1.16

### DIFF
--- a/app-web/darkhttpd/spec
+++ b/app-web/darkhttpd/spec
@@ -1,4 +1,4 @@
-VER=1.13
+VER=1.16
 SRCS="tbl::https://github.com/emikulic/darkhttpd/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::1d88c395ac79ca9365aa5af71afe4ad136a4ed45099ca398168d4a2014dc0fc2"
+CHKSUMS="sha256::ab97ea3404654af765f78282aa09cfe4226cb007d2fcc59fe1a475ba0fef1981"
 CHKUPDATE="anitya::id=391"


### PR DESCRIPTION
Topic Description
-----------------

- darkhttpd: update to 1.16
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- darkhttpd: 1.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit darkhttpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
