### PR TITLE
cloud-init: update to 24.2

### DIFF
--- a/app-admin/cloud-init/autobuild/patches/0001-feat-aosc-Add-AOSC-OS-support-5310.patch
+++ b/app-admin/cloud-init/autobuild/patches/0001-feat-aosc-Add-AOSC-OS-support-5310.patch
@@ -1,0 +1,377 @@
+From 9357c3899f6f6551c1969573f59b7f99568c34c1 Mon Sep 17 00:00:00 2001
+From: Yuanhang Sun <leavelet@163.com>
+Date: Thu, 4 Jul 2024 03:10:22 +0800
+Subject: [PATCH] feat(aosc): Add 'AOSC OS' support (#5310)
+
+---
+ cloudinit/config/cc_ca_certs.py      |  10 +-
+ cloudinit/config/cc_ntp.py           |   7 ++
+ cloudinit/distros/__init__.py        |   1 +
+ cloudinit/distros/aosc.py            | 148 +++++++++++++++++++++++++++
+ cloudinit/util.py                    |   1 +
+ config/cloud.cfg.tmpl                |  10 +-
+ doc/rtd/reference/distros.rst        |   1 +
+ tests/unittests/distros/test_aosc.py |  10 ++
+ tests/unittests/test_cli.py          |   3 +-
+ tools/.github-cla-signers            |   1 +
+ tools/render-template                |   1 +
+ 11 files changed, 186 insertions(+), 7 deletions(-)
+ create mode 100644 cloudinit/distros/aosc.py
+ create mode 100644 tests/unittests/distros/test_aosc.py
+
+diff --git a/cloudinit/config/cc_ca_certs.py b/cloudinit/config/cc_ca_certs.py
+index 61345fcb..4e80947f 100644
+--- a/cloudinit/config/cc_ca_certs.py
++++ b/cloudinit/config/cc_ca_certs.py
+@@ -23,6 +23,13 @@ DEFAULT_CONFIG = {
+     "ca_cert_update_cmd": ["update-ca-certificates"],
+ }
+ DISTRO_OVERRIDES = {
++    "aosc": {
++        "ca_cert_path": "/etc/ssl/certs/",
++        "ca_cert_local_path": "/etc/ssl/certs/",
++        "ca_cert_filename": "cloud-init-ca-cert-{cert_index}.pem",
++        "ca_cert_config": "/etc/ca-certificates/conf.d/cloud-init.conf",
++        "ca_cert_update_cmd": ["update-ca-bundle"],
++    },
+     "fedora": {
+         "ca_cert_path": "/etc/pki/ca-trust/",
+         "ca_cert_local_path": "/usr/share/pki/ca-trust-source/",
+@@ -71,6 +78,7 @@ for distro in (
+ 
+ distros = [
+     "almalinux",
++    "aosc",
+     "cloudlinux",
+     "alpine",
+     "debian",
+@@ -149,7 +157,7 @@ def disable_default_ca_certs(distro_name, distro_cfg):
+     """
+     if distro_name in ["rhel", "photon"]:
+         remove_default_ca_certs(distro_cfg)
+-    elif distro_name in ["alpine", "debian", "ubuntu"]:
++    elif distro_name in ["alpine", "aosc", "debian", "ubuntu"]:
+         disable_system_ca_certs(distro_cfg)
+ 
+         if distro_name in ["debian", "ubuntu"]:
+diff --git a/cloudinit/config/cc_ntp.py b/cloudinit/config/cc_ntp.py
+index 3d659525..e2b83191 100644
+--- a/cloudinit/config/cc_ntp.py
++++ b/cloudinit/config/cc_ntp.py
+@@ -24,6 +24,7 @@ NR_POOL_SERVERS = 4
+ distros = [
+     "almalinux",
+     "alpine",
++    "aosc",
+     "azurelinux",
+     "centos",
+     "cloudlinux",
+@@ -109,6 +110,12 @@ DISTRO_CLIENT_CONFIG = {
+             "service_name": "ntpd",
+         },
+     },
++    "aosc": {
++        "systemd-timesyncd": {
++            "check_exe": "/usr/lib/systemd/systemd-timesyncd",
++            "confpath": "/etc/systemd/timesyncd.conf",
++        },
++    },
+     "azurelinux": {
+         "chrony": {
+             "service_name": "chronyd",
+diff --git a/cloudinit/distros/__init__.py b/cloudinit/distros/__init__.py
+index 4557d432..73873ceb 100644
+--- a/cloudinit/distros/__init__.py
++++ b/cloudinit/distros/__init__.py
+@@ -60,6 +60,7 @@ ALL_DISTROS = "all"
+ 
+ OSFAMILIES = {
+     "alpine": ["alpine"],
++    "aosc": ["aosc"],
+     "arch": ["arch"],
+     "debian": ["debian", "ubuntu"],
+     "freebsd": ["freebsd", "dragonfly"],
+diff --git a/cloudinit/distros/aosc.py b/cloudinit/distros/aosc.py
+new file mode 100644
+index 00000000..0460c740
+--- /dev/null
++++ b/cloudinit/distros/aosc.py
+@@ -0,0 +1,148 @@
++# Copyright (C) 2024 AOSC Developers
++#
++# Author: Yuanhang Sun <leavelet@aosc.io>
++#
++# This file is part of cloud-init. See LICENSE file for license information.
++import logging
++
++from cloudinit import distros, helpers, subp, util
++from cloudinit.distros import PackageList
++from cloudinit.distros.parsers.hostname import HostnameConf
++from cloudinit.distros.parsers.sys_conf import SysConf
++from cloudinit.settings import PER_INSTANCE
++
++LOG = logging.getLogger(__name__)
++
++
++class Distro(distros.Distro):
++    systemd_locale_conf_fn = "/etc/locale.conf"
++    init_cmd = ["systemctl"]
++    network_conf_dir = "/etc/sysconfig/network"
++    resolve_conf_fn = "/etc/systemd/resolved.conf"
++    tz_local_fn = "/etc/localtime"
++
++    dhclient_lease_directory = "/var/lib/NetworkManager"
++    dhclient_lease_file_regex = r"dhclient-[\w-]+\.lease"
++
++    renderer_configs = {
++        "sysconfig": {
++            "control": "etc/sysconfig/network",
++            "iface_templates": "%(base)s/network-scripts/ifcfg-%(name)s",
++            "route_templates": {
++                "ipv4": "%(base)s/network-scripts/route-%(name)s",
++                "ipv6": "%(base)s/network-scripts/route6-%(name)s",
++            },
++        }
++    }
++
++    prefer_fqdn = False
++
++    def __init__(self, name, cfg, paths):
++        distros.Distro.__init__(self, name, cfg, paths)
++        self._runner = helpers.Runners(paths)
++        self.osfamily = "aosc"
++        self.default_locale = "en_US.UTF-8"
++        cfg["ssh_svcname"] = "sshd"
++
++    def apply_locale(self, locale, out_fn=None):
++        if not out_fn:
++            out_fn = self.systemd_locale_conf_fn
++        locale_cfg = {
++            "LANG": locale,
++        }
++        update_locale_conf(out_fn, locale_cfg)
++
++    def _write_hostname(self, hostname, filename):
++        if filename.endswith("/previous-hostname"):
++            conf = HostnameConf("")
++            conf.set_hostname(hostname)
++            util.write_file(filename, str(conf), 0o644)
++        create_hostname_file = util.get_cfg_option_bool(
++            self._cfg, "create_hostname_file", True
++        )
++        if create_hostname_file:
++            subp.subp(["hostnamectl", "set-hostname", str(hostname)])
++        else:
++            subp.subp(
++                [
++                    "hostnamectl",
++                    "set-hostname",
++                    "--transient",
++                    str(hostname),
++                ]
++            )
++            LOG.info("create_hostname_file is False; hostname set transiently")
++
++    def _read_hostname(self, filename, default=None):
++        if filename.endswith("/previous-hostname"):
++            return util.load_text_file(filename).strip()
++        (out, _err) = subp.subp(["hostname"])
++        out = out.strip()
++        if len(out):
++            return out
++        else:
++            return default
++
++    def _read_system_hostname(self):
++        sys_hostname = self._read_hostname(self.hostname_conf_fn)
++        return (self.hostname_conf_fn, sys_hostname)
++
++    def set_timezone(self, tz):
++        tz_file = self._find_tz_file(tz)
++        util.del_file(self.tz_local_fn)
++        util.sym_link(tz_file, self.tz_local_fn)
++
++    def package_command(self, command, args=None, pkgs=None):
++        if pkgs is None:
++            pkgs = []
++
++        cmd = ["oma"]
++        if command:
++            cmd.append(command)
++        cmd.append("-y")
++        cmd.extend(pkgs)
++
++        subp.subp(cmd, capture=False)
++
++    def install_packages(self, pkglist: PackageList):
++        self.package_command("install", pkgs=pkglist)
++
++    def update_package_sources(self):
++        self._runner.run(
++            "update-sources",
++            self.package_command,
++            "refresh",
++            freq=PER_INSTANCE,
++        )
++
++
++def read_locale_conf(sys_path):
++    exists = False
++    try:
++        contents = util.load_text_file(sys_path).splitlines()
++        exists = True
++    except IOError:
++        contents = []
++    return (exists, SysConf(contents))
++
++
++def update_locale_conf(sys_path, locale_cfg):
++    if not locale_cfg:
++        return
++    (exists, contents) = read_locale_conf(sys_path)
++    updated_am = 0
++    for (k, v) in locale_cfg.items():
++        if v is None:
++            continue
++        v = str(v)
++        if len(v) == 0:
++            continue
++        contents[k] = v
++        updated_am += 1
++    if updated_am:
++        lines = [
++            str(contents),
++        ]
++        if not exists:
++            lines.insert(0, util.make_header())
++        util.write_file(sys_path, "\n".join(lines) + "\n", 0o644)
+diff --git a/cloudinit/util.py b/cloudinit/util.py
+index 98dd66d5..505ae1b8 100644
+--- a/cloudinit/util.py
++++ b/cloudinit/util.py
+@@ -656,6 +656,7 @@ def _get_variant(info):
+         if linux_dist in (
+             "almalinux",
+             "alpine",
++            "aosc",
+             "arch",
+             "azurelinux",
+             "centos",
+diff --git a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
+index 68175cd0..4b1efdbc 100644
+--- a/config/cloud.cfg.tmpl
++++ b/config/cloud.cfg.tmpl
+@@ -11,7 +11,7 @@
+                  "netbsd": "NetBSD", "openbsd": "openBSD",
+                  "openmandriva": "OpenMandriva admin", "photon": "PhotonOS",
+                  "ubuntu": "Ubuntu", "unknown": "Ubuntu"}) %}
+-{% set groups = ({"alpine": "adm, wheel", "arch": "wheel, users",
++{% set groups = ({"alpine": "adm, wheel", "aosc": "wheel", "arch": "wheel, users",
+                   "azurelinux": "wheel",
+                   "debian": "adm, audio, cdrom, dialout, dip, floppy, netdev, plugdev, sudo, video",
+                   "gentoo": "users, wheel", "mariner": "wheel",
+@@ -220,7 +220,7 @@ cloud_final_modules:
+ # (not accessible to handlers/transforms)
+ system_info:
+   # This will affect which distro class gets used
+-{% if variant in ["alpine", "amazon", "arch", "azurelinux", "debian", "fedora",
++{% if variant in ["alpine", "amazon", "aosc", "arch", "azurelinux", "debian", "fedora",
+                   "freebsd", "gentoo", "mariner", "netbsd", "openbsd",
+                   "OpenCloudOS", "openeuler", "openmandriva", "photon", "suse",
+                   "TencentOS", "ubuntu"] or is_rhel %}
+@@ -238,7 +238,7 @@ system_info:
+ {% else %}
+     name: {{ variant }}
+ {% endif %}
+-{% if variant in ["alpine", "amazon", "arch", "azurelinux", "debian", "fedora",
++{% if variant in ["alpine", "amazon", "aosc", "arch", "azurelinux", "debian", "fedora",
+                   "gentoo", "mariner", "OpenCloudOS", "openeuler",
+                   "openmandriva", "photon", "suse", "TencentOS", "ubuntu",
+                   "unknown"]
+@@ -320,7 +320,7 @@ system_info:
+   # Automatically discover the best ntp_client
+   ntp_client: auto
+ {% endif %}
+-{% if variant in ["alpine", "amazon", "arch", "azurelinux", "debian", "fedora",
++{% if variant in ["alpine", "amazon", "aosc", "arch", "azurelinux", "debian", "fedora",
+                   "gentoo", "mariner", "OpenCloudOS", "openeuler",
+                   "openmandriva", "photon", "suse", "TencentOS", "ubuntu",
+                   "unknown"]
+@@ -368,7 +368,7 @@ system_info:
+ {% endif %}
+ {% if variant in ["debian", "ubuntu", "unknown"] %}
+   ssh_svcname: ssh
+-{% elif variant in ["alpine", "amazon", "arch", "azurelinux", "fedora",
++{% elif variant in ["alpine", "amazon", "aosc", "arch", "azurelinux", "fedora",
+                     "gentoo", "mariner", "OpenCloudOS", "openeuler",
+                     "openmandriva", "photon", "suse", "TencentOS"]
+                    or is_rhel %}
+diff --git a/doc/rtd/reference/distros.rst b/doc/rtd/reference/distros.rst
+index 59309ece..d54cb889 100644
+--- a/doc/rtd/reference/distros.rst
++++ b/doc/rtd/reference/distros.rst
+@@ -7,6 +7,7 @@ Unix family of operating systems. See the complete list below.
+ 
+ * AlmaLinux
+ * Alpine Linux
++* AOSC OS
+ * Arch Linux
+ * CentOS
+ * CloudLinux
+diff --git a/tests/unittests/distros/test_aosc.py b/tests/unittests/distros/test_aosc.py
+new file mode 100644
+index 00000000..e8a66b7a
+--- /dev/null
++++ b/tests/unittests/distros/test_aosc.py
+@@ -0,0 +1,10 @@
++# This file is part of cloud-init. See LICENSE file for license information.
++
++from tests.unittests.distros import _get_distro
++from tests.unittests.helpers import CiTestCase
++
++
++class TestAOSC(CiTestCase):
++    def test_get_distro(self):
++        distro = _get_distro("aosc")
++        self.assertEqual(distro.osfamily, "aosc")
+diff --git a/tests/unittests/test_cli.py b/tests/unittests/test_cli.py
+index 3a92d29e..6ab6d496 100644
+--- a/tests/unittests/test_cli.py
++++ b/tests/unittests/test_cli.py
+@@ -319,7 +319,8 @@ class TestCLI:
+                 ["all"],
+                 [
+                     "**Supported distros:** all",
+-                    "**Supported distros:** almalinux, alpine, azurelinux, "
++                    "**Supported distros:** "
++                    "almalinux, alpine, aosc, azurelinux, "
+                     "centos, cloudlinux, cos, debian, eurolinux, fedora, "
+                     "freebsd, mariner, miraclelinux, openbsd, openeuler, "
+                     "OpenCloudOS, openmandriva, opensuse, opensuse-microos, "
+diff --git a/tools/.github-cla-signers b/tools/.github-cla-signers
+index d9accd11..34dd55c3 100644
+--- a/tools/.github-cla-signers
++++ b/tools/.github-cla-signers
+@@ -105,6 +105,7 @@ klausenbusk
+ KsenijaS
+ landon912
+ ld9379435
++leavelet
+ licebmi
+ linitio
+ LKHN
+diff --git a/tools/render-template b/tools/render-template
+index c3af642a..78beeecb 100755
+--- a/tools/render-template
++++ b/tools/render-template
+@@ -14,6 +14,7 @@ def main():
+         "almalinux",
+         "alpine",
+         "amazon",
++        "aosc",
+         "arch",
+         "azurelinux",
+         "benchmark",
+-- 
+2.45.2
+

--- a/app-admin/cloud-init/autobuild/patches/0002-fix-add-host-template-for-AOSC.patch
+++ b/app-admin/cloud-init/autobuild/patches/0002-fix-add-host-template-for-AOSC.patch
@@ -1,0 +1,42 @@
+From 5160e61f06a49c4c8687f7a6ad562087bdb7d00b Mon Sep 17 00:00:00 2001
+From: Yuanhang Sun <leavelet@163.com>
+Date: Mon, 22 Jul 2024 09:35:01 +0800
+Subject: [PATCH] fix: add host template for AOSC
+
+---
+ templates/hosts.aosc.tmpl | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+ create mode 100644 templates/hosts.aosc.tmpl
+
+diff --git a/templates/hosts.aosc.tmpl b/templates/hosts.aosc.tmpl
+new file mode 100644
+index 00000000..897cebcc
+--- /dev/null
++++ b/templates/hosts.aosc.tmpl
+@@ -0,0 +1,23 @@
++## template:jinja
++{#
++This file (/etc/cloud/templates/hosts.aosc.tmpl) is only utilized
++if enabled in cloud-config.  Specifically, in order to enable it
++you need to add the following to config:
++   manage_etc_hosts: True
++-#}
++# Your system has configured 'manage_etc_hosts' as True.
++# As a result, if you wish for changes to this file to persist
++# then you will need to either
++# a.) make changes to the master file in /etc/cloud/templates/hosts.aosc.tmpl
++# b.) change or remove the value of 'manage_etc_hosts' in
++#     /etc/cloud/cloud.cfg or cloud-config from user-data
++#
++#<ip-address>   <hostname.domain.org>   <hostname>
++{# The value '{{hostname}}' will be replaced with the local-hostname -#}
++127.0.0.1       {{fqdn}} {{hostname}}
++127.0.0.1       localhost
++
++# The following lines are desirable for IPv6 capable hosts
++::1             localhost ip6-localhost ip6-loopback
++ff02::1         ip6-allnodes
++ff02::2         ip6-allrouters
+-- 
+2.45.2
+

--- a/app-admin/cloud-init/spec
+++ b/app-admin/cloud-init/spec
@@ -1,4 +1,4 @@
-VER=24.1.4+git20240513
-SRCS="git::commit=e98cae2::https://github.com/AOSC-Tracking/cloud-init"
+VER=24.2
+SRCS="git::commit=tags/$VER::https://github.com/canonical/cloud-init"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11545"


### PR DESCRIPTION
Topic Description
-----------------

- cloud-init: update to 24.2

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit cloud-init
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
