### PR TITLE
openssl: security update to 3.3.2

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.3.21
+VER=4.3.23
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/runtime-cryptography/openssl/spec
+++ b/runtime-cryptography/openssl/spec
@@ -1,4 +1,4 @@
-VER=3.3.1
-SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e"
+VER=3.3.2
+SRCS="tbl::https://github.com/openssl/openssl/releases/download/openssl-$VER/openssl-$VER.tar.gz"
+CHKSUMS="sha256::2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281"
 CHKUPDATE="anitya::id=2566"

--- a/runtime-optenv32/openssl+32/autobuild/build
+++ b/runtime-optenv32/openssl+32/autobuild/build
@@ -1,6 +1,6 @@
 abinfo "Setting up the environment ..."
 export PATH="/opt/32/bin:$PATH"
-export CC=i686-pc-linux-gnu-gcc
+export CC="i686-aosc-linux-gnu-gcc"
 export CPPFLAGS="${CPPFLAGS} ${CFLAGS}"
 
 abinfo "Configuring openssl+32 ..."

--- a/runtime-optenv32/openssl+32/spec
+++ b/runtime-optenv32/openssl+32/spec
@@ -1,4 +1,4 @@
-VER=3.2.0
-SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::14c826f07c7e433706fb5c69fa9e25dab95684844b4c962a2cf1bf183eb4690e"
+VER=3.3.2
+SRCS="tbl::https://github.com/openssl/openssl/releases/download/openssl-$VER/openssl-$VER.tar.gz"
+CHKSUMS="sha256::2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281"
 CHKUPDATE="anitya::id=2566"


### PR DESCRIPTION
Topic Description
-----------------

- openssl+32: update to 3.3.2
- openssl: update to 3.3.2
- autobuild4: update to 4.3.23
    This version contains a change that appends /usr/bin/core_perl to PATH. This
    change is needed to build OpenSSL without a specific prepare hack, as the
    build system calls pod2man - which is not in the default PATH
    (/usr/bin/core_perl).

Package(s) Affected
-------------------

- autobuild4: 4.3.23
- openssl: 3.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 openssl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
