### PR TITLE
mariadb: update to 11.4.3

### DIFF
--- a/app-database/mariadb/autobuild/beyond
+++ b/app-database/mariadb/autobuild/beyond
@@ -1,5 +1,5 @@
 abinfo "Dropping unneeded files ..."
-rm -rfv "$PKGDIR"/usr/{data,mysql-test,sql-bench}
+rm -rfv "$PKGDIR"/usr/{data,mariadb-test,sql-bench}
 rm -fv "$PKGDIR"/usr/share/man/man1/mysql-test-run.pl.1
 
 abinfo "Creating a compatibility symlink for libmysqlclient ..."

--- a/app-database/mariadb/autobuild/conffiles
+++ b/app-database/mariadb/autobuild/conffiles
@@ -1,2 +1,2 @@
-/etc/my.cnf
+/etc/mysql/my.cnf
 /etc/security/user_map.conf

--- a/app-database/mariadb/autobuild/overrides/etc/mysql/my.cnf
+++ b/app-database/mariadb/autobuild/overrides/etc/mysql/my.cnf
@@ -15,4 +15,4 @@ symbolic-links=0
 #
 # include all files from the config directory
 #
-!includedir /etc/mysql
+!includedir /etc/mysql/conf.d/

--- a/app-database/mariadb/autobuild/overrides/etc/mysql/my.cnf
+++ b/app-database/mariadb/autobuild/overrides/etc/mysql/my.cnf
@@ -15,4 +15,4 @@ symbolic-links=0
 #
 # include all files from the config directory
 #
-!includedir /etc/mysql/conf.d/
+#!includedir /etc/mysql/conf.d/

--- a/app-database/mariadb/spec
+++ b/app-database/mariadb/spec
@@ -1,4 +1,4 @@
-VER=10.9.8
-SRCS="tbl::https://dlm.mariadb.com/3378733/MariaDB/mariadb-$VER/source/mariadb-$VER.tar.gz"
-CHKSUMS="sha256::fcdc6f73882477c20310e795a02f746e54934aa7a8b368900bd45e78a5daf6ed"
+VER=11.4.3
+SRCS="tbl::https://dlm.mariadb.com/3893044/MariaDB/mariadb-$VER/source/mariadb-$VER.tar.gz"
+CHKSUMS="sha256::6f0017b9901bb1897de0eed21caef9ffa9d66ef559345a0d8a6f011308413ece"
 CHKUPDATE="anitya::id=1887"


### PR DESCRIPTION
Topic Description
-----------------

- mariadb: update to 11.4.3
- libantlr3c: drop, orphaned

Package(s) Affected
-------------------

- mariadb: 11.4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit mariadb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
