### PR TITLE
superslicer: update to 2.5.60.0

### DIFF
--- a/app-creativity/superslicer/autobuild/patches/0005-SeamPlacer-fix-potential-crashing-issue.patch
+++ b/app-creativity/superslicer/autobuild/patches/0005-SeamPlacer-fix-potential-crashing-issue.patch
@@ -1,0 +1,33 @@
+From 0514d5202a6ce2a96468955cbe5ebb007318eef0 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Wed, 3 Jul 2024 19:15:42 +0800
+Subject: [PATCH] SeamPlacer: fix potential crashing issue
+
+When extract_perimeter_polylines() is changed to use polylines instead
+of polygons, the no-op condition is kept as a 0 sized array, however 1
+polyline will lead to 0 polygons available too.
+
+Fix this no-op condition to prevent crashing.
+
+Fixes: 0b7ea21d4b07 ("seam: rework for polylines instead of polygons")
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/libslic3r/GCode/SeamPlacer.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libslic3r/GCode/SeamPlacer.cpp b/src/libslic3r/GCode/SeamPlacer.cpp
+index 7a54df384..bfb4a76ea 100644
+--- a/src/libslic3r/GCode/SeamPlacer.cpp
++++ b/src/libslic3r/GCode/SeamPlacer.cpp
+@@ -599,7 +599,7 @@ PolylineWithEnds extract_perimeter_polylines(const Layer *layer, const SeamPosit
+ // if Custom Seam modifiers are present, oversamples the polyline if necessary to better fit user intentions
+ void process_perimeter_polylines(const PolylineWithEnd &orig_polyline, float z_coord, const LayerRegion *region,
+         const GlobalModelInfo &global_model_info, PrintObjectSeamData::LayerSeams &result) {
+-    if (orig_polyline.size() == 0) {
++    if (orig_polyline.size() <= 1) {
+         return;
+     }
+     PolylineWithEnd polyline = orig_polyline;
+-- 
+2.45.2
+

--- a/app-creativity/superslicer/spec
+++ b/app-creativity/superslicer/spec
@@ -1,4 +1,4 @@
-VER=2.5.59.12
+VER=2.5.60.0
 SRCS="git::commit=tags/${VER}::https://github.com/supermerill/SuperSlicer.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370825"


### PR DESCRIPTION
Topic Description
-----------------

- superslicer: update to 2.5.60.0
    Co-authored-by: Icenowy Zheng (@Icenowy) <uwu@icenowy.me>

Package(s) Affected
-------------------

- superslicer: 2.5.60.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit superslicer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
