### PR TITLE
corsixth: update to 0.67

### DIFF
--- a/app-games/corsixth/autobuild/patches/0001-Use-wqy-microhei.patch
+++ b/app-games/corsixth/autobuild/patches/0001-Use-wqy-microhei.patch
@@ -2,12 +2,12 @@ diff --git a/CorsixTH/Lua/config_finder.lua b/CorsixTH/Lua/config_finder.lua
 index 25d505f3..0b98500c 100644
 --- a/CorsixTH/Lua/config_finder.lua
 +++ b/CorsixTH/Lua/config_finder.lua
-@@ -372,7 +372,7 @@ if needs_rewrite then
+@@ -408,7 +408,7 @@
  -- Specify a font file here if you wish to play the game in a language not
  -- present in the original game. Examples include Russian, Chinese and Polish.
  --
 -unicode_font = nil -- [[X:\ThemeHospital\font.ttc]]
 +unicode_font = [[/usr/share/fonts/TTF/wqy-microhei.ttc]]
- 
- -------------------------------------------------------------------------------------------------------------------------
+
+ -------------------------------------------------------------------------------
  -- Savegames. By default, the "Saves" directory alongside this config file will

--- a/app-games/corsixth/spec
+++ b/app-games/corsixth/spec
@@ -1,4 +1,4 @@
-VER=0.65.1
+VER=0.67
 SRCS="tbl::https://github.com/CorsixTH/CorsixTH/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::b8a1503371fa0c0f3d07d3b39a3de2769b8ed25923d0d931b7075bc88e3f508f"
+CHKSUMS="sha256::4e88cf1916bf4d7c304b551ddb91fb9194f110bad4663038ca73d31b939d69e3"
 CHKUPDATE="anitya::id=20298"


### PR DESCRIPTION
Topic Description
-----------------

- corsixth: update to 0.67
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- corsixth: 1:0.67

Security Update?
----------------

No

Build Order
-----------

```
#buildit corsixth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
