### PR TITLE
chromium: explicitly disable LASX to fix SIGILL

### DIFF
--- a/app-web/chromium/autobuild/prepare
+++ b/app-web/chromium/autobuild/prepare
@@ -57,5 +57,11 @@ export CFLAGS="${CFLAGS/\-flto/}"
 export CXXFLAGS="${CXXFLAGS/\-flto/}"
 export LDFLAGS="${LDFLAGS/\-flto/}"
 
+if ab_match_arch loongarch64; then
+    abinfo 'Disabling generation of 256-bit LoongArch Advanced SIMD Extension (LASX) instructions …'
+    export CFLAGS="${CFLAGS} -mno-lasx"
+    export CXXFLAGS="${CXXFLAGS} -mno-lasx"
+fi
+
 abinfo "Chromium passes -Z to rustc, allow them on stable rustc ..."
 export RUSTC_BOOTSTRAP=1


### PR DESCRIPTION
Topic Description
-----------------

- chromium: explicitly disable LASX to fix SIGILL
- chromium: add notes about LLVM OOM errors
- chromium: do not disable ThinLTO
- chromium: build with bundled libc++
- chromium: remove OAuth 2.0 client ID and client secret
    It's already broken since six years ago, and removing it fixes the blank screen of First Run Experience.
    https://www.chromium.org/developers/how-tos/api-keys/#signing-in-to-chromium-is-restricted
- chromium: update to 127.0.6533.99
    - Use Last Known Good build configurations.
    - Track patches at https://dev.azure.com/AOSC-Tracking/_git/chromium @ aosc/v127.0.6533.99.
- chromium: bump REL for topic Revision Marking Guidelines
- libyuv: bump REL for topic Revision Marking Guidelines
- chromium: try to fix build fails
- chromium: enable thin LTO

... and 9 more commits

Package(s) Affected
-------------------

- libyuv: 0+git20240215-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libyuv chromium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
