### PR TITLE
Zxing-cpp Survey 20240710

### DIFF
--- a/app-utils/zxing-cpp/spec
+++ b/app-utils/zxing-cpp/spec
@@ -1,4 +1,4 @@
-VER=1.4.0
-SRCS="tbl::https://github.com/nu-book/zxing-cpp/archive/v$VER.tar.gz"
-CHKSUMS="sha256::126767bb56f8a1f25ae84d233db2e9b9be50d71f5776092d0e170ca0f0ed1862"
+VER=2.2.1
+SRCS="git::commit=tags/v$VER::https://github.com/nu-book/zxing-cpp"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=101246"

--- a/app-utils/zxing-cpp/spec
+++ b/app-utils/zxing-cpp/spec
@@ -2,3 +2,4 @@ VER=2.2.1
 SRCS="git::commit=tags/v$VER::https://github.com/nu-book/zxing-cpp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=101246"
+REL=1

--- a/desktop-kde/kitinerary/spec
+++ b/desktop-kde/kitinerary/spec
@@ -1,4 +1,5 @@
 VER=23.08.5
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kitinerary-$VER.tar.xz"
 CHKSUMS="sha256::aebd2002fe8198cc95884af261882cce8fe0818ebcc34b1ce9a4715cf4e178a8"
 CHKUPDATE="anitya::id=8763"

--- a/desktop-kde/kitinerary/spec
+++ b/desktop-kde/kitinerary/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kitinerary-$VER.tar.xz"
 CHKSUMS="sha256::aebd2002fe8198cc95884af261882cce8fe0818ebcc34b1ce9a4715cf4e178a8"
 CHKUPDATE="anitya::id=8763"

--- a/desktop-kde/prison5/spec
+++ b/desktop-kde/prison5/spec
@@ -1,4 +1,5 @@
 VER=5.115.0
+REL=1
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/prison-$VER.tar.xz"
 CHKSUMS="sha256::8964fc90ba2b3643d62cee9d01c46f4824670ed8c1bcd12ac3b129cebe4273de"
 CHKUPDATE="anitya::id=8762"

--- a/desktop-kde/prison5/spec
+++ b/desktop-kde/prison5/spec
@@ -1,5 +1,5 @@
 VER=5.115.0
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/prison-$VER.tar.xz"
 CHKSUMS="sha256::8964fc90ba2b3643d62cee9d01c46f4824670ed8c1bcd12ac3b129cebe4273de"
 CHKUPDATE="anitya::id=8762"

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,5 @@
 VER=1.24.4
-REL=4
+REL=5
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"


### PR DESCRIPTION
Topic Description
-----------------

- prison5: bump REL for topic Revision Marking Guidelines
- kitinerary: bump REL for topic Revision Marking Guidelines
- gstreamer: bump REL for topic Revision Marking Guidelines
- zxing-cpp: bump REL for topic Revision Marking Guidelines
- prison5: bump REL due to zxing-cpp update
- kitinerary: bump REL due to zxing-cpp update
- gstreamer: bump REL due to zxing-cpp update
- zxing-cpp: update to 2.2.1

Package(s) Affected
-------------------

- gstreamer: 1.24.4-4
- kitinerary: 23.08.5-2
- prison5: 1:5.115.0-2
- zxing-cpp: 1:2.2.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zxing-cpp gstreamer kitinerary prison5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
