### PR TITLE
picom: update to 12.1

### DIFF
--- a/desktop-wm/picom/autobuild/defines
+++ b/desktop-wm/picom/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=picom
 PKGSEC=x11
-PKGDEP="x11-lib hicolor-icon-theme libconfig dbus libev libglvnd \
+PKGDEP="x11-lib hicolor-icon-theme libconfig dbus libev libglvnd rtkit \
         pcre pixman xcb-util-image xcb-util-renderutil libepoxy mesa"
-BUILDDEP="uthash x11-app asciidoc"
+BUILDDEP="uthash x11-app asciidoctor"
 PKGDES="A lightweight compositor for X11"
 
 PKGBREAK="compton<=20160907-2"

--- a/desktop-wm/picom/spec
+++ b/desktop-wm/picom/spec
@@ -1,4 +1,4 @@
-VER=11.2
+VER=12.1
 SRCS="git::commit=tags/v${VER}::https://github.com/yshui/picom"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=48078"


### PR DESCRIPTION
Topic Description
-----------------

- picom: update to 12.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- picom: 12.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit picom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
