### PR TITLE
stress-ng: new, 0.18.02

### DIFF
--- a/app-benchmarks/stress-ng/autobuild/build
+++ b/app-benchmarks/stress-ng/autobuild/build
@@ -1,0 +1,4 @@
+abinfo "Building stress-ng ..."
+make
+abinfo "Installing stress-ng ..."
+make DESTDIR="$PKGDIR" install

--- a/app-benchmarks/stress-ng/autobuild/defines
+++ b/app-benchmarks/stress-ng/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=stress-ng
+PKGSEC=utils
+# FIXME: the stressor judy cannot be packaged successfully so that it is not included in the dependencies.
+PKGDEP="apparmor gmp kmod libbsd libglvnd libjpeg-turbo lksctp-tools mpfr xxhash"
+PKGDEP__AMD64="${PKGDEP} intel-ipsec-mb"
+BUILDDEP="attr eigen-3 keyutils libaio libcap libgcrypt libglvnd libmd"
+PKGDES="Utility to stress test various components on a computer system"
+
+ABTYPE=self
+
+# FIXME: LTO may generate assembly code not supported on PPC64EL (POWER8) and cause a build error:
+# {standard input}: Assembler messages:
+# {standard input}:48268: Error: unrecognized opcode: `darn'
+NOLTO__PPC64EL=1

--- a/app-benchmarks/stress-ng/spec
+++ b/app-benchmarks/stress-ng/spec
@@ -1,0 +1,4 @@
+VER=0.18.02
+SRCS="git::commit=tags/V${VER}::https://github.com/ColinIanKing/stress-ng.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=12538"

--- a/runtime-cryptography/intel-ipsec-mb/autobuild/beyond
+++ b/runtime-cryptography/intel-ipsec-mb/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing manual pages ..."
+mkdir -pv "${PKGDIR}"/usr/share
+mv -v "${PKGDIR}"/usr/man "${PKGDIR}"/usr/share/

--- a/runtime-cryptography/intel-ipsec-mb/autobuild/defines
+++ b/runtime-cryptography/intel-ipsec-mb/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=intel-ipsec-mb
+PKGSEC=libs
+PKGDEP="glibc"
+BUILDDEP="nasm"
+PKGDES="Software implementations of the core cryptographic processing for IPsec on a range of Intel processors"
+
+ABTYPE=cmakeninja
+
+FAIL_ARCH="!(amd64)"

--- a/runtime-cryptography/intel-ipsec-mb/spec
+++ b/runtime-cryptography/intel-ipsec-mb/spec
@@ -1,0 +1,4 @@
+VER=1.5
+SRCS="git::commit=tags/v${VER}::https://github.com/intel/intel-ipsec-mb.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=373794"


### PR DESCRIPTION
Topic Description
-----------------

- stress-ng: new, 0.18.02
    Dependencies:
    - intel-ipsec-mb: new, 1.5

Package(s) Affected
-------------------

- intel-ipsec-mb: 1.5
- stress-ng: 0.18.02

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-ipsec-mb stress-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
