### PR TITLE
nautilus: update to 46.2

### DIFF
--- a/desktop-gnome/nautilus/spec
+++ b/desktop-gnome/nautilus/spec
@@ -1,5 +1,4 @@
-VER=42.2
-REL=1
+VER=46.2
 SRCS="https://download.gnome.org/sources/nautilus/${VER%.*}/nautilus-$VER.tar.xz"
-CHKSUMS="sha256::99212d2eb75996f181728ad04a2e2d86f2577b064e68a34c8b81a7037df4ccb2"
+CHKSUMS="sha256::6ee8c99019b9e3447f6918d68232a20deca89e5525c05805432b7d8840ca71fa"
 CHKUPDATE="anitya::id=2050"


### PR DESCRIPTION
Topic Description
-----------------

- nautilus: update to 46.2
    Co-authored-by: SignKirigami (@prcups) <prcups@krgm.moe>

Package(s) Affected
-------------------

- nautilus: 46.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit nautilus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
