### PR TITLE
mesa (The Mesa 3D Graphics Library): update to 24.2.2

### DIFF
--- a/runtime-display/mesa/autobuild/patches/0001-zink-reject-Imagination-proprietary-driver-w-o-geome.patch
+++ b/runtime-display/mesa/autobuild/patches/0001-zink-reject-Imagination-proprietary-driver-w-o-geome.patch
@@ -1,4 +1,4 @@
-From c6e76ab84f0ad66ac07be1d8f04c8a5e6bd9a8cb Mon Sep 17 00:00:00 2001
+From 33fa3c3fac46dd62910921afb7f3955a67e78815 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 20 Jul 2024 22:03:54 +0800
 Subject: [PATCH 1/3] zink: reject Imagination proprietary driver w/o

--- a/runtime-display/mesa/autobuild/patches/0002-r600-disable-buggy-vc-1-hardware-decoding.patch
+++ b/runtime-display/mesa/autobuild/patches/0002-r600-disable-buggy-vc-1-hardware-decoding.patch
@@ -1,7 +1,7 @@
-From e6cec29d48e6c87565119c5f44977abe2b4e28c9 Mon Sep 17 00:00:00 2001
+From 14de61e0dadd762ea37d32a0f1c186357519a863 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
-Subject: [PATCH 3/3] r600: disable buggy vc-1 hardware decoding
+Subject: [PATCH 2/3] r600: disable buggy vc-1 hardware decoding
 
 ---
  src/gallium/drivers/r600/radeon_video.c | 2 +-

--- a/runtime-display/mesa/autobuild/patches/0003-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384.patch.loongarch64
+++ b/runtime-display/mesa/autobuild/patches/0003-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384.patch.loongarch64
@@ -1,7 +1,7 @@
-From 902bf75316a1110010ca6fde85a6ed690ed18958 Mon Sep 17 00:00:00 2001
+From ecf259590daa37c1c41dfd30c39858b851483baf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
-Subject: [PATCH 2/3] fix(iris_bufmgr.c): set PAGE_SIZE as 16384
+Subject: [PATCH 3/3] fix(iris_bufmgr.c): set PAGE_SIZE as 16384
 
 Obviously not ideal, but this is simply meant as a preview/PoC.
 ---

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,10 +1,9 @@
-UPSTREAM_VER=24.2.1
+UPSTREAM_VER=24.2.2
 DXHEADERS_VER=1.614.0
 VER=${UPSTREAM_VER}+dxheaders${DXHEADERS_VER}
-REL=1
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
-CHKSUMS="sha256::fc9a495f3a9af906838be89367564e10ef335e058f88965ad49ccc3e9a3b420b \
+CHKSUMS="sha256::fd077d3104edbe459e2b8597d2757ec065f9bd2d620b8c0b9cc88c2bf9891d02 \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 24.2.2
    Refresh patches at AOSC-Tracking/mesa @ aosc/mesa-24.2.2.

Package(s) Affected
-------------------

- mesa: 1:24.2.2+dxheaders1.614.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
