### PR TITLE
lilypond: update to 2.24.4

### DIFF
--- a/app-multimedia/lilypond/autobuild/defines
+++ b/app-multimedia/lilypond/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=lilypond
 PKGDES="An automated music engraving system"
-PKGDEP="guile-2.2 python-2 texlive ghostscript pango fontconfig"
-BUILDDEP="flex bison gettext texinfo fontforge gsfonts dblatex imagemagick zip rsync netpbm tex-gyre texi2html x11-font"
+PKGDEP="guile python-3 texlive ghostscript cairo freetype glib libpng pango \
+        fontconfig tex-gyre urw-fonts"
+BUILDDEP="flex bison gettext texinfo fontforge gsfonts imagemagick zip rsync \
+          texlive texi2html dejavu-fonts noto-cjk-fonts libertine-fonts"
 PKGSEC="sound"
 
 PKGEPOCH=1

--- a/app-multimedia/lilypond/autobuild/prepare
+++ b/app-multimedia/lilypond/autobuild/prepare
@@ -1,5 +1,0 @@
-export GUILE_CONFIG=/usr/bin/guile-config2.2
-export LDFLAGS="$LDFLAGS -lpthread"
-
-sed -i 's|GUILE_CFLAGS=.*|GUILE_CFLAGS="`pkg-config --cflags guile-2.2`"|' configure
-sed -i 's|GUILE_LDFLAGS=.*|GUILE_LDFLAGS="`pkg-config --libs guile-2.2`"|' configure

--- a/app-multimedia/lilypond/spec
+++ b/app-multimedia/lilypond/spec
@@ -1,4 +1,4 @@
-VER=2.23.0
+VER=2.24.4
 SRCS="tbl::http://lilypond.org/download/sources/v${VER:0:4}/lilypond-$VER.tar.gz"
-CHKSUMS="sha256::b2c795278ecef7e7b4383be6d9ad64b735dd826e790ccf791e656fa16a135fd3"
-CHKUPDATE="anitya::id=141405"
+CHKSUMS="sha256::e96fa03571c79f20e1979653afabdbe4ee42765a3d9fd14953f0cd9eea51781c"
+CHKUPDATE="anitya::id=9785"


### PR DESCRIPTION
Topic Description
-----------------

- lilypond: update to 2.24.4
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- lilypond: 1:2.24.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit lilypond
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
