### PR TITLE
mcfly: update to 0.9.2

### DIFF
--- a/app-utils/mcfly/spec
+++ b/app-utils/mcfly/spec
@@ -1,4 +1,4 @@
-VER=0.9.1
+VER=0.9.2
 SRCS="git::commit=tags/v$VER::https://github.com/cantino/mcfly/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=179619"


### PR DESCRIPTION
Topic Description
-----------------

- mcfly: update to 0.9.2
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- mcfly: 0.9.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mcfly
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
