### PR TITLE
exim: update to 4.98

### DIFF
--- a/app-web/exim/spec
+++ b/app-web/exim/spec
@@ -1,5 +1,4 @@
-VER=4.97.1
-REL=1
+VER=4.98
 SRCS="git::commit=exim-$VER;copy-repo=true::https://github.com/Exim/exim"
 CHKSUMS="SKIP"
 SUBDIR="exim/src"


### PR DESCRIPTION
Topic Description
-----------------

- exim: update to 4.98
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- exim: 4.98

Security Update?
----------------

No

Build Order
-----------

```
#buildit exim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
