### PR TITLE
vscode: update to 1.94.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.93.1
+VER=1.94.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::29a9431daea5307cf9a22f6a95cbbe328f48ace6bda126457e1171390dc84aed"
-CHKSUMS__ARM64="sha256::7d84b3954018102ca9154c74fc5c4bd8129206eebdd0d5b1adb564917eded1fd"
+CHKSUMS__AMD64="sha256::f2c1e7d061b0c267342293b6c363cd07f5efcea24a66ea968aca700e8d065fb4"
+CHKSUMS__ARM64="sha256::ae7c9aed4940644c9ce261c578554f278ee4bcdfda2d4280b6c2410cd97594b3"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.94.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- vscode: 1.94.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
