### PR TITLE
octave: update to 9.2.0

### DIFF
--- a/app-scientific/octave/spec
+++ b/app-scientific/octave/spec
@@ -1,4 +1,4 @@
-VER=9.1.0
+VER=9.2.0
 SRCS="tbl::https://ftp.gnu.org/gnu/octave/octave-$VER.tar.lz"
-CHKSUMS="sha256::f1769f61bd10c8ade6aee352b1bbb016e5fd8fc8394896a64dc26ef675ba3cea"
+CHKSUMS="sha256::dcb2c098701cfcbc083f07e90e146261d15cdbf5e89c031032422112c89b47da"
 CHKUPDATE="anitya::id=2528"


### PR DESCRIPTION
Topic Description
-----------------

- octave: update to 9.2.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- octave: 9.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit octave
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
