### PR TITLE
vlc: update to 3.0.21

### DIFF
--- a/app-multimedia/vlc/spec
+++ b/app-multimedia/vlc/spec
@@ -1,5 +1,4 @@
-VER=3.0.20
-REL=7
+VER=3.0.21
 SRCS="tbl::https://get.videolan.org/vlc/$VER/vlc-$VER.tar.xz"
-CHKSUMS="sha256::adc7285b4d2721cddf40eb5270cada2aaa10a334cb546fd55a06353447ba29b5"
+CHKSUMS="sha256::24dbbe1d7dfaeea0994d5def0bbde200177347136dbfe573f5b6a4cee25afbb0"
 CHKUPDATE="anitya::id=6504"


### PR DESCRIPTION
Topic Description
-----------------

- vlc: update to 3.0.21
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- vlc: 3.0.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit vlc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
