### PR TITLE
exceptiongroup: update to 1.2.1

### DIFF
--- a/lang-python/exceptiongroup/spec
+++ b/lang-python/exceptiongroup/spec
@@ -1,4 +1,4 @@
-VER=1.2.0
+VER=1.2.1
 SRCS="tbl::https://files.pythonhosted.org/packages/source/e/exceptiongroup/exceptiongroup-$VER.tar.gz"
-CHKSUMS="sha256::91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+CHKSUMS="sha256::a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"
 CHKUPDATE="anitya::id=245950"


### PR DESCRIPTION
Topic Description
-----------------

- exceptiongroup: update to 1.2.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- exceptiongroup: 1.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit exceptiongroup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
