### PR TITLE
xcowsay: update to 1.6

### DIFF
--- a/app-utils/xcowsay/autobuild/defines
+++ b/app-utils/xcowsay/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=xcowsay
 PKGSEC=utils
-PKGDEP="dbus gtk-2"
+PKGDEP="dbus gtk-3"
 PKGDES="A cute cow and message on your desktop"
 
 AUTOTOOLS_AFTER="--enable-dbus"

--- a/app-utils/xcowsay/spec
+++ b/app-utils/xcowsay/spec
@@ -1,4 +1,4 @@
-VER=1.4
+VER=1.6
 SRCS="tbl::http://www.nickg.me.uk/files/xcowsay-$VER.tar.gz"
-CHKSUMS="sha256::c7e261ba0262c3821c106ccb6d6f984e3c2da999ad10151364e55d1c699f8e51"
+CHKSUMS="sha256::46ace864ff28d2d21f4b7058f0295e18d0041a120c1078a951fa43c4e0f5c8c5"
 CHKUPDATE="anitya::id=8949"


### PR DESCRIPTION
Topic Description
-----------------

- xcowsay: update to 1.6

Package(s) Affected
-------------------

- xcowsay: 1.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit xcowsay
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
