### PR TITLE
portaudio: update to 19.7.0

### DIFF
--- a/runtime-multimedia/portaudio/autobuild/defines
+++ b/runtime-multimedia/portaudio/autobuild/defines
@@ -1,11 +1,11 @@
 PKGNAME=portaudio
 PKGSEC=sound
-PKGDEP="jack"
+PKGDEP="jack alsa-lib"
 PKGDES="A free, cross platform, open source audio I/O library"
 
 AUTOTOOLS_STRICT=0
-AUTOTOOLS_AFTER="--enable-cxx"
 NOPARALLEL=1
+AUTOTOOLS_AFTER="--enable-cxx --with-alsa --with-jack"
 RECONF=0
 
 PKGEPOCH=1

--- a/runtime-multimedia/portaudio/spec
+++ b/runtime-multimedia/portaudio/spec
@@ -1,5 +1,4 @@
-VER=19+20140130
-REL=3
-SRCS="tbl::http://www.portaudio.com/archives/pa_stable_v${VER/+/_}.tgz"
-CHKSUMS="sha256::8fe024a5f0681e112c6979808f684c3516061cc51d3acc0b726af98fc96c8d57"
+VER=19.7.0
+SRCS="git::commit=tags/v${VER}::https://github.com/PortAudio/portaudio.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10597"


### PR DESCRIPTION
Topic Description
-----------------

- portaudio: update to 19.7.0
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- portaudio: 1:19.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit portaudio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
