### PR TITLE
vmpk: update to 0.9.0

### DIFF
--- a/app-creativity/drumstick/autobuild/defines
+++ b/app-creativity/drumstick/autobuild/defines
@@ -1,9 +1,8 @@
 PKGNAME=drumstick
 PKGDES="Qt5/C++ wrapper for ALSA sequencer"
-PKGDEP="qt-5 alsa-lib fluidsynth"
+PKGDEP="qt-5 alsa-lib fluidsynth sonivox"
 BUILDDEP="docbook-xsl doxygen graphviz"
 PKGSEC=sound
 
-ABTYPE=cmake
-CMAKE_AFTER="-DLIB_SUFFIX="
-AB_FLAGS_O3=1
+ABTYPE=cmakeninja
+CMAKE_AFTER="-DUSE_QT5=ON"

--- a/app-creativity/drumstick/spec
+++ b/app-creativity/drumstick/spec
@@ -1,5 +1,4 @@
-VER=2.0.0
-REL=2
+VER=2.9.0
 SRCS="tbl::https://sourceforge.net/projects/drumstick/files/$VER/drumstick-$VER.tar.bz2"
-CHKSUMS="sha256::3d7405e3d34eade111eb4de09e509edfd1a610065a028f0ea424a63c07071221"
+CHKSUMS="sha256::a7437c11e0ad5443c21b33f0891c4f748d574f95d0e6970a6040c95db6184eb3"
 CHKUPDATE="anitya::id=468"

--- a/app-creativity/drumstick/spec
+++ b/app-creativity/drumstick/spec
@@ -2,3 +2,4 @@ VER=2.9.0
 SRCS="tbl::https://sourceforge.net/projects/drumstick/files/$VER/drumstick-$VER.tar.bz2"
 CHKSUMS="sha256::a7437c11e0ad5443c21b33f0891c4f748d574f95d0e6970a6040c95db6184eb3"
 CHKUPDATE="anitya::id=468"
+REL=1

--- a/app-creativity/vmpk/autobuild/defines
+++ b/app-creativity/vmpk/autobuild/defines
@@ -5,4 +5,5 @@ PKGDEP="drumstick fluidsynth qt-5"
 BUILDDEP="docbook-xsl"
 PKGSEC="sound"
 
-ABTYPE=cmake
+ABTYPE=cmakeninja
+CMAKE_AFTER="-DUSE_QT5=ON"

--- a/app-creativity/vmpk/spec
+++ b/app-creativity/vmpk/spec
@@ -1,5 +1,4 @@
-VER=0.8.0
-REL=2
+VER=0.9.0
 SRCS="tbl::https://sourceforge.net/projects/vmpk/files/vmpk/$VER/vmpk-$VER.tar.bz2"
-CHKSUMS="sha256::e390c156de29193c8bed5cad5509098eb9f29eae7f240c993e56eda5092bc472"
+CHKSUMS="sha256::c47ee14cbf1903075440acad729d8e0e02e4c98606183756676eeac1a1aebcd9"
 CHKUPDATE="anitya::id=5100"

--- a/app-creativity/vmpk/spec
+++ b/app-creativity/vmpk/spec
@@ -2,3 +2,4 @@ VER=0.9.0
 SRCS="tbl::https://sourceforge.net/projects/vmpk/files/vmpk/$VER/vmpk-$VER.tar.bz2"
 CHKSUMS="sha256::c47ee14cbf1903075440acad729d8e0e02e4c98606183756676eeac1a1aebcd9"
 CHKUPDATE="anitya::id=5100"
+REL=1

--- a/app-multimedia/fluidsynth/autobuild/beyond
+++ b/app-multimedia/fluidsynth/autobuild/beyond
@@ -1,4 +1,7 @@
+abinfo "Installing user service ..."
 install -Dvm644 "$BLDDIR"/fluidsynth.service \
-        -t "$PKGDIR"/usr/lib/systemd/user/
+    -t "$PKGDIR"/usr/lib/systemd/user/
+
+abinfo "Installing configuration ..."
 install -Dvm644 "$BLDDIR"/fluidsynth.conf \
-        "$PKGDIR"/etc/conf.d/fluidsynth
+    "$PKGDIR"/etc/conf.d/fluidsynth

--- a/app-multimedia/fluidsynth/autobuild/defines
+++ b/app-multimedia/fluidsynth/autobuild/defines
@@ -9,6 +9,7 @@ CMAKE_AFTER="-DFLUID_DAEMON_ENV_FILE=/etc/conf.d/fluidsynth \
              -Denable-floats=ON \
              -Denable-lash=OFF \
              -DLIB_SUFFIX="
+
 PKGBREAK="audacious<=3.10 carla<=1:1.9.11-1 dosbox<=1:0.74-1 drumstick<=1.1.1 freepats2<=20170822 \
           gst-plugins-bad-1-0<=1.14.3-2 linthesia<=20161105 lmms<=2:1.2.0rc6 qsynth<=0.5.2-1 \
           scummvm<=2.0.0 sdl-mixer<=1.2.12-1 vlc<=3.0.4-5 vmpk<=0.7.0"

--- a/app-multimedia/fluidsynth/spec
+++ b/app-multimedia/fluidsynth/spec
@@ -1,5 +1,4 @@
-VER=2.0.5
-REL=1
-SRCS="tbl::https://github.com/FluidSynth/fluidsynth/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::69b244512883491e7e66b4d0151c61a0d6d867d4d2828c732563be0f78abcc51"
+VER=2.3.5
+SRCS="git::commit=tags/v$VER::https://github.com/FluidSynth/fluidsynth"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10437"

--- a/app-multimedia/fluidsynth/spec
+++ b/app-multimedia/fluidsynth/spec
@@ -2,3 +2,4 @@ VER=2.3.5
 SRCS="git::commit=tags/v$VER::https://github.com/FluidSynth/fluidsynth"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10437"
+REL=1

--- a/runtime-multimedia/sonivox/autobuild/defines
+++ b/runtime-multimedia/sonivox/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=sonivox
+PKGSEC=sound
+PKGDEP="glibc"
+PKGDES="SONiVOX EAS synthesizer library"
+
+CMAKE_AFTER="-DBUILD_SONIVOX_STATIC=OFF \
+             -DBUILD_SONIVOX_SHARED=ON"

--- a/runtime-multimedia/sonivox/spec
+++ b/runtime-multimedia/sonivox/spec
@@ -1,0 +1,4 @@
+VER=3.6.12
+SRCS="git::commit=tags/v$VER::https://github.com/pedrolcl/sonivox"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372896"

--- a/runtime-multimedia/sonivox/spec
+++ b/runtime-multimedia/sonivox/spec
@@ -2,3 +2,4 @@ VER=3.6.12
 SRCS="git::commit=tags/v$VER::https://github.com/pedrolcl/sonivox"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372896"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- vmpk: bump REL for topic Revision Marking Guidelines
- drumstick: bump REL for topic Revision Marking Guidelines
- sonivox: bump REL for topic Revision Marking Guidelines
- fluidsynth: bump REL for topic Revision Marking Guidelines
- vmpk: update to 0.9.0
- drumstick: update to 2.9.0
- sonivox: new, 3.6.12
- fluidsynth: update to 2.3.5
    Lint scripts in accordance with the Styling Manual.

Package(s) Affected
-------------------

- drumstick: 2.9.0-1
- fluidsynth: 2.3.5-1
- sonivox: 3.6.12-1
- vmpk: 0.9.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fluidsynth sonivox drumstick vmpk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
