### PR TITLE
wayland-utils: update to 1.2.0

### DIFF
--- a/app-utils/wayland-utils/spec
+++ b/app-utils/wayland-utils/spec
@@ -1,4 +1,4 @@
-VER=1.1.0
+VER=1.2.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wayland/wayland-utils"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=129361"


### PR DESCRIPTION
Topic Description
-----------------

- wayland-utils: update to 1.2.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wayland-utils: 1.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wayland-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
