### PR TITLE
mihomo: add gvisor feature

### DIFF
--- a/app-network/mihomo/autobuild/build
+++ b/app-network/mihomo/autobuild/build
@@ -1,15 +1,10 @@
-# FIXME: Go PIE not supported on loongarch64 and loongson3.
-if ! ab_match_arch loongarch64 && \
-   ! ab_match_arch loongson3; then
-    abinfo "Enabling buildmode=pie ..."
-    export GOFLAGS="${GOFLAGS} -buildmode=pie"
-fi
-
 abinfo "Building clash..."
-go build \
+
+GO_LDFLAGS=("-X github.com/metacubex/mihomo/constant.Version=$PKGVER")
+
+ab_go_build \
     -trimpath \
-    -ldflags \
-    "-X github.com/metacubex/mihomo/constant.Version=$PKGVER" \
+    -tags "with_gvisor" \
     -mod=readonly
 
 abinfo "Installing the binary..."

--- a/app-network/mihomo/spec
+++ b/app-network/mihomo/spec
@@ -1,5 +1,5 @@
 VER=1.18.5
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/MetaCubeX/mihomo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371845"


### PR DESCRIPTION
Topic Description
-----------------

- mihomo: add `gvisor` feature
    - use autobuild4 `ab_go_build` function

Package(s) Affected
-------------------

- mihomo: 1.18.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mihomo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
