### PR TITLE
abseil-cpp: update to 20240116.2 (rework)

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,5 +1,5 @@
 VER=5.0.1
-REL=2
+REL=3
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=afd9d5d31798d3eacf9ed6c30601e91d0f1e4d60
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: bump REL due to re2 update to 20240501

Package(s) Affected
-------------------

- telegram-desktop: 5.0.1-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
