### PR TITLE
judy: new, 1.0.5

### DIFF
--- a/app-benchmarks/stress-ng/autobuild/defines
+++ b/app-benchmarks/stress-ng/autobuild/defines
@@ -1,7 +1,6 @@
 PKGNAME=stress-ng
 PKGSEC=utils
-# FIXME: the stressor judy cannot be packaged successfully so that it is not included in the dependencies.
-PKGDEP="apparmor gmp kmod libbsd libglvnd libjpeg-turbo lksctp-tools mpfr xxhash"
+PKGDEP="apparmor gmp judy kmod libbsd libglvnd libjpeg-turbo lksctp-tools mpfr xxhash"
 PKGDEP__AMD64="${PKGDEP} intel-ipsec-mb"
 BUILDDEP="attr eigen-3 keyutils libaio libcap libgcrypt libglvnd libmd"
 PKGDES="Utility to stress test various components on a computer system"

--- a/app-benchmarks/stress-ng/spec
+++ b/app-benchmarks/stress-ng/spec
@@ -2,3 +2,4 @@ VER=0.18.02
 SRCS="git::commit=tags/V${VER}::https://github.com/ColinIanKing/stress-ng.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12538"
+REL=1

--- a/app-devel/judy/autobuild/defines
+++ b/app-devel/judy/autobuild/defines
@@ -1,0 +1,19 @@
+PKGNAME=judy
+PKGSEC=libs
+PKGDEP="glibc"
+BUILDDEP="automake"
+PKGDES="C library creating and accessing dynamic arrays"
+
+ABTYPE=autotools
+
+AUTOTOOLS_AFTER=" \
+    --enable-64-bit \
+"
+
+# FIXME: Build dependencies are not properly specified in automake. It may fail while building in parallel.
+NOPARALLEL=1
+ABSHADOW=0
+
+# FIXME: Debug symbols are missing and it causes a build error on LOONGSON3 as follows:
+# ABSPLITDBG is set, but we can't find any symbol files in /var/cache/acbs/build/acbs.qoxsa3ah/judy-1.0.5/abdist-dbg
+ABSPLITDBG__LOONGSON3=0

--- a/app-devel/judy/autobuild/patches/0001-Debian-02_remove_duplicate_man.patch.patch
+++ b/app-devel/judy/autobuild/patches/0001-Debian-02_remove_duplicate_man.patch.patch
@@ -1,0 +1,27 @@
+From d023c0d53e4a9f83c0f4882bc22aeb75f87426f1 Mon Sep 17 00:00:00 2001
+From: Anjia Wang <anjiawang@gmail.com>
+Date: Wed, 14 Aug 2024 05:23:20 +0000
+Subject: [PATCH 1/4] [Debian] 02_remove_duplicate_man.patch
+
+Remove duplicated entry in man pages.
+
+Ref: https://sources.debian.org/src/judy/1.0.5-5.1/debian/patches/02_remove_duplicate_man.patch
+---
+ doc/Makefile.am | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/doc/Makefile.am b/doc/Makefile.am
+index 8e6706a..fec90a2 100644
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -37,7 +37,6 @@ man3_MANS = man/man3/Judy \
+ 	    man/man3/Judy1ByCount \
+ 	    man/man3/Judy1FreeArray \
+ 	    man/man3/Judy1MemUsed \
+-	    man/man3/JudyL \
+ 	    man/man3/JLG \
+ 	    man/man3/JLI \
+ 	    man/man3/JLD \
+-- 
+2.46.0
+

--- a/app-devel/judy/autobuild/patches/0002-Debian-03_add_man_section_to_filename.patch.patch
+++ b/app-devel/judy/autobuild/patches/0002-Debian-03_add_man_section_to_filename.patch.patch
@@ -1,0 +1,423 @@
+From 39b25a8cb09b7cbde6b960ce8bb7e07609c483c9 Mon Sep 17 00:00:00 2001
+From: Anjia Wang <anjiawang@gmail.com>
+Date: Wed, 14 Aug 2024 05:26:02 +0000
+Subject: [PATCH 2/4] [Debian] 03_add_man_section_to_filename.patch
+
+Reorganize man pages.
+
+Ref: https://sources.debian.org/src/judy/1.0.5-5.1/debian/patches/03_add_man_section_to_filename
+---
+ doc/Makefile.am | 390 ++++++++++++++++++++++++------------------------
+ 1 file changed, 195 insertions(+), 195 deletions(-)
+
+diff --git a/doc/Makefile.am b/doc/Makefile.am
+index fec90a2..ea5b6a9 100644
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -1,208 +1,208 @@
+-man3_MANS = man/man3/Judy \
+-	    man/man3/Judy1 \
+-	    man/man3/Judy1_funcs \
+-	    man/man3/JudyL \
+-	    man/man3/JudyL_funcs \
+-	    man/man3/JudySL \
+-	    man/man3/JudySL_funcs \
+-	    man/man3/JudyHS \
+-	    man/man3/JudyHS_funcs \
+-	    man/man3/J1T \
+-	    man/man3/J1S \
+-	    man/man3/J1U \
+-	    man/man3/J1F \
+-	    man/man3/J1N \
+-	    man/man3/J1L \
+-	    man/man3/J1P \
+-	    man/man3/J1FE \
+-	    man/man3/J1NE \
+-	    man/man3/J1LE \
+-	    man/man3/J1PE \
+-	    man/man3/J1C \
+-	    man/man3/J1BC \
+-	    man/man3/J1FA \
+-	    man/man3/J1MU \
+-	    man/man3/Judy1Test \
+-	    man/man3/Judy1Set \
+-	    man/man3/Judy1Unset \
+-	    man/man3/Judy1First \
+-	    man/man3/Judy1Next \
+-	    man/man3/Judy1Last \
+-	    man/man3/Judy1Prev \
+-	    man/man3/Judy1FirstEmpty \
+-	    man/man3/Judy1NextEmpty \
+-	    man/man3/Judy1LastEmpty \
+-	    man/man3/Judy1PrevEmpty \
+-	    man/man3/Judy1Count \
+-	    man/man3/Judy1ByCount \
+-	    man/man3/Judy1FreeArray \
+-	    man/man3/Judy1MemUsed \
+-	    man/man3/JLG \
+-	    man/man3/JLI \
+-	    man/man3/JLD \
+-	    man/man3/JLF \
+-	    man/man3/JLN \
+-	    man/man3/JLL \
+-	    man/man3/JLP \
+-	    man/man3/JLFE \
+-	    man/man3/JLNE \
+-	    man/man3/JLLE \
+-	    man/man3/JLPE \
+-	    man/man3/JLC \
+-	    man/man3/JLBC \
+-	    man/man3/JLFA \
+-	    man/man3/JLMU \
+-	    man/man3/JudyLGet \
+-	    man/man3/JudyLIns \
+-	    man/man3/JudyLDel \
+-	    man/man3/JudyLFirst \
+-	    man/man3/JudyLNext \
+-	    man/man3/JudyLLast \
+-	    man/man3/JudyLPrev \
+-	    man/man3/JudyLFirstEmpty \
+-	    man/man3/JudyLNextEmpty \
+-	    man/man3/JudyLLastEmpty \
+-	    man/man3/JudyLPrevEmpty \
+-	    man/man3/JudyLCount \
+-	    man/man3/JudyLByCount \
+-	    man/man3/JudyLFreeArray \
+-	    man/man3/JudyLMemUsed \
+-	    man/man3/JSLG \
+-	    man/man3/JSLI \
+-	    man/man3/JSLD \
+-	    man/man3/JSLF \
+-	    man/man3/JSLN \
+-	    man/man3/JSLL \
+-	    man/man3/JSLP \
+-	    man/man3/JSLFA \
+-	    man/man3/JudySLGet \
+-	    man/man3/JudySLIns \
+-	    man/man3/JudySLDel \
+-	    man/man3/JudySLFirst \
+-	    man/man3/JudySLNext \
+-	    man/man3/JudySLLast \
+-	    man/man3/JudySLPrev \
+-	    man/man3/JudySLFreeArray \
+-	    man/man3/JHSG \
+-	    man/man3/JHSI \
+-	    man/man3/JHSD \
+-	    man/man3/JHSFA \
+-	    man/man3/JudyHSGet \
+-	    man/man3/JudyHSIns \
+-	    man/man3/JudyHSDel \
+-	    man/man3/JudyHSFreeArray
++man3_MANS = man/man3/Judy.3 \
++	    man/man3/Judy1.3 \
++	    man/man3/Judy1_funcs.3 \
++	    man/man3/JudyL.3 \
++	    man/man3/JudyL_funcs.3 \
++	    man/man3/JudySL.3 \
++	    man/man3/JudySL_funcs.3 \
++	    man/man3/JudyHS.3 \
++	    man/man3/JudyHS_funcs.3 \
++	    man/man3/J1T.3 \
++	    man/man3/J1S.3 \
++	    man/man3/J1U.3 \
++	    man/man3/J1F.3 \
++	    man/man3/J1N.3 \
++	    man/man3/J1L.3 \
++	    man/man3/J1P.3 \
++	    man/man3/J1FE.3 \
++	    man/man3/J1NE.3 \
++	    man/man3/J1LE.3 \
++	    man/man3/J1PE.3 \
++	    man/man3/J1C.3 \
++	    man/man3/J1BC.3 \
++	    man/man3/J1FA.3 \
++	    man/man3/J1MU.3 \
++	    man/man3/Judy1Test.3 \
++	    man/man3/Judy1Set.3 \
++	    man/man3/Judy1Unset.3 \
++	    man/man3/Judy1First.3 \
++	    man/man3/Judy1Next.3 \
++	    man/man3/Judy1Last.3 \
++	    man/man3/Judy1Prev.3 \
++	    man/man3/Judy1FirstEmpty.3 \
++	    man/man3/Judy1NextEmpty.3 \
++	    man/man3/Judy1LastEmpty.3 \
++	    man/man3/Judy1PrevEmpty.3 \
++	    man/man3/Judy1Count.3 \
++	    man/man3/Judy1ByCount.3 \
++	    man/man3/Judy1FreeArray.3 \
++	    man/man3/Judy1MemUsed.3 \
++	    man/man3/JLG.3 \
++	    man/man3/JLI.3 \
++	    man/man3/JLD.3 \
++	    man/man3/JLF.3 \
++	    man/man3/JLN.3 \
++	    man/man3/JLL.3 \
++	    man/man3/JLP.3 \
++	    man/man3/JLFE.3 \
++	    man/man3/JLNE.3 \
++	    man/man3/JLLE.3 \
++	    man/man3/JLPE.3 \
++	    man/man3/JLC.3 \
++	    man/man3/JLBC.3 \
++	    man/man3/JLFA.3 \
++	    man/man3/JLMU.3 \
++	    man/man3/JudyLGet.3 \
++	    man/man3/JudyLIns.3 \
++	    man/man3/JudyLDel.3 \
++	    man/man3/JudyLFirst.3 \
++	    man/man3/JudyLNext.3 \
++	    man/man3/JudyLLast.3 \
++	    man/man3/JudyLPrev.3 \
++	    man/man3/JudyLFirstEmpty.3 \
++	    man/man3/JudyLNextEmpty.3 \
++	    man/man3/JudyLLastEmpty.3 \
++	    man/man3/JudyLPrevEmpty.3 \
++	    man/man3/JudyLCount.3 \
++	    man/man3/JudyLByCount.3 \
++	    man/man3/JudyLFreeArray.3 \
++	    man/man3/JudyLMemUsed.3 \
++	    man/man3/JSLG.3 \
++	    man/man3/JSLI.3 \
++	    man/man3/JSLD.3 \
++	    man/man3/JSLF.3 \
++	    man/man3/JSLN.3 \
++	    man/man3/JSLL.3 \
++	    man/man3/JSLP.3 \
++	    man/man3/JSLFA.3 \
++	    man/man3/JudySLGet.3 \
++	    man/man3/JudySLIns.3 \
++	    man/man3/JudySLDel.3 \
++	    man/man3/JudySLFirst.3 \
++	    man/man3/JudySLNext.3 \
++	    man/man3/JudySLLast.3 \
++	    man/man3/JudySLPrev.3 \
++	    man/man3/JudySLFreeArray.3 \
++	    man/man3/JHSG.3 \
++	    man/man3/JHSI.3 \
++	    man/man3/JHSD.3 \
++	    man/man3/JHSFA.3 \
++	    man/man3/JudyHSGet.3 \
++	    man/man3/JudyHSIns.3 \
++	    man/man3/JudyHSDel.3 \
++	    man/man3/JudyHSFreeArray.3
+ 
+ 
+ 
+-man/man3/Judy: 
+-	../tool/jhton ext/Judy_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.C//' >  man/man3/Judy
++man/man3/Judy.3:
++	../tool/jhton ext/Judy_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.\.\./\&.\&.\&./' | sed -e 's/\(^Judy.*\) \([a-z].*\)s*-/\1 \\-/' | sed -e '/^.ds/d' | sed -e '/^.\\"/d' | sed -e '/^.TA/d' | sed -e 's/\.C//'| sed -e '2d' >  man/man3/Judy.3
++	cd man/man3; ln -s Judy.3 J1T.3
++	cd man/man3; ln -s Judy.3 J1S.3
++	cd man/man3; ln -s Judy.3 J1U.3
++	cd man/man3; ln -s Judy.3 J1F.3
++	cd man/man3; ln -s Judy.3 J1N.3
++	cd man/man3; ln -s Judy.3 J1L.3
++	cd man/man3; ln -s Judy.3 J1P.3
++	cd man/man3; ln -s Judy.3 J1FE.3
++	cd man/man3; ln -s Judy.3 J1NE.3
++	cd man/man3; ln -s Judy.3 J1LE.3
++	cd man/man3; ln -s Judy.3 J1PE.3
++	cd man/man3; ln -s Judy.3 J1C.3
++	cd man/man3; ln -s Judy.3 J1BC.3
++	cd man/man3; ln -s Judy.3 J1FA.3
++	cd man/man3; ln -s Judy.3 J1MU.3
+ 
+-man/man3/Judy1:
+-	../tool/jhton ext/Judy1_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.C//' > man/man3/Judy1
+-	cd man/man3; ln -s Judy J1T
+-	cd man/man3; ln -s Judy J1S
+-	cd man/man3; ln -s Judy J1U
+-	cd man/man3; ln -s Judy J1F
+-	cd man/man3; ln -s Judy J1N
+-	cd man/man3; ln -s Judy J1L
+-	cd man/man3; ln -s Judy J1P
+-	cd man/man3; ln -s Judy J1FE
+-	cd man/man3; ln -s Judy J1NE
+-	cd man/man3; ln -s Judy J1LE
+-	cd man/man3; ln -s Judy J1PE
+-	cd man/man3; ln -s Judy J1C
+-	cd man/man3; ln -s Judy J1BC
+-	cd man/man3; ln -s Judy J1FA
+-	cd man/man3; ln -s Judy J1MU
++man/man3/Judy1.3:
++	../tool/jhton ext/Judy1_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.\.\./\&.\&.\&./' | sed -e 's/\(^Judy.*\) \([a-z].*\)s*-/\1 \\-/' | sed -e '/^.ds/d' | sed -e '/^.\\"/d' | sed -e '/^.TA/d' | sed -e 's/\.C//'| sed -e '2d' > man/man3/Judy1.3
+ 
+-man/man3/Judy1_funcs:
+-	../tool/jhton ext/Judy1_funcs_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.C//' > man/man3/Judy1_funcs
+-	cd man/man3; ln -s Judy1_funcs Judy1Test 
+-	cd man/man3; ln -s Judy1_funcs Judy1Set 
+-	cd man/man3; ln -s Judy1_funcs Judy1Unset 
+-	cd man/man3; ln -s Judy1_funcs Judy1First 
+-	cd man/man3; ln -s Judy1_funcs Judy1Next
+-	cd man/man3; ln -s Judy1_funcs Judy1Last
+-	cd man/man3; ln -s Judy1_funcs Judy1Prev
+-	cd man/man3; ln -s Judy1_funcs Judy1FirstEmpty
+-	cd man/man3; ln -s Judy1_funcs Judy1NextEmpty
+-	cd man/man3; ln -s Judy1_funcs Judy1LastEmpty
+-	cd man/man3; ln -s Judy1_funcs Judy1PrevEmpty
+-	cd man/man3; ln -s Judy1_funcs Judy1Count
+-	cd man/man3; ln -s Judy1_funcs Judy1ByCount
+-	cd man/man3; ln -s Judy1_funcs Judy1FreeArray
+-	cd man/man3; ln -s Judy1_funcs Judy1MemUsed
++man/man3/Judy1_funcs.3:
++	../tool/jhton ext/Judy1_funcs_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.\.\./\&.\&.\&./' | sed -e 's/\(^Judy.*\) \([a-z].*\)s*-/\1 \\-/' | sed -e '/^.ds/d' | sed -e '/^.\\"/d' | sed -e '/^.TA/d' | sed -e 's/\.C//'| sed -e '2d' > man/man3/Judy1_funcs.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1Test.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1Set.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1Unset.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1First.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1Next.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1Last.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1Prev.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1FirstEmpty.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1NextEmpty.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1LastEmpty.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1PrevEmpty.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1Count.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1ByCount.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1FreeArray.3
++	cd man/man3; ln -s Judy1_funcs.3 Judy1MemUsed.3
+ 
+-man/man3/JudyL:
+-	../tool/jhton ext/JudyL_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.C//' > man/man3/JudyL
+-	cd man/man3; ln -s JudyL JLG
+-	cd man/man3; ln -s JudyL JLI
+-	cd man/man3; ln -s JudyL JLD
+-	cd man/man3; ln -s JudyL JLF
+-	cd man/man3; ln -s JudyL JLN
+-	cd man/man3; ln -s JudyL JLL
+-	cd man/man3; ln -s JudyL JLP
+-	cd man/man3; ln -s JudyL JLFE
+-	cd man/man3; ln -s JudyL JLNE
+-	cd man/man3; ln -s JudyL JLLE
+-	cd man/man3; ln -s JudyL JLPE
+-	cd man/man3; ln -s JudyL JLC
+-	cd man/man3; ln -s JudyL JLBC
+-	cd man/man3; ln -s JudyL JLFA
+-	cd man/man3; ln -s JudyL JLMU
++man/man3/JudyL.3:
++	../tool/jhton ext/JudyL_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.\.\./\&.\&.\&./' | sed -e 's/\(^Judy.*\) \([a-z].*\)s*-/\1 \\-/' | sed -e '/^.ds/d' | sed -e '/^.\\"/d' | sed -e '/^.TA/d' | sed -e 's/\.C//'| sed -e '2d' > man/man3/JudyL.3
++	cd man/man3; ln -s JudyL.3 JLG.3
++	cd man/man3; ln -s JudyL.3 JLI.3
++	cd man/man3; ln -s JudyL.3 JLD.3
++	cd man/man3; ln -s JudyL.3 JLF.3
++	cd man/man3; ln -s JudyL.3 JLN.3
++	cd man/man3; ln -s JudyL.3 JLL.3
++	cd man/man3; ln -s JudyL.3 JLP.3
++	cd man/man3; ln -s JudyL.3 JLFE.3
++	cd man/man3; ln -s JudyL.3 JLNE.3
++	cd man/man3; ln -s JudyL.3 JLLE.3
++	cd man/man3; ln -s JudyL.3 JLPE.3
++	cd man/man3; ln -s JudyL.3 JLC.3
++	cd man/man3; ln -s JudyL.3 JLBC.3
++	cd man/man3; ln -s JudyL.3 JLFA.3
++	cd man/man3; ln -s JudyL.3 JLMU.3
+ 
+-man/man3/JudyL_funcs:
+-	../tool/jhton ext/JudyL_funcs_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.C//' > man/man3/JudyL_funcs
+-	cd man/man3; ln -s JudyL_funcs JudyLGet
+-	cd man/man3; ln -s JudyL_funcs JudyLIns
+-	cd man/man3; ln -s JudyL_funcs JudyLDel
+-	cd man/man3; ln -s JudyL_funcs JudyLFirst
+-	cd man/man3; ln -s JudyL_funcs JudyLNext
+-	cd man/man3; ln -s JudyL_funcs JudyLLast
+-	cd man/man3; ln -s JudyL_funcs JudyLPrev
+-	cd man/man3; ln -s JudyL_funcs JudyLFirstEmpty
+-	cd man/man3; ln -s JudyL_funcs JudyLNextEmpty
+-	cd man/man3; ln -s JudyL_funcs JudyLLastEmpty
+-	cd man/man3; ln -s JudyL_funcs JudyLPrevEmpty
+-	cd man/man3; ln -s JudyL_funcs JudyLCount
+-	cd man/man3; ln -s JudyL_funcs JudyLByCount
+-	cd man/man3; ln -s JudyL_funcs JudyLFreeArray
+-	cd man/man3; ln -s JudyL_funcs JudyLMemUsed
++man/man3/JudyL_funcs.3:
++	../tool/jhton ext/JudyL_funcs_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.\.\./\&.\&.\&./' | sed -e 's/\(^Judy.*\) \([a-z].*\)s*-/\1 \\-/' | sed -e '/^.ds/d' | sed -e '/^.\\"/d' | sed -e '/^.TA/d' | sed -e 's/\.C//'| sed -e '2d' > man/man3/JudyL_funcs.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLGet.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLIns.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLDel.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLFirst.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLNext.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLLast.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLPrev.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLFirstEmpty.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLNextEmpty.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLLastEmpty.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLPrevEmpty.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLCount.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLByCount.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLFreeArray.3
++	cd man/man3; ln -s JudyL_funcs.3 JudyLMemUsed.3
+ 
+-man/man3/JudySL:
+-	../tool/jhton ext/JudySL_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.C//' > man/man3/JudySL
+-	cd man/man3; ln -s JudySL JSLG
+-	cd man/man3; ln -s JudySL JSLI
+-	cd man/man3; ln -s JudySL JSLD
+-	cd man/man3; ln -s JudySL JSLF
+-	cd man/man3; ln -s JudySL JSLN
+-	cd man/man3; ln -s JudySL JSLL
+-	cd man/man3; ln -s JudySL JSLP
+-	cd man/man3; ln -s JudySL JSLFA
++man/man3/JudySL.3:
++	../tool/jhton ext/JudySL_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.\.\./\&.\&.\&./' | sed -e 's/\(^Judy.*\) \([a-z].*\)s*-/\1 \\-/' | sed -e '/^.ds/d' | sed -e '/^.\\"/d' | sed -e '/^.TA/d' | sed -e 's/\.C//'| sed -e '2d' > man/man3/JudySL.3
++	cd man/man3; ln -s JudySL.3 JSLG.3
++	cd man/man3; ln -s JudySL.3 JSLI.3
++	cd man/man3; ln -s JudySL.3 JSLD.3
++	cd man/man3; ln -s JudySL.3 JSLF.3
++	cd man/man3; ln -s JudySL.3 JSLN.3
++	cd man/man3; ln -s JudySL.3 JSLL.3
++	cd man/man3; ln -s JudySL.3 JSLP.3
++	cd man/man3; ln -s JudySL.3 JSLFA.3
+ 
+-man/man3/JudySL_funcs:
+-	../tool/jhton ext/JudySL_funcs_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.C//' > man/man3/JudySL_funcs
+-	cd man/man3; ln -s JudySL_funcs JudySLGet
+-	cd man/man3; ln -s JudySL_funcs JudySLIns
+-	cd man/man3; ln -s JudySL_funcs JudySLDel
+-	cd man/man3; ln -s JudySL_funcs JudySLFirst
+-	cd man/man3; ln -s JudySL_funcs JudySLNext
+-	cd man/man3; ln -s JudySL_funcs JudySLLast
+-	cd man/man3; ln -s JudySL_funcs JudySLPrev
+-	cd man/man3; ln -s JudySL_funcs JudySLFreeArray
++man/man3/JudySL_funcs.3:
++	../tool/jhton ext/JudySL_funcs_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.\.\./\&.\&.\&./' | sed -e 's/\(^Judy.*\) \([a-z].*\)s*-/\1 \\-/' | sed -e '/^.ds/d' | sed -e '/^.\\"/d' | sed -e '/^.TA/d' | sed -e 's/\.C//'| sed -e '2d' > man/man3/JudySL_funcs.3
++	cd man/man3; ln -s JudySL_funcs.3 JudySLGet.3
++	cd man/man3; ln -s JudySL_funcs.3 JudySLIns.3
++	cd man/man3; ln -s JudySL_funcs.3 JudySLDel.3
++	cd man/man3; ln -s JudySL_funcs.3 JudySLFirst.3
++	cd man/man3; ln -s JudySL_funcs.3 JudySLNext.3
++	cd man/man3; ln -s JudySL_funcs.3 JudySLLast.3
++	cd man/man3; ln -s JudySL_funcs.3 JudySLPrev.3
++	cd man/man3; ln -s JudySL_funcs.3 JudySLFreeArray.3
+ 
+-man/man3/JudyHS:
+-	../tool/jhton ext/JudyHS_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.C//' > man/man3/JudyHS
+-	cd man/man3; ln -s JudyHS JHSG 
+-	cd man/man3; ln -s JudyHS JHSI
+-	cd man/man3; ln -s JudyHS JHSD
+-	cd man/man3; ln -s JudyHS JHSFA
++man/man3/JudyHS.3:
++	../tool/jhton ext/JudyHS_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.\.\./\&.\&.\&./' | sed -e 's/\(^Judy.*\) \([a-z].*\)s*-/\1 \\-/' | sed -e '/^.ds/d' | sed -e '/^.\\"/d' | sed -e '/^.TA/d' | sed -e 's/\.C//'| sed -e '2d' > man/man3/JudyHS.3
++	cd man/man3; ln -s JudyHS.3 JHSG.3
++	cd man/man3; ln -s JudyHS.3 JHSI.3
++	cd man/man3; ln -s JudyHS.3 JHSD.3
++	cd man/man3; ln -s JudyHS.3 JHSFA.3
+ 
+-man/man3/JudyHS_funcs:
+-	../tool/jhton ext/JudyHS_funcs_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.C//' > man/man3/JudyHS_funcs
+-	cd man/man3; ln -s JudyHS_funcs JudyHSGet
+-	cd man/man3; ln -s JudyHS_funcs JudyHSIns
+-	cd man/man3; ln -s JudyHS_funcs JudyHSDel
+-	cd man/man3; ln -s JudyHS_funcs JudyHSFreeArray
++man/man3/JudyHS_funcs.3:
++	../tool/jhton ext/JudyHS_funcs_3.htm | grep -v '^[   ]*$$' | sed -e 's/\.\.\./\&.\&.\&./' | sed -e 's/\(^Judy.*\) \([a-z].*\)s*-/\1 \\-/' | sed -e '/^.ds/d' | sed -e '/^.\\"/d' | sed -e '/^.TA/d' | sed -e 's/\.C//'| sed -e '2d' > man/man3/JudyHS_funcs.3
++	cd man/man3; ln -s JudyHS_funcs.3 JudyHSGet.3
++	cd man/man3; ln -s JudyHS_funcs.3 JudyHSIns.3
++	cd man/man3; ln -s JudyHS_funcs.3 JudyHSDel.3
++	cd man/man3; ln -s JudyHS_funcs.3 JudyHSFreeArray.3
+ 
+ CLEANFILES = man/man3/*
+-- 
+2.46.0
+

--- a/app-devel/judy/autobuild/patches/0003-fix-bootstrap-remove-automake-version-restriction.patch
+++ b/app-devel/judy/autobuild/patches/0003-fix-bootstrap-remove-automake-version-restriction.patch
@@ -1,0 +1,25 @@
+From ba355ed44a541876d2cb3323dd309ce8ac48fd13 Mon Sep 17 00:00:00 2001
+From: Anjia Wang <anjiawang@gmail.com>
+Date: Wed, 14 Aug 2024 05:28:47 +0000
+Subject: [PATCH 3/4] fix(bootstrap): remove automake version restriction
+
+---
+ bootstrap | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bootstrap b/bootstrap
+index 39480ed..c6c1002 100644
+--- a/bootstrap
++++ b/bootstrap
+@@ -8,7 +8,7 @@ aclocal
+ autoheader
+ #add --include-deps if you want to bootstrap with any other compiler than gcc
+ #automake --add-missing --copy --include-deps
+-automake-1.9 --add-missing --force --copy
++automake --add-missing --force --copy
+ #autoconf2.50
+ autoconf
+ rm -f config.cache
+-- 
+2.46.0
+

--- a/app-devel/judy/autobuild/patches/0004-fix-configure.ac-remove-unneeded-m64-flag.patch
+++ b/app-devel/judy/autobuild/patches/0004-fix-configure.ac-remove-unneeded-m64-flag.patch
@@ -1,0 +1,29 @@
+From 79e2e6a8e73669d82bd0743d56c451d9e72126b8 Mon Sep 17 00:00:00 2001
+From: Anjia Wang <anjiawang@gmail.com>
+Date: Wed, 14 Aug 2024 06:09:20 +0000
+Subject: [PATCH 4/4] fix(configure.ac): remove unneeded -m64 flag
+
+---
+ configure.ac | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index ddfed18..ad31f10 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -201,11 +201,7 @@ AC_ARG_ENABLE(64-bit, [  --enable-64-bit          Generate code for a 64-bit env
+               b64="$enableval", b64="no")
+ if test x"$b64" != "xno"; then
+     AC_MSG_RESULT(Configured to Building 64-bit)
+-    if test x"$GCC" = xyes; then
+-      CFLAGS="-DJU_64BIT -m64 $CFLAGS"
+-    else
+-      CFLAGS="-DJU_64BIT $CFLAGS"
+-    fi
++    CFLAGS="-DJU_64BIT $CFLAGS"
+ fi
+ 
+ 
+-- 
+2.46.0
+

--- a/app-devel/judy/spec
+++ b/app-devel/judy/spec
@@ -1,0 +1,4 @@
+VER=1.0.5
+SRCS="tbl::https://downloads.sourceforge.net/judy/Judy-$VER.tar.gz"
+CHKSUMS="sha256::d2704089f85fdb6f2cd7e77be21170ced4b4375c03ef1ad4cf1075bd414a63eb"
+CHKUPDATE="anitya::id=23331"


### PR DESCRIPTION
Topic Description
-----------------

- judy: new, 1.0.5
    - strees-ng: enable stressor judy

Package(s) Affected
-------------------

- judy: 1.0.5
- stress-ng: 0.18.02-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit judy stress-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
