### PR TITLE
linux-kernel: update to 6.10.9

### DIFF
--- a/app-admin/kernel-tools/autobuild/patches/0001-more-uarches-for-kernel-6.8-rc4-.patch.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0001-more-uarches-for-kernel-6.8-rc4-.patch.patch
@@ -1,4 +1,4 @@
-From 8d500dcf6a122095f7da4a4bd3d91ea4794720af Mon Sep 17 00:00:00 2001
+From 9bc86891d6b676dec7cf65a409b762ac2576d455 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 00:31:56 +0800
 Subject: [PATCH 001/105] more-uarches-for-kernel-6.8-rc4+.patch

--- a/app-admin/kernel-tools/autobuild/patches/0002-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0002-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,4 +1,4 @@
-From 093fff29080ccbadd8c9c052df937b38674bef43 Mon Sep 17 00:00:00 2001
+From b0ad048f2f307df6b24ae05a9e20dfd497dbf84c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:36:33 +0800
 Subject: [PATCH 002/105] Input: Add driver for PixArt PS/2 touchpad

--- a/app-admin/kernel-tools/autobuild/patches/0003-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
+++ b/app-admin/kernel-tools/autobuild/patches/0003-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
@@ -1,4 +1,4 @@
-From 3b829704f8eba5743b1c7a09c858b9328210c347 Mon Sep 17 00:00:00 2001
+From f58b095801c2790e4c56ecac66eb820c9728d191 Mon Sep 17 00:00:00 2001
 From: Mark Weiman <mark.weiman@markzz.com>
 Date: Wed, 27 Jan 2021 13:28:09 -0500
 Subject: [PATCH 003/105] pci: Enable overrides for missing ACS capabilities

--- a/app-admin/kernel-tools/autobuild/patches/0004-cpuinfo-fix-a-warning-for-CONFIG_CPUMASK_OFFSTACK.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0004-cpuinfo-fix-a-warning-for-CONFIG_CPUMASK_OFFSTACK.patch
@@ -1,4 +1,4 @@
-From bad0b78ee8aabae02045dbe16a85c66494061c23 Mon Sep 17 00:00:00 2001
+From 481505e49a250f0c862584240c69adf8f8db74a0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 12 Jul 2022 12:47:48 +0800
 Subject: [PATCH 004/105] cpuinfo: fix a warning for CONFIG_CPUMASK_OFFSTACK

--- a/app-admin/kernel-tools/autobuild/patches/0005-drm-amdgpu-use-amdgpu-by-default-for-si-cik-devices.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0005-drm-amdgpu-use-amdgpu-by-default-for-si-cik-devices.patch
@@ -1,4 +1,4 @@
-From da1a6ecbb3ed78ad6d86c8ef5eee9e4b9244060b Mon Sep 17 00:00:00 2001
+From eb9da968e5e9e752a4efcae0762db27dd737d975 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 29 Feb 2024 20:54:51 +0800
 Subject: [PATCH 005/105] drm: amdgpu: use amdgpu by default for si/cik devices

--- a/app-admin/kernel-tools/autobuild/patches/0006-drm-amdgpu-radeon-disable-cache-flush-workaround-for.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0006-drm-amdgpu-radeon-disable-cache-flush-workaround-for.patch
@@ -1,4 +1,4 @@
-From 0507b4abba4519d1f256639a0b3d733a5a6f1209 Mon Sep 17 00:00:00 2001
+From f9473f3e99a5310258cb4e7a7ab03f05f908f333 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 16 Jul 2024 14:37:00 +0800
 Subject: [PATCH 006/105] drm: amdgpu: radeon: disable cache flush workaround

--- a/app-admin/kernel-tools/autobuild/patches/0007-ethernet-bundle-module-for-Motorcomm-YT6801.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0007-ethernet-bundle-module-for-Motorcomm-YT6801.patch
@@ -1,4 +1,4 @@
-From 012daf7541d04738f41ffd006703139aa6b76a63 Mon Sep 17 00:00:00 2001
+From f6f7f13cb043ccbbef01e5a027dadb93c822c006 Mon Sep 17 00:00:00 2001
 From: wanghuai <748928840@qq.com>
 Date: Fri, 2 Feb 2024 19:05:26 +0000
 Subject: [PATCH 007/105] ethernet: bundle module for Motorcomm YT6801

--- a/app-admin/kernel-tools/autobuild/patches/0008-net-stmmac-Move-the-atds-flag-to-the-stmmac_dma_cfg-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0008-net-stmmac-Move-the-atds-flag-to-the-stmmac_dma_cfg-.patch
@@ -1,4 +1,4 @@
-From 7978adfe9bfec39babe3495496c179ed7ae95b61 Mon Sep 17 00:00:00 2001
+From 3a887dc37b55509c68fd45e135deb932fa3b2b32 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:45:28 +0800
 Subject: [PATCH 008/105] net: stmmac: Move the atds flag to the stmmac_dma_cfg

--- a/app-admin/kernel-tools/autobuild/patches/0009-net-stmmac-Add-multi-channel-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0009-net-stmmac-Add-multi-channel-support.patch
@@ -1,4 +1,4 @@
-From e4cee26aa5ee646703628d6e9f742b51cdf2ec09 Mon Sep 17 00:00:00 2001
+From 46fdedf93430f4fc8e0a9b29511873740cea5191 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:45:29 +0800
 Subject: [PATCH 009/105] net: stmmac: Add multi-channel support

--- a/app-admin/kernel-tools/autobuild/patches/0010-net-stmmac-Export-dwmac1000_dma_ops.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0010-net-stmmac-Export-dwmac1000_dma_ops.patch
@@ -1,4 +1,4 @@
-From 18f49d2580bd8155386c447449dd7b69b88c1427 Mon Sep 17 00:00:00 2001
+From cf26daf8993be2fd5f2703e4da7537b4a3f4b7d2 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:45:30 +0800
 Subject: [PATCH 010/105] net: stmmac: Export dwmac1000_dma_ops

--- a/app-admin/kernel-tools/autobuild/patches/0011-net-stmmac-dwmac-loongson-Drop-duplicated-hash-based.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0011-net-stmmac-dwmac-loongson-Drop-duplicated-hash-based.patch
@@ -1,4 +1,4 @@
-From 64eef03c381ae21ce3ec9100dc239ab0d10b1abf Mon Sep 17 00:00:00 2001
+From ab356bcfd868a271235da4cd4d2516a855c751c6 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:47:07 +0800
 Subject: [PATCH 011/105] net: stmmac: dwmac-loongson: Drop duplicated

--- a/app-admin/kernel-tools/autobuild/patches/0012-net-stmmac-dwmac-loongson-Drop-pci_enable-disable_ms.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0012-net-stmmac-dwmac-loongson-Drop-pci_enable-disable_ms.patch
@@ -1,4 +1,4 @@
-From a8330c574be1d4c4dc2035d9b7161fa9c9ab417d Mon Sep 17 00:00:00 2001
+From f6efcf4b7b144d2cf0eb1ce0dc8d466b29239bab Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:47:08 +0800
 Subject: [PATCH 012/105] net: stmmac: dwmac-loongson: Drop

--- a/app-admin/kernel-tools/autobuild/patches/0013-net-stmmac-dwmac-loongson-Use-PCI_DEVICE_DATA-macro-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0013-net-stmmac-dwmac-loongson-Use-PCI_DEVICE_DATA-macro-.patch
@@ -1,4 +1,4 @@
-From fad364ea9045531fd132965abf21be9737aba981 Mon Sep 17 00:00:00 2001
+From b67fdde8adf0e6b3851c7d276e1801f2bc27b2fe Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:47:09 +0800
 Subject: [PATCH 013/105] net: stmmac: dwmac-loongson: Use PCI_DEVICE_DATA()

--- a/app-admin/kernel-tools/autobuild/patches/0014-net-stmmac-dwmac-loongson-Detach-GMAC-specific-platf.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0014-net-stmmac-dwmac-loongson-Detach-GMAC-specific-platf.patch
@@ -1,4 +1,4 @@
-From 1ca6a63d880de39b76be02c751c36d60e26e98a5 Mon Sep 17 00:00:00 2001
+From 56bd60f345279ac7a053245cbcb7b16c3286d89a Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:47:10 +0800
 Subject: [PATCH 014/105] net: stmmac: dwmac-loongson: Detach GMAC-specific

--- a/app-admin/kernel-tools/autobuild/patches/0015-net-stmmac-dwmac-loongson-Init-ref-and-PTP-clocks-ra.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0015-net-stmmac-dwmac-loongson-Init-ref-and-PTP-clocks-ra.patch
@@ -1,4 +1,4 @@
-From b08629e3fff52e58c74d239072e46d9abb7f612f Mon Sep 17 00:00:00 2001
+From 25dac4023b837625d061156c7e985a44075ccfc1 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:02 +0800
 Subject: [PATCH 015/105] net: stmmac: dwmac-loongson: Init ref and PTP clocks

--- a/app-admin/kernel-tools/autobuild/patches/0016-net-stmmac-dwmac-loongson-Add-phy_interface-for-Loon.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0016-net-stmmac-dwmac-loongson-Add-phy_interface-for-Loon.patch
@@ -1,4 +1,4 @@
-From a88f69cfe1d8ec426ccaed90cd94f37fd858b694 Mon Sep 17 00:00:00 2001
+From ed06cfc623aa61a6340d0d41e9d88c0c53b0a3d4 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:03 +0800
 Subject: [PATCH 016/105] net: stmmac: dwmac-loongson: Add phy_interface for

--- a/app-admin/kernel-tools/autobuild/patches/0017-net-stmmac-dwmac-loongson-Introduce-PCI-device-info-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0017-net-stmmac-dwmac-loongson-Introduce-PCI-device-info-.patch
@@ -1,4 +1,4 @@
-From 7d41de006c6a3f7d1a7f0769bcc11245189e2c06 Mon Sep 17 00:00:00 2001
+From d30a5bb2450312a95f0f66dcfa6e87dd5b8b0213 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:04 +0800
 Subject: [PATCH 017/105] net: stmmac: dwmac-loongson: Introduce PCI device

--- a/app-admin/kernel-tools/autobuild/patches/0018-net-stmmac-dwmac-loongson-Add-DT-less-GMAC-PCI-devic.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0018-net-stmmac-dwmac-loongson-Add-DT-less-GMAC-PCI-devic.patch
@@ -1,4 +1,4 @@
-From d935016a53afcd57612a2b39ee285356e8241954 Mon Sep 17 00:00:00 2001
+From 0c254aaf06ac585fdecb8a2f7dc00e4631335d9f Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:05 +0800
 Subject: [PATCH 018/105] net: stmmac: dwmac-loongson: Add DT-less GMAC

--- a/app-admin/kernel-tools/autobuild/patches/0019-net-stmmac-dwmac-loongson-Add-Loongson-Multi-channel.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0019-net-stmmac-dwmac-loongson-Add-Loongson-Multi-channel.patch
@@ -1,4 +1,4 @@
-From 6ceacd86583545421ed8c266bc4603e66539211f Mon Sep 17 00:00:00 2001
+From f182a46931641d90a4dc0258b9d8a3e5f9d8703a Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:54 +0800
 Subject: [PATCH 019/105] net: stmmac: dwmac-loongson: Add Loongson

--- a/app-admin/kernel-tools/autobuild/patches/0020-net-stmmac-dwmac-loongson-Add-Loongson-GNET-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0020-net-stmmac-dwmac-loongson-Add-Loongson-GNET-support.patch
@@ -1,4 +1,4 @@
-From c1eec78ac2a4a7a9a9a26fb68330866df138617f Mon Sep 17 00:00:00 2001
+From 84cf4586f645965586c3f75a7907209e9013d5d3 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:55 +0800
 Subject: [PATCH 020/105] net: stmmac: dwmac-loongson: Add Loongson GNET

--- a/app-admin/kernel-tools/autobuild/patches/0021-net-stmmac-dwmac-loongson-Add-loongson-module-author.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0021-net-stmmac-dwmac-loongson-Add-loongson-module-author.patch
@@ -1,4 +1,4 @@
-From d89ddd516da112058c721a01b5625e5481aef4ca Mon Sep 17 00:00:00 2001
+From 12dfffe9dc28fb6294a624a0db9c63bff4ee372a Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:56 +0800
 Subject: [PATCH 021/105] net: stmmac: dwmac-loongson: Add loongson module

--- a/app-admin/kernel-tools/autobuild/patches/0022-net-stmmac-Add-Phytium-GMAC-glue-layer.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0022-net-stmmac-Add-Phytium-GMAC-glue-layer.patch
@@ -1,4 +1,4 @@
-From 7a48220076f39e8a8bc26fb1e8ba294a7fe23fea Mon Sep 17 00:00:00 2001
+From b3087234016bb229ca7ed98cfca72c8a38a11ac5 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
 Subject: [PATCH 022/105] net: stmmac: Add Phytium GMAC glue layer

--- a/app-admin/kernel-tools/autobuild/patches/0023-net-stmmac-Add-a-barrier-to-make-sure-all-access-coh.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0023-net-stmmac-Add-a-barrier-to-make-sure-all-access-coh.patch
@@ -1,4 +1,4 @@
-From bc62ce27d3ffdd55ad4b450d40238d40e4568f9a Mon Sep 17 00:00:00 2001
+From f2d4c6d94fe0b32966e06ca0f062857a6ec98780 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
 Subject: [PATCH 023/105] net: stmmac: Add a barrier to make sure all access

--- a/app-admin/kernel-tools/autobuild/patches/0024-drivers-fix-build-errors.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0024-drivers-fix-build-errors.patch
@@ -1,4 +1,4 @@
-From 306e64b53036560483d814f8fac22329d1c14b6b Mon Sep 17 00:00:00 2001
+From 12e72ea91ad25fff43420681864998824b191cf8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 00:02:32 +0800
 Subject: [PATCH 024/105] drivers: fix build errors

--- a/app-admin/kernel-tools/autobuild/patches/0025-Update-phytium-copyright-info-to-2024.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0025-Update-phytium-copyright-info-to-2024.patch
@@ -1,4 +1,4 @@
-From 476812becece6343b0ff4da0d215e127e3e24f47 Mon Sep 17 00:00:00 2001
+From 4de01cb30448b342555a2984c7d897cce9ad7c98 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 00:05:33 +0800
 Subject: [PATCH 025/105] Update phytium copyright info to 2024

--- a/app-admin/kernel-tools/autobuild/patches/0026-net-stmmac-Add-phytium-DWMAC-driver-support-v2.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0026-net-stmmac-Add-phytium-DWMAC-driver-support-v2.patch
@@ -1,4 +1,4 @@
-From fc3725d1050e6ed83ba6e3bcc4b2844a42935152 Mon Sep 17 00:00:00 2001
+From 2cfb0c232ad9856429c8a36e4913be46be109485 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
 Subject: [PATCH 026/105] net/stmmac: Add phytium DWMAC driver support v2

--- a/app-admin/kernel-tools/autobuild/patches/0027-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0027-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,4 +1,4 @@
-From c1dfb5398f2156e73ce905f030917c0c8e0031a7 Mon Sep 17 00:00:00 2001
+From a8876ae1b077cb9d625fed21653dede5cc941e7c Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
 Subject: [PATCH 027/105] net: stmmac: phytium driver add pm support

--- a/app-admin/kernel-tools/autobuild/patches/0028-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0028-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,4 +1,4 @@
-From ec0a0334d36fd05d799e69533aebc374b518cc7a Mon Sep 17 00:00:00 2001
+From 2fbd6ae94b77205932f99967aecfb2ee1b67fe53 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
 Subject: [PATCH 028/105] net: stmmac: fix dwmac-phytium build on 6.9

--- a/app-admin/kernel-tools/autobuild/patches/0029-net-stmmac-Add-phytium-old-dwmac-acpi_device_id.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0029-net-stmmac-Add-phytium-old-dwmac-acpi_device_id.patch
@@ -1,4 +1,4 @@
-From 770904b01bb9f19a227e7710de9cfc83ef31eb27 Mon Sep 17 00:00:00 2001
+From c945f963f72c371e0a37c8a48ef67be6d5d63b85 Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
 Subject: [PATCH 029/105] net/stmmac: Add phytium old dwmac acpi_device_id

--- a/app-admin/kernel-tools/autobuild/patches/0030-net-stmmac-fix-potential-double-free-of-dma-descript.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0030-net-stmmac-fix-potential-double-free-of-dma-descript.patch
@@ -1,4 +1,4 @@
-From 9b8edf4e86511e172ea6a204550971a2890454b7 Mon Sep 17 00:00:00 2001
+From c5ad144a80dbe48fe95bc85e4e8581c2deeacd78 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
 Subject: [PATCH 030/105] net: stmmac: fix potential double free of dma

--- a/app-admin/kernel-tools/autobuild/patches/0031-net-phytium-Add-support-for-phytium-GMAC.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0031-net-phytium-Add-support-for-phytium-GMAC.patch
@@ -1,4 +1,4 @@
-From 3236169ed6e3491326ace7374d32fba8ed0d29a9 Mon Sep 17 00:00:00 2001
+From fe598bebbd60d210e90d26aea5e12cc64dcc1e84 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:48:50 +0800
 Subject: [PATCH 031/105] net: phytium: Add support for phytium GMAC

--- a/app-admin/kernel-tools/autobuild/patches/0032-net-phytmac-Bugfixed-the-MDIO-registration-failures.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0032-net-phytmac-Bugfixed-the-MDIO-registration-failures.patch
@@ -1,4 +1,4 @@
-From af97afc5d7c1dfeb5e668c3a7bfb6a2d83c6e81e Mon Sep 17 00:00:00 2001
+From bbdca87f2c14b61694df89279e091f49b27c0683 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:58:33 +0800
 Subject: [PATCH 032/105] net/phytmac: Bugfixed the MDIO registration failures

--- a/app-admin/kernel-tools/autobuild/patches/0033-net-phytmac-Fixed-the-issue-of-pxe-startup-failure.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0033-net-phytmac-Fixed-the-issue-of-pxe-startup-failure.patch
@@ -1,4 +1,4 @@
-From ec1c5cff436dcbce412570ad32a29fa8762b2b4a Mon Sep 17 00:00:00 2001
+From a85aee20d0c84551582910815924d69b1a61739b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:58:56 +0800
 Subject: [PATCH 033/105] net/phytmac: Fixed the issue of pxe startup failure.

--- a/app-admin/kernel-tools/autobuild/patches/0034-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0034-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,4 +1,4 @@
-From c902def81e9c29abdb96f0b3885b066ae52e26c6 Mon Sep 17 00:00:00 2001
+From 6671e5dcd9b00c295a48c995ed7a7becb8dc7b91 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:59:09 +0800
 Subject: [PATCH 034/105] net/phytmac: Adapt interface type 1000BASE-x

--- a/app-admin/kernel-tools/autobuild/patches/0035-net-ethernet-phytium-fix-phytmac_platform-on-6.9.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0035-net-ethernet-phytium-fix-phytmac_platform-on-6.9.patch
@@ -1,4 +1,4 @@
-From f4b4f3c338a9c7cbd5e740214f11c7569540cac0 Mon Sep 17 00:00:00 2001
+From c7c2275e3231425e8479a3c6e5157f8917755cda Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
 Subject: [PATCH 035/105] net: ethernet: phytium: fix phytmac_platform on 6.9

--- a/app-admin/kernel-tools/autobuild/patches/0036-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0036-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,4 +1,4 @@
-From 6bcc779af3b9ab178986b560ad422f0fdafee454 Mon Sep 17 00:00:00 2001
+From 1e6a914535802ca28273f705962799d281c3fb9a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
 Subject: [PATCH 036/105] net: ethernet: fix phytmac on 6.9

--- a/app-admin/kernel-tools/autobuild/patches/0037-net-ethernet-phytium-add-a-missing-declaration-for-n.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0037-net-ethernet-phytium-add-a-missing-declaration-for-n.patch
@@ -1,4 +1,4 @@
-From 5025b0f2346f9469bfb4f870f27e588eeecda1b0 Mon Sep 17 00:00:00 2001
+From 13af82108b55e4e0a372bc54e9f7e552b23f94aa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
 Subject: [PATCH 037/105] net: ethernet: phytium: add a missing declaration for

--- a/app-admin/kernel-tools/autobuild/patches/0038-net-phytium-convert-and-remove-validate-references.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0038-net-phytium-convert-and-remove-validate-references.patch
@@ -1,4 +1,4 @@
-From 27628a9a0010868156066cbda5d5f8a766c5d36e Mon Sep 17 00:00:00 2001
+From d64e25261ba26ee878aa9641a9b028bf417353c6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
 Subject: [PATCH 038/105] net: phytium: convert and remove validate()

--- a/app-admin/kernel-tools/autobuild/patches/0039-arm-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0039-arm-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,4 +1,4 @@
-From 24981666038443428e73156c0cbe10c125fc51aa Mon Sep 17 00:00:00 2001
+From 8d5b0b481c52f41e735d484186bc086e8a45055d Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux@gmail.com>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
 Subject: [PATCH 039/105] arm: usb: phy: tegra: Add 38.4MHz clock table entry

--- a/app-admin/kernel-tools/autobuild/patches/0040-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0040-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
@@ -1,4 +1,4 @@
-From 8031be36405adcf0fa4c072703b2037a37c9a604 Mon Sep 17 00:00:00 2001
+From 7b2a6d4d9baa115e06a58e9143c5057e357c11e8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
 Subject: [PATCH 040/105] arm64: dts: rockchip: change GMAC rx_delay for

--- a/app-admin/kernel-tools/autobuild/patches/0041-arm64-phytium-Add-support-for-Phytium-SoC-family.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0041-arm64-phytium-Add-support-for-Phytium-SoC-family.patch
@@ -1,4 +1,4 @@
-From 7314dd71401f880987a51ee8515e1a0c922d0cc3 Mon Sep 17 00:00:00 2001
+From d0784931893e8f958732482ad9cb7e0a17cdb06e Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
 Subject: [PATCH 041/105] arm64: phytium: Add support for Phytium SoC family

--- a/app-admin/kernel-tools/autobuild/patches/0042-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0042-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,4 +1,4 @@
-From c561aebb3a126a34bb62295eba712da76b602954 Mon Sep 17 00:00:00 2001
+From bca429add2782929c1b172a4b803526c0f488125 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Thu, 21 Apr 2022 11:36:35 +0800
 Subject: [PATCH 042/105] arm64: dts: rockchip: disable usb3 on quartz64

--- a/app-admin/kernel-tools/autobuild/patches/0043-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0043-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,4 +1,4 @@
-From f6460b86c96bd714f4d8a6ccd97f8a1700915d08 Mon Sep 17 00:00:00 2001
+From 4db75f5ee120693313f0bad0669b3349da5e7aa9 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 27 Jul 2023 11:13:25 -0400
 Subject: [PATCH 043/105] arm64: drop hisi_ddrc_pmu driver

--- a/app-admin/kernel-tools/autobuild/patches/0044-PCI-Add-Phytium-vendor-ID.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0044-PCI-Add-Phytium-vendor-ID.patch
@@ -1,4 +1,4 @@
-From 157f0c75ae3015fa050b01ee77fa23b324e6172e Mon Sep 17 00:00:00 2001
+From 42877462e6b8f55712498c78ac70ae3e56b602fd Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:06:38 +0800
 Subject: [PATCH 044/105] PCI: Add Phytium vendor ID

--- a/app-admin/kernel-tools/autobuild/patches/0045-mips-loongson64-disable-writecombine-for-Loongson-3A.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0045-mips-loongson64-disable-writecombine-for-Loongson-3A.patch
@@ -1,4 +1,4 @@
-From fc337efd09675ac43dd330f2d22536f177f127c6 Mon Sep 17 00:00:00 2001
+From 5a52710ba6dbb4f6cd4d3ada02006415e06a8cb7 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Mon, 12 Oct 2020 13:32:23 +0800
 Subject: [PATCH 045/105] mips: loongson64: disable writecombine for

--- a/app-admin/kernel-tools/autobuild/patches/0046-mips-loongson64-init-suppress-memcpy-out-of-bound-ch.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0046-mips-loongson64-init-suppress-memcpy-out-of-bound-ch.patch
@@ -1,4 +1,4 @@
-From a83a729aed21b07df0ded7c44d9fad599c77af87 Mon Sep 17 00:00:00 2001
+From baf08584577500740002f19c8c93239b2ea3443e Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Wed, 24 Aug 2022 03:54:11 +0000
 Subject: [PATCH 046/105] mips: loongson64/init: suppress memcpy out-of-bound

--- a/app-admin/kernel-tools/autobuild/patches/0047-mips-loongson64-video-output-re-introduce-display-ou.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0047-mips-loongson64-video-output-re-introduce-display-ou.patch
@@ -1,4 +1,4 @@
-From d123d0fbfd95ed47fc0230836faf1803d9f8a455 Mon Sep 17 00:00:00 2001
+From 85e8394a32b4dba8af76bd1bbe68f1358ac344ab Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 7 Nov 2017 09:01:33 +0800
 Subject: [PATCH 047/105] mips: loongson64: video: output: re-introduce display

--- a/app-admin/kernel-tools/autobuild/patches/0048-mips-video-fbdev-sis-add-1368x768-resolution.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0048-mips-video-fbdev-sis-add-1368x768-resolution.patch
@@ -1,4 +1,4 @@
-From a20dfb43e5f3b3523a03f12066b9c281b5687cfa Mon Sep 17 00:00:00 2001
+From 0c3aa4255a625cb597c625c0693c7d1e892b0af4 Mon Sep 17 00:00:00 2001
 From: flygoat <flygoatfree@gmail.com>
 Date: Sun, 5 Mar 2017 20:33:17 +0800
 Subject: [PATCH 048/105] mips: video: fbdev: sis: add 1368x768 resolution

--- a/app-admin/kernel-tools/autobuild/patches/0049-loongarch-LoongArch-Update-the-flush-cache-policy.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0049-loongarch-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,4 +1,4 @@
-From 858e0bda8729e967eaa7de3f79eca59352e78943 Mon Sep 17 00:00:00 2001
+From 0b7d37b68cd86c8df48d192845dfe67b2b2bb55d Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
 Subject: [PATCH 049/105] loongarch: LoongArch: Update the flush cache policy

--- a/app-admin/kernel-tools/autobuild/patches/0050-loongarch-PCI-pci_call_probe-call-local_pci_probe-wh.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0050-loongarch-PCI-pci_call_probe-call-local_pci_probe-wh.patch
@@ -1,4 +1,4 @@
-From e4262cf1c52da962170fd91d3ec565016ef4d1ce Mon Sep 17 00:00:00 2001
+From a131b2a8845b60d8ff8efdbb16ea883dcea97e8c Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Thu, 13 Jun 2024 15:42:58 +0800
 Subject: [PATCH 050/105] loongarch: PCI: pci_call_probe: call
@@ -17,7 +17,7 @@ Fixes: 69a18b18699b ("PCI: Restrict probe functions to housekeeping CPUs")
 Cc: <stable@vger.kernel.org>
 Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
 Signed-off-by: Hongchen Zhang <zhanghongchen@loongson.cn>
-Ref: https://github.com/chenhuacai/linux/commit/380c035bd4b59019b742b0be494f99b527f138f6
+Ref: https://github.com/chenhuacai/linux/commit/a504a1880885168e96db422e00adc2709b8bcd8b
 ---
  drivers/pci/pci-driver.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/app-admin/kernel-tools/autobuild/patches/0051-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0051-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,4 +1,4 @@
-From d93bea7eb40c9c939479994588091cebfc7052eb Mon Sep 17 00:00:00 2001
+From 6e8e53af8950911ac20eae6737db8056abe1e9ad Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 01:23:57 +0800
 Subject: [PATCH 051/105] LoongArch: Add CPU HWMon platform driver

--- a/app-admin/kernel-tools/autobuild/patches/0052-LoongArch-KVM-Add-PV-steal-time-support-in-host-side.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0052-LoongArch-KVM-Add-PV-steal-time-support-in-host-side.patch
@@ -1,4 +1,4 @@
-From 01ca25ede44e2455f61919664778eef51bc59cfc Mon Sep 17 00:00:00 2001
+From 0b22cb03f83db0581637bfabffa55a766c5d074d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:31:59 +0800
 Subject: [PATCH 052/105] LoongArch: KVM: Add PV steal time support in host

--- a/app-admin/kernel-tools/autobuild/patches/0053-LoongArch-KVM-Add-PV-steal-time-support-in-guest-sid.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0053-LoongArch-KVM-Add-PV-steal-time-support-in-guest-sid.patch
@@ -1,4 +1,4 @@
-From 670d5046d565acfac5b5b500a64923d303389ad4 Mon Sep 17 00:00:00 2001
+From 4de98f4790b40ea3535f3b9a335349452934d6c7 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:32:22 +0800
 Subject: [PATCH 053/105] LoongArch: KVM: Add PV steal time support in guest

--- a/app-admin/kernel-tools/autobuild/patches/0054-LoongArch-KVM-Add-HW-Binary-Translation-extension-su.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0054-LoongArch-KVM-Add-HW-Binary-Translation-extension-su.patch
@@ -1,4 +1,4 @@
-From 8d992bbc1605a7e5af7d15988dca70c9ff3c6282 Mon Sep 17 00:00:00 2001
+From 1524ad234aa34ee4f98792a2c84466584da0c5c0 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Jul 2024 15:57:41 +0800
 Subject: [PATCH 054/105] LoongArch: KVM: Add HW Binary Translation extension

--- a/app-admin/kernel-tools/autobuild/patches/0055-LoongArch-KVM-Add-LBT-feature-detection-function.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0055-LoongArch-KVM-Add-LBT-feature-detection-function.patch
@@ -1,4 +1,4 @@
-From 4c03530889852dea33bbe11183a347185ba81266 Mon Sep 17 00:00:00 2001
+From 84c6c9792cde2a03aea7b625b5ee66e4edb086aa Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Jul 2024 15:57:42 +0800
 Subject: [PATCH 055/105] LoongArch: KVM: Add LBT feature detection function

--- a/app-admin/kernel-tools/autobuild/patches/0056-LoongArch-KVM-Add-vm-migration-support-for-LBT-regis.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0056-LoongArch-KVM-Add-vm-migration-support-for-LBT-regis.patch
@@ -1,4 +1,4 @@
-From 9940c6f7450814bda94c92274707d88d13029490 Mon Sep 17 00:00:00 2001
+From 626827036c6d2dedc324f8826a67d5f5077cb739 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Jul 2024 15:57:43 +0800
 Subject: [PATCH 056/105] LoongArch: KVM: Add vm migration support for LBT

--- a/app-admin/kernel-tools/autobuild/patches/0057-LoongArch-Add-architectural-preparation-for-CPUFreq.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0057-LoongArch-Add-architectural-preparation-for-CPUFreq.patch
@@ -1,4 +1,4 @@
-From 8364f33d9c75e4281dab73989213011001efe426 Mon Sep 17 00:00:00 2001
+From c78f28e1415e035a3dfe20edda26cf6deee88076 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sat, 20 Jul 2024 22:41:06 +0800
 Subject: [PATCH 057/105] LoongArch: Add architectural preparation for CPUFreq

--- a/app-admin/kernel-tools/autobuild/patches/0058-cpufreq-Add-Loongson-3-CPUFreq-driver-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0058-cpufreq-Add-Loongson-3-CPUFreq-driver-support.patch
@@ -1,4 +1,4 @@
-From 6202d0bdb7c3b5282f1637b7d4400f3e8ba746fe Mon Sep 17 00:00:00 2001
+From 71cd2aa3d4fb1e9ac23001da9b2ddcea4190f07b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 5 Jul 2024 14:06:49 +0800
 Subject: [PATCH 058/105] cpufreq: Add Loongson-3 CPUFreq driver support

--- a/app-admin/kernel-tools/autobuild/patches/0059-dt-bindings-pwm-Add-Loongson-PWM-controller.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0059-dt-bindings-pwm-Add-Loongson-PWM-controller.patch
@@ -1,4 +1,4 @@
-From 25a42ddbe5d3db070b8372d583c4b120bd2a2606 Mon Sep 17 00:00:00 2001
+From 607760f1f45e07c6bb1341c599b5cdfab7ac6099 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 10 Jul 2024 10:04:06 +0800
 Subject: [PATCH 059/105] dt-bindings: pwm: Add Loongson PWM controller

--- a/app-admin/kernel-tools/autobuild/patches/0060-pwm-Add-Loongson-PWM-controller-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0060-pwm-Add-Loongson-PWM-controller-support.patch
@@ -1,4 +1,4 @@
-From 635049a83a2b1127e5f3358f22b3295e23f22b7e Mon Sep 17 00:00:00 2001
+From d9ee332d3387ffad79e3e35b3462ec5e91f7102f Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 10 Jul 2024 10:04:07 +0800
 Subject: [PATCH 060/105] pwm: Add Loongson PWM controller support

--- a/app-admin/kernel-tools/autobuild/patches/0061-cpufreq-Make-Loongson-3-s-cpufreq_driver-exit-return.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0061-cpufreq-Make-Loongson-3-s-cpufreq_driver-exit-return.patch
@@ -1,4 +1,4 @@
-From 3b433594fdb395acb3ff24c6ec5e893ff821383d Mon Sep 17 00:00:00 2001
+From b20fc38236fb743d82b65f57f1569507aa02924d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 20:00:46 +0800
 Subject: [PATCH 061/105] cpufreq: Make Loongson-3's cpufreq_driver->exit()

--- a/app-admin/kernel-tools/autobuild/patches/0062-loongarch-basic-boot-support-for-legacy-firmware.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0062-loongarch-basic-boot-support-for-legacy-firmware.patch
@@ -1,4 +1,4 @@
-From f3b623efe8b1cd48e64d243caad130db4aae645f Mon Sep 17 00:00:00 2001
+From 8638763456e863f1e7a89fc068e551d4e4fad87a Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
 Subject: [PATCH 062/105] loongarch: basic boot support for legacy firmware

--- a/app-admin/kernel-tools/autobuild/patches/0063-loongarch-parse-BPI-data-and-add-memory-mapping.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0063-loongarch-parse-BPI-data-and-add-memory-mapping.patch
@@ -1,4 +1,4 @@
-From ae5a4f1d818abc053789671f846629067672b48b Mon Sep 17 00:00:00 2001
+From a138a1cc6ac56253c161c4aca8bb369d93a09c7e Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
 Subject: [PATCH 063/105] loongarch: parse BPI data and add memory mapping

--- a/app-admin/kernel-tools/autobuild/patches/0064-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0064-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,4 +1,4 @@
-From 13dd1fe6a8f564b565bd64259ff70b8f3ee6bc5d Mon Sep 17 00:00:00 2001
+From c27c08f5008114a4f75feee0ed578a899153f370 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
 Subject: [PATCH 064/105] loongarch: add MADT ACPI table conversion

--- a/app-admin/kernel-tools/autobuild/patches/0065-loongarch-correct-missing-offset-of-PCI-root-control.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0065-loongarch-correct-missing-offset-of-PCI-root-control.patch
@@ -1,4 +1,4 @@
-From c3c28b811e8ef54e50f1d179bb6caec115b8a4ed Mon Sep 17 00:00:00 2001
+From 873d0be8905dd7d4eccdb617ac86b8333e823977 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
 Subject: [PATCH 065/105] loongarch: correct missing offset of PCI root

--- a/app-admin/kernel-tools/autobuild/patches/0066-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0066-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,4 +1,4 @@
-From 3534c3b4dd3eefb3e5a4a51345b52883f5f3442c Mon Sep 17 00:00:00 2001
+From 0176e9778b0e5e252bf913d3768aa1b6570bc2cb Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
 Subject: [PATCH 066/105] loongarch: fix missing dependency info in DSDT

--- a/app-admin/kernel-tools/autobuild/patches/0067-loongarch-fix-DMA-address-offset.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0067-loongarch-fix-DMA-address-offset.patch
@@ -1,4 +1,4 @@
-From 02b192cd701583f880883c55f3ca4739808e4d5c Mon Sep 17 00:00:00 2001
+From 168cdaea83c43a6539b08da03675c58405b47a0f Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
 Subject: [PATCH 067/105] loongarch: fix DMA address offset

--- a/app-admin/kernel-tools/autobuild/patches/0068-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0068-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,4 +1,4 @@
-From feb00228da8b35215f2de6f74349aa42a79bb073 Mon Sep 17 00:00:00 2001
+From ddd5db10a25a8184e82040986f89edf28ab97aba Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
 Subject: [PATCH 068/105] loongarch: fix HT_RX_INT_TRANS register

--- a/app-admin/kernel-tools/autobuild/patches/0069-ntsync-Introduce-NTSYNC_IOC_WAIT_ANY.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0069-ntsync-Introduce-NTSYNC_IOC_WAIT_ANY.patch
@@ -1,4 +1,4 @@
-From 381241ae87ca79389a1b4fc284e761d815e63249 Mon Sep 17 00:00:00 2001
+From f9128dc067dc05ab5bb99ed22701b92c6a954765 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:27 -0500
 Subject: [PATCH 069/105] ntsync: Introduce NTSYNC_IOC_WAIT_ANY.

--- a/app-admin/kernel-tools/autobuild/patches/0070-ntsync-Introduce-NTSYNC_IOC_WAIT_ALL.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0070-ntsync-Introduce-NTSYNC_IOC_WAIT_ALL.patch
@@ -1,4 +1,4 @@
-From dd9d2b52858993d7af26b20de4191c5e3a5c0be9 Mon Sep 17 00:00:00 2001
+From 8ef9f6bd6053e4318d15532c1a7b9ff2fe033e6f Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:28 -0500
 Subject: [PATCH 070/105] ntsync: Introduce NTSYNC_IOC_WAIT_ALL.

--- a/app-admin/kernel-tools/autobuild/patches/0071-ntsync-Introduce-NTSYNC_IOC_CREATE_MUTEX.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0071-ntsync-Introduce-NTSYNC_IOC_CREATE_MUTEX.patch
@@ -1,4 +1,4 @@
-From 0fa015dad912a54218c445f9afd98c913a96a433 Mon Sep 17 00:00:00 2001
+From 2ead7f30170b803a677a95c8544758c23c156c5f Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:29 -0500
 Subject: [PATCH 071/105] ntsync: Introduce NTSYNC_IOC_CREATE_MUTEX.

--- a/app-admin/kernel-tools/autobuild/patches/0072-ntsync-Introduce-NTSYNC_IOC_MUTEX_UNLOCK.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0072-ntsync-Introduce-NTSYNC_IOC_MUTEX_UNLOCK.patch
@@ -1,4 +1,4 @@
-From 46106a7d30c26f31a7b33a259b55c3d99b4764fe Mon Sep 17 00:00:00 2001
+From f6c8da96c07b0e49d5d3d814b3ebf49f3088ef74 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:30 -0500
 Subject: [PATCH 072/105] ntsync: Introduce NTSYNC_IOC_MUTEX_UNLOCK.

--- a/app-admin/kernel-tools/autobuild/patches/0073-ntsync-Introduce-NTSYNC_IOC_MUTEX_KILL.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0073-ntsync-Introduce-NTSYNC_IOC_MUTEX_KILL.patch
@@ -1,4 +1,4 @@
-From 974885e695d3ea2047fe459f9d4fd7173f063962 Mon Sep 17 00:00:00 2001
+From f36e74e0ce18fed09cd3dfb65476ea25744c78eb Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:31 -0500
 Subject: [PATCH 073/105] ntsync: Introduce NTSYNC_IOC_MUTEX_KILL.

--- a/app-admin/kernel-tools/autobuild/patches/0074-ntsync-Introduce-NTSYNC_IOC_CREATE_EVENT.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0074-ntsync-Introduce-NTSYNC_IOC_CREATE_EVENT.patch
@@ -1,4 +1,4 @@
-From 112fe37356d421feafcd055418fa1fc2261852a3 Mon Sep 17 00:00:00 2001
+From 0bc816807b5cadc48a2100f9a57f9ce8a53bb39f Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:32 -0500
 Subject: [PATCH 074/105] ntsync: Introduce NTSYNC_IOC_CREATE_EVENT.

--- a/app-admin/kernel-tools/autobuild/patches/0075-ntsync-Introduce-NTSYNC_IOC_EVENT_SET.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0075-ntsync-Introduce-NTSYNC_IOC_EVENT_SET.patch
@@ -1,4 +1,4 @@
-From 0523e8abd44dfb23923e3a70c36f472e6dc5a8cd Mon Sep 17 00:00:00 2001
+From ae2545ea3800a585e32536cd38082abd410833bc Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:33 -0500
 Subject: [PATCH 075/105] ntsync: Introduce NTSYNC_IOC_EVENT_SET.

--- a/app-admin/kernel-tools/autobuild/patches/0076-ntsync-Introduce-NTSYNC_IOC_EVENT_RESET.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0076-ntsync-Introduce-NTSYNC_IOC_EVENT_RESET.patch
@@ -1,4 +1,4 @@
-From d95ebbc19780c1ceb538457459141696704a4b9f Mon Sep 17 00:00:00 2001
+From 343c028a96b72a307e1c1e48e265f7b6d3634896 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:34 -0500
 Subject: [PATCH 076/105] ntsync: Introduce NTSYNC_IOC_EVENT_RESET.

--- a/app-admin/kernel-tools/autobuild/patches/0077-ntsync-Introduce-NTSYNC_IOC_EVENT_PULSE.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0077-ntsync-Introduce-NTSYNC_IOC_EVENT_PULSE.patch
@@ -1,4 +1,4 @@
-From 266c5f06f0f3c57eb33743b39dfdbf5cd28ab161 Mon Sep 17 00:00:00 2001
+From 0d0894e15379d97fc1947d9718ce30e2ed2a1b74 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:35 -0500
 Subject: [PATCH 077/105] ntsync: Introduce NTSYNC_IOC_EVENT_PULSE.

--- a/app-admin/kernel-tools/autobuild/patches/0078-ntsync-Introduce-NTSYNC_IOC_SEM_READ.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0078-ntsync-Introduce-NTSYNC_IOC_SEM_READ.patch
@@ -1,4 +1,4 @@
-From e745ab08635d0a4cf8e7784720e8d4632002add4 Mon Sep 17 00:00:00 2001
+From e3ef24b81d38ad08e3b011a86807c0ff5b81b935 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:36 -0500
 Subject: [PATCH 078/105] ntsync: Introduce NTSYNC_IOC_SEM_READ.

--- a/app-admin/kernel-tools/autobuild/patches/0079-ntsync-Introduce-NTSYNC_IOC_MUTEX_READ.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0079-ntsync-Introduce-NTSYNC_IOC_MUTEX_READ.patch
@@ -1,4 +1,4 @@
-From f1fe2eb16de29de9e1d7bd2eb517f64aca9f02af Mon Sep 17 00:00:00 2001
+From a31921415b4413c52d7c4785dd2d7dd9bc1c8ec9 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:37 -0500
 Subject: [PATCH 079/105] ntsync: Introduce NTSYNC_IOC_MUTEX_READ.

--- a/app-admin/kernel-tools/autobuild/patches/0080-ntsync-Introduce-NTSYNC_IOC_EVENT_READ.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0080-ntsync-Introduce-NTSYNC_IOC_EVENT_READ.patch
@@ -1,4 +1,4 @@
-From 48b43e5a92d64d76dc369ccdd7c0251b1aff1086 Mon Sep 17 00:00:00 2001
+From 7d26280379d847b123809cf85794c26c7fbe098b Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:38 -0500
 Subject: [PATCH 080/105] ntsync: Introduce NTSYNC_IOC_EVENT_READ.

--- a/app-admin/kernel-tools/autobuild/patches/0081-ntsync-Introduce-alertable-waits.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0081-ntsync-Introduce-alertable-waits.patch
@@ -1,4 +1,4 @@
-From 370f01f13ef86a22f7bbc4252aee462e1f72e078 Mon Sep 17 00:00:00 2001
+From 5b5094e1f184e8d1601ec072b64ab630627a819d Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:39 -0500
 Subject: [PATCH 081/105] ntsync: Introduce alertable waits.

--- a/app-admin/kernel-tools/autobuild/patches/0082-selftests-ntsync-Add-some-tests-for-semaphore-state.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0082-selftests-ntsync-Add-some-tests-for-semaphore-state.patch
@@ -1,4 +1,4 @@
-From bc5421a1de808448ce252541dd07855b855774fa Mon Sep 17 00:00:00 2001
+From a07b45ae0a3b9ad5299f77e9d77d3b5ead479158 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:40 -0500
 Subject: [PATCH 082/105] selftests: ntsync: Add some tests for semaphore

--- a/app-admin/kernel-tools/autobuild/patches/0083-selftests-ntsync-Add-some-tests-for-mutex-state.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0083-selftests-ntsync-Add-some-tests-for-mutex-state.patch
@@ -1,4 +1,4 @@
-From 65da3cf6ec42413a84745643251e7405c2c5de8a Mon Sep 17 00:00:00 2001
+From aca58682d73a53650159bfda8b54705e01c2a7d3 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:41 -0500
 Subject: [PATCH 083/105] selftests: ntsync: Add some tests for mutex state.

--- a/app-admin/kernel-tools/autobuild/patches/0084-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0084-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
@@ -1,4 +1,4 @@
-From 95655fbf2ef092e396ba6e5dbaf7932241729137 Mon Sep 17 00:00:00 2001
+From 2dc6982d8b20e0daf64537a7e1bb85470ea5630e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:42 -0500
 Subject: [PATCH 084/105] selftests: ntsync: Add some tests for

--- a/app-admin/kernel-tools/autobuild/patches/0085-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0085-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
@@ -1,4 +1,4 @@
-From 0479739836ec28caca2c742366fadcdeb66aeb34 Mon Sep 17 00:00:00 2001
+From 241e855718938bcaa1056d696b899db3e2673a53 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:43 -0500
 Subject: [PATCH 085/105] selftests: ntsync: Add some tests for

--- a/app-admin/kernel-tools/autobuild/patches/0086-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0086-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From 8d2803b0bee464d736654c6f8b9ca18cfb11ce69 Mon Sep 17 00:00:00 2001
+From 89264b99af8a2bfcddcb7a6ff2004344b554ff68 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:44 -0500
 Subject: [PATCH 086/105] selftests: ntsync: Add some tests for wakeup

--- a/app-admin/kernel-tools/autobuild/patches/0087-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0087-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From ef8dc9529f13e389e58a81d3b2aaf5e0357ea718 Mon Sep 17 00:00:00 2001
+From 7345d59a0a4587d7a55be1ece5730aaf96878bd4 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:45 -0500
 Subject: [PATCH 087/105] selftests: ntsync: Add some tests for wakeup

--- a/app-admin/kernel-tools/autobuild/patches/0088-selftests-ntsync-Add-some-tests-for-manual-reset-eve.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0088-selftests-ntsync-Add-some-tests-for-manual-reset-eve.patch
@@ -1,4 +1,4 @@
-From 3abe1ba530ac1eaeca673e133cca239ad2d63a30 Mon Sep 17 00:00:00 2001
+From 8a39caa26f40d3089dd8e00c433e1ac6b98d6436 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:46 -0500
 Subject: [PATCH 088/105] selftests: ntsync: Add some tests for manual-reset

--- a/app-admin/kernel-tools/autobuild/patches/0089-selftests-ntsync-Add-some-tests-for-auto-reset-event.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0089-selftests-ntsync-Add-some-tests-for-auto-reset-event.patch
@@ -1,4 +1,4 @@
-From bebea8095d68ec0d5b3cf11c795360b3c50db7c9 Mon Sep 17 00:00:00 2001
+From 204da0c7dac7908d842abadc88cfea8e0f8fa404 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:47 -0500
 Subject: [PATCH 089/105] selftests: ntsync: Add some tests for auto-reset

--- a/app-admin/kernel-tools/autobuild/patches/0090-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0090-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From 8da41817dd8cfcd830e017dc867d65079e170472 Mon Sep 17 00:00:00 2001
+From ed8295284c687b562e4153f5dd8c91120552de50 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:48 -0500
 Subject: [PATCH 090/105] selftests: ntsync: Add some tests for wakeup

--- a/app-admin/kernel-tools/autobuild/patches/0091-selftests-ntsync-Add-tests-for-alertable-waits.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0091-selftests-ntsync-Add-tests-for-alertable-waits.patch
@@ -1,4 +1,4 @@
-From 03eb5e090abc4c534c4d5b93c3602f25d0b501e0 Mon Sep 17 00:00:00 2001
+From efd0b2f920a4cc097a9fecc02ad82f7b496395f9 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:49 -0500
 Subject: [PATCH 091/105] selftests: ntsync: Add tests for alertable waits.

--- a/app-admin/kernel-tools/autobuild/patches/0092-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0092-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From db6b41bc0a20123730219577e1e3df6fcf52744a Mon Sep 17 00:00:00 2001
+From b087eb5feefb3fda50f1881cf146530c56f06301 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:50 -0500
 Subject: [PATCH 092/105] selftests: ntsync: Add some tests for wakeup

--- a/app-admin/kernel-tools/autobuild/patches/0093-selftests-ntsync-Add-a-stress-test-for-contended-wai.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0093-selftests-ntsync-Add-a-stress-test-for-contended-wai.patch
@@ -1,4 +1,4 @@
-From ae8826fe425d42f9e2ddf91ed78855a3a57cb146 Mon Sep 17 00:00:00 2001
+From 9cde892c768c39868b0f279b4c2a4ead4c0beb09 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:51 -0500
 Subject: [PATCH 093/105] selftests: ntsync: Add a stress test for contended

--- a/app-admin/kernel-tools/autobuild/patches/0094-maintainers-Add-an-entry-for-ntsync.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0094-maintainers-Add-an-entry-for-ntsync.patch
@@ -1,4 +1,4 @@
-From 1b5c3c01134483e415e5a39f97e2946dd81e801d Mon Sep 17 00:00:00 2001
+From af9168bc3452f1de7d22478aa6b8591ae92c3a5e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:52 -0500
 Subject: [PATCH 094/105] maintainers: Add an entry for ntsync.

--- a/app-admin/kernel-tools/autobuild/patches/0095-docs-ntsync-Add-documentation-for-the-ntsync-uAPI.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0095-docs-ntsync-Add-documentation-for-the-ntsync-uAPI.patch
@@ -1,4 +1,4 @@
-From a548a8b2c54432dc46f94c7bec3cf82b52c448e9 Mon Sep 17 00:00:00 2001
+From b6d358f4bd50bc6e87a526cfb820326f9b03585f Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:53 -0500
 Subject: [PATCH 095/105] docs: ntsync: Add documentation for the ntsync uAPI.

--- a/app-admin/kernel-tools/autobuild/patches/0096-ntsync-No-longer-depend-on-BROKEN.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0096-ntsync-No-longer-depend-on-BROKEN.patch
@@ -1,4 +1,4 @@
-From 035ebfd6331bbb2345bfee369db41dee0f6a0f39 Mon Sep 17 00:00:00 2001
+From a1e93dbd8de8a81c8e6cdbeadf654ef28364192c Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:54 -0500
 Subject: [PATCH 096/105] ntsync: No longer depend on BROKEN.

--- a/app-admin/kernel-tools/autobuild/patches/0097-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0097-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
@@ -1,4 +1,4 @@
-From 3676040433024a33970fa222588094eee21e3063 Mon Sep 17 00:00:00 2001
+From 67c03141074c46aa63f4ed75e617ff0758fec02a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 28 Aug 2024 03:09:24 +0800
 Subject: [PATCH 097/105] arch/loongarch: add la_ow_syscall as in-tree module

--- a/app-admin/kernel-tools/autobuild/patches/0098-la_ow_syscall-add-kconfig-for-module.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0098-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,4 +1,4 @@
-From 4c649a865eb19f20bf10fc1e6737407c2e8f4804 Mon Sep 17 00:00:00 2001
+From b21be99f3c6d21cbdec779d82b9ede8941b4a80e Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
 Subject: [PATCH 098/105] la_ow_syscall: add kconfig for module

--- a/app-admin/kernel-tools/autobuild/patches/0099-platform-x86-ideapad-laptop-add-fixes-for-ThinkBook-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0099-platform-x86-ideapad-laptop-add-fixes-for-ThinkBook-.patch
@@ -1,4 +1,4 @@
-From d459aee09c48f05ab801d0f375a4b6cb960bf16b Mon Sep 17 00:00:00 2001
+From 0a47cf0ef76833fd28bbb4ff73a88ae988bd9e2d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 17 Aug 2024 11:32:11 +0800
 Subject: [PATCH 099/105] platform: x86: ideapad-laptop: add fixes for

--- a/app-admin/kernel-tools/autobuild/patches/0100-Revert-drm-amdgpu-fix-contiguous-handling-for-IB-par.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0100-Revert-drm-amdgpu-fix-contiguous-handling-for-IB-par.patch
@@ -1,4 +1,4 @@
-From c2eaa9bad62a18a833f4922478beaef5ff28b6a1 Mon Sep 17 00:00:00 2001
+From 4d3098f7a335873aa015bb3159e0740fab9c9924 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Mon, 2 Sep 2024 10:19:00 +0800
 Subject: [PATCH 100/105] Revert "drm/amdgpu: fix contiguous handling for IB

--- a/app-admin/kernel-tools/autobuild/patches/0101-tpm-export-tpm2_sessions_init-to-fix-ibmvtpm-buildin.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0101-tpm-export-tpm2_sessions_init-to-fix-ibmvtpm-buildin.patch
@@ -1,4 +1,4 @@
-From 6e551f78d824326f35faa7e7d593d2a4e8d1bfc6 Mon Sep 17 00:00:00 2001
+From c68ba0f9f509f528a288f393e61920307f24fbf8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 2 Sep 2024 08:26:38 +0800
 Subject: [PATCH 101/105] tpm: export tpm2_sessions_init() to fix ibmvtpm
@@ -19,7 +19,7 @@ Closes: https://lore.kernel.org/oe-kbuild-all/202408051735.ZJkAPQ3b-lkp@intel.co
 Fixes: 08d08e2e9f0a ("tpm: ibmvtpm: Call tpm2_sessions_init() to initialize session support")
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
-Ref: https://lore.kernel.org/all/20240902095835.16925-2-kexybiscuit@aosc.io/
+Ref: https://lore.kernel.org/all/20240905085219.77240-2-kexybiscuit@aosc.io/
 ---
  drivers/char/tpm/tpm2-sessions.c | 1 +
  1 file changed, 1 insertion(+)

--- a/app-admin/kernel-tools/autobuild/patches/0102-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
+++ b/app-admin/kernel-tools/autobuild/patches/0102-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
@@ -1,4 +1,4 @@
-From 2329d1632a1612de7aa5d5d959ac25251546cfb4 Mon Sep 17 00:00:00 2001
+From b838bf8c0657ec29f8695e27db8f25abeb55fdc7 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:43:11 +0800
 Subject: [PATCH 102/105] [LOONGARCH64] drivers/firmware: Move sysfb_init()
@@ -35,7 +35,7 @@ sysfb_disable() is sometimes missed. So here we move sysfb_init() to an
 fs_initcall function which is ensured after vgaarb initialization.
 
 Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
-Ref: https://github.com/chenhuacai/linux/commit/dce263743282606930684acd18288986a4c9e7bb
+Ref: https://github.com/chenhuacai/linux/commit/ea80c559590d4f79ea71d9ee7410450db0fb2e3d
 ---
  drivers/firmware/sysfb.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/app-admin/kernel-tools/autobuild/patches/0103-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
+++ b/app-admin/kernel-tools/autobuild/patches/0103-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
@@ -1,4 +1,4 @@
-From 03863ab134e7439a2099049bdb0c25aa63d47fb7 Mon Sep 17 00:00:00 2001
+From 76c4eb6c68ae117b3bed46c236168e92a22f8e92 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Mon, 11 Mar 2024 00:14:58 +0800
 Subject: [PATCH 103/105] [LOONGARCH64] drm/xe: fix build on non-4K kernels
@@ -255,10 +255,10 @@ index 23382ced4ea7..5508c931c28c 100644
  
  	if (xe->info.skip_guc_pc)
 diff --git a/drivers/gpu/drm/xe/xe_migrate.c b/drivers/gpu/drm/xe/xe_migrate.c
-index 198f5c2189cb..d5d160ff1b9e 100644
+index 208649436fdb..8d318785ad73 100644
 --- a/drivers/gpu/drm/xe/xe_migrate.c
 +++ b/drivers/gpu/drm/xe/xe_migrate.c
-@@ -516,7 +516,7 @@ static void emit_pte(struct xe_migrate *m,
+@@ -545,7 +545,7 @@ static void emit_pte(struct xe_migrate *m,
  			u64 addr, flags = 0;
  			bool devmem = false;
  
@@ -267,7 +267,7 @@ index 198f5c2189cb..d5d160ff1b9e 100644
  			if (is_vram) {
  				if (vm->flags & XE_VM_FLAG_64K) {
  					u64 va = cur_ofs * XE_PAGE_SIZE / 8;
-@@ -537,7 +537,7 @@ static void emit_pte(struct xe_migrate *m,
+@@ -566,7 +566,7 @@ static void emit_pte(struct xe_migrate *m,
  			bb->cs[bb->len++] = lower_32_bits(addr);
  			bb->cs[bb->len++] = upper_32_bits(addr);
  
@@ -276,7 +276,7 @@ index 198f5c2189cb..d5d160ff1b9e 100644
  			cur_ofs += 8;
  		}
  	}
-@@ -730,7 +730,7 @@ struct dma_fence *xe_migrate_copy(struct xe_migrate *m,
+@@ -759,7 +759,7 @@ struct dma_fence *xe_migrate_copy(struct xe_migrate *m,
  
  	if (copy_system_ccs)
  		xe_res_first_sg(xe_bo_sg(src_bo), xe_bo_ccs_pages_start(src_bo),

--- a/app-admin/kernel-tools/autobuild/patches/0104-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
+++ b/app-admin/kernel-tools/autobuild/patches/0104-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
@@ -1,4 +1,4 @@
-From 5d50d1e52b18e7676fd88cef5917f3a1cb3f4c8c Mon Sep 17 00:00:00 2001
+From 371c89498be82117e9c5e53afa9a2b5df43ef743 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
 Subject: [PATCH 104/105] [LOONGARCH64] drm/radeon: Workaround radeon driver
@@ -10,7 +10,7 @@ enable interrupt again when interrupt is faster than DMA data.
 
 Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
 Signed-off-by: Zhijie Zhang <zhangzhijie@loongson.cn>
-Ref: https://github.com/chenhuacai/linux/commit/fa2d2552f43966a758c0318be671687ec1483837
+Ref: https://github.com/chenhuacai/linux/commit/00c74f4ed9227dcf239f81854744927b922af6de
 ---
  drivers/gpu/drm/radeon/cik.c       | 1 +
  drivers/gpu/drm/radeon/evergreen.c | 1 +

--- a/app-admin/kernel-tools/autobuild/patches/0105-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
+++ b/app-admin/kernel-tools/autobuild/patches/0105-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
@@ -1,4 +1,4 @@
-From 9af58888341eca4f35df569f2e0b5a7f8d8f8e36 Mon Sep 17 00:00:00 2001
+From 84df10e1622d7ee8f19a464ac867642765d77981 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 14:28:02 +0800
 Subject: [PATCH 105/105] [LOONGARCH64] drm/radeon: Call mmiowb() at the end of

--- a/app-admin/kernel-tools/spec
+++ b/app-admin/kernel-tools/spec
@@ -1,10 +1,10 @@
-VER=6.10.8
-REL=1
+VER=6.10.9
 
 # Note: For use inside autobuild/.
 __VER="${VER}"
 
 # Use this for stable releases.
+# Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 
 # Use this for RC releases.
@@ -13,5 +13,5 @@ SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 #REL=0.${RC}
 #SRCS="tbl::https://git.kernel.org/torvalds/t/linux-${VER%%.0}-rc${RC}.tar.gz"
 
-CHKSUMS="sha256::c0923235779d4606bba87f72b6fe11f796e9e40c1ca9f4d5dbe04cd47ee3c595"
+CHKSUMS="sha256::a4489b70e0a7c2dc8f501b9cd7fc76989be2febb5519e163ecf816064f2f6858"
 CHKUPDATE="anitya::id=6501"

--- a/runtime-kernel/linux+kernel/autobuild/defines
+++ b/runtime-kernel/linux+kernel/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=linux+kernel
 PKGSEC=kernel
-PKGDEP="linux-kernel-6.10.8"
+PKGDEP="linux-kernel-6.10.9"
 PKGDES="Generic Linux Kernel for AOSC OS (Mainline)"
 
 PKGREP="linux+image+new linux+header+new linux+image linux+header linux+image+old linux+header+old"

--- a/runtime-kernel/linux+kernel/spec
+++ b/runtime-kernel/linux+kernel/spec
@@ -1,4 +1,4 @@
-VER=6.10.8
+VER=6.10.9
 # To RFC: Increment by 0.1 per RC release, i.e., RC3 = 0.3.
 #RC=
 #REL=0.${RC}

--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-more-uarches-for-kernel-6.8-rc4-.patch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-more-uarches-for-kernel-6.8-rc4-.patch.patch
@@ -1,4 +1,4 @@
-From 8d500dcf6a122095f7da4a4bd3d91ea4794720af Mon Sep 17 00:00:00 2001
+From 9bc86891d6b676dec7cf65a409b762ac2576d455 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 00:31:56 +0800
 Subject: [PATCH 001/105] more-uarches-for-kernel-6.8-rc4+.patch

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,4 +1,4 @@
-From 093fff29080ccbadd8c9c052df937b38674bef43 Mon Sep 17 00:00:00 2001
+From b0ad048f2f307df6b24ae05a9e20dfd497dbf84c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:36:33 +0800
 Subject: [PATCH 002/105] Input: Add driver for PixArt PS/2 touchpad

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-pci-Enable-overrides-for-missing-ACS-capabilities-5..patch
@@ -1,4 +1,4 @@
-From 3b829704f8eba5743b1c7a09c858b9328210c347 Mon Sep 17 00:00:00 2001
+From f58b095801c2790e4c56ecac66eb820c9728d191 Mon Sep 17 00:00:00 2001
 From: Mark Weiman <mark.weiman@markzz.com>
 Date: Wed, 27 Jan 2021 13:28:09 -0500
 Subject: [PATCH 003/105] pci: Enable overrides for missing ACS capabilities

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-cpuinfo-fix-a-warning-for-CONFIG_CPUMASK_OFFSTACK.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-cpuinfo-fix-a-warning-for-CONFIG_CPUMASK_OFFSTACK.patch
@@ -1,4 +1,4 @@
-From bad0b78ee8aabae02045dbe16a85c66494061c23 Mon Sep 17 00:00:00 2001
+From 481505e49a250f0c862584240c69adf8f8db74a0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 12 Jul 2022 12:47:48 +0800
 Subject: [PATCH 004/105] cpuinfo: fix a warning for CONFIG_CPUMASK_OFFSTACK

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-drm-amdgpu-use-amdgpu-by-default-for-si-cik-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-drm-amdgpu-use-amdgpu-by-default-for-si-cik-devices.patch
@@ -1,4 +1,4 @@
-From da1a6ecbb3ed78ad6d86c8ef5eee9e4b9244060b Mon Sep 17 00:00:00 2001
+From eb9da968e5e9e752a4efcae0762db27dd737d975 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 29 Feb 2024 20:54:51 +0800
 Subject: [PATCH 005/105] drm: amdgpu: use amdgpu by default for si/cik devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-drm-amdgpu-radeon-disable-cache-flush-workaround-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-drm-amdgpu-radeon-disable-cache-flush-workaround-for.patch
@@ -1,4 +1,4 @@
-From 0507b4abba4519d1f256639a0b3d733a5a6f1209 Mon Sep 17 00:00:00 2001
+From f9473f3e99a5310258cb4e7a7ab03f05f908f333 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 16 Jul 2024 14:37:00 +0800
 Subject: [PATCH 006/105] drm: amdgpu: radeon: disable cache flush workaround

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-ethernet-bundle-module-for-Motorcomm-YT6801.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-ethernet-bundle-module-for-Motorcomm-YT6801.patch
@@ -1,4 +1,4 @@
-From 012daf7541d04738f41ffd006703139aa6b76a63 Mon Sep 17 00:00:00 2001
+From f6f7f13cb043ccbbef01e5a027dadb93c822c006 Mon Sep 17 00:00:00 2001
 From: wanghuai <748928840@qq.com>
 Date: Fri, 2 Feb 2024 19:05:26 +0000
 Subject: [PATCH 007/105] ethernet: bundle module for Motorcomm YT6801

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-net-stmmac-Move-the-atds-flag-to-the-stmmac_dma_cfg-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-net-stmmac-Move-the-atds-flag-to-the-stmmac_dma_cfg-.patch
@@ -1,4 +1,4 @@
-From 7978adfe9bfec39babe3495496c179ed7ae95b61 Mon Sep 17 00:00:00 2001
+From 3a887dc37b55509c68fd45e135deb932fa3b2b32 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:45:28 +0800
 Subject: [PATCH 008/105] net: stmmac: Move the atds flag to the stmmac_dma_cfg

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-net-stmmac-Add-multi-channel-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-net-stmmac-Add-multi-channel-support.patch
@@ -1,4 +1,4 @@
-From e4cee26aa5ee646703628d6e9f742b51cdf2ec09 Mon Sep 17 00:00:00 2001
+From 46fdedf93430f4fc8e0a9b29511873740cea5191 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:45:29 +0800
 Subject: [PATCH 009/105] net: stmmac: Add multi-channel support

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-net-stmmac-Export-dwmac1000_dma_ops.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-net-stmmac-Export-dwmac1000_dma_ops.patch
@@ -1,4 +1,4 @@
-From 18f49d2580bd8155386c447449dd7b69b88c1427 Mon Sep 17 00:00:00 2001
+From cf26daf8993be2fd5f2703e4da7537b4a3f4b7d2 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:45:30 +0800
 Subject: [PATCH 010/105] net: stmmac: Export dwmac1000_dma_ops

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-net-stmmac-dwmac-loongson-Drop-duplicated-hash-based.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-net-stmmac-dwmac-loongson-Drop-duplicated-hash-based.patch
@@ -1,4 +1,4 @@
-From 64eef03c381ae21ce3ec9100dc239ab0d10b1abf Mon Sep 17 00:00:00 2001
+From ab356bcfd868a271235da4cd4d2516a855c751c6 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:47:07 +0800
 Subject: [PATCH 011/105] net: stmmac: dwmac-loongson: Drop duplicated

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-net-stmmac-dwmac-loongson-Drop-pci_enable-disable_ms.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-net-stmmac-dwmac-loongson-Drop-pci_enable-disable_ms.patch
@@ -1,4 +1,4 @@
-From a8330c574be1d4c4dc2035d9b7161fa9c9ab417d Mon Sep 17 00:00:00 2001
+From f6efcf4b7b144d2cf0eb1ce0dc8d466b29239bab Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:47:08 +0800
 Subject: [PATCH 012/105] net: stmmac: dwmac-loongson: Drop

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-net-stmmac-dwmac-loongson-Use-PCI_DEVICE_DATA-macro-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-net-stmmac-dwmac-loongson-Use-PCI_DEVICE_DATA-macro-.patch
@@ -1,4 +1,4 @@
-From fad364ea9045531fd132965abf21be9737aba981 Mon Sep 17 00:00:00 2001
+From b67fdde8adf0e6b3851c7d276e1801f2bc27b2fe Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:47:09 +0800
 Subject: [PATCH 013/105] net: stmmac: dwmac-loongson: Use PCI_DEVICE_DATA()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-net-stmmac-dwmac-loongson-Detach-GMAC-specific-platf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-net-stmmac-dwmac-loongson-Detach-GMAC-specific-platf.patch
@@ -1,4 +1,4 @@
-From 1ca6a63d880de39b76be02c751c36d60e26e98a5 Mon Sep 17 00:00:00 2001
+From 56bd60f345279ac7a053245cbcb7b16c3286d89a Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:47:10 +0800
 Subject: [PATCH 014/105] net: stmmac: dwmac-loongson: Detach GMAC-specific

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-net-stmmac-dwmac-loongson-Init-ref-and-PTP-clocks-ra.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-net-stmmac-dwmac-loongson-Init-ref-and-PTP-clocks-ra.patch
@@ -1,4 +1,4 @@
-From b08629e3fff52e58c74d239072e46d9abb7f612f Mon Sep 17 00:00:00 2001
+From 25dac4023b837625d061156c7e985a44075ccfc1 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:02 +0800
 Subject: [PATCH 015/105] net: stmmac: dwmac-loongson: Init ref and PTP clocks

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-net-stmmac-dwmac-loongson-Add-phy_interface-for-Loon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-net-stmmac-dwmac-loongson-Add-phy_interface-for-Loon.patch
@@ -1,4 +1,4 @@
-From a88f69cfe1d8ec426ccaed90cd94f37fd858b694 Mon Sep 17 00:00:00 2001
+From ed06cfc623aa61a6340d0d41e9d88c0c53b0a3d4 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:03 +0800
 Subject: [PATCH 016/105] net: stmmac: dwmac-loongson: Add phy_interface for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-net-stmmac-dwmac-loongson-Introduce-PCI-device-info-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-net-stmmac-dwmac-loongson-Introduce-PCI-device-info-.patch
@@ -1,4 +1,4 @@
-From 7d41de006c6a3f7d1a7f0769bcc11245189e2c06 Mon Sep 17 00:00:00 2001
+From d30a5bb2450312a95f0f66dcfa6e87dd5b8b0213 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:04 +0800
 Subject: [PATCH 017/105] net: stmmac: dwmac-loongson: Introduce PCI device

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-net-stmmac-dwmac-loongson-Add-DT-less-GMAC-PCI-devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-net-stmmac-dwmac-loongson-Add-DT-less-GMAC-PCI-devic.patch
@@ -1,4 +1,4 @@
-From d935016a53afcd57612a2b39ee285356e8241954 Mon Sep 17 00:00:00 2001
+From 0c254aaf06ac585fdecb8a2f7dc00e4631335d9f Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:05 +0800
 Subject: [PATCH 018/105] net: stmmac: dwmac-loongson: Add DT-less GMAC

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-net-stmmac-dwmac-loongson-Add-Loongson-Multi-channel.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-net-stmmac-dwmac-loongson-Add-Loongson-Multi-channel.patch
@@ -1,4 +1,4 @@
-From 6ceacd86583545421ed8c266bc4603e66539211f Mon Sep 17 00:00:00 2001
+From f182a46931641d90a4dc0258b9d8a3e5f9d8703a Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:54 +0800
 Subject: [PATCH 019/105] net: stmmac: dwmac-loongson: Add Loongson

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-net-stmmac-dwmac-loongson-Add-Loongson-GNET-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-net-stmmac-dwmac-loongson-Add-Loongson-GNET-support.patch
@@ -1,4 +1,4 @@
-From c1eec78ac2a4a7a9a9a26fb68330866df138617f Mon Sep 17 00:00:00 2001
+From 84cf4586f645965586c3f75a7907209e9013d5d3 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:55 +0800
 Subject: [PATCH 020/105] net: stmmac: dwmac-loongson: Add Loongson GNET

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-net-stmmac-dwmac-loongson-Add-loongson-module-author.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-net-stmmac-dwmac-loongson-Add-loongson-module-author.patch
@@ -1,4 +1,4 @@
-From d89ddd516da112058c721a01b5625e5481aef4ca Mon Sep 17 00:00:00 2001
+From 12dfffe9dc28fb6294a624a0db9c63bff4ee372a Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 7 Aug 2024 21:48:56 +0800
 Subject: [PATCH 021/105] net: stmmac: dwmac-loongson: Add loongson module

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-net-stmmac-Add-Phytium-GMAC-glue-layer.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-net-stmmac-Add-Phytium-GMAC-glue-layer.patch
@@ -1,4 +1,4 @@
-From 7a48220076f39e8a8bc26fb1e8ba294a7fe23fea Mon Sep 17 00:00:00 2001
+From b3087234016bb229ca7ed98cfca72c8a38a11ac5 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
 Subject: [PATCH 022/105] net: stmmac: Add Phytium GMAC glue layer

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-net-stmmac-Add-a-barrier-to-make-sure-all-access-coh.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-net-stmmac-Add-a-barrier-to-make-sure-all-access-coh.patch
@@ -1,4 +1,4 @@
-From bc62ce27d3ffdd55ad4b450d40238d40e4568f9a Mon Sep 17 00:00:00 2001
+From f2d4c6d94fe0b32966e06ca0f062857a6ec98780 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
 Subject: [PATCH 023/105] net: stmmac: Add a barrier to make sure all access

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-drivers-fix-build-errors.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-drivers-fix-build-errors.patch
@@ -1,4 +1,4 @@
-From 306e64b53036560483d814f8fac22329d1c14b6b Mon Sep 17 00:00:00 2001
+From 12e72ea91ad25fff43420681864998824b191cf8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 00:02:32 +0800
 Subject: [PATCH 024/105] drivers: fix build errors

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-Update-phytium-copyright-info-to-2024.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-Update-phytium-copyright-info-to-2024.patch
@@ -1,4 +1,4 @@
-From 476812becece6343b0ff4da0d215e127e3e24f47 Mon Sep 17 00:00:00 2001
+From 4de01cb30448b342555a2984c7d897cce9ad7c98 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 00:05:33 +0800
 Subject: [PATCH 025/105] Update phytium copyright info to 2024

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-net-stmmac-Add-phytium-DWMAC-driver-support-v2.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-net-stmmac-Add-phytium-DWMAC-driver-support-v2.patch
@@ -1,4 +1,4 @@
-From fc3725d1050e6ed83ba6e3bcc4b2844a42935152 Mon Sep 17 00:00:00 2001
+From 2cfb0c232ad9856429c8a36e4913be46be109485 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
 Subject: [PATCH 026/105] net/stmmac: Add phytium DWMAC driver support v2

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,4 +1,4 @@
-From c1dfb5398f2156e73ce905f030917c0c8e0031a7 Mon Sep 17 00:00:00 2001
+From a8876ae1b077cb9d625fed21653dede5cc941e7c Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
 Subject: [PATCH 027/105] net: stmmac: phytium driver add pm support

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,4 +1,4 @@
-From ec0a0334d36fd05d799e69533aebc374b518cc7a Mon Sep 17 00:00:00 2001
+From 2fbd6ae94b77205932f99967aecfb2ee1b67fe53 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
 Subject: [PATCH 028/105] net: stmmac: fix dwmac-phytium build on 6.9

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-net-stmmac-Add-phytium-old-dwmac-acpi_device_id.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-net-stmmac-Add-phytium-old-dwmac-acpi_device_id.patch
@@ -1,4 +1,4 @@
-From 770904b01bb9f19a227e7710de9cfc83ef31eb27 Mon Sep 17 00:00:00 2001
+From c945f963f72c371e0a37c8a48ef67be6d5d63b85 Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
 Subject: [PATCH 029/105] net/stmmac: Add phytium old dwmac acpi_device_id

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-net-stmmac-fix-potential-double-free-of-dma-descript.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-net-stmmac-fix-potential-double-free-of-dma-descript.patch
@@ -1,4 +1,4 @@
-From 9b8edf4e86511e172ea6a204550971a2890454b7 Mon Sep 17 00:00:00 2001
+From c5ad144a80dbe48fe95bc85e4e8581c2deeacd78 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
 Subject: [PATCH 030/105] net: stmmac: fix potential double free of dma

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-net-phytium-Add-support-for-phytium-GMAC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-net-phytium-Add-support-for-phytium-GMAC.patch
@@ -1,4 +1,4 @@
-From 3236169ed6e3491326ace7374d32fba8ed0d29a9 Mon Sep 17 00:00:00 2001
+From fe598bebbd60d210e90d26aea5e12cc64dcc1e84 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:48:50 +0800
 Subject: [PATCH 031/105] net: phytium: Add support for phytium GMAC

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-net-phytmac-Bugfixed-the-MDIO-registration-failures.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-net-phytmac-Bugfixed-the-MDIO-registration-failures.patch
@@ -1,4 +1,4 @@
-From af97afc5d7c1dfeb5e668c3a7bfb6a2d83c6e81e Mon Sep 17 00:00:00 2001
+From bbdca87f2c14b61694df89279e091f49b27c0683 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:58:33 +0800
 Subject: [PATCH 032/105] net/phytmac: Bugfixed the MDIO registration failures

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-net-phytmac-Fixed-the-issue-of-pxe-startup-failure.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-net-phytmac-Fixed-the-issue-of-pxe-startup-failure.patch
@@ -1,4 +1,4 @@
-From ec1c5cff436dcbce412570ad32a29fa8762b2b4a Mon Sep 17 00:00:00 2001
+From a85aee20d0c84551582910815924d69b1a61739b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:58:56 +0800
 Subject: [PATCH 033/105] net/phytmac: Fixed the issue of pxe startup failure.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,4 +1,4 @@
-From c902def81e9c29abdb96f0b3885b066ae52e26c6 Mon Sep 17 00:00:00 2001
+From 6671e5dcd9b00c295a48c995ed7a7becb8dc7b91 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 07:59:09 +0800
 Subject: [PATCH 034/105] net/phytmac: Adapt interface type 1000BASE-x

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-net-ethernet-phytium-fix-phytmac_platform-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-net-ethernet-phytium-fix-phytmac_platform-on-6.9.patch
@@ -1,4 +1,4 @@
-From f4b4f3c338a9c7cbd5e740214f11c7569540cac0 Mon Sep 17 00:00:00 2001
+From c7c2275e3231425e8479a3c6e5157f8917755cda Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
 Subject: [PATCH 035/105] net: ethernet: phytium: fix phytmac_platform on 6.9

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,4 +1,4 @@
-From 6bcc779af3b9ab178986b560ad422f0fdafee454 Mon Sep 17 00:00:00 2001
+From 1e6a914535802ca28273f705962799d281c3fb9a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
 Subject: [PATCH 036/105] net: ethernet: fix phytmac on 6.9

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-net-ethernet-phytium-add-a-missing-declaration-for-n.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-net-ethernet-phytium-add-a-missing-declaration-for-n.patch
@@ -1,4 +1,4 @@
-From 5025b0f2346f9469bfb4f870f27e588eeecda1b0 Mon Sep 17 00:00:00 2001
+From 13af82108b55e4e0a372bc54e9f7e552b23f94aa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
 Subject: [PATCH 037/105] net: ethernet: phytium: add a missing declaration for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-net-phytium-convert-and-remove-validate-references.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-net-phytium-convert-and-remove-validate-references.patch
@@ -1,4 +1,4 @@
-From 27628a9a0010868156066cbda5d5f8a766c5d36e Mon Sep 17 00:00:00 2001
+From d64e25261ba26ee878aa9641a9b028bf417353c6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
 Subject: [PATCH 038/105] net: phytium: convert and remove validate()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-arm-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-arm-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,4 +1,4 @@
-From 24981666038443428e73156c0cbe10c125fc51aa Mon Sep 17 00:00:00 2001
+From 8d5b0b481c52f41e735d484186bc086e8a45055d Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux@gmail.com>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
 Subject: [PATCH 039/105] arm: usb: phy: tegra: Add 38.4MHz clock table entry

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-arm64-dts-rockchip-change-GMAC-rx_delay-for-RockPro6.patch
@@ -1,4 +1,4 @@
-From 8031be36405adcf0fa4c072703b2037a37c9a604 Mon Sep 17 00:00:00 2001
+From 7b2a6d4d9baa115e06a58e9143c5057e357c11e8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
 Subject: [PATCH 040/105] arm64: dts: rockchip: change GMAC rx_delay for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-arm64-phytium-Add-support-for-Phytium-SoC-family.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-arm64-phytium-Add-support-for-Phytium-SoC-family.patch
@@ -1,4 +1,4 @@
-From 7314dd71401f880987a51ee8515e1a0c922d0cc3 Mon Sep 17 00:00:00 2001
+From d0784931893e8f958732482ad9cb7e0a17cdb06e Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
 Subject: [PATCH 041/105] arm64: phytium: Add support for Phytium SoC family

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,4 +1,4 @@
-From c561aebb3a126a34bb62295eba712da76b602954 Mon Sep 17 00:00:00 2001
+From bca429add2782929c1b172a4b803526c0f488125 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Thu, 21 Apr 2022 11:36:35 +0800
 Subject: [PATCH 042/105] arm64: dts: rockchip: disable usb3 on quartz64

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,4 +1,4 @@
-From f6460b86c96bd714f4d8a6ccd97f8a1700915d08 Mon Sep 17 00:00:00 2001
+From 4db75f5ee120693313f0bad0669b3349da5e7aa9 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 27 Jul 2023 11:13:25 -0400
 Subject: [PATCH 043/105] arm64: drop hisi_ddrc_pmu driver

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-PCI-Add-Phytium-vendor-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-PCI-Add-Phytium-vendor-ID.patch
@@ -1,4 +1,4 @@
-From 157f0c75ae3015fa050b01ee77fa23b324e6172e Mon Sep 17 00:00:00 2001
+From 42877462e6b8f55712498c78ac70ae3e56b602fd Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:06:38 +0800
 Subject: [PATCH 044/105] PCI: Add Phytium vendor ID

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-mips-loongson64-disable-writecombine-for-Loongson-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-mips-loongson64-disable-writecombine-for-Loongson-3A.patch
@@ -1,4 +1,4 @@
-From fc337efd09675ac43dd330f2d22536f177f127c6 Mon Sep 17 00:00:00 2001
+From 5a52710ba6dbb4f6cd4d3ada02006415e06a8cb7 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Mon, 12 Oct 2020 13:32:23 +0800
 Subject: [PATCH 045/105] mips: loongson64: disable writecombine for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-mips-loongson64-init-suppress-memcpy-out-of-bound-ch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-mips-loongson64-init-suppress-memcpy-out-of-bound-ch.patch
@@ -1,4 +1,4 @@
-From a83a729aed21b07df0ded7c44d9fad599c77af87 Mon Sep 17 00:00:00 2001
+From baf08584577500740002f19c8c93239b2ea3443e Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Wed, 24 Aug 2022 03:54:11 +0000
 Subject: [PATCH 046/105] mips: loongson64/init: suppress memcpy out-of-bound

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-mips-loongson64-video-output-re-introduce-display-ou.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-mips-loongson64-video-output-re-introduce-display-ou.patch
@@ -1,4 +1,4 @@
-From d123d0fbfd95ed47fc0230836faf1803d9f8a455 Mon Sep 17 00:00:00 2001
+From 85e8394a32b4dba8af76bd1bbe68f1358ac344ab Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 7 Nov 2017 09:01:33 +0800
 Subject: [PATCH 047/105] mips: loongson64: video: output: re-introduce display

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-mips-video-fbdev-sis-add-1368x768-resolution.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-mips-video-fbdev-sis-add-1368x768-resolution.patch
@@ -1,4 +1,4 @@
-From a20dfb43e5f3b3523a03f12066b9c281b5687cfa Mon Sep 17 00:00:00 2001
+From 0c3aa4255a625cb597c625c0693c7d1e892b0af4 Mon Sep 17 00:00:00 2001
 From: flygoat <flygoatfree@gmail.com>
 Date: Sun, 5 Mar 2017 20:33:17 +0800
 Subject: [PATCH 048/105] mips: video: fbdev: sis: add 1368x768 resolution

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-loongarch-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-loongarch-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,4 +1,4 @@
-From 858e0bda8729e967eaa7de3f79eca59352e78943 Mon Sep 17 00:00:00 2001
+From 0b7d37b68cd86c8df48d192845dfe67b2b2bb55d Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
 Subject: [PATCH 049/105] loongarch: LoongArch: Update the flush cache policy

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-loongarch-PCI-pci_call_probe-call-local_pci_probe-wh.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-loongarch-PCI-pci_call_probe-call-local_pci_probe-wh.patch
@@ -1,4 +1,4 @@
-From e4262cf1c52da962170fd91d3ec565016ef4d1ce Mon Sep 17 00:00:00 2001
+From a131b2a8845b60d8ff8efdbb16ea883dcea97e8c Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Thu, 13 Jun 2024 15:42:58 +0800
 Subject: [PATCH 050/105] loongarch: PCI: pci_call_probe: call
@@ -17,7 +17,7 @@ Fixes: 69a18b18699b ("PCI: Restrict probe functions to housekeeping CPUs")
 Cc: <stable@vger.kernel.org>
 Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
 Signed-off-by: Hongchen Zhang <zhanghongchen@loongson.cn>
-Ref: https://github.com/chenhuacai/linux/commit/380c035bd4b59019b742b0be494f99b527f138f6
+Ref: https://github.com/chenhuacai/linux/commit/a504a1880885168e96db422e00adc2709b8bcd8b
 ---
  drivers/pci/pci-driver.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,4 +1,4 @@
-From d93bea7eb40c9c939479994588091cebfc7052eb Mon Sep 17 00:00:00 2001
+From 6e8e53af8950911ac20eae6737db8056abe1e9ad Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 01:23:57 +0800
 Subject: [PATCH 051/105] LoongArch: Add CPU HWMon platform driver

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-LoongArch-KVM-Add-PV-steal-time-support-in-host-side.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-LoongArch-KVM-Add-PV-steal-time-support-in-host-side.patch
@@ -1,4 +1,4 @@
-From 01ca25ede44e2455f61919664778eef51bc59cfc Mon Sep 17 00:00:00 2001
+From 0b22cb03f83db0581637bfabffa55a766c5d074d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:31:59 +0800
 Subject: [PATCH 052/105] LoongArch: KVM: Add PV steal time support in host

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-LoongArch-KVM-Add-PV-steal-time-support-in-guest-sid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-LoongArch-KVM-Add-PV-steal-time-support-in-guest-sid.patch
@@ -1,4 +1,4 @@
-From 670d5046d565acfac5b5b500a64923d303389ad4 Mon Sep 17 00:00:00 2001
+From 4de98f4790b40ea3535f3b9a335349452934d6c7 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:32:22 +0800
 Subject: [PATCH 053/105] LoongArch: KVM: Add PV steal time support in guest

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-LoongArch-KVM-Add-HW-Binary-Translation-extension-su.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-LoongArch-KVM-Add-HW-Binary-Translation-extension-su.patch
@@ -1,4 +1,4 @@
-From 8d992bbc1605a7e5af7d15988dca70c9ff3c6282 Mon Sep 17 00:00:00 2001
+From 1524ad234aa34ee4f98792a2c84466584da0c5c0 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Jul 2024 15:57:41 +0800
 Subject: [PATCH 054/105] LoongArch: KVM: Add HW Binary Translation extension

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-LoongArch-KVM-Add-LBT-feature-detection-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-LoongArch-KVM-Add-LBT-feature-detection-function.patch
@@ -1,4 +1,4 @@
-From 4c03530889852dea33bbe11183a347185ba81266 Mon Sep 17 00:00:00 2001
+From 84c6c9792cde2a03aea7b625b5ee66e4edb086aa Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Jul 2024 15:57:42 +0800
 Subject: [PATCH 055/105] LoongArch: KVM: Add LBT feature detection function

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-LoongArch-KVM-Add-vm-migration-support-for-LBT-regis.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-LoongArch-KVM-Add-vm-migration-support-for-LBT-regis.patch
@@ -1,4 +1,4 @@
-From 9940c6f7450814bda94c92274707d88d13029490 Mon Sep 17 00:00:00 2001
+From 626827036c6d2dedc324f8826a67d5f5077cb739 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Jul 2024 15:57:43 +0800
 Subject: [PATCH 056/105] LoongArch: KVM: Add vm migration support for LBT

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-LoongArch-Add-architectural-preparation-for-CPUFreq.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-LoongArch-Add-architectural-preparation-for-CPUFreq.patch
@@ -1,4 +1,4 @@
-From 8364f33d9c75e4281dab73989213011001efe426 Mon Sep 17 00:00:00 2001
+From c78f28e1415e035a3dfe20edda26cf6deee88076 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sat, 20 Jul 2024 22:41:06 +0800
 Subject: [PATCH 057/105] LoongArch: Add architectural preparation for CPUFreq

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-cpufreq-Add-Loongson-3-CPUFreq-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-cpufreq-Add-Loongson-3-CPUFreq-driver-support.patch
@@ -1,4 +1,4 @@
-From 6202d0bdb7c3b5282f1637b7d4400f3e8ba746fe Mon Sep 17 00:00:00 2001
+From 71cd2aa3d4fb1e9ac23001da9b2ddcea4190f07b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 5 Jul 2024 14:06:49 +0800
 Subject: [PATCH 058/105] cpufreq: Add Loongson-3 CPUFreq driver support

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-dt-bindings-pwm-Add-Loongson-PWM-controller.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-dt-bindings-pwm-Add-Loongson-PWM-controller.patch
@@ -1,4 +1,4 @@
-From 25a42ddbe5d3db070b8372d583c4b120bd2a2606 Mon Sep 17 00:00:00 2001
+From 607760f1f45e07c6bb1341c599b5cdfab7ac6099 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 10 Jul 2024 10:04:06 +0800
 Subject: [PATCH 059/105] dt-bindings: pwm: Add Loongson PWM controller

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-pwm-Add-Loongson-PWM-controller-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-pwm-Add-Loongson-PWM-controller-support.patch
@@ -1,4 +1,4 @@
-From 635049a83a2b1127e5f3358f22b3295e23f22b7e Mon Sep 17 00:00:00 2001
+From d9ee332d3387ffad79e3e35b3462ec5e91f7102f Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 10 Jul 2024 10:04:07 +0800
 Subject: [PATCH 060/105] pwm: Add Loongson PWM controller support

--- a/runtime-kernel/linux-kernel/autobuild/patches/0061-cpufreq-Make-Loongson-3-s-cpufreq_driver-exit-return.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0061-cpufreq-Make-Loongson-3-s-cpufreq_driver-exit-return.patch
@@ -1,4 +1,4 @@
-From 3b433594fdb395acb3ff24c6ec5e893ff821383d Mon Sep 17 00:00:00 2001
+From b20fc38236fb743d82b65f57f1569507aa02924d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 6 Aug 2024 20:00:46 +0800
 Subject: [PATCH 061/105] cpufreq: Make Loongson-3's cpufreq_driver->exit()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0062-loongarch-basic-boot-support-for-legacy-firmware.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0062-loongarch-basic-boot-support-for-legacy-firmware.patch
@@ -1,4 +1,4 @@
-From f3b623efe8b1cd48e64d243caad130db4aae645f Mon Sep 17 00:00:00 2001
+From 8638763456e863f1e7a89fc068e551d4e4fad87a Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
 Subject: [PATCH 062/105] loongarch: basic boot support for legacy firmware

--- a/runtime-kernel/linux-kernel/autobuild/patches/0063-loongarch-parse-BPI-data-and-add-memory-mapping.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0063-loongarch-parse-BPI-data-and-add-memory-mapping.patch
@@ -1,4 +1,4 @@
-From ae5a4f1d818abc053789671f846629067672b48b Mon Sep 17 00:00:00 2001
+From a138a1cc6ac56253c161c4aca8bb369d93a09c7e Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
 Subject: [PATCH 063/105] loongarch: parse BPI data and add memory mapping

--- a/runtime-kernel/linux-kernel/autobuild/patches/0064-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0064-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,4 +1,4 @@
-From 13dd1fe6a8f564b565bd64259ff70b8f3ee6bc5d Mon Sep 17 00:00:00 2001
+From c27c08f5008114a4f75feee0ed578a899153f370 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
 Subject: [PATCH 064/105] loongarch: add MADT ACPI table conversion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0065-loongarch-correct-missing-offset-of-PCI-root-control.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0065-loongarch-correct-missing-offset-of-PCI-root-control.patch
@@ -1,4 +1,4 @@
-From c3c28b811e8ef54e50f1d179bb6caec115b8a4ed Mon Sep 17 00:00:00 2001
+From 873d0be8905dd7d4eccdb617ac86b8333e823977 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
 Subject: [PATCH 065/105] loongarch: correct missing offset of PCI root

--- a/runtime-kernel/linux-kernel/autobuild/patches/0066-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0066-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,4 +1,4 @@
-From 3534c3b4dd3eefb3e5a4a51345b52883f5f3442c Mon Sep 17 00:00:00 2001
+From 0176e9778b0e5e252bf913d3768aa1b6570bc2cb Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
 Subject: [PATCH 066/105] loongarch: fix missing dependency info in DSDT

--- a/runtime-kernel/linux-kernel/autobuild/patches/0067-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0067-loongarch-fix-DMA-address-offset.patch
@@ -1,4 +1,4 @@
-From 02b192cd701583f880883c55f3ca4739808e4d5c Mon Sep 17 00:00:00 2001
+From 168cdaea83c43a6539b08da03675c58405b47a0f Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
 Subject: [PATCH 067/105] loongarch: fix DMA address offset

--- a/runtime-kernel/linux-kernel/autobuild/patches/0068-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0068-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,4 +1,4 @@
-From feb00228da8b35215f2de6f74349aa42a79bb073 Mon Sep 17 00:00:00 2001
+From ddd5db10a25a8184e82040986f89edf28ab97aba Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
 Subject: [PATCH 068/105] loongarch: fix HT_RX_INT_TRANS register

--- a/runtime-kernel/linux-kernel/autobuild/patches/0069-ntsync-Introduce-NTSYNC_IOC_WAIT_ANY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0069-ntsync-Introduce-NTSYNC_IOC_WAIT_ANY.patch
@@ -1,4 +1,4 @@
-From 381241ae87ca79389a1b4fc284e761d815e63249 Mon Sep 17 00:00:00 2001
+From f9128dc067dc05ab5bb99ed22701b92c6a954765 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:27 -0500
 Subject: [PATCH 069/105] ntsync: Introduce NTSYNC_IOC_WAIT_ANY.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0070-ntsync-Introduce-NTSYNC_IOC_WAIT_ALL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0070-ntsync-Introduce-NTSYNC_IOC_WAIT_ALL.patch
@@ -1,4 +1,4 @@
-From dd9d2b52858993d7af26b20de4191c5e3a5c0be9 Mon Sep 17 00:00:00 2001
+From 8ef9f6bd6053e4318d15532c1a7b9ff2fe033e6f Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:28 -0500
 Subject: [PATCH 070/105] ntsync: Introduce NTSYNC_IOC_WAIT_ALL.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0071-ntsync-Introduce-NTSYNC_IOC_CREATE_MUTEX.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0071-ntsync-Introduce-NTSYNC_IOC_CREATE_MUTEX.patch
@@ -1,4 +1,4 @@
-From 0fa015dad912a54218c445f9afd98c913a96a433 Mon Sep 17 00:00:00 2001
+From 2ead7f30170b803a677a95c8544758c23c156c5f Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:29 -0500
 Subject: [PATCH 071/105] ntsync: Introduce NTSYNC_IOC_CREATE_MUTEX.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0072-ntsync-Introduce-NTSYNC_IOC_MUTEX_UNLOCK.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0072-ntsync-Introduce-NTSYNC_IOC_MUTEX_UNLOCK.patch
@@ -1,4 +1,4 @@
-From 46106a7d30c26f31a7b33a259b55c3d99b4764fe Mon Sep 17 00:00:00 2001
+From f6c8da96c07b0e49d5d3d814b3ebf49f3088ef74 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:30 -0500
 Subject: [PATCH 072/105] ntsync: Introduce NTSYNC_IOC_MUTEX_UNLOCK.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0073-ntsync-Introduce-NTSYNC_IOC_MUTEX_KILL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0073-ntsync-Introduce-NTSYNC_IOC_MUTEX_KILL.patch
@@ -1,4 +1,4 @@
-From 974885e695d3ea2047fe459f9d4fd7173f063962 Mon Sep 17 00:00:00 2001
+From f36e74e0ce18fed09cd3dfb65476ea25744c78eb Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:31 -0500
 Subject: [PATCH 073/105] ntsync: Introduce NTSYNC_IOC_MUTEX_KILL.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0074-ntsync-Introduce-NTSYNC_IOC_CREATE_EVENT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0074-ntsync-Introduce-NTSYNC_IOC_CREATE_EVENT.patch
@@ -1,4 +1,4 @@
-From 112fe37356d421feafcd055418fa1fc2261852a3 Mon Sep 17 00:00:00 2001
+From 0bc816807b5cadc48a2100f9a57f9ce8a53bb39f Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:32 -0500
 Subject: [PATCH 074/105] ntsync: Introduce NTSYNC_IOC_CREATE_EVENT.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0075-ntsync-Introduce-NTSYNC_IOC_EVENT_SET.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0075-ntsync-Introduce-NTSYNC_IOC_EVENT_SET.patch
@@ -1,4 +1,4 @@
-From 0523e8abd44dfb23923e3a70c36f472e6dc5a8cd Mon Sep 17 00:00:00 2001
+From ae2545ea3800a585e32536cd38082abd410833bc Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:33 -0500
 Subject: [PATCH 075/105] ntsync: Introduce NTSYNC_IOC_EVENT_SET.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0076-ntsync-Introduce-NTSYNC_IOC_EVENT_RESET.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0076-ntsync-Introduce-NTSYNC_IOC_EVENT_RESET.patch
@@ -1,4 +1,4 @@
-From d95ebbc19780c1ceb538457459141696704a4b9f Mon Sep 17 00:00:00 2001
+From 343c028a96b72a307e1c1e48e265f7b6d3634896 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:34 -0500
 Subject: [PATCH 076/105] ntsync: Introduce NTSYNC_IOC_EVENT_RESET.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0077-ntsync-Introduce-NTSYNC_IOC_EVENT_PULSE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0077-ntsync-Introduce-NTSYNC_IOC_EVENT_PULSE.patch
@@ -1,4 +1,4 @@
-From 266c5f06f0f3c57eb33743b39dfdbf5cd28ab161 Mon Sep 17 00:00:00 2001
+From 0d0894e15379d97fc1947d9718ce30e2ed2a1b74 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:35 -0500
 Subject: [PATCH 077/105] ntsync: Introduce NTSYNC_IOC_EVENT_PULSE.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0078-ntsync-Introduce-NTSYNC_IOC_SEM_READ.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0078-ntsync-Introduce-NTSYNC_IOC_SEM_READ.patch
@@ -1,4 +1,4 @@
-From e745ab08635d0a4cf8e7784720e8d4632002add4 Mon Sep 17 00:00:00 2001
+From e3ef24b81d38ad08e3b011a86807c0ff5b81b935 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:36 -0500
 Subject: [PATCH 078/105] ntsync: Introduce NTSYNC_IOC_SEM_READ.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0079-ntsync-Introduce-NTSYNC_IOC_MUTEX_READ.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0079-ntsync-Introduce-NTSYNC_IOC_MUTEX_READ.patch
@@ -1,4 +1,4 @@
-From f1fe2eb16de29de9e1d7bd2eb517f64aca9f02af Mon Sep 17 00:00:00 2001
+From a31921415b4413c52d7c4785dd2d7dd9bc1c8ec9 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:37 -0500
 Subject: [PATCH 079/105] ntsync: Introduce NTSYNC_IOC_MUTEX_READ.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0080-ntsync-Introduce-NTSYNC_IOC_EVENT_READ.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0080-ntsync-Introduce-NTSYNC_IOC_EVENT_READ.patch
@@ -1,4 +1,4 @@
-From 48b43e5a92d64d76dc369ccdd7c0251b1aff1086 Mon Sep 17 00:00:00 2001
+From 7d26280379d847b123809cf85794c26c7fbe098b Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:38 -0500
 Subject: [PATCH 080/105] ntsync: Introduce NTSYNC_IOC_EVENT_READ.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0081-ntsync-Introduce-alertable-waits.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0081-ntsync-Introduce-alertable-waits.patch
@@ -1,4 +1,4 @@
-From 370f01f13ef86a22f7bbc4252aee462e1f72e078 Mon Sep 17 00:00:00 2001
+From 5b5094e1f184e8d1601ec072b64ab630627a819d Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:39 -0500
 Subject: [PATCH 081/105] ntsync: Introduce alertable waits.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0082-selftests-ntsync-Add-some-tests-for-semaphore-state.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0082-selftests-ntsync-Add-some-tests-for-semaphore-state.patch
@@ -1,4 +1,4 @@
-From bc5421a1de808448ce252541dd07855b855774fa Mon Sep 17 00:00:00 2001
+From a07b45ae0a3b9ad5299f77e9d77d3b5ead479158 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:40 -0500
 Subject: [PATCH 082/105] selftests: ntsync: Add some tests for semaphore

--- a/runtime-kernel/linux-kernel/autobuild/patches/0083-selftests-ntsync-Add-some-tests-for-mutex-state.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0083-selftests-ntsync-Add-some-tests-for-mutex-state.patch
@@ -1,4 +1,4 @@
-From 65da3cf6ec42413a84745643251e7405c2c5de8a Mon Sep 17 00:00:00 2001
+From aca58682d73a53650159bfda8b54705e01c2a7d3 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:41 -0500
 Subject: [PATCH 083/105] selftests: ntsync: Add some tests for mutex state.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0084-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0084-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
@@ -1,4 +1,4 @@
-From 95655fbf2ef092e396ba6e5dbaf7932241729137 Mon Sep 17 00:00:00 2001
+From 2dc6982d8b20e0daf64537a7e1bb85470ea5630e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:42 -0500
 Subject: [PATCH 084/105] selftests: ntsync: Add some tests for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0085-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0085-selftests-ntsync-Add-some-tests-for-NTSYNC_IOC_WAIT_.patch
@@ -1,4 +1,4 @@
-From 0479739836ec28caca2c742366fadcdeb66aeb34 Mon Sep 17 00:00:00 2001
+From 241e855718938bcaa1056d696b899db3e2673a53 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:43 -0500
 Subject: [PATCH 085/105] selftests: ntsync: Add some tests for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0086-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0086-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From 8d2803b0bee464d736654c6f8b9ca18cfb11ce69 Mon Sep 17 00:00:00 2001
+From 89264b99af8a2bfcddcb7a6ff2004344b554ff68 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:44 -0500
 Subject: [PATCH 086/105] selftests: ntsync: Add some tests for wakeup

--- a/runtime-kernel/linux-kernel/autobuild/patches/0087-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0087-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From ef8dc9529f13e389e58a81d3b2aaf5e0357ea718 Mon Sep 17 00:00:00 2001
+From 7345d59a0a4587d7a55be1ece5730aaf96878bd4 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:45 -0500
 Subject: [PATCH 087/105] selftests: ntsync: Add some tests for wakeup

--- a/runtime-kernel/linux-kernel/autobuild/patches/0088-selftests-ntsync-Add-some-tests-for-manual-reset-eve.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0088-selftests-ntsync-Add-some-tests-for-manual-reset-eve.patch
@@ -1,4 +1,4 @@
-From 3abe1ba530ac1eaeca673e133cca239ad2d63a30 Mon Sep 17 00:00:00 2001
+From 8a39caa26f40d3089dd8e00c433e1ac6b98d6436 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:46 -0500
 Subject: [PATCH 088/105] selftests: ntsync: Add some tests for manual-reset

--- a/runtime-kernel/linux-kernel/autobuild/patches/0089-selftests-ntsync-Add-some-tests-for-auto-reset-event.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0089-selftests-ntsync-Add-some-tests-for-auto-reset-event.patch
@@ -1,4 +1,4 @@
-From bebea8095d68ec0d5b3cf11c795360b3c50db7c9 Mon Sep 17 00:00:00 2001
+From 204da0c7dac7908d842abadc88cfea8e0f8fa404 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:47 -0500
 Subject: [PATCH 089/105] selftests: ntsync: Add some tests for auto-reset

--- a/runtime-kernel/linux-kernel/autobuild/patches/0090-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0090-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From 8da41817dd8cfcd830e017dc867d65079e170472 Mon Sep 17 00:00:00 2001
+From ed8295284c687b562e4153f5dd8c91120552de50 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:48 -0500
 Subject: [PATCH 090/105] selftests: ntsync: Add some tests for wakeup

--- a/runtime-kernel/linux-kernel/autobuild/patches/0091-selftests-ntsync-Add-tests-for-alertable-waits.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0091-selftests-ntsync-Add-tests-for-alertable-waits.patch
@@ -1,4 +1,4 @@
-From 03eb5e090abc4c534c4d5b93c3602f25d0b501e0 Mon Sep 17 00:00:00 2001
+From efd0b2f920a4cc097a9fecc02ad82f7b496395f9 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:49 -0500
 Subject: [PATCH 091/105] selftests: ntsync: Add tests for alertable waits.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0092-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0092-selftests-ntsync-Add-some-tests-for-wakeup-signaling.patch
@@ -1,4 +1,4 @@
-From db6b41bc0a20123730219577e1e3df6fcf52744a Mon Sep 17 00:00:00 2001
+From b087eb5feefb3fda50f1881cf146530c56f06301 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:50 -0500
 Subject: [PATCH 092/105] selftests: ntsync: Add some tests for wakeup

--- a/runtime-kernel/linux-kernel/autobuild/patches/0093-selftests-ntsync-Add-a-stress-test-for-contended-wai.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0093-selftests-ntsync-Add-a-stress-test-for-contended-wai.patch
@@ -1,4 +1,4 @@
-From ae8826fe425d42f9e2ddf91ed78855a3a57cb146 Mon Sep 17 00:00:00 2001
+From 9cde892c768c39868b0f279b4c2a4ead4c0beb09 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:51 -0500
 Subject: [PATCH 093/105] selftests: ntsync: Add a stress test for contended

--- a/runtime-kernel/linux-kernel/autobuild/patches/0094-maintainers-Add-an-entry-for-ntsync.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0094-maintainers-Add-an-entry-for-ntsync.patch
@@ -1,4 +1,4 @@
-From 1b5c3c01134483e415e5a39f97e2946dd81e801d Mon Sep 17 00:00:00 2001
+From af9168bc3452f1de7d22478aa6b8591ae92c3a5e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:52 -0500
 Subject: [PATCH 094/105] maintainers: Add an entry for ntsync.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0095-docs-ntsync-Add-documentation-for-the-ntsync-uAPI.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0095-docs-ntsync-Add-documentation-for-the-ntsync-uAPI.patch
@@ -1,4 +1,4 @@
-From a548a8b2c54432dc46f94c7bec3cf82b52c448e9 Mon Sep 17 00:00:00 2001
+From b6d358f4bd50bc6e87a526cfb820326f9b03585f Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:53 -0500
 Subject: [PATCH 095/105] docs: ntsync: Add documentation for the ntsync uAPI.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0096-ntsync-No-longer-depend-on-BROKEN.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0096-ntsync-No-longer-depend-on-BROKEN.patch
@@ -1,4 +1,4 @@
-From 035ebfd6331bbb2345bfee369db41dee0f6a0f39 Mon Sep 17 00:00:00 2001
+From a1e93dbd8de8a81c8e6cdbeadf654ef28364192c Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Sun, 19 May 2024 15:24:54 -0500
 Subject: [PATCH 096/105] ntsync: No longer depend on BROKEN.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0097-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0097-arch-loongarch-add-la_ow_syscall-as-in-tree-module.patch
@@ -1,4 +1,4 @@
-From 3676040433024a33970fa222588094eee21e3063 Mon Sep 17 00:00:00 2001
+From 67c03141074c46aa63f4ed75e617ff0758fec02a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 28 Aug 2024 03:09:24 +0800
 Subject: [PATCH 097/105] arch/loongarch: add la_ow_syscall as in-tree module

--- a/runtime-kernel/linux-kernel/autobuild/patches/0098-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0098-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,4 +1,4 @@
-From 4c649a865eb19f20bf10fc1e6737407c2e8f4804 Mon Sep 17 00:00:00 2001
+From b21be99f3c6d21cbdec779d82b9ede8941b4a80e Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
 Subject: [PATCH 098/105] la_ow_syscall: add kconfig for module

--- a/runtime-kernel/linux-kernel/autobuild/patches/0099-platform-x86-ideapad-laptop-add-fixes-for-ThinkBook-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0099-platform-x86-ideapad-laptop-add-fixes-for-ThinkBook-.patch
@@ -1,4 +1,4 @@
-From d459aee09c48f05ab801d0f375a4b6cb960bf16b Mon Sep 17 00:00:00 2001
+From 0a47cf0ef76833fd28bbb4ff73a88ae988bd9e2d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 17 Aug 2024 11:32:11 +0800
 Subject: [PATCH 099/105] platform: x86: ideapad-laptop: add fixes for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0100-Revert-drm-amdgpu-fix-contiguous-handling-for-IB-par.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0100-Revert-drm-amdgpu-fix-contiguous-handling-for-IB-par.patch
@@ -1,4 +1,4 @@
-From c2eaa9bad62a18a833f4922478beaef5ff28b6a1 Mon Sep 17 00:00:00 2001
+From 4d3098f7a335873aa015bb3159e0740fab9c9924 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Mon, 2 Sep 2024 10:19:00 +0800
 Subject: [PATCH 100/105] Revert "drm/amdgpu: fix contiguous handling for IB

--- a/runtime-kernel/linux-kernel/autobuild/patches/0101-tpm-export-tpm2_sessions_init-to-fix-ibmvtpm-buildin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0101-tpm-export-tpm2_sessions_init-to-fix-ibmvtpm-buildin.patch
@@ -1,4 +1,4 @@
-From 6e551f78d824326f35faa7e7d593d2a4e8d1bfc6 Mon Sep 17 00:00:00 2001
+From c68ba0f9f509f528a288f393e61920307f24fbf8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 2 Sep 2024 08:26:38 +0800
 Subject: [PATCH 101/105] tpm: export tpm2_sessions_init() to fix ibmvtpm
@@ -19,7 +19,7 @@ Closes: https://lore.kernel.org/oe-kbuild-all/202408051735.ZJkAPQ3b-lkp@intel.co
 Fixes: 08d08e2e9f0a ("tpm: ibmvtpm: Call tpm2_sessions_init() to initialize session support")
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
-Ref: https://lore.kernel.org/all/20240902095835.16925-2-kexybiscuit@aosc.io/
+Ref: https://lore.kernel.org/all/20240905085219.77240-2-kexybiscuit@aosc.io/
 ---
  drivers/char/tpm/tpm2-sessions.c | 1 +
  1 file changed, 1 insertion(+)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0102-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0102-LOONGARCH64-drivers-firmware-Move-sysfb_init-from-de.patch.loongarch64
@@ -1,4 +1,4 @@
-From 2329d1632a1612de7aa5d5d959ac25251546cfb4 Mon Sep 17 00:00:00 2001
+From b838bf8c0657ec29f8695e27db8f25abeb55fdc7 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 12 Aug 2024 08:43:11 +0800
 Subject: [PATCH 102/105] [LOONGARCH64] drivers/firmware: Move sysfb_init()
@@ -35,7 +35,7 @@ sysfb_disable() is sometimes missed. So here we move sysfb_init() to an
 fs_initcall function which is ensured after vgaarb initialization.
 
 Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
-Ref: https://github.com/chenhuacai/linux/commit/dce263743282606930684acd18288986a4c9e7bb
+Ref: https://github.com/chenhuacai/linux/commit/ea80c559590d4f79ea71d9ee7410450db0fb2e3d
 ---
  drivers/firmware/sysfb.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0103-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0103-LOONGARCH64-drm-xe-fix-build-on-non-4K-kernels.patch.loongarch64
@@ -1,4 +1,4 @@
-From 03863ab134e7439a2099049bdb0c25aa63d47fb7 Mon Sep 17 00:00:00 2001
+From 76c4eb6c68ae117b3bed46c236168e92a22f8e92 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Mon, 11 Mar 2024 00:14:58 +0800
 Subject: [PATCH 103/105] [LOONGARCH64] drm/xe: fix build on non-4K kernels
@@ -255,10 +255,10 @@ index 23382ced4ea7..5508c931c28c 100644
  
  	if (xe->info.skip_guc_pc)
 diff --git a/drivers/gpu/drm/xe/xe_migrate.c b/drivers/gpu/drm/xe/xe_migrate.c
-index 198f5c2189cb..d5d160ff1b9e 100644
+index 208649436fdb..8d318785ad73 100644
 --- a/drivers/gpu/drm/xe/xe_migrate.c
 +++ b/drivers/gpu/drm/xe/xe_migrate.c
-@@ -516,7 +516,7 @@ static void emit_pte(struct xe_migrate *m,
+@@ -545,7 +545,7 @@ static void emit_pte(struct xe_migrate *m,
  			u64 addr, flags = 0;
  			bool devmem = false;
  
@@ -267,7 +267,7 @@ index 198f5c2189cb..d5d160ff1b9e 100644
  			if (is_vram) {
  				if (vm->flags & XE_VM_FLAG_64K) {
  					u64 va = cur_ofs * XE_PAGE_SIZE / 8;
-@@ -537,7 +537,7 @@ static void emit_pte(struct xe_migrate *m,
+@@ -566,7 +566,7 @@ static void emit_pte(struct xe_migrate *m,
  			bb->cs[bb->len++] = lower_32_bits(addr);
  			bb->cs[bb->len++] = upper_32_bits(addr);
  
@@ -276,7 +276,7 @@ index 198f5c2189cb..d5d160ff1b9e 100644
  			cur_ofs += 8;
  		}
  	}
-@@ -730,7 +730,7 @@ struct dma_fence *xe_migrate_copy(struct xe_migrate *m,
+@@ -759,7 +759,7 @@ struct dma_fence *xe_migrate_copy(struct xe_migrate *m,
  
  	if (copy_system_ccs)
  		xe_res_first_sg(xe_bo_sg(src_bo), xe_bo_ccs_pages_start(src_bo),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0104-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0104-LOONGARCH64-drm-radeon-Workaround-radeon-driver-bug-.patch.loongarch64
@@ -1,4 +1,4 @@
-From 5d50d1e52b18e7676fd88cef5917f3a1cb3f4c8c Mon Sep 17 00:00:00 2001
+From 371c89498be82117e9c5e53afa9a2b5df43ef743 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
 Subject: [PATCH 104/105] [LOONGARCH64] drm/radeon: Workaround radeon driver
@@ -10,7 +10,7 @@ enable interrupt again when interrupt is faster than DMA data.
 
 Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
 Signed-off-by: Zhijie Zhang <zhangzhijie@loongson.cn>
-Ref: https://github.com/chenhuacai/linux/commit/fa2d2552f43966a758c0318be671687ec1483837
+Ref: https://github.com/chenhuacai/linux/commit/00c74f4ed9227dcf239f81854744927b922af6de
 ---
  drivers/gpu/drm/radeon/cik.c       | 1 +
  drivers/gpu/drm/radeon/evergreen.c | 1 +

--- a/runtime-kernel/linux-kernel/autobuild/patches/0105-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0105-LOONGARCH64-drm-radeon-Call-mmiowb-at-the-end-of-rad.patch.loongarch64
@@ -1,4 +1,4 @@
-From 9af58888341eca4f35df569f2e0b5a7f8d8f8e36 Mon Sep 17 00:00:00 2001
+From 84df10e1622d7ee8f19a464ac867642765d77981 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 14:28:02 +0800
 Subject: [PATCH 105/105] [LOONGARCH64] drm/radeon: Call mmiowb() at the end of

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -1,10 +1,10 @@
-VER=6.10.8
-REL=1
+VER=6.10.9
 
 # Note: For use inside autobuild/.
 __VER="${VER}"
 
 # Use this for stable releases.
+# Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 
 # Use this for RC releases.
@@ -13,5 +13,5 @@ SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 #REL=0.${RC}
 #SRCS="tbl::https://git.kernel.org/torvalds/t/linux-${VER%%.0}-rc${RC}.tar.gz"
 
-CHKSUMS="sha256::c0923235779d4606bba87f72b6fe11f796e9e40c1ca9f4d5dbe04cd47ee3c595"
+CHKSUMS="sha256::a4489b70e0a7c2dc8f501b9cd7fc76989be2febb5519e163ecf816064f2f6858"
 CHKUPDATE="anitya::id=6501"


### PR DESCRIPTION
Topic Description
-----------------

- kernel-tools: update to 6.10.9
    - Track patches at https://github.com/AOSC-Tracking/linux @ aosc/v6.10.9, current HEAD is 84df10e1622d7ee8f19a464ac867642765d77981.
- linux+kernel: update to 6.10.9
- linux-kernel: update to 6.10.9
    - Track patches at https://github.com/AOSC-Tracking/linux @ aosc/v6.10.9, current HEAD is 84df10e1622d7ee8f19a464ac867642765d77981.

Package(s) Affected
-------------------

- kernel-tools: 6.10.9
- linux+kernel: 3:6.10.9
- linux-kernel-${__VER}: 1:6.10.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel linux+kernel kernel-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
