### PR TITLE
wireshark: update to 4.2.5

### DIFF
--- a/app-network/wireshark/spec
+++ b/app-network/wireshark/spec
@@ -1,5 +1,4 @@
-VER=4.2.3
-REL=1
+VER=4.2.5
 SRCS="tbl::https://www.wireshark.org/download/src/all-versions/wireshark-$VER.tar.xz"
-CHKSUMS="sha256::958bd5996f543d91779b1a4e7e952dcd7b0245fe82194202c3333a8f78795811"
+CHKSUMS="sha256::55e793ab87a9a73aac44336235c92cb76c52180c469b362ed3a54f26fbb1261f"
 CHKUPDATE="anitya::id=5137"


### PR DESCRIPTION
Topic Description
-----------------

- wireshark: upd to 4.2.5, fix symbol linkage with qt-6

Package(s) Affected
-------------------

- wireshark: 4.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireshark
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
