### PR TITLE
alsa-ucm-conf: update to 1.2.12

### DIFF
--- a/runtime-multimedia/alsa-ucm-conf/spec
+++ b/runtime-multimedia/alsa-ucm-conf/spec
@@ -1,4 +1,4 @@
-VER=1.2.5.1
+VER=1.2.12
 SRCS="tbl::https://www.alsa-project.org/files/pub/lib/alsa-ucm-conf-$VER.tar.bz2"
-CHKSUMS="sha256::5841a444166dcbf479db751303dbc3556f685085ac7e00f0c9e7755676195d97"
+CHKSUMS="sha256::168e7c0549b7bf8991092fa2bfb903631df779dc4c43ee8f4277fcb772d8c035"
 CHKUPDATE="anitya::id=141467"


### PR DESCRIPTION
Topic Description
-----------------

- alsa-ucm-conf: update to 1.2.12
    Co-authored-by: Icenowy Zheng (@Icenowy) <uwu@icenowy.me>

Package(s) Affected
-------------------

- alsa-ucm-conf: 1.2.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit alsa-ucm-conf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
