### PR TITLE
botan-3: new, 3.5.0

### DIFF
--- a/runtime-cryptography/botan-2/autobuild/beyond
+++ b/runtime-cryptography/botan-2/autobuild/beyond
@@ -1,3 +1,3 @@
 abinfo "Rename /usr/bin/botan to botan2 ..."
 mv -v "$PKGDIR"/usr/bin/botan "$PKGDIR"/usr/bin/botan2
-mv -v "$PKGDIR"/usr/share/man/man1/botan.1.xz "$PKGDIR"/usr/share/man/man1/botan2.1.xz
+mv -v "$PKGDIR"/usr/share/man/man1/botan.1 "$PKGDIR"/usr/share/man/man1/botan2.1

--- a/runtime-cryptography/botan-2/autobuild/beyond
+++ b/runtime-cryptography/botan-2/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Rename /usr/bin/botan to botan2 ..."
+mv -v "$PKGDIR"/usr/bin/botan "$PKGDIR"/usr/bin/botan2
+mv -v "$PKGDIR"/usr/share/man/man1/botan.1.xz "$PKGDIR"/usr/share/man/man1/botan2.1.xz

--- a/runtime-cryptography/botan-2/autobuild/build
+++ b/runtime-cryptography/botan-2/autobuild/build
@@ -1,7 +1,12 @@
-./configure.py --prefix=/usr \
+abinfo "Configuring botan-2 ..."
+"$SRCDIR"/configure.py --prefix=/usr \
                --with-bzip \
                --with-lzma \
                --with-zlib \
                --with-os-feature=getrandom
+
+abinfo "Building botan-2 ..."
 make
+
+abinfo "Installing botan-2 ..."
 make install DESTDIR="$PKGDIR"

--- a/runtime-cryptography/botan-2/spec
+++ b/runtime-cryptography/botan-2/spec
@@ -1,5 +1,5 @@
 VER=2.12.1
-REL=1
+REL=2
 SRCS="tbl::https://botan.randombit.net/releases/Botan-$VER.tar.xz"
 CHKSUMS="sha256::7e035f142a51fca1359705792627a282456d49749bf62a37a8e48375d41baaa9"
 CHKUPDATE="anitya::id=369470"

--- a/runtime-cryptography/botan-3/autobuild/build
+++ b/runtime-cryptography/botan-3/autobuild/build
@@ -1,0 +1,15 @@
+abinfo "Configuring botan-3 ..."
+"$SRCDIR"/configure.py --prefix=/usr \
+               --with-bzip \
+               --with-lzma \
+               --with-zlib \
+               --with-tpm \
+               --with-os-feature=getrandom \
+               --with-debug-info \
+               --with-rst2man
+
+abinfo "Building botan-3 ..."
+make
+
+abinfo "Installing botan-3 ..."
+make install DESTDIR="$PKGDIR"

--- a/runtime-cryptography/botan-3/autobuild/defines
+++ b/runtime-cryptography/botan-3/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=botan-3
+PKGSEC=libs
+PKGDES="C++ cryptography library (version 3)"
+BUILDDEP="docutils"
+PKGBREAK="botan-2<=2.12.1"
+
+AB_FLAGS_O3=1

--- a/runtime-cryptography/botan-3/spec
+++ b/runtime-cryptography/botan-3/spec
@@ -1,0 +1,4 @@
+VER=3.5.0
+SRCS="tbl::https://botan.randombit.net/releases/Botan-$VER.tar.xz"
+CHKSUMS="sha256::67e8dae1ca2468d90de4e601c87d5f31ff492b38e8ab8bcbd02ddf7104ed8a9f"
+CHKUPDATE="anitya::id=214"


### PR DESCRIPTION
Topic Description
-----------------

- botan-3: new, 3.5.0
- botan-2: rename botan binary to botan-2

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit botan-3 botan-2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
