### PR TITLE
superslicer: update to 2.5.59.12

### DIFF
--- a/app-creativity/superslicer/spec
+++ b/app-creativity/superslicer/spec
@@ -1,4 +1,4 @@
-VER=2.5.59.11
+VER=2.5.59.12
 SRCS="git::commit=tags/${VER}::https://github.com/supermerill/SuperSlicer.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370825"


### PR DESCRIPTION
Topic Description
-----------------

- superslicer: update to 2.5.59.12
    Co-authored-by: Icenowy Zheng (@Icenowy) <uwu@icenowy.me>

Package(s) Affected
-------------------

- superslicer: 2.5.59.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit superslicer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
