### PR TITLE
ghidra: update to 11.1.2

### DIFF
--- a/app-devel/ghidra/spec
+++ b/app-devel/ghidra/spec
@@ -1,4 +1,5 @@
-VER=11.0
+UPSTREAM_VER=11.1.2_build
+VER=${UPSTREAM_VER/_build/}
 SRCS="git::commit=tags/Ghidra_${VER}_build;rename=ghidra::https://github.com/NationalSecurityAgency/ghidra"
 SUBDIR="ghidra"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- ghidra: update to 11.1.2_build
    Mark UPSTREAM_VER to help aosc-findupdate.

Package(s) Affected
-------------------

- ghidra: ${VER/_build/}

Security Update?
----------------

No

Build Order
-----------

```
#buildit ghidra
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
