### PR TITLE
tesseract: set default model directory to /usr/share/tessdata

### DIFF
--- a/app-utils/tesseract/autobuild/defines
+++ b/app-utils/tesseract/autobuild/defines
@@ -4,5 +4,5 @@ PKGDEP="leptonica icu cairo pango openjpeg libpng libtiff libjpeg-turbo giflib g
 PKGDES="An OCR program"
 
 ABTYPE=cmakeninja
-CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON"
+CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON -DTESSDATA_PREFIX=/usr/share"
 PKGBREAK="crow-translate<=2.11.1 opencv<=4.7.0-2 skanpage<=22.08.5"

--- a/app-utils/tesseract/spec
+++ b/app-utils/tesseract/spec
@@ -6,4 +6,4 @@ CHKSUMS="SKIP \
          SKIP"
 SUBDIR="tesseract"
 CHKUPDATE="anitya::id=4954"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- tesseract: set default model directory to /usr/share/tessdata

Package(s) Affected
-------------------

- tesseract: 5.4.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit tesseract
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
