### PR TITLE
gdb: bump REL due to icu update to 74.2

### DIFF
--- a/app-devel/gdb/autobuild/defines
+++ b/app-devel/gdb/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gdb
 PKGSEC=devel
-PKGDEP="babeltrace elfutils expat glibc-dbg guile isl python-3 readline xz xxhash source-highlight ncurses"
+PKGDEP="babeltrace elfutils expat glibc-dbg guile icu isl python-3 readline xz xxhash source-highlight ncurses"
 PKGDEP__RETRO="expat glibc-dbg isl readline"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/app-devel/gdb/autobuild/defines.stage2
+++ b/app-devel/gdb/autobuild/defines.stage2
@@ -1,6 +1,6 @@
 PKGNAME=gdb
 PKGSEC=devel
-PKGDEP="babeltrace elfutils expat guile isl python-2 readline xz xxhash source-highlight ncurses"
+PKGDEP="babeltrace elfutils expat guile icu isl python-2 readline xz xxhash source-highlight ncurses"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
 PKGDEP__ARMV7HF="${BUILDDEP__RETRO}"

--- a/app-devel/gdb/spec
+++ b/app-devel/gdb/spec
@@ -1,4 +1,5 @@
 VER=15.1
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/gdb/gdb-$VER.tar.xz"
 CHKSUMS="sha256::38254eacd4572134bca9c5a5aa4d4ca564cbbd30c369d881f733fb6b903354f2"
 CHKUPDATE="anitya::id=11798"


### PR DESCRIPTION
Topic Description
-----------------

- gdb: bump REL due to icu update to 74.2

Package(s) Affected
-------------------

- gdb: 15.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
