### PR TITLE
yazi: Replace unar with 7-zip, add ImageMagick as recommendation

### DIFF
--- a/app-utils/yazi/autobuild/defines
+++ b/app-utils/yazi/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME="yazi"
 PKGDES="A file manager for the terminal"
 PKGDEP="glibc gcc-runtime"
-PKGRECOM="jq ffmpegthumbnailer 7-zip poppler fd ripgrep fzf zoxide"
+PKGRECOM="jq ffmpegthumbnailer 7-zip poppler fd ripgrep fzf zoxide imagemagick"
 BUILDDEP="rustc imagemagick"
 PKGSEC=utils
 

--- a/app-utils/yazi/autobuild/defines
+++ b/app-utils/yazi/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME="yazi"
 PKGDES="A file manager for the terminal"
 PKGDEP="glibc gcc-runtime"
-PKGRECOM="jq ffmpegthumbnailer unar poppler fd ripgrep fzf zoxide"
+PKGRECOM="jq ffmpegthumbnailer 7-zip poppler fd ripgrep fzf zoxide"
 BUILDDEP="rustc imagemagick"
 PKGSEC=utils
 


### PR DESCRIPTION
Topic Description
-----------------

- yazi: Replace unar with 7-zip
- yazi: Add ImageMagick as recommendation

Package(s) Affected
-------------------

- yazi: 0.3.0

Security Update?
----------------

No

<!--
Build Order
-----------
-->

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

<!--
```
pkg1 pkg2 pkg3 ...
```
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
