### PR TITLE
Rework for cmark update to 0.31.0

### DIFF
--- a/app-multimedia/mkvtoolnix/spec
+++ b/app-multimedia/mkvtoolnix/spec
@@ -1,4 +1,5 @@
 VER=84.0
+REL=1
 SRCS="tbl::https://www.bunkus.org/videotools/mkvtoolnix/sources/mkvtoolnix-$VER.tar.xz"
 CHKSUMS="sha256::e9176dea435c3b06b4716fb131d53c8f2621977576ccc4aee8ff9050c0d9ea7a"
 CHKUPDATE="anitya::id=1991"

--- a/desktop-gnome/evolution/spec
+++ b/desktop-gnome/evolution/spec
@@ -1,5 +1,5 @@
 VER=3.44.4
-REL=5
+REL=6
 SRCS="https://download.gnome.org/sources/evolution/${VER:0:4}/evolution-$VER.tar.xz"
 CHKSUMS="sha256::f0b16e7abad3c7945a29c322f17dab4a08d61e99bd7cc91b8df35053c5c12e8c"
 CHKUPDATE="anitya::id=10934"

--- a/desktop-gnome/gnome-builder/spec
+++ b/desktop-gnome/gnome-builder/spec
@@ -1,5 +1,5 @@
 VER=42.1
-REL=6
+REL=7
 SRCS="https://download.gnome.org/sources/gnome-builder/${VER%.*}/gnome-builder-$VER.tar.xz"
 CHKSUMS="sha256::5d4d51b702865b48017201f0c607e24a27d72031a8f5c88d4fce875b5545670a"
 CHKUPDATE="anitya::id=5574"

--- a/desktop-kde/neochat/spec
+++ b/desktop-kde/neochat/spec
@@ -1,4 +1,5 @@
 VER=23.08.5
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/neochat-$VER.tar.xz"
 CHKSUMS="sha256::d300c6d8eb1dcc96b853c61a43e058ae923b939e3991755ddce1d9f210904632"
 CHKUPDATE="anitya::id=8763"

--- a/groups/cmark-rebuilds
+++ b/groups/cmark-rebuilds
@@ -1,0 +1,4 @@
+evolution
+gnome-builder
+mkvtoolnix
+neochat

--- a/runtime-doc/cmark/autobuild/defines
+++ b/runtime-doc/cmark/autobuild/defines
@@ -3,6 +3,6 @@ PKGSEC=libs
 PKGDEP="glibc"
 PKGDES="CommonMark parsing and rendering library and program in C"
 
-PKGBREAK="evolution<=3.44.4-1 mkvtoolnix<=79.0-1 gnome-builder<=42.1-3"
+PKGBREAK="evolution<=3.44.4-5 mkvtoolnix<=84.0 gnome-builder<=42.1-6 neochat<=23.08.5"
 
 CMAKE_AFTER="-DCMARK_STATIC=OFF"


### PR DESCRIPTION
Topic Description
-----------------

- cmark: add PKGDEP for packages built against old 0.30.3 version
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- groups: add cmark-rebuilds
    Note that cmark have the full version number present in soname, so
    rebuilding is needed for every version number bump of it.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- neochat: bump REL for cmark update
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- mkvtoolnix: bump REL for cmark update
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- gnome-builder: bump REL for cmark update
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- evolution: bump REL for cmark update
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- cmark: 0.31.0
- evolution: 3.44.4-6
- gnome-builder: 42.1-7
- mkvtoolnix: 84.0-1
- neochat: 23.08.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit evolution gnome-builder mkvtoolnix neochat cmark
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
