### PR TITLE
deno: update to 1.44.1

### DIFF
--- a/lang-js/deno/autobuild/beyond
+++ b/lang-js/deno/autobuild/beyond
@@ -1,7 +1,3 @@
 abinfo "Removing demo apps ..."
 rm -fv "$PKGDIR"/usr/bin/{hyper_hello,test_server}
 rm -fv "$PKGDIR"/usr/bin/libtest_*.so
-
-abinfo "Moving shared libraries ..."
-mkdir -p "$PKGDIR"/usr/lib/
-mv -v "$PKGDIR"/usr/bin/*.so "$PKGDIR"/usr/lib/

--- a/lang-js/deno/autobuild/defines
+++ b/lang-js/deno/autobuild/defines
@@ -2,12 +2,15 @@ PKGNAME=deno
 PKGSEC=devel
 PKGDES="A secure JavaScript and TypeScript runtime"
 PKGDEP="glibc gcc-runtime"
-BUILDDEP="python-2 rustc gn llvm ninja"
+PKGSUG="mesa"
+BUILDDEP="python-3 rustc gn llvm ninja"
 
 USECLANG=1
 NOLTO=1
 NOCARGOAUDIT=1
-FAIL_ARCH="!(amd64|arm64)"
-# LS3 workaround
+FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64)"
+# FIXME: missing ld.lld support
 USECLANG__LOONGSON3=0
+USECLANG__LOONGARCH64=0
+USECLANG__MIPS64R6EL=0
 ABSPLITDBG=0

--- a/lang-js/deno/autobuild/patches/0001-fix-v8-build.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0001-fix-v8-build.patch.deferred
@@ -1,17 +1,36 @@
---- a/v8/src/api/api.cc	2021-01-03 00:39:31.758124134 -0800
-+++ b/v8/src/api/api.cc	2021-01-03 00:25:20.259196126 -0800
-@@ -11172,12 +11172,11 @@
-     : pc(nullptr), sp(nullptr), fp(nullptr), lr(nullptr) {}
- RegisterState::~RegisterState() = default;
- 
--RegisterState::RegisterState(const RegisterState& other) V8_NOEXCEPT {
-+RegisterState::RegisterState(const RegisterState& other) {
-   *this = other;
+diff --git a/build/config/riscv.gni b/build/config/riscv.gni
+index b9597a0a9..07dacb943 100644
+--- a/build/config/riscv.gni
++++ b/build/config/riscv.gni
+@@ -1,19 +1,26 @@
+-# Copyright 2023 The Chromium Authors. All rights reserved.
++# Copyright 2023 The Chromium Authors
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+-
+ import("//build/config/v8_target_cpu.gni")
+-
+-if (current_cpu == "riscv64" || v8_current_cpu == "riscv64") {
++if (current_cpu == "riscv64" || v8_current_cpu == "riscv64" ||
++    current_cpu == "riscv32" || v8_current_cpu == "riscv32") {
+   declare_args() {
+     # RISCV Vector extension compilation flag.
+     riscv_use_rvv = false
+-
+     # RISCV Vector extension VELEN. Possible values are:
+     #   128
+     #   256
+     #   512
+     #   1024
+     riscv_rvv_vlen = 128
++    # RISCV profile compilation flag. Possible values are:
++    # rv64gc
++    # rvau22
++    riscv_profile = "rv64gc"
++    # RISCV B extension compilation flag.
++    # See https://github.com/riscv/riscv-bitmanip/blob/main/bitmanip/bitmanip.adoc#colophon
++    riscv_use_zba = false
++    riscv_use_zbb = false
++    riscv_use_zbs = false
+   }
  }
- 
--RegisterState& RegisterState::operator=(const RegisterState& other)
--    V8_NOEXCEPT {
-+RegisterState& RegisterState::operator=(const RegisterState& other) {
-   if (&other != this) {
-     pc = other.pc;
-     sp = other.sp;

--- a/lang-js/deno/autobuild/patches/0001-use-O3-optimization.patch
+++ b/lang-js/deno/autobuild/patches/0001-use-O3-optimization.patch
@@ -1,7 +1,7 @@
---- a/Cargo.toml	2021-05-26 18:54:20.722359063 -0700
-+++ b/Cargo.toml	2021-05-26 18:55:04.006149777 -0700
-@@ -24,9 +24,9 @@
- 
+--- a/Cargo.toml	2024-06-11 23:19:13.929010256 -0600
++++ b/Cargo.toml	2024-06-11 23:19:21.258108450 -0600
+@@ -207,9 +207,9 @@
+ # NB: the `bench` and `release` profiles must remain EXACTLY the same.
  [profile.release]
  codegen-units = 1
 -incremental = true
@@ -10,5 +10,5 @@
 -opt-level = 'z' # Optimize for size
 +opt-level = 3
  
- [profile.bench]
- codegen-units = 1
+ # Build release with debug symbols: cargo build --profile=release-with-debug
+ [profile.release-with-debug]

--- a/lang-js/deno/autobuild/prepare
+++ b/lang-js/deno/autobuild/prepare
@@ -1,7 +1,8 @@
 export V8_FROM_SOURCE=1
 export CLANG_BASE_PATH='/usr/'
-export GN_ARGS="no_inline_line_tables=false is_clang=false \
-                custom_toolchain=\"//build/toolchain/linux/unbundle:default\" host_toolchain=\"//build/toolchain/linux/unbundle:default\""
+export GN_ARGS="no_inline_line_tables=false is_clang=false v8_enable_pointer_compression=true treat_warnings_as_errors=false \
+                custom_toolchain=\"//build/toolchain/linux/unbundle:default\" host_toolchain=\"//build/toolchain/linux/unbundle:default\" \
+                v8_enable_pointer_compression=true"
 export GN="/usr/bin/gn"
 export AR=ar
 export NM=nm
@@ -11,16 +12,19 @@ export CXXFLAGS="$CXXFLAGS -fPIC"
 # ld.gold is very likely to crash on amd64/aarch64/ppc64, and lld is unusable on loongson3
 if [[ "${CROSS:-$ARCH}" != 'loongson3' ]]; then
    export AR=llvm-ar
+   export NM=llvm-nm
    export LDFLAGS="${LDFLAGS} -fuse-ld=lld"
    export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-fuse-ld=lld -Clink-arg=-Wl,-build-id=sha1 -Clinker=clang"
    export GN_ARGS="$GN_ARGS use_lld=true"
 else
+   export DISABLE_CLANG=1
    export GN_ARGS="$GN_ARGS use_lld=false use_gold=false"
 fi
 # workaround v8 issues
 abinfo "Fetching dependency sources ..."
+cargo update simd-json
 cargo fetch --locked
 PATCHES_DIR="$SRCDIR/autobuild/patches"
-TOPDIR=/root/.cargo/registry/src/github.com-1ecc6299db9ec823/v8-0.60.1
-mkdir -pv "$TOPDIR"/v8/tools/builtins-pgo/
-cp -v "$SRCDIR"/../*.profile "$TOPDIR"/v8/tools/builtins-pgo/
+pushd /root/.cargo/registry/src/index.crates.io-*/v8-0.92.0/
+ab_apply_patches "${PATCHES_DIR}"/*.deferred
+popd

--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,10 +1,5 @@
-VER=1.31.3
-V8_COMMIT=05fb6e97fc6c5fdd2e79e4f9a51c5bf0ca0ef991
-SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
-      file::rename=x64.profile::https://github.com/denoland/v8/raw/${V8_COMMIT}/tools/builtins-pgo/x64.profile \
-      file::rename=arm64.profile::https://github.com/denoland/v8/raw/${V8_COMMIT}/tools/builtins-pgo/arm64.profile"
-CHKSUMS="sha256::94746cfdc02333e7b47a1154784aeb2b1eef30b42ba285d77e62f92958442d30 \
-         sha256::0a42cb234c9d886813f5a162167e200acb3e27631ae6fedd59f604066cf711b5 \
-         sha256::e708ed32978313aec2ae866566d2152451438bfe3a0c03955099dd39d205671a"
+VER=1.44.1
+SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz"
+CHKSUMS="sha256::9fb530b85dc795310ee9e0c4edd2dbfa722d2489a3b7bebc9a4078c2d2f67594"
 SUBDIR=deno
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 1.44.1 ...
    * Enable build for all support architectures
    * Refresh patches and fix build on RISC-V 64 (backport a patch from
    Google Chromium tree to fix build tools not understanding RV64 flags)
    * Use autobuild4 builtin functions for applying deferred patches
    * Remove prebuilt profile data (not useful now)
    * Added a build workaround for non-amd64 and non-arm64 devices
    * Explicitly enable v8 pointer compression, as this is enforced by Deno
    now
    * Use python-3 instead of python-2 in BUILDDEP
    * LTO is kept disabled due to LLVM optimizations errors still
    unresolved

Package(s) Affected
-------------------

- deno: 1.44.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

