### PR TITLE
obs-studio: update to 30.2.3

### DIFF
--- a/app-multimedia/obs-studio/spec
+++ b/app-multimedia/obs-studio/spec
@@ -1,4 +1,4 @@
-VER=30.2.2
+VER=30.2.3
 # __OBS_CEF_VER: Find the build version on https://cef-builds.spotifycdn.com/index.html#linux64
 # FIXME: 126.x has https://github.com/chromiumembedded/cef/issues/3616#issuecomment-2158624330
 __OBS_CEF_VER="125.0.22+gc410c95+chromium-125.0.6422.142"


### PR DESCRIPTION
Topic Description
-----------------

- obs-studio: update to 30.2.3
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- obs-studio: 30.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit obs-studio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
