### PR TITLE
adwaita-icon-theme-legacy: new, 46.2

### DIFF
--- a/desktop-gnome/adwaita-icon-theme-legacy/autobuild/defines
+++ b/desktop-gnome/adwaita-icon-theme-legacy/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=adwaita-icon-theme-legacy
+PKGSEC=gnome
+PKGDEP="hicolor-icon-theme"
+BUILDDEP="gtk-update-icon-cache icon-naming-utils intltool"
+PKGDES="Fallback icons for Adwaita icon theme"
+
+ABSHADOW=0
+ABHOST=noarch

--- a/desktop-gnome/adwaita-icon-theme-legacy/autobuild/patches/0001-meson.build-change-license-install-dir.patch
+++ b/desktop-gnome/adwaita-icon-theme-legacy/autobuild/patches/0001-meson.build-change-license-install-dir.patch
@@ -1,0 +1,25 @@
+From c4e526a6f8d77fa56d27d1cde7eeb231b8206ed4 Mon Sep 17 00:00:00 2001
+From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
+Date: Tue, 9 Jul 2024 15:50:37 +0800
+Subject: [PATCH] meson.build: change license install dir
+
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 5b4a4c0..abe27b4 100644
+--- a/meson.build
++++ b/meson.build
+@@ -7,7 +7,7 @@ pkg.generate(
+   dataonly : true,
+ )
+ 
+-licenses_dir = get_option('datadir') / 'licenses' / 'adwaita-icon-theme'
++licenses_dir = get_option('datadir') / 'licenses' / 'adwaita-icon-theme-legacy'
+ install_data('COPYING', install_dir : licenses_dir, install_tag : 'runtime')
+ install_data('COPYING_CCBYSA3', install_dir : licenses_dir, install_tag : 'runtime')
+ install_data('COPYING_LGPL', install_dir : licenses_dir, install_tag : 'runtime')
+-- 
+2.45.2
+

--- a/desktop-gnome/adwaita-icon-theme-legacy/spec
+++ b/desktop-gnome/adwaita-icon-theme-legacy/spec
@@ -1,0 +1,4 @@
+VER=46.2
+SRCS="git::commit=$VER::https://gitlab.gnome.org/GNOME/adwaita-icon-theme-legacy"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372552"

--- a/desktop-gnome/adwaita-icon-theme/autobuild/defines
+++ b/desktop-gnome/adwaita-icon-theme/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=adwaita-icon-theme
 PKGSEC=gnome
 PKGDEP="hicolor-icon-theme"
+PKGRECOM="adwaita-icon-theme-legacy"
 BUILDDEP="gtk-update-icon-cache icon-naming-utils intltool"
 PKGDES="Adwaita icon theme, the official icon theme of GNOME"
 

--- a/desktop-gnome/adwaita-icon-theme/spec
+++ b/desktop-gnome/adwaita-icon-theme/spec
@@ -1,4 +1,4 @@
-VER=46.0
+VER=46.2
 SRCS="https://download.gnome.org/sources/adwaita-icon-theme/${VER%%.*}/adwaita-icon-theme-${VER/\~/.}.tar.xz"
-CHKSUMS="sha256::4bcb539bd75d64da385d6fa08cbaa9ddeaceb6ac8e82b85ba6c41117bf5ba64e"
+CHKSUMS="sha256::beb126b9429339ba762e0818d5e73b2c46f444975bf80076366eae2d0f96b5cb"
 CHKUPDATE="anitya::id=13117"


### PR DESCRIPTION
Topic Description
-----------------

- adwaita-icon-theme: update to 46.2
  - update to 46.2
  - add recommended dependency: adwaita-icon-theme-legacy
- adwaita-icon-theme-legacy: new, 46.2

Package(s) Affected
-------------------

- adwaita-icon-theme: 46.2
- adwaita-icon-theme-legacy: 46.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit adwaita-icon-theme adwaita-icon-theme-legacy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
