### PR TITLE
php: update to 8.3.11

### DIFF
--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,5 +1,4 @@
-VER=8.3.8
-REL=2
+VER=8.3.11
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::aea358b56186f943c2bbd350c9005b9359133d47e954cfc561385319ae5bb8d7"
+CHKSUMS="sha256::b862b098a08ab9bf4b36ed12c7d0d9f65353656b36fb0e3c5344093aceb35802"
 CHKUPDATE="anitya::id=3627"


### PR DESCRIPTION
Topic Description
-----------------

- php: update to 8.3.11
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- php: 1:8.3.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
