### PR TITLE
libgcrypt: rebuild for missing Spiral markers

### DIFF
--- a/runtime-cryptography/libgcrypt/spec
+++ b/runtime-cryptography/libgcrypt/spec
@@ -1,4 +1,5 @@
 VER=1.11.0
+REL=1
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-$VER.tar.bz2"
 CHKSUMS="sha256::09120c9867ce7f2081d6aaa1775386b98c2f2f246135761aae47d81f58685b9c"
 CHKUPDATE="anitya::id=1623"


### PR DESCRIPTION
Topic Description
-----------------

- libgcrypt: rebuild for missing Spiral markers
    A previous Autobuild 4.3 version broke Spiral markers for packages with
    multiple package name matches. Rebuild this package to fix broken provides in
    the previous package.

Package(s) Affected
-------------------

- libgcrypt: 1.11.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgcrypt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
