### PR TITLE
libxdmcp: update to 1.1.5

### DIFF
--- a/runtime-display/libxdmcp/spec
+++ b/runtime-display/libxdmcp/spec
@@ -1,4 +1,4 @@
-VER=1.1.4
+VER=1.1.5
 SRCS="tbl::https://xorg.freedesktop.org/releases/individual/lib/libXdmcp-$VER.tar.xz"
-CHKSUMS="sha256::2dce5cc317f8f0b484ec347d87d81d552cdbebb178bd13c5d8193b6b7cd6ad00"
+CHKSUMS="sha256::d8a5222828c3adab70adf69a5583f1d32eb5ece04304f7f8392b6a353aa2228c"
 CHKUPDATE="anitya::id=1772"


### PR DESCRIPTION
Topic Description
-----------------

- libxdmcp: update to 1.1.5
    Co-authored-by: 温柔 (@xunpod)

Package(s) Affected
-------------------

- libxdmcp: 1.1.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxdmcp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
