### PR TITLE
openssh: update to 9.8p1

### DIFF
--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -1,4 +1,4 @@
-VER=9.7p1
+VER=9.8p1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
-CHKSUMS="sha256::490426f766d82a2763fcacd8d83ea3d70798750c7bd2aff2e57dc5660f773ffd"
+CHKSUMS="sha256::dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3"
 CHKUPDATE="anitya::id=2565"


### PR DESCRIPTION
Topic Description
-----------------

- openssh: update to 9.8p1

Package(s) Affected
-------------------

- openssh: 9.8p1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
