### PR TITLE
nvidia: update to 560.35.03

### DIFF
--- a/runtime-display/nvidia/autobuild/build
+++ b/runtime-display/nvidia/autobuild/build
@@ -78,7 +78,10 @@ if [[ -d "${SRCDIR}/autobuild/patches" ]]; then
     abinfo "Patching kernel driver"
     for i in $(find "${SRCDIR}/autobuild/patches/" -type f -name "*.patch" | sort); do
         abinfo "Applying $(basename $i)"
-        (cd kernel; patch -Np1 -i "$i")
+        (
+            cd kernel
+            patch -Np1 -i "$i"
+        )
     done
 else
     abinfo "No kernel patches needed"
@@ -149,6 +152,18 @@ install -Dvm755 "libnvidia-cfg.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-cfg.so.$PKGVER
 install -Dvm755 "libnvidia-ml.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-ml.so.$PKGVER
+install -Dvm755 "libnvidia-egl-xlib.so.1" \
+    "$PKGDIR"/usr/lib/libnvidia-egl-xlib.so.1
+install -Dvm755 "libnvidia-egl-xcb.so.1" \
+    "$PKGDIR"/usr/lib/libnvidia-egl-xcb.so.1
+install -Dvm644 "20_nvidia_xlib.json" \
+    "$PKGDIR"/usr/share/egl/egl_external_platform.d/20_nvidia_xlib.json
+install -Dvm644 "20_nvidia_xcb.json" \
+    "$PKGDIR"/usr/share/egl/egl_external_platform.d/20_nvidia_xcb.json
+install -Dvm644 "10_nvidia.json" \
+    "$PKGDIR"/usr/share/glvnd/egl_vendor.d/20_nvidia_xlib.json
+install -Dvm644 "10_nvidia.json" \
+    "$PKGDIR"/usr/share/glvnd/egl_vendor.d/20_nvidia_xcb.json
 
 install_for_all 755 "libnvidia-fbc.so.$PKGVER" "$PKGDIR"/usr/lib
 
@@ -208,6 +223,10 @@ abinfo 'Vulkan Ray tracing extensions'
 install_for_all 755 "libnvidia-rtcore.so.$PKGVER" "$PKGDIR"/usr/lib
 install_for_all 755 "libnvoptix.so.$PKGVER" "$PKGDIR"/usr/lib
 install_for_all 644 "nvoptix.bin" "$PKGDIR"/usr/share/nvidia
+
+abinfo "Vulkan SC Core"
+install_if_amd64 755 "libnvidia-vksc-core.so.$PKGVER" \
+    "$PKGDIR"/usr/lib
 
 abinfo 'Optical flow library'
 install -Dvm755 "libnvidia-opticalflow.so.${PKGVER}" \
@@ -274,10 +293,10 @@ install_for_all 755 libnvidia-gtk3.so.$PKGVER "$PKGDIR"/usr/lib
 abinfo "Power management services"
 for i in suspend hibernate resume; do
     install_for_all 644 systemd/system/nvidia-${i}.service \
-        "$PKGDIR"/usr/lib/systemd/system/nvidia-${i}.service
+        "$PKGDIR"/usr/lib/systemd/system
 done
-install_for_all 755 systemd/system-sleep/nvidia "$PKGDIR"/usr/lib/systemd/system-sleep/nvidia
-install_for_all 755 systemd/nvidia-sleep.sh "$PKGDIR"/usr/bin/nvidia-sleep.sh
+install_for_all 755 systemd/system-sleep/nvidia "$PKGDIR"/usr/lib/systemd/system-sleep
+install_for_all 755 systemd/nvidia-sleep.sh "$PKGDIR"/usr/bin
 install_for_all 755 nvidia-powerd "${PKGDIR}/usr/bin"
 install_for_all 644 nvidia-dbus.conf "${PKGDIR}/usr/share/dbus-1/system.d"
 install_for_all 644 systemd/system/nvidia-powerd.service "$PKGDIR"/usr/lib/systemd/system

--- a/runtime-display/nvidia/autobuild/build-optenv32
+++ b/runtime-display/nvidia/autobuild/build-optenv32
@@ -33,6 +33,12 @@ install -Dvm755 "libnvidia-opticalflow.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-opticalflow.so.$PKGVER
 install -Dvm755 "libnvidia-nvvm.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-nvvm.so.$PKGVER
+install -Dvm755 "libnvidia-egl-xlib.so.1" \
+    "$PKGDIR"/opt/32/lib/libnvidia-egl-xlib.so.1
+install -Dvm755 "libnvidia-egl-xcb.so.1" \
+    "$PKGDIR"/opt/32/lib/libnvidia-egl-xcb.so.1
+install -Dvm755 "libnvidia-egl-gbm.so.1.1.1" \
+    "$PKGDIR"/opt/32/lib/libnvidia-egl-gbm.so.1.1.1
 
 install -Dvm755 "libnvidia-gpucomp.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-gpucomp.so.$PKGVER

--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,4 +1,4 @@
-VER=555.58.02
+VER=560.35.03
 _SETTINGS_VER=${VER}
 
 SRCS__AMD64="
@@ -6,16 +6,16 @@ SRCS__AMD64="
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__AMD64="
-	sha256::c5cb6de133d194e27aaf94b9e21e56e8f4faff7672d91e0048d14fbbc4d21ca3
-	sha256::4b191403aa4948fa8336c8fa02b309327121c030f6c680a46a7b28a0a0d92dc0
+	sha256::f2932c92fadd43c5b2341be453fc4f73f0ad7185c26bb7a43fbde81ae29f1fe3
+	sha256::e0e85a58423c30bcc2f95b7c28c674593a95e862f9c8c5c7b82e19cd3ce18fe5
 "
 SRCS__ARM64="
 	file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/aarch64/$VER/NVIDIA-Linux-aarch64-${VER}.run
 	tbl::https://github.com/NVIDIA/nvidia-settings/archive/${_SETTINGS_VER}.tar.gz
 "
 CHKSUMS__ARM64="
-	sha256::c1bdb48ac32b460f0f790054f7a95627304c9237f248051aaade048199e1c85f
-	sha256::4b191403aa4948fa8336c8fa02b309327121c030f6c680a46a7b28a0a0d92dc0
+	sha256::b3c64054abd1357a63c5162a337139a2cb3915da96fadbf5a900b6a438df1beb
+	sha256::e0e85a58423c30bcc2f95b7c28c674593a95e862f9c8c5c7b82e19cd3ce18fe5
 "
 
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- nvidia: update to 560.35.03

Package(s) Affected
-------------------

- nvidia: 560.35.03

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
