### PR TITLE
opus: update to 1.5.2

### DIFF
--- a/runtime-multimedia/opus/spec
+++ b/runtime-multimedia/opus/spec
@@ -1,4 +1,4 @@
-VER=1.3.1
+VER=1.5.2
 SRCS="tbl::https://downloads.xiph.org/releases/opus/opus-$VER.tar.gz"
-CHKSUMS="sha256::65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d"
+CHKSUMS="sha256::65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1"
 CHKUPDATE="anitya::id=11081"


### PR DESCRIPTION
Topic Description
-----------------

- opus: update to 1.5.2
    Co-authored-by: Suyun (@Suyun114)

Package(s) Affected
-------------------

- opus: 1.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit opus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
