### PR TITLE
libvirt: update to 10.5.0

### DIFF
--- a/app-virtualization/libvirt/autobuild/prepare
+++ b/app-virtualization/libvirt/autobuild/prepare
@@ -1,7 +1,7 @@
 abinfo "Tweaking files to use /etc/conf.d ..."
 sed -e 's|/sysconfig/|/conf.d/|g' \
     -i "$SRCDIR"/src/remote/libvirtd.service.in \
-    -i "$SRCDIR"/tools/{libvirt-guests.service,libvirt-guests.sh,virt-pki-validate}.in \
+    -i "$SRCDIR"/tools/{libvirt-guests.service,libvirt-guests.sh}.in \
     -i "$SRCDIR"/src/locking/virtlockd.service.in
 
 abinfo "Tweaking files to install binary executables to /usr/bin ..."

--- a/app-virtualization/libvirt/spec
+++ b/app-virtualization/libvirt/spec
@@ -1,5 +1,4 @@
-VER=10.2.0
-REL=1
+VER=10.5.0
 SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
-CHKSUMS="sha256::215772bc5dc4a672e67ffa9de3774f05ed4b7ed282dbe296ec5c9fec01dd7ae3"
+CHKSUMS="sha256::8e853a9c91c9029b9019cf5fdf2b5fea36d501d563e43254efc20e12c00557e8"
 CHKUPDATE="anitya::id=13830"


### PR DESCRIPTION
Topic Description
-----------------

- libvirt: update to 10.5.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libvirt: 10.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvirt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
