### PR TITLE
httpie: update to 3.2.3

### DIFF
--- a/app-web/httpie/autobuild/defines
+++ b/app-web/httpie/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=httpie
 PKGSEC=utils
-PKGDEP="defusedxml multidict pygments pysocks requests toolbelt"
+PKGDEP="defusedxml multidict pygments pysocks requests toolbelt rich"
 PKGDES="An interactive command line HTTP client"
 
 ABHOST=noarch

--- a/app-web/httpie/autobuild/patches/0001-Explicitly-load-default-certificates-when-creating-S.patch
+++ b/app-web/httpie/autobuild/patches/0001-Explicitly-load-default-certificates-when-creating-S.patch
@@ -1,0 +1,43 @@
+From 6a0e0aa3186f97ce086637de838265e5c61246a0 Mon Sep 17 00:00:00 2001
+From: Adam Williamson <awilliam@redhat.com>
+Date: Tue, 3 Sep 2024 16:58:01 -0700
+Subject: [PATCH 1/2] Explicitly load default certificates when creating SSL
+ context (#1583)
+
+Requests prior to 2.32.3 always loaded the default (system-wide)
+set of trusted certificates into custom SSL contexts. 2.32.3 no
+longer does. This has broken a lot of users, but the fix is
+moving slowly upstream due to security considerations - see
+https://github.com/psf/requests/issues/6730 and
+https://github.com/psf/requests/pull/6731 .
+
+As suggested at
+https://github.com/psf/requests/pull/6710#issuecomment-2137802782
+this can be worked around by explicitly loading the default
+certificates into the context. We check the method exists before
+calling it just to be safe, but I'm pretty sure it's been there
+as long as this interface has existed.
+
+Signed-off-by: Adam Williamson <awilliam@redhat.com>
+---
+ httpie/ssl_.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/httpie/ssl_.py b/httpie/ssl_.py
+index af5ca54..8ebd5fc 100644
+--- a/httpie/ssl_.py
++++ b/httpie/ssl_.py
+@@ -48,6 +48,10 @@ class HTTPieHTTPSAdapter(HTTPAdapter):
+             ssl_version=ssl_version,
+             ciphers=ciphers,
+         )
++        # workaround for a bug in requests 2.32.3, see:
++        # https://github.com/httpie/cli/issues/1583
++        if getattr(self._ssl_context, 'load_default_certs', None) is not None:
++            self._ssl_context.load_default_certs()
+         super().__init__(**kwargs)
+ 
+     def init_poolmanager(self, *args, **kwargs):
+-- 
+2.46.0
+

--- a/app-web/httpie/autobuild/patches/0002-Drop-the-upper-bound-on-the-requests-dependency-agai.patch
+++ b/app-web/httpie/autobuild/patches/0002-Drop-the-upper-bound-on-the-requests-dependency-agai.patch
@@ -1,0 +1,29 @@
+From c84503ac69a715519a9921e12f25742fd39d0aa0 Mon Sep 17 00:00:00 2001
+From: Adam Williamson <awilliam@redhat.com>
+Date: Tue, 3 Sep 2024 17:07:43 -0700
+Subject: [PATCH 2/2] Drop the upper bound on the requests dependency again
+
+As we can now work with requests 2.32.3+, we no longer need this
+pin.
+
+Signed-off-by: Adam Williamson <awilliam@redhat.com>
+---
+ setup.cfg | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.cfg b/setup.cfg
+index 3766339..8549098 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -50,7 +50,7 @@ install_requires =
+     pip
+     charset_normalizer>=2.0.0
+     defusedxml>=0.6.0
+-    requests[socks] >=2.22.0, <=2.31.0
++    requests[socks] >=2.22.0
+     Pygments>=2.5.2
+     requests-toolbelt>=0.9.1
+     multidict>=4.7.0
+-- 
+2.46.0
+

--- a/app-web/httpie/spec
+++ b/app-web/httpie/spec
@@ -1,4 +1,4 @@
-VER=3.2.2
+VER=3.2.3
 SRCS="git::commit=tags/$VER::https://github.com/jakubroztocil/httpie"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1337"


### PR DESCRIPTION
Topic Description
-----------------

- httpie: update to 3.2.3
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- httpie: 3.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit httpie
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
