### PR TITLE
xkeyboard-config: update to 2.42

### DIFF
--- a/runtime-display/xkeyboard-config/spec
+++ b/runtime-display/xkeyboard-config/spec
@@ -1,4 +1,4 @@
-VER=2.40
+VER=2.42
 SRCS="tbl::https://xorg.freedesktop.org/archive/individual/data/xkeyboard-config/xkeyboard-config-$VER.tar.xz"
-CHKSUMS="sha256::7a3dba1bec7dc7191432da021242d17c9cf6c89690e6c57b0de048ff8c9d2ae3"
+CHKSUMS="sha256::a6b06ebfc1f01fc505f2f05f265f95f67cc8873a54dd247e3c2d754b8f7e0807"
 CHKUPDATE="anitya::id=5191"


### PR DESCRIPTION
Topic Description
-----------------

- xkeyboard-config: update to 2.42
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- xkeyboard-config: 2.42

Security Update?
----------------

No

Build Order
-----------

```
#buildit xkeyboard-config
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
