### PR TITLE
rustc: update to 1.80.1

### DIFF
--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,4 +1,4 @@
-VER=1.80.0
+VER=1.80.1
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::0b9ca1e2e45b8a5f0b58db140af0dc92f8311faeb0ad883c5b71a72c02dc6e80"
+CHKSUMS="sha256::6ab79b70dc57737a1de378f212fcf8852d67fe6cf272d122a15b3ea13be77947"
 CHKUPDATE="anitya::id=7635"


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.80.1

Package(s) Affected
-------------------

- rustc: 1:1.80.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
