### PR TITLE
usbutils: update to 017

### DIFF
--- a/app-utils/usbutils/spec
+++ b/app-utils/usbutils/spec
@@ -1,4 +1,4 @@
-VER=015
+VER=017
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/usb/usbutils/usbutils-$VER.tar.xz"
-CHKSUMS="sha256::c3b451bb1f4ff9f6356cac5a6956a9ac8e85d81651af56a29e689f94fa6fda6e"
+CHKSUMS="sha256::a6a25ffdcf9103e38d7a44732aca17073f4e602b92e4ae55625231a82702e05b"
 CHKUPDATE="anitya::id=5061"


### PR DESCRIPTION
Topic Description
-----------------

- usbutils: update to 017
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- usbutils: 017

Security Update?
----------------

No

Build Order
-----------

```
#buildit usbutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
