### PR TITLE
lighttpd: refresh configs with upstream

### DIFF
--- a/app-network/lighttpd/autobuild/defines
+++ b/app-network/lighttpd/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=lighttpd
 PKGSEC=net
-PKGDEP="bzip2 gamin libxml2 lua mariadb openldap pcre sqlite systemd util-linux"
-PKGDEP__RETRO="bzip2 libxml2 lua pcre sqlite systemd util-linux"
+PKGDEP="libxml2 lua mariadb openldap pcre2 sqlite systemd util-linux"
+PKGDEP__RETRO="libxml2 lua pcre2 sqlite systemd util-linux"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
 PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
@@ -10,7 +10,6 @@ PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
-BUILDDEP="fcgi"
 PKGDES="A secure, fast, compliant and very flexible web server"
 
 AUTOTOOLS_STRICT=0
@@ -20,24 +19,17 @@ AUTOTOOLS_AFTER="--libdir=/usr/lib/lighttpd/ \
                  --with-ldap \
                  --with-attr \
                  --with-openssl \
-                 --with-fam \
                  --with-webdav-props \
                  --with-webdav-locks \
-                 --with-gdbm \
                  --with-lua"
 AUTOTOOLS_AFTER__RETRO=" \
                  --libdir=/usr/lib/lighttpd/ \
                  --sysconfdir=/etc/lighttpd \
-                 --without-mysql \
-                 --without-ldap \
                  --with-attr \
                  --with-openssl \
                  --with-kerberos5 \
-                 --without-fam \
                  --with-webdav-props \
                  --with-webdav-locks \
-                 --with-gdbm \
-                 --with-memcache \
                  --with-lua"
 AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"

--- a/app-network/lighttpd/autobuild/overrides/etc/lighttpd/lighttpd.conf
+++ b/app-network/lighttpd/autobuild/overrides/etc/lighttpd/lighttpd.conf
@@ -1,6 +1,6 @@
 # This is a minimal example config
 # See /usr/share/doc/lighttpd
-# and http://redmine.lighttpd.net/projects/lighttpd/wiki/Docs:ConfigurationOptions
+# and https://wiki.lighttpd.net/Docs:ConfigurationOptions
 
 server.port		= 80
 server.username		= "http"
@@ -9,15 +9,3 @@ server.document-root	= "/srv/http"
 server.errorlog		= "/var/log/lighttpd/error.log"
 dir-listing.activate	= "enable"
 index-file.names	= ( "index.html" )
-mimetype.assign		= (
-				".html" => "text/html",
-				".txt" => "text/plain",
-				".css" => "text/css",
-				".js" => "application/x-javascript",
-				".jpg" => "image/jpeg",
-				".jpeg" => "image/jpeg",
-				".gif" => "image/gif",
-				".png" => "image/png",
-				"" => "application/octet-stream"
-			)
-

--- a/app-network/lighttpd/autobuild/overrides/usr/lib/systemd/system/lighttpd.service
+++ b/app-network/lighttpd/autobuild/overrides/usr/lib/systemd/system/lighttpd.service
@@ -4,8 +4,10 @@ After=syslog.target network.target
 
 [Service]
 PrivateTmp=true
-ExecStart=/usr/bin/lighttpd-angel -D -f /etc/lighttpd/lighttpd.conf
-ExecReload=/usr/bin/kill -HUP $MAINPID
+ExecStartPre=/usr/bin/lighttpd -tt -f /etc/lighttpd/lighttpd.conf
+ExecStart=/usr/bin/lighttpd -D -f /etc/lighttpd/lighttpd.conf
+ExecReload=/usr/bin/kill -USR1 $MAINPID
+Restart=on-failure
 KillSignal=SIGINT
 
 [Install]

--- a/app-network/lighttpd/spec
+++ b/app-network/lighttpd/spec
@@ -2,3 +2,4 @@ VER=1.4.76
 SRCS="tbl::https://download.lighttpd.net/lighttpd/releases-${VER%.*}.x/lighttpd-$VER.tar.xz"
 CHKSUMS="sha256::8cbf4296e373cfd0cedfe9d978760b5b05c58fdc4048b4e2bcaf0a61ac8f5011"
 CHKUPDATE="anitya::id=1817"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

* use pcre2 instead of pcre
* remove deprecated config options
* simplify lighttpd.conf (modern lighttpd has a built-in mimetype.assign with commonly used web file types)
* update systemd lighttpd.service to match upstream recommendations

Note: not modified: if `AUTOTOOLS_AFTER__RETRO` includes `--with-kerberos5`, then `PKGDEP__RETRO` should be updated to add a dependency on the appropriate package for krb5 libs.

Note: I did not understand the issue in #7296, so that is not addressed here.

Package(s) Affected
-------------------

lighttpd

Build Order
------------------

```
#buildit lighttpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`