### PR TITLE
php: update to 8.3.8

### DIFF
--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,4 +1,4 @@
-VER=8.3.7
+VER=8.3.8
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::d53433c1ca6b2c8741afa7c524272e6806c1e895e5912a058494fea89988570a"
+CHKSUMS="sha256::aea358b56186f943c2bbd350c9005b9359133d47e954cfc561385319ae5bb8d7"
 CHKUPDATE="anitya::id=3627"


### PR DESCRIPTION
Topic Description
-----------------

- php: update to 8.3.8
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- php: 1:8.3.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
