### PR TITLE
vkmark: update to 2017.08

### DIFF
--- a/app-benchmarks/vkmark/spec
+++ b/app-benchmarks/vkmark/spec
@@ -1,4 +1,4 @@
-VER=2017.08+git20230412
+VER=2017.08
 SRCS="git::commit=ab6e6f34077722d5ae33f6bd40b18ef9c0e99a15::https://github.com/vkmark/vkmark.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15696"


### PR DESCRIPTION
Topic Description
-----------------

- vkmark: update to 2017.08
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- vkmark: 2017.08

Security Update?
----------------

No

Build Order
-----------

```
#buildit vkmark
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
