### PR TITLE
git: update to 2.46.0

### DIFF
--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,4 +1,4 @@
-VER=2.45.2
+VER=2.46.0
 SRCS="https://www.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
-CHKSUMS="sha256::98b26090ed667099a3691b93698d1e213e1ded73d36a2fde7e9125fce28ba234"
+CHKSUMS="sha256::b138811e16838f669a2516e40f09d50500e1c7fc541b5ab50ce84b98585e5230"
 CHKUPDATE="anitya::id=5350"


### PR DESCRIPTION
Topic Description
-----------------

- git: update to 2.46.0
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- git: 2.46.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
