### PR TITLE
zram-generator: rework 1.1.2

### DIFF
--- a/app-admin/zram-generator/autobuild/defines
+++ b/app-admin/zram-generator/autobuild/defines
@@ -7,3 +7,8 @@ BUILDDEP="rustc llvm ronn-ng"
 USECLANG=1
 ABSPLITDBG=0
 ABTYPE=rust
+
+# FIXME: ld.lld is not yet available.
+NOLTO__LOONGSON3=1
+NOLTO__LOONGARCH64=1
+NOLTO__MIPS64R6EL=1

--- a/app-admin/zram-generator/autobuild/prepare
+++ b/app-admin/zram-generator/autobuild/prepare
@@ -4,4 +4,4 @@ abinfo "Running cargo update due to lack of Cargo.lock ..."
 cargo update
 
 abinfo "Specifying systemd util directory ..."
-export SYSTEMD_UTIL_DIR=/usr/lib/systemd
+export SYSTEMD_UTIL_DIR="/usr/lib/systemd"

--- a/app-admin/zram-generator/spec
+++ b/app-admin/zram-generator/spec
@@ -1,4 +1,5 @@
 VER=1.1.2
-SRCS="tbl::https://github.com/systemd/zram-generator/archive/v$VER.tar.gz"
-CHKSUMS="sha256::506d47acbabffa7013bb40a1f61c6edfa758a7bd55820d06ef49c7bc83dba762"
+REL=1
+SRCS="git::commit=tags/v$VER::https://github.com/systemd/zram-generator"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18509"


### PR DESCRIPTION
Topic Description
-----------------

- zram-generator: fix build and lint
    - Use Git tag per the Styling Manual.
    - Disable LTO on architectures with broken/missing ld.lld.

Package(s) Affected
-------------------

- ronn-ng: 0.10.1-1
- zram-generator: 1.1.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ronn-ng zram-generator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
