### PR TITLE
sqlite: update to 3.46.1

### DIFF
--- a/app-database/sqlite/spec
+++ b/app-database/sqlite/spec
@@ -1,4 +1,4 @@
-VER=3.45.1
+VER=3.46.1
 LOCAL_VER=3450100
 YEAR=2024
 SRCS="tbl::https://sqlite.org/$YEAR/sqlite-src-$LOCAL_VER.zip"


### PR DESCRIPTION
Topic Description
-----------------

- sqlite: update to 3.46.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- sqlite: 3.46.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sqlite
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
