### PR TITLE
tuned: update to 2.24.1

### DIFF
--- a/app-admin/tuned/autobuild/beyond
+++ b/app-admin/tuned/autobuild/beyond
@@ -22,5 +22,5 @@ for i in \
     spectrumscale-ece; do
     abinfo "Dropping RHEL- and cloud-specific (and unsupported) profile: $i ..."
     rm -rv \
-        "$PKGDIR"/usr/lib/tuned/$i
+        "$PKGDIR"/usr/lib/tuned/profiles/$i
 done

--- a/app-admin/tuned/spec
+++ b/app-admin/tuned/spec
@@ -1,4 +1,4 @@
-VER=2.24.0
-SRCS="tbl::https://github.com/redhat-performance/tuned/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::0f4a72c89772deb8a4e572df70ee3967ba33c1351096a6e87d67674f72830e0e"
+VER=2.24.1
+SRCS="git::commit=tags/v$VER::https://github.com/redhat-performance/tuned.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11277"

--- a/app-admin/tuned/spec
+++ b/app-admin/tuned/spec
@@ -1,4 +1,4 @@
-VER=2.19.0
+VER=2.24.0
 SRCS="tbl::https://github.com/redhat-performance/tuned/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::3cb2aeb9ecebd66a1a1c3aaff9589f5c5402201d16f7caa01acf0b9374ed8724"
+CHKSUMS="sha256::0f4a72c89772deb8a4e572df70ee3967ba33c1351096a6e87d67674f72830e0e"
 CHKUPDATE="anitya::id=11277"


### PR DESCRIPTION
Topic Description
-----------------

- tuned: update to 2.24.1, use Git source
- tuned: update to 2.24.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>
    Co-authored-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- tuned: 2.24.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tuned
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
