### PR TITLE
lmdb: update to 0.9.31

### DIFF
--- a/app-database/lmdb/autobuild/overrides/usr/lib/pkgconfig/lmdb.pc
+++ b/app-database/lmdb/autobuild/overrides/usr/lib/pkgconfig/lmdb.pc
@@ -5,7 +5,6 @@ includedir=${prefix}/include
 Name: liblmdb
 Description: Lightning Memory-Mapped Database
 URL: https://symas.com/products/lightning-memory-mapped-database/
-Version: 0.9.22
+Version: 0.9.31
 Libs: -L${libdir} -llmdb
 Cflags: -I${includedir}
-

--- a/app-database/lmdb/spec
+++ b/app-database/lmdb/spec
@@ -1,4 +1,4 @@
-VER=0.9.28
-SRCS="tbl::https://github.com/LMDB/lmdb/archive/LMDB_$VER.tar.gz"
-CHKSUMS="sha256::47457d3d3ae2c489b52078a07e9f55ec6e094b48c2204029c7754e2972fe1882"
+VER=0.9.31
+SRCS="git::commit=tags/LMDB_$VER::https://github.com/LMDB/lmdb"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6974"


### PR DESCRIPTION
Topic Description
-----------------

- lmdb: update to 0.9.31

Package(s) Affected
-------------------

- lmdb: 0.9.31

Security Update?
----------------

No

Build Order
-----------

```
#buildit lmdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
