### PR TITLE
wireshark: update to 4.4.0

### DIFF
--- a/app-network/wireshark/spec
+++ b/app-network/wireshark/spec
@@ -1,4 +1,4 @@
-VER=4.2.5
+VER=4.4.0
 SRCS="tbl::https://www.wireshark.org/download/src/all-versions/wireshark-$VER.tar.xz"
-CHKSUMS="sha256::55e793ab87a9a73aac44336235c92cb76c52180c469b362ed3a54f26fbb1261f"
+CHKSUMS="sha256::ead5cdcc08529a2e7ce291e01defc3b0f8831ba24c938db0762b1ebc59c71269"
 CHKUPDATE="anitya::id=5137"


### PR DESCRIPTION
Topic Description
-----------------

- wireshark: update to 4.4.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wireshark: 4.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireshark
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
