### PR TITLE
colord-gtk: update to 0.3.1

### DIFF
--- a/desktop-gnome/colord-gtk/spec
+++ b/desktop-gnome/colord-gtk/spec
@@ -1,4 +1,4 @@
-VER=0.3.0
+VER=0.3.1
 SRCS="tbl::https://www.freedesktop.org/software/colord/releases/colord-gtk-$VER.tar.xz"
-CHKSUMS="sha256::b9466656d66d9a6ffbc2dd04fa91c8f6af516bf9efaacb69744eec0f56f3c1d0"
+CHKSUMS="sha256::c176b889b75630a17f4e3d7ef24c09a3e12368e633496087459c8b53ac3a122d"
 CHKUPDATE="anitya::id=331"


### PR DESCRIPTION
Topic Description
-----------------

- colord-gtk: update to 0.3.1
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- colord-gtk: 0.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit colord-gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
