### PR TITLE
wavemon: update to 0.9.5

### DIFF
--- a/app-network/wavemon/autobuild/prepare
+++ b/app-network/wavemon/autobuild/prepare
@@ -1,1 +1,0 @@
-export CFLAGS="${CFLAGS} -I/usr/include/libnl3 -lpthread"

--- a/app-network/wavemon/spec
+++ b/app-network/wavemon/spec
@@ -1,3 +1,4 @@
-VER=0.9.1
-SRCS="tbl::https://github.com/uoaerg/wavemon/archive/v$VER.tar.gz"
-CHKSUMS="sha256::5ebd5b79d3b7c546bc16b95161872c699a75e9acdfc6e3f02ec48dad10802067"CHKUPDATE="anitya::id=5120"
+VER=0.9.5
+SRCS="git::commit=tags/v$VER::https://github.com/uoaerg/wavemon"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=5120"

--- a/app-network/wavemon/spec
+++ b/app-network/wavemon/spec
@@ -1,4 +1,5 @@
 VER=0.9.5
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/uoaerg/wavemon"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5120"


### PR DESCRIPTION
Topic Description
-----------------

- wavemon: bump REL for topic Revision Marking Guidelines
- wavemon: update to 0.9.5

Package(s) Affected
-------------------

- wavemon: 0.9.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wavemon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
