### PR TITLE
systemd: update to 256.7

### DIFF
--- a/app-admin/systemd/autobuild/patches/0001-sleep.conf-AllowHibernation-no-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0001-sleep.conf-AllowHibernation-no-by-default.patch
@@ -1,4 +1,4 @@
-From 62743af531f8c6df757664ddf743f4198c653282 Mon Sep 17 00:00:00 2001
+From 679d56b7d1bbff4141cf30d7cab9d97d619d897f Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Tue, 11 Apr 2023 18:04:25 -0700
 Subject: [PATCH 1/3] sleep.conf: AllowHibernation=no by default
@@ -9,7 +9,7 @@ Signed-off-by: Kaiyang Wu <origincode@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/sleep/sleep.conf b/src/sleep/sleep.conf
-index 98430348a7..41534e6c15 100644
+index 98430348a7bf..41534e6c15d3 100644
 --- a/src/sleep/sleep.conf
 +++ b/src/sleep/sleep.conf
 @@ -18,7 +18,7 @@
@@ -22,5 +22,5 @@ index 98430348a7..41534e6c15 100644
  #AllowHybridSleep=yes
  #SuspendState=mem standby freeze
 -- 
-2.46.0
+2.47.0
 

--- a/app-admin/systemd/autobuild/patches/0002-main.c-revert-part-of-systemd-systemd-31442.patch
+++ b/app-admin/systemd/autobuild/patches/0002-main.c-revert-part-of-systemd-systemd-31442.patch
@@ -1,4 +1,4 @@
-From aa081fb940258ad35a088af1dabd6ee25ad6dd43 Mon Sep 17 00:00:00 2001
+From 0df968c5b5b0e0fc82aec9d37da9ca667fcac4c5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 27 Jul 2024 14:43:07 +0800
 Subject: [PATCH 2/3] main.c: revert part of systemd/systemd#31442
@@ -9,7 +9,7 @@ To make the user happy.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/core/main.c b/src/core/main.c
-index 4b8a315d86..830cd4a801 100644
+index 4b8a315d8609..830cd4a80138 100644
 --- a/src/core/main.c
 +++ b/src/core/main.c
 @@ -3110,8 +3110,8 @@ int main(int argc, char *argv[]) {
@@ -24,5 +24,5 @@ index 4b8a315d86..830cd4a801 100644
                  }
  
 -- 
-2.46.0
+2.47.0
 

--- a/app-admin/systemd/autobuild/patches/0003-fix-do-not-tint-terminal-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0003-fix-do-not-tint-terminal-by-default.patch
@@ -1,4 +1,4 @@
-From c1c43f43f8b566d784ba2baa2bc231202bb402e7 Mon Sep 17 00:00:00 2001
+From 24c6faa5aaaec6d5408c0505c258ae8ace9d0828 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 12 Aug 2024 22:19:25 +0800
 Subject: [PATCH 3/3] fix: do not tint terminal by default
@@ -11,7 +11,7 @@ default) to only tint when the user specifies a --background= parameter.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/shared/pretty-print.c b/src/shared/pretty-print.c
-index 4692a6aedc..695c986c9e 100644
+index 4692a6aedc80..695c986c9e12 100644
 --- a/src/shared/pretty-print.c
 +++ b/src/shared/pretty-print.c
 @@ -453,7 +453,7 @@ bool shall_tint_background(void) {
@@ -24,5 +24,5 @@ index 4692a6aedc..695c986c9e 100644
                  log_debug_errno(cache, "Failed to parse $SYSTEMD_TINT_BACKGROUND, leaving background tinting enabled: %m");
  
 -- 
-2.46.0
+2.47.0
 

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,5 +1,4 @@
-VER=256.4
-REL=1
-SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd"
+VER=256.7
+SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205088"


### PR DESCRIPTION
Topic Description
-----------------

- systemd: update to 256.7
    - No noteble change... from my perspective.

Package(s) Affected
-------------------

- systemd: 1:256.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
