### PR TITLE
caddy: update to 2.8.4

### DIFF
--- a/app-web/caddy/spec
+++ b/app-web/caddy/spec
@@ -1,4 +1,4 @@
-VER=2.7.6
+VER=2.8.4
 SRCS="git::commit=tags/v$VER::https://github.com/caddyserver/dist"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15601"


### PR DESCRIPTION
Topic Description
-----------------

- caddy: update to 2.8.4
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- caddy: 2.8.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit caddy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
