### PR TITLE
postgresql (PostgreSQL): update to 13.16

### DIFF
--- a/app-database/postgresql/spec
+++ b/app-database/postgresql/spec
@@ -1,4 +1,4 @@
-VER=13.15
+VER=13.16
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::42edd415446d33b8c242be76d1ad057531b2264b2e86939339b7075c6e4ec925"
+CHKSUMS="sha256::c9cbbb6129f02328204828066bb3785c00a85c8ca8fd329c2a8a53c1f5cd8865"
 CHKUPDATE="anitya::id=5601"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql: update to 13.16

Package(s) Affected
-------------------

- postgresql: 1:13.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit postgresql
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
