### PR TITLE
vscode: update to 1.90.0

### DIFF
--- a/app-editors/vscode/autobuild/prepare
+++ b/app-editors/vscode/autobuild/prepare
@@ -1,9 +1,9 @@
 abinfo "Setting SHA256SUM and PKGARCH ..."
 if [[ "$ARCH" = "amd64" ]]; then
-	export __SHA256SUM="${__SHA256SUM_AMD64}"
+	export __SHA256SUM="$(echo ${__SHA256SUM_AMD64} | cut -d ':' -f3)"
 	export __PKGARCH="x64"
 elif [[ "$ARCH" = "arm64" ]]; then
-	export __SHA256SUM="${__SHA256SUM_ARM64}"
+	export __SHA256SUM="$(echo ${__SHA256SUM_ARM64} | cut -d ':' -f3)"
 	export __PKGARCH="arm64"
 fi
 

--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,5 +1,8 @@
-VER=1.89.1
-__SHA256SUM_AMD64="69a61255ce164fac5563be656b226998d9d04d2f16b31259ff1876dec06184c1"
-__SHA256SUM_ARM64="4ad88e027bd9ca14b689159f3deab20911a5c7cfcffb2b1228e1670a50955b99"
-
-DUMMYSRC=1
+VER=1.90.0
+SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
+SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
+CHKSUMS__AMD64="sha256::8f4a3f4eb9e3da98eef709d3ceb4fb26504200f5d4961591e2279f375ea92063"
+CHKSUMS__ARM64="sha256::5de0d9a4d2cd57dffa57c87b5d3dea7435b2f82b69e4f01d1b6c7f6290d6e9f5"
+__SHA256SUM_AMD64="${CHKSUMS__AMD64}"
+__SHA256SUM_ARM64="${CHKSUMS__ARM64}"
+CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.90.0
    - Add `CHKUPDATE`

Package(s) Affected
-------------------

- vscode: 1.90.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
