### PR TITLE
deploykit-gui: update to 0.3.2

### DIFF
--- a/app-admin/deploykit-gui/spec
+++ b/app-admin/deploykit-gui/spec
@@ -1,7 +1,7 @@
-VER=0.3.1
+VER=0.3.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-gui \
       tbl::https://github.com/AOSC-Dev/deploykit-gui/releases/download/v$VER/dist.tar.xz"
 CHKSUMS="SKIP \
-         sha256::1a5a7d1c0af358177c060bd878d90bc33bf17055bcb18708b8f8f8a7c3ed4ef7"
+         sha256::585aca3f6ddc5231887107656b1f644405e5cbf588ceee3e9040ec5b3a392ebf"
 SUBDIR="deploykit-gui/src-tauri"
 CHKUPDATE="anitya::id=371971"


### PR DESCRIPTION
Topic Description
-----------------

- deploykit-gui: update to 0.3.2

Package(s) Affected
-------------------

- deploykit-gui: 0.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-gui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
