### PR TITLE
libmatroska: update to 1.7.1

### DIFF
--- a/runtime-multimedia/libebml/spec
+++ b/runtime-multimedia/libebml/spec
@@ -1,4 +1,4 @@
-VER=1.4.0
-SRCS="tbl::https://github.com/Matroska-Org/libebml/archive/release-$VER.tar.gz"
-CHKSUMS='sha256::5ad468d78d21dfcde2901320faad4122ade2a12ecb65ce557b5e15d46671cceb'
+VER=1.4.5
+SRCS="git::commit=tags/release-$VER::https://github.com/Matroska-Org/libebml"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7879"

--- a/runtime-multimedia/libmatroska/spec
+++ b/runtime-multimedia/libmatroska/spec
@@ -1,4 +1,4 @@
-VER=1.6.2
+VER=1.7.1
 SRCS="tbl::https://dl.matroska.org/downloads/libmatroska/libmatroska-$VER.tar.xz"
-CHKSUMS='sha256::bc4479aa8422ab07643df6a1fa5a19e4bed4badfd41ca77e081628620d1e1990'
+CHKSUMS='sha256::572a3033b8d93d48a6a858e514abce4b2f7a946fe1f02cbfeca39bfd703018b3'
 CHKUPDATE="anitya::id=1657"


### PR DESCRIPTION
Topic Description
-----------------

- libmatroska: update to 1.7.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libmatroska: 1.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libebml libmatroska
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
