### PR TITLE
mirrormgr: update to 0.10.3

### DIFF
--- a/app-admin/mirrormgr/spec
+++ b/app-admin/mirrormgr/spec
@@ -1,4 +1,4 @@
-VER="0.10.2"
+VER=0.10.3
 SRCS="git::commit=tags/v${VER/\~beta/-beta}::https://github.com/AOSC-Dev/mirrormgr"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226680"


### PR DESCRIPTION
Topic Description
-----------------

- mirrormgr: update to 0.10.3
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- mirrormgr: 0.10.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit mirrormgr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
