### PR TITLE
tree: fix manpage path

### DIFF
--- a/app-utils/tree/autobuild/build
+++ b/app-utils/tree/autobuild/build
@@ -6,4 +6,4 @@ abinfo "Installing tree ..."
 # Note: From the Makefile - DESTDIR=${PREFIX}/bin.
 make install \
     PREFIX="$PKGDIR"/usr \
-    MANDIR="$PKGDIR"/usr/share/man/man1
+    MANDIR="$PKGDIR"/usr/share/man

--- a/app-utils/tree/spec
+++ b/app-utils/tree/spec
@@ -1,4 +1,5 @@
 VER=2.1.1
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.com/OldManProgrammer/unix-tree"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5006"


### PR DESCRIPTION
Topic Description
-----------------

- tree: fix manpage path
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- tree: 2.1.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
