### PR TITLE
mesa: revert two DRI patches to prevent the usage of LLVMpipe on Hyper-V virtual machines

### DIFF
--- a/runtime-display/mesa/autobuild/patches/0001-zink-reject-Imagination-proprietary-driver-w-o-geome.patch
+++ b/runtime-display/mesa/autobuild/patches/0001-zink-reject-Imagination-proprietary-driver-w-o-geome.patch
@@ -1,7 +1,7 @@
 From 33fa3c3fac46dd62910921afb7f3955a67e78815 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 20 Jul 2024 22:03:54 +0800
-Subject: [PATCH 1/3] zink: reject Imagination proprietary driver w/o
+Subject: [PATCH 1/5] zink: reject Imagination proprietary driver w/o
  geometryShader
 
 On some low-end GPUs (e.g. BXE/BXM series), the Imagination proprietary
@@ -35,5 +35,5 @@ index b00438583ee..b44b3db43dc 100644
        simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
        screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
 -- 
-2.46.0
+2.46.0.windows.1
 

--- a/runtime-display/mesa/autobuild/patches/0002-r600-disable-buggy-vc-1-hardware-decoding.patch
+++ b/runtime-display/mesa/autobuild/patches/0002-r600-disable-buggy-vc-1-hardware-decoding.patch
@@ -1,7 +1,7 @@
 From 14de61e0dadd762ea37d32a0f1c186357519a863 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
-Subject: [PATCH 2/3] r600: disable buggy vc-1 hardware decoding
+Subject: [PATCH 2/5] r600: disable buggy vc-1 hardware decoding
 
 ---
  src/gallium/drivers/r600/radeon_video.c | 2 +-
@@ -21,5 +21,5 @@ index 670e0aafb9e..6e5abd8d1a1 100644
  			return false;
  		case PIPE_VIDEO_FORMAT_JPEG:
 -- 
-2.46.0
+2.46.0.windows.1
 

--- a/runtime-display/mesa/autobuild/patches/0003-LOONGARCH64-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384.patch.loongarch64
+++ b/runtime-display/mesa/autobuild/patches/0003-LOONGARCH64-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384.patch.loongarch64
@@ -1,7 +1,7 @@
-From ecf259590daa37c1c41dfd30c39858b851483baf Mon Sep 17 00:00:00 2001
+From a25fd75300e44368f5e68c4f6ef01cb66b997822 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
-Subject: [PATCH 3/3] fix(iris_bufmgr.c): set PAGE_SIZE as 16384
+Subject: [PATCH 3/5] [LOONGARCH64] fix(iris_bufmgr.c): set PAGE_SIZE as 16384
 
 Obviously not ideal, but this is simply meant as a preview/PoC.
 ---
@@ -22,5 +22,5 @@ index 0dde4b2e3d1..341dbf6b635 100644
  
  #define WARN_ONCE(cond, fmt...) do {                            \
 -- 
-2.46.0
+2.46.0.windows.1
 

--- a/runtime-display/mesa/autobuild/patches/0004-Revert-dril-also-create-double-buffered-configs-in-s.patch
+++ b/runtime-display/mesa/autobuild/patches/0004-Revert-dril-also-create-double-buffered-configs-in-s.patch
@@ -1,0 +1,40 @@
+From a1c324aae6e5722009d3a2b412b686fe0cdb795f Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Wed, 11 Sep 2024 19:30:18 +0800
+Subject: [PATCH 4/5] Revert "dril: also create double-buffered configs in
+ swrast fallback"
+
+This reverts commit 56ac37845487b62f495428b0f20d145489f621e2.
+
+Ref: https://gitlab.freedesktop.org/mesa/mesa/-/issues/11839
+Ref: https://gitlab.freedesktop.org/mesa/mesa/-/issues/11840
+---
+ src/gallium/targets/dril/dril_target.c | 11 ++---------
+ 1 file changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/src/gallium/targets/dril/dril_target.c b/src/gallium/targets/dril/dril_target.c
+index a94ab09858f..0caa3514dde 100644
+--- a/src/gallium/targets/dril/dril_target.c
++++ b/src/gallium/targets/dril/dril_target.c
+@@ -437,16 +437,9 @@ drilCreateNewScreen(int scrn, int fd,
+    const __DRIconfig **configs = init_dri2_configs(fd);
+    if (!configs && fd == -1) {
+       // otherwise set configs to point to our config list
+-      configs = calloc(ARRAY_SIZE(drilConfigs) * 2 + 1, sizeof(void *));
+-      int c = 0;
++      configs = calloc(ARRAY_SIZE(drilConfigs) + 1, sizeof(void *));
+       for (int i = 0; i < ARRAY_SIZE(drilConfigs); i++) {
+-         /* create normal config */
+-         configs[c++] = mem_dup(&drilConfigs[i], sizeof(drilConfigs[i]));
+-
+-         /* create double-buffered config */
+-         configs[c] = mem_dup(&drilConfigs[i], sizeof(drilConfigs[i]));
+-         struct gl_config *cfg = (void*)configs[c++];
+-         cfg->doubleBufferMode = 1;
++         configs[i] = mem_dup(&drilConfigs[i], sizeof(drilConfigs[i]));
+       }
+    }
+ 
+-- 
+2.46.0.windows.1
+

--- a/runtime-display/mesa/autobuild/patches/0005-Revert-dril-use-the-super-fallback-path-for-software.patch
+++ b/runtime-display/mesa/autobuild/patches/0005-Revert-dril-use-the-super-fallback-path-for-software.patch
@@ -1,0 +1,37 @@
+From b083cbcd280703b73f3f665f4e90622f426b4725 Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Wed, 11 Sep 2024 19:31:04 +0800
+Subject: [PATCH 5/5] Revert "dril: use the super fallback path for software
+ fallback"
+
+This reverts commit 06d417af80bc1f171cadc338e63a7aa75c877754.
+
+Ref: https://gitlab.freedesktop.org/mesa/mesa/-/issues/11839
+Ref: https://gitlab.freedesktop.org/mesa/mesa/-/issues/11840
+---
+ src/gallium/targets/dril/dril_target.c | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/src/gallium/targets/dril/dril_target.c b/src/gallium/targets/dril/dril_target.c
+index 0caa3514dde..b7a6ada5197 100644
+--- a/src/gallium/targets/dril/dril_target.c
++++ b/src/gallium/targets/dril/dril_target.c
+@@ -435,13 +435,8 @@ drilCreateNewScreen(int scrn, int fd,
+                     const __DRIconfig ***driver_configs, void *data)
+ {
+    const __DRIconfig **configs = init_dri2_configs(fd);
+-   if (!configs && fd == -1) {
+-      // otherwise set configs to point to our config list
+-      configs = calloc(ARRAY_SIZE(drilConfigs) + 1, sizeof(void *));
+-      for (int i = 0; i < ARRAY_SIZE(drilConfigs); i++) {
+-         configs[i] = mem_dup(&drilConfigs[i], sizeof(drilConfigs[i]));
+-      }
+-   }
++   if (!configs)
++      return NULL;
+ 
+    // outpointer it
+    *driver_configs = configs;
+-- 
+2.46.0.windows.1
+

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,8 +1,9 @@
 UPSTREAM_VER=24.2.2
-DXHEADERS_VER=1.614.0
+DXHEADERS_VER=1.614.1
 VER=${UPSTREAM_VER}+dxheaders${DXHEADERS_VER}
+
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
-      git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers"
+      git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
 CHKSUMS="sha256::fd077d3104edbe459e2b8597d2757ec065f9bd2d620b8c0b9cc88c2bf9891d02 \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: revert two DRI patches to prevent the usage of LLVMpipe on Hyper-V virtual machines
    - See <https://gitlab.freedesktop.org/mesa/mesa/-/issues/11839> and <https://gitlab.freedesktop.org/mesa/mesa/-/issues/11840> for details on the problem.
    - Track patches at https://github.com/AOSC-Tracking/mesa @ aosc/mesa-24.2.2, current HEAD is b083cbcd280703b73f3f665f4e90622f426b4725.
    - Update DirectX Headers to 1.614.1.

Package(s) Affected
-------------------

- mesa: 1:24.2.2+dxheaders1.614.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
