### PR TITLE
i3status: update to 2.15

### DIFF
--- a/desktop-wm/i3status/spec
+++ b/desktop-wm/i3status/spec
@@ -1,4 +1,4 @@
-VER=2.14
+VER=2.15
 SRCS="tbl::https://i3wm.org/i3status/i3status-$VER.tar.xz"
-CHKSUMS="sha256::5c4d0273410f9fa3301fd32065deda32e9617fcae8b3cb34793061bf21644924"
+CHKSUMS="sha256::6c67f52cae4f139df764ad1cc736562be0f97750791bc212b53f34c06eaf2205"
 CHKUPDATE="anitya::id=1350"


### PR DESCRIPTION
Topic Description
-----------------

- i3status: update to 2.15
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- i3status: 2.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit i3status
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
