### PR TITLE
rathole: new, 0.5.0

### DIFF
--- a/app-network/rathole/autobuild/defines
+++ b/app-network/rathole/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=rathole
+PKGSEC=net
+PKGDEP="glibc"
+BUILDDEP="rustc cargo"
+PKGDES="A reverse proxy for NAT traversal, written in Rust."
+
+USECLANG=0
+NOLTO=1

--- a/app-network/rathole/spec
+++ b/app-network/rathole/spec
@@ -1,0 +1,4 @@
+VER=0.5.0
+SRCS="git::commit=tags/v$VER::https://github.com/rapiz1/rathole"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=rapiz1/rathole"


### PR DESCRIPTION
Topic Description
-----------------

- rathole: new, 0.5.0

Package(s) Affected
-------------------

- rathole: 0.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rathole
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
