### PR TITLE
[FLIGHT] xorg-server: apply patch from RHEL9

### DIFF
--- a/runtime-display/xorg-server/autobuild/patches/0005-mustard-xfree86-Disable-the-PCI-probe-path.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0005-mustard-xfree86-Disable-the-PCI-probe-path.patch
@@ -1,0 +1,83 @@
+From b3afd9ccefe156ab2dee993118fcdba40341f66e Mon Sep 17 00:00:00 2001
+From: Adam Jackson <ajax@redhat.com>
+Date: Fri, 1 Oct 2021 11:47:21 -0400
+Subject: [PATCH xserver] mustard: xfree86: Disable the PCI probe path
+
+RHEL 9 does not support userspace modesetting drivers for Xorg. Ideally
+it would only support DRM drivers, but there are some fallback paths
+(efifb mainly) that still require fbdev support. Since the primary use
+of the PCI probe path is devices _without_ kernel support, we can safely
+disable it. And indeed we want to, because there are some devices
+(hyperv v1 e.g.) with both a platform and a PCI presentation, which the
+PCI probe code fails to handle such that the server fails to start.
+
+Thus: we #if 0 out the PCI probe in xf86CallDriverProbe.
+
+It might be nice if the platform code knew about fbdev devices, but it
+does not, and teaching it would be a large change for little benefit
+given we do intend to sunset the fbdev path as well. Since the fbdev
+path exists solely for cases where we have only the rudimentary firmare
+framebuffer, we should only use it if _no_ platform driver is available.
+
+Thus: we only call the legacy probe method if xf86ProbeIgnorePrimary.
+
+Having done this, we need to go back into fbdevhw and undo fc78bcca:
+
+    commit fc78bcca21e767697de6ad4d8e03b6728856f613 (merge-requests/38)
+    Author: Adam Jackson <ajax@redhat.com>
+    Date:   Wed Oct 10 14:09:11 2018 -0400
+
+    fbdevhw: Refuse to touch PCI devices on the fallback probe path
+
+Which was well intentioned, but given the above changes we know by the
+time we're trying to probe fbdev we really do want it, either because of
+the above fallback path or because xorg.conf asked for it. In either
+case we shouldn't spuriously fail just because it happens to be PCI.
+
+Thus: We if (0) out the code added in fc78bcca.
+
+Any one of the above might be questionable upstream, hence the mustard
+nature of this patch.
+---
+ hw/xfree86/common/xf86Bus.c  | 4 ++--
+ hw/xfree86/fbdevhw/fbdevhw.c | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/hw/xfree86/common/xf86Bus.c b/hw/xfree86/common/xf86Bus.c
+index fd144dbe7a..844ce5a890 100644
+--- a/hw/xfree86/common/xf86Bus.c
++++ b/hw/xfree86/common/xf86Bus.c
+@@ -84,7 +84,7 @@ xf86CallDriverProbe(DriverPtr drv, Bool detect_only)
+     }
+ #endif
+ 
+-#ifdef XSERVER_LIBPCIACCESS
++#if 0
+     if (!foundScreen && (drv->PciProbe != NULL)) {
+         if (xf86DoConfigure && xf86DoConfigurePass1) {
+             assert(detect_only);
+@@ -96,7 +96,7 @@ xf86CallDriverProbe(DriverPtr drv, Bool detect_only)
+         }
+     }
+ #endif
+-    if (!foundScreen && (drv->Probe != NULL)) {
++    if (!foundScreen && xf86ProbeIgnorePrimary && (drv->Probe != NULL)) {
+         xf86Msg(X_WARNING, "Falling back to old probe method for %s\n",
+                 drv->driverName);
+         foundScreen = (*drv->Probe) (drv, (detect_only) ? PROBE_DETECT
+diff --git a/hw/xfree86/fbdevhw/fbdevhw.c b/hw/xfree86/fbdevhw/fbdevhw.c
+index 3d8b92e669..171038f46d 100644
+--- a/hw/xfree86/fbdevhw/fbdevhw.c
++++ b/hw/xfree86/fbdevhw/fbdevhw.c
+@@ -330,7 +330,7 @@ fbdev_open(int scrnIndex, const char *dev, char **namep)
+     }
+ 
+     /* only touch non-PCI devices on this path */
+-    {
++    if (0) {
+         char buf[PATH_MAX] = {0};
+         char *sysfs_path = NULL;
+         char *node = strrchr(dev, '/') + 1;
+-- 
+2.31.1
+

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,5 +1,5 @@
 VER=21.1.13
-REL=1
+REL=2
 SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
 CHKSUMS="sha256::b45a02d5943f72236a360d3cc97e75134aa4f63039ff88c04686b508a3dc740c"
 CHKUPDATE="anitya::id=5250"


### PR DESCRIPTION
Topic Description
-----------------

- xorg-server: apply patch from https://bugzilla.redhat.com/show_bug.cgi?id=2000921

Package(s) Affected
-------------------

- xorg-server: 21.1.13-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorg-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
