### PR TITLE
ffmpeg: fix bilibili av1 metadata bug

### DIFF
--- a/app-multimedia/ffmpeg/autobuild/patches/0001-avcodec-mips-Add-switch-for-MADD-instruction.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0001-avcodec-mips-Add-switch-for-MADD-instruction.patch
@@ -1,7 +1,7 @@
 From cac8b0b75e1259c37fbd78ab617622e94ed106ea Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Wed, 17 Feb 2021 22:27:11 +0800
-Subject: [PATCH 01/15] avcodec/mips: Add switch for MADD instruction
+Subject: [PATCH 01/17] avcodec/mips: Add switch for MADD instruction
 
 MADD.{d,s} is only available after MIPS IV and being dropped
 in MIPS R6 (Replaced by FMADD).
@@ -666,5 +666,5 @@ index 0943d6f343..8e8c00bda1 100644
  #endif /* HAVE_INLINE_ASM && HAVE_MIPSFPU */
  }
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0002-avutil-mips-Use-MMI_-L-S-QC1-macro-in-SAVE-RECOVER-_.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0002-avutil-mips-Use-MMI_-L-S-QC1-macro-in-SAVE-RECOVER-_.patch
@@ -1,7 +1,7 @@
 From 5dfb9b79d42fe389a2880ba1f98f2dd256b42b66 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 18 Feb 2021 15:34:04 +0800
-Subject: [PATCH 02/15] avutil/mips: Use MMI_{L,S}QC1 macro in
+Subject: [PATCH 02/17] avutil/mips: Use MMI_{L,S}QC1 macro in
  {SAVE,RECOVER}_REG
 
 {SAVE,RECOVER}_REG will be avilable for Loongson2 again,
@@ -80,5 +80,5 @@ index 6a82caa908..41715c6490 100644
        : [temp]"r"(temp_backup_reg)                              \
        : "memory"                                                \
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0003-avutil-mips-Extract-load-store-with-shift-C1-pair-ma.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0003-avutil-mips-Extract-load-store-with-shift-C1-pair-ma.patch
@@ -1,7 +1,7 @@
 From 0c900c14513a9143a82535bf8ae728f2324ecbe8 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 18 Feb 2021 15:58:25 +0800
-Subject: [PATCH 03/15] avutil/mips: Extract load store with shift C1 pair
+Subject: [PATCH 03/17] avutil/mips: Extract load store with shift C1 pair
  marco
 
 We're doing some fancy hacks with load store with shift C1
@@ -138,5 +138,5 @@ index 41715c6490..f5b600e50c 100644
   * Backup saved registers
   * We're not using compiler's clobber list as it's not smart enough
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0004-avcodec-mips-Use-MMI-marcos-to-replace-Loongson3-ins.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0004-avcodec-mips-Use-MMI-marcos-to-replace-Loongson3-ins.patch
@@ -1,7 +1,7 @@
 From a5c646959b719087c7541624bd0ca65cd83d4a57 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 18 Feb 2021 17:02:07 +0800
-Subject: [PATCH 04/15] avcodec/mips: Use MMI marcos to replace Loongson3
+Subject: [PATCH 04/17] avcodec/mips: Use MMI marcos to replace Loongson3
  instructions
 
 Loongson3's extention instructions (prefixed with gs) are widely used
@@ -1304,5 +1304,5 @@ index e7a83875b9..57825fb967 100644
            [tmp0]"=&r"(tmp[0]),    [tmp1]"=&r"(tmp[1]),
            [src]"+&r"(src),        [dst]"+&r"(dst),
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0005-avutil-mips-Use-at-as-MMI-macro-temporary-register.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0005-avutil-mips-Use-at-as-MMI-macro-temporary-register.patch
@@ -1,7 +1,7 @@
 From f549bdb86ce7ac11961806bf6e4ecaab8ffd9193 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 18 Feb 2021 17:35:03 +0800
-Subject: [PATCH 05/15] avutil/mips: Use $at as MMI macro temporary register
+Subject: [PATCH 05/17] avutil/mips: Use $at as MMI macro temporary register
 
 Some function had exceed 30 inline assembly register oprands limiation
 when using LOONGSON2 version of MMI macros. We can avoid that by take
@@ -194,5 +194,5 @@ index f5b600e50c..c1a8046798 100644
  #else /* _MIPS_SIM != _ABIO32 */
  
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0006-avcodec-x86-mathops-clip-constants-used-with-shift-i.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0006-avcodec-x86-mathops-clip-constants-used-with-shift-i.patch
@@ -1,7 +1,7 @@
 From f677ead4dd9032d93c4077b3db7e08c199101f8e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
 Date: Sun, 16 Jul 2023 18:18:02 +0300
-Subject: [PATCH 06/15] avcodec/x86/mathops: clip constants used with shift
+Subject: [PATCH 06/17] avcodec/x86/mathops: clip constants used with shift
  instructions within inline assembly
 
 Fixes assembling with binutil as >= 2.41
@@ -72,5 +72,5 @@ index 6298f5ed19..ca7e2dffc1 100644
  }
  
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0007-Only-use-cpuinfo-to-read-cpu-ISAs.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0007-Only-use-cpuinfo-to-read-cpu-ISAs.patch
@@ -1,7 +1,7 @@
 From f24ba2a4b3ddcab28fba994b9422e373eb62dae9 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 7 Sep 2020 03:49:55 +0800
-Subject: [PATCH 07/15] Only use cpuinfo to read cpu ISAs
+Subject: [PATCH 07/17] Only use cpuinfo to read cpu ISAs
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
 ---
@@ -133,5 +133,5 @@ index 59619d54de..02579c8047 100644
      /* Assume no SIMD ASE supported */
      return 0;
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0008-Add-mips64r6-generic-options.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0008-Add-mips64r6-generic-options.patch
@@ -1,7 +1,7 @@
 From 9c18b08622a6ef56cbc69ff59a9e78ba8eebfcd5 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Tue, 20 Feb 2024 06:57:42 -0800
-Subject: [PATCH 08/15] Add mips64r6 generic options
+Subject: [PATCH 08/17] Add mips64r6 generic options
 
 ---
  configure | 4 ++++
@@ -23,5 +23,5 @@ index 2602bf584a..8218bbfa23 100755
              loongson2e|loongson2f|loongson3*)
                  enable local_aligned
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0009-doc-t2h.pm-fix-missing-CSS-with-texinfo-6.8-and-abov.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0009-doc-t2h.pm-fix-missing-CSS-with-texinfo-6.8-and-abov.patch
@@ -1,7 +1,7 @@
 From 7cc351b2bc1fe54b9de420e7b8f69ecee9368001 Mon Sep 17 00:00:00 2001
 From: Matthew White <mehw.is.me@inventati.org>
 Date: Sun, 14 Nov 2021 00:42:27 +0000
-Subject: [PATCH 09/15] doc/t2h.pm: fix missing CSS with texinfo 6.8 and above
+Subject: [PATCH 09/17] doc/t2h.pm: fix missing CSS with texinfo 6.8 and above
 
 Since texinfo commit 6a5ceab6a48a4f052baad9f3474d741428409fd7, the
 formatting functions, in particular begin_file, program_string and
@@ -78,5 +78,5 @@ index e83d564a65..87412699aa 100644
  # Dummy title command
  # Ignore title. Title is handled through ffmpeg_begin_file().
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0010-doc-t2h.pm-fix-missing-TOC-with-texinfo-6.8-and-abov.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0010-doc-t2h.pm-fix-missing-TOC-with-texinfo-6.8-and-abov.patch
@@ -1,7 +1,7 @@
 From 2015a9aeac5bc1bbf51d2cb2021759b01ac29532 Mon Sep 17 00:00:00 2001
 From: Matthew White <mehw.is.me@inventati.org>
 Date: Sun, 14 Nov 2021 01:10:58 +0000
-Subject: [PATCH 10/15] doc/t2h.pm: fix missing TOC with texinfo 6.8 and above
+Subject: [PATCH 10/17] doc/t2h.pm: fix missing TOC with texinfo 6.8 and above
 
 Since texinfo 6.8, there's no longer an INLINE_CONTENTS variable.
 
@@ -41,5 +41,5 @@ index 87412699aa..d07d974286 100644
  # make chapters <h2>
  set_from_init_file('CHAPTER_HEADER_LEVEL', 2);
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0011-doc-html-support-texinfo-7.0.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0011-doc-html-support-texinfo-7.0.patch
@@ -1,7 +1,7 @@
 From d2931b124860f2c6098f9d3b80fa6a6586fdeab4 Mon Sep 17 00:00:00 2001
 From: Frank Plowman <post@frankplowman.com>
 Date: Wed, 8 Nov 2023 07:55:18 +0000
-Subject: [PATCH 11/15] doc/html: support texinfo 7.0
+Subject: [PATCH 11/17] doc/html: support texinfo 7.0
 
 Resolves trac ticket #10636 (http://trac.ffmpeg.org/ticket/10636).
 
@@ -216,5 +216,5 @@ index d07d974286..b7485e1f1e 100644
  
  texinfo_register_command_formatting('float',
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0012-lavc-vaapi_decode-Make-it-possible-to-send-multiple-.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0012-lavc-vaapi_decode-Make-it-possible-to-send-multiple-.patch
@@ -1,7 +1,7 @@
-From 5b86ed6dd241808f60f10b53d599b8e34d2a7f92 Mon Sep 17 00:00:00 2001
+From 6e31b21f9e9745cc199096db24032ddad545028d Mon Sep 17 00:00:00 2001
 From: David Rosca <nowrep@gmail.com>
 Date: Wed, 8 May 2024 09:11:11 +0200
-Subject: [PATCH 12/15] lavc/vaapi_decode: Make it possible to send multiple
+Subject: [PATCH 12/17] lavc/vaapi_decode: Make it possible to send multiple
  slice params buffers
 
 Reviewed-by: Neal Gompa <ngompa13@gmail.com>
@@ -181,5 +181,5 @@ index 776382f683..237f6c5c63 100644
      if (err) {
          ff_vaapi_decode_cancel(avctx, pic);
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0013-lavc-vaapi_av1-Avoid-sending-the-same-slice-buffer-m.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0013-lavc-vaapi_av1-Avoid-sending-the-same-slice-buffer-m.patch
@@ -1,7 +1,7 @@
-From 7507e92a1ecf33543a3e5fba75f973ea02416afa Mon Sep 17 00:00:00 2001
+From d654f1e249c569d9e4e46bf2be311fd5f9a2dca8 Mon Sep 17 00:00:00 2001
 From: David Rosca <nowrep@gmail.com>
 Date: Wed, 8 May 2024 09:11:13 +0200
-Subject: [PATCH 13/15] lavc/vaapi_av1: Avoid sending the same slice buffer
+Subject: [PATCH 13/17] lavc/vaapi_av1: Avoid sending the same slice buffer
  multiple times
 
 When there are multiple tiles in one slice buffer, use multiple slice
@@ -108,5 +108,5 @@ index df8b98ca85..c2884eebe7 100644
  
  const AVHWAccel ff_av1_vaapi_hwaccel = {
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0014-configure-use-non-deprecated-nvenc-GUID-for-conftest.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0014-configure-use-non-deprecated-nvenc-GUID-for-conftest.patch
@@ -1,7 +1,7 @@
-From c0a4e0131aaff4ea7969b736222c8323b054e399 Mon Sep 17 00:00:00 2001
+From dfac18d5b5f5924e3839be4191a7ed3c926bf8bb Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Thu, 1 Jun 2023 23:24:43 +0200
-Subject: [PATCH 14/15] configure: use non-deprecated nvenc GUID for conftest
+Subject: [PATCH 14/17] configure: use non-deprecated nvenc GUID for conftest
 
 ---
  configure | 2 +-
@@ -21,5 +21,5 @@ index 8218bbfa23..4ab6491bd3 100755
  EOF
  
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0015-avcodec-nvenc-stop-using-deprecated-rc-modes-with-SD.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0015-avcodec-nvenc-stop-using-deprecated-rc-modes-with-SD.patch
@@ -1,7 +1,7 @@
-From f0063048380156d046b2e00c4d1f4121758c20c4 Mon Sep 17 00:00:00 2001
+From 3eb7947a68ec2584c542d757229ccbe9ac04491e Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Thu, 1 Jun 2023 23:46:46 +0200
-Subject: [PATCH 15/15] avcodec/nvenc: stop using deprecated rc modes with SDK
+Subject: [PATCH 15/17] avcodec/nvenc: stop using deprecated rc modes with SDK
  12.1
 
 ---
@@ -146,5 +146,5 @@ index 82fbb23bf7..8e330d65b3 100644
                                                              OFFSET(rc_lookahead), AV_OPT_TYPE_INT,   { .i64 = 0 }, 0, INT_MAX, VE },
      { "surfaces",     "Number of concurrent surfaces",      OFFSET(nb_surfaces),  AV_OPT_TYPE_INT,   { .i64 = 0 }, 0, MAX_REGISTERED_FRAMES, VE },
 -- 
-2.45.2
+2.46.0
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0016-avcodec-av1dec-reset-the-fragment-on-extradata-readi.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0016-avcodec-av1dec-reset-the-fragment-on-extradata-readi.patch
@@ -1,0 +1,27 @@
+From 21da5df668bd3ca605f66e5886556e3518899781 Mon Sep 17 00:00:00 2001
+From: James Almer <jamrial@gmail.com>
+Date: Fri, 2 Jun 2023 14:07:20 -0300
+Subject: [PATCH 16/17] avcodec/av1dec: reset the fragment on extradata reading
+ failure
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+---
+ libavcodec/av1dec.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/av1dec.c b/libavcodec/av1dec.c
+index a3301f454f..1bc37d732a 100644
+--- a/libavcodec/av1dec.c
++++ b/libavcodec/av1dec.c
+@@ -760,7 +760,7 @@ static av_cold int av1_decode_init(AVCodecContext *avctx)
+                                                avctx);
+         if (ret < 0) {
+             av_log(avctx, AV_LOG_WARNING, "Failed to read extradata.\n");
+-            return ret;
++            goto end;
+         }
+ 
+         seq = ((CodedBitstreamAV1Context *)(s->cbc->priv_data))->sequence_header;
+-- 
+2.46.0
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0017-cbs_av1-Don-t-reject-unknown-metadata.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0017-cbs_av1-Don-t-reject-unknown-metadata.patch
@@ -1,0 +1,108 @@
+From 43245ae42d492f9d57fd2d12f26256ed89446948 Mon Sep 17 00:00:00 2001
+From: Mark Thompson <sw@jkqxz.net>
+Date: Tue, 24 Jan 2023 22:46:21 +0000
+Subject: [PATCH 17/17] cbs_av1: Don't reject unknown metadata
+
+Accept it and pass it through unchanged.
+
+The standard requires that decoders ignore unknown metadata, and indeed
+this is tested by some of the Argon coverage streams.
+---
+ libavcodec/cbs_av1.c                 |  7 +++++++
+ libavcodec/cbs_av1.h                 |  7 +++++++
+ libavcodec/cbs_av1_syntax_template.c | 26 ++++++++++++++++++++++++--
+ 3 files changed, 38 insertions(+), 2 deletions(-)
+
+diff --git a/libavcodec/cbs_av1.c b/libavcodec/cbs_av1.c
+index 302e1f38f5..248f386d9a 100644
+--- a/libavcodec/cbs_av1.c
++++ b/libavcodec/cbs_av1.c
+@@ -1276,9 +1276,16 @@ static void cbs_av1_free_metadata(void *unit, uint8_t *content)
+     md = &obu->obu.metadata;
+ 
+     switch (md->metadata_type) {
++    case AV1_METADATA_TYPE_HDR_CLL:
++    case AV1_METADATA_TYPE_HDR_MDCV:
++    case AV1_METADATA_TYPE_SCALABILITY:
++    case AV1_METADATA_TYPE_TIMECODE:
++        break;
+     case AV1_METADATA_TYPE_ITUT_T35:
+         av_buffer_unref(&md->metadata.itut_t35.payload_ref);
+         break;
++    default:
++        av_buffer_unref(&md->metadata.unknown.payload_ref);
+     }
+     av_free(content);
+ }
+diff --git a/libavcodec/cbs_av1.h b/libavcodec/cbs_av1.h
+index 1fc80dcfa0..36848d4410 100644
+--- a/libavcodec/cbs_av1.h
++++ b/libavcodec/cbs_av1.h
+@@ -370,6 +370,12 @@ typedef struct AV1RawMetadataTimecode {
+     uint32_t time_offset_value;
+ } AV1RawMetadataTimecode;
+ 
++typedef struct AV1RawMetadataUnknown {
++    uint8_t     *payload;
++    AVBufferRef *payload_ref;
++    size_t       payload_size;
++} AV1RawMetadataUnknown;
++
+ typedef struct AV1RawMetadata {
+     uint64_t metadata_type;
+     union {
+@@ -378,6 +384,7 @@ typedef struct AV1RawMetadata {
+         AV1RawMetadataScalability scalability;
+         AV1RawMetadataITUTT35     itut_t35;
+         AV1RawMetadataTimecode    timecode;
++        AV1RawMetadataUnknown     unknown;
+     } metadata;
+ } AV1RawMetadata;
+ 
+diff --git a/libavcodec/cbs_av1_syntax_template.c b/libavcodec/cbs_av1_syntax_template.c
+index d98d3d42de..9f4551235c 100644
+--- a/libavcodec/cbs_av1_syntax_template.c
++++ b/libavcodec/cbs_av1_syntax_template.c
+@@ -1997,6 +1997,29 @@ static int FUNC(metadata_timecode)(CodedBitstreamContext *ctx, RWContext *rw,
+     return 0;
+ }
+ 
++static int FUNC(metadata_unknown)(CodedBitstreamContext *ctx, RWContext *rw,
++                                  AV1RawMetadataUnknown *current)
++{
++    int err;
++    size_t i;
++
++    HEADER("Unknown Metadata");
++
++#ifdef READ
++    current->payload_size = cbs_av1_get_payload_bytes_left(rw);
++
++    current->payload_ref = av_buffer_alloc(current->payload_size);
++    if (!current->payload_ref)
++        return AVERROR(ENOMEM);
++    current->payload = current->payload_ref->data;
++#endif
++
++    for (i = 0; i < current->payload_size; i++)
++        fbs(8, payload[i], 1, i);
++
++    return 0;
++}
++
+ static int FUNC(metadata_obu)(CodedBitstreamContext *ctx, RWContext *rw,
+                               AV1RawMetadata *current)
+ {
+@@ -2021,8 +2044,7 @@ static int FUNC(metadata_obu)(CodedBitstreamContext *ctx, RWContext *rw,
+         CHECK(FUNC(metadata_timecode)(ctx, rw, &current->metadata.timecode));
+         break;
+     default:
+-        // Unknown metadata type.
+-        return AVERROR_PATCHWELCOME;
++        CHECK(FUNC(metadata_unknown)(ctx, rw, &current->metadata.unknown));
+     }
+ 
+     return 0;
+-- 
+2.46.0
+

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=4.4.4
-REL=8
+REL=9
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::e80b380d595c809060f66f96a5d849511ef4a76a26b76eacf5778b94c3570309"
 CHKUPDATE="anitya::id=5405"


### PR DESCRIPTION
Topic Description
-----------------

- ffmpeg: backport av1 codec fixes from upstream, fix bilibili's av1 metadata bug

Package(s) Affected
-------------------

- ffmpeg: 4.4.4-9

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
