### PR TITLE
libvirt: fix firewalld support

### DIFF
--- a/app-virtualization/libvirt/spec
+++ b/app-virtualization/libvirt/spec
@@ -1,4 +1,5 @@
 VER=10.5.0
+REL=1
 SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
 CHKSUMS="sha256::8e853a9c91c9029b9019cf5fdf2b5fea36d501d563e43254efc20e12c00557e8"
 CHKUPDATE="anitya::id=13830"


### PR DESCRIPTION
Topic Description
-----------------

- libvirt: rebuild for firewalld zone detection (?)

Package(s) Affected
-------------------

- libvirt: 10.5.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvirt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
