### PR TITLE
crun: update to 1.15

### DIFF
--- a/app-admin/crun/spec
+++ b/app-admin/crun/spec
@@ -1,4 +1,4 @@
-VER=1.12
-SRCS="https://github.com/containers/crun/releases/download/$VER/crun-$VER.tar.xz"
-CHKSUMS="sha256::860f4d1972dd2fdb17e4a1aae4386c4da2989e547d1e17f909b3ca0aff135c28"
+VER=1.15
+SRCS="https://github.com/containers/crun/releases/download/$VER/crun-$VER.tar.zst"
+CHKSUMS="sha256::f6b21df7824ee2328fc46d2592b9e453c4ecc031b3dd3708dc50f5aa22b35c7e"
 CHKUPDATE="anitya::id=96792"


### PR DESCRIPTION
Topic Description
-----------------

- crun: update to 1.15

Package(s) Affected
-------------------

- crun: 1.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit crun
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
