### PR TITLE
rhythmbox: enable daap

### DIFF
--- a/app-multimedia/rhythmbox/autobuild/defines
+++ b/app-multimedia/rhythmbox/autobuild/defines
@@ -9,12 +9,10 @@ BUILDDEP="brasero gobject-introspection grilo intltool itstool \
           libgpod libmtp vala lirc yelp-tools"
 PKGDES="An iTunes-like music player and manager"
 
-# FIXME: Can't open /usr/share/gtk-doc/html/cairo/index.sgml: No such file or directory at /bin/gtkdoc-rebase line 234.
-AUTOTOOLS_AFTER="--enable-daap \
-                 --enable-python \
-                 --enable-vala \
-                 --libexecdir=/usr/lib/rhythmbox \
-                 --disable-gtk-doc \
-                 PYTHON=/usr/bin/python3"
-ABSHADOW=0
+ABTYPE=meson
+
+# FIXME: Enable grilo after grilo built against libsoup3 - gnome 43
+MESON_AFTER="-Dgrilo=disabled \
+             -Ddaap=enabled"
+
 PKGQUIRK=gnome

--- a/app-multimedia/rhythmbox/spec
+++ b/app-multimedia/rhythmbox/spec
@@ -1,4 +1,5 @@
 VER=3.4.7
+REL=1
 SRCS="tbl::https://download.gnome.org/sources/rhythmbox/${VER:0:3}/rhythmbox-$VER.tar.xz"
 CHKSUMS="sha256::2f6d56c13fc1a64c534f500788fb482936ce547b343ed90c67de1f2bce0cfa7e"
 CHKUPDATE="anitya::id=9525"

--- a/desktop-gnome/grilo-plugins/spec
+++ b/desktop-gnome/grilo-plugins/spec
@@ -1,5 +1,5 @@
 VER=0.3.15
-REL=1
+REL=2
 SRCS="tbl::https://download.gnome.org/sources/grilo-plugins/${VER%.*}/grilo-plugins-$VER.tar.xz"
 CHKSUMS="sha256::8518c3d954f93095d955624a044ce16a7345532f811d299dbfa1e114cfebab33"
 CHKUPDATE="anitya::id=10929"

--- a/runtime-multimedia/libdmapsharing/autobuild/defines
+++ b/runtime-multimedia/libdmapsharing/autobuild/defines
@@ -9,3 +9,5 @@ AUTOTOOLS_AFTER="--with-mdns=avahi --enable-gtk-doc LIBS=-lm"
 
 RECONF=0
 ABSHADOW=0
+
+PKGBREAK="rhythmbox<=3.4.7 grilo-plugins<=0.3.15-1"

--- a/runtime-multimedia/libdmapsharing/spec
+++ b/runtime-multimedia/libdmapsharing/spec
@@ -1,5 +1,4 @@
-VER=2.9.41
-REL=2
+VER=3.9.13
 SRCS="tbl::https://www.flyn.org/projects/libdmapsharing/libdmapsharing-$VER.tar.gz"
-CHKSUMS='sha256::0c1fcf89e9de5489fd9a28c7b5cd7e2538fbcf187b1480c0b74d5a1785fb0154'
+CHKSUMS='sha256::3659f63f29e11d6d6ae78b53d7cc6be3f3adeff9c00c67cc50ad19c6af699f7a'
 CHKUPDATE="anitya::id=11641"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Enable daap plugin of rhythmbox

Package(s) Affected
-------------------

- rhythmbox
- libdmapsharing
- grilo-plugins

Security Update?
----------------
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

```
#buildit libdmapsharing:-pkgbreak grilo-plugins rhythmbox libdmapsharing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

Architectural progress for experimental ports does not impede on merging of this topic.

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
