### PR TITLE
qtcreator: update to 13.0.2

### DIFF
--- a/app-devel/qtcreator/spec
+++ b/app-devel/qtcreator/spec
@@ -1,4 +1,4 @@
-VER=13.0.1
+VER=13.0.2
 SRCS="tbl::https://download.qt.io/official_releases/qtcreator/${VER%.*}/$VER/qt-creator-opensource-src-$VER.tar.xz"
-CHKSUMS="sha256::819006d1921f61cc675980bcc9d795a2248cfd796115dad466a4454759dab32e"
+CHKSUMS="sha256::c125cc5522619c7f8fc2805a750ab96cbbb56a5fdfc388b6cb15ab75af7ec0ce"
 CHKUPDATE="anitya::id=4136"


### PR DESCRIPTION
Topic Description
-----------------

- qtcreator: update to 13.0.2
    Co-authored-by: SignKirigami (@prcups) <prcups@krgm.moe>

Package(s) Affected
-------------------

- qtcreator: 13.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qtcreator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
