### PR TITLE
qemu (QEMU): install binfmt configuration conditionally for official ports

### DIFF
--- a/app-virtualization/qemu/02-static-aarch64/arm64/beyond
+++ b/app-virtualization/qemu/02-static-aarch64/arm64/beyond
@@ -1,2 +1,0 @@
-abinfo "Removing unneeded binfmt configuration ..."
-rm -v "$PKGDIR"/usr/lib/binfmt.d/qemu-aarch64.conf

--- a/app-virtualization/qemu/02-static-aarch64/build
+++ b/app-virtualization/qemu/02-static-aarch64/build
@@ -6,6 +6,9 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch arm64; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/03-static-alpha/build
+++ b/app-virtualization/qemu/03-static-alpha/build
@@ -6,6 +6,9 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch alpha; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/04-static-arm/build
+++ b/app-virtualization/qemu/04-static-arm/build
@@ -6,6 +6,11 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch armv4 && \
+   ! ab_match_arch armv6hf && \
+   ! ab_match_arch armv7hf; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/08-static-m68k/build
+++ b/app-virtualization/qemu/08-static-m68k/build
@@ -6,6 +6,9 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch m68k; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/13-static-mips64el/build
+++ b/app-virtualization/qemu/13-static-mips64el/build
@@ -6,6 +6,10 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch loongson2f && \
+   ! ab_match_arch loongson3; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/13-static-mips64el/loongson3/beyond
+++ b/app-virtualization/qemu/13-static-mips64el/loongson3/beyond
@@ -1,2 +1,0 @@
-abinfo "Removing unneeded binfmt configuration ..."
-rm -f "$PKGDIR"/usr/lib/binfmt.d/qemu-mips64el.conf

--- a/app-virtualization/qemu/14-static-mipsel/build
+++ b/app-virtualization/qemu/14-static-mipsel/build
@@ -6,6 +6,10 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch loongson2f && \
+   ! ab_match_arch loongson3; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/14-static-mipsel/loongson3/beyond
+++ b/app-virtualization/qemu/14-static-mipsel/loongson3/beyond
@@ -1,2 +1,0 @@
-abinfo "Removing unneeded binfmt configuration ..."
-rm -f "$PKGDIR"/usr/lib/binfmt.d/qemu-mipsel.conf

--- a/app-virtualization/qemu/18-static-ppc/build
+++ b/app-virtualization/qemu/18-static-ppc/build
@@ -6,6 +6,11 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch powerpc && \
+   ! ab_match_arch ppc64 && \
+   ! ab_match_arch ppc64el; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/18-static-ppc/ppc64el/beyond
+++ b/app-virtualization/qemu/18-static-ppc/ppc64el/beyond
@@ -1,2 +1,0 @@
-abinfo "Removing unneeded binfmt configuration ..."
-rm -vf "$PKGDIR"/usr/lib/binfmt.d/qemu-ppc*.conf

--- a/app-virtualization/qemu/19-static-ppc64/build
+++ b/app-virtualization/qemu/19-static-ppc64/build
@@ -6,6 +6,11 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch powerpc && \
+   ! ab_match_arch ppc64 && \
+   ! ab_match_arch ppc64el; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/19-static-ppc64/ppc64el/beyond
+++ b/app-virtualization/qemu/19-static-ppc64/ppc64el/beyond
@@ -1,2 +1,0 @@
-abinfo "Removing unneeded binfmt configuration ..."
-rm -vf "$PKGDIR"/usr/lib/binfmt.d/qemu-ppc*.conf

--- a/app-virtualization/qemu/21-static-ppc64le/build
+++ b/app-virtualization/qemu/21-static-ppc64le/build
@@ -6,6 +6,9 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch ppc64el; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/21-static-ppc64le/ppc64el/beyond
+++ b/app-virtualization/qemu/21-static-ppc64le/ppc64el/beyond
@@ -1,2 +1,0 @@
-abinfo "Removing unneeded binfmt configuration ..."
-rm -vf "$PKGDIR"/usr/lib/binfmt.d/qemu-ppc*.conf

--- a/app-virtualization/qemu/25-static-sparc/build
+++ b/app-virtualization/qemu/25-static-sparc/build
@@ -6,6 +6,9 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch sparc64; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/27-static-sparc64/build
+++ b/app-virtualization/qemu/27-static-sparc64/build
@@ -6,6 +6,9 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch sparc64; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/30-static-riscv64/build
+++ b/app-virtualization/qemu/30-static-riscv64/build
@@ -6,6 +6,9 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch riscv64; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/30-static-riscv64/riscv64/beyond
+++ b/app-virtualization/qemu/30-static-riscv64/riscv64/beyond
@@ -1,2 +1,0 @@
-abinfo "Removing unneeded binfmt configuration ..."
-rm -v "$PKGDIR"/usr/lib/binfmt.d/qemu-riscv64.conf

--- a/app-virtualization/qemu/33-static-loongarch64/build
+++ b/app-virtualization/qemu/33-static-loongarch64/build
@@ -6,6 +6,9 @@ rm -rfv "$PKGDIR"
 abinfo "Installing static user emulator for ${this_one} ..."
 install -Dvm755 "$SRCDIR"/staticbin/qemu-${this_one} \
     "$PKGDIR"/usr/bin/qemu-${this_one}-static
-abinfo "Installing binfmt files for ${this_one} ..."
-install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
-    "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+
+if ! ab_match_arch loongarch64; then
+    abinfo "Installing binfmt files for ${this_one} ..."
+    install -Dvm644 "$SRCDIR"/autobuild/qemu-${this_one}.conf \
+        "$PKGDIR"/usr/lib/binfmt.d/qemu-${this_one}.conf
+fi

--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,5 +1,5 @@
 VER=9.0.1
-REL=1
+REL=2
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz \
       file::rename=edk2-loongarch64-code.fd::https://github.com/AOSC-Dev/LoongArchQemuVirtFirmware/releases/download/20240430-1/QEMU_EFI.fd \
       file::rename=edk2-loongarch64-vars.fd::https://github.com/AOSC-Dev/LoongArchQemuVirtFirmware/releases/download/20240430-1/QEMU_VARS.fd"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: install binfmt config conditionally for AOSC OS ports
    Previously, most architectures shipped with binfmt_misc configuration for each
    of the native architectures, which may cause problems (i.e., on LoongArch).
    Installing binfmt_misc for the native architecture is pointless anyway.
    Mark installation as conditional by hardware capability.

Package(s) Affected
-------------------

- qemu: 9.0.1-2
- qemu-aarch64-static: 9.0.1-2
- qemu-alpha-static: 9.0.1-2
- qemu-arm-static: 9.0.1-2
- qemu-armeb-static: 9.0.1-2
- qemu-cris-static: 9.0.1-2
- qemu-i386-static: 9.0.1-2
- qemu-loongarch64-static: 9.0.1-2
- qemu-m68k-static: 9.0.1-2
- qemu-microblaze-static: 9.0.1-2
- qemu-microblazeel-static: 9.0.1-2
- qemu-mips-static: 9.0.1-2
- qemu-mips64-static: 9.0.1-2
- qemu-mips64el-static: 9.0.1-2
- qemu-mipsel-static: 9.0.1-2
- qemu-mipsn32-static: 9.0.1-2
- qemu-mipsn32el-static: 9.0.1-2
- qemu-nios2-static: 9.0.1-2
- qemu-or32-static: 9.0.1-2
- qemu-ppc-static: 9.0.1-2
- qemu-ppc64-static: 9.0.1-2
- qemu-ppc64le-static: 9.0.1-2
- qemu-riscv32-static: 9.0.1-2
- qemu-riscv64-static: 9.0.1-2
- qemu-s390x-static: 9.0.1-2
- qemu-sh4-static: 9.0.1-2
- qemu-sh4eb-static: 9.0.1-2
- qemu-sparc-static: 9.0.1-2
- qemu-sparc32plus-static: 9.0.1-2
- qemu-sparc64-static: 9.0.1-2
- qemu-user-static: 9.0.1-2
- qemu-x86-64-static: 9.0.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
