### PR TITLE
udisks-2: update to 2.10.1

### DIFF
--- a/app-admin/udisks-2/autobuild/defines
+++ b/app-admin/udisks-2/autobuild/defines
@@ -29,8 +29,7 @@ PKGDES="Storage media interface"
 AUTOTOOLS_AFTER="--with-systemdsystemunitdir=/usr/lib/systemd/system \
                  --localstatedir=/var \
                  --libexecdir=/usr/lib \
-                 --disable-iscsi \
-                 --disable-bcache"
+                 --disable-iscsi"
 
 MAKE_AFTER="bash_completiondir=/usr/share/bash-completion/completions"
 ABSHADOW=0

--- a/app-admin/udisks-2/autobuild/postinst
+++ b/app-admin/udisks-2/autobuild/postinst
@@ -1,0 +1,10 @@
+echo -e "Checking whether systemd units need to be reload..."
+if [[ $(systemctl show udisks2 --property=NeedDaemonReload | cut -d= -f2) == "yes" ]]; then
+    echo "Reloading systemd units ..."
+    systemctl daemon-reload
+else
+    echo "Nothing needs reloading."
+fi
+
+echo "Restarting udisks2 service ..."
+systemctl try-restart udisks2

--- a/app-admin/udisks-2/spec
+++ b/app-admin/udisks-2/spec
@@ -1,5 +1,4 @@
-VER=2.8.4
-REL=3
+VER=2.10.1
 SRCS="tbl::https://github.com/storaged-project/udisks/releases/download/udisks-$VER/udisks-$VER.tar.bz2"
-CHKSUMS="sha256::d28367bdacfa039719327e68300b6118427874f2dc53ff7109dedb70a7289819"
+CHKSUMS="sha256::b75734ccf602540dedb4068bec206adcb508a4c003725e117ae8f994d92d8ece"
 CHKUPDATE="anitya::id=5028"

--- a/runtime-devices/libblockdev/autobuild/defines
+++ b/runtime-devices/libblockdev/autobuild/defines
@@ -25,11 +25,9 @@ BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="A library for manipulating block devices"
 
-AUTOTOOLS_AFTER="--with-dm=no \
-                 --with-bcache"
+AUTOTOOLS_AFTER="--with-dm=no"
 AUTOTOOLS_AFTER__RETRO=" \
                  ${AUTOTOOLS_AFTER} \
-                 --without-bcache \
                  --without-nvdimm"
 AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"

--- a/runtime-devices/libblockdev/spec
+++ b/runtime-devices/libblockdev/spec
@@ -1,5 +1,4 @@
-VER=2.23
-REL=2
-SRCS="tbl::https://github.com/storaged-project/libblockdev/archive/${VER}-1.tar.gz"
-CHKSUMS="sha256::c5fc030474b44afcaedd8ea10388282534a6d5bb25488b780e645fbf0a6d4d80"
+VER=3.1.1
+SRCS="tbl::https://github.com/storaged-project/libblockdev/releases/download/${VER}-1/libblockdev-${VER}.tar.gz"
+CHKSUMS="sha256::a5cb33a53ff5969067982704f45399d02555fdb2313ed0c56eac9555397dc2db"
 CHKUPDATE="anitya::id=9397"


### PR DESCRIPTION
Topic Description
-----------------

- udisks-2: update to 2.10.1

Package(s) Affected
-------------------

- udisks-2: 2.8.4-3
- libblockdev
Security Update?
----------------

No

Build Order
-----------

```
#buildit libblockdev udisks-2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
