### PR TITLE
gstreamer: update to 1.24.4

### DIFF
--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,4 @@
-VER=1.24.3
-REL=1
+VER=1.24.4
 SRCS="tbl::https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/$VER/gstreamer-$VER.tar.gz"
-CHKSUMS="sha256::ed10e1ce7144ed1791712d32afa485423015b5264f05280653b37724fe382089"
+CHKSUMS="sha256::3121a186f707b2bd5a8ecbb4a84e9a31a25401cdaa03acff891b634b112800e1"
 CHKUPDATE="anitya::id=1263"


### PR DESCRIPTION
Topic Description
-----------------

- gstreamer: update to 1.24.4
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- gstreamer: 1.24.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit gstreamer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
