### PR TITLE
distorm: update to 3.5.2b

### DIFF
--- a/app-devel/distorm/spec
+++ b/app-devel/distorm/spec
@@ -1,5 +1,4 @@
-VER=3.5.1
-SRCS="tbl::https://pypi.io/packages/source/d/distorm3/distorm3-$VER.tar.gz"
-CHKSUMS="sha256::6a7f99b62c83819b4a3ff2d735aff7ccb0f88daffb0cef070f67884f64f0e47e"
+VER=3.5.2b
+SRCS="git::commit=tags/$VER::https://github.com/gdabah/distorm.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14551"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- distorm: update to 3.5.2b

Package(s) Affected
-------------------

- distorm: 3.5.2b

Security Update?
----------------

No

Build Order
-----------

```
#buildit distorm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
