### PR TITLE
PrismLauncher: fix Java version detection

### DIFF
--- a/app-games/prismlauncher/autobuild/patches/0001-javautils-detect-Java-paths-on-AOSC-OS.patch
+++ b/app-games/prismlauncher/autobuild/patches/0001-javautils-detect-Java-paths-on-AOSC-OS.patch
@@ -1,0 +1,40 @@
+From b1c44f27e590df54d921d72af7ae413e3ef37f6a Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Mon, 17 Jun 2024 22:41:46 -0700
+Subject: [PATCH] javautils: detect Java paths on AOSC OS
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ launcher/java/JavaUtils.cpp | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/launcher/java/JavaUtils.cpp b/launcher/java/JavaUtils.cpp
+index b12461f44..9eeabd8bb 100644
+--- a/launcher/java/JavaUtils.cpp
++++ b/launcher/java/JavaUtils.cpp
+@@ -377,7 +377,13 @@ QList<QString> JavaUtils::FindJavaPaths()
+         QDir dir(dirPath);
+         if (!dir.exists())
+             return;
+-        auto entries = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
++        QFileInfoList entries;
++        if (dirPath == "/usr/lib") {
++            QStringList javaDirs = { "java*" };
++            entries = dir.entryInfoList(javaDirs, QDir::Dirs | QDir::NoDotAndDotDot);
++        } else {
++            entries = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
++        }
+         for (auto& entry : entries) {
+             QString prefix;
+             prefix = entry.canonicalFilePath();
+@@ -399,6 +405,7 @@ QList<QString> JavaUtils::FindJavaPaths()
+     scanJavaDirs("/usr/lib/jvm");
+     scanJavaDirs("/usr/lib64/jvm");
+     scanJavaDirs("/usr/lib32/jvm");
++    scanJavaDirs("/usr/lib");
+     // javas stored in Prism Launcher's folder
+     scanJavaDirs("java");
+     // manually installed JDKs in /opt
+-- 
+2.45.2
+

--- a/app-games/prismlauncher/spec
+++ b/app-games/prismlauncher/spec
@@ -1,4 +1,5 @@
 VER=8.3
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/PrismLauncher/PrismLauncher"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301949"


### PR DESCRIPTION
Topic Description
-----------------

- prismlauncher: fix Java version detection
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- rustc: update to 1.79.0
    FIXME: Previous cross toolchain was built against dynamic LLVM by mistake.
    Revert to system binary bootstrap in the next update (from 1.79.0-0).

Package(s) Affected
-------------------

- prismlauncher: 8.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit prismlauncher
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
