### PR TITLE
zerotier-one: update to 1.14.0

### DIFF
--- a/app-network/zerotier-one/autobuild/build
+++ b/app-network/zerotier-one/autobuild/build
@@ -3,13 +3,7 @@ sed -e 's/sbin/bin/' \
     -i "$SRCDIR"/make-linux.mk \
     -i "$SRCDIR"/debian/zerotier-one.service
 
-# FIXME: I haven't found a way to compile it successfully in Autobuild without
-# turning on ZT_DEBUG. It may be related to some compiler flags but I'm not
-# sure which.
-#
-# Without ZT_DEBUG, I get errors about an undefined probestack symbol.
 abinfo "Making zerotier-one..."
-export ZT_DEBUG=1
 make
 
 abinfo "Installing zerotier-one..."

--- a/app-network/zerotier-one/autobuild/defines
+++ b/app-network/zerotier-one/autobuild/defines
@@ -1,9 +1,7 @@
 PKGNAME="zerotier-one"
-PKGDES="ZeroTier creates secure networks between on-premise, cloud, desktop, and mobile devices"
+PKGDES="A client for ZeroTier network virtualization service"
 PKGSEC=net
 PKGDEP="miniupnpc"
 BUILDDEP="llvm ronn cargo"
 
 USECLANG=1
-# FIXME: Causes bus error with LLVM 16.0.6.
-USECLANG__LOONGSON3=0

--- a/app-network/zerotier-one/autobuild/patches/0001-Update-dependencies.patch
+++ b/app-network/zerotier-one/autobuild/patches/0001-Update-dependencies.patch
@@ -1,0 +1,57 @@
+From a6afafead07d9b43c2066e6980833a963b5e0d76 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Tue, 13 Aug 2024 17:41:11 +0800
+Subject: [PATCH] Update dependencies
+
+- update 'time' crate to fix time-rs/time #681
+---
+ rustybits/Cargo.lock         | 8 ++++----
+ rustybits/zeroidc/Cargo.toml | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/rustybits/Cargo.lock b/rustybits/Cargo.lock
+index 1b01a0df3e12..09d9ced0cfc9 100644
+--- a/rustybits/Cargo.lock
++++ b/rustybits/Cargo.lock
+@@ -2855,9 +2855,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.34"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
+@@ -2876,9 +2876,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.17"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
+  "num-conv",
+  "time-core",
+diff --git a/rustybits/zeroidc/Cargo.toml b/rustybits/zeroidc/Cargo.toml
+index e38c80e690de..f10a133236aa 100644
+--- a/rustybits/zeroidc/Cargo.toml
++++ b/rustybits/zeroidc/Cargo.toml
+@@ -19,7 +19,7 @@ url = "2.3"
+ reqwest = "0.11"
+ jwt = { version = "0.16", git = "https://github.com/glimberg/rust-jwt" }
+ serde = "1.0"
+-time = { version = "~0.3", features = ["formatting"] }
++time = { version = "^0.3.35", features = ["formatting"] }
+ bytes = "1.3"
+ thiserror = "1"
+ tokio = { version = ">=1.24" }
+
+base-commit: 91e7ce87f09ac1cfdeaf6ff22c3cedcd93574c86
+-- 
+2.46.0
+

--- a/app-network/zerotier-one/spec
+++ b/app-network/zerotier-one/spec
@@ -1,5 +1,4 @@
-VER=1.12.2
-REL=2
+VER=1.14.0
 SRCS="git::commit=tags/$VER::https://github.com/zerotier/ZeroTierOne"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17578"


### PR DESCRIPTION
Topic Description
-----------------

- zerotier-one: update to 1.14.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- zerotier-one: 1.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit zerotier-one
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
