### PR TITLE
libvirt-python: update to 10.5.0

### DIFF
--- a/runtime-virtualization/libvirt-python/spec
+++ b/runtime-virtualization/libvirt-python/spec
@@ -1,4 +1,4 @@
-VER=10.1.0
+VER=10.5.0
 SRCS="tbl::https://libvirt.org/sources/python/libvirt-python-$VER.tar.gz"
-CHKSUMS="sha256::3e7d07bb4a4a8d2a38f1445e9cf47b68d928d93b163555e153c045535ae87444"
+CHKSUMS="sha256::785023500f58d3e8e829af98647d43eee97e517aacc9d9e7ded43594ea52d032"
 CHKUPDATE="anitya::id=13829"


### PR DESCRIPTION
Topic Description
-----------------

- libvirt-python: update to 10.5.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libvirt-python: 10.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvirt-python
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
