### PR TITLE
stressapptest (Stressful Application Test): new, 1.0.11

### DIFF
--- a/app-benchmarks/stressapptest/autobuild/defines
+++ b/app-benchmarks/stressapptest/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=stressapptest
+PKGSEC=utils
+PKGDEP="gcc-runtime glibc libaio"
+PKGDES="A general-purpose memory interface testsuite"
+
+ABTYPE=autotools

--- a/app-benchmarks/stressapptest/spec
+++ b/app-benchmarks/stressapptest/spec
@@ -1,0 +1,4 @@
+VER=1.0.11
+SRCS="git::commit=tags/v$VER::https://github.com/stressapptest/stressapptest"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=369645"


### PR DESCRIPTION
Topic Description
-----------------

- stressapptest: new, 1.0.11

Package(s) Affected
-------------------

- stressapptest: 1.0.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit stressapptest
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
