### PR TITLE
google-chrome: security update to 127.0.6533.88

### DIFF
--- a/app-web/google-chrome/spec
+++ b/app-web/google-chrome/spec
@@ -1,4 +1,4 @@
-VER=127.0.6533.72
+VER=127.0.6533.88
 SRCS="file::rename=google-chrome-stable_current_amd64.deb::https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_$VER-1_amd64.deb"
-CHKSUMS="sha256::0e91182bfe9211a35f11af2ecc68578402d24b1b79d57f57e64b1a89af2cac98"
+CHKSUMS="sha256::d25f5c89d3453b475ccb35b2e270c3fce18540304b5f1f5a3d5aba8a80e4a8ad"
 CHKUPDATE="anitya::id=5349"


### PR DESCRIPTION
Topic Description
-----------------

- google-chrome: security update to 127.0.6533.88

Package(s) Affected
-------------------

- google-chrome: 127.0.6533.88

Security Update?
----------------

No

Build Order
-----------

```
#buildit google-chrome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
