### PR TITLE
primus+32: drop, orphaned

### DIFF
--- a/runtime-optenv32/primus+32/autobuild/build
+++ b/runtime-optenv32/primus+32/autobuild/build
@@ -1,8 +1,0 @@
-export PATH=/opt/32/bin:$PATH
-export CC=/opt/32/bin/i686-pc-linux-gnu-gcc
-export CXX=/opt/32/bin/i686-pc-linux-gnu-g++
-
-make PRIMUS_libGLa="/opt/32/lib/nvidia/libGL.so.1" \
-     PRIMUS_libGLd="/opt/32/lib/libGL.so.1"
-
-install -D lib/libGL.so.1 "$PKGDIR"/opt/32/lib/primus/libGL.so.1

--- a/runtime-optenv32/primus+32/autobuild/defines
+++ b/runtime-optenv32/primus+32/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=primus+32
-PKGSEC=utils
-PKGDEP="bumblebee mesa+32"
-PKGDES="Faster OpenGL offloading for Bumblebee (32-Bit runtime)"
-
-NOLTO=1
-ABHOST=noarch

--- a/runtime-optenv32/primus+32/spec
+++ b/runtime-optenv32/primus+32/spec
@@ -1,5 +1,0 @@
-VER=20150328
-REL=3
-SRCS="git::commit=d1afbf6fce2778c0751eddf19db9882e04f18bfd::https://github.com/amonakov/primus"
-CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=12297"


### PR DESCRIPTION
Topic Description
-----------------

- primus+32: drop, orphaned

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit primus+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
