### PR TITLE
ghidra: 11.1.2 rework

### DIFF
--- a/app-devel/ghidra/autobuild/build
+++ b/app-devel/ghidra/autobuild/build
@@ -1,12 +1,24 @@
+# FIXME: ghidra known issue (#2166)
+export LC_MESSAGES=en_US.UTF-8
+
 abinfo "Replacing version number in the manifest ..."
 sed -i "s/application.version=.*\$/application.version=${PKGVER}/" Ghidra/application.properties
 sed -i 's/application.release.name=.*$/application.release.name=PUBLIC/' Ghidra/application.properties
 
-abinfo "Downloading dependencies ..."
-gradle --init-script gradle/support/fetchDependencies.gradle init
+abinfo "Downloading non-Maven Central dependencies ..."
+gradle --init-script gradle/support/fetchDependencies.gradle
+
+abinfo "Downloading Maven Central dependencies ..."
+gradle prepdev
+
+abinfo "Building native components ..."
+gradle buildNatives
 
 abinfo "Compiling language module caches ..."
 gradle sleighCompile
+
+abinfo "Building Python3 debugger packages ..."
+gradle buildPyPackage
 
 abinfo "Building Ghidra ..."
 gradle buildGhidra

--- a/app-devel/ghidra/spec
+++ b/app-devel/ghidra/spec
@@ -1,5 +1,6 @@
 UPSTREAM_VER=11.1.2_build
 VER=${UPSTREAM_VER/_build/}
+REL=1
 SRCS="git::commit=tags/Ghidra_${VER}_build;rename=ghidra::https://github.com/NationalSecurityAgency/ghidra"
 SUBDIR="ghidra"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- ghidra: remove explicit init task on fetching deps
    - running init task will lead to an interactive ask

Package(s) Affected
-------------------

- ghidra: 11.1.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ghidra
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
