### PR TITLE
neofetch: list all Intel GPUs as detected

### DIFF
--- a/app-utils/neofetch/autobuild/patches/0001-neofetch-AOSC-OS-print-dpkg-architecture-where-possi.patch
+++ b/app-utils/neofetch/autobuild/patches/0001-neofetch-AOSC-OS-print-dpkg-architecture-where-possi.patch
@@ -1,7 +1,7 @@
 From 5b7bf6cf969429b5068dc151018882ecfb129a56 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Fri, 21 Oct 2022 18:06:45 -0700
-Subject: [PATCH 1/2] neofetch: (AOSC OS) print dpkg architecture where
+Subject: [PATCH 1/3] neofetch: (AOSC OS) print dpkg architecture where
  possible
 
 ---
@@ -26,5 +26,5 @@ index c2f56f04..a07a8e68 100755
      if [[ "$kernel_name" == "Darwin" ]] ||
         [[ "$kernel_name" == "FreeBSD" && -f /System/Library/CoreServices/SystemVersion.plist ]]; then
 -- 
-2.44.0
+2.46.0
 

--- a/app-utils/neofetch/autobuild/patches/0002-neofetch-AOSC-OS-add-quotation-marks-around-architec.patch
+++ b/app-utils/neofetch/autobuild/patches/0002-neofetch-AOSC-OS-add-quotation-marks-around-architec.patch
@@ -1,7 +1,7 @@
 From 6916763b8e9be69cac3cd20eb4344d39460f45df Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Fri, 21 Oct 2022 18:16:03 -0700
-Subject: [PATCH 2/2] neofetch: (AOSC OS) add quotation marks around
+Subject: [PATCH 2/3] neofetch: (AOSC OS) add quotation marks around
  architecture name
 
 ---
@@ -22,5 +22,5 @@ index a07a8e68..0dc4bc97 100755
      [[ ${ascii_distro:-auto} == auto ]] && \
          ascii_distro=$(trim "$distro")
 -- 
-2.44.0
+2.46.0
 

--- a/app-utils/neofetch/autobuild/patches/0003-fix-neofetch-list-all-Intel-GPUs-as-detected.patch
+++ b/app-utils/neofetch/autobuild/patches/0003-fix-neofetch-list-all-Intel-GPUs-as-detected.patch
@@ -1,0 +1,46 @@
+From b73e87a05eabc1f5365640425a2c01f7f38d39f5 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 3 Sep 2024 16:41:19 +0800
+Subject: [PATCH 3/3] fix(neofetch): list all Intel GPUs as detected
+
+Now that Intel is selling its own dedicated GPUs, it is increasingly
+common to see laptops and desktop devices with multiple Intel GPUs. This
+patch is intended to fix GPU detection on a laptop with both an integrated
+UHD Graphics GPU and an Arc 380 (DG2).
+
+Note that this may potentially cause regressions, but the original
+upstream did not record the original issue, so I'm inclined to write it
+off as an outdated fix:
+
+  commit ee815f9c6651423ae93f8ead237ebc99e2373c06
+  Author: Dylan Araps <dylan.araps@gmail.com>
+  Date:   Mon Apr 9 09:51:23 2018 +1000
+
+      gpu: Fixed duplicate intel bug.
+---
+ neofetch | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/neofetch b/neofetch
+index 0dc4bc97..84b3a274 100755
+--- a/neofetch
++++ b/neofetch
+@@ -3299,15 +3299,6 @@ get_gpu() {
+ 
+             IFS=$'\n' read -d "" -ra gpus <<< "$gpu_cmd"
+ 
+-            # Remove duplicate Intel Graphics outputs.
+-            # This fixes cases where the outputs are both
+-            # Intel but not entirely identical.
+-            #
+-            # Checking the first two array elements should
+-            # be safe since there won't be 2 intel outputs if
+-            # there's a dedicated GPU in play.
+-            [[ "${gpus[0]}" == *Intel* && "${gpus[1]}" == *Intel* ]] && unset -v "gpus[0]"
+-
+             for gpu in "${gpus[@]}"; do
+                 # GPU shorthand tests.
+                 [[ "$gpu_type" == "dedicated" && "$gpu" == *Intel* ]] || \
+-- 
+2.46.0
+

--- a/app-utils/neofetch/spec
+++ b/app-utils/neofetch/spec
@@ -1,4 +1,5 @@
 VER=7.3.11
+REL=1
 SRCS="git::commit=tags/neofetch-$VER::https://github.com/hykilpikonna/neofetch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16261"


### PR DESCRIPTION
Topic Description
-----------------

- neofetch: list all Intel GPUs as detected
    Now that Intel is selling its own dedicated GPUs, it is increasingly
    common to see laptops and desktop devices with multiple Intel GPUs. This
    patch is intended to fix GPU detection on a laptop with both an
    integrated UHD Graphics GPU and an Arc 380 (DG2).
    Note that this may potentially cause regressions, but the original
    upstream did not record the original issue, so I'm inclined to write it
    off as an outdated fix:
    commit ee815f9c6651423ae93f8ead237ebc99e2373c06
    Author: Dylan Araps <dylan.araps@gmail.com>
    Date:   Mon Apr 9 09:51:23 2018 +1000
    gpu: Fixed duplicate intel bug.

Package(s) Affected
-------------------

- neofetch: 2:7.3.11-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit neofetch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
