### PR TITLE
libinput: update to 1.26.0

### DIFF
--- a/runtime-devices/libinput/spec
+++ b/runtime-devices/libinput/spec
@@ -1,4 +1,4 @@
-VER=1.24.0
+VER=1.26.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/libinput/libinput"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5781"


### PR DESCRIPTION
Topic Description
-----------------

- libinput: update to 1.26.0
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- libinput: 1.26.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libinput
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
