### PR TITLE
guitarix: new, 0.44.1

### DIFF
--- a/app-multimedia/guitarix/autobuild/defines
+++ b/app-multimedia/guitarix/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=guitarix
+PKGDES="A virtual guitar amplifier running on JACK"
+PKGSEC=sound
+PKGDEP="ladspa-sdk gtk-3 gtkmm-3 glib libsigc++ zita-resampler libsndfile jack boost lilv liblrdf fftw liblo avahi bluez"
+BUILDDEP="sassc eigen-3 intltool"
+
+ABTYPE=waf
+
+WAF_AFTER="--includeconvolver --no-faust"
+
+# The software hardcodes -fno-lto somewhere in its build configuration
+NOLTO=1

--- a/app-multimedia/guitarix/autobuild/patches/0001-FEDORA-guitarix-cstdint-include.patch
+++ b/app-multimedia/guitarix/autobuild/patches/0001-FEDORA-guitarix-cstdint-include.patch
@@ -1,0 +1,13 @@
+diff --git a/src/LV2/DSP/gx_common.h b/trunk/src/LV2/DSP/gx_common.h
+index 71108442..132a6839 100644
+--- a/src/LV2/DSP/gx_common.h
++++ b/src/LV2/DSP/gx_common.h
+@@ -22,7 +22,7 @@
+ #ifndef SRC_HEADERS_GX_COMMON_H_
+ #define SRC_HEADERS_GX_COMMON_H_
+ 
+-
++#include <cstdint>
+ #include <cstdlib>
+ #include <cmath>
+ #include <iostream>

--- a/app-multimedia/guitarix/autobuild/patches/0002-FEDORA-guitarix-mismatched-delete.patch
+++ b/app-multimedia/guitarix/autobuild/patches/0002-FEDORA-guitarix-mismatched-delete.patch
@@ -1,0 +1,20 @@
+diff --git a/src/gx_head/engine/gx_resampler.cpp b/trunk/src/gx_head/engine/gx_resampler.cpp
+index 38eaaec7..adbba7cc 100644
+--- a/src/gx_head/engine/gx_resampler.cpp
++++ b/src/gx_head/engine/gx_resampler.cpp
+@@ -121,13 +121,13 @@ float *BufferResampler::process(int fs_inp, int ilen, float *input, int fs_outp,
+     inp_data = input;
+ 	float *p = out_data = new float[out_count];
+ 	if (Resampler::process() != 0) {
+-		delete p;
++		delete[] p;
+ 		return 0;
+ 	}
+ 	inp_data = 0;
+ 	inp_count = k/2;
+ 	if (Resampler::process() != 0) {
+-		delete p;
++		delete[] p;
+ 		return 0;
+ 	}
+ 	assert(inp_count == 0);

--- a/app-multimedia/guitarix/autobuild/patches/0003-FEDORA-guitarix-python-3.11-ftbfs.patch
+++ b/app-multimedia/guitarix/autobuild/patches/0003-FEDORA-guitarix-python-3.11-ftbfs.patch
@@ -1,0 +1,13 @@
+diff --git a/wscript b/trunk/wscript
+index b915199a..f3e4d129 100644
+--- a/wscript
++++ b/wscript
+@@ -534,7 +534,7 @@ def sub_file(task):
+     dst_fname = task.outputs[0].abspath()
+     lst = task.generator.sub_list
+ 
+-    with open(src_fname, 'rU') as f:
++    with open(src_fname, 'r') as f:
+         txt = f.read()
+     for (key, val) in lst:
+         re_pat = re.compile(key, re.M)

--- a/app-multimedia/guitarix/autobuild/prepare
+++ b/app-multimedia/guitarix/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Overrideing WAF_DEF to remove configdir option ..."
+WAF_DEF=("--prefix=$PREFIX" "--libdir=$LIBDIR")

--- a/app-multimedia/guitarix/spec
+++ b/app-multimedia/guitarix/spec
@@ -1,0 +1,4 @@
+VER=0.44.1
+SRCS="tbl::https://sourceforge.net/projects/guitarix/files/guitarix/guitarix2-${VER}.tar.xz"
+CHKSUMS="sha256::77e83d754f51ac38c5423f38eeb55de5b3e26128e60b511b02d2defcf36e6c18"
+CHKUPDATE="anitya::id=10599"


### PR DESCRIPTION
Topic Description
-----------------

- guitarix: new, 0.44.1
    - 3 patches are taken from Fedora to fix FTBFS.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- guitarix: 0.44.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit guitarix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
