### PR TITLE
xwayland: update to 24.1.1

### DIFF
--- a/runtime-display/xwayland/spec
+++ b/runtime-display/xwayland/spec
@@ -1,4 +1,4 @@
-VER=24.1.0
+VER=24.1.1
 SRCS="tbl::https://xorg.freedesktop.org/archive/individual/xserver/xwayland-$VER.tar.xz"
-CHKSUMS="sha256::bef21c4f18807a4ed571c4e2df60ab63b5466bbd502ecceb2485b892ab76dcc2"
+CHKSUMS="sha256::7125bee0b10335805d7f5ba57dfaa359a7850af1a68524f1d97b362741a51832"
 CHKUPDATE="anitya::id=180949"


### PR DESCRIPTION
Topic Description
-----------------

- xwayland: update to 24.1.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xwayland: 24.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xwayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
