### PR TITLE
git: update to 2.47.0

### DIFF
--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -4,8 +4,8 @@ VER=2.47.0
 #SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 
 # Use this for RC releases.
-RC=0
+RC=1
 SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
 
-CHKSUMS="sha256::45f093fea7f2d3189db5da62569e74579553dbc2295217126cf6944bb6699a2e"
+CHKSUMS="sha256::05f6c0e4f34878ccaef329317a3f9de7d6ea4c84970cb9cdbad4a69656bc44b1"
 CHKUPDATE="anitya::id=5350"

--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,4 +1,11 @@
-VER=2.46.2
-SRCS="https://www.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
-CHKSUMS="sha256::65c5689fd44f1d09de7fd8c44de7fef074ddd69dda8b8503d44afb91495ecbce"
+VER=2.47.0
+
+# Use this for stable releases.
+#SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
+
+# Use this for RC releases.
+RC=0
+SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
+
+CHKSUMS="sha256::45f093fea7f2d3189db5da62569e74579553dbc2295217126cf6944bb6699a2e"
 CHKUPDATE="anitya::id=5350"

--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,11 +1,11 @@
 VER=2.47.0
 
 # Use this for stable releases.
-#SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
+SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 
 # Use this for RC releases.
-RC=1
-SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
+#RC=1
+#SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
 
-CHKSUMS="sha256::05f6c0e4f34878ccaef329317a3f9de7d6ea4c84970cb9cdbad4a69656bc44b1"
+CHKSUMS="sha256::a84a7917e0ab608312834413f01fc01edc7844f9f9002ba69f3b4f4bcb8d937a"
 CHKUPDATE="anitya::id=5350"


### PR DESCRIPTION
Topic Description
-----------------

- git: update to 2.47.0
- git: update to 2.47.0-rc1
- git: update to 2.47.0-rc0

Package(s) Affected
-------------------

- git: 2.47.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
