### PR TITLE
Use Pipewire as the default JACK implementation

### DIFF
--- a/app-multimedia/pipewire-jack/autobuild/defines
+++ b/app-multimedia/pipewire-jack/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=pipewire-jack
+PKGDES="Enable Pipewire as the default JACK implementation"
+PKGSEC=sound
+PKGDEP="pipewire"
+PKGRECOM="wireplumber"
+
+ABTYPE=dummy
+ABHOST=noarch

--- a/app-multimedia/pipewire-jack/autobuild/overrides/etc/ld.so.conf.d/pipewire-jack.conf
+++ b/app-multimedia/pipewire-jack/autobuild/overrides/etc/ld.so.conf.d/pipewire-jack.conf
@@ -1,0 +1,1 @@
+/usr/lib/pipewire-0.3/jack

--- a/app-multimedia/pipewire-jack/spec
+++ b/app-multimedia/pipewire-jack/spec
@@ -1,0 +1,2 @@
+VER=0
+DUMMYSRC=1

--- a/app-multimedia/pipewire/autobuild/defines
+++ b/app-multimedia/pipewire/autobuild/defines
@@ -5,6 +5,7 @@ PKGDEP="alsa-lib bluez dbus ffmpeg gstreamer-1-0 gst-plugins-base-1-0 \
         libcanberra libfdk-aac libldac libfreeaptx libsndfile libusb libva \
         lilv ncurses readline rtkit sbc systemd v4l-utils vulkan \
         webrtc-audio-processing libcamera wireplumber"
+PKGRECOM="pipewire-jack"
 
 BUILDDEP="avahi doxygen docutils graphviz meson ninja pulseaudio sdl2 sphinx"
 

--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,4 +1,5 @@
 VER=1.2.3
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/pipewire"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57357"


### PR DESCRIPTION
Topic Description
-----------------

- pipewire: recommend pipewire-jack
    Pipewire is designed to be the one-for-all solution for audio server,
    and provides a set of drop-in-compatible JACK libraries to use it as
    JACK server.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- pipewire-jack: add a package to use Pipewire as JACK
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- pipewire: 1.2.3-1
- pipewire-jack: 0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pipewire-jack pipewire
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
