### PR TITLE
aoscbootstrap: update to 0.5.1

### DIFF
--- a/app-utils/aoscbootstrap/autobuild/beyond
+++ b/app-utils/aoscbootstrap/autobuild/beyond
@@ -2,7 +2,9 @@ abinfo 'Installing assets ...'
 install -dv "$PKGDIR/usr/share/aoscbootstrap"
 cp -rv "$SRCDIR/"{contrib,scripts,config,recipes} "$PKGDIR/usr/share/aoscbootstrap/"
 
-abinfo 'Creating a symlink for generate-releases ...'
+abinfo 'Creating a symlink for generate-{emukit,releases} ...'
 chmod -v +x "$PKGDIR"/usr/share/aoscbootstrap/contrib/generate-releases.sh
 ln -sv ../share/aoscbootstrap/contrib/generate-releases.sh \
     "$PKGDIR"/usr/bin/generate-releases
+ln -sv ../share/aoscbootstrap/contrib/generate-emukit \
+    "$PKGDIR"/usr/bin/generate-emukit

--- a/app-utils/aoscbootstrap/autobuild/defines
+++ b/app-utils/aoscbootstrap/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=aoscbootstrap
 PKGSEC=utils
 PKGDEP="openssl squashfs-tools xz"
 BUILDDEP="cmake cargo llvm"
-PKGDES="An utility to bootstrap an AOSC OS distribution"
+PKGDES="Utility to bootstrap an AOSC OS distribution"
 
+# FIXME: ld.lld: error: undefined symbol: solvable_lookup_bin_checksum
 NOLTO=1

--- a/app-utils/aoscbootstrap/autobuild/prepare
+++ b/app-utils/aoscbootstrap/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo 'Modifying LTO directive ...'
-sed -i 's/lto = "fat"/lto = true/' "$SRCDIR"/Cargo.toml

--- a/app-utils/aoscbootstrap/spec
+++ b/app-utils/aoscbootstrap/spec
@@ -1,4 +1,4 @@
-VER=0.5.0
+VER=0.5.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscbootstrap"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231687"


### PR DESCRIPTION
Topic Description
-----------------

- aoscbootstrap: update to 0.5.1
    - Install generate-emukit symlink.
    - Drop unused prepare script.
    - Add a FIXME note about why LTO is disabled.

Package(s) Affected
-------------------

- aoscbootstrap: 0.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit aoscbootstrap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
