### PR TITLE
libgee: update to 0.20.6

### DIFF
--- a/desktop-gnome/libgee/spec
+++ b/desktop-gnome/libgee/spec
@@ -1,4 +1,4 @@
-VER=0.20.5
+VER=0.20.6
 SRCS="tbl::https://download.gnome.org/sources/libgee/${VER:0:4}/libgee-$VER.tar.xz"
-CHKSUMS="sha256::31863a8957d5a727f9067495cabf0a0889fa5d3d44626e54094331188d5c1518"
+CHKSUMS="sha256::1bf834f5e10d60cc6124d74ed3c1dd38da646787fbf7872220b8b4068e476d4d"
 CHKUPDATE="anitya::id=1625"


### PR DESCRIPTION
Topic Description
-----------------

- libgee: update to 0.20.6
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- libgee: 0.20.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgee
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
