### PR TITLE
hashcat: fix CHKUPDATE

### DIFF
--- a/app-penetration/hashcat/spec
+++ b/app-penetration/hashcat/spec
@@ -1,4 +1,4 @@
 VER=6.2.6
 SRCS="tbl::https://fossies.org/linux/privat/hashcat-$VER.tar.gz"
 CHKSUMS="sha256::b25e1077bcf34908cc8f18c1a69a2ec98b047b2cbcf0f51144dcf3ba1e0b7b2a"
-CHKUPDATE="anitya::id=63046"
+CHKUPDATE="anitya::id=14448"


### PR DESCRIPTION
Topic Description
-----------------

- hashcat: fix CHKUPDATE

Package(s) Affected
-------------------

- hashcat: 6.2.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit hashcat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
