### PR TITLE
32subsystem: make wrappers change PATH for the 32-bit compilers

### DIFF
--- a/runtime-optenv32/32subsystem/autobuild/wrappers/clang++-multilib-wrapper
+++ b/runtime-optenv32/32subsystem/autobuild/wrappers/clang++-multilib-wrapper
@@ -4,6 +4,7 @@ for i
 do
     if [ "x$i" = "x-m32" ]
     then
+        export PATH="/opt/32/bin:$PATH"
         exec /opt/32/bin/clang++ "$@"
     fi
 done

--- a/runtime-optenv32/32subsystem/autobuild/wrappers/clang-multilib-wrapper
+++ b/runtime-optenv32/32subsystem/autobuild/wrappers/clang-multilib-wrapper
@@ -4,6 +4,7 @@ for i
 do
     if [ "x$i" = "x-m32" ]
     then
+        export PATH="/opt/32/bin:$PATH"
         exec /opt/32/bin/clang "$@"
     fi
 done

--- a/runtime-optenv32/32subsystem/autobuild/wrappers/g++-multilib-wrapper
+++ b/runtime-optenv32/32subsystem/autobuild/wrappers/g++-multilib-wrapper
@@ -4,6 +4,7 @@ for i
 do
     if [ "x$i" = "x-m32" ]
     then
+        export PATH="/opt/32/bin:$PATH"
         exec /opt/32/bin/g++ "$@"
     fi
 done

--- a/runtime-optenv32/32subsystem/autobuild/wrappers/gcc-multilib-wrapper
+++ b/runtime-optenv32/32subsystem/autobuild/wrappers/gcc-multilib-wrapper
@@ -4,6 +4,7 @@ for i
 do
     if [ "x$i" = "x-m32" ]
     then
+        export PATH="/opt/32/bin:$PATH"
         exec /opt/32/bin/gcc "$@"
     fi
 done

--- a/runtime-optenv32/32subsystem/spec
+++ b/runtime-optenv32/32subsystem/spec
@@ -1,2 +1,2 @@
-VER=1
+VER=2
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- 32subsystem: make wrappers change PATH for the 32-bit compilers
    This makes sure +32 compilers won't call undesirable linkers
    found in other paths.

Package(s) Affected
-------------------

- 32subsystem: 1:2

Security Update?
----------------

No

Build Order
-----------

```
#buildit 32subsystem
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
