### PR TITLE
nodejs: update to 20.18.0

### DIFF
--- a/lang-js/nodejs/spec
+++ b/lang-js/nodejs/spec
@@ -2,3 +2,5 @@ VER=20.18.0
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
 CHKSUMS="sha256::7d9433e91fd88d82ba8de86e711ec41907638e227993d22e95126b02f6cd714a"
 CHKUPDATE="anitya::id=369796"
+# Note: Node.js currently requires large memory to build
+ENVREQ__LOONGARCH64="total_mem=30"

--- a/lang-js/nodejs/spec
+++ b/lang-js/nodejs/spec
@@ -1,4 +1,4 @@
-VER=20.16.0
+VER=20.18.0
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
-CHKSUMS="sha256::cd6c8fc3ff2606aadbc7155db6f7e77247d2d0065ac18e2f7f049095584b8b46"
+CHKSUMS="sha256::7d9433e91fd88d82ba8de86e711ec41907638e227993d22e95126b02f6cd714a"
 CHKUPDATE="anitya::id=369796"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs: update to 20.18.0
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- nodejs: 2:20.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
