### PR TITLE
systemd: disable systemd-resolved in the default preset

### DIFF
--- a/app-admin/systemd/autobuild/patches/0001-sleep.conf-AllowHibernation-no-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0001-sleep.conf-AllowHibernation-no-by-default.patch
@@ -22,5 +22,5 @@ index 98430348a7..41534e6c15 100644
  #AllowHybridSleep=yes
  #SuspendState=mem standby freeze
 -- 
-2.45.2
+2.46.0
 

--- a/app-admin/systemd/autobuild/patches/0002-presets-disable-systemd-networkd-systemd-networkd-wa.patch
+++ b/app-admin/systemd/autobuild/patches/0002-presets-disable-systemd-networkd-systemd-networkd-wa.patch
@@ -1,19 +1,19 @@
-From 81d7c36800b5bd4c875352a9af84acb7b8d6fcc9 Mon Sep 17 00:00:00 2001
+From 4bc1c27e4ced946439da303a99978bd33449affa Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 19 Jul 2024 18:38:48 -0700
-Subject: [PATCH 2/3] presets: disable systemd-networkd and
- systemd-networkd-wait-online by default
+Subject: [PATCH 2/3] presets: disable systemd-networkd,
+ systemd-networkd-wait-online and systemd-resolved by default
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
- presets/90-systemd.preset | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ presets/90-systemd.preset | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/presets/90-systemd.preset b/presets/90-systemd.preset
-index da6b9805fd..dcbcd56a7f 100644
+index da6b9805fd..3042d7e73a 100644
 --- a/presets/90-systemd.preset
 +++ b/presets/90-systemd.preset
-@@ -24,8 +24,8 @@ enable systemd-homed-activate.service
+@@ -24,11 +24,11 @@ enable systemd-homed-activate.service
  enable systemd-journald-audit.socket
  enable systemd-mountfsd.socket
  enable systemd-network-generator.service
@@ -23,7 +23,11 @@ index da6b9805fd..dcbcd56a7f 100644
 +disable systemd-networkd-wait-online.service
  enable systemd-nsresourced.socket
  enable systemd-pstore.service
- enable systemd-resolved.service
+-enable systemd-resolved.service
++disable systemd-resolved.service
+ enable systemd-sysext.service
+ enable systemd-timesyncd.service
+ enable systemd-userdbd.socket
 -- 
-2.45.2
+2.46.0
 

--- a/app-admin/systemd/autobuild/patches/0003-main.c-revert-part-of-systemd-systemd-31442.patch
+++ b/app-admin/systemd/autobuild/patches/0003-main.c-revert-part-of-systemd-systemd-31442.patch
@@ -1,4 +1,4 @@
-From a931fd3d5ec741de7c672aa194fc262130d0218d Mon Sep 17 00:00:00 2001
+From 3c6f1921720d28bf33fd18d729f6e0b76066ce9d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 27 Jul 2024 14:43:07 +0800
 Subject: [PATCH 3/3] main.c: revert part of systemd/systemd#31442
@@ -24,5 +24,5 @@ index 4b8a315d86..830cd4a801 100644
                  }
  
 -- 
-2.45.2
+2.46.0
 

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,4 +1,5 @@
 VER=256.4
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205088"


### PR DESCRIPTION
Topic Description
-----------------

- systemd: disable systemd-resolved in the default preset
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- systemd: 1:256.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
