### PR TITLE
audacity: update to 3.5.1

### DIFF
--- a/app-creativity/audacity/spec
+++ b/app-creativity/audacity/spec
@@ -1,5 +1,4 @@
-VER=3.4.2
-REL=1
+VER=3.5.1
 SRCS="git::commit=tags/Audacity-$VER::https://github.com/audacity/audacity"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=139"


### PR DESCRIPTION
Topic Description
-----------------

- audacity: update to 3.5.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- audacity: 3.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit audacity
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
