### PR TITLE
yazi: update to 0.3.1

### DIFF
--- a/app-utils/yazi/spec
+++ b/app-utils/yazi/spec
@@ -1,5 +1,4 @@
-VER=0.3.0
-REL=1
+VER=0.3.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/sxyazi/yazi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370571"


### PR DESCRIPTION
Topic Description
-----------------

- yazi: update to 0.3.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- yazi: 0.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit yazi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
