### PR TITLE
sudo: update to 1.9.16

### DIFF
--- a/app-admin/sudo/spec
+++ b/app-admin/sudo/spec
@@ -1,5 +1,4 @@
-VER=1.9.15p5
+VER=1.9.16
 SRCS="tbl::https://www.sudo.ws/dist/sudo-$VER.tar.gz"
-CHKSUMS="sha256::558d10b9a1991fb3b9fa7fa7b07ec4405b7aefb5b3cb0b0871dbc81e3a88e558"
+CHKSUMS="sha256::c0d84d797f06b732fc573d0b798ae83128c2bc33052057f05b560ec6bcbfa03d"
 CHKUPDATE="anitya::id=4906"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- sudo: update to 1.9.16

Package(s) Affected
-------------------

- sudo: 1.9.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit sudo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
