### PR TITLE
fwupd: update to 1.9.21

### DIFF
--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,4 @@
-VER=1.9.20
+VER=1.9.21
 SRCS="git::commit=tags/$VER::https://github.com/hughsie/fwupd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5833"


### PR DESCRIPTION
Topic Description
-----------------

- fwupd: update to 1.9.21
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- fwupd: 1.9.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
