### PR TITLE
tig: update to 2.5.10

### DIFF
--- a/app-utils/tig/spec
+++ b/app-utils/tig/spec
@@ -1,5 +1,5 @@
-VER=2.4.1
+VER=2.5.10
 SRCS="tbl::https://github.com/jonas/tig/archive/tig-$VER.tar.gz"
-CHKSUMS="sha256::833c81b04082ed318ae5fd5342193f086781e74372cf418c2f82a1313b84cedd"
+CHKSUMS="sha256::bb0ceda7694ed161a830d022c2f282388c7979d97a409a81028d489738ad127a"
 SUBDIR="tig-tig-$VER"
 CHKUPDATE="anitya::id=4969"


### PR DESCRIPTION
Topic Description
-----------------

- tig: update to 2.5.10
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- tig: 2.5.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit tig
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
