### PR TITLE
Tilix Rebuild for libphobos sover 108

### DIFF
--- a/app-utils/tilix/autobuild/defines
+++ b/app-utils/tilix/autobuild/defines
@@ -15,3 +15,4 @@ PKGEPOCH=1
 # FIXME: LDC seem to have some issues with fp ABI selection on RISCV64
 # when LTO is enabled
 NOLTO__RISCV64=1
+FAIL_ARCH="!(amd64|arm64|loongson3|riscv64)"

--- a/app-utils/tilix/spec
+++ b/app-utils/tilix/spec
@@ -1,4 +1,5 @@
 VER=1.9.6
+REL=1
 SRCS="git::commit=tags/$VER;rename=tilix::https://github.com/gnunn1/tilix"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10148"

--- a/desktop-gnome/gtkd/spec
+++ b/desktop-gnome/gtkd/spec
@@ -1,5 +1,5 @@
 VER=3.10.0
-REL=3
+REL=4
 SRCS="https://github.com/gtkd-developers/GtkD/archive/v$VER.tar.gz"
 CHKSUMS="sha256::5c6edcdcfb6160ffc1524ab4996471e608c3632d81bd8ea689cf0e52ed13e953"
 CHKUPDATE="anitya::id=228569"


### PR DESCRIPTION
Topic Description
-----------------

- tilix: rebuild for libphobos sover 108
- gtkd: rebuild for libphobos sover 108

Package(s) Affected
-------------------

- gtkd: 3.10.0-4
- tilix: 1:1.9.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtkd tilix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
