### PR TITLE
texlive: update to 20240312

### DIFF
--- a/app-doc/texlive/spec
+++ b/app-doc/texlive/spec
@@ -1,7 +1,6 @@
-VER=20220321
-REL=7
+VER=20240312
 SRCS="tbl::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-source.tar.xz \
       file::rename=texlive-$VER-texmf.tar.xz::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-texmf.tar.xz"
-CHKSUMS="sha256::5ffa3485e51eb2c4490496450fc69b9d7bd7cb9e53357d92db4bcd4fd6179b56 \
-         sha256::372b2b07b1f7d1dd12766cfc7f6656e22c34a5a20d03c1fe80510129361a3f16"
+CHKSUMS="sha256::7b6d87cf01661670fac45c93126bed97b9843139ed510f975d047ea938b6fe96 \
+         sha256::c8eae2deaaf51e86d93baa6bbcc4e94c12aa06a0d92893df474cc7d2a012c7a7"
 CHKUPDATE="anitya::id=11725"


### PR DESCRIPTION
Topic Description
-----------------

- texlive: update to 20240312

Package(s) Affected
-------------------

- texlive: 20240312

Security Update?
----------------

No

Build Order
-----------

```
#buildit texlive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
