### PR TITLE
nginx: update to 1.27.1

### DIFF
--- a/app-web/nginx/spec
+++ b/app-web/nginx/spec
@@ -1,4 +1,4 @@
-VER=1.27.0
+VER=1.27.1
 SRCS="tbl::https://nginx.org/download/nginx-$VER.tar.gz"
-CHKSUMS="sha256::b7230e3cf87eaa2d4b0bc56aadc920a960c7873b9991a1b66ffcc08fc650129c"
+CHKSUMS="sha256::bd7ba68a6ce1ea3768b771c7e2ab4955a59fb1b1ae8d554fedb6c2304104bdfc"
 CHKUPDATE="anitya::id=5413"


### PR DESCRIPTION
Topic Description
-----------------

- nginx: update to 1.27.1
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- nginx: 1.27.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nginx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
