### PR TITLE
fractal: update to 8

### DIFF
--- a/desktop-gnome/fractal/autobuild/defines
+++ b/desktop-gnome/fractal/autobuild/defines
@@ -2,13 +2,15 @@ PKGNAME=fractal
 PKGSEC=gnome
 PKGDEP="glib gtk-4 libadwaita gstreamer gtksourceview-5 openssl libshumate \
     sqlite pipewire pango graphene"
-BUILDDEP="meson ninja rustc llvm xdg-desktop-portal"
+BUILDDEP="meson ninja rustc llvm xdg-desktop-portal gtk-update-icon-cache \
+    desktop-file-utils"
 PKGDES="A Matrix messaging client for GNOME"
 
 USECLANG=1
+ABTYPE=meson
 MESON_AFTER="-Dprofile=default \
     -Dsandboxed=false"
 
-# FIXME: FTBFS with LTO on loongarch64 and riscv64
-NOLTO__LOONGARCH64=1
+# FIXME: FTBFS with LTO on loongson3 and riscv64
+NOLTO__LOONGSON3=1
 NOLTO__RISCV64=1

--- a/desktop-gnome/fractal/spec
+++ b/desktop-gnome/fractal/spec
@@ -1,4 +1,4 @@
-VER=7.0
+VER=8.0
 # FIXME: APT does not recognize single digit version without REL
 SRCS="git::commit=tags/${VER/.*/}::https://gitlab.gnome.org/World/fractal"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- fractal: update to 8
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- gradle: update to 8.9

Package(s) Affected
-------------------

- fractal: 8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit fractal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
