### PR TITLE
git-filter-repo: new, 2.45.0

### DIFF
--- a/app-devel/git-filter-repo/autobuild/build
+++ b/app-devel/git-filter-repo/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Installing git-filter-repo ..."
+make install \
+    prefix="$PKGDIR"/usr \
+    bindir="$PKGDIR"/usr/bin \
+    pythondir="$PKGDIR"/usr/lib/python"$ABPY3VER"/site-packages \
+    no-refresh-mandb=1

--- a/app-devel/git-filter-repo/autobuild/defines
+++ b/app-devel/git-filter-repo/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=git-filter-repo
+PKGSEC=devel
+PKGDEP="git python-3"
+PKGDES="A versatile tool for rewriting git history"
+
+ABHOST=noarch
+ABTYPE=self

--- a/app-devel/git-filter-repo/autobuild/patches/0001-Makefile-Add-option-to-skip-mandb-refresh.patch
+++ b/app-devel/git-filter-repo/autobuild/patches/0001-Makefile-Add-option-to-skip-mandb-refresh.patch
@@ -1,0 +1,28 @@
+From 3d58172f9352bfd2b5089bc3299e3ac3150eb9b1 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Fri, 2 Aug 2024 22:29:46 +0800
+Subject: [PATCH] Makefile: Add option to skip mandb refresh
+
+Signed-off-by: Bingwu Zhang <xtexchooser@duck.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 3330a1ded823..8d40c5de176a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -41,7 +41,7 @@ install: snag_docs #fixup_locale
+ 	ln -sf "$(bindir)/git-filter-repo" "$(DESTDIR)/$(pythondir)/git_filter_repo.py"
+ 	$(INSTALL) -Dm0644 Documentation/man1/git-filter-repo.1 "$(DESTDIR)/$(mandir)/man1/git-filter-repo.1"
+ 	$(INSTALL) -Dm0644 Documentation/html/git-filter-repo.html "$(DESTDIR)/$(htmldir)/git-filter-repo.html"
+-	if which mandb > /dev/null; then mandb; fi
++	$(if $(no-refresh-mandb),,if which mandb > /dev/null; then mandb; fi)
+ 
+ 
+ #
+
+base-commit: e1b7c3d1eae4b8e724ad81b584d20fffe78dd092
+-- 
+2.46.0
+

--- a/app-devel/git-filter-repo/spec
+++ b/app-devel/git-filter-repo/spec
@@ -1,0 +1,4 @@
+VER=2.45.0
+SRCS="tbl::https://github.com/newren/git-filter-repo/releases/download/v$VER/git-filter-repo-$VER.tar.xz"
+CHKSUMS="sha256::430a2c4a5d6f010ebeafac6e724e3d8d44c83517f61ea2b2d0d07ed8a6fc555a"
+CHKUPDATE="anitya::id=63454"

--- a/app-devel/git-filter-repo/spec
+++ b/app-devel/git-filter-repo/spec
@@ -1,4 +1,5 @@
 VER=2.45.0
+REL=1
 SRCS="tbl::https://github.com/newren/git-filter-repo/releases/download/v$VER/git-filter-repo-$VER.tar.xz"
 CHKSUMS="sha256::430a2c4a5d6f010ebeafac6e724e3d8d44c83517f61ea2b2d0d07ed8a6fc555a"
 CHKUPDATE="anitya::id=63454"


### PR DESCRIPTION
Topic Description
-----------------

- git-filter-repo: bump REL for topic Revision Marking Guidelines
- git-filter-repo: new, 2.45.0

Package(s) Affected
-------------------

- git-filter-repo: 2.45.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-filter-repo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
