### PR TITLE
linyaps: new, 1.6.3

### DIFF
--- a/app-admin/linglong/autobuild/defines
+++ b/app-admin/linglong/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=linglong
+PKGSEC=admin
+PKGDEP="linyaps"
+PKGDES="Transitional package for linglong"
+
+ABHOST=noarch
+ABTYPE=dummy
+
+PKGEPOCH=1

--- a/app-admin/linglong/spec
+++ b/app-admin/linglong/spec
@@ -1,0 +1,2 @@
+VER=0
+DUMMYSRC=1

--- a/app-admin/linyaps/autobuild/defines
+++ b/app-admin/linyaps/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=linyaps
+PKGSEC=admin
+PKGDEP="glib libseccomp ostree qt-5 systemd yaml-cpp"
+BUILDDEP="nlohmann-json"
+PKGDES="Containerized application distribution and packaging toolkit"
+
+CMAKE_AFTER="-DCPM_LOCAL_PACKAGES_ONLY=ON \
+             -DLINGLONG_DEFAULT_OCI_RUNTIME=ll-box"
+
+# Note: Project renamed during linglong-preview.
+PKGBREAK="linglong<=1.5.6"
+PKGREP="linglong<=1.5.6"

--- a/app-admin/linyaps/autobuild/postinst
+++ b/app-admin/linyaps/autobuild/postinst
@@ -1,0 +1,8 @@
+echo "Creating user account for the Linglong daemon owner ..."
+systemd-sysusers linglong.conf
+
+echo "Reloading D-Bus configurations ..."
+dbus-send \
+	--system \
+	--type=method_call \
+	--dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig

--- a/app-admin/linyaps/spec
+++ b/app-admin/linyaps/spec
@@ -1,0 +1,4 @@
+VER=1.6.3
+SRCS="git::commit=tags/$VER::https://github.com/OpenAtom-Linyaps/linyaps"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372461"


### PR DESCRIPTION
Topic Description
-----------------

- linyaps: new, 1.6.3
    Add a transitional package for linyaps (linglong), as we have already shipped
    linglong during the `linglong-preview' topic.

Package(s) Affected
-------------------

- linglong: 0
- linyaps: 1.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit linyaps linglong
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
