### PR TITLE
LibSoup 3 Survey 20240612

### DIFF
--- a/app-admin/appdata-tools/autobuild/defines
+++ b/app-admin/appdata-tools/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=appdata-tools
 PKGSEC=utils
-PKGDEP="appstream-glib glib libsoup gdk-pixbuf"
+PKGDEP="appstream-glib glib gdk-pixbuf"
 BUILDDEP="intltool"
 PKGDES="Command line program designed to validate AppData descriptions for standards compliance and to the style guide"
 

--- a/app-admin/appdata-tools/spec
+++ b/app-admin/appdata-tools/spec
@@ -1,5 +1,5 @@
 VER=0.1.8
-REL=5
+REL=6
 SRCS="tbl::https://people.freedesktop.org/~hughsient/releases/appdata-tools-$VER.tar.xz"
 CHKSUMS="sha256::401583d27f0f91bbc03de09f53efd4bf86b20da37d6930ff7bff297d7f1e5461"
 CHKUPDATE="anitya::id=16058"

--- a/app-admin/appstream-glib/autobuild/defines
+++ b/app-admin/appstream-glib/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=appstream-glib
 PKGSEC=libs
-PKGDEP="gcab gdk-pixbuf gtk-3 json-glib libsoup libarchive yaml"
+PKGDEP="gcab gdk-pixbuf gtk-3 json-glib libarchive yaml"
 BUILDDEP="intltool gobject-introspection gperf gtk-doc meson"
 PKGDES="Provides GObjects and helper methods to make it easy to read and write AppStream metadata"
 
@@ -8,5 +8,5 @@ PKGREP=appdata-tools
 PKGPROV=appdata-tools
 ABTYPE=meson
 
-MESON_AFTER="-Drpm=false -Dstemmer=false -Dgtk-doc=true -Dman=true \
+MESON_AFTER="-Drpm=false -Dgtk-doc=true -Dman=true \
              -Dfonts=true -Dbuilder=true -Ddep11=true"

--- a/app-admin/appstream-glib/spec
+++ b/app-admin/appstream-glib/spec
@@ -1,5 +1,4 @@
-VER=0.7.18
-REL=2
+VER=0.8.3
 SRCS="tbl::https://github.com/hughsie/appstream-glib/archive/appstream_glib_${VER//./_}.tar.gz"
-CHKSUMS="sha256::73b8c10273c4cdd8f6de03c2524fedad64e34ccae08ee847dba804bb15461f6e"
+CHKSUMS="sha256::15ad7690b0132d883bd066699a7b55f6cef4c0f266d18d781ce5d8112fb4ee63"
 CHKUPDATE="anitya::id=14018"

--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=fwupd
 PKGSEC=admin
 PKGDEP="appstream-glib colord dbus elfutils gcab glib gnutls \
-        gpgme json-glib libarchive libgpg-error libgudev libgusb libsoup \
+        gpgme json-glib libarchive libgpg-error libgudev libgusb \
         libxmlb modemmanager pango pillow polkit pycairo pygobject-3 python-3 \
         shared-mime-info sqlite systemd tpm2-tss libjcat protobuf-c libftdi"
 PKGDEP__AMD64="${PKGDEP} flashrom thunderbolt-software-user-space"

--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,5 @@
 VER=1.9.20
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/hughsie/fwupd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5833"

--- a/app-admin/osinfo-db-tools/autobuild/defines
+++ b/app-admin/osinfo-db-tools/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=osinfo-db-tools
 PKGSEC=admin
-PKGDEP="libsoup libxslt json-glib"
+PKGDEP="libsoup-3 libxslt json-glib"
 BUILDDEP="intltool"
 PKGDES="Tools for managing the Operating System information database"

--- a/app-admin/osinfo-db-tools/spec
+++ b/app-admin/osinfo-db-tools/spec
@@ -1,4 +1,5 @@
 VER=1.10.0
+REL=1
 SRCS="tbl::https://releases.pagure.org/libosinfo/osinfo-db-tools-${VER}.tar.xz"
 CHKSUMS="sha256::802cdd53b416706ea5844f046ddcfb658c1b4906b9f940c79ac7abc50981ca68"
 CHKUPDATE="anitya::id=226782"

--- a/app-creativity/darktable/autobuild/defines
+++ b/app-creativity/darktable/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=darktable
 PKGSEC=graphics
 PKGDEP="colord-gtk dbus-glib exiv2 flickcurl graphicsmagick gtk-3 \
         json-glib lcms2 lensfun libglade libgphoto2 libjpeg-turbo \
-        librsvg libsecret libsoup libtiff libwebp iso-codes\
+        librsvg libsecret libtiff libwebp iso-codes\
         libxslt openexr openjpeg pugixml sdl sqlite libosmgpsmap \
         libcl jasper gmic lua-5.4 libheif libavif portmidi \
         libcamera"

--- a/app-creativity/darktable/spec
+++ b/app-creativity/darktable/spec
@@ -1,5 +1,5 @@
 VER=4.6.1
-REL=1
+REL=2
 SRCS="git::commit=tags/release-$VER::https://github.com/darktable-org/darktable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=392"

--- a/app-devel/flatpak-builder/autobuild/defines
+++ b/app-devel/flatpak-builder/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=flatpak-builder
 PKGSEC=devel
-PKGDEP="flatpak libsoup"
+PKGDEP="flatpak"
 BUILDDEP="docbook-xsl"
 PKGDES="A tool for building flatpaks from sources"

--- a/app-devel/flatpak-builder/spec
+++ b/app-devel/flatpak-builder/spec
@@ -1,4 +1,5 @@
 VER=1.4.3
+REL=1
 SRCS="tbl::https://github.com/flatpak/flatpak-builder/releases/download/$VER/flatpak-builder-$VER.tar.xz"
 CHKSUMS="sha256::d8e264e939922cd25a80e0dc795e6ce9e249d1c33738a564f6fe5ca7816beade"
 CHKUPDATE="anitya::id=16046"

--- a/app-multimedia/rhythmbox/autobuild/defines
+++ b/app-multimedia/rhythmbox/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=rhythmbox
 PKGSEC=gnome
 PKGDEP="dconf desktop-file-utils gst-plugins-base-1-0 gst-plugins-good-1-0 \
-        json-glib libnotify libpeas libsoup media-player-info pygobject-3 \
+        json-glib libnotify libpeas libsoup-3 media-player-info pygobject-3 \
         tdb totem-pl-parser webkit2gtk libdmapsharing libgpod check libgudev"
 PKGSUG="brasero grilo-plugins gst-libav-1-0 gst-plugins-bad-1-0 \
           gst-plugins-ugly-1-0 gvfs libgpod libmtp mako lirc"
@@ -11,8 +11,6 @@ PKGDES="An iTunes-like music player and manager"
 
 ABTYPE=meson
 
-# FIXME: Enable grilo after grilo built against libsoup3 - gnome 43
-MESON_AFTER="-Dgrilo=disabled \
-             -Ddaap=enabled"
+MESON_AFTER="-Ddaap=enabled"
 
 PKGQUIRK=gnome

--- a/app-multimedia/rhythmbox/spec
+++ b/app-multimedia/rhythmbox/spec
@@ -1,5 +1,5 @@
 VER=3.4.7
-REL=1
+REL=2
 SRCS="tbl::https://download.gnome.org/sources/rhythmbox/${VER:0:3}/rhythmbox-$VER.tar.xz"
 CHKSUMS="sha256::2f6d56c13fc1a64c534f500788fb482936ce547b343ed90c67de1f2bce0cfa7e"
 CHKUPDATE="anitya::id=9525"

--- a/desktop-gnome/geocode-glib/autobuild/defines
+++ b/desktop-gnome/geocode-glib/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=geocode-glib
 PKGSEC=gnome
-PKGDEP="glib json-glib libsoup"
+PKGDEP="glib json-glib libsoup-3"
 BUILDDEP="gobject-introspection gtk-doc intltool"
 PKGDES="GLib interface to the Geocode helper library"
 
@@ -8,4 +8,4 @@ ABTYPE=meson
 MESON_AFTER="-Denable-installed-tests=false \
              -Denable-introspection=true \
              -Denable-gtk-doc=true \
-             -Dsoup2=true"
+             -Dsoup2=false"

--- a/desktop-gnome/geocode-glib/spec
+++ b/desktop-gnome/geocode-glib/spec
@@ -1,4 +1,5 @@
 VER=3.26.4
+REL=1
 SRCS="tbl::https://download.gnome.org/sources/geocode-glib/${VER:0:4}/geocode-glib-$VER.tar.xz"
 CHKSUMS="sha256::2d9a6826d158470449a173871221596da0f83ebdcff98b90c7049089056a37aa"
 CHKUPDATE="anitya::id=13123"

--- a/desktop-gnome/grilo-plugins/autobuild/defines
+++ b/desktop-gnome/grilo-plugins/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=grilo-plugins
 PKGSEC=gnome
 PKGDEP="dleyna-server gom grilo libdmapsharing libgdata libmediaart \
-        lua-5.3 tracker tracker-miners"
+        lua-5.3 tracker tracker-miners libsoup-3"
 BUILDDEP="gperf intltool itstool"
 PKGDES="Plugins for Grilo"
 
@@ -18,7 +18,7 @@ MESON_AFTER="-Denable-bookmarks=yes \
              -Denable-lua-factory=yes \
              -Denable-magnatune=yes \
              -Denable-metadata-store=yes \
-             -Denable-opensubtitles=yes \
+             -Denable-opensubtitles=no \
              -Denable-optical-media=yes \
              -Denable-podcasts=yes \
              -Denable-raitv=yes \
@@ -27,6 +27,6 @@ MESON_AFTER="-Denable-bookmarks=yes \
              -Denable-tmdb=yes \
              -Denable-tracker=no \
              -Denable-tracker3=yes \
-             -Denable-youtube=yes \
+             -Denable-youtube=no \
              -Dgoa=enabled \
              -Dhelp=yes"

--- a/desktop-gnome/grilo-plugins/spec
+++ b/desktop-gnome/grilo-plugins/spec
@@ -1,5 +1,4 @@
-VER=0.3.15
-REL=2
+VER=0.3.16
 SRCS="tbl::https://download.gnome.org/sources/grilo-plugins/${VER%.*}/grilo-plugins-$VER.tar.xz"
-CHKSUMS="sha256::8518c3d954f93095d955624a044ce16a7345532f811d299dbfa1e114cfebab33"
+CHKSUMS="sha256::fe6f4dbe586c6b8ba2406394e202f22d009d642a96eb3a54f32f6a21d084cdcb"
 CHKUPDATE="anitya::id=10929"

--- a/desktop-gnome/grilo/autobuild/defines
+++ b/desktop-gnome/grilo/autobuild/defines
@@ -1,15 +1,14 @@
 PKGNAME=grilo
 PKGSEC=gnome
-PKGDEP="gtk-3 libxml2 libsoup liboauth totem-pl-parser check lua-5.3"
+PKGDEP="gtk-3 libxml2 libsoup-3 liboauth totem-pl-parser check lua-5.3"
 PKGSUG="grilo-plugins"
 BUILDDEP="gtk-doc intltool vala vim gobject-introspection"
 PKGDES="Framework that provides access to various sources of multimedia content"
 
-# FIXME: Switch to libsoup-3 with GNOME 43.
 MESON_AFTER="-Denable-grl-net=true \
              -Denable-grl-pls=true \
              -Denable-gtk-doc=true \
              -Denable-introspection=true \
              -Denable-test-ui=false \
              -Denable-vala=true \
-             -Dsoup3=false"
+             -Dsoup3=true"

--- a/desktop-gnome/grilo/spec
+++ b/desktop-gnome/grilo/spec
@@ -1,4 +1,4 @@
-VER=0.3.15
+VER=0.3.16
 SRCS="https://download.gnome.org/sources/grilo/${VER%.*}/grilo-$VER.tar.xz"
-CHKSUMS="sha256::f352acf73665669934270636fede66b52da6801fe20f638c4048ab2678577b2d"
+CHKSUMS="sha256::884580e8c5ece280df23aa63ff5234b7d48988a404df7d6bfccd1e77b473bd96"
 CHKUPDATE="anitya::id=10928"

--- a/desktop-gnome/gupnp/autobuild/defines
+++ b/desktop-gnome/gupnp/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gupnp
 PKGSEC=libs
-PKGDEP="gssdp util-linux python-2"
+PKGDEP="gssdp util-linux libsoup-3"
 BUILDDEP="gobject-introspection gtk-doc vala"
 PKGDES="An object-oriented UPNP framework"
 

--- a/desktop-gnome/gupnp/spec
+++ b/desktop-gnome/gupnp/spec
@@ -1,4 +1,4 @@
-VER=1.2.4
+VER=1.6.6
 SRCS="tbl::https://download.gnome.org/sources/gupnp/${VER:0:3}/gupnp-$VER.tar.xz"
-CHKSUMS="sha256::f7a0307ea51f5e44d1b832f493dd9045444a3a4e211ef85dfd9aa5dd6eaea7d1"
+CHKSUMS="sha256::c9dc50e8c78b3792d1b0e6c5c5f52c93e9345d3dae2891e311a993a574f5a04f"
 CHKUPDATE="anitya::id=1281"

--- a/runtime-network/gssdp/autobuild/defines
+++ b/runtime-network/gssdp/autobuild/defines
@@ -1,8 +1,14 @@
 PKGNAME=gssdp
 PKGSEC=libs
-PKGDEP="libsoup gtk-3"
+PKGDEP="libsoup-3 gtk-4"
 BUILDDEP="gobject-introspection vala gtk-doc"
+BUILDDEP__AMD64="${BUILDDEP} pandoc"
+BUILDDEP__ARM64="${BUILDDEP} pandoc"
 PKGDES="A GObject-based API for handling resource discovery and announcement over SSDP"
+
+MESON_AFTER="-Dmanpages=false"
+MESON_AFTER__AMD64="-Dmanpages=true"
+MESON_AFTER__ARM64="-Dmanpages=true"
 
 PKGBREAK="dleyna-renderer<=0.6.0 dleyna-server<=0.6.0 \
           gupnp-igd<=0.2.5 gupnp<=1.0.4 rygel<=0.36.2-1"

--- a/runtime-network/gssdp/spec
+++ b/runtime-network/gssdp/spec
@@ -1,4 +1,4 @@
-VER=1.2.3
+VER=1.6.3
 SRCS="tbl::https://download.gnome.org/sources/gssdp/${VER:0:3}/gssdp-$VER.tar.xz"
-CHKSUMS="sha256::a263dcb6730e3b3dc4bbbff80cf3fab4cd364021981d419db6dd5a8e148aa7e8"
+CHKSUMS="sha256::2fedb5afdb22cf14d5498a39a773ca89788a250fcf70118783df821e1f3f3446"
 CHKUPDATE="anitya::id=1262"

--- a/runtime-web/rest/autobuild/defines
+++ b/runtime-web/rest/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME=rest
 PKGSEC=libs
-PKGDEP="glib libxml2 libsoup"
-BUILDDEP="gtk-doc gobject-introspection vim"
+PKGDEP="glib libxml2 libsoup-3 libadwaita gtksourceview-5"
+BUILDDEP="gi-docgen gobject-introspection vim"
 PKGDES="A helper library for RESTful services"
 
-AUTOTOOLS_AFTER="--enable-gtk-doc"
 ABSHADOW=no

--- a/runtime-web/rest/spec
+++ b/runtime-web/rest/spec
@@ -1,4 +1,4 @@
-VER=0.8.1
+VER=0.9.1
 SRCS="tbl::https://download.gnome.org/sources/rest/${VER:0:3}/rest-$VER.tar.xz"
-CHKSUMS="sha256::0513aad38e5d3cedd4ae3c551634e3be1b9baaa79775e53b2dba9456f15b01c9"
+CHKSUMS="sha256::9266a5c10ece383e193dfb7ffb07b509cc1f51521ab8dad76af96ed14212c2e3"
 CHKUPDATE="anitya::id=4194"


### PR DESCRIPTION
Topic Description
-----------------

- gupnp: update to 1.6.6
- gssdp: update to 1.6.3
- geocode-glib: switch to libsoup-3
- rest: update to 0.9.1
    Switch to libsoup-3
- grilo-plugins: update to 0.3.16
    Switch to libsoup-3, disable plugins that required libsoup.
- libdmapsharing: update to 3.9.13
- grilo: update to 0.3.16
    Switch to libsoup-3
- darktable: drop unused dependency of libsoup
- osinfo-db-tools: build against libsoup-3

... and 3 more commits

Package(s) Affected
-------------------

- appdata-tools: 0.1.8-6
- appstream-glib: 0.8.3
- darktable: 1:4.6.1-2
- fwupd: 1.9.20-1
- geocode-glib: 3.26.4-1
- grilo: 0.3.16
- grilo-plugins: 0.3.16
- gssdp: 1.6.3
- gupnp: 1.6.6
- libdmapsharing: 3.9.13
- osinfo-db-tools: 1.10.0-1
- rest: 0.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit appstream-glib appdata-tools fwupd osinfo-db-tools darktable grilo libdmapsharing grilo-plugins rest geocode-glib gssdp gupnp flatpak-builder rhythmbox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
