### PR TITLE
go-rebuilds: replace v2ray-plugin with xray-plugin

### DIFF
--- a/groups/go-rebuilds
+++ b/groups/go-rebuilds
@@ -27,7 +27,7 @@ app-network/popub
 app-network/syncthing
 app-network/tailscale
 app-network/v2ray
-app-network/v2ray-plugin
+app-network/xray-plugin
 app-network/v2raya
 app-network/xray
 app-utils/automatic-component-toolkit

--- a/groups/go-rebuilds.amd64
+++ b/groups/go-rebuilds.amd64
@@ -20,7 +20,7 @@ app-network/obfs4proxy
 app-network/popub
 app-network/syncthing
 app-network/v2ray
-app-network/v2ray-plugin
+app-network/xray-plugin
 app-network/xray
 app-utils/direnv
 app-utils/fzf

--- a/groups/go-rebuilds.arm64
+++ b/groups/go-rebuilds.arm64
@@ -19,7 +19,7 @@ app-network/obfs4proxy
 app-network/popub
 app-network/syncthing
 app-network/v2ray
-app-network/v2ray-plugin
+app-network/xray-plugin
 app-network/xray
 app-utils/direnv
 app-utils/fzf

--- a/groups/go-rebuilds.loongson3
+++ b/groups/go-rebuilds.loongson3
@@ -13,7 +13,7 @@ app-network/obfs4proxy
 app-network/popub
 app-network/syncthing
 app-network/v2ray
-app-network/v2ray-plugin
+app-network/xray-plugin
 app-network/xray
 app-utils/direnv
 app-utils/fzf

--- a/groups/go-rebuilds.ppc64el
+++ b/groups/go-rebuilds.ppc64el
@@ -18,7 +18,7 @@ app-network/obfs4proxy
 app-network/popub
 app-network/syncthing
 app-network/v2ray
-app-network/v2ray-plugin
+app-network/xray-plugin
 app-network/xray
 app-utils/direnv
 app-utils/fzf

--- a/groups/go-rebuilds.riscv64
+++ b/groups/go-rebuilds.riscv64
@@ -10,7 +10,7 @@ app-network/obfs4proxy
 app-network/popub
 app-network/syncthing
 app-network/v2ray
-app-network/v2ray-plugin
+app-network/xray-plugin
 app-network/xray
 app-utils/direnv
 app-utils/fzf


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

v2ray-plugin has been replaced by xray-plugin, this PR replaces v2ray-plugin in go-rebuilds with xray-plugin.