### PR TITLE
[DONT MERGE] chromium: do not disable ThinLTO

### DIFF
--- a/app-web/chromium/autobuild/build
+++ b/app-web/chromium/autobuild/build
@@ -30,7 +30,6 @@ GNFLAGS=(
     'use_ozone=true'
     'use_qt=true'
     'use_system_libffi=true'
-    'use_thin_lto=false'
     'is_cfi=false'
     'ozone_platform_wayland=true'
     'ozone_platform_x11=true'

--- a/app-web/chromium/autobuild/patches/0001-Fedora-chromium-115-initial_prefs-etc-path.patch.patch
+++ b/app-web/chromium/autobuild/patches/0001-Fedora-chromium-115-initial_prefs-etc-path.patch.patch
@@ -1,7 +1,7 @@
 From fb45013a8b6f1fceb81ae49b335ff12e42e28b80 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:02:40 +0800
-Subject: [PATCH 01/26] [Fedora] chromium-115-initial_prefs-etc-path.patch
+Subject: [PATCH 01/27] [Fedora] chromium-115-initial_prefs-etc-path.patch
 
 https://src.fedoraproject.org/rpms/chromium/blob/5b27efc518c86b93dd2f30e877536599ed07beac/f/chromium-115-initial_prefs-etc-path.patch
 

--- a/app-web/chromium/autobuild/patches/0002-Fedora-chromium-77.0.3865.75-no-zlib-mangle.patch.patch
+++ b/app-web/chromium/autobuild/patches/0002-Fedora-chromium-77.0.3865.75-no-zlib-mangle.patch.patch
@@ -1,7 +1,7 @@
 From 53076fe89885904dd6e16dce5348d5a4feb42e89 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:04:35 +0800
-Subject: [PATCH 02/26] [Fedora] chromium-77.0.3865.75-no-zlib-mangle.patch
+Subject: [PATCH 02/27] [Fedora] chromium-77.0.3865.75-no-zlib-mangle.patch
 
 https://src.fedoraproject.org/rpms/chromium/blob/5b27efc518c86b93dd2f30e877536599ed07beac/f/chromium-77.0.3865.75-no-zlib-mangle.patch
 

--- a/app-web/chromium/autobuild/patches/0003-Fedora-update-rjsmin-to-1.2.0-to-see-if-Python-3.11-.patch
+++ b/app-web/chromium/autobuild/patches/0003-Fedora-update-rjsmin-to-1.2.0-to-see-if-Python-3.11-.patch
@@ -1,7 +1,7 @@
 From d4b647748969fb913d40a79ae4fc47ddaca0872e Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:08:55 +0800
-Subject: [PATCH 03/26] [Fedora] update rjsmin to 1.2.0 to see if Python 3.11
+Subject: [PATCH 03/27] [Fedora] update rjsmin to 1.2.0 to see if Python 3.11
  likes it better
 
 https://src.fedoraproject.org/rpms/chromium/blob/5b27efc518c86b93dd2f30e877536599ed07beac/f/chromium-103.0.5060.53-update-rjsmin-to-1.2.0.patch

--- a/app-web/chromium/autobuild/patches/0004-Fedora-chromium-98.0.4758.102-remoting-no-tests.patc.patch
+++ b/app-web/chromium/autobuild/patches/0004-Fedora-chromium-98.0.4758.102-remoting-no-tests.patc.patch
@@ -1,7 +1,7 @@
 From c59c441cddc5a0f2f18f4f7c6a2b024cb3ac50ec Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:13:02 +0800
-Subject: [PATCH 04/26] [Fedora] chromium-98.0.4758.102-remoting-no-tests.patch
+Subject: [PATCH 04/27] [Fedora] chromium-98.0.4758.102-remoting-no-tests.patch
 
 https://src.fedoraproject.org/rpms/chromium/blob/5b27efc518c86b93dd2f30e877536599ed07beac/f/chromium-98.0.4758.102-remoting-no-tests.patch
 

--- a/app-web/chromium/autobuild/patches/0005-Fedora-chromium-126-split-threshold-for-reg-with-hin.patch
+++ b/app-web/chromium/autobuild/patches/0005-Fedora-chromium-126-split-threshold-for-reg-with-hin.patch
@@ -1,7 +1,7 @@
 From 52a0f36e8dd1d0c63ea50260f7502aa5b92d3d0e Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:17:29 +0800
-Subject: [PATCH 05/26] [Fedora]
+Subject: [PATCH 05/27] [Fedora]
  chromium-126-split-threshold-for-reg-with-hint.patch
 
 https://src.fedoraproject.org/rpms/chromium/blob/5b27efc518c86b93dd2f30e877536599ed07beac/f/chromium-126-split-threshold-for-reg-with-hint.patch

--- a/app-web/chromium/autobuild/patches/0006-Debian-ruy-include.patch.patch
+++ b/app-web/chromium/autobuild/patches/0006-Debian-ruy-include.patch.patch
@@ -1,7 +1,7 @@
 From 21e1fed02bb34899cc802767aea944bd082cd6f4 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:10:48 +0800
-Subject: [PATCH 06/26] [Debian] ruy-include.patch
+Subject: [PATCH 06/27] [Debian] ruy-include.patch
 
 https://salsa.debian.org/chromium-team/chromium/-/blob/6514253919d9398a61ffa7f4e579ac565092165b/debian/patches/upstream/ruy-include.patch
 

--- a/app-web/chromium/autobuild/patches/0007-iwyu-include-cstddef-for-nullptr_t-in-fragment_data_.patch
+++ b/app-web/chromium/autobuild/patches/0007-iwyu-include-cstddef-for-nullptr_t-in-fragment_data_.patch
@@ -1,7 +1,7 @@
 From f533547c56948c9512b928e91708d3d01128d68d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 02:23:48 +0800
-Subject: [PATCH 07/26] iwyu: include cstddef for nullptr_t in
+Subject: [PATCH 07/27] iwyu: include cstddef for nullptr_t in
  fragment_data_iterator.h
 
 Bug: 41455655

--- a/app-web/chromium/autobuild/patches/0008-AOSC-TBI-rollup.patch.patch
+++ b/app-web/chromium/autobuild/patches/0008-AOSC-TBI-rollup.patch.patch
@@ -1,7 +1,7 @@
 From 6aa7dfda5cc89a7f1801a2bacccf688d04e2979b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:20:58 +0800
-Subject: [PATCH 08/26] [AOSC, TBI] rollup.patch
+Subject: [PATCH 08/27] [AOSC, TBI] rollup.patch
 
 https://github.com/AOSC-Dev/aosc-os-abbs/blob/c0cc5a4aab518bf24451de466fba520ea70ddc34/app-web/chromium/autobuild/patches/3002-rollup.patch
 

--- a/app-web/chromium/autobuild/patches/0009-AOSC-TBI-fix-invalid-substition-type.patch.patch
+++ b/app-web/chromium/autobuild/patches/0009-AOSC-TBI-fix-invalid-substition-type.patch.patch
@@ -1,7 +1,7 @@
 From dfc19eaff0ab053f75128a3b37eb30f1ab8c93c3 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:22:10 +0800
-Subject: [PATCH 09/26] [AOSC, TBI] fix-invalid-substition-type.patch
+Subject: [PATCH 09/27] [AOSC, TBI] fix-invalid-substition-type.patch
 
 https://github.com/AOSC-Dev/aosc-os-abbs/blob/c0cc5a4aab518bf24451de466fba520ea70ddc34/app-web/chromium/autobuild/patches/3003-fix-invalid-substition-type.patch
 

--- a/app-web/chromium/autobuild/patches/0010-AOSC-fix-clang-builtins-path.patch.patch
+++ b/app-web/chromium/autobuild/patches/0010-AOSC-fix-clang-builtins-path.patch.patch
@@ -1,7 +1,7 @@
 From 8d3ec35b45a405c3d2c95b50563bcb7166528d2c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:22:53 +0800
-Subject: [PATCH 10/26] [AOSC] fix-clang-builtins-path.patch
+Subject: [PATCH 10/27] [AOSC] fix-clang-builtins-path.patch
 
 https://github.com/AOSC-Dev/aosc-os-abbs/blob/c0cc5a4aab518bf24451de466fba520ea70ddc34/app-web/chromium/autobuild/patches/3004-fix-clang-builtins-path.patch
 

--- a/app-web/chromium/autobuild/patches/0011-AOSC-TBI-fix-missing-header.patch.patch
+++ b/app-web/chromium/autobuild/patches/0011-AOSC-TBI-fix-missing-header.patch.patch
@@ -1,7 +1,7 @@
 From bad9ee408ce48987f00d3e74de4f6990035992ae Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 02:49:50 +0800
-Subject: [PATCH 11/26] [AOSC, TBI] fix-missing-header.patch
+Subject: [PATCH 11/27] [AOSC, TBI] fix-missing-header.patch
 
 https://github.com/AOSC-Dev/aosc-os-abbs/blob/c0cc5a4aab518bf24451de466fba520ea70ddc34/app-web/chromium/autobuild/patches/3005-fix-missing-header.patch
 

--- a/app-web/chromium/autobuild/patches/0012-AOSC-TBI-fix-static-assertion.patch.patch
+++ b/app-web/chromium/autobuild/patches/0012-AOSC-TBI-fix-static-assertion.patch.patch
@@ -1,7 +1,7 @@
 From 5ab3e730dbd685944c5c101781102fab4f435a0d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:25:37 +0800
-Subject: [PATCH 12/26] [AOSC, TBI] fix-static-assertion.patch
+Subject: [PATCH 12/27] [AOSC, TBI] fix-static-assertion.patch
 
 https://github.com/AOSC-Dev/aosc-os-abbs/blob/c0cc5a4aab518bf24451de466fba520ea70ddc34/app-web/chromium/autobuild/patches/3006-fix-static-assertion.patch
 

--- a/app-web/chromium/autobuild/patches/0013-AOSC-TBI-swiftshader.patch.patch
+++ b/app-web/chromium/autobuild/patches/0013-AOSC-TBI-swiftshader.patch.patch
@@ -1,7 +1,7 @@
 From 052df48469da4557cfd4c99b5daf5e13d8e46f5e Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:29:50 +0800
-Subject: [PATCH 13/26] [AOSC, TBI] swiftshader.patch
+Subject: [PATCH 13/27] [AOSC, TBI] swiftshader.patch
 
 https://github.com/AOSC-Dev/aosc-os-abbs/blob/c0cc5a4aab518bf24451de466fba520ea70ddc34/app-web/chromium/autobuild/patches/4001-loongarch64-swiftshader.patch
 

--- a/app-web/chromium/autobuild/patches/0014-AOSC-sandbox.patch.patch
+++ b/app-web/chromium/autobuild/patches/0014-AOSC-sandbox.patch.patch
@@ -1,7 +1,7 @@
 From 29f2031f7d4729670fc959e55b51026ef7769f5d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:31:27 +0800
-Subject: [PATCH 14/26] [AOSC] sandbox.patch
+Subject: [PATCH 14/27] [AOSC] sandbox.patch
 
 https://github.com/AOSC-Dev/aosc-os-abbs/blob/c0cc5a4aab518bf24451de466fba520ea70ddc34/app-web/chromium/autobuild/patches/4002-loongarch64-sandbox.patch
 

--- a/app-web/chromium/autobuild/patches/0015-AOSC-crashpad.patch.patch
+++ b/app-web/chromium/autobuild/patches/0015-AOSC-crashpad.patch.patch
@@ -1,7 +1,7 @@
 From b333244462027d33e00f878173cba573072fc909 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 02:57:43 +0800
-Subject: [PATCH 15/26] [AOSC] crashpad.patch
+Subject: [PATCH 15/27] [AOSC] crashpad.patch
 
 https://github.com/AOSC-Dev/aosc-os-abbs/blob/c0cc5a4aab518bf24451de466fba520ea70ddc34/app-web/chromium/autobuild/patches/4003-loongarch64-crashpad.patch
 

--- a/app-web/chromium/autobuild/patches/0016-AOSC-ffmpeg.patch.patch
+++ b/app-web/chromium/autobuild/patches/0016-AOSC-ffmpeg.patch.patch
@@ -1,7 +1,7 @@
 From 7078a61015a17f47a5669ec5aaf95d41121e4d58 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:42:17 +0800
-Subject: [PATCH 16/26] [AOSC] ffmpeg.patch
+Subject: [PATCH 16/27] [AOSC] ffmpeg.patch
 
 https://github.com/AOSC-Dev/aosc-os-abbs/blob/c0cc5a4aab518bf24451de466fba520ea70ddc34/app-web/chromium/autobuild/patches/4005-loongarch64-ffmpeg.patch
 

--- a/app-web/chromium/autobuild/patches/0017-AOSC-medium-cmodel.patch.patch
+++ b/app-web/chromium/autobuild/patches/0017-AOSC-medium-cmodel.patch.patch
@@ -1,7 +1,7 @@
 From 5adcc8eaedbb4e179d7dd88f07654449e8ed14e7 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 03:59:19 +0800
-Subject: [PATCH 17/26] [AOSC] medium-cmodel.patch
+Subject: [PATCH 17/27] [AOSC] medium-cmodel.patch
 
 https://github.com/AOSC-Dev/aosc-os-abbs/blob/c0cc5a4aab518bf24451de466fba520ea70ddc34/app-web/chromium/autobuild/patches/4006-loongarch64-medium-cmodel.patch
 

--- a/app-web/chromium/autobuild/patches/0018-AOSC-patch.patch
+++ b/app-web/chromium/autobuild/patches/0018-AOSC-patch.patch
@@ -1,7 +1,7 @@
 From 110c1a1995a1119b6a06354b4be75c17948def24 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 04:13:27 +0800
-Subject: [PATCH 18/26] [AOSC] patch
+Subject: [PATCH 18/27] [AOSC] patch
 
 https://github.com/AOSC-Dev/aosc-os-abbs/blob/c0cc5a4aab518bf24451de466fba520ea70ddc34/app-web/chromium/autobuild/patches/4007-loongarch64.patch
 

--- a/app-web/chromium/autobuild/patches/0019-IWYU-missing-include-for-usage-of-std-exchange-in-lo.patch
+++ b/app-web/chromium/autobuild/patches/0019-IWYU-missing-include-for-usage-of-std-exchange-in-lo.patch
@@ -1,7 +1,7 @@
 From 6fe686cadb1e603ee580434e5287a8f5f2ecfc11 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 10:52:16 +0800
-Subject: [PATCH 19/26] IWYU: missing include for usage of std::exchange in
+Subject: [PATCH 19/27] IWYU: missing include for usage of std::exchange in
  lock_impl.h
 
 Bug: 41455655

--- a/app-web/chromium/autobuild/patches/0020-IWYU-missing-include-for-usage-of-std-optional-in-en.patch
+++ b/app-web/chromium/autobuild/patches/0020-IWYU-missing-include-for-usage-of-std-optional-in-en.patch
@@ -1,7 +1,7 @@
 From 07a3ed394f8865d58daf61f094d09da9557e9c4e Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 11:12:57 +0800
-Subject: [PATCH 20/26] IWYU: missing include for usage of std::optional in
+Subject: [PATCH 20/27] IWYU: missing include for usage of std::optional in
  enum_set.h
 
 Bug: 41455655

--- a/app-web/chromium/autobuild/patches/0021-IWYU-missing-include-for-usage-of-std-optional-in-pa.patch
+++ b/app-web/chromium/autobuild/patches/0021-IWYU-missing-include-for-usage-of-std-optional-in-pa.patch
@@ -1,7 +1,7 @@
 From 081e9452e599756a010cdfdd512a09ffc960a440 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 15:27:19 +0800
-Subject: [PATCH 21/26] IWYU: missing include for usage of std::optional in
+Subject: [PATCH 21/27] IWYU: missing include for usage of std::optional in
  paint_layer_resource_info.h
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-web/chromium/autobuild/patches/0022-chrome-browser-add-missing-dependency.patch
+++ b/app-web/chromium/autobuild/patches/0022-chrome-browser-add-missing-dependency.patch
@@ -1,7 +1,7 @@
 From 886455ca2440d2d934109a4e9423403c261d6cb9 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 17:04:39 +0800
-Subject: [PATCH 22/26] chrome/browser: add missing dependency
+Subject: [PATCH 22/27] chrome/browser: add missing dependency
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/app-web/chromium/autobuild/patches/0023-chrome-browser-ui-add-missing-dependency.patch
+++ b/app-web/chromium/autobuild/patches/0023-chrome-browser-ui-add-missing-dependency.patch
@@ -1,7 +1,7 @@
 From 9c6041ede2e921693ae003a6ffa22e7e13a2b845 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 17:05:57 +0800
-Subject: [PATCH 23/26] chrome/browser/ui: add missing dependency
+Subject: [PATCH 23/27] chrome/browser/ui: add missing dependency
 
 This is to fix build error due to missing dependency when we update
 ninja to 1.12.

--- a/app-web/chromium/autobuild/patches/0024-Move-chrome-browser-ui-webui_name_variants-to-public.patch
+++ b/app-web/chromium/autobuild/patches/0024-Move-chrome-browser-ui-webui_name_variants-to-public.patch
@@ -1,7 +1,7 @@
 From 46a0c26f75d19ca2bda97f68637beff4bfa77b3d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 04:21:45 +0800
-Subject: [PATCH 24/26] Move chrome/browser/ui:webui_name_variants to
+Subject: [PATCH 24/27] Move chrome/browser/ui:webui_name_variants to
  public_deps
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-web/chromium/autobuild/patches/0025-Build-LoongArch64-LSX-optimizations-in-libpng.patch
+++ b/app-web/chromium/autobuild/patches/0025-Build-LoongArch64-LSX-optimizations-in-libpng.patch
@@ -1,7 +1,7 @@
 From 46eb31d5009344805b076c5668db89a8ecbdebe9 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 04:30:35 +0800
-Subject: [PATCH 25/26] Build LoongArch64 LSX optimizations in libpng
+Subject: [PATCH 25/27] Build LoongArch64 LSX optimizations in libpng
 
 These files were added in Chromium Change Number 5454197, but not referenced in BUILD.gn.
 

--- a/app-web/chromium/autobuild/patches/0026-Make-more-deps-entries-public_deps-in-chrome-browser.patch
+++ b/app-web/chromium/autobuild/patches/0026-Make-more-deps-entries-public_deps-in-chrome-browser.patch
@@ -1,7 +1,7 @@
 From 1dae1973123d7185b7403074b0fbd1738bd8560a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 05:59:37 +0800
-Subject: [PATCH 26/26] Make more deps entries public_deps in
+Subject: [PATCH 26/27] Make more deps entries public_deps in
  chrome/browser/ui/BUILD.gn
 
 The chrome/browser/ui build target includes several buildflag headers.

--- a/app-web/chromium/autobuild/patches/0027-Reland-2-linux-build-Enable-fission-for-symbol_level.patch
+++ b/app-web/chromium/autobuild/patches/0027-Reland-2-linux-build-Enable-fission-for-symbol_level.patch
@@ -1,0 +1,107 @@
+From f19f826ba3509faea6f8249bee34a02552ea8a7e Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Fri, 9 Aug 2024 23:09:18 +0800
+Subject: [PATCH 27/27] Reland^2 "linux/build: Enable fission for (symbol_level
+ = 2) release builds as well"
+
+This is a reland of commit b7da3afa43ecb6a1a4839c4f91e798a6d72b221f
+
+The CL got reverted for breaking android-official, and a comment
+on the original review mentioned that it also broke a few cros bots
+like arm-generic-cq.
+
+For the reland, this now also allows non-fission static symbol_level 2
+for android and chromeos.
+
+Original change's description:
+> Reland "linux/build: Enable fission for (symbol_level = 2) release builds as well"
+>
+> This is a reland of commit c031e3aa3a7a0ad71715655e140ba52ffa82a08d
+> The reland removes an assert on macOS (where is_debug_fission isn't
+> used -- darwin toolchains have always used something like fission,
+> but under a different name).
+>
+> Original change's description:
+> > linux/build: Enable fission for (symbol_level = 2) release builds as well
+> >
+> > Looks like full-symbol non-component builds are getting too big for
+> > debug info even in release builds.
+> >
+> > Turn on fission by default on linux in release builds as well.
+> >
+> > This might affect official builds, where dump_syms etc might not
+> > handle fission yet. If this is a problem, we'll have to fix this
+> > at some point, but short-term we can not do this for official
+> > builds in that case. (zequanwu@ says CrOS enabled fission already,
+> > encountered dump_syms issues, and those already got fixed.
+> > And a linux-official try run is green. We'll see!)
+> >
+> > (Component builds don't need fission yet, but for simplicity I'm
+> > enabling fission independent of is_component_build.)
+> >
+> > Bug: 353915727
+> > Cq-Include-Trybots: luci.chromium.try:linux-official
+> > Change-Id: I0df4031726f024e60646e43285d85b150a778d24
+> > Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5730815
+> > Auto-Submit: Nico Weber <thakis@chromium.org>
+> > Reviewed-by: Zequan Wu <zequanwu@google.com>
+> > Commit-Queue: Zequan Wu <zequanwu@google.com>
+> > Cr-Commit-Position: refs/heads/main@{#1331406}
+>
+> Bug: 353915727
+> Change-Id: Idf9df6d94ab3a8c7b4e3f6d8bbb7d50fd2066b13
+> Cq-Include-Trybots: luci.chromium.try:linux-official
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5731601
+> Auto-Submit: Nico Weber <thakis@chromium.org>
+> Commit-Queue: Nico Weber <thakis@chromium.org>
+> Commit-Queue: Kenichi Ishibashi <bashi@chromium.org>
+> Reviewed-by: Kenichi Ishibashi <bashi@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1331479}
+
+Bug: 353915727
+Change-Id: I71bbfff81f9d2e04d3f457e25b90d5da234b25fb
+Cq-Include-Trybots: luci.chromium.try:linux-official
+Cq-Include-Trybots: luci.chromium.try:android-official
+Cq-Include-Trybots: luci.chromium.try:chromeos-amd64-generic-rel
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5753311
+Commit-Queue: Zequan Wu <zequanwu@google.com>
+Reviewed-by: Zequan Wu <zequanwu@google.com>
+Auto-Submit: Nico Weber <thakis@chromium.org>
+Commit-Queue: Nico Weber <thakis@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1335843}
+Co-authored-by: Nico Weber <thakis@chromium.org>
+---
+ build/config/compiler/compiler.gni | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/build/config/compiler/compiler.gni b/build/config/compiler/compiler.gni
+index e9acde43a5..36645382cf 100644
+--- a/build/config/compiler/compiler.gni
++++ b/build/config/compiler/compiler.gni
+@@ -73,8 +73,8 @@ declare_args() {
+   # with some utilities such as icecc and ccache. Requires gold and
+   # gcc >= 4.8 or clang.
+   # http://gcc.gnu.org/wiki/DebugFission
+-  use_debug_fission = is_debug && !is_android && !is_fuchsia && !is_apple &&
+-                      !is_win && use_lld && cc_wrapper == ""
++  use_debug_fission = !is_android && !is_fuchsia && !is_apple && !is_win &&
++                      use_lld && cc_wrapper == ""
+ 
+   # Enables support for ThinLTO, which links 3x-10x faster than full LTO. See
+   # also http://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html
+@@ -312,9 +312,9 @@ use_debug_fission = use_debug_fission && symbol_level == 2
+ if (forbid_non_component_debug_builds) {
+   assert(
+       symbol_level != 2 || current_toolchain != default_toolchain ||
+-          is_component_build || !is_debug || is_ios || use_debug_fission ||
+-          host_os == "win",
+-      "Can't do non-component debug builds at symbol_level=2 without use_debug_fission=true")
++          is_component_build || is_fuchsia || is_apple || use_debug_fission ||
++          is_android || is_chromeos || host_os == "win",
++      "Can't do non-component builds at symbol_level=2 without use_debug_fission=true")
+ }
+ 
+ # TODO(crbug.com/40230692) For Windows, to assemble lzma_sdk's assembly files,
+-- 
+2.46.0
+

--- a/app-web/chromium/spec
+++ b/app-web/chromium/spec
@@ -11,3 +11,13 @@ CHKUPDATE="anitya::id=13344"
 ENVREQ__AMD64="core=96"
 ENVREQ__ARM64="total_mem_per_core=3 core=64"
 ENVREQ__LOONGARCH64="core=16"
+
+# FIXME: Automate the following procedure
+# Note: For errors like "LLVM ERROR: out of memory"
+# Check the current max_map_count kernel parameter
+# `sysctl vm.max_map_count`
+# If it's 65530 aka the default value, try increasing it
+# `sudo sysctl -w vm.max_map_count=262144`
+# https://chromium.googlesource.com/chromium/src/+/main/docs/linux/build_instructions.md#Linker-Crashes
+# https://manpages.ubuntu.com/manpages/oracular/en/man8/sysctl.8.html
+# https://www.kernel.org/doc/html/latest/admin-guide/sysctl/vm.html#max-map-count


### PR DESCRIPTION
Topic Description
-----------------

- chromium: do not disable ThinLTO
- chromium: build with bundled libc++
- chromium: update to 127.0.6533.99
    - Use Last Known Good build configurations.
    - Track patches at https://dev.azure.com/AOSC-Tracking/_git/chromium @ aosc/v127.0.6533.99.
- chromium: bump REL for topic Revision Marking Guidelines
- libyuv: bump REL for topic Revision Marking Guidelines
- chromium: try to fix build fails
- chromium: enable thin LTO
- chromium: drop obsolete patch
    https://src.fedoraproject.org/rpms/chromium/c/7a9444bd5f608685cc1993c4cf8a3fee6825b084?branch=rawhide
- chromium: add llvm as Depends
- chromium: remove unused build argument

... and 6 more commits

Package(s) Affected
-------------------

- chromium: 127.0.6533.99
- libyuv: 0+git20240215-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libyuv chromium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
