### PR TITLE
nvidia (NVIDIA Proprietary Drivers): update to 555.58.02

### DIFF
--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,4 +1,4 @@
-VER=550.54.14
+VER=555.58.02
 _SETTINGS_VER=${VER}
 
 SRCS__AMD64="
@@ -6,17 +6,16 @@ SRCS__AMD64="
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__AMD64="
-	sha256::8c497ff1cfc7c310fb875149bc30faa4fd26d2237b2cba6cd2e8b0780157cfe3
-	sha256::c1e163ea047d04c2bfdc5e48e3666d79af51cd0b36f3e731c5b2877920b678d6
+	sha256::c5cb6de133d194e27aaf94b9e21e56e8f4faff7672d91e0048d14fbbc4d21ca3
+	sha256::4b191403aa4948fa8336c8fa02b309327121c030f6c680a46a7b28a0a0d92dc0
 "
-
 SRCS__ARM64="
 	file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/aarch64/$VER/NVIDIA-Linux-aarch64-${VER}.run
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__ARM64="
-	sha256::b0fae8061633885c24f6b0c047649b46249a3bb44cadffbf658af28f80642c1d
-	sha256::c1e163ea047d04c2bfdc5e48e3666d79af51cd0b36f3e731c5b2877920b678d6
+	sha256::c1bdb48ac32b460f0f790054f7a95627304c9237f248051aaade048199e1c85f
+	sha256::4b191403aa4948fa8336c8fa02b309327121c030f6c680a46a7b28a0a0d92dc0
 "
 
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- nvidia: update to 555.58.02

Package(s) Affected
-------------------

- nvidia: 555.58.02

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
