### PR TITLE
libgdiplus: update to 6.1

### DIFF
--- a/lang-dotnet/libgdiplus/spec
+++ b/lang-dotnet/libgdiplus/spec
@@ -1,4 +1,4 @@
-VER=6.0.5
-SRCS="tbl::https://github.com/mono/libgdiplus/archive/$VER.tar.gz"
-CHKSUMS="sha256::1fd034f4b636214cc24e94c563cd10b3f3444d9f0660927b60e63fd4131d97fa"
+VER=6.1
+SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/mono/libgdiplus"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6440"


### PR DESCRIPTION
Topic Description
-----------------

- libgdiplus: update to 6.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libgdiplus: 6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgdiplus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
