### PR TITLE
ly: drop, orphaned

### DIFF
--- a/desktop-displaymanagers/ly/autobuild/build
+++ b/desktop-displaymanagers/ly/autobuild/build
@@ -1,5 +1,0 @@
-abinfo "Building ly ..."
-make
-
-abinfo "Installing ly ..."
-make DESTDIR="$PKGDIR" install installsystemd

--- a/desktop-displaymanagers/ly/autobuild/defines
+++ b/desktop-displaymanagers/ly/autobuild/defines
@@ -1,4 +1,0 @@
-PKGNAME=ly
-PKGSEC=x11
-PKGDEP="xorg-server x11-app libxcb linux-pam ncurses util-linux systemd"
-PKGDES="A display manager with terminal user interface"

--- a/desktop-displaymanagers/ly/spec
+++ b/desktop-displaymanagers/ly/spec
@@ -1,4 +1,0 @@
-VER=0.6.0
-SRCS="git::commit=tags/v${VER}::https://github.com/fairyglade/ly"
-CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=371742"


### PR DESCRIPTION
Topic Description
-----------------

- ly: drop
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
