### PR TITLE
godot: new, 4.2.2

### DIFF
--- a/app-devel/godot/autobuild/build
+++ b/app-devel/godot/autobuild/build
@@ -1,0 +1,38 @@
+abinfo "Building Godot Engine ..."
+
+HAS_DOTNET=yes
+# arch={auto|x86_32|x86_64|arm32|arm64|rv64|ppc32|ppc64|wasm32}
+if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
+    GODOT_ARCH=x86_64
+elif [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
+    GODOT_ARCH=arm64
+elif [[ "${CROSS:-$ARCH}" = "riscv64" ]]; then
+    GODOT_ARCH=rv64
+    HAS_DOTNET=no
+elif [[ "${CROSS:-$ARCH}" = "ppc64el" ]]; then
+    GODOT_ARCH=ppc64
+    HAS_DOTNET=no
+else
+    exit 1
+fi
+
+export BUILD_NAME=aosc
+scons platform=linuxbsd target=editor production=yes debug_symbols=yes \
+    arch=$GODOT_ARCH module_mono_enabled=$HAS_DOTNET
+
+EXE_NAME="godot.linuxbsd.editor.$GODOT_ARCH"
+
+if [[ "$HAS_DOTNET" = "yes" ]]; then
+    abinfo "Building Godot C# binding ..."
+    EXE_NAME+=".mono"
+    $SRCDIR/bin/$EXE_NAME --headless --generate-mono-glue $SRCDIR/modules/mono/glue
+    $SRCDIR/modules/mono/build_scripts/build_assemblies.py --godot-output-dir=$SRCDIR/bin --godot-platform=linuxbsd
+fi
+
+abinfo "Installing Godot..."
+install -dv $PKGDIR/usr/lib/godot/
+if [[ "$HAS_DOTNET" = "yes" ]]; then
+    mv -v $SRCDIR/bin/GodotSharp $PKGDIR/usr/lib/godot/
+fi
+install -Dvm755 $SRCDIR/bin/$EXE_NAME $PKGDIR/usr/lib/godot/godot
+install -Dvm644 $SRCDIR/icon.svg $PKGDIR/usr/share/icons/hicolor/scalable/apps/godot.svg

--- a/app-devel/godot/autobuild/defines
+++ b/app-devel/godot/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=godot
+PKGDES="Multi-platform 2D and 3D game engine"
+PKGSEC=devel
+
+PKGDEP="x11-lib libglvnd glu alsa-lib pulseaudio systemd dotnet-sdk-8.0"
+PKGDEP__NO_DOTNET="x11-lib libglvnd glu alsa-lib pulseaudio systemd"
+PKGDEP__PPC64EL="${PKGDEP_NO_DOTNET}"
+PKGDEP__RISCV64="${PKGDEP_NO_DOTNET}"
+
+BUILDDEP="pkg-config gcc scons"
+
+FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64)"

--- a/app-devel/godot/autobuild/overrides/usr/bin/godot
+++ b/app-devel/godot/autobuild/overrides/usr/bin/godot
@@ -1,0 +1,2 @@
+#! /bin/sh
+/usr/lib/godot/godot "$@"

--- a/app-devel/godot/autobuild/overrides/usr/share/applications/godot.desktop
+++ b/app-devel/godot/autobuild/overrides/usr/share/applications/godot.desktop
@@ -1,0 +1,19 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Categories=Development;IDE;
+Comment[en_US]=Godot Engine
+Comment=Godot Engine
+Exec=/usr/lib/godot/godot
+GenericName[en_US]=Text Editor
+GenericName=Text Editor
+Icon=godot
+MimeType=application/x-godot-project;application/x-godot-scene;application/x-gdscript;application/x-godot-resource
+Name[en_US]=Godot Engine
+Name=Godot Engine
+Path=
+StartupNotify=true
+Terminal=false
+TerminalOptions=
+Type=Application
+X-KDE-SubstituteUID=false
+X-KDE-Username=

--- a/app-devel/godot/spec
+++ b/app-devel/godot/spec
@@ -1,0 +1,3 @@
+VER=4.2.2
+SRCS="git::commit=tags/$VER-stable::https://github.com/godotengine/godot"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- godot: new 4.2.2

Package(s) Affected
-------------------

- godot: 4.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit godot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
