### PR TITLE
clblast: new, 1.6.3

### DIFF
--- a/runtime-scientific/clblast/autobuild/defines
+++ b/runtime-scientific/clblast/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=clblast
+PKGSEC=libs
+PKGDEP="gcc-runtime opencl-registry-api"
+PKGDES="A tuned OpenCL BLAS library"
+
+ABTYPE=cmakeninja

--- a/runtime-scientific/clblast/spec
+++ b/runtime-scientific/clblast/spec
@@ -1,0 +1,4 @@
+VER=1.6.3
+SRCS="git::commit=tags/$VER::https://github.com/CNugteren/CLBlast.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=17818"


### PR DESCRIPTION
Topic Description
-----------------

- clblast: new, 1.6.3

Package(s) Affected
-------------------

- clblast: 1.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit clblast
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
