### PR TITLE
haruna: do not execute new mpv window

### DIFF
--- a/desktop-kde/haruna/autobuild/patches/0001-mpv-set-vo-to-libmpv-otherwise-mpv-creates-it-s-own-.patch
+++ b/desktop-kde/haruna/autobuild/patches/0001-mpv-set-vo-to-libmpv-otherwise-mpv-creates-it-s-own-.patch
@@ -1,0 +1,56 @@
+From 711e1187f2436ef3ebc364b8d064c1536acceed8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?George=20Florea=20B=C4=83nu=C8=99?= <georgefb899@gmail.com>
+Date: Fri, 19 Apr 2024 02:37:32 +0300
+Subject: [PATCH] mpv: set vo to libmpv, otherwise mpv creates it's own window
+
+BUG: 485720
+---
+ src/mpv/mpvitem.cpp     | 2 ++
+ src/mpv/mpvpreview.cpp  | 3 ++-
+ src/mpv/mpvproperties.h | 3 +++
+ 3 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/mpv/mpvitem.cpp b/src/mpv/mpvitem.cpp
+index 73a65811..7d6a0d85 100644
+--- a/src/mpv/mpvitem.cpp
++++ b/src/mpv/mpvitem.cpp
+@@ -116,6 +116,8 @@ void MpvItem::initProperties()
+     //    setProperty(QStringLiteral("terminal"), InformationSettings::mpvLogging());
+     //    setProperty(QStringLiteral("msg-level"), QStringLiteral("all=v"));
+ 
++    Q_EMIT setProperty(MpvProperties::self()->VO, QStringLiteral("libmpv"));
++
+     QString hwdec = PlaybackSettings::useHWDecoding() ? PlaybackSettings::hWDecoding() : QStringLiteral("no");
+     setProperty(MpvProperties::self()->HardwareDecoding, hwdec);
+     setProperty(MpvProperties::self()->VolumeMax, QStringLiteral("100"));
+diff --git a/src/mpv/mpvpreview.cpp b/src/mpv/mpvpreview.cpp
+index 8df68856..c876cd0c 100644
+--- a/src/mpv/mpvpreview.cpp
++++ b/src/mpv/mpvpreview.cpp
+@@ -11,7 +11,8 @@
+ 
+ MpvPreview::MpvPreview()
+ {
+-    mpv_observe_property(m_mpv, 0, "time-pos", MPV_FORMAT_DOUBLE);
++    Q_EMIT setProperty(MpvProperties::self()->VO, QStringLiteral("libmpv"));
++    Q_EMIT observeProperty(MpvProperties::self()->Position, MPV_FORMAT_DOUBLE);
+ 
+     setProperty(MpvProperties::self()->Mute, true);
+     setProperty(MpvProperties::self()->Pause, true);
+diff --git a/src/mpv/mpvproperties.h b/src/mpv/mpvproperties.h
+index f632957c..b8988a8e 100644
+--- a/src/mpv/mpvproperties.h
++++ b/src/mpv/mpvproperties.h
+@@ -20,6 +20,9 @@ public:
+         return &p;
+     }
+ 
++    Q_PROPERTY(QString VO MEMBER Pause CONSTANT)
++    const QString VO{QStringLiteral("vo")};
++
+     Q_PROPERTY(QString Pause MEMBER Pause CONSTANT)
+     const QString Pause{QStringLiteral("pause")};
+ 
+-- 
+2.45.2
+

--- a/desktop-kde/haruna/spec
+++ b/desktop-kde/haruna/spec
@@ -1,4 +1,5 @@
 VER=0.12.3
+REL=1
 SRCS="tbl::https://download.kde.org/stable/haruna/haruna-$VER.tar.xz"
 CHKSUMS="sha256::d0202e0060ae86e10c461e7529f6de6b67f8281bf7b82c845479f46772b9fa6f"
 CHKUPDATE="anitya::id=267594"


### PR DESCRIPTION
Topic Description
-----------------

- haruna: (upstream) do not execute new mpv window

Package(s) Affected
-------------------

- haruna: 0.12.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit haruna
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
