### PR TITLE
tornado update to 6.4.1

### DIFF
--- a/lang-python/tornado/autobuild/defines
+++ b/lang-python/tornado/autobuild/defines
@@ -1,4 +1,7 @@
 PKGNAME=tornado
 PKGSEC=python
-PKGDEP="backports-abc"
+PKGDEP="backports-abc python-3"
+BUILDDEP="python-installer python-build wheel"
 PKGDES="A Python web framework and asynchronous networking library"
+
+NOPYTHON2=1

--- a/lang-python/tornado/spec
+++ b/lang-python/tornado/spec
@@ -1,5 +1,4 @@
-VER=5.1
-REL=3
+VER=6.4.1
 SRCS="tbl::https://pypi.io/packages/source/t/tornado/tornado-$VER.tar.gz"
-CHKSUMS="sha256::4f66a2172cb947387193ca4c2c3e19131f1c70fa8be470ddbbd9317fd0801582"
+CHKSUMS="sha256::92d3ab53183d8c50f8204a51e6f91d18a15d5ef261e84d452800d4ff6fc504e9"
 CHKUPDATE="anitya::id=7498"


### PR DESCRIPTION
Topic Description
-----------------

- tornado: update to 6.4.1
    The new version has fixed "module 'collections' has no attribute' MutableMapping '"

Package(s) Affected
-------------------

- tornado: 6.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tornado
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
