### PR TITLE
openh264: update to 2.4.0+gmp2.4.1

### DIFF
--- a/app-multimedia/openh264/spec
+++ b/app-multimedia/openh264/spec
@@ -1,4 +1,4 @@
-GMPVER=114_2
+GMPVER=2.4.1
 VER=2.4.0+gmp${GMPVER/_/+}
 SRCS="git::commit=tags/v${VER%%+*}::https://github.com/cisco/openh264 \
       git::commit=tags/Firefox${GMPVER};rename=gmp-api::https://github.com/mozilla/gmp-api"


### PR DESCRIPTION
Topic Description
-----------------

- openh264: update to 2.4.0+gmp2.4.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- openh264: 2.4.0+gmp2.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openh264
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
