### PR TITLE
p-vector: update to 0.7.0

### DIFF
--- a/app-admin/p-vector/spec
+++ b/app-admin/p-vector/spec
@@ -1,4 +1,4 @@
-VER=0.6.0
+VER=0.7.0
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/p-vector-rs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242069"


### PR DESCRIPTION
Topic Description
-----------------

- p-vector: update to 0.7.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- p-vector: 0.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit p-vector
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
