### PR TITLE
wine: update to 9.15+gecko2.47.4+mono9.2.0

### DIFF
--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,13 +1,13 @@
 __GECKO_VER=2.47.4
 __MONO_VER=9.2.0
-UPSTREAM_VER=9.14
+UPSTREAM_VER=9.15
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER:0:1}.x/wine-${UPSTREAM_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
-CHKSUMS="sha256::24572f49cf3473fc9ef2a1ad1cddf511ce0ef43daa55413b4720a6c3e3c89ea6 \
+CHKSUMS="sha256::79adef436dd68ddbd70178670a3c23aa98e8afd5540ac0f42345894c458b78dd \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 9.15+gecko2.47.4+mono9.2.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wine: 3:9.15+gecko2.47.4+mono9.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
