### PR TITLE
iosevka-fonts: update to 31.8.0

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=31.7.1
+VER=31.8.0
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::ba56a3fec0ee202bd6b68a0e591d06a1902f3f1ff8aa6f6f77d8c98ac1777f08 \
-         sha256::a15a4717019edf0c1ac59e9d7d11ebd8eb48e05d58e3017da1b0fe190bdd3df7 \
-         sha256::f822dfcde7342248d8787a3791dd61fc142b528bd22841b7c57565ad7a47f05d \
-         sha256::9596403176138140dba71bc6adf14168d528faa94b0b54a05454aff7b6c00b5a \
-         sha256::645645a3abfd112916104db30b9ef792182280319274db045927eb10826c87eb \
-         sha256::7738ba3952e1a43d94827f9ef88c1123350c61dc957cf62edf36edbe34056e95 \
-         sha256::fae919118ed5de08df7d5df768ad38285afac9a4b5efc6e20f4cced684d2a4e8 \
-         sha256::3cfd38d83a93d332b63fe09b7eb27ce8a30f723f898d957acfb780cb77bd3fe3 \
-         sha256::b2d298b6664a0a24402dfa2fde2e7939cd41554078fb59da69cf66454f4df328 \
-         sha256::1c01c89a36ab7fd31d82fe81b6c401d233b3ec49294cb54cdc4fbe6859616daa \
-         sha256::aa2e7ac4cdc67e2561ef4589d24a171b6d849b752b0bec5fc3c14d5432f72ae1 \
-         sha256::715c5ca224c7fe5c8208d2a4136ff92e1fc56e6990ec57ad9d974ff7bb7b71f4 \
-         sha256::54a36386289d9cd9b8ce40ee6555c6d96054f07d0f5cbb9cc3363e1df4c90e3d \
-         sha256::8387679dcfc74c2b5dd8b52334875f2969d3ac8d4d883d9e91f1aa3515a4ba7f \
-         sha256::3e1b9d9d670b156d01c688d0876afd6f31ce76681d4187f781242375cb30c634 \
-         sha256::6d874d622b43bf1ecb5d9ac9fcd6badebf58e58f34ee5943bdaecf0dde0432e3 \
-         sha256::f5782ecc40b835acd8a9c0433f479026622303204bf26fc3d3c628417aa90a16 \
-         sha256::73d122dbae341c27d557de632c917372c0a048c347ea50c49cd5ff22b431e861 \
-         sha256::d7de9217ca81054c4d43aeca77a7cf6dad9e177858c058a8b87cee3d60ababc9 \
-         sha256::690b21959398acd37e418ed734b24c71d37d6a5308c447f2b451f78745af71fa \
-         sha256::a32ef10c8a91385604a8529e16af029d32bbb53020dc8fd3f4122542a1a9c51f \
-         sha256::80697d8c4218e35e0071231cc66fbddb4dcf7d17a3d825ad6f477854157c693d \
-         sha256::cf5c9ce00f522c67fb972f3d323504e70e949d7b1cd436444efc14719379ab0f \
-         sha256::f12da2cd1822808c842509114e68d8bb2fa7c53d6e136d9cd629131c916f64a9 \
+CHKSUMS="sha256::e50fec11065acda7b39ec69a5c8cbad61064d64037596961d3d30b74750a239b \
+         sha256::a0b5e4b10337080a14131acaef950c81ffd6927d1ea46875d4df33751e6e92f3 \
+         sha256::1ee228437e621056a46845586136d2db0cbcea337851d1d450d5bdfe30e41cf0 \
+         sha256::0c9ab25d2798354780434b4fc4339b4732cceddc8aa20c993e27083abaf8262b \
+         sha256::ca5b55798ee94a518b86f2aaaf907ad7f658bf4347df7fb03538033fdba62205 \
+         sha256::dcb3f5766cb5e71017417e35541172dc260a9ece9e533f7e8d234ee16c708b2d \
+         sha256::d6ce032db2d4c27972ee5e4c19bea5d0723f2a4245ad74fecf1c8a78a9af5b0b \
+         sha256::bf889bef1c62c719c2cc3aa2842d0730df12175000d0a61d1eb6b1b989b8ee93 \
+         sha256::3287001dd8a09f9192c0ab5213108829f490bd0b1a7e58573bba99a474596d72 \
+         sha256::7280f8d24ee5714a2e8e99f6145154c5f6a7aa5ff2aaafc79a8cc6f879b80d77 \
+         sha256::13d1eaefa9de0cfee56623f595c80c8373818a59896f74930b5d557f3dad5a81 \
+         sha256::f6855e9aa2d5cf43d9deeac4f6ba199a97086fc4527a993098b58bd35fdfc0f7 \
+         sha256::510a0dad258194aadea85118c2e70284bff410774dc432d83cb88fb10a4cf2d8 \
+         sha256::59c6539a37cc936b7871a50ae056a9d3fe6286667911794354e8fbd3ac5ff2da \
+         sha256::6d4f2c966799b90b94ba606f0b1989eb26d56c43ae7ffbeed54f8391dca64899 \
+         sha256::5402c11fe71d5b2950f22161e97ffdaaa6851a5bf6824d6a308bd3b32de843c5 \
+         sha256::693991880134ec629b401bbbb69f8e65c0024e8c6d3f1f454a95f6821cdadd26 \
+         sha256::0928730699188f26db621e96e204868fabaf5f8eca60775348f220c00d0058e7 \
+         sha256::73f3eed86743876555cb74333346c869a62e86092839c3c60469135632408a8e \
+         sha256::4f12c44954344602370a63700b954766e588542dedcdd702fc65457701ec22b9 \
+         sha256::edb5c492f48ba4b677ba13ce6fd6e37b0b22232ad7bfdf3a67ca93765433ea31 \
+         sha256::fe0efcb9080d6d80464804b2ac3f1b463d9788e66eab8d3468e1f366e275ab3c \
+         sha256::126b5aae677110354a89247a2d0bcb2f1c8f71e16371ae269b1085bef9466e3f \
+         sha256::a65acbb6e5a2ef763f42c032ba11acc03475641fdcf675cb70e48d085e509c13 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 31.8.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 31.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
