### PR TITLE
slick-greeter: update to 2.0.4

### DIFF
--- a/desktop-displaymanagers/slick-greeter/spec
+++ b/desktop-displaymanagers/slick-greeter/spec
@@ -1,4 +1,4 @@
-VER=2.0.3
+VER=2.0.4
 SRCS="git::commit=tags/$VER::https://github.com/linuxmint/slick-greeter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14546"


### PR DESCRIPTION
Topic Description
-----------------

- slick-greeter: update to 2.0.4
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- slick-greeter: 2.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit slick-greeter
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
