### PR TITLE
exfatprogs: update to 1.2.5

### DIFF
--- a/app-admin/exfatprogs/spec
+++ b/app-admin/exfatprogs/spec
@@ -1,4 +1,4 @@
-VER=1.2.4
+VER=1.2.5
 SRCS="tbl::https://github.com/exfatprogs/exfatprogs/releases/download/$VER/exfatprogs-$VER.tar.xz"
-CHKSUMS="sha256::ad38126dfd9f74f8c6ecb35ddfd34d2582601d6c3ff26756610b8418360c8ee2"
+CHKSUMS="sha256::f27160dcc1ddd17c96cd41a6ceef7037adc2796ab5c5633d3d85cf532c3ee2f0"
 CHKUPDATE="anitya::id=94441"


### PR DESCRIPTION
Topic Description
-----------------

- exfatprogs: update to 1.2.5
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- exfatprogs: 1.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit exfatprogs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
