### PR TITLE
xz: update to 5.6.2

### DIFF
--- a/app-utils/xz/spec
+++ b/app-utils/xz/spec
@@ -1,4 +1,4 @@
-VER=5.4.1
+VER=5.6.2
 SRCS="tbl::https://tukaani.org/xz/xz-$VER.tar.xz"
-CHKSUMS="sha256::5d9827aa1875b21c288f78864bb26d2650b436ea8d2cad364e4921eb6266a5a5"
+CHKSUMS="sha256::a9db3bb3d64e248a0fae963f8fb6ba851a26ba1822e504dc0efd18a80c626caf"
 CHKUPDATE="anitya::id=5277"


### PR DESCRIPTION
Topic Description
-----------------

- xz: update to 5.6.2
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- xz: 5.6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit xz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
