### PR TITLE
zfs: update to 2.2.6

### DIFF
--- a/app-admin/zfs/autobuild/build
+++ b/app-admin/zfs/autobuild/build
@@ -19,10 +19,10 @@ cd "$SRCDIR"/build
     PYTHON=/usr/bin/python3
 
 abinfo "Building ZFS userspace tools ..."
+cp -rv "$SRCDIR"/{contrib,build/}
 make
 
 abinfo "Installing ZFS userspace tools ..."
-cp -rv "$SRCDIR"/{contrib,build/}
 make DESTDIR="${PKGDIR}" install
 
 cd "$SRCDIR"

--- a/app-admin/zfs/autobuild/patches/0005-META-Bump-Linux-Maximum-to-6.10.patch
+++ b/app-admin/zfs/autobuild/patches/0005-META-Bump-Linux-Maximum-to-6.10.patch
@@ -1,7 +1,7 @@
 From 660bf235f2d3d801229176fe1d1132c6d203bd31 Mon Sep 17 00:00:00 2001
 From: Shengqi Chen <harry-chen@outlook.com>
-Date: Tue, 13 Aug 2024 16:16:39 +0800
-Subject: [PATCH 5/5] META: Bump Linux-Maximum to 6.10
+Date: Thu, 05 Sep 2024 20:30:39 +0800
+Subject: [PATCH 5/5] META: Bump Linux-Maximum to 6.11
 
 See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/master/debian/patches/bump-linux-maximum.patch
 
@@ -18,8 +18,8 @@ index 14cfc5f00..35428285e 100644
  Release-Tags:  relext
  License:       CDDL
  Author:        OpenZFS
--Linux-Maximum: 6.9
-+Linux-Maximum: 6.10
+-Linux-Maximum: 6.10
++Linux-Maximum: 6.11
  Linux-Minimum: 3.10
 -- 
 2.39.2

--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,5 +1,4 @@
-VER=2.2.5
-REL=1
-SRCS="tbl::https://github.com/zfsonlinux/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
-CHKSUMS="sha256::2388cf6f29cd75e87d6d05e4858a09d419c4f883a658d51ef57796121cd08897"
+VER=2.2.6
+SRCS="tbl::https://github.com/openzfs/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
+CHKSUMS="sha256::c92e02103ac5dd77bf01d7209eabdca55c7b3356aa747bb2357ec4222652a2a7"
 CHKUPDATE="anitya::id=11706"


### PR DESCRIPTION
Topic Description
-----------------

- zfs: update to 2.2.6, refresh patches
    Signed-off-by: Shengqi Chen <harry-chen@outlook.com>

Package(s) Affected
-------------------

- zfs: 2.2.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit zfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
