### PR TITLE
py-filelock: update to 3.14.0

### DIFF
--- a/lang-python/hatch-vcs/spec
+++ b/lang-python/hatch-vcs/spec
@@ -1,5 +1,4 @@
-VER=0.3.0
-REL=1
+VER=0.4.0
 SRCS="tbl::https://github.com/ofek/hatch-vcs/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::f9d04225bcab0344b11f8daa5f14cb6b4ca591428a3a9166f876a7311ed165e5"
+CHKSUMS="sha256::08d52088c3cc97a719e2530f42a05829cf442c63ea735e63e4d152e75966c4f1"
 CHKUPDATE="anitya::id=301800"

--- a/lang-python/py-filelock/autobuild/defines
+++ b/lang-python/py-filelock/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=py-filelock
 PKGSEC=python
 PKGDES="A platform-independent file lock implemention for Python"
-PKGDEP="python-3 python-2"
-BUILDDEP="setuptools"
+PKGDEP="python-3"
+BUILDDEP="python-build hatchling hatch-vcs python-installer"
 
 ABHOST=noarch
-ABTYPE=python
+ABTYPE=pep517

--- a/lang-python/py-filelock/spec
+++ b/lang-python/py-filelock/spec
@@ -1,5 +1,4 @@
-VER=3.0.12
-REL=2
+VER=3.14.0
 SRCS="https://pypi.io/packages/source/f/filelock/filelock-${VER}.tar.gz"
-CHKSUMS="sha256::18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"
+CHKSUMS="sha256::6ea72da3be9b8c82afd3edcf99f2fffbb5076335a5ae4d03248bb5b6c3eae78a"
 CHKUPDATE="anitya::id=11739"


### PR DESCRIPTION
Topic Description
-----------------

- py-filelock: update to 3.14.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- py-filelock: 3.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit hatch-vcs py-filelock
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
