### PR TITLE
xray-plugin: rebuild for Go 1.22.5

### DIFF
--- a/app-network/xray-plugin/spec
+++ b/app-network/xray-plugin/spec
@@ -1,4 +1,5 @@
 VER=1.8.11
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/teddysun/xray-plugin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372439"


### PR DESCRIPTION
Topic Description
-----------------

- xray-plugin: rebuild for Go 1.22.5
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- xray-plugin: 1.8.11-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xray-plugin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
