### PR TITLE
proot: update to 5.4.0

### DIFF
--- a/app-utils/proot/autobuild/build
+++ b/app-utils/proot/autobuild/build
@@ -1,20 +1,15 @@
-cd "${SRCDIR}/src"
+abinfo "Building binary ..."
+cd "$SRCDIR"/src
 make -f GNUmakefile
 
-cd "${SRCDIR}/doc"
+abinfo "Building manpage ..."
+cd "$SRCDIR"/doc
 make -f GNUmakefile
 
-install -m755 -d "${PKGDIR}/usr/bin"
-install -m755 "${SRCDIR}/src/proot" "${PKGDIR}/usr/bin"
+abinfo "Installing binary ..."
+install -Dvm755 "$SRCDIR"/src/proot \
+    "$PKGDIR"/usr/bin/proot
 
-install -m755 -d "${PKGDIR}/usr/share/man/man1/"
-install -m644 -T "${SRCDIR}doc/proot/man.1" "${PKGDIR}"/usr/share/man/man1/proot.1
-
-install -m755 -d "${PKGDIR}/usr/share/doc/proot/"
-install -m644 "${SRCDIR}/doc/proot/changelog.txt" "${PKGDIR}/usr/share/doc/proot"
-install -m644 "${SRCDIR}/doc/proot/index.html" "${PKGDIR}"/usr/share/doc/proot"
-install -m644 "${SRCDIR}/doc/proot/manual.txt" "${PKGDIR}"/usr/share/doc/proot"
-install -m644 "${SRCDIR}/doc/proot/roadmap.txt" "${PKGDIR}"/usr/share/doc/proot"
-
-install -m755 -d "${PKGDIR}/usr/share/doc/proot/stylesheets/"
-install -m644 "${SRCDIR}/doc/proot/stylesheets/*" "${PKGDIR}/usr/share/doc/proot/stylesheets"
+abinfo "Installing manpage ..."
+install -Dvm644 "$SRCDIR"/doc/proot/man.1 \
+    "$PKGDIR"/usr/share/man/man1/proot.1

--- a/app-utils/proot/autobuild/defines
+++ b/app-utils/proot/autobuild/defines
@@ -1,5 +1,8 @@
 PKGNAME=proot
 PKGSEC=utils
-PKGDES="a powerful tool that can chroot, mount --bind, and binfmt_misc without privilege/setup"
+PKGDES="A tool for chroot, mount --bind, and binfmt_misc without privilege/setup"
 PKGDEP="talloc"
 BUILDDEP="gcc docutils libxslt"
+
+# FIXME: Upstream only supports x86, arm and sh4 architecture
+FAIL_ARCH="!(amd64|arm64)"

--- a/app-utils/proot/spec
+++ b/app-utils/proot/spec
@@ -1,4 +1,4 @@
-VER=5.1.20171016
-SRCS="git::commit=0bf2ee17daafeeadfed079cec97fe1ac781e696a::https://github.com/proot-me/PRoot.git"
+VER=5.4.0
+SRCS="git::commit=tags/v$VER::https://github.com/proot-me/proot.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231637"


### PR DESCRIPTION
Topic Description
-----------------

- proot: update build process
- proot: update to 5.4.0
    Add FAIL_ARCH for architectures other than x86 and arm

Package(s) Affected
-------------------

- proot: 5.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit proot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
