### PR TITLE
ca-certs: update to 20240703

### DIFF
--- a/runtime-data/ca-certs/spec
+++ b/runtime-data/ca-certs/spec
@@ -1,5 +1,4 @@
-VER=20231115
-REL=1
-CHANGESET=a3dd112b0ed075be924f114a490abaeb9d7c3cd6
+VER=20240703
+CHANGESET=e3195e969188a333692e5e366d6fda6bb8d7c761
 SRCS="file::rename=certdata.txt::https://hg.mozilla.org/mozilla-central/raw-file/$CHANGESET/security/nss/lib/ckfw/builtins/certdata.txt"
-CHKSUMS="sha256::1970dd65858925d68498d2356aea6d03f764422523c5887deca8ce3ba9e1f845"
+CHKSUMS="sha256::456ff095dde6dd73354c5c28c73d9c06f53b61a803963414cb91a1d92945cdd3"


### PR DESCRIPTION
Topic Description
-----------------

- ca-certs: update to 20240703

Package(s) Affected
-------------------

- ca-certs: 20240703

Security Update?
----------------

No

Build Order
-----------

```
#buildit ca-certs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
