### PR TITLE
gradle: update to 8.10.0

### DIFF
--- a/lang-java/gradle/spec
+++ b/lang-java/gradle/spec
@@ -1,4 +1,4 @@
-VER=8.9.0
+VER=8.10.0
 SRCS="tbl::https://services.gradle.org/distributions/gradle-${VER%.0}-all.zip"
-CHKSUMS="sha256::258e722ec21e955201e31447b0aed14201765a3bfbae296a46cf60b70e66db70"
+CHKSUMS="sha256::682b4df7fe5accdca84a4d1ef6a3a6ab096b3efd5edf7de2bd8c758d95a93703"
 CHKUPDATE="anitya::id=6088"


### PR DESCRIPTION
Topic Description
-----------------

- gradle: update to 8.10.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- gradle: 8.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gradle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
