### PR TITLE
gdk-pixbuf: update to 2.42.12

### DIFF
--- a/runtime-imaging/gdk-pixbuf/autobuild/defines
+++ b/runtime-imaging/gdk-pixbuf/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=gdk-pixbuf
 PKGDES="A toolkit for image loading and pixel buffer manipulation"
 PKGDEP="fribidi glib libpng libtiff libjpeg-turbo jasper shared-mime-info"
-BUILDDEP="gobject-introspection gi-docgen gtk-doc vim"
+BUILDDEP="gobject-introspection gi-docgen gtk-doc vim docutils"
 BUILDDEP__RETRO=""
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"

--- a/runtime-imaging/gdk-pixbuf/spec
+++ b/runtime-imaging/gdk-pixbuf/spec
@@ -1,5 +1,4 @@
-VER=2.42.8
-REL=4
+VER=2.42.12
 SRCS="https://download.gnome.org/sources/gdk-pixbuf/${VER:0:4}/gdk-pixbuf-$VER.tar.xz"
-CHKSUMS="sha256::84acea3acb2411b29134b32015a5b1aaa62844b19c4b1ef8b8971c6b0759f4c6"
+CHKSUMS="sha256::b9505b3445b9a7e48ced34760c3bcb73e966df3ac94c95a148cb669ab748e3c7"
 CHKUPDATE="anitya::id=9533"


### PR DESCRIPTION
Topic Description
-----------------

- gdk-pixbuf: update to 2.42.12
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gdk-pixbuf: 2.42.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdk-pixbuf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
