### PR TITLE
curl+32: security update to 8.9.0

### DIFF
--- a/runtime-optenv32/curl+32/autobuild/build
+++ b/runtime-optenv32/curl+32/autobuild/build
@@ -13,7 +13,7 @@ export LDFLAGS+=" -L/opt/32/lib"
             --without-libidn --with-openssl --with-random=/dev/urandom \
             --with-ca-bundle=/etc/ssl/ca-bundle.crt \
             --without-libpsl \
-            CC=i686-pc-linux-gnu-gcc CXX=i686-pc-linux-gnu-g++ \
+            CC=i686-aosc-linux-gnu-gcc CXX=i686-aosc-linux-gnu-g++ \
             PKG_CONFIG_PATH=/opt/32/lib/pkconfig
 make
 make install DESTDIR="$PKGDIR"

--- a/runtime-optenv32/curl+32/spec
+++ b/runtime-optenv32/curl+32/spec
@@ -1,4 +1,4 @@
-VER=8.6.0
+VER=8.9.0
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
-CHKSUMS="sha256::3ccd55d91af9516539df80625f818c734dc6f2ecf9bada33c76765e99121db15"
+CHKSUMS="sha256::ff09b2791ca56d25fd5c3f3a4927dce7c8a9dc4182200c487ca889fba1fdd412"
 CHKUPDATE="anitya::id=381"


### PR DESCRIPTION
Topic Description
-----------------

- curl+32: security update to 8.9.0

Package(s) Affected
-------------------

- curl+32: 8.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit curl+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
