### PR TITLE
firefox: fix AV1 playback bug using VAAPI

### DIFF
--- a/app-web/firefox/autobuild/patches/0001-Add-support-for-LoongArch64.patch
+++ b/app-web/firefox/autobuild/patches/0001-Add-support-for-LoongArch64.patch
@@ -1,7 +1,7 @@
 From f3a27a4821bc2dffd9f65a668821eb5e99df9608 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Sun, 22 Oct 2023 22:13:17 -0700
-Subject: [PATCH 01/11] Add support for LoongArch64
+Subject: [PATCH 01/12] Add support for LoongArch64
 
 Adapted from LoongArchLinux. Rebased to Firefox 122.0.0.
 
@@ -41,5 +41,5 @@ index 30f2907c72..e6645227a2 100644
  
  #include <zlib.h>
 -- 
-2.46.0.rc2.windows.1
+2.46.0
 

--- a/app-web/firefox/autobuild/patches/0002-feat-netwerk-declare-AOSC-OS-in-user-agent-string.patch
+++ b/app-web/firefox/autobuild/patches/0002-feat-netwerk-declare-AOSC-OS-in-user-agent-string.patch
@@ -1,7 +1,7 @@
 From 6374d601ddbc2e654b7f91446cf4bbf62e08a03f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 5 Apr 2024 22:52:21 +0800
-Subject: [PATCH 02/11] feat(netwerk): declare AOSC OS in user agent string
+Subject: [PATCH 02/12] feat(netwerk): declare AOSC OS in user agent string
 
 ---
  netwerk/protocol/http/nsHttpHandler.cpp | 2 ++
@@ -28,5 +28,5 @@ index 0ddb378e2b..df042350d7 100644
  #endif
    if (!mCompatDevice.IsEmpty()) {
 -- 
-2.46.0.rc2.windows.1
+2.46.0
 

--- a/app-web/firefox/autobuild/patches/0003-Enable-WebRTC-for-LoongArch.patch
+++ b/app-web/firefox/autobuild/patches/0003-Enable-WebRTC-for-LoongArch.patch
@@ -1,7 +1,7 @@
 From 21271679b418bc4a824f00a9ebd0cf9d32f3751e Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Tue, 21 Nov 2023 17:17:16 -0800
-Subject: [PATCH 03/11] Enable WebRTC for LoongArch
+Subject: [PATCH 03/12] Enable WebRTC for LoongArch
 
 Co-Authored-By: WANG Xuerui <xen0n@gentoo.org>
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
@@ -153,5 +153,5 @@ index a424446c7d..b68315241f 100644
          "mips64",
          "ppc",
 -- 
-2.46.0.rc2.windows.1
+2.46.0
 

--- a/app-web/firefox/autobuild/patches/0004-Fix-libyuv-build-with-LSX-LASX.patch
+++ b/app-web/firefox/autobuild/patches/0004-Fix-libyuv-build-with-LSX-LASX.patch
@@ -1,7 +1,7 @@
 From 9e991746b5dc9310be05996dd73455c5debc9fce Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Sun, 31 Dec 2023 13:16:33 +0800
-Subject: [PATCH 04/11] Fix libyuv build with LSX & LASX
+Subject: [PATCH 04/12] Fix libyuv build with LSX & LASX
 
 This is not of upstream quality, and will not be upstreamed as-is.
 This is only meant as a quick-and-dirty build fix for LoongArch early
@@ -396,5 +396,5 @@ index 9c1e16f22e..91221ff03c 100644
  }  // extern "C"
  }  // namespace libyuv
 -- 
-2.46.0.rc2.windows.1
+2.46.0
 

--- a/app-web/firefox/autobuild/patches/0005-Enable-VA-API-support-for-AMD-GPUs.patch
+++ b/app-web/firefox/autobuild/patches/0005-Enable-VA-API-support-for-AMD-GPUs.patch
@@ -1,7 +1,7 @@
 From 9c1acd153b0ae8e845c8660078206847f5a66723 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Tue, 14 Nov 2023 18:14:20 -0800
-Subject: [PATCH 05/11] Enable VA-API support for AMD GPUs
+Subject: [PATCH 05/12] Enable VA-API support for AMD GPUs
 
 ---
  widget/gtk/GfxInfo.cpp | 8 --------
@@ -27,5 +27,5 @@ index baf3fb452a..bd4a90605a 100644
      // FEATURE_HW_DECODED_VIDEO_ZERO_COPY - ALLOWLIST
      APPEND_TO_DRIVER_BLOCKLIST2(OperatingSystem::Linux, DeviceFamily::All,
 -- 
-2.46.0.rc2.windows.1
+2.46.0
 

--- a/app-web/firefox/autobuild/patches/0006-Keep-unsigned-32-bit-parameter-sign-extended-in-regi.patch
+++ b/app-web/firefox/autobuild/patches/0006-Keep-unsigned-32-bit-parameter-sign-extended-in-regi.patch
@@ -1,7 +1,7 @@
 From 86171d5beb97ff4d63b3b637892d84cc1689e03e Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Fri, 8 Mar 2024 17:24:55 +0800
-Subject: [PATCH 06/11] Keep unsigned 32-bit parameter sign-extended in
+Subject: [PATCH 06/12] Keep unsigned 32-bit parameter sign-extended in
  register.
 
 On riscv64, 32-bit value in 64-bit register should be sign-extended, even
@@ -28,5 +28,5 @@ index ddd6692156..ee2f7ff767 100644
          case nsXPTType::T_U64:
            value = s->val.u64;
 -- 
-2.46.0.rc2.windows.1
+2.46.0
 

--- a/app-web/firefox/autobuild/patches/0007-Implement-SummarizeTrapInstruction-for-MIPS64.patch
+++ b/app-web/firefox/autobuild/patches/0007-Implement-SummarizeTrapInstruction-for-MIPS64.patch
@@ -1,7 +1,7 @@
 From 743cc1e9da35ace2d2c15b64a3be0d2833e8fc96 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <the@salted.fish>
 Date: Tue, 28 Nov 2023 21:44:16 -0800
-Subject: [PATCH 07/11] Implement SummarizeTrapInstruction for MIPS64
+Subject: [PATCH 07/12] Implement SummarizeTrapInstruction for MIPS64
 
 Co-Authored-By: Zhao Jiazhong <zhaojiazhong-hf@loongson.cn>
 ---
@@ -209,5 +209,5 @@ index 99834d6740..c4b449d79d 100644
  
  #  elif defined(JS_CODEGEN_NONE)
 -- 
-2.46.0.rc2.windows.1
+2.46.0
 

--- a/app-web/firefox/autobuild/patches/0008-Bug-1855960-MIPS64-Make-some-assembler-routines-retu.patch
+++ b/app-web/firefox/autobuild/patches/0008-Bug-1855960-MIPS64-Make-some-assembler-routines-retu.patch
@@ -1,7 +1,7 @@
 From 71ef00c60fc0fd2c7b1537cb8a59d626d9c91cba Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <the@salted.fish>
 Date: Wed, 29 Nov 2023 23:14:38 +0000
-Subject: [PATCH 08/11] Bug 1855960 - [MIPS64] Make some assembler routines
+Subject: [PATCH 08/12] Bug 1855960 - [MIPS64] Make some assembler routines
  return FaultingCodeOffset. r=jseward
 
 Differential Revision: https://phabricator.services.mozilla.com/D194834
@@ -1077,5 +1077,5 @@ index 24c76a65a7..95f127151d 100644
  
    void storeUnalignedFloat32(const wasm::MemoryAccessDesc& access,
 -- 
-2.46.0.rc2.windows.1
+2.46.0
 

--- a/app-web/firefox/autobuild/patches/0009-Add-missing-loongarch-lsx-code-for-libpng.patch
+++ b/app-web/firefox/autobuild/patches/0009-Add-missing-loongarch-lsx-code-for-libpng.patch
@@ -1,7 +1,7 @@
 From 52c3816b97e244ee2b4008b68bdb03bbb1e7685a Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Tue, 14 May 2024 16:36:09 -0700
-Subject: [PATCH 09/11] Add missing loongarch lsx code for libpng
+Subject: [PATCH 09/12] Add missing loongarch lsx code for libpng
 
 ---
  .../libpng/loongarch/filter_lsx_intrinsics.c  | 412 ++++++++++++++++++
@@ -550,5 +550,5 @@ index 1cbb828436..7d50038c28 100644
  #define PNG_PROGRESSIVE_READ_SUPPORTED
  #define PNG_READ_APNG_SUPPORTED
 -- 
-2.46.0.rc2.windows.1
+2.46.0
 

--- a/app-web/firefox/autobuild/patches/0010-Revert-MoveEmitter-mips64.cpp-part-in-Bug-1870747-Us.patch
+++ b/app-web/firefox/autobuild/patches/0010-Revert-MoveEmitter-mips64.cpp-part-in-Bug-1870747-Us.patch
@@ -1,7 +1,7 @@
 From 1359cd110eb8dac410cfa4dd067806a35af853f4 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 24 Jul 2024 09:14:29 +0800
-Subject: [PATCH 10/11] Revert MoveEmitter-mips64.cpp part in "Bug 1870747: Use
+Subject: [PATCH 10/12] Revert MoveEmitter-mips64.cpp part in "Bug 1870747: Use
  ABIType instead of MoveOp::Type for callWithABI r=rhunt"
 
 This reverts part of commit 1e5b0f3713070c2d43a548ae0f9e3c97e64004f7.
@@ -32,5 +32,5 @@ index 53ee23820a..70217a37f8 100644
          FloatRegister temp = ScratchDoubleReg;
          masm.loadDouble(cycleSlot(slotId), temp);
 -- 
-2.46.0.rc2.windows.1
+2.46.0
 

--- a/app-web/firefox/autobuild/patches/0011-Add-move8ZeroExtend-for-mips.patch
+++ b/app-web/firefox/autobuild/patches/0011-Add-move8ZeroExtend-for-mips.patch
@@ -1,7 +1,7 @@
 From a376b435d137444176603807b8c0ffc12b9ff412 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Wed, 24 Jul 2024 14:24:59 +0800
-Subject: [PATCH 11/11] Add `move8ZeroExtend` for mips
+Subject: [PATCH 11/12] Add `move8ZeroExtend` for mips
 
 ---
  js/src/jit/mips-shared/MacroAssembler-mips-shared-inl.h | 4 ++++
@@ -23,5 +23,5 @@ index f92b4fd675..efcef9314d 100644
    ma_seb(dest, src);
  }
 -- 
-2.46.0.rc2.windows.1
+2.46.0
 

--- a/app-web/firefox/autobuild/patches/0012-Bug-1902227-Linux-VA-API-Backport-AV1-VA-API-playbac.patch
+++ b/app-web/firefox/autobuild/patches/0012-Bug-1902227-Linux-VA-API-Backport-AV1-VA-API-playbac.patch
@@ -1,0 +1,171 @@
+From 3b47b13144597e17015bb2123dd9e18012b47b20 Mon Sep 17 00:00:00 2001
+From: stransky <stransky@redhat.com>
+Date: Thu, 18 Jul 2024 10:01:27 +0000
+Subject: [PATCH 12/12] Bug 1902227 [Linux/VA-API] Backport AV1/VA-API playback
+ fix for AMD/mesa > 24.0.7 r=padenot
+
+Backport of https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29400
+Allows to use multiple slices for AV1 VA-API decode.
+
+Differential Revision: https://phabricator.services.mozilla.com/D216919
+---
+ media/ffvpx/libavcodec/vaapi_av1.c    | 47 +++++++++++++++++++--------
+ media/ffvpx/libavcodec/vaapi_decode.c |  3 +-
+ media/ffvpx/libavcodec/vaapi_decode.h |  1 +
+ media/ffvpx/libavcodec/vaapi_vp8.c    |  2 +-
+ media/ffvpx/libavcodec/vaapi_vp9.c    |  2 +-
+ 5 files changed, 38 insertions(+), 17 deletions(-)
+
+diff --git a/media/ffvpx/libavcodec/vaapi_av1.c b/media/ffvpx/libavcodec/vaapi_av1.c
+index 1f9a6071ba..ea8dd4d93d 100644
+--- a/media/ffvpx/libavcodec/vaapi_av1.c
++++ b/media/ffvpx/libavcodec/vaapi_av1.c
+@@ -19,6 +19,7 @@
+  */
+ 
+ #include "libavutil/frame.h"
++#include "libavutil/mem.h"
+ #include "hwaccel_internal.h"
+ #include "vaapi_decode.h"
+ #include "internal.h"
+@@ -42,6 +43,9 @@ typedef struct VAAPIAV1DecContext {
+     */
+     VAAPIAV1FrameRef ref_tab[AV1_NUM_REF_FRAMES];
+     AVFrame *tmp_frame;
++
++    int nb_slice_params;
++    VASliceParameterBufferAV1 *slice_params;
+ } VAAPIAV1DecContext;
+ 
+ static VASurfaceID vaapi_av1_surface_id(AV1Frame *vf)
+@@ -97,6 +101,8 @@ static int vaapi_av1_decode_uninit(AVCodecContext *avctx)
+     for (int i = 0; i < FF_ARRAY_ELEMS(ctx->ref_tab); i++)
+         av_frame_free(&ctx->ref_tab[i].frame);
+ 
++    av_freep(&ctx->slice_params);
++
+     return ff_vaapi_decode_uninit(avctx);
+ }
+ 
+@@ -393,13 +399,24 @@ static int vaapi_av1_decode_slice(AVCodecContext *avctx,
+ {
+     const AV1DecContext *s = avctx->priv_data;
+     VAAPIDecodePicture *pic = s->cur_frame.hwaccel_picture_private;
+-    VASliceParameterBufferAV1 slice_param;
+-    int err = 0;
++    VAAPIAV1DecContext *ctx = avctx->internal->hwaccel_priv_data;
++    int err, nb_params;
++
++    nb_params = s->tg_end - s->tg_start + 1;
++    if (ctx->nb_slice_params < nb_params) {
++        ctx->slice_params = av_realloc_array(ctx->slice_params,
++                                             nb_params,
++                                             sizeof(*ctx->slice_params));
++        if (!ctx->slice_params) {
++            ctx->nb_slice_params = 0;
++            err = AVERROR(ENOMEM);
++            goto fail;
++        }
++        ctx->nb_slice_params = nb_params;
++    }
+ 
+     for (int i = s->tg_start; i <= s->tg_end; i++) {
+-        memset(&slice_param, 0, sizeof(VASliceParameterBufferAV1));
+-
+-        slice_param = (VASliceParameterBufferAV1) {
++        ctx->slice_params[i - s->tg_start] = (VASliceParameterBufferAV1) {
+             .slice_data_size   = s->tile_group_info[i].tile_size,
+             .slice_data_offset = s->tile_group_info[i].tile_offset,
+             .slice_data_flag   = VA_SLICE_DATA_FLAG_ALL,
+@@ -408,18 +425,20 @@ static int vaapi_av1_decode_slice(AVCodecContext *avctx,
+             .tg_start          = s->tg_start,
+             .tg_end            = s->tg_end,
+         };
+-
+-        err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &slice_param,
+-                                                sizeof(VASliceParameterBufferAV1),
+-                                                buffer,
+-                                                size);
+-        if (err) {
+-            ff_vaapi_decode_cancel(avctx, pic);
+-            return err;
+-        }
+     }
+ 
++    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, ctx->slice_params, nb_params,
++                                            sizeof(VASliceParameterBufferAV1),
++                                            buffer,
++                                            size);
++    if (err)
++        goto fail;
++
+     return 0;
++
++fail:
++    ff_vaapi_decode_cancel(avctx, pic);
++    return err;
+ }
+ 
+ const FFHWAccel ff_av1_vaapi_hwaccel = {
+diff --git a/media/ffvpx/libavcodec/vaapi_decode.c b/media/ffvpx/libavcodec/vaapi_decode.c
+index 5665639dd7..f3078ffe77 100644
+--- a/media/ffvpx/libavcodec/vaapi_decode.c
++++ b/media/ffvpx/libavcodec/vaapi_decode.c
+@@ -63,6 +63,7 @@ int ff_vaapi_decode_make_param_buffer(AVCodecContext *avctx,
+ int ff_vaapi_decode_make_slice_buffer(AVCodecContext *avctx,
+                                       VAAPIDecodePicture *pic,
+                                       const void *params_data,
++                                      int nb_params,
+                                       size_t params_size,
+                                       const void *slice_data,
+                                       size_t slice_size)
+@@ -88,7 +89,7 @@ int ff_vaapi_decode_make_slice_buffer(AVCodecContext *avctx,
+ 
+     vas = vaCreateBuffer(ctx->hwctx->display, ctx->va_context,
+                          VASliceParameterBufferType,
+-                         params_size, 1, (void*)params_data,
++                         params_size, nb_params, (void*)params_data,
+                          &pic->slice_buffers[index]);
+     if (vas != VA_STATUS_SUCCESS) {
+         av_log(avctx, AV_LOG_ERROR, "Failed to create slice "
+diff --git a/media/ffvpx/libavcodec/vaapi_decode.h b/media/ffvpx/libavcodec/vaapi_decode.h
+index 6beda14e52..702171e108 100644
+--- a/media/ffvpx/libavcodec/vaapi_decode.h
++++ b/media/ffvpx/libavcodec/vaapi_decode.h
+@@ -73,6 +73,7 @@ int ff_vaapi_decode_make_param_buffer(AVCodecContext *avctx,
+ int ff_vaapi_decode_make_slice_buffer(AVCodecContext *avctx,
+                                       VAAPIDecodePicture *pic,
+                                       const void *params_data,
++                                      int nb_params,
+                                       size_t params_size,
+                                       const void *slice_data,
+                                       size_t slice_size);
+diff --git a/media/ffvpx/libavcodec/vaapi_vp8.c b/media/ffvpx/libavcodec/vaapi_vp8.c
+index 31137a45bd..66fdde1f39 100644
+--- a/media/ffvpx/libavcodec/vaapi_vp8.c
++++ b/media/ffvpx/libavcodec/vaapi_vp8.c
+@@ -209,7 +209,7 @@ static int vaapi_vp8_decode_slice(AVCodecContext *avctx,
+     for (i = 0; i < 8; i++)
+         sp.partition_size[i+1] = s->coeff_partition_size[i];
+ 
+-    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &sp, sizeof(sp), data, data_size);
++    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &sp, 1, sizeof(sp), data, data_size);
+     if (err)
+         goto fail;
+ 
+diff --git a/media/ffvpx/libavcodec/vaapi_vp9.c b/media/ffvpx/libavcodec/vaapi_vp9.c
+index 9dc7d5e72b..ff11022db7 100644
+--- a/media/ffvpx/libavcodec/vaapi_vp9.c
++++ b/media/ffvpx/libavcodec/vaapi_vp9.c
+@@ -158,7 +158,7 @@ static int vaapi_vp9_decode_slice(AVCodecContext *avctx,
+     }
+ 
+     err = ff_vaapi_decode_make_slice_buffer(avctx, pic,
+-                                            &slice_param, sizeof(slice_param),
++                                            &slice_param, 1, sizeof(slice_param),
+                                             buffer, size);
+     if (err) {
+         ff_vaapi_decode_cancel(avctx, pic);
+-- 
+2.46.0
+

--- a/app-web/firefox/spec
+++ b/app-web/firefox/spec
@@ -1,4 +1,5 @@
 VER=128.0.3
+REL=1
 CHKUPDATE="anitya::id=5506"
 SRCS="tbl::https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz \
       file::rename=ach.xpi::https://archive.mozilla.org/pub/firefox/releases/$VER/linux-x86_64/xpi/ach.xpi \


### PR DESCRIPTION
Topic Description
-----------------

- firefox: update to 128.0.3-1, fix AV1 playback bug using VAAPI

Package(s) Affected
-------------------

- firefox: 128.0.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit firefox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
