### PR TITLE
xorg-server: backport a patch to fix high-refresh panels' fitting

### DIFF
--- a/runtime-display/xorg-server/autobuild/patches/0004-BACKPORT-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0004-BACKPORT-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
@@ -1,0 +1,88 @@
+From e7bcde7df6179501ac252e9e68534340cfb1a305 Mon Sep 17 00:00:00 2001
+From: "Chia-Lin Kao (AceLan)" <acelan.kao@canonical.com>
+Date: Tue, 8 Nov 2022 08:11:50 +0800
+Subject: [PATCH] hw/xfree86: re-calculate the clock and refresh rate
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+xserver fails to generate useable resolutions with 90Hz framerate
+panels(encounter the same issue with 3 different 2.5k resolution
+panels). All the resolutions shown by xrandr lead to blank screen except
+the one written in EDID.
+Ville Syrjälä from Intel provides a method to calculate the preferred
+clock and refresh rate from the existing resolution table and this
+works for the issue.
+
+v2. xf86ModeVRefresh might return 0, need to check it before use it.
+v3. reported by Markus on launchpad that the issue is not devided by 0,
+it's the "preferred" being accessed unconditionally.
+BugLink: https://launchpad.net/bugs/1999852
+
+Closes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1388
+Signed-off-by: Chia-Lin Kao (AceLan) <acelan.kao@canonical.com>
+---
+ hw/xfree86/common/xf86Mode.c                     |  2 ++
+ hw/xfree86/drivers/modesetting/drmmode_display.c | 13 ++++++++++++-
+ include/displaymode.h                            |  1 +
+ 3 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/hw/xfree86/common/xf86Mode.c b/hw/xfree86/common/xf86Mode.c
+index eb0885571..fec60a957 100644
+--- a/hw/xfree86/common/xf86Mode.c
++++ b/hw/xfree86/common/xf86Mode.c
+@@ -230,6 +230,8 @@ xf86ModeStatusToString(ModeStatus status)
+         return "monitor doesn't support reduced blanking";
+     case MODE_BANDWIDTH:
+         return "mode requires too much memory bandwidth";
++    case MODE_DUPLICATE:
++        return "the same mode has been added";
+     case MODE_BAD:
+         return "unknown reason";
+     case MODE_ERROR:
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
+index 48dccad73..4d046169a 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
+@@ -2641,7 +2641,7 @@ static DisplayModePtr
+ drmmode_output_add_gtf_modes(xf86OutputPtr output, DisplayModePtr Modes)
+ {
+     xf86MonPtr mon = output->MonInfo;
+-    DisplayModePtr i, m, preferred = NULL;
++    DisplayModePtr i, j, m, preferred = NULL;
+     int max_x = 0, max_y = 0;
+     float max_vrefresh = 0.0;
+ 
+@@ -2673,6 +2673,17 @@ drmmode_output_add_gtf_modes(xf86OutputPtr output, DisplayModePtr Modes)
+             i->VDisplay >= preferred->VDisplay &&
+             xf86ModeVRefresh(i) >= xf86ModeVRefresh(preferred))
+             i->status = MODE_VSYNC;
++        if (preferred && xf86ModeVRefresh(i) > 0.0) {
++            i->Clock = i->Clock * xf86ModeVRefresh(preferred) / xf86ModeVRefresh(i);
++            i->VRefresh = xf86ModeVRefresh(preferred);
++        }
++        for (j = m; j != i; j = j->next) {
++            if (!strcmp(i->name, j->name) &&
++                xf86ModeVRefresh(i) * (1 + SYNC_TOLERANCE) >= xf86ModeVRefresh(j) &&
++                xf86ModeVRefresh(i) * (1 - SYNC_TOLERANCE) <= xf86ModeVRefresh(j)) {
++                i->status = MODE_DUPLICATE;
++            }
++        }
+     }
+ 
+     xf86PruneInvalidModes(output->scrn, &m, FALSE);
+diff --git a/include/displaymode.h b/include/displaymode.h
+index ad01b87ec..561087717 100644
+--- a/include/displaymode.h
++++ b/include/displaymode.h
+@@ -47,6 +47,7 @@ typedef enum {
+     MODE_ONE_SIZE,              /* only one resolution is supported */
+     MODE_NO_REDUCED,            /* monitor doesn't accept reduced blanking */
+     MODE_BANDWIDTH,             /* mode requires too much memory bandwidth */
++    MODE_DUPLICATE,             /* mode is duplicated */
+     MODE_BAD = -2,              /* unspecified reason */
+     MODE_ERROR = -1             /* error condition */
+ } ModeStatus;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,5 @@
 VER=21.1.13
+REL=1
 SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
 CHKSUMS="sha256::b45a02d5943f72236a360d3cc97e75134aa4f63039ff88c04686b508a3dc740c"
 CHKUPDATE="anitya::id=5250"


### PR DESCRIPTION
Topic Description
-----------------

- xorg-server: backport a patch to fix high-refresh panels' fitting
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- xorg-server: 21.1.13-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorg-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
