### PR TITLE
mesa: Enable all video codecs

### DIFF
--- a/runtime-display/mesa/autobuild/defines
+++ b/runtime-display/mesa/autobuild/defines
@@ -59,7 +59,7 @@ MESON_AFTER="-Ddri-drivers-path=/usr/lib/xorg/modules/dri \
              -Dosmesa=true \
              -Dshared-glapi=enabled \
              -Dvalgrind=enabled \
-             -Dvideo-codecs=vc1dec,h264dec,h264enc,h265dec,h265enc"
+             -Dvideo-codecs=all"
 
 MESON_AFTER__X86=" \
              ${MESON_AFTER} \

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,6 +1,7 @@
 MESA_VER=24.0.7
 DXHEADERS_VER=1.613.1
 VER=${MESA_VER}+dxheaders${DXHEADERS_VER}
+REL=1
 SRCS="tbl::https://archive.mesa3d.org/mesa-${MESA_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
 CHKSUMS="sha256::7454425f1ed4a6f1b5b107e1672b30c88b22ea0efea000ae2c7d96db93f6c26a \


### PR DESCRIPTION
Topic Description
-----------------

- mesa: enable all video codecs

Package(s) Affected
-------------------

- mesa: 1:24.0.7+dxheaders1.613.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
