### PR TITLE
rhythmbox: update to 3.4.7

### DIFF
--- a/app-multimedia/rhythmbox/autobuild/beyond
+++ b/app-multimedia/rhythmbox/autobuild/beyond
@@ -1,2 +1,0 @@
-rm -r "$PKGDIR"/usr/lib/rhythmbox/sample-plugins
-rm -r "$PKGDIR"/usr/lib/rhythmbox/plugins/rbzeitgeist

--- a/app-multimedia/rhythmbox/spec
+++ b/app-multimedia/rhythmbox/spec
@@ -1,6 +1,4 @@
-VER=3.4.4
-REL=5
-CHKSUMS="sha256::ee0eb0d7d7bdf696ac9471b19ff3bea3240d63b6cb8a134bf632054af8665d90"
+VER=3.4.7
 SRCS="tbl::https://download.gnome.org/sources/rhythmbox/${VER:0:3}/rhythmbox-$VER.tar.xz"
-CHKSUMS="sha256::ee0eb0d7d7bdf696ac9471b19ff3bea3240d63b6cb8a134bf632054af8665d90"
+CHKSUMS="sha256::2f6d56c13fc1a64c534f500788fb482936ce547b343ed90c67de1f2bce0cfa7e"
 CHKUPDATE="anitya::id=9525"


### PR DESCRIPTION
Topic Description
-----------------

- rhythmbox: update to 3.4.7

Package(s) Affected
-------------------

- rhythmbox: 3.4.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit rhythmbox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
