### PR TITLE
autobuild4: update to 4.3.1 (set correct runtime data path)

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.2.2
+VER=4.3.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/runtime-devices/tpm2-tss/spec
+++ b/runtime-devices/tpm2-tss/spec
@@ -1,4 +1,5 @@
 VER=4.1.3
+REL=1
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/tpm2-software/tpm2-tss"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12683"


### PR DESCRIPTION
Topic Description
-----------------

- tpm2-tss: bump REL to correct the runtime data path
    The default runtime data path was /var/run which is not allowed. Bump
    REL after the autobuild4 update, which sets the correct runtime data
    path to /run.
- autobuild4: update to 4.3.1

Package(s) Affected
-------------------

- autobuild4: 4.3.1
- tpm2-tss: 4.1.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 tpm2-tss
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
