### PR TITLE
oma: update to 1.8.2

### DIFF
--- a/app-admin/oma/autobuild/beyond
+++ b/app-admin/oma/autobuild/beyond
@@ -34,9 +34,9 @@ cp -v "$SRCDIR"/data/completions/oma.bash \
 	"$PKGDIR"/usr/share/bash-completion/completions/oma.bash
 
 abinfo "Installing fish completions ..."
-mkdir -pv "$PKGDIR"/usr/share/fish/completions
+mkdir -pv "$PKGDIR"/usr/share/fish/vendor_completions.d/
 cp -v "$SRCDIR"/data/completions/oma.fish \
-	"$PKGDIR"/usr/share/fish/completions/oma.fish
+	"$PKGDIR"/usr/share/fish/vendor_completions.d/oma.fish
 
 abinfo "Installing config file ..."
 cp -v "$SRCDIR"/data/config/oma.toml \

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.8.1
+VER=1.8.2
 SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.8.2

Package(s) Affected
-------------------

- oma: 1.8.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



