### PR TITLE
orca: drop autostart hack

### DIFF
--- a/desktop-gnome/orca/autobuild/patches/0001-Autostart-on-all-desktops.patch
+++ b/desktop-gnome/orca/autobuild/patches/0001-Autostart-on-all-desktops.patch
@@ -1,8 +1,0 @@
-diff -Naur orca-42.3/orca-autostart.desktop.in orca-42.3.desktop/orca-autostart.desktop.in
---- orca-42.3/orca-autostart.desktop.in	2021-02-19 14:39:17.000000000 +0000
-+++ orca-42.3.desktop/orca-autostart.desktop.in	2022-08-28 00:17:47.912484831 +0000
-@@ -6,4 +6,3 @@
- AutostartCondition=GSettings org.gnome.desktop.a11y.applications screen-reader-enabled
- X-GNOME-AutoRestart=true
- #X-GNOME-Autostart-Phase=Initialization
--OnlyShowIn=GNOME;MATE;Unity;Cinnamon;

--- a/desktop-gnome/orca/spec
+++ b/desktop-gnome/orca/spec
@@ -1,5 +1,5 @@
 VER=42.3
-REL=1
+REL=2
 SRCS="https://download.gnome.org/sources/orca/${VER%.*}/orca-$VER.tar.xz"
 CHKSUMS="sha256::fadcba0bfeae1e6672266264e76f63fe5abf8f0efb34be118b5a973fb6f2f724"
 CHKUPDATE="anitya::id=13156"


### PR DESCRIPTION
Topic Description
-----------------

- orca: drop autostart hack
    This hack may not be needed in the latest KDE release and causes unexpected
    autostart behavior inconsistent with the System Settings UI.

Package(s) Affected
-------------------

- orca: 42.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit orca
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
