### PR TITLE
intel-oneapi-basekit: update to 2024.2.0

### DIFF
--- a/app-devel/intel-oneapi-basekit/spec
+++ b/app-devel/intel-oneapi-basekit/spec
@@ -1,6 +1,6 @@
-VER=2024.1.0
-PKG_URL=fdc7a2bc-b7a8-47eb-8876-de6201297144
-PKG_CODE=596
+VER=2024.2.0
+PKG_URL=9a98af19-1c68-46ce-9fdd-e249240c7c42
+PKG_CODE=634
 SRCS="file::rename=l_BaseKit_p_"${VER}"."${PKG_CODE}"_offline.sh::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"${PKG_URL}"/l_BaseKit_p_"${VER}"."${PKG_CODE}"_offline.sh"
-CHKSUMS="sha256::25473cb183421f6eb5703be8bff14e7d84a897b6b76b849717301489e55749c8"
+CHKSUMS="sha256::ae97f1b7146f610c07232d75cac8d37f6b2998df416411bef9a9f6c9d23591a4"
 CHKUPDATE="anitya::id=372585"


### PR DESCRIPTION
Topic Description
-----------------

- intel-oneapi-basekit: update to 2024.2.0

Package(s) Affected
-------------------

- intel-oneapi-basekit: 2024.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-oneapi-basekit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
