### PR TITLE
nginx: update to 1.27.0

### DIFF
--- a/app-web/nginx/autobuild/defines
+++ b/app-web/nginx/autobuild/defines
@@ -38,6 +38,7 @@ AUTOTOOLS_AFTER="--prefix=/etc/nginx \
                  --with-http_stub_status_module \
                  --with-http_sub_module \
                  --with-http_v2_module \
+                 --with-http_v3_module \
                  --with-mail \
                  --with-mail_ssl_module \
                  --with-pcre-jit \

--- a/app-web/nginx/autobuild/prepare
+++ b/app-web/nginx/autobuild/prepare
@@ -1,1 +1,2 @@
-export AUTOTOOLS_DEF=""
+# FIXME: invalid option "--sysconfdir=/etc"
+AUTOTOOLS_DEF=("--prefix=/etc/nginx")

--- a/app-web/nginx/spec
+++ b/app-web/nginx/spec
@@ -1,4 +1,4 @@
-VER=1.25.3
+VER=1.27.0
 SRCS="tbl::https://nginx.org/download/nginx-$VER.tar.gz"
-CHKSUMS="sha256::64c5b975ca287939e828303fa857d22f142b251f17808dfe41733512d9cded86"
+CHKSUMS="sha256::b7230e3cf87eaa2d4b0bc56aadc920a960c7873b9991a1b66ffcc08fc650129c"
 CHKUPDATE="anitya::id=5413"


### PR DESCRIPTION
Topic Description
-----------------

- nginx: update to 1.27.0
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- nginx: 1.27.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nginx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
