### PR TITLE
podman: rework 5.2.3

### DIFF
--- a/app-containers/podman/autobuild/defines
+++ b/app-containers/podman/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=podman
 PKGSEC=admin
 PKGDES="A tool for managing OCI containers and pods"
-PKGDEP="ostree gpgme containers-common passt catatonit"
+PKGDEP="ostree gpgme conmon containers-common passt catatonit"
 PKGRECOM="btrfs-progs"
 BUILDDEP="go btrfs-progs go-md2man"
 

--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=5.2.3
+REL=1
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile


### PR DESCRIPTION
Topic Description
-----------------

- podman: rework 5.2.3, add conmon back as dependency

Package(s) Affected
-------------------

- podman: 5.2.3+vsock0.7.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
