### PR TITLE
mupdf: update to 1.24.3

### DIFF
--- a/app-doc/mupdf/spec
+++ b/app-doc/mupdf/spec
@@ -1,5 +1,4 @@
-VER=1.18.0
-REL=2
-SRCS="git::commit=tags/$VER::git://git.ghostscript.com/mupdf.git"
+VER=1.24.3
+SRCS="git::commit=tags/$VER::https://github.com/ArtifexSoftware/mupdf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2034"


### PR DESCRIPTION
Topic Description
-----------------

- mupdf: update to 1.24.3

Package(s) Affected
-------------------

- mupdf: 1:1.24.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit mupdf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
