### PR TITLE
noto-fonts: update to 24.8.1+emoji2.042+cjksans2.004+cjkserif2.002

### DIFF
--- a/desktop-fonts/noto-fonts/spec
+++ b/desktop-fonts/noto-fonts/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=24.7.1
+UPSTREAM_VER=24.8.1
 # Note: For the main version number, go with NotoSans- prefixed tags at
 # https://github.com/notofonts/notofonts.github.io/.
 EMOJI_VER=2.042
@@ -14,7 +14,7 @@ CJK_COMMIT="4efc595762d1f4b4fa504bccfe8e59de91fda063"
 SRCS="tbl::https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-${UPSTREAM_VER}.tar.gz \
       tbl::https://github.com/googlefonts/noto-emoji/archive/refs/tags/v${EMOJI_VER}.tar.gz \
       git::commit=${CJK_COMMIT};rename=noto-cjk::https://github.com/googlefonts/noto-cjk"
-CHKSUMS="sha256::934ec561b5c623b460aea837f7bad243073165b1ed6766b61c44d623997b88e0 \
+CHKSUMS="sha256::84d292fc934ad6a9f20705fdfa5764b81b456b0e733f98b6f44388fb8c8eb44a \
          sha256::b56bd2fa4029d0f057b66b742ac59af243dbc91067fed3eb4929dac762440fc9 \
          SKIP"
 CHKUPDATE="anitya::id=10671"


### PR DESCRIPTION
Topic Description
-----------------

- noto-fonts: update to 24.8.1+emoji2.042+cjksans2.004+cjkserif2.002
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- noto-cjk-fonts: 2:24.8.1+emoji2.042+cjksans2.004+cjkserif2.002
- noto-fonts: 2:24.8.1+emoji2.042+cjksans2.004+cjkserif2.002

Security Update?
----------------

No

Build Order
-----------

```
#buildit noto-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
