### PR TITLE
[FLIGHT] plymouth: update to master

### DIFF
--- a/app-admin/plymouth/spec
+++ b/app-admin/plymouth/spec
@@ -1,4 +1,4 @@
-VER=24.004.60
-SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/plymouth/plymouth"
+VER=24.004.60+git20240828
+SRCS="git::commit=d2ab367e12423646d3a6bb35d16570f8e3126234;copy-repo=true::https://gitlab.freedesktop.org/plymouth/plymouth.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3669"


### PR DESCRIPTION
Topic Description
-----------------

- [FLIGHT] plymouth: update to Git master
    In an attempt to investigate NVIDIA boot-up issues.

Package(s) Affected
-------------------

- plymouth: 2:24.004.60+git20240828

Security Update?
----------------

No

Build Order
-----------

```
#buildit plymouth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
