### PR TITLE
waybar: update to 0.11.0

### DIFF
--- a/app-utils/waybar/autobuild/patches/0001-fix-tray-revert-ustring-formatting-changes.patch
+++ b/app-utils/waybar/autobuild/patches/0001-fix-tray-revert-ustring-formatting-changes.patch
@@ -1,0 +1,85 @@
+From 5796db51d1520d453083071fcc3ef9b0ea9b2d34 Mon Sep 17 00:00:00 2001
+From: Aleksei Bavshin <alebastr89@gmail.com>
+Date: Sat, 14 Sep 2024 07:37:37 -0700
+Subject: [PATCH 1/2] fix(tray): revert ustring formatting changes
+
+This reverts commit a4d31ab10d1630cb9104c695d7b777ca12468904.
+---
+ src/modules/sni/item.cpp | 23 +++++++++--------------
+ 1 file changed, 9 insertions(+), 14 deletions(-)
+
+diff --git a/src/modules/sni/item.cpp b/src/modules/sni/item.cpp
+index 8afb39fb..6c4ec8c0 100644
+--- a/src/modules/sni/item.cpp
++++ b/src/modules/sni/item.cpp
+@@ -104,11 +104,9 @@ void Item::proxyReady(Glib::RefPtr<Gio::AsyncResult>& result) {
+     this->updateImage();
+ 
+   } catch (const Glib::Error& err) {
+-    spdlog::error("Failed to create DBus Proxy for {} {}: {}", bus_name, object_path,
+-                  std::string(err.what()));
++    spdlog::error("Failed to create DBus Proxy for {} {}: {}", bus_name, object_path, err.what());
+   } catch (const std::exception& err) {
+-    spdlog::error("Failed to create DBus Proxy for {} {}: {}", bus_name, object_path,
+-                  std::string(err.what()));
++    spdlog::error("Failed to create DBus Proxy for {} {}: {}", bus_name, object_path, err.what());
+   }
+ }
+ 
+@@ -126,15 +124,14 @@ ToolTip get_variant<ToolTip>(const Glib::VariantBase& value) {
+   result.text = get_variant<Glib::ustring>(container.get_child(2));
+   auto description = get_variant<Glib::ustring>(container.get_child(3));
+   if (!description.empty()) {
+-    result.text = fmt::format("<b>{}</b>\n{}", std::string(result.text), std::string(description));
++    result.text = fmt::format("<b>{}</b>\n{}", result.text, description);
+   }
+   return result;
+ }
+ 
+ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
+   try {
+-    spdlog::trace("Set tray item property: {}.{} = {}", id.empty() ? bus_name : id,
+-                  std::string(name), get_variant<std::string>(value));
++    spdlog::trace("Set tray item property: {}.{} = {}", id.empty() ? bus_name : id, name, value);
+ 
+     if (name == "Category") {
+       category = get_variant<std::string>(value);
+@@ -179,12 +176,10 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
+     }
+   } catch (const Glib::Error& err) {
+     spdlog::warn("Failed to set tray item property: {}.{}, value = {}, err = {}",
+-                 id.empty() ? bus_name : id, std::string(name), get_variant<std::string>(value),
+-                 std::string(err.what()));
++                 id.empty() ? bus_name : id, name, value, err.what());
+   } catch (const std::exception& err) {
+     spdlog::warn("Failed to set tray item property: {}.{}, value = {}, err = {}",
+-                 id.empty() ? bus_name : id, std::string(name), get_variant<std::string>(value),
+-                 std::string(err.what()));
++                 id.empty() ? bus_name : id, name, value, err.what());
+   }
+ }
+ 
+@@ -226,9 +221,9 @@ void Item::processUpdatedProperties(Glib::RefPtr<Gio::AsyncResult>& _result) {
+ 
+     this->updateImage();
+   } catch (const Glib::Error& err) {
+-    spdlog::warn("Failed to update properties: {}", std::string(err.what()));
++    spdlog::warn("Failed to update properties: {}", err.what());
+   } catch (const std::exception& err) {
+-    spdlog::warn("Failed to update properties: {}", std::string(err.what()));
++    spdlog::warn("Failed to update properties: {}", err.what());
+   }
+   update_pending_.clear();
+ }
+@@ -250,7 +245,7 @@ static const std::map<std::string_view, std::set<std::string_view>> signal2props
+ 
+ void Item::onSignal(const Glib::ustring& sender_name, const Glib::ustring& signal_name,
+                     const Glib::VariantContainerBase& arguments) {
+-  spdlog::trace("Tray item '{}' got signal {}", id, std::string(signal_name));
++  spdlog::trace("Tray item '{}' got signal {}", id, signal_name);
+   auto changed = signal2props.find(signal_name.raw());
+   if (changed != signal2props.end()) {
+     if (update_pending_.empty()) {
+-- 
+2.46.0
+

--- a/app-utils/waybar/autobuild/patches/0002-chore-update-fmt-wrap-to-11.0.2.patch
+++ b/app-utils/waybar/autobuild/patches/0002-chore-update-fmt-wrap-to-11.0.2.patch
@@ -1,0 +1,39 @@
+From 41bfea0be78a212c3086aaab2953a5c5781cccc1 Mon Sep 17 00:00:00 2001
+From: Aleksei Bavshin <alebastr89@gmail.com>
+Date: Sat, 14 Sep 2024 07:36:23 -0700
+Subject: [PATCH 2/2] chore: update fmt wrap to 11.0.2
+
+---
+ subprojects/fmt.wrap | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/subprojects/fmt.wrap b/subprojects/fmt.wrap
+index 42b61596..fd508477 100644
+--- a/subprojects/fmt.wrap
++++ b/subprojects/fmt.wrap
+@@ -1,13 +1,13 @@
+ [wrap-file]
+-directory = fmt-11.0.1
+-source_url = https://github.com/fmtlib/fmt/archive/11.0.1.tar.gz
+-source_filename = fmt-11.0.1.tar.gz
+-source_hash = 7d009f7f89ac84c0a83f79ed602463d092fbf66763766a907c97fd02b100f5e9
+-patch_filename = fmt_11.0.1-1_patch.zip
+-patch_url = https://wrapdb.mesonbuild.com/v2/fmt_11.0.1-1/get_patch
+-patch_hash = 0a8b93d1ee6d84a82d3872a9bfb4c3977d8a53f7f484d42d1f7ed63ed496d549
+-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fmt_11.0.1-1/fmt-11.0.1.tar.gz
+-wrapdb_version = 11.0.1-1
++directory = fmt-11.0.2
++source_url = https://github.com/fmtlib/fmt/archive/11.0.2.tar.gz
++source_filename = fmt-11.0.2.tar.gz
++source_hash = 6cb1e6d37bdcb756dbbe59be438790db409cdb4868c66e888d5df9f13f7c027f
++patch_filename = fmt_11.0.2-1_patch.zip
++patch_url = https://wrapdb.mesonbuild.com/v2/fmt_11.0.2-1/get_patch
++patch_hash = 90c9e3b8e8f29713d40ca949f6f93ad115d78d7fb921064112bc6179e6427c5e
++source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fmt_11.0.2-1/fmt-11.0.2.tar.gz
++wrapdb_version = 11.0.2-1
+ 
+ [provide]
+ fmt = fmt_dep
+-- 
+2.46.0
+

--- a/app-utils/waybar/spec
+++ b/app-utils/waybar/spec
@@ -1,4 +1,4 @@
-VER=0.10.4
+VER=0.11.0
 SRCS="git::commit=tags/$VER::https://github.com/Alexays/Waybar"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21287"


### PR DESCRIPTION
Topic Description
-----------------

- waybar: update to 0.11.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- waybar: 0.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit waybar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
