### PR TITLE
kdev-php: 23.08.5 rework

### DIFF
--- a/desktop-kde/kdev-php/autobuild/defines
+++ b/desktop-kde/kdev-php/autobuild/defines
@@ -1,4 +1,4 @@
-PKGNAME=kdev-python
+PKGNAME=kdev-php
 PKGSEC=kde
 PKGDEP="kcmutils kdevelop ki18n ktexteditor threadweaver php"
 BUILDDEP="extra-cmake-modules"

--- a/desktop-kde/kdev-php/spec
+++ b/desktop-kde/kdev-php/spec
@@ -2,3 +2,4 @@ VER=23.08.5
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kdev-php-$VER.tar.xz"
 CHKSUMS="sha256::2663298ffaa479791d3600e82046069867d8fbcc1aa449f86c075712747e2e77"
 CHKUPDATE="anitya::id=8763"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- kdev-php: fix the package name

Package(s) Affected
-------------------

- kdev-php: 23.08.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit kdev-php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
