### PR TITLE
[FLIGHT] curl: 8.10.0 breaks git promisor remote

### DIFF
--- a/app-web/curl/autobuild/build
+++ b/app-web/curl/autobuild/build
@@ -1,3 +1,6 @@
+abinfo "Updating generated configuration files ..."
+autoreconf -fi
+
 abinfo "Configuring cURL (OpenSSL, with versioned symbols) ..."
 "$SRCDIR"/configure \
      ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER[@]} ${AUTOTOOLS_TARGET[@]} \

--- a/app-web/curl/spec
+++ b/app-web/curl/spec
@@ -1,4 +1,5 @@
-VER=8.10.0
-SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
-CHKSUMS="sha256::e6b142f0e85e954759d37e26a3627e2278137595be80e3a860c4353e4335e5a0"
+VER=8.9.1
+REL=4
+SRCS="git::commit=344ba8c883acf4ba5e824e8ef2f6dcb6fe00b27f::https://github.com/curl/curl.git"
+CHKSUMS="sha256::SKIP"
 CHKUPDATE="anitya::id=381"


### PR DESCRIPTION
Topic Description
-----------------

- curl: bisecting...

Package(s) Affected
-------------------

- curl: 8.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit curl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
