### PR TITLE
qt-6: update to 6.7.3

### DIFF
--- a/runtime-desktop/qt-6/autobuild/patches/0001-Arch-Linux-qtbase-respect-system-compiler-linker-fla.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0001-Arch-Linux-qtbase-respect-system-compiler-linker-fla.patch
@@ -1,7 +1,8 @@
-From 6b01d20514e06c8a19b9208903eb02b9d91460e6 Mon Sep 17 00:00:00 2001
+From f447b2a2560ab672cc85a8efc95fd0a73cc8956a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Mon, 1 Jul 2024 11:21:53 +0800
-Subject: [PATCH 1/8] [Arch Linux] qtbase: respect system compiler/linker flags
+Subject: [PATCH 01/12] [Arch Linux] qtbase: respect system compiler/linker
+ flags
 
 ---
  qtbase/mkspecs/common/g++-unix.conf |  3 ++-
@@ -55,5 +56,5 @@ index ae58326289..af00173312 100644
  QMAKE_CXXFLAGS_STATIC_LIB += $$QMAKE_CFLAGS_STATIC_LIB
  QMAKE_CXXFLAGS_APP        += $$QMAKE_CFLAGS_APP
 -- 
-2.46.0
+2.46.2
 

--- a/runtime-desktop/qt-6/autobuild/patches/0002-Fedora-qt3d-assimp-fix-build-with-GCC-13.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0002-Fedora-qt3d-assimp-fix-build-with-GCC-13.patch
@@ -1,7 +1,7 @@
-From 77bff899320aed4383c91096bb5a9706c0e8c25e Mon Sep 17 00:00:00 2001
+From d50c84b445c0a7370a6a589a418dabb7f8549453 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Mon, 1 Jul 2024 11:22:43 +0800
-Subject: [PATCH 2/8] [Fedora] qt3d: assimp: fix build with GCC >= 13
+Subject: [PATCH 02/12] [Fedora] qt3d: assimp: fix build with GCC >= 13
 
 ---
  .../assimp/src/code/AssetLib/FBX/FBXBinaryTokenizer.cpp        | 2 ++
@@ -51,5 +51,5 @@ index a3a0d9eae0..b9de4c2840 100644
  // =======================================================================
  // Public interface to Assimp
 -- 
-2.46.0
+2.46.2
 

--- a/runtime-desktop/qt-6/autobuild/patches/0003-Gentoo-qtwebengine-chromium-add-a-missing-header-for.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0003-Gentoo-qtwebengine-chromium-add-a-missing-header-for.patch
@@ -1,8 +1,8 @@
-From 22383ad33b72a19c9a6f4d968e02ea1e1c035f51 Mon Sep 17 00:00:00 2001
+From 5fce6669a2e630c1d390e4bcdffac109d844b964 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Mon, 1 Jul 2024 11:23:29 +0800
-Subject: [PATCH 3/8] [Gentoo] qtwebengine: chromium: add a missing header for
- USE_GLX builds
+Subject: [PATCH 03/12] [Gentoo] qtwebengine: chromium: add a missing header
+ for USE_GLX builds
 
 ---
  qtwebengine/src/3rdparty/chromium/ui/gl/gl_display.cc | 4 ++++
@@ -24,5 +24,5 @@ index 672756a48b..75d817a094 100644
  #include "ui/ozone/buildflags.h"
  #endif  // BUILDFLAG(IS_OZONE)
 -- 
-2.46.0
+2.46.2
 

--- a/runtime-desktop/qt-6/autobuild/patches/0004-Gentoo-qtwebengine-chromium-fix-build-time-race-cond.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0004-Gentoo-qtwebengine-chromium-fix-build-time-race-cond.patch
@@ -1,17 +1,16 @@
-From cdb50e69ec19e6e7c80efddc9319d11cda38e53d Mon Sep 17 00:00:00 2001
+From e66d9a62d572706b90823a9f2a5feb4bcce4ef9f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Mon, 1 Jul 2024 11:24:09 +0800
-Subject: [PATCH 4/8] [Gentoo] qtwebengine: chromium: fix build-time race
+Subject: [PATCH 04/12] [Gentoo] qtwebengine: chromium: fix build-time race
  condition with Ninja >= 1.12
 
 ---
  qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn       | 1 +
  .../extensions/browser/api/declarative_net_request/BUILD.gn      | 1 +
- qtwebengine/src/core/configure/BUILD.root.gn.in                  | 1 +
- 3 files changed, 3 insertions(+)
+ 2 files changed, 2 insertions(+)
 
 diff --git a/qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn b/qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn
-index d40a9252d0..c882a4e003 100644
+index 20164d81fe..44dda915cc 100644
 --- a/qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn
 +++ b/qtwebengine/src/3rdparty/chromium/content/browser/BUILD.gn
 @@ -196,6 +196,7 @@ jumbo_source_set("browser") {
@@ -34,18 +33,6 @@ index 13a266e22f..a2d27936f6 100644
      "//extensions/common",
      "//extensions/common/api",
      "//services/preferences/public/cpp",
-diff --git a/qtwebengine/src/core/configure/BUILD.root.gn.in b/qtwebengine/src/core/configure/BUILD.root.gn.in
-index 986db50262..e20fcf138f 100644
---- a/qtwebengine/src/core/configure/BUILD.root.gn.in
-+++ b/qtwebengine/src/core/configure/BUILD.root.gn.in
-@@ -233,6 +233,7 @@ source_set("qtwebengine_spellcheck_sources") {
- source_set("devtools_sources") {
-   configs += [ ":cpp20_config" ]
-   deps = [
-+    "//chrome/app:generated_resources",
-     "//components/zoom",
-     "//third_party/blink/public/mojom:mojom_platform",
-     ]
 -- 
-2.46.0
+2.46.2
 

--- a/runtime-desktop/qt-6/autobuild/patches/0005-qtbase-fallback-to-GLES-if-GL-EGL-context-creation-f.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0005-qtbase-fallback-to-GLES-if-GL-EGL-context-creation-f.patch
@@ -1,7 +1,7 @@
-From eafbb85d0ed2aa02cdb531bc50686378bfb4bb04 Mon Sep 17 00:00:00 2001
+From 94ed9c61176098dfe823b3cb2f4ee21bb2a69f8f Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Wed, 26 Jun 2024 22:16:10 +0800
-Subject: [PATCH 5/8] qtbase: fallback to GLES if GL EGL context creation
+Subject: [PATCH 05/12] qtbase: fallback to GLES if GL EGL context creation
  failed
 
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
@@ -32,5 +32,5 @@ index 4af50d72f2..1e7b2c3228 100644
      // For OpenVG, we sometimes try to create a surface using a pre-multiplied format. If we can't
      // find a config which supports pre-multiplied formats, remove the flag on the surface type:
 -- 
-2.46.0
+2.46.2
 

--- a/runtime-desktop/qt-6/autobuild/patches/0006-Fixup-Fix-building-with-system-ffmpeg.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0006-Fixup-Fix-building-with-system-ffmpeg.patch
@@ -1,7 +1,7 @@
-From 85e1ebd6524e13d3eeb022f1096296c515a6b3dc Mon Sep 17 00:00:00 2001
+From 595718878da2fb11a3fde6785a274bcf4611ffdf Mon Sep 17 00:00:00 2001
 From: Martin Negyokru <negyokru@inf.u-szeged.hu>
 Date: Thu, 27 Jun 2024 12:29:29 +0200
-Subject: [PATCH 6/8] Fixup: Fix building with system ffmpeg
+Subject: [PATCH 06/12] Fixup: Fix building with system ffmpeg
 
 Add support for FFmpeg 7 and 6.1.
 FFmpeg 6.0 and below need bigger changes.
@@ -414,5 +414,5 @@ index 138cea9d60..7714ff3bd7 100644
          reinterpret_cast<const uint32_t*>(av_packet_get_side_data(
              packet.get(), AV_PKT_DATA_SKIP_SAMPLES, &skip_samples_size));
 -- 
-2.46.0
+2.46.2
 

--- a/runtime-desktop/qt-6/autobuild/patches/0007-Revert-xcb-handle-XI2-input-button-and-motion-events.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0007-Revert-xcb-handle-XI2-input-button-and-motion-events.patch
@@ -1,0 +1,171 @@
+From 96c55b9fc2a8ce544f9367c6db5de5ca0a293ff9 Mon Sep 17 00:00:00 2001
+From: Liang Qi <liang.qi@qt.io>
+Date: Tue, 1 Oct 2024 12:46:30 +0200
+Subject: [PATCH 07/12] Revert "xcb: handle XI2 input button and motion events
+ from slave devices"
+
+This reverts commit b71be292780b858f2c55ce92601452e2ea946de2, which causes a regression when using mouse wheel and moving cursor together
+on scroll bar for some qt applications, like qutebrowser and
+qbittorrent.
+
+Fixes: QTBUG-129509
+Fixes: QTBUG-129514
+Task-number: QTBUG-110841
+Pick-to: 6.8.0 6.7 6.5 6.2 5.15
+Change-Id: I703158874413a1306ea99217bced4ba38382f543
+Reviewed-by: Liang Qi <liang.qi@qt.io>
+Reviewed-by: Axel Spoerl <axel.spoerl@qt.io>
+(cherry picked from commit 5875da6d70303468eab85030a80f54c268f80b79)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+---
+ .../platforms/xcb/qxcbconnection_xi2.cpp      | 121 +++---------------
+ 1 file changed, 16 insertions(+), 105 deletions(-)
+
+diff --git a/qtbase/src/plugins/platforms/xcb/qxcbconnection_xi2.cpp b/qtbase/src/plugins/platforms/xcb/qxcbconnection_xi2.cpp
+index 55c226d3e6..4f62a1880b 100644
+--- a/qtbase/src/plugins/platforms/xcb/qxcbconnection_xi2.cpp
++++ b/qtbase/src/plugins/platforms/xcb/qxcbconnection_xi2.cpp
+@@ -682,96 +682,23 @@ static inline qreal fixed1616ToReal(xcb_input_fp1616_t val)
+     return qreal(val) / 0x10000;
+ }
+ 
+-//implementation is ported from https://codereview.qt-project.org/c/qt/qtbase/+/231552/12/src/plugins/platforms/xcb/qxcbconnection_xi2.cpp#558
+-namespace {
+-
+-/*! \internal
+-
+- Qt listens for XIAllDevices to avoid losing mouse events. This function
+- ensures that we don't process the same event twice: from a slave device and
+- then again from a master device.
+-
+- In a normal use case (e.g. mouse press and release inside a window), we will
+- drop events from master devices as duplicates. Other advantage of processing
+- events from slave devices is that they don't share button state. All buttons
+- on a master device share the state.
+-
+- Examples of special cases:
+-
+-\list
+-
+-\li During system move/resize, window manager (_NET_WM_MOVERESIZE) grabs the
+-   master pointer, in this case we process the matching release from the slave
+-   device. A master device event is not sent by the server, hence no duplicate
+-   event to drop. If we listened for XIAllMasterDevices instead, we would never
+-   see a release event in this case.
+-
+-\li If we dismiss a context menu by clicking somewhere outside a Qt application,
+-   we will process the mouse press from the master pointer as that is the
+-   device we are grabbing. We are not grabbing slave devices (grabbing on the
+-   slave device is buggy according to 19d289ab1b5bde3e136765e5432b5c7d004df3a4).
+-   And since the event occurs outside our window, the slave device event is
+-   not sent to us by the server, hence no duplicate event to drop.
+-
+-\endlist
+-*/
+-bool isDuplicateEvent(xcb_ge_event_t *event)
+-{
+-    Q_ASSERT(event);
+-
+-    struct qXIEvent {
+-        bool isValid = false;
+-        uint16_t sourceid;
+-        uint8_t evtype;
+-        uint32_t detail;
+-        int32_t root_x;
+-        int32_t root_y;
+-    };
+-    static qXIEvent lastSeenEvent;
+-
+-    bool isDuplicate = false;
+-    auto *xiDeviceEvent = reinterpret_cast<qt_xcb_input_device_event_t *>(event);
+-    if (lastSeenEvent.isValid) {
+-        isDuplicate = lastSeenEvent.sourceid == xiDeviceEvent->sourceid &&
+-                lastSeenEvent.evtype == xiDeviceEvent->event_type &&
+-                lastSeenEvent.detail == xiDeviceEvent->detail &&
+-                lastSeenEvent.root_x == xiDeviceEvent->root_x &&
+-                lastSeenEvent.root_y == xiDeviceEvent->root_y;
+-    } else {
+-        lastSeenEvent.isValid = true;
+-    }
+-    lastSeenEvent.sourceid = xiDeviceEvent->sourceid;
+-    lastSeenEvent.evtype = xiDeviceEvent->event_type;
+-    lastSeenEvent.detail = xiDeviceEvent->detail;
+-    lastSeenEvent.root_x = xiDeviceEvent->root_x;
+-    lastSeenEvent.root_y = xiDeviceEvent->root_y;
+-
+-    if (isDuplicate) {
+-        qCDebug(lcQpaXInputEvents, "Duplicate XI2 event %d", event->event_type);
+-        // This sanity check ensures that special cases like QTBUG-59277 keep working.
+-        lastSeenEvent.isValid = false; // An event can be a duplicate only once.
+-    }
+-
+-    return isDuplicate;
+-}
+-
+-} // namespace
+-
+ void QXcbConnection::xi2HandleEvent(xcb_ge_event_t *event)
+ {
+     auto *xiEvent = reinterpret_cast<qt_xcb_input_device_event_t *>(event);
+-    if (m_xiSlavePointerIds.contains(xiEvent->deviceid)) {
+-        if (!(xiEvent->event_type == XCB_INPUT_BUTTON_PRESS
+-              || xiEvent->event_type == XCB_INPUT_BUTTON_RELEASE
+-              || xiEvent->event_type == XCB_INPUT_MOTION)) {
+-            if (!m_duringSystemMoveResize)
+-                return;
+-            if (xiEvent->event == XCB_NONE)
+-                return;
+-
+-            if (xiEvent->event_type == XCB_INPUT_TOUCH_END)
+-                abortSystemMoveResize(xiEvent->event);
++    setTime(xiEvent->time);
++    if (m_xiSlavePointerIds.contains(xiEvent->deviceid) && xiEvent->event_type != XCB_INPUT_PROPERTY) {
++        if (!m_duringSystemMoveResize)
++            return;
++        if (xiEvent->event == XCB_NONE)
++            return;
+ 
++        if (xiEvent->event_type == XCB_INPUT_BUTTON_RELEASE
++            && xiEvent->detail == XCB_BUTTON_INDEX_1 ) {
++            abortSystemMoveResize(xiEvent->event);
++        } else if (xiEvent->event_type == XCB_INPUT_TOUCH_END) {
++            abortSystemMoveResize(xiEvent->event);
++            return;
++        } else {
+             return;
+         }
+     }
+@@ -783,27 +710,11 @@ void QXcbConnection::xi2HandleEvent(xcb_ge_event_t *event)
+     switch (xiEvent->event_type) {
+     case XCB_INPUT_BUTTON_PRESS:
+     case XCB_INPUT_BUTTON_RELEASE:
+-    case XCB_INPUT_MOTION: {
+-        if (isDuplicateEvent(event))
+-            return;
+-        if (m_xiSlavePointerIds.contains(xiEvent->deviceid)) {
+-            if (m_duringSystemMoveResize) {
+-                if (xiEvent->event_type == XCB_INPUT_BUTTON_RELEASE
+-                    && xiEvent->detail == XCB_BUTTON_INDEX_1 ) {
+-                    abortSystemMoveResize(xiEvent->event);
+-                } else {
+-                    return;
+-                }
+-            }
+-        }
+-        xiDeviceEvent = xiEvent;
+-        eventListener = windowEventListenerFromId(xiDeviceEvent->event);
+-        sourceDeviceId = xiDeviceEvent->sourceid; // use the actual device id instead of the master
+-        break;
+-    }
++    case XCB_INPUT_MOTION:
+     case XCB_INPUT_TOUCH_BEGIN:
+     case XCB_INPUT_TOUCH_UPDATE:
+-    case XCB_INPUT_TOUCH_END: {
++    case XCB_INPUT_TOUCH_END:
++    {
+         xiDeviceEvent = xiEvent;
+         eventListener = windowEventListenerFromId(xiDeviceEvent->event);
+         sourceDeviceId = xiDeviceEvent->sourceid; // use the actual device id instead of the master
+-- 
+2.46.2
+

--- a/runtime-desktop/qt-6/autobuild/patches/0008-Revert-QQmlDelegateModel-fix-delegates-not-being-cre.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0008-Revert-QQmlDelegateModel-fix-delegates-not-being-cre.patch
@@ -1,0 +1,420 @@
+From 0cf5976db472a31c431e7ff1e52a6f02ea3bab6a Mon Sep 17 00:00:00 2001
+From: Mitch Curtis <mitch.curtis@qt.io>
+Date: Sat, 5 Oct 2024 23:12:47 +0800
+Subject: [PATCH 08/12] Revert "QQmlDelegateModel: fix delegates not being
+ created in certain cases"
+
+This reverts commit 6561344dd2d1ba69abe6edec4fe340b256da9e13. It needs
+to be fixed in a different way.
+
+Fixes: QTBUG-127340
+Pick-to: 6.7 6.5
+Change-Id: I8503b22a5257e0fb5ee11a1bdf83d3dcab4a600a
+Reviewed-by: Richard Moe Gustavsen <richard.gustavsen@qt.io>
+(cherry picked from commit 281f620ceea03e7a222d796ae0cca917a9778368)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+---
+ .../src/qmlmodels/qqmldelegatemodel.cpp       |  61 +++-----
+ .../src/qmlmodels/qqmldelegatemodel_p_p.h     |   2 -
+ .../auto/qml/qqmldelegatemodel/CMakeLists.txt |   1 -
+ .../auto/qml/qqmldelegatemodel/data/reset.qml |  28 ----
+ .../data/resetInQAIMConstructor.qml           |  28 ----
+ .../tst_qqmldelegatemodel.cpp                 | 135 ++----------------
+ 6 files changed, 29 insertions(+), 226 deletions(-)
+ delete mode 100644 qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/reset.qml
+ delete mode 100644 qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/resetInQAIMConstructor.qml
+
+diff --git a/qtdeclarative/src/qmlmodels/qqmldelegatemodel.cpp b/qtdeclarative/src/qmlmodels/qqmldelegatemodel.cpp
+index e84e8e6453..8a1482cbf8 100644
+--- a/qtdeclarative/src/qmlmodels/qqmldelegatemodel.cpp
++++ b/qtdeclarative/src/qmlmodels/qqmldelegatemodel.cpp
+@@ -167,7 +167,6 @@ QQmlDelegateModelPrivate::QQmlDelegateModelPrivate(QQmlContext *ctxt)
+     , m_transaction(false)
+     , m_incubatorCleanupScheduled(false)
+     , m_waitingToFetchMore(false)
+-    , m_maybeResetRoleNames(false)
+     , m_cacheItems(nullptr)
+     , m_items(nullptr)
+     , m_persistedItems(nullptr)
+@@ -372,7 +371,6 @@ void QQmlDelegateModelPrivate::connectToAbstractItemModel()
+     QObject::connect(aim, &QAbstractItemModel::modelAboutToBeReset, q, &QQmlDelegateModel::_q_modelAboutToBeReset);
+     qmlobject_connect(aim, QAbstractItemModel, SIGNAL(layoutChanged(QList<QPersistentModelIndex>,QAbstractItemModel::LayoutChangeHint)),
+                       q, QQmlDelegateModel, SLOT(_q_layoutChanged(QList<QPersistentModelIndex>,QAbstractItemModel::LayoutChangeHint)));
+-    QObject::connect(aim, &QAbstractItemModel::modelReset, q, &QQmlDelegateModel::handleModelReset);
+     QObject::connect(aim, &QAbstractItemModel::layoutChanged, q, &QQmlDelegateModel::_q_layoutChanged);
+ }
+ 
+@@ -403,7 +401,6 @@ void QQmlDelegateModelPrivate::disconnectFromAbstractItemModel()
+     QObject::disconnect(aim, &QAbstractItemModel::modelAboutToBeReset, q, &QQmlDelegateModel::_q_modelAboutToBeReset);
+     QObject::disconnect(aim, SIGNAL(layoutChanged(QList<QPersistentModelIndex>,QAbstractItemModel::LayoutChangeHint)),
+                         q, SLOT(_q_layoutChanged(QList<QPersistentModelIndex>,QAbstractItemModel::LayoutChangeHint)));
+-    QObject::disconnect(aim, &QAbstractItemModel::modelReset, q, &QQmlDelegateModel::handleModelReset);
+     QObject::disconnect(aim, &QAbstractItemModel::layoutChanged, q, &QQmlDelegateModel::_q_layoutChanged);
+ }
+ 
+@@ -1914,28 +1911,25 @@ void QQmlDelegateModel::_q_modelAboutToBeReset()
+     Q_D(QQmlDelegateModel);
+     if (!d->m_adaptorModel.adaptsAim())
+         return;
+-
+-    /*
+-        roleNames are generally guaranteed to be stable (given that QAIM has no
+-        change signal for them), except that resetting the model is allowed to
+-        invalidate them (QTBUG-32132). DelegateModel must take this into account by
+-        snapshotting the current roleNames before the model is reset.
+-        Afterwards, if we detect that roleNames has changed, we throw the
+-        current model set up away and rebuild everything from scratch – it is
+-        unlikely that a more efficient implementation would be worth it.
+-
+-        If we detect no changes, we simply use the existing logic to handle the
+-        model reset.
+-
+-        This (role name resetting) logic relies on the fact that
+-        modelAboutToBeReset must be followed by a modelReset signal before any
+-        further modelAboutToBeReset can occur. However, it's possible for user
+-        code to begin the reset before connectToAbstractItemModel is called
+-        (QTBUG-125053), in which case we don't attempt to reset the role names.
+-    */
+-    Q_ASSERT(!d->m_maybeResetRoleNames);
+-    d->m_maybeResetRoleNames = true;
+-    d->m_roleNamesBeforeReset = d->m_adaptorModel.aim()->roleNames();
++    auto aim = d->m_adaptorModel.aim();
++    auto oldRoleNames = aim->roleNames();
++    // this relies on the fact that modelAboutToBeReset must be followed
++    // by a modelReset signal before any further modelAboutToBeReset can occur
++    QObject::connect(aim, &QAbstractItemModel::modelReset, this, [this, d, oldRoleNames, aim](){
++        if (!d->m_adaptorModel.adaptsAim() || d->m_adaptorModel.aim() != aim)
++            return;
++        if (oldRoleNames == aim->roleNames()) {
++            // if the rolenames stayed the same (most common case), then we don't have
++            // to throw away all the setup that we did
++            handleModelReset();
++        } else {
++            // If they did change, we give up and just start from scratch via setMode
++            setModel(QVariant::fromValue(model()));
++            // but we still have to call handleModelReset, otherwise views will
++            // not refresh
++            handleModelReset();
++        }
++    }, Qt::SingleShotConnection);
+ }
+ 
+ void QQmlDelegateModel::handleModelReset()
+@@ -1945,23 +1939,6 @@ void QQmlDelegateModel::handleModelReset()
+         return;
+ 
+     int oldCount = d->m_count;
+-
+-    if (d->m_maybeResetRoleNames) {
+-        auto aim = d->m_adaptorModel.aim();
+-        if (!d->m_adaptorModel.adaptsAim() || d->m_adaptorModel.aim() != aim)
+-            return;
+-
+-        // If the role names stayed the same (most common case), then we don't have
+-        // to throw away all the setup that we did.
+-        // If they did change, we give up and just start from scratch via setModel.
+-        // We do this before handling the reset to ensure that views refresh.
+-        if (aim->roleNames() != d->m_roleNamesBeforeReset)
+-            setModel(QVariant::fromValue(model()));
+-
+-        d->m_maybeResetRoleNames = false;
+-        d->m_roleNamesBeforeReset.clear();
+-    }
+-
+     d->m_adaptorModel.rootIndex = QModelIndex();
+ 
+     if (d->m_complete) {
+diff --git a/qtdeclarative/src/qmlmodels/qqmldelegatemodel_p_p.h b/qtdeclarative/src/qmlmodels/qqmldelegatemodel_p_p.h
+index d28d88dac7..44181cf138 100644
+--- a/qtdeclarative/src/qmlmodels/qqmldelegatemodel_p_p.h
++++ b/qtdeclarative/src/qmlmodels/qqmldelegatemodel_p_p.h
+@@ -334,7 +334,6 @@ public:
+     QQmlReusableDelegateModelItemsPool m_reusableItemsPool;
+     QList<QQDMIncubationTask *> m_finishedIncubating;
+     QList<QByteArray> m_watchedRoles;
+-    QHash<int, QByteArray> m_roleNamesBeforeReset;
+ 
+     QString m_filterGroup;
+ 
+@@ -348,7 +347,6 @@ public:
+     bool m_transaction : 1;
+     bool m_incubatorCleanupScheduled : 1;
+     bool m_waitingToFetchMore : 1;
+-    bool m_maybeResetRoleNames : 1;
+ 
+     union {
+         struct {
+diff --git a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/CMakeLists.txt b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/CMakeLists.txt
+index 966f5229df..8d8a90e0a7 100644
+--- a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/CMakeLists.txt
++++ b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/CMakeLists.txt
+@@ -29,7 +29,6 @@ qt_internal_add_test(tst_qqmldelegatemodel
+         Qt::QmlModelsPrivate
+         Qt::QmlPrivate
+         Qt::Quick
+-        Qt::QuickPrivate
+         Qt::QuickTestUtilsPrivate
+     TESTDATA ${test_data}
+ )
+diff --git a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/reset.qml b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/reset.qml
+deleted file mode 100644
+index 0fcd5e8afa..0000000000
+--- a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/reset.qml
++++ /dev/null
+@@ -1,28 +0,0 @@
+-import QtQuick
+-import Test
+-
+-Window {
+-    id: root
+-    width: 200
+-    height: 200
+-
+-    property alias listView: listView
+-
+-    ResettableModel {
+-        id: resetModel
+-    }
+-
+-    ListView {
+-        id: listView
+-        anchors.fill: parent
+-        model: resetModel
+-
+-        delegate: Rectangle {
+-            implicitWidth: 100
+-            implicitHeight: 50
+-            color: "olivedrab"
+-
+-            required property string display
+-        }
+-    }
+-}
+diff --git a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/resetInQAIMConstructor.qml b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/resetInQAIMConstructor.qml
+deleted file mode 100644
+index cb1f226737..0000000000
+--- a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/resetInQAIMConstructor.qml
++++ /dev/null
+@@ -1,28 +0,0 @@
+-import QtQuick
+-import Test
+-
+-Window {
+-    id: root
+-    width: 200
+-    height: 200
+-
+-    property alias listView: listView
+-
+-    ResetInConstructorModel {
+-        id: resetInConstructorModel
+-    }
+-
+-    ListView {
+-        id: listView
+-        anchors.fill: parent
+-        model: resetInConstructorModel
+-
+-        delegate: Rectangle {
+-            implicitWidth: 100
+-            implicitHeight: 50
+-            color: "olivedrab"
+-
+-            required property string display
+-        }
+-    }
+-}
+diff --git a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/tst_qqmldelegatemodel.cpp b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/tst_qqmldelegatemodel.cpp
+index d9f8b7aeba..2cacda5513 100644
+--- a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/tst_qqmldelegatemodel.cpp
++++ b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/tst_qqmldelegatemodel.cpp
+@@ -4,7 +4,6 @@
+ #include <QtTest/qtest.h>
+ #include <QtCore/qjsonobject.h>
+ #include <QtCore/QConcatenateTablesProxyModel>
+-#include <QtCore/qtimer.h>
+ #include <QtGui/QStandardItemModel>
+ #include <QtQml/qqmlcomponent.h>
+ #include <QtQml/qqmlapplicationengine.h>
+@@ -12,17 +11,11 @@
+ #include <QtQmlModels/private/qqmllistmodel_p.h>
+ #include <QtQuick/qquickview.h>
+ #include <QtQuick/qquickitem.h>
+-#include <QtQuick/private/qquickitemview_p_p.h>
+-#include <QtQuick/private/qquicklistview_p.h>
+-#include <QtQuickTest/quicktest.h>
+ #include <QtQuickTestUtils/private/qmlutils_p.h>
+-#include <QtQuickTestUtils/private/visualtestutils_p.h>
+ #include <QtTest/QSignalSpy>
+ 
+ #include <forward_list>
+ 
+-using namespace QQuickVisualTestUtils;
+-
+ class tst_QQmlDelegateModel : public QQmlDataTest
+ {
+     Q_OBJECT
+@@ -32,8 +25,6 @@ public:
+ 
+ private slots:
+     void resettingRolesRespected();
+-    void resetInQAIMConstructor();
+-    void reset();
+     void valueWithoutCallingObjectFirst_data();
+     void valueWithoutCallingObjectFirst();
+     void qtbug_86017();
+@@ -53,9 +44,16 @@ private slots:
+     void viewUpdatedOnDelegateChoiceAffectingRoleChange();
+ };
+ 
+-class BaseAbstractItemModel : public QAbstractItemModel
++class AbstractItemModel : public QAbstractItemModel
+ {
++    Q_OBJECT
+ public:
++    AbstractItemModel()
++    {
++        for (int i = 0; i < 3; ++i)
++            mValues.append(QString::fromLatin1("Item %1").arg(i));
++    }
++
+     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override
+     {
+         if (parent.isValid())
+@@ -93,21 +91,10 @@ public:
+         return mValues.at(index.row());
+     }
+ 
+-protected:
++private:
+     QVector<QString> mValues;
+ };
+ 
+-class AbstractItemModel : public BaseAbstractItemModel
+-{
+-    Q_OBJECT
+-public:
+-    AbstractItemModel()
+-    {
+-        for (int i = 0; i < 3; ++i)
+-            mValues.append(QString::fromLatin1("Item %1").arg(i));
+-    }
+-};
+-
+ tst_QQmlDelegateModel::tst_QQmlDelegateModel()
+     : QQmlDataTest(QT_QMLTEST_DATADIR)
+ {
+@@ -166,109 +153,7 @@ void tst_QQmlDelegateModel::resettingRolesRespected()
+     QObject *root = engine.rootObjects().constFirst();
+     QVERIFY(!root->property("success").toBool());
+     model->change();
+-    QTRY_VERIFY_WITH_TIMEOUT(root->property("success").toBool(), 100);
+-}
+-
+-class ResetInConstructorModel : public BaseAbstractItemModel
+-{
+-    Q_OBJECT
+-    QML_ELEMENT
+-
+-public:
+-    ResetInConstructorModel()
+-    {
+-        beginResetModel();
+-        QTimer::singleShot(0, this, &ResetInConstructorModel::finishReset);
+-    }
+-
+-private:
+-    void finishReset()
+-    {
+-        mValues.append("First");
+-        endResetModel();
+-    }
+-};
+-
+-void tst_QQmlDelegateModel::resetInQAIMConstructor()
+-{
+-    qmlRegisterTypesAndRevisions<ResetInConstructorModel>("Test", 1);
+-
+-    QQuickApplicationHelper helper(this, "resetInQAIMConstructor.qml");
+-    QVERIFY2(helper.ready, helper.failureMessage());
+-    QQuickWindow *window = helper.window;
+-    window->show();
+-    QVERIFY(QTest::qWaitForWindowExposed(window));
+-
+-    auto *listView = window->property("listView").value<QQuickListView *>();
+-    QVERIFY(listView);
+-    QTRY_VERIFY_WITH_TIMEOUT(listView->itemAtIndex(0), 100);
+-    QQuickItem *firstDelegateItem = listView->itemAtIndex(0);
+-    QVERIFY(firstDelegateItem);
+-    QCOMPARE(firstDelegateItem->property("display").toString(), "First");
+-}
+-
+-class ResettableModel : public BaseAbstractItemModel
+-{
+-    Q_OBJECT
+-    QML_ELEMENT
+-
+-public:
+-    ResettableModel()
+-    {
+-        mValues.append("First");
+-    }
+-
+-    void callBeginResetModel()
+-    {
+-        beginResetModel();
+-        mValues.clear();
+-    }
+-
+-    void appendData()
+-    {
+-        mValues.append(QString::fromLatin1("Item %1").arg(mValues.size()));
+-    }
+-
+-    void callEndResetModel()
+-    {
+-        endResetModel();
+-    }
+-};
+-
+-// Tests that everything works as expected when calling beginResetModel/endResetModel
+-// after the QAIM subclass constructor has run.
+-void tst_QQmlDelegateModel::reset()
+-{
+-    qmlRegisterTypesAndRevisions<ResettableModel>("Test", 1);
+-
+-    QQuickApplicationHelper helper(this, "reset.qml");
+-    QVERIFY2(helper.ready, helper.failureMessage());
+-    QQuickWindow *window = helper.window;
+-    window->show();
+-    QVERIFY(QTest::qWaitForWindowExposed(window));
+-
+-    auto *listView = window->property("listView").value<QQuickListView *>();
+-    QVERIFY(listView);
+-    QQuickItem *firstDelegateItem = listView->itemAtIndex(0);
+-    QVERIFY(firstDelegateItem);
+-    QCOMPARE(firstDelegateItem->property("display").toString(), "First");
+-
+-    const auto delegateModel = QQuickItemViewPrivate::get(listView)->model;
+-    QSignalSpy rootIndexChangedSpy(delegateModel, SIGNAL(rootIndexChanged()));
+-    QVERIFY(rootIndexChangedSpy.isValid());
+-
+-    auto *model = listView->model().value<ResettableModel *>();
+-    model->callBeginResetModel();
+-    model->appendData();
+-    model->callEndResetModel();
+-    // This is verifies that handleModelReset isn't called
+-    // more than once during this process, since it unconditionally emits rootIndexChanged.
+-    QCOMPARE(rootIndexChangedSpy.count(), 1);
+-
+-    QTRY_VERIFY_WITH_TIMEOUT(listView->itemAtIndex(0), 100);
+-    firstDelegateItem = listView->itemAtIndex(0);
+-    QVERIFY(firstDelegateItem);
+-    QCOMPARE(firstDelegateItem->property("display").toString(), "Item 0");
++    QTRY_VERIFY(root->property("success").toBool());
+ }
+ 
+ void tst_QQmlDelegateModel::valueWithoutCallingObjectFirst_data()
+-- 
+2.46.2
+

--- a/runtime-desktop/qt-6/autobuild/patches/0009-QQmlDelegateModel-fix-delegates-not-being-created-in.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0009-QQmlDelegateModel-fix-delegates-not-being-created-in.patch
@@ -1,0 +1,473 @@
+From c6cfc217414f4e0d86bbc7d21201ea1c32395b84 Mon Sep 17 00:00:00 2001
+From: Mitch Curtis <mitch.curtis@qt.io>
+Date: Tue, 24 Sep 2024 10:22:12 +0800
+Subject: [PATCH 09/12] QQmlDelegateModel: fix delegates not being created in
+ certain cases v2
+
+Since 837c2f18cd223707e7cedb213257b0158ea07146, we connect to
+modelAboutToBeReset rather than modelReset so that we can handle role
+name changes. _q_modelAboutToBeReset now connects modelReset to
+handleModelReset with a single shot connection instead.
+
+However, it's possible for user code to begin the reset before
+connectToAbstractItemModel is called (QTBUG-125053), in which case we
+connect to modelReset too late and handleModelReset is never called,
+resulting in delegates not being created in certain cases.
+
+So, we check at the earliest point we can if the model is in the
+process of being reset, and if so, connect modelReset to
+handleModelReset.
+
+This is a less intrusive alternative to
+6561344dd2d1ba69abe6edec4fe340b256da9e13, which caused regressions and
+was reverted.
+
+Fixes: QTBUG-125053
+Task-number: QTBUG-127340
+Pick-to: 6.7 6.5
+Change-Id: I2bfe192ed61eddaa481de4b1e14b1fa5d07a51c1
+Reviewed-by: Richard Moe Gustavsen <richard.gustavsen@qt.io>
+(cherry picked from commit 4bb16ce2c8ea94f768991593a581c8838d48f3a3)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+---
+ .../src/qmlmodels/qqmldelegatemodel.cpp       |  17 ++
+ .../auto/qml/qqmldelegatemodel/CMakeLists.txt |   1 +
+ ...yModelWithDelayedSourceModelInListView.qml |  30 +++
+ .../auto/qml/qqmldelegatemodel/data/reset.qml |  28 +++
+ .../data/resetInQAIMConstructor.qml           |  28 +++
+ .../tst_qqmldelegatemodel.cpp                 | 210 +++++++++++++++++-
+ 6 files changed, 304 insertions(+), 10 deletions(-)
+ create mode 100644 qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/proxyModelWithDelayedSourceModelInListView.qml
+ create mode 100644 qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/reset.qml
+ create mode 100644 qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/resetInQAIMConstructor.qml
+
+diff --git a/qtdeclarative/src/qmlmodels/qqmldelegatemodel.cpp b/qtdeclarative/src/qmlmodels/qqmldelegatemodel.cpp
+index 8a1482cbf8..a4acbb85a6 100644
+--- a/qtdeclarative/src/qmlmodels/qqmldelegatemodel.cpp
++++ b/qtdeclarative/src/qmlmodels/qqmldelegatemodel.cpp
+@@ -3,6 +3,8 @@
+ 
+ #include "qqmldelegatemodel_p_p.h"
+ 
++#include <QtCore/private/qabstractitemmodel_p.h>
++
+ #include <QtQml/qqmlinfo.h>
+ 
+ #include <private/qqmlabstractdelegatecomponent_p.h>
+@@ -425,6 +427,21 @@ void QQmlDelegateModel::setModel(const QVariant &model)
+         _q_itemsInserted(0, d->adaptorModelCount());
+         d->requestMoreIfNecessary();
+     }
++
++    // Since 837c2f18cd223707e7cedb213257b0158ea07146, we connect to modelAboutToBeReset
++    // rather than modelReset so that we can handle role name changes. _q_modelAboutToBeReset
++    // now connects modelReset to handleModelReset with a single shot connection instead.
++    // However, it's possible for user code to begin the reset before connectToAbstractItemModel is called
++    // (QTBUG-125053), in which case we connect to modelReset too late and handleModelReset is never called,
++    // resulting in delegates not being created in certain cases.
++    // So, we check at the earliest point we can if the model is in the process of being reset,
++    // and if so, connect modelReset to handleModelReset.
++    if (d->m_adaptorModel.adaptsAim()) {
++        auto *aim = d->m_adaptorModel.aim();
++        auto *aimPrivate = QAbstractItemModelPrivate::get(aim);
++        if (aimPrivate->resetting)
++            QObject::connect(aim, &QAbstractItemModel::modelReset, this, &QQmlDelegateModel::handleModelReset, Qt::SingleShotConnection);
++    }
+ }
+ 
+ /*!
+diff --git a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/CMakeLists.txt b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/CMakeLists.txt
+index 8d8a90e0a7..966f5229df 100644
+--- a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/CMakeLists.txt
++++ b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/CMakeLists.txt
+@@ -29,6 +29,7 @@ qt_internal_add_test(tst_qqmldelegatemodel
+         Qt::QmlModelsPrivate
+         Qt::QmlPrivate
+         Qt::Quick
++        Qt::QuickPrivate
+         Qt::QuickTestUtilsPrivate
+     TESTDATA ${test_data}
+ )
+diff --git a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/proxyModelWithDelayedSourceModelInListView.qml b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/proxyModelWithDelayedSourceModelInListView.qml
+new file mode 100644
+index 0000000000..b6733bd38c
+--- /dev/null
++++ b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/proxyModelWithDelayedSourceModelInListView.qml
+@@ -0,0 +1,30 @@
++import QtQuick
++import Test
++
++Window {
++    id: root
++    title: listView.count
++
++    property alias listView: listView
++    property ProxySourceModel connectionModel: null
++
++    Component {
++        id: modelComponent
++        ProxySourceModel {}
++    }
++
++    ListView {
++        id: listView
++        anchors.fill: parent
++
++        delegate: Text {
++            text: model.Name
++        }
++
++        model: ProxyModel {
++            sourceModel: root.connectionModel
++        }
++    }
++
++    Component.onCompleted: root.connectionModel = modelComponent.createObject(root)
++}
+diff --git a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/reset.qml b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/reset.qml
+new file mode 100644
+index 0000000000..0fcd5e8afa
+--- /dev/null
++++ b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/reset.qml
+@@ -0,0 +1,28 @@
++import QtQuick
++import Test
++
++Window {
++    id: root
++    width: 200
++    height: 200
++
++    property alias listView: listView
++
++    ResettableModel {
++        id: resetModel
++    }
++
++    ListView {
++        id: listView
++        anchors.fill: parent
++        model: resetModel
++
++        delegate: Rectangle {
++            implicitWidth: 100
++            implicitHeight: 50
++            color: "olivedrab"
++
++            required property string display
++        }
++    }
++}
+diff --git a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/resetInQAIMConstructor.qml b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/resetInQAIMConstructor.qml
+new file mode 100644
+index 0000000000..cb1f226737
+--- /dev/null
++++ b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/data/resetInQAIMConstructor.qml
+@@ -0,0 +1,28 @@
++import QtQuick
++import Test
++
++Window {
++    id: root
++    width: 200
++    height: 200
++
++    property alias listView: listView
++
++    ResetInConstructorModel {
++        id: resetInConstructorModel
++    }
++
++    ListView {
++        id: listView
++        anchors.fill: parent
++        model: resetInConstructorModel
++
++        delegate: Rectangle {
++            implicitWidth: 100
++            implicitHeight: 50
++            color: "olivedrab"
++
++            required property string display
++        }
++    }
++}
+diff --git a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/tst_qqmldelegatemodel.cpp b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/tst_qqmldelegatemodel.cpp
+index 2cacda5513..3f08d8fc85 100644
+--- a/qtdeclarative/tests/auto/qml/qqmldelegatemodel/tst_qqmldelegatemodel.cpp
++++ b/qtdeclarative/tests/auto/qml/qqmldelegatemodel/tst_qqmldelegatemodel.cpp
+@@ -3,7 +3,9 @@
+ 
+ #include <QtTest/qtest.h>
+ #include <QtCore/qjsonobject.h>
++#include <QtCore/qsortfilterproxymodel.h>
+ #include <QtCore/QConcatenateTablesProxyModel>
++#include <QtCore/qtimer.h>
+ #include <QtGui/QStandardItemModel>
+ #include <QtQml/qqmlcomponent.h>
+ #include <QtQml/qqmlapplicationengine.h>
+@@ -11,11 +13,17 @@
+ #include <QtQmlModels/private/qqmllistmodel_p.h>
+ #include <QtQuick/qquickview.h>
+ #include <QtQuick/qquickitem.h>
++#include <QtQuick/private/qquickitemview_p_p.h>
++#include <QtQuick/private/qquicklistview_p.h>
++#include <QtQuickTest/quicktest.h>
+ #include <QtQuickTestUtils/private/qmlutils_p.h>
++#include <QtQuickTestUtils/private/visualtestutils_p.h>
+ #include <QtTest/QSignalSpy>
+ 
+ #include <forward_list>
+ 
++using namespace QQuickVisualTestUtils;
++
+ class tst_QQmlDelegateModel : public QQmlDataTest
+ {
+     Q_OBJECT
+@@ -25,6 +33,8 @@ public:
+ 
+ private slots:
+     void resettingRolesRespected();
++    void resetInQAIMConstructor();
++    void reset();
+     void valueWithoutCallingObjectFirst_data();
+     void valueWithoutCallingObjectFirst();
+     void qtbug_86017();
+@@ -42,18 +52,12 @@ private slots:
+     void doNotUnrefObjectUnderConstruction();
+     void clearCacheDuringInsertion();
+     void viewUpdatedOnDelegateChoiceAffectingRoleChange();
++    void proxyModelWithDelayedSourceModelInListView();
+ };
+ 
+-class AbstractItemModel : public QAbstractItemModel
++class BaseAbstractItemModel : public QAbstractItemModel
+ {
+-    Q_OBJECT
+ public:
+-    AbstractItemModel()
+-    {
+-        for (int i = 0; i < 3; ++i)
+-            mValues.append(QString::fromLatin1("Item %1").arg(i));
+-    }
+-
+     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override
+     {
+         if (parent.isValid())
+@@ -91,10 +95,21 @@ public:
+         return mValues.at(index.row());
+     }
+ 
+-private:
++protected:
+     QVector<QString> mValues;
+ };
+ 
++class AbstractItemModel : public BaseAbstractItemModel
++{
++    Q_OBJECT
++public:
++    AbstractItemModel()
++    {
++        for (int i = 0; i < 3; ++i)
++            mValues.append(QString::fromLatin1("Item %1").arg(i));
++    }
++};
++
+ tst_QQmlDelegateModel::tst_QQmlDelegateModel()
+     : QQmlDataTest(QT_QMLTEST_DATADIR)
+ {
+@@ -153,7 +168,109 @@ void tst_QQmlDelegateModel::resettingRolesRespected()
+     QObject *root = engine.rootObjects().constFirst();
+     QVERIFY(!root->property("success").toBool());
+     model->change();
+-    QTRY_VERIFY(root->property("success").toBool());
++    QTRY_VERIFY_WITH_TIMEOUT(root->property("success").toBool(), 100);
++}
++
++class ResetInConstructorModel : public BaseAbstractItemModel
++{
++    Q_OBJECT
++    QML_ELEMENT
++
++public:
++    ResetInConstructorModel()
++    {
++        beginResetModel();
++        QTimer::singleShot(0, this, &ResetInConstructorModel::finishReset);
++    }
++
++private:
++    void finishReset()
++    {
++        mValues.append("First");
++        endResetModel();
++    }
++};
++
++void tst_QQmlDelegateModel::resetInQAIMConstructor()
++{
++    qmlRegisterTypesAndRevisions<ResetInConstructorModel>("Test", 1);
++
++    QQuickApplicationHelper helper(this, "resetInQAIMConstructor.qml");
++    QVERIFY2(helper.ready, helper.failureMessage());
++    QQuickWindow *window = helper.window;
++    window->show();
++    QVERIFY(QTest::qWaitForWindowExposed(window));
++
++    auto *listView = window->property("listView").value<QQuickListView *>();
++    QVERIFY(listView);
++    QTRY_VERIFY_WITH_TIMEOUT(listView->itemAtIndex(0), 100);
++    QQuickItem *firstDelegateItem = listView->itemAtIndex(0);
++    QVERIFY(firstDelegateItem);
++    QCOMPARE(firstDelegateItem->property("display").toString(), "First");
++}
++
++class ResettableModel : public BaseAbstractItemModel
++{
++    Q_OBJECT
++    QML_ELEMENT
++
++public:
++    ResettableModel()
++    {
++        mValues.append("First");
++    }
++
++    void callBeginResetModel()
++    {
++        beginResetModel();
++        mValues.clear();
++    }
++
++    void appendData()
++    {
++        mValues.append(QString::fromLatin1("Item %1").arg(mValues.size()));
++    }
++
++    void callEndResetModel()
++    {
++        endResetModel();
++    }
++};
++
++// Tests that everything works as expected when calling beginResetModel/endResetModel
++// after the QAIM subclass constructor has run.
++void tst_QQmlDelegateModel::reset()
++{
++    qmlRegisterTypesAndRevisions<ResettableModel>("Test", 1);
++
++    QQuickApplicationHelper helper(this, "reset.qml");
++    QVERIFY2(helper.ready, helper.failureMessage());
++    QQuickWindow *window = helper.window;
++    window->show();
++    QVERIFY(QTest::qWaitForWindowExposed(window));
++
++    auto *listView = window->property("listView").value<QQuickListView *>();
++    QVERIFY(listView);
++    QQuickItem *firstDelegateItem = listView->itemAtIndex(0);
++    QVERIFY(firstDelegateItem);
++    QCOMPARE(firstDelegateItem->property("display").toString(), "First");
++
++    const auto delegateModel = QQuickItemViewPrivate::get(listView)->model;
++    QSignalSpy rootIndexChangedSpy(delegateModel, SIGNAL(rootIndexChanged()));
++    QVERIFY(rootIndexChangedSpy.isValid());
++
++    auto *model = listView->model().value<ResettableModel *>();
++    model->callBeginResetModel();
++    model->appendData();
++    model->callEndResetModel();
++    // This is verifies that handleModelReset isn't called
++    // more than once during this process, since it unconditionally emits rootIndexChanged.
++    QCOMPARE(rootIndexChangedSpy.count(), 1);
++
++    QTRY_VERIFY_WITH_TIMEOUT(listView->itemAtIndex(0), 100);
++    firstDelegateItem = listView->itemAtIndex(0);
++    QVERIFY(firstDelegateItem);
++    QCOMPARE(firstDelegateItem->property("display").toString(), "Item 0");
+ }
+ 
+ void tst_QQmlDelegateModel::valueWithoutCallingObjectFirst_data()
+@@ -616,6 +733,79 @@ void tst_QQmlDelegateModel::viewUpdatedOnDelegateChoiceAffectingRoleChange()
+     QVERIFY(returnedValue);
+ }
+ 
++class ProxySourceModel : public QAbstractListModel
++{
++    Q_OBJECT
++    QML_ELEMENT
++public:
++    explicit ProxySourceModel(QObject *parent = nullptr)
++        : QAbstractListModel(parent)
++    {
++        for (int i = 0; i < rows; ++i) {
++            beginInsertRows(QModelIndex(), i, i);
++            endInsertRows();
++        }
++    }
++
++    ~ProxySourceModel() override = default;
++
++    int rowCount(const QModelIndex &) const override
++    {
++        return rows;
++    }
++
++    QVariant data(const QModelIndex &, int ) const override
++    {
++        return "Hello";
++    }
++
++    QHash<int, QByteArray> roleNames() const override
++    {
++        QHash<int, QByteArray> roles = QAbstractListModel::roleNames();
++        roles[Qt::UserRole + 1] = "Name";
++
++        return roles;
++    }
++
++    static const int rows = 1;
++};
++
++class ProxyModel : public QSortFilterProxyModel
++{
++    Q_OBJECT
++    QML_ELEMENT
++    Q_PROPERTY(QAbstractItemModel *sourceModel READ sourceModel WRITE setSourceModel)
++
++public:
++    explicit ProxyModel(QObject *parent = nullptr)
++        : QSortFilterProxyModel(parent)
++    {
++    }
++
++    ~ProxyModel() override = default;
++};
++
++// Checks that the correct amount of delegates are created when using a proxy
++// model whose source model is set after a delay.
++void tst_QQmlDelegateModel::proxyModelWithDelayedSourceModelInListView()
++{
++    QTest::failOnWarning();
++
++    qmlRegisterTypesAndRevisions<ProxySourceModel>("Test", 1);
++    qmlRegisterTypesAndRevisions<ProxyModel>("Test", 1);
++
++    QQuickApplicationHelper helper(this, "proxyModelWithDelayedSourceModelInListView.qml");
++    QVERIFY2(helper.ready, helper.failureMessage());
++    QQuickWindow *window = helper.window;
++    window->show();
++    QVERIFY(QTest::qWaitForWindowExposed(window));
++
++    auto *listView = window->property("listView").value<QQuickListView *>();
++    QVERIFY(listView);
++    const auto delegateModel = QQuickItemViewPrivate::get(listView)->model;
++    QTRY_COMPARE(listView->count(), 1);
++}
++
+ QTEST_MAIN(tst_QQmlDelegateModel)
+ 
+ #include "tst_qqmldelegatemodel.moc"
+-- 
+2.46.2
+

--- a/runtime-desktop/qt-6/autobuild/patches/0010-QAbstractItemModelPrivate-add-resetting-member.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0010-QAbstractItemModelPrivate-add-resetting-member.patch
@@ -1,0 +1,83 @@
+From c672b4d3432181b57ecb56caf1e698d07a31a28f Mon Sep 17 00:00:00 2001
+From: Mitch Curtis <mitch.curtis@qt.io>
+Date: Tue, 24 Sep 2024 10:40:37 +0800
+Subject: [PATCH 10/12] QAbstractItemModelPrivate: add resetting member
+
+This allows QQmlDelegateModel to know if a QAbstractItemModel subclass
+is in the process of a reset, which it can't know if beginResetModel
+was called in the model's constructor.
+
+As an added bonus, it also allows us to warn the user if they call
+endResetModel with a previous call to beginResetModel.
+
+Task-number: QTBUG-125053
+Task-number: QTBUG-127340
+Pick-to: 6.5
+Change-Id: I7d1fb983e9bf868c48472624ad945ae158115943
+Reviewed-by: Richard Moe Gustavsen <richard.gustavsen@qt.io>
+(cherry picked from commit 9d8663c18e88cb0b5a65f86cfd7726f3d31e04d6)
+(cherry picked from commit 2ea3abed0125d81ca4f3bacb9650db7314657332)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+---
+ .../src/corelib/itemmodels/qabstractitemmodel.cpp   | 13 +++++++++++++
+ .../src/corelib/itemmodels/qabstractitemmodel_p.h   |  4 ++++
+ 2 files changed, 17 insertions(+)
+
+diff --git a/qtbase/src/corelib/itemmodels/qabstractitemmodel.cpp b/qtbase/src/corelib/itemmodels/qabstractitemmodel.cpp
+index dbc3cd3872..aae736af9c 100644
+--- a/qtbase/src/corelib/itemmodels/qabstractitemmodel.cpp
++++ b/qtbase/src/corelib/itemmodels/qabstractitemmodel.cpp
+@@ -3395,6 +3395,13 @@ void QAbstractItemModel::endMoveColumns()
+ */
+ void QAbstractItemModel::beginResetModel()
+ {
++    Q_D(QAbstractItemModel);
++    if (d->resetting) {
++        qWarning() << "beginResetModel called on" << this << "without calling endResetModel first";
++        // Warn, but don't return early in case user code relies on the incorrect behavior.
++    }
++
++    d->resetting = true;
+     emit modelAboutToBeReset(QPrivateSignal());
+ }
+ 
+@@ -3412,8 +3419,14 @@ void QAbstractItemModel::beginResetModel()
+ void QAbstractItemModel::endResetModel()
+ {
+     Q_D(QAbstractItemModel);
++    if (!d->resetting) {
++        qWarning() << "endResetModel called on" << this << "without calling beginResetModel first";
++        // Warn, but don't return early in case user code relies on the incorrect behavior.
++    }
++
+     d->invalidatePersistentIndexes();
+     resetInternalData();
++    d->resetting = false;
+     emit modelReset(QPrivateSignal());
+ }
+ 
+diff --git a/qtbase/src/corelib/itemmodels/qabstractitemmodel_p.h b/qtbase/src/corelib/itemmodels/qabstractitemmodel_p.h
+index e34dc3262c..c2113fde9a 100644
+--- a/qtbase/src/corelib/itemmodels/qabstractitemmodel_p.h
++++ b/qtbase/src/corelib/itemmodels/qabstractitemmodel_p.h
+@@ -45,6 +45,8 @@ public:
+     QAbstractItemModelPrivate();
+     ~QAbstractItemModelPrivate();
+ 
++    static const QAbstractItemModelPrivate *get(const QAbstractItemModel *model) { return model->d_func(); }
++
+     void removePersistentIndexData(QPersistentModelIndexData *data);
+     void movePersistentIndexes(const QList<QPersistentModelIndexData *> &indexes, int change, const QModelIndex &parent,
+                                Qt::Orientation orientation);
+@@ -115,6 +117,8 @@ public:
+         void insertMultiAtEnd(const QModelIndex& key, QPersistentModelIndexData *data);
+     } persistent;
+ 
++    bool resetting = false;
++
+     static const QHash<int,QByteArray> &defaultRoleNames();
+     static bool isVariantLessThan(const QVariant &left, const QVariant &right,
+                                   Qt::CaseSensitivity cs = Qt::CaseSensitive, bool isLocaleAware = false);
+-- 
+2.46.2
+

--- a/runtime-desktop/qt-6/autobuild/patches/0011-LOONGARCH64-qtwebengine-chromium-skip-unreliable-ter.patch.loongarch64
+++ b/runtime-desktop/qt-6/autobuild/patches/0011-LOONGARCH64-qtwebengine-chromium-skip-unreliable-ter.patch.loongarch64
@@ -1,7 +1,7 @@
-From be2c780778d746d9e851c23b5c5e48960871eab2 Mon Sep 17 00:00:00 2001
+From f71b3e338528a48b18782aa05883f72a15f3b879 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Mon, 1 Jul 2024 11:25:04 +0800
-Subject: [PATCH 7/8] [LOONGARCH64] qtwebengine: chromium: skip unreliable
+Subject: [PATCH 11/12] [LOONGARCH64] qtwebengine: chromium: skip unreliable
  terser plugin
 
 Co-authored-by: Jiajie Chen <c@jia.je>
@@ -31,5 +31,5 @@ index fe205b0327..a14df757d3 100644
        name: 'devtools-plugin',
        resolveId(source, importer) {
 -- 
-2.46.0
+2.46.2
 

--- a/runtime-desktop/qt-6/autobuild/patches/0012-LOONGARCH64-qtwebengine-chromium-add-LoongArch-suppo.patch.loongarch64
+++ b/runtime-desktop/qt-6/autobuild/patches/0012-LOONGARCH64-qtwebengine-chromium-add-LoongArch-suppo.patch.loongarch64
@@ -1,7 +1,7 @@
-From 0e525c99748978362fc40eb327aa1d4bb77a8795 Mon Sep 17 00:00:00 2001
+From d35265a98dd30e14b2b4d7600bb1768410c3517b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Mon, 1 Jul 2024 11:25:38 +0800
-Subject: [PATCH 8/8] [LOONGARCH64] qtwebengine: chromium: add LoongArch
+Subject: [PATCH 12/12] [LOONGARCH64] qtwebengine: chromium: add LoongArch
  support
 
 Co-authored-by: Jiajie Chen <c@jia.je>
@@ -9866,5 +9866,5 @@ index c8dc590ac9..3c9f4cb4ed 100644
      arch = "ppc64";
    } else if (std::string(info.sysname) == "OS/390") {
 -- 
-2.46.0
+2.46.2
 

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,5 +1,4 @@
-VER=6.7.2
-REL=3
+VER=6.7.3
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
-CHKSUMS="sha256::0aaea247db870193c260e8453ae692ca12abc1bd841faa1a6e6c99459968ca8a"
+CHKSUMS="sha256::a3f1d257cbb14c6536585ffccf7c203ce7017418e1a0c2ed7c316c20c729c801"
 CHKUPDATE="anitya::id=7927"


### PR DESCRIPTION
Topic Description
-----------------

- qt-6: update to 6.7.3
    - Track patches at AOSC-Tracking/qt-6 @ aosc/v6.7.3.
    - Backport fixes for QTBUG-127340, QTBUG-129509.[^1][^2]
    [^1]: https://bugreports.qt.io/browse/QTBUG-127340
    [^2]: https://bugreports.qt.io/browse/QTBUG-129509

Package(s) Affected
-------------------

- qt-6: 6.7.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
