### PR TITLE
telepathy-mission-control: update to 5.16.6

### DIFF
--- a/runtime-web/telepathy-mission-control/spec
+++ b/runtime-web/telepathy-mission-control/spec
@@ -1,4 +1,4 @@
-VER=5.16.4
+VER=5.16.6
 SRCS="tbl::https://telepathy.freedesktop.org/releases/telepathy-mission-control/telepathy-mission-control-$VER.tar.gz"
-CHKSUMS="sha256::9769ddac7ad8aad21f6db854016792162b57e6fa0b0aed8d823d76a71fe7e6cb"
+CHKSUMS="sha256::2df8ae3995e919a7670e01aa3568215ef0777e34961ace1cac1c6477cb297a45"
 CHKUPDATE="anitya::id=4949"


### PR DESCRIPTION
Topic Description
-----------------

- telepathy-mission-control: update to 5.16.6
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- telepathy-mission-control: 5.16.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit telepathy-mission-control
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
