### PR TITLE
nodejs: update to 20.14.0

### DIFF
--- a/lang-js/nodejs/spec
+++ b/lang-js/nodejs/spec
@@ -1,4 +1,4 @@
-VER=20.13.0
+VER=20.14.0
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.gz"
-CHKSUMS="sha256::733ab5d27a805056b674f12ae5493ad3a40e39c97f4d27407a85003a8b7a570e"
+CHKSUMS="sha256::f01109d3102754ac360fcf25aa588f3bef5c090a8eed3fb1d0be194149c46cf2"
 CHKUPDATE="anitya::id=12594"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs: update to 20.14.0

Package(s) Affected
-------------------

- nodejs: 2:20.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
