### PR TITLE
sway-audio-idle-inhibit: update to 0.1.2

### DIFF
--- a/app-utils/sway-audio-idle-inhibit/spec
+++ b/app-utils/sway-audio-idle-inhibit/spec
@@ -1,8 +1,4 @@
-VER=0.1.1+git20240820
-SRCS="git::commit=7a70ef14ced6cfe9c1aac6b3a5542a86d26004e8::https://github.com/ErikReider/SwayAudioIdleInhibit"
-
-# Use this for stable releases.
-#SRCS="git::commit=tags/v$VER::https://github.com/ErikReider/SwayAudioIdleInhibit"
-
+VER=0.1.2
+SRCS="git::commit=tags/v$VER::https://github.com/ErikReider/SwayAudioIdleInhibit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372107"


### PR DESCRIPTION
Topic Description
-----------------

- sway-audio-idle-inhibit: update to 0.1.2
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- sway-audio-idle-inhibit: 0.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit sway-audio-idle-inhibit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
