### PR TITLE
deploykit survey 20240611

### DIFF
--- a/app-admin/deploykit-backend/spec
+++ b/app-admin/deploykit-backend/spec
@@ -1,4 +1,4 @@
-VER=0.3.0
+VER=0.4.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-backend/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371972"

--- a/app-admin/deploykit-gui/spec
+++ b/app-admin/deploykit-gui/spec
@@ -1,7 +1,7 @@
-VER=0.4.6
+VER=0.5.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-gui \
       tbl::https://github.com/AOSC-Dev/deploykit-gui/releases/download/v$VER/dist.tar.xz"
 CHKSUMS="SKIP \
-         sha256::fe0d434257cc5c0525218693fc0100e70b098ddd65ac07a1ba87dda64ecca160"
+         sha256::11c2a2183a4cdceef7188e1aff270087111382c0972fdffae1eb05568855829c"
 SUBDIR="deploykit-gui/src-tauri"
 CHKUPDATE="anitya::id=371971"


### PR DESCRIPTION
Topic Description
-----------------

- deploykit-gui: update to 0.5.0
- deploykit-backend: update to 0.4.0

Package(s) Affected
-------------------

- deploykit-backend: 0.4.0
- deploykit-gui: 0.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-backend deploykit-gui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
