### PR TITLE
libappimage: rebase patch

### DIFF
--- a/runtime-desktop/libappimage/autobuild/patches/0001-Fix-build-with-gcc-13.1.1.patch
+++ b/runtime-desktop/libappimage/autobuild/patches/0001-Fix-build-with-gcc-13.1.1.patch
@@ -17,7 +17,7 @@ index 45240f7..6b68489 100644
  // system
 +#include <cstdint>
  #include <istream>
- #include <vector>
+
  
 -- 
 2.42.0

--- a/runtime-desktop/libappimage/spec
+++ b/runtime-desktop/libappimage/spec
@@ -1,5 +1,5 @@
 VER=1.0.4+5
-REL=2
+REL=3
 SRCS="git::commit=tags/v${VER/+/-}::https://github.com/AppImage/libappimage"
 CHKSUMS="sha256::2c4e18860a790c5959da6eb064cbd07f165fe6a9b15989491a3a3f176d06af31"
 CHKUPDATE="anitya::id=288151"


### PR DESCRIPTION
Topic Description
-----------------

- libappimage: rebase patch

Package(s) Affected
-------------------

- libappimage: 1.0.4+5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libappimage
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
