### PR TITLE
openjdk-8: enable JIT for LoongArch64

### DIFF
--- a/lang-java/openjdk-8/autobuild/build
+++ b/lang-java/openjdk-8/autobuild/build
@@ -16,7 +16,8 @@ SJAVAC=1
 if [[ "${CROSS:-$ARCH}" != "amd64" && \
       "${CROSS:-$ARCH}" != "arm64" && \
       "${CROSS:-$ARCH}" != ppc64* && \
-      "${CROSS:-$ARCH}" != "loongson3" ]]; then
+      "${CROSS:-$ARCH}" != "loongson3" && \
+      "${CROSS:-$ARCH}" != "loongarch64" ]]; then
     config_zero="--with-jvm-variants=zero"
     SJAVAC=0
 else
@@ -114,7 +115,8 @@ if [[ "${CROSS:-$ARCH}" != "amd64" && \
        "${CROSS:-$ARCH}" != "armv6hf" && \
        "${CROSS:-$ARCH}" != armv7hf && \
        "${CROSS:-$ARCH}" != ppc64* && \
-       "${CROSS:-$ARCH}" != "loongson3" ]]; then
+       "${CROSS:-$ARCH}" != "loongson3" && \
+       "${CROSS:-$ARCH}" != "loongarch64" ]]; then
     cp -r build/linux-${JARCH}-normal-zero-release/docs/* \
         "$PKGDIR"/usr/share/doc/openjdk-8/
 elif [[ "${CROSS:-$ARCH}" = "armv4" || \

--- a/lang-java/openjdk-8/autobuild/build.stage2
+++ b/lang-java/openjdk-8/autobuild/build.stage2
@@ -34,7 +34,8 @@ BOOTSTRAP_LOONGARCH64="8"
 if [[ "${CROSS:-$ARCH}" != "amd64" && \
       "${CROSS:-$ARCH}" != "arm64" && \
       "${CROSS:-$ARCH}" != ppc64* && \
-      "${CROSS:-$ARCH}" != "loongson3" ]]; then
+      "${CROSS:-$ARCH}" != "loongson3" && \
+      "${CROSS:-$ARCH}" != "loongarch64" ]]; then
     config_zero="--with-jvm-variants=zero"
     SJAVAC=0
 else
@@ -247,7 +248,8 @@ if [[ "${CROSS:-$ARCH}" != "amd64" && \
        "${CROSS:-$ARCH}" != "armv6hf" && \
        "${CROSS:-$ARCH}" != armv7hf && \
        "${CROSS:-$ARCH}" != ppc64* && \
-       "${CROSS:-$ARCH}" != "loongson3" ]]; then
+       "${CROSS:-$ARCH}" != "loongson3" && \
+       "${CROSS:-$ARCH}" != "loongarch64" ]]; then
     cp -r build/linux-${JARCH}-normal-zero-release/docs/* \
         "$PKGDIR"/usr/share/doc/openjdk-8/
 elif [[ "${CROSS:-$ARCH}" = "armv4" || \

--- a/lang-java/openjdk-8/spec
+++ b/lang-java/openjdk-8/spec
@@ -1,5 +1,6 @@
 UPSTREAM_VER=8u422-ga
 VER=${UPSTREAM_VER/-/+}
+REL=1
 SRCS="git::commit=aosc/jdk${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk8u.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17307"


### PR DESCRIPTION
Topic Description
-----------------

- openjdk-8: enable JIT for LoongArch64

Package(s) Affected
-------------------

- openjdk-8: 3:8u422+ga-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openjdk-8
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
