### PR TITLE
qmidiarp: new, 0.7.1

### DIFF
--- a/app-multimedia/qmidiarp/autobuild/defines
+++ b/app-multimedia/qmidiarp/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=qmidiarp
+PKGDES="An arpeggiator for ALSA/JACK, as dedicated UI or LV2 plugins"
+PKGSEC=sound
+PKGDEP="qt-5 alsa-lib jack liblo lv2 libglvnd glu pango cairo"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER="-DCONFIG_APPBUILD=ON
+             -DCONFIG_JACK_MIDI=ON
+             -DCONFIG_ALSA_MIDI=ON
+             -DCONFIG_LV2=ON
+             -DCONFIG_LV2_UI=ON
+             -DCONFIG_LV2_UI_RTK=ON
+             -DCONFIG_NSM=ON
+             -DCONFIG_TRANSLATIONS=ON"

--- a/app-multimedia/qmidiarp/spec
+++ b/app-multimedia/qmidiarp/spec
@@ -1,0 +1,4 @@
+VER=0.7.1
+SRCS="tbl::https://sourceforge.net/projects/qmidiarp/files/qmidiarp/${VER}/qmidiarp-${VER}.tar.bz2/download"
+CHKSUMS="sha256::40d3bdbebbb6dd0a39f05c793446e4a33295692d9840e0627f8cb744d6f0e114"
+CHKUPDATE="anitya::id=8937"


### PR DESCRIPTION
Topic Description
-----------------

- qmidiarp: new, 0.7.1
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- qmidiarp: 0.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qmidiarp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
