### PR TITLE
ncdu: update to 2.5

### DIFF
--- a/app-utils/ncdu/autobuild/build
+++ b/app-utils/ncdu/autobuild/build
@@ -1,0 +1,1 @@
+make PREFIX="$PKGDIR"/usr install

--- a/app-utils/ncdu/autobuild/defines
+++ b/app-utils/ncdu/autobuild/defines
@@ -1,4 +1,9 @@
 PKGNAME=ncdu
 PKGSEC=utils
 PKGDEP="ncurses"
+BUILDDEP="zig"
 PKGDES="A disk usage analyzer with an ncurses interface"
+
+# FIXME:
+# Zig only supports amd64
+FAIL_ARCH="!(amd64)"

--- a/app-utils/ncdu/spec
+++ b/app-utils/ncdu/spec
@@ -1,4 +1,4 @@
-VER=1.16
+VER=2.5
 SRCS="tbl::https://dev.yorhel.nl/download/ncdu-$VER.tar.gz"
-CHKSUMS="sha256::2b915752a183fae014b5e5b1f0a135b4b408de7488c716e325217c2513980fd4"
+CHKSUMS="sha256::7f49de25024abab1af1ff22b3b8542c0d158e018fe0e96074fd94b0e1e6d31a5"
 CHKUPDATE="anitya::id=6045"


### PR DESCRIPTION
Topic Description
-----------------

- ncdu: update to 2.5

Package(s) Affected
-------------------

- ncdu: 2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit ncdu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
