### PR TITLE
godot: add loongarch64 support

### DIFF
--- a/app-devel/godot/autobuild/build
+++ b/app-devel/godot/autobuild/build
@@ -1,24 +1,30 @@
 abinfo "Building Godot Engine ..."
 
 HAS_DOTNET=yes
-# arch={auto|x86_32|x86_64|arm32|arm64|rv64|ppc32|ppc64|wasm32}
-if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
+ADDITIONAL_PARAMS=""
+
+if ab_match_arch amd64; then
     GODOT_ARCH=x86_64
-elif [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
+elif ab_match_arch arm64; then
     GODOT_ARCH=arm64
-elif [[ "${CROSS:-$ARCH}" = "riscv64" ]]; then
+elif ab_match_arch riscv64; then
     GODOT_ARCH=rv64
     HAS_DOTNET=no
-elif [[ "${CROSS:-$ARCH}" = "ppc64el" ]]; then
+elif ab_match_arch ppc64el; then
     GODOT_ARCH=ppc64
     HAS_DOTNET=no
+elif ab_match_arch loongarch64; then
+    GODOT_ARCH=loongarch64
+    HAS_DOTNET=no
+    # FIXME: godot 4.3 bundled libpcre2 is too old, does not support JIT on loongarch
+    ADDITIONAL_PARAMS="builtin_pcre2_with_jit=no"
 else
     exit 1
 fi
 
 export BUILD_NAME=aosc
 scons platform=linuxbsd target=editor production=yes debug_symbols=yes \
-    arch=$GODOT_ARCH module_mono_enabled=$HAS_DOTNET
+    arch=$GODOT_ARCH module_mono_enabled=$HAS_DOTNET $ADDITIONAL_PARAMS
 
 EXE_NAME="godot.linuxbsd.editor.$GODOT_ARCH"
 

--- a/app-devel/godot/autobuild/defines
+++ b/app-devel/godot/autobuild/defines
@@ -6,7 +6,8 @@ PKGDEP="x11-lib libglvnd glu alsa-lib pulseaudio systemd dotnet-sdk-8.0"
 PKGDEP__NO_DOTNET="x11-lib libglvnd glu alsa-lib pulseaudio systemd"
 PKGDEP__PPC64EL="${PKGDEP_NO_DOTNET}"
 PKGDEP__RISCV64="${PKGDEP_NO_DOTNET}"
+PKGDEP__LOONGARCH64="${PKGDEP_NO_DOTNET}"
 
 BUILDDEP="pkg-config gcc scons"
 
-FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64)"
+FAIL_ARCH="loongson3"

--- a/app-devel/godot/autobuild/patches/0001-Add-loongarch64-support.patch
+++ b/app-devel/godot/autobuild/patches/0001-Add-loongarch64-support.patch
@@ -1,0 +1,132 @@
+From ab38b618725cbbac679849c121aa610b0bb7c8e5 Mon Sep 17 00:00:00 2001
+From: Student Main <studentmain@aosc.io>
+Date: Sat, 5 Oct 2024 02:24:15 +0800
+Subject: [PATCH 1/2] Add loongarch64 support
+
+---
+ core/config/engine.cpp                                        | 3 +++
+ core/os/os.cpp                                                | 4 ++++
+ editor/editor_property_name_processor.cpp                     | 1 +
+ editor/plugins/gdextension_export_plugin.h                    | 1 +
+ platform/linuxbsd/detect.py                                   | 2 +-
+ .../linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml     | 2 +-
+ platform/linuxbsd/export/export_plugin.cpp                    | 2 +-
+ platform_methods.py                                           | 3 ++-
+ 8 files changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/core/config/engine.cpp b/core/config/engine.cpp
+index 3574430cf7..5a8cd0fb55 100644
+--- a/core/config/engine.cpp
++++ b/core/config/engine.cpp
+@@ -238,6 +238,9 @@ String Engine::get_architecture_name() const {
+ 	return "ppc";
+ #endif
+ 
++#elif defined(__loongarch__)
++	return "loongarch64";
++
+ #elif defined(__wasm__)
+ #if defined(__wasm64__)
+ 	return "wasm64";
+diff --git a/core/os/os.cpp b/core/os/os.cpp
+index 642de11a9f..4a7b660ac3 100644
+--- a/core/os/os.cpp
++++ b/core/os/os.cpp
+@@ -504,6 +504,10 @@ bool OS::has_feature(const String &p_feature) {
+ 	if (p_feature == "wasm") {
+ 		return true;
+ 	}
++#elif defined(__loongarch__)
++	if (p_feature == "loongarch64") {
++		return true;
++	}
+ #endif
+ 
+ #if defined(IOS_SIMULATOR)
+diff --git a/editor/editor_property_name_processor.cpp b/editor/editor_property_name_processor.cpp
+index f23cab676c..6dcec0bce6 100644
+--- a/editor/editor_property_name_processor.cpp
++++ b/editor/editor_property_name_processor.cpp
+@@ -233,6 +233,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
+ 	capitalize_string_remaps["lod"] = "LOD";
+ 	capitalize_string_remaps["lods"] = "LODs";
+ 	capitalize_string_remaps["lowpass"] = "Low-pass";
++	capitalize_string_remaps["loongarch64"] = "loongarch64";
+ 	capitalize_string_remaps["macos"] = "macOS";
+ 	capitalize_string_remaps["mb"] = "(MB)"; // Unit.
+ 	capitalize_string_remaps["mjpeg"] = "MJPEG";
+diff --git a/editor/plugins/gdextension_export_plugin.h b/editor/plugins/gdextension_export_plugin.h
+index da136b70ae..c8abe33040 100644
+--- a/editor/plugins/gdextension_export_plugin.h
++++ b/editor/plugins/gdextension_export_plugin.h
+@@ -72,6 +72,7 @@ void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p
+ 	all_archs.insert("ppc32");
+ 	all_archs.insert("ppc64");
+ 	all_archs.insert("wasm32");
++	all_archs.insert("loongarch64");
+ 	all_archs.insert("universal");
+ 
+ 	HashSet<String> archs;
+diff --git a/platform/linuxbsd/detect.py b/platform/linuxbsd/detect.py
+index d1de760f34..ddc8bb83cf 100644
+--- a/platform/linuxbsd/detect.py
++++ b/platform/linuxbsd/detect.py
+@@ -73,7 +73,7 @@ def get_flags():
+ 
+ def configure(env: "SConsEnvironment"):
+     # Validate arch.
+-    supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64"]
++    supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "loongarch64"]
+     if env["arch"] not in supported_arches:
+         print_error(
+             'Unsupported CPU architecture "%s" for Linux / *BSD. Supported architectures are: %s.'
+diff --git a/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml b/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
+index a44c86202e..2ffae6f7a5 100644
+--- a/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
++++ b/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
+@@ -11,7 +11,7 @@
+ 	<members>
+ 		<member name="binary_format/architecture" type="String" setter="" getter="">
+ 			Application executable architecture.
+-			Supported architectures: [code]x86_32[/code], [code]x86_64[/code], [code]arm64[/code], [code]arm32[/code], [code]rv64[/code], [code]ppc64[/code], and [code]ppc32[/code].
++			Supported architectures: [code]x86_32[/code], [code]x86_64[/code], [code]arm64[/code], [code]arm32[/code], [code]rv64[/code], [code]ppc64[/code], [code]ppc32[/code] and [code]loongarch64[/code].
+ 			Official export templates include [code]x86_32[/code] and [code]x86_64[/code] binaries only.
+ 		</member>
+ 		<member name="binary_format/embed_pck" type="bool" setter="" getter="">
+diff --git a/platform/linuxbsd/export/export_plugin.cpp b/platform/linuxbsd/export/export_plugin.cpp
+index 936adddda3..ac2102f7d3 100644
+--- a/platform/linuxbsd/export/export_plugin.cpp
++++ b/platform/linuxbsd/export/export_plugin.cpp
+@@ -166,7 +166,7 @@ bool EditorExportPlatformLinuxBSD::get_export_option_visibility(const EditorExpo
+ void EditorExportPlatformLinuxBSD::get_export_options(List<ExportOption> *r_options) const {
+ 	EditorExportPlatformPC::get_export_options(r_options);
+ 
+-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "x86_64,x86_32,arm64,arm32,rv64,ppc64,ppc32"), "x86_64"));
++	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "x86_64,x86_32,arm64,arm32,rv64,ppc64,ppc32,loongarch64"), "x86_64"));
+ 
+ 	String run_script = "#!/usr/bin/env bash\n"
+ 						"export DISPLAY=:0\n"
+diff --git a/platform_methods.py b/platform_methods.py
+index 2b157da22b..446bfd8bd4 100644
+--- a/platform_methods.py
++++ b/platform_methods.py
+@@ -8,7 +8,7 @@ import methods
+ 
+ 
+ # CPU architecture options.
+-architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32"]
++architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32", "loongarch64"]
+ architecture_aliases = {
+     "x86": "x86_32",
+     "x64": "x86_64",
+@@ -23,6 +23,7 @@ architecture_aliases = {
+     "ppcle": "ppc32",
+     "ppc": "ppc32",
+     "ppc64le": "ppc64",
++    "loong64": "loongarch64",
+ }
+ 
+ 
+-- 
+2.46.2
+

--- a/app-devel/godot/autobuild/patches/0002-Ignore-case-when-parse-proc-cpuinfo.patch
+++ b/app-devel/godot/autobuild/patches/0002-Ignore-case-when-parse-proc-cpuinfo.patch
@@ -1,0 +1,25 @@
+From 1087f3c89f780b8c472f14bf03c884895f245197 Mon Sep 17 00:00:00 2001
+From: Student Main <studentmain@aosc.io>
+Date: Sat, 5 Oct 2024 03:56:14 +0800
+Subject: [PATCH 2/2] Ignore case when parse /proc/cpuinfo
+
+---
+ platform/linuxbsd/os_linuxbsd.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/platform/linuxbsd/os_linuxbsd.cpp b/platform/linuxbsd/os_linuxbsd.cpp
+index 6355562feb..25902bf1be 100644
+--- a/platform/linuxbsd/os_linuxbsd.cpp
++++ b/platform/linuxbsd/os_linuxbsd.cpp
+@@ -184,7 +184,7 @@ String OS_LinuxBSD::get_processor_name() const {
+ 
+ 	while (!f->eof_reached()) {
+ 		const String line = f->get_line();
+-		if (line.contains("model name")) {
++		if (line.to_lower().contains("model name")) {
+ 			return line.split(":")[1].strip_edges();
+ 		}
+ 	}
+-- 
+2.46.2
+

--- a/app-devel/godot/autobuild/patches/0003-Add-loongarch-support-for-bundled-OpenXR.patch
+++ b/app-devel/godot/autobuild/patches/0003-Add-loongarch-support-for-bundled-OpenXR.patch
@@ -1,0 +1,26 @@
+From 1b04a4ff4eb987ffbc1d497db394548005c5b551 Mon Sep 17 00:00:00 2001
+From: Student Main <studentmain@aosc.io>
+Date: Sat, 5 Oct 2024 16:19:25 +0800
+Subject: [PATCH 3/3] Add loongarch support for bundled OpenXR
+
+basically https://github.com/KhronosGroup/OpenXR-SDK-Source/pull/479
+---
+ thirdparty/openxr/src/common/platform_utils.hpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/thirdparty/openxr/src/common/platform_utils.hpp b/thirdparty/openxr/src/common/platform_utils.hpp
+index 35369a1477..8bbefe202e 100644
+--- a/thirdparty/openxr/src/common/platform_utils.hpp
++++ b/thirdparty/openxr/src/common/platform_utils.hpp
+@@ -71,6 +71,8 @@
+ #define XR_ARCH_ABI "riscv64"
+ #elif defined(__sparc__) && defined(__arch64__)
+ #define XR_ARCH_ABI "sparc64"
++#elif defined(__loongarch64)
++#define XR_ARCH_ABI "loong64"
+ #else
+ #error "No architecture string known!"
+ #endif
+-- 
+2.46.2
+

--- a/app-devel/godot/spec
+++ b/app-devel/godot/spec
@@ -2,3 +2,4 @@ VER=4.3
 SRCS="git::commit=tags/$VER-stable::https://github.com/godotengine/godot"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373975"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- godot: add loongarch64 support

Package(s) Affected
-------------------

- godot: 4.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit godot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
