### PR TITLE
streamlink: update to 6.7.4

### DIFF
--- a/app-multimedia/streamlink/spec
+++ b/app-multimedia/streamlink/spec
@@ -1,4 +1,4 @@
-VER=6.5.1
+VER=6.7.4
 SRCS="tbl::https://pypi.io/packages/source/s/streamlink/streamlink-$VER.tar.gz"
-CHKSUMS="sha256::207fb4ce99c35bfeb1b8f7c76b96cfcb4076ad6881c61eaea553c2ec13d97c57"
+CHKSUMS="sha256::9337537ab119fe77524a5d665aaecebbfb06e2cb8df28d1260d92876425751ce"
 CHKUPDATE="anitya::id=47101"


### PR DESCRIPTION
Topic Description
-----------------

- streamlink: update to 6.7.4
    Co-authored-by: 温柔 (@xunpod)

Package(s) Affected
-------------------

- streamlink: 6.7.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit streamlink
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
