### PR TITLE
meta-bases: add cloud base

### DIFF
--- a/meta-bases/cloud-base/autobuild/build
+++ b/meta-bases/cloud-base/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Enable console output for Cloud images ..."
+mkdir -p "$PKGDIR"/etc/default/grub.d
+cat > "$PKGDIR"/etc/default/grub.d/cloud.cfg << EOF
+GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT} console=ttyS0 earlyprintk=ttyS0"
+EOF

--- a/meta-bases/cloud-base/autobuild/defines
+++ b/meta-bases/cloud-base/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=cloud-base
+PKGSEC=Bases
+PKGDEP="openssh aosc-os-presets-cloud cloud-init cloud-utils qemu-guest-agent grub"
+PKGDES="Meta package for AOSC OS Cloud images"
+
+VER_NONE=1
+
+ABHOST=noarch

--- a/meta-bases/cloud-base/autobuild/postinst
+++ b/meta-bases/cloud-base/autobuild/postinst
@@ -1,0 +1,6 @@
+if ! systemd-detect-virt -q --container || ( systemd-detect-virt -q --container && systemd-detect-virt -q --chroot ) ; then
+	if [[ -x /usr/bin/grub-mkconfig ]]; then
+		echo -e "\033[36m**\033[0m\tUpdating GRUB for the new kernel..."
+		update-grub
+	fi
+fi

--- a/meta-bases/cloud-base/spec
+++ b/meta-bases/cloud-base/spec
@@ -1,0 +1,2 @@
+VER=1
+DUMMYSRC=1

--- a/runtime-data/aosc-os-presets-cloud/autobuild/build
+++ b/runtime-data/aosc-os-presets-cloud/autobuild/build
@@ -1,0 +1,16 @@
+mkdir -pv "$PKGDIR"/usr/lib/systemd/system-preset
+
+abinfo "Writing 75-aosc-os-cloud.preset ..."
+cat > "$PKGDIR"/usr/lib/systemd/system-preset/70-aosc-os-cloud.preset << EOF
+## 70-aosc-os-cloud.preset
+## Systemd presets for AOSC OS hosted on the cloud
+
+# Cloud Services
+enable cloud-init-network.service
+
+# Remote access
+enable sshd.service
+
+# Clouds will have their own firewall
+disable firewalld.service
+EOF

--- a/runtime-data/aosc-os-presets-cloud/autobuild/defines
+++ b/runtime-data/aosc-os-presets-cloud/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=aosc-os-presets-cloud
+PKGSEC=misc
+PKGDEP=""
+PKGDES="Systemd presets for AOSC OS hosted on the cloud"
+
+ABHOST=noarch

--- a/runtime-data/aosc-os-presets-cloud/spec
+++ b/runtime-data/aosc-os-presets-cloud/spec
@@ -1,0 +1,2 @@
+VER=1
+DUMMYSRC=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Add cloud and azure bases to support cloud images.

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------
-->

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

```
#buildit aosc-os-presets-cloud cloud-base
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [x] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
