### PR TITLE
kstars: update to 3.7.3

### DIFF
--- a/desktop-kde/kstars/spec
+++ b/desktop-kde/kstars/spec
@@ -1,4 +1,4 @@
-VER=3.7.2
+VER=3.7.3
 SRCS="tbl::https://download.kde.org/stable/kstars/$VER/kstars-$VER.tar.xz"
-CHKSUMS="sha256::7c4bb7046056e5c82b637f33041de22f4fd246ba1b12d255b0635644db53e34b"
+CHKSUMS="sha256::d3a469ad8068ceaa47fb145f90bc0818a8162a0545e15e424c00ddf0ac3f588d"
 CHKUPDATE="anitya::id=229035"


### PR DESCRIPTION
Topic Description
-----------------

- kstars: update to 3.7.3
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- kstars: 1:3.7.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit kstars
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
