### PR TITLE
v4l2loopback 0.13.2

### DIFF
--- a/app-utils/v4l2loopback/autobuild/build
+++ b/app-utils/v4l2loopback/autobuild/build
@@ -1,9 +1,18 @@
-pushd ${SRCDIR}
+for i in postinst prerm; do
+	abinfo "Generating $i"
+	cat "${SRCDIR}/autobuild/$i.in" | sed -e "s/@PKGVER@/${PKGVER}/g" > "${SRCDIR}/autobuild/$i"
+done
 
-install -d ${PKGDIR}/usr/src/v4l2loopback-${PKGVER}
-install -Dm644 v4l2loopback.c v4l2loopback_formats.h dkms.conf Makefile \
-        -t "${PKGDIR}/usr/src/v4l2loopback-${PKGVER}"
+abinfo "Installing dkms sources"
+install -vd "${PKGDIR}/usr/src/v4l2loopback-${PKGVER}"
+(cd "${SRCDIR}"; for i in *.c *.h dkms.conf Makefile Kbuild; do
+	install -Dvm644 "${SRCDIR}/$i" -t "${PKGDIR}/usr/src/v4l2loopback-${PKGVER}"
+done)
 
-make DESTDIR="${PKGDIR}" PREFIX="/usr" install-utils install-man
+abinfo "Installing tools and documentation"
+make -C "${SRCDIR}" DESTDIR="${PKGDIR}" PREFIX="/usr" install-utils install-man
 
-popd
+abinfo "Installing udev rules"
+for i in "${SRCDIR}"/udev/*; do
+	install -Dvm644 "$i" -t "${PKGDIR}/usr/lib/udev/rules.d"
+done

--- a/app-utils/v4l2loopback/autobuild/postinst.in
+++ b/app-utils/v4l2loopback/autobuild/postinst.in
@@ -1,6 +1,6 @@
 unset ARCH
 
-DRIVER_VER=0.12.5
+DRIVER_VER=@PKGVER@
 NAME=v4l2loopback
 
 for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
@@ -11,3 +11,5 @@ for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
         echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $i ..."
     fi
 done
+
+dpkg-trigger --no-await initrd-update

--- a/app-utils/v4l2loopback/autobuild/prerm.in
+++ b/app-utils/v4l2loopback/autobuild/prerm.in
@@ -1,5 +1,7 @@
 unset ARCH
 
-DRIVER_VER=0.12.5
+DRIVER_VER=@PKGVER@
 
 dkms remove v4l2loopback/${DRIVER_VER} --all || true > /dev/null
+
+dpkg-trigger --no-await initrd-update

--- a/app-utils/v4l2loopback/spec
+++ b/app-utils/v4l2loopback/spec
@@ -1,5 +1,5 @@
-VER=0.12.5
+VER=0.13.2
 SRCS="tbl::https://github.com/umlaeute/v4l2loopback/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::e152cd6df6a8add172fb74aca3a9188264823efa5a2317fe960d45880b9406ae"
+CHKSUMS="sha256::1e57e1e382d7451aa2a88d63cc9f146eab1f425b90e76104d4c3d73127e34771"
 
 CHKUPDATE="anitya::id=10956"


### PR DESCRIPTION
Topic Description
-----------------

- v4l2loopback: update to 0.13.2
    - Rework postinst / prerm, fill template vars at build
    - Install udev rules
    - Kick initrd regen after postinst / prerm

Package(s) Affected
-------------------

- v4l2loopback: 0.13.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit v4l2loopback
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
