### PR TITLE
obs-studio: fix ffmpeg av1 unavailable bug

### DIFF
--- a/app-multimedia/obs-studio/spec
+++ b/app-multimedia/obs-studio/spec
@@ -1,4 +1,5 @@
 VER=30.2.2
+REL=1
 # __OBS_CEF_VER: Find the build version on https://cef-builds.spotifycdn.com/index.html#linux64
 # FIXME: 126.x has https://github.com/chromiumembedded/cef/issues/3616#issuecomment-2158624330
 __OBS_CEF_VER="125.0.22+gc410c95+chromium-125.0.6422.142"


### PR DESCRIPTION
Topic Description
-----------------

- obs-studio: try to rebuild with latest ffmpeg and mesa

Package(s) Affected
-------------------

- obs-studio: 30.2.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit obs-studio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
