### PR TITLE
linux-kernel: update to 6.10.6

### DIFF
--- a/app-admin/kernel-tools/spec
+++ b/app-admin/kernel-tools/spec
@@ -1,4 +1,4 @@
-VER=6.10.5
+VER=6.10.6
 
 # Use this for stable releases.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
@@ -9,5 +9,5 @@ SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 #REL=0.${RC}
 #SRCS="tbl::https://git.kernel.org/torvalds/t/linux-${VER%%.0}-rc${RC}.tar.gz"
 
-CHKSUMS="sha256::30909eb2e0434dce97a93cd97ed0dfab7688a124bc3ebc3ecf6c776de09ccc0b"
+CHKSUMS="sha256::e0d50d5b74f8599375660e79f187af7493864dba5ff6671b14983376a070b3d1"
 CHKUPDATE="anitya::id=6501"

--- a/runtime-kernel/linux+kernel/autobuild/defines
+++ b/runtime-kernel/linux+kernel/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=linux+kernel
 PKGSEC=kernel
-PKGDEP="linux-kernel-6.10.5"
+PKGDEP="linux-kernel-6.10.6"
 PKGDES="Generic Linux Kernel for AOSC OS (Mainline)"
 
 PKGREP="linux+image+new linux+header+new linux+image linux+header linux+image+old linux+header+old"

--- a/runtime-kernel/linux+kernel/spec
+++ b/runtime-kernel/linux+kernel/spec
@@ -1,4 +1,4 @@
-VER=6.10.5
+VER=6.10.6
 # To RFC: Increment by 0.1 per RC release, i.e., RC3 = 0.3.
 #RC=
 #REL=0.${RC}

--- a/runtime-kernel/linux-kernel/autobuild/defines
+++ b/runtime-kernel/linux-kernel/autobuild/defines
@@ -1,11 +1,11 @@
-PKGNAME=linux-kernel-6.10.5
+PKGNAME=linux-kernel-6.10.6
 PKGSEC=kernel
 PKGDEP=""
 BUILDDEP="bc git pahole parallel kernel-build-common"
 BUILDDEP__AMD64="$BUILDDEP llvm"
 BUILDDEP__ARM64="$BUILDDEP llvm"
 BUILDDEP__MIPS64R6EL="${BUILDDEP} uboot-tools"
-PKGDES="Generic Linux Kernel v6.10.5 for AOSC OS (Mainline)"
+PKGDES="Generic Linux Kernel v6.10.6 for AOSC OS (Mainline)"
 
 ABSTRIP=0
 ABELFDEP=0

--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-more-uarches-for-kernel-6.8-rc4-.patch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-more-uarches-for-kernel-6.8-rc4-.patch.patch
@@ -1,4 +1,4 @@
-From ef143487a85320473b711692de7278b9f7a056fc Mon Sep 17 00:00:00 2001
+From b211106687c194a8ef7bd49f47562eec0bd9509c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 00:31:56 +0800
 Subject: [PATCH 001/103] more-uarches-for-kernel-6.8-rc4+.patch
@@ -116,7 +116,7 @@ Ref: https://github.com/graysky2/kernel_compiler_patch/blob/30db2170d3ddefa13a3d
  3 files changed, 537 insertions(+), 16 deletions(-)
 
 diff --git a/arch/x86/Kconfig.cpu b/arch/x86/Kconfig.cpu
-index 2a7279d80460..55941c31ade3 100644
+index 2a7279d80460a..55941c31ade35 100644
 --- a/arch/x86/Kconfig.cpu
 +++ b/arch/x86/Kconfig.cpu
 @@ -157,7 +157,7 @@ config MPENTIUM4
@@ -653,7 +653,7 @@ index 2a7279d80460..55941c31ade3 100644
  	default "4"
  
 diff --git a/arch/x86/Makefile b/arch/x86/Makefile
-index 801fd85c3ef6..93cc88b59cbb 100644
+index 801fd85c3ef69..93cc88b59cbb8 100644
 --- a/arch/x86/Makefile
 +++ b/arch/x86/Makefile
 @@ -176,8 +176,49 @@ else
@@ -709,7 +709,7 @@ index 801fd85c3ef6..93cc88b59cbb 100644
          KBUILD_CFLAGS += $(cflags-y)
  
 diff --git a/arch/x86/include/asm/vermagic.h b/arch/x86/include/asm/vermagic.h
-index 75884d2cdec3..7acca9b5a9d5 100644
+index 75884d2cdec37..7acca9b5a9d56 100644
 --- a/arch/x86/include/asm/vermagic.h
 +++ b/arch/x86/include/asm/vermagic.h
 @@ -17,6 +17,54 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,4 +1,4 @@
-From 4a9611b9eb8bbb6f08114150cc051ff9f9979d10 Mon Sep 17 00:00:00 2001
+From 4236ae0cc202c9bc4c735019ec568b3113ed0764 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:36:33 +0800
 Subject: [PATCH 002/103] Input: Add driver for PixArt PS/2 touchpad
@@ -30,7 +30,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/
  create mode 100644 drivers/input/mouse/pixart_ps2.h
 
 diff --git a/drivers/input/mouse/Kconfig b/drivers/input/mouse/Kconfig
-index 833b643f0616..8a27a20d04b0 100644
+index 833b643f06164..8a27a20d04b01 100644
 --- a/drivers/input/mouse/Kconfig
 +++ b/drivers/input/mouse/Kconfig
 @@ -69,6 +69,18 @@ config MOUSE_PS2_LOGIPS2PP
@@ -53,7 +53,7 @@ index 833b643f0616..8a27a20d04b0 100644
  	bool "Synaptics PS/2 mouse protocol extension" if EXPERT
  	default y
 diff --git a/drivers/input/mouse/Makefile b/drivers/input/mouse/Makefile
-index a1336d5bee6f..563029551529 100644
+index a1336d5bee6f3..5630295515291 100644
 --- a/drivers/input/mouse/Makefile
 +++ b/drivers/input/mouse/Makefile
 @@ -32,6 +32,7 @@ psmouse-$(CONFIG_MOUSE_PS2_ELANTECH)	+= elantech.o
@@ -66,7 +66,7 @@ index a1336d5bee6f..563029551529 100644
  psmouse-$(CONFIG_MOUSE_PS2_TOUCHKIT)	+= touchkit_ps2.o
 diff --git a/drivers/input/mouse/pixart_ps2.c b/drivers/input/mouse/pixart_ps2.c
 new file mode 100644
-index 000000000000..1993fc760d7b
+index 0000000000000..1993fc760d7bc
 --- /dev/null
 +++ b/drivers/input/mouse/pixart_ps2.c
 @@ -0,0 +1,300 @@
@@ -372,7 +372,7 @@ index 000000000000..1993fc760d7b
 +}
 diff --git a/drivers/input/mouse/pixart_ps2.h b/drivers/input/mouse/pixart_ps2.h
 new file mode 100644
-index 000000000000..47a1d040f2d1
+index 0000000000000..47a1d040f2d10
 --- /dev/null
 +++ b/drivers/input/mouse/pixart_ps2.h
 @@ -0,0 +1,36 @@
@@ -413,7 +413,7 @@ index 000000000000..47a1d040f2d1
 +
 +#endif  /* _PIXART_PS2_H */
 diff --git a/drivers/input/mouse/psmouse-base.c b/drivers/input/mouse/psmouse-base.c
-index a0aac76b1e41..41af3460077d 100644
+index a0aac76b1e41d..41af3460077d6 100644
 --- a/drivers/input/mouse/psmouse-base.c
 +++ b/drivers/input/mouse/psmouse-base.c
 @@ -36,6 +36,7 @@
@@ -455,7 +455,7 @@ index a0aac76b1e41..41af3460077d 100644
  		if (psmouse_try_protocol(psmouse, PSMOUSE_GENPS,
  					 &max_proto, set_properties, true))
 diff --git a/drivers/input/mouse/psmouse.h b/drivers/input/mouse/psmouse.h
-index 4d8acfe0d82a..23f7fa7243cb 100644
+index 4d8acfe0d82aa..23f7fa7243cb5 100644
 --- a/drivers/input/mouse/psmouse.h
 +++ b/drivers/input/mouse/psmouse.h
 @@ -69,6 +69,7 @@ enum psmouse_type {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
@@ -1,4 +1,4 @@
-From a8beb3341635f6ba41b989244d7f29e4cc147162 Mon Sep 17 00:00:00 2001
+From b1a30a2098cc49e0da843543beab31174cc9da8e Mon Sep 17 00:00:00 2001
 From: Mark Weiman <mark.weiman@markzz.com>
 Date: Wed, 27 Jan 2021 13:28:09 -0500
 Subject: [PATCH 003/103] pci: Enable overrides for missing ACS capabilities
@@ -14,7 +14,7 @@ Ref: To be replaced by https://github.com/torvalds/linux/commit/47c8846a49baa8c0
  2 files changed, 110 insertions(+)
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index c82446cef8e2..913defca544d 100644
+index c82446cef8e21..913defca544d8 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -4447,6 +4447,14 @@
@@ -33,7 +33,7 @@ index c82446cef8e2..913defca544d 100644
  				Safety option to keep boot IRQs enabled. This
  				should never be necessary.
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 568410e64ce6..86600feb22f8 100644
+index 568410e64ce64..86600feb22f86 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -287,6 +287,106 @@ static int __init pci_apply_final_quirks(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-cpuinfo-fix-a-warning-for-CONFIG_CPUMASK_OFFSTACK.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-cpuinfo-fix-a-warning-for-CONFIG_CPUMASK_OFFSTACK.patch
@@ -1,4 +1,4 @@
-From 3730b0c05ba5af1f5e83794047f368168fddc597 Mon Sep 17 00:00:00 2001
+From 28a2d6b30f3ba8e329fedf289d2432a0d098c78e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 12 Jul 2022 12:47:48 +0800
 Subject: [PATCH 004/103] cpuinfo: fix a warning for CONFIG_CPUMASK_OFFSTACK
@@ -45,7 +45,7 @@ Ref: https://lore.kernel.org/all/20220714084136.570176-3-chenhuacai@loongson.cn/
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/sh/kernel/cpu/proc.c b/arch/sh/kernel/cpu/proc.c
-index a306bcd6b341..5f6d0e827bae 100644
+index a306bcd6b3413..5f6d0e827baeb 100644
 --- a/arch/sh/kernel/cpu/proc.c
 +++ b/arch/sh/kernel/cpu/proc.c
 @@ -132,7 +132,7 @@ static int show_cpuinfo(struct seq_file *m, void *v)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-drm-amdgpu-use-amdgpu-by-default-for-si-cik-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-drm-amdgpu-use-amdgpu-by-default-for-si-cik-devices.patch
@@ -1,4 +1,4 @@
-From e4ebdb28862ed6f311018232a22f42df35a363cf Mon Sep 17 00:00:00 2001
+From 119325f8ec3aa715c63f73747aa446da7127038b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 29 Feb 2024 20:54:51 +0800
 Subject: [PATCH 005/103] drm: amdgpu: use amdgpu by default for si/cik devices
@@ -18,7 +18,7 @@ Ref: Contact the author.
  2 files changed, 4 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index ea14f1c8f430..980dde77689d 100644
+index ea14f1c8f4304..980dde77689df 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -595,13 +595,8 @@ module_param_named(timeout_period, amdgpu_watchdog_timer.period, uint, 0644);
@@ -50,7 +50,7 @@ index ea14f1c8f430..980dde77689d 100644
  module_param_named(cik_support, amdgpu_cik_support, int, 0444);
  #endif
 diff --git a/drivers/gpu/drm/radeon/radeon_drv.c b/drivers/gpu/drm/radeon/radeon_drv.c
-index 7bf08164140e..e42956b683bb 100644
+index 7bf08164140ef..e42956b683bb1 100644
 --- a/drivers/gpu/drm/radeon/radeon_drv.c
 +++ b/drivers/gpu/drm/radeon/radeon_drv.c
 @@ -239,12 +239,12 @@ module_param_named(uvd, radeon_uvd, int, 0444);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-drm-amdgpu-radeon-disable-cache-flush-workaround-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-drm-amdgpu-radeon-disable-cache-flush-workaround-for.patch
@@ -1,4 +1,4 @@
-From 505c92978d96d9fcd3aa947396d4dcc4ae7d6d72 Mon Sep 17 00:00:00 2001
+From 86e48dc0f0f968cc6ddee1a23d9077abd3fec461 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 16 Jul 2024 14:37:00 +0800
 Subject: [PATCH 006/103] drm: amdgpu: radeon: disable cache flush workaround
@@ -19,7 +19,7 @@ Ref: https://lore.kernel.org/all/20240617105846.1516006-1-uwu@icenowy.me/
  3 files changed, 25 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
-index 541dbd70d8c7..e0049fbdbe15 100644
+index 541dbd70d8c75..e0049fbdbe158 100644
 --- a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
 @@ -2117,6 +2117,14 @@ static void gfx_v7_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
@@ -46,7 +46,7 @@ index 541dbd70d8c7..e0049fbdbe15 100644
  	/* Then send the real EOP event down the pipe. */
  	amdgpu_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));
 diff --git a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
-index 2f0e72caee1a..e36179b221a6 100644
+index 2f0e72caee1af..e36179b221a6b 100644
 --- a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
 @@ -6153,6 +6153,13 @@ static void gfx_v8_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
@@ -72,7 +72,7 @@ index 2f0e72caee1a..e36179b221a6 100644
  	/* Then send the real EOP event down the pipe:
  	 * EVENT_WRITE_EOP - flush caches, send int */
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index b5e96a8fc2c1..e9034b40e0d0 100644
+index b5e96a8fc2c16..e9034b40e0d02 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -3543,6 +3543,13 @@ void cik_fence_gfx_ring_emit(struct radeon_device *rdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-ethernet-bundle-module-for-Motorcomm-YT6801.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-ethernet-bundle-module-for-Motorcomm-YT6801.patch
@@ -1,4 +1,4 @@
-From 3a301cb317f9e0b280949042e5025ac8fc680e90 Mon Sep 17 00:00:00 2001
+From df22e26397404fd9e315fdb285f17dbc74dd8c7e Mon Sep 17 00:00:00 2001
 From: wanghuai <748928840@qq.com>
 Date: Fri, 2 Feb 2024 19:05:26 +0000
 Subject: [PATCH 007/103] ethernet: bundle module for Motorcomm YT6801
@@ -61,7 +61,7 @@ Ref: https://github.com/deepin-community/kernel/pull/194
  create mode 100644 drivers/net/ethernet/motorcomm/fuxi-os.h
 
 diff --git a/drivers/net/ethernet/Kconfig b/drivers/net/ethernet/Kconfig
-index 6a19b5393ed1..0a2125de8bc1 100644
+index 6a19b5393ed11..0a2125de8bc13 100644
 --- a/drivers/net/ethernet/Kconfig
 +++ b/drivers/net/ethernet/Kconfig
 @@ -124,6 +124,7 @@ source "drivers/net/ethernet/mediatek/Kconfig"
@@ -73,7 +73,7 @@ index 6a19b5393ed1..0a2125de8bc1 100644
  source "drivers/net/ethernet/microsoft/Kconfig"
  source "drivers/net/ethernet/moxa/Kconfig"
 diff --git a/drivers/net/ethernet/Makefile b/drivers/net/ethernet/Makefile
-index 0d872d4efcd1..3e3d90f93697 100644
+index 0d872d4efcd10..3e3d90f936978 100644
 --- a/drivers/net/ethernet/Makefile
 +++ b/drivers/net/ethernet/Makefile
 @@ -61,6 +61,7 @@ obj-$(CONFIG_NET_VENDOR_MEDIATEK) += mediatek/
@@ -91,7 +91,7 @@ index 0d872d4efcd1..3e3d90f93697 100644
 +obj-m += motorcomm/
 diff --git a/drivers/net/ethernet/motorcomm/Kconfig b/drivers/net/ethernet/motorcomm/Kconfig
 new file mode 100644
-index 000000000000..30fc2eabd2be
+index 0000000000000..30fc2eabd2bef
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/Kconfig
 @@ -0,0 +1,29 @@
@@ -126,7 +126,7 @@ index 000000000000..30fc2eabd2be
 +endif # NET_VENDOR_MOTORCOMM
 diff --git a/drivers/net/ethernet/motorcomm/Makefile b/drivers/net/ethernet/motorcomm/Makefile
 new file mode 100644
-index 000000000000..5f25a4eda63c
+index 0000000000000..5f25a4eda63c5
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/Makefile
 @@ -0,0 +1,23 @@
@@ -155,7 +155,7 @@ index 000000000000..5f25a4eda63c
 +	fuxi-gmac-debugfs.o
 diff --git a/drivers/net/ethernet/motorcomm/Notice.txt b/drivers/net/ethernet/motorcomm/Notice.txt
 new file mode 100644
-index 000000000000..230978a18635
+index 0000000000000..230978a186357
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/Notice.txt
 @@ -0,0 +1,30 @@
@@ -191,7 +191,7 @@ index 000000000000..230978a18635
 +
 diff --git a/drivers/net/ethernet/motorcomm/README b/drivers/net/ethernet/motorcomm/README
 new file mode 100644
-index 000000000000..fb76cff20c1c
+index 0000000000000..fb76cff20c1ce
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/README
 @@ -0,0 +1,89 @@
@@ -286,7 +286,7 @@ index 000000000000..fb76cff20c1c
 +	YT6801 supports Jumbo Frame size up to 9 kBytes.
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-dbg.c b/drivers/net/ethernet/motorcomm/fuxi-dbg.c
 new file mode 100644
-index 000000000000..5deddef39242
+index 0000000000000..5deddef392424
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-dbg.c
 @@ -0,0 +1,510 @@
@@ -802,7 +802,7 @@ index 000000000000..5deddef39242
 +
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-dbg.h b/drivers/net/ethernet/motorcomm/fuxi-dbg.h
 new file mode 100644
-index 000000000000..a8c42369e783
+index 0000000000000..a8c42369e7837
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-dbg.h
 @@ -0,0 +1,24 @@
@@ -833,7 +833,7 @@ index 000000000000..a8c42369e783
 \ No newline at end of file
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-efuse.c b/drivers/net/ethernet/motorcomm/fuxi-efuse.c
 new file mode 100644
-index 000000000000..a91734fd84d7
+index 0000000000000..a91734fd84d70
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-efuse.c
 @@ -0,0 +1,968 @@
@@ -1808,7 +1808,7 @@ index 000000000000..a91734fd84d7
 \ No newline at end of file
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-efuse.h b/drivers/net/ethernet/motorcomm/fuxi-efuse.h
 new file mode 100644
-index 000000000000..7832028e5168
+index 0000000000000..7832028e51684
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-efuse.h
 @@ -0,0 +1,33 @@
@@ -1848,7 +1848,7 @@ index 000000000000..7832028e5168
 \ No newline at end of file
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-gmac-common.c b/drivers/net/ethernet/motorcomm/fuxi-gmac-common.c
 new file mode 100644
-index 000000000000..86b55a7b6df3
+index 0000000000000..86b55a7b6df3b
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-gmac-common.c
 @@ -0,0 +1,1014 @@
@@ -2868,7 +2868,7 @@ index 000000000000..86b55a7b6df3
 +}
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-gmac-debugfs.c b/drivers/net/ethernet/motorcomm/fuxi-gmac-debugfs.c
 new file mode 100644
-index 000000000000..6e3a8684c423
+index 0000000000000..6e3a8684c4237
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-gmac-debugfs.c
 @@ -0,0 +1,760 @@
@@ -3634,7 +3634,7 @@ index 000000000000..6e3a8684c423
 +#endif /* HAVE_XLGMAC_DEBUG_FS */
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-gmac-desc.c b/drivers/net/ethernet/motorcomm/fuxi-gmac-desc.c
 new file mode 100644
-index 000000000000..d030b6eb9fc3
+index 0000000000000..d030b6eb9fc3c
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-gmac-desc.c
 @@ -0,0 +1,1254 @@
@@ -4894,7 +4894,7 @@ index 000000000000..d030b6eb9fc3
 +}
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-gmac-ethtool.c b/drivers/net/ethernet/motorcomm/fuxi-gmac-ethtool.c
 new file mode 100644
-index 000000000000..32ce0fa7b6ed
+index 0000000000000..32ce0fa7b6ed4
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-gmac-ethtool.c
 @@ -0,0 +1,1178 @@
@@ -6078,7 +6078,7 @@ index 000000000000..32ce0fa7b6ed
 +}
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-gmac-hw.c b/drivers/net/ethernet/motorcomm/fuxi-gmac-hw.c
 new file mode 100644
-index 000000000000..f63dbb0c9e0b
+index 0000000000000..f63dbb0c9e0b0
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-gmac-hw.c
 @@ -0,0 +1,6714 @@
@@ -12798,7 +12798,7 @@ index 000000000000..f63dbb0c9e0b
 +}
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-gmac-net.c b/drivers/net/ethernet/motorcomm/fuxi-gmac-net.c
 new file mode 100644
-index 000000000000..905bb997a2ab
+index 0000000000000..905bb997a2abf
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-gmac-net.c
 @@ -0,0 +1,2366 @@
@@ -15170,7 +15170,7 @@ index 000000000000..905bb997a2ab
 +}
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-gmac-pci.c b/drivers/net/ethernet/motorcomm/fuxi-gmac-pci.c
 new file mode 100644
-index 000000000000..7233de3438d7
+index 0000000000000..7233de3438d7e
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-gmac-pci.c
 @@ -0,0 +1,365 @@
@@ -15541,7 +15541,7 @@ index 000000000000..7233de3438d7
 +MODULE_LICENSE("Dual BSD/GPL");
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-gmac-phy.c b/drivers/net/ethernet/motorcomm/fuxi-gmac-phy.c
 new file mode 100644
-index 000000000000..59b017a37f41
+index 0000000000000..59b017a37f41e
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-gmac-phy.c
 @@ -0,0 +1,422 @@
@@ -15969,7 +15969,7 @@ index 000000000000..59b017a37f41
 +#endif
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-gmac-reg.h b/drivers/net/ethernet/motorcomm/fuxi-gmac-reg.h
 new file mode 100644
-index 000000000000..5977de44f7b9
+index 0000000000000..5977de44f7b9e
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-gmac-reg.h
 @@ -0,0 +1,1876 @@
@@ -17851,7 +17851,7 @@ index 000000000000..5977de44f7b9
 +#endif /* __FUXI_GMAC_REG_H__ */
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-gmac.h b/drivers/net/ethernet/motorcomm/fuxi-gmac.h
 new file mode 100644
-index 000000000000..855a82bd11be
+index 0000000000000..855a82bd11be6
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-gmac.h
 @@ -0,0 +1,924 @@
@@ -18781,7 +18781,7 @@ index 000000000000..855a82bd11be
 +#endif /* __FUXI_GMAC_H__ */
 diff --git a/drivers/net/ethernet/motorcomm/fuxi-os.h b/drivers/net/ethernet/motorcomm/fuxi-os.h
 new file mode 100644
-index 000000000000..26518fae6ae6
+index 0000000000000..26518fae6ae6a
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/fuxi-os.h
 @@ -0,0 +1,560 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-net-stmmac-Move-the-atds-flag-to-the-stmmac_dma_cfg-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-net-stmmac-Move-the-atds-flag-to-the-stmmac_dma_cfg-.patch
@@ -1,4 +1,4 @@
-From b931da8d83881be1fa9866079e82869b994ee781 Mon Sep 17 00:00:00 2001
+From 881ed3622d63489ed66f639e58f67c3303028654 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:45:28 +0800
 Subject: [PATCH 008/103] net: stmmac: Move the atds flag to the stmmac_dma_cfg
@@ -39,7 +39,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  8 files changed, 10 insertions(+), 11 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
-index e1b761dcfa1d..d87079016952 100644
+index e1b761dcfa1dd..d870790169524 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
 @@ -299,7 +299,7 @@ static int sun8i_dwmac_dma_reset(void __iomem *ioaddr)
@@ -52,7 +52,7 @@ index e1b761dcfa1d..d87079016952 100644
  	writel(EMAC_RX_INT | EMAC_TX_INT, ioaddr + EMAC_INT_EN);
  	writel(0x1FFFFFF, ioaddr + EMAC_INT_STA);
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
-index daf79cdbd3ec..bb82ee9b855f 100644
+index daf79cdbd3ecf..bb82ee9b855fe 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
 @@ -71,7 +71,7 @@ static void dwmac1000_dma_axi(void __iomem *ioaddr, struct stmmac_axi *axi)
@@ -74,7 +74,7 @@ index daf79cdbd3ec..bb82ee9b855f 100644
  
  	if (dma_cfg->aal)
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac100_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwmac100_dma.c
-index dea270f60cc3..f861babc06f9 100644
+index dea270f60cc3e..f861babc06f97 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac100_dma.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac100_dma.c
 @@ -19,7 +19,7 @@
@@ -87,7 +87,7 @@ index dea270f60cc3..f861babc06f9 100644
  	/* Enable Application Access by writing to DMA CSR0 */
  	writel(DMA_BUS_MODE_DEFAULT | (dma_cfg->pbl << DMA_BUS_MODE_PBL_SHIFT),
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.c
-index 84d3a8551b03..e0165358c4ac 100644
+index 84d3a8551b032..e0165358c4ac8 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.c
 @@ -153,7 +153,7 @@ static void dwmac410_dma_init_channel(struct stmmac_priv *priv,
@@ -100,7 +100,7 @@ index 84d3a8551b03..e0165358c4ac 100644
  	u32 value = readl(ioaddr + DMA_SYS_BUS_MODE);
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.c
-index dd2ab6185c40..7840bc403788 100644
+index dd2ab6185c40e..7840bc403788e 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.c
 @@ -20,7 +20,7 @@ static int dwxgmac2_dma_reset(void __iomem *ioaddr)
@@ -113,7 +113,7 @@ index dd2ab6185c40..7840bc403788 100644
  	u32 value = readl(ioaddr + XGMAC_DMA_SYSBUS_MODE);
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/hwif.h b/drivers/net/ethernet/stmicro/stmmac/hwif.h
-index a318c84ddb8a..0bc1a0130df6 100644
+index a318c84ddb8ac..0bc1a0130df64 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/hwif.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/hwif.h
 @@ -175,8 +175,7 @@ struct dma_features;
@@ -127,7 +127,7 @@ index a318c84ddb8a..0bc1a0130df6 100644
  			  struct stmmac_dma_cfg *dma_cfg, u32 chan);
  	void (*init_rx_chan)(struct stmmac_priv *priv, void __iomem *ioaddr,
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 33e2bd5a351c..cea52d4921a4 100644
+index 33e2bd5a351ca..cea52d4921a45 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -3006,7 +3006,6 @@ static int stmmac_init_dma_engine(struct stmmac_priv *priv)
@@ -157,7 +157,7 @@ index 33e2bd5a351c..cea52d4921a4 100644
  	if (priv->plat->axi)
  		stmmac_axi(priv, priv->ioaddr, priv->plat->axi);
 diff --git a/include/linux/stmmac.h b/include/linux/stmmac.h
-index f92c195c76ed..1536455f9052 100644
+index f92c195c76ed2..1536455f90529 100644
 --- a/include/linux/stmmac.h
 +++ b/include/linux/stmmac.h
 @@ -100,6 +100,7 @@ struct stmmac_dma_cfg {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-net-stmmac-Add-multi-channel-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-net-stmmac-Add-multi-channel-support.patch
@@ -1,4 +1,4 @@
-From 8d7897faf9707418f8467648c5a55646944fa170 Mon Sep 17 00:00:00 2001
+From 00c47865225b45e227bf4134cc92892c6362b1d7 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:45:29 +0800
 Subject: [PATCH 009/103] net: stmmac: Add multi-channel support
@@ -37,7 +37,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  6 files changed, 68 insertions(+), 39 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
-index d87079016952..cc93f73a380e 100644
+index d870790169524..cc93f73a380e5 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
 @@ -395,7 +395,7 @@ static void sun8i_dwmac_dma_start_tx(struct stmmac_priv *priv,
@@ -50,7 +50,7 @@ index d87079016952..cc93f73a380e 100644
  	u32 v;
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
-index bb82ee9b855f..f161ec9ac490 100644
+index bb82ee9b855fe..f161ec9ac490a 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
 @@ -70,15 +70,17 @@ static void dwmac1000_dma_axi(void __iomem *ioaddr, struct stmmac_axi *axi)
@@ -158,7 +158,7 @@ index bb82ee9b855f..f161ec9ac490 100644
  	.init_tx_chan = dwmac1000_dma_init_tx,
  	.axi = dwmac1000_dma_axi,
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac_dma.h b/drivers/net/ethernet/stmicro/stmmac/dwmac_dma.h
-index 72672391675f..5d9c18f5bbf5 100644
+index 72672391675f6..5d9c18f5bbf58 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac_dma.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac_dma.h
 @@ -22,6 +22,31 @@
@@ -203,7 +203,7 @@ index 72672391675f..5d9c18f5bbf5 100644
  			  u32 chan, bool rx, bool tx);
  void dwmac_disable_dma_irq(struct stmmac_priv *priv, void __iomem *ioaddr,
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac_lib.c b/drivers/net/ethernet/stmicro/stmmac/dwmac_lib.c
-index 85e18f9a22f9..4846bf49c576 100644
+index 85e18f9a22f92..4846bf49c576a 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac_lib.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac_lib.c
 @@ -28,65 +28,65 @@ int dwmac_dma_reset(void __iomem *ioaddr)
@@ -296,7 +296,7 @@ index 85e18f9a22f9..4846bf49c576 100644
  #ifdef DWMAC_DMA_DEBUG
  	/* Enable it to monitor DMA rx/tx status in case of critical problems */
 diff --git a/drivers/net/ethernet/stmicro/stmmac/hwif.h b/drivers/net/ethernet/stmicro/stmmac/hwif.h
-index 0bc1a0130df6..42192a52a5ab 100644
+index 0bc1a0130df64..42192a52a5abe 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/hwif.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/hwif.h
 @@ -197,7 +197,7 @@ struct stmmac_dma_ops {
@@ -309,7 +309,7 @@ index 0bc1a0130df6..42192a52a5ab 100644
  			       u32 chan, bool rx, bool tx);
  	void (*disable_dma_irq)(struct stmmac_priv *priv, void __iomem *ioaddr,
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index cea52d4921a4..71c6a6b70768 100644
+index cea52d4921a45..71c6a6b70768f 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -2370,9 +2370,11 @@ static void stmmac_dma_operation_mode(struct stmmac_priv *priv)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-net-stmmac-Export-dwmac1000_dma_ops.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-net-stmmac-Export-dwmac1000_dma_ops.patch
@@ -1,4 +1,4 @@
-From 89c8fbc414b487b8f18f9a74edd7e0bebde8b059 Mon Sep 17 00:00:00 2001
+From 0f381674e37587661c828c05beb92c04e06a986e Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:45:30 +0800
 Subject: [PATCH 010/103] net: stmmac: Export dwmac1000_dma_ops
@@ -22,7 +22,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
-index f161ec9ac490..66c0c22908b1 100644
+index f161ec9ac490a..66c0c22908b17 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
 @@ -296,3 +296,4 @@ const struct stmmac_dma_ops dwmac1000_dma_ops = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-net-stmmac-dwmac-loongson-Drop-duplicated-hash-based.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-net-stmmac-dwmac-loongson-Drop-duplicated-hash-based.patch
@@ -1,4 +1,4 @@
-From 873685803dd97eb37ce264b5316f0960d2fc8b88 Mon Sep 17 00:00:00 2001
+From 83a9702809a4813c67a1b0c368af58db3df80be0 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:47:07 +0800
 Subject: [PATCH 011/103] net: stmmac: dwmac-loongson: Drop duplicated
@@ -22,7 +22,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 9e40c28d453a..9dbd11766364 100644
+index 9e40c28d453ab..9dbd117663645 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -16,7 +16,7 @@ static int loongson_default_data(struct plat_stmmacenet_data *plat)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-net-stmmac-dwmac-loongson-Drop-pci_enable-disable_ms.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-net-stmmac-dwmac-loongson-Drop-pci_enable-disable_ms.patch
@@ -1,4 +1,4 @@
-From 24f8efe4267f949c3c5d457f1c9f97c5105fb44d Mon Sep 17 00:00:00 2001
+From f93e4047a879696e8e6e3cdadf3165382c58546b Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:47:08 +0800
 Subject: [PATCH 012/103] net: stmmac: dwmac-loongson: Drop
@@ -21,7 +21,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  1 file changed, 3 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 9dbd11766364..32814afdf321 100644
+index 9dbd117663645..32814afdf3216 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -114,7 +114,6 @@ static int loongson_dwmac_probe(struct pci_dev *pdev, const struct pci_device_id

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-net-stmmac-dwmac-loongson-Use-PCI_DEVICE_DATA-macro-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-net-stmmac-dwmac-loongson-Use-PCI_DEVICE_DATA-macro-.patch
@@ -1,4 +1,4 @@
-From daac6f488aa04c56fbbdda947cf7de0b5d1a5b53 Mon Sep 17 00:00:00 2001
+From 2d2a6edc137e1eef64509f5b965c085f048a18d0 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:47:09 +0800
 Subject: [PATCH 013/103] net: stmmac: dwmac-loongson: Use PCI_DEVICE_DATA()
@@ -24,7 +24,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 32814afdf321..f39c13a74bb5 100644
+index 32814afdf3216..f39c13a74bb57 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -9,6 +9,8 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-net-stmmac-dwmac-loongson-Detach-GMAC-specific-platf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-net-stmmac-dwmac-loongson-Detach-GMAC-specific-platf.patch
@@ -1,4 +1,4 @@
-From cd2108adb7e915038b600cbc8bdf2aa9d0b9ed65 Mon Sep 17 00:00:00 2001
+From 1d311ee30f4cc043cd76719a3aba3ea35e5106e1 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:47:10 +0800
 Subject: [PATCH 014/103] net: stmmac: dwmac-loongson: Detach GMAC-specific
@@ -41,7 +41,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  1 file changed, 12 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index f39c13a74bb5..9b2e4bdf7cc7 100644
+index f39c13a74bb57..9b2e4bdf7cc76 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -11,7 +11,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-net-stmmac-dwmac-loongson-Init-ref-and-PTP-clocks-ra.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-net-stmmac-dwmac-loongson-Init-ref-and-PTP-clocks-ra.patch
@@ -1,4 +1,4 @@
-From 3896e1e010dc58bd44c4e9df897a7f3c1a436e71 Mon Sep 17 00:00:00 2001
+From 0bb2a322401d4a6807cce45672c9eb9146f61c17 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:02 +0800
 Subject: [PATCH 015/103] net: stmmac: dwmac-loongson: Init ref and PTP clocks
@@ -23,7 +23,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 9b2e4bdf7cc7..327275b28dc2 100644
+index 9b2e4bdf7cc76..327275b28dc2c 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -35,6 +35,9 @@ static void loongson_default_data(struct plat_stmmacenet_data *plat)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-net-stmmac-dwmac-loongson-Add-phy_interface-for-Loon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-net-stmmac-dwmac-loongson-Add-phy_interface-for-Loon.patch
@@ -1,4 +1,4 @@
-From fb1c3aaeda0b484d3d36bd4fd99d75ff2fc33962 Mon Sep 17 00:00:00 2001
+From 0931892523d49e96c0bce51635bf838b7137c94d Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:03 +0800
 Subject: [PATCH 016/103] net: stmmac: dwmac-loongson: Add phy_interface for
@@ -22,7 +22,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 327275b28dc2..7d3f284b9176 100644
+index 327275b28dc2c..7d3f284b9176c 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -52,6 +52,8 @@ static int loongson_gmac_data(struct plat_stmmacenet_data *plat)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-net-stmmac-dwmac-loongson-Introduce-PCI-device-info-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-net-stmmac-dwmac-loongson-Introduce-PCI-device-info-.patch
@@ -1,4 +1,4 @@
-From 60e036563f2dc5b71530bca1ff01c3029ab1d92d Mon Sep 17 00:00:00 2001
+From 344da002409669167eb3c90a967337fdea0c386f Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:04 +0800
 Subject: [PATCH 017/103] net: stmmac: dwmac-loongson: Introduce PCI device
@@ -23,7 +23,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  1 file changed, 15 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 7d3f284b9176..10b49bea8e3c 100644
+index 7d3f284b9176c..10b49bea8e3cd 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -11,6 +11,10 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-net-stmmac-dwmac-loongson-Add-DT-less-GMAC-PCI-devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-net-stmmac-dwmac-loongson-Add-DT-less-GMAC-PCI-devic.patch
@@ -1,4 +1,4 @@
-From da409a66d606a7892874c881bd5d88a8a6fd8160 Mon Sep 17 00:00:00 2001
+From 51716c9d5f55143b65077b2c13620c5a8517167f Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:05 +0800
 Subject: [PATCH 018/103] net: stmmac: dwmac-loongson: Add DT-less GMAC
@@ -32,7 +32,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  1 file changed, 102 insertions(+), 63 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 10b49bea8e3c..c0740a41025b 100644
+index 10b49bea8e3cd..c0740a41025bd 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -12,11 +12,15 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-net-stmmac-dwmac-loongson-Add-Loongson-Multi-channel.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-net-stmmac-dwmac-loongson-Add-Loongson-Multi-channel.patch
@@ -1,4 +1,4 @@
-From 8b856dd0d4ab68f2dc599b68ce98b9890f93b412 Mon Sep 17 00:00:00 2001
+From 49ff02591b437576354f5ceae228745576985860 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:54 +0800
 Subject: [PATCH 019/103] net: stmmac: dwmac-loongson: Add Loongson
@@ -59,7 +59,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  2 files changed, 327 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/common.h b/drivers/net/ethernet/stmicro/stmmac/common.h
-index 9cd62b2110a1..aed6ae80cc7c 100644
+index 9cd62b2110a14..aed6ae80cc7cf 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/common.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/common.h
 @@ -29,6 +29,7 @@
@@ -71,7 +71,7 @@ index 9cd62b2110a1..aed6ae80cc7c 100644
  #define DWMAC_CORE_4_10		0x41
  #define DWMAC_CORE_5_00		0x50
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index c0740a41025b..48c92ba826d9 100644
+index c0740a41025bd..48c92ba826d9e 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -8,8 +8,69 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-net-stmmac-dwmac-loongson-Add-Loongson-GNET-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-net-stmmac-dwmac-loongson-Add-Loongson-GNET-support.patch
@@ -1,4 +1,4 @@
-From a66c432af44c1c61e258da50564e7902bed3f012 Mon Sep 17 00:00:00 2001
+From 0a27c27cb7eb164fb4941ccd18a5842c9128bd47 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:55 +0800
 Subject: [PATCH 020/103] net: stmmac: dwmac-loongson: Add Loongson GNET
@@ -47,7 +47,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  1 file changed, 74 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 48c92ba826d9..949e349ef856 100644
+index 48c92ba826d9e..949e349ef8568 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -65,11 +65,13 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-net-stmmac-dwmac-loongson-Add-loongson-module-author.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-net-stmmac-dwmac-loongson-Add-loongson-module-author.patch
@@ -1,4 +1,4 @@
-From 24b916ef01ce64f453230547519e42cc8292b042 Mon Sep 17 00:00:00 2001
+From 542634e99bbdf5e570f19a27e49a52c2defa74bb Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:56 +0800
 Subject: [PATCH 021/103] net: stmmac: dwmac-loongson: Add loongson module
@@ -19,7 +19,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 949e349ef856..bfe6e2d631bd 100644
+index 949e349ef8568..bfe6e2d631bdf 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -686,4 +686,5 @@ module_pci_driver(loongson_dwmac_driver);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-net-stmmac-Add-Phytium-GMAC-glue-layer.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-net-stmmac-Add-Phytium-GMAC-glue-layer.patch
@@ -1,4 +1,4 @@
-From ae06cdee64edc3d22cc7fe3525a99f0fbb3d46a4 Mon Sep 17 00:00:00 2001
+From ce1d71e50393cbfcce32ae072468ce65c2d9f1d1 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
 Subject: [PATCH 022/103] net: stmmac: Add Phytium GMAC glue layer
@@ -21,7 +21,7 @@ Ref: https://gitee.com/phytium_embedded/phytium-linux-kernel/commit/bf64fd4ae38b
  create mode 100644 drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 958e935449e5..a778ab226d00 100644
+index 958e935449e58..a778ab226d00b 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -2625,6 +2625,12 @@ S:	Maintained
@@ -38,7 +38,7 @@ index 958e935449e5..a778ab226d00 100644
  R:	cros-qcom-dts-watchers@chromium.org
  F:	arch/arm64/boot/dts/qcom/sc7180*
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-index 05cc07b8f48c..0a30d9b406a1 100644
+index 05cc07b8f48c0..0a30d9b406a16 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
 +++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
 @@ -121,6 +121,16 @@ config DWMAC_MESON
@@ -59,7 +59,7 @@ index 05cc07b8f48c..0a30d9b406a1 100644
  	tristate "Qualcomm ETHQOS support"
  	default ARCH_QCOM
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet/stmicro/stmmac/Makefile
-index c2f0e91f6bf8..9ad873b60920 100644
+index c2f0e91f6bf83..9ad873b60920e 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Makefile
 +++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
 @@ -19,6 +19,7 @@ obj-$(CONFIG_DWMAC_IPQ806X)	+= dwmac-ipq806x.o
@@ -72,7 +72,7 @@ index c2f0e91f6bf8..9ad873b60920 100644
  obj-$(CONFIG_DWMAC_RZN1)	+= dwmac-rzn1.o
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 new file mode 100644
-index 000000000000..db1672deae82
+index 0000000000000..db1672deae824
 --- /dev/null
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -0,0 +1,229 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-net-stmmac-Add-a-barrier-to-make-sure-all-access-coh.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-net-stmmac-Add-a-barrier-to-make-sure-all-access-coh.patch
@@ -1,4 +1,4 @@
-From aa418a6212aea9e6896033e2a1bc7bd9a9eaed68 Mon Sep 17 00:00:00 2001
+From b50baad091481f967b9099703a99a51ab4fc17ae Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
 Subject: [PATCH 023/103] net: stmmac: Add a barrier to make sure all access
@@ -19,7 +19,7 @@ Ref: https://gitee.com/phytium_embedded/phytium-linux-kernel/commit/cc1c23a77c92
  2 files changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/common.h b/drivers/net/ethernet/stmicro/stmmac/common.h
-index aed6ae80cc7c..65d545368611 100644
+index aed6ae80cc7cf..65d5453686115 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/common.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/common.h
 @@ -51,10 +51,10 @@
@@ -36,7 +36,7 @@ index aed6ae80cc7c..65d545368611 100644
  
  #undef FRAME_FILTER_DEBUG
 diff --git a/drivers/net/ethernet/stmicro/stmmac/norm_desc.c b/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
-index 68a7cfcb1d8f..40088a390f7b 100644
+index 68a7cfcb1d8f3..40088a390f7b3 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
 @@ -200,6 +200,10 @@ static void ndesc_prepare_tx_desc(struct dma_desc *p, int is_fs, int len,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-drivers-fix-build-errors.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-drivers-fix-build-errors.patch
@@ -1,4 +1,4 @@
-From b20c9df4801c5383b83363b445b97087a00806fd Mon Sep 17 00:00:00 2001
+From b2a312a1e3a1e54e6c4e78b91768153b6abbe338 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 00:02:32 +0800
 Subject: [PATCH 024/103] drivers: fix build errors
@@ -18,7 +18,7 @@ Ref: https://gitee.com/phytium_embedded/phytium-linux-kernel/commit/52a27ae1196d
  1 file changed, 7 insertions(+), 9 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index db1672deae82..86f491ea569e 100644
+index db1672deae824..86f491ea569e6 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -73,14 +73,14 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-Update-phytium-copyright-info-to-2024.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-Update-phytium-copyright-info-to-2024.patch
@@ -1,4 +1,4 @@
-From b73ff01f4d5407b97f8bd255b155623738931557 Mon Sep 17 00:00:00 2001
+From aa6fcd7ec2411ace21bebc35b6993d64f3177b1a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 00:05:33 +0800
 Subject: [PATCH 025/103] Update phytium copyright info to 2024
@@ -10,7 +10,7 @@ Ref: https://gitee.com/phytium_embedded/phytium-linux-kernel/commit/f1b4bd2a3b84
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 86f491ea569e..a930cea6280b 100644
+index 86f491ea569e6..a930cea6280b6 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -2,7 +2,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-net-stmmac-Add-phytium-DWMAC-driver-support-v2.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-net-stmmac-Add-phytium-DWMAC-driver-support-v2.patch
@@ -1,4 +1,4 @@
-From 05d814038f9b02a3e59264ffc1dea49e09973219 Mon Sep 17 00:00:00 2001
+From 2f2bf1f850700cf245962ccb82b305dfd73b3a71 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
 Subject: [PATCH 026/103] net/stmmac: Add phytium DWMAC driver support v2
@@ -16,7 +16,7 @@ Ref: https://gitee.com/phytium_embedded/phytium-linux-kernel/commit/f18feb0bef42
  2 files changed, 21 insertions(+), 22 deletions(-)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index a778ab226d00..f05ca0b5fd0e 100644
+index a778ab226d00b..f05ca0b5fd0e4 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -18187,6 +18187,12 @@ F:	include/sound/pxa2xx-lib.h
@@ -33,7 +33,7 @@ index a778ab226d00..f05ca0b5fd0e 100644
  M:	Giovanni Cabiddu <giovanni.cabiddu@intel.com>
  L:	qat-linux@intel.com
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index a930cea6280b..d31b8e870f64 100644
+index a930cea6280b6..d31b8e870f647 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -37,8 +37,7 @@ static int phytium_get_mac_mode(struct fwnode_handle *fwnode)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,4 +1,4 @@
-From 05471c506d0c9094a9406bf0eaf992d4e405d235 Mon Sep 17 00:00:00 2001
+From f2fa2b007a1ec4e6a7e97262dca26445a294c89c Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
 Subject: [PATCH 027/103] net: stmmac: phytium driver add pm support
@@ -19,7 +19,7 @@ Ref: https://gitee.com/phytium_embedded/phytium-linux-kernel/commit/e4084ab6219f
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index d31b8e870f64..6e8e44730bec 100644
+index d31b8e870f647..6e8e44730bec6 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -209,6 +209,7 @@ static struct platform_driver phytium_dwmac_driver = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,4 +1,4 @@
-From 26d0515e0051d8df2d9dec5dd4f91821331c8507 Mon Sep 17 00:00:00 2001
+From 0b8514e16355d2abe647a5e7ce3548e7e68cc973 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
 Subject: [PATCH 028/103] net: stmmac: fix dwmac-phytium build on 6.9
@@ -13,7 +13,7 @@ Ref: https://github.com/deepin-community/kernel-rolling/commit/ea0ab78657ab6bbb4
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 6e8e44730bec..6ecfa671b7f3 100644
+index 6e8e44730bec6..6ecfa671b7f37 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -176,7 +176,7 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-net-stmmac-Add-phytium-old-dwmac-acpi_device_id.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-net-stmmac-Add-phytium-old-dwmac-acpi_device_id.patch
@@ -1,4 +1,4 @@
-From 71e10b8bfb877b343d5dd5a05a9ac1dc06a0f05e Mon Sep 17 00:00:00 2001
+From 8fadcd5e9364a039589ae264300c2492b5fbf8a4 Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
 Subject: [PATCH 029/103] net/stmmac: Add phytium old dwmac acpi_device_id
@@ -14,7 +14,7 @@ Ref: https://github.com/deepin-community/kernel-rolling/commit/71379b1f6b41a17fc
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 6ecfa671b7f3..dd4171a39a4a 100644
+index 6ecfa671b7f37..dd4171a39a4a9 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -198,6 +198,7 @@ MODULE_DEVICE_TABLE(of, phytium_dwmac_of_match);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-net-stmmac-fix-potential-double-free-of-dma-descript.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-net-stmmac-fix-potential-double-free-of-dma-descript.patch
@@ -1,4 +1,4 @@
-From 2f0af1f033af0afe872d2199b4716f0d17f28f16 Mon Sep 17 00:00:00 2001
+From 6594b7e3abe1f50c61f44652c707972375d32005 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
 Subject: [PATCH 030/103] net: stmmac: fix potential double free of dma
@@ -28,7 +28,7 @@ Ref: https://github.com/deepin-community/kernel-rolling/commit/5f7d6773390404077
  1 file changed, 11 insertions(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 71c6a6b70768..95998e47b04f 100644
+index 71c6a6b70768f..95998e47b04f9 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -1933,13 +1933,18 @@ static void __free_dma_rx_desc_resources(struct stmmac_priv *priv,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-net-phytium-Add-support-for-phytium-GMAC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-net-phytium-Add-support-for-phytium-GMAC.patch
@@ -1,4 +1,4 @@
-From 493b902cc6bd615ece8217f94c6d427b722d6da9 Mon Sep 17 00:00:00 2001
+From 5a8882a6ec713dfac400f82afc515c5eb2793afa Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:48:50 +0800
 Subject: [PATCH 031/103] net: phytium: Add support for phytium GMAC
@@ -43,7 +43,7 @@ Ref: https://gitee.com/phytium_embedded/phytium-linux-kernel/commit/4a478e247258
  create mode 100644 drivers/net/ethernet/phytium/phytmac_v2.h
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index f05ca0b5fd0e..cb931b7a8028 100644
+index f05ca0b5fd0e4..cb931b7a80288 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -18191,6 +18191,9 @@ ARM/PHYTIUM SOC SUPPORT
@@ -57,7 +57,7 @@ index f05ca0b5fd0e..cb931b7a8028 100644
  
  QAT DRIVER
 diff --git a/drivers/net/ethernet/Kconfig b/drivers/net/ethernet/Kconfig
-index 0a2125de8bc1..87debbc16c8e 100644
+index 0a2125de8bc13..87debbc16c8e2 100644
 --- a/drivers/net/ethernet/Kconfig
 +++ b/drivers/net/ethernet/Kconfig
 @@ -161,6 +161,7 @@ config ETHOC
@@ -69,7 +69,7 @@ index 0a2125de8bc1..87debbc16c8e 100644
  source "drivers/net/ethernet/brocade/Kconfig"
  source "drivers/net/ethernet/qualcomm/Kconfig"
 diff --git a/drivers/net/ethernet/Makefile b/drivers/net/ethernet/Makefile
-index 3e3d90f93697..7c91d98b4d48 100644
+index 3e3d90f936978..7c91d98b4d487 100644
 --- a/drivers/net/ethernet/Makefile
 +++ b/drivers/net/ethernet/Makefile
 @@ -76,6 +76,7 @@ obj-$(CONFIG_NET_VENDOR_OKI) += oki-semi/
@@ -82,7 +82,7 @@ index 3e3d90f93697..7c91d98b4d48 100644
  obj-$(CONFIG_NET_VENDOR_REALTEK) += realtek/
 diff --git a/drivers/net/ethernet/phytium/Kconfig b/drivers/net/ethernet/phytium/Kconfig
 new file mode 100644
-index 000000000000..14a77adbfdc1
+index 0000000000000..14a77adbfdc12
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/Kconfig
 @@ -0,0 +1,58 @@
@@ -146,7 +146,7 @@ index 000000000000..14a77adbfdc1
 +endif # NET_VENDOR_PHYTIUM
 diff --git a/drivers/net/ethernet/phytium/Makefile b/drivers/net/ethernet/phytium/Makefile
 new file mode 100644
-index 000000000000..6e710d4d54b6
+index 0000000000000..6e710d4d54b66
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/Makefile
 @@ -0,0 +1,17 @@
@@ -169,7 +169,7 @@ index 000000000000..6e710d4d54b6
 +phytmac-pci-objs := phytmac_pci.o
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
 new file mode 100644
-index 000000000000..b90e1551499e
+index 0000000000000..b90e1551499ef
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -0,0 +1,591 @@
@@ -766,7 +766,7 @@ index 000000000000..b90e1551499e
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 new file mode 100644
-index 000000000000..592d2d9dc6d4
+index 0000000000000..592d2d9dc6d4b
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -0,0 +1,544 @@
@@ -1316,7 +1316,7 @@ index 000000000000..592d2d9dc6d4
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
 new file mode 100644
-index 000000000000..b0977f5cae75
+index 0000000000000..b0977f5cae755
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -0,0 +1,2236 @@
@@ -3558,7 +3558,7 @@ index 000000000000..b0977f5cae75
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
 new file mode 100644
-index 000000000000..fd21bf80f138
+index 0000000000000..fd21bf80f1388
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -0,0 +1,318 @@
@@ -3882,7 +3882,7 @@ index 000000000000..fd21bf80f138
 +MODULE_DESCRIPTION("Phytium NIC PCI wrapper");
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
 new file mode 100644
-index 000000000000..305ff5866e2f
+index 0000000000000..305ff5866e2fe
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -0,0 +1,255 @@
@@ -4143,7 +4143,7 @@ index 000000000000..305ff5866e2f
 +MODULE_ALIAS("platform:phytmac");
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.c b/drivers/net/ethernet/phytium/phytmac_ptp.c
 new file mode 100644
-index 000000000000..26b1b75edbde
+index 0000000000000..26b1b75edbde1
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.c
 @@ -0,0 +1,304 @@
@@ -4453,7 +4453,7 @@ index 000000000000..26b1b75edbde
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.h b/drivers/net/ethernet/phytium/phytmac_ptp.h
 new file mode 100644
-index 000000000000..72c8b7c67413
+index 0000000000000..72c8b7c674137
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.h
 @@ -0,0 +1,55 @@
@@ -4514,7 +4514,7 @@ index 000000000000..72c8b7c67413
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
 new file mode 100644
-index 000000000000..2d9f67c82050
+index 0000000000000..2d9f67c82050c
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -0,0 +1,1370 @@
@@ -5890,7 +5890,7 @@ index 000000000000..2d9f67c82050
 +EXPORT_SYMBOL_GPL(phytmac_1p0_hw);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
 new file mode 100644
-index 000000000000..6f2b521aaebd
+index 0000000000000..6f2b521aaebdb
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -0,0 +1,453 @@
@@ -6349,7 +6349,7 @@ index 000000000000..6f2b521aaebd
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
 new file mode 100644
-index 000000000000..df142aa6797f
+index 0000000000000..df142aa6797f6
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -0,0 +1,1254 @@
@@ -7609,7 +7609,7 @@ index 000000000000..df142aa6797f
 +EXPORT_SYMBOL_GPL(phytmac_2p0_hw);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
 new file mode 100644
-index 000000000000..92e4806ac2c1
+index 0000000000000..92e4806ac2c1f
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -0,0 +1,362 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-net-phytmac-Bugfixed-the-MDIO-registration-failures.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-net-phytmac-Bugfixed-the-MDIO-registration-failures.patch
@@ -1,4 +1,4 @@
-From dd41d4ec15d9f4cfc9a35708395faed623782eff Mon Sep 17 00:00:00 2001
+From 3af9e12bca35738f3e4b4f0f4606270feac44e17 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:58:33 +0800
 Subject: [PATCH 032/103] net/phytmac: Bugfixed the MDIO registration failures
@@ -15,7 +15,7 @@ Ref: https://gitee.com/phytium_embedded/phytium-linux-kernel/commit/593ac038cf31
  1 file changed, 19 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index b0977f5cae75..da4e06736280 100644
+index b0977f5cae755..da4e067362803 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1508,7 +1508,7 @@ int phytmac_mdio_register(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-net-phytmac-Fixed-the-issue-of-pxe-startup-failure.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-net-phytmac-Fixed-the-issue-of-pxe-startup-failure.patch
@@ -1,4 +1,4 @@
-From 865377f231b8cb358338308e81b4c8910bd6f578 Mon Sep 17 00:00:00 2001
+From d2aa9be113eeb10348d91bbe47a9c5c1405e1e74 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:58:56 +0800
 Subject: [PATCH 033/103] net/phytmac: Fixed the issue of pxe startup failure.
@@ -15,7 +15,7 @@ Ref: https://gitee.com/phytium_embedded/phytium-linux-kernel/commit/82a2fb0b2765
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 2d9f67c82050..79df9a7f981f 100644
+index 2d9f67c82050c..79df9a7f981f1 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -357,8 +357,11 @@ static int phytmac_init_hw(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,4 +1,4 @@
-From 4564e142771409788fc17005de0a042fa409f2ec Mon Sep 17 00:00:00 2001
+From 8512f9ef328866e92b02aef8729dfb3e399ffa08 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:59:09 +0800
 Subject: [PATCH 034/103] net/phytmac: Adapt interface type 1000BASE-x
@@ -16,7 +16,7 @@ Ref: https://gitee.com/phytium_embedded/phytium-linux-kernel/commit/b590f0e74c19
  3 files changed, 34 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index da4e06736280..c172103a9736 100644
+index da4e067362803..c172103a97362 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1560,6 +1560,7 @@ static void phytmac_validate(struct phylink_config *config,
@@ -28,7 +28,7 @@ index da4e06736280..c172103a9736 100644
  	    state->interface != PHY_INTERFACE_MODE_5GBASER &&
  	    state->interface != PHY_INTERFACE_MODE_10GBASER &&
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 79df9a7f981f..ec95c6c79b06 100644
+index 79df9a7f981f1..ec95c6c79b066 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -161,6 +161,20 @@ static int phytmac_enable_autoneg(struct phytmac *pdata, int enable)
@@ -103,7 +103,7 @@ index 79df9a7f981f..ec95c6c79b06 100644
  		return PHYTMAC_READ_BITS(pdata, PHYTMAC_NSTATUS, PCS_LINK);
  	else if (interface == PHY_INTERFACE_MODE_USXGMII ||
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 6f2b521aaebd..d8de2c26cab4 100644
+index 6f2b521aaebdb..d8de2c26cab4b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -228,6 +228,8 @@ extern struct phytmac_hw_if phytmac_1p0_hw;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-net-ethernet-phytium-fix-phytmac_platform-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-net-ethernet-phytium-fix-phytmac_platform-on-6.9.patch
@@ -1,4 +1,4 @@
-From 0313bd8ee0d32b9747a3ec2b6ff85f51e3f753a9 Mon Sep 17 00:00:00 2001
+From fbe9e3799b4147eee119632a302d9e7477da3715 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
 Subject: [PATCH 035/103] net: ethernet: phytium: fix phytmac_platform on 6.9
@@ -12,7 +12,7 @@ Ref: https://github.com/deepin-community/kernel-rolling/commit/7fbb31760c9c71325
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 305ff5866e2f..b72e728a924b 100644
+index 305ff5866e2fe..b72e728a924b1 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -14,6 +14,8 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,4 +1,4 @@
-From 7f48bc161acb51827e3882b3ac7a24346ba2cf5e Mon Sep 17 00:00:00 2001
+From e41917e2eaa4bca518bd08eeb115bdb8f03f15c2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
 Subject: [PATCH 036/103] net: ethernet: fix phytmac on 6.9
@@ -15,7 +15,7 @@ Ref: https://github.com/deepin-community/kernel-rolling/commit/7f27ea4b8c04c5399
  3 files changed, 13 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index c172103a9736..d329aded10f0 100644
+index c172103a97362..d329aded10f0a 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -293,7 +293,7 @@ inline struct phytmac_dma_desc *phytmac_get_rx_desc(struct phytmac_queue *queue,
@@ -64,7 +64,7 @@ index c172103a9736..d329aded10f0 100644
  	struct net_device *ndev = pdata->ndev;
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index b72e728a924b..797909211fed 100644
+index b72e728a924b1..797909211fed1 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -77,7 +77,6 @@ static int phytmac_get_phy_mode(struct platform_device *pdev)
@@ -76,7 +76,7 @@ index b72e728a924b..797909211fed 100644
  	struct phytmac *pdata;
  	int ret, i;
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index df142aa6797f..77fde5c5e291 100644
+index df142aa6797f6..77fde5c5e2915 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -60,7 +60,7 @@ static int phytmac_msg_send(struct phytmac *pdata, u16 cmd_id,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-net-ethernet-phytium-add-a-missing-declaration-for-n.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-net-ethernet-phytium-add-a-missing-declaration-for-n.patch
@@ -1,4 +1,4 @@
-From 5e1f46b04b598eccfbcf0432c530d7cc22ee7558 Mon Sep 17 00:00:00 2001
+From 947283046289567fa512b188d66debaa2e50336b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
 Subject: [PATCH 037/103] net: ethernet: phytium: add a missing declaration for
@@ -22,7 +22,7 @@ Ref: https://github.com/deepin-community/kernel-rolling/commit/eec8d65bd08c528c7
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 797909211fed..343e1a5ce564 100644
+index 797909211fed1..343e1a5ce564a 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -77,6 +77,7 @@ static int phytmac_get_phy_mode(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-net-phytium-convert-and-remove-validate-references.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-net-phytium-convert-and-remove-validate-references.patch
@@ -1,4 +1,4 @@
-From 1b33ab1a74d2e393bfabc327c3b2986aa7039452 Mon Sep 17 00:00:00 2001
+From d7eaf681575f5f35b0c74082cf4e2a887b65a181 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
 Subject: [PATCH 038/103] net: phytium: convert and remove validate()
@@ -15,7 +15,7 @@ Ref: https://github.com/deepin-community/kernel-rolling/commit/39bfbc99a80e04cd1
  1 file changed, 6 insertions(+), 64 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index d329aded10f0..696b491750ae 100644
+index d329aded10f0a..696b491750ae5 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1551,71 +1551,7 @@ static void phytmac_pcs_get_state(struct phylink_config *config,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-arm-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-arm-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,4 +1,4 @@
-From 96d98bd41c7cc085427910b91f52f864f73044c9 Mon Sep 17 00:00:00 2001
+From d375d862444f20e5b42102ef7f5cfa2b914d1bdd Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux@gmail.com>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
 Subject: [PATCH 039/103] arm: usb: phy: tegra: Add 38.4MHz clock table entry
@@ -16,7 +16,7 @@ Ref: https://lore.kernel.org/all/1459929245-23449-1-git-send-email-hunterlaux@gm
  1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/phy/phy-tegra-usb.c b/drivers/usb/phy/phy-tegra-usb.c
-index 4ea47e6f835b..12f6a2bb4057 100644
+index 4ea47e6f835bf..12f6a2bb4057d 100644
 --- a/drivers/usb/phy/phy-tegra-usb.c
 +++ b/drivers/usb/phy/phy-tegra-usb.c
 @@ -174,7 +174,7 @@ struct tegra_xtal_freq {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
@@ -1,4 +1,4 @@
-From a30124706fc5b064c0bdbf1f4d5877eb0b32f4d6 Mon Sep 17 00:00:00 2001
+From ba04266645ed4f447b9f73410ece963bcd6539b0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
 Subject: [PATCH 040/103] arm64: dts: rockchip: change GMAC rx_delay for
@@ -10,7 +10,7 @@ Ref: https://github.com/armbian/build/blob/42cc795f4d4ffed60f81fe64cbf96be39ae07
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-index f30b82a10ca3..1692689f674e 100644
+index f30b82a10ca38..1692689f674ef 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 @@ -308,7 +308,7 @@ &gmac {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-arm64-phytium-Add-support-for-Phytium-SoC-family.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-arm64-phytium-Add-support-for-Phytium-SoC-family.patch
@@ -1,4 +1,4 @@
-From 8b81184c10d8c92f4ea18a64260650a075d5dfe5 Mon Sep 17 00:00:00 2001
+From 4889369b6c7118d6cd501852a94b1f14c45a3eff Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
 Subject: [PATCH 041/103] arm64: phytium: Add support for Phytium SoC family
@@ -13,7 +13,7 @@ Ref: https://gitee.com/phytium_embedded/phytium-linux-kernel/commit/154f8e5d365d
  1 file changed, 8 insertions(+)
 
 diff --git a/arch/arm64/Kconfig.platforms b/arch/arm64/Kconfig.platforms
-index a52618073de2..e27f7aa29bd0 100644
+index a52618073de2f..e27f7aa29bd02 100644
 --- a/arch/arm64/Kconfig.platforms
 +++ b/arch/arm64/Kconfig.platforms
 @@ -263,6 +263,14 @@ config ARCH_PENSANDO

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,4 +1,4 @@
-From f6a8fd378dbc6057fcbc995e331fbf172c6f5805 Mon Sep 17 00:00:00 2001
+From 69875e6047de3edccfe4c810c61039b6f829442d Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Thu, 21 Apr 2022 11:36:35 +0800
 Subject: [PATCH 042/103] arm64: dts: rockchip: disable usb3 on quartz64
@@ -13,7 +13,7 @@ Ref: Contact the author.
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts b/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
-index 0b191d8462ad..23287780d26a 100644
+index 0b191d8462ad8..23287780d26ac 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
 @@ -789,6 +789,10 @@ &usb_host0_xhci {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,4 +1,4 @@
-From f0f9f4f1843aacb4dd4773d8fcdd50c6361d51b6 Mon Sep 17 00:00:00 2001
+From 6d0bae59e8d70977442b06e564e8a9994d753106 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 27 Jul 2023 11:13:25 -0400
 Subject: [PATCH 043/103] arm64: drop hisi_ddrc_pmu driver
@@ -12,7 +12,7 @@ Ref: Contact the author.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/perf/hisilicon/Makefile b/drivers/perf/hisilicon/Makefile
-index 48dcc8381ea7..a62ab2f0766f 100644
+index 48dcc8381ea75..a62ab2f0766f0 100644
 --- a/drivers/perf/hisilicon/Makefile
 +++ b/drivers/perf/hisilicon/Makefile
 @@ -1,6 +1,6 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-PCI-Add-Phytium-vendor-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-PCI-Add-Phytium-vendor-ID.patch
@@ -1,4 +1,4 @@
-From 5f8595e80d3a9c0c8772cbeca890474f9c2a9545 Mon Sep 17 00:00:00 2001
+From 7739c21302e62c8a45062ccbbee2e27b8849a9fa Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:06:38 +0800
 Subject: [PATCH 044/103] PCI: Add Phytium vendor ID
@@ -13,7 +13,7 @@ Ref: https://gitee.com/phytium_embedded/phytium-linux-kernel/commit/b570810d41c9
  1 file changed, 2 insertions(+)
 
 diff --git a/include/linux/pci_ids.h b/include/linux/pci_ids.h
-index 677aea20d3e1..5b923cb5698c 100644
+index 677aea20d3e11..5b923cb5698c5 100644
 --- a/include/linux/pci_ids.h
 +++ b/include/linux/pci_ids.h
 @@ -3224,4 +3224,6 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-mips-loongson64-disable-writecombine-for-Loongson-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-mips-loongson64-disable-writecombine-for-Loongson-3A.patch
@@ -1,4 +1,4 @@
-From db08cca16ba5651cd447a14574fb9a9eafa197e2 Mon Sep 17 00:00:00 2001
+From 11e5754651ed57de80f542853ccb42c2262a2621 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Mon, 12 Oct 2020 13:32:23 +0800
 Subject: [PATCH 045/103] mips: loongson64: disable writecombine for
@@ -13,7 +13,7 @@ Ref: Contact the author.
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/kernel/cpu-probe.c b/arch/mips/kernel/cpu-probe.c
-index bda7f193baab..8956d833c4c7 100644
+index bda7f193baab9..8956d833c4c78 100644
 --- a/arch/mips/kernel/cpu-probe.c
 +++ b/arch/mips/kernel/cpu-probe.c
 @@ -1252,6 +1252,7 @@ static inline void cpu_probe_legacy(struct cpuinfo_mips *c, unsigned int cpu)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-mips-loongson64-init-suppress-memcpy-out-of-bound-ch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-mips-loongson64-init-suppress-memcpy-out-of-bound-ch.patch
@@ -1,4 +1,4 @@
-From 18b4978b0ca9f938d3ab86d4caeb004131284f60 Mon Sep 17 00:00:00 2001
+From 44262293c6fe75bee360e723955528eb43ff9223 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Wed, 24 Aug 2022 03:54:11 +0000
 Subject: [PATCH 046/103] mips: loongson64/init: suppress memcpy out-of-bound
@@ -10,7 +10,7 @@ Ref: Contact the author.
  1 file changed, 3 insertions(+)
 
 diff --git a/arch/mips/loongson64/init.c b/arch/mips/loongson64/init.c
-index a35dd7311795..159a3f82bda1 100644
+index a35dd73117958..159a3f82bda10 100644
 --- a/arch/mips/loongson64/init.c
 +++ b/arch/mips/loongson64/init.c
 @@ -27,7 +27,10 @@ static void __init mips_nmi_setup(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-mips-loongson64-video-output-re-introduce-display-ou.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-mips-loongson64-video-output-re-introduce-display-ou.patch
@@ -1,4 +1,4 @@
-From f4a509b3e3e00e0868275cb61340126bd20f4a02 Mon Sep 17 00:00:00 2001
+From 995b9118b43b99e436fb91bc6ffac624fda7ef9e Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 7 Nov 2017 09:01:33 +0800
 Subject: [PATCH 047/103] mips: loongson64: video: output: re-introduce display
@@ -19,7 +19,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?
  create mode 100644 include/linux/video_output.h
 
 diff --git a/drivers/video/Kconfig b/drivers/video/Kconfig
-index 44c9ef1435a2..07fd5ed893ae 100644
+index 44c9ef1435a2d..07fd5ed893ae1 100644
 --- a/drivers/video/Kconfig
 +++ b/drivers/video/Kconfig
 @@ -52,6 +52,12 @@ config VGASTATE
@@ -36,7 +36,7 @@ index 44c9ef1435a2..07fd5ed893ae 100644
  	bool
  
 diff --git a/drivers/video/Makefile b/drivers/video/Makefile
-index ffbac4387c67..99368ea8db70 100644
+index ffbac4387c670..99368ea8db70d 100644
 --- a/drivers/video/Makefile
 +++ b/drivers/video/Makefile
 @@ -17,6 +17,8 @@ obj-y				  += backlight/
@@ -50,7 +50,7 @@ index ffbac4387c67..99368ea8db70 100644
  obj-$(CONFIG_VIDEOMODE_HELPERS) += of_display_timing.o of_videomode.o
 diff --git a/drivers/video/output.c b/drivers/video/output.c
 new file mode 100644
-index 000000000000..1446c49fe6af
+index 0000000000000..1446c49fe6aff
 --- /dev/null
 +++ b/drivers/video/output.c
 @@ -0,0 +1,133 @@
@@ -189,7 +189,7 @@ index 000000000000..1446c49fe6af
 +module_exit(video_output_class_exit);
 diff --git a/include/linux/video_output.h b/include/linux/video_output.h
 new file mode 100644
-index 000000000000..ed5cdeb3604d
+index 0000000000000..ed5cdeb3604db
 --- /dev/null
 +++ b/include/linux/video_output.h
 @@ -0,0 +1,57 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-mips-video-fbdev-sis-add-1368x768-resolution.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-mips-video-fbdev-sis-add-1368x768-resolution.patch
@@ -1,4 +1,4 @@
-From 4155585f33bd6c2d0216ea10fb993d5ae78e4ad2 Mon Sep 17 00:00:00 2001
+From 58ae42a71188a39e39786a2bd2358981c24fa8e5 Mon Sep 17 00:00:00 2001
 From: flygoat <flygoatfree@gmail.com>
 Date: Sun, 5 Mar 2017 20:33:17 +0800
 Subject: [PATCH 048/103] mips: video: fbdev: sis: add 1368x768 resolution
@@ -16,7 +16,7 @@ Ref: Contact the author.
  6 files changed, 36 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/video/fbdev/sis/310vtbl.h b/drivers/video/fbdev/sis/310vtbl.h
-index 54fcbbf4ef63..4d8197ccf25c 100644
+index 54fcbbf4ef635..4d8197ccf25c0 100644
 --- a/drivers/video/fbdev/sis/310vtbl.h
 +++ b/drivers/video/fbdev/sis/310vtbl.h
 @@ -130,6 +130,9 @@ static const struct SiS_Ext SiS310_EModeIDTable[] =
@@ -76,7 +76,7 @@ index 54fcbbf4ef63..4d8197ccf25c 100644
 -
 -
 diff --git a/drivers/video/fbdev/sis/init.c b/drivers/video/fbdev/sis/init.c
-index 2ba91d62af92..108a564a0f87 100644
+index 2ba91d62af92e..108a564a0f875 100644
 --- a/drivers/video/fbdev/sis/init.c
 +++ b/drivers/video/fbdev/sis/init.c
 @@ -440,6 +440,9 @@ SiS_GetModeID(int VGAEngine, unsigned int VBFlags, int HDisplay, int VDisplay,
@@ -110,7 +110,7 @@ index 2ba91d62af92..108a564a0f87 100644
  	     if(VGAEngine == SIS_315_VGA) {
  		if(VBFlags2 & VB2_LCDOVER1280BRIDGE) {
 diff --git a/drivers/video/fbdev/sis/init.h b/drivers/video/fbdev/sis/init.h
-index 400b0e5681b2..d23c49cf69e8 100644
+index 400b0e5681b24..d23c49cf69e81 100644
 --- a/drivers/video/fbdev/sis/init.h
 +++ b/drivers/video/fbdev/sis/init.h
 @@ -104,6 +104,7 @@ static const unsigned short ModeIndex_1920x1080[]    = {0x2c, 0x2d, 0x00, 0x73};
@@ -147,7 +147,7 @@ index 400b0e5681b2..d23c49cf69e8 100644
  #endif
 -
 diff --git a/drivers/video/fbdev/sis/init301.c b/drivers/video/fbdev/sis/init301.c
-index 09329072004f..39101889a2b7 100644
+index 09329072004f4..39101889a2b76 100644
 --- a/drivers/video/fbdev/sis/init301.c
 +++ b/drivers/video/fbdev/sis/init301.c
 @@ -2331,7 +2331,7 @@ SiS_GetLCDResInfo(struct SiS_Private *SiS_Pr, unsigned short ModeNo, unsigned sh
@@ -182,7 +182,7 @@ index 09329072004f..39101889a2b7 100644
  #endif
 -
 diff --git a/drivers/video/fbdev/sis/initdef.h b/drivers/video/fbdev/sis/initdef.h
-index 264b55a5947b..5232f5c2a87e 100644
+index 264b55a5947b8..5232f5c2a87e7 100644
 --- a/drivers/video/fbdev/sis/initdef.h
 +++ b/drivers/video/fbdev/sis/initdef.h
 @@ -488,6 +488,7 @@
@@ -202,7 +202,7 @@ index 264b55a5947b..5232f5c2a87e 100644
  #define TVCLKBASE_300		0x21   /* Indices on TV clocks in VCLKData table (300) */
  #define TVCLKBASE_315	        0x3a   /* Indices on TV clocks in (VB)VCLKData table (315) */
 diff --git a/drivers/video/fbdev/sis/sis_main.c b/drivers/video/fbdev/sis/sis_main.c
-index 009bf1d92644..01aab3b045d7 100644
+index 009bf1d926448..01aab3b045d73 100644
 --- a/drivers/video/fbdev/sis/sis_main.c
 +++ b/drivers/video/fbdev/sis/sis_main.c
 @@ -3641,6 +3641,11 @@ sisfb_pre_setmode(struct sis_video_info *ivideo)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-loongarch-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-loongarch-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,4 +1,4 @@
-From 857ff455f6dc7b3ee2f4322b0a9760623e025e25 Mon Sep 17 00:00:00 2001
+From e950ffbe5f11c6b101d854440d0f5f29c6d8e9a0 Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
 Subject: [PATCH 049/103] loongarch: LoongArch: Update the flush cache policy
@@ -17,7 +17,7 @@ Ref: https://t.me/c/1109254909/492828
  1 file changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/mm/cache.c b/arch/loongarch/mm/cache.c
-index 6be04d36ca07..89eeb9a97dd5 100644
+index 6be04d36ca076..89eeb9a97dd5d 100644
 --- a/arch/loongarch/mm/cache.c
 +++ b/arch/loongarch/mm/cache.c
 @@ -63,6 +63,27 @@ static void flush_cache_leaf(unsigned int leaf)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-loongarch-PCI-pci_call_probe-call-local_pci_probe-wh.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-loongarch-PCI-pci_call_probe-call-local_pci_probe-wh.patch
@@ -1,4 +1,4 @@
-From 95d5e4925c520ec4977f64a14c9384e2c723e407 Mon Sep 17 00:00:00 2001
+From 90aa23c2b7b95f2a3e981967c21f69bb188d97ce Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Thu, 13 Jun 2024 15:42:58 +0800
 Subject: [PATCH 050/103] loongarch: PCI: pci_call_probe: call
@@ -23,7 +23,7 @@ Ref: https://lore.kernel.org/all/20240613074258.4124603-1-zhanghongchen@loongson
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
-index af2996d0d17f..32a99828e6a3 100644
+index af2996d0d17ff..32a99828e6a31 100644
 --- a/drivers/pci/pci-driver.c
 +++ b/drivers/pci/pci-driver.c
 @@ -386,7 +386,7 @@ static int pci_call_probe(struct pci_driver *drv, struct pci_dev *dev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,4 +1,4 @@
-From cd67dd65ce8eda715ffdfd7bb7e3e5c912c0e646 Mon Sep 17 00:00:00 2001
+From 7c393fdfb960335dcfe3f917f8c7ea6032b7415d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 01:23:57 +0800
 Subject: [PATCH 051/103] LoongArch: Add CPU HWMon platform driver
@@ -17,7 +17,7 @@ Ref: https://lore.kernel.org/all/20220818042208.2896457-1-chenhuacai@loongson.cn
  create mode 100644 drivers/platform/loongarch/cpu_hwmon.c
 
 diff --git a/drivers/platform/loongarch/Kconfig b/drivers/platform/loongarch/Kconfig
-index 5633e4d73991..4c827bae910c 100644
+index 5633e4d73991a..4c827bae910ce 100644
 --- a/drivers/platform/loongarch/Kconfig
 +++ b/drivers/platform/loongarch/Kconfig
 @@ -28,4 +28,12 @@ config LOONGSON_LAPTOP
@@ -34,7 +34,7 @@ index 5633e4d73991..4c827bae910c 100644
 +
  endif # LOONGARCH_PLATFORM_DEVICES
 diff --git a/drivers/platform/loongarch/Makefile b/drivers/platform/loongarch/Makefile
-index f43ab03db1a2..695688bed423 100644
+index f43ab03db1a2d..695688bed4232 100644
 --- a/drivers/platform/loongarch/Makefile
 +++ b/drivers/platform/loongarch/Makefile
 @@ -1 +1,2 @@
@@ -42,7 +42,7 @@ index f43ab03db1a2..695688bed423 100644
 +obj-$(CONFIG_CPU_HWMON) += cpu_hwmon.o
 diff --git a/drivers/platform/loongarch/cpu_hwmon.c b/drivers/platform/loongarch/cpu_hwmon.c
 new file mode 100644
-index 000000000000..71a462426397
+index 0000000000000..71a462426397d
 --- /dev/null
 +++ b/drivers/platform/loongarch/cpu_hwmon.c
 @@ -0,0 +1,194 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-LoongArch-KVM-Add-PV-steal-time-support-in-host-side.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-LoongArch-KVM-Add-PV-steal-time-support-in-host-side.patch
@@ -1,4 +1,4 @@
-From 61d8d56ff765d32cd66feaa537e1fdbd7d76db9c Mon Sep 17 00:00:00 2001
+From 1dcfc80f76936e2e51eeb392870bcdaec3b9658d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:31:59 +0800
 Subject: [PATCH 052/103] LoongArch: KVM: Add PV steal time support in host
@@ -29,7 +29,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?
  8 files changed, 189 insertions(+), 4 deletions(-)
 
 diff --git a/arch/loongarch/include/asm/kvm_host.h b/arch/loongarch/include/asm/kvm_host.h
-index c87b6ea0ec47..e4976b4938cd 100644
+index c87b6ea0ec47a..e4976b4938cd3 100644
 --- a/arch/loongarch/include/asm/kvm_host.h
 +++ b/arch/loongarch/include/asm/kvm_host.h
 @@ -30,6 +30,7 @@
@@ -55,7 +55,7 @@ index c87b6ea0ec47..e4976b4938cd 100644
  
  static inline unsigned long readl_sw_gcsr(struct loongarch_csrs *csr, int reg)
 diff --git a/arch/loongarch/include/asm/kvm_para.h b/arch/loongarch/include/asm/kvm_para.h
-index 4ba2312e5f8c..335fb86778e2 100644
+index 4ba2312e5f8c8..335fb86778e2b 100644
 --- a/arch/loongarch/include/asm/kvm_para.h
 +++ b/arch/loongarch/include/asm/kvm_para.h
 @@ -14,6 +14,7 @@
@@ -84,7 +84,7 @@ index 4ba2312e5f8c..335fb86778e2 100644
   * Hypercall interface for KVM hypervisor
   *
 diff --git a/arch/loongarch/include/asm/kvm_vcpu.h b/arch/loongarch/include/asm/kvm_vcpu.h
-index 590a92cb5416..c416cb7125c0 100644
+index 590a92cb54165..c416cb7125c0e 100644
 --- a/arch/loongarch/include/asm/kvm_vcpu.h
 +++ b/arch/loongarch/include/asm/kvm_vcpu.h
 @@ -120,4 +120,9 @@ static inline void kvm_write_reg(struct kvm_vcpu *vcpu, int num, unsigned long v
@@ -98,7 +98,7 @@ index 590a92cb5416..c416cb7125c0 100644
 +
  #endif /* __ASM_LOONGARCH_KVM_VCPU_H__ */
 diff --git a/arch/loongarch/include/asm/loongarch.h b/arch/loongarch/include/asm/loongarch.h
-index eb09adda54b7..7a4633ef284b 100644
+index eb09adda54b7c..7a4633ef284b7 100644
 --- a/arch/loongarch/include/asm/loongarch.h
 +++ b/arch/loongarch/include/asm/loongarch.h
 @@ -169,6 +169,7 @@
@@ -110,7 +110,7 @@ index eb09adda54b7..7a4633ef284b 100644
  #ifndef __ASSEMBLY__
  
 diff --git a/arch/loongarch/include/uapi/asm/kvm.h b/arch/loongarch/include/uapi/asm/kvm.h
-index f9abef382317..ddc5cab0ffd0 100644
+index f9abef382317d..ddc5cab0ffd00 100644
 --- a/arch/loongarch/include/uapi/asm/kvm.h
 +++ b/arch/loongarch/include/uapi/asm/kvm.h
 @@ -81,7 +81,11 @@ struct kvm_fpu {
@@ -126,7 +126,7 @@ index f9abef382317..ddc5cab0ffd0 100644
  struct kvm_debug_exit_arch {
  };
 diff --git a/arch/loongarch/kvm/Kconfig b/arch/loongarch/kvm/Kconfig
-index c4ef2b4d9797..248744b4d086 100644
+index c4ef2b4d97974..248744b4d086d 100644
 --- a/arch/loongarch/kvm/Kconfig
 +++ b/arch/loongarch/kvm/Kconfig
 @@ -29,6 +29,7 @@ config KVM
@@ -138,7 +138,7 @@ index c4ef2b4d9797..248744b4d086 100644
  	  Support hosting virtualized guest machines using
  	  hardware virtualization extensions. You will need
 diff --git a/arch/loongarch/kvm/exit.c b/arch/loongarch/kvm/exit.c
-index a68573e091c0..ea73f9dc2cc6 100644
+index a68573e091c01..ea73f9dc2cc6a 100644
 --- a/arch/loongarch/kvm/exit.c
 +++ b/arch/loongarch/kvm/exit.c
 @@ -24,7 +24,7 @@
@@ -208,7 +208,7 @@ index a68573e091c0..ea73f9dc2cc6 100644
  		ret = KVM_HCALL_INVALID_CODE;
  		break;
 diff --git a/arch/loongarch/kvm/vcpu.c b/arch/loongarch/kvm/vcpu.c
-index 9e8030d45129..4b289718b4e1 100644
+index 9e8030d451290..4b289718b4e19 100644
 --- a/arch/loongarch/kvm/vcpu.c
 +++ b/arch/loongarch/kvm/vcpu.c
 @@ -31,6 +31,50 @@ const struct kvm_stats_header kvm_vcpu_stats_header = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-LoongArch-KVM-Add-PV-steal-time-support-in-guest-sid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-LoongArch-KVM-Add-PV-steal-time-support-in-guest-sid.patch
@@ -1,4 +1,4 @@
-From 9a7f083bb995181b7226e2361884d29859e92d55 Mon Sep 17 00:00:00 2001
+From 5ca600ed6e5ee11bed7b9bf031e7a54e9d680d9b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:32:22 +0800
 Subject: [PATCH 053/103] LoongArch: KVM: Add PV steal time support in guest
@@ -36,7 +36,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?
  5 files changed, 166 insertions(+), 3 deletions(-)
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index 913defca544d..6ae03788ab54 100644
+index 913defca544d8..6ae03788ab542 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -4073,9 +4073,9 @@
@@ -53,7 +53,7 @@ index 913defca544d..6ae03788ab54 100644
  	nosync		[HW,M68K] Disables sync negotiation for all devices.
  
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index ddc042895d01..b81d0eba5c7e 100644
+index ddc042895d011..b81d0eba5c7eb 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -649,6 +649,17 @@ config PARAVIRT
@@ -75,7 +75,7 @@ index ddc042895d01..b81d0eba5c7e 100644
  
  config ARCH_SELECT_MEMORY_MODEL
 diff --git a/arch/loongarch/include/asm/paravirt.h b/arch/loongarch/include/asm/paravirt.h
-index 0965710f47f2..dddec49671ae 100644
+index 0965710f47f23..dddec49671ae4 100644
 --- a/arch/loongarch/include/asm/paravirt.h
 +++ b/arch/loongarch/include/asm/paravirt.h
 @@ -18,6 +18,7 @@ static inline u64 paravirt_steal_clock(int cpu)
@@ -97,7 +97,7 @@ index 0965710f47f2..dddec49671ae 100644
  #endif // CONFIG_PARAVIRT
  #endif
 diff --git a/arch/loongarch/kernel/paravirt.c b/arch/loongarch/kernel/paravirt.c
-index 1633ed4f692f..9abe8b71aa48 100644
+index 1633ed4f692f6..9abe8b71aa487 100644
 --- a/arch/loongarch/kernel/paravirt.c
 +++ b/arch/loongarch/kernel/paravirt.c
 @@ -4,11 +4,14 @@
@@ -269,7 +269,7 @@ index 1633ed4f692f..9abe8b71aa48 100644
 +	return 0;
 +}
 diff --git a/arch/loongarch/kernel/time.c b/arch/loongarch/kernel/time.c
-index fd5354f9be7c..46d7d40c87e3 100644
+index fd5354f9be7c3..46d7d40c87e38 100644
 --- a/arch/loongarch/kernel/time.c
 +++ b/arch/loongarch/kernel/time.c
 @@ -15,6 +15,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-LoongArch-KVM-Add-HW-Binary-Translation-extension-su.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-LoongArch-KVM-Add-HW-Binary-Translation-extension-su.patch
@@ -1,4 +1,4 @@
-From 5aaab6905d8f0b873126a9c0a7481d83214f3ac5 Mon Sep 17 00:00:00 2001
+From fe61268423d911545788331c7e83ae44b12c74be Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Jul 2024 15:57:41 +0800
 Subject: [PATCH 054/103] LoongArch: KVM: Add HW Binary Translation extension
@@ -21,7 +21,7 @@ Ref: https://lore.kernel.org/all/20240730075744.1215856-2-maobibo@loongson.cn/
  4 files changed, 88 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/include/asm/kvm_host.h b/arch/loongarch/include/asm/kvm_host.h
-index e4976b4938cd..d769483b6e0c 100644
+index e4976b4938cd3..d769483b6e0cf 100644
 --- a/arch/loongarch/include/asm/kvm_host.h
 +++ b/arch/loongarch/include/asm/kvm_host.h
 @@ -133,6 +133,7 @@ enum emulation_result {
@@ -54,7 +54,7 @@ index e4976b4938cd..d769483b6e0c 100644
  int kvm_arch_vcpu_dump_regs(struct kvm_vcpu *vcpu);
  
 diff --git a/arch/loongarch/include/asm/kvm_vcpu.h b/arch/loongarch/include/asm/kvm_vcpu.h
-index c416cb7125c0..3cc906a0ff54 100644
+index c416cb7125c0e..3cc906a0ff54a 100644
 --- a/arch/loongarch/include/asm/kvm_vcpu.h
 +++ b/arch/loongarch/include/asm/kvm_vcpu.h
 @@ -75,6 +75,12 @@ static inline void kvm_save_lasx(struct loongarch_fpu *fpu) { }
@@ -71,7 +71,7 @@ index c416cb7125c0..3cc906a0ff54 100644
  void kvm_reset_timer(struct kvm_vcpu *vcpu);
  void kvm_save_timer(struct kvm_vcpu *vcpu);
 diff --git a/arch/loongarch/kvm/exit.c b/arch/loongarch/kvm/exit.c
-index ea73f9dc2cc6..be2c326253a3 100644
+index ea73f9dc2cc6a..be2c326253a3e 100644
 --- a/arch/loongarch/kvm/exit.c
 +++ b/arch/loongarch/kvm/exit.c
 @@ -835,6 +835,14 @@ static int kvm_handle_hypercall(struct kvm_vcpu *vcpu)
@@ -98,7 +98,7 @@ index ea73f9dc2cc6..be2c326253a3 100644
  
  int kvm_handle_fault(struct kvm_vcpu *vcpu, int fault)
 diff --git a/arch/loongarch/kvm/vcpu.c b/arch/loongarch/kvm/vcpu.c
-index 4b289718b4e1..e11dc3370976 100644
+index 4b289718b4e19..e11dc33709762 100644
 --- a/arch/loongarch/kvm/vcpu.c
 +++ b/arch/loongarch/kvm/vcpu.c
 @@ -6,6 +6,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-LoongArch-KVM-Add-LBT-feature-detection-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-LoongArch-KVM-Add-LBT-feature-detection-function.patch
@@ -1,4 +1,4 @@
-From 5a23050d8565a2d7a74dc0959245d249da235356 Mon Sep 17 00:00:00 2001
+From cb4b1e258b263071335e10d9ee62a1a37a02c6cc Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Jul 2024 15:57:42 +0800
 Subject: [PATCH 055/103] LoongArch: KVM: Add LBT feature detection function
@@ -35,7 +35,7 @@ Ref: https://lore.kernel.org/all/20240730075744.1215856-3-maobibo@loongson.cn/
  3 files changed, 65 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/include/uapi/asm/kvm.h b/arch/loongarch/include/uapi/asm/kvm.h
-index ddc5cab0ffd0..49bafac8b22d 100644
+index ddc5cab0ffd00..49bafac8b22d3 100644
 --- a/arch/loongarch/include/uapi/asm/kvm.h
 +++ b/arch/loongarch/include/uapi/asm/kvm.h
 @@ -82,6 +82,14 @@ struct kvm_fpu {
@@ -54,7 +54,7 @@ index ddc5cab0ffd0..49bafac8b22d 100644
  #define KVM_LOONGARCH_VCPU_CPUCFG	0
  #define KVM_LOONGARCH_VCPU_PVTIME_CTRL	1
 diff --git a/arch/loongarch/kvm/vcpu.c b/arch/loongarch/kvm/vcpu.c
-index e11dc3370976..a663cad2edcc 100644
+index e11dc33709762..a663cad2edccf 100644
 --- a/arch/loongarch/kvm/vcpu.c
 +++ b/arch/loongarch/kvm/vcpu.c
 @@ -470,6 +470,12 @@ static int _kvm_get_cpucfg_mask(int id, u64 *v)
@@ -71,7 +71,7 @@ index e11dc3370976..a663cad2edcc 100644
  		return 0;
  	case LOONGARCH_CPUCFG3:
 diff --git a/arch/loongarch/kvm/vm.c b/arch/loongarch/kvm/vm.c
-index 6b2e4f66ad26..f9604bc2b3ea 100644
+index 6b2e4f66ad261..f9604bc2b3eac 100644
 --- a/arch/loongarch/kvm/vm.c
 +++ b/arch/loongarch/kvm/vm.c
 @@ -99,7 +99,57 @@ int kvm_vm_ioctl_check_extension(struct kvm *kvm, long ext)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-LoongArch-KVM-Add-vm-migration-support-for-LBT-regis.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-LoongArch-KVM-Add-vm-migration-support-for-LBT-regis.patch
@@ -1,4 +1,4 @@
-From 42f13e6326806493e54a2a03a358b3dceea57a0b Mon Sep 17 00:00:00 2001
+From c771d8c6c49099420618bf5aea18d3624e047326 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Jul 2024 15:57:43 +0800
 Subject: [PATCH 056/103] LoongArch: KVM: Add vm migration support for LBT
@@ -25,7 +25,7 @@ Ref: https://lore.kernel.org/all/20240730075744.1215856-4-maobibo@loongson.cn/
  2 files changed, 65 insertions(+)
 
 diff --git a/arch/loongarch/include/uapi/asm/kvm.h b/arch/loongarch/include/uapi/asm/kvm.h
-index 49bafac8b22d..003fb766c93f 100644
+index 49bafac8b22d3..003fb766c93f7 100644
 --- a/arch/loongarch/include/uapi/asm/kvm.h
 +++ b/arch/loongarch/include/uapi/asm/kvm.h
 @@ -64,6 +64,7 @@ struct kvm_fpu {
@@ -52,7 +52,7 @@ index 49bafac8b22d..003fb766c93f 100644
  #define LOONGARCH_REG_64(TYPE, REG)	(TYPE | KVM_REG_SIZE_U64 | (REG << LOONGARCH_REG_SHIFT))
  #define KVM_IOC_CSRID(REG)		LOONGARCH_REG_64(KVM_REG_LOONGARCH_CSR, REG)
 diff --git a/arch/loongarch/kvm/vcpu.c b/arch/loongarch/kvm/vcpu.c
-index a663cad2edcc..e83ea07996ef 100644
+index a663cad2edccf..e83ea07996eff 100644
 --- a/arch/loongarch/kvm/vcpu.c
 +++ b/arch/loongarch/kvm/vcpu.c
 @@ -569,6 +569,34 @@ static int kvm_get_one_reg(struct kvm_vcpu *vcpu,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-LoongArch-Add-architectural-preparation-for-CPUFreq.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-LoongArch-Add-architectural-preparation-for-CPUFreq.patch
@@ -1,4 +1,4 @@
-From f8a18abb95ce5e8bfb1006180e53915333539568 Mon Sep 17 00:00:00 2001
+From 3c6b7381d15ef5455771f60e496021ba44acf66e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sat, 20 Jul 2024 22:41:06 +0800
 Subject: [PATCH 057/103] LoongArch: Add architectural preparation for CPUFreq
@@ -20,7 +20,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?
  3 files changed, 19 insertions(+)
 
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index b81d0eba5c7e..b2a171a45544 100644
+index b81d0eba5c7eb..b2a171a455444 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -710,6 +710,7 @@ config ARCH_HIBERNATION_POSSIBLE
@@ -32,7 +32,7 @@ index b81d0eba5c7e..b2a171a45544 100644
  endmenu
  
 diff --git a/arch/loongarch/include/asm/loongarch.h b/arch/loongarch/include/asm/loongarch.h
-index 7a4633ef284b..721bf0c81dc7 100644
+index 7a4633ef284b7..721bf0c81dc77 100644
 --- a/arch/loongarch/include/asm/loongarch.h
 +++ b/arch/loongarch/include/asm/loongarch.h
 @@ -1054,11 +1054,14 @@
@@ -51,7 +51,7 @@ index 7a4633ef284b..721bf0c81dc7 100644
  #define LOONGARCH_IOCSR_IPI_STATUS	0x1000
  #define LOONGARCH_IOCSR_IPI_EN		0x1004
 diff --git a/arch/loongarch/power/platform.c b/arch/loongarch/power/platform.c
-index 3ea8e07aa225..a19353f7d1b0 100644
+index 3ea8e07aa225f..a19353f7d1b07 100644
 --- a/arch/loongarch/power/platform.c
 +++ b/arch/loongarch/power/platform.c
 @@ -34,6 +34,21 @@ void enable_pci_wakeup(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-cpufreq-Add-Loongson-3-CPUFreq-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-cpufreq-Add-Loongson-3-CPUFreq-driver-support.patch
@@ -1,4 +1,4 @@
-From 81f4ceb836018c8bc651010cd4bce32e42659b36 Mon Sep 17 00:00:00 2001
+From b5bdc2418f699ee9b945dda309383e3fba9ee023 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 5 Jul 2024 14:06:49 +0800
 Subject: [PATCH 058/103] cpufreq: Add Loongson-3 CPUFreq driver support
@@ -49,7 +49,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?
  create mode 100644 drivers/cpufreq/loongson3_cpufreq.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index cb931b7a8028..d7742e4e2b88 100644
+index cb931b7a80288..d7742e4e2b88d 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -12953,6 +12953,7 @@ F:	Documentation/arch/loongarch/
@@ -61,7 +61,7 @@ index cb931b7a8028..d7742e4e2b88 100644
  LOONGSON GPIO DRIVER
  M:	Yinbo Zhu <zhuyinbo@loongson.cn>
 diff --git a/drivers/cpufreq/Kconfig b/drivers/cpufreq/Kconfig
-index 94e55c40970a..10cda6f2fe1d 100644
+index 94e55c40970a6..10cda6f2fe1d1 100644
 --- a/drivers/cpufreq/Kconfig
 +++ b/drivers/cpufreq/Kconfig
 @@ -262,6 +262,18 @@ config LOONGSON2_CPUFREQ
@@ -84,7 +84,7 @@ index 94e55c40970a..10cda6f2fe1d 100644
  config SPARC_US3_CPUFREQ
  	tristate "UltraSPARC-III CPU Frequency driver"
 diff --git a/drivers/cpufreq/Makefile b/drivers/cpufreq/Makefile
-index 8d141c71b016..0f184031dd12 100644
+index 8d141c71b016b..0f184031dd123 100644
 --- a/drivers/cpufreq/Makefile
 +++ b/drivers/cpufreq/Makefile
 @@ -103,6 +103,7 @@ obj-$(CONFIG_POWERNV_CPUFREQ)		+= powernv-cpufreq.o
@@ -97,7 +97,7 @@ index 8d141c71b016..0f184031dd12 100644
  obj-$(CONFIG_SPARC_US3_CPUFREQ)		+= sparc-us3-cpufreq.o
 diff --git a/drivers/cpufreq/loongson3_cpufreq.c b/drivers/cpufreq/loongson3_cpufreq.c
 new file mode 100644
-index 000000000000..5f79b6de127c
+index 0000000000000..5f79b6de127c9
 --- /dev/null
 +++ b/drivers/cpufreq/loongson3_cpufreq.c
 @@ -0,0 +1,395 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-dt-bindings-pwm-Add-Loongson-PWM-controller.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-dt-bindings-pwm-Add-Loongson-PWM-controller.patch
@@ -1,4 +1,4 @@
-From bf29dd5ea58e73056e9901b16743b5543e79d7c2 Mon Sep 17 00:00:00 2001
+From 30a8222e84748e995571878a1fd604a156ff4073 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 10 Jul 2024 10:04:06 +0800
 Subject: [PATCH 059/103] dt-bindings: pwm: Add Loongson PWM controller
@@ -18,7 +18,7 @@ Ref: https://lore.kernel.org/all/28e74b9f25265d7ac743d46c65a2181001eb5817.172051
 
 diff --git a/Documentation/devicetree/bindings/pwm/loongson,ls7a-pwm.yaml b/Documentation/devicetree/bindings/pwm/loongson,ls7a-pwm.yaml
 new file mode 100644
-index 000000000000..46814773e0cc
+index 0000000000000..46814773e0cc8
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/pwm/loongson,ls7a-pwm.yaml
 @@ -0,0 +1,66 @@
@@ -89,7 +89,7 @@ index 000000000000..46814773e0cc
 +        #pwm-cells = <3>;
 +    };
 diff --git a/MAINTAINERS b/MAINTAINERS
-index d7742e4e2b88..7dc8dc66a6ff 100644
+index d7742e4e2b88d..7dc8dc66a6ffe 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -12976,6 +12976,12 @@ S:	Maintained

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-pwm-Add-Loongson-PWM-controller-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-pwm-Add-Loongson-PWM-controller-support.patch
@@ -1,4 +1,4 @@
-From 836640259ac470310df4b4f5e5aa7a888443ee95 Mon Sep 17 00:00:00 2001
+From c44626b2ff61f5dffba12ef8aa76215e0fa69953 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 10 Jul 2024 10:04:07 +0800
 Subject: [PATCH 060/103] pwm: Add Loongson PWM controller support
@@ -20,7 +20,7 @@ Ref: https://lore.kernel.org/all/63a540e93147eff5e7c942133c462530689f707c.172051
  create mode 100644 drivers/pwm/pwm-loongson.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 7dc8dc66a6ff..c1598b0c92e5 100644
+index 7dc8dc66a6ffe..c1598b0c92e5f 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -12981,6 +12981,7 @@ M:	Binbin Zhou <zhoubinbin@loongson.cn>
@@ -32,7 +32,7 @@ index 7dc8dc66a6ff..c1598b0c92e5 100644
  LOONGSON-2 SOC SERIES CLOCK DRIVER
  M:	Yinbo Zhu <zhuyinbo@loongson.cn>
 diff --git a/drivers/pwm/Kconfig b/drivers/pwm/Kconfig
-index 1dd7921194f5..839a63ccda0e 100644
+index 1dd7921194f58..839a63ccda0e6 100644
 --- a/drivers/pwm/Kconfig
 +++ b/drivers/pwm/Kconfig
 @@ -320,6 +320,18 @@ config PWM_KEEMBAY
@@ -55,7 +55,7 @@ index 1dd7921194f5..839a63ccda0e 100644
  	tristate "TI/National Semiconductor LP3943 PWM support"
  	depends on MFD_LP3943
 diff --git a/drivers/pwm/Makefile b/drivers/pwm/Makefile
-index 90913519f11a..032d73327509 100644
+index 90913519f11a8..032d733275094 100644
 --- a/drivers/pwm/Makefile
 +++ b/drivers/pwm/Makefile
 @@ -27,6 +27,7 @@ obj-$(CONFIG_PWM_INTEL_LGM)	+= pwm-intel-lgm.o
@@ -68,7 +68,7 @@ index 90913519f11a..032d73327509 100644
  obj-$(CONFIG_PWM_LPC32XX)	+= pwm-lpc32xx.o
 diff --git a/drivers/pwm/pwm-loongson.c b/drivers/pwm/pwm-loongson.c
 new file mode 100644
-index 000000000000..17ab2a2f48ad
+index 0000000000000..17ab2a2f48ad0
 --- /dev/null
 +++ b/drivers/pwm/pwm-loongson.c
 @@ -0,0 +1,285 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0061-cpufreq-Make-Loongson-3-s-cpufreq_driver-exit-return.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0061-cpufreq-Make-Loongson-3-s-cpufreq_driver-exit-return.patch
@@ -1,4 +1,4 @@
-From 1b8b299dd41c3bf74be2d75d6f51f4fc717006c3 Mon Sep 17 00:00:00 2001
+From 35a1a5cc509c727c120650adb4463b4bf708f92b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 20:00:46 +0800
 Subject: [PATCH 061/103] cpufreq: Make Loongson-3's cpufreq_driver->exit()
@@ -12,7 +12,7 @@ Ref: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/cpufreq/loongson3_cpufreq.c b/drivers/cpufreq/loongson3_cpufreq.c
-index 5f79b6de127c..30201dc89191 100644
+index 5f79b6de127c9..30201dc89191a 100644
 --- a/drivers/cpufreq/loongson3_cpufreq.c
 +++ b/drivers/cpufreq/loongson3_cpufreq.c
 @@ -311,11 +311,13 @@ static int loongson3_cpufreq_cpu_init(struct cpufreq_policy *policy)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0062-loongarch-basic-boot-support-for-legacy-firmware.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0062-loongarch-basic-boot-support-for-legacy-firmware.patch
@@ -1,4 +1,4 @@
-From bb6be8253353566ce840cc49eb6efaf85475b8a1 Mon Sep 17 00:00:00 2001
+From 945d2a50554c7263457abf7b4e768d1a789d37cf Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
 Subject: [PATCH 062/103] loongarch: basic boot support for legacy firmware
@@ -29,7 +29,7 @@ Ref: https://github.com/shankerwangmiao/linux/commit/f955b18b71caf472345595a81cf
  3 files changed, 37 insertions(+)
 
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index 2bf86aeda874..ff44bb09ee96 100644
+index 2bf86aeda874c..ff44bb09ee96f 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
 @@ -98,6 +98,23 @@ static void __init init_screen_info(void)
@@ -65,7 +65,7 @@ index 2bf86aeda874..ff44bb09ee96 100644
  	early_memunmap(config_tables, efi_nr_tables * size);
  
 diff --git a/arch/loongarch/kernel/mem.c b/arch/loongarch/kernel/mem.c
-index aed901c57fb4..86d37a447eec 100644
+index aed901c57fb43..86d37a447eec1 100644
 --- a/arch/loongarch/kernel/mem.c
 +++ b/arch/loongarch/kernel/mem.c
 @@ -19,6 +19,7 @@ void __init memblock_init(void)
@@ -77,7 +77,7 @@ index aed901c57fb4..86d37a447eec 100644
  		mem_size = md->num_pages << EFI_PAGE_SHIFT;
  		mem_end = mem_start + mem_size;
 diff --git a/drivers/firmware/efi/libstub/loongarch.c b/drivers/firmware/efi/libstub/loongarch.c
-index d0ef93551c44..e0ae9c8550c3 100644
+index d0ef93551c44f..e0ae9c8550c32 100644
 --- a/drivers/firmware/efi/libstub/loongarch.c
 +++ b/drivers/firmware/efi/libstub/loongarch.c
 @@ -23,6 +23,8 @@ struct exit_boot_struct {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0063-loongarch-parse-BPI-data-and-add-memory-mapping.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0063-loongarch-parse-BPI-data-and-add-memory-mapping.patch
@@ -1,4 +1,4 @@
-From d3f8cee497f62cf718ae8fee9340ec7632c2b635 Mon Sep 17 00:00:00 2001
+From 8ca043f9b2414cb6dc66076c997542a18cc35b9e Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
 Subject: [PATCH 063/103] loongarch: parse BPI data and add memory mapping
@@ -33,7 +33,7 @@ Ref: https://github.com/shankerwangmiao/linux/commit/ef08c6d2447bf14e5a940416493
  create mode 100644 arch/loongarch/kernel/legacy_boot.h
 
 diff --git a/arch/loongarch/kernel/Makefile b/arch/loongarch/kernel/Makefile
-index c9bfeda89e40..e52144b9f282 100644
+index c9bfeda89e407..e52144b9f2827 100644
 --- a/arch/loongarch/kernel/Makefile
 +++ b/arch/loongarch/kernel/Makefile
 @@ -79,3 +79,5 @@ obj-$(CONFIG_UPROBES)		+= uprobes.o
@@ -43,7 +43,7 @@ index c9bfeda89e40..e52144b9f282 100644
 +
 +obj-y				+= legacy_boot.o
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index ff44bb09ee96..9ae0afaa2ddf 100644
+index ff44bb09ee96f..9ae0afaa2ddfb 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
 @@ -25,6 +25,8 @@
@@ -65,7 +65,7 @@ index ff44bb09ee96..9ae0afaa2ddf 100644
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
 new file mode 100644
-index 000000000000..30c01c8b22a0
+index 0000000000000..30c01c8b22a0a
 --- /dev/null
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -0,0 +1,297 @@
@@ -368,7 +368,7 @@ index 000000000000..30c01c8b22a0
 +}
 diff --git a/arch/loongarch/kernel/legacy_boot.h b/arch/loongarch/kernel/legacy_boot.h
 new file mode 100644
-index 000000000000..6d3a36ebaab7
+index 0000000000000..6d3a36ebaab71
 --- /dev/null
 +++ b/arch/loongarch/kernel/legacy_boot.h
 @@ -0,0 +1,18 @@
@@ -391,7 +391,7 @@ index 000000000000..6d3a36ebaab7
 +
 +#endif /* __LEGACY_BOOT_H_ */
 diff --git a/arch/loongarch/kernel/mem.c b/arch/loongarch/kernel/mem.c
-index 86d37a447eec..b24b3db96018 100644
+index 86d37a447eec1..b24b3db96018d 100644
 --- a/arch/loongarch/kernel/mem.c
 +++ b/arch/loongarch/kernel/mem.c
 @@ -10,6 +10,8 @@
@@ -413,7 +413,7 @@ index 86d37a447eec..b24b3db96018 100644
  
  	/* Reserve the first 2MB */
 diff --git a/arch/loongarch/kernel/numa.c b/arch/loongarch/kernel/numa.c
-index 8fe21f868f72..5d45c389e961 100644
+index 8fe21f868f72d..5d45c389e9612 100644
 --- a/arch/loongarch/kernel/numa.c
 +++ b/arch/loongarch/kernel/numa.c
 @@ -26,6 +26,8 @@
@@ -434,7 +434,7 @@ index 8fe21f868f72..5d45c389e961 100644
  		return -EINVAL;
  
 diff --git a/arch/loongarch/kernel/setup.c b/arch/loongarch/kernel/setup.c
-index 3d048f1be143..98c02ec29011 100644
+index 3d048f1be1438..98c02ec290118 100644
 --- a/arch/loongarch/kernel/setup.c
 +++ b/arch/loongarch/kernel/setup.c
 @@ -49,6 +49,8 @@
@@ -455,7 +455,7 @@ index 3d048f1be143..98c02ec29011 100644
  	pagetable_init();
  	bootcmdline_init(cmdline_p);
 diff --git a/arch/loongarch/kernel/smp.c b/arch/loongarch/kernel/smp.c
-index 1436d2465939..bf3713d88738 100644
+index 1436d2465939b..bf3713d88738f 100644
 --- a/arch/loongarch/kernel/smp.c
 +++ b/arch/loongarch/kernel/smp.c
 @@ -34,6 +34,8 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0064-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0064-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,4 +1,4 @@
-From 5f9d69e9f54a5ce9408d1333d6f59f421dbbd975 Mon Sep 17 00:00:00 2001
+From c0e8203977c5ea5609b6cff44af9f569bf6cd449 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
 Subject: [PATCH 064/103] loongarch: add MADT ACPI table conversion
@@ -20,7 +20,7 @@ Ref: https://github.com/shankerwangmiao/linux/commit/1d4b825130faf3cf6ead22163b2
  4 files changed, 321 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index 313f66f7913a..ba78288a26e3 100644
+index 313f66f7913af..ba78288a26e3f 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -45,6 +45,11 @@ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
@@ -36,7 +36,7 @@ index 313f66f7913a..ba78288a26e3 100644
  
  #define ACPI_TABLE_UPGRADE_MAX_PHYS ARCH_LOW_ADDRESS_LIMIT
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 30c01c8b22a0..841d8db85a3c 100644
+index 30c01c8b22a0a..841d8db85a3cb 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -1,7 +1,13 @@
@@ -380,7 +380,7 @@ index 30c01c8b22a0..841d8db85a3c 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/tables.c b/drivers/acpi/tables.c
-index b976e5fc3fbc..6cd17bb24426 100644
+index b976e5fc3fbcd..6cd17bb244267 100644
 --- a/drivers/acpi/tables.c
 +++ b/drivers/acpi/tables.c
 @@ -679,6 +679,7 @@ acpi_status acpi_os_table_override(struct acpi_table_header *existing_table,
@@ -400,7 +400,7 @@ index b976e5fc3fbc..6cd17bb24426 100644
  
  int __init acpi_table_init(void)
 diff --git a/include/linux/acpi.h b/include/linux/acpi.h
-index 28c3fb2bef0d..d894549538b3 100644
+index 28c3fb2bef0da..d894549538b3b 100644
 --- a/include/linux/acpi.h
 +++ b/include/linux/acpi.h
 @@ -764,6 +764,16 @@ static inline u64 acpi_arch_get_root_pointer(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0065-loongarch-correct-missing-offset-of-PCI-root-control.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0065-loongarch-correct-missing-offset-of-PCI-root-control.patch
@@ -1,4 +1,4 @@
-From a7c7d4dcc88df8e46a964452e134830c64f68c27 Mon Sep 17 00:00:00 2001
+From f0f9ad15d518d90ae682fa3d2261d2262116c0df Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
 Subject: [PATCH 065/103] loongarch: correct missing offset of PCI root
@@ -30,7 +30,7 @@ Ref: https://github.com/shankerwangmiao/linux/commit/0a8e8d2d3c88430d8b7b8004852
  4 files changed, 29 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index ba78288a26e3..c954d15d0a47 100644
+index ba78288a26e3f..c954d15d0a47c 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -49,6 +49,8 @@ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
@@ -43,7 +43,7 @@ index ba78288a26e3..c954d15d0a47 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 841d8db85a3c..7043bfd0399d 100644
+index 841d8db85a3cb..7043bfd0399d6 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -60,7 +60,7 @@ struct loongarch_bpi_info __initdata loongarch_bpi_info = {
@@ -84,7 +84,7 @@ index 841d8db85a3c..7043bfd0399d 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/pci_root.c b/drivers/acpi/pci_root.c
-index 58b89b8d950e..93936225dc37 100644
+index 58b89b8d950ed..93936225dc37f 100644
 --- a/drivers/acpi/pci_root.c
 +++ b/drivers/acpi/pci_root.c
 @@ -914,6 +914,7 @@ int acpi_pci_probe_root_resources(struct acpi_pci_root_info *info)
@@ -96,7 +96,7 @@ index 58b89b8d950e..93936225dc37 100644
  				acpi_pci_root_remap_iospace(&device->fwnode,
  						entry);
 diff --git a/include/linux/pci-acpi.h b/include/linux/pci-acpi.h
-index 078225b514d4..1c22ca4ec794 100644
+index 078225b514d48..1c22ca4ec794c 100644
 --- a/include/linux/pci-acpi.h
 +++ b/include/linux/pci-acpi.h
 @@ -133,6 +133,10 @@ static inline void pci_acpi_remove_edr_notifier(struct pci_dev *pdev) { }

--- a/runtime-kernel/linux-kernel/autobuild/patches/0066-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0066-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,4 +1,4 @@
-From b50bec13689c6bc68b0c3cde5095a90934acb25c Mon Sep 17 00:00:00 2001
+From 07d4ea65d470c013e6a7d018cbb7bb4dadd691e1 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
 Subject: [PATCH 066/103] loongarch: fix missing dependency info in DSDT
@@ -29,7 +29,7 @@ Ref: https://github.com/shankerwangmiao/linux/commit/21736f3f1d145879cea0a34b21d
  4 files changed, 54 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index c954d15d0a47..8d8551c2b6c0 100644
+index c954d15d0a47c..8d8551c2b6c04 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -51,6 +51,8 @@ extern void acpi_arch_os_table_override (struct acpi_table_header *existing_tabl
@@ -42,7 +42,7 @@ index c954d15d0a47..8d8551c2b6c0 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 7043bfd0399d..3ec69ffd8b94 100644
+index 7043bfd0399d6..3ec69ffd8b942 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -617,6 +617,53 @@ void acpi_arch_pci_probe_root_dev_filter(struct resource_entry *entry)
@@ -100,7 +100,7 @@ index 7043bfd0399d..3ec69ffd8b94 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/bus.c b/drivers/acpi/bus.c
-index 787eca838410..0ec78091d4dc 100644
+index 787eca8384100..0ec78091d4dc0 100644
 --- a/drivers/acpi/bus.c
 +++ b/drivers/acpi/bus.c
 @@ -1457,6 +1457,7 @@ static int __init acpi_init(void)
@@ -112,7 +112,7 @@ index 787eca838410..0ec78091d4dc 100644
  	acpi_ec_init();
  	acpi_debugfs_init();
 diff --git a/include/linux/acpi.h b/include/linux/acpi.h
-index d894549538b3..34802bc07815 100644
+index d894549538b3b..34802bc07815f 100644
 --- a/include/linux/acpi.h
 +++ b/include/linux/acpi.h
 @@ -1528,6 +1528,10 @@ void acpi_arm_init(void);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0067-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0067-loongarch-fix-DMA-address-offset.patch
@@ -1,4 +1,4 @@
-From 0f1d5bf8e302c522cdd5f6d30825744e0d970c58 Mon Sep 17 00:00:00 2001
+From 20a748872b126c15e1e93e652603431cb8d76734 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
 Subject: [PATCH 067/103] loongarch: fix DMA address offset
@@ -43,7 +43,7 @@ Ref: https://github.com/shankerwangmiao/linux/commit/09ffbc5f78f5d49c858db724305
  1 file changed, 27 insertions(+)
 
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 3ec69ffd8b94..2888e2b9fb45 100644
+index 3ec69ffd8b942..2888e2b9fb456 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -46,6 +46,19 @@ enum bpi_mem_type {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0068-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0068-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,4 +1,4 @@
-From ae8e3b672e5568bc6b25462b134e84517ad16c7d Mon Sep 17 00:00:00 2001
+From 0962e48aa3825ba4a1a60720a1619b345543391c Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
 Subject: [PATCH 068/103] loongarch: fix HT_RX_INT_TRANS register
@@ -18,7 +18,7 @@ Ref: https://github.com/shankerwangmiao/linux/commit/9068d3d154686bdfacf241cb18f
  1 file changed, 24 insertions(+)
 
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 2888e2b9fb45..204b33109f37 100644
+index 2888e2b9fb456..204b33109f37d 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -59,6 +59,16 @@ enum bpi_mem_type {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0069-ntsync-Introduce-NTSYNC_IOC_WAIT_ANY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0069-ntsync-Introduce-NTSYNC_IOC_WAIT_ANY.patch
@@ -1,4 +1,4 @@
-From 473e3a0c52a6f6ad579367e9493c2ccbf42362b3 Mon Sep 17 00:00:00 2001
+From 5289a2d294c0393110af11193e0b3547a0a4928a Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:27 -0500
 Subject: [PATCH 069/103] ntsync: Introduce NTSYNC_IOC_WAIT_ANY.
@@ -44,7 +44,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 259 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 3c2f743c58b0..d5864891caf0 100644
+index 3c2f743c58b00..d5864891caf04 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -6,11 +6,16 @@
@@ -353,7 +353,7 @@ index 3c2f743c58b0..d5864891caf0 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index dcfa38fdc93c..edc12c7a10dc 100644
+index dcfa38fdc93c6..edc12c7a10dca 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -16,7 +16,21 @@ struct ntsync_sem_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0070-ntsync-Introduce-NTSYNC_IOC_WAIT_ALL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0070-ntsync-Introduce-NTSYNC_IOC_WAIT_ALL.patch
@@ -1,4 +1,4 @@
-From 71a2cd573611a1f4bf8a6cf7fb22d57c014d0aaf Mon Sep 17 00:00:00 2001
+From 66504510694fbb7646e6b931aec717902806b562 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:28 -0500
 Subject: [PATCH 070/103] ntsync: Introduce NTSYNC_IOC_WAIT_ALL.
@@ -33,7 +33,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 322 insertions(+), 13 deletions(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index d5864891caf0..a2f2dfadc3ee 100644
+index d5864891caf04..a2f2dfadc3ee6 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -13,6 +13,7 @@
@@ -524,7 +524,7 @@ index d5864891caf0..a2f2dfadc3ee 100644
  		return ntsync_wait_any(dev, argp);
  	default:
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index edc12c7a10dc..addf187b1573 100644
+index edc12c7a10dca..addf187b15737 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -31,6 +31,7 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0071-ntsync-Introduce-NTSYNC_IOC_CREATE_MUTEX.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0071-ntsync-Introduce-NTSYNC_IOC_CREATE_MUTEX.patch
@@ -1,4 +1,4 @@
-From 46706bd96db1c466f1b1909a25c6030cafe1aa8d Mon Sep 17 00:00:00 2001
+From 20c9d4c64dc63551190924c4d6b673d2a1e1ef30 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:29 -0500
 Subject: [PATCH 071/103] ntsync: Introduce NTSYNC_IOC_CREATE_MUTEX.
@@ -24,7 +24,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 83 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index a2f2dfadc3ee..cfe802c79d7d 100644
+index a2f2dfadc3ee6..cfe802c79d7dc 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -25,6 +25,7 @@
@@ -195,7 +195,7 @@ index a2f2dfadc3ee..cfe802c79d7d 100644
  		return ntsync_create_sem(dev, argp);
  	case NTSYNC_IOC_WAIT_ALL:
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index addf187b1573..d5e5a2fbcb4d 100644
+index addf187b15737..d5e5a2fbcb4dc 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -16,6 +16,12 @@ struct ntsync_sem_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0072-ntsync-Introduce-NTSYNC_IOC_MUTEX_UNLOCK.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0072-ntsync-Introduce-NTSYNC_IOC_MUTEX_UNLOCK.patch
@@ -1,4 +1,4 @@
-From f2c86d33526c23a4da9a52d6b7a44a11f644d69b Mon Sep 17 00:00:00 2001
+From fd6654556825c0d9c817a9e093d718ff42538676 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:30 -0500
 Subject: [PATCH 072/103] ntsync: Introduce NTSYNC_IOC_MUTEX_UNLOCK.
@@ -17,7 +17,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 54 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index cfe802c79d7d..f00af9b15164 100644
+index cfe802c79d7dc..f00af9b151645 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -396,6 +396,57 @@ static int ntsync_sem_post(struct ntsync_obj *sem, void __user *argp)
@@ -88,7 +88,7 @@ index cfe802c79d7d..f00af9b15164 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index d5e5a2fbcb4d..a633db34f284 100644
+index d5e5a2fbcb4dc..a633db34f2841 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -42,5 +42,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0073-ntsync-Introduce-NTSYNC_IOC_MUTEX_KILL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0073-ntsync-Introduce-NTSYNC_IOC_MUTEX_KILL.patch
@@ -1,4 +1,4 @@
-From 681fee97549d6b4a008ab41b52e409f950a996cd Mon Sep 17 00:00:00 2001
+From fc8ef7eea8f289744213f9cd9dce1b0a6ce93280 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:31 -0500
 Subject: [PATCH 073/103] ntsync: Introduce NTSYNC_IOC_MUTEX_KILL.
@@ -21,7 +21,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 60 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index f00af9b15164..5aaf9dad76b6 100644
+index f00af9b151645..5aaf9dad76b68 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -59,6 +59,7 @@ struct ntsync_obj {
@@ -149,7 +149,7 @@ index f00af9b15164..5aaf9dad76b6 100644
  		if (put_user(signaled, &user_args->index))
  			ret = -EFAULT;
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index a633db34f284..d7996180c1d2 100644
+index a633db34f2841..d7996180c1d2a 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -43,5 +43,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0074-ntsync-Introduce-NTSYNC_IOC_CREATE_EVENT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0074-ntsync-Introduce-NTSYNC_IOC_CREATE_EVENT.patch
@@ -1,4 +1,4 @@
-From 86ec87c725a6eebd34c2606024174fe694bbef16 Mon Sep 17 00:00:00 2001
+From f4ec6b8241b19bad0fd4d377c8048d16b88cd093 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:32 -0500
 Subject: [PATCH 074/103] ntsync: Introduce NTSYNC_IOC_CREATE_EVENT.
@@ -23,7 +23,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 69 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 5aaf9dad76b6..2bce03187c17 100644
+index 5aaf9dad76b68..2bce03187c170 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -26,6 +26,7 @@
@@ -145,7 +145,7 @@ index 5aaf9dad76b6..2bce03187c17 100644
  		return ntsync_create_mutex(dev, argp);
  	case NTSYNC_IOC_CREATE_SEM:
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index d7996180c1d2..4c0c4271c7de 100644
+index d7996180c1d2a..4c0c4271c7de7 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -22,6 +22,12 @@ struct ntsync_mutex_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0075-ntsync-Introduce-NTSYNC_IOC_EVENT_SET.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0075-ntsync-Introduce-NTSYNC_IOC_EVENT_SET.patch
@@ -1,4 +1,4 @@
-From 559976376291fdc41f03436d48fbf863037c87b3 Mon Sep 17 00:00:00 2001
+From 92b3d616787fd0a967a08b397c9e95d4bf6e93e1 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:33 -0500
 Subject: [PATCH 075/103] ntsync: Introduce NTSYNC_IOC_EVENT_SET.
@@ -15,7 +15,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 28 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 2bce03187c17..97d9b6047fbe 100644
+index 2bce03187c170..97d9b6047fbea 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -534,6 +534,31 @@ static int ntsync_mutex_kill(struct ntsync_obj *mutex, void __user *argp)
@@ -60,7 +60,7 @@ index 2bce03187c17..97d9b6047fbe 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 4c0c4271c7de..36d903521bbe 100644
+index 4c0c4271c7de7..36d903521bbe7 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -51,5 +51,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0076-ntsync-Introduce-NTSYNC_IOC_EVENT_RESET.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0076-ntsync-Introduce-NTSYNC_IOC_EVENT_RESET.patch
@@ -1,4 +1,4 @@
-From 829b04dd86ef68ea8ea458fbb1c9d2356e4f792b Mon Sep 17 00:00:00 2001
+From 10c582b2a977334e50cce35df2bfe27a3db7f512 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:34 -0500
 Subject: [PATCH 076/103] ntsync: Introduce NTSYNC_IOC_EVENT_RESET.
@@ -15,7 +15,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 25 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 97d9b6047fbe..b070ceccc3af 100644
+index 97d9b6047fbea..b070ceccc3afd 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -559,6 +559,28 @@ static int ntsync_event_set(struct ntsync_obj *event, void __user *argp)
@@ -57,7 +57,7 @@ index 97d9b6047fbe..b070ceccc3af 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 36d903521bbe..7fdf79729b20 100644
+index 36d903521bbe7..7fdf79729b208 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -52,5 +52,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0077-ntsync-Introduce-NTSYNC_IOC_EVENT_PULSE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0077-ntsync-Introduce-NTSYNC_IOC_EVENT_PULSE.patch
@@ -1,4 +1,4 @@
-From b829810d20b95050fb9bd4fb97fa6b7eabf8a621 Mon Sep 17 00:00:00 2001
+From 723f4bfcb399714e0a74f327281d313bfe6e6e46 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:35 -0500
 Subject: [PATCH 077/103] ntsync: Introduce NTSYNC_IOC_EVENT_PULSE.
@@ -18,7 +18,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index b070ceccc3af..b0c1d644f0af 100644
+index b070ceccc3afd..b0c1d644f0afe 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -534,7 +534,7 @@ static int ntsync_mutex_kill(struct ntsync_obj *mutex, void __user *argp)
@@ -53,7 +53,7 @@ index b070ceccc3af..b0c1d644f0af 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 7fdf79729b20..5586fadd9bdd 100644
+index 7fdf79729b208..5586fadd9bddf 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -53,5 +53,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0078-ntsync-Introduce-NTSYNC_IOC_SEM_READ.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0078-ntsync-Introduce-NTSYNC_IOC_SEM_READ.patch
@@ -1,4 +1,4 @@
-From 7ce6b8eef5ada2ca9d35509455dd3903b4da646b Mon Sep 17 00:00:00 2001
+From 40b08a859fd2c63d06d4d42d3fcef15046714376 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:36 -0500
 Subject: [PATCH 078/103] ntsync: Introduce NTSYNC_IOC_SEM_READ.
@@ -15,7 +15,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 27 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index b0c1d644f0af..4c680a2b8353 100644
+index b0c1d644f0afe..4c680a2b83530 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -583,6 +583,30 @@ static int ntsync_event_reset(struct ntsync_obj *event, void __user *argp)
@@ -59,7 +59,7 @@ index b0c1d644f0af..4c680a2b8353 100644
  		return ntsync_mutex_unlock(obj, argp);
  	case NTSYNC_IOC_MUTEX_KILL:
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 5586fadd9bdd..5e922703686f 100644
+index 5586fadd9bddf..5e922703686f8 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -54,5 +54,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0079-ntsync-Introduce-NTSYNC_IOC_MUTEX_READ.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0079-ntsync-Introduce-NTSYNC_IOC_MUTEX_READ.patch
@@ -1,4 +1,4 @@
-From 1e1cd181123f9cf7121f85db2fb622e13af358c5 Mon Sep 17 00:00:00 2001
+From db009013fe08cb6a7bd8eefa5a84bc37716242e4 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:37 -0500
 Subject: [PATCH 079/103] ntsync: Introduce NTSYNC_IOC_MUTEX_READ.
@@ -15,7 +15,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 29 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 4c680a2b8353..622be0075ba4 100644
+index 4c680a2b83530..622be0075ba4e 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -607,6 +607,32 @@ static int ntsync_sem_read(struct ntsync_obj *sem, void __user *argp)
@@ -61,7 +61,7 @@ index 4c680a2b8353..622be0075ba4 100644
  		return ntsync_event_set(obj, argp, false);
  	case NTSYNC_IOC_EVENT_RESET:
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 5e922703686f..eced73d08783 100644
+index 5e922703686f8..eced73d087838 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -55,5 +55,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0080-ntsync-Introduce-NTSYNC_IOC_EVENT_READ.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0080-ntsync-Introduce-NTSYNC_IOC_EVENT_READ.patch
@@ -1,4 +1,4 @@
-From 6563479a82f12063d07a1b781fb1fbdcd39baebb Mon Sep 17 00:00:00 2001
+From 4dd7bace62b90150c00a3bd9e7f6aff25dcc05c7 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:38 -0500
 Subject: [PATCH 080/103] ntsync: Introduce NTSYNC_IOC_EVENT_READ.
@@ -15,7 +15,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 27 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 622be0075ba4..a11fe2469841 100644
+index 622be0075ba4e..a11fe2469841b 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -633,6 +633,30 @@ static int ntsync_mutex_read(struct ntsync_obj *mutex, void __user *argp)
@@ -59,7 +59,7 @@ index 622be0075ba4..a11fe2469841 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index eced73d08783..74abeba832f7 100644
+index eced73d087838..74abeba832f77 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -56,5 +56,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0081-ntsync-Introduce-alertable-waits.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0081-ntsync-Introduce-alertable-waits.patch
@@ -1,4 +1,4 @@
-From 4009fd9f2fe5e9f63709c1085b70c00c45b074f5 Mon Sep 17 00:00:00 2001
+From f30d4439fe601ad445628ed2b8f828e39bfc0517 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:39 -0500
 Subject: [PATCH 081/103] ntsync: Introduce alertable waits.
@@ -21,7 +21,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  2 files changed, 63 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index a11fe2469841..87a24798a5c7 100644
+index a11fe2469841b..87a24798a5c7b 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -885,22 +885,29 @@ static int setup_wait(struct ntsync_device *dev,
@@ -177,7 +177,7 @@ index a11fe2469841..87a24798a5c7 100644
  	if (signaled != -1) {
  		struct ntsync_wait_args __user *user_args = argp;
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 74abeba832f7..4a8095a3fc34 100644
+index 74abeba832f77..4a8095a3fc34c 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -37,7 +37,8 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0082-selftests-ntsync-Add-some-tests-for-semaphore-state.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0082-selftests-ntsync-Add-some-tests-for-semaphore-state.patch
@@ -1,4 +1,4 @@
-From 5fac0bdf6d1ed8615676aeae46aa33c4d9eb6dcb Mon Sep 17 00:00:00 2001
+From 6f3310abc7128c9a07a218b3b497cc05263ca986 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:40 -0500
 Subject: [PATCH 082/103] selftests: ntsync: Add some tests for semaphore
@@ -26,7 +26,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  create mode 100644 tools/testing/selftests/drivers/ntsync/ntsync.c
 
 diff --git a/tools/testing/selftests/Makefile b/tools/testing/selftests/Makefile
-index 9039f3709aff..d5aeaa8fe3ca 100644
+index 9039f3709affb..d5aeaa8fe3cac 100644
 --- a/tools/testing/selftests/Makefile
 +++ b/tools/testing/selftests/Makefile
 @@ -16,6 +16,7 @@ TARGETS += damon
@@ -39,14 +39,14 @@ index 9039f3709aff..d5aeaa8fe3ca 100644
  TARGETS += drivers/net/bonding
 diff --git a/tools/testing/selftests/drivers/ntsync/.gitignore b/tools/testing/selftests/drivers/ntsync/.gitignore
 new file mode 100644
-index 000000000000..848573a3d3ea
+index 0000000000000..848573a3d3eaf
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/.gitignore
 @@ -0,0 +1 @@
 +ntsync
 diff --git a/tools/testing/selftests/drivers/ntsync/Makefile b/tools/testing/selftests/drivers/ntsync/Makefile
 new file mode 100644
-index 000000000000..dbf2b055c0b2
+index 0000000000000..dbf2b055c0b28
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/Makefile
 @@ -0,0 +1,7 @@
@@ -59,14 +59,14 @@ index 000000000000..dbf2b055c0b2
 +include ../../lib.mk
 diff --git a/tools/testing/selftests/drivers/ntsync/config b/tools/testing/selftests/drivers/ntsync/config
 new file mode 100644
-index 000000000000..60539c826d06
+index 0000000000000..60539c826d062
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/config
 @@ -0,0 +1 @@
 +CONFIG_WINESYNC=y
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
 new file mode 100644
-index 000000000000..1e145c6dfded
+index 0000000000000..1e145c6dfded3
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -0,0 +1,149 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0083-selftests-ntsync-Add-some-tests-for-mutex-state.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0083-selftests-ntsync-Add-some-tests-for-mutex-state.patch
@@ -1,4 +1,4 @@
-From c4362ae1fce0595169c83392cb74bd8c2410f640 Mon Sep 17 00:00:00 2001
+From fb9e53bc278581191d65ba56b71840a36da4d4b5 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:41 -0500
 Subject: [PATCH 083/103] selftests: ntsync: Add some tests for mutex state.
@@ -13,7 +13,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 196 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 1e145c6dfded..7cd0f40594fd 100644
+index 1e145c6dfded3..7cd0f40594fd0 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -40,6 +40,39 @@ static int post_sem(int sem, __u32 *count)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0084-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0084-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
@@ -1,4 +1,4 @@
-From c3f7cc00789949884a54024ea4e2d5f487ddc87b Mon Sep 17 00:00:00 2001
+From 7da14759463228da4680d6556255251c9935b28e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:42 -0500
 Subject: [PATCH 084/103] selftests: ntsync: Add some tests for
@@ -15,7 +15,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 119 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 7cd0f40594fd..40ad8cbd3138 100644
+index 7cd0f40594fd0..40ad8cbd31388 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -342,4 +342,123 @@ TEST(mutex_state)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0085-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0085-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
@@ -1,4 +1,4 @@
-From 44261d57762ea9b6e05d321136029d0455a85543 Mon Sep 17 00:00:00 2001
+From 71f82696279f15ea49554a0d5c86476303d2fb34 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:43 -0500
 Subject: [PATCH 085/103] selftests: ntsync: Add some tests for
@@ -14,7 +14,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 97 insertions(+), 2 deletions(-)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 40ad8cbd3138..c0f372167557 100644
+index 40ad8cbd31388..c0f372167557d 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -73,7 +73,8 @@ static int unlock_mutex(int mutex, __u32 owner, __u32 *count)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0086-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0086-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From 0e39887012b81f12484a20d852f81f3c9738b2e5 Mon Sep 17 00:00:00 2001
+From f44cdad3e9e7ce668b7194b43b0db95413b70f77 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:44 -0500
 Subject: [PATCH 086/103] selftests: ntsync: Add some tests for wakeup
@@ -14,7 +14,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 150 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index c0f372167557..993f5db23768 100644
+index c0f372167557d..993f5db237682 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -556,4 +556,154 @@ TEST(test_wait_all)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0087-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0087-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From 126aed1e85784e8388398843dacf0b50098ccfa7 Mon Sep 17 00:00:00 2001
+From 4f9529cefc0afb35c0cbc772c3e7ae6b2b109ed0 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:45 -0500
 Subject: [PATCH 087/103] selftests: ntsync: Add some tests for wakeup
@@ -15,7 +15,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 98 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 993f5db23768..b77fb0b2c4b1 100644
+index 993f5db237682..b77fb0b2c4b1f 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -706,4 +706,102 @@ TEST(wake_any)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0088-selftests-ntsync-Add-some-tests-for-manual-reset-eve.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0088-selftests-ntsync-Add-some-tests-for-manual-reset-eve.patch
@@ -1,4 +1,4 @@
-From 2f1793fb4c14ca9a57f38581f7d84c58c8eccc80 Mon Sep 17 00:00:00 2001
+From e05bf2d05bdc650890e5bb14a3313999463705f3 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:46 -0500
 Subject: [PATCH 088/103] selftests: ntsync: Add some tests for manual-reset
@@ -15,7 +15,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 89 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index b77fb0b2c4b1..b6481c2b85cc 100644
+index b77fb0b2c4b1f..b6481c2b85cc9 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -73,6 +73,27 @@ static int unlock_mutex(int mutex, __u32 owner, __u32 *count)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0089-selftests-ntsync-Add-some-tests-for-auto-reset-event.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0089-selftests-ntsync-Add-some-tests-for-auto-reset-event.patch
@@ -1,4 +1,4 @@
-From 80253aff81ff4d945e5c7b322d37661580ad6783 Mon Sep 17 00:00:00 2001
+From 2f9f6ee86a2d88efbc5118a87f47572773806a3e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:47 -0500
 Subject: [PATCH 089/103] selftests: ntsync: Add some tests for auto-reset
@@ -15,7 +15,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 59 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index b6481c2b85cc..12ccb4ec28e4 100644
+index b6481c2b85cc9..12ccb4ec28e43 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -442,6 +442,65 @@ TEST(manual_event_state)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0090-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0090-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From 3fcf63356c097832ce347f18e2ae17a7b892e98f Mon Sep 17 00:00:00 2001
+From bd5e52c3e136a0b446621399cb6d22416f805cb7 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:48 -0500
 Subject: [PATCH 090/103] selftests: ntsync: Add some tests for wakeup
@@ -14,7 +14,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 147 insertions(+), 4 deletions(-)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 12ccb4ec28e4..5d17eff6a370 100644
+index 12ccb4ec28e43..5d17eff6a3700 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -622,6 +622,7 @@ TEST(test_wait_any)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0091-selftests-ntsync-Add-tests-for-alertable-waits.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0091-selftests-ntsync-Add-tests-for-alertable-waits.patch
@@ -1,4 +1,4 @@
-From 9b54b90bd1b659510ed0b0f86d501c458f9e1a76 Mon Sep 17 00:00:00 2001
+From c79b7d74cc0b29151631aed2da27cb827f51029e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:49 -0500
 Subject: [PATCH 091/103] selftests: ntsync: Add tests for alertable waits.
@@ -13,7 +13,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 176 insertions(+), 3 deletions(-)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 5d17eff6a370..5465a16d38b3 100644
+index 5d17eff6a3700..5465a16d38b3f 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -95,7 +95,7 @@ static int read_event_state(int event, __u32 *signaled, __u32 *manual)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0092-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0092-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From b2416b3a73306b473e918280ef089306c6367102 Mon Sep 17 00:00:00 2001
+From 88136ca85da06922dc7d6c2160e2de739852aa33 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:50 -0500
 Subject: [PATCH 092/103] selftests: ntsync: Add some tests for wakeup
@@ -14,7 +14,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 62 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 5465a16d38b3..968874d7e325 100644
+index 5465a16d38b3f..968874d7e325a 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -1113,9 +1113,12 @@ TEST(wake_all)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0093-selftests-ntsync-Add-a-stress-test-for-contended-wai.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0093-selftests-ntsync-Add-a-stress-test-for-contended-wai.patch
@@ -1,4 +1,4 @@
-From afc2240467182404f8932c13ed3278edb19b4322 Mon Sep 17 00:00:00 2001
+From 52504fca54c6f17185eece0ec667f49023d50ee9 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:51 -0500
 Subject: [PATCH 093/103] selftests: ntsync: Add a stress test for contended
@@ -18,7 +18,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 74 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 968874d7e325..5fa2c9a0768c 100644
+index 968874d7e325a..5fa2c9a0768c0 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -1330,4 +1330,78 @@ TEST(alert_all)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0094-maintainers-Add-an-entry-for-ntsync.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0094-maintainers-Add-an-entry-for-ntsync.patch
@@ -1,4 +1,4 @@
-From 07fb7c67a93966e3cfd7bd113e589651261fc571 Mon Sep 17 00:00:00 2001
+From 8df7a010ebb5eacc422fc6829a95c3732587e7de Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:52 -0500
 Subject: [PATCH 094/103] maintainers: Add an entry for ntsync.
@@ -12,7 +12,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 9 insertions(+)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index c1598b0c92e5..a0dfe62f3a1c 100644
+index c1598b0c92e5f..a0dfe62f3a1c0 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -15990,6 +15990,15 @@ T:	git https://github.com/Paragon-Software-Group/linux-ntfs3.git

--- a/runtime-kernel/linux-kernel/autobuild/patches/0095-docs-ntsync-Add-documentation-for-the-ntsync-uAPI.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0095-docs-ntsync-Add-documentation-for-the-ntsync-uAPI.patch
@@ -1,4 +1,4 @@
-From e7a7be25f0968383a4a28947091615ce2b1860da Mon Sep 17 00:00:00 2001
+From 2057d7b5f5ab45fa0e66a4684bd453f6d37065a5 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:53 -0500
 Subject: [PATCH 095/103] docs: ntsync: Add documentation for the ntsync uAPI.
@@ -15,7 +15,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  create mode 100644 Documentation/userspace-api/ntsync.rst
 
 diff --git a/Documentation/userspace-api/index.rst b/Documentation/userspace-api/index.rst
-index 8a251d71fa6e..02bea81fb4bf 100644
+index 8a251d71fa6e1..02bea81fb4bf7 100644
 --- a/Documentation/userspace-api/index.rst
 +++ b/Documentation/userspace-api/index.rst
 @@ -64,6 +64,7 @@ Everything else
@@ -28,7 +28,7 @@ index 8a251d71fa6e..02bea81fb4bf 100644
  
 diff --git a/Documentation/userspace-api/ntsync.rst b/Documentation/userspace-api/ntsync.rst
 new file mode 100644
-index 000000000000..767844637a7d
+index 0000000000000..767844637a7df
 --- /dev/null
 +++ b/Documentation/userspace-api/ntsync.rst
 @@ -0,0 +1,398 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0096-ntsync-No-longer-depend-on-BROKEN.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0096-ntsync-No-longer-depend-on-BROKEN.patch
@@ -1,4 +1,4 @@
-From 78eb13e82478306e0b8af62a6c17eb189ab01f31 Mon Sep 17 00:00:00 2001
+From 1d6116069d4e6668825310bd0bbc53e2c2a58728 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:54 -0500
 Subject: [PATCH 096/103] ntsync: No longer depend on BROKEN.
@@ -15,7 +15,7 @@ Ref: https://lore.kernel.org/all/20240519202454.1192826-1-zfigura@codeweavers.co
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/misc/Kconfig b/drivers/misc/Kconfig
-index faf983680040..2907b5c23368 100644
+index faf9836800403..2907b5c23368d 100644
 --- a/drivers/misc/Kconfig
 +++ b/drivers/misc/Kconfig
 @@ -507,7 +507,6 @@ config OPEN_DICE

--- a/runtime-kernel/linux-kernel/autobuild/patches/0097-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0097-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
@@ -1,10 +1,10 @@
-From 2b8390c0edd9f88cc03d964457f046ab5cda97f4 Mon Sep 17 00:00:00 2001
+From 37dd8dd1eec525a13438c6458e5815ba5565d067 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Wed, 21 Feb 2024 16:58:32 -0500
 Subject: [PATCH 097/103] arch/loongarch: add la_ow_syscall as in-tree module
 
 Co-authored-By: Miao Wang <shankerwangmiao@gmail.com>
-Ref: Contact the author.
+Ref: https://github.com/AOSC-Dev/la_ow_syscall
 ---
  arch/loongarch/Kbuild                         |   2 +
  arch/loongarch/ow_syscall/Kbuild              |  26 ++
@@ -32,7 +32,7 @@ Ref: Contact the author.
  create mode 100644 arch/loongarch/ow_syscall/signal.h
 
 diff --git a/arch/loongarch/Kbuild b/arch/loongarch/Kbuild
-index bfa21465d83a..52ddcb17537c 100644
+index bfa21465d83af..52ddcb17537ce 100644
 --- a/arch/loongarch/Kbuild
 +++ b/arch/loongarch/Kbuild
 @@ -8,3 +8,5 @@ obj-$(CONFIG_BUILTIN_DTB) += boot/dts/
@@ -43,7 +43,7 @@ index bfa21465d83a..52ddcb17537c 100644
 +obj-y += ow_syscall/
 diff --git a/arch/loongarch/ow_syscall/Kbuild b/arch/loongarch/ow_syscall/Kbuild
 new file mode 100644
-index 000000000000..f3921c3fd96d
+index 0000000000000..f3921c3fd96db
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kbuild
 @@ -0,0 +1,26 @@
@@ -75,7 +75,7 @@ index 000000000000..f3921c3fd96d
 +endif
 diff --git a/arch/loongarch/ow_syscall/LICENSE b/arch/loongarch/ow_syscall/LICENSE
 new file mode 100644
-index 000000000000..d159169d1050
+index 0000000000000..d159169d10508
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/LICENSE
 @@ -0,0 +1,339 @@
@@ -420,7 +420,7 @@ index 000000000000..d159169d1050
 +Public License instead of this License.
 diff --git a/arch/loongarch/ow_syscall/Makefile b/arch/loongarch/ow_syscall/Makefile
 new file mode 100644
-index 000000000000..e975aa1cdb7a
+index 0000000000000..e975aa1cdb7af
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Makefile
 @@ -0,0 +1,37 @@
@@ -463,7 +463,7 @@ index 000000000000..e975aa1cdb7a
 +dev: modprobe-remove dkms-remove dkms-add dkms-build dkms-install modprobe-install
 diff --git a/arch/loongarch/ow_syscall/README.md b/arch/loongarch/ow_syscall/README.md
 new file mode 100644
-index 000000000000..24ec0eae161f
+index 0000000000000..24ec0eae161f1
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/README.md
 @@ -0,0 +1,74 @@
@@ -543,7 +543,7 @@ index 000000000000..24ec0eae161f
 +```
 diff --git a/arch/loongarch/ow_syscall/VERSION b/arch/loongarch/ow_syscall/VERSION
 new file mode 100644
-index 000000000000..6c6aa7cb0918
+index 0000000000000..6c6aa7cb0918d
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/VERSION
 @@ -0,0 +1 @@
@@ -551,7 +551,7 @@ index 000000000000..6c6aa7cb0918
 \ No newline at end of file
 diff --git a/arch/loongarch/ow_syscall/dkms.conf.in b/arch/loongarch/ow_syscall/dkms.conf.in
 new file mode 100644
-index 000000000000..b2a3493106c2
+index 0000000000000..b2a3493106c24
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/dkms.conf.in
 @@ -0,0 +1,7 @@
@@ -564,7 +564,7 @@ index 000000000000..b2a3493106c2
 +DEST_MODULE_LOCATION[0]="/extra"
 diff --git a/arch/loongarch/ow_syscall/fsstat.c b/arch/loongarch/ow_syscall/fsstat.c
 new file mode 100644
-index 000000000000..e540d6ff2548
+index 0000000000000..e540d6ff2548c
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.c
 @@ -0,0 +1,84 @@
@@ -654,7 +654,7 @@ index 000000000000..e540d6ff2548
 +}
 diff --git a/arch/loongarch/ow_syscall/fsstat.h b/arch/loongarch/ow_syscall/fsstat.h
 new file mode 100644
-index 000000000000..7c970ad8fd00
+index 0000000000000..7c970ad8fd009
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.h
 @@ -0,0 +1,3 @@
@@ -663,7 +663,7 @@ index 000000000000..7c970ad8fd00
 +extern int (*p_vfs_fstat)(int fd, struct kstat *stat);
 diff --git a/arch/loongarch/ow_syscall/la_ow_syscall_main.c b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 new file mode 100644
-index 000000000000..3308ef082539
+index 0000000000000..3308ef082539e
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 @@ -0,0 +1,326 @@
@@ -995,7 +995,7 @@ index 000000000000..3308ef082539
 +#endif
 diff --git a/arch/loongarch/ow_syscall/signal.c b/arch/loongarch/ow_syscall/signal.c
 new file mode 100644
-index 000000000000..1593fdba30c2
+index 0000000000000..1593fdba30c26
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.c
 @@ -0,0 +1,222 @@
@@ -1223,7 +1223,7 @@ index 000000000000..1593fdba30c2
 +#endif
 diff --git a/arch/loongarch/ow_syscall/signal.h b/arch/loongarch/ow_syscall/signal.h
 new file mode 100644
-index 000000000000..a640b39e982d
+index 0000000000000..a640b39e982d3
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.h
 @@ -0,0 +1,41 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0098-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0098-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,9 +1,9 @@
-From e0fdcdb753224ac6447c748f202d8601ec8fdcae Mon Sep 17 00:00:00 2001
+From eba89deb4c9688fd5bc60bbece2d3e93d16f7828 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
 Subject: [PATCH 098/103] la_ow_syscall: add kconfig for module
 
-Ref: Contact the author.
+Ref: https://github.com/AOSC-Dev/la_ow_syscall
 ---
  arch/loongarch/Kconfig            |  2 ++
  arch/loongarch/ow_syscall/Kconfig | 15 +++++++++++++++
@@ -11,7 +11,7 @@ Ref: Contact the author.
  create mode 100644 arch/loongarch/ow_syscall/Kconfig
 
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index b2a171a45544..23400dc312f9 100644
+index b2a171a455444..23400dc312f9d 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -715,3 +715,5 @@ source "drivers/cpufreq/Kconfig"
@@ -22,7 +22,7 @@ index b2a171a45544..23400dc312f9 100644
 +source "arch/loongarch/ow_syscall/Kconfig"
 diff --git a/arch/loongarch/ow_syscall/Kconfig b/arch/loongarch/ow_syscall/Kconfig
 new file mode 100644
-index 000000000000..c28a37145b6f
+index 0000000000000..c28a37145b6f6
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kconfig
 @@ -0,0 +1,15 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0099-platform-x86-ideapad-laptop-add-fixes-for-ThinkBook-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0099-platform-x86-ideapad-laptop-add-fixes-for-ThinkBook-.patch
@@ -1,4 +1,4 @@
-From 79bd70645491cb17c2d1f919fee8bcd181d8e163 Mon Sep 17 00:00:00 2001
+From 1d9d9f165130c5688d1be64ac967e62ad6a7f7af Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 17 Aug 2024 11:32:11 +0800
 Subject: [PATCH 099/103] platform: x86: ideapad-laptop: add fixes for
@@ -20,10 +20,10 @@ Ref: https://github.com/ty2/ideapad-laptop-tb2024g6plus
  1 file changed, 26 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/platform/x86/ideapad-laptop.c b/drivers/platform/x86/ideapad-laptop.c
-index fcf13d88fd6e..f7d28fe886ef 100644
+index 490815917adec..ac2f030245774 100644
 --- a/drivers/platform/x86/ideapad-laptop.c
 +++ b/drivers/platform/x86/ideapad-laptop.c
-@@ -157,6 +157,7 @@ struct ideapad_private {
+@@ -159,6 +159,7 @@ struct ideapad_private {
  		struct led_classdev led;
  		unsigned int last_brightness;
  	} fn_lock;
@@ -31,7 +31,7 @@ index fcf13d88fd6e..f7d28fe886ef 100644
  };
  
  static bool no_bt_rfkill;
-@@ -1140,6 +1141,8 @@ static const struct key_entry ideapad_keymap[] = {
+@@ -1160,6 +1161,8 @@ static const struct key_entry ideapad_keymap[] = {
  	{ KE_KEY,	0x27 | IDEAPAD_WMI_KEY, { KEY_HELP } },
  	/* Refresh Rate Toggle */
  	{ KE_KEY,	0x0a | IDEAPAD_WMI_KEY, { KEY_REFRESH_RATE_TOGGLE } },
@@ -40,24 +40,24 @@ index fcf13d88fd6e..f7d28fe886ef 100644
  
  	{ KE_END },
  };
-@@ -1604,6 +1607,16 @@ static void ideapad_acpi_notify(acpi_handle handle, u32 event, void *data)
- 	struct ideapad_private *priv = data;
+@@ -1709,6 +1712,16 @@ static void ideapad_acpi_notify(acpi_handle handle, u32 event, void *data)
  	unsigned long vpc1, vpc2, bit;
  
-+	acpi_handle_info(handle, "event: %lu\n",
-+					(unsigned long)event);
+ 	scoped_guard(mutex, &priv->vpc_mutex) {
++		acpi_handle_info(handle, "event: %lu\n",
++						(unsigned long)event);
 +
-+	if(!data)
-+		acpi_handle_info(handle, "no data");
-+		return;
++		if(!data)
++			acpi_handle_info(handle, "no data");
++			return;
 +
-+	if (priv->suspended)
-+		return;
++		if (priv->suspended)
++			return;
 +
- 	if (read_ec_data(handle, VPCCMD_R_VPC1, &vpc1))
- 		return;
+ 		if (read_ec_data(handle, VPCCMD_R_VPC1, &vpc1))
+ 			return;
  
-@@ -1649,6 +1662,7 @@ static void ideapad_acpi_notify(acpi_handle handle, u32 event, void *data)
+@@ -1755,6 +1768,7 @@ static void ideapad_acpi_notify(acpi_handle handle, u32 event, void *data)
  			ideapad_backlight_notify_power(priv);
  			break;
  		case KBD_BL_KBLC_CHANGED_EVENT:
@@ -65,7 +65,7 @@ index fcf13d88fd6e..f7d28fe886ef 100644
  		case 1:
  			/*
  			 * Some IdeaPads report event 1 every ~20
-@@ -1658,8 +1672,6 @@ static void ideapad_acpi_notify(acpi_handle handle, u32 event, void *data)
+@@ -1764,8 +1778,6 @@ static void ideapad_acpi_notify(acpi_handle handle, u32 event, void *data)
  			 * backlight has changed.
  			 */
  			ideapad_kbd_bl_notify(priv);
@@ -74,7 +74,7 @@ index fcf13d88fd6e..f7d28fe886ef 100644
  			ideapad_check_special_buttons(priv);
  			break;
  		default:
-@@ -1863,6 +1875,8 @@ static const struct wmi_device_id ideapad_wmi_ids[] = {
+@@ -1971,6 +1983,8 @@ static const struct wmi_device_id ideapad_wmi_ids[] = {
  	{ "26CAB2E5-5CF1-46AE-AAC3-4A12B6BA50E6", &ideapad_wmi_context_esc }, /* Yoga 3 */
  	{ "56322276-8493-4CE8-A783-98C991274F5E", &ideapad_wmi_context_esc }, /* Yoga 700 */
  	{ "8FC0DE0C-B4E4-43FD-B0F3-8871711C1294", &ideapad_wmi_context_fn_keys }, /* Legion 5 */
@@ -83,7 +83,7 @@ index fcf13d88fd6e..f7d28fe886ef 100644
  	{},
  };
  MODULE_DEVICE_TABLE(wmi, ideapad_wmi_ids);
-@@ -2045,10 +2059,19 @@ static int ideapad_acpi_resume(struct device *dev)
+@@ -2161,10 +2175,19 @@ static int ideapad_acpi_resume(struct device *dev)
  	if (priv->dytc)
  		dytc_profile_refresh(priv);
  

--- a/runtime-kernel/linux-kernel/autobuild/patches/0100-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0100-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
@@ -1,4 +1,4 @@
-From 1442d22b206cc463937a7bac455b65ace38c96a6 Mon Sep 17 00:00:00 2001
+From c8ec0e10304166479ff5ecd8761f3c69a57762bd Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:43:11 +0800
 Subject: [PATCH 100/103] [LOONGARCH64] drivers/firmware: Move sysfb_init()
@@ -35,13 +35,13 @@ sysfb_disable() is sometimes missed. So here we move sysfb_init() to an
 fs_initcall function which is ensured after vgaarb initialization.
 
 Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
-Ref: https://github.com/chenhuacai/linux/commit/2d5e3c77512c64f31ecb647f3073100e1f3d0f4a
+Ref: https://github.com/chenhuacai/linux/commit/ceedf1b7a4523c18bf1fb96fd658e15898661adf
 ---
  drivers/firmware/sysfb.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/firmware/sysfb.c b/drivers/firmware/sysfb.c
-index 921f61507ae8..7a9c4c40c88b 100644
+index 921f61507ae83..7a9c4c40c88be 100644
 --- a/drivers/firmware/sysfb.c
 +++ b/drivers/firmware/sysfb.c
 @@ -183,4 +183,4 @@ static __init int sysfb_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0101-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0101-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
@@ -1,4 +1,4 @@
-From 1617065f39999d3fea576a95b255282db3fa1219 Mon Sep 17 00:00:00 2001
+From c4398ade8a6923d5baa80d4df0b051c4fb0dd0ed Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Mon, 11 Mar 2024 00:14:58 +0800
 Subject: [PATCH 101/103] [LOONGARCH64] drm/xe: fix build on non-4K kernels
@@ -23,7 +23,7 @@ Ref: Contact the author.
  13 files changed, 38 insertions(+), 34 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/regs/xe_engine_regs.h b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
-index 03c6d4d50a83..f65f86e27147 100644
+index 03c6d4d50a839..f65f86e271473 100644
 --- a/drivers/gpu/drm/xe/regs/xe_engine_regs.h
 +++ b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
 @@ -52,8 +52,7 @@
@@ -37,7 +37,7 @@ index 03c6d4d50a83..f65f86e27147 100644
  #define RING_PSMI_CTL(base)			XE_REG((base) + 0x50, XE_REG_OPTION_MASKED)
  #define   RC_SEMA_IDLE_MSG_DISABLE		REG_BIT(12)
 diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
-index b6f3a43d637f..642e2efacf9d 100644
+index b6f3a43d637f7..642e2efacf9d5 100644
 --- a/drivers/gpu/drm/xe/xe_bo.c
 +++ b/drivers/gpu/drm/xe/xe_bo.c
 @@ -1214,7 +1214,7 @@ struct xe_bo *___xe_bo_create_locked(struct xe_device *xe, struct xe_bo *bo,
@@ -87,7 +87,7 @@ index b6f3a43d637f..642e2efacf9d 100644
  	if (resv) {
  		ctx.allow_res_evict = !(flags & XE_BO_FLAG_NO_RESV_EVICT);
 diff --git a/drivers/gpu/drm/xe/xe_ggtt.c b/drivers/gpu/drm/xe/xe_ggtt.c
-index 0d541f55b4fc..a45e8ae6e617 100644
+index 0d541f55b4fcf..a45e8ae6e617f 100644
 --- a/drivers/gpu/drm/xe/xe_ggtt.c
 +++ b/drivers/gpu/drm/xe/xe_ggtt.c
 @@ -30,7 +30,7 @@ static u64 xelp_ggtt_pte_encode_bo(struct xe_bo *bo, u64 bo_offset,
@@ -100,7 +100,7 @@ index 0d541f55b4fc..a45e8ae6e617 100644
  
  	if (xe_bo_is_vram(bo) || xe_bo_is_stolen_devmem(bo))
 diff --git a/drivers/gpu/drm/xe/xe_guc.c b/drivers/gpu/drm/xe/xe_guc.c
-index 5faca4fc2fef..186a4fa5e0c8 100644
+index 5faca4fc2fef5..186a4fa5e0c80 100644
 --- a/drivers/gpu/drm/xe/xe_guc.c
 +++ b/drivers/gpu/drm/xe/xe_guc.c
 @@ -75,7 +75,7 @@ static u32 guc_ctl_feature_flags(struct xe_guc *guc)
@@ -122,7 +122,7 @@ index 5faca4fc2fef..186a4fa5e0c8 100644
  
  	return flags;
 diff --git a/drivers/gpu/drm/xe/xe_guc_ads.c b/drivers/gpu/drm/xe/xe_guc_ads.c
-index 7f5a523795c8..e2f4469a40c8 100644
+index 7f5a523795c86..e2f4469a40c8f 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ads.c
 +++ b/drivers/gpu/drm/xe/xe_guc_ads.c
 @@ -135,7 +135,7 @@ static size_t guc_ads_regset_size(struct xe_guc_ads *ads)
@@ -207,7 +207,7 @@ index 7f5a523795c8..e2f4469a40c8 100644
  
  		/*
 diff --git a/drivers/gpu/drm/xe/xe_guc_ct.c b/drivers/gpu/drm/xe/xe_guc_ct.c
-index 0151d29b3c58..e500321d5210 100644
+index 0151d29b3c580..e500321d52105 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ct.c
 +++ b/drivers/gpu/drm/xe/xe_guc_ct.c
 @@ -145,7 +145,7 @@ int xe_guc_ct_init(struct xe_guc_ct *ct)
@@ -220,7 +220,7 @@ index 0151d29b3c58..e500321d5210 100644
  	ct->g2h_wq = alloc_ordered_workqueue("xe-g2h-wq", 0);
  	if (!ct->g2h_wq)
 diff --git a/drivers/gpu/drm/xe/xe_guc_log.c b/drivers/gpu/drm/xe/xe_guc_log.c
-index a37ee3419428..d2bb7427404f 100644
+index a37ee34194284..d2bb7427404fd 100644
 --- a/drivers/gpu/drm/xe/xe_guc_log.c
 +++ b/drivers/gpu/drm/xe/xe_guc_log.c
 @@ -45,7 +45,7 @@ static size_t guc_log_size(void)
@@ -233,7 +233,7 @@ index a37ee3419428..d2bb7427404f 100644
  }
  
 diff --git a/drivers/gpu/drm/xe/xe_guc_pc.c b/drivers/gpu/drm/xe/xe_guc_pc.c
-index 23382ced4ea7..5508c931c28c 100644
+index 23382ced4ea74..5508c931c28c2 100644
 --- a/drivers/gpu/drm/xe/xe_guc_pc.c
 +++ b/drivers/gpu/drm/xe/xe_guc_pc.c
 @@ -817,7 +817,7 @@ int xe_guc_pc_start(struct xe_guc_pc *pc)
@@ -255,7 +255,7 @@ index 23382ced4ea7..5508c931c28c 100644
  
  	if (xe->info.skip_guc_pc)
 diff --git a/drivers/gpu/drm/xe/xe_migrate.c b/drivers/gpu/drm/xe/xe_migrate.c
-index 198f5c2189cb..d5d160ff1b9e 100644
+index 198f5c2189cb4..d5d160ff1b9e6 100644
 --- a/drivers/gpu/drm/xe/xe_migrate.c
 +++ b/drivers/gpu/drm/xe/xe_migrate.c
 @@ -516,7 +516,7 @@ static void emit_pte(struct xe_migrate *m,
@@ -286,7 +286,7 @@ index 198f5c2189cb..d5d160ff1b9e 100644
  
  	while (size) {
 diff --git a/drivers/gpu/drm/xe/xe_pt.c b/drivers/gpu/drm/xe/xe_pt.c
-index 5b7930f46cf3..cbccc0940bc0 100644
+index 5b7930f46cf36..cbccc0940bc0f 100644
 --- a/drivers/gpu/drm/xe/xe_pt.c
 +++ b/drivers/gpu/drm/xe/xe_pt.c
 @@ -1229,7 +1229,7 @@ __xe_pt_bind_vma(struct xe_tile *tile, struct xe_vma *vma, struct xe_exec_queue
@@ -299,7 +299,7 @@ index 5b7930f46cf3..cbccc0940bc0 100644
  	       xe_vma_start(vma), xe_vma_end(vma), q);
  
 diff --git a/drivers/gpu/drm/xe/xe_query.c b/drivers/gpu/drm/xe/xe_query.c
-index df407d73e5f5..9520f0654a47 100644
+index df407d73e5f5f..9520f0654a476 100644
 --- a/drivers/gpu/drm/xe/xe_query.c
 +++ b/drivers/gpu/drm/xe/xe_query.c
 @@ -337,7 +337,7 @@ static int query_config(struct xe_device *xe, struct drm_xe_device_query *query)
@@ -312,7 +312,7 @@ index df407d73e5f5..9520f0654a47 100644
  	config->info[DRM_XE_QUERY_CONFIG_MAX_EXEC_QUEUE_PRIORITY] =
  		xe_exec_queue_device_get_max_priority(xe);
 diff --git a/drivers/gpu/drm/xe/xe_res_cursor.h b/drivers/gpu/drm/xe/xe_res_cursor.h
-index 0a306963aa8e..253daaecf3de 100644
+index 0a306963aa8e5..253daaecf3dee 100644
 --- a/drivers/gpu/drm/xe/xe_res_cursor.h
 +++ b/drivers/gpu/drm/xe/xe_res_cursor.h
 @@ -157,8 +157,8 @@ static inline void xe_res_first_sg(const struct sg_table *sg,
@@ -327,7 +327,7 @@ index 0a306963aa8e..253daaecf3de 100644
  	cur->start = start;
  	cur->remaining = size;
 diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
-index 4aa3943e6f29..63cbbf750875 100644
+index 4aa3943e6f292..63cbbf750875d 100644
 --- a/drivers/gpu/drm/xe/xe_vm.c
 +++ b/drivers/gpu/drm/xe/xe_vm.c
 @@ -18,6 +18,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0102-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0102-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
@@ -1,4 +1,4 @@
-From 479468bdb3bfa44b24aff23f0f9b6ae7afd9597f Mon Sep 17 00:00:00 2001
+From bc17922d7c8a10d815dff984a021591a495aeb36 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
 Subject: [PATCH 102/103] [LOONGARCH64] drm/radeon: Workaround radeon driver
@@ -10,7 +10,7 @@ enable interrupt again when interrupt is faster than DMA data.
 
 Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
 Signed-off-by: Zhijie Zhang <zhangzhijie@loongson.cn>
-Ref: https://github.com/chenhuacai/linux/commit/acb78a94724f4a56522cdd1d9f2aee4a6cd167fc
+Ref: https://github.com/chenhuacai/linux/commit/dcbc616760ca5453f9406b3503e53d48f3b70d6b
 ---
  drivers/gpu/drm/radeon/cik.c       | 1 +
  drivers/gpu/drm/radeon/evergreen.c | 1 +
@@ -19,7 +19,7 @@ Ref: https://github.com/chenhuacai/linux/commit/acb78a94724f4a56522cdd1d9f2aee4a
  4 files changed, 4 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index e9034b40e0d0..84942c8ca84d 100644
+index e9034b40e0d02..84942c8ca84db 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -8101,6 +8101,7 @@ int cik_irq_process(struct radeon_device *rdev)
@@ -31,7 +31,7 @@ index e9034b40e0d0..84942c8ca84d 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index c634dc28e6c3..fd9ff62f292a 100644
+index c634dc28e6c30..fd9ff62f292ac 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -4919,6 +4919,7 @@ int evergreen_irq_process(struct radeon_device *rdev)
@@ -43,7 +43,7 @@ index c634dc28e6c3..fd9ff62f292a 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/r600.c b/drivers/gpu/drm/radeon/r600.c
-index 087d41e370fd..00621ae44bde 100644
+index 087d41e370fdc..00621ae44bded 100644
 --- a/drivers/gpu/drm/radeon/r600.c
 +++ b/drivers/gpu/drm/radeon/r600.c
 @@ -4328,6 +4328,7 @@ int r600_irq_process(struct radeon_device *rdev)
@@ -55,7 +55,7 @@ index 087d41e370fd..00621ae44bde 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/si.c b/drivers/gpu/drm/radeon/si.c
-index 15759c8ca5b7..3bc479da07cd 100644
+index 15759c8ca5b7b..3bc479da07cdf 100644
 --- a/drivers/gpu/drm/radeon/si.c
 +++ b/drivers/gpu/drm/radeon/si.c
 @@ -6423,6 +6423,7 @@ int si_irq_process(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0103-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0103-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
@@ -1,4 +1,4 @@
-From 423215e4227f509755c06236a067ddd48e20a227 Mon Sep 17 00:00:00 2001
+From 432739d360ce6dee5d855d8835e6b861fb93bb98 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 14:28:02 +0800
 Subject: [PATCH 103/103] [LOONGARCH64] drm/radeon: Call mmiowb() at the end of
@@ -49,7 +49,7 @@ Ref: https://lore.kernel.org/all/20240220074958.3288170-1-chenhuacai@loongson.cn
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_ring.c b/drivers/gpu/drm/radeon/radeon_ring.c
-index 8d1d458286a8..d6a58952cc9d 100644
+index 8d1d458286a84..d6a58952cc9da 100644
 --- a/drivers/gpu/drm/radeon/radeon_ring.c
 +++ b/drivers/gpu/drm/radeon/radeon_ring.c
 @@ -185,6 +185,7 @@ void radeon_ring_commit(struct radeon_device *rdev, struct radeon_ring *ring,

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -1,5 +1,4 @@
-VER=6.10.5
-REL=1
+VER=6.10.6
 
 # Use this for stable releases.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
@@ -10,5 +9,5 @@ SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 #REL=0.${RC}
 #SRCS="tbl::https://git.kernel.org/torvalds/t/linux-${VER%%.0}-rc${RC}.tar.gz"
 
-CHKSUMS="sha256::30909eb2e0434dce97a93cd97ed0dfab7688a124bc3ebc3ecf6c776de09ccc0b"
+CHKSUMS="sha256::e0d50d5b74f8599375660e79f187af7493864dba5ff6671b14983376a070b3d1"
 CHKUPDATE="anitya::id=6501"


### PR DESCRIPTION
Topic Description
-----------------

- kernel-tools: update to 6.10.6
- linux+kernel: update to 6.10.6
- linux-kernel: update to 6.10.6
    - Track patches at https://github.com/AOSC-Tracking/linux @ aosc/v6.10.6, current HEAD is 432739d360ce6dee5d855d8835e6b861fb93bb98.

Package(s) Affected
-------------------

- kernel-tools: 6.10.6
- linux+kernel: 3:6.10.6
- linux-kernel-6.10.6: 1:6.10.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel linux+kernel kernel-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
