### PR TITLE
plasma-default-settings: update to 2024.09.3

### DIFF
--- a/runtime-data/plasma-default-settings/spec
+++ b/runtime-data/plasma-default-settings/spec
@@ -1,4 +1,4 @@
-VER=2024.09.2
+VER=2024.09.3
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-default-settings"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=362934"


### PR DESCRIPTION
Topic Description
-----------------

- plasma-default-settings: update to 2024.09.3
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- plasma-default-settings: 1:2024.09.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit plasma-default-settings
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
