### PR TITLE
[DONT MERGE] Set code model to medium to fix Chromium on LA64

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,5 @@
-VER=4.3.8
-SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
+VER=4.3.8+git20240728
+#SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4.git"
+SRCS="git::commit=3bf77286abf2eff09b78072309cd5e6da9441193::https://github.com/AOSC-Dev/autobuild4.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/core-devel/gcc/spec
+++ b/core-devel/gcc/spec
@@ -1,5 +1,5 @@
 VER=13.2.0
-REL=6
+REL=7
 # Note: Use with Git snapshots.
 # SRCS="tbl::https://repo.aosc.io/aosc-repacks/gcc-$VER.tar.xz"
 # Note: Use with upstream stable releases.


### PR DESCRIPTION
Topic Description
-----------------

- gcc: bump REL to rebuild with new CFLAGS on LA64
- autobuild4: update to 4.3.8+git20240728

Package(s) Affected
-------------------

- autobuild4: 4.3.8+git20240728
- gcc: 13.2.0-7
- gcc-runtime: 13.2.0-7

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 gcc libyuv chromium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] LoongArch 64-bit `loongarch64`
