### PR TITLE
libavif: update to 1.1.0

### DIFF
--- a/runtime-multimedia/libavif/spec
+++ b/runtime-multimedia/libavif/spec
@@ -1,5 +1,4 @@
-VER=0.11.1
-REL=3
+VER=1.1.0
 SRCS="tbl::https://github.com/AOMediaCodec/libavif/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::0eb49965562a0e5e5de58389650d434cff32af84c34185b6c9b7b2fccae06d4e"
+CHKSUMS="sha256::edb31951005d7a143be1724f24825809599a4832073add50eaf987733defb5c8"
 CHKUPDATE="anitya::id=178015"


### PR DESCRIPTION
Topic Description
-----------------

- libavif: update to 1.1.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libavif: 1.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libavif
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
