### PR TITLE
rosegarden: update to 24.06

### DIFF
--- a/app-creativity/rosegarden/autobuild/defines
+++ b/app-creativity/rosegarden/autobuild/defines
@@ -1,9 +1,11 @@
 PKGNAME=rosegarden
 PKGSEC=sound
-PKGDEP="dssi dssi fftw liblo liblrdf lirc perl qt-5 flac"
-PKGDEP__AMD64="${PKGDEP} dssi-vst"
-BUILDDEP="cmake imake"
+PKGDEP="dssi fftw liblo liblrdf lirc qt-5 libsndfile libsamplerate jack lilv ladspa-sdk gtk-2"
+PKGRECOM__AMD64="dssi-vst"
+BUILDDEP="cmake"
 PKGDES="A music composition and editing environment"
 
 AB_FLAGS_O3=1
-NOLTO__LOONGSON3=1
+
+ABTYPE=cmakeninja
+CMAKE_AFTER="-DUSE_QT6=OFF"

--- a/app-creativity/rosegarden/spec
+++ b/app-creativity/rosegarden/spec
@@ -1,5 +1,4 @@
-VER=20.12
-REL=3
-SRCS="tbl::https://downloads.sourceforge.net/project/rosegarden/rosegarden/$VER/rosegarden-${VER}.tar.bz2"
-CHKSUMS="sha256::886684afc5858a9578234d1f845188db130114f7fbf38208c4d5ecda15131c5b"
+VER=24.06
+SRCS="tbl::https://downloads.sourceforge.net/project/rosegarden/rosegarden/$VER/rosegarden-${VER}.tar.xz"
+CHKSUMS="sha256::866cd4297c128a68208edd28a37808f278f630219533fff32441ad6647e09c27"
 CHKUPDATE="anitya::id=8939"


### PR DESCRIPTION
Topic Description
-----------------

- rosegarden: updated to 24.06
    - Added new dependencies (for audio file I/O and LADSPA/LV2 plugins).
    - Explicitly set ABTYPE and declared USE_QT6 to OFF.
    - Lowered dssi-vst to RECOM because this package contains only loadable
    plugin wrappers.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- rosegarden: 24.06

Security Update?
----------------

No

Build Order
-----------

```
#buildit rosegarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
