### PR TITLE
openssh: update revoke instructions and restart daemon on revoke

### DIFF
--- a/app-network/openssh/autobuild/postinst
+++ b/app-network/openssh/autobuild/postinst
@@ -37,6 +37,10 @@ _match_all_fingerprints() {
 	return 1
 }
 
+# No need to reload daemon unless the host keys were refreshed (due to
+# accidental leaks, etc.).
+_host_key_refreshed=0
+
 if \
 	_match_all_keys || \
 	_match_all_fingerprints; then
@@ -55,10 +59,13 @@ if \
 		/etc/ssh/ssh_host_rsa_key \
 		/etc/ssh/ssh_host_rsa_key.pub
 	/usr/bin/ssh-keygen -A
+
+	_host_key_refreshed=1
 fi
 
 echo -e "Checking whether systemd units need to be reload..."
-if [[ $(systemctl show sshd --property=NeedDaemonReload | cut -d= -f2) == "yes" ]]; then
+if [[ $(systemctl show sshd --property=NeedDaemonReload | cut -d= -f2) == "yes" || \
+      "$_host_key_refreshed" = "1" ]]; then
 	echo "Reloading systemd units ..."
 	systemctl daemon-reload
 	echo "Restarting sshd service ..."

--- a/app-network/openssh/autobuild/templates
+++ b/app-network/openssh/autobuild/templates
@@ -1,23 +1,14 @@
 Template: openssh/leaked_keys_20240913
 Type: note
 Description: WARNING - POSSIBLY LEAKED OPENSSH HOST KEYS
- AOSC OS has detected leaked SSH host key(s) on your system, which should be
- considered vulnerable and untrusted. These keys may have shipped with
- previously published AOSC OS installation media, system images, and tarballs.
+ AOSC OS has detected leaked SSH host key(s) on your system, which should be considered vulnerable and untrusted. These keys may have shipped with previously published AOSC OS installation media, system images, and tarballs.
  .
- This update will remove all SSH host keys from your system and replace them
- with newly generated ones.
+ This update will remove all SSH host keys from your system and replace them with newly generated ones.
  .
- There is no need to restart your SSH daemon after this operation. However, in
- case you are running AOSC OS on a server, you would need to inform your
- SSH/SCP/SFTP users regarding possible SSH errors and should remove the
- previous key records from their trust store.
+ Note: AOSC OS will restart your SSH daemon after this update. However, this will not affect currently active SSH connections. In case you are running AOSC OS on a server, you would need to inform your SSH/SCP/SFTP users regarding possible SSH errors and should remove the previous key records from their trust store.
 Description-zh_CN.UTF-8: 警告 - 系统可能包含已泄漏的 OpenSSH 主机密钥
- AOSC OS 在您的系统中发现了遭意外泄漏的 SSH 主机密钥，这些密钥不可信且可能带来
- 潜在安全风险。这些密钥是随先前发布的 AOSC OS 安装盘、系统镜像和系统包泄漏的。
+ AOSC OS 在您的系统中发现了遭意外泄漏的 SSH 主机密钥，这些密钥不可信且可能带来潜在安全风险。这些密钥是随先前发布的 AOSC OS 安装盘、系统镜像和系统包泄漏的。
  .
  本更新将删除在您系统上的所有 SSH 主机密钥并重新生成替代密钥。
  .
- 更新完成后无需重启 SSH 服务守护程序，但如果您对外提供 SSH 服务，您的用户在连接
- 该设备上运行的 SSH/SCP/SFTP 服务时可能会遇到连接错误。因此，您可能需要将有关
- 情况告知您的用户，并引导他们删除先前信任的 SSH 主机密钥记录。
+ 请注意：更新完成后，AOSC OS 将重启 SSH 服务守护程序，但不会影响当前已经建立的 SSH 连接。如果您对外提供 SSH 服务，您的用户在连接该设备上运行的 SSH/SCP/SFTP 服务时可能会遇到连接错误。因此，您可能需要将有关情况告知您的用户，并引导其删除先前信任的 SSH 主机密钥记录。

--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -1,5 +1,5 @@
 VER=9.8p1
-REL=4
+REL=5
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
 CHKSUMS="sha256::dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3"
 CHKUPDATE="anitya::id=2565"


### PR DESCRIPTION
Topic Description
-----------------

- openssh: update revoke instructions; restart daemon on revoke

Package(s) Affected
-------------------

- openssh: 9.8p1-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
