### PR TITLE
neovim: update to 0.10.1

### DIFF
--- a/app-editors/neovim/spec
+++ b/app-editors/neovim/spec
@@ -1,4 +1,4 @@
-VER=0.10.0
+VER=0.10.1
 SRCS="git::commit=tags/v$VER::https://github.com/neovim/neovim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9037"


### PR DESCRIPTION
Topic Description
-----------------

- neovim: update to 0.10.1
    Co-authored-by: Suyun (@Suyun114)

Package(s) Affected
-------------------

- neovim: 1:0.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit neovim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
