### PR TITLE
ncmpc: update to 0.50

### DIFF
--- a/app-multimedia/ncmpc/autobuild/beyond
+++ b/app-multimedia/ncmpc/autobuild/beyond
@@ -1,4 +1,0 @@
-abinfo "Installing lyrics provider scripts ..."
-for i in lyrics/*; do
-    install -Dvm755 "$i" "$PKGDIR/usr/share/ncmpc/$i"
-done

--- a/app-multimedia/ncmpc/autobuild/defines
+++ b/app-multimedia/ncmpc/autobuild/defines
@@ -1,5 +1,9 @@
 PKGNAME=ncmpc
 PKGSEC=sound
-PKGDEP="ncurses libmpdclient lirc boost"
+PKGDEP="ncurses libmpdclient lirc boost fmt pcre"
 BUILDDEP="sphinx"
 PKGDES="Fully featured MPD client using ncurses"
+
+ABTYPE=meson
+MESON_AFTER="-Dlyrics_screen=true \
+             -Dchat_screen=true"

--- a/app-multimedia/ncmpc/spec
+++ b/app-multimedia/ncmpc/spec
@@ -1,4 +1,4 @@
-VER=0.49
+VER=0.50
 SRCS="https://www.musicpd.org/download/ncmpc/${VER%.*}/ncmpc-${VER}.tar.xz"
-CHKSUMS="sha256::65bbec0ede9e6bcf62ac647b0c706485beb2bdd5db70ca8d60103f32f162cf29"
+CHKSUMS="sha256::4f860f91a11090a72d580ff68b117e76a2b212be5e46cc4b986a08a1aaf4d597"
 CHKUPDATE="anitya::id=2055"


### PR DESCRIPTION
Topic Description
-----------------

- ncmpc: update to 0.50
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- ncmpc: 0.50

Security Update?
----------------

No

Build Order
-----------

```
#buildit ncmpc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
