### PR TITLE
flatpak: update to 1.14.10

### DIFF
--- a/app-admin/bubblewrap/spec
+++ b/app-admin/bubblewrap/spec
@@ -1,4 +1,4 @@
-VER=0.9.0
+VER=0.10.0
 SRCS="tbl::https://github.com/projectatomic/bubblewrap/releases/download/v$VER/bubblewrap-$VER.tar.xz"
-CHKSUMS="sha256::c6347eaced49ac0141996f46bba3b089e5e6ea4408bc1c43bab9f2d05dd094e1"
+CHKSUMS="sha256::65d92cf44a63a51e1b7771f70c05013dce5bd6b0b2841c4b4be54b0c45565471"
 CHKUPDATE="anitya::id=10937"

--- a/app-admin/flatpak/spec
+++ b/app-admin/flatpak/spec
@@ -1,4 +1,4 @@
-VER=1.14.8
+VER=1.14.10
 SRCS="git::commit=tags/$VER::https://github.com/flatpak/flatpak \
       file::rename=flathub.flatpakrepo::https://flathub.org/repo/flathub.flatpakrepo"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- bubblewrap: update to 0.10.0
- flatpak: update to 1.14.10
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- bubblewrap: 0.10.0
- flatpak: 1.14.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit bubblewrap flatpak
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
