### PR TITLE
kid3: update to 3.9.5

### DIFF
--- a/app-multimedia/kid3/spec
+++ b/app-multimedia/kid3/spec
@@ -1,5 +1,4 @@
-VER=3.8.3
-REL=2
-SRCS="tbl::https://downloads.sourceforge.net/kid3/kid3-$VER.tar.gz"
-CHKSUMS="sha256::6a1aa06d2f225f6d8a139cfd3c3d382f82170fa17196517690d28caaeb220c44"
+VER=3.9.5
+SRCS="git::commit=tags/v$VER::https://github.com/KDE/kid3"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1509"


### PR DESCRIPTION
Topic Description
-----------------

- kid3: update to 3.9.5
    Co-authored-by: 温柔 (@xunpod)

Package(s) Affected
-------------------

- kid3: 3.9.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit kid3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
