### PR TITLE
clash-verge-rev: update to 1.7.7

### DIFF
--- a/app-network/clash-verge-rev/autobuild/patches/0001-fix-package.json-allow-building-on-platforms-without.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0001-fix-package.json-allow-building-on-platforms-without.patch
@@ -1,4 +1,4 @@
-From d98060ac7d756a805ad66c31cdef5ed5bd2d04af Mon Sep 17 00:00:00 2001
+From b7cef521347d96264973a317830572cf724c9ae5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 15:42:32 +0800
 Subject: [PATCH 01/13] fix(package.json): allow building on platforms without
@@ -10,10 +10,10 @@ Ref: https://github.com/clash-verge-rev/clash-verge-rev/issues/453#issuecomment-
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/package.json b/package.json
-index f6465c3..67038fe 100644
+index 6f8ba93..6397091 100644
 --- a/package.json
 +++ b/package.json
-@@ -89,5 +89,10 @@
+@@ -91,5 +91,10 @@
      "singleQuote": false,
      "endOfLine": "lf"
    },
@@ -26,5 +26,5 @@ index f6465c3..67038fe 100644
 +  }
  }
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0002-feat-src-assets-add-XDG-.desktop-entry.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0002-feat-src-assets-add-XDG-.desktop-entry.patch
@@ -1,4 +1,4 @@
-From 0ecf33e8a22f8e5450039cee5ebdc8b7bde0276c Mon Sep 17 00:00:00 2001
+From ed42cf7662309687ea8797677f3b8baf762df753 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 16:28:51 +0800
 Subject: [PATCH 02/13] feat(src/assets): add XDG .desktop entry
@@ -29,5 +29,5 @@ index 0000000..1dc4106
 +Comment=A graphical rule-based proxy manager
 +Comment[zh_CN]=图形化代理服务规则管理器
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0003-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0003-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,4 +1,4 @@
-From 63aed8b0f101d794c248488dec068b777128837f Mon Sep 17 00:00:00 2001
+From 4b6d449c3b26e92e7fb177959a77833826f4a702 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 16:32:18 +0800
 Subject: [PATCH 03/13] fix(tauri.conf.json): disable bundle distribution
@@ -9,7 +9,7 @@ We only need the binary in /src-tauri/target.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index c33c989..25eb530 100644
+index 7f6a2a3..ebd7d9c 100644
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -12,7 +12,7 @@
@@ -22,5 +22,5 @@ index c33c989..25eb530 100644
        "icon": [
          "icons/32x32.png",
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0004-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0004-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
@@ -1,4 +1,4 @@
-From 6dad9d4716f287b88a0d1922882828e696bf8157 Mon Sep 17 00:00:00 2001
+From dfab64f3291f8b091e4e61d3627df5d62148dd3e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 17:26:12 +0800
 Subject: [PATCH 04/13] fix(scripts): use ABI2 (New-World) Mihomo binary for
@@ -11,7 +11,7 @@ and abi2 (new-world) binaries.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/scripts/check.mjs b/scripts/check.mjs
-index 335bd6c..7be53aa 100644
+index 19e2ac6..ccf6e89 100644
 --- a/scripts/check.mjs
 +++ b/scripts/check.mjs
 @@ -68,7 +68,7 @@ const META_ALPHA_MAP = {
@@ -24,5 +24,5 @@ index 335bd6c..7be53aa 100644
  
  // Fetch the latest alpha release version from the version.txt file
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0005-feat-drop-clash-meta-alpha-support.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0005-feat-drop-clash-meta-alpha-support.patch
@@ -1,4 +1,4 @@
-From 2b7852af53aed6d8f1165f85699a15c2a0bcab13 Mon Sep 17 00:00:00 2001
+From f5d79e6930a9e8de2303b2b5e52cd86bc0d5fad6 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
 Subject: [PATCH 05/13] feat: drop clash-meta-alpha support
@@ -8,10 +8,10 @@ Subject: [PATCH 05/13] feat: drop clash-meta-alpha support
  1 file changed, 1 deletion(-)
 
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
-index ee52c7e..cb037d7 100644
+index fc94352..714ba6d 100644
 --- a/src/components/setting/mods/clash-core-viewer.tsx
 +++ b/src/components/setting/mods/clash-core-viewer.tsx
-@@ -19,7 +19,6 @@ import { closeAllConnections, upgradeCore } from "@/services/api";
+@@ -22,7 +22,6 @@ import { closeAllConnections, upgradeCore } from "@/services/api";
  
  const VALID_CORE = [
    { name: "Mihomo", core: "verge-mihomo", chip: "Release Version" },
@@ -20,5 +20,5 @@ index ee52c7e..cb037d7 100644
  
  export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0006-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0006-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
@@ -1,4 +1,4 @@
-From 56418c497c6b1616f54117cdd3208e62a2a7d1cd Mon Sep 17 00:00:00 2001
+From 92b9ec078d4bf23acfa62505dab07b597d09b099 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 11:45:21 +0800
 Subject: [PATCH 06/13] fix(check.mjs): do not fetch Mihomo (Clash Meta)
@@ -10,10 +10,10 @@ We use a system copy for this purpose.
  1 file changed, 13 deletions(-)
 
 diff --git a/scripts/check.mjs b/scripts/check.mjs
-index 7be53aa..87b10c8 100644
+index ccf6e89..3065995 100644
 --- a/scripts/check.mjs
 +++ b/scripts/check.mjs
-@@ -432,19 +432,6 @@ const resolveEnableLoopback = () =>
+@@ -422,19 +422,6 @@ const resolveEnableLoopback = () =>
    });
  
  const tasks = [
@@ -34,5 +34,5 @@ index 7be53aa..87b10c8 100644
    { name: "service", func: resolveService, retry: 5 },
    { name: "install", func: resolveInstall, retry: 5 },
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0007-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0007-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
@@ -1,4 +1,4 @@
-From d67ee1ff9a298be7045935ae0b196cf1256a4cd0 Mon Sep 17 00:00:00 2001
+From b65c814c14420340cb3568cf58b6690356575d76 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 12:04:58 +0800
 Subject: [PATCH 07/13] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
@@ -9,7 +9,7 @@ Subject: [PATCH 07/13] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
  1 file changed, 2 deletions(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 25eb530..a2f0dfa 100644
+index ebd7d9c..5838ba6 100644
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -22,8 +22,6 @@
@@ -22,5 +22,5 @@ index 25eb530..a2f0dfa 100644
        "category": "DeveloperTool",
        "shortDescription": "A Clash Meta GUI based on tauri.",
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0008-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0008-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
@@ -1,4 +1,4 @@
-From 904e5637d990450c540574a6b87d411f30cf06d7 Mon Sep 17 00:00:00 2001
+From 79cd22e205f810055dde817c21424e8e3100245c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 13:07:37 +0800
 Subject: [PATCH 08/13] fix(check.mjs): do not check Mihomo (Clash Meta)
@@ -10,7 +10,7 @@ This is pointless, as we supply our own.
  1 file changed, 15 deletions(-)
 
 diff --git a/scripts/check.mjs b/scripts/check.mjs
-index 87b10c8..8390e2c 100644
+index 3065995..7aa1937 100644
 --- a/scripts/check.mjs
 +++ b/scripts/check.mjs
 @@ -145,21 +145,6 @@ async function getLatestReleaseVersion() {
@@ -36,5 +36,5 @@ index 87b10c8..8390e2c 100644
   * core info
   */
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0009-Do-not-find-clash-meta-binary-in-current-dir.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0009-Do-not-find-clash-meta-binary-in-current-dir.patch
@@ -1,4 +1,4 @@
-From 1b38d419fd6dc6c976e3421e24b9f117d6022c35 Mon Sep 17 00:00:00 2001
+From 4c355933418510972819f4f581d1a121d3a305ee Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Wed, 29 May 2024 14:43:22 +0800
 Subject: [PATCH 09/13] Do not find `clash-meta` binary in current dir
@@ -8,19 +8,19 @@ Subject: [PATCH 09/13] Do not find `clash-meta` binary in current dir
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/src-tauri/src/core/core.rs b/src-tauri/src/core/core.rs
-index 1fa7612..e730c26 100644
+index d49cfcd..0aa430d 100644
 --- a/src-tauri/src/core/core.rs
 +++ b/src-tauri/src/core/core.rs
-@@ -49,7 +49,7 @@ impl CoreManager {
-         let app_dir = dirs::app_home_dir()?;
-         let app_dir = dirs::path_to_str(&app_dir)?;
+@@ -63,7 +63,7 @@ impl CoreManager {
+         let test_dir = dirs::app_home_dir()?.join("test");
+         let test_dir = dirs::path_to_str(&test_dir)?;
  
 -        let output = Command::new_sidecar(clash_core)?
 +        let output = Command::new(clash_core)
-             .args(["-t", "-d", app_dir, "-f", config_path])
+             .args(["-t", "-d", test_dir, "-f", config_path])
              .output()?;
  
-@@ -149,10 +149,9 @@ impl CoreManager {
+@@ -153,10 +153,9 @@ impl CoreManager {
          }
  
          let config_path = dirs::path_to_str(&config_path)?;
@@ -33,5 +33,5 @@ index 1fa7612..e730c26 100644
  
          let mut sidecar = self.sidecar.lock();
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0010-Do-not-create-any-bundle-package.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0010-Do-not-create-any-bundle-package.patch
@@ -1,4 +1,4 @@
-From a1bba8c94d620482e0698484e29e98e8f9f1b3b8 Mon Sep 17 00:00:00 2001
+From a45df579b0d353b6e62635e88bb7ed7d22615971 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 14 Jun 2024 23:06:45 +0800
 Subject: [PATCH 10/13] Do not create any bundle package
@@ -37,5 +37,5 @@ index 3a2dc9e..5f3f493 100644
    }
  }
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0011-Drop-check-update-feature.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0011-Drop-check-update-feature.patch
@@ -1,4 +1,4 @@
-From 68747772dca386cb80680789b9a084dd360fda55 Mon Sep 17 00:00:00 2001
+From 192d705252fd6c3e9777759fd3e7a1e7f8e558fe Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 14 Jun 2024 23:05:46 +0800
 Subject: [PATCH 11/13] Drop check update feature
@@ -6,9 +6,9 @@ Subject: [PATCH 11/13] Drop check update feature
 ---
  src/components/layout/update-button.tsx       |  47 ------
  src/components/setting/mods/update-viewer.tsx | 143 ------------------
- src/components/setting/setting-verge.tsx      |  21 +--
+ src/components/setting/setting-verge.tsx      |  39 +----
  src/pages/_layout.tsx                         |   2 -
- 4 files changed, 1 insertion(+), 212 deletions(-)
+ 4 files changed, 3 insertions(+), 228 deletions(-)
  delete mode 100644 src/components/layout/update-button.tsx
  delete mode 100644 src/components/setting/mods/update-viewer.tsx
 
@@ -215,12 +215,28 @@ index bea9a01..0000000
 -  );
 -});
 diff --git a/src/components/setting/setting-verge.tsx b/src/components/setting/setting-verge.tsx
-index 73db3cf..7d620c6 100644
+index 77c45e5..784a0f5 100644
 --- a/src/components/setting/setting-verge.tsx
 +++ b/src/components/setting/setting-verge.tsx
-@@ -9,10 +9,9 @@ import {
-   openLogsDir,
+@@ -1,14 +1,7 @@
+ import { useCallback, useRef } from "react";
+ import { useTranslation } from "react-i18next";
+ import { open } from "@tauri-apps/api/dialog";
+-import {
+-  Button,
+-  MenuItem,
+-  Select,
+-  Input,
+-  Typography,
+-  Box,
+-} from "@mui/material";
++import { Button, MenuItem, Select, Input, Typography } from "@mui/material";
+ import {
+   exitApp,
+   openAppDir,
+@@ -17,10 +10,9 @@ import {
    openDevTools,
+   copyClashEnv,
  } from "@/services/cmds";
 -import { checkUpdate } from "@tauri-apps/api/updater";
  import { useVerge } from "@/hooks/use-verge";
@@ -230,15 +246,15 @@ index 73db3cf..7d620c6 100644
  import { SettingList, SettingItem } from "./mods/setting-comp";
  import { ThemeModeSwitch } from "./mods/theme-mode-switch";
  import { ConfigViewer } from "./mods/config-viewer";
-@@ -21,7 +20,6 @@ import { MiscViewer } from "./mods/misc-viewer";
+@@ -29,7 +21,6 @@ import { MiscViewer } from "./mods/misc-viewer";
  import { ThemeViewer } from "./mods/theme-viewer";
  import { GuardState } from "./mods/guard-state";
  import { LayoutViewer } from "./mods/layout-viewer";
 -import { UpdateViewer } from "./mods/update-viewer";
  import getSystem from "@/utils/get-system";
  import { routers } from "@/pages/_routers";
- 
-@@ -48,25 +46,11 @@ const SettingVerge = ({ onError }: Props) => {
+ import { TooltipIcon } from "@/components/base/base-tooltip-icon";
+@@ -58,30 +49,11 @@ const SettingVerge = ({ onError }: Props) => {
    const miscRef = useRef<DialogRef>(null);
    const themeRef = useRef<DialogRef>(null);
    const layoutRef = useRef<DialogRef>(null);
@@ -261,10 +277,15 @@ index 73db3cf..7d620c6 100644
 -    }
 -  };
 -
+-  const onCopyClashEnv = useCallback(async () => {
+-    await copyClashEnv();
+-    Notice.success(t("Copy Success"), 1000);
+-  }, []);
+-
    return (
      <SettingList title={t("Verge Setting")}>
        <ThemeViewer ref={themeRef} />
-@@ -74,7 +58,6 @@ const SettingVerge = ({ onError }: Props) => {
+@@ -89,7 +61,6 @@ const SettingVerge = ({ onError }: Props) => {
        <HotkeyViewer ref={hotkeyRef} />
        <MiscViewer ref={miscRef} />
        <LayoutViewer ref={layoutRef} />
@@ -272,7 +293,18 @@ index 73db3cf..7d620c6 100644
  
        <SettingItem label={t("Language")}>
          <GuardState
-@@ -236,8 +219,6 @@ const SettingVerge = ({ onError }: Props) => {
+@@ -140,9 +111,7 @@ const SettingVerge = ({ onError }: Props) => {
+ 
+       <SettingItem
+         label={t("Copy Env Type")}
+-        extra={
+-          <TooltipIcon icon={ContentCopyRounded} onClick={onCopyClashEnv} />
+-        }
++        extra={<TooltipIcon icon={ContentCopyRounded} onClick={copyClashEnv} />}
+       >
+         <GuardState
+           value={env_type ?? (OS === "windows" ? "powershell" : "bash")}
+@@ -256,8 +225,6 @@ const SettingVerge = ({ onError }: Props) => {
  
        <SettingItem onClick={openLogsDir} label={t("Open Logs Dir")} />
  
@@ -302,5 +334,5 @@ index 836c7ad..6627333 100644
  
              <List className="the-menu">
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0012-Set-core-binary-name-as-mihomo.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0012-Set-core-binary-name-as-mihomo.patch
@@ -1,4 +1,4 @@
-From 0b9ed6b329d6e693be97c332a59ecb9ee56abb4f Mon Sep 17 00:00:00 2001
+From 07c8853c9e0c1498f192bf074df5ed90b5557bd4 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Thu, 4 Jul 2024 11:05:47 +0800
 Subject: [PATCH 12/13] Set core binary name as mihomo
@@ -8,15 +8,15 @@ Subject: [PATCH 12/13] Set core binary name as mihomo
  scripts/portable-fixed-webview2.mjs           |  4 ++--
  scripts/portable.mjs                          |  4 ++--
  src-tauri/src/config/verge.rs                 |  2 +-
- src-tauri/src/core/core.rs                    | 12 +++++-----
+ src-tauri/src/core/core.rs                    | 19 ++++++++-------
  src-tauri/src/core/service.rs                 |  6 ++---
  src-tauri/src/enhance/chain.rs                |  4 ++--
  src-tauri/template/installer.nsi              | 24 +++++++++----------
  .../setting/mods/clash-core-viewer.tsx        |  4 ++--
- 9 files changed, 34 insertions(+), 34 deletions(-)
+ 9 files changed, 38 insertions(+), 37 deletions(-)
 
 diff --git a/scripts/check.mjs b/scripts/check.mjs
-index 8390e2c..ed4a178 100644
+index 7aa1937..61a872c 100644
 --- a/scripts/check.mjs
 +++ b/scripts/check.mjs
 @@ -157,8 +157,8 @@ function clashMetaAlpha() {
@@ -72,7 +72,7 @@ index 1a9d125..4499f7f 100644
    zip.addLocalFolder(configDir, ".config");
  
 diff --git a/src-tauri/src/config/verge.rs b/src-tauri/src/config/verge.rs
-index a7f8827..0b6bd47 100644
+index 6086b8c..012981d 100644
 --- a/src-tauri/src/config/verge.rs
 +++ b/src-tauri/src/config/verge.rs
 @@ -201,7 +201,7 @@ impl IVerge {
@@ -85,19 +85,36 @@ index a7f8827..0b6bd47 100644
              theme_mode: Some("system".into()),
              #[cfg(not(target_os = "windows"))]
 diff --git a/src-tauri/src/core/core.rs b/src-tauri/src/core/core.rs
-index e730c26..94ebf0f 100644
+index 0aa430d..f81e48f 100644
 --- a/src-tauri/src/core/core.rs
 +++ b/src-tauri/src/core/core.rs
-@@ -86,7 +86,7 @@ impl CoreManager {
+@@ -44,13 +44,13 @@ impl CoreManager {
+         let config_path = dirs::path_to_str(&config_path)?;
  
-         let mut system = System::new();
-         system.refresh_all();
--        let procs = system.processes_by_name("verge-mihomo");
-+        let procs = system.processes_by_name("mihomo");
-         for proc in procs {
-             log::debug!(target: "app", "kill all clash process");
-             proc.kill();
-@@ -132,13 +132,13 @@ impl CoreManager {
+         let clash_core = { Config::verge().latest().clash_core.clone() };
+-        let mut clash_core = clash_core.unwrap_or("verge-mihomo".into());
++        let mut clash_core = clash_core.unwrap_or("mihomo".into());
+ 
+         // compatibility
+         if clash_core.contains("clash") {
+-            clash_core = "verge-mihomo".to_string();
++            clash_core = "mihomo".to_string();
+             Config::verge().draft().patch_config(IVerge {
+-                clash_core: Some("verge-mihomo".to_string()),
++                clash_core: Some("mihomo".to_string()),
+                 ..IVerge::default()
+             });
+             Config::verge().apply();
+@@ -99,7 +99,7 @@ impl CoreManager {
+             let system = System::new_with_specifics(
+                 RefreshKind::new().with_processes(ProcessRefreshKind::everything()),
+             );
+-            let procs = system.processes_by_name("verge-mihomo");
++            let procs = system.processes_by_name("mihomo");
+ 
+             for proc in procs {
+                 log::debug!(target: "app", "kill all clash process");
+@@ -136,13 +136,13 @@ impl CoreManager {
          let app_dir = dirs::path_to_str(&app_dir)?;
  
          let clash_core = { Config::verge().latest().clash_core.clone() };
@@ -114,16 +131,20 @@ index e730c26..94ebf0f 100644
                  ..IVerge::default()
              });
              Config::verge().apply();
-@@ -238,7 +238,7 @@ impl CoreManager {
- 
-         let mut system = System::new();
-         system.refresh_all();
+@@ -243,18 +243,19 @@ impl CoreManager {
+         let system = System::new_with_specifics(
+             RefreshKind::new().with_processes(ProcessRefreshKind::everything()),
+         );
 -        let procs = system.processes_by_name("verge-mihomo");
 +        let procs = system.processes_by_name("mihomo");
          for proc in procs {
              log::debug!(target: "app", "kill all clash process");
              proc.kill();
-@@ -249,7 +249,7 @@ impl CoreManager {
+         }
++    
+         Ok(())
+     }
+ 
      /// 切换核心
      pub async fn change_core(&self, clash_core: Option<String>) -> Result<()> {
          let clash_core = clash_core.ok_or(anyhow::anyhow!("clash core is null"))?;
@@ -133,10 +154,10 @@ index e730c26..94ebf0f 100644
          if !CLASH_CORES.contains(&clash_core.as_str()) {
              bail!("invalid clash core name \"{clash_core}\"");
 diff --git a/src-tauri/src/core/service.rs b/src-tauri/src/core/service.rs
-index 4f9db5f..a085b80 100644
+index 3a06648..849d985 100644
 --- a/src-tauri/src/core/service.rs
 +++ b/src-tauri/src/core/service.rs
-@@ -238,13 +238,13 @@ pub(super) async fn run_core_by_service(config_file: &PathBuf) -> Result<()> {
+@@ -285,13 +285,13 @@ pub(super) async fn run_core_by_service(config_file: &PathBuf) -> Result<()> {
      }
  
      let clash_core = { Config::verge().latest().clash_core.clone() };
@@ -221,10 +242,10 @@ index 6b90a09..d4a325f 100644
    ${EndIf}
  
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
-index cb037d7..9f31e01 100644
+index 714ba6d..15f0bff 100644
 --- a/src/components/setting/mods/clash-core-viewer.tsx
 +++ b/src/components/setting/mods/clash-core-viewer.tsx
-@@ -18,7 +18,7 @@ import { changeClashCore, restartSidecar } from "@/services/cmds";
+@@ -21,7 +21,7 @@ import { changeClashCore, restartSidecar } from "@/services/cmds";
  import { closeAllConnections, upgradeCore } from "@/services/api";
  
  const VALID_CORE = [
@@ -233,7 +254,7 @@ index cb037d7..9f31e01 100644
  ];
  
  export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
-@@ -34,7 +34,7 @@ export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
+@@ -37,7 +37,7 @@ export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
      close: () => setOpen(false),
    }));
  
@@ -243,5 +264,5 @@ index cb037d7..9f31e01 100644
    const onCoreChange = useLockFn(async (core: string) => {
      if (core === clash_core) return;
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0013-find-clash-verge-service-from-PATH.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0013-find-clash-verge-service-from-PATH.patch
@@ -1,4 +1,4 @@
-From d2a7042eecb0c32c1053cf1ba457625188ae4567 Mon Sep 17 00:00:00 2001
+From ad5d49298ad196fd854802f618721cdaf4d7eba4 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Thu, 4 Jul 2024 14:36:15 +0800
 Subject: [PATCH 13/13] find `clash-verge-service` from `$PATH`
@@ -10,10 +10,10 @@ Subject: [PATCH 13/13] find `clash-verge-service` from `$PATH`
  3 files changed, 22 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/Cargo.lock b/src-tauri/Cargo.lock
-index c11de2b..040db7f 100644
+index 062fb64..d9b0de1 100644
 --- a/src-tauri/Cargo.lock
 +++ b/src-tauri/Cargo.lock
-@@ -814,6 +814,7 @@ dependencies = [
+@@ -821,6 +821,7 @@ dependencies = [
   "tokio",
   "users",
   "warp",
@@ -21,7 +21,7 @@ index c11de2b..040db7f 100644
   "window-shadows",
   "winreg 0.52.0",
  ]
-@@ -4597,7 +4598,7 @@ checksum = "b96d6b6c505282b007a9b009f2aa38b2fd0359b81a0430ceacc60f69ade4c6a0"
+@@ -4640,7 +4641,7 @@ checksum = "b96d6b6c505282b007a9b009f2aa38b2fd0359b81a0430ceacc60f69ade4c6a0"
  dependencies = [
   "libc",
   "security-framework-sys",
@@ -30,7 +30,7 @@ index c11de2b..040db7f 100644
   "windows-sys 0.48.0",
  ]
  
-@@ -6702,6 +6703,18 @@ dependencies = [
+@@ -6745,6 +6746,18 @@ dependencies = [
   "rustix 0.38.34",
  ]
  
@@ -49,7 +49,7 @@ index c11de2b..040db7f 100644
  [[package]]
  name = "winapi"
  version = "0.3.9"
-@@ -7197,6 +7210,12 @@ dependencies = [
+@@ -7240,6 +7253,12 @@ dependencies = [
   "windows-sys 0.48.0",
  ]
  
@@ -63,10 +63,10 @@ index c11de2b..040db7f 100644
  name = "wl-clipboard-rs"
  version = "0.8.1"
 diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
-index 0171e52..e18237f 100644
+index a66a2da..f332880 100644
 --- a/src-tauri/Cargo.toml
 +++ b/src-tauri/Cargo.toml
-@@ -45,6 +45,7 @@ winreg = "0.52.0"
+@@ -46,6 +46,7 @@ winreg = "0.52.0"
  
  [target.'cfg(target_os = "linux")'.dependencies]
  users = "0.11.0"
@@ -88,5 +88,5 @@ index deda1c1..f89af77 100644
  
  #[cfg(windows)]
 -- 
-2.45.2
+2.47.0
 

--- a/app-network/clash-verge-rev/autobuild/prepare
+++ b/app-network/clash-verge-rev/autobuild/prepare
@@ -1,5 +1,5 @@
 abinfo "Installing tauri-cli ..."
-cargo install tauri-cli
+cargo install tauri-cli@1.6.4
 
 abinfo "Prevent Corepack from showing the URL ..."
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/app-network/clash-verge-rev/spec
+++ b/app-network/clash-verge-rev/spec
@@ -1,5 +1,4 @@
-VER=1.7.2
-REL=1
+VER=1.7.7
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: update to 1.7.7
    Co-authored-by: Alan Lin (@miwu04) <mail@alanlin.icu>

Package(s) Affected
-------------------

- clash-verge-rev: 1.7.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
