### PR TITLE
httpd (Apache HTTPD): update to 2.4.61

### DIFF
--- a/app-web/httpd/autobuild/patches/0001-Fedora-Detect-systemd-dependency.patch
+++ b/app-web/httpd/autobuild/patches/0001-Fedora-Detect-systemd-dependency.patch
@@ -1,5 +1,16 @@
+From dd5cd88eec00f0c38166004372ff40f5bb74cd3b Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 4 Jul 2024 03:40:00 +0800
+Subject: [PATCH 1/4] [Fedora] Detect systemd dependency
+
+---
+ Makefile.in  | 2 +-
+ acinclude.m4 | 1 +
+ configure.in | 2 ++
+ 3 files changed, 4 insertions(+), 1 deletion(-)
+
 diff --git a/Makefile.in b/Makefile.in
-index a2e9c82..bd8045c 100644
+index ebf7a1660f..bf30c64ffb 100644
 --- a/Makefile.in
 +++ b/Makefile.in
 @@ -4,7 +4,7 @@ CLEAN_SUBDIRS = test
@@ -12,10 +23,10 @@ index a2e9c82..bd8045c 100644
  PROGRAM_DEPENDENCIES = \
    server/libmain.la \
 diff --git a/acinclude.m4 b/acinclude.m4
-index 97484c9..05abe18 100644
+index 51cf130c9e..70d6c18de6 100644
 --- a/acinclude.m4
 +++ b/acinclude.m4
-@@ -631,6 +631,7 @@ case $host in
+@@ -630,6 +630,7 @@ case $host in
        if test "${ac_cv_header_systemd_sd_daemon_h}" = "no" || test -z "${SYSTEMD_LIBS}"; then
          AC_MSG_WARN([Your system does not support systemd.])
        else
@@ -24,7 +35,7 @@ index 97484c9..05abe18 100644
        fi
     fi
 diff --git a/configure.in b/configure.in
-index cf437fe..521fc45 100644
+index d2a009d790..e8372e1063 100644
 --- a/configure.in
 +++ b/configure.in
 @@ -239,6 +239,7 @@ if test "x$PCRE_CONFIG" != "x"; then
@@ -35,7 +46,7 @@ index cf437fe..521fc45 100644
  else
    AC_MSG_ERROR([pcre(2)-config for libpcre not found. PCRE is required and available from http://pcre.org/])
  fi
-@@ -734,6 +735,7 @@ APACHE_SUBST(OS_DIR)
+@@ -735,6 +736,7 @@ APACHE_SUBST(OS_DIR)
  APACHE_SUBST(BUILTIN_LIBS)
  APACHE_SUBST(SHLIBPATH_VAR)
  APACHE_SUBST(OS_SPECIFIC_VARS)
@@ -43,3 +54,6 @@ index cf437fe..521fc45 100644
  
  PRE_SHARED_CMDS='echo ""'
  POST_SHARED_CMDS='echo ""'
+-- 
+2.45.2
+

--- a/app-web/httpd/autobuild/patches/0002-Fedora-More-verbose-startup-logging-for-mod_systemd.patch
+++ b/app-web/httpd/autobuild/patches/0002-Fedora-More-verbose-startup-logging-for-mod_systemd.patch
@@ -1,8 +1,16 @@
+From 4d7ed313affda67d84149d9ae824af90d279035b Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 4 Jul 2024 03:40:41 +0800
+Subject: [PATCH 2/4] [Fedora] More verbose startup logging for mod_systemd.
 
-More verbose startup logging for mod_systemd.
+---
+ modules/arch/unix/mod_systemd.c | 55 +++++++++++++++++++++++++++++++--
+ 1 file changed, 52 insertions(+), 3 deletions(-)
 
---- httpd-2.4.43/modules/arch/unix/mod_systemd.c.mod_systemd
-+++ httpd-2.4.43/modules/arch/unix/mod_systemd.c
+diff --git a/modules/arch/unix/mod_systemd.c b/modules/arch/unix/mod_systemd.c
+index c3e7082df1..eda1272e8c 100644
+--- a/modules/arch/unix/mod_systemd.c
++++ b/modules/arch/unix/mod_systemd.c
 @@ -29,11 +29,14 @@
  #include "mpm_common.h"
  
@@ -18,7 +26,7 @@ More verbose startup logging for mod_systemd.
  static int systemd_pre_config(apr_pool_t *pconf, apr_pool_t *plog,
                                apr_pool_t *ptemp)
  {
-@@ -44,6 +47,20 @@
+@@ -44,6 +47,20 @@ static int systemd_pre_config(apr_pool_t *pconf, apr_pool_t *plog,
      return OK;
  }
  
@@ -39,7 +47,7 @@ More verbose startup logging for mod_systemd.
  /* Report the service is ready in post_config, which could be during
   * startup or after a reload.  The server could still hit a fatal
   * startup error after this point during ap_run_mpm(), so this is
-@@ -51,19 +68,51 @@
+@@ -51,19 +68,51 @@ static int systemd_pre_config(apr_pool_t *pconf, apr_pool_t *plog,
   * the TCP ports so new connections will not be rejected.  There will
   * always be a possible async failure event simultaneous to the
   * service reporting "ready", so this should be good enough. */
@@ -94,3 +102,6 @@ More verbose startup logging for mod_systemd.
  
      return OK;
  }
+-- 
+2.45.2
+

--- a/app-web/httpd/autobuild/patches/0003-Fedora-Implement-systemd-socket-activation.patch
+++ b/app-web/httpd/autobuild/patches/0003-Fedora-Implement-systemd-socket-activation.patch
@@ -1,8 +1,17 @@
+From 864f87b1e408fc5d6cfca96e1bc6eeb2e65fe309 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 4 Jul 2024 03:41:41 +0800
+Subject: [PATCH 3/4] [Fedora] Implement systemd socket activation
+
+---
+ server/listen.c | 223 +++++++++++++++++++++++++++++++++++++++++-------
+ 1 file changed, 190 insertions(+), 33 deletions(-)
+
 diff --git a/server/listen.c b/server/listen.c
-index 5242c2a..e2e028a 100644
+index 9577d60269..d718db17ef 100644
 --- a/server/listen.c
 +++ b/server/listen.c
-@@ -34,6 +34,10 @@
+@@ -35,6 +35,10 @@
  #include <unistd.h>
  #endif
  
@@ -13,7 +22,7 @@ index 5242c2a..e2e028a 100644
  /* we know core's module_index is 0 */
  #undef APLOG_MODULE_INDEX
  #define APLOG_MODULE_INDEX AP_CORE_MODULE_INDEX
-@@ -59,9 +63,12 @@ static int ap_listenbacklog;
+@@ -60,9 +64,12 @@ static int ap_listenbacklog;
  static int ap_listencbratio;
  static int send_buffer_size;
  static int receive_buffer_size;
@@ -27,7 +36,7 @@ index 5242c2a..e2e028a 100644
  {
      apr_socket_t *s = server->sd;
      int one = 1;
-@@ -94,20 +101,6 @@ static apr_status_t make_sock(apr_pool_t *p, ap_listen_rec *server)
+@@ -95,20 +102,6 @@ static apr_status_t make_sock(apr_pool_t *p, ap_listen_rec *server)
          return stat;
      }
  
@@ -48,7 +57,7 @@ index 5242c2a..e2e028a 100644
      /*
       * To send data over high bandwidth-delay connections at full
       * speed we must force the TCP window to open wide enough to keep the
-@@ -169,21 +162,37 @@ static apr_status_t make_sock(apr_pool_t *p, ap_listen_rec *server)
+@@ -170,21 +163,37 @@ static apr_status_t make_sock(apr_pool_t *p, ap_listen_rec *server)
      }
  #endif
  
@@ -100,7 +109,7 @@ index 5242c2a..e2e028a 100644
      }
  
  #ifdef WIN32
-@@ -315,6 +324,123 @@ static int find_listeners(ap_listen_rec **from, ap_listen_rec **to,
+@@ -335,6 +344,123 @@ static int find_listeners(ap_listen_rec **from, ap_listen_rec **to,
      return found;
  }
  
@@ -223,8 +232,8 @@ index 5242c2a..e2e028a 100644
 +
  static const char *alloc_listener(process_rec *process, const char *addr,
                                    apr_port_t port, const char* proto,
-                                   void *slave)
-@@ -495,7 +621,7 @@ static int open_listeners(apr_pool_t *pool)
+                                   const char *scope_id, void *slave,
+@@ -529,7 +655,7 @@ static int open_listeners(apr_pool_t *pool)
                  }
              }
  #endif
@@ -233,7 +242,7 @@ index 5242c2a..e2e028a 100644
                  ++num_open;
              }
              else {
-@@ -607,8 +733,28 @@ AP_DECLARE(int) ap_setup_listeners(server_rec *s)
+@@ -641,8 +767,28 @@ AP_DECLARE(int) ap_setup_listeners(server_rec *s)
          }
      }
  
@@ -264,7 +273,7 @@ index 5242c2a..e2e028a 100644
      }
  
      for (lr = ap_listeners; lr; lr = lr->next) {
-@@ -698,7 +844,7 @@ AP_DECLARE(apr_status_t) ap_duplicate_listeners(apr_pool_t *p, server_rec *s,
+@@ -732,7 +878,7 @@ AP_DECLARE(apr_status_t) ap_duplicate_listeners(apr_pool_t *p, server_rec *s,
                              duplr->bind_addr);
                  return stat;
              }
@@ -273,7 +282,7 @@ index 5242c2a..e2e028a 100644
  #if AP_NONBLOCK_WHEN_MULTI_LISTEN
              use_nonblock = (ap_listeners && ap_listeners->next);
              stat = apr_socket_opt_set(duplr->sd, APR_SO_NONBLOCK, use_nonblock);
-@@ -825,6 +971,11 @@ AP_DECLARE_NONSTD(const char *) ap_set_listener(cmd_parms *cmd, void *dummy,
+@@ -859,6 +1005,11 @@ AP_DECLARE_NONSTD(const char *) ap_set_listener(cmd_parms *cmd, void *dummy,
      if (argc < 1 || argc > 2) {
          return "Listen requires 1 or 2 arguments.";
      }
@@ -285,7 +294,7 @@ index 5242c2a..e2e028a 100644
  
      rv = apr_parse_addr_port(&host, &scope_id, &port, argv[0], cmd->pool);
      if (rv != APR_SUCCESS) {
-@@ -856,6 +1007,12 @@ AP_DECLARE_NONSTD(const char *) ap_set_listener(cmd_parms *cmd, void *dummy,
+@@ -894,6 +1045,12 @@ AP_DECLARE_NONSTD(const char *) ap_set_listener(cmd_parms *cmd, void *dummy,
          ap_str_tolower(proto);
      }
  
@@ -295,6 +304,9 @@ index 5242c2a..e2e028a 100644
 +    }
 +#endif
 +
-     return alloc_listener(cmd->server->process, host, port, proto, NULL);
+     return alloc_listener(cmd->server->process, host, port, proto,
+                           scope_id, NULL, cmd->temp_pool);
  }
- 
+-- 
+2.45.2
+

--- a/app-web/httpd/autobuild/patches/0004-Fedora-Fix-envvars-install-location.patch
+++ b/app-web/httpd/autobuild/patches/0004-Fedora-Fix-envvars-install-location.patch
@@ -1,7 +1,18 @@
-diff -Naur httpd-2.4.46.orig/support/Makefile.in httpd-2.4.46/support/Makefile.in
---- httpd-2.4.46.orig/support/Makefile.in	2018-02-09 10:17:30.000000000 +0000
-+++ httpd-2.4.46/support/Makefile.in	2021-08-26 04:23:04.161224664 +0000
-@@ -30,9 +30,9 @@
+From 5f4eff2f2a36c2daa324eed25b50a720dea5392a Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 4 Jul 2024 03:42:08 +0800
+Subject: [PATCH 4/4] [Fedora] Fix envvars install location
+
+---
+ support/Makefile.in  | 6 +++---
+ support/apachectl.in | 4 ++--
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/support/Makefile.in b/support/Makefile.in
+index c7d7687612..a0ccca1f79 100644
+--- a/support/Makefile.in
++++ b/support/Makefile.in
+@@ -30,9 +30,9 @@ install:
  	    fi ; \
  	done
  	@if test -f "$(builddir)/envvars-std"; then \
@@ -14,10 +25,11 @@ diff -Naur httpd-2.4.46.orig/support/Makefile.in httpd-2.4.46/support/Makefile.i
  	    fi ; \
  	fi
  
-diff -Naur httpd-2.4.46.orig/support/apachectl.in httpd-2.4.46/support/apachectl.in
---- httpd-2.4.46.orig/support/apachectl.in	2012-02-01 03:47:28.000000000 +0000
-+++ httpd-2.4.46/support/apachectl.in	2021-08-26 04:23:56.299424715 +0000
-@@ -45,8 +45,8 @@
+diff --git a/support/apachectl.in b/support/apachectl.in
+index 3281c2e6cd..549f08b28f 100644
+--- a/support/apachectl.in
++++ b/support/apachectl.in
+@@ -45,8 +45,8 @@ ARGV="$@"
  HTTPD='@exp_sbindir@/@progname@'
  #
  # pick up any necessary environment variables
@@ -28,3 +40,6 @@ diff -Naur httpd-2.4.46.orig/support/apachectl.in httpd-2.4.46/support/apachectl
  fi
  #
  # a command that outputs a formatted text version of the HTML at the
+-- 
+2.45.2
+

--- a/app-web/httpd/spec
+++ b/app-web/httpd/spec
@@ -1,5 +1,4 @@
-VER=2.4.58
-REL=1
+VER=2.4.61
 SRCS="tbl::http://archive.apache.org/dist/httpd/httpd-$VER.tar.bz2"
-CHKSUMS="sha256::fa16d72a078210a54c47dd5bef2f8b9b8a01d94909a51453956b3ec6442ea4c5"
+CHKSUMS="sha256::ea8ba86fd95bd594d15e46d25ac5bbda82ae0c9122ad93998cc539c133eaceb6"
 CHKUPDATE="anitya::id=1335"


### PR DESCRIPTION
Topic Description
-----------------

- httpd: update to 2.4.61
    Track patches at AOSC-Tracking/httpd @ aosc/2.4.61.

Package(s) Affected
-------------------

- httpd: 2.4.61

Security Update?
----------------

No

Build Order
-----------

```
#buildit httpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
