### PR TITLE
Firewalld postinst - interactive reload

### DIFF
--- a/app-network/firewalld/autobuild/config
+++ b/app-network/firewalld/autobuild/config
@@ -1,0 +1,21 @@
+#!/bin/sh -e
+
+source /usr/share/debconf/confmodule
+
+# Borrowed from Debian.
+_systemctl() {
+	if [ -z "$DPKG_ROOT" ] && [ -d /run/systemd/system ]; then
+		systemctl "$@" 1>&2
+	else
+		return 127
+	fi
+}
+
+# Note: `db_input high' is the minimum input level to show a dialog.
+#
+# https://askubuntu.com/a/476574
+db_fset firewalld/select_auto_reload seen false
+if _systemctl is-active --quiet firewalld; then
+	db_input high firewalld/select_auto_reload || true
+	db_go
+fi

--- a/app-network/firewalld/autobuild/defines
+++ b/app-network/firewalld/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=firewalld
 PKGSEC=net
 PKGDEP="dbus-glib dconf ipset nftables iptables slip python-3 \
-        dbus-python pygobject-3 libcap-ng"
+        dbus-python pygobject-3 libcap-ng debconf"
 PKGSUG="bash-completion gtk-3 libnotify pyqt5 hicolor-icon-theme \
         network-manager-applet"
 BUILDDEP="docbook-xsl doxygen intltool ${PKGSUG}"

--- a/app-network/firewalld/autobuild/postinst
+++ b/app-network/firewalld/autobuild/postinst
@@ -1,7 +1,13 @@
+#!/usr/bin/bash
+
+source /usr/share/debconf/confmodule
+
 # Borrowed from Debian.
 _systemctl() {
 	if [ -z "$DPKG_ROOT" ] && [ -d /run/systemd/system ]; then
-		systemctl "$@"
+		systemctl "$@" 1>&2
+	else
+		return 127
 	fi
 }
 
@@ -13,6 +19,24 @@ _systemctl daemon-reload || true
 # Only preset these services for a fresh installation
 # i.e. installing for the first time or after purging
 if [ "$1" = configure ] && [ -z "$2" ]; then
-	_systemctl preset nftables.service
-	_systemctl preset firewalld.service
+	_systemctl preset nftables.service || true
+	_systemctl preset firewalld.service || true
+fi
+
+if ([ "$1" = configure ] || [ "$1" = reconfigure ]); then
+	db_fset firewalld/select_auto_reload seen false
+	if _systemctl is-active --quiet firewalld; then
+		db_get firewalld/select_auto_reload
+		if [ "$RET" = "Discard all rules in-use and reload from disk" ]; then
+			echo "Reloading firewalld immediately..." 1>&2
+			firewall-cmd --reload 1>&2 || true
+		elif [ "$RET" = "Save current rules in-use and reload from disk" ]; then
+			echo "Saving and reloading firewalld..." 1>&2
+			(firewall-cmd --runtime-to-permanent && firewall-cmd --reload) 1>&2 || true
+		else
+			echo "Not reloading firewalld..." 1>&2
+		fi
+	else
+		echo "Firewalld isn't running - not reloading"
+	fi
 fi

--- a/app-network/firewalld/autobuild/templates
+++ b/app-network/firewalld/autobuild/templates
@@ -1,0 +1,16 @@
+Template: firewalld/select_auto_reload
+Type: select
+Choices: Discard all rules in-use and reload from disk, Save current rules in-use and reload from disk, Do nothing
+Choices-zh_CN: 丢弃当前使用的规则并重新从硬盘读取规则, 保存生效中的规则并重新加载, 什么都不做
+Default: Do nothing
+Description: Incoming packages have modified firewalld rule definitions. Would
+ you like to reload firewalld to make new rules available immediately?
+ 
+ Choose "Do nothing" if you have unsaved changes and need to further modify
+ rules that are currently in effect. New rules will be available after a manual
+ reload or system reboot.
+Description-zh_CN: 软件包操作更改了 firewalld 防火墙规则定义。必须重新加载
+ firewalld 配置才可使用新规则。您要立刻重新加载 firewalld 吗？
+ 
+ 若您有未保存的规则，且需要进一步手动配置，请选择“什么都不做”。
+ 您需要手动重新加载 firewalld 或重新启动系统才能使 firewalld 发现并加载新规则。

--- a/app-network/firewalld/autobuild/triggers
+++ b/app-network/firewalld/autobuild/triggers
@@ -1,0 +1,6 @@
+interest-noawait /usr/lib/firewalld/helpers
+interest-noawait /usr/lib/firewalld/ipsets
+interest-noawait /usr/lib/firewalld/policies
+interest-noawait /usr/lib/firewalld/services
+interest-noawait /usr/lib/firewalld/xmlschema
+interest-noawait /usr/lib/firewalld/zones

--- a/app-network/firewalld/spec
+++ b/app-network/firewalld/spec
@@ -1,4 +1,5 @@
 VER=2.2.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/firewalld/firewalld"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9989"


### PR DESCRIPTION
Topic Description
-----------------

- firewalld: trigger reload mechanism via debconf

Note: testing procedures:
* install `firewalld` from this topic - make sure `libvirt` isn't installed yet
* start and enable `firewalld.service`
* install `libvirt` - should see pop up asking whether user wants to reload

Package(s) Affected
-------------------

- firewalld: 2.2.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit firewalld
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
