### PR TITLE
telegram-desktop: update to 5.2.3

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,7 +1,7 @@
-From 6c4147b6dc8e7ad284c44a66e9ed4961cdc42fcb Mon Sep 17 00:00:00 2001
+From 255baee7fed520ca1a2474e2cb1ff7cf86367cda Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
-Subject: [PATCH 1/5] fix(window.style): set default window width to 360px
+Subject: [PATCH 1/6] fix(window.style): set default window width to 360px
 
 This allows the Telegram window to scale properly on the PinePhone.
 ---
@@ -9,7 +9,7 @@ This allows the Telegram window to scale properly on the PinePhone.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Telegram/SourceFiles/window/window.style b/Telegram/SourceFiles/window/window.style
-index 8b13c0a..5171c15 100644
+index 37654c9..c6d2d67 100644
 --- a/Telegram/SourceFiles/window/window.style
 +++ b/Telegram/SourceFiles/window/window.style
 @@ -10,7 +10,7 @@ using "ui/widgets/widgets.style";
@@ -31,5 +31,5 @@ index 8b13c0a..5171c15 100644
  columnMaximalWidthThird: 392px;
  
 -- 
-2.45.0
+2.45.2
 

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,7 +1,7 @@
-From a105362dd037c7582f4876b03bd18dbc1a23d626 Mon Sep 17 00:00:00 2001
+From b860c69610609eaa25ffe28e3fb2df29d1d49632 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
-Subject: [PATCH 2/5] fix(core_settings.h): use system window decoration by
+Subject: [PATCH 2/6] fix(core_settings.h): use system window decoration by
  default
 
 ---
@@ -9,11 +9,11 @@ Subject: [PATCH 2/5] fix(core_settings.h): use system window decoration by
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 9ebd488..4b51d48 100644
+index 3412c45..1ae4bb1 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
-@@ -972,7 +972,7 @@ private:
- 	rpl::variable<float64> _dialogsWidthRatio; // per-window
+@@ -986,7 +986,7 @@ private:
+ 	rpl::variable<float64> _dialogsNoChatWidthRatio; // per-window
  	rpl::variable<int> _thirdColumnWidth = kDefaultThirdColumnWidth; // p-w
  	bool _notifyFromAll = true;
 -	rpl::variable<bool> _nativeWindowFrame = false;
@@ -22,5 +22,5 @@ index 9ebd488..4b51d48 100644
  	rpl::variable<bool> _systemDarkModeEnabled = false;
  	rpl::variable<WindowTitleContent> _windowTitleContent;
 -- 
-2.45.0
+2.45.2
 

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,7 +1,7 @@
-From f6758eea1483fee957f0da419005cfe5354b3a59 Mon Sep 17 00:00:00 2001
+From 134afbc0a7e3f56c88afb4fb63a176ac16c9ff6c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
-Subject: [PATCH 3/5] fix(ui): fix build with Qt 5
+Subject: [PATCH 3/6] fix(ui): fix build with Qt 5
 
 Co-authored-by: Henry Chen <chenx97@aosc.io>
 ---
@@ -12,10 +12,10 @@ Co-authored-by: Henry Chen <chenx97@aosc.io>
  4 files changed, 8 insertions(+)
 
 diff --git a/Telegram/lib_ui/ui/text/text_entity.cpp b/Telegram/lib_ui/ui/text/text_entity.cpp
-index 7083ac9..81176e9 100644
+index 3d40068..d96a4cd 100644
 --- a/Telegram/lib_ui/ui/text/text_entity.cpp
 +++ b/Telegram/lib_ui/ui/text/text_entity.cpp
-@@ -2350,6 +2350,8 @@ EntityInText::EntityInText(
+@@ -2384,6 +2384,8 @@ EntityInText::EntityInText(
  , _data(data) {
  }
  
@@ -25,10 +25,10 @@ index 7083ac9..81176e9 100644
  		const EntitiesInText &entities,
  		int textLength) {
 diff --git a/Telegram/lib_ui/ui/text/text_entity.h b/Telegram/lib_ui/ui/text/text_entity.h
-index 10bddc2..02ec5f7 100644
+index f6ba110..0961743 100644
 --- a/Telegram/lib_ui/ui/text/text_entity.h
 +++ b/Telegram/lib_ui/ui/text/text_entity.h
-@@ -70,6 +70,8 @@ public:
+@@ -71,6 +71,8 @@ public:
  		int length,
  		const QString &data = QString());
  
@@ -38,7 +38,7 @@ index 10bddc2..02ec5f7 100644
  		return _type;
  	}
 diff --git a/Telegram/lib_webview/CMakeLists.txt b/Telegram/lib_webview/CMakeLists.txt
-index b1d3299..9496a1d 100644
+index 1bd7385..98d623a 100644
 --- a/Telegram/lib_webview/CMakeLists.txt
 +++ b/Telegram/lib_webview/CMakeLists.txt
 @@ -7,6 +7,7 @@
@@ -50,23 +50,23 @@ index b1d3299..9496a1d 100644
  get_filename_component(src_loc . REALPATH)
  
 diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
-index c4e2228..1f3a863 100644
+index 0e2ee87..99a54ed 100644
 --- a/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
 +++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
-@@ -42,6 +42,7 @@ private:
+@@ -53,6 +53,7 @@ private:
  };
  
- class Output : public QWaylandQuickOutput {
+ class Compositor::Output : public QWaylandQuickOutput {
 +	Q_OBJECT
  public:
- 	Output(
- 			QWaylandCompositor *compositor,
-@@ -260,3 +261,5 @@ void Compositor::setWidget(QQuickWidget *widget) {
+ 	Output(Compositor *compositor, QObject *parent = nullptr)
+ 	: _xdg(this, &compositor->_private->xdgOutput) {
+@@ -302,3 +303,5 @@ void Compositor::setWidget(QQuickWidget *widget) {
  }
  
  } // namespace Webview
 +
 +#include "webview_linux_compositor.moc"
 -- 
-2.45.0
+2.45.2
 

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,7 +1,7 @@
-From 381d19fc01f0c526ee411b6b6e9469dc9a722059 Mon Sep 17 00:00:00 2001
+From e72847cc84a8516f544abd5ba6131eb16daab597 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
-Subject: [PATCH 4/5] fix(core/launcher.cpp): revert to old HiDPI handling
+Subject: [PATCH 4/6] fix(core/launcher.cpp): revert to old HiDPI handling
  behaviour
 
 The current implementation makes icons blurry in Qt 5 builds, whilst
@@ -28,5 +28,5 @@ index 0b6afb7..f38dd54 100644
  
  	if (OptionFractionalScalingEnabled.value()) {
 -- 
-2.45.0
+2.45.2
 

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,4 +1,4 @@
-From dc2c01f8ca398eeedb2a0a96583fd119a5d09444 Mon Sep 17 00:00:00 2001
+From fa2ee89ba6827bc6b23c360e043b26cc8b4ead23 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
 Subject: [PATCH 5/6] fix(settings): use system fonts by default
@@ -8,7 +8,7 @@ Subject: [PATCH 5/6] fix(settings): use system fonts by default
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 4b51d48..885b627 100644
+index 1ae4bb1..55f7847 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
 @@ -11,6 +11,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
@@ -19,15 +19,15 @@ index 4b51d48..885b627 100644
  #include "base/flags.h"
  #include "emoji.h"
  
-@@ -1006,7 +1007,7 @@ private:
+@@ -1020,7 +1021,7 @@ private:
  	rpl::variable<bool> _storiesClickTooltipHidden = false;
  	rpl::variable<bool> _ttlVoiceClickTooltipHidden = false;
  	WindowPosition _ivPosition;
 -	QString _customFontFamily;
 +	QString _customFontFamily = style::SystemFontTag();
+ 	bool _systemUnlockEnabled = false;
  
  	bool _tabbedReplacedWithInfo = false; // per-window
- 	rpl::event_stream<bool> _tabbedReplacedWithInfoValue; // per-window
 -- 
-2.45.0
+2.45.2
 

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,4 +1,4 @@
-From 37f179c8755f67fe041a8f669bd2e7144568c15f Mon Sep 17 00:00:00 2001
+From 2d32331be0da7b8950356253fa4b09753bc0f819 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
 Subject: [PATCH 6/6] Remove the confusing "Default" option from selectable
@@ -9,7 +9,7 @@ Subject: [PATCH 6/6] Remove the confusing "Default" option from selectable
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
-index 512e8a6..c627116 100644
+index 80168ca..d90d318 100644
 --- a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
 +++ b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
 @@ -531,7 +531,7 @@ std::vector<Selector::Entry> Selector::FullList(const QString &now) {
@@ -29,9 +29,9 @@ index 512e8a6..c627116 100644
  	add(tr::lng_font_system(tr::now), style::SystemFontTag());
  	for (const auto &family : families) {
  		if (database.isScalable(family)) {
-@@ -549,12 +548,12 @@ std::vector<Selector::Entry> Selector::FullList(const QString &now) {
- 	if (!ranges::contains(result, now, &Entry::id)) {
+@@ -551,12 +550,12 @@ std::vector<Selector::Entry> Selector::FullList(const QString &now) {
  		result.push_back({ .id = now });
+ 		nowIt = end(result) - 1;
  	}
 -	for (auto i = begin(result) + 2; i != end(result); ++i) {
 +	for (auto i = begin(result) + 1; i != end(result); ++i) {
@@ -39,11 +39,11 @@ index 512e8a6..c627116 100644
  		i->text = i->id;
  		i->keywords = TextUtilities::PrepareSearchWords(i->id);
  	}
--	ranges::sort(begin(result) + 2, end(result), std::less<>(), &Entry::key);
-+	ranges::sort(begin(result) + 1, end(result), std::less<>(), &Entry::key);
- 	return result;
- }
- 
+-	auto skip = 2;
++	auto skip = 1;
+ 	if (nowIt - begin(result) >= skip) {
+ 		std::swap(result[2], *nowIt);
+ 		++skip;
 -- 
-2.45.0
+2.45.2
 

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=5.0.1
-REL=3
+VER=5.2.3
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=afd9d5d31798d3eacf9ed6c30601e91d0f1e4d60
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::728bf0cf4c795ef3c481c958ab9b2a8e4799679f6ad7e823723b984dd3ce72d8 \
+CHKSUMS="sha256::d36a08859b4fb4dfdac0febbfcec9bd825ebcb4e8a0e937061870c03d51f320f \
          SKIP"
 SUBDIR="tdesktop-$VER-full"
 CHKUPDATE="anitya::id=16951"
 ENVREQ__ARM64="total_mem_per_core=3"
+ENVREQ__LOONGARCH64="total_mem_per_core=4"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 5.2.3
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- telegram-desktop: 5.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
