### PR TITLE
mate-settings-daemon: enable tap-to-click by default for touchpads

### DIFF
--- a/desktop-mate/mate-settings-daemon/autobuild/patches/0001-feat-gschema-enable-tap-to-click-on-touchpads-by-def.patch
+++ b/desktop-mate/mate-settings-daemon/autobuild/patches/0001-feat-gschema-enable-tap-to-click-on-touchpads-by-def.patch
@@ -1,0 +1,25 @@
+From c58a08a03699a12c5530b99127e2d77c62686422 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 13 Sep 2024 00:12:24 +0800
+Subject: [PATCH] feat(gschema): enable tap-to-click on touchpads by default
+
+---
+ data/org.mate.peripherals-touchpad.gschema.xml.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/org.mate.peripherals-touchpad.gschema.xml.in b/data/org.mate.peripherals-touchpad.gschema.xml.in
+index 2755174..2e5c067 100644
+--- a/data/org.mate.peripherals-touchpad.gschema.xml.in
++++ b/data/org.mate.peripherals-touchpad.gschema.xml.in
+@@ -16,7 +16,7 @@
+       <description>Set this to TRUE if you have problems with accidentally hitting the touchpad while typing.</description>
+     </key>
+     <key name="tap-to-click" type="b">
+-      <default>false</default>
++      <default>true</default>
+       <summary>Enable mouse clicks with touchpad</summary>
+       <description>Set this to TRUE to be able to send mouse clicks by tapping on the touchpad.</description>
+     </key>
+-- 
+2.46.0
+

--- a/desktop-mate/mate-settings-daemon/spec
+++ b/desktop-mate/mate-settings-daemon/spec
@@ -1,4 +1,5 @@
 VER=1.28.0
+REL=1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-settings-daemon-$VER.tar.xz"
 CHKSUMS="sha256::4ed7cdadaaa4c99efffc0282b8411703bb76e072c41c4b57989f8c5b40611a3a"
 CHKUPDATE="anitya::id=230625"


### PR DESCRIPTION
Topic Description
-----------------

- mate-settings-daemon: enable tap-to-click by default for touchpads

Package(s) Affected
-------------------

- mate-settings-daemon: 1.28.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mate-settings-daemon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
