### PR TITLE
mesa: update to 24.2.4+dxheaders1.614.1

### DIFF
--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=24.2.3
+UPSTREAM_VER=24.2.4
 DXHEADERS_VER=1.614.1
 VER=${UPSTREAM_VER}+dxheaders${DXHEADERS_VER}
 
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::4ea18b1155a4544a09f7361848974768f6f73c19d88f63de2ec650be313b2d0c \
+CHKSUMS="sha256::5ea42a8bb6d58aec9754c9f553b1e413f67c09403741f8e2786c3f9e63d3461a \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 24.2.4+dxheaders1.614.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mesa: 1:24.2.4+dxheaders1.614.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
