### PR TITLE
antlr4: update to 4.13.2

### DIFF
--- a/app-devel/antlr4/spec
+++ b/app-devel/antlr4/spec
@@ -1,7 +1,7 @@
-VER=4.13.1
+VER=4.13.2
 SRCS="file::rename=antlr-complete.jar::https://www.antlr.org/download/antlr-${VER}-complete.jar \
       file::rename=LICENSE.txt::https://raw.githubusercontent.com/antlr/antlr4/master/LICENSE.txt"
-CHKSUMS="sha256::bc13a9c57a8dd7d5196888211e5ede657cb64a3ce968608697e4f668251a8487 \
+CHKSUMS="sha256::eae2dfa119a64327444672aff63e9ec35a20180dc5b8090b7a6ab85125df4d76 \
          sha256::3db1fb3ee79a4b4f9918fc4d0f6133bf18a3cf787f126cd22f8aa9b862281c0c"
 CHKUPDATE="anitya::id=14373"
 SUBDIR=.

--- a/runtime-common/antlr4-cpp-runtime/autobuild/defines
+++ b/runtime-common/antlr4-cpp-runtime/autobuild/defines
@@ -2,8 +2,8 @@ PKGNAME=antlr4-cpp-runtime
 PKGSEC=libs
 PKGDEP="gcc-runtime glibc"
 PKGDES="C++ runtime for ANTLR 4"
-ABTYPES=cmake
 
-CMAKE_AFTER=(
-    -DINSTALL_GTEST=OFF
-)
+ABTYPE=cmakeninja
+CMAKE_AFTER=" \
+    -DINSTALL_GTEST=OFF \
+"

--- a/runtime-common/antlr4-cpp-runtime/spec
+++ b/runtime-common/antlr4-cpp-runtime/spec
@@ -1,5 +1,5 @@
-VER=4.13.1
+VER=4.13.2
 SRCS="tbl::https://www.antlr.org/download/antlr4-cpp-runtime-${VER}-source.zip"
-CHKSUMS="sha256::d350e09917a633b738c68e1d6dc7d7710e91f4d6543e154a78bb964cfd8eb4de"
+CHKSUMS="sha256::0ed13668906e86dbc0dcddf30fdee68c10203dea4e83852b4edb810821bee3c4"
 CHKUPDATE="anitya::id=14373"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- antlr4: update to 4.13.2
    Related package:
    antlr4-cpp-runtime: update to 4.13.2

Package(s) Affected
-------------------

- antlr4: 4.13.2
- antlr4-cpp-runtime: 4.13.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit antlr4 antlr4-cpp-runtime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
