### PR TITLE
bottles: update to 51.13

### DIFF
--- a/app-utils/bottles/autobuild/defines
+++ b/app-utils/bottles/autobuild/defines
@@ -1,7 +1,11 @@
 PKGNAME=bottles
 PKGSEC=utils
 PKGDES="A Wine prefix manager"
-PKGDEP="cabextract gtk-3 libhandy markdown patool pygobject-3 python-3 pyyaml"
+PKGDEP="blueprint-compiler cabextract chardet fvs gtk-3 gtksourceview-5 \
+        gtk-update-icon-cache icoextract libadwaita libhandy markdown \
+        orjson pathvalidate patool pefile perl-xml-namespacesupport \
+        pycurl pygobject-3 python-3 pyyaml vkbasalt-cli"
 PKGRECOM="wine lutris"
 
 ABHOST=noarch
+PKGEPOCH=1

--- a/app-utils/bottles/autobuild/defines
+++ b/app-utils/bottles/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=bottles
 PKGSEC=utils
 PKGDES="A Wine prefix manager"
-PKGDEP="blueprint-compiler cabextract chardet fvs gtk-3 gtksourceview-5 \
+PKGDEP="blueprint-compiler cabextract chardet fvs gtk-4 gtksourceview-5 \
         gtk-update-icon-cache icoextract libadwaita libhandy markdown \
         orjson pathvalidate patool pefile perl-xml-namespacesupport \
         pycurl pygobject-3 python-3 pyyaml vkbasalt-cli"

--- a/app-utils/bottles/spec
+++ b/app-utils/bottles/spec
@@ -1,4 +1,4 @@
-VER=2022.2.28+trento+4
-SRCS="tbl::https://github.com/bottlesdevs/Bottles/archive/refs/tags/${VER//+/-}.tar.gz"
-CHKSUMS="sha256::fb54db4114b0abbe8376af4008b6ccd06c41eb2e5d64e372c75f5d2f8e24deff"
+VER=51.13
+SRCS="git::commit=tags/$VER::https://github.com/bottlesdevs/Bottles"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=155688"

--- a/lang-python/fvs/autobuild/defines
+++ b/lang-python/fvs/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=fvs
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer wheel"
+PKGDES="A File Versioning System"
+
+ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/fvs/spec
+++ b/lang-python/fvs/spec
@@ -1,0 +1,4 @@
+VER=0.3.4
+SRCS="git::commit=tags/$VER::https://github.com/mirkobrombin/FVS"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=269658"

--- a/lang-python/icoextract/autobuild/defines
+++ b/lang-python/icoextract/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=icoextract
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer wheel"
+PKGDES="Icon extractor for Windows PE files"
+
+ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/icoextract/spec
+++ b/lang-python/icoextract/spec
@@ -1,0 +1,4 @@
+VER=0.1.5
+SRCS="git::commit=tags/$VER::https://github.com/jlu5/icoextract"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=105900"

--- a/lang-python/orjson/autobuild/defines
+++ b/lang-python/orjson/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=orjson
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer wheel llvm maturin rustc"
+PKGDES="A python JSON library for dataclasses and datetimes"
+
+ABTYPE=pep517

--- a/lang-python/orjson/autobuild/defines
+++ b/lang-python/orjson/autobuild/defines
@@ -5,3 +5,6 @@ BUILDDEP="python-build python-installer wheel llvm maturin rustc"
 PKGDES="A python JSON library for dataclasses and datetimes"
 
 ABTYPE=pep517
+# FIXME: LTO stripped yyjson code from the native Python module, resulting
+# in a symbol not found error during importing.
+NOLTO=1

--- a/lang-python/orjson/spec
+++ b/lang-python/orjson/spec
@@ -1,0 +1,4 @@
+VER=3.10.14
+SRCS="git::commit=tags/$VER::https://github.com/ijl/orjson"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=31737"

--- a/lang-python/pathvalidate/autobuild/defines
+++ b/lang-python/pathvalidate/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=pathvalidate
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer wheel setuptools-scm"
+PKGDES="Python library for sanitizing/validating a string such as filenames/file-paths/etc"
+
+ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/pathvalidate/spec
+++ b/lang-python/pathvalidate/spec
@@ -1,0 +1,4 @@
+VER=3.2.3
+SRCS="tbl::https://github.com/thombashi/pathvalidate/releases/download/v$VER/pathvalidate-$VER.tar.gz"
+CHKSUMS="sha256::59b5b9278e30382d6d213497623043ebe63f10e29055be4419a9c04c721739cb"
+CHKUPDATE="anitya::id=21704"

--- a/lang-python/vkbasalt-cli/autobuild/defines
+++ b/lang-python/vkbasalt-cli/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=vkbasalt-cli
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer wheel"
+PKGDES="Command-line utility for vkBasalt"
+
+ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/vkbasalt-cli/spec
+++ b/lang-python/vkbasalt-cli/spec
@@ -1,0 +1,4 @@
+VER=3.1.1
+SRCS="git::commit=tags/v$VER::https://gitlab.com/TheEvilSkeleton/vkbasalt-cli"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=350372"


### PR DESCRIPTION
Topic Description
-----------------

- vkbasalt-cli: new, 3.1.1, needed by bottles
- orjson: disable LTO to fix undefined symbol yyjson_doc_free
    Co-authored-by: Cyanoxygen <cyan@cyano.uk>
- orjson: new, 3.10.14, needed by bottles
- fvs: new, 0.3.4, needed by bottles
- icoextract: new, 0.1.5, needed by bottles
- pathvalidate: new, 3.2.3, needed by bottles
- bottles: update to 51.13
    Add PKGDEP and BUILDDEP

Package(s) Affected
-------------------

- bottles: 1:51.13
- fvs: 0.3.4
- icoextract: 0.1.5
- orjson: 3.10.14
- pathvalidate: 3.2.3
- vkbasalt-cli: 3.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pathvalidate icoextract fvs orjson vkbasalt-cli bottles
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
