### PR TITLE
plasma-default-settings: update to 2024.09.2

### DIFF
--- a/runtime-data/plasma-default-settings/spec
+++ b/runtime-data/plasma-default-settings/spec
@@ -1,3 +1,4 @@
-VER=2024.09.1
+VER=2024.09.2
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-default-settings"
 CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=362934"


### PR DESCRIPTION
Topic Description
-----------------

- plasma-default-settings: update to 2024.09.2
    - This version reverts Konsole tab position to bottom, reverting a change
    introduced by KDE Applications 23.08.
    - Mark CHKUPDATE.

Package(s) Affected
-------------------

- plasma-default-settings: 1:2024.09.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit plasma-default-settings
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
