### PR TITLE
docker (Docker): fix postinst for systemd 256

### DIFF
--- a/app-containers/docker/autobuild/overrides/usr/lib/systemd/system-preset/40-docker.preset
+++ b/app-containers/docker/autobuild/overrides/usr/lib/systemd/system-preset/40-docker.preset
@@ -1,1 +1,2 @@
 enable docker.service
+enable docker.socket

--- a/app-containers/docker/autobuild/postinst
+++ b/app-containers/docker/autobuild/postinst
@@ -1,2 +1,6 @@
 systemd-sysusers docker.conf
-systemctl preset docker.service --now
+
+# Note: Only call preset during installation.
+if [[ "$1" = "install" ]]; then
+	systemctl preset docker.service
+fi

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -5,6 +5,7 @@ UPSTREAM_VER=27.0.3
 TINI_VER=0.19.0
 
 VER=${UPSTREAM_VER}+tini${TINI_VER}
+REL=1
 SRCS="git::commit=tags/v${UPSTREAM_VER};rename=cli::https://github.com/docker/cli \
       git::commit=tags/v${UPSTREAM_VER};rename=moby::https://github.com/moby/moby \
       git::commit=tags/v${TINI_VER};rename=tini::https://github.com/krallin/tini"


### PR DESCRIPTION
Topic Description
-----------------

- docker: fix postinst and preset
    - Move preset up to 40- to make sure it gets enabled.
    - Drop --now flag from systemctl preset in postinst
    - Only run preset during installation (but not upgrades).

Package(s) Affected
-------------------

- docker: 27.0.3+tini0.19.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit docker
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
