### PR TITLE
qt-5: lessen total_mem to 60

### DIFF
--- a/runtime-desktop/qt-5/spec
+++ b/runtime-desktop/qt-5/spec
@@ -6,6 +6,6 @@ CHKSUMS="sha256::48b528491c345c32760a0554c1f99c9c3fbd5bc8d8200bf1b28f008d3c3e600
 SUBDIR="qt-${VER:0:1}"
 CHKUPDATE="anitya::id=230518"
 # Note: Prefer larger RAM.
-ENVREQ="total_mem=64"
+ENVREQ="total_mem=60"
 # Note: Prefer 3C5000 (or faster) build hosts.
 ENVREQ__LOONGARCH64="core=16"


### PR DESCRIPTION
No 64GiB machine would actually come with 64GiB usable RAM. Lower it to 60GiB to make it more compatible.
