### PR TITLE
plasma-default-settings (AOSC OS Plasma Defaults): enable Konsole menu bar explicitly

### DIFF
--- a/runtime-data/plasma-default-settings/spec
+++ b/runtime-data/plasma-default-settings/spec
@@ -1,3 +1,3 @@
-VER=2024.09.0
+VER=2024.09.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-default-settings"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- plasma-default-settings: update to 2024.09.1
    Enable Konsole menu bar explicitly.

Package(s) Affected
-------------------

- plasma-default-settings: 1:2024.09.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit plasma-default-settings
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
