### PR TITLE
menulibre: update to 2.4.0

### DIFF
--- a/app-utils/menulibre/autobuild/beyond
+++ b/app-utils/menulibre/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing unwanted uninstaller ..."
+rm -v "$PKGDIR"/usr/lib/python*/site-packages/uninstall.py

--- a/app-utils/menulibre/spec
+++ b/app-utils/menulibre/spec
@@ -1,5 +1,4 @@
-VER=2.2.1
+VER=2.4.0
 SRCS="tbl::https://github.com/bluesabre/menulibre/releases/download/menulibre-$VER/menulibre-$VER.tar.gz"
-CHKSUMS="sha256::5b3ef8e6073d584f6accf282fa1eb649185ee42eb22fab70231491c7377d7e8f"
+CHKSUMS="sha256::d906acf9cc13b0e15b8e342ae9aab8b0680db336a382d0c42f5d5f465f593c9f"
 CHKUPDATE="anitya::id=7951"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- menulibre: update to 2.4.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- menulibre: 2.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit menulibre
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
