### PR TITLE
ipython: update to 8.25.0

### DIFF
--- a/lang-python/ipython/spec
+++ b/lang-python/ipython/spec
@@ -1,4 +1,4 @@
-VER=7.28.0
+VER=8.25.0
 SRCS="tbl::https://pypi.io/packages/source/i/ipython/ipython-$VER.tar.gz"
-CHKSUMS="sha256::2097be5c814d1b974aea57673176a924c4c8c9583890e7a5f082f547b9975b11"
+CHKSUMS="sha256::c6ed726a140b6e725b911528f80439c534fac915246af3efc39440a6b0f9d716"
 CHKUPDATE="anitya::id=1399"


### PR DESCRIPTION
Topic Description
-----------------

- ipython: update to 8.25.0

Package(s) Affected
-------------------

- ipython: 8.25.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ipython
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
