### PR TITLE
bandwhich: update to 0.23.0

### DIFF
--- a/app-network/bandwhich/spec
+++ b/app-network/bandwhich/spec
@@ -1,4 +1,4 @@
-VER=0.22.2
+VER=0.23.0
 SRCS="git::commit=tags/v$VER::https://github.com/imsnif/bandwhich"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236376"


### PR DESCRIPTION
Topic Description
-----------------

- bandwhich: update to 0.23.0
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- bandwhich: 0.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bandwhich
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
