### PR TITLE
intel-compute-runtime: update to 24.26.30049.6

### DIFF
--- a/runtime-scientific/intel-compute-runtime/spec
+++ b/runtime-scientific/intel-compute-runtime/spec
@@ -1,4 +1,4 @@
-VER=24.22.29735.20
+VER=24.26.30049.6
 SRCS="git::commit=tags/$VER::https://github.com/intel/compute-runtime.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229527"


### PR DESCRIPTION
Topic Description
-----------------

- intel-compute-runtime: update to 24.26.30049.6
    Co-authored-by: Anjia Wang (@ouankou) <anjia@ouankou.com>

Package(s) Affected
-------------------

- intel-compute-runtime: 24.26.30049.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-compute-runtime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
