### PR TITLE
qt-5: fix doc (rework)

### DIFF
--- a/runtime-desktop/qt-5/01-runtime/defines
+++ b/runtime-desktop/qt-5/01-runtime/defines
@@ -11,7 +11,7 @@ PKGDEP="alsa-lib bluez cups dbus desktop-file-utils double-conversion ffmpeg \
         snappy sqlite srtp systemd tslib vulkan x11-lib xcb-util \
         xcb-util-cursor xcb-util-image xcb-util-keysyms xcb-util-renderutil \
         xcb-util-wm xdg-utils zlib"
-BUILDDEP="gperf gtk-3 mariadb nodejs openssl postgresql python-2 ruby \
+BUILDDEP="gperf gtk-3 mariadb llvm nodejs openssl postgresql python-2 ruby \
           unixodbc ninja cmake qt-5"
 BUILDDEP__NOWEBENGINE=" \
           ${BUILDDEP/nodejs/}"

--- a/runtime-desktop/qt-5/spec
+++ b/runtime-desktop/qt-5/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=5.15.13
 VER=${UPSTREAM_VER}+webengine5.15.16+webkit5.212.0+kde20240408
-REL=3
+REL=4
 SRCS="https://repo.aosc.io/aosc-repacks/qt-5-$VER.tar.xz"
 CHKSUMS="sha256::48b528491c345c32760a0554c1f99c9c3fbd5bc8d8200bf1b28f008d3c3e600a"
 SUBDIR="qt-${VER:0:1}"


### PR DESCRIPTION
Topic Description
-----------------

- qt-5: fix doc (rework)

Package(s) Affected
-------------------

- qt-5: 1:5.15.13+webengine5.15.16+webkit5.212.0+kde20240408-4
- qt-5-doc: 1:5.15.13+webengine5.15.16+webkit5.212.0+kde20240408-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
