### PR TITLE
bcrypt: update to 4.1.3

### DIFF
--- a/lang-python/bcrypt/autobuild/defines
+++ b/lang-python/bcrypt/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=bcrypt
 PKGSEC=python
 PKGDEP="cffi six"
-BUILDDEP="setuptools"
+BUILDDEP="llvm setuptools-rust"
 PKGDES="Modern password hashing for your software and your servers"
 
+NOLTO__LOONGSON3=1
+ABSPLITDBG__MIPS64R6EL=0
+ABTYPE=pep517
 NOPYTHON2=1

--- a/lang-python/bcrypt/autobuild/patches/0001-Cargo.toml-enable-debug-info-for-release-profile.patch
+++ b/lang-python/bcrypt/autobuild/patches/0001-Cargo.toml-enable-debug-info-for-release-profile.patch
@@ -1,0 +1,22 @@
+From fcf341da9141e334945362396f31ebc72429eab7 Mon Sep 17 00:00:00 2001
+From: Runhua He <hua@aosc.io>
+Date: Thu, 18 Jul 2024 16:51:57 +0800
+Subject: [PATCH] Cargo.toml: enable debug info for release profile
+
+---
+ bcrypt_src/src/_bcrypt/Cargo.toml | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/bcrypt_src/src/_bcrypt/Cargo.toml b/bcrypt_src/src/_bcrypt/Cargo.toml
+index 58f6c13..df99d78 100644
+--- a/src/_bcrypt/Cargo.toml
++++ b/src/_bcrypt/Cargo.toml
+@@ -24,3 +24,5 @@ crate-type = ["cdylib"]
+ [profile.release]
+ lto = "thin"
+ overflow-checks = true
++debug = 1
++strip = false
+-- 
+2.45.2
+

--- a/lang-python/bcrypt/spec
+++ b/lang-python/bcrypt/spec
@@ -1,5 +1,4 @@
-VER=3.1.7
-REL=3
+VER=4.1.3
 SRCS="tbl::https://pypi.io/packages/source/b/bcrypt/bcrypt-$VER.tar.gz"
-CHKSUMS="sha256::0b0069c752ec14172c5f78208f1863d7ad6755a6fae6fe76ec2c80d13be41e42"
+CHKSUMS="sha256::2ee15dd749f5952fe3f0430d0ff6b74082e159c50332a1413d51b5689cf06623"
 CHKUPDATE="anitya::id=9047"


### PR DESCRIPTION
Topic Description
-----------------

- bcrypt: update to 4.1.3

Package(s) Affected
-------------------

- bcrypt: 4.1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit bcrypt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
