### PR TITLE
tio: new, 3.6

### DIFF
--- a/app-utils/tio/autobuild/defines
+++ b/app-utils/tio/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=tio
+PKGDES="A serial device I/O tool for connecting to TTY devices"
+PKGDEP="glib lua inih"
+PKGSEC="utils"
+
+ABTYPE=meson

--- a/app-utils/tio/spec
+++ b/app-utils/tio/spec
@@ -1,0 +1,4 @@
+VER=3.6
+SRCS="git::commit=tags/v$VER::https://github.com/tio/tio.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=20587"


### PR DESCRIPTION
Topic Description
-----------------

- tio: new, 3.6

Package(s) Affected
-------------------

- tio: 3.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit tio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
