### PR TITLE
qbittorrent: update to 4.6.5

### DIFF
--- a/app-web/qbittorrent/spec
+++ b/app-web/qbittorrent/spec
@@ -1,4 +1,4 @@
-VER=4.6.4
+VER=4.6.5
 SRCS="tbl::https://sourceforge.net/projects/qbittorrent/files/qbittorrent/qbittorrent-$VER/qbittorrent-$VER.tar.xz"
-CHKSUMS="sha256::8e62a24145582a0b36e8268a2e574c5d61a396d28a7d02b899ca59f2244a8913"
+CHKSUMS="sha256::89cd79f58af4db346a9744e4bf61181c4bd40cce201b79a9f54ac31a8676e921"
 CHKUPDATE="anitya::id=6111"


### PR DESCRIPTION
Topic Description
-----------------

- qbittorrent: update to 4.6.5

Package(s) Affected
-------------------

- qbittorrent: 4.6.5
- qbittorrent-nox: 4.6.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit qbittorrent
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
