### PR TITLE
grub (GRand Unified Bootloader): add --force-extra-removable option

### DIFF
--- a/app-admin/grub/autobuild/amd64/build
+++ b/app-admin/grub/autobuild/amd64/build
@@ -1,6 +1,6 @@
 for i in efi efi32 emu; do
     abinfo "Copy source tree for $i ..."
-    cp -rv "$SRCDIR"/grub-${__GRUBVER} \
+    cp -rv "$SRCDIR"/grub-${__GRUB_VER} \
         "$SRCDIR"/build-$i
 done
 
@@ -59,7 +59,7 @@ make install \
 )
 
 abinfo "Entering source tree for GRUB for PC BIOS ..."
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for PC BIOS ..."
 ./configure \

--- a/app-admin/grub/autobuild/amd64/build.stage2
+++ b/app-admin/grub/autobuild/amd64/build.stage2
@@ -1,6 +1,6 @@
 for i in efi efi32 emu; do
     abinfo "Copy source tree for $i ..."
-    cp -rv "$SRCDIR"/grub-${__GRUBVER} \
+    cp -rv "$SRCDIR"/grub-${__GRUB_VER} \
         "$SRCDIR"/build-$i
 done
 
@@ -42,7 +42,7 @@ make install \
     bashcompletiondir="/usr/share/bash-completion/completions"
 
 abinfo "Entering source tree for GRUB for PC BIOS ..."
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for PC BIOS ..."
 ./configure \

--- a/app-admin/grub/autobuild/arm32/build
+++ b/app-admin/grub/autobuild/arm32/build
@@ -1,4 +1,4 @@
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for EFI (32-bit) ..."
 ./configure \

--- a/app-admin/grub/autobuild/arm32/build.stage2
+++ b/app-admin/grub/autobuild/arm32/build.stage2
@@ -1,4 +1,4 @@
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for EFI (32-bit) ..."
 ./configure \

--- a/app-admin/grub/autobuild/arm64/build
+++ b/app-admin/grub/autobuild/arm64/build
@@ -1,7 +1,7 @@
 abinfo "Setting extra target flags for AArch64 .."
 export TARGET_CFLAGS="${TARGET_CFLAGS} -Os -mpc-relative-literal-loads"
 
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for EFI ..."
 ./configure \

--- a/app-admin/grub/autobuild/arm64/build.stage2
+++ b/app-admin/grub/autobuild/arm64/build.stage2
@@ -1,7 +1,7 @@
 abinfo "Setting extra target flags for AArch64 .."
 export TARGET_CFLAGS="${TARGET_CFLAGS} -Os -mpc-relative-literal-loads"
 
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for EFI ..."
 ./configure \

--- a/app-admin/grub/autobuild/i486/build
+++ b/app-admin/grub/autobuild/i486/build
@@ -1,7 +1,7 @@
 abinfo "Copying build directories for PC BIOS/EFI32 targets ..."
-cp -rv "$SRCDIR"/{grub-${__GRUBVER},build-efi32}
+cp -rv "$SRCDIR"/{grub-${__GRUB_VER},build-efi32}
 
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for PC BIOS ..."
 ./configure \

--- a/app-admin/grub/autobuild/loongarch64/build
+++ b/app-admin/grub/autobuild/loongarch64/build
@@ -1,4 +1,4 @@
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for EFI ..."
 ./configure \

--- a/app-admin/grub/autobuild/loongarch64/build.stage2
+++ b/app-admin/grub/autobuild/loongarch64/build.stage2
@@ -1,4 +1,4 @@
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for EFI ..."
 ./configure \

--- a/app-admin/grub/autobuild/loongson2f/build
+++ b/app-admin/grub/autobuild/loongson2f/build
@@ -1,4 +1,4 @@
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for PMON2000 ..."
 ./configure \

--- a/app-admin/grub/autobuild/patch
+++ b/app-admin/grub/autobuild/patch
@@ -17,11 +17,11 @@ if ab_match_archgroup mainline; then
         < $(readlink "$SRCDIR"/unifont-${__UNIFONTVER}.bdf.gz) \
         > "$SRCDIR"/unifont-${__UNIFONTVER}.bdf
 
-    cd "$SRCDIR"/grub-${__GRUBVER}
+    cd "$SRCDIR"/grub-${__GRUB_VER}
 
     abinfo "Bundling Unifont for use with GRUB ..."
     cp -v "$SRCDIR"/unifont-${__UNIFONTVER}.bdf \
-        "$SRCDIR"/grub-${__GRUBVER}/unifont.bdf
+        "$SRCDIR"/grub-${__GRUB_VER}/unifont.bdf
 fi
 
 # Exception: Adding Unifont for loongson2f support.
@@ -31,14 +31,14 @@ if ab_match_arch loongson2f; then
         < $(readlink "$SRCDIR"/unifont-${__UNIFONTVER}.bdf.gz) \
         > "$SRCDIR"/unifont-${__UNIFONTVER}.bdf
 
-    cd "$SRCDIR"/grub-${__GRUBVER}
+    cd "$SRCDIR"/grub-${__GRUB_VER}
 
     abinfo "Bundling Unifont for use with GRUB ..."
     cp -v "$SRCDIR"/unifont-${__UNIFONTVER}.bdf \
-        "$SRCDIR"/grub-${__GRUBVER}/unifont.bdf
+        "$SRCDIR"/grub-${__GRUB_VER}/unifont.bdf
 fi
 
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 for i in "$SRCDIR"/autobuild/patches/*; do
     abinfo "Applying patch $i ..."

--- a/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,7 +1,7 @@
 From 2ec97c359ea87a2152e4076770c9ec8f7cbd225d Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:54 +0200
-Subject: [PATCH 01/22] Revert "templates: Properly disable the os-prober by
+Subject: [PATCH 01/23] Revert "templates: Properly disable the os-prober by
  default"
 
 This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.

--- a/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,7 +1,7 @@
 From a3daa95d2769516586f7c38af93029663c9133a4 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:58 +0200
-Subject: [PATCH 02/22] Revert "templates: Disable the os-prober by default"
+Subject: [PATCH 02/23] Revert "templates: Disable the os-prober by default"
 
 This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
 ---

--- a/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
+++ b/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
@@ -1,7 +1,7 @@
 From 6bd3d7c7b9e643f6452e8dff6fcebc60d2c4d512 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 17:49:45 -0400
-Subject: [PATCH 03/22] Don't add '*' to highlighted row
+Subject: [PATCH 03/23] Don't add '*' to highlighted row
 
 It is already highlighted.
 ---

--- a/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
+++ b/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
@@ -1,7 +1,7 @@
 From e5c241ea0ea922abbb2ecb8b3140518a6e2a03cd Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:08:23 -0400
-Subject: [PATCH 04/22] Fix border spacing now that we aren't displaying it
+Subject: [PATCH 04/23] Fix border spacing now that we aren't displaying it
 
 ---
  grub-core/normal/menu_text.c | 6 +++---

--- a/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
+++ b/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
@@ -1,7 +1,7 @@
 From 2b35e4db8d9f1f9cab8004e0761a28be960fbf7f Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:30:55 -0400
-Subject: [PATCH 05/22] Indent menu entries
+Subject: [PATCH 05/23] Indent menu entries
 
 ---
  grub-core/normal/menu_text.c | 3 ++-

--- a/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
+++ b/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
@@ -1,7 +1,7 @@
 From d21e8096b9cc9eecfe6da4bb101c6d5d43cec3c5 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:59:36 -0400
-Subject: [PATCH 06/22] Fix margins
+Subject: [PATCH 06/23] Fix margins
 
 ---
  grub-core/normal/menu_text.c | 8 +++-----

--- a/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
+++ b/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
@@ -1,7 +1,7 @@
 From 8ea6cc861054a03a1b437356a0b9b114a0d21adf Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Fri, 21 Jun 2013 14:44:08 -0400
-Subject: [PATCH 07/22] Use -2 instead of -1 for our right-hand margin, so
+Subject: [PATCH 07/23] Use -2 instead of -1 for our right-hand margin, so
  linewrapping works (#976643).
 
 Signed-off-by: Peter Jones <grub2-owner@fedoraproject.org>

--- a/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
+++ b/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
@@ -1,7 +1,7 @@
 From 59c31c490870dd98bc6ca72862a97862bcef0c1b Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 14 Mar 2011 14:27:42 -0400
-Subject: [PATCH 08/22] Don't say "GNU/Linux" in generated menus.
+Subject: [PATCH 08/23] Don't say "GNU/Linux" in generated menus.
 
 ---
  util/grub.d/10_linux.in     | 4 ++--

--- a/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
@@ -1,7 +1,7 @@
 From 12e6fa95ada35a999b46adcbc35a34a73d178ebf Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 16:47:33 -0400
-Subject: [PATCH 09/22] Don't draw a border around the menu
+Subject: [PATCH 09/23] Don't draw a border around the menu
 
 It looks cleaner without it.
 ---

--- a/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
+++ b/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
@@ -1,7 +1,7 @@
 From 8a14427edcdf93bc2c38822465d1082672bb9263 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 10:52:32 -0400
-Subject: [PATCH 10/22] Use the standard margin for the timeout string
+Subject: [PATCH 10/23] Use the standard margin for the timeout string
 
 So that it aligns with the other messages
 ---

--- a/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
+++ b/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
@@ -1,7 +1,7 @@
 From 5ff724e6a6e01cb6f03f5ce09d6cb01a44ad3d67 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:14 -0800
-Subject: [PATCH 11/22] grub-mkrescue: specify -iso-level 3
+Subject: [PATCH 11/23] grub-mkrescue: specify -iso-level 3
 
 This allows GRUB rescue ISOs to boot on LoongArch firmware.
 ---

--- a/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
+++ b/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
@@ -1,7 +1,7 @@
 From b127120988f3d85ebc75c493eba08fc54c8b99dd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:42 -0800
-Subject: [PATCH 12/22] 10_linux: do not count intel-ucode image as a valid
+Subject: [PATCH 12/23] 10_linux: do not count intel-ucode image as a valid
  initrd
 
 ---

--- a/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
+++ b/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
@@ -1,7 +1,7 @@
 From 42a8d6a924f700586328325eb3abe28c4055cc5e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:12:01 -0800
-Subject: [PATCH 13/22] util: add GRUB_COLOR_* variables
+Subject: [PATCH 13/23] util: add GRUB_COLOR_* variables
 
 ---
  util/grub-mkconfig.in    | 2 ++

--- a/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
@@ -1,7 +1,7 @@
 From 5b839a619f7d871de5d6666bde4875c6a262edec Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:26:57 -0800
-Subject: [PATCH 14/22] grub-core: drop GRUB title from the menu
+Subject: [PATCH 14/23] grub-core: drop GRUB title from the menu
 
 We did not display it before, and it's really not very useful since we don't
 encourage reinstalling GRUB anyway.

--- a/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
+++ b/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
@@ -1,7 +1,7 @@
 From 4b607755f602b9844d637c7b7f48617600764238 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Jan 2024 13:58:02 +0800
-Subject: [PATCH 15/22] grub-install: add /efi to the candidate of the ESP
+Subject: [PATCH 15/23] grub-install: add /efi to the candidate of the ESP
  mountpoints
 
 ---

--- a/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
+++ b/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
@@ -1,7 +1,7 @@
 From df48d64d21efa1e01ab1cf24f30e07e9efecf923 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 10 Nov 2023 10:57:02 +0800
-Subject: [PATCH 16/22] commands: add new command memsize
+Subject: [PATCH 16/23] commands: add new command memsize
 
 - This command traverses the entire GRUB memory map, adds the size of each
   region together. The result is the total amount of system memory

--- a/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
+++ b/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
@@ -1,7 +1,7 @@
 From 0ded438a6ab7e8d11922582bf90a7dfa6b7fdcd4 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Mon, 10 Jul 2023 00:14:13 +0800
-Subject: [PATCH 17/22] commands: add new command 'pause'
+Subject: [PATCH 17/23] commands: add new command 'pause'
 
 - Simple enough, this command prints out a prompt, either pre-defined or
   user specified, and awaits a key stroke from the user.

--- a/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
+++ b/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
@@ -1,7 +1,7 @@
 From f608b5788b0e653ad9c2bbdcf078287f2a88d204 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 21:30:22 +0800
-Subject: [PATCH 18/22] normal: align countdown text with rest of the UI
+Subject: [PATCH 18/23] normal: align countdown text with rest of the UI
 
 And add an extra blank line above it.
 ---

--- a/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
+++ b/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
@@ -1,7 +1,7 @@
 From 1e1ce61d967cc992b44c5206cc0cfe21cd44c7ff Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 22:21:55 +0800
-Subject: [PATCH 19/22] po: add patch to disable parallel execution
+Subject: [PATCH 19/23] po: add patch to disable parallel execution
 
 - `msgfilter' might fail while processing de.po to generate de_CH.po, if
   there are too many prarallel jobs.

--- a/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
+++ b/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
@@ -1,7 +1,7 @@
 From 30e70b8cda4b71b524c413954002d4a5961872a0 Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Tue, 30 Jan 2024 14:41:10 +0800
-Subject: [PATCH 20/22] util/bash-completion: Load scripts on demand
+Subject: [PATCH 20/23] util/bash-completion: Load scripts on demand
 
 There are two system directories for bash-completion scripts. One is
 /usr/share/bash-completion/completions/ and the other is

--- a/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
+++ b/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
@@ -1,7 +1,7 @@
 From 209de8a3053c8b0e223836d5b29fe95e0a33b857 Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Mon, 25 Mar 2024 10:11:34 +0800
-Subject: [PATCH 21/22] util/bash-completion: Fix for bash-completion 2.12
+Subject: [PATCH 21/23] util/bash-completion: Fix for bash-completion 2.12
 
 _split_longopt() was the bash-completion private API and removed since
 bash-completion 2.12. This commit initializes the bash-completion

--- a/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
+++ b/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
@@ -1,7 +1,7 @@
 From 8a52d2d391b662681f7c92286ab9e45906119b5d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 11 Jun 2024 22:40:24 +0800
-Subject: [PATCH 22/22] util/grub-mkrescue: use capitalised paths for removable
+Subject: [PATCH 22/23] util/grub-mkrescue: use capitalised paths for removable
  EFI images
 
 Per UEFI Specification, section 3.4.1.1:

--- a/app-admin/grub/autobuild/patches/0023-Add-support-for-forcing-EFI-installation-to-the-remo.patch
+++ b/app-admin/grub/autobuild/patches/0023-Add-support-for-forcing-EFI-installation-to-the-remo.patch
@@ -1,0 +1,198 @@
+From e654d2a23868ef6d58c0fed1dbebe3864156b13a Mon Sep 17 00:00:00 2001
+From: Steve McIntyre <93sam@debian.org>
+Date: Wed, 19 Jul 2023 12:23:19 +0200
+Subject: [PATCH 23/23] Add support for forcing EFI installation to the
+ removable media path
+
+Add an extra option to grub-install "--force-extra-removable". On EFI
+platforms, this will cause an extra copy of the grub-efi image to be
+written to the appropriate removable media patch
+/boot/efi/EFI/BOOT/BOOT$ARCH.EFI as well. This will help with broken
+UEFI implementations where the firmware does not work when configured
+with new boot paths.
+
+Signed-off-by: Steve McIntyre <93sam@debian.org>
+
+Bug-Debian: https://bugs.debian.org/767037 https://bugs.debian.org/773092
+Forwarded: Not yet
+Last-Update: 2021-09-24
+
+Patch-Name: grub-install-extra-removable.patch
+---
+ util/grub-install.c | 104 +++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 103 insertions(+), 1 deletion(-)
+
+diff --git a/util/grub-install.c b/util/grub-install.c
+index c5eef8ac6..e2879306f 100644
+--- a/util/grub-install.c
++++ b/util/grub-install.c
+@@ -55,6 +55,7 @@
+ 
+ static char *target;
+ static int removable = 0;
++static int force_extra_removable = 0;
+ static int recheck = 0;
+ static int update_nvram = 1;
+ static char *install_device = NULL;
+@@ -109,7 +110,8 @@ enum
+     OPTION_LABEL_FONT,
+     OPTION_LABEL_COLOR,
+     OPTION_LABEL_BGCOLOR,
+-    OPTION_PRODUCT_VERSION
++    OPTION_PRODUCT_VERSION,
++    OPTION_FORCE_EXTRA_REMOVABLE
+   };
+ 
+ static int fs_probe = 1;
+@@ -212,6 +214,10 @@ argp_parser (int key, char *arg, struct argp_state *state)
+       removable = 1;
+       return 0;
+ 
++    case OPTION_FORCE_EXTRA_REMOVABLE:
++      force_extra_removable = 1;
++      return 0;
++
+     case OPTION_ALLOW_FLOPPY:
+       allow_floppy = 1;
+       return 0;
+@@ -302,6 +308,9 @@ static struct argp_option options[] = {
+   {"label-color", OPTION_LABEL_COLOR, N_("COLOR"), 0, N_("use COLOR for label"), 2},
+   {"label-bgcolor", OPTION_LABEL_BGCOLOR, N_("COLOR"), 0, N_("use COLOR for label background"), 2},
+   {"product-version", OPTION_PRODUCT_VERSION, N_("STRING"), 0, N_("use STRING as product version"), 2},
++  {"force-extra-removable", OPTION_FORCE_EXTRA_REMOVABLE, 0, 0,
++   N_("force installation to the removable media path also. "
++      "This option is only available on EFI."), 2},
+   {0, 0, 0, 0, 0, 0}
+ };
+ 
+@@ -843,6 +852,91 @@ try_open (const char *path)
+ }
+ #endif
+ 
++/* Helper routine for also_install_removable() below. Walk through the
++   specified dir, looking to see if there is a file/dir that matches
++   the search string exactly, but in a case-insensitive manner. If so,
++   return a copy of the exact file/dir that *does* exist. If not,
++   return NULL */
++static char *
++check_component_exists(const char *dir,
++		       const char *search)
++{
++  grub_util_fd_dir_t d;
++  grub_util_fd_dirent_t de;
++  char *found = NULL;
++
++  d = grub_util_fd_opendir (dir);
++  if (!d)
++    grub_util_error (_("cannot open directory `%s': %s"),
++		     dir, grub_util_fd_strerror ());
++
++  while ((de = grub_util_fd_readdir (d)))
++    {
++      if (strcasecmp (de->d_name, search) == 0)
++	{
++	  found = xstrdup (de->d_name);
++	  break;
++	}
++    }
++  grub_util_fd_closedir (d);
++  return found;
++}
++
++/* Some complex directory-handling stuff in here, to cope with
++ * case-insensitive FAT/VFAT filesystem semantics. Ugh. */
++static void
++also_install_removable(const char *src,
++		       const char *base_efidir,
++		       const char *efi_suffix_upper)
++{
++  char *efi_file = NULL;
++  char *dst = NULL;
++  char *cur = NULL;
++  char *found = NULL;
++
++  if (!efi_suffix_upper)
++    grub_util_error ("%s", _("efi_suffix_upper not set"));
++  efi_file = xasprintf ("BOOT%s.EFI", efi_suffix_upper);
++
++  /* We need to install in $base_efidir/EFI/BOOT/$efi_file, but we
++   * need to cope with case-insensitive stuff here. Build the path one
++   * component at a time, checking for existing matches each time. */
++
++  /* Look for "EFI" in base_efidir. Make it if it does not exist in
++   * some form. */
++  found = check_component_exists(base_efidir, "EFI");
++  if (found == NULL)
++    found = xstrdup("EFI");
++  dst = grub_util_path_concat (2, base_efidir, found);
++  cur = xstrdup (dst);
++  free (dst);
++  free (found);
++  grub_install_mkdir_p (cur);
++
++  /* Now BOOT */
++  found = check_component_exists(cur, "BOOT");
++  if (found == NULL)
++    found = xstrdup("BOOT");
++  dst = grub_util_path_concat (2, cur, found);
++  cur = xstrdup (dst);
++  free (dst);
++  free (found);
++  grub_install_mkdir_p (cur);
++
++  /* Now $efi_file */
++  found = check_component_exists(cur, efi_file);
++  if (found == NULL)
++    found = xstrdup(efi_file);
++  dst = grub_util_path_concat (2, cur, found);
++  cur = xstrdup (dst);
++  free (dst);
++  free (found);
++  grub_install_copy_file (src, cur, 1);
++
++  free (cur);
++  free (efi_file);
++}
++
+ int
+ main (int argc, char *argv[])
+ {
+@@ -859,6 +953,7 @@ main (int argc, char *argv[])
+   char *relative_grubdir;
+   char **efidir_device_names = NULL;
+   grub_device_t efidir_grub_dev = NULL;
++  char *base_efidir = NULL;
+   char *efidir_grub_devname;
+   int efidir_is_mac = 0;
+   int is_prep = 0;
+@@ -891,6 +986,9 @@ main (int argc, char *argv[])
+       bootloader_id = xstrdup ("grub");
+     }
+ 
++  if (removable && force_extra_removable)
++    grub_util_error (_("Invalid to use both --removable and --force_extra_removable"));
++
+   if (!grub_install_source_directory)
+     {
+       if (!target)
+@@ -1141,6 +1239,8 @@ main (int argc, char *argv[])
+ 	    grub_util_error (_("%s doesn't look like an EFI partition"), efidir);
+ 	}
+ 
++      base_efidir = xstrdup(efidir);
++
+       /* The EFI specification requires that an EFI System Partition must
+ 	 contain an "EFI" subdirectory, and that OS loaders are stored in
+ 	 subdirectories below EFI.  Vendors are expected to pick names that do
+@@ -1988,6 +2088,8 @@ main (int argc, char *argv[])
+       {
+ 	char *dst = grub_util_path_concat (2, efidir, efi_file);
+ 	grub_install_copy_file (imgfile, dst, 1);
++	if (force_extra_removable)
++	  also_install_removable(imgfile, base_efidir, efi_suffix_upper);
+ 
+ 	grub_set_install_backup_ponr ();
+ 
+-- 
+2.43.4
+

--- a/app-admin/grub/autobuild/powerpc/build
+++ b/app-admin/grub/autobuild/powerpc/build
@@ -1,4 +1,4 @@
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for IEEE1275 PowerPC bootloaders ..."
 ./configure \

--- a/app-admin/grub/autobuild/ppc64el/build
+++ b/app-admin/grub/autobuild/ppc64el/build
@@ -1,4 +1,4 @@
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for IEEE1275 PowerPC bootloaders ..."
 ./configure \

--- a/app-admin/grub/autobuild/prepare
+++ b/app-admin/grub/autobuild/prepare
@@ -13,4 +13,4 @@ done
             echo "$x";
         done
     ) | sort | uniq | xargs
-) > "$SRCDIR"/grub-${__GRUBVER}/po/LINGUAS
+) > "$SRCDIR"/grub-${__GRUB_VER}/po/LINGUAS

--- a/app-admin/grub/autobuild/riscv64/build
+++ b/app-admin/grub/autobuild/riscv64/build
@@ -1,4 +1,4 @@
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for EFI ..."
 ./configure \

--- a/app-admin/grub/autobuild/riscv64/build.stage2
+++ b/app-admin/grub/autobuild/riscv64/build.stage2
@@ -1,4 +1,4 @@
-cd "$SRCDIR"/grub-${__GRUBVER}
+cd "$SRCDIR"/grub-${__GRUB_VER}
 
 abinfo "Configuring GRUB for EFI ..."
 ./configure \

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -8,7 +8,7 @@ __UNIFONTVER=15.1.04
 LINGUAS_VER=2.12-rc1
 
 VER=${__GRUB_VER}+unifont${__UNIFONTVER}
-REL=3
+REL=4
 RETROFONTVER=20200402
 
 SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https://git.savannah.gnu.org/git/grub.git \

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -8,7 +8,7 @@ __UNIFONTVER=15.1.04
 LINGUAS_VER=2.12-rc1
 
 VER=${__GRUB_VER}+unifont${__UNIFONTVER}
-REL=4
+REL=5
 RETROFONTVER=20200402
 
 SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https://git.savannah.gnu.org/git/grub.git \


### PR DESCRIPTION
Topic Description
-----------------

- grub: (Debian) add --force-extra-removable option
    Sync a patch from Debian to add the --force-extra-removable option, which
    allows grub-install to install its EFI image at *both* the standard,
    bootloader-ID-marked path *and* the standard UEFI removable paths for some
    known bad firmware, such as:
    - Huawei Qinyun W510
    - Loongson 3C5000 boards with Loongson firmware
    - Loongson "new-world" boards with Kunlun/Lemote firmware
    - ... and many more

Package(s) Affected
-------------------

- grub: 2:2.12+unifont15.1.04-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
