### PR TITLE
iosevka-fonts: update to 31.7.1

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=31.6.1
+VER=31.7.1
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::6ba820a01f0dd5fe282f3132cb5474042a5a75cb21a876c0c4d96996bd8118ad \
-         sha256::785a6634e295e54fbe414426549f259fe4318dec33152d3e58ba760e6fad1c88 \
-         sha256::0815f9e43a99a2afc1305273ad4768ea2a6737f46402ddc1718ab30d8f5de506 \
-         sha256::b39658a3e15344de5e3879f9a4f8a27de404dc191ee7bfe0f06068bef09bacda \
-         sha256::83ea67d19f29c56c7bb7d10e0d6b426bffde08eccbf2aebfe83fb00f812a25e3 \
-         sha256::36ff34e8fd2240f3bac047c84794d0076eb4d00afe4dd5664536662fdcbca8ea \
-         sha256::0afec43faa51c0c0f7bc7c97904b05b196cf0d9c33fa51877b119d2076bf29cb \
-         sha256::f0dc895af9404f02cafc69b056ddefe05d7d0af00292ea3e23eceb6875a9b19c \
-         sha256::5fb86614e4150db297a9f38686ec736ed8794ebee7a2dc925e31c2e7c508a4e7 \
-         sha256::981e8dad8d9787549a76705f9553323ec2ad1b2a681672039ec75e57b1a70843 \
-         sha256::e7afea72a9d7aef462441a551465e9253bb3bd7336faad994ed46f24fff882de \
-         sha256::3adbcc808483db0529ec9eb880adf0ac49172b4c0d10cf381320a8b2afcd590a \
-         sha256::3c5d988b796e8a875505440734bcc154d80865b4bb39a520a31462821419efb3 \
-         sha256::fa35fae5c32aba851cb876158160233414fadf18b84cb2f294780366b99fc07e \
-         sha256::a16749cf82f65a3ac7fe0d7efd9a7a78b12c35991fadff0835cade8937ff86b2 \
-         sha256::ae2d8da469f72e3792d867068386fe11c9dc6662fcb3cfe45c9b5cf0f041715c \
-         sha256::ad4259e5f8130ebc1046f8ca78cdfabee7d30626044b85afb3cb1df423afe9a4 \
-         sha256::ebfe475d659b323cd8636de39e4e38750a4b60284d23c5991cc93e3d00ee86f6 \
-         sha256::c8cc5b3e48edbb1036798a96300aece00519ae8608fbe4de8ad3487161e18d23 \
-         sha256::87a7dfb6170808d146a661982ec4913adada072987a36f83e1f50e652945401a \
-         sha256::a24c12dc4664c7fbc8c629f91e4d50ab337c46f0abffbd26832ce36c435657d9 \
-         sha256::f7fd3a095c41cc98fef6c22ef3e8b14d05287ce71260ce4ce1c4028cb094ecae \
-         sha256::a247408bacce63f3adf76cc41dc22254e41fdf78026d6ba2e4d69c7407209d5f \
-         sha256::300c1e6098105b6b205d9d7b658704a720b5d218a05a6b5b6866de11198d01b2 \
+CHKSUMS="sha256::ba56a3fec0ee202bd6b68a0e591d06a1902f3f1ff8aa6f6f77d8c98ac1777f08 \
+         sha256::a15a4717019edf0c1ac59e9d7d11ebd8eb48e05d58e3017da1b0fe190bdd3df7 \
+         sha256::f822dfcde7342248d8787a3791dd61fc142b528bd22841b7c57565ad7a47f05d \
+         sha256::9596403176138140dba71bc6adf14168d528faa94b0b54a05454aff7b6c00b5a \
+         sha256::645645a3abfd112916104db30b9ef792182280319274db045927eb10826c87eb \
+         sha256::7738ba3952e1a43d94827f9ef88c1123350c61dc957cf62edf36edbe34056e95 \
+         sha256::fae919118ed5de08df7d5df768ad38285afac9a4b5efc6e20f4cced684d2a4e8 \
+         sha256::3cfd38d83a93d332b63fe09b7eb27ce8a30f723f898d957acfb780cb77bd3fe3 \
+         sha256::b2d298b6664a0a24402dfa2fde2e7939cd41554078fb59da69cf66454f4df328 \
+         sha256::1c01c89a36ab7fd31d82fe81b6c401d233b3ec49294cb54cdc4fbe6859616daa \
+         sha256::aa2e7ac4cdc67e2561ef4589d24a171b6d849b752b0bec5fc3c14d5432f72ae1 \
+         sha256::715c5ca224c7fe5c8208d2a4136ff92e1fc56e6990ec57ad9d974ff7bb7b71f4 \
+         sha256::54a36386289d9cd9b8ce40ee6555c6d96054f07d0f5cbb9cc3363e1df4c90e3d \
+         sha256::8387679dcfc74c2b5dd8b52334875f2969d3ac8d4d883d9e91f1aa3515a4ba7f \
+         sha256::3e1b9d9d670b156d01c688d0876afd6f31ce76681d4187f781242375cb30c634 \
+         sha256::6d874d622b43bf1ecb5d9ac9fcd6badebf58e58f34ee5943bdaecf0dde0432e3 \
+         sha256::f5782ecc40b835acd8a9c0433f479026622303204bf26fc3d3c628417aa90a16 \
+         sha256::73d122dbae341c27d557de632c917372c0a048c347ea50c49cd5ff22b431e861 \
+         sha256::d7de9217ca81054c4d43aeca77a7cf6dad9e177858c058a8b87cee3d60ababc9 \
+         sha256::690b21959398acd37e418ed734b24c71d37d6a5308c447f2b451f78745af71fa \
+         sha256::a32ef10c8a91385604a8529e16af029d32bbb53020dc8fd3f4122542a1a9c51f \
+         sha256::80697d8c4218e35e0071231cc66fbddb4dcf7d17a3d825ad6f477854157c693d \
+         sha256::cf5c9ce00f522c67fb972f3d323504e70e949d7b1cd436444efc14719379ab0f \
+         sha256::f12da2cd1822808c842509114e68d8bb2fa7c53d6e136d9cd629131c916f64a9 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 31.7.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 31.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
