### PR TITLE
numpy update to 2.0.0

### DIFF
--- a/lang-python/numpy/spec
+++ b/lang-python/numpy/spec
@@ -1,4 +1,4 @@
-VER=1.26.4
+VER=2.0.0
 SRCS="tbl::https://pypi.org/packages/source/n/numpy/numpy-$VER.tar.gz"
-CHKSUMS="sha256::2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"
+CHKSUMS="sha256::cf5d1c9e6837f8af9f92b6bd3e86d513cdc11f60fd62185cc49ec7d1aba34864"
 CHKUPDATE="anitya::id=41556"


### PR DESCRIPTION
Topic Description
-----------------

- numpy: update to 2.0.0

Package(s) Affected
-------------------

- numpy: 2.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit numpy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
