### PR TITLE
wavemon: update to 0.9.6

### DIFF
--- a/app-network/wavemon/autobuild/patches/0001-fix-Makefile.in-honor-system-CC-variable.patch
+++ b/app-network/wavemon/autobuild/patches/0001-fix-Makefile.in-honor-system-CC-variable.patch
@@ -1,0 +1,35 @@
+From 4588853ad10bd9ad30b253a3f17fea72b56e261a Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 11 Aug 2024 17:05:24 +0800
+Subject: [PATCH 1/2] fix(Makefile.in): honor system CC variable
+
+From Ubuntu: wavemon (0.8.1-1) unstable (not sure where the patch originated
+though but they did refresh it in this revisison).
+
+--- Credit ---
+
+From: Helmut Grohne <helmut@subdivi.de>
+Subject: honour the CC variable from configure
+
+A ?= assignment to CC is a noop, because CC has a make default of "cc". This
+breaks e.g. cross compilation.
+---
+ Makefile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index acab13e..c8e520c 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -13,7 +13,7 @@ CC_DEFAULT := @CC@
+ ifeq ($(origin CC), default)
+ CC	 := $(CC_DEFAULT)
+ else
+-CC	 ?= $(CC_DEFAULT)
++CC	 = $(CC_DEFAULT)
+ endif
+ CFLAGS	 ?= @CFLAGS@ @LIBNL3_CLI_CFLAGS@
+ CPPFLAGS ?= @CPPFLAGS@
+-- 
+2.46.0
+

--- a/app-network/wavemon/autobuild/patches/0002-fix-Makefile.in-honor-Autobuild-flags.patch
+++ b/app-network/wavemon/autobuild/patches/0002-fix-Makefile.in-honor-Autobuild-flags.patch
@@ -1,0 +1,29 @@
+From 44d68781fff4eed17ced9f1ee301780b1d10f434 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 11 Aug 2024 18:34:12 +0800
+Subject: [PATCH 2/2] fix(Makefile.in): honor Autobuild flags
+
+---
+ Makefile.in | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index c8e520c..171d4d7 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -15,9 +15,9 @@ CC	 := $(CC_DEFAULT)
+ else
+ CC	 = $(CC_DEFAULT)
+ endif
+-CFLAGS	 ?= @CFLAGS@ @LIBNL3_CLI_CFLAGS@
+-CPPFLAGS ?= @CPPFLAGS@
+-LDFLAGS  ?= @LDFLAGS@
++CFLAGS	 = @CFLAGS@ @LIBNL3_CLI_CFLAGS@
++CPPFLAGS = @CPPFLAGS@
++LDFLAGS  = @LDFLAGS@
+ DEFS	 ?= @DEFS@
+ LDLIBS	 ?= @LIBS@ @LIBNL3_CLI_LIBS@
+ 
+-- 
+2.46.0
+

--- a/app-network/wavemon/autobuild/prepare
+++ b/app-network/wavemon/autobuild/prepare
@@ -1,1 +1,2 @@
+abinfo "Appending missing flags to fix build ..."
 export CFLAGS="${CFLAGS} -I/usr/include/libnl3 -lpthread"

--- a/app-network/wavemon/spec
+++ b/app-network/wavemon/spec
@@ -1,3 +1,4 @@
-VER=0.9.1
-SRCS="tbl::https://github.com/uoaerg/wavemon/archive/v$VER.tar.gz"
-CHKSUMS="sha256::5ebd5b79d3b7c546bc16b95161872c699a75e9acdfc6e3f02ec48dad10802067"CHKUPDATE="anitya::id=5120"
+VER=0.9.6
+SRCS="git::commit=tags/v$VER::https://github.com/uoaerg/wavemon"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=5120"


### PR DESCRIPTION
Topic Description
-----------------

- wavemon: update to 0.9.6

Package(s) Affected
-------------------

- wavemon: 0.9.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit wavemon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
