### PR TITLE
Upstream Version Marking Survey (June 2024)

### DIFF
--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -1,14 +1,17 @@
+UPSTREAM_VER=2.12
+# Note: For use inside autobuild/.
+# Note: 2.12-rc1+unifont15.1.04 => 2.12~rc1+unifont15.1.04
+__GRUB_VER=${UPSTREAM_VER/\-/~}
 __UNIFONTVER=15.1.04
-__GRUBVER=2.12
-# Maintainer note: Please check for translation updates each time updating GRUB at:
+# Note: Please check for translation updates each time updating GRUB at:
 # https://translationproject.org/domain/grub.html
 LINGUAS_VER=2.12-rc1
 
-VER=${__GRUBVER}+unifont${__UNIFONTVER}
+VER=${__GRUB_VER}+unifont${__UNIFONTVER}
 REL=3
 RETROFONTVER=20200402
 
-SRCS="git::commit=tags/grub-${__GRUBVER/\~/-};rename=grub-${__GRUBVER/\~/-}::https://git.savannah.gnu.org/git/grub.git \
+SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https://git.savannah.gnu.org/git/grub.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftp.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \
       tbl::https://repo.aosc.io/aosc-repacks/grub-fonts-$RETROFONTVER.tar.xz \
       file::rename=ast.po::https://translationproject.org/PO-files/ast/grub-$LINGUAS_VER.ast.po \

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -1,12 +1,12 @@
+UPSTREAM_VER=26.1.3
 # Find tini version at:
 #
 # https://github.com/moby/moby/blob/v$PKGVER/hack/dockerfile/install/tini.installer
 TINI_VER=0.19.0
-DOCKER_VER=26.1.3
 
-VER=${DOCKER_VER}+tini${TINI_VER}
-SRCS="git::commit=tags/v${DOCKER_VER};rename=cli::https://github.com/docker/cli \
-      git::commit=tags/v${DOCKER_VER};rename=moby::https://github.com/moby/moby \
+VER=${UPSTREAM_VER}+tini${TINI_VER}
+SRCS="git::commit=tags/v${UPSTREAM_VER};rename=cli::https://github.com/docker/cli \
+      git::commit=tags/v${UPSTREAM_VER};rename=moby::https://github.com/moby/moby \
       git::commit=tags/v${TINI_VER};rename=tini::https://github.com/krallin/tini"
 CHKSUMS="SKIP \
          SKIP \

--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,12 +1,13 @@
+UPSTREAM_VER=5.1.0
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile
-PODMAN_VER=5.1.0
 GVISOR_TAP_VSOCK_VER=0.7.3
-VER=${PODMAN_VER}+vsock${GVISOR_TAP_VSOCK_VER}
-SRCS="tbl::https://github.com/containers/podman/archive/v${PODMAN_VER}.tar.gz \
+
+VER=${UPSTREAM_VER}+vsock${GVISOR_TAP_VSOCK_VER}
+SRCS="tbl::https://github.com/containers/podman/archive/v${UPSTREAM_VER}.tar.gz \
       git::commit=tags/v${GVISOR_TAP_VSOCK_VER};rename=gvisor-tap-vsock::https://github.com/containers/gvisor-tap-vsock"
 CHKSUMS="sha256::e0687779c82b58422d458dc3776ffa7f79e1a04614a3f1a7ef93f7769bf8a8e6 \
          SKIP"
 CHKUPDATE="anitya::id=93284"
-SUBDIR="podman-$PODMAN_VER"
+SUBDIR="podman-$UPSTREAM_VER"

--- a/app-devel/cuda/spec
+++ b/app-devel/cuda/spec
@@ -1,10 +1,10 @@
-CUDA_VER=12.5.0
+UPSTREAM_VER=12.5.0
 MIN_DRIVER_VER=555.42.02
-VER=${CUDA_VER}+${MIN_DRIVER_VER}
+VER=${UPSTREAM_VER}+${MIN_DRIVER_VER}
 CHKUPDATE="anitya::id=13462"
 
-SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${VER/+/_}_linux.run"
+SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux.run"
 CHKSUMS__AMD64="sha256::90fcc7df48226434065ff12a4372136b40b9a4cbf0c8602bb763b745f22b7a99"
 
-SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
+SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
 CHKSUMS__ARM64="sha256::e7b864c9ae27cef77cafc78614ec33cbb0a27606af9375deffa09c4269a07f04"

--- a/app-editors/nano/spec
+++ b/app-editors/nano/spec
@@ -1,7 +1,8 @@
+UPSTREAM_VER=8.0
 NANORC_VER=2024.1.16
-VER=8.0+nanorc${NANORC_VER}
+VER=${UPSTREAM_VER}+nanorc${NANORC_VER}
 REL=1
-SRCS="git::commit=tags/v${VER%%+nanorc*}::git://git.savannah.gnu.org/nano.git \
+SRCS="git::commit=tags/v${UPSTREAM_VER}::git://git.savannah.gnu.org/nano.git \
       git::rename=nanorc;commit=tags/${NANORC_VER}::https://github.com/Quentium-Forks/nanorc"
 CHKSUMS="SKIP \
          SKIP"

--- a/app-electronics/prjoxide/spec
+++ b/app-electronics/prjoxide/spec
@@ -1,4 +1,4 @@
-VER=0+20230831
+VER=0+git20230831
 SRCS="git::commit=74c4f593b184d9e45bbf8f9df559f873bb17505f::https://github.com/gatecat/prjoxide"
 CHKSUMS="SKIP"
 SUBDIR="prjoxide/libprjoxide"

--- a/app-emulation/latx/spec
+++ b/app-emulation/latx/spec
@@ -1,17 +1,18 @@
-__LATX_VER=1.5.2~rc1
+UPSTREAM_VER=1.5.2-rc1
+# Note: 1.5.2-rc1 => 1.5.2~rc1
+__LATX_VER=${UPSTREAM_VER/\-/~}
 __EMUKIT_VER=20240529
 VER=${__LATX_VER}+emukit${__EMUKIT_VER}
 REL=1
 # Note: deepin-udis86 (closed source) is used by Loongapps's WeChat, which comes bundled with deepin-wine.
 # FIXME: Remove the 4th source at the next LATX release. This source is currently included for documentation.
-SRCS="tbl::https://github.com/deuso/latx-build/releases/download/${__LATX_VER/\~/-}/${__LATX_VER/\~/-}.tar.gz \
-      file::rename=amd64.squashfs::https://releases.aosc.io/os-amd64/emukit/aosc-os_emukit_${VER##*+emukit}_amd64.squashfs \
+SRCS="tbl::https://github.com/deuso/latx-build/releases/download/${UPSTREAM_VER}/${UPSTREAM_VER}.tar.gz \
+      file::rename=amd64.squashfs::https://releases.aosc.io/os-amd64/emukit/aosc-os_emukit_${__EMUKIT_VER}_amd64.squashfs \
       file::rename=deepin-udis86.deb::https://community-packages.deepin.com/deepin/pool/non-free/u/udis86/udis86_1.72-4_i386.deb \
       git::commit=167e1bac202b370631d7ca3b7caefe7f4b68a766;rename=latx-build::https://github.com/deuso/latx-build"
 CHKSUMS="sha256::3dbd2b1e01d82f1f0850254461286aa7952f4a09aed6edb03c69c39f2a6cdfd5 \
          sha256::fbce6c63001d7ee3f881da0bfe2432d71854a436aaec0fb23e8236f02f77e554 \
          sha256::ec874ecdf12f95d634c038a4dd2915951aae09753f4baba50b2074d154e04374 \
          SKIP"
-# FIXME: No valid way to check for version updates.
-# CHKUPDATE=""
+CHKUPDATE="anitya::id=372899"
 SUBDIR=.

--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,9 +1,9 @@
 __GECKO_VER=2.47.4
 __MONO_VER=9.1.0
-WINE_VER=9.9
-VER=${WINE_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
-SRCS="tbl::https://dl.winehq.org/wine/source/${WINE_VER:0:1}.x/wine-${WINE_VER}.tar.xz \
-      git::rename=wine-staging;commit=tags/v${WINE_VER}::https://github.com/wine-staging/wine-staging \
+UPSTREAM_VER=9.9
+VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
+SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER:0:1}.x/wine-${UPSTREAM_VER}.tar.xz \
+      git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
@@ -13,4 +13,4 @@ CHKSUMS="sha256::4d67a7812c4abd4a3de923238e60f5a86b16ac7fb20f6294e0dc6ef9e8beca3
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \
          sha256::601169d0203b291fbfd946b356a9538855e01de22abd470ded73baf312c88767"
 CHKUPDATE="anitya::id=15657"
-SUBDIR="wine-${WINE_VER}"
+SUBDIR="wine-${UPSTREAM_VER}"

--- a/app-games/minetest/spec
+++ b/app-games/minetest/spec
@@ -1,12 +1,13 @@
+UPSTREAM_VER=5.7.0
+# Note: For use in autobuild/.
+__GAMEVER="${UPSTREAM_VER}"
 __IRRLICHTVER=1.9.0mt10
-__GAMEVER=5.7.0
-VER=${__GAMEVER}+irrlicht${__IRRLICHTVER}
-SRCS="tbl::https://github.com/minetest/minetest/archive/${__GAMEVER}.tar.gz \
-      git::commit=tags/${__GAMEVER};rename=minetest_game::https://github.com/minetest/minetest_game \
+VER=${UPSTREAM_VER}+irrlicht${__IRRLICHTVER}
+SRCS="tbl::https://github.com/minetest/minetest/archive/${UPSTREAM_VER}.tar.gz \
+      git::commit=tags/${UPSTREAM_VER};rename=minetest_game::https://github.com/minetest/minetest_game \
       git::commit=tags/${__IRRLICHTVER};rename=irrlichtmt::https://github.com/minetest/irrlicht"
 CHKSUMS="sha256::0cd0fd48a97f76e337a2e1284599a054f8f92906a84a4ef2122ed321e1b75fa7 \
          SKIP \
          SKIP"
 CHKUPDATE="anitya::id=1978"
 SUBDIR="minetest-${__GAMEVER}"
-

--- a/app-games/openttd/spec
+++ b/app-games/openttd/spec
@@ -1,7 +1,10 @@
-VER=12.2+opengfx7.1+opensfx1.0.3
-SRCS="tbl::https://cdn.openttd.org/openttd-releases/${VER%%+*}/openttd-${VER%%+*}-source.tar.xz \
-      tbl::https://cdn.openttd.org/opengfx-releases/${VER:12:3}/opengfx-${VER:12:3}-all.zip \
-      tbl::https://cdn.openttd.org/opensfx-releases/${VER##*+opensfx}/opensfx-${VER##*+opensfx}-all.zip"
+UPSTREAM_VER=12.2
+OPENGFX_VER=7.1
+OPENSFX_VER=1.0.3
+VER=${UPSTREAM_VER}+opengfx${OPENGFX_VER}+opensfx${OPENSFX_VER}
+SRCS="tbl::https://cdn.openttd.org/openttd-releases/${UPSTREAM_VER}/openttd-${UPSTREAM_VER}-source.tar.xz \
+      tbl::https://cdn.openttd.org/opengfx-releases/${OPENGFX_VER}/opengfx-${OPENGFX_VER}-all.zip \
+      tbl::https://cdn.openttd.org/opensfx-releases/${OPENSFX_VER}/opensfx-${OPENSFX_VER}-all.zip"
 CHKSUMS="sha256::81508f0de93a0c264b216ef56a05f8381fff7bffa6d010121a21490b4dace95c \
          sha256::928fcf34efd0719a3560cbab6821d71ce686b6315e8825360fba87a7a94d7846 \
          sha256::e0a218b7dd9438e701503b0f84c25a97c1c11b7c2f025323fb19d6db16ef3759"

--- a/app-i18n/fcitx5-pinyin-zhwiki/spec
+++ b/app-i18n/fcitx5-pinyin-zhwiki/spec
@@ -1,10 +1,10 @@
+UPSTREAM_VER=0.2.3
 DICT_VER=20210823
-SCRIPT_VER=0.2.3
-VER="${SCRIPT_VER}"+dict"${DICT_VER}"
+VER="${UPSTREAM_VER}"+dict"${DICT_VER}"
 
 # Arch Linux (felixonmars, also fcitx5-pinyin-zhwiki author): use FDL 1.3 LICENSE
-SRCS="file::rename=zhwiki.dict::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/${SCRIPT_VER}/zhwiki-${DICT_VER}.dict \
-      file::rename=zhwiki.dict.yaml::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/${SCRIPT_VER}/zhwiki-${DICT_VER}.dict.yaml \
+SRCS="file::rename=zhwiki.dict::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/${UPSTREAM_VER}/zhwiki-${DICT_VER}.dict \
+      file::rename=zhwiki.dict.yaml::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/${UPSTREAM_VER}/zhwiki-${DICT_VER}.dict.yaml \
       file::rename=LICENSE::https://www.gnu.org/licenses/fdl-1.3.txt"
 CHKSUMS="sha256::b355b16a5c8c90edc0e859ccf2bd1509dd604180fe6631b852756f65a13ddacf \
          sha256::e9ff15c746477cb8157a9825e22c5fa44c70c2676bb1bf5f1710a47149c0da7c \

--- a/app-multimedia/openh264/spec
+++ b/app-multimedia/openh264/spec
@@ -1,6 +1,7 @@
+UPSTREAM_VER=2.4.1
 GMPVER=114_2
-VER=2.4.1+gmp${GMPVER/_/+}
-SRCS="git::commit=tags/v${VER%%+*}::https://github.com/cisco/openh264 \
+VER=${UPSTREAM_VER}+gmp${GMPVER/_/+}
+SRCS="git::commit=tags/v${UPSTREAM_VER}::https://github.com/cisco/openh264 \
       git::commit=tags/Firefox${GMPVER};rename=gmp-api::https://github.com/mozilla/gmp-api"
 CHKSUMS="SKIP \
          SKIP"

--- a/app-multimedia/pulseaudio/spec
+++ b/app-multimedia/pulseaudio/spec
@@ -1,9 +1,9 @@
-PULSEAUDIO_VER=17.0
-PULSEAUDIO_MODULE_XRDP_VER=0.7
-VER=${PULSEAUDIO_VER}+xrdp${PULSEAUDIO_MODULE_XRDP_VER}
-SRCS="tbl::https://freedesktop.org/software/pulseaudio/releases/pulseaudio-${PULSEAUDIO_VER}.tar.xz \
-      git::commit=tags/v$PULSEAUDIO_MODULE_XRDP_VER;rename=pulseaudio-module-xrdp::https://github.com/neutrinolabs/pulseaudio-module-xrdp"
+UPSTREAM_VER=17.0
+XRDP_VER=0.7
+VER=${UPSTREAM_VER}+xrdp${XRDP_VER}
+SRCS="tbl::https://freedesktop.org/software/pulseaudio/releases/pulseaudio-${UPSTREAM_VER}.tar.xz \
+      git::commit=tags/v${XRDP_VER};rename=pulseaudio-module-xrdp::https://github.com/neutrinolabs/pulseaudio-module-xrdp"
 CHKSUMS="sha256::053794d6671a3e397d849e478a80b82a63cb9d8ca296bd35b73317bb5ceb87b5
          SKIP"
-SUBDIR="pulseaudio-${PULSEAUDIO_VER}"
+SUBDIR="pulseaudio-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=3729"

--- a/app-network/unbound/spec
+++ b/app-network/unbound/spec
@@ -1,8 +1,8 @@
-UNBOUND_VER=1.19.2
+UPSTREAM_VER=1.19.2
 ICANNBUNDLE_VER=20210902
-VER=$UNBOUND_VER+icannbundle$ICANNBUNDLE_VER
-SRCS="tbl::https://unbound.net/downloads/unbound-$UNBOUND_VER.tar.gz \
-      file::rename=icannbundle.pem::https://repo.aosc.io/aosc-repacks/icannbundle-$ICANNBUNDLE_VER.pem"
+VER=${UPSTREAM_VER}+icannbundle${ICANNBUNDLE_VER}
+SRCS="tbl::https://unbound.net/downloads/unbound-${UPSTREAM_VER}.tar.gz \
+      file::rename=icannbundle.pem::https://repo.aosc.io/aosc-repacks/icannbundle-${ICANNBUNDLE_VER}.pem"
 CHKSUMS="sha256::cc560d345734226c1b39e71a769797e7fdde2265cbb77ebce542704bba489e55 \
          sha256::d4c77eafb8a3bc1d68fb7c171afbd0d2a76870dae81ad18d0c584fa46ecd1eb1"
 CHKUPDATE="anitya::id=5042"

--- a/app-shells/ksh93/autobuild/defines
+++ b/app-shells/ksh93/autobuild/defines
@@ -4,4 +4,10 @@ PKGDEP="glibc"
 PKGDES="AT&T version of the Korn shell"
 PKGREP="ksh"
 
-PKGEPOCH=1
+PKGEPOCH=2
+
+MESON_AFTER="-Dbuild-api-tests=false \
+             -Dbuild-api-tests-only=false \
+             -Dfallback-version-number=$PKGVER \
+             -DASAN=false \
+             -Dwarnings-are-errors=false"

--- a/app-shells/ksh93/spec
+++ b/app-shells/ksh93/spec
@@ -1,5 +1,4 @@
-VER=2020.0.0+20200208
-REL=1
-SRCS="git::commit=505818242e36f79fd68c171772c239c9701868da::https://github.com/att/ast"
-CHKSUMS="SKIP"
+VER=2020.0.0
+SRCS="tbl::https://github.com/att/ast/releases/download/$VER/ksh-$VER.tar.xz"
+CHKSUMS="sha256::3d6287f9ad13132bf8e57a8eac512b36a63ccce2b1e4531d7a946c5bf2375c63"
 CHKUPDATE="anitya::id=1523"

--- a/app-utils/arch-install-scripts/spec
+++ b/app-utils/arch-install-scripts/spec
@@ -1,7 +1,8 @@
+UPSTREAM_VER=28
 MIRRORLIST_VER=20231113
 PACMAN_VER=6.0.1
-VER=28+mirrorlist20231113+pacman6.0.1
-SRCS="git::commit=tags/v${VER%%+*}::https://github.com/archlinux/arch-install-scripts.git \
+VER=${UPSTREAM_VER}+mirrorlist20231113+pacman6.0.1
+SRCS="git::commit=tags/v${UPSTREAM_VER}::https://github.com/archlinux/arch-install-scripts.git \
       file::rename=pacman.conf.pacstrap::https://gitlab.archlinux.org/pacman/pacman/-/raw/v${PACMAN_VER}/etc/pacman.conf.in \
       file::rename=mirrorlist.pacstrap::https://repo.aosc.io/aosc-repacks/mirrorlist-${MIRRORLIST_VER}.pacstrap"
 CHKSUMS="SKIP \

--- a/app-utils/autojump-rs/spec
+++ b/app-utils/autojump-rs/spec
@@ -1,10 +1,10 @@
-SRC_VER=0.5.1
+UPSTREAM_VER=0.5.1
 ASSET_VER=22.5.3
-VER=${SRC_VER}+${ASSET_VER}
+VER=${UPSTREAM_VER}+${ASSET_VER}
 REL=1
-SRCS="tbl::https://github.com/xen0n/autojump-rs/archive/$SRC_VER.tar.gz \
-      tbl::https://github.com/wting/autojump/archive/release-v$ASSET_VER.tar.gz"
+SRCS="tbl::https://github.com/xen0n/autojump-rs/archive/${UPSTREAM_VER}.tar.gz \
+      tbl::https://github.com/wting/autojump/archive/release-v${ASSET_VER}.tar.gz"
 CHKSUMS="sha256::c04be3d0fbeef741ce9363c4f29d1b61b94f6614ed046e283062f9692cfcf584 \
          sha256::00daf3698e17ac3ac788d529877c03ee80c3790472a85d0ed063ac3a354c37b1"
 CHKUPDATE="anitya::id=231695"
-SUBDIR=autojump-rs-$SRC_VER
+SUBDIR="autojump-rs-${UPSTREAM_VER}"

--- a/desktop-fonts/gsfonts/spec
+++ b/desktop-fonts/gsfonts/spec
@@ -1,5 +1,5 @@
 VER=8.11+urwcyr1.0.7~pre44
-SRCS="tbl::https://deb.debian.org/debian/pool/main/g/gsfonts/gsfonts_8.11+urwcyr1.0.7~pre44.orig.tar.gz"
+SRCS="tbl::https://deb.debian.org/debian/pool/main/g/gsfonts/gsfonts_${VER}.orig.tar.gz"
 CHKSUMS="sha256::9f2a598998bf05e023546ac981aa2a857aa1635d2e0e3020a3c3004ad564dc00"
 SUBDIR=.
 REL=1

--- a/desktop-fonts/noto-fonts/spec
+++ b/desktop-fonts/noto-fonts/spec
@@ -1,17 +1,20 @@
+UPSTREAM_VER=24.1.1
 # Note: For the main version number, go with NotoSans- prefixed tags at
 # https://github.com/notofonts/notofonts.github.io/.
-EMOJIVER=2.042
-VER=24.1.1+emoji${EMOJIVER}+cjksans2.004+cjkserif2.002
+EMOJI_VER=2.042
+CJKSANS_VER=2.004
+CJKSERIF_VER=2.002
+VER=${UPSTREAM_VER}+emoji${EMOJI_VER}+cjksans${CJKSANS_VER}+cjkserif${CJKSERIF_VER}
 REL=1
 # Note: We don't use the tags any more, since it's easier to install from a
 # Git repository.
 # CJKSANSVER=${VER:24:5}
 # CJKSERIFVER=${VER##*+cjkserif}
 # Note: Match the newest Sans or Serif tag.
-CJKCOMMIT="4efc595762d1f4b4fa504bccfe8e59de91fda063"
-SRCS="tbl::https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-${VER%%+*}.tar.gz \
-      tbl::https://github.com/googlefonts/noto-emoji/archive/refs/tags/v${EMOJIVER}.tar.gz \
-      git::commit=4efc595762d1f4b4fa504bccfe8e59de91fda063;rename=noto-cjk::https://github.com/googlefonts/noto-cjk"
+CJK_COMMIT="4efc595762d1f4b4fa504bccfe8e59de91fda063"
+SRCS="tbl::https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-${UPSTREAM_VER}.tar.gz \
+      tbl::https://github.com/googlefonts/noto-emoji/archive/refs/tags/v${EMOJI_VER}.tar.gz \
+      git::commit=${CJK_COMMIT};rename=noto-cjk::https://github.com/googlefonts/noto-cjk"
 CHKSUMS="sha256::435e383e26200b10e9c4442e1f588bdeb9c5b498aead02e4819602fff2b4b22b \
          sha256::b56bd2fa4029d0f057b66b742ac59af243dbc91067fed3eb4929dac762440fc9 \
          SKIP"

--- a/desktop-fonts/wqy-microhei/autobuild/defines
+++ b/desktop-fonts/wqy-microhei/autobuild/defines
@@ -3,5 +3,5 @@ PKGSEC=fonts
 PKGDEP=fontconfig
 PKGDES="A Droid Sans derived CJK outline font"
 
-PKGEPOCH=1
+PKGEPOCH=2
 ABHOST=noarch

--- a/desktop-fonts/wqy-microhei/spec
+++ b/desktop-fonts/wqy-microhei/spec
@@ -1,5 +1,6 @@
-VER=0.2.0+beta
-REL=4
-SRCS="tbl::https://sourceforge.net/projects/wqy/files/wqy-microhei/${VER/+/-}/wqy-microhei-${VER/+/-}.tar.gz"
+UPSTREAM_VER=0.2.0-beta
+# Note: 0.2.0-beta => 0.2.0~beta
+VER=${UPSTREAM_VER/\-/~}
+SRCS="tbl::https://sourceforge.net/projects/wqy/files/wqy-microhei/${UPSTREAM_VER}/wqy-microhei-${UPSTREAM_VER}.tar.gz"
 CHKSUMS="sha256::2802ac8023aa36a66ea6e7445854e3a078d377ffff42169341bd237871f7213e"
 CHKUPDATE="anitya::id=5324"

--- a/lang-golang/go/spec
+++ b/lang-golang/go/spec
@@ -1,11 +1,11 @@
+UPSTREAM_VER=1.22.3
 # Versions of Golang, net library and Go tools
 TOOLS_VER=0.21.0
 NET_VER=0.25.0
-GOLANG_VER=1.22.3
 
-VER="${GOLANG_VER}+tools${TOOLS_VER}+net${NET_VER}"
+VER="${UPSTREAM_VER}+tools${TOOLS_VER}+net${NET_VER}"
 REL=1
-SRCS="tbl::https://go.dev/dl/go${GOLANG_VER}.src.tar.gz \
+SRCS="tbl::https://go.dev/dl/go${UPSTREAM_VER}.src.tar.gz \
       git::commit=tags/v${TOOLS_VER};rename=tools::https://go.googlesource.com/tools \
       git::commit=tags/v${NET_VER};rename=net::https://github.com/golang/net"
 CHKSUMS="sha256::80648ef34f903193d72a59c0dff019f5f98ae0c9aa13ade0b0ecbff991a76f68 \

--- a/runtime-containers/containers-common/spec
+++ b/runtime-containers/containers-common/spec
@@ -1,16 +1,16 @@
+UPSTREAM_VER=0.59.0
 # Find dependency versions at
 #
 # https://github.com/containers/common/blob/v$PKGVER/go.sum
-
 __IMAGE_VER=5.31.0
 __SHORTNAMES_VER=2023.02.20
 __STORAGE_VER=1.54.0
 __SKOPEO_VER=1.15.1
 
-VER=0.59.0+image${__IMAGE_VER}+shortnames${__SHORTNAMES_VER}+skopeo${__SKOPEO_VER}+storage${__STORAGE_VER}
+VER=${UPSTREAM_VER}+image${__IMAGE_VER}+shortnames${__SHORTNAMES_VER}+skopeo${__SKOPEO_VER}+storage${__STORAGE_VER}
 
 __ORG_URL="https://github.com/containers"
-SRCS="git::commit=tags/v${VER%%+*};rename=common::${__ORG_URL}/common \
+SRCS="git::commit=tags/v${UPSTREAM_VER};rename=common::${__ORG_URL}/common \
       git::commit=tags/v${__IMAGE_VER};rename=image::${__ORG_URL}/image \
       git::commit=tags/v${__SHORTNAMES_VER};rename=shortnames::${__ORG_URL}/shortnames \
       git::commit=tags/v${__SKOPEO_VER};rename=skopeo::${__ORG_URL}/skopeo \

--- a/runtime-data/man-pages/spec
+++ b/runtime-data/man-pages/spec
@@ -1,6 +1,7 @@
+UPSTREAM_VER=6.05.01
 POSIXVER=2017-a
-VER=6.05.01+posix${POSIXVER/-a/a}
-SRCS="https://www.kernel.org/pub/linux/docs/man-pages/man-pages-${VER%%+posix*}.tar.xz \
+VER=${UPSTREAM_VER}+posix${POSIXVER/-a/a}
+SRCS="https://www.kernel.org/pub/linux/docs/man-pages/man-pages-${UPSTREAM_VER}.tar.xz \
       https://www.kernel.org/pub/linux/docs/man-pages/man-pages-posix/man-pages-posix-${POSIXVER}.tar.xz"
 SUBDIR="man-pages-${VER%%+posix*}"
 CHKSUMS="sha256::b96ab6b44a688c91d1b572e52fece519e1cfd2bb4c33fe7014fc3fd1ef3f9cae \

--- a/runtime-desktop/qt-5/spec
+++ b/runtime-desktop/qt-5/spec
@@ -1,4 +1,5 @@
-VER=5.15.13+webengine5.15.16+webkit5.212.0+kde20240408
+UPSTREAM_VER=5.15.13
+VER=${UPSTREAM_VER}+webengine5.15.16+webkit5.212.0+kde20240408
 REL=2
 SRCS="https://repo.aosc.io/aosc-repacks/qt-5-$VER.tar.xz"
 CHKSUMS="sha256::48b528491c345c32760a0554c1f99c9c3fbd5bc8d8200bf1b28f008d3c3e600a"

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,10 +1,10 @@
-MESA_VER=24.0.7
+UPSTREAM_VER=24.0.7
 DXHEADERS_VER=1.613.1
-VER=${MESA_VER}+dxheaders${DXHEADERS_VER}
+VER=${UPSTREAM_VER}+dxheaders${DXHEADERS_VER}
 REL=1
-SRCS="tbl::https://archive.mesa3d.org/mesa-${MESA_VER}.tar.xz \
+SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
 CHKSUMS="sha256::7454425f1ed4a6f1b5b107e1672b30c88b22ea0efea000ae2c7d96db93f6c26a \
          SKIP"
-SUBDIR="mesa-${MESA_VER}"
+SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"

--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,7 +1,8 @@
+UPSTREAM_VER=20240506
 DEBIANVER=20230210-5~bpo11+1
-VER=20240506+debian${DEBIANVER/-/+}
+VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 # When using a stable tag.
-# SRCS="git::commit=tags/${VER%%+debian*}::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
+# SRCS="git::commit=tags/${UPSTREAM_VER}::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
 SRCS="git::commit=b93493c01691104b9a9b612f9e161702418d10a3::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.clm_blob \

--- a/runtime-kernel/m1n1/spec
+++ b/runtime-kernel/m1n1/spec
@@ -1,8 +1,9 @@
-LOGOVER=20231113.1
-VER=1.4.6+logo${LOGOVER}
+UPSTREAM_VER=1.4.6
+LOGO_VER=20231113.1
+VER=${UPSTREAM_VER}+logo${LOGO_VER}
 REL=1
-SRCS="git::commit=tags/v${VER%%+*}::https://github.com/AsahiLinux/m1n1 \
-      git::commit=tags/v$LOGOVER;rename=aosc-logo::https://github.com/AOSC-Dev/logo"
+SRCS="git::commit=tags/v${UPSTREAM_VER}::https://github.com/AsahiLinux/m1n1 \
+      git::commit=tags/v${LOGO_VER};rename=aosc-logo::https://github.com/AOSC-Dev/logo"
 CHKSUMS="SKIP \
          SKIP"
 SUBDIR="m1n1"


### PR DESCRIPTION
Topic Description
-----------------

- ksh93: fix +git usage
- prjoxide: fix +git usage
- m1n1: (no build) mark UPSTREAM_VERSION
    To ease aosc-findupdate in finding updates in compound packages.
- linux-firmware: (no build) mark UPSTREAM_VERSION
    To ease aosc-findupdate in finding updates in compound packages.
- mesa: (no build) mark UPSTREAM_VERSION
    To ease aosc-findupdate in finding updates in compound packages.
- qt-5: (no build) mark UPSTREAM_VERSION
    To ease aosc-findupdate in finding updates in compound packages.
- man-pages: (no build) mark UPSTREAM_VERSION
    To ease aosc-findupdate in finding updates in compound packages.
- containers-common: (no build) mark UPSTREAM_VERSION
    To ease aosc-findupdate in finding updates in compound packages.
- go: (no build) mark UPSTREAM_VERSION
    To ease aosc-findupdate in finding updates in compound packages.
- wqy-microhei: (no build) mark UPSTREAM_VERSION
    To ease aosc-findupdate in finding updates in compound packages.

... and 17 more commits

Package(s) Affected
-------------------

- ksh93: 1:2020.0.0+git20200630
- prjoxide: 0+git20230831

Security Update?
----------------

No

Build Order
-----------

```
#buildit prjoxide ksh93
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
