### PR TITLE
gconf: rebuild for Spiral marker

### DIFF
--- a/app-admin/gconf/spec
+++ b/app-admin/gconf/spec
@@ -1,5 +1,5 @@
 VER=3.2.6
-REL=6
+REL=7
 SRCS="tbl::https://download.gnome.org/sources/GConf/${VER:0:3}/GConf-$VER.tar.xz"
 CHKSUMS="sha256::1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c"
 CHKUPDATE="anitya::id=8423"


### PR DESCRIPTION
Topic Description
-----------------

- gconf: rebuild for Spiral markers

Package(s) Affected
-------------------

- gconf: 3.2.6-7

Security Update?
----------------

No

Build Order
-----------

```
#buildit gconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
