### PR TITLE
git: update to 2.46.1

### DIFF
--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,5 +1,4 @@
-VER=2.46.0
-REL=1
+VER=2.46.1
 SRCS="https://www.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
-CHKSUMS="sha256::b138811e16838f669a2516e40f09d50500e1c7fc541b5ab50ce84b98585e5230"
+CHKSUMS="sha256::b0a4d1ad50e820edd84c0d1b609c29349d4ae2681ed458914ea759aafcd4bf21"
 CHKUPDATE="anitya::id=5350"


### PR DESCRIPTION
Topic Description
-----------------

- git: update to 2.46.1

Package(s) Affected
-------------------

- git: 2.46.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
