### PR TITLE
--now removal for systemctl preset commands in postinst (Wave 2)

### DIFF
--- a/app-admin/cockpit-machines/autobuild/postinst
+++ b/app-admin/cockpit-machines/autobuild/postinst
@@ -1,4 +1,4 @@
-systemctl preset --now \
+systemctl preset \
     cockpit.socket \
     libvirtd.service \
     libvirt-dbus.service

--- a/app-admin/cockpit-machines/spec
+++ b/app-admin/cockpit-machines/spec
@@ -1,4 +1,5 @@
 VER=284.1
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/cockpit-project/cockpit-machines"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=234956"

--- a/app-admin/cockpit-podman/autobuild/postinst
+++ b/app-admin/cockpit-podman/autobuild/postinst
@@ -1,3 +1,3 @@
-systemctl preset --now \
+systemctl preset \
     cockpit.socket \
     podman.service

--- a/app-admin/cockpit-podman/spec
+++ b/app-admin/cockpit-podman/spec
@@ -1,4 +1,5 @@
 VER=63
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/cockpit-project/cockpit-podman"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=234953"


### PR DESCRIPTION
Topic Description
-----------------

Depends on #7215.

- cockpit-machines: remove `--now' from systemctl preset in postinst
- cockpit-podman: remove `--now' from systemctl preset in postinst

Package(s) Affected
-------------------

- cockpit-machines: 284.1-1
- cockpit-podman: 63-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cockpit-machines cockpit-podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
