### PR TITLE
stellarium: update to 24.3

### DIFF
--- a/app-scientific/stellarium/spec
+++ b/app-scientific/stellarium/spec
@@ -1,5 +1,4 @@
-VER=0.21.3
-REL=2
+VER=24.3
 SRCS="tbl::https://github.com/Stellarium/stellarium/releases/download/v$VER/stellarium-$VER.tar.gz"
-CHKSUMS="sha256::8ac6c054d12f136fe0d5c0deaaa8d7b69dd2a462be1711a187364574aef97e7f"
+CHKSUMS="sha256::c3ffb56a049061c7754bafab176146a2c4474ecede108d650f3c7551e1eae50a"
 CHKUPDATE="anitya::id=4891"


### PR DESCRIPTION
Topic Description
-----------------

- stellarium: update to 24.3
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- stellarium: 24.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit stellarium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
