### PR TITLE
curl: enable http3 support

### DIFF
--- a/app-web/curl/autobuild/build
+++ b/app-web/curl/autobuild/build
@@ -53,6 +53,8 @@ abinfo "Configuring cURL (GnuTLS, without versioned symbols) ..."
      --without-openssl \
      --with-gnutls \
      --without-nss \
+     --with-nghttp3 \
+     --with-ngtcp2 \
      --disable-versioned-symbols
 abinfo "Building cURL (GnuTLS, without versioned symbols) ..."
 make -C "$SRCDIR"/lib

--- a/app-web/curl/autobuild/defines
+++ b/app-web/curl/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=curl
 PKGSEC=utils
 PKGDEP="ca-certs openssl krb5 libidn2 libssh2 nghttp2 gnutls zlib \
-        rtmpdump brotli libpsl zstd e2fsprogs nss"
+        rtmpdump brotli libpsl zstd e2fsprogs nss nghttp3 ngtcp2"
 BUILDDEP="patchelf"
 PKGDES="A URL retrieval utility and library"
 PKGRECOM="ca-certs"

--- a/app-web/curl/spec
+++ b/app-web/curl/spec
@@ -1,4 +1,5 @@
 VER=8.8.0
+REL=1
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
 CHKSUMS="sha256::0f58bb95fc330c8a46eeb3df5701b0d90c9d9bfcc42bd1cd08791d12551d4400"
 CHKUPDATE="anitya::id=381"

--- a/runtime-cryptography/openssl/autobuild/build
+++ b/runtime-cryptography/openssl/autobuild/build
@@ -39,7 +39,7 @@ fi
 
 abinfo "Running Configure ..."
 "$SRCDIR"/Configure --prefix=/usr --openssldir=/etc/ssl --libdir=lib \
-            shared zlib ${ARCH_OPTS} \
+            shared zlib enable-tls1_3 ${ARCH_OPTS} \
             "-Wa,--noexecstack ${CPPFLAGS} ${CFLAGS}"
 
 abinfo "Building binaries ..."

--- a/runtime-cryptography/openssl/spec
+++ b/runtime-cryptography/openssl/spec
@@ -1,4 +1,5 @@
 VER=3.3.0
+REL=1
 SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
 CHKSUMS="sha256::53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02"
 CHKUPDATE="anitya::id=2566"

--- a/runtime-web/nghttp3/autobuild/defines
+++ b/runtime-web/nghttp3/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=nghttp3
+PKGSEC=libs
+PKGDEP="glibc"
+PKGDES="Next-generation HTTP/3 library"

--- a/runtime-web/nghttp3/spec
+++ b/runtime-web/nghttp3/spec
@@ -1,0 +1,4 @@
+VER=1.3.0
+SRCS="git::commit=tags/v$VER::https://github.com/ngtcp2/nghttp3"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=243323"

--- a/runtime-web/ngtcp2/autobuild/defines
+++ b/runtime-web/ngtcp2/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=ngtcp2
+PKGSEC=libs
+PKGDEP="glibc gnutls wolfssl brotli"
+PKGDES="QUIC library in C"
+
+AUTOTOOLS_AFTER="--with-gnutls \
+                 --with-wolfssl \
+                 --with-libbrotlienc \
+                 --with-libbrotlidec"

--- a/runtime-web/ngtcp2/spec
+++ b/runtime-web/ngtcp2/spec
@@ -1,0 +1,4 @@
+VER=1.5.0
+SRCS="git::commit=tags/v$VER::https://github.com/ngtcp2/ngtcp2"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=370247"


### PR DESCRIPTION
Topic Description
-----------------

- curl: enable http 3 via ngtcp2
- ngtcp2: new, 1.5.0
- nghttp3: new, 1.3.0
- openssl: enable tls 1.3

Package(s) Affected
-------------------

- curl: 8.8.0-1
- nghttp3: 1.3.0
- ngtcp2: 1.5.0
- openssl: 3.3.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl nghttp3 ngtcp2 curl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
