### PR TITLE
docker: update to 26.1.3+tini0.19.0

### DIFF
--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -1,9 +1,5 @@
-# Find tini version at:
-REL=2
-#
-# https://github.com/moby/moby/blob/v$PKGVER/hack/dockerfile/install/tini.installer
 TINI_VER=0.19.0
-DOCKER_VER=25.0.3
+DOCKER_VER=26.1.3
 
 VER=${DOCKER_VER}+tini${TINI_VER}
 SRCS="git::commit=tags/v${DOCKER_VER};rename=cli::https://github.com/docker/cli \


### PR DESCRIPTION
Topic Description
-----------------

- docker: update to 26.1.3+tini0.19.0

Package(s) Affected
-------------------

- docker: 26.1.3+tini0.19.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit docker
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
