### PR TITLE
chromium: update to 127.0.6533.119

### DIFF
--- a/app-web/chromium/autobuild/patches/0001-Fedora-chromium-115-initial_prefs-etc-path.patch.patch
+++ b/app-web/chromium/autobuild/patches/0001-Fedora-chromium-115-initial_prefs-etc-path.patch.patch
@@ -1,4 +1,4 @@
-From fb45013a8b6f1fceb81ae49b335ff12e42e28b80 Mon Sep 17 00:00:00 2001
+From 8bb7cb670dd810355b62742ae9b277530280b1e6 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:02:40 +0800
 Subject: [PATCH 01/27] [Fedora] chromium-115-initial_prefs-etc-path.patch

--- a/app-web/chromium/autobuild/patches/0002-Fedora-chromium-77.0.3865.75-no-zlib-mangle.patch.patch
+++ b/app-web/chromium/autobuild/patches/0002-Fedora-chromium-77.0.3865.75-no-zlib-mangle.patch.patch
@@ -1,4 +1,4 @@
-From 53076fe89885904dd6e16dce5348d5a4feb42e89 Mon Sep 17 00:00:00 2001
+From 20022b58e765008d48da080b306fa0dbbbbd6c03 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:04:35 +0800
 Subject: [PATCH 02/27] [Fedora] chromium-77.0.3865.75-no-zlib-mangle.patch

--- a/app-web/chromium/autobuild/patches/0003-Fedora-update-rjsmin-to-1.2.0-to-see-if-Python-3.11-.patch
+++ b/app-web/chromium/autobuild/patches/0003-Fedora-update-rjsmin-to-1.2.0-to-see-if-Python-3.11-.patch
@@ -1,4 +1,4 @@
-From d4b647748969fb913d40a79ae4fc47ddaca0872e Mon Sep 17 00:00:00 2001
+From 77030ed7956b0f01955ae72e3ee34f167da38ef5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:08:55 +0800
 Subject: [PATCH 03/27] [Fedora] update rjsmin to 1.2.0 to see if Python 3.11

--- a/app-web/chromium/autobuild/patches/0004-Fedora-chromium-98.0.4758.102-remoting-no-tests.patc.patch
+++ b/app-web/chromium/autobuild/patches/0004-Fedora-chromium-98.0.4758.102-remoting-no-tests.patc.patch
@@ -1,4 +1,4 @@
-From c59c441cddc5a0f2f18f4f7c6a2b024cb3ac50ec Mon Sep 17 00:00:00 2001
+From 76cd3f115a84f0512f82329bb1fec2b972623525 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:13:02 +0800
 Subject: [PATCH 04/27] [Fedora] chromium-98.0.4758.102-remoting-no-tests.patch

--- a/app-web/chromium/autobuild/patches/0005-Fedora-chromium-126-split-threshold-for-reg-with-hin.patch
+++ b/app-web/chromium/autobuild/patches/0005-Fedora-chromium-126-split-threshold-for-reg-with-hin.patch
@@ -1,4 +1,4 @@
-From 52a0f36e8dd1d0c63ea50260f7502aa5b92d3d0e Mon Sep 17 00:00:00 2001
+From 75502bfd68a05cbbfa603f647fe79f5c4f9bd4f3 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:17:29 +0800
 Subject: [PATCH 05/27] [Fedora]

--- a/app-web/chromium/autobuild/patches/0006-Debian-ruy-include.patch.patch
+++ b/app-web/chromium/autobuild/patches/0006-Debian-ruy-include.patch.patch
@@ -1,4 +1,4 @@
-From 21e1fed02bb34899cc802767aea944bd082cd6f4 Mon Sep 17 00:00:00 2001
+From 1e5813989e231d8bdc122b5c0bd832f6cbeeee94 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:10:48 +0800
 Subject: [PATCH 06/27] [Debian] ruy-include.patch

--- a/app-web/chromium/autobuild/patches/0007-iwyu-include-cstddef-for-nullptr_t-in-fragment_data_.patch
+++ b/app-web/chromium/autobuild/patches/0007-iwyu-include-cstddef-for-nullptr_t-in-fragment_data_.patch
@@ -1,4 +1,4 @@
-From f533547c56948c9512b928e91708d3d01128d68d Mon Sep 17 00:00:00 2001
+From 1cd94681b1a30f1ce493667a0e9d234b0b569ba5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 02:23:48 +0800
 Subject: [PATCH 07/27] iwyu: include cstddef for nullptr_t in

--- a/app-web/chromium/autobuild/patches/0008-AOSC-TBI-rollup.patch.patch
+++ b/app-web/chromium/autobuild/patches/0008-AOSC-TBI-rollup.patch.patch
@@ -1,4 +1,4 @@
-From 6aa7dfda5cc89a7f1801a2bacccf688d04e2979b Mon Sep 17 00:00:00 2001
+From dcc5c71701276d1336234fef490f82b1292e87b6 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:20:58 +0800
 Subject: [PATCH 08/27] [AOSC, TBI] rollup.patch

--- a/app-web/chromium/autobuild/patches/0009-AOSC-TBI-fix-invalid-substition-type.patch.patch
+++ b/app-web/chromium/autobuild/patches/0009-AOSC-TBI-fix-invalid-substition-type.patch.patch
@@ -1,4 +1,4 @@
-From dfc19eaff0ab053f75128a3b37eb30f1ab8c93c3 Mon Sep 17 00:00:00 2001
+From cf9fdcd49e09f723275e59b68ec7337f5c4f017a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:22:10 +0800
 Subject: [PATCH 09/27] [AOSC, TBI] fix-invalid-substition-type.patch

--- a/app-web/chromium/autobuild/patches/0010-AOSC-fix-clang-builtins-path.patch.patch
+++ b/app-web/chromium/autobuild/patches/0010-AOSC-fix-clang-builtins-path.patch.patch
@@ -1,4 +1,4 @@
-From 8d3ec35b45a405c3d2c95b50563bcb7166528d2c Mon Sep 17 00:00:00 2001
+From cee2bdd32e26a1795901566537c48d4d420fcae5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:22:53 +0800
 Subject: [PATCH 10/27] [AOSC] fix-clang-builtins-path.patch

--- a/app-web/chromium/autobuild/patches/0011-AOSC-TBI-fix-missing-header.patch.patch
+++ b/app-web/chromium/autobuild/patches/0011-AOSC-TBI-fix-missing-header.patch.patch
@@ -1,4 +1,4 @@
-From bad9ee408ce48987f00d3e74de4f6990035992ae Mon Sep 17 00:00:00 2001
+From 10d5f03c77e77f8eaa7a1ab3dae5eb37d975f007 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 02:49:50 +0800
 Subject: [PATCH 11/27] [AOSC, TBI] fix-missing-header.patch

--- a/app-web/chromium/autobuild/patches/0012-AOSC-TBI-fix-static-assertion.patch.patch
+++ b/app-web/chromium/autobuild/patches/0012-AOSC-TBI-fix-static-assertion.patch.patch
@@ -1,4 +1,4 @@
-From 5ab3e730dbd685944c5c101781102fab4f435a0d Mon Sep 17 00:00:00 2001
+From bd61756509370fa44b7311c39ed7843c0f00620f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:25:37 +0800
 Subject: [PATCH 12/27] [AOSC, TBI] fix-static-assertion.patch

--- a/app-web/chromium/autobuild/patches/0013-AOSC-TBI-swiftshader.patch.patch
+++ b/app-web/chromium/autobuild/patches/0013-AOSC-TBI-swiftshader.patch.patch
@@ -1,4 +1,4 @@
-From 052df48469da4557cfd4c99b5daf5e13d8e46f5e Mon Sep 17 00:00:00 2001
+From f7352c1b7e360c1eb47be6e007dc86aae10a1a99 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:29:50 +0800
 Subject: [PATCH 13/27] [AOSC, TBI] swiftshader.patch

--- a/app-web/chromium/autobuild/patches/0014-AOSC-sandbox.patch.patch
+++ b/app-web/chromium/autobuild/patches/0014-AOSC-sandbox.patch.patch
@@ -1,4 +1,4 @@
-From 29f2031f7d4729670fc959e55b51026ef7769f5d Mon Sep 17 00:00:00 2001
+From 1c4da8b0ef5b0343b4e3797150c885e490f0e5a5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:31:27 +0800
 Subject: [PATCH 14/27] [AOSC] sandbox.patch

--- a/app-web/chromium/autobuild/patches/0015-AOSC-crashpad.patch.patch
+++ b/app-web/chromium/autobuild/patches/0015-AOSC-crashpad.patch.patch
@@ -1,4 +1,4 @@
-From b333244462027d33e00f878173cba573072fc909 Mon Sep 17 00:00:00 2001
+From ba0ef852b10d36a908dfccbe33cbb6d1635aba98 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 02:57:43 +0800
 Subject: [PATCH 15/27] [AOSC] crashpad.patch

--- a/app-web/chromium/autobuild/patches/0016-AOSC-ffmpeg.patch.patch
+++ b/app-web/chromium/autobuild/patches/0016-AOSC-ffmpeg.patch.patch
@@ -1,4 +1,4 @@
-From 7078a61015a17f47a5669ec5aaf95d41121e4d58 Mon Sep 17 00:00:00 2001
+From eb575e5912d379bd5c81ab0a2c692fc48edd520c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 08:42:17 +0800
 Subject: [PATCH 16/27] [AOSC] ffmpeg.patch

--- a/app-web/chromium/autobuild/patches/0017-AOSC-medium-cmodel.patch.patch
+++ b/app-web/chromium/autobuild/patches/0017-AOSC-medium-cmodel.patch.patch
@@ -1,4 +1,4 @@
-From 5adcc8eaedbb4e179d7dd88f07654449e8ed14e7 Mon Sep 17 00:00:00 2001
+From 742e32cee754784a0647dcbcb789beeac437760d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 03:59:19 +0800
 Subject: [PATCH 17/27] [AOSC] medium-cmodel.patch

--- a/app-web/chromium/autobuild/patches/0018-AOSC-patch.patch
+++ b/app-web/chromium/autobuild/patches/0018-AOSC-patch.patch
@@ -1,4 +1,4 @@
-From 110c1a1995a1119b6a06354b4be75c17948def24 Mon Sep 17 00:00:00 2001
+From ad0dad495d94eefc623b356775c463f14704612e Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 04:13:27 +0800
 Subject: [PATCH 18/27] [AOSC] patch

--- a/app-web/chromium/autobuild/patches/0019-IWYU-missing-include-for-usage-of-std-exchange-in-lo.patch
+++ b/app-web/chromium/autobuild/patches/0019-IWYU-missing-include-for-usage-of-std-exchange-in-lo.patch
@@ -1,4 +1,4 @@
-From 6fe686cadb1e603ee580434e5287a8f5f2ecfc11 Mon Sep 17 00:00:00 2001
+From a65c64c77f323649f35bb3080c28448555c5368f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 10:52:16 +0800
 Subject: [PATCH 19/27] IWYU: missing include for usage of std::exchange in

--- a/app-web/chromium/autobuild/patches/0020-IWYU-missing-include-for-usage-of-std-optional-in-en.patch
+++ b/app-web/chromium/autobuild/patches/0020-IWYU-missing-include-for-usage-of-std-optional-in-en.patch
@@ -1,4 +1,4 @@
-From 07a3ed394f8865d58daf61f094d09da9557e9c4e Mon Sep 17 00:00:00 2001
+From a2a67eb3503a7abdeb65d854f86a191332342814 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 11:12:57 +0800
 Subject: [PATCH 20/27] IWYU: missing include for usage of std::optional in

--- a/app-web/chromium/autobuild/patches/0021-IWYU-missing-include-for-usage-of-std-optional-in-pa.patch
+++ b/app-web/chromium/autobuild/patches/0021-IWYU-missing-include-for-usage-of-std-optional-in-pa.patch
@@ -1,4 +1,4 @@
-From 081e9452e599756a010cdfdd512a09ffc960a440 Mon Sep 17 00:00:00 2001
+From a89d9661d5287d31454a1265962f80ba17463d34 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 15:27:19 +0800
 Subject: [PATCH 21/27] IWYU: missing include for usage of std::optional in

--- a/app-web/chromium/autobuild/patches/0022-chrome-browser-add-missing-dependency.patch
+++ b/app-web/chromium/autobuild/patches/0022-chrome-browser-add-missing-dependency.patch
@@ -1,4 +1,4 @@
-From 886455ca2440d2d934109a4e9423403c261d6cb9 Mon Sep 17 00:00:00 2001
+From fbbb8e26ac91cc46677d3e7af9c79f01f5faa502 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 17:04:39 +0800
 Subject: [PATCH 22/27] chrome/browser: add missing dependency

--- a/app-web/chromium/autobuild/patches/0023-chrome-browser-ui-add-missing-dependency.patch
+++ b/app-web/chromium/autobuild/patches/0023-chrome-browser-ui-add-missing-dependency.patch
@@ -1,4 +1,4 @@
-From 9c6041ede2e921693ae003a6ffa22e7e13a2b845 Mon Sep 17 00:00:00 2001
+From 51ff6aca014688ca2e360c3c1d0bb43c1f196df6 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 17:05:57 +0800
 Subject: [PATCH 23/27] chrome/browser/ui: add missing dependency

--- a/app-web/chromium/autobuild/patches/0024-Move-chrome-browser-ui-webui_name_variants-to-public.patch
+++ b/app-web/chromium/autobuild/patches/0024-Move-chrome-browser-ui-webui_name_variants-to-public.patch
@@ -1,4 +1,4 @@
-From 46a0c26f75d19ca2bda97f68637beff4bfa77b3d Mon Sep 17 00:00:00 2001
+From 7c3be266d6b47b4c80b6fa00903743647ed28d82 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 04:21:45 +0800
 Subject: [PATCH 24/27] Move chrome/browser/ui:webui_name_variants to

--- a/app-web/chromium/autobuild/patches/0025-Build-LoongArch64-LSX-optimizations-in-libpng.patch
+++ b/app-web/chromium/autobuild/patches/0025-Build-LoongArch64-LSX-optimizations-in-libpng.patch
@@ -1,7 +1,10 @@
-From 46eb31d5009344805b076c5668db89a8ecbdebe9 Mon Sep 17 00:00:00 2001
+From 009b4b079ac1dd64ca14765bd761768b4ce8fe07 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
-Date: Thu, 8 Aug 2024 04:30:35 +0800
+Date: Fri, 16 Aug 2024 05:51:43 +0800
 Subject: [PATCH 25/27] Build LoongArch64 LSX optimizations in libpng
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 These files were added in Chromium Change Number 5454197, but not referenced in BUILD.gn.
 
@@ -9,8 +12,12 @@ Update BUILD.gn to compile them when appropriate.
 
 Bug: 356038456
 Change-Id: I2d15071261a3785184c5fa7c26ea26b182d4ba6c
-
-https://chromium-review.googlesource.com/c/chromium/src/+/5740787
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5740787
+Reviewed-by: Rick Byers <rbyers@chromium.org>
+Commit-Queue: Rick Byers <rbyers@chromium.org>
+Auto-Submit: Kexy Biscuit (百合ヶ咲るる / 被子饼) <kexybiscuit@gmail.com>
+Reviewed-by: Leon Scroggins <scroggo@google.com>
+Cr-Commit-Position: refs/heads/main@{#1338820}
 ---
  AUTHORS                     | 2 ++
  third_party/libpng/BUILD.gn | 6 ++++++

--- a/app-web/chromium/autobuild/patches/0026-Make-more-deps-entries-public_deps-in-chrome-browser.patch
+++ b/app-web/chromium/autobuild/patches/0026-Make-more-deps-entries-public_deps-in-chrome-browser.patch
@@ -1,4 +1,4 @@
-From 1dae1973123d7185b7403074b0fbd1738bd8560a Mon Sep 17 00:00:00 2001
+From 4b623b402aa0d52221ee6be0e2b1a39945f05747 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 8 Aug 2024 05:59:37 +0800
 Subject: [PATCH 26/27] Make more deps entries public_deps in

--- a/app-web/chromium/autobuild/patches/0027-Reland-2-linux-build-Enable-fission-for-symbol_level.patch
+++ b/app-web/chromium/autobuild/patches/0027-Reland-2-linux-build-Enable-fission-for-symbol_level.patch
@@ -1,4 +1,4 @@
-From f19f826ba3509faea6f8249bee34a02552ea8a7e Mon Sep 17 00:00:00 2001
+From 6ecdbb1db2a09f11f08958739751b63d25ceb596 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 9 Aug 2024 23:09:18 +0800
 Subject: [PATCH 27/27] Reland^2 "linux/build: Enable fission for (symbol_level

--- a/app-web/chromium/spec
+++ b/app-web/chromium/spec
@@ -1,23 +1,13 @@
-VER=127.0.6533.99
+VER=127.0.6533.119
 LAUNCHERVER=8
 SRCS="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$VER.tar.xz \
       https://github.com/foutrelis/chromium-launcher/archive/v$LAUNCHERVER.tar.gz \
       file::rename=chromium-$VER.txt::https://chromium.googlesource.com/chromium/src/+/$VER?format=TEXT"
-CHKSUMS="sha256::e33a57b0cab75f2fb8bd128be24da0ee18d4a0052e4cd99ad37fcb8dfc9c5875 \
+CHKSUMS="sha256::acc9e3f9fd2d180b8831865a1ac4f5cdd9ffe6211f47f467296d9ee1be2a577e \
          sha256::213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a \
-         sha256::3aaaf1824f41af288a1eae72256313447475f25ba1bad29b42b029d5742ab418"
+         sha256::a9a993b61bc5444b1d38120b13ca53655fd0a20b506d204e802d2a97be679e8e"
 SUBDIR="chromium-$VER"
 CHKUPDATE="anitya::id=13344"
 ENVREQ__AMD64="core=96"
 ENVREQ__ARM64="total_mem_per_core=3 core=64"
 ENVREQ__LOONGARCH64="core=16"
-
-# FIXME: Automate the following procedure
-# Note: For errors like "LLVM ERROR: out of memory"
-# Check the current max_map_count kernel parameter
-# `sysctl vm.max_map_count`
-# If it's 65530 aka the default value, try increasing it
-# `sudo sysctl -w vm.max_map_count=262144`
-# https://chromium.googlesource.com/chromium/src/+/main/docs/linux/build_instructions.md#Linker-Crashes
-# https://manpages.ubuntu.com/manpages/oracular/en/man8/sysctl.8.html
-# https://www.kernel.org/doc/html/latest/admin-guide/sysctl/vm.html#max-map-count


### PR DESCRIPTION
Topic Description
-----------------

- chromium: update to 127.0.6533.119
    - Track patches at https://dev.azure.com/AOSC-Tracking/_git/chromium @ aosc/v127.0.6533.119.

Package(s) Affected
-------------------

- chromium: 127.0.6533.119

Security Update?
----------------

No

Build Order
-----------

```
#buildit chromium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
