### PR TITLE
xfce4-session: update to 4.18.4

### DIFF
--- a/desktop-xfce/xfce4-session/spec
+++ b/desktop-xfce/xfce4-session/spec
@@ -1,4 +1,4 @@
-VER=4.18.3
+VER=4.18.4
 SRCS="https://archive.xfce.org/src/xfce/xfce4-session/${VER%.*}/xfce4-session-$VER.tar.bz2"
-CHKSUMS="sha256::382f93e096ec6493098719cab8cc31b93ad9bb469c0715c0c5117d75fe7394ec"
+CHKSUMS="sha256::9a9c5074c7338b881a5259d3b643619bf84901360c03478e1a697938ece06516"
 CHKUPDATE="anitya::id=232010"


### PR DESCRIPTION
Topic Description
-----------------

- xfce4-session: update to 4.18.4
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- xfce4-session: 1:4.18.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit xfce4-session
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
