### PR TITLE
systemd: Allow display managers to start on Hyper-V framebuffer device

### DIFF
--- a/app-admin/systemd/autobuild/patches/0001-hwdb-add-resolution-override-for-Pinebook-Pro-touchp.patch
+++ b/app-admin/systemd/autobuild/patches/0001-hwdb-add-resolution-override-for-Pinebook-Pro-touchp.patch
@@ -1,7 +1,7 @@
 From a9261e758696d3c69ef7d7d89feaf9c24bc05fcc Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Tue, 13 Feb 2024 19:58:35 -0800
-Subject: [PATCH 1/2] hwdb: add resolution override for Pinebook Pro touchpad
+Subject: [PATCH 1/3] hwdb: add resolution override for Pinebook Pro touchpad
 
 The Pinebook Pro touchpad returns a resolution data that is 2 times of
 the real value, which makes libinput think the touchpad is only 1/4 the

--- a/app-admin/systemd/autobuild/patches/0002-sleep.conf-AllowHibernation-no-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0002-sleep.conf-AllowHibernation-no-by-default.patch
@@ -1,7 +1,7 @@
 From abc758fbac474598c10a393338c27362f94aedea Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Tue, 11 Apr 2023 18:04:25 -0700
-Subject: [PATCH 2/2] sleep.conf: AllowHibernation=no by default
+Subject: [PATCH 2/3] sleep.conf: AllowHibernation=no by default
 
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---

--- a/app-admin/systemd/autobuild/patches/0003-hwdb-add-a-vmbus-id-for-HyperV-Video-device.patch
+++ b/app-admin/systemd/autobuild/patches/0003-hwdb-add-a-vmbus-id-for-HyperV-Video-device.patch
@@ -1,0 +1,44 @@
+From ab151758ce0258ab53aad2588076091f6da6a204 Mon Sep 17 00:00:00 2001
+From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
+Date: Thu, 30 May 2024 13:51:40 +0800
+Subject: [PATCH 3/3] hwdb: add a vmbus id for HyperV Video device
+
+---
+ hwdb.d/60-seat.hwdb  | 7 +++++++
+ hwdb.d/parse_hwdb.py | 2 +-
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/hwdb.d/60-seat.hwdb b/hwdb.d/60-seat.hwdb
+index fcb8f53cd1..927ea025a2 100644
+--- a/hwdb.d/60-seat.hwdb
++++ b/hwdb.d/60-seat.hwdb
+@@ -28,6 +28,13 @@ fb:pci:v000018CAd00000020*
+ fb:pci:v00001414d00005353*
+  ID_TAG_MASTER_OF_SEAT=1
+ 
++# In some HyperV VMs, the video device only can be recognized by a vmbus id.
++# So we should add a vmbus id for HyperV Video device.
++#
++# This id is extracted from Linux kernel's hyperv.h
++fb:vmbus:02780ada77e3ac4a8e770558eb1073f8
++ ID_TAG_MASTER_OF_SEAT=1
++
+ #########################################
+ # Parallels
+ #########################################
+diff --git a/hwdb.d/parse_hwdb.py b/hwdb.d/parse_hwdb.py
+index 30d5f8a569..88b013aaaf 100755
+--- a/hwdb.d/parse_hwdb.py
++++ b/hwdb.d/parse_hwdb.py
+@@ -74,7 +74,7 @@ UDEV_TAG = Word(string.ascii_uppercase, alphanums + '_')
+ # Those patterns are used in type-specific matches
+ TYPES = {'mouse':    ('usb', 'bluetooth', 'ps2', '*'),
+          'evdev':    ('name', 'atkbd', 'input'),
+-         'fb':       ('pci'),
++         'fb':       ('pci','vmbus'),
+          'id-input': ('modalias'),
+          'touchpad': ('i8042', 'rmi', 'bluetooth', 'usb'),
+          'joystick': ('i8042', 'rmi', 'bluetooth', 'usb'),
+-- 
+2.45.1
+

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,4 +1,5 @@
 VER=255.6
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd-stable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205088"


### PR DESCRIPTION
Topic Description
-----------------

- systemd: allow DMs to start on Hyper-V framebuffer devices
    Co-Authored-By: Lain <fsf@live.com>

Package(s) Affected
-------------------

- systemd: 1:255.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
