### PR TITLE
podman: update to 5.2.0+vsock0.7.4

### DIFF
--- a/app-containers/podman/autobuild/defines
+++ b/app-containers/podman/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=podman
 PKGSEC=admin
 PKGDES="A tool for managing OCI containers and pods"
-PKGDEP="ostree gpgme conmon containers-common slirp4netns catatonit dnsmasq"
+PKGDEP="ostree gpgme conmon containers-common passt catatonit dnsmasq"
 PKGRECOM="btrfs-progs"
 BUILDDEP="go btrfs-progs go-md2man"
 

--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,14 +1,13 @@
-UPSTREAM_VER=5.1.0
+UPSTREAM_VER=5.2.0
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile
-GVISOR_TAP_VSOCK_VER=0.7.3
+GVISOR_TAP_VSOCK_VER=0.7.4
 
 VER=${UPSTREAM_VER}+vsock${GVISOR_TAP_VSOCK_VER}
 SRCS="tbl::https://github.com/containers/podman/archive/v${UPSTREAM_VER}.tar.gz \
       git::commit=tags/v${GVISOR_TAP_VSOCK_VER};rename=gvisor-tap-vsock::https://github.com/containers/gvisor-tap-vsock"
-CHKSUMS="sha256::e0687779c82b58422d458dc3776ffa7f79e1a04614a3f1a7ef93f7769bf8a8e6 \
+CHKSUMS="sha256::d2362700314fdb23baf6c021e73755655294f0e7b21e29c2d6798973cb08d5bb \
          SKIP"
 CHKUPDATE="anitya::id=93284"
 SUBDIR="podman-$UPSTREAM_VER"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- podman: update to 5.2.0+vsock0.7.4
    - update podman to 5.2.0
    - update gvsock to 0.7.4, as required by podman 5.2.0
    - replace slirp4netns with passt, as podman 5.0.0's update of default
    rootless network backend

Package(s) Affected
-------------------

- podman: 5.2.0+vsock0.7.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
