### PR TITLE
grsync: update to 1.3.1

### DIFF
--- a/app-network/grsync/spec
+++ b/app-network/grsync/spec
@@ -1,4 +1,4 @@
-VER=1.2.8
-SRCS="tbl::https://sourceforge.net/projects/grsync/files/grsync-$VER.tar.gz"
-CHKSUMS="sha256::94ea5faca67e3df467b5283377af3cb32b2b47631b6a32d38bc7b371209306b1"
+VER=1.3.1
+SRCS="tbl::https://www.opbyte.it/release/grsync-$VER.tar.gz"
+CHKSUMS="sha256::33cc0e25daa62e5ba7091caea3c83a8dc74dc5d7721c4501d349f210c4b3c6d3"
 CHKUPDATE="anitya::id=10088"


### PR DESCRIPTION
Topic Description
-----------------

- grsync: update to 1.3.1
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- grsync: 1.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit grsync
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
