### PR TITLE
vscode: update to 1.93.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,9 +1,8 @@
-VER=1.92.2
-REL=2
+VER=1.93.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::5cad830451bb8369f30c2b8bf5a1037425c7b4dd277ed10d8fdbe227397eea40"
-CHKSUMS__ARM64="sha256::e2e9f9e0681c612b8901d0371cb31e7a8b1a914750e8ad841792518d1defb3a3"
+CHKSUMS__AMD64="sha256::29a9431daea5307cf9a22f6a95cbbe328f48ace6bda126457e1171390dc84aed"
+CHKSUMS__ARM64="sha256::7d84b3954018102ca9154c74fc5c4bd8129206eebdd0d5b1adb564917eded1fd"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.93.1
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- vscode: 1.93.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
