### PR TITLE
pygobject-3 update to 3.48.2

### DIFF
--- a/lang-python/pygobject-3/autobuild/defines
+++ b/lang-python/pygobject-3/autobuild/defines
@@ -1,10 +1,13 @@
 PKGNAME=pygobject-3
 PKGSEC=gnome
 PKGDEP="gobject-introspection pycairo"
+BUILDDEP="meson"
 PKGDES="Python bindings for GObject"
 
 MESON_AFTER="-Dpython=python3 \
              -Dpycairo=enabled"
+
+ABTYPE=meson
 
 PKGREP="pygobject-3+rt3"
 PKGPROV="pygobject-3+rt3"

--- a/lang-python/pygobject-3/spec
+++ b/lang-python/pygobject-3/spec
@@ -1,5 +1,4 @@
-VER=3.42.2
+VER=3.48.2
 SRCS="https://download.gnome.org/sources/pygobject/${VER:0:4}/pygobject-$VER.tar.xz"
-CHKSUMS="sha256::ade8695e2a7073849dd0316d31d8728e15e1e0bc71d9ff6d1c09e86be52bc957"
+CHKSUMS="sha256::0794aeb4a9be31a092ac20621b5f54ec280f9185943d328b105cdae6298ad1a7"
 CHKUPDATE="anitya::id=13158"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- pygobject-3: update to 3.48.2

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit pygobject-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
