### PR TITLE
xsel: update to 1.2.1

### DIFF
--- a/app-utils/xsel/autobuild/build
+++ b/app-utils/xsel/autobuild/build
@@ -1,0 +1,8 @@
+abinfo "Configuring xsel ..."
+"$SRCDIR"/autogen.sh --prefix=/usr
+
+abinfo "Building xsel ..."
+make
+
+abinfo "Installing xsel ..."
+make install DESTDIR="$PKGDIR"

--- a/app-utils/xsel/autobuild/prepare
+++ b/app-utils/xsel/autobuild/prepare
@@ -1,1 +1,0 @@
-export CFLAGS="${CFLAGS} -Wno-error=stringop-truncation"

--- a/app-utils/xsel/spec
+++ b/app-utils/xsel/spec
@@ -1,5 +1,4 @@
-VER=1.2.0
-REL=2
-SRCS="tbl::http://www.vergenet.net/~conrad/software/xsel/download/xsel-$VER.tar.gz"
-CHKSUMS="sha256::b927ce08dc82f4c30140223959b90cf65e1076f000ce95e520419ec32f5b141c"
+VER=1.2.1
+SRCS="git::commit=tags/$VER::https://github.com/kfish/xsel"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13995"


### PR DESCRIPTION
Topic Description
-----------------

- xsel: update to 1.2.1

Package(s) Affected
-------------------

- xsel: 1.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xsel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
