### PR TITLE
zathura Survey 20240804

### DIFF
--- a/app-doc/zathura-djvu/spec
+++ b/app-doc/zathura-djvu/spec
@@ -1,5 +1,4 @@
-VER=0.2.9
-REL=3
+VER=0.2.10
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-djvu"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11036"

--- a/app-doc/zathura-pdf-poppler/spec
+++ b/app-doc/zathura-pdf-poppler/spec
@@ -1,4 +1,4 @@
-VER=0.3.2
+VER=0.3.3
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-pdf-poppler"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14847"

--- a/app-doc/zathura-ps/spec
+++ b/app-doc/zathura-ps/spec
@@ -1,5 +1,4 @@
-VER=0.2.7
-REL=1
+VER=0.2.8
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-ps"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14848"

--- a/app-doc/zathura/spec
+++ b/app-doc/zathura/spec
@@ -1,4 +1,4 @@
-VER=0.5.6
+VER=0.5.8
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5298"


### PR DESCRIPTION
Topic Description
-----------------

- zathura-ps: bump REL due to zathura update to 0.5.8
- zathura-pdf-poppler: bump REL due to zathura update to 0.5.8
- zathura-djvu: update to 0.2.10
- zathura: update to 0.5.8
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- zathura: 0.5.8
- zathura-djvu: 0.2.10
- zathura-pdf-poppler: 0.3.2-1
- zathura-ps: 0.2.7-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit zathura zathura-djvu zathura-pdf-poppler zathura-ps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
