### PR TITLE
Certbot 2.10.0 Dependency Rework

### DIFF
--- a/app-web/certbot/autobuild/defines
+++ b/app-web/certbot/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME=certbot
 PKGSEC=net
+# Really should have been acme=${PKGVER} but alas acbs doesn't have that yet
+# - cth451
 PKGDEP="acme ca-certs configargparse configobj future josepy mock parsedatetime pyopenssl \
         pypsutil pyrfc3339 pythondialog pytz requests setuptools six toolbelt zope-component zope-interface distro"
 PKGDES="A tool to automatically receive and install X.509 certificates to enable TLS on servers"

--- a/app-web/certbot/spec
+++ b/app-web/certbot/spec
@@ -1,4 +1,5 @@
 VER=2.10.0
+REL=1
 SRCS="tbl::https://pypi.io/packages/source/c/certbot/certbot-$VER.tar.gz"
 CHKSUMS="sha256::892aa57d4db74af174aec5e4bb7f7537b200de2545a066c049d03a53215f0e4e"
 CHKUPDATE="anitya::id=10690"

--- a/lang-python/acme/autobuild/defines
+++ b/lang-python/acme/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=acme
 PKGSEC=python
-PKGDEP="cryptography josepy pyopenssl pyrfc3339 pytz toolbelt setuptools"
+PKGDEP="cryptography josepy pyopenssl pyrfc3339 pytz toolbelt"
+BUILDDEP="setuptools python-installer python-build wheel"
 PKGDES="ACME protocol implementation in Python"
 
 NOPYTHON2=1
-PKGBREAK="letencrypt<=0.2.0"
+PKGBREAK="letencrypt<=2.5.0"
 ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/acme/spec
+++ b/lang-python/acme/spec
@@ -1,4 +1,4 @@
-VER=2.5.0
+VER=2.10.0
 SRCS="tbl::https://pypi.io/packages/source/a/acme/acme-$VER.tar.gz"
-CHKSUMS="sha256::9c760b115c54f55f692321abe5d09f5c70ce437e61f9f22340341621d9909a5a"
+CHKSUMS="sha256::de110d6550f22094c920ad6022f4b329380a6bd8f58dd671135c6226c3a470cc"
 CHKUPDATE="anitya::id=8231"

--- a/lang-python/configargparse/autobuild/defines
+++ b/lang-python/configargparse/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=configargparse
 PKGSEC=python
 PKGDEP="pyyaml"
-BUILDDEP="setuptools"
+BUILDDEP="setuptools python-build python-installer wheel"
 PKGDES="A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables"
 
 ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/configargparse/spec
+++ b/lang-python/configargparse/spec
@@ -1,5 +1,4 @@
-VER=1.3
+VER=1.7
 SRCS="tbl::https://github.com/bw2/ConfigArgParse/archive/$VER.tar.gz"
-CHKSUMS="sha256::aee4156db260051207d4757548b524bcb56ed0988cdf23cf7c69fa7afca6d382"
+CHKSUMS="sha256::4549d105790386d01f71beebc3aa457d4177315680b75415f05bc22e1e28183a"
 CHKUPDATE="anitya::id=25830"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- certbot: rebuild to enforce dependency versions
    - acme: 2.10.0
    - configargparse: 1.4+
- acme: update to 2.10.0
- configargparse: update to 1.7

Package(s) Affected
-------------------

- acme: 2.10.0
- certbot: 2.10.0-1
- configargparse: 1.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit configargparse acme certbot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
