### PR TITLE
autobuild4: update to 4.3.13

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.3.10
+VER=4.3.13
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/app-web/hugo/autobuild/beyond
+++ b/app-web/hugo/autobuild/beyond
@@ -1,5 +1,5 @@
 abinfo "Generating man pages..."
-"$SRCDIR"/abbuild/hugo gen man
+"$PKGDIR"/usr/bin/hugo gen man
 
 abinfo "Installing Hugo's man pages..."
 install -Dvm644 "$SRCDIR"/man/*.1 -t "$PKGDIR"/usr/share/man/man1/
@@ -7,11 +7,11 @@ abinfo "Generating and installing hugo's shell auto completion ..."
 mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions/ \
     "$PKGDIR"/usr/share/fish/completions/ \
     "$PKGDIR"/usr/share/zsh/site-functions/ 
-"$SRCDIR"/abbuild/hugo completion bash > \
+"$PKGDIR"/usr/bin/hugo completion bash > \
     "$PKGDIR"/usr/share/bash-completion/completions/"$PKGNAME"
 # FIXME: resolve file belonging issue in further discussion.
 # Commenting out the fish completion for now, as fish also provided the completion file
-# "$SRCDIR"/abbuild/hugo completion fish > \
+# "$PKGDIR"/usr/bin/hugo completion fish > \
 #    "$PKGDIR"/usr/share/fish/completions/"$PKGNAME".fish
-"$SRCDIR"/abbuild/hugo completion zsh > \
+"$PKGDIR"/usr/bin/hugo completion zsh > \
     "$PKGDIR"/usr/share/zsh/site-functions/_"$PKGNAME"

--- a/app-web/hugo/spec
+++ b/app-web/hugo/spec
@@ -2,4 +2,4 @@ VER=0.129.0
 SRCS="git::commit=tags/v$VER::https://github.com/gohugoio/hugo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12959"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- hugo: fix build fails
- autobuild4: update to 4.3.13
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 hugo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
