### PR TITLE
libnotify: rebuild to fix Spiral markers

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,5 +1,5 @@
 VER=4.3.3
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/runtime-desktop/libnotify/spec
+++ b/runtime-desktop/libnotify/spec
@@ -1,5 +1,5 @@
 VER=0.7.9
-REL=2
+REL=3
 SRCS="tbl::https://download.gnome.org/sources/libnotify/${VER:0:3}/libnotify-$VER.tar.xz"
 CHKSUMS="sha256::66c0517ed16df7af258e83208faaf5069727dfd66995c4bbc51c16954d674761"
 CHKUPDATE="anitya::id=13149"


### PR DESCRIPTION
Topic Description
-----------------

- libnotify: rebuild for Spiral markers
- autobuild4: update to 4.3.4
    This version fixes Spiral detection for libraries with multiple matches.

Package(s) Affected
-------------------

- autobuild4: 4.3.3-3
- libnotify: 0.7.9-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 libnotify
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
