### PR TITLE
chafa: new, 1.14.2

### DIFF
--- a/app-utils/chafa/autobuild/defines
+++ b/app-utils/chafa/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=chafa
+PKGDES="A image-to-text converter for terminal"
+PKGSEC=utils
+PKGDEP="bash libjpeg-turbo librsvg glib cairo libtiff libwebp libjxl freetype libavif"
+BUILDDEP="libxml2 libxslt libtool gtk-doc imagemagick"
+
+AUTOTOOLS_AFTER="--enable-gtk-doc"

--- a/app-utils/chafa/spec
+++ b/app-utils/chafa/spec
@@ -1,0 +1,4 @@
+VER=1.14.2
+SRCS="git::commit=tags/$VER::https://github.com/hpjansson/chafa"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=17542"


### PR DESCRIPTION
Topic Description
-----------------

- chafa: new, 1.14.2

Package(s) Affected
-------------------

- chafa: 1.14.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit chafa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
