### PR TITLE
bash-startup: update to 0.6.7

### DIFF
--- a/runtime-data/bash-startup/spec
+++ b/runtime-data/bash-startup/spec
@@ -1,4 +1,4 @@
-VER=0.6.6
+VER=0.6.7
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226642"


### PR DESCRIPTION
Topic Description
-----------------

- bash-startup: update to 0.6.7
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- bash-startup: 2:0.6.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-startup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
