### PR TITLE
perl-par-dist: update to 0.52

### DIFF
--- a/lang-perl/perl-par-dist/spec
+++ b/lang-perl/perl-par-dist/spec
@@ -1,5 +1,4 @@
-VER=0.49
+VER=0.52
 SRCS="tbl::https://cpan.metacpan.org/authors/id/R/RS/RSCHUPP/PAR-Dist-$VER.tar.gz"
-CHKSUMS='sha256::9e47220b594a27bd1750bcfa1d6f60a57ae670c68ce331895a79f08bac671e1d'
-REL=1
+CHKSUMS='sha256::cbe963009ea79d2454a85fe1794f425b7ddc1e86b71749c884db29d601ea8f88'
 CHKUPDATE="anitya::id=11961"


### PR DESCRIPTION
Topic Description
-----------------

- perl-par-dist: update to 0.52
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- perl-par-dist: 0.52

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-par-dist
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
