### PR TITLE
zvm: update to 6.0.0

### DIFF
--- a/lang-ziglang/zvm/spec
+++ b/lang-ziglang/zvm/spec
@@ -1,4 +1,4 @@
-VER=0.7.4
+VER=6.0.0
 SRCS="git::commit=tags/v$VER::https://github.com/tristanisham/zvm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=363557"


### PR DESCRIPTION
Topic Description
-----------------

- zvm: update to 6.0.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- zvm: 6.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit zvm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
