### PR TITLE
grub (GRand Unified Bootloader): add old-world firmware support for LoongArch

### DIFF
--- a/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,7 +1,7 @@
 From 2ec97c359ea87a2152e4076770c9ec8f7cbd225d Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:54 +0200
-Subject: [PATCH 01/22] Revert "templates: Properly disable the os-prober by
+Subject: [PATCH 01/23] Revert "templates: Properly disable the os-prober by
  default"
 
 This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.
@@ -71,5 +71,5 @@ index 656301eaf..30f27f15b 100644
  
  osx_entry() {
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,7 +1,7 @@
 From a3daa95d2769516586f7c38af93029663c9133a4 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:58 +0200
-Subject: [PATCH 02/22] Revert "templates: Disable the os-prober by default"
+Subject: [PATCH 02/23] Revert "templates: Disable the os-prober by default"
 
 This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
 ---
@@ -69,5 +69,5 @@ index 30f27f15b..f300e46fc 100644
  
  osx_entry() {
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
+++ b/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
@@ -1,7 +1,7 @@
 From 6bd3d7c7b9e643f6452e8dff6fcebc60d2c4d512 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 17:49:45 -0400
-Subject: [PATCH 03/22] Don't add '*' to highlighted row
+Subject: [PATCH 03/23] Don't add '*' to highlighted row
 
 It is already highlighted.
 ---
@@ -22,5 +22,5 @@ index b1321eb26..b147e0657 100644
    grub_print_ucs4_menu (unicode_title,
  			unicode_title + len,
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
+++ b/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
@@ -1,7 +1,7 @@
 From e5c241ea0ea922abbb2ecb8b3140518a6e2a03cd Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:08:23 -0400
-Subject: [PATCH 04/22] Fix border spacing now that we aren't displaying it
+Subject: [PATCH 04/23] Fix border spacing now that we aren't displaying it
 
 ---
  grub-core/normal/menu_text.c | 6 +++---
@@ -28,5 +28,5 @@ index b147e0657..e5960fd65 100644
    geo->timeout_lines = 2;
  
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
+++ b/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
@@ -1,7 +1,7 @@
 From 2b35e4db8d9f1f9cab8004e0761a28be960fbf7f Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:30:55 -0400
-Subject: [PATCH 05/22] Indent menu entries
+Subject: [PATCH 05/23] Indent menu entries
 
 ---
  grub-core/normal/menu_text.c | 3 ++-
@@ -22,5 +22,5 @@ index e5960fd65..fd1de05e3 100644
    grub_print_ucs4_menu (unicode_title,
  			unicode_title + len,
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
+++ b/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
@@ -1,7 +1,7 @@
 From d21e8096b9cc9eecfe6da4bb101c6d5d43cec3c5 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:59:36 -0400
-Subject: [PATCH 06/22] Fix margins
+Subject: [PATCH 06/23] Fix margins
 
 ---
  grub-core/normal/menu_text.c | 8 +++-----
@@ -33,5 +33,5 @@ index fd1de05e3..371524bf2 100644
      - geo->timeout_lines /* timeout */
      - 1 /* empty final line  */;
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
+++ b/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
@@ -1,7 +1,7 @@
 From 8ea6cc861054a03a1b437356a0b9b114a0d21adf Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Fri, 21 Jun 2013 14:44:08 -0400
-Subject: [PATCH 07/22] Use -2 instead of -1 for our right-hand margin, so
+Subject: [PATCH 07/23] Use -2 instead of -1 for our right-hand margin, so
  linewrapping works (#976643).
 
 Signed-off-by: Peter Jones <grub2-owner@fedoraproject.org>
@@ -23,5 +23,5 @@ index 371524bf2..f83f7ca54 100644
    geo->first_entry_y = 3; /* three empty lines*/
  
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
+++ b/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
@@ -1,7 +1,7 @@
 From 59c31c490870dd98bc6ca72862a97862bcef0c1b Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 14 Mar 2011 14:27:42 -0400
-Subject: [PATCH 08/22] Don't say "GNU/Linux" in generated menus.
+Subject: [PATCH 08/23] Don't say "GNU/Linux" in generated menus.
 
 ---
  util/grub.d/10_linux.in     | 4 ++--
@@ -41,5 +41,5 @@ index 94dd8be13..98ee5bc58 100644
  fi
  
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
@@ -1,7 +1,7 @@
 From 12e6fa95ada35a999b46adcbc35a34a73d178ebf Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 16:47:33 -0400
-Subject: [PATCH 09/22] Don't draw a border around the menu
+Subject: [PATCH 09/23] Don't draw a border around the menu
 
 It looks cleaner without it.
 ---
@@ -70,5 +70,5 @@ index f83f7ca54..982ef9100 100644
    grub_term_highlight_color = old_color_highlight;
    geo->timeout_y = geo->first_entry_y + geo->num_entries
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
+++ b/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
@@ -1,7 +1,7 @@
 From 8a14427edcdf93bc2c38822465d1082672bb9263 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 10:52:32 -0400
-Subject: [PATCH 10/22] Use the standard margin for the timeout string
+Subject: [PATCH 10/23] Use the standard margin for the timeout string
 
 So that it aligns with the other messages
 ---
@@ -39,5 +39,5 @@ index 982ef9100..986877454 100644
      }
  
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
+++ b/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
@@ -1,7 +1,7 @@
 From 5ff724e6a6e01cb6f03f5ce09d6cb01a44ad3d67 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:14 -0800
-Subject: [PATCH 11/22] grub-mkrescue: specify -iso-level 3
+Subject: [PATCH 11/23] grub-mkrescue: specify -iso-level 3
 
 This allows GRUB rescue ISOs to boot on LoongArch firmware.
 ---
@@ -22,5 +22,5 @@ index abcc1c2f5..27696e034 100644
    iso9660_dir = grub_util_make_temporary_dir ();
    grub_util_info ("temporary iso9660 dir is `%s'", iso9660_dir);
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
+++ b/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
@@ -1,7 +1,7 @@
 From b127120988f3d85ebc75c493eba08fc54c8b99dd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:42 -0800
-Subject: [PATCH 12/22] 10_linux: do not count intel-ucode image as a valid
+Subject: [PATCH 12/23] 10_linux: do not count intel-ucode image as a valid
  initrd
 
 ---
@@ -23,5 +23,5 @@ index c9bde9182..e896c0c1a 100644
      # no initrd or builtin initramfs, it can't work here.
      if [ "x${GRUB_DEVICE_PARTUUID}" = "x" ] \
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
+++ b/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
@@ -1,7 +1,7 @@
 From 42a8d6a924f700586328325eb3abe28c4055cc5e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:12:01 -0800
-Subject: [PATCH 13/22] util: add GRUB_COLOR_* variables
+Subject: [PATCH 13/23] util: add GRUB_COLOR_* variables
 
 ---
  util/grub-mkconfig.in    | 2 ++
@@ -41,5 +41,5 @@ index 6a316a5ba..6816e09d4 100644
  gfxterm=0;
  for x in ${GRUB_TERMINAL_INPUT} ${GRUB_TERMINAL_OUTPUT}; do
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
@@ -1,7 +1,7 @@
 From 5b839a619f7d871de5d6666bde4875c6a262edec Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:26:57 -0800
-Subject: [PATCH 14/22] grub-core: drop GRUB title from the menu
+Subject: [PATCH 14/23] grub-core: drop GRUB title from the menu
 
 We did not display it before, and it's really not very useful since we don't
 encourage reinstalling GRUB anyway.
@@ -23,5 +23,5 @@ index bd4431000..ca123caac 100644
      return;
  
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
+++ b/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
@@ -1,7 +1,7 @@
 From 4b607755f602b9844d637c7b7f48617600764238 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Jan 2024 13:58:02 +0800
-Subject: [PATCH 15/22] grub-install: add /efi to the candidate of the ESP
+Subject: [PATCH 15/23] grub-install: add /efi to the candidate of the ESP
  mountpoints
 
 ---
@@ -29,5 +29,5 @@ index 7dc5657bb..c5eef8ac6 100644
  	    The EFI System Partition may have been given directly using
  	    --root-directory.
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
+++ b/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
@@ -1,7 +1,7 @@
 From df48d64d21efa1e01ab1cf24f30e07e9efecf923 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 10 Nov 2023 10:57:02 +0800
-Subject: [PATCH 16/22] commands: add new command memsize
+Subject: [PATCH 16/23] commands: add new command memsize
 
 - This command traverses the entire GRUB memory map, adds the size of each
   region together. The result is the total amount of system memory
@@ -361,5 +361,5 @@ index 000000000..9c67971ac
 +  grub_unregister_extcmd (cmd);
 +}
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
+++ b/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
@@ -1,7 +1,7 @@
 From 0ded438a6ab7e8d11922582bf90a7dfa6b7fdcd4 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Mon, 10 Jul 2023 00:14:13 +0800
-Subject: [PATCH 17/22] commands: add new command 'pause'
+Subject: [PATCH 17/23] commands: add new command 'pause'
 
 - Simple enough, this command prints out a prompt, either pre-defined or
   user specified, and awaits a key stroke from the user.
@@ -88,5 +88,5 @@ index 000000000..39d193a17
 +  grub_unregister_extcmd (cmd);
 +}
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
+++ b/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
@@ -1,7 +1,7 @@
 From f608b5788b0e653ad9c2bbdcf078287f2a88d204 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 21:30:22 +0800
-Subject: [PATCH 18/22] normal: align countdown text with rest of the UI
+Subject: [PATCH 18/23] normal: align countdown text with rest of the UI
 
 And add an extra blank line above it.
 ---
@@ -23,5 +23,5 @@ index 986877454..584620a52 100644
    if (data->timeout_msg == TIMEOUT_TERSE
        || data->timeout_msg == TIMEOUT_TERSE_NO_MARGIN)
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
+++ b/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
@@ -1,7 +1,7 @@
 From 1e1ce61d967cc992b44c5206cc0cfe21cd44c7ff Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 22:21:55 +0800
-Subject: [PATCH 19/22] po: add patch to disable parallel execution
+Subject: [PATCH 19/23] po: add patch to disable parallel execution
 
 - `msgfilter' might fail while processing de.po to generate de_CH.po, if
   there are too many prarallel jobs.
@@ -76,5 +76,5 @@ index 000000000..0cef9fafe
 +2.39.1
 +
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
+++ b/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
@@ -1,7 +1,7 @@
 From 30e70b8cda4b71b524c413954002d4a5961872a0 Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Tue, 30 Jan 2024 14:41:10 +0800
-Subject: [PATCH 20/22] util/bash-completion: Load scripts on demand
+Subject: [PATCH 20/23] util/bash-completion: Load scripts on demand
 
 There are two system directories for bash-completion scripts. One is
 /usr/share/bash-completion/completions/ and the other is
@@ -856,5 +856,5 @@ index 000000000..6123d7b7c
 +# End:
 +# ex: ts=4 sw=4 et filetype=sh
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
+++ b/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
@@ -1,7 +1,7 @@
 From 209de8a3053c8b0e223836d5b29fe95e0a33b857 Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Mon, 25 Mar 2024 10:11:34 +0800
-Subject: [PATCH 21/22] util/bash-completion: Fix for bash-completion 2.12
+Subject: [PATCH 21/23] util/bash-completion: Fix for bash-completion 2.12
 
 _split_longopt() was the bash-completion private API and removed since
 bash-completion 2.12. This commit initializes the bash-completion
@@ -185,5 +185,5 @@ index 4c88ee901..749a5d3cf 100644
      if [[ "$cur" == -* ]]; then
          __grubcomp "$(__grub_get_options_from_help)"
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
+++ b/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
@@ -1,7 +1,7 @@
 From 8a52d2d391b662681f7c92286ab9e45906119b5d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 11 Jun 2024 22:40:24 +0800
-Subject: [PATCH 22/22] util/grub-mkrescue: use capitalised paths for removable
+Subject: [PATCH 22/23] util/grub-mkrescue: use capitalised paths for removable
  EFI images
 
 Per UEFI Specification, section 3.4.1.1:
@@ -93,5 +93,5 @@ index 27696e034..cfb749967 100644
        free (imgname);
  
 -- 
-2.43.4
+2.46.0
 

--- a/app-admin/grub/autobuild/patches/0023-loongarch64-able-to-start-on-legacy-firmware.patch
+++ b/app-admin/grub/autobuild/patches/0023-loongarch64-able-to-start-on-legacy-firmware.patch
@@ -1,0 +1,48 @@
+From 6740b5a0d995e41d1407ed844f4f5e358df9a421 Mon Sep 17 00:00:00 2001
+From: Miao Wang <shankerwangmiao@gmail.com>
+Date: Wed, 17 Jul 2024 09:16:26 +0800
+Subject: [PATCH 23/23] loongarch64: able to start on legacy firmware
+
+On legacy firmware, the DMW is already enabled by the firmware, and the
+addresses in all the pointers and the PC register are virtual addresses.
+GRUB, however, is location independent, so will not be affected. The
+only problem happens at the GRUB_EFI_MAX_USABLE_ADDRESS, which should
+be dynamically decided by detecting if DMW is enabled.
+---
+ include/grub/loongarch64/efi/memory.h | 21 ++++++++++++++++++++-
+ 1 file changed, 20 insertions(+), 1 deletion(-)
+
+diff --git a/include/grub/loongarch64/efi/memory.h b/include/grub/loongarch64/efi/memory.h
+index d460267be..534ba4b32 100644
+--- a/include/grub/loongarch64/efi/memory.h
++++ b/include/grub/loongarch64/efi/memory.h
+@@ -19,6 +19,25 @@
+ #ifndef GRUB_MEMORY_CPU_HEADER
+ #include <grub/efi/memory.h>
+ 
+-#define GRUB_EFI_MAX_USABLE_ADDRESS 0xfffffffffffULL
++static inline grub_uint64_t
++grub_efi_max_usable_address(void)
++{
++  static grub_uint64_t addr;
++  static int addr_valid = 0;
++
++  if (!addr_valid)
++  {
++    asm volatile ("csrrd %0, 0x181" : "=r" (addr));
++    if (addr & 0x1)
++      addr |= 0xfffffffffffUL;
++    else
++      addr = 0xfffffffffffUL;
++    addr_valid = 1;
++  }
++
++  return addr;
++}
++
++#define GRUB_EFI_MAX_USABLE_ADDRESS (grub_efi_max_usable_address())
+ 
+ #endif /* ! GRUB_MEMORY_CPU_HEADER */
+-- 
+2.46.0
+

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -1,14 +1,14 @@
 UPSTREAM_VER=2.12
 # Note: For use inside autobuild/.
 # Note: 2.12-rc1+unifont15.1.04 => 2.12~rc1+unifont15.1.04
-__GRUB_VER=${UPSTREAM_VER/\-/~}
+__GRUBVER=${UPSTREAM_VER/\-/~}
 __UNIFONTVER=15.1.04
 # Note: Please check for translation updates each time updating GRUB at:
 # https://translationproject.org/domain/grub.html
 LINGUAS_VER=2.12-rc1
 
-VER=${__GRUB_VER}+unifont${__UNIFONTVER}
-REL=3
+VER=${__GRUBVER}+unifont${__UNIFONTVER}
+REL=4
 RETROFONTVER=20200402
 
 SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https://git.savannah.gnu.org/git/grub.git \
@@ -61,7 +61,7 @@ CHKSUMS="SKIP \
          sha256::297fa257b46e6b83bf85adb6a934e437b0e1fd987cdfe596cb63b65d8053c082 \
          sha256::444c7b230da7f0580bf2014f752d361ffd52e54da47674423d85c4c07903cbc8 \
          sha256::29616fbb8b18c591ff05355c7fa71b4668c1d3ce20f9de7bd2ae04245f117c94 \
-         sha256::b1f75dc2ffac9b538017d14af1e32cb4db6510ef389d806d4a2c7270d970e372 \
+         sha256::e550b680f305d2606a90561a5262ed8ff6d65a53f67c07146e4e9e10f073b8d1 \
          sha256::6bbb1487539da6c8e2fa66fee412c6ed0c4d07d1f227f2155785bc8cfc1f193d \
          sha256::b0fc789b2cc8a4aecacb49faa276e0b7984e911bd52e8214798f168441798994 \
          sha256::2c47a944a28106cae79938f6f738a6a10cdeaaaff180c4c603f13414eb2776e1 \

--- a/app-utils/os-prober/autobuild/build
+++ b/app-utils/os-prober/autobuild/build
@@ -1,16 +1,47 @@
-make newns
+abinfo "Building os-prober ..."
+make \
+    CFLAGS="${CPPFLAGS} ${CFLAGS}"
+    LDFLAGS="${LDFLAGS}"
 
-install -Dm755 linux-boot-prober "$PKGDIR"/usr/bin/linux-boot-prober
-install -Dm755 os-prober "$PKGDIR"/usr/bin/os-prober
-install -Dm755 newns "$PKGDIR"/usr/lib/os-prober/newns
-install -Dm755 common.sh "$PKGDIR"/usr/share/os-prober/common.sh  
+# Note: Follow debian/os-prober.install
+abinfo "Installing os-prober executables ..."
+install -Dvm755 "$SRCDIR"/linux-boot-prober \
+    "$PKGDIR"/usr/bin/linux-boot-prober
+install -Dvm755 "$SRCDIR"/os-prober \
+    "$PKGDIR"/usr/bin/os-prober
+install -Dvm755 "$SRCDIR"/newns \
+    "$PKGDIR"/usr/lib/os-prober/newns
+install -Dvm755 "$SRCDIR"/common.sh \
+    "$PKGDIR"/usr/share/os-prober/common.sh
 
-for dir in os-probes os-probes/mounted os-probes/init linux-boot-probes linux-boot-probes/mounted; do
-  install -dm755 "$PKGDIR"/usr/lib/$dir
-  install -m755 -t "$PKGDIR"/usr/lib/$dir $dir/common/*
-  [[ -d $dir/x86 ]] && cp -r $dir/x86/* "$PKGDIR"/usr/lib/$dir
+# Note: Our LoongArch port uses "loongarch64" as the architecture name whereas
+# Debian uses loong64, we perform a simple translation here.
+if ab_match_arch loongarch64; then
+    export PROBES_ARCH="loong64"
+else
+    export PROBES_ARCH="$ARCH"
+fi
+
+# Note: Follow override_dh_install in debian/rules (except the udeb components
+# as we don't use debian-installer.
+abinfo "Installing probe scripts ..."
+for probes in os-probes os-probes/mounted os-probes/init \
+              linux-boot-probes linux-boot-probes/mounted; do
+    mkdir -pv "$PKGDIR"/usr/lib/${probes}
+    cp -av "$SRCDIR"/${probes}/common/* \
+        -t "$PKGDIR"/usr/lib/${probes}/
+    # Install architecture-specific probes ..."
+    if [ -d "$SRCDIR"/${probes}/${PROBES_ARCH} ]; then
+        abinfo "Installing architecture-specific probe scripts for $ARCH ..."
+        cp -av "$SRCDIR"/${probes}/${PROBES_ARCH}/* \
+            "$PKGDIR"/usr/lib/${probes}/
+    fi
 done
-
-install -Dm755 os-probes/mounted/powerpc/20macosx "$PKGDIR"/usr/lib/os-probes/mounted/20macosx
-
-install -dm755 "$PKGDIR"/var/lib/os-prober
+# Note: Install macOS (Mac OS X) probes which were erroneously marked as
+# powerpc-specific.
+if ab_match_arch amd64 || \
+   ab_match_arch i486; then
+    abinfo "Installing macOS (Mac OS X) probes for $ARCH ..."
+    cp -av "$SRCDIR"/os-probes/mounted/powerpc/20macosx \
+        "$PKGDIR"/usr/lib/os-probes/mounted/20macosx
+fi

--- a/app-utils/os-prober/autobuild/overrides/usr/lib/tmpfiles.d/os-prober.conf
+++ b/app-utils/os-prober/autobuild/overrides/usr/lib/tmpfiles.d/os-prober.conf
@@ -1,0 +1,1 @@
+d /var/lib/os-prober 0755 root root - -

--- a/app-utils/os-prober/autobuild/patch
+++ b/app-utils/os-prober/autobuild/patch
@@ -1,3 +1,0 @@
-sed -i -e "s:/lib/ld\*\.so\*:/lib*/ld*.so*:g" os-probes/mounted/common/90linux-distro
-
-rm -f "$SRCDIR"/Makefile

--- a/app-utils/os-prober/autobuild/patches/0001-feat-linux-boot-probes-detect-old-world-kernels-and-.patch
+++ b/app-utils/os-prober/autobuild/patches/0001-feat-linux-boot-probes-detect-old-world-kernels-and-.patch
@@ -1,0 +1,206 @@
+From 77dfa9efe3271f7adcbd6a3f768057957dcdbfb7 Mon Sep 17 00:00:00 2001
+From: Miao Wang <shankerwangmiao@gmail.com>
+Date: Tue, 6 Aug 2024 02:13:27 +0800
+Subject: [PATCH] feat(linux-boot-probes): detect old-world kernels and
+ bootloaders
+
+Use is_efi_stub (90fallback) to detect non-PE (non-EFI-stub) kernel images
+to see if the kernel belongs to an old-world system.
+
+With LoongArch, the old-world firmware expects to boot from an ELF-formatted
+kernel image (vmlinu{x,z}), whereas new-world firmware expects PE-formatted
+EFI stub kernels (vmlinu{x,z}.efi). However, for our purpose, new-world
+GRUB2 bootloaders are not *yet* able to directly boot old-world kernels, so
+we take advantage of this format difference to detect old-world systems and
+simply chainload their bootloaders.
+
+Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.xyz>
+---
+ common.sh                                     |  9 +++
+ debian/changelog                              |  9 +++
+ linux-boot-probes/mounted/common/40grub2      | 11 +++-
+ linux-boot-probes/mounted/common/90fallback   | 17 ++++++
+ .../mounted/loong64/00_flag-loong64           | 12 ++++
+ .../mounted/loong64/95old-world-grub2         | 55 +++++++++++++++++++
+ 6 files changed, 112 insertions(+), 1 deletion(-)
+ create mode 100755 linux-boot-probes/mounted/loong64/00_flag-loong64
+ create mode 100755 linux-boot-probes/mounted/loong64/95old-world-grub2
+
+diff --git a/common.sh b/common.sh
+index e1646d4..bbe950d 100644
+--- a/common.sh
++++ b/common.sh
+@@ -296,3 +296,12 @@ linux_mount_boot () {
+ 
+ 	mountboot="$bootpart $mounted"
+ }
++
++is_efi_stub() {
++  _file=$1
++  if [ -f "$_file" ] && [ "MZ" = "$(head --bytes=2 "$_file")" ]; then
++	  return 0
++  else
++	  return 1
++  fi
++}
+diff --git a/debian/changelog b/debian/changelog
+index eda67dd..ab68162 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -1,3 +1,12 @@
++os-prober (1.81+1) unstable; urgency=medium
++
++  * loong64: filter out non-EFI-stub (old-world) kernels.
++  * loong64: chainload old-world GRUB2 when non-EFI-stub kernels exist in a
++    particular system rootfs, making it possible to boot from a new-world
++    GRUB2 bootloader.
++
++ -- Miao Wang <shankerwangmiao@gmail.com>  Tue, 06 Aug 2024 02:12:00 +0800
++
+ os-prober (1.81) unstable; urgency=medium
+ 
+   * Team upload
+diff --git a/linux-boot-probes/mounted/common/40grub2 b/linux-boot-probes/mounted/common/40grub2
+index e333a66..3d031b4 100755
+--- a/linux-boot-probes/mounted/common/40grub2
++++ b/linux-boot-probes/mounted/common/40grub2
+@@ -8,11 +8,20 @@ mpoint="$3"
+ type="$4"
+ 
+ found_item=0
++is_loong64=0
++
++# The current system from which os-prober is run is a LoongArch system.
++# Marked by 00_flag-loong64.
++if [ -e "$OS_PROBER_TMP/is_loong64" ]; then
++	is_loong64=1
++fi
+ 
+ entry_result () {
+ 	if [ "$ignore_item" = 0 ] && \
+ 	   [ -n "$kernel" ] && \
+-	   [ -e "$mpoint/$kernel" ]; then
++	   [ -e "$mpoint/$kernel" ] && ( \
++	     [ "$is_loong64" = 0 ] || is_efi_stub "$mpoint/$kernel" \
++	   ); then
+ 		result "$rootpart:$bootpart:$title:$kernel:$initrd:$parameters"
+ 		found_item=1
+ 	fi
+diff --git a/linux-boot-probes/mounted/common/90fallback b/linux-boot-probes/mounted/common/90fallback
+index 6b2c125..dbb9f7a 100755
+--- a/linux-boot-probes/mounted/common/90fallback
++++ b/linux-boot-probes/mounted/common/90fallback
+@@ -4,6 +4,14 @@
+ . /usr/share/os-prober/common.sh
+ set -e
+ 
++is_loong64=0
++
++# The current system from which os-prober is run is a LoongArch system.
++# Marked by 00_flag-loong64.
++if [ -e "$OS_PROBER_TMP/is_loong64" ]; then
++        is_loong64=1
++fi
++
+ partition="$1"
+ bootpart="$2"
+ mpoint="$3"
+@@ -22,6 +30,15 @@ for kernpat in /vmlinuz /vmlinux /boot/vmlinuz /boot/vmlinux "/boot/vmlinuz*" \
+ 	for kernfile in $(eval ls -vr "$mpoint$kernpat" 2>/dev/null); do
+ 		kernbasefile=$(echo "$kernfile" | sed "s!^$mpoint!!")
+ 		if [ -f "$kernfile" ] && [ ! -L "$kernfile" ]; then
++			# Detect if the kernel image is non-PE (non-EFI-stub).
++			# Non-EFI-stub kernels can be assumed to be old-world
++			# ones, which needs to be booted from an old-world
++			# GRUB2 bootloader (new-world GRUB2 can't yet boot
++			# old-world kernels.
++			if [ "$is_loong64" = "1" ] && ! is_efi_stub "$kernfile"; then
++				touch "$OS_PROBER_TMP/loong64_have_non_pe_kernel"
++				continue
++			fi
+ 			initrdname=$(echo "$kernfile" | sed "s/vmlinu[zx]/initrd\*/")
+ 			# Yellow Dog Linux appends .img to it.
+ 			initrdname1="${initrdname}.img"
+diff --git a/linux-boot-probes/mounted/loong64/00_flag-loong64 b/linux-boot-probes/mounted/loong64/00_flag-loong64
+new file mode 100755
+index 0000000..57b2d30
+--- /dev/null
++++ b/linux-boot-probes/mounted/loong64/00_flag-loong64
+@@ -0,0 +1,12 @@
++#!/bin/sh
++
++. /usr/share/os-prober/common.sh
++
++# Mark the current system as a LoongArch (loong64) one.
++#
++# We use this marker to run special routines for detecting old-world kernels
++# and systems to make it possible for users to boot those systems from new-
++# world GRUB2 bootloaders.
++touch "$OS_PROBER_TMP/is_loong64"
++
++exit 1
+diff --git a/linux-boot-probes/mounted/loong64/95old-world-grub2 b/linux-boot-probes/mounted/loong64/95old-world-grub2
+new file mode 100755
+index 0000000..2af4f8a
+--- /dev/null
++++ b/linux-boot-probes/mounted/loong64/95old-world-grub2
+@@ -0,0 +1,55 @@
++#!/bin/sh
++# Locate old-world GRUB2 boot files for chainloading.
++
++. /usr/share/os-prober/common.sh
++
++set -e
++
++partition="$1"
++bootpart="$2"
++mpoint="$3"
++type="$4"
++
++
++exitcode=1
++# In mounted/common/90fallback, we used is_efi_stub to detect non-PE
++# (non-EFI-stub) kernel images to see if the kernel belongs to an old-world
++# system.
++#
++# With LoongArch, the old-world firmware expects to boot from an ELF-formatted
++# kernel image (vmlinu{x,z}), whereas new-world firmware expects PE-formatted
++# EFI stub kernels (vmlinu{x,z}.efi). However, for our purpose, new-world
++# GRUB2 bootloaders are not *yet* able to directly boot old-world kernels, so
++# we take advantage of this format difference to detect old-world systems and
++# simply chainload their bootloaders.
++if [ -e "$OS_PROBER_TMP/loong64_have_non_pe_kernel" ]; then
++	# Usually, $boot_mount/$grub_prefix/$grub_arch/core.efi contains an
++	# EFI GRUB boot image equivalent to that installed in the ESP.
++	#
++	# We use this image for chainloading from a new-world bootloader.
++	for kernpat in \
++		"/grub*/loongarch64-efi/core.efi" \
++		"/boot/grub*/loongarch64-efi/core.efi"; do
++		if echo "$kernpat" | grep -q boot/; then
++			kernbootpart="$bootpart"
++		else
++			kernbootpart="$partition"
++		fi
++		for kernfile in $(eval ls -vr "$mpoint$kernpat" 2>/dev/null); do
++			kernbasefile=$(echo "$kernfile" | sed "s!^$mpoint!!")
++			if [ -f "$kernfile" ] && [ ! -L "$kernfile" ]; then
++				kernrelfile=$kernbasefile
++				if [ "$kernbootpart" != "$partition" ]; then
++					kernrelfile="${kernrelfile#/boot}"
++				fi
++				result "$partition:$kernbootpart::$kernbasefile::; chainloader $kernrelfile"
++				exitcode=0
++				break;
++			fi
++		done
++		if [ "$exitcode" = "0" ]; then
++			break;
++		fi
++	done
++fi
++exit "$exitcode"
+-- 
+2.46.0
+

--- a/app-utils/os-prober/autobuild/postinst
+++ b/app-utils/os-prober/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Creating tmpfiles for os-prober ..."
+systemd-tmpfiles --create os-prober.conf

--- a/app-utils/os-prober/spec
+++ b/app-utils/os-prober/spec
@@ -1,4 +1,5 @@
 VER=1.81
+REL=1
 SRCS="tbl::http://http.debian.net/debian/pool/main/o/os-prober/os-prober_$VER.tar.xz"
 CHKSUMS="sha256::2fd928ec86538227711e2adf49cfd6a1ef74f6bb3555c5dad4e0425ccd978883"
 CHKUPDATE="anitya::id=2574"


### PR DESCRIPTION
Topic Description
-----------------

- grub: add support for booting on LoongArch old-world firmware
- os-prober: introduce LoongArch old-world bootloader detection
    - Lint scripts in accordance with the Styling Manual.
    - Drop unused patch script.

Package(s) Affected
-------------------

- grub: 2:2.12+unifont15.1.04-4
- os-prober: 1.81-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit os-prober grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
