### PR TITLE
netavark: update to 1.11.0

### DIFF
--- a/runtime-containers/netavark/spec
+++ b/runtime-containers/netavark/spec
@@ -1,4 +1,4 @@
-VER=1.10.3
+VER=1.11.0
 SRCS="https://github.com/containers/netavark/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::fdc3010cb221f0fcef0302f57ef6f4d9168a61f9606238a3e1ed4d2e348257b7"
+CHKSUMS="sha256::5b96e5a00a41a550d716f1e5c180df6e0ee5b0ce20961827ef17aff3d6a92f9c"
 CHKUPDATE="anitya::id=242639"


### PR DESCRIPTION
Topic Description
-----------------

- netavark: update to 1.11.0
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- netavark: 1.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit netavark
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
