### PR TITLE
abbs-update-checksum: update to 0.2.1

### DIFF
--- a/app-devel/abbs-update-checksum/spec
+++ b/app-devel/abbs-update-checksum/spec
@@ -1,4 +1,4 @@
-VER=0.2.0
+VER=0.2.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/abbs-update-checksum"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372823"


### PR DESCRIPTION
Topic Description
-----------------

- abbs-update-checksum: update to 0.2.1
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- abbs-update-checksum: 0.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit abbs-update-checksum
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
