### PR TITLE
weston: update to 14.0.0

### DIFF
--- a/runtime-display/weston/spec
+++ b/runtime-display/weston/spec
@@ -1,4 +1,4 @@
-VER=13.0.0
+VER=14.0.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wayland/weston"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13745"


### PR DESCRIPTION
Topic Description
-----------------

- weston: update to 14.0.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- weston: 14.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit weston
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
