### PR TITLE
ffmpeg (FFmpeg): fix AMD GPU AV1 hardware decoding with Mesa >= 24.1.4

### DIFF
--- a/app-multimedia/ffmpeg/autobuild/patches/0001-avcodec-mips-Add-switch-for-MADD-instruction.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0001-avcodec-mips-Add-switch-for-MADD-instruction.patch
@@ -1,7 +1,7 @@
 From cac8b0b75e1259c37fbd78ab617622e94ed106ea Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Wed, 17 Feb 2021 22:27:11 +0800
-Subject: [PATCH 01/11] avcodec/mips: Add switch for MADD instruction
+Subject: [PATCH 01/15] avcodec/mips: Add switch for MADD instruction
 
 MADD.{d,s} is only available after MIPS IV and being dropped
 in MIPS R6 (Replaced by FMADD).
@@ -666,5 +666,5 @@ index 0943d6f343..8e8c00bda1 100644
  #endif /* HAVE_INLINE_ASM && HAVE_MIPSFPU */
  }
 -- 
-2.45.0
+2.45.2
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0002-avutil-mips-Use-MMI_-L-S-QC1-macro-in-SAVE-RECOVER-_.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0002-avutil-mips-Use-MMI_-L-S-QC1-macro-in-SAVE-RECOVER-_.patch
@@ -1,7 +1,7 @@
 From 5dfb9b79d42fe389a2880ba1f98f2dd256b42b66 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 18 Feb 2021 15:34:04 +0800
-Subject: [PATCH 02/11] avutil/mips: Use MMI_{L,S}QC1 macro in
+Subject: [PATCH 02/15] avutil/mips: Use MMI_{L,S}QC1 macro in
  {SAVE,RECOVER}_REG
 
 {SAVE,RECOVER}_REG will be avilable for Loongson2 again,
@@ -80,5 +80,5 @@ index 6a82caa908..41715c6490 100644
        : [temp]"r"(temp_backup_reg)                              \
        : "memory"                                                \
 -- 
-2.45.0
+2.45.2
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0003-avutil-mips-Extract-load-store-with-shift-C1-pair-ma.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0003-avutil-mips-Extract-load-store-with-shift-C1-pair-ma.patch
@@ -1,7 +1,7 @@
 From 0c900c14513a9143a82535bf8ae728f2324ecbe8 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 18 Feb 2021 15:58:25 +0800
-Subject: [PATCH 03/11] avutil/mips: Extract load store with shift C1 pair
+Subject: [PATCH 03/15] avutil/mips: Extract load store with shift C1 pair
  marco
 
 We're doing some fancy hacks with load store with shift C1
@@ -138,5 +138,5 @@ index 41715c6490..f5b600e50c 100644
   * Backup saved registers
   * We're not using compiler's clobber list as it's not smart enough
 -- 
-2.45.0
+2.45.2
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0004-avcodec-mips-Use-MMI-marcos-to-replace-Loongson3-ins.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0004-avcodec-mips-Use-MMI-marcos-to-replace-Loongson3-ins.patch
@@ -1,7 +1,7 @@
 From a5c646959b719087c7541624bd0ca65cd83d4a57 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 18 Feb 2021 17:02:07 +0800
-Subject: [PATCH 04/11] avcodec/mips: Use MMI marcos to replace Loongson3
+Subject: [PATCH 04/15] avcodec/mips: Use MMI marcos to replace Loongson3
  instructions
 
 Loongson3's extention instructions (prefixed with gs) are widely used
@@ -1304,5 +1304,5 @@ index e7a83875b9..57825fb967 100644
            [tmp0]"=&r"(tmp[0]),    [tmp1]"=&r"(tmp[1]),
            [src]"+&r"(src),        [dst]"+&r"(dst),
 -- 
-2.45.0
+2.45.2
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0005-avutil-mips-Use-at-as-MMI-macro-temporary-register.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0005-avutil-mips-Use-at-as-MMI-macro-temporary-register.patch
@@ -1,7 +1,7 @@
 From f549bdb86ce7ac11961806bf6e4ecaab8ffd9193 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 18 Feb 2021 17:35:03 +0800
-Subject: [PATCH 05/11] avutil/mips: Use $at as MMI macro temporary register
+Subject: [PATCH 05/15] avutil/mips: Use $at as MMI macro temporary register
 
 Some function had exceed 30 inline assembly register oprands limiation
 when using LOONGSON2 version of MMI macros. We can avoid that by take
@@ -194,5 +194,5 @@ index f5b600e50c..c1a8046798 100644
  #else /* _MIPS_SIM != _ABIO32 */
  
 -- 
-2.45.0
+2.45.2
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0006-avcodec-x86-mathops-clip-constants-used-with-shift-i.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0006-avcodec-x86-mathops-clip-constants-used-with-shift-i.patch
@@ -1,7 +1,7 @@
 From f677ead4dd9032d93c4077b3db7e08c199101f8e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
 Date: Sun, 16 Jul 2023 18:18:02 +0300
-Subject: [PATCH 06/11] avcodec/x86/mathops: clip constants used with shift
+Subject: [PATCH 06/15] avcodec/x86/mathops: clip constants used with shift
  instructions within inline assembly
 
 Fixes assembling with binutil as >= 2.41
@@ -72,5 +72,5 @@ index 6298f5ed19..ca7e2dffc1 100644
  }
  
 -- 
-2.45.0
+2.45.2
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0007-Only-use-cpuinfo-to-read-cpu-ISAs.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0007-Only-use-cpuinfo-to-read-cpu-ISAs.patch
@@ -1,7 +1,7 @@
 From f24ba2a4b3ddcab28fba994b9422e373eb62dae9 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 7 Sep 2020 03:49:55 +0800
-Subject: [PATCH 07/11] Only use cpuinfo to read cpu ISAs
+Subject: [PATCH 07/15] Only use cpuinfo to read cpu ISAs
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
 ---
@@ -133,5 +133,5 @@ index 59619d54de..02579c8047 100644
      /* Assume no SIMD ASE supported */
      return 0;
 -- 
-2.45.0
+2.45.2
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0008-Add-mips64r6-generic-options.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0008-Add-mips64r6-generic-options.patch
@@ -1,7 +1,7 @@
 From 9c18b08622a6ef56cbc69ff59a9e78ba8eebfcd5 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Tue, 20 Feb 2024 06:57:42 -0800
-Subject: [PATCH 08/11] Add mips64r6 generic options
+Subject: [PATCH 08/15] Add mips64r6 generic options
 
 ---
  configure | 4 ++++
@@ -23,5 +23,5 @@ index 2602bf584a..8218bbfa23 100755
              loongson2e|loongson2f|loongson3*)
                  enable local_aligned
 -- 
-2.45.0
+2.45.2
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0009-doc-t2h.pm-fix-missing-CSS-with-texinfo-6.8-and-abov.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0009-doc-t2h.pm-fix-missing-CSS-with-texinfo-6.8-and-abov.patch
@@ -1,7 +1,7 @@
 From 7cc351b2bc1fe54b9de420e7b8f69ecee9368001 Mon Sep 17 00:00:00 2001
 From: Matthew White <mehw.is.me@inventati.org>
 Date: Sun, 14 Nov 2021 00:42:27 +0000
-Subject: [PATCH 09/11] doc/t2h.pm: fix missing CSS with texinfo 6.8 and above
+Subject: [PATCH 09/15] doc/t2h.pm: fix missing CSS with texinfo 6.8 and above
 
 Since texinfo commit 6a5ceab6a48a4f052baad9f3474d741428409fd7, the
 formatting functions, in particular begin_file, program_string and
@@ -78,5 +78,5 @@ index e83d564a65..87412699aa 100644
  # Dummy title command
  # Ignore title. Title is handled through ffmpeg_begin_file().
 -- 
-2.45.0
+2.45.2
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0010-doc-t2h.pm-fix-missing-TOC-with-texinfo-6.8-and-abov.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0010-doc-t2h.pm-fix-missing-TOC-with-texinfo-6.8-and-abov.patch
@@ -1,7 +1,7 @@
 From 2015a9aeac5bc1bbf51d2cb2021759b01ac29532 Mon Sep 17 00:00:00 2001
 From: Matthew White <mehw.is.me@inventati.org>
 Date: Sun, 14 Nov 2021 01:10:58 +0000
-Subject: [PATCH 10/11] doc/t2h.pm: fix missing TOC with texinfo 6.8 and above
+Subject: [PATCH 10/15] doc/t2h.pm: fix missing TOC with texinfo 6.8 and above
 
 Since texinfo 6.8, there's no longer an INLINE_CONTENTS variable.
 
@@ -41,5 +41,5 @@ index 87412699aa..d07d974286 100644
  # make chapters <h2>
  set_from_init_file('CHAPTER_HEADER_LEVEL', 2);
 -- 
-2.45.0
+2.45.2
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0011-doc-html-support-texinfo-7.0.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0011-doc-html-support-texinfo-7.0.patch
@@ -1,7 +1,7 @@
 From d2931b124860f2c6098f9d3b80fa6a6586fdeab4 Mon Sep 17 00:00:00 2001
 From: Frank Plowman <post@frankplowman.com>
 Date: Wed, 8 Nov 2023 07:55:18 +0000
-Subject: [PATCH 11/11] doc/html: support texinfo 7.0
+Subject: [PATCH 11/15] doc/html: support texinfo 7.0
 
 Resolves trac ticket #10636 (http://trac.ffmpeg.org/ticket/10636).
 
@@ -216,5 +216,5 @@ index d07d974286..b7485e1f1e 100644
  
  texinfo_register_command_formatting('float',
 -- 
-2.45.0
+2.45.2
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0012-lavc-vaapi_decode-Make-it-possible-to-send-multiple-.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0012-lavc-vaapi_decode-Make-it-possible-to-send-multiple-.patch
@@ -1,0 +1,185 @@
+From 5b86ed6dd241808f60f10b53d599b8e34d2a7f92 Mon Sep 17 00:00:00 2001
+From: David Rosca <nowrep@gmail.com>
+Date: Wed, 8 May 2024 09:11:11 +0200
+Subject: [PATCH 12/15] lavc/vaapi_decode: Make it possible to send multiple
+ slice params buffers
+
+Reviewed-by: Neal Gompa <ngompa13@gmail.com>
+Signed-off-by: David Rosca <nowrep@gmail.com>
+Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
+---
+ libavcodec/vaapi_av1.c    | 2 +-
+ libavcodec/vaapi_decode.c | 3 ++-
+ libavcodec/vaapi_decode.h | 1 +
+ libavcodec/vaapi_h264.c   | 2 +-
+ libavcodec/vaapi_hevc.c   | 4 ++--
+ libavcodec/vaapi_mjpeg.c  | 2 +-
+ libavcodec/vaapi_mpeg2.c  | 2 +-
+ libavcodec/vaapi_mpeg4.c  | 2 +-
+ libavcodec/vaapi_vc1.c    | 2 +-
+ libavcodec/vaapi_vp8.c    | 2 +-
+ libavcodec/vaapi_vp9.c    | 2 +-
+ 11 files changed, 13 insertions(+), 11 deletions(-)
+
+diff --git a/libavcodec/vaapi_av1.c b/libavcodec/vaapi_av1.c
+index 5985493b8d..df8b98ca85 100644
+--- a/libavcodec/vaapi_av1.c
++++ b/libavcodec/vaapi_av1.c
+@@ -419,7 +419,7 @@ static int vaapi_av1_decode_slice(AVCodecContext *avctx,
+             .tg_end            = s->tg_end,
+         };
+ 
+-        err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &slice_param,
++        err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &slice_param, 1,
+                                                 sizeof(VASliceParameterBufferAV1),
+                                                 buffer,
+                                                 size);
+diff --git a/libavcodec/vaapi_decode.c b/libavcodec/vaapi_decode.c
+index 032e8531f2..9a9289ac85 100644
+--- a/libavcodec/vaapi_decode.c
++++ b/libavcodec/vaapi_decode.c
+@@ -59,6 +59,7 @@ int ff_vaapi_decode_make_param_buffer(AVCodecContext *avctx,
+ int ff_vaapi_decode_make_slice_buffer(AVCodecContext *avctx,
+                                       VAAPIDecodePicture *pic,
+                                       const void *params_data,
++                                      int nb_params,
+                                       size_t params_size,
+                                       const void *slice_data,
+                                       size_t slice_size)
+@@ -87,7 +88,7 @@ int ff_vaapi_decode_make_slice_buffer(AVCodecContext *avctx,
+ 
+     vas = vaCreateBuffer(ctx->hwctx->display, ctx->va_context,
+                          VASliceParameterBufferType,
+-                         params_size, 1, (void*)params_data,
++                         params_size, nb_params, (void*)params_data,
+                          &pic->slice_buffers[index]);
+     if (vas != VA_STATUS_SUCCESS) {
+         av_log(avctx, AV_LOG_ERROR, "Failed to create slice "
+diff --git a/libavcodec/vaapi_decode.h b/libavcodec/vaapi_decode.h
+index 6b415dd1d3..b7315ccde3 100644
+--- a/libavcodec/vaapi_decode.h
++++ b/libavcodec/vaapi_decode.h
+@@ -86,6 +86,7 @@ int ff_vaapi_decode_make_param_buffer(AVCodecContext *avctx,
+ int ff_vaapi_decode_make_slice_buffer(AVCodecContext *avctx,
+                                       VAAPIDecodePicture *pic,
+                                       const void *params_data,
++                                      int nb_params,
+                                       size_t params_size,
+                                       const void *slice_data,
+                                       size_t slice_size);
+diff --git a/libavcodec/vaapi_h264.c b/libavcodec/vaapi_h264.c
+index 9332aa6f31..0536ee8f93 100644
+--- a/libavcodec/vaapi_h264.c
++++ b/libavcodec/vaapi_h264.c
+@@ -375,7 +375,7 @@ static int vaapi_h264_decode_slice(AVCodecContext *avctx,
+                                        slice_param.chroma_offset_l1);
+ 
+     err = ff_vaapi_decode_make_slice_buffer(avctx, pic,
+-                                            &slice_param, sizeof(slice_param),
++                                            &slice_param, 1, sizeof(slice_param),
+                                             buffer, size);
+     if (err) {
+         ff_vaapi_decode_cancel(avctx, pic);
+diff --git a/libavcodec/vaapi_hevc.c b/libavcodec/vaapi_hevc.c
+index 9083331c45..c1416592c5 100644
+--- a/libavcodec/vaapi_hevc.c
++++ b/libavcodec/vaapi_hevc.c
+@@ -305,7 +305,7 @@ static int vaapi_hevc_end_frame(AVCodecContext *avctx)
+     if (pic->last_size) {
+         last_slice_param->LongSliceFlags.fields.LastSliceOfPic = 1;
+         ret = ff_vaapi_decode_make_slice_buffer(avctx, &pic->pic,
+-                                                &pic->last_slice_param, slice_param_size,
++                                                &pic->last_slice_param, 1, slice_param_size,
+                                                 pic->last_buffer, pic->last_size);
+         if (ret < 0)
+             goto fail;
+@@ -410,7 +410,7 @@ static int vaapi_hevc_decode_slice(AVCodecContext *avctx,
+ 
+     if (!sh->first_slice_in_pic_flag) {
+         err = ff_vaapi_decode_make_slice_buffer(avctx, &pic->pic,
+-                                                &pic->last_slice_param, slice_param_size,
++                                                &pic->last_slice_param, 1, slice_param_size,
+                                                 pic->last_buffer, pic->last_size);
+         pic->last_buffer = NULL;
+         pic->last_size   = 0;
+diff --git a/libavcodec/vaapi_mjpeg.c b/libavcodec/vaapi_mjpeg.c
+index 81582114b6..3ee1663e3d 100644
+--- a/libavcodec/vaapi_mjpeg.c
++++ b/libavcodec/vaapi_mjpeg.c
+@@ -131,7 +131,7 @@ static int vaapi_mjpeg_decode_slice(AVCodecContext *avctx,
+         sp.components[i].ac_table_selector  = s->ac_index[i];
+     }
+ 
+-    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &sp, sizeof(sp), buffer, size);
++    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &sp, 1, sizeof(sp), buffer, size);
+     if (err)
+         goto fail;
+ 
+diff --git a/libavcodec/vaapi_mpeg2.c b/libavcodec/vaapi_mpeg2.c
+index 26e0cd827c..28eec7fe86 100644
+--- a/libavcodec/vaapi_mpeg2.c
++++ b/libavcodec/vaapi_mpeg2.c
+@@ -162,7 +162,7 @@ static int vaapi_mpeg2_decode_slice(AVCodecContext *avctx, const uint8_t *buffer
+     };
+ 
+     err = ff_vaapi_decode_make_slice_buffer(avctx, pic,
+-                                            &slice_param, sizeof(slice_param),
++                                            &slice_param, 1, sizeof(slice_param),
+                                             buffer, size);
+     if (err < 0) {
+         ff_vaapi_decode_cancel(avctx, pic);
+diff --git a/libavcodec/vaapi_mpeg4.c b/libavcodec/vaapi_mpeg4.c
+index 71e155154c..532b4c50e4 100644
+--- a/libavcodec/vaapi_mpeg4.c
++++ b/libavcodec/vaapi_mpeg4.c
+@@ -167,7 +167,7 @@ static int vaapi_mpeg4_decode_slice(AVCodecContext *avctx, const uint8_t *buffer
+     };
+ 
+     err = ff_vaapi_decode_make_slice_buffer(avctx, pic,
+-                                            &slice_param, sizeof(slice_param),
++                                            &slice_param, 1, sizeof(slice_param),
+                                             buffer, size);
+     if (err < 0) {
+         ff_vaapi_decode_cancel(avctx, pic);
+diff --git a/libavcodec/vaapi_vc1.c b/libavcodec/vaapi_vc1.c
+index 4e9607d9be..741014869d 100644
+--- a/libavcodec/vaapi_vc1.c
++++ b/libavcodec/vaapi_vc1.c
+@@ -490,7 +490,7 @@ static int vaapi_vc1_decode_slice(AVCodecContext *avctx, const uint8_t *buffer,
+     };
+ 
+     err = ff_vaapi_decode_make_slice_buffer(avctx, pic,
+-                                            &slice_param, sizeof(slice_param),
++                                            &slice_param, 1, sizeof(slice_param),
+                                             buffer, size);
+     if (err < 0) {
+         ff_vaapi_decode_cancel(avctx, pic);
+diff --git a/libavcodec/vaapi_vp8.c b/libavcodec/vaapi_vp8.c
+index 06c23e760b..10fb4ec8d2 100644
+--- a/libavcodec/vaapi_vp8.c
++++ b/libavcodec/vaapi_vp8.c
+@@ -209,7 +209,7 @@ static int vaapi_vp8_decode_slice(AVCodecContext *avctx,
+     for (i = 0; i < 8; i++)
+         sp.partition_size[i+1] = s->coeff_partition_size[i];
+ 
+-    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &sp, sizeof(sp), data, data_size);
++    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &sp, 1, sizeof(sp), data, data_size);
+     if (err)
+         goto fail;
+ 
+diff --git a/libavcodec/vaapi_vp9.c b/libavcodec/vaapi_vp9.c
+index 776382f683..237f6c5c63 100644
+--- a/libavcodec/vaapi_vp9.c
++++ b/libavcodec/vaapi_vp9.c
+@@ -158,7 +158,7 @@ static int vaapi_vp9_decode_slice(AVCodecContext *avctx,
+     }
+ 
+     err = ff_vaapi_decode_make_slice_buffer(avctx, pic,
+-                                            &slice_param, sizeof(slice_param),
++                                            &slice_param, 1, sizeof(slice_param),
+                                             buffer, size);
+     if (err) {
+         ff_vaapi_decode_cancel(avctx, pic);
+-- 
+2.45.2
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0013-lavc-vaapi_av1-Avoid-sending-the-same-slice-buffer-m.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0013-lavc-vaapi_av1-Avoid-sending-the-same-slice-buffer-m.patch
@@ -1,0 +1,112 @@
+From 7507e92a1ecf33543a3e5fba75f973ea02416afa Mon Sep 17 00:00:00 2001
+From: David Rosca <nowrep@gmail.com>
+Date: Wed, 8 May 2024 09:11:13 +0200
+Subject: [PATCH 13/15] lavc/vaapi_av1: Avoid sending the same slice buffer
+ multiple times
+
+When there are multiple tiles in one slice buffer, use multiple slice
+params to avoid sending the same slice buffer multiple times and thus
+increasing the bitstream size the driver will need to upload to hw.
+
+Reviewed-by: Neal Gompa <ngompa13@gmail.com>
+Signed-off-by: David Rosca <nowrep@gmail.com>
+Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
+---
+ libavcodec/vaapi_av1.c | 48 ++++++++++++++++++++++++++++++------------
+ 1 file changed, 34 insertions(+), 14 deletions(-)
+
+diff --git a/libavcodec/vaapi_av1.c b/libavcodec/vaapi_av1.c
+index df8b98ca85..c2884eebe7 100644
+--- a/libavcodec/vaapi_av1.c
++++ b/libavcodec/vaapi_av1.c
+@@ -20,6 +20,8 @@
+ 
+ #include "libavutil/pixdesc.h"
+ #include "hwconfig.h"
++#include "libavutil/frame.h"
++#include "libavutil/mem.h"
+ #include "vaapi_decode.h"
+ #include "internal.h"
+ #include "av1dec.h"
+@@ -41,6 +43,9 @@ typedef struct VAAPIAV1DecContext {
+     */
+     VAAPIAV1FrameRef ref_tab[AV1_NUM_REF_FRAMES];
+     ThreadFrame tmp_frame;
++
++    int nb_slice_params;
++    VASliceParameterBufferAV1 *slice_params;
+ } VAAPIAV1DecContext;
+ 
+ static VASurfaceID vaapi_av1_surface_id(AV1Frame *vf)
+@@ -107,6 +112,8 @@ static int vaapi_av1_decode_uninit(AVCodecContext *avctx)
+         av_frame_free(&ctx->ref_tab[i].frame.f);
+     }
+ 
++    av_freep(&ctx->slice_params);
++
+     return ff_vaapi_decode_uninit(avctx);
+ }
+ 
+@@ -403,13 +410,24 @@ static int vaapi_av1_decode_slice(AVCodecContext *avctx,
+ {
+     const AV1DecContext *s = avctx->priv_data;
+     VAAPIDecodePicture *pic = s->cur_frame.hwaccel_picture_private;
+-    VASliceParameterBufferAV1 slice_param;
+-    int err = 0;
++    VAAPIAV1DecContext *ctx = avctx->internal->hwaccel_priv_data;
++    int err, nb_params;
++
++    nb_params = s->tg_end - s->tg_start + 1;
++    if (ctx->nb_slice_params < nb_params) {
++        ctx->slice_params = av_realloc_array(ctx->slice_params,
++                                             nb_params,
++                                             sizeof(*ctx->slice_params));
++        if (!ctx->slice_params) {
++            ctx->nb_slice_params = 0;
++            err = AVERROR(ENOMEM);
++            goto fail;
++        }
++        ctx->nb_slice_params = nb_params;
++    }
+ 
+     for (int i = s->tg_start; i <= s->tg_end; i++) {
+-        memset(&slice_param, 0, sizeof(VASliceParameterBufferAV1));
+-
+-        slice_param = (VASliceParameterBufferAV1) {
++        ctx->slice_params[i - s->tg_start] = (VASliceParameterBufferAV1) {
+             .slice_data_size   = s->tile_group_info[i].tile_size,
+             .slice_data_offset = s->tile_group_info[i].tile_offset,
+             .slice_data_flag   = VA_SLICE_DATA_FLAG_ALL,
+@@ -418,18 +436,20 @@ static int vaapi_av1_decode_slice(AVCodecContext *avctx,
+             .tg_start          = s->tg_start,
+             .tg_end            = s->tg_end,
+         };
+-
+-        err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &slice_param, 1,
+-                                                sizeof(VASliceParameterBufferAV1),
+-                                                buffer,
+-                                                size);
+-        if (err) {
+-            ff_vaapi_decode_cancel(avctx, pic);
+-            return err;
+-        }
+     }
+ 
++    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, ctx->slice_params, nb_params,
++                                            sizeof(VASliceParameterBufferAV1),
++                                            buffer,
++                                            size);
++    if (err)
++        goto fail;
++
+     return 0;
++
++fail:
++    ff_vaapi_decode_cancel(avctx, pic);
++    return err;
+ }
+ 
+ const AVHWAccel ff_av1_vaapi_hwaccel = {
+-- 
+2.45.2
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0014-configure-use-non-deprecated-nvenc-GUID-for-conftest.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0014-configure-use-non-deprecated-nvenc-GUID-for-conftest.patch
@@ -1,0 +1,25 @@
+From c0a4e0131aaff4ea7969b736222c8323b054e399 Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Thu, 1 Jun 2023 23:24:43 +0200
+Subject: [PATCH 14/15] configure: use non-deprecated nvenc GUID for conftest
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 8218bbfa23..4ab6491bd3 100755
+--- a/configure
++++ b/configure
+@@ -6790,7 +6790,7 @@ enabled nvenc &&
+     test_cc -I$source_path <<EOF || disable nvenc
+ #include <ffnvcodec/nvEncodeAPI.h>
+ NV_ENCODE_API_FUNCTION_LIST flist;
+-void f(void) { struct { const GUID guid; } s[] = { { NV_ENC_PRESET_HQ_GUID } }; }
++void f(void) { struct { const GUID guid; } s[] = { { NV_ENC_CODEC_H264_GUID } }; }
+ int main(void) { return 0; }
+ EOF
+ 
+-- 
+2.45.2
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0015-avcodec-nvenc-stop-using-deprecated-rc-modes-with-SD.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0015-avcodec-nvenc-stop-using-deprecated-rc-modes-with-SD.patch
@@ -1,0 +1,150 @@
+From f0063048380156d046b2e00c4d1f4121758c20c4 Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Thu, 1 Jun 2023 23:46:46 +0200
+Subject: [PATCH 15/15] avcodec/nvenc: stop using deprecated rc modes with SDK
+ 12.1
+
+---
+ libavcodec/nvenc.c      | 11 +++++++++++
+ libavcodec/nvenc.h      |  5 +++++
+ libavcodec/nvenc_h264.c | 12 ++++++++++++
+ libavcodec/nvenc_hevc.c | 12 ++++++++++++
+ 4 files changed, 40 insertions(+)
+
+diff --git a/libavcodec/nvenc.c b/libavcodec/nvenc.c
+index c6498864c8..28eaf2ef92 100644
+--- a/libavcodec/nvenc.c
++++ b/libavcodec/nvenc.c
+@@ -39,9 +39,14 @@
+ #define CHECK_CU(x) FF_CUDA_CHECK_DL(avctx, dl_fn->cuda_dl, x)
+ 
+ #define NVENC_CAP 0x30
++
++#ifndef NVENC_NO_DEPRECATED_RC
+ #define IS_CBR(rc) (rc == NV_ENC_PARAMS_RC_CBR ||             \
+                     rc == NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ || \
+                     rc == NV_ENC_PARAMS_RC_CBR_HQ)
++#else
++#define IS_CBR(rc) (rc == NV_ENC_PARAMS_RC_CBR)
++#endif
+ 
+ const enum AVPixelFormat ff_nvenc_pix_fmts[] = {
+     AV_PIX_FMT_YUV420P,
+@@ -825,6 +830,7 @@ static void nvenc_override_rate_control(AVCodecContext *avctx)
+     case NV_ENC_PARAMS_RC_CONSTQP:
+         set_constqp(avctx);
+         return;
++#ifndef NVENC_NO_DEPRECATED_RC
+     case NV_ENC_PARAMS_RC_VBR_MINQP:
+         if (avctx->qmin < 0) {
+             av_log(avctx, AV_LOG_WARNING,
+@@ -835,12 +841,15 @@ static void nvenc_override_rate_control(AVCodecContext *avctx)
+         }
+         /* fall through */
+     case NV_ENC_PARAMS_RC_VBR_HQ:
++#endif
+     case NV_ENC_PARAMS_RC_VBR:
+         set_vbr(avctx);
+         break;
+     case NV_ENC_PARAMS_RC_CBR:
++#ifndef NVENC_NO_DEPRECATED_RC
+     case NV_ENC_PARAMS_RC_CBR_HQ:
+     case NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ:
++#endif
+         break;
+     }
+ 
+@@ -1074,12 +1083,14 @@ static av_cold int nvenc_setup_h264_config(AVCodecContext *avctx)
+ 
+     h264->outputPictureTimingSEI = 1;
+ 
++#ifndef NVENC_NO_DEPRECATED_RC
+     if (cc->rcParams.rateControlMode == NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ ||
+         cc->rcParams.rateControlMode == NV_ENC_PARAMS_RC_CBR_HQ ||
+         cc->rcParams.rateControlMode == NV_ENC_PARAMS_RC_VBR_HQ) {
+         h264->adaptiveTransformMode = NV_ENC_H264_ADAPTIVE_TRANSFORM_ENABLE;
+         h264->fmoMode = NV_ENC_H264_FMO_DISABLE;
+     }
++#endif
+ 
+     if (ctx->flags & NVENC_LOSSLESS) {
+         h264->qpPrimeYZeroTransformBypassFlag = 1;
+diff --git a/libavcodec/nvenc.h b/libavcodec/nvenc.h
+index 314c270e74..8e646f215d 100644
+--- a/libavcodec/nvenc.h
++++ b/libavcodec/nvenc.h
+@@ -70,6 +70,11 @@ typedef void ID3D11Device;
+ #define NVENC_HAVE_H264_LVL6
+ #endif
+ 
++// SDK 12.1 compile time feature checks
++#if NVENCAPI_CHECK_VERSION(12, 1)
++#define NVENC_NO_DEPRECATED_RC
++#endif
++
+ typedef struct NvencSurface
+ {
+     NV_ENC_INPUT_PTR input_surface;
+diff --git a/libavcodec/nvenc_h264.c b/libavcodec/nvenc_h264.c
+index 4c2585876e..129fc1bfe3 100644
+--- a/libavcodec/nvenc_h264.c
++++ b/libavcodec/nvenc_h264.c
+@@ -100,6 +100,7 @@ static const AVOption options[] = {
+     { "constqp",      "Constant QP mode",                   0,                    AV_OPT_TYPE_CONST, { .i64 = NV_ENC_PARAMS_RC_CONSTQP },                   0, 0, VE, "rc" },
+     { "vbr",          "Variable bitrate mode",              0,                    AV_OPT_TYPE_CONST, { .i64 = NV_ENC_PARAMS_RC_VBR },                       0, 0, VE, "rc" },
+     { "cbr",          "Constant bitrate mode",              0,                    AV_OPT_TYPE_CONST, { .i64 = NV_ENC_PARAMS_RC_CBR },                       0, 0, VE, "rc" },
++#ifndef NVENC_NO_DEPRECATED_RC
+     { "vbr_minqp",    "Variable bitrate mode with MinQP (deprecated)", 0,         AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_VBR_MINQP) },            0, 0, VE, "rc" },
+     { "ll_2pass_quality", "Multi-pass optimized for image quality (deprecated)",
+                                                             0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_2_PASS_QUALITY) },       0, 0, VE, "rc" },
+@@ -109,6 +110,17 @@ static const AVOption options[] = {
+     { "cbr_ld_hq",    "Constant bitrate low delay high quality mode", 0,          AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ) },      0, 0, VE, "rc" },
+     { "cbr_hq",       "Constant bitrate high quality mode", 0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_CBR_HQ) },               0, 0, VE, "rc" },
+     { "vbr_hq",       "Variable bitrate high quality mode", 0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_VBR_HQ) },               0, 0, VE, "rc" },
++#else
++    { "vbr_minqp",    "Variable bitrate mode with MinQP (deprecated)", 0,         AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_VBR) },                  0, 0, VE, "rc" },
++    { "ll_2pass_quality", "Multi-pass optimized for image quality (deprecated)",
++                                                            0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_VBR) },                  0, 0, VE, "rc" },
++    { "ll_2pass_size", "Multi-pass optimized for constant frame size (deprecated)",
++                                                            0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_CBR) },                  0, 0, VE, "rc" },
++    { "vbr_2pass",    "Multi-pass variable bitrate mode (deprecated)", 0,         AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_VBR) },                  0, 0, VE, "rc" },
++    { "cbr_ld_hq",    "Constant bitrate low delay high quality mode", 0,          AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_CBR) },                  0, 0, VE, "rc" },
++    { "cbr_hq",       "Constant bitrate high quality mode", 0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_CBR) },                  0, 0, VE, "rc" },
++    { "vbr_hq",       "Variable bitrate high quality mode", 0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_VBR) },                  0, 0, VE, "rc" },
++#endif
+     { "rc-lookahead", "Number of frames to look ahead for rate-control",
+                                                             OFFSET(rc_lookahead), AV_OPT_TYPE_INT,   { .i64 = 0 }, 0, INT_MAX, VE },
+     { "surfaces",     "Number of concurrent surfaces",      OFFSET(nb_surfaces),  AV_OPT_TYPE_INT,   { .i64 = 0 }, 0, MAX_REGISTERED_FRAMES, VE },
+diff --git a/libavcodec/nvenc_hevc.c b/libavcodec/nvenc_hevc.c
+index 82fbb23bf7..8e330d65b3 100644
+--- a/libavcodec/nvenc_hevc.c
++++ b/libavcodec/nvenc_hevc.c
+@@ -89,6 +89,7 @@ static const AVOption options[] = {
+     { "constqp",      "Constant QP mode",                   0,                    AV_OPT_TYPE_CONST, { .i64 = NV_ENC_PARAMS_RC_CONSTQP },                   0, 0, VE, "rc" },
+     { "vbr",          "Variable bitrate mode",              0,                    AV_OPT_TYPE_CONST, { .i64 = NV_ENC_PARAMS_RC_VBR },                       0, 0, VE, "rc" },
+     { "cbr",          "Constant bitrate mode",              0,                    AV_OPT_TYPE_CONST, { .i64 = NV_ENC_PARAMS_RC_CBR },                       0, 0, VE, "rc" },
++#ifndef NVENC_NO_DEPRECATED_RC
+     { "vbr_minqp",    "Variable bitrate mode with MinQP (deprecated)", 0,         AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_VBR_MINQP) },            0, 0, VE, "rc" },
+     { "ll_2pass_quality", "Multi-pass optimized for image quality (deprecated)",
+                                                             0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_2_PASS_QUALITY) },       0, 0, VE, "rc" },
+@@ -98,6 +99,17 @@ static const AVOption options[] = {
+     { "cbr_ld_hq",    "Constant bitrate low delay high quality mode", 0,          AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ) },      0, 0, VE, "rc" },
+     { "cbr_hq",       "Constant bitrate high quality mode", 0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_CBR_HQ) },               0, 0, VE, "rc" },
+     { "vbr_hq",       "Variable bitrate high quality mode", 0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_VBR_HQ) },               0, 0, VE, "rc" },
++#else
++    { "vbr_minqp",    "Variable bitrate mode with MinQP (deprecated)", 0,         AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_VBR) },                  0, 0, VE, "rc" },
++    { "ll_2pass_quality", "Multi-pass optimized for image quality (deprecated)",
++                                                            0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_VBR) },                  0, 0, VE, "rc" },
++    { "ll_2pass_size", "Multi-pass optimized for constant frame size (deprecated)",
++                                                            0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_CBR) },                  0, 0, VE, "rc" },
++    { "vbr_2pass",    "Multi-pass variable bitrate mode (deprecated)", 0,         AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_VBR) },                  0, 0, VE, "rc" },
++    { "cbr_ld_hq",    "Constant bitrate low delay high quality mode", 0,          AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_CBR) },                  0, 0, VE, "rc" },
++    { "cbr_hq",       "Constant bitrate high quality mode", 0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_CBR) },                  0, 0, VE, "rc" },
++    { "vbr_hq",       "Variable bitrate high quality mode", 0,                    AV_OPT_TYPE_CONST, { .i64 = RCD(NV_ENC_PARAMS_RC_VBR) },                  0, 0, VE, "rc" },
++#endif
+     { "rc-lookahead", "Number of frames to look ahead for rate-control",
+                                                             OFFSET(rc_lookahead), AV_OPT_TYPE_INT,   { .i64 = 0 }, 0, INT_MAX, VE },
+     { "surfaces",     "Number of concurrent surfaces",      OFFSET(nb_surfaces),  AV_OPT_TYPE_INT,   { .i64 = 0 }, 0, MAX_REGISTERED_FRAMES, VE },
+-- 
+2.45.2
+

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=4.4.4
-REL=7
+REL=8
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::e80b380d595c809060f66f96a5d849511ef4a76a26b76eacf5778b94c3570309"
 CHKUPDATE="anitya::id=5405"


### PR DESCRIPTION
Topic Description
-----------------

- ffmpeg: fix AMD GPU AV1 hardware decoding with Mesa >= 24.1.4
    - Ref: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29400#note_2432971
    - Backport patches to fix build with ffnvcodec >= 12.1.

Package(s) Affected
-------------------

- ffmpeg: 4.4.4-8

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
