### PR TITLE
imagemagick: update to 6.9.13+14

### DIFF
--- a/app-utils/imagemagick/autobuild/beyond
+++ b/app-utils/imagemagick/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Remove unused empty directory …"
+rm -rv "$PKGDIR"/usr/man

--- a/app-utils/imagemagick/autobuild/defines
+++ b/app-utils/imagemagick/autobuild/defines
@@ -35,6 +35,7 @@ AUTOTOOLS_AFTER="--with-modules \
                  --with-gslib \
                  --with-gs-font-dir=/usr/share/fonts/Type1 \
                  --with-perl \
+                 --with-perl-options=INSTALLDIRS=site \
                  --with-lqr \
                  --with-rsvg \
                  --with-openjp2 \

--- a/app-utils/imagemagick/spec
+++ b/app-utils/imagemagick/spec
@@ -1,4 +1,4 @@
-VER=6.9.13+7
-SRCS="git::commit=tags/${VER/+/-}::https://github.com/ImageMagick/ImageMagick6"
+VER=6.9.13+14
+SRCS="git::commit=tags/${VER/+/-}::https://github.com/ImageMagick/ImageMagick6.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16253"


### PR DESCRIPTION
Topic Description
-----------------

- imagemagick: update to 6.9.13+14

Package(s) Affected
-------------------

- imagemagick: 6.9.13+14

Security Update?
----------------

No

Build Order
-----------

```
#buildit imagemagick
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
