### PR TITLE
qemu: update to 9.0.1

### DIFF
--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,9 +1,8 @@
-VER=9.0.0
-REL=1
+VER=9.0.1
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz \
       file::rename=edk2-loongarch64-code.fd::https://github.com/AOSC-Dev/LoongArchQemuVirtFirmware/releases/download/20240430-1/QEMU_EFI.fd \
       file::rename=edk2-loongarch64-vars.fd::https://github.com/AOSC-Dev/LoongArchQemuVirtFirmware/releases/download/20240430-1/QEMU_VARS.fd"
-CHKSUMS="sha256::32708ac66c30d8c892633ea968c771c1c76d597d70ddead21a0d22ccf386da69 \
+CHKSUMS="sha256::d0f4db0fbd151c0cf16f84aeb2a500f6e95009732546f44dafab8d2049bbb805 \
          sha256::7648ded53fb8d250ec1a9fb3b6d274dc23e3ddd6d4046fe026bd7bc41a3c0e40 \
          sha256::8b634c1e6bd11607850b69111f6c4dbd1583dbbd1460dac72dbacbdc1a4a130a"
 CHKUPDATE="anitya::id=13607"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: update to 9.0.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- qemu: 9.0.1
- qemu-aarch64-static: 9.0.1
- qemu-alpha-static: 9.0.1
- qemu-arm-static: 9.0.1
- qemu-armeb-static: 9.0.1
- qemu-cris-static: 9.0.1
- qemu-i386-static: 9.0.1
- qemu-loongarch64-static: 9.0.1
- qemu-m68k-static: 9.0.1
- qemu-microblaze-static: 9.0.1
- qemu-microblazeel-static: 9.0.1
- qemu-mips-static: 9.0.1
- qemu-mips64-static: 9.0.1
- qemu-mips64el-static: 9.0.1
- qemu-mipsel-static: 9.0.1
- qemu-mipsn32-static: 9.0.1
- qemu-mipsn32el-static: 9.0.1
- qemu-nios2-static: 9.0.1
- qemu-or32-static: 9.0.1
- qemu-ppc-static: 9.0.1
- qemu-ppc64-static: 9.0.1
- qemu-ppc64le-static: 9.0.1
- qemu-riscv32-static: 9.0.1
- qemu-riscv64-static: 9.0.1
- qemu-s390x-static: 9.0.1
- qemu-sh4-static: 9.0.1
- qemu-sh4eb-static: 9.0.1
- qemu-sparc-static: 9.0.1
- qemu-sparc32plus-static: 9.0.1
- qemu-sparc64-static: 9.0.1
- qemu-user-static: 9.0.1
- qemu-x86-64-static: 9.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
