### PR TITLE
linux-kernel-lts: improve support for LoongArch old-world multiprocessor system

### DIFF
--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0001-lib-cpumask-Make-CPUMASK_OFFSTACK-usable-without-deb.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0001-lib-cpumask-Make-CPUMASK_OFFSTACK-usable-without-deb.patch
@@ -1,7 +1,7 @@
 From e076c1ac141b6d1777b561b329188d81a3b0dd16 Mon Sep 17 00:00:00 2001
 From: Josh Boyer <jwboyer@fedoraproject.org>
 Date: Mon, 11 Nov 2013 08:39:16 -0500
-Subject: [PATCH 01/33] lib/cpumask: Make CPUMASK_OFFSTACK usable without debug
+Subject: [PATCH 01/34] lib/cpumask: Make CPUMASK_OFFSTACK usable without debug
  dependency
 
 When CPUMASK_OFFSTACK was added in 2008, it was dependent upon
@@ -21,7 +21,7 @@ Ref: https://lore.kernel.org/all/tip-962d9c5757b2ebd30678a88a4f475ae997f4d5dd@gi
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/lib/Kconfig b/lib/Kconfig
-index ee365b7402f19..16d1c4f95c5ac 100644
+index ee365b7402f1..16d1c4f95c5a 100644
 --- a/lib/Kconfig
 +++ b/lib/Kconfig
 @@ -532,7 +532,8 @@ config CHECK_SIGNATURE

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0002-input-kill-stupid-messages.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0002-input-kill-stupid-messages.patch
@@ -1,7 +1,7 @@
 From 5fc4a4e54c27b8eca77df22542f9b5ab72d0b5b0 Mon Sep 17 00:00:00 2001
 From: "kernel-team@fedoraproject.org" <kernel-team@fedoraproject.org>
 Date: Thu, 29 Jul 2010 16:46:31 -0700
-Subject: [PATCH 02/33] input: kill stupid messages
+Subject: [PATCH 02/34] input: kill stupid messages
 
 Bugzilla: N/A
 Upstream-status: Fedora mustard
@@ -11,7 +11,7 @@ Ref: https://src.fedoraproject.org/rpms/kernel/c/bde70da19cc3965c06ae7998a449d13
  1 file changed, 4 insertions(+)
 
 diff --git a/drivers/input/keyboard/atkbd.c b/drivers/input/keyboard/atkbd.c
-index c229bd6b3f7f2..07a014fc3d494 100644
+index c229bd6b3f7f..07a014fc3d49 100644
 --- a/drivers/input/keyboard/atkbd.c
 +++ b/drivers/input/keyboard/atkbd.c
 @@ -486,11 +486,15 @@ static void atkbd_receive_byte(struct ps2dev *ps2dev, u8 data)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0003-lis3-improve-handling-of-null-rate.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0003-lis3-improve-handling-of-null-rate.patch
@@ -1,7 +1,7 @@
 From 01169c89110c9fa722dc37a0a581ec01e49ae762 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=89ric=20Piel?= <eric.piel@tremplin-utc.net>
 Date: Thu, 3 Nov 2011 16:22:40 +0100
-Subject: [PATCH 03/33] lis3: improve handling of null rate
+Subject: [PATCH 03/34] lis3: improve handling of null rate
 
 When obtaining a rate of 0, we would disable the device supposely
 because it seems to behave incorectly. It actually only comes from the
@@ -19,7 +19,7 @@ Ref: https://src.fedoraproject.org/rpms/kernel/c/3d246278f1c64d7e1d5ab46d7b885a3
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/misc/lis3lv02d/lis3lv02d.c b/drivers/misc/lis3lv02d/lis3lv02d.c
-index 49868a45c0ad1..eaedefe0ca5c3 100644
+index 49868a45c0ad..eaedefe0ca5c 100644
 --- a/drivers/misc/lis3lv02d/lis3lv02d.c
 +++ b/drivers/misc/lis3lv02d/lis3lv02d.c
 @@ -204,7 +204,8 @@ static void lis3lv02d_get_xyz(struct lis3lv02d *lis3, int *x, int *y, int *z)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0004-Input-synaptics-pin-3-touches-when-the-firmware-repo.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0004-Input-synaptics-pin-3-touches-when-the-firmware-repo.patch
@@ -1,7 +1,7 @@
 From 167801effb58e3a5e8a79988572ddc62f4d5971b Mon Sep 17 00:00:00 2001
 From: Benjamin Tissoires <benjamin.tissoires@redhat.com>
 Date: Thu, 16 Apr 2015 13:01:46 -0400
-Subject: [PATCH 04/33] Input - synaptics: pin 3 touches when the firmware
+Subject: [PATCH 04/34] Input - synaptics: pin 3 touches when the firmware
  reports 3 fingers
 
 Synaptics PS/2 touchpad can send only 2 touches in a report. They can
@@ -29,7 +29,7 @@ Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1212230#c15
  1 file changed, 8 insertions(+)
 
 diff --git a/drivers/input/mouse/synaptics.c b/drivers/input/mouse/synaptics.c
-index 7a303a9d6bf72..9eab057a0bee2 100644
+index 7a303a9d6bf7..9eab057a0bee 100644
 --- a/drivers/input/mouse/synaptics.c
 +++ b/drivers/input/mouse/synaptics.c
 @@ -1012,6 +1012,14 @@ static void synaptics_report_mt_data(struct psmouse *psmouse,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0005-driver-sisfb-add-resolution-1368-768-for-loongson-ly.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0005-driver-sisfb-add-resolution-1368-768-for-loongson-ly.patch
@@ -1,7 +1,7 @@
 From e837f8201022f08ddc05bdb7c8948f93413be2a9 Mon Sep 17 00:00:00 2001
 From: flygoat <flygoatfree@gmail.com>
 Date: Sun, 5 Mar 2017 20:33:17 +0800
-Subject: [PATCH 05/33] driver sisfb add resolution 1368*768 for loongson
+Subject: [PATCH 05/34] driver sisfb add resolution 1368*768 for loongson
  lynloong
 
 Ref: Contact the author.
@@ -15,7 +15,7 @@ Ref: Contact the author.
  6 files changed, 36 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/video/fbdev/sis/310vtbl.h b/drivers/video/fbdev/sis/310vtbl.h
-index 54fcbbf4ef635..4d8197ccf25c0 100644
+index 54fcbbf4ef63..4d8197ccf25c 100644
 --- a/drivers/video/fbdev/sis/310vtbl.h
 +++ b/drivers/video/fbdev/sis/310vtbl.h
 @@ -130,6 +130,9 @@ static const struct SiS_Ext SiS310_EModeIDTable[] =
@@ -75,7 +75,7 @@ index 54fcbbf4ef635..4d8197ccf25c0 100644
 -
 -
 diff --git a/drivers/video/fbdev/sis/init.c b/drivers/video/fbdev/sis/init.c
-index 2ba91d62af92e..108a564a0f875 100644
+index 2ba91d62af92..108a564a0f87 100644
 --- a/drivers/video/fbdev/sis/init.c
 +++ b/drivers/video/fbdev/sis/init.c
 @@ -440,6 +440,9 @@ SiS_GetModeID(int VGAEngine, unsigned int VBFlags, int HDisplay, int VDisplay,
@@ -109,7 +109,7 @@ index 2ba91d62af92e..108a564a0f875 100644
  	     if(VGAEngine == SIS_315_VGA) {
  		if(VBFlags2 & VB2_LCDOVER1280BRIDGE) {
 diff --git a/drivers/video/fbdev/sis/init.h b/drivers/video/fbdev/sis/init.h
-index 400b0e5681b24..d23c49cf69e81 100644
+index 400b0e5681b2..d23c49cf69e8 100644
 --- a/drivers/video/fbdev/sis/init.h
 +++ b/drivers/video/fbdev/sis/init.h
 @@ -104,6 +104,7 @@ static const unsigned short ModeIndex_1920x1080[]    = {0x2c, 0x2d, 0x00, 0x73};
@@ -146,7 +146,7 @@ index 400b0e5681b24..d23c49cf69e81 100644
  #endif
 -
 diff --git a/drivers/video/fbdev/sis/init301.c b/drivers/video/fbdev/sis/init301.c
-index 09329072004f4..39101889a2b76 100644
+index 09329072004f..39101889a2b7 100644
 --- a/drivers/video/fbdev/sis/init301.c
 +++ b/drivers/video/fbdev/sis/init301.c
 @@ -2331,7 +2331,7 @@ SiS_GetLCDResInfo(struct SiS_Private *SiS_Pr, unsigned short ModeNo, unsigned sh
@@ -181,7 +181,7 @@ index 09329072004f4..39101889a2b76 100644
  #endif
 -
 diff --git a/drivers/video/fbdev/sis/initdef.h b/drivers/video/fbdev/sis/initdef.h
-index 264b55a5947b8..5232f5c2a87e7 100644
+index 264b55a5947b..5232f5c2a87e 100644
 --- a/drivers/video/fbdev/sis/initdef.h
 +++ b/drivers/video/fbdev/sis/initdef.h
 @@ -488,6 +488,7 @@
@@ -201,7 +201,7 @@ index 264b55a5947b8..5232f5c2a87e7 100644
  #define TVCLKBASE_300		0x21   /* Indices on TV clocks in VCLKData table (300) */
  #define TVCLKBASE_315	        0x3a   /* Indices on TV clocks in (VB)VCLKData table (315) */
 diff --git a/drivers/video/fbdev/sis/sis_main.c b/drivers/video/fbdev/sis/sis_main.c
-index 6d524a65af181..92a3fff91ba79 100644
+index 6d524a65af18..92a3fff91ba7 100644
 --- a/drivers/video/fbdev/sis/sis_main.c
 +++ b/drivers/video/fbdev/sis/sis_main.c
 @@ -3670,6 +3670,11 @@ sisfb_pre_setmode(struct sis_video_info *ivideo)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0006-Revert-video-output-Drop-display-output-class-suppor.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0006-Revert-video-output-Drop-display-output-class-suppor.patch
@@ -1,7 +1,7 @@
 From ef97bea86b110e7b5e1c1409cbf21f8f9612c3c2 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 7 Nov 2017 09:01:33 +0800
-Subject: [PATCH 06/33] Revert "video / output: Drop display output class
+Subject: [PATCH 06/34] Revert "video / output: Drop display output class
  support" This reverts commit f167a64e9d67ebd03d304e369c12011cf2bffaf5
  Required by some Loongson platform devices drivers
 
@@ -17,7 +17,7 @@ Ref: Contact the author.
  create mode 100644 include/linux/video_output.h
 
 diff --git a/drivers/video/Kconfig b/drivers/video/Kconfig
-index b694d7669d320..f297f929adbfe 100644
+index b694d7669d32..f297f929adbf 100644
 --- a/drivers/video/Kconfig
 +++ b/drivers/video/Kconfig
 @@ -51,6 +51,12 @@ config VGASTATE
@@ -34,7 +34,7 @@ index b694d7669d320..f297f929adbfe 100644
  	bool
  
 diff --git a/drivers/video/Makefile b/drivers/video/Makefile
-index 6bbc039508995..d7734d11b8aaf 100644
+index 6bbc03950899..d7734d11b8aa 100644
 --- a/drivers/video/Makefile
 +++ b/drivers/video/Makefile
 @@ -14,6 +14,8 @@ obj-y				  += backlight/
@@ -48,7 +48,7 @@ index 6bbc039508995..d7734d11b8aaf 100644
  obj-$(CONFIG_VIDEOMODE_HELPERS) += of_display_timing.o of_videomode.o
 diff --git a/drivers/video/output.c b/drivers/video/output.c
 new file mode 100644
-index 0000000000000..1446c49fe6aff
+index 000000000000..1446c49fe6af
 --- /dev/null
 +++ b/drivers/video/output.c
 @@ -0,0 +1,133 @@
@@ -187,7 +187,7 @@ index 0000000000000..1446c49fe6aff
 +module_exit(video_output_class_exit);
 diff --git a/include/linux/video_output.h b/include/linux/video_output.h
 new file mode 100644
-index 0000000000000..ed5cdeb3604db
+index 000000000000..ed5cdeb3604d
 --- /dev/null
 +++ b/include/linux/video_output.h
 @@ -0,0 +1,57 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0007-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0007-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
@@ -1,7 +1,7 @@
 From 81c40cfdc6ca3680aeec0f96575bc8229303bd4c Mon Sep 17 00:00:00 2001
 From: Mark Weiman <mark.weiman@markzz.com>
 Date: Wed, 27 Jan 2021 13:28:09 -0500
-Subject: [PATCH 07/33] pci: Enable overrides for missing ACS capabilities
+Subject: [PATCH 07/34] pci: Enable overrides for missing ACS capabilities
  (5.10.11+)
 
 This an updated version of Alex Williamson's patch from:
@@ -15,7 +15,7 @@ Ref: To be replaced by https://github.com/torvalds/linux/commit/47c8846a49baa8c0
  2 files changed, 110 insertions(+)
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index 8d2f9ed3f1076..2c4b4eb98f22d 100644
+index 8d2f9ed3f107..2c4b4eb98f22 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -4310,6 +4310,14 @@
@@ -34,7 +34,7 @@ index 8d2f9ed3f1076..2c4b4eb98f22d 100644
  				Safety option to keep boot IRQs enabled. This
  				should never be necessary.
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index ec4277d7835b2..0c07e4e8231f5 100644
+index ec4277d7835b..0c07e4e8231f 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -287,6 +287,106 @@ static int __init pci_apply_final_quirks(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0008-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0008-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
 From 9dc96a85fd50eeb1062b43122e0c50d0cb2d1f7e Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux@gmail.com>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 08/33] usb: phy: tegra: Add 38.4MHz clock table entry
+Subject: [PATCH 08/34] usb: phy: tegra: Add 38.4MHz clock table entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to
 use the ehci phy on the Jetson TX1.
@@ -16,7 +16,7 @@ Ref: https://lore.kernel.org/all/1459929245-23449-1-git-send-email-hunterlaux@gm
  1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/phy/phy-tegra-usb.c b/drivers/usb/phy/phy-tegra-usb.c
-index 4ea47e6f835bf..12f6a2bb4057d 100644
+index 4ea47e6f835b..12f6a2bb4057 100644
 --- a/drivers/usb/phy/phy-tegra-usb.c
 +++ b/drivers/usb/phy/phy-tegra-usb.c
 @@ -174,7 +174,7 @@ struct tegra_xtal_freq {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0009-more-uarches-for-kernel.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0009-more-uarches-for-kernel.patch
@@ -1,7 +1,7 @@
 From 1b5ab4651bc32e2f8a697f4370a213928f5a5dae Mon Sep 17 00:00:00 2001
 From: graysky <therealgraysky@proton.me>
 Date: Wed, 21 Feb 2024 08:38:13 -0500
-Subject: [PATCH 09/33] more uarches for kernel
+Subject: [PATCH 09/34] more uarches for kernel
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -112,7 +112,7 @@ Ref: https://github.com/graysky2/kernel_compiler_patch/blob/30db2170d3ddefa13a3d
  3 files changed, 528 insertions(+), 17 deletions(-)
 
 diff --git a/arch/x86/Kconfig.cpu b/arch/x86/Kconfig.cpu
-index 87396575cfa77..5ac6e8463dd0b 100644
+index 87396575cfa7..5ac6e8463dd0 100644
 --- a/arch/x86/Kconfig.cpu
 +++ b/arch/x86/Kconfig.cpu
 @@ -157,7 +157,7 @@ config MPENTIUM4
@@ -645,7 +645,7 @@ index 87396575cfa77..5ac6e8463dd0b 100644
  config IA32_FEAT_CTL
  	def_bool y
 diff --git a/arch/x86/Makefile b/arch/x86/Makefile
-index 3ff53a2d4ff08..24f2d87305ad9 100644
+index 3ff53a2d4ff0..24f2d87305ad 100644
 --- a/arch/x86/Makefile
 +++ b/arch/x86/Makefile
 @@ -151,8 +151,48 @@ else
@@ -700,7 +700,7 @@ index 3ff53a2d4ff08..24f2d87305ad9 100644
          KBUILD_CFLAGS += $(cflags-y)
  
 diff --git a/arch/x86/include/asm/vermagic.h b/arch/x86/include/asm/vermagic.h
-index 75884d2cdec37..02c1386eb653e 100644
+index 75884d2cdec3..02c1386eb653 100644
 --- a/arch/x86/include/asm/vermagic.h
 +++ b/arch/x86/include/asm/vermagic.h
 @@ -17,6 +17,54 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0010-MIPS-Loongson64-Disable-writecombine-for-Loongson-3A.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0010-MIPS-Loongson64-Disable-writecombine-for-Loongson-3A.patch
@@ -1,7 +1,7 @@
 From a256018721abddc793647334a33d787d11e79b79 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Mon, 12 Oct 2020 13:32:23 +0800
-Subject: [PATCH 10/33] MIPS: Loongson64: Disable writecombine for Loongson-3A
+Subject: [PATCH 10/34] MIPS: Loongson64: Disable writecombine for Loongson-3A
  R1
 
 It breaks radeon.
@@ -13,7 +13,7 @@ Ref: Contact the author.
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/kernel/cpu-probe.c b/arch/mips/kernel/cpu-probe.c
-index b406d8bfb15a3..79864d9beef6a 100644
+index b406d8bfb15a..79864d9beef6 100644
 --- a/arch/mips/kernel/cpu-probe.c
 +++ b/arch/mips/kernel/cpu-probe.c
 @@ -1253,6 +1253,7 @@ static inline void cpu_probe_legacy(struct cpuinfo_mips *c, unsigned int cpu)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0011-platform-surface-hid.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0011-platform-surface-hid.patch
@@ -1,7 +1,7 @@
 From 6bf6531d8663051dc4bfd980073d2784650735ff Mon Sep 17 00:00:00 2001
 From: qzed <qzed@users.noreply.github.com>
 Date: Tue, 17 Sep 2019 17:16:23 +0200
-Subject: [PATCH 11/33] platform: surface hid
+Subject: [PATCH 11/34] platform: surface hid
 
 Ref: https://github.com/linux-surface/kernel/commit/352b9fcff865d3d693675ba3add91b186f0beb97
 ---
@@ -9,7 +9,7 @@ Ref: https://github.com/linux-surface/kernel/commit/352b9fcff865d3d693675ba3add9
  1 file changed, 12 insertions(+)
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index 4246348ca16e9..5ecd905ffc790 100644
+index 4246348ca16e..5ecd905ffc79 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
 @@ -943,6 +943,18 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0012-loongson64-init-suppress-memcpy-out-of-bound-checkin.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0012-loongson64-init-suppress-memcpy-out-of-bound-checkin.patch
@@ -1,7 +1,7 @@
 From 69f4d44f8c3a98aa33bdd7d1e63689d8856488b9 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Wed, 24 Aug 2022 03:54:11 +0000
-Subject: [PATCH 12/33] loongson64/init: suppress memcpy out-of-bound checking
+Subject: [PATCH 12/34] loongson64/init: suppress memcpy out-of-bound checking
 
 Ref: Contact the author.
 ---
@@ -9,7 +9,7 @@ Ref: Contact the author.
  1 file changed, 3 insertions(+)
 
 diff --git a/arch/mips/loongson64/init.c b/arch/mips/loongson64/init.c
-index f25caa6aa9d30..17895a9e75323 100644
+index f25caa6aa9d3..17895a9e7532 100644
 --- a/arch/mips/loongson64/init.c
 +++ b/arch/mips/loongson64/init.c
 @@ -27,7 +27,10 @@ static void __init mips_nmi_setup(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0013-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0013-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
@@ -1,7 +1,7 @@
 From 496620b9483cd04232c08fcc5fbd0bcb8fd4ff83 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 13/33] arm64: dts: rockchip: change GMAC rx_delay for
+Subject: [PATCH 13/34] arm64: dts: rockchip: change GMAC rx_delay for
  RockPro64
 
 Ref: https://github.com/armbian/build/blob/42cc795f4d4ffed60f81fe64cbf96be39ae0783a/patch/kernel/archive/rockchip64-6.10/board-rockpro64-change-rx_delay-for-gmac.patch
@@ -10,7 +10,7 @@ Ref: https://github.com/armbian/build/blob/42cc795f4d4ffed60f81fe64cbf96be39ae07
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-index bca2b50e0a934..37719b771371f 100644
+index bca2b50e0a93..37719b771371 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 @@ -307,7 +307,7 @@ &gmac {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0014-arm64-dts-rockchip-add-out-of-band-IRQ-for-RK3399-Wi.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0014-arm64-dts-rockchip-add-out-of-band-IRQ-for-RK3399-Wi.patch
@@ -1,7 +1,7 @@
 From 7119fd050061cb554c93ebc764bb172a3920b084 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 30 Nov 2020 22:49:55 +0800
-Subject: [PATCH 14/33] arm64: dts: rockchip: add out-of-band IRQ for RK3399
+Subject: [PATCH 14/34] arm64: dts: rockchip: add out-of-band IRQ for RK3399
  Wi-Fi
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
@@ -11,7 +11,7 @@ Ref: Contact the author.
  1 file changed, 16 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts b/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts
-index 294eb2de263de..bcaf61fb29186 100644
+index 294eb2de263d..bcaf61fb2918 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts
 @@ -903,6 +903,10 @@ bt_host_wake_pin: bt-host-wake-pin {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0015-arm64-rockchip-dts-rk3399-fix-PD-on-Pinebook-Pro.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0015-arm64-rockchip-dts-rk3399-fix-PD-on-Pinebook-Pro.patch
@@ -1,7 +1,7 @@
 From 1d4aac419a1896a93c555bcda3be2b9b66f5c68e Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Tue, 1 Dec 2020 16:19:04 +0800
-Subject: [PATCH 15/33] arm64: rockchip: dts: rk3399: fix PD on Pinebook Pro
+Subject: [PATCH 15/34] arm64: rockchip: dts: rk3399: fix PD on Pinebook Pro
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
 Ref: Contact the author.
@@ -10,7 +10,7 @@ Ref: Contact the author.
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts b/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts
-index bcaf61fb29186..206726656c411 100644
+index bcaf61fb2918..206726656c41 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts
 @@ -701,10 +701,10 @@ connector {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0016-HACK-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0016-HACK-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
 From 5be372c8e45b5039d7b792b7226d910367e9407c Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Thu, 21 Apr 2022 11:36:35 +0800
-Subject: [PATCH 16/33] HACK: arm64: dts: rockchip: disable usb3 on quartz64
+Subject: [PATCH 16/34] HACK: arm64: dts: rockchip: disable usb3 on quartz64
 
 USB3 on Quartz64 is of bad quality because of sharing lines with SATA.
 
@@ -12,7 +12,7 @@ Ref: Contact the author.
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts b/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
-index 854d02b46e6fc..2de152da3faca 100644
+index 854d02b46e6f..2de152da3fac 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
 @@ -788,6 +788,10 @@ &usb_host0_xhci {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0017-arm64-add-Kconfig-option-for-Phytium-SoCs.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0017-arm64-add-Kconfig-option-for-Phytium-SoCs.patch
@@ -1,7 +1,7 @@
 From 52cf41ed105160faa7b9ee0d724727870a1ab1c1 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 25 Sep 2022 23:02:39 +0800
-Subject: [PATCH 17/33] arm64: add Kconfig option for Phytium SoCs
+Subject: [PATCH 17/34] arm64: add Kconfig option for Phytium SoCs
 
 This option works as a gate for Phytium-specific drivers.
 
@@ -12,7 +12,7 @@ Ref: Contact the author.
  1 file changed, 5 insertions(+)
 
 diff --git a/arch/arm64/Kconfig.platforms b/arch/arm64/Kconfig.platforms
-index 6069120199bbc..9191add0f1bb6 100644
+index 6069120199bb..9191add0f1bb 100644
 --- a/arch/arm64/Kconfig.platforms
 +++ b/arch/arm64/Kconfig.platforms
 @@ -244,6 +244,11 @@ config ARCH_NPCM

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0018-net-stmmac-add-a-glue-driver-for-GMACs-in-Phytium-So.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0018-net-stmmac-add-a-glue-driver-for-GMACs-in-Phytium-So.patch
@@ -1,7 +1,7 @@
 From cf74828e2e66145fd0094dc039141af5ae583090 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 25 Sep 2022 23:03:51 +0800
-Subject: [PATCH 18/33] net: stmmac: add a glue driver for GMACs in Phytium
+Subject: [PATCH 18/34] net: stmmac: add a glue driver for GMACs in Phytium
  SoCs
 
 Multiple Phytium ARM64 SoCs feature DesignWare GMACs that is mostly
@@ -20,7 +20,7 @@ Ref: Contact the author.
  create mode 100644 drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-index 92d7d5a00b84c..fbccb24befd0c 100644
+index 92d7d5a00b84..fbccb24befd0 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
 +++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
 @@ -121,6 +121,15 @@ config DWMAC_MESON
@@ -40,7 +40,7 @@ index 92d7d5a00b84c..fbccb24befd0c 100644
  	tristate "Qualcomm ETHQOS support"
  	default ARCH_QCOM
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet/stmicro/stmmac/Makefile
-index 5b57aee19267f..91b1cf9bc81c8 100644
+index 5b57aee19267..91b1cf9bc81c 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Makefile
 +++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
 @@ -19,6 +19,7 @@ obj-$(CONFIG_DWMAC_IPQ806X)	+= dwmac-ipq806x.o
@@ -53,7 +53,7 @@ index 5b57aee19267f..91b1cf9bc81c8 100644
  obj-$(CONFIG_DWMAC_SOCFPGA)	+= dwmac-altr-socfpga.o
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 new file mode 100644
-index 0000000000000..cda672e23b2c3
+index 000000000000..cda672e23b2c
 --- /dev/null
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -0,0 +1,222 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0019-HID-logitech-dj-add-support-for-the-new-lightspeed-r.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0019-HID-logitech-dj-add-support-for-the-new-lightspeed-r.patch
@@ -1,7 +1,7 @@
 From b9fffdd93b4eaefabe186b69d52ad333597cb852 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Filipe=20La=C3=ADns?= <lains@riseup.net>
 Date: Sat, 23 Jan 2021 18:03:33 +0000
-Subject: [PATCH 19/33] HID: logitech-dj: add support for the new lightspeed
+Subject: [PATCH 19/34] HID: logitech-dj: add support for the new lightspeed
  receiver iteration
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -27,7 +27,7 @@ Ref: https://lore.kernel.org/all/20231124172043.140796747@linuxfoundation.org/
  2 files changed, 38 insertions(+), 13 deletions(-)
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index 5ecd905ffc790..01f5fe9730f97 100644
+index 5ecd905ffc79..01f5fe9730f9 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
 @@ -874,6 +874,7 @@
@@ -39,7 +39,7 @@ index 5ecd905ffc790..01f5fe9730f97 100644
  #define USB_DEVICE_ID_SPACENAVIGATOR	0xc626
  #define USB_DEVICE_ID_DINOVO_DESKTOP	0xc704
 diff --git a/drivers/hid/hid-logitech-dj.c b/drivers/hid/hid-logitech-dj.c
-index 37958edec55f5..cdb298707eb05 100644
+index 37958edec55f..cdb298707eb0 100644
 --- a/drivers/hid/hid-logitech-dj.c
 +++ b/drivers/hid/hid-logitech-dj.c
 @@ -116,6 +116,7 @@ enum recvr_type {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0020-HACK-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0020-HACK-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
 From f4a1ab0397504ec13c10a1caba134b022a626189 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 27 Jul 2023 11:13:25 -0400
-Subject: [PATCH 20/33] HACK arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 20/34] HACK arm64: drop hisi_ddrc_pmu driver
 
 Ref: Contact the author.
 ---
@@ -9,7 +9,7 @@ Ref: Contact the author.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/perf/hisilicon/Makefile b/drivers/perf/hisilicon/Makefile
-index 48dcc8381ea75..a62ab2f0766f0 100644
+index 48dcc8381ea7..a62ab2f0766f 100644
 --- a/drivers/perf/hisilicon/Makefile
 +++ b/drivers/perf/hisilicon/Makefile
 @@ -1,6 +1,6 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0021-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0021-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
@@ -1,7 +1,7 @@
 From 145eb6e39826b6f24d89cf5d29b7f527d3f714d4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Wed, 21 Feb 2024 16:58:32 -0500
-Subject: [PATCH 21/33] arch/loongarch: add la_ow_syscall as in-tree module
+Subject: [PATCH 21/34] arch/loongarch: add la_ow_syscall as in-tree module
 
 Co-authored-By: Miao Wang <shankerwangmiao@gmail.com>
 Ref: Contact the author.
@@ -32,7 +32,7 @@ Ref: Contact the author.
  create mode 100644 arch/loongarch/ow_syscall/signal.h
 
 diff --git a/arch/loongarch/Kbuild b/arch/loongarch/Kbuild
-index b01f5cdb27e03..ab27f01230fc4 100644
+index b01f5cdb27e0..ab27f01230fc 100644
 --- a/arch/loongarch/Kbuild
 +++ b/arch/loongarch/Kbuild
 @@ -5,3 +5,5 @@ obj-y += vdso/
@@ -43,7 +43,7 @@ index b01f5cdb27e03..ab27f01230fc4 100644
 +obj-y += ow_syscall/
 diff --git a/arch/loongarch/ow_syscall/Kbuild b/arch/loongarch/ow_syscall/Kbuild
 new file mode 100644
-index 0000000000000..f3921c3fd96db
+index 000000000000..f3921c3fd96d
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kbuild
 @@ -0,0 +1,26 @@
@@ -75,7 +75,7 @@ index 0000000000000..f3921c3fd96db
 +endif
 diff --git a/arch/loongarch/ow_syscall/LICENSE b/arch/loongarch/ow_syscall/LICENSE
 new file mode 100644
-index 0000000000000..d159169d10508
+index 000000000000..d159169d1050
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/LICENSE
 @@ -0,0 +1,339 @@
@@ -420,7 +420,7 @@ index 0000000000000..d159169d10508
 +Public License instead of this License.
 diff --git a/arch/loongarch/ow_syscall/Makefile b/arch/loongarch/ow_syscall/Makefile
 new file mode 100644
-index 0000000000000..e975aa1cdb7af
+index 000000000000..e975aa1cdb7a
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Makefile
 @@ -0,0 +1,37 @@
@@ -463,7 +463,7 @@ index 0000000000000..e975aa1cdb7af
 +dev: modprobe-remove dkms-remove dkms-add dkms-build dkms-install modprobe-install
 diff --git a/arch/loongarch/ow_syscall/README.md b/arch/loongarch/ow_syscall/README.md
 new file mode 100644
-index 0000000000000..24ec0eae161f1
+index 000000000000..24ec0eae161f
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/README.md
 @@ -0,0 +1,74 @@
@@ -543,7 +543,7 @@ index 0000000000000..24ec0eae161f1
 +```
 diff --git a/arch/loongarch/ow_syscall/VERSION b/arch/loongarch/ow_syscall/VERSION
 new file mode 100644
-index 0000000000000..6c6aa7cb0918d
+index 000000000000..6c6aa7cb0918
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/VERSION
 @@ -0,0 +1 @@
@@ -551,7 +551,7 @@ index 0000000000000..6c6aa7cb0918d
 \ No newline at end of file
 diff --git a/arch/loongarch/ow_syscall/dkms.conf.in b/arch/loongarch/ow_syscall/dkms.conf.in
 new file mode 100644
-index 0000000000000..b2a3493106c24
+index 000000000000..b2a3493106c2
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/dkms.conf.in
 @@ -0,0 +1,7 @@
@@ -564,7 +564,7 @@ index 0000000000000..b2a3493106c24
 +DEST_MODULE_LOCATION[0]="/extra"
 diff --git a/arch/loongarch/ow_syscall/fsstat.c b/arch/loongarch/ow_syscall/fsstat.c
 new file mode 100644
-index 0000000000000..e540d6ff2548c
+index 000000000000..e540d6ff2548
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.c
 @@ -0,0 +1,84 @@
@@ -654,7 +654,7 @@ index 0000000000000..e540d6ff2548c
 +}
 diff --git a/arch/loongarch/ow_syscall/fsstat.h b/arch/loongarch/ow_syscall/fsstat.h
 new file mode 100644
-index 0000000000000..7c970ad8fd009
+index 000000000000..7c970ad8fd00
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.h
 @@ -0,0 +1,3 @@
@@ -663,7 +663,7 @@ index 0000000000000..7c970ad8fd009
 +extern int (*p_vfs_fstat)(int fd, struct kstat *stat);
 diff --git a/arch/loongarch/ow_syscall/la_ow_syscall_main.c b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 new file mode 100644
-index 0000000000000..3308ef082539e
+index 000000000000..3308ef082539
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 @@ -0,0 +1,326 @@
@@ -995,7 +995,7 @@ index 0000000000000..3308ef082539e
 +#endif
 diff --git a/arch/loongarch/ow_syscall/signal.c b/arch/loongarch/ow_syscall/signal.c
 new file mode 100644
-index 0000000000000..1593fdba30c26
+index 000000000000..1593fdba30c2
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.c
 @@ -0,0 +1,222 @@
@@ -1223,7 +1223,7 @@ index 0000000000000..1593fdba30c26
 +#endif
 diff --git a/arch/loongarch/ow_syscall/signal.h b/arch/loongarch/ow_syscall/signal.h
 new file mode 100644
-index 0000000000000..a640b39e982d3
+index 000000000000..a640b39e982d
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.h
 @@ -0,0 +1,41 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0022-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0022-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
 From 4a91aa5671b957aa6492efc7a8220c3d73e5dc63 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 22/33] la_ow_syscall: add kconfig for module
+Subject: [PATCH 22/34] la_ow_syscall: add kconfig for module
 
 Ref: Contact the author.
 ---
@@ -11,7 +11,7 @@ Ref: Contact the author.
  create mode 100644 arch/loongarch/ow_syscall/Kconfig
 
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index 9fd8644a9a4c6..017034368ff1d 100644
+index 9fd8644a9a4c..017034368ff1 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -657,3 +657,5 @@ source "kernel/power/Kconfig"
@@ -22,7 +22,7 @@ index 9fd8644a9a4c6..017034368ff1d 100644
 +source "arch/loongarch/ow_syscall/Kconfig"
 diff --git a/arch/loongarch/ow_syscall/Kconfig b/arch/loongarch/ow_syscall/Kconfig
 new file mode 100644
-index 0000000000000..c28a37145b6f6
+index 000000000000..c28a37145b6f
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kconfig
 @@ -0,0 +1,15 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0023-drm-Makefile-Move-tiny-drivers-before-native-drivers.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0023-drm-Makefile-Move-tiny-drivers-before-native-drivers.patch
@@ -1,7 +1,7 @@
-From d12e7c9577adcc2f08f10204413e98f902d866de Mon Sep 17 00:00:00 2001
+From 877b31c5281d163944c5c17321fd3aa3648a1463 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 7 Nov 2023 20:25:53 +0800
-Subject: [PATCH 24/33] drm/Makefile: Move tiny drivers before native drivers
+Subject: [PATCH 23/34] drm/Makefile: Move tiny drivers before native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from
 device_initcall to subsys_initcall_sync") some Lenovo laptops get a blank
@@ -35,7 +35,7 @@ Ref: https://lore.kernel.org/all/20231108024613.2898921-1-chenhuacai@loongson.cn
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/Makefile b/drivers/gpu/drm/Makefile
-index 215e78e791250..bc0ce6079a17f 100644
+index 215e78e79125..bc0ce6079a17 100644
 --- a/drivers/gpu/drm/Makefile
 +++ b/drivers/gpu/drm/Makefile
 @@ -141,6 +141,7 @@ obj-y			+= arm/

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0024-loongarch-reset-use-general-efi-poweroff.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0024-loongarch-reset-use-general-efi-poweroff.patch
@@ -1,7 +1,7 @@
-From 4c1032fc40910a3fc854a2c21aff1200924d893d Mon Sep 17 00:00:00 2001
+From d7b7c873ed4d1a0364e48d323ad406bd211b5ed0 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Fri, 26 Jul 2024 17:17:53 +0800
-Subject: [PATCH 33/33] loongarch/reset: use general efi poweroff
+Subject: [PATCH 24/34] loongarch/reset: use general efi poweroff
 
 Currently efi_shutdown_init can register a general sys_off handler,
 efi_power_off, which will be called during do_kernel_power_off and shut
@@ -16,10 +16,10 @@ Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>
  2 files changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index e5e95c1506672..2645cc0d2c430 100644
+index 9fc10cea21e1..3223da046a6d 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
-@@ -71,6 +71,11 @@ void __init efi_runtime_init(void)
+@@ -68,6 +68,11 @@ void __init efi_runtime_init(void)
  
  unsigned long __initdata screen_info_table = EFI_INVALID_TABLE_ADDR;
  
@@ -32,7 +32,7 @@ index e5e95c1506672..2645cc0d2c430 100644
  {
  	struct screen_info *si;
 diff --git a/arch/loongarch/kernel/reset.c b/arch/loongarch/kernel/reset.c
-index 1ef8c63835351..9c8156798e8de 100644
+index 1ef8c6383535..9c8156798e8d 100644
 --- a/arch/loongarch/kernel/reset.c
 +++ b/arch/loongarch/kernel/reset.c
 @@ -48,9 +48,6 @@ void machine_power_off(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0025-loongarch-basic-boot-support-for-legacy-firmware.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0025-loongarch-basic-boot-support-for-legacy-firmware.patch
@@ -1,7 +1,7 @@
-From 0ed15b0ef833fd9d7587f572c7cd8598a84be52a Mon Sep 17 00:00:00 2001
+From 2f21e177e5a97f4d4ad079b46f9cd09b0b6b175f Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
-Subject: [PATCH 28/33] loongarch: basic boot support for legacy firmware
+Subject: [PATCH 25/34] loongarch: basic boot support for legacy firmware
 
 The addresses passed from legacy firmware in efi system tables, the
 initrd table, the efi system memory mapping table are virtual addresses.
@@ -23,14 +23,14 @@ With this patch, the linux kernel is basically able to boot.
 ---
  arch/loongarch/kernel/efi.c              | 18 ++++++++++++++++++
  arch/loongarch/kernel/mem.c              |  1 +
- drivers/firmware/efi/libstub/loongarch.c | 20 ++++++++++++++++++++
- 3 files changed, 39 insertions(+)
+ drivers/firmware/efi/libstub/loongarch.c | 18 ++++++++++++++++++
+ 3 files changed, 37 insertions(+)
 
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index 9fc10cea21e10..201db70ac995f 100644
+index 3223da046a6d..ad01784699fb 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
-@@ -87,6 +87,23 @@ static void __init init_screen_info(void)
+@@ -92,6 +92,23 @@ static void __init init_screen_info(void)
  	memblock_reserve(screen_info.lfb_base, screen_info.lfb_size);
  }
  
@@ -54,7 +54,7 @@ index 9fc10cea21e10..201db70ac995f 100644
  void __init efi_init(void)
  {
  	int size;
-@@ -110,6 +127,7 @@ void __init efi_init(void)
+@@ -115,6 +132,7 @@ void __init efi_init(void)
  
  	size = sizeof(efi_config_table_t);
  	config_tables = early_memremap(efi_config_table, efi_nr_tables * size);
@@ -63,7 +63,7 @@ index 9fc10cea21e10..201db70ac995f 100644
  	early_memunmap(config_tables, efi_nr_tables * size);
  
 diff --git a/arch/loongarch/kernel/mem.c b/arch/loongarch/kernel/mem.c
-index aed901c57fb43..86d37a447eec1 100644
+index aed901c57fb4..86d37a447eec 100644
 --- a/arch/loongarch/kernel/mem.c
 +++ b/arch/loongarch/kernel/mem.c
 @@ -19,6 +19,7 @@ void __init memblock_init(void)
@@ -75,7 +75,7 @@ index aed901c57fb43..86d37a447eec1 100644
  		mem_size = md->num_pages << EFI_PAGE_SHIFT;
  		mem_end = mem_start + mem_size;
 diff --git a/drivers/firmware/efi/libstub/loongarch.c b/drivers/firmware/efi/libstub/loongarch.c
-index d0ef93551c44f..bd2e20c0cf423 100644
+index d0ef93551c44..e0ae9c8550c3 100644
 --- a/drivers/firmware/efi/libstub/loongarch.c
 +++ b/drivers/firmware/efi/libstub/loongarch.c
 @@ -23,6 +23,8 @@ struct exit_boot_struct {
@@ -87,17 +87,7 @@ index d0ef93551c44f..bd2e20c0cf423 100644
  static efi_status_t exit_boot_func(struct efi_boot_memmap *map, void *priv)
  {
  	struct exit_boot_struct *p = priv;
-@@ -35,9 +37,25 @@ static efi_status_t exit_boot_func(struct efi_boot_memmap *map, void *priv)
- 	efi_get_virtmap(map->map, map->map_size, map->desc_size,
- 			p->runtime_map, &p->runtime_entry_count);
- 
-+	if (is_oldworld) {
-+		for(int l = 0; l < p->runtime_entry_count * map->desc_size; l += map->desc_size) {
-+			efi_memory_desc_t *entry = (void *)(p->runtime_map) + l;
-+			entry->virt_addr = TO_CACHE(entry->virt_addr);
-+		}
-+	}
-+
+@@ -38,6 +40,15 @@ static efi_status_t exit_boot_func(struct efi_boot_memmap *map, void *priv)
  	return EFI_SUCCESS;
  }
  
@@ -113,7 +103,7 @@ index d0ef93551c44f..bd2e20c0cf423 100644
  unsigned long __weak kernel_entry_address(unsigned long kernel_addr,
  		efi_loaded_image_t *image)
  {
-@@ -53,6 +71,8 @@ efi_status_t efi_boot_kernel(void *handle, efi_loaded_image_t *image,
+@@ -53,6 +64,8 @@ efi_status_t efi_boot_kernel(void *handle, efi_loaded_image_t *image,
  	efi_status_t status;
  	u32 desc_ver;
  
@@ -122,6 +112,23 @@ index d0ef93551c44f..bd2e20c0cf423 100644
  	status = efi_alloc_virtmap(&priv.runtime_map, &desc_size, &desc_ver);
  	if (status != EFI_SUCCESS) {
  		efi_err("Unable to retrieve UEFI memory map.\n");
+@@ -66,11 +79,16 @@ efi_status_t efi_boot_kernel(void *handle, efi_loaded_image_t *image,
+ 	if (status != EFI_SUCCESS)
+ 		return status;
+ 
++	if (is_oldworld) {
++		goto skip_set_virtual_address_map;
++	}
++
+ 	/* Install the new virtual address map */
+ 	efi_rt_call(set_virtual_address_map,
+ 		    priv.runtime_entry_count * desc_size, desc_size,
+ 		    desc_ver, priv.runtime_map);
+ 
++skip_set_virtual_address_map:
+ 	/* Config Direct Mapping */
+ 	csr_write64(CSR_DMW0_INIT, LOONGARCH_CSR_DMWIN0);
+ 	csr_write64(CSR_DMW1_INIT, LOONGARCH_CSR_DMWIN1);
 -- 
 2.46.0
 

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0026-loongarch-parse-BPI-data-and-add-memory-mapping.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0026-loongarch-parse-BPI-data-and-add-memory-mapping.patch
@@ -1,7 +1,7 @@
-From a56e0529a19dae966225acc846e0180e55654248 Mon Sep 17 00:00:00 2001
+From c8a0b5f21fc9a63aacfd18e1f8c50a0656b953a2 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
-Subject: [PATCH 29/33] loongarch: parse BPI data and add memory mapping
+Subject: [PATCH 26/34] loongarch: parse BPI data and add memory mapping
 
 On legacy firmwares, the memory mapping information passed in the EFI
 system table is not enough to cover all the available memory regions,
@@ -31,7 +31,7 @@ BPI01001, i.e. the newer version, can boot normally.
  create mode 100644 arch/loongarch/kernel/legacy_boot.h
 
 diff --git a/arch/loongarch/kernel/Makefile b/arch/loongarch/kernel/Makefile
-index 4fcc168f07323..2b4bfdefe623a 100644
+index 4fcc168f0732..2b4bfdefe623 100644
 --- a/arch/loongarch/kernel/Makefile
 +++ b/arch/loongarch/kernel/Makefile
 @@ -74,3 +74,5 @@ obj-$(CONFIG_UPROBES)		+= uprobes.o
@@ -41,7 +41,7 @@ index 4fcc168f07323..2b4bfdefe623a 100644
 +
 +obj-y				+= legacy_boot.o
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index 201db70ac995f..e5e95c1506672 100644
+index ad01784699fb..2645cc0d2c43 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
 @@ -25,6 +25,8 @@
@@ -63,7 +63,7 @@ index 201db70ac995f..e5e95c1506672 100644
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
 new file mode 100644
-index 0000000000000..30c01c8b22a0a
+index 000000000000..30c01c8b22a0
 --- /dev/null
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -0,0 +1,297 @@
@@ -366,7 +366,7 @@ index 0000000000000..30c01c8b22a0a
 +}
 diff --git a/arch/loongarch/kernel/legacy_boot.h b/arch/loongarch/kernel/legacy_boot.h
 new file mode 100644
-index 0000000000000..6d3a36ebaab71
+index 000000000000..6d3a36ebaab7
 --- /dev/null
 +++ b/arch/loongarch/kernel/legacy_boot.h
 @@ -0,0 +1,18 @@
@@ -389,7 +389,7 @@ index 0000000000000..6d3a36ebaab71
 +
 +#endif /* __LEGACY_BOOT_H_ */
 diff --git a/arch/loongarch/kernel/mem.c b/arch/loongarch/kernel/mem.c
-index 86d37a447eec1..b24b3db96018d 100644
+index 86d37a447eec..b24b3db96018 100644
 --- a/arch/loongarch/kernel/mem.c
 +++ b/arch/loongarch/kernel/mem.c
 @@ -10,6 +10,8 @@
@@ -411,7 +411,7 @@ index 86d37a447eec1..b24b3db96018d 100644
  
  	/* Reserve the first 2MB */
 diff --git a/arch/loongarch/kernel/numa.c b/arch/loongarch/kernel/numa.c
-index 6e65ff12d5c7d..618c2d70079cb 100644
+index 6e65ff12d5c7..618c2d70079c 100644
 --- a/arch/loongarch/kernel/numa.c
 +++ b/arch/loongarch/kernel/numa.c
 @@ -26,6 +26,8 @@
@@ -432,7 +432,7 @@ index 6e65ff12d5c7d..618c2d70079cb 100644
  		return -EINVAL;
  
 diff --git a/arch/loongarch/kernel/setup.c b/arch/loongarch/kernel/setup.c
-index 6748d7f3f2219..7c03b11b3b315 100644
+index 6748d7f3f221..7c03b11b3b31 100644
 --- a/arch/loongarch/kernel/setup.c
 +++ b/arch/loongarch/kernel/setup.c
 @@ -49,6 +49,8 @@
@@ -453,7 +453,7 @@ index 6748d7f3f2219..7c03b11b3b315 100644
  	pagetable_init();
  	bootcmdline_init(cmdline_p);
 diff --git a/arch/loongarch/kernel/smp.c b/arch/loongarch/kernel/smp.c
-index d74dfe1206ed0..1414f308ec62e 100644
+index d74dfe1206ed..1414f308ec62 100644
 --- a/arch/loongarch/kernel/smp.c
 +++ b/arch/loongarch/kernel/smp.c
 @@ -33,6 +33,8 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0027-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0027-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,7 +1,7 @@
-From 49021ace582e44ab596e990f7e3c135448383ffa Mon Sep 17 00:00:00 2001
+From 32866234b3f5b00c25e7544f2c1ab3ee681faeb0 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
-Subject: [PATCH 30/33] loongarch: add MADT ACPI table conversion
+Subject: [PATCH 27/34] loongarch: add MADT ACPI table conversion
 
 On machines with legacy firmware with BPI version BPI01000, i.e. the
 older version, the content of the MADT ACPI table is not following the
@@ -18,7 +18,7 @@ is detected.
  4 files changed, 318 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index 49e29b29996f0..473d86523b036 100644
+index 49e29b29996f..473d86523b03 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -44,6 +44,11 @@ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
@@ -34,7 +34,7 @@ index 49e29b29996f0..473d86523b036 100644
  
  #define ACPI_TABLE_UPGRADE_MAX_PHYS ARCH_LOW_ADDRESS_LIMIT
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 30c01c8b22a0a..367f9ee7e315e 100644
+index 30c01c8b22a0..367f9ee7e315 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -1,7 +1,13 @@
@@ -375,7 +375,7 @@ index 30c01c8b22a0a..367f9ee7e315e 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/tables.c b/drivers/acpi/tables.c
-index 8ab0a82b4da41..2c152edb9022a 100644
+index 8ab0a82b4da4..2c152edb9022 100644
 --- a/drivers/acpi/tables.c
 +++ b/drivers/acpi/tables.c
 @@ -851,6 +851,7 @@ acpi_status acpi_os_table_override(struct acpi_table_header *existing_table,
@@ -395,7 +395,7 @@ index 8ab0a82b4da41..2c152edb9022a 100644
  
  int __init acpi_table_init(void)
 diff --git a/include/linux/acpi.h b/include/linux/acpi.h
-index 1b76d2f83eac6..627834d8654d7 100644
+index 1b76d2f83eac..627834d8654d 100644
 --- a/include/linux/acpi.h
 +++ b/include/linux/acpi.h
 @@ -762,6 +762,16 @@ static inline u64 acpi_arch_get_root_pointer(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0028-loongarch-correct-missing-offset-of-PCI-root-control.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0028-loongarch-correct-missing-offset-of-PCI-root-control.patch
@@ -1,7 +1,7 @@
-From f45d13e1aecb72ba7bba9862d0c71756af05cbe8 Mon Sep 17 00:00:00 2001
+From ff8dc6c094d68cbce7e6edc2be5fcfa56263ab85 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
-Subject: [PATCH 31/33] loongarch: correct missing offset of PCI root
+Subject: [PATCH 28/34] loongarch: correct missing offset of PCI root
  controller in DSDT table
 
 On machines with legacy firmware with BPI version BPI01000, the PCI root
@@ -14,6 +14,10 @@ This patch also fixes the lack of the leading 16K, i.e. ISA_IOSIZE, in
 the defination of WordIO resource. This is because that address range is
 registered unconditionally on the legacy loongarch linux port.
 
+This patch also fixes the start addresses or end addresses of WordIO
+resource not aligned to the page size by rouding the addresses up to the
+nearest page starting.
+
 The above behavior is only enabled when BPI data and the BPI01000 version
 is detected.
 ---
@@ -24,7 +28,7 @@ is detected.
  4 files changed, 29 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index 473d86523b036..ecf05448fe9da 100644
+index 473d86523b03..ecf05448fe9d 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -48,6 +48,8 @@ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
@@ -37,7 +41,7 @@ index 473d86523b036..ecf05448fe9da 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 367f9ee7e315e..f1e50ef4c429c 100644
+index 367f9ee7e315..f5a90d1bad3d 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -60,7 +60,7 @@ struct loongarch_bpi_info __initdata loongarch_bpi_info = {
@@ -64,12 +68,12 @@ index 367f9ee7e315e..f1e50ef4c429c 100644
 +
 +	if (entry->res->flags & IORESOURCE_IO) {
 +		if (entry->offset == 0) {
-+			if (entry->res->start > 0) {
++			if (entry->res->start == ISA_IOSIZE) {
 +				entry->res->start = 0;
 +			}
 +			entry->offset = LOONGSON_LIO_BASE;
-+			entry->res->start += LOONGSON_LIO_BASE;
-+			entry->res->end += LOONGSON_LIO_BASE;
++			entry->res->start = LOONGSON_LIO_BASE + PFN_ALIGN(entry->res->start);
++			entry->res->end = LOONGSON_LIO_BASE + PFN_ALIGN(entry->res->end + 1) - 1;
 +		}
 +	}
 +}
@@ -78,7 +82,7 @@ index 367f9ee7e315e..f1e50ef4c429c 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/pci_root.c b/drivers/acpi/pci_root.c
-index 84030804a7633..18e7784086cc0 100644
+index 84030804a763..18e7784086cc 100644
 --- a/drivers/acpi/pci_root.c
 +++ b/drivers/acpi/pci_root.c
 @@ -914,6 +914,7 @@ int acpi_pci_probe_root_resources(struct acpi_pci_root_info *info)
@@ -90,7 +94,7 @@ index 84030804a7633..18e7784086cc0 100644
  				acpi_pci_root_remap_iospace(&device->fwnode,
  						entry);
 diff --git a/include/linux/pci-acpi.h b/include/linux/pci-acpi.h
-index 078225b514d48..1c22ca4ec794c 100644
+index 078225b514d4..1c22ca4ec794 100644
 --- a/include/linux/pci-acpi.h
 +++ b/include/linux/pci-acpi.h
 @@ -133,6 +133,10 @@ static inline void pci_acpi_remove_edr_notifier(struct pci_dev *pdev) { }

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0029-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0029-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,7 +1,7 @@
-From c02e962b3c334897ded2c133c5e5b99242ef1ccb Mon Sep 17 00:00:00 2001
+From 8e196ff4979b079f2a417ac649e02591b9565da0 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
-Subject: [PATCH 32/33] loongarch: fix missing dependency info in DSDT
+Subject: [PATCH 29/34] loongarch: fix missing dependency info in DSDT
 
 On machines with legacy firmware with BPI01000 version, the devices on
 the LIO bus lackes the dependency on the PCI root controller, causing
@@ -27,7 +27,7 @@ is detected.
  4 files changed, 54 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index ecf05448fe9da..915cb0a2c2393 100644
+index ecf05448fe9d..915cb0a2c239 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -50,6 +50,8 @@ extern void acpi_arch_os_table_override (struct acpi_table_header *existing_tabl
@@ -40,7 +40,7 @@ index ecf05448fe9da..915cb0a2c2393 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index f1e50ef4c429c..434bab8f98cdd 100644
+index f5a90d1bad3d..48c13e1ad220 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -614,6 +614,53 @@ void acpi_arch_pci_probe_root_dev_filter(struct resource_entry *entry)
@@ -98,7 +98,7 @@ index f1e50ef4c429c..434bab8f98cdd 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/bus.c b/drivers/acpi/bus.c
-index a4aa53b7e2bb3..9757976700ce9 100644
+index a4aa53b7e2bb..9757976700ce 100644
 --- a/drivers/acpi/bus.c
 +++ b/drivers/acpi/bus.c
 @@ -1414,6 +1414,7 @@ static int __init acpi_init(void)
@@ -110,7 +110,7 @@ index a4aa53b7e2bb3..9757976700ce9 100644
  	acpi_ec_init();
  	acpi_debugfs_init();
 diff --git a/include/linux/acpi.h b/include/linux/acpi.h
-index 627834d8654d7..30f9bc8f317d8 100644
+index 627834d8654d..30f9bc8f317d 100644
 --- a/include/linux/acpi.h
 +++ b/include/linux/acpi.h
 @@ -1534,6 +1534,10 @@ void acpi_arm_init(void);

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0030-irqchip-loongarch-cpu-Fix-return-value-of-lpic_gsi_t.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0030-irqchip-loongarch-cpu-Fix-return-value-of-lpic_gsi_t.patch
@@ -1,0 +1,40 @@
+From 4094b16b2637544832c72f2c721f9d2a96006887 Mon Sep 17 00:00:00 2001
+From: Huacai Chen <chenhuacai@loongson.cn>
+Date: Tue, 23 Jul 2024 14:45:08 +0800
+Subject: [PATCH 30/34] irqchip/loongarch-cpu: Fix return value of
+ lpic_gsi_to_irq()
+
+lpic_gsi_to_irq() should return a valid irq if acpi_register_gsi()
+succeed, and return 0 otherwise. But now lpic_gsi_to_irq() converts
+a negative return value of acpi_register_gsi() to a positive value
+silently, so fix it.
+
+Reported-by: Miao Wang <shankerwangmiao@gmail.com>
+Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
+---
+ drivers/irqchip/irq-loongarch-cpu.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/irqchip/irq-loongarch-cpu.c b/drivers/irqchip/irq-loongarch-cpu.c
+index 9d8f2c406043..b35903a06902 100644
+--- a/drivers/irqchip/irq-loongarch-cpu.c
++++ b/drivers/irqchip/irq-loongarch-cpu.c
+@@ -18,11 +18,13 @@ struct fwnode_handle *cpuintc_handle;
+ 
+ static u32 lpic_gsi_to_irq(u32 gsi)
+ {
++	int irq = 0;
++
+ 	/* Only pch irqdomain transferring is required for LoongArch. */
+ 	if (gsi >= GSI_MIN_PCH_IRQ && gsi <= GSI_MAX_PCH_IRQ)
+-		return acpi_register_gsi(NULL, gsi, ACPI_LEVEL_SENSITIVE, ACPI_ACTIVE_HIGH);
++		irq = acpi_register_gsi(NULL, gsi, ACPI_LEVEL_SENSITIVE, ACPI_ACTIVE_HIGH);
+ 
+-	return 0;
++	return (irq > 0) ? irq : 0;
+ }
+ 
+ static struct fwnode_handle *lpic_get_gsi_domain_id(u32 gsi)
+-- 
+2.46.0
+

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0031-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0031-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
@@ -1,7 +1,7 @@
-From 41d0b8f1edbdfe22aff2eadb6c59365b0cc6e9b9 Mon Sep 17 00:00:00 2001
+From 09ed774fbb55fa46aaa3dc740e03391a49fb9978 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
-Subject: [PATCH 23/33] [LOONGARCH64] drivers/firmware: Move sysfb_init() from
+Subject: [PATCH 31/34] [LOONGARCH64] drivers/firmware: Move sysfb_init() from
  device_initcall to fs_initcall
 
 Consider a configuration like this:
@@ -42,7 +42,7 @@ Ref: Contact the author.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/firmware/sysfb.c b/drivers/firmware/sysfb.c
-index 3c197db42c9d9..1238a38409e23 100644
+index 3c197db42c9d..1238a38409e2 100644
 --- a/drivers/firmware/sysfb.c
 +++ b/drivers/firmware/sysfb.c
 @@ -128,4 +128,4 @@ static __init int sysfb_init(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0032-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0032-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
@@ -1,7 +1,7 @@
-From 2e9d2c26b1ec9f2b0ca179218932806430e75316 Mon Sep 17 00:00:00 2001
+From 74b085d7e0f49335f1608dc1c3ede57969e443d9 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 25/33] [LOONGARCH64] drm/radeon: Workaround radeon driver bug
+Subject: [PATCH 32/34] [LOONGARCH64] drm/radeon: Workaround radeon driver bug
  for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so
@@ -19,7 +19,7 @@ Ref: https://github.com/chenhuacai/linux/commit/ce7f7dd7740ca07d97c861ca55e9dfc4
  4 files changed, 4 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index 10be30366c2bf..62cc8a598f06e 100644
+index 10be30366c2b..62cc8a598f06 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -8093,6 +8093,7 @@ int cik_irq_process(struct radeon_device *rdev)
@@ -31,7 +31,7 @@ index 10be30366c2bf..62cc8a598f06e 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index f0ae087be914e..0dc5db59e95bf 100644
+index f0ae087be914..0dc5db59e95b 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -4922,6 +4922,7 @@ int evergreen_irq_process(struct radeon_device *rdev)
@@ -43,7 +43,7 @@ index f0ae087be914e..0dc5db59e95bf 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/r600.c b/drivers/gpu/drm/radeon/r600.c
-index a17b95eec65fb..664b10b58c0f2 100644
+index a17b95eec65f..664b10b58c0f 100644
 --- a/drivers/gpu/drm/radeon/r600.c
 +++ b/drivers/gpu/drm/radeon/r600.c
 @@ -4328,6 +4328,7 @@ int r600_irq_process(struct radeon_device *rdev)
@@ -55,7 +55,7 @@ index a17b95eec65fb..664b10b58c0f2 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/si.c b/drivers/gpu/drm/radeon/si.c
-index 85e9cba49cecb..95cb2b4afb48c 100644
+index 85e9cba49cec..95cb2b4afb48 100644
 --- a/drivers/gpu/drm/radeon/si.c
 +++ b/drivers/gpu/drm/radeon/si.c
 @@ -6442,6 +6442,7 @@ int si_irq_process(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0033-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0033-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
@@ -1,7 +1,7 @@
-From 4852af6472fd3a46eeb29ba2df6ba0967a6561ae Mon Sep 17 00:00:00 2001
+From 340ca110ad4c35c9bd75bf5f6d9ec2fea1ff9df8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 14:28:02 +0800
-Subject: [PATCH 26/33] [LOONGARCH64] drm/radeon: Call mmiowb() at the end of
+Subject: [PATCH 33/34] [LOONGARCH64] drm/radeon: Call mmiowb() at the end of
  radeon_ring_commit()
 
 Commit fb24ea52f78e0d595852e ("drivers: Remove explicit invocations of
@@ -49,7 +49,7 @@ Ref: https://lore.kernel.org/all/20240220074958.3288170-1-chenhuacai@loongson.cn
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_ring.c b/drivers/gpu/drm/radeon/radeon_ring.c
-index e6534fa9f1fb5..2f755213486fb 100644
+index e6534fa9f1fb..2f755213486f 100644
 --- a/drivers/gpu/drm/radeon/radeon_ring.c
 +++ b/drivers/gpu/drm/radeon/radeon_ring.c
 @@ -183,6 +183,7 @@ void radeon_ring_commit(struct radeon_device *rdev, struct radeon_ring *ring,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0034-LOONGARCH64-HACK-drm-amdgpu-disable-DPM-in-auto-mode.patch.loongarch64
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0034-LOONGARCH64-HACK-drm-amdgpu-disable-DPM-in-auto-mode.patch.loongarch64
@@ -1,7 +1,7 @@
-From f9c84d68e018add1e65f8be1b65161cf6da4f1b0 Mon Sep 17 00:00:00 2001
+From 275f5c1176199bbd5ba5578dd20c30c4c767289c Mon Sep 17 00:00:00 2001
 From: Cyan <cyanoxygen@aosc.io>
 Date: Wed, 10 Apr 2024 16:44:01 +0800
-Subject: [PATCH 27/33] [LOONGARCH64] HACK(drm/amdgpu): disable DPM in auto
+Subject: [PATCH 34/34] [LOONGARCH64] HACK(drm/amdgpu): disable DPM in auto
  mode for Polaris
 
 Ref: Contact the author.
@@ -10,7 +10,7 @@ Ref: Contact the author.
  1 file changed, 16 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index f9bc38d20ce3e..55db2e87837f7 100644
+index f9bc38d20ce3..55db2e87837f 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -2124,7 +2124,22 @@ static int amdgpu_pci_probe(struct pci_dev *pdev,

--- a/runtime-kernel/linux-kernel-lts/spec
+++ b/runtime-kernel/linux-kernel-lts/spec
@@ -1,5 +1,5 @@
 VER=6.6.44
-REL=1
+REL=2
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v${VER:0:1}.x/linux-${VER/.0/}.tar.xz"
 CHKSUMS="sha256::93218296934915636fe6ba08e125948424cc270fd8948502c0ab91087a9fccd8"
 CHKUPDATE="anitya::id=6501"


### PR DESCRIPTION
Topic Description
-----------------

- linux-kernel-lts: (loongarch64) improve old-world support on multiprocessor systems

Package(s) Affected
-------------------

- linux-kernel-lts-6.6.44: 6.6.44-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel-lts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
