### PR TITLE
[WIP] zig: update to 0.13.0

### DIFF
--- a/lang-ziglang/zig/autobuild/defines
+++ b/lang-ziglang/zig/autobuild/defines
@@ -20,4 +20,5 @@ NOLTO=1
 # ppc64el/loongson3: ‘asm’ specifier for variable ‘xx’ conflicts with ‘asm’ clobber list
 # mips64r6el: the register ‘lo’ cannot be clobbered in ‘asm’ for the current target
 # riscv64: infinite hang
-FAIL_ARCH="!(amd64)"
+# Temporarily enable all architectures for evaluation
+# FAIL_ARCH="!(amd64)"

--- a/lang-ziglang/zig/autobuild/patches/0001-enable-build-id-tagging.patch
+++ b/lang-ziglang/zig/autobuild/patches/0001-enable-build-id-tagging.patch
@@ -1,10 +1,24 @@
---- a/CMakeLists.txt	2024-03-03 14:50:37.897551046 -0800
-+++ b/CMakeLists.txt	2024-03-03 14:51:10.764685290 -0800
-@@ -925,6 +925,7 @@
-   --zig-lib-dir "${CMAKE_SOURCE_DIR}/lib"
-   "-Dconfig_h=${ZIG_CONFIG_H_OUT}"
-   "-Denable-llvm"
+From 4a9e64534e2c64709a5e589f976f6d8fe3cd0b79 Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Thu, 4 Jul 2024 22:52:42 +0800
+Subject: [PATCH] enable build id tagging
+
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 22051f190..257549255 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -933,6 +933,7 @@ set(ZIG_BUILD_ARGS
+   "-Dcpu=${ZIG_TARGET_MCPU}"
+ 
+   -Denable-llvm
 +  "-Dbuild-id=sha1"
-   ${ZIG_RELEASE_ARG}
-   ${ZIG_STATIC_ARG}
-   ${ZIG_NO_LIB_ARG}
+   "-Dconfig_h=${ZIG_CONFIG_H_OUT}"
+ 
+   -Dno-langref
+-- 
+2.45.2.windows.1
+

--- a/lang-ziglang/zig/spec
+++ b/lang-ziglang/zig/spec
@@ -1,4 +1,4 @@
-VER=0.12.0
-SRCS="git::commit=tags/$VER::https://github.com/ziglang/zig"
+VER=0.13.0
+SRCS="git::commit=tags/$VER::https://github.com/ziglang/zig.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13871"


### PR DESCRIPTION
Topic Description
-----------------

- zig: update to 0.13.0, WIP

Package(s) Affected
-------------------

- zig: 0.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit zig
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
