### PR TITLE
tcl: update to 8.6.14

### DIFF
--- a/lang-tcl/tcl/autobuild/build
+++ b/lang-tcl/tcl/autobuild/build
@@ -40,7 +40,7 @@ sed -e "s#$SRCDIR/unix#/usr/lib#" \
     -i "$PKGDIR/usr/lib/tclConfig.sh"
 
 abinfo "Tweaking tdbcConfig.sh ..."
-tdbcver=tdbc1.1.1
+tdbcver=tdbc1.1.7
 sed -e "s#$SRCDIR/unix/pkgs/$tdbcver#/usr/lib/$tdbcver#" \
     -e "s#$SRCDIR/pkgs/$tdbcver/generic#/usr/include#" \
     -e "s#$SRCDIR/pkgs/$tdbcver/library#/usr/lib/tcl${PKGVER%.*}#" \
@@ -48,7 +48,7 @@ sed -e "s#$SRCDIR/unix/pkgs/$tdbcver#/usr/lib/$tdbcver#" \
     -i "$PKGDIR/usr/lib/$tdbcver/tdbcConfig.sh"
 
 abinfo "Tweaking itclConfig.sh ..."
-itclver=itcl4.2.0
+itclver=itcl4.2.4
 sed -e "s#$SRCDIR/unix/pkgs/$itclver#/usr/lib/$itclver#" \
     -e "s#$SRCDIR/pkgs/$itclver/generic#/usr/include#" \
     -e "s#$SRCDIR/pkgs/$itclver#/usr/include#" \

--- a/lang-tcl/tcl/spec
+++ b/lang-tcl/tcl/spec
@@ -1,6 +1,5 @@
-VER=8.6.10
-REL=4
+VER=8.6.14
 SRCS="tbl::https://downloads.sourceforge.net/tcl/tcl$VER-src.tar.gz"
-CHKSUMS="sha256::5196dbf6638e3df8d5c87b5815c8c2b758496eb6f0e41446596c9a4e638d87ed"
+CHKSUMS="sha256::5880225babf7954c58d4fb0f5cf6279104ce1cd6aa9b71e9a6322540e1c4de66"
 CHKUPDATE="anitya::id=4941"
 SUBDIR="tcl$VER/unix"


### PR DESCRIPTION
Topic Description
-----------------

- tcl: update to 8.6.14

Package(s) Affected
-------------------

- tcl: 8.6.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit tcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
