### PR TITLE
handbrake: update to 1.8.2

### DIFF
--- a/app-multimedia/handbrake/spec
+++ b/app-multimedia/handbrake/spec
@@ -1,4 +1,4 @@
-VER=1.8.1
+VER=1.8.2
 SRCS="git::commit=tags/$VER::https://github.com/HandBrake/HandBrake"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9156"


### PR DESCRIPTION
Topic Description
-----------------

- handbrake: update to 1.8.2
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- handbrake: 1.8.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit handbrake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
