### PR TITLE
mesa: update to 24.1.4+dxheaders1.614.0

### DIFF
--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=24.1.3
+UPSTREAM_VER=24.1.4
 DXHEADERS_VER=1.614.0
 VER=${UPSTREAM_VER}+dxheaders${DXHEADERS_VER}
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
-CHKSUMS="sha256::63236426b25a745ba6aa2d6daf8cd769d5ea01887b0745ab7124d2ef33a9020d \
+CHKSUMS="sha256::7cf7c6f665263ad0122889c1d4b076654c1eedea7a2f38c69c8c51579937ade1 \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 24.1.4+dxheaders1.614.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mesa: 1:24.1.3+dxheaders1.614.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
