### PR TITLE
picocom: update to 2024-07

### DIFF
--- a/app-utils/picocom/autobuild/build
+++ b/app-utils/picocom/autobuild/build
@@ -1,5 +1,9 @@
+abinfo "Building picocom..."
 make
-mkdir -p "$PKGDIR"/usr/bin
-cp picocom "$PKGDIR"/usr/bin/
-mkdir -p "$PKGDIR"/usr/share/man/man1
-cp picocom.1 "$PKGDIR"/usr/share/man/man1/
+
+abinfo "Building manpage..."
+make doc
+
+abinfo "Install binary and manpage..."
+install -D -m 755 picocom "$PKGDIR/usr/bin/picocom"
+install -D -m 644 picocom.1 "$PKGDIR/usr/share/man/man1/picocom.1"

--- a/app-utils/picocom/autobuild/defines
+++ b/app-utils/picocom/autobuild/defines
@@ -2,4 +2,4 @@ PKGNAME=picocom
 PKGEPOCH=1
 PKGDES="Minimal dumb-terminal emulation program"
 PKGSEC=utils
-PKGDEP="glibc"
+PKGDEP="glibc go-md2man"

--- a/app-utils/picocom/autobuild/defines
+++ b/app-utils/picocom/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=picocom
+PKGEPOCH=1
 PKGDES="Minimal dumb-terminal emulation program"
 PKGSEC=utils
 PKGDEP="glibc"

--- a/app-utils/picocom/spec
+++ b/app-utils/picocom/spec
@@ -1,4 +1,5 @@
-VER=3.1
-SRCS="tbl::https://github.com/npat-efault/picocom/archive/$VER.tar.gz"
-CHKSUMS="sha256::e6761ca932ffc6d09bd6b11ff018bdaf70b287ce518b3282d29e0270e88420bb"
+UPSTREAM_VER=2024-07
+VER="${UPSTREAM_VER//\-/.}"
+SRCS="git::commit=tags/$UPSTREAM_VER::https://gitlab.com/wsakernel/picocom"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3634"


### PR DESCRIPTION
Topic Description
-----------------

- picocom: build documentation picocom.1
- picocom: update to 2024-07

Package(s) Affected
-------------------

- picocom: 1:2024-07

Security Update?
----------------

No

Build Order
-----------

```
#buildit picocom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
