### PR TITLE
nasm: update to 2.16.03

### DIFF
--- a/app-devel/nasm/spec
+++ b/app-devel/nasm/spec
@@ -1,4 +1,4 @@
-VER=2.16.01
+VER=2.16.03
 SRCS="tbl::https://www.nasm.us/pub/nasm/releasebuilds/$VER/nasm-$VER.tar.xz"
-CHKSUMS="sha256::c77745f4802375efeee2ec5c0ad6b7f037ea9c87c92b149a9637ff099f162558"
+CHKSUMS="sha256::1412a1c760bbd05db026b6c0d1657affd6631cd0a63cddb6f73cc6d4aa616148"
 CHKUPDATE="anitya::id=2048"


### PR DESCRIPTION
Topic Description
-----------------

- nasm: update to 2.16.03
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- nasm: 2.16.03

Security Update?
----------------

No

Build Order
-----------

```
#buildit nasm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
