### PR TITLE
catdoc: fix build

### DIFF
--- a/app-doc/catdoc/autobuild/patches/0001-CVE-2017-11110.patch
+++ b/app-doc/catdoc/autobuild/patches/0001-CVE-2017-11110.patch
@@ -1,3 +1,8 @@
+From 0afca1be9fb3cdd500d61e66dc9e459ff81a9770 Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Wed, 5 Jun 2024 11:28:34 +0800
+Subject: [PATCH] CVE-2017-11110: Heap buffer overflow in ole_init
+
 Description: CVE-2017-11110: Heap buffer overflow in ole_init
 Origin: vendor, https://build.opensuse.org/package/view_file/openSUSE:Maintenance:6985/catdoc.openSUSE_Leap_42.2_Update/CVE-2017-11110.patch?rev=d437c3be72c2e5a3516b75f4e9de6b35
 Bug-Debian: https://bugs.debian.org/867717
@@ -8,9 +13,15 @@ Author: Andreas Stieger <astieger@suse.com>
 Reviewed-by: Salvatore Bonaccorso <carnil@debian.org>
 Last-Update: 2017-07-20
 
+---
+ src/ole.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/ole.c b/src/ole.c
+index dbcda42..27b67bb 100644
 --- a/src/ole.c
 +++ b/src/ole.c
-@@ -101,6 +101,11 @@ FILE* ole_init(FILE *f, void *buffer, si
+@@ -106,6 +106,11 @@ FILE* ole_init(FILE *f, void *buffer, size_t bufSize)  {
  		return NULL;
  	}
   	sectorSize = 1<<getshort(oleBuf,0x1e);
@@ -20,14 +31,17 @@ Last-Update: 2017-07-20
 +		return NULL;
 +	}
  	shortSectorSize=1<<getshort(oleBuf,0x20);
- 	
+ 
  /* Read BBD into memory */
-@@ -132,7 +137,7 @@ FILE* ole_init(FILE *f, void *buffer, si
+@@ -147,7 +152,7 @@ FILE* ole_init(FILE *f, void *buffer, size_t bufSize)  {
  		}
- 		
+ 
  		fseek(newfile, 512+mblock*sectorSize, SEEK_SET);
 -		if(fread(tmpBuf+MSAT_ORIG_SIZE+(sectorSize-4)*i,
 +		if(fread(tmpBuf+MSAT_ORIG_SIZE+(sectorSize-4)*i, /* >=4 for CVE-2017-11110 */
  						 1, sectorSize, newfile) != sectorSize) {
  			fprintf(stderr, "Error read MSAT!\n");
  			ole_finish();
+-- 
+2.34.1
+

--- a/app-doc/catdoc/spec
+++ b/app-doc/catdoc/spec
@@ -1,5 +1,5 @@
 VER=0.95
-REL=3
+REL=4
 SRCS="tbl::http://ftp.wagner.pp.ru/pub/catdoc/catdoc-$VER.tar.gz"
 CHKSUMS="sha256::514a84180352b6bf367c1d2499819dfa82b60d8c45777432fa643a5ed7d80796"
 CHKUPDATE="anitya::id=13398"


### PR DESCRIPTION
Topic Description
-----------------

- catdoc: exporting patch using git

Package(s) Affected
-------------------

- catdoc: 0.95-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit catdoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
