### PR TITLE
yelp-xsl: update to 42.1

### DIFF
--- a/desktop-gnome/yelp-xsl/spec
+++ b/desktop-gnome/yelp-xsl/spec
@@ -1,4 +1,4 @@
-VER=42.0
+VER=42.1
 SRCS="https://download.gnome.org/sources/yelp-xsl/${VER%.*}/yelp-xsl-$VER.tar.xz"
-CHKSUMS="sha256::29b273cc0bd16efb6e983443803f1e9fdc03511e5c4ff6348fd30a604d4dc846"
+CHKSUMS="sha256::238be150b1653080ce139971330fd36d3a26595e0d6a040a2c030bf3d2005bcd"
 CHKUPDATE="anitya::id=13164"


### PR DESCRIPTION
Topic Description
-----------------

- yelp-xsl: update to 42.1
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- yelp-xsl: 42.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit yelp-xsl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
