### PR TITLE
gnome-base: drop gnome-remote-desktop

### DIFF
--- a/desktop-gnome/gnome-shell/autobuild/defines
+++ b/desktop-gnome/gnome-shell/autobuild/defines
@@ -5,7 +5,8 @@ PKGDEP="accountsservice gcr gjs gnome-bluetooth gnome-menus upower \
         libcanberra libcroco libsecret mutter network-manager-applet \
         telepathy-logger telepathy-mission-control unzip gstreamer-1-0 \
         evolution-data-server libgsystem python-3 gnome-autoar \
-        gnome-control-center gtk-4 xdg-desktop-portal-gnome"
+        gnome-control-center gtk-4 xdg-desktop-portal-gnome \
+        gtk-update-icon-cache"
 BUILDDEP="appstream-glib gobject-introspection gtk-doc intltool \
           sassc asciidoc"
 PKGDES="The default GNOME desktop interface"

--- a/desktop-gnome/gnome-shell/spec
+++ b/desktop-gnome/gnome-shell/spec
@@ -1,5 +1,5 @@
 VER=42.4
-REL=2
+REL=3
 SRCS="https://download.gnome.org/sources/gnome-shell/${VER%%.*}/gnome-shell-$VER.tar.xz"
 CHKSUMS="sha256::875ff2970ea9fb7a05506e32a0d50dc917f41b4ca37134b41377f9c82873c54e"
 CHKUPDATE="anitya::id=5409"

--- a/meta-bases/gnome-base/autobuild/defines
+++ b/meta-bases/gnome-base/autobuild/defines
@@ -7,7 +7,7 @@ PKGRECOM="baobab brasero celluloid chrome-gnome-shell desktop-base eog \
           gnome-contacts gnome-disk-utility gnome-font-viewer \
           gnome-getting-started-docs gnome-initial-setup gnome-logs \
           gnome-maps gnome-packagekit gnome-power-manager \
-          gnome-remote-desktop gnome-shell-extensions gnome-sound-recorder \
+          gnome-shell-extensions gnome-sound-recorder \
           gnome-system-monitor gnome-terminal gnome-tweaks gnome-user-docs \
           gnome-weather nautilus polari simple-scan"
 PKGDES="Meta package for GNOME desktop environment"

--- a/meta-bases/gnome-base/spec
+++ b/meta-bases/gnome-base/spec
@@ -1,3 +1,5 @@
-VER=5
-DUMMYSRC=1
+VER=6
+# FIXME: APT may crash whilst fetch packages with a single-digit version and
+# no REL.
 REL=1
+DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- gnome-shell: add gtk-update-icon-cache dep
- gnome-base: drop gnome-remote-desktop
    This package was temporarily dropped in the FFmpeg 7.0.2 update.

Package(s) Affected
-------------------

- gnome-base: 6
- gnome-control-center: 42.3-2
- gnome-shell: 42.4-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnome-control-center gnome-shell gnome-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
