### PR TITLE
opencv (OpenCV): rework rebuilds for 4.9.0

### DIFF
--- a/desktop-kde/digikam/spec
+++ b/desktop-kde/digikam/spec
@@ -1,5 +1,5 @@
 VER=7.9.0
-REL=4
+REL=5
 SRCS="tbl::http://download.kde.org/stable/digikam/$VER/digiKam-$VER.tar.xz \
       file::rename=shapepredictor.dat::http://cdn.files.kde.org/digikam/facesengine/shape-predictor/shapepredictor.dat \
       file::rename=yolov3-face.cfg::http://cdn.files.kde.org/digikam/facesengine/dnnface/yolov3-face.cfg \

--- a/runtime-imaging/gmic/spec
+++ b/runtime-imaging/gmic/spec
@@ -1,4 +1,5 @@
 VER=3.2.6
+REL=1
 SRCS="tbl::https://gmic.eu/files/source/gmic_${VER}.tar.gz"
 CHKSUMS="sha256::55993e55a30fe2da32f9533b9db2a3250affa2b32003b0c49c36eec2b2c6e007"
 CHKUPDATE="anitya::id=10217"

--- a/runtime-imaging/openimageio/spec
+++ b/runtime-imaging/openimageio/spec
@@ -1,5 +1,5 @@
 VER=2.4.17.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/AcademySoftwareFoundation/OpenImageIO"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2548"

--- a/runtime-multimedia/frei0r-plugins/spec
+++ b/runtime-multimedia/frei0r-plugins/spec
@@ -1,4 +1,5 @@
 VER=2.3.2
+REL=1
 SRCS="tbl::https://github.com/dyne/frei0r/archive/refs/tags/v$VER.tar.gz"
 CHKSUMS="sha256::304291e0ecb456a8b054fe04e14adc50ace54d0223b7b29165ff5343e820ef9d"
 CHKUPDATE="anitya::id=10670"

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,4 +1,5 @@
 VER=1.24.4
+REL=1
 SRCS="tbl::https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/$VER/gstreamer-$VER.tar.gz"
 CHKSUMS="sha256::3121a186f707b2bd5a8ecbb4a84e9a31a25401cdaa03acff891b634b112800e1"
 CHKUPDATE="anitya::id=1263"

--- a/runtime-multimedia/mlt/spec
+++ b/runtime-multimedia/mlt/spec
@@ -1,4 +1,5 @@
 VER=7.22.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/mltframework/mlt"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11007"

--- a/runtime-scientific/opencv/autobuild/defines
+++ b/runtime-scientific/opencv/autobuild/defines
@@ -13,9 +13,9 @@ BUILDDEP="apache-ant beautifulsoup4 eigen-3 gflags glog glu jasper lapack \
 BUILDDEP__MIPS64R6EL="${BUILDDEP/apache-ant/}"
 PKGDES="Open Source Computer Vision Library"
 
-PKGBREAK="caffe-cpu<=1.0-15 digikam<=7.6.0 frei0r-plugins<=1.7.0 \
-          gst-plugins-bad-1-0<=1.18.5 mlt<=7.0.1-3 mlt-6<=6.26.1-3 \
-          openimageio<=2.2.19.0-3 waifu2x-converter-cpp<=1:5.3.4-1"
+PKGBREAK="caffe-cpu<=1.0-15 digikam<=7.9.0-4 frei0r-plugins<=2.3.2 \
+          gstreamer<=1.24.4 gst-plugins-bad-1-0<=1.18.5 mlt<=7.22.0 \
+          mlt-6<=6.26.1-3 openimageio<=2.4.17.0-1 waifu2x-converter-cpp<=1:5.3.4-1"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER="-DCV_TRACE=OFF \

--- a/runtime-scientific/opencv/spec
+++ b/runtime-scientific/opencv/spec
@@ -1,5 +1,5 @@
 VER=4.9.0
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/opencv/opencv \
       git::commit=tags/$VER;rename=opencv_contrib::https://github.com/opencv/opencv_contrib"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- openimageio: rebuild for OpenCV 4.9.0
- mlt: rebuild for OpenCV 4.9.0
- gstreamer: rebuild for OpenCV 4.9.0
- gmic: rebuild for OpenCV 4.9.0
- frei0r-plugins: rebuild for OpenCV 4.9.0
- digikam: rebuild for OpenCV 4.9.0
- opencv: update PKGBREAK for 4.9.0

Package(s) Affected
-------------------

- digikam: 7.9.0-5
- frei0r-plugins: 2.3.2-1
- gmic: 3.2.6-1
- gstreamer: 1.24.4-1
- mlt: 7.22.0-1
- opencv: 4.9.0-2
- openimageio: 2.4.17.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit opencv:-pkgbreak digikam frei0r-plugins gmic gstreamer mlt openimageio opencv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
