### PR TITLE
poetry: update to 1.8.3

### DIFF
--- a/lang-python/cachecontrol/autobuild/defines
+++ b/lang-python/cachecontrol/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=cachecontrol
 PKGSEC=python
 PKGDEP="requests python-msgpack"
-BUILDDEP="setuptools"
+BUILDDEP="flit-core"
 PKGDES="A port of the caching algorithms in httplib2 for use with requests session object"
 
 ABHOST=noarch

--- a/lang-python/cachecontrol/spec
+++ b/lang-python/cachecontrol/spec
@@ -1,5 +1,4 @@
-VER=0.12.6
-REL=2
-SRCS="tbl::https://pypi.io/packages/source/C/CacheControl/CacheControl-$VER.tar.gz"
-CHKSUMS="sha256::be9aa45477a134aee56c8fac518627e1154df063e85f67d4f83ce0ccc23688e8"
+VER=0.14.0
+SRCS="tbl::https://pypi.io/packages/source/C/CacheControl/cachecontrol-$VER.tar.gz"
+CHKSUMS="sha256::7db1195b41c81f8274a7bbd97c956f44e8348265a1bc7641c37dfebc39f0c938"
 CHKUPDATE="anitya::id=59291"

--- a/lang-python/poetry-core/spec
+++ b/lang-python/poetry-core/spec
@@ -1,4 +1,4 @@
-VER=1.7.0
+VER=1.9.0
 SRCS="tbl::https://github.com/python-poetry/poetry-core/releases/download/${VER}/poetry_core-${VER}.tar.gz"
-CHKSUMS="sha256::8f679b83bd9c820082637beca1204124d5d2a786e4818da47ec8acefd0353b74"
+CHKSUMS="sha256::fa7a4001eae8aa572ee84f35feb510b321bd652e5cf9293249d62853e1f935a2"
 CHKUPDATE="anitya::id=71155"

--- a/lang-python/poetry/autobuild/defines
+++ b/lang-python/poetry/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=python
 PKGDEP="cachecontrol cachy cleo clikit html5lib-python jsonschema pexpect \
         pkginfo pyparsing pyrsistent toolbelt requests shellingham tomlkit \
 	crashtest pexpect packaging virtualenv keyring poetry-core lockfile \
-	platformdirs dulwich tomli"
+	platformdirs dulwich tomli pyproject-hooks"
 BUILDDEP="setuptools python-build python-installer"
 PKGDES="Python dependency management and packaging made easy"
 

--- a/lang-python/poetry/spec
+++ b/lang-python/poetry/spec
@@ -1,5 +1,4 @@
-VER=1.6.1
-REL=1
+VER=1.8.3
 SRCS="https://pypi.io/packages/source/p/poetry/poetry-$VER.tar.gz"
-CHKSUMS="sha256::0ab9b1a592731cc8b252b8d6aaeea19c72cc0a109d7468b829ad57e6c48039d2"
+CHKSUMS="sha256::67f4eb68288eab41e841cc71a00d26cf6bdda9533022d0189a145a34d0a35f48"
 CHKUPDATE="anitya::id=32514"

--- a/lang-python/poetry/spec
+++ b/lang-python/poetry/spec
@@ -1,4 +1,5 @@
 VER=1.6.1
+REL=1
 SRCS="https://pypi.io/packages/source/p/poetry/poetry-$VER.tar.gz"
 CHKSUMS="sha256::0ab9b1a592731cc8b252b8d6aaeea19c72cc0a109d7468b829ad57e6c48039d2"
 CHKUPDATE="anitya::id=32514"

--- a/lang-python/pyproject-hooks/autobuild/defines
+++ b/lang-python/pyproject-hooks/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=pyproject-hooks
+PKGSEC=python
+BUILDDEP="flit-core"
+PKGDES="A library for calling build-backends in pyproject.toml-based project"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pyproject-hooks/autobuild/defines.stage2
+++ b/lang-python/pyproject-hooks/autobuild/defines.stage2
@@ -1,0 +1,7 @@
+PKGNAME=pyproject-hooks
+PKGSEC=python
+BUILDDEP="flit-core"
+PKGDES="A library for calling build-backends in pyproject.toml-based project"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pyproject-hooks/autobuild/prepare.stage2
+++ b/lang-python/pyproject-hooks/autobuild/prepare.stage2
@@ -1,0 +1,2 @@
+abinfo "Installing bootstrap packages from pypi ..."
+pip install build pyproject-hooks

--- a/lang-python/pyproject-hooks/spec
+++ b/lang-python/pyproject-hooks/spec
@@ -1,0 +1,4 @@
+VER=1.1.0
+SRCS="tbl::https://pypi.io/packages/source/p/pyproject-hooks/pyproject_hooks-$VER.tar.gz"
+CHKSUMS="sha256::4b37730834edbd6bd37f26ece6b44802fb1c1ee2ece0e54ddff8bfc06db86965"
+CHKUPDATE="anitya::id=320474"

--- a/lang-python/python-build/autobuild/defines
+++ b/lang-python/python-build/autobuild/defines
@@ -1,10 +1,8 @@
 PKGNAME=python-build
 PKGSEC=python
-PKGDEP="packaging pep517 tomli virtualenv"
-BUILDDEP="setuptools"
+PKGDEP="packaging tomli virtualenv pyproject-hooks"
+BUILDDEP="flit-core"
 PKGDES="A compliant PEP 517 build frontend"
 
 ABHOST=noarch
 NOPYTHON2=1
-
-ABTYPE=python

--- a/lang-python/python-build/spec
+++ b/lang-python/python-build/spec
@@ -1,4 +1,4 @@
-VER=0.8.0
+VER=1.2.1
 SRCS="tbl::https://pypi.io/packages/source/b/build/build-$VER.tar.gz"
-CHKSUMS="sha256::887a6d471c901b1a6e6574ebaeeebb45e5269a79d095fe9a8f88d6614ed2e5f0"
+CHKSUMS="sha256::526263f4870c26f26c433545579475377b2b7588b6f1eac76a001e873ae3e19d"
 CHKUPDATE="anitya::id=132276"

--- a/lang-python/python-installer/autobuild/defines
+++ b/lang-python/python-installer/autobuild/defines
@@ -6,5 +6,4 @@ PKGDES="A low-level library for installing from a Python wheel distribution"
 
 ABHOST=noarch
 NOPYTHON2=1
-
-ABTYPE=python
+ABTYPE=pep517

--- a/lang-python/python-installer/spec
+++ b/lang-python/python-installer/spec
@@ -1,4 +1,4 @@
-VER=0.5.1
+VER=0.7.0
 SRCS="tbl::https://pypi.io/packages/source/i/installer/installer-$VER.tar.gz"
-CHKSUMS="sha256::f970995ec2bb815e2fdaf7977b26b2091e1e386f0f42eafd5ac811953dc5d445"
+CHKSUMS="sha256::a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631"
 CHKUPDATE="anitya::id=197662"

--- a/lang-python/toolbelt/spec
+++ b/lang-python/toolbelt/spec
@@ -1,5 +1,4 @@
-VER=0.9.1
-REL=4
+VER=1.0.0
 SRCS="tbl::https://github.com/requests/toolbelt/archive/$VER.tar.gz"
-CHKSUMS="sha256::c8e68e537e87ae088e3a0eb6d80ed5b7cf5d6df503d0e843e0a5e47283db487b"
+CHKSUMS="sha256::0a052d9b5595718b7ec79c201e45e123dd3b9c6d659561479f24b7a2a85bbe81"
 CHKUPDATE="anitya::id=5665"


### PR DESCRIPTION
Topic Description
-----------------

- python-build: update 1.2.1
- cachecontrol: update to 0.14.0
- toolbelt: update 1.0.0
- python-installer: update to 0.7.0
- poetry-core: update to 1.9.0
- poetry: update to 1.8.3
- pyproject-hooks: new, 1.1.0

Package(s) Affected
-------------------

- cachecontrol: 0.14.0
- poetry: 1.8.3
- poetry-core: 1.9.0
- pyproject-hooks: 1.1.0
- python-build: 1.2.1
- python-installer: 0.7.0
- toolbelt: 1.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyproject-hooks python-installer python-build toolbelt cachecontrol poetry-core poetry
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
