### PR TITLE
numpy new vierson 2.0.0

### DIFF
--- a/lang-python/meson-python/autobuild/defines
+++ b/lang-python/meson-python/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=meson-python
+PKGSEC=python
+PKGDEP="python-3 pyproject-metadata"
+BUILDDEP="python-installer patchelf python-build wheel"
+PKGDES="Meson Python build backend"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/meson-python/spec
+++ b/lang-python/meson-python/spec
@@ -1,0 +1,4 @@
+VER=0.16.0
+SRCS="git::commit=tags/$VER::https://github.com/mesonbuild/meson-python.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=248985"

--- a/lang-python/numpy-2/autobuild/defines
+++ b/lang-python/numpy-2/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=numpy
+PKGSEC=python
+PKGDEP="lapack python-3 openblas"
+BUILDDEP="setuptools cython meson meson-python llvm"
+PKGDES="Scientific tools for Python"
+
+USECLANG=1
+USECLANG__LOONGSON3=0
+ABTYPE=meson
+
+NOSTATIC=0
+NOPYTHON2=1

--- a/lang-python/numpy-2/autobuild/prepare
+++ b/lang-python/numpy-2/autobuild/prepare
@@ -1,0 +1,13 @@
+abinfo "Setting Meson to vendored one in the numpy tree ..."
+export PATH="$SRCDIR"/vendored-meson/meson/:$PATH
+ln -sv meson.py "$SRCDIR"/vendored-meson/meson/meson
+
+# use lld on applicable platforms
+if bool USECLANG; then
+  if command -v ld.lld; then
+    abinfo "Using ld.lld on this platform."
+    export LDFLAGS="$LDFLAGS -fuse-ld=lld -Wl,--lto-O3"
+  fi
+else
+    abinfo "NOT using ld.lld on this platform"
+fi

--- a/lang-python/numpy-2/spec
+++ b/lang-python/numpy-2/spec
@@ -1,0 +1,4 @@
+VER=2.0.0
+SRCS="tbl::https://pypi.org/packages/source/n/numpy/numpy-$VER.tar.gz"
+CHKSUMS="sha256::cf5d1c9e6837f8af9f92b6bd3e86d513cdc11f60fd62185cc49ec7d1aba34864"
+CHKUPDATE="anitya::id=41556"

--- a/lang-python/pyproject-metadata/autobuild/defines
+++ b/lang-python/pyproject-metadata/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=pyproject-metadata
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-installer python-build wheel"
+PKGDES="PEP 621 metadata parsing"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pyproject-metadata/spec
+++ b/lang-python/pyproject-metadata/spec
@@ -1,0 +1,4 @@
+VER=0.8.0
+SRCS="git::commit=tags/$VER::https://github.com/pypa/pyproject-metadata.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=255630"

--- a/lang-python/python-patchelf/autobuild/defines
+++ b/lang-python/python-patchelf/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=python-patchelf
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools-scm scikit-build"
+PKGDES="A small utility to modify the dynamic linker and RPATH of ELF executables."
+
+ABTYPE=python
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/python-patchelf/spec
+++ b/lang-python/python-patchelf/spec
@@ -1,0 +1,4 @@
+VER=0.18.0.0
+SRCS="git::copy-repo=true;commit=tags/v$VER::https://github.com/mayeut/patchelf-pypi.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=303267"


### PR DESCRIPTION
Topic Description
-----------------

- numpy-2: new, 2.0.0
    Numpy major version update, ABI has changed
- pyproject-metadata: new, 0.8.0
    Building meson-python requires
- meson-python: new, 0.16.0
    Building numpy-2 requires

Package(s) Affected
-------------------

- numpy: 2.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit numpy-2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
