### PR TITLE
fvwm (F Virtual Window Manager): drop, orphaned

### DIFF
--- a/desktop-wm/fvwm/autobuild/defines
+++ b/desktop-wm/fvwm/autobuild/defines
@@ -1,4 +1,0 @@
-PKGNAME=fvwm
-PKGDES="A customizable X11 window manager with virtual desktop support"
-PKGSEC=x11
-PKGDEP="librsvg cairo libpng imlib2 fribidi readline"

--- a/desktop-wm/fvwm/spec
+++ b/desktop-wm/fvwm/spec
@@ -1,4 +1,0 @@
-VER=2.6.9
-SRCS="tbl::https://github.com/fvwmorg/fvwm/releases/download/${VER}/fvwm-${VER}.tar.gz"
-CHKSUMS="sha256::1bc64cf3ccd0073008758168327a8265b8059def9b239b451d6b9fab2cc391ae"
-CHKUPDATE="anitya::id=11128"


### PR DESCRIPTION
Topic Description
-----------------

- fvwm: drop, orphaned

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit fvwm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
