### PR TITLE
kvantum: update to 1.1.2

### DIFF
--- a/desktop-kde/kvantum/autobuild/build
+++ b/desktop-kde/kvantum/autobuild/build
@@ -1,14 +1,24 @@
 abinfo "Building Qt 5 support and manager ..."
-cmake -B "$BLDDIR"/build5 -S "$SRCDIR" \
-    -DCMAKE_INSTALL_PREFIX=/usr
+cmake \
+    -B "$BLDDIR"/build5 \
+    -S "$SRCDIR" \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DENABLE_QT5=ON \
+    -DWITHOUT_KF=OFF
 make -C "$BLDDIR"/build5
 
 abinfo "Building Qt 6 support ..."
-cmake -B "$BLDDIR"/build6 -S "$SRCDIR" \
+# FIXME: We are not shipping KF6 yet (2024/8/11).
+cmake \
+    -B "$BLDDIR"/build6 \
+    -S "$SRCDIR" \
     -DCMAKE_INSTALL_PREFIX=/usr \
-    -DENABLE_QT5=OFF
+    -DENABLE_QT5=OFF \
+    -DWITHOUT_KF=ON
 make -C "$BLDDIR"/build6
 
 abinfo "Installing Kvantum ..."
-DESTDIR="$PKGDIR" cmake --install "$BLDDIR"/build5
-DESTDIR="$PKGDIR" cmake --install "$BLDDIR"/build6
+DESTDIR="$PKGDIR" \
+    cmake install "$BLDDIR"/build5
+DESTDIR="$PKGDIR" \
+    cmake install "$BLDDIR"/build6

--- a/desktop-kde/kvantum/autobuild/defines
+++ b/desktop-kde/kvantum/autobuild/defines
@@ -1,6 +1,4 @@
 PKGNAME=kvantum
 PKGSEC=kde
-PKGDEP="qt-5 qt-6 kwindowsystem xorg-server"
-PKGDES="An SVG-based theme engine for Qt/KDE/LxQt"
-
-ABSHADOW=1
+PKGDEP="qt-5 qt-6 kwindowsystem"
+PKGDES="An SVG-based theme engine for Qt/KDE"

--- a/desktop-kde/kvantum/spec
+++ b/desktop-kde/kvantum/spec
@@ -1,5 +1,5 @@
-VER=1.0.10
+VER=1.1.2
 SRCS="tbl::https://github.com/tsujan/Kvantum/archive/V$VER.tar.gz"
-CHKSUMS="sha256::2ef368df6c54a3bde2097ed89341f188b6670d1b1f8d11bcb3a80138887aca12"
+CHKSUMS="sha256::e865e6b6a154bc009ac289866b067cf3e3ec228fafffa7d790ed09312a9420ac"
 CHKUPDATE="anitya::id=17749"
 SUBDIR="Kvantum-$VER/Kvantum"

--- a/desktop-kde/kvantum/spec
+++ b/desktop-kde/kvantum/spec
@@ -1,4 +1,5 @@
 VER=1.1.2
+REL=1
 SRCS="tbl::https://github.com/tsujan/Kvantum/archive/V$VER.tar.gz"
 CHKSUMS="sha256::e865e6b6a154bc009ac289866b067cf3e3ec228fafffa7d790ed09312a9420ac"
 CHKUPDATE="anitya::id=17749"


### PR DESCRIPTION
Topic Description
-----------------

- kvantum: bump REL for topic Revision Marking Guidelines
- kvantum: update to 1.1.2
    Disable Qt 6 support as it now requires KWindowSystem >= 6, which we are not
    yet ready to provide.
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- kvantum: 1.1.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit kvantum
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
