### PR TITLE
intel-oneapi-basekit: remove packaging log

### DIFF
--- a/app-devel/intel-oneapi-basekit/autobuild/build
+++ b/app-devel/intel-oneapi-basekit/autobuild/build
@@ -3,19 +3,24 @@ PKG_FILENAME=$(ls | grep -oP 'l_BaseKit_p_.+(?=\.sh)')
 abinfo "Extracting Intel oneAPI Base Toolkit package ..."
 sh "${SRCDIR}"/"${PKG_FILENAME}".sh \
     --extract-folder "${SRCDIR}" --extract-only \
-    --remove-extracted-files no
+    --remove-extracted-files no \
+    --log "${SRCDIR}"/extract.log
 
 abinfo "Installing Intel oneAPI Base Toolkit ..."
 sh "${SRCDIR}"/"${PKG_FILENAME}"/install.sh \
     --silent --eula accept \
     --components all \
     --install-dir "${PKGDIR}"/usr/lib/intel/oneapi \
+    --log-dir "${SRCDIR}" \
     --ignore-errors
 
-find "$PKGDIR"/usr/lib/intel/oneapi/licensing/latest/licensing \
+find "${PKGDIR}"/usr/lib/intel/oneapi/licensing/latest/licensing \
     -type f -name "license.htm" \
     -exec install -v -Dm644 {} -t "${PKGDIR}"/usr/share/doc/"${PKGNAME}" \;
 
-mkdir -p "$PKGDIR"/usr/bin
-cd "$PKGDIR"/usr/bin
+mkdir -pv "${PKGDIR}"/usr/bin
+cd "${PKGDIR}"/usr/bin
 ln -sv ../lib/intel/oneapi/setvars.sh setup_intel_oneapi.sh
+
+abinfo "Cleaning up Intel oneAPI Base Toolkit installation leftover ..."
+rm -v "${PKGDIR}"/usr/lib/intel/oneapi/logs/*

--- a/app-devel/intel-oneapi-basekit/spec
+++ b/app-devel/intel-oneapi-basekit/spec
@@ -4,4 +4,4 @@ PKG_CODE=100
 SRCS="file::rename=l_BaseKit_p_"${VER}"."${PKG_CODE}"_offline.sh::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"${PKG_URL}"/l_BaseKit_p_"${VER}"."${PKG_CODE}"_offline.sh"
 CHKSUMS="sha256::bfd0b61db946549f72104cda11af01790142b371b17340f3a7cd45fe0c900cba"
 CHKUPDATE="anitya::id=372585"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- intel-oneapi-basekit: remove packaging log

Package(s) Affected
-------------------

- intel-oneapi-basekit: 2024.2.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-oneapi-basekit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
