### PR TITLE
mesa: disable VC-1 hardware decoding

### DIFF
--- a/runtime-display/mesa/autobuild/patches/0001-zink-reject-Imagination-proprietary-driver-w-o-geome.patch
+++ b/runtime-display/mesa/autobuild/patches/0001-zink-reject-Imagination-proprietary-driver-w-o-geome.patch
@@ -1,7 +1,7 @@
-From 7f3b41eef91db1519c5e7c9d5ef2cca47888bd1f Mon Sep 17 00:00:00 2001
+From c6e76ab84f0ad66ac07be1d8f04c8a5e6bd9a8cb Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 20 Jul 2024 22:03:54 +0800
-Subject: [PATCH 1/2] zink: reject Imagination proprietary driver w/o
+Subject: [PATCH 1/3] zink: reject Imagination proprietary driver w/o
  geometryShader
 
 On some low-end GPUs (e.g. BXE/BXM series), the Imagination proprietary
@@ -18,10 +18,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 6 insertions(+)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 75e4997d4be..4971a6c3505 100644
+index b00438583ee..b44b3db43dc 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -3415,6 +3415,12 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+@@ -3418,6 +3418,12 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
        goto fail;
     }
  

--- a/runtime-display/mesa/autobuild/patches/0002-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384.patch.loongarch64
+++ b/runtime-display/mesa/autobuild/patches/0002-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384.patch.loongarch64
@@ -1,7 +1,7 @@
-From 3c411dcaf91220f750725347a1573f2da885b46f Mon Sep 17 00:00:00 2001
+From 902bf75316a1110010ca6fde85a6ed690ed18958 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
-Subject: [PATCH 2/2] fix(iris_bufmgr.c): set PAGE_SIZE as 16384
+Subject: [PATCH 2/3] fix(iris_bufmgr.c): set PAGE_SIZE as 16384
 
 Obviously not ideal, but this is simply meant as a preview/PoC.
 ---

--- a/runtime-display/mesa/autobuild/patches/0003-r600-disable-buggy-vc-1-hardware-decoding.patch
+++ b/runtime-display/mesa/autobuild/patches/0003-r600-disable-buggy-vc-1-hardware-decoding.patch
@@ -1,0 +1,25 @@
+From e6cec29d48e6c87565119c5f44977abe2b4e28c9 Mon Sep 17 00:00:00 2001
+From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
+Date: Fri, 30 Aug 2024 17:27:37 +0800
+Subject: [PATCH 3/3] r600: disable buggy vc-1 hardware decoding
+
+---
+ src/gallium/drivers/r600/radeon_video.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/gallium/drivers/r600/radeon_video.c b/src/gallium/drivers/r600/radeon_video.c
+index 670e0aafb9e..6e5abd8d1a1 100644
+--- a/src/gallium/drivers/r600/radeon_video.c
++++ b/src/gallium/drivers/r600/radeon_video.c
+@@ -237,7 +237,7 @@ int rvid_get_video_param(struct pipe_screen *screen,
+ 		case PIPE_VIDEO_FORMAT_MPEG4_AVC:
+ 			return true;
+ 		case PIPE_VIDEO_FORMAT_VC1:
+-			return true;
++			return false;
+ 		case PIPE_VIDEO_FORMAT_HEVC:
+ 			return false;
+ 		case PIPE_VIDEO_FORMAT_JPEG:
+-- 
+2.46.0
+

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,6 +1,7 @@
 UPSTREAM_VER=24.2.0
 DXHEADERS_VER=1.614.0
 VER=${UPSTREAM_VER}+dxheaders${DXHEADERS_VER}
+REL=1
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
 CHKSUMS="sha256::c02bb72cea290f78b11895a0c95c7c92394f180d7ff66d4a762ec6950a58addf \


### PR DESCRIPTION
Topic Description
-----------------

- mesa: disable buggy VC-1 hardware decoding in r600 driver

Package(s) Affected
-------------------

- mesa: 1:24.2.0+dxheaders1.614.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
