### PR TITLE
oath-toolkit: update to 2.6.12

### DIFF
--- a/app-admin/oath-toolkit/spec
+++ b/app-admin/oath-toolkit/spec
@@ -1,4 +1,4 @@
-VER=2.6.11
+VER=2.6.12
 SRCS="tbl::https://download.savannah.nongnu.org/releases/oath-toolkit/oath-toolkit-$VER.tar.gz"
-CHKSUMS="sha256::fc512a4a5b46f4c43ab0586c3189fece4d54f7e649397d6fa1e23428431e2cb4"
+CHKSUMS="sha256::cafdf739b1ec4b276441c6aedae6411434bbd870071f66154b909cc6e2d9e8ba"
 CHKUPDATE="anitya::id=2515"


### PR DESCRIPTION
Topic Description
-----------------

- oath-toolkit: update to 2.6.12
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- oath-toolkit: 2.6.12

Security Update?
----------------

Yes, #8160

Build Order
-----------

```
#buildit oath-toolkit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
