### PR TITLE
sbcl: update to 2.4.5

### DIFF
--- a/lang-lisp/sbcl/spec
+++ b/lang-lisp/sbcl/spec
@@ -1,4 +1,4 @@
-VER=2.4.3
+VER=2.4.5
 SRCS="tbl::https://downloads.sourceforge.net/project/sbcl/sbcl/$VER/sbcl-$VER-source.tar.bz2"
-CHKSUMS="sha256::89c9aadf92b82ad3c74a3d4f158a038893dea0e4f394dcafc963583c30b7c3f2"
+CHKSUMS="sha256::4df68e90c9031807642b4b761988deb5bf6a1bd152c4723482834efa735a7bd1"
 CHKUPDATE="anitya::id=16339"


### PR DESCRIPTION
Topic Description
-----------------

- sbcl: update to 2.4.5
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- sbcl: 2.4.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit sbcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
