### PR TITLE
wine: bump bundled wine-mono to 9.3.0

### DIFF
--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,5 +1,5 @@
 __GECKO_VER=2.47.4
-__MONO_VER=9.2.0
+__MONO_VER=9.3.0
 UPSTREAM_VER=9.17
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER:0:1}.x/wine-${UPSTREAM_VER}.tar.xz \
@@ -11,6 +11,6 @@ CHKSUMS="sha256::3edb7eb6f31bb5c3f7378dd5623da9d95f7d4d6d7c8378afd89c8e3a30aa080
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \
-         sha256::59b35dfe525f32c581884b6c7865496e13b3cd200c5ed267c43fb4663e0cd757"
+         sha256::c23deb9e3217a574f242b78d74cb94c4948a37d1f2715941b803a02e535854a6"
 CHKUPDATE="anitya::id=15657"
 SUBDIR="wine-${UPSTREAM_VER}"


### PR DESCRIPTION
Topic Description
-----------------

- wine: bump mono to 9.3.0
    According to the Wine wiki [1], Wine 9.17 requires Wine-Mono 9.3.0, but
    we still bundle 9.2.0.
    Bump the version of wine-mono to 9.3.0.
    [1] https://gitlab.winehq.org/wine/wine/-/wikis/Wine-Mono
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- wine: 3:9.17+gecko2.47.4+mono9.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
