### PR TITLE
x42-plugins: new, 0.6.0

### DIFF
--- a/app-multimedia/x42-plugins/autobuild/build
+++ b/app-multimedia/x42-plugins/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Making ..."
+make PREFIX=/usr STRIP=/bin/true $ABMK
+
+abinfo "Installing ..."
+make PREFIX=/usr STRIP=/bin/true DESTDIR="$PKGDIR" install $ABMK

--- a/app-multimedia/x42-plugins/autobuild/defines
+++ b/app-multimedia/x42-plugins/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=x42-plugins
+PKGDES="An collection of LV2 audio plugins useful for professional audio processing"
+PKGDEP="lv2 liblo libsndfile libsamplerate fftw jack cairo libglvnd glu libltc ftgl"
+PKGSEC=sound
+
+ABTYPE=self

--- a/app-multimedia/x42-plugins/spec
+++ b/app-multimedia/x42-plugins/spec
@@ -1,0 +1,4 @@
+VER=20240611
+SRCS="tbl::https://gareus.org/misc/x42-plugins/x42-plugins-$VER.tar.xz"
+CHKSUMS="sha256::94ee98d731061a1bfa1c8ac79aaf5bd0b037ecadd9cc1b42fc447306c194662c"
+CHKUPDATE="anitya::id=374569"


### PR DESCRIPTION
Topic Description
-----------------

- x42-plugins: new, 20240611
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- x42-plugins: 20240611

Security Update?
----------------

No

Build Order
-----------

```
#buildit x42-plugins
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
