### PR TITLE
libreoffice (LibreOffice): rework for ICU 74.2

### DIFF
--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,4 +1,5 @@
 VER=24.2.3.2
+REL=1
 SRCS="tbl::https://download.documentfoundation.org/libreoffice/src/${VER:0:6}/libreoffice-$VER.tar.xz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz \


### PR DESCRIPTION
Topic Description
-----------------

- libreoffice: rework for icu 74.2

Package(s) Affected
-------------------

- libreoffice: 24.2.3.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libreoffice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
