### PR TITLE
polkit: update to 125

### DIFF
--- a/app-admin/polkit/autobuild/defines
+++ b/app-admin/polkit/autobuild/defines
@@ -15,7 +15,7 @@ BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
 ABTYPE=meson
 MESON_AFTER=" \
-    -Dsession_tracking=libsystemd-login \
+    -Dsession_tracking=logind \
     -Dlibs-only=false \
     -Dpolkitd_user=polkitd \
     -Dauthfw=pam \

--- a/app-admin/polkit/spec
+++ b/app-admin/polkit/spec
@@ -1,4 +1,4 @@
-VER=124
-SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/polkit/polkit"
+VER=125
+SRCS="git::commit=tags/$VER::https://github.com/polkit-org/polkit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3682"


### PR DESCRIPTION
Topic Description
-----------------

- polkit: update to 125
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- polkit: 1:125

Security Update?
----------------

No

Build Order
-----------

```
#buildit polkit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
