### PR TITLE
mesa (Mesa 3D Graphics Library): update to 24.1.5

### DIFF
--- a/runtime-display/mesa/autobuild/patches/0001-meson-set-default-drivers-for-ppc-ppc64.patch
+++ b/runtime-display/mesa/autobuild/patches/0001-meson-set-default-drivers-for-ppc-ppc64.patch
@@ -1,7 +1,7 @@
-From 3b16b3a424cbdeb022c7329eaf55ab9517a2c602 Mon Sep 17 00:00:00 2001
+From 1cc1cb3b5893fa6ba91fe79aa25a28743114c871 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 20 Jun 2024 15:25:42 +0000
-Subject: [PATCH 01/25] meson: set default drivers for ppc, ppc64
+Subject: [PATCH 01/26] meson: set default drivers for ppc, ppc64
 
 Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29811>
 ---
@@ -9,7 +9,7 @@ Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29811>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 7b9a0f06bd6..e7fce68f9c0 100644
+index dee53381935..68c04ff38a4 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -140,7 +140,7 @@ system_has_kms_drm = ['openbsd', 'netbsd', 'freebsd', 'gnu/kfreebsd', 'dragonfly
@@ -31,5 +31,5 @@ index 7b9a0f06bd6..e7fce68f9c0 100644
          'r300', 'r600', 'radeonsi', 'nouveau', 'virgl', 'swrast', 'zink'
        ]
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0002-meson-set-default-Vulkan-drivers-for-ppc-ppc64.patch
+++ b/runtime-display/mesa/autobuild/patches/0002-meson-set-default-Vulkan-drivers-for-ppc-ppc64.patch
@@ -1,14 +1,14 @@
-From c22d36066c6268dad3ac328dd14cc2955d60219b Mon Sep 17 00:00:00 2001
+From bf7cadf01a553442373ee65d490106cf27a33324 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Fri, 21 Jun 2024 11:26:38 +0800
-Subject: [PATCH 02/25] meson: set default Vulkan drivers for ppc, ppc64
+Subject: [PATCH 02/26] meson: set default Vulkan drivers for ppc, ppc64
 
 ---
  meson.build | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index e7fce68f9c0..6b84fe69d5d 100644
+index 68c04ff38a4..bc38e845194 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -224,7 +224,7 @@ if _vulkan_drivers.contains('auto')
@@ -21,5 +21,5 @@ index e7fce68f9c0..6b84fe69d5d 100644
      elif ['loongarch64'].contains(host_machine.cpu_family())
        _vulkan_drivers = ['amd', 'swrast']
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0003-fix-meson.build-more-Gallium-Vulkan-drivers-for-on-a.patch
+++ b/runtime-display/mesa/autobuild/patches/0003-fix-meson.build-more-Gallium-Vulkan-drivers-for-on-a.patch
@@ -1,7 +1,7 @@
-From d9fd9482e34af409a2c79bf91ae05be01e0f549b Mon Sep 17 00:00:00 2001
+From 71b26e87e31f3405c46b9c4eb308909080e39dd8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 20 Jun 2024 23:18:13 +0800
-Subject: [PATCH 03/25] fix(meson.build): more Gallium, Vulkan drivers for on
+Subject: [PATCH 03/26] fix(meson.build): more Gallium, Vulkan drivers for on
  all architectures
 
 - This is a pre-upstream patch, I will split this into multiple ones to
@@ -19,7 +19,7 @@ Subject: [PATCH 03/25] fix(meson.build): more Gallium, Vulkan drivers for on
  1 file changed, 19 insertions(+), 8 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 6b84fe69d5d..1f676a4f3fc 100644
+index bc38e845194..b4d5e2bc0dc 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -144,21 +144,23 @@ if gallium_drivers.contains('auto')
@@ -78,5 +78,5 @@ index 6b84fe69d5d..1f676a4f3fc 100644
        error('Unknown architecture @0@. Please pass -Dvulkan-drivers to set driver options. Patches gladly accepted to fix this.'.format(
              host_machine.cpu_family()))
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0004-gallivm-add-lp_context_ref-for-combine-usage-of-LLVM.patch
+++ b/runtime-display/mesa/autobuild/patches/0004-gallivm-add-lp_context_ref-for-combine-usage-of-LLVM.patch
@@ -1,7 +1,7 @@
-From 7ca8984256b10372b8e62d23401838a0984743f4 Mon Sep 17 00:00:00 2001
+From 65b265375f4982cbcf9a94dcf70857e7d0ad06c7 Mon Sep 17 00:00:00 2001
 From: Yonggang Luo <luoyonggang@gmail.com>
 Date: Wed, 19 Jun 2024 16:35:39 +1000
-Subject: [PATCH 04/25] gallivm: add lp_context_ref for combine usage of
+Subject: [PATCH 04/26] gallivm: add lp_context_ref for combine usage of
  LLVMContextSetOpaquePointers
 
 Reviewed-by: Dave Airlie <airlied@redhat.com>
@@ -599,5 +599,5 @@ index 6259b517ddd..333bfd14eba 100644
     struct util_dynarray gallivms;
  };
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0005-gallivm-move-ppc-denorm-disable-to-inline.patch
+++ b/runtime-display/mesa/autobuild/patches/0005-gallivm-move-ppc-denorm-disable-to-inline.patch
@@ -1,7 +1,7 @@
-From e793aa4b87fc8f101a1099f2c687f473a91acc05 Mon Sep 17 00:00:00 2001
+From 18a926c9ca1ddac5dd224b5d7d75c65bc0dc6e21 Mon Sep 17 00:00:00 2001
 From: Dave Airlie <airlied@redhat.com>
 Date: Fri, 21 Jun 2024 12:13:42 +1000
-Subject: [PATCH 05/25] gallivm: move ppc denorm disable to inline
+Subject: [PATCH 05/26] gallivm: move ppc denorm disable to inline
 
 This just puts it out of the way
 
@@ -92,5 +92,5 @@ index f53702f17a1..d29837eeb0e 100644
  }
  #endif
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0006-gallivm-split-some-code-out-from-init-module.patch
+++ b/runtime-display/mesa/autobuild/patches/0006-gallivm-split-some-code-out-from-init-module.patch
@@ -1,7 +1,7 @@
-From b917bb5352865f2e70e071a0a3adf4bbf7db37da Mon Sep 17 00:00:00 2001
+From 59671a7a7af5a465d9e0e5d72de184b018ddf59c Mon Sep 17 00:00:00 2001
 From: Dave Airlie <airlied@redhat.com>
 Date: Fri, 21 Jun 2024 13:13:18 +1000
-Subject: [PATCH 06/25] gallivm: split some code out from init module.
+Subject: [PATCH 06/26] gallivm: split some code out from init module.
 
 In order to introduce orc some code should be split out where
 it can be reused.
@@ -300,5 +300,5 @@ index 35ad5247b4c..a67f71ef35a 100644
      'gallivm/lp_bld_intr.c',
      'gallivm/lp_bld_intr.h',
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0007-gallivm-make-lp_bld_coro.h-c-include-safe.patch
+++ b/runtime-display/mesa/autobuild/patches/0007-gallivm-make-lp_bld_coro.h-c-include-safe.patch
@@ -1,7 +1,7 @@
-From 6f314b5044a2f690fd4957e6c673768b5ad21ebc Mon Sep 17 00:00:00 2001
+From 5a89f0224d8dc7ce2be56dfe5ae65a49d34d0df2 Mon Sep 17 00:00:00 2001
 From: Dave Airlie <airlied@redhat.com>
 Date: Mon, 24 Jun 2024 13:38:32 +1000
-Subject: [PATCH 07/25] gallivm: make lp_bld_coro.h c++ include safe.
+Subject: [PATCH 07/26] gallivm: make lp_bld_coro.h c++ include safe.
 
 Reviewed-By: Mike Blumenkrantz <michael.blumenkrantz@gmail.com>
 Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29869>
@@ -34,5 +34,5 @@ index 2fbaecc3152..5421d0926ca 100644
 +
  #endif
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0008-gallivm-export-target-init-code-for-orc-jit-to-reuse.patch
+++ b/runtime-display/mesa/autobuild/patches/0008-gallivm-export-target-init-code-for-orc-jit-to-reuse.patch
@@ -1,7 +1,7 @@
-From 5ab7d184222d8bafa876a08197b23c5ba9cc0f04 Mon Sep 17 00:00:00 2001
+From a455b83147d6fbd1a69f44fbb673281e92d49ca9 Mon Sep 17 00:00:00 2001
 From: Dave Airlie <airlied@redhat.com>
 Date: Mon, 24 Jun 2024 13:38:55 +1000
-Subject: [PATCH 08/25] gallivm: export target init code for orc-jit to reuse
+Subject: [PATCH 08/26] gallivm: export target init code for orc-jit to reuse
 
 It doesn't need the wrapper since it already has a singleton
 
@@ -13,7 +13,7 @@ Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29869>
  2 files changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
-index 817be7b5300..f359682bad7 100644
+index fa9b4b75fdb..fc8b374a98f 100644
 --- a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
 +++ b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
 @@ -108,7 +108,7 @@ static LLVMEnsureMultithreaded lLVMEnsureMultithreaded;
@@ -48,5 +48,5 @@ index fa0ce90162e..3506a15d882 100644
  extern int
  lp_build_create_jit_compiler_for_module(LLVMExecutionEngineRef *OutJIT,
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0009-gallivm-split-out-generating-LLVM-Mattrs.patch
+++ b/runtime-display/mesa/autobuild/patches/0009-gallivm-split-out-generating-LLVM-Mattrs.patch
@@ -1,7 +1,7 @@
-From 9e10358b175bc74fb71133177f8eb22a166dce13 Mon Sep 17 00:00:00 2001
+From 16a8eb1edf5158760081bc84537fabc606deac5a Mon Sep 17 00:00:00 2001
 From: Dave Airlie <airlied@redhat.com>
 Date: Mon, 24 Jun 2024 13:18:46 +1000
-Subject: [PATCH 09/25] gallivm: split out generating LLVM Mattrs
+Subject: [PATCH 09/26] gallivm: split out generating LLVM Mattrs
 
 This will be reused in the orc jit
 
@@ -13,7 +13,7 @@ Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29869>
  2 files changed, 84 insertions(+), 64 deletions(-)
 
 diff --git a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
-index f359682bad7..95a8a6c6a08 100644
+index fc8b374a98f..f3c10652ed6 100644
 --- a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
 +++ b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
 @@ -320,69 +320,9 @@ public:
@@ -199,5 +199,5 @@ index 3506a15d882..302f2d445da 100644
  #endif
  
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0010-gallivm-create-a-pass-manager-wrapper.patch
+++ b/runtime-display/mesa/autobuild/patches/0010-gallivm-create-a-pass-manager-wrapper.patch
@@ -1,7 +1,7 @@
-From 059c3b4e26fdc6b2d727e167864ad7920ff5c759 Mon Sep 17 00:00:00 2001
+From 98d7ef301fa42cce4881324289fd78b5a13dd855 Mon Sep 17 00:00:00 2001
 From: Dave Airlie <airlied@redhat.com>
 Date: Thu, 20 Jun 2024 15:05:10 +1000
-Subject: [PATCH 10/25] gallivm: create a pass manager wrapper.
+Subject: [PATCH 10/26] gallivm: create a pass manager wrapper.
 
 With the introduction of the orc jit and looking at the mess that
 is integrating with LLVM pass mgmt, encapsulate the passmgr
@@ -607,5 +607,5 @@ index a67f71ef35a..0f23a7889db 100644
      'gallivm/lp_bld_printf.h',
      'gallivm/lp_bld_quad.c',
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0011-llvmpipe-add-gallivm_add_global_mapping.patch
+++ b/runtime-display/mesa/autobuild/patches/0011-llvmpipe-add-gallivm_add_global_mapping.patch
@@ -1,7 +1,7 @@
-From e247f4be0b6d975229f458a799c23b3d618926cd Mon Sep 17 00:00:00 2001
+From 5cf6144b22aec8469b8bfa01175768b7baa6d721 Mon Sep 17 00:00:00 2001
 From: Yukari Chiba <i@0x7f.cc>
 Date: Wed, 19 Jun 2024 16:22:13 +0800
-Subject: [PATCH 11/25] llvmpipe: add gallivm_add_global_mapping
+Subject: [PATCH 11/26] llvmpipe: add gallivm_add_global_mapping
 
 Reviewed-by: Dave Airlie <airlied@redhat.com>
 Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29796>
@@ -75,5 +75,5 @@ index 4fb99ad8184..d1549ee71b8 100644
  
  func_pointer
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0012-llvmpipe-make-unnamed-global-have-internal-linkage.patch
+++ b/runtime-display/mesa/autobuild/patches/0012-llvmpipe-make-unnamed-global-have-internal-linkage.patch
@@ -1,7 +1,7 @@
-From 158f4a58f84b096ef96ef23ff086608a974597e4 Mon Sep 17 00:00:00 2001
+From b50d25b435ad3045dd1ae8efb5ede338acce2829 Mon Sep 17 00:00:00 2001
 From: Yukari Chiba <i@0x7f.cc>
 Date: Wed, 19 Jun 2024 16:22:45 +0800
-Subject: [PATCH 12/25] llvmpipe: make unnamed global have internal linkage
+Subject: [PATCH 12/26] llvmpipe: make unnamed global have internal linkage
 
 Reviewed-by: Dave Airlie <airlied@redhat.com>
 Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29796>
@@ -22,5 +22,5 @@ index 0e1e6ebcaba..89b1b6816c0 100644
  
        if (key->multisample && key->coverage_samples == 4) {
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0013-util-detect-RISC-V-architecture.patch
+++ b/runtime-display/mesa/autobuild/patches/0013-util-detect-RISC-V-architecture.patch
@@ -1,7 +1,7 @@
-From 3a79d796b66ca8a40256885415210380fa67fbf3 Mon Sep 17 00:00:00 2001
+From dcc49942d672154bb70d1c7a05a281066bb71f57 Mon Sep 17 00:00:00 2001
 From: Yukari Chiba <i@0x7f.cc>
 Date: Tue, 25 Jun 2024 13:44:40 +0800
-Subject: [PATCH 13/25] util: detect RISC-V architecture
+Subject: [PATCH 13/26] util: detect RISC-V architecture
 
 ---
  src/util/detect_arch.h | 23 +++++++++++++++++++++++
@@ -47,5 +47,5 @@ index 83e4784465b..35385a02b49 100644
 +
  #endif /* UTIL_DETECT_ARCH_H_ */
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0014-gallivm-add-riscv-support-to-the-mattrs-setting-code.patch
+++ b/runtime-display/mesa/autobuild/patches/0014-gallivm-add-riscv-support-to-the-mattrs-setting-code.patch
@@ -1,14 +1,14 @@
-From bb6f61c391d9a265748ec8c8d2a1ce9e76de906f Mon Sep 17 00:00:00 2001
+From ca992e86e7ac182013d1f906b4aa0259a7d8e466 Mon Sep 17 00:00:00 2001
 From: Yukari Chiba <i@0x7f.cc>
 Date: Tue, 25 Jun 2024 13:46:29 +0800
-Subject: [PATCH 14/25] gallivm: add riscv support to the mattrs setting code
+Subject: [PATCH 14/26] gallivm: add riscv support to the mattrs setting code
 
 ---
  src/gallium/auxiliary/gallivm/lp_bld_misc.cpp | 8 ++++++++
  1 file changed, 8 insertions(+)
 
 diff --git a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
-index 95a8a6c6a08..f0e55bc4d46 100644
+index f3c10652ed6..4a169c84b9e 100644
 --- a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
 +++ b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
 @@ -406,6 +406,14 @@ lp_build_fill_mattrs(std::vector<std::string> &MAttrs)
@@ -27,5 +27,5 @@ index 95a8a6c6a08..f0e55bc4d46 100644
  
  void
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0015-llvmpipe-add-function-name-to-gallivm_jit_function.patch
+++ b/runtime-display/mesa/autobuild/patches/0015-llvmpipe-add-function-name-to-gallivm_jit_function.patch
@@ -1,7 +1,7 @@
-From 9bba2df1d3f1f28f9cb593391fdb1142240079d6 Mon Sep 17 00:00:00 2001
+From 1b46e200ca1c40f94b94c0abeccf197b6924cfea Mon Sep 17 00:00:00 2001
 From: Yukari Chiba <i@0x7f.cc>
 Date: Tue, 25 Jun 2024 13:47:28 +0800
-Subject: [PATCH 15/25] llvmpipe: add function name to gallivm_jit_function
+Subject: [PATCH 15/26] llvmpipe: add function name to gallivm_jit_function
 
 ---
  src/gallium/auxiliary/draw/draw_llvm.c        | 24 +++++++++++++++----
@@ -540,5 +540,5 @@ index fac2a2be94e..b0c15997c24 100644
  
  static void
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0016-llvmpipe-tests-add-a-new-test-for-multiple-symbols-f.patch
+++ b/runtime-display/mesa/autobuild/patches/0016-llvmpipe-tests-add-a-new-test-for-multiple-symbols-f.patch
@@ -1,7 +1,7 @@
-From e203ac629e3324e7b419e15178c7c089bbdd47f4 Mon Sep 17 00:00:00 2001
+From 64a68a96d9e01d90d3ad99b27fdc96fe2ecdca9e Mon Sep 17 00:00:00 2001
 From: Yukari Chiba <i@0x7f.cc>
 Date: Tue, 25 Jun 2024 13:48:12 +0800
-Subject: [PATCH 16/25] llvmpipe/tests: add a new test for multiple symbols for
+Subject: [PATCH 16/26] llvmpipe/tests: add a new test for multiple symbols for
  orc jit testing
 
 ---
@@ -185,5 +185,5 @@ index 33e80cc38fa..6b851db34f7 100644
        t,
        executable(
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0017-llvmpipe-add-an-implementation-with-llvm-orcjit.patch
+++ b/runtime-display/mesa/autobuild/patches/0017-llvmpipe-add-an-implementation-with-llvm-orcjit.patch
@@ -1,7 +1,7 @@
-From b7a8cb6ba6d128771422c589cc5c14837be31a1c Mon Sep 17 00:00:00 2001
+From f41fdd85fb2f9a9c9a924f5d5cb895c30bcc72c1 Mon Sep 17 00:00:00 2001
 From: Yukari Chiba <i@0x7f.cc>
 Date: Tue, 25 Jun 2024 13:50:51 +0800
-Subject: [PATCH 17/25] llvmpipe: add an implementation with llvm orcjit
+Subject: [PATCH 17/26] llvmpipe: add an implementation with llvm orcjit
 
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
 ---
@@ -20,10 +20,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  create mode 100644 src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
 
 diff --git a/meson.build b/meson.build
-index 1f676a4f3fc..121ef9f3ca2 100644
+index b4d5e2bc0dc..1e8a9081f27 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1752,13 +1752,14 @@ if with_clc
+@@ -1749,13 +1749,14 @@ if with_clc
    llvm_optional_modules += ['all-targets', 'windowsdriver', 'frontendhlsl', 'frontenddriver']
  endif
  draw_with_llvm = get_option('draw-use-llvm')
@@ -39,7 +39,7 @@ index 1f676a4f3fc..121ef9f3ca2 100644
    _llvm_version = '>= 15.0.0'
  elif with_gallium_opencl
    _llvm_version = '>= 11.0.0'
-@@ -1838,6 +1839,7 @@ else
+@@ -1835,6 +1836,7 @@ else
  endif
  pre_args += '-DLLVM_AVAILABLE=' + (with_llvm ? '1' : '0')
  pre_args += '-DDRAW_LLVM_AVAILABLE=' + (with_llvm and draw_with_llvm ? '1' : '0')
@@ -3281,5 +3281,5 @@ index 18256ff5a44..7728b53366a 100644
     if (variant->function[RAST_EDGE_TEST]) {
        variant->jit_function[RAST_EDGE_TEST] = (lp_jit_frag_func)
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0018-llvmpipe-append-partial-mask-to-partial-fs_variant-f.patch
+++ b/runtime-display/mesa/autobuild/patches/0018-llvmpipe-append-partial-mask-to-partial-fs_variant-f.patch
@@ -1,7 +1,7 @@
-From d70071ac03b15bd292d12b7c10fa68ca57767720 Mon Sep 17 00:00:00 2001
+From fb125db23d206f91f15b3bbddc3f5a4dc1535109 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Fri, 1 Mar 2024 11:21:48 +0800
-Subject: [PATCH 18/25] llvmpipe: append partial mask to partial fs_variant
+Subject: [PATCH 18/26] llvmpipe: append partial mask to partial fs_variant
  func name
 
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
@@ -28,5 +28,5 @@ index 7728b53366a..aab0d532de5 100644
     arg_types[0] = variant->jit_context_ptr_type;       /* context */
     arg_types[1] = variant->jit_resources_ptr_type;       /* context */
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0019-llvmpipe-add-shader-cache-support-for-ORCJIT-impleme.patch
+++ b/runtime-display/mesa/autobuild/patches/0019-llvmpipe-add-shader-cache-support-for-ORCJIT-impleme.patch
@@ -1,7 +1,7 @@
-From f2d78231daf97189a92152d879353b9785aa993a Mon Sep 17 00:00:00 2001
+From f84d93a230d428d0b5e5f6dbd1ae5086657a35d9 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Fri, 28 Jun 2024 12:43:29 +0800
-Subject: [PATCH 19/25] llvmpipe: add shader cache support for ORCJIT
+Subject: [PATCH 19/26] llvmpipe: add shader cache support for ORCJIT
  implementation
 
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
@@ -286,5 +286,5 @@ index 70db126994d..1776fdb8bf3 100644
     LLVMValueRef context_ptr = LLVMGetParam(function, 0);
     LLVMValueRef x = LLVMGetParam(function, 1);
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0020-util-detect-LoongArch-architecture.patch
+++ b/runtime-display/mesa/autobuild/patches/0020-util-detect-LoongArch-architecture.patch
@@ -1,7 +1,7 @@
-From 21052b6722134da790635e9257f3e5fe1a0ed856 Mon Sep 17 00:00:00 2001
+From 8be48a46675472352101a7af0a4d17d01a98f8a9 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 6 Jul 2024 00:06:45 +0800
-Subject: [PATCH 20/25] util: detect LoongArch architecture
+Subject: [PATCH 20/26] util: detect LoongArch architecture
 
 Only 64-bit is considered now because 32-bit LoongArch Linux support
 doesn't exist in upstream yet.
@@ -40,5 +40,5 @@ index 35385a02b49..413575c2b72 100644
 +
  #endif /* UTIL_DETECT_ARCH_H_ */
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0021-gallivm-add-LoongArch-support-to-the-mattrs-setting-.patch
+++ b/runtime-display/mesa/autobuild/patches/0021-gallivm-add-LoongArch-support-to-the-mattrs-setting-.patch
@@ -1,7 +1,7 @@
-From eb2ee5b4856adf3360e1397c45c457594f7b6ead Mon Sep 17 00:00:00 2001
+From d0088af36303f49430e44f765b47c8a7d78177d1 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 6 Jul 2024 00:10:39 +0800
-Subject: [PATCH 21/25] gallivm: add LoongArch support to the mattrs setting
+Subject: [PATCH 21/26] gallivm: add LoongArch support to the mattrs setting
  code
 
 Currently the mattrs is set according to the softdev convention, with
@@ -13,7 +13,7 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 17 insertions(+)
 
 diff --git a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
-index f0e55bc4d46..07f6b8326ed 100644
+index 4a169c84b9e..612da9e6aee 100644
 --- a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
 +++ b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
 @@ -414,6 +414,23 @@ lp_build_fill_mattrs(std::vector<std::string> &MAttrs)
@@ -41,5 +41,5 @@ index f0e55bc4d46..07f6b8326ed 100644
  
  void
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0022-llvmpipe-add-LoongArch-support-in-ORCJIT.patch
+++ b/runtime-display/mesa/autobuild/patches/0022-llvmpipe-add-LoongArch-support-in-ORCJIT.patch
@@ -1,7 +1,7 @@
-From 281429edcb71f3cfbf810acba99e4dd462c06312 Mon Sep 17 00:00:00 2001
+From b7fa7cb7e728097ccb492685295e6358ec7d0bae Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 6 Jul 2024 00:12:18 +0800
-Subject: [PATCH 22/25] llvmpipe: add LoongArch support in ORCJIT
+Subject: [PATCH 22/26] llvmpipe: add LoongArch support in ORCJIT
 
 LoongArch is an architecture too new to have MCJIT support.
 
@@ -41,5 +41,5 @@ index 74593289ed1..952db26fd0e 100644
  
     JTMB.setOptions(options);
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0023-vulkan-runtime-Rename-vk_meta_object_list-to-vk_obje.patch
+++ b/runtime-display/mesa/autobuild/patches/0023-vulkan-runtime-Rename-vk_meta_object_list-to-vk_obje.patch
@@ -1,7 +1,7 @@
-From b6e46e47dfd29fa23465568fdb7e29630c57f309 Mon Sep 17 00:00:00 2001
+From 6b660ed933727d598f230d4b59fe676afd0ac97f Mon Sep 17 00:00:00 2001
 From: Yonggang Luo <luoyonggang@gmail.com>
 Date: Fri, 3 May 2024 17:14:02 +0800
-Subject: [PATCH 24/25] vulkan/runtime: Rename vk_meta_object_list to
+Subject: [PATCH 23/26] vulkan/runtime: Rename vk_meta_object_list to
  vk_object_list
 
 Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>
@@ -154,5 +154,5 @@ index dd113b0ea13..0120b636e63 100644
  }
  
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0024-vulkan-runtime-Split-vk_object_list-into-separate-fi.patch
+++ b/runtime-display/mesa/autobuild/patches/0024-vulkan-runtime-Split-vk_object_list-into-separate-fi.patch
@@ -1,7 +1,7 @@
-From 2075170c0084e9dac3fbf4b23069e8b0ad31fd35 Mon Sep 17 00:00:00 2001
+From 7f507b00cbdb5ae88196ea38994cced5685a8bdd Mon Sep 17 00:00:00 2001
 From: Gurchetan Singh <gurchetansingh@google.com>
 Date: Wed, 10 Jan 2024 15:09:02 -0800
-Subject: [PATCH 25/25] vulkan/runtime: Split vk_object_list into separate file
+Subject: [PATCH 24/26] vulkan/runtime: Split vk_object_list into separate file
 
 Code movement: Move the object list + destroy_object
 function to separate files.
@@ -302,5 +302,5 @@ index 00000000000..d393233f8ff
 +
 +#endif
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0025-zink-reject-Imagination-proprietary-driver-w-o-geome.patch
+++ b/runtime-display/mesa/autobuild/patches/0025-zink-reject-Imagination-proprietary-driver-w-o-geome.patch
@@ -1,7 +1,7 @@
-From 8f7107e7cc70f67279667d151874f0f7f4375108 Mon Sep 17 00:00:00 2001
+From 11eb324ba321fe04c9853aaa0aa309603170a54f Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 20 Jul 2024 22:03:54 +0800
-Subject: [PATCH] zink: reject Imagination proprietary driver w/o
+Subject: [PATCH 25/26] zink: reject Imagination proprietary driver w/o
  geometryShader
 
 On some low-end GPUs (e.g. BXE/BXM series), the Imagination proprietary
@@ -35,5 +35,5 @@ index 43ae9829d47..5b80f1657d7 100644
        simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
        screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/autobuild/patches/0026-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384.patch.loongarch64
+++ b/runtime-display/mesa/autobuild/patches/0026-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384.patch.loongarch64
@@ -1,8 +1,7 @@
-From ca5bc7e508508a4f981e8f8b7c614db4439a2471 Mon Sep 17 00:00:00 2001
+From 7c9af9b28eb9f08c2ac40ce5eb8f255d63681348 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
-Subject: [PATCH 23/25] [LOONGARCH64] fix(iris_bufmgr.c): set PAGE_SIZE as
- 16384
+Subject: [PATCH 26/26] fix(iris_bufmgr.c): set PAGE_SIZE as 16384
 
 Obviously not ideal, but this is simply meant as a preview/PoC.
 ---
@@ -23,5 +22,5 @@ index 59261c96cff..e3879985553 100644
  
  #define WARN_ONCE(cond, fmt...) do {                            \
 -- 
-2.45.2
+2.46.0
 

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=24.1.4
+UPSTREAM_VER=24.1.5
 DXHEADERS_VER=1.614.0
 VER=${UPSTREAM_VER}+dxheaders${DXHEADERS_VER}
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
-CHKSUMS="sha256::7cf7c6f665263ad0122889c1d4b076654c1eedea7a2f38c69c8c51579937ade1 \
+CHKSUMS="sha256::02761ffd965dd64b95421ebfca1191d73724aba00f30034009237564f34cf976 \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 24.1.5
    Track patches at AOSC-Tracking/mesa @ aosc/mesa-24.1.5.

Package(s) Affected
-------------------

- mesa: 1:24.1.4+dxheaders1.614.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
