### PR TITLE
lxgwnewcleargothic-font: update to 1.124

### DIFF
--- a/desktop-fonts/lxgwnewcleargothic-font/spec
+++ b/desktop-fonts/lxgwnewcleargothic-font/spec
@@ -1,9 +1,9 @@
-VER=1.123.2
+VER=1.124
 SRCS="file::rename=LXGWFasmartGothic.ttf::https://github.com/lxgw/LxgwNeoXiHei/releases/download/v$VER/LXGWFasmartGothic.ttf \
       file::rename=LxgwNeoXiHei-Book.ttf::https://github.com/lxgw/LxgwNeoXiHei/releases/download/v$VER/LxgwNeoXiHei.ttf \
       tbl::https://github.com/lxgw/LxgwNeoXiHei/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::77210a70955a5cf216fb6513934943527fb904641270a87a47812708c2f19a03 \
-         sha256::b285453dea14e11a2f938c695ddf740a3cd0d72d6bc75393ff878a0993537784 \
-         sha256::5bda71288042d310ef85959867e385a1aca6ad78a1633abf5dc91912e43aff46"
+CHKSUMS="sha256::fdd76652cda628b3b7fe9e6dacde8a5c45ff0808712ebc512bc9287a56a22cc1 \
+         sha256::76f7736d46053aea81c30d370e1f2dde8713241cef64f95c023c1d15b0e6f58b \
+         sha256::c9da3bc1f91c570621666408457d6e4ec7e9e044fef7c2a446bebec6e5e25852"
 CHKUPDATE="anitya::id=234778"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- lxgwnewcleargothic-font: update to 1.124
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- lxgwnewcleargothic-font: 1.124

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxgwnewcleargothic-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
