### PR TITLE
btrfs-progs: update to 6.10

### DIFF
--- a/app-admin/btrfs-progs/spec
+++ b/app-admin/btrfs-progs/spec
@@ -1,4 +1,4 @@
-VER=6.9.2
+VER=6.10
 SRCS="https://www.kernel.org/pub/linux/kernel/people/kdave/btrfs-progs/btrfs-progs-v$VER.tar.xz"
-CHKSUMS="sha256::43865bb272dc0ab2585de3605434d81ba217578f0897bf700cd36c14ac40652a"
+CHKSUMS="sha256::3382a84e3fcfe1ffdea07a61ab3f4e86665d38fa35f1f34548d5df867423e0df"
 CHKUPDATE="anitya::id=227"


### PR DESCRIPTION
Topic Description
-----------------

- btrfs-progs: update to 6.10
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- btrfs-progs: 6.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit btrfs-progs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
