### PR TITLE
systemd: disable networkd related services in the default preset

### DIFF
--- a/app-admin/systemd/autobuild/patches/0001-sleep.conf-AllowHibernation-no-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0001-sleep.conf-AllowHibernation-no-by-default.patch
@@ -1,7 +1,7 @@
 From c4bc93835c75d9aac221325c0228283f7b292e48 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Tue, 11 Apr 2023 18:04:25 -0700
-Subject: [PATCH 1/2] sleep.conf: AllowHibernation=no by default
+Subject: [PATCH 1/3] sleep.conf: AllowHibernation=no by default
 
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---

--- a/app-admin/systemd/autobuild/patches/0002-vmspawn-define-default-machines-for-mips-targets.patch
+++ b/app-admin/systemd/autobuild/patches/0002-vmspawn-define-default-machines-for-mips-targets.patch
@@ -1,7 +1,7 @@
 From b480ef8dc857dffedc3a50a74224100decccff41 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Fri, 5 Jul 2024 11:19:35 +0800
-Subject: [PATCH 2/2] vmspawn: define default machines for mips targets
+Subject: [PATCH 2/3] vmspawn: define default machines for mips targets
 
 All mips variants of qemu-system default to malta.
 

--- a/app-admin/systemd/autobuild/patches/0003-presets-disable-systemd-networkd-and-systemd-network.patch
+++ b/app-admin/systemd/autobuild/patches/0003-presets-disable-systemd-networkd-and-systemd-network.patch
@@ -1,0 +1,29 @@
+From 02424674930085000819de6db419817661c5078c Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Fri, 19 Jul 2024 18:38:48 -0700
+Subject: [PATCH 3/3] presets: disable systemd-networkd and
+ systemd-networkd-wait-online by default
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ presets/90-systemd.preset | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/presets/90-systemd.preset b/presets/90-systemd.preset
+index da6b9805fd..dcbcd56a7f 100644
+--- a/presets/90-systemd.preset
++++ b/presets/90-systemd.preset
+@@ -24,8 +24,8 @@ enable systemd-homed-activate.service
+ enable systemd-journald-audit.socket
+ enable systemd-mountfsd.socket
+ enable systemd-network-generator.service
+-enable systemd-networkd.service
+-enable systemd-networkd-wait-online.service
++disable systemd-networkd.service
++disable systemd-networkd-wait-online.service
+ enable systemd-nsresourced.socket
+ enable systemd-pstore.service
+ enable systemd-resolved.service
+-- 
+2.45.2
+

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,4 +1,5 @@
 VER=256.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205088"


### PR DESCRIPTION
Topic Description
-----------------

- systemd: disable networkd related services in the default preset
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- systemd: 1:256.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
