### PR TITLE
vscode: conflict official deb pacakge

### DIFF
--- a/app-editors/vscode/autobuild/defines
+++ b/app-editors/vscode/autobuild/defines
@@ -4,6 +4,9 @@ PKGDEP="alsa-lib at-spi2-core cups desktop-file-utils fontconfig gtk-3 gconf \
         libnotify libsecret nss x11-lib aosc-nanny"
 PKGDES="Visual Studio Code - an extensible code editor from Microsoft"
 
+# Conflict official vscode deb package
+PKGCONFL="code"
+
 PKGPROV="code"
 
 FAIL_ARCH="!(amd64|arm64)"

--- a/app-editors/vscode/autobuild/postinst.in
+++ b/app-editors/vscode/autobuild/postinst.in
@@ -33,6 +33,4 @@ done
 rm -Rf "${TEMP_PATH}"
 
 # Symlink to code
-if [ ! -e /usr/bin/code ]; then
-    ln -sv /usr/bin/vscode /usr/bin/code
-fi
+ln -sfv /usr/bin/vscode /usr/bin/code

--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,5 +1,5 @@
 VER=1.92.2
-REL=1
+REL=2
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
 CHKSUMS__AMD64="sha256::5cad830451bb8369f30c2b8bf5a1037425c7b4dd277ed10d8fdbe227397eea40"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: conflict vscode official package
    - also force set code symlink in postinst

Package(s) Affected
-------------------

- vscode: 1.92.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
