### PR TITLE
upower (UPower): rework to remove installed tests

### DIFF
--- a/app-admin/upower/autobuild/defines
+++ b/app-admin/upower/autobuild/defines
@@ -17,11 +17,13 @@ MESON_AFTER="-Dman=true \
              -Dgtk-doc=true \
              -Dintrospection=enabled \
              -Dos_backend=linux \
-             -Didevice=enabled"
+             -Didevice=enabled \
+             -Dinstalled_tests=false"
 MESON_AFTER__RETRO=" \
              ${MESON_AFTER} \
              -Dgtk-doc=disabled \
-             -Didevice=disabled"
+             -Didevice=disabled \
+             -Dinstalled_tests=false"
 MESON_AFTER__ARMV4="${MESON_AFTER__RETRO}"
 MESON_AFTER__ARMV6HF="${MESON_AFTER__RETRO}"
 MESON_AFTER__ARMV7HF="${MESON_AFTER__RETRO}"

--- a/app-admin/upower/autobuild/patches/0001-build-Make-installation-of-tests-optional.patch
+++ b/app-admin/upower/autobuild/patches/0001-build-Make-installation-of-tests-optional.patch
@@ -1,0 +1,71 @@
+From f056d758240ea88d2c9b476054441888916e7c18 Mon Sep 17 00:00:00 2001
+From: Luciano Santos <luc14n0@opensuse.org>
+Date: Fri, 4 Aug 2023 22:21:20 -0300
+Subject: [PATCH] build: Make installation of tests optional
+
+Default to installing them, while letting people/distributors decide
+what they want.
+---
+ meson_options.txt |  4 ++++
+ src/meson.build   | 35 +++++++++++++++++++----------------
+ 2 files changed, 23 insertions(+), 16 deletions(-)
+
+diff --git a/meson_options.txt b/meson_options.txt
+index eec3659..ef3f03d 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -33,3 +33,7 @@ option('idevice',
+        type : 'feature',
+        value : 'auto',
+        description : 'Build with libimobiledevice')
++option('installed_tests',
++       type : 'boolean',
++       value : 'true',
++       description : 'Install integration tests')
+diff --git a/src/meson.build b/src/meson.build
+index f072328..0701a12 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -143,20 +143,23 @@ if os_backend == 'linux' and gobject_introspection.found()
+             )
+     endforeach
+ 
+-    install_data( [
+-        'linux/integration-test.py',
+-        'linux/output_checker.py',
+-      ],
+-      install_dir: get_option('prefix') / get_option('libexecdir') / 'upower'
+-    )
+-    install_subdir('linux/tests/',
+-      install_dir: get_option('prefix') / get_option('libexecdir') / 'upower'
+-    )
+-
+-    configure_file(
+-      input: 'upower-integration.test.in',
+-      output: 'upower-integration.test',
+-      install_dir: get_option('datadir') / 'installed-tests' / 'upower',
+-      configuration: cdata
+-    )
++    installed_tests = get_option('installed_tests')
++    if installed_tests
++        install_data( [
++            'linux/integration-test.py',
++            'linux/output_checker.py',
++          ],
++          install_dir: get_option('prefix') / get_option('libexecdir') / 'upower'
++        )
++        install_subdir('linux/tests/',
++          install_dir: get_option('prefix') / get_option('libexecdir') / 'upower'
++        )
++
++        configure_file(
++          input: 'upower-integration.test.in',
++          output: 'upower-integration.test',
++          install_dir: get_option('datadir') / 'installed-tests' / 'upower',
++          configuration: cdata
++        )
++    endif
+ endif
+-- 
+2.43.4
+

--- a/app-admin/upower/spec
+++ b/app-admin/upower/spec
@@ -1,4 +1,5 @@
 VER=1.90.4
+REL=1
 SRCS="tbl::https://gitlab.freedesktop.org/upower/upower/-/archive/v$VER/upower-v$VER.tar.gz"
 CHKSUMS="sha256::cd194dd278bd8d058b4728efd1d0a91cdf017378f025b558beb6f60a86af4781"
 CHKUPDATE="anitya::id=5056"


### PR DESCRIPTION
Topic Description
-----------------

- upower: do not install tests
    Ref: https://gitlab.freedesktop.org/upower/upower/-/merge_requests/202

Package(s) Affected
-------------------

- upower: 1.90.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit upower
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
