### PR TITLE
linux-kernel-lts: improve support for LoongArch old-world multiprocessor system

### DIFF
--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0001-lib-cpumask-Make-CPUMASK_OFFSTACK-usable-without-deb.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0001-lib-cpumask-Make-CPUMASK_OFFSTACK-usable-without-deb.patch
@@ -1,7 +1,7 @@
 From 5574d1a66d3cdd94ba2bb1f306bb8a7cd889b8e2 Mon Sep 17 00:00:00 2001
 From: Josh Boyer <jwboyer@fedoraproject.org>
 Date: Mon, 11 Nov 2013 08:39:16 -0500
-Subject: [PATCH 01/34] lib/cpumask: Make CPUMASK_OFFSTACK usable without debug
+Subject: [PATCH 01/36] lib/cpumask: Make CPUMASK_OFFSTACK usable without debug
  dependency
 
 When CPUMASK_OFFSTACK was added in 2008, it was dependent upon

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0002-input-kill-stupid-messages.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0002-input-kill-stupid-messages.patch
@@ -1,7 +1,7 @@
 From bd3ae85753504dbf88f15c1410cc144118d3e70d Mon Sep 17 00:00:00 2001
 From: "kernel-team@fedoraproject.org" <kernel-team@fedoraproject.org>
 Date: Thu, 29 Jul 2010 16:46:31 -0700
-Subject: [PATCH 02/34] input: kill stupid messages
+Subject: [PATCH 02/36] input: kill stupid messages
 
 Bugzilla: N/A
 Upstream-status: Fedora mustard

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0003-lis3-improve-handling-of-null-rate.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0003-lis3-improve-handling-of-null-rate.patch
@@ -1,7 +1,7 @@
 From a3269b3f15245b0092118c90eb45ddaa9046ca77 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=89ric=20Piel?= <eric.piel@tremplin-utc.net>
 Date: Thu, 3 Nov 2011 16:22:40 +0100
-Subject: [PATCH 03/34] lis3: improve handling of null rate
+Subject: [PATCH 03/36] lis3: improve handling of null rate
 
 When obtaining a rate of 0, we would disable the device supposely
 because it seems to behave incorectly. It actually only comes from the

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0004-Input-synaptics-pin-3-touches-when-the-firmware-repo.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0004-Input-synaptics-pin-3-touches-when-the-firmware-repo.patch
@@ -1,7 +1,7 @@
 From 77e770492017d69a9ee34811b4922b78b07bab3a Mon Sep 17 00:00:00 2001
 From: Benjamin Tissoires <benjamin.tissoires@redhat.com>
 Date: Thu, 16 Apr 2015 13:01:46 -0400
-Subject: [PATCH 04/34] Input - synaptics: pin 3 touches when the firmware
+Subject: [PATCH 04/36] Input - synaptics: pin 3 touches when the firmware
  reports 3 fingers
 
 Synaptics PS/2 touchpad can send only 2 touches in a report. They can

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0005-driver-sisfb-add-resolution-1368-768-for-loongson-ly.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0005-driver-sisfb-add-resolution-1368-768-for-loongson-ly.patch
@@ -1,7 +1,7 @@
 From 2b9234fe26acc476ab35e1766eabdafdea31a0ca Mon Sep 17 00:00:00 2001
 From: flygoat <flygoatfree@gmail.com>
 Date: Sun, 5 Mar 2017 20:33:17 +0800
-Subject: [PATCH 05/34] driver sisfb add resolution 1368*768 for loongson
+Subject: [PATCH 05/36] driver sisfb add resolution 1368*768 for loongson
  lynloong
 
 Ref: Contact the author.

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0006-Revert-video-output-Drop-display-output-class-suppor.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0006-Revert-video-output-Drop-display-output-class-suppor.patch
@@ -1,7 +1,7 @@
 From a990bc593c344d04c88dcc7a2606c8cd1faaa80b Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 7 Nov 2017 09:01:33 +0800
-Subject: [PATCH 06/34] Revert "video / output: Drop display output class
+Subject: [PATCH 06/36] Revert "video / output: Drop display output class
  support" This reverts commit f167a64e9d67ebd03d304e369c12011cf2bffaf5
  Required by some Loongson platform devices drivers
 

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0007-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0007-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
@@ -1,7 +1,7 @@
 From 23b9140a1d09fc21267ca685f2abc3fa806994e2 Mon Sep 17 00:00:00 2001
 From: Mark Weiman <mark.weiman@markzz.com>
 Date: Wed, 27 Jan 2021 13:28:09 -0500
-Subject: [PATCH 07/34] pci: Enable overrides for missing ACS capabilities
+Subject: [PATCH 07/36] pci: Enable overrides for missing ACS capabilities
  (5.10.11+)
 
 This an updated version of Alex Williamson's patch from:

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0008-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0008-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
 From 37fa8d433f9a50500605285a9676f2d5c7920829 Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux@gmail.com>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 08/34] usb: phy: tegra: Add 38.4MHz clock table entry
+Subject: [PATCH 08/36] usb: phy: tegra: Add 38.4MHz clock table entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to
 use the ehci phy on the Jetson TX1.

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0009-more-uarches-for-kernel.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0009-more-uarches-for-kernel.patch
@@ -1,7 +1,7 @@
 From 17cb162fd117b87350746620a846acd6c3c497dc Mon Sep 17 00:00:00 2001
 From: graysky <therealgraysky@proton.me>
 Date: Wed, 21 Feb 2024 08:38:13 -0500
-Subject: [PATCH 09/34] more uarches for kernel
+Subject: [PATCH 09/36] more uarches for kernel
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0010-MIPS-Loongson64-Disable-writecombine-for-Loongson-3A.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0010-MIPS-Loongson64-Disable-writecombine-for-Loongson-3A.patch
@@ -1,7 +1,7 @@
 From bed97487bd0e41596868c9a32773e3fe14a725aa Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Mon, 12 Oct 2020 13:32:23 +0800
-Subject: [PATCH 10/34] MIPS: Loongson64: Disable writecombine for Loongson-3A
+Subject: [PATCH 10/36] MIPS: Loongson64: Disable writecombine for Loongson-3A
  R1
 
 It breaks radeon.

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0011-platform-surface-hid.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0011-platform-surface-hid.patch
@@ -1,7 +1,7 @@
 From 36249bd5a85f479c9dcca272bdac49e8e95271e2 Mon Sep 17 00:00:00 2001
 From: qzed <qzed@users.noreply.github.com>
 Date: Tue, 17 Sep 2019 17:16:23 +0200
-Subject: [PATCH 11/34] platform: surface hid
+Subject: [PATCH 11/36] platform: surface hid
 
 Ref: https://github.com/linux-surface/kernel/commit/352b9fcff865d3d693675ba3add91b186f0beb97
 ---

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0012-loongson64-init-suppress-memcpy-out-of-bound-checkin.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0012-loongson64-init-suppress-memcpy-out-of-bound-checkin.patch
@@ -1,7 +1,7 @@
 From b8208e9589e3a6551c861e5514fe8061dac72420 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Wed, 24 Aug 2022 03:54:11 +0000
-Subject: [PATCH 12/34] loongson64/init: suppress memcpy out-of-bound checking
+Subject: [PATCH 12/36] loongson64/init: suppress memcpy out-of-bound checking
 
 Ref: Contact the author.
 ---

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0013-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0013-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
@@ -1,7 +1,7 @@
 From 6ad5352514f049445dd88cf82cba42496bc754a9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 13/34] arm64: dts: rockchip: change GMAC rx_delay for
+Subject: [PATCH 13/36] arm64: dts: rockchip: change GMAC rx_delay for
  RockPro64
 
 Ref: https://github.com/armbian/build/blob/42cc795f4d4ffed60f81fe64cbf96be39ae0783a/patch/kernel/archive/rockchip64-6.10/board-rockpro64-change-rx_delay-for-gmac.patch

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0014-arm64-dts-rockchip-add-out-of-band-IRQ-for-RK3399-Wi.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0014-arm64-dts-rockchip-add-out-of-band-IRQ-for-RK3399-Wi.patch
@@ -1,7 +1,7 @@
 From c048faec3a1b3843f5cbd2722ef31853067f72c1 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 30 Nov 2020 22:49:55 +0800
-Subject: [PATCH 14/34] arm64: dts: rockchip: add out-of-band IRQ for RK3399
+Subject: [PATCH 14/36] arm64: dts: rockchip: add out-of-band IRQ for RK3399
  Wi-Fi
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0015-arm64-rockchip-dts-rk3399-fix-PD-on-Pinebook-Pro.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0015-arm64-rockchip-dts-rk3399-fix-PD-on-Pinebook-Pro.patch
@@ -1,7 +1,7 @@
 From c4ac69b9f819ea07dbb12791d2a5c6308ac19f44 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Tue, 1 Dec 2020 16:19:04 +0800
-Subject: [PATCH 15/34] arm64: rockchip: dts: rk3399: fix PD on Pinebook Pro
+Subject: [PATCH 15/36] arm64: rockchip: dts: rk3399: fix PD on Pinebook Pro
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
 Ref: Contact the author.

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0016-HACK-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0016-HACK-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
 From 380c1ef8393628c3e5098518912ad71f9ff08c65 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Thu, 21 Apr 2022 11:36:35 +0800
-Subject: [PATCH 16/34] HACK: arm64: dts: rockchip: disable usb3 on quartz64
+Subject: [PATCH 16/36] HACK: arm64: dts: rockchip: disable usb3 on quartz64
 
 USB3 on Quartz64 is of bad quality because of sharing lines with SATA.
 

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0017-arm64-add-Kconfig-option-for-Phytium-SoCs.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0017-arm64-add-Kconfig-option-for-Phytium-SoCs.patch
@@ -1,7 +1,7 @@
 From 54b7d4ed4694f46d0f457623a6e58ec1cb559aac Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 25 Sep 2022 23:02:39 +0800
-Subject: [PATCH 17/34] arm64: add Kconfig option for Phytium SoCs
+Subject: [PATCH 17/36] arm64: add Kconfig option for Phytium SoCs
 
 This option works as a gate for Phytium-specific drivers.
 

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0018-net-stmmac-add-a-glue-driver-for-GMACs-in-Phytium-So.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0018-net-stmmac-add-a-glue-driver-for-GMACs-in-Phytium-So.patch
@@ -1,7 +1,7 @@
 From 5152d9ca1fbefe2c8ceb95ea9934404330567bc8 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 25 Sep 2022 23:03:51 +0800
-Subject: [PATCH 18/34] net: stmmac: add a glue driver for GMACs in Phytium
+Subject: [PATCH 18/36] net: stmmac: add a glue driver for GMACs in Phytium
  SoCs
 
 Multiple Phytium ARM64 SoCs feature DesignWare GMACs that is mostly

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0019-HID-logitech-dj-add-support-for-the-new-lightspeed-r.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0019-HID-logitech-dj-add-support-for-the-new-lightspeed-r.patch
@@ -1,7 +1,7 @@
 From f686ab99cf83a56fe81f520ea1bc124f69de6427 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Filipe=20La=C3=ADns?= <lains@riseup.net>
 Date: Sat, 23 Jan 2021 18:03:33 +0000
-Subject: [PATCH 19/34] HID: logitech-dj: add support for the new lightspeed
+Subject: [PATCH 19/36] HID: logitech-dj: add support for the new lightspeed
  receiver iteration
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0020-HACK-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0020-HACK-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
 From 4faf97b1f449f6b5aba39edfb11dc517a3493fa1 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 27 Jul 2023 11:13:25 -0400
-Subject: [PATCH 20/34] HACK arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 20/36] HACK arm64: drop hisi_ddrc_pmu driver
 
 Ref: Contact the author.
 ---

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0021-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0021-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
@@ -1,7 +1,7 @@
 From 5e94a35156751acd931cf2e626b38f01f7ad19c5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Wed, 21 Feb 2024 16:58:32 -0500
-Subject: [PATCH 21/34] arch/loongarch: add la_ow_syscall as in-tree module
+Subject: [PATCH 21/36] arch/loongarch: add la_ow_syscall as in-tree module
 
 Co-authored-By: Miao Wang <shankerwangmiao@gmail.com>
 Ref: Contact the author.

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0022-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0022-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
 From aa232219a9cc75f3579c4ad67d9cf2e5cb52f70c Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 22/34] la_ow_syscall: add kconfig for module
+Subject: [PATCH 22/36] la_ow_syscall: add kconfig for module
 
 Ref: Contact the author.
 ---

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0023-drm-Makefile-Move-tiny-drivers-before-native-drivers.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0023-drm-Makefile-Move-tiny-drivers-before-native-drivers.patch
@@ -1,7 +1,7 @@
 From 761254490da52cc2c4b8ea6299dd5bf9ddc85b6f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 7 Nov 2023 20:25:53 +0800
-Subject: [PATCH 23/34] drm/Makefile: Move tiny drivers before native drivers
+Subject: [PATCH 23/36] drm/Makefile: Move tiny drivers before native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from
 device_initcall to subsys_initcall_sync") some Lenovo laptops get a blank

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0024-loongarch-basic-boot-support-for-legacy-firmware.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0024-loongarch-basic-boot-support-for-legacy-firmware.patch
@@ -1,7 +1,7 @@
-From 082a15b38f461116eca66171eec297b4933ea1e1 Mon Sep 17 00:00:00 2001
+From 0b867b9443b02b62d0d82f3e584261c05ca33cb5 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
-Subject: [PATCH 25/34] loongarch: basic boot support for legacy firmware
+Subject: [PATCH 24/36] loongarch: basic boot support for legacy firmware
 
 The addresses passed from legacy firmware in efi system tables, the
 initrd table, the efi system memory mapping table are virtual addresses.
@@ -20,8 +20,6 @@ the legacy firmware by reading DMW1 CSR, as done in the legacy loongarch
 GRUB port. Only if legacy firmwares detected, this correction happens.
 
 With this patch, the linux kernel is basically able to boot.
-
-Ref: Contact the author.
 ---
  arch/loongarch/kernel/efi.c              | 18 ++++++++++++++++++
  arch/loongarch/kernel/mem.c              |  1 +
@@ -29,10 +27,10 @@ Ref: Contact the author.
  3 files changed, 37 insertions(+)
 
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index 3223da046a6d..ad01784699fb 100644
+index 9fc10cea21e1..201db70ac995 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
-@@ -92,6 +92,23 @@ static void __init init_screen_info(void)
+@@ -87,6 +87,23 @@ static void __init init_screen_info(void)
  	memblock_reserve(screen_info.lfb_base, screen_info.lfb_size);
  }
  
@@ -56,7 +54,7 @@ index 3223da046a6d..ad01784699fb 100644
  void __init efi_init(void)
  {
  	int size;
-@@ -115,6 +132,7 @@ void __init efi_init(void)
+@@ -110,6 +127,7 @@ void __init efi_init(void)
  
  	size = sizeof(efi_config_table_t);
  	config_tables = early_memremap(efi_config_table, efi_nr_tables * size);

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0025-loongarch-parse-BPI-data-and-add-memory-mapping.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0025-loongarch-parse-BPI-data-and-add-memory-mapping.patch
@@ -1,7 +1,7 @@
-From 89dbeb5a9a6aa5f7f60c6cb155d89c21a262b6a6 Mon Sep 17 00:00:00 2001
+From 4cc2627d49e432803da90bbfcac604285f2a74cf Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
-Subject: [PATCH 26/34] loongarch: parse BPI data and add memory mapping
+Subject: [PATCH 25/36] loongarch: parse BPI data and add memory mapping
 
 On legacy firmwares, the memory mapping information passed in the EFI
 system table is not enough to cover all the available memory regions,
@@ -17,8 +17,6 @@ discover all the available memory regions.
 
 With this patch, machines with legacy firmware, with the BPI version
 BPI01001, i.e. the newer version, can boot normally.
-
-Ref: Contact the author.
 ---
  arch/loongarch/kernel/Makefile      |   2 +
  arch/loongarch/kernel/efi.c         |   3 +
@@ -43,7 +41,7 @@ index 4fcc168f0732..2b4bfdefe623 100644
 +
 +obj-y				+= legacy_boot.o
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index ad01784699fb..2645cc0d2c43 100644
+index 201db70ac995..e5e95c150667 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
 @@ -25,6 +25,8 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0026-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0026-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,7 +1,7 @@
-From be58cef39b8f6bcdb477dbe2507763c6542de0ba Mon Sep 17 00:00:00 2001
+From 3004c1c0e4c5e8a0a43fd34ee450cf4730f46838 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
-Subject: [PATCH 27/34] loongarch: add MADT ACPI table conversion
+Subject: [PATCH 26/36] loongarch: add MADT ACPI table conversion
 
 On machines with legacy firmware with BPI version BPI01000, i.e. the
 older version, the content of the MADT ACPI table is not following the
@@ -10,14 +10,12 @@ this patch. Also the patch generates and adds a MCFG table accordingly.
 
 The above behavior is only enabled when BPI data and the BPI01000 version
 is detected.
-
-Ref: Contact the author.
 ---
  arch/loongarch/include/asm/acpi.h   |   5 +
- arch/loongarch/kernel/legacy_boot.c | 301 ++++++++++++++++++++++++++++
+ arch/loongarch/kernel/legacy_boot.c | 304 ++++++++++++++++++++++++++++
  drivers/acpi/tables.c               |   2 +
  include/linux/acpi.h                |  10 +
- 4 files changed, 318 insertions(+)
+ 4 files changed, 321 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
 index 49e29b29996f..473d86523b03 100644
@@ -36,7 +34,7 @@ index 49e29b29996f..473d86523b03 100644
  
  #define ACPI_TABLE_UPGRADE_MAX_PHYS ARCH_LOW_ADDRESS_LIMIT
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 30c01c8b22a0..367f9ee7e315 100644
+index 30c01c8b22a0..841d8db85a3c 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -1,7 +1,13 @@
@@ -82,7 +80,7 @@ index 30c01c8b22a0..367f9ee7e315 100644
  		}
  		unsigned long bpi_extlist = tbl->extlist;
  		parse_bpi_ext_list(bpi_extlist);
-@@ -292,6 +306,293 @@ void __init bpi_init_node_memblock(void (*p_add_numamem_region)(u64 start, u64 e
+@@ -292,6 +306,296 @@ void __init bpi_init_node_memblock(void (*p_add_numamem_region)(u64 start, u64 e
  	}
  }
  
@@ -135,6 +133,7 @@ index 30c01c8b22a0..367f9ee7e315 100644
 +	int entry_count = 0;
 +	int local_apic_count = 0;
 +	int io_apic_count = 0;
++	u64 node_map = 0;
 +	while((void *)entry < madt_end) {
 +		unsigned int ent_len = entry->length;
 +		if (ent_len < sizeof(struct acpi_subtable_header)) {
@@ -148,6 +147,8 @@ index 30c01c8b22a0..367f9ee7e315 100644
 +		switch(entry->type) {
 +		case ACPI_MADT_TYPE_LOCAL_APIC:
 +			local_apic_count++;
++			struct acpi_madt_local_apic *lapic = (struct acpi_madt_local_apic *)entry;
++			node_map |= 1 << (lapic->id / CORES_PER_EIO_NODE);
 +			break;
 +		case ACPI_MADT_TYPE_IO_APIC:
 +			io_apic_count++;
@@ -268,10 +269,10 @@ index 30c01c8b22a0..367f9ee7e315 100644
 +			eio_pics[eio_idx].cascade = 3 + eio_idx;
 +			eio_pics[eio_idx].node = ioapic->id;
 +			if(eio_idx == 0){
-+				eio_pics[eio_idx].node_map = 1;
++				eio_pics[eio_idx].node_map = node_map;
 +			}else{
-+				eio_pics[0].node_map = 0x1DF;
-+				eio_pics[eio_idx].node_map = 0xFE20;
++				eio_pics[0].node_map = node_map & 0x0f0f0f0f0f0f0f0full;
++				eio_pics[eio_idx].node_map = node_map & 0xf0f0f0f0f0f0f0f0ull;
 +			}
 +
 +			unsigned long addr = ioapic->address;
@@ -296,7 +297,7 @@ index 30c01c8b22a0..367f9ee7e315 100644
 +			bio_pics[eio_idx].id = ioapic->id;
 +			bio_pics[eio_idx].gsi_base = ioapic->global_irq_base;
 +
-+			mcfg_entry->address = mcfg_addr_init(eio_idx);
++			mcfg_entry->address = mcfg_addr_init(ioapic->id);
 +			mcfg_entry->pci_segment = eio_idx;
 +			mcfg_entry->start_bus_number = 0;
 +			mcfg_entry->end_bus_number = 0xFF; // Who knows?

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0027-loongarch-correct-missing-offset-of-PCI-root-control.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0027-loongarch-correct-missing-offset-of-PCI-root-control.patch
@@ -1,7 +1,7 @@
-From 9dcfe5710fada9ee370e138599cdbb48c9c98561 Mon Sep 17 00:00:00 2001
+From 16e42bfc4acbb80d4a4d18426c167f4396d3971c Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
-Subject: [PATCH 28/34] loongarch: correct missing offset of PCI root
+Subject: [PATCH 27/36] loongarch: correct missing offset of PCI root
  controller in DSDT table
 
 On machines with legacy firmware with BPI version BPI01000, the PCI root
@@ -20,8 +20,6 @@ nearest page starting.
 
 The above behavior is only enabled when BPI data and the BPI01000 version
 is detected.
-
-Ref: Contact the author.
 ---
  arch/loongarch/include/asm/acpi.h   |  2 ++
  arch/loongarch/kernel/legacy_boot.c | 23 ++++++++++++++++++++++-
@@ -43,7 +41,7 @@ index 473d86523b03..ecf05448fe9d 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 367f9ee7e315..f5a90d1bad3d 100644
+index 841d8db85a3c..7043bfd0399d 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -60,7 +60,7 @@ struct loongarch_bpi_info __initdata loongarch_bpi_info = {
@@ -55,7 +53,7 @@ index 367f9ee7e315..f5a90d1bad3d 100644
  static u64 __initdata bpi_flags = 0;
  
  static int have_bpi = 0;
-@@ -593,6 +593,27 @@ void acpi_arch_os_table_override (struct acpi_table_header *existing_table, stru
+@@ -596,6 +596,27 @@ void acpi_arch_os_table_override (struct acpi_table_header *existing_table, stru
  	}
  }
  

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0028-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0028-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,7 +1,7 @@
-From be979a8cd61a31fba9b4ad4d4f3f51fb66875c48 Mon Sep 17 00:00:00 2001
+From a7b1c9330f4b2824a1cb53e4921a81a45822e47f Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
-Subject: [PATCH 29/34] loongarch: fix missing dependency info in DSDT
+Subject: [PATCH 28/36] loongarch: fix missing dependency info in DSDT
 
 On machines with legacy firmware with BPI01000 version, the devices on
 the LIO bus lackes the dependency on the PCI root controller, causing
@@ -19,8 +19,6 @@ Thus, this patch will be improved to include more devices.
 
 The above behavior is only enabled when BPI data and the BPI01000 version
 is detected.
-
-Ref: Contact the author.
 ---
  arch/loongarch/include/asm/acpi.h   |  2 ++
  arch/loongarch/kernel/legacy_boot.c | 47 +++++++++++++++++++++++++++++
@@ -42,10 +40,10 @@ index ecf05448fe9d..915cb0a2c239 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index f5a90d1bad3d..48c13e1ad220 100644
+index 7043bfd0399d..3ec69ffd8b94 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
-@@ -614,6 +614,53 @@ void acpi_arch_pci_probe_root_dev_filter(struct resource_entry *entry)
+@@ -617,6 +617,53 @@ void acpi_arch_pci_probe_root_dev_filter(struct resource_entry *entry)
  	}
  }
  

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0029-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0029-loongarch-fix-DMA-address-offset.patch
@@ -1,0 +1,90 @@
+From 7e1678800e847c30de872e5144bbff1e063ccd3e Mon Sep 17 00:00:00 2001
+From: Miao Wang <shankerwangmiao@gmail.com>
+Date: Tue, 13 Aug 2024 16:05:28 +0800
+Subject: [PATCH 29/36] loongarch: fix DMA address offset
+
+Loongarch CPUs are using HT bus interface, which is only 40-bit wide,
+to communicate with the bridge chipset. However, the actual memory
+bus of the CPUs is 48-bit wide, and the available address space of DMA
+requests of PCI devices is also larger than the 40-bit address space.
+The address space of loongarch systems is not continuous, the bits
+[47:44] of which are used to denote the belonging node id, which is
+far beyond the space provided by the 40-bit wide HT bus. As a result,
+a translation on the both LS7A and CPU sides is needed.
+
+The translation happens on the LS7A side is controlled by the higher
+half of the register, HT_ROUTE. Bits [12:8] denotes dma_node_id_offset
+and bits[15:13] denotes dma_node_id_offset_mapped. The behavior of the
+translation is that the chip extracts the node id from bit
+dma_node_id_offset + 36 of a DMA address, places it at bit
+dma_node_id_offset_mapped + 32, and generates the address on the HT bus.
+On the CPU side, an alike translation happens, to convert the address on
+the HT bus back to a proper memory address.
+
+On machines with legacy firmware with BPI01000 version,
+dma_node_id_offset is configured with 0, resulting the address which
+should be used by the DMA engine of a PCI device differs from the
+actural physical memeory address, which requires a pair of arch-specific
+phys_to_dma and dma_to_phys functions or setting up the whole mapping
+in the _DMA method of the PCI root device in the DSDT table.
+
+The former method requires we add back the prevoiusly removed functions,
+and the latter method degrades the performance since when the
+translation happens, the mapping table is scanned linearly.
+
+This patch addresses this issue by directly setting dma_node_id_offset
+to 8, like what is done by modern firmwares, making the address used by
+the DMA engine just the same as the actual physical memory address, and
+eliminating the need of DMA address translation on the kernel side.
+---
+ arch/loongarch/kernel/legacy_boot.c | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
+index 3ec69ffd8b94..2888e2b9fb45 100644
+--- a/arch/loongarch/kernel/legacy_boot.c
++++ b/arch/loongarch/kernel/legacy_boot.c
+@@ -46,6 +46,19 @@ enum bpi_mem_type {
+ #define MSI_MSG_ADDRESS		0x2FF00000
+ #define MSI_MSG_DEFAULT_COUNT	0xC0
+ 
++/*
++  ``This should be configured by firmware"
++    -- Section 4, Page 25 of Loongson-7A1000 User Manual v2.0
++  but unable to figure out the exact value.
++  The manual gives a typical value in Table 3.2, Page 23.
++*/
++#define LS7A_CHIPCFG_REG_OFF	0x00010000
++
++/* Section 4.1, Page 26 of Loongson-7A1000 User Manual v2.0 */
++#define LS7A_DMA_CFG_OFF	0x041c
++#define LS7A_DMA_NODE_ID_OFFSET_SHF	8
++#define LS7A_DMA_NODE_ID_OFFSET_MASK	GENMASK(12, 8)
++
+ struct loongarch_bpi_mem_map {
+ 	struct	loongarch_bpi_ext_hdr header;	/*{"M", "E", "M"}*/
+ 	u8	map_count;
+@@ -588,6 +601,20 @@ static void __init init_acpi_arch_os_table_override (struct acpi_table_header *e
+ 	new_madt->header.checksum = 0 - ext_listhdr_checksum((u8 *)new_madt, new_madt_size);
+ 	new_mcfg->header.checksum = 0 - ext_listhdr_checksum((u8 *)new_mcfg, new_mcfg_size);
+ 	*new_table = (struct acpi_table_header *)new_madt;
++
++	// Override LS7A dma_node_id_offset
++	for(int i = 0; i < io_apic_count; i++){
++		u64 ls7a_base_addr = bio_pics[i].address;
++		void __iomem *dma_node_id_addr = (void __iomem *) TO_UNCACHE(ls7a_base_addr + LS7A_CHIPCFG_REG_OFF + LS7A_DMA_CFG_OFF);
++		u32 dma_cfg = readl(dma_node_id_addr);
++		u32 dma_node_id_offset = (dma_cfg & LS7A_DMA_NODE_ID_OFFSET_MASK) >> LS7A_DMA_NODE_ID_OFFSET_SHF;
++		if(dma_node_id_offset != 8){
++			pr_info("BPI: LS7A %d DMA node id offset is %d, will set to 8\n", i, dma_node_id_offset);
++			dma_cfg &= ~LS7A_DMA_NODE_ID_OFFSET_MASK;
++			dma_cfg |= 8 << LS7A_DMA_NODE_ID_OFFSET_SHF;
++			writel(dma_cfg, dma_node_id_addr);
++		}
++	}
+ }
+ 
+ void acpi_arch_os_table_override (struct acpi_table_header *existing_table, struct acpi_table_header **new_table){
+-- 
+2.46.0
+

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0030-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0030-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,0 +1,62 @@
+From 48c518112dd1b22c53da204c6674b8a2d3d64720 Mon Sep 17 00:00:00 2001
+From: Miao Wang <shankerwangmiao@gmail.com>
+Date: Tue, 13 Aug 2024 22:33:01 +0800
+Subject: [PATCH 30/36] loongarch: fix HT_RX_INT_TRANS register
+
+On machines with legacy firmware with BPI01000 version, the
+HT_RX_INT_TRANS register on the node 5, i.e. the node connected with the
+second LS7A bridge chip, is not initialized correctly, causing the
+failure of the delivery of interrupts from PCIe devices connected to the
+second LS7A bridge chip.
+
+This patch fixes this by correctly pointing the HT_RX_INT_TRANS register
+to the EXT_IOI_SEND_OFF register on the corresponding node.
+---
+ arch/loongarch/kernel/legacy_boot.c | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
+index 2888e2b9fb45..204b33109f37 100644
+--- a/arch/loongarch/kernel/legacy_boot.c
++++ b/arch/loongarch/kernel/legacy_boot.c
+@@ -59,6 +59,16 @@ enum bpi_mem_type {
+ #define LS7A_DMA_NODE_ID_OFFSET_SHF	8
+ #define LS7A_DMA_NODE_ID_OFFSET_MASK	GENMASK(12, 8)
+ 
++/* Section 14.4.1, Page 100 of Loongson-3A5000 User Manual v1.03 */
++#define HT_CTRL_CFG_OFF		0xfdfb000000ull
++/* Section 14.5.34, Page 141 of Loongson-3A5000 User Manual v1.03 */
++#define HT_CTRL_HT_RX_INT_TRANS_LO_OFF	0x270
++#define HT_CTRL_HT_RX_INT_TRANS_HI_OFF	0x274
++#define HT_CTRL_HT_RX_INT_TRANS_INT_TRANS_ALLOW BIT(30)
++
++/* Section 11.2.3, Page 61 of Loongson-3A5000 User Manual v1.03 */
++#define EXT_IOI_SEND_OFF	0x1140
++
+ struct loongarch_bpi_mem_map {
+ 	struct	loongarch_bpi_ext_hdr header;	/*{"M", "E", "M"}*/
+ 	u8	map_count;
+@@ -615,6 +625,20 @@ static void __init init_acpi_arch_os_table_override (struct acpi_table_header *e
+ 			writel(dma_cfg, dma_node_id_addr);
+ 		}
+ 	}
++
++	// Override HT_RX_INT_TRANS
++	for(int i = 0; i < io_apic_count; i++){
++		unsigned int node = eio_pics[i].node;
++		void __iomem *ht_rx_int_trans_hi = (void __iomem *) TO_UNCACHE(nid_to_addrbase(node) + HT1LO_OFFSET + HT_CTRL_CFG_OFF + HT_CTRL_HT_RX_INT_TRANS_HI_OFF);
++		void __iomem *ht_rx_int_trans_lo = (void __iomem *) TO_UNCACHE(nid_to_addrbase(node) + HT1LO_OFFSET + HT_CTRL_CFG_OFF + HT_CTRL_HT_RX_INT_TRANS_LO_OFF);
++		u64 ext_ioi_addr = nid_to_addrbase(node) + LOONGSON_REG_BASE + EXT_IOI_SEND_OFF;
++		u64 ht_rx_int_trans_cfg_orig = ((u64)readl(ht_rx_int_trans_hi) << 32) | readl(ht_rx_int_trans_lo);
++		u32 ht_rx_int_trans_cfg_hi = HT_CTRL_HT_RX_INT_TRANS_INT_TRANS_ALLOW | (ext_ioi_addr >> 32);
++		u32 ht_rx_int_trans_cfg_lo = ext_ioi_addr & GENMASK(31, 0);
++		pr_info("BPI: HT controller on node %u RX_INT_TRANS is 0x%llx, will set to 0x%llx\n", node, ht_rx_int_trans_cfg_orig, ((u64)ht_rx_int_trans_cfg_hi << 32) | ht_rx_int_trans_cfg_lo);
++		writel(ht_rx_int_trans_cfg_hi, ht_rx_int_trans_hi);
++		writel(ht_rx_int_trans_cfg_lo, ht_rx_int_trans_lo);
++	}
+ }
+ 
+ void acpi_arch_os_table_override (struct acpi_table_header *existing_table, struct acpi_table_header **new_table){
+-- 
+2.46.0
+

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0031-loongarch-reset-use-general-efi-poweroff.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0031-loongarch-reset-use-general-efi-poweroff.patch
@@ -1,7 +1,7 @@
-From 3b2d4b039595ac500e809e4ed98c8dd9e5c24d9a Mon Sep 17 00:00:00 2001
+From dec9d41105f56232dce43b37550f6d9715820b35 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Fri, 26 Jul 2024 17:17:53 +0800
-Subject: [PATCH 24/34] loongarch/reset: use general efi poweroff
+Subject: [PATCH 31/36] loongarch/reset: use general efi poweroff
 
 Currently efi_shutdown_init can register a general sys_off handler,
 efi_power_off, which will be called during do_kernel_power_off and shut
@@ -17,10 +17,10 @@ Ref: Contact the author.
  2 files changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index 9fc10cea21e1..3223da046a6d 100644
+index e5e95c150667..2645cc0d2c43 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
-@@ -68,6 +68,11 @@ void __init efi_runtime_init(void)
+@@ -71,6 +71,11 @@ void __init efi_runtime_init(void)
  
  unsigned long __initdata screen_info_table = EFI_INVALID_TABLE_ADDR;
  

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0032-irqchip-loongarch-cpu-Fix-return-value-of-lpic_gsi_t.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0032-irqchip-loongarch-cpu-Fix-return-value-of-lpic_gsi_t.patch
@@ -1,7 +1,7 @@
-From ba2ae8eff4dc757ce556160430f0b8c1508ea1f5 Mon Sep 17 00:00:00 2001
+From 5eabfd655a00941f16862c72b3c859c0cf11a126 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 23 Jul 2024 14:45:08 +0800
-Subject: [PATCH 30/34] irqchip/loongarch-cpu: Fix return value of
+Subject: [PATCH 32/36] irqchip/loongarch-cpu: Fix return value of
  lpic_gsi_to_irq()
 
 lpic_gsi_to_irq() should return a valid irq if acpi_register_gsi()

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0033-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0033-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
@@ -1,7 +1,7 @@
-From f2e79ada85dc59175fdf12e9f1ab523b84cb2535 Mon Sep 17 00:00:00 2001
+From e2c30f3686c8bd394f41600eeb5b349e06226440 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
-Subject: [PATCH 31/34] [LOONGARCH64] drivers/firmware: Move sysfb_init() from
+Subject: [PATCH 33/36] [LOONGARCH64] drivers/firmware: Move sysfb_init() from
  device_initcall to fs_initcall
 
 Consider a configuration like this:

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0034-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0034-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
@@ -1,7 +1,7 @@
-From f5bf736dd8a6fd711605fad9017f46cabf7f2302 Mon Sep 17 00:00:00 2001
+From fa0eab509e6bc7c842b6fadf679c75275494affc Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 32/34] [LOONGARCH64] drm/radeon: Workaround radeon driver bug
+Subject: [PATCH 34/36] [LOONGARCH64] drm/radeon: Workaround radeon driver bug
  for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0035-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0035-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
@@ -1,7 +1,7 @@
-From 70073ea3167b01dcc054bab2ce1107171431d7b4 Mon Sep 17 00:00:00 2001
+From 4ad8f0146edcfba9a257167998de1d6c5fca57c5 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 14:28:02 +0800
-Subject: [PATCH 33/34] [LOONGARCH64] drm/radeon: Call mmiowb() at the end of
+Subject: [PATCH 35/36] [LOONGARCH64] drm/radeon: Call mmiowb() at the end of
  radeon_ring_commit()
 
 Commit fb24ea52f78e0d595852e ("drivers: Remove explicit invocations of

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0036-LOONGARCH64-HACK-drm-amdgpu-disable-DPM-in-auto-mode.patch.loongarch64
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0036-LOONGARCH64-HACK-drm-amdgpu-disable-DPM-in-auto-mode.patch.loongarch64
@@ -1,7 +1,7 @@
-From d4e630cf9207679fe3d4ce358f59544a9b44fc4f Mon Sep 17 00:00:00 2001
+From 5a0b1e7a839e1d75d040c649dca3f0dd47a53037 Mon Sep 17 00:00:00 2001
 From: Cyan <cyanoxygen@aosc.io>
 Date: Wed, 10 Apr 2024 16:44:01 +0800
-Subject: [PATCH 34/34] [LOONGARCH64] HACK(drm/amdgpu): disable DPM in auto
+Subject: [PATCH 36/36] [LOONGARCH64] HACK(drm/amdgpu): disable DPM in auto
  mode for Polaris
 
 Ref: Contact the author.

--- a/runtime-kernel/linux-kernel-lts/spec
+++ b/runtime-kernel/linux-kernel-lts/spec
@@ -1,4 +1,5 @@
 VER=6.6.45
+REL=1
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v${VER:0:1}.x/linux-${VER/.0/}.tar.xz"
 CHKSUMS="sha256::121bed240767e4a0959c1609e78eeaaf3e0620d9d1a5ed1f6e36bdf609c4f179"
 CHKUPDATE="anitya::id=6501"


### PR DESCRIPTION
Topic Description
-----------------

- linux-kernel-lts: (loongarch64) improve old-world support on multiprocessor systems

Package(s) Affected
-------------------

- linux-kernel-lts-6.6.45: 6.6.45-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel-lts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
