### PR TITLE
grub (GRand Unified Bootloader): improve compliance with UEFI Specification

### DIFF
--- a/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,7 +1,7 @@
 From 2ec97c359ea87a2152e4076770c9ec8f7cbd225d Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:54 +0200
-Subject: [PATCH 01/21] Revert "templates: Properly disable the os-prober by
+Subject: [PATCH 01/22] Revert "templates: Properly disable the os-prober by
  default"
 
 This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.
@@ -71,5 +71,5 @@ index 656301eaf..30f27f15b 100644
  
  osx_entry() {
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,7 +1,7 @@
 From a3daa95d2769516586f7c38af93029663c9133a4 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:58 +0200
-Subject: [PATCH 02/21] Revert "templates: Disable the os-prober by default"
+Subject: [PATCH 02/22] Revert "templates: Disable the os-prober by default"
 
 This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
 ---
@@ -69,5 +69,5 @@ index 30f27f15b..f300e46fc 100644
  
  osx_entry() {
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
+++ b/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
@@ -1,7 +1,7 @@
 From 6bd3d7c7b9e643f6452e8dff6fcebc60d2c4d512 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 17:49:45 -0400
-Subject: [PATCH 03/21] Don't add '*' to highlighted row
+Subject: [PATCH 03/22] Don't add '*' to highlighted row
 
 It is already highlighted.
 ---
@@ -22,5 +22,5 @@ index b1321eb26..b147e0657 100644
    grub_print_ucs4_menu (unicode_title,
  			unicode_title + len,
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
+++ b/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
@@ -1,7 +1,7 @@
 From e5c241ea0ea922abbb2ecb8b3140518a6e2a03cd Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:08:23 -0400
-Subject: [PATCH 04/21] Fix border spacing now that we aren't displaying it
+Subject: [PATCH 04/22] Fix border spacing now that we aren't displaying it
 
 ---
  grub-core/normal/menu_text.c | 6 +++---
@@ -28,5 +28,5 @@ index b147e0657..e5960fd65 100644
    geo->timeout_lines = 2;
  
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
+++ b/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
@@ -1,7 +1,7 @@
 From 2b35e4db8d9f1f9cab8004e0761a28be960fbf7f Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:30:55 -0400
-Subject: [PATCH 05/21] Indent menu entries
+Subject: [PATCH 05/22] Indent menu entries
 
 ---
  grub-core/normal/menu_text.c | 3 ++-
@@ -22,5 +22,5 @@ index e5960fd65..fd1de05e3 100644
    grub_print_ucs4_menu (unicode_title,
  			unicode_title + len,
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
+++ b/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
@@ -1,7 +1,7 @@
 From d21e8096b9cc9eecfe6da4bb101c6d5d43cec3c5 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:59:36 -0400
-Subject: [PATCH 06/21] Fix margins
+Subject: [PATCH 06/22] Fix margins
 
 ---
  grub-core/normal/menu_text.c | 8 +++-----
@@ -33,5 +33,5 @@ index fd1de05e3..371524bf2 100644
      - geo->timeout_lines /* timeout */
      - 1 /* empty final line  */;
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
+++ b/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
@@ -1,7 +1,7 @@
 From 8ea6cc861054a03a1b437356a0b9b114a0d21adf Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Fri, 21 Jun 2013 14:44:08 -0400
-Subject: [PATCH 07/21] Use -2 instead of -1 for our right-hand margin, so
+Subject: [PATCH 07/22] Use -2 instead of -1 for our right-hand margin, so
  linewrapping works (#976643).
 
 Signed-off-by: Peter Jones <grub2-owner@fedoraproject.org>
@@ -23,5 +23,5 @@ index 371524bf2..f83f7ca54 100644
    geo->first_entry_y = 3; /* three empty lines*/
  
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
+++ b/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
@@ -1,7 +1,7 @@
 From 59c31c490870dd98bc6ca72862a97862bcef0c1b Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 14 Mar 2011 14:27:42 -0400
-Subject: [PATCH 08/21] Don't say "GNU/Linux" in generated menus.
+Subject: [PATCH 08/22] Don't say "GNU/Linux" in generated menus.
 
 ---
  util/grub.d/10_linux.in     | 4 ++--
@@ -41,5 +41,5 @@ index 94dd8be13..98ee5bc58 100644
  fi
  
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
@@ -1,7 +1,7 @@
 From 12e6fa95ada35a999b46adcbc35a34a73d178ebf Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 16:47:33 -0400
-Subject: [PATCH 09/21] Don't draw a border around the menu
+Subject: [PATCH 09/22] Don't draw a border around the menu
 
 It looks cleaner without it.
 ---
@@ -70,5 +70,5 @@ index f83f7ca54..982ef9100 100644
    grub_term_highlight_color = old_color_highlight;
    geo->timeout_y = geo->first_entry_y + geo->num_entries
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
+++ b/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
@@ -1,7 +1,7 @@
 From 8a14427edcdf93bc2c38822465d1082672bb9263 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 10:52:32 -0400
-Subject: [PATCH 10/21] Use the standard margin for the timeout string
+Subject: [PATCH 10/22] Use the standard margin for the timeout string
 
 So that it aligns with the other messages
 ---
@@ -39,5 +39,5 @@ index 982ef9100..986877454 100644
      }
  
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
+++ b/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
@@ -1,7 +1,7 @@
 From 5ff724e6a6e01cb6f03f5ce09d6cb01a44ad3d67 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:14 -0800
-Subject: [PATCH 11/21] grub-mkrescue: specify -iso-level 3
+Subject: [PATCH 11/22] grub-mkrescue: specify -iso-level 3
 
 This allows GRUB rescue ISOs to boot on LoongArch firmware.
 ---
@@ -22,5 +22,5 @@ index abcc1c2f5..27696e034 100644
    iso9660_dir = grub_util_make_temporary_dir ();
    grub_util_info ("temporary iso9660 dir is `%s'", iso9660_dir);
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
+++ b/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
@@ -1,7 +1,7 @@
 From b127120988f3d85ebc75c493eba08fc54c8b99dd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:42 -0800
-Subject: [PATCH 12/21] 10_linux: do not count intel-ucode image as a valid
+Subject: [PATCH 12/22] 10_linux: do not count intel-ucode image as a valid
  initrd
 
 ---
@@ -23,5 +23,5 @@ index c9bde9182..e896c0c1a 100644
      # no initrd or builtin initramfs, it can't work here.
      if [ "x${GRUB_DEVICE_PARTUUID}" = "x" ] \
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
+++ b/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
@@ -1,7 +1,7 @@
 From 42a8d6a924f700586328325eb3abe28c4055cc5e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:12:01 -0800
-Subject: [PATCH 13/21] util: add GRUB_COLOR_* variables
+Subject: [PATCH 13/22] util: add GRUB_COLOR_* variables
 
 ---
  util/grub-mkconfig.in    | 2 ++
@@ -41,5 +41,5 @@ index 6a316a5ba..6816e09d4 100644
  gfxterm=0;
  for x in ${GRUB_TERMINAL_INPUT} ${GRUB_TERMINAL_OUTPUT}; do
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
@@ -1,7 +1,7 @@
 From 5b839a619f7d871de5d6666bde4875c6a262edec Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:26:57 -0800
-Subject: [PATCH 14/21] grub-core: drop GRUB title from the menu
+Subject: [PATCH 14/22] grub-core: drop GRUB title from the menu
 
 We did not display it before, and it's really not very useful since we don't
 encourage reinstalling GRUB anyway.
@@ -23,5 +23,5 @@ index bd4431000..ca123caac 100644
      return;
  
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
+++ b/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
@@ -1,7 +1,7 @@
 From 4b607755f602b9844d637c7b7f48617600764238 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Jan 2024 13:58:02 +0800
-Subject: [PATCH 15/21] grub-install: add /efi to the candidate of the ESP
+Subject: [PATCH 15/22] grub-install: add /efi to the candidate of the ESP
  mountpoints
 
 ---
@@ -29,5 +29,5 @@ index 7dc5657bb..c5eef8ac6 100644
  	    The EFI System Partition may have been given directly using
  	    --root-directory.
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
+++ b/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
@@ -1,7 +1,7 @@
 From df48d64d21efa1e01ab1cf24f30e07e9efecf923 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 10 Nov 2023 10:57:02 +0800
-Subject: [PATCH 16/21] commands: add new command memsize
+Subject: [PATCH 16/22] commands: add new command memsize
 
 - This command traverses the entire GRUB memory map, adds the size of each
   region together. The result is the total amount of system memory
@@ -361,5 +361,5 @@ index 000000000..9c67971ac
 +  grub_unregister_extcmd (cmd);
 +}
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
+++ b/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
@@ -1,7 +1,7 @@
 From 0ded438a6ab7e8d11922582bf90a7dfa6b7fdcd4 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Mon, 10 Jul 2023 00:14:13 +0800
-Subject: [PATCH 17/21] commands: add new command 'pause'
+Subject: [PATCH 17/22] commands: add new command 'pause'
 
 - Simple enough, this command prints out a prompt, either pre-defined or
   user specified, and awaits a key stroke from the user.
@@ -88,5 +88,5 @@ index 000000000..39d193a17
 +  grub_unregister_extcmd (cmd);
 +}
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
+++ b/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
@@ -1,7 +1,7 @@
 From f608b5788b0e653ad9c2bbdcf078287f2a88d204 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 21:30:22 +0800
-Subject: [PATCH 18/21] normal: align countdown text with rest of the UI
+Subject: [PATCH 18/22] normal: align countdown text with rest of the UI
 
 And add an extra blank line above it.
 ---
@@ -23,5 +23,5 @@ index 986877454..584620a52 100644
    if (data->timeout_msg == TIMEOUT_TERSE
        || data->timeout_msg == TIMEOUT_TERSE_NO_MARGIN)
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
+++ b/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
@@ -1,7 +1,7 @@
 From 1e1ce61d967cc992b44c5206cc0cfe21cd44c7ff Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 22:21:55 +0800
-Subject: [PATCH 19/21] po: add patch to disable parallel execution
+Subject: [PATCH 19/22] po: add patch to disable parallel execution
 
 - `msgfilter' might fail while processing de.po to generate de_CH.po, if
   there are too many prarallel jobs.
@@ -76,5 +76,5 @@ index 000000000..0cef9fafe
 +2.39.1
 +
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
+++ b/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
@@ -1,7 +1,7 @@
-From 919557515accb7a58bcd91fd07cdf20f78afaf52 Mon Sep 17 00:00:00 2001
+From c56bae7448a2f2051ddac396b88d1ac36506bff9 Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Tue, 30 Jan 2024 14:41:10 +0800
-Subject: [PATCH 20/21] util/bash-completion: Load scripts on demand
+Subject: [PATCH 20/22] util/bash-completion: Load scripts on demand
 
 There are two system directories for bash-completion scripts. One is
 /usr/share/bash-completion/completions/ and the other is
@@ -856,5 +856,5 @@ index 000000000..6123d7b7c
 +# End:
 +# ex: ts=4 sw=4 et filetype=sh
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
+++ b/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
@@ -1,7 +1,7 @@
-From 08b69851db8922397fc18f8e0f636d1661ce66f1 Mon Sep 17 00:00:00 2001
+From 547487c4b84b7f9d83c1937e495ca144b208d728 Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Mon, 25 Mar 2024 10:11:34 +0800
-Subject: [PATCH 21/21] util/bash-completion: Fix for bash-completion 2.12
+Subject: [PATCH 21/22] util/bash-completion: Fix for bash-completion 2.12
 
 _split_longopt() was the bash-completion private API and removed since
 bash-completion 2.12. This commit initializes the bash-completion
@@ -185,5 +185,5 @@ index 4c88ee901..749a5d3cf 100644
      if [[ "$cur" == -* ]]; then
          __grubcomp "$(__grub_get_options_from_help)"
 -- 
-2.44.0
+2.45.1
 

--- a/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
+++ b/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
@@ -1,0 +1,112 @@
+From 8c4aa0755c5be97a350a3e5a6f51d8aefece8cb9 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 11 Jun 2024 22:40:24 +0800
+Subject: [PATCH 22/22] util/grub-mkrescue: use capitalised paths for removable
+ EFI images
+
+Per UEFI Specification, section 3.4.1.1:
+
+... If FilePathList[0] points to a device that supports the
+EFI_SIMPLE_FILE_SYSTEM_PROTOCOL, then the system firmware will attempt to boot
+from a removable media FilePathList[0] by adding a default file name in the
+form \EFI\BOOT\BOOT{machine type short-name}.EFI.
+
+While FAT < 32 filesystems are not case sensitive (which grub-mkrescue creates
+as a FAT12 image via mformat with a size of 2.88MiB), it seems that
+some of Loongson's LoongArch-based firmware (namely those found on their
+latest XA61200 boards) seems to treat this file system as case-sensitive. In
+this case, at least the XA61200 board seems incapable of identifying
+/efi/boot/bootloongarch64.efi as a valid removable EFI image.
+
+In any case, according to the UEFI Specification, all paths and image
+filenames should be capitalised (with the exception of BOOTx64.EFI, according
+to section 3.5.1.1, for some reason) to stay compliant. The Loongson case is
+only one example of users running into buggy firmware and unbootable GRUB
+ISO images.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ util/grub-mkrescue.c | 24 ++++++++++++------------
+ 1 file changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/util/grub-mkrescue.c b/util/grub-mkrescue.c
+index 27696e034..963b47117 100644
+--- a/util/grub-mkrescue.c
++++ b/util/grub-mkrescue.c
+@@ -769,8 +769,8 @@ main (int argc, char *argv[])
+       || source_dirs[GRUB_INSTALL_PLATFORM_RISCV64_EFI])
+     {
+       FILE *f;
+-      char *efidir_efi = grub_util_path_concat (2, iso9660_dir, "efi");
+-      char *efidir_efi_boot = grub_util_path_concat (3, iso9660_dir, "efi", "boot");
++      char *efidir_efi = grub_util_path_concat (2, iso9660_dir, "EFI");
++      char *efidir_efi_boot = grub_util_path_concat (3, iso9660_dir, "EFI", "BOOT");
+       char *imgname, *img32, *img64, *img_mac = NULL;
+       char *efiimgfat, *iso_uuid_file, *diskdir, *diskdir_uuid;
+       grub_install_mkdir_p (efidir_efi_boot);
+@@ -792,52 +792,52 @@ main (int argc, char *argv[])
+       free (diskdir_uuid);
+       free (diskdir);
+ 
+-      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootia64.efi");
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOTIA64.EFI");
+       make_image_fwdisk_abs (GRUB_INSTALL_PLATFORM_IA64_EFI, "ia64-efi", imgname);
+       free (imgname);
+ 
+       grub_install_push_module ("part_apple");
+-      img64 = grub_util_path_concat (2, efidir_efi_boot, "bootx64.efi");
++      img64 = grub_util_path_concat (2, efidir_efi_boot, "BOOTx64.EFI");
+       make_image_abs (GRUB_INSTALL_PLATFORM_X86_64_EFI, "x86_64-efi", img64);
+       grub_install_pop_module ();
+ 
+       grub_install_push_module ("part_apple");
+-      img32 = grub_util_path_concat (2, efidir_efi_boot, "bootia32.efi");
++      img32 = grub_util_path_concat (2, efidir_efi_boot, "BOOTIA32.EFI");
+       make_image_abs (GRUB_INSTALL_PLATFORM_I386_EFI, "i386-efi", img32);
+       grub_install_pop_module ();
+ 
+-      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootarm.efi");
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOTARM.EFI");
+       make_image_abs (GRUB_INSTALL_PLATFORM_ARM_EFI, "arm-efi", imgname);
+       free (imgname);
+ 
+-      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootaa64.efi");
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOTAA64.EFI");
+       make_image_abs (GRUB_INSTALL_PLATFORM_ARM64_EFI, "arm64-efi", imgname);
+       free (imgname);
+ 
+-      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootloongarch64.efi");
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOTLOONGARCH64.EFI");
+       make_image_fwdisk_abs (GRUB_INSTALL_PLATFORM_LOONGARCH64_EFI,
+ 			     "loongarch64-efi",
+ 			     imgname);
+       free (imgname);
+ 
+-      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootriscv32.efi");
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOTRISCV32.EFI");
+       make_image_abs (GRUB_INSTALL_PLATFORM_RISCV32_EFI, "riscv32-efi", imgname);
+       free (imgname);
+ 
+-      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootriscv64.efi");
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOTRISCV64.EFI");
+       make_image_abs (GRUB_INSTALL_PLATFORM_RISCV64_EFI, "riscv64-efi", imgname);
+       free (imgname);
+ 
+       if (source_dirs[GRUB_INSTALL_PLATFORM_I386_EFI])
+ 	{
+-	  imgname = grub_util_path_concat (2, efidir_efi_boot, "boot.efi");
++	  imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOT.EFI");
+ 	  /* For old macs. Suggested by Peter Jones.  */
+ 	  grub_install_copy_file (img32, imgname, 1);
+ 	}
+ 
+       if (source_dirs[GRUB_INSTALL_PLATFORM_I386_EFI]
+ 	  || source_dirs[GRUB_INSTALL_PLATFORM_X86_64_EFI])
+-	img_mac = grub_util_path_concat (2, core_services, "boot.efi");
++	img_mac = grub_util_path_concat (2, core_services, "BOOT.EFI");
+ 
+       if (source_dirs[GRUB_INSTALL_PLATFORM_I386_EFI]
+ 	  && source_dirs[GRUB_INSTALL_PLATFORM_X86_64_EFI])
+-- 
+2.45.1
+

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -5,7 +5,7 @@ __GRUBVER=2.12
 LINGUAS_VER=2.12-rc1
 
 VER=${__GRUBVER}+unifont${__UNIFONTVER}
-REL=1
+REL=2
 RETROFONTVER=20200402
 
 SRCS="git::commit=tags/grub-${__GRUBVER/\~/-};rename=grub-${__GRUBVER/\~/-}::https://git.savannah.gnu.org/git/grub.git \
@@ -75,11 +75,11 @@ CHKSUMS="SKIP \
          sha256::092ef544447397d45465b3ca42769bc408f4b46b4b81b672ea50e118cfdfd9c5 \
          sha256::28b5f8cc63bbbc24d8e5c98869bb7f4524ea4a00e0764755b9ebcdfc15f5e385 \
          sha256::06276d9b7bf95c154e8a5d919e18cec145a023175178009a4fffdaab2b5a1abc \
-         sha256::a8b274f46cf0664cafd9e9497a649d97c164c67064ce785353b5b2d0f7d9779b \
+         sha256::8cee974d75784316c331ca1c32ba34dcff3a2a43d9694cc4121212d4e8dedb6b \
          sha256::292376512add95aa03f81d1db015c92128620c187d2a37b80e20e4295a2b5a0c \
          sha256::ce6b47fdf0bc051961206c883e38918cc2c632472678e396124a5ba0c9e2df86 \
          sha256::7459a6d61dcbeebc510583722b1e5884cb6774c6d64088215fa784c8ffeba68a \
-         sha256::24de8a9768370ba816a6e126fba7de6582dcb7ef5e0383e707dcc56aedf87505 \
+         sha256::3f5f2920b1f732eb279767aff2b7da01344ade98d4bb8f7e498cf62e903caa10 \
          sha256::dce6aa0cb390f0c8ba7e20c7283b1d9bb11af4b6fe93746be969d215c3f6cd1e \
          sha256::3e1d1429b74e714f8d8959f9859c19d4598058aac51dfe9989ed72d5d458a029 \
          sha256::869dec48e46d265e48924730ab60bdf205ce6366a6e33fd775fc0bc84c9c1df8 \


### PR DESCRIPTION
Topic Description
-----------------

- grub: use capitalised path in grub-mkrescue
    Per UEFI Specification, section 3.4.1.1:
    ... If FilePathList[0] points to a device that supports the
    EFI_SIMPLE_FILE_SYSTEM_PROTOCOL, then the system firmware will attempt to boot
    from a removable media FilePathList[0] by adding a default file name in the
    form \EFI\BOOT\BOOT{machine type short-name}.EFI.
    While FAT < 32 filesystems are not case sensitive (which grub-mkrescue creates
    as a FAT12 image via mformat with a size of 2.88MiB), it seems that
    some of Loongson's LoongArch-based firmware (namely those found on their
    latest XA61200 boards) seems to treat this file system as case-sensitive. In
    this case, at least the XA61200 board seems incapable of identifying
    /efi/boot/bootloongarch64.efi as a valid removable EFI image.
    In any case, according to the UEFI Specification, all paths and image
    filenames should be capitalised (with the exception of BOOTx64.EFI, according
    to section 3.5.1.1, for some reason) to stay compliant. The Loongson case is
    only one example of users running into buggy firmware and unbootable GRUB
    ISO images.

Package(s) Affected
-------------------

- grub: 2:2.12+unifont15.1.04-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
