### PR TITLE
gnupg: update to 2.5.1

### DIFF
--- a/app-cryptography/gnupg/autobuild/defines
+++ b/app-cryptography/gnupg/autobuild/defines
@@ -27,7 +27,6 @@ AUTOTOOLS_AFTER="--enable-gpgsm \
                  --enable-doc \
                  --enable-gpgtar \
                  --enable-wks-tools \
-                 --disable-gpg-is-gpg2 \
                  --disable-selinux-support \
                  --enable-large-secmem \
                  --enable-trust-models \

--- a/app-cryptography/gnupg/autobuild/patches/0001-Debian-avoid-beta-warning.patch
+++ b/app-cryptography/gnupg/autobuild/patches/0001-Debian-avoid-beta-warning.patch
@@ -19,19 +19,19 @@ See discussion at:
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/autogen.sh b/autogen.sh
-index b238550..9b86d3f 100755
+index 9f91297..7ea7bff 100755
 --- a/autogen.sh
 +++ b/autogen.sh
-@@ -229,7 +229,7 @@ if [ "$myhost" = "find-version" ]; then
-     esac
+@@ -244,7 +244,7 @@ if [ "$myhost" = "find-version" ]; then
+     fi
  
      beta=no
 -    if [ -e .git ]; then
 +    if false; then
        ingit=yes
        tmp=$(git describe --match "${matchstr1}" --long 2>/dev/null)
-       tmp=$(echo "$tmp" | sed s/^"$package"//)
-@@ -245,8 +245,8 @@ if [ "$myhost" = "find-version" ]; then
+       if [ -n "$tmp" ]; then
+@@ -270,8 +270,8 @@ if [ "$myhost" = "find-version" ]; then
        rvd=$((0x$(echo ${rev} | dd bs=1 count=4 2>/dev/null)))
      else
        ingit=no
@@ -39,6 +39,6 @@ index b238550..9b86d3f 100755
 -      tmp="-unknown"
 +      beta=no
 +      tmp=""
+       cid="0000000"
        rev="0000000"
        rvd="0"
-     fi

--- a/app-cryptography/gnupg/spec
+++ b/app-cryptography/gnupg/spec
@@ -1,4 +1,4 @@
-VER=2.4.5
+VER=2.5.1
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-$VER.tar.bz2"
-CHKSUMS="sha256::f68f7d75d06cb1635c336d34d844af97436c3f64ea14bcb7c869782f96f44277"
+CHKSUMS="sha256::8a34bb318499867962c939e156666ada93ed81f01926590ac68f3ff79178375e"
 CHKUPDATE="anitya::id=1215"

--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,5 +1,5 @@
 VER=24.2.3.2
-REL=3
+REL=4
 SRCS="tbl::https://download.documentfoundation.org/libreoffice/src/${VER:0:6}/libreoffice-$VER.tar.xz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz \

--- a/app-utils/dar/spec
+++ b/app-utils/dar/spec
@@ -1,5 +1,5 @@
 VER=2.7.15
-REL=2
+REL=3
 SRCS="tbl::https://sourceforge.net/projects/dar/files/dar/$VER/dar-$VER.tar.gz"
 CHKSUMS="sha256::fac56b59b78b5435ee19541ff4bd3dc329c8252ff78749ffea240f6421534bfe"
 CHKUPDATE="anitya::id=389"

--- a/app-utils/pinentry/spec
+++ b/app-utils/pinentry/spec
@@ -1,5 +1,5 @@
 VER=1.1.0
-REL=8
+REL=9
 SRCS="tbl::https://gnupg.org/ftp/gcrypt/pinentry/pinentry-$VER.tar.bz2"
 CHKSUMS="sha256::68076686fa724a290ea49cdf0d1c0c1500907d1b759a3bcbfbec0293e8f56570"
 CHKUPDATE="anitya::id=3643"

--- a/desktop-gnome/gmime-3/spec
+++ b/desktop-gnome/gmime-3/spec
@@ -2,4 +2,4 @@ VER=3.2.7
 SRCS="https://download.gnome.org/sources/gmime/${VER:0:3}/gmime-$VER.tar.xz"
 CHKSUMS="sha256::2aea96647a468ba2160a64e17c6dc6afe674ed9ac86070624a3f584c10737d44"
 CHKUPDATE="anitya::id=13124"
-REL=1
+REL=2

--- a/desktop-kde/kleopatra/spec
+++ b/desktop-kde/kleopatra/spec
@@ -1,4 +1,5 @@
 VER=23.08.5
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kleopatra-$VER.tar.xz"
 CHKSUMS="sha256::a9c416599ed3763148fe8305d220b5950043b3c7ae12ffd2a960196c65dbf1a6"
 CHKUPDATE="anitya::id=8763"

--- a/runtime-admin/volume-key/spec
+++ b/runtime-admin/volume-key/spec
@@ -1,4 +1,5 @@
 VER=0.3.12
+REL=1
 SRCS="git::commit=fa9ea913b1886d041de2de5b10efd577bdb229f7::https://pagure.io/volume_key.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15970"

--- a/runtime-common/libassuan/autobuild/defines
+++ b/runtime-common/libassuan/autobuild/defines
@@ -5,6 +5,8 @@ PKGDEP="libgpg-error"
 PKGREP="libassusan"
 
 PKGPROV="libassusan"
-PKGBREAK="gnupg<=2.1.9"
+PKGBREAK="dar<=2.7.15-2 gmime-3<=3.2.7-1 gnupg<=1:2.4.5 gpgme<=1.23.2 \
+          kleopatra<=23.08.5 libreoffice<=24.2.3.2-3 pinentry<=1.1.0-8 \
+          volume-key<=0.3.12"
 
 ABSHADOW=no

--- a/runtime-common/libassuan/spec
+++ b/runtime-common/libassuan/spec
@@ -1,5 +1,4 @@
-VER=2.5.3
-REL=1
+VER=3.0.1
 SRCS="tbl::https://gnupg.org/ftp/gcrypt/libassuan/libassuan-$VER.tar.bz2"
-CHKSUMS="sha256::91bcb0403866b4e7c4bc1cc52ed4c364a9b5414b3994f718c70303f7f765e702"
+CHKSUMS="sha256::c8f0f42e6103dea4b1a6a483cb556654e97302c7465308f58363778f95f194b1"
 CHKUPDATE="anitya::id=1559"

--- a/runtime-cryptography/gpgme/autobuild/patches/0001-FROM-AOSC-remove-unknown-suffix.patch
+++ b/runtime-cryptography/gpgme/autobuild/patches/0001-FROM-AOSC-remove-unknown-suffix.patch
@@ -1,0 +1,28 @@
+From 01f05b4cbb1b0f7f400ecf7d889f3d1ec68dc007 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Fri, 23 Aug 2024 17:06:41 +0800
+Subject: [PATCH] FROM AOSC: remove -unknown suffix
+
+Git tags are not available in AOSC's build environment, and -unknown suffix leads to python "packaging" module's error.
+---
+ autogen.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index 4e1665b98d4a..a55326dc873f 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -269,7 +269,7 @@ if [ "$myhost" = "find-version" ]; then
+     else
+       ingit=no
+       beta=yes
+-      tmp="-unknown"
++      tmp=""
+       rev="0000000"
+       rvd="0"
+     fi
+
+base-commit: 1a26db717575068f0ab0d00a437ae870a93e1bb8
+-- 
+2.46.0
+

--- a/runtime-cryptography/gpgme/spec
+++ b/runtime-cryptography/gpgme/spec
@@ -1,4 +1,5 @@
 VER=1.23.2
+REL=1
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-$VER.tar.bz2"
 CHKSUMS="sha256::9499e8b1f33cccb6815527a1bc16049d35a6198a6c5fae0185f2bd561bce5224"
 CHKUPDATE="anitya::id=1239"


### PR DESCRIPTION
Topic Description
-----------------

- gpgme: fix packaging error
    - Picked from python-3-3.12.5 branch, commit 7c64a4467f5c4d898103aa039a41a87cc5350819
- gnupg: update to 2.5.1
    - Update to 2.5.1
    - Patches are picked from https://salsa.debian.org/debian/gnupg2/-/commit/b543a5458065b49b42c9168e5eae182b12ec456b
    - Removed --disable-gpg-is-gpg2 option, see upstream rG2125f228d36c
- volume-key: bump REL due to libassuan update to 3.0.1
- pinentry: bump REL due to libassuan update to 3.0.1
- libreoffice: bump REL due to libassuan update to 3.0.1
- kleopatra: bump REL due to libassuan update to 3.0.1
- gpgme: bump REL due to libassuan update to 3.0.1
- gmime-3: bump REL due to libassuan update to 3.0.1
- dar: bump REL due to libassuan update to 3.0.1
- libassuan: update to 3.0.1

Package(s) Affected
-------------------

- dar: 2.7.15-3
- gmime-3: 3.2.7-2
- gnupg: 1:2.5.1
- gpgme: 1.23.2-1
- kleopatra: 23.08.5-1
- libassuan: 3.0.1
- libreoffice: 24.2.3.2-4
- pinentry: 1.1.0-9
- volume-key: 0.3.12-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libassuan:-pkgbreak gnupg gpgme dar gmime-3 kleopatra libreoffice pinentry volume-key libassuan
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
