### PR TITLE
wine: update to 9.16+gecko2.47.4+mono9.2.0

### DIFF
--- a/app-emulation/wine/autobuild/defines
+++ b/app-emulation/wine/autobuild/defines
@@ -25,13 +25,6 @@ BUILDDEP__AMD64="${BUILDDEP} gcc+w64 binutils+w64 mingw+w64"
 BUILDDEP__ARM64="${BUILDDEP} llvm"
 USECLANG__ARM64=1
 
-# FIXME: clang-16: error: unsupported option '-fPIC' for target 'aarch64-unknown-windows-msvc'
-AB_FLAGS_PIC__ARM64=0
-# FIXME: clang-16: error: unsupported option '-fPIE' for target 'aarch64-unknown-windows-msvc'
-AB_FLAGS_PIE__ARM64=0
-# FIXME: LDFLAGS was unset due to a build system bug.
-ABSPLITDBG__ARM64=0
-
 NOSTATIC=0
 
 PKGEPOCH=3

--- a/app-emulation/wine/autobuild/overrides/usr/bin/wordpad
+++ b/app-emulation/wine/autobuild/overrides/usr/bin/wordpad
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# For some reason, wordpad.exe would not launch unless launched from its
+# executable path or when referenced with absolute path.
+#
+# This wrapper serves as a temporary workaround for this issue.
+#
+# wine wordpad.exe would still fail.
+case $(uname -m) in
+	aarch64)
+		_WINE_ARCH="aarch64"
+		_WINE_BITS="64"
+		;;
+	i*86)
+		_WINE_ARCH="i386"
+		_WINE_BITS="32"
+		;;
+	x86_64)
+		_WINE_ARCH="x86_64"
+		_WINE_BITS="64"
+		;;
+	*)
+		echo "Error: wordpad.exe is not yet supported on this platform."
+		exit 1
+		;;
+esac
+
+wine \
+	/usr/lib/wine"${_WINE_BITS}"/wine/"${_WINE_ARCH}"-windows/wordpad.exe \
+	"$@"

--- a/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-mime-msi.desktop
+++ b/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-mime-msi.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
-Name=Windows Installer File
-Name[ar]=مثبت حزم واين
+Name=Windows Installer Package
+Name[zh_CN]=Windows Installer 程序包
 Exec=wine %f
 MimeType=application/x-ole-storage;text/mspg-legacyinfo;
 Hidden=true

--- a/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-notepad.desktop
+++ b/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-notepad.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=Notepad
-Comment=Text Editor
-Name[ar]=مفكرة
-Comment[ar]=محرر النّصوص مفكرة واين
+Name=Wine Notepad
+Comment=Wine Text Editor
+Name[zh_CN]=Wine 记事本
+Name[zh_CN]=Wine 文本文件编辑器
 Exec=notepad
 Icon=notepad
 Terminal=false

--- a/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-oleview.desktop
+++ b/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-oleview.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Name=Wine OLE View
-Comment=Windows OLE View
-Name[ar]=عارض العناصر
-Comment[ar]=لعرض العناصر البيئية في واين
+Comment=View Windows OLE Properties
+Name[zh_CN]=Wine OLE 查看器
+Comment[zh_CN]=查看 Windows OLE 属性
 Exec=wine oleview
 Icon=wine
 Terminal=false

--- a/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-regedit.desktop
+++ b/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-regedit.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=Regedit
-Comment=Wine registry editor
-Name[ar]=محرر السّجل
-Comment[ar]=محرر لسجلات واين
+Name=Wine Regedit
+Comment=Utility to edit Wine (Windows) registry
+Name[zh_CN]=Wine 注册表编辑器
+Comment[zh_CN]=Wine (Windows) 注册表编辑实用工具
 Exec=regedit
 Icon=regedit
 Terminal=false

--- a/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-uninstaller.desktop
+++ b/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-uninstaller.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Name=Wine Software Uninstaller
-Comment=Interface to uninstall software
-Name[ar]=مزيل التطبيقات من واين
-Comment[ar]=واجهة إزالة التّطبيقات من واين
+Comment=Utility to uninstall Wine (Windows) software
+Name[zh_CN]=Wine 软件卸载工具
+Comment[zh_CN]=Wine (Windows) 软件卸载实用工具
 Exec=wine uninstaller
 Icon=msiexec
 Terminal=false

--- a/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-wineboot.desktop
+++ b/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-wineboot.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Name=Wine Boot
-Comment=Simulate restart
-Name[ar]=إقلاع واين
-Comment[ar]=محاكاة إعادة التشغيل لواين
+Comment=Simulate Wine (Windows) restart
+Name[zh_CN]=引导 Wine 环境
+Comment[zh_CN]=模拟 Wine (Windows) 环境重新启动
 Exec=wineboot
 Icon=wine
 Terminal=false

--- a/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-winecfg.desktop
+++ b/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-winecfg.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Name=Wine Configuration
-Comment=Interface to set wine parameters
-Name[ar]=إعدادات واين
-Comment[ar]=لوحة تحكم بمنظومة واين
+Comment=Utility to configure Wine preferences and parameters
+Name[zh_CN]=Wine 设置
+Comment[zh_CN]=Wine 参数与首选项配置实用工具
 Exec=winecfg
 Icon=winecfg
 Terminal=false

--- a/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-winefile.desktop
+++ b/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-winefile.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Name=Wine File
-Comment=Wine File Browser
-Name[ar]=مدير ملفات واين
-Comment[ar]=إدارة الملفات بطريقة واين
+Comment=File manager for Wine
+Name[zh_CN]=Wine 文件管理器
+Comment[zh_CN]=用于 Wine 环境的文件管理器
 Exec=winefile
 Icon=winefile
 Terminal=false

--- a/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-winemine.desktop
+++ b/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-winemine.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=WineMine
+Name=Wine Mine
 Comment=Wine Minesweeper
-Name[ar]=كانسة ألغام واين
-Comment[ar]=لعبة كانسة ألغام واين
+Name[zh_CN]=Wine 扫雷
+Comment[zh_CN]=Wine 扫雷游戏
 Exec=winemine
 Icon=winemine
 Terminal=false

--- a/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-winhelp.desktop
+++ b/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-winhelp.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Name=Wine Help
-Comment=Windows Help Browser
-Name[ar]=أداة المساعدة في واين
-Comment[ar]=استعراض ملفات المساعدة بتنسيقات وندوز
+Comment=Viewer for Windows Help files
+Name[zh_CN]=Wine 帮助查看器
+Comment[zh_CN]=Windows Help 文件查看器
 Exec=wine winhlp32
 Icon=winhelp
 Terminal=false

--- a/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-wordpad.desktop
+++ b/app-emulation/wine/autobuild/overrides/usr/share/applications/wine-wordpad.desktop
@@ -1,9 +1,9 @@
 [Desktop Entry]
-Name=Wine Wordpad
-Comment=Text Editor
-Name[ar]=دفتر واين
-Comment[ar]=محرر النّصوص دفتر واين
-Exec=wine wordpad
+Name=Wine WordPad
+Comment=Rich text file editor for Wine
+Name[zh_CN]=Wine 写字板
+Comment[zh_CN]=Wine 富文本编辑器
+Exec=wordpad
 Icon=wordpad
 Terminal=false
 Type=Application

--- a/app-emulation/wine/autobuild/prepare
+++ b/app-emulation/wine/autobuild/prepare
@@ -5,13 +5,6 @@ if ab_match_arch amd64 || \
     export LDFLAGS="${LDFLAGS} -fPIC"
 fi
 
-# FIXME: lld did not read LDFLAGS correctly, this may be fixed with a Wine update.
-# (Noted as of 7.22)
-if ab_match_arch arm64; then
-    abinfo "Unsetting LDFLAGS to work around a build failure ..."
-    unset LDFLAGS
-fi
-
 abinfo "Dropping -ffunction-sections, -fdata-sections, --gc-sections flags to fix build ..."
 export CFLAGS="${CFLAGS/-ffunction-sections -fdata-sections/}"
 export LDFLAGS="${LDFLAGS/-Wl,--gc-sections/}"

--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,13 +1,13 @@
 __GECKO_VER=2.47.4
 __MONO_VER=9.2.0
-UPSTREAM_VER=9.15
+UPSTREAM_VER=9.16
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER:0:1}.x/wine-${UPSTREAM_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
-CHKSUMS="sha256::79adef436dd68ddbd70178670a3c23aa98e8afd5540ac0f42345894c458b78dd \
+CHKSUMS="sha256::89042ae8c80b2333f8a7d18877fc4179c07d6357ab7f28ccbda6d06f3c330c50 \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 9.16+gecko2.47.4+mono9.2.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wine: 3:9.16+gecko2.47.4+mono9.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
