### PR TITLE
[DONT MERGE] mozilla: rebuild with GCC

### DIFF
--- a/app-web/firefox/autobuild/defines
+++ b/app-web/firefox/autobuild/defines
@@ -10,14 +10,6 @@ PKGDES="Standalone Web browser from Mozilla"
 PKGBREAK="firefox-i18n<=43.0.1"
 PKGREP="firefox-i18n<=43.0.1"
 
-USECLANG=1
-
-# FIXME
-# ld.lld: error: ../../../dist/bin/libxul.so.lto.o:(function nsXPTCStubBase::Stub3(): .text+0x4): relocation R_RISCV_JAL out of range: -15402334 is not in [-1048576, 1048575]; references 'SharedStub'
-# >>> referenced by ld-temp.o
-# >>> defined in ../../../xpcom/reflect/xptcall/md/unix/xptcstubs_asm_riscv64.o
-NOLTO__RISCV64=1
-
 # No debug symbols found in /var/cache/acbs/build/acbs.xatt16c9/firefox-128.0.2/abdist/usr/lib/firefox/firefox
 ABSTRIP=0
 ABSPLITDBG=0

--- a/app-web/firefox/autobuild/prepare
+++ b/app-web/firefox/autobuild/prepare
@@ -1,38 +1,14 @@
-abinfo "Tweaking CXXFLAGS ..."
-# FIXME: clang: error: unknown argument: '-fira-loop-pressure'
-export CXXFLAGS="${CXXFLAGS/-fira-loop-pressure/}"
-export CXXFLAGS="${CXXFLAGS/-fira-hoist-pressure/}"
-export CXXFLAGS="${CXXFLAGS/-fdeclone-ctor-dtor/}"
-
 abinfo "Preparing mozconfig ..."
 sed -e "s,@HOST@,${ARCH_TARGET[${CROSS:-ARCH}]},g" \
     -i "$SRCDIR"/autobuild/mozconfig
 
 if ! ab_match_arch loongson3; then
-    echo "ac_add_options --enable-linker=lld" \
-        >> "$SRCDIR"/autobuild/mozconfig
     echo "ac_add_options --with-wasi-sysroot=/usr/lib/wasm32-wasi/" \
         >> "$SRCDIR"/autobuild/mozconfig
 fi
 
-# FIXME
-# error: linking with `/var/cache/acbs/build/acbs.tdg5m00_/firefox-128.0.2/build/cargo-linker` failed: exit status: 1
-#   |
-#   = note: LC_ALL="C" PATH="/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/bin:/var/cache/acbs/build/acbs.tdg5m00_/firefox-128.0.2/mozbuild/srcdirs/firefox-128.0.2-cd118c606d13/_virtualenvs/build/bin:/var/cache/acbs/build/acbs.tdg5m00_/firefox-128.0.2/mozbuild/srcdirs/firefox-128.0.2-cd118c606d13/_virtualenvs/mach/bin:/usr/local/bin:/usr/bin:/root/.cargo/bin" VSLANG="1033" "/var/cache/acbs/build/acbs.tdg5m00_/firefox-128.0.2/build/cargo-linker" "/tmp/rustcNfYF5C/symbols.o" "/var/cache/acbs/build/acbs.tdg5m00_/firefox-128.0.2/obj-mips64el-unknown-linux-gnuabi64/release/build/proc-macro2-2e9eccf43e42a20c/build_script_build-2e9eccf43e42a20c.build_script_build.7fc36fe6be68b652-cgu.0.rcgu.o" "/var/cache/acbs/build/acbs.tdg5m00_/firefox-128.0.2/obj-mips64el-unknown-linux-gnuabi64/release/build/proc-macro2-2e9eccf43e42a20c/build_script_build-2e9eccf43e42a20c.build_script_build.7fc36fe6be68b652-cgu.1.rcgu.o" "/var/cache/acbs/build/acbs.tdg5m00_/firefox-128.0.2/obj-mips64el-unknown-linux-gnuabi64/release/build/proc-macro2-2e9eccf43e42a20c/build_script_build-2e9eccf43e42a20c.46klksw3d6aqgnt6.rcgu.o" "-Wl,--as-needed" "-L" "/var/cache/acbs/build/acbs.tdg5m00_/firefox-128.0.2/obj-mips64el-unknown-linux-gnuabi64/release/deps" "-L" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib" "-Wl,-Bstatic" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libstd-6dcaeb4e3195ef4c.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libpanic_unwind-3b492db5f861c144.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libobject-a4d15655b8d59547.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libmemchr-433eb4217c15c220.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libaddr2line-3694f367f2cdb9fc.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libgimli-73fb45a729ed0e30.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/librustc_demangle-41cacb4ff97fa4cf.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libstd_detect-73d35a69185f39da.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libhashbrown-f5654efde69fe63a.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/librustc_std_workspace_alloc-d553094a352c860a.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libminiz_oxide-660efaccb5d68a60.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libadler-b79bbf5dab20e247.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libunwind-12f55669c7956981.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libcfg_if-098c3160b34fea81.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/liblibc-9879917f39f4f518.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/liballoc-0695d1b670b70049.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/librustc_std_workspace_core-b92546fd4bf9da36.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libcore-306fddc16bfa4696.rlib" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libcompiler_builtins-609434335fac640f.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib" "-o" "/var/cache/acbs/build/acbs.tdg5m00_/firefox-128.0.2/obj-mips64el-unknown-linux-gnuabi64/release/build/proc-macro2-2e9eccf43e42a20c/build_script_build-2e9eccf43e42a20c" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,--strip-debug" "-nodefaultlibs"
-#   = note: ld.lld: error: relocation R_MIPS_64 cannot be used against symbol 'DW.ref.rust_eh_personality'; recompile with -fPIC
-#           >>> defined in /var/cache/acbs/build/acbs.tdg5m00_/firefox-128.0.2/obj-mips64el-unknown-linux-gnuabi64/release/build/proc-macro2-2e9eccf43e42a20c/build_script_build-2e9eccf43e42a20c.build_script_build.7fc36fe6be68b652-cgu.0.rcgu.o
-#           >>> referenced by build_script_build.7fc36fe6be68b652-cgu.0
-#           >>>               /var/cache/acbs/build/acbs.tdg5m00_/firefox-128.0.2/obj-mips64el-unknown-linux-gnuabi64/release/build/proc-macro2-2e9eccf43e42a20c/build_script_build-2e9eccf43e42a20c.build_script_build.7fc36fe6be68b652-cgu.0.rcgu.o:(.eh_frame+0x4103)
 if ab_match_arch loongson3; then
-    echo "ac_add_options --enable-linker=bfd" \
-        >> "$SRCDIR"/autobuild/mozconfig
     echo "ac_add_options --without-wasm-sandboxed-libraries" \
-        >> "$SRCDIR"/autobuild/mozconfig
-fi
-
-if ab_match_arch ppc64el; then
-    abinfo "FIXME: Disabling broken WebRTC on ppc64el ..."
-    echo "ac_add_options --disable-webrtc" \
         >> "$SRCDIR"/autobuild/mozconfig
 fi
 

--- a/app-web/firefox/spec
+++ b/app-web/firefox/spec
@@ -1,5 +1,5 @@
 VER=128.0.3
-REL=1
+REL=2
 CHKUPDATE="anitya::id=5506"
 SRCS="tbl::https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz \
       file::rename=ach.xpi::https://archive.mozilla.org/pub/firefox/releases/$VER/linux-x86_64/xpi/ach.xpi \

--- a/app-web/thunderbird/autobuild/defines
+++ b/app-web/thunderbird/autobuild/defines
@@ -11,18 +11,7 @@ PKGDES="Standalone mail and news reader from Mozilla"
 PKGBREAK="thunderbird-i18n<=38.5.0"
 PKGREP="thunderbird-i18n<=38.5.0"
 
-USECLANG=1
 ABSPLITDBG=0
-
-# FIXME: Confuses lld on amd64 and will produce broken binary
-AB_FLAGS_PIE=0
 
 # FIXME: STL code can only be used with -fno-exceptions
 AB_FLAGS_EXC=0
-
-# FIXME: LLVM crashes.
-USECLANG__PPC64EL=0
-NOLTO__PPC64EL=1
-
-# FIXME: ld.lld is not available.
-USECLANG__LOONGSON3=0

--- a/app-web/thunderbird/spec
+++ b/app-web/thunderbird/spec
@@ -1,5 +1,5 @@
 VER=128.0.1esr
-REL=1
+REL=2
 CHKUPDATE="anitya::id=4967"
 SRCS="https://archive.mozilla.org/pub/thunderbird/releases/$VER/source/thunderbird-$VER.source.tar.xz \
       file::rename=af.xpi::http://ftp.mozilla.org/pub/thunderbird/releases/$VER/linux-x86_64/xpi/af.xpi \


### PR DESCRIPTION
Topic Description
-----------------

- thunderbird: bump REL to rebuild with GCC
- firefox: bump REL to rebuild with GCC
- thunderbird: bump REL to rebuild with LSX on LA64
- firefox: bump REL to rebuild with LSX on LA64
- aosc-aaa: update to 11.4.7
- gcc: bump REL to rebuild with new CFLAGS on LA64
- autobuild4: update to 4.3.10
- libyuv: update to 0+git20240215…
    … to satisfy Chromium.
- chromium: add libyuv as Depends
- chromium: update to 127.0.6533.72
    - Use rust-bindgen provided by the system.
    - Drop unused build argument.
    - Remove OpenJDK from Build-Depends, since it's no longer invoked in the build process.
    - Also remove OpenJDK related workarounds and patches.
    - Remove some workarounds for testing.
    - Remove an extra character in the appdata.xml.
    - Add patch to build libpng's LSX code on LoongArch64.
    - Track patches at https://dev.azure.com/AOSC-Tracking/_git/chromium @ aosc/v127.0.6533.72.
    - Most patches are now properly credited.

Package(s) Affected
-------------------

- aosc-aaa: 11.4.7
- autobuild4: 4.3.10
- firefox: 128.0.3-2
- gcc: 13.2.0-7
- gcc-runtime: 13.2.0-7
- thunderbird: 128.0.1esr-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 gcc aosc-aaa firefox thunderbird
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
