### PR TITLE
deploykit-gui: update to 0.7.1

### DIFF
--- a/app-admin/deploykit-gui/spec
+++ b/app-admin/deploykit-gui/spec
@@ -1,7 +1,7 @@
-VER=0.7.0
+VER=0.7.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-gui \
       tbl::https://github.com/AOSC-Dev/deploykit-gui/releases/download/v$VER/dist.tar.xz"
 CHKSUMS="SKIP \
-         sha256::9759e7761b27ecfd9ace883608101745163011e3b98d659d6ef2240dff48f5b8"
+         sha256::cae159b11224ebd2772778b9b8b0b53bfbee149c7ed2f3ba499497495514ecfd"
 SUBDIR="deploykit-gui/src-tauri"
 CHKUPDATE="anitya::id=371971"


### PR DESCRIPTION
Topic Description
-----------------

- deploykit-gui: update to 0.7.1
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- deploykit-gui: 0.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-gui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
