### PR TITLE
chromium: update to 125.0.6422.141

### DIFF
--- a/app-web/chromium/spec
+++ b/app-web/chromium/spec
@@ -1,11 +1,11 @@
-VER=125.0.6422.60
+VER=125.0.6422.141
 LAUNCHERVER=8
 SRCS="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$VER.tar.xz \
       https://github.com/foutrelis/chromium-launcher/archive/v$LAUNCHERVER.tar.gz \
       file::rename=chromium-$VER.txt::https://chromium.googlesource.com/chromium/src/+/$VER?format=TEXT"
-CHKSUMS="sha256::93f5850101225945d7ec80959b38460e6a63777055bf2d9e893860c33cb60080 \
+CHKSUMS="sha256::9966b50279d0cfaaf4b58570387f0d526388f8d5f6dd990e3f083a55d8d8e603 \
          sha256::213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a \
-         sha256::427485c733a31a214c796b48ada5d906e43d95561de728cb11b6e312f8742429"
+         sha256::0e718b9e71f63b78be018d17f202494e38093d1ec76a7b3cfefecf752334b276"
 SUBDIR="chromium-$VER"
 CHKUPDATE="anitya::id=13344"
 ENVREQ__ARM64="total_mem_per_core=3"


### PR DESCRIPTION
Topic Description
-----------------

- chromium: update to 125.0.6422.141
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- chromium: 125.0.6422.141

Security Update?
----------------

No

Build Order
-----------

```
#buildit chromium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
