### PR TITLE
nodejs: security update to 20.15.1

### DIFF
--- a/lang-js/nodejs/autobuild/defines
+++ b/lang-js/nodejs/autobuild/defines
@@ -4,9 +4,10 @@ PKGDEP="icu openssl python-2 zlib"
 PKGDES="A JavaScript runtime built on the V8 JavaScript engine"
 
 PKGEPOCH=2
-NOLTO__LOONGSON3=1
+# Redundant variable, see below
+#NOLTO__LOONGSON3=1
 
-# Node.js 16.13.0 fails to build with LTO enabled.
+# https://github.com/nodejs/node/issues/44195#issuecomment-1545966528
 NOLTO=1
 
 FAIL_ARCH="!(amd64|arm64|loongarch64|loongson3|ppc64el|riscv64)"

--- a/lang-js/nodejs/autobuild/prepare
+++ b/lang-js/nodejs/autobuild/prepare
@@ -9,9 +9,7 @@ export CXXFLAGS="${CXXFLAGS} -g -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fno-
 if ab_match_arch armv7hf; then
     abinfo "ARMv7hf detected, appending NEON as FPU ..."
     NODEARCHCONFOPTIONS="--with-arm-fpu=neon"
-fi
-
-if ab_match_arch loongson3; then
+elif ab_match_arch loongson3; then
     abinfo "Loongson 3 detected, specifying r2 target and fp64 FPU mode ..."
     MIPS64CONF="--with-mips-arch-variant=r2 --with-mips-fpu-mode=fp64"
 elif ab_match_arch mips64r6el; then

--- a/lang-js/nodejs/spec
+++ b/lang-js/nodejs/spec
@@ -1,4 +1,4 @@
-VER=20.15.0
-SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.gz"
-CHKSUMS="sha256::01e2c034467a324a33e778c81f2808dff13d289eaa9307d3e9b06c171e4d932d"
+VER=20.15.1
+SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
+CHKSUMS="sha256::fdd53a5729d936691a2a1151046fb4897721cb8b0fca2af957823a9b40fe0c34"
 CHKUPDATE="anitya::id=369796"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs: update to 20.15.1, try enabling LTO

Package(s) Affected
-------------------

- nodejs: 2:20.15.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
