### PR TITLE
libwebsockets: update to 4.3.3

### DIFF
--- a/app-games/ddnet/spec
+++ b/app-games/ddnet/spec
@@ -1,4 +1,5 @@
 VER=18.3
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/ddnet/ddnet"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138153"

--- a/app-multimedia/owntone/autobuild/defines
+++ b/app-multimedia/owntone/autobuild/defines
@@ -1,5 +1,6 @@
 PKGNAME=owntone
 PKGSEC=sound
 PKGDEP="avahi confuse mxml ffmpeg libwebsockets protobuf-c libplist"
+BUILDDEP="gperf"
 PKGDES="Linux DAAP (iTunes) and MPD media server with Airplay speakers support and more"
 PKGREP="forked-daapd"

--- a/app-multimedia/owntone/spec
+++ b/app-multimedia/owntone/spec
@@ -1,4 +1,5 @@
 VER=28.9
-SRCTBL="https://github.com/owntone/owntone-server/releases/download/${VER}/owntone-${VER}.tar.xz"
-CHKSUM="sha256::76671ab46315566541018fd404cec315b7d0f9d4c9b9dbc51fcdae7fca7be832"
+REL=1
+SRCS="git::commit=tags/$VER::https://github.com/owntone/owntone-server"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230673"

--- a/app-multimedia/owntone/spec
+++ b/app-multimedia/owntone/spec
@@ -1,5 +1,5 @@
 VER=28.9
 REL=1
-SRCS="git::commit=tags/$VER::https://github.com/owntone/owntone-server"
-CHKSUMS="SKIP"
+SRCS="tbl::https://github.com/owntone/owntone-server/releases/download/$VER/owntone-$VER.tar.xz"
+CHKSUMS="sha256::76671ab46315566541018fd404cec315b7d0f9d4c9b9dbc51fcdae7fca7be832"
 CHKUPDATE="anitya::id=230673"

--- a/runtime-web/libwebsockets/spec
+++ b/runtime-web/libwebsockets/spec
@@ -1,5 +1,4 @@
-VER=3.1.0
-REL=4
+VER=4.3.3
 SRCS="tbl::https://github.com/warmcat/libwebsockets/archive/v$VER.tar.gz"
-CHKSUMS="sha256::db948be74c78fc13f1f1a55e76707d7baae3a1c8f62b625f639e8f2736298324"
+CHKSUMS="sha256::6fd33527b410a37ebc91bb64ca51bdabab12b076bc99d153d7c5dd405e4bdf90"
 CHKUPDATE="anitya::id=11181"

--- a/runtime-web/libwebsockets/spec
+++ b/runtime-web/libwebsockets/spec
@@ -1,4 +1,4 @@
 VER=4.3.3
-SRCS="tbl::https://github.com/warmcat/libwebsockets/archive/v$VER.tar.gz"
-CHKSUMS="sha256::6fd33527b410a37ebc91bb64ca51bdabab12b076bc99d153d7c5dd405e4bdf90"
+SRCS="git::commit=tags/v$VER::https://github.com/warmcat/libwebsockets"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11181"


### PR DESCRIPTION
Topic Description
-----------------

- owntone: rebuild for libwebsocket
- ddnet: rebuild for libwebsocket
- libwebsockets: update to 4.3.3
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- ddnet: 18.3-1
- libwebsockets: 4.3.3
- owntone: 28.9-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libwebsockets ddnet owntone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
