### PR TITLE
qbittorrent: update to 4.6.6

### DIFF
--- a/app-web/qbittorrent/spec
+++ b/app-web/qbittorrent/spec
@@ -1,4 +1,4 @@
-VER=4.6.5
-SRCS="tbl::https://sourceforge.net/projects/qbittorrent/files/qbittorrent/qbittorrent-$VER/qbittorrent-$VER.tar.xz"
-CHKSUMS="sha256::89cd79f58af4db346a9744e4bf61181c4bd40cce201b79a9f54ac31a8676e921"
+VER=4.6.6
+SRCS="git::commit=tags/release-$VER::https://github.com/qbittorrent/qBittorrent"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6111"


### PR DESCRIPTION
Topic Description
-----------------

- qbittorrent: update to 4.6.6
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- qbittorrent: 4.6.6
- qbittorrent-nox: 4.6.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit qbittorrent
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
