### PR TITLE
vscodium: update to 1.93.1.24256

### DIFF
--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.92.2.24228
+VER=1.93.1.24256
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.93.1.24256
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- vscodium: 1.93.1.24256

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
