### PR TITLE
prismlauncher: fix mangohud library loading

### DIFF
--- a/app-games/prismlauncher/autobuild/patches/0001-javautils-detect-Java-paths-on-AOSC-OS.patch
+++ b/app-games/prismlauncher/autobuild/patches/0001-javautils-detect-Java-paths-on-AOSC-OS.patch
@@ -1,7 +1,7 @@
-From b1c44f27e590df54d921d72af7ae413e3ef37f6a Mon Sep 17 00:00:00 2001
+From ed82cd3473d06083b0a7c3a3298a5989a991f25e Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Mon, 17 Jun 2024 22:41:46 -0700
-Subject: [PATCH] javautils: detect Java paths on AOSC OS
+Subject: [PATCH 1/2] javautils: detect Java paths on AOSC OS
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/launcher/java/JavaUtils.cpp b/launcher/java/JavaUtils.cpp
-index b12461f44..9eeabd8bb 100644
+index 3b32b54c7..3bd2161b6 100644
 --- a/launcher/java/JavaUtils.cpp
 +++ b/launcher/java/JavaUtils.cpp
-@@ -377,7 +377,13 @@ QList<QString> JavaUtils::FindJavaPaths()
+@@ -393,7 +393,13 @@ QList<QString> JavaUtils::FindJavaPaths()
          QDir dir(dirPath);
          if (!dir.exists())
              return;
@@ -27,7 +27,7 @@ index b12461f44..9eeabd8bb 100644
          for (auto& entry : entries) {
              QString prefix;
              prefix = entry.canonicalFilePath();
-@@ -399,6 +405,7 @@ QList<QString> JavaUtils::FindJavaPaths()
+@@ -415,6 +421,7 @@ QList<QString> JavaUtils::FindJavaPaths()
      scanJavaDirs("/usr/lib/jvm");
      scanJavaDirs("/usr/lib64/jvm");
      scanJavaDirs("/usr/lib32/jvm");
@@ -36,5 +36,5 @@ index b12461f44..9eeabd8bb 100644
      scanJavaDirs("java");
      // manually installed JDKs in /opt
 -- 
-2.45.2
+2.46.0
 

--- a/app-games/prismlauncher/autobuild/patches/0002-mangohud-support-MangoHud-getLibraryString-should-re.patch
+++ b/app-games/prismlauncher/autobuild/patches/0002-mangohud-support-MangoHud-getLibraryString-should-re.patch
@@ -1,0 +1,111 @@
+From 557780c93861c2c953f01bd1da4a80fb4aef54ad Mon Sep 17 00:00:00 2001
+From: Tianhao Chai <cth451@gmail.com>
+Date: Thu, 8 Aug 2024 18:47:01 -0400
+Subject: [PATCH 2/2] mangohud support: MangoHud::getLibraryString should
+ return absolute path
+
+Some distros (i.e. my distro) ships MangoHub vulkan layer json with
+bare shared object name instead of absolute path. This breaks game
+environment config steps as MinecraftInstance::createLaunchEnvironment()
+will deem libMangoHud.so non-existent.
+
+Since we already have MangoHud::findLibrary() lying around, use that to
+figure out absolute path to the libMangoHud.so.
+---
+ launcher/MangoHud.cpp                    | 41 +++++++++++++++---------
+ launcher/minecraft/MinecraftInstance.cpp |  2 +-
+ 2 files changed, 26 insertions(+), 17 deletions(-)
+
+diff --git a/launcher/MangoHud.cpp b/launcher/MangoHud.cpp
+index ab79f418b..bd81ea511 100644
+--- a/launcher/MangoHud.cpp
++++ b/launcher/MangoHud.cpp
+@@ -38,19 +38,20 @@
+ 
+ namespace MangoHud {
+ 
++/**
++ * Guess MangoHud install location by searching for vulkan layers in this order:
++ *
++ * $VK_LAYER_PATH
++ * $XDG_DATA_DIRS (/usr/local/share/:/usr/share/)
++ * $XDG_DATA_HOME  (~/.local/share)
++ * /etc
++ * $XDG_CONFIG_DIRS (/etc/xdg)
++ * $XDG_CONFIG_HOME (~/.config)
++ *
++ * @returns Absolute path to libMangoHud.so if found and empty QString otherwise.
++ */
+ QString getLibraryString()
+ {
+-    /*
+-     * Check for vulkan layers in this order:
+-     *
+-     * $VK_LAYER_PATH
+-     * $XDG_DATA_DIRS (/usr/local/share/:/usr/share/)
+-     * $XDG_DATA_HOME  (~/.local/share)
+-     * /etc
+-     * $XDG_CONFIG_DIRS (/etc/xdg)
+-     * $XDG_CONFIG_HOME (~/.config)
+-     */
+-
+     QStringList vkLayerList;
+     {
+         QString home = QDir::homePath();
+@@ -85,7 +86,7 @@ QString getLibraryString()
+         vkLayerList << FS::PathCombine(xdgConfigHome, "vulkan", "implicit_layer.d");
+     }
+ 
+-    for (QString vkLayer : vkLayerList) {
++    for (const QString& vkLayer : vkLayerList) {
+         // prefer to use architecture specific vulkan layers
+         QString currentArch = QSysInfo::currentCpuArchitecture();
+ 
+@@ -95,8 +96,8 @@ QString getLibraryString()
+ 
+         QStringList manifestNames = { QString("MangoHud.%1.json").arg(currentArch), "MangoHud.json" };
+ 
+-        QString filePath = "";
+-        for (QString manifestName : manifestNames) {
++        QString filePath{};
++        for (const QString& manifestName : manifestNames) {
+             QString tryPath = FS::PathCombine(vkLayer, manifestName);
+             if (QFile::exists(tryPath)) {
+                 filePath = tryPath;
+@@ -111,10 +112,18 @@ QString getLibraryString()
+         auto conf = Json::requireDocument(filePath, vkLayer);
+         auto confObject = Json::requireObject(conf, vkLayer);
+         auto layer = Json::ensureObject(confObject, "layer");
+-        return Json::ensureString(layer, "library_path");
++        QString libraryName = Json::ensureString(layer, "library_path");
++
++        // Check whether mangohud is usable
++        if (!libraryName.isEmpty()) {
++            QString libraryPath = findLibrary(libraryName);
++            if (!libraryPath.isEmpty()) {
++                return libraryPath;
++            }
++        }
+     }
+ 
+-    return QString();
++    return {};
+ }
+ 
+ QString findLibrary(QString libName)
+diff --git a/launcher/minecraft/MinecraftInstance.cpp b/launcher/minecraft/MinecraftInstance.cpp
+index a9dbfac28..b4d2a1b40 100644
+--- a/launcher/minecraft/MinecraftInstance.cpp
++++ b/launcher/minecraft/MinecraftInstance.cpp
+@@ -607,7 +607,7 @@ QProcessEnvironment MinecraftInstance::createLaunchEnvironment()
+             // dlsym variant is only needed for OpenGL and not included in the vulkan layer
+             appendLib("libMangoHud_dlsym.so");
+             appendLib("libMangoHud_opengl.so");
+-            appendLib(mangoHudLib.fileName());
++            preloadList << mangoHudLibString;
+         }
+ 
+         env.insert("LD_PRELOAD", preloadList.join(QLatin1String(":")));
+-- 
+2.46.0
+

--- a/app-games/prismlauncher/spec
+++ b/app-games/prismlauncher/spec
@@ -1,4 +1,5 @@
 VER=8.4
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/PrismLauncher/PrismLauncher"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301949"


### PR DESCRIPTION
Topic Description
-----------------

- prismlauncher: fix mangohud library loading
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- prismlauncher: 8.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit prismlauncher
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
