### PR TITLE
cherrypy (CherryPy): update to 18.10.0

### DIFF
--- a/lang-python/cherrypy/autobuild/defines
+++ b/lang-python/cherrypy/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=cherrypy
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-scm"
-PKGDES="A pythonic, object-oriented web development framework"
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer setuptools-scm wheel"
+PKGDES="An object-oriented web development framework for Python"
 
 ABHOST=noarch
+
+ABTYPE=pep517

--- a/lang-python/cherrypy/autobuild/patches/0001-fix-pyproject.toml-drop-release-management-only-dep.patch
+++ b/lang-python/cherrypy/autobuild/patches/0001-fix-pyproject.toml-drop-release-management-only-dep.patch
@@ -1,0 +1,24 @@
+From 1d9bada3dbf625c2db5f70611ad08dbe2074863c Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 7 Aug 2024 15:51:51 +0800
+Subject: [PATCH] fix(pyproject.toml): drop release-management-only dep
+
+---
+ pyproject.toml | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index ff499d3d..25a3c4f9 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -6,7 +6,6 @@ requires = [
+     # Plugins
+     "setuptools_scm[toml] >= 7; python_version >= '3.7'",
+     "setuptools_scm[toml] < 7; python_version < '3.7'",
+-    "setuptools_scm_git_archive >= 1.1; python_version < '3.7'",
+ ]
+ build-backend = "setuptools.build_meta"
+ 
+-- 
+2.46.0
+

--- a/lang-python/cherrypy/spec
+++ b/lang-python/cherrypy/spec
@@ -1,5 +1,4 @@
-VER=18.1.0
-REL=3
-SRCS="tbl::https://pypi.io/packages/source/C/CherryPy/CherryPy-$VER.tar.gz"
-CHKSUMS="sha256::4dd2f59b5af93bd9ca85f1ed0bb8295cd0f5a8ee2b84d476374d4e070aa5c615"
+VER=18.10.0
+SRCS="tbl::https://pypi.io/packages/source/C/CherryPy/cherrypy-$VER.tar.gz"
+CHKSUMS="sha256::6c70e78ee11300e8b21c0767c542ae6b102a49cac5cfd4e3e313d7bb907c5891"
 CHKUPDATE="anitya::id=3799"

--- a/lang-python/cherrypy/spec
+++ b/lang-python/cherrypy/spec
@@ -1,4 +1,5 @@
 VER=18.10.0
+REL=1
 SRCS="tbl::https://pypi.io/packages/source/C/CherryPy/cherrypy-$VER.tar.gz"
 CHKSUMS="sha256::6c70e78ee11300e8b21c0767c542ae6b102a49cac5cfd4e3e313d7bb907c5891"
 CHKUPDATE="anitya::id=3799"


### PR DESCRIPTION
Topic Description
-----------------

- cherrypy: bump REL for topic Revision Marking Guidelines
- cherrypy: update to 18.10.0
    Disable Python 2 binding as it is no longer supported (and switch to pep517).
    Co-authored-by: Mingcong Bai (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cherrypy: 18.10.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cherrypy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
