### PR TITLE
sof-tools: update to 2.10

### DIFF
--- a/app-multimedia/sof-tools/autobuild/patches/0001-tools-logger-convert-work-around-implicit-sign-conve.patch
+++ b/app-multimedia/sof-tools/autobuild/patches/0001-tools-logger-convert-work-around-implicit-sign-conve.patch
@@ -1,7 +1,7 @@
-From 47667a444403a85cebbabf8aeacd905bd949b6e7 Mon Sep 17 00:00:00 2001
-From: Henry Chen <henry.chen@oss.cipunited.com>
-Date: Fri, 19 Jul 2024 12:34:18 +0800
-Subject: [PATCH] tools/logger/convert: work around implicit sign conversion
+From 32d52128340162afb07e0d7b5c14dec5ca079584 Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Tue, 13 Aug 2024 12:45:26 +0800
+Subject: [PATCH] tools/logger/convert: work around implicit sign conversion 
  for mips64
 
 ---
@@ -9,12 +9,12 @@ Subject: [PATCH] tools/logger/convert: work around implicit sign conversion
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/logger/convert.c b/logger/convert.c
-index e393f828e..5e39ad35c 100644
+index 4e0a6cdc5..bbf69411f 100644
 --- a/logger/convert.c
 +++ b/logger/convert.c
 @@ -354,7 +354,7 @@ static inline void print_table_header(void)
  	if (global_config->time_precision >= 0) {
- 		const unsigned int ts_width = timestamp_width(global_config->time_precision);
+ 		const uint8_t ts_width = timestamp_width(global_config->time_precision);
  
 -		fprintf(out_fd, "%*s(us)%*s  ", -ts_width, " TIMESTAMP", ts_width, "DELTA");
 +		fprintf(out_fd, "%*s(us)%*s  ", -(int)ts_width, " TIMESTAMP", ts_width, "DELTA");
@@ -22,5 +22,5 @@ index e393f828e..5e39ad35c 100644
  
  	fprintf(out_fd, "%2s %-18s ", "C#", "COMPONENT");
 -- 
-2.45.2
+2.34.1
 

--- a/app-multimedia/sof-tools/spec
+++ b/app-multimedia/sof-tools/spec
@@ -1,5 +1,5 @@
-VER=2.8.1
+VER=2.10
 SRCS="git::commit=tags/v$VER::https://github.com/thesofproject/sof"
 CHKSUMS="SKIP"
 SUBDIR="sof-tools/tools"
-CHKUPDATE="anitya::id=246473"
+CHKUPDATE="anitya::id=373749"


### PR DESCRIPTION
Topic Description
-----------------

- sof-tools: update to 2.10
    - Update anitya id for the right project
    - Modify the patch for v2.10

Package(s) Affected
-------------------

- sof-tools: 2.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit sof-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
