### PR TITLE
egl-wayland: update to 1.1.16

### DIFF
--- a/runtime-display/egl-wayland/autobuild/defines
+++ b/runtime-display/egl-wayland/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=egl-wayland
 PKGSEC=libs
-PKGDEP="eglexternalplatform wayland"
+PKGDEP="libglvnd eglexternalplatform wayland"
 PKGDES="The EGLStream-based Wayland external platform"
 
 ABTYPE=meson

--- a/runtime-display/egl-wayland/autobuild/overrides/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
+++ b/runtime-display/egl-wayland/autobuild/overrides/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
@@ -1,0 +1,6 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libnvidia-egl-gbm.so.1"
+    }
+}

--- a/runtime-display/egl-wayland/spec
+++ b/runtime-display/egl-wayland/spec
@@ -1,4 +1,4 @@
-VER=1.1.14
+VER=1.1.16
 SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/egl-wayland"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17778"


### PR DESCRIPTION
Topic Description
-----------------

- egl-wayland: update to 1.1.16
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- egl-wayland: 1.1.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit egl-wayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
