### PR TITLE
zed: update to 0.146.5

### DIFF
--- a/app-editors/zed/spec
+++ b/app-editors/zed/spec
@@ -1,4 +1,4 @@
-VER=0.145.1
+VER=0.146.5
 SRCS="git::commit=v$VER::https://github.com/zed-industries/zed"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373275"


### PR DESCRIPTION
Topic Description
-----------------

- zed: update to 0.146.5
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- zed: 0.146.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit zed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
