### PR TITLE
dpdk: update to 24.07

### DIFF
--- a/runtime-network/dpdk/autobuild/defines
+++ b/runtime-network/dpdk/autobuild/defines
@@ -24,5 +24,10 @@ MESON_AFTER__ARM64="
 	${MESON_AFTER}
 	-Dplatform=generic
 "
+# FIXME: Lest the build system falls back to native for some reason...
+MESON_AFTER__RISCV64="
+        ${MESON_AFTER}
+        -Dcpu_instruction_set=rv64gc
+"
 
 FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el|riscv64)"

--- a/runtime-network/dpdk/spec
+++ b/runtime-network/dpdk/spec
@@ -1,5 +1,4 @@
-VER=22.11.1
+VER=24.07
 SRCS="tbl::http://fast.dpdk.org/rel/dpdk-${VER}.tar.xz"
-CHKSUMS="sha256::de076465f7174a0d52714b9072e4837a726baac82d8fe7dc644cad5c8cf74d4c"
+CHKSUMS="sha256::9944f7e5f268e7ac9b4193e2cd54ef6d98f6e1d7dddc967c77ae4f6616d6fbbd"
 CHKUPDATE="anitya::id=459"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- dpdk: update to 24.07
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dpdk: 24.07

Security Update?
----------------

No

Build Order
-----------

```
#buildit dpdk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
