### PR TITLE
discord: update to 0.0.56

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,5 +1,5 @@
-VER=0.0.55
+VER=0.0.56
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::afc6901ccb80b916566d67fae6651f903617f8e6868f6321e4b3538a319e4f9d"
+CHKSUMS="sha256::1e976cbf35ad078028a995dfecb574279d3f3900ec6202bc6e44351c6beeec47"
 SUBDIR=.
 CHKUPDATE="anitya::id=372593"


### PR DESCRIPTION
Topic Description
-----------------

- discord: update to 0.0.56
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- discord: 0.0.56

Security Update?
----------------

No

Build Order
-----------

```
#buildit discord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
