### PR TITLE
llvm: backport two patches for orcjit

### DIFF
--- a/app-devel/llvm/01-runtime/patches/0010-JITLink-RISCV-Use-hashmap-to-find-PCREL_HI20-edge-78.patch
+++ b/app-devel/llvm/01-runtime/patches/0010-JITLink-RISCV-Use-hashmap-to-find-PCREL_HI20-edge-78.patch
@@ -1,0 +1,108 @@
+From c020430f7b9c827e9f43e2abdd37b523656d5a50 Mon Sep 17 00:00:00 2001
+From: Jonas Hahnfeld <hahnjo@hahnjo.de>
+Date: Mon, 12 Feb 2024 19:45:52 +0100
+Subject: [PATCH 10/11] [JITLink][RISCV] Use hashmap to find PCREL_HI20 edge
+ (#78849)
+
+As noted in issues #68594 and #73935, `JITLink/RISCV/ELF_ehframe.s`
+fails with libstdc++'s expensive checks because `getRISCVPCRelHi20`
+calls `std::equal_range` on the edges which may not be ordered by their
+offset. Instead let `ELFJITLinker_riscv` build a hashmap of all edges
+with type `R_RISCV_PCREL_HI20` that can be looked up in constant time.
+
+Closes #73935
+---
+ .../lib/ExecutionEngine/JITLink/ELF_riscv.cpp | 68 ++++++++++---------
+ 1 file changed, 35 insertions(+), 33 deletions(-)
+
+diff --git a/llvm/lib/ExecutionEngine/JITLink/ELF_riscv.cpp b/llvm/lib/ExecutionEngine/JITLink/ELF_riscv.cpp
+index d0701ba08bd9..627f186ca591 100644
+--- a/llvm/lib/ExecutionEngine/JITLink/ELF_riscv.cpp
++++ b/llvm/lib/ExecutionEngine/JITLink/ELF_riscv.cpp
+@@ -133,38 +133,6 @@ const uint8_t
+ namespace llvm {
+ namespace jitlink {
+ 
+-static Expected<const Edge &> getRISCVPCRelHi20(const Edge &E) {
+-  using namespace riscv;
+-  assert((E.getKind() == R_RISCV_PCREL_LO12_I ||
+-          E.getKind() == R_RISCV_PCREL_LO12_S) &&
+-         "Can only have high relocation for R_RISCV_PCREL_LO12_I or "
+-         "R_RISCV_PCREL_LO12_S");
+-
+-  const Symbol &Sym = E.getTarget();
+-  const Block &B = Sym.getBlock();
+-  orc::ExecutorAddrDiff Offset = Sym.getOffset();
+-
+-  struct Comp {
+-    bool operator()(const Edge &Lhs, orc::ExecutorAddrDiff Offset) {
+-      return Lhs.getOffset() < Offset;
+-    }
+-    bool operator()(orc::ExecutorAddrDiff Offset, const Edge &Rhs) {
+-      return Offset < Rhs.getOffset();
+-    }
+-  };
+-
+-  auto Bound =
+-      std::equal_range(B.edges().begin(), B.edges().end(), Offset, Comp{});
+-
+-  for (auto It = Bound.first; It != Bound.second; ++It) {
+-    if (It->getKind() == R_RISCV_PCREL_HI20)
+-      return *It;
+-  }
+-
+-  return make_error<JITLinkError>(
+-      "No HI20 PCREL relocation type be found for LO12 PCREL relocation type");
+-}
+-
+ static uint32_t extractBits(uint32_t Num, unsigned Low, unsigned Size) {
+   return (Num & (((1ULL << Size) - 1) << Low)) >> Low;
+ }
+@@ -184,9 +152,43 @@ class ELFJITLinker_riscv : public JITLinker<ELFJITLinker_riscv> {
+ public:
+   ELFJITLinker_riscv(std::unique_ptr<JITLinkContext> Ctx,
+                      std::unique_ptr<LinkGraph> G, PassConfiguration PassConfig)
+-      : JITLinker(std::move(Ctx), std::move(G), std::move(PassConfig)) {}
++      : JITLinker(std::move(Ctx), std::move(G), std::move(PassConfig)) {
++    JITLinkerBase::getPassConfig().PostAllocationPasses.push_back(
++        [this](LinkGraph &G) { return gatherRISCVPCRelHi20(G); });
++  }
+ 
+ private:
++  DenseMap<std::pair<const Block *, orc::ExecutorAddrDiff>, const Edge *>
++      RelHi20;
++
++  Error gatherRISCVPCRelHi20(LinkGraph &G) {
++    for (Block *B : G.blocks())
++      for (Edge &E : B->edges())
++        if (E.getKind() == R_RISCV_PCREL_HI20)
++          RelHi20[{B, E.getOffset()}] = &E;
++
++    return Error::success();
++  }
++
++  Expected<const Edge &> getRISCVPCRelHi20(const Edge &E) const {
++    using namespace riscv;
++    assert((E.getKind() == R_RISCV_PCREL_LO12_I ||
++            E.getKind() == R_RISCV_PCREL_LO12_S) &&
++           "Can only have high relocation for R_RISCV_PCREL_LO12_I or "
++           "R_RISCV_PCREL_LO12_S");
++
++    const Symbol &Sym = E.getTarget();
++    const Block &B = Sym.getBlock();
++    orc::ExecutorAddrDiff Offset = Sym.getOffset();
++
++    auto It = RelHi20.find({&B, Offset});
++    if (It != RelHi20.end())
++      return *It->second;
++
++    return make_error<JITLinkError>("No HI20 PCREL relocation type be found "
++                                    "for LO12 PCREL relocation type");
++  }
++
+   Error applyFixup(LinkGraph &G, Block &B, const Edge &E) const {
+     using namespace riscv;
+     using namespace llvm::support;
+-- 
+2.46.0
+

--- a/app-devel/llvm/01-runtime/patches/0011-JITLink-Always-unmap-standard-segments-in-InProcessM.patch
+++ b/app-devel/llvm/01-runtime/patches/0011-JITLink-Always-unmap-standard-segments-in-InProcessM.patch
@@ -1,0 +1,38 @@
+From 94fb8943c3a9627e18288f06dceb6380e84b8490 Mon Sep 17 00:00:00 2001
+From: Min-Yih Hsu <min.hsu@sifive.com>
+Date: Fri, 16 Feb 2024 16:19:56 -0800
+Subject: [PATCH 11/11] [JITLink] Always unmap standard segments in
+ InProcessMemoryManager::deallocate (#81943)
+
+Right now InProcessMemoryManager only releases a standard segment (via
+sys::Memory::releaseMappedMemory) in `deallocate` when there is a
+DeallocAction associated, leaving residual memory pages in the process
+until termination.
+Despite being a de facto memory leak, it won't cause a major issue if
+users only create a single LLJIT instance per process, which is the most
+common use cases. It will, however, drain virtual memory pages if we
+create thousands of ephemeral LLJIT instances in the same process.
+
+This patch fixes this issue by releasing every standard segments
+regardless of the attached DeallocAction.
+---
+ llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp b/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp
+index 474a0b5160bc..dacf0e6c8aa4 100644
+--- a/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp
++++ b/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp
+@@ -449,8 +449,7 @@ void InProcessMemoryManager::deallocate(std::vector<FinalizedAlloc> Allocs,
+     for (auto &Alloc : Allocs) {
+       auto *FA = Alloc.release().toPtr<FinalizedAllocInfo *>();
+       StandardSegmentsList.push_back(std::move(FA->StandardSegments));
+-      if (!FA->DeallocActions.empty())
+-        DeallocActionsList.push_back(std::move(FA->DeallocActions));
++      DeallocActionsList.push_back(std::move(FA->DeallocActions));
+       FA->~FinalizedAllocInfo();
+       FinalizedAllocInfos.Deallocate(FA);
+     }
+-- 
+2.46.0
+

--- a/app-devel/llvm/spec
+++ b/app-devel/llvm/spec
@@ -1,4 +1,5 @@
 VER=18.1.8
+REL=1
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"


### PR DESCRIPTION
Topic Description
-----------------

- llvm: backport two patches to fix some LLVMPipe ORCJIT issues
    - Backport a patch which fixes page leaks in ORCJIT JITLink.
    - Backport a patch for RISC-V which fixes some linking issue in JITLink.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- llvm: 18.1.8-1
- llvm-runtime: 18.1.8-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
