### PR TITLE
egl-wayland: remove 15_nvidia_gbm.json provided by nvidia

### DIFF
--- a/runtime-display/egl-wayland/autobuild/overrides/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
+++ b/runtime-display/egl-wayland/autobuild/overrides/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
@@ -1,6 +1,0 @@
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libnvidia-egl-gbm.so.1"
-    }
-}

--- a/runtime-display/egl-wayland/spec
+++ b/runtime-display/egl-wayland/spec
@@ -1,4 +1,5 @@
 VER=1.1.16
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/egl-wayland"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17778"


### PR DESCRIPTION
Topic Description
-----------------

- egl-wayland: remove 15_nvidia_gbm.json provided by nvidia
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- egl-wayland: 1.1.16-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit egl-wayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
