### PR TITLE
gtk-doc: update to 1.34.0

### DIFF
--- a/app-doc/gtk-doc/spec
+++ b/app-doc/gtk-doc/spec
@@ -1,5 +1,4 @@
-VER=1.33.2
-REL=3
+VER=1.34.0
 SRCS="https://download.gnome.org/sources/gtk-doc/${VER:0:4}/gtk-doc-$VER.tar.xz"
-CHKSUMS="sha256::cc1b709a20eb030a278a1f9842a362e00402b7f834ae1df4c1998a723152bf43"
+CHKSUMS="sha256::b20b72b32a80bc18c7f975c9d4c16460c2276566a0b50f87d6852dff3aa7861c"
 CHKUPDATE="anitya::id=13140"


### PR DESCRIPTION
Topic Description
-----------------

- gtk-doc: update to 1.34.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gtk-doc: 1.34.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtk-doc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
