### PR TITLE
libvpl: update to 2.13.0

### DIFF
--- a/runtime-multimedia/libvpl/spec
+++ b/runtime-multimedia/libvpl/spec
@@ -1,4 +1,4 @@
-VER=2.11.0
+VER=2.13.0
 SRCS="git::commit=tags/v$VER::https://github.com/intel/libvpl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242664"


### PR DESCRIPTION
Topic Description
-----------------

- libvpl: update to 2.13.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- libvpl: 2.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvpl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
