### PR TITLE
git-extras: new, 7.2.0

### DIFF
--- a/app-devel/git-extras/autobuild/beyond
+++ b/app-devel/git-extras/autobuild/beyond
@@ -1,0 +1,10 @@
+abinfo "Installing Fish completion .."
+install -dv "$PKGDIR"/usr/share/fish/vendor_completions.d/
+install -Dvm644 "$SRCDIR"/etc/git-extras.fish \
+    "$PKGDIR"/usr/share/fish/vendor_completions.d/git-extras.fish
+
+abinfo "Installing Zsh completion ..."
+install -dv "$PKGDIR"/usr/share/zsh/site-functions/
+install -Dvm644 "$SRCDIR"/etc/git-extras-completion.zsh \
+    "$PKGDIR"/usr/share/zsh/site-functions/_git-extras
+

--- a/app-devel/git-extras/autobuild/build
+++ b/app-devel/git-extras/autobuild/build
@@ -1,0 +1,3 @@
+abinfo "Installing ..."
+make install PREFIX="$PKGDIR"/usr SYSCONFDIR="$PKGDIR"/etc
+

--- a/app-devel/git-extras/autobuild/defines
+++ b/app-devel/git-extras/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=git-extras
+PKGSEC=devel
+PKGDEP="git"
+PKGDES="Little git extras"
+
+ABHOST=noarch
+ABTYPE=self
+

--- a/app-devel/git-extras/spec
+++ b/app-devel/git-extras/spec
@@ -1,0 +1,4 @@
+VER=7.2.0
+SRCS="git::commit=tags/$VER::https://github.com/tj/git-extras.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=1167"


### PR DESCRIPTION
Topic Description
-----------------

- git-extras: new, 7.2.0

Package(s) Affected
-------------------

- git-extras: 7.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-extras
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
