### PR TITLE
texstudio (TeXstudio): fix dependency

### DIFF
--- a/app-doc/texstudio/autobuild/patches/0001-Fedora-Disable-update-check.patch
+++ b/app-doc/texstudio/autobuild/patches/0001-Fedora-Disable-update-check.patch
@@ -1,15 +1,16 @@
-From 3d277f1e446343511177893102704da36582158f Mon Sep 17 00:00:00 2001
-From: hannes <hannes@fedoraproject.org>
-Date: Sat, 2 Jan 2021 10:23:12 +0100
-Subject: [PATCH] Update fix
+From 74e51ebcd552010037857a86de211b9cddc857ef Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 4 Jul 2024 03:58:16 +0800
+Subject: [PATCH 1/3] [Fedora] Disable update check
 
+Co-authored-by: hannes <hannes@fedoraproject.org>
 ---
  src/configdialog.ui   | 6 ++++++
  src/configmanager.cpp | 2 +-
  2 files changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/src/configdialog.ui b/src/configdialog.ui
-index 88710e9..12b38b0 100644
+index bdd914471..e2e1f6ecf 100644
 --- a/src/configdialog.ui
 +++ b/src/configdialog.ui
 @@ -590,6 +590,9 @@
@@ -33,10 +34,10 @@ index 88710e9..12b38b0 100644
                </item>
                <item row="0" column="5">
 diff --git a/src/configmanager.cpp b/src/configmanager.cpp
-index 7e6effc..0193acc 100644
+index cca83e8c8..cae93261c 100644
 --- a/src/configmanager.cpp
 +++ b/src/configmanager.cpp
-@@ -489,7 +489,7 @@ ConfigManager::ConfigManager(QObject *parent): QObject (parent),
+@@ -501,7 +501,7 @@ ConfigManager::ConfigManager(QObject *parent): QObject (parent),
      registerOption("Macros/RepositoryURL", &URLmacroRepository, "https://api.github.com/repos/texstudio-org/texstudio-macro/contents/", nullptr);
  
  	//updates
@@ -46,5 +47,5 @@ index 7e6effc..0193acc 100644
  	registerOption("Update/AutoCheckInvervalDays", &autoUpdateCheckIntervalDays, 7, &pseudoDialog->spinBoxAutoUpdateCheckIntervalDays);
  	registerOption("Update/LastCheck", &lastUpdateCheck, QDateTime());
 -- 
-2.29.2
+2.45.2
 

--- a/app-doc/texstudio/autobuild/patches/0002-Fedora-Use-system-qtsingleapplication.patch
+++ b/app-doc/texstudio/autobuild/patches/0002-Fedora-Use-system-qtsingleapplication.patch
@@ -1,14 +1,15 @@
-From 80f36b2b857c73ce4c74d3e16fc0745b83d4fbff Mon Sep 17 00:00:00 2001
-From: hannes <hannes@fedoraproject.org>
-Date: Sun, 26 Sep 2021 07:45:00 +0200
-Subject: [PATCH] qtsingle
+From 8bd0c83abdc4c0db58b3b60cb8a0cdc91d2ab577 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 4 Jul 2024 03:58:47 +0800
+Subject: [PATCH 2/3] [Fedora] Use system qtsingleapplication
 
+Co-authored-by: hannes <hannes@fedoraproject.org>
 ---
  texstudio.pro | 6 +++++-
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/texstudio.pro b/texstudio.pro
-index 16e704b..c59894e 100644
+index 0873fec20..7f8bf4232 100644
 --- a/texstudio.pro
 +++ b/texstudio.pro
 @@ -105,7 +105,11 @@ versionGreaterOrEqual($$QT_VERSION, "6.0.0") {
@@ -25,5 +26,5 @@ index 16e704b..c59894e 100644
  # ##############################
  # precompile_header: PRECOMPILED_HEADER = mostQtHeaders.h
 -- 
-2.31.1
+2.45.2
 

--- a/app-doc/texstudio/autobuild/patches/0003-disable-backtrace-on-loongarch64-as-code-does-not-co.patch
+++ b/app-doc/texstudio/autobuild/patches/0003-disable-backtrace-on-loongarch64-as-code-does-not-co.patch
@@ -1,0 +1,31 @@
+From a410e90d91ffd1a77362327ee488e29f7a48a7d8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E7=8E=8B=E6=98=8E?= <wming126@126.com>
+Date: Mon, 18 Apr 2022 16:48:23 +0800
+Subject: [PATCH 3/3] disable backtrace on loongarch64 as code does not compile
+ (#2250)
+
+./BUILD.sh need build release version.
+
+Signed-off-by: wangming <wangming@loongson-pc>
+
+Co-authored-by: wangming <wangming@loongson-pc>
+---
+ src/debug/debughelper.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/debug/debughelper.cpp b/src/debug/debughelper.cpp
+index ee7f0934e..f8a03b3a2 100644
+--- a/src/debug/debughelper.cpp
++++ b/src/debug/debughelper.cpp
+@@ -12,7 +12,7 @@
+ // disable backtrace on ARM as the code does not compile
+ // disable backtrace on RISC-V. RISC-V does not support stack unwinding using frame pointer.
+ // Recommended approach for RISC-V is dwarf cfi info.
+-#if (defined(arm) || defined(__arm__) || defined(__riscv))
++#if (defined(arm) || defined(__arm__) || defined(__riscv) || defined(__loongarch64))
+ #define NO_CRASH_HANDLER
+ #endif
+ 
+-- 
+2.45.2
+

--- a/app-doc/texstudio/spec
+++ b/app-doc/texstudio/spec
@@ -1,5 +1,5 @@
 VER=4.0.2
-REL=3
-SRCS="tbl::https://github.com/texstudio-org/texstudio/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::134558670800bf9e9564d25c61efa888ba4b8b0f145c09ca64bcbeffecf12fa6"
+REL=4
+SRCS="git::commit=tags/$VER::https://github.com/texstudio-org/texstudio"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6239"

--- a/desktop-lxqt/lxqt-build-tools/autobuild/defines
+++ b/desktop-lxqt/lxqt-build-tools/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=lxqt-build-tools
+PKGSEC=LxQt
+BUILDDEP="qt-5"
+PKGDES="Various packaging tools and scripts for LXQt applications"
+
+ABHOST=noarch

--- a/desktop-lxqt/lxqt-build-tools/spec
+++ b/desktop-lxqt/lxqt-build-tools/spec
@@ -1,0 +1,5 @@
+VER=0.8.0
+REL=1
+SRCS="https://github.com/lxqt/lxqt-build-tools/releases/download/$VER/lxqt-build-tools-$VER.tar.xz"
+CHKSUMS="sha256::8cad73636e3a1f09baab0d82a2e76f3e171ce2adacade03ccc0a6cf0a51d69a9"
+CHKUPDATE="anitya::id=12779"

--- a/desktop-lxqt/qtermwidget/autobuild/defines
+++ b/desktop-lxqt/qtermwidget/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=qtermwidget
+PKGSEC=x11
+PKGDEP="qt-5"
+BUILDDEP="lxqt-build-tools"
+PKGDES="A terminal widget for Qt"
+
+CMAKE_AFTER="-DBUILD_DESIGNER_PLUGIN=0 -DUSE_QT5=true"

--- a/desktop-lxqt/qtermwidget/spec
+++ b/desktop-lxqt/qtermwidget/spec
@@ -1,0 +1,5 @@
+VER=0.16.1
+REL=3
+SRCS="git::commit=tags/$VER::https://github.com/lxqt/qtermwidget"
+CHKSUMS="sha256::9266fe2b9d8b8c7297960660c13f816093706f18453c883671445ed49123b938"
+CHKUPDATE="anitya::id=8343"


### PR DESCRIPTION
Topic Description
-----------------

- texstudio: drop unused qtermwidget dep
    - Use Git tag per the Styling Manual.
    - Backport an upstream patch to fix build on loongarch64. [^1]
    - Track patches at AOSC-Tracking/texstudio @ aosc/4.0.2.
    [^1]: https://github.com/texstudio-org/texstudio/commit/e5098eaa06341503cd31ac494c4a2ccdef081985
- qtermwidget: resurrect
    This reverts commit 2932ec4352fd243ef2b9e2b703d959313d703b92.
- lxqt-build-tools: resurrect
    This reverts commit 13804e35d3df2a0aed8fc0059cddaf1c8194320e.

Package(s) Affected
-------------------

- lxqt-build-tools: 0.8.0-1
- qtermwidget: 0.16.1-3
- texstudio: 4.0.2-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxqt-build-tools qtermwidget texstudio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
