### PR TITLE
iosevka-fonts: update to 31.6.1

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=31.6.0
+VER=31.6.1
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::b9c2ffb867ebc55b15b2f1c6dddee01aaebdd11a6e7cfcda05aba5dd2ffee56b \
-         sha256::8a4bd98134de0397ad89f5561dc24daedf4415322ada0b7472e1b361591a512d \
-         sha256::a2a7bf483da1108e9bc44f9ddd33c01b8ea5357debbc703356674db2bbbf17cd \
-         sha256::dbd51bc3e399573651e90bd6f376213447b7c8a33640d102962160af44265ce2 \
-         sha256::5812eb21de1b92f6c573a4d6b67871587a797aedea16409fd0fb89f985e5bb60 \
-         sha256::419f91717080eb9a8dec0270c0e575e74ad0ca32e23cb270d2985e411ec4b96e \
-         sha256::8574f92e8b9393680250b18bc1b9a874060f2bb7750b4a97e05a9691e52388b2 \
-         sha256::28337e83662a42cdd7a410aa63c5de1b337506763bd3ed97dbe81eeb15e4fef6 \
-         sha256::5677d24124577ea4ee08aa2c63939cac7e681f2d5b4fc6a4ad0f21ef108183ff \
-         sha256::4ccae93bed5db916088709fe448a1d1d3cbf49ef6cebf2274b88f01a8344e6c9 \
-         sha256::cceda761f5b6429a6bd4540fc9522efd8988767e720ec22fbd7c7ce7a2604464 \
-         sha256::f7ccb993650d61602adf655b35c4bc4fd9835ba71e312d7df589cbaae7ba11a2 \
-         sha256::22723aa1b8d28c54eb5a304216bc84e0cebe35af5699d872061c6eb403fc5b68 \
-         sha256::658a3526a03dcd7297b3aa1892b8f085d4428c2a9632f917dcc69f905e300e1e \
-         sha256::34056ddbd90c23e1c69c0bf5c18ef8708a4735c104bc7d125d5bd9aa8aaff9dc \
-         sha256::261f33ce1ae8516aa6cb979a14ae855850a7b0fd2c7db7986f1c58377adddadd \
-         sha256::4efa03ab78edecfd35935db7c91149a1c162e857ca678aef9bc5e9bfe83eaa87 \
-         sha256::e088a4fa1fa9d2135367fceb5e1d631bd28ee20035c009625bd108b615877fd7 \
-         sha256::c0c2acbf159441c349d074fafc7c2261dd313f9d8171415560eaf17d3cfd9872 \
-         sha256::365067944153890e1a8da42b070a1698503c21442af403bb8e1448e7f5bcadc6 \
-         sha256::bbc98b0415e1013720daed8f42eacf1f475d65c44b09b769106ad6713abd8341 \
-         sha256::96886e7bdf65a7d82fb068d840790f61d29b9a533752716cbaa3d279e6f85f7b \
-         sha256::69f31f1a307d920d417057788fb63fdb5aec6a8f845040228b23b69f212e0f0e \
-         sha256::a50a4bd8f1a6912334f1cc8faca9950d27a8871cc061ec3323e7297aef31e397 \
+CHKSUMS="sha256::6ba820a01f0dd5fe282f3132cb5474042a5a75cb21a876c0c4d96996bd8118ad \
+         sha256::785a6634e295e54fbe414426549f259fe4318dec33152d3e58ba760e6fad1c88 \
+         sha256::0815f9e43a99a2afc1305273ad4768ea2a6737f46402ddc1718ab30d8f5de506 \
+         sha256::b39658a3e15344de5e3879f9a4f8a27de404dc191ee7bfe0f06068bef09bacda \
+         sha256::83ea67d19f29c56c7bb7d10e0d6b426bffde08eccbf2aebfe83fb00f812a25e3 \
+         sha256::36ff34e8fd2240f3bac047c84794d0076eb4d00afe4dd5664536662fdcbca8ea \
+         sha256::0afec43faa51c0c0f7bc7c97904b05b196cf0d9c33fa51877b119d2076bf29cb \
+         sha256::f0dc895af9404f02cafc69b056ddefe05d7d0af00292ea3e23eceb6875a9b19c \
+         sha256::5fb86614e4150db297a9f38686ec736ed8794ebee7a2dc925e31c2e7c508a4e7 \
+         sha256::981e8dad8d9787549a76705f9553323ec2ad1b2a681672039ec75e57b1a70843 \
+         sha256::e7afea72a9d7aef462441a551465e9253bb3bd7336faad994ed46f24fff882de \
+         sha256::3adbcc808483db0529ec9eb880adf0ac49172b4c0d10cf381320a8b2afcd590a \
+         sha256::3c5d988b796e8a875505440734bcc154d80865b4bb39a520a31462821419efb3 \
+         sha256::fa35fae5c32aba851cb876158160233414fadf18b84cb2f294780366b99fc07e \
+         sha256::a16749cf82f65a3ac7fe0d7efd9a7a78b12c35991fadff0835cade8937ff86b2 \
+         sha256::ae2d8da469f72e3792d867068386fe11c9dc6662fcb3cfe45c9b5cf0f041715c \
+         sha256::ad4259e5f8130ebc1046f8ca78cdfabee7d30626044b85afb3cb1df423afe9a4 \
+         sha256::ebfe475d659b323cd8636de39e4e38750a4b60284d23c5991cc93e3d00ee86f6 \
+         sha256::c8cc5b3e48edbb1036798a96300aece00519ae8608fbe4de8ad3487161e18d23 \
+         sha256::87a7dfb6170808d146a661982ec4913adada072987a36f83e1f50e652945401a \
+         sha256::a24c12dc4664c7fbc8c629f91e4d50ab337c46f0abffbd26832ce36c435657d9 \
+         sha256::f7fd3a095c41cc98fef6c22ef3e8b14d05287ce71260ce4ce1c4028cb094ecae \
+         sha256::a247408bacce63f3adf76cc41dc22254e41fdf78026d6ba2e4d69c7407209d5f \
+         sha256::300c1e6098105b6b205d9d7b658704a720b5d218a05a6b5b6866de11198d01b2 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 31.6.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 31.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
