### PR TITLE
swayfx: add patch to support input method popup menu

### DIFF
--- a/desktop-wm/swayfx/autobuild/patches/0001-text_input-Implement-input-method-popups.patch
+++ b/desktop-wm/swayfx/autobuild/patches/0001-text_input-Implement-input-method-popups.patch
@@ -1,0 +1,753 @@
+From 7a426fb7535fdbfdaad8f4d7a9dc814415ab8690 Mon Sep 17 00:00:00 2001
+From: ShootingStarDragons <ShootingStarDragons@protonmail.com>
+Date: Wed, 3 May 2023 14:21:27 +0800
+Subject: [PATCH] text_input: Implement input-method popups
+
+origin one is the pr by tadeokondrak in pr 5890
+
+Co-authored-by: tadeokondrak <me@tadeo.ca>
+(cherry picked from commit dc9912bef22412b463f9d004ae7ea84b97a2a82b)
+
+chore: fractal scale handle
+
+(cherry picked from commit 4a3a624314e38859cab72df1c2ff5599b69a3190)
+
+chore: left_pt on method popup
+
+this keep cusor the same action with qt and gtk im module
+
+(cherry picked from commit c12115897a71bf50fc858d8785bf1405bbde0fc7)
+---
+ include/sway/input/text_input.h |  25 +++
+ include/sway/output.h           |   4 +
+ sway/desktop/output.c           |  52 +++++
+ sway/desktop/render.c           |  15 +-
+ sway/input/cursor.c             |  29 +++
+ sway/input/text_input.c         | 354 +++++++++++++++++++++++++++++++-
+ sway/tree/container.c           |   3 +
+ sway/tree/view.c                |   3 +
+ 8 files changed, 477 insertions(+), 8 deletions(-)
+
+diff --git a/include/sway/input/text_input.h b/include/sway/input/text_input.h
+index 214e61d1..f583af7a 100644
+--- a/include/sway/input/text_input.h
++++ b/include/sway/input/text_input.h
+@@ -4,6 +4,7 @@
+ #include <wlr/types/wlr_text_input_v3.h>
+ #include <wlr/types/wlr_input_method_v2.h>
+ #include <wlr/types/wlr_compositor.h>
++#include <wlr/types/wlr_fractional_scale_v1.h>
+ 
+ /**
+  * The relay structure manages the relationship between text-input and
+@@ -21,18 +22,37 @@ struct sway_input_method_relay {
+ 	struct sway_seat *seat;
+ 
+ 	struct wl_list text_inputs; // sway_text_input::link
++	struct wl_list input_popups; // sway_input_popup::link
+ 	struct wlr_input_method_v2 *input_method; // doesn't have to be present
+ 
+ 	struct wl_listener text_input_new;
+ 
+ 	struct wl_listener input_method_new;
+ 	struct wl_listener input_method_commit;
++	struct wl_listener input_method_new_popup_surface;
+ 	struct wl_listener input_method_grab_keyboard;
+ 	struct wl_listener input_method_destroy;
+ 
+ 	struct wl_listener input_method_keyboard_grab_destroy;
+ };
+ 
++struct sway_input_popup {
++	struct sway_input_method_relay *relay;
++	struct wlr_input_popup_surface_v2 *popup_surface;
++
++	int x, y;
++	bool visible;
++
++	struct wl_list link;
++
++	struct wl_listener popup_map;
++	struct wl_listener popup_unmap;
++	struct wl_listener popup_destroy;
++	struct wl_listener popup_surface_commit;
++
++	struct wl_listener focused_surface_unmap;
++};
++
+ struct sway_text_input {
+ 	struct sway_input_method_relay *relay;
+ 
+@@ -65,4 +85,9 @@ struct sway_text_input *sway_text_input_create(
+ 	struct sway_input_method_relay *relay,
+ 	struct wlr_text_input_v3 *text_input);
+ 
++bool sway_input_popup_get_position(
++        struct sway_input_popup *popup, int *lx, int *ly);
++
++void sway_input_popup_damage(struct sway_input_popup *popup);
++
+ #endif
+diff --git a/include/sway/output.h b/include/sway/output.h
+index a60ddec8..0e9e27c9 100644
+--- a/include/sway/output.h
++++ b/include/sway/output.h
+@@ -178,6 +178,10 @@ void output_unmanaged_for_each_surface(struct sway_output *output,
+ 	void *user_data);
+ #endif
+ 
++void output_input_popups_for_each_surface(struct sway_output *output,
++	struct wl_list *input_popups, sway_surface_iterator_func_t iterator,
++	void *user_data);
++
+ void output_drag_icons_for_each_surface(struct sway_output *output,
+ 	struct wl_list *drag_icons, sway_surface_iterator_func_t iterator,
+ 	void *user_data);
+diff --git a/sway/desktop/output.c b/sway/desktop/output.c
+index 2ccb28f2..3e6b1a2d 100644
+--- a/sway/desktop/output.c
++++ b/sway/desktop/output.c
+@@ -18,6 +18,7 @@
+ #include <wlr/types/wlr_output.h>
+ #include <wlr/types/wlr_presentation_time.h>
+ #include <wlr/types/wlr_compositor.h>
++#include <wlr/types/wlr_fractional_scale_v1.h>
+ #include <wlr/util/region.h>
+ #include "config.h"
+ #include "log.h"
+@@ -27,6 +28,7 @@
+ #include "sway/input/input-manager.h"
+ #include "sway/input/seat.h"
+ #include "sway/ipc-server.h"
++#include "sway/input/text_input.h"
+ #include "sway/layers.h"
+ #include "sway/output.h"
+ #include "sway/server.h"
+@@ -270,6 +272,31 @@ void output_unmanaged_for_each_surface(struct sway_output *output,
+ }
+ #endif
+ 
++void output_input_popups_for_each_surface(struct sway_output *output,
++		struct wl_list *input_popups, sway_surface_iterator_func_t iterator,
++		void *user_data) {
++	struct sway_input_popup *popup;
++	wl_list_for_each(popup, input_popups, link) {
++		int lx, ly;
++		if (!sway_input_popup_get_position(popup, &lx, &ly)) {
++			continue;
++		}
++		if (!popup->popup_surface->surface->mapped || !popup->visible) {
++			continue;
++		}
++
++		// damage the popup if surface is updated
++		sway_input_popup_damage(popup);
++
++		double ox = lx - output->lx;
++		double oy = ly - output->ly;
++
++		output_surface_for_each_surface(output,
++			popup->popup_surface->surface, ox, oy,
++			iterator, user_data);
++	}
++}
++
+ void output_drag_icons_for_each_surface(struct sway_output *output,
+ 		struct wl_list *drag_icons, sway_surface_iterator_func_t iterator,
+ 		void *user_data) {
+@@ -380,6 +407,9 @@ overlay:
+ 	output_layer_for_each_surface(output,
+ 		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],
+ 		iterator, user_data);
++	output_input_popups_for_each_surface(
++		output, &input_manager_current_seat()->im_relay.input_popups,
++		iterator, user_data);
+ 	output_drag_icons_for_each_surface(output, &root->drag_icons,
+ 		iterator, user_data);
+ }
+@@ -976,6 +1006,27 @@ static void update_output_scale_iterator(struct sway_output *output,
+ 	surface_update_outputs(surface);
+ }
+ 
++static void update_im_scale(struct sway_output *output) {
++	struct sway_seat* im_seat = input_manager_current_seat();
++	if (im_seat == NULL) {
++		return;
++	}
++	struct sway_input_method_relay* relay = &im_seat->im_relay;
++	struct sway_input_popup *popup;
++	wl_list_for_each(popup, &relay->input_popups, link) {
++		struct wl_list current_outputs = popup->popup_surface->surface->current_outputs;
++		struct wlr_surface_output *current_output;
++		wl_list_for_each(current_output, &current_outputs, link) {
++			if (current_output->output == output->wlr_output) {
++				double scale = current_output->output->scale;
++				wlr_fractional_scale_v1_notify_scale(popup->popup_surface->surface, scale);
++				wlr_surface_set_preferred_buffer_scale(popup->popup_surface->surface, ceil(scale));
++				break;
++			}
++		}
++	}
++}
++
+ static void handle_commit(struct wl_listener *listener, void *data) {
+ 	struct sway_output *output = wl_container_of(listener, output, commit);
+ 	struct wlr_output_event_commit *event = data;
+@@ -987,6 +1038,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
+ 	if (event->state->committed & WLR_OUTPUT_STATE_SCALE) {
+ 		output_for_each_container(output, update_textures, NULL);
+ 		output_for_each_surface(output, update_output_scale_iterator, NULL);
++		update_im_scale(output);
+ 	}
+ 
+ 	if (event->state->committed & (
+diff --git a/sway/desktop/render.c b/sway/desktop/render.c
+index 30f1c541..f52c6cea 100644
+--- a/sway/desktop/render.c
++++ b/sway/desktop/render.c
+@@ -447,6 +447,15 @@ static void render_unmanaged(struct fx_render_context *ctx, struct wl_list *unma
+ }
+ #endif
+ 
++static void render_input_popups(struct fx_render_context *ctx, struct wl_list *input_popups) {
++	struct render_data data = {
++		.deco_data = get_undecorated_decoration_data(),
++		.ctx = ctx,
++	};
++	output_input_popups_for_each_surface(ctx->output, input_popups,
++		render_surface_iterator, &data);
++}
++
+ static void render_drag_icons(struct fx_render_context *ctx, struct wl_list *drag_icons) {
+ 	struct render_data data = {
+ 		.deco_data = get_undecorated_decoration_data(),
+@@ -1662,6 +1671,9 @@ void output_render(struct fx_render_context *ctx) {
+ 		goto renderer_end;
+ 	}
+ 
++	struct sway_seat *seat = input_manager_current_seat();
++	struct sway_container *focus = seat_get_focused_container(seat);
++
+ 	if (output_has_opaque_overlay_layer_surface(output)) {
+ 		goto render_overlay;
+ 	}
+@@ -1797,8 +1809,6 @@ void output_render(struct fx_render_context *ctx) {
+ 
+ 	render_seatops(ctx);
+ 
+-	struct sway_seat *seat = input_manager_current_seat();
+-	struct sway_container *focus = seat_get_focused_container(seat);
+ 	if (focus && focus->view) {
+ 		struct decoration_data deco_data = {
+ 			.alpha = focus->alpha,
+@@ -1821,6 +1831,7 @@ render_overlay:
+ 		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
+ 	render_layer_popups(ctx,
+ 		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
++	render_input_popups(ctx, &seat->im_relay.input_popups);
+ 	render_drag_icons(ctx, &root->drag_icons);
+ 
+ renderer_end:
+diff --git a/sway/input/cursor.c b/sway/input/cursor.c
+index 36aab93e..fa9d5b33 100644
+--- a/sway/input/cursor.c
++++ b/sway/input/cursor.c
+@@ -37,6 +37,28 @@ static uint32_t get_current_time_msec(void) {
+ 	return now.tv_sec * 1000 + now.tv_nsec / 1000000;
+ }
+ 
++static struct wlr_surface *input_popup_surface_at(struct sway_output *output,
++		struct sway_input_method_relay *relay, double ox, double oy, double *sx, double *sy) {
++	struct sway_input_popup *popup;
++	wl_list_for_each(popup, &relay->input_popups, link) {
++		int lx, ly;
++		if (!sway_input_popup_get_position(popup, &lx, &ly)) {
++			continue;
++		}
++		if (!popup->visible) {
++			continue;
++		}
++		double _sx = ox - lx;
++		double _sy = oy - ly;
++		struct wlr_surface *sub = wlr_surface_surface_at(
++			popup->popup_surface->surface, _sx, _sy, sx, sy);
++		if (sub) {
++			return sub;
++		}
++	}
++	return NULL;
++}
++
+ static struct wlr_surface *layer_surface_at(struct sway_output *output,
+ 		struct wl_list *layer, double ox, double oy, double *sx, double *sy) {
+ 	struct sway_layer_surface *sway_layer;
+@@ -120,6 +142,13 @@ struct sway_node *node_at_coords(
+ 		return NULL;
+ 	}
+ 
++	if ((*surface = input_popup_surface_at(output,
++			&seat->im_relay, ox, oy, sx, sy))) {
++		struct sway_cursor* cursor = seat->cursor;
++		// set cursot to left_ptr
++		cursor_set_image(cursor, "left_ptr", NULL);
++		return NULL;
++	}
+ 	// check for unmanaged views
+ #if HAVE_XWAYLAND
+ 	struct wl_list *unmanaged = &root->xwayland_unmanaged;
+diff --git a/sway/input/text_input.c b/sway/input/text_input.c
+index 58911c2d..fec11e77 100644
+--- a/sway/input/text_input.c
++++ b/sway/input/text_input.c
+@@ -1,8 +1,14 @@
+ #include <assert.h>
++#include <stdio.h>
+ #include <stdlib.h>
+ #include "log.h"
+ #include "sway/input/seat.h"
+ #include "sway/input/text_input.h"
++#include "sway/tree/view.h"
++#include "sway/tree/container.h"
++#include "sway/desktop.h"
++#include "sway/output.h"
++#include "sway/layers.h"
+ 
+ static struct sway_text_input *relay_get_focusable_text_input(
+ 		struct sway_input_method_relay *relay) {
+@@ -26,6 +32,333 @@ static struct sway_text_input *relay_get_focused_text_input(
+ 	return NULL;
+ }
+ 
++// damage the popup
++void sway_input_popup_damage(struct sway_input_popup *popup) {
++	if (!popup->visible) {
++		return;
++	}
++
++	struct sway_text_input *text_input =
++		relay_get_focused_text_input(popup->relay);
++	if (text_input == NULL || text_input->input->focused_surface == NULL) {
++		return;
++	}
++
++	struct wlr_surface *focused_surface = text_input->input->focused_surface;
++	struct wlr_layer_surface_v1 *layer_surface =
++		wlr_layer_surface_v1_try_from_wlr_surface(focused_surface);
++	if (layer_surface != NULL) {
++		struct sway_layer_surface *layer =
++			layer_from_wlr_layer_surface_v1(layer_surface);
++		output_damage_surface(layer->layer_surface->output->data,
++			layer->geo.x + popup->x, layer->geo.y + popup->y,
++			popup->popup_surface->surface, true);
++		return;
++	}
++
++	struct sway_view *view = view_from_wlr_surface(
++		text_input->input->focused_surface);
++	if (view->container == NULL) {
++		sway_log(SWAY_INFO, "Tried to damage popup, but view is gone");
++		return;
++	}
++	desktop_damage_surface(popup->popup_surface->surface,
++		view->container->surface_x - view->geometry.x + popup->x,
++		view->container->surface_y - view->geometry.y + popup->y, true);
++}
++
++static void input_popup_update(struct sway_input_popup *popup) {
++	sway_input_popup_damage(popup);
++
++	struct sway_text_input *text_input =
++		relay_get_focused_text_input(popup->relay);
++
++	if (text_input == NULL || text_input->input->focused_surface == NULL) {
++		return;
++	}
++
++	if (!popup->popup_surface->surface->mapped) {
++		return;
++	}
++
++	bool cursor_rect = text_input->input->current.features
++		& WLR_TEXT_INPUT_V3_FEATURE_CURSOR_RECTANGLE;
++	struct wlr_surface *focused_surface = text_input->input->focused_surface;
++	struct wlr_box cursor = text_input->input->current.cursor_rectangle;
++
++	struct wlr_output *output;
++	struct wlr_box output_box;
++	struct wlr_box parent;
++	struct wlr_layer_surface_v1 *layer_surface =
++		wlr_layer_surface_v1_try_from_wlr_surface(focused_surface);
++	if (layer_surface != NULL) {
++		struct sway_layer_surface *layer =
++			layer_from_wlr_layer_surface_v1(layer_surface);
++		output = layer->layer_surface->output;
++		wlr_output_layout_get_box(root->output_layout, output, &output_box);
++		parent = layer->geo;
++		parent.x += output_box.x;
++		parent.y += output_box.y;
++	} else {
++		struct sway_view *view = view_from_wlr_surface(focused_surface);
++		output = wlr_output_layout_output_at(root->output_layout,
++			view->container->surface_x + view->geometry.x,
++			view->container->surface_y + view->geometry.y);
++		wlr_output_layout_get_box(root->output_layout, output, &output_box);
++		parent.x = view->container->surface_x + view->geometry.x;
++		parent.y = view->container->surface_y + view->geometry.y;
++		parent.width = view->geometry.width;
++		parent.height = view->geometry.height;
++	}
++
++	if (!cursor_rect) {
++		cursor.x = 0;
++		cursor.y = 0;
++		cursor.width = parent.width;
++		cursor.height = parent.height;
++	}
++
++	int popup_width = popup->popup_surface->surface->current.width;
++	int popup_height = popup->popup_surface->surface->current.height;
++	int x1 = parent.x + cursor.x;
++	int x2 = parent.x + cursor.x + cursor.width;
++	int y1 = parent.y + cursor.y;
++	int y2 = parent.y + cursor.y + cursor.height;
++	int x = x1;
++	int y = y2;
++
++	int available_right = output_box.x + output_box.width - x1;
++	int available_left = x2 - output_box.x;
++	if (available_right < popup_width && available_left > available_right) {
++		x = x2 - popup_width;
++	}
++
++	int available_down = output_box.y + output_box.height - y2;
++	int available_up = y1 - output_box.y;
++	if (available_down < popup_height && available_up > available_down) {
++		y = y1 - popup_height;
++	}
++
++	popup->x = x - parent.x;
++	popup->y = y - parent.y;
++
++	// Hide popup if cursor position is completely out of bounds
++	bool x1_in_bounds = (cursor.x >= 0 && cursor.x < parent.width);
++	bool y1_in_bounds = (cursor.y >= 0 && cursor.y < parent.height);
++	bool x2_in_bounds = (cursor.x + cursor.width >= 0
++		&& cursor.x + cursor.width < parent.width);
++	bool y2_in_bounds = (cursor.y + cursor.height >= 0
++		&& cursor.y + cursor.height < parent.height);
++	popup->visible =
++		(x1_in_bounds && y1_in_bounds) || (x2_in_bounds && y2_in_bounds);
++
++	if (cursor_rect) {
++		struct wlr_box box = {
++			.x = x1 - x,
++			.y = y1 - y,
++			.width = cursor.width,
++			.height = cursor.height,
++		};
++		wlr_input_popup_surface_v2_send_text_input_rectangle(
++			popup->popup_surface, &box);
++	}
++
++	sway_input_popup_damage(popup);
++}
++
++static void surface_send_enter_iterator(struct wlr_surface *surface,
++		int x, int y, void *data) {
++	struct wlr_output *wlr_output = data;
++	float scale = wlr_output->scale;
++	wlr_surface_send_enter(surface, wlr_output);
++
++	wlr_fractional_scale_v1_notify_scale(surface, scale);
++	wlr_surface_set_preferred_buffer_scale(surface, ceil(scale));
++}
++
++static void surface_send_leave_iterator(struct wlr_surface *surface,
++		int x, int y, void *data) {
++	struct wlr_output *wlr_output = data;
++	wlr_surface_send_leave(surface, wlr_output);
++}
++
++static void input_popup_send_outputs(struct sway_input_popup *popup,
++		wlr_surface_iterator_func_t iterator) {
++	struct sway_text_input *text_input =
++		relay_get_focused_text_input(popup->relay);
++	if (text_input == NULL || text_input->input->focused_surface == NULL) {
++		return;
++	}
++	struct wlr_surface *focused_surface = text_input->input->focused_surface;
++	struct wlr_layer_surface_v1 *layer_surface =
++		wlr_layer_surface_v1_try_from_wlr_surface(focused_surface);
++	if (layer_surface != NULL) {
++		struct sway_layer_surface *layer =
++			layer_from_wlr_layer_surface_v1(layer_surface);
++		wlr_surface_for_each_surface(popup->popup_surface->surface,
++			iterator, layer->layer_surface->output);
++		return;
++	}
++	struct sway_view *view = view_from_wlr_surface(focused_surface);
++	for (int i = 0; i < view->container->outputs->length; i++) {
++		struct sway_output *output = view->container->outputs->items[i];
++		wlr_surface_for_each_surface(popup->popup_surface->surface,
++			iterator, output->wlr_output);
++	}
++}
++
++static void handle_im_popup_map(struct wl_listener *listener, void *data) {
++	struct sway_input_popup *popup =
++		wl_container_of(listener, popup, popup_map);
++	input_popup_send_outputs(popup, surface_send_enter_iterator);
++	input_popup_update(popup);
++}
++
++static void handle_im_popup_unmap(struct wl_listener *listener, void *data) {
++	struct sway_input_popup *popup =
++		wl_container_of(listener, popup, popup_unmap);
++	input_popup_send_outputs(popup, surface_send_leave_iterator);
++	input_popup_update(popup);
++}
++
++static void handle_im_popup_destroy(struct wl_listener *listener, void *data) {
++	struct sway_input_popup *popup =
++		wl_container_of(listener, popup, popup_destroy);
++	wl_list_remove(&popup->focused_surface_unmap.link);
++	wl_list_remove(&popup->popup_surface_commit.link);
++	wl_list_remove(&popup->popup_destroy.link);
++	wl_list_remove(&popup->popup_unmap.link);
++	wl_list_remove(&popup->popup_map.link);
++	wl_list_remove(&popup->link);
++	free(popup);
++}
++
++static void handle_im_popup_surface_commit(struct wl_listener *listener,
++		void *data) {
++	struct sway_input_popup *popup =
++		wl_container_of(listener, popup, popup_surface_commit);
++	input_popup_update(popup);
++}
++
++static void handle_im_focused_surface_unmap(
++		struct wl_listener *listener, void *data) {
++	struct sway_input_popup *popup =
++		wl_container_of(listener, popup, focused_surface_unmap);
++	input_popup_update(popup);
++}
++
++static void input_popup_set_focus(struct sway_input_popup *popup,
++		struct wlr_surface *surface) {
++	wl_list_remove(&popup->focused_surface_unmap.link);
++
++	if (surface == NULL) {
++		wl_list_init(&popup->focused_surface_unmap.link);
++		input_popup_update(popup);
++		return;
++	}
++	struct wlr_layer_surface_v1 *layer_surface =
++		wlr_layer_surface_v1_try_from_wlr_surface(surface);
++	if (layer_surface != NULL) {
++		struct sway_layer_surface *layer =
++			layer_from_wlr_layer_surface_v1(layer_surface);
++		wl_signal_add(
++			&layer->layer_surface->surface->events.unmap, &popup->focused_surface_unmap);
++		input_popup_update(popup);
++		return;
++	}
++
++	struct sway_view *view = view_from_wlr_surface(surface);
++	wl_signal_add(&view->events.unmap, &popup->focused_surface_unmap);
++
++	// Since the focus has changed, the popup may have to adjust
++}
++
++static void handle_im_new_popup_surface(struct wl_listener *listener,
++		void *data) {
++	struct sway_input_method_relay *relay = wl_container_of(listener, relay,
++		input_method_new_popup_surface);
++	struct sway_input_popup *popup = calloc(1, sizeof(*popup));
++	popup->relay = relay;
++	popup->popup_surface = data;
++	popup->popup_surface->data = popup;
++
++	wl_signal_add(&popup->popup_surface->surface->events.map, &popup->popup_map);
++	popup->popup_map.notify = handle_im_popup_map;
++	wl_signal_add(
++		&popup->popup_surface->surface->events.unmap, &popup->popup_unmap);
++	popup->popup_unmap.notify = handle_im_popup_unmap;
++	wl_signal_add(
++		&popup->popup_surface->events.destroy, &popup->popup_destroy);
++	popup->popup_destroy.notify = handle_im_popup_destroy;
++	wl_signal_add(&popup->popup_surface->surface->events.commit,
++		&popup->popup_surface_commit);
++	popup->popup_surface_commit.notify = handle_im_popup_surface_commit;
++	wl_list_init(&popup->focused_surface_unmap.link);
++	popup->focused_surface_unmap.notify = handle_im_focused_surface_unmap;
++
++	struct sway_text_input *text_input = relay_get_focused_text_input(relay);
++	if (text_input != NULL) {
++		input_popup_set_focus(popup, text_input->input->focused_surface);
++	} else {
++		input_popup_set_focus(popup, NULL);
++	}
++
++	wl_list_insert(&relay->input_popups, &popup->link);
++}
++
++bool sway_input_popup_get_position(
++			struct sway_input_popup *popup, int *lx, int *ly) {
++	struct sway_text_input *text_input =
++		relay_get_focused_text_input(popup->relay);
++	if (text_input == NULL || text_input->input->focused_surface == NULL) {
++		*lx = 0;
++		*ly = 0;
++		return false;
++	}
++
++	struct wlr_surface *focused_surface = text_input->input->focused_surface;
++	struct wlr_layer_surface_v1 *layer_surface =
++		wlr_layer_surface_v1_try_from_wlr_surface(focused_surface);
++	if (layer_surface != NULL) {
++		struct sway_layer_surface *layer =
++			layer_from_wlr_layer_surface_v1(layer_surface);
++		*lx = layer->geo.x + popup->x;
++		*ly = layer->geo.y + popup->y;
++		return true;
++	}
++
++
++	struct sway_view *view = view_from_wlr_surface(
++		text_input->input->focused_surface);
++	if (view->container == NULL || view == NULL) {
++		sway_log(SWAY_INFO, "Tried to find popup, but view is gone");
++		return false;
++	}
++	*lx = view->container->surface_x - view->geometry.x + popup->x;
++	*ly = view->container->surface_y - view->geometry.y + popup->y;
++	return true;
++}
++
++static void text_input_send_enter(struct sway_text_input *text_input,
++		struct wlr_surface *surface) {
++	wlr_text_input_v3_send_enter(text_input->input, surface);
++	struct sway_input_popup *popup;
++	wl_list_for_each(popup, &text_input->relay->input_popups, link) {
++		input_popup_set_focus(popup, surface);
++	}
++}
++
++static void text_input_send_leave(struct sway_text_input *text_input,
++		struct wlr_surface *surface) {
++	wlr_text_input_v3_send_leave(text_input->input);
++	if (text_input->input->focused_surface == surface) {
++		struct sway_input_popup *popup;
++		wl_list_for_each(popup, &text_input->relay->input_popups, link) {
++			input_popup_set_focus(popup, NULL);
++		}
++	}
++}
++
+ static void handle_im_commit(struct wl_listener *listener, void *data) {
+ 	struct sway_input_method_relay *relay = wl_container_of(listener, relay,
+ 		input_method_commit);
+@@ -109,7 +442,7 @@ static void handle_im_destroy(struct wl_listener *listener, void *data) {
+ 		// the input method returns
+ 		text_input_set_pending_focused_surface(text_input,
+ 			text_input->input->focused_surface);
+-		wlr_text_input_v3_send_leave(text_input->input);
++		text_input_send_leave(text_input, text_input->input->focused_surface);
+ 	}
+ }
+ 
+@@ -133,8 +466,13 @@ static void relay_send_im_state(struct sway_input_method_relay *relay,
+ 			input->current.content_type.hint,
+ 			input->current.content_type.purpose);
+ 	}
++	struct sway_input_popup *popup;
++	wl_list_for_each(popup, &relay->input_popups, link) {
++		// send_text_input_rectangle is called in this function
++		input_popup_update(popup);
++	}
+ 	wlr_input_method_v2_send_done(input_method);
+-	// TODO: pass intent, display popup size
++	// TODO: pass intent
+ }
+ 
+ static void handle_text_input_enable(struct wl_listener *listener, void *data) {
+@@ -274,6 +612,9 @@ static void relay_handle_input_method(struct wl_listener *listener,
+ 	wl_signal_add(&relay->input_method->events.commit,
+ 		&relay->input_method_commit);
+ 	relay->input_method_commit.notify = handle_im_commit;
++	wl_signal_add(&relay->input_method->events.new_popup_surface,
++		&relay->input_method_new_popup_surface);
++	relay->input_method_new_popup_surface.notify = handle_im_new_popup_surface;
+ 	wl_signal_add(&relay->input_method->events.grab_keyboard,
+ 		&relay->input_method_grab_keyboard);
+ 	relay->input_method_grab_keyboard.notify = handle_im_grab_keyboard;
+@@ -283,8 +624,7 @@ static void relay_handle_input_method(struct wl_listener *listener,
+ 
+ 	struct sway_text_input *text_input = relay_get_focusable_text_input(relay);
+ 	if (text_input) {
+-		wlr_text_input_v3_send_enter(text_input->input,
+-			text_input->pending_focused_surface);
++		text_input_send_enter(text_input, text_input->pending_focused_surface);
+ 		text_input_set_pending_focused_surface(text_input, NULL);
+ 	}
+ }
+@@ -293,6 +633,7 @@ void sway_input_method_relay_init(struct sway_seat *seat,
+ 		struct sway_input_method_relay *relay) {
+ 	relay->seat = seat;
+ 	wl_list_init(&relay->text_inputs);
++	wl_list_init(&relay->input_popups);
+ 
+ 	relay->text_input_new.notify = relay_handle_text_input;
+ 	wl_signal_add(&server.text_input->events.text_input,
+@@ -321,8 +662,9 @@ void sway_input_method_relay_set_focus(struct sway_input_method_relay *relay,
+ 		} else if (text_input->input->focused_surface) {
+ 			assert(text_input->pending_focused_surface == NULL);
+ 			if (surface != text_input->input->focused_surface) {
++				text_input_send_leave(
++					text_input, text_input->input->focused_surface);
+ 				relay_disable_text_input(relay, text_input);
+-				wlr_text_input_v3_send_leave(text_input->input);
+ 			} else {
+ 				sway_log(SWAY_DEBUG, "IM relay set_focus already focused");
+ 				continue;
+@@ -333,7 +675,7 @@ void sway_input_method_relay_set_focus(struct sway_input_method_relay *relay,
+ 				&& wl_resource_get_client(text_input->input->resource)
+ 				== wl_resource_get_client(surface->resource)) {
+ 			if (relay->input_method) {
+-				wlr_text_input_v3_send_enter(text_input->input, surface);
++				text_input_send_enter(text_input, surface);
+ 			} else {
+ 				text_input_set_pending_focused_surface(text_input, surface);
+ 			}
+diff --git a/sway/tree/container.c b/sway/tree/container.c
+index 9b90b774..2de58a26 100644
+--- a/sway/tree/container.c
++++ b/sway/tree/container.c
+@@ -397,6 +397,9 @@ static bool surface_is_popup(struct wlr_surface *surface) {
+ 		}
+ 		surface = subsurface->parent;
+ 	}
++	if (wlr_input_popup_surface_v2_try_from_wlr_surface(surface) != NULL) {
++		return true;
++	}
+ 	struct wlr_xdg_surface *xdg_surface =
+ 		wlr_xdg_surface_try_from_wlr_surface(surface);
+ 	return xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP && xdg_surface->popup != NULL;
+diff --git a/sway/tree/view.c b/sway/tree/view.c
+index bd2268fd..4604f480 100644
+--- a/sway/tree/view.c
++++ b/sway/tree/view.c
+@@ -1248,6 +1248,9 @@ struct sway_view *view_from_wlr_surface(struct wlr_surface *wlr_surface) {
+ 	if (wlr_layer_surface_v1_try_from_wlr_surface(wlr_surface) != NULL) {
+ 		return NULL;
+ 	}
++	if (wlr_input_popup_surface_v2_try_from_wlr_surface(wlr_surface) != NULL) {
++		return NULL;
++	}
+ 
+ 	const char *role = wlr_surface->role ? wlr_surface->role->name : NULL;
+ 	sway_log(SWAY_DEBUG, "Surface of unknown type (role %s): %p",
+-- 
+2.45.2
+

--- a/desktop-wm/swayfx/spec
+++ b/desktop-wm/swayfx/spec
@@ -1,4 +1,5 @@
 VER=0.4
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/WillPower3309/swayfx"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371635"


### PR DESCRIPTION
Topic Description
-----------------

- swayfx: add patch to support input method popup menu
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- swayfx: 0.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit swayfx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
