### PR TITLE
containers-common: use pasta by default

### DIFF
--- a/runtime-containers/containers-common/autobuild/defines
+++ b/runtime-containers/containers-common/autobuild/defines
@@ -2,7 +2,8 @@ PKGNAME=containers-common
 PKGSEC=admin
 PKGDES="Common dependencies, configuration and documentation for containers"
 PKGDEP="crun netavark iptables nftables"
-PKGRECOM="slirp4netns qemu-user-static fuse-overlayfs"
+PKGRECOM="pasta qemu-user-static fuse-overlayfs"
+PKGSUG="slirp4netns"
 BUILDDEP="go-md2man"
 
 ABHOST=noarch

--- a/runtime-containers/containers-common/spec
+++ b/runtime-containers/containers-common/spec
@@ -9,6 +9,7 @@ __SHORTNAMES_VER=2023.02.20
 __SKOPEO_VER=1.15.1
 
 VER=${UPSTREAM_VER}+image${__IMAGE_VER}+shortnames${__SHORTNAMES_VER}+skopeo${__SKOPEO_VER}+storage${__STORAGE_VER}
+REL=1
 
 __ORG_URL="https://github.com/containers"
 SRCS="git::commit=tags/v${UPSTREAM_VER};rename=common::${__ORG_URL}/common \


### PR DESCRIPTION
Topic Description
-----------------

- containers-common: use pasta by default
    - use pasta by default, add slirp4netns as suggestion, podman 5.0.0+
    uses pasta as default network backend

Package(s) Affected
-------------------

- containers-common: 0.59.2+image5.31.1+shortnames2023.02.20+skopeo1.15.1+storage1.54.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit containers-common
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
