### PR TITLE
buildah,skopeo: rework to fix dependencies

### DIFF
--- a/app-containers/buildah/autobuild/defines
+++ b/app-containers/buildah/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=buildah
 PKGSEC=devel
+PKGDEP="gpgme containers-common"
 PKGDES="Utility for building OCI images"
-BUILDDEP="go gpgme"
+BUILDDEP="go"
 
 ABSPLITDBG=0

--- a/app-containers/buildah/spec
+++ b/app-containers/buildah/spec
@@ -1,4 +1,5 @@
 VER=1.37.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/containers/buildah"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14974"

--- a/app-containers/skopeo/autobuild/defines
+++ b/app-containers/skopeo/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=skopeo
 PKGSEC=admin
+PKGDEP="gpgme containers-common"
 PKGDES="Utility for operating on container images and repositories"
-BUILDDEP="go go-md2man gpgme"
+BUILDDEP="go go-md2man"
 
 ABSPLITDBG=0

--- a/app-containers/skopeo/spec
+++ b/app-containers/skopeo/spec
@@ -1,4 +1,5 @@
 VER=1.16.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/containers/skopeo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9216"


### PR DESCRIPTION
Topic Description
-----------------

- skopeo: 1.16.0 rework
- buildah: 1.37.0 rework

Package(s) Affected
-------------------

- buildah: 1.37.0-1
- skopeo: 1.16.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit buildah skopeo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
