### PR TITLE
ripgrep: update to 14.1.1

### DIFF
--- a/app-utils/ripgrep/spec
+++ b/app-utils/ripgrep/spec
@@ -1,4 +1,4 @@
-VER=14.1.0
+VER=14.1.1
 SRCS="git::commit=tags/$VER::https://github.com/BurntSushi/ripgrep"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15461"


### PR DESCRIPTION
Topic Description
-----------------

- ripgrep: update to 14.1.1
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- ripgrep: 14.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ripgrep
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
