### PR TITLE
gcc+w64: update to 14.2.0

### DIFF
--- a/runtime-optenvw64/binutils+w64/spec
+++ b/runtime-optenvw64/binutils+w64/spec
@@ -1,4 +1,4 @@
-VER=2.42
+VER=2.43
 SRCS="git::commit=binutils-${VER/./_}::https://sourceware.org/git/binutils-gdb.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7981"

--- a/runtime-optenvw64/gcc+w64/autobuild/build
+++ b/runtime-optenvw64/gcc+w64/autobuild/build
@@ -15,7 +15,7 @@ for _target in ${_targets}; do
     fi
     $SRCDIR/configure --prefix=/opt/w64 --libexecdir=/opt/w64/lib \
                       --target=${_target} \
-                      --enable-languages=c,lto,c++,fortran \
+                      --enable-languages=c,c++,lto,fortran \
                       --enable-shared --enable-static \
                       --enable-threads=posix --enable-fully-dynamic-string \
                       --enable-libstdcxx-time=yes \
@@ -26,7 +26,8 @@ for _target in ${_targets}; do
                       --with-libiconv \
                       --enable-libatomic ${EXTRA_OPTS} \
                       --enable-lto --enable-libgomp \
-                      --disable-multilib --enable-checking=release
+                      --disable-multilib --enable-checking=release \
+                      --enable-year2038 --enable-nls
     make all AS_FOR_TARGET="${_target}-as" \
              LD_FOR_TARGET="${_target}-ld"
     make install DESTDIR=$PKGDIR

--- a/runtime-optenvw64/gcc+w64/spec
+++ b/runtime-optenvw64/gcc+w64/spec
@@ -1,4 +1,4 @@
-VER=9.3.1
-SRCS="git::commit=93c2834e92419abf04fd9f54ca25ed22086611b0::https://github.com/gcc-mirror/gcc"
+VER=14.2.0
+SRCS="git::commit=tags/releases/gcc-${VER}::https://github.com/gcc-mirror/gcc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6502"

--- a/runtime-optenvw64/mingw+w64/autobuild/build
+++ b/runtime-optenvw64/mingw+w64/autobuild/build
@@ -9,10 +9,10 @@ for _target in ${_targets}; do
         --prefix=/opt/w64/${_target} --enable-sdk=all --enable-secure-api \
         --host=${_target} CC=${_target}-gcc CXX=${_target}-g++
 
-    abinfo "Building ${_target} ..."
+    abinfo "Building ${_target} headers ..."
     make
 
-    abinfo "Installing ${_target} ..."
+    abinfo "Installing ${_target} headers ..."
     make install DESTDIR=$PKGDIR
 done
 
@@ -26,9 +26,14 @@ for _target in ${_targets}; do
         _crt_configure_args="--disable-lib32 --enable-lib64"
     fi
     mkdir $SRCDIR/rt-build-${_target} && cd $SRCDIR/rt-build-${_target}
+
+    headers="$PKGDIR"/opt/w64/${_target}/include
     $SRCDIR/mingw-w64-crt/configure --prefix=/opt/w64/${_target} \
         --host=${_target} --enable-wildcard \
-        ${_crt_configure_args} CC=${_target}-gcc CXX=${_target}-g++
+        ${_crt_configure_args} \
+        CC=${_target}-gcc CXX=${_target}-g++ \
+        CFLAGS="$CFLAGS -I${headers}" \
+        CXXFLAGS="$CXXFLAGS -I${headers}"
 
     abinfo "Building ${_target} runtime ..."
     make

--- a/runtime-optenvw64/mingw+w64/spec
+++ b/runtime-optenvw64/mingw+w64/spec
@@ -1,4 +1,4 @@
-VER=8.0.2
+VER=12.0.0
 SRCS="https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v$VER.tar.bz2"
-CHKSUMS="sha256::f00cf50951867a356d3dc0dcc7a9a9b422972302e23d54a33fc05ee7f73eee4d"
+CHKSUMS="sha256::cc41898aac4b6e8dd5cffd7331b9d9515b912df4420a3a612b5ea2955bbeed2f"
 CHKUPDATE="anitya::id=231062"


### PR DESCRIPTION
Topic Description
-----------------

- gcc+w64: update to 14.2.0
- mingw+w64: update to 12.0.0
    - update to 12.0.0
    - fix build scripts to include new headers in CRT building
- binutils+w64: update to 2.43

Package(s) Affected
-------------------

- binutils+w64: 2.43
- gcc+w64: 14.2.0
- mingw+w64: 12.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils+w64 mingw+w64 gcc+w64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
