### PR TITLE
libpeas: update to 1.36.0

### DIFF
--- a/desktop-gnome/libpeas/spec
+++ b/desktop-gnome/libpeas/spec
@@ -1,5 +1,4 @@
-VER=1.32.0
-REL=1
+VER=1.36.0
 SRCS="https://download.gnome.org/sources/libpeas/${VER:0:4}/libpeas-$VER.tar.xz"
-CHKSUMS="sha256::d625520fa02e8977029b246ae439bc218968965f1e82d612208b713f1dcc3d0e"
+CHKSUMS="sha256::297cb9c2cccd8e8617623d1a3e8415b4530b8e5a893e3527bbfd1edd13237b4c"
 CHKUPDATE="anitya::id=6871"


### PR DESCRIPTION
Topic Description
-----------------

- libpeas: update to 1.36.0

Package(s) Affected
-------------------

- libpeas: 1.36.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpeas
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
