### PR TITLE
osdlyrics: update to 0.5.15

### DIFF
--- a/app-multimedia/osdlyrics/autobuild/defines
+++ b/app-multimedia/osdlyrics/autobuild/defines
@@ -3,5 +3,5 @@ PKGSEC=sound
 PKGDEP="gtk-2 dbus-glib curl libappindicator libnotify desktop-file-utils hicolor-icon-theme"
 BUILDDEP="intltool"
 PKGDES="Standalone lyrics fetcher/displayer"
-
+PKGEPOCH=1
 ABSHADOW=0

--- a/app-multimedia/osdlyrics/spec
+++ b/app-multimedia/osdlyrics/spec
@@ -1,5 +1,4 @@
-VER=20190407
-REL=1
-SRCS="git::commit=818bac81ea3454bd9754602888203e0786cfd50b::https://github.com/osdlyrics/osdlyrics"
+VER=0.5.15
+SRCS="git::commit=tags/$VER::https://github.com/osdlyrics/osdlyrics"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230945"


### PR DESCRIPTION
Topic Description
-----------------

- osdlyrics: update to 0.5.15

Package(s) Affected
-------------------

- osdlyrics: 1:0.5.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit osdlyrics
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
