### PR TITLE
godot: update to 4.3

### DIFF
--- a/app-devel/godot/spec
+++ b/app-devel/godot/spec
@@ -1,3 +1,4 @@
-VER=4.2.2
+VER=4.3
 SRCS="git::commit=tags/$VER-stable::https://github.com/godotengine/godot"
 CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=373975"


### PR DESCRIPTION
Topic Description
-----------------

- godot: update to 4.3

Package(s) Affected
-------------------

- godot: 4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit godot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
