### PR TITLE
boost: fix a typo in PKGBREAK

### DIFF
--- a/runtime-common/boost/autobuild/defines
+++ b/runtime-common/boost/autobuild/defines
@@ -5,7 +5,7 @@ BUILDDEP="numpy"
 PKGSEC=libs
 
 NOSTATIC=0
-PKGBREAK="0ad<=0.0.23 abyss<=2.0.3 aegisub<=3.2.2-8 aptitude<=0.8.10=1 \
+PKGBREAK="0ad<=0.0.23 abyss<=2.0.3 aegisub<=3.2.2-8 aptitude<=0.8.10-1 \
           asio<=1.12.0 avogadro<=1.2.0-1 blender<=2.79b botan<=1.10.17 \
           calligra<=3.1.0-3 cclive<=0.9.3-3 ceph<=12.2.2-1 cgal<=4.11.1 \
           clucene<=2.3.3.4-4 codeblocks<=17.12 compiz<=0.9.13.1-4 \

--- a/runtime-common/boost/spec
+++ b/runtime-common/boost/spec
@@ -1,5 +1,5 @@
 VER=1.83.0
-REL=1
+REL=2
 SRCS="tbl::https://downloads.sourceforge.net/project/boost/boost/$VER/boost_${VER//./_}.tar.bz2"
 CHKSUMS="sha256::6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e"
 CHKUPDATE="anitya::id=6845"


### PR DESCRIPTION
Topic Description
-----------------

- boost: fix a typo in PKGBREAK

Package(s) Affected
-------------------

- boost: 1:1.83.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit boost
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
