### PR TITLE
json-glib: update to 1.8.0

### DIFF
--- a/runtime-common/json-glib/autobuild/defines
+++ b/runtime-common/json-glib/autobuild/defines
@@ -4,7 +4,8 @@ PKGDEP="glib"
 BUILDDEP="gi-docgen gobject-introspection gtk-doc vim meson ninja"
 PKGDES="JSON library built on GLib"
 
-ABTYPE=meson
 MESON_AFTER="-Dintrospection=enabled \
              -Dgtk_doc=enabled \
-             -Dman=true"
+             -Dman=true \
+             -Dtests=false \
+             -Dnls=enabled"

--- a/runtime-common/json-glib/spec
+++ b/runtime-common/json-glib/spec
@@ -1,4 +1,4 @@
-VER=1.6.6
+VER=1.8.0
 SRCS="tbl::https://download.gnome.org/sources/json-glib/${VER%.*}/json-glib-$VER.tar.xz"
-CHKSUMS="sha256::96ec98be7a91f6dde33636720e3da2ff6ecbb90e76ccaa49497f31a6855a490e"
+CHKSUMS="sha256::97ef5eb92ca811039ad50a65f06633f1aae64792789307be7170795d8b319454"
 CHKUPDATE="anitya::id=13144"


### PR DESCRIPTION
Topic Description
-----------------

- json-glib: update to 1.8.0

Package(s) Affected
-------------------

- json-glib: 1.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit json-glib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
