### PR TITLE
colordiff: update to 1.0.21

### DIFF
--- a/app-utils/colordiff/spec
+++ b/app-utils/colordiff/spec
@@ -1,4 +1,4 @@
-VER=1.0.20
+VER=1.0.21
 SRCS="tbl::https://www.colordiff.org/colordiff-$VER.tar.gz"
-CHKSUMS="sha256::e3b2017beeb9f619ebc3b15392f22810c882d1b657aab189623cffef351d7bcd"
+CHKSUMS="sha256::9b30f4257ef0f0806dea5a27c9ad8edc3f7999f05ddaff6f0627064dc927e615"
 CHKUPDATE="anitya::id=332"


### PR DESCRIPTION
Topic Description
-----------------

- colordiff: update to 1.0.21
    Co-authored-by: 温柔 (@xunpod)

Package(s) Affected
-------------------

- colordiff: 1.0.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit colordiff
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
