### PR TITLE
qpwgraph: update to 0.7.8

### DIFF
--- a/app-multimedia/qpwgraph/spec
+++ b/app-multimedia/qpwgraph/spec
@@ -1,4 +1,4 @@
-VER=0.7.7
+VER=0.7.8
 SRCS="git::commit=tags/v${VER}::https://gitlab.freedesktop.org/rncbc/qpwgraph.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242723"


### PR DESCRIPTION
Topic Description
-----------------

- qpwgraph: update to 0.7.8
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- qpwgraph: 0.7.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit qpwgraph
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
