### PR TITLE
systemd-boot-friend: update to 0.27.1

### DIFF
--- a/app-admin/systemd-boot-friend/spec
+++ b/app-admin/systemd-boot-friend/spec
@@ -1,4 +1,4 @@
-VER=0.26.3
+VER=0.27.1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/systemd-boot-friend-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226819"


### PR DESCRIPTION
Topic Description
-----------------

- systemd-boot-friend: update to 0.27.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- systemd-boot-friend: 0.27.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd-boot-friend
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
