### PR TITLE
audacity: update to 3.6.0

### DIFF
--- a/app-creativity/audacity/autobuild/defines
+++ b/app-creativity/audacity/autobuild/defines
@@ -21,4 +21,5 @@ CMAKE_AFTER="-Daudacity_use_ffmpeg=loaded \
              -Daudacity_has_url_schemes_support=ON \
              -DwxBUILD_TOOLKIT=gtk3 \
              -DAUDACITY_BUILD_LEVEL=2 \
-             -DCMAKE_SKIP_RPATH=OFF"
+             -DCMAKE_SKIP_RPATH=OFF \
+             -DCMAKE_SKIP_INSTALL_RPATH=OFF"

--- a/app-creativity/audacity/spec
+++ b/app-creativity/audacity/spec
@@ -1,5 +1,4 @@
-VER=3.4.2
-REL=1
+VER=3.6.0
 SRCS="git::commit=tags/Audacity-$VER::https://github.com/audacity/audacity"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=139"


### PR DESCRIPTION
Topic Description
-----------------

- audacity: update to 3.6.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- audacity: 3.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit audacity
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
