### PR TITLE
scrcpy: update to 2.6.1

### DIFF
--- a/app-devices/scrcpy/spec
+++ b/app-devices/scrcpy/spec
@@ -1,7 +1,7 @@
-VER=2.4
+VER=2.6.1
 SRCS="git::commit=tags/v$VER::https://github.com/Genymobile/scrcpy \
       file::rename=scrcpy-server::https://github.com/Genymobile/scrcpy/releases/download/v$VER/scrcpy-server-v$VER"
 CHKSUMS="SKIP \
-         sha256::93c272b7438605c055e127f7444064ed78fa9ca49f81156777fd201e79ce7ba3"
+         sha256::ca7ab50b2e25a0e5af7599c30383e365983fa5b808e65ce2e1c1bba5bfe8dc3b"
 SUBDIR="scrcpy"
 CHKUPDATE="anitya::id=226924"


### PR DESCRIPTION
Topic Description
-----------------

- scrcpy: update to 2.6.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- scrcpy: 2.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit scrcpy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
