### PR TITLE
fcron: update to 3.3.1

### DIFF
--- a/app-admin/fcron/autobuild/beyond
+++ b/app-admin/fcron/autobuild/beyond
@@ -22,8 +22,3 @@ ln -sv /usr/bin/fcrontab "$PKGDIR"/usr/bin/crontab
 
 abinfo "Moving /var/run => /run ..."
 rm -rv "$PKGDIR"/var/run
-
-abinfo "Setting permission for /var/spool/fcron/ ..."
-chown -R fcron:fcron "$PKGDIR"/var/spool/fcron
-abinfo "Setting setuid && setgid bits for /var/spool/fcron ..."
-chmod 6770 "$PKGDIR"/var/spool/fcron

--- a/app-admin/fcron/autobuild/defines
+++ b/app-admin/fcron/autobuild/defines
@@ -7,6 +7,7 @@ PKGDES="A feature-rich Cron implementation"
 
 PKGPROV=cron
 
+ABTYPE=autotools
 RECONF=0
 ABSHADOW=0
 # Note: sysconfdir set to /etc/fcron to remain consistent with previous

--- a/app-admin/fcron/autobuild/overrides/usr/lib/sysusers.d/fcron.conf
+++ b/app-admin/fcron/autobuild/overrides/usr/lib/sysusers.d/fcron.conf
@@ -1,0 +1,2 @@
+u fcron 33 - /var/spool/fcron
+g fcron

--- a/app-admin/fcron/autobuild/overrides/usr/lib/tmpfiles.d/fcron.conf
+++ b/app-admin/fcron/autobuild/overrides/usr/lib/tmpfiles.d/fcron.conf
@@ -1,0 +1,1 @@
+d /var/spool/fcron 6770 fcron fcron

--- a/app-admin/fcron/autobuild/postinst
+++ b/app-admin/fcron/autobuild/postinst
@@ -1,4 +1,8 @@
-getent group fcron >/dev/null || groupadd -g 33 fcron
-getent passwd fcron >/dev/null || useradd -r -d /var/spool/fcron -u 33 -g 33 fcron
+echo "Creating user and group for fcron ..."
+systemd-sysusers fcron.conf
 
+echo "Updating daemon owner directory ..."
+systemd-tmpfiles --create fcron.conf
+
+echo "Initializing systab ..."
 fcrontab -z -u systab &>/dev/null

--- a/app-admin/fcron/autobuild/prepare
+++ b/app-admin/fcron/autobuild/prepare
@@ -1,5 +1,6 @@
-# Ensure that it builds...
+echo "Creating group and user for fcron ..."
 getent group fcron >/dev/null || groupadd -g 33 fcron
 getent passwd fcron >/dev/null || useradd -r -d /var/spool/fcron -u 33 -g 33 fcron
 
-export CFLAGS="${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
+echo "Generating configure ..."
+autoconf

--- a/app-admin/fcron/spec
+++ b/app-admin/fcron/spec
@@ -1,5 +1,4 @@
-VER=3.3.0
-REL=1
-SRCS="tbl::http://fcron.free.fr/archives/fcron-$VER.src.tar.gz"
-CHKSUMS="sha256::9aead33a0926e2eec123698c502114c6d67b483fe1ec232969fae6809b0bab60"
+VER=3.3.1
+SRCS="git::commit=tags/ver${VER//./_}::https://github.com/yo8192/fcron"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=784"


### PR DESCRIPTION
Topic Description
-----------------

- fcron: update to 3.3.1

Package(s) Affected
-------------------

- fcron: 3.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcron
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
