### PR TITLE
brltty: fix build

### DIFF
--- a/app-a11y/brltty/autobuild/prepare
+++ b/app-a11y/brltty/autobuild/prepare
@@ -3,7 +3,7 @@ for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
     # FIXME: hard-coded automake version.
     # Adapted from redhat-rpm-config.
     # http://pkgs.fedoraproject.org/cgit/rpms/redhat-rpm-config.git/tree/macros#n35
-    cp -v /usr/share/automake-1.16/$(basename $i) $i ; \
+    cp -v /usr/bin/$(basename $i) $i ; \
 done
 
 if ab_match_arch mips64r6el; then

--- a/app-a11y/brltty/spec
+++ b/app-a11y/brltty/spec
@@ -1,5 +1,5 @@
 VER=6.6
-REL=3
+REL=4
 SRCS="tbl::http://mielke.cc/brltty/archive/brltty-$VER.tar.gz"
 CHKSUMS="sha256::13e8f699bf144ee1b1e8f9003add3785092f7f55ef107c4912e3c14f6ccca4fc"
 CHKUPDATE="anitya::id=220"


### PR DESCRIPTION
Topic Description
-----------------

- brltty: modify prepare for automake 1.17

Package(s) Affected
-------------------

- brltty: 6.6-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit brltty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
