### PR TITLE
stow: update to 2.4.0

### DIFF
--- a/app-admin/stow/autobuild/defines
+++ b/app-admin/stow/autobuild/defines
@@ -6,3 +6,7 @@ PKGDES="Manage installation of multiple softwares in the same directory tree"
 ABHOST=noarch
 ABSHADOW=0
 AUTOTOOLS_AFTER="--with-pmdir=/usr/lib/perl5/vendor_perl/"
+
+# FIXME: Makefile.am:131: warning: escaping \# comment markers is not portable
+# due to --warnings=category, this is treated as an error
+RECONF=0

--- a/app-admin/stow/spec
+++ b/app-admin/stow/spec
@@ -1,5 +1,4 @@
-VER=2.3.1
-REL=2
+VER=2.4.0
 SRCS="tbl::https://ftp.gnu.org/gnu/stow/stow-$VER.tar.gz"
-CHKSUMS="sha256::09d5d99671b78537fd9b2c0b39a5e9761a7a0e979f6fdb7eabfa58ee45f03d4b"
+CHKSUMS="sha256::6fed67cf64deab6d3d9151a43e2c06c95cdfca6a88fab7d416f46a648b1d761d"
 CHKUPDATE="anitya::id=4900"


### PR DESCRIPTION
Topic Description
-----------------

- stow: update to 2.4.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- stow: 2.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit stow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
