### PR TITLE
git-absorb: new, 0.6.15

### DIFF
--- a/app-devel/git-absorb/autobuild/defines
+++ b/app-devel/git-absorb/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=git-absorb
+PKGDES="Automatically write fixup! commits, similar to hg absort"
+PKGSEC=devel
+PKGDEP="git"
+BUILDDEP="rustc llvm libgit2"
+
+CARGO_AFTER="--features=git2/vendored-libgit2"
+USECLANG=1
+# FIXME: loongson3 + lld building issue
+NOLTO__LOONGSON3=1

--- a/app-devel/git-absorb/autobuild/prepare
+++ b/app-devel/git-absorb/autobuild/prepare
@@ -1,0 +1,4 @@
+# FIXME: loongson3 + lld building issue
+if ab_match_arch loongson3; then
+    export RUSTFLAGS="$RUSTFLAGS -Clink-args=-fuse-ld=bfd"
+fi

--- a/app-devel/git-absorb/spec
+++ b/app-devel/git-absorb/spec
@@ -1,0 +1,4 @@
+VER=0.6.15
+SRCS="git::commit=tags/$VER::https://github.com/tummychow/git-absorb.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=328525"

--- a/app-devel/git-absorb/spec
+++ b/app-devel/git-absorb/spec
@@ -1,4 +1,5 @@
 VER=0.6.15
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/tummychow/git-absorb.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328525"


### PR DESCRIPTION
Topic Description
-----------------

- git-absorb: bump REL for topic Revision Marking Guidelines
- git-absorb: new, 0.6.15

Package(s) Affected
-------------------

- git-absorb: 0.6.15-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-absorb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
