### PR TITLE
dill: update to 0.3.8

### DIFF
--- a/lang-python/dill/spec
+++ b/lang-python/dill/spec
@@ -1,3 +1,4 @@
-VER=0.3.5.1
+VER=0.3.8
 SRCS="tbl::https://pypi.io/packages/source/d/dill/dill-$VER.tar.gz"
-CHKSUMS="sha256::d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"
+CHKSUMS="sha256::3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca"
+CHKUPDATE="anitya::id=7687"


### PR DESCRIPTION
Topic Description
-----------------

- dill: update to 0.3.8
- qt-5: fix doc (rework)

Package(s) Affected
-------------------

- dill: 0.3.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit dill
```

Test Build(s) Done
------------------

