### PR TITLE
urfkill: fix ftbfs

### DIFF
--- a/app-admin/urfkill/autobuild/patches/0001-fix-autoconf-ftbfs.patch
+++ b/app-admin/urfkill/autobuild/patches/0001-fix-autoconf-ftbfs.patch
@@ -1,0 +1,12 @@
+diff -Naur urfkill.orig/configure.ac urfkill/configure.ac
+--- urfkill.orig/configure.ac	2024-07-11 09:56:46.185554582 +0800
++++ urfkill/configure.ac	2024-07-11 09:57:16.382909782 +0800
+@@ -184,7 +184,7 @@
+ AS_IF([test "$with_session_tracking" = "none"], with_session_tracking=no)
+ # check value
+ AS_IF([! (echo "$with_session_tracking" | grep -q -E "^(systemd|consolekit|no)$")],
+-        AC_MSG_ERROR([--with-session-tracking must be systemd/consolekit/no, not $with_session_tracking]))
++        AC_MSG_ERROR([--with-session-tracking must be systemd/consolekit/no instead of $with_session_tracking]))
+ # add conditionals and subtitution
+ AM_CONDITIONAL(SESSION_TRACKING_CK, test "$with_session_tracking" = "consolekit")
+ AM_CONDITIONAL(SESSION_TRACKING_SYSTEMD, test "$with_session_tracking" = "systemd")

--- a/app-admin/urfkill/spec
+++ b/app-admin/urfkill/spec
@@ -1,4 +1,5 @@
 VER=0.5.0+git20210401
+REL=1
 SRCS="git::commit=333a29d5d7b09c4ae296ec37d9c6aaaf1b8f539b::https://github.com/lcp/urfkill"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21896"


### PR DESCRIPTION
Topic Description
-----------------

- urfkill: fix ftbfs due to newer m4/autoconf
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- urfkill: 1:0.5.0+git20210401-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit urfkill
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
