### PR TITLE
skopeo: new, 1.16.0

### DIFF
--- a/app-containers/skopeo/autobuild/beyond
+++ b/app-containers/skopeo/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Removing files from containers-common"
+# included in containers-common package
+rm -v "$PKGDIR"/etc/containers/policy.json
+rm -v "$PKGDIR"/etc/containers/registries.d/default.yaml

--- a/app-containers/skopeo/autobuild/build
+++ b/app-containers/skopeo/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building skopeo ..."
+make
+
+abinfo "Installing skopeo ..."
+make install DESTDIR="$PKGDIR" PREFIX=/usr

--- a/app-containers/skopeo/autobuild/defines
+++ b/app-containers/skopeo/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=skopeo
+PKGSEC=admin
+PKGDES="Utility for operating on container images and repositories"
+BUILDDEP="go go-md2man gpgme"
+
+ABSPLITDBG=0

--- a/app-containers/skopeo/spec
+++ b/app-containers/skopeo/spec
@@ -1,0 +1,4 @@
+VER=1.16.0
+SRCS="git::commit=tags/v$VER::https://github.com/containers/skopeo"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=9216"


### PR DESCRIPTION
Topic Description
-----------------

- skopeo: new, 1.16.0

Package(s) Affected
-------------------

- skopeo: 1.16.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit skopeo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
