### PR TITLE
ncmpcpp: update to 0.10

### DIFF
--- a/app-multimedia/ncmpcpp/autobuild/build
+++ b/app-multimedia/ncmpcpp/autobuild/build
@@ -2,10 +2,9 @@ abinfo "Configuring ncmpcpp ..."
 "$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} \
     --enable-clock \
     --enable-outputs \
-    --enable-unicode \
     --enable-visualizer \
-    --with-curl \
     --with-fftw \
+    --with-lto \
     --with-taglib
 
 abinfo "Building ncmpcpp ..."

--- a/app-multimedia/ncmpcpp/spec
+++ b/app-multimedia/ncmpcpp/spec
@@ -1,5 +1,4 @@
-VER=0.9.2
-REL=3
+VER=0.10
 SRCS="git::commit=tags/$VER::https://github.com/arybczak/ncmpcpp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5521"


### PR DESCRIPTION
Topic Description
-----------------

- ncmpcpp: update to 0.10
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- ncmpcpp: 0.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit ncmpcpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
