### PR TITLE
intel-compute-runtime: update to 24.35.30872.22

### DIFF
--- a/app-devel/intel-graphics-compiler/spec
+++ b/app-devel/intel-graphics-compiler/spec
@@ -1,8 +1,8 @@
-VER=1.0.17384.11
+VER=1.0.17537.20
 LLVM_VER=15.0.7
 OPENCL_CLANG_VER=15.0.0
 SPIRV_LLVM_TRANSLATOR_VER=15.0.3
-VS_INTRINSICS_VER=0.19.0
+VS_INTRINSICS_VER=0.20.0
 SPIRV_TOOLS_VER=1.3.290.0
 
 SRCS="git::commit=tags/igc-$VER;copy-repo=true::https://github.com/intel/intel-graphics-compiler.git \

--- a/runtime-common/level-zero/spec
+++ b/runtime-common/level-zero/spec
@@ -1,4 +1,4 @@
-VER=1.17.39
+VER=1.17.42
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/oneapi-src/level-zero"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229539"

--- a/runtime-devices/intel-gmmlib/spec
+++ b/runtime-devices/intel-gmmlib/spec
@@ -1,4 +1,4 @@
-VER=22.5.1
+VER=22.5.2
 SRCS="git::commit=tags/intel-gmmlib-$VER;copy-repo=true::https://github.com/intel/gmmlib"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20342"

--- a/runtime-scientific/intel-compute-runtime/spec
+++ b/runtime-scientific/intel-compute-runtime/spec
@@ -1,4 +1,4 @@
-VER=24.31.30508.7
+VER=24.35.30872.22
 SRCS="git::commit=tags/$VER::https://github.com/intel/compute-runtime.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229527"


### PR DESCRIPTION
Topic Description
-----------------

- intel-compute-runtime: update to 24.35.30872.22
- intel-graphics-compiler: update to 1.0.17537.20
- intel-gmmlib: update to 22.5.2
- level-zero: update to 1.17.42

Package(s) Affected
-------------------

- intel-compute-runtime: 24.35.30872.22
- intel-gmmlib: 22.5.2
- intel-graphics-compiler: 1.0.17537.20
- level-zero: 1.17.42

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-gmmlib level-zero intel-graphics-compiler intel-compute-runtime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
