### PR TITLE
vulkan-* (Vulkan Runtime and Tools): update to 1.3.283.0

### DIFF
--- a/app-utils/vulkan-tools/spec
+++ b/app-utils/vulkan-tools/spec
@@ -1,4 +1,4 @@
-VER=1.3.280.0
+VER=1.3.283.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15953"

--- a/groups/vulkan
+++ b/groups/vulkan
@@ -1,0 +1,8 @@
+runtime-display/vulkan-headers
+runtime-display/vulkan-loader
+runtime-display/vulkan-utility-libraries
+runtime-display/vulkan-validationlayers
+runtime-display/spirv-headers
+runtime-display/volk-meta-loader
+app-utils/vulkan-tools
+runtime-display/vulkan-extensionlayer

--- a/runtime-display/spirv-headers/spec
+++ b/runtime-display/spirv-headers/spec
@@ -1,4 +1,4 @@
-VER=1.3.280.0
+VER=1.3.283.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/SPIRV-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230542"

--- a/runtime-display/volk-meta-loader/spec
+++ b/runtime-display/volk-meta-loader/spec
@@ -1,4 +1,4 @@
-VER=1.3.280.0
+VER=1.3.283.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/zeux/volk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370476"

--- a/runtime-display/vulkan-extensionlayer/spec
+++ b/runtime-display/vulkan-extensionlayer/spec
@@ -1,4 +1,4 @@
-VER=1.3.280.0
+VER=1.3.283.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-ExtensionLayer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230558"

--- a/runtime-display/vulkan-headers/spec
+++ b/runtime-display/vulkan-headers/spec
@@ -1,4 +1,4 @@
-VER=1.3.280.0
+VER=1.3.283.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88835"

--- a/runtime-display/vulkan-loader/spec
+++ b/runtime-display/vulkan-loader/spec
@@ -1,4 +1,4 @@
-VER=1.3.280.0
+VER=1.3.283.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Loader"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230557"

--- a/runtime-display/vulkan-utility-libraries/spec
+++ b/runtime-display/vulkan-utility-libraries/spec
@@ -1,4 +1,4 @@
-VER=1.3.280.0
+VER=1.3.283.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Utility-Libraries"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370173"

--- a/runtime-display/vulkan-validationlayers/spec
+++ b/runtime-display/vulkan-validationlayers/spec
@@ -1,4 +1,4 @@
-VER=1.3.280.0
+VER=1.3.283.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-ValidationLayers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230558"

--- a/runtime-optenv32/volk-meta-loader+32/autobuild/build
+++ b/runtime-optenv32/volk-meta-loader+32/autobuild/build
@@ -6,6 +6,7 @@ cmake "$SRCDIR" \
     -DCMAKE_INSTALL_PREFIX=/opt/32 \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=/opt/32/bin/gcc \
+    -DCMAKE_CXX_COMPILER=/opt/32/bin/g++ \
     ${CMAKE_AFTER}
 
 abinfo "Building $i ..."
@@ -15,9 +16,4 @@ abinfo "Installing $i ..."
 make install DESTDIR="$PKGDIR"
 
 abinfo "Removing non-runtime data ..."
-rm -rfv "$PKGDIR"/opt/32/share
-
-abinfo "Renaming all optenv32 utilities ..."
-for i in "$PKGDIR"/usr/bin/*; do
-    mv -v $i{,32}
-done
+rm -rfv "$PKGDIR"/opt/32/{bin,share}

--- a/runtime-optenv32/volk-meta-loader+32/autobuild/defines
+++ b/runtime-optenv32/volk-meta-loader+32/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=volk-meta-loader+32
+PKGSEC=libs
+PKGDEP="vulkan-headers+32"
+BUILDDEP="32subsystem"
+PKGDES="Meta loader for Vulkan API (optenv32)"
+
+CMAKE_AFTER="-DVOLK_PULL_IN_VULKAN=ON \
+             -DVOLK_INSTALL=ON \
+             -DVOLK_HEADERS_ONLY=OFF"
+
+# Note: Static-only library.
+NOSTATIC=0
+ABSPLITDBG=0
+
+# optenv32 - mark noarch
+ABHOST=noarch

--- a/runtime-optenv32/volk-meta-loader+32/spec
+++ b/runtime-optenv32/volk-meta-loader+32/spec
@@ -1,0 +1,4 @@
+VER=1.3.283.0
+SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/zeux/volk"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=370476"

--- a/runtime-optenv32/vulkan-headers+32/autobuild/build
+++ b/runtime-optenv32/vulkan-headers+32/autobuild/build
@@ -5,7 +5,7 @@ abinfo "Running CMake for $PKGNAME ..."
 cmake "$SRCDIR" \
     -DCMAKE_INSTALL_PREFIX=/opt/32 \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_C_COMPILER=/opt/32/bin/i686-pc-linux-gnu-gcc \
+    -DCMAKE_C_COMPILER=/opt/32/bin/gcc \
     ${CMAKE_AFTER}
 
 abinfo "Building $i ..."

--- a/runtime-optenv32/vulkan-headers+32/spec
+++ b/runtime-optenv32/vulkan-headers+32/spec
@@ -1,4 +1,4 @@
-VER=1.3.272
-SRCS="git::commit=tags/v$VER::https://github.com/KhronosGroup/Vulkan-Headers"
+VER=1.3.283.0
+SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88835"

--- a/runtime-optenv32/vulkan-loader+32/autobuild/build
+++ b/runtime-optenv32/vulkan-loader+32/autobuild/build
@@ -5,7 +5,8 @@ abinfo "Running CMake for $PKGNAME ..."
 cmake "$SRCDIR" \
     -DCMAKE_INSTALL_PREFIX=/opt/32 \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_C_COMPILER=/opt/32/bin/i686-pc-linux-gnu-gcc \
+    -DCMAKE_C_COMPILER=/opt/32/bin/gcc \
+    -DCMAKE_CXX_COMPILER=/opt/32/bin/g++ \
     ${CMAKE_AFTER}
 
 abinfo "Building $i ..."

--- a/runtime-optenv32/vulkan-loader+32/spec
+++ b/runtime-optenv32/vulkan-loader+32/spec
@@ -1,4 +1,4 @@
-VER=1.3.272
-SRCS="git::commit=tags/v$VER::https://github.com/KhronosGroup/Vulkan-Loader"
+VER=1.3.283.0
+SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Loader"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230557"

--- a/runtime-optenv32/vulkan-tools+32/autobuild/defines
+++ b/runtime-optenv32/vulkan-tools+32/autobuild/defines
@@ -1,9 +1,10 @@
 PKGNAME=vulkan-tools+32
 PKGSEC=utils
 PKGDEP="libxkbcommon+32 x11-lib+32 vulkan-loader+32"
-BUILDDEP="lxml glslang vulkan-headers+32 32subsystem"
+BUILDDEP="lxml glslang vulkan-headers+32 volk-meta-loader+32 32subsystem"
 PKGDES="Vulkan Tools and Utilities (optenv32)"
 
+# FIXME: WSL_WAYLAND requires waylandpp+32
 CMAKE_AFTER="-DBUILD_CUBE=ON \
              -DBUILD_VULKANINFO=ON \
              -DBUILD_ICD=OFF \

--- a/runtime-optenv32/vulkan-tools+32/spec
+++ b/runtime-optenv32/vulkan-tools+32/spec
@@ -1,4 +1,4 @@
-VER=1.3.227
-SRCS="tbl::https://github.com/KhronosGroup/Vulkan-Tools/archive/v$VER.tar.gz"
-CHKSUMS="sha256::dbba74f6a4b3a4288276543ab692dd3a8298d9e37ed6c5f594e4ea1717052920"
+VER=1.3.283.0
+SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Tools"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15953"


### PR DESCRIPTION
Topic Description
-----------------

- vulkan-tools+32: update to 1.3.283.0
- volk-meta-loader+32: new, 1.3.283.0
- vulkan-loader+32: update to 1.3.283.0
- vulkan-headers+32: update to 1.3.283.0
- vulkan-extensionlayer: update to 1.3.283.0
- volk-meta-loader: update to 1.3.283.0
- spirv-headers: update to 1.3.283.0
- vulkan-tools: update to 1.3.283.0
- vulkan-validationlayers: update to 1.3.283.0
- vulkan-utility-libraries: update to 1.3.283.0
- vulkan-loader: update to 1.3.283.0
- vulkan-headers: update to 1.3.283.0
- groups: add vulkan

Package(s) Affected
-------------------

- vulkan-tools+32: 1.3.283.0
- volk-meta-loader+32: 1.3.283.0
- vulkan-loader+32: 1.3.283.0
- vulkan-headers+32: 1.3.283.0
- spirv-headers: 1:1.3.283.0
- volk-meta-loader: 1.3.283.0
- vulkan-extensionlayer: 1.3.283.0
- vulkan-headers: 1.3.283.0
- vulkan-loader: 1.3.283.0
- vulkan-tools: 1.3.283.0
- vulkan-utility-libraries: 1.3.283.0
- vulkan-validationlayers: 1.3.283.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vulkan-headers vulkan-loader vulkan-utility-libraries vulkan-validationlayers spirv-headers volk-meta-loader  vulkan-tools vulkan-extensionlayer vulkan-headers+32 vulkan-loader+32 volk-meta-loader+32 vulkan-tools+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
