### PR TITLE
coreboot-utils: update to 24.08

### DIFF
--- a/app-admin/coreboot-utils/spec
+++ b/app-admin/coreboot-utils/spec
@@ -1,4 +1,4 @@
-VER=24.05
+VER=24.08
 SRCS="https://www.coreboot.org/releases/coreboot-$VER.tar.xz"
-CHKSUMS="sha256::e22afdbac40068ba687fd975f03f6b958599a32e70f539d9d0c74d16a63d7cea"
+CHKSUMS="sha256::1fc9a997d497539f915dc6498e4aca4bf049955d4db9a17a85454ad6b342710c"
 CHKUPDATE="anitya::id=10128"


### PR DESCRIPTION
Topic Description
-----------------

- coreboot-utils: update to 24.08
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- coreboot-utils: 24.08

Security Update?
----------------

No

Build Order
-----------

```
#buildit coreboot-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
