### PR TITLE
libreoffice: rebuild against zxing-cpp 2.2.1-1

### DIFF
--- a/app-productivity/libreoffice/autobuild/defines
+++ b/app-productivity/libreoffice/autobuild/defines
@@ -10,7 +10,7 @@ PKGDEP="boost bsh clucene coinmp cups curl dbus-glib desktop-file-utils glew glu
         libqxp libstaroffice libtommath libvisio libwpd libwpg libwps libxslt \
         libzmf lpsolve mariadb mythes neon nspr nss openjdk pango poppler postgresql \
         python-3 redland sane-backends serf shared-mime-info unixodbc xmlsec \
-        libnumbertext lxml vulkan abseil-cpp"
+        libnumbertext lxml vulkan abseil-cpp zxing-cpp"
 PKGDEP__LOONGSON3="${PKGDEP/openjdk/openjdk-8}"
 BUILDDEP="abseil-cpp apache-ant apr bluez cppunit dejavu-fonts doxygen gdb glm \
           gobject-introspection gperf icu liberation-fonts mdds \

--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,5 +1,5 @@
 VER=24.2.3.2
-REL=2
+REL=3
 SRCS="tbl::https://download.documentfoundation.org/libreoffice/src/${VER:0:6}/libreoffice-$VER.tar.xz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz \


### PR DESCRIPTION
Topic Description
-----------------

- libreoffice: rebuild against zxing-cpp 2.2.1-1

Package(s) Affected
-------------------

- libreoffice: 24.2.3.2-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libreoffice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
