### PR TITLE
xviewer: update to 3.4.6

### DIFF
--- a/app-imaging/xviewer/spec
+++ b/app-imaging/xviewer/spec
@@ -1,4 +1,4 @@
-VER=3.0.2
-SRCS="tbl::https://github.com/linuxmint/xviewer/archive/$VER.tar.gz"
-CHKSUMS="sha256::ffced7574ac1f8f6ebde41c83eee25fdfeb4566f4f4dd972fda4a8e410745b8f"
+VER=3.4.6
+SRCS="git::commit=tags/$VER::https://github.com/linuxmint/xviewer.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13328"


### PR DESCRIPTION
Topic Description
-----------------

- xviewer: update to 3.4.6

Package(s) Affected
-------------------

- xviewer: 3.4.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit xviewer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
