### PR TITLE
emacs: update to 29.4

### DIFF
--- a/app-editors/emacs/spec
+++ b/app-editors/emacs/spec
@@ -1,4 +1,4 @@
-VER=29.3
+VER=29.4
 SRCS="tbl::https://ftp.gnu.org/gnu/emacs/emacs-$VER.tar.gz"
-CHKSUMS="sha256::2de8df5cab8ac697c69a1c46690772b0cf58fe7529f1d1999582c67d927d22e4"
+CHKSUMS="sha256::1adb1b9a2c6cdb316609b3e86b0ba1ceb523f8de540cfdda2aec95b6a5343abf"
 CHKUPDATE="anitya::id=675"


### PR DESCRIPTION
Topic Description
-----------------

- emacs: update to 29.4
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- emacs: 29.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit emacs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
