### PR TITLE
zfs: run autoreconf in prepare

### DIFF
--- a/app-admin/zfs/autobuild/build
+++ b/app-admin/zfs/autobuild/build
@@ -36,7 +36,7 @@ abinfo "Cleaning up ZFS kernel module source tree ..."
 find "${PKGDIR}"/usr/src/zfs-${PKGVER} -name ".git*" -print0 | \
     xargs -0 rm -vfr --
 
-abinfo "Generating DKMS configuration"
+abinfo "Generating DKMS configuration ..."
 "${PKGDIR}"/usr/src/zfs-${PKGVER}/scripts/dkms.mkconf \
     -v ${PKGVER} \
     -f "${PKGDIR}"/usr/src/zfs-${PKGVER}/dkms.conf \

--- a/app-admin/zfs/autobuild/prepare
+++ b/app-admin/zfs/autobuild/prepare
@@ -8,3 +8,6 @@ sed -e "s|\@ZFSVER\@|$PKGVER|g" \
     -i "$SRCDIR"/autobuild/postinst
 sed -e "s|\@ZFSVER\@|$PKGVER|g" \
     -i "$SRCDIR"/autobuild/prerm
+
+abinfo "Re-generating Autotools scripts ..."
+autoreconf -fvi

--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,5 +1,5 @@
 VER=2.2.4
-REL=1
+REL=2
 SRCS="tbl::https://github.com/zfsonlinux/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
 CHKSUMS="sha256::9790905f7683d41759418e1ef3432828c31116654ff040e91356ff1c21c31ec0"
 CHKUPDATE="anitya::id=11706"


### PR DESCRIPTION
Topic Description
-----------------

- zfs: run autoreconf in prepare
    Signed-off-by: Shengqi Chen <harry-chen@outlook.com>

Package(s) Affected
-------------------

- zfs: 2.2.4-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit zfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
