### PR TITLE
xorg-server: backport patches from upstream master branch

### DIFF
--- a/runtime-display/xorg-server/autobuild/patches/1001-BACKPORT-build-Drop-libxcvt-requirement-from-SDK_REQUIRED_MOD.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1001-BACKPORT-build-Drop-libxcvt-requirement-from-SDK_REQUIRED_MOD.patch
@@ -1,0 +1,32 @@
+From 99302dc7640ae4840c1ec64a4ac7df703c4d4b11 Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Tue, 23 Jul 2024 17:11:55 +0200
+Subject: [PATCH 001/105] build: Drop libxcvt requirement from
+ SDK_REQUIRED_MODULES
+
+The SDK doed not need libxcvt, only Xorg and Xwayland do.
+
+Closes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1721
+Fixes: a4ab57cb7 - build: Add dependency on libxcvt
+Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1618>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index f8145e4a9..7d442c214 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -763,7 +763,7 @@ PKG_CHECK_MODULES(PIXMAN, $LIBPIXMAN)
+ REQUIRED_LIBS="$REQUIRED_LIBS $LIBPIXMAN $LIBXFONT xau"
+ 
+ dnl Core modules for most extensions, et al.
+-SDK_REQUIRED_MODULES="$XPROTO $RANDRPROTO $RENDERPROTO $XEXTPROTO $INPUTPROTO $KBPROTO $FONTSPROTO $LIBPIXMAN $LIBXCVT"
++SDK_REQUIRED_MODULES="$XPROTO $RANDRPROTO $RENDERPROTO $XEXTPROTO $INPUTPROTO $KBPROTO $FONTSPROTO $LIBPIXMAN"
+ # Make SDK_REQUIRED_MODULES available for inclusion in xorg-server.pc
+ AC_SUBST(SDK_REQUIRED_MODULES)
+ 
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1002-BACKPORT-ephyr-glamor-Port-to-EGL.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1002-BACKPORT-ephyr-glamor-Port-to-EGL.patch
@@ -1,0 +1,757 @@
+From 9848012c1a8b7a90c14df500a5d5ec5ac8d5b3aa Mon Sep 17 00:00:00 2001
+From: Adam Jackson <ajax@redhat.com>
+Date: Thu, 1 Jul 2021 15:40:19 -0400
+Subject: [PATCH 002/105] ephyr/glamor: Port to EGL
+
+There's no real benefit to using GLX, and the other DDXes are using EGL
+already, so let's converge on EGL so we can concentrate the fixes in one
+place.
+
+We go to some effort to avoid being the thing that requires libX11 here.
+We prefer EGL_EXT_platform_xcb over _x11, and if forced to use the
+latter we'll ask the dynamic linker for XGetXCBConnection and
+XOpenDisplay rather than link against xlib stuff ourselves. Xephyr is
+now a pure XCB application if it can be.
+
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ configure.ac                                  |   3 -
+ glamor/Makefile.am                            |   1 -
+ glamor/glamor.c                               |   3 -
+ glamor/glamor_glx.c                           |  68 ----
+ glamor/meson.build                            |   1 -
+ hw/kdrive/ephyr/Makefile.am                   |   4 +-
+ hw/kdrive/ephyr/ephyr.c                       |   5 +-
+ hw/kdrive/ephyr/ephyr.h                       |   5 +-
+ .../{ephyr_glamor_glx.c => ephyr_glamor.c}    | 290 ++++++++----------
+ .../{ephyr_glamor_glx.h => ephyr_glamor.h}    |  22 +-
+ hw/kdrive/ephyr/hostx.c                       |  25 +-
+ hw/kdrive/ephyr/meson.build                   |   3 +-
+ 12 files changed, 148 insertions(+), 282 deletions(-)
+ delete mode 100644 glamor/glamor_glx.c
+ rename hw/kdrive/ephyr/{ephyr_glamor_glx.c => ephyr_glamor.c} (57%)
+ rename hw/kdrive/ephyr/{ephyr_glamor_glx.h => ephyr_glamor.h} (82%)
+
+diff --git a/configure.ac b/configure.ac
+index 7d442c214..dad009e4e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2192,9 +2192,6 @@ if test "$KDRIVE" = yes; then
+     if test "x$DRI" = xyes && test "x$GLX" = xyes; then
+         XEPHYR_REQUIRED_LIBS="$XEPHYR_REQUIRED_LIBS $LIBDRM xcb-glx xcb-xf86dri > 1.6"
+     fi
+-    if test "x$GLAMOR" = xyes; then
+-        XEPHYR_REQUIRED_LIBS="$XEPHYR_REQUIRED_LIBS x11-xcb"
+-    fi
+ 
+     if test "x$XEPHYR" = xauto; then
+         PKG_CHECK_MODULES(XEPHYR, $XEPHYR_REQUIRED_LIBS, [XEPHYR="yes"], [XEPHYR="no"])
+diff --git a/glamor/Makefile.am b/glamor/Makefile.am
+index aaf0aab17..7069fbd16 100644
+--- a/glamor/Makefile.am
++++ b/glamor/Makefile.am
+@@ -13,7 +13,6 @@ libglamor_la_SOURCES = \
+ 	glamor_debug.h \
+ 	glamor_font.c \
+ 	glamor_font.h \
+-	glamor_glx.c \
+ 	glamor_composite_glyphs.c \
+ 	glamor_image.c \
+ 	glamor_lines.c \
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index da2ea94ba..65fb132e5 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -670,9 +670,6 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+      * register correct close screen function. */
+     if (flags & GLAMOR_USE_EGL_SCREEN) {
+         glamor_egl_screen_init(screen, &glamor_priv->ctx);
+-    } else {
+-        if (!glamor_glx_screen_init(&glamor_priv->ctx))
+-            goto fail;
+     }
+ 
+     glamor_make_current(glamor_priv);
+diff --git a/glamor/glamor_glx.c b/glamor/glamor_glx.c
+deleted file mode 100644
+index 7107c7c17..000000000
+--- a/glamor/glamor_glx.c
++++ /dev/null
+@@ -1,68 +0,0 @@
+-/*
+- * Copyright © 2013 Intel Corporation
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining a
+- * copy of this software and associated documentation files (the "Software"),
+- * to deal in the Software without restriction, including without limitation
+- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+- * and/or sell copies of the Software, and to permit persons to whom the
+- * Software is furnished to do so, subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice (including the next
+- * paragraph) shall be included in all copies or substantial portions of the
+- * Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+- * IN THE SOFTWARE.
+- */
+-
+-#include <epoxy/glx.h>
+-#include "glamor_context.h"
+-
+-/**
+- * @file glamor_glx.c
+- *
+- * GLX context management for glamor.
+- *
+- * This has to be kept separate from the server sources because of
+- * Xlib's conflicting definition of CARD32 and similar typedefs.
+- */
+-
+-static void
+-glamor_glx_make_current(struct glamor_context *glamor_ctx)
+-{
+-    /* There's only a single global dispatch table in Mesa.  EGL, GLX,
+-     * and AIGLX's direct dispatch table manipulation don't talk to
+-     * each other.  We need to set the context to NULL first to avoid
+-     * GLX's no-op context change fast path when switching back to
+-     * GLX.
+-     */
+-    glXMakeCurrent(glamor_ctx->display, None, None);
+-
+-    glXMakeCurrent(glamor_ctx->display, glamor_ctx->drawable_xid,
+-                   glamor_ctx->ctx);
+-}
+-
+-
+-Bool
+-glamor_glx_screen_init(struct glamor_context *glamor_ctx)
+-{
+-    glamor_ctx->ctx = glXGetCurrentContext();
+-    if (!glamor_ctx->ctx)
+-        return False;
+-
+-    glamor_ctx->display = glXGetCurrentDisplay();
+-    if (!glamor_ctx->display)
+-        return False;
+-
+-    glamor_ctx->drawable_xid = glXGetCurrentDrawable();
+-
+-    glamor_ctx->make_current = glamor_glx_make_current;
+-
+-    return True;
+-}
+diff --git a/glamor/meson.build b/glamor/meson.build
+index 268af593e..4a3f6241a 100644
+--- a/glamor/meson.build
++++ b/glamor/meson.build
+@@ -4,7 +4,6 @@ srcs_glamor = [
+     'glamor_core.c',
+     'glamor_dash.c',
+     'glamor_font.c',
+-    'glamor_glx.c',
+     'glamor_composite_glyphs.c',
+     'glamor_image.c',
+     'glamor_lines.c',
+diff --git a/hw/kdrive/ephyr/Makefile.am b/hw/kdrive/ephyr/Makefile.am
+index d12559b39..a3d6b1c02 100644
+--- a/hw/kdrive/ephyr/Makefile.am
++++ b/hw/kdrive/ephyr/Makefile.am
+@@ -41,8 +41,8 @@ GLAMOR_XV_SRCS = ephyr_glamor_xv.c
+ endif
+ 
+ GLAMOR_SRCS = \
+-	ephyr_glamor_glx.c \
+-	ephyr_glamor_glx.h \
++	ephyr_glamor.c \
++	ephyr_glamor.h \
+ 	$(GLAMOR_XV_SRCS)  \
+ 	$()
+ endif
+diff --git a/hw/kdrive/ephyr/ephyr.c b/hw/kdrive/ephyr/ephyr.c
+index c503ad6a6..9236252b2 100644
+--- a/hw/kdrive/ephyr/ephyr.c
++++ b/hw/kdrive/ephyr/ephyr.c
+@@ -39,7 +39,7 @@
+ #ifdef GLAMOR
+ #include "glamor.h"
+ #endif
+-#include "ephyr_glamor_glx.h"
++#include "ephyr_glamor.h"
+ #include "glx_extinit.h"
+ #include "xkbsrv.h"
+ 
+@@ -1171,9 +1171,6 @@ ephyrXcbProcessEvents(Bool queued_only)
+         }
+ 
+         if (xev) {
+-            if (ephyr_glamor)
+-                ephyr_glamor_process_event(xev);
+-
+             free(xev);
+         }
+     }
+diff --git a/hw/kdrive/ephyr/ephyr.h b/hw/kdrive/ephyr/ephyr.h
+index 587a48dc7..8833de8a9 100644
+--- a/hw/kdrive/ephyr/ephyr.h
++++ b/hw/kdrive/ephyr/ephyr.h
+@@ -71,6 +71,7 @@ typedef struct _ephyrScrPriv {
+     xcb_window_t win;
+     xcb_window_t win_pre_existing;    /* Set via -parent option like xnest */
+     xcb_window_t peer_win;            /* Used for GL; should be at most one */
++    xcb_visualid_t vid;
+     xcb_image_t *ximg;
+     Bool win_explicit_position;
+     int win_x, win_y;
+@@ -87,10 +88,6 @@ typedef struct _ephyrScrPriv {
+ 
+     ScreenBlockHandlerProcPtr   BlockHandler;
+ 
+-    /**
+-     * Per-screen Xlib-using state for glamor (private to
+-     * ephyr_glamor_glx.c)
+-     */
+     struct ephyr_glamor *glamor;
+ } EphyrScrPriv;
+ 
+diff --git a/hw/kdrive/ephyr/ephyr_glamor_glx.c b/hw/kdrive/ephyr/ephyr_glamor.c
+similarity index 57%
+rename from hw/kdrive/ephyr/ephyr_glamor_glx.c
+rename to hw/kdrive/ephyr/ephyr_glamor.c
+index 40b80cbe7..1e22cbd02 100644
+--- a/hw/kdrive/ephyr/ephyr_glamor_glx.c
++++ b/hw/kdrive/ephyr/ephyr_glamor.c
+@@ -21,25 +21,20 @@
+  * IN THE SOFTWARE.
+  */
+ 
+-/** @file ephyr_glamor_glx.c
++/** @file ephyr_glamor.c
+  *
+- * Separate file for hiding Xlib and GLX-using parts of xephyr from
+- * the rest of the server-struct-aware build.
++ * Glamor support and EGL setup.
+  */
+ 
+ #include <stdlib.h>
+-#include <X11/Xlib.h>
+-#include <X11/Xlibint.h>
+-#undef Xcalloc
+-#undef Xrealloc
+-#undef Xfree
+-#include <X11/Xlib-xcb.h>
++#include <stdint.h>
++#include <xcb/xcb.h>
+ #include <xcb/xcb_aux.h>
+ #include <pixman.h>
+-#include <epoxy/glx.h>
+-#include "ephyr_glamor_glx.h"
++#include "glamor_egl.h"
++#include "glamor_priv.h"
++#include "ephyr_glamor.h"
+ #include "os.h"
+-#include <X11/Xproto.h>
+ 
+ /* until we need geometry shaders GL3.1 should suffice. */
+ /* Xephyr has its own copy of this for build reasons */
+@@ -47,15 +42,8 @@
+ #define GLAMOR_GL_CORE_VER_MINOR 1
+ /** @{
+  *
+- * global state for Xephyr with glamor.
+- *
+- * Xephyr can render with multiple windows, but all the windows have
+- * to be on the same X connection and all have to have the same
+- * visual.
++ * global state for Xephyr with glamor, all of which is arguably a bug.
+  */
+-static Display *dpy;
+-static XVisualInfo *visual_info;
+-static GLXFBConfig fb_config;
+ Bool ephyr_glamor_gles2;
+ Bool ephyr_glamor_skip_present;
+ /** @} */
+@@ -64,9 +52,10 @@ Bool ephyr_glamor_skip_present;
+  * Per-screen state for Xephyr with glamor.
+  */
+ struct ephyr_glamor {
+-    GLXContext ctx;
+-    Window win;
+-    GLXWindow glx_win;
++    EGLDisplay dpy;
++    EGLContext ctx;
++    xcb_window_t win;
++    EGLSurface egl_win;
+ 
+     GLuint tex;
+ 
+@@ -178,16 +167,86 @@ ephyr_glamor_setup_texturing_shader(struct ephyr_glamor *glamor)
+     assert(glamor->texture_shader_texcoord_loc != -1);
+ }
+ 
++#ifndef EGL_PLATFORM_XCB_EXT
++#define EGL_PLATFORM_XCB_EXT 0x31DC
++#endif
++
++#include <dlfcn.h>
++#ifndef RTLD_DEFAULT
++#define RTLD_DEFAULT NULL
++#endif
++
++/* (loud booing)
++ *
++ * keeping this as a static variable is bad form, we _could_ have zaphod heads
++ * on different displays (for example). but other bits of Xephyr are already
++ * broken for that case, and fixing that would entail fixing the rest of the
++ * contortions with hostx.c anyway, so this works for now.
++ */
++static EGLDisplay edpy = EGL_NO_DISPLAY;
++
+ xcb_connection_t *
+ ephyr_glamor_connect(void)
+ {
+-    dpy = XOpenDisplay(NULL);
+-    if (!dpy)
+-        return NULL;
++    int major = 0, minor = 0;
++
++    /*
++     * Try pure xcb first. If that doesn't work but we can find XOpenDisplay,
++     * fall back to xlib. This lets us potentially not load libX11 at all, if
++     * the EGL is also pure xcb.
++     */
++
++    if (epoxy_has_egl_extension(EGL_NO_DISPLAY, "EGL_EXT_platform_xcb")) {
++        xcb_connection_t *conn = xcb_connect(NULL, NULL);
++        EGLDisplay dpy = glamor_egl_get_display(EGL_PLATFORM_XCB_EXT, conn);
++
++        if (dpy == EGL_NO_DISPLAY) {
++            xcb_disconnect(conn);
++            return NULL;
++        }
++
++        edpy = dpy;
++        eglInitialize(dpy, &major, &minor);
++        return conn;
++    }
++
++    if (epoxy_has_egl_extension(EGL_NO_DISPLAY, "EGL_EXT_platform_x11") ||
++        epoxy_has_egl_extension(EGL_NO_DISPLAY, "EGL_KHR_platform_x11)")) {
++        void *lib = NULL;
++        xcb_connection_t *ret = NULL;
++        void *(*x_open_display)(void *) =
++            (void *) dlsym(RTLD_DEFAULT, "XOpenDisplay");
++        xcb_connection_t *(*x_get_xcb_connection)(void *) =
++            (void *) dlsym(RTLD_DEFAULT, "XGetXCBConnection");
++
++        if (x_open_display == NULL)
++            return NULL;
++
++        if (x_get_xcb_connection == NULL) {
++            lib = dlopen("libX11-xcb.so.1", RTLD_LOCAL | RTLD_LAZY);
++            x_get_xcb_connection =
++                (void *) dlsym(lib, "XGetXCBConnection");
++        }
++
++        if (x_get_xcb_connection == NULL)
++            goto out;
+ 
+-    XSetEventQueueOwner(dpy, XCBOwnsEventQueue);
++        void *xdpy = x_open_display(NULL);
++        EGLDisplay dpy = glamor_egl_get_display(EGL_PLATFORM_X11_KHR, xdpy);
++        if (dpy == EGL_NO_DISPLAY)
++            goto out;
++
++        edpy = dpy;
++        eglInitialize(dpy, &major, &minor);
++        ret = x_get_xcb_connection(xdpy);
++out:
++        if (lib)
++            dlclose(lib);
++
++        return ret;
++    }
+ 
+-    return XGetXCBConnection(dpy);
++    return NULL;
+ }
+ 
+ void
+@@ -221,7 +280,7 @@ ephyr_glamor_damage_redisplay(struct ephyr_glamor *glamor,
+     if (ephyr_glamor_skip_present)
+         return;
+ 
+-    glXMakeCurrent(dpy, glamor->glx_win, glamor->ctx);
++    eglMakeCurrent(glamor->dpy, glamor->egl_win, glamor->egl_win, glamor->ctx);
+ 
+     glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &old_vao);
+     glBindVertexArray(glamor->vao);
+@@ -238,53 +297,12 @@ ephyr_glamor_damage_redisplay(struct ephyr_glamor *glamor,
+ 
+     glBindVertexArray(old_vao);
+ 
+-    glXSwapBuffers(dpy, glamor->glx_win);
+-}
+-
+-/**
+- * Xlib-based handling of xcb events for glamor.
+- *
+- * We need to let the Xlib event filtering run on the event so that
+- * Mesa's dri2_glx.c userspace event mangling gets run, and we
+- * correctly get our invalidate events propagated into the driver.
+- */
+-void
+-ephyr_glamor_process_event(xcb_generic_event_t *xev)
+-{
+-
+-    uint32_t response_type = xev->response_type & 0x7f;
+-    /* Note the types on wire_to_event: there's an Xlib XEvent (with
+-     * the broken types) that it returns, and a protocol xEvent that
+-     * it inspects.
+-     */
+-    Bool (*wire_to_event)(Display *dpy, XEvent *ret, xEvent *event);
+-
+-    XLockDisplay(dpy);
+-    /* Set the event handler to NULL to get access to the current one. */
+-    wire_to_event = XESetWireToEvent(dpy, response_type, NULL);
+-    if (wire_to_event) {
+-        XEvent processed_event;
+-
+-        /* OK they had an event handler.  Plug it back in, and call
+-         * through to it.
+-         */
+-        XESetWireToEvent(dpy, response_type, wire_to_event);
+-        xev->sequence = LastKnownRequestProcessed(dpy);
+-        wire_to_event(dpy, &processed_event, (xEvent *)xev);
+-    }
+-    XUnlockDisplay(dpy);
+-}
+-
+-static int
+-ephyr_glx_error_handler(Display * _dpy, XErrorEvent * ev)
+-{
+-    return 0;
++    eglSwapBuffers(glamor->dpy, glamor->egl_win);
+ }
+ 
+ struct ephyr_glamor *
+-ephyr_glamor_glx_screen_init(xcb_window_t win)
++ephyr_glamor_screen_init(xcb_window_t win, xcb_visualid_t vid)
+ {
+-    int (*oldErrorHandler) (Display *, XErrorEvent *);
+     static const float position[] = {
+         -1, -1,
+          1, -1,
+@@ -297,9 +315,9 @@ ephyr_glamor_glx_screen_init(xcb_window_t win)
+     };
+     GLint old_vao;
+ 
+-    GLXContext ctx;
++    EGLContext ctx;
+     struct ephyr_glamor *glamor;
+-    GLXWindow glx_win;
++    EGLSurface egl_win;
+ 
+     glamor = calloc(1, sizeof(struct ephyr_glamor));
+     if (!glamor) {
+@@ -307,56 +325,49 @@ ephyr_glamor_glx_screen_init(xcb_window_t win)
+         return NULL;
+     }
+ 
+-    glx_win = glXCreateWindow(dpy, fb_config, win, NULL);
+-
+-    if (ephyr_glamor_gles2) {
+-        static const int context_attribs[] = {
+-            GLX_CONTEXT_MAJOR_VERSION_ARB, 2,
+-            GLX_CONTEXT_MINOR_VERSION_ARB, 0,
+-            GLX_CONTEXT_PROFILE_MASK_ARB, GLX_CONTEXT_ES_PROFILE_BIT_EXT,
+-            0,
+-        };
+-        if (epoxy_has_glx_extension(dpy, DefaultScreen(dpy),
+-                                    "GLX_EXT_create_context_es2_profile")) {
+-            ctx = glXCreateContextAttribsARB(dpy, fb_config, NULL, True,
+-                                             context_attribs);
+-        } else {
+-            FatalError("Xephyr -glamor_gles2 requires "
+-                       "GLX_EXT_create_context_es2_profile\n");
+-        }
+-    } else {
+-        if (epoxy_has_glx_extension(dpy, DefaultScreen(dpy),
+-                                    "GLX_ARB_create_context")) {
+-            static const int context_attribs[] = {
+-                GLX_CONTEXT_PROFILE_MASK_ARB,
+-                GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
+-                GLX_CONTEXT_MAJOR_VERSION_ARB,
+-                GLAMOR_GL_CORE_VER_MAJOR,
+-                GLX_CONTEXT_MINOR_VERSION_ARB,
+-                GLAMOR_GL_CORE_VER_MINOR,
+-                0,
+-            };
+-            oldErrorHandler = XSetErrorHandler(ephyr_glx_error_handler);
+-            ctx = glXCreateContextAttribsARB(dpy, fb_config, NULL, True,
+-                                             context_attribs);
+-            XSync(dpy, False);
+-            XSetErrorHandler(oldErrorHandler);
+-        } else {
+-            ctx = NULL;
+-        }
++    const EGLint config_attribs[] = {
++        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
++        EGL_NATIVE_VISUAL_ID, vid,
++        EGL_NONE,
++    };
++    EGLConfig config = EGL_NO_CONFIG_KHR;
++    int num_configs = 0;
++
++    /* (loud booing (see above)) */
++    glamor->dpy = edpy;
++
++    eglChooseConfig(glamor->dpy, config_attribs, &config, 1, &num_configs);
++    if (num_configs != 1)
++        FatalError("Unable to find an EGLConfig for vid %#x\n", vid);
++
++    egl_win = eglCreatePlatformWindowSurfaceEXT(glamor->dpy, config,
++                                                &win, NULL);
++
++    if (ephyr_glamor_gles2)
++        eglBindAPI(EGL_OPENGL_ES_API);
++    else
++        eglBindAPI(EGL_OPENGL_API);
++
++    EGLint context_attribs[5];
++    int i = 0;
++    context_attribs[i++] = EGL_CONTEXT_MAJOR_VERSION;
++    context_attribs[i++] = ephyr_glamor_gles2 ? 2 : 3;
++    context_attribs[i++] = EGL_CONTEXT_MINOR_VERSION;
++    context_attribs[i++] = ephyr_glamor_gles2 ? 0 : 1;
++    context_attribs[i++] = EGL_NONE;
++
++    ctx = eglCreateContext(glamor->dpy, config, EGL_NO_CONTEXT,
++                           context_attribs);
+ 
+-        if (!ctx)
+-            ctx = glXCreateContext(dpy, visual_info, NULL, True);
+-    }
+     if (ctx == NULL)
+-        FatalError("glXCreateContext failed\n");
++        FatalError("eglCreateContext failed\n");
+ 
+-    if (!glXMakeCurrent(dpy, glx_win, ctx))
+-        FatalError("glXMakeCurrent failed\n");
++    if (!eglMakeCurrent(glamor->dpy, egl_win, egl_win, ctx))
++        FatalError("eglMakeCurrent failed\n");
+ 
+     glamor->ctx = ctx;
+     glamor->win = win;
+-    glamor->glx_win = glx_win;
++    glamor->egl_win = egl_win;
+     ephyr_glamor_setup_texturing_shader(glamor);
+ 
+     glGenVertexArrays(1, &glamor->vao);
+@@ -375,48 +386,17 @@ ephyr_glamor_glx_screen_init(xcb_window_t win)
+ }
+ 
+ void
+-ephyr_glamor_glx_screen_fini(struct ephyr_glamor *glamor)
++ephyr_glamor_screen_fini(struct ephyr_glamor *glamor)
+ {
+-    glXMakeCurrent(dpy, None, NULL);
+-    glXDestroyContext(dpy, glamor->ctx);
+-    glXDestroyWindow(dpy, glamor->glx_win);
++    eglMakeCurrent(glamor->dpy,
++                   EGL_NO_SURFACE, EGL_NO_SURFACE,
++                   EGL_NO_CONTEXT);
++    eglDestroyContext(glamor->dpy, glamor->ctx);
++    eglDestroySurface(glamor->dpy, glamor->egl_win);
+ 
+     free(glamor);
+ }
+ 
+-xcb_visualtype_t *
+-ephyr_glamor_get_visual(void)
+-{
+-    xcb_screen_t *xscreen =
+-        xcb_aux_get_screen(XGetXCBConnection(dpy), DefaultScreen(dpy));
+-    int attribs[] = {
+-        GLX_RENDER_TYPE, GLX_RGBA_BIT,
+-        GLX_DRAWABLE_TYPE, GLX_WINDOW_BIT,
+-        GLX_RED_SIZE, 1,
+-        GLX_GREEN_SIZE, 1,
+-        GLX_BLUE_SIZE, 1,
+-        GLX_DOUBLEBUFFER, 1,
+-        None
+-    };
+-    int event_base = 0, error_base = 0, nelements;
+-    GLXFBConfig *fbconfigs;
+-
+-    if (!glXQueryExtension (dpy, &error_base, &event_base))
+-        FatalError("Couldn't find GLX extension\n");
+-
+-    fbconfigs = glXChooseFBConfig(dpy, DefaultScreen(dpy), attribs, &nelements);
+-    if (!nelements)
+-        FatalError("Couldn't choose an FBConfig\n");
+-    fb_config = fbconfigs[0];
+-    free(fbconfigs);
+-
+-    visual_info = glXGetVisualFromFBConfig(dpy, fb_config);
+-    if (visual_info == NULL)
+-        FatalError("Couldn't get RGB visual\n");
+-
+-    return xcb_aux_find_visual_by_id(xscreen, visual_info->visualid);
+-}
+-
+ void
+ ephyr_glamor_set_window_size(struct ephyr_glamor *glamor,
+                              unsigned width, unsigned height)
+diff --git a/hw/kdrive/ephyr/ephyr_glamor_glx.h b/hw/kdrive/ephyr/ephyr_glamor.h
+similarity index 82%
+rename from hw/kdrive/ephyr/ephyr_glamor_glx.h
+rename to hw/kdrive/ephyr/ephyr_glamor.h
+index 0c238cf5b..fc4a80d9f 100644
+--- a/hw/kdrive/ephyr/ephyr_glamor_glx.h
++++ b/hw/kdrive/ephyr/ephyr_glamor.h
+@@ -21,13 +21,6 @@
+  * IN THE SOFTWARE.
+  */
+ 
+-/**
+- * ephyr_glamor_glx.h
+- *
+- * Prototypes exposed by ephyr_glamor_glx.c, without including any
+- * server headers.
+- */
+-
+ #include <xcb/xcb.h>
+ #include "dix-config.h"
+ 
+@@ -40,14 +33,11 @@ ephyr_glamor_connect(void);
+ void
+ ephyr_glamor_set_texture(struct ephyr_glamor *ephyr_glamor, uint32_t tex);
+ 
+-xcb_visualtype_t *
+-ephyr_glamor_get_visual(void);
+-
+ struct ephyr_glamor *
+-ephyr_glamor_glx_screen_init(xcb_window_t win);
++ephyr_glamor_screen_init(xcb_window_t win, xcb_visualid_t vid);
+ 
+ void
+-ephyr_glamor_glx_screen_fini(struct ephyr_glamor *glamor);
++ephyr_glamor_screen_fini(struct ephyr_glamor *glamor);
+ 
+ #ifdef GLAMOR
+ void
+@@ -58,9 +48,6 @@ void
+ ephyr_glamor_damage_redisplay(struct ephyr_glamor *glamor,
+                               struct pixman_region16 *damage);
+ 
+-void
+-ephyr_glamor_process_event(xcb_generic_event_t *xev);
+-
+ #else /* !GLAMOR */
+ 
+ static inline void
+@@ -75,9 +62,4 @@ ephyr_glamor_damage_redisplay(struct ephyr_glamor *glamor,
+ {
+ }
+ 
+-static inline void
+-ephyr_glamor_process_event(xcb_generic_event_t *xev)
+-{
+-}
+-
+ #endif /* !GLAMOR */
+diff --git a/hw/kdrive/ephyr/hostx.c b/hw/kdrive/ephyr/hostx.c
+index a5b2e344e..f9cb6980f 100644
+--- a/hw/kdrive/ephyr/hostx.c
++++ b/hw/kdrive/ephyr/hostx.c
+@@ -57,7 +57,7 @@
+ #ifdef GLAMOR
+ #include <epoxy/gl.h>
+ #include "glamor.h"
+-#include "ephyr_glamor_glx.h"
++#include "ephyr_glamor.h"
+ #endif
+ #include "ephyrlog.h"
+ #include "ephyr.h"
+@@ -556,21 +556,7 @@ hostx_init(void)
+     HostX.winroot = xscreen->root;
+     HostX.gc = xcb_generate_id(HostX.conn);
+     HostX.depth = xscreen->root_depth;
+-#ifdef GLAMOR
+-    if (ephyr_glamor) {
+-        HostX.visual = ephyr_glamor_get_visual();
+-        if (HostX.visual->visual_id != xscreen->root_visual) {
+-            attrs[1] = xcb_generate_id(HostX.conn);
+-            attr_mask |= XCB_CW_COLORMAP;
+-            xcb_create_colormap(HostX.conn,
+-                                XCB_COLORMAP_ALLOC_NONE,
+-                                attrs[1],
+-                                HostX.winroot,
+-                                HostX.visual->visual_id);
+-        }
+-    } else
+-#endif
+-        HostX.visual = xcb_aux_find_visual_by_id(xscreen,xscreen->root_visual);
++    HostX.visual = xcb_aux_find_visual_by_id(xscreen, xscreen->root_visual);
+ 
+     xcb_create_gc(HostX.conn, HostX.gc, HostX.winroot, 0, NULL);
+     cookie_WINDOW_STATE = xcb_intern_atom(HostX.conn, FALSE,
+@@ -586,6 +572,7 @@ hostx_init(void)
+         EphyrScrPriv *scrpriv = screen->driver;
+ 
+         scrpriv->win = xcb_generate_id(HostX.conn);
++        scrpriv->vid = xscreen->root_visual;
+         scrpriv->server_depth = HostX.depth;
+         scrpriv->ximg = NULL;
+         scrpriv->win_x = 0;
+@@ -1570,11 +1557,11 @@ ephyr_glamor_init(ScreenPtr screen)
+     KdScreenInfo *kd_screen = pScreenPriv->screen;
+     EphyrScrPriv *scrpriv = kd_screen->driver;
+ 
+-    scrpriv->glamor = ephyr_glamor_glx_screen_init(scrpriv->win);
++    scrpriv->glamor = ephyr_glamor_screen_init(scrpriv->win, scrpriv->vid);
+     ephyr_glamor_set_window_size(scrpriv->glamor,
+                                  scrpriv->win_width, scrpriv->win_height);
+ 
+-    if (!glamor_init(screen, 0)) {
++    if (!glamor_init(screen, GLAMOR_USE_EGL_SCREEN)) {
+         FatalError("Failed to initialize glamor\n");
+         return FALSE;
+     }
+@@ -1660,7 +1647,7 @@ ephyr_glamor_fini(ScreenPtr screen)
+     EphyrScrPriv *scrpriv = kd_screen->driver;
+ 
+     glamor_fini(screen);
+-    ephyr_glamor_glx_screen_fini(scrpriv->glamor);
++    ephyr_glamor_screen_fini(scrpriv->glamor);
+     scrpriv->glamor = NULL;
+ }
+ #endif
+diff --git a/hw/kdrive/ephyr/meson.build b/hw/kdrive/ephyr/meson.build
+index 9e329ba67..dff1dfb68 100644
+--- a/hw/kdrive/ephyr/meson.build
++++ b/hw/kdrive/ephyr/meson.build
+@@ -23,13 +23,12 @@ xephyr_dep = [
+ 
+ xephyr_glamor = []
+ if build_glamor
+-    srcs += 'ephyr_glamor_glx.c'
++    srcs += 'ephyr_glamor.c'
+     if build_xv
+         srcs += 'ephyr_glamor_xv.c'
+     endif
+     xephyr_glamor += glamor
+     xephyr_glamor += glamor_egl_stubs
+-    xephyr_dep += dependency('x11-xcb')
+     xephyr_dep += epoxy_dep
+ endif
+ 
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1003-BACKPORT-glamor-Don-t-open-code-epoxy_glsl_version.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1003-BACKPORT-glamor-Don-t-open-code-epoxy_glsl_version.patch
@@ -1,0 +1,59 @@
+From 1e626980ab4d5d2b9e16bf96f08b7f8b672553e8 Mon Sep 17 00:00:00 2001
+From: Adam Jackson <ajax@redhat.com>
+Date: Fri, 2 Jul 2021 15:27:44 -0400
+Subject: [PATCH 003/105] glamor: Don't open-code epoxy_glsl_version()
+
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor.c | 27 +--------------------------
+ 1 file changed, 1 insertion(+), 26 deletions(-)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index 65fb132e5..9dcef5fac 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -618,10 +618,7 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+ {
+     glamor_screen_private *glamor_priv;
+     int gl_version;
+-    int glsl_major, glsl_minor;
+     int max_viewport_size[2];
+-    const char *shading_version_string;
+-    int shading_version_offset;
+ 
+     PictureScreenPtr ps = GetPictureScreenIfSet(screen);
+ 
+@@ -683,29 +680,7 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+     glamor_priv->is_core_profile =
+         gl_version >= 31 && !epoxy_has_gl_extension("GL_ARB_compatibility");
+ 
+-    shading_version_string = (char *) glGetString(GL_SHADING_LANGUAGE_VERSION);
+-
+-    if (!shading_version_string) {
+-        LogMessage(X_WARNING,
+-                   "glamor%d: Failed to get GLSL version\n",
+-                   screen->myNum);
+-        goto fail;
+-    }
+-
+-    shading_version_offset = 0;
+-    if (strncmp("OpenGL ES GLSL ES ", shading_version_string, 18) == 0)
+-        shading_version_offset = 18;
+-
+-    if (sscanf(shading_version_string + shading_version_offset,
+-               "%i.%i",
+-               &glsl_major,
+-               &glsl_minor) != 2) {
+-        LogMessage(X_WARNING,
+-                   "glamor%d: Failed to parse GLSL version string %s\n",
+-                   screen->myNum, shading_version_string);
+-        goto fail;
+-    }
+-    glamor_priv->glsl_version = glsl_major * 100 + glsl_minor;
++    glamor_priv->glsl_version = epoxy_glsl_version();
+ 
+     if (glamor_priv->is_gles) {
+         /* Force us back to the base version of our programs on an ES
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1004-BACKPORT-ephyr-Don-t-open-code-glamor_compile_glsl_prog.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1004-BACKPORT-ephyr-Don-t-open-code-glamor_compile_glsl_prog.patch
@@ -1,0 +1,66 @@
+From 274ba4df31cdea7bccecb5a70dbb904dfb388201 Mon Sep 17 00:00:00 2001
+From: Adam Jackson <ajax@redhat.com>
+Date: Mon, 12 Jul 2021 15:29:25 -0400
+Subject: [PATCH 004/105] ephyr: Don't open-code glamor_compile_glsl_prog
+
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ hw/kdrive/ephyr/ephyr_glamor.c | 35 ++--------------------------------
+ 1 file changed, 2 insertions(+), 33 deletions(-)
+
+diff --git a/hw/kdrive/ephyr/ephyr_glamor.c b/hw/kdrive/ephyr/ephyr_glamor.c
+index 1e22cbd02..44e48ff59 100644
+--- a/hw/kdrive/ephyr/ephyr_glamor.c
++++ b/hw/kdrive/ephyr/ephyr_glamor.c
+@@ -69,37 +69,6 @@ struct ephyr_glamor {
+     GLuint vao, vbo;
+ };
+ 
+-static GLint
+-ephyr_glamor_compile_glsl_prog(GLenum type, const char *source)
+-{
+-    GLint ok;
+-    GLint prog;
+-
+-    prog = glCreateShader(type);
+-    glShaderSource(prog, 1, (const GLchar **) &source, NULL);
+-    glCompileShader(prog);
+-    glGetShaderiv(prog, GL_COMPILE_STATUS, &ok);
+-    if (!ok) {
+-        GLchar *info;
+-        GLint size;
+-
+-        glGetShaderiv(prog, GL_INFO_LOG_LENGTH, &size);
+-        info = malloc(size);
+-        if (info) {
+-            glGetShaderInfoLog(prog, size, NULL, info);
+-            ErrorF("Failed to compile %s: %s\n",
+-                   type == GL_FRAGMENT_SHADER ? "FS" : "VS", info);
+-            ErrorF("Program source:\n%s", source);
+-            free(info);
+-        }
+-        else
+-            ErrorF("Failed to get shader compilation info.\n");
+-        FatalError("GLSL compile failure\n");
+-    }
+-
+-    return prog;
+-}
+-
+ static GLuint
+ ephyr_glamor_build_glsl_prog(GLuint vs, GLuint fs)
+ {
+@@ -156,8 +125,8 @@ ephyr_glamor_setup_texturing_shader(struct ephyr_glamor *glamor)
+ 
+     GLuint fs, vs, prog;
+ 
+-    vs = ephyr_glamor_compile_glsl_prog(GL_VERTEX_SHADER, vs_source);
+-    fs = ephyr_glamor_compile_glsl_prog(GL_FRAGMENT_SHADER, fs_source);
++    vs = glamor_compile_glsl_prog(GL_VERTEX_SHADER, vs_source);
++    fs = glamor_compile_glsl_prog(GL_FRAGMENT_SHADER, fs_source);
+     prog = ephyr_glamor_build_glsl_prog(vs, fs);
+ 
+     glamor->texture_shader = prog;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1005-BACKPORT-glamor-Require-EGL_KHR_no_config_context.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1005-BACKPORT-glamor-Require-EGL_KHR_no_config_context.patch
@@ -1,0 +1,85 @@
+From 93d8f7434c1a939826e51cf5e4756c05b9916c6f Mon Sep 17 00:00:00 2001
+From: Adam Jackson <ajax@redhat.com>
+Date: Tue, 17 Aug 2021 12:41:08 -0400
+Subject: [PATCH 005/105] glamor: Require EGL_KHR_no_config_context
+
+This is not actually a change for xwayland with gbm, or for xfree86 with
+big-GL, but we do change them as well to use EGL_NO_CONFIG_KHR
+explicitly.
+
+Reviewed-by: Emma Anholt <emma@anholt.net>
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ glamor/glamor_egl.c            | 16 +++++-----------
+ hw/kdrive/ephyr/ephyr_glamor.c |  2 +-
+ 2 files changed, 6 insertions(+), 12 deletions(-)
+
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index 6e0fc6596..60d0df893 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -933,8 +933,6 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+ {
+     struct glamor_egl_screen_private *glamor_egl;
+     const GLubyte *renderer;
+-    EGLConfig egl_config;
+-    int n;
+ 
+     glamor_egl = calloc(sizeof(*glamor_egl), 1);
+     if (glamor_egl == NULL)
+@@ -977,6 +975,7 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+ 	}
+ 
+     GLAMOR_CHECK_EGL_EXTENSION(KHR_surfaceless_context);
++    GLAMOR_CHECK_EGL_EXTENSION(KHR_no_config_context);
+ 
+     if (eglBindAPI(EGL_OPENGL_API)) {
+         static const EGLint config_attribs_core[] = {
+@@ -993,12 +992,13 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+         };
+ 
+         glamor_egl->context = eglCreateContext(glamor_egl->display,
+-                                               NULL, EGL_NO_CONTEXT,
++                                               EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT,
+                                                config_attribs_core);
+ 
+         if (glamor_egl->context == EGL_NO_CONTEXT)
+             glamor_egl->context = eglCreateContext(glamor_egl->display,
+-                                                   NULL, EGL_NO_CONTEXT,
++                                                   EGL_NO_CONFIG_KHR,
++                                                   EGL_NO_CONTEXT,
+                                                    config_attribs);
+     }
+ 
+@@ -1029,14 +1029,8 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+             goto error;
+         }
+ 
+-        if (!eglChooseConfig(glamor_egl->display, NULL, &egl_config, 1, &n)) {
+-            xf86DrvMsg(scrn->scrnIndex, X_ERROR,
+-                       "glamor: No acceptable EGL configs found\n");
+-            goto error;
+-        }
+-
+         glamor_egl->context = eglCreateContext(glamor_egl->display,
+-                                               egl_config, EGL_NO_CONTEXT,
++                                               EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT,
+                                                config_attribs);
+ 
+         if (glamor_egl->context == EGL_NO_CONTEXT) {
+diff --git a/hw/kdrive/ephyr/ephyr_glamor.c b/hw/kdrive/ephyr/ephyr_glamor.c
+index 44e48ff59..724611d69 100644
+--- a/hw/kdrive/ephyr/ephyr_glamor.c
++++ b/hw/kdrive/ephyr/ephyr_glamor.c
+@@ -325,7 +325,7 @@ ephyr_glamor_screen_init(xcb_window_t win, xcb_visualid_t vid)
+     context_attribs[i++] = ephyr_glamor_gles2 ? 0 : 1;
+     context_attribs[i++] = EGL_NONE;
+ 
+-    ctx = eglCreateContext(glamor->dpy, config, EGL_NO_CONTEXT,
++    ctx = eglCreateContext(glamor->dpy, EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT,
+                            context_attribs);
+ 
+     if (ctx == NULL)
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1006-BACKPORT-glamor-Assume-EGL-in-glamor_context.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1006-BACKPORT-glamor-Assume-EGL-in-glamor_context.patch
@@ -1,0 +1,59 @@
+From 37ceecdbeff40187e72c7c217ee7f30a8d05bdbd Mon Sep 17 00:00:00 2001
+From: Adam Jackson <ajax@redhat.com>
+Date: Fri, 9 Jul 2021 17:14:47 -0400
+Subject: [PATCH 006/105] glamor: Assume EGL in glamor_context
+
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor_context.h | 27 ++++++++++++---------------
+ 1 file changed, 12 insertions(+), 15 deletions(-)
+
+diff --git a/glamor/glamor_context.h b/glamor/glamor_context.h
+index 47b87e620..50986971c 100644
+--- a/glamor/glamor_context.h
++++ b/glamor/glamor_context.h
+@@ -21,29 +21,26 @@
+  * IN THE SOFTWARE.
+  */
+ 
++#ifndef GLAMOR_CONTEXT_H
++#define GLAMOR_CONTEXT_H
++
++#include <epoxy/egl.h>
++
+ /**
+  * @file glamor_context.h
+  *
+  * This is the struct of state required for context switching in
+- * glamor.  It has to use types that don't require including either
+- * server headers or Xlib headers, since it will be included by both
+- * the server and the GLX (xlib) code.
++ * glamor. Initially this was abstracted away from EGL, and
++ * presumably it would need to be again if someone wanted to use
++ * glamor with WGL/CGL.
+  */
+ 
+ struct glamor_context {
+-    /** Either an EGLDisplay or an Xlib Display */
+-    void *display;
+-
+-    /** Either a GLXContext or an EGLContext. */
+-    void *ctx;
+-
+-    /** The EGLSurface we should MakeCurrent to */
+-    void *drawable;
+-
+-    /** The GLXDrawable we should MakeCurrent to */
+-    uint32_t drawable_xid;
++    EGLDisplay display;
++    EGLContext ctx;
++    EGLSurface surface;
+ 
+     void (*make_current)(struct glamor_context *glamor_ctx);
+ };
+ 
+-Bool glamor_glx_screen_init(struct glamor_context *glamor_ctx);
++#endif
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1007-BACKPORT-modesetting-Fix-dirty-updates-for-sw-rotation.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1007-BACKPORT-modesetting-Fix-dirty-updates-for-sw-rotation.patch
@@ -1,0 +1,165 @@
+From 6e78af07c855f7b76c9b675bbe0e285f3e0a68f2 Mon Sep 17 00:00:00 2001
+From: Patrik Jakobsson <patrik.r.jakobsson@gmail.com>
+Date: Wed, 9 Jun 2021 20:58:59 +0200
+Subject: [PATCH 007/105] modesetting: Fix dirty updates for sw rotation
+
+Rotation is broken for all drm drivers not providing hardware rotation
+support. Drivers that give direct access to vram and not needing dirty
+updates still work but only by accident. The problem is caused by
+modesetting not sending the correct fb_id to drmModeDirtyFB() and
+passing the damage rects in the rotated state and not as the crtc
+expects them. This patch takes care of both problems.
+
+Signed-off-by: Patrik Jakobsson <pjakobsson@suse.de>
+---
+ hw/xfree86/drivers/modesetting/driver.c       | 81 ++++++++++++++-----
+ .../drivers/modesetting/drmmode_display.c     |  2 +-
+ .../drivers/modesetting/drmmode_display.h     |  2 +
+ 3 files changed, 63 insertions(+), 22 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.c b/hw/xfree86/drivers/modesetting/driver.c
+index 535f49d1d..fe3315a9c 100644
+--- a/hw/xfree86/drivers/modesetting/driver.c
++++ b/hw/xfree86/drivers/modesetting/driver.c
+@@ -515,9 +515,41 @@ GetRec(ScrnInfoPtr pScrn)
+     return TRUE;
+ }
+ 
++static void
++rotate_clip(PixmapPtr pixmap, BoxPtr rect, drmModeClip *clip, Rotation rotation)
++{
++    int w = pixmap->drawable.width;
++    int h = pixmap->drawable.height;
++
++    if (rotation == RR_Rotate_90) {
++	/* Rotate 90 degrees counter clockwise */
++        clip->x1 = rect->y1;
++	clip->x2 = rect->y2;
++	clip->y1 = w - rect->x2;
++	clip->y2 = w - rect->x1;
++    } else if (rotation == RR_Rotate_180) {
++	/* Rotate 180 degrees */
++        clip->x1 = w - rect->x2;
++	clip->x2 = w - rect->x1;
++	clip->y1 = h - rect->y2;
++	clip->y2 = h - rect->y1;
++    } else if (rotation == RR_Rotate_270) {
++	/* Rotate 90 degrees clockwise */
++        clip->x1 = h - rect->y2;
++	clip->x2 = h - rect->y1;
++	clip->y1 = rect->x1;
++	clip->y2 = rect->x2;
++    } else {
++	clip->x1 = rect->x1;
++	clip->x2 = rect->x2;
++	clip->y1 = rect->y1;
++	clip->y2 = rect->y2;
++    }
++}
++
+ static int
+-dispatch_dirty_region(ScrnInfoPtr scrn,
+-                      PixmapPtr pixmap, DamagePtr damage, int fb_id)
++dispatch_dirty_region(ScrnInfoPtr scrn, xf86CrtcPtr crtc,
++		      PixmapPtr pixmap, DamagePtr damage, int fb_id)
+ {
+     modesettingPtr ms = modesettingPTR(scrn);
+     RegionPtr dirty = DamageRegion(damage);
+@@ -532,13 +564,9 @@ dispatch_dirty_region(ScrnInfoPtr scrn,
+         if (!clip)
+             return -ENOMEM;
+ 
+-        /* XXX no need for copy? */
+-        for (i = 0; i < num_cliprects; i++, rect++) {
+-            clip[i].x1 = rect->x1;
+-            clip[i].y1 = rect->y1;
+-            clip[i].x2 = rect->x2;
+-            clip[i].y2 = rect->y2;
+-        }
++        /* Rotate and copy rects into clips */
++        for (i = 0; i < num_cliprects; i++, rect++)
++	    rotate_clip(pixmap, rect, &clip[i], crtc->rotation);
+ 
+         /* TODO query connector property to see if this is needed */
+         ret = drmModeDirtyFB(ms->fd, fb_id, clip, num_cliprects);
+@@ -561,20 +589,31 @@ static void
+ dispatch_dirty(ScreenPtr pScreen)
+ {
+     ScrnInfoPtr scrn = xf86ScreenToScrn(pScreen);
++    xf86CrtcConfigPtr xf86_config = XF86_CRTC_CONFIG_PTR(scrn);
+     modesettingPtr ms = modesettingPTR(scrn);
+     PixmapPtr pixmap = pScreen->GetScreenPixmap(pScreen);
+-    int fb_id = ms->drmmode.fb_id;
+-    int ret;
++    uint32_t fb_id;
++    int ret, c, x, y ;
+ 
+-    ret = dispatch_dirty_region(scrn, pixmap, ms->damage, fb_id);
+-    if (ret == -EINVAL || ret == -ENOSYS) {
+-        ms->dirty_enabled = FALSE;
+-        DamageUnregister(ms->damage);
+-        DamageDestroy(ms->damage);
+-        ms->damage = NULL;
+-        xf86DrvMsg(scrn->scrnIndex, X_INFO,
+-                   "Disabling kernel dirty updates, not required.\n");
+-        return;
++    for (c = 0; c < xf86_config->num_crtc; c++) {
++        xf86CrtcPtr crtc = xf86_config->crtc[c];
++        drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++
++        if (!drmmode_crtc)
++            continue;
++
++	drmmode_crtc_get_fb_id(crtc, &fb_id, &x, &y);
++
++        ret = dispatch_dirty_region(scrn, crtc, pixmap, ms->damage, fb_id);
++        if (ret == -EINVAL || ret == -ENOSYS) {
++            ms->dirty_enabled = FALSE;
++            DamageUnregister(ms->damage);
++            DamageDestroy(ms->damage);
++            ms->damage = NULL;
++            xf86DrvMsg(scrn->scrnIndex, X_INFO,
++                       "Disabling kernel dirty updates, not required.\n");
++            return;
++        }
+     }
+ }
+ 
+@@ -586,7 +625,7 @@ dispatch_dirty_pixmap(ScrnInfoPtr scrn, xf86CrtcPtr crtc, PixmapPtr ppix)
+     DamagePtr damage = ppriv->secondary_damage;
+     int fb_id = ppriv->fb_id;
+ 
+-    dispatch_dirty_region(scrn, ppix, damage, fb_id);
++    dispatch_dirty_region(scrn, crtc, ppix, damage, fb_id);
+ }
+ 
+ static void
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
+index 48dccad73..21c9222e1 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
+@@ -627,7 +627,7 @@ drmmode_crtc_can_test_mode(xf86CrtcPtr crtc)
+     return ms->atomic_modeset;
+ }
+ 
+-static Bool
++Bool
+ drmmode_crtc_get_fb_id(xf86CrtcPtr crtc, uint32_t *fb_id, int *x, int *y)
+ {
+     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.h b/hw/xfree86/drivers/modesetting/drmmode_display.h
+index 29f9b8f7d..2a9a91529 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.h
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.h
+@@ -311,6 +311,8 @@ void drmmode_copy_fb(ScrnInfoPtr pScrn, drmmode_ptr drmmode);
+ 
+ int drmmode_crtc_flip(xf86CrtcPtr crtc, uint32_t fb_id, uint32_t flags, void *data);
+ 
++Bool drmmode_crtc_get_fb_id(xf86CrtcPtr crtc, uint32_t *fb_id, int *x, int *y);
++
+ void drmmode_set_dpms(ScrnInfoPtr scrn, int PowerManagementMode, int flags);
+ void drmmode_crtc_set_vrr(xf86CrtcPtr crtc, Bool enabled);
+ 
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1008-BACKPORT-os-Try-to-discover-the-current-seat-with-the-XDG_SEA.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1008-BACKPORT-os-Try-to-discover-the-current-seat-with-the-XDG_SEA.patch
@@ -1,0 +1,25 @@
+From 8e5124bb116c3c800692950ec10eb390d343aa94 Mon Sep 17 00:00:00 2001
+From: nerdopolis <bluescreen_avenger@verizon.net>
+Date: Fri, 8 Oct 2021 18:15:29 -0400
+Subject: [PATCH 008/105] os: Try to discover the current seat with the
+ XDG_SEAT var first
+
+---
+ os/utils.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/os/utils.c b/os/utils.c
+index f0d022fba..3e4a4fa4f 100644
+--- a/os/utils.c
++++ b/os/utils.c
+@@ -685,6 +685,7 @@ ProcessCommandLine(int argc, char *argv[])
+                     ErrorF("Failed to disable listen for %s transport",
+                            defaultNoListenList[i]);
+     }
++    SeatId = getenv("XDG_SEAT");
+ 
+     for (i = 1; i < argc; i++) {
+         /* call ddx first, so it can peek/override if it wants */
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1009-BACKPORT-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1009-BACKPORT-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
@@ -1,0 +1,31 @@
+From 79dfb5f6024358ca8c4b701ed05660d7043841e7 Mon Sep 17 00:00:00 2001
+From: Thomas Zimmermann <tzimmermann@suse.de>
+Date: Mon, 13 Dec 2021 16:10:35 +0100
+Subject: [PATCH 009/105] xf86: Accept devices with the 'hyperv_drm' driver
+
+Put in a workaround to accept devices of the kernel's hyperv_drm
+driver. Makes Xorg work on HyperV Gen 1/2 with the DRM graphics
+stack.
+
+Signed-off-by: Thomas Zimmermann <tzimmermann@suse.de>
+---
+ hw/xfree86/common/xf86platformBus.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/hw/xfree86/common/xf86platformBus.c b/hw/xfree86/common/xf86platformBus.c
+index 45028f7a6..071f44b2a 100644
+--- a/hw/xfree86/common/xf86platformBus.c
++++ b/hw/xfree86/common/xf86platformBus.c
+@@ -560,6 +560,9 @@ xf86platformProbeDev(DriverPtr drvp)
+                 if (ServerIsNotSeat0()) {
+                     break;
+                 } else {
++                    /* Accept the device if the driver is hyperv_drm */
++                    if (strcmp(xf86_platform_devices[j].attribs->driver, "hyperv_drm") == 0)
++                        break;
+                     /* Accept the device if the driver is simpledrm */
+                     if (strcmp(xf86_platform_devices[j].attribs->driver, "simpledrm") == 0)
+                         break;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1010-BACKPORT-x86emu-re-align-breaks-in-ins-and-outs.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1010-BACKPORT-x86emu-re-align-breaks-in-ins-and-outs.patch
@@ -1,0 +1,45 @@
+From c92aa841a1e15311aa014853fa1e860a5c865e96 Mon Sep 17 00:00:00 2001
+From: Brian Ruthven <Brian.Ruthven@oracle.com>
+Date: Mon, 28 Mar 2022 17:50:49 -0700
+Subject: [PATCH 010/105] x86emu: re-align breaks in ins() and outs()
+
+Makes the 4-byte cases match those for 1- & 2-byte handling,
+moving the break from being unconditionally hit the first time
+through the to loop to after the loop is done.
+
+Fixes Solaris Studio compiler warnings:
+"prim_ops.c", line 2626: warning: end-of-loop code not reached
+"prim_ops.c", line 2692: warning: end-of-loop code not reached
+
+Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
+---
+ hw/xfree86/x86emu/prim_ops.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/hw/xfree86/x86emu/prim_ops.c b/hw/xfree86/x86emu/prim_ops.c
+index 35ef94710..47877eb26 100644
+--- a/hw/xfree86/x86emu/prim_ops.c
++++ b/hw/xfree86/x86emu/prim_ops.c
+@@ -2622,8 +2622,8 @@ ins(int size)
+                 store_data_long_abs(M.x86.R_ES, M.x86.R_DI,
+                                     (*sys_inl) (M.x86.R_DX));
+                 M.x86.R_DI += inc;
+-                break;
+             }
++            break;
+         }
+         M.x86.R_CX = 0;
+         if (M.x86.mode & SYSMODE_PREFIX_DATA) {
+@@ -2688,8 +2688,8 @@ outs(int size)
+                 (*sys_outl) (M.x86.R_DX,
+                              fetch_data_long_abs(M.x86.R_ES, M.x86.R_SI));
+                 M.x86.R_SI += inc;
+-                break;
+             }
++            break;
+         }
+         M.x86.R_CX = 0;
+         if (M.x86.mode & SYSMODE_PREFIX_DATA) {
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1011-BACKPORT-os-print-signal-handler-called-if-unw_is_signal_fram.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1011-BACKPORT-os-print-signal-handler-called-if-unw_is_signal_fram.patch
@@ -1,0 +1,45 @@
+From a0a59d36586086a588215f3f4ffa1734e3a2e10a Mon Sep 17 00:00:00 2001
+From: Aaron Plattner <aplattner@nvidia.com>
+Date: Thu, 27 May 2021 16:58:56 -0700
+Subject: [PATCH 011/105] os: print <signal handler called> if
+ unw_is_signal_frame()
+
+libunwind has a function to query whether the cursor points to a signal frame.
+Use this to print
+
+ 1: <signal handler called>
+
+like GDB does, rather than printing something less useful such as
+
+ 1: /usr/lib/libpthread.so.0 (funlockfile+0x60) [0x7f679838b870]
+
+Signed-off-by: Aaron Plattner <aplattner@nvidia.com>
+---
+ os/backtrace.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/os/backtrace.c b/os/backtrace.c
+index 99d776950..bf7ee68e2 100644
+--- a/os/backtrace.c
++++ b/os/backtrace.c
+@@ -97,9 +97,14 @@ xorg_backtrace(void)
+         else
+             filename = "?";
+ 
+-        ErrorFSigSafe("%u: %s (%s%s+0x%x) [%p]\n", i++, filename, procname,
+-            ret == -UNW_ENOMEM ? "..." : "", (int)off,
+-            (void *)(uintptr_t)(ip));
++
++        if (unw_is_signal_frame(&cursor)) {
++            ErrorFSigSafe("%u: <signal handler called>\n", i++);
++        } else {
++            ErrorFSigSafe("%u: %s (%s%s+0x%x) [%p]\n", i++, filename, procname,
++                ret == -UNW_ENOMEM ? "..." : "", (int)off,
++                (void *)(uintptr_t)(ip));
++        }
+ 
+         ret = unw_step(&cursor);
+         if (ret < 0)
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1012-BACKPORT-os-print-registers-in-the-libunwind-version-of-xorg_.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1012-BACKPORT-os-print-registers-in-the-libunwind-version-of-xorg_.patch
@@ -1,0 +1,148 @@
+From f763c4bda77302e5760ea5e5b63d4d1f4850ac27 Mon Sep 17 00:00:00 2001
+From: Aaron Plattner <aplattner@nvidia.com>
+Date: Thu, 27 May 2021 17:06:16 -0700
+Subject: [PATCH 012/105] os: print registers in the libunwind version of
+ xorg_backtrace()
+
+If the stack walker finds a signal frame, record the cursor at that point and
+then use unw_get_reg() to query the values of the architecture-specific
+registers at the frame that triggered the signal.
+
+Example output:
+
+ (EE) Backtrace:
+ (EE) 0: hw/xfree86/Xorg (OsSigHandler+0x25) [0x561458bb8195]
+ (EE) 1: <signal handler called>
+ (EE) 2: hw/xfree86/Xorg (dix_main+0x9c) [0x561458aead6c]
+ (EE) 3: /usr/lib/libc.so.6 (__libc_start_main+0xd5) [0x7f2d23170b25]
+ (EE) 4: hw/xfree86/Xorg (_start+0x2e) [0x561458aad8be]
+ (EE)
+ (EE) Registers at frame #2:
+ (EE)   rax: 0x0
+ (EE)   rbx: 0x561458c3ae60
+ (EE)   rcx: 0x7f2d23328943
+ (EE)   rdx: 0x0
+ (EE)   rsi: 0x7ffcb6025030
+ (EE)   rdi: 0xe
+ (EE)   rbp: 0x0
+ (EE)   rsp: 0x7ffcb6026430
+ (EE)    r8: 0x0
+ (EE)    r9: 0x0
+ (EE)   r10: 0x8
+ (EE)   r11: 0x246
+ (EE)   r12: 0x561458aad890
+ (EE)   r13: 0x0
+ (EE)   r14: 0x0
+ (EE)   r15: 0x0
+ (EE)
+ (EE) Segmentation fault at address 0x0
+
+Signed-off-by: Aaron Plattner <aplattner@nvidia.com>
+---
+ os/backtrace.c | 69 ++++++++++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 67 insertions(+), 2 deletions(-)
+
+diff --git a/os/backtrace.c b/os/backtrace.c
+index bf7ee68e2..8025bffae 100644
+--- a/os/backtrace.c
++++ b/os/backtrace.c
+@@ -40,15 +40,73 @@
+ #endif
+ #include <dlfcn.h>
+ 
++static void
++print_registers(int frame, unw_cursor_t cursor)
++{
++    const struct {
++        const char *name;
++        int regnum;
++    } regs[] = {
++#if UNW_TARGET_X86_64
++        { "rax", UNW_X86_64_RAX },
++        { "rbx", UNW_X86_64_RBX },
++        { "rcx", UNW_X86_64_RCX },
++        { "rdx", UNW_X86_64_RDX },
++        { "rsi", UNW_X86_64_RSI },
++        { "rdi", UNW_X86_64_RDI },
++        { "rbp", UNW_X86_64_RBP },
++        { "rsp", UNW_X86_64_RSP },
++        { " r8", UNW_X86_64_R8  },
++        { " r9", UNW_X86_64_R9  },
++        { "r10", UNW_X86_64_R10 },
++        { "r11", UNW_X86_64_R11 },
++        { "r12", UNW_X86_64_R12 },
++        { "r13", UNW_X86_64_R13 },
++        { "r14", UNW_X86_64_R14 },
++        { "r15", UNW_X86_64_R15 },
++#endif
++    };
++    const int num_regs = sizeof(regs) / sizeof(*regs);
++    int ret, i;
++
++    if (num_regs == 0)
++        return;
++
++    /*
++     * Advance the cursor from the signal frame to the one that triggered the
++     * signal.
++     */
++    frame++;
++    ret = unw_step(&cursor);
++    if (ret < 0) {
++        ErrorFSigSafe("unw_step failed: %s [%d]\n", unw_strerror(ret), ret);
++        return;
++    }
++
++    ErrorFSigSafe("\n");
++    ErrorFSigSafe("Registers at frame #%d:\n", frame);
++
++    for (i = 0; i < num_regs; i++) {
++        uint64_t val;
++        ret = unw_get_reg(&cursor, regs[i].regnum, &val);
++        if (ret < 0) {
++            ErrorFSigSafe("unw_get_reg(%s) failed: %s [%d]\n",
++                          regs[i].name, unw_strerror(ret), ret);
++        } else {
++            ErrorFSigSafe("  %s: 0x%" PRIx64 "\n", regs[i].name, val);
++        }
++    }
++}
++
+ void
+ xorg_backtrace(void)
+ {
+-    unw_cursor_t cursor;
++    unw_cursor_t cursor, signal_cursor;
+     unw_context_t context;
+     unw_word_t ip;
+     unw_word_t off;
+     unw_proc_info_t pip;
+-    int ret, i = 0;
++    int ret, i = 0, signal_frame = -1;
+     char procname[256];
+     const char *filename;
+     Dl_info dlinfo;
+@@ -99,6 +157,9 @@ xorg_backtrace(void)
+ 
+ 
+         if (unw_is_signal_frame(&cursor)) {
++            signal_cursor = cursor;
++            signal_frame = i;
++
+             ErrorFSigSafe("%u: <signal handler called>\n", i++);
+         } else {
+             ErrorFSigSafe("%u: %s (%s%s+0x%x) [%p]\n", i++, filename, procname,
+@@ -110,6 +171,10 @@ xorg_backtrace(void)
+         if (ret < 0)
+             ErrorFSigSafe("unw_step failed: %s [%d]\n", unw_strerror(ret), ret);
+     }
++
++    if (signal_frame >= 0)
++        print_registers(signal_frame, signal_cursor);
++
+     ErrorFSigSafe("\n");
+ }
+ #else /* HAVE_LIBUNWIND */
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1013-BACKPORT-ephyr-Sync-less-in-hostx_paint_rect.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1013-BACKPORT-ephyr-Sync-less-in-hostx_paint_rect.patch
@@ -1,0 +1,57 @@
+From 837cc4a0982a1030d4579b1657cb5467f8160984 Mon Sep 17 00:00:00 2001
+From: Adam Jackson <ajax@redhat.com>
+Date: Tue, 8 Feb 2022 18:02:40 -0500
+Subject: [PATCH 013/105] ephyr: Sync less in hostx_paint_rect
+
+Move the xcb_aux_sync into the shm path, where we do still need it to
+synchronize access with the host. In the non-shm path the image is
+copied to the host anyway so the sync just adds latency and keeps you
+from using all your network bandwidth.
+
+Only the non-shm-putimage path benefits from this, but the benefit is
+significant even on the local machine (here a 3.2GHz Core i7-8700, using
+XEPHYR_NO_SHM=1):
+
+      before                  after   Operation
+------------   --------------------   -------------------------
+ 228000000.0    225000000.0 (0.987)   Dot
+  40900000.0     41600000.0 (1.017)   1x1 rectangle
+  10400000.0     10700000.0 (1.029)   10x10 rectangle
+    477000.0       471000.0 (0.987)   100x100 rectangle
+     30900.0        31800.0 (1.029)   500x500 rectangle
+    760000.0       981000.0 (1.291)   PutImage 10x10 square
+     14700.0        19200.0 (1.306)   PutImage 100x100 square
+       320.0          382.0 (1.194)   PutImage 500x500 square
+    749000.0       984000.0 (1.314)   ShmPutImage 10x10 square
+    268000.0       304000.0 (1.134)   ShmPutImage 100x100 square
+     16600.0        18500.0 (1.114)   ShmPutImage 500x500 square
+
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ hw/kdrive/ephyr/hostx.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/hw/kdrive/ephyr/hostx.c b/hw/kdrive/ephyr/hostx.c
+index f9cb6980f..d8ed68bfd 100644
+--- a/hw/kdrive/ephyr/hostx.c
++++ b/hw/kdrive/ephyr/hostx.c
+@@ -1100,6 +1100,7 @@ hostx_paint_rect(KdScreenInfo *screen,
+                           HostX.gc, scrpriv->ximg,
+                           scrpriv->shminfo,
+                           sx, sy, dx, dy, width, height, FALSE);
++        xcb_aux_sync(HostX.conn);
+     }
+     else {
+         xcb_image_t *subimg = xcb_image_subimage(scrpriv->ximg, sx, sy,
+@@ -1110,8 +1111,6 @@ hostx_paint_rect(KdScreenInfo *screen,
+             xcb_image_destroy(img);
+         xcb_image_destroy(subimg);
+     }
+-
+-    xcb_aux_sync(HostX.conn);
+ }
+ 
+ static void
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1014-BACKPORT-ephyr-Sync-even-less-in-ephyrInternalDamageRedisplay.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1014-BACKPORT-ephyr-Sync-even-less-in-ephyrInternalDamageRedisplay.patch
@@ -1,0 +1,104 @@
+From 1726a2ce57eeabe48f18e37a4afe4cbc5c523f87 Mon Sep 17 00:00:00 2001
+From: Adam Jackson <ajax@redhat.com>
+Date: Wed, 9 Feb 2022 00:33:10 -0500
+Subject: [PATCH 014/105] ephyr: Sync even less in ephyrInternalDamageRedisplay
+
+If we have multiple damage rects we would sync (if we would sync) after
+every hostx_paint_rect. For shm images you'd rather push all the
+ShmPutImage requests and wait after the last one.
+
+      before                  after   Operation
+------------   --------------------   -------------------------
+ 232000000.0    240000000.0 (1.034)   Dot
+  41500000.0     41400000.0 (0.998)   1x1 rectangle
+  11400000.0     11400000.0 (1.000)   10x10 rectangle
+    553000.0       553000.0 (1.000)   100x100 rectangle
+     37300.0        38500.0 (1.032)   500x500 rectangle
+    831000.0      1140000.0 (1.372)   PutImage 10x10 square
+     65200.0       134000.0 (2.055)   PutImage 100x100 square
+      3410.0         3500.0 (1.026)   PutImage 500x500 square
+    810000.0      1150000.0 (1.420)   ShmPutImage 10x10 square
+    346000.0       364000.0 (1.052)   ShmPutImage 100x100 square
+     22400.0        22800.0 (1.018)   ShmPutImage 500x500 square
+
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ hw/kdrive/ephyr/ephyr.c | 8 +++++---
+ hw/kdrive/ephyr/hostx.c | 6 ++++--
+ hw/kdrive/ephyr/hostx.h | 3 ++-
+ 3 files changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/hw/kdrive/ephyr/ephyr.c b/hw/kdrive/ephyr/ephyr.c
+index 9236252b2..8b90584be 100644
+--- a/hw/kdrive/ephyr/ephyr.c
++++ b/hw/kdrive/ephyr/ephyr.c
+@@ -298,7 +298,7 @@ ephyrShadowUpdate(ScreenPtr pScreen, shadowBufPtr pBuf)
+      * pBuf->pDamage  regions
+      */
+     shadowUpdateRotatePacked(pScreen, pBuf);
+-    hostx_paint_rect(screen, 0, 0, 0, 0, screen->width, screen->height);
++    hostx_paint_rect(screen, 0, 0, 0, 0, screen->width, screen->height, TRUE);
+ }
+ 
+ static void
+@@ -328,7 +328,8 @@ ephyrInternalDamageRedisplay(ScreenPtr pScreen)
+                 hostx_paint_rect(screen,
+                                  pbox->x1, pbox->y1,
+                                  pbox->x1, pbox->y1,
+-                                 pbox->x2 - pbox->x1, pbox->y2 - pbox->y1);
++                                 pbox->x2 - pbox->x1, pbox->y2 - pbox->y1,
++                                 nbox == 0);
+                 pbox++;
+             }
+         }
+@@ -889,7 +890,8 @@ ephyrProcessExpose(xcb_generic_event_t *xev)
+     if (scrpriv) {
+         hostx_paint_rect(scrpriv->screen, 0, 0, 0, 0,
+                          scrpriv->win_width,
+-                         scrpriv->win_height);
++                         scrpriv->win_height,
++                         TRUE);
+     } else {
+         EPHYR_LOG_ERROR("failed to get host screen\n");
+     }
+diff --git a/hw/kdrive/ephyr/hostx.c b/hw/kdrive/ephyr/hostx.c
+index d8ed68bfd..1dc14be38 100644
+--- a/hw/kdrive/ephyr/hostx.c
++++ b/hw/kdrive/ephyr/hostx.c
+@@ -1011,7 +1011,8 @@ static void hostx_paint_debug_rect(KdScreenInfo *screen,
+ 
+ void
+ hostx_paint_rect(KdScreenInfo *screen,
+-                 int sx, int sy, int dx, int dy, int width, int height)
++                 int sx, int sy, int dx, int dy, int width, int height,
++                 Bool sync)
+ {
+     EphyrScrPriv *scrpriv = screen->driver;
+ 
+@@ -1100,7 +1101,8 @@ hostx_paint_rect(KdScreenInfo *screen,
+                           HostX.gc, scrpriv->ximg,
+                           scrpriv->shminfo,
+                           sx, sy, dx, dy, width, height, FALSE);
+-        xcb_aux_sync(HostX.conn);
++        if (sync)
++            xcb_aux_sync(HostX.conn);
+     }
+     else {
+         xcb_image_t *subimg = xcb_image_subimage(scrpriv->ximg, sx, sy,
+diff --git a/hw/kdrive/ephyr/hostx.h b/hw/kdrive/ephyr/hostx.h
+index 4b2678e58..8b3caf245 100644
+--- a/hw/kdrive/ephyr/hostx.h
++++ b/hw/kdrive/ephyr/hostx.h
+@@ -146,7 +146,8 @@ void *hostx_screen_init(KdScreenInfo *screen,
+ 
+ void
+ hostx_paint_rect(KdScreenInfo *screen,
+-                 int sx, int sy, int dx, int dy, int width, int height);
++                 int sx, int sy, int dx, int dy, int width, int height,
++                 Bool sync);
+ 
+ Bool
+ hostx_load_keymap(KeySymsPtr keySyms, CARD8 *modmap, XkbControlsPtr controls);
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1015-BACKPORT-randr-Correctly-get-physical-size-for-screen-with-Ra.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1015-BACKPORT-randr-Correctly-get-physical-size-for-screen-with-Ra.patch
@@ -1,0 +1,28 @@
+From 278e743de7ba296242b0b58fa6b9687d44270330 Mon Sep 17 00:00:00 2001
+From: JiangWu <wujiang@kylinos.cn>
+Date: Tue, 9 Aug 2022 07:17:07 +0000
+Subject: [PATCH 015/105] randr: Correctly get physical size for screen with
+ RandR 1.5
+
+---
+ randr/rrmonitor.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/randr/rrmonitor.c b/randr/rrmonitor.c
+index ec9cc3ef4..a0fb820d7 100644
+--- a/randr/rrmonitor.c
++++ b/randr/rrmonitor.c
+@@ -156,8 +156,8 @@ RRMonitorGetGeometry(RRMonitorPtr monitor, RRMonitorGeometryPtr geometry)
+ 
+         /* Adjust physical sizes to account for total area */
+         if (active_crtcs > 1 && first.box.x2 != first.box.x1 && first.box.y2 != first.box.y1) {
+-            geometry->mmWidth = (this.box.x2 - this.box.x1) / (first.box.x2 - first.box.x1) * first.mmWidth;
+-            geometry->mmHeight = (this.box.y2 - this.box.y1) / (first.box.y2 - first.box.y1) * first.mmHeight;
++            geometry->mmWidth = ((double)(geometry->box.x2 - geometry->box.x1) / (first.box.x2 - first.box.x1)) * first.mmWidth;
++            geometry->mmHeight = ((double)(geometry->box.y2 - geometry->box.y1) / (first.box.y2 - first.box.y1)) * first.mmHeight;
+         }
+     } else {
+         *geometry = monitor->geometry;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1016-BACKPORT-os-Restore-buffer-when-writing-to-network.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1016-BACKPORT-os-Restore-buffer-when-writing-to-network.patch
@@ -1,0 +1,43 @@
+From 37ef4e3af39f5f2e1db68e64b76b7e35816c52e3 Mon Sep 17 00:00:00 2001
+From: Peter Harris <pharris@opentext.com>
+Date: Tue, 21 Apr 2020 15:19:22 -0400
+Subject: [PATCH 016/105] os: Restore buffer when writing to network
+
+The commit 9bf46610a9d20962854016032de4567974e87957 "os: Immediately
+queue initial WriteToClient" effectively disables buffering (of all
+writes, not just the "initial" write), since the OS's network buffers
+will usually be large enough to hold whatever replies we have sent.
+
+This does improve performance when drawing over a Unix socket (I measure
+approximtely 10%, not the ~5x mentioned in that commit message, probably
+due to the large changes in this area since that commit), but it
+decreases performance when drawing over a network due to the additional
+TCP packets. This decrease is small (~10%) in most cases, but if the two
+machines have mismatched Nagle / tcp_delay settings it can cause
+XGetWindowAttributes to take 200ms (because it's composed of two
+requests, the 2nd of which might wait for the ack which is delayed).
+
+Avoid network slowdowns by making the immediate flush conditional on
+who->local.
+
+Signed-off-by: Peter Harris <pharris@opentext.com>
+---
+ os/io.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/os/io.c b/os/io.c
+index 5b7fac349..841a0ee40 100644
+--- a/os/io.c
++++ b/os/io.c
+@@ -790,7 +790,7 @@ WriteToClient(ClientPtr who, int count, const void *__buf)
+         }
+     }
+ #endif
+-    if (oco->count == 0 || oco->count + count + padBytes > oco->size) {
++    if ((oco->count == 0 && who->local) || oco->count + count + padBytes > oco->size) {
+         output_pending_clear(who);
+         if (!any_output_pending()) {
+             CriticalOutputPending = FALSE;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1017-BACKPORT-xf86AutoConfig-try-modesetting-on-all-platforms-we-b.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1017-BACKPORT-xf86AutoConfig-try-modesetting-on-all-platforms-we-b.patch
@@ -1,0 +1,56 @@
+From 9cf7cf6d075842f4a999647a22e24af98b811c88 Mon Sep 17 00:00:00 2001
+From: Alan Coopersmith <alan.coopersmith@oracle.com>
+Date: Mon, 29 Aug 2022 14:39:57 -0700
+Subject: [PATCH 017/105] xf86AutoConfig: try modesetting on all platforms we
+ build it on
+
+Changes check for trying modesetting driver from if defined(__linux__)
+to use meson check for if we built the driver for this platform.
+
+Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
+---
+ hw/xfree86/common/xf86AutoConfig.c | 2 +-
+ include/meson.build                | 1 +
+ include/xorg-config.h.meson.in     | 3 +++
+ 3 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/hw/xfree86/common/xf86AutoConfig.c b/hw/xfree86/common/xf86AutoConfig.c
+index 0f4f05de9..c2a897250 100644
+--- a/hw/xfree86/common/xf86AutoConfig.c
++++ b/hw/xfree86/common/xf86AutoConfig.c
+@@ -294,7 +294,7 @@ listPossibleVideoDrivers(XF86MatchedDrivers *md)
+     xf86PciMatchDriver(md);
+ #endif
+ 
+-#if defined(__linux__)
++#if defined(HAVE_MODESETTING_DRIVER)
+     xf86AddMatchedDriver(md, "modesetting");
+ #endif
+ 
+diff --git a/include/meson.build b/include/meson.build
+index 591bc25e0..0a7bcf3cb 100644
+--- a/include/meson.build
++++ b/include/meson.build
+@@ -376,6 +376,7 @@ xorg_data.set('WSCONS_SUPPORT',
+ xorg_data.set('HAVE_STROPTS_H', cc.has_header('stropts.h') ? '1' : false)
+ xorg_data.set('HAVE_SYS_KD_H', cc.has_header('sys/kd.h') ? '1' : false)
+ xorg_data.set('HAVE_SYS_VT_H', cc.has_header('sys/vt.h') ? '1' : false)
++xorg_data.set('HAVE_MODESETTING_DRIVER', build_modesetting ? '1' : false)
+ 
+ if host_machine.system() == 'freebsd' or host_machine.system() == 'dragonfly'
+     if host_machine.cpu_family() == 'x86' or host_machine.cpu_family() == 'x86_64'
+diff --git a/include/xorg-config.h.meson.in b/include/xorg-config.h.meson.in
+index 59f1c2a8d..192c340dc 100644
+--- a/include/xorg-config.h.meson.in
++++ b/include/xorg-config.h.meson.in
+@@ -145,4 +145,7 @@
+ /* Fallback input driver if the assigned driver fails */
+ #mesondefine FALLBACK_INPUT_DRIVER
+ 
++/* Define if building the modesetting driver */
++#mesondefine HAVE_MODESETTING_DRIVER
++
+ #endif /* _XORG_CONFIG_H_ */
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1018-BACKPORT-glamor_egl-handle-fd-export-failure-in-glamor_egl_fd.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1018-BACKPORT-glamor_egl-handle-fd-export-failure-in-glamor_egl_fd.patch
@@ -1,0 +1,46 @@
+From 63a78ad0c8fbb7f74b8ca2f254f9edebedbe4195 Mon Sep 17 00:00:00 2001
+From: Lucas Stach <l.stach@pengutronix.de>
+Date: Thu, 28 Jul 2022 22:52:15 +0200
+Subject: [PATCH 018/105] glamor_egl: handle fd export failure in
+ glamor_egl_fds_from_pixmap
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Check the fd for validity before giving a success return code.
+
+Signed-off-by: Lucas Stach <l.stach@pengutronix.de>
+Reviewed-by: Simon Ser <contact@emersion.fr>
+Tested-by: Guido Günther <agx@sigxcpu.org>
+---
+ glamor/glamor_egl.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index 60d0df893..fa5fcbd04 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -417,6 +417,11 @@ glamor_egl_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
+     num_fds = gbm_bo_get_plane_count(bo);
+     for (i = 0; i < num_fds; i++) {
+         fds[i] = gbm_bo_get_fd(bo);
++        if (fds[i] == -1) {
++            while (--i >= 0)
++                close(fds[i]);
++            return 0;
++        }
+         strides[i] = gbm_bo_get_stride_for_plane(bo, i);
+         offsets[i] = gbm_bo_get_offset(bo, i);
+     }
+@@ -424,6 +429,8 @@ glamor_egl_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
+ #else
+     num_fds = 1;
+     fds[0] = gbm_bo_get_fd(bo);
++    if (fds[0] == -1)
++        return 0;
+     strides[0] = gbm_bo_get_stride(bo);
+     offsets[0] = 0;
+     *modifier = DRM_FORMAT_MOD_INVALID;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1019-BACKPORT-glamor_egl-properly-get-FDs-from-multiplanar-GBM-BOs.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1019-BACKPORT-glamor_egl-properly-get-FDs-from-multiplanar-GBM-BOs.patch
@@ -1,0 +1,62 @@
+From c284f30b682f2fa48b5576f0dff686f3b78ffa1c Mon Sep 17 00:00:00 2001
+From: Lucas Stach <l.stach@pengutronix.de>
+Date: Sun, 10 Jul 2022 19:35:43 +0200
+Subject: [PATCH 019/105] glamor_egl: properly get FDs from multiplanar GBM BOs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Multiplanar GBM buffers can point to different objects from each plane.
+Use the _for_plane API when possible to retrieve the correct prime FD
+for each plane.
+
+Signed-off-by: Lucas Stach <l.stach@pengutronix.de>
+Reviewed-by: Simon Ser <contact@emersion.fr>
+Tested-by: Guido Günther <agx@sigxcpu.org>
+---
+ glamor/glamor_egl.c | 22 +++++++++++++++++++++-
+ 1 file changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index fa5fcbd04..aa82a5608 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -403,6 +403,9 @@ glamor_egl_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
+     struct gbm_bo *bo;
+     int num_fds;
+ #ifdef GBM_BO_WITH_MODIFIERS
++#ifndef GBM_BO_FD_FOR_PLANE
++    int32_t first_handle;
++#endif
+     int i;
+ #endif
+ 
+@@ -416,7 +419,24 @@ glamor_egl_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
+ #ifdef GBM_BO_WITH_MODIFIERS
+     num_fds = gbm_bo_get_plane_count(bo);
+     for (i = 0; i < num_fds; i++) {
+-        fds[i] = gbm_bo_get_fd(bo);
++#ifdef GBM_BO_FD_FOR_PLANE
++        fds[i] = gbm_bo_get_fd_for_plane(bo, i);
++#else
++        union gbm_bo_handle plane_handle = gbm_bo_get_handle_for_plane(bo, i);
++
++        if (i == 0)
++            first_handle = plane_handle.s32;
++
++        /* If all planes point to the same object as the first plane, i.e. they
++         * all have the same handle, we can fall back to the non-planar
++         * gbm_bo_get_fd without losing information. If they point to different
++         * objects we are out of luck and need to give up.
++         */
++	if (first_handle == plane_handle.s32)
++            fds[i] = gbm_bo_get_fd(bo);
++        else
++            fds[i] = -1;
++#endif
+         if (fds[i] == -1) {
+             while (--i >= 0)
+                 close(fds[i]);
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1020-BACKPORT-xf86-allow-DDX-driver-for-GPU-PCI-hot-plug.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1020-BACKPORT-xf86-allow-DDX-driver-for-GPU-PCI-hot-plug.patch
@@ -1,0 +1,244 @@
+From 8d843dfe2382ab0ef7b392e0a4f7b7a1c1621476 Mon Sep 17 00:00:00 2001
+From: Shashank Sharma <shashank.sharma@amd.com>
+Date: Tue, 16 Aug 2022 13:39:59 +0200
+Subject: [PATCH 020/105] xf86: allow DDX driver for GPU/PCI hot-plug
+
+The current X server infrastructure sets modesetting driver as default driver
+to handle PCI-hotplug of a GPU device. This prevents the respective DDX driver
+(like AMDGPU DDX driver) to take control of the card.
+
+This patch:
+- Adds a few functions and fine-tunes the GPU hotplug infrastructure to allow
+  the DDX driver to be loaded, if it is configured in the X config file
+  options as "hotplug-driver".
+- Scans and updates the PCI device list before adding the new GPU device
+  in platform, so that the association of the platform device and PCI device
+  is in place (dev->pdev).
+- Adds documentation of this new option
+
+An example usage in the config file would look like:
+
+Section "OutputClass"
+        Identifier "AMDgpu"
+        MatchDriver "amdgpu"
+        Driver "amdgpu"
+	HotplugDriver "amdgpu"
+EndSection
+
+V2:
+Fixed typo in commit message (Martin)
+Added R-B from Adam.
+Added ACK from Alex and Martin.
+
+V3:
+Added an output class based approach for finding the DDX driver (Aaron)
+Rebase
+
+V4:
+Addressed review comment from Aaron:
+GPU hot-plug handling driver's name to be read from the DDX config file options.
+In this way only the DDX drivers interested in handling GPU hot-plug will be
+picked and loaded, for others modesetting driver will be used as usual.
+
+V5:
+Addressed review comments from Aaron:
+- X config option to be listed in CamelCase.
+- Indentation fix at one place.
+- Code readability related optimization.
+
+V6:
+Addressed review comments from Aaron:
+- Squash the doc in the same patch
+- Doc formatting changes
+
+Cc: Alex Deucher <alexander.deucher@amd.com>
+Suggested-by: Aaron Plattner aplattner@nvidia.com (v3)
+Acked-by: Martin Roukala martin.roukala@mupuf.org(v1)
+Acked-by: Alex Deucher alexander.deucher@amd.com (v1)
+Reviewed-by: Adam Jackson ajax@redhat.com(v1)
+Signed-off-by: Shashank Sharma shashank.sharma@amd.com
+---
+ hw/xfree86/common/xf86platformBus.c        | 55 +++++++++++++++++++---
+ hw/xfree86/common/xf86platformBus.h        |  4 +-
+ hw/xfree86/man/xorg.conf.man               | 15 +++++-
+ hw/xfree86/os-support/linux/lnx_platform.c | 10 +++-
+ 4 files changed, 74 insertions(+), 10 deletions(-)
+
+diff --git a/hw/xfree86/common/xf86platformBus.c b/hw/xfree86/common/xf86platformBus.c
+index 071f44b2a..1d1f87c74 100644
+--- a/hw/xfree86/common/xf86platformBus.c
++++ b/hw/xfree86/common/xf86platformBus.c
+@@ -272,6 +272,22 @@ xf86PlatformMatchDriver(XF86MatchedDrivers *md)
+     }
+ }
+ 
++void xf86PlatformScanPciDev(void)
++{
++    int i;
++
++    if (!xf86scanpci())
++        return;
++
++    xf86Msg(X_CONFIG, "Scanning the platform PCI devices\n");
++    for (i = 0; i < xf86_num_platform_devices; i++) {
++        char *busid = xf86_platform_odev_attributes(i)->busid;
++
++        if (strncmp(busid, "pci:", 4) == 0)
++            platform_find_pci_info(&xf86_platform_devices[i], busid);
++    }
++}
++
+ int
+ xf86platformProbe(void)
+ {
+@@ -613,31 +629,58 @@ xf86platformAddGPUDevices(DriverPtr drvp)
+     return foundScreen;
+ }
+ 
++const char *
++xf86PlatformFindHotplugDriver(int dev_index)
++{
++    XF86ConfOutputClassPtr cl;
++    const char *hp_driver = NULL;
++    struct xf86_platform_device *dev = &xf86_platform_devices[dev_index];
++
++    for (cl = xf86configptr->conf_outputclass_lst; cl; cl = cl->list.next) {
++        if (!OutputClassMatches(cl, dev) || !cl->option_lst)
++	    continue;
++
++        hp_driver = xf86FindOptionValue(cl->option_lst, "HotplugDriver");
++        if (hp_driver)
++            xf86MarkOptionUsed(cl->option_lst);
++    }
++
++    /* Return the first driver from the match list */
++    xf86Msg(X_INFO, "matching hotplug-driver is %s\n",
++            hp_driver ? hp_driver : "none");
++    return hp_driver;
++}
++
+ int
+-xf86platformAddDevice(int index)
++xf86platformAddDevice(const char *driver_name, int index)
+ {
+     int i, old_screens, scr_index, scrnum;
+     DriverPtr drvp = NULL;
+     screenLayoutPtr layout;
+-    static const char *hotplug_driver_name = "modesetting";
+ 
+     if (!xf86Info.autoAddGPU)
+         return -1;
+ 
+-    /* force load the driver for now */
+-    xf86LoadOneModule(hotplug_driver_name, NULL);
++    /* Load modesetting driver if no driver given, or driver open failed */
++    if (!driver_name || !xf86LoadOneModule(driver_name, NULL)) {
++        driver_name = "modesetting";
++        xf86LoadOneModule(driver_name, NULL);
++    }
+ 
+     for (i = 0; i < xf86NumDrivers; i++) {
+         if (!xf86DriverList[i])
+             continue;
+ 
+-        if (!strcmp(xf86DriverList[i]->driverName, hotplug_driver_name)) {
++        if (!strcmp(xf86DriverList[i]->driverName, driver_name)) {
+             drvp = xf86DriverList[i];
+             break;
+         }
+     }
+-    if (i == xf86NumDrivers)
++
++    if (i == xf86NumDrivers) {
++        ErrorF("can't find driver %s for hotplugged device\n", driver_name);
+         return -1;
++    }
+ 
+     old_screens = xf86NumGPUScreens;
+     doPlatformProbe(&xf86_platform_devices[index], drvp, NULL,
+diff --git a/hw/xfree86/common/xf86platformBus.h b/hw/xfree86/common/xf86platformBus.h
+index 1e75e6352..9979106a1 100644
+--- a/hw/xfree86/common/xf86platformBus.h
++++ b/hw/xfree86/common/xf86platformBus.h
+@@ -44,6 +44,8 @@ int xf86platformProbe(void);
+ int xf86platformProbeDev(DriverPtr drvp);
+ int xf86platformAddGPUDevices(DriverPtr drvp);
+ void xf86MergeOutputClassOptions(int entityIndex, void **options);
++void xf86PlatformScanPciDev(void);
++const char *xf86PlatformFindHotplugDriver(int dev_index);
+ 
+ extern int xf86_num_platform_devices;
+ extern struct xf86_platform_device *xf86_platform_devices;
+@@ -56,7 +58,7 @@ extern Bool
+ xf86_get_platform_device_unowned(int index);
+ 
+ extern int
+-xf86platformAddDevice(int index);
++xf86platformAddDevice(const char *driver_name, int index);
+ extern void
+ xf86platformRemoveDevice(int index);
+ 
+diff --git a/hw/xfree86/man/xorg.conf.man b/hw/xfree86/man/xorg.conf.man
+index ed125b3ee..92f0e0d26 100644
+--- a/hw/xfree86/man/xorg.conf.man
++++ b/hw/xfree86/man/xorg.conf.man
+@@ -1299,7 +1299,20 @@ This option specifies that the matched device should be treated as the
+ primary GPU, replacing the selection of the GPU used as output by the
+ firmware. If multiple output devices match an OutputClass section with
+ the PrimaryGPU option set, the first one enumerated becomes the primary GPU.
+-.PP
++.TP 7
++.BI "Option \*qHotplugDriver\*q \*q" driver \*q
++This option specifies that the matched driver should be used to handle a
++hot-plugged GPU device.
++The module specified by
++.I driver
++will be loaded during setup of the GPU device.
++If loading of this module fails or there is no driver by that name, the
++modesetting driver will be used, which is the default behavior.
++If multiple output devices match an
++.B OutputClass
++section with the
++.B HotplugDriver
++option, the first one enumerated becomes the hotplug driver.
+ A
+ .B OutputClass
+ Section may contain
+diff --git a/hw/xfree86/os-support/linux/lnx_platform.c b/hw/xfree86/os-support/linux/lnx_platform.c
+index 8a6be97aa..90013573c 100644
+--- a/hw/xfree86/os-support/linux/lnx_platform.c
++++ b/hw/xfree86/os-support/linux/lnx_platform.c
+@@ -125,7 +125,7 @@ xf86PlatformReprobeDevice(int index, struct OdevAttributes *attribs)
+         xf86_remove_platform_device(index);
+         return;
+     }
+-    ret = xf86platformAddDevice(index);
++    ret = xf86platformAddDevice(xf86PlatformFindHotplugDriver(index), index);
+     if (ret == -1)
+         xf86_remove_platform_device(index);
+ }
+@@ -173,6 +173,8 @@ void NewGPUDeviceRequest(struct OdevAttributes *attribs)
+ {
+     int old_num = xf86_num_platform_devices;
+     int ret;
++    const char *driver_name;
++
+     xf86PlatformDeviceProbe(attribs);
+ 
+     if (old_num == xf86_num_platform_devices)
+@@ -181,7 +183,11 @@ void NewGPUDeviceRequest(struct OdevAttributes *attribs)
+     if (xf86_get_platform_device_unowned(xf86_num_platform_devices - 1) == TRUE)
+         return;
+ 
+-    ret = xf86platformAddDevice(xf86_num_platform_devices-1);
++    /* Scan and update PCI devices before adding new platform device */
++    xf86PlatformScanPciDev();
++    driver_name = xf86PlatformFindHotplugDriver(xf86_num_platform_devices - 1);
++
++    ret = xf86platformAddDevice(driver_name, xf86_num_platform_devices-1);
+     if (ret == -1)
+         xf86_remove_platform_device(xf86_num_platform_devices-1);
+ 
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1021-BACKPORT-glamor-Only-check-for-llvmpipe-renderer.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1021-BACKPORT-glamor-Only-check-for-llvmpipe-renderer.patch
@@ -1,0 +1,36 @@
+From e7635e420cf3d9061315c4ea854c0d95453a4042 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Corentin=20No=C3=ABl?= <corentin.noel@collabora.com>
+Date: Mon, 1 Aug 2022 16:03:38 +0200
+Subject: [PATCH 021/105] glamor: Only check for llvmpipe renderer
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The virgl driver exposes the name of the host renderer which might be llvmpipe.
+In this case we still need glamor to be initialized.
+
+Only check if the renderer starts with llvmpipe (which is what llvmpipe exposes).
+
+Signed-off-by: Corentin Noël <corentin.noel@collabora.com>
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ glamor/glamor_egl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index aa82a5608..e2a2a1050 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -1080,7 +1080,7 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+                    "glGetString() returned NULL, your GL is broken\n");
+         goto error;
+     }
+-    if (strstr((const char *)renderer, "llvmpipe")) {
++    if (!strncmp("llvmpipe", (const char *)renderer, strlen("llvmpipe"))) {
+         if (scrn->confScreen->num_gpu_devices)
+             xf86DrvMsg(scrn->scrnIndex, X_INFO,
+                        "Allowing glamor on llvmpipe for PRIME\n");
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1022-BACKPORT-glamor-make-use-of-GL_EXT_texture_format_BGRA8888.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1022-BACKPORT-glamor-make-use-of-GL_EXT_texture_format_BGRA8888.patch
@@ -1,0 +1,71 @@
+From c04ac168bd42dd16e891c4b6d9a02ea3e410c438 Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Sun, 26 Jun 2022 00:01:54 +0300
+Subject: [PATCH 022/105] glamor: make use of GL_EXT_texture_format_BGRA8888
+
+For 24 and 32 bit depth pictures xserver uses PICT_x8r8g8b8 and PICT_a8r8g8b8 formats,
+which must be backed with GL_BGRA format. It is present in OpenGL ES 2.0 only with
+GL_EXT_texture_format_BGRA8888 extension. We require such extension in glamor_init,
+so, why not to make use of it?
+Fixes #1208
+Fixes #1354
+
+Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ glamor/glamor.c         | 8 ++++----
+ glamor/glamor_picture.c | 7 ++-----
+ 2 files changed, 6 insertions(+), 9 deletions(-)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index 9dcef5fac..0a757db35 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -586,10 +586,10 @@ glamor_setup_formats(ScreenPtr screen)
+ 
+     if (glamor_priv->is_gles) {
+         assert(X_BYTE_ORDER == X_LITTLE_ENDIAN);
+-        glamor_add_format(screen, 24, PICT_x8b8g8r8,
+-                          GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE, TRUE);
+-        glamor_add_format(screen, 32, PICT_a8b8g8r8,
+-                          GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE, TRUE);
++        glamor_add_format(screen, 24, PICT_x8r8g8b8,
++                          GL_BGRA, GL_BGRA, GL_UNSIGNED_BYTE, TRUE);
++        glamor_add_format(screen, 32, PICT_a8r8g8b8,
++                          GL_BGRA, GL_BGRA, GL_UNSIGNED_BYTE, TRUE);
+     } else {
+         glamor_add_format(screen, 24, PICT_x8r8g8b8,
+                           GL_RGBA, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, TRUE);
+diff --git a/glamor/glamor_picture.c b/glamor/glamor_picture.c
+index 33b3bebd9..2152b85e1 100644
+--- a/glamor/glamor_picture.c
++++ b/glamor/glamor_picture.c
+@@ -94,7 +94,7 @@ glamor_get_tex_format_type_from_pictformat(ScreenPtr pScreen,
+             *tex_format = GL_BGRA;
+             *tex_type = GL_UNSIGNED_INT_8_8_8_8;
+         } else {
+-            *tex_format = GL_RGBA;
++            *tex_format = GL_BGRA;
+             *tex_type = GL_UNSIGNED_BYTE;
+ 
+             swizzle[0] = GL_GREEN;
+@@ -113,12 +113,9 @@ glamor_get_tex_format_type_from_pictformat(ScreenPtr pScreen,
+             *tex_format = GL_BGRA;
+             *tex_type = GL_UNSIGNED_INT_8_8_8_8_REV;
+         } else {
+-            *tex_format = GL_RGBA;
++            *tex_format = GL_BGRA;
+             *tex_type = GL_UNSIGNED_BYTE;
+ 
+-            swizzle[0] = GL_BLUE;
+-            swizzle[2] = GL_RED;
+-
+             if (!is_little_endian)
+                 byte_swap_swizzle(swizzle);
+             break;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1023-BACKPORT-glamor-transpose-gradients-transparently.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1023-BACKPORT-glamor-transpose-gradients-transparently.patch
@@ -1,0 +1,99 @@
+From 147c5ee82f3791d86c0d3eb0ea5c340fbc436ab7 Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Sat, 25 Jun 2022 17:51:15 +0300
+Subject: [PATCH 023/105] glamor: transpose gradients transparently
+
+glUniformMatrix3fv is used with argument transpose set to GL_TRUE.
+According to the Khronos OpenGL ES 2.0 pages transpose must be GL_FALSE.
+Actually we can just return transformed matrix from
+_glamor_gradient_convert_trans_matrix (@anholt suggest),
+so @uvas workaround is not required
+
+Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor_gradient.c | 32 +++++++++++++++++++++-----------
+ 1 file changed, 21 insertions(+), 11 deletions(-)
+
+diff --git a/glamor/glamor_gradient.c b/glamor/glamor_gradient.c
+index 7e5d5cca9..4c7ae4d77 100644
+--- a/glamor/glamor_gradient.c
++++ b/glamor/glamor_gradient.c
+@@ -605,27 +605,35 @@ _glamor_gradient_convert_trans_matrix(PictTransform *from, float to[3][3],
+      * T_s = | w*t21/h  t22      t23/h|
+      *       | w*t31    h*t32    t33  |
+      *       --                      --
++     *
++     * Because GLES2 cannot do trasposed mat by spec, we did transposing inside this function
++     * already, and matrix becoming look like this:
++     *       --                      --
++     *       | t11      w*t21/h  t31*w|
++     * T_s = | h*t12/w  t22      t32*h|
++     *       | t13/w    t23/h    t33  |
++     *       --                      --
+      */
+ 
+     to[0][0] = (float) pixman_fixed_to_double(from->matrix[0][0]);
+-    to[0][1] = (float) pixman_fixed_to_double(from->matrix[0][1])
++    to[1][0] = (float) pixman_fixed_to_double(from->matrix[0][1])
+         * (normalize ? (((float) height) / ((float) width)) : 1.0);
+-    to[0][2] = (float) pixman_fixed_to_double(from->matrix[0][2])
++    to[2][0] = (float) pixman_fixed_to_double(from->matrix[0][2])
+         / (normalize ? ((float) width) : 1.0);
+ 
+-    to[1][0] = (float) pixman_fixed_to_double(from->matrix[1][0])
++    to[0][1] = (float) pixman_fixed_to_double(from->matrix[1][0])
+         * (normalize ? (((float) width) / ((float) height)) : 1.0);
+     to[1][1] = (float) pixman_fixed_to_double(from->matrix[1][1]);
+-    to[1][2] = (float) pixman_fixed_to_double(from->matrix[1][2])
++    to[2][1] = (float) pixman_fixed_to_double(from->matrix[1][2])
+         / (normalize ? ((float) height) : 1.0);
+ 
+-    to[2][0] = (float) pixman_fixed_to_double(from->matrix[2][0])
++    to[0][2] = (float) pixman_fixed_to_double(from->matrix[2][0])
+         * (normalize ? ((float) width) : 1.0);
+-    to[2][1] = (float) pixman_fixed_to_double(from->matrix[2][1])
++    to[1][2] = (float) pixman_fixed_to_double(from->matrix[2][1])
+         * (normalize ? ((float) height) : 1.0);
+     to[2][2] = (float) pixman_fixed_to_double(from->matrix[2][2]);
+ 
+-    DEBUGF("the transform matrix is:\n%f\t%f\t%f\n%f\t%f\t%f\n%f\t%f\t%f\n",
++    DEBUGF("the transposed transform matrix is:\n%f\t%f\t%f\n%f\t%f\t%f\n%f\t%f\t%f\n",
+            to[0][0], to[0][1], to[0][2],
+            to[1][0], to[1][1], to[1][2], to[2][0], to[2][1], to[2][2]);
+ }
+@@ -950,11 +958,12 @@ glamor_generate_radial_gradient_picture(ScreenPtr screen,
+         _glamor_gradient_convert_trans_matrix(src_picture->transform,
+                                               transform_mat, width, height, 0);
+         glUniformMatrix3fv(transform_mat_uniform_location,
+-                           1, 1, &transform_mat[0][0]);
++                           1, GL_FALSE, &transform_mat[0][0]);
+     }
+     else {
++        /* identity matrix dont need to be transposed */
+         glUniformMatrix3fv(transform_mat_uniform_location,
+-                           1, 1, &identity_mat[0][0]);
++                           1, GL_FALSE, &identity_mat[0][0]);
+     }
+ 
+     if (!_glamor_gradient_set_pixmap_destination
+@@ -1266,11 +1275,12 @@ glamor_generate_linear_gradient_picture(ScreenPtr screen,
+         _glamor_gradient_convert_trans_matrix(src_picture->transform,
+                                               transform_mat, width, height, 1);
+         glUniformMatrix3fv(transform_mat_uniform_location,
+-                           1, 1, &transform_mat[0][0]);
++                           1, GL_FALSE, &transform_mat[0][0]);
+     }
+     else {
++        /* identity matrix dont need to be transposed */
+         glUniformMatrix3fv(transform_mat_uniform_location,
+-                           1, 1, &identity_mat[0][0]);
++                           1, GL_FALSE, &identity_mat[0][0]);
+     }
+ 
+     if (!_glamor_gradient_set_pixmap_destination
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1024-BACKPORT-glamor-fix-CbCr-format-handling.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1024-BACKPORT-glamor-fix-CbCr-format-handling.patch
@@ -1,0 +1,103 @@
+From 98d51a0d83054faaa6c66674b08dfaaf741e5b79 Mon Sep 17 00:00:00 2001
+From: Yuriy <uuvasiliev@yandex.ru>
+Date: Thu, 16 Sep 2021 14:47:44 +0300
+Subject: [PATCH 024/105] glamor: fix CbCr format handling
+
+In GLES2, we cannot do GL_RED or GL_RG without GL_EXT_texture_rg.
+So, add check for GL_EXT_texture_rg to make it working. Also add
+a yuv2 pixman format into render.h to make Xv yuv rendering works.
+
+Signed-off-by: Yuriy Vasilev <uuvasiliev@yandex.ru>
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor.c      | 19 +++++++++++++++----
+ glamor/glamor_priv.h |  1 +
+ render/picture.h     |  5 ++++-
+ 3 files changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index 0a757db35..c6bb01d8e 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -223,7 +223,7 @@ glamor_create_pixmap(ScreenPtr screen, int w, int h, int depth,
+ 
+     pixmap_priv = glamor_get_pixmap_private(pixmap);
+ 
+-    pixmap_priv->is_cbcr = (usage == GLAMOR_CREATE_FORMAT_CBCR);
++    pixmap_priv->is_cbcr = (GLAMOR_CREATE_FORMAT_CBCR & usage) == GLAMOR_CREATE_FORMAT_CBCR;
+ 
+     pitch = (((w * pixmap->drawable.bitsPerPixel + 7) / 8) + 3) & ~3;
+     screen->ModifyPixmapHeader(pixmap, w, h, 0, 0, pitch, NULL);
+@@ -550,9 +550,10 @@ glamor_setup_formats(ScreenPtr screen)
+     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+ 
+     /* Prefer r8 textures since they're required by GLES3 and core,
+-     * only falling back to a8 if we can't do them.
++     * only falling back to a8 if we can't do them. We cannot do them
++     * on GLES2 due to lack of texture swizzle.
+      */
+-    if (glamor_priv->is_gles || epoxy_has_gl_extension("GL_ARB_texture_rg")) {
++    if (glamor_priv->has_rg && glamor_priv->has_texture_swizzle) {
+         glamor_add_format(screen, 1, PICT_a1,
+                           GL_R8, GL_RED, GL_UNSIGNED_BYTE, FALSE);
+         glamor_add_format(screen, 8, PICT_a8,
+@@ -606,8 +607,13 @@ glamor_setup_formats(ScreenPtr screen)
+     }
+ 
+     glamor_priv->cbcr_format.depth = 16;
+-    glamor_priv->cbcr_format.internalformat = GL_RG8;
++    if (glamor_priv->is_gles && glamor_priv->has_rg) {
++        glamor_priv->cbcr_format.internalformat = GL_RG;
++    } else {
++        glamor_priv->cbcr_format.internalformat = GL_RG8;
++    }
+     glamor_priv->cbcr_format.format = GL_RG;
++    glamor_priv->cbcr_format.render_format = PICT_yuv2;
+     glamor_priv->cbcr_format.type = GL_UNSIGNED_BYTE;
+     glamor_priv->cbcr_format.rendering_supported = TRUE;
+ }
+@@ -787,6 +793,11 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+     glamor_priv->has_clear_texture =
+         epoxy_gl_version() >= 44 ||
+         epoxy_has_gl_extension("GL_ARB_clear_texture");
++    /* GL_EXT_texture_rg is part of GLES3 core */
++    glamor_priv->has_rg =
++        (glamor_priv->is_gles && epoxy_gl_version() >= 30) ||
++        epoxy_has_gl_extension("GL_EXT_texture_rg") ||
++        epoxy_has_gl_extension("GL_ARB_texture_rg");
+ 
+     glamor_priv->can_copyplane = (gl_version >= 30);
+ 
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index 028a6d374..da20bc5aa 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -216,6 +216,7 @@ typedef struct glamor_screen_private {
+     Bool has_dual_blend;
+     Bool has_clear_texture;
+     Bool has_texture_swizzle;
++    Bool has_rg;
+     Bool is_core_profile;
+     Bool can_copyplane;
+     Bool use_gpu_shader4;
+diff --git a/render/picture.h b/render/picture.h
+index 4499a0021..c3a73d1d8 100644
+--- a/render/picture.h
++++ b/render/picture.h
+@@ -125,7 +125,10 @@ typedef enum _PictFormatShort {
+ /* 1bpp formats */
+     PICT_a1 = PIXMAN_a1,
+ 
+-    PICT_g1 = PIXMAN_g1
++    PICT_g1 = PIXMAN_g1,
++
++/* YCbCr formats */
++    PICT_yuv2 = PIXMAN_yuy2
+ } PictFormatShort;
+ 
+ /*
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1025-BACKPORT-glamor-use-dual-source-blend-on-GL-2.1-with-ARB_ES2_.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1025-BACKPORT-glamor-use-dual-source-blend-on-GL-2.1-with-ARB_ES2_.patch
@@ -1,0 +1,245 @@
+From 82bd5216fdd8f688fed2b3ffdb3c11fd713b32ba Mon Sep 17 00:00:00 2001
+From: Vasily Khoruzhick <anarsoul@gmail.com>
+Date: Fri, 27 May 2022 18:00:56 -0700
+Subject: [PATCH 025/105] glamor: use dual source blend on GL 2.1 with
+ ARB_ES2_compatibility
+
+ARB_blend_func_extended may be exposed even without GLSL 1.30.
+In order to use it we need GLES2 shaders that are available if
+ARB_ES2_compatibility is exposed.
+
+Signed-off-by: Vasily Khoruzhick <anarsoul@gmail.com>
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor.c                  |  6 ++++--
+ glamor/glamor_composite_glyphs.c | 20 +++++++++++++++++++-
+ glamor/glamor_program.c          | 23 ++++++++++++++++-------
+ glamor/glamor_program.h          |  5 +++--
+ glamor/glamor_render.c           | 32 ++++++++++++++++++++++++++++----
+ 5 files changed, 70 insertions(+), 16 deletions(-)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index c6bb01d8e..f15b5a18a 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -788,8 +788,10 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+         epoxy_gl_version() >= 30 ||
+         epoxy_has_gl_extension("GL_NV_pack_subimage");
+     glamor_priv->has_dual_blend =
+-        glamor_glsl_has_ints(glamor_priv) &&
+-        epoxy_has_gl_extension("GL_ARB_blend_func_extended");
++        (epoxy_has_gl_extension("GL_ARB_blend_func_extended") &&
++        (glamor_glsl_has_ints(glamor_priv) ||
++        epoxy_has_gl_extension("GL_ARB_ES2_compatibility"))) ||
++        epoxy_has_gl_extension("GL_EXT_blend_func_extended");
+     glamor_priv->has_clear_texture =
+         epoxy_gl_version() >= 44 ||
+         epoxy_has_gl_extension("GL_ARB_clear_texture");
+diff --git a/glamor/glamor_composite_glyphs.c b/glamor/glamor_composite_glyphs.c
+index 147e3bb31..c69b940d4 100644
+--- a/glamor/glamor_composite_glyphs.c
++++ b/glamor/glamor_composite_glyphs.c
+@@ -208,6 +208,22 @@ static const glamor_facet glamor_facet_composite_glyphs_120 = {
+     .locations = glamor_program_location_atlas,
+ };
+ 
++static const glamor_facet glamor_facet_composite_glyphs_gles2 = {
++    .name = "composite_glyphs",
++    .version = 100,
++    .fs_extensions = ("#extension GL_EXT_blend_func_extended : enable\n"),
++    .vs_vars = ("attribute vec2 primitive;\n"
++                "attribute vec2 source;\n"
++                "varying vec2 glyph_pos;\n"),
++    .vs_exec = ("       vec2 pos = vec2(0,0);\n"
++                GLAMOR_POS(gl_Position, primitive.xy)
++                "       glyph_pos = source.xy * ATLAS_DIM_INV;\n"),
++    .fs_vars = ("varying vec2 glyph_pos;\n"),
++    .fs_exec = ("       vec4 mask = texture2D(atlas, glyph_pos);\n"),
++    .source_name = "source",
++    .locations = glamor_program_location_atlas,
++};
++
+ static Bool
+ glamor_glyphs_init_facet(ScreenPtr screen)
+ {
+@@ -442,7 +458,9 @@ glamor_composite_glyphs(CARD8 op,
+                         else
+                             prog = glamor_setup_program_render(op, src, glyph_pict, dst,
+                                                                glyphs_program,
+-                                                               &glamor_facet_composite_glyphs_120,
++                                                               glamor_priv->has_dual_blend ?
++                                                                   &glamor_facet_composite_glyphs_gles2 :
++                                                                   &glamor_facet_composite_glyphs_120,
+                                                                glamor_priv->glyph_defines);
+                         if (!prog)
+                             goto bail_one;
+diff --git a/glamor/glamor_program.c b/glamor/glamor_program.c
+index d8ddb4c77..46a506aaf 100644
+--- a/glamor/glamor_program.c
++++ b/glamor/glamor_program.c
+@@ -201,6 +201,8 @@ static const char vs_template[] =
+ static const char fs_template[] =
+     "%s"                                /* version */
+     "%s"                                /* exts */
++    "%s"                                /* prim fs_extensions */
++    "%s"                                /* fill fs_extensions */
+     GLAMOR_DEFAULT_PRECISION
+     "%s"                                /* defines */
+     "%s"                                /* prim fs_vars */
+@@ -312,6 +314,8 @@ glamor_build_program(ScreenPtr          screen,
+     if (asprintf(&fs_prog_string,
+                  fs_template,
+                  str(version_string),
++                 str(prim->fs_extensions),
++                 str(fill->fs_extensions),
+                  gpu_shader4 ? "#extension GL_EXT_gpu_shader4 : require\n#define texelFetch texelFetch2D\n#define uint unsigned int\n" : "",
+                  str(defines),
+                  str(prim->fs_vars),
+@@ -494,7 +498,8 @@ glamor_set_blend(CARD8 op, glamor_program_alpha alpha, PicturePtr dst)
+     }
+ 
+     /* Set up the source alpha value for blending in component alpha mode. */
+-    if (alpha == glamor_program_alpha_dual_blend) {
++    if (alpha == glamor_program_alpha_dual_blend ||
++        alpha == glamor_program_alpha_dual_blend_gles2) {
+         switch (dst_blend) {
+         case GL_SRC_ALPHA:
+             dst_blend = GL_SRC1_COLOR;
+@@ -581,11 +586,13 @@ static const glamor_facet *glamor_facet_source[glamor_program_source_count] = {
+ };
+ 
+ static const char *glamor_combine[] = {
+-    [glamor_program_alpha_normal]    = "       gl_FragColor = source * mask.a;\n",
+-    [glamor_program_alpha_ca_first]  = "       gl_FragColor = source.a * mask;\n",
+-    [glamor_program_alpha_ca_second] = "       gl_FragColor = source * mask;\n",
+-    [glamor_program_alpha_dual_blend] = "      color0 = source * mask;\n"
+-                                        "      color1 = source.a * mask;\n"
++    [glamor_program_alpha_normal]    = "        gl_FragColor = source * mask.a;\n",
++    [glamor_program_alpha_ca_first]  = "        gl_FragColor = source.a * mask;\n",
++    [glamor_program_alpha_ca_second] = "        gl_FragColor = source * mask;\n",
++    [glamor_program_alpha_dual_blend] = "       color0 = source * mask;\n"
++                                        "       color1 = source.a * mask;\n",
++    [glamor_program_alpha_dual_blend_gles2] = " gl_FragColor = source * mask;\n"
++                                              " gl_SecondaryFragColorEXT = source.a * mask;\n"
+ };
+ 
+ static Bool
+@@ -633,7 +640,9 @@ glamor_setup_program_render(CARD8                 op,
+ 
+     if (glamor_is_component_alpha(mask)) {
+         if (glamor_priv->has_dual_blend) {
+-            alpha = glamor_program_alpha_dual_blend;
++            alpha = glamor_glsl_has_ints(glamor_priv) ?
++                    glamor_program_alpha_dual_blend :
++                    glamor_program_alpha_dual_blend_gles2;
+         } else {
+             /* This only works for PictOpOver */
+             if (op != PictOpOver)
+diff --git a/glamor/glamor_program.h b/glamor/glamor_program.h
+index ab6e46f7b..0bd918fff 100644
+--- a/glamor/glamor_program.h
++++ b/glamor/glamor_program.h
+@@ -44,6 +44,7 @@ typedef enum {
+     glamor_program_alpha_ca_first,
+     glamor_program_alpha_ca_second,
+     glamor_program_alpha_dual_blend,
++    glamor_program_alpha_dual_blend_gles2,
+     glamor_program_alpha_count
+ } glamor_program_alpha;
+ 
+@@ -56,8 +57,8 @@ typedef Bool (*glamor_use_render) (CARD8 op, PicturePtr src, PicturePtr dst, gla
+ typedef struct {
+     const char                          *name;
+     const int                           version;
+-    char                                *vs_defines;
+-    char                                *fs_defines;
++    char                                *vs_extensions;
++    const char                          *fs_extensions;
+     const char                          *vs_vars;
+     const char                          *vs_exec;
+     const char                          *fs_vars;
+diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
+index 2af65bf93..c9a125ef9 100644
+--- a/glamor/glamor_render.c
++++ b/glamor/glamor_render.c
+@@ -223,6 +223,15 @@ glamor_create_composite_fs(struct shader_key *key)
+         "}\n";
+     const char *header_ca_dual_blend =
+         "#version 130\n";
++    const char *in_ca_dual_blend_gles2 =
++        "void main()\n"
++        "{\n"
++        "	gl_FragColor = dest_swizzle(get_source() * get_mask());\n"
++        "	gl_SecondaryFragColorEXT = dest_swizzle(get_source().a * get_mask());\n"
++        "}\n";
++    const char *header_ca_dual_blend_gles2 =
++        "#version 100\n"
++        "#extension GL_EXT_blend_func_extended : require\n";
+ 
+     char *source;
+     const char *source_fetch;
+@@ -294,6 +303,10 @@ glamor_create_composite_fs(struct shader_key *key)
+         in = in_ca_dual_blend;
+         header = header_ca_dual_blend;
+         break;
++    case glamor_program_alpha_dual_blend_gles2:
++        in = in_ca_dual_blend_gles2;
++        header = header_ca_dual_blend_gles2;
++        break;
+     default:
+         FatalError("Bad composite IN type");
+     }
+@@ -327,6 +340,8 @@ glamor_create_composite_vs(struct shader_key *key)
+     const char *main_closing = "}\n";
+     const char *source_coords_setup = "";
+     const char *mask_coords_setup = "";
++    const char *version_gles2 = "#version 100\n";
++    const char *version = "";
+     char *source;
+     GLuint prog;
+ 
+@@ -336,10 +351,15 @@ glamor_create_composite_vs(struct shader_key *key)
+     if (key->mask != SHADER_MASK_NONE && key->mask != SHADER_MASK_SOLID)
+         mask_coords_setup = mask_coords;
+ 
++    if (key->in == glamor_program_alpha_dual_blend_gles2)
++        version = version_gles2;
++
+     XNFasprintf(&source,
++                "%s"
++                GLAMOR_DEFAULT_PRECISION
+                 "%s%s%s%s",
+-                main_opening,
+-                source_coords_setup, mask_coords_setup, main_closing);
++                version, main_opening, source_coords_setup,
++                mask_coords_setup, main_closing);
+ 
+     prog = glamor_compile_glsl_prog(GL_VERTEX_SHADER, source);
+     free(source);
+@@ -701,6 +721,7 @@ combine_pict_format(PictFormatShort * des, const PictFormatShort src,
+         mask_type = PICT_FORMAT_TYPE(mask);
+         break;
+     case glamor_program_alpha_dual_blend:
++    case glamor_program_alpha_dual_blend_gles2:
+         src_type = PICT_FORMAT_TYPE(src);
+         mask_type = PICT_FORMAT_TYPE(mask);
+         break;
+@@ -886,8 +907,11 @@ glamor_composite_choose_shader(CARD8 op,
+         else {
+             if (op == PictOpClear)
+                 key.mask = SHADER_MASK_NONE;
+-            else if (glamor_priv->has_dual_blend)
+-                key.in = glamor_program_alpha_dual_blend;
++            else if (glamor_priv->has_dual_blend) {
++                key.in = glamor_glsl_has_ints(glamor_priv) ?
++                    glamor_program_alpha_dual_blend :
++                    glamor_program_alpha_dual_blend_gles2;
++            }
+             else if (op == PictOpSrc || op == PictOpAdd
+                      || op == PictOpIn || op == PictOpOut
+                      || op == PictOpOverReverse)
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1026-BACKPORT-glamor-fix-XVideo-run-with-GLES.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1026-BACKPORT-glamor-fix-XVideo-run-with-GLES.patch
@@ -1,0 +1,36 @@
+From e3af1e1844eaee0a3f0b6800bcae7a74ae45203e Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Tue, 28 Jun 2022 12:28:39 +0300
+Subject: [PATCH 026/105] glamor: fix XVideo run with GLES
+
+For now, it sets .version=120, which prevents shader from compiling on ES.
+We just force version of shaders to be always 100 on ES, because we use
+only 120 shaders on ES anyway, and all shaders works.
+
+Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor_program.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/glamor/glamor_program.c b/glamor/glamor_program.c
+index 46a506aaf..f361b726e 100644
+--- a/glamor/glamor_program.c
++++ b/glamor/glamor_program.c
+@@ -283,6 +283,11 @@ glamor_build_program(ScreenPtr          screen,
+             gpu_shader4 = TRUE;
+         }
+     }
++    /* For now, fix shader version to GLES as 100. We will fall with 130 shaders
++     * in previous check due to forcibly set 120 glsl for GLES. But this patch
++     * makes xv shaders to work */
++    if(version && glamor_priv->is_gles)
++        version = 100;
+ 
+     vs_vars = vs_location_vars(locations);
+     fs_vars = fs_location_vars(locations);
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1027-BACKPORT-GLX-Free-the-tag-of-the-old-context-later.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1027-BACKPORT-GLX-Free-the-tag-of-the-old-context-later.patch
@@ -1,0 +1,59 @@
+From 43e5354fcbbb0f9ee05e25f4a8cbaefbcdb4541a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Do=C4=9Fukan=20Korkmazt=C3=BCrk?= <dkorkmazturk@nvidia.com>
+Date: Tue, 22 Nov 2022 13:43:16 -0500
+Subject: [PATCH 027/105] GLX: Free the tag of the old context later
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In CommonMakeCurrent() function, the tag of the old context is freed
+before the new context is made current. This is problematic because if
+the CommonMakeNewCurrent() function fails, the tag of the old context
+ends up being removed, even though it is still active. This causes
+subsequent glXMakeCurrent() or glXMakeContextCurrent() requests to
+generate a GLXBadContextTag error.
+
+This change moves the function call that frees the old tag to a location
+where the result of CommonMakeNewCurrent() call is known and it is safe
+to free it.
+
+Signed-off-by: Doğukan Korkmaztürk <dkorkmazturk@nvidia.com>
+---
+ glx/vndcmds.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/glx/vndcmds.c b/glx/vndcmds.c
+index d6d8719e1..d1e088973 100644
+--- a/glx/vndcmds.c
++++ b/glx/vndcmds.c
+@@ -165,9 +165,6 @@ static int CommonLoseCurrent(ClientPtr client, GlxContextTagInfo *tagInfo)
+             tagInfo->tag, // No old context tag,
+             None, None, None, 0);
+ 
+-    if (ret == Success) {
+-        GlxFreeContextTag(tagInfo);
+-    }
+     return ret;
+ }
+ 
+@@ -259,7 +256,6 @@ static int CommonMakeCurrent(ClientPtr client,
+             if (ret != Success) {
+                 return ret;
+             }
+-            oldTag = NULL;
+         }
+ 
+         if (newVendor != NULL) {
+@@ -270,6 +266,9 @@ static int CommonMakeCurrent(ClientPtr client,
+         } else {
+             reply.contextTag = 0;
+         }
++
++        GlxFreeContextTag(oldTag);
++        oldTag = NULL;
+     }
+ 
+     reply.contextTag = GlxCheckSwap(client, reply.contextTag);
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1028-BACKPORT-randr-add-new-interface-to-allow-delaying-lease-resp.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1028-BACKPORT-randr-add-new-interface-to-allow-delaying-lease-resp.patch
@@ -1,0 +1,116 @@
+From f2047ffcdb265376caf41f8f5aee4be4fb0ddd5e Mon Sep 17 00:00:00 2001
+From: Xaver Hugl <xaver.hugl@gmail.com>
+Date: Thu, 2 Dec 2021 13:22:53 +0100
+Subject: [PATCH 028/105] randr: add new interface to allow delaying lease
+ responses
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add a new interface to _rrScrPriv to make it possible for the server to
+delay answering a lease request, at the cost of blocking the client. This
+is needed for implementing drm-lease-v1, as the Wayland protocol has no
+defined time table for responding to lease requests.
+
+Signed-off-by: Xaver Hugl <xaver.hugl@gmail.com>
+Acked-by: Michel Dänzer <mdaenzer@redhat.com>
+---
+ hw/xfree86/common/xf86Module.h |  2 +-
+ randr/randrstr.h               | 12 ++++++++++++
+ randr/rrlease.c                | 27 +++++++++++++++++++++++----
+ 3 files changed, 36 insertions(+), 5 deletions(-)
+
+diff --git a/hw/xfree86/common/xf86Module.h b/hw/xfree86/common/xf86Module.h
+index 1eb09bca3..33cf0e56a 100644
+--- a/hw/xfree86/common/xf86Module.h
++++ b/hw/xfree86/common/xf86Module.h
+@@ -74,7 +74,7 @@
+  * mask is 0xFFFF0000.
+  */
+ #define ABI_ANSIC_VERSION	SET_ABI_VERSION(0, 4)
+-#define ABI_VIDEODRV_VERSION	SET_ABI_VERSION(25, 2)
++#define ABI_VIDEODRV_VERSION	SET_ABI_VERSION(25, 3)
+ #define ABI_XINPUT_VERSION	SET_ABI_VERSION(24, 4)
+ #define ABI_EXTENSION_VERSION	SET_ABI_VERSION(10, 0)
+ 
+diff --git a/randr/randrstr.h b/randr/randrstr.h
+index b23390575..173ecdf4e 100644
+--- a/randr/randrstr.h
++++ b/randr/randrstr.h
+@@ -280,6 +280,15 @@ typedef int (*RRCreateLeaseProcPtr)(ScreenPtr screen,
+ typedef void (*RRTerminateLeaseProcPtr)(ScreenPtr screen,
+                                         RRLeasePtr lease);
+ 
++typedef int (*RRRequestLeaseProcPtr)(ClientPtr client,
++                                     ScreenPtr screen,
++                                     RRLeasePtr lease);
++
++typedef void (*RRGetLeaseProcPtr)(ClientPtr client,
++                                 ScreenPtr screen,
++                                 RRLeasePtr *lease,
++                                 int *fd);
++
+ /* These are for 1.0 compatibility */
+ 
+ typedef struct _rrRefresh {
+@@ -408,6 +417,9 @@ typedef struct _rrScrPriv {
+     RRMonitorPtr *monitors;
+ 
+     struct xorg_list leases;
++
++    RRRequestLeaseProcPtr rrRequestLease;
++    RRGetLeaseProcPtr rrGetLease;
+ } rrScrPrivRec, *rrScrPrivPtr;
+ 
+ extern _X_EXPORT DevPrivateKeyRec rrPrivKeyRec;
+diff --git a/randr/rrlease.c b/randr/rrlease.c
+index 11ba96f24..cb366e767 100644
+--- a/randr/rrlease.c
++++ b/randr/rrlease.c
+@@ -239,9 +239,19 @@ ProcRRCreateLease(ClientPtr client)
+     if (!scr_priv)
+         return BadMatch;
+ 
+-    if (!scr_priv->rrCreateLease)
++    if (!scr_priv->rrCreateLease && !scr_priv->rrRequestLease)
+         return BadMatch;
+ 
++    if (scr_priv->rrGetLease) {
++        scr_priv->rrGetLease(client, screen, &lease, &fd);
++        if (lease) {
++            if (fd >= 0)
++                goto leaseReturned;
++            else
++                goto bail_lease;
++        }
++    }
++
+     /* Allocate a structure to hold all of the lease information */
+ 
+     lease = RRLeaseAlloc(screen, stuff->lid, stuff->nCrtcs, stuff->nOutputs);
+@@ -291,10 +301,19 @@ ProcRRCreateLease(ClientPtr client)
+         lease->outputs[o] = output;
+     }
+ 
+-    rc = scr_priv->rrCreateLease(screen, lease, &fd);
+-    if (rc != Success)
+-        goto bail_lease;
++    if (scr_priv->rrRequestLease) {
++        rc = scr_priv->rrRequestLease(client, screen, lease);
++        if (rc == Success)
++            return Success;
++        else
++            goto bail_lease;
++    } else {
++        rc = scr_priv->rrCreateLease(screen, lease, &fd);
++        if (rc != Success)
++            goto bail_lease;
++    }
+ 
++leaseReturned:
+     xorg_list_add(&lease->list, &scr_priv->leases);
+ 
+     if (!AddResource(stuff->lid, RRLeaseType, lease)) {
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1029-BACKPORT-pixmap-make-PixmapDirtyCopyArea-public.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1029-BACKPORT-pixmap-make-PixmapDirtyCopyArea-public.patch
@@ -1,0 +1,76 @@
+From 9df9c8c96a379c964fbb7d41cb01e1140e85af76 Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sat, 3 Dec 2022 18:35:23 -0800
+Subject: [PATCH 029/105] pixmap: make PixmapDirtyCopyArea public
+
+PixmapDirtyCopyArea() is about to be used outside of pixmap.c, so fix up
+its interface by specifying the dirty area directly rather than passing a
+`PixmapDirtyUpdatePtr`. This makes it easier to use outside of pixmap.c, as
+the caller doesn't need to create a bulky PixmapDirtyUpdateRec to use this
+function.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+---
+ dix/pixmap.c     | 15 +++++++--------
+ include/pixmap.h |  5 +++++
+ 2 files changed, 12 insertions(+), 8 deletions(-)
+
+diff --git a/dix/pixmap.c b/dix/pixmap.c
+index 5a0146bbb..0b01c4ee0 100644
+--- a/dix/pixmap.c
++++ b/dix/pixmap.c
+@@ -262,12 +262,11 @@ PixmapStopDirtyTracking(DrawablePtr src, PixmapPtr secondary_dst)
+     return TRUE;
+ }
+ 
+-static void
+-PixmapDirtyCopyArea(PixmapPtr dst,
+-                    PixmapDirtyUpdatePtr dirty,
++void
++PixmapDirtyCopyArea(PixmapPtr dst, DrawablePtr src,
++                    int x, int y, int dst_x, int dst_y,
+                     RegionPtr dirty_region)
+ {
+-    DrawablePtr src = dirty->src;
+     ScreenPtr pScreen = src->pScreen;
+     int n;
+     BoxPtr b;
+@@ -294,9 +293,8 @@ PixmapDirtyCopyArea(PixmapPtr dst,
+         h = dst_box.y2 - dst_box.y1;
+ 
+         pGC->ops->CopyArea(src, &dst->drawable, pGC,
+-                           dirty->x + dst_box.x1, dirty->y + dst_box.y1, w, h,
+-                           dirty->dst_x + dst_box.x1,
+-                           dirty->dst_y + dst_box.y1);
++                           x + dst_box.x1, y + dst_box.y1, w, h,
++                           dst_x + dst_box.x1, dst_y + dst_box.y1);
+         b++;
+     }
+     FreeScratchGC(pGC);
+@@ -408,7 +406,8 @@ Bool PixmapSyncDirtyHelper(PixmapDirtyUpdatePtr dirty)
+     RegionTranslate(&pixregion, -dirty->x, -dirty->y);
+ 
+     if (!pScreen->root || dirty->rotation == RR_Rotate_0)
+-        PixmapDirtyCopyArea(dst, dirty, &pixregion);
++        PixmapDirtyCopyArea(dst, dirty->src, dirty->x, dirty->y,
++                            dirty->dst_x, dirty->dst_y, &pixregion);
+     else
+         PixmapDirtyCompositeRotate(dst, dirty, &pixregion);
+     pScreen->SourceValidate = SourceValidate;
+diff --git a/include/pixmap.h b/include/pixmap.h
+index 7144bfb30..e251690d5 100644
+--- a/include/pixmap.h
++++ b/include/pixmap.h
+@@ -134,4 +134,9 @@ PixmapStopDirtyTracking(DrawablePtr src, PixmapPtr slave_dst);
+ extern _X_EXPORT Bool
+ PixmapSyncDirtyHelper(PixmapDirtyUpdatePtr dirty);
+ 
++extern _X_EXPORT void
++PixmapDirtyCopyArea(PixmapPtr dst, DrawablePtr src,
++                    int x, int y, int dst_x, int dst_y,
++                    RegionPtr dirty_region);
++
+ #endif                          /* PIXMAP_H */
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1030-BACKPORT-xfree86-make-xf86RotateCrtcRedisplay-public.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1030-BACKPORT-xfree86-make-xf86RotateCrtcRedisplay-public.patch
@@ -1,0 +1,113 @@
+From d9f46a8612ec967a1dbd13e8759a7341ab9b6502 Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Mon, 5 Dec 2022 23:20:31 -0800
+Subject: [PATCH 030/105] xfree86: make xf86RotateCrtcRedisplay public
+
+xf86RotateCrtcRedisplay() is about to be used outside of xf86Rotate.c in
+order to copy transformed pixmaps, so fix up its interface by specifying
+the source drawable and destination pixmap rather than assuming the root
+drawable and rotated pixmap, respectively. In addition, add an argument to
+make xf86RotateCrtcRedisplay() not perform any transformations, which is an
+indicator that it should only copy a transformed pixmap rather than
+actually transform a pixmap.
+
+These changes make it possible to use xf86RotateCrtcRedisplay() to not
+only copy transformed pixmaps, but also actually transform pixmaps, making
+it very useful outside of xf86Rotate.c.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+---
+ hw/xfree86/common/xf86Module.h |  2 +-
+ hw/xfree86/modes/xf86Crtc.h    |  5 +++++
+ hw/xfree86/modes/xf86Rotate.c  | 22 +++++++++++++---------
+ 3 files changed, 19 insertions(+), 10 deletions(-)
+
+diff --git a/hw/xfree86/common/xf86Module.h b/hw/xfree86/common/xf86Module.h
+index 33cf0e56a..c59e53a55 100644
+--- a/hw/xfree86/common/xf86Module.h
++++ b/hw/xfree86/common/xf86Module.h
+@@ -74,7 +74,7 @@
+  * mask is 0xFFFF0000.
+  */
+ #define ABI_ANSIC_VERSION	SET_ABI_VERSION(0, 4)
+-#define ABI_VIDEODRV_VERSION	SET_ABI_VERSION(25, 3)
++#define ABI_VIDEODRV_VERSION	SET_ABI_VERSION(25, 4)
+ #define ABI_XINPUT_VERSION	SET_ABI_VERSION(24, 4)
+ #define ABI_EXTENSION_VERSION	SET_ABI_VERSION(10, 0)
+ 
+diff --git a/hw/xfree86/modes/xf86Crtc.h b/hw/xfree86/modes/xf86Crtc.h
+index 7a562874c..b4c3215e3 100644
+--- a/hw/xfree86/modes/xf86Crtc.h
++++ b/hw/xfree86/modes/xf86Crtc.h
+@@ -912,6 +912,11 @@ extern _X_EXPORT void
+ extern _X_EXPORT Bool
+  xf86CrtcRotate(xf86CrtcPtr crtc);
+ 
++extern _X_EXPORT void
++ xf86RotateCrtcRedisplay(xf86CrtcPtr crtc, PixmapPtr dst_pixmap,
++                         DrawableRec *src_drawable, RegionPtr region,
++                         Bool transform_src);
++
+ /*
+  * Clean up any rotation data, used when a crtc is turned off
+  * as well as when rotation is disabled.
+diff --git a/hw/xfree86/modes/xf86Rotate.c b/hw/xfree86/modes/xf86Rotate.c
+index ea9c43c0f..944a01b1c 100644
+--- a/hw/xfree86/modes/xf86Rotate.c
++++ b/hw/xfree86/modes/xf86Rotate.c
+@@ -39,13 +39,13 @@
+ #include "X11/extensions/dpmsconst.h"
+ #include "X11/Xatom.h"
+ 
+-static void
+-xf86RotateCrtcRedisplay(xf86CrtcPtr crtc, RegionPtr region)
++void
++xf86RotateCrtcRedisplay(xf86CrtcPtr crtc, PixmapPtr dst_pixmap,
++                        DrawableRec *src_drawable, RegionPtr region,
++                        Bool transform_src)
+ {
+     ScrnInfoPtr scrn = crtc->scrn;
+     ScreenPtr screen = scrn->pScreen;
+-    WindowPtr root = screen->root;
+-    PixmapPtr dst_pixmap = crtc->rotatedPixmap;
+     PictFormatPtr format = PictureWindowFormat(screen->root);
+     int error;
+     PicturePtr src, dst;
+@@ -57,7 +57,7 @@ xf86RotateCrtcRedisplay(xf86CrtcPtr crtc, RegionPtr region)
+         return;
+ 
+     src = CreatePicture(None,
+-                        &root->drawable,
++                        src_drawable,
+                         format,
+                         CPSubwindowMode,
+                         &include_inferiors, serverClient, &error);
+@@ -70,9 +70,11 @@ xf86RotateCrtcRedisplay(xf86CrtcPtr crtc, RegionPtr region)
+     if (!dst)
+         return;
+ 
+-    error = SetPictureTransform(src, &crtc->crtc_to_framebuffer);
+-    if (error)
+-        return;
++    if (transform_src) {
++        error = SetPictureTransform(src, &crtc->crtc_to_framebuffer);
++        if (error)
++            return;
++    }
+     if (crtc->transform_in_use && crtc->filter)
+         SetPicturePictFilter(src, crtc->filter, crtc->params, crtc->nparams);
+ 
+@@ -205,7 +207,9 @@ xf86RotateRedisplay(ScreenPtr pScreen)
+ 
+                 /* update damaged region */
+                 if (RegionNotEmpty(&crtc_damage))
+-                    xf86RotateCrtcRedisplay(crtc, &crtc_damage);
++                    xf86RotateCrtcRedisplay(crtc, crtc->rotatedPixmap,
++                                            &pScreen->root->drawable,
++                                            &crtc_damage, TRUE);
+ 
+                 RegionUninit(&crtc_damage);
+             }
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1031-BACKPORT-modesetting-make-the-shadow-buffer-helpers-generic.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1031-BACKPORT-modesetting-make-the-shadow-buffer-helpers-generic.patch
@@ -1,0 +1,190 @@
+From e459180a234456bb24de05ada2e6845e716992dd Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sat, 3 Dec 2022 18:51:36 -0800
+Subject: [PATCH 031/105] modesetting: make the shadow buffer helpers generic
+
+Shadow buffers are about to be used for TearFree, so make the shadow buffer
+helpers generic such that they can be used to create arbitrary per-CRTC
+shadows aside from just the per-CRTC rotated buffer.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+---
+ .../drivers/modesetting/drmmode_display.c     | 98 ++++++++++++-------
+ 1 file changed, 64 insertions(+), 34 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
+index 21c9222e1..0ddb41c00 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
+@@ -1931,33 +1931,42 @@ drmmode_clear_pixmap(PixmapPtr pixmap)
+ }
+ 
+ static void *
+-drmmode_shadow_allocate(xf86CrtcPtr crtc, int width, int height)
++drmmode_shadow_fb_allocate(xf86CrtcPtr crtc, int width, int height,
++                           drmmode_bo *bo, uint32_t *fb_id)
+ {
+     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+     drmmode_ptr drmmode = drmmode_crtc->drmmode;
+     int ret;
+ 
+-    if (!drmmode_create_bo(drmmode, &drmmode_crtc->rotate_bo,
+-                           width, height, drmmode->kbpp)) {
++    if (!drmmode_create_bo(drmmode, bo, width, height, drmmode->kbpp)) {
+         xf86DrvMsg(crtc->scrn->scrnIndex, X_ERROR,
+                "Couldn't allocate shadow memory for rotated CRTC\n");
+         return NULL;
+     }
+ 
+-    ret = drmmode_bo_import(drmmode, &drmmode_crtc->rotate_bo,
+-                            &drmmode_crtc->rotate_fb_id);
++    ret = drmmode_bo_import(drmmode, bo, fb_id);
+ 
+     if (ret) {
+         ErrorF("failed to add rotate fb\n");
+-        drmmode_bo_destroy(drmmode, &drmmode_crtc->rotate_bo);
++        drmmode_bo_destroy(drmmode, bo);
+         return NULL;
+     }
+ 
+ #ifdef GLAMOR_HAS_GBM
+     if (drmmode->gbm)
+-        return drmmode_crtc->rotate_bo.gbm;
++        return bo->gbm;
+ #endif
+-    return drmmode_crtc->rotate_bo.dumb;
++    return bo->dumb;
++}
++
++static void *
++drmmode_shadow_allocate(xf86CrtcPtr crtc, int width, int height)
++{
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++
++    return drmmode_shadow_fb_allocate(crtc, width, height,
++                                      &drmmode_crtc->rotate_bo,
++                                      &drmmode_crtc->rotate_fb_id);
+ }
+ 
+ static PixmapPtr
+@@ -1983,70 +1992,91 @@ static Bool
+ drmmode_set_pixmap_bo(drmmode_ptr drmmode, PixmapPtr pixmap, drmmode_bo *bo);
+ 
+ static PixmapPtr
+-drmmode_shadow_create(xf86CrtcPtr crtc, void *data, int width, int height)
++drmmode_shadow_fb_create(xf86CrtcPtr crtc, void *data, int width, int height,
++                         drmmode_bo *bo, uint32_t *fb_id)
+ {
+     ScrnInfoPtr scrn = crtc->scrn;
+     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+     drmmode_ptr drmmode = drmmode_crtc->drmmode;
+-    uint32_t rotate_pitch;
+-    PixmapPtr rotate_pixmap;
++    uint32_t pitch;
++    PixmapPtr pixmap;
+     void *pPixData = NULL;
+ 
+     if (!data) {
+-        data = drmmode_shadow_allocate(crtc, width, height);
++        data = drmmode_shadow_fb_allocate(crtc, width, height, bo, fb_id);
+         if (!data) {
+             xf86DrvMsg(scrn->scrnIndex, X_ERROR,
+-                       "Couldn't allocate shadow pixmap for rotated CRTC\n");
++                       "Couldn't allocate shadow pixmap for CRTC\n");
+             return NULL;
+         }
+     }
+ 
+-    if (!drmmode_bo_has_bo(&drmmode_crtc->rotate_bo)) {
++    if (!drmmode_bo_has_bo(bo)) {
+         xf86DrvMsg(scrn->scrnIndex, X_ERROR,
+-                   "Couldn't allocate shadow pixmap for rotated CRTC\n");
++                   "Couldn't allocate shadow pixmap for CRTC\n");
+         return NULL;
+     }
+ 
+-    pPixData = drmmode_bo_map(drmmode, &drmmode_crtc->rotate_bo);
+-    rotate_pitch = drmmode_bo_get_pitch(&drmmode_crtc->rotate_bo);
++    pPixData = drmmode_bo_map(drmmode, bo);
++    pitch = drmmode_bo_get_pitch(bo);
+ 
+-    rotate_pixmap = drmmode_create_pixmap_header(scrn->pScreen,
+-                                                 width, height,
+-                                                 scrn->depth,
+-                                                 drmmode->kbpp,
+-                                                 rotate_pitch,
+-                                                 pPixData);
++    pixmap = drmmode_create_pixmap_header(scrn->pScreen,
++                                          width, height,
++                                          scrn->depth,
++                                          drmmode->kbpp,
++                                          pitch,
++                                          pPixData);
+ 
+-    if (rotate_pixmap == NULL) {
++    if (pixmap == NULL) {
+         xf86DrvMsg(scrn->scrnIndex, X_ERROR,
+-                   "Couldn't allocate shadow pixmap for rotated CRTC\n");
++                   "Couldn't allocate shadow pixmap for CRTC\n");
+         return NULL;
+     }
+ 
+-    drmmode_set_pixmap_bo(drmmode, rotate_pixmap, &drmmode_crtc->rotate_bo);
++    drmmode_set_pixmap_bo(drmmode, pixmap, bo);
+ 
+-    return rotate_pixmap;
++    return pixmap;
++}
++
++static PixmapPtr
++drmmode_shadow_create(xf86CrtcPtr crtc, void *data, int width, int height)
++{
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++
++    return drmmode_shadow_fb_create(crtc, data, width, height,
++                                    &drmmode_crtc->rotate_bo,
++                                    &drmmode_crtc->rotate_fb_id);
+ }
+ 
+ static void
+-drmmode_shadow_destroy(xf86CrtcPtr crtc, PixmapPtr rotate_pixmap, void *data)
++drmmode_shadow_fb_destroy(xf86CrtcPtr crtc, PixmapPtr pixmap,
++                          void *data, drmmode_bo *bo, uint32_t *fb_id)
+ {
+     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+     drmmode_ptr drmmode = drmmode_crtc->drmmode;
+ 
+-    if (rotate_pixmap) {
+-        rotate_pixmap->drawable.pScreen->DestroyPixmap(rotate_pixmap);
++    if (pixmap) {
++        pixmap->drawable.pScreen->DestroyPixmap(pixmap);
+     }
+ 
+     if (data) {
+-        drmModeRmFB(drmmode->fd, drmmode_crtc->rotate_fb_id);
+-        drmmode_crtc->rotate_fb_id = 0;
++        drmModeRmFB(drmmode->fd, *fb_id);
++        *fb_id = 0;
+ 
+-        drmmode_bo_destroy(drmmode, &drmmode_crtc->rotate_bo);
+-        memset(&drmmode_crtc->rotate_bo, 0, sizeof drmmode_crtc->rotate_bo);
++        drmmode_bo_destroy(drmmode, bo);
++        memset(bo, 0, sizeof(*bo));
+     }
+ }
+ 
++static void
++drmmode_shadow_destroy(xf86CrtcPtr crtc, PixmapPtr pixmap, void *data)
++{
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++
++    drmmode_shadow_fb_destroy(crtc, pixmap, data, &drmmode_crtc->rotate_bo,
++                              &drmmode_crtc->rotate_fb_id);
++}
++
+ static void
+ drmmode_crtc_destroy(xf86CrtcPtr crtc)
+ {
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1032-BACKPORT-modesetting-make-do_queue_flip_on_crtc-generic.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1032-BACKPORT-modesetting-make-do_queue_flip_on_crtc-generic.patch
@@ -1,0 +1,115 @@
+From c334786ad79c5bfb4bc24d05976167e0e7959e5d Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sun, 11 Dec 2022 23:51:34 -0800
+Subject: [PATCH 032/105] modesetting: make do_queue_flip_on_crtc generic
+
+do_queue_flip_on_crtc() is about to be used to flip buffers other than the
+primary scanout (`ms->drmmode.fb_id`), so make it generic to accept any
+frame buffer ID, as well as x and y coordinates in the frame buffer, to
+flip on a given CRTC. Move the retry logic from queue_flip_on_crtc() into
+it as well, so that it's robust for all callers.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+---
+ .../drivers/modesetting/drmmode_display.c     |  5 ++-
+ .../drivers/modesetting/drmmode_display.h     |  3 +-
+ hw/xfree86/drivers/modesetting/pageflip.c     | 38 ++++++++++---------
+ 3 files changed, 25 insertions(+), 21 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
+index 0ddb41c00..37035ce00 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
+@@ -930,7 +930,8 @@ drmmode_crtc_set_mode(xf86CrtcPtr crtc, Bool test_only)
+ }
+ 
+ int
+-drmmode_crtc_flip(xf86CrtcPtr crtc, uint32_t fb_id, uint32_t flags, void *data)
++drmmode_crtc_flip(xf86CrtcPtr crtc, uint32_t fb_id, int x, int y,
++                  uint32_t flags, void *data)
+ {
+     modesettingPtr ms = modesettingPTR(crtc->scrn);
+     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+@@ -942,7 +943,7 @@ drmmode_crtc_flip(xf86CrtcPtr crtc, uint32_t fb_id, uint32_t flags, void *data)
+         if (!req)
+             return 1;
+ 
+-        ret = plane_add_props(req, crtc, fb_id, crtc->x, crtc->y);
++        ret = plane_add_props(req, crtc, fb_id, x, y);
+         flags |= DRM_MODE_ATOMIC_NONBLOCK;
+         if (ret == 0)
+             ret = drmModeAtomicCommit(ms->fd, req, flags, data);
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.h b/hw/xfree86/drivers/modesetting/drmmode_display.h
+index 2a9a91529..3a267a67d 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.h
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.h
+@@ -309,7 +309,8 @@ void drmmode_get_default_bpp(ScrnInfoPtr pScrn, drmmode_ptr drmmmode,
+ 
+ void drmmode_copy_fb(ScrnInfoPtr pScrn, drmmode_ptr drmmode);
+ 
+-int drmmode_crtc_flip(xf86CrtcPtr crtc, uint32_t fb_id, uint32_t flags, void *data);
++int drmmode_crtc_flip(xf86CrtcPtr crtc, uint32_t fb_id, int x, int y,
++                      uint32_t flags, void *data);
+ 
+ Bool drmmode_crtc_get_fb_id(xf86CrtcPtr crtc, uint32_t *fb_id, int *x, int *y);
+ 
+diff --git a/hw/xfree86/drivers/modesetting/pageflip.c b/hw/xfree86/drivers/modesetting/pageflip.c
+index 23ee95f9a..a51a10a2c 100644
+--- a/hw/xfree86/drivers/modesetting/pageflip.c
++++ b/hw/xfree86/drivers/modesetting/pageflip.c
+@@ -160,11 +160,24 @@ ms_pageflip_abort(void *data)
+ }
+ 
+ static Bool
+-do_queue_flip_on_crtc(modesettingPtr ms, xf86CrtcPtr crtc,
+-                      uint32_t flags, uint32_t seq)
++do_queue_flip_on_crtc(ScreenPtr screen, xf86CrtcPtr crtc, uint32_t flags,
++                      uint32_t seq, uint32_t fb_id, int x, int y)
+ {
+-    return drmmode_crtc_flip(crtc, ms->drmmode.fb_id, flags,
+-                             (void *) (uintptr_t) seq);
++    while (drmmode_crtc_flip(crtc, fb_id, x, y, flags, (void *)(long)seq)) {
++        /* We may have failed because the event queue was full.  Flush it
++         * and retry.  If there was nothing to flush, then we failed for
++         * some other reason and should just return an error.
++         */
++        if (ms_flush_drm_events(screen) <= 0) {
++            ms_drm_abort_seq(crtc->scrn, seq);
++            return TRUE;
++        }
++
++        /* We flushed some events, so try again. */
++        xf86DrvMsg(crtc->scrn->scrnIndex, X_WARNING, "flip queue retry\n");
++    }
++
++    return FALSE;
+ }
+ 
+ enum queue_flip_status {
+@@ -205,20 +218,9 @@ queue_flip_on_crtc(ScreenPtr screen, xf86CrtcPtr crtc,
+     /* take a reference on flipdata for use in flip */
+     flipdata->flip_count++;
+ 
+-    while (do_queue_flip_on_crtc(ms, crtc, flags, seq)) {
+-        /* We may have failed because the event queue was full.  Flush it
+-         * and retry.  If there was nothing to flush, then we failed for
+-         * some other reason and should just return an error.
+-         */
+-        if (ms_flush_drm_events(screen) <= 0) {
+-            /* Aborting will also decrement flip_count and free(flip). */
+-            ms_drm_abort_seq(scrn, seq);
+-            return QUEUE_FLIP_DRM_FLUSH_FAILED;
+-        }
+-
+-        /* We flushed some events, so try again. */
+-        xf86DrvMsg(scrn->scrnIndex, X_WARNING, "flip queue retry\n");
+-    }
++    if (do_queue_flip_on_crtc(screen, crtc, flags, seq, ms->drmmode.fb_id,
++                              crtc->x, crtc->y))
++        return QUEUE_FLIP_DRM_FLUSH_FAILED;
+ 
+     /* The page flip succeeded. */
+     return QUEUE_FLIP_SUCCESS;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1033-BACKPORT-present-add-awareness-for-drivers-with-TearFree.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1033-BACKPORT-present-add-awareness-for-drivers-with-TearFree.patch
@@ -1,0 +1,197 @@
+From 736bf4a024b2099eedff3fb555d3842156d04f1c Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sat, 10 Dec 2022 16:09:26 -0800
+Subject: [PATCH 033/105] present: add awareness for drivers with TearFree
+
+When a driver uses TearFree to flip all frames synchronized to the vblank
+interval, Present has no idea and still assumes that each presentation
+occurs immediately upon copying its damages to the primary scanout. This
+faulty assumption breaks presentation timestamping, potentially leading to
+A/V de-synchronization and dropped frames.
+
+Present needs to have some awareness of a driver using TearFree so that it
+can know when each presentation actually becomes visible on the screen.
+
+Teach Present about drivers using TearFree by expanding PresentFlipReason
+to allow drivers to export some contextual info about TearFree when Present
+cannot page-flip directly anyway.
+
+PRESENT_FLIP_REASON_DRIVER_TEARFREE indicates that a driver has TearFree
+enabled but doesn't have a TearFree flip currently pending.
+
+PRESENT_FLIP_REASON_DRIVER_TEARFREE_FLIPPING indicates that a driver has a
+TearFree flip currently pending.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+---
+ present/present.h      |  4 ++-
+ present/present_scmd.c | 82 ++++++++++++++++++++++++++++++++++--------
+ 2 files changed, 71 insertions(+), 15 deletions(-)
+
+diff --git a/present/present.h b/present/present.h
+index d41b36033..1d7b0ce42 100644
+--- a/present/present.h
++++ b/present/present.h
+@@ -29,7 +29,9 @@
+ 
+ typedef enum {
+     PRESENT_FLIP_REASON_UNKNOWN,
+-    PRESENT_FLIP_REASON_BUFFER_FORMAT
++    PRESENT_FLIP_REASON_BUFFER_FORMAT,
++    PRESENT_FLIP_REASON_DRIVER_TEARFREE,
++    PRESENT_FLIP_REASON_DRIVER_TEARFREE_FLIPPING
+ } PresentFlipReason;
+ 
+ typedef struct present_vblank present_vblank_rec, *present_vblank_ptr;
+diff --git a/present/present_scmd.c b/present/present_scmd.c
+index 239055bc1..46fd9a1fd 100644
+--- a/present/present_scmd.c
++++ b/present/present_scmd.c
+@@ -71,6 +71,7 @@ present_check_flip(RRCrtcPtr            crtc,
+     PixmapPtr                   window_pixmap;
+     WindowPtr                   root = screen->root;
+     present_screen_priv_ptr     screen_priv = present_screen_priv(screen);
++    PresentFlipReason           tmp_reason = PRESENT_FLIP_REASON_UNKNOWN;
+ 
+     if (crtc) {
+        screen_priv = present_screen_priv(crtc->pScreen);
+@@ -91,6 +92,27 @@ present_check_flip(RRCrtcPtr            crtc,
+     if (!screen_priv->info->flip)
+         return FALSE;
+ 
++    /* Ask the driver for permission. Do this now to see if there's TearFree. */
++    if (screen_priv->info->version >= 1 && screen_priv->info->check_flip2) {
++        if (!(*screen_priv->info->check_flip2) (crtc, window, pixmap, sync_flip, &tmp_reason)) {
++            DebugPresent(("\td %08" PRIx32 " -> %08" PRIx32 "\n", window->drawable.id, pixmap ? pixmap->drawable.id : 0));
++            /* It's fine to return now unless the page flip failure reason is
++             * PRESENT_FLIP_REASON_BUFFER_FORMAT; we must only output that
++             * reason if all the other checks pass.
++             */
++            if (!reason || tmp_reason != PRESENT_FLIP_REASON_BUFFER_FORMAT) {
++                if (reason)
++                    *reason = tmp_reason;
++                return FALSE;
++            }
++        }
++    } else if (screen_priv->info->check_flip) {
++        if (!(*screen_priv->info->check_flip) (crtc, window, pixmap, sync_flip)) {
++            DebugPresent(("\td %08" PRIx32 " -> %08" PRIx32 "\n", window->drawable.id, pixmap ? pixmap->drawable.id : 0));
++            return FALSE;
++        }
++    }
++
+     /* Make sure the window hasn't been redirected with Composite */
+     window_pixmap = screen->GetWindowPixmap(window);
+     if (window_pixmap != screen->GetScreenPixmap(screen) &&
+@@ -123,17 +145,10 @@ present_check_flip(RRCrtcPtr            crtc,
+         return FALSE;
+     }
+ 
+-    /* Ask the driver for permission */
+-    if (screen_priv->info->version >= 1 && screen_priv->info->check_flip2) {
+-        if (!(*screen_priv->info->check_flip2) (crtc, window, pixmap, sync_flip, reason)) {
+-            DebugPresent(("\td %08" PRIx32 " -> %08" PRIx32 "\n", window->drawable.id, pixmap ? pixmap->drawable.id : 0));
+-            return FALSE;
+-        }
+-    } else if (screen_priv->info->check_flip) {
+-        if (!(*screen_priv->info->check_flip) (crtc, window, pixmap, sync_flip)) {
+-            DebugPresent(("\td %08" PRIx32 " -> %08" PRIx32 "\n", window->drawable.id, pixmap ? pixmap->drawable.id : 0));
+-            return FALSE;
+-        }
++    if (tmp_reason == PRESENT_FLIP_REASON_BUFFER_FORMAT) {
++        if (reason)
++            *reason = tmp_reason;
++        return FALSE;
+     }
+ 
+     return TRUE;
+@@ -456,7 +471,9 @@ present_check_flip_window (WindowPtr window)
+     xorg_list_for_each_entry(vblank, &window_priv->vblank, window_list) {
+         if (vblank->queued && vblank->flip && !present_check_flip(vblank->crtc, window, vblank->pixmap, vblank->sync_flip, NULL, 0, 0, &reason)) {
+             vblank->flip = FALSE;
+-            vblank->reason = reason;
++            /* Don't spuriously flag this as a TearFree presentation */
++            if (reason < PRESENT_FLIP_REASON_DRIVER_TEARFREE)
++                vblank->reason = reason;
+             if (vblank->sync_flip)
+                 vblank->exec_msc = vblank->target_msc;
+         }
+@@ -537,6 +554,7 @@ present_execute(present_vblank_ptr vblank, uint64_t ust, uint64_t crtc_msc)
+     WindowPtr                   window = vblank->window;
+     ScreenPtr                   screen = window->drawable.pScreen;
+     present_screen_priv_ptr     screen_priv = present_screen_priv(screen);
++    uint64_t                    completion_msc;
+     if (vblank && vblank->crtc) {
+         screen_priv=present_screen_priv(vblank->crtc->pScreen);
+     }
+@@ -560,7 +578,9 @@ present_execute(present_vblank_ptr vblank, uint64_t ust, uint64_t crtc_msc)
+     xorg_list_del(&vblank->window_list);
+     vblank->queued = FALSE;
+ 
+-    if (vblank->pixmap && vblank->window) {
++    if (vblank->pixmap && vblank->window &&
++        (vblank->reason < PRESENT_FLIP_REASON_DRIVER_TEARFREE ||
++         vblank->exec_msc != vblank->target_msc)) {
+ 
+         if (vblank->flip) {
+ 
+@@ -627,6 +647,30 @@ present_execute(present_vblank_ptr vblank, uint64_t ust, uint64_t crtc_msc)
+ 
+         present_execute_copy(vblank, crtc_msc);
+ 
++        /* The presentation will be visible at the next vblank with TearFree, so
++         * the PresentComplete notification needs to be sent at the next vblank.
++         * If TearFree is already flipping then the presentation will be visible
++         * at the *next* next vblank.
++         */
++        completion_msc = crtc_msc + 1;
++        switch (vblank->reason) {
++        case PRESENT_FLIP_REASON_DRIVER_TEARFREE_FLIPPING:
++            if (vblank->exec_msc < crtc_msc)
++                completion_msc++;
++        case PRESENT_FLIP_REASON_DRIVER_TEARFREE:
++            if (Success == screen_priv->queue_vblank(screen,
++                                                     window,
++                                                     vblank->crtc,
++                                                     vblank->event_id,
++                                                     completion_msc)) {
++                /* Ensure present_execute_post() runs at the next MSC */
++                vblank->exec_msc = vblank->target_msc;
++                vblank->queued = TRUE;
++            }
++        default:
++            break;
++        }
++
+         if (vblank->queued) {
+             xorg_list_add(&vblank->event_queue, &present_exec_queue);
+             xorg_list_append(&vblank->window_list,
+@@ -739,6 +783,11 @@ present_scmd_pixmap(WindowPtr window,
+             if (vblank->crtc != target_crtc || vblank->target_msc != target_msc)
+                 continue;
+ 
++            /* Too late to abort now if TearFree execution already happened */
++            if (vblank->reason >= PRESENT_FLIP_REASON_DRIVER_TEARFREE &&
++                vblank->exec_msc == vblank->target_msc)
++                continue;
++
+             present_vblank_scrap(vblank);
+             if (vblank->flip_ready)
+                 present_re_execute(vblank);
+@@ -767,7 +816,12 @@ present_scmd_pixmap(WindowPtr window,
+ 
+     vblank->event_id = ++present_scmd_event_id;
+ 
+-    if (vblank->flip && vblank->sync_flip)
++    /* The soonest presentation is crtc_msc+2 if TearFree is already flipping */
++    if (vblank->reason == PRESENT_FLIP_REASON_DRIVER_TEARFREE_FLIPPING &&
++        !msc_is_after(vblank->exec_msc, crtc_msc + 1))
++        vblank->exec_msc -= 2;
++    else if (vblank->reason >= PRESENT_FLIP_REASON_DRIVER_TEARFREE ||
++             (vblank->flip && vblank->sync_flip))
+         vblank->exec_msc--;
+ 
+     xorg_list_append(&vblank->event_queue, &present_exec_queue);
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1034-BACKPORT-modesetting-coalesce-vblank-events-to-avoid-DRM-even.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1034-BACKPORT-modesetting-coalesce-vblank-events-to-avoid-DRM-even.patch
@@ -1,0 +1,275 @@
+From cba8a6e95c1378408a0781e7145256044c98d73a Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Mon, 12 Dec 2022 23:51:17 -0800
+Subject: [PATCH 034/105] modesetting: coalesce vblank events to avoid DRM
+ event queue exhaustion
+
+The DRM event queue in the kernel is quite small and can be easily
+exhausted by DRI clients. When the event queue is full, that means nothing
+can be queued onto it anymore, which can lead to incorrect presentation
+times for DRI clients and failure when attempting to queue a page flip.
+
+To make matters worse, once an event is placed onto the kernel's event
+queue, there's no straightforward way to prematurely remove it from the
+kernel's event queue in userspace, which means that aborting a sequence
+number doesn't free up space in the event queue.
+
+Since vblank events from DRI clients are the largest consumers of the
+event queue, and since it's often easy to know the desired target MSC of
+their vblank events without querying the kernel for a CRTC's current MSC,
+we can coalesce vblank events occurring at the same MSC such that only one
+of them is placed onto the kernel's event queue, instead of allowing
+duplicate vblank events to pollute the event queue.
+
+This is achieved by tracking the next kernel-queued event's MSC on a
+per-CRTC basis and then running all of that CRTC's vblank event handlers
+which have reached their target MSC when the queued MSC is signaled.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+---
+ hw/xfree86/drivers/modesetting/driver.h       |   3 +
+ .../drivers/modesetting/drmmode_display.c     |   1 +
+ .../drivers/modesetting/drmmode_display.h     |   2 +
+ hw/xfree86/drivers/modesetting/vblank.c       | 123 ++++++++++++++++--
+ 4 files changed, 121 insertions(+), 8 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.h b/hw/xfree86/drivers/modesetting/driver.h
+index 71aa8730e..4f62646a0 100644
+--- a/hw/xfree86/drivers/modesetting/driver.h
++++ b/hw/xfree86/drivers/modesetting/driver.h
+@@ -86,10 +86,13 @@ struct ms_drm_queue {
+     struct xorg_list list;
+     xf86CrtcPtr crtc;
+     uint32_t seq;
++    uint64_t msc;
+     void *data;
+     ScrnInfoPtr scrn;
+     ms_drm_handler_proc handler;
+     ms_drm_abort_proc abort;
++    Bool kernel_queued;
++    Bool aborted;
+ };
+ 
+ typedef struct _modesettingRec {
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
+index 37035ce00..38c7b15f3 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
+@@ -2411,6 +2411,7 @@ drmmode_crtc_init(ScrnInfoPtr pScrn, drmmode_ptr drmmode, drmModeResPtr mode_res
+     drmmode_crtc->drmmode = drmmode;
+     drmmode_crtc->vblank_pipe = drmmode_crtc_vblank_pipe(num);
+     xorg_list_init(&drmmode_crtc->mode_list);
++    drmmode_crtc->next_msc = UINT64_MAX;
+ 
+     props = drmModeObjectGetProperties(drmmode->fd, mode_res->crtcs[num],
+                                        DRM_MODE_OBJECT_CRTC);
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.h b/hw/xfree86/drivers/modesetting/drmmode_display.h
+index 3a267a67d..d6ad15501 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.h
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.h
+@@ -200,6 +200,8 @@ typedef struct {
+     uint64_t msc_high;
+     /** @} */
+ 
++    uint64_t next_msc;
++
+     Bool need_modeset;
+     struct xorg_list mode_list;
+ 
+diff --git a/hw/xfree86/drivers/modesetting/vblank.c b/hw/xfree86/drivers/modesetting/vblank.c
+index ea9e7a88c..4d250aa34 100644
+--- a/hw/xfree86/drivers/modesetting/vblank.c
++++ b/hw/xfree86/drivers/modesetting/vblank.c
+@@ -260,6 +260,51 @@ ms_get_kernel_ust_msc(xf86CrtcPtr crtc,
+     }
+ }
+ 
++static void
++ms_drm_set_seq_msc(uint32_t seq, uint64_t msc)
++{
++    struct ms_drm_queue *q;
++
++    xorg_list_for_each_entry(q, &ms_drm_queue, list) {
++        if (q->seq == seq) {
++            q->msc = msc;
++            break;
++        }
++    }
++}
++
++static void
++ms_drm_set_seq_queued(uint32_t seq, uint64_t msc)
++{
++    drmmode_crtc_private_ptr drmmode_crtc;
++    struct ms_drm_queue *q;
++
++    xorg_list_for_each_entry(q, &ms_drm_queue, list) {
++        if (q->seq == seq) {
++            drmmode_crtc = q->crtc->driver_private;
++            if (msc < drmmode_crtc->next_msc)
++                drmmode_crtc->next_msc = msc;
++            q->msc = msc;
++            q->kernel_queued = TRUE;
++            break;
++        }
++    }
++}
++
++static Bool
++ms_queue_coalesce(xf86CrtcPtr crtc, uint32_t seq, uint64_t msc)
++{
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++
++    /* If the next MSC is too late, then this event can't be coalesced */
++    if (msc < drmmode_crtc->next_msc)
++        return FALSE;
++
++    /* Set the target MSC on this sequence number */
++    ms_drm_set_seq_msc(seq, msc);
++    return TRUE;
++}
++
+ Bool
+ ms_queue_vblank(xf86CrtcPtr crtc, ms_queue_flag flags,
+                 uint64_t msc, uint64_t *msc_queued, uint32_t seq)
+@@ -271,6 +316,10 @@ ms_queue_vblank(xf86CrtcPtr crtc, ms_queue_flag flags,
+     drmVBlank vbl;
+     int ret;
+ 
++    /* Try coalescing this event into another to avoid event queue exhaustion */
++    if (flags == MS_QUEUE_ABSOLUTE && ms_queue_coalesce(crtc, seq, msc))
++        return TRUE;
++
+     for (;;) {
+         /* Queue an event at the specified sequence */
+         if (ms->has_queue_sequence || !ms->tried_queue_sequence) {
+@@ -287,8 +336,10 @@ ms_queue_vblank(xf86CrtcPtr crtc, ms_queue_flag flags,
+             ret = drmCrtcQueueSequence(ms->fd, drmmode_crtc->mode_crtc->crtc_id,
+                                        drm_flags, msc, &kernel_queued, seq);
+             if (ret == 0) {
++                msc = ms_kernel_msc_to_crtc_msc(crtc, kernel_queued, TRUE);
++                ms_drm_set_seq_queued(seq, msc);
+                 if (msc_queued)
+-                    *msc_queued = ms_kernel_msc_to_crtc_msc(crtc, kernel_queued, TRUE);
++                    *msc_queued = msc;
+                 ms->has_queue_sequence = TRUE;
+                 return TRUE;
+             }
+@@ -310,8 +361,10 @@ ms_queue_vblank(xf86CrtcPtr crtc, ms_queue_flag flags,
+         vbl.request.signal = seq;
+         ret = drmWaitVBlank(ms->fd, &vbl);
+         if (ret == 0) {
++            msc = ms_kernel_msc_to_crtc_msc(crtc, vbl.reply.sequence, FALSE);
++            ms_drm_set_seq_queued(seq, msc);
+             if (msc_queued)
+-                *msc_queued = ms_kernel_msc_to_crtc_msc(crtc, vbl.reply.sequence, FALSE);
++                *msc_queued = msc;
+             return TRUE;
+         }
+     check:
+@@ -418,13 +471,15 @@ ms_drm_queue_alloc(xf86CrtcPtr crtc,
+     if (!ms_drm_seq)
+         ++ms_drm_seq;
+     q->seq = ms_drm_seq++;
++    q->msc = UINT64_MAX;
+     q->scrn = scrn;
+     q->crtc = crtc;
+     q->data = data;
+     q->handler = handler;
+     q->abort = abort;
+ 
+-    xorg_list_add(&q->list, &ms_drm_queue);
++    /* Keep the list formatted in ascending order of sequence number */
++    xorg_list_append(&q->list, &ms_drm_queue);
+ 
+     return q->seq;
+ }
+@@ -437,9 +492,18 @@ ms_drm_queue_alloc(xf86CrtcPtr crtc,
+ static void
+ ms_drm_abort_one(struct ms_drm_queue *q)
+ {
++    if (q->aborted)
++        return;
++
++    /* Don't remove vblank events if they were queued in the kernel */
++    if (q->kernel_queued) {
++        q->abort(q->data);
++        q->aborted = TRUE;
++    } else {
+         xorg_list_del(&q->list);
+         q->abort(q->data);
+         free(q);
++    }
+ }
+ 
+ /**
+@@ -500,18 +564,61 @@ ms_drm_sequence_handler(int fd, uint64_t frame, uint64_t ns, Bool is64bit, uint6
+ {
+     struct ms_drm_queue *q, *tmp;
+     uint32_t seq = (uint32_t) user_data;
++    xf86CrtcPtr crtc = NULL;
++    drmmode_crtc_private_ptr drmmode_crtc;
++    uint64_t msc, next_msc = UINT64_MAX;
+ 
+-    xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
++    /* Handle the seq for this event first in order to get the CRTC */
++    xorg_list_for_each_entry(q, &ms_drm_queue, list) {
+         if (q->seq == seq) {
+-            uint64_t msc;
+-
+-            msc = ms_kernel_msc_to_crtc_msc(q->crtc, frame, is64bit);
++            crtc = q->crtc;
++            msc = ms_kernel_msc_to_crtc_msc(crtc, frame, is64bit);
+             xorg_list_del(&q->list);
+-            q->handler(msc, ns / 1000, q->data);
++            if (!q->aborted)
++                q->handler(msc, ns / 1000, q->data);
+             free(q);
+             break;
+         }
+     }
++
++    if (!crtc)
++        return;
++
++    /* Now run all of the vblank events for this CRTC with an expired MSC */
++    xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
++        if (q->crtc == crtc && q->msc <= msc) {
++            xorg_list_del(&q->list);
++            if (!q->aborted)
++                q->handler(msc, ns / 1000, q->data);
++            free(q);
++        }
++    }
++
++    /* Find this CRTC's next queued MSC and next non-queued MSC to be handled */
++    msc = UINT64_MAX;
++    xorg_list_for_each_entry(q, &ms_drm_queue, list) {
++        if (q->crtc == crtc) {
++            if (q->kernel_queued) {
++                if (q->msc < next_msc)
++                    next_msc = q->msc;
++            } else if (q->msc < msc) {
++                msc = q->msc;
++                seq = q->seq;
++            }
++        }
++    }
++
++    /* Queue an event if the next queued MSC isn't soon enough */
++    drmmode_crtc = crtc->driver_private;
++    drmmode_crtc->next_msc = next_msc;
++    if (msc < next_msc && !ms_queue_vblank(crtc, MS_QUEUE_ABSOLUTE, msc, NULL, seq)) {
++        xf86DrvMsg(crtc->scrn->scrnIndex, X_WARNING,
++                   "failed to queue next vblank event, aborting lost events\n");
++        xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
++            if (q->crtc == crtc && q->msc < next_msc)
++                ms_drm_abort_one(q);
++        }
++    }
+ }
+ 
+ static void
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1035-BACKPORT-modesetting-add-support-for-TearFree-page-flips.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1035-BACKPORT-modesetting-add-support-for-TearFree-page-flips.patch
@@ -1,0 +1,668 @@
+From 1603d6d0b75302cac8229c190be09b631eda798f Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Mon, 19 Dec 2022 23:39:23 -0800
+Subject: [PATCH 035/105] modesetting: add support for TearFree page flips
+
+This adds support for TearFree page flips to eliminate tearing without the
+use of a compositor. It allocates two shadow buffers for each CRTC, a back
+buffer and a front buffer, and uses damage tracking to minimize excessive
+copying between buffers and skip unnecessary flips when the screen's
+contents remain unchanged. It works on transformed screens too, such as
+rotated and scaled CRTCs.
+
+When PageFlip is enabled, TearFree won't force fullscreen DRI clients to
+synchronize their page flips to the vblank interval.
+
+TearFree is disabled by default.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+---
+ hw/xfree86/drivers/modesetting/driver.c       | 132 ++++++++++++++++--
+ hw/xfree86/drivers/modesetting/driver.h       |   3 +
+ .../drivers/modesetting/drmmode_display.c     | 119 ++++++++++++++++
+ .../drivers/modesetting/drmmode_display.h     |  19 +++
+ .../drivers/modesetting/modesetting.man       |  11 ++
+ hw/xfree86/drivers/modesetting/pageflip.c     |  70 +++++++++-
+ hw/xfree86/drivers/modesetting/present.c      |  22 ++-
+ 7 files changed, 360 insertions(+), 16 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.c b/hw/xfree86/drivers/modesetting/driver.c
+index fe3315a9c..7a7d5c388 100644
+--- a/hw/xfree86/drivers/modesetting/driver.c
++++ b/hw/xfree86/drivers/modesetting/driver.c
+@@ -145,6 +145,7 @@ static const OptionInfoRec Options[] = {
+     {OPTION_VARIABLE_REFRESH, "VariableRefresh", OPTV_BOOLEAN, {0}, FALSE},
+     {OPTION_USE_GAMMA_LUT, "UseGammaLUT", OPTV_BOOLEAN, {0}, FALSE},
+     {OPTION_ASYNC_FLIP_SECONDARIES, "AsyncFlipSecondaries", OPTV_BOOLEAN, {0}, FALSE},
++    {OPTION_TEARFREE, "TearFree", OPTV_BOOLEAN, {0}, FALSE},
+     {-1, NULL, OPTV_NONE, {0}, FALSE}
+ };
+ 
+@@ -548,14 +549,16 @@ rotate_clip(PixmapPtr pixmap, BoxPtr rect, drmModeClip *clip, Rotation rotation)
+ }
+ 
+ static int
+-dispatch_dirty_region(ScrnInfoPtr scrn, xf86CrtcPtr crtc,
+-		      PixmapPtr pixmap, DamagePtr damage, int fb_id)
++dispatch_damages(ScrnInfoPtr scrn, xf86CrtcPtr crtc, RegionPtr dirty,
++                 PixmapPtr pixmap, DamagePtr damage, int fb_id)
+ {
+     modesettingPtr ms = modesettingPTR(scrn);
+-    RegionPtr dirty = DamageRegion(damage);
+     unsigned num_cliprects = REGION_NUM_RECTS(dirty);
+     int ret = 0;
+ 
++    if (!ms->dirty_enabled)
++        return 0;
++
+     if (num_cliprects) {
+         drmModeClip *clip = xallocarray(num_cliprects, sizeof(drmModeClip));
+         BoxPtr rect = REGION_RECTS(dirty);
+@@ -579,12 +582,102 @@ dispatch_dirty_region(ScrnInfoPtr scrn, xf86CrtcPtr crtc,
+             }
+         }
+ 
++        if (ret == -EINVAL || ret == -ENOSYS) {
++            xf86DrvMsg(scrn->scrnIndex, X_INFO,
++                       "Disabling kernel dirty updates, not required.\n");
++            ms->dirty_enabled = FALSE;
++        }
++
+         free(clip);
+-        DamageEmpty(damage);
++        if (damage)
++            DamageEmpty(damage);
+     }
+     return ret;
+ }
+ 
++static int
++dispatch_dirty_region(ScrnInfoPtr scrn, xf86CrtcPtr crtc,
++                      PixmapPtr pixmap, DamagePtr damage, int fb_id)
++{
++    return dispatch_damages(scrn, crtc, DamageRegion(damage),
++                            pixmap, damage, fb_id);
++}
++
++static void
++ms_tearfree_update_damages(ScreenPtr pScreen)
++{
++    ScrnInfoPtr scrn = xf86ScreenToScrn(pScreen);
++    xf86CrtcConfigPtr xf86_config = XF86_CRTC_CONFIG_PTR(scrn);
++    modesettingPtr ms = modesettingPTR(scrn);
++    RegionPtr dirty = DamageRegion(ms->damage);
++    int c, i;
++
++    if (RegionNil(dirty))
++        return;
++
++    for (c = 0; c < xf86_config->num_crtc; c++) {
++        xf86CrtcPtr crtc = xf86_config->crtc[c];
++        drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++        drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
++        RegionRec region;
++
++        /* Compute how much of the damage intersects with this CRTC */
++        RegionInit(&region, &crtc->bounds, 0);
++        RegionIntersect(&region, &region, dirty);
++
++        if (trf->buf[0].px) {
++            for (i = 0; i < ARRAY_SIZE(trf->buf); i++)
++                RegionUnion(&trf->buf[i].dmg, &trf->buf[i].dmg, &region);
++        } else {
++            /* Just notify the kernel of the damages if TearFree isn't used */
++            dispatch_damages(scrn, crtc, &region,
++                             pScreen->GetScreenPixmap(pScreen),
++                             NULL, ms->drmmode.fb_id);
++        }
++    }
++    DamageEmpty(ms->damage);
++}
++
++static void
++ms_tearfree_do_flips(ScreenPtr pScreen)
++{
++#ifdef GLAMOR_HAS_GBM
++    ScrnInfoPtr scrn = xf86ScreenToScrn(pScreen);
++    xf86CrtcConfigPtr xf86_config = XF86_CRTC_CONFIG_PTR(scrn);
++    modesettingPtr ms = modesettingPTR(scrn);
++    int c;
++
++    if (!ms->drmmode.tearfree_enable)
++        return;
++
++    for (c = 0; c < xf86_config->num_crtc; c++) {
++        xf86CrtcPtr crtc = xf86_config->crtc[c];
++        drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++        drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
++
++        /* Skip disabled CRTCs and those which aren't using TearFree */
++        if (!trf->buf[0].px || !crtc->scrn->vtSema || !xf86_crtc_on(crtc))
++            continue;
++
++        /* Skip if the last flip is still pending, a DRI client is flipping, or
++         * there isn't any damage on the front buffer.
++         */
++        if (trf->flip_seq || ms->drmmode.dri2_flipping ||
++            ms->drmmode.present_flipping ||
++            RegionNil(&trf->buf[trf->back_idx ^ 1].dmg))
++            continue;
++
++        /* Flip. If it fails, notify the kernel of the front buffer damages */
++        if (ms_do_tearfree_flip(pScreen, crtc)) {
++            dispatch_damages(scrn, crtc, &trf->buf[trf->back_idx ^ 1].dmg,
++                             trf->buf[trf->back_idx ^ 1].px, NULL,
++                             trf->buf[trf->back_idx ^ 1].fb_id);
++            RegionEmpty(&trf->buf[trf->back_idx ^ 1].dmg);
++        }
++    }
++#endif
++}
++
+ static void
+ dispatch_dirty(ScreenPtr pScreen)
+ {
+@@ -606,12 +699,9 @@ dispatch_dirty(ScreenPtr pScreen)
+ 
+         ret = dispatch_dirty_region(scrn, crtc, pixmap, ms->damage, fb_id);
+         if (ret == -EINVAL || ret == -ENOSYS) {
+-            ms->dirty_enabled = FALSE;
+             DamageUnregister(ms->damage);
+             DamageDestroy(ms->damage);
+             ms->damage = NULL;
+-            xf86DrvMsg(scrn->scrnIndex, X_INFO,
+-                       "Disabling kernel dirty updates, not required.\n");
+             return;
+         }
+     }
+@@ -742,10 +832,13 @@ msBlockHandler(ScreenPtr pScreen, void *timeout)
+     pScreen->BlockHandler = msBlockHandler;
+     if (pScreen->isGPU && !ms->drmmode.reverse_prime_offload_mode)
+         dispatch_secondary_dirty(pScreen);
++    else if (ms->drmmode.tearfree_enable)
++        ms_tearfree_update_damages(pScreen);
+     else if (ms->dirty_enabled)
+         dispatch_dirty(pScreen);
+ 
+     ms_dirty_update(pScreen, timeout);
++    ms_tearfree_do_flips(pScreen);
+ }
+ 
+ static void
+@@ -1281,6 +1374,27 @@ PreInit(ScrnInfoPtr pScrn, int flags)
+         ms->atomic_modeset = FALSE;
+     }
+ 
++    /* TearFree requires glamor and, if PageFlip is enabled, universal planes */
++    if (xf86ReturnOptValBool(ms->drmmode.Options, OPTION_TEARFREE, FALSE)) {
++        if (pScrn->is_gpu) {
++            xf86DrvMsg(pScrn->scrnIndex, X_WARNING,
++                       "TearFree cannot synchronize PRIME; use 'PRIME Synchronization' instead\n");
++        } else if (ms->drmmode.glamor) {
++            /* Atomic modesetting implicitly enables universal planes */
++            if (!ms->drmmode.pageflip || ms->atomic_modeset ||
++                !drmSetClientCap(ms->fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1)) {
++                ms->drmmode.tearfree_enable = TRUE;
++                xf86DrvMsg(pScrn->scrnIndex, X_INFO, "TearFree: enabled\n");
++            } else {
++                xf86DrvMsg(pScrn->scrnIndex, X_WARNING,
++                           "TearFree requires either universal planes, or setting 'Option \"PageFlip\" \"off\"'\n");
++            }
++        } else {
++            xf86DrvMsg(pScrn->scrnIndex, X_WARNING,
++                       "TearFree requires Glamor acceleration\n");
++        }
++    }
++
+     ms->kms_has_modifiers = FALSE;
+     ret = drmGetCap(ms->fd, DRM_CAP_ADDFB2_MODIFIERS, &value);
+     if (ret == 0 && value != 0)
+@@ -1628,13 +1742,13 @@ CreateScreenResources(ScreenPtr pScreen)
+ 
+     err = drmModeDirtyFB(ms->fd, ms->drmmode.fb_id, NULL, 0);
+ 
+-    if (err != -EINVAL && err != -ENOSYS) {
++    if ((err != -EINVAL && err != -ENOSYS) || ms->drmmode.tearfree_enable) {
+         ms->damage = DamageCreate(NULL, NULL, DamageReportNone, TRUE,
+                                   pScreen, rootPixmap);
+ 
+         if (ms->damage) {
+             DamageRegister(&rootPixmap->drawable, ms->damage);
+-            ms->dirty_enabled = TRUE;
++            ms->dirty_enabled = err != -EINVAL && err != -ENOSYS;
+             xf86DrvMsg(pScrn->scrnIndex, X_INFO, "Damage tracking initialized\n");
+         }
+         else {
+diff --git a/hw/xfree86/drivers/modesetting/driver.h b/hw/xfree86/drivers/modesetting/driver.h
+index 4f62646a0..3f2b1d1ae 100644
+--- a/hw/xfree86/drivers/modesetting/driver.h
++++ b/hw/xfree86/drivers/modesetting/driver.h
+@@ -61,6 +61,7 @@ typedef enum {
+     OPTION_VARIABLE_REFRESH,
+     OPTION_USE_GAMMA_LUT,
+     OPTION_ASYNC_FLIP_SECONDARIES,
++    OPTION_TEARFREE,
+ } modesettingOpts;
+ 
+ typedef struct
+@@ -241,6 +242,8 @@ Bool ms_do_pageflip(ScreenPtr screen,
+                     ms_pageflip_abort_proc pageflip_abort,
+                     const char *log_prefix);
+ 
++Bool ms_do_tearfree_flip(ScreenPtr screen, xf86CrtcPtr crtc);
++
+ #endif
+ 
+ int ms_flush_drm_events(ScreenPtr screen);
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
+index 38c7b15f3..6583fdd14 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
+@@ -632,6 +632,7 @@ drmmode_crtc_get_fb_id(xf86CrtcPtr crtc, uint32_t *fb_id, int *x, int *y)
+ {
+     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+     drmmode_ptr drmmode = drmmode_crtc->drmmode;
++    drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
+     int ret;
+ 
+     *fb_id = 0;
+@@ -646,6 +647,10 @@ drmmode_crtc_get_fb_id(xf86CrtcPtr crtc, uint32_t *fb_id, int *x, int *y)
+             *x = drmmode_crtc->prime_pixmap_x;
+         *y = 0;
+     }
++    else if (trf->buf[trf->back_idx ^ 1].px) {
++        *fb_id = trf->buf[trf->back_idx ^ 1].fb_id;
++        *x = *y = 0;
++    }
+     else if (drmmode_crtc->rotate_fb_id) {
+         *fb_id = drmmode_crtc->rotate_fb_id;
+         *x = *y = 0;
+@@ -922,6 +927,10 @@ drmmode_crtc_set_mode(xf86CrtcPtr crtc, Bool test_only)
+     drmmode_ConvertToKMode(crtc->scrn, &kmode, &crtc->mode);
+     ret = drmModeSetCrtc(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
+                          fb_id, x, y, output_ids, output_count, &kmode);
++    if (!ret && !ms->atomic_modeset) {
++        drmmode_crtc->src_x = x;
++        drmmode_crtc->src_y = y;
++    }
+ 
+     drmmode_set_ctm(crtc, ctm);
+ 
+@@ -951,6 +960,26 @@ drmmode_crtc_flip(xf86CrtcPtr crtc, uint32_t fb_id, int x, int y,
+         return ret;
+     }
+ 
++    /* The frame buffer source coordinates may change when switching between the
++     * primary frame buffer and a per-CRTC frame buffer. Set the correct source
++     * coordinates if they differ for this flip.
++     */
++    if (drmmode_crtc->src_x != x || drmmode_crtc->src_y != y) {
++        ret = drmModeSetPlane(ms->fd, drmmode_crtc->plane_id,
++                              drmmode_crtc->mode_crtc->crtc_id, fb_id, 0,
++                              0, 0, crtc->mode.HDisplay, crtc->mode.VDisplay,
++                              x << 16, y << 16, crtc->mode.HDisplay << 16,
++                              crtc->mode.VDisplay << 16);
++        if (ret) {
++            xf86DrvMsg(crtc->scrn->scrnIndex, X_WARNING,
++                       "error changing fb src coordinates for flip: %d\n", ret);
++            return ret;
++        }
++
++        drmmode_crtc->src_x = x;
++        drmmode_crtc->src_y = y;
++    }
++
+     return drmModePageFlip(ms->fd, drmmode_crtc->mode_crtc->crtc_id,
+                            fb_id, flags, data);
+ }
+@@ -1549,6 +1578,90 @@ drmmode_copy_fb(ScrnInfoPtr pScrn, drmmode_ptr drmmode)
+ #endif
+ }
+ 
++void
++drmmode_copy_damage(xf86CrtcPtr crtc, PixmapPtr dst, RegionPtr dmg, Bool empty)
++{
++#ifdef GLAMOR_HAS_GBM
++    ScreenPtr pScreen = xf86ScrnToScreen(crtc->scrn);
++    DrawableRec *src;
++
++    /* Copy the screen's pixmap into the destination pixmap */
++    if (crtc->rotatedPixmap) {
++        src = &crtc->rotatedPixmap->drawable;
++        xf86RotateCrtcRedisplay(crtc, dst, src, dmg, FALSE);
++    } else {
++        src = &pScreen->GetScreenPixmap(pScreen)->drawable;
++        PixmapDirtyCopyArea(dst, src, 0, 0, -crtc->x, -crtc->y, dmg);
++    }
++
++    /* Reset the damages if requested */
++    if (empty)
++        RegionEmpty(dmg);
++
++    /* Wait until the GC operations finish */
++    modesettingPTR(crtc->scrn)->glamor.finish(pScreen);
++#endif
++}
++
++static void
++drmmode_shadow_fb_destroy(xf86CrtcPtr crtc, PixmapPtr pixmap,
++                          void *data, drmmode_bo *bo, uint32_t *fb_id);
++static void
++drmmode_destroy_tearfree_shadow(xf86CrtcPtr crtc)
++{
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++    drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
++    int i;
++
++    if (trf->flip_seq)
++        ms_drm_abort_seq(crtc->scrn, trf->flip_seq);
++
++    for (i = 0; i < ARRAY_SIZE(trf->buf); i++) {
++        if (trf->buf[i].px) {
++            drmmode_shadow_fb_destroy(crtc, trf->buf[i].px, (void *)(long)1,
++                                      &trf->buf[i].bo, &trf->buf[i].fb_id);
++            trf->buf[i].px = NULL;
++            RegionUninit(&trf->buf[i].dmg);
++        }
++    }
++}
++
++static PixmapPtr
++drmmode_shadow_fb_create(xf86CrtcPtr crtc, void *data, int width, int height,
++                         drmmode_bo *bo, uint32_t *fb_id);
++static Bool
++drmmode_create_tearfree_shadow(xf86CrtcPtr crtc)
++{
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++    drmmode_ptr drmmode = drmmode_crtc->drmmode;
++    drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
++    uint32_t w = crtc->mode.HDisplay, h = crtc->mode.VDisplay;
++    int i;
++
++    if (!drmmode->tearfree_enable)
++        return TRUE;
++
++    /* Destroy the old mode's buffers and make new ones */
++    drmmode_destroy_tearfree_shadow(crtc);
++    for (i = 0; i < ARRAY_SIZE(trf->buf); i++) {
++        trf->buf[i].px = drmmode_shadow_fb_create(crtc, NULL, w, h,
++                                                  &trf->buf[i].bo,
++                                                  &trf->buf[i].fb_id);
++        if (!trf->buf[i].px) {
++            drmmode_destroy_tearfree_shadow(crtc);
++            xf86DrvMsg(crtc->scrn->scrnIndex, X_ERROR,
++                       "shadow creation failed for TearFree buf%d\n", i);
++            return FALSE;
++        }
++        RegionInit(&trf->buf[i].dmg, &crtc->bounds, 0);
++    }
++
++    /* Initialize the front buffer with the current scanout */
++    drmmode_copy_damage(crtc, trf->buf[trf->back_idx ^ 1].px,
++                        &trf->buf[trf->back_idx ^ 1].dmg, TRUE);
++    return TRUE;
++}
++
+ static Bool
+ drmmode_set_mode_major(xf86CrtcPtr crtc, DisplayModePtr mode,
+                        Rotation rotation, int x, int y)
+@@ -1582,6 +1695,10 @@ drmmode_set_mode_major(xf86CrtcPtr crtc, DisplayModePtr mode,
+         crtc->funcs->gamma_set(crtc, crtc->gamma_red, crtc->gamma_green,
+                                crtc->gamma_blue, crtc->gamma_size);
+ 
++        ret = drmmode_create_tearfree_shadow(crtc);
++        if (!ret)
++            goto done;
++
+         can_test = drmmode_crtc_can_test_mode(crtc);
+         if (drmmode_crtc_set_mode(crtc, can_test)) {
+             xf86DrvMsg(crtc->scrn->scrnIndex, X_ERROR,
+@@ -1627,6 +1744,7 @@ drmmode_set_mode_major(xf86CrtcPtr crtc, DisplayModePtr mode,
+         crtc->y = saved_y;
+         crtc->rotation = saved_rotation;
+         crtc->mode = saved_mode;
++        drmmode_create_tearfree_shadow(crtc);
+     } else
+         crtc->active = TRUE;
+ 
+@@ -4274,6 +4392,7 @@ drmmode_free_bos(ScrnInfoPtr pScrn, drmmode_ptr drmmode)
+         drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+ 
+         dumb_bo_destroy(drmmode->fd, drmmode_crtc->cursor_bo);
++        drmmode_destroy_tearfree_shadow(crtc);
+     }
+ }
+ 
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.h b/hw/xfree86/drivers/modesetting/drmmode_display.h
+index d6ad15501..145cb8cc7 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.h
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.h
+@@ -135,6 +135,7 @@ typedef struct {
+     Bool async_flip_secondaries;
+     Bool dri2_enable;
+     Bool present_enable;
++    Bool tearfree_enable;
+ 
+     uint32_t vrr_prop_id;
+     Bool use_ctm;
+@@ -166,6 +167,19 @@ typedef struct {
+     uint64_t *modifiers;
+ } drmmode_format_rec, *drmmode_format_ptr;
+ 
++typedef struct {
++    drmmode_bo bo;
++    uint32_t fb_id;
++    PixmapPtr px;
++    RegionRec dmg;
++} drmmode_shadow_fb_rec, *drmmode_shadow_fb_ptr;
++
++typedef struct {
++    drmmode_shadow_fb_rec buf[2];
++    uint32_t back_idx;
++    uint32_t flip_seq;
++} drmmode_tearfree_rec, *drmmode_tearfree_ptr;
++
+ typedef struct {
+     drmmode_ptr drmmode;
+     drmModeCrtcPtr mode_crtc;
+@@ -184,11 +198,14 @@ typedef struct {
+ 
+     drmmode_bo rotate_bo;
+     unsigned rotate_fb_id;
++    drmmode_tearfree_rec tearfree;
+ 
+     PixmapPtr prime_pixmap;
+     PixmapPtr prime_pixmap_back;
+     unsigned prime_pixmap_x;
+ 
++    int src_x, src_y;
++
+     /**
+      * @{ MSC (vblank count) handling for the PRESENT extension.
+      *
+@@ -310,6 +327,8 @@ void drmmode_get_default_bpp(ScrnInfoPtr pScrn, drmmode_ptr drmmmode,
+                              int *depth, int *bpp);
+ 
+ void drmmode_copy_fb(ScrnInfoPtr pScrn, drmmode_ptr drmmode);
++void drmmode_copy_damage(xf86CrtcPtr crtc, PixmapPtr dst, RegionPtr damage,
++                         Bool empty);
+ 
+ int drmmode_crtc_flip(xf86CrtcPtr crtc, uint32_t fb_id, int x, int y,
+                       uint32_t flags, void *data);
+diff --git a/hw/xfree86/drivers/modesetting/modesetting.man b/hw/xfree86/drivers/modesetting/modesetting.man
+index 71790011e..9e40b04f3 100644
+--- a/hw/xfree86/drivers/modesetting/modesetting.man
++++ b/hw/xfree86/drivers/modesetting/modesetting.man
+@@ -109,6 +109,17 @@ When enabled, this option allows the driver to use gamma ramps with more
+ entries, if supported by the kernel. By default, GAMMA_LUT will be used for
+ kms drivers which are known to be safe for use of GAMMA_LUT.
+ .TP
++.BI "Option \*qTearFree\*q \*q" boolean \*q
++Enable tearing prevention using the hardware page flipping mechanism.
++It allocates two extra scanout buffers for each CRTC and utilizes damage
++tracking to minimize buffer copying and skip unnecessary flips when the
++screen's contents have not changed. It works on transformed screens too, such
++as rotated and scaled CRTCs. When PageFlip is enabled, fullscreen DRI
++applications will still have the discretion to not use tearing prevention.
++.br
++The default is
++.B off.
++.TP
+ .SH "SEE ALSO"
+ @xservername@(@appmansuffix@), @xconfigfile@(@filemansuffix@), Xserver(@appmansuffix@),
+ X(@miscmansuffix@)
+diff --git a/hw/xfree86/drivers/modesetting/pageflip.c b/hw/xfree86/drivers/modesetting/pageflip.c
+index a51a10a2c..8d57047ef 100644
+--- a/hw/xfree86/drivers/modesetting/pageflip.c
++++ b/hw/xfree86/drivers/modesetting/pageflip.c
+@@ -35,8 +35,8 @@
+  * Returns a negative value on error, 0 if there was nothing to process,
+  * or 1 if we handled any events.
+  */
+-int
+-ms_flush_drm_events(ScreenPtr screen)
++static int
++ms_flush_drm_events_timeout(ScreenPtr screen, int timeout)
+ {
+     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
+     modesettingPtr ms = modesettingPTR(scrn);
+@@ -45,7 +45,7 @@ ms_flush_drm_events(ScreenPtr screen)
+     int r;
+ 
+     do {
+-            r = xserver_poll(&p, 1, 0);
++            r = xserver_poll(&p, 1, timeout);
+     } while (r == -1 && (errno == EINTR || errno == EAGAIN));
+ 
+     /* If there was an error, r will be < 0.  Return that.  If there was
+@@ -63,6 +63,12 @@ ms_flush_drm_events(ScreenPtr screen)
+     return 1;
+ }
+ 
++int
++ms_flush_drm_events(ScreenPtr screen)
++{
++    return ms_flush_drm_events_timeout(screen, 0);
++}
++
+ #ifdef GLAMOR_HAS_GBM
+ 
+ /*
+@@ -163,14 +169,22 @@ static Bool
+ do_queue_flip_on_crtc(ScreenPtr screen, xf86CrtcPtr crtc, uint32_t flags,
+                       uint32_t seq, uint32_t fb_id, int x, int y)
+ {
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++    drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
++
+     while (drmmode_crtc_flip(crtc, fb_id, x, y, flags, (void *)(long)seq)) {
+         /* We may have failed because the event queue was full.  Flush it
+          * and retry.  If there was nothing to flush, then we failed for
+          * some other reason and should just return an error.
+          */
+         if (ms_flush_drm_events(screen) <= 0) {
+-            ms_drm_abort_seq(crtc->scrn, seq);
+-            return TRUE;
++            /* The failure could be caused by a pending TearFree flip, in which
++             * case we should wait until there's a new event and try again.
++             */
++            if (!trf->flip_seq || ms_flush_drm_events_timeout(screen, -1) < 0) {
++                ms_drm_abort_seq(crtc->scrn, seq);
++                return TRUE;
++            }
+         }
+ 
+         /* We flushed some events, so try again. */
+@@ -467,4 +481,50 @@ error_out:
+ #endif /* GLAMOR_HAS_GBM */
+ }
+ 
++static void
++ms_tearfree_flip_abort(void *data)
++{
++    drmmode_tearfree_ptr trf = data;
++
++    trf->flip_seq = 0;
++}
++
++static void
++ms_tearfree_flip_handler(uint64_t msc, uint64_t usec, void *data)
++{
++    drmmode_tearfree_ptr trf = data;
++
++    /* Swap the buffers and complete the flip */
++    trf->back_idx ^= 1;
++    trf->flip_seq = 0;
++}
++
++Bool
++ms_do_tearfree_flip(ScreenPtr screen, xf86CrtcPtr crtc)
++{
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++    drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
++    uint32_t idx = trf->back_idx, seq;
++
++    seq = ms_drm_queue_alloc(crtc, trf, ms_tearfree_flip_handler,
++                             ms_tearfree_flip_abort);
++    if (!seq)
++        goto no_flip;
++
++    /* Copy the damage to the back buffer and then flip it at the vblank */
++    drmmode_copy_damage(crtc, trf->buf[idx].px, &trf->buf[idx].dmg, TRUE);
++    if (do_queue_flip_on_crtc(screen, crtc, DRM_MODE_PAGE_FLIP_EVENT,
++                              seq, trf->buf[idx].fb_id, 0, 0))
++        goto no_flip;
++
++    trf->flip_seq = seq;
++    return FALSE;
++
++no_flip:
++    xf86DrvMsg(crtc->scrn->scrnIndex, X_WARNING,
++               "TearFree flip failed, rendering frame without TearFree\n");
++    drmmode_copy_damage(crtc, trf->buf[idx ^ 1].px,
++                        &trf->buf[idx ^ 1].dmg, FALSE);
++    return TRUE;
++}
+ #endif
+diff --git a/hw/xfree86/drivers/modesetting/present.c b/hw/xfree86/drivers/modesetting/present.c
+index c3266d871..642f7baaf 100644
+--- a/hw/xfree86/drivers/modesetting/present.c
++++ b/hw/xfree86/drivers/modesetting/present.c
+@@ -318,14 +318,32 @@ ms_present_check_flip(RRCrtcPtr crtc,
+     modesettingPtr ms = modesettingPTR(scrn);
+ 
+     if (ms->drmmode.sprites_visible > 0)
+-        return FALSE;
++        goto no_flip;
+ 
+     if(!ms_present_check_unflip(crtc, window, pixmap, sync_flip, reason))
+-        return FALSE;
++        goto no_flip;
+ 
+     ms->flip_window = window;
+ 
+     return TRUE;
++
++no_flip:
++    /* Export some info about TearFree if Present can't flip anyway */
++    if (reason && ms->drmmode.tearfree_enable) {
++        xf86CrtcPtr xf86_crtc = crtc->devPrivate;
++        drmmode_crtc_private_ptr drmmode_crtc = xf86_crtc->driver_private;
++        drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
++
++        if (trf->buf[0].px) {
++            if (trf->flip_seq)
++                /* The driver has a TearFree flip pending */
++                *reason = PRESENT_FLIP_REASON_DRIVER_TEARFREE_FLIPPING;
++            else
++                /* The driver uses TearFree flips and there's no flip pending */
++                *reason = PRESENT_FLIP_REASON_DRIVER_TEARFREE;
++        }
++    }
++    return FALSE;
+ }
+ 
+ /*
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1036-BACKPORT-modesetting-Document-the-Atomic-option.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1036-BACKPORT-modesetting-Document-the-Atomic-option.patch
@@ -1,0 +1,34 @@
+From 0f543554e07b22895f523b236364a509a71bce1d Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Thu, 15 Dec 2022 16:57:01 +0100
+Subject: [PATCH 036/105] modesetting: Document the "Atomic" option
+
+The modesetting driver has atomic modesetting disabled by default but
+can be enabled (if supported) using a configuration option.
+
+Add this option in the man page.
+
+Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
+Reviewed-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ hw/xfree86/drivers/modesetting/modesetting.man | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/hw/xfree86/drivers/modesetting/modesetting.man b/hw/xfree86/drivers/modesetting/modesetting.man
+index 9e40b04f3..485beff48 100644
+--- a/hw/xfree86/drivers/modesetting/modesetting.man
++++ b/hw/xfree86/drivers/modesetting/modesetting.man
+@@ -120,6 +120,10 @@ applications will still have the discretion to not use tearing prevention.
+ The default is
+ .B off.
+ .TP
++.BI "Option \*qAtomic\*q \*q" boolean \*q
++Enable atomic modesetting when supported.  The default is
++.B off.
++.TP
+ .SH "SEE ALSO"
+ @xservername@(@appmansuffix@), @xconfigfile@(@filemansuffix@), Xserver(@appmansuffix@),
+ X(@miscmansuffix@)
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1037-BACKPORT-modesetting-Log-whether-atomic-modesetting-is-enable.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1037-BACKPORT-modesetting-Log-whether-atomic-modesetting-is-enable.patch
@@ -1,0 +1,36 @@
+From 58bd8d081a3d5739ee408e912b067547f726dcdf Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Thu, 15 Dec 2022 16:59:04 +0100
+Subject: [PATCH 037/105] modesetting: Log whether atomic modesetting is
+ enabled
+
+If atomic modesetting is to be enabled in the configuration file, log
+whether this is supported and eventually enabled or disabled.
+
+Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
+Reviewed-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ hw/xfree86/drivers/modesetting/driver.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.c b/hw/xfree86/drivers/modesetting/driver.c
+index 7a7d5c388..3f185489e 100644
+--- a/hw/xfree86/drivers/modesetting/driver.c
++++ b/hw/xfree86/drivers/modesetting/driver.c
+@@ -1370,9 +1370,13 @@ PreInit(ScrnInfoPtr pScrn, int flags)
+     if (xf86ReturnOptValBool(ms->drmmode.Options, OPTION_ATOMIC, FALSE)) {
+         ret = drmSetClientCap(ms->fd, DRM_CLIENT_CAP_ATOMIC, 1);
+         ms->atomic_modeset = (ret == 0);
++        if (!ms->atomic_modeset)
++            xf86DrvMsg(pScrn->scrnIndex, X_WARNING, "Atomic modesetting not supported\n");
+     } else {
+         ms->atomic_modeset = FALSE;
+     }
++    xf86DrvMsg(pScrn->scrnIndex, X_INFO,
++               "Atomic modesetting %sabled\n", ms->atomic_modeset ? "en" : "dis");
+ 
+     /* TearFree requires glamor and, if PageFlip is enabled, universal planes */
+     if (xf86ReturnOptValBool(ms->drmmode.Options, OPTION_TEARFREE, FALSE)) {
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1038-BACKPORT-x86-logind-fix-suspend-resume-when-there-are-no-inpu.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1038-BACKPORT-x86-logind-fix-suspend-resume-when-there-are-no-inpu.patch
@@ -1,0 +1,46 @@
+From 8ed233344d00724be340ded963ad39f32c43b8f0 Mon Sep 17 00:00:00 2001
+From: Jocelyn Falempe <jfalempe@redhat.com>
+Date: Fri, 21 Oct 2022 09:06:56 +0200
+Subject: [PATCH 038/105] x86/logind fix suspend/resume when there are no input
+ devices
+
+Make sure info->active and info->vt_active are false after
+dropping drm master.
+Normally, this is done when pausing the first input device, so it
+breaks when there are no input device at all.
+
+Fixes: da9d012a9 ("xf86/logind: Fix drm_drop_master before vt_reldisp")
+Closes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1387
+Signed-off-by: Jocelyn Falempe <jfalempe@redhat.com>
+---
+ hw/xfree86/os-support/linux/systemd-logind.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/hw/xfree86/os-support/linux/systemd-logind.c b/hw/xfree86/os-support/linux/systemd-logind.c
+index dbb00cd85..d97e92ff8 100644
+--- a/hw/xfree86/os-support/linux/systemd-logind.c
++++ b/hw/xfree86/os-support/linux/systemd-logind.c
+@@ -310,15 +310,19 @@ cleanup:
+  */
+ void systemd_logind_drop_master(void)
+ {
++    struct systemd_logind_info *info = &logind_info;
+     int i;
++    /* Our VT_PROCESS usage guarantees we've already given up the vt */
++    info->active = info->vt_active = FALSE;
+     for (i = 0; i < xf86_num_platform_devices; i++) {
+         if (xf86_platform_devices[i].flags & XF86_PDEV_SERVER_FD) {
+             dbus_int32_t major, minor;
+-            struct systemd_logind_info *info = &logind_info;
+ 
+             xf86_platform_devices[i].flags |= XF86_PDEV_PAUSED;
+             major = xf86_platform_odev_attributes(i)->major;
+             minor = xf86_platform_odev_attributes(i)->minor;
++            LogMessage(X_INFO, "systemd-logind: drop master for %u:%u\n",
++               major, minor);
+             systemd_logind_ack_pause(info, minor, major);
+         }
+     }
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1039-BACKPORT-config-add-a-quirk-for-Apple-Silicon-appledrm.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1039-BACKPORT-config-add-a-quirk-for-Apple-Silicon-appledrm.patch
@@ -1,0 +1,35 @@
+From 52627628618b604ff5fa07131d135dd26d133889 Mon Sep 17 00:00:00 2001
+From: Eric Curtin <ecurtin@redhat.com>
+Date: Fri, 16 Dec 2022 11:10:12 +0000
+Subject: [PATCH 039/105] config: add a quirk for Apple Silicon appledrm
+
+Xorg server does not correctly select the DCP for the display without a
+quirk on Apple Silicon.
+
+Signed-off-by: Eric Curtin <ecurtin@redhat.com>
+Suggested-by: Hector Martin <marcan@marcan.st>
+---
+ config/10-quirks.conf | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/config/10-quirks.conf b/config/10-quirks.conf
+index 47907d82d..54dd908a7 100644
+--- a/config/10-quirks.conf
++++ b/config/10-quirks.conf
+@@ -36,3 +36,13 @@ Section "InputClass"
+         MatchDriver "evdev"
+         Option "TypeName" "MOUSE"
+ EndSection
++
++# https://bugzilla.redhat.com/show_bug.cgi?id=2152414
++# Xorg server does not correctly select the DCP for the display without
++# a quirk on Apple Silicon
++Section "OutputClass"
++        Identifier "appledrm"
++        MatchDriver "apple"
++        Driver "modesetting"
++        Option "PrimaryGPU" "true"
++EndSection
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1040-BACKPORT-glamor-Don-t-initialize-on-softpipe.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1040-BACKPORT-glamor-Don-t-initialize-on-softpipe.patch
@@ -1,0 +1,39 @@
+From 6f9bee67ef5934ac3c09852c175649abf0428b20 Mon Sep 17 00:00:00 2001
+From: "Ivan A. Melnikov" <iv@altlinux.org>
+Date: Wed, 21 Dec 2022 18:29:21 +0400
+Subject: [PATCH 040/105] glamor: Don't initialize on softpipe
+
+There are systems where softpipe is the default renderer,
+e.g. when llvmpipe is not is not available. Using glamor
+on such systems is never a good idea.
+
+This mirrors what commit 0a9415cf793babed1f28c61f8047d51de04f1528
+did for llvmpipe.
+
+Closes: #1417
+
+Signed-off-by: Ivan A. Melnikov <iv@altlinux.org>
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ glamor/glamor_egl.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index e2a2a1050..c35b10d83 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -1080,6 +1080,11 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+                    "glGetString() returned NULL, your GL is broken\n");
+         goto error;
+     }
++    if (strstr((const char *)renderer, "softpipe")) {
++        xf86DrvMsg(scrn->scrnIndex, X_INFO,
++                   "Refusing to try glamor on softpipe\n");
++        goto error;
++    }
+     if (!strncmp("llvmpipe", (const char *)renderer, strlen("llvmpipe"))) {
+         if (scrn->confScreen->num_gpu_devices)
+             xf86DrvMsg(scrn->scrnIndex, X_INFO,
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1041-BACKPORT-dri3-Don-t-compute-intersection-with-drawable-modifi.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1041-BACKPORT-dri3-Don-t-compute-intersection-with-drawable-modifi.patch
@@ -1,0 +1,122 @@
+From 566d87e8e881144ea3028132828d19037d552f76 Mon Sep 17 00:00:00 2001
+From: Austin Shafer <ashafer@nvidia.com>
+Date: Tue, 20 Dec 2022 12:22:53 +0100
+Subject: [PATCH 041/105] dri3: Don't compute intersection with drawable
+ modifiers
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In dri3_get_supported_modifiers we were previously intersecting
+the drawable mods and the screen mods. This meant all screen mods
+were returned, but the ones compatible with the drawable were
+returned in the drawable mods list and the rest are returned in
+the screen mods list.
+
+This is a problem with linux_dmabuf v4 since the drawable mods may
+contain different mods not found in the screen mods (such as scanout
+entries). This change removes the intersection, and just returns
+the drawable/screen mod lists directly.
+
+Reviewed-by: Michel Dänzer <mdaenzer@redhat.com>
+---
+ dri3/dri3_screen.c | 56 ++++++++++------------------------------------
+ 1 file changed, 12 insertions(+), 44 deletions(-)
+
+diff --git a/dri3/dri3_screen.c b/dri3/dri3_screen.c
+index 3c7e5bf60..bc96e5339 100644
+--- a/dri3/dri3_screen.c
++++ b/dri3/dri3_screen.c
+@@ -211,18 +211,17 @@ cache_formats_and_modifiers(ScreenPtr screen)
+ int
+ dri3_get_supported_modifiers(ScreenPtr screen, DrawablePtr drawable,
+                              CARD8 depth, CARD8 bpp,
+-                             CARD32 *num_intersect_modifiers,
+-                             CARD64 **intersect_modifiers,
++                             CARD32 *num_drawable_modifiers,
++                             CARD64 **drawable_modifiers,
+                              CARD32 *num_screen_modifiers,
+                              CARD64 **screen_modifiers)
+ {
+     dri3_screen_priv_ptr        ds = dri3_screen_priv(screen);
+     const dri3_screen_info_rec *info = ds->info;
+-    int                         i, j;
++    int                         i;
+     int                         ret;
+     uint32_t                    num_drawable_mods;
+     uint64_t                   *drawable_mods;
+-    CARD64                     *intersect_mods = NULL;
+     CARD64                     *screen_mods = NULL;
+     CARD32                      format;
+     dri3_dmabuf_format_ptr      screen_format = NULL;
+@@ -248,10 +247,15 @@ dri3_get_supported_modifiers(ScreenPtr screen, DrawablePtr drawable,
+ 
+     if (screen_format->num_modifiers == 0) {
+         *num_screen_modifiers = 0;
+-        *num_intersect_modifiers = 0;
++        *num_drawable_modifiers = 0;
+         return Success;
+     }
+ 
++    /* copy the screen mods so we can return an owned allocation */
++    screen_mods = xnfalloc(screen_format->num_modifiers * sizeof(CARD64));
++    memcpy(screen_mods, screen_format->modifiers,
++           screen_format->num_modifiers * sizeof(CARD64));
++
+     if (!info->get_drawable_modifiers ||
+         !info->get_drawable_modifiers(drawable, format,
+                                       &num_drawable_mods,
+@@ -260,47 +264,11 @@ dri3_get_supported_modifiers(ScreenPtr screen, DrawablePtr drawable,
+         drawable_mods = NULL;
+     }
+ 
+-    /* We're allocating slightly more memory than necessary but it reduces
+-     * the complexity of finding the intersection set.
+-     */
+-    screen_mods = malloc(screen_format->num_modifiers * sizeof(CARD64));
+-    if (!screen_mods)
+-        return BadAlloc;
+-    if (num_drawable_mods > 0) {
+-        intersect_mods = malloc(screen_format->num_modifiers * sizeof(CARD64));
+-        if (!intersect_mods) {
+-            free(screen_mods);
+-            return BadAlloc;
+-        }
+-    }
+-
+-    *num_screen_modifiers = 0;
+-    *num_intersect_modifiers = 0;
+-    for (i = 0; i < screen_format->num_modifiers; i++) {
+-        CARD64 modifier = screen_format->modifiers[i];
+-        Bool intersect = FALSE;
+-
+-        for (j = 0; j < num_drawable_mods; j++) {
+-            if (drawable_mods[j] == modifier) {
+-                intersect = TRUE;
+-                break;
+-            }
+-        }
+-
+-        if (intersect) {
+-            intersect_mods[*num_intersect_modifiers] = modifier;
+-            *num_intersect_modifiers += 1;
+-        } else {
+-            screen_mods[*num_screen_modifiers] = modifier;
+-            *num_screen_modifiers += 1;
+-        }
+-    }
+-
+-    assert(*num_intersect_modifiers + *num_screen_modifiers == screen_format->num_modifiers);
++    *num_drawable_modifiers = num_drawable_mods;
++    *drawable_modifiers = drawable_mods;
+ 
+-    *intersect_modifiers = intersect_mods;
++    *num_screen_modifiers = screen_format->num_modifiers;
+     *screen_modifiers = screen_mods;
+-    free(drawable_mods);
+ 
+     return Success;
+ }
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1042-BACKPORT-glamor-handle-EXT_gpu_shader4-in-dual-source-blend-p.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1042-BACKPORT-glamor-handle-EXT_gpu_shader4-in-dual-source-blend-p.patch
@@ -1,0 +1,58 @@
+From fb0563a54fb07becb3864ffc52471e58c773a4f5 Mon Sep 17 00:00:00 2001
+From: Dave Airlie <airlied@redhat.com>
+Date: Thu, 9 Feb 2023 13:48:30 +1000
+Subject: [PATCH 042/105] glamor: handle EXT_gpu_shader4 in dual source blend
+ paths
+
+Fixes: a9552868697c ("glamor: add EXT_gpu_shader4 support")
+Acked-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor_render.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
+index c9a125ef9..889fe1b36 100644
+--- a/glamor/glamor_render.c
++++ b/glamor/glamor_render.c
+@@ -61,7 +61,7 @@ static struct blendinfo composite_op_info[] = {
+ 
+ #define RepeatFix			10
+ static GLuint
+-glamor_create_composite_fs(struct shader_key *key)
++glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key *key)
+ {
+     const char *repeat_define =
+         "#define RepeatNone               	      0\n"
+@@ -223,6 +223,8 @@ glamor_create_composite_fs(struct shader_key *key)
+         "}\n";
+     const char *header_ca_dual_blend =
+         "#version 130\n";
++    const char *header_ca_dual_blend_gpu_shader4 =
++        "#version 120\n#extension GL_EXT_gpu_shader4 : require\n";
+     const char *in_ca_dual_blend_gles2 =
+         "void main()\n"
+         "{\n"
+@@ -301,7 +303,10 @@ glamor_create_composite_fs(struct shader_key *key)
+         break;
+     case glamor_program_alpha_dual_blend:
+         in = in_ca_dual_blend;
+-        header = header_ca_dual_blend;
++        if (glamor_priv->glsl_version >= 130)
++           header = header_ca_dual_blend;
++        else
++           header = header_ca_dual_blend_gpu_shader4;
+         break;
+     case glamor_program_alpha_dual_blend_gles2:
+         in = in_ca_dual_blend_gles2;
+@@ -379,7 +384,7 @@ glamor_create_composite_shader(ScreenPtr screen, struct shader_key *key,
+     vs = glamor_create_composite_vs(key);
+     if (vs == 0)
+         return;
+-    fs = glamor_create_composite_fs(key);
++    fs = glamor_create_composite_fs(glamor_priv, key);
+     if (fs == 0)
+         return;
+ 
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1043-BACKPORT-modesetting-Remove-redundant-GLAMOR_HAS_GBM-ifdef-fr.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1043-BACKPORT-modesetting-Remove-redundant-GLAMOR_HAS_GBM-ifdef-fr.patch
@@ -1,0 +1,42 @@
+From df31bb66a20efb7f3b02cfa9c89f552266ea3221 Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sun, 22 Jan 2023 14:56:36 -0800
+Subject: [PATCH 043/105] modesetting: Remove redundant GLAMOR_HAS_GBM #ifdef
+ from ms_do_pageflip
+
+This #ifdef is redundant since ms_do_pageflip is already enclosed within a
+larger GLAMOR_HAS_GBM #ifdef.
+
+No functional change.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Reviewed-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ hw/xfree86/drivers/modesetting/pageflip.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/pageflip.c b/hw/xfree86/drivers/modesetting/pageflip.c
+index 8d57047ef..5a4ad1dba 100644
+--- a/hw/xfree86/drivers/modesetting/pageflip.c
++++ b/hw/xfree86/drivers/modesetting/pageflip.c
+@@ -321,9 +321,6 @@ ms_do_pageflip(ScreenPtr screen,
+                ms_pageflip_abort_proc pageflip_abort,
+                const char *log_prefix)
+ {
+-#ifndef GLAMOR_HAS_GBM
+-    return FALSE;
+-#else
+     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
+     modesettingPtr ms = modesettingPTR(scrn);
+     xf86CrtcConfigPtr config = XF86_CRTC_CONFIG_PTR(scrn);
+@@ -478,7 +475,6 @@ error_out:
+         flipdata->flip_count--;
+ 
+     return FALSE;
+-#endif /* GLAMOR_HAS_GBM */
+ }
+ 
+ static void
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1044-BACKPORT-modesetting-Pass-reference-CRTC-pointer-to-ms_do_pag.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1044-BACKPORT-modesetting-Pass-reference-CRTC-pointer-to-ms_do_pag.patch
@@ -1,0 +1,148 @@
+From ad20fe8705ab05fde6ecece8c6de9f522ef65613 Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sun, 22 Jan 2023 14:58:23 -0800
+Subject: [PATCH 044/105] modesetting: Pass reference CRTC pointer to
+ ms_do_pageflip
+
+Rather than passing the reference CRTC's vblank pipe to ms_do_pageflip,
+just pass the pointer to the reference CRTC directly instead. This is
+clearer and more useful than the vblank pipe, since the vblank pipe is only
+used to identify whether or not a given CRTC is the reference CRTC.
+
+No functional change.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Reviewed-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ hw/xfree86/drivers/modesetting/dri2.c     |  3 +--
+ hw/xfree86/drivers/modesetting/driver.h   |  2 +-
+ hw/xfree86/drivers/modesetting/pageflip.c | 14 +++++---------
+ hw/xfree86/drivers/modesetting/present.c  |  5 ++---
+ 4 files changed, 9 insertions(+), 15 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/dri2.c b/hw/xfree86/drivers/modesetting/dri2.c
+index 8d1b742ef..34ddec424 100644
+--- a/hw/xfree86/drivers/modesetting/dri2.c
++++ b/hw/xfree86/drivers/modesetting/dri2.c
+@@ -483,7 +483,6 @@ ms_dri2_schedule_flip(ms_dri2_frame_event_ptr info)
+     modesettingPtr ms = modesettingPTR(scrn);
+     ms_dri2_buffer_private_ptr back_priv = info->back->driverPrivate;
+     struct ms_dri2_vblank_event *event;
+-    drmmode_crtc_private_ptr drmmode_crtc = info->crtc->driver_private;
+ 
+     event = calloc(1, sizeof(struct ms_dri2_vblank_event));
+     if (!event)
+@@ -495,7 +494,7 @@ ms_dri2_schedule_flip(ms_dri2_frame_event_ptr info)
+     event->event_data = info->event_data;
+ 
+     if (ms_do_pageflip(screen, back_priv->pixmap, event,
+-                       drmmode_crtc->vblank_pipe, FALSE,
++                       info->crtc, FALSE,
+                        ms_dri2_flip_handler,
+                        ms_dri2_flip_abort,
+                        "DRI2-flip")) {
+diff --git a/hw/xfree86/drivers/modesetting/driver.h b/hw/xfree86/drivers/modesetting/driver.h
+index 3f2b1d1ae..605fd8530 100644
+--- a/hw/xfree86/drivers/modesetting/driver.h
++++ b/hw/xfree86/drivers/modesetting/driver.h
+@@ -236,7 +236,7 @@ typedef void (*ms_pageflip_abort_proc)(modesettingPtr ms, void *data);
+ Bool ms_do_pageflip(ScreenPtr screen,
+                     PixmapPtr new_front,
+                     void *event,
+-                    int ref_crtc_vblank_pipe,
++                    xf86CrtcPtr ref_crtc,
+                     Bool async,
+                     ms_pageflip_handler_proc pageflip_handler,
+                     ms_pageflip_abort_proc pageflip_abort,
+diff --git a/hw/xfree86/drivers/modesetting/pageflip.c b/hw/xfree86/drivers/modesetting/pageflip.c
+index 5a4ad1dba..b0ff9655b 100644
+--- a/hw/xfree86/drivers/modesetting/pageflip.c
++++ b/hw/xfree86/drivers/modesetting/pageflip.c
+@@ -204,11 +204,10 @@ enum queue_flip_status {
+ static int
+ queue_flip_on_crtc(ScreenPtr screen, xf86CrtcPtr crtc,
+                    struct ms_flipdata *flipdata,
+-                   int ref_crtc_vblank_pipe, uint32_t flags)
++                   xf86CrtcPtr ref_crtc, uint32_t flags)
+ {
+     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
+     modesettingPtr ms = modesettingPTR(scrn);
+-    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+     struct ms_crtc_pageflip *flip;
+     uint32_t seq;
+ 
+@@ -220,7 +219,7 @@ queue_flip_on_crtc(ScreenPtr screen, xf86CrtcPtr crtc,
+     /* Only the reference crtc will finally deliver its page flip
+      * completion event. All other crtc's events will be discarded.
+      */
+-    flip->on_reference_crtc = (drmmode_crtc->vblank_pipe == ref_crtc_vblank_pipe);
++    flip->on_reference_crtc = crtc == ref_crtc;
+     flip->flipdata = flipdata;
+ 
+     seq = ms_drm_queue_alloc(crtc, flip, ms_pageflip_handler, ms_pageflip_abort);
+@@ -315,7 +314,7 @@ Bool
+ ms_do_pageflip(ScreenPtr screen,
+                PixmapPtr new_front,
+                void *event,
+-               int ref_crtc_vblank_pipe,
++               xf86CrtcPtr ref_crtc,
+                Bool async,
+                ms_pageflip_handler_proc pageflip_handler,
+                ms_pageflip_abort_proc pageflip_abort,
+@@ -393,7 +392,6 @@ ms_do_pageflip(ScreenPtr screen,
+     for (i = 0; i < config->num_crtc; i++) {
+         enum queue_flip_status flip_status;
+         xf86CrtcPtr crtc = config->crtc[i];
+-        drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+ 
+         if (!xf86_crtc_on(crtc))
+             continue;
+@@ -414,13 +412,11 @@ ms_do_pageflip(ScreenPtr screen,
+          * outputs in a "clone-mode" or "mirror-mode" configuration.
+          */
+         if (ms->drmmode.can_async_flip && ms->drmmode.async_flip_secondaries &&
+-            (drmmode_crtc->vblank_pipe != ref_crtc_vblank_pipe) &&
+-            (ref_crtc_vblank_pipe >= 0))
++            ref_crtc && crtc != ref_crtc)
+             flags |= DRM_MODE_PAGE_FLIP_ASYNC;
+ 
+         flip_status = queue_flip_on_crtc(screen, crtc, flipdata,
+-                                         ref_crtc_vblank_pipe,
+-                                         flags);
++                                         ref_crtc, flags);
+ 
+         switch (flip_status) {
+             case QUEUE_FLIP_ALLOC_FAILED:
+diff --git a/hw/xfree86/drivers/modesetting/present.c b/hw/xfree86/drivers/modesetting/present.c
+index 642f7baaf..e147f3eda 100644
+--- a/hw/xfree86/drivers/modesetting/present.c
++++ b/hw/xfree86/drivers/modesetting/present.c
+@@ -361,7 +361,6 @@ ms_present_flip(RRCrtcPtr crtc,
+     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
+     modesettingPtr ms = modesettingPTR(scrn);
+     xf86CrtcPtr xf86_crtc = crtc->devPrivate;
+-    drmmode_crtc_private_ptr drmmode_crtc = xf86_crtc->driver_private;
+     Bool ret;
+     struct ms_present_vblank_event *event;
+ 
+@@ -389,7 +388,7 @@ ms_present_flip(RRCrtcPtr crtc,
+         ms_present_set_screen_vrr(scrn, TRUE);
+     }
+ 
+-    ret = ms_do_pageflip(screen, pixmap, event, drmmode_crtc->vblank_pipe, !sync_flip,
++    ret = ms_do_pageflip(screen, pixmap, event, xf86_crtc, !sync_flip,
+                          ms_present_flip_handler, ms_present_flip_abort,
+                          "Present-flip");
+     if (ret)
+@@ -421,7 +420,7 @@ ms_present_unflip(ScreenPtr screen, uint64_t event_id)
+     event->unflip = TRUE;
+ 
+     if (ms_present_check_unflip(NULL, screen->root, pixmap, TRUE, NULL) &&
+-        ms_do_pageflip(screen, pixmap, event, -1, FALSE,
++        ms_do_pageflip(screen, pixmap, event, NULL, FALSE,
+                        ms_present_flip_handler, ms_present_flip_abort,
+                        "Present-unflip")) {
+         return;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1045-BACKPORT-modesetting-Pass-CRTC-pointer-to-TearFree-flip-handl.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1045-BACKPORT-modesetting-Pass-CRTC-pointer-to-TearFree-flip-handl.patch
@@ -1,0 +1,55 @@
+From 7964ef3aca5b0f2e493854ade1efa0dcfaa84df8 Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sun, 22 Jan 2023 20:57:14 -0800
+Subject: [PATCH 045/105] modesetting: Pass CRTC pointer to TearFree flip
+ handlers
+
+The CRTC pointer will soon be needed in the TearFree flip handlers, so pass
+it in instead of passing in drmmode_tearfree_ptr.
+
+No functional change.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Reviewed-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ hw/xfree86/drivers/modesetting/pageflip.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/pageflip.c b/hw/xfree86/drivers/modesetting/pageflip.c
+index b0ff9655b..08a1bcd31 100644
+--- a/hw/xfree86/drivers/modesetting/pageflip.c
++++ b/hw/xfree86/drivers/modesetting/pageflip.c
+@@ -476,7 +476,9 @@ error_out:
+ static void
+ ms_tearfree_flip_abort(void *data)
+ {
+-    drmmode_tearfree_ptr trf = data;
++    xf86CrtcPtr crtc = data;
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++    drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
+ 
+     trf->flip_seq = 0;
+ }
+@@ -484,7 +486,9 @@ ms_tearfree_flip_abort(void *data)
+ static void
+ ms_tearfree_flip_handler(uint64_t msc, uint64_t usec, void *data)
+ {
+-    drmmode_tearfree_ptr trf = data;
++    xf86CrtcPtr crtc = data;
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++    drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
+ 
+     /* Swap the buffers and complete the flip */
+     trf->back_idx ^= 1;
+@@ -498,7 +502,7 @@ ms_do_tearfree_flip(ScreenPtr screen, xf86CrtcPtr crtc)
+     drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
+     uint32_t idx = trf->back_idx, seq;
+ 
+-    seq = ms_drm_queue_alloc(crtc, trf, ms_tearfree_flip_handler,
++    seq = ms_drm_queue_alloc(crtc, crtc, ms_tearfree_flip_handler,
+                              ms_tearfree_flip_abort);
+     if (!seq)
+         goto no_flip;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1046-BACKPORT-modesetting-Fix-memory-leak-on-ms_do_pageflip-error.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1046-BACKPORT-modesetting-Fix-memory-leak-on-ms_do_pageflip-error.patch
@@ -1,0 +1,67 @@
+From 6f0edd19f4b842b728021fbaded915bafbea44ce Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sun, 22 Jan 2023 20:59:32 -0800
+Subject: [PATCH 046/105] modesetting: Fix memory leak on ms_do_pageflip error
+
+The event allocation for ms_do_pageflip is leaked on error because callers
+of ms_do_pageflip have no way of knowing whether or not a page flip
+succeeded for any CRTCs. If a page flip succeeded for at least one CRTC,
+then it's not safe for the caller to free the event allocation, and the
+allocation won't be leaked. The event allocation is only leaked when not a
+single CRTC's page flip succeeded.
+
+Since all callers of ms_do_pageflip allocate the event pointer, and all of
+them intentionally leak the event allocation when ms_do_pageflip returns an
+error, just free the event pointer inside ms_do_pageflip when a page flip
+doesn't succeed for any CRTC.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Reviewed-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ hw/xfree86/drivers/modesetting/pageflip.c | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/pageflip.c b/hw/xfree86/drivers/modesetting/pageflip.c
+index 08a1bcd31..94437c0f3 100644
+--- a/hw/xfree86/drivers/modesetting/pageflip.c
++++ b/hw/xfree86/drivers/modesetting/pageflip.c
+@@ -336,7 +336,7 @@ ms_do_pageflip(ScreenPtr screen,
+         xf86DrvMsg(scrn->scrnIndex, X_ERROR,
+                    "%s: Failed to get GBM BO for flip to new front.\n",
+                    log_prefix);
+-        return FALSE;
++        goto error_free_event;
+     }
+ 
+     flipdata = calloc(1, sizeof(struct ms_flipdata));
+@@ -344,7 +344,7 @@ ms_do_pageflip(ScreenPtr screen,
+         drmmode_bo_destroy(&ms->drmmode, &new_front_bo);
+         xf86DrvMsg(scrn->scrnIndex, X_ERROR,
+                    "%s: Failed to allocate flipdata.\n", log_prefix);
+-        return FALSE;
++        goto error_free_event;
+     }
+ 
+     flipdata->event = event;
+@@ -465,11 +465,16 @@ error_out:
+     drmmode_bo_destroy(&ms->drmmode, &new_front_bo);
+     /* if only the local reference - free the structure,
+      * else drop the local reference and return */
+-    if (flipdata->flip_count == 1)
++    if (flipdata->flip_count == 1) {
+         free(flipdata);
+-    else
++    } else {
+         flipdata->flip_count--;
++        return FALSE;
++    }
+ 
++error_free_event:
++    /* Free the event since the caller has no way to know it's safe to free */
++    free(event);
+     return FALSE;
+ }
+ 
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1047-BACKPORT-modesetting-Improve-TearFree-state-check-in-ms_prese.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1047-BACKPORT-modesetting-Improve-TearFree-state-check-in-ms_prese.patch
@@ -1,0 +1,40 @@
+From ae25daf632eda78cca48d78626f392a2dc9b0ff7 Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sun, 22 Jan 2023 21:02:45 -0800
+Subject: [PATCH 047/105] modesetting: Improve TearFree state check in
+ ms_present_check_flip
+
+Check that the VT is owned and that the CRTC is on before exporting info to
+Present stating that TearFree is available. Also, since `trf->buf[0].px` is
+checked, the `ms->drmmode.tearfree_enable` check is redundant and can
+therefore be removed.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Reviewed-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ hw/xfree86/drivers/modesetting/present.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/present.c b/hw/xfree86/drivers/modesetting/present.c
+index e147f3eda..acc299f3b 100644
+--- a/hw/xfree86/drivers/modesetting/present.c
++++ b/hw/xfree86/drivers/modesetting/present.c
+@@ -329,12 +329,13 @@ ms_present_check_flip(RRCrtcPtr crtc,
+ 
+ no_flip:
+     /* Export some info about TearFree if Present can't flip anyway */
+-    if (reason && ms->drmmode.tearfree_enable) {
++    if (reason) {
+         xf86CrtcPtr xf86_crtc = crtc->devPrivate;
+         drmmode_crtc_private_ptr drmmode_crtc = xf86_crtc->driver_private;
+         drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
+ 
+-        if (trf->buf[0].px) {
++        /* Check if TearFree is active on this CRTC and tell Present about it */
++        if (trf->buf[0].px && scrn->vtSema && xf86_crtc_on(xf86_crtc)) {
+             if (trf->flip_seq)
+                 /* The driver has a TearFree flip pending */
+                 *reason = PRESENT_FLIP_REASON_DRIVER_TEARFREE_FLIPPING;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1048-BACKPORT-modesetting-Introduce-ms_tearfree_is_active_on_crtc-.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1048-BACKPORT-modesetting-Introduce-ms_tearfree_is_active_on_crtc-.patch
@@ -1,0 +1,78 @@
+From dc31fe1a5cd2a2a17adb834e2ee550adac64036c Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Tue, 14 Feb 2023 19:30:08 -0800
+Subject: [PATCH 048/105] modesetting: Introduce ms_tearfree_is_active_on_crtc
+ helper
+
+There is more than one place with the confusing TearFree state check for a
+CRTC. Instead of open-coding the TearFree check everywhere, introduce a
+helper, ms_tearfree_is_active_on_crtc, to cover the TearFree state checks.
+
+Suggested-by: Martin Roukala <martin.roukala@mupuf.org>
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Reviewed-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ hw/xfree86/drivers/modesetting/driver.c   |  3 +--
+ hw/xfree86/drivers/modesetting/driver.h   |  1 +
+ hw/xfree86/drivers/modesetting/pageflip.c | 10 ++++++++++
+ hw/xfree86/drivers/modesetting/present.c  |  3 +--
+ 4 files changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.c b/hw/xfree86/drivers/modesetting/driver.c
+index 3f185489e..5176b6d40 100644
+--- a/hw/xfree86/drivers/modesetting/driver.c
++++ b/hw/xfree86/drivers/modesetting/driver.c
+@@ -655,8 +655,7 @@ ms_tearfree_do_flips(ScreenPtr pScreen)
+         drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+         drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
+ 
+-        /* Skip disabled CRTCs and those which aren't using TearFree */
+-        if (!trf->buf[0].px || !crtc->scrn->vtSema || !xf86_crtc_on(crtc))
++        if (!ms_tearfree_is_active_on_crtc(crtc))
+             continue;
+ 
+         /* Skip if the last flip is still pending, a DRI client is flipping, or
+diff --git a/hw/xfree86/drivers/modesetting/driver.h b/hw/xfree86/drivers/modesetting/driver.h
+index 605fd8530..a54bf28ff 100644
+--- a/hw/xfree86/drivers/modesetting/driver.h
++++ b/hw/xfree86/drivers/modesetting/driver.h
+@@ -249,3 +249,4 @@ Bool ms_do_tearfree_flip(ScreenPtr screen, xf86CrtcPtr crtc);
+ int ms_flush_drm_events(ScreenPtr screen);
+ Bool ms_window_has_variable_refresh(modesettingPtr ms, WindowPtr win);
+ void ms_present_set_screen_vrr(ScrnInfoPtr scrn, Bool vrr_enabled);
++Bool ms_tearfree_is_active_on_crtc(xf86CrtcPtr crtc);
+diff --git a/hw/xfree86/drivers/modesetting/pageflip.c b/hw/xfree86/drivers/modesetting/pageflip.c
+index 94437c0f3..a804841fa 100644
+--- a/hw/xfree86/drivers/modesetting/pageflip.c
++++ b/hw/xfree86/drivers/modesetting/pageflip.c
+@@ -529,3 +529,13 @@ no_flip:
+     return TRUE;
+ }
+ #endif
++
++Bool
++ms_tearfree_is_active_on_crtc(xf86CrtcPtr crtc)
++{
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++    drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
++
++    /* If TearFree is enabled, XServer owns the VT, and the CRTC is active */
++    return trf->buf[0].px && crtc->scrn->vtSema && xf86_crtc_on(crtc);
++}
+diff --git a/hw/xfree86/drivers/modesetting/present.c b/hw/xfree86/drivers/modesetting/present.c
+index acc299f3b..89fca1a9c 100644
+--- a/hw/xfree86/drivers/modesetting/present.c
++++ b/hw/xfree86/drivers/modesetting/present.c
+@@ -334,8 +334,7 @@ no_flip:
+         drmmode_crtc_private_ptr drmmode_crtc = xf86_crtc->driver_private;
+         drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
+ 
+-        /* Check if TearFree is active on this CRTC and tell Present about it */
+-        if (trf->buf[0].px && scrn->vtSema && xf86_crtc_on(xf86_crtc)) {
++        if (ms_tearfree_is_active_on_crtc(xf86_crtc)) {
+             if (trf->flip_seq)
+                 /* The driver has a TearFree flip pending */
+                 *reason = PRESENT_FLIP_REASON_DRIVER_TEARFREE_FLIPPING;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1049-BACKPORT-modesetting-Ensure-vblank-events-always-run-in-seque.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1049-BACKPORT-modesetting-Ensure-vblank-events-always-run-in-seque.patch
@@ -1,0 +1,55 @@
+From 2a2157822ecfd242dd06f7de61256320ec1e51ac Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Wed, 25 Jan 2023 18:06:20 -0800
+Subject: [PATCH 049/105] modesetting: Ensure vblank events always run in
+ sequential order
+
+It is possible for vblank events to run out of order with respect to one
+another because the event which was queued to the kernel has the privilege
+of running before all other events are handled. This allows kernel-queued
+events to run before other, older events which should've run first.
+
+Although this isn't a huge problem now, it will become more problematic
+after the next change which ties DRI client notifications to TearFree page
+flips. This increases the likelihood of DRI clients erroneously receiving
+presentation-completion notifications out of order; i.e., a client could
+receive a notification for a newer pixmap it submitted *before* receiving a
+notification for an older pixmap.
+
+Ensure vblank events always run in sequential order by removing the bias
+towards kernel-queued events, and therefore forcing them to run at their
+sequential position in the queue like other events.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Reviewed-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ hw/xfree86/drivers/modesetting/vblank.c | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/vblank.c b/hw/xfree86/drivers/modesetting/vblank.c
+index 4d250aa34..1c5f2578f 100644
+--- a/hw/xfree86/drivers/modesetting/vblank.c
++++ b/hw/xfree86/drivers/modesetting/vblank.c
+@@ -573,10 +573,15 @@ ms_drm_sequence_handler(int fd, uint64_t frame, uint64_t ns, Bool is64bit, uint6
+         if (q->seq == seq) {
+             crtc = q->crtc;
+             msc = ms_kernel_msc_to_crtc_msc(crtc, frame, is64bit);
+-            xorg_list_del(&q->list);
+-            if (!q->aborted)
+-                q->handler(msc, ns / 1000, q->data);
+-            free(q);
++
++            /* Write the current MSC to this event to ensure its handler runs in
++             * the loop below. This is done because we don't want to run the
++             * handler right now, since we need to ensure all events are handled
++             * in FIFO order with respect to one another. Otherwise, if this
++             * event were handled first just because it was queued to the
++             * kernel, it could run before older events expiring at this MSC.
++             */
++            q->msc = msc;
+             break;
+         }
+     }
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1050-BACKPORT-modesetting-Support-accurate-DRI-presentation-timing.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1050-BACKPORT-modesetting-Support-accurate-DRI-presentation-timing.patch
@@ -1,0 +1,363 @@
+From 823e0665f9dade6375a77ff147248fb4910cea94 Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Tue, 14 Feb 2023 19:41:39 -0800
+Subject: [PATCH 050/105] modesetting: Support accurate DRI presentation timing
+ with TearFree
+
+When using TearFree, DRI clients have no way of accurately knowing when
+their copied pixmaps appear on the display without utilizing the kernel
+driver's notification indicating that the TearFree flip containing their
+pixmap is complete. This is because the target CRTC's MSC can change while
+the predicted completion MSC is calculated and even while the page flip
+IOCTL is sent to the kernel due to scheduling delays and/or unfortunate
+timing. Even worse, a page flip isn't actually guaranteed to be finished
+after one vblank; it may be several MSCs until a flip actually finishes
+depending on delays and load in hardware.
+
+As a result, DRI clients may be off by one or more MSCs when they naively
+expect their pixmaps to be visible at MSC+1 with TearFree enabled. This,
+for example, makes it impossible for DRI clients to achieve precise A/V
+synchronization when TearFree is enabled.
+
+This change therefore adds a way for DRI clients to receive a notification
+straight from the TearFree flip-done handler to know exactly when their
+pixmaps appear on the display. This is done by checking for a NULL pixmap
+pointer to modesetting's DRI flip routine, which indicates that the DRI
+client has copied its pixmap and wants TearFree to send a notification when
+the copied pixmap appears on the display as part of a TearFree flip. The
+existing PageFlip scaffolding is reused to achieve this with minimal churn.
+
+The Present extension will be updated in an upcoming change to utilize this
+new mechanism for DRI clients' presentations.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Acked-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ hw/xfree86/drivers/modesetting/driver.c       |   5 +-
+ hw/xfree86/drivers/modesetting/driver.h       |   8 +
+ .../drivers/modesetting/drmmode_display.c     |   1 +
+ .../drivers/modesetting/drmmode_display.h     |   1 +
+ hw/xfree86/drivers/modesetting/pageflip.c     | 154 +++++++++++++++++-
+ hw/xfree86/drivers/modesetting/present.c      |  17 +-
+ 6 files changed, 182 insertions(+), 4 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.c b/hw/xfree86/drivers/modesetting/driver.c
+index 5176b6d40..9a69452bd 100644
+--- a/hw/xfree86/drivers/modesetting/driver.c
++++ b/hw/xfree86/drivers/modesetting/driver.c
+@@ -655,8 +655,11 @@ ms_tearfree_do_flips(ScreenPtr pScreen)
+         drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+         drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
+ 
+-        if (!ms_tearfree_is_active_on_crtc(crtc))
++        if (!ms_tearfree_is_active_on_crtc(crtc)) {
++            /* Notify any lingering DRI clients waiting for a flip to finish */
++            ms_tearfree_dri_abort_all(crtc);
+             continue;
++        }
+ 
+         /* Skip if the last flip is still pending, a DRI client is flipping, or
+          * there isn't any damage on the front buffer.
+diff --git a/hw/xfree86/drivers/modesetting/driver.h b/hw/xfree86/drivers/modesetting/driver.h
+index a54bf28ff..e302c067d 100644
+--- a/hw/xfree86/drivers/modesetting/driver.h
++++ b/hw/xfree86/drivers/modesetting/driver.h
+@@ -242,6 +242,14 @@ Bool ms_do_pageflip(ScreenPtr screen,
+                     ms_pageflip_abort_proc pageflip_abort,
+                     const char *log_prefix);
+ 
++Bool
++ms_tearfree_dri_abort(xf86CrtcPtr crtc,
++                      Bool (*match)(void *data, void *match_data),
++                      void *match_data);
++
++void
++ms_tearfree_dri_abort_all(xf86CrtcPtr crtc);
++
+ Bool ms_do_tearfree_flip(ScreenPtr screen, xf86CrtcPtr crtc);
+ 
+ #endif
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
+index 6583fdd14..54ab18fbb 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
+@@ -2529,6 +2529,7 @@ drmmode_crtc_init(ScrnInfoPtr pScrn, drmmode_ptr drmmode, drmModeResPtr mode_res
+     drmmode_crtc->drmmode = drmmode;
+     drmmode_crtc->vblank_pipe = drmmode_crtc_vblank_pipe(num);
+     xorg_list_init(&drmmode_crtc->mode_list);
++    xorg_list_init(&drmmode_crtc->tearfree.dri_flip_list);
+     drmmode_crtc->next_msc = UINT64_MAX;
+ 
+     props = drmModeObjectGetProperties(drmmode->fd, mode_res->crtcs[num],
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.h b/hw/xfree86/drivers/modesetting/drmmode_display.h
+index 145cb8cc7..b4074a30f 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.h
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.h
+@@ -176,6 +176,7 @@ typedef struct {
+ 
+ typedef struct {
+     drmmode_shadow_fb_rec buf[2];
++    struct xorg_list dri_flip_list;
+     uint32_t back_idx;
+     uint32_t flip_seq;
+ } drmmode_tearfree_rec, *drmmode_tearfree_ptr;
+diff --git a/hw/xfree86/drivers/modesetting/pageflip.c b/hw/xfree86/drivers/modesetting/pageflip.c
+index a804841fa..c1ee542b7 100644
+--- a/hw/xfree86/drivers/modesetting/pageflip.c
++++ b/hw/xfree86/drivers/modesetting/pageflip.c
+@@ -99,6 +99,8 @@ struct ms_crtc_pageflip {
+     Bool on_reference_crtc;
+     /* reference to the ms_flipdata */
+     struct ms_flipdata *flipdata;
++    struct xorg_list node;
++    uint32_t tearfree_seq;
+ };
+ 
+ /**
+@@ -142,7 +144,8 @@ ms_pageflip_handler(uint64_t msc, uint64_t ust, void *data)
+                                 flipdata->fe_usec,
+                                 flipdata->event);
+ 
+-        drmModeRmFB(ms->fd, flipdata->old_fb_id);
++        if (flipdata->old_fb_id)
++            drmModeRmFB(ms->fd, flipdata->old_fb_id);
+     }
+     ms_pageflip_free(flip);
+ }
+@@ -309,6 +312,64 @@ ms_print_pageflip_error(int screen_index, const char *log_prefix,
+     }
+ }
+ 
++static Bool
++ms_tearfree_dri_flip(modesettingPtr ms, xf86CrtcPtr crtc, void *event,
++                     ms_pageflip_handler_proc pageflip_handler,
++                     ms_pageflip_abort_proc pageflip_abort)
++{
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++    drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
++    struct ms_crtc_pageflip *flip;
++    struct ms_flipdata *flipdata;
++    RegionRec region;
++    RegionPtr dirty;
++
++    if (!ms_tearfree_is_active_on_crtc(crtc))
++        return FALSE;
++
++    /* Check for damage on the primary scanout to know if TearFree will flip */
++    dirty = DamageRegion(ms->damage);
++    if (RegionNil(dirty))
++        return FALSE;
++
++    /* Compute how much of the current damage intersects with this CRTC */
++    RegionInit(&region, &crtc->bounds, 0);
++    RegionIntersect(&region, &region, dirty);
++
++    /* No damage on this CRTC means no TearFree flip. This means the DRI client
++     * didn't change this CRTC's contents at all with its presentation, possibly
++     * because its window is fully occluded by another window on this CRTC.
++     */
++    if (RegionNil(&region))
++        return FALSE;
++
++    flip = calloc(1, sizeof(*flip));
++    if (!flip)
++        return FALSE;
++
++    flipdata = calloc(1, sizeof(*flipdata));
++    if (!flipdata) {
++        free(flip);
++        return FALSE;
++    }
++
++    /* Only track the DRI client's fake flip on the reference CRTC, which aligns
++     * with the behavior of Present when a client copies its pixmap rather than
++     * directly flipping it onto the display.
++     */
++    flip->on_reference_crtc = TRUE;
++    flip->flipdata = flipdata;
++    flip->tearfree_seq = trf->flip_seq;
++    flipdata->screen = xf86ScrnToScreen(crtc->scrn);
++    flipdata->event = event;
++    flipdata->flip_count = 1;
++    flipdata->event_handler = pageflip_handler;
++    flipdata->abort_handler = pageflip_abort;
++
++    /* Keep the list in FIFO order so that clients are notified in order */
++    xorg_list_append(&flip->node, &trf->dri_flip_list);
++    return TRUE;
++}
+ 
+ Bool
+ ms_do_pageflip(ScreenPtr screen,
+@@ -327,6 +388,22 @@ ms_do_pageflip(ScreenPtr screen,
+     uint32_t flags;
+     int i;
+     struct ms_flipdata *flipdata;
++
++    /* A NULL pixmap indicates this DRI client's pixmap is to be flipped through
++     * TearFree instead. The pixmap is already copied to the primary scanout at
++     * this point, so all that's left is to wire up this fake flip to TearFree
++     * so that TearFree can send a notification to the DRI client when the
++     * pixmap actually appears on the display. This is the only way to let DRI
++     * clients accurately know when their pixmaps appear on the display when
++     * TearFree is enabled.
++     */
++    if (!new_front) {
++        if (!ms_tearfree_dri_flip(ms, ref_crtc, event, pageflip_handler,
++                                  pageflip_abort))
++            goto error_free_event;
++        return TRUE;
++    }
++
+     ms->glamor.block_handler(screen);
+ 
+     new_front_bo.gbm = ms->glamor.gbm_bo_from_pixmap(screen, new_front);
+@@ -478,6 +555,69 @@ error_free_event:
+     return FALSE;
+ }
+ 
++Bool
++ms_tearfree_dri_abort(xf86CrtcPtr crtc,
++                      Bool (*match)(void *data, void *match_data),
++                      void *match_data)
++{
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++    drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
++    struct ms_crtc_pageflip *flip;
++
++    /* The window is getting destroyed; abort without notifying the client */
++    xorg_list_for_each_entry(flip, &trf->dri_flip_list, node) {
++        if (match(flip->flipdata->event, match_data)) {
++            xorg_list_del(&flip->node);
++            ms_pageflip_abort(flip);
++            return TRUE;
++        }
++    }
++
++    return FALSE;
++}
++
++void
++ms_tearfree_dri_abort_all(xf86CrtcPtr crtc)
++{
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++    drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
++    struct ms_crtc_pageflip *flip, *tmp;
++    uint64_t usec = 0, msc = 0;
++
++    /* Nothing to abort if there aren't any DRI clients waiting for a flip */
++    if (xorg_list_is_empty(&trf->dri_flip_list))
++        return;
++
++    /* Even though we're aborting, these clients' pixmaps were actually blitted,
++     * so technically the presentation isn't aborted. That's why the normal
++     * handler is called instead of the abort handler, along with the current
++     * time and MSC for this CRTC.
++     */
++    ms_get_crtc_ust_msc(crtc, &usec, &msc);
++    xorg_list_for_each_entry_safe(flip, tmp, &trf->dri_flip_list, node)
++        ms_pageflip_handler(msc, usec, flip);
++    xorg_list_init(&trf->dri_flip_list);
++}
++
++static void
++ms_tearfree_dri_notify(drmmode_tearfree_ptr trf, uint64_t msc, uint64_t usec)
++{
++    struct ms_crtc_pageflip *flip, *tmp;
++
++    xorg_list_for_each_entry_safe(flip, tmp, &trf->dri_flip_list, node) {
++        /* If a TearFree flip was already pending at the time this DRI client's
++         * pixmap was copied, then the pixmap isn't contained in this TearFree
++         * flip, but will be part of the next TearFree flip instead.
++         */
++        if (flip->tearfree_seq) {
++            flip->tearfree_seq = 0;
++        } else {
++            xorg_list_del(&flip->node);
++            ms_pageflip_handler(msc, usec, flip);
++        }
++    }
++}
++
+ static void
+ ms_tearfree_flip_abort(void *data)
+ {
+@@ -486,6 +626,7 @@ ms_tearfree_flip_abort(void *data)
+     drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
+ 
+     trf->flip_seq = 0;
++    ms_tearfree_dri_abort_all(crtc);
+ }
+ 
+ static void
+@@ -498,6 +639,9 @@ ms_tearfree_flip_handler(uint64_t msc, uint64_t usec, void *data)
+     /* Swap the buffers and complete the flip */
+     trf->back_idx ^= 1;
+     trf->flip_seq = 0;
++
++    /* Notify DRI clients that their pixmaps are now visible on the display */
++    ms_tearfree_dri_notify(trf, msc, usec);
+ }
+ 
+ Bool
+@@ -509,8 +653,14 @@ ms_do_tearfree_flip(ScreenPtr screen, xf86CrtcPtr crtc)
+ 
+     seq = ms_drm_queue_alloc(crtc, crtc, ms_tearfree_flip_handler,
+                              ms_tearfree_flip_abort);
+-    if (!seq)
++    if (!seq) {
++        /* Need to notify the DRI clients if a sequence wasn't allocated. Once a
++         * sequence is allocated, explicitly performing this cleanup isn't
++         * necessary since it's already done as part of aborting the sequence.
++         */
++        ms_tearfree_dri_abort_all(crtc);
+         goto no_flip;
++    }
+ 
+     /* Copy the damage to the back buffer and then flip it at the vblank */
+     drmmode_copy_damage(crtc, trf->buf[idx].px, &trf->buf[idx].dmg, TRUE);
+diff --git a/hw/xfree86/drivers/modesetting/present.c b/hw/xfree86/drivers/modesetting/present.c
+index 89fca1a9c..3d8f16aa9 100644
+--- a/hw/xfree86/drivers/modesetting/present.c
++++ b/hw/xfree86/drivers/modesetting/present.c
+@@ -165,6 +165,13 @@ ms_present_abort_vblank(RRCrtcPtr crtc, uint64_t event_id, uint64_t msc)
+ {
+     ScreenPtr screen = crtc->pScreen;
+     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
++#ifdef GLAMOR_HAS_GBM
++    xf86CrtcPtr xf86_crtc = crtc->devPrivate;
++
++    /* Check if this is a fake flip routed through TearFree and abort it */
++    if (ms_tearfree_dri_abort(xf86_crtc, ms_present_event_match, &event_id))
++        return;
++#endif
+ 
+     ms_drm_abort(scrn, ms_present_event_match, &event_id);
+ }
+@@ -364,7 +371,9 @@ ms_present_flip(RRCrtcPtr crtc,
+     Bool ret;
+     struct ms_present_vblank_event *event;
+ 
+-    if (!ms_present_check_flip(crtc, ms->flip_window, pixmap, sync_flip, NULL))
++    /* A NULL pixmap means this is a fake flip to be routed through TearFree */
++    if (pixmap &&
++        !ms_present_check_flip(crtc, ms->flip_window, pixmap, sync_flip, NULL))
+         return FALSE;
+ 
+     event = calloc(1, sizeof(struct ms_present_vblank_event));
+@@ -377,6 +386,12 @@ ms_present_flip(RRCrtcPtr crtc,
+     event->event_id = event_id;
+     event->unflip = FALSE;
+ 
++    /* Register the fake flip (indicated by a NULL pixmap) with TearFree */
++    if (!pixmap)
++        return ms_do_pageflip(screen, NULL, event, xf86_crtc, FALSE,
++                              ms_present_flip_handler, ms_present_flip_abort,
++                              "Present-TearFree-flip");
++
+     /* A window can only flip if it covers the entire X screen.
+      * Only one window can flip at a time.
+      *
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1051-BACKPORT-present-Prevent-double-vblank-enqueue-on-error-when-.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1051-BACKPORT-present-Prevent-double-vblank-enqueue-on-error-when-.patch
@@ -1,0 +1,85 @@
+From 35e5344810485a34fb21b3b81be9a6d017e396c4 Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sun, 22 Jan 2023 22:16:58 -0800
+Subject: [PATCH 051/105] present: Prevent double vblank enqueue on error when
+ TearFree is used
+
+It's possible for present_execute_copy to enqueue a vblank even when
+TearFree is used, specifically when the present_queue_vblank in
+present_scmd_pixmap fails and the subsequent vblank enqueue in
+present_execute_copy somehow doesn't. This could happen if the DRM event
+queue is exhausted when present_queue_vblank is called, but is no longer
+exhausted by the time present_execute_copy is reached.
+
+This exceedingly unlikely chain of events can lead to a vblank getting
+enqueued a second time by the TearFree machinery in present_execute, which
+is not good.
+
+Although this scenario is very unlikely, prevent it by first checking that
+the vblank wasn't enqueued by present_execute_copy before attempting to
+enqueue it for TearFree.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Acked-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ present/present_scmd.c | 36 +++++++++++++++++++-----------------
+ 1 file changed, 19 insertions(+), 17 deletions(-)
+
+diff --git a/present/present_scmd.c b/present/present_scmd.c
+index 46fd9a1fd..5cec31ab8 100644
+--- a/present/present_scmd.c
++++ b/present/present_scmd.c
+@@ -554,7 +554,6 @@ present_execute(present_vblank_ptr vblank, uint64_t ust, uint64_t crtc_msc)
+     WindowPtr                   window = vblank->window;
+     ScreenPtr                   screen = window->drawable.pScreen;
+     present_screen_priv_ptr     screen_priv = present_screen_priv(screen);
+-    uint64_t                    completion_msc;
+     if (vblank && vblank->crtc) {
+         screen_priv=present_screen_priv(vblank->crtc->pScreen);
+     }
+@@ -652,23 +651,26 @@ present_execute(present_vblank_ptr vblank, uint64_t ust, uint64_t crtc_msc)
+          * If TearFree is already flipping then the presentation will be visible
+          * at the *next* next vblank.
+          */
+-        completion_msc = crtc_msc + 1;
+-        switch (vblank->reason) {
+-        case PRESENT_FLIP_REASON_DRIVER_TEARFREE_FLIPPING:
+-            if (vblank->exec_msc < crtc_msc)
+-                completion_msc++;
+-        case PRESENT_FLIP_REASON_DRIVER_TEARFREE:
+-            if (Success == screen_priv->queue_vblank(screen,
+-                                                     window,
+-                                                     vblank->crtc,
+-                                                     vblank->event_id,
+-                                                     completion_msc)) {
+-                /* Ensure present_execute_post() runs at the next MSC */
+-                vblank->exec_msc = vblank->target_msc;
+-                vblank->queued = TRUE;
++        if (!vblank->queued) {
++            uint64_t completion_msc = crtc_msc + 1;
++
++            switch (vblank->reason) {
++            case PRESENT_FLIP_REASON_DRIVER_TEARFREE_FLIPPING:
++                if (vblank->exec_msc < crtc_msc)
++                    completion_msc++;
++            case PRESENT_FLIP_REASON_DRIVER_TEARFREE:
++                if (Success == screen_priv->queue_vblank(screen,
++                                                         window,
++                                                         vblank->crtc,
++                                                         vblank->event_id,
++                                                         completion_msc)) {
++                    /* Ensure present_execute_post() runs at the next MSC */
++                    vblank->exec_msc = vblank->target_msc;
++                    vblank->queued = TRUE;
++                }
++            default:
++                break;
+             }
+-        default:
+-            break;
+         }
+ 
+         if (vblank->queued) {
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1052-BACKPORT-present-Fix-inaccurate-PresentCompleteNotify-timing-.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1052-BACKPORT-present-Fix-inaccurate-PresentCompleteNotify-timing-.patch
@@ -1,0 +1,99 @@
+From 0e66f8053966f21e0900046fc54e1da27c75ea6b Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sun, 22 Jan 2023 23:31:52 -0800
+Subject: [PATCH 052/105] present: Fix inaccurate PresentCompleteNotify timing
+ for TearFree
+
+The timing of PresentCompleteNotify events is inaccurate when a driver uses
+TearFree because there's no way to know exactly when a presentation will
+appear on the display without receiving a notification directly from the
+driver indicating that the TearFree flip containing a presentation's pixmap
+is actually visible on the display.
+
+To fix the inaccurate PresentCompleteNotify timing, make use of the new
+assumption that drivers which export TearFree permit a NULL pixmap to be
+passed to their flip callback in order to make a presentation track the
+exact TearFree flip responsible for rendering it onto the display.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Acked-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ present/present_scmd.c | 58 +++++++++++++++++++++++++++---------------
+ 1 file changed, 38 insertions(+), 20 deletions(-)
+
+diff --git a/present/present_scmd.c b/present/present_scmd.c
+index 5cec31ab8..de8cd09c2 100644
+--- a/present/present_scmd.c
++++ b/present/present_scmd.c
+@@ -646,30 +646,48 @@ present_execute(present_vblank_ptr vblank, uint64_t ust, uint64_t crtc_msc)
+ 
+         present_execute_copy(vblank, crtc_msc);
+ 
+-        /* The presentation will be visible at the next vblank with TearFree, so
+-         * the PresentComplete notification needs to be sent at the next vblank.
+-         * If TearFree is already flipping then the presentation will be visible
+-         * at the *next* next vblank.
++        /* With TearFree, there's no way to tell exactly when the presentation
++         * will be visible except by waiting for a notification from the kernel
++         * driver indicating that the page flip is complete. This is because the
++         * CRTC's MSC can change while the target MSC is calculated and even
++         * while the page flip IOCTL is sent to the kernel due to scheduling
++         * delays and/or unfortunate timing. Even worse, a page flip isn't
++         * actually guaranteed to be finished after one vblank; it may be
++         * several MSCs until a flip actually finishes depending on delays and
++         * load in hardware.
++         *
++         * So, to get a notification from the driver with TearFree active, the
++         * driver expects a present_flip() call with a NULL pixmap to indicate
++         * that this is a fake flip for a pixmap that's already been copied to
++         * the primary scanout, which will then be flipped by TearFree. TearFree
++         * will then send a notification once the flip containing this pixmap is
++         * complete.
++         *
++         * If the fake flip attempt fails, then fall back to just enqueuing a
++         * vblank event targeting the next MSC.
+          */
+-        if (!vblank->queued) {
++        if (!vblank->queued &&
++            vblank->reason >= PRESENT_FLIP_REASON_DRIVER_TEARFREE) {
+             uint64_t completion_msc = crtc_msc + 1;
+ 
+-            switch (vblank->reason) {
+-            case PRESENT_FLIP_REASON_DRIVER_TEARFREE_FLIPPING:
+-                if (vblank->exec_msc < crtc_msc)
++            /* If TearFree is already flipping then the presentation will be
++             * visible at the *next* next vblank. This calculation only matters
++             * for the vblank event fallback.
++             */
++            if (vblank->reason == PRESENT_FLIP_REASON_DRIVER_TEARFREE_FLIPPING &&
++                vblank->exec_msc < crtc_msc)
+                     completion_msc++;
+-            case PRESENT_FLIP_REASON_DRIVER_TEARFREE:
+-                if (Success == screen_priv->queue_vblank(screen,
+-                                                         window,
+-                                                         vblank->crtc,
+-                                                         vblank->event_id,
+-                                                         completion_msc)) {
+-                    /* Ensure present_execute_post() runs at the next MSC */
+-                    vblank->exec_msc = vblank->target_msc;
+-                    vblank->queued = TRUE;
+-                }
+-            default:
+-                break;
++
++            /* Try the fake flip first and then fall back to a vblank event */
++            if (present_flip(vblank->crtc, vblank->event_id, 0, NULL, TRUE) ||
++                Success == screen_priv->queue_vblank(screen,
++                                                     window,
++                                                     vblank->crtc,
++                                                     vblank->event_id,
++                                                     completion_msc)) {
++                /* Ensure present_execute_post() runs at the next execution */
++                vblank->exec_msc = vblank->target_msc;
++                vblank->queued = TRUE;
+             }
+         }
+ 
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1053-BACKPORT-present-Document-the-TearFree-flip-reasons-in-Presen.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1053-BACKPORT-present-Document-the-TearFree-flip-reasons-in-Presen.patch
@@ -1,0 +1,37 @@
+From 4c12d943752d93cdd17a4f35b2f0268ac7547bc1 Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Tue, 14 Feb 2023 19:41:50 -0800
+Subject: [PATCH 053/105] present: Document the TearFree flip reasons in
+ PresentFlipReason
+
+Adding new flip reasons after the TearFree ones would break the assumption
+that `reason >= PRESENT_FLIP_REASON_DRIVER_TEARFREE` implies either of the
+TearFree reasons. Document this in the PresentFlipReason enum in order to
+save someone a very bad headache in the future.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Reviewed-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ present/present.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/present/present.h b/present/present.h
+index 1d7b0ce42..a3f34a929 100644
+--- a/present/present.h
++++ b/present/present.h
+@@ -30,6 +30,12 @@
+ typedef enum {
+     PRESENT_FLIP_REASON_UNKNOWN,
+     PRESENT_FLIP_REASON_BUFFER_FORMAT,
++
++    /* Don't add new flip reasons after the TearFree ones, since it's expected
++     * that the TearFree reasons are the highest ones in order to allow doing
++     * `reason >= PRESENT_FLIP_REASON_DRIVER_TEARFREE` to check if a reason is
++     * PRESENT_FLIP_REASON_DRIVER_TEARFREE{_FLIPPING}.
++     */
+     PRESENT_FLIP_REASON_DRIVER_TEARFREE,
+     PRESENT_FLIP_REASON_DRIVER_TEARFREE_FLIPPING
+ } PresentFlipReason;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1054-BACKPORT-glamor-Don-t-glFlush-ctx-switch-unless-any-work-has-.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1054-BACKPORT-glamor-Don-t-glFlush-ctx-switch-unless-any-work-has-.patch
@@ -1,0 +1,106 @@
+From be5b350d2b64c29ffa0fbdd9a1451490ae066679 Mon Sep 17 00:00:00 2001
+From: Joshua Ashton <joshua@froggi.es>
+Date: Fri, 17 Mar 2023 12:31:44 +0000
+Subject: [PATCH 054/105] glamor: Don't glFlush/ctx switch unless any work has
+ been performed
+
+`glamor_make_current` is always called before any calls to GL.
+
+Apply some dirty-tracking to whenever we call `glamor_make_current` so
+that we can avoid a decent amount of redundant GL work on each
+Dispatch cycle.
+
+Gamescope previously was waking up an empty Xwayland server with an
+XQueryPointer and I noticed a significant amount of churn doing
+redundant GL work.
+
+This has been addressed on the Gamescope side as well, but avoiding any
+useless GL context switches and flushes when glamor is doing nothing
+is still beneficial for CPU and power usage on portable devices.
+
+Signed-off-by: Joshua Ashton <joshua@froggi.es>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+Acked-by: Olivier Fourdan <ofourdan@redhat.com
+---
+ glamor/glamor.c       |  7 ++-----
+ glamor/glamor_priv.h  |  1 +
+ glamor/glamor_sync.c  |  3 +--
+ glamor/glamor_utils.h | 11 +++++++++++
+ 4 files changed, 15 insertions(+), 7 deletions(-)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index f15b5a18a..0cbc89ee4 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -271,9 +271,7 @@ void
+ glamor_block_handler(ScreenPtr screen)
+ {
+     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+-
+-    glamor_make_current(glamor_priv);
+-    glFlush();
++    glamor_flush(glamor_priv);
+ }
+ 
+ static void
+@@ -281,8 +279,7 @@ _glamor_block_handler(ScreenPtr screen, void *timeout)
+ {
+     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+ 
+-    glamor_make_current(glamor_priv);
+-    glFlush();
++    glamor_flush(glamor_priv);
+ 
+     screen->BlockHandler = glamor_priv->saved_procs.block_handler;
+     screen->BlockHandler(screen, timeout);
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index da20bc5aa..1032b880b 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -314,6 +314,7 @@ typedef struct glamor_screen_private {
+     Bool suppress_gl_out_of_memory_logging;
+     Bool logged_any_fbo_allocation_failure;
+     Bool logged_any_pbo_allocation_failure;
++    Bool dirty;
+ 
+     /* xv */
+     glamor_program xv_prog;
+diff --git a/glamor/glamor_sync.c b/glamor/glamor_sync.c
+index 907e0c613..3f98be400 100644
+--- a/glamor/glamor_sync.c
++++ b/glamor/glamor_sync.c
+@@ -52,8 +52,7 @@ glamor_sync_fence_set_triggered (SyncFence *fence)
+ 	struct glamor_sync_fence *glamor_fence = glamor_get_sync_fence(fence);
+ 
+ 	/* Flush pending rendering operations */
+-        glamor_make_current(glamor);
+-        glFlush();
++	glamor_flush(glamor);
+ 
+ 	fence->funcs.SetTriggered = glamor_fence->set_triggered;
+ 	fence->funcs.SetTriggered(fence);
+diff --git a/glamor/glamor_utils.h b/glamor/glamor_utils.h
+index 93a933eed..bee48d989 100644
+--- a/glamor/glamor_utils.h
++++ b/glamor/glamor_utils.h
+@@ -672,6 +672,17 @@ glamor_make_current(glamor_screen_private *glamor_priv)
+         lastGLContext = glamor_priv->ctx.ctx;
+         glamor_priv->ctx.make_current(&glamor_priv->ctx);
+     }
++    glamor_priv->dirty = TRUE;
++}
++
++static inline void
++glamor_flush(glamor_screen_private *glamor_priv)
++{
++    if (glamor_priv->dirty) {
++        glamor_make_current(glamor_priv);
++        glFlush();
++        glamor_priv->dirty = FALSE;
++    }
+ }
+ 
+ static inline BoxRec
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1055-BACKPORT-glamor-Fix-build-without-GBM.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1055-BACKPORT-glamor-Fix-build-without-GBM.patch
@@ -1,0 +1,41 @@
+From f795be00d2aee9da2ad800cb1d9a54642adcd75f Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Thu, 6 Apr 2023 16:12:54 +0200
+Subject: [PATCH 055/105] glamor: Fix build without GBM
+
+The functions glamor_egl_fd_from_pixmap()/glamor_egl_fds_from_pixmap()
+are not available without GBM support.
+
+So if GBM is not available or too old, the code would fail to link
+trying to find the references to those functions.
+
+Make sure we skip that code when glamor is built without GBM.
+
+Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
+---
+ glamor/glamor.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index 0cbc89ee4..617766c2a 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -1003,6 +1003,7 @@ _glamor_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
+                         uint32_t *strides, uint32_t *offsets,
+                         CARD32 *size, uint64_t *modifier)
+ {
++#ifdef GLAMOR_HAS_GBM
+     glamor_pixmap_private *pixmap_priv = glamor_get_pixmap_private(pixmap);
+     glamor_screen_private *glamor_priv =
+         glamor_get_screen_private(pixmap->drawable.pScreen);
+@@ -1030,6 +1031,7 @@ _glamor_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
+     default:
+         break;
+     }
++#endif /* GLAMOR_HAS_GBM */
+     return 0;
+ }
+ 
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1056-BACKPORT-fb-Declare-wfbFinishScreenInit-wfbScreenInit-for-FB_.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1056-BACKPORT-fb-Declare-wfbFinishScreenInit-wfbScreenInit-for-FB_.patch
@@ -1,0 +1,39 @@
+From 006fc8ff493d20ec0891617b54e3e7f65f21a826 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Thu, 13 Apr 2023 15:45:58 +0200
+Subject: [PATCH 056/105] fb: Declare wfbFinishScreenInit, wfbScreenInit for
+ !FB_ACCESS_WRAPPER
+
+xf86-video-nouveau calls wfbScreenInit without defining
+FB_ACCESS_WRAPPER (which has other unintended side effects).
+Presently, this compiles and links because compilers still support
+implicit function declarations, but this is going to change fairly
+soon.  This seems to be the most straightforward change to keep
+the driver building.
+---
+ fb/fb.h | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/fb/fb.h b/fb/fb.h
+index 8ab050d0f..02e4731f8 100644
+--- a/fb/fb.h
++++ b/fb/fb.h
+@@ -1027,7 +1027,6 @@ extern _X_EXPORT Bool
+                int dpiy, int width,     /* pixel width of frame buffer */
+                int bpp);        /* bits per pixel of frame buffer */
+ 
+-#ifdef FB_ACCESS_WRAPPER
+ extern _X_EXPORT Bool
+ wfbFinishScreenInit(ScreenPtr pScreen,
+                     void *pbits,
+@@ -1049,7 +1048,6 @@ wfbScreenInit(ScreenPtr pScreen,
+               int width,
+               int bpp,
+               SetupWrapProcPtr setupWrap, FinishWrapProcPtr finishWrap);
+-#endif
+ 
+ extern _X_EXPORT Bool
+ fbFinishScreenInit(ScreenPtr pScreen,
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1057-BACKPORT-logind-call-SetType-on-the-logind-session.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1057-BACKPORT-logind-call-SetType-on-the-logind-session.patch
@@ -1,0 +1,64 @@
+From 9894734ea3589dde3a72763dc683c4564e91af17 Mon Sep 17 00:00:00 2001
+From: Aaron Dill <aaronsacks2006@gmail.com>
+Date: Mon, 12 Jun 2023 22:48:03 +0000
+Subject: [PATCH 057/105] logind: call SetType on the logind session
+
+This allows manual handling of IdleAction and IdleHint rather than automatically
+calling the IdleAction every IdleSecs, due to inactivity on the underlying tty.
+Fixes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1194
+
+Signed-off-by: aarondill <aaronsacks2006@gmail.com>
+Reviewed-by: Hans de Goede <hdegoede@redhat.com>
+---
+ hw/xfree86/os-support/linux/systemd-logind.c | 28 ++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/hw/xfree86/os-support/linux/systemd-logind.c b/hw/xfree86/os-support/linux/systemd-logind.c
+index d97e92ff8..16a9df675 100644
+--- a/hw/xfree86/os-support/linux/systemd-logind.c
++++ b/hw/xfree86/os-support/linux/systemd-logind.c
+@@ -444,6 +444,7 @@ message_filter(DBusConnection * connection, DBusMessage * message, void *data)
+ static void
+ connect_hook(DBusConnection *connection, void *data)
+ {
++    const char *session_type = "x11";
+     struct systemd_logind_info *info = data;
+     DBusError error;
+     DBusMessage *msg = NULL;
+@@ -510,6 +511,33 @@ connect_hook(DBusConnection *connection, void *data)
+                    error.message);
+         goto cleanup;
+     }
++    dbus_message_unref(msg);
++    dbus_message_unref(reply);
++    reply = NULL;
++
++    msg = dbus_message_new_method_call("org.freedesktop.login1",
++            session, "org.freedesktop.login1.Session", "SetType");
++    if (!msg) {
++        LogMessage(X_ERROR, "systemd-logind: out of memory\n");
++        goto cleanup;
++    }
++
++    if (!dbus_message_append_args(msg, DBUS_TYPE_STRING, &session_type,
++                                  DBUS_TYPE_INVALID)) {
++        LogMessage(X_ERROR, "systemd-logind: out of memory\n");
++        goto cleanup;
++    }
++
++    reply = dbus_connection_send_with_reply_and_block(connection, msg,
++                                                      DBUS_TIMEOUT_USE_DEFAULT, &error);
++    /* Requires systemd >= 246, SetType() is not critical for xserver function */
++    if (!reply) {
++        /* unprevileged users get access denied rather than unknown method */
++        if (!dbus_error_has_name(&error, DBUS_ERROR_ACCESS_DENIED) &&
++            !dbus_error_has_name(&error, DBUS_ERROR_UNKNOWN_METHOD))
++            LogMessage(X_WARNING, "systemd-logind: SetType failed: %s\n", error.message);
++        dbus_error_free(&error);
++    }
+ 
+     dbus_bus_add_match(connection,
+         "type='signal',sender='org.freedesktop.login1',interface='org.freedesktop.login1.Session',member='PauseDevice'",
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1058-BACKPORT-glamor-Remove-unused-transfer-functions.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1058-BACKPORT-glamor-Remove-unused-transfer-functions.patch
@@ -1,0 +1,103 @@
+From 25430c3a60abab3318d321b7e99ab6cbf5aeb7a1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Sat, 24 Jun 2023 11:08:01 +0200
+Subject: [PATCH 058/105] glamor: Remove unused transfer functions
+
+Never used AFAICT.
+---
+ glamor/glamor_transfer.c | 50 ----------------------------------------
+ glamor/glamor_transfer.h |  9 --------
+ 2 files changed, 59 deletions(-)
+
+diff --git a/glamor/glamor_transfer.c b/glamor/glamor_transfer.c
+index e706e0fb4..842114235 100644
+--- a/glamor/glamor_transfer.c
++++ b/glamor/glamor_transfer.c
+@@ -107,22 +107,6 @@ glamor_upload_region(PixmapPtr pixmap, RegionPtr region,
+                         bits, byte_stride);
+ }
+ 
+-/*
+- * Take the data in the pixmap and stuff it back into the FBO
+- */
+-void
+-glamor_upload_pixmap(PixmapPtr pixmap)
+-{
+-    BoxRec box;
+-
+-    box.x1 = 0;
+-    box.x2 = pixmap->drawable.width;
+-    box.y1 = 0;
+-    box.y2 = pixmap->drawable.height;
+-    glamor_upload_boxes(pixmap, &box, 1, 0, 0, 0, 0,
+-                        pixmap->devPrivate.ptr, pixmap->devKind);
+-}
+-
+ /*
+  * Read stuff from the pixmap FBOs and write to memory
+  */
+@@ -182,37 +166,3 @@ glamor_download_boxes(PixmapPtr pixmap, BoxPtr in_boxes, int in_nbox,
+     if (glamor_priv->has_pack_subimage)
+         glPixelStorei(GL_PACK_ROW_LENGTH, 0);
+ }
+-
+-/*
+- * Read data from the pixmap FBO
+- */
+-void
+-glamor_download_rect(PixmapPtr pixmap, int x, int y, int w, int h, uint8_t *bits)
+-{
+-    BoxRec      box;
+-
+-    box.x1 = x;
+-    box.x2 = x + w;
+-    box.y1 = y;
+-    box.y2 = y + h;
+-
+-    glamor_download_boxes(pixmap, &box, 1, 0, 0, -x, -y,
+-                          bits, PixmapBytePad(w, pixmap->drawable.depth));
+-}
+-
+-/*
+- * Pull the data from the FBO down to the pixmap
+- */
+-void
+-glamor_download_pixmap(PixmapPtr pixmap)
+-{
+-    BoxRec      box;
+-
+-    box.x1 = 0;
+-    box.x2 = pixmap->drawable.width;
+-    box.y1 = 0;
+-    box.y2 = pixmap->drawable.height;
+-
+-    glamor_download_boxes(pixmap, &box, 1, 0, 0, 0, 0,
+-                          pixmap->devPrivate.ptr, pixmap->devKind);
+-}
+diff --git a/glamor/glamor_transfer.h b/glamor/glamor_transfer.h
+index a6137b3ff..26b5a6b0d 100644
+--- a/glamor/glamor_transfer.h
++++ b/glamor/glamor_transfer.h
+@@ -34,19 +34,10 @@ glamor_upload_region(PixmapPtr pixmap, RegionPtr region,
+                      int region_x, int region_y,
+                      uint8_t *bits, uint32_t byte_stride);
+ 
+-void
+-glamor_upload_pixmap(PixmapPtr pixmap);
+-
+ void
+ glamor_download_boxes(PixmapPtr pixmap, BoxPtr in_boxes, int in_nbox,
+                       int dx_src, int dy_src,
+                       int dx_dst, int dy_dst,
+                       uint8_t *bits, uint32_t byte_stride);
+ 
+-void
+-glamor_download_rect(PixmapPtr pixmap, int x, int y, int w, int h, uint8_t *bits);
+-
+-void
+-glamor_download_pixmap(PixmapPtr pixmap);
+-
+ #endif /* _GLAMOR_TRANSFER_H_ */
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1059-BACKPORT-glamor-Make-program-APIs-take-DrawablePtrs-instead-o.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1059-BACKPORT-glamor-Make-program-APIs-take-DrawablePtrs-instead-o.patch
@@ -1,0 +1,496 @@
+From bd89bdbb645f033dd0a4c9460bd6f639bb51d4ff Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Sat, 24 Jun 2023 10:39:34 +0200
+Subject: [PATCH 059/105] glamor: Make program APIs take DrawablePtrs instead
+ of PixmapPtrs
+
+Will give better results if the window depth doesn't match the backing
+pixmap depth.
+---
+ glamor/glamor_copy.c      | 14 +++++++-------
+ glamor/glamor_dash.c      |  8 ++++----
+ glamor/glamor_glyphblt.c  |  4 ++--
+ glamor/glamor_lines.c     |  2 +-
+ glamor/glamor_points.c    |  2 +-
+ glamor/glamor_program.c   | 30 +++++++++++++++---------------
+ glamor/glamor_program.h   |  6 +++---
+ glamor/glamor_rects.c     |  4 ++--
+ glamor/glamor_segs.c      |  2 +-
+ glamor/glamor_spans.c     |  4 ++--
+ glamor/glamor_text.c      | 14 +++++++-------
+ glamor/glamor_transform.c | 14 +++++++-------
+ glamor/glamor_transform.h | 12 ++++++------
+ 13 files changed, 58 insertions(+), 58 deletions(-)
+
+diff --git a/glamor/glamor_copy.c b/glamor/glamor_copy.c
+index 1ab2be6c0..1d9d4eca4 100644
+--- a/glamor/glamor_copy.c
++++ b/glamor/glamor_copy.c
+@@ -33,12 +33,12 @@ struct copy_args {
+ };
+ 
+ static Bool
+-use_copyarea(PixmapPtr dst, GCPtr gc, glamor_program *prog, void *arg)
++use_copyarea(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ {
+     struct copy_args *args = arg;
+     glamor_pixmap_fbo *src = args->src;
+ 
+-    glamor_bind_texture(glamor_get_screen_private(dst->drawable.pScreen),
++    glamor_bind_texture(glamor_get_screen_private(drawable->pScreen),
+                         GL_TEXTURE0, src, TRUE);
+ 
+     glUniform2f(prog->fill_offset_uniform, args->dx, args->dy);
+@@ -62,19 +62,19 @@ static const glamor_facet glamor_facet_copyarea = {
+  */
+ 
+ static Bool
+-use_copyplane(PixmapPtr dst, GCPtr gc, glamor_program *prog, void *arg)
++use_copyplane(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ {
+     struct copy_args *args = arg;
+     glamor_pixmap_fbo *src = args->src;
+ 
+-    glamor_bind_texture(glamor_get_screen_private(dst->drawable.pScreen),
++    glamor_bind_texture(glamor_get_screen_private(drawable->pScreen),
+                         GL_TEXTURE0, src, TRUE);
+ 
+     glUniform2f(prog->fill_offset_uniform, args->dx, args->dy);
+     glUniform2f(prog->fill_size_inv_uniform, 1.0f/src->width, 1.0f/src->height);
+ 
+-    glamor_set_color(dst, gc->fgPixel, prog->fg_uniform);
+-    glamor_set_color(dst, gc->bgPixel, prog->bg_uniform);
++    glamor_set_color(drawable, gc->fgPixel, prog->fg_uniform);
++    glamor_set_color(drawable, gc->bgPixel, prog->bg_uniform);
+ 
+     /* XXX handle 2 10 10 10 and 1555 formats; presumably the pixmap private knows this? */
+     switch (args->src_pixmap->drawable.depth) {
+@@ -453,7 +453,7 @@ glamor_copy_fbo_fbo_draw(DrawablePtr src,
+         args.dy = dy + src_off_y - src_box->y1;
+         args.src = glamor_pixmap_fbo_at(src_priv, src_box_index);
+ 
+-        if (!glamor_use_program(dst_pixmap, gc, prog, &args))
++        if (!glamor_use_program(dst, gc, prog, &args))
+             goto bail_ctx;
+ 
+         glamor_pixmap_loop(dst_priv, dst_box_index) {
+diff --git a/glamor/glamor_dash.c b/glamor/glamor_dash.c
+index b53ce5c50..e0fe0e7e0 100644
+--- a/glamor/glamor_dash.c
++++ b/glamor/glamor_dash.c
+@@ -156,7 +156,7 @@ glamor_dash_setup(DrawablePtr drawable, GCPtr gc)
+ 
+     switch (gc->lineStyle) {
+     case LineOnOffDash:
+-        prog = glamor_use_program_fill(pixmap, gc,
++        prog = glamor_use_program_fill(drawable, gc,
+                                        &glamor_priv->on_off_dash_line_progs,
+                                        &glamor_facet_on_off_dash_lines);
+         if (!prog)
+@@ -175,11 +175,11 @@ glamor_dash_setup(DrawablePtr drawable, GCPtr gc)
+                 goto bail;
+         }
+ 
+-        if (!glamor_use_program(pixmap, gc, prog, NULL))
++        if (!glamor_use_program(drawable, gc, prog, NULL))
+             goto bail;
+ 
+-        glamor_set_color(pixmap, gc->fgPixel, prog->fg_uniform);
+-        glamor_set_color(pixmap, gc->bgPixel, prog->bg_uniform);
++        glamor_set_color(drawable, gc->fgPixel, prog->fg_uniform);
++        glamor_set_color(drawable, gc->bgPixel, prog->bg_uniform);
+         break;
+ 
+     default:
+diff --git a/glamor/glamor_glyphblt.c b/glamor/glamor_glyphblt.c
+index 78315ea9b..808e9066b 100644
+--- a/glamor/glamor_glyphblt.c
++++ b/glamor/glamor_glyphblt.c
+@@ -57,7 +57,7 @@ glamor_poly_glyph_blt_gl(DrawablePtr drawable, GCPtr gc,
+ 
+     glamor_make_current(glamor_priv);
+ 
+-    prog = glamor_use_program_fill(pixmap, gc,
++    prog = glamor_use_program_fill(drawable, gc,
+                                    &glamor_priv->poly_glyph_blt_progs,
+                                    &glamor_facet_poly_glyph_blt);
+     if (!prog)
+@@ -188,7 +188,7 @@ glamor_push_pixels_gl(GCPtr gc, PixmapPtr bitmap,
+ 
+     glamor_make_current(glamor_priv);
+ 
+-    prog = glamor_use_program_fill(pixmap, gc,
++    prog = glamor_use_program_fill(drawable, gc,
+                                    &glamor_priv->poly_glyph_blt_progs,
+                                    &glamor_facet_poly_glyph_blt);
+     if (!prog)
+diff --git a/glamor/glamor_lines.c b/glamor/glamor_lines.c
+index 5d95333fe..ec70804ac 100644
+--- a/glamor/glamor_lines.c
++++ b/glamor/glamor_lines.c
+@@ -61,7 +61,7 @@ glamor_poly_lines_solid_gl(DrawablePtr drawable, GCPtr gc,
+ 
+     glamor_make_current(glamor_priv);
+ 
+-    prog = glamor_use_program_fill(pixmap, gc,
++    prog = glamor_use_program_fill(drawable, gc,
+                                    &glamor_priv->poly_line_program,
+                                    &glamor_facet_poly_lines);
+ 
+diff --git a/glamor/glamor_points.c b/glamor/glamor_points.c
+index faf6f433b..8f0e4b1da 100644
+--- a/glamor/glamor_points.c
++++ b/glamor/glamor_points.c
+@@ -66,7 +66,7 @@ glamor_poly_point_gl(DrawablePtr drawable, GCPtr gc, int mode, int npt, DDXPoint
+             goto bail;
+     }
+ 
+-    if (!glamor_use_program(pixmap, gc, prog, NULL))
++    if (!glamor_use_program(drawable, gc, prog, NULL))
+         goto bail;
+ 
+     vbo_ppt = glamor_get_vbo_space(screen, npt * (2 * sizeof (INT16)), &vbo_offset);
+diff --git a/glamor/glamor_program.c b/glamor/glamor_program.c
+index f361b726e..9ee945d11 100644
+--- a/glamor/glamor_program.c
++++ b/glamor/glamor_program.c
+@@ -25,9 +25,9 @@
+ #include "glamor_program.h"
+ 
+ static Bool
+-use_solid(PixmapPtr pixmap, GCPtr gc, glamor_program *prog, void *arg)
++use_solid(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ {
+-    return glamor_set_solid(pixmap, gc, TRUE, prog->fg_uniform);
++    return glamor_set_solid(drawable, gc, TRUE, prog->fg_uniform);
+ }
+ 
+ const glamor_facet glamor_fill_solid = {
+@@ -38,9 +38,9 @@ const glamor_facet glamor_fill_solid = {
+ };
+ 
+ static Bool
+-use_tile(PixmapPtr pixmap, GCPtr gc, glamor_program *prog, void *arg)
++use_tile(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ {
+-    return glamor_set_tiled(pixmap, gc, prog->fill_offset_uniform, prog->fill_size_inv_uniform);
++    return glamor_set_tiled(drawable, gc, prog->fill_offset_uniform, prog->fill_size_inv_uniform);
+ }
+ 
+ static const glamor_facet glamor_fill_tile = {
+@@ -52,9 +52,9 @@ static const glamor_facet glamor_fill_tile = {
+ };
+ 
+ static Bool
+-use_stipple(PixmapPtr pixmap, GCPtr gc, glamor_program *prog, void *arg)
++use_stipple(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ {
+-    return glamor_set_stippled(pixmap, gc, prog->fg_uniform,
++    return glamor_set_stippled(drawable, gc, prog->fg_uniform,
+                                prog->fill_offset_uniform,
+                                prog->fill_size_inv_uniform);
+ }
+@@ -71,11 +71,11 @@ static const glamor_facet glamor_fill_stipple = {
+ };
+ 
+ static Bool
+-use_opaque_stipple(PixmapPtr pixmap, GCPtr gc, glamor_program *prog, void *arg)
++use_opaque_stipple(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ {
+-    if (!use_stipple(pixmap, gc, prog, arg))
++    if (!use_stipple(drawable, gc, prog, arg))
+         return FALSE;
+-    glamor_set_color(pixmap, gc->bgPixel, prog->bg_uniform);
++    glamor_set_color(drawable, gc->bgPixel, prog->bg_uniform);
+     return TRUE;
+ }
+ 
+@@ -401,29 +401,29 @@ fail:
+ }
+ 
+ Bool
+-glamor_use_program(PixmapPtr            pixmap,
++glamor_use_program(DrawablePtr          drawable,
+                    GCPtr                gc,
+                    glamor_program       *prog,
+                    void                 *arg)
+ {
+     glUseProgram(prog->prog);
+ 
+-    if (prog->prim_use && !prog->prim_use(pixmap, gc, prog, arg))
++    if (prog->prim_use && !prog->prim_use(drawable, gc, prog, arg))
+         return FALSE;
+ 
+-    if (prog->fill_use && !prog->fill_use(pixmap, gc, prog, arg))
++    if (prog->fill_use && !prog->fill_use(drawable, gc, prog, arg))
+         return FALSE;
+ 
+     return TRUE;
+ }
+ 
+ glamor_program *
+-glamor_use_program_fill(PixmapPtr               pixmap,
++glamor_use_program_fill(DrawablePtr             drawable,
+                         GCPtr                   gc,
+                         glamor_program_fill     *program_fill,
+                         const glamor_facet      *prim)
+ {
+-    ScreenPtr                   screen = pixmap->drawable.pScreen;
++    ScreenPtr                   screen = drawable->pScreen;
+     glamor_program              *prog = &program_fill->progs[gc->fillStyle];
+ 
+     int                         fill_style = gc->fillStyle;
+@@ -441,7 +441,7 @@ glamor_use_program_fill(PixmapPtr               pixmap,
+             return NULL;
+     }
+ 
+-    if (!glamor_use_program(pixmap, gc, prog, NULL))
++    if (!glamor_use_program(drawable, gc, prog, NULL))
+         return NULL;
+ 
+     return prog;
+diff --git a/glamor/glamor_program.h b/glamor/glamor_program.h
+index 0bd918fff..72bf1fc3f 100644
+--- a/glamor/glamor_program.h
++++ b/glamor/glamor_program.h
+@@ -50,7 +50,7 @@ typedef enum {
+ 
+ typedef struct _glamor_program glamor_program;
+ 
+-typedef Bool (*glamor_use) (PixmapPtr pixmap, GCPtr gc, glamor_program *prog, void *arg);
++typedef Bool (*glamor_use) (DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg);
+ 
+ typedef Bool (*glamor_use_render) (CARD8 op, PicturePtr src, PicturePtr dst, glamor_program *prog);
+ 
+@@ -108,13 +108,13 @@ glamor_build_program(ScreenPtr          screen,
+                      const char         *defines);
+ 
+ Bool
+-glamor_use_program(PixmapPtr            pixmap,
++glamor_use_program(DrawablePtr          drawable,
+                    GCPtr                gc,
+                    glamor_program       *prog,
+                    void                 *arg);
+ 
+ glamor_program *
+-glamor_use_program_fill(PixmapPtr               pixmap,
++glamor_use_program_fill(DrawablePtr             drawable,
+                         GCPtr                   gc,
+                         glamor_program_fill     *program_fill,
+                         const glamor_facet      *prim);
+diff --git a/glamor/glamor_rects.c b/glamor/glamor_rects.c
+index 8cdad64e4..afe680d1b 100644
+--- a/glamor/glamor_rects.c
++++ b/glamor/glamor_rects.c
+@@ -70,7 +70,7 @@ glamor_poly_fill_rect_gl(DrawablePtr drawable,
+     }
+ 
+     if (glamor_glsl_has_ints(glamor_priv)) {
+-        prog = glamor_use_program_fill(pixmap, gc,
++        prog = glamor_use_program_fill(drawable, gc,
+                                        &glamor_priv->poly_fill_rect_program,
+                                        &glamor_facet_polyfillrect_130);
+ 
+@@ -97,7 +97,7 @@ glamor_poly_fill_rect_gl(DrawablePtr drawable,
+     } else {
+         int n;
+ 
+-        prog = glamor_use_program_fill(pixmap, gc,
++        prog = glamor_use_program_fill(drawable, gc,
+                                        &glamor_priv->poly_fill_rect_program,
+                                        &glamor_facet_polyfillrect_120);
+ 
+diff --git a/glamor/glamor_segs.c b/glamor/glamor_segs.c
+index 4dfa6553b..78c19ec48 100644
+--- a/glamor/glamor_segs.c
++++ b/glamor/glamor_segs.c
+@@ -58,7 +58,7 @@ glamor_poly_segment_solid_gl(DrawablePtr drawable, GCPtr gc,
+ 
+     glamor_make_current(glamor_priv);
+ 
+-    prog = glamor_use_program_fill(pixmap, gc,
++    prog = glamor_use_program_fill(drawable, gc,
+                                    &glamor_priv->poly_segment_program,
+                                    &glamor_facet_poly_segment);
+ 
+diff --git a/glamor/glamor_spans.c b/glamor/glamor_spans.c
+index 00a019c7b..dfa37dc07 100644
+--- a/glamor/glamor_spans.c
++++ b/glamor/glamor_spans.c
+@@ -65,7 +65,7 @@ glamor_fill_spans_gl(DrawablePtr drawable,
+     glamor_make_current(glamor_priv);
+ 
+     if (glamor_glsl_has_ints(glamor_priv)) {
+-        prog = glamor_use_program_fill(pixmap, gc, &glamor_priv->fill_spans_program,
++        prog = glamor_use_program_fill(drawable, gc, &glamor_priv->fill_spans_program,
+                                        &glamor_facet_fillspans_130);
+ 
+         if (!prog)
+@@ -90,7 +90,7 @@ glamor_fill_spans_gl(DrawablePtr drawable,
+ 
+         glamor_put_vbo_space(screen);
+     } else {
+-        prog = glamor_use_program_fill(pixmap, gc, &glamor_priv->fill_spans_program,
++        prog = glamor_use_program_fill(drawable, gc, &glamor_priv->fill_spans_program,
+                                        &glamor_facet_fillspans_120);
+ 
+         if (!prog)
+diff --git a/glamor/glamor_text.c b/glamor/glamor_text.c
+index cf165cad8..a559aea8a 100644
+--- a/glamor/glamor_text.c
++++ b/glamor/glamor_text.c
+@@ -288,7 +288,7 @@ glamor_poly_text(DrawablePtr drawable, GCPtr gc,
+ 
+     glamor_make_current(glamor_priv);
+ 
+-    prog = glamor_use_program_fill(pixmap, gc, &glamor_priv->poly_text_progs, &glamor_facet_poly_text);
++    prog = glamor_use_program_fill(drawable, gc, &glamor_priv->poly_text_progs, &glamor_facet_poly_text);
+ 
+     if (!prog)
+         goto bail;
+@@ -346,9 +346,9 @@ static const glamor_facet glamor_facet_image_text = {
+ };
+ 
+ static Bool
+-use_image_solid(PixmapPtr pixmap, GCPtr gc, glamor_program *prog, void *arg)
++use_image_solid(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ {
+-    return glamor_set_solid(pixmap, gc, FALSE, prog->fg_uniform);
++    return glamor_set_solid(drawable, gc, FALSE, prog->fg_uniform);
+ }
+ 
+ static const glamor_facet glamor_facet_image_fill = {
+@@ -359,11 +359,11 @@ static const glamor_facet glamor_facet_image_fill = {
+ };
+ 
+ static Bool
+-glamor_te_text_use(PixmapPtr pixmap, GCPtr gc, glamor_program *prog, void *arg)
++glamor_te_text_use(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ {
+-    if (!glamor_set_solid(pixmap, gc, FALSE, prog->fg_uniform))
++    if (!glamor_set_solid(drawable, gc, FALSE, prog->fg_uniform))
+         return FALSE;
+-    glamor_set_color(pixmap, gc->bgPixel, prog->bg_uniform);
++    glamor_set_color(drawable, gc->bgPixel, prog->bg_uniform);
+     return TRUE;
+ }
+ 
+@@ -461,7 +461,7 @@ glamor_image_text(DrawablePtr drawable, GCPtr gc,
+         RegionUninit(&region);
+     }
+ 
+-    if (!glamor_use_program(pixmap, gc, prog, NULL))
++    if (!glamor_use_program(drawable, gc, prog, NULL))
+         goto bail;
+ 
+     (void) glamor_text(drawable, gc, glamor_font, prog,
+diff --git a/glamor/glamor_transform.c b/glamor/glamor_transform.c
+index 11a08f7f6..b969bc114 100644
+--- a/glamor/glamor_transform.c
++++ b/glamor/glamor_transform.c
+@@ -130,7 +130,7 @@ glamor_set_color_depth(ScreenPtr      pScreen,
+ }
+ 
+ Bool
+-glamor_set_solid(PixmapPtr      pixmap,
++glamor_set_solid(DrawablePtr    drawable,
+                  GCPtr          gc,
+                  Bool           use_alu,
+                  GLint          uniform)
+@@ -143,7 +143,7 @@ glamor_set_solid(PixmapPtr      pixmap,
+ 
+     pixel = gc->fgPixel;
+ 
+-    if (!glamor_set_alu(pixmap->drawable.pScreen, alu)) {
++    if (!glamor_set_alu(drawable->pScreen, alu)) {
+         switch (gc->alu) {
+         case GXclear:
+             pixel = 0;
+@@ -158,7 +158,7 @@ glamor_set_solid(PixmapPtr      pixmap,
+             return FALSE;
+         }
+     }
+-    glamor_set_color(pixmap, pixel, uniform);
++    glamor_set_color(drawable, pixel, uniform);
+ 
+     return TRUE;
+ }
+@@ -204,12 +204,12 @@ glamor_set_texture(PixmapPtr    texture,
+ }
+ 
+ Bool
+-glamor_set_tiled(PixmapPtr      pixmap,
++glamor_set_tiled(DrawablePtr    drawable,
+                  GCPtr          gc,
+                  GLint          offset_uniform,
+                  GLint          size_inv_uniform)
+ {
+-    if (!glamor_set_alu(pixmap->drawable.pScreen, gc->alu))
++    if (!glamor_set_alu(drawable->pScreen, gc->alu))
+         return FALSE;
+ 
+     if (!glamor_set_planemask(gc->depth, gc->planemask))
+@@ -282,7 +282,7 @@ bail:
+ }
+ 
+ Bool
+-glamor_set_stippled(PixmapPtr      pixmap,
++glamor_set_stippled(DrawablePtr    drawable,
+                     GCPtr          gc,
+                     GLint          fg_uniform,
+                     GLint          offset_uniform,
+@@ -294,7 +294,7 @@ glamor_set_stippled(PixmapPtr      pixmap,
+     if (!stipple)
+         return FALSE;
+ 
+-    if (!glamor_set_solid(pixmap, gc, TRUE, fg_uniform))
++    if (!glamor_set_solid(drawable, gc, TRUE, fg_uniform))
+         return FALSE;
+ 
+     return glamor_set_texture(stipple,
+diff --git a/glamor/glamor_transform.h b/glamor/glamor_transform.h
+index 28855e3d3..305253310 100644
+--- a/glamor/glamor_transform.h
++++ b/glamor/glamor_transform.h
+@@ -39,12 +39,12 @@ glamor_set_color_depth(ScreenPtr      pScreen,
+                        GLint          uniform);
+ 
+ static inline void
+-glamor_set_color(PixmapPtr      pixmap,
++glamor_set_color(DrawablePtr    drawable,
+                  CARD32         pixel,
+                  GLint          uniform)
+ {
+-    glamor_set_color_depth(pixmap->drawable.pScreen,
+-                           pixmap->drawable.depth, pixel, uniform);
++    glamor_set_color_depth(drawable->pScreen,
++                           drawable->depth, pixel, uniform);
+ }
+ 
+ Bool
+@@ -60,19 +60,19 @@ glamor_set_texture(PixmapPtr    texture,
+                    GLint        size_uniform);
+ 
+ Bool
+-glamor_set_solid(PixmapPtr      pixmap,
++glamor_set_solid(DrawablePtr    drawable,
+                  GCPtr          gc,
+                  Bool           use_alu,
+                  GLint          uniform);
+ 
+ Bool
+-glamor_set_tiled(PixmapPtr      pixmap,
++glamor_set_tiled(DrawablePtr    drawable,
+                  GCPtr          gc,
+                  GLint          offset_uniform,
+                  GLint          size_uniform);
+ 
+ Bool
+-glamor_set_stippled(PixmapPtr      pixmap,
++glamor_set_stippled(DrawablePtr    drawable,
+                     GCPtr          gc,
+                     GLint          fg_uniform,
+                     GLint          offset_uniform,
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1060-BACKPORT-glamor-Take-DrawablePtr-instead-of-PixmapPtr-in-up-d.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1060-BACKPORT-glamor-Take-DrawablePtr-instead-of-PixmapPtr-in-up-d.patch
@@ -1,0 +1,239 @@
+From 30cea2de5554561e39ed97eb09b84abd2e88c8ec Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Sat, 24 Jun 2023 11:22:14 +0200
+Subject: [PATCH 060/105] glamor: Take DrawablePtr instead of PixmapPtr in
+ up/download_boxes
+
+Will allow for better results if the window depth doesn't match the
+backing pixmap depth.
+---
+ glamor/glamor_composite_glyphs.c |  2 +-
+ glamor/glamor_copy.c             |  6 +++---
+ glamor/glamor_image.c            |  4 ++--
+ glamor/glamor_prepare.c          |  4 ++--
+ glamor/glamor_transfer.c         | 22 ++++++++++++----------
+ glamor/glamor_transfer.h         |  6 +++---
+ glamor/glamor_xv.c               | 10 +++++-----
+ 7 files changed, 28 insertions(+), 26 deletions(-)
+
+diff --git a/glamor/glamor_composite_glyphs.c b/glamor/glamor_composite_glyphs.c
+index c69b940d4..7911e0009 100644
+--- a/glamor/glamor_composite_glyphs.c
++++ b/glamor/glamor_composite_glyphs.c
+@@ -107,7 +107,7 @@ glamor_copy_glyph(PixmapPtr     glyph_pixmap,
+                                       glyph_draw->height,
+                                       0, 0, 0x1);
+     }
+-    glamor_upload_boxes((PixmapPtr) atlas_draw,
++    glamor_upload_boxes(atlas_draw,
+                         &box, 1,
+                         0, 0,
+                         x, y,
+diff --git a/glamor/glamor_copy.c b/glamor/glamor_copy.c
+index 1d9d4eca4..7492db351 100644
+--- a/glamor/glamor_copy.c
++++ b/glamor/glamor_copy.c
+@@ -255,7 +255,7 @@ glamor_copy_cpu_fbo(DrawablePtr src,
+             fbCopy1toN(src, &tmp_pix->drawable, gc, box, nbox, dx, dy,
+                        reverse, upsidedown, bitplane, closure);
+ 
+-        glamor_upload_boxes(dst_pixmap, box, nbox, tmp_xoff, tmp_yoff,
++        glamor_upload_boxes(dst, box, nbox, tmp_xoff, tmp_yoff,
+                             dst_xoff, dst_yoff, (uint8_t *) tmp_bits,
+                             tmp_stride * sizeof(FbBits));
+         fbDestroyPixmap(tmp_pix);
+@@ -266,7 +266,7 @@ glamor_copy_cpu_fbo(DrawablePtr src,
+         int src_xoff, src_yoff;
+ 
+         fbGetDrawable(src, src_bits, src_stride, src_bpp, src_xoff, src_yoff);
+-        glamor_upload_boxes(dst_pixmap, box, nbox, src_xoff + dx, src_yoff + dy,
++        glamor_upload_boxes(dst, box, nbox, src_xoff + dx, src_yoff + dy,
+                             dst_xoff, dst_yoff,
+                             (uint8_t *) src_bits, src_stride * sizeof (FbBits));
+     }
+@@ -319,7 +319,7 @@ glamor_copy_fbo_cpu(DrawablePtr src,
+ 
+     fbGetDrawable(dst, dst_bits, dst_stride, dst_bpp, dst_xoff, dst_yoff);
+ 
+-    glamor_download_boxes(src_pixmap, box, nbox, src_xoff + dx, src_yoff + dy,
++    glamor_download_boxes(src, box, nbox, src_xoff + dx, src_yoff + dy,
+                           dst_xoff, dst_yoff,
+                           (uint8_t *) dst_bits, dst_stride * sizeof (FbBits));
+     glamor_finish_access(dst);
+diff --git a/glamor/glamor_image.c b/glamor/glamor_image.c
+index 453ef79ba..1a8e527b6 100644
+--- a/glamor/glamor_image.c
++++ b/glamor/glamor_image.c
+@@ -76,7 +76,7 @@ glamor_put_image_gl(DrawablePtr drawable, GCPtr gc, int depth, int x, int y,
+ 
+     glamor_make_current(glamor_priv);
+ 
+-    glamor_upload_region(pixmap, &region, x, y, (uint8_t *) bits, byte_stride);
++    glamor_upload_region(drawable, &region, x, y, (uint8_t *) bits, byte_stride);
+ 
+     RegionUninit(&region);
+     return TRUE;
+@@ -124,7 +124,7 @@ glamor_get_image_gl(DrawablePtr drawable, int x, int y, int w, int h,
+     box.x2 = x + w;
+     box.y1 = y;
+     box.y2 = y + h;
+-    glamor_download_boxes(pixmap, &box, 1,
++    glamor_download_boxes(drawable, &box, 1,
+                           drawable->x + off_x, drawable->y + off_y,
+                           -x, -y,
+                           (uint8_t *) d, byte_stride);
+diff --git a/glamor/glamor_prepare.c b/glamor/glamor_prepare.c
+index 835c4ebea..7600e4f6b 100644
+--- a/glamor/glamor_prepare.c
++++ b/glamor/glamor_prepare.c
+@@ -119,7 +119,7 @@ glamor_prep_pixmap_box(PixmapPtr pixmap, glamor_access_t access, BoxPtr box)
+         priv->map_access = access;
+     }
+ 
+-    glamor_download_boxes(pixmap, RegionRects(&region), RegionNumRects(&region),
++    glamor_download_boxes(&pixmap->drawable, RegionRects(&region), RegionNumRects(&region),
+                           0, 0, 0, 0, pixmap->devPrivate.ptr, pixmap->devKind);
+ 
+     RegionUninit(&region);
+@@ -161,7 +161,7 @@ glamor_fini_pixmap(PixmapPtr pixmap)
+     }
+ 
+     if (priv->map_access == GLAMOR_ACCESS_RW) {
+-        glamor_upload_boxes(pixmap,
++        glamor_upload_boxes(&pixmap->drawable,
+                             RegionRects(&priv->prepare_region),
+                             RegionNumRects(&priv->prepare_region),
+                             0, 0, 0, 0, pixmap->devPrivate.ptr, pixmap->devKind);
+diff --git a/glamor/glamor_transfer.c b/glamor/glamor_transfer.c
+index 842114235..80b2e906e 100644
+--- a/glamor/glamor_transfer.c
++++ b/glamor/glamor_transfer.c
+@@ -24,19 +24,20 @@
+ #include "glamor_transfer.h"
+ 
+ /*
+- * Write a region of bits into a pixmap
++ * Write a region of bits into a drawable's backing pixmap
+  */
+ void
+-glamor_upload_boxes(PixmapPtr pixmap, BoxPtr in_boxes, int in_nbox,
++glamor_upload_boxes(DrawablePtr drawable, BoxPtr in_boxes, int in_nbox,
+                     int dx_src, int dy_src,
+                     int dx_dst, int dy_dst,
+                     uint8_t *bits, uint32_t byte_stride)
+ {
+-    ScreenPtr                   screen = pixmap->drawable.pScreen;
++    ScreenPtr                   screen = drawable->pScreen;
+     glamor_screen_private       *glamor_priv = glamor_get_screen_private(screen);
++    PixmapPtr                   pixmap = glamor_get_drawable_pixmap(drawable);
+     glamor_pixmap_private       *priv = glamor_get_pixmap_private(pixmap);
+     int                         box_index;
+-    int                         bytes_per_pixel = pixmap->drawable.bitsPerPixel >> 3;
++    int                         bytes_per_pixel = drawable->bitsPerPixel >> 3;
+     const struct glamor_format *f = glamor_format_for_pixmap(pixmap);
+ 
+     glamor_make_current(glamor_priv);
+@@ -97,30 +98,31 @@ glamor_upload_boxes(PixmapPtr pixmap, BoxPtr in_boxes, int in_nbox,
+  */
+ 
+ void
+-glamor_upload_region(PixmapPtr pixmap, RegionPtr region,
++glamor_upload_region(DrawablePtr drawable, RegionPtr region,
+                      int region_x, int region_y,
+                      uint8_t *bits, uint32_t byte_stride)
+ {
+-    glamor_upload_boxes(pixmap, RegionRects(region), RegionNumRects(region),
++    glamor_upload_boxes(drawable, RegionRects(region), RegionNumRects(region),
+                         -region_x, -region_y,
+                         0, 0,
+                         bits, byte_stride);
+ }
+ 
+ /*
+- * Read stuff from the pixmap FBOs and write to memory
++ * Read stuff from the drawable's backing pixmap FBOs and write to memory
+  */
+ void
+-glamor_download_boxes(PixmapPtr pixmap, BoxPtr in_boxes, int in_nbox,
++glamor_download_boxes(DrawablePtr drawable, BoxPtr in_boxes, int in_nbox,
+                       int dx_src, int dy_src,
+                       int dx_dst, int dy_dst,
+                       uint8_t *bits, uint32_t byte_stride)
+ {
+-    ScreenPtr screen = pixmap->drawable.pScreen;
++    ScreenPtr screen = drawable->pScreen;
+     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
++    PixmapPtr pixmap = glamor_get_drawable_pixmap(drawable);
+     glamor_pixmap_private *priv = glamor_get_pixmap_private(pixmap);
+     int box_index;
+-    int bytes_per_pixel = pixmap->drawable.bitsPerPixel >> 3;
++    int bytes_per_pixel = drawable->bitsPerPixel >> 3;
+     const struct glamor_format *f = glamor_format_for_pixmap(pixmap);
+ 
+     glamor_make_current(glamor_priv);
+diff --git a/glamor/glamor_transfer.h b/glamor/glamor_transfer.h
+index 26b5a6b0d..17d80a2e9 100644
+--- a/glamor/glamor_transfer.h
++++ b/glamor/glamor_transfer.h
+@@ -24,18 +24,18 @@
+ #define _GLAMOR_TRANSFER_H_
+ 
+ void
+-glamor_upload_boxes(PixmapPtr pixmap, BoxPtr in_boxes, int in_nbox,
++glamor_upload_boxes(DrawablePtr drawable, BoxPtr in_boxes, int in_nbox,
+                     int dx_src, int dy_src,
+                     int dx_dst, int dy_dst,
+                     uint8_t *bits, uint32_t byte_stride);
+ 
+ void
+-glamor_upload_region(PixmapPtr pixmap, RegionPtr region,
++glamor_upload_region(DrawablePtr drawable, RegionPtr region,
+                      int region_x, int region_y,
+                      uint8_t *bits, uint32_t byte_stride);
+ 
+ void
+-glamor_download_boxes(PixmapPtr pixmap, BoxPtr in_boxes, int in_nbox,
++glamor_download_boxes(DrawablePtr drawable, BoxPtr in_boxes, int in_nbox,
+                       int dx_src, int dy_src,
+                       int dx_dst, int dy_dst,
+                       uint8_t *bits, uint32_t byte_stride);
+diff --git a/glamor/glamor_xv.c b/glamor/glamor_xv.c
+index dbb490599..a3d6b3bc3 100644
+--- a/glamor/glamor_xv.c
++++ b/glamor/glamor_xv.c
+@@ -584,15 +584,15 @@ glamor_xv_put_image(glamor_port_private *port_priv,
+         half_box.x2 = width >> 1;
+         half_box.y2 = (nlines + 1) >> 1;
+ 
+-        glamor_upload_boxes(port_priv->src_pix[0], &full_box, 1,
++        glamor_upload_boxes(&port_priv->src_pix[0]->drawable, &full_box, 1,
+                             0, 0, 0, 0,
+                             buf + (top * srcPitch), srcPitch);
+ 
+-        glamor_upload_boxes(port_priv->src_pix[1], &half_box, 1,
++        glamor_upload_boxes(&port_priv->src_pix[1]->drawable, &half_box, 1,
+                             0, 0, 0, 0,
+                             buf + s2offset, srcPitch2);
+ 
+-        glamor_upload_boxes(port_priv->src_pix[2], &half_box, 1,
++        glamor_upload_boxes(&port_priv->src_pix[2]->drawable, &half_box, 1,
+                             0, 0, 0, 0,
+                             buf + s3offset, srcPitch2);
+         break;
+@@ -611,11 +611,11 @@ glamor_xv_put_image(glamor_port_private *port_priv,
+         half_box.x2 = width;
+         half_box.y2 = (nlines + 1) >> 1;
+ 
+-        glamor_upload_boxes(port_priv->src_pix[0], &full_box, 1,
++        glamor_upload_boxes(&port_priv->src_pix[0]->drawable, &full_box, 1,
+                             0, 0, 0, 0,
+                             buf + (top * srcPitch), srcPitch);
+ 
+-        glamor_upload_boxes(port_priv->src_pix[1], &half_box, 1,
++        glamor_upload_boxes(&port_priv->src_pix[1]->drawable, &half_box, 1,
+                             0, 0, 0, 0,
+                             buf + s2offset, srcPitch);
+         break;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1061-BACKPORT-glamor-Eliminate-glamor_fini_pixmap.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1061-BACKPORT-glamor-Eliminate-glamor_fini_pixmap.patch
@@ -1,0 +1,54 @@
+From 2e41cfa8b3cfb744ba34087bd53782e8f8159891 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Sat, 24 Jun 2023 11:27:21 +0200
+Subject: [PATCH 061/105] glamor: Eliminate glamor_fini_pixmap
+
+Pass the DrawablePtr directly from glamor_finish_access to
+glamor_upload_boxes. This will allow for better results if the window
+depth doesn't match the backing pixmap depth.
+---
+ glamor/glamor_prepare.c | 13 ++++---------
+ 1 file changed, 4 insertions(+), 9 deletions(-)
+
+diff --git a/glamor/glamor_prepare.c b/glamor/glamor_prepare.c
+index 7600e4f6b..f7bb5d254 100644
+--- a/glamor/glamor_prepare.c
++++ b/glamor/glamor_prepare.c
+@@ -143,9 +143,10 @@ glamor_prep_pixmap_box(PixmapPtr pixmap, glamor_access_t access, BoxPtr box)
+  * if we were writing to it and then unbind it to release the memory
+  */
+ 
+-static void
+-glamor_fini_pixmap(PixmapPtr pixmap)
++void
++glamor_finish_access(DrawablePtr drawable)
+ {
++    PixmapPtr pixmap = glamor_get_drawable_pixmap(drawable);
+     glamor_pixmap_private       *priv = glamor_get_pixmap_private(pixmap);
+ 
+     if (!GLAMOR_PIXMAP_PRIV_HAS_FBO(priv))
+@@ -161,7 +162,7 @@ glamor_fini_pixmap(PixmapPtr pixmap)
+     }
+ 
+     if (priv->map_access == GLAMOR_ACCESS_RW) {
+-        glamor_upload_boxes(&pixmap->drawable,
++        glamor_upload_boxes(drawable,
+                             RegionRects(&priv->prepare_region),
+                             RegionNumRects(&priv->prepare_region),
+                             0, 0, 0, 0, pixmap->devPrivate.ptr, pixmap->devKind);
+@@ -213,12 +214,6 @@ glamor_prepare_access_box(DrawablePtr drawable, glamor_access_t access,
+     return glamor_prep_pixmap_box(pixmap, access, &box);
+ }
+ 
+-void
+-glamor_finish_access(DrawablePtr drawable)
+-{
+-    glamor_fini_pixmap(glamor_get_drawable_pixmap(drawable));
+-}
+-
+ /*
+  * Make a picture ready to use with fb.
+  */
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1062-BACKPORT-glamor-glamor_prep_pixmap_box-glamor_prep_drawable_b.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1062-BACKPORT-glamor-glamor_prep_pixmap_box-glamor_prep_drawable_b.patch
@@ -1,0 +1,109 @@
+From 6298bf461acf71ddd2b4780b51a693fbdb13d8bf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Sat, 24 Jun 2023 11:39:03 +0200
+Subject: [PATCH 062/105] =?UTF-8?q?glamor:=20glamor=5Fprep=5Fpixmap=5Fbox?=
+ =?UTF-8?q?=20=E2=86=92=20glamor=5Fprep=5Fdrawable=5Fbox?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Pass the DrawablePtr directly to glamor_download_boxes. This will allow
+for better results if the window depth doesn't match the backing pixmap
+depth.
+---
+ glamor/glamor_prepare.c | 34 +++++++++++++++++-----------------
+ 1 file changed, 17 insertions(+), 17 deletions(-)
+
+diff --git a/glamor/glamor_prepare.c b/glamor/glamor_prepare.c
+index f7bb5d254..208319628 100644
+--- a/glamor/glamor_prepare.c
++++ b/glamor/glamor_prepare.c
+@@ -25,19 +25,21 @@
+ #include "glamor_transfer.h"
+ 
+ /*
+- * Make a pixmap ready to draw with fb by
++ * Make a drawable ready to draw with fb by
+  * creating a PBO large enough for the whole object
+  * and downloading all of the FBOs into it.
+  */
+ 
+ static Bool
+-glamor_prep_pixmap_box(PixmapPtr pixmap, glamor_access_t access, BoxPtr box)
++glamor_prep_drawable_box(DrawablePtr drawable, glamor_access_t access, BoxPtr box)
+ {
+-    ScreenPtr                   screen = pixmap->drawable.pScreen;
++    ScreenPtr                   screen = drawable->pScreen;
+     glamor_screen_private       *glamor_priv = glamor_get_screen_private(screen);
++    PixmapPtr                   pixmap = glamor_get_drawable_pixmap(drawable);
+     glamor_pixmap_private       *priv = glamor_get_pixmap_private(pixmap);
+     int                         gl_access, gl_usage;
+     RegionRec                   region;
++    int                         off_x, off_y;
+ 
+     if (priv->type == GLAMOR_DRM_ONLY)
+         return FALSE;
+@@ -47,6 +49,11 @@ glamor_prep_pixmap_box(PixmapPtr pixmap, glamor_access_t access, BoxPtr box)
+ 
+     glamor_make_current(glamor_priv);
+ 
++    glamor_get_drawable_deltas(drawable, pixmap, &off_x, &off_y);
++    box->x1 += off_x;
++    box->x2 += off_x;
++    box->y1 += off_y;
++    box->y2 += off_y;
+     RegionInit(&region, box, 1);
+ 
+     /* See if it's already mapped */
+@@ -119,7 +126,7 @@ glamor_prep_pixmap_box(PixmapPtr pixmap, glamor_access_t access, BoxPtr box)
+         priv->map_access = access;
+     }
+ 
+-    glamor_download_boxes(&pixmap->drawable, RegionRects(&region), RegionNumRects(&region),
++    glamor_download_boxes(drawable, RegionRects(&region), RegionNumRects(&region),
+                           0, 0, 0, 0, pixmap->devPrivate.ptr, pixmap->devKind);
+ 
+     RegionUninit(&region);
+@@ -185,33 +192,26 @@ glamor_finish_access(DrawablePtr drawable)
+ Bool
+ glamor_prepare_access(DrawablePtr drawable, glamor_access_t access)
+ {
+-    PixmapPtr pixmap = glamor_get_drawable_pixmap(drawable);
+     BoxRec box;
+-    int off_x, off_y;
+-
+-    glamor_get_drawable_deltas(drawable, pixmap, &off_x, &off_y);
+ 
+-    box.x1 = drawable->x + off_x;
++    box.x1 = drawable->x;
+     box.x2 = box.x1 + drawable->width;
+-    box.y1 = drawable->y + off_y;
++    box.y1 = drawable->y;
+     box.y2 = box.y1 + drawable->height;
+-    return glamor_prep_pixmap_box(pixmap, access, &box);
++    return glamor_prep_drawable_box(drawable, access, &box);
+ }
+ 
+ Bool
+ glamor_prepare_access_box(DrawablePtr drawable, glamor_access_t access,
+                          int x, int y, int w, int h)
+ {
+-    PixmapPtr pixmap = glamor_get_drawable_pixmap(drawable);
+     BoxRec box;
+-    int off_x, off_y;
+ 
+-    glamor_get_drawable_deltas(drawable, pixmap, &off_x, &off_y);
+-    box.x1 = drawable->x + x + off_x;
++    box.x1 = drawable->x + x;
+     box.x2 = box.x1 + w;
+-    box.y1 = drawable->y + y + off_y;
++    box.y1 = drawable->y + y;
+     box.y2 = box.y1 + h;
+-    return glamor_prep_pixmap_box(pixmap, access, &box);
++    return glamor_prep_drawable_box(drawable, access, &box);
+ }
+ 
+ /*
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1063-BACKPORT-glamor-Fix-up-alpha-channel-if-needed-in-glamor_uplo.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1063-BACKPORT-glamor-Fix-up-alpha-channel-if-needed-in-glamor_uplo.patch
@@ -1,0 +1,115 @@
+From b9c42094ac1a0b4d89ac3f926005257f3cec2725 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Wed, 28 Jun 2023 16:33:32 +0200
+Subject: [PATCH 063/105] glamor: Fix up alpha channel if needed in
+ glamor_upload_boxes
+
+It's needed for a depth 24 window backed by a depth 32 pixmap, to make
+sure the window's pixels sample alpha as 1.0.
+
+v2:
+* Make sure glamor_finish_access doesn't pass in a NULL pointer.
+---
+ glamor/glamor_prepare.c  |  9 +++++++--
+ glamor/glamor_transfer.c | 29 ++++++++++++++++++++++++++---
+ 2 files changed, 33 insertions(+), 5 deletions(-)
+
+diff --git a/glamor/glamor_prepare.c b/glamor/glamor_prepare.c
+index 208319628..2bab2b613 100644
+--- a/glamor/glamor_prepare.c
++++ b/glamor/glamor_prepare.c
+@@ -162,7 +162,8 @@ glamor_finish_access(DrawablePtr drawable)
+     if (!priv->prepared)
+         return;
+ 
+-    if (priv->pbo) {
++    if (priv->pbo &&
++        !(drawable->depth == 24 && pixmap->drawable.depth == 32)) {
+         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, priv->pbo);
+         glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+         pixmap->devPrivate.ptr = NULL;
+@@ -178,7 +179,11 @@ glamor_finish_access(DrawablePtr drawable)
+     RegionUninit(&priv->prepare_region);
+ 
+     if (priv->pbo) {
+-        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
++        if (drawable->depth == 24 && pixmap->drawable.depth == 32)
++            pixmap->devPrivate.ptr = NULL;
++        else
++            glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
++
+         glDeleteBuffers(1, &priv->pbo);
+         priv->pbo = 0;
+     } else {
+diff --git a/glamor/glamor_transfer.c b/glamor/glamor_transfer.c
+index 80b2e906e..a2727f109 100644
+--- a/glamor/glamor_transfer.c
++++ b/glamor/glamor_transfer.c
+@@ -39,6 +39,10 @@ glamor_upload_boxes(DrawablePtr drawable, BoxPtr in_boxes, int in_nbox,
+     int                         box_index;
+     int                         bytes_per_pixel = drawable->bitsPerPixel >> 3;
+     const struct glamor_format *f = glamor_format_for_pixmap(pixmap);
++    char *tmp_bits = NULL;
++
++    if (drawable->depth == 24 && pixmap->drawable.depth == 32)
++        tmp_bits = xnfalloc(byte_stride * pixmap->drawable.height);
+ 
+     glamor_make_current(glamor_priv);
+ 
+@@ -63,6 +67,7 @@ glamor_upload_boxes(DrawablePtr drawable, BoxPtr in_boxes, int in_nbox,
+             int y1 = MAX(boxes->y1 + dy_dst, box->y1);
+             int y2 = MIN(boxes->y2 + dy_dst, box->y2);
+ 
++            uint32_t *src_line;
+             size_t ofs = (y1 - dy_dst + dy_src) * byte_stride;
+             ofs += (x1 - dx_dst + dx_src) * bytes_per_pixel;
+ 
+@@ -71,24 +76,42 @@ glamor_upload_boxes(DrawablePtr drawable, BoxPtr in_boxes, int in_nbox,
+             if (x2 <= x1 || y2 <= y1)
+                 continue;
+ 
++            src_line = (uint32_t *)(bits + ofs);
++
++            if (tmp_bits) {
++                uint32_t *tmp_line = (uint32_t *)(tmp_bits + ofs);
++                int x, y;
++
++                /* Make sure any sampling of the alpha channel will return 1.0 */
++                for (y = y1; y < y2;
++                     y++, src_line += byte_stride / 4, tmp_line += byte_stride / 4) {
++                    for (x = 0; x < x2 - x1; x++)
++                        tmp_line[x] = src_line[x] | 0xff000000;
++                }
++
++                src_line = (uint32_t *)(tmp_bits + ofs);
++            }
++
+             if (glamor_priv->has_unpack_subimage ||
+                 x2 - x1 == byte_stride / bytes_per_pixel) {
+                 glTexSubImage2D(GL_TEXTURE_2D, 0,
+                                 x1 - box->x1, y1 - box->y1,
+                                 x2 - x1, y2 - y1,
+                                 f->format, f->type,
+-                                bits + ofs);
++                                src_line);
+             } else {
+-                for (; y1 < y2; y1++, ofs += byte_stride)
++                for (; y1 < y2; y1++, src_line += byte_stride / bytes_per_pixel)
+                     glTexSubImage2D(GL_TEXTURE_2D, 0,
+                                     x1 - box->x1, y1 - box->y1,
+                                     x2 - x1, 1,
+                                     f->format, f->type,
+-                                    bits + ofs);
++                                    src_line);
+             }
+         }
+     }
+ 
++    free(tmp_bits);
++
+     if (glamor_priv->has_unpack_subimage)
+         glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+ }
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1064-BACKPORT-glamor-Use-DrawablePtr-in-struct-copy_args.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1064-BACKPORT-glamor-Use-DrawablePtr-in-struct-copy_args.patch
@@ -1,0 +1,45 @@
+From bac0e88f4ea3941cbd1ccd2c63b0d6e6d901f94e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Sat, 24 Jun 2023 11:47:33 +0200
+Subject: [PATCH 064/105] glamor: Use DrawablePtr in struct copy_args
+
+Will give better results if the window depth doesn't match the backing
+pixmap depth.
+---
+ glamor/glamor_copy.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/glamor/glamor_copy.c b/glamor/glamor_copy.c
+index 7492db351..0ff7f28e7 100644
+--- a/glamor/glamor_copy.c
++++ b/glamor/glamor_copy.c
+@@ -26,7 +26,7 @@
+ #include "glamor_transform.h"
+ 
+ struct copy_args {
+-    PixmapPtr           src_pixmap;
++    DrawablePtr         src_drawable;
+     glamor_pixmap_fbo   *src;
+     uint32_t            bitplane;
+     int                 dx, dy;
+@@ -77,7 +77,7 @@ use_copyplane(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+     glamor_set_color(drawable, gc->bgPixel, prog->bg_uniform);
+ 
+     /* XXX handle 2 10 10 10 and 1555 formats; presumably the pixmap private knows this? */
+-    switch (args->src_pixmap->drawable.depth) {
++    switch (args->src_drawable->depth) {
+     case 30:
+         glUniform4ui(prog->bitplane_uniform,
+                      (args->bitplane >> 20) & 0x3ff,
+@@ -401,7 +401,7 @@ glamor_copy_fbo_fbo_draw(DrawablePtr src,
+             goto bail_ctx;
+     }
+ 
+-    args.src_pixmap = src_pixmap;
++    args.src_drawable = src;
+     args.bitplane = bitplane;
+ 
+     /* Set up the vertex buffers for the points */
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1065-BACKPORT-composite-Free-cs-implicitRedirectExceptions-in-comp.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1065-BACKPORT-composite-Free-cs-implicitRedirectExceptions-in-comp.patch
@@ -1,0 +1,26 @@
+From c19a3fc72c02fb57af182dfbc92355cf120b0ac2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Thu, 29 Jun 2023 10:57:51 +0200
+Subject: [PATCH 065/105] composite: Free cs->implicitRedirectExceptions in
+ compCloseScreen
+
+Fixes leaking the memory it points to.
+---
+ composite/compinit.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/composite/compinit.c b/composite/compinit.c
+index a62c8d3c4..3e2acc001 100644
+--- a/composite/compinit.c
++++ b/composite/compinit.c
+@@ -59,6 +59,7 @@ compCloseScreen(ScreenPtr pScreen)
+     Bool ret;
+ 
+     free(cs->alternateVisuals);
++    free(cs->implicitRedirectExceptions);
+ 
+     pScreen->CloseScreen = cs->CloseScreen;
+     pScreen->InstallColormap = cs->InstallColormap;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1066-BACKPORT-composite-Expose-CompositeIsImplicitRedirectExceptio.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1066-BACKPORT-composite-Expose-CompositeIsImplicitRedirectExceptio.patch
@@ -1,0 +1,54 @@
+From 8f1a67458dfd5c4356a835da1fd9d130f5755de9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Fri, 23 Jun 2023 18:30:07 +0200
+Subject: [PATCH 066/105] composite: Expose
+ CompositeIsImplicitRedirectException
+
+Make it usable by code outside of the composite layer.
+---
+ composite/compositeext.h | 2 ++
+ composite/compwindow.c   | 8 ++++----
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/composite/compositeext.h b/composite/compositeext.h
+index 5aad0735e..27ce7ce40 100644
+--- a/composite/compositeext.h
++++ b/composite/compositeext.h
+@@ -41,6 +41,8 @@ extern _X_EXPORT Bool CompositeRegisterImplicitRedirectionException(ScreenPtr pS
+ 
+ 
+ extern _X_EXPORT Bool compIsAlternateVisual(ScreenPtr pScreen, XID visual);
++Bool CompositeIsImplicitRedirectException(ScreenPtr pScreen,
++                                          XID parentVisual, XID winVisual);
+ extern _X_EXPORT RESTYPE CompositeClientWindowType;
+ 
+ #endif                          /* _COMPOSITEEXT_H_ */
+diff --git a/composite/compwindow.c b/composite/compwindow.c
+index 9a651636e..0bdcd8aa7 100644
+--- a/composite/compwindow.c
++++ b/composite/compwindow.c
+@@ -339,9 +339,9 @@ compIsAlternateVisual(ScreenPtr pScreen, XID visual)
+     return FALSE;
+ }
+ 
+-static Bool
+-compIsImplicitRedirectException(ScreenPtr pScreen,
+-                                XID parentVisual, XID winVisual)
++Bool
++CompositeIsImplicitRedirectException(ScreenPtr pScreen,
++                                     XID parentVisual, XID winVisual)
+ {
+     CompScreenPtr cs = GetCompScreen(pScreen);
+     int i;
+@@ -362,7 +362,7 @@ compImplicitRedirect(WindowPtr pWin, WindowPtr pParent)
+         XID winVisual = wVisual(pWin);
+         XID parentVisual = wVisual(pParent);
+ 
+-        if (compIsImplicitRedirectException(pScreen, parentVisual, winVisual))
++        if (CompositeIsImplicitRedirectException(pScreen, parentVisual, winVisual))
+             return FALSE;
+ 
+         if (winVisual != parentVisual &&
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1067-BACKPORT-glamor-Make-glamor_solid_boxes-take-a-DrawablePtr.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1067-BACKPORT-glamor-Make-glamor_solid_boxes-take-a-DrawablePtr.patch
@@ -1,0 +1,108 @@
+From 16d3ad81b6bc68d9e812956a763eeff4ef534607 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Wed, 19 Jul 2023 18:00:18 +0200
+Subject: [PATCH 067/105] glamor: Make glamor_solid_boxes take a DrawablePtr
+
+Instead of a PixmapPtr. Gives better results if the window depth
+doesn't match the backing pixmap depth.
+
+Closes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1565
+---
+ glamor/glamor_compositerects.c | 8 +++-----
+ glamor/glamor_priv.h           | 2 +-
+ glamor/glamor_text.c           | 7 ++-----
+ glamor/glamor_utils.c          | 3 +--
+ 4 files changed, 7 insertions(+), 13 deletions(-)
+
+diff --git a/glamor/glamor_compositerects.c b/glamor/glamor_compositerects.c
+index 199e62705..0796fed41 100644
+--- a/glamor/glamor_compositerects.c
++++ b/glamor/glamor_compositerects.c
+@@ -227,12 +227,10 @@ glamor_composite_rectangles(CARD8 op,
+     boxes = pixman_region_rectangles(&region, &num_boxes);
+     if (op == PictOpSrc || op == PictOpClear) {
+         CARD32 pixel;
+-        int dst_x, dst_y;
+ 
+-        glamor_get_drawable_deltas(dst->pDrawable, pixmap, &dst_x, &dst_y);
+-        pixman_region_translate(&region, dst_x, dst_y);
++        pixman_region_translate(&region, -dst->pDrawable->x, -dst->pDrawable->y);
+ 
+-        DEBUGF("%s: pixmap +(%d, %d) extents (%d, %d),(%d, %d)\n",
++        DEBUGF("%s: drawable extents (%d, %d),(%d, %d)\n",
+                __FUNCTION__, dst_x, dst_y,
+                RegionExtents(&region)->x1, RegionExtents(&region)->y1,
+                RegionExtents(&region)->x2, RegionExtents(&region)->y2);
+@@ -241,7 +239,7 @@ glamor_composite_rectangles(CARD8 op,
+             pixel = 0;
+         else
+             miRenderColorToPixel(dst->pFormat, color, &pixel);
+-        glamor_solid_boxes(pixmap, boxes, num_boxes, pixel);
++        glamor_solid_boxes(dst->pDrawable, boxes, num_boxes, pixel);
+ 
+         goto done;
+     }
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index 1032b880b..9c9a3485f 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -871,7 +871,7 @@ glamor_solid(PixmapPtr pixmap, int x, int y, int width, int height,
+              unsigned long fg_pixel);
+ 
+ void
+-glamor_solid_boxes(PixmapPtr pixmap,
++glamor_solid_boxes(DrawablePtr drawable,
+                    BoxPtr box, int nbox, unsigned long fg_pixel);
+ 
+ 
+diff --git a/glamor/glamor_text.c b/glamor/glamor_text.c
+index a559aea8a..5343cc93b 100644
+--- a/glamor/glamor_text.c
++++ b/glamor/glamor_text.c
+@@ -432,7 +432,6 @@ glamor_image_text(DrawablePtr drawable, GCPtr gc,
+         int c;
+         RegionRec region;
+         BoxRec box;
+-        int off_x, off_y;
+ 
+         /* Check planemask before drawing background to
+          * bail early if it's not OK
+@@ -443,8 +442,6 @@ glamor_image_text(DrawablePtr drawable, GCPtr gc,
+             if (charinfo[c])
+                 width += charinfo[c]->metrics.characterWidth;
+ 
+-        glamor_get_drawable_deltas(drawable, pixmap, &off_x, &off_y);
+-
+         if (width >= 0) {
+             box.x1 = drawable->x + x;
+             box.x2 = drawable->x + x + width;
+@@ -456,8 +453,8 @@ glamor_image_text(DrawablePtr drawable, GCPtr gc,
+         box.y2 = drawable->y + y + gc->font->info.fontDescent;
+         RegionInit(&region, &box, 1);
+         RegionIntersect(&region, &region, gc->pCompositeClip);
+-        RegionTranslate(&region, off_x, off_y);
+-        glamor_solid_boxes(pixmap, RegionRects(&region), RegionNumRects(&region), gc->bgPixel);
++        RegionTranslate(&region, -drawable->x, -drawable->y);
++        glamor_solid_boxes(drawable, RegionRects(&region), RegionNumRects(&region), gc->bgPixel);
+         RegionUninit(&region);
+     }
+ 
+diff --git a/glamor/glamor_utils.c b/glamor/glamor_utils.c
+index d3e6fd3ff..8f085da3f 100644
+--- a/glamor/glamor_utils.c
++++ b/glamor/glamor_utils.c
+@@ -23,10 +23,9 @@
+ #include "glamor_priv.h"
+ 
+ void
+-glamor_solid_boxes(PixmapPtr pixmap,
++glamor_solid_boxes(DrawablePtr drawable,
+                    BoxPtr box, int nbox, unsigned long fg_pixel)
+ {
+-    DrawablePtr drawable = &pixmap->drawable;
+     GCPtr gc;
+     xRectangle *rect;
+     int n;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1068-BACKPORT-glamor-Ignore-destination-alpha-as-necessary-for-com.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1068-BACKPORT-glamor-Ignore-destination-alpha-as-necessary-for-com.patch
@@ -1,0 +1,69 @@
+From 4323011435285609496bcca3b1245fc42d5c290f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Tue, 12 Sep 2023 16:57:16 +0200
+Subject: [PATCH 068/105] glamor: Ignore destination alpha as necessary for
+ composite operation
+
+If the destination drawable is a window with effective depth 24 backed
+by a depth 32 pixmap.
+
+Closes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1575
+---
+ glamor/glamor_priv.h   |  1 +
+ glamor/glamor_render.c | 14 +++++++++++++-
+ 2 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index 9c9a3485f..1ba71e421 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -111,6 +111,7 @@ enum shader_mask {
+ enum shader_dest_swizzle {
+     SHADER_DEST_SWIZZLE_DEFAULT,
+     SHADER_DEST_SWIZZLE_ALPHA_TO_RED,
++    SHADER_DEST_SWIZZLE_IGNORE_ALPHA,
+     SHADER_DEST_SWIZZLE_COUNT,
+ };
+ 
+diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
+index 889fe1b36..a070f075e 100644
+--- a/glamor/glamor_render.c
++++ b/glamor/glamor_render.c
+@@ -197,6 +197,11 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "	float undef;\n"
+         "	return vec4(color.a, undef, undef, undef);"
+         "}";
++    const char *dest_swizzle_ignore_alpha =
++        "vec4 dest_swizzle(vec4 color)\n"
++        "{"
++        "	return vec4(color.xyz, 1.0);"
++        "}";
+ 
+     const char *in_normal =
+         "void main()\n"
+@@ -286,6 +291,9 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+     case SHADER_DEST_SWIZZLE_ALPHA_TO_RED:
+         dest_swizzle = dest_swizzle_alpha_to_red;
+         break;
++    case SHADER_DEST_SWIZZLE_IGNORE_ALPHA:
++        dest_swizzle = dest_swizzle_ignore_alpha;
++        break;
+     default:
+         FatalError("Bad composite shader dest swizzle");
+     }
+@@ -938,7 +946,11 @@ glamor_composite_choose_shader(CARD8 op,
+         glamor_priv->formats[8].format == GL_RED) {
+         key.dest_swizzle = SHADER_DEST_SWIZZLE_ALPHA_TO_RED;
+     } else {
+-        key.dest_swizzle = SHADER_DEST_SWIZZLE_DEFAULT;
++        if (dest_pixmap->drawable.depth == 32 &&
++            glamor_drawable_effective_depth(dest->pDrawable) == 24)
++            key.dest_swizzle = SHADER_DEST_SWIZZLE_IGNORE_ALPHA;
++        else
++            key.dest_swizzle = SHADER_DEST_SWIZZLE_DEFAULT;
+     }
+ 
+     if (source && source->alphaMap) {
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1069-BACKPORT-glamor-fixes-GL_INVALID_ENUM-errors-on-ES-if-there-i.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1069-BACKPORT-glamor-fixes-GL_INVALID_ENUM-errors-on-ES-if-there-i.patch
@@ -1,0 +1,34 @@
+From 802d45d8f8c74910cf50d0722b1e41ba8297e8e0 Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Fri, 2 Dec 2022 16:22:15 +0300
+Subject: [PATCH 069/105] glamor: fixes GL_INVALID_ENUM errors on ES if there
+ is no quads
+
+If there is no quads to draw, then we have a possibility to call
+glDrawElements with type as zero, which will generate
+GL_INVALID_ENUM error. While this error is harmless, it is annoying.
+
+Signed-off-by: Konstantin <ria.freelander@gmail.com>
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+---
+ glamor/glamor.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index 617766c2a..848b484cf 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -307,6 +307,10 @@ glamor_gldrawarrays_quads_using_indices(glamor_screen_private *glamor_priv,
+ {
+     unsigned i;
+ 
++    /* If there is no quads to draw, just exit */
++    if (count == 0)
++        return;
++
+     /* For a single quad, don't bother with an index buffer. */
+     if (count ==  1)
+         goto fallback;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1070-BACKPORT-glamor-add-gl_PointSize-for-ES-shaders.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1070-BACKPORT-glamor-add-gl_PointSize-for-ES-shaders.patch
@@ -1,0 +1,72 @@
+From 162a88d2b35e965193773c0b48c8668a046c371c Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Tue, 19 Jul 2022 11:22:30 +0300
+Subject: [PATCH 070/105] glamor: add gl_PointSize for ES shaders
+
+GLES3.2 spec, page 126:
+> The variable gl_PointSize is intended for a shader to write
+> the size of the point to be rasterized. It is measured in pixels.
+> If gl_PointSize is not written to, its value
+> is undefined in subsequent pipe stages.
+
+If glamor shader is use points, we should define gl_PointSize for GLES.
+On Desktop GL, it "just work" due to default gl_PointSize is 1.
+
+As @anholt requested, define this only for minimal amount of shaders
+(point and glyphbit ones), to make sure than performance will not
+affected
+
+Reviewed-by: Emma Anholt <emma@anholt.net>
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Signed-off-by: Konstantin <ria.freelander@gmail.com>
+---
+ glamor/glamor_glyphblt.c | 1 +
+ glamor/glamor_points.c   | 3 ++-
+ glamor/glamor_priv.h     | 5 +++++
+ 3 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/glamor/glamor_glyphblt.c b/glamor/glamor_glyphblt.c
+index 808e9066b..ddc02656d 100644
+--- a/glamor/glamor_glyphblt.c
++++ b/glamor/glamor_glyphblt.c
+@@ -34,6 +34,7 @@ static const glamor_facet glamor_facet_poly_glyph_blt = {
+     .name = "poly_glyph_blt",
+     .vs_vars = "attribute vec2 primitive;\n",
+     .vs_exec = ("       vec2 pos = vec2(0,0);\n"
++                GLAMOR_DEFAULT_POINT_SIZE
+                 GLAMOR_POS(gl_Position, primitive)),
+ };
+ 
+diff --git a/glamor/glamor_points.c b/glamor/glamor_points.c
+index 8f0e4b1da..d6d6784f7 100644
+--- a/glamor/glamor_points.c
++++ b/glamor/glamor_points.c
+@@ -32,7 +32,8 @@
+ static const glamor_facet glamor_facet_point = {
+     .name = "poly_point",
+     .vs_vars = "attribute vec2 primitive;\n",
+-    .vs_exec = GLAMOR_POS(gl_Position, primitive),
++    .vs_exec = (GLAMOR_DEFAULT_POINT_SIZE
++                GLAMOR_POS(gl_Position, primitive)),
+ };
+ 
+ static Bool
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index 1ba71e421..e2652449f 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -49,6 +49,11 @@
+     "precision mediump float;\n"  \
+     "#endif\n"
+ 
++#define GLAMOR_DEFAULT_POINT_SIZE  \
++    "#ifdef GL_ES\n"              \
++    "       gl_PointSize = 1.0;\n"  \
++    "#endif\n"
++
+ #include "glyphstr.h"
+ 
+ #include "glamor_debug.h"
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1071-BACKPORT-glamor-support-GLES3-shaders.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1071-BACKPORT-glamor-support-GLES3-shaders.patch
@@ -1,0 +1,768 @@
+From 5ab4fad291daba8ddb9415885a396f0355b90d1c Mon Sep 17 00:00:00 2001
+From: Konstantin Pugin <ria.freelander@gmail.com>
+Date: Sun, 24 Jul 2022 16:03:51 +0300
+Subject: [PATCH 071/105] glamor: support GLES3 shaders
+
+Some hardware (preferably mobile) working on GLES3 way faster than
+on desktop GL and supports more features. This commit will allow using
+GLES3 if glamor is running over GL ES, and version 3 is supported.
+
+Changes are the following:
+1. Add compatibility layer for 120/GLES2 shaders with defines in and out
+2. Switch attribute and varying to in and out in almost all shaders
+   (aside gradient)
+3. Add newGL-only frag_color variable, which defines as gl_FragColor on
+   old pipelines
+4. Switch all shaders to use frag_color.
+5. Previous commit is reverted, because now we have more than one GL ES
+version, previous commit used to set version 100 for all ES shaders, which
+is not true for ES 3
+
+Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
+---
+ glamor/glamor.c                  | 12 +-----
+ glamor/glamor_composite_glyphs.c | 10 ++---
+ glamor/glamor_copy.c             | 12 +++---
+ glamor/glamor_dash.c             | 14 +++----
+ glamor/glamor_glyphblt.c         |  2 +-
+ glamor/glamor_lines.c            |  2 +-
+ glamor/glamor_points.c           |  2 +-
+ glamor/glamor_priv.h             | 13 +++++++
+ glamor/glamor_program.c          | 54 ++++++++++++++++-----------
+ glamor/glamor_rects.c            |  4 +-
+ glamor/glamor_render.c           | 64 ++++++++++++++++----------------
+ glamor/glamor_segs.c             |  2 +-
+ glamor/glamor_spans.c            |  2 +-
+ glamor/glamor_text.c             | 14 +++----
+ glamor/glamor_xv.c               | 30 +++++++--------
+ 15 files changed, 125 insertions(+), 112 deletions(-)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index 848b484cf..a2cee41a0 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -689,17 +689,6 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+ 
+     glamor_priv->glsl_version = epoxy_glsl_version();
+ 
+-    if (glamor_priv->is_gles) {
+-        /* Force us back to the base version of our programs on an ES
+-         * context, anyway.  Basically glamor only uses desktop 1.20
+-         * or 1.30 currently.  1.30's new features are also present in
+-         * ES 3.0, but our glamor_program.c constructions use a lot of
+-         * compatibility features (to reduce the diff between 1.20 and
+-         * 1.30 programs).
+-         */
+-        glamor_priv->glsl_version = 120;
+-    }
+-
+     /* We'd like to require GL_ARB_map_buffer_range or
+      * GL_OES_map_buffer_range, since it offers more information to
+      * the driver than plain old glMapBuffer() or glBufferSubData().
+@@ -733,6 +722,7 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+          * etnaviv offers GLSL 140 with OpenGL 2.1.
+          */
+         if (glamor_glsl_has_ints(glamor_priv) &&
++            !glamor_priv->is_gles &&
+             !epoxy_has_gl_extension("GL_ARB_instanced_arrays"))
+                 glamor_priv->glsl_version = 120;
+     } else {
+diff --git a/glamor/glamor_composite_glyphs.c b/glamor/glamor_composite_glyphs.c
+index 7911e0009..f208504dd 100644
+--- a/glamor/glamor_composite_glyphs.c
++++ b/glamor/glamor_composite_glyphs.c
+@@ -180,16 +180,16 @@ glamor_glyph_add(struct glamor_glyph_atlas *atlas, DrawablePtr glyph_draw)
+ static const glamor_facet glamor_facet_composite_glyphs_130 = {
+     .name = "composite_glyphs",
+     .version = 130,
+-    .vs_vars = ("attribute vec4 primitive;\n"
+-                "attribute vec2 source;\n"
+-                "varying vec2 glyph_pos;\n"),
++    .vs_vars = ("in vec4 primitive;\n"
++                "in vec2 source;\n"
++                "out vec2 glyph_pos;\n"),
+     .vs_exec = ("       vec2 pos = primitive.zw * vec2(gl_VertexID&1, (gl_VertexID&2)>>1);\n"
+                 GLAMOR_POS(gl_Position, (primitive.xy + pos))
+                 "       glyph_pos = (source + pos) * ATLAS_DIM_INV;\n"),
+-    .fs_vars = ("varying vec2 glyph_pos;\n"
++    .fs_vars = ("in vec2 glyph_pos;\n"
+                 "out vec4 color0;\n"
+                 "out vec4 color1;\n"),
+-    .fs_exec = ("       vec4 mask = texture2D(atlas, glyph_pos);\n"),
++    .fs_exec = ("       vec4 mask = texture(atlas, glyph_pos);\n"),
+     .source_name = "source",
+     .locations = glamor_program_location_atlas,
+ };
+diff --git a/glamor/glamor_copy.c b/glamor/glamor_copy.c
+index 0ff7f28e7..67465867b 100644
+--- a/glamor/glamor_copy.c
++++ b/glamor/glamor_copy.c
+@@ -49,10 +49,10 @@ use_copyarea(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ 
+ static const glamor_facet glamor_facet_copyarea = {
+     "copy_area",
+-    .vs_vars = "attribute vec2 primitive;\n",
++    .vs_vars = "in vec2 primitive;\n",
+     .vs_exec = (GLAMOR_POS(gl_Position, primitive.xy)
+                 "       fill_pos = (fill_offset + primitive.xy) * fill_size_inv;\n"),
+-    .fs_exec = "       gl_FragColor = texture2D(sampler, fill_pos);\n",
++    .fs_exec = "       frag_color = texture(sampler, fill_pos);\n",
+     .locations = glamor_program_location_fillsamp | glamor_program_location_fillpos,
+     .use = use_copyarea,
+ };
+@@ -141,14 +141,14 @@ use_copyplane(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ static const glamor_facet glamor_facet_copyplane = {
+     "copy_plane",
+     .version = 130,
+-    .vs_vars = "attribute vec2 primitive;\n",
++    .vs_vars = "in vec2 primitive;\n",
+     .vs_exec = (GLAMOR_POS(gl_Position, (primitive.xy))
+                 "       fill_pos = (fill_offset + primitive.xy) * fill_size_inv;\n"),
+-    .fs_exec = ("       uvec4 bits = uvec4(round(texture2D(sampler, fill_pos) * bitmul));\n"
++    .fs_exec = ("       uvec4 bits = uvec4(round(texture(sampler, fill_pos) * bitmul));\n"
+                 "       if ((bits & bitplane) != uvec4(0,0,0,0))\n"
+-                "               gl_FragColor = fg;\n"
++                "               frag_color = fg;\n"
+                 "       else\n"
+-                "               gl_FragColor = bg;\n"),
++                "               frag_color = bg;\n"),
+     .locations = glamor_program_location_fillsamp|glamor_program_location_fillpos|glamor_program_location_fg|glamor_program_location_bg|glamor_program_location_bitplane,
+     .use = use_copyplane,
+ };
+diff --git a/glamor/glamor_dash.c b/glamor/glamor_dash.c
+index e0fe0e7e0..828969d91 100644
+--- a/glamor/glamor_dash.c
++++ b/glamor/glamor_dash.c
+@@ -27,8 +27,8 @@
+ #include "glamor_prepare.h"
+ 
+ static const char dash_vs_vars[] =
+-    "attribute vec3 primitive;\n"
+-    "varying float dash_offset;\n";
++    "in vec3 primitive;\n"
++    "out float dash_offset;\n";
+ 
+ static const char dash_vs_exec[] =
+     "       dash_offset = primitive.z / dash_length;\n"
+@@ -36,20 +36,20 @@ static const char dash_vs_exec[] =
+     GLAMOR_POS(gl_Position, primitive.xy);
+ 
+ static const char dash_fs_vars[] =
+-    "varying float dash_offset;\n";
++    "in float dash_offset;\n";
+ 
+ static const char on_off_fs_exec[] =
+-    "       float pattern = texture2D(dash, vec2(dash_offset, 0.5)).w;\n"
++    "       float pattern = texture(dash, vec2(dash_offset, 0.5)).w;\n"
+     "       if (pattern == 0.0)\n"
+     "               discard;\n";
+ 
+ /* XXX deal with stippled double dashed lines once we have stippling support */
+ static const char double_fs_exec[] =
+-    "       float pattern = texture2D(dash, vec2(dash_offset, 0.5)).w;\n"
++    "       float pattern = texture(dash, vec2(dash_offset, 0.5)).w;\n"
+     "       if (pattern == 0.0)\n"
+-    "               gl_FragColor = bg;\n"
++    "               frag_color = bg;\n"
+     "       else\n"
+-    "               gl_FragColor = fg;\n";
++    "               frag_color = fg;\n";
+ 
+ 
+ static const glamor_facet glamor_facet_on_off_dash_lines = {
+diff --git a/glamor/glamor_glyphblt.c b/glamor/glamor_glyphblt.c
+index ddc02656d..44f668818 100644
+--- a/glamor/glamor_glyphblt.c
++++ b/glamor/glamor_glyphblt.c
+@@ -32,7 +32,7 @@
+ 
+ static const glamor_facet glamor_facet_poly_glyph_blt = {
+     .name = "poly_glyph_blt",
+-    .vs_vars = "attribute vec2 primitive;\n",
++    .vs_vars = "in vec2 primitive;\n",
+     .vs_exec = ("       vec2 pos = vec2(0,0);\n"
+                 GLAMOR_DEFAULT_POINT_SIZE
+                 GLAMOR_POS(gl_Position, primitive)),
+diff --git a/glamor/glamor_lines.c b/glamor/glamor_lines.c
+index ec70804ac..c9b776bb5 100644
+--- a/glamor/glamor_lines.c
++++ b/glamor/glamor_lines.c
+@@ -27,7 +27,7 @@
+ 
+ static const glamor_facet glamor_facet_poly_lines = {
+     .name = "poly_lines",
+-    .vs_vars = "attribute vec2 primitive;\n",
++    .vs_vars = "in vec2 primitive;\n",
+     .vs_exec = ("       vec2 pos = vec2(0.0,0.0);\n"
+                 GLAMOR_POS(gl_Position, primitive.xy)),
+ };
+diff --git a/glamor/glamor_points.c b/glamor/glamor_points.c
+index d6d6784f7..91b5e4789 100644
+--- a/glamor/glamor_points.c
++++ b/glamor/glamor_points.c
+@@ -31,7 +31,7 @@
+ 
+ static const glamor_facet glamor_facet_point = {
+     .name = "poly_point",
+-    .vs_vars = "attribute vec2 primitive;\n",
++    .vs_vars = "in vec2 primitive;\n",
+     .vs_exec = (GLAMOR_DEFAULT_POINT_SIZE
+                 GLAMOR_POS(gl_Position, primitive)),
+ };
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index e2652449f..712bd6a33 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -54,6 +54,19 @@
+     "       gl_PointSize = 1.0;\n"  \
+     "#endif\n"
+ 
++#define GLAMOR_COMPAT_DEFINES_VS  \
++    "#define in attribute\n" \
++    "#define out varying\n"  \
++
++#define GLAMOR_COMPAT_DEFINES_FS  \
++    "#if __VERSION__ < 130\n" \
++    "#define in varying\n"  \
++    "#define frag_color gl_FragColor\n" \
++    "#define texture texture2D\n" \
++    "#else\n" \
++    "out vec4 frag_color;\n" \
++    "#endif\n"
++
+ #include "glyphstr.h"
+ 
+ #include "glamor_debug.h"
+diff --git a/glamor/glamor_program.c b/glamor/glamor_program.c
+index 9ee945d11..6f08e3211 100644
+--- a/glamor/glamor_program.c
++++ b/glamor/glamor_program.c
+@@ -32,7 +32,7 @@ use_solid(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ 
+ const glamor_facet glamor_fill_solid = {
+     .name = "solid",
+-    .fs_exec = "       gl_FragColor = fg;\n",
++    .fs_exec = "       frag_color = fg;\n",
+     .locations = glamor_program_location_fg,
+     .use = use_solid,
+ };
+@@ -46,7 +46,7 @@ use_tile(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ static const glamor_facet glamor_fill_tile = {
+     .name = "tile",
+     .vs_exec =  "       fill_pos = (fill_offset + primitive.xy + pos) * fill_size_inv;\n",
+-    .fs_exec =  "       gl_FragColor = texture2D(sampler, fill_pos);\n",
++    .fs_exec =  "       frag_color = texture(sampler, fill_pos);\n",
+     .locations = glamor_program_location_fillsamp | glamor_program_location_fillpos,
+     .use = use_tile,
+ };
+@@ -62,10 +62,10 @@ use_stipple(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ static const glamor_facet glamor_fill_stipple = {
+     .name = "stipple",
+     .vs_exec =  "       fill_pos = (fill_offset + primitive.xy + pos) * fill_size_inv;\n",
+-    .fs_exec = ("       float a = texture2D(sampler, fill_pos).w;\n"
++    .fs_exec = ("       float a = texture(sampler, fill_pos).w;\n"
+                 "       if (a == 0.0)\n"
+                 "               discard;\n"
+-                "       gl_FragColor = fg;\n"),
++                "       frag_color = fg;\n"),
+     .locations = glamor_program_location_fg | glamor_program_location_fillsamp | glamor_program_location_fillpos,
+     .use = use_stipple,
+ };
+@@ -82,11 +82,11 @@ use_opaque_stipple(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *a
+ static const glamor_facet glamor_fill_opaque_stipple = {
+     .name = "opaque_stipple",
+     .vs_exec =  "       fill_pos = (fill_offset + primitive.xy + pos) * fill_size_inv;\n",
+-    .fs_exec = ("       float a = texture2D(sampler, fill_pos).w;\n"
++    .fs_exec = ("       float a = texture(sampler, fill_pos).w;\n"
+                 "       if (a == 0.0)\n"
+-                "               gl_FragColor = bg;\n"
++                "               frag_color = bg;\n"
+                 "       else\n"
+-                "               gl_FragColor = fg;\n"),
++                "               frag_color = fg;\n"),
+     .locations = glamor_program_location_fg | glamor_program_location_bg | glamor_program_location_fillsamp | glamor_program_location_fillpos,
+     .use = use_opaque_stipple
+ };
+@@ -121,12 +121,15 @@ static glamor_location_var location_vars[] = {
+         .location = glamor_program_location_fillpos,
+         .vs_vars = ("uniform vec2 fill_offset;\n"
+                     "uniform vec2 fill_size_inv;\n"
+-                    "varying vec2 fill_pos;\n"),
+-        .fs_vars = ("varying vec2 fill_pos;\n")
++                    "out vec2 fill_pos;\n"),
++        .fs_vars = ("in vec2 fill_pos;\n")
+     },
+     {
+         .location = glamor_program_location_font,
+-        .fs_vars = "uniform usampler2D font;\n",
++        .fs_vars = ("#ifdef GL_ES\n"
++                    "precision mediump usampler2D;\n"
++                    "#endif\n"
++                    "uniform usampler2D font;\n"),
+     },
+     {
+         .location = glamor_program_location_bitplane,
+@@ -188,6 +191,7 @@ fs_location_vars(glamor_program_location locations)
+ static const char vs_template[] =
+     "%s"                                /* version */
+     "%s"                                /* exts */
++    "%s"                                /* in/out defines */
+     "%s"                                /* defines */
+     "%s"                                /* prim vs_vars */
+     "%s"                                /* fill vs_vars */
+@@ -204,6 +208,7 @@ static const char fs_template[] =
+     "%s"                                /* prim fs_extensions */
+     "%s"                                /* fill fs_extensions */
+     GLAMOR_DEFAULT_PRECISION
++    "%s"                                /* in/out defines */
+     "%s"                                /* defines */
+     "%s"                                /* prim fs_vars */
+     "%s"                                /* fill fs_vars */
+@@ -283,11 +288,13 @@ glamor_build_program(ScreenPtr          screen,
+             gpu_shader4 = TRUE;
+         }
+     }
+-    /* For now, fix shader version to GLES as 100. We will fall with 130 shaders
+-     * in previous check due to forcibly set 120 glsl for GLES. But this patch
+-     * makes xv shaders to work */
+-    if(version && glamor_priv->is_gles)
++
++    if (version == 130 && glamor_priv->is_gles && glamor_priv->glsl_version > 110)
++        version = 300;
++    else if (glamor_priv->is_gles)
+         version = 100;
++    else if (!version)
++        version = 120;
+ 
+     vs_vars = vs_location_vars(locations);
+     fs_vars = fs_location_vars(locations);
+@@ -298,7 +305,8 @@ glamor_build_program(ScreenPtr          screen,
+         goto fail;
+ 
+     if (version) {
+-        if (asprintf(&version_string, "#version %d\n", version) < 0)
++        if (asprintf(&version_string, "#version %d %s\n", version,
++                     glamor_priv->is_gles && version > 100 ? "es" : "") < 0)
+             version_string = NULL;
+         if (!version_string)
+             goto fail;
+@@ -308,6 +316,7 @@ glamor_build_program(ScreenPtr          screen,
+                  vs_template,
+                  str(version_string),
+                  gpu_shader4 ? "#extension GL_EXT_gpu_shader4 : require\n" : "",
++                 version < 130 ? GLAMOR_COMPAT_DEFINES_VS : "",
+                  str(defines),
+                  str(prim->vs_vars),
+                  str(fill->vs_vars),
+@@ -322,6 +331,7 @@ glamor_build_program(ScreenPtr          screen,
+                  str(prim->fs_extensions),
+                  str(fill->fs_extensions),
+                  gpu_shader4 ? "#extension GL_EXT_gpu_shader4 : require\n#define texelFetch texelFetch2D\n#define uint unsigned int\n" : "",
++                 GLAMOR_COMPAT_DEFINES_FS,
+                  str(defines),
+                  str(prim->fs_vars),
+                  str(fill->fs_vars),
+@@ -563,7 +573,7 @@ use_source_picture(CARD8 op, PicturePtr src, PicturePtr dst, glamor_program *pro
+ static const glamor_facet glamor_source_picture = {
+     .name = "render_picture",
+     .vs_exec =  "       fill_pos = (fill_offset + primitive.xy + pos) * fill_size_inv;\n",
+-    .fs_exec =  "       vec4 source = texture2D(sampler, fill_pos);\n",
++    .fs_exec =  "       vec4 source = texture(sampler, fill_pos);\n",
+     .locations = glamor_program_location_fillsamp | glamor_program_location_fillpos,
+     .use_render = use_source_picture,
+ };
+@@ -579,7 +589,7 @@ use_source_1x1_picture(CARD8 op, PicturePtr src, PicturePtr dst, glamor_program
+ 
+ static const glamor_facet glamor_source_1x1_picture = {
+     .name = "render_picture",
+-    .fs_exec =  "       vec4 source = texture2D(sampler, vec2(0.5));\n",
++    .fs_exec =  "       vec4 source = texture(sampler, vec2(0.5));\n",
+     .locations = glamor_program_location_fillsamp,
+     .use_render = use_source_1x1_picture,
+ };
+@@ -591,11 +601,11 @@ static const glamor_facet *glamor_facet_source[glamor_program_source_count] = {
+ };
+ 
+ static const char *glamor_combine[] = {
+-    [glamor_program_alpha_normal]    = "        gl_FragColor = source * mask.a;\n",
+-    [glamor_program_alpha_ca_first]  = "        gl_FragColor = source.a * mask;\n",
+-    [glamor_program_alpha_ca_second] = "        gl_FragColor = source * mask;\n",
+-    [glamor_program_alpha_dual_blend] = "       color0 = source * mask;\n"
+-                                        "       color1 = source.a * mask;\n",
++    [glamor_program_alpha_normal]    = "       frag_color = source * mask.a;\n",
++    [glamor_program_alpha_ca_first]  = "       frag_color = source.a * mask;\n",
++    [glamor_program_alpha_ca_second] = "       frag_color = source * mask;\n",
++    [glamor_program_alpha_dual_blend] = "      color0 = source * mask;\n"
++                                        "      color1 = source.a * mask;\n",
+     [glamor_program_alpha_dual_blend_gles2] = " gl_FragColor = source * mask;\n"
+                                               " gl_SecondaryFragColorEXT = source.a * mask;\n"
+ };
+diff --git a/glamor/glamor_rects.c b/glamor/glamor_rects.c
+index afe680d1b..aa05b8cef 100644
+--- a/glamor/glamor_rects.c
++++ b/glamor/glamor_rects.c
+@@ -28,8 +28,8 @@ static const glamor_facet glamor_facet_polyfillrect_130 = {
+     .name = "poly_fill_rect",
+     .version = 130,
+     .source_name = "size",
+-    .vs_vars = "attribute vec2 primitive;\n"
+-               "attribute vec2 size;\n",
++    .vs_vars = "in vec2 primitive;\n"
++               "in vec2 size;\n",
+     .vs_exec = ("       vec2 pos = size * vec2(gl_VertexID&1, (gl_VertexID&2)>>1);\n"
+                 GLAMOR_POS(gl_Position, (primitive.xy + pos))),
+ };
+diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
+index a070f075e..d678e6fc5 100644
+--- a/glamor/glamor_render.c
++++ b/glamor/glamor_render.c
+@@ -116,7 +116,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "			tex = (fract(tex) / wh.xy);\n"
+         "		}\n"
+         "	}\n"
+-        "	return texture2D(tex_image, tex);\n"
++        "	return texture(tex_image, tex);\n"
+         "}\n"
+         " vec4 rel_sampler_rgbx(sampler2D tex_image, vec2 tex, vec4 wh, int repeat)\n"
+         "{\n"
+@@ -129,7 +129,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "			tex = (fract(tex) / wh.xy);\n"
+         "		}\n"
+         "	}\n"
+-        "	return vec4(texture2D(tex_image, tex).rgb, 1.0);\n"
++        "	return vec4(texture(tex_image, tex).rgb, 1.0);\n"
+         "}\n";
+ 
+     const char *source_solid_fetch =
+@@ -139,7 +139,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "	return source;\n"
+         "}\n";
+     const char *source_alpha_pixmap_fetch =
+-        "varying vec2 source_texture;\n"
++        "in vec2 source_texture;\n"
+         "uniform sampler2D source_sampler;\n"
+         "uniform vec4 source_wh;"
+         "vec4 get_source()\n"
+@@ -148,7 +148,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "			        source_wh, source_repeat_mode);\n"
+         "}\n";
+     const char *source_pixmap_fetch =
+-        "varying vec2 source_texture;\n"
++        "in vec2 source_texture;\n"
+         "uniform sampler2D source_sampler;\n"
+         "uniform vec4 source_wh;\n"
+         "vec4 get_source()\n"
+@@ -168,7 +168,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "	return mask;\n"
+         "}\n";
+     const char *mask_alpha_pixmap_fetch =
+-        "varying vec2 mask_texture;\n"
++        "in vec2 mask_texture;\n"
+         "uniform sampler2D mask_sampler;\n"
+         "uniform vec4 mask_wh;\n"
+         "vec4 get_mask()\n"
+@@ -177,7 +177,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "			        mask_wh, mask_repeat_mode);\n"
+         "}\n";
+     const char *mask_pixmap_fetch =
+-        "varying vec2 mask_texture;\n"
++        "in vec2 mask_texture;\n"
+         "uniform sampler2D mask_sampler;\n"
+         "uniform vec4 mask_wh;\n"
+         "vec4 get_mask()\n"
+@@ -206,17 +206,17 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+     const char *in_normal =
+         "void main()\n"
+         "{\n"
+-        "	gl_FragColor = dest_swizzle(get_source() * get_mask().a);\n"
++        "	frag_color = dest_swizzle(get_source() * get_mask().a);\n"
+         "}\n";
+     const char *in_ca_source =
+         "void main()\n"
+         "{\n"
+-        "	gl_FragColor = dest_swizzle(get_source() * get_mask());\n"
++        "	frag_color = dest_swizzle(get_source() * get_mask());\n"
+         "}\n";
+     const char *in_ca_alpha =
+         "void main()\n"
+         "{\n"
+-        "	gl_FragColor = dest_swizzle(get_source().a * get_mask());\n"
++        "	frag_color = dest_swizzle(get_source().a * get_mask());\n"
+         "}\n";
+     const char *in_ca_dual_blend =
+         "out vec4 color0;\n"
+@@ -226,10 +226,6 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "	color0 = dest_swizzle(get_source() * get_mask());\n"
+         "	color1 = dest_swizzle(get_source().a * get_mask());\n"
+         "}\n";
+-    const char *header_ca_dual_blend =
+-        "#version 130\n";
+-    const char *header_ca_dual_blend_gpu_shader4 =
+-        "#version 120\n#extension GL_EXT_gpu_shader4 : require\n";
+     const char *in_ca_dual_blend_gles2 =
+         "void main()\n"
+         "{\n"
+@@ -238,14 +234,16 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "}\n";
+     const char *header_ca_dual_blend_gles2 =
+         "#version 100\n"
+-        "#extension GL_EXT_blend_func_extended : require\n";
++        "#extension GL_EXT_blend_func_extended : require\n"
++        GLAMOR_COMPAT_DEFINES_FS;
+ 
+     char *source;
+     const char *source_fetch;
+     const char *mask_fetch = "";
+     const char *in;
+     const char *header;
+-    const char *header_norm = "";
++    const char *header_norm = glamor_priv->glsl_version > 120 ? "#version 130\n" : "#version 120\n#extension GL_EXT_gpu_shader4 : require\n" GLAMOR_COMPAT_DEFINES_FS;
++    const char *header_es = glamor_priv->glsl_version > 100 ? "#version 300 es\n" : "#version 100\n" GLAMOR_COMPAT_DEFINES_FS;
+     const char *dest_swizzle;
+     GLuint prog;
+ 
+@@ -298,7 +296,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         FatalError("Bad composite shader dest swizzle");
+     }
+ 
+-    header = header_norm;
++    header = glamor_priv->is_gles ? header_es : header_norm;
+     switch (key->in) {
+     case glamor_program_alpha_normal:
+         in = in_normal;
+@@ -311,10 +309,6 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         break;
+     case glamor_program_alpha_dual_blend:
+         in = in_ca_dual_blend;
+-        if (glamor_priv->glsl_version >= 130)
+-           header = header_ca_dual_blend;
+-        else
+-           header = header_ca_dual_blend_gpu_shader4;
+         break;
+     case glamor_program_alpha_dual_blend_gles2:
+         in = in_ca_dual_blend_gles2;
+@@ -327,7 +321,8 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+     XNFasprintf(&source,
+                 "%s"
+                 GLAMOR_DEFAULT_PRECISION
+-                "%s%s%s%s%s%s%s", header, repeat_define, relocate_texture,
++                "%s%s%s%s%s%s%s%s", header, GLAMOR_COMPAT_DEFINES_FS,
++                repeat_define, relocate_texture,
+                 rel_sampler, source_fetch, mask_fetch, dest_swizzle, in);
+ 
+     prog = glamor_compile_glsl_prog(GL_FRAGMENT_SHADER, source);
+@@ -337,14 +332,14 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+ }
+ 
+ static GLuint
+-glamor_create_composite_vs(struct shader_key *key)
++glamor_create_composite_vs(glamor_screen_private* priv, struct shader_key *key)
+ {
+     const char *main_opening =
+-        "attribute vec4 v_position;\n"
+-        "attribute vec4 v_texcoord0;\n"
+-        "attribute vec4 v_texcoord1;\n"
+-        "varying vec2 source_texture;\n"
+-        "varying vec2 mask_texture;\n"
++        "in vec4 v_position;\n"
++        "in vec4 v_texcoord0;\n"
++        "in vec4 v_texcoord1;\n"
++        "out vec2 source_texture;\n"
++        "out vec2 mask_texture;\n"
+         "void main()\n"
+         "{\n"
+         "	gl_Position = v_position;\n";
+@@ -354,7 +349,9 @@ glamor_create_composite_vs(struct shader_key *key)
+     const char *source_coords_setup = "";
+     const char *mask_coords_setup = "";
+     const char *version_gles2 = "#version 100\n";
+-    const char *version = "";
++    const char *version_gles3 = "#version 300 es\n";
++    const char *version = priv->glsl_version > 120 ? "#version 130\n" : "#version 120\n";
++    const char *defines = priv->glsl_version > 120 ? "": GLAMOR_COMPAT_DEFINES_VS;
+     char *source;
+     GLuint prog;
+ 
+@@ -364,14 +361,17 @@ glamor_create_composite_vs(struct shader_key *key)
+     if (key->mask != SHADER_MASK_NONE && key->mask != SHADER_MASK_SOLID)
+         mask_coords_setup = mask_coords;
+ 
+-    if (key->in == glamor_program_alpha_dual_blend_gles2)
++    if (priv->is_gles)
+         version = version_gles2;
+ 
++    if (priv->is_gles && priv->glsl_version > 120)
++        version = version_gles3;
++
+     XNFasprintf(&source,
+                 "%s"
+                 GLAMOR_DEFAULT_PRECISION
+-                "%s%s%s%s",
+-                version, main_opening, source_coords_setup,
++                "%s%s%s%s%s",
++                version, defines, main_opening, source_coords_setup,
+                 mask_coords_setup, main_closing);
+ 
+     prog = glamor_compile_glsl_prog(GL_VERTEX_SHADER, source);
+@@ -389,7 +389,7 @@ glamor_create_composite_shader(ScreenPtr screen, struct shader_key *key,
+     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+ 
+     glamor_make_current(glamor_priv);
+-    vs = glamor_create_composite_vs(key);
++    vs = glamor_create_composite_vs(glamor_priv, key);
+     if (vs == 0)
+         return;
+     fs = glamor_create_composite_fs(glamor_priv, key);
+diff --git a/glamor/glamor_segs.c b/glamor/glamor_segs.c
+index 78c19ec48..7b0108f83 100644
+--- a/glamor/glamor_segs.c
++++ b/glamor/glamor_segs.c
+@@ -27,7 +27,7 @@
+ 
+ static const glamor_facet glamor_facet_poly_segment = {
+     .name = "poly_segment",
+-    .vs_vars = "attribute vec2 primitive;\n",
++    .vs_vars = "in vec2 primitive;\n",
+     .vs_exec = ("       vec2 pos = vec2(0.0,0.0);\n"
+                 GLAMOR_POS(gl_Position, primitive.xy)),
+ };
+diff --git a/glamor/glamor_spans.c b/glamor/glamor_spans.c
+index dfa37dc07..93beb61d5 100644
+--- a/glamor/glamor_spans.c
++++ b/glamor/glamor_spans.c
+@@ -29,7 +29,7 @@ glamor_program  fill_spans_progs[4];
+ static const glamor_facet glamor_facet_fillspans_130 = {
+     .name = "fill_spans",
+     .version = 130,
+-    .vs_vars =  "attribute vec3 primitive;\n",
++    .vs_vars =  "in vec3 primitive;\n",
+     .vs_exec = ("       vec2 pos = vec2(primitive.z,1) * vec2(gl_VertexID&1, (gl_VertexID&2)>>1);\n"
+                 GLAMOR_POS(gl_Position, (primitive.xy + pos))),
+ };
+diff --git a/glamor/glamor_text.c b/glamor/glamor_text.c
+index 5343cc93b..f1672d420 100644
+--- a/glamor/glamor_text.c
++++ b/glamor/glamor_text.c
+@@ -221,9 +221,9 @@ glamor_text(DrawablePtr drawable, GCPtr gc,
+ }
+ 
+ static const char vs_vars_text[] =
+-    "attribute vec4 primitive;\n"
+-    "attribute vec2 source;\n"
+-    "varying vec2 glyph_pos;\n";
++    "in vec4 primitive;\n"
++    "in vec2 source;\n"
++    "out vec2 glyph_pos;\n";
+ 
+ static const char vs_exec_text[] =
+     "       vec2 pos = primitive.zw * vec2(gl_VertexID&1, (gl_VertexID&2)>>1);\n"
+@@ -231,7 +231,7 @@ static const char vs_exec_text[] =
+     "       glyph_pos = source + pos;\n";
+ 
+ static const char fs_vars_text[] =
+-    "varying vec2 glyph_pos;\n";
++    "in vec2 glyph_pos;\n";
+ 
+ static const char fs_exec_text[] =
+     "       ivec2 itile_texture = ivec2(glyph_pos);\n"
+@@ -249,9 +249,9 @@ static const char fs_exec_te[] =
+     "       uint texel = texelFetch(font, itile_texture, 0).x;\n"
+     "       uint bit = (texel >> x) & uint(1);\n"
+     "       if (bit == uint(0))\n"
+-    "               gl_FragColor = bg;\n"
++    "               frag_color = bg;\n"
+     "       else\n"
+-    "               gl_FragColor = fg;\n";
++    "               frag_color = fg;\n";
+ 
+ static const glamor_facet glamor_facet_poly_text = {
+     .name = "poly_text",
+@@ -353,7 +353,7 @@ use_image_solid(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ 
+ static const glamor_facet glamor_facet_image_fill = {
+     .name = "solid",
+-    .fs_exec = "       gl_FragColor = fg;\n",
++    .fs_exec = "       frag_color = fg;\n",
+     .locations = glamor_program_location_fg,
+     .use = use_image_solid,
+ };
+diff --git a/glamor/glamor_xv.c b/glamor/glamor_xv.c
+index a3d6b3bc3..3467af86f 100644
+--- a/glamor/glamor_xv.c
++++ b/glamor/glamor_xv.c
+@@ -65,9 +65,9 @@ static const glamor_facet glamor_facet_xv_planar_2 = {
+     .version = 120,
+ 
+     .source_name = "v_texcoord0",
+-    .vs_vars = ("attribute vec2 position;\n"
+-                "attribute vec2 v_texcoord0;\n"
+-                "varying vec2 tcs;\n"),
++    .vs_vars = ("in vec2 position;\n"
++                "in vec2 v_texcoord0;\n"
++                "out vec2 tcs;\n"),
+     .vs_exec = (GLAMOR_POS(gl_Position, position)
+                 "        tcs = v_texcoord0;\n"),
+ 
+@@ -76,18 +76,18 @@ static const glamor_facet glamor_facet_xv_planar_2 = {
+                 "uniform vec4 offsetyco;\n"
+                 "uniform vec4 ucogamma;\n"
+                 "uniform vec4 vco;\n"
+-                "varying vec2 tcs;\n"),
++                "in vec2 tcs;\n"),
+     .fs_exec = (
+                 "        float sample;\n"
+                 "        vec2 sample_uv;\n"
+                 "        vec4 temp1;\n"
+-                "        sample = texture2D(y_sampler, tcs).w;\n"
++                "        sample = texture(y_sampler, tcs).w;\n"
+                 "        temp1.xyz = offsetyco.www * vec3(sample) + offsetyco.xyz;\n"
+-                "        sample_uv = texture2D(u_sampler, tcs).xy;\n"
++                "        sample_uv = texture(u_sampler, tcs).xy;\n"
+                 "        temp1.xyz = ucogamma.xyz * vec3(sample_uv.x) + temp1.xyz;\n"
+                 "        temp1.xyz = clamp(vco.xyz * vec3(sample_uv.y) + temp1.xyz, 0.0, 1.0);\n"
+                 "        temp1.w = 1.0;\n"
+-                "        gl_FragColor = temp1;\n"
++                "        frag_color = temp1;\n"
+                 ),
+ };
+ 
+@@ -97,9 +97,9 @@ static const glamor_facet glamor_facet_xv_planar_3 = {
+     .version = 120,
+ 
+     .source_name = "v_texcoord0",
+-    .vs_vars = ("attribute vec2 position;\n"
+-                "attribute vec2 v_texcoord0;\n"
+-                "varying vec2 tcs;\n"),
++    .vs_vars = ("in vec2 position;\n"
++                "in vec2 v_texcoord0;\n"
++                "out vec2 tcs;\n"),
+     .vs_exec = (GLAMOR_POS(gl_Position, position)
+                 "        tcs = v_texcoord0;\n"),
+ 
+@@ -109,18 +109,18 @@ static const glamor_facet glamor_facet_xv_planar_3 = {
+                 "uniform vec4 offsetyco;\n"
+                 "uniform vec4 ucogamma;\n"
+                 "uniform vec4 vco;\n"
+-                "varying vec2 tcs;\n"),
++                "in vec2 tcs;\n"),
+     .fs_exec = (
+                 "        float sample;\n"
+                 "        vec4 temp1;\n"
+-                "        sample = texture2D(y_sampler, tcs).w;\n"
++                "        sample = texture(y_sampler, tcs).w;\n"
+                 "        temp1.xyz = offsetyco.www * vec3(sample) + offsetyco.xyz;\n"
+-                "        sample = texture2D(u_sampler, tcs).w;\n"
++                "        sample = texture(u_sampler, tcs).w;\n"
+                 "        temp1.xyz = ucogamma.xyz * vec3(sample) + temp1.xyz;\n"
+-                "        sample = texture2D(v_sampler, tcs).w;\n"
++                "        sample = texture(v_sampler, tcs).w;\n"
+                 "        temp1.xyz = clamp(vco.xyz * vec3(sample) + temp1.xyz, 0.0, 1.0);\n"
+                 "        temp1.w = 1.0;\n"
+-                "        gl_FragColor = temp1;\n"
++                "        frag_color = temp1;\n"
+                 ),
+ };
+ 
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1072-BACKPORT-glamor-xv-Fix-invalid-accessing-of-plane-attributes-.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1072-BACKPORT-glamor-xv-Fix-invalid-accessing-of-plane-attributes-.patch
@@ -1,0 +1,33 @@
+From 545103bcfa5676a2a91422b3e6273970fc44a0cb Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Fri, 8 Nov 2019 15:44:41 +0800
+Subject: [PATCH 072/105] glamor: xv: Fix invalid accessing of plane attributes
+ for NV12
+
+NV12 only has 2 planes.
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+ glamor/glamor_xv.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/glamor/glamor_xv.c b/glamor/glamor_xv.c
+index 3467af86f..1548f8079 100644
+--- a/glamor/glamor_xv.c
++++ b/glamor/glamor_xv.c
+@@ -291,10 +291,10 @@ glamor_xv_query_image_attributes(int id,
+             pitches[0] = size;
+         size *= *h;
+         if (offsets)
+-            offsets[1] = offsets[2] = size;
++            offsets[1] = size;
+         tmp = ALIGN(*w, 4);
+         if (pitches)
+-            pitches[1] = pitches[2] = tmp;
++            pitches[1] = tmp;
+         tmp *= (*h >> 1);
+         size += tmp;
+         break;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1073-BACKPORT-glamor-accelerate-incomplete-textures-for-GL-ES.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1073-BACKPORT-glamor-accelerate-incomplete-textures-for-GL-ES.patch
@@ -1,0 +1,138 @@
+From 71cc77d8f38580fc297185c105bf9d69da080330 Mon Sep 17 00:00:00 2001
+From: Konstantin Pugin <ria.freelander@gmail.com>
+Date: Sun, 10 Jul 2022 17:08:44 +0300
+Subject: [PATCH 073/105] glamor: accelerate incomplete textures for GL ES
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+If texture can be uploaded to GL using glTexImage2D normally, but
+cannot be read back using glReadPixels, we still can accelerate it,
+but we cannot create pixmap with FBO using this texture type. So,
+add a flag to avoid such creations.
+
+This allow us to accelerate 8-bit glyph masks on GL ES 2.0, because those
+masks are used only as textures, and in next stages are rendered on RGBA
+surfaces normally, so, we do not need to call glReadPixels on them.
+
+This is needed for correctly working fonts on GL ES 2.0, due to inability
+to use GL_RED and texture swizzle. We should use GL_ALPHA there, and
+with this format we cannot have a complete framebuffer. But completed
+framebuffer, according to testing, is not required for fonts anyway.
+Also it fixes all 8-bit formats for GLES2.
+
+Fixes #1362
+Fixes #1411
+
+Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Acked-by: Michel Dänzer <mdaenzer@redhat.com>
+Acked-by: Martin Roukala <martin.roukala@mupuf.org>
+---
+ glamor/glamor.c      | 26 ++++++++++++++++++++------
+ glamor/glamor_priv.h |  7 +++++++
+ 2 files changed, 27 insertions(+), 6 deletions(-)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index a2cee41a0..9bd2b90db 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -216,7 +216,9 @@ glamor_create_pixmap(ScreenPtr screen, int w, int h, int depth,
+              w <= glamor_priv->glyph_max_dim &&
+              h <= glamor_priv->glyph_max_dim)
+          || (w == 0 && h == 0)
+-         || !glamor_priv->formats[depth].rendering_supported))
++         || !glamor_priv->formats[depth].rendering_supported
++         || (glamor_priv->formats[depth].texture_only &&
++              (usage != GLAMOR_CREATE_FBO_NO_FBO))))
+         return fbCreatePixmap(screen, w, h, depth, usage);
+     else
+         pixmap = fbCreatePixmap(screen, 0, 0, depth, usage);
+@@ -467,6 +469,7 @@ glamor_add_format(ScreenPtr screen, int depth, CARD32 render_format,
+ {
+     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+     struct glamor_format *f = &glamor_priv->formats[depth];
++    Bool texture_only = FALSE;
+ 
+     /* If we're trying to run on GLES, make sure that we get the read
+      * formats that we're expecting, since glamor_transfer relies on
+@@ -489,6 +492,13 @@ glamor_add_format(ScreenPtr screen, int depth, CARD32 render_format,
+         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+         glTexImage2D(GL_TEXTURE_2D, 0, internalformat, 1, 1, 0,
+                      format, type, NULL);
++        if (glGetError() != GL_NO_ERROR)
++        {
++            ErrorF("glamor: Cannot upload texture for depth %d.  "
++                   "Falling back to software.\n", depth);
++            glDeleteTextures(1, &tex);
++            return;
++        }
+ 
+         glGenFramebuffers(1, &fbo);
+         glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+@@ -500,21 +510,23 @@ glamor_add_format(ScreenPtr screen, int depth, CARD32 render_format,
+                    "Falling back to software.\n", depth);
+             glDeleteTextures(1, &tex);
+             glDeleteFramebuffers(1, &fbo);
+-            return;
++            texture_only = TRUE;
+         }
+ 
+-        glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &read_format);
+-        glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE, &read_type);
++        if (!texture_only) {
++            glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &read_format);
++            glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE, &read_type);
++        }
+ 
+         glDeleteTextures(1, &tex);
+         glDeleteFramebuffers(1, &fbo);
+ 
+-        if (format != read_format || type != read_type) {
++        if (!texture_only && (format != read_format || type != read_type)) {
+             ErrorF("glamor: Implementation returned 0x%x/0x%x read format/type "
+                    "for depth %d, expected 0x%x/0x%x.  "
+                    "Falling back to software.\n",
+                    read_format, read_type, depth, format, type);
+-            return;
++            texture_only = TRUE;
+         }
+     }
+ 
+@@ -524,6 +536,7 @@ glamor_add_format(ScreenPtr screen, int depth, CARD32 render_format,
+     f->format = format;
+     f->type = type;
+     f->rendering_supported = rendering_supported;
++    f->texture_only = texture_only;
+ }
+ 
+ /* Set up the GL format/types that glamor will use for the various depths
+@@ -617,6 +630,7 @@ glamor_setup_formats(ScreenPtr screen)
+     glamor_priv->cbcr_format.render_format = PICT_yuv2;
+     glamor_priv->cbcr_format.type = GL_UNSIGNED_BYTE;
+     glamor_priv->cbcr_format.rendering_supported = TRUE;
++    glamor_priv->cbcr_format.texture_only = FALSE;
+ }
+ 
+ /** Set up glamor for an already-configured GL context. */
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index 712bd6a33..e9e7fc90b 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -194,6 +194,13 @@ struct glamor_format {
+      * just before upload)
+      */
+     Bool rendering_supported;
++    /**
++     * Whether image with this depth is framebuffer-complete in GL.
++     * This flag is set on GL ES when rendering is supported without
++     * conversion, but reading from framebuffer can bring some caveats
++     * like different format combination or incomplete framebuffer.
++     */
++    Bool texture_only;
+ };
+ 
+ struct glamor_saved_procs {
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1074-BACKPORT-glamor-Don-t-require-EXT_gpu_shader4-unconditionally.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1074-BACKPORT-glamor-Don-t-require-EXT_gpu_shader4-unconditionally.patch
@@ -1,0 +1,32 @@
+From 79813baec0befd62f3d03f2a679ca0c4ffb3947b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ball=C3=B3=20Gy=C3=B6rgy?= <ballogyor@gmail.com>
+Date: Wed, 11 Oct 2023 16:01:13 +0200
+Subject: [PATCH 074/105] glamor: Don't require EXT_gpu_shader4 unconditionally
+
+It causes a shader compilation error on systems without EXT_gpu_shader4.
+
+Fixes: ee107cd4
+---
+ glamor/glamor_render.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
+index d678e6fc5..2549637b6 100644
+--- a/glamor/glamor_render.c
++++ b/glamor/glamor_render.c
+@@ -242,7 +242,11 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+     const char *mask_fetch = "";
+     const char *in;
+     const char *header;
+-    const char *header_norm = glamor_priv->glsl_version > 120 ? "#version 130\n" : "#version 120\n#extension GL_EXT_gpu_shader4 : require\n" GLAMOR_COMPAT_DEFINES_FS;
++    const char *header_norm = glamor_priv->glsl_version > 120 ?
++        "#version 130\n" :
++        glamor_priv->use_gpu_shader4 ?
++          "#version 120\n#extension GL_EXT_gpu_shader4 : require\n" GLAMOR_COMPAT_DEFINES_FS :
++          "#version 120\n" GLAMOR_COMPAT_DEFINES_FS;
+     const char *header_es = glamor_priv->glsl_version > 100 ? "#version 300 es\n" : "#version 100\n" GLAMOR_COMPAT_DEFINES_FS;
+     const char *dest_swizzle;
+     GLuint prog;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1075-BACKPORT-glamor_egl-add-helper-functions-for-contexts.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1075-BACKPORT-glamor_egl-add-helper-functions-for-contexts.patch
@@ -1,0 +1,189 @@
+From f2ded4a7c62a21ec9af33b7acc4fe73861cad141 Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Tue, 31 Oct 2023 19:52:07 +0300
+Subject: [PATCH 075/105] glamor_egl: add helper functions for contexts
+
+This is just a split big glamor_egl_init to 3 smaller functions.
+No functional change.
+
+Signed-off-by: Konstantin <ria.freelander@gmail.com>
+---
+ glamor/glamor_egl.c | 150 +++++++++++++++++++++++++-------------------
+ 1 file changed, 87 insertions(+), 63 deletions(-)
+
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index c35b10d83..65cf1ecf5 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -955,6 +955,86 @@ glamor_egl_free_screen(ScrnInfoPtr scrn)
+     }
+ }
+ 
++static Bool
++glamor_egl_try_big_gl_api(ScrnInfoPtr scrn)
++{
++    struct glamor_egl_screen_private *glamor_egl =
++        glamor_egl_get_screen_private(scrn);
++
++    if (eglBindAPI(EGL_OPENGL_API)) {
++        static const EGLint config_attribs_core[] = {
++            EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR,
++            EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR,
++            EGL_CONTEXT_MAJOR_VERSION_KHR,
++            GLAMOR_GL_CORE_VER_MAJOR,
++            EGL_CONTEXT_MINOR_VERSION_KHR,
++            GLAMOR_GL_CORE_VER_MINOR,
++            EGL_NONE
++        };
++        static const EGLint config_attribs[] = {
++            EGL_NONE
++        };
++
++        glamor_egl->context = eglCreateContext(glamor_egl->display,
++                                               EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT,
++                                               config_attribs_core);
++
++        if (glamor_egl->context == EGL_NO_CONTEXT)
++            glamor_egl->context = eglCreateContext(glamor_egl->display,
++                                                   EGL_NO_CONFIG_KHR,
++                                                   EGL_NO_CONTEXT,
++                                                   config_attribs);
++    }
++
++    if (glamor_egl->context != EGL_NO_CONTEXT) {
++        if (!eglMakeCurrent(glamor_egl->display,
++                            EGL_NO_SURFACE, EGL_NO_SURFACE, glamor_egl->context)) {
++            xf86DrvMsg(scrn->scrnIndex, X_ERROR,
++                       "Failed to make GL context current\n");
++            return FALSE;
++        }
++
++        if (epoxy_gl_version() < 21) {
++            xf86DrvMsg(scrn->scrnIndex, X_INFO,
++                       "glamor: Ignoring GL < 2.1, falling back to GLES.\n");
++            eglDestroyContext(glamor_egl->display, glamor_egl->context);
++            glamor_egl->context = EGL_NO_CONTEXT;
++        }
++    }
++    return TRUE;
++}
++
++static Bool
++glamor_egl_try_gles_api(ScrnInfoPtr scrn)
++{
++    struct glamor_egl_screen_private *glamor_egl =
++        glamor_egl_get_screen_private(scrn);
++        
++    static const EGLint config_attribs[] = {
++        EGL_CONTEXT_CLIENT_VERSION, 2,
++        EGL_NONE
++    };
++    if (!eglBindAPI(EGL_OPENGL_ES_API)) {
++        xf86DrvMsg(scrn->scrnIndex, X_ERROR,
++                    "glamor: Failed to bind GLES API.\n");
++        return FALSE;
++    }
++
++    glamor_egl->context = eglCreateContext(glamor_egl->display,
++                                            EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT,
++                                            config_attribs);
++
++    if (glamor_egl->context != EGL_NO_CONTEXT) {
++        if (!eglMakeCurrent(glamor_egl->display,
++                            EGL_NO_SURFACE, EGL_NO_SURFACE, glamor_egl->context)) {
++            xf86DrvMsg(scrn->scrnIndex, X_ERROR,
++                       "Failed to make GLES context current\n");
++            return FALSE;
++        }
++    }
++    return TRUE;
++}
++
+ Bool
+ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+ {
+@@ -1004,74 +1084,18 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+     GLAMOR_CHECK_EGL_EXTENSION(KHR_surfaceless_context);
+     GLAMOR_CHECK_EGL_EXTENSION(KHR_no_config_context);
+ 
+-    if (eglBindAPI(EGL_OPENGL_API)) {
+-        static const EGLint config_attribs_core[] = {
+-            EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR,
+-            EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR,
+-            EGL_CONTEXT_MAJOR_VERSION_KHR,
+-            GLAMOR_GL_CORE_VER_MAJOR,
+-            EGL_CONTEXT_MINOR_VERSION_KHR,
+-            GLAMOR_GL_CORE_VER_MINOR,
+-            EGL_NONE
+-        };
+-        static const EGLint config_attribs[] = {
+-            EGL_NONE
+-        };
+-
+-        glamor_egl->context = eglCreateContext(glamor_egl->display,
+-                                               EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT,
+-                                               config_attribs_core);
+-
+-        if (glamor_egl->context == EGL_NO_CONTEXT)
+-            glamor_egl->context = eglCreateContext(glamor_egl->display,
+-                                                   EGL_NO_CONFIG_KHR,
+-                                                   EGL_NO_CONTEXT,
+-                                                   config_attribs);
+-    }
++    if(!glamor_egl_try_big_gl_api(scrn))
++        goto error;
+ 
+-    if (glamor_egl->context != EGL_NO_CONTEXT) {
+-        if (!eglMakeCurrent(glamor_egl->display,
+-                            EGL_NO_SURFACE, EGL_NO_SURFACE, glamor_egl->context)) {
+-            xf86DrvMsg(scrn->scrnIndex, X_ERROR,
+-                       "Failed to make GL context current\n");
++    if (glamor_egl->context == EGL_NO_CONTEXT) {
++        if(!glamor_egl_try_gles_api(scrn))
+             goto error;
+-        }
+-
+-        if (epoxy_gl_version() < 21) {
+-            xf86DrvMsg(scrn->scrnIndex, X_INFO,
+-                       "glamor: Ignoring GL < 2.1, falling back to GLES.\n");
+-            eglDestroyContext(glamor_egl->display, glamor_egl->context);
+-            glamor_egl->context = EGL_NO_CONTEXT;
+-        }
+     }
+ 
+     if (glamor_egl->context == EGL_NO_CONTEXT) {
+-        static const EGLint config_attribs[] = {
+-            EGL_CONTEXT_CLIENT_VERSION, 2,
+-            EGL_NONE
+-        };
+-        if (!eglBindAPI(EGL_OPENGL_ES_API)) {
+-            xf86DrvMsg(scrn->scrnIndex, X_ERROR,
+-                       "glamor: Failed to bind either GL or GLES APIs.\n");
+-            goto error;
+-        }
+-
+-        glamor_egl->context = eglCreateContext(glamor_egl->display,
+-                                               EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT,
+-                                               config_attribs);
+-
+-        if (glamor_egl->context == EGL_NO_CONTEXT) {
+-            xf86DrvMsg(scrn->scrnIndex, X_ERROR,
+-                       "glamor: Failed to create GL or GLES2 contexts\n");
+-            goto error;
+-        }
+-
+-        if (!eglMakeCurrent(glamor_egl->display,
+-                            EGL_NO_SURFACE, EGL_NO_SURFACE, glamor_egl->context)) {
+-            xf86DrvMsg(scrn->scrnIndex, X_ERROR,
+-                       "Failed to make GLES2 context current\n");
+-            goto error;
+-        }
++        xf86DrvMsg(scrn->scrnIndex, X_ERROR,
++                    "glamor: Failed to create GL or GLES2 contexts\n");
++        goto error;
+     }
+ 
+     renderer = glGetString(GL_RENDERER);
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1076-BACKPORT-glamor_egl-add-RenderingAPI-option.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1076-BACKPORT-glamor_egl-add-RenderingAPI-option.patch
@@ -1,0 +1,79 @@
+From 164426d9ffcf7154170e6ac72dd097c54e9a1642 Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Thu, 21 Sep 2023 18:06:14 +0300
+Subject: [PATCH 076/105] glamor_egl: add RenderingAPI option
+
+This allows to choose between Glamor on OpenGL and Glamor on OpenGL ES
+via an option.
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Signed-off-by: Konstantin <ria.freelander@gmail.com>
+---
+ glamor/glamor_egl.c | 31 ++++++++++++++++++++++++++++---
+ 1 file changed, 28 insertions(+), 3 deletions(-)
+
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index 65cf1ecf5..e70711e67 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -1035,11 +1035,24 @@ glamor_egl_try_gles_api(ScrnInfoPtr scrn)
+     return TRUE;
+ }
+ 
++enum {
++    GLAMOREGLOPT_RENDERING_API,
++};
++
++static const OptionInfoRec GlamorEGLOptions[] = {
++    { GLAMOREGLOPT_RENDERING_API, "RenderingAPI", OPTV_STRING, {0}, FALSE },
++    { -1, NULL, OPTV_NONE, {0}, FALSE },
++};
++
+ Bool
+ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+ {
+     struct glamor_egl_screen_private *glamor_egl;
+     const GLubyte *renderer;
++    OptionInfoPtr options;
++    const char *api = NULL;
++    Bool es_allowed = TRUE;
++    Bool force_es = FALSE;
+ 
+     glamor_egl = calloc(sizeof(*glamor_egl), 1);
+     if (glamor_egl == NULL)
+@@ -1047,6 +1060,16 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+     if (xf86GlamorEGLPrivateIndex == -1)
+         xf86GlamorEGLPrivateIndex = xf86AllocateScrnInfoPrivateIndex();
+ 
++    options = xnfalloc(sizeof(GlamorEGLOptions));
++    memcpy(options, GlamorEGLOptions, sizeof(GlamorEGLOptions));
++    xf86ProcessOptions(scrn->scrnIndex, scrn->options, options);
++    api = xf86GetOptValString(options, GLAMOREGLOPT_RENDERING_API);
++    if (api && !strncasecmp(api, "es", 2))
++        force_es = TRUE;
++    else if (api && !strncasecmp(api, "gl", 2))
++        es_allowed = FALSE;
++    free(options);
++
+     scrn->privates[xf86GlamorEGLPrivateIndex].ptr = glamor_egl;
+     glamor_egl->fd = fd;
+     glamor_egl->gbm = gbm_create_device(glamor_egl->fd);
+@@ -1084,10 +1107,12 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+     GLAMOR_CHECK_EGL_EXTENSION(KHR_surfaceless_context);
+     GLAMOR_CHECK_EGL_EXTENSION(KHR_no_config_context);
+ 
+-    if(!glamor_egl_try_big_gl_api(scrn))
+-        goto error;
++    if (!force_es) {
++        if(!glamor_egl_try_big_gl_api(scrn))
++            goto error;
++    }
+ 
+-    if (glamor_egl->context == EGL_NO_CONTEXT) {
++    if (glamor_egl->context == EGL_NO_CONTEXT && es_allowed) {
+         if(!glamor_egl_try_gles_api(scrn))
+             goto error;
+     }
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1077-BACKPORT-glamor_egl-add-info-message-about-context-API.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1077-BACKPORT-glamor_egl-add-info-message-about-context-API.patch
@@ -1,0 +1,43 @@
+From 0a314c38337f67b72ecca4da01e7a11f9866e2b0 Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Thu, 21 Sep 2023 17:07:43 +0300
+Subject: [PATCH 077/105] glamor_egl: add info message about context API
+
+It is useful to know on what context we are running, and
+we need to show it into xorg.log
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Signed-off-by: Konstantin <ria.freelander@gmail.com>
+---
+ glamor/glamor_egl.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index e70711e67..9bdff24c5 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -1000,6 +1000,10 @@ glamor_egl_try_big_gl_api(ScrnInfoPtr scrn)
+             eglDestroyContext(glamor_egl->display, glamor_egl->context);
+             glamor_egl->context = EGL_NO_CONTEXT;
+         }
++        xf86DrvMsg(scrn->scrnIndex, X_INFO,
++            "glamor: Using OpenGL %d.%d context.\n",
++            epoxy_gl_version() / 10,
++            epoxy_gl_version() % 10);
+     }
+     return TRUE;
+ }
+@@ -1031,6 +1035,10 @@ glamor_egl_try_gles_api(ScrnInfoPtr scrn)
+                        "Failed to make GLES context current\n");
+             return FALSE;
+         }
++        xf86DrvMsg(scrn->scrnIndex, X_INFO,
++                "glamor: Using OpenGL ES %d.%d context.\n",
++                epoxy_gl_version() / 10,
++                epoxy_gl_version() % 10);
+     }
+     return TRUE;
+ }
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1078-BACKPORT-xorg.conf.man-document-new-RenderingAPI-option.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1078-BACKPORT-xorg.conf.man-document-new-RenderingAPI-option.patch
@@ -1,0 +1,33 @@
+From cd60a62ee3a32fddb81116509b24f6d421c0620a Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Fri, 22 Sep 2023 12:29:52 +0300
+Subject: [PATCH 078/105] xorg.conf.man: document new RenderingAPI option
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Signed-off-by: Konstantin <ria.freelander@gmail.com>
+---
+ hw/xfree86/man/xorg.conf.man | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/hw/xfree86/man/xorg.conf.man b/hw/xfree86/man/xorg.conf.man
+index 92f0e0d26..93acdded5 100644
+--- a/hw/xfree86/man/xorg.conf.man
++++ b/hw/xfree86/man/xorg.conf.man
+@@ -2097,6 +2097,14 @@ use for the screen. This may be used to select an alternate implementation
+ for development, debugging, or alternate feature sets.
+ Default: mesa.
+ .TP 7
++.BI "Option \*RenderingAPI\*q \*q" string \*q
++This option specifies an rendering API for use in conjunction with Glamor
++accel method. You can specify OpenGL with a value "gl" and OpenGL ES with a 
++value "es", and the default is both, when Glamor fallbacks to GLES if GL 2.1 is
++not available. This may be useful for embedded and old cards, where GL ES
++feature set works faster than GL feature set.
++Default: gl.
++.TP 7
+ .BI "Option \*qInitPrimary\*q \*q" boolean \*q
+ Use the Int10 module to initialize the primary graphics card.
+ Normally, only secondary cards are soft-booted using the Int10 module, as the
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1079-BACKPORT-glamor-xv-do-not-force-a-version-on-XV-shaders.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1079-BACKPORT-glamor-xv-do-not-force-a-version-on-XV-shaders.patch
@@ -1,0 +1,39 @@
+From 962316c5b6a598d45862ee9cad9281e6612e6cf5 Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Tue, 10 Oct 2023 13:07:41 +0300
+Subject: [PATCH 079/105] glamor: xv: do not force a version on XV shaders
+
+There is a no need to force a low version for XV shaders, it will
+work on higher version too.
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Signed-off-by: Konstantin <ria.freelander@gmail.com>
+---
+ glamor/glamor_xv.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/glamor/glamor_xv.c b/glamor/glamor_xv.c
+index 1548f8079..f68053e8c 100644
+--- a/glamor/glamor_xv.c
++++ b/glamor/glamor_xv.c
+@@ -62,8 +62,6 @@ typedef struct tagREF_TRANSFORM {
+ static const glamor_facet glamor_facet_xv_planar_2 = {
+     .name = "xv_planar_2",
+ 
+-    .version = 120,
+-
+     .source_name = "v_texcoord0",
+     .vs_vars = ("in vec2 position;\n"
+                 "in vec2 v_texcoord0;\n"
+@@ -94,8 +92,6 @@ static const glamor_facet glamor_facet_xv_planar_2 = {
+ static const glamor_facet glamor_facet_xv_planar_3 = {
+     .name = "xv_planar_3",
+ 
+-    .version = 120,
+-
+     .source_name = "v_texcoord0",
+     .vs_vars = ("in vec2 position;\n"
+                 "in vec2 v_texcoord0;\n"
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1080-BACKPORT-glamor-xv-reuse-ports-and-shaders-when-possible.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1080-BACKPORT-glamor-xv-reuse-ports-and-shaders-when-possible.patch
@@ -1,0 +1,161 @@
+From 64bc640f9d87dfe64a410615bb2505a72c2ca461 Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Fri, 20 Oct 2023 22:45:11 +0300
+Subject: [PATCH 080/105] glamor: xv: reuse ports and shaders when possible
+
+Xv currently calls glamor_xv_free_port_data at the end of every putImage.
+This leads to shader recompilation for every frame, which is a huge performance loss.
+This commit changes behaviour of glamor_xv_free_port_data, and its now is called only
+if width, height or format is changed for xv port.
+
+Shader management also done in a port now, because if shaders will be
+stored in core glamor and try to be reused, this can lead to a bug if we
+try to play 2 videos with different formats simultaneously.
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Signed-off-by: Konstantin <ria.freelander@gmail.com>
+---
+ glamor/glamor_priv.h |  3 +++
+ glamor/glamor_xv.c   | 54 ++++++++++++++++++++++++++++----------------
+ 2 files changed, 37 insertions(+), 20 deletions(-)
+
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index e9e7fc90b..1d0a46920 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -920,6 +920,9 @@ typedef struct {
+     RegionRec clip;
+     PixmapPtr src_pix[3];       /* y, u, v for planar */
+     int src_pix_w, src_pix_h;
++    /* Port optimization */
++    int prev_fmt;
++    glamor_program xv_prog;
+ } glamor_port_private;
+ 
+ extern XvAttributeRec glamor_xv_attributes[];
+diff --git a/glamor/glamor_xv.c b/glamor/glamor_xv.c
+index f68053e8c..eba756555 100644
+--- a/glamor/glamor_xv.c
++++ b/glamor/glamor_xv.c
+@@ -143,9 +143,8 @@ XvImageRec glamor_xv_images[] = {
+ int glamor_xv_num_images = ARRAY_SIZE(glamor_xv_images);
+ 
+ static void
+-glamor_init_xv_shader(ScreenPtr screen, int id)
++glamor_init_xv_shader(ScreenPtr screen, glamor_port_private *port_priv, int id)
+ {
+-    glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+     GLint sampler_loc;
+     const glamor_facet *glamor_facet_xv_planar = NULL;
+ 
+@@ -162,10 +161,10 @@ glamor_init_xv_shader(ScreenPtr screen, int id)
+     }
+ 
+     glamor_build_program(screen,
+-                         &glamor_priv->xv_prog,
++                         &port_priv->xv_prog,
+                          glamor_facet_xv_planar, NULL, NULL, NULL);
+ 
+-    glUseProgram(glamor_priv->xv_prog.prog);
++    glUseProgram(port_priv->xv_prog.prog);
+     sampler_loc = glGetUniformLocation(glamor_priv->xv_prog.prog, "y_sampler");
+     glUniform1i(sampler_loc, 0);
+     sampler_loc = glGetUniformLocation(glamor_priv->xv_prog.prog, "u_sampler");
+@@ -330,8 +329,8 @@ glamor_xv_render(glamor_port_private *port_priv, int id)
+     char *vbo_offset;
+     int dst_box_index;
+ 
+-    if (!glamor_priv->xv_prog.prog)
+-        glamor_init_xv_shader(screen, id);
++    if (!port_priv->xv_prog.prog)
++        glamor_init_xv_shader(screen, port_priv, id);
+ 
+     cont = RTFContrast(port_priv->contrast);
+     bright = RTFBrightness(port_priv->brightness);
+@@ -365,13 +364,13 @@ glamor_xv_render(glamor_port_private *port_priv, int id)
+         }
+     }
+     glamor_make_current(glamor_priv);
+-    glUseProgram(glamor_priv->xv_prog.prog);
++    glUseProgram(port_priv->xv_prog.prog);
+ 
+-    uloc = glGetUniformLocation(glamor_priv->xv_prog.prog, "offsetyco");
++    uloc = glGetUniformLocation(port_priv->xv_prog.prog, "offsetyco");
+     glUniform4f(uloc, off[0], off[1], off[2], yco);
+-    uloc = glGetUniformLocation(glamor_priv->xv_prog.prog, "ucogamma");
++    uloc = glGetUniformLocation(port_priv->xv_prog.prog, "ucogamma");
+     glUniform4f(uloc, uco[0], uco[1], uco[2], gamma);
+-    uloc = glGetUniformLocation(glamor_priv->xv_prog.prog, "vco");
++    uloc = glGetUniformLocation(port_priv->xv_prog.prog, "vco");
+     glUniform4f(uloc, vco[0], vco[1], vco[2], 0);
+ 
+     glActiveTexture(GL_TEXTURE0);
+@@ -455,7 +454,7 @@ glamor_xv_render(glamor_port_private *port_priv, int id)
+         glamor_set_destination_drawable(port_priv->pDraw,
+                                         dst_box_index,
+                                         FALSE, FALSE,
+-                                        glamor_priv->xv_prog.matrix_uniform,
++                                        port_priv->xv_prog.matrix_uniform,
+                                         &dst_off_x, &dst_off_y);
+ 
+         for (i = 0; i < nBox; i++) {
+@@ -476,8 +475,25 @@ glamor_xv_render(glamor_port_private *port_priv, int id)
+     glDisableVertexAttribArray(GLAMOR_VERTEX_SOURCE);
+ 
+     DamageDamageRegion(port_priv->pDraw, &port_priv->clip);
++}
++
++static Bool
++glamor_xv_can_reuse_port(glamor_port_private *port_priv, int id, short w, short h)
++{
++    int ret = TRUE;
++
++    if (port_priv->prev_fmt != id)
++        ret = FALSE;
+ 
+-    glamor_xv_free_port_data(port_priv);
++    if (w != port_priv->src_pix_w || h != port_priv->src_pix_h)
++        ret = FALSE;
++
++    if (!port_priv->src_pix[0])
++        ret = FALSE;
++
++    port_priv->prev_fmt = id;
++
++    return ret;
+ }
+ 
+ int
+@@ -495,7 +511,6 @@ glamor_xv_put_image(glamor_port_private *port_priv,
+                     RegionPtr clipBoxes)
+ {
+     ScreenPtr pScreen = pDrawable->pScreen;
+-    glamor_screen_private *glamor_priv = glamor_get_screen_private(pScreen);
+     int srcPitch, srcPitch2;
+     int top, nlines;
+     int s2offset, s3offset, tmp;
+@@ -503,15 +518,14 @@ glamor_xv_put_image(glamor_port_private *port_priv,
+ 
+     s2offset = s3offset = srcPitch2 = 0;
+ 
+-    if (!port_priv->src_pix[0] ||
+-        (width != port_priv->src_pix_w || height != port_priv->src_pix_h) ||
+-        (port_priv->src_pix[2] && id == FOURCC_NV12) ||
+-        (!port_priv->src_pix[2] && id != FOURCC_NV12)) {
++    if (!glamor_xv_can_reuse_port(port_priv, id, width, height)) {
+         int i;
+ 
+-        if (glamor_priv->xv_prog.prog) {
+-            glDeleteProgram(glamor_priv->xv_prog.prog);
+-            glamor_priv->xv_prog.prog = 0;
++        glamor_xv_free_port_data(port_priv);
++
++        if (port_priv->xv_prog.prog) {
++            glDeleteProgram(port_priv->xv_prog.prog);
++            port_priv->xv_prog.prog = 0;
+         }
+ 
+         for (i = 0; i < 3; i++)
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1081-BACKPORT-glamor-xv-prepare-to-one-plane-formats.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1081-BACKPORT-glamor-xv-prepare-to-one-plane-formats.patch
@@ -1,0 +1,137 @@
+From fef96b741311720b43e6de8ede8cc6ba680c663e Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Fri, 20 Oct 2023 22:51:55 +0300
+Subject: [PATCH 081/105] glamor: xv: prepare to one-plane formats
+
+As a preparation to one-plane formats (for example, UYVY), second
+texture definition is moved inside a format switch, and all allocations
+now also done inside a texture switch.
+No functional change.
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Signed-off-by: Konstantin <ria.freelander@gmail.com>
+---
+ glamor/glamor_xv.c | 52 ++++++++++++++++++++++++++++++----------------
+ 1 file changed, 34 insertions(+), 18 deletions(-)
+
+diff --git a/glamor/glamor_xv.c b/glamor/glamor_xv.c
+index eba756555..bbee58fb8 100644
+--- a/glamor/glamor_xv.c
++++ b/glamor/glamor_xv.c
+@@ -165,18 +165,22 @@ glamor_init_xv_shader(ScreenPtr screen, glamor_port_private *port_priv, int id)
+                          glamor_facet_xv_planar, NULL, NULL, NULL);
+ 
+     glUseProgram(port_priv->xv_prog.prog);
+-    sampler_loc = glGetUniformLocation(glamor_priv->xv_prog.prog, "y_sampler");
+-    glUniform1i(sampler_loc, 0);
+-    sampler_loc = glGetUniformLocation(glamor_priv->xv_prog.prog, "u_sampler");
+-    glUniform1i(sampler_loc, 1);
+ 
+     switch (id) {
+     case FOURCC_YV12:
+     case FOURCC_I420:
+-        sampler_loc = glGetUniformLocation(glamor_priv->xv_prog.prog, "v_sampler");
++        sampler_loc = glGetUniformLocation(port_priv->xv_prog.prog, "y_sampler");
++        glUniform1i(sampler_loc, 0);
++        sampler_loc = glGetUniformLocation(port_priv->xv_prog.prog, "u_sampler");
++        glUniform1i(sampler_loc, 1);
++        sampler_loc = glGetUniformLocation(port_priv->xv_prog.prog, "v_sampler");
+         glUniform1i(sampler_loc, 2);
+         break;
+     case FOURCC_NV12:
++        sampler_loc = glGetUniformLocation(port_priv->xv_prog.prog, "y_sampler");
++        glUniform1i(sampler_loc, 0);
++        sampler_loc = glGetUniformLocation(port_priv->xv_prog.prog, "u_sampler");
++        glUniform1i(sampler_loc, 1);
+         break;
+     default:
+         break;
+@@ -380,16 +384,16 @@ glamor_xv_render(glamor_port_private *port_priv, int id)
+     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+ 
+-    glActiveTexture(GL_TEXTURE1);
+-    glBindTexture(GL_TEXTURE_2D, src_pixmap_priv[1]->fbo->tex);
+-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+-
+     switch (id) {
+     case FOURCC_YV12:
+     case FOURCC_I420:
++        glActiveTexture(GL_TEXTURE1);
++        glBindTexture(GL_TEXTURE_2D, src_pixmap_priv[1]->fbo->tex);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
++
+         glActiveTexture(GL_TEXTURE2);
+         glBindTexture(GL_TEXTURE_2D, src_pixmap_priv[2]->fbo->tex);
+         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+@@ -398,6 +402,12 @@ glamor_xv_render(glamor_port_private *port_priv, int id)
+         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+         break;
+     case FOURCC_NV12:
++        glActiveTexture(GL_TEXTURE1);
++        glBindTexture(GL_TEXTURE_2D, src_pixmap_priv[1]->fbo->tex);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+         break;
+     default:
+         break;
+@@ -532,28 +542,34 @@ glamor_xv_put_image(glamor_port_private *port_priv,
+             if (port_priv->src_pix[i])
+                 glamor_destroy_pixmap(port_priv->src_pix[i]);
+ 
+-        port_priv->src_pix[0] =
+-            glamor_create_pixmap(pScreen, width, height, 8,
+-                                 GLAMOR_CREATE_FBO_NO_FBO);
+-
+         switch (id) {
+         case FOURCC_YV12:
+         case FOURCC_I420:
++            port_priv->src_pix[0] =
++                glamor_create_pixmap(pScreen, width, height, 8,
++                                     GLAMOR_CREATE_FBO_NO_FBO);
++
+             port_priv->src_pix[1] =
+                 glamor_create_pixmap(pScreen, width >> 1, height >> 1, 8,
+                                      GLAMOR_CREATE_FBO_NO_FBO);
+             port_priv->src_pix[2] =
+                 glamor_create_pixmap(pScreen, width >> 1, height >> 1, 8,
+                                      GLAMOR_CREATE_FBO_NO_FBO);
+-            if (!port_priv->src_pix[2])
++            if (!port_priv->src_pix[1] || !port_priv->src_pix[2])
+                 return BadAlloc;
+             break;
+         case FOURCC_NV12:
++            port_priv->src_pix[0] =
++                glamor_create_pixmap(pScreen, width, height, 8,
++                                     GLAMOR_CREATE_FBO_NO_FBO);
+             port_priv->src_pix[1] =
+                 glamor_create_pixmap(pScreen, width >> 1, height >> 1, 16,
+                                      GLAMOR_CREATE_FBO_NO_FBO |
+                                      GLAMOR_CREATE_FORMAT_CBCR);
+             port_priv->src_pix[2] = NULL;
++
++            if (!port_priv->src_pix[1])
++                return BadAlloc;
+             break;
+         default:
+             return BadMatch;
+@@ -562,7 +578,7 @@ glamor_xv_put_image(glamor_port_private *port_priv,
+         port_priv->src_pix_w = width;
+         port_priv->src_pix_h = height;
+ 
+-        if (!port_priv->src_pix[0] || !port_priv->src_pix[1])
++        if (!port_priv->src_pix[0])
+             return BadAlloc;
+     }
+ 
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1082-BACKPORT-glamor-xv-enable-UYVY-acceleration.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1082-BACKPORT-glamor-xv-enable-UYVY-acceleration.patch
@@ -1,0 +1,204 @@
+From fa1cdc518bb779a3afd93fafa92e8759c6ef2f71 Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Tue, 19 Oct 2021 15:03:35 +0300
+Subject: [PATCH 082/105] glamor: xv: enable UYVY acceleration
+
+This commit adds UYVY format in XVideo for Glamor
+along with shader support.
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Signed-off-by: Konstantin <ria.freelander@gmail.com>
+---
+ glamor/glamor_xv.c | 110 +++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 102 insertions(+), 8 deletions(-)
+
+diff --git a/glamor/glamor_xv.c b/glamor/glamor_xv.c
+index bbee58fb8..6a6e41ce1 100644
+--- a/glamor/glamor_xv.c
++++ b/glamor/glamor_xv.c
+@@ -120,6 +120,47 @@ static const glamor_facet glamor_facet_xv_planar_3 = {
+                 ),
+ };
+ 
++static const glamor_facet glamor_facet_xv_uyvy = {
++    .name = "xv_uyvy",
++
++    .source_name = "v_texcoord0",
++    .vs_vars = ("in vec2 position;\n"
++                "in vec2 v_texcoord0;\n"
++                "out vec2 tcs;\n"),
++    .vs_exec = (GLAMOR_POS(gl_Position, position)
++                "        tcs = v_texcoord0;\n"),
++
++    .fs_vars = ("#ifdef GL_ES\n"
++                "precision highp float;\n"
++                "#endif\n"
++                "uniform sampler2D sampler;\n"
++                "uniform vec2 texelSize;\n"
++                "uniform vec4 offsetyco;\n"
++                "uniform vec4 ucogamma;\n"
++                "uniform vec4 vco;\n"
++                "in vec2 tcs;\n"
++                ),
++    .fs_exec = (
++        "    vec3 uyv;\n"
++        "    vec4 frameOut = texture2D(sampler, tcs.st);\n"
++        "\n"
++        "    vec4 prevPixel = texture2D(sampler, vec2(tcs.s - texelSize.x, tcs.t));\n"
++        "    vec4 nextPixel = texture2D(sampler, vec2(tcs.s + texelSize.x, tcs.t));\n"
++        "\n"
++        "    float delta = 0.50;\n"
++        "\n"
++        "    int even = int(mod(tcs.x / texelSize.x, 2.0));\n"
++        "\n"
++        "    uyv.rgb = float(even)*vec3(frameOut.rg, nextPixel.r) + (1.0-float(even))*vec3(prevPixel.r, frameOut.gr);\n"
++        "\n"
++        "    frameOut.r = uyv.g + 1.403*(uyv.r - delta);\n"
++        "    frameOut.g = uyv.g - 0.714*(uyv.r - delta) - 0.344*(uyv.b - delta);\n"
++        "    frameOut.b = uyv.g + 1.773*(uyv.b - delta);\n"
++        "    frameOut.a = 1.0;\n"
++        "    frag_color = frameOut;\n"
++        ),
++};
++
+ #define MAKE_ATOM(a) MakeAtom(a, sizeof(a) - 1, TRUE)
+ 
+ XvAttributeRec glamor_xv_attributes[] = {
+@@ -138,7 +179,8 @@ Atom glamorBrightness, glamorContrast, glamorSaturation, glamorHue,
+ XvImageRec glamor_xv_images[] = {
+     XVIMAGE_YV12,
+     XVIMAGE_I420,
+-    XVIMAGE_NV12
++    XVIMAGE_NV12,
++    XVIMAGE_UYVY,
+ };
+ int glamor_xv_num_images = ARRAY_SIZE(glamor_xv_images);
+ 
+@@ -156,6 +198,9 @@ glamor_init_xv_shader(ScreenPtr screen, glamor_port_private *port_priv, int id)
+     case FOURCC_NV12:
+         glamor_facet_xv_planar = &glamor_facet_xv_planar_2;
+         break;
++    case FOURCC_UYVY:
++        glamor_facet_xv_planar = &glamor_facet_xv_uyvy;
++        break;
+     default:
+         break;
+     }
+@@ -182,6 +227,10 @@ glamor_init_xv_shader(ScreenPtr screen, glamor_port_private *port_priv, int id)
+         sampler_loc = glGetUniformLocation(port_priv->xv_prog.prog, "u_sampler");
+         glUniform1i(sampler_loc, 1);
+         break;
++    case FOURCC_UYVY:
++        sampler_loc = glGetUniformLocation(port_priv->xv_prog.prog, "sampler");
++        glUniform1i(sampler_loc, 0);
++        break;
+     default:
+         break;
+     }
+@@ -297,6 +346,15 @@ glamor_xv_query_image_attributes(int id,
+         tmp *= (*h >> 1);
+         size += tmp;
+         break;
++    case FOURCC_UYVY:
++        /* UYVU is single-plane really, all tranformation is processed inside a shader */
++        size = *w * 2;
++        if (pitches)
++            pitches[0] = size;
++        if (offsets)
++            offsets[0] = 0;
++        size *= *h;
++        break;
+     }
+     return size;
+ }
+@@ -377,16 +435,16 @@ glamor_xv_render(glamor_port_private *port_priv, int id)
+     uloc = glGetUniformLocation(port_priv->xv_prog.prog, "vco");
+     glUniform4f(uloc, vco[0], vco[1], vco[2], 0);
+ 
+-    glActiveTexture(GL_TEXTURE0);
+-    glBindTexture(GL_TEXTURE_2D, src_pixmap_priv[0]->fbo->tex);
+-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+-
+     switch (id) {
+     case FOURCC_YV12:
+     case FOURCC_I420:
++        glActiveTexture(GL_TEXTURE0);
++        glBindTexture(GL_TEXTURE_2D, src_pixmap_priv[0]->fbo->tex);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
++
+         glActiveTexture(GL_TEXTURE1);
+         glBindTexture(GL_TEXTURE_2D, src_pixmap_priv[1]->fbo->tex);
+         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+@@ -402,6 +460,13 @@ glamor_xv_render(glamor_port_private *port_priv, int id)
+         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+         break;
+     case FOURCC_NV12:
++        glActiveTexture(GL_TEXTURE0);
++        glBindTexture(GL_TEXTURE_2D, src_pixmap_priv[0]->fbo->tex);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
++
+         glActiveTexture(GL_TEXTURE1);
+         glBindTexture(GL_TEXTURE_2D, src_pixmap_priv[1]->fbo->tex);
+         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+@@ -409,6 +474,17 @@ glamor_xv_render(glamor_port_private *port_priv, int id)
+         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+         break;
++    case FOURCC_UYVY:
++        uloc = glGetUniformLocation(port_priv->xv_prog.prog, "texelSize");
++        glUniform2f(uloc, 1.0 / port_priv->w, 1.0 / port_priv->h);
++
++        glActiveTexture(GL_TEXTURE0);
++        glBindTexture(GL_TEXTURE_2D, src_pixmap_priv[0]->fbo->tex);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
++        break;
+     default:
+         break;
+     }
+@@ -571,6 +647,14 @@ glamor_xv_put_image(glamor_port_private *port_priv,
+             if (!port_priv->src_pix[1])
+                 return BadAlloc;
+             break;
++        case FOURCC_UYVY:
++            port_priv->src_pix[0] =
++                glamor_create_pixmap(pScreen, width, height, 32,
++                                     GLAMOR_CREATE_FBO_NO_FBO |
++                                     GLAMOR_CREATE_FORMAT_CBCR);
++            port_priv->src_pix[1] = NULL;
++            port_priv->src_pix[2] = NULL;
++            break;
+         default:
+             return BadMatch;
+         }
+@@ -645,6 +729,16 @@ glamor_xv_put_image(glamor_port_private *port_priv,
+                             0, 0, 0, 0,
+                             buf + s2offset, srcPitch);
+         break;
++    case FOURCC_UYVY:
++        srcPitch = width * 2;
++        full_box.x1 = 0;
++        full_box.y1 = 0;
++        full_box.x2 = width;
++        full_box.y2 = height;
++        glamor_upload_boxes(&port_priv->src_pix[0]->drawable, &full_box, 1,
++                            0, 0, 0, 0,
++                            buf, srcPitch);
++        break;
+     default:
+         return BadMatch;
+     }
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1083-BACKPORT-glamor-xv-add-rgba32-format.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1083-BACKPORT-glamor-xv-add-rgba32-format.patch
@@ -1,0 +1,160 @@
+From de0e44401b9207def75254cd0a3a086b24b2b6b1 Mon Sep 17 00:00:00 2001
+From: Yuriy Vasilev <uuvasiliev@yandex.ru>
+Date: Thu, 9 Sep 2021 18:14:02 +0300
+Subject: [PATCH 083/105] glamor: xv: add rgba32 format
+
+This commit adds RGBA32 format to XVideo along with shader for handling it.
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Signed-off-by: Yuriy Vasilev <uuvasiliev@yandex.ru>
+---
+ glamor/glamor_xv.c | 55 ++++++++++++++++++++++++++++++++++++++++++++++
+ include/fourcc.h   | 19 ++++++++++++++++
+ 2 files changed, 74 insertions(+)
+
+diff --git a/glamor/glamor_xv.c b/glamor/glamor_xv.c
+index 6a6e41ce1..f368c0a9b 100644
+--- a/glamor/glamor_xv.c
++++ b/glamor/glamor_xv.c
+@@ -161,6 +161,23 @@ static const glamor_facet glamor_facet_xv_uyvy = {
+         ),
+ };
+ 
++static const glamor_facet glamor_facet_xv_rgb_raw = {
++    .name = "xv_rgb",
++
++    .source_name = "v_texcoord0",
++    .vs_vars = ("in vec2 position;\n"
++                "in vec2 v_texcoord0;\n"
++                "out vec2 tcs;\n"),
++    .vs_exec = (GLAMOR_POS(gl_Position, position)
++                "        tcs = v_texcoord0;\n"),
++
++    .fs_vars = ("uniform sampler2D sampler;\n"
++                "in vec2 tcs;\n"),
++    .fs_exec = (
++                "        frag_color = texture2D(sampler, tcs);\n"
++                ),
++};
++
+ #define MAKE_ATOM(a) MakeAtom(a, sizeof(a) - 1, TRUE)
+ 
+ XvAttributeRec glamor_xv_attributes[] = {
+@@ -181,6 +198,7 @@ XvImageRec glamor_xv_images[] = {
+     XVIMAGE_I420,
+     XVIMAGE_NV12,
+     XVIMAGE_UYVY,
++    XVIMAGE_RGB32,
+ };
+ int glamor_xv_num_images = ARRAY_SIZE(glamor_xv_images);
+ 
+@@ -201,6 +219,9 @@ glamor_init_xv_shader(ScreenPtr screen, glamor_port_private *port_priv, int id)
+     case FOURCC_UYVY:
+         glamor_facet_xv_planar = &glamor_facet_xv_uyvy;
+         break;
++    case FOURCC_RGBA32:
++        glamor_facet_xv_planar = &glamor_facet_xv_rgb_raw;
++        break;
+     default:
+         break;
+     }
+@@ -228,6 +249,7 @@ glamor_init_xv_shader(ScreenPtr screen, glamor_port_private *port_priv, int id)
+         glUniform1i(sampler_loc, 1);
+         break;
+     case FOURCC_UYVY:
++    case FOURCC_RGBA32:
+         sampler_loc = glGetUniformLocation(port_priv->xv_prog.prog, "sampler");
+         glUniform1i(sampler_loc, 0);
+         break;
+@@ -346,6 +368,14 @@ glamor_xv_query_image_attributes(int id,
+         tmp *= (*h >> 1);
+         size += tmp;
+         break;
++    case FOURCC_RGBA32:
++        size = *w * 4;
++        if(pitches)
++            pitches[0] = size;
++        if(offsets)
++            offsets[0] = 0;
++        size *= *h;
++        break;
+     case FOURCC_UYVY:
+         /* UYVU is single-plane really, all tranformation is processed inside a shader */
+         size = *w * 2;
+@@ -485,6 +515,14 @@ glamor_xv_render(glamor_port_private *port_priv, int id)
+         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+         break;
++    case FOURCC_RGBA32:
++        glActiveTexture(GL_TEXTURE0);
++        glBindTexture(GL_TEXTURE_2D, src_pixmap_priv[0]->fbo->tex);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
++        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
++        break;
+     default:
+         break;
+     }
+@@ -647,6 +685,13 @@ glamor_xv_put_image(glamor_port_private *port_priv,
+             if (!port_priv->src_pix[1])
+                 return BadAlloc;
+             break;
++        case FOURCC_RGBA32:
++            port_priv->src_pix[0] =
++            glamor_create_pixmap(pScreen, width, height, 32,
++                                     GLAMOR_CREATE_FBO_NO_FBO);
++            port_priv->src_pix[1] = NULL;
++            port_priv->src_pix[2] = NULL;
++            break;
+         case FOURCC_UYVY:
+             port_priv->src_pix[0] =
+                 glamor_create_pixmap(pScreen, width, height, 32,
+@@ -739,6 +784,16 @@ glamor_xv_put_image(glamor_port_private *port_priv,
+                             0, 0, 0, 0,
+                             buf, srcPitch);
+         break;
++    case FOURCC_RGBA32:
++        srcPitch = width * 4;
++        full_box.x1 = 0;
++        full_box.y1 = 0;
++        full_box.x2 = width;
++        full_box.y2 = height;
++        glamor_upload_boxes(&port_priv->src_pix[0]->drawable, &full_box, 1,
++                            0, 0, 0, 0,
++                            buf, srcPitch);
++        break;
+     default:
+         return BadMatch;
+     }
+diff --git a/include/fourcc.h b/include/fourcc.h
+index a19e6869e..582a95afe 100644
+--- a/include/fourcc.h
++++ b/include/fourcc.h
+@@ -176,4 +176,23 @@
+         XvTopToBottom \
+    }
+ 
++#define FOURCC_RGBA32 0x34325241
++#define XVIMAGE_RGB32 \
++   { \
++        FOURCC_RGBA32, \
++        XvRGB, \
++		LSBFirst, \
++		{'R','A','2','4', \
++		 0x00, 0x00, 0x00,0x10,0x80,0x00,0x00,0xAA,0x00,0x38,0x9B,0x71}, \
++		32, \
++		XvPacked, \
++		1, \
++		32, 0xff0000, 0xff00, 0xff, \
++		0, 0, 0, \
++		0, 0, 0, \
++		0, 0, 0, \
++		{0,0,0,0, \
++		 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}, \
++		0 \
++   }
+ #endif                          /* _XF86_FOURCC_H_ */
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1084-BACKPORT-glamor-xv-add-rgb565.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1084-BACKPORT-glamor-xv-add-rgb565.patch
@@ -1,0 +1,112 @@
+From 444dcf95eaf9c932d1ac65c2302130cfdcb50903 Mon Sep 17 00:00:00 2001
+From: Yuriy Vasilev <uuvasiliev@yandex.ru>
+Date: Fri, 10 Sep 2021 16:20:06 +0300
+Subject: [PATCH 084/105] glamor: xv: add rgb565
+
+This commit adds RGB565 format to XVideo with reuse of RGBA32 shader
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Signed-off-by: Yuriy Vasilev <uuvasiliev@yandex.ru>
+---
+ glamor/glamor_xv.c | 13 +++++++++++++
+ include/fourcc.h   | 20 ++++++++++++++++++++
+ 2 files changed, 33 insertions(+)
+
+diff --git a/glamor/glamor_xv.c b/glamor/glamor_xv.c
+index f368c0a9b..d897e9901 100644
+--- a/glamor/glamor_xv.c
++++ b/glamor/glamor_xv.c
+@@ -199,6 +199,7 @@ XvImageRec glamor_xv_images[] = {
+     XVIMAGE_NV12,
+     XVIMAGE_UYVY,
+     XVIMAGE_RGB32,
++    XVIMAGE_RGB565,
+ };
+ int glamor_xv_num_images = ARRAY_SIZE(glamor_xv_images);
+ 
+@@ -220,6 +221,7 @@ glamor_init_xv_shader(ScreenPtr screen, glamor_port_private *port_priv, int id)
+         glamor_facet_xv_planar = &glamor_facet_xv_uyvy;
+         break;
+     case FOURCC_RGBA32:
++    case FOURCC_RGB565:
+         glamor_facet_xv_planar = &glamor_facet_xv_rgb_raw;
+         break;
+     default:
+@@ -250,6 +252,7 @@ glamor_init_xv_shader(ScreenPtr screen, glamor_port_private *port_priv, int id)
+         break;
+     case FOURCC_UYVY:
+     case FOURCC_RGBA32:
++    case FOURCC_RGB565:
+         sampler_loc = glGetUniformLocation(port_priv->xv_prog.prog, "sampler");
+         glUniform1i(sampler_loc, 0);
+         break;
+@@ -376,6 +379,7 @@ glamor_xv_query_image_attributes(int id,
+             offsets[0] = 0;
+         size *= *h;
+         break;
++    case FOURCC_RGB565:
+     case FOURCC_UYVY:
+         /* UYVU is single-plane really, all tranformation is processed inside a shader */
+         size = *w * 2;
+@@ -516,6 +520,7 @@ glamor_xv_render(glamor_port_private *port_priv, int id)
+         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+         break;
+     case FOURCC_RGBA32:
++    case FOURCC_RGB565:
+         glActiveTexture(GL_TEXTURE0);
+         glBindTexture(GL_TEXTURE_2D, src_pixmap_priv[0]->fbo->tex);
+         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+@@ -692,6 +697,13 @@ glamor_xv_put_image(glamor_port_private *port_priv,
+             port_priv->src_pix[1] = NULL;
+             port_priv->src_pix[2] = NULL;
+             break;
++        case FOURCC_RGB565:
++            port_priv->src_pix[0] =
++            glamor_create_pixmap(pScreen, width, height, 16,
++                                     GLAMOR_CREATE_FBO_NO_FBO);
++            port_priv->src_pix[1] = NULL;
++            port_priv->src_pix[2] = NULL;
++            break;
+         case FOURCC_UYVY:
+             port_priv->src_pix[0] =
+                 glamor_create_pixmap(pScreen, width, height, 32,
+@@ -775,6 +787,7 @@ glamor_xv_put_image(glamor_port_private *port_priv,
+                             buf + s2offset, srcPitch);
+         break;
+     case FOURCC_UYVY:
++    case FOURCC_RGB565:
+         srcPitch = width * 2;
+         full_box.x1 = 0;
+         full_box.y1 = 0;
+diff --git a/include/fourcc.h b/include/fourcc.h
+index 582a95afe..83e51a888 100644
+--- a/include/fourcc.h
++++ b/include/fourcc.h
+@@ -195,4 +195,24 @@
+ 		 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}, \
+ 		0 \
+    }
++
++#define FOURCC_RGB565 0x36314752
++#define XVIMAGE_RGB565 \
++   { \
++        FOURCC_RGB565, \
++        XvRGB, \
++		LSBFirst, \
++		{'R','G','1','6', \
++		 0x00, 0x00, 0x00,0x10,0x80,0x00,0x00,0xAA,0x00,0x38,0x9B,0x71}, \
++		16, \
++		XvPacked, \
++		1, \
++		16, 0xf800, 0x7e0, 0x1f, \
++		0, 0, 0, \
++		0, 0, 0, \
++		0, 0, 0, \
++		{0,0,0,0, \
++		 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}, \
++		0 \
++   }
+ #endif                          /* _XF86_FOURCC_H_ */
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1085-BACKPORT-modesetting-unflip-before-any-setcrtc-calls.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1085-BACKPORT-modesetting-unflip-before-any-setcrtc-calls.patch
@@ -1,0 +1,212 @@
+From c0b6c79c358b49f3ded778ae180659cc2a6a2a82 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ville=20Syrj=C3=A4l=C3=A4?= <ville.syrjala@linux.intel.com>
+Date: Thu, 22 Oct 2020 15:45:13 +0300
+Subject: [PATCH 085/105] modesetting: unflip before any setcrtc() calls
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Make sure we're not scanning out any fbs with fancy modifiers when
+we try to light up new displays. This is already the case in cases
+where the screen gets resized, but in cases where that doesn't happen
+it might be possible for the modeset(s) to fail due to watermark/etc.
+constraints imposed by the fancy modifiers. We can avoid that by
+making sure everything gets unflipped before the modeset.
+
+v2: make poll timeout infinite
+    s/in_modeset/pending_modeset/
+    deal with tearfree fallout (goto no_flip)
+
+Signed-off-by: Ville Syrjälä <ville.syrjala@linux.intel.com>
+---
+ hw/xfree86/drivers/modesetting/driver.h       |  3 +++
+ .../drivers/modesetting/drmmode_display.c     | 25 +++++++++++++++++++
+ .../drivers/modesetting/drmmode_display.h     |  2 ++
+ hw/xfree86/drivers/modesetting/pageflip.c     |  7 ++++++
+ hw/xfree86/drivers/modesetting/present.c      |  3 +++
+ hw/xfree86/drivers/modesetting/vblank.c       |  6 +++++
+ present/present.h                             |  3 +++
+ present/present_screen.c                      | 20 +++++++++++++++
+ 8 files changed, 69 insertions(+)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.h b/hw/xfree86/drivers/modesetting/driver.h
+index e302c067d..6e1381d53 100644
+--- a/hw/xfree86/drivers/modesetting/driver.h
++++ b/hw/xfree86/drivers/modesetting/driver.h
+@@ -206,6 +206,8 @@ void ms_drm_abort(ScrnInfoPtr scrn,
+                   void *match_data);
+ void ms_drm_abort_seq(ScrnInfoPtr scrn, uint32_t seq);
+ 
++Bool ms_drm_queue_is_empty(void);
++
+ Bool xf86_crtc_on(xf86CrtcPtr crtc);
+ 
+ xf86CrtcPtr ms_dri2_crtc_covering_drawable(DrawablePtr pDraw);
+@@ -255,6 +257,7 @@ Bool ms_do_tearfree_flip(ScreenPtr screen, xf86CrtcPtr crtc);
+ #endif
+ 
+ int ms_flush_drm_events(ScreenPtr screen);
++void ms_drain_drm_events(ScreenPtr screen);
+ Bool ms_window_has_variable_refresh(modesettingPtr ms, WindowPtr win);
+ void ms_present_set_screen_vrr(ScrnInfoPtr scrn, Bool vrr_enabled);
+ Bool ms_tearfree_is_active_on_crtc(xf86CrtcPtr crtc);
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
+index 54ab18fbb..93ed56946 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
+@@ -1662,6 +1662,26 @@ drmmode_create_tearfree_shadow(xf86CrtcPtr crtc)
+     return TRUE;
+ }
+ 
++static void drmmmode_prepare_modeset(ScrnInfoPtr scrn)
++{
++    ScreenPtr pScreen = scrn->pScreen;
++    modesettingPtr ms = modesettingPTR(scrn);
++
++    if (ms->drmmode.pending_modeset)
++        return;
++
++    /*
++     * Force present to unflip everything before we might
++     * try lighting up new displays. This makes sure fancy
++     * modifiers can't cause the modeset to fail.
++     */
++    ms->drmmode.pending_modeset = TRUE;
++    present_check_flips(pScreen->root);
++    ms->drmmode.pending_modeset = FALSE;
++
++    ms_drain_drm_events(pScreen);
++}
++
+ static Bool
+ drmmode_set_mode_major(xf86CrtcPtr crtc, DisplayModePtr mode,
+                        Rotation rotation, int x, int y)
+@@ -1677,6 +1697,9 @@ drmmode_set_mode_major(xf86CrtcPtr crtc, DisplayModePtr mode,
+     Bool can_test;
+     int i;
+ 
++    if (mode)
++        drmmmode_prepare_modeset(crtc->scrn);
++
+     saved_mode = crtc->mode;
+     saved_x = crtc->x;
+     saved_y = crtc->y;
+@@ -3906,6 +3929,8 @@ drmmode_set_desired_modes(ScrnInfoPtr pScrn, drmmode_ptr drmmode, Bool set_hw,
+     Bool success = TRUE;
+     int c;
+ 
++    drmmmode_prepare_modeset(pScrn);
++
+     for (c = 0; c < config->num_crtc; c++) {
+         xf86CrtcPtr crtc = config->crtc[c];
+         drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.h b/hw/xfree86/drivers/modesetting/drmmode_display.h
+index b4074a30f..32901025d 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.h
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.h
+@@ -139,6 +139,8 @@ typedef struct {
+ 
+     uint32_t vrr_prop_id;
+     Bool use_ctm;
++
++    Bool pending_modeset;
+ } drmmode_rec, *drmmode_ptr;
+ 
+ typedef struct {
+diff --git a/hw/xfree86/drivers/modesetting/pageflip.c b/hw/xfree86/drivers/modesetting/pageflip.c
+index c1ee542b7..f6903adb2 100644
+--- a/hw/xfree86/drivers/modesetting/pageflip.c
++++ b/hw/xfree86/drivers/modesetting/pageflip.c
+@@ -69,6 +69,13 @@ ms_flush_drm_events(ScreenPtr screen)
+     return ms_flush_drm_events_timeout(screen, 0);
+ }
+ 
++void
++ms_drain_drm_events(ScreenPtr screen)
++{
++    while (!ms_drm_queue_is_empty())
++        ms_flush_drm_events_timeout(screen, -1);
++}
++
+ #ifdef GLAMOR_HAS_GBM
+ 
+ /*
+diff --git a/hw/xfree86/drivers/modesetting/present.c b/hw/xfree86/drivers/modesetting/present.c
+index 3d8f16aa9..788b500d6 100644
+--- a/hw/xfree86/drivers/modesetting/present.c
++++ b/hw/xfree86/drivers/modesetting/present.c
+@@ -327,6 +327,9 @@ ms_present_check_flip(RRCrtcPtr crtc,
+     if (ms->drmmode.sprites_visible > 0)
+         goto no_flip;
+ 
++    if (ms->drmmode.pending_modeset)
++        goto no_flip;
++
+     if(!ms_present_check_unflip(crtc, window, pixmap, sync_flip, reason))
+         goto no_flip;
+ 
+diff --git a/hw/xfree86/drivers/modesetting/vblank.c b/hw/xfree86/drivers/modesetting/vblank.c
+index 1c5f2578f..c7aeb9f16 100644
+--- a/hw/xfree86/drivers/modesetting/vblank.c
++++ b/hw/xfree86/drivers/modesetting/vblank.c
+@@ -642,6 +642,12 @@ ms_drm_handler(int fd, uint32_t frame, uint32_t sec, uint32_t usec,
+                             FALSE, (uint32_t) (uintptr_t) user_ptr);
+ }
+ 
++Bool
++ms_drm_queue_is_empty(void)
++{
++    return xorg_list_is_empty(&ms_drm_queue);
++}
++
+ Bool
+ ms_vblank_screen_init(ScreenPtr screen)
+ {
+diff --git a/present/present.h b/present/present.h
+index a3f34a929..c6762cecc 100644
+--- a/present/present.h
++++ b/present/present.h
+@@ -157,6 +157,9 @@ present_event_notify(uint64_t event_id, uint64_t ust, uint64_t msc);
+ extern _X_EXPORT Bool
+ present_screen_init(ScreenPtr screen, present_screen_info_ptr info);
+ 
++extern _X_EXPORT void
++present_check_flips(WindowPtr window);
++
+ typedef void (*present_complete_notify_proc)(WindowPtr window,
+                                              CARD8 kind,
+                                              CARD8 mode,
+diff --git a/present/present_screen.c b/present/present_screen.c
+index 2c29aafd2..ef56ff779 100644
+--- a/present/present_screen.c
++++ b/present/present_screen.c
+@@ -191,6 +191,26 @@ present_screen_priv_init(ScreenPtr screen)
+     return screen_priv;
+ }
+ 
++static int
++check_flip_visit(WindowPtr window, void *data)
++{
++    ScreenPtr screen = window->drawable.pScreen;
++    present_screen_priv_ptr screen_priv = present_screen_priv(screen);
++
++    if (!screen_priv)
++        return WT_DONTWALKCHILDREN;
++
++    screen_priv->check_flip_window(window);
++
++    return WT_WALKCHILDREN;
++}
++
++void
++present_check_flips(WindowPtr window)
++{
++    TraverseTree(window, check_flip_visit, NULL);
++}
++
+ /*
+  * Initialize a screen for use with present in default screen flip mode (scmd)
+  */
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1086-BACKPORT-modesetting-Use-a-more-optimal-hw-cursor-size.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1086-BACKPORT-modesetting-Use-a-more-optimal-hw-cursor-size.patch
@@ -1,0 +1,308 @@
+From d5f9df373564e588643b0fc499803dd82124bd3d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ville=20Syrj=C3=A4l=C3=A4?= <ville.syrjala@linux.intel.com>
+Date: Sat, 4 Feb 2023 18:25:53 +0200
+Subject: [PATCH 086/105] modesetting: Use a more optimal hw cursor size
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Try to minimize the used hw cursor size in order to
+minimize power consumption. There is no kernel query
+for the minimum so we'll just probe around with
+setcursor2 (using an invisible cursor image so
+there will be no visual artifacts).
+
+To avoid having to deal with absolutely every size stick
+to power-of-two numbers. And with a bit of extra effort
+we can determine whether non-square dimesions will also
+work, which they do to some degree on current Intel GPUs.
+
+On my Alderlake laptop I'm seeing a massive (up to .5W)
+difference in power consumption between 64x64 vs. 256x256
+cursors. While some of that is undoubtedly something that
+needs to be fixed in i915's display data buffer allocation
+code, it still makes sense to use as small as possible
+cursor to minimize the wastege.
+
+In case the crtc is rotated just punt to the max cursor size
+for now since midlayer has already done the coordinate
+transformations based on that. To make smaller cursors work
+with rotation we'd either need to make the midlayer(s) aware
+of the final cursor size, or just handle the whole roation
+business in modesetting. I suspect the latter option would
+be easier.
+
+v2: Only allow square cursors in most cases for now as eg.
+    on modern Intel hardware non-square only works with
+    wide+short but not with narrow+tall cursors. Non-square
+    size may still be used when maximum limits aren't
+    square and the squared+POT'd dimensions would exceed
+    one of the max limits.
+
+Signed-off-by: Ville Syrjälä <ville.syrjala@linux.intel.com>
+---
+ hw/xfree86/drivers/modesetting/driver.c       |  10 +-
+ hw/xfree86/drivers/modesetting/driver.h       |   3 +-
+ .../drivers/modesetting/drmmode_display.c     | 107 +++++++++++++++---
+ .../drivers/modesetting/drmmode_display.h     |   2 +
+ 4 files changed, 103 insertions(+), 19 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.c b/hw/xfree86/drivers/modesetting/driver.c
+index 9a69452bd..334102d9c 100644
+--- a/hw/xfree86/drivers/modesetting/driver.c
++++ b/hw/xfree86/drivers/modesetting/driver.c
+@@ -1292,15 +1292,15 @@ PreInit(ScrnInfoPtr pScrn, int flags)
+         ms->drmmode.sw_cursor = TRUE;
+     }
+ 
+-    ms->cursor_width = 64;
+-    ms->cursor_height = 64;
++    ms->max_cursor_width = 64;
++    ms->max_cursor_height = 64;
+     ret = drmGetCap(ms->fd, DRM_CAP_CURSOR_WIDTH, &value);
+     if (!ret) {
+-        ms->cursor_width = value;
++        ms->max_cursor_width = value;
+     }
+     ret = drmGetCap(ms->fd, DRM_CAP_CURSOR_HEIGHT, &value);
+     if (!ret) {
+-        ms->cursor_height = value;
++        ms->max_cursor_height = value;
+     }
+ 
+     try_enable_glamor(pScrn);
+@@ -2035,7 +2035,7 @@ ScreenInit(ScreenPtr pScreen, int argc, char **argv)
+ 
+     /* Need to extend HWcursor support to handle mask interleave */
+     if (!ms->drmmode.sw_cursor)
+-        xf86_cursors_init(pScreen, ms->cursor_width, ms->cursor_height,
++        xf86_cursors_init(pScreen, ms->max_cursor_width, ms->max_cursor_height,
+                           HARDWARE_CURSOR_SOURCE_MASK_INTERLEAVE_64 |
+                           HARDWARE_CURSOR_UPDATE_UNHIDDEN |
+                           HARDWARE_CURSOR_ARGB);
+diff --git a/hw/xfree86/drivers/modesetting/driver.h b/hw/xfree86/drivers/modesetting/driver.h
+index 6e1381d53..74630cac4 100644
+--- a/hw/xfree86/drivers/modesetting/driver.h
++++ b/hw/xfree86/drivers/modesetting/driver.h
+@@ -129,7 +129,8 @@ typedef struct _modesettingRec {
+     DamagePtr damage;
+     Bool dirty_enabled;
+ 
+-    uint32_t cursor_width, cursor_height;
++    uint32_t min_cursor_width, min_cursor_height;
++    uint32_t max_cursor_width, max_cursor_height;
+ 
+     Bool has_queue_sequence;
+     Bool tried_queue_sequence;
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
+index 93ed56946..48f8e5f5e 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
+@@ -1790,12 +1790,11 @@ drmmode_set_cursor_position(xf86CrtcPtr crtc, int x, int y)
+ }
+ 
+ static Bool
+-drmmode_set_cursor(xf86CrtcPtr crtc)
++drmmode_set_cursor(xf86CrtcPtr crtc, int width, int height)
+ {
+     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+     drmmode_ptr drmmode = drmmode_crtc->drmmode;
+     uint32_t handle = drmmode_crtc->cursor_bo->handle;
+-    modesettingPtr ms = modesettingPTR(crtc->scrn);
+     CursorPtr cursor = xf86CurrentCursor(crtc->scrn->pScreen);
+     int ret = -EINVAL;
+ 
+@@ -1803,14 +1802,14 @@ drmmode_set_cursor(xf86CrtcPtr crtc)
+ 	    return TRUE;
+ 
+     ret = drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
+-                            handle, ms->cursor_width, ms->cursor_height,
++                            handle, width, height,
+                             cursor->bits->xhot, cursor->bits->yhot);
+ 
+     /* -EINVAL can mean that an old kernel supports drmModeSetCursor but
+      * not drmModeSetCursor2, though it can mean other things too. */
+     if (ret == -EINVAL)
+         ret = drmModeSetCursor(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
+-                               handle, ms->cursor_width, ms->cursor_height);
++                               handle, width, height);
+ 
+     /* -ENXIO normally means that the current drm driver supports neither
+      * cursor_set nor cursor_set2.  Disable hardware cursor support for
+@@ -1826,6 +1825,10 @@ drmmode_set_cursor(xf86CrtcPtr crtc)
+     if (ret)
+         /* fallback to swcursor */
+         return FALSE;
++
++    drmmode_crtc->cursor_width = width;
++    drmmode_crtc->cursor_height = height;
++
+     return TRUE;
+ }
+ 
+@@ -1842,31 +1845,55 @@ static Bool
+ drmmode_load_cursor_argb_check(xf86CrtcPtr crtc, CARD32 *image)
+ {
+     modesettingPtr ms = modesettingPTR(crtc->scrn);
++    CursorPtr cursor = xf86CurrentCursor(crtc->scrn->pScreen);
+     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+-    int i;
++    int width, height, x, y, i;
+     uint32_t *ptr;
+ 
+     /* cursor should be mapped already */
+     ptr = (uint32_t *) (drmmode_crtc->cursor_bo->ptr);
+ 
+-    for (i = 0; i < ms->cursor_width * ms->cursor_height; i++)
+-        ptr[i] = image[i];      // cpu_to_le32(image[i]);
++    /* FIXME deal with rotation */
++    if (crtc->rotation == RR_Rotate_0) {
++        for (width = ms->min_cursor_width; width < cursor->bits->width; )
++            width *= 2;
++        for (height = ms->min_cursor_height; height < cursor->bits->height; )
++            height *= 2;
++
++        /* assume only square works for now */
++        width = height = max(width, height);
++
++        /* if the max limits aren't square+POT we may have gone a bit over */
++        width = min(width, ms->max_cursor_width);
++        height = min(height, ms->max_cursor_height);
++    } else {
++        width = ms->max_cursor_width;
++        height = ms->max_cursor_height;
++    }
++
++    i = 0;
++    for (y = 0; y < height; y++) {
++        for (x = 0; x < width; x++)
++            ptr[i++] = image[y * ms->max_cursor_width + x];      // cpu_to_le32(image[i]);
++    }
++    /* clear the remainder for good measure */
++    for (; i < ms->max_cursor_width * ms->max_cursor_height; i++)
++        ptr[i++] = 0;
+ 
+     if (drmmode_crtc->cursor_up)
+-        return drmmode_set_cursor(crtc);
++        return drmmode_set_cursor(crtc, width, height);
+     return TRUE;
+ }
+ 
+ static void
+ drmmode_hide_cursor(xf86CrtcPtr crtc)
+ {
+-    modesettingPtr ms = modesettingPTR(crtc->scrn);
+     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+     drmmode_ptr drmmode = drmmode_crtc->drmmode;
+ 
+     drmmode_crtc->cursor_up = FALSE;
+     drmModeSetCursor(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id, 0,
+-                     ms->cursor_width, ms->cursor_height);
++                     drmmode_crtc->cursor_width, drmmode_crtc->cursor_height);
+ }
+ 
+ static Bool
+@@ -1874,7 +1901,7 @@ drmmode_show_cursor(xf86CrtcPtr crtc)
+ {
+     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+     drmmode_crtc->cursor_up = TRUE;
+-    return drmmode_set_cursor(crtc);
++    return drmmode_set_cursor(crtc, drmmode_crtc->cursor_width, drmmode_crtc->cursor_height);
+ }
+ 
+ static void
+@@ -4330,6 +4357,52 @@ drmmode_uevent_fini(ScrnInfoPtr scrn, drmmode_ptr drmmode)
+ #endif
+ }
+ 
++static void drmmode_probe_cursor_size(xf86CrtcPtr crtc)
++{
++    modesettingPtr ms = modesettingPTR(crtc->scrn);
++    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
++    uint32_t handle = drmmode_crtc->cursor_bo->handle;
++    drmmode_ptr drmmode = drmmode_crtc->drmmode;
++    int width, height, size;
++
++    /* probe square min first */
++    for (size = 1; size <= ms->max_cursor_width &&
++             size <= ms->max_cursor_height; size *= 2) {
++        int ret;
++
++        ret = drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
++                                handle, size, size, 0, 0);
++        if (ret == 0)
++            break;
++    }
++
++    /* check if smaller width works with non-square */
++    for (width = 1; width <= size; width *= 2) {
++        int ret;
++
++        ret = drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
++                                handle, width, size, 0, 0);
++        if (ret == 0) {
++            ms->min_cursor_width = width;
++            break;
++        }
++    }
++
++    /* check if smaller height works with non-square */
++    for (height = 1; height <= size; height *= 2) {
++        int ret;
++
++        ret = drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
++                                handle, size, height, 0, 0);
++        if (ret == 0) {
++            ms->min_cursor_height = height;
++            break;
++        }
++    }
++
++    drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id, 0, 0, 0, 0, 0);
++}
++
+ /* create front and cursor BOs */
+ Bool
+ drmmode_create_initial_bos(ScrnInfoPtr pScrn, drmmode_ptr drmmode)
+@@ -4349,8 +4422,8 @@ drmmode_create_initial_bos(ScrnInfoPtr pScrn, drmmode_ptr drmmode)
+         return FALSE;
+     pScrn->displayWidth = drmmode_bo_get_pitch(&drmmode->front_bo) / cpp;
+ 
+-    width = ms->cursor_width;
+-    height = ms->cursor_height;
++    width = ms->max_cursor_width;
++    height = ms->max_cursor_height;
+     bpp = 32;
+     for (i = 0; i < xf86_config->num_crtc; i++) {
+         xf86CrtcPtr crtc = xf86_config->crtc[i];
+@@ -4359,6 +4432,14 @@ drmmode_create_initial_bos(ScrnInfoPtr pScrn, drmmode_ptr drmmode)
+         drmmode_crtc->cursor_bo =
+             dumb_bo_create(drmmode->fd, width, height, bpp);
+     }
++
++    drmmode_probe_cursor_size(xf86_config->crtc[0]);
++
++    xf86DrvMsgVerb(pScrn->scrnIndex, X_INFO, MS_LOGLEVEL_DEBUG,
++                   "Supported cursor sizes %dx%d -> %dx%d\n",
++                   ms->min_cursor_width, ms->min_cursor_height,
++                   ms->max_cursor_width, ms->max_cursor_height);
++
+     return TRUE;
+ }
+ 
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.h b/hw/xfree86/drivers/modesetting/drmmode_display.h
+index 32901025d..a82ae2609 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.h
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.h
+@@ -222,6 +222,8 @@ typedef struct {
+ 
+     uint64_t next_msc;
+ 
++    int cursor_width, cursor_height;
++
+     Bool need_modeset;
+     struct xorg_list mode_list;
+ 
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1087-BACKPORT-modesetting-Don-t-feed-stack-garbage-to-the-kernel-i.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1087-BACKPORT-modesetting-Don-t-feed-stack-garbage-to-the-kernel-i.patch
@@ -1,0 +1,33 @@
+From dd566bbfaf40644809feefb96f58f160e99a78b9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ville=20Syrj=C3=A4l=C3=A4?= <ville.syrjala@linux.intel.com>
+Date: Thu, 19 Jan 2023 20:32:22 +0200
+Subject: [PATCH 087/105] modesetting: Don't feed stack garbage to the kernel
+ in LUT reserved fields
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Stop putting stack garbage into the gamma LUT blob reserved
+fields.
+
+Fixes: 245b9db03a1e ("modesetting: Use GAMMA_LUT when available")
+Signed-off-by: Ville Syrjälä <ville.syrjala@linux.intel.com>
+---
+ hw/xfree86/drivers/modesetting/drmmode_display.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
+index 48f8e5f5e..cfe77079e 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
+@@ -1922,6 +1922,7 @@ drmmode_set_gamma_lut(drmmode_crtc_private_ptr drmmode_crtc,
+         lut[i].red = red[i];
+         lut[i].green = green[i];
+         lut[i].blue = blue[i];
++        lut[i].reserved = 0;
+     }
+ 
+     if (drmModeCreatePropertyBlob(drmmode->fd, lut, sizeof(lut), &blob_id))
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1088-BACKPORT-Fixed-mirrored-glyphs-on-big-endian-machines.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1088-BACKPORT-Fixed-mirrored-glyphs-on-big-endian-machines.patch
@@ -1,0 +1,69 @@
+From 59dcd83a2a6e7918d39ea2ad745b088a512b41a7 Mon Sep 17 00:00:00 2001
+From: Alexey <fatton2011@yandex.ru>
+Date: Fri, 24 Jun 2022 15:12:54 +0000
+Subject: [PATCH 088/105] Fixed mirrored glyphs on big-endian machines
+
+---
+ glamor/glamor_glyphblt.c | 8 ++++++++
+ glamor/glamor_text.c     | 8 ++++++++
+ 2 files changed, 16 insertions(+)
+
+diff --git a/glamor/glamor_glyphblt.c b/glamor/glamor_glyphblt.c
+index 44f668818..4ab23b333 100644
+--- a/glamor/glamor_glyphblt.c
++++ b/glamor/glamor_glyphblt.c
+@@ -102,7 +102,11 @@ glamor_poly_glyph_blt_gl(DrawablePtr drawable, GCPtr gc,
+                         int pt_x_i = glyph_x + xx;
+                         int pt_y_i = glyph_y + yy;
+ 
++#if BITMAP_BIT_ORDER == MSBFirst
++                        if (!(*glyph & (128 >> (xx & 7))))
++#else
+                         if (!(*glyph & (1 << (xx & 7))))
++#endif
+                             continue;
+ 
+                         if (!RegionContainsPoint(clip, pt_x_i, pt_y_i, NULL))
+@@ -209,7 +213,11 @@ glamor_push_pixels_gl(GCPtr gc, PixmapPtr bitmap,
+     for (yy = 0; yy < h; yy++) {
+         uint8_t *bitmap_row = bitmap_data + yy * bitmap_stride;
+         for (xx = 0; xx < w; xx++) {
++#if BITMAP_BIT_ORDER == MSBFirst
++            if (bitmap_row[xx / 8] & (128 >> xx % 8) &&
++#else
+             if (bitmap_row[xx / 8] & (1 << xx % 8) &&
++#endif
+                 RegionContainsPoint(clip,
+                                     x + xx,
+                                     y + yy,
+diff --git a/glamor/glamor_text.c b/glamor/glamor_text.c
+index f1672d420..0cabecbd5 100644
+--- a/glamor/glamor_text.c
++++ b/glamor/glamor_text.c
+@@ -235,7 +235,11 @@ static const char fs_vars_text[] =
+ 
+ static const char fs_exec_text[] =
+     "       ivec2 itile_texture = ivec2(glyph_pos);\n"
++#if BITMAP_BIT_ORDER == MSBFirst
++    "       uint x = uint(7) - uint(itile_texture.x & 7);\n"
++#else
+     "       uint x = uint(itile_texture.x & 7);\n"
++#endif
+     "       itile_texture.x >>= 3;\n"
+     "       uint texel = texelFetch(font, itile_texture, 0).x;\n"
+     "       uint bit = (texel >> x) & uint(1);\n"
+@@ -244,7 +248,11 @@ static const char fs_exec_text[] =
+ 
+ static const char fs_exec_te[] =
+     "       ivec2 itile_texture = ivec2(glyph_pos);\n"
++#if BITMAP_BIT_ORDER == MSBFirst
++    "       uint x = uint(7) - uint(itile_texture.x & 7);\n"
++#else
+     "       uint x = uint(itile_texture.x & 7);\n"
++#endif
+     "       itile_texture.x >>= 3;\n"
+     "       uint texel = texelFetch(font, itile_texture, 0).x;\n"
+     "       uint bit = (texel >> x) & uint(1);\n"
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1089-BACKPORT-modesetting-Enable-TearFree-by-default.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1089-BACKPORT-modesetting-Enable-TearFree-by-default.patch
@@ -1,0 +1,49 @@
+From 0775c18cbe96ee6ed779fbaf98c6fca65cdc6d12 Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sat, 16 Dec 2023 11:05:33 -0800
+Subject: [PATCH 089/105] modesetting: Enable TearFree by default
+
+TearFree support has been available in the modesetting driver for a year
+with no issues reported. The code is mature and robust, with error handling
+that's been vetted across many hardware configurations.
+
+Notably, TearFree is also the only way to achieve a tear-free desktop with
+mismatched displays and transformed CRTCs.
+
+Enable TearFree by default for a smooth desktop experience out of the box.
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+---
+ hw/xfree86/drivers/modesetting/driver.c        | 2 +-
+ hw/xfree86/drivers/modesetting/modesetting.man | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.c b/hw/xfree86/drivers/modesetting/driver.c
+index 334102d9c..c8542b89f 100644
+--- a/hw/xfree86/drivers/modesetting/driver.c
++++ b/hw/xfree86/drivers/modesetting/driver.c
+@@ -1381,7 +1381,7 @@ PreInit(ScrnInfoPtr pScrn, int flags)
+                "Atomic modesetting %sabled\n", ms->atomic_modeset ? "en" : "dis");
+ 
+     /* TearFree requires glamor and, if PageFlip is enabled, universal planes */
+-    if (xf86ReturnOptValBool(ms->drmmode.Options, OPTION_TEARFREE, FALSE)) {
++    if (xf86ReturnOptValBool(ms->drmmode.Options, OPTION_TEARFREE, TRUE)) {
+         if (pScrn->is_gpu) {
+             xf86DrvMsg(pScrn->scrnIndex, X_WARNING,
+                        "TearFree cannot synchronize PRIME; use 'PRIME Synchronization' instead\n");
+diff --git a/hw/xfree86/drivers/modesetting/modesetting.man b/hw/xfree86/drivers/modesetting/modesetting.man
+index 485beff48..4a8af97c8 100644
+--- a/hw/xfree86/drivers/modesetting/modesetting.man
++++ b/hw/xfree86/drivers/modesetting/modesetting.man
+@@ -118,7 +118,7 @@ as rotated and scaled CRTCs. When PageFlip is enabled, fullscreen DRI
+ applications will still have the discretion to not use tearing prevention.
+ .br
+ The default is
+-.B off.
++.B on.
+ .TP
+ .BI "Option \*qAtomic\*q \*q" boolean \*q
+ Enable atomic modesetting when supported.  The default is
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1090-BACKPORT-modesetting-Check-the-return-value-of-the-drmGetVers.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1090-BACKPORT-modesetting-Check-the-return-value-of-the-drmGetVers.patch
@@ -1,0 +1,45 @@
+From e914c7d4b80f93f23fcf0f7b20600475b35145d4 Mon Sep 17 00:00:00 2001
+From: xurui <xurui@kylinos.cn>
+Date: Wed, 22 Mar 2023 17:08:58 +0800
+Subject: [PATCH 090/105] modesetting: Check the return value of the
+ drmGetVersion
+
+Signed-off-by: xurui <xurui@kylinos.cn>
+---
+ hw/xfree86/drivers/modesetting/driver.c | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.c b/hw/xfree86/drivers/modesetting/driver.c
+index c8542b89f..f9648522f 100644
+--- a/hw/xfree86/drivers/modesetting/driver.c
++++ b/hw/xfree86/drivers/modesetting/driver.c
+@@ -1100,16 +1100,21 @@ msShouldDoubleShadow(ScrnInfoPtr pScrn, modesettingPtr ms)
+ {
+     Bool ret = FALSE, asked;
+     int from;
+-    drmVersionPtr v = drmGetVersion(ms->fd);
++    drmVersionPtr v;
+ 
+     if (!ms->drmmode.shadow_enable)
+         return FALSE;
+ 
+-    if (!strcmp(v->name, "mgag200") ||
+-        !strcmp(v->name, "ast")) /* XXX || rn50 */
+-        ret = TRUE;
++    if ((v = drmGetVersion(ms->fd))) {
++        if (!strcmp(v->name, "mgag200") ||
++            !strcmp(v->name, "ast")) /* XXX || rn50 */
++            ret = TRUE;
+ 
+-    drmFreeVersion(v);
++        drmFreeVersion(v);
++    }
++    else
++        xf86DrvMsg(pScrn->scrnIndex, X_ERROR,
++                   "Failed to query DRM version.\n");
+ 
+     asked = xf86GetOptValBool(ms->drmmode.Options, OPTION_DOUBLE_SHADOW, &ret);
+ 
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1091-BACKPORT-fbdevhw-Support-symbolic-links-in-fbdev_open.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1091-BACKPORT-fbdevhw-Support-symbolic-links-in-fbdev_open.patch
@@ -1,0 +1,82 @@
+From 42681fd5de0708ff44b838f3e730d0a84dd77028 Mon Sep 17 00:00:00 2001
+From: Moritz Bruder <muesli4@gmail.com>
+Date: Sat, 17 Dec 2022 18:19:57 +0100
+Subject: [PATCH 091/105] fbdevhw: Support symbolic links in fbdev_open
+
+Resolve symbolic links before the PCI device check in fbdev_open.
+Otherwise, opening device files that are symbolic links will fail.
+
+Fixes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1419
+
+Signed-off-by: Moritz Bruder <muesli4@gmail.com>
+---
+ hw/xfree86/fbdevhw/fbdevhw.c | 44 +++++++++++++++++++++++++++++++++++-
+ 1 file changed, 43 insertions(+), 1 deletion(-)
+
+diff --git a/hw/xfree86/fbdevhw/fbdevhw.c b/hw/xfree86/fbdevhw/fbdevhw.c
+index 3d8b92e66..8d4e3c596 100644
+--- a/hw/xfree86/fbdevhw/fbdevhw.c
++++ b/hw/xfree86/fbdevhw/fbdevhw.c
+@@ -304,6 +304,31 @@ fbdev_open_pci(struct pci_device *pPci, char **namep)
+     return -1;
+ }
+ 
++/* *
++ * Try to resolve a filename as symbolic link.  If the file is not a link, the
++ * original filename is returned.  NULL is returned if readlink raised an
++ * error.
++ */
++static const char *
++resolve_link(const char *filename, char *resolve_buf, size_t resolve_buf_size)
++{
++    ssize_t len = readlink(filename, resolve_buf, resolve_buf_size - 1);
++    /* if it is a link resolve it */
++    if (len >= 0) {
++        resolve_buf[len] = '\0';
++        return resolve_buf;
++    }
++    else {
++        if (errno == EINVAL) {
++            return filename;
++        }
++        else {
++            // Have caller handle error condition.
++            return NULL;
++        }
++    }
++}
++
+ static int
+ fbdev_open(int scrnIndex, const char *dev, char **namep)
+ {
+@@ -331,9 +356,26 @@ fbdev_open(int scrnIndex, const char *dev, char **namep)
+ 
+     /* only touch non-PCI devices on this path */
+     {
++        char device_path_buf[PATH_MAX];
+         char buf[PATH_MAX] = {0};
+         char *sysfs_path = NULL;
+-        char *node = strrchr(dev, '/') + 1;
++        char const *real_dev = resolve_link(dev, device_path_buf,
++                                            sizeof(device_path_buf));
++        if (real_dev == NULL) {
++            xf86DrvMsg(scrnIndex, X_ERROR,
++                       "Failed resolving symbolic link for device '%s': %s",
++                       dev, strerror(errno));
++            return -1;
++        }
++
++        const char *node = strrchr(real_dev, '/');
++
++        if (node == NULL) {
++            node = real_dev;
++        }
++        else {
++            node++;
++        }
+ 
+         if (asprintf(&sysfs_path, "/sys/class/graphics/%s", node) < 0 ||
+             readlink(sysfs_path, buf, sizeof(buf) - 1) < 0 ||
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1092-BACKPORT-xf86-Accept-devices-with-the-kernel-s-ofdrm-driver.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1092-BACKPORT-xf86-Accept-devices-with-the-kernel-s-ofdrm-driver.patch
@@ -1,0 +1,31 @@
+From cfc7f0a0070a3919aa4a0293278369e6db717aab Mon Sep 17 00:00:00 2001
+From: Thomas Zimmermann <tzimmermann@suse.de>
+Date: Wed, 18 May 2022 10:44:06 +0200
+Subject: [PATCH 092/105] xf86: Accept devices with the kernel's ofdrm driver
+
+Add a workaround to accept devices of the kernel's ofdrm driver.
+Makes Xorg work on Open Firmware's pre-configured display with the
+DRM graphics stack.
+
+Signed-off-by: Thomas Zimmermann <tzimmermann@suse.de>
+---
+ hw/xfree86/common/xf86platformBus.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/hw/xfree86/common/xf86platformBus.c b/hw/xfree86/common/xf86platformBus.c
+index 1d1f87c74..4cb9a671d 100644
+--- a/hw/xfree86/common/xf86platformBus.c
++++ b/hw/xfree86/common/xf86platformBus.c
+@@ -579,6 +579,9 @@ xf86platformProbeDev(DriverPtr drvp)
+                     /* Accept the device if the driver is hyperv_drm */
+                     if (strcmp(xf86_platform_devices[j].attribs->driver, "hyperv_drm") == 0)
+                         break;
++                    /* Accept the device if the driver is ofdrm */
++                    if (strcmp(xf86_platform_devices[j].attribs->driver, "ofdrm") == 0)
++                        break;
+                     /* Accept the device if the driver is simpledrm */
+                     if (strcmp(xf86_platform_devices[j].attribs->driver, "simpledrm") == 0)
+                         break;
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1093-BACKPORT-RandR-Allow-duplicate-monitor-name-when-adding-it.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1093-BACKPORT-RandR-Allow-duplicate-monitor-name-when-adding-it.patch
@@ -1,0 +1,51 @@
+From 9cf5c9b4dd18c14fc9772e17c48995675f753764 Mon Sep 17 00:00:00 2001
+From: Ilya Pominov <ipominov@astralinux.ru>
+Date: Mon, 10 Apr 2023 18:52:25 +0300
+Subject: [PATCH 093/105] RandR: Allow duplicate monitor name when adding it
+
+When calling RRSetMonitor, an existing monitor name is allowed.
+"If 'name' matches an existing Monitor on the screen, the existing one
+will be deleted as if RRDeleteMonitor were called."
+https://cgit.freedesktop.org/xorg/proto/randrproto/tree/randrproto.txt
+
+It looks like the check was added by mistake, because in the next 'for'
+the monitor is deleted if it is in this list.
+
+Steps to reproduce:
+Try RRSetMonitor with existing monitor name and other valid params
+OBSERVED RESULT:
+RRSetMonitors returns BadValue
+EXPECTED RESULT:
+RRSetMonitors returns OK
+
+Amend: 7e1f86d42b54fb7f6492875e47a718eaeca3069b
+Signed-off-by: Ilya Pominov <ipominov@astralinux.ru>
+---
+ randr/rrmonitor.c | 11 -----------
+ 1 file changed, 11 deletions(-)
+
+diff --git a/randr/rrmonitor.c b/randr/rrmonitor.c
+index a0fb820d7..0ec36f677 100644
+--- a/randr/rrmonitor.c
++++ b/randr/rrmonitor.c
+@@ -489,17 +489,6 @@ RRMonitorAdd(ClientPtr client, ScreenPtr screen, RRMonitorPtr monitor)
+         }
+     }
+ 
+-    /* 'name' must not match the name of any Monitor on the screen, or
+-     * a Value error results.
+-     */
+-
+-    for (m = 0; m < pScrPriv->numMonitors; m++) {
+-        if (pScrPriv->monitors[m]->name == monitor->name) {
+-            client->errorValue = monitor->name;
+-            return BadValue;
+-        }
+-    }
+-
+     /* Allocate space for the new pointer. This is done before
+      * removing matching monitors as it may fail, and the request
+      * needs to not have any side-effects on failure
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1094-BACKPORT-glamor-Use-render-node-for-glamor-device-path-where-.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1094-BACKPORT-glamor-Use-render-node-for-glamor-device-path-where-.patch
@@ -1,0 +1,35 @@
+From 2277c6a4e396b9a210a50f118df04c73b315c033 Mon Sep 17 00:00:00 2001
+From: msizanoen1 <msizanoen@qtmlabs.xyz>
+Date: Sat, 5 Feb 2022 13:34:27 +0700
+Subject: [PATCH 094/105] glamor: Use render node for glamor device path where
+ possible
+
+On certain system deployments, /dev/dri/card* nodes aren't directly
+accessible to the currently logged in user, but the display server only
+access it by asking systemd-logind to open the device for it. This
+causes the X server to fail when trying to re-open the card* device
+directly, causing all use of DRI3 to fail.
+
+Fix this by using the render device path instead where possible.
+---
+ glamor/glamor_egl.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index 9bdff24c5..c2d1c0b17 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -914,7 +914,9 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
+         /* To do DRI3 device FD generation, we need to open a new fd
+          * to the same device we were handed in originally.
+          */
+-        glamor_egl->device_path = drmGetDeviceNameFromFd2(glamor_egl->fd);
++        glamor_egl->device_path = drmGetRenderDeviceNameFromFd(glamor_egl->fd);
++        if (!glamor_egl->device_path)
++            glamor_egl->device_path = drmGetDeviceNameFromFd2(glamor_egl->fd);
+ 
+         if (!dri3_screen_init(screen, &glamor_dri3_info)) {
+             xf86DrvMsg(scrn->scrnIndex, X_ERROR,
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1095-BACKPORT-glamor-Enable-dmabuf_capable-by-default-on-Intel-har.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1095-BACKPORT-glamor-Enable-dmabuf_capable-by-default-on-Intel-har.patch
@@ -1,0 +1,39 @@
+From 006b6b43b8bc774e6ff1d8403fff4ce90c65cd83 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ville=20Syrj=C3=A4l=C3=A4?= <ville.syrjala@linux.intel.com>
+Date: Sat, 16 Dec 2023 08:38:11 +0200
+Subject: [PATCH 095/105] glamor: Enable dmabuf_capable by default on Intel
+ hardware
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With the potential modeset vs. modifiers issue covered by
+commit 899c87af1fc2 ("modesetting: unflip before any setcrtc() calls")
+we can safely enable modifiers by default, at least on Intel
+hardware where we know that things work properly.
+
+I suppose the one open question is whether everything will work
+correctly with wonky multi-GPU setups? I don't have one to test
+myself.
+
+Signed-off-by: Ville Syrjälä <ville.syrjala@linux.intel.com>
+---
+ glamor/glamor_egl.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index c2d1c0b17..77adad09e 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -1178,6 +1178,8 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+         if (xf86Info.debug != NULL)
+             glamor_egl->dmabuf_capable = !!strstr(xf86Info.debug,
+                                                   "dmabuf_capable");
++        else if (strstr((const char *)renderer, "Intel"))
++            glamor_egl->dmabuf_capable = TRUE;
+         else
+             glamor_egl->dmabuf_capable = FALSE;
+     }
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1096-BACKPORT-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1096-BACKPORT-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
@@ -1,7 +1,7 @@
-From e7bcde7df6179501ac252e9e68534340cfb1a305 Mon Sep 17 00:00:00 2001
+From 73825036cd811425ddc237e7ce460c340b8bcb01 Mon Sep 17 00:00:00 2001
 From: "Chia-Lin Kao (AceLan)" <acelan.kao@canonical.com>
 Date: Tue, 8 Nov 2022 08:11:50 +0800
-Subject: [PATCH] hw/xfree86: re-calculate the clock and refresh rate
+Subject: [PATCH 096/105] hw/xfree86: re-calculate the clock and refresh rate
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -28,7 +28,7 @@ Signed-off-by: Chia-Lin Kao (AceLan) <acelan.kao@canonical.com>
  3 files changed, 15 insertions(+), 1 deletion(-)
 
 diff --git a/hw/xfree86/common/xf86Mode.c b/hw/xfree86/common/xf86Mode.c
-index eb0885571..fec60a957 100644
+index ef3be84c3..b275ce9d8 100644
 --- a/hw/xfree86/common/xf86Mode.c
 +++ b/hw/xfree86/common/xf86Mode.c
 @@ -230,6 +230,8 @@ xf86ModeStatusToString(ModeStatus status)
@@ -41,10 +41,10 @@ index eb0885571..fec60a957 100644
          return "unknown reason";
      case MODE_ERROR:
 diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
-index 48dccad73..4d046169a 100644
+index cfe77079e..efcca0b03 100644
 --- a/hw/xfree86/drivers/modesetting/drmmode_display.c
 +++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
-@@ -2641,7 +2641,7 @@ static DisplayModePtr
+@@ -2843,7 +2843,7 @@ static DisplayModePtr
  drmmode_output_add_gtf_modes(xf86OutputPtr output, DisplayModePtr Modes)
  {
      xf86MonPtr mon = output->MonInfo;
@@ -53,7 +53,7 @@ index 48dccad73..4d046169a 100644
      int max_x = 0, max_y = 0;
      float max_vrefresh = 0.0;
  
-@@ -2673,6 +2673,17 @@ drmmode_output_add_gtf_modes(xf86OutputPtr output, DisplayModePtr Modes)
+@@ -2875,6 +2875,17 @@ drmmode_output_add_gtf_modes(xf86OutputPtr output, DisplayModePtr Modes)
              i->VDisplay >= preferred->VDisplay &&
              xf86ModeVRefresh(i) >= xf86ModeVRefresh(preferred))
              i->status = MODE_VSYNC;

--- a/runtime-display/xorg-server/autobuild/patches/1097-BACKPORT-modesetting-Correct-coordinate-info-of-dirty-clips-f.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1097-BACKPORT-modesetting-Correct-coordinate-info-of-dirty-clips-f.patch
@@ -1,0 +1,228 @@
+From 61d5c002f676f559356afa07e42637fcd41788f5 Mon Sep 17 00:00:00 2001
+From: Dongwon Kim <dongwon.kim@intel.com>
+Date: Tue, 24 Oct 2023 10:28:11 +0000
+Subject: [PATCH 097/105] modesetting: Correct coordinate info of dirty clips
+ for front-buffer flushing
+
+A clip should represent the area that is covering the current FB associated
+with the CRTC. So making sure each input rect covers any area in the FB is
+the first thing to do. If that is the case, the size and coordinates should
+be adjusted based on the partial area in the FB the each rect covers. The size
+elements need to be truncated if the rect's size exceeds FB's for the CRTC.
+Then offsets should be applied to coordinates if the CRTC's offsets aren't 0.
+And coordinate transposing and inversion are needed in case the rotated image
+is assigned to the FB.
+
+Signed-off-by: Dongwon Kim <dongwon.kim@intel.com>
+---
+ hw/xfree86/drivers/modesetting/driver.c | 121 ++++++++++++++++--------
+ 1 file changed, 80 insertions(+), 41 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.c b/hw/xfree86/drivers/modesetting/driver.c
+index f9648522f..cf2d4cfe4 100644
+--- a/hw/xfree86/drivers/modesetting/driver.c
++++ b/hw/xfree86/drivers/modesetting/driver.c
+@@ -516,41 +516,64 @@ GetRec(ScrnInfoPtr pScrn)
+     return TRUE;
+ }
+ 
+-static void
+-rotate_clip(PixmapPtr pixmap, BoxPtr rect, drmModeClip *clip, Rotation rotation)
++static int
++rotate_clip(PixmapPtr pixmap, xf86CrtcPtr crtc, BoxPtr rect, drmModeClip *clip,
++            Rotation rotation, int x, int y)
+ {
+-    int w = pixmap->drawable.width;
+-    int h = pixmap->drawable.height;
+-
+-    if (rotation == RR_Rotate_90) {
+-	/* Rotate 90 degrees counter clockwise */
+-        clip->x1 = rect->y1;
+-	clip->x2 = rect->y2;
+-	clip->y1 = w - rect->x2;
+-	clip->y2 = w - rect->x1;
+-    } else if (rotation == RR_Rotate_180) {
+-	/* Rotate 180 degrees */
+-        clip->x1 = w - rect->x2;
+-	clip->x2 = w - rect->x1;
+-	clip->y1 = h - rect->y2;
+-	clip->y2 = h - rect->y1;
+-    } else if (rotation == RR_Rotate_270) {
+-	/* Rotate 90 degrees clockwise */
+-        clip->x1 = h - rect->y2;
+-	clip->x2 = h - rect->y1;
+-	clip->y1 = rect->x1;
+-	clip->y2 = rect->x2;
++    int w, h;
++    int x1, y1, x2, y2;
++
++    if (rotation == RR_Rotate_90 || rotation == RR_Rotate_270) {
++	/* width and height are swapped if rotated 90 or 270 degrees */
++        w = pixmap->drawable.height;
++        h = pixmap->drawable.width;
+     } else {
+-	clip->x1 = rect->x1;
+-	clip->x2 = rect->x2;
+-	clip->y1 = rect->y1;
+-	clip->y2 = rect->y2;
++        w = pixmap->drawable.width;
++        h = pixmap->drawable.height;
++    }
++
++    /* check if the given rect covers any area in FB of the crtc */
++    if (rect->x2 > crtc->x && rect->x1 < crtc->x + w &&
++        rect->y2 > crtc->y && rect->y1 < crtc->y + h) {
++        /* new coordinate of the partial rect on the crtc area
++         * + x/y offsets in the framebuffer */
++        x1 = max(rect->x1 - crtc->x, 0) + x;
++        y1 = max(rect->y1 - crtc->y, 0) + y;
++        x2 = min(rect->x2 - crtc->x, w) + x;
++        y2 = min(rect->y2 - crtc->y, h) + y;
++
++        /* coordinate transposing/inversion and offset adjustment */
++        if (rotation == RR_Rotate_90) {
++            clip->x1 = y1;
++            clip->y1 = w - x2;
++            clip->x2 = y2;
++            clip->y2 = w - x1;
++        } else if (rotation == RR_Rotate_180) {
++            clip->x1 = w - x2;
++            clip->y1 = h - y2;
++            clip->x2 = w - x1;
++            clip->y2 = h - y1;
++        } else if (rotation == RR_Rotate_270) {
++            clip->x1 = h - y2;
++            clip->y1 = x1;
++            clip->x2 = h - y1;;
++            clip->y2 = x2;
++        } else {
++            clip->x1 = x1;
++            clip->y1 = y1;
++            clip->x2 = x2;
++            clip->y2 = y2;
++        }
++    } else {
++        return -1;
+     }
++
++    return 0;
+ }
+ 
+ static int
+ dispatch_damages(ScrnInfoPtr scrn, xf86CrtcPtr crtc, RegionPtr dirty,
+-                 PixmapPtr pixmap, DamagePtr damage, int fb_id)
++                 PixmapPtr pixmap, DamagePtr damage, int fb_id, int x, int y)
+ {
+     modesettingPtr ms = modesettingPTR(scrn);
+     unsigned num_cliprects = REGION_NUM_RECTS(dirty);
+@@ -563,20 +586,30 @@ dispatch_damages(ScrnInfoPtr scrn, xf86CrtcPtr crtc, RegionPtr dirty,
+         drmModeClip *clip = xallocarray(num_cliprects, sizeof(drmModeClip));
+         BoxPtr rect = REGION_RECTS(dirty);
+         int i;
++        int c = 0;
+ 
+         if (!clip)
+             return -ENOMEM;
+ 
+-        /* Rotate and copy rects into clips */
+-        for (i = 0; i < num_cliprects; i++, rect++)
+-	    rotate_clip(pixmap, rect, &clip[i], crtc->rotation);
++        /* Create clips for the given rects in case the rect covers any
++         * area in the FB.
++         */
++        for (i = 0; i < num_cliprects; i++, rect++) {
++            if (rotate_clip(pixmap, crtc, rect, &clip[c], crtc->rotation, x, y) < 0)
++                continue;
++
++            c++;
++        }
++
++        if (!c)
++            return 0;
+ 
+         /* TODO query connector property to see if this is needed */
+-        ret = drmModeDirtyFB(ms->fd, fb_id, clip, num_cliprects);
++        ret = drmModeDirtyFB(ms->fd, fb_id, clip, c);
+ 
+         /* if we're swamping it with work, try one at a time */
+         if (ret == -EINVAL) {
+-            for (i = 0; i < num_cliprects; i++) {
++            for (i = 0; i < c; i++) {
+                 if ((ret = drmModeDirtyFB(ms->fd, fb_id, &clip[i], 1)) < 0)
+                     break;
+             }
+@@ -589,18 +622,17 @@ dispatch_damages(ScrnInfoPtr scrn, xf86CrtcPtr crtc, RegionPtr dirty,
+         }
+ 
+         free(clip);
+-        if (damage)
+-            DamageEmpty(damage);
+     }
+     return ret;
+ }
+ 
+ static int
+ dispatch_dirty_region(ScrnInfoPtr scrn, xf86CrtcPtr crtc,
+-                      PixmapPtr pixmap, DamagePtr damage, int fb_id)
++                      PixmapPtr pixmap, DamagePtr damage,
++                      int fb_id, int x, int y)
+ {
+     return dispatch_damages(scrn, crtc, DamageRegion(damage),
+-                            pixmap, damage, fb_id);
++                            pixmap, damage, fb_id, x, y);
+ }
+ 
+ static void
+@@ -632,7 +664,7 @@ ms_tearfree_update_damages(ScreenPtr pScreen)
+             /* Just notify the kernel of the damages if TearFree isn't used */
+             dispatch_damages(scrn, crtc, &region,
+                              pScreen->GetScreenPixmap(pScreen),
+-                             NULL, ms->drmmode.fb_id);
++                             NULL, ms->drmmode.fb_id, 0, 0);
+         }
+     }
+     DamageEmpty(ms->damage);
+@@ -673,7 +705,7 @@ ms_tearfree_do_flips(ScreenPtr pScreen)
+         if (ms_do_tearfree_flip(pScreen, crtc)) {
+             dispatch_damages(scrn, crtc, &trf->buf[trf->back_idx ^ 1].dmg,
+                              trf->buf[trf->back_idx ^ 1].px, NULL,
+-                             trf->buf[trf->back_idx ^ 1].fb_id);
++                             trf->buf[trf->back_idx ^ 1].fb_id, 0, 0);
+             RegionEmpty(&trf->buf[trf->back_idx ^ 1].dmg);
+         }
+     }
+@@ -692,6 +724,8 @@ dispatch_dirty(ScreenPtr pScreen)
+ 
+     for (c = 0; c < xf86_config->num_crtc; c++) {
+         xf86CrtcPtr crtc = xf86_config->crtc[c];
++        PixmapPtr pmap;
++
+         drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+ 
+         if (!drmmode_crtc)
+@@ -699,7 +733,12 @@ dispatch_dirty(ScreenPtr pScreen)
+ 
+ 	drmmode_crtc_get_fb_id(crtc, &fb_id, &x, &y);
+ 
+-        ret = dispatch_dirty_region(scrn, crtc, pixmap, ms->damage, fb_id);
++        if (crtc->rotatedPixmap)
++            pmap = crtc->rotatedPixmap;
++        else
++            pmap = pixmap;
++
++        ret = dispatch_dirty_region(scrn, crtc, pmap, ms->damage, fb_id, x, y);
+         if (ret == -EINVAL || ret == -ENOSYS) {
+             DamageUnregister(ms->damage);
+             DamageDestroy(ms->damage);
+@@ -717,7 +756,7 @@ dispatch_dirty_pixmap(ScrnInfoPtr scrn, xf86CrtcPtr crtc, PixmapPtr ppix)
+     DamagePtr damage = ppriv->secondary_damage;
+     int fb_id = ppriv->fb_id;
+ 
+-    dispatch_dirty_region(scrn, crtc, ppix, damage, fb_id);
++    dispatch_dirty_region(scrn, crtc, ppix, damage, fb_id, 0, 0);
+ }
+ 
+ static void
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1098-BACKPORT-glamor-Add-and-use-glamor_drawable_effective_depth-h.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1098-BACKPORT-glamor-Add-and-use-glamor_drawable_effective_depth-h.patch
@@ -1,0 +1,184 @@
+From f8b947a5b77379e6cefec87381f7f4c1e95d72ba Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Wed, 19 Jul 2023 12:26:21 +0200
+Subject: [PATCH 098/105] glamor: Add and use glamor_drawable_effective_depth
+ helper
+
+Consider the following window hierarchy, from ancestors to descendants:
+
+ A
+ |
+ B
+ |
+ C
+
+If both A & C have depth 32, but B has depth 24, C must effectively
+behave as if it had depth 24, even if its backing pixmap has depth 32
+as well.
+
+Fixes the xmag issue described in the GitLab issue below.
+
+Issue: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1564
+---
+ glamor/glamor_copy.c      |  8 ++++----
+ glamor/glamor_image.c     |  2 +-
+ glamor/glamor_prepare.c   |  4 ++--
+ glamor/glamor_priv.h      | 24 ++++++++++++++++++++++++
+ glamor/glamor_render.c    |  2 +-
+ glamor/glamor_transfer.c  |  2 +-
+ glamor/glamor_transform.h |  3 ++-
+ 7 files changed, 35 insertions(+), 10 deletions(-)
+
+diff --git a/glamor/glamor_copy.c b/glamor/glamor_copy.c
+index 67465867b..f8fe01036 100644
+--- a/glamor/glamor_copy.c
++++ b/glamor/glamor_copy.c
+@@ -77,7 +77,7 @@ use_copyplane(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+     glamor_set_color(drawable, gc->bgPixel, prog->bg_uniform);
+ 
+     /* XXX handle 2 10 10 10 and 1555 formats; presumably the pixmap private knows this? */
+-    switch (args->src_drawable->depth) {
++    switch (glamor_drawable_effective_depth(args->src_drawable)) {
+     case 30:
+         glUniform4ui(prog->bitplane_uniform,
+                      (args->bitplane >> 20) & 0x3ff,
+@@ -235,7 +235,7 @@ glamor_copy_cpu_fbo(DrawablePtr src,
+ 
+         PixmapPtr tmp_pix = fbCreatePixmap(screen, dst_pixmap->drawable.width,
+                                            dst_pixmap->drawable.height,
+-                                           dst->depth, 0);
++                                           glamor_drawable_effective_depth(dst), 0);
+ 
+         if (!tmp_pix) {
+             glamor_finish_access(src);
+@@ -547,7 +547,7 @@ glamor_copy_fbo_fbo_temp(DrawablePtr src,
+     tmp_pixmap = glamor_create_pixmap(screen,
+                                       bounds.x2 - bounds.x1,
+                                       bounds.y2 - bounds.y1,
+-                                      src->depth, 0);
++                                      glamor_drawable_effective_depth(src), 0);
+     if (!tmp_pixmap)
+         goto bail;
+ 
+@@ -757,7 +757,7 @@ glamor_copy_plane(DrawablePtr src, DrawablePtr dst, GCPtr gc,
+                   int srcx, int srcy, int width, int height, int dstx, int dsty,
+                   unsigned long bitplane)
+ {
+-    if ((bitplane & FbFullMask(src->depth)) == 0)
++    if ((bitplane & FbFullMask(glamor_drawable_effective_depth(src))) == 0)
+         return miHandleExposures(src, dst, gc,
+                                  srcx, srcy, width, height, dstx, dsty);
+     return miDoCopy(src, dst, gc,
+diff --git a/glamor/glamor_image.c b/glamor/glamor_image.c
+index 1a8e527b6..28bdc159f 100644
+--- a/glamor/glamor_image.c
++++ b/glamor/glamor_image.c
+@@ -129,7 +129,7 @@ glamor_get_image_gl(DrawablePtr drawable, int x, int y, int w, int h,
+                           -x, -y,
+                           (uint8_t *) d, byte_stride);
+ 
+-    if (!glamor_pm_is_solid(drawable->depth, plane_mask)) {
++    if (!glamor_pm_is_solid(glamor_drawable_effective_depth(drawable), plane_mask)) {
+         FbStip pm = fbReplicatePixel(plane_mask, drawable->bitsPerPixel);
+         FbStip *dst = (void *)d;
+         uint32_t dstStride = byte_stride / sizeof(FbStip);
+diff --git a/glamor/glamor_prepare.c b/glamor/glamor_prepare.c
+index 2bab2b613..fba875e28 100644
+--- a/glamor/glamor_prepare.c
++++ b/glamor/glamor_prepare.c
+@@ -163,7 +163,7 @@ glamor_finish_access(DrawablePtr drawable)
+         return;
+ 
+     if (priv->pbo &&
+-        !(drawable->depth == 24 && pixmap->drawable.depth == 32)) {
++        !(glamor_drawable_effective_depth(drawable) == 24 && pixmap->drawable.depth == 32)) {
+         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, priv->pbo);
+         glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+         pixmap->devPrivate.ptr = NULL;
+@@ -179,7 +179,7 @@ glamor_finish_access(DrawablePtr drawable)
+     RegionUninit(&priv->prepare_region);
+ 
+     if (priv->pbo) {
+-        if (drawable->depth == 24 && pixmap->drawable.depth == 32)
++        if (glamor_drawable_effective_depth(drawable) == 24 && pixmap->drawable.depth == 32)
+             pixmap->devPrivate.ptr = NULL;
+         else
+             glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index 1d0a46920..78bfcc220 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -539,6 +539,30 @@ glamor_pixmap_hcnt(glamor_pixmap_private *priv)
+     for (box_index = 0; box_index < glamor_pixmap_hcnt(priv) *         \
+              glamor_pixmap_wcnt(priv); box_index++)                    \
+ 
++static inline int
++glamor_drawable_effective_depth(DrawablePtr drawable)
++{
++    WindowPtr window;
++
++    if (drawable->type != DRAWABLE_WINDOW ||
++        drawable->depth != 32)
++        return drawable->depth;
++
++    window = (WindowPtr)drawable;
++    window = window->parent;
++    while (window && window->parent) {
++        /* A depth 32 window with any depth 24 ancestors (other than the root
++         * window) effectively behaves like depth 24
++         */
++        if (window->drawable.depth == 24)
++            return 24;
++
++        window = window->parent;
++    }
++
++    return 32;
++}
++
+ /* GC private structure. Currently holds only any computed dash pixmap */
+ 
+ typedef struct {
+diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
+index 2549637b6..179b62dd8 100644
+--- a/glamor/glamor_render.c
++++ b/glamor/glamor_render.c
+@@ -818,7 +818,7 @@ glamor_render_format_is_supported(PicturePtr picture)
+         return TRUE;
+ 
+     glamor_priv = glamor_get_screen_private(picture->pDrawable->pScreen);
+-    f = &glamor_priv->formats[picture->pDrawable->depth];
++    f = &glamor_priv->formats[glamor_drawable_effective_depth(picture->pDrawable)];
+ 
+     if (!f->rendering_supported)
+         return FALSE;
+diff --git a/glamor/glamor_transfer.c b/glamor/glamor_transfer.c
+index a2727f109..9404e899c 100644
+--- a/glamor/glamor_transfer.c
++++ b/glamor/glamor_transfer.c
+@@ -41,7 +41,7 @@ glamor_upload_boxes(DrawablePtr drawable, BoxPtr in_boxes, int in_nbox,
+     const struct glamor_format *f = glamor_format_for_pixmap(pixmap);
+     char *tmp_bits = NULL;
+ 
+-    if (drawable->depth == 24 && pixmap->drawable.depth == 32)
++    if (glamor_drawable_effective_depth(drawable) == 24 && pixmap->drawable.depth == 32)
+         tmp_bits = xnfalloc(byte_stride * pixmap->drawable.height);
+ 
+     glamor_make_current(glamor_priv);
+diff --git a/glamor/glamor_transform.h b/glamor/glamor_transform.h
+index 305253310..6eef2fc7a 100644
+--- a/glamor/glamor_transform.h
++++ b/glamor/glamor_transform.h
+@@ -44,7 +44,8 @@ glamor_set_color(DrawablePtr    drawable,
+                  GLint          uniform)
+ {
+     glamor_set_color_depth(drawable->pScreen,
+-                           drawable->depth, pixel, uniform);
++                           glamor_drawable_effective_depth(drawable),
++                           pixel, uniform);
+ }
+ 
+ Bool
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1099-BACKPORT-glamor-Don-t-override-source-alpha-to-1.0-if-it-s-us.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1099-BACKPORT-glamor-Don-t-override-source-alpha-to-1.0-if-it-s-us.patch
@@ -1,0 +1,89 @@
+From e1b4ed5ba25925f35bb81b47002b135087b65b17 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Fri, 5 Jan 2024 18:31:11 +0100
+Subject: [PATCH 099/105] glamor: Don't override source alpha to 1.0 if it's
+ used for blending
+
+It caused an incorrect result of the blend operation.
+
+Use glColorMask to prevent non-1.0 alpha channel values in a depth 32
+pixmap backing an effective depth 24 window. For blending operations,
+the expectation is that the destination drawable contains valid pixel
+values, so the alpha channel should already be 1.0.
+
+Fixes: d1f142891ef3 ("glamor: Ignore destination alpha as necessary for composite operation")
+Issue: https://gitlab.gnome.org/GNOME/mutter/-/issues/3104
+---
+ glamor/glamor_render.c | 28 +++++++++++++++++++++++++++-
+ 1 file changed, 27 insertions(+), 1 deletion(-)
+
+diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
+index 179b62dd8..7545268f3 100644
+--- a/glamor/glamor_render.c
++++ b/glamor/glamor_render.c
+@@ -838,6 +838,20 @@ glamor_render_format_is_supported(PicturePtr picture)
+     }
+ }
+ 
++static Bool
++render_op_uses_src_alpha(CARD8 op)
++{
++    struct blendinfo *info = &composite_op_info[op];
++
++    switch (info->dest_blend) {
++    case GL_ONE_MINUS_SRC_ALPHA:
++    case GL_SRC_ALPHA:
++        return TRUE;
++    }
++
++    return FALSE;
++}
++
+ static Bool
+ glamor_composite_choose_shader(CARD8 op,
+                                PicturePtr source,
+@@ -951,7 +965,8 @@ glamor_composite_choose_shader(CARD8 op,
+         key.dest_swizzle = SHADER_DEST_SWIZZLE_ALPHA_TO_RED;
+     } else {
+         if (dest_pixmap->drawable.depth == 32 &&
+-            glamor_drawable_effective_depth(dest->pDrawable) == 24)
++            glamor_drawable_effective_depth(dest->pDrawable) == 24 &&
++            !render_op_uses_src_alpha(op))
+             key.dest_swizzle = SHADER_DEST_SWIZZLE_IGNORE_ALPHA;
+         else
+             key.dest_swizzle = SHADER_DEST_SWIZZLE_DEFAULT;
+@@ -1185,6 +1200,7 @@ glamor_composite_with_shader(CARD8 op,
+     Bool ret = FALSE;
+     glamor_composite_shader *shader = NULL, *shader_ca = NULL;
+     struct blendinfo op_info, op_info_ca;
++    Bool restore_colormask = FALSE;
+ 
+     if (!glamor_composite_choose_shader(op, source, mask, dest,
+                                         source_pixmap, mask_pixmap, dest_pixmap,
+@@ -1209,6 +1225,14 @@ glamor_composite_with_shader(CARD8 op,
+ 
+     glamor_make_current(glamor_priv);
+ 
++    if (ca_state != CA_TWO_PASS &&
++        key.dest_swizzle == SHADER_DEST_SWIZZLE_DEFAULT &&
++        dest_pixmap->drawable.depth == 32 &&
++        glamor_drawable_effective_depth(dest->pDrawable) == 24) {
++        glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
++        restore_colormask = TRUE;
++    }
++
+     glamor_set_destination_pixmap_priv_nc(glamor_priv, dest_pixmap, dest_pixmap_priv);
+     glamor_composite_set_shader_blend(glamor_priv, dest_pixmap_priv, &key, shader, &op_info);
+     glamor_set_alu(screen, GXcopy);
+@@ -1351,6 +1375,8 @@ glamor_composite_with_shader(CARD8 op,
+ 
+     glDisable(GL_SCISSOR_TEST);
+ disable_va:
++    if (restore_colormask)
++        glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+     glDisableVertexAttribArray(GLAMOR_VERTEX_POS);
+     glDisableVertexAttribArray(GLAMOR_VERTEX_SOURCE);
+     glDisableVertexAttribArray(GLAMOR_VERTEX_MASK);
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1100-BACKPORT-glamor-Make-glamor_set_alu-take-a-DrawablePtr.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1100-BACKPORT-glamor-Make-glamor_set_alu-take-a-DrawablePtr.patch
@@ -1,0 +1,141 @@
+From 371d39b372679ce4748366fbc8518f4756367229 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Thu, 4 Jan 2024 16:03:01 +0100
+Subject: [PATCH 100/105] glamor: Make glamor_set_alu take a DrawablePtr
+
+Preparation for the following commit, no functional change intended.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ glamor/glamor_copy.c      | 4 ++--
+ glamor/glamor_gradient.c  | 4 ++--
+ glamor/glamor_pixmap.c    | 3 ++-
+ glamor/glamor_priv.h      | 2 +-
+ glamor/glamor_render.c    | 2 +-
+ glamor/glamor_transform.c | 4 ++--
+ glamor/glamor_xv.c        | 2 +-
+ 7 files changed, 11 insertions(+), 10 deletions(-)
+
+diff --git a/glamor/glamor_copy.c b/glamor/glamor_copy.c
+index f8fe01036..25fa9ee06 100644
+--- a/glamor/glamor_copy.c
++++ b/glamor/glamor_copy.c
+@@ -378,7 +378,7 @@ glamor_copy_fbo_fbo_draw(DrawablePtr src,
+     if (gc && !glamor_set_planemask(gc->depth, gc->planemask))
+         goto bail_ctx;
+ 
+-    if (!glamor_set_alu(screen, gc ? gc->alu : GXcopy))
++    if (!glamor_set_alu(dst, gc ? gc->alu : GXcopy))
+         goto bail_ctx;
+ 
+     if (bitplane && !glamor_priv->can_copyplane)
+@@ -529,7 +529,7 @@ glamor_copy_fbo_fbo_temp(DrawablePtr src,
+     if (gc && !glamor_set_planemask(gc->depth, gc->planemask))
+         goto bail_ctx;
+ 
+-    if (!glamor_set_alu(screen, gc ? gc->alu : GXcopy))
++    if (!glamor_set_alu(dst, gc ? gc->alu : GXcopy))
+         goto bail_ctx;
+ 
+     /* Find the size of the area to copy
+diff --git a/glamor/glamor_gradient.c b/glamor/glamor_gradient.c
+index 4c7ae4d77..1036ff5e1 100644
+--- a/glamor/glamor_gradient.c
++++ b/glamor/glamor_gradient.c
+@@ -971,7 +971,7 @@ glamor_generate_radial_gradient_picture(ScreenPtr screen,
+          0))
+         goto GRADIENT_FAIL;
+ 
+-    glamor_set_alu(screen, GXcopy);
++    glamor_set_alu(&pixmap->drawable, GXcopy);
+ 
+     /* Set all the stops and colors to shader. */
+     if (stops_count > RADIAL_SMALL_STOPS) {
+@@ -1288,7 +1288,7 @@ glamor_generate_linear_gradient_picture(ScreenPtr screen,
+          1))
+         goto GRADIENT_FAIL;
+ 
+-    glamor_set_alu(screen, GXcopy);
++    glamor_set_alu(&pixmap->drawable, GXcopy);
+ 
+     /* Normalize the PTs. */
+     glamor_set_normalize_pt(xscale, yscale,
+diff --git a/glamor/glamor_pixmap.c b/glamor/glamor_pixmap.c
+index 9aa169cdc..59a7db2b0 100644
+--- a/glamor/glamor_pixmap.c
++++ b/glamor/glamor_pixmap.c
+@@ -120,8 +120,9 @@ glamor_set_planemask(int depth, unsigned long planemask)
+ }
+ 
+ Bool
+-glamor_set_alu(ScreenPtr screen, unsigned char alu)
++glamor_set_alu(DrawablePtr drawable, unsigned char alu)
+ {
++    ScreenPtr screen = drawable->pScreen;
+     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+ 
+     if (glamor_priv->is_gles) {
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index 78bfcc220..3bdbd4ed9 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -667,7 +667,7 @@ void glamor_set_destination_pixmap_fbo(glamor_screen_private *glamor_priv, glamo
+  * */
+ void glamor_set_destination_pixmap_priv_nc(glamor_screen_private *glamor_priv, PixmapPtr pixmap, glamor_pixmap_private *pixmap_priv);
+ 
+-Bool glamor_set_alu(ScreenPtr screen, unsigned char alu);
++Bool glamor_set_alu(DrawablePtr drawable, unsigned char alu);
+ Bool glamor_set_planemask(int depth, unsigned long planemask);
+ RegionPtr glamor_bitmap_to_region(PixmapPtr pixmap);
+ 
+diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
+index 7545268f3..3fb71e103 100644
+--- a/glamor/glamor_render.c
++++ b/glamor/glamor_render.c
+@@ -1235,7 +1235,7 @@ glamor_composite_with_shader(CARD8 op,
+ 
+     glamor_set_destination_pixmap_priv_nc(glamor_priv, dest_pixmap, dest_pixmap_priv);
+     glamor_composite_set_shader_blend(glamor_priv, dest_pixmap_priv, &key, shader, &op_info);
+-    glamor_set_alu(screen, GXcopy);
++    glamor_set_alu(dest->pDrawable, GXcopy);
+ 
+     glamor_priv->has_source_coords = key.source != SHADER_SOURCE_SOLID;
+     glamor_priv->has_mask_coords = (key.mask != SHADER_MASK_NONE &&
+diff --git a/glamor/glamor_transform.c b/glamor/glamor_transform.c
+index b969bc114..891f7ee51 100644
+--- a/glamor/glamor_transform.c
++++ b/glamor/glamor_transform.c
+@@ -143,7 +143,7 @@ glamor_set_solid(DrawablePtr    drawable,
+ 
+     pixel = gc->fgPixel;
+ 
+-    if (!glamor_set_alu(drawable->pScreen, alu)) {
++    if (!glamor_set_alu(drawable, alu)) {
+         switch (gc->alu) {
+         case GXclear:
+             pixel = 0;
+@@ -209,7 +209,7 @@ glamor_set_tiled(DrawablePtr    drawable,
+                  GLint          offset_uniform,
+                  GLint          size_inv_uniform)
+ {
+-    if (!glamor_set_alu(drawable->pScreen, gc->alu))
++    if (!glamor_set_alu(drawable, gc->alu))
+         return FALSE;
+ 
+     if (!glamor_set_planemask(gc->depth, gc->planemask))
+diff --git a/glamor/glamor_xv.c b/glamor/glamor_xv.c
+index d897e9901..40b9ca4ea 100644
+--- a/glamor/glamor_xv.c
++++ b/glamor/glamor_xv.c
+@@ -447,7 +447,7 @@ glamor_xv_render(glamor_port_private *port_priv, int id)
+     off[2] = Loff * yco + Coff * (uco[2] + vco[2]) + bright;
+     gamma = 1.0;
+ 
+-    glamor_set_alu(screen, GXcopy);
++    glamor_set_alu(&pixmap->drawable, GXcopy);
+ 
+     for (i = 0; i < 3; i++) {
+         if (port_priv->src_pix[i]) {
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1101-BACKPORT-glamor-Fall-back-for-mixed-depth-24-32-in-glamor_set.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1101-BACKPORT-glamor-Fall-back-for-mixed-depth-24-32-in-glamor_set.patch
@@ -1,0 +1,45 @@
+From 779cf1fef91fec290b1830922090e1a054637a4d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Thu, 4 Jan 2024 16:14:17 +0100
+Subject: [PATCH 101/105] glamor: Fall back for mixed depth 24/32 in
+ glamor_set_alu
+
+For ALUs which may leave the alpha channel at values other than 1.0.
+
+Closes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1615
+
+v2:
+* List safe ALUs instead of unsafe ones
+---
+ glamor/glamor_pixmap.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/glamor/glamor_pixmap.c b/glamor/glamor_pixmap.c
+index 59a7db2b0..2c2c23a6e 100644
+--- a/glamor/glamor_pixmap.c
++++ b/glamor/glamor_pixmap.c
+@@ -136,6 +136,21 @@ glamor_set_alu(DrawablePtr drawable, unsigned char alu)
+         glDisable(GL_COLOR_LOGIC_OP);
+         return TRUE;
+     }
++
++    switch (alu) {
++    case GXnoop:
++    case GXor:
++    case GXset:
++        /* These leave the alpha channel at 1.0 */
++        break;
++    default:
++        if (glamor_drawable_effective_depth(drawable) == 24 &&
++            glamor_get_drawable_pixmap(drawable)->drawable.depth == 32) {
++            glamor_fallback("ALU %x not supported with mixed depth\n", alu);
++            return FALSE;
++        }
++    }
++
+     glEnable(GL_COLOR_LOGIC_OP);
+     switch (alu) {
+     case GXclear:
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1102-BACKPORT-glamor-glamor_debug.h-drop-unused-AbortServer-declar.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1102-BACKPORT-glamor-glamor_debug.h-drop-unused-AbortServer-declar.patch
@@ -1,0 +1,36 @@
+From ba7a58aadb9363a860e1a77d6170f8efe1c5a05e Mon Sep 17 00:00:00 2001
+From: "Enrico Weigelt, metux IT consult" <info@metux.net>
+Date: Thu, 1 Feb 2024 16:25:11 +0100
+Subject: [PATCH 102/105] glamor: glamor_debug.h: drop unused AbortServer()
+ declaration
+
+This really looks like a leftover from b861aad8e2fcf6fe1fae4f26abb650bb4eb499c6.
+
+In any case, if that function shall become part of extension/driver API,
+it should be declared with _X_EXPORT in some suitable header file - locally
+declaring extern really isn't a good idea and just an invitation for subtle bugs.
+
+Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1265>
+---
+ glamor/glamor_debug.h | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/glamor/glamor_debug.h b/glamor/glamor_debug.h
+index f64c44832..68189d484 100644
+--- a/glamor/glamor_debug.h
++++ b/glamor/glamor_debug.h
+@@ -35,10 +35,6 @@
+ #define GLAMOR_DEBUG_TEXTURE_DOWNLOAD         2
+ #define GLAMOR_DEBUG_TEXTURE_DYNAMIC_UPLOAD   3
+ 
+-extern void
+-AbortServer(void)
+-    _X_NORETURN;
+-
+ #define GLAMOR_PANIC(_format_, ...)			\
+   do {							\
+     LogMessageVerb(X_NONE, 0, "Glamor Fatal Error"	\
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1103-BACKPORT-drop-remains-of-DMX.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1103-BACKPORT-drop-remains-of-DMX.patch
@@ -1,0 +1,199 @@
+From 105ed9f72c190b2e9b70634e48f68c1f89dba370 Mon Sep 17 00:00:00 2001
+From: "Enrico Weigelt, metux IT consult" <info@metux.net>
+Date: Tue, 5 Mar 2024 16:57:50 +0100
+Subject: [PATCH 103/105] drop remains of DMX
+
+DMX has long gone, but there's still some fallout from it's removal
+yet to be cleaned up.
+
+Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1362>
+---
+ Xext/panoramiX.c             |  4 ---
+ dix/events.c                 | 54 ------------------------------------
+ dix/protocol.txt             | 18 ------------
+ include/dix.h                |  5 ----
+ include/protocol-versions.h  |  5 ----
+ mi/miinitext.c               | 11 --------
+ mi/mipointer.c               |  2 +-
+ 8 files changed, 1 insertion(+), 99 deletions(-)
+
+diff --git a/Xext/panoramiX.c b/Xext/panoramiX.c
+index bd9c45b03..d5347341b 100644
+--- a/Xext/panoramiX.c
++++ b/Xext/panoramiX.c
+@@ -27,10 +27,6 @@ Equipment Corporation.
+ #include <dix-config.h>
+ #endif
+ 
+-#ifdef HAVE_DMX_CONFIG_H
+-#include <dmx-config.h>
+-#endif
+-
+ #include <stdio.h>
+ #include <X11/X.h>
+ #include <X11/Xproto.h>
+diff --git a/dix/events.c b/dix/events.c
+index 86f5357e8..aa0131902 100644
+--- a/dix/events.c
++++ b/dix/events.c
+@@ -3245,60 +3245,6 @@ WindowsRestructured(void)
+     }
+ }
+ 
+-#ifdef PANORAMIX
+-/* This was added to support reconfiguration under Xdmx.  The problem is
+- * that if the 0th screen (i.e., screenInfo.screens[0]) is moved to an origin
+- * other than 0,0, the information in the private sprite structure must
+- * be updated accordingly, or XYToWindow (and other routines) will not
+- * compute correctly. */
+-void
+-ReinitializeRootWindow(WindowPtr win, int xoff, int yoff)
+-{
+-    GrabPtr grab;
+-    DeviceIntPtr pDev;
+-    SpritePtr pSprite;
+-
+-    if (noPanoramiXExtension)
+-        return;
+-
+-    pDev = inputInfo.devices;
+-    while (pDev) {
+-        if (DevHasCursor(pDev)) {
+-            pSprite = pDev->spriteInfo->sprite;
+-            pSprite->hot.x -= xoff;
+-            pSprite->hot.y -= yoff;
+-
+-            pSprite->hotPhys.x -= xoff;
+-            pSprite->hotPhys.y -= yoff;
+-
+-            pSprite->hotLimits.x1 -= xoff;
+-            pSprite->hotLimits.y1 -= yoff;
+-            pSprite->hotLimits.x2 -= xoff;
+-            pSprite->hotLimits.y2 -= yoff;
+-
+-            if (RegionNotEmpty(&pSprite->Reg1))
+-                RegionTranslate(&pSprite->Reg1, xoff, yoff);
+-            if (RegionNotEmpty(&pSprite->Reg2))
+-                RegionTranslate(&pSprite->Reg2, xoff, yoff);
+-
+-            /* FIXME: if we call ConfineCursorToWindow, must we do anything else? */
+-            if ((grab = pDev->deviceGrab.grab) && grab->confineTo) {
+-                if (grab->confineTo->drawable.pScreen
+-                    != pSprite->hotPhys.pScreen)
+-                    pSprite->hotPhys.x = pSprite->hotPhys.y = 0;
+-                ConfineCursorToWindow(pDev, grab->confineTo, TRUE, TRUE);
+-            }
+-            else
+-                ConfineCursorToWindow(pDev,
+-                                      pSprite->hotPhys.pScreen->root,
+-                                      TRUE, FALSE);
+-
+-        }
+-        pDev = pDev->next;
+-    }
+-}
+-#endif
+-
+ /**
+  * Initialize a sprite for the given device and set it to some sane values. If
+  * the device already has a sprite alloc'd, don't realloc but just reset to
+diff --git a/dix/protocol.txt b/dix/protocol.txt
+index a1bf93652..189ad5d40 100644
+--- a/dix/protocol.txt
++++ b/dix/protocol.txt
+@@ -51,24 +51,6 @@ R003 DAMAGE:Subtract
+ R004 DAMAGE:Add
+ V000 DAMAGE:Notify
+ E000 DAMAGE:BadDamage
+-R000 DMX:DMXQueryVersion
+-R001 DMX:DMXGetScreenCount
+-R002 DMX:DMXGetScreenInfoDEPRECATED
+-R003 DMX:DMXGetWindowAttributes
+-R004 DMX:DMXGetInputCount
+-R005 DMX:DMXGetInputAttributes
+-R006 DMX:DMXForceWindowCreationDEPRECATED
+-R007 DMX:DMXReconfigureScreenDEPRECATED
+-R008 DMX:DMXSync
+-R009 DMX:DMXForceWindowCreation
+-R010 DMX:DMXGetScreenAttributes
+-R011 DMX:DMXChangeScreensAttributes
+-R012 DMX:DMXAddScreen
+-R013 DMX:DMXRemoveScreen
+-R014 DMX:DMXGetDesktopAttributes
+-R015 DMX:DMXChangeDesktopAttributes
+-R016 DMX:DMXAddInput
+-R017 DMX:DMXRemoveInput
+ R000 DOUBLE-BUFFER:GetVersion
+ R001 DOUBLE-BUFFER:AllocateBackBufferName
+ R002 DOUBLE-BUFFER:DeallocateBackBufferName
+diff --git a/include/dix.h b/include/dix.h
+index 0dcd09b65..576c0fc0f 100644
+--- a/include/dix.h
++++ b/include/dix.h
+@@ -570,11 +570,6 @@ IsInterferingGrab(ClientPtr /* client */ ,
+                   DeviceIntPtr /* dev */ ,
+                   xEvent * /* events */ );
+ 
+-#ifdef PANORAMIX
+-extern _X_EXPORT void
+-ReinitializeRootWindow(WindowPtr win, int xoff, int yoff);
+-#endif
+-
+ #ifdef RANDR
+ extern _X_EXPORT void
+ ScreenRestructured(ScreenPtr pScreen);
+diff --git a/include/protocol-versions.h b/include/protocol-versions.h
+index d7bfc6dca..07e21df49 100644
+--- a/include/protocol-versions.h
++++ b/include/protocol-versions.h
+@@ -50,11 +50,6 @@
+ #define SERVER_DRI3_MAJOR_VERSION               1
+ #define SERVER_DRI3_MINOR_VERSION               2
+ 
+-/* DMX */
+-#define SERVER_DMX_MAJOR_VERSION		2
+-#define SERVER_DMX_MINOR_VERSION		2
+-#define SERVER_DMX_PATCH_VERSION		20040604
+-
+ /* Generic event extension */
+ #define SERVER_GE_MAJOR_VERSION                 1
+ #define SERVER_GE_MINOR_VERSION                 0
+diff --git a/mi/miinitext.c b/mi/miinitext.c
+index 2e4aba534..8249ca247 100644
+--- a/mi/miinitext.c
++++ b/mi/miinitext.c
+@@ -80,17 +80,6 @@ SOFTWARE.
+ #include "xf86Extensions.h"
+ #endif
+ 
+-#ifdef HAVE_DMX_CONFIG_H
+-#include <dmx-config.h>
+-#undef XV
+-#undef DBE
+-#undef SCREENSAVER
+-#undef RANDR
+-#undef DAMAGE
+-#undef COMPOSITE
+-#undef MITSHM
+-#endif
+-
+ #ifdef HAVE_XNEST_CONFIG_H
+ #include <xnest-config.h>
+ #undef COMPOSITE
+diff --git a/mi/mipointer.c b/mi/mipointer.c
+index 8ab814785..652726f3b 100644
+--- a/mi/mipointer.c
++++ b/mi/mipointer.c
+@@ -251,7 +251,7 @@ miPointerCursorLimits(DeviceIntPtr pDev, ScreenPtr pScreen, CursorPtr pCursor,
+  *
+  * This function is called from:
+  *    - sprite init code to place onto initial position
+- *    - the various WarpPointer implementations (core, XI, Xinerama, dmx,…)
++ *    - the various WarpPointer implementations (core, XI, Xinerama,…)
+  *    - during the cursor update path in CheckMotion
+  *    - in the Xinerama part of NewCurrentScreen
+  *    - when a RandR/RandR1.2 mode was applied (it may have moved the pointer, so
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1104-BACKPORT-modesetting-Fix-invalid-identity-CTM-on-32-bit.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1104-BACKPORT-modesetting-Fix-invalid-identity-CTM-on-32-bit.patch
@@ -1,0 +1,39 @@
+From 4e52e7b275341b71d734ff627bd13ba7c67e52ed Mon Sep 17 00:00:00 2001
+From: Trevor Davenport <trevor_davenport@selinc.com>
+Date: Thu, 9 May 2024 11:51:03 -0600
+Subject: [PATCH 104/105] modesetting: Fix invalid identity CTM on 32-bit.
+
+On 32-bit, the shifts used to initialized the identity CTM overflow and
+result in zero instead of the intended 1.  This results in a broken
+display (on at least i915) when using the modesetting xorg driver.
+
+Fix the invalid CTM by using ULL suffix on the shifts.
+
+Fixes:4e670f1281ad75c5673b6ac75645036d810da8d9
+
+Signed-off-by: Trevor Davenport <trevor_davenport@selinc.com>
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1526>
+---
+ hw/xfree86/drivers/modesetting/drmmode_display.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
+index efcca0b03..6672cafd4 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
+@@ -63,9 +63,9 @@ static PixmapPtr drmmode_create_pixmap_header(ScreenPtr pScreen, int width, int
+                                               void *pPixData);
+ 
+ static const struct drm_color_ctm ctm_identity = { {
+-    1UL << 32, 0, 0,
+-    0, 1UL << 32, 0,
+-    0, 0, 1UL << 32
++    1ULL << 32, 0, 0,
++    0, 1ULL << 32, 0,
++    0, 0, 1ULL << 32
+ } };
+ 
+ static Bool ctm_is_identity(const struct drm_color_ctm *ctm)
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/autobuild/patches/1105-BACKPORT-modesetting-Fix-hang-when-all-probed-cursor-sizes-fa.patch
+++ b/runtime-display/xorg-server/autobuild/patches/1105-BACKPORT-modesetting-Fix-hang-when-all-probed-cursor-sizes-fa.patch
@@ -1,0 +1,30 @@
+From 8aa2d88cccd4e12d937af41522ec13e05d081072 Mon Sep 17 00:00:00 2001
+From: nerdopolis <bluescreen_avenger@verizon.net>
+Date: Tue, 28 May 2024 06:31:21 -0400
+Subject: [PATCH 105/105] modesetting: Fix hang when all probed cursor sizes
+ fail to find a minimum one
+
+This fixes a hang on simpledrm where min_cursor_height and min_cursor_width is
+never established, and drmmode_load_cursor_argb_check would infinitely when
+the minimum values where 0 or less.
+---
+ hw/xfree86/drivers/modesetting/drmmode_display.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
+index 6672cafd4..15c75484a 100644
+--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
++++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
+@@ -4377,6 +4377,9 @@ static void drmmode_probe_cursor_size(xf86CrtcPtr crtc)
+     drmmode_ptr drmmode = drmmode_crtc->drmmode;
+     int width, height, size;
+ 
++    ms->min_cursor_width = ms->max_cursor_width;
++    ms->min_cursor_height = ms->max_cursor_height;
++
+     /* probe square min first */
+     for (size = 1; size <= ms->max_cursor_width &&
+              size <= ms->max_cursor_height; size *= 2) {
+-- 
+2.45.2
+

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,5 +1,4 @@
-VER=21.1.13
-REL=1
-SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
+VER=21.1.13+backport
+SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-${VER%+*}.tar.xz"
 CHKSUMS="sha256::b45a02d5943f72236a360d3cc97e75134aa4f63039ff88c04686b508a3dc740c"
 CHKUPDATE="anitya::id=5250"


### PR DESCRIPTION
Topic Description
-----------------

- xorg-server: backport a bunch of patches from xserver master
    These backports majorly affects glamor and modesetting DDX.
    Significant things include proper Glamor GLES support, Modesetting DDX
    TearFree.
    Some bugfix-alike patches are backported too.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- xorg-server: 21.1.13+backport

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorg-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
