### PR TITLE
libglvnd: temporary Spiral fix for Tencent QQ

### DIFF
--- a/runtime-display/libglvnd/autobuild/defines
+++ b/runtime-display/libglvnd/autobuild/defines
@@ -15,3 +15,22 @@ AUTOTOOLS_AFTER="PYTHON=/usr/bin/python3"
 AUTOTOOLS_AFTER__LOONGARCH64=" \
                  --disable-asm \
                  PYTHON=/usr/bin/python3"
+
+# FIXME: Spiral does not check for libraries in /usr/lib/glvnd.
+# FIXME: Manually specified _spiral provides do not have :$ARCH suffix.
+PKGPROV="""
+libegl-dev_spiral
+libegl1_spiral
+libgl-dev_spiral
+libgl1_spiral
+libgles-dev_spiral
+libgles1_spiral
+libgles2_spiral
+libglvnd-core-dev_spiral
+libglvnd-dev_spiral
+libglvnd0_spiral
+libglx-dev_spiral
+libglx0_spiral
+libopengl-dev_spiral
+libopengl0_spiral
+"""

--- a/runtime-display/libglvnd/spec
+++ b/runtime-display/libglvnd/spec
@@ -1,4 +1,5 @@
 VER=1.7.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/NVIDIA/libglvnd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12098"


### PR DESCRIPTION
Topic Description
-----------------

- libglvnd: manually specify Spiral provides
    Temporary fix needed for Tencent QQ. To be addressed in Autobuild4, see FIXMEs.

Package(s) Affected
-------------------

- libglvnd: 1.7.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libglvnd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
