### PR TITLE
nokogiri: update to 1.16.6

### DIFF
--- a/lang-ruby/nokogiri/spec
+++ b/lang-ruby/nokogiri/spec
@@ -1,5 +1,5 @@
-VER=1.16.5
+VER=1.16.6
 SRCS="tbl::https://rubygems.org/downloads/nokogiri-$VER.gem"
-CHKSUMS="sha256::ec36162c68984fa0a90a5c4ae7ab7759460639e716cc1ce75f34c3cb54158ad2"
+CHKSUMS="sha256::935fe4dd67d4377f4a05002acb1ffbadbcae265ea8e7869fc40e3a8121f3e1ef"
 CHKUPDATE="anitya::id=4641"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- nokogiri: update to 1.16.6
    Co-authored-by: 温柔 (@xunpod)

Package(s) Affected
-------------------

- nokogiri: 1.16.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit nokogiri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
