### PR TITLE
findutils: update to 4.10.0

### DIFF
--- a/app-utils/findutils/spec
+++ b/app-utils/findutils/spec
@@ -1,4 +1,4 @@
-VER=4.9.0
+VER=4.10.0
 SRCS="tbl::https://ftp.gnu.org/gnu/findutils/findutils-$VER.tar.xz"
-CHKSUMS="sha256::a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe"
+CHKSUMS="sha256::1387e0b67ff247d2abde998f90dfbf70c1491391a59ddfecb8ae698789f0a4f5"
 CHKUPDATE="anitya::id=812"


### PR DESCRIPTION
Topic Description
-----------------

- findutils: update to 4.10.0
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- findutils: 4.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit findutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
