### PR TITLE
greetd-tuigreet: new, 0.9.1

### DIFF
--- a/desktop-displaymanagers/greetd-tuigreet/autobuild/beyond
+++ b/desktop-displaymanagers/greetd-tuigreet/autobuild/beyond
@@ -1,0 +1,7 @@
+abinfo "Generating manpage ..."
+scdoc < "$SRCDIR"/contrib/man/tuigreet-1.scd \
+      > "$SRCDIR"/contrib/man/tuigreet.1
+
+abinfo "Installing manpage ..."
+install -Dvm644 "$SRCDIR"/contrib/man/tuigreet.1 \
+                "$PKGDIR"/usr/share/man/man1/tuigreet.1

--- a/desktop-displaymanagers/greetd-tuigreet/autobuild/defines
+++ b/desktop-displaymanagers/greetd-tuigreet/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=greetd-tuigreet
+PKGSEC=x11
+PKGDEP="greetd"
+BUILDDEP="rustc llvm scdoc"
+PKGDES="A graphical console greeter for greetd"
+
+USECLANG=1
+ABTYPE=rust
+
+# FIXME: ld.lld is not yet available.
+NOLTO__LOONGARCH64=1
+
+# FIXME: SIGSEGV: invalid memory reference on loongson3 with LTO enabled
+NOLTO__LOONGSON3=1

--- a/desktop-displaymanagers/greetd-tuigreet/autobuild/overrides/usr/lib/tmpfiles.d/tuigreet.conf
+++ b/desktop-displaymanagers/greetd-tuigreet/autobuild/overrides/usr/lib/tmpfiles.d/tuigreet.conf
@@ -1,0 +1,1 @@
+d /var/cache/tuigreet 0750 greeter greeter -

--- a/desktop-displaymanagers/greetd-tuigreet/autobuild/postinst
+++ b/desktop-displaymanagers/greetd-tuigreet/autobuild/postinst
@@ -1,0 +1,1 @@
+systemd-tmpfiles --create /usr/lib/tmpfiles.d/tuigreet.conf

--- a/desktop-displaymanagers/greetd-tuigreet/spec
+++ b/desktop-displaymanagers/greetd-tuigreet/spec
@@ -1,0 +1,4 @@
+VER=0.9.1
+SRCS="git::commit=tags/$VER::https://github.com/apognu/tuigreet"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=266462"


### PR DESCRIPTION
Topic Description
-----------------

- greetd-tuigreet: new, 0.9.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- greetd-tuigreet: 0.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit greetd-tuigreet
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
