### PR TITLE
virtualbox (Oracle VM VirtualBox): update to 7.0.20

### DIFF
--- a/app-virtualization/virtualbox/spec
+++ b/app-virtualization/virtualbox/spec
@@ -1,12 +1,10 @@
-VER=7.0.16
+VER=7.0.20
 # Note: Sometimes Oracle seems to release fix-up tarballs.
-VBOX_REV=
-REL=1
-UBUNTU_VBOX_VER="162802~Ubuntu~jammy"
-SRCS="tbl::https://download.virtualbox.org/virtualbox/$VER/VirtualBox-${VER}${VBOX_REV}.tar.bz2 \
+UBUNTU_VBOX_VER="163906~Ubuntu~noble"
+SRCS="tbl::https://download.virtualbox.org/virtualbox/$VER/VirtualBox-${VER}.tar.bz2 \
       file::rename=virtualbox.deb::https://download.virtualbox.org/virtualbox/$VER/virtualbox-${VER%.*}_${VER}-${UBUNTU_VBOX_VER}_amd64.deb \
       file::rename=VBoxGuestAdditions.iso::https://download.virtualbox.org/virtualbox/$VER/VBoxGuestAdditions_$VER.iso"
-CHKSUMS="sha256::ca9062daf386a1810282503f83a7baa296ad46c4fc38aa988bca57f037e811fb \
-         sha256::32c88448e26a7a19d87beea5333b61edb6e6b5cc4f66f941f5c081085708e33e \
-         sha256::269dcd2217aedfea65daaa75317ffa32c0e3110e541f7dce74a8d16973eca0df"
+CHKSUMS="sha256::5cf5979bef66ebab3fcd495796b215a940e8a07c469d4bc56d064de44222dd02 \
+         sha256::f0aadadad827e02d73721e2d746a236bfa343598f0ae9b612a24960fe8b8d6ca \
+         sha256::4c7523fa6d17436e3b7788f62956674270572cfefa340d03111b85f8517d5981"
 CHKUPDATE="anitya::id=14449"


### PR DESCRIPTION
Topic Description
-----------------

- virtualbox: update to 7.0.20

Package(s) Affected
-------------------

- virtualbox: 7.0.20
- virtualbox-guest: 7.0.20

Security Update?
----------------

No

Build Order
-----------

```
#buildit virtualbox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
