### PR TITLE
vscode: do not create symlink code -> vscode if it has been created

### DIFF
--- a/app-editors/vscode/autobuild/postinst.in
+++ b/app-editors/vscode/autobuild/postinst.in
@@ -33,4 +33,6 @@ done
 rm -Rf "${TEMP_PATH}"
 
 # Symlink to code
-ln -sv /usr/bin/vscode /usr/bin/code
+if [ ! -e /usr/bin/code ]; then
+    ln -sv /usr/bin/vscode /usr/bin/code
+fi

--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,4 +1,5 @@
 VER=1.92.2
+REL=1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
 CHKSUMS__AMD64="sha256::5cad830451bb8369f30c2b8bf5a1037425c7b4dd277ed10d8fdbe227397eea40"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: do not create symlink code -> vscode if it has been created
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- vscode: 1.92.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
