### PR TITLE
gstreamer (GStreamer): rework dependency

### DIFF
--- a/runtime-imaging/dssim-c/autobuild/beyond
+++ b/runtime-imaging/dssim-c/autobuild/beyond
@@ -1,0 +1,4 @@
+# A newer dssim is available as a standalone Rust application.
+# GNOME wants the C library, so let's feed that freak.
+abinfo "Dropping executables ..."
+rm -rv "$PKGDIR"/usr/bin

--- a/runtime-imaging/dssim-c/autobuild/defines
+++ b/runtime-imaging/dssim-c/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=dssim-c
+PKGSEC=libs
+PKGDEP="libjpeg-turbo libpng"
+PKGDES="Library for computing (dis)similarity between two or more PNG &/or JPEG images using an algorithm approximating human vision"
+
+MESON_AFTER="-Djpeg=enabled"

--- a/runtime-imaging/dssim-c/autobuild/defines
+++ b/runtime-imaging/dssim-c/autobuild/defines
@@ -4,3 +4,6 @@ PKGDEP="libjpeg-turbo libpng"
 PKGDES="Library for computing (dis)similarity between two or more PNG &/or JPEG images using an algorithm approximating human vision"
 
 MESON_AFTER="-Djpeg=enabled"
+
+PKGBREAK="gstreamer<=1.24.4-5"
+PKGREP="gstreamer<=1.24.4-5"

--- a/runtime-imaging/dssim-c/spec
+++ b/runtime-imaging/dssim-c/spec
@@ -1,0 +1,4 @@
+VER=1.3.2+git20200922
+SRCS="git::commit=a40c62b95fa2a4223218c973a85dc183e610070a::https://github.com/kornelski/dssim"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=15340"

--- a/runtime-imaging/dssim-c/spec
+++ b/runtime-imaging/dssim-c/spec
@@ -1,4 +1,5 @@
 VER=1.3.2+git20200922
+REL=1
 SRCS="git::commit=a40c62b95fa2a4223218c973a85dc183e610070a::https://github.com/kornelski/dssim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15340"

--- a/runtime-multimedia/gstreamer/autobuild/beyond
+++ b/runtime-multimedia/gstreamer/autobuild/beyond
@@ -6,7 +6,7 @@ rm -frv \
     "$PKGDIR"/usr/lib/lib{dssim,nice,openjp2,orc}* \
     "$PKGDIR"/usr/lib/girepository-1.0/Nice* \
     "$PKGDIR"/usr/lib/gstreamer-1.0/libgstnice.so \
-    "$PKGDIR"/usr/lib/pkgconfig/{libopenjp2,nice,orc}* \
+    "$PKGDIR"/usr/lib/pkgconfig/{dssim,libopenjp2,nice,orc}* \
     "$PKGDIR"/usr/share/aclocal/orc* \
     "$PKGDIR"/usr/share/gir-1.0/Nice* \
     "$PKGDIR"/usr/share/gtk-doc/html/{libnice,orc}

--- a/runtime-multimedia/gstreamer/autobuild/defines
+++ b/runtime-multimedia/gstreamer/autobuild/defines
@@ -12,7 +12,7 @@ PKGDEP="a52dec aalib bluez bzip2 cairo cdparanoia chromaprint elfutils faac \
         pulseaudio pygobject-3 qrencode rtmpdump sbc sdl2 soundtouch \
         spandsp srtp taglib twolame v4l-utils wavpack wayland \
         webrtc-audio-processing wildmidi x264 x265 zbar zlib zvbi zxing-cpp \
-        openjpeg"
+        dssim-c openjpeg"
 # Rust-only dependencies.
 PKGDEP__RUST="rav1e"
 PKGDEP__AMD64="${PKGDEP} ${PKGDEP__RUST} openmpt svt-hevc"

--- a/runtime-multimedia/gstreamer/autobuild/defines
+++ b/runtime-multimedia/gstreamer/autobuild/defines
@@ -18,7 +18,6 @@ PKGDEP__RUST="rav1e"
 PKGDEP__AMD64="${PKGDEP} ${PKGDEP__RUST} openmpt svt-hevc"
 PKGDEP__ARM64="${PKGDEP} ${PKGDEP__RUST} openmpt"
 PKGDEP__LOONGSON3="${PKGDEP} ${PKGDEP__RUST}"
-PKGDEP__MIPS64R6EL="${PKGDEP/zbar/}"
 PKGDEP__PPC64EL="${PKGDEP} ${PKGDEP__RUST}"
 BUILDDEP="bash-completion cargo-c gobject-introspection gtk-doc graphviz \
           hotdoc mono nasm opencv qt-5 rustc shaderc tomli vulkan-headers \
@@ -27,11 +26,6 @@ BUILDDEP="bash-completion cargo-c gobject-introspection gtk-doc graphviz \
 BUILDDEP__LOONGARCH64="${BUILDDEP/mono/}"
 BUILDDEP__LOONGSON3="${BUILDDEP/mono/}"
 BUILDDEP__RISCV64="${BUILDDEP/mono/}"
-BUILDDEP__MIPS64R6EL="${BUILDDEP/mono/}"
-# FIXME: Cargo-c fails to build.
-BUILDDEP__MIPS64R6EL="${BUILDDEP__MIPS64R6EL/cargo-c/}"
-# FIXME: rustc fails to build.
-BUILDDEP__MIPS64R6EL="${BUILDDEP__MIPS64R6EL/rustc/}"
 PKGDES="A modular and extensible multimedia framework"
 
 PKGBREAK="gst-editing-services<=1.18.4-1 gst-libav-1-0<=1.18.4 \
@@ -75,18 +69,13 @@ MESON_AFTER="-Dpython=enabled \
              -Dglib-asserts=disabled \
              -Dglib-checks=disabled"
 # FIXME: No Mono support.
-# FIXME: No Ring support.
+# FIXME: nix bindings broken.
 MESON_AFTER__LOONGARCH64=" \
              ${MESON_AFTER} \
              -Dsharp=disabled \
              -Drs=disabled"
 # FIXME: No Ring support.
 MESON_AFTER__LOONGSON3=" \
-             ${MESON_AFTER} \
-             -Dsharp=disabled \
-             -Drs=disabled"
-# FIXME: Cargo-c fails to build.
-MESON_AFTER__MIPS64R6EL=" \
              ${MESON_AFTER} \
              -Dsharp=disabled \
              -Drs=disabled"

--- a/runtime-multimedia/gstreamer/autobuild/defines.stage2
+++ b/runtime-multimedia/gstreamer/autobuild/defines.stage2
@@ -15,16 +15,13 @@ PKGDEP="a52dec aalib bluez bzip2 cairo cdparanoia chromaprint elfutils faac \
 PKGDEP__AMD64="${PKGDEP} openmpt svt-hevc"
 PKGDEP__ARM64="${PKGDEP} openmpt"
 PKGDEP__LOONGSON3="${PKGDEP}"
-PKGDEP__MIPS64R6EL="${PKGDEP/zbar/}"
 PKGDEP__PPC64EL="${PKGDEP}"
 BUILDDEP="bash-completion cargo-c gobject-introspection gtk-doc \
           hotdoc mono nasm rustc shaderc vulkan-headers vulkan-loader \
           vulkan-validationlayers wayland-protocols graphviz"
+# FIXME: No Mono support.
+BUILDDEP__LOONGARCH64="${BUILDDEP/mono/}"
 BUILDDEP__LOONGSON3="${BUILDDEP/mono/}"
-BUILDDEP__MIPS64R6EL=" \
-          bash-completion gobject-introspection gtk-doc \
-          nasm shaderc vulkan-headers vulkan-loader \
-          vulkan-validationlayers wayland-protocols graphviz"
 BUILDDEP__RISCV64=" \
           bash-completion gobject-introspection gtk-doc \
           hotdoc shaderc vulkan-headers vulkan-loader \
@@ -71,13 +68,16 @@ MESON_AFTER="-Dpython=enabled \
              -Dgobject-cast-checks=disabled \
              -Dglib-asserts=disabled \
              -Dglib-checks=disabled"
-MESON_AFTER__LOONGSON3=" \
-             ${MESON_AFTER} \
-             -Dsharp=disabled"
-MESON_AFTER__MIPS64R6EL=" \
+# FIXME: No Mono support.
+# FIXME: nix bindings broken.
+MESON_AFTER__LOONGARCH64=" \
              ${MESON_AFTER} \
              -Dsharp=disabled \
              -Drs=disabled"
+# FIXME: No Mono support.
+MESON_AFTER__LOONGSON3=" \
+             ${MESON_AFTER} \
+             -Dsharp=disabled"
 # FIXME: gstreamer-rs depends on Ring.
 MESON_AFTER__PPC64EL=" \
              ${MESON_AFTER} \
@@ -86,3 +86,5 @@ MESON_AFTER__RISCV64=" \
              ${MESON_AFTER} \
              -Dsharp=disabled \
              -Drs=disabled"
+
+NOLTO=1

--- a/runtime-multimedia/gstreamer/autobuild/defines.stage2
+++ b/runtime-multimedia/gstreamer/autobuild/defines.stage2
@@ -11,7 +11,7 @@ PKGDEP="a52dec aalib bluez bzip2 cairo cdparanoia chromaprint elfutils faac \
         mpg123 neon nettle openal-soft opencore-amr openh264 opus orc \
         pulseaudio pygobject-3 qrencode rtmpdump sbc sdl2 soundtouch \
         spandsp srtp taglib twolame v4l-utils wavpack wayland \
-        webrtc-audio-processing wildmidi x264 x265 zbar zlib zvbi zxing-cpp"
+        webrtc-audio-processing wildmidi x264 x265 zbar zlib zvbi zxing-cpp dssim-c"
 PKGDEP__AMD64="${PKGDEP} openmpt svt-hevc"
 PKGDEP__ARM64="${PKGDEP} openmpt"
 PKGDEP__LOONGSON3="${PKGDEP}"

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,5 @@
 VER=1.24.4
-REL=5
+REL=6
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"


### PR DESCRIPTION
Topic Description
-----------------

- dssim-c: mark break + replace gstreamer<=1.24.4-5
- dssim-c: bump REL for re-introduction
- gstreamer: drop dssim-c pkg-config
- Revert "gstreamer: drop unused dssim-c dep"
    This reverts commit b4a04ad2308858a75510a786c9e84c221b8f246c.
- Revert "dssim-c: drop, orphaned"
    This reverts commit 27805911f6645e535308d52a2c9a67707dbda0ca.

Package(s) Affected
-------------------

- dssim-c: 1.3.2+git20200922-1
- gstreamer: 1.24.4-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit dssim-c gstreamer:+stage2 gstreamer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
