### PR TITLE
dkcli: update to 0.3.1

### DIFF
--- a/app-admin/dkcli/spec
+++ b/app-admin/dkcli/spec
@@ -1,4 +1,4 @@
-VER=0.1.0
+VER=0.3.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/dkcli"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373533"


### PR DESCRIPTION
Topic Description
-----------------

- dkcli: update to 0.3.1
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- dkcli: 0.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dkcli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
