### PR TITLE
nokogiri: update to 1.16.7

### DIFF
--- a/lang-ruby/nokogiri/spec
+++ b/lang-ruby/nokogiri/spec
@@ -1,5 +1,5 @@
-VER=1.16.6
+VER=1.16.7
 SRCS="tbl::https://rubygems.org/downloads/nokogiri-$VER.gem"
-CHKSUMS="sha256::935fe4dd67d4377f4a05002acb1ffbadbcae265ea8e7869fc40e3a8121f3e1ef"
+CHKSUMS="sha256::f819cbfdfb0a7b19c9c52c6f2ca63df0e58a6125f4f139707b586b9511d7fe95"
 CHKUPDATE="anitya::id=4641"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- nokogiri: update to 1.16.7
    Co-authored-by: 温柔 (@xunpod)

Package(s) Affected
-------------------

- nokogiri: 1.16.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit nokogiri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
