### PR TITLE
gmetadom: drop again

### DIFF
--- a/desktop-gnome/gmetadom/spec
+++ b/desktop-gnome/gmetadom/spec
@@ -1,5 +1,0 @@
-VER=0.2.6
-REL=7
-SRCS="tbl::https://downloads.sourceforge.net/sourceforge/gmetadom/gmetadom-$VER.tar.gz"
-CHKSUMS="sha256::2f1e286dfceb7877f90c72de7e5e17a87d0e3f8121feff794a6f637bc1a6756a"
-CHKUPDATE="anitya::id=229513"


### PR DESCRIPTION
Topic Description
-----------------

- gmetadom: drop again
- dpdk: use `SRCS` and `CHKSUMS`

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
