### PR TITLE
podman: update to 5.2.3+vsock0.7.4

### DIFF
--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=5.2.2
+UPSTREAM_VER=5.2.3
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile
@@ -11,4 +11,3 @@ CHKSUMS="SKIP\
          SKIP"
 CHKUPDATE="anitya::id=93284"
 SUBDIR="podman-$UPSTREAM_VER"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- podman: update to 5.2.3+vsock0.7.4
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- podman: 5.2.3+vsock0.7.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
