### PR TITLE
brltty: backport fix in python binding

### DIFF
--- a/app-a11y/brltty/autobuild/patches/0001-brlapi-Fix-python-crash-on-connection-error.patch
+++ b/app-a11y/brltty/autobuild/patches/0001-brlapi-Fix-python-crash-on-connection-error.patch
@@ -1,0 +1,45 @@
+From e6707d5e094dc36db4319ce4d052a6ad568a5d26 Mon Sep 17 00:00:00 2001
+From: Samuel Thibault <samuel.thibault@ens-lyon.org>
+Date: Tue, 15 Aug 2023 16:29:13 +0200
+Subject: [PATCH] brlapi: Fix python crash on connection error
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+From Lukáš Tyrychtr:
+“
+Cython 3.0 started using the new Python object finalization APIs from PEP 442
+”
+
+This means that __del__ gets called even when raising an exception from
+__init__, while it was not before. To cope with both behaviors, we can
+set self.h to NULL to determine whether it still exists or not.
+
+Thanks Lukáš Tyrychtr for the investigation and patch draft!
+---
+ Bindings/Python/brlapi.pyx | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/Bindings/Python/brlapi.pyx b/Bindings/Python/brlapi.pyx
+index 0136895eaf..af62cc9be0 100644
+--- a/Bindings/Python/brlapi.pyx
++++ b/Bindings/Python/brlapi.pyx
+@@ -453,6 +453,7 @@ cdef class Connection:
+ 		c_brlapi.brlapi_protocolExceptionInit(self.h)
+ 		if self.fd == -1:
+ 			c_brlapi.free(self.h)
++			self.h = NULL
+ 			raise ConnectionError(self.settings.host, self.settings.auth)
+ 
+ 	def closeConnection(self):
+@@ -465,7 +466,8 @@ cdef class Connection:
+ 		"""Release resources used by the connection"""
+ 		if self.fd != -1:
+ 			c_brlapi.brlapi__closeConnection(self.h)
+-		c_brlapi.free(self.h)
++		if self.h != NULL:
++			c_brlapi.free(self.h)
+ 
+ 	property host:
+ 		"""To get authorized to connect, libbrlapi has to tell the BrlAPI server a secret key, for security reasons. This is the path to the file which holds it; it will hence have to be readable by the application."""
+

--- a/app-a11y/brltty/spec
+++ b/app-a11y/brltty/spec
@@ -1,5 +1,5 @@
 VER=6.6
-REL=1
+REL=2
 SRCS="tbl::http://mielke.cc/brltty/archive/brltty-$VER.tar.gz"
 CHKSUMS="sha256::13e8f699bf144ee1b1e8f9003add3785092f7f55ef107c4912e3c14f6ccca4fc"
 CHKUPDATE="anitya::id=220"


### PR DESCRIPTION
Topic Description
-----------------

- brltty: backport fix in python binding
    See
    https://discourse.gnome.org/t/psa-for-distros-brltty-should-be-built-using-cython-0-29-x-not-cython-3/16715
    for discussions.

Package(s) Affected
-------------------

- brltty: 6.6-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit brltty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
