### PR TITLE
texlive: update to 20240312 (rework)

### DIFF
--- a/app-doc/texlive/autobuild/postinst
+++ b/app-doc/texlive/autobuild/postinst
@@ -7,16 +7,12 @@ cp /usr/share/texmf-dist/web2c/updmap-hdr.cfg $UPDMAP
 
 echo "Updating the filename database..."
 mktexlsr > /dev/null
-(cd /etc/texmf && ../../bin/mtxrun --generate >/dev/null)
 for item in /var/lib/texmf/luatex-cache/context/*/trees/*.lua; do
     grep -F '["root"]="."' "$item" >/dev/null && rm -f "$item" "${item%.lua}.luc"
 done
 
 echo "Creating all formats..."
 fmtutil-sys --all --cnffile /etc/texmf/web2c/fmtutil.cnf 1>/dev/null
-
-echo "Initializing the ConTeXt system..." 
-mtxrun --generate 1>/dev/null
 
 echo "Updating the fontmap files with updmap..."
 updmap-sys --quiet --nohash 1>/dev/null

--- a/app-doc/texlive/spec
+++ b/app-doc/texlive/spec
@@ -1,4 +1,5 @@
 VER=20240312
+REL=1
 SRCS="tbl::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-source.tar.xz \
       file::rename=texlive-$VER-texmf.tar.xz::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-texmf.tar.xz"
 CHKSUMS="sha256::7b6d87cf01661670fac45c93126bed97b9843139ed510f975d047ea938b6fe96 \


### PR DESCRIPTION
Topic Description
-----------------

- texlive: update to 20240312 (rework)

Package(s) Affected
-------------------

- texlive: 20240312

Security Update?
----------------

No

Build Order
-----------

```
#buildit texlive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
