### PR TITLE
shotcut: fix desktop categories

### DIFF
--- a/app-creativity/shotcut/autobuild/overrides/usr/share/applications/shotcut.desktop
+++ b/app-creativity/shotcut/autobuild/overrides/usr/share/applications/shotcut.desktop
@@ -9,4 +9,4 @@ Exec=shotcut
 Terminal=false
 Type=Application
 Icon=applications-multimedia
-Categories=Categories=AudioVideo;Audio;Video;
+Categories=AudioVideo;Audio;Video;

--- a/app-creativity/shotcut/spec
+++ b/app-creativity/shotcut/spec
@@ -1,5 +1,5 @@
 VER=21.08.11
-REL=2
+REL=3
 SRCS="tbl::https://github.com/mltframework/shotcut/archive/v$VER.tar.gz"
 CHKSUMS="sha256::8e030dd51dfdb357fc5455fdbc9ef835bab476f7c85448d21097bca9b4c2a9cf"
 CHKUPDATE="anitya::id=20347"


### PR DESCRIPTION
Topic Description
-----------------

- shotcut: fix desktop categories

Package(s) Affected
-------------------

- shotcut: 21.08.11-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit shotcut
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
