### PR TITLE
nvchecker: update to 2.15.1

### DIFF
--- a/app-utils/nvchecker/autobuild/defines
+++ b/app-utils/nvchecker/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=nvchecker
 PKGSEC=utils
 PKGDEP="pycurl tornado structlog"
-BUILDDEP="setuptools"
+BUILDDEP="setuptools python-installer python-build wheel"
 PKGDES="New version checker for software releases"
 
+ABTYPE=pep517
 NOPYTHON2=1
 ABHOST=noarch

--- a/app-utils/nvchecker/spec
+++ b/app-utils/nvchecker/spec
@@ -1,5 +1,4 @@
-VER=1.5
-SRCS="tbl::https://github.com/lilydjwg/nvchecker/archive/v$VER.tar.gz"
-CHKSUMS="sha256::dba80d95a8e7eea633d887c04a4c0d2c7ad2a25550260208594b42c5e0091a70"
-REL=3
+VER=2.15.1
+SRCS="git::commit=tags/v$VER::https://github.com/lilydjwg/nvchecker"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=37582"


### PR DESCRIPTION
Topic Description
-----------------

- nvchecker: update to 2.15.1
    Specify pep517 ABTYPE

Package(s) Affected
-------------------

- nvchecker: 2.15.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvchecker
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
