### PR TITLE
oma: update to 1.8.1

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.8.0
+VER=1.8.1
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.8.1

Package(s) Affected
-------------------

- oma: 1.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`



