### PR TITLE
intel-ucode: update to 20240813

### DIFF
--- a/runtime-data/intel-ucode/spec
+++ b/runtime-data/intel-ucode/spec
@@ -1,4 +1,4 @@
-VER=20240531
-SRCS="tbl::https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/microcode-$VER.tar.gz"
-CHKSUMS="sha256::c29eb35fdbd39e3ed8587e6f0b1275cc03265f230c2fcaf88e2a1556451e773f"
+VER=20240813
+SRCS="git::commit=tags/microcode-${VER}::https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20614"


### PR DESCRIPTION
Topic Description
-----------------

- intel-ucode: update to 20240813

Package(s) Affected
-------------------

- intel-ucode: 20240813

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-ucode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
