### PR TITLE
pyside6 (PySide for Qt 6.x): new, 6.7.3

### DIFF
--- a/lang-python/pyside6/autobuild/beyond
+++ b/lang-python/pyside6/autobuild/beyond
@@ -1,0 +1,9 @@
+abinfo "Generating egg_info ..."
+python3 setup.py egg_info
+
+abinfo "Installing Python Egg-info files ..."
+for name in PySide6 shiboken6 shiboken6_generator; do
+  install -dv "$PKGDIR/usr/lib/python${ABPY3VER}/$name-${PKGVER}-py${ABPY3VER}.egg-info"
+  cp -pv $name.egg-info/{PKG-INFO,not-zip-safe,top_level.txt} \
+        "$PKGDIR/usr/lib/python${ABPY3VER}/$name-${PKGVER}-py${ABPY3VER}.egg-info"/
+done

--- a/lang-python/pyside6/autobuild/defines
+++ b/lang-python/pyside6/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=pyside2
+PKGSEC=libs
+PKGDEP="qt-6 python-3 llvm"
+BUILDDEP="sphinx"
+PKGDES="Python bindings for the Qt 6 cross-platform application and UI framework"
+
+PKGPROV="shiboken6"
+
+# FIXME: race condition if ABTYPE=cmakeninja
+ABTYPE=cmake
+
+CMAKE_AFTER="-DUSE_PYTHON_VERSION=3 \
+             -DBUILD_TESTS=OFF \
+             -DNO_QT_TOOLS=yes"

--- a/lang-python/pyside6/autobuild/patches/0001-Arch-Linux-fix-qtexampleicons-CMakeLists.txt-fix-mis.patch
+++ b/lang-python/pyside6/autobuild/patches/0001-Arch-Linux-fix-qtexampleicons-CMakeLists.txt-fix-mis.patch
@@ -1,0 +1,27 @@
+From 64d240c0da3326e0bd5bb8d6adca00e43f65e8db Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.xyz>
+Date: Mon, 23 Sep 2024 16:08:46 +0800
+Subject: [PATCH] [Arch Linux] fix(qtexampleicons/CMakeLists.txt): fix missing
+ Python path definitions
+
+---
+ sources/pyside6/qtexampleicons/CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/sources/pyside6/qtexampleicons/CMakeLists.txt b/sources/pyside6/qtexampleicons/CMakeLists.txt
+index 1562f7b27..58ecc7c17 100644
+--- a/sources/pyside6/qtexampleicons/CMakeLists.txt
++++ b/sources/pyside6/qtexampleicons/CMakeLists.txt
+@@ -32,6 +32,9 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+     target_compile_definitions(QtExampleIcons PRIVATE "-DNDEBUG")
+ endif()
+ 
++get_property(SHIBOKEN_PYTHON_LIBRARIES GLOBAL PROPERTY shiboken_python_libraries)
++get_property(SHIBOKEN_PYTHON_INCLUDE_DIRS GLOBAL PROPERTY shiboken_python_include_dirs)
++
+ target_include_directories(QtExampleIcons PRIVATE ${SHIBOKEN_PYTHON_INCLUDE_DIRS})
+ 
+ get_property(SHIBOKEN_PYTHON_LIBRARIES GLOBAL PROPERTY shiboken_python_libraries)
+-- 
+2.46.1
+

--- a/lang-python/pyside6/spec
+++ b/lang-python/pyside6/spec
@@ -1,0 +1,4 @@
+VER=6.7.3
+SRCS="tbl::https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-$VER-src/pyside-setup-everywhere-src-$VER.tar.xz"
+CHKSUMS="sha256::a4c414be013d5051a2d10a9a1151e686488a3172c08a57461ea04b0a0ab74e09"
+CHKUPDATE="anitya::id=148812"


### PR DESCRIPTION
Topic Description
-----------------

- pyside6: new, 6.7.3

Package(s) Affected
-------------------

- pyside2: 6.7.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyside6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
