### PR TITLE
midori: drop a profile file that pollutes env for all gtk apps

### DIFF
--- a/app-web/midori/autobuild/overrides/etc/profile.d/midori-csd.sh
+++ b/app-web/midori/autobuild/overrides/etc/profile.d/midori-csd.sh
@@ -1,1 +1,0 @@
-export GTK_CSD=1

--- a/app-web/midori/spec
+++ b/app-web/midori/spec
@@ -1,5 +1,5 @@
 VER=9.0
 SRCS="tbl::https://github.com/midori-browser/core/archive/v${VER}.tar.gz"
 CHKSUMS="sha256::913a7cba95ddcc3dc5f6b12d861e765d6fa990fe7d4efc3768d3a3567ea460db"
-REL=3
+REL=4
 CHKUPDATE="anitya::id=1974"


### PR DESCRIPTION
Topic Description
-----------------

- midori: drop a profile that pollutes environment variables
    This will lead to all Gtk programs to use CSD even on KDE.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- midori: 9.0-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit midori
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
