### PR TITLE
openssh (OpenSSH): drop ASCII colour markers in postinst

### DIFF
--- a/app-network/openssh/autobuild/postinst
+++ b/app-network/openssh/autobuild/postinst
@@ -40,13 +40,13 @@ https://aosc.io/news/5986-aosa-2017-0034-openssh-in-tarballs-shipped-identical-h
 \033[0m"
 fi
 
-echo -e "\033[1;33mChecking whether systemd units need to be reload...\033[0m" 
+echo -e "Checking whether systemd units need to be reload..." 
 if [[ $(systemctl show sshd --property=NeedDaemonReload | cut -d= -f2) == "yes" ]]; then
-    echo -e "\033[1;33mReloading systemd units..."
+    echo -e "Reloading systemd units..."
     systemctl daemon-reload
-    echo -e "\033[1;33mRestarting sshd service..."
+    echo -e "Restarting sshd service..."
     systemctl restart sshd
 else
-    echo -e "\033[0;32mNothing can be reloaded.\033[0m"
+    echo -e "Nothing can be reloaded."
 fi
 

--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -1,5 +1,5 @@
 VER=9.8p1
-REL=1
+REL=2
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
 CHKSUMS="sha256::dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3"
 CHKUPDATE="anitya::id=2565"


### PR DESCRIPTION
Topic Description
-----------------

- openssh: drop ASCII colour markers in postinst
    We barely use this and the original implementation missed the \033[0m sequence.

Package(s) Affected
-------------------

- openssh: 9.8p1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
