### PR TITLE
kmail: fix runtime dependencies

### DIFF
--- a/desktop-kde/kmail/autobuild/defines
+++ b/desktop-kde/kmail/autobuild/defines
@@ -3,12 +3,13 @@ PKGSEC=kde
 PKGDEP="akonadi akonadi-calendar akonadi-contacts akonadi-mime akonadi-search \
         kaccounts-integration kauth kcalcore kcalutils kcmutils kcodecs \
         kcompletion kconfig kconfigwidgets kcontacts kcoreaddons kcrash \
-        kdbusaddons ki18n kiconthemes kidentitymanagement kimap kio \
-        kitemmodels kitemviews kjobwidgets kldap kmailtransport kmime \
-        knotifications knotifyconfig kontactinterface kparts kpimtextedit \
-        kservice ktextwidgets ktnef kwallet kwidgetsaddons kxmlgui \
-        libgravatar libkdepim libksieve mailcommon messagelib pimcommon \
-        qtkeychain solid sonnet syntax-highlighting"
+        kdbusaddons kdepim-runtime ki18n kiconthemes kidentitymanagement \
+        kimap kio kitemmodels kitemviews kjobwidgets kldap kmailtransport \
+        kmail-account-wizard kmime knotifications knotifyconfig \
+        kontactinterface kparts kpimtextedit kservice ktextwidgets ktnef \
+        kwallet kwidgetsaddons kxmlgui libgravatar libkdepim libksieve \
+        mailcommon messagelib pimcommon qtkeychain solid sonnet \
+        syntax-highlighting"
 BUILDDEP="extra-cmake-modules kdoctools"
 PKGDES="An e-mail client for KDE"
 

--- a/desktop-kde/kmail/spec
+++ b/desktop-kde/kmail/spec
@@ -1,4 +1,5 @@
 VER=23.08.5
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kmail-$VER.tar.xz"
 CHKSUMS="sha256::7138ac647b82208c2d93f142ca1bac2cd080c2bd9a81145d1dbd0471ba2ab755"
 CHKUPDATE="anitya::id=8763"


### PR DESCRIPTION
Topic Description
-----------------

- kmail: fix runtime dependencies
    - add kdepim-runtime as dependency
    - add kmail-account-wizard as recommended package

Package(s) Affected
-------------------

- kmail: 23.08.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit kmail
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
