### PR TITLE
Chromium, Google Chrome: update to 126.0.6478.182

### DIFF
--- a/app-web/chromium/autobuild/patches/2013-Debian-blink-header2.patch
+++ b/app-web/chromium/autobuild/patches/2013-Debian-blink-header2.patch
@@ -1,0 +1,39 @@
+commit f3fce92b27296068b4c304321b53bd1c7c4beb61
+Author: lauren n. liberda <lauren@selfisekai.rocks>
+Date:   Tue May 28 17:54:26 2024 +0000
+
+    iwyu: missing <optional> in page_popup_controller.h
+    
+    Bug: 41455655
+    Change-Id: I6483b9ec9d3c4acc08fb2bce8cac409c32a06dc4
+    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5569043
+    Reviewed-by: Lei Zhang <thestig@chromium.org>
+    Commit-Queue: Lei Zhang <thestig@chromium.org>
+    Reviewed-by: Khushal Sagar <khushalsagar@chromium.org>
+    Cr-Commit-Position: refs/heads/main@{#1306871}
+
+diff --git a/AUTHORS b/AUTHORS
+index eba1dc976d8fa..715e108aca1c3 100644
+--- a/AUTHORS
++++ b/AUTHORS
+@@ -818,6 +818,7 @@ Lalit Chandivade <lalit.chandivade@einfochips.com>
+ Lam Lu <lamlu@amazon.com>
+ Laszlo Gombos <l.gombos@samsung.com>
+ Laszlo Radanyi <bekkra@gmail.com>
++lauren n. liberda <lauren@selfisekai.rocks>
+ Lauren Yeun Kim <lauren.yeun.kim@gmail.com>
+ Lauri Oherd <lauri.oherd@gmail.com>
+ Lavar Askew <open.hyperion@gmail.com>
+diff --git a/third_party/blink/renderer/core/page/page_popup_controller.h b/third_party/blink/renderer/core/page/page_popup_controller.h
+index 5da38d0b9ab26..c4e8e865fa96d 100644
+--- a/third_party/blink/renderer/core/page/page_popup_controller.h
++++ b/third_party/blink/renderer/core/page/page_popup_controller.h
+@@ -31,6 +31,8 @@
+ #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_PAGE_POPUP_CONTROLLER_H_
+ #define THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_PAGE_POPUP_CONTROLLER_H_
+ 
++#include <optional>
++
+ #include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
+ #include "third_party/blink/renderer/platform/heap/collection_support/heap_vector.h"
+ #include "third_party/blink/renderer/platform/heap/garbage_collected.h"

--- a/app-web/chromium/spec
+++ b/app-web/chromium/spec
@@ -1,11 +1,11 @@
-VER=126.0.6478.114
+VER=126.0.6478.182
 LAUNCHERVER=8
 SRCS="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$VER.tar.xz \
       https://github.com/foutrelis/chromium-launcher/archive/v$LAUNCHERVER.tar.gz \
       file::rename=chromium-$VER.txt::https://chromium.googlesource.com/chromium/src/+/$VER?format=TEXT"
-CHKSUMS="sha256::cf4aad7fccc2a6c2339691c23f4c46ef2818e2474a9f83292b237eaa958015ed \
+CHKSUMS="sha256::3939f5b3116ebd3cb15ff8c7059888f6b00f4cfa8a77bde983ee4ce5d0eea427 \
          sha256::213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a \
-         sha256::886bf0ece16481aa112b7b9d63042eb25a482aeaddf2ef7326430b0beecb996e"
+         sha256::b556eb3f28a8824066cb0536925a2b59736f5145c682eb68111878b422a95a74"
 SUBDIR="chromium-$VER"
 CHKUPDATE="anitya::id=13344"
 ENVREQ__AMD64="core=96"

--- a/app-web/google-chrome/spec
+++ b/app-web/google-chrome/spec
@@ -1,4 +1,4 @@
-VER=126.0.6478.126
+VER=126.0.6478.182
 SRCS="file::rename=google-chrome-stable_current_amd64.deb::https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_$VER-1_amd64.deb"
-CHKSUMS="sha256::3ec1cadbb55cf66cc51f0421eace324a88836ee2d982b945b8f67a3f131b0924"
+CHKSUMS="sha256::8b3cf7a0424049c235315de90472f3c3108ab3a33ead33917ab9ef2efdec0580"
 CHKUPDATE="anitya::id=5349"


### PR DESCRIPTION
Topic Description
-----------------

- google-chrome: update to 126.0.6478.182
- chromium: update to 126.0.6478.182

Package(s) Affected
-------------------

- chromium: 126.0.6478.182
- google-chrome: 126.0.6478.182

Security Update?
----------------

No

Build Order
-----------

```
#buildit chromium google-chrome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
