### PR TITLE
botan-2: add loongarch64 to archinfo

### DIFF
--- a/runtime-cryptography/botan-2/autobuild/patches/0001-Add-loongarch64-to-archinfo.patch
+++ b/runtime-cryptography/botan-2/autobuild/patches/0001-Add-loongarch64-to-archinfo.patch
@@ -1,0 +1,61 @@
+From 83d3190d489a30b6d298e55002ffd4e9f0d1cd44 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sat, 3 Aug 2024 14:25:41 +0800
+Subject: [PATCH] Add loongarch64 to archinfo
+X-Developer-Signature: v=1; a=openpgp-sha256; l=1110; i=xtexchooser@duck.com;
+ h=from:subject; bh=LLwBdNsiAM9za4GZMm6CChmBwZ49PlxDTBJLzDxT5kI=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDGlrzzmHxaVphwYtC8nx6Cupld3iItS/tkEm6t/SqKgZb
+ 1nYNhzrKGVhEONikBVTZCkybPBm1UnnF11WLgszh5UJZAgDF6cATMT9N8M/8zaJWXM4Cyq+xi8t
+ +Zm2wSFjg8luja8LfVTS2JU+y/lMY/hfP1PPMUdL5cCF6hfBcia+3dK3Vye5NMi2JFvVnfkhx8A
+ PAA==
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+From AOSC-OS-AABS/thunderbird/autobuild/patches/
+0016-comm-botan-add-loongarch64-to-archinfo.patch
+
+Signed-off-by: Bingwu Zhang <xtexchooser@duck.com>
+---
+ src/build-data/arch/loongarch64.txt | 13 +++++++++++++
+ src/build-data/detect_arch.cpp      |  3 +++
+ 2 files changed, 16 insertions(+)
+ create mode 100644 src/build-data/arch/loongarch64.txt
+
+diff --git a/src/build-data/arch/loongarch64.txt b/src/build-data/arch/loongarch64.txt
+new file mode 100644
+index 000000000000..3e6e89460e8c
+--- /dev/null
++++ b/src/build-data/arch/loongarch64.txt
+@@ -0,0 +1,13 @@
++endian little
++wordsize 64
++
++family loongarch
++
++<aliases>
++loong64
++</aliases>
++
++<isa_extensions>
++lsx
++lasx
++</isa_extensions>
+diff --git a/src/build-data/detect_arch.cpp b/src/build-data/detect_arch.cpp
+index 4de58922fe3f..3a4bf8ecebc2 100644
+--- a/src/build-data/detect_arch.cpp
++++ b/src/build-data/detect_arch.cpp
+@@ -70,6 +70,9 @@
+      RISCV32
+   #endif
+ 
++#elif defined(__loongarch64)
++  LOONGARCH64
++
+ #else
+   UNKNOWN
+ 
+
+base-commit: 1a6ad661ce64287ccbe26460ccc3aa4247d86ba8
+-- 
+2.46.0
+

--- a/runtime-cryptography/botan-2/spec
+++ b/runtime-cryptography/botan-2/spec
@@ -1,4 +1,5 @@
 VER=2.12.1
+REL=1
 SRCS="tbl::https://botan.randombit.net/releases/Botan-$VER.tar.xz"
 CHKSUMS="sha256::7e035f142a51fca1359705792627a282456d49749bf62a37a8e48375d41baaa9"
-CHKUPDATE="anitya::id=214"
+CHKUPDATE="anitya::id=369470"


### PR DESCRIPTION
Topic Description
-----------------

- botan-2: add loongarch64 to archinfo

Package(s) Affected
-------------------

- botan-2: 2.12.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit botan-2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
