### PR TITLE
endless-sky: new, 0.10.8

### DIFF
--- a/app-games/endless-sky/autobuild/beyond
+++ b/app-games/endless-sky/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Install endless-sky ..."
+install -Dvm755 "$SRCDIR"/abbuild/endless-sky \
+    "$PKGDIR"/usr/bin/endless-sky

--- a/app-games/endless-sky/autobuild/defines
+++ b/app-games/endless-sky/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=endless-sky
+PKGSEC=games
+PKGDES="Space exploration, trading, and combat game"
+PKGDEP="sdl2 libpng zlib libjpeg-turbo openal-soft libmad util-linux-runtime \
+        libglvnd glew gcc-runtime glibc x11-lib libxcb libxau libxdmcp"

--- a/app-games/endless-sky/spec
+++ b/app-games/endless-sky/spec
@@ -1,0 +1,4 @@
+VER=0.10.8
+SRCS="git::commit=tags/v$VER::https://github.com/endless-sky/endless-sky.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=10359"


### PR DESCRIPTION
Topic Description
-----------------

- endless-sky: new, 0.10.8

Package(s) Affected
-------------------

- endless-sky: 0.10.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit endless-sky
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
