### PR TITLE
os-prober: properly map autobuild4 arch to os-prober arch

### DIFF
--- a/app-utils/os-prober/autobuild/build
+++ b/app-utils/os-prober/autobuild/build
@@ -14,10 +14,16 @@ install -Dvm755 "$SRCDIR"/newns \
 install -Dvm755 "$SRCDIR"/common.sh \
     "$PKGDIR"/usr/share/os-prober/common.sh
 
-# Note: Our LoongArch port uses "loongarch64" as the architecture name whereas
-# Debian uses loong64, we perform a simple translation here.
+# Note: We name our architectures differently from os-prober as shown below.
 if ab_match_arch loongarch64; then
     export PROBES_ARCH="loong64"
+elif ab_match_arch amd64 || \
+     ab_match_arch i486; then
+    export PROBES_ARCH="x86"
+elif ab_match_arch powerpc || \
+     ab_match_arch ppc64 || \
+     ab_match_arch ppc64el; then
+    export PROBES_ARCH="powerpc"
 else
     export PROBES_ARCH="$ARCH"
 fi

--- a/app-utils/os-prober/spec
+++ b/app-utils/os-prober/spec
@@ -1,5 +1,5 @@
 VER=1.81
-REL=1
+REL=2
 SRCS="tbl::http://http.debian.net/debian/pool/main/o/os-prober/os-prober_$VER.tar.xz"
 CHKSUMS="sha256::2fd928ec86538227711e2adf49cfd6a1ef74f6bb3555c5dad4e0425ccd978883"
 CHKUPDATE="anitya::id=2574"


### PR DESCRIPTION
Topic Description
-----------------

- os-prober: properly map autobuild4 arch to os-prober arch
- gmetadom: drop again
- nautilus-python: use `SRCS` and `CHKSUMS`
- dpdk: use `SRCS` and `CHKSUMS`

Package(s) Affected
-------------------

- os-prober: 1.81-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit os-prober
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
