### PR TITLE
httpd: security update to 2.4.62

### DIFF
--- a/app-web/httpd/spec
+++ b/app-web/httpd/spec
@@ -1,4 +1,4 @@
-VER=2.4.61
-SRCS="tbl::http://archive.apache.org/dist/httpd/httpd-$VER.tar.bz2"
-CHKSUMS="sha256::ea8ba86fd95bd594d15e46d25ac5bbda82ae0c9122ad93998cc539c133eaceb6"
+VER=2.4.62
+SRCS="tbl::https://archive.apache.org/dist/httpd/httpd-$VER.tar.bz2"
+CHKSUMS="sha256::674188e7bf44ced82da8db522da946849e22080d73d16c93f7f4df89e25729ec"
 CHKUPDATE="anitya::id=1335"


### PR DESCRIPTION
Topic Description
-----------------

- httpd: security update to 2.4.62

Package(s) Affected
-------------------

- httpd: 2.4.62

Security Update?
----------------

No

Build Order
-----------

```
#buildit httpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
