### PR TITLE
wmctrl: (no build) fix source link

### DIFF
--- a/desktop-wm/wmctrl/spec
+++ b/desktop-wm/wmctrl/spec
@@ -1,4 +1,4 @@
 VER=1.07
-SRCS="http://tripie.sweb.cz/utils/wmctrl/dist/wmctrl-${VER}.tar.gz"
+SRCS="https://repo.aosc.io/aosc-repacks/wmctrl-$VER.tar.gz"
 CHKSUMS="sha256::d78a1efdb62f18674298ad039c5cbdb1edb6e8e149bb3a8e3a01a4750aa3cca9"
 CHKUPDATE="anitya::id=15258"


### PR DESCRIPTION
Topic Description
-----------------

- wmctrl: (no build) fix source link

Package(s) Affected
-------------------

- wmctrl: 1.07

Security Update?
----------------

No

Build Order
-----------

```
#buildit wmctrl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
