### PR TITLE
Racket: update to 8.14

### DIFF
--- a/lang-lisp/racket/autobuild/beyond
+++ b/lang-lisp/racket/autobuild/beyond
@@ -1,13 +1,9 @@
 abinfo "Installing DrRacket desktop entry and icons ..."
 install -Dvm644 "$SRCDIR"/../share/pkgs/drracket/drracket/drracket.desktop \
     "$PKGDIR"/usr/share/applications/drracket.desktop
-install -dv "$PKGDIR"/usr/share/icons/hicolor/{16x16,32x32,48x48,256x256}/apps
-for i in 16 32 48; do
-    ln -sv ../../../../racket/pkgs/icons/plt-${i}x${i}.png \
-        "$PKGDIR"/usr/share/icons/hicolor/${i}x${i}/apps/drracket.png
-done
-ln -sv ../../../../racket/pkgs/icons/plt-logo-red-diffuse.png \
-    "$PKGDIR"/usr/share/icons/hicolor/256x256/apps/drracket.png
+install -dv "$PKGDIR"/usr/share/icons/hicolor/scalable/apps
+ln -sv ../../../../racket/pkgs/icons/racket-logo.svg \
+    "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/drracket.svg
 
 abinfo "Appending Icon= to desktop entry ..."
 echo "Icon=drracket" \

--- a/lang-lisp/racket/autobuild/defines
+++ b/lang-lisp/racket/autobuild/defines
@@ -1,16 +1,10 @@
 PKGNAME=racket
 PKGSEC=devel
-PKGDEP="gtk-3 libffi"
-BUILDDEP="ncurses lz4 urw-fonts"
+PKGDEP="gtk-3 libffi glibc"
+BUILDDEP="ncurses lz4 zlib urw-fonts"
 PKGDES="A full-spectrum programming language"
 
 RECONF=0
 
 AUTOTOOLS_AFTER__PPC64EL="--enable-pb --enable-mach=tpb64l"
 AUTOTOOLS_AFTER__LOONGSON3="--enable-pb --enable-mach=pb64l"
-AUTOTOOLS_AFTER__LOONGARCH64="--enable-pb --enable-mach=pb64l"
-
-# FIXME: FTBFS on mips64r6el, illegal instruction
-FAIL_ARCH="mips64r6el"
-# If fixed, uncomment the following building options
-# AUTOTOOLS_AFTER__MIPS64R6EL="--enable-pb --enable-mach=pb64l"

--- a/lang-lisp/racket/spec
+++ b/lang-lisp/racket/spec
@@ -1,5 +1,5 @@
-VER=8.13
-SRCS="tbl::https://mirror.racket-lang.org/installers/$VER/racket-$VER-src.tgz"
+VER=8.14
+SRCS="tbl::https://download.racket-lang.org/installers/$VER/racket-$VER-src.tgz"
 SUBDIR="racket-$VER/src"
-CHKSUMS="sha256::001e04920440b6589cf62d5677d18cc2ff6ae8fbaf77e63b8a8cf20890685fbc"
+CHKSUMS="sha256::aab8cc0db336ed2d382803c708ad55a95fc52a4436c912f616f7c49d4845ae2c"
 CHKUPDATE="anitya::id=13609"


### PR DESCRIPTION
Topic Description
-----------------

- racket: update to 8.14
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- racket: 8.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit racket
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
