### PR TITLE
gajim: drop, orphaned

### DIFF
--- a/app-web/gajim/autobuild/defines
+++ b/app-web/gajim/autobuild/defines
@@ -1,9 +1,0 @@
-PKGNAME=gajim
-PKGSEC=net
-PKGDEP="ca-certs dbus-python desktop-file-utils docutils gtkspell gupnp-igd ldns nbxmpp \
-        notification-daemon pycryptodome pygtk keyring css-parser gtksourceview-4"
-BUILDDEP="intltool"
-PKGDES="A fully featured and easy to use Jabber client"
-
-NOPYTHON2=1
-ABHOST=noarch

--- a/app-web/gajim/spec
+++ b/app-web/gajim/spec
@@ -1,4 +1,0 @@
-VER=1.4.0
-SRCS="tbl::https://gajim.org/downloads/${VER:0:3}/gajim-$VER.tar.gz"
-CHKSUMS="sha256::2db26fb0359f80e8d9f03116b2927f7947d873ebc950cc563195c3f22e56936c"
-CHKUPDATE="anitya::id=870"

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -322,10 +322,8 @@ runtime-multimedia/portmidi
 lang-python/pygame
 app-multimedia/frescobaldi
 lang-python/precis-i18n
-lang-python/nbxmpp
 lang-python/pygobject-2
 desktop-gnome/gupnp-igd
-app-web/gajim
 lang-python/pyenchant
 app-multimedia/gaupol
 desktop-gnome/glade

--- a/lang-python/nbxmpp/autobuild/defines
+++ b/lang-python/nbxmpp/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=nbxmpp
-PKGSEC=python
-PKGDEP="idna libsoup precis-i18n pygobject-3"
-BUILDDEP="setuptools"
-PKGDES="A Python library for using Jabber/XMPP networks"
-
-ABHOST=noarch
-NOPYTHON2=1

--- a/lang-python/nbxmpp/spec
+++ b/lang-python/nbxmpp/spec
@@ -1,4 +1,0 @@
-VER=3.1.0
-SRCS="tbl::https://pypi.io/packages/source/n/nbxmpp/nbxmpp-$VER.tar.gz"
-CHKSUMS="sha256::d236a76500142f445ba03b42a4e76deea5a688646d1c3be1f1d185fc40026230"
-CHKUPDATE="anitya::id=108291"


### PR DESCRIPTION
Topic Description
-----------------

- groups/py3-rebuild: drop nbxmpp, gajim
- nbxmpp: drop, orphaned
- gajim: drop, orphaned

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit gajim nbxmpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
