### PR TITLE
binutils: add support for OUTPUT_FORMAT("binary") on LoongArch

### DIFF
--- a/app-devel/binutils/01-main/patches/0002-LoongArch-Add-support-for-OUTPUT_FORMAT-binary.patch
+++ b/app-devel/binutils/01-main/patches/0002-LoongArch-Add-support-for-OUTPUT_FORMAT-binary.patch
@@ -1,0 +1,121 @@
+From 3a83f0342e545a638aba06f27bba76938ef251ab Mon Sep 17 00:00:00 2001
+From: mengqinggang <mengqinggang@loongson.cn>
+Date: Fri, 28 Jun 2024 14:24:19 +0800
+Subject: [PATCH] LoongArch: Add support for OUTPUT_FORMAT("binary")
+
+In binary output format, loongarch_elf_hash_table return NULL and result
+in segment fault.
+
+When ld output binary file, it seems that elf related functions should
+not be called. But loongarch_elf_relax_section be called and
+loongarch_elf_hash_table cause segment fault.
+
+Just redefined loongarch_elf_hash_table and always return
+link_info->hash.
+
+The tests of binutils, glibc and gcc is ok.
+
+0  loongarch_elf_relax_section ()
+1  0x000055555557ab28 in lang_size_sections_1 ()
+2  0x000055555557a16c in lang_size_sections_1 ()
+3  0x000055555557b0a8 in one_lang_size_sections_pass ()
+4  0x000055555557b478 in lang_size_sections ()
+5  0x000055555557e65c in lang_relax_sections ()
+6  0x000055555559f9c8 in ldelf_map_segments ()
+7  0x000055555559783c in gldelf64loongarch_after_allocation ()
+8  0x000055555558dac0 in ldemul_after_allocation ()
+9  0x000055555557f6c0 in lang_process ()
+10 0x0000555555585314 in main ()
+---
+ bfd/elfnn-loongarch.c                            |  4 +---
+ ld/emultempl/loongarchelf.em                     | 16 ----------------
+ ld/testsuite/ld-loongarch-elf/binary.ld          |  1 +
+ ld/testsuite/ld-loongarch-elf/binary.s           |  4 ++++
+ .../ld-loongarch-elf/ld-loongarch-elf.exp        | 12 ++++++++++++
+ 5 files changed, 18 insertions(+), 19 deletions(-)
+ create mode 100644 ld/testsuite/ld-loongarch-elf/binary.ld
+ create mode 100644 ld/testsuite/ld-loongarch-elf/binary.s
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index db6d419a052e..71fa8fa6f015 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -157,9 +157,7 @@ loongarch_elf_new_section_hook (bfd *abfd, asection *sec)
+ 
+ /* Get the LoongArch ELF linker hash table from a link_info structure.  */
+ #define loongarch_elf_hash_table(p)					\
+-  (elf_hash_table_id (elf_hash_table (p)) == LARCH_ELF_DATA		\
+-   ? ((struct loongarch_elf_link_hash_table *) ((p)->hash))		\
+-   : NULL)
++    ((struct loongarch_elf_link_hash_table *) ((p)->hash))		\
+ 
+ #define MINUS_ONE ((bfd_vma) 0 - 1)
+ 
+diff --git a/ld/emultempl/loongarchelf.em b/ld/emultempl/loongarchelf.em
+index 2da405820087..8a1a898f9e75 100644
+--- a/ld/emultempl/loongarchelf.em
++++ b/ld/emultempl/loongarchelf.em
+@@ -102,23 +102,7 @@ gld${EMULATION_NAME}_after_allocation (void)
+   ldelf_map_segments (need_layout);
+ }
+ 
+-/* This is a convenient point to tell BFD about target specific flags.
+-   After the output has been created, but before inputs are read.  */
+-
+-static void
+-larch_create_output_section_statements (void)
+-{
+-  /* See PR 22920 for an example of why this is necessary.  */
+-  if (strstr (bfd_get_target (link_info.output_bfd), "loong") == NULL)
+-    {
+-      einfo (_("%F%P: error: cannot change output format"
+-	       " whilst linking %s binaries\n"), "LoongArch");
+-      return;
+-    }
+-}
+-
+ EOF
+ 
+ LDEMUL_BEFORE_ALLOCATION=larch_elf_before_allocation
+ LDEMUL_AFTER_ALLOCATION=gld${EMULATION_NAME}_after_allocation
+-LDEMUL_CREATE_OUTPUT_SECTION_STATEMENTS=larch_create_output_section_statements
+diff --git a/ld/testsuite/ld-loongarch-elf/binary.ld b/ld/testsuite/ld-loongarch-elf/binary.ld
+new file mode 100644
+index 000000000000..73cd4f2c1fc4
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/binary.ld
+@@ -0,0 +1 @@
++OUTPUT_FORMAT(binary);
+diff --git a/ld/testsuite/ld-loongarch-elf/binary.s b/ld/testsuite/ld-loongarch-elf/binary.s
+new file mode 100644
+index 000000000000..b0aeb62af1cf
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/binary.s
+@@ -0,0 +1,4 @@
++.text
++  ret
++.data
++  .4byte 0x12345678
+diff --git a/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp b/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp
+index fb34eeb80cbb..16d89cd5a432 100644
+--- a/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp
++++ b/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp
+@@ -118,6 +118,18 @@ if [istarget "loongarch64-*-*"] {
+ 	      "abi1_max_imm" \
+ 	  ] \
+       ]
++
++  run_ld_link_tests \
++      [list \
++	   [list \
++		"binary output format" \
++		"-T binary.ld" "" \
++		"" \
++		{binary.s} \
++		{} \
++		"a.binary" \
++	   ] \
++      ]
+ }
+ 
+ if [istarget "loongarch64-*-*"] {

--- a/app-devel/binutils/spec
+++ b/app-devel/binutils/spec
@@ -1,4 +1,5 @@
 VER=2.43
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/binutils/binutils-$VER.tar.xz"
 CHKSUMS="sha256::b53606f443ac8f01d1d5fc9c39497f2af322d99e14cea5c0b4b124d630379365"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION
Topic Description
-----------------

- binutils: Add support for OUTPUT_FORMAT("binary") on LoongArch

Package(s) Affected
-------------------

- binutils: 2.43-1
- binutils+cross-amd64: 2.43-1
- binutils+cross-arm64: 2.43-1
- binutils+cross-loongarch64: 2.43-1
- binutils+cross-loongson3: 2.43-1
- binutils+cross-mips64r6el: 2.43-1
- binutils+cross-ppc64el: 2.43-1
- binutils+cross-riscv64: 2.43-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
