### PR TITLE
Racket: use racket to build racket instead of using prebuilt portable bytecode files

### DIFF
--- a/lang-lisp/racket/autobuild/defines
+++ b/lang-lisp/racket/autobuild/defines
@@ -1,16 +1,12 @@
 PKGNAME=racket
 PKGSEC=devel
 PKGDEP="gtk-3 libffi"
-BUILDDEP="ncurses lz4 urw-fonts"
+BUILDDEP="ncurses lz4 urw-fonts racket"
 PKGDES="A full-spectrum programming language"
 
 RECONF=0
 
-AUTOTOOLS_AFTER__PPC64EL="--enable-pb --enable-mach=tpb64l"
-AUTOTOOLS_AFTER__LOONGSON3="--enable-pb --enable-mach=pb64l"
-AUTOTOOLS_AFTER__LOONGARCH64="--enable-pb --enable-mach=pb64l"
+AUTOTOOLS_AFTER="--enable-racket=/usr/bin/racket"
 
-# FIXME: FTBFS on mips64r6el, illegal instruction
-FAIL_ARCH="mips64r6el"
-# If fixed, uncomment the following building options
-# AUTOTOOLS_AFTER__MIPS64R6EL="--enable-pb --enable-mach=pb64l"
+AUTOTOOLS_AFTER__PPC64EL="${AUTOTOOLS_AFTER} --enable-mach=tpb64l"
+AUTOTOOLS_AFTER__LOONGSON3="${AUTOTOOLS_AFTER} --enable-mach=pb64l"

--- a/lang-lisp/racket/autobuild/defines.stage2
+++ b/lang-lisp/racket/autobuild/defines.stage2
@@ -1,0 +1,10 @@
+PKGNAME=racket
+PKGSEC=devel
+PKGDEP="gtk-3 libffi"
+BUILDDEP="ncurses lz4 urw-fonts"
+PKGDES="A full-spectrum programming language"
+
+RECONF=0
+
+AUTOTOOLS_AFTER__PPC64EL="--enable-pb --enable-mach=tpb64l"
+AUTOTOOLS_AFTER__LOONGSON3="--enable-pb --enable-mach=pb64l"

--- a/lang-lisp/racket/spec
+++ b/lang-lisp/racket/spec
@@ -1,4 +1,5 @@
 VER=8.13
+REL=1
 SRCS="tbl::https://mirror.racket-lang.org/installers/$VER/racket-$VER-src.tgz"
 SUBDIR="racket-$VER/src"
 CHKSUMS="sha256::001e04920440b6589cf62d5677d18cc2ff6ae8fbaf77e63b8a8cf20890685fbc"


### PR DESCRIPTION
Topic Description
-----------------

- racket: use racket to build racket instead of using prebuilt portable bytecode files
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- racket: 8.13-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit racket
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
