### PR TITLE
lz4: update to 1.10.0

### DIFF
--- a/app-utils/lz4/spec
+++ b/app-utils/lz4/spec
@@ -1,5 +1,5 @@
 VER=1.10.0
 SRCS="git::commit=tags/v$VER::https://github.com/lz4/lz4"
 CHKSUMS="SKIP"
-SUBDIR="lz4/contrib/meson"
+SUBDIR="lz4/build/meson"
 CHKUPDATE="anitya::id=1865"

--- a/app-utils/lz4/spec
+++ b/app-utils/lz4/spec
@@ -1,5 +1,4 @@
-VER=1.9.4
-REL=1
+VER=1.10.0
 SRCS="git::commit=tags/v$VER::https://github.com/lz4/lz4"
 CHKSUMS="SKIP"
 SUBDIR="lz4/contrib/meson"


### PR DESCRIPTION
Topic Description
-----------------

- lz4: update to 1.10.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lz4: 1:1.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lz4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
