### PR TITLE
ca-certs: update to 20240828

### DIFF
--- a/runtime-data/ca-certs/spec
+++ b/runtime-data/ca-certs/spec
@@ -1,4 +1,6 @@
-VER=20240703
-CHANGESET=e3195e969188a333692e5e366d6fda6bb8d7c761
+VER=20240828
+CHANGESET=9727cd2f7983d01cc4fd3b5ef21b72fc8f6a052a
 SRCS="file::rename=certdata.txt::https://hg.mozilla.org/mozilla-central/raw-file/$CHANGESET/security/nss/lib/ckfw/builtins/certdata.txt"
-CHKSUMS="sha256::456ff095dde6dd73354c5c28c73d9c06f53b61a803963414cb91a1d92945cdd3"
+CHKSUMS="sha256::36105b01631f9fc03b1eca779b44a30a1a5890b9bf8dc07ccb001a07301e01cf"
+
+# FIXME: Check for updates at https://hg.mozilla.org/mozilla-central/log/tip/security/nss/lib/ckfw/builtins/certdata.txt


### PR DESCRIPTION
Topic Description
-----------------

- ca-certs: update to 20240828

Package(s) Affected
-------------------

- ca-certs: 20240828

Security Update?
----------------

No

Build Order
-----------

```
#buildit ca-certs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
