### PR TITLE
libquotient: update to 0.8.2

### DIFF
--- a/desktop-kde/neochat/autobuild/defines
+++ b/desktop-kde/neochat/autobuild/defines
@@ -12,3 +12,6 @@ CMAKE_AFTER="-DBUILD_COVERAGE=OFF \
              -DENABLE_BSYMBOLICFUNCTIONS=OFF \
              -DKDE_INSTALL_PREFIX_SCRIPT=OFF \
              -DKDE_INSTALL_USE_QT_SYS_PATHS=ON"
+
+# FIXME: mips64r6el has not yet built KDE-related dependencies, skipping for now.
+FAIL_ARCH="mips64r6el"

--- a/desktop-kde/neochat/spec
+++ b/desktop-kde/neochat/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/neochat-$VER.tar.xz"
 CHKSUMS="sha256::d300c6d8eb1dcc96b853c61a43e058ae923b939e3991755ddce1d9f210904632"
 CHKUPDATE="anitya::id=8763"

--- a/runtime-web/libquotient/autobuild/defines
+++ b/runtime-web/libquotient/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libquotient
 PKGSEC=libs
-PKGDEP="qt-5 qtkeychain"
+PKGDEP="qt-5 qtkeychain libolm"
 PKGDES="A Qt5 library for writing cross-platform Matrix clients"
 
-CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON"
+CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON -DQuotient_ENABLE_E2EE=ON"

--- a/runtime-web/libquotient/spec
+++ b/runtime-web/libquotient/spec
@@ -1,4 +1,4 @@
-VER=0.8.1.2
+VER=0.8.2
 SRCS="git::commit=tags/$VER::https://github.com/quotient-im/libQuotient"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=89357"


### PR DESCRIPTION
Topic Description
-----------------

- neochat: bump REL due to libquotient enabling E2EE
    - E2EE will be disabled without rebuilding neochat.
    - Add FAIL_ARCH: mips64r6el
- libquotient: update to 0.8.2
    - Enable E2EE
    - Add libolm as dependency

Package(s) Affected
-------------------

- libquotient: 0.8.2
- neochat: 23.08.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libquotient neochat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [ ] MIPS R6 64-bit (Little Endian) `mips64r6el`
