### PR TITLE
Deploykit Survey (20240605)

### DIFF
--- a/app-admin/deploykit-backend/spec
+++ b/app-admin/deploykit-backend/spec
@@ -1,4 +1,4 @@
-VER=0.2.4
+VER=0.2.5
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-backend/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371972"

--- a/app-admin/deploykit-gui/autobuild/defines
+++ b/app-admin/deploykit-gui/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME="deploykit-gui"
 PKGDES="Graphical frontend for AOSC OS Installer (DeployKit)"
-PKGDEP="deploykit-backend gcc-runtime webkit2gtk"
+PKGDEP="deploykit-backend gcc-runtime webkit2gtk wmctrl"
 BUILDDEP="llvm rustc yarn"
 PKGSEC="admin"
 

--- a/app-admin/deploykit-gui/spec
+++ b/app-admin/deploykit-gui/spec
@@ -1,7 +1,7 @@
-VER=0.3.5
+VER=0.4.3
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-gui \
       tbl::https://github.com/AOSC-Dev/deploykit-gui/releases/download/v$VER/dist.tar.xz"
 CHKSUMS="SKIP \
-         sha256::48207cd331b462b878d8b286492b8080b8264b5e96bc8c68b6239d901b0a99b9"
+         sha256::c82de3584569fa05bd707ddaa366410548a0053a74f116d70e3012e340c4886e"
 SUBDIR="deploykit-gui/src-tauri"
 CHKUPDATE="anitya::id=371971"


### PR DESCRIPTION
Topic Description
-----------------

- deploykit-backend: update to 0.2.5
- deploykit-gui: update to 0.4.3

Package(s) Affected
-------------------

- deploykit-backend: 0.2.5
- deploykit-gui: 0.4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-backend deploykit-gui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
