### PR TITLE
hdrhistogram-c: update to 0.11.8

### DIFF
--- a/runtime-common/hdrhistogram-c/spec
+++ b/runtime-common/hdrhistogram-c/spec
@@ -1,4 +1,4 @@
-VER=0.11.6
-SRCS="tbl::https://github.com/HdrHistogram/HdrHistogram_c/archive/refs/tags/0.11.6.tar.gz"
-CHKSUMS="sha256::b9bb6425d9b0ac5424f6d2286a1295900edab0170d1f50767decb00196785de3"
+VER=0.11.8
+SRCS="git::commit=tags/$VER::https://github.com/HdrHistogram/HdrHistogram_c"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241910"


### PR DESCRIPTION
Topic Description
-----------------

- hdrhistogram-c: update to 0.11.8
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- hdrhistogram-c: 0.11.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit hdrhistogram-c
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
