### PR TITLE
obs-studio: update to 30.2.0

### DIFF
--- a/app-multimedia/obs-studio/autobuild/defines
+++ b/app-multimedia/obs-studio/autobuild/defines
@@ -2,11 +2,11 @@ PKGNAME=obs-studio
 PKGSEC=video
 
 PKGDEP="ffmpeg jansson libfdk-aac x11-lib libxkbcommon qt-6 curl imagemagick \
-        mbedtls sndio rnnoise pciutils libdatachannel"
+        mbedtls sndio rnnoise pciutils libdatachannel uthash"
 PKGDEP__INTEL_QSV="libvpl"
 PKGDEP__AMD64="${PKGDEP} ${PKGDEP__INTEL_QSV}"
 
-BUILDDEP="cmake x264 swig vlc pipewire jack patchelf python-3 nlohmann-json"
+BUILDDEP="cmake x264 swig vlc pipewire jack patchelf python-3 nlohmann-json ffnvcodec"
 BUILDDEP__AMD64="${BUILDDEP} luajit"
 BUILDDEP__ARM64="${BUILDDEP__AMD64}"
 BUILDDEP__LOONGSON3="${BUILDDEP__AMD64}"

--- a/app-multimedia/obs-studio/spec
+++ b/app-multimedia/obs-studio/spec
@@ -1,4 +1,4 @@
-VER=30.1.2
+VER=30.2.0
 # __OBS_CEF_VER: Find the build version on https://cef-builds.spotifycdn.com/index.html#linux64
 # FIXME: 126.x has https://github.com/chromiumembedded/cef/issues/3616#issuecomment-2158624330
 __OBS_CEF_VER="125.0.22+gc410c95+chromium-125.0.6422.142"
@@ -8,8 +8,7 @@ SRCS__AMD64="${SRCS} \
 SRCS__ARM64="${SRCS} \
             tbl::rename=cef.tar.bz2::https://cef-builds.spotifycdn.com/cef_binary_${__OBS_CEF_VER}_linuxarm64_minimal.tar.bz2"
 CHKSUMS="SKIP"
-CHKSUMS__AMD64="$CHKSUMS sha1::ee19988e7d8530a8aec334679d1b9d949c33d473"
-CHKSUMS__ARM64="$CHKSUMS sha1::7956e3ac60683577a3d45df33df646f50e4b720c"
+CHKSUMS__AMD64="$CHKSUMS sha256::9c99e4346bf4e07c81201186e67ef1f35d6204cde14957579a22dd55a49fdfda"
+CHKSUMS__ARM64="$CHKSUMS sha256::65e99652b4cd57f29d818bc7aa27f3be119a8ce0c69e59b1ea01af59583d0594"
 SUBDIR="obs-studio"
-REL=1
 CHKUPDATE="anitya::id=7239"

--- a/runtime-multimedia/ffnvcodec/spec
+++ b/runtime-multimedia/ffnvcodec/spec
@@ -1,4 +1,5 @@
-VER=11.1.5.1
-SRCS="tbl::https://github.com/FFmpeg/nv-codec-headers/releases/download/n$VER/nv-codec-headers-$VER.tar.gz"
-CHKSUMS="sha256::a28cdde3ac0e9e02c2dde7a1b4de5333b4ac6148a8332ca712da243a3361a0d9"
+# FIXME: obs-studio requires 12.0.0.0<=VERSION<12.2.0.0
+VER=12.1.14.0
+SRCS="git::commit=tags/n$VER::https://github.com/FFmpeg/nv-codec-headers"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=223796"


### PR DESCRIPTION
Topic Description
-----------------

- ffnvcodec: update to 12.1.14.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- obs-studio: update to 30.2.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- ffnvcodec: 12.1.14.0
- obs-studio: 30.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffnvcodec obs-studio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
