### PR TITLE
syncthing: update to 1.27.9

### DIFF
--- a/app-network/syncthing/spec
+++ b/app-network/syncthing/spec
@@ -1,4 +1,5 @@
 VER=1.27.9
+REL=1
 SRCS="https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
 CHKSUMS="sha256::82364794e5dfc912128dd47bd1da3304396bc8a0cae3d1fdb15d9a86a51085e9"
 CHKUPDATE="anitya::id=11814"

--- a/app-network/syncthing/spec
+++ b/app-network/syncthing/spec
@@ -1,6 +1,5 @@
-VER=1.27.3
-REL=3
+VER=1.27.9
 SRCS="https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
-CHKSUMS="sha256::3fe25b863bb3a0f74bc95a7afa71bdaa2a79971542962236be5d85f469aa897d"
+CHKSUMS="sha256::82364794e5dfc912128dd47bd1da3304396bc8a0cae3d1fdb15d9a86a51085e9"
 CHKUPDATE="anitya::id=11814"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- syncthing: bump REL for topic Revision Marking Guidelines
- syncthing: update to 1.27.9
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- syncthing: 1.27.9-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit syncthing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
