### PR TITLE
libolm: new, 3.2.16

### DIFF
--- a/runtime-web/libolm/autobuild/defines
+++ b/runtime-web/libolm/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=libolm
+PKGSEC=libs
+PKGDEP="glibc gcc-runtime"
+PKGDES="Implementation of the Olm and Megolm cryptographic ratchets"

--- a/runtime-web/libolm/spec
+++ b/runtime-web/libolm/spec
@@ -1,0 +1,4 @@
+VER=3.2.16
+SRCS="git::commit=tags/$VER::https://gitlab.matrix.org/matrix-org/olm"
+CHKSUMS="sha256::f77032dbdc9a2040879bcc21c3e62cb6656b62e9550a1bb8da5a5b38ba21352a"
+CHKUPDATE="anitya::id=29706"


### PR DESCRIPTION
Topic Description
-----------------

- libolm: new, 3.2.16

Package(s) Affected
-------------------

- libolm: 3.2.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit libolm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
