### PR TITLE
zram-generator: update to 1.1.2

### DIFF
--- a/app-admin/zram-generator/spec
+++ b/app-admin/zram-generator/spec
@@ -1,4 +1,4 @@
-VER=1.1.1
+VER=1.1.2
 SRCS="tbl::https://github.com/systemd/zram-generator/archive/v$VER.tar.gz"
-CHKSUMS="sha256::7e411fe5ef4b4f0ba80c30eaaa1c3a0f01a50a95975354c170cc49ff7dbd2463"
+CHKSUMS="sha256::506d47acbabffa7013bb40a1f61c6edfa758a7bd55820d06ef49c7bc83dba762"
 CHKUPDATE="anitya::id=18509"

--- a/lang-ruby/ronn-ng/autobuild/defines
+++ b/lang-ruby/ronn-ng/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=ronn-ng
 PKGSEC=ruby
 PKGDES="An updated fork of ronn, build man pages from Markdown"
-PKGDEP="ruby mustache kramdown nokogiri"
+PKGDEP="ruby mustache kramdown nokogiri kramdown-parser-gfm"
 
 PKGCONFL="ronn"
 PKGREP="ronn"

--- a/lang-ruby/ronn-ng/spec
+++ b/lang-ruby/ronn-ng/spec
@@ -1,4 +1,5 @@
 VER=0.10.1
+REL=1
 SRCS="tbl::https://github.com/apjanke/ronn-ng/archive/v$VER.tar.gz"
 CHKSUMS="sha256::180f18015ce01be1d10c24e13414134363d56f9efb741fda460358bb67d96684"
 CHKUPDATE="anitya::id=90983"


### PR DESCRIPTION
Topic Description
-----------------

- zram-generator: update to 1.1.2
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- zram-generator: 1.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ronn-ng zram-generator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
