### PR TITLE
haruna: update to 1.1.2

### DIFF
--- a/desktop-kde/haruna/spec
+++ b/desktop-kde/haruna/spec
@@ -1,4 +1,4 @@
-VER=0.12.3
-SRCS="tbl::https://download.kde.org/stable/haruna/haruna-$VER.tar.xz"
-CHKSUMS="sha256::d0202e0060ae86e10c461e7529f6de6b67f8281bf7b82c845479f46772b9fa6f"
+VER=1.1.2
+SRCS="git::commit=tags/v$VER::https://invent.kde.org/multimedia/haruna"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=267594"


### PR DESCRIPTION
Topic Description
-----------------

- haruna: update to 1.1.2
    - Update source uri

Package(s) Affected
-------------------

- haruna: 1.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit haruna
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
