### PR TITLE
pipx: new, 1.6.0

### DIFF
--- a/lang-python/argcomplete/autobuild/defines
+++ b/lang-python/argcomplete/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=argcomplete
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="Shells tab completion for argparse"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/argcomplete/spec
+++ b/lang-python/argcomplete/spec
@@ -1,0 +1,4 @@
+VER=3.5.0
+SRCS="git::commit=tags/v${VER}::https://github.com/kislyuk/argcomplete.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=3773"

--- a/lang-python/pipx/autobuild/defines
+++ b/lang-python/pipx/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=pipx
+PKGSEC=python
+PKGDEP="python-3 argcomplete packaging platformdirs tomli userpath"
+BUILDDEP="hatchling hatch-vcs"
+PKGDES="Python tool for installing Python applications to isolated venvs"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pipx/spec
+++ b/lang-python/pipx/spec
@@ -1,0 +1,5 @@
+VER=1.6.0
+# copy-repo is required for setuptools_scm to work
+SRCS="git::commit=tags/${VER};copy-repo=true::https://github.com/pypa/pipx.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=59676"

--- a/lang-python/userpath/autobuild/defines
+++ b/lang-python/userpath/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=userpath
+PKGSEC=python
+PKGDEP="python-3 click"
+BUILDDEP="hatchling"
+PKGDES="Python module for adding locations to PATH"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/userpath/spec
+++ b/lang-python/userpath/spec
@@ -1,0 +1,4 @@
+VER=1.9.2
+SRCS="git::commit=tags/v${VER}::https://github.com/ofek/userpath.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=37501"


### PR DESCRIPTION
Topic Description
-----------------

- pipx: new, 1.6.0
- userpath: new, 1.9.2
- argcomplete: new, 3.5.0

Package(s) Affected
-------------------

- argcomplete: 3.5.0
- pipx: 1.6.0
- userpath: 1.9.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit argcomplete userpath pipx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
