### PR TITLE
ghostwriter: update to 24.08.0

### DIFF
--- a/desktop-kde/ghostwriter/spec
+++ b/desktop-kde/ghostwriter/spec
@@ -1,4 +1,4 @@
-VER=23.08.5
+VER=24.08.0
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/ghostwriter-$VER.tar.xz"
-CHKSUMS="sha256::a0b75649441f3ee2ef6746b30231d85be1dd125836f8aadcc3e31e619cb4d0d9"
+CHKSUMS="sha256::54a16a02f11398a962fd184327d238c31c86ca968ae7f10d7502a301cc1782b1"
 CHKUPDATE="anitya::id=8763"


### PR DESCRIPTION
Topic Description
-----------------

- ghostwriter: update to 24.08.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- ghostwriter: 24.08.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ghostwriter
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
