### PR TITLE
audacity: update to 3.6.1

### DIFF
--- a/app-creativity/audacity/spec
+++ b/app-creativity/audacity/spec
@@ -1,5 +1,4 @@
-VER=3.6.0
-REL=1
+VER=3.6.1
 SRCS="git::commit=tags/Audacity-$VER::https://github.com/audacity/audacity"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=139"


### PR DESCRIPTION
Topic Description
-----------------

- audacity: update to 3.6.1
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- audacity: 3.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit audacity
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
