### PR TITLE
udns: update to 0.5

### DIFF
--- a/app-network/udns/spec
+++ b/app-network/udns/spec
@@ -1,5 +1,4 @@
-VER=0.4
-REL=2
+VER=0.5
 SRCS="tbl::https://www.corpit.ru/mjt/udns/udns-$VER.tar.gz"
-CHKSUMS="sha256::115108dc791a2f9e99e150012bcb459d9095da2dd7d80699b584ac0ac3768710"
+CHKSUMS="sha256::035bfc12e3819d0aba8f40ee8220a974b7e9b29c3259d310970cc4b2d1c203c0"
 CHKUPDATE="anitya::id=5031"


### PR DESCRIPTION
Topic Description
-----------------

- udns: update to 0.5
    Co-authored-by: Suyun (@Suyun114)

Package(s) Affected
-------------------

- udns: 0.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit udns
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
