### PR TITLE
logiops: new

### DIFF
--- a/runtime-devices/logiops/autobuild/defines
+++ b/runtime-devices/logiops/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=logiops
+PKGDES="A unofficial userspace driver for Logitech HID++ devices"
+PKGDEP="systemd libevdev glib libconfig"
+PKGSEC=libs
+
+ABTYPE=cmakeninja
+CMAKE_AFTER="-DCMAKE_BUILD_TYPE=Release"

--- a/runtime-devices/logiops/spec
+++ b/runtime-devices/logiops/spec
@@ -1,0 +1,4 @@
+VER=0.3.4
+SRCS="git::commit=tags/v$VER::https://github.com/pixlone/logiops.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=130358"


### PR DESCRIPTION
Topic Description
-----------------

- logiops: new, 0.3.4

Package(s) Affected
-------------------

- logiops: 0.3.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit logiops
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
