### PR TITLE
tor: update to 0.4.8.12

### DIFF
--- a/app-network/tor/autobuild/overrides/usr/lib/sysusers.d/tor.conf
+++ b/app-network/tor/autobuild/overrides/usr/lib/sysusers.d/tor.conf
@@ -1,0 +1,2 @@
+g tor 443
+u tor 443:443 "Tor daemon owner" /var/lib/tor /bin/false

--- a/app-network/tor/autobuild/postinst
+++ b/app-network/tor/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Creating user and group for tor ..."
+systemd-sysusers tor.conf

--- a/app-network/tor/autobuild/usergroup
+++ b/app-network/tor/autobuild/usergroup
@@ -1,2 +1,0 @@
-group tor 443
-user tor 443 tor /var/lib/tor "Tor daemon owner" /bin/false

--- a/app-network/tor/spec
+++ b/app-network/tor/spec
@@ -1,4 +1,4 @@
-VER=0.4.7.14
+VER=0.4.8.12
 SRCS="tbl::https://www.torproject.org/dist/tor-$VER.tar.gz"
-CHKSUMS="sha256::a5ac67f6466380fc05e8043d01c581e4e8a2b22fe09430013473e71065e65df8"
+CHKSUMS="sha256::ca7cc735d98e3747b58f2f3cc14f804dd789fa0fb333a84dcb6bd70adbb8c874"
 CHKUPDATE="anitya::id=4991"


### PR DESCRIPTION
Topic Description
-----------------

- tor: update to 0.4.8.12
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- tor: 0.4.8.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit tor
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
