### PR TITLE
wayland: update to 1.23.0

### DIFF
--- a/desktop-kde/kwin/spec
+++ b/desktop-kde/kwin/spec
@@ -1,4 +1,5 @@
 VER=5.27.11
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwin-$VER.tar.xz"
 CHKSUMS="sha256::8902b23b29bd54cd26590fe04abfe58fe334a5bf9c0dfd1f7dc5aacc4191b56f"
 CHKUPDATE="anitya::id=8761"

--- a/runtime-display/wayland/autobuild/defines
+++ b/runtime-display/wayland/autobuild/defines
@@ -4,13 +4,7 @@ PKGDEP="libffi expat libxml2 wayland-protocols"
 BUILDDEP="docbook-xsl doxygen xmlto graphviz"
 PKGDES="A display server to replace X.Org"
 
+ABTYPE=meson
 NOLTO=1
-PKGBREAK="mesa<=1:18.1.7-1"
+PKGBREAK="mesa<=1:18.1.7-1 kwin<=5.27.11"
 PKGREP="mesa<=1:18.1.7-1"
-
-# FIXME: dot SIGILLs at the following command.
-#
-# /usr/bin/dot -Tpng -odoc/doxygen/xml/wayland-architecture.png ../doc/doxygen/dot/wayland-architecture.gv
-MESON_AFTER__MIPS64R6EL=" \
-             ${MESON_AFTER} \
-             -Ddocumentation=false"

--- a/runtime-display/wayland/autobuild/defines.stage2
+++ b/runtime-display/wayland/autobuild/defines.stage2
@@ -5,7 +5,7 @@ BUILDDEP="docbook-xsl doxygen xmlto graphviz"
 PKGDES="A display server to replace X.Org"
 
 NOLTO=1
-PKGBREAK="mesa<=1:18.1.7-1"
+PKGBREAK="mesa<=1:18.1.7-1 kwin<=5.27.11"
 PKGREP="mesa<=1:18.1.7-1"
 
 # FIXME: dot SIGILLs

--- a/runtime-display/wayland/spec
+++ b/runtime-display/wayland/spec
@@ -1,4 +1,4 @@
-VER=1.22.0
+VER=1.23.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wayland/wayland"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10061"


### PR DESCRIPTION
Topic Description
-----------------

- wayland: update to 1.23.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- wayland: 1.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wayland kwin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
