### PR TITLE
discord: bump to 0.0.59

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,5 +1,5 @@
-VER=0.0.58
+VER=0.0.59
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::624ca78858240f818cc54c9afbf29ee5fc68b192872b2738f9c031dc7238c3c7"
+CHKSUMS="sha256::c2fd0771b3e51516fc393be790275bd4c02ebe5ffb2c74d47c4e54c6979220fc"
 SUBDIR=.
 CHKUPDATE="anitya::id=372593"


### PR DESCRIPTION
Topic Description
-----------------

- discord: bump to 0.0.59
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- discord: 0.0.59

Security Update?
----------------

No

Build Order
-----------

```
#buildit discord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
