### PR TITLE
spectacle: move SimpleScreenRecorder to PKGRECOM

### DIFF
--- a/desktop-kde/spectacle/autobuild/defines
+++ b/desktop-kde/spectacle/autobuild/defines
@@ -4,8 +4,9 @@ PKGDEP="fontconfig freetype kauth kcodecs kcolorpicker kcompletion kconfig \
         kconfigwidgets kcoreaddons kdbusaddons kglobalaccel kguiaddons ki18n \
         kimageannotator kio kitemviews kjobwidgets knewstuff knotifications \
         kservice kwayland kwidgetsaddons kwindowsystem kxmlgui purpose solid \
-        libxcb simplescreenrecorder"
+        libxcb"
 BUILDDEP="extra-cmake-modules kdoctools"
+PKGRECOM="simplescreenrecorder"
 PKGDES="KDE screenshot capture utility"
 
 CMAKE_AFTER="-DBUILD_COVERAGE=OFF \

--- a/desktop-kde/spectacle/spec
+++ b/desktop-kde/spectacle/spec
@@ -1,4 +1,5 @@
 VER=22.12.3
+REL=1
 SRCS="tbl::https://download.kde.org/Attic/release-service/$VER/src/spectacle-$VER.tar.xz"
 CHKSUMS="sha256::497e4b71f4ca3b20456213a66db3cd2b31c3c3040c924aa6fc2b05304717cd07"
 CHKUPDATE="anitya::id=8763"


### PR DESCRIPTION
Topic Description
-----------------

- spectacle: move SimpleScreenRecorder to PKGRECOM

Package(s) Affected
-------------------

- spectacle: 22.12.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit spectacle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
