### PR TITLE
imhex: new, 1.35.4

### DIFF
--- a/app-editors/imhex/autobuild/defines
+++ b/app-editors/imhex/autobuild/defines
@@ -1,0 +1,19 @@
+PKGNAME=imhex
+PKGSEC=devel
+PKGDEP__with_dotnet="dotnet-runtime-8.0"
+PKGDES="A hex editor with pattern and yara rule support"
+BUILDDEP="yara fmt nlohmann-json capstone llvm boost glfw"
+
+CMAKE_AFTER="-DUSE_SYSTEM_FMT=ON \
+        -DUSE_SYSTEM_YARA=ON \
+        -DUSE_SYSTEM_NLOHMANN_JSON=ON \
+        -DUSE_SYSTEM_CAPSTONE=ON \
+        -DUSE_SYSTEM_LLVM=ON \
+        -DUSE_SYSTEM_BOOST=ON \
+        -DIMHEX_ENABLE_LTO=ON \
+        -DIMHEX_STRIP_RELEASE=OFF \
+        -DIMHEX_ENABLE_UNIT_TESTS=OFF \
+        -DIMHEX_PATTERNS_PULL_MASTER=ON \
+        -DIMHEX_USE_GTK_FILE_PICKER=OFF"
+
+CMAKE_AFTER__without_dotnet="$CMAKE_AFTER -DIMHEX_EXCLUDE_PLUGINS=script_loader"

--- a/app-editors/imhex/autobuild/defines
+++ b/app-editors/imhex/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=imhex
 PKGSEC=devel
 PKGDEP__with_dotnet="dotnet-runtime-8.0"
-PKGDES="A hex editor with pattern and yara rule support"
+PKGDES="A hex editor with Pattern and YARA Rule support"
 BUILDDEP="yara fmt nlohmann-json capstone llvm boost glfw"
 
 CMAKE_AFTER="-DUSE_SYSTEM_FMT=ON \

--- a/app-editors/imhex/autobuild/patches/0001-build-Find-boost-with-name-Boost.patch
+++ b/app-editors/imhex/autobuild/patches/0001-build-Find-boost-with-name-Boost.patch
@@ -1,0 +1,38 @@
+From f11186877a3d077cdf58992190c79fd9d77ac203 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Tue, 6 Aug 2024 15:11:51 +0800
+Subject: [PATCH] build: Find boost with name "Boost"
+
+On many distributions like AOSC OS, Alpine Linux, Arch Linux, etc., boost should be searched with name "Boost".
+This should fix the packaging issue on AOSC OS.
+
+Signed-off-by: xtex <xtexchooser@duck.com>
+---
+ cmake/build_helpers.cmake | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/build_helpers.cmake b/cmake/build_helpers.cmake
+index dce5eaae1b1d..d3bd92cd6a02 100644
+--- a/cmake/build_helpers.cmake
++++ b/cmake/build_helpers.cmake
+@@ -702,8 +702,13 @@ macro(addBundledLibraries)
+     endif()
+ 
+     if (USE_SYSTEM_BOOST)
+-        find_package(boost REQUIRED)
+-        set(BOOST_LIBRARIES boost::regex)
++        find_package(Boost CONFIG QUIET COMPONENTS regex)
++        if (Boost_FOUND)
++            set(BOOST_LIBRARIES Boost::regex)
++        else()
++            find_package(boost REQUIRED)
++            set(BOOST_LIBRARIES boost::regex)
++        endif()
+     else()
+         add_subdirectory(${THIRD_PARTY_LIBS_FOLDER}/boost ${CMAKE_CURRENT_BINARY_DIR}/boost EXCLUDE_FROM_ALL)
+         set(BOOST_LIBRARIES boost::regex)
+
+base-commit: 811214ddb79b66dba5ca56021212f81f9d89d608
+-- 
+2.46.0
+

--- a/app-editors/imhex/spec
+++ b/app-editors/imhex/spec
@@ -1,4 +1,5 @@
 VER=1.35.4
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/WerWolv/ImHex.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141621"

--- a/app-editors/imhex/spec
+++ b/app-editors/imhex/spec
@@ -1,0 +1,4 @@
+VER=1.35.4
+SRCS="git::commit=tags/v$VER::https://github.com/WerWolv/ImHex.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=141621"


### PR DESCRIPTION
Topic Description
-----------------

- imhex: bump REL for topic Revision Marking Guidelines
- imhex: new, 1.35.4

Package(s) Affected
-------------------

- imhex: 1.35.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit imhex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
