### PR TITLE
hugo: update to 0.128.2

### DIFF
--- a/app-web/hugo/autobuild/defines
+++ b/app-web/hugo/autobuild/defines
@@ -6,3 +6,5 @@ PKGDES="Fast and Flexible Static Site Generator in Go"
 
 ABSPLITDBG=0
 GO_BUILD_AFTER="-tags extended"
+# FIXME: missing Go support
+FAIL_ARCH="mips64r6el"

--- a/app-web/hugo/spec
+++ b/app-web/hugo/spec
@@ -1,4 +1,4 @@
-VER=0.127.0
+VER=0.128.2
 SRCS="git::commit=tags/v$VER::https://github.com/gohugoio/hugo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12959"


### PR DESCRIPTION
Topic Description
-----------------

- hugo: update to 0.128.2
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- hugo: 0.128.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit hugo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
