### PR TITLE
ipset,iptables: schedule iptables loading service before network-pre.target

### DIFF
--- a/app-network/ipset/autobuild/overrides/usr/lib/systemd/system/ipset.service
+++ b/app-network/ipset/autobuild/overrides/usr/lib/systemd/system/ipset.service
@@ -1,7 +1,11 @@
 [Unit]
 Description=Loading IP Sets
-Before=network-pre.target iptables.service ip6tables.service
-Wants=network-pre.target
+DefaultDependencies=no
+Wants=network-pre.target systemd-modules-load.service local-fs.target
+Before=network-pre.target iptables.service ip6tables.service shutdown.target
+After=systemd-modules-load.service local-fs.target
+Conflicts=shutdown.target
+ConditionPathExists=/etc/ipset.conf
 
 [Service]
 Type=oneshot

--- a/app-network/ipset/spec
+++ b/app-network/ipset/spec
@@ -1,4 +1,5 @@
 VER=7.1
+REL=1
 SRCS="tbl::http://ipset.netfilter.org/ipset-$VER.tar.bz2"
 CHKSUMS="sha256::7b5eb3b93205c20cdc39e3fc8b6e5f7bb214bf79a7c0c00729dd4a31ce16adc4"
 CHKUPDATE="anitya::id=1393"

--- a/app-network/iptables/autobuild/overrides/usr/lib/systemd/system/ip6tables.service
+++ b/app-network/iptables/autobuild/overrides/usr/lib/systemd/system/ip6tables.service
@@ -1,5 +1,11 @@
 [Unit]
 Description=IPv6 Packet Filtering Framework
+DefaultDependencies=no
+Wants=network-pre.target systemd-modules-load.service local-fs.target
+Before=network-pre.target shutdown.target
+After=systemd-modules-load.service local-fs.target
+Conflicts=shutdown.target
+ConditionPathExists=/etc/iptables/ip6tables.rules
 
 [Service]
 Type=oneshot
@@ -10,4 +16,3 @@ RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target
-

--- a/app-network/iptables/autobuild/overrides/usr/lib/systemd/system/iptables.service
+++ b/app-network/iptables/autobuild/overrides/usr/lib/systemd/system/iptables.service
@@ -1,5 +1,11 @@
 [Unit]
 Description=Packet Filtering Framework
+DefaultDependencies=no
+Wants=network-pre.target systemd-modules-load.service local-fs.target
+Before=network-pre.target shutdown.target
+After=systemd-modules-load.service local-fs.target
+Conflicts=shutdown.target
+ConditionPathExists=/etc/iptables/iptables.rules
 
 [Service]
 Type=oneshot

--- a/app-network/iptables/spec
+++ b/app-network/iptables/spec
@@ -1,5 +1,5 @@
 VER=1.8.8
-REL=2
+REL=3
 SRCS="https://netfilter.org/projects/iptables/files/iptables-$VER.tar.bz2"
 CHKSUMS="sha256::71c75889dc710676631553eb1511da0177bbaaf1b551265b912d236c3f51859f"
 CHKUPDATE="anitya::id=1394"


### PR DESCRIPTION
Topic Description
-----------------

- ipset,iptables: schedule iptables loading service before network-pre.target

Package(s) Affected
-------------------

- ipset: 7.1-1
- iptables: 1:1.8.8-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit iptables ipset
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
