### PR TITLE
Containers Survey (June, 2024)

### DIFF
--- a/app-containers/containerd/spec
+++ b/app-containers/containerd/spec
@@ -1,5 +1,4 @@
-VER=1.7.13
-REL=2
+VER=1.7.17
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/containerd/containerd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16460"

--- a/app-containers/docker-compose/spec
+++ b/app-containers/docker-compose/spec
@@ -1,5 +1,4 @@
-VER=2.24.6
-REL=2
+VER=2.27.1
 SRCS="git::commit=tags/v$VER::https://github.com/docker/compose"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6185"

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -1,9 +1,8 @@
 # Find tini version at:
-REL=2
 #
 # https://github.com/moby/moby/blob/v$PKGVER/hack/dockerfile/install/tini.installer
 TINI_VER=0.19.0
-DOCKER_VER=25.0.3
+DOCKER_VER=26.1.3
 
 VER=${DOCKER_VER}+tini${TINI_VER}
 SRCS="git::commit=tags/v${DOCKER_VER};rename=cli::https://github.com/docker/cli \

--- a/app-containers/podman/autobuild/build
+++ b/app-containers/podman/autobuild/build
@@ -14,23 +14,23 @@ abinfo "Making the source directory as the module directory ..."
 mkdir -v _build
 pushd _build
 mkdir -p src/github.com/containers/podman
-ln -sv ../../../../.. src/github.com/containers/podman/v4
+ln -sv ../../../../.. src/github.com/containers/podman/v5
 popd
 
 abinfo "Stage 1: Building podman rootlessport ..."
-go_build -o bin/rootlessport github.com/containers/podman/v4/cmd/rootlessport/
+go_build -o bin/rootlessport github.com/containers/podman/v5/cmd/rootlessport/
 
 abinfo "Stage 1.5: Building podman self ..."
 export BUILDTAGS="${BASE_BUILDTAGS} $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh) $(hack/libdm_tag.sh)"
-go_build -o bin/podman github.com/containers/podman/v4/cmd/podman
+go_build -o bin/podman github.com/containers/podman/v5/cmd/podman
 
 abinfo "Stage 2: Building podman remote ..."
 export BUILDTAGS="${BASE_BUILDTAGS} exclude_graphdriver_btrfs btrfs_noversion remote"
-go_build -o bin/podman-remote github.com/containers/podman/v4/cmd/podman
+go_build -o bin/podman-remote github.com/containers/podman/v5/cmd/podman
 
 abinfo "Stage 3: Building quadlet ..."
 export BUILDTAGS="${BASE_BUILDTAGS} $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh)"
-go_build -o bin/quadlet github.com/containers/podman/v4/cmd/quadlet
+go_build -o bin/quadlet github.com/containers/podman/v5/cmd/quadlet
 
 abinfo "Stage 4: Building gvproxy plugin ..."
 pushd "$SRCDIR/../gvisor-tap-vsock"

--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,13 +1,12 @@
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile
-PODMAN_VER=4.9.3
-GVISOR_TAP_VSOCK_VER=0.7.2
+PODMAN_VER=5.1.0
+GVISOR_TAP_VSOCK_VER=0.7.3
 VER=${PODMAN_VER}+vsock${GVISOR_TAP_VSOCK_VER}
-REL=3
 SRCS="tbl::https://github.com/containers/podman/archive/v${PODMAN_VER}.tar.gz \
       git::commit=tags/v${GVISOR_TAP_VSOCK_VER};rename=gvisor-tap-vsock::https://github.com/containers/gvisor-tap-vsock"
-CHKSUMS="sha256::37afc5bba2738c68dc24400893b99226c658cc9a2b22309f4d7abe7225d8c437 \
+CHKSUMS="sha256::e0687779c82b58422d458dc3776ffa7f79e1a04614a3f1a7ef93f7769bf8a8e6 \
          SKIP"
 CHKUPDATE="anitya::id=93284"
 SUBDIR="podman-$PODMAN_VER"

--- a/runtime-containers/containers-common/spec
+++ b/runtime-containers/containers-common/spec
@@ -2,12 +2,12 @@
 #
 # https://github.com/containers/common/blob/v$PKGVER/go.sum
 
-__IMAGE_VER=5.29.0
+__IMAGE_VER=5.31.0
 __SHORTNAMES_VER=2023.02.20
-__STORAGE_VER=1.51.0
-__SKOPEO_VER=1.14.0
+__STORAGE_VER=1.54.0
+__SKOPEO_VER=1.15.1
 
-VER=0.57.0+image${__IMAGE_VER}+shortnames${__SHORTNAMES_VER}+skopeo${__SKOPEO_VER}+storage${__STORAGE_VER}
+VER=0.59.0+image${__IMAGE_VER}+shortnames${__SHORTNAMES_VER}+skopeo${__SKOPEO_VER}+storage${__STORAGE_VER}
 
 __ORG_URL="https://github.com/containers"
 SRCS="git::commit=tags/v${VER%%+*};rename=common::${__ORG_URL}/common \

--- a/runtime-containers/netavark/spec
+++ b/runtime-containers/netavark/spec
@@ -1,4 +1,4 @@
-VER=1.10.3
+VER=1.11.0
 SRCS="https://github.com/containers/netavark/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::fdc3010cb221f0fcef0302f57ef6f4d9168a61f9606238a3e1ed4d2e348257b7"
+CHKSUMS="sha256::5b96e5a00a41a550d716f1e5c180df6e0ee5b0ce20961827ef17aff3d6a92f9c"
 CHKUPDATE="anitya::id=242639"


### PR DESCRIPTION
Topic Description
-----------------

- docker-compose: update to 2.27.1
- docker: update to 26.1.3+tini0.19.0
- containerd: update to 1.7.17
- podman: update to 5.1.0+vsock0.7.3
- containers-common: update to 0.59.0+image5.31.0+shortnames2023.02.20+skopeo1.15.1+storage1.54.0
- netavark: update to 1.11.0
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- containerd: 1.7.17
- containers-common: 0.59.0+image5.31.0+shortnames2023.02.20+skopeo1.15.1+storage1.54.0
- docker: 26.1.3+tini0.19.0
- docker-compose: 2.27.1
- netavark: 1.11.0
- podman: 5.1.0+vsock0.7.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit containers-common netavark podman containerd docker docker-compose
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
