### PR TITLE
bind: security update to 9.18.28

### DIFF
--- a/app-network/bind/spec
+++ b/app-network/bind/spec
@@ -1,5 +1,4 @@
-VER=9.18.24
-REL=1
+VER=9.18.28
 SRCS="tbl::https://downloads.isc.org/isc/bind${VER:0:1}/${VER/.P/-P}/bind-${VER/.P/-P}.tar.xz"
-CHKSUMS="sha256::709d73023c9115ddad3bab65b6c8c79a590196d0d114f5d0ca2533dbd52ddf66"
+CHKSUMS="sha256::e7cce9a165f7b619eefc4832f0a8dc16b005d29e3890aed6008c506ea286a5e7"
 CHKUPDATE="anitya::id=77661"


### PR DESCRIPTION
Topic Description
-----------------

- bind: security update to 9.18.28, #7229

Package(s) Affected
-------------------

- bind: 1:9.18.28

Security Update?
----------------

No

Build Order
-----------

```
#buildit bind
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
