### PR TITLE
libxdg-basedir: update to 1.2.3

### DIFF
--- a/runtime-desktop/libxdg-basedir/spec
+++ b/runtime-desktop/libxdg-basedir/spec
@@ -1,5 +1,4 @@
-VER=1.2.0
-REL=3
+VER=1.2.3
 SRCS="tbl::https://github.com/devnev/libxdg-basedir/archive/libxdg-basedir-$VER.tar.gz"
-CHKSUMS="sha256::1c2b0032a539033313b5be2e48ddd0ae94c84faf21d93956d53562eef4614868"
+CHKSUMS="sha256::ff30c60161f7043df4dcc6e7cdea8e064e382aa06c73dcc3d1885c7d2c77451d"
 CHKUPDATE="anitya::id=230210"


### PR DESCRIPTION
Topic Description
-----------------

- libxdg-basedir: update to 1.2.3
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libxdg-basedir: 1.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxdg-basedir
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
