### PR TITLE
yazi: update to 0.3.0

### DIFF
--- a/app-utils/yazi/autobuild/beyond
+++ b/app-utils/yazi/autobuild/beyond
@@ -2,14 +2,23 @@ abinfo "Installing completions ..."
 mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions
 cp -v "$SRCDIR"/yazi-boot/completions/yazi.bash \
         "$PKGDIR"/usr/share/bash-completion/completions/yazi.bash
+cp -v "$SRCDIR"/yazi-cli/completions/ya.bash \
+        "$PKGDIR"/usr/share/bash-completion/completions/ya.bash
 
-mkdir -pv "$PKGDIR"/usr/share/fish/completions
+
+mkdir -pv "$PKGDIR"/usr/share/fish/vendor_completions.d
 cp -v "$SRCDIR"/yazi-boot/completions/yazi.fish \
-        "$PKGDIR"/usr/share/fish/completions/yazi.fish
+        "$PKGDIR"/usr/share/fish/vendor_completions.d/yazi.fish
+cp -v "$SRCDIR"/yazi-cli/completions/ya.fish \
+        "$PKGDIR"/usr/share/fish/vendor_completions.d/ya.fish
+
 
 mkdir -pv "$PKGDIR"/usr/share/zsh/site-functions
 cp -v "$SRCDIR"/yazi-boot/completions/_yazi \
 	"$PKGDIR"/usr/share/zsh/site-functions/_yazi
+cp -v "$SRCDIR"/yazi-cli/completions/_ya \
+        "$PKGDIR"/usr/share/zsh/site-functions/_ya
+
 
 abinfo "Installing .desktop file and icons ..."
 for RES in 16 24 32 48 64 128 256; do

--- a/app-utils/yazi/autobuild/defines
+++ b/app-utils/yazi/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME="yazi"
 PKGDES="A file manager for the terminal"
 PKGDEP="glibc gcc-runtime"
-PKGRECOM="jq ffmpegthumbnailer 7-zip poppler fd ripgrep fzf zoxide"
+PKGRECOM="jq ffmpegthumbnailer 7-zip poppler fd ripgrep fzf zoxide imagemagick"
 BUILDDEP="rustc imagemagick"
 PKGSEC=utils
 

--- a/app-utils/yazi/autobuild/defines
+++ b/app-utils/yazi/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME="yazi"
 PKGDES="A file manager for the terminal"
 PKGDEP="glibc gcc-runtime"
-PKGRECOM="jq ffmpegthumbnailer unar poppler fd ripgrep fzf zoxide"
+PKGRECOM="jq ffmpegthumbnailer 7-zip poppler fd ripgrep fzf zoxide"
 BUILDDEP="rustc imagemagick"
 PKGSEC=utils
 

--- a/app-utils/yazi/spec
+++ b/app-utils/yazi/spec
@@ -1,4 +1,4 @@
-VER=0.2.5
+VER=0.3.0
 SRCS="git::commit=tags/v$VER::https://github.com/sxyazi/yazi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370571"

--- a/app-utils/yazi/spec
+++ b/app-utils/yazi/spec
@@ -1,4 +1,4 @@
 VER=0.3.0
-SRCS="git::commit=tags/v$VER::https://github.com/sxyazi/yazi"
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/sxyazi/yazi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370571"


### PR DESCRIPTION
Topic Description
-----------------

- yazi: update to 0.3.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- yazi: 0.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit yazi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
