### PR TITLE
httpd: update to 2.4.60

### DIFF
--- a/app-web/httpd/spec
+++ b/app-web/httpd/spec
@@ -1,5 +1,4 @@
-VER=2.4.58
-REL=1
+VER=2.4.60
 SRCS="tbl::http://archive.apache.org/dist/httpd/httpd-$VER.tar.bz2"
-CHKSUMS="sha256::fa16d72a078210a54c47dd5bef2f8b9b8a01d94909a51453956b3ec6442ea4c5"
+CHKSUMS="sha256::7b1ec7ec5635da7cb01550513215a90f8b2f52bb7c90cf3e97ede936d3e55b0f"
 CHKUPDATE="anitya::id=1335"


### PR DESCRIPTION
Topic Description
-----------------

- httpd: update to 2.4.60
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- httpd: 2.4.60

Security Update?
----------------

No

Build Order
-----------

```
#buildit httpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
