### PR TITLE
postgresql: update to 13.15 and use sysusers

### DIFF
--- a/app-database/postgresql/autobuild/overrides/usr/lib/sysusers.d/postgresql.conf
+++ b/app-database/postgresql/autobuild/overrides/usr/lib/sysusers.d/postgresql.conf
@@ -1,0 +1,2 @@
+g    postgres  90
+u    postgres  90:90 "Postgres Daemon Owner" /var/lib/postgres  /bin/bash

--- a/app-database/postgresql/autobuild/postinst
+++ b/app-database/postgresql/autobuild/postinst
@@ -1,8 +1,14 @@
+echo "Setting up postgres user and group ..."
+systemd-sysusers postgresql.conf
+
+echo "Migrating postgres home directory ..."
 usermod -d /var/lib/postgres postgres
 
+echo "Creating temporary directory for postgresql ..."
 systemd-tmpfiles --create postgresqld.conf
 
 if [ ! -d /var/lib/postgres/data ]; then
+    echo "Creating initial postgresql database ..."
     mkdir -p /var/lib/postgres/data
     chown 90:90 /var/lib/postgres/data
     su - postgres -c \

--- a/app-database/postgresql/autobuild/usergroup
+++ b/app-database/postgresql/autobuild/usergroup
@@ -1,2 +1,0 @@
-group postgres 90
-user postgres 90 postgres /srv/postgres "Postgres Daemon Owner" /bin/bash 

--- a/app-database/postgresql/spec
+++ b/app-database/postgresql/spec
@@ -1,4 +1,4 @@
-VER=13.13
+VER=13.15
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::8af69c2599047a2ad246567d68ec4131aef116954d8c3e469e9789080b37a474"
+CHKSUMS="sha256::42edd415446d33b8c242be76d1ad057531b2264b2e86939339b7075c6e4ec925"
 CHKUPDATE="anitya::id=5601"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql: update to 13.15 and use sysusers

Package(s) Affected
-------------------

- postgresql: 13.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit postgresql
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
