### PR TITLE
screen: update to 5.0.0

### DIFF
--- a/app-utils/screen/autobuild/defines
+++ b/app-utils/screen/autobuild/defines
@@ -3,12 +3,23 @@ PKGSEC=utils
 PKGDEP="ncurses linux-pam libutempter"
 PKGDES="Full-screen window manager that multiplexes a physical terminal"
 
-AUTOTOOLS_AFTER="--enable-socket-dir \
-                 --enable-pam \
-                 --enable-use-locale \
+# Note: PTY group ID 5: tty.
+#
+# Note: --with-pty-rofs=no, no is upstream default.
+#
+# From configure.ac:
+#   AH_TEMPLATE([PTY_ROFS], [pty devices are on read only filesystem])
+#
+# Our devtmpfs is mounted read-write so I'm assuming that PTY_ROFS does not
+# suit our needs.
+AUTOTOOLS_AFTER="--enable-pam \
+                 --enable-utmp \
                  --enable-telnet \
-                 --enable-colors256 \
-                 --enable-rxvt_osc \
-                 --with-socket-dir=/tmp/screens \
+                 --enable-socket-dir \
+                 --with-system_screenrc=/etc/screenrc \
+                 --with-pty-mode=0622 \
                  --with-pty-group=5 \
-                 --with-sys-screenrc=/etc/screenrc"
+                 --with-pty-rofs=no"
+
+# FIXME: fatal error: kmapdef.h: No such file or directory
+ABSHADOW=0

--- a/app-utils/screen/spec
+++ b/app-utils/screen/spec
@@ -1,4 +1,4 @@
-VER=4.9.0
+VER=5.0.0
 SRCS="tbl::https://ftp.gnu.org/gnu/screen/screen-$VER.tar.gz"
-CHKSUMS="sha256::f9335281bb4d1538ed078df78a20c2f39d3af9a4e91c57d084271e0289c730f4"
+CHKSUMS="sha256::f04a39d00a0e5c7c86a55338808903082ad5df4d73df1a2fd3425976aed94971"
 CHKUPDATE="anitya::id=4772"


### PR DESCRIPTION
Topic Description
-----------------

- screen: update to 5.0.0
    - Update Autotools options.
    - Disable shadow build to fix build. [^1]
    [^1]: FIXME: fatal error: kmapdef.h: No such file or directory
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- screen: 5.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit screen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
