### PR TITLE
libolm: 3.2.16 rework

### DIFF
--- a/runtime-web/libolm/autobuild/defines
+++ b/runtime-web/libolm/autobuild/defines
@@ -2,3 +2,6 @@ PKGNAME=libolm
 PKGSEC=libs
 PKGDEP="glibc gcc-runtime"
 PKGDES="Implementation of the Olm and Megolm cryptographic ratchets"
+
+PKGBREAK="olm<=3.2.2-1"
+PKGREP="olm<=3.2.2-1"


### PR DESCRIPTION
Topic Description
-----------------

- libolm: add PKGBREAK and PKGREP

Package(s) Affected
-------------------

- libolm: 3.2.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit libolm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
