### PR TITLE
grub (GRand Unified Bootloader): install old-world compatible removable image for LoongArch

### DIFF
--- a/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,7 +1,7 @@
 From 2ec97c359ea87a2152e4076770c9ec8f7cbd225d Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:54 +0200
-Subject: [PATCH 01/23] Revert "templates: Properly disable the os-prober by
+Subject: [PATCH 01/24] Revert "templates: Properly disable the os-prober by
  default"
 
 This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.

--- a/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,7 +1,7 @@
 From a3daa95d2769516586f7c38af93029663c9133a4 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:58 +0200
-Subject: [PATCH 02/23] Revert "templates: Disable the os-prober by default"
+Subject: [PATCH 02/24] Revert "templates: Disable the os-prober by default"
 
 This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
 ---

--- a/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
+++ b/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
@@ -1,7 +1,7 @@
 From 6bd3d7c7b9e643f6452e8dff6fcebc60d2c4d512 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 17:49:45 -0400
-Subject: [PATCH 03/23] Don't add '*' to highlighted row
+Subject: [PATCH 03/24] Don't add '*' to highlighted row
 
 It is already highlighted.
 ---

--- a/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
+++ b/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
@@ -1,7 +1,7 @@
 From e5c241ea0ea922abbb2ecb8b3140518a6e2a03cd Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:08:23 -0400
-Subject: [PATCH 04/23] Fix border spacing now that we aren't displaying it
+Subject: [PATCH 04/24] Fix border spacing now that we aren't displaying it
 
 ---
  grub-core/normal/menu_text.c | 6 +++---

--- a/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
+++ b/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
@@ -1,7 +1,7 @@
 From 2b35e4db8d9f1f9cab8004e0761a28be960fbf7f Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:30:55 -0400
-Subject: [PATCH 05/23] Indent menu entries
+Subject: [PATCH 05/24] Indent menu entries
 
 ---
  grub-core/normal/menu_text.c | 3 ++-

--- a/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
+++ b/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
@@ -1,7 +1,7 @@
 From d21e8096b9cc9eecfe6da4bb101c6d5d43cec3c5 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:59:36 -0400
-Subject: [PATCH 06/23] Fix margins
+Subject: [PATCH 06/24] Fix margins
 
 ---
  grub-core/normal/menu_text.c | 8 +++-----

--- a/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
+++ b/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
@@ -1,7 +1,7 @@
 From 8ea6cc861054a03a1b437356a0b9b114a0d21adf Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Fri, 21 Jun 2013 14:44:08 -0400
-Subject: [PATCH 07/23] Use -2 instead of -1 for our right-hand margin, so
+Subject: [PATCH 07/24] Use -2 instead of -1 for our right-hand margin, so
  linewrapping works (#976643).
 
 Signed-off-by: Peter Jones <grub2-owner@fedoraproject.org>

--- a/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
+++ b/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
@@ -1,7 +1,7 @@
 From 59c31c490870dd98bc6ca72862a97862bcef0c1b Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 14 Mar 2011 14:27:42 -0400
-Subject: [PATCH 08/23] Don't say "GNU/Linux" in generated menus.
+Subject: [PATCH 08/24] Don't say "GNU/Linux" in generated menus.
 
 ---
  util/grub.d/10_linux.in     | 4 ++--

--- a/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
@@ -1,7 +1,7 @@
 From 12e6fa95ada35a999b46adcbc35a34a73d178ebf Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 16:47:33 -0400
-Subject: [PATCH 09/23] Don't draw a border around the menu
+Subject: [PATCH 09/24] Don't draw a border around the menu
 
 It looks cleaner without it.
 ---

--- a/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
+++ b/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
@@ -1,7 +1,7 @@
 From 8a14427edcdf93bc2c38822465d1082672bb9263 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 10:52:32 -0400
-Subject: [PATCH 10/23] Use the standard margin for the timeout string
+Subject: [PATCH 10/24] Use the standard margin for the timeout string
 
 So that it aligns with the other messages
 ---

--- a/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
+++ b/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
@@ -1,7 +1,7 @@
 From 5ff724e6a6e01cb6f03f5ce09d6cb01a44ad3d67 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:14 -0800
-Subject: [PATCH 11/23] grub-mkrescue: specify -iso-level 3
+Subject: [PATCH 11/24] grub-mkrescue: specify -iso-level 3
 
 This allows GRUB rescue ISOs to boot on LoongArch firmware.
 ---

--- a/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
+++ b/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
@@ -1,7 +1,7 @@
 From b127120988f3d85ebc75c493eba08fc54c8b99dd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:42 -0800
-Subject: [PATCH 12/23] 10_linux: do not count intel-ucode image as a valid
+Subject: [PATCH 12/24] 10_linux: do not count intel-ucode image as a valid
  initrd
 
 ---

--- a/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
+++ b/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
@@ -1,7 +1,7 @@
 From 42a8d6a924f700586328325eb3abe28c4055cc5e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:12:01 -0800
-Subject: [PATCH 13/23] util: add GRUB_COLOR_* variables
+Subject: [PATCH 13/24] util: add GRUB_COLOR_* variables
 
 ---
  util/grub-mkconfig.in    | 2 ++

--- a/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
@@ -1,7 +1,7 @@
 From 5b839a619f7d871de5d6666bde4875c6a262edec Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:26:57 -0800
-Subject: [PATCH 14/23] grub-core: drop GRUB title from the menu
+Subject: [PATCH 14/24] grub-core: drop GRUB title from the menu
 
 We did not display it before, and it's really not very useful since we don't
 encourage reinstalling GRUB anyway.

--- a/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
+++ b/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
@@ -1,7 +1,7 @@
 From 4b607755f602b9844d637c7b7f48617600764238 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Jan 2024 13:58:02 +0800
-Subject: [PATCH 15/23] grub-install: add /efi to the candidate of the ESP
+Subject: [PATCH 15/24] grub-install: add /efi to the candidate of the ESP
  mountpoints
 
 ---

--- a/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
+++ b/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
@@ -1,7 +1,7 @@
 From df48d64d21efa1e01ab1cf24f30e07e9efecf923 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 10 Nov 2023 10:57:02 +0800
-Subject: [PATCH 16/23] commands: add new command memsize
+Subject: [PATCH 16/24] commands: add new command memsize
 
 - This command traverses the entire GRUB memory map, adds the size of each
   region together. The result is the total amount of system memory

--- a/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
+++ b/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
@@ -1,7 +1,7 @@
 From 0ded438a6ab7e8d11922582bf90a7dfa6b7fdcd4 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Mon, 10 Jul 2023 00:14:13 +0800
-Subject: [PATCH 17/23] commands: add new command 'pause'
+Subject: [PATCH 17/24] commands: add new command 'pause'
 
 - Simple enough, this command prints out a prompt, either pre-defined or
   user specified, and awaits a key stroke from the user.

--- a/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
+++ b/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
@@ -1,7 +1,7 @@
 From f608b5788b0e653ad9c2bbdcf078287f2a88d204 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 21:30:22 +0800
-Subject: [PATCH 18/23] normal: align countdown text with rest of the UI
+Subject: [PATCH 18/24] normal: align countdown text with rest of the UI
 
 And add an extra blank line above it.
 ---

--- a/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
+++ b/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
@@ -1,7 +1,7 @@
 From 1e1ce61d967cc992b44c5206cc0cfe21cd44c7ff Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 22:21:55 +0800
-Subject: [PATCH 19/23] po: add patch to disable parallel execution
+Subject: [PATCH 19/24] po: add patch to disable parallel execution
 
 - `msgfilter' might fail while processing de.po to generate de_CH.po, if
   there are too many prarallel jobs.

--- a/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
+++ b/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
@@ -1,7 +1,7 @@
 From 30e70b8cda4b71b524c413954002d4a5961872a0 Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Tue, 30 Jan 2024 14:41:10 +0800
-Subject: [PATCH 20/23] util/bash-completion: Load scripts on demand
+Subject: [PATCH 20/24] util/bash-completion: Load scripts on demand
 
 There are two system directories for bash-completion scripts. One is
 /usr/share/bash-completion/completions/ and the other is

--- a/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
+++ b/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
@@ -1,7 +1,7 @@
 From 209de8a3053c8b0e223836d5b29fe95e0a33b857 Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Mon, 25 Mar 2024 10:11:34 +0800
-Subject: [PATCH 21/23] util/bash-completion: Fix for bash-completion 2.12
+Subject: [PATCH 21/24] util/bash-completion: Fix for bash-completion 2.12
 
 _split_longopt() was the bash-completion private API and removed since
 bash-completion 2.12. This commit initializes the bash-completion

--- a/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
+++ b/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
@@ -1,7 +1,7 @@
 From 8a52d2d391b662681f7c92286ab9e45906119b5d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 11 Jun 2024 22:40:24 +0800
-Subject: [PATCH 22/23] util/grub-mkrescue: use capitalised paths for removable
+Subject: [PATCH 22/24] util/grub-mkrescue: use capitalised paths for removable
  EFI images
 
 Per UEFI Specification, section 3.4.1.1:

--- a/app-admin/grub/autobuild/patches/0023-loongarch64-able-to-start-on-legacy-firmware.patch
+++ b/app-admin/grub/autobuild/patches/0023-loongarch64-able-to-start-on-legacy-firmware.patch
@@ -1,7 +1,7 @@
 From 6740b5a0d995e41d1407ed844f4f5e358df9a421 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:16:26 +0800
-Subject: [PATCH 23/23] loongarch64: able to start on legacy firmware
+Subject: [PATCH 23/24] loongarch64: able to start on legacy firmware
 
 On legacy firmware, the DMW is already enabled by the firmware, and the
 addresses in all the pointers and the PC register are virtual addresses.

--- a/app-admin/grub/autobuild/patches/0024-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
+++ b/app-admin/grub/autobuild/patches/0024-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
@@ -1,0 +1,57 @@
+From d11dd08454cb78cb866f7ec4f5c1891e3eb5c0ea Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 9 Aug 2024 14:45:18 +0800
+Subject: [PATCH 24/24] grub-install: (loongarch64-efi) also install
+ BOOTLOONGARCH.EFI
+
+Some old-world firmware (especially that of the BPI01000 revision) does not
+recognise the standardised BOOTLOONGARCH64.EFI and only sees BOOTLOONGARCH.EFI
+as the removable image name. Make a copy (since it is FAT/VFAT) to satisfy
+both old- and new-world firmware.
+---
+ util/grub-install.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/util/grub-install.c b/util/grub-install.c
+index c5eef8ac6..803101889 100644
+--- a/util/grub-install.c
++++ b/util/grub-install.c
+@@ -849,6 +849,7 @@ main (int argc, char *argv[])
+   int is_efi = 0;
+   const char *efi_distributor = NULL;
+   const char *efi_file = NULL;
++  const char *efi_file_ow = NULL;
+   char **grub_devices;
+   grub_fs_t grub_fs;
+   grub_device_t grub_dev = NULL;
+@@ -1176,6 +1177,7 @@ main (int argc, char *argv[])
+ 	      break;
+ 	    case GRUB_INSTALL_PLATFORM_LOONGARCH64_EFI:
+ 	      efi_file = "BOOTLOONGARCH64.EFI";
++	      efi_file_ow = "BOOTLOONGARCH.EFI";
+ 	      break;
+ 	    case GRUB_INSTALL_PLATFORM_RISCV32_EFI:
+ 	      efi_file = "BOOTRISCV32.EFI";
+@@ -1212,6 +1214,7 @@ main (int argc, char *argv[])
+ 	      break;
+ 	    case GRUB_INSTALL_PLATFORM_LOONGARCH64_EFI:
+ 	      efi_file = "grubloongarch64.efi";
++	      efi_file_ow = "grubloongarch.efi";
+ 	      break;
+ 	    case GRUB_INSTALL_PLATFORM_RISCV32_EFI:
+ 	      efi_file = "grubriscv32.efi";
+@@ -1989,6 +1992,11 @@ main (int argc, char *argv[])
+ 	char *dst = grub_util_path_concat (2, efidir, efi_file);
+ 	grub_install_copy_file (imgfile, dst, 1);
+ 
++	if (platform == GRUB_INSTALL_PLATFORM_LOONGARCH64_EFI) {
++	  char *dst_ow = grub_util_path_concat (2, efidir, efi_file_ow);
++	  grub_install_copy_file (dst, dst_ow, 1);
++	}
++
+ 	grub_set_install_backup_ponr ();
+ 
+ 	free (dst);
+-- 
+2.46.0
+

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -8,7 +8,7 @@ __UNIFONTVER=15.1.04
 LINGUAS_VER=2.12-rc1
 
 VER=${__GRUBVER}+unifont${__UNIFONTVER}
-REL=4
+REL=5
 RETROFONTVER=20200402
 
 SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https://git.savannah.gnu.org/git/grub.git \


### PR DESCRIPTION
Topic Description
-----------------

- grub: (loongarch64) also install BOOTLOONGARCH.EFI for old-world compatibility
    Some old-world firmware (especially that of the BPI01000 revision) does not
    recognise the standardised BOOTLOONGARCH64.EFI and only sees BOOTLOONGARCH.EFI
    as the removable image name. Make a copy (since it is FAT/VFAT) to satisfy
    both old- and new-world firmware.

Package(s) Affected
-------------------

- grub: 2:2.12+unifont15.1.04-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
