### PR TITLE
deploykit-backend: update to 0.6.5

### DIFF
--- a/app-admin/deploykit-backend/spec
+++ b/app-admin/deploykit-backend/spec
@@ -1,4 +1,4 @@
-VER=0.6.4
+VER=0.6.5
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-backend/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371972"


### PR DESCRIPTION
Topic Description
-----------------

- deploykit-backend: update to 0.6.5
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- deploykit-backend: 0.6.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-backend
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
