### PR TITLE
libisofs: update to 1.5.6.pl01

### DIFF
--- a/runtime-common/libisofs/spec
+++ b/runtime-common/libisofs/spec
@@ -1,5 +1,4 @@
-VER=1.5.2
-REL=1
+VER=1.5.6.pl01
 SRCS="tbl::http://files.libburnia-project.org/releases/libisofs-$VER.tar.gz"
-CHKSUMS="sha256::ef5a139600b3e688357450e52381e40ec26a447d35eb8d21524598c7b1675500"
+CHKSUMS="sha256::ac1fd338d641744ca1fb1567917188b79bc8c2506832dd56885fec98656b9f25"
 CHKUPDATE="anitya::id=1646"


### PR DESCRIPTION
Topic Description
-----------------

- libisofs: update to 1.5.6.pl01
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libisofs: 1.5.6.pl01

Security Update?
----------------

No

Build Order
-----------

```
#buildit libisofs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
