### PR TITLE
xwayland: update to 24.1.0

### DIFF
--- a/runtime-display/xwayland/autobuild/defines
+++ b/runtime-display/xwayland/autobuild/defines
@@ -6,7 +6,6 @@ BUILDDEP="egl-wayland wayland-protocols"
 PKGDES="X11 compatibility layer for Wayland"
 
 MESON_AFTER="-Dglamor=true \
-             -Dxwayland_eglstream=true \
              -Dxvfb=true \
              -Dglx=true \
              -Dxdmcp=true \

--- a/runtime-display/xwayland/spec
+++ b/runtime-display/xwayland/spec
@@ -1,4 +1,4 @@
-VER=23.2.6
+VER=24.1.0
 SRCS="tbl::https://xorg.freedesktop.org/archive/individual/xserver/xwayland-$VER.tar.xz"
-CHKSUMS="sha256::1c9a366b4e7ccadba0f9bd313c59eae12d23bd72543b22a26eaf8b20835cfc6d"
+CHKSUMS="sha256::bef21c4f18807a4ed571c4e2df60ab63b5466bbd502ecceb2485b892ab76dcc2"
 CHKUPDATE="anitya::id=180949"


### PR DESCRIPTION
Topic Description
-----------------

- xwayland: update to 24.1.0
    Co-authored-by: Icenowy Zheng (@Icenowy) <uwu@icenowy.me>

Package(s) Affected
-------------------

- xwayland: 24.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xwayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
