### PR TITLE
noise-suppression-for-voice: update to 1.10

### DIFF
--- a/app-multimedia/noise-suppression-for-voice/autobuild/defines
+++ b/app-multimedia/noise-suppression-for-voice/autobuild/defines
@@ -1,13 +1,16 @@
 PKGNAME=noise-suppression-for-voice
 PKGSEC=sound
+PKGDEP="gcc-runtime freetype"
 BUILDDEP="cmake"
 PKGDES="Noise suppression plugin based on Xiph's RNNoise"
 
 ABTYPE=cmake
 AB_FLAGS_O3=1
-CMAKE_AFTER="-DBUILD_LADSPA_PLUGIN=ON \
+CMAKE_AFTER="-DBUILD_FOR_RELEASE=ON \
+             -DBUILD_LADSPA_PLUGIN=ON \
              -DBUILD_LV2_PLUGIN=ON \
-             -DBUILD_VST_PLUGIN=OFF"
+             -DBUILD_VST_PLUGIN=ON \
+             -DBUILD_VST3_PLUGIN=ON"
 
 PKGBREAK="rnnoise<=0.9"
 PKGREP="rnnoise<=0.9"

--- a/app-multimedia/noise-suppression-for-voice/spec
+++ b/app-multimedia/noise-suppression-for-voice/spec
@@ -1,4 +1,4 @@
-VER=0.91
-SRCS="tbl::https://github.com/werman/noise-suppression-for-voice/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::4f3a112534d4abb5ee2b6c328cde89193dbdb2146cffc98505972c3b5397a35e"
+VER=1.10
+SRCS="git::commit=tags/v$VER::https://github.com/werman/noise-suppression-for-voice"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230943"


### PR DESCRIPTION
Topic Description
-----------------

- noise-suppression-for-voice: update to 1.10
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- noise-suppression-for-voice: 1.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit noise-suppression-for-voice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
