### PR TITLE
Node.js Package Manager Survey 20241010

### DIFF
--- a/app-multimedia/feishin/autobuild/build
+++ b/app-multimedia/feishin/autobuild/build
@@ -1,5 +1,5 @@
 abinfo "Installing NPM dependencies ..."
-npm ci
+npm ci --legacy-peer-deps
 
 abinfo "Building Feishin ..."
 npm run postinstall

--- a/app-multimedia/feishin/autobuild/build
+++ b/app-multimedia/feishin/autobuild/build
@@ -1,5 +1,5 @@
 abinfo "Installing NPM dependencies ..."
-npm install --legacy-peer-deps
+npm ci
 
 abinfo "Building Feishin ..."
 npm run postinstall

--- a/app-multimedia/feishin/spec
+++ b/app-multimedia/feishin/spec
@@ -1,4 +1,5 @@
 VER=0.10.1
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/jeffvli/feishin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368971"

--- a/app-multimedia/sunshine/autobuild/prepare
+++ b/app-multimedia/sunshine/autobuild/prepare
@@ -1,2 +1,3 @@
 abinfo "Preparing NPM modules ..."
+# FIXME: upstream doesn't provide package-lock.json file
 npm install

--- a/app-productivity/zotero/autobuild/build
+++ b/app-productivity/zotero/autobuild/build
@@ -1,6 +1,6 @@
 pushd "${SRCDIR}/zotero-client"
 abinfo "Building zotero JavaScript components ..."
-npm install
+npm ci
 npm run build
 popd
 

--- a/app-productivity/zotero/spec
+++ b/app-productivity/zotero/spec
@@ -1,4 +1,5 @@
 VER=6.0.26
+REL=1
 _BUILD_REPO_COMMIT=5cec38cd40361d939e32eb0b6e0fd18ac7b78a56
 SRCS="
 	git::commit=tags/${VER};rename=zotero-client::https://github.com/zotero/zotero.git


### PR DESCRIPTION
Topic Description
-----------------

- zotero: bump rel
- feishin: reapply --legacy-peer-deps to npm
- feishin: use npm ci instead of npm install
- sunshine: add comment about npm install
- zotero: use npm ci instead of npm install

Package(s) Affected
-------------------

- feishin: 0.10.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit feishin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
