### PR TITLE
dhcpcd: update to 10.0.8

### DIFF
--- a/app-network/dhcpcd/spec
+++ b/app-network/dhcpcd/spec
@@ -1,5 +1,4 @@
-VER=9.2.0
-REL=2
+VER=10.0.8
 SRCS="git::commit=tags/v$VER::https://github.com/NetworkConfiguration/dhcpcd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11429"


### PR DESCRIPTION
Topic Description
-----------------

- dhcpcd: update to 10.0.8

Package(s) Affected
-------------------

- dhcpcd: 10.0.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit dhcpcd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
