### PR TITLE
upx: update to 4.2.4

### DIFF
--- a/app-devel/upx/spec
+++ b/app-devel/upx/spec
@@ -1,4 +1,4 @@
-VER=4.2.1
+VER=4.2.4
 SRCS="tbl::https://github.com/upx/upx/releases/download/v$VER/upx-$VER-src.tar.xz"
-CHKSUMS="sha256::cc562ea7dbd8cec4505edea68736e04030ec5891c1e2a300e3c0d0eac6364479"
+CHKSUMS="sha256::5ed6561607d27fb4ef346fc19f08a93696fa8fa127081e7a7114068306b8e1c4"
 CHKUPDATE="anitya::id=13737"


### PR DESCRIPTION
Topic Description
-----------------

- upx: update to 4.2.4
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- upx: 4.2.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit upx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
