### PR TITLE
 fcitx5-pinyin-moegirl: update to 20240909

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20240809
+VER=20240909
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::da348acc3823c6ecf4fc082a79fcb826b49c9aa33b4979c8b9994b324a80193d \
-         sha256::377676009901f9dcab91b6846e226fb12a4503f650dd7ca34619d5b97e54687a \
+CHKSUMS="sha256::f9ee1acc45876128771b2f576be63c13b7fbac003c6255a56ef6ef6bd90d5c22 \
+         sha256::19e9bd5be47e8d621900ec88755090464c62c50063436413f1c24c1e4b72f477 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: upgrade to 20240909

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20240909
- rime-pinyin-moegirl: 20240909

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
