### PR TITLE
jellyfish: update to 1.0.4

### DIFF
--- a/lang-python/jellyfish/autobuild/defines
+++ b/lang-python/jellyfish/autobuild/defines
@@ -1,7 +1,11 @@
 PKGNAME=jellyfish
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools"
+PKGDEP="python-3 maturin"
+BUILDDEP="setuptools python-build python-installer rustc llvm"
 PKGDES="A Python library for doing approximate and phonetic matching of strings"
 
 PKGEPOCH=1
+ABTYPE=pep517
+
+ABSPLITDBG=0
+NOPYTHON2=1

--- a/lang-python/jellyfish/autobuild/defines
+++ b/lang-python/jellyfish/autobuild/defines
@@ -9,3 +9,6 @@ ABTYPE=pep517
 
 ABSPLITDBG=0
 NOPYTHON2=1
+
+# FIXME: ld.lld: error: unknown relocation against symbol .Lla-relax-align
+NOLTO__LOONGARCH64=1

--- a/lang-python/jellyfish/spec
+++ b/lang-python/jellyfish/spec
@@ -1,5 +1,4 @@
-VER=0.6.0
-REL=3
-SRCS="git::commit=tags/$VER::https://github.com/jamesturk/jellyfish"
+VER=1.0.4
+SRCS="git::commit=tags/v$VER::https://github.com/jamesturk/jellyfish"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6587"


### PR DESCRIPTION
Topic Description
-----------------

- jellyfish: disable LTO for loongarch64
- jellyfish: update to 1.0.4
    Specify pep517 ABTYPE

Package(s) Affected
-------------------

- jellyfish: 1:1.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit jellyfish
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
