### PR TITLE
clash-verge-rev: update to 1.6.4

### DIFF
--- a/app-network/clash-verge-rev/autobuild/build
+++ b/app-network/clash-verge-rev/autobuild/build
@@ -11,8 +11,15 @@ install -Dvm755 "$SRCDIR"/src-tauri/target/release/clash-verge \
 
 abinfo "Installing icon ..."
 # Note: This seems to be the only appropriate icon.
-install -Dvm644 "$SRCDIR"/src/assets/image/logo.bak.svg \
+install -Dvm644 "$SRCDIR"/src/assets/image/icon_light.svg \
     "$PKGDIR"/usr/share/pixmaps/clash-verge.svg
+
+install -Dvm644 "$SRCDIR"/src/assets/image/icon_dark.svg \
+    "$PKGDIR"/usr/share/pixmaps/clash-verge-dark.svg
+
+install -Dvm644 "$SRCDIR"/src/assets/image/logo.svg \
+    "$PKGDIR"/usr/share/pixmaps/clash-verge-logo.svg
+
 
 abinfo "Installing .desktop entry ..."
 install -Dvm644 "$SRCDIR"/src/assets/xdg/io.github.clash-verge-rev.desktop \

--- a/app-network/clash-verge-rev/autobuild/patches/0001-fix-package.json-allow-building-on-platforms-without.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0001-fix-package.json-allow-building-on-platforms-without.patch
@@ -1,7 +1,7 @@
-From a5997440e8734e9909741f44539397ff52236990 Mon Sep 17 00:00:00 2001
+From 0426a960d6ef1438c02a36fe688bfbe90fd3a47e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 15:42:32 +0800
-Subject: [PATCH 01/10] fix(package.json): allow building on platforms without
+Subject: [PATCH 01/11] fix(package.json): allow building on platforms without
  native rollup binaries
 
 Ref: https://github.com/clash-verge-rev/clash-verge-rev/issues/453#issuecomment-2002506344
@@ -10,10 +10,10 @@ Ref: https://github.com/clash-verge-rev/clash-verge-rev/issues/453#issuecomment-
  1 file changed, 5 insertions(+)
 
 diff --git a/package.json b/package.json
-index 89267c1..250bac1 100644
+index 7d8680d..fa4dac2 100644
 --- a/package.json
 +++ b/package.json
-@@ -81,5 +81,10 @@
+@@ -86,5 +86,10 @@
      "semi": true,
      "singleQuote": false,
      "endOfLine": "lf"

--- a/app-network/clash-verge-rev/autobuild/patches/0002-chore-src-tauri-update-Cargo-dependencies.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0002-chore-src-tauri-update-Cargo-dependencies.patch
@@ -1,28 +1,47 @@
-From 5f1f30f28b7be5e1784ab2aebba7cb870c2dace2 Mon Sep 17 00:00:00 2001
+From 38f1073af8f1050c729bcdf0b65c7cfbfdc725ea Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
-Date: Sat, 18 May 2024 16:35:42 +0800
-Subject: [PATCH 02/10] chore(src-tauri): update Cargo dependencies
+Date: Tue, 28 May 2024 22:51:30 +0800
+Subject: [PATCH 02/11] chore(src-tauri): update Cargo dependencies
 
-- This allows building clash-verge-rev on loongarch64.
-- Procedure: cd src-tauri && cargo update.
 ---
- src-tauri/Cargo.lock | 537 ++++++++++++++++++++++++-------------------
- 1 file changed, 298 insertions(+), 239 deletions(-)
+ src-tauri/Cargo.lock | 705 ++++++++++++++++++++++++-------------------
+ 1 file changed, 391 insertions(+), 314 deletions(-)
 
 diff --git a/src-tauri/Cargo.lock b/src-tauri/Cargo.lock
-index 70c55c4..898440c 100644
+index 50433c1..cd5ae99 100644
 --- a/src-tauri/Cargo.lock
 +++ b/src-tauri/Cargo.lock
-@@ -23,7 +23,7 @@ version = "0.7.8"
+@@ -4,9 +4,9 @@ version = 3
+ 
+ [[package]]
+ name = "addr2line"
+-version = "0.21.0"
++version = "0.22.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
++checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
  dependencies = [
-- "getrandom 0.2.14",
-+ "getrandom 0.2.15",
-  "once_cell",
-  "version_check",
+  "gimli",
  ]
-@@ -35,7 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -17,17 +17,6 @@ version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+ 
+-[[package]]
+-name = "ahash"
+-version = "0.7.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+-dependencies = [
+- "getrandom 0.2.14",
+- "once_cell",
+- "version_check",
+-]
+-
+ [[package]]
+ name = "ahash"
+ version = "0.8.11"
+@@ -35,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
  dependencies = [
   "cfg-if",
@@ -31,15 +50,15 @@ index 70c55c4..898440c 100644
   "once_cell",
   "version_check",
   "zerocopy",
-@@ -97,25 +97,24 @@ dependencies = [
+@@ -97,25 +86,24 @@ dependencies = [
  
  [[package]]
  name = "anyhow"
 -version = "1.0.82"
-+version = "1.0.85"
++version = "1.0.86"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
-+checksum = "27a4bd113ab6da4cd0f521068a6e2ee1065eab54107266a11835d02c8ec86a37"
++checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
  
  [[package]]
  name = "arboard"
@@ -65,7 +84,7 @@ index 70c55c4..898440c 100644
   "windows-sys 0.48.0",
   "wl-clipboard-rs",
   "x11rb",
-@@ -158,12 +157,11 @@ dependencies = [
+@@ -158,12 +146,11 @@ dependencies = [
  
  [[package]]
  name = "async-channel"
@@ -80,7 +99,19 @@ index 70c55c4..898440c 100644
   "event-listener-strategy 0.5.2",
   "futures-core",
   "pin-project-lite",
-@@ -298,7 +296,7 @@ version = "2.2.2"
+@@ -171,9 +158,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "async-executor"
+-version = "1.11.0"
++version = "1.12.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
++checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
+ dependencies = [
+  "async-task",
+  "concurrent-queue",
+@@ -298,7 +285,7 @@ version = "2.2.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "a53fc6301894e04a92cb2584fedde80cb25ba8e02d9dc39d4a87d036e22f397d"
  dependencies = [
@@ -89,25 +120,25 @@ index 70c55c4..898440c 100644
   "async-io 2.3.2",
   "async-lock 3.3.0",
   "async-signal",
-@@ -320,7 +318,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+@@ -320,7 +307,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -355,7 +353,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+@@ -355,7 +342,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -400,9 +398,9 @@ dependencies = [
+@@ -400,15 +387,15 @@ dependencies = [
  
  [[package]]
  name = "autocfg"
@@ -119,7 +150,15 @@ index 70c55c4..898440c 100644
  
  [[package]]
  name = "backtrace"
-@@ -433,9 +431,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+-version = "0.3.71"
++version = "0.3.72"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
++checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+ dependencies = [
+  "addr2line",
+  "cc",
+@@ -433,9 +420,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
  
  [[package]]
  name = "base64"
@@ -131,40 +170,46 @@ index 70c55c4..898440c 100644
  
  [[package]]
  name = "bitflags"
-@@ -473,13 +471,22 @@ dependencies = [
+@@ -473,14 +460,22 @@ dependencies = [
   "generic-array",
  ]
  
 +[[package]]
 +name = "block2"
-+version = "0.5.0"
++version = "0.5.1"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "43ff7d91d3c1d568065b06c899777d1e48dcf76103a672a0adbc238a7f247f1e"
++checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 +dependencies = [
 + "objc2",
 +]
 +
  [[package]]
  name = "blocking"
- version = "1.6.0"
+-version = "1.6.0"
++version = "1.6.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
+-checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
++checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
  dependencies = [
 - "async-channel 2.2.1",
+- "async-lock 3.3.0",
 + "async-channel 2.3.1",
-  "async-lock 3.3.0",
   "async-task",
   "futures-io",
-@@ -519,7 +526,7 @@ dependencies = [
+  "futures-lite 2.3.0",
+@@ -517,9 +512,9 @@ dependencies = [
+  "boa_profiler",
+  "bytemuck",
   "cfg-if",
-  "dashmap 5.5.3",
+- "dashmap 5.5.3",
++ "dashmap",
   "fast-float",
 - "hashbrown 0.14.3",
 + "hashbrown 0.14.5",
   "icu_normalizer",
   "indexmap 2.2.6",
   "intrusive-collections",
-@@ -554,7 +561,7 @@ checksum = "c055ef3cd87ea7db014779195bc90c6adfc35de4902e3b2fe587adecbd384578"
+@@ -554,7 +549,7 @@ checksum = "c055ef3cd87ea7db014779195bc90c6adfc35de4902e3b2fe587adecbd384578"
  dependencies = [
   "boa_macros",
   "boa_profiler",
@@ -173,7 +218,7 @@ index 70c55c4..898440c 100644
   "thin-vec",
  ]
  
-@@ -566,7 +573,7 @@ checksum = "0cacc9caf022d92195c827a3e5bf83f96089d4bfaff834b359ac7b6be46e9187"
+@@ -566,7 +561,7 @@ checksum = "0cacc9caf022d92195c827a3e5bf83f96089d4bfaff834b359ac7b6be46e9187"
  dependencies = [
   "boa_gc",
   "boa_macros",
@@ -182,16 +227,16 @@ index 70c55c4..898440c 100644
   "indexmap 2.2.6",
   "once_cell",
   "phf 0.11.2",
-@@ -582,7 +589,7 @@ checksum = "6be9c93793b60dac381af475b98634d4b451e28336e72218cad9a20176218dbc"
+@@ -582,7 +577,7 @@ checksum = "6be9c93793b60dac381af475b98634d4b451e28336e72218cad9a20176218dbc"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
   "synstructure",
  ]
  
-@@ -650,9 +657,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+@@ -650,22 +645,22 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
  
  [[package]]
  name = "bytemuck"
@@ -203,28 +248,35 @@ index 70c55c4..898440c 100644
  dependencies = [
   "bytemuck_derive",
  ]
-@@ -665,7 +672,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
+ 
+ [[package]]
+ name = "bytemuck_derive"
+-version = "1.6.0"
++version = "1.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
++checksum = "369cfaf2a5bed5d8f8202073b2e093c9f508251de1551a0deb4253e4c7d80909"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -719,9 +726,9 @@ dependencies = [
+@@ -719,9 +714,9 @@ dependencies = [
  
  [[package]]
  name = "cc"
 -version = "1.0.95"
-+version = "1.0.97"
++version = "1.0.98"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
-+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
++checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
  
  [[package]]
  name = "cesu8"
-@@ -802,7 +809,7 @@ dependencies = [
+@@ -802,7 +797,7 @@ dependencies = [
   "log4rs",
   "nanoid",
   "once_cell",
@@ -233,30 +285,66 @@ index 70c55c4..898440c 100644
   "parking_lot",
   "percent-encoding",
   "port_scanner",
-@@ -900,7 +907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -900,7 +895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "f76990911f2267d837d9d0ad060aa63aaad170af40904b29461734c339030d4d"
  dependencies = [
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -1068,7 +1075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -982,9 +977,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crc32fast"
+-version = "1.4.0"
++version = "1.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
++checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+ dependencies = [
+  "cfg-if",
+ ]
+@@ -1002,9 +997,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-channel"
+-version = "0.5.12"
++version = "0.5.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
++checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+ dependencies = [
+  "crossbeam-utils",
+ ]
+@@ -1030,9 +1025,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-utils"
+-version = "0.8.19"
++version = "0.8.20"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
++checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+ 
+ [[package]]
+ name = "crypto-common"
+@@ -1068,7 +1063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
  dependencies = [
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -1078,14 +1085,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -1078,14 +1073,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
  dependencies = [
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
@@ -269,7 +357,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "darling_core",
   "darling_macro",
-@@ -1093,27 +1100,27 @@ dependencies = [
+@@ -1093,37 +1088,27 @@ dependencies = [
  
  [[package]]
  name = "darling_core"
@@ -285,7 +373,7 @@ index 70c55c4..898440c 100644
   "quote",
   "strsim",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
@@ -299,11 +387,21 @@ index 70c55c4..898440c 100644
   "darling_core",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
+-]
+-
+-[[package]]
+-name = "dashmap"
+-version = "4.0.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+-dependencies = [
+- "cfg-if",
+- "num_cpus",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -1133,7 +1140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -1133,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
  dependencies = [
   "cfg-if",
@@ -312,25 +410,47 @@ index 70c55c4..898440c 100644
   "lock_api",
   "once_cell",
   "parking_lot_core",
-@@ -1213,7 +1220,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
+@@ -1161,17 +1146,17 @@ dependencies = [
+ 
+ [[package]]
+ name = "delay_timer"
+-version = "0.11.5"
++version = "0.11.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d70c0d5d2addc05d1e0cf7e60b3a5bf08415f03136a773d7c66b4e4a3b892cef"
++checksum = "20eba879b7ee5f1d255d5666e16646fe384f899f71a4c0b4b0644e2e074964fe"
+ dependencies = [
+  "anyhow",
+  "async-trait",
+  "autocfg",
+  "concat-idents",
+  "cron_clock",
+- "dashmap 4.0.2",
+- "event-listener 2.5.3",
++ "dashmap",
++ "event-listener 5.3.0",
+  "futures",
+  "log 0.4.21",
+  "lru",
+@@ -1213,7 +1198,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -1330,7 +1337,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+@@ -1330,7 +1315,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -1371,9 +1378,9 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+@@ -1371,9 +1356,9 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
  
  [[package]]
  name = "either"
@@ -342,7 +462,7 @@ index 70c55c4..898440c 100644
  
  [[package]]
  name = "embed-resource"
-@@ -1384,7 +1391,7 @@ dependencies = [
+@@ -1384,7 +1369,7 @@ dependencies = [
   "cc",
   "memchr",
   "rustc_version 0.4.0",
@@ -351,16 +471,16 @@ index 70c55c4..898440c 100644
   "vswhom",
   "winreg 0.52.0",
  ]
-@@ -1428,7 +1435,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
+@@ -1428,7 +1413,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -1439,9 +1446,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+@@ -1439,9 +1424,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
  
  [[package]]
  name = "errno"
@@ -372,7 +492,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "libc",
   "windows-sys 0.52.0",
-@@ -1583,9 +1590,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+@@ -1583,9 +1568,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
  
  [[package]]
  name = "flate2"
@@ -384,25 +504,25 @@ index 70c55c4..898440c 100644
  dependencies = [
   "crc32fast",
   "miniz_oxide",
-@@ -1624,7 +1631,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+@@ -1624,7 +1609,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -1742,7 +1749,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+@@ -1742,7 +1727,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -1916,9 +1923,9 @@ dependencies = [
+@@ -1916,9 +1901,9 @@ dependencies = [
  
  [[package]]
  name = "getrandom"
@@ -414,7 +534,19 @@ index 70c55c4..898440c 100644
  dependencies = [
   "cfg-if",
   "libc",
-@@ -2112,15 +2119,15 @@ dependencies = [
+@@ -1927,9 +1912,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "gimli"
+-version = "0.28.1"
++version = "0.29.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
++checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+ 
+ [[package]]
+ name = "gio"
+@@ -2112,15 +2097,15 @@ dependencies = [
  
  [[package]]
  name = "h2"
@@ -433,7 +565,13 @@ index 70c55c4..898440c 100644
   "http 1.1.0",
   "indexmap 2.2.6",
   "slab",
-@@ -2155,9 +2162,9 @@ dependencies = [
+@@ -2149,17 +2134,14 @@ name = "hashbrown"
+ version = "0.12.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+-dependencies = [
+- "ahash 0.7.8",
+-]
  
  [[package]]
  name = "hashbrown"
@@ -443,9 +581,12 @@ index 70c55c4..898440c 100644
 -checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 +checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
  dependencies = [
-  "ahash 0.8.11",
+- "ahash 0.8.11",
++ "ahash",
   "allocator-api2",
-@@ -2340,7 +2347,7 @@ dependencies = [
+ ]
+ 
+@@ -2340,7 +2322,7 @@ dependencies = [
   "httpdate",
   "itoa 1.0.11",
   "pin-project-lite",
@@ -454,7 +595,7 @@ index 70c55c4..898440c 100644
   "tokio",
   "tower-service",
   "tracing",
-@@ -2356,7 +2363,7 @@ dependencies = [
+@@ -2356,7 +2338,7 @@ dependencies = [
   "bytes",
   "futures-channel",
   "futures-util",
@@ -463,7 +604,19 @@ index 70c55c4..898440c 100644
   "http 1.1.0",
   "http-body 1.0.0",
   "httparse",
-@@ -2426,7 +2433,7 @@ dependencies = [
+@@ -2415,9 +2397,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "hyper-util"
+-version = "0.1.3"
++version = "0.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
++checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+ dependencies = [
+  "bytes",
+  "futures-channel",
+@@ -2426,7 +2408,7 @@ dependencies = [
   "http-body 1.0.0",
   "hyper 1.3.1",
   "pin-project-lite",
@@ -472,16 +625,60 @@ index 70c55c4..898440c 100644
   "tokio",
   "tower",
   "tower-service",
-@@ -2591,7 +2598,7 @@ checksum = "d2abdd3a62551e8337af119c5899e600ca0c88ec8f23a46c60ba216c803dcf1a"
+@@ -2523,9 +2505,9 @@ checksum = "545c6c3e8bf9580e2dafee8de6f9ec14826aaf359787789c7724f1f85f47d3dc"
+ 
+ [[package]]
+ name = "icu_normalizer"
+-version = "1.4.1"
++version = "1.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c183e31ed700f1ecd6b032d104c52fe8b15d028956b73727c97ec176b170e187"
++checksum = "accb85c5b2e76f8dade22978b3795ae1e550198c6cfc7e915144e17cd6e2ab56"
+ dependencies = [
+  "displaydoc",
+  "icu_collections",
+@@ -2541,15 +2523,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "icu_normalizer_data"
+-version = "1.4.0"
++version = "1.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "22026918a80e6a9a330cb01b60f950e2b4e5284c59528fd0c6150076ef4c8522"
++checksum = "e3744fecc0df9ce19999cdaf1f9f3a48c253431ce1d67ef499128fe9d0b607ab"
+ 
+ [[package]]
+ name = "icu_properties"
+-version = "1.4.0"
++version = "1.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "976e296217453af983efa25f287a4c1da04b9a63bf1ed63719455068e4453eb5"
++checksum = "d8173ba888885d250016e957b8ebfd5a65cdb690123d8833a19f6833f9c2b579"
+ dependencies = [
+  "displaydoc",
+  "icu_collections",
+@@ -2562,9 +2544,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "icu_properties_data"
+-version = "1.4.0"
++version = "1.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f6a86c0e384532b06b6c104814f9c1b13bcd5b64409001c0d05713a1f3529d99"
++checksum = "e70a8b51ee5dd4ff8f20ee9b1dd1bc07afc110886a3747b1fec04cc6e5a15815"
+ 
+ [[package]]
+ name = "icu_provider"
+@@ -2591,7 +2573,7 @@ checksum = "d2abdd3a62551e8337af119c5899e600ca0c88ec8f23a46c60ba216c803dcf1a"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -2636,6 +2643,17 @@ dependencies = [
+@@ -2636,6 +2618,17 @@ dependencies = [
   "byteorder",
   "color_quant",
   "num-traits",
@@ -499,7 +696,7 @@ index 70c55c4..898440c 100644
   "png",
   "tiff",
  ]
-@@ -2658,7 +2676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -2658,7 +2651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
  dependencies = [
   "equivalent",
@@ -508,7 +705,7 @@ index 70c55c4..898440c 100644
   "serde",
  ]
  
-@@ -2682,9 +2700,9 @@ dependencies = [
+@@ -2682,9 +2675,9 @@ dependencies = [
  
  [[package]]
  name = "instant"
@@ -520,7 +717,16 @@ index 70c55c4..898440c 100644
  dependencies = [
   "cfg-if",
  ]
-@@ -2842,14 +2860,13 @@ dependencies = [
+@@ -2737,7 +2730,7 @@ version = "0.2.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c416c05ba2a10240e022887617af3128fccdbf69713214da0fc81a5690d00df7"
+ dependencies = [
+- "ahash 0.8.11",
++ "ahash",
+  "once_cell",
+  "regex 1.10.4",
+ ]
+@@ -2842,14 +2835,13 @@ dependencies = [
  
  [[package]]
  name = "json-patch"
@@ -537,7 +743,7 @@ index 70c55c4..898440c 100644
  ]
  
  [[package]]
-@@ -2903,9 +2920,9 @@ dependencies = [
+@@ -2903,9 +2895,9 @@ dependencies = [
  
  [[package]]
  name = "libc"
@@ -549,7 +755,7 @@ index 70c55c4..898440c 100644
  
  [[package]]
  name = "libloading"
-@@ -2951,9 +2968,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+@@ -2951,9 +2943,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
  
  [[package]]
  name = "linux-raw-sys"
@@ -561,7 +767,22 @@ index 70c55c4..898440c 100644
  
  [[package]]
  name = "litemap"
-@@ -3173,9 +3190,9 @@ checksum = "933dca44d65cdd53b355d0b73d380a2ff5da71f87f036053188bf1eab6a19881"
+@@ -3040,11 +3032,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "lru"
+-version = "0.7.8"
++version = "0.12.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
++checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+ dependencies = [
+- "hashbrown 0.12.3",
++ "hashbrown 0.14.5",
+ ]
+ 
+ [[package]]
+@@ -3173,9 +3165,9 @@ checksum = "933dca44d65cdd53b355d0b73d380a2ff5da71f87f036053188bf1eab6a19881"
  
  [[package]]
  name = "miniz_oxide"
@@ -573,7 +794,21 @@ index 70c55c4..898440c 100644
  dependencies = [
   "adler",
   "simd-adler32",
-@@ -3369,11 +3386,10 @@ dependencies = [
+@@ -3221,11 +3213,10 @@ dependencies = [
+ 
+ [[package]]
+ name = "native-tls"
+-version = "0.2.11"
++version = "0.2.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
++checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+ dependencies = [
+- "lazy_static 1.4.0",
+  "libc",
+  "log 0.4.21",
+  "openssl",
+@@ -3369,11 +3360,10 @@ dependencies = [
  
  [[package]]
  name = "num-bigint"
@@ -587,7 +822,7 @@ index 70c55c4..898440c 100644
   "num-integer",
   "num-traits",
   "serde",
-@@ -3407,9 +3423,9 @@ dependencies = [
+@@ -3407,9 +3397,9 @@ dependencies = [
  
  [[package]]
  name = "num-traits"
@@ -599,30 +834,30 @@ index 70c55c4..898440c 100644
  dependencies = [
   "autocfg",
  ]
-@@ -3463,7 +3479,7 @@ dependencies = [
+@@ -3463,7 +3453,7 @@ dependencies = [
   "proc-macro-crate 3.1.0",
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -3496,6 +3512,61 @@ dependencies = [
+@@ -3496,6 +3486,105 @@ dependencies = [
   "objc_id",
  ]
  
 +[[package]]
 +name = "objc-sys"
-+version = "0.3.3"
++version = "0.3.5"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "da284c198fb9b7b0603f8635185e85fbd5b64ee154b1ed406d489077de2d6d60"
++checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 +
 +[[package]]
 +name = "objc2"
-+version = "0.5.1"
++version = "0.5.2"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "b4b25e1034d0e636cd84707ccdaa9f81243d399196b8a773946dcffec0401659"
++checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 +dependencies = [
 + "objc-sys",
 + "objc2-encode",
@@ -630,47 +865,103 @@ index 70c55c4..898440c 100644
 +
 +[[package]]
 +name = "objc2-app-kit"
-+version = "0.2.0"
++version = "0.2.2"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "fb79768a710a9a1798848179edb186d1af7e8a8679f369e4b8d201dd2a034047"
++checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 +dependencies = [
++ "bitflags 2.5.0",
 + "block2",
++ "libc",
 + "objc2",
 + "objc2-core-data",
++ "objc2-core-image",
 + "objc2-foundation",
++ "objc2-quartz-core",
 +]
 +
 +[[package]]
 +name = "objc2-core-data"
-+version = "0.2.0"
++version = "0.2.2"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "6e092bc42eaf30a08844e6a076938c60751225ec81431ab89f5d1ccd9f958d6c"
++checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 +dependencies = [
++ "bitflags 2.5.0",
 + "block2",
 + "objc2",
 + "objc2-foundation",
 +]
 +
 +[[package]]
-+name = "objc2-encode"
-+version = "4.0.1"
++name = "objc2-core-image"
++version = "0.2.2"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "88658da63e4cc2c8adb1262902cd6af51094df0488b760d6fd27194269c0950a"
-+
-+[[package]]
-+name = "objc2-foundation"
-+version = "0.2.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "cfaefe14254871ea16c7d88968c0ff14ba554712a20d76421eec52f0a7fb8904"
++checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 +dependencies = [
 + "block2",
 + "objc2",
++ "objc2-foundation",
++ "objc2-metal",
++]
++
++[[package]]
++name = "objc2-encode"
++version = "4.0.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
++
++[[package]]
++name = "objc2-foundation"
++version = "0.2.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
++dependencies = [
++ "bitflags 2.5.0",
++ "block2",
++ "libc",
++ "objc2",
++]
++
++[[package]]
++name = "objc2-metal"
++version = "0.2.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
++dependencies = [
++ "bitflags 2.5.0",
++ "block2",
++ "objc2",
++ "objc2-foundation",
++]
++
++[[package]]
++name = "objc2-quartz-core"
++version = "0.2.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
++dependencies = [
++ "bitflags 2.5.0",
++ "block2",
++ "objc2",
++ "objc2-foundation",
++ "objc2-metal",
 +]
 +
  [[package]]
  name = "objc_exception"
  version = "0.1.2"
-@@ -3547,9 +3618,9 @@ dependencies = [
+@@ -3516,9 +3605,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "object"
+-version = "0.32.2"
++version = "0.35.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
++checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+ dependencies = [
+  "memchr",
+ ]
+@@ -3547,9 +3636,9 @@ dependencies = [
  
  [[package]]
  name = "open"
@@ -682,16 +973,28 @@ index 70c55c4..898440c 100644
  dependencies = [
   "is-wsl",
   "libc",
-@@ -3579,7 +3650,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+@@ -3579,7 +3668,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -3697,9 +3768,9 @@ dependencies = [
+@@ -3674,9 +3763,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+ 
+ [[package]]
+ name = "parking_lot"
+-version = "0.12.2"
++version = "0.12.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
++checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+ dependencies = [
+  "lock_api",
+  "parking_lot_core",
+@@ -3697,9 +3786,9 @@ dependencies = [
  
  [[package]]
  name = "paste"
@@ -703,7 +1006,7 @@ index 70c55c4..898440c 100644
  
  [[package]]
  name = "pathdiff"
-@@ -3731,9 +3802,9 @@ checksum = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
+@@ -3731,9 +3820,9 @@ checksum = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
  
  [[package]]
  name = "pest"
@@ -715,7 +1018,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "memchr",
   "thiserror",
-@@ -3742,9 +3813,9 @@ dependencies = [
+@@ -3742,9 +3831,9 @@ dependencies = [
  
  [[package]]
  name = "petgraph"
@@ -727,25 +1030,25 @@ index 70c55c4..898440c 100644
  dependencies = [
   "fixedbitset",
   "indexmap 2.2.6",
-@@ -3864,7 +3935,7 @@ dependencies = [
+@@ -3864,7 +3953,7 @@ dependencies = [
   "phf_shared 0.11.2",
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -3911,7 +3982,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+@@ -3911,7 +4000,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -3928,9 +3999,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+@@ -3928,9 +4017,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
  
  [[package]]
  name = "piper"
@@ -757,19 +1060,19 @@ index 70c55c4..898440c 100644
  dependencies = [
   "atomic-waker",
   "fastrand 2.1.0",
-@@ -4088,9 +4159,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+@@ -4088,9 +4177,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
  
  [[package]]
  name = "proc-macro2"
 -version = "1.0.81"
-+version = "1.0.82"
++version = "1.0.84"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
-+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
++checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
  dependencies = [
   "unicode-ident",
  ]
-@@ -4179,7 +4250,7 @@ version = "0.6.4"
+@@ -4179,7 +4268,7 @@ version = "0.6.4"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
  dependencies = [
@@ -778,7 +1081,7 @@ index 70c55c4..898440c 100644
  ]
  
  [[package]]
-@@ -4250,7 +4321,7 @@ version = "0.4.5"
+@@ -4250,7 +4339,7 @@ version = "0.4.5"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
  dependencies = [
@@ -787,7 +1090,7 @@ index 70c55c4..898440c 100644
   "libredox",
   "thiserror",
  ]
-@@ -4327,7 +4398,7 @@ version = "0.9.1"
+@@ -4327,7 +4416,7 @@ version = "0.9.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "0eae2a1ebfecc58aff952ef8ccd364329abe627762f5bf09ff42eb9d98522479"
  dependencies = [
@@ -796,7 +1099,7 @@ index 70c55c4..898440c 100644
   "memchr",
  ]
  
-@@ -4379,12 +4450,12 @@ version = "0.12.4"
+@@ -4379,12 +4468,12 @@ version = "0.12.4"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
  dependencies = [
@@ -811,7 +1114,7 @@ index 70c55c4..898440c 100644
   "http 1.1.0",
   "http-body 1.0.0",
   "http-body-util",
-@@ -4452,7 +4523,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+@@ -4452,7 +4541,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
  dependencies = [
   "cc",
   "cfg-if",
@@ -820,7 +1123,7 @@ index 70c55c4..898440c 100644
   "libc",
   "spin",
   "untrusted",
-@@ -4479,9 +4550,9 @@ dependencies = [
+@@ -4479,9 +4568,9 @@ dependencies = [
  
  [[package]]
  name = "rustc-demangle"
@@ -832,7 +1135,7 @@ index 70c55c4..898440c 100644
  
  [[package]]
  name = "rustc-hash"
-@@ -4504,7 +4575,7 @@ version = "0.4.0"
+@@ -4504,7 +4593,7 @@ version = "0.4.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
  dependencies = [
@@ -841,7 +1144,7 @@ index 70c55c4..898440c 100644
  ]
  
  [[package]]
-@@ -4530,7 +4601,7 @@ dependencies = [
+@@ -4530,7 +4619,7 @@ dependencies = [
   "bitflags 2.5.0",
   "errno",
   "libc",
@@ -850,7 +1153,7 @@ index 70c55c4..898440c 100644
   "windows-sys 0.52.0",
  ]
  
-@@ -4563,21 +4634,21 @@ version = "2.1.2"
+@@ -4563,21 +4652,21 @@ version = "2.1.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
  dependencies = [
@@ -877,7 +1180,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "ring",
   "rustls-pki-types",
-@@ -4586,15 +4657,15 @@ dependencies = [
+@@ -4586,15 +4675,15 @@ dependencies = [
  
  [[package]]
  name = "rustversion"
@@ -897,7 +1200,7 @@ index 70c55c4..898440c 100644
  
  [[package]]
  name = "ryu-js"
-@@ -4634,11 +4705,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+@@ -4634,11 +4723,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
  
  [[package]]
  name = "security-framework"
@@ -912,7 +1215,7 @@ index 70c55c4..898440c 100644
   "core-foundation",
   "core-foundation-sys",
   "libc",
-@@ -4647,9 +4718,9 @@ dependencies = [
+@@ -4647,9 +4736,9 @@ dependencies = [
  
  [[package]]
  name = "security-framework-sys"
@@ -924,7 +1227,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "core-foundation-sys",
   "libc",
-@@ -4695,9 +4766,9 @@ dependencies = [
+@@ -4695,9 +4784,9 @@ dependencies = [
  
  [[package]]
  name = "semver"
@@ -936,7 +1239,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "serde",
  ]
-@@ -4714,14 +4785,14 @@ version = "0.10.2"
+@@ -4714,14 +4803,14 @@ version = "0.10.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
  dependencies = [
@@ -947,27 +1250,27 @@ index 70c55c4..898440c 100644
  [[package]]
  name = "serde"
 -version = "1.0.199"
-+version = "1.0.202"
++version = "1.0.203"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
-+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
++checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
  dependencies = [
   "serde_derive",
  ]
-@@ -4738,20 +4809,20 @@ dependencies = [
+@@ -4738,20 +4827,20 @@ dependencies = [
  
  [[package]]
  name = "serde_derive"
 -version = "1.0.199"
-+version = "1.0.202"
++version = "1.0.203"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
-+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
++checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
@@ -980,12 +1283,12 @@ index 70c55c4..898440c 100644
  dependencies = [
   "indexmap 2.2.6",
   "itoa 1.0.11",
-@@ -4767,14 +4838,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+@@ -4767,14 +4856,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
@@ -998,7 +1301,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "serde",
  ]
-@@ -4793,11 +4864,11 @@ dependencies = [
+@@ -4793,11 +4882,11 @@ dependencies = [
  
  [[package]]
  name = "serde_with"
@@ -1013,7 +1316,7 @@ index 70c55c4..898440c 100644
   "chrono",
   "hex",
   "indexmap 1.9.3",
-@@ -4811,14 +4882,14 @@ dependencies = [
+@@ -4811,14 +4900,14 @@ dependencies = [
  
  [[package]]
  name = "serde_with_macros"
@@ -1027,11 +1330,11 @@ index 70c55c4..898440c 100644
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -5005,9 +5076,9 @@ dependencies = [
+@@ -5005,9 +5094,9 @@ dependencies = [
  
  [[package]]
  name = "socket2"
@@ -1043,7 +1346,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "libc",
   "windows-sys 0.52.0",
-@@ -5102,9 +5173,9 @@ dependencies = [
+@@ -5102,9 +5191,9 @@ dependencies = [
  
  [[package]]
  name = "strsim"
@@ -1055,24 +1358,24 @@ index 70c55c4..898440c 100644
  
  [[package]]
  name = "subtle"
-@@ -5125,9 +5196,9 @@ dependencies = [
+@@ -5125,9 +5214,9 @@ dependencies = [
  
  [[package]]
  name = "syn"
 -version = "2.0.60"
-+version = "2.0.64"
++version = "2.0.66"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
-+checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
++checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -5148,14 +5219,14 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+@@ -5148,14 +5237,14 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
@@ -1085,7 +1388,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "cfg-if",
   "core-foundation-sys",
-@@ -5223,7 +5294,7 @@ dependencies = [
+@@ -5223,7 +5312,7 @@ dependencies = [
   "cfg-expr 0.15.8",
   "heck 0.5.0",
   "pkg-config",
@@ -1094,7 +1397,7 @@ index 70c55c4..898440c 100644
   "version-compare 0.2.0",
  ]
  
-@@ -5251,7 +5322,7 @@ dependencies = [
+@@ -5251,7 +5340,7 @@ dependencies = [
   "glib",
   "glib-sys",
   "gtk",
@@ -1103,19 +1406,27 @@ index 70c55c4..898440c 100644
   "instant",
   "jni",
   "lazy_static 1.4.0",
-@@ -5312,9 +5383,9 @@ checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+@@ -5312,9 +5401,9 @@ checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
  
  [[package]]
  name = "tauri"
 -version = "1.6.2"
-+version = "1.6.6"
++version = "1.6.7"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "047aefcc7721bfb8024a9bc39d4719112262610502de7a224fa62c4570cd78d4"
-+checksum = "f3f99c42ed6e39885ad1bb14317b0379bc99aad7ffe20db517cd761267b30343"
++checksum = "67c7177b6be45bbb875aa239578f5adc982a1b3d5ea5b315ccd100aeb0043374"
  dependencies = [
   "anyhow",
   "base64 0.21.7",
-@@ -5349,7 +5420,7 @@ dependencies = [
+@@ -5326,6 +5415,7 @@ dependencies = [
+  "encoding_rs",
+  "flate2",
+  "futures-util",
++ "getrandom 0.2.15",
+  "glib",
+  "glob",
+  "gtk",
+@@ -5349,7 +5439,7 @@ dependencies = [
   "regex 1.10.4",
   "reqwest 0.11.27",
   "rfd",
@@ -1124,7 +1435,7 @@ index 70c55c4..898440c 100644
   "serde",
   "serde_json",
   "serde_repr",
-@@ -5375,16 +5446,16 @@ dependencies = [
+@@ -5375,16 +5465,16 @@ dependencies = [
  
  [[package]]
  name = "tauri-build"
@@ -1145,7 +1456,7 @@ index 70c55c4..898440c 100644
   "serde",
   "serde_json",
   "tauri-utils",
-@@ -5394,9 +5465,9 @@ dependencies = [
+@@ -5394,9 +5484,9 @@ dependencies = [
  
  [[package]]
  name = "tauri-codegen"
@@ -1157,7 +1468,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "base64 0.21.7",
   "brotli",
-@@ -5407,7 +5478,7 @@ dependencies = [
+@@ -5407,7 +5497,7 @@ dependencies = [
   "proc-macro2",
   "quote",
   "regex 1.10.4",
@@ -1166,7 +1477,7 @@ index 70c55c4..898440c 100644
   "serde",
   "serde_json",
   "sha2 0.10.8",
-@@ -5420,11 +5491,11 @@ dependencies = [
+@@ -5420,11 +5510,11 @@ dependencies = [
  
  [[package]]
  name = "tauri-macros"
@@ -1181,7 +1492,7 @@ index 70c55c4..898440c 100644
   "proc-macro2",
   "quote",
   "syn 1.0.109",
-@@ -5434,9 +5505,9 @@ dependencies = [
+@@ -5434,9 +5524,9 @@ dependencies = [
  
  [[package]]
  name = "tauri-runtime"
@@ -1193,19 +1504,19 @@ index 70c55c4..898440c 100644
  dependencies = [
   "gtk",
   "http 0.2.12",
-@@ -5455,9 +5526,9 @@ dependencies = [
+@@ -5455,9 +5545,9 @@ dependencies = [
  
  [[package]]
  name = "tauri-runtime-wry"
 -version = "0.14.5"
-+version = "0.14.7"
++version = "0.14.8"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "067c56fc153b3caf406d7cd6de4486c80d1d66c0f414f39e94cb2f5543f6445f"
-+checksum = "ef2af45aeb15b1cadb4ca91248423f4438a0864b836298cecb436892afbfdff4"
++checksum = "1989b3b4d611f5428b3414a4abae6fa6df30c7eb8ed33250ca90a5f7e5bb3655"
  dependencies = [
   "arboard",
   "cocoa 0.24.1",
-@@ -5476,15 +5547,15 @@ dependencies = [
+@@ -5476,15 +5566,15 @@ dependencies = [
  
  [[package]]
  name = "tauri-utils"
@@ -1224,7 +1535,7 @@ index 70c55c4..898440c 100644
   "html5ever",
   "infer 0.13.0",
   "json-patch",
-@@ -5494,7 +5565,7 @@ dependencies = [
+@@ -5494,7 +5584,7 @@ dependencies = [
   "phf 0.11.2",
   "proc-macro2",
   "quote",
@@ -1233,7 +1544,7 @@ index 70c55c4..898440c 100644
   "serde",
   "serde_json",
   "serde_with",
-@@ -5616,22 +5687,22 @@ checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
+@@ -5616,22 +5706,22 @@ checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
  
  [[package]]
  name = "thiserror"
@@ -1257,11 +1568,11 @@ index 70c55c4..898440c 100644
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -5747,7 +5818,7 @@ dependencies = [
+@@ -5747,7 +5837,7 @@ dependencies = [
   "parking_lot",
   "pin-project-lite",
   "signal-hook-registry",
@@ -1270,16 +1581,16 @@ index 70c55c4..898440c 100644
   "tokio-macros",
   "windows-sys 0.48.0",
  ]
-@@ -5760,7 +5831,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+@@ -5760,7 +5850,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -5798,16 +5869,15 @@ dependencies = [
+@@ -5798,16 +5888,15 @@ dependencies = [
  
  [[package]]
  name = "tokio-util"
@@ -1298,7 +1609,7 @@ index 70c55c4..898440c 100644
  ]
  
  [[package]]
-@@ -5833,21 +5903,21 @@ dependencies = [
+@@ -5833,21 +5922,21 @@ dependencies = [
  
  [[package]]
  name = "toml"
@@ -1325,7 +1636,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "serde",
  ]
-@@ -5878,15 +5948,15 @@ dependencies = [
+@@ -5878,15 +5967,15 @@ dependencies = [
  
  [[package]]
  name = "toml_edit"
@@ -1344,16 +1655,24 @@ index 70c55c4..898440c 100644
  ]
  
  [[package]]
-@@ -5937,7 +6007,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+@@ -5902,7 +5991,6 @@ dependencies = [
+  "tokio",
+  "tower-layer",
+  "tower-service",
+- "tracing",
+ ]
+ 
+ [[package]]
+@@ -5937,7 +6025,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -5993,15 +6063,6 @@ dependencies = [
+@@ -5993,15 +6081,6 @@ dependencies = [
   "petgraph",
  ]
  
@@ -1369,7 +1688,7 @@ index 70c55c4..898440c 100644
  [[package]]
  name = "try-lock"
  version = "0.2.5"
-@@ -6180,7 +6241,7 @@ version = "1.8.0"
+@@ -6180,7 +6259,7 @@ version = "1.8.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
  dependencies = [
@@ -1378,7 +1697,7 @@ index 70c55c4..898440c 100644
  ]
  
  [[package]]
-@@ -6244,9 +6305,9 @@ dependencies = [
+@@ -6244,9 +6323,9 @@ dependencies = [
  
  [[package]]
  name = "waker-fn"
@@ -1390,43 +1709,43 @@ index 70c55c4..898440c 100644
  
  [[package]]
  name = "walkdir"
-@@ -6329,7 +6390,7 @@ dependencies = [
+@@ -6329,7 +6408,7 @@ dependencies = [
   "once_cell",
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
   "wasm-bindgen-shared",
  ]
  
-@@ -6363,7 +6424,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+@@ -6363,7 +6442,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
   "wasm-bindgen-backend",
   "wasm-bindgen-shared",
  ]
-@@ -6730,7 +6791,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+@@ -6730,7 +6809,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -6741,7 +6802,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+@@ -6741,7 +6820,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -7041,9 +7102,9 @@ dependencies = [
+@@ -7041,9 +7120,9 @@ dependencies = [
  
  [[package]]
  name = "winnow"
@@ -1438,7 +1757,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "memchr",
  ]
-@@ -7111,9 +7172,9 @@ checksum = "dad7bb64b8ef9c0aa27b6da38b452b0ee9fd82beaf276a87dd796fb55cbae14e"
+@@ -7111,9 +7190,9 @@ checksum = "dad7bb64b8ef9c0aa27b6da38b452b0ee9fd82beaf276a87dd796fb55cbae14e"
  
  [[package]]
  name = "wry"
@@ -1450,7 +1769,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "base64 0.13.1",
   "block",
-@@ -7170,9 +7231,9 @@ dependencies = [
+@@ -7170,9 +7249,9 @@ dependencies = [
  
  [[package]]
  name = "x11rb"
@@ -1462,7 +1781,7 @@ index 70c55c4..898440c 100644
  dependencies = [
   "gethostname",
   "rustix 0.38.34",
-@@ -7181,9 +7242,9 @@ dependencies = [
+@@ -7181,9 +7260,9 @@ dependencies = [
  
  [[package]]
  name = "x11rb-protocol"
@@ -1474,7 +1793,7 @@ index 70c55c4..898440c 100644
  
  [[package]]
  name = "xattr"
-@@ -7192,7 +7253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7192,7 +7271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
  dependencies = [
   "libc",
@@ -1483,26 +1802,26 @@ index 70c55c4..898440c 100644
   "rustix 0.38.34",
  ]
  
-@@ -7232,15 +7293,15 @@ checksum = "9e6936f0cce458098a201c245a11bef556c6a0181129c7034d10d76d1ec3a2b8"
+@@ -7232,15 +7311,15 @@ checksum = "9e6936f0cce458098a201c245a11bef556c6a0181129c7034d10d76d1ec3a2b8"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
   "synstructure",
  ]
  
  [[package]]
  name = "zbus"
 -version = "4.1.2"
-+version = "4.2.1"
++version = "4.2.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "c9ff46f2a25abd690ed072054733e0bc3157e3d4c45f41bd183dce09c2ff8ab9"
-+checksum = "e5915716dff34abef1351d2b10305b019c8ef33dcf6c72d31a6e227d5d9d7a21"
++checksum = "989c3977a7aafa97b12b9a35d21cdcff9b0d2289762b14683f45d66b1ba6c48f"
  dependencies = [
   "async-broadcast",
   "async-executor",
-@@ -7252,7 +7313,6 @@ dependencies = [
+@@ -7252,7 +7331,6 @@ dependencies = [
   "async-task",
   "async-trait",
   "blocking",
@@ -1510,24 +1829,26 @@ index 70c55c4..898440c 100644
   "enumflags2",
   "event-listener 5.3.0",
   "futures-core",
-@@ -7277,14 +7337,13 @@ dependencies = [
+@@ -7277,15 +7355,14 @@ dependencies = [
  
  [[package]]
  name = "zbus_macros"
 -version = "4.1.2"
-+version = "4.2.1"
++version = "4.2.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "4e0e3852c93dcdb49c9462afe67a2a468f7bd464150d866e861eaf06208633e0"
-+checksum = "66fceb36d0c1c4a6b98f3ce40f410e64e5a134707ed71892e1b178abc4c695d4"
++checksum = "6fe9de53245dcf426b7be226a4217dd5e339080e5d46e64a02d6e5dcbf90fca1"
  dependencies = [
   "proc-macro-crate 3.1.0",
   "proc-macro2",
   "quote",
 - "regex 1.10.4",
-  "syn 1.0.109",
+- "syn 1.0.109",
++ "syn 2.0.66",
   "zvariant_utils",
  ]
-@@ -7302,22 +7361,22 @@ dependencies = [
+ 
+@@ -7302,22 +7379,22 @@ dependencies = [
  
  [[package]]
  name = "zerocopy"
@@ -1551,64 +1872,81 @@ index 70c55c4..898440c 100644
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -7337,7 +7396,7 @@ checksum = "e6a647510471d372f2e6c2e6b7219e44d8c574d24fdc11c610a61455782f18c3"
+@@ -7337,15 +7414,15 @@ checksum = "e6a647510471d372f2e6c2e6b7219e44d8c574d24fdc11c610a61455782f18c3"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
   "synstructure",
  ]
  
-@@ -7366,7 +7425,7 @@ checksum = "7b4e5997cbf58990550ef1f0e5124a05e47e1ebd33a84af25739be6031a62c20"
+ [[package]]
+ name = "zeroize"
+-version = "1.7.0"
++version = "1.8.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
++checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+ 
+ [[package]]
+ name = "zerovec"
+@@ -7366,7 +7443,7 @@ checksum = "7b4e5997cbf58990550ef1f0e5124a05e47e1ebd33a84af25739be6031a62c20"
  dependencies = [
   "proc-macro2",
   "quote",
 - "syn 2.0.60",
-+ "syn 2.0.64",
++ "syn 2.0.66",
  ]
  
  [[package]]
-@@ -7382,9 +7441,9 @@ dependencies = [
+@@ -7382,9 +7459,9 @@ dependencies = [
  
  [[package]]
  name = "zvariant"
 -version = "4.0.2"
-+version = "4.1.0"
++version = "4.1.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "2c1b3ca6db667bfada0f1ebfc94b2b1759ba25472ee5373d4551bb892616389a"
-+checksum = "877ef94e5e82b231d2a309c531f191a8152baba8241a7939ee04bd76b0171308"
++checksum = "9aa6d31a02fbfb602bfde791de7fedeb9c2c18115b3d00f3a36e489f46ffbbc7"
  dependencies = [
   "endi",
   "enumflags2",
-@@ -7395,9 +7454,9 @@ dependencies = [
+@@ -7395,24 +7472,24 @@ dependencies = [
  
  [[package]]
  name = "zvariant_derive"
 -version = "4.0.2"
-+version = "4.1.0"
++version = "4.1.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "b7a4b236063316163b69039f77ce3117accb41a09567fd24c168e43491e521bc"
-+checksum = "b7ca98581cc6a8120789d8f1f0997e9053837d6aa5346cbb43454d7121be6e39"
++checksum = "642bf1b6b6d527988b3e8193d20969d53700a36eac734d21ae6639db168701c8"
  dependencies = [
   "proc-macro-crate 3.1.0",
   "proc-macro2",
-@@ -7408,9 +7467,9 @@ dependencies = [
+  "quote",
+- "syn 1.0.109",
++ "syn 2.0.66",
+  "zvariant_utils",
+ ]
  
  [[package]]
  name = "zvariant_utils"
 -version = "1.1.0"
-+version = "1.1.1"
++version = "2.0.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "00bedb16a193cc12451873fee2a1bc6550225acece0e36f333e68326c73c8172"
-+checksum = "75fa7291bdd68cd13c4f97cc9d78cbf16d96305856dfc7ac942aeff4c2de7d5a"
++checksum = "fc242db087efc22bd9ade7aa7809e4ba828132edc312871584a6b4391bdf8786"
  dependencies = [
   "proc-macro2",
   "quote",
+- "syn 1.0.109",
++ "syn 2.0.66",
+ ]
 -- 
 2.45.1
 

--- a/app-network/clash-verge-rev/autobuild/patches/0003-feat-src-assets-add-XDG-.desktop-entry.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0003-feat-src-assets-add-XDG-.desktop-entry.patch
@@ -1,7 +1,7 @@
-From 1b4515191f1a890cfe656591c654160b267bc9e2 Mon Sep 17 00:00:00 2001
+From 29631db35da3a466a8dcf7e5c2b811b1c4003e95 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 16:28:51 +0800
-Subject: [PATCH 03/10] feat(src/assets): add XDG .desktop entry
+Subject: [PATCH 03/11] feat(src/assets): add XDG .desktop entry
 
 ---
  src/assets/xdg/io.github.clash-verge-rev.desktop | 14 ++++++++++++++

--- a/app-network/clash-verge-rev/autobuild/patches/0004-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0004-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,7 +1,7 @@
-From 29ac019131d641a91cb6a125290c206b2f596782 Mon Sep 17 00:00:00 2001
+From 0161273ad4628417096676d504400a8dcca12bc7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 16:32:18 +0800
-Subject: [PATCH 04/10] fix(tauri.conf.json): disable bundle distribution
+Subject: [PATCH 04/11] fix(tauri.conf.json): disable bundle distribution
 
 We only need the binary in /src-tauri/target.
 ---
@@ -9,7 +9,7 @@ We only need the binary in /src-tauri/target.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 0f6c98a..1af8107 100644
+index 3b909b7..6938d36 100644
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -12,7 +12,7 @@

--- a/app-network/clash-verge-rev/autobuild/patches/0005-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0005-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
@@ -1,7 +1,7 @@
-From a8cf8871f7596fdc9563dd09aad4e17d74ef90c9 Mon Sep 17 00:00:00 2001
+From bc91a9310f6e22b19bcacc5fec77066241333d36 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 17:26:12 +0800
-Subject: [PATCH 05/10] fix(scripts): use ABI2 (New-World) Mihomo binary for
+Subject: [PATCH 05/11] fix(scripts): use ABI2 (New-World) Mihomo binary for
  loongarch64
 
 Currently, only the alpha Mihomo binary distinguishes between abi1 (old-world)
@@ -11,7 +11,7 @@ and abi2 (new-world) binaries.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/scripts/check.mjs b/scripts/check.mjs
-index d3dca2f..6ac2e77 100644
+index 99b9755..26fe85e 100644
 --- a/scripts/check.mjs
 +++ b/scripts/check.mjs
 @@ -68,7 +68,7 @@ const META_ALPHA_MAP = {

--- a/app-network/clash-verge-rev/autobuild/patches/0006-feat-drop-clash-meta-alpha-support.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0006-feat-drop-clash-meta-alpha-support.patch
@@ -1,14 +1,14 @@
-From e9bd6e352b0c92daeaa0e2090e14e595248f068f Mon Sep 17 00:00:00 2001
+From d8ee3c7db2e573a9b08967a3f05634112a88b932 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
-Subject: [PATCH 06/10] feat: drop clash-meta-alpha support
+Subject: [PATCH 06/11] feat: drop clash-meta-alpha support
 
 ---
  src/components/setting/mods/clash-core-viewer.tsx | 5 +----
  1 file changed, 1 insertion(+), 4 deletions(-)
 
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
-index 0b12147..8e957a6 100644
+index b5f4986..4a14242 100644
 --- a/src/components/setting/mods/clash-core-viewer.tsx
 +++ b/src/components/setting/mods/clash-core-viewer.tsx
 @@ -19,10 +19,7 @@ import { closeAllConnections, upgradeCore } from "@/services/api";

--- a/app-network/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
@@ -1,7 +1,7 @@
-From 8fa66ca0ab637f41be3acac442fbd31e30d7c4db Mon Sep 17 00:00:00 2001
+From 9f33a2a67f6711246bfce084f80a38bf3726a6ec Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 11:45:21 +0800
-Subject: [PATCH 07/10] fix(check.mjs): do not fetch Mihomo (Clash Meta)
+Subject: [PATCH 07/11] fix(check.mjs): do not fetch Mihomo (Clash Meta)
  binaries
 
 We use a system copy for this purpose.
@@ -10,7 +10,7 @@ We use a system copy for this purpose.
  1 file changed, 12 deletions(-)
 
 diff --git a/scripts/check.mjs b/scripts/check.mjs
-index 6ac2e77..4f4c8b7 100644
+index 26fe85e..94a83c8 100644
 --- a/scripts/check.mjs
 +++ b/scripts/check.mjs
 @@ -433,18 +433,6 @@ const resolveEnableLoopback = () =>

--- a/app-network/clash-verge-rev/autobuild/patches/0008-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0008-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
@@ -1,7 +1,7 @@
-From ba2cba77643be5746437c63edc54c023b7bf04f9 Mon Sep 17 00:00:00 2001
+From fe5f3bc42b3933bd6c3dea9d637d55908c78d134 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 12:04:58 +0800
-Subject: [PATCH 08/10] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
+Subject: [PATCH 08/11] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
  Meta) bundling
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 08/10] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
  1 file changed, 1 deletion(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 1af8107..1db6aa3 100644
+index 6938d36..d85820f 100644
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -22,7 +22,6 @@

--- a/app-network/clash-verge-rev/autobuild/patches/0009-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0009-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
@@ -1,7 +1,7 @@
-From fcdd5dd13f1c2a1ea172260cc782f71a1fbc50d0 Mon Sep 17 00:00:00 2001
+From 19cab8d44c9b79401a4cb40d56909bfc736d7027 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 13:07:37 +0800
-Subject: [PATCH 09/10] fix(check.mjs): do not check Mihomo (Clash Meta)
+Subject: [PATCH 09/11] fix(check.mjs): do not check Mihomo (Clash Meta)
  platform support
 
 This is pointless, as we supply our own.
@@ -10,7 +10,7 @@ This is pointless, as we supply our own.
  1 file changed, 15 deletions(-)
 
 diff --git a/scripts/check.mjs b/scripts/check.mjs
-index 4f4c8b7..3bb7590 100644
+index 94a83c8..3c1bb02 100644
 --- a/scripts/check.mjs
 +++ b/scripts/check.mjs
 @@ -145,21 +145,6 @@ async function getLatestReleaseVersion() {

--- a/app-network/clash-verge-rev/autobuild/patches/0010-Do-not-find-clash-meta-binary-in-current-dir.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0010-Do-not-find-clash-meta-binary-in-current-dir.patch
@@ -1,0 +1,26 @@
+From 8182893bc1bf2994030d4237056972e7f3702091 Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Wed, 29 May 2024 14:43:22 +0800
+Subject: [PATCH 10/11] Do not find `clash-meta` binary in current dir
+
+---
+ src-tauri/src/core/core.rs | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src-tauri/src/core/core.rs b/src-tauri/src/core/core.rs
+index 34fd06c..addff31 100644
+--- a/src-tauri/src/core/core.rs
++++ b/src-tauri/src/core/core.rs
+@@ -145,8 +145,7 @@ impl CoreManager {
+             "clash-meta-alpha" => vec!["-d", app_dir, "-f", config_path],
+             _ => vec!["-d", app_dir, "-f", config_path],
+         };
+-
+-        let cmd = Command::new_sidecar(clash_core)?;
++        let cmd = Command::new(clash_core);
+         let (mut rx, cmd_child) = cmd.args(args).spawn()?;
+ 
+         // 将pid写入文件中
+-- 
+2.45.1
+

--- a/app-network/clash-verge-rev/autobuild/patches/0011-Drop-check-update-feature.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0011-Drop-check-update-feature.patch
@@ -1,7 +1,7 @@
-From 4c1327cd8dff1d19bbde4727b8aaffc32a4fb253 Mon Sep 17 00:00:00 2001
+From 52da2c62590cf17fba1e63a6260ffe9b36ef30b8 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
-Date: Fri, 29 Mar 2024 11:31:50 +0800
-Subject: [PATCH 10/10] Drop check update feature
+Date: Wed, 29 May 2024 14:55:35 +0800
+Subject: [PATCH 11/11] Drop check update feature
 
 ---
  src/components/layout/update-button.tsx       |  47 --------
@@ -184,7 +184,7 @@ index ca66e16..0000000
 -  );
 -});
 diff --git a/src/components/setting/setting-verge.tsx b/src/components/setting/setting-verge.tsx
-index fa32c28..7d4d016 100644
+index 53c3014..bec23b7 100644
 --- a/src/components/setting/setting-verge.tsx
 +++ b/src/components/setting/setting-verge.tsx
 @@ -30,7 +30,6 @@ import { MiscViewer } from "./mods/misc-viewer";
@@ -203,7 +203,7 @@ index fa32c28..7d4d016 100644
 -    try {
 -      const info = await checkUpdate();
 -      if (!info?.shouldUpdate) {
--        Notice.success("No Updates Available");
+-        Notice.success(t("Currently on the Latest Version"));
 -      } else {
 -        updateRef.current?.open();
 -      }
@@ -242,10 +242,10 @@ index fa32c28..7d4d016 100644
          <IconButton
            color="inherit"
 diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
-index be11146..fa21946 100644
+index 196bc43..35b2f4f 100644
 --- a/src/pages/_layout.tsx
 +++ b/src/pages/_layout.tsx
-@@ -19,7 +19,6 @@ import { Notice } from "@/components/base";
+@@ -20,7 +20,6 @@ import { Notice } from "@/components/base";
  import { LayoutItem } from "@/components/layout/layout-item";
  import { LayoutControl } from "@/components/layout/layout-control";
  import { LayoutTraffic } from "@/components/layout/layout-traffic";
@@ -253,10 +253,10 @@ index be11146..fa21946 100644
  import { useCustomTheme } from "@/components/layout/use-custom-theme";
  import getSystem from "@/utils/get-system";
  import "dayjs/locale/ru";
-@@ -138,7 +137,6 @@ const Layout = () => {
-           <div className="layout__left">
-             <div className="the-logo" data-tauri-drag-region="true">
-               {!isDark ? <LogoSvg /> : <LogoSvg_dark />}
+@@ -158,7 +157,6 @@ const Layout = () => {
+                 />
+                 <LogoSvg fill={isDark ? "white" : "black"} />
+               </div>
 -              {<UpdateButton className="the-newbtn" />}
              </div>
  

--- a/app-network/clash-verge-rev/autobuild/patches/0012-Drop-upgrade-core-feature.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0012-Drop-upgrade-core-feature.patch
@@ -1,0 +1,94 @@
+From d964e765d55e37b13103bc5ad5ed42da827392d0 Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Wed, 29 May 2024 23:08:12 +0800
+Subject: [PATCH] Drop upgrade core feature
+
+---
+ .../setting/mods/clash-core-viewer.tsx        | 32 ++++---------------
+ src/services/api.ts                           |  6 ----
+ 2 files changed, 7 insertions(+), 31 deletions(-)
+
+diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
+index 4a14242..1dda97a 100644
+--- a/src/components/setting/mods/clash-core-viewer.tsx
++++ b/src/components/setting/mods/clash-core-viewer.tsx
+@@ -15,7 +15,7 @@ import {
+   ListItemText,
+ } from "@mui/material";
+ import { changeClashCore, restartSidecar } from "@/services/cmds";
+-import { closeAllConnections, upgradeCore } from "@/services/api";
++import { closeAllConnections } from "@/services/api";
+ import { grantPermission } from "@/services/cmds";
+ import getSystem from "@/utils/get-system";
+ 
+@@ -60,7 +60,12 @@ export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
+       await grantPermission(core);
+       // 自动重启
+       if (core === clash_core) await restartSidecar();
+-      Notice.success(t("Permissions Granted Successfully for _clash Core", { core: `${core}` }), 1000);
++      Notice.success(
++        t("Permissions Granted Successfully for _clash Core", {
++          core: `${core}`,
++        }),
++        1000
++      );
+     } catch (err: any) {
+       Notice.error(err?.message || err.toString());
+     }
+@@ -75,18 +80,6 @@ export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
+     }
+   });
+ 
+-  const onUpgrade = useLockFn(async () => {
+-    try {
+-      setUpgrading(true);
+-      await upgradeCore();
+-      setUpgrading(false);
+-      Notice.success(t(`Core Version Updated`), 1000);
+-    } catch (err: any) {
+-      setUpgrading(false);
+-      Notice.error(err?.response.data.message || err.toString());
+-    }
+-  });
+-
+   return (
+     <BaseDialog
+       open={open}
+@@ -94,17 +87,6 @@ export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
+         <Box display="flex" justifyContent="space-between">
+           {t("Clash Core")}
+           <Box>
+-            <LoadingButton
+-              variant="contained"
+-              size="small"
+-              startIcon={<SwitchAccessShortcut />}
+-              loadingPosition="start"
+-              loading={upgrading}
+-              sx={{ marginRight: "8px" }}
+-              onClick={onUpgrade}
+-            >
+-              {t("Upgrade")}
+-            </LoadingButton>
+             <Button
+               variant="contained"
+               size="small"
+diff --git a/src/services/api.ts b/src/services/api.ts
+index bded6e3..994f95f 100644
+--- a/src/services/api.ts
++++ b/src/services/api.ts
+@@ -61,12 +61,6 @@ export const updateGeoData = async () => {
+   return instance.post("/configs/geo");
+ };
+ 
+-/// Upgrade clash core
+-export const upgradeCore = async () => {
+-  const instance = await getAxios();
+-  return instance.post("/upgrade");
+-};
+-
+ /// Get current rules
+ export const getRules = async () => {
+   const instance = await getAxios();
+-- 
+2.45.1
+

--- a/app-network/clash-verge-rev/spec
+++ b/app-network/clash-verge-rev/spec
@@ -1,4 +1,4 @@
-VER=1.6.2
+VER=1.6.4
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: update to 1.6.4
    - Rebase all patch

Package(s) Affected
-------------------

- clash-verge-rev: 1.6.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
