### PR TITLE
cmake: fix postinst script

### DIFF
--- a/app-devel/cmake/autobuild/build
+++ b/app-devel/cmake/autobuild/build
@@ -29,7 +29,7 @@ abinfo "Generating postinst script ..."
 MMVER="${PKGVER%.*}"
 cat << EOF > "$SRCDIR"/autobuild/postinst
 for i in 3.{1..${MMVER#*.}}; do
-        if [ -d /usr/share/cmake-\$i ]; then
+        if [ -d /usr/share/cmake-\$i ] && [ ! -L /usr/share/cmake-\$i ]; then
                 cp -rf /usr/share/cmake-\$i/* /usr/share/cmake/
                 rm -r /usr/share/cmake-\$i
         fi

--- a/app-devel/cmake/spec
+++ b/app-devel/cmake/spec
@@ -1,4 +1,5 @@
 VER=3.29.6
+REL=1
 SRCS="tbl::https://cmake.org/files/v${VER:0:4}/cmake-$VER.tar.gz"
 CHKSUMS="sha256::1391313003b83d48e2ab115a8b525a557f78d8c1544618b48d1d90184a10f0af"
 CHKUPDATE="anitya::id=306"


### PR DESCRIPTION
Topic Description
-----------------

- cmake: fix postinst script

Package(s) Affected
-------------------

- cmake: 3.29.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cmake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
