### PR TITLE
pyqt6-webengine: new, 6.7.0

### DIFF
--- a/lang-python/pyqt6-webengine/autobuild/build
+++ b/lang-python/pyqt6-webengine/autobuild/build
@@ -1,0 +1,24 @@
+abinfo "Stashing compiler and linker flags to renamed variables to prevent recursion in Makefile ..."
+export ABCFLAGS="${CPPFLAGS} ${CFLAGS}"
+export ABCXXFLAGS="${CPPFLAGS} ${CXXFLAGS}"
+export ABLDFLAGS="${LDFLAGS}"
+
+abinfo "Configuring PyQt6-WebEngine ..."
+sip-build \
+    --no-make \
+    --qmake /usr/bin/qmake-qt6 \
+    --api-dir /usr/share/qt/qsci/api/python \
+    --qmake-setting 'QMAKE_CFLAGS += "${ABCFLAGS}"' \
+    --qmake-setting 'QMAKE_CXXFLAGS += "${ABCXXFLAGS}"' \
+    --qmake-setting 'QMAKE_LFLAGS += "${ABLDFLAGS}"' \
+    --verbose
+
+(
+    cd "$SRCDIR"/build
+
+    abinfo "Building PyQt6-WebEngine ..."
+    make
+
+    abinfo "Installing PyQt6-WebEngine ..."
+    make install -j1 DESTDIR="$PKGDIR" INSTALL_ROOT="$PKGDIR"
+)

--- a/lang-python/pyqt6-webengine/autobuild/defines
+++ b/lang-python/pyqt6-webengine/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=pyqt6-webengine
+PKGSEC=python
+PKGDEP="pyqt6"
+BUILDDEP="pyqt-builder"
+PKGDES="Python bindings for Qt6WebEngine"
+
+NOPYTHON2=1
+
+# Note: Limit to architectures with Qt6WebEngine support.
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/lang-python/pyqt6-webengine/spec
+++ b/lang-python/pyqt6-webengine/spec
@@ -1,0 +1,4 @@
+VER=6.7.0
+SRCS="tbl::https://pypi.python.org/packages/source/P/PyQt6-WebEngine/PyQt6_WebEngine-$VER.tar.gz"
+CHKSUMS="sha256::68edc7adb6d9e275f5de956881e79cca0d71fad439abeaa10d823bff5ac55001"
+CHKUPDATE="anitya::id=258848"


### PR DESCRIPTION
Topic Description
-----------------

- pyqt6-webengine: new, 6.7.0

Package(s) Affected
-------------------

- pyqt6-webengine: 6.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyqt6-webengine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
