### PR TITLE
zathura: update to 0.5.7

### DIFF
--- a/app-doc/zathura-djvu/spec
+++ b/app-doc/zathura-djvu/spec
@@ -1,5 +1,4 @@
-VER=0.2.9
-REL=3
+VER=0.2.10
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-djvu"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11036"

--- a/app-doc/zathura-pdf-poppler/spec
+++ b/app-doc/zathura-pdf-poppler/spec
@@ -1,4 +1,5 @@
 VER=0.3.2
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-pdf-poppler"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14847"

--- a/app-doc/zathura-ps/spec
+++ b/app-doc/zathura-ps/spec
@@ -1,5 +1,5 @@
 VER=0.2.7
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-ps"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14848"

--- a/app-doc/zathura/autobuild/defines
+++ b/app-doc/zathura/autobuild/defines
@@ -3,6 +3,8 @@ PKGSEC=doc
 PKGDEP="girara sqlite desktop-file-utils file libseccomp texlive"
 BUILDDEP="docutils sphinx appstream-glib bash-completion fish"
 PKGDES="A minimalistic document viewer"
+PKGBREAK="zathura-djvu<=0.2.9-3 zathura-pdf-poppler<=0.3.2 \
+          zathura-ps<=0.2.7-1"
 
 ABTYPE=meson
 MESON_AFTER="-Dsynctex=enabled \

--- a/app-doc/zathura/spec
+++ b/app-doc/zathura/spec
@@ -1,4 +1,4 @@
-VER=0.5.6
+VER=0.5.7
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5298"


### PR DESCRIPTION
Topic Description
-----------------

- zathura: update to 0.5.7
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- zathura: 0.5.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit zathura:-pkgbreak zathura-djvu zathura-pdf-poppler zathura-ps zathura
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
