### PR TITLE
postgresql (PostgreSQL): drop duplicate sysusers.d configuration

### DIFF
--- a/app-database/postgresql/autobuild/overrides/etc/sysusers.d/postgres.conf
+++ b/app-database/postgresql/autobuild/overrides/etc/sysusers.d/postgres.conf
@@ -1,3 +1,0 @@
-#Type Name       ID                  GECOS              Home directory Shell
-g    postgres  90
-u    postgres  90:90 "Postgres Daemon Owner" /srv/postgres  /bin/bash

--- a/app-database/postgresql/spec
+++ b/app-database/postgresql/spec
@@ -1,4 +1,5 @@
 VER=13.16
+REL=1
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
 CHKSUMS="sha256::c9cbbb6129f02328204828066bb3785c00a85c8ca8fd329c2a8a53c1f5cd8865"
 CHKUPDATE="anitya::id=5601"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql: drop duplicate sysusers.d configuration

Package(s) Affected
-------------------

- postgresql: 1:13.16-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit postgresql
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
