### PR TITLE
DeployKit Survey (Sept. 12, 2024)

### DIFF
--- a/app-admin/deploykit-backend/autobuild/defines
+++ b/app-admin/deploykit-backend/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME="deploykit-backend"
 PKGDES="Backend service for AOSC OS Installer (DeployKit)"
 PKGDEP="gcc-runtime glibc libcap lvm2 openssl parted systemd \
-        util-linux-runtime zlib"
+        util-linux-runtime zlib squashfs-tools"
 BUILDDEP="llvm rustc"
 PKGSEC="admin"
 

--- a/app-admin/deploykit-backend/spec
+++ b/app-admin/deploykit-backend/spec
@@ -1,4 +1,5 @@
 VER=0.6.6
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-backend/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371972"

--- a/app-admin/dkcli/spec
+++ b/app-admin/dkcli/spec
@@ -1,4 +1,4 @@
-VER=0.3.3
+VER=0.4.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/dkcli"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373533"


### PR DESCRIPTION
Topic Description
-----------------

- dkcli: update to 0.4.0
- deploykit-backend: add squashfs-tools dep

Package(s) Affected
-------------------

- deploykit-backend: 0.6.6-1
- dkcli: 0.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-backend dkcli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
