### PR TITLE
intel-compute-runtime: update to 24.31.30508.7

### DIFF
--- a/app-devel/intel-graphics-compiler/autobuild/beyond
+++ b/app-devel/intel-graphics-compiler/autobuild/beyond
@@ -1,4 +1,4 @@
-LLVM_MAJOR_VER=14
+LLVM_MAJOR_VER=15
 
 mv -v "${PKGDIR}"/usr/include/opencl-c{,-base}.h "${PKGDIR}"/usr/include/igc
 mkdir -pv "${PKGDIR}"/usr/share/doc/"${PKGNAME}"

--- a/app-devel/intel-graphics-compiler/autobuild/defines
+++ b/app-devel/intel-graphics-compiler/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=intel-graphics-compiler
 PKGSEC=devel
 PKGDEP="gcc-runtime glibc zlib"
-BUILDDEP="mako"
+BUILDDEP="mako pyyaml"
 PKGDES="An LLVM based compiler for OpenCL targeting Intel Gen graphics hardware architecture"
 
-LLVM_VER=14.0.6
+LLVM_VER=15.0.7
 ABTYPE=cmakeninja
 CMAKE_AFTER=" \
     -DCCLANG_FROM_SYSTEM=OFF \

--- a/app-devel/intel-graphics-compiler/autobuild/prepare
+++ b/app-devel/intel-graphics-compiler/autobuild/prepare
@@ -5,7 +5,7 @@ export LDFLAGS="${LDFLAGS} -Wl,-Bsymbolic"
 git config --local user.name "AOSC Maintainers"
 git config --local user.email "maintainers@aosc.io"
 
-LLVM_VER=14.0.6
+LLVM_VER=15.0.7
 mv "${SRCDIR}"/../llvm-project-"${LLVM_VER}".src "${SRCDIR}"/../llvm-project
 cd "${SRCDIR}"/../llvm-project
 
@@ -15,11 +15,11 @@ do
     patch -p1 -t -s -N -i "$file"
 done
 rm "${SRCDIR}"/../opencl-clang/patches/clang/*.patch
-for file in "${SRCDIR}"/external/llvm/releases/14.0.0/patches_external/*.patch
+for file in "${SRCDIR}"/external/llvm/releases/15.0.0/patches_external/*.patch
 do
     patch -p1 -t -s -N -i "$file"
 done
-rm "${SRCDIR}"/external/llvm/releases/14.0.0/patches_external/*.patch
+rm "${SRCDIR}"/external/llvm/releases/15.0.0/patches_external/*.patch
 
 mkdir "${SRCDIR}"/../llvm-project/.git
 ln -s "${SRCDIR}"/../SPIRV-LLVM-Translator  "${SRCDIR}"/../llvm-project/llvm/projects/llvm-spirv

--- a/app-devel/intel-graphics-compiler/spec
+++ b/app-devel/intel-graphics-compiler/spec
@@ -1,9 +1,9 @@
-VER=1.0.17193.4
-LLVM_VER=14.0.6
-OPENCL_CLANG_VER=14.0.0
-SPIRV_LLVM_TRANSLATOR_VER=14.0.0
-VS_INTRINSICS_VER=0.18.0
-SPIRV_TOOLS_VER=1.3.280.0
+VER=1.0.17384.11
+LLVM_VER=15.0.7
+OPENCL_CLANG_VER=15.0.0
+SPIRV_LLVM_TRANSLATOR_VER=15.0.3
+VS_INTRINSICS_VER=0.19.0
+SPIRV_TOOLS_VER=1.3.290.0
 
 SRCS="git::commit=tags/igc-$VER;copy-repo=true::https://github.com/intel/intel-graphics-compiler.git \
       tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-"${LLVM_VER}"/llvm-project-"${LLVM_VER}".src.tar.xz \
@@ -13,7 +13,7 @@ SRCS="git::commit=tags/igc-$VER;copy-repo=true::https://github.com/intel/intel-g
       git::commit=tags/vulkan-sdk-$SPIRV_TOOLS_VER;rename=SPIRV-Tools::https://github.com/KhronosGroup/SPIRV-Tools.git \
       git::commit=tags/vulkan-sdk-$SPIRV_TOOLS_VER;rename=SPIRV-Headers::https://github.com/KhronosGroup/SPIRV-Headers.git"
 CHKSUMS="SKIP \
-         sha256::8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a \
+         sha256::8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6 \
          SKIP \
          SKIP \
          SKIP \

--- a/runtime-common/level-zero/spec
+++ b/runtime-common/level-zero/spec
@@ -1,4 +1,4 @@
-VER=1.17.6
+VER=1.17.39
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/oneapi-src/level-zero"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229539"

--- a/runtime-devices/igsc/spec
+++ b/runtime-devices/igsc/spec
@@ -1,4 +1,4 @@
-VER=0.8.16
+VER=0.9.3
 SRCS="git::commit=tags/V$VER::https://github.com/intel/igsc.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229526"

--- a/runtime-devices/intel-gmmlib/spec
+++ b/runtime-devices/intel-gmmlib/spec
@@ -1,4 +1,4 @@
-VER=22.3.20
+VER=22.5.1
 SRCS="git::commit=tags/intel-gmmlib-$VER;copy-repo=true::https://github.com/intel/gmmlib"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20342"

--- a/runtime-devices/metee/spec
+++ b/runtime-devices/metee/spec
@@ -1,4 +1,4 @@
-VER=4.0.0
+VER=4.2.0
 SRCS="git::commit=tags/$VER::https://github.com/intel/metee.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230452"

--- a/runtime-scientific/intel-compute-runtime/autobuild/beyond
+++ b/runtime-scientific/intel-compute-runtime/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Symlinking libze_intel_gpu.so ..."
+ln -sv $(find "${PKGDIR}"/usr/lib -regex '.*libze_intel_gpu.so.[0-9]*' -exec basename {} \;) "${PKGDIR}"/usr/lib/libze_intel_gpu.so

--- a/runtime-scientific/intel-compute-runtime/autobuild/defines
+++ b/runtime-scientific/intel-compute-runtime/autobuild/defines
@@ -1,13 +1,20 @@
 PKGNAME=intel-compute-runtime
 PKGSEC=libs
-PKGDEP="gcc-runtime intel-gmmlib intel-graphics-compiler libdrm libva igsc level-zero"
-BUILDDEP="intel-gmmlib intel-graphics-compiler libdrm libva igsc level-zero"
+PKGDEP="gcc-runtime intel-gmmlib intel-graphics-compiler"
+BUILDDEP="igsc level-zero libva opencl-registry-api"
 PKGDES="Intel Graphics Compute Runtime for oneAPI Level Zero and OpenCL Driver"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=" \
-    -DSKIP_UNIT_TESTS=1 \
+    -DKHRONOS_GL_HEADERS_DIR=/usr/include \
+    -DKHRONOS_HEADERS_DIR=/usr/include \
     -DNEO_DISABLE_LD_GOLD:BOOL=ON \
+    -DNEO_OCL_VERSION_MAJOR=${PKGVER%%.*} \
+    -DNEO_OCL_VERSION_MINOR=$(echo ${PKGVER} | cut -d . -f2) \
+    -DNEO_VERSION_BUILD=$(echo ${PKGVER} | cut -d . -f3) \
+    -DSKIP_UNIT_TESTS=1 \
+    -DSUPPORT_DG1=ON \
+    -DSUPPORT_DG2=ON \
 "
 
 NOLTO=1

--- a/runtime-scientific/intel-compute-runtime/spec
+++ b/runtime-scientific/intel-compute-runtime/spec
@@ -1,4 +1,4 @@
-VER=24.26.30049.6
+VER=24.31.30508.7
 SRCS="git::commit=tags/$VER::https://github.com/intel/compute-runtime.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229527"


### PR DESCRIPTION
Topic Description
-----------------

- intel-compute-runtime: update to 24.31.30508.7
    Dependencies:
    - intel-graphics-compiler: update to 1.0.17384.11
    - metee: update to 4.2.0
    - igsc: update to 0.9.3
    - level-zero: update to 1.17.39
    - intel-gmmlib: update to 22.5.1

Package(s) Affected
-------------------
- igsc: 0.9.3
- intel-compute-runtime: 24.31.30508.7
- intel-gmmlib: 2.5.1
- intel-graphics-compiler: 1.0.17384.11
- level-zero: 1.17.39
- metee: 4.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-gmmlib metee igsc level-zero intel-graphics-compiler intel-compute-runtime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
