### PR TITLE
Desktop Defaults Survey (September, 2024)

### DIFF
--- a/desktop-displaymanagers/sddm/autobuild/overrides/etc/sddm.conf
+++ b/desktop-displaymanagers/sddm/autobuild/overrides/etc/sddm.conf
@@ -14,7 +14,7 @@ User=
 HaltCommand=/usr/bin/systemctl poweroff
 
 # Input method module
-InputMethod=
+InputMethod=qtvirtualkeyboard
 
 # Initial NumLock state. Can be on, off or none.
 # If property is set to none, numlock won't be changed
@@ -28,7 +28,7 @@ RebootCommand=/usr/bin/systemctl reboot
 [Theme]
 # Current theme name
 Current=breeze
- 
+
 # Cursor theme used in the greeter
 CursorTheme=breeze_cursors
 

--- a/desktop-displaymanagers/sddm/spec
+++ b/desktop-displaymanagers/sddm/spec
@@ -1,4 +1,5 @@
 VER=0.21.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/sddm/sddm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4776"

--- a/runtime-data/plasma-default-settings/spec
+++ b/runtime-data/plasma-default-settings/spec
@@ -1,3 +1,3 @@
-VER=2024.04.0
+VER=2024.09.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-default-settings"
 CHKSUMS="SKIP"

--- a/runtime-devices/libinput/autobuild/patches/0001-fix-evdev-mt-touchpad-tap.c-enable-tap-to-click-by-d.patch
+++ b/runtime-devices/libinput/autobuild/patches/0001-fix-evdev-mt-touchpad-tap.c-enable-tap-to-click-by-d.patch
@@ -1,0 +1,54 @@
+From 33aa42d5a50f13dd8b48f1385a7de29aa9010c87 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 10 Sep 2024 00:10:11 +0800
+Subject: [PATCH] fix(evdev-mt-touchpad-tap.c): enable tap-to-click by default
+
+Seriously, it's 2024... This is a partial revert of:
+
+  commit 2219c12c3aa45b80f235e761e87c17fb9ec70eae
+  Author: Peter Hutterer <peter.hutterer@who-t.net>
+  Date:   Tue Feb 4 10:38:21 2014 +1000
+
+    touchpad: hook up to the tapping configuration
+
+    Now that we have run-time changes of the tap.enabled state move the check
+    to the IDLE state only. Otherwise the tap machine may hang if tapping is
+    disabled while a gesture is in progress.
+
+    Two basic tests are added to check for the tap default setting - which is now
+    "tap disabled by default", for two reasons:
+    * if you don't know that tapping is a thing (or enabled by default), you get
+      spurious button events that make the desktop feel buggy.
+    * if you do know what tapping is and you want it, you usually know where to
+      enable it, or at least you can search for it.
+
+    Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>
+---
+ src/evdev-mt-touchpad-tap.c | 11 -----------
+ 1 file changed, 11 deletions(-)
+
+diff --git a/src/evdev-mt-touchpad-tap.c b/src/evdev-mt-touchpad-tap.c
+index 299cd554..6e332275 100644
+--- a/src/evdev-mt-touchpad-tap.c
++++ b/src/evdev-mt-touchpad-tap.c
+@@ -1425,17 +1425,6 @@ tp_tap_default(struct evdev_device *evdev)
+ 	 */
+ 	if (!libevdev_has_event_code(evdev->evdev, EV_KEY, BTN_LEFT))
+ 		return LIBINPUT_CONFIG_TAP_ENABLED;
+-
+-	/**
+-	 * Tapping is disabled by default for two reasons:
+-	 * * if you don't know that tapping is a thing (or enabled by
+-	 *   default), you get spurious mouse events that make the desktop
+-	 *   feel buggy.
+-	 * * if you do know what tapping is and you want it, you
+-	 *   usually know where to enable it, or at least you can search for
+-	 *   it.
+-	 */
+-	return LIBINPUT_CONFIG_TAP_DISABLED;
+ }
+ 
+ static enum libinput_config_tap_state
+-- 
+2.46.0
+

--- a/runtime-devices/libinput/spec
+++ b/runtime-devices/libinput/spec
@@ -1,4 +1,4 @@
-VER=1.26.1
+VER=1.26.2
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/libinput/libinput"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5781"


### PR DESCRIPTION
Topic Description
-----------------

- sddm: enable qtvirtualkeyboard input support
    This would add a button on the login screen, with which the user can click and
    invoke an on-screen keyboard.
- libinput: update to 1.26.2
    - Patch to enable tap-to-click by default (which was disabled circa 2014).
    - Track patches at AOSC-Tracking/libinput @ aosc/1.26.2.
- plasma-default-settings: update to 2024.09.0
    - Add Meta-Shift-S shortcut for Spectacle, conforming to Windows behaviors.
    - Add a pretty name for Spectacle.

Package(s) Affected
-------------------

- libinput: 1.26.2
- plasma-default-settings: 1:2024.09.0
- sddm: 1:0.21.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit plasma-default-settings libinput sddm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
