### PR TITLE
acbs: update to 20240717

### DIFF
--- a/app-devel/acbs/spec
+++ b/app-devel/acbs/spec
@@ -1,4 +1,4 @@
-VER=20240620
+VER=20240717
 SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/acbs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226984"


### PR DESCRIPTION
Topic Description
-----------------

- acbs: update to 20240717
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- acbs: 2:20240717

Security Update?
----------------

No

Build Order
-----------

```
#buildit acbs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
