### PR TITLE
desktop-base: move noto-fonts and noto-cjk-fonts to PKGRECOM

### DIFF
--- a/meta-bases/desktop-base/autobuild/defines
+++ b/meta-bases/desktop-base/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=desktop-base
 PKGSEC=Bases
-PKGDEP="noto-fonts noto-cjk-fonts x11-base"
+PKGDEP="x11-base"
 BUILDDEP="pillow pyyaml lxml imagemagick"
+PKGRECOM="noto-fonts noto-cjk-fonts"
 PKGDES="Base desktop definition and assets for AOSC OS"
 
 ABHOST=noarch

--- a/meta-bases/desktop-base/spec
+++ b/meta-bases/desktop-base/spec
@@ -1,3 +1,4 @@
 VER=11.3.1
+REL=1
 SRCS="git::rename=logo;commit=aa0462d91c4cee125961d5bb29eea8aa9c574359::https://github.com/AOSC-Dev/logo"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- desktop-base: move `noto-fonts` and `noto-cjk-fonts` to `PKGRECOM`

Package(s) Affected
-------------------

- desktop-base: 11.3.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit desktop-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
