### PR TITLE
sudo: fix missing of PAM files

### DIFF
--- a/app-admin/sudo/autobuild/overrides/etc/pam.d/sudo-i
+++ b/app-admin/sudo/autobuild/overrides/etc/pam.d/sudo-i
@@ -1,0 +1,4 @@
+#%PAM-1.0
+auth		include		system-auth
+account		include		system-auth
+session		include		system-auth

--- a/app-admin/sudo/spec
+++ b/app-admin/sudo/spec
@@ -1,4 +1,5 @@
 VER=1.9.16
+REL=1
 SRCS="tbl::https://www.sudo.ws/dist/sudo-$VER.tar.gz"
 CHKSUMS="sha256::c0d84d797f06b732fc573d0b798ae83128c2bc33052057f05b560ec6bcbfa03d"
 CHKUPDATE="anitya::id=4906"


### PR DESCRIPTION
Topic Description
-----------------

- sudo: fix missing of PAM files

Package(s) Affected
-------------------

- sudo: 1.9.16-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sudo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
