### PR TITLE
Zstd Package Distribution Rework

### DIFF
--- a/app-admin/p-vector/autobuild/defines
+++ b/app-admin/p-vector/autobuild/defines
@@ -9,6 +9,8 @@ PKGDES="A deb package scanner and APT metadata generator"
 NOCARGOAUDIT=1
 
 USECLANG=1
+# FIXME: clang: error: clang frontend command failed with exit code 139
+USECLANG__MIPS64R6EL=0
 
 # FIXME
 # error: linking with `clang` failed: exit status: 1

--- a/app-admin/p-vector/autobuild/defines
+++ b/app-admin/p-vector/autobuild/defines
@@ -5,6 +5,9 @@ PKGRECOM="sqlite-fdw gnupg"
 BUILDDEP="rustc llvm"
 PKGDES="A deb package scanner and APT metadata generator"
 
+# FIXME: cargo-audit hates git repo
+NOCARGOAUDIT=1
+
 USECLANG=1
 
 # FIXME

--- a/app-admin/p-vector/autobuild/defines
+++ b/app-admin/p-vector/autobuild/defines
@@ -6,10 +6,14 @@ BUILDDEP="rustc llvm"
 PKGDES="A deb package scanner and APT metadata generator"
 
 USECLANG=1
-ABSPLITDBG=0
 
-# FIXME: Segfaults during linkage.
+# FIXME
+# error: linking with `clang` failed: exit status: 1
+#   |
+#   = note: LC_ALL="C" PATH="/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/bin:/usr/local/bin:/usr/bin" VSLANG="1033" "clang" "/tmp/rustcvF3DEX/symbols.o" "/var/cache/acbs/build/acbs.kf711uo2/p-vector/target/release/build/parking_lot_core-47deb56c435e10eb/build_script_build-47deb56c435e10eb.build_script_build.e26e8f45230bb829-cgu.0.rcgu.o" "/var/cache/acbs/build/acbs.kf711uo2/p-vector/target/release/build/parking_lot_core-47deb56c435e10eb/build_script_build-47deb56c435e10eb.597xuuklyq2jnh22.rcgu.o" "-Wl,--as-needed" "-L" "/var/cache/acbs/build/acbs.kf711uo2/p-vector/target/release/deps" "-L" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib" "-Wl,-Bstatic" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libstd-bccd059e17955a73.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libpanic_unwind-24a454ed5dcb8454.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libobject-5d6a8eb77b5797b1.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libmemchr-e1faf9edb463f095.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libaddr2line-5efc153f47d8bb40.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libgimli-36d2c641f2739812.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/librustc_demangle-b418896c90ff386a.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libstd_detect-e587d61c68aa9f29.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libhashbrown-81136854c7c05b83.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/librustc_std_workspace_alloc-f3702ca41025cfda.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libminiz_oxide-66c6ebb01e1bcf66.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libadler-8c4d58bf8084241f.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libunwind-edd1600e6a10c3b0.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libcfg_if-634b11ebe68c58fa.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/liblibc-a9da0b8bc29df4a0.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/liballoc-0515d4bf03de665c.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/librustc_std_workspace_core-1cde6993ecf2ea6b.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libcore-5837ef799bc248c1.rlib" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libcompiler_builtins-71962349a9833762.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-Wl,-plugin-opt=O3,-plugin-opt=mcpu=mips64r6" "-L" "/usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib" "-o" "/var/cache/acbs/build/acbs.kf711uo2/p-vector/target/release/build/parking_lot_core-47deb56c435e10eb/build_script_build-47deb56c435e10eb" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-nodefaultlibs" "-flto" "-fuse-ld=lld" "-Wl,-build-id=sha1" "-Wl,--lto-O3" "-Wl,--relax"
+#   = note: ld.lld: error: relocation R_MIPS_64 cannot be used against symbol 'DW.ref.rust_eh_personality'; recompile with -fPIC
+#           >>> defined in /usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libstd-bccd059e17955a73.rlib(std-bccd059e17955a73.std.b38466d5fa66b5e1-cgu.0.rcgu.o)
+#           >>> referenced by std.b38466d5fa66b5e1-cgu.0
+#           >>>               std-bccd059e17955a73.std.b38466d5fa66b5e1-cgu.0.rcgu.o:(.eh_frame+0x378F) in archive /usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libstd-bccd059e17955a73.rlib
 NOLTO__LOONGSON3=1
-
-# FIXME: ld.lld is not yet available.
-NOLTO__LOONGARCH64=1
+NOLTO__MIPS64R6EL=1

--- a/app-admin/p-vector/spec
+++ b/app-admin/p-vector/spec
@@ -1,4 +1,4 @@
-VER=0.3.8
+VER=0.4.0
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/p-vector-rs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242069"

--- a/app-admin/p-vector/spec
+++ b/app-admin/p-vector/spec
@@ -1,4 +1,4 @@
-VER=0.4.0
+VER=0.4.1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/p-vector-rs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242069"

--- a/app-devel/ciel/autobuild/defines
+++ b/app-devel/ciel/autobuild/defines
@@ -5,6 +5,8 @@ BUILDDEP="rustc llvm"
 PKGDES="An integrated packaging environment for AOSC OS"
 
 USECLANG=1
+# FIXME: clang: error: clang frontend command failed with exit code 139
+USECLANG__MIPS64R6EL=0
 
 # FIXME
 # error: linking with `clang` failed: exit status: 1

--- a/app-devel/ciel/autobuild/defines
+++ b/app-devel/ciel/autobuild/defines
@@ -5,10 +5,14 @@ BUILDDEP="rustc llvm"
 PKGDES="An integrated packaging environment for AOSC OS"
 
 USECLANG=1
-USECLANG__LOONGSON3=0
-USECLANG__PPC64=0
-USECLANG__MIPS64R6EL=0
+
+# FIXME
+# error: linking with `clang` failed: exit status: 1
+#   |
+#   = note: (command-line)
+#   = note: ld.lld: error: relocation R_MIPS_64 cannot be used against symbol 'DW.ref.rust_eh_personality'; recompile with -fPIC
+#           >>> defined in /usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libstd-bccd059e17955a73.rlib(std-bccd059e17955a73.std.b38466d5fa66b5e1-cgu.0.rcgu.o)
+#           >>> referenced by std.b38466d5fa66b5e1-cgu.0
+#           >>>               std-bccd059e17955a73.std.b38466d5fa66b5e1-cgu.0.rcgu.o:(.eh_frame+0x378F) in archive /usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libstd-bccd059e17955a73.rlib
 NOLTO__LOONGSON3=1
 NOLTO__MIPS64R6EL=1
-NOLTO__LOONGARCH64=1
-ABSPLITDBG=0

--- a/app-devel/ciel/spec
+++ b/app-devel/ciel/spec
@@ -1,4 +1,4 @@
-VER=3.2.8
+VER=3.3.0
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227000"


### PR DESCRIPTION
Topic Description
-----------------

- ciel: update to 3.3.0
    This version adds the ability to handle Zstd-compressed .deb packages, as we
    have recently switched to this format system-wide.
- p-vector: update to 0.4.0
    This version adds the ability to handle Zstd-compressed .deb packages, as we
    have recently switched to this format system-wide.

Package(s) Affected
-------------------

- ciel: 3.3.0
- p-vector: 0.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit p-vector ciel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
