### PR TITLE
containers-common: update to 0.59.2

### DIFF
--- a/runtime-containers/containers-common/spec
+++ b/runtime-containers/containers-common/spec
@@ -1,10 +1,11 @@
-UPSTREAM_VER=0.59.0
+UPSTREAM_VER=0.59.2
 # Find dependency versions at
 #
 # https://github.com/containers/common/blob/v$PKGVER/go.sum
-__IMAGE_VER=5.31.0
-__SHORTNAMES_VER=2023.02.20
+__IMAGE_VER=5.31.1
 __STORAGE_VER=1.54.0
+# FIXME: the following two dependencies are not in the go.sum file above.
+__SHORTNAMES_VER=2023.02.20
 __SKOPEO_VER=1.15.1
 
 VER=${UPSTREAM_VER}+image${__IMAGE_VER}+shortnames${__SHORTNAMES_VER}+skopeo${__SKOPEO_VER}+storage${__STORAGE_VER}


### PR DESCRIPTION
Topic Description
-----------------

- containers-common: update to 0.59.2

Package(s) Affected
-------------------

- containers-common: 0.59.2+image5.31.1+shortnames2023.02.20+skopeo1.15.1+storage1.54.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit containers-common
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
