### PR TITLE
fwupd: update to 1.9.25

### DIFF
--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,4 @@
-VER=1.9.24
+VER=1.9.25
 SRCS="git::commit=tags/$VER::https://github.com/fwupd/fwupd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5833"

--- a/runtime-common/libjcat/autobuild/defines
+++ b/runtime-common/libjcat/autobuild/defines
@@ -9,7 +9,8 @@ MESON_AFTER="-Dgtkdoc=true \
              -Dvapi=true \
              -Dgpg=true \
              -Dpkcs7=true \
-             -Dman=true"
+             -Dman=true \
+             -Dcli=true"
 
 PKGBREAK="fwupd<=1.5.4-1"
 PKGREP="fwupd<=1.5.4-1"

--- a/runtime-common/libjcat/spec
+++ b/runtime-common/libjcat/spec
@@ -1,4 +1,4 @@
-VER=0.1.8
-SRCS="https://github.com/hughsie/libjcat/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::aedb6e508120ace7cfc2c03f2972e8a422f0e0b01ee00654a093ea3b7e2e35d1"
+VER=0.2.1
+SRCS="git::commit=tags/$VER::https://github.com/hughsie/libjcat"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229583"


### PR DESCRIPTION
Topic Description
-----------------

- fwupd: update to 1.9.25
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>
- libjcat: update to 0.2.1

Package(s) Affected
-------------------

- fwupd: 1.9.25
- libjcat: 0.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjcat fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
