### PR TITLE
fastfetch: update to 2.18.1

### DIFF
--- a/app-utils/fastfetch/autobuild/defines
+++ b/app-utils/fastfetch/autobuild/defines
@@ -2,4 +2,4 @@ PKGNAME=fastfetch
 PKGDES="A fast command-line system information tool"
 PKGSEC=utils
 PKGDEP="bash"
-BUILDDEP="pathlib libnma libpurple ddcutil gcc make xfconf imagemagick+7 libclc libcl opencl-registry-api opencl-clang vulkan-headers"
+BUILDDEP="pathlib libnma libpurple ddcutil gcc make xfconf imagemagick+7 libclc libcl opencl-registry-api opencl-clang vulkan-headers dbus zlib pkg-config"

--- a/app-utils/fastfetch/spec
+++ b/app-utils/fastfetch/spec
@@ -1,4 +1,4 @@
-VER=2.17.2
+VER=2.18.1
 SRCS="git::commit=tags/$VER::https://github.com/fastfetch-cli/fastfetch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=279670"


### PR DESCRIPTION
Topic Description
-----------------

- fastfetch: update to 2.18.1
    Co-authored-by: 温柔 (@xunpod)

Package(s) Affected
-------------------

- fastfetch: 2.18.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fastfetch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
