### PR TITLE
libhandy: update to 1.8.3

### DIFF
--- a/desktop-gnome/libhandy/spec
+++ b/desktop-gnome/libhandy/spec
@@ -1,4 +1,4 @@
-VER=1.6.3
+VER=1.8.3
 SRCS="https://download.gnome.org/sources/libhandy/${VER:0:3}/libhandy-$VER.tar.xz"
-CHKSUMS="sha256::47788bd35804ebd33cb09911e975344c84359e0b6d9520afd1c821eba8ba77ff"
+CHKSUMS="sha256::05b497229073ff557f10b326e074c5066f8743a302d4820ab97bcb5cd2dab087"
 CHKUPDATE="anitya::id=114486"


### PR DESCRIPTION
Topic Description
-----------------

- libhandy: update to 1.8.3
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- libhandy: 1.8.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libhandy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
