### PR TITLE
select-language-gui: resurrect and update to 0.2.1

### DIFF
--- a/app-utils/select-language-gui/autobuild/defines
+++ b/app-utils/select-language-gui/autobuild/defines
@@ -1,0 +1,17 @@
+PKGNAME=select-language-gui
+PKGSEC=utils
+PKGDEP="gcc-runtime webkit2gtk"
+BUILDDEP="llvm rustc"
+PKGDES="A system language setting utility (graphical UI)"
+
+USECLANG=1
+
+# FIXME: ld.lld is not yet available.
+USECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1
+USECLANG__LOONGARCH64=0
+NOLTO__LOONGARCH64=1
+USECLANG__MIPS64R6EL=0
+NOLTO__MIPS64R6EL=1
+
+CARGO_AFTER="--features custom-protocol"

--- a/app-utils/select-language-gui/autobuild/prepare
+++ b/app-utils/select-language-gui/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Installing pre-built Web assets ..."
+cp -rv "$SRCDIR"/../../dist \
+    "$SRCDIR"/../dist

--- a/app-utils/select-language-gui/spec
+++ b/app-utils/select-language-gui/spec
@@ -1,0 +1,7 @@
+VER=0.2.1
+SRCS="git::commit=tags/v${VER/+/-}::https://github.com/AOSC-Dev/select-language-gui \
+      tbl::https://github.com/AOSC-Dev/select-language-gui/releases/download/v${VER/+/-}/dist.tar.xz"
+CHKSUMS="SKIP \
+         sha256::da84b609b7402228905238e040cad31d0864b901152a0316974d463d36cce13b"
+CHKUPDATE="anitya::id=371442"
+SUBDIR="select-language-gui/src-tauri"


### PR DESCRIPTION
Topic Description
-----------------

- select-language-gui: update to 0.2.1
    - We still need this for "Try AOSC OS."
    - This reverts commit 35213fc60557f1f453295ddc4e02569a9e706f84.

Package(s) Affected
-------------------

- select-language-gui: 0.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit select-language-gui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
