### PR TITLE
jack: update to 1.9.22

### DIFF
--- a/app-multimedia/jack/spec
+++ b/app-multimedia/jack/spec
@@ -1,5 +1,4 @@
-VER=1.9.21
-REL=2
-SRCS="tbl::https://github.com/jackaudio/jack2/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::8b044a40ba5393b47605a920ba30744fdf8bf77d210eca90d39c8637fe6bc65d"
+VER=1.9.22
+SRCS="git::commit=tags/v$VER::https://github.com/jackaudio/jack2"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21358"


### PR DESCRIPTION
Topic Description
-----------------

- jack: update to 1.9.22
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- jack: 1.9.22

Security Update?
----------------

No

Build Order
-----------

```
#buildit jack
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
