### PR TITLE
wireguard-tools: update to 1.0.20210914

### DIFF
--- a/app-network/wireguard-tools/spec
+++ b/app-network/wireguard-tools/spec
@@ -1,4 +1,4 @@
-VER=1.0.20200827
+VER=1.0.20210914
 SRCS="tbl::https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${VER}.tar.xz"
-CHKSUMS="sha256::51bc85e33a5b3cf353786ae64b0f1216d7a871447f058b6137f793eb0f53b7fd"
+CHKSUMS="sha256::97ff31489217bb265b7ae850d3d0f335ab07d2652ba1feec88b734bc96bd05ac"
 CHKUPDATE="anitya::id=62381"


### PR DESCRIPTION
Topic Description
-----------------

- wireguard-tools: update to 1.0.20210914

Package(s) Affected
-------------------

- wireguard-tools: 1.0.20210914

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireguard-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
