### PR TITLE
7-zip: update to 24.06

### DIFF
--- a/app-utils/7-zip/spec
+++ b/app-utils/7-zip/spec
@@ -1,4 +1,4 @@
-VER=24.05
+VER=24.06
 SRCS="git::commit=tags/$VER::https://github.com/ip7z/7zip"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17875"


### PR DESCRIPTION
Topic Description
-----------------

- 7-zip: update to 24.06
    Co-authored-by: Anjia Wang (@ouankou) <anjia@ouankou.com>

Package(s) Affected
-------------------

- 7-zip: 24.06

Security Update?
----------------

No

Build Order
-----------

```
#buildit 7-zip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
