### PR TITLE
qjackctl: update to 1.0.1

### DIFF
--- a/app-multimedia/qjackctl/autobuild/defines
+++ b/app-multimedia/qjackctl/autobuild/defines
@@ -3,7 +3,5 @@ PKGDES="User interface for controlling the JACK sound server"
 PKGSEC=sound
 PKGDEP="jack qt-5"
 
-ABSHADOW=0
-RECONF=0
-
-AUTOTOOLS_AFTER="--enable-debug"
+ABTYPE=cmakeninja
+CMAKE_AFTER="-DCONFIG_QT6=no"

--- a/app-multimedia/qjackctl/spec
+++ b/app-multimedia/qjackctl/spec
@@ -1,5 +1,4 @@
-VER=0.9.7
-REL=1
+VER=1.0.1
 SRCS="tbl::https://downloads.sourceforge.net/qjackctl/qjackctl-$VER.tar.gz"
-CHKSUMS="sha256::524843618152070c90a40a18d0e9a16e784424ce54231aff5c0ced12f2769080"
+CHKSUMS="sha256::b955b00e72272da027f8fffa02822529d6d993b3c4782a764cda9c4c2f27c13d"
 CHKUPDATE="anitya::id=4127"


### PR DESCRIPTION
Topic Description
-----------------

- qjackctl: update to 1.0.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- qjackctl: 1.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qjackctl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
