### PR TITLE
cmake (CMake): rework postinst

### DIFF
--- a/app-devel/cmake/autobuild/build
+++ b/app-devel/cmake/autobuild/build
@@ -29,11 +29,13 @@ abinfo "Generating postinst script ..."
 MMVER="${PKGVER%.*}"
 cat << EOF > "$SRCDIR"/autobuild/postinst
 for i in 3.{1..${MMVER#*.}}; do
-        if [ -d /usr/share/cmake-\$i ] && [ ! -L /usr/share/cmake-\$i ]; then
-                cp -rf /usr/share/cmake-\$i/* /usr/share/cmake/
-                rm -r /usr/share/cmake-\$i
-        fi
+	if [ -d /usr/share/cmake-\$i ] && [ ! -L /usr/share/cmake-\$i ]; then
+		cp -rf /usr/share/cmake-\$i/* /usr/share/cmake/
+	fi
+	if [ -e /usr/share/cmake-\$i ]; then
+		rm -r /usr/share/cmake-\$i
+	fi
 done
 
-ln -s /usr/share/cmake /usr/share/cmake-$MMVER
+ln -s cmake /usr/share/cmake-$MMVER
 EOF

--- a/app-devel/cmake/spec
+++ b/app-devel/cmake/spec
@@ -1,5 +1,5 @@
 VER=3.29.6
-REL=1
+REL=2
 SRCS="tbl::https://cmake.org/files/v${VER:0:4}/cmake-$VER.tar.gz"
 CHKSUMS="sha256::1391313003b83d48e2ab115a8b525a557f78d8c1544618b48d1d90184a10f0af"
 CHKUPDATE="anitya::id=306"


### PR DESCRIPTION
Topic Description
-----------------

- cmake: fix postinst during intra-minor upgrades
    The previous change to the postinst breaks when the user attempts to upgrade
    cmake from the same minor series (i.e., 3.29.1 => 3.29.2), as the symlinked
    /usr/share/cmake-x.y never gets removed (since it was already a symlink).
    This revision only tests for the existence of such a matching name and removes
    the symlink (as well as real directories) when found, allowing upgrades to
    commence smoothly.
    Also, create symlinks with relative targets.

Package(s) Affected
-------------------

- cmake: 3.29.6-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cmake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
