### PR TITLE
flac (FLAC): rework for 1.4.3

### DIFF
--- a/runtime-multimedia/libsndfile/spec
+++ b/runtime-multimedia/libsndfile/spec
@@ -1,5 +1,5 @@
 VER=1.2.0
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/libsndfile/libsndfile"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13277"


### PR DESCRIPTION
Topic Description
-----------------

- libsndfile: rebuild to fix a bad bump
    libsndfile was not correctly built against libFLAC.so.12, causing KDE to fail
    to start.

Package(s) Affected
-------------------

- libsndfile: 1.2.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libsndfile
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Experimental Architectures**

- [x] MIPS R6 64-bit (Little Endian) `mips64r6el`
