### PR TITLE
curl: add patch for curl/curl#14344

### DIFF
--- a/app-web/curl/autobuild/patches/0001-sigpipe-init-the-struct-so-that-first-apply-ignores.patch
+++ b/app-web/curl/autobuild/patches/0001-sigpipe-init-the-struct-so-that-first-apply-ignores.patch
@@ -1,0 +1,35 @@
+From c943b56f30bab52e2da73d797bd41371a1a8820d Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 5 Aug 2024 00:17:17 +0200
+Subject: [PATCH] sigpipe: init the struct so that first apply ignores
+
+Initializes 'no_signal' to TRUE, so that a call to sigpipe_apply() after
+init ignores the signal (unless CURLOPT_NOSIGNAL) is set.
+
+I have read the existing code multiple times now and I think it gets the
+initial state reversed this missing to ignore.
+
+Regression from 17e6f06ea37136c36d27
+
+Reported-by: Rasmus Thomsen
+Fixes #14344
+Closes #14390
+---
+ lib/sigpipe.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/sigpipe.h b/lib/sigpipe.h
+index b91a2f513..d78afd905 100644
+--- a/lib/sigpipe.h
++++ b/lib/sigpipe.h
+@@ -39,6 +39,7 @@ struct sigpipe_ignore {
+ static void sigpipe_init(struct sigpipe_ignore *ig)
+ {
+   memset(ig, 0, sizeof(*ig));
++  ig->no_signal = TRUE;
+ }
+ 
+ /*
+-- 
+2.46.0.windows.1
+

--- a/app-web/curl/spec
+++ b/app-web/curl/spec
@@ -1,5 +1,5 @@
 VER=8.9.1
-REL=2
+REL=3
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
 CHKSUMS="sha256::f292f6cc051d5bbabf725ef85d432dfeacc8711dd717ea97612ae590643801e5"
 CHKUPDATE="anitya::id=381"

--- a/runtime-optenv32/curl+32/autobuild/patches/0001-sigpipe-init-the-struct-so-that-first-apply-ignores.patch
+++ b/runtime-optenv32/curl+32/autobuild/patches/0001-sigpipe-init-the-struct-so-that-first-apply-ignores.patch
@@ -1,0 +1,35 @@
+From c943b56f30bab52e2da73d797bd41371a1a8820d Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 5 Aug 2024 00:17:17 +0200
+Subject: [PATCH] sigpipe: init the struct so that first apply ignores
+
+Initializes 'no_signal' to TRUE, so that a call to sigpipe_apply() after
+init ignores the signal (unless CURLOPT_NOSIGNAL) is set.
+
+I have read the existing code multiple times now and I think it gets the
+initial state reversed this missing to ignore.
+
+Regression from 17e6f06ea37136c36d27
+
+Reported-by: Rasmus Thomsen
+Fixes #14344
+Closes #14390
+---
+ lib/sigpipe.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/sigpipe.h b/lib/sigpipe.h
+index b91a2f513..d78afd905 100644
+--- a/lib/sigpipe.h
++++ b/lib/sigpipe.h
+@@ -39,6 +39,7 @@ struct sigpipe_ignore {
+ static void sigpipe_init(struct sigpipe_ignore *ig)
+ {
+   memset(ig, 0, sizeof(*ig));
++  ig->no_signal = TRUE;
+ }
+ 
+ /*
+-- 
+2.46.0.windows.1
+

--- a/runtime-optenv32/curl+32/spec
+++ b/runtime-optenv32/curl+32/spec
@@ -1,4 +1,5 @@
 VER=8.9.1
+REL=1
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
 CHKSUMS="sha256::f292f6cc051d5bbabf725ef85d432dfeacc8711dd717ea97612ae590643801e5"
 CHKUPDATE="anitya::id=381"


### PR DESCRIPTION
Topic Description
-----------------

- curl+32: add patch for curl/curl#14344
- curl: add patch for curl/curl#14344

Package(s) Affected
-------------------

- curl: 8.9.1-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit curl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
