### PR TITLE
simde: new, 0.8.2

### DIFF
--- a/runtime-common/simde/autobuild/defines
+++ b/runtime-common/simde/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=simde
+PKGSEC=libs
+PKGDEP=""
+PKGDES="Implementations of SIMD instruction sets for systems that don't natively support them"
+ABHOST=noarch

--- a/runtime-common/simde/spec
+++ b/runtime-common/simde/spec
@@ -1,0 +1,4 @@
+VER=0.8.2
+SRCS="git::commit=tags/v$VER::https://github.com/simd-everywhere/simde"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=180908"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

simde: new, 0.8.2

Package(s) Affected
-------------------

simde

Security Update?
----------------

No

Build Order
-----------

```
#buildit simde
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

Architectural progress for experimental ports does not impede on merging of this topic.

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`