### PR TITLE
oma: install command-not-found handler for fish

### DIFF
--- a/app-admin/oma/autobuild/beyond
+++ b/app-admin/oma/autobuild/beyond
@@ -3,6 +3,15 @@ mkdir -pv "$PKGDIR"/etc/bashrc.d
 cp -v "$SRCDIR"/data/command-not-found/command-not-found.sh \
 	"$PKGDIR"/etc/bashrc.d/command-not-found.sh
 
+abinfo "Installing command-not-found handler (bash) ..."
+mkdir -pv "$PKGDIR"/etc/profile.d
+cp -v "$SRCDIR"/data/command-not-found/command-not-found.sh \
+	"$PKGDIR"/etc/profile.d/command-not-found.sh
+
+abinfo "Installing command-not-found handler (fish) ..."
+mkdir -pv "$PKGDIR"/usr/share/fish/vendor_conf.d/
+cp -v "$SRCDIR"/data/command-not-found/command-not-found.fish \
+	"$PKGDIR"/usr/share/fish/vendor_conf.d/command-not-found.fish
 
 abinfo "Installing man to /usr/share/man/man1 ..."
 mkdir -pv "$PKGDIR"/usr/share/man/man1
@@ -28,11 +37,6 @@ abinfo "Installing fish completions ..."
 mkdir -pv "$PKGDIR"/usr/share/fish/completions
 cp -v "$SRCDIR"/data/completions/oma.fish \
 	"$PKGDIR"/usr/share/fish/completions/oma.fish
-
-abinfo "Installing command-not-found handler (bash) ..."
-mkdir -pv "$PKGDIR"/etc/profile.d
-cp -v "$SRCDIR"/data/command-not-found/command-not-found.sh \
-	"$PKGDIR"/etc/profile.d/command-not-found.sh
 
 abinfo "Installing config file ..."
 cp -v "$SRCDIR"/data/config/oma.toml \

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,5 @@
 VER=1.3.39
+REL=1
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: install command-not-found handler for fish

Package(s) Affected
-------------------

- oma: 1.3.39-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
