### PR TITLE
dotnet-8.0: update to 8.0.8

### DIFF
--- a/app-devel/aspnetcore-runtime-8.0/spec
+++ b/app-devel/aspnetcore-runtime-8.0/spec
@@ -1,11 +1,11 @@
-VER=8.0.6
+VER=8.0.8
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$VER/aspnetcore-runtime-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha256::d4f8ce14e12aba9ca970c15c1ce09486bffc930fe05d4520678763562ca6b48b"
+CHKSUMS__AMD64="sha256::7bee47a53a0a4977e4182e8085355d146be6b2f958aa3f3ae2de0c39439e7348"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$VER/aspnetcore-runtime-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha256::2d03221eb786ad84b865aa5eca84ad79bb2e8cde57e96cac9e0c4edaaec14c0f"
+CHKSUMS__ARM64="sha256::ac79115682ee679756838ee623ca46617322c787826f3638438bc6443fcee345"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$VER/aspnetcore-runtime-$VER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha256::b621a6cee65890a123bbf6282fc23190a8abe12af76279a1aa799b0e82f814bf"
+CHKSUMS__ARMV7HF="sha256::284c4c9ae3eae7548450ead59e445b3b64c72301ecf393926578231e480dd21e"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(8\..+?)\""

--- a/app-devel/dotnet-sdk-8.0/spec
+++ b/app-devel/dotnet-sdk-8.0/spec
@@ -1,12 +1,11 @@
-VER=8.0.302
+VER=8.0.401
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Sdk/$VER/dotnet-sdk-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha512::43d0ea1df12c15a0e47560d2a84857ab50eb04ac693ab41413c04c591719101c4c8165e052a42a66719c67bd07ac299ca47edbb4944a2901df765042e56b316f"
+CHKSUMS__AMD64="sha256::6231d3902d2b2d8e73a3d681c5cbaacc95be35bdc02e25bd3947d0ab8629f9f9"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Sdk/$VER/dotnet-sdk-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha512::a6432f93056d74a7dd666f0deda80c96e6dd6a5e6291f71a0128846df9dee5aa0016fc3bd39f34ce5a859bb82ea4e4302790a78ffc2d05216f07f9bf94440c40"
+CHKSUMS__ARM64="sha256::4ae045ce1dd681a55613dfafbf3a6f4a27b467ba4718855f163e453f810a73d8"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Sdk/$VER/dotnet-sdk-$VER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha512::12edb024ab48f19e4f14405ab4d48f3f0da431168258ed0232e89bb98f57063c"
+CHKSUMS__ARMV7HF="sha256::d1dc3b47cd245489a2fcf772263376dd041b1e30420e45ac5dee91a08b574a32"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-sdk\": \"(8\..+?)\""
-CHKSUM="sha256::8c84340e7bbbe478463debb9230e18d5b1a94583c2ebc04eb28a39a232b37f55"

--- a/lang-dotnet/dotnet-host/spec
+++ b/lang-dotnet/dotnet-host/spec
@@ -1,11 +1,11 @@
-VER=8.0.6
+VER=8.0.8
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha256::b29b4e02b622cf0ff4581b0a96824b74a6690e97b95158a2e3d8fb43342dadfd"
+CHKSUMS__AMD64="sha256::4a9f56ae329a16f30c40a10c73fb4ebb713d01d8aa739ecb59ae277e5cabd8bd"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha256::0c1355dfba7b0e354294fd202274e4fa1838b93afcc180ecf667e25e5d1b7df6"
+CHKSUMS__ARM64="sha256::cf065e996c937cc0f0030af1bb078e758ae33d7a0c57854c0c0e90e91a58edc7"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha256::811b3d6d052e0d37c5cb2f6746cb950ae7c87a1c5082897a27bcd9258c94de66"
+CHKSUMS__ARMV7HF="sha256::fac8bd967b9010dc462b0cbe0564e8268eb3792f7edb03dcce825ad6be5cadf4"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(8\..+?)\""

--- a/lang-dotnet/dotnet-runtime-8.0/spec
+++ b/lang-dotnet/dotnet-runtime-8.0/spec
@@ -1,11 +1,11 @@
-VER=8.0.6
+VER=8.0.8
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha256::b29b4e02b622cf0ff4581b0a96824b74a6690e97b95158a2e3d8fb43342dadfd"
+CHKSUMS__AMD64="sha256::4a9f56ae329a16f30c40a10c73fb4ebb713d01d8aa739ecb59ae277e5cabd8bd"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha256::0c1355dfba7b0e354294fd202274e4fa1838b93afcc180ecf667e25e5d1b7df6"
+CHKSUMS__ARM64="sha256::cf065e996c937cc0f0030af1bb078e758ae33d7a0c57854c0c0e90e91a58edc7"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Runtime/$VER/dotnet-runtime-$VER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha256::811b3d6d052e0d37c5cb2f6746cb950ae7c87a1c5082897a27bcd9258c94de66"
+CHKSUMS__ARMV7HF="sha256::fac8bd967b9010dc462b0cbe0564e8268eb3792f7edb03dcce825ad6be5cadf4"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(8\..+?)\""


### PR DESCRIPTION
Topic Description
-----------------

- dotnet-sdk-8.0: update to 8.0.401
- aspnetcore-runtime-8.0: update to 8.0.8
- dotnet-runtime-8.0: update to 8.0.8
- dotnet-host: update to 8.0.8

Package(s) Affected
-------------------

- aspnetcore-runtime-8.0: 8.0.8
- aspnetcore-targeting-pack-8.0: 8.0.401
- dotnet-apphost-pack-8.0: 8.0.401
- dotnet-host: 8.0.8
- dotnet-hostfxr-8.0: 8.0.8
- dotnet-runtime-8.0: 8.0.8
- dotnet-sdk-8.0: 8.0.401
- dotnet-targeting-pack-8.0: 8.0.401
- dotnet-templates-8.0: 8.0.401

Security Update?
----------------

No

Build Order
-----------

```
#buildit dotnet-host dotnet-runtime-8.0 aspnetcore-runtime-8.0 dotnet-sdk-8.0
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
