### PR TITLE
x11-proto: update to 2024.1

### DIFF
--- a/runtime-display/x11-proto/spec
+++ b/runtime-display/x11-proto/spec
@@ -1,4 +1,4 @@
-VER=2023.2
+VER=2024.1
 SRCS="tbl::https://xorg.freedesktop.org/archive/individual/proto/xorgproto-$VER.tar.xz"
-CHKSUMS="sha256::b61fbc7db82b14ce2dc705ab590efc32b9ad800037113d1973811781d5118c2c"
+CHKSUMS="sha256::372225fd40815b8423547f5d890c5debc72e88b91088fbfb13158c20495ccb59"
 CHKUPDATE="anitya::id=17190"


### PR DESCRIPTION
Topic Description
-----------------

- x11-proto: update to 2024.1
    Co-authored-by: Icenowy Zheng (@Icenowy) <uwu@icenowy.me>

Package(s) Affected
-------------------

- x11-proto: 1:2024.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit x11-proto
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
