### PR TITLE
Stable Revision Marking Rework (20240808)

### DIFF
--- a/app-admin/mbpfan/spec
+++ b/app-admin/mbpfan/spec
@@ -1,4 +1,5 @@
 VER=2.4.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/dgraziotin/mbpfan/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=115980"

--- a/app-scientific/boinc/spec
+++ b/app-scientific/boinc/spec
@@ -1,4 +1,5 @@
 VER=8.0.4
+REL=1
 SRCS="git::commit=tags/client_release/${VER%.*}/$VER::https://github.com/BOINC/boinc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=211"

--- a/app-utils/dar/spec
+++ b/app-utils/dar/spec
@@ -1,5 +1,5 @@
 VER=2.7.15
-REL=1
+REL=2
 SRCS="tbl::https://sourceforge.net/projects/dar/files/dar/$VER/dar-$VER.tar.gz"
 CHKSUMS="sha256::fac56b59b78b5435ee19541ff4bd3dc329c8252ff78749ffea240f6421534bfe"
 CHKUPDATE="anitya::id=389"

--- a/app-web/dovecot/spec
+++ b/app-web/dovecot/spec
@@ -1,4 +1,5 @@
 VER=2.3.21
+REL=1
 SRCS="tbl::https://dovecot.org/releases/${VER:0:3}/dovecot-$VER.tar.gz"
 CHKSUMS="sha256::05b11093a71c237c2ef309ad587510721cc93bbee6828251549fc1586c36502d"
 CHKUPDATE="anitya::id=456"

--- a/lang-python/pybind11/spec
+++ b/lang-python/pybind11/spec
@@ -1,5 +1,5 @@
 VER=2.11.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/pybind/pybind11"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138380"


### PR DESCRIPTION
Topic Description
-----------------

- pybind11: rebuild for bad revision marking
- mbpfan: rebuild for bad revision marking
- dovecot: rebuild for bad revision marking
- dar: rebuild for bad revision marking
- boinc: rebuild for bad revision marking

Package(s) Affected
-------------------

- boinc: 8.0.4-1
- dar: 2.7.15-2
- dovecot: 2.3.21-1
- mbpfan: 2.4.0-1
- pybind11: 2.11.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit boinc dar dovecot mbpfan pybind11
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
