### PR TITLE
zvm: new, 0.7.4

### DIFF
--- a/lang-ziglang/zvm/autobuild/defines
+++ b/lang-ziglang/zvm/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=zvm
+PKGSEC=devel
+PKGDES="A tool for managing Zig installs"
+BUILDDEP="go"
+
+ABSPLITDBG=0

--- a/lang-ziglang/zvm/autobuild/defines
+++ b/lang-ziglang/zvm/autobuild/defines
@@ -3,4 +3,6 @@ PKGSEC=devel
 PKGDES="A tool for managing Zig installs"
 BUILDDEP="go"
 
+# FIXME: Autobuild does not yet support splitting debug symbols out of Go
+# executables.
 ABSPLITDBG=0

--- a/lang-ziglang/zvm/autobuild/overrides/etc/bashrc.d/zvm.sh
+++ b/lang-ziglang/zvm/autobuild/overrides/etc/bashrc.d/zvm.sh
@@ -1,0 +1,1 @@
+export PATH="$HOME/.zvm/bin:$PATH"

--- a/lang-ziglang/zvm/spec
+++ b/lang-ziglang/zvm/spec
@@ -1,0 +1,4 @@
+VER=0.7.4
+SRCS="git::commit=tags/v$VER::https://github.com/tristanisham/zvm"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=363557"

--- a/lang-ziglang/zvm/spec
+++ b/lang-ziglang/zvm/spec
@@ -1,4 +1,5 @@
 VER=0.7.4
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/tristanisham/zvm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=363557"


### PR DESCRIPTION
Topic Description
-----------------

- zvm: add FIXME note about ABSPLITDBG=0
- zvm: bump REL for topic Revision Marking Guidelines
- zvm: new, 0.7.4

Package(s) Affected
-------------------

- zvm: 0.7.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zvm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
