### PR TITLE
openttd: update to 14.1

### DIFF
--- a/app-games/openttd/spec
+++ b/app-games/openttd/spec
@@ -1,11 +1,11 @@
-UPSTREAM_VER=12.2
+UPSTREAM_VER=14.1
 OPENGFX_VER=7.1
 OPENSFX_VER=1.0.3
 VER=${UPSTREAM_VER}+opengfx${OPENGFX_VER}+opensfx${OPENSFX_VER}
 SRCS="tbl::https://cdn.openttd.org/openttd-releases/${UPSTREAM_VER}/openttd-${UPSTREAM_VER}-source.tar.xz \
       tbl::https://cdn.openttd.org/opengfx-releases/${OPENGFX_VER}/opengfx-${OPENGFX_VER}-all.zip \
       tbl::https://cdn.openttd.org/opensfx-releases/${OPENSFX_VER}/opensfx-${OPENSFX_VER}-all.zip"
-CHKSUMS="sha256::81508f0de93a0c264b216ef56a05f8381fff7bffa6d010121a21490b4dace95c \
+CHKSUMS="sha256::2c14c8f01f44148c4f2c88c169a30abcdb002eb128a92b9adb76baa76b013494 \
          sha256::928fcf34efd0719a3560cbab6821d71ce686b6315e8825360fba87a7a94d7846 \
          sha256::e0a218b7dd9438e701503b0f84c25a97c1c11b7c2f025323fb19d6db16ef3759"
 CHKUPDATE="anitya::id=8640"


### PR DESCRIPTION
Topic Description
-----------------

- openttd: update to 14.1

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit upgrade
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
