### PR TITLE
trivy: new, 0.55.0

### DIFF
--- a/app-devel/trivy/autobuild/build
+++ b/app-devel/trivy/autobuild/build
@@ -1,0 +1,19 @@
+# enter build directory manually
+# because goreleaser needs git directory to be clean
+cd "$SRCDIR"/trivy
+
+abinfo "Building trivy ..."
+# FIXME: trivy does not build simply with normal "go build"
+#        use autobuild gomod template, drop goreleaser build-dep,
+#        drop SUBDIR and drop copy-repo once goreleaser can be dropped
+goreleaser build --single-target
+
+abinfo "Installing trivy ..."
+install -Dvm644 "$SRCDIR"/trivy/dist/*/trivy \
+    "$PKGDIR"/usr/bin/trivy
+chmod -v +x "$PKGDIR"/usr/bin/trivy
+
+abinfo "Installing default templates ..."
+mkdir -vp "$PKGDIR"/usr/share/trivy/templates
+cp -v "$SRCDIR"/trivy/contrib/*.tpl \
+    "$PKGDIR"/usr/share/trivy/templates

--- a/app-devel/trivy/autobuild/defines
+++ b/app-devel/trivy/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=trivy
+PKGSEC=devel
+BUILDDEP="go goreleaser"
+PKGDES="A software security scanner for multiple kinds of inputs"
+
+# FIXME: Autobuild does not yet support splitting out debug symbol from Go executables
+ABSPLITDBG=0
+
+# FIXME: goreleaser does not build properly on these archs
+FAIL_ARCH="loongarch64|loongson3|riscv64"

--- a/app-devel/trivy/spec
+++ b/app-devel/trivy/spec
@@ -1,0 +1,5 @@
+VER=0.55.0
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/aquasecurity/trivy"
+CHKSUMS=SKIP
+CHKUPDATE="anitya::id=141362"
+SUBDIR="."

--- a/lang-golang/goreleaser/autobuild/beyond
+++ b/lang-golang/goreleaser/autobuild/beyond
@@ -1,0 +1,21 @@
+abinfo "Building shell completions ..."
+"$SRCDIR"/scripts/completions.sh
+
+abinfo "Building manpages ..."
+"$SRCDIR"/scripts/manpages.sh
+
+abinfo "Installing shell completions ..."
+install -Dvm644 "$SRCDIR"/completions/goreleaser.bash \
+    "$PKGDIR"/usr/share/bash-completion/completions/goreleaser
+install -Dvm644 "$SRCDIR"/completions/goreleaser.fish \
+    "$PKGDIR"/usr/share/fish/vendor_completions.d/goreleaser.fish
+install -Dvm644 "$SRCDIR"/completions/goreleaser.zsh \
+    "$PKGDIR"/usr/share/zsh/vendor-completions/_goreleaser
+
+abinfo "Installing manpages ..."
+install -Dvm644 "$SRCDIR"/manpages/goreleaser.1.gz \
+    "$PKGDIR"/usr/share/man/man1/goreleaser.1.gz
+
+abinfo "Installing license file ..."
+install -Dvm644 "$SRCDIR"/LICENSE.md \
+    "$PKGDIR"/usr/share/doc/goreleaser/copyright

--- a/lang-golang/goreleaser/autobuild/defines
+++ b/lang-golang/goreleaser/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=goreleaser
+PKGSEC=devel
+PKGDEP="glibc"
+BUILDDEP="go"
+PKGDES="A tool for building and releasing Go projects"
+
+# FIXME: Autobuild does not yet support splitting out debug symbol from Go executables
+ABSPLITDBG=0

--- a/lang-golang/goreleaser/spec
+++ b/lang-golang/goreleaser/spec
@@ -1,0 +1,4 @@
+VER=2.2.0
+SRCS="git::commit=tags/v$VER::https://github.com/goreleaser/goreleaser.git"
+CHKSUMS=SKIP
+CHKUPDATE="anitya::id=374129"


### PR DESCRIPTION
Topic Description
-----------------

- trivy: new, 0.55.0
- goreleaser: new, 2.2.0

Package(s) Affected
-------------------

- goreleaser: 2.2.0
- trivy: 0.55.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit goreleaser trivy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
