### PR TITLE
qt-6: add a patch to automatically select GLES

### DIFF
--- a/runtime-desktop/qt-6/autobuild/patches/0007-fallback-to-GLES-if-GL-EGL-context-creation-failed.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0007-fallback-to-GLES-if-GL-EGL-context-creation-failed.patch
@@ -1,0 +1,35 @@
+From 3876d760d51369d1ab7ba84daacaa5ebadaaedd5 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Wed, 26 Jun 2024 22:16:10 +0800
+Subject: [PATCH] fallback to GLES if GL EGL context creation failed
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ qtbase/src/gui/opengl/platform/egl/qeglconvenience.cpp | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/qtbase/src/gui/opengl/platform/egl/qeglconvenience.cpp b/qtbase/src/gui/opengl/platform/egl/qeglconvenience.cpp
+index 4af50d72f2..1e7b2c3228 100644
+--- a/qtbase/src/gui/opengl/platform/egl/qeglconvenience.cpp
++++ b/qtbase/src/gui/opengl/platform/egl/qeglconvenience.cpp
+@@ -98,6 +98,17 @@ bool q_reduceConfigAttributes(QList<EGLint> *configAttributes)
+         configAttributes->remove(i,2);
+     }
+ 
++#ifdef EGL_VERSION_1_4
++    i = configAttributes->indexOf(EGL_RENDERABLE_TYPE);
++    if (i >= 0) {
++        EGLint renderableType = configAttributes->at(i+1);
++        if (renderableType == EGL_OPENGL_BIT) {
++            renderableType = EGL_OPENGL_ES2_BIT;
++            configAttributes->replace(i+1,renderableType);
++	}
++    }
++#endif
++
+ #ifdef EGL_VG_ALPHA_FORMAT_PRE_BIT
+     // For OpenVG, we sometimes try to create a surface using a pre-multiplied format. If we can't
+     // find a config which supports pre-multiplied formats, remove the flag on the surface type:
+-- 
+2.45.2
+

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,5 +1,5 @@
 VER=6.7.1
-REL=1
+REL=2
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
 CHKSUMS="sha256::38dbf2768776e875ed5cdea8cccf1a240512a29769768084430914c4a33bedc4"
 CHKUPDATE="anitya::id=7927"


### PR DESCRIPTION
Topic Description
-----------------

Allow Qt 6 to work with GLES-only EGL driver.

Tested on Lichee Console 4A with GLVNDized PVR driver.

Package(s) Affected
-------------------

- `qt-6`

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6
```


Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

Architectural progress for experimental ports does not impede on merging of this topic.

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
