### PR TITLE
verilator: update to 5.026

### DIFF
--- a/app-electronics/verilator/autobuild/patches/0001-Fix-binary-install-path.patch
+++ b/app-electronics/verilator/autobuild/patches/0001-Fix-binary-install-path.patch
@@ -1,0 +1,75 @@
+From a1f8cba0e9deedb9db835eba7b798a6e04a4ec83 Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Wed, 17 Jul 2024 17:29:43 +0800
+Subject: [PATCH] Fix binary install path
+
+---
+ Makefile.in  | 14 +++++++++-----
+ configure.ac |  3 ++-
+ 2 files changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 88de77fda..d963d8402 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -80,6 +80,10 @@ infodir = @infodir@
+ # Generally ${prefix}/share/verilator
+ pkgdatadir = @pkgdatadir@
+ 
++# Directory in which to install package specific libraries
++# Generally $(prefix}/lib/verilator
++pkglibdir = @pkglibdir@
++
+ # Directory in which to install pkgconfig file
+ # Generally ${prefix}/share/pkgconfig
+ pkgconfigdir = @pkgconfigdir@
+@@ -238,27 +242,27 @@ VL_INST_DATA_SRCDIR_FILES = \
+ 	examples/*/vl_* \
+ 
+ mkbindirs:
+-	$(MKINSTALLDIRS) $(DESTDIR)$(pkgdatadir)/bin
++	$(MKINSTALLDIRS) $(DESTDIR)$(pkglibdir)/bin
+ 	$(MKINSTALLDIRS) $(DESTDIR)$(bindir)
+ 
+ installbin: | mkbindirs
+ 	cd $(srcdir)/bin; \
+ 	for p in $(VL_INST_PUBLIC_SCRIPT_FILES) ; do \
+-	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(pkgdatadir)/bin/$$p; \
++	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(pkglibdir)/bin/$$p; \
+ 	done
+ 	cd bin; \
+ 	for p in $(VL_INST_PUBLIC_BIN_FILES) ; do \
+-	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(pkgdatadir)/bin/$$p; \
++	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(pkglibdir)/bin/$$p; \
+ 	done
+ 	cd $(srcdir)/bin; \
+ 	for p in $(VL_INST_PRIVATE_SCRIPT_FILES) ; do \
+-	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(pkgdatadir)/bin/$$p; \
++	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(pkglibdir)/bin/$$p; \
+ 	done
+ 
+ installredirect: installbin | mkbindirs
+ 	cp ${srcdir}/bin/redirect ${srcdir}/bin/redirect.tmp
+ 	perl -p -i -e 'use File::Spec;' \
+-	           -e' $$path = File::Spec->abs2rel("$(realpath $(DESTDIR)$(pkgdatadir)/bin)", "$(realpath $(DESTDIR)$(bindir))");' \
++	           -e' $$path = File::Spec->abs2rel("$(realpath $(DESTDIR)$(pkglibdir)/bin)", "$(realpath $(DESTDIR)$(bindir))");' \
+ 	           -e 's/RELPATH.*/"$$path";/g' -- "${srcdir}/bin/redirect.tmp"
+ 	cd $(srcdir)/bin; \
+ 	for p in $(VL_INST_PUBLIC_SCRIPT_FILES) $(VL_INST_PUBLIC_BIN_FILES) ; do \
+diff --git a/configure.ac b/configure.ac
+index 4f4fb6432..9793c85fb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -612,7 +612,8 @@ pkgdatadir=${datadir}/verilator
+ AC_SUBST(pkgdatadir)
+ pkgconfigdir=${datadir}/pkgconfig
+ AC_SUBST(pkgconfigdir)
+-
++pkglibdir=${libdir}/verilator
++AC_SUBST(pkglibdir)
+ AC_OUTPUT
+ 
+ AC_MSG_RESULT([])
+-- 
+2.45.2
+

--- a/app-electronics/verilator/autobuild/prepare
+++ b/app-electronics/verilator/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Preparing Verilator..."
+autoconf

--- a/app-electronics/verilator/spec
+++ b/app-electronics/verilator/spec
@@ -1,5 +1,4 @@
-VER=4.204
-SRCS="tbl::https://www.veripool.org/ftp/verilator-$VER.tgz"
-CHKSUMS="sha256::7fd520ca15a997bc98482a3075211bb80095709f329dcc13c4eb5c8ae01cef34"
+VER=5.026
+SRCS="git::copy-repo=true;commit=tags/v${VER}::https://github.com/verilator/verilator"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5085"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- verilator: update to 5.026

Package(s) Affected
-------------------

- verilator: 5.026

Security Update?
----------------

No

Build Order
-----------

```
#buildit verilator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
