### PR TITLE
fcron: fix sysusers.d, fcron.conf permissions, and EPERM

### DIFF
--- a/app-admin/fcron/autobuild/beyond
+++ b/app-admin/fcron/autobuild/beyond
@@ -22,3 +22,7 @@ ln -sv /usr/bin/fcrontab "$PKGDIR"/usr/bin/crontab
 
 abinfo "Moving /var/run => /run ..."
 rm -rv "$PKGDIR"/var/run
+
+abinfo "Correcting ownership and permissions on /etc/fcron/fcron.conf ..."
+chown -v root:fcron "$PKGDIR"/etc/fcron/fcron.conf
+chmod 0644 "$PKGDIR"/etc/fcron/fcron.conf

--- a/app-admin/fcron/autobuild/overrides/usr/lib/sysusers.d/fcron.conf
+++ b/app-admin/fcron/autobuild/overrides/usr/lib/sysusers.d/fcron.conf
@@ -1,2 +1,2 @@
 u fcron 33 - /var/spool/fcron
-g fcron
+g fcron 33

--- a/app-admin/fcron/autobuild/patch
+++ b/app-admin/fcron/autobuild/patch
@@ -1,2 +1,0 @@
-abinfo "Masking strip in Makefile.in ..."
-sed -i 's/install-staged strip/install-staged/g' Makefile.in

--- a/app-admin/fcron/autobuild/patches/0001-fix-set-effective-UID-after-setting-effective-GID-to.patch
+++ b/app-admin/fcron/autobuild/patches/0001-fix-set-effective-UID-after-setting-effective-GID-to.patch
@@ -1,0 +1,101 @@
+From 61078461a66bd96f5d3f9975303520f627f959bb Mon Sep 17 00:00:00 2001
+From: Cyan <cyan@cyano.uk>
+Date: Thu, 20 Jun 2024 14:05:22 +0800
+Subject: [PATCH 1/2] fix: set effective UID after setting effective GID to
+ prevent EPERM
+
+---
+ fcrontab.c |  6 +++---
+ subs.c     | 12 ++++++------
+ 2 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/fcrontab.c b/fcrontab.c
+index 10dc5b5..fe7ba02 100644
+--- a/fcrontab.c
++++ b/fcrontab.c
+@@ -175,10 +175,10 @@ xexit(int exit_val)
+ 
+ #ifdef HAVE_LIBPAM
+     /* we need those rights for pam to close properly */
+-    if (geteuid() != fcrontab_uid && seteuid(fcrontab_uid) != 0)
+-        die_e("could not change euid to %d", fcrontab_uid);
+     if (getegid() != fcrontab_gid && setegid(fcrontab_gid) != 0)
+         die_e("could not change egid to %d", fcrontab_gid);
++    if (geteuid() != fcrontab_uid && seteuid(fcrontab_uid) != 0)
++        die_e("could not change euid to %d", fcrontab_uid);
+     pam_setcred(pamh, PAM_DELETE_CRED | PAM_SILENT);
+     pam_end(pamh, pam_close_session(pamh, PAM_SILENT));
+ #endif
+@@ -1038,8 +1038,8 @@ main(int argc, char **argv)
+ #ifdef USE_SETE_ID
+     /* drop any privilege we may have: we will only get them back
+      * temporarily every time we need it. */
+-    seteuid_safe(useruid);
+     setegid_safe(usergid);
++    seteuid_safe(useruid);
+ #endif
+ 
+ #ifdef HAVE_LIBPAM
+diff --git a/subs.c b/subs.c
+index b5a29be..d96d9ef 100644
+--- a/subs.c
++++ b/subs.c
+@@ -109,8 +109,8 @@ open_as_user(const char *pathname, uid_t openuid, gid_t opengid, int flags, ...)
+         va_end(ap);
+     }
+ 
+-    seteuid_safe(openuid);
+     setegid_safe(opengid);
++    seteuid_safe(openuid);
+ 
+     if (flags & O_CREAT) {
+         fd = open(pathname, flags, mode);
+@@ -121,8 +121,8 @@ open_as_user(const char *pathname, uid_t openuid, gid_t opengid, int flags, ...)
+     saved_errno = errno;
+ 
+     /* change the effective uid/gid back to original values */
+-    seteuid_safe(orig_euid);
+     setegid_safe(orig_egid);
++    seteuid_safe(orig_euid);
+ 
+     /* if open() didn't fail make sure we opened a 'normal' file */
+     if (fd >= 0) {
+@@ -271,15 +271,15 @@ remove_as_user(const char *pathname, uid_t removeuid, gid_t removegid)
+     uid_t orig_euid = geteuid();
+     gid_t orig_egid = getegid();
+ 
+-    seteuid_safe(removeuid);
+     setegid_safe(removegid);
++    seteuid_safe(removeuid);
+ #endif                          /* def USE_SETE_ID */
+ 
+     rval = remove(pathname);
+ 
+ #ifdef USE_SETE_ID
+-    seteuid_safe(orig_euid);
+     setegid_safe(orig_egid);
++    seteuid_safe(orig_euid);
+ #endif                          /* def USE_SETE_ID */
+ 
+     return rval;
+@@ -295,15 +295,15 @@ rename_as_user(const char *oldpath, const char *newpath, uid_t renameuid,
+     uid_t orig_euid = geteuid();
+     gid_t orig_egid = getegid();
+ 
+-    seteuid_safe(renameuid);
+     setegid_safe(renamegid);
++    seteuid_safe(renameuid);
+ #endif                          /* def USE_SETE_ID */
+ 
+     rval = rename(oldpath, newpath);
+ 
+ #ifdef USE_SETE_ID
+-    seteuid_safe(orig_euid);
+     setegid_safe(orig_egid);
++    seteuid_safe(orig_euid);
+ #endif                          /* def USE_SETE_ID */
+ 
+     return rval;
+-- 
+2.45.2
+

--- a/app-admin/fcron/autobuild/patches/0002-fix-Makefile.in-do-not-strip-during-install-time.patch
+++ b/app-admin/fcron/autobuild/patches/0002-fix-Makefile.in-do-not-strip-during-install-time.patch
@@ -1,0 +1,34 @@
+From 2aecb0c49b4bd5ea05cc71ab817236475f2263cb Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.xyz>
+Date: Thu, 20 Jun 2024 15:10:41 +0800
+Subject: [PATCH 2/2] fix(Makefile.in): do not strip during install time
+
+---
+ Makefile.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 251445f..cbc942b 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -137,7 +137,7 @@ initscripts:
+ documentation:
+ 	$(MAKE) -C doc doc-if-none
+ 
+-install: install-staged strip perms 
++install: install-staged perms
+ ifeq ($(BOOTINSTALL), 1)
+ 	$(SRCDIR)/script/boot-install "$(INSTALL) -o $(ROOTNAME)" $(DESTSBIN) $(DEBUG) $(FCRONTABS) $(ANSWERALL) $(SRCDIR)
+ endif
+@@ -174,7 +174,7 @@ endif
+ 	$(MAKE) -C doc install-staged
+ 
+ 
+-perms: install-staged strip
++perms: install-staged
+ # Note : we don't use "chown user:group file" because some systems use ":"
+ #        and others "." as separator.
+ 	chown $(ROOTNAME) $(DESTDIR)$(DESTSBIN) 
+-- 
+2.45.2
+

--- a/app-admin/fcron/autobuild/postinst
+++ b/app-admin/fcron/autobuild/postinst
@@ -1,3 +1,8 @@
+# Note: Removing fcron user and group just to be safe, we made at mistake at
+# 3.3.1-0 by not specifying the GID.
+userdel fcron
+groupdel fcron
+
 echo "Creating user and group for fcron ..."
 systemd-sysusers fcron.conf
 

--- a/app-admin/fcron/spec
+++ b/app-admin/fcron/spec
@@ -1,4 +1,5 @@
 VER=3.3.1
+REL=1
 SRCS="git::commit=tags/ver${VER//./_}::https://github.com/yo8192/fcron"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=784"


### PR DESCRIPTION
Topic Description
-----------------

- fcron: fix sysuser and fcron.conf permissions
    - Pin fcron GID at 33 in sysusers.d as we did in autobuild/prepare.
    - Remove old fcron user and group to be safe.
    - Fix ownership and permissions on /etc/fcron/fcron.conf.
    - Fix EPERM while setting effective GID. [^1]
    - Track patches at AOSC-Tracking/fcron @ aosc/ver3_1_1.
    [^1]: GID may not be set after setting the UID, which results in an EPERM.
    However this is not observed on normal installation and Ciel containers.
    Co-authored-by: Cyan <cyan@cyano.uk>

Package(s) Affected
-------------------

- fcron: 3.3.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcron
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
