### PR TITLE
nautilus-python: use SRCS and CHKSUMS

### DIFF
--- a/desktop-gnome/nautilus-python/spec
+++ b/desktop-gnome/nautilus-python/spec
@@ -1,5 +1,5 @@
 VER=1.2.3
 REL=3
-SRCTBL=https://download.gnome.org/sources/nautilus-python/${VER:0:3}/nautilus-python-${VER}.tar.xz
-CHKSUM="sha256::073ce0297282259937ab473d189b97a04f42b97197c9292fc3bde9d135282098"
+SRCS="tbl::https://download.gnome.org/sources/nautilus-python/${VER:0:3}/nautilus-python-${VER}.tar.xz"
+CHKSUMS="sha256::073ce0297282259937ab473d189b97a04f42b97197c9292fc3bde9d135282098"
 CHKUPDATE="anitya::id=228583"


### PR DESCRIPTION
Topic Description
-----------------

- nautilus-python: use `SRCS` and `CHKSUMS`
- dpdk: use `SRCS` and `CHKSUMS`

Package(s) Affected
-------------------

- nautilus-python: 1.2.3-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit nautilus-python
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
