### PR TITLE
linux-kernel: update la_ow_syscall module

### DIFF
--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-loongarch-PCI-pci_call_probe-call-local_pci_probe-wh.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-loongarch-PCI-pci_call_probe-call-local_pci_probe-wh.patch
@@ -1,4 +1,4 @@
-From 90aa23c2b7b95f2a3e981967c21f69bb188d97ce Mon Sep 17 00:00:00 2001
+From 2b1bf071bf9fa828d4c56618c4516a4fdbbb5ae9 Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Thu, 13 Jun 2024 15:42:58 +0800
 Subject: [PATCH 050/103] loongarch: PCI: pci_call_probe: call
@@ -17,7 +17,7 @@ Fixes: 69a18b18699b ("PCI: Restrict probe functions to housekeeping CPUs")
 Cc: <stable@vger.kernel.org>
 Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
 Signed-off-by: Hongchen Zhang <zhanghongchen@loongson.cn>
-Ref: https://lore.kernel.org/all/20240613074258.4124603-1-zhanghongchen@loongson.cn/
+Ref: https://github.com/AOSC-Tracking/linux/commit/90aa23c2b7b95f2a3e981967c21f69bb188d97ce
 ---
  drivers/pci/pci-driver.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,4 +1,4 @@
-From 7c393fdfb960335dcfe3f917f8c7ea6032b7415d Mon Sep 17 00:00:00 2001
+From cc3ba4e0d875681ebc3a91c7e5f63a117ecb5257 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 01:23:57 +0800
 Subject: [PATCH 051/103] LoongArch: Add CPU HWMon platform driver

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-LoongArch-KVM-Add-PV-steal-time-support-in-host-side.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-LoongArch-KVM-Add-PV-steal-time-support-in-host-side.patch
@@ -1,4 +1,4 @@
-From 1dcfc80f76936e2e51eeb392870bcdaec3b9658d Mon Sep 17 00:00:00 2001
+From abcfbd194217fa49f9f534facd0f3a7bb0ae6a3e Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:31:59 +0800
 Subject: [PATCH 052/103] LoongArch: KVM: Add PV steal time support in host

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-LoongArch-KVM-Add-PV-steal-time-support-in-guest-sid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-LoongArch-KVM-Add-PV-steal-time-support-in-guest-sid.patch
@@ -1,4 +1,4 @@
-From 5ca600ed6e5ee11bed7b9bf031e7a54e9d680d9b Mon Sep 17 00:00:00 2001
+From 3f10de2782ed37661c6fad864f66389d2d7699fe Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:32:22 +0800
 Subject: [PATCH 053/103] LoongArch: KVM: Add PV steal time support in guest

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-LoongArch-KVM-Add-HW-Binary-Translation-extension-su.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-LoongArch-KVM-Add-HW-Binary-Translation-extension-su.patch
@@ -1,4 +1,4 @@
-From fe61268423d911545788331c7e83ae44b12c74be Mon Sep 17 00:00:00 2001
+From 7266a9b27ebbc751fac9ec3911e5263bfbea191e Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Jul 2024 15:57:41 +0800
 Subject: [PATCH 054/103] LoongArch: KVM: Add HW Binary Translation extension

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-LoongArch-KVM-Add-LBT-feature-detection-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-LoongArch-KVM-Add-LBT-feature-detection-function.patch
@@ -1,4 +1,4 @@
-From cb4b1e258b263071335e10d9ee62a1a37a02c6cc Mon Sep 17 00:00:00 2001
+From 1a079593bae631e31cec63c2d394246d0d48b7ab Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Jul 2024 15:57:42 +0800
 Subject: [PATCH 055/103] LoongArch: KVM: Add LBT feature detection function

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-LoongArch-KVM-Add-vm-migration-support-for-LBT-regis.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-LoongArch-KVM-Add-vm-migration-support-for-LBT-regis.patch
@@ -1,4 +1,4 @@
-From c771d8c6c49099420618bf5aea18d3624e047326 Mon Sep 17 00:00:00 2001
+From d92d018e6cfb84f0ebd7f9b4c139b23043cf6c62 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Jul 2024 15:57:43 +0800
 Subject: [PATCH 056/103] LoongArch: KVM: Add vm migration support for LBT

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-LoongArch-Add-architectural-preparation-for-CPUFreq.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-LoongArch-Add-architectural-preparation-for-CPUFreq.patch
@@ -1,4 +1,4 @@
-From 3c6b7381d15ef5455771f60e496021ba44acf66e Mon Sep 17 00:00:00 2001
+From 2ed1b77879e3886bb80f1fbe74a0cb1c163e8613 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sat, 20 Jul 2024 22:41:06 +0800
 Subject: [PATCH 057/103] LoongArch: Add architectural preparation for CPUFreq

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-cpufreq-Add-Loongson-3-CPUFreq-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-cpufreq-Add-Loongson-3-CPUFreq-driver-support.patch
@@ -1,4 +1,4 @@
-From b5bdc2418f699ee9b945dda309383e3fba9ee023 Mon Sep 17 00:00:00 2001
+From 2e8b9e6ec20dae0d3e53cc6579e333efd8fb14ae Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 5 Jul 2024 14:06:49 +0800
 Subject: [PATCH 058/103] cpufreq: Add Loongson-3 CPUFreq driver support

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-dt-bindings-pwm-Add-Loongson-PWM-controller.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-dt-bindings-pwm-Add-Loongson-PWM-controller.patch
@@ -1,4 +1,4 @@
-From 30a8222e84748e995571878a1fd604a156ff4073 Mon Sep 17 00:00:00 2001
+From a6a720636291d21c7510f87dcce6de311a0bd510 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 10 Jul 2024 10:04:06 +0800
 Subject: [PATCH 059/103] dt-bindings: pwm: Add Loongson PWM controller

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-pwm-Add-Loongson-PWM-controller-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-pwm-Add-Loongson-PWM-controller-support.patch
@@ -1,4 +1,4 @@
-From c44626b2ff61f5dffba12ef8aa76215e0fa69953 Mon Sep 17 00:00:00 2001
+From 3fa5142e8614db8ccd980cb6aea2fe0e2485ea25 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 10 Jul 2024 10:04:07 +0800
 Subject: [PATCH 060/103] pwm: Add Loongson PWM controller support

--- a/runtime-kernel/linux-kernel/autobuild/patches/0061-cpufreq-Make-Loongson-3-s-cpufreq_driver-exit-return.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0061-cpufreq-Make-Loongson-3-s-cpufreq_driver-exit-return.patch
@@ -1,4 +1,4 @@
-From 35a1a5cc509c727c120650adb4463b4bf708f92b Mon Sep 17 00:00:00 2001
+From 326114811819834e889cc7e2dbf36098c5328108 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 20:00:46 +0800
 Subject: [PATCH 061/103] cpufreq: Make Loongson-3's cpufreq_driver->exit()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0062-loongarch-basic-boot-support-for-legacy-firmware.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0062-loongarch-basic-boot-support-for-legacy-firmware.patch
@@ -1,4 +1,4 @@
-From 945d2a50554c7263457abf7b4e768d1a789d37cf Mon Sep 17 00:00:00 2001
+From 1b4a4e3561363185dfa365c219728f00b2773bbf Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
 Subject: [PATCH 062/103] loongarch: basic boot support for legacy firmware

--- a/runtime-kernel/linux-kernel/autobuild/patches/0063-loongarch-parse-BPI-data-and-add-memory-mapping.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0063-loongarch-parse-BPI-data-and-add-memory-mapping.patch
@@ -1,4 +1,4 @@
-From 8ca043f9b2414cb6dc66076c997542a18cc35b9e Mon Sep 17 00:00:00 2001
+From 9d2ff51b8d376817d5b3af03e3b6709c467aed87 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
 Subject: [PATCH 063/103] loongarch: parse BPI data and add memory mapping

--- a/runtime-kernel/linux-kernel/autobuild/patches/0064-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0064-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,4 +1,4 @@
-From c0e8203977c5ea5609b6cff44af9f569bf6cd449 Mon Sep 17 00:00:00 2001
+From adb0995b290a060a17a391599319a6941e241dba Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
 Subject: [PATCH 064/103] loongarch: add MADT ACPI table conversion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0065-loongarch-correct-missing-offset-of-PCI-root-control.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0065-loongarch-correct-missing-offset-of-PCI-root-control.patch
@@ -1,4 +1,4 @@
-From f0f9ad15d518d90ae682fa3d2261d2262116c0df Mon Sep 17 00:00:00 2001
+From a8129edce74c22d4f7fa6d9ac0de581943e6f886 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
 Subject: [PATCH 065/103] loongarch: correct missing offset of PCI root

--- a/runtime-kernel/linux-kernel/autobuild/patches/0066-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0066-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,4 +1,4 @@
-From 07d4ea65d470c013e6a7d018cbb7bb4dadd691e1 Mon Sep 17 00:00:00 2001
+From f859d654fac4369472448e763ce4e2c7c4591d96 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
 Subject: [PATCH 066/103] loongarch: fix missing dependency info in DSDT

--- a/runtime-kernel/linux-kernel/autobuild/patches/0067-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0067-loongarch-fix-DMA-address-offset.patch
@@ -1,4 +1,4 @@
-From 20a748872b126c15e1e93e652603431cb8d76734 Mon Sep 17 00:00:00 2001
+From 330da3c77c226a950caad49c88e7de20d0eea30c Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
 Subject: [PATCH 067/103] loongarch: fix DMA address offset

--- a/runtime-kernel/linux-kernel/autobuild/patches/0068-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0068-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,4 +1,4 @@
-From 0962e48aa3825ba4a1a60720a1619b345543391c Mon Sep 17 00:00:00 2001
+From 2ef9fbaf65a3d2062d9b54223541d61ede0369da Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
 Subject: [PATCH 068/103] loongarch: fix HT_RX_INT_TRANS register

--- a/runtime-kernel/linux-kernel/autobuild/patches/0069-ntsync-Introduce-NTSYNC_IOC_WAIT_ANY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0069-ntsync-Introduce-NTSYNC_IOC_WAIT_ANY.patch
@@ -1,4 +1,4 @@
-From 5289a2d294c0393110af11193e0b3547a0a4928a Mon Sep 17 00:00:00 2001
+From f29b6f9e1819c61516caf01b9362341cc02aae1b Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:27 -0500
 Subject: [PATCH 069/103] ntsync: Introduce NTSYNC_IOC_WAIT_ANY.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0070-ntsync-Introduce-NTSYNC_IOC_WAIT_ALL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0070-ntsync-Introduce-NTSYNC_IOC_WAIT_ALL.patch
@@ -1,4 +1,4 @@
-From 66504510694fbb7646e6b931aec717902806b562 Mon Sep 17 00:00:00 2001
+From 3fed7ee1bbfe7af6655160a6fc60644b5b060a23 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:28 -0500
 Subject: [PATCH 070/103] ntsync: Introduce NTSYNC_IOC_WAIT_ALL.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0071-ntsync-Introduce-NTSYNC_IOC_CREATE_MUTEX.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0071-ntsync-Introduce-NTSYNC_IOC_CREATE_MUTEX.patch
@@ -1,4 +1,4 @@
-From 20c9d4c64dc63551190924c4d6b673d2a1e1ef30 Mon Sep 17 00:00:00 2001
+From d9e98c2c1c7e273da42ec476f60c59f2628dc300 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:29 -0500
 Subject: [PATCH 071/103] ntsync: Introduce NTSYNC_IOC_CREATE_MUTEX.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0072-ntsync-Introduce-NTSYNC_IOC_MUTEX_UNLOCK.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0072-ntsync-Introduce-NTSYNC_IOC_MUTEX_UNLOCK.patch
@@ -1,4 +1,4 @@
-From fd6654556825c0d9c817a9e093d718ff42538676 Mon Sep 17 00:00:00 2001
+From 69f6603d556767aac370f3048bab7b29e92faa99 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:30 -0500
 Subject: [PATCH 072/103] ntsync: Introduce NTSYNC_IOC_MUTEX_UNLOCK.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0073-ntsync-Introduce-NTSYNC_IOC_MUTEX_KILL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0073-ntsync-Introduce-NTSYNC_IOC_MUTEX_KILL.patch
@@ -1,4 +1,4 @@
-From fc8ef7eea8f289744213f9cd9dce1b0a6ce93280 Mon Sep 17 00:00:00 2001
+From 4174686c50c5f9b2d53eaed08271e935d0fdc5cb Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:31 -0500
 Subject: [PATCH 073/103] ntsync: Introduce NTSYNC_IOC_MUTEX_KILL.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0074-ntsync-Introduce-NTSYNC_IOC_CREATE_EVENT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0074-ntsync-Introduce-NTSYNC_IOC_CREATE_EVENT.patch
@@ -1,4 +1,4 @@
-From f4ec6b8241b19bad0fd4d377c8048d16b88cd093 Mon Sep 17 00:00:00 2001
+From d4931fcdadacc849e1c9eed1910f853eed05bce2 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:32 -0500
 Subject: [PATCH 074/103] ntsync: Introduce NTSYNC_IOC_CREATE_EVENT.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0075-ntsync-Introduce-NTSYNC_IOC_EVENT_SET.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0075-ntsync-Introduce-NTSYNC_IOC_EVENT_SET.patch
@@ -1,4 +1,4 @@
-From 92b3d616787fd0a967a08b397c9e95d4bf6e93e1 Mon Sep 17 00:00:00 2001
+From 0789dd6cd898fd91783ab2fbaaebe78127e27d68 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:33 -0500
 Subject: [PATCH 075/103] ntsync: Introduce NTSYNC_IOC_EVENT_SET.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0076-ntsync-Introduce-NTSYNC_IOC_EVENT_RESET.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0076-ntsync-Introduce-NTSYNC_IOC_EVENT_RESET.patch
@@ -1,4 +1,4 @@
-From 10c582b2a977334e50cce35df2bfe27a3db7f512 Mon Sep 17 00:00:00 2001
+From 6f725577f95fa1d5f1e7f38963b06eeebb574bcd Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:34 -0500
 Subject: [PATCH 076/103] ntsync: Introduce NTSYNC_IOC_EVENT_RESET.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0077-ntsync-Introduce-NTSYNC_IOC_EVENT_PULSE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0077-ntsync-Introduce-NTSYNC_IOC_EVENT_PULSE.patch
@@ -1,4 +1,4 @@
-From 723f4bfcb399714e0a74f327281d313bfe6e6e46 Mon Sep 17 00:00:00 2001
+From 925e8fe5683f6ad6c419688fc2718f72acc67498 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:35 -0500
 Subject: [PATCH 077/103] ntsync: Introduce NTSYNC_IOC_EVENT_PULSE.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0078-ntsync-Introduce-NTSYNC_IOC_SEM_READ.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0078-ntsync-Introduce-NTSYNC_IOC_SEM_READ.patch
@@ -1,4 +1,4 @@
-From 40b08a859fd2c63d06d4d42d3fcef15046714376 Mon Sep 17 00:00:00 2001
+From d8bd72cc602a7896356f62946376c461a37076c0 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:36 -0500
 Subject: [PATCH 078/103] ntsync: Introduce NTSYNC_IOC_SEM_READ.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0079-ntsync-Introduce-NTSYNC_IOC_MUTEX_READ.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0079-ntsync-Introduce-NTSYNC_IOC_MUTEX_READ.patch
@@ -1,4 +1,4 @@
-From db009013fe08cb6a7bd8eefa5a84bc37716242e4 Mon Sep 17 00:00:00 2001
+From cbdc785290e49fdd08e034a26d71fd7020f52664 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:37 -0500
 Subject: [PATCH 079/103] ntsync: Introduce NTSYNC_IOC_MUTEX_READ.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0080-ntsync-Introduce-NTSYNC_IOC_EVENT_READ.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0080-ntsync-Introduce-NTSYNC_IOC_EVENT_READ.patch
@@ -1,4 +1,4 @@
-From 4dd7bace62b90150c00a3bd9e7f6aff25dcc05c7 Mon Sep 17 00:00:00 2001
+From 40c9bd8e607ab57e6da48cfe727dcb1b812cae0e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:38 -0500
 Subject: [PATCH 080/103] ntsync: Introduce NTSYNC_IOC_EVENT_READ.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0081-ntsync-Introduce-alertable-waits.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0081-ntsync-Introduce-alertable-waits.patch
@@ -1,4 +1,4 @@
-From f30d4439fe601ad445628ed2b8f828e39bfc0517 Mon Sep 17 00:00:00 2001
+From 845147892ec14877e56686e6801ee47dffbeecee Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:39 -0500
 Subject: [PATCH 081/103] ntsync: Introduce alertable waits.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0082-selftests-ntsync-Add-some-tests-for-semaphore-state.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0082-selftests-ntsync-Add-some-tests-for-semaphore-state.patch
@@ -1,4 +1,4 @@
-From 6f3310abc7128c9a07a218b3b497cc05263ca986 Mon Sep 17 00:00:00 2001
+From e458fff07efbb7b4c3fb38ccbc45e08d7176f8e2 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:40 -0500
 Subject: [PATCH 082/103] selftests: ntsync: Add some tests for semaphore

--- a/runtime-kernel/linux-kernel/autobuild/patches/0083-selftests-ntsync-Add-some-tests-for-mutex-state.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0083-selftests-ntsync-Add-some-tests-for-mutex-state.patch
@@ -1,4 +1,4 @@
-From fb9e53bc278581191d65ba56b71840a36da4d4b5 Mon Sep 17 00:00:00 2001
+From 3e59f10256a1b83c7db702d557dcb86c85753964 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:41 -0500
 Subject: [PATCH 083/103] selftests: ntsync: Add some tests for mutex state.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0084-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0084-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
@@ -1,4 +1,4 @@
-From 7da14759463228da4680d6556255251c9935b28e Mon Sep 17 00:00:00 2001
+From 0a1df5dca6e37392527a8a4601eb53c90a1a1584 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:42 -0500
 Subject: [PATCH 084/103] selftests: ntsync: Add some tests for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0085-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0085-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
@@ -1,4 +1,4 @@
-From 71f82696279f15ea49554a0d5c86476303d2fb34 Mon Sep 17 00:00:00 2001
+From bd7d39a397f50bb607484c460b2992b50153b587 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:43 -0500
 Subject: [PATCH 085/103] selftests: ntsync: Add some tests for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0086-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0086-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From f44cdad3e9e7ce668b7194b43b0db95413b70f77 Mon Sep 17 00:00:00 2001
+From 46c8b511631ce46e9d701d08013f94e4edbc2fa1 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:44 -0500
 Subject: [PATCH 086/103] selftests: ntsync: Add some tests for wakeup

--- a/runtime-kernel/linux-kernel/autobuild/patches/0087-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0087-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From 4f9529cefc0afb35c0cbc772c3e7ae6b2b109ed0 Mon Sep 17 00:00:00 2001
+From 9c00765e6abf77d1010fdffbc0bf60240622210e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:45 -0500
 Subject: [PATCH 087/103] selftests: ntsync: Add some tests for wakeup

--- a/runtime-kernel/linux-kernel/autobuild/patches/0088-selftests-ntsync-Add-some-tests-for-manual-reset-eve.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0088-selftests-ntsync-Add-some-tests-for-manual-reset-eve.patch
@@ -1,4 +1,4 @@
-From e05bf2d05bdc650890e5bb14a3313999463705f3 Mon Sep 17 00:00:00 2001
+From 63b7b700dde2b639fd3ba7e40f0eea1e0cc6618e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:46 -0500
 Subject: [PATCH 088/103] selftests: ntsync: Add some tests for manual-reset

--- a/runtime-kernel/linux-kernel/autobuild/patches/0089-selftests-ntsync-Add-some-tests-for-auto-reset-event.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0089-selftests-ntsync-Add-some-tests-for-auto-reset-event.patch
@@ -1,4 +1,4 @@
-From 2f9f6ee86a2d88efbc5118a87f47572773806a3e Mon Sep 17 00:00:00 2001
+From 58ec15dd73917edf8af294d8956d05408f712cf2 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:47 -0500
 Subject: [PATCH 089/103] selftests: ntsync: Add some tests for auto-reset

--- a/runtime-kernel/linux-kernel/autobuild/patches/0090-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0090-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From bd5e52c3e136a0b446621399cb6d22416f805cb7 Mon Sep 17 00:00:00 2001
+From dccd46139c71f3a8416b205aa357ce86af3e7618 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:48 -0500
 Subject: [PATCH 090/103] selftests: ntsync: Add some tests for wakeup

--- a/runtime-kernel/linux-kernel/autobuild/patches/0091-selftests-ntsync-Add-tests-for-alertable-waits.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0091-selftests-ntsync-Add-tests-for-alertable-waits.patch
@@ -1,4 +1,4 @@
-From c79b7d74cc0b29151631aed2da27cb827f51029e Mon Sep 17 00:00:00 2001
+From 04194a960e52e2f6ec1d5ab5de1395bbf0477d83 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:49 -0500
 Subject: [PATCH 091/103] selftests: ntsync: Add tests for alertable waits.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0092-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0092-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From 88136ca85da06922dc7d6c2160e2de739852aa33 Mon Sep 17 00:00:00 2001
+From 1108bfd95f67dd34875cea045e81e33712f0e584 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:50 -0500
 Subject: [PATCH 092/103] selftests: ntsync: Add some tests for wakeup

--- a/runtime-kernel/linux-kernel/autobuild/patches/0093-selftests-ntsync-Add-a-stress-test-for-contended-wai.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0093-selftests-ntsync-Add-a-stress-test-for-contended-wai.patch
@@ -1,4 +1,4 @@
-From 52504fca54c6f17185eece0ec667f49023d50ee9 Mon Sep 17 00:00:00 2001
+From eaf86f6f5e2fb6f7325ce7dc9591daa763238d76 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:51 -0500
 Subject: [PATCH 093/103] selftests: ntsync: Add a stress test for contended

--- a/runtime-kernel/linux-kernel/autobuild/patches/0094-maintainers-Add-an-entry-for-ntsync.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0094-maintainers-Add-an-entry-for-ntsync.patch
@@ -1,4 +1,4 @@
-From 8df7a010ebb5eacc422fc6829a95c3732587e7de Mon Sep 17 00:00:00 2001
+From 41723721c2761c607a023c74a17789fbae25eab5 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:52 -0500
 Subject: [PATCH 094/103] maintainers: Add an entry for ntsync.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0095-docs-ntsync-Add-documentation-for-the-ntsync-uAPI.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0095-docs-ntsync-Add-documentation-for-the-ntsync-uAPI.patch
@@ -1,4 +1,4 @@
-From 2057d7b5f5ab45fa0e66a4684bd453f6d37065a5 Mon Sep 17 00:00:00 2001
+From c680fcfb8197e9ac315f6dfcc3004acfa3235d23 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:53 -0500
 Subject: [PATCH 095/103] docs: ntsync: Add documentation for the ntsync uAPI.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0096-ntsync-No-longer-depend-on-BROKEN.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0096-ntsync-No-longer-depend-on-BROKEN.patch
@@ -1,4 +1,4 @@
-From 1d6116069d4e6668825310bd0bbc53e2c2a58728 Mon Sep 17 00:00:00 2001
+From 713f046a4a57e77f0fccb937e66f96e264720bed Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:54 -0500
 Subject: [PATCH 096/103] ntsync: No longer depend on BROKEN.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0097-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0097-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
@@ -1,35 +1,41 @@
-From 37dd8dd1eec525a13438c6458e5815ba5565d067 Mon Sep 17 00:00:00 2001
-From: Mingcong Bai <jeffbai@aosc.xyz>
-Date: Wed, 21 Feb 2024 16:58:32 -0500
+From fec7a8902853c96296b309d8bead04e26521d233 Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Wed, 28 Aug 2024 03:09:24 +0800
 Subject: [PATCH 097/103] arch/loongarch: add la_ow_syscall as in-tree module
 
 Co-authored-By: Miao Wang <shankerwangmiao@gmail.com>
-Ref: https://github.com/AOSC-Dev/la_ow_syscall
+Ref: https://github.com/AOSC-Dev/la_ow_syscall/tree/492c16dc5f6d2a8606b25077086a42cb4b0347ea
 ---
  arch/loongarch/Kbuild                         |   2 +
- arch/loongarch/ow_syscall/Kbuild              |  26 ++
+ arch/loongarch/ow_syscall/Kbuild              |  38 ++
  arch/loongarch/ow_syscall/LICENSE             | 339 ++++++++++++++++++
  arch/loongarch/ow_syscall/Makefile            |  37 ++
- arch/loongarch/ow_syscall/README.md           |  74 ++++
+ arch/loongarch/ow_syscall/README.md           |  77 ++++
  arch/loongarch/ow_syscall/VERSION             |   1 +
- arch/loongarch/ow_syscall/dkms.conf.in        |   7 +
- arch/loongarch/ow_syscall/fsstat.c            |  84 +++++
- arch/loongarch/ow_syscall/fsstat.h            |   3 +
- .../loongarch/ow_syscall/la_ow_syscall_main.c | 326 +++++++++++++++++
- arch/loongarch/ow_syscall/signal.c            | 222 ++++++++++++
- arch/loongarch/ow_syscall/signal.h            |  41 +++
- 12 files changed, 1162 insertions(+)
+ arch/loongarch/ow_syscall/dkms.conf.in        |  11 +
+ arch/loongarch/ow_syscall/feat_test.c         |  16 +
+ arch/loongarch/ow_syscall/fsstat.c            |  87 +++++
+ arch/loongarch/ow_syscall/fsstat.h            |   4 +
+ .../loongarch/ow_syscall/la_ow_syscall_main.c | 274 ++++++++++++++
+ arch/loongarch/ow_syscall/signal.c            | 239 ++++++++++++
+ arch/loongarch/ow_syscall/signal.h            |  44 +++
+ arch/loongarch/ow_syscall/systable.c          |  65 ++++
+ arch/loongarch/ow_syscall/systable.h          |   8 +
+ 15 files changed, 1242 insertions(+)
  create mode 100644 arch/loongarch/ow_syscall/Kbuild
  create mode 100644 arch/loongarch/ow_syscall/LICENSE
  create mode 100644 arch/loongarch/ow_syscall/Makefile
  create mode 100644 arch/loongarch/ow_syscall/README.md
  create mode 100644 arch/loongarch/ow_syscall/VERSION
  create mode 100644 arch/loongarch/ow_syscall/dkms.conf.in
+ create mode 100644 arch/loongarch/ow_syscall/feat_test.c
  create mode 100644 arch/loongarch/ow_syscall/fsstat.c
  create mode 100644 arch/loongarch/ow_syscall/fsstat.h
  create mode 100644 arch/loongarch/ow_syscall/la_ow_syscall_main.c
  create mode 100644 arch/loongarch/ow_syscall/signal.c
  create mode 100644 arch/loongarch/ow_syscall/signal.h
+ create mode 100644 arch/loongarch/ow_syscall/systable.c
+ create mode 100644 arch/loongarch/ow_syscall/systable.h
 
 diff --git a/arch/loongarch/Kbuild b/arch/loongarch/Kbuild
 index bfa21465d83af..52ddcb17537ce 100644
@@ -43,10 +49,10 @@ index bfa21465d83af..52ddcb17537ce 100644
 +obj-y += ow_syscall/
 diff --git a/arch/loongarch/ow_syscall/Kbuild b/arch/loongarch/ow_syscall/Kbuild
 new file mode 100644
-index 0000000000000..f3921c3fd96db
+index 0000000000000..65cd78995176f
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kbuild
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,38 @@
 +# SPDX-License-Identifier: GPL-2.0
 +#
 +# Makefile for LoongArch old-world syscall compatible layer.
@@ -57,22 +63,34 @@ index 0000000000000..f3921c3fd96db
 +endif
 +
 +obj-$(CONFIG_LOONGARCH_OW_SYSCALL) += la_ow_syscall.o
-+la_ow_syscall-y += fsstat.o la_ow_syscall_main.o signal.o
++la_ow_syscall-y += fsstat.o la_ow_syscall_main.o signal.o systable.o
++targets += feat_test.o
 +
-+ifndef KBUILD_EXTMOD
-+  ifdef CONFIG_KALLSYMS
-+$(obj)/ksym_addr.h: System.map
++$(obj)/kernel_feature.h: $(obj)/feat_test.syms
 +	@$(kecho) '  GEN     $@'
-+	$(Q)grep ' sys_call_table$$' $< >/dev/null
-+	$(Q)grep ' kallsyms_lookup_name$$' $< >/dev/null
-+	$(Q)grep ' system_state$$' $< >/dev/null
-+	$(Q)echo "#define LAOWSYS_SYS_CALL_TABLE_ADDR 0x$$(grep ' sys_call_table$$' $< | cut -d ' ' -f 1)ul" > $@
-+	$(Q)echo "#define LAOWSYS_KALLSYMS_LOOKUP_NAME_ADDR 0x$$(grep ' kallsyms_lookup_name$$' $< | cut -d ' ' -f 1)ul" >> $@
-+	$(Q)echo "#define LAOWSYS_SYSTEM_STATE_ADDR 0x$$(grep ' system_state$$' $< | cut -d ' ' -f 1)ul" >> $@
-+ccflags-y += -DHAVE_KSYM_ADDR
-+$(obj)/$(la_ow_syscall-y): $(obj)/ksym_addr.h
-+  endif
-+endif
++	$(Q)if grep "kernel_have_new_stat" $< >/dev/null; then \
++		echo "#define KERNEL_HAVE_NEW_STAT"; \
++	    else \
++		echo "/* KERNEL_HAVE_NEW_STAT is not defined */"; \
++	    fi > $@
++	$(Q)if grep "kernel_have_systbl" $< >/dev/null; then \
++                echo "#define KERNEL_HAVE_SYSTBL"; \
++            else \
++                echo "/* KERNEL_HAVE_SYSTBL is not defined */"; \
++            fi >> $@
++
++$(obj)/feat_test.syms: $(obj)/feat_test.o
++	@$(kecho) '  GEN     $@'
++	$(Q)$(OBJDUMP) -t --section=.text $< >$@
++
++$(obj)/module_version.h: $(src)/VERSION
++	@$(kecho) '  GEN     $@'
++	$(Q)echo "#define THIS_MODULE_VERSION \"$(shell cat $<)\"" > $@
++
++$(obj)/systable.o $(obj)/fsstat.o: $(obj)/kernel_feature.h
++$(obj)/la_ow_syscall_main.o: $(obj)/module_version.h
++
++clean-files += kernel_feature.h feat_test.syms module_version.h
 diff --git a/arch/loongarch/ow_syscall/LICENSE b/arch/loongarch/ow_syscall/LICENSE
 new file mode 100644
 index 0000000000000..d159169d10508
@@ -463,10 +481,10 @@ index 0000000000000..e975aa1cdb7af
 +dev: modprobe-remove dkms-remove dkms-add dkms-build dkms-install modprobe-install
 diff --git a/arch/loongarch/ow_syscall/README.md b/arch/loongarch/ow_syscall/README.md
 new file mode 100644
-index 0000000000000..24ec0eae161f1
+index 0000000000000..25c6757983896
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/README.md
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,77 @@
 +la\_ow\_syscall
 +====
 +
@@ -480,6 +498,8 @@ index 0000000000000..24ec0eae161f1
 +Linux Kernel >= 6.1.0 for `loongarch64` with the following option(s) set:
 +
 +- `CONFIG_KALLSYMS=y` (for reading kernel symbol addresses).
++- `CONFIG_KPROBES=y` (for probing kernel symbol addresses using kernels where
++  base address randomisation - `CONFIG_RANDOMIZE_BASE` - is enabled).
 +
 +Installation
 +----
@@ -501,17 +521,18 @@ index 0000000000000..24ec0eae161f1
 +kernel module:
 +
 +```
-+# $PWD is the kernel source root.
++# $PWD is containing built objects
++# /path/to/source_dir is containing Linux source code
 +make \
-+    -C ${PWD} \
++    -C /path/to/source_dir \
 +    ARCH=loongarch \
-+    O=(pwd) \
++    O="$PWD" \
 +    arch/loongarch/ow_syscall/la_ow_syscall.ko \
 +    CONFIG_LOONGARCH_OW_SYSCALL=m
 +```
 +
 +Upon completion, copy the kernel module in place
-+(`/usr/lib/modules/.../arch/loongarch/ow_syscall/la_ow_syscall.ko`) and
++(`/lib/modules/.../arch/loongarch/ow_syscall/la_ow_syscall.ko`) and
 +re-generate modules.dep and map files:
 +
 +```
@@ -543,38 +564,65 @@ index 0000000000000..24ec0eae161f1
 +```
 diff --git a/arch/loongarch/ow_syscall/VERSION b/arch/loongarch/ow_syscall/VERSION
 new file mode 100644
-index 0000000000000..6c6aa7cb0918d
+index 0000000000000..17e51c385ea38
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/VERSION
 @@ -0,0 +1 @@
-+0.1.0
-\ No newline at end of file
++0.1.1
 diff --git a/arch/loongarch/ow_syscall/dkms.conf.in b/arch/loongarch/ow_syscall/dkms.conf.in
 new file mode 100644
-index 0000000000000..b2a3493106c24
+index 0000000000000..ad9aec128e6f8
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/dkms.conf.in
-@@ -0,0 +1,7 @@
+@@ -0,0 +1,11 @@
 +PACKAGE_NAME="la_ow_syscall"
 +PACKAGE_VERSION="VERSION"
++
++BUILD_EXCLUSIVE_KERNEL_MIN="5.19"
++BUILD_EXCLUSIVE_CONFIG="CONFIG_KALLSYMS"
++
 +MAKE="KDIR=/lib/modules/${kernelver}/build make"
 +CLEAN="make clean"
-+BUILT_MODULE_NAME[0]="la_ow_syscall"
++BUILT_MODULE_NAME[0]="$PACKAGE_NAME"
 +AUTOINSTALL="yes"
 +DEST_MODULE_LOCATION[0]="/extra"
+diff --git a/arch/loongarch/ow_syscall/feat_test.c b/arch/loongarch/ow_syscall/feat_test.c
+new file mode 100644
+index 0000000000000..5fc3b8709364d
+--- /dev/null
++++ b/arch/loongarch/ow_syscall/feat_test.c
+@@ -0,0 +1,16 @@
++/*
++  This file is used to test if the coresponding macro is defined in unistd.h
++    If a macro is defined, the coresponding function will be defined, and
++    the symbol will be shown in the .o file. Later, the Kbuild script will
++    generate kernel_feature.h according to the existence of the symbols.
++*/
++
++#include <asm/unistd.h>
++#ifdef __ARCH_WANT_NEW_STAT
++void kernel_have_new_stat(void);
++void kernel_have_new_stat(void){ }
++#endif
++#ifndef __SYSCALL
++void kernel_have_systbl(void);
++void kernel_have_systbl(void){ }
++#endif
 diff --git a/arch/loongarch/ow_syscall/fsstat.c b/arch/loongarch/ow_syscall/fsstat.c
 new file mode 100644
-index 0000000000000..e540d6ff2548c
+index 0000000000000..1f5c336f52ec1
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.c
-@@ -0,0 +1,84 @@
+@@ -0,0 +1,87 @@
 +#include <linux/syscalls.h>
 +#include <linux/uaccess.h>
 +#include <linux/errno.h>
 +#include <linux/file.h>
 +#include <linux/mm.h>
 +#include "fsstat.h"
++#include "kernel_feature.h"
 +
++#ifndef KERNEL_HAVE_NEW_STAT
 +#define INIT_STRUCT_STAT_PADDING(st) memset(&st, 0, sizeof(st))
 +
 +struct __old_kernel_stat {
@@ -652,25 +700,28 @@ index 0000000000000..e540d6ff2548c
 +		return error;
 +	return cp_new_stat(&stat, statbuf);
 +}
++#endif
 diff --git a/arch/loongarch/ow_syscall/fsstat.h b/arch/loongarch/ow_syscall/fsstat.h
 new file mode 100644
-index 0000000000000..7c970ad8fd009
+index 0000000000000..fa40914afa414
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.h
-@@ -0,0 +1,3 @@
+@@ -0,0 +1,4 @@
++#include <linux/stat.h>
 +extern int (*p_vfs_fstatat)(int dfd, const char __user *filename,
 +			    struct kstat *stat, int flags);
 +extern int (*p_vfs_fstat)(int fd, struct kstat *stat);
 diff --git a/arch/loongarch/ow_syscall/la_ow_syscall_main.c b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 new file mode 100644
-index 0000000000000..3308ef082539e
+index 0000000000000..4ae3fc6d70785
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
-@@ -0,0 +1,326 @@
+@@ -0,0 +1,274 @@
 +#include <linux/module.h> /* Needed by all modules */
 +#include <linux/kernel.h> /* Needed for KERN_INFO */
 +#include <linux/init.h> /* Needed for the macros */
 +#include <linux/kprobes.h> /* Needed for kprobe calls */
++#include "module_version.h"
 +
 +///< The license type -- this affects runtime behavior
 +MODULE_LICENSE("GPL");
@@ -682,77 +733,26 @@ index 0000000000000..3308ef082539e
 +MODULE_DESCRIPTION("LoongArch old-world syscall compatibility module");
 +
 +///< The version of the module
-+MODULE_VERSION("0.1.0");
++MODULE_VERSION(THIS_MODULE_VERSION);
 +
 +#include <linux/kallsyms.h>
 +#include <linux/syscalls.h>
++
++#include "systable.h"
 +
 +#define __EXTERN
 +#include "fsstat.h"
 +#include "signal.h"
 +
-+#define __ARCH_WANT_SET_GET_RLIMIT
-+#define __ARCH_WANT_NEW_STAT
-+#undef __SYSCALL
-+#define __SYSCALL(nr, call) [nr] = (#call),
-+
-+const char *sys_call_table_name[__NR_syscalls] = {
-+	[0 ... __NR_syscalls - 1] = "sys_ni_syscall",
-+#include <asm/unistd.h>
-+};
-+
 +#ifndef __loongarch64
 +#error This Linux kernel module is only supported on LoongArch
 +#endif
-+
-+#ifdef HAVE_KSYM_ADDR
-+#include "ksym_addr.h"
-+#endif
-+
-+static struct {
-+	long syscall_num;
-+	void *symbol_addr;
-+	void *orig;
-+} syscall_to_replace[] = {
-+	{ __NR_fstat, sys_newfstat },
-+	{ __NR_newfstatat, sys_newfstatat },
-+	{ __NR_getrlimit, NULL },
-+	{ __NR_setrlimit, NULL },
-+	{ __NR_rt_sigprocmask, sys_rt_sigprocmask },
-+	{ __NR_rt_sigpending, sys_rt_sigpending },
-+	{ __NR_rt_sigtimedwait, sys_rt_sigtimedwait },
-+	{ __NR_rt_sigaction, sys_rt_sigaction },
-+	{ __NR_rt_sigsuspend, sys_rt_sigsuspend },
-+	{ __NR_pselect6, sys_pselect6 },
-+#ifdef CONFIG_SIGNALFD
-+	{ __NR_signalfd4, sys_signalfd4 },
-+#endif
-+#ifdef CONFIG_EPOLL
-+	{ __NR_epoll_pwait, sys_epoll_pwait },
-+	{ __NR_epoll_pwait2, sys_epoll_pwait2 },
-+#endif
-+};
-+
-+#define nr_syscalls_to_replace \
-+	(sizeof(syscall_to_replace) / sizeof(syscall_to_replace[0]))
 +
 +static unsigned long kallsyms_lookup_name_addr = 0;
 +static unsigned int allow_mod_unreg = 0;
 +
 +#include <asm-generic/sections.h>
 +
-+#ifdef HAVE_KSYM_ADDR
-+static int __init find_kallsyms_lookup_name(void)
-+{
-+	unsigned long offset =
-+		(unsigned long)&system_state - LAOWSYS_SYSTEM_STATE_ADDR;
-+	pr_debug("kernel offset = %lx\n", offset);
-+	kallsyms_lookup_name_addr = offset + LAOWSYS_KALLSYMS_LOOKUP_NAME_ADDR;
-+	pr_debug("using kallsyms_lookup_name @ %p\n",
-+		 (void *)kallsyms_lookup_name_addr);
-+	return 0;
-+}
-+#else
 +// Taken from https://github.com/zizzu0/LinuxKernelModules/blob/main/FindKallsymsLookupName.c
 +#define KPROBE_PRE_HANDLER(fname) \
 +	static int __kprobes fname(struct kprobe *p, struct pt_regs *regs)
@@ -793,10 +793,8 @@ index 0000000000000..3308ef082539e
 +	return ret;
 +}
 +
-+static int __init find_kallsyms_lookup_name(void)
++static int __init kprobe_kallsyms_lookup_name(void)
 +{
-+	char fn_name[KSYM_SYMBOL_LEN];
-+
 +	int ret = 0;
 +
 +	ret = do_register_kprobe(&kp0, "kallsyms_lookup_name", handler_pre0);
@@ -812,9 +810,26 @@ index 0000000000000..3308ef082539e
 +	unregister_kprobe(&kp0);
 +	unregister_kprobe(&kp1);
 +
++	return ret;
++}
++
++
++static int __init find_kallsyms_lookup_name(void)
++{
++	char fn_name[KSYM_SYMBOL_LEN];
++
++	int ret = 0;
++
 +	if (kallsyms_lookup_name_addr == 0 ||
 +	    kallsyms_lookup_name_addr == (unsigned long)-1) {
-+		return -EINVAL;
++		ret = kprobe_kallsyms_lookup_name();
++		if ( ret < 0 ) {
++			return ret;
++		}
++		if (kallsyms_lookup_name_addr == 0 ||
++		    kallsyms_lookup_name_addr == (unsigned long)-1) {
++			return -EINVAL;
++		}
 +	}
 +	sprint_symbol(fn_name, kallsyms_lookup_name_addr);
 +	if (strncmp(fn_name, "kallsyms_lookup_name+0x0",
@@ -828,8 +843,6 @@ index 0000000000000..3308ef082539e
 +		return -EINVAL;
 +	}
 +}
-+#endif
-+
 +
 +int (*p_vfs_fstatat)(int dfd, const char __user *filename, struct kstat *stat,
 +		     int flags);
@@ -850,7 +863,7 @@ index 0000000000000..3308ef082539e
 +	__rel(sys_clone),	  __rel(sys_rt_sigprocmask),
 +	__rel(sys_rt_sigpending), __rel(sys_rt_sigtimedwait),
 +	__rel(sys_rt_sigaction),  __rel(sys_rt_sigsuspend),
-+	__rel(sys_pselect6),
++	__rel(sys_pselect6),	  __rel(sys_ppoll),
 +#ifdef CONFIG_SIGNALFD
 +	__rel(sys_signalfd4),
 +#endif
@@ -861,18 +874,6 @@ index 0000000000000..3308ef082539e
 +#define nr_rel_tab (sizeof(relocation_table) / sizeof(relocation_table[0]))
 +
 +static void **p_sys_call_table;
-+
-+#ifdef HAVE_KSYM_ADDR
-+static int __init find_sys_call_table(void)
-+{
-+	unsigned long offset =
-+		(unsigned long)&system_state - LAOWSYS_SYSTEM_STATE_ADDR;
-+	pr_debug("kernel offset = %lx\n", offset);
-+	p_sys_call_table = (void **)(offset + LAOWSYS_SYS_CALL_TABLE_ADDR);
-+	pr_debug("using sys_call_table @ %p\n", p_sys_call_table);
-+	return 0;
-+}
-+#else
 +
 +#include <linux/jiffies.h>
 +#include <linux/reboot.h>
@@ -910,7 +911,6 @@ index 0000000000000..3308ef082539e
 +
 +	return -ENOSYS;
 +}
-+#endif
 +
 +static int __init oldsyscall_start(void)
 +{
@@ -937,7 +937,7 @@ index 0000000000000..3308ef082539e
 +	if (rc < 0) {
 +		return rc;
 +	}
-+	for (int i = 0; i < nr_syscalls_to_replace; i++) {
++	for (int i = 0; syscall_to_replace[i].syscall_num != -1; i++) {
 +		if (syscall_to_replace[i].symbol_addr) {
 +			continue;
 +		}
@@ -959,7 +959,7 @@ index 0000000000000..3308ef082539e
 +			return -EINVAL;
 +		}
 +	}
-+	for (int i = 0; i < nr_syscalls_to_replace; i++) {
++	for (int i = 0; syscall_to_replace[i].syscall_num != -1; i++) {
 +		pr_debug("will replace syscall_%ld with %px, orig %px\n",
 +			 syscall_to_replace[i].syscall_num,
 +			 syscall_to_replace[i].symbol_addr,
@@ -975,7 +975,7 @@ index 0000000000000..3308ef082539e
 +
 +static void __exit oldsyscall_end(void)
 +{
-+	for (int i = 0; i < nr_syscalls_to_replace; i++) {
++	for (int i = 0; syscall_to_replace[i].syscall_num != -1; i++) {
 +		pr_debug("will restore syscall_%ld to %px\n",
 +			 syscall_to_replace[i].syscall_num,
 +			 syscall_to_replace[i].orig);
@@ -989,16 +989,14 @@ index 0000000000000..3308ef082539e
 +module_param(allow_mod_unreg, uint, 0000);
 +MODULE_PARM_DESC(allow_mod_unreg,
 +		 "Allow this module to be unload (Danger! Debug use only)");
-+#ifndef HAVE_KSYM_ADDR
 +module_param(kallsyms_lookup_name_addr, ulong, 0000);
-+MODULE_PARM_DESC(kallsyms_lookup_name_addr, "Address for kallsyms_lookup_name");
-+#endif
++MODULE_PARM_DESC(kallsyms_lookup_name_addr, "Address for kallsyms_lookup_name, provide this when unable to find using kprobe");
 diff --git a/arch/loongarch/ow_syscall/signal.c b/arch/loongarch/ow_syscall/signal.c
 new file mode 100644
-index 0000000000000..1593fdba30c26
+index 0000000000000..90eb34727680d
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.c
-@@ -0,0 +1,222 @@
+@@ -0,0 +1,239 @@
 +#include <linux/syscalls.h>
 +#include <linux/uaccess.h>
 +#include <linux/errno.h>
@@ -1158,6 +1156,23 @@ index 0000000000000..1593fdba30c26
 +	}
 +}
 +
++__SYSCALL_DEFINEx(5, _ppoll, struct pollfd __user *, ufds, unsigned int, nfds,
++		struct __kernel_timespec __user *, tsp, const sigset_t __user *, sigmask,
++		size_t, sigsetsize)
++{
++	if (sigmask == NULL || sigsetsize == sizeof(sigset_t)) {
++		return p_sys_ppoll(ufds, nfds, tsp, sigmask, sigsetsize);
++	} else if (sigsetsize == sizeof(_la_ow_sigset_t)) {
++		int rc = p_sys_ppoll(ufds, nfds, tsp, sigmask, sizeof(sigset_t));
++		if (rc < 0) {
++			return rc;
++		}
++		return rc;
++	} else {
++		return -EINVAL;
++	}
++}
++
 +#ifdef CONFIG_EPOLL
 +
 +__SYSCALL_DEFINEx(6, _epoll_pwait, int, epfd, struct epoll_event __user *,
@@ -1223,10 +1238,10 @@ index 0000000000000..1593fdba30c26
 +#endif
 diff --git a/arch/loongarch/ow_syscall/signal.h b/arch/loongarch/ow_syscall/signal.h
 new file mode 100644
-index 0000000000000..a640b39e982d3
+index 0000000000000..adcd53bedc662
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.h
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,44 @@
 +#include <linux/syscalls.h>
 +
 +#ifndef __EXTERN
@@ -1254,6 +1269,9 @@ index 0000000000000..a640b39e982d3
 +P__SYSCALL_DEFINEx(6, _pselect6, int, n, fd_set __user *, inp, fd_set __user *,
 +		   outp, fd_set __user *, exp,
 +		   struct __kernel_timespec __user *, tsp, void __user *, sig);
++P__SYSCALL_DEFINEx(5, _ppoll, struct pollfd __user *, ufds, unsigned int, nfds,
++		struct __kernel_timespec __user *, tsp, const sigset_t __user *, sigmask,
++		size_t, sigsetsize);
 +#ifdef CONFIG_SIGNALFD
 +P__SYSCALL_DEFINEx(4, _signalfd4, int, ufd, sigset_t __user *, user_mask,
 +		   size_t, sizemask, int, flags);
@@ -1268,6 +1286,91 @@ index 0000000000000..a640b39e982d3
 +		   const sigset_t __user *, sigmask, size_t, sigsetsize);
 +#undef P__SYSCALL_DEFINEx
 +#endif
+diff --git a/arch/loongarch/ow_syscall/systable.c b/arch/loongarch/ow_syscall/systable.c
+new file mode 100644
+index 0000000000000..8b311954d62ef
+--- /dev/null
++++ b/arch/loongarch/ow_syscall/systable.c
+@@ -0,0 +1,65 @@
++#include "systable.h"
++#include "kernel_feature.h"
++
++/*
++  In 6.11 or newer, the asm-generic/unistd.h is not used by the loongarch
++    asm/unistd.h. Instead, the definition of the syscall table and the syscall
++    numbers is generated after commit 26a3b85bac08 ("loongarch: convert to
++    generic syscall table"). As a result, we can no more get the definition of
++    those syscalls that are not available on Loongarch.
++
++  To solve this problem, we still use asm-generic/unistd.h to retrive the
++    definitions.
++
++  To avoid any possible conflicts, only syscall related data are defined here.
++    No functions are implemented here, so the above hacks will not affect other
++    parts of our module and will not introduce unexpected changes related to the
++    syscall numbers, ensuring the consistence of our module with the kernel.
++*/
++
++#include <asm-generic/unistd.h>
++
++/*
++  And we also need those hacks to prevent including asm/unistd.h, which will
++    cause redefinition of the syscall numbers.
++*/
++
++#define _LINUX_UNISTD_H_	/* prevent loading uapi/linux/unistd.h */
++#define __ASM_VDSO_H		/* prevent loading asm/vdso.h */
++#define _ASM_SECCOMP_H		/* prevent loading asm/seccomp.h */
++#include <linux/syscalls.h>
++
++#define __ARCH_WANT_SET_GET_RLIMIT
++#define __ARCH_WANT_NEW_STAT
++
++#undef __SYSCALL
++#define __SYSCALL(nr, call) [nr] = (#call),
++
++const char *sys_call_table_name[__NR_syscalls] = {
++	[0 ... __NR_syscalls - 1] = "sys_ni_syscall",
++#include <asm-generic/unistd.h>
++};
++
++struct syscall_replace_table syscall_to_replace[] = {
++#ifndef KERNEL_HAVE_NEW_STAT
++	{ __NR_fstat, sys_newfstat },
++	{ __NR_newfstatat, sys_newfstatat },
++#endif
++	{ __NR_getrlimit, NULL },
++	{ __NR_setrlimit, NULL },
++	{ __NR_rt_sigprocmask, sys_rt_sigprocmask },
++	{ __NR_rt_sigpending, sys_rt_sigpending },
++	{ __NR_rt_sigtimedwait, sys_rt_sigtimedwait },
++	{ __NR_rt_sigaction, sys_rt_sigaction },
++	{ __NR_rt_sigsuspend, sys_rt_sigsuspend },
++	{ __NR_pselect6, sys_pselect6 },
++	{ __NR_ppoll, sys_ppoll },
++#ifdef CONFIG_SIGNALFD
++	{ __NR_signalfd4, sys_signalfd4 },
++#endif
++#ifdef CONFIG_EPOLL
++	{ __NR_epoll_pwait, sys_epoll_pwait },
++	{ __NR_epoll_pwait2, sys_epoll_pwait2 },
++#endif
++	{ -1, NULL },
++};
+diff --git a/arch/loongarch/ow_syscall/systable.h b/arch/loongarch/ow_syscall/systable.h
+new file mode 100644
+index 0000000000000..f2b6602cc7ef4
+--- /dev/null
++++ b/arch/loongarch/ow_syscall/systable.h
+@@ -0,0 +1,8 @@
++struct syscall_replace_table {
++        long syscall_num;
++        void *symbol_addr;
++        void *orig;
++};
++
++extern const char *sys_call_table_name[];
++extern struct syscall_replace_table syscall_to_replace[];
 -- 
 2.46.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0098-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0098-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,4 +1,4 @@
-From eba89deb4c9688fd5bc60bbece2d3e93d16f7828 Mon Sep 17 00:00:00 2001
+From eedc70c89dbc12e4ac1ef29430f187c509ecf7ab Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
 Subject: [PATCH 098/103] la_ow_syscall: add kconfig for module

--- a/runtime-kernel/linux-kernel/autobuild/patches/0099-platform-x86-ideapad-laptop-add-fixes-for-ThinkBook-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0099-platform-x86-ideapad-laptop-add-fixes-for-ThinkBook-.patch
@@ -1,4 +1,4 @@
-From 1d9d9f165130c5688d1be64ac967e62ad6a7f7af Mon Sep 17 00:00:00 2001
+From ed942308560c9d9b61bb2d42181c40202778fa5a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 17 Aug 2024 11:32:11 +0800
 Subject: [PATCH 099/103] platform: x86: ideapad-laptop: add fixes for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0100-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0100-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
@@ -1,4 +1,4 @@
-From c8ec0e10304166479ff5ecd8761f3c69a57762bd Mon Sep 17 00:00:00 2001
+From 9c5a45f6e92d426d47d290f05f5662e7bc747a60 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:43:11 +0800
 Subject: [PATCH 100/103] [LOONGARCH64] drivers/firmware: Move sysfb_init()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0101-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0101-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
@@ -1,4 +1,4 @@
-From c4398ade8a6923d5baa80d4df0b051c4fb0dd0ed Mon Sep 17 00:00:00 2001
+From c7ae2e5ae0b917ca9ff8e46742d8fa3bb760029c Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Mon, 11 Mar 2024 00:14:58 +0800
 Subject: [PATCH 101/103] [LOONGARCH64] drm/xe: fix build on non-4K kernels

--- a/runtime-kernel/linux-kernel/autobuild/patches/0102-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0102-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
@@ -1,4 +1,4 @@
-From bc17922d7c8a10d815dff984a021591a495aeb36 Mon Sep 17 00:00:00 2001
+From 9b20da1b48ec9b2658f763579326c795037dd726 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
 Subject: [PATCH 102/103] [LOONGARCH64] drm/radeon: Workaround radeon driver

--- a/runtime-kernel/linux-kernel/autobuild/patches/0103-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0103-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
@@ -1,4 +1,4 @@
-From 432739d360ce6dee5d855d8835e6b861fb93bb98 Mon Sep 17 00:00:00 2001
+From 57c18b0624dc1c4b5d1d532e6fef757479d0378b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 14:28:02 +0800
 Subject: [PATCH 103/103] [LOONGARCH64] drm/radeon: Call mmiowb() at the end of

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -1,4 +1,5 @@
 VER=6.10.6
+REL=1
 
 # Use this for stable releases.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- linux-kernel: update la_ow_syscall module
    - Track patches at https://github.com/AOSC-Tracking/linux @ aosc/v6.10.6, current HEAD is 5e30271e71d00d8d72de90e9216e902d7d5292cc.

Package(s) Affected
-------------------

- linux-kernel-6.10.6: 1:6.10.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
