### PR TITLE
autobuild4: update to 4.3.7

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.3.5
+VER=4.3.7
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: update to 4.3.7
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- autobuild4: 4.3.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
