### PR TITLE
Linux Firmware Survey 20241009

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,19 +1,19 @@
-UPSTREAM_VER=20240506
-DEBIANVER=20230210-5~bpo11+1
+UPSTREAM_VER=20241004
+DEBIANVER=20240909-1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 # When using a stable tag.
 # SRCS="git::commit=tags/${UPSTREAM_VER}::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
-SRCS="git::commit=b93493c01691104b9a9b612f9e161702418d10a3::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
-      file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.bin \
-      file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5/brcm/brcmfmac43456-sdio.clm_blob \
-      file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/292e1e5b5bc5756e9314ea6d494d561422d23264/rkwifi/nvram_ap6256.txt \
-      file::rename=BCM4345C5.hcd::https://github.com/armbian/firmware/raw/292e1e5b5bc5756e9314ea6d494d561422d23264/brcm/BCM4345C5.hcd \
-      tbl::rename=firmware-nonfree.debian.tar.xz::https://deb.debian.org/debian/pool/non-free/f/firmware-nonfree/firmware-nonfree_${DEBIANVER}.debian.tar.xz"
+SRCS="git::commit=919f79f9fb5536c1928a15ac82a2e53183b213cf::https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git \
+      file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
+      file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
+      file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \
+      file::rename=BCM4345C5.hcd::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/BCM4345C5.hcd \
+      tbl::rename=firmware-nonfree.debian.tar.xz::https://deb.debian.org/debian/pool/non-free-firmware/f/firmware-nonfree/firmware-nonfree_${DEBIANVER}.debian.tar.xz"
 CHKSUMS="SKIP \
          sha256::ddf83f2100885b166be52d21c8966db164fdd4e1d816aca2acc67ee9cc28d726 \
          sha256::2dbd7d22fc9af0eb560ceab45b19646d211bc7b34a1dd00c6bfac5dd6ba25e8a \
-         sha256::66c71eb53b47c49d42386b66735134578640b0946f3f46e44f384fef5aacfd9e \
+         sha256::588430b4c2c167ca035f17da7478bec3d4922487152610d385d5ccb8f7c0a75f \
          sha256::f67164f0eda8d4ca96305e177a61542bf8b470f2f1c456b66fe8c660650f1c7a \
-         sha256::6845d19bd8acd4466256cd29e12203ec6f2f63b8f7ca99a1ab8a91cf82822018"
+         sha256::29f592003e89e8fdb2d82ac9e07d6a0d53111509f78bb1285ad179e69c8551dc"
 CHKUPDATE="anitya::id=141464"
 SUBDIR="linux-firmware"


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update...
    - Update linux-firmware to the current HEAD, see below for notable changes.
    - Update RPi firmware-nonfree commit hash (files remain unchanged in the
    upstream repository).
    - Use nvram_ap6256.txt in the brcm folder of armbian/firmware.
    - Update firmware-nonfree to 20240909-1 from Debian unstable.
    Notable changes from linux-firmware.git:
    - AMD CPU microcode updates...
    - AMD Family 17/19h.
    - AMD GPU and platform fiwmare updates...
    - AMD Image Signal Processor (ISP) firmware updates.
    - AMD GPU firwmare updates for most Zen2+-based APUs, as well as GCN 5.0, RDNA 1.0/2.0/3.0/4.0 cores.
    - AMD SEV firmware updates...
    - Version 0.24 build 20 for AMD family 17h models 30h~3fh.
    - Version 1.55 build 21 for AMD family 19h models 00h~0fh.
    - Version 1.55 build 37 for AMD family 19h models 10h~1fh.
    - New: AMD SEV firmware version 1.55 build 37 for AMD family 19h models a0h~afh.
    - Intel GPU firmware updates...
    - ADL-P, DG1, DG2, MTL, TGL GuC v70.29.2.
    - BMG GuC v70.29.2.
    - BMG HuC v8.2.10.
    - DG2 HuC v7.10.16.
    - MTL DMC v2.23.
    - MTL GSC to v102.0.10.1878.
    - LNL GSC v104.0.0.1161.
    - LNL GuC v70.29.2.
    - LNL HuC v9.4.13.
    - Xe2LPD DMC v2.21.
    - Qualcomm QCM6490 GPU firmware updates...
    - qcom/a660_gmu.bin: v3.01.0B.
    - qcom/a660_sqe.fw: v1.12.
    - qcom/qcm6490/a660_zap.mbn: v0.09.
    - Wi-Fi, Bluetooth, and mobile broadband firmware updates...
    - Intel Wireless cc/Qu/QuZ (AX200/AX201) (core89-58).
    - Intel Wireless ty/So/Ma (AX210/AX211) (core88-87).
    - Intel Wireless gl (BE200) (core89-58).
    - Intel Wireless Bz (BE200) (core89-58).
    - Intel Bluetooth firmware update package 23.80.0.3...
    - Gale Peak2 (BE200), firmware version 23.80.24332.64815.
    - Garfield Peak2 (AX211), Johnson Peak2 (AX203), Harrison Peak1 (AX101), firmware version 23.50.24332.103427.
    - Typhoon Peak2 (AX210), firmware version 23.50.24332.81755.
    - Intel Bluetooth firmware update package 23.60.0.1...
    - Thunder Peak2 (9260), Jefferson Peak2 (9560), firmware version 22.20.2412.20425.
    - MediaTek
    - MT7922...
    - Bluetooth devices (20240716163157).
    - Wi-Fi devices (MCU header 20240716150944a; RAM code 20240716151027).
    - MT7925 Wi-Fi devices (MCU header 20240816132951a; RAM code 20240816133044).
    - MT7961...
    - MT7921 Bluetooth devices (20240930111457).
    - Wi-Fi devices (MCU header 20240930111002a; RAM code 20240930111041).
    - MT7996 Wi-Fi devices (20240809).
    - Qualcomm...
    - Atheros IPQ5018 hw1.0 (WLAN.HK.2.6.0.1-01291-QCAHKSWPL_SILICONZ-1).
    - QCA2066 hw2.1 Wi-Fi devices (WLAN.HSP.1.1-03926.13-QCAHSPSWPL_V2_SILICONZ_CE-2.52297.3).
    - QCA2066 Bluetooth devices (2.1.0-00641).
    - WCN6855 Wi-Fi devices (WLAN.HSP.1.1-03125-QCAHSPSWPL_V1_V2_SILICONZ_LITE-3.6510.41).
    - WCN6855 hw2.0 Wi-Fi devices (WLAN.HSP.1.1-03125-QCAHSPSWPL_V1_V2_SILICONZ_LITE-3.6510.41).
    - WCN685x 2.1 Bluetooth devices (2.1.0-00642).
    - WCN7850 Wi-Fi devices.
    - Realtek RTL8852B Bluetooth USB controller (0x048F_4008).
    - New: AmLogic w265s1 bluetooth HCI.
    - New: Broadcom BCM4354 Bluetooth and Wi-Fi module (Jetson TX1).
    - New: MediaTek MT7992/7996 Wi-Fi 7 devices.
    - New: Qualcomm...
    - Cloud AI 100 (AIC100).
    - QCM6490 IDP and Qualcomm RB3 Gen 2 Development Kit (ADSP.HT.5.5.c8-00149-KODIAK-1, CDSP.HT.2.5.c3-00077-KODIAK-1).
    - New: Realtek...
    - RTL8126A (rev. B).
    - RTL8723CS Bluetooth devices (2.17.119.0525).
    - RTL8852BE-VT Bluetooth devices (v0.29.91.0).
    - RTL8852C Wi-Fi devices (format-1, v0.27.97.0).
    - RTL8922A...
    - USB Bluetooth devices (0x04fa9428).
    - Wi-Fi devices (format-1, v0.35.41.0).
    - New: Texas Instrument CC33XX (single and dual-band Wi-Fi 6 and Bluetooth Low Energy 5.4 companion devices).
    - Multimedia device firmware updates...
    - MediaTek MT8173 VPU firmware v1.2.0.
    - New: Cirrus Logic...
    - ASUS Zenbook S 16 UM5606 (Cirrus Logic Smart Amplifier CS35L56 HDA).
    - ASUS ROG Zephyrus G16 (2024) GA605(W) and ASUS ProArt P16 H7606(W) (Cirrus Logic Smart Amplifier CS35L56 HDA).
    - Lenovo ThinkBook 13X and Lenovo ThinkBook 16p Gen 5 (Cirrus Logic Smart Amp CS35L41 HDA).
    - New: Intel codec topology files for the `avs' kernel module...
    - Digital Microphone Array
    - HD Audio codecs.
    - HDMI codecs.
    - New: Non-Intel codec topology files for the `avs' kernel module...
    - Analog Devices SSM4567 (I2S).
    - Maxim 98357a/98373/98927 (I2S).
    - MediaTek MT8195 series SoC.
    - Nuvoton 8825 (I2S).
    - Realtek 274/286/298/5514/5640/5663/7219 (I2S).
    - New: Firmware for Qualcomm platforms and GPUs.
    - Snapdragon X1 Elite GPU (x1e80100).
    - qcom/gen70500_gmu.bin: v4.03.11.
    - qcom/gen70500_sqe.fw: v1.62.
    - qcom/gen70500_zap.mbn: v0.15.
    - Snapdragon SM8550 (VIDEO.VPU.3.1-0076).
    - SA8775P VPU.
    - New: Firmware for Intel cryptography/compression accelerators...
    - Intel QAT 402xx.
    Co-authored-by: Mingcong Bai <jeffbai@aosc.xyz>

Package(s) Affected
-------------------

- firmware-free: 20241004+debian20240909+1
- firmware-nonfree: 20241004+debian20240909+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
