### PR TITLE
nodejs (Node.js): fix CHKUPDATE for LTS 20.x

### DIFF
--- a/lang-js/nodejs/spec
+++ b/lang-js/nodejs/spec
@@ -1,4 +1,4 @@
 VER=20.14.0
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.gz"
 CHKSUMS="sha256::f01109d3102754ac360fcf25aa588f3bef5c090a8eed3fb1d0be194149c46cf2"
-CHKUPDATE="anitya::id=12594"
+CHKUPDATE="anitya::id=369796"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs: fix CHKUPDATE for LTS 20.x

Package(s) Affected
-------------------

- nodejs: 2:20.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
