### PR TITLE
zfs: (Debian patches) import some patches

### DIFF
--- a/app-admin/zfs/autobuild/patches/0001-Block-manual-building-in-the-DKMS-source-tree.patch
+++ b/app-admin/zfs/autobuild/patches/0001-Block-manual-building-in-the-DKMS-source-tree.patch
@@ -1,0 +1,51 @@
+From c092c64a2588822fd152b268aa47a2346171304c Mon Sep 17 00:00:00 2001
+From: Shengqi Chen <harry-chen@outlook.com>
+Date: Tue, 16 Jul 2024 15:28:03 +0800
+Subject: [PATCH 1/4] Block manual building in the DKMS source tree.
+
+To avoid messing up future DKMS builds and the zfs installation, block manual building of the DKMS source tree.
+
+Reviewed-By: Petter Reinholdtsen <pere@hungry.com>
+Last-Update: 2017-10-06
+See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd01921cfaa7ce1bad87/debian/patches/1001-Prevent-manual-builds-in-the-DKMS-source.patch
+---
+ config/dkms.m4 | 14 ++++++++++++++
+ config/user.m4 |  1 +
+ 2 files changed, 15 insertions(+)
+ create mode 100644 config/dkms.m4
+
+diff --git a/config/dkms.m4 b/config/dkms.m4
+new file mode 100644
+index 00000000..cfa11529
+--- /dev/null
++++ b/config/dkms.m4
+@@ -0,0 +1,14 @@
++dnl #
++dnl # Prevent manual building in DKMS source tree.
++dnl #
++AC_DEFUN([ZFS_AC_DKMS_INHIBIT], [
++	AC_MSG_CHECKING([for dkms.conf file])
++        AS_IF([test -e dkms.conf], [
++		AC_MSG_ERROR([
++	*** ZFS should not be manually built in the DKMS source tree.
++	*** Remove all ZFS packages before compiling the ZoL sources.
++	*** Running "make install" breaks ZFS packages.])
++        ], [
++		AC_MSG_RESULT([not found])
++        ])
++])
+diff --git a/config/user.m4 b/config/user.m4
+index 6ec27a5b..9a624ab5 100644
+--- a/config/user.m4
++++ b/config/user.m4
+@@ -2,6 +2,7 @@ dnl #
+ dnl # Default ZFS user configuration
+ dnl #
+ AC_DEFUN([ZFS_AC_CONFIG_USER], [
++	ZFS_AC_DKMS_INHIBIT
+ 	ZFS_AC_CONFIG_USER_GETTEXT
+ 	ZFS_AC_CONFIG_USER_MOUNT_HELPER
+ 	ZFS_AC_CONFIG_USER_SYSVINIT
+-- 
+2.39.2
+

--- a/app-admin/zfs/autobuild/patches/0002-Enable-zed-emails.patch
+++ b/app-admin/zfs/autobuild/patches/0002-Enable-zed-emails.patch
@@ -1,0 +1,28 @@
+From b13e17882e0fb3d14a9c500b5dfd3a30774687ed Mon Sep 17 00:00:00 2001
+From: Richard Laager <rlaager@wiktel.com>
+Date: Tue, 16 Jul 2024 15:30:50 +0800
+Subject: [PATCH 2/4] Enable zed emails
+
+The OpenZFS event daemon monitors pools. This patch enables the email sending function by default (if zed is installed). This is consistent with the default behavior of mdadm.
+
+See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd01921cfaa7ce1bad87/debian/patches/1005-enable-zed.patch
+---
+ cmd/zed/zed.d/zed.rc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmd/zed/zed.d/zed.rc b/cmd/zed/zed.d/zed.rc
+index bc269b15..e6d4b170 100644
+--- a/cmd/zed/zed.d/zed.rc
++++ b/cmd/zed/zed.d/zed.rc
+@@ -41,7 +41,7 @@ ZED_EMAIL_ADDR="root"
+ ##
+ # Minimum number of seconds between notifications for a similar event.
+ #
+-#ZED_NOTIFY_INTERVAL_SECS=3600
++ZED_NOTIFY_INTERVAL_SECS=3600
+ 
+ ##
+ # Notification verbosity.
+-- 
+2.39.2
+

--- a/app-admin/zfs/autobuild/patches/0003-Explicitly-load-the-ZFS-module-via-systemd-service.patch
+++ b/app-admin/zfs/autobuild/patches/0003-Explicitly-load-the-ZFS-module-via-systemd-service.patch
@@ -1,0 +1,105 @@
+From 14173a0ad45b770324a8f44962ffba9c92bf4105 Mon Sep 17 00:00:00 2001
+From: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+Date: Tue, 16 Jul 2024 15:35:34 +0800
+Subject: [PATCH 3/4] Explicitly load the ZFS module via systemd service
+
+See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd01921cfaa7ce1bad87/debian/patches/2100-zfs-load-module.patch
+---
+ contrib/dracut/90zfs/module-setup.sh.in        |  3 ++-
+ etc/Makefile.am                                |  1 +
+ etc/systemd/system/50-zfs.preset               |  1 +
+ etc/systemd/system/zfs-import-cache.service.in |  2 ++
+ etc/systemd/system/zfs-import-scan.service.in  |  2 ++
+ etc/systemd/system/zfs-load-module.service.in  | 17 +++++++++++++++++
+ 6 files changed, 25 insertions(+), 1 deletion(-)
+ create mode 100644 etc/systemd/system/zfs-load-module.service.in
+
+diff --git a/contrib/dracut/90zfs/module-setup.sh.in b/contrib/dracut/90zfs/module-setup.sh.in
+index acad468e..58a98d77 100755
+--- a/contrib/dracut/90zfs/module-setup.sh.in
++++ b/contrib/dracut/90zfs/module-setup.sh.in
+@@ -95,7 +95,8 @@ install() {
+ 
+ 		for _service in \
+ 			"zfs-import-scan.service" \
+-			"zfs-import-cache.service"; do
++			"zfs-import-cache.service" \
++            "zfs-load-module.service"; do
+ 			inst_simple "${systemdsystemunitdir}/${_service}"
+ 			systemctl -q --root "${initdir}" add-wants zfs-import.target "${_service}"
+ 
+diff --git a/etc/Makefile.am b/etc/Makefile.am
+index 7187762d..9ae38bd8 100644
+--- a/etc/Makefile.am
++++ b/etc/Makefile.am
+@@ -52,6 +52,7 @@ dist_systemdpreset_DATA = \
+ 	%D%/systemd/system/50-zfs.preset
+ 
+ systemdunit_DATA = \
++	%D%/systemd/system/zfs-load-module.service \
+ 	%D%/systemd/system/zfs-import-cache.service \
+ 	%D%/systemd/system/zfs-import-scan.service \
+ 	%D%/systemd/system/zfs-import.target \
+diff --git a/etc/systemd/system/50-zfs.preset b/etc/systemd/system/50-zfs.preset
+index e4056a92..b53e2c8a 100644
+--- a/etc/systemd/system/50-zfs.preset
++++ b/etc/systemd/system/50-zfs.preset
+@@ -7,3 +7,4 @@ enable zfs-share.service
+ enable zfs-zed.service
+ enable zfs-volume-wait.service
+ enable zfs.target
++enable zfs-load-module.service
+diff --git a/etc/systemd/system/zfs-import-cache.service.in b/etc/systemd/system/zfs-import-cache.service.in
+index fd822989..7e1fea5f 100644
+--- a/etc/systemd/system/zfs-import-cache.service.in
++++ b/etc/systemd/system/zfs-import-cache.service.in
+@@ -3,7 +3,9 @@ Description=Import ZFS pools by cache file
+ Documentation=man:zpool(8)
+ DefaultDependencies=no
+ Requires=systemd-udev-settle.service
++Requires=zfs-load-module.service
+ After=systemd-udev-settle.service
++After=zfs-load-module.service
+ After=cryptsetup.target
+ After=multipathd.service
+ After=systemd-remount-fs.service
+diff --git a/etc/systemd/system/zfs-import-scan.service.in b/etc/systemd/system/zfs-import-scan.service.in
+index c5dd45d8..ca506891 100644
+--- a/etc/systemd/system/zfs-import-scan.service.in
++++ b/etc/systemd/system/zfs-import-scan.service.in
+@@ -3,7 +3,9 @@ Description=Import ZFS pools by device scanning
+ Documentation=man:zpool(8)
+ DefaultDependencies=no
+ Requires=systemd-udev-settle.service
++Requires=zfs-load-module.service
+ After=systemd-udev-settle.service
++After=zfs-load-module.service
+ After=cryptsetup.target
+ After=multipathd.service
+ Before=zfs-import.target
+diff --git a/etc/systemd/system/zfs-load-module.service.in b/etc/systemd/system/zfs-load-module.service.in
+new file mode 100644
+index 00000000..d74af046
+--- /dev/null
++++ b/etc/systemd/system/zfs-load-module.service.in
+@@ -0,0 +1,17 @@
++[Unit]
++Description=Install ZFS kernel module
++DefaultDependencies=no
++Requires=systemd-udev-settle.service
++After=systemd-udev-settle.service
++After=cryptsetup.target
++Before=dracut-mount.service
++After=systemd-remount-fs.service
++
++[Service]
++Type=oneshot
++RemainAfterExit=yes
++ExecStart=/sbin/modprobe zfs
++
++[Install]
++WantedBy=zfs-mount.service
++WantedBy=zfs.target
+-- 
+2.39.2
+

--- a/app-admin/zfs/autobuild/patches/0004-Force-libtool-to-produce-verbose-output.patch
+++ b/app-admin/zfs/autobuild/patches/0004-Force-libtool-to-produce-verbose-output.patch
@@ -1,0 +1,26 @@
+From 8efc7a4277f960e8611f2ab5669e3a47d675f9d4 Mon Sep 17 00:00:00 2001
+From: Mo Zhou <lumin@debian.org>
+Date: Tue, 16 Jul 2024 15:37:19 +0800
+Subject: [PATCH 4/4] Force libtool to produce verbose output
+
+See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd01921cfaa7ce1bad87/debian/patches/force-verbose-rules.patch
+---
+ config/Rules.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config/Rules.am b/config/Rules.am
+index 2e463ae6..d71d8239 100644
+--- a/config/Rules.am
++++ b/config/Rules.am
+@@ -12,7 +12,7 @@ AM_CPPFLAGS = \
+ 	-I$(top_srcdir)/lib/libspl/include \
+ 	-I$(top_srcdir)/lib/libspl/include/os/@ac_system_l@
+ 
+-AM_LIBTOOLFLAGS = --silent
++AM_LIBTOOLFLAGS =
+ 
+ AM_CFLAGS  = -std=gnu99 -Wall -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wwrite-strings -Wno-sign-compare -Wno-missing-field-initializers
+ AM_CFLAGS += -fno-strict-aliasing
+-- 
+2.39.2
+

--- a/app-admin/zfs/autobuild/prepare
+++ b/app-admin/zfs/autobuild/prepare
@@ -1,6 +1,6 @@
 for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
     abinfo "Copying replacement $i ..."
-    cp -v /usr/share/automake-1.16/$(basename $i) $i ; \
+    cp -v /usr/bin/$(basename $i) $i ; \
 done
 
 abinfo "Calibrating postinst, prerm ..."

--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,4 +1,5 @@
 VER=2.2.4
+REL=1
 SRCS="tbl::https://github.com/zfsonlinux/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
 CHKSUMS="sha256::9790905f7683d41759418e1ef3432828c31116654ff040e91356ff1c21c31ec0"
 CHKUPDATE="anitya::id=11706"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Import some useful patches for app-admin/zfs from debian, including:

* Enable zed notifications by default.
* Disallow manual build of zfs in DKMS directory (i.e. running `./configure` in `/usr/src/zfs-$ver`, which would break building in dkms infra).
* Add a `zfs-load-module.service` to workaround some strange racing.
* Enable verbose output on building.

Ref: https://salsa.debian.org/zfsonlinux-team/zfs/-/tree/master/debian/patches

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

app-admin/zfs

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

Architectural progress for experimental ports does not impede on merging of this topic.

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
