### PR TITLE
webkit2gtk: add webkitgtk-6.0 variant

### DIFF
--- a/runtime-web/webkit2gtk/autobuild/build
+++ b/runtime-web/webkit2gtk/autobuild/build
@@ -15,3 +15,20 @@ for i in ON OFF; do
     DESTDIR="$PKGDIR" \
         cmake --install .
 done
+
+mkdir -pv "$SRCDIR"/build_gtk4
+cd "$SRCDIR"/build_gtk4
+
+abinfo "Running CMake for WebKitGTK (GTK 4.x) ..."
+cmake "$SRCDIR" \
+    ${CMAKE_DEF[@]} ${CMAKE_AFTER[@]} \
+    -DUSE_SOUP2=OFF \
+    -DUSE_GTK4=ON \
+    -GNinja
+
+abinfo "Building WebKitGTK (GTK 4.x) ..."
+cmake --build .
+
+abinfo "Installing WebKitGTK (GTK 4.x) ..."
+DESTDIR="$PKGDIR" \
+    cmake --install .

--- a/runtime-web/webkit2gtk/autobuild/defines
+++ b/runtime-web/webkit2gtk/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=webkit2gtk
 PKGSEC=gnome
-PKGDEP="bubblewrap enchant-2 geoclue2 gstreamer gtk-3 hyphen icu libavif \
-        libjxl libmanette libnotify libsecret libsoup libwebp libxslt \
+PKGDEP="bubblewrap enchant-2 geoclue2 gstreamer gtk-3 gtk-4 hyphen icu \
+        libavif libjxl libmanette libnotify libsecret libsoup libwebp libxslt \
         openjpeg sqlite woff2 wpebackend-fdo xdg-dbus-proxy"
 BUILDDEP="gi-docgen gobject-introspection gperf gtk-doc ruby unifdef vim"
 PKGDES="A WebKit rendering engine port for GTK"

--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -4,4 +4,4 @@ CHKSUMS="sha256::523f42c8ff24832add17631f6eaafe8f9303afe316ef1a7e1844b952a7f7521
 CHKUPDATE="anitya::id=324014"
 ENVREQ__ARM64="total_mem_per_core=3"
 ENVREQ__LOONGARCH64="total_mem=100"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- webkit2gtk: add webkitgtk-6.0 variant
    Add GTK 4.x variant (6.0).

Package(s) Affected
-------------------

- webkit2gtk: 1:2.44.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit webkit2gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
