### PR TITLE
arc-theme: update to 20221218

### DIFF
--- a/desktop-themes/arc-theme/spec
+++ b/desktop-themes/arc-theme/spec
@@ -1,4 +1,4 @@
-VER=20210412
+VER=20221218
 SRCS="tbl::https://github.com/jnsh/arc-theme/releases/download/$VER/arc-theme-$VER.tar.xz"
-CHKSUMS="sha256::3d0fadc9ccbf3a49c257388d56d6e15fb4acb39ce7f3cdfbeffa8326ec6770b7"
+CHKSUMS="sha256::264570cc90a13b88d181334fb325f99a6ddc2a45392aa9ed7dba312aea042bb0"
 CHKUPDATE="anitya::id=12811"


### PR DESCRIPTION
Topic Description
-----------------

- arc-theme: update to 20221218
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- arc-theme: 20221218

Security Update?
----------------

No

Build Order
-----------

```
#buildit arc-theme
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
