### PR TITLE
Audio Stack Survey (July, 2024)

### DIFF
--- a/app-multimedia/alsa-utils/spec
+++ b/app-multimedia/alsa-utils/spec
@@ -1,5 +1,4 @@
-VER=1.2.8
-REL=1
+VER=1.2.12
 SRCS="tbl::https://www.alsa-project.org/files/pub/utils/alsa-utils-${VER}.tar.bz2"
-CHKSUMS="sha256::e140fa604c351f36bd72167c8860c69d81b964ae6ab53992d6434dde38e9333c"
+CHKSUMS="sha256::98bc6677d0c0074006679051822324a0ab0879aea558a8f68b511780d30cd924"
 CHKUPDATE="anitya::id=37"

--- a/app-multimedia/sof-tools/autobuild/patches/0001-tools-logger-convert-work-around-implicit-sign-conve.patch
+++ b/app-multimedia/sof-tools/autobuild/patches/0001-tools-logger-convert-work-around-implicit-sign-conve.patch
@@ -1,0 +1,26 @@
+From 47667a444403a85cebbabf8aeacd905bd949b6e7 Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Fri, 19 Jul 2024 12:34:18 +0800
+Subject: [PATCH] tools/logger/convert: work around implicit sign conversion
+ for mips64
+
+---
+ logger/convert.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/logger/convert.c b/logger/convert.c
+index e393f828e..5e39ad35c 100644
+--- a/logger/convert.c
++++ b/logger/convert.c
+@@ -354,7 +354,7 @@ static inline void print_table_header(void)
+ 	if (global_config->time_precision >= 0) {
+ 		const unsigned int ts_width = timestamp_width(global_config->time_precision);
+ 
+-		fprintf(out_fd, "%*s(us)%*s  ", -ts_width, " TIMESTAMP", ts_width, "DELTA");
++		fprintf(out_fd, "%*s(us)%*s  ", -(int)ts_width, " TIMESTAMP", ts_width, "DELTA");
+ 	}
+ 
+ 	fprintf(out_fd, "%2s %-18s ", "C#", "COMPONENT");
+-- 
+2.45.2
+

--- a/app-multimedia/sof-tools/spec
+++ b/app-multimedia/sof-tools/spec
@@ -1,5 +1,5 @@
-VER=2.2.3
-SRCS="tbl::https://github.com/thesofproject/sof/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::9884a202e92cec56a03a090e30a6a7bd8a8b611fada2c38702d0c3d4c764931b"
-SUBDIR="sof-${VER}/tools"
+VER=2.8.1
+SRCS="git::commit=tags/v$VER::https://github.com/thesofproject/sof"
+CHKSUMS="SKIP"
+SUBDIR="sof-tools/tools"
 CHKUPDATE="anitya::id=246473"

--- a/runtime-kernel/sof-firmware/autobuild/build
+++ b/runtime-kernel/sof-firmware/autobuild/build
@@ -3,7 +3,7 @@ export FW_DEST="${PKGDIR}/usr/lib/firmware/intel"
 
 abinfo "Installing SOF firmware data ..."
 mkdir -vp "${FW_DEST}"
-"$SRCDIR"/install.sh v$PKGVER
+"$SRCDIR"/install.sh
 
 abinfo "Installing upstream legal notices ..."
 install -Dvm644 "$SRCDIR"/Notice* \

--- a/runtime-kernel/sof-firmware/spec
+++ b/runtime-kernel/sof-firmware/spec
@@ -1,4 +1,4 @@
-VER=2.2.3
-SRCS="tbl::https://github.com/thesofproject/sof-bin/releases/download/v${VER}/sof-bin-v${VER}.tar.gz"
-CHKSUMS="sha256::591ffd66f1e2b327038c91edf3c8502b4172c1dc850cfe44050eadf8e4fadb42"
+VER=2024.03
+SRCS="tbl::https://github.com/thesofproject/sof-bin/releases/download/v${VER}/sof-bin-${VER}.tar.gz"
+CHKSUMS="sha256::4fd932f7bbc1517b06fa7911e6d566814d5dc4fec5608bdb44e7c4fe4929fbf6"
 CHKUPDATE="anitya::id=246473"

--- a/runtime-multimedia/alsa-lib/spec
+++ b/runtime-multimedia/alsa-lib/spec
@@ -1,5 +1,4 @@
-VER=1.2.6.1
-REL=1
+VER=1.2.12
 SRCS="tbl::https://www.alsa-project.org/files/pub/lib/alsa-lib-$VER.tar.bz2"
-CHKSUMS="sha256::ad582993d52cdb5fb159a0beab60a6ac57eab0cc1bdf85dc4db6d6197f02333f"
+CHKSUMS="sha256::4868cd908627279da5a634f468701625be8cc251d84262c7e5b6a218391ad0d2"
 CHKUPDATE="anitya::id=38"

--- a/runtime-multimedia/alsa-plugins/spec
+++ b/runtime-multimedia/alsa-plugins/spec
@@ -1,4 +1,4 @@
-VER=1.2.7.1
+VER=1.2.12
 SRCS="tbl::https://www.alsa-project.org/files/pub/plugins/alsa-plugins-$VER.tar.bz2"
-CHKSUMS="sha256::8c337814954bb7c167456733a6046142a2931f12eccba3ec2a4ae618a3432511"
+CHKSUMS="sha256::7bd8a83d304e8e2d86a25895d8dcb0ef0245a8df32e271959cdbdc6af39b66f2"
 CHKUPDATE="anitya::id=41"

--- a/runtime-multimedia/alsa-ucm-conf-asahi/spec
+++ b/runtime-multimedia/alsa-ucm-conf-asahi/spec
@@ -1,4 +1,4 @@
-VER=4
+VER=5
 SRCS="git::commit=tags/v$VER::https://github.com/AsahiLinux/alsa-ucm-conf-asahi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=345832"


### PR DESCRIPTION
Topic Description
-----------------

- alsa-ucm-conf-asahi: update to 5
- sof-firmware: update to 2024.03
- sof-tools: update to 2.8.1
- alsa-utils: update to 1.2.12
- alsa-plugins: update to 1.2.12
- alsa-lib: update to 1.2.12

Package(s) Affected
-------------------

- alsa-lib: 1.2.12
- alsa-plugins: 1.2.12
- alsa-ucm-conf-asahi: 5
- alsa-utils: 1.2.12
- sof-firmware: 2024.03
- sof-tools: 2.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit alsa-lib alsa-plugins alsa-utils sof-tools sof-firmware alsa-ucm-conf-asahi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
