### PR TITLE
tilda: update to 2.0.0

### DIFF
--- a/app-utils/tilda/spec
+++ b/app-utils/tilda/spec
@@ -1,5 +1,4 @@
-VER=1.4.1
-REL=1
-SRCS="tbl::https://github.com/lanoxx/tilda/archive/tilda-$VER.tar.gz"
-CHKSUMS="sha256::da51002210d8fd8fe875907f84b581515399545800044a669c1933bc84cf5070"
+VER=2.0.0
+SRCS="git::commit=tags/tilda-$VER::https://github.com/lanoxx/tilda"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8340"


### PR DESCRIPTION
Topic Description
-----------------

- tilda: update to 2.0.0
- wine: bump mono to 9.3.0
    According to the Wine wiki [1], Wine 9.17 requires Wine-Mono 9.3.0, but
    we still bundle 9.2.0.
    Bump the version of wine-mono to 9.3.0.
    [1] https://gitlab.winehq.org/wine/wine/-/wikis/Wine-Mono
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- tilda: 2.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit tilda
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
