### PR TITLE
handbrake: update to 1.8.1

### DIFF
--- a/app-multimedia/handbrake/spec
+++ b/app-multimedia/handbrake/spec
@@ -1,5 +1,4 @@
-VER=1.7.3
-REL=1
+VER=1.8.1
 SRCS="git::commit=tags/$VER::https://github.com/HandBrake/HandBrake"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9156"


### PR DESCRIPTION
Topic Description
-----------------

- handbrake: update to 1.8.1
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- handbrake: 1.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit handbrake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
