### PR TITLE
split lxgwnewcleargothic and lxgwfasmartgothic font

### DIFF
--- a/desktop-fonts/lxgwfasmartgothic-font/autobuild/build
+++ b/desktop-fonts/lxgwfasmartgothic-font/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Installing font file..."
+install -Dvm644 "$SRCDIR"/*.ttf \
+    -t "$PKGDIR"/usr/share/fonts/TTF
+
+abinfo "Installing LICENSE..."
+install -Dvm644 "$SRCDIR"/"$PKGNAME"/license.txt \
+    -t "$PKGDIR"/usr/share/doc/$PKGNAME/

--- a/desktop-fonts/lxgwfasmartgothic-font/autobuild/defines
+++ b/desktop-fonts/lxgwfasmartgothic-font/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="lxgwfasmartgothic-font"
+PKGDES="A Sans Serif font derived from 03 Smartfont UI"
+PKGDEP="fontconfig"
+PKGSEC="fonts"
+
+ABHOST="noarch"
+
+PKGBREAK="lxgwnewcleargothic-font<=1.124"
+PKGREP="lxgwnewcleargothic-font<=1.124"

--- a/desktop-fonts/lxgwfasmartgothic-font/spec
+++ b/desktop-fonts/lxgwfasmartgothic-font/spec
@@ -1,0 +1,11 @@
+VER=1.200
+SRCS="file::rename=LxgwFasmartGothic.ttf::https://github.com/lxgw/LxgwFasmartGothic/releases/download/v$VER/LXGWFasmartGothic.ttf \
+      file::rename=LxgwFasmartGothicCL.ttf::https://github.com/lxgw/LxgwFasmartGothic/releases/download/v$VER/LXGWFasmartGothicCL.ttf \
+      file::rename=LxgwFasmartGothicMN.ttf::https://github.com/lxgw/LxgwFasmartGothic/releases/download/v$VER/LXGWFasmartGothicMN.ttf \
+      git::commit=v$VER::https://github.com/lxgw/LxgwFasmartGothic.git"
+CHKSUMS="sha256::46c06f85c75aa55b4450fa02c37a35f0f8a4efe8058ffcb6e48b9e2eccd764eb \
+         sha256::984471f8b0bb1fe2cb2039fcad9c6b73e6d91e67d255be3840cd2d472ebf551e \
+         sha256::ab4523ef71e3f0c9dcf222388ad96b272e532eaf44ba9aaf4dd71289e4fc5f42 \
+         SKIP"
+CHKUPDATE="anitya::id=374031"
+SUBDIR="."

--- a/desktop-fonts/lxgwneoxihei-font/autobuild/build
+++ b/desktop-fonts/lxgwneoxihei-font/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Installing font file..."
+install -Dvm644 "$SRCDIR"/*.ttf \
+    -t "$PKGDIR"/usr/share/fonts/TTF
+
+abinfo "Installing LICENSE..."
+install -Dvm644 "$SRCDIR"/"$PKGNAME"/LICENSE* \
+    -t "$PKGDIR"/usr/share/doc/$PKGNAME/

--- a/desktop-fonts/lxgwneoxihei-font/autobuild/defines
+++ b/desktop-fonts/lxgwneoxihei-font/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="lxgwneoxihei-font"
+PKGDES="A Chinese sans-serif font derived from IPAex Gothic"
+PKGDEP="fontconfig"
+PKGSEC="fonts"
+
+ABHOST="noarch"
+
+PKGBREAK="lxgwnewcleargothic-font<=1.124"
+PKGREP="lxgwnewcleargothic-font<=1.124"

--- a/desktop-fonts/lxgwneoxihei-font/spec
+++ b/desktop-fonts/lxgwneoxihei-font/spec
@@ -1,0 +1,7 @@
+VER=1.200
+SRCS="file::rename=LxgwNeoXiHei-Book.ttf::https://github.com/lxgw/LxgwNeoXiHei/releases/download/v$VER/LxgwNeoXiHei.ttf \
+      git::commit=v$VER::https://github.com/lxgw/LxgwNeoXiHei.git"
+CHKSUMS="sha256::f26fb5f6524d760fa606fbc702283c37267800e0b6344de4eeb965eeedf672ec \
+         SKIP"
+CHKUPDATE="anitya::id=234778"
+SUBDIR="."

--- a/desktop-fonts/lxgwnewcleargothic-font/autobuild/build
+++ b/desktop-fonts/lxgwnewcleargothic-font/autobuild/build
@@ -1,7 +1,0 @@
-abinfo "Installing font file..."
-install -Dvm644 "$SRCDIR"/*.ttf \
-    -t "$PKGDIR"/usr/share/fonts/TTF
-
-abinfo "Installing LICENSE..."
-install -Dvm644 "$SRCDIR"/LxgwNeoXiHei-"$PKGVER"/LICENSE* \
-    -t "$PKGDIR"/usr/share/doc/$PKGNAME/

--- a/desktop-fonts/lxgwnewcleargothic-font/autobuild/defines
+++ b/desktop-fonts/lxgwnewcleargothic-font/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME="lxgwnewcleargothic-font"
-PKGDES="A Sans Serif font derived from IPAex Gothic (optimized for Simplified Chinese)"
-PKGDEP="fontconfig"
+PKGDES="Transitional package for LXGW Neo XiHei and LXGW Fasmart Gothic"
+PKGDEP="lxgwneoxihei-font lxgwfasmartgothic-font"
 PKGSEC="fonts"
 
 ABHOST="noarch"
-
-PKGPROV="lxgwneoxihei-font"
+ABTYPE=dummy
+PKGEPOCH=1

--- a/desktop-fonts/lxgwnewcleargothic-font/spec
+++ b/desktop-fonts/lxgwnewcleargothic-font/spec
@@ -1,9 +1,2 @@
-VER=1.124
-SRCS="file::rename=LXGWFasmartGothic.ttf::https://github.com/lxgw/LxgwNeoXiHei/releases/download/v$VER/LXGWFasmartGothic.ttf \
-      file::rename=LxgwNeoXiHei-Book.ttf::https://github.com/lxgw/LxgwNeoXiHei/releases/download/v$VER/LxgwNeoXiHei.ttf \
-      tbl::https://github.com/lxgw/LxgwNeoXiHei/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::fdd76652cda628b3b7fe9e6dacde8a5c45ff0808712ebc512bc9287a56a22cc1 \
-         sha256::76f7736d46053aea81c30d370e1f2dde8713241cef64f95c023c1d15b0e6f58b \
-         sha256::c9da3bc1f91c570621666408457d6e4ec7e9e044fef7c2a446bebec6e5e25852"
-CHKUPDATE="anitya::id=234778"
-SUBDIR="."
+VER=0
+DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- lxgwnewcleargothic-font: transitionalize => lxgwneoxihei-font, lxgwfasmartgothic-font
- lxgwfasmartgothic-font: new, 1.200, split from lxgwnewcleargothic-font
- lxgwneoxihei-font: update to 1.200, renamed from lxgwnewcleargothic-font

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit lxgwfasmartgothic-font lxgwnewcleargothic-font  lxgwneoxihei-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
