### PR TITLE
libgcrypt: update to 1.11.0

### DIFF
--- a/runtime-cryptography/libgcrypt/spec
+++ b/runtime-cryptography/libgcrypt/spec
@@ -1,4 +1,4 @@
-VER=1.10.3
+VER=1.11.0
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-$VER.tar.bz2"
-CHKSUMS="sha256::8b0870897ac5ac67ded568dcfadf45969cfa8a6beb0fd60af2a9eadc2a3272aa"
+CHKSUMS="sha256::09120c9867ce7f2081d6aaa1775386b98c2f2f246135761aae47d81f58685b9c"
 CHKUPDATE="anitya::id=1623"

--- a/runtime-cryptography/libgpg-error-static/autobuild/beyond
+++ b/runtime-cryptography/libgpg-error-static/autobuild/beyond
@@ -1,1 +1,0 @@
-rm -rf "$PKGDIR"/usr/{bin,include,lib/pkgconfig,share}

--- a/runtime-cryptography/libgpg-error-static/autobuild/defines
+++ b/runtime-cryptography/libgpg-error-static/autobuild/defines
@@ -1,11 +1,9 @@
 PKGNAME=libgpg-error-static
-PKGDES="Support library for libgcrypt (static libraries)"
+PKGDES="Static support library for GnuPG components (transitional package for libgpg-error)"
 PKGSEC=libs
 PKGDEP="libgpg-error"
 
-ABSHADOW=0
-AUTOTOOLS_AFTER="--enable-static --disable-shared"
-NOSTATIC=0
-NOLTO=1
+PKGEPOCH=1
 
-ABSPLITDBG=0
+ABTYPE=dummy
+ABHOST=noarch

--- a/runtime-cryptography/libgpg-error-static/autobuild/prepare
+++ b/runtime-cryptography/libgpg-error-static/autobuild/prepare
@@ -1,1 +1,0 @@
-ln -sfv lock-obj-pub.arm-unknown-linux-gnueabihf.h src/syscfg/lock-obj-pub.linux-gnueabi.h

--- a/runtime-cryptography/libgpg-error-static/spec
+++ b/runtime-cryptography/libgpg-error-static/spec
@@ -1,4 +1,2 @@
-VER=1.48
-SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-$VER.tar.bz2"
-CHKSUMS="sha256::89ce1ae893e122924b858de84dc4f67aae29ffa610ebf668d5aa539045663d6f"
-CHKUPDATE="anitya::id=1628"
+VER=0
+DUMMYSRC=1

--- a/runtime-cryptography/libgpg-error/autobuild/beyond
+++ b/runtime-cryptography/libgpg-error/autobuild/beyond
@@ -1,1 +1,3 @@
-ln -sv /usr/lib/libgpg-error.so.0.12.1 $PKGDIR/usr/lib/libgpg-error.so.0.11.0
+abinfo "Creating a compatibility symlink for ABI level 0.11 ..."
+ln -sv libgpg-error.so.0.12.1 \
+    "$PKGDIR"/usr/lib/libgpg-error.so.0.11.0

--- a/runtime-cryptography/libgpg-error/autobuild/defines
+++ b/runtime-cryptography/libgpg-error/autobuild/defines
@@ -1,5 +1,10 @@
 PKGNAME=libgpg-error
-PKGDES="Support library for libgcrypt"
 PKGSEC=libs
-PKGDEP=glibc
-ABSHADOW=no
+PKGDEP="glibc"
+PKGDES="Support library for GnuPG components"
+
+AUTOTOOLS_AFTER="--enable-static"
+NOSTATIC=0
+
+PKGBREAK="libgpg-error-static<=1.48"
+PKgREP="libgpg-error-static<=1.48"

--- a/runtime-cryptography/libgpg-error/autobuild/prepare
+++ b/runtime-cryptography/libgpg-error/autobuild/prepare
@@ -1,1 +1,0 @@
-ln -sfv lock-obj-pub.arm-unknown-linux-gnueabihf.h src/syscfg/lock-obj-pub.linux-gnueabi.h

--- a/runtime-cryptography/libgpg-error/spec
+++ b/runtime-cryptography/libgpg-error/spec
@@ -1,4 +1,4 @@
-VER=1.48
+VER=1.50
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-$VER.tar.bz2"
-CHKSUMS="sha256::89ce1ae893e122924b858de84dc4f67aae29ffa610ebf668d5aa539045663d6f"
+CHKSUMS="sha256::69405349e0a633e444a28c5b35ce8f14484684518a508dc48a089992fe93e20a"
 CHKUPDATE="anitya::id=1628"


### PR DESCRIPTION
Topic Description
-----------------

- libgcrypt: update to 1.11.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>
- libgpg-error-static: transitionalise => libgpg-error
- libgpg-error: update to 1.50
    Merge static libraries (let's make this happen gradually).

Package(s) Affected
-------------------

- libgcrypt: 1.11.0
- libgpg-error: 1.50
- libgpg-error-static: 1:0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgpg-error libgpg-error-static libgcrypt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
