### PR TITLE
vscode: update to 1.92.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.92.0
+VER=1.92.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::52726a61fadce5b933b507c32c3e004b91ffea64e9f7edeb4350c23d4e80b3e3"
-CHKSUMS__ARM64="sha256::ecfc9f73de6029202f0010ddbc2113964dd635e3a901076dbfb3366b04c59cc6"
+CHKSUMS__AMD64="sha256::d0f161ec79145772445d5a14b15030592498aaafa59237a602d66f43653e5309"
+CHKSUMS__ARM64="sha256::200e9be6cd02f62969c762919d9677e3e48ef321c73b9e1a85a43d06a43a099f"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.92.1
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- vscode: 1.92.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
