### PR TITLE
clit: fix build

### DIFF
--- a/app-utils/clit/autobuild/patch
+++ b/app-utils/clit/autobuild/patch
@@ -1,6 +1,0 @@
-abinfo "Patching Makefile to use System libtommath ..."
-sed -i 's|../libtommath-0.30/|/usr/lib/|' "$SRCDIR"/clit18/Makefile
-abinfo "Patching Makefiles to inject CFLAGS ..."
-for i in lib clit18; do
-	sed -i "s|CFLAGS=|&${CFLAGS}|g" "$SRCDIR"/$i/Makefile
-done

--- a/app-utils/clit/autobuild/patches/0001-use-System-libtommath.patch
+++ b/app-utils/clit/autobuild/patches/0001-use-System-libtommath.patch
@@ -1,0 +1,28 @@
+From a8de20c20b7edb1794d878f2316b70ab0605117c Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Thu, 6 Jun 2024 16:55:31 +0800
+Subject: [PATCH 1/2] use System libtommath
+
+---
+ clit18/Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/clit18/Makefile b/clit18/Makefile
+index d0acaa3..67b5e80 100644
+--- a/clit18/Makefile
++++ b/clit18/Makefile
+@@ -1,9 +1,9 @@
+ all: clit
+ 
+-CFLAGS=-funsigned-char -Wall -O2 -I ../libtommath-0.30/ -I ../lib -I ../lib/des -I .
++CFLAGS=-funsigned-char -Wall -O2 -I /usr/lib/ -I ../lib -I ../lib/des -I .
+ clean:
+ 	rm -f *.o clit
+ 
+ clit: clit.o hexdump.o drm5.o explode.o transmute.o display.o utils.o manifest.o ../lib/openclit.a 
+-	gcc -o clit $^  ../libtommath-0.30/libtommath.a
++	gcc -o clit $^  /usr/lib/libtommath.a
+ 
+-- 
+2.34.1
+

--- a/app-utils/clit/autobuild/patches/0002-inject-CFLAGS.patch
+++ b/app-utils/clit/autobuild/patches/0002-inject-CFLAGS.patch
@@ -1,0 +1,37 @@
+From 08fce5301fc35335495ec7ab3aaa203015781e68 Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Thu, 6 Jun 2024 16:56:22 +0800
+Subject: [PATCH 2/2] inject CFLAGS
+
+---
+ clit18/Makefile | 2 +-
+ lib/Makefile    | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/clit18/Makefile b/clit18/Makefile
+index 67b5e80..ae5ff8c 100644
+--- a/clit18/Makefile
++++ b/clit18/Makefile
+@@ -1,6 +1,6 @@
+ all: clit
+ 
+-CFLAGS=-funsigned-char -Wall -O2 -I /usr/lib/ -I ../lib -I ../lib/des -I .
++CFLAGS := -funsigned-char -Wall -O2 -I /usr/lib/ -I ../lib -I ../lib/des -I . $(CFLAGS)
+ clean:
+ 	rm -f *.o clit
+ 
+diff --git a/lib/Makefile b/lib/Makefile
+index 9104f27..53ababc 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -1,6 +1,6 @@
+ all: openclit.a
+ 
+-CFLAGS=-O3 -Wall -Ides -Isha -Inewlzx -I.
++CFLAGS := -O3 -Wall -Ides -Isha -Inewlzx -I. $(CFLAGS)
+ clean:
+ 	rm -f *.o openclit.a des/*.o lzx/*.o sha/*.o
+ 
+-- 
+2.34.1
+

--- a/app-utils/clit/spec
+++ b/app-utils/clit/spec
@@ -1,5 +1,5 @@
 VER=1.8
-REL=6
+REL=7
 SRCS="tbl::http://www.convertlit.com/clit18src.zip"
 CHKSUMS="sha256::d70a85f5b945104340d56f48ec17bcf544e3bb3c35b1b3d58d230be699e557ba"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- clit: fix exporting error $CFLAGS

Package(s) Affected
-------------------

- clit: 1.8-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit clit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
