### PR TITLE
openssh: update to 9.8p1-1

### DIFF
--- a/app-network/openssh/autobuild/overrides/usr/lib/systemd/system/sshd.service
+++ b/app-network/openssh/autobuild/overrides/usr/lib/systemd/system/sshd.service
@@ -1,18 +1,18 @@
 [Unit]
 Description=OpenSSH Daemon
 Wants=sshdgenkeys.service
-After=sshdgenkeys.service
-After=network.target
+After=sshdgenkeys.service network.target
 
 [Service]
+Type=notify
+ExecStartPre=/usr/bin/sshd -t
 ExecStart=/usr/bin/sshd -D
+ExecStartPre=/usr/bin/sshd -t
 ExecReload=/usr/bin/kill -HUP $MAINPID
 KillMode=process
-Restart=always
+Restart=on-failure
+RestartPreventExitStatus=255
 
 [Install]
 WantedBy=multi-user.target
-
-# This service file runs an SSH daemon that forks for each incoming connection.
-# If you prefer to spawn on-demand daemons, use sshd.socket and sshd@.service.
-
+Alias=ssh.service

--- a/app-network/openssh/autobuild/overrides/usr/lib/systemd/system/sshd.socket
+++ b/app-network/openssh/autobuild/overrides/usr/lib/systemd/system/sshd.socket
@@ -1,10 +1,11 @@
 [Unit]
-Conflicts=sshd.service
+Description=OpenSSH Daemon Server Socket
+Before=sockets.target
 Wants=sshdgenkeys.service
 
 [Socket]
 ListenStream=22
-Accept=yes
+Accept=no
 
 [Install]
 WantedBy=sockets.target

--- a/app-network/openssh/autobuild/overrides/usr/lib/systemd/system/sshd@.service
+++ b/app-network/openssh/autobuild/overrides/usr/lib/systemd/system/sshd@.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=OpenSSH Per-Connection Daemon
-After=sshdgenkeys.service
-
-[Service]
-ExecStart=-/usr/bin/sshd -i
-StandardInput=socket
-StandardError=syslog
-

--- a/app-network/openssh/autobuild/postinst
+++ b/app-network/openssh/autobuild/postinst
@@ -39,3 +39,14 @@ please checkout the main AOSA-2017-0034 article:
 https://aosc.io/news/5986-aosa-2017-0034-openssh-in-tarballs-shipped-identical-host-keys
 \033[0m"
 fi
+
+echo -e "\033[1;33mChecking whether systemd units need to be reload...\033[0m" 
+if [[ $(systemctl show sshd --property=NeedDaemonReload | cut -d= -f2) == "yes" ]]; then
+    echo -e "\033[1;33mReloading systemd units..."
+    systemctl daemon-reload
+    echo -e "\033[1;33mRestarting sshd service..."
+    systemctl restart sshd
+else
+    echo -e "\033[0;32mNothing can be reloaded.\033[0m"
+fi
+

--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -1,4 +1,5 @@
 VER=9.8p1
+REL=1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
 CHKSUMS="sha256::dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3"
 CHKUPDATE="anitya::id=2565"


### PR DESCRIPTION
Topic Description
-----------------

- openssh: improve systemd services unit and bump
    This commit improves systemd services and postinst in the package.
    Includes these changes:
    - add reload and daemon-reload detection in postinst script
    - remove sshd@.service, don't allow create service per connection
    when using sshd.socket
    - fix sshd.socket unit requirements
    - make sshd.service running in Type=notify, adopted openssh's
    automatically systemd reload notification
    - add alias ssh.service

Package(s) Affected
-------------------

- openssh: 9.8p1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
