### PR TITLE
vulkan-loader: update to 1.3.296

### DIFF
--- a/runtime-display/vulkan-loader/spec
+++ b/runtime-display/vulkan-loader/spec
@@ -1,4 +1,4 @@
-VER=1.3.283.0
+VER=1.3.296
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Loader"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230557"


### PR DESCRIPTION
Topic Description
-----------------

- vulkan-loader: update to 1.3.296
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- vulkan-loader: 1.3.296

Security Update?
----------------

No

Build Order
-----------

```
#buildit vulkan-loader
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
