### PR TITLE
libspice-gtk: fix libsoup incompatibility

### DIFF
--- a/runtime-virtualization/libspice-gtk/autobuild/defines
+++ b/runtime-virtualization/libspice-gtk/autobuild/defines
@@ -1,15 +1,17 @@
 PKGNAME=libspice-gtk
 PKGSEC=libs
-PKGDEP="libcacard gtk-3 pulseaudio usbredir libsoup-3 lz4 phodav usbutils \
-        gst-plugins-base-1-0 json-glib opus"
+PKGDEP="libcacard gtk-3 pulseaudio usbredir libsoup-3 lz4 usbutils gstreamer \
+        json-glib opus"
 BUILDDEP="gobject-introspection gtk-doc vala spice-protocol intltool \
           wayland-protocols"
 PKGDES="GTK+ client and libraries for SPICE remote desktop servers"
 
+# FIXME: WebDAV support disabled temporarily due to incomplete libsoup-2.4/3.0
+# transition. Re-enable with GNOME update.
 MESON_AFTER=(
     -Dgtk=enabled
     -Dwayland-protocols=enabled
-    -Dwebdav=enabled
+    -Dwebdav=disabled
     -Dbuiltin-mjpeg=false
     -Dusbredir=enabled
     -Dlibcap-ng=enabled

--- a/runtime-virtualization/libspice-gtk/autobuild/prepare
+++ b/runtime-virtualization/libspice-gtk/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Appending core_perl to PATH ..."
+export PATH="$PATH:/usr/bin/core_perl"

--- a/runtime-virtualization/libspice-gtk/spec
+++ b/runtime-virtualization/libspice-gtk/spec
@@ -1,5 +1,5 @@
 VER=0.42
+REL=2
 SRCS="tbl::https://www.spice-space.org/download/gtk/spice-gtk-$VER.tar.xz"
 CHKSUMS="sha256::9380117f1811ad1faa1812cb6602479b6290d4a0d8cc442d44427f7f6c0e7a58"
 CHKUPDATE="anitya::id=11576"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- libspice-gtk: temporarily disable WebDAV feature due to libsoup ABI incompatibility
    FIXME: WebDAV support disabled temporarily due to incomplete libsoup-2.4/3.0
    transition (PhoDAV requires libsoup-3.0 yet our virtualisation binding runtime,
    libgovirt, was still built against libsoup-2.4). Re-enable with GNOME update.

Package(s) Affected
-------------------

- libspice-gtk: 0.42-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libspice-gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
