### PR TITLE
lyx (LyX): update to 2.4.0

### DIFF
--- a/app-doc/lyx/autobuild/defines
+++ b/app-doc/lyx/autobuild/defines
@@ -1,15 +1,13 @@
 PKGNAME=lyx
 PKGSEC=tex
-PKGDEP="boost enchant file imagemagick mythes qt-5 texlive"
+PKGDEP="boost enchant file imagemagick mythes qt-6 texlive"
 PKGSUG="rcs"
 BUILDDEP="bc"
-PKGDES="An advanced WYSIWYM document processor & LaTeX front-end"
+PKGDES="Graphical LaTeX editor and document processor"
 
 AUTOTOOLS_AFTER="--without-included-boost \
                  --with-enchant \
                  --with-hunspell \
-                 --enable-qt5 \
-                 QTDIR=/usr/lib/qt5"
+                 --enable-qt6 \
+                 QTDIR=/usr/lib/qt6"
 RECONF=0
-
-NOLTO__LOONGSON3=1

--- a/app-doc/lyx/spec
+++ b/app-doc/lyx/spec
@@ -1,4 +1,4 @@
-VER=2.3.7
-SRCS="tbl::https://ftp.lip6.fr/pub/lyx/stable/2.3.x/lyx-$VER-1.tar.xz"
-CHKSUMS="sha256::39be8864fb86b34e88310e70fb80e5e9e296601f0856cf161aa094171718d8ed"
+VER=2.4.0
+SRCS="tbl::https://ftp.lip6.fr/pub/lyx/stable/${VER%.*}.x/lyx-$VER.tar.xz"
+CHKSUMS="sha256::e7575d3a42e96e57d45e06022a924bcc51128b55c6a0d83f8742fe346c2e59f2"
 CHKUPDATE="anitya::id=1864"


### PR DESCRIPTION
Topic Description
-----------------

- lyx: update to 2.4.0
    - Re-enable LTO for loongson3.
    - Lint PKGDES in accordance with the Styling Manual.

Package(s) Affected
-------------------

- lyx: 2.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lyx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
