### PR TITLE
elfutils: retire AOSC debuginfo server

### DIFF
--- a/app-utils/elfutils/autobuild/overrides/etc/profile.d/debuginfod.sh
+++ b/app-utils/elfutils/autobuild/overrides/etc/profile.d/debuginfod.sh
@@ -1,2 +1,2 @@
-export DEBUGINFOD_URLS="https://debuginfod.aosc.io https://debuginfod.elfutils.org"
+export DEBUGINFOD_URLS="https://debuginfod.elfutils.org"
 export DEBUGINFOD_PROGRESS=1

--- a/app-utils/elfutils/spec
+++ b/app-utils/elfutils/spec
@@ -1,4 +1,5 @@
 VER=0.191
+REL=1
 SRCS="tbl::https://sourceware.org/elfutils/ftp/$VER/elfutils-$VER.tar.bz2"
 # checksum: https://sourceware.org/elfutils/ftp/$VER/sha512.sum
 CHKSUMS="sha256::df76db71366d1d708365fc7a6c60ca48398f14367eb2b8954efc8897147ad871"


### PR DESCRIPTION
Topic Description
-----------------

- elfutils: retire AOSC debuginfo server
    We no longer provide debuginfo analysis and export on our own server.

Package(s) Affected
-------------------

- elfutils: 0.191-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit elfutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
