### PR TITLE
libarchive: update to 3.7.4

### DIFF
--- a/runtime-common/libarchive/spec
+++ b/runtime-common/libarchive/spec
@@ -1,4 +1,4 @@
-VER=3.7.3
+VER=3.7.4
 SRCS="tbl::https://www.libarchive.org/downloads/libarchive-$VER.tar.gz"
-CHKSUMS="sha256::f27a97bc22ceb996e72502df47dc19f99f9a0f09181ae909f09f3c9eb17b67e2"
+CHKSUMS="sha256::7875d49596286055b52439ed42f044bd8ad426aa4cc5aabd96bfe7abb971d5e8"
 CHKUPDATE="anitya::id=1558"


### PR DESCRIPTION
Topic Description
-----------------

- libarchive: update to 3.7.4
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- libarchive: 1:3.7.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit libarchive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
