### PR TITLE
rustc: update to 1.81.0

### DIFF
--- a/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,4 +1,4 @@
-From 123d4b5c02d3f89e9c9c254288963b72cf6a6d93 Mon Sep 17 00:00:00 2001
+From 1e21011f5612a2ae77e363217060513572b379f6 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
 Subject: [PATCH 1/2] Add i486-unknown-linux-gnu compiler target
@@ -10,10 +10,10 @@ Subject: [PATCH 1/2] Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index fe07d11672..c81dd75a3b 100644
+index 607eeac7cc..6278e69006 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1528,6 +1528,7 @@ supported_targets! {
+@@ -1542,6 +1542,7 @@ supported_targets! {
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),

--- a/lang-rust/rustc/autobuild/patches/0002-Add-MIPS-definitions-to-vendored-libffi-sys.patch
+++ b/lang-rust/rustc/autobuild/patches/0002-Add-MIPS-definitions-to-vendored-libffi-sys.patch
@@ -1,4 +1,4 @@
-From 70ddd78d0f195802786707c53bd715119c52cd37 Mon Sep 17 00:00:00 2001
+From 9f944a0e2c7ee6a5fee1ff41c793291712a482bf Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:40 -0800
 Subject: [PATCH 2/2] Add MIPS definitions to vendored libffi-sys

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,4 +1,4 @@
-VER=1.80.1
+VER=1.81.0
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::6ab79b70dc57737a1de378f212fcf8852d67fe6cf272d122a15b3ea13be77947"
+CHKSUMS="sha256::36217ef7e32f40a180e3d79bd666b4dfdaed49dd381023a5fb765fd12d0092ce"
 CHKUPDATE="anitya::id=7635"


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.81.0
    Refresh patches at AOSC-Tracking/rustc @ aosc/v1.81.0.

Package(s) Affected
-------------------

- rustc: 1:1.81.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
