### PR TITLE
oma: install apt config file

### DIFF
--- a/app-admin/oma/autobuild/beyond
+++ b/app-admin/oma/autobuild/beyond
@@ -41,6 +41,8 @@ cp -v "$SRCDIR"/data/completions/oma.fish \
 abinfo "Installing config file ..."
 cp -v "$SRCDIR"/data/config/oma.toml \
 	"$PKGDIR"/etc/oma.toml
+install -Dvm644 "$SRCDIR"/data/apt.conf.d/50oma.conf \
+	-t "$PKGDIR"/etc/apt/apt.conf.d
 
 abinfo "Installing D-Bus config file ..."
 install -Dvm644 "$SRCDIR"/data/dbus/oma-dbus.conf \

--- a/app-admin/oma/autobuild/conffiles
+++ b/app-admin/oma/autobuild/conffiles
@@ -1,0 +1,2 @@
+/etc/oma.toml
+/etc/apt/apt.conf.d/50oma.conf

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,5 @@
 VER=1.7.1
+REL=1
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: install 50oma.conf to `/etc/apt/apt.conf.d` ...
    ... to allow `apt update` download `BinContents`, also add `confflies`

Package(s) Affected
-------------------

- oma: 1.7.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
