### PR TITLE
libantlr3c: drop, orphaned

### DIFF
--- a/runtime-common/libantlr3c/autobuild/defines
+++ b/runtime-common/libantlr3c/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=libantlr3c
-PKGSEC=libs
-PKGDEP="glibc"
-PKGDES="C runtime for the ANTLR parsing library"
-
-ABSHADOW=0
-AUTOTOOLS_AFTER="--disable-abiflags"

--- a/runtime-common/libantlr3c/spec
+++ b/runtime-common/libantlr3c/spec
@@ -1,5 +1,0 @@
-VER=3.4
-REL=2
-SRCS="tbl::https://www.antlr3.org/download/C/libantlr3c-$VER.tar.gz"
-CHKSUMS="sha256::ca914a97f1a2d2f2c8e1fca12d3df65310ff0286d35c48b7ae5f11dcc8b2eb52"
-CHKUPDATE="anitya::id=229548"


### PR DESCRIPTION
Topic Description
-----------------

- libantlr3c: drop, orphaned

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit libantlr3c
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
