### PR TITLE
linux-kernel: update la_ow_syscall module

### DIFF
--- a/runtime-kernel/linux-kernel/autobuild/patches/0097-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0097-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
@@ -1,24 +1,24 @@
-From 37dd8dd1eec525a13438c6458e5815ba5565d067 Mon Sep 17 00:00:00 2001
-From: Mingcong Bai <jeffbai@aosc.xyz>
-Date: Wed, 21 Feb 2024 16:58:32 -0500
+From 62a16caa93f6d23f4bb86054409a0777848ccc6f Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Wed, 28 Aug 2024 03:09:24 +0800
 Subject: [PATCH 097/103] arch/loongarch: add la_ow_syscall as in-tree module
 
 Co-authored-By: Miao Wang <shankerwangmiao@gmail.com>
-Ref: https://github.com/AOSC-Dev/la_ow_syscall
+Ref: https://github.com/AOSC-Dev/la_ow_syscall/tree/492c16dc5f6d2a8606b25077086a42cb4b0347ea
 ---
  arch/loongarch/Kbuild                         |   2 +
  arch/loongarch/ow_syscall/Kbuild              |  26 ++
  arch/loongarch/ow_syscall/LICENSE             | 339 ++++++++++++++++++
  arch/loongarch/ow_syscall/Makefile            |  37 ++
- arch/loongarch/ow_syscall/README.md           |  74 ++++
+ arch/loongarch/ow_syscall/README.md           |  77 ++++
  arch/loongarch/ow_syscall/VERSION             |   1 +
- arch/loongarch/ow_syscall/dkms.conf.in        |   7 +
+ arch/loongarch/ow_syscall/dkms.conf.in        |  11 +
  arch/loongarch/ow_syscall/fsstat.c            |  84 +++++
  arch/loongarch/ow_syscall/fsstat.h            |   3 +
- .../loongarch/ow_syscall/la_ow_syscall_main.c | 326 +++++++++++++++++
- arch/loongarch/ow_syscall/signal.c            | 222 ++++++++++++
- arch/loongarch/ow_syscall/signal.h            |  41 +++
- 12 files changed, 1162 insertions(+)
+ .../loongarch/ow_syscall/la_ow_syscall_main.c | 332 +++++++++++++++++
+ arch/loongarch/ow_syscall/signal.c            | 239 ++++++++++++
+ arch/loongarch/ow_syscall/signal.h            |  44 +++
+ 12 files changed, 1195 insertions(+)
  create mode 100644 arch/loongarch/ow_syscall/Kbuild
  create mode 100644 arch/loongarch/ow_syscall/LICENSE
  create mode 100644 arch/loongarch/ow_syscall/Makefile
@@ -43,7 +43,7 @@ index bfa21465d83af..52ddcb17537ce 100644
 +obj-y += ow_syscall/
 diff --git a/arch/loongarch/ow_syscall/Kbuild b/arch/loongarch/ow_syscall/Kbuild
 new file mode 100644
-index 0000000000000..f3921c3fd96db
+index 0000000000000..19a9a9156381f
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kbuild
 @@ -0,0 +1,26 @@
@@ -61,16 +61,16 @@ index 0000000000000..f3921c3fd96db
 +
 +ifndef KBUILD_EXTMOD
 +  ifdef CONFIG_KALLSYMS
++    ifndef CONFIG_RANDOMIZE_BASE
 +$(obj)/ksym_addr.h: System.map
 +	@$(kecho) '  GEN     $@'
 +	$(Q)grep ' sys_call_table$$' $< >/dev/null
 +	$(Q)grep ' kallsyms_lookup_name$$' $< >/dev/null
-+	$(Q)grep ' system_state$$' $< >/dev/null
-+	$(Q)echo "#define LAOWSYS_SYS_CALL_TABLE_ADDR 0x$$(grep ' sys_call_table$$' $< | cut -d ' ' -f 1)ul" > $@
-+	$(Q)echo "#define LAOWSYS_KALLSYMS_LOOKUP_NAME_ADDR 0x$$(grep ' kallsyms_lookup_name$$' $< | cut -d ' ' -f 1)ul" >> $@
-+	$(Q)echo "#define LAOWSYS_SYSTEM_STATE_ADDR 0x$$(grep ' system_state$$' $< | cut -d ' ' -f 1)ul" >> $@
++	$(Q)echo "#define LAOWSYS_SYS_CALL_TABLE_ADDR 0x$$(grep ' sys_call_table$$' $< | cut -d ' ' -f 1)" > $@
++	$(Q)echo "#define LAOWSYS_KALLSYMS_LOOKUP_NAME_ADDR 0x$$(grep ' kallsyms_lookup_name$$' $< | cut -d ' ' -f 1)" >> $@
 +ccflags-y += -DHAVE_KSYM_ADDR
 +$(obj)/$(la_ow_syscall-y): $(obj)/ksym_addr.h
++    endif
 +  endif
 +endif
 diff --git a/arch/loongarch/ow_syscall/LICENSE b/arch/loongarch/ow_syscall/LICENSE
@@ -463,10 +463,10 @@ index 0000000000000..e975aa1cdb7af
 +dev: modprobe-remove dkms-remove dkms-add dkms-build dkms-install modprobe-install
 diff --git a/arch/loongarch/ow_syscall/README.md b/arch/loongarch/ow_syscall/README.md
 new file mode 100644
-index 0000000000000..24ec0eae161f1
+index 0000000000000..25c6757983896
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/README.md
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,77 @@
 +la\_ow\_syscall
 +====
 +
@@ -480,6 +480,8 @@ index 0000000000000..24ec0eae161f1
 +Linux Kernel >= 6.1.0 for `loongarch64` with the following option(s) set:
 +
 +- `CONFIG_KALLSYMS=y` (for reading kernel symbol addresses).
++- `CONFIG_KPROBES=y` (for probing kernel symbol addresses using kernels where
++  base address randomisation - `CONFIG_RANDOMIZE_BASE` - is enabled).
 +
 +Installation
 +----
@@ -501,17 +503,18 @@ index 0000000000000..24ec0eae161f1
 +kernel module:
 +
 +```
-+# $PWD is the kernel source root.
++# $PWD is containing built objects
++# /path/to/source_dir is containing Linux source code
 +make \
-+    -C ${PWD} \
++    -C /path/to/source_dir \
 +    ARCH=loongarch \
-+    O=(pwd) \
++    O="$PWD" \
 +    arch/loongarch/ow_syscall/la_ow_syscall.ko \
 +    CONFIG_LOONGARCH_OW_SYSCALL=m
 +```
 +
 +Upon completion, copy the kernel module in place
-+(`/usr/lib/modules/.../arch/loongarch/ow_syscall/la_ow_syscall.ko`) and
++(`/lib/modules/.../arch/loongarch/ow_syscall/la_ow_syscall.ko`) and
 +re-generate modules.dep and map files:
 +
 +```
@@ -551,15 +554,19 @@ index 0000000000000..6c6aa7cb0918d
 \ No newline at end of file
 diff --git a/arch/loongarch/ow_syscall/dkms.conf.in b/arch/loongarch/ow_syscall/dkms.conf.in
 new file mode 100644
-index 0000000000000..b2a3493106c24
+index 0000000000000..ad9aec128e6f8
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/dkms.conf.in
-@@ -0,0 +1,7 @@
+@@ -0,0 +1,11 @@
 +PACKAGE_NAME="la_ow_syscall"
 +PACKAGE_VERSION="VERSION"
++
++BUILD_EXCLUSIVE_KERNEL_MIN="5.19"
++BUILD_EXCLUSIVE_CONFIG="CONFIG_KALLSYMS"
++
 +MAKE="KDIR=/lib/modules/${kernelver}/build make"
 +CLEAN="make clean"
-+BUILT_MODULE_NAME[0]="la_ow_syscall"
++BUILT_MODULE_NAME[0]="$PACKAGE_NAME"
 +AUTOINSTALL="yes"
 +DEST_MODULE_LOCATION[0]="/extra"
 diff --git a/arch/loongarch/ow_syscall/fsstat.c b/arch/loongarch/ow_syscall/fsstat.c
@@ -663,10 +670,10 @@ index 0000000000000..7c970ad8fd009
 +extern int (*p_vfs_fstat)(int fd, struct kstat *stat);
 diff --git a/arch/loongarch/ow_syscall/la_ow_syscall_main.c b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 new file mode 100644
-index 0000000000000..3308ef082539e
+index 0000000000000..edf8de50daa84
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
-@@ -0,0 +1,326 @@
+@@ -0,0 +1,332 @@
 +#include <linux/module.h> /* Needed by all modules */
 +#include <linux/kernel.h> /* Needed for KERN_INFO */
 +#include <linux/init.h> /* Needed for the macros */
@@ -724,6 +731,7 @@ index 0000000000000..3308ef082539e
 +	{ __NR_rt_sigaction, sys_rt_sigaction },
 +	{ __NR_rt_sigsuspend, sys_rt_sigsuspend },
 +	{ __NR_pselect6, sys_pselect6 },
++	{ __NR_ppoll, sys_ppoll },
 +#ifdef CONFIG_SIGNALFD
 +	{ __NR_signalfd4, sys_signalfd4 },
 +#endif
@@ -736,22 +744,19 @@ index 0000000000000..3308ef082539e
 +#define nr_syscalls_to_replace \
 +	(sizeof(syscall_to_replace) / sizeof(syscall_to_replace[0]))
 +
-+static unsigned long kallsyms_lookup_name_addr = 0;
++static unsigned long kallsyms_lookup_name_addr =
++#ifdef HAVE_KSYM_ADDR
++LAOWSYS_KALLSYMS_LOOKUP_NAME_ADDR
++#else
++0
++#endif
++;
 +static unsigned int allow_mod_unreg = 0;
 +
 +#include <asm-generic/sections.h>
 +
 +#ifdef HAVE_KSYM_ADDR
-+static int __init find_kallsyms_lookup_name(void)
-+{
-+	unsigned long offset =
-+		(unsigned long)&system_state - LAOWSYS_SYSTEM_STATE_ADDR;
-+	pr_debug("kernel offset = %lx\n", offset);
-+	kallsyms_lookup_name_addr = offset + LAOWSYS_KALLSYMS_LOOKUP_NAME_ADDR;
-+	pr_debug("using kallsyms_lookup_name @ %p\n",
-+		 (void *)kallsyms_lookup_name_addr);
-+	return 0;
-+}
++static int __init find_kallsyms_lookup_name(void){ return 0; }
 +#else
 +// Taken from https://github.com/zizzu0/LinuxKernelModules/blob/main/FindKallsymsLookupName.c
 +#define KPROBE_PRE_HANDLER(fname) \
@@ -793,10 +798,8 @@ index 0000000000000..3308ef082539e
 +	return ret;
 +}
 +
-+static int __init find_kallsyms_lookup_name(void)
++static int __init kprobe_kallsyms_lookup_name(void)
 +{
-+	char fn_name[KSYM_SYMBOL_LEN];
-+
 +	int ret = 0;
 +
 +	ret = do_register_kprobe(&kp0, "kallsyms_lookup_name", handler_pre0);
@@ -812,9 +815,26 @@ index 0000000000000..3308ef082539e
 +	unregister_kprobe(&kp0);
 +	unregister_kprobe(&kp1);
 +
++	return ret;
++}
++
++
++static int __init find_kallsyms_lookup_name(void)
++{
++	char fn_name[KSYM_SYMBOL_LEN];
++
++	int ret = 0;
++
 +	if (kallsyms_lookup_name_addr == 0 ||
 +	    kallsyms_lookup_name_addr == (unsigned long)-1) {
-+		return -EINVAL;
++		ret = kprobe_kallsyms_lookup_name();
++		if ( ret < 0 ) {
++			return ret;
++		}
++		if (kallsyms_lookup_name_addr == 0 ||
++		    kallsyms_lookup_name_addr == (unsigned long)-1) {
++			return -EINVAL;
++		}
 +	}
 +	sprint_symbol(fn_name, kallsyms_lookup_name_addr);
 +	if (strncmp(fn_name, "kallsyms_lookup_name+0x0",
@@ -850,7 +870,7 @@ index 0000000000000..3308ef082539e
 +	__rel(sys_clone),	  __rel(sys_rt_sigprocmask),
 +	__rel(sys_rt_sigpending), __rel(sys_rt_sigtimedwait),
 +	__rel(sys_rt_sigaction),  __rel(sys_rt_sigsuspend),
-+	__rel(sys_pselect6),
++	__rel(sys_pselect6),	  __rel(sys_ppoll),
 +#ifdef CONFIG_SIGNALFD
 +	__rel(sys_signalfd4),
 +#endif
@@ -860,19 +880,12 @@ index 0000000000000..3308ef082539e
 +};
 +#define nr_rel_tab (sizeof(relocation_table) / sizeof(relocation_table[0]))
 +
-+static void **p_sys_call_table;
-+
 +#ifdef HAVE_KSYM_ADDR
-+static int __init find_sys_call_table(void)
-+{
-+	unsigned long offset =
-+		(unsigned long)&system_state - LAOWSYS_SYSTEM_STATE_ADDR;
-+	pr_debug("kernel offset = %lx\n", offset);
-+	p_sys_call_table = (void **)(offset + LAOWSYS_SYS_CALL_TABLE_ADDR);
-+	pr_debug("using sys_call_table @ %p\n", p_sys_call_table);
-+	return 0;
-+}
++static void **p_sys_call_table = (void **)LAOWSYS_SYS_CALL_TABLE_ADDR;
++static int __init find_sys_call_table(void){ return 0; };
 +#else
++
++static void **p_sys_call_table;
 +
 +#include <linux/jiffies.h>
 +#include <linux/reboot.h>
@@ -991,14 +1004,14 @@ index 0000000000000..3308ef082539e
 +		 "Allow this module to be unload (Danger! Debug use only)");
 +#ifndef HAVE_KSYM_ADDR
 +module_param(kallsyms_lookup_name_addr, ulong, 0000);
-+MODULE_PARM_DESC(kallsyms_lookup_name_addr, "Address for kallsyms_lookup_name");
++MODULE_PARM_DESC(kallsyms_lookup_name_addr, "Address for kallsyms_lookup_name, provide this when unable to find using kprobe");
 +#endif
 diff --git a/arch/loongarch/ow_syscall/signal.c b/arch/loongarch/ow_syscall/signal.c
 new file mode 100644
-index 0000000000000..1593fdba30c26
+index 0000000000000..90eb34727680d
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.c
-@@ -0,0 +1,222 @@
+@@ -0,0 +1,239 @@
 +#include <linux/syscalls.h>
 +#include <linux/uaccess.h>
 +#include <linux/errno.h>
@@ -1158,6 +1171,23 @@ index 0000000000000..1593fdba30c26
 +	}
 +}
 +
++__SYSCALL_DEFINEx(5, _ppoll, struct pollfd __user *, ufds, unsigned int, nfds,
++		struct __kernel_timespec __user *, tsp, const sigset_t __user *, sigmask,
++		size_t, sigsetsize)
++{
++	if (sigmask == NULL || sigsetsize == sizeof(sigset_t)) {
++		return p_sys_ppoll(ufds, nfds, tsp, sigmask, sigsetsize);
++	} else if (sigsetsize == sizeof(_la_ow_sigset_t)) {
++		int rc = p_sys_ppoll(ufds, nfds, tsp, sigmask, sizeof(sigset_t));
++		if (rc < 0) {
++			return rc;
++		}
++		return rc;
++	} else {
++		return -EINVAL;
++	}
++}
++
 +#ifdef CONFIG_EPOLL
 +
 +__SYSCALL_DEFINEx(6, _epoll_pwait, int, epfd, struct epoll_event __user *,
@@ -1223,10 +1253,10 @@ index 0000000000000..1593fdba30c26
 +#endif
 diff --git a/arch/loongarch/ow_syscall/signal.h b/arch/loongarch/ow_syscall/signal.h
 new file mode 100644
-index 0000000000000..a640b39e982d3
+index 0000000000000..adcd53bedc662
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.h
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,44 @@
 +#include <linux/syscalls.h>
 +
 +#ifndef __EXTERN
@@ -1254,6 +1284,9 @@ index 0000000000000..a640b39e982d3
 +P__SYSCALL_DEFINEx(6, _pselect6, int, n, fd_set __user *, inp, fd_set __user *,
 +		   outp, fd_set __user *, exp,
 +		   struct __kernel_timespec __user *, tsp, void __user *, sig);
++P__SYSCALL_DEFINEx(5, _ppoll, struct pollfd __user *, ufds, unsigned int, nfds,
++		struct __kernel_timespec __user *, tsp, const sigset_t __user *, sigmask,
++		size_t, sigsetsize);
 +#ifdef CONFIG_SIGNALFD
 +P__SYSCALL_DEFINEx(4, _signalfd4, int, ufd, sigset_t __user *, user_mask,
 +		   size_t, sizemask, int, flags);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0098-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0098-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,4 +1,4 @@
-From eba89deb4c9688fd5bc60bbece2d3e93d16f7828 Mon Sep 17 00:00:00 2001
+From 359c4bd62694e877562646e0f0ed8880a8a80940 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
 Subject: [PATCH 098/103] la_ow_syscall: add kconfig for module

--- a/runtime-kernel/linux-kernel/autobuild/patches/0099-platform-x86-ideapad-laptop-add-fixes-for-ThinkBook-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0099-platform-x86-ideapad-laptop-add-fixes-for-ThinkBook-.patch
@@ -1,4 +1,4 @@
-From 1d9d9f165130c5688d1be64ac967e62ad6a7f7af Mon Sep 17 00:00:00 2001
+From dc61e8a50d97176270aeaeaa46f58ef6169b1d7f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 17 Aug 2024 11:32:11 +0800
 Subject: [PATCH 099/103] platform: x86: ideapad-laptop: add fixes for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0100-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0100-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
@@ -1,4 +1,4 @@
-From c8ec0e10304166479ff5ecd8761f3c69a57762bd Mon Sep 17 00:00:00 2001
+From 115f8cc731010f4ee41f4b9a597c729d1c5c04bf Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:43:11 +0800
 Subject: [PATCH 100/103] [LOONGARCH64] drivers/firmware: Move sysfb_init()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0101-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0101-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
@@ -1,4 +1,4 @@
-From c4398ade8a6923d5baa80d4df0b051c4fb0dd0ed Mon Sep 17 00:00:00 2001
+From 5ec766d3a1cc4e35796a873af748cf3a49303fa6 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Mon, 11 Mar 2024 00:14:58 +0800
 Subject: [PATCH 101/103] [LOONGARCH64] drm/xe: fix build on non-4K kernels

--- a/runtime-kernel/linux-kernel/autobuild/patches/0102-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0102-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
@@ -1,4 +1,4 @@
-From bc17922d7c8a10d815dff984a021591a495aeb36 Mon Sep 17 00:00:00 2001
+From fec4c44526d0193d67131df61063efc515770c78 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
 Subject: [PATCH 102/103] [LOONGARCH64] drm/radeon: Workaround radeon driver

--- a/runtime-kernel/linux-kernel/autobuild/patches/0103-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0103-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
@@ -1,4 +1,4 @@
-From 432739d360ce6dee5d855d8835e6b861fb93bb98 Mon Sep 17 00:00:00 2001
+From 368808faad2998083746890971f3fb874f944062 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 14:28:02 +0800
 Subject: [PATCH 103/103] [LOONGARCH64] drm/radeon: Call mmiowb() at the end of

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -1,4 +1,5 @@
 VER=6.10.6
+REL=1
 
 # Use this for stable releases.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- linux-kernel: update la_ow_syscall module
    - Track patches at https://github.com/AOSC-Tracking/linux @ aosc/v6.10.6, current HEAD is 368808faad2998083746890971f3fb874f944062.

Package(s) Affected
-------------------

- linux-kernel-6.10.6: 1:6.10.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
