### PR TITLE
perl: append executable paths unconditionally

### DIFF
--- a/lang-perl/perl/autobuild/build
+++ b/lang-perl/perl/autobuild/build
@@ -53,7 +53,3 @@ abinfo "Creating symlinks for core executables ..."
 abinfo "Purging metadata files ..."
 find "$PKGDIR" -name perllocal.pod -delete
 find "$PKGDIR" -name .packlist -delete
-
-abinfo "Moving /usr/bin/core_perl/* => /usr/bin ..."
-mv -v "$PKGDIR"/usr/bin/core_perl/* \
-    "$PKGDIR"/usr/bin/

--- a/lang-perl/perl/autobuild/overrides/etc/bashrc.d/perl.sh
+++ b/lang-perl/perl/autobuild/overrides/etc/bashrc.d/perl.sh
@@ -1,5 +1,1 @@
-[ -d /usr/bin/site_perl ] && PATH="$PATH:/usr/bin/site_perl"
-[ -d /usr/lib/perl5/site_perl/bin ] && PATH="$PATH:/usr/lib/perl5/site_perl/bin"
-[ -d /usr/bin/vendor_perl ] && PATH="$PATH:/usr/bin/vendor_perl"
-[ -d /usr/lib/perl5/vendor_perl/bin ] && PATH="$PATH:/usr/lib/perl5/vendor_perl/bin"
-[ -d /usr/bin/core_perl ] && PATH="$PATH:/usr/bin/core_perl"
+PATH="$PATH:/usr/bin/site_perl:/usr/lib/perl5/site_perl/bin:/usr/bin/vendor_perl:/usr/lib/perl5/vendor_perl/bin:/usr/bin/core_perl:/usr/lib/perl5/core_perl/bin"

--- a/lang-perl/perl/spec
+++ b/lang-perl/perl/spec
@@ -1,5 +1,5 @@
 VER=5.36.3
-REL=1
+REL=2
 SRCS="tbl::https://www.cpan.org/src/5.0/perl-${VER}.tar.xz"
 CHKSUMS="sha256::45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd"
 CHKUPDATE="anitya::id=13599"

--- a/lang-perl/perl/spec
+++ b/lang-perl/perl/spec
@@ -1,5 +1,5 @@
 VER=5.36.3
-REL=2
+REL=3
 SRCS="tbl::https://www.cpan.org/src/5.0/perl-${VER}.tar.xz"
 CHKSUMS="sha256::45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd"
 CHKUPDATE="anitya::id=13599"


### PR DESCRIPTION
Topic Description
-----------------

- perl: bump REL for topic Revision Marking Guidelines
- perl: append PATH unconditionally
    Previously, the profile script only appends Perl core, site, and vendor
    executable paths only if the paths exist. This can cause issues where a
    package creates one of those paths, as the user would not immediately be able
    to make use of the executables they installed (until the next login).
    Append PATHs unconditionally since it would not cause problems if any of the
    paths do not exist.

Package(s) Affected
-------------------

- perl: 4:5.36.3-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
