### PR TITLE
pcsclite (PCSClite): fix dependency relation with ccid (CCID drivers)

### DIFF
--- a/app-devices/pcsclite/autobuild/defines
+++ b/app-devices/pcsclite/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=pcsclite
 PKGSEC=libs
-PKGDEP="polkit python-2 systemd"
-PKGDEP__RETRO="systemd"
+PKGDEP="ccid polkit python-2 systemd"
+PKGDEP__RETRO="ccid systemd"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
 PKGDEP__ARMV7HF="${PKGDEP__RETRO}"

--- a/app-devices/pcsclite/spec
+++ b/app-devices/pcsclite/spec
@@ -1,4 +1,5 @@
 VER=1.9.9
+REL=1
 SRCS="tbl::https://pcsclite.apdu.fr/files/pcsc-lite-$VER.tar.bz2"
 CHKSUMS="sha256::cbcc3b34c61f53291cecc0d831423c94d437b188eb2b97b7febc08de1c914e8a"
 CHKUPDATE="anitya::id=2611"

--- a/runtime-devices/ccid/autobuild/defines
+++ b/runtime-devices/ccid/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=ccid
 PKGSEC=libs
-PKGDEP="pcsclite libusb"
+PKGDEP="libusb"
 PKGDES="A generic USB Chip/Smart Card Interface Devices driver"
 
 AUTOTOOLS_AFTER="--enable-twinserial --enable-serialconfdir=/etc/reader.conf.d \

--- a/runtime-devices/ccid/spec
+++ b/runtime-devices/ccid/spec
@@ -1,4 +1,5 @@
 VER=1.5.1
+REL=1
 SRCS="tbl::https://ccid.apdu.fr/files/ccid-$VER.tar.bz2"
 CHKSUMS="sha256::e7a78c398ec0d617a4f98bac70d5b64f78689284dd0ae87d4692e2857f117377"
 CHKUPDATE="anitya::id=2612"


### PR DESCRIPTION
Topic Description
-----------------

- ccid: drop pcsclite dep
    The dependency was reversed by mistake.
- pcsclite: add ccid dep

Package(s) Affected
-------------------

- ccid: 1.5.1-1
- pcsclite: 1.9.9-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pcsclite ccid
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
