### PR TITLE
[FLIGHT] Revert "plymouth: update to 24.004.60"

### DIFF
--- a/app-admin/plymouth/autobuild/beyond
+++ b/app-admin/plymouth/autobuild/beyond
@@ -2,3 +2,6 @@ abinfo "Glow isn't quite ready for prime time..."
 rm -rfv "$PKGDIR"/usr/share/plymouth/glow/
 rm -fv "$PKGDIR"/usr/lib/plymouth/glow.so
 rm -rfv "$PKGDIR"/usr/share/plymouth/themes/glow
+
+abinfo "Moving /var/run => /run ..."
+mv -v "$PKGDIR"/{var/,}run

--- a/app-admin/plymouth/autobuild/defines
+++ b/app-admin/plymouth/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=plymouth
 PKGSEC=kernel
-PKGDEP="dracut libdrm pango systemd gtk-3 libevdev"
+PKGDEP="dracut libdrm pango systemd"
 PKGRECOM="plymouth-semaphore"
 BUILDDEP="docbook-xsl intltool"
 PKGDES="Graphical boot animation and logger"
@@ -12,4 +12,4 @@ AUTOTOOLS_AFTER="--enable-tracing \
                  --without-rhgb-compat-link \
                  --disable-gtk"
 
-PKGEPOCH=2
+PKGEPOCH=3

--- a/app-admin/plymouth/autobuild/patches/0001-ply-utils-Drop-linux-fs.h-include.patch
+++ b/app-admin/plymouth/autobuild/patches/0001-ply-utils-Drop-linux-fs.h-include.patch
@@ -1,0 +1,30 @@
+From 5f1e43c00039a7fe1fff768b91a05a695fb4a53d Mon Sep 17 00:00:00 2001
+From: Ray Strode <rstrode@redhat.com>
+Date: Wed, 3 Aug 2022 15:23:33 -0400
+Subject: [PATCH] ply-utils: Drop linux/fs.h include
+
+It was needed long ago for a function we no longer even have.
+
+Now it's causing compile errors on Fedora 37 because it's conflicting
+with sys/mount.h.
+
+This commit drops it.
+---
+ src/libply/ply-utils.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/libply/ply-utils.c b/src/libply/ply-utils.c
+index c7b165e..219e2e7 100644
+--- a/src/libply/ply-utils.c
++++ b/src/libply/ply-utils.c
+@@ -46,7 +46,6 @@
+ #include <sys/user.h>
+ #include <sys/wait.h>
+ #include <time.h>
+-#include <linux/fs.h>
+ #include <linux/vt.h>
+ 
+ #include <dlfcn.h>
+-- 
+2.37.1
+

--- a/app-admin/plymouth/spec
+++ b/app-admin/plymouth/spec
@@ -1,4 +1,5 @@
-VER=24.004.60
-SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/plymouth/plymouth"
+VER=22.02.122
+REL=4
+SRCS="git::commit=e31c81f9849c176d7b293ca79cc4507ba740c2fa::https://gitlab.freedesktop.org/plymouth/plymouth"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3669"


### PR DESCRIPTION
Topic Description
-----------------

- Revert "plymouth: update to 24.004.60"
    This reverts commit ce1807ef7f06a19038b9000726de7e5253325ac7.
- crun: update to 1.16.1

Package(s) Affected
-------------------

- plymouth: 3:22.02.122-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit plymouth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
