### PR TITLE
buildah: new, 1.37.0

### DIFF
--- a/app-containers/buildah/autobuild/build
+++ b/app-containers/buildah/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building buildah ..."
+make all
+
+abinfo "Installing buildah ..."
+make install DESTDIR="$PKGDIR" PREFIX=/usr

--- a/app-containers/buildah/autobuild/defines
+++ b/app-containers/buildah/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=buildah
+PKGSEC=devel
+PKGDES="Utility for building OCI images"
+BUILDDEP="go gpgme"
+
+ABSPLITDBG=0

--- a/app-containers/buildah/spec
+++ b/app-containers/buildah/spec
@@ -1,0 +1,4 @@
+VER=1.37.0
+SRCS="git::commit=tags/v$VER::https://github.com/containers/buildah"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=14974"


### PR DESCRIPTION
Topic Description
-----------------

- buildah: new, 1.37.0

Package(s) Affected
-------------------

- buildah: 1.37.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit buildah
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
