### PR TITLE
alsa-plugins: disable maemo plugins (to fix audacity startup issue)

### DIFF
--- a/runtime-multimedia/alsa-plugins/autobuild/defines
+++ b/runtime-multimedia/alsa-plugins/autobuild/defines
@@ -21,8 +21,8 @@ AUTOTOOLS_AFTER="--disable-oss \
                  --enable-jack \
                  --enable-pulseaudio \
                  --enable-samplerate \
-                 --enable-maemo-plugin \
-                 --enable-maemo-resource-manager \
+                 --disable-maemo-plugin \
+                 --disable-maemo-resource-manager \
                  --enable-libav \
                  --enable-a52 \
                  --enable-lavrate \

--- a/runtime-multimedia/alsa-plugins/spec
+++ b/runtime-multimedia/alsa-plugins/spec
@@ -1,4 +1,5 @@
 VER=1.2.12
+REL=1
 SRCS="tbl::https://www.alsa-project.org/files/pub/plugins/alsa-plugins-$VER.tar.bz2"
 CHKSUMS="sha256::7bd8a83d304e8e2d86a25895d8dcb0ef0245a8df32e271959cdbdc6af39b66f2"
 CHKUPDATE="anitya::id=41"


### PR DESCRIPTION
Topic Description
-----------------

- alsa-plugins: disable maemo plugins
    We do not have the runtime daemons packaged for these plugins, and the
    daemons are even not available for Maemo Leste (I doubt whether these
    are open source at all). In addition, the plugins are badly implemented
    that it will easily crash when the expected criteria is not met, which
    will get triggered when PortAudio tries to scan all audio devices.
    Disable these plugins to fix (at least) Audacity startup.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- alsa-plugins: 1.2.12-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit alsa-plugins
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
