### PR TITLE
yelp-tools: update to 42.1

### DIFF
--- a/desktop-gnome/yelp-tools/spec
+++ b/desktop-gnome/yelp-tools/spec
@@ -1,4 +1,4 @@
-VER=42.0
+VER=42.1
 SRCS="https://download.gnome.org/sources/yelp-tools/${VER%.*}/yelp-tools-$VER.tar.xz"
-CHKSUMS="sha256::2cd43063ffa7262df15dd8d379aa3ea3999d42661f07563f4802daa1149f7df4"
+CHKSUMS="sha256::3e496a4020d4145b99fd508a25fa09336a503a4e8900028421e72c6a4b11f905"
 CHKUPDATE="anitya::id=8420"


### PR DESCRIPTION
Topic Description
-----------------

- yelp-tools: update to 42.1
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- yelp-tools: 42.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit yelp-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
