### PR TITLE
tigervnc (TigerVNC): update to 1.14.0

### DIFF
--- a/app-network/tigervnc/autobuild/beyond
+++ b/app-network/tigervnc/autobuild/beyond
@@ -12,8 +12,8 @@ cd "$SRCDIR"/unix/xserver
 make
 
 abinfo "Installing VNC 'hardware' backend ..."
-make install -C "$SRCDIR"/unix/xserver/hw/vnc/ DESTDIR="$PKGDIR"
-cd "$SRCDIR"
+make install \
+    -C "$SRCDIR"/unix/xserver/hw/vnc/ DESTDIR="$PKGDIR"
 
 abinfo "Removing the libvnc.so extension that won't work with system Xorg ..."
 rm -v "$PKGDIR"/usr/lib/xorg/modules/extensions/libvnc.so

--- a/app-network/tigervnc/autobuild/defines
+++ b/app-network/tigervnc/autobuild/defines
@@ -1,9 +1,11 @@
 PKGNAME=tigervnc
 PKGSEC=net
-PKGDEP="fltk gnutls libgcrypt mesa libjpeg-turbo pixman x11-app xkeyboard-config"
+PKGDEP="fltk gnutls libgcrypt mesa libjpeg-turbo pixman x11-app \
+        xkeyboard-config ffmpeg libxcvt"
 BUILDDEP="x11-font x11-app x11-proto cmake imagemagick nasm"
 PKGDES="Suite of VNC servers and clients"
 
 ABTYPE=cmakeninja
-# Library built by CMake is needed for Xvnc
+
+# Note: Library built by CMake is needed for Xvnc
 ABSHADOW=0

--- a/app-network/tigervnc/autobuild/prepare
+++ b/app-network/tigervnc/autobuild/prepare
@@ -3,12 +3,13 @@ cd "$SRCDIR"/unix/xserver
 cp -av "$SRCDIR"/../xorg-server*/* "$SRCDIR"/unix/xserver/
 
 abinfo "Patching Xorg server ..."
-patch -d "$SRCDIR"/unix/xserver -Np1 -i "$SRCDIR"/unix/xserver120.patch
+patch \
+    -d "$SRCDIR"/unix/xserver \
+    -Np1 \
+    -i "$SRCDIR"/unix/xserver21.patch
 
 abinfo "Regenerating autotools scripts for Xorg server ..."
-autoreconf -fi
+autoreconf -fvi
 
 abinfo "Adding /usr/include/libdrm to include path ..."
 export CFLAGS="${CFLAGS} -I/usr/include/libdrm"
-
-cd "$SRCDIR"

--- a/app-network/tigervnc/spec
+++ b/app-network/tigervnc/spec
@@ -1,8 +1,9 @@
-VER=1.12.0
-XORGVER=1.20.14
-SRCS="git::rename=tigervnc;commit=tags/v1.12.0::https://github.com/TigerVNC/tigervnc.git \
-      tbl::https://www.x.org/archive/individual/xserver/xorg-server-$XORGVER.tar.xz"
+UPSTREAM_VER=1.14.0
+XORG_VER=21.1.13
+VER=${UPSTREAM_VER}+xserver${XORG_VER}
+SRCS="git::rename=tigervnc;commit=tags/v${UPSTREAM_VER}::https://github.com/TigerVNC/tigervnc.git \
+      tbl::https://www.x.org/archive/individual/xserver/xorg-server-${XORG_VER}.tar.xz"
 CHKSUMS="SKIP \
-         sha256::5cc5b70b9be89443e2594b93656c60bd5e82cd7f01deb4ce4faf81dcf546a16b"
+         sha256::b45a02d5943f72236a360d3cc97e75134aa4f63039ff88c04686b508a3dc740c"
 SUBDIR="tigervnc"
 CHKUPDATE="anitya::id=4970"


### PR DESCRIPTION
Topic Description
-----------------

- tigervnc: update to 1.14.0
    - Add ffmpeg dep for H.264 codec support.
    - Clean up spec and use UPSTREAM_VER (as well as removing a hard-coded v1.12.0
    version reference!).
    - Switch to xorg-server 21.x per upstream requirement.
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- tigervnc: 1.14.0+xserver21.1.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit tigervnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
