### PR TITLE
flaky: new, 3.8.1

### DIFF
--- a/lang-python/flaky/autobuild/defines
+++ b/lang-python/flaky/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=flaky
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="wheel python-build python-installer"
+PKGDES="Plugin for nose or pytest that automatically reruns flaky tests"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/flaky/spec
+++ b/lang-python/flaky/spec
@@ -1,0 +1,4 @@
+VER=3.8.1
+SRCS="git::commit=tags/v$VER::https://github.com/box/flaky.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=19589"


### PR DESCRIPTION
Topic Description
-----------------

- flaky: new, 3.8.1

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit flaky
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
