### PR TITLE
[DONT MERGE] Revert GCC target/PR 81616 for Afterglow

### DIFF
--- a/core-devel/gcc/01-runtime/patches/0200-i386-revert-PR-target-81616-for-afterglow.patch.i486
+++ b/core-devel/gcc/01-runtime/patches/0200-i386-revert-PR-target-81616-for-afterglow.patch.i486
@@ -1,0 +1,1568 @@
+diff -ruNd a/gcc/config/i386/athlon.md b/gcc/config/i386/athlon.md
+--- a/gcc/config/i386/athlon.md
++++ b/gcc/config/i386/athlon.md
+@@ -151,11 +151,11 @@
+ 
+ ;; Jump instructions are executed in the branch unit completely transparent to us
+ (define_insn_reservation "athlon_branch" 0
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (eq_attr "type" "ibr"))
+ 			 "athlon-direct,athlon-ieu")
+ (define_insn_reservation "athlon_call" 0
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (eq_attr "type" "call,callv"))
+ 			 "athlon-vector,athlon-ieu")
+ (define_insn_reservation "athlon_call_amdfam10" 0
+@@ -166,15 +166,15 @@
+ ;; Latency of push operation is 3 cycles, but ESP value is available
+ ;; earlier
+ (define_insn_reservation "athlon_push" 2
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (eq_attr "type" "push"))
+ 			 "athlon-direct,athlon-agu,athlon-store")
+ (define_insn_reservation "athlon_pop" 4
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (eq_attr "type" "pop"))
+ 			 "athlon-vector,athlon-load,athlon-ieu")
+ (define_insn_reservation "athlon_pop_k8" 3
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (eq_attr "type" "pop"))
+ 			 "athlon-double,(athlon-ieu+athlon-load)")
+ (define_insn_reservation "athlon_pop_amdfam10" 3
+@@ -186,13 +186,13 @@
+ 			      (eq_attr "type" "leave"))
+ 			 "athlon-vector,(athlon-ieu+athlon-load)")
+ (define_insn_reservation "athlon_leave_k8" 3
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (eq_attr "type" "leave"))
+ 			 "athlon-double,(athlon-ieu+athlon-load)")
+ 
+ ;; Lea executes in AGU unit with 2 cycles latency.
+ (define_insn_reservation "athlon_lea" 2
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (eq_attr "type" "lea"))
+ 			 "athlon-direct,athlon-agu,nothing")
+ ;; Lea executes in AGU unit with 1 cycle latency on AMDFAM10
+@@ -209,13 +209,13 @@
+ 			 "athlon-vector,athlon-ieu0,athlon-mult,nothing,nothing,athlon-ieu0")
+ ;; ??? Widening multiply is vector or double.
+ (define_insn_reservation "athlon_imul_k8_DI" 4
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "imul")
+ 				   (and (eq_attr "mode" "DI")
+ 					(eq_attr "memory" "none,unknown"))))
+ 			 "athlon-direct0,athlon-ieu0,athlon-mult,nothing,athlon-ieu0")
+ (define_insn_reservation "athlon_imul_k8" 3
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "imul")
+ 				   (eq_attr "memory" "none,unknown")))
+ 			 "athlon-direct0,athlon-ieu0,athlon-mult,athlon-ieu0")
+@@ -231,13 +231,13 @@
+ 				   (eq_attr "memory" "load,both")))
+ 			 "athlon-vector,athlon-load,athlon-ieu,athlon-mult,nothing,nothing,athlon-ieu")
+ (define_insn_reservation "athlon_imul_mem_k8_DI" 7
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "imul")
+ 				   (and (eq_attr "mode" "DI")
+ 					(eq_attr "memory" "load,both"))))
+ 			 "athlon-vector,athlon-load,athlon-ieu,athlon-mult,nothing,athlon-ieu")
+ (define_insn_reservation "athlon_imul_mem_k8" 6
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "imul")
+ 				   (eq_attr "memory" "load,both")))
+ 			 "athlon-vector,athlon-load,athlon-ieu,athlon-mult,athlon-ieu")
+@@ -251,12 +251,12 @@
+ ;; Using the same heuristics for amdfam10 as K8 with idiv
+ 
+ (define_insn_reservation "athlon_idiv" 6
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "idiv")
+ 				   (eq_attr "memory" "none,unknown")))
+ 			 "athlon-vector,(athlon-ieu0*6+(athlon-fpsched,athlon-fvector))")
+ (define_insn_reservation "athlon_idiv_mem" 9
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "idiv")
+ 				   (eq_attr "memory" "load,both")))
+ 			 "athlon-vector,((athlon-load,athlon-ieu0*6)+(athlon-fpsched,athlon-fvector))")
+@@ -264,13 +264,13 @@
+ ;; as idiv to create smaller automata.  This probably does not matter much.
+ ;; Using the same heuristics for amdfam10 as K8 with idiv
+ (define_insn_reservation "athlon_str" 6
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "str")
+ 				   (eq_attr "memory" "load,both,store")))
+ 			 "athlon-vector,athlon-load,athlon-ieu0*6")
+ 
+ (define_insn_reservation "athlon_idirect" 1
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "athlon_decode" "direct")
+ 				   (and (eq_attr "unit" "integer,unknown")
+ 					(eq_attr "memory" "none,unknown"))))
+@@ -282,7 +282,7 @@
+ 					(eq_attr "memory" "none,unknown"))))
+ 			 "athlon-direct,athlon-ieu")
+ (define_insn_reservation "athlon_ivector" 2
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "athlon_decode" "vector")
+ 				   (and (eq_attr "unit" "integer,unknown")
+ 					(eq_attr "memory" "none,unknown"))))
+@@ -295,13 +295,13 @@
+ 			 "athlon-vector,athlon-ieu,athlon-ieu")
+ 
+ (define_insn_reservation "athlon_idirect_loadmov" 3
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "imov")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-load")
+ 
+ (define_insn_reservation "athlon_idirect_load" 4
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "athlon_decode" "direct")
+ 				   (and (eq_attr "unit" "integer,unknown")
+ 					(eq_attr "memory" "load"))))
+@@ -313,7 +313,7 @@
+ 					(eq_attr "memory" "load"))))
+ 			 "athlon-direct,athlon-load,athlon-ieu")
+ (define_insn_reservation "athlon_ivector_load" 6
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "athlon_decode" "vector")
+ 				   (and (eq_attr "unit" "integer,unknown")
+ 					(eq_attr "memory" "load"))))
+@@ -326,13 +326,13 @@
+ 			 "athlon-vector,athlon-load,athlon-ieu,athlon-ieu")
+ 
+ (define_insn_reservation "athlon_idirect_movstore" 1
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "imov")
+ 				   (eq_attr "memory" "store")))
+ 			 "athlon-direct,athlon-agu,athlon-store")
+ 
+ (define_insn_reservation "athlon_idirect_both" 4
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "athlon_decode" "direct")
+ 				   (and (eq_attr "unit" "integer,unknown")
+ 					(eq_attr "memory" "both"))))
+@@ -349,7 +349,7 @@
+ 			  athlon-store")
+ 
+ (define_insn_reservation "athlon_ivector_both" 6
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "athlon_decode" "vector")
+ 				   (and (eq_attr "unit" "integer,unknown")
+ 					(eq_attr "memory" "both"))))
+@@ -368,7 +368,7 @@
+ 			  athlon-store")
+ 
+ (define_insn_reservation "athlon_idirect_store" 1
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "athlon_decode" "direct")
+ 				   (and (eq_attr "unit" "integer,unknown")
+ 					(eq_attr "memory" "store"))))
+@@ -383,7 +383,7 @@
+ 			  athlon-store")
+ 
+ (define_insn_reservation "athlon_ivector_store" 2
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "athlon_decode" "vector")
+ 				   (and (eq_attr "unit" "integer,unknown")
+ 					(eq_attr "memory" "store"))))
+@@ -405,7 +405,7 @@
+ 					(eq_attr "mode" "XF"))))
+ 			 "athlon-vector,athlon-fpload2,athlon-fvector*9")
+ (define_insn_reservation "athlon_fldxf_k8" 13
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "fmov")
+ 				   (and (eq_attr "memory" "load")
+ 					(eq_attr "mode" "XF"))))
+@@ -417,7 +417,7 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fpload,athlon-fany")
+ (define_insn_reservation "athlon_fld_k8" 2
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "fmov")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fstore")
+@@ -429,7 +429,7 @@
+ 					(eq_attr "mode" "XF"))))
+ 			 "athlon-vector,(athlon-fpsched+athlon-agu),(athlon-store2+(athlon-fvector*7))")
+ (define_insn_reservation "athlon_fstxf_k8" 8
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "fmov")
+ 				   (and (eq_attr "memory" "store,both")
+ 					(eq_attr "mode" "XF"))))
+@@ -440,16 +440,16 @@
+ 				   (eq_attr "memory" "store,both")))
+ 			 "athlon-direct,(athlon-fpsched+athlon-agu),(athlon-fstore+athlon-store)")
+ (define_insn_reservation "athlon_fst_k8" 2
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "fmov")
+ 				   (eq_attr "memory" "store,both")))
+ 			 "athlon-direct,(athlon-fpsched+athlon-agu),(athlon-fstore+athlon-store)")
+ (define_insn_reservation "athlon_fist" 4
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (eq_attr "type" "fistp,fisttp"))
+ 			 "athlon-direct,(athlon-fpsched+athlon-agu),(athlon-fstore+athlon-store)")
+ (define_insn_reservation "athlon_fmov" 2
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (eq_attr "type" "fmov"))
+ 			 "athlon-direct,athlon-fpsched,athlon-faddmul")
+ (define_insn_reservation "athlon_fadd_load" 4
+@@ -458,12 +458,12 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fpload,athlon-fadd")
+ (define_insn_reservation "athlon_fadd_load_k8" 6
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "fop")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fadd")
+ (define_insn_reservation "athlon_fadd" 4
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (eq_attr "type" "fop"))
+ 			 "athlon-direct,athlon-fpsched,athlon-fadd")
+ (define_insn_reservation "athlon_fmul_load" 4
+@@ -472,16 +472,16 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fpload,athlon-fmul")
+ (define_insn_reservation "athlon_fmul_load_k8" 6
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "fmul")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fmul")
+ (define_insn_reservation "athlon_fmul" 4
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (eq_attr "type" "fmul"))
+ 			 "athlon-direct,athlon-fpsched,athlon-fmul")
+ (define_insn_reservation "athlon_fsgn" 2
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (eq_attr "type" "fsgn"))
+ 			 "athlon-direct,athlon-fpsched,athlon-fmul")
+ (define_insn_reservation "athlon_fdiv_load" 24
+@@ -490,7 +490,7 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fpload,athlon-fmul")
+ (define_insn_reservation "athlon_fdiv_load_k8" 13
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "fdiv")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fmul")
+@@ -499,16 +499,16 @@
+ 			      (eq_attr "type" "fdiv"))
+ 			 "athlon-direct,athlon-fpsched,athlon-fmul")
+ (define_insn_reservation "athlon_fdiv_k8" 11
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (eq_attr "type" "fdiv"))
+ 			 "athlon-direct,athlon-fpsched,athlon-fmul")
+ (define_insn_reservation "athlon_fpspc_load" 103
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "fpspc")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-vector,athlon-fpload,athlon-fvector")
+ (define_insn_reservation "athlon_fpspc" 100
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (eq_attr "type" "fpspc"))
+ 			 "athlon-vector,athlon-fpsched,athlon-fvector")
+ (define_insn_reservation "athlon_fcmov_load" 7
+@@ -521,12 +521,12 @@
+ 			      (eq_attr "type" "fcmov"))
+ 			 "athlon-vector,athlon-fpsched,athlon-fvector")
+ (define_insn_reservation "athlon_fcmov_load_k8" 17
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "fcmov")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-vector,athlon-fploadk8,athlon-fvector")
+ (define_insn_reservation "athlon_fcmov_k8" 15
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (eq_attr "type" "fcmov"))
+ 			 "athlon-vector,athlon-fpsched,athlon-fvector")
+ ;; fcomi is vector decoded by uses only one pipe.
+@@ -537,13 +537,13 @@
+ 				        (eq_attr "memory" "load"))))
+ 			 "athlon-vector,athlon-fpload,athlon-fadd")
+ (define_insn_reservation "athlon_fcomi_load_k8" 5
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "fcmp")
+ 				   (and (eq_attr "athlon_decode" "vector")
+ 				        (eq_attr "memory" "load"))))
+ 			 "athlon-vector,athlon-fploadk8,athlon-fadd")
+ (define_insn_reservation "athlon_fcomi" 3
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (and (eq_attr "athlon_decode" "vector")
+ 				   (eq_attr "type" "fcmp")))
+ 			 "athlon-vector,athlon-fpsched,athlon-fadd")
+@@ -553,18 +553,18 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fpload,athlon-fadd")
+ (define_insn_reservation "athlon_fcom_load_k8" 4
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "fcmp")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fadd")
+ (define_insn_reservation "athlon_fcom" 2
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (eq_attr "type" "fcmp"))
+ 			 "athlon-direct,athlon-fpsched,athlon-fadd")
+ ;; Never seen by the scheduler because we still don't do post reg-stack
+ ;; scheduling.
+ ;(define_insn_reservation "athlon_fxch" 2
+-;			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++;			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ ;			      (eq_attr "type" "fxch"))
+ ;			 "athlon-direct,athlon-fpsched,athlon-fany")
+ 
+@@ -580,8 +580,13 @@
+ 			      (and (eq_attr "type" "ssemov")
+ 				   (match_operand:DF 1 "memory_operand")))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fstore")
++(define_insn_reservation "athlon_movsd_load_generic" 2
++			 (and (eq_attr "cpu" "generic")
++			      (and (eq_attr "type" "ssemov")
++				   (match_operand:DF 1 "memory_operand")))
++			 "athlon-double,athlon-fploadk8,(athlon-fstore+athlon-fmul)")
+ (define_insn_reservation "athlon_movaps_load_k8" 2
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "ssemov")
+ 				   (and (eq_attr "mode" "V4SF,V2DF,TI")
+ 					(eq_attr "memory" "load"))))
+@@ -599,7 +604,7 @@
+ 					(eq_attr "memory" "load"))))
+ 			 "athlon-vector,athlon-fpload,(athlon-fany*2)")
+ (define_insn_reservation "athlon_movss_load_k8" 1
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "ssemov")
+ 				   (and (eq_attr "mode" "SF,DI")
+ 					(eq_attr "memory" "load"))))
+@@ -610,7 +615,7 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fpload,athlon-fany")
+ (define_insn_reservation "athlon_mmxsseld_k8" 2
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "mmxmov,ssemov")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fstore")
+@@ -632,19 +637,19 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fploadk8, athlon-fany")
+ (define_insn_reservation "athlon_mmxssest" 3
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "mmxmov,ssemov")
+ 				   (and (eq_attr "mode" "V4SF,V2DF,TI")
+ 					(eq_attr "memory" "store,both"))))
+ 			 "athlon-vector,(athlon-fpsched+athlon-agu),((athlon-fstore+athlon-store2)*2)")
+ (define_insn_reservation "athlon_mmxssest_k8" 3
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "mmxmov,ssemov")
+ 				   (and (eq_attr "mode" "V4SF,V2DF,TI")
+ 					(eq_attr "memory" "store,both"))))
+ 			 "athlon-double,(athlon-fpsched+athlon-agu),((athlon-fstore+athlon-store2)*2)")
+ (define_insn_reservation "athlon_mmxssest_short" 2
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "type" "mmxmov,ssemov")
+ 				   (eq_attr "memory" "store,both")))
+ 			 "athlon-direct,(athlon-fpsched+athlon-agu),(athlon-fstore+athlon-store)")
+@@ -668,7 +673,7 @@
+ 				   (eq_attr "memory" "store,both")))
+ 			 "athlon-direct,(athlon-fpsched+athlon-agu),(athlon-fstore+athlon-store)")
+ (define_insn_reservation "athlon_movaps_k8" 2
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "ssemov")
+ 				   (eq_attr "mode" "V4SF,V2DF,TI")))
+ 			 "athlon-double,athlon-fpsched,((athlon-faddmul+athlon-faddmul) | (athlon-faddmul, athlon-faddmul))")
+@@ -678,25 +683,25 @@
+ 				   (eq_attr "mode" "V4SF,V2DF,TI")))
+ 			 "athlon-vector,athlon-fpsched,(athlon-faddmul+athlon-faddmul)")
+ (define_insn_reservation "athlon_mmxssemov" 2
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (eq_attr "type" "mmxmov,ssemov"))
+ 			 "athlon-direct,athlon-fpsched,athlon-faddmul")
+ (define_insn_reservation "athlon_mmxmul_load" 4
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "type" "mmxmul")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fpload,athlon-fmul")
+ (define_insn_reservation "athlon_mmxmul" 3
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (eq_attr "type" "mmxmul"))
+ 			 "athlon-direct,athlon-fpsched,athlon-fmul")
+ (define_insn_reservation "athlon_mmx_load" 3
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "unit" "mmx")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fpload,athlon-faddmul")
+ (define_insn_reservation "athlon_mmx" 2
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (eq_attr "unit" "mmx"))
+ 			 "athlon-direct,athlon-fpsched,athlon-faddmul")
+ ;; SSE operations are handled by the i387 unit as well.  The latency
+@@ -708,7 +713,7 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-vector,athlon-fpload2,(athlon-fmul*2)")
+ (define_insn_reservation "athlon_sselog_load_k8" 5
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "sselog,sselog1,sseshuf,sseshuf1")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-double,athlon-fpload2k8,(athlon-fmul*2)")
+@@ -722,7 +727,7 @@
+ 			      (eq_attr "type" "sselog,sselog1,sseshuf,sseshuf1"))
+ 			 "athlon-vector,athlon-fpsched,athlon-fmul*2")
+ (define_insn_reservation "athlon_sselog_k8" 3
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (eq_attr "type" "sselog,sselog1,sseshuf,sseshuf1"))
+ 			 "athlon-double,athlon-fpsched,athlon-fmul")
+ (define_insn_reservation "athlon_sselog_amdfam10" 2
+@@ -738,13 +743,13 @@
+ 					(eq_attr "memory" "load"))))
+ 			 "athlon-direct,athlon-fpload,athlon-fadd")
+ (define_insn_reservation "athlon_ssecmp_load_k8" 4
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "ssecmp")
+ 				   (and (eq_attr "mode" "SF,DF,DI,TI")
+ 					(eq_attr "memory" "load"))))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fadd")
+ (define_insn_reservation "athlon_ssecmp" 2
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "ssecmp")
+ 				   (eq_attr "mode" "SF,DF,DI,TI")))
+ 			 "athlon-direct,athlon-fpsched,athlon-fadd")
+@@ -754,7 +759,7 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-vector,athlon-fpload2,(athlon-fadd*2)")
+ (define_insn_reservation "athlon_ssecmpvector_load_k8" 5
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "ssecmp")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-double,athlon-fpload2k8,(athlon-fadd*2)")
+@@ -768,7 +773,7 @@
+ 			      (eq_attr "type" "ssecmp"))
+ 			 "athlon-vector,athlon-fpsched,(athlon-fadd*2)")
+ (define_insn_reservation "athlon_ssecmpvector_k8" 3
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (eq_attr "type" "ssecmp"))
+ 			 "athlon-double,athlon-fpsched,(athlon-fadd*2)")
+ (define_insn_reservation "athlon_ssecmpvector_amdfam10" 2
+@@ -781,7 +786,7 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-vector,athlon-fpload,athlon-fadd")
+ (define_insn_reservation "athlon_ssecomi_load_k8" 6
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "ssecomi")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-vector,athlon-fploadk8,athlon-fadd")
+@@ -791,7 +796,7 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fadd")
+ (define_insn_reservation "athlon_ssecomi" 4
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (eq_attr "type" "ssecomi"))
+ 			 "athlon-vector,athlon-fpsched,athlon-fadd")
+ (define_insn_reservation "athlon_ssecomi_amdfam10" 3
+@@ -806,13 +811,13 @@
+ 					(eq_attr "memory" "load"))))
+ 			 "athlon-direct,athlon-fpload,athlon-fadd")
+ (define_insn_reservation "athlon_sseadd_load_k8" 6
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "sseadd,sseadd1")
+ 				   (and (eq_attr "mode" "SF,DF,DI")
+ 					(eq_attr "memory" "load"))))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fadd")
+ (define_insn_reservation "athlon_sseadd" 4
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "sseadd,sseadd1")
+ 				   (eq_attr "mode" "SF,DF,DI")))
+ 			 "athlon-direct,athlon-fpsched,athlon-fadd")
+@@ -822,7 +827,7 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-vector,athlon-fpload2,(athlon-fadd*2)")
+ (define_insn_reservation "athlon_sseaddvector_load_k8" 7
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "sseadd,sseadd1")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-double,athlon-fpload2k8,(athlon-fadd*2)")
+@@ -836,7 +841,7 @@
+ 			      (eq_attr "type" "sseadd,sseadd1"))
+ 			 "athlon-vector,athlon-fpsched,(athlon-fadd*2)")
+ (define_insn_reservation "athlon_sseaddvector_k8" 5
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (eq_attr "type" "sseadd,sseadd1"))
+ 			 "athlon-double,athlon-fpsched,(athlon-fadd*2)")
+ (define_insn_reservation "athlon_sseaddvector_amdfam10" 4
+@@ -850,7 +855,7 @@
+ 
+ ;; cvtss2sd
+ (define_insn_reservation "athlon_ssecvt_cvtss2sd_load_k8" 4
+-			 (and (eq_attr "cpu" "k8,athlon")
++			 (and (eq_attr "cpu" "k8,athlon,generic")
+ 			      (and (eq_attr "type" "ssecvt")
+ 				   (and (eq_attr "athlon_decode" "direct")
+ 					(and (eq_attr "mode" "DF")
+@@ -864,7 +869,7 @@
+ 					     (eq_attr "memory" "load")))))
+ 			 "athlon-double,athlon-fploadk8,(athlon-faddmul+athlon-fstore)")
+ (define_insn_reservation "athlon_ssecvt_cvtss2sd" 2
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "type" "ssecvt")
+ 				   (and (eq_attr "athlon_decode" "direct")
+ 					(eq_attr "mode" "DF"))))
+@@ -877,7 +882,7 @@
+ 			 "athlon-vector,athlon-fpsched,athlon-faddmul,(athlon-fstore*2)")
+ ;; cvtps2pd.  Model same way the other double decoded FP conversions.
+ (define_insn_reservation "athlon_ssecvt_cvtps2pd_load_k8" 5
+-			 (and (eq_attr "cpu" "k8,athlon")
++			 (and (eq_attr "cpu" "k8,athlon,generic")
+ 			      (and (eq_attr "type" "ssecvt")
+ 				   (and (eq_attr "athlon_decode" "double")
+ 					(and (eq_attr "mode" "V2DF,V4SF,TI")
+@@ -891,7 +896,7 @@
+ 					     (eq_attr "memory" "load")))))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fstore")
+ (define_insn_reservation "athlon_ssecvt_cvtps2pd_k8" 3
+-			 (and (eq_attr "cpu" "k8,athlon")
++			 (and (eq_attr "cpu" "k8,athlon,generic")
+ 			      (and (eq_attr "type" "ssecvt")
+ 				   (and (eq_attr "athlon_decode" "double")
+ 					(eq_attr "mode" "V2DF,V4SF,TI"))))
+@@ -927,7 +932,7 @@
+ 					     (eq_attr "memory" "load")))))
+ 			 "athlon-vector,athlon-fpload,(athlon-fstore*2)")
+ (define_insn_reservation "athlon_sseicvt_cvtsi2ss_load_k8" 9
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "sseicvt")
+ 				   (and (eq_attr "athlon_decode" "double")
+ 					(and (eq_attr "mode" "SF,DF")
+@@ -942,7 +947,7 @@
+ 			 "athlon-double,athlon-fploadk8,(athlon-faddmul+athlon-fstore)")
+ ;; cvtsi2sd reg,reg is double decoded (vector on Athlon)
+ (define_insn_reservation "athlon_sseicvt_cvtsi2sd_k8" 11
+-			 (and (eq_attr "cpu" "k8,athlon")
++			 (and (eq_attr "cpu" "k8,athlon,generic")
+ 			      (and (eq_attr "type" "sseicvt")
+ 				   (and (eq_attr "athlon_decode" "double")
+ 					(and (eq_attr "mode" "SF,DF")
+@@ -957,7 +962,7 @@
+ 			 "athlon-vector,athlon-fploadk8,(athlon-faddmul+athlon-fstore)")
+ ;; cvtsi2ss reg, reg is doublepath
+ (define_insn_reservation "athlon_sseicvt_cvtsi2ss" 14
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "type" "sseicvt")
+ 				   (and (eq_attr "athlon_decode" "vector")
+ 					(and (eq_attr "mode" "SF,DF")
+@@ -972,7 +977,7 @@
+ 			 "athlon-vector,athlon-fploadk8,(athlon-faddmul+athlon-fstore)")
+ ;; cvtsd2ss mem,reg is doublepath, troughput unknown, latency 9
+ (define_insn_reservation "athlon_ssecvt_cvtsd2ss_load_k8" 9
+-			 (and (eq_attr "cpu" "k8,athlon")
++			 (and (eq_attr "cpu" "k8,athlon,generic")
+ 			      (and (eq_attr "type" "ssecvt")
+ 				   (and (eq_attr "athlon_decode" "double")
+ 					(and (eq_attr "mode" "SF")
+@@ -987,7 +992,7 @@
+ 			 "athlon-double,athlon-fploadk8,(athlon-faddmul+athlon-fstore)")
+ ;; cvtsd2ss reg,reg is vectorpath, troughput unknown, latency 12
+ (define_insn_reservation "athlon_ssecvt_cvtsd2ss" 12
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "type" "ssecvt")
+ 				   (and (eq_attr "athlon_decode" "vector")
+ 					(and (eq_attr "mode" "SF")
+@@ -1001,7 +1006,7 @@
+ 					     (eq_attr "memory" "none")))))
+ 			 "athlon-vector,athlon-fpsched,athlon-faddmul,(athlon-fstore*2)")
+ (define_insn_reservation "athlon_ssecvt_cvtpd2ps_load_k8" 8
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "type" "ssecvt")
+ 				   (and (eq_attr "athlon_decode" "vector")
+ 					(and (eq_attr "mode" "V4SF,V2DF,TI")
+@@ -1017,7 +1022,7 @@
+ ;; cvtpd2ps mem,reg is vectorpath, troughput unknown, latency 10
+ ;; ??? Why it is fater than cvtsd2ss?
+ (define_insn_reservation "athlon_ssecvt_cvtpd2ps" 8
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "type" "ssecvt")
+ 				   (and (eq_attr "athlon_decode" "vector")
+ 					(and (eq_attr "mode" "V4SF,V2DF,TI")
+@@ -1032,7 +1037,7 @@
+ 			 "athlon-double,athlon-fpsched,(athlon-faddmul+athlon-fstore)")
+ ;; cvtsd2si mem,reg is doublepath, troughput 1, latency 9
+ (define_insn_reservation "athlon_secvt_cvtsX2si_load" 9
+-			 (and (eq_attr "cpu" "athlon,k8")
++			 (and (eq_attr "cpu" "athlon,k8,generic")
+ 			      (and (eq_attr "type" "sseicvt")
+ 				   (and (eq_attr "athlon_decode" "vector")
+ 					(and (eq_attr "mode" "SI,DI")
+@@ -1054,7 +1059,7 @@
+ 					     (eq_attr "memory" "none")))))
+ 			 "athlon-vector,athlon-fpsched,athlon-fvector")
+ (define_insn_reservation "athlon_ssecvt_cvtsX2si_k8" 9
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "sseicvt")
+ 				   (and (eq_attr "athlon_decode" "double")
+ 					(and (eq_attr "mode" "SI,DI")
+@@ -1092,13 +1097,13 @@
+ 					(eq_attr "memory" "load"))))
+ 			 "athlon-direct,athlon-fpload,athlon-fmul")
+ (define_insn_reservation "athlon_ssemul_load_k8" 6
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "ssemul")
+ 				   (and (eq_attr "mode" "SF,DF")
+ 					(eq_attr "memory" "load"))))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fmul")
+ (define_insn_reservation "athlon_ssemul" 4
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "ssemul")
+ 				   (eq_attr "mode" "SF,DF")))
+ 			 "athlon-direct,athlon-fpsched,athlon-fmul")
+@@ -1108,7 +1113,7 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-vector,athlon-fpload2,(athlon-fmul*2)")
+ (define_insn_reservation "athlon_ssemulvector_load_k8" 7
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "ssemul")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-double,athlon-fpload2k8,(athlon-fmul*2)")
+@@ -1122,7 +1127,7 @@
+ 			      (eq_attr "type" "ssemul"))
+ 			 "athlon-vector,athlon-fpsched,(athlon-fmul*2)")
+ (define_insn_reservation "athlon_ssemulvector_k8" 5
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (eq_attr "type" "ssemul"))
+ 			 "athlon-double,athlon-fpsched,(athlon-fmul*2)")
+ (define_insn_reservation "athlon_ssemulvector_amdfam10" 4
+@@ -1137,13 +1142,13 @@
+ 					(eq_attr "memory" "load"))))
+ 			 "athlon-direct,athlon-fpload,athlon-fmul*17")
+ (define_insn_reservation "athlon_ssediv_load_k8" 22
+-			 (and (eq_attr "cpu" "k8,amdfam10")
++			 (and (eq_attr "cpu" "k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "ssediv")
+ 				   (and (eq_attr "mode" "SF,DF")
+ 					(eq_attr "memory" "load"))))
+ 			 "athlon-direct,athlon-fploadk8,athlon-fmul*17")
+ (define_insn_reservation "athlon_ssediv" 20
+-			 (and (eq_attr "cpu" "athlon,k8,amdfam10")
++			 (and (eq_attr "cpu" "athlon,k8,generic,amdfam10")
+ 			      (and (eq_attr "type" "ssediv")
+ 				   (eq_attr "mode" "SF,DF")))
+ 			 "athlon-direct,athlon-fpsched,athlon-fmul*17")
+@@ -1153,7 +1158,7 @@
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-vector,athlon-fpload2,athlon-fmul*34")
+ (define_insn_reservation "athlon_ssedivvector_load_k8" 35
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (and (eq_attr "type" "ssediv")
+ 				   (eq_attr "memory" "load")))
+ 			 "athlon-double,athlon-fpload2k8,athlon-fmul*34")
+@@ -1167,7 +1172,7 @@
+ 			      (eq_attr "type" "ssediv"))
+ 			 "athlon-vector,athlon-fmul*34")
+ (define_insn_reservation "athlon_ssedivvector_k8" 39
+-			 (and (eq_attr "cpu" "k8")
++			 (and (eq_attr "cpu" "k8,generic")
+ 			      (eq_attr "type" "ssediv"))
+ 			 "athlon-double,athlon-fmul*34")
+ (define_insn_reservation "athlon_ssedivvector_amdfam10" 20
+diff -ruNd a/gcc/config/i386/haswell.md b/gcc/config/i386/haswell.md
+--- a/gcc/config/i386/haswell.md
++++ b/gcc/config/i386/haswell.md
+@@ -74,12 +74,12 @@
+ (define_reservation "hsw_p01" "hsw_p0|hsw_p1")
+ 
+ (define_insn_reservation "hsw_complex_insn" 6
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (eq_attr "type" "other,multi,str"))
+ 			 "hsw_decoder0")
+ 
+ (define_insn_reservation "hsw_call" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (eq_attr "type" "call,callv"))
+ 			 "hsw_decoder0")
+ 
+@@ -87,104 +87,104 @@
+ ;; imovx always decodes to one uop, and also doesn't use the integer
+ ;; units if it has memory operands.
+ (define_insn_reservation "hsw_imov" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "imov,imovx")))
+ 			 "hsw_decodern,hsw_p0156")
+ 
+ (define_insn_reservation "hsw_imov_load" 2
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "imov,imovx")))
+ 			 "hsw_decodern,hsw_p23")
+ 
+ (define_insn_reservation "hsw_imov_store" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "store")
+ 				   (eq_attr "type" "imov")))
+ 			 "hsw_decodern,hsw_p4+(hsw_p2|hsw_p3|hsw_p7)")
+ 
+ (define_insn_reservation "hsw_icmov" 2
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "icmov")))
+ 			 "hsw_decodern,hsw_p0156,hsw_p0156")
+ 
+ (define_insn_reservation "hsw_icmov_load" 2
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "icmov")))
+ 			 "hsw_decodern,hsw_p23+hsw_p0156,hsw_p0156")
+ 
+ (define_insn_reservation "hsw_push_reg" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "store")
+ 				   (eq_attr "type" "push")))
+ 			 "hsw_decodern,hsw_p4+hsw_p237")
+ 
+ (define_insn_reservation "hsw_push_mem" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "both")
+ 				   (eq_attr "type" "push")))
+ 			 "hsw_decodern,hsw_p4+hsw_p237,hsw_p237")
+ 
+ ;; Consider lea latency as having 2 components.
+ (define_insn_reservation "hsw_lea" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "lea")))
+ 			 "hsw_decodern,hsw_p1|hsw_p5")
+ 
+ (define_insn_reservation "hsw_shift_rotate" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "ishift,ishift1,rotate,rotate1")))
+ 			 "hsw_decodern,hsw_p0|hsw_p6")
+ 
+ (define_insn_reservation "hsw_shift_rotate_mem" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "!none")
+ 				   (eq_attr "type" "ishift,ishift1,rotate,rotate1")))
+ 			 "hsw_decodern,(hsw_p0|hsw_p6)+hsw_p237+hsw_p4")
+ 
+ (define_insn_reservation "hsw_branch" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "ibr")))
+ 			 "hsw_decodern,hsw_p6")
+ 
+ (define_insn_reservation "hsw_indirect_branch" 2
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "!none")
+ 				   (eq_attr "type" "ibr")))
+ 			 "hsw_decoder0,hsw_p23+hsw_p6")
+ 
+ (define_insn_reservation "hsw_leave" 4
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (eq_attr "type" "leave"))
+ 			 "hsw_decoder0,hsw_p23+hsw_p0156,hsw_p0156")
+ 
+ ;; imul and imulx with two/three operands only execute on port 1.
+ (define_insn_reservation "hsw_imul" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "imul")))
+ 			 "hsw_decodern,hsw_p1")
+ 
+ (define_insn_reservation "hsw_imul_mem" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "!none")
+ 				   (eq_attr "type" "imul")))
+ 			 "hsw_decodern,hsw_p23+hsw_p1")
+ 
+ (define_insn_reservation "hsw_imulx" 4
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "imulx")))
+ 			 "hsw_decodern,hsw_p0156,hsw_p0156")
+ 
+ (define_insn_reservation "hsw_imulx_mem" 4
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "!none")
+ 				   (eq_attr "type" "imulx")))
+ 			 "hsw_decodern,hsw_p23+hsw_p0156,(hsw_p0|hsw_p6|hsw_p6)")
+@@ -193,13 +193,13 @@
+ ;; div and idiv are very similar, so we model them the same.
+ ;; Use the same latency for all QI,HI and SI modes.
+ (define_insn_reservation "hsw_idiv" 23
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "idiv")))
+ 			 "hsw_decoder0,(hsw_p0p1p5p6+hsw_idiv)*9")
+ 
+ (define_insn_reservation "hsw_idiv_load" 23
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 					(eq_attr "type" "idiv")))
+ 			 "hsw_decoder0,hsw_p23+hsw_p0+hsw_idiv,(hsw_p0p1p5p6+hsw_idiv)*9")
+@@ -207,103 +207,103 @@
+ ;; x87 floating point operations.
+ 
+ (define_insn_reservation "hsw_fxch" 0
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (eq_attr "type" "fxch"))
+ 			 "hsw_decodern")
+ 
+ (define_insn_reservation "hsw_fop" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none,unknown")
+ 				   (eq_attr "type" "fop")))
+ 			 "hsw_decodern,hsw_p1")
+ 
+ (define_insn_reservation "hsw_fop_load" 5
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "fop")))
+ 			 "hsw_decodern,hsw_p23+hsw_p1,hsw_p1")
+ 
+ (define_insn_reservation "hsw_fop_store" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "store")
+ 				   (eq_attr "type" "fop")))
+ 			 "hsw_decodern,hsw_p0,hsw_p0,hsw_p0+hsw_p4+hsw_p3")
+ 
+ (define_insn_reservation "hsw_fop_both" 5
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "both")
+ 				   (eq_attr "type" "fop")))
+ 			 "hsw_decodern,hsw_p2+hsw_p0,hsw_p0+hsw_p4+hsw_p3")
+ 
+ (define_insn_reservation "hsw_fsgn" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (eq_attr "type" "fsgn"))
+ 			 "hsw_decodern,hsw_p0")
+ 
+ (define_insn_reservation "hsw_fistp" 7
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (eq_attr "type" "fistp"))
+ 			 "hsw_decoder0,hsw_p1+hsw_p4+hsw_p23")
+ 
+ (define_insn_reservation "hsw_fcmov" 2
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (eq_attr "type" "fcmov"))
+ 			 "hsw_decoder0,hsw_p0+hsw_p5,hsw_p0")
+ 
+ (define_insn_reservation "hsw_fcmp" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "fcmp")))
+ 			 "hsw_decodern,hsw_p1")
+ 
+ (define_insn_reservation "hsw_fcmp_load" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "fcmp")))
+ 			 "hsw_decodern,hsw_p23+hsw_p1")
+ 
+ (define_insn_reservation "hsw_fmov" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "fmov")))
+ 			 "hsw_decodern,hsw_p01")
+ 
+ (define_insn_reservation "hsw_fmov_load" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (and (eq_attr "mode" "!XF")
+ 					(eq_attr "type" "fmov"))))
+ 			 "hsw_decodern,hsw_p23")
+ 
+ (define_insn_reservation "hsw_fmov_XF_load" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (and (eq_attr "mode" "XF")
+ 					(eq_attr "type" "fmov"))))
+ 			 "hsw_decodern,(hsw_p23+hsw_p0)*2")
+ 
+ (define_insn_reservation "hsw_fmov_store" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "store")
+ 				   (and (eq_attr "mode" "!XF")
+ 					(eq_attr "type" "fmov"))))
+ 			 "hsw_decodern,hsw_p4p7")
+ 
+ (define_insn_reservation "hsw_fmov_XF_store" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "store")
+ 				   (and (eq_attr "mode" "XF")
+ 					(eq_attr "type" "fmov"))))
+ 			 "hsw_decodern,hsw_p4p7,hsw_p4p7")
+ 
+ (define_insn_reservation "hsw_fmul" 4
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "fmul")))
+ 			 "hsw_decodern,hsw_p01")
+ 
+ (define_insn_reservation "hsw_fmul_load" 4
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "fmul")))
+ 			 "hsw_decodern,hsw_p23+hsw_p01")
+@@ -314,42 +314,42 @@
+ ;; that.  Throughput is equal to latency - 1, which we model using the
+ ;; hsw_div automaton.
+ (define_insn_reservation "hsw_fdiv_SF" 18
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (and (eq_attr "mode" "SF")
+ 					(eq_attr "type" "fdiv,fpspc"))))
+ 			 "hsw_decodern,hsw_p0+hsw_fdiv,hsw_fdiv*16")
+ 
+ (define_insn_reservation "hsw_fdiv_SF_load" 19
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (and (eq_attr "mode" "SF")
+ 					(eq_attr "type" "fdiv,fpspc"))))
+ 			 "hsw_decodern,hsw_p23+hsw_p0+hsw_fdiv,hsw_fdiv*16")
+ 
+ (define_insn_reservation "hsw_fdiv_DF" 32
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (and (eq_attr "mode" "DF")
+ 					(eq_attr "type" "fdiv,fpspc"))))
+ 			 "hsw_decodern,hsw_p0+hsw_fdiv,hsw_fdiv*30")
+ 
+ (define_insn_reservation "hsw_fdiv_DF_load" 33
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (and (eq_attr "mode" "DF")
+ 					(eq_attr "type" "fdiv,fpspc"))))
+ 			 "hsw_decodern,hsw_p23+hsw_p0+hsw_fdiv,hsw_fdiv*30")
+ 
+ (define_insn_reservation "hsw_fdiv_XF" 38
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (and (eq_attr "mode" "XF")
+ 					(eq_attr "type" "fdiv,fpspc"))))
+ 			 "hsw_decodern,hsw_p0+hsw_fdiv,hsw_fdiv*36")
+ 
+ (define_insn_reservation "hsw_fdiv_XF_load" 39
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (and (eq_attr "mode" "XF")
+ 					(eq_attr "type" "fdiv,fpspc"))))
+@@ -358,253 +358,253 @@
+ ;; MMX instructions.
+ 
+ (define_insn_reservation "hsw_mmx_add" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "mmxadd,sseiadd")))
+ 			 "hsw_decodern,hsw_p1|hsw_p5")
+ 
+ (define_insn_reservation "hsw_mmx_add_load" 2
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "mmxadd,sseiadd")))
+ 			 "hsw_decodern,hsw_p23+(hsw_p1|hsw_p5)")
+ 
+ (define_insn_reservation "hsw_mmx_shft" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "mmxshft")))
+ 			 "hsw_decodern,hsw_p0")
+ 
+ (define_insn_reservation "hsw_mmx_shft_load" 2
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "mmxshft")))
+ 			 "hsw_decodern,hsw_p23+hsw_p0")
+ 
+ (define_insn_reservation "hsw_mmx_sse_shft" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (and (eq_attr "type" "sseishft")
+ 					(eq_attr "length_immediate" "!0"))))
+ 			 "hsw_decodern,hsw_p01")
+ 
+ (define_insn_reservation "hsw_mmx_sse_shft_load" 2
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (and (eq_attr "type" "sseishft")
+ 					(eq_attr "length_immediate" "!0"))))
+ 			 "hsw_decodern,hsw_p01+hsw_p23")
+ 
+ (define_insn_reservation "hsw_mmx_sse_shft1" 2
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (and (eq_attr "type" "sseishft")
+ 					(eq_attr "length_immediate" "0"))))
+ 			 "hsw_decodern,hsw_p01")
+ 
+ (define_insn_reservation "hsw_mmx_sse_shft1_load" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (and (eq_attr "type" "sseishft")
+ 					(eq_attr "length_immediate" "0"))))
+ 			 "hsw_decodern,hsw_p01+hsw_p23")
+ 
+ (define_insn_reservation "hsw_mmx_mul" 5
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "mmxmul,sseimul")))
+ 			 "hsw_decodern,hsw_p01")
+ 
+ (define_insn_reservation "hsw_mmx_mul_load" 5
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "mmxmul,sseimul")))
+ 			 "hsw_decodern,hsw_p23+hsw_p01")
+ 
+ (define_insn_reservation "hsw_sse_mmxcvt" 4
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "mode" "DI")
+ 				   (eq_attr "type" "mmxcvt")))
+ 			 "hsw_decodern,hsw_p1")
+ 
+ ;; (define_insn_reservation "hsw_sse_mmxshft" 2
+-;;			 (and (eq_attr "cpu" "generic,haswell")
++;;			 (and (eq_attr "cpu" "haswell")
+ ;;			      (and (eq_attr "mode" "TI")
+ ;;				   (eq_attr "type" "mmxshft")))
+ ;;			 "hsw_decodern,hsw_p01")
+ 
+ ;; The sfence instruction.
+ (define_insn_reservation "hsw_sse_sfence" 2
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "unknown")
+ 				   (eq_attr "type" "sse")))
+ 			 "hsw_decoder0,hsw_p23+hsw_p4")
+ 
+ (define_insn_reservation "hsw_sse_SFDF" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "mode" "SF,DF")
+ 				   (eq_attr "type" "sse")))
+ 			 "hsw_decodern,hsw_p01")
+ 
+ (define_insn_reservation "hsw_sse_V4SF" 4
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "mode" "V4SF")
+ 				   (eq_attr "type" "sse")))
+ 			 "hsw_decodern,hsw_p01")
+ 
+ (define_insn_reservation "hsw_sse_V8SF" 4
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "mode" "V8SF,V4DF")
+ 				   (eq_attr "type" "sse")))
+ 			 "hsw_decodern,hsw_p01")
+ 
+ (define_insn_reservation "hsw_sse_addcmp" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "sseadd1,ssecmp,ssecomi")))
+ 			 "hsw_decodern,hsw_p01")
+ 
+ (define_insn_reservation "hsw_sse_addcmp_load" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "sseadd1,ssecmp,ssecomi")))
+ 			 "hsw_decodern,hsw_p23+hsw_p01")
+ 
+ (define_insn_reservation "hsw_sse_logic" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "sselog,sselog1")))
+ 			 "hsw_decodern,hsw_p015")
+ 
+ (define_insn_reservation "hsw_sse_logic_load" 2
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "sselog,sselog1")))
+ 			 "hsw_decodern,hsw_p015+hsw_p23")
+ 
+ (define_insn_reservation "hsw_sse_add" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "sseadd")))
+ 			"hsw_decodern,hsw_p1|hsw_p5")
+ 
+ (define_insn_reservation "hsw_sse_add_load" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "sseadd")))
+ 			"hsw_decodern,(hsw_p1|hsw_p5)+hsw_p23")
+ 
+ (define_insn_reservation "hsw_sse_mul" 5
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "ssemul")))
+ 			"hsw_decodern,hsw_p0")
+ 
+ (define_insn_reservation "hsw_sse_mul_load" 5
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "ssemul")))
+ 			"hsw_decodern,hsw_p0+hsw_p23")
+ ;; Use skylake pipeline.
+ (define_insn_reservation "hsw_sse_muladd" 5
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 					(eq_attr "type" "ssemuladd")))
+ 			"hsw_decodern,hsw_p01")
+ 
+ (define_insn_reservation "hsw_sse_muladd_load" 5
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 					(eq_attr "type" "ssemuladd")))
+ 			"hsw_decodern,hsw_p01+hsw_p23")
+ 
+ (define_insn_reservation "hsw_sse_div_SF" 18
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (and (eq_attr "mode" "SF,V4SF,V8SF")
+ 					(eq_attr "type" "ssediv"))))
+ 			 "hsw_decodern,hsw_p0,hsw_ssediv*14")
+ 
+ (define_insn_reservation "hsw_sse_div_SF_load" 18
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (and (eq_attr "mode" "SF,V4SF,V8SF")
+ 					(eq_attr "type" "ssediv"))))
+ 			 "hsw_decodern,(hsw_p23+hsw_p0),hsw_ssediv*14")
+ 
+ (define_insn_reservation "hsw_sse_div_DF" 28
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (and (eq_attr "mode" "DF,V2DF,V4DF")
+ 					(eq_attr "type" "ssediv"))))
+ 			 "hsw_decodern,hsw_p0,hsw_ssediv*20")
+ 
+ (define_insn_reservation "hsw_sse_div_DF_load" 28
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (and (eq_attr "mode" "DF,V2DF,V4DF")
+ 					(eq_attr "type" "ssediv"))))
+ 			 "hsw_decodern,(hsw_p23+hsw_p0),hsw_ssediv*20")
+ 
+ (define_insn_reservation "hsw_sse_icvt" 4
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "sseicvt")))
+ 			 "hsw_decodern,hsw_p1")
+ 
+ (define_insn_reservation "hsw_sse_icvt_load" 4
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "!none")
+ 				   (eq_attr "type" "sseicvt")))
+ 			 "hsw_decodern,hsw_p23+hsw_p1")
+ 
+ 
+ (define_insn_reservation "hsw_sse_icvt_SI" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (and (eq_attr "mode" "SI")
+ 					(eq_attr "type" "sseicvt"))))
+ 			 "hsw_decodern,hsw_p1")
+ 
+ (define_insn_reservation "hsw_sse_icvt_SI_load" 3
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "!none")
+ 				   (and (eq_attr "mode" "SI")
+ 					(eq_attr "type" "sseicvt"))))
+ 			 "hsw_decodern,hsw_p23+hsw_p1")
+ 
+ (define_insn_reservation "hsw_sse_mov" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none")
+ 				   (eq_attr "type" "ssemov")))
+ 			 "hsw_decodern,hsw_p015")
+ 
+ (define_insn_reservation "hsw_sse_mov_load" 2
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "ssemov")))
+ 			 "hsw_decodern,hsw_p23")
+ 
+ (define_insn_reservation "hsw_sse_mov_store" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "store")
+ 				   (eq_attr "type" "ssemov")))
+ 			 "hsw_decodern,hsw_p4p7")
+ 
+ (define_insn_reservation "hsw_insn" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "none,unknown")
+ 				   (eq_attr "type" "alu,alu1,negnot,incdec,icmp,test,setcc,sseishft1,mmx,mmxcmp")))
+ 			 "hsw_decodern,hsw_p0156")
+ 
+ (define_insn_reservation "hsw_insn_load" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "load")
+ 				   (eq_attr "type" "alu,alu1,negnot,incdec,icmp,test,setcc,pop,sseishft1,mmx,mmxcmp")))
+ 			 "hsw_decodern,hsw_p23+hsw_p0156")
+ 
+ (define_insn_reservation "hsw_insn_store" 1
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "store")
+ 				   (eq_attr "type" "alu,alu1,negnot,incdec,icmp,test,setcc,sseishft1,mmx,mmxcmp")))
+ 			 "hsw_decodern,hsw_p0156+hsw_p4p7")
+@@ -612,7 +612,7 @@
+ ;; read-modify-store instructions produce 4 uops so they have to be
+ ;; decoded on hsw_decoder0 as well.
+ (define_insn_reservation "hsw_insn_both" 4
+-			 (and (eq_attr "cpu" "generic,haswell")
++			 (and (eq_attr "cpu" "haswell")
+ 			      (and (eq_attr "memory" "both")
+ 				   (eq_attr "type" "alu,alu1,negnot,incdec,icmp,test,setcc,pop,sseishft1,mmx,mmxcmp")))
+ 			 "hsw_decodern,hsw_p23+hsw_p0156+hsw_p4p7")
+diff -ruNd a/gcc/config/i386/i386.cc b/gcc/config/i386/i386.cc
+--- a/gcc/config/i386/i386.cc
++++ b/gcc/config/i386/i386.cc
+@@ -17263,7 +17263,6 @@
+     case PROCESSOR_HASWELL:
+     case PROCESSOR_TREMONT:
+     case PROCESSOR_ALDERLAKE:
+-    case PROCESSOR_GENERIC:
+       /* Do not perform multipass scheduling for pre-reload schedule
+          to save compile time.  */
+       if (reload_completed)
+diff -ruNd a/gcc/config/i386/x86-tune-costs.h b/gcc/config/i386/x86-tune-costs.h
+--- a/gcc/config/i386/x86-tune-costs.h
++++ b/gcc/config/i386/x86-tune-costs.h
+@@ -3410,8 +3410,8 @@
+ struct processor_costs generic_cost = {
+   {
+   /* Start of register allocator costs.  integer->integer move cost is 2. */
+-  6,				     /* cost for loading QImode using movzbl */
+-  {6, 6, 6},				/* cost of loading integer registers
++  4,				     /* cost for loading QImode using movzbl */
++  {4, 4, 4},				/* cost of loading integer registers
+ 					   in QImode, HImode and SImode.
+ 					   Relative to reg-reg move (2).  */
+   {6, 6, 6},				/* cost of storing integer registers */
+@@ -3430,7 +3430,7 @@
+ 					   in 32,64,128,256 and 512-bit */
+   {6, 6, 6, 10, 15},			/* cost of storing SSE registers
+ 					   in 32,64,128,256 and 512-bit */
+-  6, 6,				/* SSE->integer and integer->SSE moves */
++  20, 20,				/* SSE->integer and integer->SSE moves */
+   6, 6,				/* mask->integer and integer->mask moves */
+   {6, 6, 6},				/* cost of loading mask register
+ 					   in QImode, HImode, SImode.  */
+@@ -3451,11 +3451,11 @@
+    COSTS_N_INSNS (4),			/*				 HI */
+    COSTS_N_INSNS (3),			/*				 SI */
+    COSTS_N_INSNS (4),			/*				 DI */
+-   COSTS_N_INSNS (4)},			/*			      other */
++   COSTS_N_INSNS (2)},			/*			      other */
+   0,					/* cost of multiply per each bit set */
+-  {COSTS_N_INSNS (16),			/* cost of a divide/mod for QI */
+-   COSTS_N_INSNS (22),			/*			    HI */
+-   COSTS_N_INSNS (30),			/*			    SI */
++  {COSTS_N_INSNS (18),			/* cost of a divide/mod for QI */
++   COSTS_N_INSNS (26),			/*			    HI */
++   COSTS_N_INSNS (42),			/*			    SI */
+    COSTS_N_INSNS (74),			/*			    DI */
+    COSTS_N_INSNS (74)},			/*			    other */
+   COSTS_N_INSNS (1),			/* cost of movsx */
+@@ -3471,12 +3471,12 @@
+ 					   in 32bit, 64bit, 128bit, 256bit and 512bit */
+   {6, 6, 6, 10, 15},			/* cost of storing SSE register
+ 					   in 32bit, 64bit, 128bit, 256bit and 512bit */
+-  {6, 6, 6, 10, 15},			/* cost of unaligned loads.  */
+-  {6, 6, 6, 10, 15},			/* cost of unaligned storess.  */
++  {10, 10, 10, 15, 20},			/* cost of unaligned loads.  */
++  {10, 10, 10, 15, 20},			/* cost of unaligned storess.  */
+   2, 3, 4,				/* cost of moving XMM,YMM,ZMM register */
+   6,					/* cost of moving SSE register to integer.  */
+-  18, 6,				/* Gather load static, per_elt.  */
+-  18, 6,				/* Gather store static, per_elt.  */
++  6, 6,					/* Gather load static, per_elt.  */
++  6, 6,					/* Gather store static, per_elt.  */
+   32,					/* size of l1 cache.  */
+   512,					/* size of l2 cache.  */
+   64,					/* size of prefetch block */
+@@ -3485,11 +3485,11 @@
+      value is increased to perhaps more appropriate value of 5.  */
+   3,					/* Branch cost */
+   COSTS_N_INSNS (3),			/* cost of FADD and FSUB insns.  */
+-  COSTS_N_INSNS (5),			/* cost of FMUL instruction.  */
+-  COSTS_N_INSNS (17),			/* cost of FDIV instruction.  */
++  COSTS_N_INSNS (3),			/* cost of FMUL instruction.  */
++  COSTS_N_INSNS (20),			/* cost of FDIV instruction.  */
+   COSTS_N_INSNS (1),			/* cost of FABS instruction.  */
+   COSTS_N_INSNS (1),			/* cost of FCHS instruction.  */
+-  COSTS_N_INSNS (14),			/* cost of FSQRT instruction.  */
++  COSTS_N_INSNS (40),			/* cost of FSQRT instruction.  */
+ 
+   COSTS_N_INSNS (1),			/* cost of cheap SSE instruction.  */
+   COSTS_N_INSNS (3),			/* cost of ADDSS/SD SUBSS/SD insns.  */
+@@ -3497,15 +3497,15 @@
+   COSTS_N_INSNS (5),			/* cost of MULSD instruction.  */
+   COSTS_N_INSNS (5),			/* cost of FMA SS instruction.  */
+   COSTS_N_INSNS (5),			/* cost of FMA SD instruction.  */
+-  COSTS_N_INSNS (13),			/* cost of DIVSS instruction.  */
+-  COSTS_N_INSNS (17),			/* cost of DIVSD instruction.  */
+-  COSTS_N_INSNS (14),			/* cost of SQRTSS instruction.  */
+-  COSTS_N_INSNS (18),			/* cost of SQRTSD instruction.  */
+-  1, 4, 3, 3,				/* reassoc int, fp, vec_int, vec_fp.  */
++  COSTS_N_INSNS (18),			/* cost of DIVSS instruction.  */
++  COSTS_N_INSNS (32),			/* cost of DIVSD instruction.  */
++  COSTS_N_INSNS (30),			/* cost of SQRTSS instruction.  */
++  COSTS_N_INSNS (58),			/* cost of SQRTSD instruction.  */
++  1, 2, 1, 1,				/* reassoc int, fp, vec_int, vec_fp.  */
+   generic_memcpy,
+   generic_memset,
+-  COSTS_N_INSNS (4),			/* cond_taken_branch_cost.  */
+-  COSTS_N_INSNS (2),			/* cond_not_taken_branch_cost.  */
++  COSTS_N_INSNS (3),			/* cond_taken_branch_cost.  */
++  COSTS_N_INSNS (1),			/* cond_not_taken_branch_cost.  */
+   "16:11:8",				/* Loop alignment.  */
+   "16:11:8",				/* Jump alignment.  */
+   "0:0:8",				/* Label alignment.  */
+diff -ruNd a/gcc/config/i386/x86-tune.def b/gcc/config/i386/x86-tune.def
+--- a/gcc/config/i386/x86-tune.def
++++ b/gcc/config/i386/x86-tune.def
+@@ -103,10 +103,12 @@
+    setting full flags.
+ 
+    The flags does not affect generation of INC and DEC that is controlled
+-   by X86_TUNE_USE_INCDEC.  */
++   by X86_TUNE_USE_INCDEC.
+ 
++   This flag may be dropped from generic once core2-corei5 machines are
++   rare enough.  */
+ DEF_TUNE (X86_TUNE_PARTIAL_FLAG_REG_STALL, "partial_flag_reg_stall",
+-          m_CORE2)
++          m_CORE2 | m_GENERIC)
+ 
+ /* X86_TUNE_MOVX: Enable to zero extend integer registers to avoid
+    partial dependencies.  */
+@@ -126,26 +128,26 @@
+ /* X86_TUNE_FUSE_CMP_AND_BRANCH_32: Fuse compare with a subsequent
+    conditional jump instruction for 32 bit TARGET.  */
+ DEF_TUNE (X86_TUNE_FUSE_CMP_AND_BRANCH_32, "fuse_cmp_and_branch_32",
+-	  m_CORE_ALL | m_BDVER | m_ZNVER | m_LUJIAZUI | m_GENERIC)
++	  m_CORE_ALL | m_BDVER | m_ZNVER | m_LUJIAZUI)
+ 
+ /* X86_TUNE_FUSE_CMP_AND_BRANCH_64: Fuse compare with a subsequent
+    conditional jump instruction for TARGET_64BIT.  */
+ DEF_TUNE (X86_TUNE_FUSE_CMP_AND_BRANCH_64, "fuse_cmp_and_branch_64",
+ 	  m_NEHALEM | m_SANDYBRIDGE | m_CORE_AVX2 | m_BDVER
+-	  | m_ZNVER | m_LUJIAZUI | m_GENERIC)
++	  | m_ZNVER | m_LUJIAZUI)
+ 
+ /* X86_TUNE_FUSE_CMP_AND_BRANCH_SOFLAGS: Fuse compare with a
+    subsequent conditional jump instruction when the condition jump
+    check sign flag (SF) or overflow flag (OF).  */
+ DEF_TUNE (X86_TUNE_FUSE_CMP_AND_BRANCH_SOFLAGS, "fuse_cmp_and_branch_soflags",
+ 	  m_NEHALEM | m_SANDYBRIDGE | m_CORE_AVX2 | m_BDVER
+-	  | m_ZNVER | m_LUJIAZUI | m_GENERIC)
++	  | m_ZNVER | m_LUJIAZUI)
+ 
+ /* X86_TUNE_FUSE_ALU_AND_BRANCH: Fuse alu with a subsequent conditional
+    jump instruction when the alu instruction produces the CCFLAG consumed by
+    the conditional jump instruction. */
+ DEF_TUNE (X86_TUNE_FUSE_ALU_AND_BRANCH, "fuse_alu_and_branch",
+-		  m_SANDYBRIDGE | m_CORE_AVX2 | m_LUJIAZUI | m_GENERIC)
++		  m_SANDYBRIDGE | m_CORE_AVX2 | m_LUJIAZUI)
+ 
+ 
+ /*****************************************************************************/
+@@ -219,7 +221,7 @@
+    architecture expect at most one jump per 2 byte window.  Failing to
+    pad returns leads to misaligned return stack.  */
+ DEF_TUNE (X86_TUNE_PAD_RETURNS, "pad_returns",
+-          m_ATHLON_K8 | m_AMDFAM10)
++          m_ATHLON_K8 | m_AMDFAM10 | m_GENERIC)
+ 
+ /* X86_TUNE_FOUR_JUMP_LIMIT: Some CPU cores are not able to predict more
+    than 4 branch instructions in the 16 byte window.  */
+diff -ruNd a/gcc/config/i386/x86-tune-sched.cc b/gcc/config/i386/x86-tune-sched.cc
+--- a/gcc/config/i386/x86-tune-sched.cc
++++ b/gcc/config/i386/x86-tune-sched.cc
+@@ -57,6 +57,7 @@
+     case PROCESSOR_ATHLON:
+     case PROCESSOR_K8:
+     case PROCESSOR_AMDFAM10:
++    case PROCESSOR_GENERIC:
+     case PROCESSOR_BTVER1:
+     case PROCESSOR_LUJIAZUI:
+       return 3;
+@@ -79,7 +80,6 @@
+     case PROCESSOR_CASCADELAKE:
+     case PROCESSOR_CANNONLAKE:
+     case PROCESSOR_ALDERLAKE:
+-    case PROCESSOR_GENERIC:
+       return 4;
+ 
+     case PROCESSOR_ICELAKE_CLIENT:
+@@ -376,6 +376,7 @@
+     case PROCESSOR_BDVER4:
+     case PROCESSOR_BTVER1:
+     case PROCESSOR_BTVER2:
++    case PROCESSOR_GENERIC:
+       /* Stack engine allows to execute push&pop instructions in parall.  */
+       if ((insn_type == TYPE_PUSH || insn_type == TYPE_POP)
+ 	  && (dep_insn_type == TYPE_PUSH || dep_insn_type == TYPE_POP))
+@@ -451,7 +452,6 @@
+     case PROCESSOR_HASWELL:
+     case PROCESSOR_TREMONT:
+     case PROCESSOR_ALDERLAKE:
+-    case PROCESSOR_GENERIC:
+       /* Stack engine allows to execute push&pop instructions in parall.  */
+       if ((insn_type == TYPE_PUSH || insn_type == TYPE_POP)
+ 	  && (dep_insn_type == TYPE_PUSH || dep_insn_type == TYPE_POP))


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Revert GCC target/PR 81616 for Afterglow so older 32-bit x86 devices might get better compiler optimizations.
This patch only applies to behavior of -mtune=generic. So there should be another patch for Autobuild4.
The previous -mtune=bonnell parameter is obviously not suitable for most devices.

Patch should be okay for upstream GCC version 13.3.x, modifications needed for newer versions of GCC.
Note that if you blindly apply the patch to a later version of GCC source code, the generic_cost struct may be incorrectly patched.

The patch looks good on mingw-w64 and crosstool-NG generated toolchains.

Package(s) Affected
-------------------

core-devel/gcc (cross-toolchain could be affected too?)

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------
-->

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

<!--
```
pkg1 pkg2 pkg3 ...
```
-->

IDK but there should be a complete recompilation for BuildKit and all other packages.

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
