### PR TITLE
iptraf: (no build) add missing checksum

### DIFF
--- a/app-network/iptraf-ng/spec
+++ b/app-network/iptraf-ng/spec
@@ -1,3 +1,4 @@
 VER=1.1.4
 SRCS="tbl::https://fedorahosted.org/releases/i/p/iptraf-ng/iptraf-ng-$VER.tar.gz"
+CHKSUMS="sha256::d0a5572f4e113a40f720146f68981442d4578b829fcc68c0ba621030e2ddf39b"
 CHKUPDATE="anitya::id=7034"


### PR DESCRIPTION
Topic Description
-----------------

- iptraf-ng: (no build) add checksum

Package(s) Affected
-------------------

- iptraf-ng: 1.1.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit iptraf-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
