### PR TITLE
fnm: new, 1.37.2

### DIFF
--- a/app-multimedia/yesplaymusic/autobuild/defines
+++ b/app-multimedia/yesplaymusic/autobuild/defines
@@ -8,7 +8,7 @@ PKGDEP="alsa-lib desktop-file-utils flac harfbuzz hicolor-icon-theme icu libpng 
 # FIXME: Desktop OSD lyrics has been disabled by the upstream as of 0.4.8-2.
 # Add this dependency back when it's ready.
 # PKGDEP+=" osdlyrics"
-BUILDDEP="nvm"
+BUILDDEP="fnm"
 
 PKGPROV="YesPlayMusic"
 FAIL_ARCH="!(amd64|arm64)"

--- a/app-multimedia/yesplaymusic/autobuild/prepare
+++ b/app-multimedia/yesplaymusic/autobuild/prepare
@@ -5,7 +5,7 @@ abinfo "Installing Node.js 16 ..."
 # FIXME: .nvmrc points to Node.js 14
 rm -v .nvmrc
 eval "$(fnm env --use-on-cd --shell bash)"
-fnm use --install-if-missing 16
+fnm use --install-if-missing --corepack-enabled 16
 
 abinfo "Prevent Corepack from showing the URL ..."
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/app-multimedia/yesplaymusic/autobuild/prepare
+++ b/app-multimedia/yesplaymusic/autobuild/prepare
@@ -2,6 +2,7 @@ acbs_copy_git
 
 # FIXME: Node.js 16 is unsupported.
 abinfo "Installing Node.js 16 ..."
+eval "$(fnm env --use-on-cd --shell bash)"
 fnm use --install-if-missing 16
 
 abinfo "Prevent Corepack from showing the URL ..."

--- a/app-multimedia/yesplaymusic/autobuild/prepare
+++ b/app-multimedia/yesplaymusic/autobuild/prepare
@@ -1,19 +1,13 @@
 acbs_copy_git
 
-abinfo "Unset PREFIX to fix nvm use"
-unset PREFIX
+# FIXME: Node.js 16 is unsupported.
+abinfo "Installing Node.js 16 ..."
+fnm use --install-if-missing 16
 
-abinfo "Source /etc/profile.d/30-nvm.sh to add nvm binary to env ..."
-abinfo "FIXME: nvm.sh does not source successfully with Autobuild4 as it traps all errors. use '|| true' here to work around it."
-source /etc/profile.d/30-nvm.sh || true
+abinfo "Prevent Corepack from showing the URL ..."
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
-abinfo "Use Nodejs 16 to compile yesplaymusic ..."
-nvm install 16
-nvm use 16
-
-abinfo "Installing dependencies ..."
-npm install -g yarn
-yarn install
+yarn install --frozen-lockfile
 
 abinfo "Setting up the build environment ..."
 cp -av "$SRCDIR"/.env.example "$SRCDIR"/.env

--- a/app-multimedia/yesplaymusic/autobuild/prepare
+++ b/app-multimedia/yesplaymusic/autobuild/prepare
@@ -2,6 +2,8 @@ acbs_copy_git
 
 # FIXME: Node.js 16 is unsupported.
 abinfo "Installing Node.js 16 ..."
+# FIXME: .nvmrc points to Node.js 14
+rm -v .nvmrc
 eval "$(fnm env --use-on-cd --shell bash)"
 fnm use --install-if-missing 16
 

--- a/app-multimedia/yesplaymusic/spec
+++ b/app-multimedia/yesplaymusic/spec
@@ -1,4 +1,5 @@
-VER=0.4.8+2 
+VER=0.4.8+2
+REL=1
 SRCS="git::commit=tags/v${VER/+/-}::https://github.com/qier222/YesPlayMusic"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372820"

--- a/lang-js/fnm/autobuild/defines
+++ b/lang-js/fnm/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME="fnm"
+PKGDES="Fast and simple Node.js version manager, built in Rust"
+PKGDEP="glibc"
+BUILDDEP="rustc llvm"
+PKGSEC="devel"

--- a/lang-js/fnm/autobuild/defines
+++ b/lang-js/fnm/autobuild/defines
@@ -6,3 +6,6 @@ BUILDDEP="rustc llvm"
 
 # https://github.com/briansmith/ring/issues/1444
 USECLANG=1
+
+# FIXME: ld.lld is not yet available.
+NOLTO__LOONGSON3=1

--- a/lang-js/fnm/autobuild/defines
+++ b/lang-js/fnm/autobuild/defines
@@ -1,5 +1,8 @@
 PKGNAME="fnm"
+PKGSEC="devel"
 PKGDES="Fast and simple Node.js version manager, built in Rust"
 PKGDEP="glibc"
 BUILDDEP="rustc llvm"
-PKGSEC="devel"
+
+# https://github.com/briansmith/ring/issues/1444
+USECLANG=1

--- a/lang-js/fnm/autobuild/overrides/usr/share/bash-completion/completions/fnm
+++ b/lang-js/fnm/autobuild/overrides/usr/share/bash-completion/completions/fnm
@@ -1,0 +1,1 @@
+eval "$(fnm env --use-on-cd --shell bash)"

--- a/lang-js/fnm/autobuild/overrides/usr/share/fish/completions/fnm
+++ b/lang-js/fnm/autobuild/overrides/usr/share/fish/completions/fnm
@@ -1,0 +1,1 @@
+fnm env --use-on-cd --shell fish | source

--- a/lang-js/fnm/autobuild/overrides/usr/share/zsh/site-functions/_fnm
+++ b/lang-js/fnm/autobuild/overrides/usr/share/zsh/site-functions/_fnm
@@ -1,0 +1,1 @@
+eval "$(fnm env --use-on-cd --shell zsh)"

--- a/lang-js/fnm/spec
+++ b/lang-js/fnm/spec
@@ -1,0 +1,4 @@
+VER=1.37.2
+SRCS="git::commit=tags/v$VER::https://github.com/Schniz/fnm.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=374841"


### PR DESCRIPTION
Topic Description
-----------------

- yesplaymusic: enable corepack
- yesplaymusic: remove .nvmrc to use Node.js 16
- yesplaymusic: setup fnm
- yesplaymusic: use fnm instead of nvm
- fnm: disable LTO on Loongson 3
- fnm: use Clang to fix ring building
- fnm: new, 1.37.2

Package(s) Affected
-------------------

- fnm: 1.37.2
- yesplaymusic: 0.4.8+2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fnm yesplaymusic
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
