### PR TITLE
lasem: update to 0.5.2

### DIFF
--- a/runtime-network/gwenhywfar/spec
+++ b/runtime-network/gwenhywfar/spec
@@ -1,5 +1,4 @@
-VER=5.4.0
-SRCS="tbl::https://www.aquamaniac.de/rdm/attachments/download/331/gwenhywfar-$VER.tar.gz"
-CHKSUMS="sha256::e59fed9873c0e4880f5cf43748498df9ff4ff67cb5061157d21a55d16bb97489"
+VER=5.10.2
+SRCS="tbl::https://www.aquamaniac.de/rdm/attachments/download/501/gwenhywfar-$VER.tar.gz"   
+CHKSUMS="sha256::60A7DA03542865501208F20E18DE32B45A75E3F4AA8515CA622B391A2728A9E1"
 CHKUPDATE="anitya::id=6891"
-REL=3

--- a/runtime-productivity/lasem/spec
+++ b/runtime-productivity/lasem/spec
@@ -1,4 +1,4 @@
-VER=0.5.1
-SRCS="tbl::https://download.gnome.org/sources/lasem/${VER:0:3}/lasem-$VER.tar.xz"
-CHKSUMS="sha256::51f019984bc94b8a0dec70bb7af2950345759304584a5cc3d990d9ff2c66b443"
+VER=0.5.2
+SRCS="git::commit=tags/$VER::https://github.com/LasemProject/lasem"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11553"


### PR DESCRIPTION
Topic Description
-----------------

- lasem: update to 0.5.2
- gwenhywfar: update to 5.10.2

Package(s) Affected
-------------------

- gwenhywfar: 5.10.2
- lasem: 1:0.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit lasem gwenhywfar
```

Test Build(s) Done
------------------

