### PR TITLE
kstars: update to 3.7.2

### DIFF
--- a/desktop-kde/kstars/autobuild/defines
+++ b/desktop-kde/kstars/autobuild/defines
@@ -1,9 +1,11 @@
 PKGNAME=kstars
 PKGSEC=kde
-PKGDEP="knewstuff kplotting libindi libraw wcslib astrometry.net \
-        xplanet knotifyconfig qtkeychain libindi stellarsolver"
+PKGDEP="knewstuff kplotting kconfig kguiaddons kwidgetsaddons kinit ki18n \
+        kio kxmlgui kiconthemes \
+        cfitsio libindi xplanet astrometry.net libraw wcslib  \
+        gsl qtkeychain stellarsolver zlib"
 BUILDDEP="extra-cmake-modules kdoctools eigen-3"
-PKGDES="A star field simulator"
+PKGDES="A desktop planetarium software"
 
 PKGREP="kstar"
 PKGREP="kde-l10n<=16.12.3"
@@ -11,6 +13,8 @@ PKGBREAK="kde-l10n<=16.12.3"
 
 PKGEPOCH=1
 
-CMAKE_AFTER="-DBUILD_TESTING=OFF"
+CMAKE_AFTER=(
+        -DBUILD_TESTING=OFF
+)
 
 FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64)"

--- a/desktop-kde/kstars/spec
+++ b/desktop-kde/kstars/spec
@@ -1,4 +1,4 @@
-VER=3.6.7
-SRCS="tbl::https://download.kde.org/stable/kstars/kstars-$VER.tar.xz"
-CHKSUMS="sha256::b84833be19471e95f2be2dc38dfc20dc6998799abeaf8f26ece245203011a5ee"
+VER=3.7.2
+SRCS="tbl::https://download.kde.org/stable/kstars/$VER/kstars-$VER.tar.xz"
+CHKSUMS="sha256::7c4bb7046056e5c82b637f33041de22f4fd246ba1b12d255b0635644db53e34b"
 CHKUPDATE="anitya::id=229035"


### PR DESCRIPTION
Topic Description
-----------------

- kstars: update to 3.7.2

Package(s) Affected
-------------------

- kstars: 1:3.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit kstars
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
