### PR TITLE
botan-2: update to 3.5.0

### DIFF
--- a/runtime-cryptography/botan-2/spec
+++ b/runtime-cryptography/botan-2/spec
@@ -1,4 +1,4 @@
-VER=2.12.1
+VER=3.5.0
 SRCS="tbl::https://botan.randombit.net/releases/Botan-$VER.tar.xz"
-CHKSUMS="sha256::7e035f142a51fca1359705792627a282456d49749bf62a37a8e48375d41baaa9"
+CHKSUMS="sha256::67e8dae1ca2468d90de4e601c87d5f31ff492b38e8ab8bcbd02ddf7104ed8a9f"
 CHKUPDATE="anitya::id=214"


### PR DESCRIPTION
Topic Description
-----------------

- botan-2: update to 3.5.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- botan-2: 3.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit botan-2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
