### PR TITLE
[DONT MERGE] mozilla: rebuild with LSX

### DIFF
--- a/app-web/firefox/spec
+++ b/app-web/firefox/spec
@@ -1,4 +1,5 @@
 VER=128.0.3
+REL=1
 CHKUPDATE="anitya::id=5506"
 SRCS="tbl::https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz \
       file::rename=ach.xpi::https://archive.mozilla.org/pub/firefox/releases/$VER/linux-x86_64/xpi/ach.xpi \

--- a/app-web/thunderbird/spec
+++ b/app-web/thunderbird/spec
@@ -1,4 +1,5 @@
 VER=128.0.1esr
+REL=1
 CHKUPDATE="anitya::id=4967"
 SRCS="https://archive.mozilla.org/pub/thunderbird/releases/$VER/source/thunderbird-$VER.source.tar.xz \
       file::rename=af.xpi::http://ftp.mozilla.org/pub/thunderbird/releases/$VER/linux-x86_64/xpi/af.xpi \


### PR DESCRIPTION
Topic Description
-----------------

- thunderbird: bump REL to rebuild with LSX on LA64
- firefox: bump REL to rebuild with LSX on LA64
- aosc-aaa: update to 11.4.7
- gcc: bump REL to rebuild with new CFLAGS on LA64
- autobuild4: update to 4.3.10
- libyuv: update to 0+git20240215…
    … to satisfy Chromium.
- chromium: add libyuv as Depends
- chromium: update to 127.0.6533.72
    - Use rust-bindgen provided by the system.
    - Drop unused build argument.
    - Remove OpenJDK from Build-Depends, since it's no longer invoked in the build process.
    - Also remove OpenJDK related workarounds and patches.
    - Remove some workarounds for testing.
    - Remove an extra character in the appdata.xml.
    - Add patch to build libpng's LSX code on LoongArch64.
    - Track patches at https://dev.azure.com/AOSC-Tracking/_git/chromium @ aosc/v127.0.6533.72.
    - Most patches are now properly credited.

Package(s) Affected
-------------------

- aosc-aaa: 11.4.7
- autobuild4: 4.3.10
- firefox: 128.0.3-1
- gcc: 13.2.0-7
- gcc-runtime: 13.2.0-7
- thunderbird: 128.0.1esr-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 gcc aosc-aaa firefox thunderbird
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
