### PR TITLE
xfce4-settings: update to 4.18.6

### DIFF
--- a/desktop-xfce/xfce4-settings/spec
+++ b/desktop-xfce/xfce4-settings/spec
@@ -1,5 +1,4 @@
-VER=4.18.4
-REL=1
+VER=4.18.6
 SRCS="https://archive.xfce.org/src/xfce/xfce4-settings/${VER%.*}/xfce4-settings-$VER.tar.bz2"
-CHKSUMS="sha256::f10c55d0360308d9944f415645d9596d4352f952a20fc7c4a66f30fe511ca1dc"
+CHKSUMS="sha256::d9a9051b6026edd6766c64bb403b51e9167e4d31e7f1c7f843d3aed19f667bfe"
 CHKUPDATE="anitya::id=232011"


### PR DESCRIPTION
Topic Description
-----------------

- xfce4-settings: update to 4.18.6
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- xfce4-settings: 4.18.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit xfce4-settings
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
