### PR TITLE
kitty: update to 0.36.2

### DIFF
--- a/app-utils/kitty/autobuild/defines
+++ b/app-utils/kitty/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=kitty
 PKGSEC=utils
 PKGDEP="fontconfig glew glfw python-3 x11-app lcms2 librsync simde"
-BUILDDEP="go"
+BUILDDEP="go symbols-nerd-font"
 PKGDES="Terminal emulator featuring OpenGL acceleration"

--- a/app-utils/kitty/spec
+++ b/app-utils/kitty/spec
@@ -1,5 +1,4 @@
-VER=0.35.2
-REL=1
+VER=0.36.2
 SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
-CHKSUMS="sha256::b48ac902643bc225ec6ed830f496253ce4522dbe1d4b44fedc3106314c4fade2"
+CHKSUMS="sha256::16db7fba5541f322ecc35f15755bc5dc0b4ab3d02156778317f541c44447fb62"
 CHKUPDATE="anitya::id=17405"

--- a/desktop-fonts/symbols-nerd-font/autobuild/build
+++ b/desktop-fonts/symbols-nerd-font/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Installing Symbols Nerd Font ..."
+install -Dvm644 -t "$PKGDIR"/usr/share/fonts/TTF "$SRCDIR"/*.ttf

--- a/desktop-fonts/symbols-nerd-font/autobuild/defines
+++ b/desktop-fonts/symbols-nerd-font/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=symbols-nerd-font
+PKGDES="Nerd Font icons"
+PKGDEP="fontconfig x11-font"
+PKGSEC=fonts
+
+ABHOST=noarch

--- a/desktop-fonts/symbols-nerd-font/spec
+++ b/desktop-fonts/symbols-nerd-font/spec
@@ -1,0 +1,4 @@
+VER=3.2.1
+SRCS="tbl::https://github.com/ryanoasis/nerd-fonts/releases/download/v$VER/NerdFontsSymbolsOnly.zip"
+CHKSUMS="sha256::bc59c2ea74d022a6262ff9e372fde5c36cd5ae3f82a567941489ecfab4f03d66"
+CHKUPDATE="anitya::id=227412"


### PR DESCRIPTION
Topic Description
-----------------

- kitty: update to 0.36.2
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- kitty: 0.36.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit symbols-nerd-font kitty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
