### PR TITLE
configshell-fb: update to 1.1.30

### DIFF
--- a/lang-python/configshell-fb/spec
+++ b/lang-python/configshell-fb/spec
@@ -1,5 +1,4 @@
-VER=1.1.28
+VER=1.1.30
 SRCS="tbl::https://github.com/open-iscsi/configshell-fb/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::435822d4cee6d66cd7dc0d34725962bcf0168840556bbb9cc01335a78a3ec79d"
+CHKSUMS="sha256::44696b92bea2b44c1d0bf2828477dddeb3b4dfb312ad82ce06d7b704c0985e27"
 CHKUPDATE="anitya::id=38968"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- configshell-fb: update to 1.1.30
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- configshell-fb: 1.1.30

Security Update?
----------------

No

Build Order
-----------

```
#buildit configshell-fb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
