### PR TITLE
praat: update to 6.4.21

### DIFF
--- a/app-scientific/praat/spec
+++ b/app-scientific/praat/spec
@@ -1,4 +1,4 @@
-VER=6.4.20
+VER=6.4.21
 SRCS="git::commit=tags/v$VER::https://github.com/praat/praat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373832"


### PR DESCRIPTION
Topic Description
-----------------

- praat: update to 6.4.21
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- praat: 6.4.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit praat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
