### PR TITLE
libva-nvidia-driver (nvidia-vaapi-driver): update to 0.0.12

### DIFF
--- a/runtime-multimedia/libva-nvidia-driver/autobuild/config
+++ b/runtime-multimedia/libva-nvidia-driver/autobuild/config
@@ -1,0 +1,8 @@
+# Source debconf library.
+. /usr/share/debconf/confmodule
+
+# Let the user know that nvidia_drm.modeset=1 needs to be set for the driver
+# to function correctly.
+db_fset libva-nvidia-driver/nvidia_drm_modeset seen false
+db_input high libva-nvidia-driver/nvidia_drm_modeset || true
+db_go

--- a/runtime-multimedia/libva-nvidia-driver/autobuild/defines
+++ b/runtime-multimedia/libva-nvidia-driver/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libva-nvidia-driver
 PKGDES="NVDEC backend for VA-API"
 PKGSEC=libs
-PKGDEP="libva gstreamer"
+PKGDEP="debconf libva gstreamer"
 BUILDDEP="ffnvcodec"
 
 PKGBREAK="libva-vdpau-driver<=0.7.4-6"

--- a/runtime-multimedia/libva-nvidia-driver/autobuild/postinst
+++ b/runtime-multimedia/libva-nvidia-driver/autobuild/postinst
@@ -1,0 +1,4 @@
+# Source Debconf module.
+. /usr/share/debconf/confmodule
+
+db_get libva-nvidia-driver/nvidia_drm_modeset

--- a/runtime-multimedia/libva-nvidia-driver/autobuild/templates
+++ b/runtime-multimedia/libva-nvidia-driver/autobuild/templates
@@ -1,0 +1,48 @@
+Template: libva-nvidia-driver/nvidia_drm_modeset
+Type: note
+Description: Kernel Settings Required for the NVIDIA VA-API Driver
+ The NVIDIA VA-API Driver (libva-nvidia-driver) for hardware accelerated video
+ decoding requires a non-default Kernel parameter to function correctly:
+ .
+ nvidia_drm.modeset=1
+ .
+ This parameter is known to break configurations with multiple NVIDIA cards
+ and renders hot-reloading of the nvidia_drm module impossible. If your device
+ does not have the aforementioned configuration and you do not have the need
+ to reload the nvidia_drm module without a reboot, please edit your bootloader
+ configuration to append the said parameter.
+ .
+ Using GRUB (the default bootloader) as an example, edit the
+ `/etc/default/grub' file:
+ .
+ $ sudo -e /etc/default/grub
+ .
+ And edit the `GRUB_CMDLINE_LINUX_DEFAULT=' line to append the said parameter:
+ .
+ GRUB_CMDLINE_LINUX_DEFAULT="nvidia_drm.modeset=1"
+ .
+ After which, regenerate GRUB bootloader configurations and reboot to apply
+ the changes:
+ .
+ $ sudo update-grub
+Description-zh_CN.UTF-8: NVIDIA VA-API 驱动需要设置内核参数
+ NVIDIA VA-API 驱动 (libva-nvidia-driver) 可用于为 NVIDIA 显卡提供硬件视频解码
+ 加速，但该驱动需要非默认内核参数才能正常工作：
+ .
+ nvidia_drm.modeset=1
+ .
+ 该参数已知会破坏多 NVIDIA 显卡的功能性及 nvidia_drm 模块热重载。如果您的设备
+ 没有同时使用多张 NVIDIA 显卡及热重载（即不重启系统的情况下重载）上述模块的
+ 需求，您可以考虑编辑引导器配置并加入上述内核参数。
+ .
+ 以默认的 GRUB 引导器为例，可编辑 `/etc/default/grub' 配置文件：
+ .
+ $ sudo -e /etc/default/grub
+ .
+ 并在 `GRUB_CMDLINE_LINUX_DEFAULT=' 配置项并添加上述内核参数：
+ .
+ GRUB_CMDLINE_LINUX_DEFAULT="nvidia_drm.modeset=1"
+ .
+ 而后，重新生成 GRUB 引导器配置并重启即可让更改生效：
+ .
+ $ sudo update-grub

--- a/runtime-multimedia/libva-nvidia-driver/spec
+++ b/runtime-multimedia/libva-nvidia-driver/spec
@@ -1,4 +1,4 @@
-VER=0.0.11
+VER=0.0.12
 SRCS="git::commit=tags/v$VER::https://github.com/elFarto/nvidia-vaapi-driver"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1754"


### PR DESCRIPTION
Topic Description
-----------------

- libva-nvidia-driver: update to 0.0.12

Package(s) Affected
-------------------

- libva-nvidia-driver: 0.0.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit libva-nvidia-driver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
