### PR TITLE
intel-oneapi-basekit: fix package dependency

### DIFF
--- a/app-devel/intel-oneapi-basekit/autobuild/defines
+++ b/app-devel/intel-oneapi-basekit/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=intel-oneapi-basekit
 PKGSEC=devel
-PKGDEP="debconf intel-compute-runtime nss glib mesa libdrm at-spi2-core libxcb gtk-3"
+PKGDEP="debconf intel-compute-runtime nss glib mesa libdrm at-spi2-core libxcb gtk-3 level-zero"
 PKGDES="Intel oneAPI base toolkit"
 
 FAIL_ARCH="!(amd64)"

--- a/app-devel/intel-oneapi-basekit/spec
+++ b/app-devel/intel-oneapi-basekit/spec
@@ -4,3 +4,4 @@ PKG_CODE=100
 SRCS="file::rename=l_BaseKit_p_"${VER}"."${PKG_CODE}"_offline.sh::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"${PKG_URL}"/l_BaseKit_p_"${VER}"."${PKG_CODE}"_offline.sh"
 CHKSUMS="sha256::bfd0b61db946549f72104cda11af01790142b371b17340f3a7cd45fe0c900cba"
 CHKUPDATE="anitya::id=372585"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- intel-oneapi-basekit: fix package dependency
    Add the missing dependency level-zero due to recent relevant package updates.

Package(s) Affected
-------------------

- intel-oneapi-basekit: 2024.2.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-oneapi-basekit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
