### PR TITLE
rclone: update to 1.67.0

### DIFF
--- a/app-web/rclone/autobuild/defines
+++ b/app-web/rclone/autobuild/defines
@@ -8,4 +8,5 @@ PKGREP="fish<=3.5.1"
 
 ABSPLITDBG=0
 
-FAIL_ARCH="loongarch64"
+# FIXME: mips64r6el has not yet built Go, skipping for now.
+FAIL_ARCH="(loongarch64|mips64r6el)"

--- a/app-web/rclone/spec
+++ b/app-web/rclone/spec
@@ -1,5 +1,4 @@
-VER=1.65.2
-REL=3
+VER=1.67.0
 SRCS="git::commit=tags/v$VER::https://github.com/rclone/rclone/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11750"


### PR DESCRIPTION
Topic Description
-----------------

- rclone: update to 1.67.0
    Add mips64r6el as FAIL_ARCH (no Go)

Package(s) Affected
-------------------

- rclone: 1.67.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rclone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
