### PR TITLE
peazip: update to 9.9.0

### DIFF
--- a/app-utils/peazip/spec
+++ b/app-utils/peazip/spec
@@ -1,9 +1,9 @@
-VER=9.8.0
+VER=9.9.0
 SRCS="tbl::rename=peazip-${VER}.src.zip::https://github.com/peazip/PeaZip/releases/download/${VER}/peazip-${VER}.src.zip \
       file::rename=peazip_help.pdf::https://github.com/peazip/PeaZip/releases/download/${VER%.*}.0/peazip_help.pdf \
       tbl::https://github.com/peazip/PeaZip/releases/download/${VER}/peazip-${VER}.about_translations.zip"
-CHKSUMS="sha256::023e95eb698e1645a66315b9db1bf5f996fbc32c9ec41c64d96a2e02e00ab5de \
-         sha256::828e1d202bcd0db61f605aa4cbc52385d3e8697c4621231758ff33d69dbe6ded \
-         sha256::6ed74b24f055680439ad4354065a1d4f290f76d3d6f68ab70064cebc3ea6443e"
+CHKSUMS="sha256::1be24e7036f5fd0b9935cc9fdd6ec57f31402f4c9566df2cf1f34945a65a0fbc \
+         sha256::028de4bd231ba923503502a04680689ecd02a67067d21e2a7e5bbbceb8a65587 \
+         sha256::3a11d193d53b3141116a7daa91a7744acceb06c3caf40e96661a3d5e729ecca8"
 SUBDIR=peazip-${VER}.src
 CHKUPDATE="anitya::id=8759"


### PR DESCRIPTION
Topic Description
-----------------

- peazip: update to 9.9.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- peazip: 9.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit peazip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
