### PR TITLE
sdl2: update to 2.30.4

### DIFF
--- a/runtime-multimedia/sdl2/spec
+++ b/runtime-multimedia/sdl2/spec
@@ -1,5 +1,4 @@
-VER=2.24.2
-REL=1
+VER=2.30.4
 SRCS="tbl::https://www.libsdl.org/release/SDL2-$VER.tar.gz"
-CHKSUMS="sha256::b35ef0a802b09d90ed3add0dcac0e95820804202914f5bb7b0feb710f1a1329f"
+CHKSUMS="sha256::59c89d0ed40d4efb23b7318aa29fe7039dbbc098334b14f17f1e7e561da31a26"
 CHKUPDATE="anitya::id=4779"


### PR DESCRIPTION
Topic Description
-----------------

- sdl2: update to 2.30.4

Package(s) Affected
-------------------

- sdl2: 2.30.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit sdl2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
