### PR TITLE
open-rs: update to 5.3.0

### DIFF
--- a/app-utils/open-rs/spec
+++ b/app-utils/open-rs/spec
@@ -1,4 +1,4 @@
-VER=5.1.3
+VER=5.3.0
 SRCS="git::commit=tags/v$VER::https://github.com/Byron/open-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=339452"


### PR DESCRIPTION
Topic Description
-----------------

- open-rs: update to 5.3.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- open-rs: 5.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit open-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
