### PR TITLE
palp: update to 2.21

### DIFF
--- a/app-scientific/palp/spec
+++ b/app-scientific/palp/spec
@@ -1,5 +1,4 @@
-VER=2.1
-REL=1
+VER=2.21
 SRCS="tbl::http://hep.itp.tuwien.ac.at/~kreuzer/CY/palp/palp-$VER.tar.gz"
-CHKSUMS="sha256::3a3b7c746f92a74b91d47879de2bc14b8fda9a1e503f7fbc0f2f02571815fae8"
+CHKSUMS="sha256::7e4a7bf219998a844c0bcce0a176e49d0743cb4b505a0e195329bf2ec196ddd7"
 CHKUPDATE="anitya::id=231484"


### PR DESCRIPTION
Topic Description
-----------------

- palp: update to 2.21

Package(s) Affected
-------------------

- palp: 2.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit palp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
