### PR TITLE
ddrescueview: update to 0.4.5

### DIFF
--- a/app-utils/ddrescueview/autobuild/build
+++ b/app-utils/ddrescueview/autobuild/build
@@ -1,7 +1,8 @@
-lazbuild source/ddrescueview.lpi
+lazbuild --bm="GNU/Linux Release" "$SRCDIR"/source/ddrescueview.lpi
 
-install -Dm755 "$SRCDIR"/source/ddrescueview "$PKGDIR"/usr/bin/ddrescueview
-install -Dm644 "$SRCDIR"/resources/linux/ddrescueview.desktop \
-               "$PKGDIR"/usr/share/applications/ddrescueview.desktop
-install -Dm644 "$SRCDIR"/resources/linux/ddrescueview.xpm \
-               "$PKGDIR"/usr/share/pixmaps/ddrescueview.xpm
+install -Dvm755 "$SRCDIR"/source/ddrescueview "$PKGDIR"/usr/bin/ddrescueview
+install -dvm755 "$PKGDIR"/usr/share
+cp -r "$SRCDIR"/resources/linux/{applications,icons,man} "$PKGDIR"/usr/share
+
+install -Dvm644 "$SRCDIR"/changelog.txt "$PKGDIR"/usr/share/doc/ddrescueview/changelog.txt
+install -Dvm644 "$SRCDIR"/readme.txt "$PKGDIR"/usr/share/doc/ddrescueview/readme.txt

--- a/app-utils/ddrescueview/autobuild/defines
+++ b/app-utils/ddrescueview/autobuild/defines
@@ -3,3 +3,8 @@ PKGSEC=utils
 PKGDEP="gtk-2"
 BUILDDEP="lazarus"
 PKGDES="Graphical viewer for GNU ddrescue mapfiles"
+
+PKGEPOCH=1
+
+# FIXME: Lazarus is available for these architectures only.
+FAIL_ARCH="!(amd64|arm64|ppc64el)"

--- a/app-utils/ddrescueview/autobuild/patches/0001-enable-debug-symbol-generation.patch
+++ b/app-utils/ddrescueview/autobuild/patches/0001-enable-debug-symbol-generation.patch
@@ -1,0 +1,27 @@
+From 4721ed83927d1eda1d6fdc7aabc7c4fbd552eb92 Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Tue, 11 Jun 2024 18:02:38 +0800
+Subject: [PATCH] enable debug symbol generation
+
+---
+ source/ddrescueview.lpi | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/source/ddrescueview.lpi b/source/ddrescueview.lpi
+index baa8e34..cfd8e90 100644
+--- a/source/ddrescueview.lpi
++++ b/source/ddrescueview.lpi
+@@ -98,8 +98,8 @@
+           </CodeGeneration>
+           <Linking>
+             <Debugging>
+-              <GenerateDebugInfo Value="False"/>
+-              <StripSymbols Value="True"/>
++              <GenerateDebugInfo Value="True"/>
++              <StripSymbols Value="False"/>
+             </Debugging>
+             <LinkSmart Value="True"/>
+             <Options>
+-- 
+2.34.1
+

--- a/app-utils/ddrescueview/spec
+++ b/app-utils/ddrescueview/spec
@@ -1,5 +1,4 @@
-VER=1.23
-SRCS="tbl::https://sourceforge.net/projects/ddrescueview/files/Test%20builds/v0.4%20alpha%203/ddrescueview-source-0.4%7Ealpha3.tar.xz"
-CHKSUMS="sha256::32f15913573b0700caa3c0d757db40ce136d9103220e3d12f48eebd975940318"
-SUBDIR=.
+VER=0.4.5
+SRCS="tbl::https://sourceforge.net/projects/ddrescueview/files/Test%20builds/v$VER/ddrescueview-source-$VER.tar.xz"
+CHKSUMS="sha256::57383c394e62612ce2a799438b00c6e3c465c31f9ba940e077f624e2e7028465"
 CHKUPDATE="anitya::id=16892"


### PR DESCRIPTION
Topic Description
-----------------

- ddrescueview: add FAIL_ARCH from lazarus
- ddrescueview: enable debug symbol generation
- ddrescueview: (Arch Linux) fix build
- ddrescueview: update to 0.4.5
    Bump epoch to replace previously incorrect version number in stable.

Package(s) Affected
-------------------

- ddrescueview: 1:0.4.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit ddrescueview
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
