### PR TITLE
highlight: update to 4.10

### DIFF
--- a/app-devel/highlight/spec
+++ b/app-devel/highlight/spec
@@ -1,5 +1,4 @@
-VER=4.2
-REL=1
+VER=4.10
 SRCS="tbl::http://www.andre-simon.de/zip/highlight-$VER.tar.bz2"
-CHKSUMS="sha256::ed3efdb9b416b236e503989f9dfebdd94bf515536cfd183aefe36cefdd0d0468"
+CHKSUMS="sha256::4389a022367ceafb55a6cf7774c5d82d320ec2df4339bae4aab058c511338ad0"
 CHKUPDATE="anitya::id=14752"


### PR DESCRIPTION
Topic Description
-----------------

- highlight: update to 4.10
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- highlight: 4.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit highlight
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
