### PR TITLE
hmcl: update to 3.5.9

### DIFF
--- a/app-games/hmcl/autobuild/build
+++ b/app-games/hmcl/autobuild/build
@@ -2,7 +2,7 @@ abinfo "Building hmcl.jar..."
 export VERSION_TYPE=stable
 export BUILD_NUMBER=$(echo $PKGVER | cut -d '.' -f 3)
 export MICROSOFT_AUTH_ID=81a207c0-a53c-46a3-be07-57d2b28c1643
-export CURSEFORGE_API_KEY="$2a$10$gWtfk4i6mQvxSLhtMdvBfuM1E46vEbmYV4w4sHSJBX6c3hO6WCDWG"
+export CURSEFORGE_API_KEY='$2a$10$gWtfk4i6mQvxSLhtMdvBfuM1E46vEbmYV4w4sHSJBX6c3hO6WCDWG'
 "$SRCDIR"/gradlew build
 
 abinfo "Installing hmcl.jar..."

--- a/app-games/hmcl/spec
+++ b/app-games/hmcl/spec
@@ -1,4 +1,4 @@
-VER=3.5.8
+VER=3.5.9
 SRCS="git::commit=tags/release-$VER::https://github.com/HMCL-dev/HMCL"
 CHKSUMS=SKIP
 CHKUPDATE="github::repo=HMCL-dev/HMCL"


### PR DESCRIPTION
Topic Description
-----------------

- hmcl: update to 3.5.9

Package(s) Affected
-------------------

- hmcl: 3.5.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit hmcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
