### PR TITLE
sof-firmware: update to 2024.06

### DIFF
--- a/runtime-kernel/sof-firmware/spec
+++ b/runtime-kernel/sof-firmware/spec
@@ -1,4 +1,4 @@
-VER=2024.03
+VER=2024.06
 SRCS="tbl::https://github.com/thesofproject/sof-bin/releases/download/v${VER}/sof-bin-${VER}.tar.gz"
-CHKSUMS="sha256::4fd932f7bbc1517b06fa7911e6d566814d5dc4fec5608bdb44e7c4fe4929fbf6"
+CHKSUMS="sha256::581ca3285bb56837a8954953f629ebddce644152b673ecd4bbfae1504306d7d6"
 CHKUPDATE="anitya::id=246473"


### PR DESCRIPTION
Topic Description
-----------------

- sof-firmware: update to 2024.06
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- sof-firmware: 2024.06

Security Update?
----------------

No

Build Order
-----------

```
#buildit sof-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
