### PR TITLE
ffmpeg (FFmpeg): enable SVT-AV1 codec

### DIFF
--- a/app-multimedia/ffmpeg/autobuild/build
+++ b/app-multimedia/ffmpeg/autobuild/build
@@ -66,7 +66,8 @@ CONFIGURE_OPTIONS=" \
     --enable-version3 \
     --enable-vaapi \
     --enable-libaom \
-    --enable-libsmbclient"
+    --enable-libsmbclient \
+    --enable-libsvtav1"
 
 # FIXME: lto1: fatal error: target specific builtin not available
 # Potentially a compiler bug?

--- a/app-multimedia/ffmpeg/autobuild/defines
+++ b/app-multimedia/ffmpeg/autobuild/defines
@@ -1,9 +1,10 @@
 PKGNAME=ffmpeg
 PKGSEC=sound
-PKGDEP="alsa-lib bzip2 fontconfig freetype fribidi gnutls gsm lame libass libbluray \
-        libmodplug pulseaudio libssh libtheora libvdpau libvorbis libvpx libxcb \
-        x264 x265 opencore-amr opus schroedinger sdl speex v4l-utils xvidcore \
-        zlib soxr libva sdl2 numactl ladspa-sdk xz aom samba dav1d avisynthplus"
+PKGDEP="alsa-lib bzip2 fontconfig freetype fribidi gnutls gsm lame libass \
+        libbluray libmodplug pulseaudio libssh libtheora libvdpau libvorbis \
+        libvpx libxcb x264 x265 opencore-amr opus schroedinger sdl speex \
+        v4l-utils xvidcore zlib soxr libva sdl2 numactl ladspa-sdk xz aom \
+        samba dav1d avisynthplus svt-av1"
 PKGDEP__AMD64="${PKGDEP} intel-media-sdk"
 BUILDDEP__AMD64="${BUILDDEP} yasm ffnvcodec llvm"
 BUILDDEP_ARM64="${BUILDDEP} yasm"

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,4 +1,5 @@
 VER=7.1
+REL=1
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6"
 CHKUPDATE="anitya::id=5405"


### PR DESCRIPTION
Topic Description
-----------------

- ffmpeg: enable SVT-AV1 codec

Package(s) Affected
-------------------

- ffmpeg: 7.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
