### PR TITLE
discord: update to 0.0.63

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,5 +1,5 @@
-VER=0.0.62
+VER=0.0.63
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::82da1371371960975c944aa2d41731961549a94d8f39d93b5e90eaec3b7960c8"
+CHKSUMS="sha256::2ad557f4424f626cc341dd9b795fdd0d6f238cb0e369c2990eb0fbda42d4c0aa"
 SUBDIR=.
 CHKUPDATE="anitya::id=372593"


### PR DESCRIPTION
Topic Description
-----------------

- discord: update to 0.0.63
    Co-authored-by: SkyBird (@SkyBird233)

Package(s) Affected
-------------------

- discord: 0.0.63

Security Update?
----------------

No

Build Order
-----------

```
#buildit discord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
