### PR TITLE
kstars: update to 3.7.0

### DIFF
--- a/desktop-kde/kstars/spec
+++ b/desktop-kde/kstars/spec
@@ -1,4 +1,4 @@
-VER=3.6.7
+VER=3.7.0
 SRCS="tbl::https://download.kde.org/stable/kstars/kstars-$VER.tar.xz"
-CHKSUMS="sha256::b84833be19471e95f2be2dc38dfc20dc6998799abeaf8f26ece245203011a5ee"
+CHKSUMS="sha256::caf3759342ea522e4e75bdf8364f143f9aa821b15472f522c844a9a0c2a6baa8"
 CHKUPDATE="anitya::id=229035"


### PR DESCRIPTION
Topic Description
-----------------

- kstars: update to 3.7.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- kstars: 1:3.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit kstars
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
