### PR TITLE
DeployKit Survey (20240915)

### DIFF
--- a/app-admin/deploykit-gui/spec
+++ b/app-admin/deploykit-gui/spec
@@ -1,7 +1,7 @@
-VER=0.8.2
+VER=0.8.3
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-gui \
       tbl::https://github.com/AOSC-Dev/deploykit-gui/releases/download/v$VER/dist.tar.xz"
 CHKSUMS="SKIP \
-         sha256::1ab2c9dd2b20a1ea5ca3635a44a19524bcb12139c3b1872cac6bcec25cdacd05"
+         sha256::f18c8643c66f67c80d5c4ec43066a663f2f1caef75cd860530d2454ceb220bc0"
 SUBDIR="deploykit-gui/src-tauri"
 CHKUPDATE="anitya::id=371971"

--- a/app-admin/dkcli/spec
+++ b/app-admin/dkcli/spec
@@ -1,4 +1,4 @@
-VER=0.4.1
+VER=0.4.2
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/dkcli"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373533"


### PR DESCRIPTION
Topic Description
-----------------

- dkcli: update to 0.4.2
- deploykit-gui: update to 0.8.3

Package(s) Affected
-------------------

- deploykit-gui: 0.8.3
- dkcli: 0.4.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-gui dkcli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
