### PR TITLE
wezterm: allow more architecture build

### DIFF
--- a/app-utils/wezterm/autobuild/defines
+++ b/app-utils/wezterm/autobuild/defines
@@ -5,10 +5,22 @@ PKGDES="A GPU-accelerated cross-platform terminal emulator and multiplexer"
 BUILDDEP="rustc llvm ncurses"
 
 USECLANG=1
-FAIL_ARCH="!(amd64|arm64)"
+# FIXME(ppc64el): undefined reference to `png_init_filter_functions_vsx'
+FAIL_ARCH="(mips64r6el|ppc64el)"
 CARGO_AFTER="--no-default-features \
              --features distro-defaults,wayland"
+
+CARGO_AFTER__LOONGARCH64="--no-default-features \
+             --features distro-defaults"
 
 # FIXME: Enabling auditing pulls in broken dependencies.
 # ... the trait bound `xcb::Connection: as_raw_xcb_connection::AsRawXcbConnection` is not satisfied
 NOCARGOAUDIT=1
+
+# FIXME: ld.lld is not yet available.
+NOLTO__LOONGSON3=1
+NOLTO__LOONGARCH64=1
+
+# FIXME: ld.lld will fail
+USECLANG__PPC64EL=0
+NOLTO__PPC64EL=1

--- a/app-utils/wezterm/autobuild/patches/0001-deps-dedup-some-nix-versions.patch.loongarch64
+++ b/app-utils/wezterm/autobuild/patches/0001-deps-dedup-some-nix-versions.patch.loongarch64
@@ -1,0 +1,4077 @@
+From c3100aecba595e7f5d0feece448f1a35cf0b3f5c Mon Sep 17 00:00:00 2001
+From: Wez Furlong <wez@wezfurlong.org>
+Date: Mon, 13 May 2024 11:53:27 -0700
+Subject: [PATCH 1/4] deps: dedup some nix versions
+
+---
+ Cargo.lock                | 1451 +++++++++++++++++++------------------
+ config/Cargo.toml         |    2 +-
+ mux/Cargo.toml            |    2 +-
+ pty/Cargo.toml            |    2 +-
+ pty/src/unix.rs           |    3 +-
+ termwiz/Cargo.toml        |    2 +-
+ termwiz/src/escape/apc.rs |    5 +-
+ 7 files changed, 759 insertions(+), 708 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 58f7820be..d049f9c85 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -4,9 +4,9 @@ version = 3
+ 
+ [[package]]
+ name = "addr2line"
+-version = "0.21.0"
++version = "0.22.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
++checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+ dependencies = [
+  "gimli",
+ ]
+@@ -25,9 +25,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+ 
+ [[package]]
+ name = "ahash"
+-version = "0.7.7"
++version = "0.7.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
++checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+ dependencies = [
+  "getrandom",
+  "once_cell",
+@@ -36,9 +36,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ahash"
+-version = "0.8.7"
++version = "0.8.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
++checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+ dependencies = [
+  "cfg-if",
+  "getrandom",
+@@ -49,18 +49,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "aho-corasick"
+-version = "1.1.2"
++version = "1.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
++checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+ dependencies = [
+  "memchr",
+ ]
+ 
+ [[package]]
+ name = "allocator-api2"
+-version = "0.2.16"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
++checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+ 
+ [[package]]
+ name = "android-tzdata"
+@@ -85,47 +85,48 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+ 
+ [[package]]
+ name = "anstream"
+-version = "0.6.11"
++version = "0.6.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
++checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+ dependencies = [
+  "anstyle",
+  "anstyle-parse",
+  "anstyle-query",
+  "anstyle-wincon",
+  "colorchoice",
++ "is_terminal_polyfill",
+  "utf8parse",
+ ]
+ 
+ [[package]]
+ name = "anstyle"
+-version = "1.0.5"
++version = "1.0.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
++checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+ 
+ [[package]]
+ name = "anstyle-parse"
+-version = "0.2.3"
++version = "0.2.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
++checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+ dependencies = [
+  "utf8parse",
+ ]
+ 
+ [[package]]
+ name = "anstyle-query"
+-version = "1.0.2"
++version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
++checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+ dependencies = [
+  "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+ name = "anstyle-wincon"
+-version = "3.0.2"
++version = "3.0.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
++checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+ dependencies = [
+  "anstyle",
+  "windows-sys 0.52.0",
+@@ -133,9 +134,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "anyhow"
+-version = "1.0.79"
++version = "1.0.86"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
++checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+ 
+ [[package]]
+ name = "arrayref"
+@@ -202,12 +203,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "async-channel"
+-version = "2.1.1"
++version = "2.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
++checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+ dependencies = [
+  "concurrent-queue",
+- "event-listener 4.0.3",
+  "event-listener-strategy",
+  "futures-core",
+  "pin-project-lite",
+@@ -215,15 +215,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "async-executor"
+-version = "1.8.0"
++version = "1.12.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
++checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
+ dependencies = [
+- "async-lock 3.3.0",
+  "async-task",
+  "concurrent-queue",
+- "fastrand 2.0.1",
+- "futures-lite 2.2.0",
++ "fastrand 2.1.0",
++ "futures-lite 2.3.0",
+  "slab",
+ ]
+ 
+@@ -261,18 +260,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "async-io"
+-version = "2.3.1"
++version = "2.3.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
++checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
+ dependencies = [
+- "async-lock 3.3.0",
++ "async-lock 3.4.0",
+  "cfg-if",
+  "concurrent-queue",
+  "futures-io",
+- "futures-lite 2.2.0",
++ "futures-lite 2.3.0",
+  "parking",
+- "polling 3.3.2",
+- "rustix 0.38.30",
++ "polling 3.7.2",
++ "rustix 0.38.34",
+  "slab",
+  "tracing",
+  "windows-sys 0.52.0",
+@@ -289,11 +288,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "async-lock"
+-version = "3.3.0"
++version = "3.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
++checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+ dependencies = [
+- "event-listener 4.0.3",
++ "event-listener 5.3.1",
+  "event-listener-strategy",
+  "pin-project-lite",
+ ]
+@@ -322,54 +321,54 @@ dependencies = [
+  "cfg-if",
+  "event-listener 3.1.0",
+  "futures-lite 1.13.0",
+- "rustix 0.38.30",
++ "rustix 0.38.34",
+  "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+ name = "async-recursion"
+-version = "1.0.5"
++version = "1.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
++checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+ name = "async-signal"
+-version = "0.2.5"
++version = "0.2.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
++checksum = "794f185324c2f00e771cd9f1ae8b5ac68be2ca7abb129a87afd6e86d228bc54d"
+ dependencies = [
+- "async-io 2.3.1",
+- "async-lock 2.8.0",
++ "async-io 2.3.3",
++ "async-lock 3.4.0",
+  "atomic-waker",
+  "cfg-if",
+  "futures-core",
+  "futures-io",
+- "rustix 0.38.30",
++ "rustix 0.38.34",
+  "signal-hook-registry",
+  "slab",
+- "windows-sys 0.48.0",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+ name = "async-task"
+-version = "4.7.0"
++version = "4.7.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
++checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+ 
+ [[package]]
+ name = "async-trait"
+-version = "0.1.77"
++version = "0.1.80"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
++checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -381,9 +380,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "atomic"
+-version = "0.5.3"
++version = "0.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
++checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
++dependencies = [
++ "bytemuck",
++]
+ 
+ [[package]]
+ name = "atomic-waker"
+@@ -404,9 +406,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "autocfg"
+-version = "1.1.0"
++version = "1.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
++checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+ 
+ [[package]]
+ name = "az"
+@@ -416,15 +418,15 @@ checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+ 
+ [[package]]
+ name = "backtrace"
+-version = "0.3.69"
++version = "0.3.73"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
++checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+ dependencies = [
+  "addr2line",
+  "cc",
+  "cfg-if",
+  "libc",
+- "miniz_oxide 0.7.1",
++ "miniz_oxide 0.7.4",
+  "object",
+  "rustc-demangle",
+ ]
+@@ -441,6 +443,12 @@ version = "0.21.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+ 
++[[package]]
++name = "base64"
++version = "0.22.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
++
+ [[package]]
+ name = "base91"
+ version = "0.1.0"
+@@ -458,9 +466,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "benchmarking"
+-version = "0.4.12"
++version = "0.4.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "32842502e72b27b30b2681692d16bf47a8a375c5a2795613f0dc699bed9a48bb"
++checksum = "6c335a9de639ba6a3e4107fe7763c9dcd4eb9422575f1191c2b8f2009f03fe4a"
+ 
+ [[package]]
+ name = "bintree"
+@@ -495,9 +503,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+ 
+ [[package]]
+ name = "bitflags"
+-version = "2.4.2"
++version = "2.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
++checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+ dependencies = [
+  "serde",
+ ]
+@@ -519,66 +527,52 @@ dependencies = [
+ 
+ [[package]]
+ name = "blocking"
+-version = "1.5.1"
++version = "1.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
++checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+ dependencies = [
+- "async-channel 2.1.1",
+- "async-lock 3.3.0",
++ "async-channel 2.3.1",
+  "async-task",
+- "fastrand 2.0.1",
+  "futures-io",
+- "futures-lite 2.2.0",
++ "futures-lite 2.3.0",
+  "piper",
+- "tracing",
+ ]
+ 
+ [[package]]
+ name = "bstr"
+-version = "0.1.4"
++version = "1.9.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "59604ece62a407dc9164732e5adea02467898954c3a5811fd2dc140af14ef15b"
++checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+ dependencies = [
+- "lazy_static",
+  "memchr",
+- "regex-automata 0.1.10",
+-]
+-
+-[[package]]
+-name = "bstr"
+-version = "1.9.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+-dependencies = [
+- "memchr",
+- "regex-automata 0.4.5",
++ "regex-automata",
+  "serde",
+ ]
+ 
+ [[package]]
+ name = "bumpalo"
+-version = "3.14.0"
++version = "3.16.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
++checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+ 
+ [[package]]
+ name = "bytemuck"
+-version = "1.14.1"
++version = "1.16.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
++checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+ dependencies = [
+  "bytemuck_derive",
+ ]
+ 
+ [[package]]
+ name = "bytemuck_derive"
+-version = "1.5.0"
++version = "1.7.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
++checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -589,9 +583,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+ 
+ [[package]]
+ name = "bytes"
+-version = "1.5.0"
++version = "1.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
++checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+ 
+ [[package]]
+ name = "cairo-rs"
+@@ -599,7 +593,7 @@ version = "0.18.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "cairo-sys-rs",
+  "libc",
+  "once_cell",
+@@ -616,9 +610,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "camino"
+-version = "1.1.6"
++version = "1.1.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
++checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+ 
+ [[package]]
+ name = "cassowary"
+@@ -634,12 +628,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.83"
++version = "1.0.103"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
++checksum = "2755ff20a1d93490d26ba33a6f092a38a508398a5320df5d4b3014fcccce9410"
+ dependencies = [
+  "jobserver",
+  "libc",
++ "once_cell",
+ ]
+ 
+ [[package]]
+@@ -648,6 +643,12 @@ version = "1.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+ 
++[[package]]
++name = "cfg_aliases"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
++
+ [[package]]
+ name = "cgl"
+ version = "0.3.2"
+@@ -659,16 +660,16 @@ dependencies = [
+ 
+ [[package]]
+ name = "chrono"
+-version = "0.4.33"
++version = "0.4.38"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
++checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+ dependencies = [
+  "android-tzdata",
+  "iana-time-zone",
+  "num-traits",
+  "pure-rust-locales",
+  "serde",
+- "windows-targets 0.52.0",
++ "windows-targets 0.52.5",
+ ]
+ 
+ [[package]]
+@@ -695,7 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+ dependencies = [
+  "ciborium-io",
+- "half 2.3.1",
++ "half 2.4.1",
+ ]
+ 
+ [[package]]
+@@ -718,14 +719,14 @@ dependencies = [
+  "bitflags 1.3.2",
+  "clap_lex 0.2.4",
+  "indexmap 1.9.3",
+- "textwrap 0.16.0",
++ "textwrap 0.16.1",
+ ]
+ 
+ [[package]]
+ name = "clap"
+-version = "4.4.18"
++version = "4.5.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
++checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+ dependencies = [
+  "clap_builder",
+  "clap_derive",
+@@ -733,46 +734,46 @@ dependencies = [
+ 
+ [[package]]
+ name = "clap_builder"
+-version = "4.4.18"
++version = "4.5.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
++checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+ dependencies = [
+  "anstream",
+  "anstyle",
+- "clap_lex 0.6.0",
+- "strsim",
++ "clap_lex 0.7.1",
++ "strsim 0.11.1",
+  "terminal_size 0.3.0",
+ ]
+ 
+ [[package]]
+ name = "clap_complete"
+-version = "4.4.9"
++version = "4.5.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "df631ae429f6613fcd3a7c1adbdb65f637271e561b03680adaa6573015dfb106"
++checksum = "1d598e88f6874d4b888ed40c71efbcbf4076f1dfbae128a08a8c9e45f710605d"
+ dependencies = [
+- "clap 4.4.18",
++ "clap 4.5.8",
+ ]
+ 
+ [[package]]
+ name = "clap_complete_fig"
+-version = "4.4.2"
++version = "4.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "87e571d70e22ec91d34e1c5317c8308035a2280d925167646bf094fc5de1737c"
++checksum = "fb4bc503cddc1cd320736fb555d6598309ad07c2ddeaa23891a10ffb759ee612"
+ dependencies = [
+- "clap 4.4.18",
++ "clap 4.5.8",
+  "clap_complete",
+ ]
+ 
+ [[package]]
+ name = "clap_derive"
+-version = "4.4.7"
++version = "4.5.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
++checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+ dependencies = [
+  "heck",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -786,9 +787,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "clap_lex"
+-version = "0.6.0"
++version = "0.7.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
++checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+ 
+ [[package]]
+ name = "clipboard-win"
+@@ -824,7 +825,7 @@ dependencies = [
+  "block",
+  "cocoa-foundation",
+  "core-foundation 0.9.4",
+- "core-graphics 0.23.1",
++ "core-graphics 0.23.2",
+  "foreign-types 0.5.0",
+  "libc",
+  "objc",
+@@ -905,9 +906,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+ 
+ [[package]]
+ name = "colorchoice"
+-version = "1.0.0"
++version = "1.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
++checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+ 
+ [[package]]
+ name = "colored"
+@@ -947,9 +948,9 @@ checksum = "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642"
+ 
+ [[package]]
+ name = "concurrent-queue"
+-version = "2.4.0"
++version = "2.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
++checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+ dependencies = [
+  "crossbeam-utils",
+ ]
+@@ -963,14 +964,14 @@ dependencies = [
+  "colorgrad",
+  "dirs-next",
+  "enum-display-derive",
+- "env_logger 0.11.1",
++ "env_logger 0.11.3",
+  "hostname",
+  "lazy_static",
+  "libc",
+  "log",
+  "luahelper",
+  "mlua",
+- "nix 0.26.4",
++ "nix 0.28.0",
+  "notify",
+  "once_cell",
+  "ordered-float",
+@@ -981,7 +982,7 @@ dependencies = [
+  "shlex",
+  "smol",
+  "termwiz",
+- "toml 0.8.8",
++ "toml 0.8.14",
+  "umask",
+  "wezterm-bidi",
+  "wezterm-config-derive",
+@@ -1038,9 +1039,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "core-graphics"
+-version = "0.23.1"
++version = "0.23.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
++checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+ dependencies = [
+  "bitflags 1.3.2",
+  "core-foundation 0.9.4",
+@@ -1067,7 +1068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
+ dependencies = [
+  "core-foundation 0.9.4",
+- "core-graphics 0.23.1",
++ "core-graphics 0.23.2",
+  "foreign-types 0.5.0",
+  "libc",
+ ]
+@@ -1092,9 +1093,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crc32fast"
+-version = "1.3.2"
++version = "1.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
++checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+ dependencies = [
+  "cfg-if",
+ ]
+@@ -1186,9 +1187,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-channel"
+-version = "0.5.11"
++version = "0.5.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
++checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+ dependencies = [
+  "crossbeam-utils",
+ ]
+@@ -1223,9 +1224,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-utils"
+-version = "0.8.19"
++version = "0.8.20"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
++checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+ 
+ [[package]]
+ name = "crunchy"
+@@ -1280,16 +1281,16 @@ version = "0.7.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
+ dependencies = [
+- "bitflags 2.4.2",
+- "libloading 0.8.1",
++ "bitflags 2.6.0",
++ "libloading 0.8.4",
+  "winapi",
+ ]
+ 
+ [[package]]
+ name = "darling"
+-version = "0.20.3"
++version = "0.20.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
++checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+ dependencies = [
+  "darling_core",
+  "darling_macro",
+@@ -1297,27 +1298,27 @@ dependencies = [
+ 
+ [[package]]
+ name = "darling_core"
+-version = "0.20.3"
++version = "0.20.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
++checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+ dependencies = [
+  "fnv",
+  "ident_case",
+  "proc-macro2",
+  "quote",
+- "strsim",
+- "syn 2.0.48",
++ "strsim 0.11.1",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+ name = "darling_macro"
+-version = "0.20.3"
++version = "0.20.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
++checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+ dependencies = [
+  "darling_core",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -1328,9 +1329,9 @@ checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
+ 
+ [[package]]
+ name = "data-encoding"
+-version = "2.5.0"
++version = "2.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
++checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+ 
+ [[package]]
+ name = "deltae"
+@@ -1361,15 +1362,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "dhat"
+-version = "0.3.2"
++version = "0.3.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4f2aaf837aaf456f6706cb46386ba8dffd4013a757e36f4ea05c20dd46b209a3"
++checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+ dependencies = [
+  "backtrace",
+  "lazy_static",
+  "mintex",
+- "parking_lot 0.12.1",
+- "rustc-hash",
++ "parking_lot 0.12.3",
++ "rustc-hash 1.1.0",
+  "serde",
+  "serde_json",
+  "thousands",
+@@ -1444,7 +1445,7 @@ version = "0.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+ dependencies = [
+- "libloading 0.8.1",
++ "libloading 0.8.4",
+ ]
+ 
+ [[package]]
+@@ -1455,9 +1456,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+ 
+ [[package]]
+ name = "downcast-rs"
+-version = "1.2.0"
++version = "1.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
++checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+ 
+ [[package]]
+ name = "dwrote"
+@@ -1475,9 +1476,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "either"
+-version = "1.9.0"
++version = "1.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
++checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+ 
+ [[package]]
+ name = "embed-resource"
+@@ -1494,18 +1495,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "emojis"
+-version = "0.6.1"
++version = "0.6.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4ee61eb945bff65ee7d19d157d39c67c33290ff0742907413fd5eefd29edc979"
++checksum = "9f619a926616ae7149a0d82610b051134a0d6c4ae2962d990c06c847a445c5d9"
+ dependencies = [
+  "phf",
+ ]
+ 
+ [[package]]
+ name = "encoding_rs"
+-version = "0.8.33"
++version = "0.8.34"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
++checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+ dependencies = [
+  "cfg-if",
+ ]
+@@ -1523,9 +1524,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "enumflags2"
+-version = "0.7.8"
++version = "0.7.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5998b4f30320c9d93aed72f63af821bfdac50465b75428fce77b48ec482c3939"
++checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
+ dependencies = [
+  "enumflags2_derive",
+  "serde",
+@@ -1533,13 +1534,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "enumflags2_derive"
+-version = "0.7.8"
++version = "0.7.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
++checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -1600,9 +1601,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "env_logger"
+-version = "0.11.1"
++version = "0.11.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "05e7cf40684ae96ade6232ed84582f40ce0a66efcd43a5117aef610534f8e0b8"
++checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+ dependencies = [
+  "anstream",
+  "anstyle",
+@@ -1619,9 +1620,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+ 
+ [[package]]
+ name = "errno"
+-version = "0.3.8"
++version = "0.3.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
++checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+ dependencies = [
+  "libc",
+  "windows-sys 0.52.0",
+@@ -1629,9 +1630,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "euclid"
+-version = "0.22.9"
++version = "0.22.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787"
++checksum = "e0f0eb73b934648cd7a4a61f1b15391cd95dab0b4da6e2e66c2a072c144b4a20"
+ dependencies = [
+  "num-traits",
+ ]
+@@ -1655,9 +1656,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "event-listener"
+-version = "4.0.3"
++version = "5.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
++checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+ dependencies = [
+  "concurrent-queue",
+  "parking",
+@@ -1666,25 +1667,25 @@ dependencies = [
+ 
+ [[package]]
+ name = "event-listener-strategy"
+-version = "0.4.0"
++version = "0.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
++checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+ dependencies = [
+- "event-listener 4.0.3",
++ "event-listener 5.3.1",
+  "pin-project-lite",
+ ]
+ 
+ [[package]]
+ name = "exr"
+-version = "1.6.4"
++version = "1.72.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "279d3efcc55e19917fff7ab3ddd6c14afb6a90881a0078465196fe2f99d08c56"
++checksum = "887d93f60543e9a9362ef8a21beedd0a833c5d9610e18c67abe15a5963dcb1a4"
+ dependencies = [
+  "bit_field",
+- "flume 0.10.14",
+- "half 2.3.1",
++ "flume 0.11.0",
++ "half 2.4.1",
+  "lebe",
+- "miniz_oxide 0.7.1",
++ "miniz_oxide 0.7.4",
+  "rayon-core",
+  "smallvec",
+  "zune-inflate",
+@@ -1723,9 +1724,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "fastrand"
+-version = "2.0.1"
++version = "2.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
++checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+ 
+ [[package]]
+ name = "fdeflate"
+@@ -1747,12 +1748,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "filenamegen"
+-version = "0.2.4"
++version = "0.2.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0b2da6e8ef70499318bc50abd003fd66dbf6d8a46c23f9e90158f388a788976a"
++checksum = "6f40529622e8c4e7c28f600abb501b0ca07047d4e15d576aff1837cca8318ab6"
+ dependencies = [
+  "anyhow",
+- "bstr 0.1.4",
++ "bstr",
+  "regex",
+  "walkdir",
+ ]
+@@ -1788,13 +1789,13 @@ checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+ 
+ [[package]]
+ name = "fixed"
+-version = "1.24.0"
++version = "1.27.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "02c69ce7e7c0f17aa18fdd9d0de39727adb9c6281f2ad12f57cbe54ae6e76e7d"
++checksum = "2fc715d38bea7b5bf487fcd79bcf8c209f0b58014f3018a7a19c2b855f472048"
+ dependencies = [
+  "az",
+  "bytemuck",
+- "half 2.3.1",
++ "half 2.4.1",
+  "typenum",
+ ]
+ 
+@@ -1806,12 +1807,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+ 
+ [[package]]
+ name = "flate2"
+-version = "1.0.28"
++version = "1.0.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
++checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+ dependencies = [
+  "crc32fast",
+- "miniz_oxide 0.7.1",
++ "miniz_oxide 0.7.4",
+ ]
+ 
+ [[package]]
+@@ -1889,7 +1890,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -2005,11 +2006,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "futures-lite"
+-version = "2.2.0"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
++checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+ dependencies = [
+- "fastrand 2.0.1",
++ "fastrand 2.1.0",
+  "futures-core",
+  "futures-io",
+  "parking",
+@@ -2024,7 +2025,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -2041,9 +2042,9 @@ checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+ 
+ [[package]]
+ name = "futures-timer"
+-version = "3.0.2"
++version = "3.0.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
++checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+ 
+ [[package]]
+ name = "futures-util"
+@@ -2110,9 +2111,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "getrandom"
+-version = "0.2.12"
++version = "0.2.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
++checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+ dependencies = [
+  "cfg-if",
+  "js-sys",
+@@ -2123,9 +2124,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "gif"
+-version = "0.12.0"
++version = "0.13.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
++checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
+ dependencies = [
+  "color_quant",
+  "weezl",
+@@ -2133,9 +2134,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "gimli"
+-version = "0.28.1"
++version = "0.29.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
++checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+ 
+ [[package]]
+ name = "git2"
+@@ -2191,9 +2192,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+ dependencies = [
+  "aho-corasick",
+- "bstr 1.9.0",
++ "bstr",
+  "log",
+- "regex-automata 0.4.5",
++ "regex-automata",
+  "regex-syntax",
+ ]
+ 
+@@ -2203,7 +2204,7 @@ version = "0.9.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "ignore",
+  "walkdir",
+ ]
+@@ -2240,7 +2241,7 @@ dependencies = [
+  "futures-timer",
+  "no-std-compat",
+  "nonzero_ext",
+- "parking_lot 0.12.1",
++ "parking_lot 0.12.3",
+  "smallvec",
+ ]
+ 
+@@ -2250,7 +2251,7 @@ version = "0.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "gpu-alloc-types",
+ ]
+ 
+@@ -2260,7 +2261,7 @@ version = "0.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+ ]
+ 
+ [[package]]
+@@ -2283,9 +2284,9 @@ version = "0.2.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "gpu-descriptor-types",
+- "hashbrown 0.14.3",
++ "hashbrown 0.14.5",
+ ]
+ 
+ [[package]]
+@@ -2294,7 +2295,7 @@ version = "0.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+ ]
+ 
+ [[package]]
+@@ -2309,9 +2310,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "h2"
+-version = "0.3.24"
++version = "0.3.26"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
++checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+ dependencies = [
+  "bytes",
+  "fnv",
+@@ -2319,7 +2320,7 @@ dependencies = [
+  "futures-sink",
+  "futures-util",
+  "http",
+- "indexmap 2.2.1",
++ "indexmap 2.2.6",
+  "slab",
+  "tokio",
+  "tokio-util",
+@@ -2328,15 +2329,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "half"
+-version = "1.8.2"
++version = "1.8.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
++checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+ 
+ [[package]]
+ name = "half"
+-version = "2.3.1"
++version = "2.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
++checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+ dependencies = [
+  "cfg-if",
+  "crunchy",
+@@ -2356,7 +2357,7 @@ version = "0.11.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+ dependencies = [
+- "ahash 0.7.7",
++ "ahash 0.7.8",
+ ]
+ 
+ [[package]]
+@@ -2365,25 +2366,16 @@ version = "0.12.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+ dependencies = [
+- "ahash 0.7.7",
+-]
+-
+-[[package]]
+-name = "hashbrown"
+-version = "0.13.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+-dependencies = [
+- "ahash 0.8.7",
++ "ahash 0.7.8",
+ ]
+ 
+ [[package]]
+ name = "hashbrown"
+-version = "0.14.3"
++version = "0.14.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
++checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+ dependencies = [
+- "ahash 0.8.7",
++ "ahash 0.8.11",
+  "allocator-api2",
+ ]
+ 
+@@ -2427,9 +2419,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "heck"
+-version = "0.4.1"
++version = "0.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
++checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+ 
+ [[package]]
+ name = "hermit-abi"
+@@ -2442,9 +2434,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "hermit-abi"
+-version = "0.3.4"
++version = "0.3.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
++checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
++
++[[package]]
++name = "hermit-abi"
++version = "0.4.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+ 
+ [[package]]
+ name = "hex"
+@@ -2480,9 +2478,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "http"
+-version = "0.2.11"
++version = "0.2.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
++checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+ dependencies = [
+  "bytes",
+  "fnv",
+@@ -2502,9 +2500,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "http_req"
+-version = "0.10.2"
++version = "0.10.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "90394b01e9de1f7eca6ca0664cc64bd92add9603c1aa4f961813f23789035e10"
++checksum = "3d9a9b34d2d0a2440774af1b1c09b045fe82ccdc4f4f37d089fbc4cc8a03104e"
+ dependencies = [
+  "native-tls",
+  "unicase",
+@@ -2512,9 +2510,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "httparse"
+-version = "1.8.0"
++version = "1.9.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
++checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+ 
+ [[package]]
+ name = "httpdate"
+@@ -2539,9 +2537,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+ 
+ [[package]]
+ name = "hyper"
+-version = "0.14.28"
++version = "0.14.29"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
++checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+ dependencies = [
+  "bytes",
+  "futures-channel",
+@@ -2554,7 +2552,7 @@ dependencies = [
+  "httpdate",
+  "itoa",
+  "pin-project-lite",
+- "socket2 0.5.5",
++ "socket2 0.5.7",
+  "tokio",
+  "tower-service",
+  "tracing",
+@@ -2576,9 +2574,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "iana-time-zone"
+-version = "0.1.59"
++version = "0.1.60"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
++checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+ dependencies = [
+  "android_system_properties",
+  "core-foundation-sys 0.8.6",
+@@ -2623,7 +2621,7 @@ dependencies = [
+  "globset",
+  "log",
+  "memchr",
+- "regex-automata 0.4.5",
++ "regex-automata",
+  "same-file",
+  "walkdir",
+  "winapi-util",
+@@ -2631,9 +2629,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "image"
+-version = "0.24.8"
++version = "0.24.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "034bbe799d1909622a74d1193aa50147769440040ff36cb2baa947609b0a4e23"
++checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+ dependencies = [
+  "bytemuck",
+  "byteorder",
+@@ -2660,12 +2658,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "indexmap"
+-version = "2.2.1"
++version = "2.2.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
++checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+ dependencies = [
+  "equivalent",
+- "hashbrown 0.14.3",
++ "hashbrown 0.14.5",
+ ]
+ 
+ [[package]]
+@@ -2690,9 +2688,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "instant"
+-version = "0.1.12"
++version = "0.1.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
++checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+ dependencies = [
+  "cfg-if",
+ ]
+@@ -2703,7 +2701,7 @@ version = "0.9.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b694dc9f70c3bda874626d2aed13b780f137aab435f4e9814121955cf706122e"
+ dependencies = [
+- "memoffset 0.9.0",
++ "memoffset 0.9.1",
+ ]
+ 
+ [[package]]
+@@ -2712,7 +2710,7 @@ version = "1.0.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+ dependencies = [
+- "hermit-abi 0.3.4",
++ "hermit-abi 0.3.9",
+  "libc",
+  "windows-sys 0.48.0",
+ ]
+@@ -2734,15 +2732,21 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+ 
+ [[package]]
+ name = "is-terminal"
+-version = "0.4.10"
++version = "0.4.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
++checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+ dependencies = [
+- "hermit-abi 0.3.4",
+- "rustix 0.38.30",
++ "hermit-abi 0.3.9",
++ "libc",
+  "windows-sys 0.52.0",
+ ]
+ 
++[[package]]
++name = "is_terminal_polyfill"
++version = "1.70.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
++
+ [[package]]
+ name = "itertools"
+ version = "0.10.5"
+@@ -2754,15 +2758,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "itoa"
+-version = "1.0.10"
++version = "1.0.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
++checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+ 
+ [[package]]
+ name = "jobserver"
+-version = "0.1.27"
++version = "0.1.31"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
++checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+ dependencies = [
+  "libc",
+ ]
+@@ -2778,9 +2782,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "js-sys"
+-version = "0.3.67"
++version = "0.3.69"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
++checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+ dependencies = [
+  "wasm-bindgen",
+ ]
+@@ -2826,7 +2830,7 @@ dependencies = [
+  "libc",
+  "proc-macro2",
+  "regex",
+- "syn 2.0.48",
++ "syn 2.0.68",
+  "terminal_size 0.2.6",
+ ]
+ 
+@@ -2837,7 +2841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+ dependencies = [
+  "libc",
+- "libloading 0.8.1",
++ "libloading 0.8.4",
+  "pkg-config",
+ ]
+ 
+@@ -2875,9 +2879,9 @@ checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+ 
+ [[package]]
+ name = "lazy_static"
+-version = "1.4.0"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
++checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+ 
+ [[package]]
+ name = "lazycell"
+@@ -2901,7 +2905,7 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
+ name = "lfucache"
+ version = "0.1.0"
+ dependencies = [
+- "ahash 0.8.7",
++ "ahash 0.8.11",
+  "config",
+  "fnv",
+  "intrusive-collections",
+@@ -2911,15 +2915,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.152"
++version = "0.2.155"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
++checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+ 
+ [[package]]
+ name = "libflate"
+-version = "2.0.0"
++version = "2.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9f7d5654ae1795afc7ff76f4365c2c8791b0feb18e8996a96adad8ffd7c3b2bf"
++checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+ dependencies = [
+  "adler32",
+  "core2",
+@@ -2930,12 +2934,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "libflate_lz77"
+-version = "2.0.0"
++version = "2.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "be5f52fb8c451576ec6b79d3f4deb327398bc05bbdbd99021a6e77a4c855d524"
++checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+ dependencies = [
+  "core2",
+- "hashbrown 0.13.2",
++ "hashbrown 0.14.5",
+  "rle-decode-fast",
+ ]
+ 
+@@ -2974,12 +2978,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "libloading"
+-version = "0.8.1"
++version = "0.8.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
++checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+ dependencies = [
+  "cfg-if",
+- "windows-sys 0.48.0",
++ "windows-targets 0.52.5",
+ ]
+ 
+ [[package]]
+@@ -2990,13 +2994,12 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+ 
+ [[package]]
+ name = "libredox"
+-version = "0.0.1"
++version = "0.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
++checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "libc",
+- "redox_syscall 0.4.1",
+ ]
+ 
+ [[package]]
+@@ -3024,9 +3027,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "libssh-rs-sys"
+-version = "0.2.2"
++version = "0.2.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3af07827858d82a7b74d6f935ad4201ff764fb1de8efcc26aeaa33e5f9c89ca2"
++checksum = "205ceca5947f473c76f34175de70b15d9e8fadbbdb1bba45d4973037bbdb5fc7"
+ dependencies = [
+  "cc",
+  "libz-sys",
+@@ -3050,9 +3053,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "libz-sys"
+-version = "1.1.15"
++version = "1.1.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
++checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+ dependencies = [
+  "cc",
+  "libc",
+@@ -3060,15 +3063,6 @@ dependencies = [
+  "vcpkg",
+ ]
+ 
+-[[package]]
+-name = "line-wrap"
+-version = "0.1.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+-dependencies = [
+- "safemem",
+-]
+-
+ [[package]]
+ name = "line_drawing"
+ version = "0.8.1"
+@@ -3092,15 +3086,15 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+ 
+ [[package]]
+ name = "linux-raw-sys"
+-version = "0.4.13"
++version = "0.4.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
++checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+ 
+ [[package]]
+ name = "lock_api"
+-version = "0.4.11"
++version = "0.4.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
++checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+ dependencies = [
+  "autocfg",
+  "scopeguard",
+@@ -3108,9 +3102,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "log"
+-version = "0.4.20"
++version = "0.4.22"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
++checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+ 
+ [[package]]
+ name = "logging"
+@@ -3144,7 +3138,7 @@ dependencies = [
+ name = "luahelper"
+ version = "0.1.0"
+ dependencies = [
+- "bstr 1.9.0",
++ "bstr",
+  "log",
+  "mlua",
+  "wezterm-dynamic",
+@@ -3152,9 +3146,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "luajit-src"
+-version = "210.5.5+f2336c4"
++version = "210.5.8+5790d25"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d8bcba9790f4e3b1c1467d75cdd011a63bbe6bc75da95af5d2cb4e3631f939c4"
++checksum = "441f18d9ad792e871fc2f7f2cb8902c386f6f56fdbddef3b835b61475e375346"
+ dependencies = [
+  "cc",
+  "which",
+@@ -3162,11 +3156,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "mac_address"
+-version = "1.1.5"
++version = "1.1.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4863ee94f19ed315bf3bc00299338d857d4b5bc856af375cc97d237382ad3856"
++checksum = "8836fae9d0d4be2c8b4efcdd79e828a2faa058a90d005abf42f91cac5493a08e"
+ dependencies = [
+- "nix 0.23.2",
++ "nix 0.28.0",
+  "winapi",
+ ]
+ 
+@@ -3202,9 +3196,9 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+ 
+ [[package]]
+ name = "memchr"
+-version = "2.7.1"
++version = "2.7.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
++checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+ 
+ [[package]]
+ name = "memmap2"
+@@ -3259,9 +3253,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "memoffset"
+-version = "0.9.0"
++version = "0.9.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
++checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+ dependencies = [
+  "autocfg",
+ ]
+@@ -3272,7 +3266,7 @@ version = "0.27.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "block",
+  "core-graphics-types",
+  "foreign-types 0.5.0",
+@@ -3287,7 +3281,7 @@ version = "0.17.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "55586aa936c35f34ba8aa5d97356d554311206e1ce1f9e68fe7b07288e5ad827"
+ dependencies = [
+- "ahash 0.7.7",
++ "ahash 0.7.8",
+  "metrics-macros",
+ ]
+ 
+@@ -3328,9 +3322,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "miniz_oxide"
+-version = "0.7.1"
++version = "0.7.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
++checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+ dependencies = [
+  "adler",
+  "simd-adler32",
+@@ -3344,9 +3338,9 @@ checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
+ 
+ [[package]]
+ name = "mio"
+-version = "0.8.10"
++version = "0.8.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
++checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+ dependencies = [
+  "libc",
+  "log",
+@@ -3356,23 +3350,23 @@ dependencies = [
+ 
+ [[package]]
+ name = "mlua"
+-version = "0.9.5"
++version = "0.9.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1d3561f79659ff3afad7b25e2bf2ec21507fe601ebecb7f81088669ec4bfd51e"
++checksum = "d111deb18a9c9bd33e1541309f4742523bfab01d276bfa9a27519f6de9c11dc7"
+ dependencies = [
+- "bstr 1.9.0",
++ "bstr",
+  "futures-util",
+  "mlua-sys",
+  "num-traits",
+  "once_cell",
+- "rustc-hash",
++ "rustc-hash 2.0.0",
+ ]
+ 
+ [[package]]
+ name = "mlua-sys"
+-version = "0.5.1"
++version = "0.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2847b42764435201d8cbee1f517edb79c4cca4181877b90047587c89e1b7bce4"
++checksum = "a088ed0723df7567f569ba018c5d48c23c501f3878b190b04144dfa5ebfa8abc"
+ dependencies = [
+  "cc",
+  "cfg-if",
+@@ -3407,9 +3401,9 @@ dependencies = [
+  "metrics",
+  "mlua",
+  "names",
+- "nix 0.25.1",
++ "nix 0.28.0",
+  "ntapi",
+- "parking_lot 0.12.1",
++ "parking_lot 0.12.3",
+  "percent-encoding",
+  "portable-pty",
+  "procinfo",
+@@ -3422,7 +3416,7 @@ dependencies = [
+  "terminfo",
+  "termwiz",
+  "termwiz-funcs",
+- "textwrap 0.16.0",
++ "textwrap 0.16.1",
+  "thiserror",
+  "url",
+  "wezterm-dynamic",
+@@ -3441,7 +3435,7 @@ dependencies = [
+  "log",
+  "luahelper",
+  "mux",
+- "parking_lot 0.12.1",
++ "parking_lot 0.12.3",
+  "portable-pty",
+  "smol",
+  "termwiz",
+@@ -3458,13 +3452,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ae585df4b6514cf8842ac0f1ab4992edc975892704835b549cf818dc0191249e"
+ dependencies = [
+  "bit-set",
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "codespan-reporting",
+  "hexf-parse",
+- "indexmap 2.2.1",
++ "indexmap 2.2.6",
+  "log",
+  "num-traits",
+- "rustc-hash",
++ "rustc-hash 1.1.0",
+  "spirv",
+  "termcolor",
+  "thiserror",
+@@ -3491,11 +3485,10 @@ dependencies = [
+ 
+ [[package]]
+ name = "native-tls"
+-version = "0.2.11"
++version = "0.2.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
++checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+ dependencies = [
+- "lazy_static",
+  "libc",
+  "log",
+  "openssl",
+@@ -3534,29 +3527,27 @@ dependencies = [
+ 
+ [[package]]
+ name = "nix"
+-version = "0.25.1"
++version = "0.26.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
++checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+ dependencies = [
+- "autocfg",
+  "bitflags 1.3.2",
+  "cfg-if",
+  "libc",
+- "memoffset 0.6.5",
+- "pin-utils",
++ "memoffset 0.7.1",
+ ]
+ 
+ [[package]]
+ name = "nix"
+-version = "0.26.4"
++version = "0.28.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
++checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+ dependencies = [
+- "bitflags 1.3.2",
++ "bitflags 2.6.0",
+  "cfg-if",
++ "cfg_aliases",
+  "libc",
+- "memoffset 0.7.1",
+- "pin-utils",
++ "memoffset 0.9.1",
+ ]
+ 
+ [[package]]
+@@ -3648,6 +3639,12 @@ dependencies = [
+  "num-traits",
+ ]
+ 
++[[package]]
++name = "num-conv"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
++
+ [[package]]
+ name = "num-derive"
+ version = "0.3.3"
+@@ -3661,19 +3658,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "num-integer"
+-version = "0.1.45"
++version = "0.1.46"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
++checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+ dependencies = [
+- "autocfg",
+  "num-traits",
+ ]
+ 
+ [[package]]
+ name = "num-iter"
+-version = "0.1.43"
++version = "0.1.45"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
++checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+ dependencies = [
+  "autocfg",
+  "num-integer",
+@@ -3694,9 +3690,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "num-traits"
+-version = "0.2.17"
++version = "0.2.19"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
++checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+ dependencies = [
+  "autocfg",
+ ]
+@@ -3707,7 +3703,7 @@ version = "1.16.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+ dependencies = [
+- "hermit-abi 0.3.4",
++ "hermit-abi 0.3.9",
+  "libc",
+ ]
+ 
+@@ -3732,9 +3728,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "object"
+-version = "0.32.2"
++version = "0.36.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
++checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+ dependencies = [
+  "memchr",
+ ]
+@@ -3753,11 +3749,11 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+ 
+ [[package]]
+ name = "openssl"
+-version = "0.10.63"
++version = "0.10.64"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
++checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "cfg-if",
+  "foreign-types 0.3.2",
+  "libc",
+@@ -3774,7 +3770,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -3785,18 +3781,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+ 
+ [[package]]
+ name = "openssl-src"
+-version = "300.2.1+3.2.0"
++version = "300.3.1+3.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
++checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+ dependencies = [
+  "cc",
+ ]
+ 
+ [[package]]
+ name = "openssl-sys"
+-version = "0.9.99"
++version = "0.9.102"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
++checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+ dependencies = [
+  "cc",
+  "libc",
+@@ -3807,9 +3803,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ordered-float"
+-version = "4.2.0"
++version = "4.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
++checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
+ dependencies = [
+  "num-traits",
+  "rand",
+@@ -3851,12 +3847,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "parking_lot"
+-version = "0.12.1"
++version = "0.12.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
++checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+ dependencies = [
+  "lock_api",
+- "parking_lot_core 0.9.9",
++ "parking_lot_core 0.9.10",
+ ]
+ 
+ [[package]]
+@@ -3875,30 +3871,30 @@ dependencies = [
+ 
+ [[package]]
+ name = "parking_lot_core"
+-version = "0.9.9"
++version = "0.9.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
++checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+ dependencies = [
+  "cfg-if",
+  "libc",
+- "redox_syscall 0.4.1",
++ "redox_syscall 0.5.2",
+  "smallvec",
+- "windows-targets 0.48.5",
++ "windows-targets 0.52.5",
+ ]
+ 
+ [[package]]
+ name = "paste"
+-version = "1.0.14"
++version = "1.0.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
++checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+ 
+ [[package]]
+ name = "pem"
+-version = "3.0.3"
++version = "3.0.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
++checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+ dependencies = [
+- "base64 0.21.7",
++ "base64 0.22.1",
+  "serde",
+ ]
+ 
+@@ -3910,9 +3906,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+ 
+ [[package]]
+ name = "pest"
+-version = "2.7.6"
++version = "2.7.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1f200d8d83c44a45b21764d1916299752ca035d15ecd46faca3e9a2a2bf6ad06"
++checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+ dependencies = [
+  "memchr",
+  "thiserror",
+@@ -3921,9 +3917,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "pest_derive"
+-version = "2.7.6"
++version = "2.7.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bcd6ab1236bbdb3a49027e920e693192ebfe8913f6d60e294de57463a493cfde"
++checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
+ dependencies = [
+  "pest",
+  "pest_generator",
+@@ -3931,22 +3927,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "pest_generator"
+-version = "2.7.6"
++version = "2.7.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2a31940305ffc96863a735bef7c7994a00b325a7138fdbc5bda0f1a0476d3275"
++checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
+ dependencies = [
+  "pest",
+  "pest_meta",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+ name = "pest_meta"
+-version = "2.7.6"
++version = "2.7.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a7ff62f5259e53b78d1af898941cdcdccfae7385cf7d793a6e55de5d05bb4b7d"
++checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
+ dependencies = [
+  "once_cell",
+  "pest",
+@@ -3993,7 +3989,7 @@ dependencies = [
+  "phf_shared",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -4007,29 +4003,29 @@ dependencies = [
+ 
+ [[package]]
+ name = "pin-project"
+-version = "1.1.4"
++version = "1.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
++checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+ dependencies = [
+  "pin-project-internal",
+ ]
+ 
+ [[package]]
+ name = "pin-project-internal"
+-version = "1.1.4"
++version = "1.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
++checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+ name = "pin-project-lite"
+-version = "0.2.13"
++version = "0.2.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
++checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+ 
+ [[package]]
+ name = "pin-utils"
+@@ -4039,40 +4035,39 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+ 
+ [[package]]
+ name = "piper"
+-version = "0.2.1"
++version = "0.2.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
++checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
+ dependencies = [
+  "atomic-waker",
+- "fastrand 2.0.1",
++ "fastrand 2.1.0",
+  "futures-io",
+ ]
+ 
+ [[package]]
+ name = "pkg-config"
+-version = "0.3.29"
++version = "0.3.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
++checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+ 
+ [[package]]
+ name = "plist"
+-version = "1.6.0"
++version = "1.7.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef"
++checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
+ dependencies = [
+- "base64 0.21.7",
+- "indexmap 2.2.1",
+- "line-wrap",
+- "quick-xml 0.31.0",
++ "base64 0.22.1",
++ "indexmap 2.2.6",
++ "quick-xml 0.32.0",
+  "serde",
+  "time",
+ ]
+ 
+ [[package]]
+ name = "plotters"
+-version = "0.3.5"
++version = "0.3.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
++checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+ dependencies = [
+  "num-traits",
+  "plotters-backend",
+@@ -4083,15 +4078,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "plotters-backend"
+-version = "0.3.5"
++version = "0.3.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
++checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+ 
+ [[package]]
+ name = "plotters-svg"
+-version = "0.3.5"
++version = "0.3.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
++checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+ dependencies = [
+  "plotters-backend",
+ ]
+@@ -4111,15 +4106,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "png"
+-version = "0.17.11"
++version = "0.17.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1f6c3c3e617595665b8ea2ff95a86066be38fb121ff920a9c0eb282abcd1da5a"
++checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+ dependencies = [
+  "bitflags 1.3.2",
+  "crc32fast",
+  "fdeflate",
+  "flate2",
+- "miniz_oxide 0.7.1",
++ "miniz_oxide 0.7.4",
+ ]
+ 
+ [[package]]
+@@ -4140,14 +4135,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "polling"
+-version = "3.3.2"
++version = "3.7.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "545c980a3880efd47b2e262f6a4bb6daad6555cf3367aa9c4e52895f69537a41"
++checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+ dependencies = [
+  "cfg-if",
+  "concurrent-queue",
++ "hermit-abi 0.4.0",
+  "pin-project-lite",
+- "rustix 0.38.30",
++ "rustix 0.38.34",
+  "tracing",
+  "windows-sys 0.52.0",
+ ]
+@@ -4164,7 +4160,7 @@ dependencies = [
+  "lazy_static",
+  "libc",
+  "log",
+- "nix 0.25.1",
++ "nix 0.28.0",
+  "serde",
+  "serde_derive",
+  "serial",
+@@ -4235,9 +4231,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.78"
++version = "1.0.86"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
++checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+ dependencies = [
+  "unicode-ident",
+ ]
+@@ -4268,9 +4264,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "profiling"
+-version = "1.0.13"
++version = "1.0.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d135ede8821cf6376eb7a64148901e1690b788c11ae94dc297ae917dbc91dc0e"
++checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
+ 
+ [[package]]
+ name = "promise"
+@@ -4291,7 +4287,7 @@ version = "0.9.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "getopts",
+  "memchr",
+  "unicase",
+@@ -4299,9 +4295,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "pure-rust-locales"
+-version = "0.7.0"
++version = "0.8.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ed02a829e62dc2715ceb8afb4f80e298148e1345749ceb369540fe0eb3368432"
++checksum = "1190fd18ae6ce9e137184f207593877e70f39b015040156b1e05081cdfe3733a"
+ 
+ [[package]]
+ name = "qoi"
+@@ -4323,18 +4319,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "quick-xml"
+-version = "0.31.0"
++version = "0.32.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
++checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+ dependencies = [
+  "memchr",
+ ]
+ 
+ [[package]]
+ name = "quote"
+-version = "1.0.35"
++version = "1.0.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
++checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+ dependencies = [
+  "proc-macro2",
+ ]
+@@ -4401,9 +4397,9 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+ 
+ [[package]]
+ name = "rayon"
+-version = "1.8.1"
++version = "1.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
++checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+ dependencies = [
+  "either",
+  "rayon-core",
+@@ -4449,11 +4445,20 @@ dependencies = [
+  "bitflags 1.3.2",
+ ]
+ 
++[[package]]
++name = "redox_syscall"
++version = "0.5.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
++dependencies = [
++ "bitflags 2.6.0",
++]
++
+ [[package]]
+ name = "redox_users"
+-version = "0.4.4"
++version = "0.4.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
++checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+ dependencies = [
+  "getrandom",
+  "libredox",
+@@ -4462,27 +4467,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "regex"
+-version = "1.10.3"
++version = "1.10.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
++checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+ dependencies = [
+  "aho-corasick",
+  "memchr",
+- "regex-automata 0.4.5",
++ "regex-automata",
+  "regex-syntax",
+ ]
+ 
+ [[package]]
+ name = "regex-automata"
+-version = "0.1.10"
++version = "0.4.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+-
+-[[package]]
+-name = "regex-automata"
+-version = "0.4.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
++checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+ dependencies = [
+  "aho-corasick",
+  "memchr",
+@@ -4491,27 +4490,27 @@ dependencies = [
+ 
+ [[package]]
+ name = "regex-syntax"
+-version = "0.8.2"
++version = "0.8.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
++checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+ 
+ [[package]]
+ name = "relative-path"
+-version = "1.9.2"
++version = "1.9.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
++checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+ 
+ [[package]]
+ name = "renderdoc-sys"
+-version = "1.0.0"
++version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "216080ab382b992234dda86873c18d4c48358f5cfcb70fd693d7f6f2131b628b"
++checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+ 
+ [[package]]
+ name = "reqwest"
+-version = "0.11.23"
++version = "0.11.27"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
++checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+ dependencies = [
+  "base64 0.21.7",
+  "bytes",
+@@ -4531,9 +4530,11 @@ dependencies = [
+  "once_cell",
+  "percent-encoding",
+  "pin-project-lite",
++ "rustls-pemfile",
+  "serde",
+  "serde_json",
+  "serde_urlencoded",
++ "sync_wrapper",
+  "system-configuration",
+  "tokio",
+  "tokio-native-tls",
+@@ -4556,25 +4557,26 @@ dependencies = [
+ 
+ [[package]]
+ name = "rgb"
+-version = "0.8.37"
++version = "0.8.40"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
++checksum = "a7439be6844e40133eda024efd85bf07f59d0dd2f59b10c00dd6cfb92cc5c741"
+ dependencies = [
+  "bytemuck",
+ ]
+ 
+ [[package]]
+ name = "ring"
+-version = "0.17.7"
++version = "0.17.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
++checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+ dependencies = [
+  "cc",
++ "cfg-if",
+  "getrandom",
+  "libc",
+  "spin",
+  "untrusted",
+- "windows-sys 0.48.0",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -4608,7 +4610,7 @@ dependencies = [
+  "regex",
+  "relative-path",
+  "rustc_version",
+- "syn 2.0.48",
++ "syn 2.0.68",
+  "unicode-ident",
+ ]
+ 
+@@ -4629,9 +4631,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustc-demangle"
+-version = "0.1.23"
++version = "0.1.24"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
++checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+ 
+ [[package]]
+ name = "rustc-hash"
+@@ -4639,13 +4641,19 @@ version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+ 
++[[package]]
++name = "rustc-hash"
++version = "2.0.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
++
+ [[package]]
+ name = "rustc_version"
+ version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+ dependencies = [
+- "semver 1.0.21",
++ "semver 1.0.23",
+ ]
+ 
+ [[package]]
+@@ -4664,28 +4672,31 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustix"
+-version = "0.38.30"
++version = "0.38.34"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
++checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "errno",
+  "libc",
+- "linux-raw-sys 0.4.13",
++ "linux-raw-sys 0.4.14",
+  "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+-name = "ryu"
+-version = "1.0.16"
++name = "rustls-pemfile"
++version = "1.0.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
++checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
++dependencies = [
++ "base64 0.21.7",
++]
+ 
+ [[package]]
+-name = "safemem"
+-version = "0.3.3"
++name = "ryu"
++version = "1.0.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
++checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+ 
+ [[package]]
+ name = "same-file"
+@@ -4719,11 +4730,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+ 
+ [[package]]
+ name = "security-framework"
+-version = "2.9.2"
++version = "2.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
++checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+ dependencies = [
+- "bitflags 1.3.2",
++ "bitflags 2.6.0",
+  "core-foundation 0.9.4",
+  "core-foundation-sys 0.8.6",
+  "libc",
+@@ -4732,9 +4743,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "security-framework-sys"
+-version = "2.9.1"
++version = "2.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
++checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+ dependencies = [
+  "core-foundation-sys 0.8.6",
+  "libc",
+@@ -4751,9 +4762,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "semver"
+-version = "1.0.21"
++version = "1.0.23"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
++checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+ 
+ [[package]]
+ name = "semver-parser"
+@@ -4766,9 +4777,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "serde"
+-version = "1.0.196"
++version = "1.0.203"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
++checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+ dependencies = [
+  "serde_derive",
+ ]
+@@ -4779,26 +4790,26 @@ version = "0.11.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+ dependencies = [
+- "half 1.8.2",
++ "half 1.8.3",
+  "serde",
+ ]
+ 
+ [[package]]
+ name = "serde_derive"
+-version = "1.0.196"
++version = "1.0.203"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
++checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+ name = "serde_json"
+-version = "1.0.113"
++version = "1.0.119"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
++checksum = "e8eddb61f0697cc3989c5d64b452f5488e2b8a60fd7d5076a3045076ffef8cb0"
+ dependencies = [
+  "itoa",
+  "ryu",
+@@ -4807,20 +4818,20 @@ dependencies = [
+ 
+ [[package]]
+ name = "serde_repr"
+-version = "0.1.18"
++version = "0.1.19"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
++checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+ name = "serde_spanned"
+-version = "0.6.5"
++version = "0.6.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
++checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+ dependencies = [
+  "serde",
+ ]
+@@ -4862,16 +4873,16 @@ dependencies = [
+  "darling",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+ name = "serde_yaml"
+-version = "0.9.31"
++version = "0.9.34+deprecated"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
++checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+ dependencies = [
+- "indexmap 2.2.1",
++ "indexmap 2.2.6",
+  "itoa",
+  "ryu",
+  "serde",
+@@ -4988,9 +4999,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "signal-hook-registry"
+-version = "1.4.1"
++version = "1.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
++checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+ dependencies = [
+  "libc",
+ ]
+@@ -5027,9 +5038,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "smallvec"
+-version = "1.13.1"
++version = "1.13.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
++checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+ 
+ [[package]]
+ name = "smawk"
+@@ -5105,12 +5116,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "socket2"
+-version = "0.5.5"
++version = "0.5.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
++checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+ dependencies = [
+  "libc",
+- "windows-sys 0.48.0",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -5127,7 +5138,7 @@ name = "spawn-funcs"
+ version = "0.1.0"
+ dependencies = [
+  "anyhow",
+- "bstr 1.9.0",
++ "bstr",
+  "config",
+  "log",
+  "luahelper",
+@@ -5223,7 +5234,7 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+ name = "strip-ansi-escapes"
+ version = "0.1.0"
+ dependencies = [
+- "clap 4.4.18",
++ "clap 4.5.8",
+  "termwiz",
+ ]
+ 
+@@ -5233,11 +5244,17 @@ version = "0.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+ 
++[[package]]
++name = "strsim"
++version = "0.11.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
++
+ [[package]]
+ name = "svg_fmt"
+-version = "0.4.1"
++version = "0.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
++checksum = "20e16a0f46cf5fd675563ef54f26e83e20f2366bcf027bcb3cc3ed2b98aaf2ca"
+ 
+ [[package]]
+ name = "syn"
+@@ -5252,9 +5269,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "syn"
+-version = "2.0.48"
++version = "2.0.68"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
++checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -5268,7 +5285,7 @@ dependencies = [
+  "anyhow",
+  "color-funcs",
+  "config",
+- "env_logger 0.11.1",
++ "env_logger 0.11.3",
+  "futures",
+  "lazy_static",
+  "libflate",
+@@ -5281,11 +5298,17 @@ dependencies = [
+  "tar",
+  "tempfile",
+  "tokio",
+- "toml 0.8.8",
++ "toml 0.8.14",
+  "wezterm-dynamic",
+  "yaml-rust",
+ ]
+ 
++[[package]]
++name = "sync_wrapper"
++version = "0.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
++
+ [[package]]
+ name = "system-configuration"
+ version = "0.5.1"
+@@ -5322,9 +5345,9 @@ checksum = "36ae8932fcfea38b7d3883ae2ab357b0d57a02caaa18ebb4f5ece08beaec4aa0"
+ 
+ [[package]]
+ name = "tar"
+-version = "0.4.40"
++version = "0.4.41"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
++checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+ dependencies = [
+  "filetime",
+  "libc",
+@@ -5333,14 +5356,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "tempfile"
+-version = "3.9.0"
++version = "3.10.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
++checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+ dependencies = [
+  "cfg-if",
+- "fastrand 2.0.1",
+- "redox_syscall 0.4.1",
+- "rustix 0.38.30",
++ "fastrand 2.1.0",
++ "rustix 0.38.34",
+  "windows-sys 0.52.0",
+ ]
+ 
+@@ -5379,7 +5401,7 @@ version = "0.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+ dependencies = [
+- "rustix 0.38.30",
++ "rustix 0.38.34",
+  "windows-sys 0.48.0",
+ ]
+ 
+@@ -5426,10 +5448,10 @@ version = "0.22.0"
+ dependencies = [
+  "anyhow",
+  "base64 0.21.7",
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "cassowary",
+  "criterion 0.4.0",
+- "env_logger 0.11.1",
++ "env_logger 0.11.3",
+  "fancy-regex",
+  "filedescriptor",
+  "finl_unicode",
+@@ -5442,7 +5464,7 @@ dependencies = [
+  "libc",
+  "log",
+  "memmem",
+- "nix 0.26.4",
++ "nix 0.28.0",
+  "num-derive",
+  "num-traits",
+  "ordered-float",
+@@ -5496,9 +5518,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "textwrap"
+-version = "0.16.0"
++version = "0.16.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
++checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+ dependencies = [
+  "smawk",
+  "unicode-linebreak",
+@@ -5507,22 +5529,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "thiserror"
+-version = "1.0.56"
++version = "1.0.61"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
++checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+ dependencies = [
+  "thiserror-impl",
+ ]
+ 
+ [[package]]
+ name = "thiserror-impl"
+-version = "1.0.56"
++version = "1.0.61"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
++checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -5533,9 +5555,9 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+ 
+ [[package]]
+ name = "thread_local"
+-version = "1.1.7"
++version = "1.1.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
++checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+ dependencies = [
+  "cfg-if",
+  "once_cell",
+@@ -5554,12 +5576,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.31"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
++ "num-conv",
+  "powerfmt",
+  "serde",
+  "time-core",
+@@ -5589,18 +5612,19 @@ dependencies = [
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.16"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
++ "num-conv",
+  "time-core",
+ ]
+ 
+ [[package]]
+ name = "tiny-skia"
+-version = "0.11.3"
++version = "0.11.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b6a067b809476893fce6a254cf285850ff69c847e6cfbade6a20b655b6c7e80d"
++checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+ dependencies = [
+  "arrayref",
+  "arrayvec",
+@@ -5613,9 +5637,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tiny-skia-path"
+-version = "0.11.3"
++version = "0.11.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5de35e8a90052baaaf61f171680ac2f8e925a1e43ea9d2e3a00514772250e541"
++checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+ dependencies = [
+  "arrayref",
+  "bytemuck",
+@@ -5634,9 +5658,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tinyvec"
+-version = "1.6.0"
++version = "1.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
++checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
+ dependencies = [
+  "tinyvec_macros",
+ ]
+@@ -5649,9 +5673,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+ 
+ [[package]]
+ name = "tokio"
+-version = "1.35.1"
++version = "1.38.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
++checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+ dependencies = [
+  "backtrace",
+  "bytes",
+@@ -5659,20 +5683,20 @@ dependencies = [
+  "mio",
+  "num_cpus",
+  "pin-project-lite",
+- "socket2 0.5.5",
++ "socket2 0.5.7",
+  "tokio-macros",
+  "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+ name = "tokio-macros"
+-version = "2.2.0"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
++checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -5687,16 +5711,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "tokio-util"
+-version = "0.7.10"
++version = "0.7.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
++checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+ dependencies = [
+  "bytes",
+  "futures-core",
+  "futures-sink",
+  "pin-project-lite",
+  "tokio",
+- "tracing",
+ ]
+ 
+ [[package]]
+@@ -5710,21 +5733,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "toml"
+-version = "0.8.8"
++version = "0.8.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
++checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+ dependencies = [
+  "serde",
+  "serde_spanned",
+  "toml_datetime",
+- "toml_edit 0.21.0",
++ "toml_edit 0.22.14",
+ ]
+ 
+ [[package]]
+ name = "toml_datetime"
+-version = "0.6.5"
++version = "0.6.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
++checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+ dependencies = [
+  "serde",
+ ]
+@@ -5735,22 +5758,22 @@ version = "0.19.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+ dependencies = [
+- "indexmap 2.2.1",
++ "indexmap 2.2.6",
+  "toml_datetime",
+- "winnow",
++ "winnow 0.5.40",
+ ]
+ 
+ [[package]]
+ name = "toml_edit"
+-version = "0.21.0"
++version = "0.22.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
++checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+ dependencies = [
+- "indexmap 2.2.1",
++ "indexmap 2.2.6",
+  "serde",
+  "serde_spanned",
+  "toml_datetime",
+- "winnow",
++ "winnow 0.6.13",
+ ]
+ 
+ [[package]]
+@@ -5778,7 +5801,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -5814,7 +5837,7 @@ version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+ dependencies = [
+- "memoffset 0.9.0",
++ "memoffset 0.9.1",
+  "tempfile",
+  "winapi",
+ ]
+@@ -5856,24 +5879,24 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+ 
+ [[package]]
+ name = "unicode-normalization"
+-version = "0.1.22"
++version = "0.1.23"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
++checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+ dependencies = [
+  "tinyvec",
+ ]
+ 
+ [[package]]
+ name = "unicode-segmentation"
+-version = "1.10.1"
++version = "1.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
++checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+ 
+ [[package]]
+ name = "unicode-width"
+-version = "0.1.11"
++version = "0.1.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
++checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+ 
+ [[package]]
+ name = "unicode-xid"
+@@ -5883,9 +5906,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+ 
+ [[package]]
+ name = "unsafe-libyaml"
+-version = "0.2.10"
++version = "0.2.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
++checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+ 
+ [[package]]
+ name = "untrusted"
+@@ -5905,9 +5928,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "url"
+-version = "2.5.0"
++version = "2.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
++checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+ dependencies = [
+  "form_urlencoded",
+  "idna",
+@@ -5928,15 +5951,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "utf8parse"
+-version = "0.2.1"
++version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
++checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+ 
+ [[package]]
+ name = "uuid"
+-version = "1.7.0"
++version = "1.9.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
++checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+ dependencies = [
+  "atomic",
+  "getrandom",
+@@ -5996,15 +6019,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "waker-fn"
+-version = "1.1.1"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
++checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+ 
+ [[package]]
+ name = "walkdir"
+-version = "2.4.0"
++version = "2.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
++checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+ dependencies = [
+  "same-file",
+  "winapi-util",
+@@ -6025,11 +6048,17 @@ version = "0.11.0+wasi-snapshot-preview1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+ 
++[[package]]
++name = "wasite"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
++
+ [[package]]
+ name = "wasm-bindgen"
+-version = "0.2.90"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
++checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+ dependencies = [
+  "cfg-if",
+  "wasm-bindgen-macro",
+@@ -6037,24 +6066,24 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-backend"
+-version = "0.2.90"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
++checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+ dependencies = [
+  "bumpalo",
+  "log",
+  "once_cell",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+  "wasm-bindgen-shared",
+ ]
+ 
+ [[package]]
+ name = "wasm-bindgen-futures"
+-version = "0.4.40"
++version = "0.4.42"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
++checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+ dependencies = [
+  "cfg-if",
+  "js-sys",
+@@ -6064,9 +6093,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro"
+-version = "0.2.90"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
++checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+ dependencies = [
+  "quote",
+  "wasm-bindgen-macro-support",
+@@ -6074,22 +6103,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro-support"
+-version = "0.2.90"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
++checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+  "wasm-bindgen-backend",
+  "wasm-bindgen-shared",
+ ]
+ 
+ [[package]]
+ name = "wasm-bindgen-shared"
+-version = "0.2.90"
++version = "0.2.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
++checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+ 
+ [[package]]
+ name = "wayland-client"
+@@ -6196,7 +6225,7 @@ dependencies = [
+  "anyhow",
+  "cc",
+  "chrono",
+- "clap 4.4.18",
++ "clap 4.5.8",
+  "clap_complete",
+  "clap_complete_fig",
+  "codec",
+@@ -6220,7 +6249,7 @@ dependencies = [
+  "termios 0.3.3",
+  "termwiz",
+  "termwiz-funcs",
+- "textwrap 0.16.0",
++ "textwrap 0.16.1",
+  "umask",
+  "url",
+  "wezterm-client",
+@@ -6233,7 +6262,7 @@ dependencies = [
+ name = "wezterm-bidi"
+ version = "0.2.3"
+ dependencies = [
+- "env_logger 0.11.1",
++ "env_logger 0.11.3",
+  "k9 0.12.0",
+  "log",
+  "wezterm-dynamic",
+@@ -6271,14 +6300,14 @@ dependencies = [
+  "metrics",
+  "mux",
+  "openssl",
+- "parking_lot 0.12.1",
++ "parking_lot 0.12.3",
+  "portable-pty",
+  "promise",
+  "rangeset",
+  "ratelim",
+  "smol",
+  "termwiz",
+- "textwrap 0.16.0",
++ "textwrap 0.16.1",
+  "thiserror",
+  "uds_windows",
+  "umask",
+@@ -6316,7 +6345,7 @@ dependencies = [
+  "log",
+  "maplit",
+  "ordered-float",
+- "strsim",
++ "strsim 0.10.0",
+  "thiserror",
+  "wezterm-dynamic-derive",
+ ]
+@@ -6343,7 +6372,7 @@ dependencies = [
+  "dwrote",
+  "encoding_rs",
+  "enum-display-derive",
+- "env_logger 0.11.1",
++ "env_logger 0.11.3",
+  "euclid",
+  "finl_unicode",
+  "fontconfig",
+@@ -6380,7 +6409,7 @@ dependencies = [
+  "bytemuck",
+  "cc",
+  "chrono",
+- "clap 4.4.18",
++ "clap 4.5.8",
+  "codec",
+  "colorgrad",
+  "config",
+@@ -6390,9 +6419,9 @@ dependencies = [
+  "embed-resource",
+  "emojis",
+  "env-bootstrap",
+- "env_logger 0.11.1",
++ "env_logger 0.11.3",
+  "euclid",
+- "fastrand 2.0.1",
++ "fastrand 2.1.0",
+  "filedescriptor",
+  "finl_unicode",
+  "frecency",
+@@ -6413,7 +6442,7 @@ dependencies = [
+  "mux-lua",
+  "once_cell",
+  "ordered-float",
+- "parking_lot 0.12.1",
++ "parking_lot 0.12.3",
+  "portable-pty",
+  "promise",
+  "pulldown-cmark",
+@@ -6431,7 +6460,7 @@ dependencies = [
+  "terminfo",
+  "termwiz",
+  "termwiz-funcs",
+- "textwrap 0.16.0",
++ "textwrap 0.16.1",
+  "thiserror",
+  "tiny-skia",
+  "uds_windows",
+@@ -6465,7 +6494,7 @@ name = "wezterm-gui-subcommands"
+ version = "0.1.0"
+ dependencies = [
+  "anyhow",
+- "clap 4.4.18",
++ "clap 4.5.8",
+  "config",
+ ]
+ 
+@@ -6487,7 +6516,7 @@ dependencies = [
+  "anyhow",
+  "async_ossl",
+  "cc",
+- "clap 4.4.18",
++ "clap 4.5.8",
+  "config",
+  "embed-resource",
+  "env-bootstrap",
+@@ -6549,9 +6578,9 @@ dependencies = [
+  "base64 0.21.7",
+  "bitflags 1.3.2",
+  "camino",
+- "clap 4.4.18",
++ "clap 4.5.8",
+  "dirs-next",
+- "env_logger 0.11.1",
++ "env_logger 0.11.3",
+  "filedescriptor",
+  "filenamegen",
+  "gethostname",
+@@ -6567,7 +6596,7 @@ dependencies = [
+  "shell-words",
+  "smol",
+  "smol-potat",
+- "socket2 0.5.5",
++ "socket2 0.5.7",
+  "ssh2",
+  "termwiz",
+  "thiserror",
+@@ -6582,7 +6611,7 @@ dependencies = [
+  "bitflags 1.3.2",
+  "csscolorparser",
+  "downcast-rs",
+- "env_logger 0.11.1",
++ "env_logger 0.11.3",
+  "finl_unicode",
+  "hex",
+  "humansize",
+@@ -6640,7 +6669,7 @@ dependencies = [
+  "js-sys",
+  "log",
+  "naga",
+- "parking_lot 0.12.1",
++ "parking_lot 0.12.3",
+  "profiling",
+  "raw-window-handle",
+  "smallvec",
+@@ -6661,14 +6690,14 @@ checksum = "ef91c1d62d1e9e81c79e600131a258edf75c9531cbdbde09c44a011a47312726"
+ dependencies = [
+  "arrayvec",
+  "bit-vec",
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "codespan-reporting",
+  "log",
+  "naga",
+- "parking_lot 0.12.1",
++ "parking_lot 0.12.3",
+  "profiling",
+  "raw-window-handle",
+- "rustc-hash",
++ "rustc-hash 1.1.0",
+  "smallvec",
+  "thiserror",
+  "web-sys",
+@@ -6686,7 +6715,7 @@ dependencies = [
+  "arrayvec",
+  "ash",
+  "bit-set",
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "block",
+  "core-graphics-types",
+  "d3d12",
+@@ -6699,18 +6728,18 @@ dependencies = [
+  "js-sys",
+  "khronos-egl",
+  "libc",
+- "libloading 0.8.1",
++ "libloading 0.8.4",
+  "log",
+  "metal",
+  "naga",
+  "objc",
+  "once_cell",
+- "parking_lot 0.12.1",
++ "parking_lot 0.12.3",
+  "profiling",
+  "range-alloc",
+  "raw-window-handle",
+  "renderdoc-sys",
+- "rustc-hash",
++ "rustc-hash 1.1.0",
+  "smallvec",
+  "thiserror",
+  "wasm-bindgen",
+@@ -6725,39 +6754,39 @@ version = "0.18.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "0d5ed5f0edf0de351fe311c53304986315ce866f394a2e6df0c4b3c70774bcdd"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.6.0",
+  "js-sys",
+  "web-sys",
+ ]
+ 
+ [[package]]
+ name = "which"
+-version = "5.0.0"
++version = "6.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
++checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
+ dependencies = [
+  "either",
+  "home",
+- "once_cell",
+- "rustix 0.38.30",
+- "windows-sys 0.48.0",
++ "rustix 0.38.34",
++ "winsafe",
+ ]
+ 
+ [[package]]
+ name = "whoami"
+-version = "1.4.1"
++version = "1.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
++checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+ dependencies = [
+- "wasm-bindgen",
++ "redox_syscall 0.4.1",
++ "wasite",
+  "web-sys",
+ ]
+ 
+ [[package]]
+ name = "widestring"
+-version = "1.0.2"
++version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
++checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+ 
+ [[package]]
+ name = "winapi"
+@@ -6777,11 +6806,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+ 
+ [[package]]
+ name = "winapi-util"
+-version = "0.1.6"
++version = "0.1.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
++checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+ dependencies = [
+- "winapi",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -6903,7 +6932,7 @@ version = "0.52.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+ dependencies = [
+- "windows-targets 0.52.0",
++ "windows-targets 0.52.5",
+ ]
+ 
+ [[package]]
+@@ -6930,7 +6959,7 @@ version = "0.52.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+ dependencies = [
+- "windows-targets 0.52.0",
++ "windows-targets 0.52.5",
+ ]
+ 
+ [[package]]
+@@ -6965,17 +6994,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "windows-targets"
+-version = "0.52.0"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
++checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+ dependencies = [
+- "windows_aarch64_gnullvm 0.52.0",
+- "windows_aarch64_msvc 0.52.0",
+- "windows_i686_gnu 0.52.0",
+- "windows_i686_msvc 0.52.0",
+- "windows_x86_64_gnu 0.52.0",
+- "windows_x86_64_gnullvm 0.52.0",
+- "windows_x86_64_msvc 0.52.0",
++ "windows_aarch64_gnullvm 0.52.5",
++ "windows_aarch64_msvc 0.52.5",
++ "windows_i686_gnu 0.52.5",
++ "windows_i686_gnullvm",
++ "windows_i686_msvc 0.52.5",
++ "windows_x86_64_gnu 0.52.5",
++ "windows_x86_64_gnullvm 0.52.5",
++ "windows_x86_64_msvc 0.52.5",
+ ]
+ 
+ [[package]]
+@@ -6992,9 +7022,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+ 
+ [[package]]
+ name = "windows_aarch64_gnullvm"
+-version = "0.52.0"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
++checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+ 
+ [[package]]
+ name = "windows_aarch64_msvc"
+@@ -7016,9 +7046,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+ 
+ [[package]]
+ name = "windows_aarch64_msvc"
+-version = "0.52.0"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
++checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+ 
+ [[package]]
+ name = "windows_i686_gnu"
+@@ -7040,9 +7070,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+ 
+ [[package]]
+ name = "windows_i686_gnu"
+-version = "0.52.0"
++version = "0.52.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
++
++[[package]]
++name = "windows_i686_gnullvm"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
++checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+ 
+ [[package]]
+ name = "windows_i686_msvc"
+@@ -7064,9 +7100,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+ 
+ [[package]]
+ name = "windows_i686_msvc"
+-version = "0.52.0"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
++checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+ 
+ [[package]]
+ name = "windows_x86_64_gnu"
+@@ -7088,9 +7124,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+ 
+ [[package]]
+ name = "windows_x86_64_gnu"
+-version = "0.52.0"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
++checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+ 
+ [[package]]
+ name = "windows_x86_64_gnullvm"
+@@ -7106,9 +7142,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+ 
+ [[package]]
+ name = "windows_x86_64_gnullvm"
+-version = "0.52.0"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
++checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+ 
+ [[package]]
+ name = "windows_x86_64_msvc"
+@@ -7130,15 +7166,24 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+ 
+ [[package]]
+ name = "windows_x86_64_msvc"
+-version = "0.52.0"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
++checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+ 
+ [[package]]
+ name = "winnow"
+-version = "0.5.35"
++version = "0.5.40"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1931d78a9c73861da0134f453bb1f790ce49b2e30eba8410b4b79bac72b46a2d"
++checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
++dependencies = [
++ "memchr",
++]
++
++[[package]]
++name = "winnow"
++version = "0.6.13"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+ dependencies = [
+  "memchr",
+ ]
+@@ -7162,6 +7207,12 @@ dependencies = [
+  "windows-sys 0.48.0",
+ ]
+ 
++[[package]]
++name = "winsafe"
++version = "0.0.19"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
++
+ [[package]]
+ name = "wio"
+ version = "0.2.2"
+@@ -7188,15 +7239,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+ dependencies = [
+  "libc",
+- "linux-raw-sys 0.4.13",
+- "rustix 0.38.30",
++ "linux-raw-sys 0.4.14",
++ "rustix 0.38.34",
+ ]
+ 
+ [[package]]
+ name = "xcb"
+-version = "1.3.0"
++version = "1.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5d27b37e69b8c05bfadcd968eb1a4fe27c9c52565b727f88512f43b89567e262"
++checksum = "02e75181b5a62b6eeaa72f303d3cef7dbb841e22885bf6d3e66fe23e88c55dc6"
+ dependencies = [
+  "as-raw-xcb-connection",
+  "bitflags 1.3.2",
+@@ -7225,12 +7276,12 @@ checksum = "6a0ccd7b4a5345edfcd0c3535718a4e9ff7798ffc536bb5b5a0e26ff84732911"
+ 
+ [[package]]
+ name = "xdg-home"
+-version = "1.0.0"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd"
++checksum = "ca91dcf8f93db085f3a0a29358cd0b9d670915468f4290e8b85d118a34211ab8"
+ dependencies = [
+- "nix 0.26.4",
+- "winapi",
++ "libc",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -7247,15 +7298,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "xkeysym"
+-version = "0.2.0"
++version = "0.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621"
++checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+ 
+ [[package]]
+ name = "xml-rs"
+-version = "0.8.19"
++version = "0.8.20"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
++checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
+ 
+ [[package]]
+ name = "yaml-rust"
+@@ -7277,9 +7328,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus"
+-version = "3.14.1"
++version = "3.15.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "31de390a2d872e4cd04edd71b425e29853f786dc99317ed72d73d6fcf5ebb948"
++checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
+ dependencies = [
+  "async-broadcast",
+  "async-executor",
+@@ -7318,9 +7369,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus_macros"
+-version = "3.14.1"
++version = "3.15.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "41d1794a946878c0e807f55a397187c11fc7a038ba5d868e7db4f3bd7760bc9d"
++checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
+ dependencies = [
+  "proc-macro-crate",
+  "proc-macro2",
+@@ -7332,9 +7383,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus_names"
+-version = "2.6.0"
++version = "2.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9"
++checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
+ dependencies = [
+  "serde",
+  "static_assertions",
+@@ -7343,22 +7394,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "zerocopy"
+-version = "0.7.32"
++version = "0.7.34"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
++checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+ dependencies = [
+  "zerocopy-derive",
+ ]
+ 
+ [[package]]
+ name = "zerocopy-derive"
+-version = "0.7.32"
++version = "0.7.34"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
++checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.68",
+ ]
+ 
+ [[package]]
+@@ -7382,9 +7433,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zstd-sys"
+-version = "2.0.9+zstd.1.5.5"
++version = "2.0.11+zstd.1.5.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
++checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
+ dependencies = [
+  "cc",
+  "pkg-config",
+@@ -7401,9 +7452,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zvariant"
+-version = "3.15.0"
++version = "3.15.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c"
++checksum = "4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db"
+ dependencies = [
+  "byteorder",
+  "enumflags2",
+@@ -7415,9 +7466,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zvariant_derive"
+-version = "3.15.0"
++version = "3.15.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd"
++checksum = "37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9"
+ dependencies = [
+  "proc-macro-crate",
+  "proc-macro2",
+diff --git a/config/Cargo.toml b/config/Cargo.toml
+index 580920b9a..bb56ed4ce 100644
+--- a/config/Cargo.toml
++++ b/config/Cargo.toml
+@@ -45,7 +45,7 @@ wezterm-ssh = { path = "../wezterm-ssh" }
+ wezterm-term = { path = "../term", features=["use_serde"] }
+ 
+ [target."cfg(unix)".dependencies]
+-nix = "0.26"
++nix = {version="0.28", features=["resource"]}
+ 
+ [target."cfg(windows)".dependencies]
+ winapi = { version = "0.3", features = ["winuser"]}
+diff --git a/mux/Cargo.toml b/mux/Cargo.toml
+index 5e508f73a..5fe4cd42a 100644
+--- a/mux/Cargo.toml
++++ b/mux/Cargo.toml
+@@ -27,7 +27,7 @@ luahelper = { path = "../luahelper" }
+ metrics = { version="0.17", features=["std"]}
+ mlua = "0.9"
+ names = { version = "0.12", default-features = false }
+-nix = {version="0.25", features=["term"]}
++nix = {version="0.28", features=["term"]}
+ parking_lot = "0.12"
+ percent-encoding = "2"
+ portable-pty = { path = "../pty", features = ["serde_support"]}
+diff --git a/pty/Cargo.toml b/pty/Cargo.toml
+index 2e717483e..d8fa02b64 100644
+--- a/pty/Cargo.toml
++++ b/pty/Cargo.toml
+@@ -14,7 +14,7 @@ downcast-rs = "1.0"
+ filedescriptor = { version="0.8", path = "../filedescriptor" }
+ log = "0.4"
+ libc = "0.2"
+-nix = {version="0.25", features=["term"]}
++nix = {version="0.28", features=["term", "fs"]}
+ shell-words = "1.1"
+ serde_derive = {version="1.0", optional=true}
+ serde = {version="1.0", optional=true}
+diff --git a/pty/src/unix.rs b/pty/src/unix.rs
+index cbe0f76fb..2fd7207a7 100644
+--- a/pty/src/unix.rs
++++ b/pty/src/unix.rs
+@@ -7,6 +7,7 @@ use libc::{self, winsize};
+ use std::cell::RefCell;
+ use std::ffi::OsStr;
+ use std::io::{Read, Write};
++use std::os::fd::AsFd;
+ use std::os::unix::ffi::OsStrExt;
+ use std::os::unix::io::{AsRawFd, FromRawFd};
+ use std::os::unix::process::CommandExt;
+@@ -378,7 +379,7 @@ impl MasterPty for UnixMasterPty {
+     }
+ 
+     fn get_termios(&self) -> Option<nix::sys::termios::Termios> {
+-        nix::sys::termios::tcgetattr(self.fd.0.as_raw_fd()).ok()
++        nix::sys::termios::tcgetattr(self.fd.0.as_fd()).ok()
+     }
+ }
+ 
+diff --git a/termwiz/Cargo.toml b/termwiz/Cargo.toml
+index 2a74a30dc..d17d47aff 100644
+--- a/termwiz/Cargo.toml
++++ b/termwiz/Cargo.toml
+@@ -67,7 +67,7 @@ version = "0.3"
+ [target."cfg(unix)".dependencies]
+ signal-hook = "0.3"
+ termios = "0.3"
+-nix = "0.26"
++nix = {version="0.28", features=["mman"]}
+ 
+ [target."cfg(windows)".dependencies.winapi]
+ features = [
+diff --git a/termwiz/src/escape/apc.rs b/termwiz/src/escape/apc.rs
+index 78e2b9c3d..c9c0e2d60 100644
+--- a/termwiz/src/escape/apc.rs
++++ b/termwiz/src/escape/apc.rs
+@@ -273,9 +273,8 @@ fn read_shared_memory_data(
+ ) -> std::result::Result<std::vec::Vec<u8>, std::io::Error> {
+     use nix::sys::mman::{shm_open, shm_unlink};
+     use std::fs::File;
+-    use std::os::unix::io::FromRawFd;
+ 
+-    let raw_fd = shm_open(
++    let fd = shm_open(
+         name,
+         nix::fcntl::OFlag::O_RDONLY,
+         nix::sys::stat::Mode::empty(),
+@@ -287,7 +286,7 @@ fn read_shared_memory_data(
+             format!("shm_open {} failed: {:#}", name, err),
+         )
+     })?;
+-    let mut f = unsafe { File::from_raw_fd(raw_fd) };
++    let mut f = File::from(fd);
+     if let Some(offset) = data_offset {
+         f.seek(std::io::SeekFrom::Start(offset.into()))?;
+     }
+-- 
+2.45.2
+

--- a/app-utils/wezterm/autobuild/patches/0002-fix-fix-as_fd.patch.loongarch64
+++ b/app-utils/wezterm/autobuild/patches/0002-fix-fix-as_fd.patch.loongarch64
@@ -1,0 +1,27 @@
+From 710e727d943f090986ef847dc08233b4cfdb165f Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Mon, 1 Jul 2024 15:18:06 +0800
+Subject: [PATCH 2/4] fix: fix `as_fd`
+
+---
+ pty/src/unix.rs | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/pty/src/unix.rs b/pty/src/unix.rs
+index 2fd7207a7..b7ef35e8b 100644
+--- a/pty/src/unix.rs
++++ b/pty/src/unix.rs
+@@ -379,7 +379,9 @@ impl MasterPty for UnixMasterPty {
+     }
+ 
+     fn get_termios(&self) -> Option<nix::sys::termios::Termios> {
+-        nix::sys::termios::tcgetattr(self.fd.0.as_fd()).ok()
++        let fd = self.fd.0.as_file().ok()?;
++        let fd = fd.as_fd();
++        nix::sys::termios::tcgetattr(fd).ok()
+     }
+ }
+ 
+-- 
+2.45.2
+

--- a/app-utils/wezterm/autobuild/patches/0003-deps-update-zbus.patch.loongarch64
+++ b/app-utils/wezterm/autobuild/patches/0003-deps-update-zbus.patch.loongarch64
@@ -1,0 +1,719 @@
+From b97f66bdec0f2d19081034e9812958ca5a85f8b4 Mon Sep 17 00:00:00 2001
+From: Wez Furlong <wez@wezfurlong.org>
+Date: Mon, 13 May 2024 09:56:11 -0700
+Subject: [PATCH 3/4] deps: update zbus
+
+---
+ .vscode/settings.json                  |   3 +
+ Cargo.lock                             | 291 +++++++++++++++----------
+ wezterm-toast-notification/Cargo.toml  |   4 +-
+ wezterm-toast-notification/src/dbus.rs |  12 +-
+ window/Cargo.toml                      |  15 +-
+ window/src/os/xdg_desktop_portal.rs    |  16 +-
+ 6 files changed, 199 insertions(+), 142 deletions(-)
+ create mode 100644 .vscode/settings.json
+
+diff --git a/.vscode/settings.json b/.vscode/settings.json
+new file mode 100644
+index 000000000..51fd3bd54
+--- /dev/null
++++ b/.vscode/settings.json
+@@ -0,0 +1,3 @@
++{
++    "rust-analyzer.checkOnSave": true
++}
+\ No newline at end of file
+diff --git a/Cargo.lock b/Cargo.lock
+index d049f9c85..b34b641d2 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -182,12 +182,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "async-broadcast"
+-version = "0.5.1"
++version = "0.7.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
++checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
+ dependencies = [
+- "event-listener 2.5.3",
++ "event-listener 5.3.1",
++ "event-listener-strategy",
+  "futures-core",
++ "pin-project-lite",
+ ]
+ 
+ [[package]]
+@@ -238,6 +240,17 @@ dependencies = [
+  "futures-lite 1.13.0",
+ ]
+ 
++[[package]]
++name = "async-fs"
++version = "2.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
++dependencies = [
++ "async-lock 3.4.0",
++ "blocking",
++ "futures-lite 2.3.0",
++]
++
+ [[package]]
+ name = "async-io"
+ version = "1.13.0"
+@@ -325,6 +338,26 @@ dependencies = [
+  "windows-sys 0.48.0",
+ ]
+ 
++[[package]]
++name = "async-process"
++version = "2.2.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f7eda79bbd84e29c2b308d1dc099d7de8dcc7035e48f4bf5dc4a531a44ff5e2a"
++dependencies = [
++ "async-channel 2.3.1",
++ "async-io 2.3.3",
++ "async-lock 3.4.0",
++ "async-signal",
++ "async-task",
++ "blocking",
++ "cfg-if",
++ "event-listener 5.3.1",
++ "futures-lite 2.3.0",
++ "rustix 0.38.34",
++ "tracing",
++ "windows-sys 0.52.0",
++]
++
+ [[package]]
+ name = "async-recursion"
+ version = "1.1.1"
+@@ -649,6 +682,12 @@ version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+ 
++[[package]]
++name = "cfg_aliases"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
++
+ [[package]]
+ name = "cgl"
+ version = "0.3.2"
+@@ -1275,6 +1314,12 @@ dependencies = [
+  "memchr",
+ ]
+ 
++[[package]]
++name = "cursor-icon"
++version = "1.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
++
+ [[package]]
+ name = "d3d12"
+ version = "0.7.0"
+@@ -1349,17 +1394,6 @@ dependencies = [
+  "serde",
+ ]
+ 
+-[[package]]
+-name = "derivative"
+-version = "2.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn 1.0.109",
+-]
+-
+ [[package]]
+ name = "dhat"
+ version = "0.3.3"
+@@ -1511,6 +1545,12 @@ dependencies = [
+  "cfg-if",
+ ]
+ 
++[[package]]
++name = "endi"
++version = "1.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
++
+ [[package]]
+ name = "enum-display-derive"
+ version = "0.1.1"
+@@ -3211,18 +3251,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "memmap2"
+-version = "0.5.10"
++version = "0.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
++checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
+ dependencies = [
+  "libc",
+ ]
+ 
+ [[package]]
+ name = "memmap2"
+-version = "0.8.0"
++version = "0.9.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
++checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+ dependencies = [
+  "libc",
+ ]
+@@ -3242,15 +3282,6 @@ dependencies = [
+  "autocfg",
+ ]
+ 
+-[[package]]
+-name = "memoffset"
+-version = "0.7.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+-dependencies = [
+- "autocfg",
+-]
+-
+ [[package]]
+ name = "memoffset"
+ version = "0.9.1"
+@@ -3515,37 +3546,26 @@ dependencies = [
+ 
+ [[package]]
+ name = "nix"
+-version = "0.24.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+-dependencies = [
+- "bitflags 1.3.2",
+- "cfg-if",
+- "libc",
+- "memoffset 0.6.5",
+-]
+-
+-[[package]]
+-name = "nix"
+-version = "0.26.4"
++version = "0.28.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
++checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+ dependencies = [
+- "bitflags 1.3.2",
++ "bitflags 2.6.0",
+  "cfg-if",
++ "cfg_aliases 0.1.1",
+  "libc",
+- "memoffset 0.7.1",
++ "memoffset 0.9.1",
+ ]
+ 
+ [[package]]
+ name = "nix"
+-version = "0.28.0"
++version = "0.29.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
++checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+ dependencies = [
+  "bitflags 2.6.0",
+  "cfg-if",
+- "cfg_aliases",
++ "cfg_aliases 0.2.1",
+  "libc",
+  "memoffset 0.9.1",
+ ]
+@@ -4221,12 +4241,11 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+ 
+ [[package]]
+ name = "proc-macro-crate"
+-version = "1.3.1"
++version = "3.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
++checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+ dependencies = [
+- "once_cell",
+- "toml_edit 0.19.15",
++ "toml_edit 0.21.1",
+ ]
+ 
+ [[package]]
+@@ -4317,6 +4336,15 @@ dependencies = [
+  "memchr",
+ ]
+ 
++[[package]]
++name = "quick-xml"
++version = "0.31.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
++dependencies = [
++ "memchr",
++]
++
+ [[package]]
+ name = "quick-xml"
+ version = "0.32.0"
+@@ -5050,20 +5078,25 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+ 
+ [[package]]
+ name = "smithay-client-toolkit"
+-version = "0.16.1"
++version = "0.18.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "870427e30b8f2cbe64bf43ec4b86e88fe39b0a84b3f15efd9c9c2d020bc86eb9"
++checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
+ dependencies = [
+- "bitflags 1.3.2",
+- "dlib",
+- "lazy_static",
++ "bitflags 2.6.0",
++ "cursor-icon",
++ "libc",
+  "log",
+- "memmap2 0.5.10",
+- "nix 0.24.3",
+- "pkg-config",
++ "memmap2 0.9.4",
++ "rustix 0.38.34",
++ "thiserror",
++ "wayland-backend",
+  "wayland-client",
++ "wayland-csd-frame",
+  "wayland-cursor",
+  "wayland-protocols",
++ "wayland-protocols-wlr",
++ "wayland-scanner",
++ "xkeysym",
+ ]
+ 
+ [[package]]
+@@ -5074,11 +5107,11 @@ checksum = "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
+ dependencies = [
+  "async-channel 1.9.0",
+  "async-executor",
+- "async-fs",
++ "async-fs 1.6.0",
+  "async-io 1.13.0",
+  "async-lock 2.8.0",
+  "async-net",
+- "async-process",
++ "async-process 1.8.1",
+  "blocking",
+  "futures-lite 1.13.0",
+ ]
+@@ -5754,9 +5787,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "toml_edit"
+-version = "0.19.15"
++version = "0.21.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
++checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+ dependencies = [
+  "indexmap 2.2.6",
+  "toml_datetime",
+@@ -6121,84 +6154,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+ 
+ [[package]]
+-name = "wayland-client"
+-version = "0.29.5"
++name = "wayland-backend"
++version = "0.3.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
++checksum = "34e9e6b6d4a2bb4e7e69433e0b35c7923b95d4dc8503a84d25ec917a4bbfdf07"
+ dependencies = [
+- "bitflags 1.3.2",
++ "cc",
+  "downcast-rs",
+- "libc",
+- "nix 0.24.3",
++ "rustix 0.38.34",
+  "scoped-tls",
+- "wayland-commons",
+- "wayland-scanner",
++ "smallvec",
+  "wayland-sys",
+ ]
+ 
+ [[package]]
+-name = "wayland-commons"
+-version = "0.29.5"
++name = "wayland-client"
++version = "0.31.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
++checksum = "1e63801c85358a431f986cffa74ba9599ff571fc5774ac113ed3b490c19a1133"
+ dependencies = [
+- "nix 0.24.3",
+- "once_cell",
+- "smallvec",
+- "wayland-sys",
++ "bitflags 2.6.0",
++ "rustix 0.38.34",
++ "wayland-backend",
++ "wayland-scanner",
++]
++
++[[package]]
++name = "wayland-csd-frame"
++version = "0.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
++dependencies = [
++ "bitflags 2.6.0",
++ "cursor-icon",
++ "wayland-backend",
+ ]
+ 
+ [[package]]
+ name = "wayland-cursor"
+-version = "0.29.5"
++version = "0.31.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
++checksum = "a206e8b2b53b1d3fcb9428fec72bc278ce539e2fa81fe2bfc1ab27703d5187b9"
+ dependencies = [
+- "nix 0.24.3",
++ "rustix 0.38.34",
+  "wayland-client",
+  "xcursor",
+ ]
+ 
+ [[package]]
+ name = "wayland-egl"
+-version = "0.29.5"
++version = "0.32.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "402de949f81a012926d821a2d659f930694257e76dd92b6e0042ceb27be4107d"
++checksum = "18cede1c33845ccd8fcebf7f107595170abf0ad0a28d47c50b444e06019b16e8"
+ dependencies = [
+- "wayland-client",
++ "wayland-backend",
+  "wayland-sys",
+ ]
+ 
+ [[package]]
+ name = "wayland-protocols"
+-version = "0.29.5"
++version = "0.31.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
++checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+ dependencies = [
+- "bitflags 1.3.2",
++ "bitflags 2.6.0",
++ "wayland-backend",
+  "wayland-client",
+- "wayland-commons",
++ "wayland-scanner",
++]
++
++[[package]]
++name = "wayland-protocols-wlr"
++version = "0.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
++dependencies = [
++ "bitflags 2.6.0",
++ "wayland-backend",
++ "wayland-client",
++ "wayland-protocols",
+  "wayland-scanner",
+ ]
+ 
+ [[package]]
+ name = "wayland-scanner"
+-version = "0.29.5"
++version = "0.31.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53"
++checksum = "67da50b9f80159dec0ea4c11c13e24ef9e7574bd6ce24b01860a175010cea565"
+ dependencies = [
+  "proc-macro2",
++ "quick-xml 0.31.0",
+  "quote",
+- "xml-rs",
+ ]
+ 
+ [[package]]
+ name = "wayland-sys"
+-version = "0.29.5"
++version = "0.31.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
++checksum = "105b1842da6554f91526c14a2a2172897b7f745a805d62af4ce698706be79c12"
+ dependencies = [
+  "dlib",
++ "log",
+  "pkg-config",
+ ]
+ 
+@@ -7328,30 +7384,27 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus"
+-version = "3.15.2"
++version = "4.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
++checksum = "851238c133804e0aa888edf4a0229481c753544ca12a60fd1c3230c8a500fe40"
+ dependencies = [
+  "async-broadcast",
+  "async-executor",
+- "async-fs",
+- "async-io 1.13.0",
+- "async-lock 2.8.0",
+- "async-process",
++ "async-fs 2.1.2",
++ "async-io 2.3.3",
++ "async-lock 3.4.0",
++ "async-process 2.2.3",
+  "async-recursion",
+  "async-task",
+  "async-trait",
+  "blocking",
+- "byteorder",
+- "derivative",
+  "enumflags2",
+- "event-listener 2.5.3",
++ "event-listener 5.3.1",
+  "futures-core",
+  "futures-sink",
+  "futures-util",
+  "hex",
+- "nix 0.26.4",
+- "once_cell",
++ "nix 0.29.0",
+  "ordered-stream",
+  "rand",
+  "serde",
+@@ -7360,7 +7413,7 @@ dependencies = [
+  "static_assertions",
+  "tracing",
+  "uds_windows",
+- "winapi",
++ "windows-sys 0.52.0",
+  "xdg-home",
+  "zbus_macros",
+  "zbus_names",
+@@ -7369,23 +7422,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus_macros"
+-version = "3.15.2"
++version = "4.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
++checksum = "8d5a3f12c20bd473be3194af6b49d50d7bb804ef3192dc70eddedb26b85d9da7"
+ dependencies = [
+  "proc-macro-crate",
+  "proc-macro2",
+  "quote",
+- "regex",
+- "syn 1.0.109",
++ "syn 2.0.68",
+  "zvariant_utils",
+ ]
+ 
+ [[package]]
+ name = "zbus_names"
+-version = "2.6.1"
++version = "3.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
++checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+ dependencies = [
+  "serde",
+  "static_assertions",
+@@ -7452,13 +7504,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "zvariant"
+-version = "3.15.2"
++version = "4.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db"
++checksum = "1724a2b330760dc7d2a8402d841119dc869ef120b139d29862d6980e9c75bfc9"
+ dependencies = [
+- "byteorder",
++ "endi",
+  "enumflags2",
+- "libc",
+  "serde",
+  "static_assertions",
+  "zvariant_derive",
+@@ -7466,24 +7517,24 @@ dependencies = [
+ 
+ [[package]]
+ name = "zvariant_derive"
+-version = "3.15.2"
++version = "4.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9"
++checksum = "55025a7a518ad14518fb243559c058a2e5b848b015e31f1d90414f36e3317859"
+ dependencies = [
+  "proc-macro-crate",
+  "proc-macro2",
+  "quote",
+- "syn 1.0.109",
++ "syn 2.0.68",
+  "zvariant_utils",
+ ]
+ 
+ [[package]]
+ name = "zvariant_utils"
+-version = "1.0.1"
++version = "2.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
++checksum = "fc242db087efc22bd9ade7aa7809e4ba828132edc312871584a6b4391bdf8786"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 1.0.109",
++ "syn 2.0.68",
+ ]
+diff --git a/wezterm-toast-notification/Cargo.toml b/wezterm-toast-notification/Cargo.toml
+index f6172885e..c5e29e7cd 100644
+--- a/wezterm-toast-notification/Cargo.toml
++++ b/wezterm-toast-notification/Cargo.toml
+@@ -13,8 +13,8 @@ log = "0.4"
+ 
+ [target.'cfg(all(not(windows), not(target_os="macos")))'.dependencies]
+ serde = {version="1.0", features = ["derive"]}
+-zbus = "3.14"
+-zvariant = "3.15"
++zbus = "4.2"
++zvariant = "4.0"
+ async-io = "1.10"
+ futures-util = "0.3"
+ 
+diff --git a/wezterm-toast-notification/src/dbus.rs b/wezterm-toast-notification/src/dbus.rs
+index 2ae2a2afe..90404cc05 100644
+--- a/wezterm-toast-notification/src/dbus.rs
++++ b/wezterm-toast-notification/src/dbus.rs
+@@ -5,7 +5,7 @@ use crate::ToastNotification;
+ use futures_util::stream::{abortable, StreamExt};
+ use serde::{Deserialize, Serialize};
+ use std::collections::HashMap;
+-use zbus::dbus_proxy;
++use zbus::proxy;
+ use zvariant::{Type, Value};
+ 
+ #[derive(Debug, Type, Serialize, Deserialize)]
+@@ -23,7 +23,7 @@ pub struct ServerInformation {
+     pub spec_version: String,
+ }
+ 
+-#[dbus_proxy(
++#[proxy(
+     interface = "org.freedesktop.Notifications",
+     default_service = "org.freedesktop.Notifications",
+     default_path = "/org/freedesktop/Notifications"
+@@ -52,11 +52,11 @@ trait Notifications {
+         expire_timeout: i32,
+     ) -> zbus::Result<u32>;
+ 
+-    #[dbus_proxy(signal)]
+-    fn action_invoked(&self, nid: u32, action_key: String) -> Result<()>;
++    #[zbus(signal)]
++    fn action_invoked(&self, nid: u32, action_key: String) -> zbus::Result<()>;
+ 
+-    #[dbus_proxy(signal)]
+-    fn notification_closed(&self, nid: u32, reason: u32) -> Result<()>;
++    #[zbus(signal)]
++    fn notification_closed(&self, nid: u32, reason: u32) -> zbus::Result<()>;
+ }
+ 
+ /// Timeout/expiration was reached
+diff --git a/window/Cargo.toml b/window/Cargo.toml
+index 218f2a17b..ee104a9b3 100644
+--- a/window/Cargo.toml
++++ b/window/Cargo.toml
+@@ -75,15 +75,18 @@ xcb = {version="1.3", features=["render", "randr", "dri2", "xkb", "xlib_xcb", "p
+ xkbcommon = { version = "0.7.0", features = ["x11", "wayland"] }
+ mio = {version="0.8", features=["os-ext"]}
+ libc = "0.2"
+-smithay-client-toolkit = {version = "0.16.1", default-features=false, optional=true}
+-wayland-protocols = {version="0.29", optional=true}
+-wayland-client = {version="0.29", optional=true}
+-wayland-egl = {version="0.29", optional=true}
+ xcb-imdkit = { version="0.3", git="https://github.com/wez/xcb-imdkit-rs.git", rev="215ce4b08ac9c4822e541efd4f4ffb1062806051"}
+-zbus = "3.14"
+-zvariant = "3.15"
++
+ futures-util = "0.3"
+ futures-lite = "1.12"
++zbus = "4.2"
++zvariant = "4.0"
++
++smithay-client-toolkit = {version = "0.18", default-features=false, optional=true}
++wayland-protocols = {version="0.31", optional=true}
++wayland-client = {version="0.31", optional=true}
++wayland-egl = {version="0.32", optional=true}
++
+ 
+ [target.'cfg(target_os="macos")'.dependencies]
+ cocoa = "0.25"
+diff --git a/window/src/os/xdg_desktop_portal.rs b/window/src/os/xdg_desktop_portal.rs
+index 9592ece8e..0709efec5 100644
+--- a/window/src/os/xdg_desktop_portal.rs
++++ b/window/src/os/xdg_desktop_portal.rs
+@@ -9,10 +9,10 @@ use futures_util::stream::StreamExt;
+ use std::collections::HashMap;
+ use std::sync::Mutex;
+ use std::time::Instant;
+-use zbus::dbus_proxy;
++use zbus::proxy;
+ use zvariant::OwnedValue;
+ 
+-#[dbus_proxy(
++#[proxy(
+     interface = "org.freedesktop.portal.Settings",
+     default_service = "org.freedesktop.portal.Desktop",
+     default_path = "/org/freedesktop/portal/desktop"
+@@ -25,8 +25,8 @@ trait PortalSettings {
+ 
+     fn Read(&self, namespace: &str, key: &str) -> zbus::Result<OwnedValue>;
+ 
+-    #[dbus_proxy(signal)]
+-    fn SettingChanged(&self, namespace: &str, key: &str, value: OwnedValue) -> Result<()>;
++    #[zbus(signal)]
++    fn SettingChanged(&self, namespace: &str, key: &str, value: OwnedValue) -> zbus::Result<()>;
+ }
+ 
+ #[derive(PartialEq)]
+@@ -89,12 +89,12 @@ pub async fn read_setting(namespace: &str, key: &str) -> anyhow::Result<OwnedVal
+ 
+ fn value_to_appearance(value: OwnedValue) -> anyhow::Result<Appearance> {
+     Ok(match value.downcast_ref::<u32>() {
+-        Some(1) => Appearance::Dark,
+-        Some(_) => Appearance::Light,
+-        None => {
++        Ok(1) => Appearance::Dark,
++        Ok(_) => Appearance::Light,
++        Err(err) => {
+             anyhow::bail!(
+                 "Unable to resolve appearance \
+-                 using xdg-desktop-portal: expected a u32 value but got {value:#?}"
++                 using xdg-desktop-portal: {err:#?}"
+             );
+         }
+     })
+-- 
+2.45.2
+

--- a/app-utils/wezterm/autobuild/patches/0004-Update-smithay-client-toolkit-to-v0.18.patch.loongarch64
+++ b/app-utils/wezterm/autobuild/patches/0004-Update-smithay-client-toolkit-to-v0.18.patch.loongarch64
@@ -1,0 +1,58 @@
+From 502bd69ad2c4a57c5ee5355eecbfcea4a39ce091 Mon Sep 17 00:00:00 2001
+From: V <v@anomalous.eu>
+Date: Mon, 8 Apr 2024 00:00:49 +0200
+Subject: [PATCH 4/4] Update smithay-client-toolkit to v0.18
+
+Also updates:
+- wayland-{client,protocols} to v0.31
+- wayland-egl to v0.32
+---
+ Cargo.lock        | 6 +++---
+ window/Cargo.toml | 4 ++--
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index b34b641d2..1d06384de 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -661,9 +661,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.103"
++version = "1.0.104"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2755ff20a1d93490d26ba33a6f092a38a508398a5320df5d4b3014fcccce9410"
++checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
+ dependencies = [
+  "jobserver",
+  "libc",
+@@ -6896,7 +6896,7 @@ dependencies = [
+  "downcast-rs",
+  "euclid",
+  "filedescriptor",
+- "futures-lite 1.13.0",
++ "futures-lite 2.3.0",
+  "futures-util",
+  "gl_generator",
+  "glium",
+diff --git a/window/Cargo.toml b/window/Cargo.toml
+index ee104a9b3..2c15402e2 100644
+--- a/window/Cargo.toml
++++ b/window/Cargo.toml
+@@ -77,10 +77,10 @@ mio = {version="0.8", features=["os-ext"]}
+ libc = "0.2"
+ xcb-imdkit = { version="0.3", git="https://github.com/wez/xcb-imdkit-rs.git", rev="215ce4b08ac9c4822e541efd4f4ffb1062806051"}
+ 
+-futures-util = "0.3"
+-futures-lite = "1.12"
+ zbus = "4.2"
+ zvariant = "4.0"
++futures-util = "0.3.30"
++futures-lite = "2.3.0"
+ 
+ smithay-client-toolkit = {version = "0.18", default-features=false, optional=true}
+ wayland-protocols = {version="0.31", optional=true}
+-- 
+2.45.2
+


### PR DESCRIPTION
Topic Description
-----------------

- wezterm: allow more architecture build

Package(s) Affected
-------------------

- wezterm: 20240203+110809+5046fc22-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit wezterm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
