### PR TITLE
libdrm: update to 2.4.123

### DIFF
--- a/runtime-display/libdrm/spec
+++ b/runtime-display/libdrm/spec
@@ -1,4 +1,4 @@
-VER=2.4.122
+VER=2.4.123
 SRCS="tbl::https://dri.freedesktop.org/libdrm/libdrm-$VER.tar.xz"
-CHKSUMS="sha256::d9f5079b777dffca9300ccc56b10a93588cdfbc9dde2fae111940dfb6292f251"
+CHKSUMS="sha256::a2b98567a149a74b0f50e91e825f9c0315d86e7be9b74394dae8b298caadb79e"
 CHKUPDATE="anitya::id=1596"

--- a/runtime-optenv32/libdrm+32/spec
+++ b/runtime-optenv32/libdrm+32/spec
@@ -1,4 +1,4 @@
-VER=2.4.122
+VER=2.4.123
 SRCS="tbl::https://dri.freedesktop.org/libdrm/libdrm-$VER.tar.xz"
-CHKSUMS="sha256::d9f5079b777dffca9300ccc56b10a93588cdfbc9dde2fae111940dfb6292f251"
+CHKSUMS="sha256::a2b98567a149a74b0f50e91e825f9c0315d86e7be9b74394dae8b298caadb79e"
 CHKUPDATE="anitya::id=1596"


### PR DESCRIPTION
Topic Description
-----------------

- libdrm+32: update to 2.4.123
- libdrm: update to 2.4.123

Package(s) Affected
-------------------

- libdrm: 2.4.123
- libdrm+32: 2.4.123

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdrm libdrm+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
