### PR TITLE
kicad: update to 8.0.4

### DIFF
--- a/app-electronics/kicad/spec
+++ b/app-electronics/kicad/spec
@@ -1,4 +1,4 @@
-VER=8.0.2
+VER=8.0.4
 SRCS="git::commit=tags/$VER;rename=kicad-$VER::https://gitlab.com/kicad/code/kicad \
       git::commit=tags/$VER;rename=kicad-footprints-$VER::https://gitlab.com/kicad/libraries/kicad-footprints \
       git::commit=tags/$VER;rename=kicad-symbols-$VER::https://gitlab.com/kicad/libraries/kicad-symbols \


### PR DESCRIPTION
Topic Description
-----------------

- kicad: update to 8.0.4
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- kicad: 8.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit kicad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
