### PR TITLE
libphonenumber update to 8.13.38

### DIFF
--- a/runtime-i18n/libphonenumber/autobuild/defines
+++ b/runtime-i18n/libphonenumber/autobuild/defines
@@ -1,8 +1,13 @@
 PKGNAME=libphonenumber
 PKGSEC=libs
 PKGDEP="boost icu protobuf"
-BUILDDEP="gtest"
+BUILDDEP="gtest openjdk abseil-cpp"
+BUILDDEP__MIPS64R6EL="${BUILDDEP/openjdk/}"
 PKGDES="Common library for parsing, formatting, storing, and validating international phone numbers"
+
+# FIXME: Under the condition that x takes effect, some test files may be mistakenly deleted, leading to build failure 
+# (this error occurs on all architectures), so test must be closed
+CMAKE_AFTER__MIPS64R6EL="-DREGENERATE_METADATA=OFF -DBUILD_TESTING=OFF"
 
 PKGBREAK="evolution-data-server<=3.28.3"
 ABTYPE=cmake

--- a/runtime-i18n/libphonenumber/spec
+++ b/runtime-i18n/libphonenumber/spec
@@ -1,5 +1,5 @@
-VER=8.12.17
-REL=3
+VER=8.13.38
 SRCS="git::commit=tags/v$VER::https://github.com/google/libphonenumber"
 CHKUPDATE="anitya::id=89344"
-SUBDIR="libphonenumber-$VER/cpp"
+SUBDIR="libphonenumber/cpp"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- libphonenumber: update to 8.13.38
    Fix build: add openjdk builddep for non mips64r6el architectures

Package(s) Affected
-------------------

- libphonenumber: 8.13.38

Security Update?
----------------

No

Build Order
-----------

```
#buildit libphonenumber
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
