### PR TITLE
libcamera: update to 0.3.2

### DIFF
--- a/runtime-devices/libcamera/autobuild/beyond
+++ b/runtime-devices/libcamera/autobuild/beyond
@@ -3,3 +3,7 @@ if [[ -e "$PKGDIR"/usr/lib/libcamera ]]; then
     abinfo 'Fixing permissions problem for signed IPA modules ...'
     find "$PKGDIR"/usr/lib/libcamera -type f -exec chmod -v 755 {} +
 fi
+
+abinfo "Moving documentations to /usr/share/doc/libcamera ..."
+mv -v "$PKGDIR"/usr/share/doc/libcamera-"$PKGVER" \
+      "$PKGDIR"/usr/share/doc/libcamera

--- a/runtime-devices/libcamera/autobuild/defines
+++ b/runtime-devices/libcamera/autobuild/defines
@@ -5,7 +5,4 @@ BUILDDEP="boost doxygen gnutls gstreamer-1-0 gtest jinja2 ply libevent libtiff \
           libdwarf lttng-ust meson ninja openssl pyyaml qt-5 sphinx systemd \
           texlive yaml graphviz"
 
-# qcam and cam will crash with LTO,
-# see https://bugs.libcamera.org/show_bug.cgi?id=83
-NOLTO=1
 MESON_AFTER="-Dv4l2=true"

--- a/runtime-devices/libcamera/spec
+++ b/runtime-devices/libcamera/spec
@@ -1,4 +1,4 @@
-VER=0.3.1
+VER=0.3.2
 SRCS="git::commit=tags/v${VER}::https://git.libcamera.org/libcamera/libcamera.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301902"


### PR DESCRIPTION
Topic Description
-----------------

- libcamera: update to 0.3.2
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- libcamera: 0.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcamera
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
