### PR TITLE
aosc-os-presets-base: disable systemd-networkd and systemd-networkd-wait-online

### DIFF
--- a/runtime-data/aosc-os-presets-base/autobuild/build
+++ b/runtime-data/aosc-os-presets-base/autobuild/build
@@ -23,6 +23,10 @@ enable ModemManager.service
 enable NetworkManager.service
 enable sshd.service
 
+# Disable systemd-networkd and systemd-networkd-wait-online
+disable systemd-networkd.service
+disable systemd-networkd-wait-online.service
+
 # Automatic system update checker.
 enable repo-refresh.timer
 EOF

--- a/runtime-data/aosc-os-presets-base/spec
+++ b/runtime-data/aosc-os-presets-base/spec
@@ -1,2 +1,2 @@
-VER=2
+VER=3
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- aosc-os-presets-base: disable systemd-networkd and systemd-networkd-wait-online
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- libantlr3c: drop, orphaned

Package(s) Affected
-------------------

- aosc-os-presets-base: 3

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-os-presets-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
