### PR TITLE
podman: update to 5.2.1+vsock0.7.4

### DIFF
--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=5.2.0
+UPSTREAM_VER=5.2.1
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile
@@ -7,7 +7,7 @@ GVISOR_TAP_VSOCK_VER=0.7.4
 VER=${UPSTREAM_VER}+vsock${GVISOR_TAP_VSOCK_VER}
 SRCS="tbl::https://github.com/containers/podman/archive/v${UPSTREAM_VER}.tar.gz \
       git::commit=tags/v${GVISOR_TAP_VSOCK_VER};rename=gvisor-tap-vsock::https://github.com/containers/gvisor-tap-vsock"
-CHKSUMS="sha256::d2362700314fdb23baf6c021e73755655294f0e7b21e29c2d6798973cb08d5bb \
+CHKSUMS="sha256::650b951b8920d01cbaed18dfc3a12af2db621a840d664d36983b521aff4af7cf \
          SKIP"
 CHKUPDATE="anitya::id=93284"
 SUBDIR="podman-$UPSTREAM_VER"


### PR DESCRIPTION
Topic Description
-----------------

- podman: update to 5.2.1+vsock0.7.4
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- podman: 5.2.1+vsock0.7.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
