### PR TITLE
wcslib: update to 8.3

### DIFF
--- a/app-scientific/stellarsolver/spec
+++ b/app-scientific/stellarsolver/spec
@@ -1,4 +1,5 @@
 VER=2.5
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/rlancaste/stellarsolver.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242699"

--- a/runtime-scientific/wcslib/autobuild/defines
+++ b/runtime-scientific/wcslib/autobuild/defines
@@ -6,5 +6,6 @@ PKGDES="A C library that implements the 'World Coordinate System' (WCS) standard
 AUTOTOOLS_AFTER="--without-pgplot --disable-fortran"
 ABSHADOW=0
 NOPARALLEL=1
+ABTPYE=autotools
 
 PKGBREAK="kstars<=1:2.9.8-1"

--- a/runtime-scientific/wcslib/spec
+++ b/runtime-scientific/wcslib/spec
@@ -1,4 +1,4 @@
-VER=6.4
+VER=8.3
 SRCS="tbl::ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-$VER.tar.bz2"
-CHKSUMS="sha256::13c11ff70a7725563ec5fa52707a9965fce186a1766db193d08c9766ea107000"
+CHKSUMS="sha256::431ea3417927bbc02b89bfa3415dc0b4668b0f21a3b46fb8a3525e2fcf614508"
 CHKUPDATE="anitya::id=7693"


### PR DESCRIPTION
Topic Description
-----------------

- stellarsolver: bump rel
- wcslib: update to 8.3

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit wcslib stellarsolver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
