### PR TITLE
distrobox: move docker dependency to suggests

### DIFF
--- a/app-utils/distrobox/autobuild/defines
+++ b/app-utils/distrobox/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=distrobox
 PKGSEC=utils
-PKGDEP="docker bash"
+PKGDEP="bash"
 PKGDES="Wrapper around Docker or Podman to create and start containers"
+PKGRECOM="docker"
+PKGSUG="podman"
 
 ABHOST=noarch

--- a/app-utils/distrobox/spec
+++ b/app-utils/distrobox/spec
@@ -1,4 +1,5 @@
 VER=1.7.2.1
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/89luca89/distrobox"
 CHKUPDATE="anitya::id=242098"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- distrobox: move docker dependency to suggests

Package(s) Affected
-------------------

- distrobox: 1.7.2.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit distrobox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
