### PR TITLE
coreboot-utils: update to 24.05

### DIFF
--- a/app-admin/coreboot-utils/autobuild/defines
+++ b/app-admin/coreboot-utils/autobuild/defines
@@ -4,3 +4,7 @@ PKGDEP="pciutils systemd"
 PKGDES="Various utilities from Coreboot project"
 
 AB_FLAGS_SPECS=0
+
+# FIXME: FTBFS on riscv64: cast discards ‘const’ qualifier from pointer target
+# type [-Werror=cast-qual]
+FAIL_ARCH="riscv64"

--- a/app-admin/coreboot-utils/spec
+++ b/app-admin/coreboot-utils/spec
@@ -1,4 +1,4 @@
-VER=4.15
+VER=24.05
 SRCS="https://www.coreboot.org/releases/coreboot-$VER.tar.xz"
-CHKSUMS="sha256::20e6aaa6dd0eaec7753441c799711d1b4630e3ca709536386f2242ac2c8a1ec5"
+CHKSUMS="sha256::e22afdbac40068ba687fd975f03f6b958599a32e70f539d9d0c74d16a63d7cea"
 CHKUPDATE="anitya::id=10128"


### PR DESCRIPTION
Topic Description
-----------------

- coreboot-utils: update to 24.05
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- coreboot-utils: 24.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit coreboot-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
