### PR TITLE
tesseract: update to 5.4.1

### DIFF
--- a/app-i18n/crow-translate/spec
+++ b/app-i18n/crow-translate/spec
@@ -1,4 +1,5 @@
 VER=2.11.1
+REL=1
 SRCS="tbl::https://github.com/crow-translate/crow-translate/releases/download/$VER/crow-translate-${VER}-source.tar.gz"
 CHKSUMS="sha256::74591a350892594946b36b198d981826a0756326a1a7991b942fccb7971ec95d"
 CHKUPDATE="anitya::id=232133"

--- a/app-i18n/crow-translate/spec
+++ b/app-i18n/crow-translate/spec
@@ -1,5 +1,5 @@
 VER=2.11.1
-REL=1
+REL=2
 SRCS="tbl::https://github.com/crow-translate/crow-translate/releases/download/$VER/crow-translate-${VER}-source.tar.gz"
 CHKSUMS="sha256::74591a350892594946b36b198d981826a0756326a1a7991b942fccb7971ec95d"
 CHKUPDATE="anitya::id=232133"

--- a/app-utils/tesseract/autobuild/beyond
+++ b/app-utils/tesseract/autobuild/beyond
@@ -1,7 +1,7 @@
 abinfo "Packing trained data..."
 mkdir -vp "$PKGDIR"/usr/share/tessdata
 
-pushd ../tessdata_fast-4.1.0
+pushd ../tessdata_fast
 
 for i in *.traineddata; do
         cp "${i}" "$PKGDIR"/usr/share/tessdata/

--- a/app-utils/tesseract/autobuild/defines
+++ b/app-utils/tesseract/autobuild/defines
@@ -5,4 +5,4 @@ PKGDES="An OCR program"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON"
-PKGBREAK="crow-translate<=2.9.1-2 opencv<=4.7.0-1 skanpage<=22.08.3"
+PKGBREAK="crow-translate<=2.11.1 opencv<=4.7.0-2 skanpage<=22.08.5"

--- a/app-utils/tesseract/spec
+++ b/app-utils/tesseract/spec
@@ -1,8 +1,8 @@
-VER=5.3.4
-REL=1
-SRCS="tbl::https://github.com/tesseract-ocr/tesseract/archive/$VER.tar.gz \
-      tbl::https://github.com/tesseract-ocr/tessdata_fast/archive/4.1.0.tar.gz"
-CHKSUMS="sha256::141afc12b34a14bb691a939b4b122db0d51bd38feda7f41696822bacea7710c7 \
-         sha256::d0e3bb6f3b4e75748680524a1d116f2bfb145618f8ceed55b279d15098a530f9"
-SUBDIR="tesseract-$VER"
-CHKUPDATE="anitya::id=123693"
+VER=5.4.1
+FASTVER=4.1.0
+SRCS="git::commit=tags/$VER::https://github.com/tesseract-ocr/tesseract \
+      git::commit=tags/$FASTVER;rename=tessdata_fast::https://github.com/tesseract-ocr/tessdata_fast"
+CHKSUMS="SKIP \
+         SKIP"
+SUBDIR="tesseract"
+CHKUPDATE="anitya::id=4954"

--- a/app-utils/tesseract/spec
+++ b/app-utils/tesseract/spec
@@ -6,3 +6,4 @@ CHKSUMS="SKIP \
          SKIP"
 SUBDIR="tesseract"
 CHKUPDATE="anitya::id=4954"
+REL=1

--- a/desktop-kde/skanpage/spec
+++ b/desktop-kde/skanpage/spec
@@ -1,4 +1,5 @@
 VER=23.08.5
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/skanpage-$VER.tar.xz"
 CHKSUMS="sha256::38e2300e1466c43bb531989c29d11221ebcaa2e3e8bb062a814c1f03270b72bb"
 CHKUPDATE="anitya::id=8763"

--- a/desktop-kde/skanpage/spec
+++ b/desktop-kde/skanpage/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/skanpage-$VER.tar.xz"
 CHKSUMS="sha256::38e2300e1466c43bb531989c29d11221ebcaa2e3e8bb062a814c1f03270b72bb"
 CHKUPDATE="anitya::id=8763"

--- a/runtime-scientific/opencv/spec
+++ b/runtime-scientific/opencv/spec
@@ -1,5 +1,5 @@
 VER=4.9.0
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER::https://github.com/opencv/opencv \
       git::commit=tags/$VER;rename=opencv_contrib::https://github.com/opencv/opencv_contrib"
 CHKSUMS="SKIP \

--- a/runtime-scientific/opencv/spec
+++ b/runtime-scientific/opencv/spec
@@ -1,5 +1,5 @@
 VER=4.9.0
-REL=3
+REL=4
 SRCS="git::commit=tags/$VER::https://github.com/opencv/opencv \
       git::commit=tags/$VER;rename=opencv_contrib::https://github.com/opencv/opencv_contrib"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- skanpage: bump REL for topic Revision Marking Guidelines
- crow-translate: bump REL for topic Revision Marking Guidelines
- opencv: bump REL for topic Revision Marking Guidelines
- tesseract: bump REL for topic Revision Marking Guidelines
- tesseract: update versions in PKGBREAK
- crow-translate: bump REL due to tesseract update
- skanpage: bump REL due to tesseract update
- opencv: bump REL due to tesseract update
- tesseract: update to 5.4.1
    - Fix the wrong anitya id
    - modify path of tesseract_fast in beyond

Package(s) Affected
-------------------

- crow-translate: 2.11.1-2
- opencv: 4.9.0-4
- skanpage: 23.08.5-2
- tesseract: 5.4.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tesseract opencv crow-translate skanpage
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
