### PR TITLE
level-zero: update to 1.17.6

### DIFF
--- a/runtime-common/level-zero/spec
+++ b/runtime-common/level-zero/spec
@@ -1,4 +1,4 @@
-VER=1.17.0
+VER=1.17.6
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/oneapi-src/level-zero"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229539"


### PR DESCRIPTION
Topic Description
-----------------

- level-zero: update to 1.17.6
    Co-authored-by: Anjia Wang (@ouankou) <anjia@ouankou.com>

Package(s) Affected
-------------------

- level-zero: 1.17.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit level-zero
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
