### PR TITLE
wpa-supplicant: update to 2.11

### DIFF
--- a/app-network/wpa-supplicant/autobuild/patches/0007-nl80211-add-extra-ies-only-if-allowed-by-driver.patch
+++ b/app-network/wpa-supplicant/autobuild/patches/0007-nl80211-add-extra-ies-only-if-allowed-by-driver.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Bauer <mail@david-bauer.net>
+Date: Sun, 30 Jan 2022 20:22:00 +0100
+Subject: [PATCH] nl80211: add extra-ies only if allowed by driver
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Upgrading wpa_supplicant from 2.9 to 2.10 breaks broadcom-wl
+based adapters. The reason for it is hostapd tries to install additional
+IEs for scanning while the driver does not support this.
+
+The kernel indicates the maximum number of bytes for additional scan IEs
+using the NL80211_ATTR_MAX_SCAN_IE_LEN attribute. Save this value and
+only add additional scan IEs in case the driver can accommodate these
+additional IEs.
+
+Reported-by: Étienne Morice <neon.emorice@mail.com>
+Tested-by: Étienne Morice <neon.emorice@mail.com>
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+Bug: http://lists.infradead.org/pipermail/hostap/2022-January/040178.html
+Bug-ArchLinux: https://bugs.archlinux.org/task/73495
+Bug-Debian: https://bugs.debian.org/1004524
+Origin: http://lists.infradead.org/pipermail/hostap/2022-January/040185.html
+---
+ src/drivers/driver.h              | 3 +++
+ src/drivers/driver_nl80211_capa.c | 4 ++++
+ src/drivers/driver_nl80211_scan.c | 2 +-
+ 3 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/drivers/driver.h b/src/drivers/driver.h
+index d3312a34d8f8..b5b626451ffd 100644
+--- a/src/drivers/driver.h
++++ b/src/drivers/driver.h
+@@ -2052,6 +2052,9 @@ struct wpa_driver_capa {
+ 	/** Maximum number of iterations in a single scan plan */
+ 	u32 max_sched_scan_plan_iterations;
+ 
++	/** Maximum number of extra IE bytes for scans */
++	u16 max_scan_ie_len;
++
+ 	/** Whether sched_scan (offloaded scanning) is supported */
+ 	int sched_scan_supported;
+ 
+diff --git a/src/drivers/driver_nl80211_capa.c b/src/drivers/driver_nl80211_capa.c
+index 83868b78e6f0..b33b6badb13e 100644
+--- a/src/drivers/driver_nl80211_capa.c
++++ b/src/drivers/driver_nl80211_capa.c
+@@ -885,6 +885,10 @@ static int wiphy_info_handler(struct nl_msg *msg, void *arg)
+ 			nla_get_u32(tb[NL80211_ATTR_MAX_SCAN_PLAN_ITERATIONS]);
+ 	}
+ 
++	if (tb[NL80211_ATTR_MAX_SCAN_IE_LEN])
++		capa->max_scan_ie_len =
++			nla_get_u16(tb[NL80211_ATTR_MAX_SCAN_IE_LEN]);
++
+ 	if (tb[NL80211_ATTR_MAX_MATCH_SETS])
+ 		capa->max_match_sets =
+ 			nla_get_u8(tb[NL80211_ATTR_MAX_MATCH_SETS]);
+diff --git a/src/drivers/driver_nl80211_scan.c b/src/drivers/driver_nl80211_scan.c
+index 1316084805a3..b0f095192714 100644
+--- a/src/drivers/driver_nl80211_scan.c
++++ b/src/drivers/driver_nl80211_scan.c
+@@ -207,7 +207,7 @@ nl80211_scan_common(struct i802_bss *bss, u8 cmd,
+ 		wpa_printf(MSG_DEBUG, "nl80211: Passive scan requested");
+ 	}
+ 
+-	if (params->extra_ies) {
++	if (params->extra_ies && drv->capa.max_scan_ie_len >= params->extra_ies_len) {
+ 		wpa_hexdump(MSG_MSGDUMP, "nl80211: Scan extra IEs",
+ 			    params->extra_ies, params->extra_ies_len);
+ 		if (nla_put(msg, NL80211_ATTR_IE, params->extra_ies_len,

--- a/app-network/wpa-supplicant/spec
+++ b/app-network/wpa-supplicant/spec
@@ -1,5 +1,4 @@
-VER=2.10
-REL=2
+VER=2.11
 SRCS="tbl::https://w1.fi/releases/wpa_supplicant-$VER.tar.gz"
-CHKSUMS="sha256::20df7ae5154b3830355f8ab4269123a87affdea59fe74fe9292a91d0d7e17b2f"
+CHKSUMS="sha256::912ea06f74e30a8e36fbb68064d6cdff218d8d591db0fc5d75dee6c81ac7fc0a"
 CHKUPDATE="anitya::id=5146"


### PR DESCRIPTION
Hi, updating [wpa_supplicant](https://w1.fi/wpa_supplicant/) to the latest version [released](https://w1.fi/cgit/hostap/plain/wpa_supplicant/ChangeLog) on Jul 20.

Also added a patch specific to proprietary `broadcom-wl` driver for PR #7212, sourced from Arch Linux https://gitlab.archlinux.org/archlinux/packaging/packages/wpa_supplicant/-/blob/main/0007-nl80211-add-extra-ies-only-if-allowed-by-driver.patch

Topic Description
-----------------

wpa-supplicant-2.11

Package(s) Affected
-------------------

app-network/wpa-supplicant

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

Architectural progress for experimental ports does not impede on merging of this topic.

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
