### PR TITLE
typos: new, 1.24.6

### DIFF
--- a/app-utils/typos/autobuild/defines
+++ b/app-utils/typos/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=typos
+PKGDES="A tool to find and correct spelling mistakes (typos) in source code"
+PKGDEP="glibc gcc-runtime"
+PKGSEC="utils"
+BUILDDEP="rustc llvm"
+ABTYPE="rust"
+
+USECLANG=1
+
+# FIXME: ld.lld does not support these architectures.
+USECLANG__LOONGSON3=0
+NOLTO__LOONGSON3=1

--- a/app-utils/typos/spec
+++ b/app-utils/typos/spec
@@ -1,0 +1,4 @@
+VER=1.24.6
+SRCS="git::commit=tags/v$VER::https://github.com/crate-ci/typos"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=373489"


### PR DESCRIPTION
Topic Description
-----------------

- typos: new, 1.24.6

Package(s) Affected
-------------------

- typos: 1.24.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit typos
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
