### PR TITLE
depthcharge-tools: new, 0.6.2

### DIFF
--- a/app-admin/depthcharge-tools/autobuild/beyond
+++ b/app-admin/depthcharge-tools/autobuild/beyond
@@ -1,0 +1,14 @@
+abinfo "Generating man pages ..."
+mkdir -pv "$PKGDIR"/usr/share/man/man1
+for i in mkdepthcharge depthchargectl; do
+	rst2man $i.rst > $i.1
+	cp -v $i.1 "$PKGDIR"/usr/share/man/man1/
+done
+
+abinfo "Installing blessing systemd unit ..."
+mkdir -pv "$PKGDIR"/usr/lib/systemd/system
+cp -v "$SRCDIR"/systemd/depthchargectl-bless.service "$PKGDIR"/usr/lib/systemd/system/
+
+abinfo "Installing bash completion files ..."
+mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions/
+cp -v "$SRCDIR"/completions/*.bash "$PKGDIR"/usr/share/bash-completion/completions/

--- a/app-admin/depthcharge-tools/autobuild/defines
+++ b/app-admin/depthcharge-tools/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=depthcharge-tools
+PKGDES="Tools to manage the Chrome OS bootloader, depthcharge"
+PKGDEP="vboot-utils uboot-tools dtc lz4 xz"
+PKGRECOM="gzip bzip2 lzop zstd"
+PKGSEC=admin
+BUILDDEP="docutils"
+
+ABTYPE=python
+NOPYTHON2=1
+
+ABHOST=noarch

--- a/app-admin/depthcharge-tools/spec
+++ b/app-admin/depthcharge-tools/spec
@@ -1,0 +1,3 @@
+VER=0.6.2
+SRCS="git::commit=tags/v${VER}::https://github.com/alpernebbi/depthcharge-tools.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- depthcharge-tools: new, 0.6.2
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- depthcharge-tools: 0.6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit depthcharge-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
