### PR TITLE
setuptools-rust update to 1.9.0

### DIFF
--- a/lang-python/setuptools-rust/autobuild/defines
+++ b/lang-python/setuptools-rust/autobuild/defines
@@ -3,10 +3,8 @@ PKGSEC=python
 PKGDES="Setuptools Rust extension plugin"
 PKGDEP="rustc setuptools semantic-version"
 
-# FIXME: No Rust support currently on MIPS64 R6
-PKGDEP__MIPS64R6EL="setuptools semantic-version"
-BUILDDEP="wheel"
+BUILDDEP="wheel python-installer python-build setuptools-scm"
 
 NOPYTHON2=1
-ABTYPE=python
+ABTYPE=pep517
 ABHOST=noarch

--- a/lang-python/setuptools-rust/spec
+++ b/lang-python/setuptools-rust/spec
@@ -1,4 +1,4 @@
-VER=1.5.2
+VER=1.9.0
 SRCS="https://pypi.io/packages/source/s/setuptools-rust/setuptools-rust-$VER.tar.gz"
-CHKSUMS="sha256::d8daccb14dc0eae1b6b6eb3ecef79675bd37b4065369f79c35393dd5c55652c7"
+CHKSUMS="sha256::704df0948f2e4cc60c2596ad6e840ea679f4f43e58ed4ad0c1857807240eab96"
 CHKUPDATE="anitya::id=122284"


### PR DESCRIPTION
Topic Description
-----------------

- setuptools-rust: update to 1.9.0

Package(s) Affected
-------------------

- setuptools-rust: 1.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit setuptools-rust
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
