### PR TITLE
vmpk: update to 0.9.0

### DIFF
--- a/app-creativity/drumstick/autobuild/defines
+++ b/app-creativity/drumstick/autobuild/defines
@@ -5,5 +5,4 @@ BUILDDEP="docbook-xsl doxygen graphviz"
 PKGSEC=sound
 
 ABTYPE=cmake
-CMAKE_AFTER="-DLIB_SUFFIX="
-AB_FLAGS_O3=1
+

--- a/app-creativity/drumstick/spec
+++ b/app-creativity/drumstick/spec
@@ -1,5 +1,4 @@
-VER=2.0.0
-REL=2
+VER=2.9.0
 SRCS="tbl::https://sourceforge.net/projects/drumstick/files/$VER/drumstick-$VER.tar.bz2"
-CHKSUMS="sha256::3d7405e3d34eade111eb4de09e509edfd1a610065a028f0ea424a63c07071221"
+CHKSUMS="sha256::a7437c11e0ad5443c21b33f0891c4f748d574f95d0e6970a6040c95db6184eb3"
 CHKUPDATE="anitya::id=468"

--- a/app-creativity/vmpk/spec
+++ b/app-creativity/vmpk/spec
@@ -1,5 +1,4 @@
-VER=0.8.0
-REL=2
+VER=0.9.0
 SRCS="tbl::https://sourceforge.net/projects/vmpk/files/vmpk/$VER/vmpk-$VER.tar.bz2"
-CHKSUMS="sha256::e390c156de29193c8bed5cad5509098eb9f29eae7f240c993e56eda5092bc472"
+CHKSUMS="sha256::c47ee14cbf1903075440acad729d8e0e02e4c98606183756676eeac1a1aebcd9"
 CHKUPDATE="anitya::id=5100"

--- a/app-network/iperf3/spec
+++ b/app-network/iperf3/spec
@@ -1,4 +1,4 @@
-VER=3.16
+VER=3.17.1
 SRCS="git::commit=tags/$VER::https://github.com/esnet/iperf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1389"


### PR DESCRIPTION
Topic Description
-----------------

- vmpk: update to 0.9.0
- drumstick: update to 2.9.0
- iperf3: update to 3.17.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- drumstick: 2.9.0
- vmpk: 0.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit drumstick vmpk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
