### PR TITLE
enet: update to 1.3.18

### DIFF
--- a/runtime-network/enet/spec
+++ b/runtime-network/enet/spec
@@ -1,4 +1,4 @@
-VER=1.3.14
+VER=1.3.18
 SRCS="tbl::http://enet.bespin.org/download/enet-$VER.tar.gz"
-CHKSUMS="sha256::98f6f57aab0a424469619ed3047728f0d3901ce8f0dea919c11e7966d807e870"
+CHKSUMS="sha256::2a8a0c5360d68bb4fcd11f2e4c47c69976e8d2c85b109dd7d60b1181a4f85d36"
 CHKUPDATE="anitya::id=696"


### PR DESCRIPTION
Topic Description
-----------------

- enet: update to 1.3.18
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- enet: 1.3.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit enet
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
