### PR TITLE
byobu: update to 6.12

### DIFF
--- a/app-utils/byobu/spec
+++ b/app-utils/byobu/spec
@@ -1,4 +1,4 @@
-VER=5.133
-SRCS="tbl::https://launchpad.net/byobu/trunk/$VER/+download/byobu_$VER.orig.tar.gz"
-CHKSUMS="sha256::4d8ea48f8c059e56f7174df89b04a08c32286bae5a21562c5c6f61be6dab7563"
+VER=6.12
+SRCS="git::commit=$VER::https://github.com/dustinkirkland/byobu"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236"


### PR DESCRIPTION
Topic Description
-----------------

- byobu: update to 6.12, switch upstream to github repository

Package(s) Affected
-------------------

- byobu: 6.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit byobu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
