### PR TITLE
zfs: update to 2.2.5

### DIFF
--- a/app-admin/zfs/autobuild/patches/0001-Block-manual-building-in-the-DKMS-source-tree.patch
+++ b/app-admin/zfs/autobuild/patches/0001-Block-manual-building-in-the-DKMS-source-tree.patch
@@ -1,7 +1,7 @@
-From c092c64a2588822fd152b268aa47a2346171304c Mon Sep 17 00:00:00 2001
+From ad5d2391cfbbf292178d5906843d60c281530a44 Mon Sep 17 00:00:00 2001
 From: Shengqi Chen <harry-chen@outlook.com>
 Date: Tue, 16 Jul 2024 15:28:03 +0800
-Subject: [PATCH 1/4] Block manual building in the DKMS source tree.
+Subject: [PATCH 1/5] Block manual building in the DKMS source tree.
 
 To avoid messing up future DKMS builds and the zfs installation, block manual building of the DKMS source tree.
 
@@ -16,7 +16,7 @@ See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd0
 
 diff --git a/config/dkms.m4 b/config/dkms.m4
 new file mode 100644
-index 00000000..cfa11529
+index 000000000..cfa115296
 --- /dev/null
 +++ b/config/dkms.m4
 @@ -0,0 +1,14 @@
@@ -35,7 +35,7 @@ index 00000000..cfa11529
 +        ])
 +])
 diff --git a/config/user.m4 b/config/user.m4
-index 6ec27a5b..9a624ab5 100644
+index badd920d2..a8a5fda3c 100644
 --- a/config/user.m4
 +++ b/config/user.m4
 @@ -2,6 +2,7 @@ dnl #

--- a/app-admin/zfs/autobuild/patches/0002-Enable-zed-emails.patch
+++ b/app-admin/zfs/autobuild/patches/0002-Enable-zed-emails.patch
@@ -1,7 +1,7 @@
-From b13e17882e0fb3d14a9c500b5dfd3a30774687ed Mon Sep 17 00:00:00 2001
+From 155d304e9b5081d41b27dafa7a8ff0a7b6ce000c Mon Sep 17 00:00:00 2001
 From: Richard Laager <rlaager@wiktel.com>
 Date: Tue, 16 Jul 2024 15:30:50 +0800
-Subject: [PATCH 2/4] Enable zed emails
+Subject: [PATCH 2/5] Enable zed emails
 
 The OpenZFS event daemon monitors pools. This patch enables the email sending function by default (if zed is installed). This is consistent with the default behavior of mdadm.
 
@@ -11,7 +11,7 @@ See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd0
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/cmd/zed/zed.d/zed.rc b/cmd/zed/zed.d/zed.rc
-index bc269b15..e6d4b170 100644
+index bc269b155..e6d4b1703 100644
 --- a/cmd/zed/zed.d/zed.rc
 +++ b/cmd/zed/zed.d/zed.rc
 @@ -41,7 +41,7 @@ ZED_EMAIL_ADDR="root"

--- a/app-admin/zfs/autobuild/patches/0003-Explicitly-load-the-ZFS-module-via-systemd-service.patch
+++ b/app-admin/zfs/autobuild/patches/0003-Explicitly-load-the-ZFS-module-via-systemd-service.patch
@@ -1,7 +1,7 @@
-From 14173a0ad45b770324a8f44962ffba9c92bf4105 Mon Sep 17 00:00:00 2001
+From 4ad539fbe1f7f0e6246f03801185fef1385aba83 Mon Sep 17 00:00:00 2001
 From: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Date: Tue, 16 Jul 2024 15:35:34 +0800
-Subject: [PATCH 3/4] Explicitly load the ZFS module via systemd service
+Subject: [PATCH 3/5] Explicitly load the ZFS module via systemd service
 
 See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd01921cfaa7ce1bad87/debian/patches/2100-zfs-load-module.patch
 ---
@@ -15,7 +15,7 @@ See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd0
  create mode 100644 etc/systemd/system/zfs-load-module.service.in
 
 diff --git a/contrib/dracut/90zfs/module-setup.sh.in b/contrib/dracut/90zfs/module-setup.sh.in
-index acad468e..58a98d77 100755
+index acad468ed..58a98d77a 100755
 --- a/contrib/dracut/90zfs/module-setup.sh.in
 +++ b/contrib/dracut/90zfs/module-setup.sh.in
 @@ -95,7 +95,8 @@ install() {
@@ -29,7 +29,7 @@ index acad468e..58a98d77 100755
  			systemctl -q --root "${initdir}" add-wants zfs-import.target "${_service}"
  
 diff --git a/etc/Makefile.am b/etc/Makefile.am
-index 7187762d..9ae38bd8 100644
+index 7187762d3..9ae38bd85 100644
 --- a/etc/Makefile.am
 +++ b/etc/Makefile.am
 @@ -52,6 +52,7 @@ dist_systemdpreset_DATA = \
@@ -41,7 +41,7 @@ index 7187762d..9ae38bd8 100644
  	%D%/systemd/system/zfs-import-scan.service \
  	%D%/systemd/system/zfs-import.target \
 diff --git a/etc/systemd/system/50-zfs.preset b/etc/systemd/system/50-zfs.preset
-index e4056a92..b53e2c8a 100644
+index e4056a92c..b53e2c8a8 100644
 --- a/etc/systemd/system/50-zfs.preset
 +++ b/etc/systemd/system/50-zfs.preset
 @@ -7,3 +7,4 @@ enable zfs-share.service
@@ -50,7 +50,7 @@ index e4056a92..b53e2c8a 100644
  enable zfs.target
 +enable zfs-load-module.service
 diff --git a/etc/systemd/system/zfs-import-cache.service.in b/etc/systemd/system/zfs-import-cache.service.in
-index fd822989..7e1fea5f 100644
+index fd822989d..7e1fea5f8 100644
 --- a/etc/systemd/system/zfs-import-cache.service.in
 +++ b/etc/systemd/system/zfs-import-cache.service.in
 @@ -3,7 +3,9 @@ Description=Import ZFS pools by cache file
@@ -64,7 +64,7 @@ index fd822989..7e1fea5f 100644
  After=multipathd.service
  After=systemd-remount-fs.service
 diff --git a/etc/systemd/system/zfs-import-scan.service.in b/etc/systemd/system/zfs-import-scan.service.in
-index c5dd45d8..ca506891 100644
+index c5dd45d87..ca506891a 100644
 --- a/etc/systemd/system/zfs-import-scan.service.in
 +++ b/etc/systemd/system/zfs-import-scan.service.in
 @@ -3,7 +3,9 @@ Description=Import ZFS pools by device scanning
@@ -79,7 +79,7 @@ index c5dd45d8..ca506891 100644
  Before=zfs-import.target
 diff --git a/etc/systemd/system/zfs-load-module.service.in b/etc/systemd/system/zfs-load-module.service.in
 new file mode 100644
-index 00000000..d74af046
+index 000000000..d74af0468
 --- /dev/null
 +++ b/etc/systemd/system/zfs-load-module.service.in
 @@ -0,0 +1,17 @@

--- a/app-admin/zfs/autobuild/patches/0004-Force-libtool-to-produce-verbose-output.patch
+++ b/app-admin/zfs/autobuild/patches/0004-Force-libtool-to-produce-verbose-output.patch
@@ -1,7 +1,7 @@
-From 8efc7a4277f960e8611f2ab5669e3a47d675f9d4 Mon Sep 17 00:00:00 2001
+From cc8c0ba185d23f329e1db1034d051a793f8b073f Mon Sep 17 00:00:00 2001
 From: Mo Zhou <lumin@debian.org>
 Date: Tue, 16 Jul 2024 15:37:19 +0800
-Subject: [PATCH 4/4] Force libtool to produce verbose output
+Subject: [PATCH 4/5] Force libtool to produce verbose output
 
 See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd01921cfaa7ce1bad87/debian/patches/force-verbose-rules.patch
 ---
@@ -9,7 +9,7 @@ See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd0
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/config/Rules.am b/config/Rules.am
-index 2e463ae6..d71d8239 100644
+index 2e463ae60..d71d82394 100644
 --- a/config/Rules.am
 +++ b/config/Rules.am
 @@ -12,7 +12,7 @@ AM_CPPFLAGS = \

--- a/app-admin/zfs/autobuild/patches/0005-META-Bump-Linux-Maximum-to-6.10.patch
+++ b/app-admin/zfs/autobuild/patches/0005-META-Bump-Linux-Maximum-to-6.10.patch
@@ -1,0 +1,26 @@
+From 660bf235f2d3d801229176fe1d1132c6d203bd31 Mon Sep 17 00:00:00 2001
+From: Shengqi Chen <harry-chen@outlook.com>
+Date: Tue, 13 Aug 2024 16:16:39 +0800
+Subject: [PATCH 5/5] META: Bump Linux-Maximum to 6.10
+
+See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/master/debian/patches/bump-linux-maximum.patch
+
+Signed-off-by: Shengqi Chen <harry-chen@outlook.com>
+---
+ META | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/META b/META
+index 14cfc5f00..35428285e 100644
+--- a/META
++++ b/META
+@@ -6,5 +6,5 @@ Release:       1
+ Release-Tags:  relext
+ License:       CDDL
+ Author:        OpenZFS
+-Linux-Maximum: 6.9
++Linux-Maximum: 6.10
+ Linux-Minimum: 3.10
+-- 
+2.39.2
+

--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,5 +1,4 @@
-VER=2.2.4
-REL=2
+VER=2.2.5
 SRCS="tbl::https://github.com/zfsonlinux/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
-CHKSUMS="sha256::9790905f7683d41759418e1ef3432828c31116654ff040e91356ff1c21c31ec0"
+CHKSUMS="sha256::2388cf6f29cd75e87d6d05e4858a09d419c4f883a658d51ef57796121cd08897"
 CHKUPDATE="anitya::id=11706"

--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,4 +1,5 @@
 VER=2.2.5
+REL=1
 SRCS="tbl::https://github.com/zfsonlinux/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
 CHKSUMS="sha256::2388cf6f29cd75e87d6d05e4858a09d419c4f883a658d51ef57796121cd08897"
 CHKUPDATE="anitya::id=11706"


### PR DESCRIPTION
Topic Description
-----------------

- zfs: bump REL for topic Revision Marking Guidelines
- zfs: update to 2.2.5
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- zfs: 2.2.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
