### PR TITLE
imath: update to 3.1.11

### DIFF
--- a/runtime-display/imath/spec
+++ b/runtime-display/imath/spec
@@ -1,5 +1,4 @@
-VER=3.1.5
-REL=1
+VER=3.1.11
 SRCS="tbl::https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::1e9c7c94797cf7b7e61908aed1f80a331088cc7d8873318f70376e4aed5f25fb"
+CHKSUMS="sha256::9057849585e49b8b85abe7cc1e76e22963b01bfdc3b6d83eac90c499cd760063"
 CHKUPDATE="anitya::id=223366"


### PR DESCRIPTION
Topic Description
-----------------

- imath: update to 3.1.11
    Co-authored-by: (@BC204)

Package(s) Affected
-------------------

- imath: 3.1.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit imath
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
