### PR TITLE
udiskie: update to 2.5.3

### DIFF
--- a/app-utils/udiskie/autobuild/build
+++ b/app-utils/udiskie/autobuild/build
@@ -1,0 +1,18 @@
+abinfo "Building udiskie ..."
+python3 "$SRCDIR"/setup.py build
+make -C doc
+
+abinfo "Installing udiskie ..."
+python3 "$SRCDIR"/setup.py install \
+        --root="$PKGDIR" \
+        --optimize=1 \
+        --skip-build
+
+abinfo "Installing License ..."
+install -m 0644 -D "$SRCDIR"/doc/udiskie.8 \
+    "$PKGDIR"/usr/share/man/man8/udiskie.8
+install -Dm644 "$SRCDIR"/COPYING \
+    "$PKGDIR"/usr/share/licenses/udiskie/LICENSE
+install -dm755 "$PKGDIR"/usr/share/zsh/site-functions
+install -m644 "$SRCDIR"/completions/zsh/* \
+    "$PKGDIR"/usr/share/zsh/site-functions

--- a/app-utils/udiskie/autobuild/defines
+++ b/app-utils/udiskie/autobuild/defines
@@ -4,6 +4,5 @@ PKGDES="A GUI frontend for UDisks-2"
 PKGDEP="python-3 docopt libappindicator pyyaml pygobject-3 libnotify udisks-2 polkit systemd python-keyutils"
 BUILDDEP="asciidoc"
 
-ABTYPE=python
 NOPYTHON2=1
 ABHOST=noarch

--- a/app-utils/udiskie/spec
+++ b/app-utils/udiskie/spec
@@ -1,5 +1,4 @@
-VER=2.2.0
-SRCS="tbl::https://github.com/coldfix/udiskie/archive/${VER}.tar.gz"
-CHKSUMS="sha256::1041bdf33e64371a68fe40ff242a7010244f4e90021cdd1435fd62ad1c5fcc50"
+VER=2.5.3
+SRCS="git::commit=tags/v$VER::https://github.com/coldfix/udiskie"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7187"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- udiskie: install manpage and license
- udiskie: update to 2.5.3

Package(s) Affected
-------------------

- udiskie: 2.5.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit udiskie
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
