### PR TITLE
kitty: update to 0.35.2

### DIFF
--- a/app-utils/kitty/autobuild/defines
+++ b/app-utils/kitty/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=kitty
 PKGSEC=utils
-PKGDEP="fontconfig glew glfw python-3 x11-app lcms2 librsync"
-PKGDES="A modern, hackable, featureful, OpenGL based terminal emulator"
+PKGDEP="fontconfig glew glfw python-3 x11-app lcms2 librsync simde"
+BUILDDEP="go"
+PKGDES="Terminal emulator featuring OpenGL acceleration"

--- a/app-utils/kitty/spec
+++ b/app-utils/kitty/spec
@@ -1,5 +1,5 @@
-VER=0.26.4
-SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
-CHKSUMS="sha256::c09591ac7c908e6a0549f75cc061c6318f46261f9f5d3f3775120063c3a43bb7"
-CHKUPDATE="anitya::id=17405"
+VER=0.35.2
 REL=1
+SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
+CHKSUMS="sha256::b48ac902643bc225ec6ed830f496253ce4522dbe1d4b44fedc3106314c4fade2"
+CHKUPDATE="anitya::id=17405"


### PR DESCRIPTION
Topic Description
-----------------

- kitty: update to 0.35.2

Package(s) Affected
-------------------

- kitty: 0.35.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit kitty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
