### PR TITLE
--now removal for systemctl preset commands in postinst (Wave 1)

### DIFF
--- a/app-admin/cockpit/autobuild/postinst
+++ b/app-admin/cockpit/autobuild/postinst
@@ -2,7 +2,7 @@ systemd-sysusers cockpit-ws.sysuser.conf
 systemd-sysusers cockpit-wsinstance.sysuser.conf
 systemd-tmpfiles --create cockpit-tempfiles.conf
 
-systemctl preset --now \
+systemctl preset \
     cockpit.socket \
     pmlogger.service \
     tuned.service

--- a/app-admin/cockpit/spec
+++ b/app-admin/cockpit/spec
@@ -1,4 +1,5 @@
 VER=286.1
+REL=1
 SRCS="tbl::https://github.com/cockpit-project/cockpit/releases/download/$VER/cockpit-$VER.tar.xz"
 CHKSUMS="sha256::64bc8772a081fdebd195a7ce240a07dfe80adadaa1ef48b679a3503b86965fcc"
 CHKUPDATE="anitya::id=8849"


### PR DESCRIPTION
Topic Description
-----------------

This PR has to be split into two batches, since it contains `noarch` packages that is unbuildable on targets other than `amd64` and `arm64`.

- cockpit: remove `--now' from systemctl preset in postinst

Package(s) Affected
-------------------

- cockpit: 286.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cockpit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
