### PR TITLE
libusb: rebuild for Spiral markers

### DIFF
--- a/runtime-devices/libusb/autobuild/defines
+++ b/runtime-devices/libusb/autobuild/defines
@@ -4,3 +4,6 @@ PKGDEP="glibc systemd"
 PKGSEC=libs
 
 NOPARALLEL=1
+
+# Note: Sync with Debian.
+PKGEPOCH_SPIRAL=2

--- a/runtime-devices/libusb/spec
+++ b/runtime-devices/libusb/spec
@@ -1,5 +1,5 @@
 VER=1.0.23
-REL=1
+REL=2
 SRCS="tbl::https://github.com/libusb/libusb/releases/download/v$VER/libusb-$VER.tar.bz2"
 CHKSUMS="sha256::db11c06e958a82dac52cf3c65cb4dd2c3f339c8a988665110e0d24d19312ad8d"
 CHKUPDATE="anitya::id=1749"


### PR DESCRIPTION
Topic Description
-----------------

- libusb: rebuild for Spiral markers

Package(s) Affected
-------------------

- libusb: 1.0.23-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libusb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
