### PR TITLE
chromium: update to 126.0.6478.126

### DIFF
--- a/app-web/chromium/spec
+++ b/app-web/chromium/spec
@@ -1,11 +1,11 @@
-VER=126.0.6478.114
+VER=126.0.6478.126
 LAUNCHERVER=8
 SRCS="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$VER.tar.xz \
       https://github.com/foutrelis/chromium-launcher/archive/v$LAUNCHERVER.tar.gz \
       file::rename=chromium-$VER.txt::https://chromium.googlesource.com/chromium/src/+/$VER?format=TEXT"
-CHKSUMS="sha256::cf4aad7fccc2a6c2339691c23f4c46ef2818e2474a9f83292b237eaa958015ed \
+CHKSUMS="sha256::5d5206637e659f03e006cd8b6b269c49c0c2c697d10517e14dbcea851831e143 \
          sha256::213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a \
-         sha256::886bf0ece16481aa112b7b9d63042eb25a482aeaddf2ef7326430b0beecb996e"
+         sha256::1bdd5b76158af6f648f2138ab468381d89fe3d58105a3e66972935ff51cfe812"
 SUBDIR="chromium-$VER"
 CHKUPDATE="anitya::id=13344"
 ENVREQ__AMD64="core=96"


### PR DESCRIPTION
Topic Description
-----------------

- chromium: update to 126.0.6478.126
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- chromium: 126.0.6478.126

Security Update?
----------------

No

Build Order
-----------

```
#buildit chromium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
