### PR TITLE
intel-oneapi-basekit: update to 2024.2.1

### DIFF
--- a/app-devel/intel-oneapi-basekit/autobuild/defines
+++ b/app-devel/intel-oneapi-basekit/autobuild/defines
@@ -6,3 +6,9 @@ PKGDES="Intel oneAPI base toolkit"
 FAIL_ARCH="!(amd64)"
 ABSTRIP=0
 NOSTATIC=0
+
+# FIXME: currently an OpenMP GPU program compiled with "-g" flag will trigger a runtime error:
+# InvalidBuiltinSetName: Expects OpenCL12, OpenCL20. Actual is NonSemantic.Shader.DebugInfo.200 [Src: /var/cache/acbs/build/acbs.kjwza1v_/intel-graphics-compiler/IGC/AdaptorOCL/SPIRV/libSPIRV/SPIRVModule.cpp:565 SPIRVBuiltinSetNameMap::rfind(BuiltinSetName, &BuiltinSet) ]
+# terminate called after throwing an instance of 'std::runtime_error'
+#   what():  internal compiler error
+# Aborted (core dumped)

--- a/app-devel/intel-oneapi-basekit/spec
+++ b/app-devel/intel-oneapi-basekit/spec
@@ -1,7 +1,6 @@
-VER=2024.2.0
-PKG_URL=9a98af19-1c68-46ce-9fdd-e249240c7c42
-PKG_CODE=634
+VER=2024.2.1
+PKG_URL=e6ff8e9c-ee28-47fb-abd7-5c524c983e1c
+PKG_CODE=100
 SRCS="file::rename=l_BaseKit_p_"${VER}"."${PKG_CODE}"_offline.sh::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"${PKG_URL}"/l_BaseKit_p_"${VER}"."${PKG_CODE}"_offline.sh"
-CHKSUMS="sha256::ae97f1b7146f610c07232d75cac8d37f6b2998df416411bef9a9f6c9d23591a4"
+CHKSUMS="sha256::bfd0b61db946549f72104cda11af01790142b371b17340f3a7cd45fe0c900cba"
 CHKUPDATE="anitya::id=372585"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- intel-oneapi-basekit: update to 2024.2.1

Package(s) Affected
-------------------

- intel-oneapi-basekit: 2024.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-oneapi-basekit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
