### PR TITLE
kvantum: update to 1.1.1

### DIFF
--- a/desktop-kde/kvantum/spec
+++ b/desktop-kde/kvantum/spec
@@ -1,5 +1,5 @@
-VER=1.0.10
+VER=1.1.1
 SRCS="tbl::https://github.com/tsujan/Kvantum/archive/V$VER.tar.gz"
-CHKSUMS="sha256::2ef368df6c54a3bde2097ed89341f188b6670d1b1f8d11bcb3a80138887aca12"
+CHKSUMS="sha256::975784b08b62cdce3044b7fc455c349b5bee3cc6a1c413783c3e4bd39086ed3a"
 CHKUPDATE="anitya::id=17749"
 SUBDIR="Kvantum-$VER/Kvantum"


### PR DESCRIPTION
Topic Description
-----------------

- kvantum: update to 1.1.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- kvantum: 1.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit kvantum
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
