### PR TITLE
layer-shell-qt: rebuild for Qt 5 update

### DIFF
--- a/desktop-kde/layer-shell-qt/spec
+++ b/desktop-kde/layer-shell-qt/spec
@@ -1,4 +1,5 @@
 VER=5.27.11
+REL=1
 SRCS="https://download.kde.org/stable/plasma/$VER/layer-shell-qt-$VER.tar.xz"
 CHKSUMS="sha256::f4c321091619c9aeffe9e3568ff22ba4434538dcb3e89e6e23f5950d1e76d350"
 CHKUPDATE="anitya::id=8761"

--- a/groups/qt5-rebuilds
+++ b/groups/qt5-rebuilds
@@ -2,3 +2,4 @@ app-i18n/fcitx-qt5
 app-i18n/fcitx5-qt
 app-creativity/lmms
 app-web/telegram-desktop
+layer-shell-qt


### PR DESCRIPTION
Topic Description
-----------------

- qt5-rebuilds: add layer-shell-qt
- layer-shell-qt: rebuild for Qt 5 update
    KDE session greeters currently can not display anything. They always
    SIGSEGV within layer-shell-qt. Rebuilding seems to fix this problem, as
    the lock screen, logout dialog and SDDM greeter now works perfectly.

Package(s) Affected
-------------------

- layer-shell-qt: 5.27.11-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit layer-shell-qt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
