### PR TITLE
perl-dbd-mysql (DBD::mysql): update to 4.052

### DIFF
--- a/lang-perl/perl-dbd-mysql/spec
+++ b/lang-perl/perl-dbd-mysql/spec
@@ -1,5 +1,4 @@
-VER=4.050
-SRCS="tbl::https://github.com/perl5-dbi/DBD-mysql/archive/${VER/./_}.tar.gz"
-CHKSUMS="sha256::55f31f02e9c0e11f7fd4cdb4ac942e2c6aea25499a1141db80536e6df653e2fa"
-REL=2
+VER=4.052
+SRCS="tbl::https://cpan.metacpan.org/authors/id/D/DV/DVEEDEN/DBD-mysql-$VER.tar.gz"
+CHKSUMS="sha256::a83f57af7817787de0ef56fb15fdfaf4f1c952c8f32ff907153b66d2da78ff5b"
 CHKUPDATE="anitya::id=2807"


### PR DESCRIPTION
Topic Description
-----------------

- perl-dbd-mysql: update to 4.052

Package(s) Affected
-------------------

- perl-dbd-mysql: 4.052

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-dbd-mysql
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
