### PR TITLE
plymouth: fix blank screen on frame buffer devices

### DIFF
--- a/app-admin/plymouth/autobuild/patches/0001-main-Go-back-to-text-mode-when-quitting-if-appropria.patch
+++ b/app-admin/plymouth/autobuild/patches/0001-main-Go-back-to-text-mode-when-quitting-if-appropria.patch
@@ -1,0 +1,37 @@
+From ad8236ef35d5645a373e77637d8188c8ac552a0f Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Sun, 1 Sep 2024 00:15:17 +0800
+Subject: [PATCH 1/2] main: Go back to text mode when quitting (if appropriate)
+
+Since commit 48881ba2ef3d25fd27fd150d4d5957d4df9868e0 plymouth
+goes into GRAPHICS mode early on. Unfortunately, there are cases
+where it neglects to go back to TEXT mode when quitting. That can
+happen if boot finishes before the splash screen is created.
+
+This commit fixes that.
+
+Ref: https://gitlab.freedesktop.org/plymouth/plymouth/-/commit/d2ab367e12423646d3a6bb35d16570f8e3126234
+---
+ src/main.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/src/main.c b/src/main.c
+index 33fe51e..5916ddc 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -1223,10 +1223,8 @@ hide_splash (state_t *state)
+ 
+         cancel_pending_delayed_show (state);
+ 
+-        if (state->boot_splash == NULL)
+-                return;
+-
+-        ply_boot_splash_hide (state->boot_splash);
++        if (state->boot_splash != NULL)
++                ply_boot_splash_hide (state->boot_splash);
+ 
+         if (state->local_console_terminal != NULL) {
+                 ply_terminal_set_mode (state->local_console_terminal, PLY_TERMINAL_MODE_TEXT);
+-- 
+2.46.0.windows.1
+

--- a/app-admin/plymouth/autobuild/patches/0002-main-Correctly-switch-back-to-text-mode-if-the-splas.patch
+++ b/app-admin/plymouth/autobuild/patches/0002-main-Correctly-switch-back-to-text-mode-if-the-splas.patch
@@ -1,0 +1,31 @@
+From 5323b33eb5073cfeb0086939993129bac14fd1a9 Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Sun, 1 Sep 2024 00:16:10 +0800
+Subject: [PATCH 2/2] main: Correctly switch back to text mode if the splash is
+ requested, but never shown
+
+Co-authored-by: filip-hejsek
+Suggested-by: filip-hejsek
+Ref: https://gitlab.freedesktop.org/plymouth/plymouth/-/commit/1e206268df99d28e9fb3d3cf8379a553abb05af0
+---
+ src/main.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/main.c b/src/main.c
+index 5916ddc..44486ac 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -1457,6 +1457,10 @@ on_quit (state_t       *state,
+                         state->splash_is_becoming_idle = true;
+                 }
+         } else {
++                if (!state->should_retain_splash) {
++                        hide_splash (state);
++                }
++                quit_splash (state);
+                 quit_program (state);
+         }
+ }
+-- 
+2.46.0.windows.1
+

--- a/app-admin/plymouth/spec
+++ b/app-admin/plymouth/spec
@@ -1,4 +1,5 @@
 VER=24.004.60
-SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/plymouth/plymouth"
+REL=1
+SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/plymouth/plymouth.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3669"


### PR DESCRIPTION
Topic Description
-----------------

- plymouth: fix blank screen on frame buffer devices
    - main: Correctly switch back to text mode if the splash is requested, but never shown
    - Ref: https://gitlab.freedesktop.org/plymouth/plymouth/-/merge_requests/334
    - Track patches at https://github.com/AOSC-Tracking/plymouth @ aosc/24.004.60, current HEAD is 5323b33eb5073cfeb0086939993129bac14fd1a9.

Package(s) Affected
-------------------

- plymouth: 2:24.004.60-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit plymouth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
