### PR TITLE
pavucontrol: update to 6.1

### DIFF
--- a/app-multimedia/pavucontrol/spec
+++ b/app-multimedia/pavucontrol/spec
@@ -1,4 +1,4 @@
-VER=6.0
+VER=6.1
 SRCS="git::commit=tags/v$VER::https://gitlab.freedesktop.org/pulseaudio/pavucontrol"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8636"


### PR DESCRIPTION
Topic Description
-----------------

- pavucontrol: update to 6.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- pavucontrol: 6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pavucontrol
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
