### PR TITLE
x11-app (X11 Applications): update to 7.7.20240830

### DIFF
--- a/runtime-display/x11-app/autobuild/build
+++ b/runtime-display/x11-app/autobuild/build
@@ -4,7 +4,7 @@ for package in `cat "$SRCDIR"/autobuild/build-order`; do
     pushd "$package"-*
 
     abinfo "Copying replacement config.* for ${package} ..."
-    cp -v /usr/share/automake-1.16/config.* .
+    cp -v /usr/bin/config.* .
 
     abinfo "Configuring ${package} ..."
     case $package in

--- a/runtime-display/x11-app/spec
+++ b/runtime-display/x11-app/spec
@@ -1,36 +1,36 @@
-VER=7.7.20231031
+VER=7.7.20240830
 __BDFTOPCF_VER=1.1
-__ICEAUTH_VER=1.0.9
+__ICEAUTH_VER=1.0.10
 __LUIT_VER=1.1.1
 __MKFONTDIR_VER=1.0.7
-__MKFONTSCALE_VER=1.2.2
+__MKFONTSCALE_VER=1.2.3
 __SESSREG_VER=1.1.3
 __SETXKBMAP_VER=1.3.4
 __SMPROXY_VER=1.0.7
-__X11PERF_VER=1.6.1
-__XAUTH_VER=1.1
+__X11PERF_VER=1.7.0
+__XAUTH_VER=1.1.3
 __XBACKLIGHT_VER=1.2.3
 __XCMSDB_VER=1.0.6
 __XCURSORGEN_VER=1.0.8
 __XDPYINFO_VER=1.3.4
 __XDRIINFO_VER=1.0.7
-__XEV_VER=1.2.5
+__XEV_VER=1.2.6
 __XGAMMA_VER=1.0.7
-__XHOST_VER=1.0.8
-__XINPUT_VER=1.6.3
-__XKBCOMP_VER=1.4.6
+__XHOST_VER=1.0.9
+__XINPUT_VER=1.6.4
+__XKBCOMP_VER=1.4.7
 __XKBEVD_VER=1.1.5
-__XKBUTILS_VER=1.0.5
+__XKBUTILS_VER=1.0.6
 __XKILL_VER=1.0.6
 __XLSATOMS_VER=1.1.4
 __XLSCLIENTS_VER=1.1.5
-__XMESSAGE_VER=1.0.6
+__XMESSAGE_VER=1.0.7
 __XMODMAP_VER=1.0.11
-__XPR_VER=1.1.0
-__XPROP_VER=1.2.6
+__XPR_VER=1.2.0
+__XPROP_VER=1.2.7
 __XRANDR_VER=1.5.2
 __XRDB_VER=1.2.2
-__XREFRESH_VER=1.0.7
+__XREFRESH_VER=1.1.0
 __XSET_VER=1.2.5
 __XSETROOT_VER=1.1.3
 __XVINFO_VER=1.1.5
@@ -47,7 +47,7 @@ SRCS="tbl::${__BASE_URL}/bdftopcf-${__BDFTOPCF_VER}.tar.gz \
       tbl::${__BASE_URL}/sessreg-${__SESSREG_VER}.tar.gz \
       tbl::${__BASE_URL}/setxkbmap-${__SETXKBMAP_VER}.tar.gz \
       tbl::${__BASE_URL}/smproxy-${__SMPROXY_VER}.tar.gz \
-      tbl::${__BASE_URL}/x11perf-${__X11PERF_VER}.tar.gz \
+      tbl::${__BASE_URL/app/test}/x11perf-${__X11PERF_VER}.tar.gz \
       tbl::${__BASE_URL}/xauth-${__XAUTH_VER}.tar.gz \
       tbl::${__BASE_URL}/xbacklight-${__XBACKLIGHT_VER}.tar.gz \
       tbl::${__BASE_URL}/xcmsdb-${__XCMSDB_VER}.tar.gz \
@@ -78,37 +78,37 @@ SRCS="tbl::${__BASE_URL}/bdftopcf-${__BDFTOPCF_VER}.tar.gz \
       tbl::${__BASE_URL}/xwininfo-${__XWININFO_VER}.tar.gz \
       tbl::${__BASE_URL}/xwud-${__XWUD_VER}.tar.gz"
 CHKSUMS="sha256::699d1a62012035b1461c7f8e3f05a51c8bd6f28f348983249fb89bbff7309b47 \
-         sha256::5ca274cf210453e7d7cf5c827a2fbc92149df83824f99a27cde17e1f20324dc6 \
+         sha256::f17f373c6e7bfef9cfa4c688f165dfebec7642ad7c6304c5bb3c9bc2bfcde747 \
          sha256::87b0be0bd01f3b857a53e6625bdd31cef18418c95394b7f4387f8ecef78e45da \
          sha256::bccc5fb7af1b614eabe4a22766758c87bfc36d66191d08c19d2fa97674b7b5b7 \
-         sha256::4a5af55e670713024639a7f7d10826d905d86faf574cd77e0f5aef2d00e70168 \
+         sha256::3a026b468874eb672a1d0a57dbd3ddeda4f0df09886caf97d30097b70c2df3f8 \
          sha256::6e3e917e881132a7a9ccb181ddd83fe08a99668892455d808c911ad38beea215 \
          sha256::cc4113eab3cd70c28c986174aa30e62690e789723c874acc53e8d1f058d11f92 \
          sha256::aabd5e644512442da2bca1ce65ccee403b760a08e354b3474753ed36033e3d21 \
-         sha256::a1874618df0e30ae1a9b2470fb50e77a40c4a6f6ddf87a5c154f7a3b913ac0b3 \
-         sha256::e9fce796c8c5c9368594b9e8bbba237fb54b6615f5fd60e8d0a5b3c52a92c5ef \
+         sha256::88563b4bcd0082285bad9c0d0596851cce021a8318e66669fa528dc86c6ae8c1 \
+         sha256::88c288e0a30bf071631118644f5232cae3a79713a7c82dd31a236e8e2c6fca15 \
          sha256::d2a8dd962454d8de3675286eab4edc4d1376ac7da040a3a8729ee250e6e798c1 \
          sha256::640b42c746eb34bdd71ca2850f2bc9fb0ade194c9f152a8d002425a0684df077 \
          sha256::b8bb2756918343b8bc15a4ce875e9efb6c4e7777adba088280e53dd09753b6ac \
          sha256::fbd1e18885f67332b330fecd83592af25ad42d21457aaabfbd31a5a97388652a \
          sha256::9fab95510b1f67409632fb8af01369b128f4d12763fe1a2662f5666976a7d30c \
-         sha256::a948974ede621a8402ed9ea64f1ec83992285aa4fbb9d40b52985156c61a358a \
+         sha256::e2e3527023017af3a9bfbef0a90f8e46ac354c506b51f0ee3834b30823e43b25 \
          sha256::61f5ef02883d65ab464678ad3d8c5445a0ff727fe6255af90b1b842ddf77370d \
-         sha256::e5aabce1533dc778ceb5bbc207105cf3770f710629caceaad64675b00c38c3f8 \
-         sha256::9f29f9bfe387c5a3d582f9edc8c5a753510ecc6fdfb154c03b5cea5975b10ce4 \
-         sha256::b216a2c8c0eab83f3dc4a3d5ee2bdf7827b30e49c8907035d0f222138eca0987 \
+         sha256::ca850367593fcddc4bff16de7ea1598aa4f6817daf5a803a1258dff5e337f7c3 \
+         sha256::64e25434af1309ed0abca1ebebd035f7631bb0bc1bfac5decefe9aa98ccaf611 \
+         sha256::00cecc490fcbe2f789cf13c408c459673c2c33ab758d802677321cffcda35373 \
          sha256::5d6b65a417be57e19a76277601da83271b19de6e71cb0e8821441f6fb9973c47 \
-         sha256::b87072f0d7e75f56ee04455e1feab92bb5847aee4534b18c2e08b926150279ff \
+         sha256::d747d4ce5c390223e3bfdb13a1f673d3e19ae46ded25838cb8b28b1bafe1b9bd \
          sha256::3b35a2f4b67dda1e98b6541488cd7f7343eb6e3dbe613aeff3d5a5a4c4c64b58 \
          sha256::e3b4dce0e6bf3b60bc308ed184d2dc201ea4af6ce03f0126aa303ccd1ccb1237 \
          sha256::225d75e4c0b0929f16f974e20931ab85204b40098d92a5479b0b9379120637e5 \
-         sha256::46acfb25c531f59a24abc85b14b956c9c03c870757dddae4d6d083833924a071 \
+         sha256::273bf3a3d6bc874ad4cd9e6da6ca26942a9dbf8f2c3016b3ebb906420aeb00fb \
          sha256::c4fac9df448b98ac5a1620f364e74ed5f7084baae0d09123700f34d4b63cb5d8 \
-         sha256::fabd02fb1a52358d521f1be7422738bc8c9b511a8d82a163888f628db6f6cb18 \
-         sha256::58ee5ee0c47fa454d3b16312e778c3f549605a8ad0fd0daafc70d2d6174b116d \
+         sha256::4c37dd062c8f61618ed5fad7be907d7f9b219c2c91aa9a312f4ff4cc3494c476 \
+         sha256::11c06a876b0aa0bfac6cbfe4b3ebe1f5062f8b39b9b1b6c136a8629265f134b6 \
          sha256::efd062cd228dc18a7de26422c81bc4be6a7e62f7f0ad6f9bebdd9ff8385c5668 \
          sha256::db2d774a35ae2f7e7ac61cc2de0dcae27fc2aa14399c35721f8300e63ea73549 \
-         sha256::f2817920f119bd9146ed3cde223b8a4ab17cb72da4ece7bddde35e18b31aa337 \
+         sha256::cbf0d3ed80f03188841a96ceb20e615b40a006e3928be2e179d9d5a0ded639b2 \
          sha256::2068d1356d80c29ce283f0fff5895667b38f24ea95df363d3dde7b8c8a92fffe \
          sha256::80dbb0d02807e89294a042298b8a62f9aa0c3a94d89244ccbc35e4cf80fcaaba \
          sha256::76fdc89a4e4207d0069ae3e511b4e30a60fcf86b630d01ef56d32ba5856e76c4 \


### PR DESCRIPTION
Topic Description
-----------------

- x11-app: update to 7.7.20240830 (component updates)
    Update the following components:
    - iceauth 1.0.10
    - mkfontscale 1.0.10
    - x11perf 1.7.0
    - xauth 1.1.3
    - xev 1.2.6
    - xhost 1.0.9
    - xinput 1.6.4
    - xkbcomp 1.4.7
    - xkbutils 1.0.6
    - xmessage 1.0.7
    - xpr 1.2.0
    - xprop 1.2.7
    - xrefresh 1.1.0

Package(s) Affected
-------------------

- x11-app: 7.7.20240830

Security Update?
----------------

No

Build Order
-----------

```
#buildit x11-app
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
