### PR TITLE
powerpc-utils: update to 1.3.12

### DIFF
--- a/app-admin/powerpc-utils/autobuild/defines
+++ b/app-admin/powerpc-utils/autobuild/defines
@@ -13,5 +13,3 @@ AUTOTOOLS_AFTER="--disable-werror \
 # FIXME: /usr/bin/install: cannot stat 'var/lib/powerpc-utils/smt.state':
 # No such file or directory
 ABSHADOW=0
-
-FAIL_ARCH="!(powerpc|ppc64|ppc64el)"

--- a/app-admin/powerpc-utils/spec
+++ b/app-admin/powerpc-utils/spec
@@ -1,5 +1,4 @@
-VER=1.3.10
-REL=2
-SRCS="tbl::https://github.com/nfont/powerpc-utils/archive/v$VER.tar.gz"
-CHKSUMS="sha256::d64d9016a3e63a1e44c6e0833742cf964ae6bb1c6a9c7f0c7c5748aa335dc3db"
+VER=1.3.12
+SRCS="git::commit=tags/v$VER::https://github.com/nfont/powerpc-utils"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10715"


### PR DESCRIPTION
Topic Description
-----------------

- powerpc-utils: update to 1.3.12

Package(s) Affected
-------------------

- powerpc-utils: 1.3.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit powerpc-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
