### PR TITLE
deploykit-backend: update to 0.6.1

### DIFF
--- a/app-admin/deploykit-backend/spec
+++ b/app-admin/deploykit-backend/spec
@@ -1,4 +1,4 @@
-VER=0.6.0
+VER=0.6.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-backend/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371972"


### PR DESCRIPTION
Topic Description
-----------------

- deploykit-backend: update to 0.6.1
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- deploykit-backend: 0.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-backend
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
