### PR TITLE
qsynth: update to 1.0.1

### DIFF
--- a/app-multimedia/qsynth/autobuild/defines
+++ b/app-multimedia/qsynth/autobuild/defines
@@ -1,8 +1,6 @@
 PKGNAME=qsynth
 PKGSEC=sound
-PKGDEP="fluidsynth qt-5"
+PKGDEP="fluidsynth qt-5 pipewire"
 PKGDES="Qt5 frontend for fluidsynth"
 
-ABSHADOW=0
-
-AUTOTOOLS_AFTER="--enable-debug"
+ABTYPE=cmakeninja

--- a/app-multimedia/qsynth/spec
+++ b/app-multimedia/qsynth/spec
@@ -1,5 +1,4 @@
-VER=0.5.6
+VER=1.0.1
 SRCS="tbl::https://downloads.sourceforge.net/qsynth/qsynth-${VER}.tar.gz"
-CHKSUMS="sha256::a6eb404778fad87bb37fa1fb4caf1d80f24a324f9c3a22b669df2f8c94849040"
-REL=4
+CHKSUMS="sha256::0c498240c0e498ae6f034e682e6bda3f4e179e3f19694dcf8d4f3d9cd4ac8f18"
 CHKUPDATE="anitya::id=4135"


### PR DESCRIPTION
Topic Description
-----------------

- qsynth: update to 1.0.1
    - Added pipewire dependency because this package gets aware of it.
    - Add explicit ABTYPE as cmakeninja and drop out-of-date AUTOTTOOLS_AFTER.
    - Dropped no-longer-needed ABSHADOW=0.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- qsynth: 1.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qsynth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
