### PR TITLE
godot: (rework) clean up packaging

### DIFF
--- a/app-devel/godot/autobuild/build
+++ b/app-devel/godot/autobuild/build
@@ -23,22 +23,33 @@ else
 fi
 
 export BUILD_NAME=aosc
-scons platform=linuxbsd target=editor production=yes debug_symbols=yes \
-    arch=$GODOT_ARCH module_mono_enabled=$HAS_DOTNET $ADDITIONAL_PARAMS
+scons \
+    platform=linuxbsd \
+    target=editor \
+    production=yes \
+    debug_symbols=yes \
+    arch=$GODOT_ARCH \
+    module_mono_enabled=$HAS_DOTNET \
+    $ADDITIONAL_PARAMS
 
 EXE_NAME="godot.linuxbsd.editor.$GODOT_ARCH"
 
 if [[ "$HAS_DOTNET" = "yes" ]]; then
     abinfo "Building Godot C# binding ..."
     EXE_NAME+=".mono"
-    $SRCDIR/bin/$EXE_NAME --headless --generate-mono-glue $SRCDIR/modules/mono/glue
-    $SRCDIR/modules/mono/build_scripts/build_assemblies.py --godot-output-dir=$SRCDIR/bin --godot-platform=linuxbsd
+    "$SRCDIR"/bin/$EXE_NAME \
+        --headless \
+        --generate-mono-glue "$SRCDIR"/modules/mono/glue
+    "$SRCDIR"/modules/mono/build_scripts/build_assemblies.py \
+        --godot-output-dir="$SRCDIR"/bin \
+        --godot-platform=linuxbsd
 fi
 
 abinfo "Installing Godot..."
-install -dv $PKGDIR/usr/lib/godot/
+install -dv "$PKGDIR"/usr/lib/godot/
 if [[ "$HAS_DOTNET" = "yes" ]]; then
-    mv -v $SRCDIR/bin/GodotSharp $PKGDIR/usr/lib/godot/
+    mv -v "$SRCDIR"/bin/GodotSharp \
+        "$PKGDIR"/usr/lib/godot/
 fi
 install -Dvm755 $SRCDIR/bin/$EXE_NAME $PKGDIR/usr/lib/godot/godot
 install -Dvm644 $SRCDIR/icon.svg $PKGDIR/usr/share/icons/hicolor/scalable/apps/godot.svg

--- a/app-devel/godot/autobuild/defines
+++ b/app-devel/godot/autobuild/defines
@@ -4,10 +4,11 @@ PKGSEC=devel
 
 PKGDEP="x11-lib libglvnd glu alsa-lib pulseaudio systemd dotnet-sdk-8.0"
 PKGDEP__NO_DOTNET="x11-lib libglvnd glu alsa-lib pulseaudio systemd"
-PKGDEP__PPC64EL="${PKGDEP_NO_DOTNET}"
-PKGDEP__RISCV64="${PKGDEP_NO_DOTNET}"
-PKGDEP__LOONGARCH64="${PKGDEP_NO_DOTNET}"
+PKGDEP__PPC64EL="${PKGDEP__NO_DOTNET}"
+PKGDEP__RISCV64="${PKGDEP__NO_DOTNET}"
+PKGDEP__LOONGARCH64="${PKGDEP__NO_DOTNET}"
 
 BUILDDEP="pkg-config gcc scons"
 
+# FIXME: No support for these architecture(s) yet.
 FAIL_ARCH="loongson3"

--- a/app-devel/godot/spec
+++ b/app-devel/godot/spec
@@ -1,5 +1,5 @@
 VER=4.3
+REL=2
 SRCS="git::commit=tags/$VER-stable::https://github.com/godotengine/godot"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373975"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- godot: apply lint
    - Fix reference to ${PKGDEP__NO_DOTNET}.
    - Lint beyond in accordance with the Styling Manual.
    - Add a FIXME note for FAIL_ARCH.

Package(s) Affected
-------------------

- godot: 4.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit godot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
