### PR TITLE
Fix apparently wrong sysctl.d options in issue #8020

### DIFF
--- a/core-misc/aosc-aaa/autobuild/overrides/etc/sysctl.d/00-kernel.conf
+++ b/core-misc/aosc-aaa/autobuild/overrides/etc/sysctl.d/00-kernel.conf
@@ -23,6 +23,3 @@ kernel.kptr_restrict = 2
 
 # NULL pointer dereference, lowest virtual address which process can use for mapping
 vm.mmap_min_addr = 4096
-
-# Allow more PIDs
-kernel.pid_max = 65536

--- a/core-misc/aosc-aaa/autobuild/overrides/etc/sysctl.d/02-net.conf
+++ b/core-misc/aosc-aaa/autobuild/overrides/etc/sysctl.d/02-net.conf
@@ -4,7 +4,6 @@
 
 # reuse/recycle time-wait sockets
 net.ipv4.tcp_tw_reuse = 1
-net.ipv4.tcp_tw_recycle = 1
 
 #### ipv4 networking and equivalent ipv6 parameters ####
 
@@ -22,7 +21,6 @@ net.ipv4.tcp_rfc1337 = 1
 ## will do source validation of the packet's recieved from all the interfaces on the machine
 ## protects from attackers that are using ip spoofing methods to do harm
 net.ipv4.conf.all.rp_filter = 1
-net.ipv6.conf.all.rp_filter = 1
 
 ## tcp timestamps
 ## + protect against wrapping sequence numbers (at gigabit speeds)


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Fix apparently wrong sysctl.d options.

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
aosc-aaa

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------
-->

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

<!--
```
pkg1 pkg2 pkg3 ...
```
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
