### PR TITLE
libcava: update to 0.10.3

### DIFF
--- a/runtime-multimedia/libcava/spec
+++ b/runtime-multimedia/libcava/spec
@@ -1,4 +1,4 @@
-VER=0.10.2
+VER=0.10.3
 SRCS="git::commit=tags/$VER::https://github.com/LukashonakV/cava"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372377"


### PR DESCRIPTION
Topic Description
-----------------

- libcava: update to 0.10.3
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- libcava: 0.10.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcava
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
