### PR TITLE
vscodium: update to 1.94.1.24283

### DIFF
--- a/app-editors/vscodium/autobuild/defines
+++ b/app-editors/vscodium/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME="vscodium"
 PKGSEC="devel"
 PKGDES="Visual Studio Code - Open Source"
 PKGDEP="alsa-lib at-spi2-core cups desktop-file-utils fontconfig gtk-3 gconf libnotify libsecret nss x11-lib"
-BUILDDEP="gcc gulp make pkg-config jq nodejs"
+BUILDDEP="gcc make pkg-config jq nodejs"
 PKGPROV="codium"
 
 FAIL_ARCH="!(amd64|arm64)"

--- a/app-editors/vscodium/autobuild/defines
+++ b/app-editors/vscodium/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME="vscodium"
 PKGSEC="devel"
 PKGDES="Visual Studio Code - Open Source"
 PKGDEP="alsa-lib at-spi2-core cups desktop-file-utils fontconfig gtk-3 gconf libnotify libsecret nss x11-lib"
-BUILDDEP="gcc nvm gulp make pkg-config python-2 yarn jq nodejs"
+BUILDDEP="gcc gulp make pkg-config jq nodejs"
 PKGPROV="codium"
 
 FAIL_ARCH="!(amd64|arm64)"

--- a/app-editors/vscodium/autobuild/prepare
+++ b/app-editors/vscodium/autobuild/prepare
@@ -1,13 +1,4 @@
 acbs_copy_git
 
-abinfo "unset PREFIX to fix nvm use"
-unset PREFIX
-
-abinfo "Use Nodejs 18 to compile vscodium ..."
-
-abinfo "source /etc/profile.d/30-nvm.sh to add nvm binary to env ..."
-abinfo "FIXME: source nvm.sh runs in autobuild4 strict mode, so use || true to ignore the error."
-source /etc/profile.d/30-nvm.sh || true
-
-nvm install 18
-nvm use 18
+abinfo "Prevent Corepack from showing the URL ..."
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.93.1.24256
-SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium"
+VER=1.94.1.24283
+SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"

--- a/lang-js/gulp/autobuild/build
+++ b/lang-js/gulp/autobuild/build
@@ -1,7 +1,0 @@
-wget https://registry.npmjs.org/gulp/-/gulp-$PKGVER.tgz
-
-npm install -g --user root \
-            --prefix "$PKGDIR"/usr "$SRCDIR"/gulp-$PKGVER.tgz
-rm -r "$PKGDIR"/usr/etc
-
-find "$PKGDIR"/usr -type d -exec chmod 755 '{}' +

--- a/lang-js/gulp/autobuild/defines
+++ b/lang-js/gulp/autobuild/defines
@@ -1,4 +1,0 @@
-PKGNAME=gulp
-PKGSEC=devel
-PKGDEP="nodejs"
-PKGDES="The streaming build system"

--- a/lang-js/gulp/spec
+++ b/lang-js/gulp/spec
@@ -1,3 +1,0 @@
-VER=4.0.0
-DUMMYSRC=1
-CHKUPDATE="anitya::id=229013"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: remove gulp from Depends
- vscodium: update to 1.94.1.24283
    - Use system Node.js 20.

Package(s) Affected
-------------------

- vscodium: 1.94.1.24283

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
