### PR TITLE
cmake: update to 3.29.6

### DIFF
--- a/app-devel/cmake/spec
+++ b/app-devel/cmake/spec
@@ -1,4 +1,4 @@
-VER=3.29.5
+VER=3.29.6
 SRCS="tbl::https://cmake.org/files/v${VER:0:4}/cmake-$VER.tar.gz"
-CHKSUMS="sha256::dd63da7d763c0db455ca232f2c443f5234fe0b11f8bd6958a81d29cc987dfd6e"
+CHKSUMS="sha256::1391313003b83d48e2ab115a8b525a557f78d8c1544618b48d1d90184a10f0af"
 CHKUPDATE="anitya::id=306"


### PR DESCRIPTION
Topic Description
-----------------

- cmake: update to 3.29.6
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- cmake: 3.29.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit cmake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
