### PR TITLE
qtcreator: update to 14.0.1

### DIFF
--- a/app-devel/qtcreator/spec
+++ b/app-devel/qtcreator/spec
@@ -1,4 +1,4 @@
-VER=14.0.0
+VER=14.0.1
 SRCS="tbl::https://download.qt.io/official_releases/qtcreator/${VER%.*}/$VER/qt-creator-opensource-src-$VER.tar.xz"
-CHKSUMS="sha256::f2fdcff9cb8ed7fd5cb1fc779352c7a7a942922788ca000de85db6dbd7a8d454"
+CHKSUMS="sha256::9595d2e6c65bb918e78376314341dc2bef491c3200a5c6d5ce6f305509b0b28b"
 CHKUPDATE="anitya::id=4136"


### PR DESCRIPTION
Topic Description
-----------------

- qtcreator: update to 14.0.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- qtcreator: 14.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qtcreator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
