### PR TITLE
xdg-user-dirs-gtk: update to 0.11

### DIFF
--- a/desktop-gnome/xdg-user-dirs-gtk/spec
+++ b/desktop-gnome/xdg-user-dirs-gtk/spec
@@ -1,5 +1,4 @@
-VER=0.10
-REL=3
+VER=0.11
 SRCS="tbl::https://download.gnome.org/sources/xdg-user-dirs-gtk/$VER/xdg-user-dirs-gtk-$VER.tar.xz"
-CHKSUMS="sha256::739a1a89baf34aa7261e924a21d2ae646b0475b67b3db3daa84327a99132d83e"
+CHKSUMS="sha256::534bd563d3c0e3f8dcbf3578cb8ab0e49d3ba41c966d477c8af9438364121e7d"
 CHKUPDATE="anitya::id=14875"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-user-dirs-gtk: update to 0.11
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- xdg-user-dirs-gtk: 0.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-user-dirs-gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
