### PR TITLE
openssh: guard against empty invalid or empty keys

### DIFF
--- a/app-network/openssh/autobuild/postinst
+++ b/app-network/openssh/autobuild/postinst
@@ -2,6 +2,10 @@ _match_key() {
 	[ -e "/etc/ssh/$1" ] || return 1
 	local _key_sha1
 	_key_sha1="$(sha1sum "/etc/ssh/$1" | cut -d ' ' -f 1)"
+	# Guard against empty or invalid keys - empty greps would return 0.
+	if [ -z "$_key_sha1" ]; then
+		return 1
+	fi
 	grep -q "$_key_sha1" "/usr/share/doc/openssh/revoked-keys/aosa-2017-0034/$1"
 }
 
@@ -22,6 +26,10 @@ _match_fingerprint() {
 	[ -e "/etc/ssh/$1" ] || return 1
 	local _key_fingerprint
 	_key_fingerprint="$(ssh-keygen -l -E sha256 -f "/etc/ssh/$1" | cut -d' ' -f 2)"
+	# Guard against empty or invalid keys - empty greps would return 0.
+	if [ -z "$_key_fingerprint" ]; then
+		return 1
+	fi
 	grep -q "$_key_fingerprint" \
 		"/usr/share/doc/openssh/revoked-keys/revoked_hosts"
 }

--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -1,5 +1,5 @@
 VER=9.8p1
-REL=5
+REL=6
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
 CHKSUMS="sha256::dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3"
 CHKUPDATE="anitya::id=2565"


### PR DESCRIPTION
Topic Description
-----------------

- openssh: guard against empty invalid or empty keys
    Old systems with /etc/ssh/sshd_host_dsa_key{,.pub} would trigger re-generation
    unconditionally. This is a bug - these keys were no longer recognised by
    ssh-keygen, but it would return an empty output (as opposed to any sort of
    error message) in stdin, giving $_key_fingerprint an empty value.
    This empty value would then return a true value as it was grep'd against the
    revoked lists, causing the postinst script to think that the system contained
    a vulnerable key when it really didn't.
    Check for empty values to prevent this.

Package(s) Affected
-------------------

- openssh: 9.8p1-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
