### PR TITLE
deploykit survey 20240607

### DIFF
--- a/app-admin/deploykit-backend/spec
+++ b/app-admin/deploykit-backend/spec
@@ -1,4 +1,4 @@
-VER=0.2.5
+VER=0.2.6
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-backend/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371972"

--- a/app-admin/deploykit-gui/spec
+++ b/app-admin/deploykit-gui/spec
@@ -1,7 +1,7 @@
-VER=0.4.3
+VER=0.4.5
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-gui \
       tbl::https://github.com/AOSC-Dev/deploykit-gui/releases/download/v$VER/dist.tar.xz"
 CHKSUMS="SKIP \
-         sha256::c82de3584569fa05bd707ddaa366410548a0053a74f116d70e3012e340c4886e"
+         sha256::1c7a280dab8639e6674a801623076173722d769afad99d3a23c40f8c0e0a356e"
 SUBDIR="deploykit-gui/src-tauri"
 CHKUPDATE="anitya::id=371971"


### PR DESCRIPTION
Topic Description
-----------------

- deploykit-gui: update to 0.4.5
- deploykit-backend: update to 0.2.6

Package(s) Affected
-------------------

- deploykit-backend: 0.2.6
- deploykit-gui: 0.4.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-backend deploykit-gui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
