### PR TITLE
re2: update to 20240601

### DIFF
--- a/runtime-common/re2/spec
+++ b/runtime-common/re2/spec
@@ -1,4 +1,5 @@
-VER=20240501
-SRCS="git::commit=2024-05-01::https://github.com/google/re2"
+UPSTREAM_VER=2024-06-01
+VER=${UPSTREAM_VER//-/}
+SRCS="git::commit=${UPSTREAM_VER}::https://github.com/google/re2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10500"


### PR DESCRIPTION
Topic Description
-----------------

- re2: update to 20240601

Package(s) Affected
-------------------

- re2: 20240601

Security Update?
----------------

No

Build Order
-----------

```
#buildit re2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
