### PR TITLE
latx (Loongson Architecture Translator for x86): rework dependencies

### DIFF
--- a/app-emulation/latx/autobuild/defines
+++ b/app-emulation/latx/autobuild/defines
@@ -3,6 +3,7 @@ PKGSEC=utils
 # Note: systemd-binfmt required for binfmt_misc configuration handling.
 # Note: Zenity is required for /usr/bin/runapp, an LATX requirement.
 PKGDEP="systemd zenity"
+PKGRECOM="wine"
 BUILDDEP="squashfs-tools"
 PKGDES="Loongson Architecture Translator for x86 applications"
 
@@ -15,9 +16,6 @@ ABQA=0
 # Note: Extra Provides for Spiral (Debian compatibility).
 ABSPIRAL=0
 PKGPROV="lat_spiral i386-runtime-base_spiral i386-runtime-extra_spiral"
-
-# Note: To ease `oma install wine' and to make it easier to install q4wine.
-PKGPROV="${PKGPROV} wine"
 
 # Note: Man pages have already been compresssed once.
 ABMANCOMPRESS=0

--- a/app-emulation/latx/spec
+++ b/app-emulation/latx/spec
@@ -1,6 +1,7 @@
 __LATX_VER=1.5.2~rc1
 __EMUKIT_VER=20240529
 VER=${__LATX_VER}+emukit${__EMUKIT_VER}
+REL=1
 # Note: deepin-udis86 (closed source) is used by Loongapps's WeChat, which comes bundled with deepin-wine.
 # FIXME: Remove the 4th source at the next LATX release. This source is currently included for documentation.
 SRCS="tbl::https://github.com/deuso/latx-build/releases/download/${__LATX_VER/\~/-}/${__LATX_VER/\~/-}.tar.gz \


### PR DESCRIPTION
Topic Description
-----------------

- latx: rework dependencies
    - Drop invalid Provides for `wine'.
    - Recommend `wine' to ease transition.

Package(s) Affected
-------------------

- latx: 1.5.2~rc1+emukit20240529-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit latx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
