### PR TITLE
sing-box: update to 1.9.4

### DIFF
--- a/app-network/sing-box/spec
+++ b/app-network/sing-box/spec
@@ -1,4 +1,4 @@
-VER=1.8.13
+VER=1.9.4
 SRCS="git::commit=tags/v$VER::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"


### PR DESCRIPTION
Topic Description
-----------------

- sing-box: update to 1.9.4
    Co-authored-by: Lain Yang (@Fearyncess) <fsf@live.com>

Package(s) Affected
-------------------

- sing-box: 1.9.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit sing-box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
