### PR TITLE
Revert "opus: update to 1.5.2"

### DIFF
--- a/runtime-multimedia/opus/spec
+++ b/runtime-multimedia/opus/spec
@@ -1,4 +1,4 @@
-VER=1.5.2
+VER=1.3.1
 SRCS="tbl::https://downloads.xiph.org/releases/opus/opus-$VER.tar.gz"
-CHKSUMS="sha256::65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1"
+CHKSUMS="sha256::65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d"
 CHKUPDATE="anitya::id=11081"


### PR DESCRIPTION
Reverts AOSC-Dev/aosc-os-abbs#7062 (needs rebuild rev deps)