### PR TITLE
xa: update to 2.4.1

### DIFF
--- a/app-devel/xa/spec
+++ b/app-devel/xa/spec
@@ -1,5 +1,4 @@
-VER=2.4.0
-REL=1
+VER=2.4.1
 SRCS="tbl::http://www.floodgap.com/retrotech/xa/dists/xa-$VER.tar.gz"
-CHKSUMS="sha256::9e587a0ca8ff791009880bfa331f6ed36935e08ef9c123822ca175285f8c030c"
+CHKSUMS="sha256::63c12a6a32a8e364f34f049d8b2477f4656021418f08b8d6b462be0ed3be3ac3"
 CHKUPDATE="anitya::id=14146"


### PR DESCRIPTION
Topic Description
-----------------

- xa: update to 2.4.1
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- xa: 2.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
