### PR TITLE
select-language-tui: update to 0.4.0

### DIFF
--- a/app-utils/select-language-tui/spec
+++ b/app-utils/select-language-tui/spec
@@ -1,4 +1,4 @@
-VER=0.3.0
+VER=0.4.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/select-language-tui"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371441"


### PR DESCRIPTION
Topic Description
-----------------

- select-language-tui: update to 0.4.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- select-language-tui: 0.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit select-language-tui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
