### PR TITLE
dpdk: use SRCS and CHKSUMS

### DIFF
--- a/runtime-network/dpdk/spec
+++ b/runtime-network/dpdk/spec
@@ -1,5 +1,5 @@
 VER=22.11.1
-SRCTBL="http://fast.dpdk.org/rel/dpdk-${VER}.tar.xz"
-CHKSUM="sha256::de076465f7174a0d52714b9072e4837a726baac82d8fe7dc644cad5c8cf74d4c"
+SRCS="tbl::http://fast.dpdk.org/rel/dpdk-${VER}.tar.xz"
+CHKSUMS="sha256::de076465f7174a0d52714b9072e4837a726baac82d8fe7dc644cad5c8cf74d4c"
 CHKUPDATE="anitya::id=459"
 REL=1


### PR DESCRIPTION
Topic Description
-----------------

- dpdk: use `SRCS` and `CHKSUMS`

Package(s) Affected
-------------------

- dpdk: 22.11.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dpdk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
