### PR TITLE
darktable: update to 4.8.0

### DIFF
--- a/app-creativity/darktable/autobuild/defines
+++ b/app-creativity/darktable/autobuild/defines
@@ -5,7 +5,7 @@ PKGDEP="colord-gtk dbus-glib exiv2 flickcurl graphicsmagick gtk-3 \
         librsvg libsecret libsoup libtiff libwebp iso-codes\
         libxslt openexr openjpeg pugixml sdl sqlite libosmgpsmap \
         libcl jasper gmic lua-5.4 libheif libavif portmidi \
-        libcamera"
+        libcamera libjxl"
 BUILDDEP="cmake gnome-doc-utils intltool po4a llvm sphinx doxygen"
 PKGDES="Utility to organize and develop raw images"
 
@@ -20,7 +20,6 @@ CMAKE_AFTER=(
 	-DBUILD_SHARED_LIBS=ON
 	-DBUILD_SSE2_CODEPATHS=OFF
 	-DBUILD_TOOLS=ON
-	-DCMAKE_SKIP_RPATH=OFF
 	-DDONT_USE_INTERNAL_LUA=ON
 	-DUSE_AVIF=ON
 	-DUSE_CAMERA_SUPPORT=ON
@@ -32,6 +31,7 @@ CMAKE_AFTER=(
 	-DUSE_LUA=ON
 	-DUSE_OPENCL=OFF
 	-DRAWSPEED_ENABLE_LTO=ON
+	-DCMAKE_SKIP_INSTALL_RPATH=OFF
 )
 CMAKE_AFTER__SSE=(
 	-DBUILD_SSE2_CODEPATHS=ON

--- a/app-creativity/darktable/autobuild/patches/0001-common-guided_filter-remove-broken-ifdefs-on-ppc.patch
+++ b/app-creativity/darktable/autobuild/patches/0001-common-guided_filter-remove-broken-ifdefs-on-ppc.patch
@@ -1,7 +1,7 @@
-From 00afe5689ec638db5d46336240db9946e44c14af Mon Sep 17 00:00:00 2001
+From 14cf9c2d9e85f1dd3cf564c7e9bb1233c3bf774a Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Tue, 20 Dec 2022 01:01:11 -0500
-Subject: [PATCH 1/2] common/guided_filter: remove broken ifdefs on ppc
+Subject: [PATCH] common/guided_filter: remove broken ifdefs on ppc
 
 ---
  src/common/sse.h | 4 +++-
@@ -23,5 +23,5 @@ index f7609add9a..45d9c8e461 100644
  
  
 -- 
-2.44.0
+2.45.2
 

--- a/app-creativity/darktable/autobuild/patches/0002-fix-building-for-mips64-and-loongarch64.patch
+++ b/app-creativity/darktable/autobuild/patches/0002-fix-building-for-mips64-and-loongarch64.patch
@@ -1,26 +1,20 @@
-From fe2144cd2647757ce96a326872b47cea41f8e9e6 Mon Sep 17 00:00:00 2001
+From 27269de3ff9d78b5fa25678d3d8bc54d538b2576 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Tue, 20 Dec 2022 01:04:49 -0500
-Subject: [PATCH 2/2] fix building for mips64 and loongarch64
+Subject: [PATCH] fix building for mips64 and loongarch64
 
 ---
- src/is_supported_platform.h | 17 +++++++++++++++--
- 1 file changed, 15 insertions(+), 2 deletions(-)
+ src/is_supported_platform.h | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/src/is_supported_platform.h b/src/is_supported_platform.h
-index 03a77f704d..275c12a28d 100644
+index 8fc8c941f3..abeadc1918 100644
 --- a/src/is_supported_platform.h
 +++ b/src/is_supported_platform.h
-@@ -36,6 +36,18 @@
+@@ -36,6 +36,12 @@
  #define DT_SUPPORTED_ARMv8A 0
  #endif
  
-+#if defined(__loongarch__) && __loongarch_grlen == 64
-+#define DT_SUPPORTED_LOONGARCH64 1
-+#else
-+#define DT_SUPPORTED_LOONGARCH64 0
-+#endif
-+
 +#if defined(__mips__) && defined(__mips64)
 +#define DT_SUPPORTED_MIPS64 1
 +#else
@@ -30,20 +24,21 @@ index 03a77f704d..275c12a28d 100644
  #if defined(__PPC64__)
  #define DT_SUPPORTED_PPC64 1
  #else
-@@ -48,16 +60,17 @@
- #define DT_SUPPORTED_RISCV64 0
+@@ -54,17 +60,18 @@
+ #define DT_SUPPORTED_LOONGARCH64 0
  #endif
  
--#if (DT_SUPPORTED_X86 + DT_SUPPORTED_ARMv8A + DT_SUPPORTED_PPC64 + DT_SUPPORTED_RISCV64) > 1
-+#if (DT_SUPPORTED_X86 + DT_SUPPORTED_ARMv8A + DT_SUPPORTED_LOONGARCH64 + DT_SUPPORTED_MIPS64 + DT_SUPPORTED_PPC64 + DT_SUPPORTED_RISCV64) > 1
+-#if (DT_SUPPORTED_X86 + DT_SUPPORTED_ARMv8A + DT_SUPPORTED_PPC64 + DT_SUPPORTED_RISCV64 + DT_SUPPORTED_LOONGARCH64) > 1
++#if (DT_SUPPORTED_X86 + DT_SUPPORTED_ARMv8A + DT_SUPPORTED_PPC64 + DT_SUPPORTED_RISCV64 + DT_SUPPORTED_LOONGARCH64 + DT_SUPPORTED_MIPS64) > 1
  #error "Looks like hardware platform detection macros are broken?"
  #endif
  
--#if !DT_SUPPORTED_X86 && !DT_SUPPORTED_ARMv8A && !DT_SUPPORTED_PPC64 && !DT_SUPPORTED_RISCV64
-+#if !DT_SUPPORTED_X86 && !DT_SUPPORTED_ARMv8A && !DT_SUPPORTED_LOONGARCH64 && !DT_SUPPORTED_MIPS64 && !DT_SUPPORTED_PPC64 && !DT_SUPPORTED_RISCV64
- #error "Unfortunately we only work on amd64, ARMv8-A, PPC64 (64-bit little-endian only) and riscv64"
+-#if !DT_SUPPORTED_X86 && !DT_SUPPORTED_ARMv8A && !DT_SUPPORTED_PPC64 && !DT_SUPPORTED_RISCV64 && !DT_SUPPORTED_LOONGARCH64
++#if !DT_SUPPORTED_X86 && !DT_SUPPORTED_ARMv8A && !DT_SUPPORTED_PPC64 && !DT_SUPPORTED_RISCV64 && !DT_SUPPORTED_LOONGARCH64 && !DT_SUPPORTED_MIPS64
+ #error "Unfortunately we only work on amd64, ARMv8-A, PPC64 (64-bit little-endian only), riscv64 and loongarch64"
  #endif
  
+ #undef DT_SUPPORTED_LOONGARCH64
  #undef DT_SUPPORTED_RISCV64
  #undef DT_SUPPORTED_PPC64
 +#undef DT_SUPPORTED_MIPS64
@@ -51,5 +46,5 @@ index 03a77f704d..275c12a28d 100644
  #undef DT_SUPPORTED_X86
  
 -- 
-2.44.0
+2.45.2
 

--- a/app-creativity/darktable/spec
+++ b/app-creativity/darktable/spec
@@ -1,5 +1,4 @@
-VER=4.6.1
-REL=1
+VER=4.8.0
 SRCS="git::commit=tags/release-$VER::https://github.com/darktable-org/darktable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=392"


### PR DESCRIPTION
Topic Description
-----------------

- darktable: upgrade to 4.8.0, enable libjxl

Package(s) Affected
-------------------

- darktable: 1:4.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit darktable
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
