### PR TITLE
vscode: update to 1.92.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,9 +1,8 @@
-VER=1.91.1
+VER=1.92.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::31a13c05295f3349d3dc168d9c67dda4fcf30823fe3c34f215f0324d197f5479"
-CHKSUMS__ARM64="sha256::4021f51ae1dfdb11953a0d0814c82e1dbf4569f14fc9ddea70dc4f4b74cd7765"
+CHKSUMS__AMD64="sha256::52726a61fadce5b933b507c32c3e004b91ffea64e9f7edeb4350c23d4e80b3e3"
+CHKSUMS__ARM64="sha256::ecfc9f73de6029202f0010ddbc2113964dd635e3a901076dbfb3366b04c59cc6"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.92.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- vscode: 1.92.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
