### PR TITLE
deploykit-gui: update to 0.8.0

### DIFF
--- a/app-admin/deploykit-gui/spec
+++ b/app-admin/deploykit-gui/spec
@@ -1,7 +1,7 @@
-VER=0.7.7
+VER=0.8.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-gui \
       tbl::https://github.com/AOSC-Dev/deploykit-gui/releases/download/v$VER/dist.tar.xz"
 CHKSUMS="SKIP \
-         sha256::8eeb528a7594d4017f9ff91312e3f1fc5a2ad8b95f24f74f2ee7e94c7c308268"
+         sha256::e7c55480ff043edbd4f996822ab728a1a94be2ffc3d2151acae746a1978a60fe"
 SUBDIR="deploykit-gui/src-tauri"
 CHKUPDATE="anitya::id=371971"


### PR DESCRIPTION
Topic Description
-----------------

- deploykit-gui: update to 0.8.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- deploykit-gui: 0.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-gui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
