### PR TITLE
lxgwnewcleargothic-font: update to 1.123.2

### DIFF
--- a/desktop-fonts/lxgwnewcleargothic-font/spec
+++ b/desktop-fonts/lxgwnewcleargothic-font/spec
@@ -1,9 +1,9 @@
-VER=1.121
+VER=1.123.2
 SRCS="file::rename=LXGWFasmartGothic.ttf::https://github.com/lxgw/LxgwNeoXiHei/releases/download/v$VER/LXGWFasmartGothic.ttf \
       file::rename=LxgwNeoXiHei-Book.ttf::https://github.com/lxgw/LxgwNeoXiHei/releases/download/v$VER/LxgwNeoXiHei.ttf \
       tbl::https://github.com/lxgw/LxgwNeoXiHei/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::c38f0b48d6b2c594969932717d720e643ccd45f05a00c08ac42ef90e6897fe5e \
-         sha256::dfeb61e1a95657e8bd9114f8179b71f24383e23f1e99c37699e95cc8dfe630c4 \
-         sha256::6be0e697f1c43f5bc224dc1988bd7816661aada3a67ab7b78482f6b81a6fbcf9"
+CHKSUMS="sha256::77210a70955a5cf216fb6513934943527fb904641270a87a47812708c2f19a03 \
+         sha256::b285453dea14e11a2f938c695ddf740a3cd0d72d6bc75393ff878a0993537784 \
+         sha256::5bda71288042d310ef85959867e385a1aca6ad78a1633abf5dc91912e43aff46"
 CHKUPDATE="anitya::id=234778"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- lxgwnewcleargothic-font: update to 1.123.2
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- lxgwnewcleargothic-font: 1.123.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxgwnewcleargothic-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
