### PR TITLE
lazygit: new, 0.43.1

### DIFF
--- a/app-vcs/lazygit/autobuild/defines
+++ b/app-vcs/lazygit/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=lazygit
+PKGSEC=vcs
+PKGDES="Simple terminal UI for git commands"
+PKGDEP="git"
+BUILDDEP="go"
+
+GO_LDFLAGS=("-X main.version=$PKGVER" "-X main.buildSource=AOSC")
+
+# FIXME: Autobuild does not yet support splitting debug symbols out of Go
+# executables.
+ABSPLITDBG=0

--- a/app-vcs/lazygit/autobuild/prepare
+++ b/app-vcs/lazygit/autobuild/prepare
@@ -1,0 +1,6 @@
+# FIXME: This dependency supports loong64 from v1.1.17
+if ab_match_arch loongarch64; then
+    abinfo "Updating dependencies for loongarch64 ..."
+    go get github.com/creack/pty@v1.1.17
+    go mod vendor
+fi

--- a/app-vcs/lazygit/spec
+++ b/app-vcs/lazygit/spec
@@ -1,0 +1,5 @@
+VER=0.43.1
+REL=1
+SRCS="git::commit=tags/v$VER::https://github.com/jesseduffield/lazygit"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=268930"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

- lazygit: new, 0.43.1

Package(s) Affected
-------------------

- lazygit: 0.43.1

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

```
#buildit lazygit
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
