### PR TITLE
zed: update to 0.152.3

### DIFF
--- a/app-editors/zed/autobuild/patches/0001-cargo-use-default-release-build-settings.patch
+++ b/app-editors/zed/autobuild/patches/0001-cargo-use-default-release-build-settings.patch
@@ -1,17 +1,17 @@
-From 56d9598e80c20eb5b8190c040910a00880311f33 Mon Sep 17 00:00:00 2001
+From a173ec83f2d1704003502f84fbd392415356ed8a Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 15 Jul 2024 15:50:05 +0800
-Subject: [PATCH 2/2] cargo: use default --release build settings
+Subject: [PATCH] cargo: use default --release build settings
 
 ---
- Cargo.toml | 13 -------------
- 1 file changed, 13 deletions(-)
+ Cargo.toml | 14 --------------
+ 1 file changed, 14 deletions(-)
 
 diff --git a/Cargo.toml b/Cargo.toml
-index 2e8b947aa..9fddd588e 100644
+index f2f08506a1..743fc49c23 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -480,19 +480,6 @@ ttf-parser = { opt-level = 3 }
+@@ -536,20 +536,6 @@ ttf-parser = { opt-level = 3 }
  wasmtime-cranelift = { opt-level = 3 }
  wasmtime = { opt-level = 3 }
  
@@ -25,6 +25,7 @@ index 2e8b947aa..9fddd588e 100644
 -
 -[profile.release-fast]
 -inherits = "release"
+-debug = "full"
 -lto = false
 -codegen-units = 16
 -
@@ -32,5 +33,5 @@ index 2e8b947aa..9fddd588e 100644
  dbg_macro = "deny"
  todo = "deny"
 -- 
-2.45.2
+2.46.0
 

--- a/app-editors/zed/spec
+++ b/app-editors/zed/spec
@@ -1,4 +1,4 @@
-VER=0.150.4
+VER=0.152.3
 SRCS="git::commit=v$VER::https://github.com/zed-industries/zed"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373275"


### PR DESCRIPTION
Topic Description
-----------------

- zed: update to 0.152.3
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- zed: 0.152.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit zed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
