### PR TITLE
deploykit-gui: update to 0.7.4

### DIFF
--- a/app-admin/deploykit-gui/spec
+++ b/app-admin/deploykit-gui/spec
@@ -1,7 +1,7 @@
-VER=0.7.3
+VER=0.7.4
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-gui \
       tbl::https://github.com/AOSC-Dev/deploykit-gui/releases/download/v$VER/dist.tar.xz"
 CHKSUMS="SKIP \
-         sha256::6b8760e4b9a38280bdb0e61d594755414e6194b989e4e0c6f46dd17c1feb4cac"
+         sha256::8a28def2c2e2c76566ed79cdb6c24340ad66db3d453ab0aaeffec79c44b32999"
 SUBDIR="deploykit-gui/src-tauri"
 CHKUPDATE="anitya::id=371971"


### PR DESCRIPTION
Topic Description
-----------------

- deploykit-gui: update to 0.7.4
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- deploykit-gui: 0.7.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-gui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
