### PR TITLE
dkcli: new, 0.1.0

### DIFF
--- a/app-admin/dkcli/autobuild/defines
+++ b/app-admin/dkcli/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=dkcli
+PKGDES="Command-line frontend for DeployKit"
+PKGDEP="openssl gcc-runtime glibc zlib"
+BUILDDEP="llvm rustc"
+PKGSEC="admin"
+
+USECLANG=1
+
+# FIXME: ld.lld does not support loongson3 and mips64r6el
+USECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1
+USECLANG__MIPS64R6EL=0
+NOLTO__MIPS64R6EL=1

--- a/app-admin/dkcli/spec
+++ b/app-admin/dkcli/spec
@@ -1,0 +1,4 @@
+VER=0.1.0
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/dkcli"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=373533"


### PR DESCRIPTION
Topic Description
-----------------

- dkcli: new, 0.1.0

Package(s) Affected
-------------------

- dkcli: 0.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dkcli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
