### PR TITLE
OpenPrinting Security Survey 20240927

### DIFF
--- a/app-admin/cups-browsed/autobuild/patches/0001-Default-BrowseRemoteProtocols-should-not-include-cup.patch
+++ b/app-admin/cups-browsed/autobuild/patches/0001-Default-BrowseRemoteProtocols-should-not-include-cup.patch
@@ -1,0 +1,31 @@
+From 1debe6b140c37e0aa928559add4abcc95ce54aa2 Mon Sep 17 00:00:00 2001
+From: Zdenek Dohnal <zdohnal@redhat.com>
+Date: Thu, 26 Sep 2024 23:03:32 +0200
+Subject: [PATCH] Default BrowseRemoteProtocols should not include "cups"
+ protocol
+
+Works around CVE-2024-47176, the fix will be complete removal of CUPS
+Browsing functionality
+---
+ configure.ac | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index d07b184c..84de9129 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -183,9 +183,9 @@ else
+ fi
+ 
+ AC_ARG_WITH([browseremoteprotocols],
+-	[AS_HELP_STRING([--with-browseremoteprotocols=value], [Set which protocols to listen for in cups-browsed (default: dnssd cups)])],
++	[AS_HELP_STRING([--with-browseremoteprotocols=value], [Set which protocols to listen for in cups-browsed (default: dnssd)])],
+ 	[with_browseremoteprotocols="$withval"],
+-	[with_browseremoteprotocols="dnssd cups"]
++	[with_browseremoteprotocols="dnssd"]
+ )
+ BROWSEREMOTEPROTOCOLS="$with_browseremoteprotocols"
+ AC_SUBST(BROWSEREMOTEPROTOCOLS)
+-- 
+2.46.2.windows.1
+

--- a/app-admin/cups-browsed/spec
+++ b/app-admin/cups-browsed/spec
@@ -1,5 +1,4 @@
-VER=2.0.0
-REL=1
+VER=2.0.1
 SRCS="git::commit=tags/$VER::https://github.com/OpenPrinting/cups-browsed"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328190"

--- a/app-admin/cups/autobuild/patches/0002-Mirror-IPP-Everywhere-printer-changes-from-master.patch
+++ b/app-admin/cups/autobuild/patches/0002-Mirror-IPP-Everywhere-printer-changes-from-master.patch
@@ -1,0 +1,79 @@
+From 85b8dac2a7ab22bf4f713798ac1597295c34c8e5 Mon Sep 17 00:00:00 2001
+From: Michael R Sweet <msweet@msweet.org>
+Date: Mon, 9 Sep 2024 10:03:10 -0400
+Subject: [PATCH 1/5] Mirror IPP Everywhere printer changes from master.
+
+---
+ cups/ppd-cache.c | 10 +++++-----
+ scheduler/ipp.c  |  9 ++++++++-
+ 2 files changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/cups/ppd-cache.c b/cups/ppd-cache.c
+index e750fccd..cd2d6cbe 100644
+--- a/cups/ppd-cache.c
++++ b/cups/ppd-cache.c
+@@ -3317,10 +3317,10 @@ _ppdCreateFromIPP2(
+   }
+   cupsFilePuts(fp, "\"\n");
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-more-info", IPP_TAG_URI)) != NULL)
++  if ((attr = ippFindAttribute(supported, "printer-more-info", IPP_TAG_URI)) != NULL && ippValidateAttribute(attr))
+     cupsFilePrintf(fp, "*APSupplies: \"%s\"\n", ippGetString(attr, 0, NULL));
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-charge-info-uri", IPP_TAG_URI)) != NULL)
++  if ((attr = ippFindAttribute(supported, "printer-charge-info-uri", IPP_TAG_URI)) != NULL && ippValidateAttribute(attr))
+     cupsFilePrintf(fp, "*cupsChargeInfoURI: \"%s\"\n", ippGetString(attr, 0, NULL));
+ 
+   if ((attr = ippFindAttribute(supported, "printer-strings-uri", IPP_TAG_URI)) != NULL)
+@@ -3389,10 +3389,10 @@ _ppdCreateFromIPP2(
+   if (ippGetBoolean(ippFindAttribute(supported, "job-accounting-user-id-supported", IPP_TAG_BOOLEAN), 0))
+     cupsFilePuts(fp, "*cupsJobAccountingUserId: True\n");
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-privacy-policy-uri", IPP_TAG_URI)) != NULL)
++  if ((attr = ippFindAttribute(supported, "printer-privacy-policy-uri", IPP_TAG_URI)) != NULL && ippValidateAttribute(attr))
+     cupsFilePrintf(fp, "*cupsPrivacyURI: \"%s\"\n", ippGetString(attr, 0, NULL));
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-mandatory-job-attributes", IPP_TAG_KEYWORD)) != NULL)
++  if ((attr = ippFindAttribute(supported, "printer-mandatory-job-attributes", IPP_TAG_KEYWORD)) != NULL && ippValidateAttribute(attr))
+   {
+     char	prefix = '\"';		// Prefix for string
+ 
+@@ -3410,7 +3410,7 @@ _ppdCreateFromIPP2(
+     cupsFilePuts(fp, "\"\n");
+   }
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-requested-job-attributes", IPP_TAG_KEYWORD)) != NULL)
++  if ((attr = ippFindAttribute(supported, "printer-requested-job-attributes", IPP_TAG_KEYWORD)) != NULL && ippValidateAttribute(attr))
+   {
+     char	prefix = '\"';		// Prefix for string
+ 
+diff --git a/scheduler/ipp.c b/scheduler/ipp.c
+index 37623c54..14b1fe1e 100644
+--- a/scheduler/ipp.c
++++ b/scheduler/ipp.c
+@@ -1,7 +1,7 @@
+ /*
+  * IPP routines for the CUPS scheduler.
+  *
+- * Copyright © 2020-2023 by OpenPrinting
++ * Copyright © 2020-2024 by OpenPrinting
+  * Copyright © 2007-2021 by Apple Inc.
+  * Copyright © 1997-2007 by Easy Software Products, all rights reserved.
+  *
+@@ -5417,6 +5417,13 @@ create_local_bg_thread(
+     }
+   }
+ 
++  // Validate response from printer...
++  if (!ippValidateAttributes(response))
++  {
++    send_ipp_status(con, IPP_STATUS_ERROR_DEVICE, _("Printer returned invalid data: %s"), cupsLastErrorString());
++    goto finish_response;
++  }
++
+   // TODO: Grab printer icon file...
+   httpClose(http);
+ 
+-- 
+2.47.0.rc0.windows.1
+

--- a/app-admin/cups/autobuild/patches/0003-Refactor-make-and-model-code.patch
+++ b/app-admin/cups/autobuild/patches/0003-Refactor-make-and-model-code.patch
@@ -1,0 +1,148 @@
+From 512ed59f61935a708862c5cf20accd453567a3d9 Mon Sep 17 00:00:00 2001
+From: Michael R Sweet <msweet@msweet.org>
+Date: Mon, 9 Sep 2024 14:05:42 -0400
+Subject: [PATCH 2/5] Refactor make-and-model code.
+
+---
+ cups/ppd-cache.c | 103 +++++++++++++++++++++++++++++++++++++++--------
+ 1 file changed, 87 insertions(+), 16 deletions(-)
+
+diff --git a/cups/ppd-cache.c b/cups/ppd-cache.c
+index cd2d6cbe..a4d74039 100644
+--- a/cups/ppd-cache.c
++++ b/cups/ppd-cache.c
+@@ -3197,9 +3197,10 @@ _ppdCreateFromIPP2(
+   ipp_t			*media_col,	/* Media collection */
+ 			*media_size;	/* Media size collection */
+   char			make[256],	/* Make and model */
+-			*model,		/* Model name */
++			*mptr,		/* Pointer into make and model */
+ 			ppdname[PPD_MAX_NAME];
+ 		    			/* PPD keyword */
++  const char		*model;		/* Model name */
+   int			i, j,		/* Looping vars */
+ 			count,		/* Number of values */
+ 			bottom,		/* Largest bottom margin */
+@@ -3260,34 +3261,104 @@ _ppdCreateFromIPP2(
+   }
+ 
+  /*
+-  * Standard stuff for PPD file...
++  * Get a sanitized make and model...
+   */
+ 
+-  cupsFilePuts(fp, "*PPD-Adobe: \"4.3\"\n");
+-  cupsFilePuts(fp, "*FormatVersion: \"4.3\"\n");
+-  cupsFilePrintf(fp, "*FileVersion: \"%d.%d\"\n", CUPS_VERSION_MAJOR, CUPS_VERSION_MINOR);
+-  cupsFilePuts(fp, "*LanguageVersion: English\n");
+-  cupsFilePuts(fp, "*LanguageEncoding: ISOLatin1\n");
+-  cupsFilePuts(fp, "*PSVersion: \"(3010.000) 0\"\n");
+-  cupsFilePuts(fp, "*LanguageLevel: \"3\"\n");
+-  cupsFilePuts(fp, "*FileSystem: False\n");
+-  cupsFilePuts(fp, "*PCFileName: \"ippeve.ppd\"\n");
++  if ((attr = ippFindAttribute(supported, "printer-make-and-model", IPP_TAG_TEXT)) != NULL && ippValidateAttribute(attr))
++  {
++   /*
++    * Sanitize the model name to only contain PPD-safe characters.
++    */
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-make-and-model", IPP_TAG_TEXT)) != NULL)
+     strlcpy(make, ippGetString(attr, 0, NULL), sizeof(make));
++
++    for (mptr = make; *mptr; mptr ++)
++    {
++      if (*mptr < ' ' || *mptr >= 127 || *mptr == '\"')
++      {
++       /*
++	* Truncate the make and model on the first bad character...
++	*/
++
++	*mptr = '\0';
++	break;
++      }
++    }
++
++    while (mptr > make)
++    {
++     /*
++      * Strip trailing whitespace...
++      */
++
++      mptr --;
++      if (*mptr == ' ')
++	*mptr = '\0';
++    }
++
++    if (!make[0])
++    {
++     /*
++      * Use a default make and model if nothing remains...
++      */
++
++      strlcpy(make, "Unknown", sizeof(make));
++    }
++  }
+   else
+-    strlcpy(make, "Unknown Printer", sizeof(make));
++  {
++   /*
++    * Use a default make and model...
++    */
++
++    strlcpy(make, "Unknown", sizeof(make));
++  }
+ 
+   if (!_cups_strncasecmp(make, "Hewlett Packard ", 16) || !_cups_strncasecmp(make, "Hewlett-Packard ", 16))
+   {
++   /*
++    * Normalize HP printer make and model...
++    */
++
+     model = make + 16;
+     strlcpy(make, "HP", sizeof(make));
++
++    if (!_cups_strncasecmp(model, "HP ", 3))
++      model += 3;
++  }
++  else if ((mptr = strchr(make, ' ')) != NULL)
++  {
++   /*
++    * Separate "MAKE MODEL"...
++    */
++
++    while (*mptr && *mptr == ' ')
++      *mptr++ = '\0';
++
++    model = mptr;
+   }
+-  else if ((model = strchr(make, ' ')) != NULL)
+-    *model++ = '\0';
+   else
+-    model = make;
++  {
++   /*
++    * No separate model name...
++    */
+ 
++    model = "Printer";
++  }
++
++ /*
++  * Standard stuff for PPD file...
++  */
++
++  cupsFilePuts(fp, "*PPD-Adobe: \"4.3\"\n");
++  cupsFilePuts(fp, "*FormatVersion: \"4.3\"\n");
++  cupsFilePrintf(fp, "*FileVersion: \"%d.%d\"\n", CUPS_VERSION_MAJOR, CUPS_VERSION_MINOR);
++  cupsFilePuts(fp, "*LanguageVersion: English\n");
++  cupsFilePuts(fp, "*LanguageEncoding: ISOLatin1\n");
++  cupsFilePuts(fp, "*PSVersion: \"(3010.000) 0\"\n");
++  cupsFilePuts(fp, "*LanguageLevel: \"3\"\n");
++  cupsFilePuts(fp, "*FileSystem: False\n");
++  cupsFilePuts(fp, "*PCFileName: \"ippeve.ppd\"\n");
+   cupsFilePrintf(fp, "*Manufacturer: \"%s\"\n", make);
+   cupsFilePrintf(fp, "*ModelName: \"%s\"\n", model);
+   cupsFilePrintf(fp, "*Product: \"(%s)\"\n", model);
+-- 
+2.47.0.rc0.windows.1
+

--- a/app-admin/cups/autobuild/patches/0004-PPDize-preset-and-template-names.patch
+++ b/app-admin/cups/autobuild/patches/0004-PPDize-preset-and-template-names.patch
@@ -1,0 +1,116 @@
+From b26804b77ce46193d278175df1a483a6a162b87f Mon Sep 17 00:00:00 2001
+From: Michael R Sweet <msweet@msweet.org>
+Date: Mon, 9 Sep 2024 15:59:57 -0400
+Subject: [PATCH 3/5] PPDize preset and template names.
+
+---
+ cups/ppd-cache.c | 33 ++++++++++++++++++++++++---------
+ 1 file changed, 24 insertions(+), 9 deletions(-)
+
+diff --git a/cups/ppd-cache.c b/cups/ppd-cache.c
+index a4d74039..53c22be0 100644
+--- a/cups/ppd-cache.c
++++ b/cups/ppd-cache.c
+@@ -4976,12 +4976,14 @@ _ppdCreateFromIPP2(
+ 
+       cupsArrayAdd(templates, (void *)keyword);
+ 
++      pwg_ppdize_name(keyword, ppdname, sizeof(ppdname));
++
+       snprintf(msgid, sizeof(msgid), "finishing-template.%s", keyword);
+       if ((msgstr = _cupsLangString(lang, msgid)) == msgid || !strcmp(msgid, msgstr))
+ 	if ((msgstr = _cupsMessageLookup(strings, msgid)) == msgid)
+ 	  msgstr = keyword;
+ 
+-      cupsFilePrintf(fp, "*cupsFinishingTemplate %s: \"\n", keyword);
++      cupsFilePrintf(fp, "*cupsFinishingTemplate %s: \"\n", ppdname);
+       for (finishing_attr = ippFirstAttribute(finishing_col); finishing_attr; finishing_attr = ippNextAttribute(finishing_col))
+       {
+         if (ippGetValueTag(finishing_attr) == IPP_TAG_BEGIN_COLLECTION)
+@@ -4994,7 +4996,7 @@ _ppdCreateFromIPP2(
+ 	}
+       }
+       cupsFilePuts(fp, "\"\n");
+-      cupsFilePrintf(fp, "*%s.cupsFinishingTemplate %s/%s: \"\"\n", lang->language, keyword, msgstr);
++      cupsFilePrintf(fp, "*%s.cupsFinishingTemplate %s/%s: \"\"\n", lang->language, ppdname, msgstr);
+       cupsFilePuts(fp, "*End\n");
+     }
+ 
+@@ -5040,7 +5042,8 @@ _ppdCreateFromIPP2(
+       if (!preset || !preset_name)
+         continue;
+ 
+-      cupsFilePrintf(fp, "*APPrinterPreset %s: \"\n", preset_name);
++      pwg_ppdize_name(preset_name, ppdname, sizeof(ppdname));
++      cupsFilePrintf(fp, "*APPrinterPreset %s: \"\n", ppdname);
+       for (member = ippFirstAttribute(preset); member; member = ippNextAttribute(preset))
+       {
+         member_name = ippGetName(member);
+@@ -5081,7 +5084,10 @@ _ppdCreateFromIPP2(
+             fin_col = ippGetCollection(member, i);
+ 
+             if ((keyword = ippGetString(ippFindAttribute(fin_col, "finishing-template", IPP_TAG_ZERO), 0, NULL)) != NULL)
+-              cupsFilePrintf(fp, "*cupsFinishingTemplate %s\n", keyword);
++            {
++              pwg_ppdize_name(keyword, ppdname, sizeof(ppdname));
++              cupsFilePrintf(fp, "*cupsFinishingTemplate %s\n", ppdname);
++            }
+           }
+         }
+         else if (!strcmp(member_name, "media"))
+@@ -5108,13 +5114,13 @@ _ppdCreateFromIPP2(
+           if ((keyword = ippGetString(ippFindAttribute(media_col, "media-source", IPP_TAG_ZERO), 0, NULL)) != NULL)
+           {
+             pwg_ppdize_name(keyword, ppdname, sizeof(ppdname));
+-            cupsFilePrintf(fp, "*InputSlot %s\n", keyword);
++            cupsFilePrintf(fp, "*InputSlot %s\n", ppdname);
+ 	  }
+ 
+           if ((keyword = ippGetString(ippFindAttribute(media_col, "media-type", IPP_TAG_ZERO), 0, NULL)) != NULL)
+           {
+             pwg_ppdize_name(keyword, ppdname, sizeof(ppdname));
+-            cupsFilePrintf(fp, "*MediaType %s\n", keyword);
++            cupsFilePrintf(fp, "*MediaType %s\n", ppdname);
+ 	  }
+         }
+         else if (!strcmp(member_name, "print-quality"))
+@@ -5160,7 +5166,10 @@ _ppdCreateFromIPP2(
+       cupsFilePuts(fp, "\"\n*End\n");
+ 
+       if ((localized_name = _cupsMessageLookup(strings, preset_name)) != preset_name)
+-        cupsFilePrintf(fp, "*%s.APPrinterPreset %s/%s: \"\"\n", lang->language, preset_name, localized_name);
++      {
++        pwg_ppdize_name(preset_name, ppdname, sizeof(ppdname));
++        cupsFilePrintf(fp, "*%s.APPrinterPreset %s/%s: \"\"\n", lang->language, ppdname, localized_name);
++      }
+     }
+   }
+ 
+@@ -5544,7 +5553,7 @@ pwg_ppdize_name(const char *ipp,	/* I - IPP keyword */
+ 	*end;				/* End of name buffer */
+ 
+ 
+-  if (!ipp)
++  if (!ipp || !_cups_isalnum(*ipp))
+   {
+     *name = '\0';
+     return;
+@@ -5559,8 +5568,14 @@ pwg_ppdize_name(const char *ipp,	/* I - IPP keyword */
+       ipp ++;
+       *ptr++ = (char)toupper(*ipp++ & 255);
+     }
+-    else
++    else if (*ipp == '_' || *ipp == '.' || *ipp == '-' || _cups_isalnum(*ipp))
++    {
+       *ptr++ = *ipp++;
++    }
++    else
++    {
++      ipp ++;
++    }
+   }
+ 
+   *ptr = '\0';
+-- 
+2.47.0.rc0.windows.1
+

--- a/app-admin/cups/autobuild/patches/0005-Quote-PPD-localized-strings.patch
+++ b/app-admin/cups/autobuild/patches/0005-Quote-PPD-localized-strings.patch
@@ -1,0 +1,246 @@
+From 83ac2dd7896b0fbab39a7fdd44fd6323e3b96436 Mon Sep 17 00:00:00 2001
+From: Michael R Sweet <msweet@msweet.org>
+Date: Mon, 23 Sep 2024 09:36:39 -0400
+Subject: [PATCH 4/5] Quote PPD localized strings.
+
+---
+ cups/ppd-cache.c | 93 +++++++++++++++++++++++++++---------------------
+ 1 file changed, 53 insertions(+), 40 deletions(-)
+
+diff --git a/cups/ppd-cache.c b/cups/ppd-cache.c
+index 53c22be0..f425ac01 100644
+--- a/cups/ppd-cache.c
++++ b/cups/ppd-cache.c
+@@ -32,6 +32,7 @@
+ static int	cups_connect(http_t **http, const char *url, char *resource, size_t ressize);
+ static int	cups_get_url(http_t **http, const char *url, char *name, size_t namesize);
+ static const char *ppd_inputslot_for_keyword(_ppd_cache_t *pc, const char *keyword);
++static void	ppd_put_string(cups_file_t *fp, cups_lang_t *lang, cups_array_t *strings, const char *ppd_option, const char *ppd_choice, const char *pwg_msgid);
+ static void	pwg_add_finishing(cups_array_t *finishings, ipp_finishings_t template, const char *name, const char *value);
+ static void	pwg_add_message(cups_array_t *a, const char *msg, const char *str);
+ static int	pwg_compare_finishings(_pwg_finishings_t *a, _pwg_finishings_t *b);
+@@ -3394,7 +3395,7 @@ _ppdCreateFromIPP2(
+   if ((attr = ippFindAttribute(supported, "printer-charge-info-uri", IPP_TAG_URI)) != NULL && ippValidateAttribute(attr))
+     cupsFilePrintf(fp, "*cupsChargeInfoURI: \"%s\"\n", ippGetString(attr, 0, NULL));
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-strings-uri", IPP_TAG_URI)) != NULL)
++  if ((attr = ippFindAttribute(supported, "printer-strings-uri", IPP_TAG_URI)) != NULL && ippValidateAttribute(attr))
+   {
+     http_t	*http = NULL;		/* Connection to printer */
+     char	stringsfile[1024];	/* Temporary strings file */
+@@ -3438,7 +3439,7 @@ _ppdCreateFromIPP2(
+ 
+ 	  response = cupsDoRequest(http, request, resource);
+ 
+-	  if ((attr = ippFindAttribute(response, "printer-strings-uri", IPP_TAG_URI)) != NULL)
++	  if ((attr = ippFindAttribute(response, "printer-strings-uri", IPP_TAG_URI)) != NULL && ippValidateAttribute(attr))
+ 	    cupsFilePrintf(fp, "*cupsStringsURI %s: \"%s\"\n", keyword, ippGetString(attr, 0, NULL));
+ 
+ 	  ippDelete(response);
+@@ -4044,18 +4045,16 @@ _ppdCreateFromIPP2(
+ 	cupsFilePrintf(fp, "*DefaultInputSlot: %s\n", ppdname);
+ 
+       for (j = 0; j < (int)(sizeof(sources) / sizeof(sources[0])); j ++)
++      {
+         if (!strcmp(sources[j], keyword))
+ 	{
+ 	  snprintf(msgid, sizeof(msgid), "media-source.%s", keyword);
+ 
+-	  if ((msgstr = _cupsLangString(lang, msgid)) == msgid || !strcmp(msgid, msgstr))
+-	    if ((msgstr = _cupsMessageLookup(strings, msgid)) == msgid)
+-	      msgstr = keyword;
+-
+ 	  cupsFilePrintf(fp, "*InputSlot %s: \"<</MediaPosition %d>>setpagedevice\"\n", ppdname, j);
+-	  cupsFilePrintf(fp, "*%s.InputSlot %s/%s: \"\"\n", lang->language, ppdname, msgstr);
++	  ppd_put_string(fp, lang, strings, "InputSlot", ppdname, msgid);
+ 	  break;
+ 	}
++      }
+     }
+     cupsFilePuts(fp, "*CloseUI: *InputSlot\n");
+   }
+@@ -4081,12 +4080,9 @@ _ppdCreateFromIPP2(
+       pwg_ppdize_name(keyword, ppdname, sizeof(ppdname));
+ 
+       snprintf(msgid, sizeof(msgid), "media-type.%s", keyword);
+-      if ((msgstr = _cupsLangString(lang, msgid)) == msgid || !strcmp(msgid, msgstr))
+-	if ((msgstr = _cupsMessageLookup(strings, msgid)) == msgid)
+-	  msgstr = keyword;
+ 
+       cupsFilePrintf(fp, "*MediaType %s: \"<</MediaType(%s)>>setpagedevice\"\n", ppdname, ppdname);
+-      cupsFilePrintf(fp, "*%s.MediaType %s/%s: \"\"\n", lang->language, ppdname, msgstr);
++      ppd_put_string(fp, lang, strings, "MediaType", ppdname, msgid);
+     }
+     cupsFilePuts(fp, "*CloseUI: *MediaType\n");
+   }
+@@ -4547,12 +4543,9 @@ _ppdCreateFromIPP2(
+       pwg_ppdize_name(keyword, ppdname, sizeof(ppdname));
+ 
+       snprintf(msgid, sizeof(msgid), "output-bin.%s", keyword);
+-      if ((msgstr = _cupsLangString(lang, msgid)) == msgid || !strcmp(msgid, msgstr))
+-	if ((msgstr = _cupsMessageLookup(strings, msgid)) == msgid)
+-	  msgstr = keyword;
+ 
+       cupsFilePrintf(fp, "*OutputBin %s: \"\"\n", ppdname);
+-      cupsFilePrintf(fp, "*%s.OutputBin %s/%s: \"\"\n", lang->language, ppdname, msgstr);
++      ppd_put_string(fp, lang, strings, "OutputBin", ppdname, msgid);
+ 
+       if ((tray_ptr = ippGetOctetString(trays, i, &tray_len)) != NULL)
+       {
+@@ -4671,9 +4664,6 @@ _ppdCreateFromIPP2(
+         cupsArrayAdd(names, (char *)keyword);
+ 
+ 	snprintf(msgid, sizeof(msgid), "finishings.%d", value);
+-	if ((msgstr = _cupsLangString(lang, msgid)) == msgid || !strcmp(msgid, msgstr))
+-	  if ((msgstr = _cupsMessageLookup(strings, msgid)) == msgid)
+-	    msgstr = keyword;
+ 
+         if (value >= IPP_FINISHINGS_NONE && value <= IPP_FINISHINGS_LAMINATE)
+           ppd_keyword = base_keywords[value - IPP_FINISHINGS_NONE];
+@@ -4688,7 +4678,7 @@ _ppdCreateFromIPP2(
+           continue;
+ 
+ 	cupsFilePrintf(fp, "*StapleLocation %s: \"\"\n", ppd_keyword);
+-	cupsFilePrintf(fp, "*%s.StapleLocation %s/%s: \"\"\n", lang->language, ppd_keyword, msgstr);
++	ppd_put_string(fp, lang, strings, "StapleLocation", ppd_keyword, msgid);
+ 	cupsFilePrintf(fp, "*cupsIPPFinishings %d/%s: \"*StapleLocation %s\"\n", value, keyword, ppd_keyword);
+       }
+ 
+@@ -4751,9 +4741,6 @@ _ppdCreateFromIPP2(
+         cupsArrayAdd(names, (char *)keyword);
+ 
+ 	snprintf(msgid, sizeof(msgid), "finishings.%d", value);
+-	if ((msgstr = _cupsLangString(lang, msgid)) == msgid || !strcmp(msgid, msgstr))
+-	  if ((msgstr = _cupsMessageLookup(strings, msgid)) == msgid)
+-	    msgstr = keyword;
+ 
+         if (value >= IPP_FINISHINGS_NONE && value <= IPP_FINISHINGS_LAMINATE)
+           ppd_keyword = base_keywords[value - IPP_FINISHINGS_NONE];
+@@ -4768,7 +4755,7 @@ _ppdCreateFromIPP2(
+           continue;
+ 
+ 	cupsFilePrintf(fp, "*FoldType %s: \"\"\n", ppd_keyword);
+-	cupsFilePrintf(fp, "*%s.FoldType %s/%s: \"\"\n", lang->language, ppd_keyword, msgstr);
++	ppd_put_string(fp, lang, strings, "FoldType", ppd_keyword, msgid);
+ 	cupsFilePrintf(fp, "*cupsIPPFinishings %d/%s: \"*FoldType %s\"\n", value, keyword, ppd_keyword);
+       }
+ 
+@@ -4839,9 +4826,6 @@ _ppdCreateFromIPP2(
+         cupsArrayAdd(names, (char *)keyword);
+ 
+ 	snprintf(msgid, sizeof(msgid), "finishings.%d", value);
+-	if ((msgstr = _cupsLangString(lang, msgid)) == msgid || !strcmp(msgid, msgstr))
+-	  if ((msgstr = _cupsMessageLookup(strings, msgid)) == msgid)
+-	    msgstr = keyword;
+ 
+         if (value >= IPP_FINISHINGS_NONE && value <= IPP_FINISHINGS_LAMINATE)
+           ppd_keyword = base_keywords[value - IPP_FINISHINGS_NONE];
+@@ -4856,7 +4840,7 @@ _ppdCreateFromIPP2(
+           continue;
+ 
+ 	cupsFilePrintf(fp, "*PunchMedia %s: \"\"\n", ppd_keyword);
+-	cupsFilePrintf(fp, "*%s.PunchMedia %s/%s: \"\"\n", lang->language, ppd_keyword, msgstr);
++	ppd_put_string(fp, lang, strings, "PunchMedia", ppd_keyword, msgid);
+ 	cupsFilePrintf(fp, "*cupsIPPFinishings %d/%s: \"*PunchMedia %s\"\n", value, keyword, ppd_keyword);
+       }
+ 
+@@ -4927,9 +4911,6 @@ _ppdCreateFromIPP2(
+         cupsArrayAdd(names, (char *)keyword);
+ 
+ 	snprintf(msgid, sizeof(msgid), "finishings.%d", value);
+-	if ((msgstr = _cupsLangString(lang, msgid)) == msgid || !strcmp(msgid, msgstr))
+-	  if ((msgstr = _cupsMessageLookup(strings, msgid)) == msgid)
+-	    msgstr = keyword;
+ 
+         if (value == IPP_FINISHINGS_TRIM)
+           ppd_keyword = "Auto";
+@@ -4937,7 +4918,7 @@ _ppdCreateFromIPP2(
+ 	  ppd_keyword = trim_keywords[value - IPP_FINISHINGS_TRIM_AFTER_PAGES];
+ 
+ 	cupsFilePrintf(fp, "*CutMedia %s: \"\"\n", ppd_keyword);
+-	cupsFilePrintf(fp, "*%s.CutMedia %s/%s: \"\"\n", lang->language, ppd_keyword, msgstr);
++	ppd_put_string(fp, lang, strings, "CutMedia", ppd_keyword, msgid);
+ 	cupsFilePrintf(fp, "*cupsIPPFinishings %d/%s: \"*CutMedia %s\"\n", value, keyword, ppd_keyword);
+       }
+ 
+@@ -4979,9 +4960,6 @@ _ppdCreateFromIPP2(
+       pwg_ppdize_name(keyword, ppdname, sizeof(ppdname));
+ 
+       snprintf(msgid, sizeof(msgid), "finishing-template.%s", keyword);
+-      if ((msgstr = _cupsLangString(lang, msgid)) == msgid || !strcmp(msgid, msgstr))
+-	if ((msgstr = _cupsMessageLookup(strings, msgid)) == msgid)
+-	  msgstr = keyword;
+ 
+       cupsFilePrintf(fp, "*cupsFinishingTemplate %s: \"\n", ppdname);
+       for (finishing_attr = ippFirstAttribute(finishing_col); finishing_attr; finishing_attr = ippNextAttribute(finishing_col))
+@@ -4996,7 +4974,7 @@ _ppdCreateFromIPP2(
+ 	}
+       }
+       cupsFilePuts(fp, "\"\n");
+-      cupsFilePrintf(fp, "*%s.cupsFinishingTemplate %s/%s: \"\"\n", lang->language, ppdname, msgstr);
++      ppd_put_string(fp, lang, strings, "cupsFinishingTemplate", ppdname, msgid);
+       cupsFilePuts(fp, "*End\n");
+     }
+ 
+@@ -5165,11 +5143,9 @@ _ppdCreateFromIPP2(
+ 
+       cupsFilePuts(fp, "\"\n*End\n");
+ 
+-      if ((localized_name = _cupsMessageLookup(strings, preset_name)) != preset_name)
+-      {
+-        pwg_ppdize_name(preset_name, ppdname, sizeof(ppdname));
+-        cupsFilePrintf(fp, "*%s.APPrinterPreset %s/%s: \"\"\n", lang->language, ppdname, localized_name);
+-      }
++      snprintf(msgid, sizeof(msgid), "preset-name.%s", preset_name);
++      pwg_ppdize_name(preset_name, ppdname, sizeof(ppdname));
++      ppd_put_string(fp, lang, strings, "APPrinterPreset", ppdname, msgid);
+     }
+   }
+ 
+@@ -5440,6 +5416,43 @@ cups_get_url(http_t     **http,		/* IO - Current HTTP connection */
+ }
+ 
+ 
++/*
++ * 'ppd_put_strings()' - Write localization attributes to a PPD file.
++ */
++
++static void
++ppd_put_string(cups_file_t  *fp,	/* I - PPD file */
++               cups_lang_t  *lang,	/* I - Language */
++               cups_array_t *strings,	/* I - Strings */
++	       const char   *ppd_option,/* I - PPD option */
++	       const char   *ppd_choice,/* I - PPD choice */
++	       const char   *pwg_msgid)	/* I - PWG message ID */
++{
++  const char	*text;			/* Localized text */
++
++
++  if ((text = _cupsLangString(lang, pwg_msgid)) == pwg_msgid || !strcmp(pwg_msgid, text))
++  {
++    if ((text = _cupsMessageLookup(strings, pwg_msgid)) == pwg_msgid)
++      return;
++  }
++
++  // Add the first line of localized text...
++  cupsFilePrintf(fp, "*%s.%s %s/", lang->language, ppd_option, ppd_choice);
++  while (*text && *text != '\n')
++  {
++    // Escape ":" and "<"...
++    if (*text == ':' || *text == '<')
++      cupsFilePrintf(fp, "<%02X>", *text);
++    else
++      cupsFilePutChar(fp, *text);
++
++    text ++;
++  }
++  cupsFilePuts(fp, ": \"\"\n");
++}
++
++
+ /*
+  * 'pwg_add_finishing()' - Add a finishings value.
+  */
+-- 
+2.47.0.rc0.windows.1
+

--- a/app-admin/cups/autobuild/patches/0006-Fix-warnings-for-unused-vars.patch
+++ b/app-admin/cups/autobuild/patches/0006-Fix-warnings-for-unused-vars.patch
@@ -1,0 +1,37 @@
+From c4dd1c3b3edb0ef3ed20024ca97b4db1f62bf597 Mon Sep 17 00:00:00 2001
+From: Michael R Sweet <msweet@msweet.org>
+Date: Mon, 23 Sep 2024 10:11:31 -0400
+Subject: [PATCH 5/5] Fix warnings for unused vars.
+
+---
+ cups/ppd-cache.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/cups/ppd-cache.c b/cups/ppd-cache.c
+index f425ac01..d2533b73 100644
+--- a/cups/ppd-cache.c
++++ b/cups/ppd-cache.c
+@@ -3223,8 +3223,7 @@ _ppdCreateFromIPP2(
+   int			have_qdraft = 0,/* Have draft quality? */
+ 			have_qhigh = 0;	/* Have high quality? */
+   char			msgid[256];	/* Message identifier (attr.value) */
+-  const char		*keyword,	/* Keyword value */
+-			*msgstr;	/* Localized string */
++  const char		*keyword;	/* Keyword value */
+   cups_array_t		*strings = NULL;/* Printer strings file */
+   struct lconv		*loc = localeconv();
+ 					/* Locale data */
+@@ -5010,9 +5009,8 @@ _ppdCreateFromIPP2(
+     {
+       ipp_t	*preset = ippGetCollection(attr, i);
+ 					/* Preset collection */
+-      const char *preset_name = ippGetString(ippFindAttribute(preset, "preset-name", IPP_TAG_ZERO), 0, NULL),
++      const char *preset_name = ippGetString(ippFindAttribute(preset, "preset-name", IPP_TAG_ZERO), 0, NULL);
+ 					/* Preset name */
+-		*localized_name;	/* Localized preset name */
+       ipp_attribute_t *member;		/* Member attribute in preset */
+       const char *member_name;		/* Member attribute name */
+       char      	member_value[256];	/* Member attribute value */
+-- 
+2.47.0.rc0.windows.1
+

--- a/app-admin/cups/spec
+++ b/app-admin/cups/spec
@@ -1,5 +1,5 @@
 VER=2.4.10
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/OpenPrinting/cups"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=380"

--- a/runtime-doc/cups-filters/autobuild/defines
+++ b/runtime-doc/cups-filters/autobuild/defines
@@ -2,8 +2,7 @@ PKGNAME=cups-filters
 PKGDES="OpenPrinting CUPS Filters"
 PKGSEC=libs
 PKGDEP="cups libcupsfilters libppd"
-PKGRECOM="cups-browsed"
-PKGSUG="foomatic ghostscript php noto-fonts"
+PKGSUG="cups-browsed foomatic ghostscript php noto-fonts"
 BUILDDEP="ghostscript noto-fonts mupdf"
 
 ABSHADOW=0

--- a/runtime-doc/cups-filters/spec
+++ b/runtime-doc/cups-filters/spec
@@ -1,5 +1,5 @@
 VER=2.0.0
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/OpenPrinting/cups-filters"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5541"

--- a/runtime-doc/libcupsfilters/autobuild/patches/0001-cfGetPrinterAttributes5-Validate-response-attributes.patch
+++ b/runtime-doc/libcupsfilters/autobuild/patches/0001-cfGetPrinterAttributes5-Validate-response-attributes.patch
@@ -1,0 +1,36 @@
+From 95576ec3d20c109332d14672a807353cdc551018 Mon Sep 17 00:00:00 2001
+From: Zdenek Dohnal <zdohnal@redhat.com>
+Date: Thu, 26 Sep 2024 23:09:29 +0200
+Subject: [PATCH] cfGetPrinterAttributes5(): Validate response attributes
+ before return
+
+The destination can be corrupted or forged, so validate the response
+to strenghten security measures.
+
+Fixes CVE-2024-47076
+---
+ cupsfilters/ipp.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/cupsfilters/ipp.c b/cupsfilters/ipp.c
+index 8d6a9b3d..db10cb3f 100644
+--- a/cupsfilters/ipp.c
++++ b/cupsfilters/ipp.c
+@@ -404,6 +404,14 @@ cfGetPrinterAttributes5(http_t *http_printer,
+ 	    ippDelete(response2);
+ 	  }
+ 	}
++
++	// Check if the response is valid
++	if (!ippValidateAttributes(response))
++	{
++	  ippDelete(response);
++	  response = NULL;
++	}
++
+ 	if (have_http == 0) httpClose(http_printer);
+ 	if (uri) free(uri);
+ 	return (response);
+-- 
+2.46.2.windows.1
+

--- a/runtime-doc/libcupsfilters/spec
+++ b/runtime-doc/libcupsfilters/spec
@@ -1,4 +1,5 @@
 VER=2.0.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/OpenPrinting/libcupsfilters"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=327181"

--- a/runtime-doc/libppd/autobuild/patches/0001-BACKPORT-Prevent-PPD-generation-based-on-invalid-IPP.patch
+++ b/runtime-doc/libppd/autobuild/patches/0001-BACKPORT-Prevent-PPD-generation-based-on-invalid-IPP.patch
@@ -1,0 +1,602 @@
+From a80577dbb65a36482d683c5cfa8c704d52e59067 Mon Sep 17 00:00:00 2001
+From: Zdenek Dohnal <zdohnal@redhat.com>
+Date: Thu, 26 Sep 2024 23:12:14 +0200
+Subject: [PATCH] BACKPORT: Prevent PPD generation based on invalid IPP
+ response
+
+Author: Mike Sweet
+Minor fixes: Zdenek Dohnal
+
+Fixes CVE-2024-47175
+
+(cherry picked from commit d681747ebf12602cb426725eb8ce2753211e2477)
+[Kexy: Resolved minor conflict in ppd/ppd-generator.c]
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ ppd/ppd-cache.c     |  17 ++-
+ ppd/ppd-generator.c | 257 ++++++++++++++++++++++++++++----------------
+ 2 files changed, 176 insertions(+), 98 deletions(-)
+
+diff --git a/ppd/ppd-cache.c b/ppd/ppd-cache.c
+index 5aa617c1..747c9ad5 100644
+--- a/ppd/ppd-cache.c
++++ b/ppd/ppd-cache.c
+@@ -1,6 +1,7 @@
+ //
+ // PPD cache implementation for libppd.
+ //
++// Copyright © 2024 by OpenPrinting
+ // Copyright © 2010-2019 by Apple Inc.
+ //
+ // Licensed under Apache License v2.0.  See the file "LICENSE" for more
+@@ -3413,7 +3414,7 @@ ppdCacheGetBin(
+ 
+   //
+   // Range check input...
+- 
++
+ 
+   if (!pc || !output_bin)
+     return (NULL);
+@@ -3914,7 +3915,7 @@ ppdCacheGetPageSize(
+       {
+ 	//
+ 	// Check not only the base size (like "A4") but also variants (like
+-        // "A4.Borderless"). We check only the margins and orientation but do 
++        // "A4.Borderless"). We check only the margins and orientation but do
+ 	// not re-check the size.
+ 	//
+ 
+@@ -4711,7 +4712,7 @@ ppdPwgPpdizeName(const char *ipp,	// I - IPP keyword
+ 	*end;				// End of name buffer
+ 
+ 
+-  if (!ipp)
++  if (!ipp || !_ppd_isalnum(*ipp))
+   {
+     *name = '\0';
+     return;
+@@ -4721,13 +4722,19 @@ ppdPwgPpdizeName(const char *ipp,	// I - IPP keyword
+ 
+   for (ptr = name + 1, end = name + namesize - 1; *ipp && ptr < end;)
+   {
+-    if (*ipp == '-' && _ppd_isalnum(ipp[1]))
++    if (*ipp == '-' && isalnum(ipp[1]))
+     {
+       ipp ++;
+       *ptr++ = (char)toupper(*ipp++ & 255);
+     }
+-    else
++    else if (*ipp == '_' || *ipp == '.' || *ipp == '-' || isalnum(*ipp))
++    {
+       *ptr++ = *ipp++;
++    }
++    else
++    {
++      ipp ++;
++    }
+   }
+ 
+   *ptr = '\0';
+diff --git a/ppd/ppd-generator.c b/ppd/ppd-generator.c
+index a815030b..011e086e 100644
+--- a/ppd/ppd-generator.c
++++ b/ppd/ppd-generator.c
+@@ -1,15 +1,16 @@
+ //
+ //   PWG Raster/Apple Raster/PCLm/PDF/IPP legacy PPD generator for libppd.
+ //
+-//   Copyright 2016-2019 by Till Kamppeter.
+-//   Copyright 2017-2019 by Sahil Arora.
+-//   Copyright 2018-2019 by Deepak Patankar.
++//   Copyright © 2024 by OpenPrinting
++//   Copyright © 2016-2019 by Till Kamppeter.
++//   Copyright © 2017-2019 by Sahil Arora.
++//   Copyright © 2018-2019 by Deepak Patankar.
+ //
+ //   The PPD generator is based on the PPD generator for the CUPS
+ //   "lpadmin -m everywhere" functionality in the cups/ppd-cache.c
+ //   file. The copyright of this file is:
+ //
+-//   Copyright 2010-2016 by Apple Inc.
++//   Copyright © 2010-2016 by Apple Inc.
+ //
+ //   Licensed under Apache License v2.0.  See the file "LICENSE" for more
+ //   information.
+@@ -51,6 +52,7 @@
+ 
+ static int	http_connect(http_t **http, const char *url, char *resource,
+ 			     size_t ressize);
++static void	ppd_put_string(cups_file_t *fp, cups_lang_t *lang, const char *ppd_option, const char *ppd_choice, const char *pwg_msgid);
+ 
+ 
+ //
+@@ -60,7 +62,7 @@ static int	http_connect(http_t **http, const char *url, char *resource,
+ // than CUPS 2.2.x. We have also an additional test and development
+ // platform for this code. Taken from cups/ppd-cache.c,
+ // cups/string-private.h, cups/string.c.
+-// 
++//
+ // The advantage of PPD generation instead of working with System V
+ // interface scripts is that the print dialogs of the clients do not
+ // need to ask the printer for its options via IPP. So we have access
+@@ -124,7 +126,7 @@ char ppdgenerator_msg[1024];
+ //                           IPP 1.x legacy)
+ //
+ 
+-char *                                             // O - PPD filename or NULL 
++char *                                             // O - PPD filename or NULL
+                                                    //     on error
+ ppdCreatePPDFromIPP(char         *buffer,          // I - Filename buffer
+ 		    size_t       bufsize,          // I - Size of filename
+@@ -175,7 +177,7 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 		     cups_array_t *conflicts,       // I - Array of
+ 						    //     constraints
+ 		     cups_array_t *sizes,           // I - Media sizes we've
+-						    //     added 
++						    //     added
+ 		     char*        default_pagesize, // I - Default page size
+ 		     const char   *default_cluster_color, // I - cluster def
+ 						    //     color (if cluster's
+@@ -187,6 +189,7 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 		     size_t       status_msg_size)  // I - Size of status
+ 						    //     message buffer
+ {
++  cups_lang_t		*lang;		// Localization language
+   cups_file_t		*fp;		// PPD file
+   cups_array_t		*printer_sizes;	// Media sizes we've added
+   cups_size_t		*size;		// Current media size
+@@ -199,9 +202,10 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+   ipp_t			*media_col,	// Media collection
+ 			*media_size;	// Media size collection
+   char			make[256],	// Make and model
+-			*model,		// Model name
++			*mptr,		// Pointer into make and model
+ 			ppdname[PPD_MAX_NAME];
+ 		    			// PPD keyword
++  const char		*model;		// Model name
+   int			i, j,		// Looping vars
+ 			count = 0,	// Number of values
+ 			bottom,		// Largest bottom margin
+@@ -283,6 +287,68 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+     return (NULL);
+   }
+ 
++  //
++  // Get a sanitized make and model...
++  //
++
++  if ((attr = ippFindAttribute(supported, "printer-make-and-model", IPP_TAG_TEXT)) != NULL && ippValidateAttribute(attr))
++  {
++    // Sanitize the model name to only contain PPD-safe characters.
++    strlcpy(make, ippGetString(attr, 0, NULL), sizeof(make));
++
++    for (mptr = make; *mptr; mptr ++)
++    {
++      if (*mptr < ' ' || *mptr >= 127 || *mptr == '\"')
++      {
++        // Truncate the make and model on the first bad character...
++	*mptr = '\0';
++	break;
++      }
++    }
++
++    while (mptr > make)
++    {
++      // Strip trailing whitespace...
++      mptr --;
++      if (*mptr == ' ')
++	*mptr = '\0';
++    }
++
++    if (!make[0])
++    {
++      // Use a default make and model if nothing remains...
++      strlcpy(make, "Unknown", sizeof(make));
++    }
++  }
++  else
++  {
++    // Use a default make and model...
++    strlcpy(make, "Unknown", sizeof(make));
++  }
++
++  if (!strncasecmp(make, "Hewlett Packard ", 16) || !strncasecmp(make, "Hewlett-Packard ", 16))
++  {
++    // Normalize HP printer make and model...
++    model = make + 16;
++    strlcpy(make, "HP", sizeof(make));
++
++    if (!strncasecmp(model, "HP ", 3))
++      model += 3;
++  }
++  else if ((mptr = strchr(make, ' ')) != NULL)
++  {
++    // Separate "MAKE MODEL"...
++    while (*mptr && *mptr == ' ')
++      *mptr++ = '\0';
++
++    model = mptr;
++  }
++  else
++  {
++    // No separate model name...
++    model = "Printer";
++  }
++
+   //
+   // Standard stuff for PPD file...
+   //
+@@ -311,25 +377,6 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+     }
+   }
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-make-and-model",
+-			       IPP_TAG_TEXT)) != NULL)
+-    strlcpy(make, ippGetString(attr, 0, NULL), sizeof(make));
+-  else if (make_model && make_model[0] != '\0')
+-    strlcpy(make, make_model, sizeof(make));
+-  else
+-    strlcpy(make, "Unknown Printer", sizeof(make));
+-
+-  if (!strncasecmp(make, "Hewlett Packard ", 16) ||
+-      !strncasecmp(make, "Hewlett-Packard ", 16))
+-  {
+-    model = make + 16;
+-    strlcpy(make, "HP", sizeof(make));
+-  }
+-  else if ((model = strchr(make, ' ')) != NULL)
+-    *model++ = '\0';
+-  else
+-    model = make;
+-
+   cupsFilePrintf(fp, "*Manufacturer: \"%s\"\n", make);
+   cupsFilePrintf(fp, "*ModelName: \"%s %s\"\n", make, model);
+   cupsFilePrintf(fp, "*Product: \"(%s %s)\"\n", make, model);
+@@ -425,21 +472,19 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+   }
+   cupsFilePuts(fp, "\"\n");
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-more-info", IPP_TAG_URI)) !=
+-      NULL)
++  if ((attr = ippFindAttribute(supported, "printer-more-info", IPP_TAG_URI)) != NULL && ippValidateAttribute(attr))
+     cupsFilePrintf(fp, "*APSupplies: \"%s\"\n", ippGetString(attr, 0, NULL));
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-charge-info-uri",
+-			       IPP_TAG_URI)) != NULL)
+-    cupsFilePrintf(fp, "*cupsChargeInfoURI: \"%s\"\n", ippGetString(attr, 0,
+-								    NULL));
++  if ((attr = ippFindAttribute(supported, "printer-charge-info-uri", IPP_TAG_URI)) != NULL && ippValidateAttribute(attr))
++    cupsFilePrintf(fp, "*cupsChargeInfoURI: \"%s\"\n", ippGetString(attr, 0, NULL));
+ 
+   // Message catalogs for UI strings
++  lang = cupsLangDefault();
+   opt_strings_catalog = cfCatalogOptionArrayNew();
+   cfCatalogLoad(NULL, NULL, opt_strings_catalog);
+ 
+   if ((attr = ippFindAttribute(supported, "printer-strings-uri",
+-			       IPP_TAG_URI)) != NULL)
++			       IPP_TAG_URI)) != NULL && ippValidateAttribute(attr))
+   {
+     printer_opt_strings_catalog = cfCatalogOptionArrayNew();
+     cfCatalogLoad(ippGetString(attr, 0, NULL), NULL,
+@@ -492,7 +537,7 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 	  response = cupsDoRequest(http, request, resource);
+ 
+ 	  if ((attr = ippFindAttribute(response, "printer-strings-uri",
+-				       IPP_TAG_URI)) != NULL)
++				       IPP_TAG_URI)) != NULL && ippValidateAttribute(attr))
+ 	    cupsFilePrintf(fp, "*cupsStringsURI %s: \"%s\"\n", keyword,
+ 			   ippGetString(attr, 0, NULL));
+ 
+@@ -518,13 +563,10 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 				     IPP_TAG_BOOLEAN), 0))
+     cupsFilePuts(fp, "*cupsJobAccountingUserId: True\n");
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-privacy-policy-uri",
+-			       IPP_TAG_URI)) != NULL)
+-    cupsFilePrintf(fp, "*cupsPrivacyURI: \"%s\"\n",
+-		   ippGetString(attr, 0, NULL));
++  if ((attr = ippFindAttribute(supported, "printer-privacy-policy-uri", IPP_TAG_URI)) != NULL && ippValidateAttribute(attr))
++    cupsFilePrintf(fp, "*cupsPrivacyURI: \"%s\"\n", ippGetString(attr, 0, NULL));
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-mandatory-job-attributes",
+-			       IPP_TAG_KEYWORD)) != NULL)
++  if ((attr = ippFindAttribute(supported, "printer-mandatory-job-attributes", IPP_TAG_KEYWORD)) != NULL && ippValidateAttribute(attr))
+   {
+     char	prefix = '\"';		// Prefix for string
+ 
+@@ -544,8 +586,7 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+     cupsFilePuts(fp, "\"\n");
+   }
+ 
+-  if ((attr = ippFindAttribute(supported, "printer-requested-job-attributes",
+-			       IPP_TAG_KEYWORD)) != NULL)
++  if ((attr = ippFindAttribute(supported, "printer-requested-job-attributes", IPP_TAG_KEYWORD)) != NULL && ippValidateAttribute(attr))
+   {
+     char	prefix = '\"';		// Prefix for string
+ 
+@@ -664,7 +705,7 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+   }
+ 
+   //
+-  // Fax 
++  // Fax
+   //
+ 
+   if (is_fax)
+@@ -705,21 +746,21 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ #ifdef CUPS_RASTER_HAVE_APPLERASTER
+   else if (cupsArrayFind(pdl_list, "image/urf"))
+   {
+-    int resStore = 0; // Variable for storing the no. of resolutions in the resolution array 
++    int resStore = 0; // Variable for storing the no. of resolutions in the resolution array
+     int resArray[__INT16_MAX__]; // Creating a resolution array supporting a maximum of 32767 resolutions.
+     int lowdpi = 0, middpi = 0, hidpi = 0; // Lower , middle and higher resolution
+     if ((attr = ippFindAttribute(supported, "urf-supported",
+ 			IPP_TAG_KEYWORD)) != NULL)
+     {
+       for (int i = 0, count = ippGetCount(attr); i < count; i ++)
+-      {  
++      {
+        	const char *rs = ippGetString(attr, i, NULL); // RS values
+-        const char *rsCopy = ippGetString(attr, i, NULL); // RS values(copy) 
++        const char *rsCopy = ippGetString(attr, i, NULL); // RS values(copy)
+ 	if (strncasecmp(rs, "RS", 2)) // Comparing attributes to have RS in
+ 	                              // the beginning to indicate the
+ 	                              // resolution feature
+ 	  continue;
+-        int resCount = 0; // Using a count variable which can be reset 
++        int resCount = 0; // Using a count variable which can be reset
+         while (*rsCopy != '\0') // Parsing through the copy pointer to
+ 	                        // determine the no. of resolutions
+         {
+@@ -817,7 +858,7 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 	    formatfound = 1;
+ 	    is_apple = 1;
+ 	  }
+-        } 
++        }
+       }
+     }
+   }
+@@ -909,7 +950,7 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+   if (manual_copies == 1)
+     cupsFilePuts(fp, "*cupsManualCopies: True\n");
+ 
+-  // No resolution requirements by any of the supported PDLs? 
++  // No resolution requirements by any of the supported PDLs?
+   // Use "printer-resolution-supported" attribute
+   if (common_res == NULL)
+   {
+@@ -1027,7 +1068,7 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+   //
+   // PageSize/PageRegion/ImageableArea/PaperDimension
+   //
+- 
++
+   cfGenerateSizes(supported, CF_GEN_SIZES_DEFAULT, &printer_sizes, &defattr,
+ 		  NULL, NULL, NULL, NULL, NULL, NULL,
+ 		  &min_width, &min_length,
+@@ -1406,15 +1447,15 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+         if (!strcmp(sources[j], keyword))
+ 	  break;
+       if (j >= 0)
+-	cupsFilePrintf(fp, "*InputSlot %s%s%s: \"<</MediaPosition %d>>setpagedevice\"\n",
+-		       ppdname,
+-		       (human_readable ? "/" : ""),
+-		       (human_readable ? human_readable : ""), j);
++      {
++	cupsFilePrintf(fp, "*InputSlot %s: \"<</MediaPosition %d>>setpagedevice\"\n", ppdname, j);
++	ppd_put_string(fp, lang, "InputSlot", ppdname, human_readable);
++      }
+       else
+-	cupsFilePrintf(fp, "*InputSlot %s%s%s: \"\"\n",
+-		       ppdname,
+-		       (human_readable ? "/" : ""),
+-		       (human_readable ? human_readable : ""));
++      {
++	cupsFilePrintf(fp, "*InputSlot %s%s%s:\"\"\n", ppdname, human_readable ? "/" : "", human_readable ? human_readable : "");
++	ppd_put_string(fp, lang, "InputSlot", ppdname, human_readable);
++      }
+     }
+     cupsFilePuts(fp, "*CloseUI: *InputSlot\n");
+   }
+@@ -1449,11 +1490,8 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+       human_readable = cfCatalogLookUpChoice((char *)keyword, "media-type",
+ 					     opt_strings_catalog,
+ 					     printer_opt_strings_catalog);
+-      cupsFilePrintf(fp, "*MediaType %s%s%s: \"<</MediaType(%s)>>setpagedevice\"\n",
+-		     ppdname,
+-		     (human_readable ? "/" : ""),
+-		     (human_readable ? human_readable : ""),
+-		     ppdname);
++      cupsFilePrintf(fp, "*MediaType %s: \"<</MediaType(%s)>>setpagedevice\"\n", ppdname, ppdname);
++      ppd_put_string(fp, lang, "MediaType", ppdname, human_readable);
+     }
+     cupsFilePuts(fp, "*CloseUI: *MediaType\n");
+   }
+@@ -1776,10 +1814,8 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+       human_readable = cfCatalogLookUpChoice((char *)keyword, "output-bin",
+ 					     opt_strings_catalog,
+ 					     printer_opt_strings_catalog);
+-      cupsFilePrintf(fp, "*OutputBin %s%s%s: \"\"\n",
+-		     ppdname,
+-		     (human_readable ? "/" : ""),
+-		     (human_readable ? human_readable : ""));
++      cupsFilePrintf(fp, "*OutputBin %s: \"\"\n", ppdname);
++      ppd_put_string(fp, lang, "OutputBin", ppdname, human_readable);
+       outputorderinfofound = 0;
+       faceupdown = 1;
+       firsttolast = 1;
+@@ -1833,7 +1869,7 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 
+   //
+   // Finishing options...
+-  // 
++  //
+ 
+   if ((attr = ippFindAttribute(supported, "finishings-supported",
+ 			       IPP_TAG_ENUM)) != NULL)
+@@ -1958,9 +1994,8 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 	human_readable = cfCatalogLookUpChoice(buf, "finishings",
+ 					       opt_strings_catalog,
+ 					       printer_opt_strings_catalog);
+-	cupsFilePrintf(fp, "*StapleLocation %s%s%s: \"\"\n", ppd_keyword,
+-		       (human_readable ? "/" : ""),
+-		       (human_readable ? human_readable : ""));
++	cupsFilePrintf(fp, "*StapleLocation %s: \"\"\n", ppd_keyword);
++	ppd_put_string(fp, lang, "StapleLocation", ppd_keyword, human_readable);
+ 	cupsFilePrintf(fp, "*cupsIPPFinishings %d/%s: \"*StapleLocation %s\"\n",
+ 		       value, keyword, ppd_keyword);
+       }
+@@ -2050,9 +2085,8 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 	human_readable = cfCatalogLookUpChoice(buf, "finishings",
+ 					       opt_strings_catalog,
+ 					       printer_opt_strings_catalog);
+-	cupsFilePrintf(fp, "*FoldType %s%s%s: \"\"\n", ppd_keyword,
+-		       (human_readable ? "/" : ""),
+-		       (human_readable ? human_readable : ""));
++	cupsFilePrintf(fp, "*FoldType %s: \"\"\n", ppd_keyword);
++	ppd_put_string(fp, lang, "FoldType", ppd_keyword, human_readable);
+ 	cupsFilePrintf(fp, "*cupsIPPFinishings %d/%s: \"*FoldType %s\"\n",
+ 		       value, keyword, ppd_keyword);
+       }
+@@ -2149,9 +2183,8 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 	human_readable = cfCatalogLookUpChoice(buf, "finishings",
+ 					       opt_strings_catalog,
+ 					       printer_opt_strings_catalog);
+-	cupsFilePrintf(fp, "*PunchMedia %s%s%s: \"\"\n", ppd_keyword,
+-		       (human_readable ? "/" : ""),
+-		       (human_readable ? human_readable : ""));
++	cupsFilePrintf(fp, "*PunchMedia %s: \"\"\n", ppd_keyword);
++	ppd_put_string(fp, lang, "PunchMedia", ppd_keyword, human_readable);
+ 	cupsFilePrintf(fp, "*cupsIPPFinishings %d/%s: \"*PunchMedia %s\"\n",
+ 		       value, keyword, ppd_keyword);
+       }
+@@ -2242,9 +2275,8 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 	human_readable = cfCatalogLookUpChoice(buf, "finishings",
+ 					       opt_strings_catalog,
+ 					       printer_opt_strings_catalog);
+-	cupsFilePrintf(fp, "*CutMedia %s%s%s: \"\"\n", ppd_keyword,
+-		       (human_readable ? "/" : ""),
+-		       (human_readable ? human_readable : ""));
++	cupsFilePrintf(fp, "*CutMedia %s: \"\"\n", ppd_keyword);
++	ppd_put_string(fp, lang, "CutMedia", ppd_keyword, human_readable);
+ 	cupsFilePrintf(fp, "*cupsIPPFinishings %d/%s: \"*CutMedia %s\"\n",
+ 		       value, keyword, ppd_keyword);
+       }
+@@ -2268,7 +2300,7 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+     cupsFilePrintf(fp, "*OpenUI *cupsFinishingTemplate/%s: PickOne\n",
+ 		   (human_readable ? human_readable : "Finishing Template"));
+     cupsFilePuts(fp, "*OrderDependency: 10 AnySetup *cupsFinishingTemplate\n");
+-    cupsFilePuts(fp, "*DefaultcupsFinishingTemplate: none\n");
++    cupsFilePuts(fp, "*DefaultcupsFinishingTemplate: None\n");
+     human_readable = cfCatalogLookUpChoice("3", "finishings",
+ 					   opt_strings_catalog,
+ 					   printer_opt_strings_catalog);
+@@ -2299,8 +2331,9 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 					     printer_opt_strings_catalog);
+       if (human_readable == NULL)
+ 	human_readable = (char *)keyword;
+-      cupsFilePrintf(fp, "*cupsFinishingTemplate %s/%s: \"\n", keyword,
+-		     human_readable);
++      ppdPwgPpdizeName(keyword, ppdname, sizeof(ppdname));
++      cupsFilePrintf(fp, "*cupsFinishingTemplate %s: \"\n", ppdname);
++      ppd_put_string(fp, lang, "cupsFinishingTemplate", ppdname, human_readable);
+       for (finishing_attr = ippFirstAttribute(finishing_col); finishing_attr;
+ 	   finishing_attr = ippNextAttribute(finishing_col)) {
+         if (ippGetValueTag(finishing_attr) == IPP_TAG_BEGIN_COLLECTION) {
+@@ -2564,14 +2597,14 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+       if (!preset || !preset_name)
+         continue;
+ 
+-      if ((localized_name =
++      ppdPwgPpdizeName(preset_name, ppdname, sizeof(ppdname));
++
++      localized_name =
+ 	   cfCatalogLookUpOption((char *)preset_name,
+ 				 opt_strings_catalog,
+-				 printer_opt_strings_catalog)) == NULL)
+-        cupsFilePrintf(fp, "*APPrinterPreset %s: \"\n", preset_name);
+-      else
+-        cupsFilePrintf(fp, "*APPrinterPreset %s/%s: \"\n", preset_name,
+-		       localized_name);
++				 printer_opt_strings_catalog);
++      cupsFilePrintf(fp, "*APPrinterPreset %s: \"\n", ppdname);
++      ppd_put_string(fp, lang, "APPrinterPreset", ppdname, localized_name);
+ 
+       for (member = ippFirstAttribute(preset); member;
+ 	   member = ippNextAttribute(preset))
+@@ -2620,7 +2653,10 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 		 ippGetString(ippFindAttribute(fin_col,
+ 					       "finishing-template",
+ 					       IPP_TAG_ZERO), 0, NULL)) != NULL)
+-              cupsFilePrintf(fp, "*cupsFinishingTemplate %s\n", keyword);
++            {
++	      ppdPwgPpdizeName(keyword, ppdname, sizeof(ppdname));
++              cupsFilePrintf(fp, "*cupsFinishingTemplate %s\n", ppdname);
++            }
+           }
+         }
+ 	else if (!strcmp(member_name, "media"))
+@@ -2659,7 +2695,7 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 				      NULL)) != NULL)
+ 	  {
+             ppdPwgPpdizeName(keyword, ppdname, sizeof(ppdname));
+-            cupsFilePrintf(fp, "*InputSlot %s\n", keyword);
++            cupsFilePrintf(fp, "*InputSlot %s\n", ppdname);
+ 	  }
+ 
+           if ((keyword = ippGetString(ippFindAttribute(media_col, "media-type",
+@@ -2667,7 +2703,7 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
+ 				      NULL)) != NULL)
+ 	  {
+             ppdPwgPpdizeName(keyword, ppdname, sizeof(ppdname));
+-            cupsFilePrintf(fp, "*MediaType %s\n", keyword);
++            cupsFilePrintf(fp, "*MediaType %s\n", ppdname);
+ 	  }
+         }
+ 	else if (!strcmp(member_name, "print-quality"))
+@@ -2817,3 +2853,38 @@ http_connect(http_t     **http,		// IO - Current HTTP connection
+ 
+   return (*http != NULL);
+ }
++
++
++/*
++ * 'ppd_put_strings()' - Write localization attributes to a PPD file.
++ */
++
++static void
++ppd_put_string(cups_file_t  *fp,	/* I - PPD file */
++               cups_lang_t  *lang,	/* I - Language */
++	       const char   *ppd_option,/* I - PPD option */
++	       const char   *ppd_choice,/* I - PPD choice */
++	       const char   *text)	/* I - Localized text */
++{
++  if (!text)
++    return;
++
++  // Add the first line of localized text...
++#if CUPS_VERSION_MAJOR > 2
++  cupsFilePrintf(fp, "*%s.%s %s/", cupsLangGetName(lang), ppd_option, ppd_choice);
++#else
++  cupsFilePrintf(fp, "*%s.%s %s/", lang->language, ppd_option, ppd_choice);
++#endif // CUPS_VERSION_MAJOR > 2
++
++  while (*text && *text != '\n')
++  {
++    // Escape ":" and "<"...
++    if (*text == ':' || *text == '<')
++      cupsFilePrintf(fp, "<%02X>", *text);
++    else
++      cupsFilePutChar(fp, *text);
++
++    text ++;
++  }
++  cupsFilePuts(fp, ": \"\"\n");
++}
+-- 
+2.46.2.windows.1
+

--- a/runtime-doc/libppd/spec
+++ b/runtime-doc/libppd/spec
@@ -1,4 +1,5 @@
 VER=2.0.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/OpenPrinting/libppd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328127"


### PR DESCRIPTION
Topic Description
-----------------

- cups: add fixes in USN-7041-1
- libppd: fix CVE-2024-47175 (GHSA-7xfx-47qg-grp6)
- libcupsfilters: fix CVE-2024-47076 (GHSA-w63j-6g73-wmg5)
- cups-browsed: update to 2.0.1 plus a security patch
    - Works around CVE-2024-47176 (GHSA-rj88-6mr5-rcw8).

Package(s) Affected
-------------------

- cups: 2.4.10-2
- cups-browsed: 2.0.1
- libcupsfilters: 2.0.0-1
- libppd: 2.0.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cups-browsed libcupsfilters libppd cups
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
