### PR TITLE
openssh: add ssh-agent.service

### DIFF
--- a/app-network/openssh/autobuild/overrides/usr/lib/systemd/user/ssh-agent.service
+++ b/app-network/openssh/autobuild/overrides/usr/lib/systemd/user/ssh-agent.service
@@ -1,0 +1,15 @@
+# Requires SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent.socket" to be set in environment
+[Unit]
+ConditionEnvironment=!SSH_AGENT_PID
+Description=OpenSSH key agent
+Documentation=man:ssh-agent(1) man:ssh-add(1) man:ssh(1)
+
+[Service]
+Environment=SSH_AUTH_SOCK=%t/ssh-agent.socket
+ExecStart=/usr/bin/ssh-agent -D -a $SSH_AUTH_SOCK
+PassEnvironment=SSH_AGENT_PID
+SuccessExitStatus=2
+Type=simple
+
+[Install]
+WantedBy=default.target

--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -1,5 +1,5 @@
 VER=9.8p1
-REL=2
+REL=3
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
 CHKSUMS="sha256::dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3"
 CHKUPDATE="anitya::id=2565"


### PR DESCRIPTION
Topic Description
-----------------

- openssh: add ssh-agent.service

Package(s) Affected
-------------------

- openssh: 9.8p1-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
