### PR TITLE
acbs: update to 20240806

### DIFF
--- a/app-devel/acbs/spec
+++ b/app-devel/acbs/spec
@@ -1,4 +1,4 @@
-VER=20240720
+VER=20240806
 SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/acbs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226984"

--- a/lang-python/pybind11/autobuild/build
+++ b/lang-python/pybind11/autobuild/build
@@ -5,7 +5,7 @@ PY3_BUILDDIR="$SRCDIR/build-py3"
 # $1 build dir; $2 python executable
 build_pybind11() {
   mkdir -pv "$1"
-  cmake "$SRCDIR" -B "$1" $CMAKE_DEF -DPYBIND11_TEST=OFF \
+  cmake "$SRCDIR" -B "$1" ${CMAKE_DEF[@]} -DPYBIND11_TEST=OFF \
                   -DPYTHON_EXECUTABLE=/usr/bin/"$2" -DPYBIND11_INSTALL=TRUE \
                   -DUSE_PYTHON_INCLUDE_DIR=FALSE -GNinja
   DESTDIR="$PKGDIR" ninja -C "$1" install
@@ -13,9 +13,6 @@ build_pybind11() {
   PYBIND11_USE_CMAKE=true "$2" setup.py install $MAKE_AFTER --prefix=/usr --root="$PKGDIR" --optimize=1
   "$2" setup.py clean || true
 }
-
-abinfo "Building pybind11 for Python 2 ..."
-build_pybind11 "$PY2_BUILDDIR" "python2"
 
 abinfo "Building pybind11 for Python 3 ..."
 build_pybind11 "$PY3_BUILDDIR" "python3"

--- a/lang-python/pybind11/spec
+++ b/lang-python/pybind11/spec
@@ -1,4 +1,5 @@
 VER=2.11.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/pybind/pybind11"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138380"


### PR DESCRIPTION
Topic Description
-----------------

- pybind11: fix remove python2 build
    - support for python 2 has been removed in pybind 2.10.0, so remove it
- acbs: update to 20240806
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- acbs: 2:20240806

Security Update?
----------------

No

Build Order
-----------

```
#buildit acbs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
