### PR TITLE
libinput: use pre-upstream patch for tap-to-click default

### DIFF
--- a/runtime-devices/libinput/autobuild/patches/0001-fix-evdev-mt-touchpad-tap.c-enable-tap-to-click-by-d.patch
+++ b/runtime-devices/libinput/autobuild/patches/0001-fix-evdev-mt-touchpad-tap.c-enable-tap-to-click-by-d.patch
@@ -1,9 +1,21 @@
-From 33aa42d5a50f13dd8b48f1385a7de29aa9010c87 Mon Sep 17 00:00:00 2001
+From 8c50678f14d193b0f36ef85d083bc223d7200259 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Sep 2024 00:10:11 +0800
 Subject: [PATCH] fix(evdev-mt-touchpad-tap.c): enable tap-to-click by default
 
-Seriously, it's 2024... This is a partial revert of:
+As we know, most touchpads these days come with no buttons *and*, more
+importantly, decent palm rejection and tap zones/recognition. The original
+patch that disabled this default behavior was built on assumptions from
+2014 and may well be accurate, but it would seem a bit bizzare today to
+see a click-only default.
+
+KDE 6 has enabled this behaviour by default since a year ago.[^1] What's
+more, the GNOME folks have been wondering why they still needed to click
+their touchpads (some distributions enables tap-to-click by default but
+some others doesn't). A quick search would find us many users confused by
+this default behavior.
+
+This is a partial revert of:
 
   commit 2219c12c3aa45b80f235e761e87c17fb9ec70eae
   Author: Peter Hutterer <peter.hutterer@who-t.net>
@@ -23,18 +35,36 @@ Seriously, it's 2024... This is a partial revert of:
       enable it, or at least you can search for it.
 
     Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>
+
+[^1]: https://invent.kde.org/plasma/plasma-desktop/-/issues/97
+
 ---
- src/evdev-mt-touchpad-tap.c | 11 -----------
- 1 file changed, 11 deletions(-)
+
+Patch submitted but NOT accepted by the upstream:
+
+https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1047
+
+---
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/evdev-mt-touchpad-tap.c | 18 +-----------------
+ 1 file changed, 1 insertion(+), 17 deletions(-)
 
 diff --git a/src/evdev-mt-touchpad-tap.c b/src/evdev-mt-touchpad-tap.c
-index 299cd554..6e332275 100644
+index 299cd554..576d71d3 100644
 --- a/src/evdev-mt-touchpad-tap.c
 +++ b/src/evdev-mt-touchpad-tap.c
-@@ -1425,17 +1425,6 @@ tp_tap_default(struct evdev_device *evdev)
- 	 */
- 	if (!libevdev_has_event_code(evdev->evdev, EV_KEY, BTN_LEFT))
- 		return LIBINPUT_CONFIG_TAP_ENABLED;
+@@ -1419,23 +1419,7 @@ tp_tap_config_is_enabled(struct libinput_device *device)
+ static enum libinput_config_tap_state
+ tp_tap_default(struct evdev_device *evdev)
+ {
+-	/**
+-	 * If we don't have a left button we must have tapping enabled by
+-	 * default.
+-	 */
+-	if (!libevdev_has_event_code(evdev->evdev, EV_KEY, BTN_LEFT))
+-		return LIBINPUT_CONFIG_TAP_ENABLED;
 -
 -	/**
 -	 * Tapping is disabled by default for two reasons:
@@ -46,6 +76,7 @@ index 299cd554..6e332275 100644
 -	 *   it.
 -	 */
 -	return LIBINPUT_CONFIG_TAP_DISABLED;
++	return LIBINPUT_CONFIG_TAP_ENABLED;
  }
  
  static enum libinput_config_tap_state

--- a/runtime-devices/libinput/spec
+++ b/runtime-devices/libinput/spec
@@ -1,4 +1,5 @@
 VER=1.26.2
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/libinput/libinput"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5781"


### PR DESCRIPTION
Topic Description
-----------------

- libinput: use pre-upstream patch for tap-to-click default
    - Refresh patches at AOSC-Tracking/libinput @ aosc/1.26.2
    (HEAD: 7c0e33112ac7e95dbd94318e70624463a9ef5296).
    - The previous version relies on undefined behavior and may not be reliable.
    - Patch submitted but not accepted by the upstream.
    Ref: https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1047

Package(s) Affected
-------------------

- libinput: 1.26.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libinput
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
