### PR TITLE
 fcitx5-pinyin-moegirl: update to 20240809

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20240709
+VER=20240809
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::d4135fc8c33b4f5f60956b01f6838e30711673e484feaaf1c79aec033dfce8eb \
-         sha256::a94944d831320193b7119837f478f9aab83ef977c5a6fec505d500939883a665 \
+CHKSUMS="sha256::da348acc3823c6ecf4fc082a79fcb826b49c9aa33b4979c8b9994b324a80193d \
+         sha256::377676009901f9dcab91b6846e226fb12a4503f650dd7ca34619d5b97e54687a \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20240809

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20240809
- rime-pinyin-moegirl: 20240809

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
