### PR TITLE
xfce4-screenshooter: update to 1.10.6

### DIFF
--- a/desktop-xfce/xfce4-screenshooter/spec
+++ b/desktop-xfce/xfce4-screenshooter/spec
@@ -1,4 +1,4 @@
-VER=1.10.5
+VER=1.10.6
 SRCS="https://archive.xfce.org/src/apps/xfce4-screenshooter/${VER%.*}/xfce4-screenshooter-$VER.tar.bz2"
-CHKSUMS="sha256::fa711f2a6a5517f575f2e129fe48c2678e836bd4ede5433075f3076d7670621c"
+CHKSUMS="sha256::992066cfecfb44a68681340bfd55d524d40410aac3da6ef25c6c6cb2150a5965"
 CHKUPDATE="anitya::id=15830"


### PR DESCRIPTION
Topic Description
-----------------

- xfce4-screenshooter: update to 1.10.6
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- xfce4-screenshooter: 1.10.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit xfce4-screenshooter
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
