### PR TITLE
[FLIGHT] Mesa color corruption

### DIFF
--- a/runtime-display/mesa/autobuild/patches/0001-zink-reject-Imagination-proprietary-driver-w-o-geome.patch
+++ b/runtime-display/mesa/autobuild/patches/0001-zink-reject-Imagination-proprietary-driver-w-o-geome.patch
@@ -1,7 +1,7 @@
 From 33fa3c3fac46dd62910921afb7f3955a67e78815 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 20 Jul 2024 22:03:54 +0800
-Subject: [PATCH 1/3] zink: reject Imagination proprietary driver w/o
+Subject: [PATCH 1/4] zink: reject Imagination proprietary driver w/o
  geometryShader
 
 On some low-end GPUs (e.g. BXE/BXM series), the Imagination proprietary
@@ -35,5 +35,5 @@ index b00438583ee..b44b3db43dc 100644
        simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
        screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
 -- 
-2.46.0
+2.46.0.windows.1
 

--- a/runtime-display/mesa/autobuild/patches/0002-r600-disable-buggy-vc-1-hardware-decoding.patch
+++ b/runtime-display/mesa/autobuild/patches/0002-r600-disable-buggy-vc-1-hardware-decoding.patch
@@ -1,7 +1,7 @@
 From 14de61e0dadd762ea37d32a0f1c186357519a863 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
-Subject: [PATCH 2/3] r600: disable buggy vc-1 hardware decoding
+Subject: [PATCH 2/4] r600: disable buggy vc-1 hardware decoding
 
 ---
  src/gallium/drivers/r600/radeon_video.c | 2 +-
@@ -21,5 +21,5 @@ index 670e0aafb9e..6e5abd8d1a1 100644
  			return false;
  		case PIPE_VIDEO_FORMAT_JPEG:
 -- 
-2.46.0
+2.46.0.windows.1
 

--- a/runtime-display/mesa/autobuild/patches/0003-LOONGARCH64-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384.patch.loongarch64
+++ b/runtime-display/mesa/autobuild/patches/0003-LOONGARCH64-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384.patch.loongarch64
@@ -1,7 +1,7 @@
-From ecf259590daa37c1c41dfd30c39858b851483baf Mon Sep 17 00:00:00 2001
+From 422820bf7509f63f2ed743b855afa9393e7a4641 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
-Subject: [PATCH 3/3] fix(iris_bufmgr.c): set PAGE_SIZE as 16384
+Subject: [PATCH 3/4] [LOONGARCH64] fix(iris_bufmgr.c): set PAGE_SIZE as 16384
 
 Obviously not ideal, but this is simply meant as a preview/PoC.
 ---
@@ -22,5 +22,5 @@ index 0dde4b2e3d1..341dbf6b635 100644
  
  #define WARN_ONCE(cond, fmt...) do {                            \
 -- 
-2.46.0
+2.46.0.windows.1
 

--- a/runtime-display/mesa/autobuild/patches/0004-Revert-dri-Let-dril-handle-the-DRI-driver-link-farm.patch
+++ b/runtime-display/mesa/autobuild/patches/0004-Revert-dri-Let-dril-handle-the-DRI-driver-link-farm.patch
@@ -1,0 +1,279 @@
+From 5ee5577d0b55fde0588ec7e84d603184070deaa9 Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Wed, 11 Sep 2024 18:23:04 +0800
+Subject: [PATCH 4/4] Revert "dri: Let dril handle the DRI driver link farm"
+
+This reverts commit d709b42180e29519ce9eb119e99226299380a9b5.
+
+Ref: https://gitlab.freedesktop.org/mesa/mesa/-/issues/11839
+Ref: https://gitlab.freedesktop.org/mesa/mesa/-/issues/11840
+---
+ src/gallium/targets/dri/meson.build  | 92 +++++++++++++++++++++++++++-
+ src/gallium/targets/dril/meson.build | 89 ---------------------------
+ src/loader/loader.c                  | 49 +++++++++++++++
+ 3 files changed, 140 insertions(+), 90 deletions(-)
+
+diff --git a/src/gallium/targets/dri/meson.build b/src/gallium/targets/dri/meson.build
+index ad7302e74ac..9d1aab8c180 100644
+--- a/src/gallium/targets/dri/meson.build
++++ b/src/gallium/targets/dri/meson.build
+@@ -29,7 +29,7 @@ else
+ endif
+ 
+ libgallium_dri = shared_library(
+-  libgallium_name,
++  'gallium_dri',
+   files('dri_target.c'),
+   include_directories : [
+     inc_include, inc_src, inc_mapi, inc_mesa, inc_gallium, inc_gallium_aux, inc_util, inc_gallium_drivers,
+@@ -54,3 +54,93 @@ libgallium_dri = shared_library(
+   install : true,
+   name_suffix : 'so',
+ )
++
++foreach d : [[with_gallium_kmsro, [
++               'armada-drm_dri.so',
++               'exynos_dri.so',
++               'gm12u320_dri.so',
++               'hdlcd_dri.so',
++               'hx8357d_dri.so',
++               'ili9163_dri.so',
++               'ili9225_dri.so',
++               'ili9341_dri.so',
++               'ili9486_dri.so',
++               'imx-drm_dri.so',
++               'imx-dcss_dri.so',
++               'imx-lcdif_dri.so',
++               'ingenic-drm_dri.so',
++               'kirin_dri.so',
++               'komeda_dri.so',
++               'mali-dp_dri.so',
++               'mcde_dri.so',
++               'mediatek_dri.so',
++               'meson_dri.so',
++               'mi0283qt_dri.so',
++               'mxsfb-drm_dri.so',
++               'panel-mipi-dbi_dri.so',
++               'pl111_dri.so',
++               'rcar-du_dri.so',
++               'repaper_dri.so',
++               'rockchip_dri.so',
++               'rzg2l-du_dri.so',
++               'ssd130x_dri.so',
++               'st7586_dri.so',
++               'st7735r_dri.so',
++               'sti_dri.so',
++               'stm_dri.so',
++               'sun4i-drm_dri.so',
++               'udl_dri.so',
++               'vkms_dri.so',
++               'zynqmp-dpsub_dri.so',
++             ]],
++             [with_gallium_radeonsi, 'radeonsi_dri.so'],
++             [with_gallium_nouveau, 'nouveau_dri.so'],
++             [with_gallium_freedreno, ['msm_dri.so', 'kgsl_dri.so']],
++             [with_gallium_softpipe, 'swrast_dri.so'],
++             [with_gallium_softpipe and with_gallium_drisw_kms, 'kms_swrast_dri.so'],
++             [with_gallium_v3d, 'v3d_dri.so'],
++             [with_gallium_vc4, 'vc4_dri.so'],
++             [with_gallium_panfrost, ['panfrost_dri.so', 'panthor_dri.so']],
++             [with_gallium_etnaviv, 'etnaviv_dri.so'],
++             [with_gallium_tegra, 'tegra_dri.so'],
++             [with_gallium_crocus, 'crocus_dri.so'],
++             [with_gallium_iris, 'iris_dri.so'],
++             [with_gallium_i915, 'i915_dri.so'],
++             [with_gallium_r300, 'r300_dri.so'],
++             [with_gallium_r600, 'r600_dri.so'],
++             [with_gallium_svga, 'vmwgfx_dri.so'],
++             [with_gallium_virgl or
++               (with_gallium_freedreno and freedreno_kmds.contains('virtio')),
++               'virtio_gpu_dri.so'],
++             [with_gallium_lima, 'lima_dri.so'],
++             [with_gallium_zink, 'zink_dri.so'],
++             [with_gallium_d3d12, 'd3d12_dri.so'],
++             [with_gallium_asahi, 'asahi_dri.so']]
++  if d[0]
++    gallium_dri_drivers += d[1]
++  endif
++endforeach
++
++# This only works on Unix-like oses, which is probably fine for dri
++prog_ln = find_program('ln', required : false)
++if prog_ln.found()
++  devenv.set('LIBGL_DRIVERS_PATH', meson.current_build_dir())
++
++  foreach d : gallium_dri_drivers
++    custom_target(
++      'devenv_@0@'.format(d),
++      input : libgallium_dri,
++      output : d,
++      command : [prog_ln, '-f', '@INPUT@', '@OUTPUT@'],
++      build_by_default : true,
++    )
++  endforeach
++endif
++
++meson.add_install_script(
++  install_megadrivers_py.full_path(),
++  libgallium_dri.full_path(),
++  dri_drivers_path,
++  gallium_dri_drivers,
++  install_tag : 'runtime',
++)
+diff --git a/src/gallium/targets/dril/meson.build b/src/gallium/targets/dril/meson.build
+index 3adf97b24a7..b89fa32a61f 100644
+--- a/src/gallium/targets/dril/meson.build
++++ b/src/gallium/targets/dril/meson.build
+@@ -61,92 +61,3 @@ dril_dri = shared_library(
+   install_dir : dri_drivers_path,
+   name_suffix : 'so',
+ )
+-
+-foreach d : [[with_gallium_kmsro, [
+-               'armada-drm_dri.so',
+-               'exynos_dri.so',
+-               'gm12u320_dri.so',
+-               'hdlcd_dri.so',
+-               'hx8357d_dri.so',
+-               'ili9163_dri.so',
+-               'ili9225_dri.so',
+-               'ili9341_dri.so',
+-               'ili9486_dri.so',
+-               'imx-drm_dri.so',
+-               'imx-dcss_dri.so',
+-               'imx-lcdif_dri.so',
+-               'ingenic-drm_dri.so',
+-               'kirin_dri.so',
+-               'komeda_dri.so',
+-               'mali-dp_dri.so',
+-               'mcde_dri.so',
+-               'mediatek_dri.so',
+-               'meson_dri.so',
+-               'mi0283qt_dri.so',
+-               'mxsfb-drm_dri.so',
+-               'panel-mipi-dbi_dri.so',
+-               'pl111_dri.so',
+-               'rcar-du_dri.so',
+-               'repaper_dri.so',
+-               'rockchip_dri.so',
+-               'rzg2l-du_dri.so',
+-               'ssd130x_dri.so',
+-               'st7586_dri.so',
+-               'st7735r_dri.so',
+-               'sti_dri.so',
+-               'stm_dri.so',
+-               'sun4i-drm_dri.so',
+-               'udl_dri.so',
+-               'vkms_dri.so',
+-               'zynqmp-dpsub_dri.so',
+-             ]],
+-             [with_gallium_radeonsi, 'radeonsi_dri.so'],
+-             [with_gallium_nouveau, 'nouveau_dri.so'],
+-             [with_gallium_freedreno, ['msm_dri.so', 'kgsl_dri.so']],
+-             [with_gallium_swrast, 'swrast_dri.so'],
+-             [with_gallium_swrast and with_gallium_drisw_kms, 'kms_swrast_dri.so'],
+-             [with_gallium_v3d, 'v3d_dri.so'],
+-             [with_gallium_vc4, 'vc4_dri.so'],
+-             [with_gallium_panfrost, ['panfrost_dri.so', 'panthor_dri.so']],
+-             [with_gallium_etnaviv, 'etnaviv_dri.so'],
+-             [with_gallium_tegra, 'tegra_dri.so'],
+-             [with_gallium_crocus, 'crocus_dri.so'],
+-             [with_gallium_iris, 'iris_dri.so'],
+-             [with_gallium_i915, 'i915_dri.so'],
+-             [with_gallium_r300, 'r300_dri.so'],
+-             [with_gallium_r600, 'r600_dri.so'],
+-             [with_gallium_svga, 'vmwgfx_dri.so'],
+-             [with_gallium_virgl or
+-               (with_gallium_freedreno and freedreno_kmds.contains('virtio')),
+-               'virtio_gpu_dri.so'],
+-             [with_gallium_lima, 'lima_dri.so'],
+-             [with_gallium_d3d12, 'd3d12_dri.so'],
+-             [with_gallium_zink, 'zink_dri.so'],
+-             [with_gallium_asahi, 'asahi_dri.so']]
+-  if d[0]
+-    dril_drivers += d[1]
+-  endif
+-endforeach
+-
+-# This only works on Unix-like oses, which is probably fine for dri
+-prog_ln = find_program('ln', required : false)
+-if prog_ln.found()
+-  foreach d : dril_drivers
+-    custom_target(
+-      d,
+-      output : d,
+-      command : [prog_ln, '-sf', 'libdril_dri.so', '@OUTPUT@'],
+-      build_by_default : true,
+-    )
+-  endforeach
+-endif
+-
+-if dril_drivers.length() > 0
+-  meson.add_install_script(
+-    install_megadrivers_py.full_path(),
+-    dril_dri.full_path(),
+-    dri_drivers_path,
+-    dril_drivers,
+-    install_tag : 'runtime',
+-  )
+-endif
+diff --git a/src/loader/loader.c b/src/loader/loader.c
+index e9eb4d8b796..c8fdb1b1ecb 100644
+--- a/src/loader/loader.c
++++ b/src/loader/loader.c
+@@ -846,3 +846,52 @@ loader_open_driver_lib(const char *driver_name,
+ 
+    return driver;
+ }
++
++/**
++ * Opens a DRI driver using its driver name, returning the __DRIextension
++ * entrypoints.
++ *
++ * \param driverName - a name like "i965", "radeon", "nouveau", etc.
++ * \param out_driver - Address where the dlopen() return value will be stored.
++ * \param search_path_vars - NULL-terminated list of env vars that can be used
++ * to override the DEFAULT_DRIVER_DIR search path.
++ */
++const struct __DRIextensionRec **
++loader_open_driver(const char *driver_name,
++                   void **out_driver_handle,
++                   const char **search_path_vars,
++                   bool driver_name_is_inferred)
++{
++   char *get_extensions_name;
++   const struct __DRIextensionRec **extensions = NULL;
++   const struct __DRIextensionRec **(*get_extensions)(void);
++
++   void *driver = loader_open_driver_lib(driver_name, "_dri", search_path_vars,
++                                         DEFAULT_DRIVER_DIR, !driver_name_is_inferred);
++
++   if (!driver)
++      goto failed;
++
++   get_extensions_name = loader_get_extensions_name(driver_name);
++   if (get_extensions_name) {
++      get_extensions = dlsym(driver, get_extensions_name);
++      if (get_extensions) {
++         extensions = get_extensions();
++      } else {
++         log_(_LOADER_DEBUG, "MESA-LOADER: driver does not expose %s(): %s\n",
++              get_extensions_name, dlerror());
++      }
++      free(get_extensions_name);
++   }
++
++   if (extensions == NULL) {
++      log_(_LOADER_WARNING,
++           "MESA-LOADER: driver exports no extensions (%s)\n", dlerror());
++      dlclose(driver);
++      driver = NULL;
++   }
++
++failed:
++   *out_driver_handle = driver;
++   return extensions;
++}
+-- 
+2.46.0.windows.1
+

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,6 +1,8 @@
 UPSTREAM_VER=24.2.2
 DXHEADERS_VER=1.614.0
 VER=${UPSTREAM_VER}+dxheaders${DXHEADERS_VER}
+REL=1
+
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
 CHKSUMS="sha256::fd077d3104edbe459e2b8597d2757ec065f9bd2d620b8c0b9cc88c2bf9891d02 \


### PR DESCRIPTION
Topic Description
-----------------

- mesa: bisecting...

Package(s) Affected
-------------------

- mesa: 1:24.2.1+dxheaders1.614.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
