### PR TITLE
stow: update to 2.4.1

### DIFF
--- a/app-admin/stow/spec
+++ b/app-admin/stow/spec
@@ -1,4 +1,4 @@
-VER=2.4.0
+VER=2.4.1
 SRCS="tbl::https://ftp.gnu.org/gnu/stow/stow-$VER.tar.gz"
-CHKSUMS="sha256::6fed67cf64deab6d3d9151a43e2c06c95cdfca6a88fab7d416f46a648b1d761d"
+CHKSUMS="sha256::2a671e75fc207303bfe86a9a7223169c7669df0a8108ebdf1a7fe8cd2b88780b"
 CHKUPDATE="anitya::id=4900"


### PR DESCRIPTION
Topic Description
-----------------

- stow: update to 2.4.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- stow: 2.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit stow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
