### PR TITLE
oma: update to 1.9.0

### DIFF
--- a/app-admin/oma/autobuild/beyond
+++ b/app-admin/oma/autobuild/beyond
@@ -23,11 +23,6 @@ mkdir -pv "$PKGDIR"/usr/share/polkit-1/actions
 cp -v "$SRCDIR"/data/policykit/io.aosc.oma.apply.policy \
 	"$PKGDIR"/usr/share/polkit-1/actions
 
-abinfo "Installing systemd files ..."
-mkdir -pv "$PKGDIR"/usr/share/systemd/system
-cp -v "$SRCDIR"/data/systemd/* \
-	"$PKGDIR"/usr/share/systemd/system
-
 abinfo "Installing bash completions ..."
 mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions
 cp -v "$SRCDIR"/data/completions/oma.bash \

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.8.2
-SRCS="git::commit=tags/v${VER/\~beta/-beta.}::https://github.com/AOSC-Dev/oma"
+VER=1.9.0
+SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.9.0

Package(s) Affected
-------------------

- oma: 1.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



