### PR TITLE
waybar: update to 0.10.4

### DIFF
--- a/app-utils/waybar/spec
+++ b/app-utils/waybar/spec
@@ -1,4 +1,4 @@
-VER=0.10.3
+VER=0.10.4
 SRCS="git::commit=tags/$VER::https://github.com/Alexays/Waybar"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21287"


### PR DESCRIPTION
Topic Description
-----------------

- waybar: update to 0.10.4
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- waybar: 0.10.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit waybar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
