### PR TITLE
tree-sitter: update to 0.22.6

### DIFF
--- a/runtime-editors/tree-sitter/spec
+++ b/runtime-editors/tree-sitter/spec
@@ -1,4 +1,4 @@
-VER=0.20.9
+VER=0.22.6
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter/tree-sitter"
 CHKSUMS="SKIP"
-CHKUPDATES="anitya::id=142464"
+CHKUPDATE="anitya::id=142464"


### PR DESCRIPTION
Topic Description
-----------------

- tree-sitter: update to 0.22.6
- qt-5: fix doc (rework)

Package(s) Affected
-------------------

- tree-sitter: 0.22.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit tree-sitter
```

Test Build(s) Done
------------------

