### PR TITLE
autobuild4: add python-{build,installer}, wheel deps

### DIFF
--- a/app-devel/autobuild4/autobuild/defines
+++ b/app-devel/autobuild4/autobuild/defines
@@ -2,7 +2,8 @@ PKGNAME=autobuild4
 PKGSEC=devel
 PKGDES="Multi-backend and extensible packaging toolkit"
 PKGDEP="autoconf autoconf-archive automake apt dpkg bash config coreutils \
-        spdx-licenses gcc-runtime glibc tomli"
+        spdx-licenses gcc-runtime glibc tomli python-build python-installer
+        wheel"
 BUILDDEP="nlohmann-json"
 PKGRECOM="cargo-audit"
 

--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,5 +1,5 @@
 VER=4.3.3
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: add python-{build,installer}, wheel deps
    These dependencies are a given for most (if not all) PEP517 packages.

Package(s) Affected
-------------------

- autobuild4: 4.3.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
