### PR TITLE
autobuild4: add tomli dep for pep517-helper

### DIFF
--- a/app-devel/autobuild4/autobuild/defines
+++ b/app-devel/autobuild4/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=autobuild4
 PKGSEC=devel
 PKGDES="Multi-backend and extensible packaging toolkit"
 PKGDEP="autoconf autoconf-archive automake apt dpkg bash config coreutils \
-        spdx-licenses gcc-runtime glibc"
+        spdx-licenses gcc-runtime glibc tomli"
 BUILDDEP="nlohmann-json"
 PKGRECOM="cargo-audit"
 

--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,5 @@
 VER=4.3.3
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: add tomli dep for pep517-helper

Package(s) Affected
-------------------

- autobuild4: 4.3.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
